### PR TITLE
feat(video): attest display rotation end-to-end in the video-stream protocol

### DIFF
--- a/android/desktop-core/src/main/kotlin/dev/jasonpearson/automobile/desktop/core/AutoMobileContent.kt
+++ b/android/desktop-core/src/main/kotlin/dev/jasonpearson/automobile/desktop/core/AutoMobileContent.kt
@@ -237,6 +237,9 @@ internal fun rememberLiveVideoFrame(
               bitmap = decodedFrame,
               sequence = frameSequence.incrementAndGet(),
               receivedAtMs = nowMs(),
+              // The stream's config packets attest the display rotation; carrying it here lets
+              // DeviceControlSession re-prove orientation from the live frame alone (issue #4786).
+              rotation = frame.rotation,
             )
         }
       }

--- a/android/desktop-core/src/main/kotlin/dev/jasonpearson/automobile/desktop/core/video/H264Decoder.kt
+++ b/android/desktop-core/src/main/kotlin/dev/jasonpearson/automobile/desktop/core/video/H264Decoder.kt
@@ -12,8 +12,19 @@ import org.bytedeco.javacpp.BytePointer
 import org.bytedeco.javacpp.IntPointer
 import org.bytedeco.javacpp.PointerPointer
 
-/** One decoded frame as tightly packed BGRA, ready to hand to Skia. */
-class DecodedFrame(val width: Int, val height: Int, val bgra: ByteArray)
+/**
+ * One decoded frame as tightly packed BGRA, ready to hand to Skia.
+ *
+ * [rotation] is the display rotation (`0..3`) attested by the most recent CONFIG packet, or null
+ * when unknown (issue #4786). The decoder itself cannot know it — [VideoStreamClient] stamps it
+ * from the stream's config packets — so it defaults to null for frames the decoder constructs.
+ */
+class DecodedFrame(
+  val width: Int,
+  val height: Int,
+  val bgra: ByteArray,
+  val rotation: Int? = null,
+)
 
 /** Raised when the decoder cannot be created or a decode step fails unrecoverably. */
 class H264DecodeException(message: String, cause: Throwable? = null) : Exception(message, cause)

--- a/android/desktop-core/src/main/kotlin/dev/jasonpearson/automobile/desktop/core/video/VideoStreamClient.kt
+++ b/android/desktop-core/src/main/kotlin/dev/jasonpearson/automobile/desktop/core/video/VideoStreamClient.kt
@@ -222,6 +222,11 @@ class VideoStreamClient(
   private fun pumpFrames(input: java.io.InputStream, decoder: H264Decoder) {
     val parser = VideoStreamParser()
     val buffer = ByteArray(64 * 1024)
+    // Latest attested rotation, updated by each config packet that carries it (issue #4786). A
+    // config packet precedes the IDR it configures, so a decoded frame is stamped with the rotation
+    // the current SPS/PPS attested. Stays null until the first attested config packet, so an
+    // unattested stream (screenrecord/iOS relay) leaves the control gate to fail closed.
+    var currentRotation: Int? = null
 
     while (true) {
       val read = input.read(buffer)
@@ -233,6 +238,9 @@ class VideoStreamClient(
           LOG.info("Live mirroring started (${header.width}x${header.height} advertised)")
         },
         onPacket = { packet ->
+          if (packet.isConfig && packet.rotation != null) {
+            currentRotation = packet.rotation
+          }
           decoder.decode(packet.payload) { frame ->
             val current = _state.value
             if (
@@ -245,7 +253,9 @@ class VideoStreamClient(
               _state.value = VideoStreamState.Streaming(frame.width, frame.height)
             }
             // The decoder reuses its buffer, so the frame must be copied before it leaves here.
-            _frames.tryEmit(DecodedFrame(frame.width, frame.height, frame.bgra.copyOf()))
+            _frames.tryEmit(
+              DecodedFrame(frame.width, frame.height, frame.bgra.copyOf(), currentRotation)
+            )
           }
         },
       )
@@ -331,7 +341,7 @@ class FakeVideoStreamSource(
   }
 
   /** Publishes a frame to collectors, as the real client would. */
-  fun emitFrame(width: Int = 1080, height: Int = 2400) {
-    _frames.tryEmit(DecodedFrame(width, height, ByteArray(width * height * 4)))
+  fun emitFrame(width: Int = 1080, height: Int = 2400, rotation: Int? = null) {
+    _frames.tryEmit(DecodedFrame(width, height, ByteArray(width * height * 4), rotation))
   }
 }

--- a/android/desktop-core/src/main/kotlin/dev/jasonpearson/automobile/desktop/core/video/VideoStreamParser.kt
+++ b/android/desktop-core/src/main/kotlin/dev/jasonpearson/automobile/desktop/core/video/VideoStreamParser.kt
@@ -10,7 +10,22 @@ private const val STREAM_HEADER_BYTES = 12
 private const val PACKET_HEADER_BYTES = 12
 private const val FLAG_CONFIG = 1L shl 63
 private const val FLAG_KEY_FRAME = 1L shl 62
-private const val PTS_MASK = (1L shl 62) - 1
+
+/**
+ * Bit 61: ROTATION_PRESENT (issue #4786). Set on a CONFIG packet whose bits 60-59 attest a display
+ * rotation (`0..3`). The daemon relay leaves it clear when its source cannot prove rotation
+ * (screenrecord/iOS), so an absent bit means "unknown" — distinct from the valid value 0. See
+ * `src/daemon/videoStreamFraming.ts` for the encoder.
+ */
+private const val FLAG_ROTATION_PRESENT = 1L shl 61
+private const val ROTATION_SHIFT = 59
+private const val ROTATION_MASK = 0b11L shl ROTATION_SHIFT
+
+/**
+ * Bits 0-58 carry the presentation timestamp. Narrowed from bits 0-61 for the rotation presence bit
+ * and field; backward compatible because a real microsecond PTS never reaches bit 59.
+ */
+private const val PTS_MASK = (1L shl ROTATION_SHIFT) - 1
 
 /** Dimensions advertised by the stream header. Both are zero unless the client sent a size hint. */
 data class VideoStreamHeader(val width: Int, val height: Int)
@@ -26,6 +41,12 @@ data class VideoPacket(
   val presentationTimeUs: Long,
   val isConfig: Boolean,
   val isKeyFrame: Boolean,
+  /**
+   * Attested display rotation (`0..3`) from a CONFIG packet, or null when unknown (issue #4786): a
+   * non-config packet, or a config packet from a relay whose source could not prove rotation. Null
+   * leaves the control gate to fail closed rather than trust an unattested orientation.
+   */
+  val rotation: Int? = null,
 ) {
   // Data classes compare arrays by identity, which would make equality useless in tests.
   override fun equals(other: Any?): Boolean =
@@ -33,7 +54,8 @@ data class VideoPacket(
       payload.contentEquals(other.payload) &&
       presentationTimeUs == other.presentationTimeUs &&
       isConfig == other.isConfig &&
-      isKeyFrame == other.isKeyFrame
+      isKeyFrame == other.isKeyFrame &&
+      rotation == other.rotation
 
   override fun hashCode(): Int =
     payload.contentHashCode() * 31 + presentationTimeUs.hashCode() * 31 + isConfig.hashCode()
@@ -97,13 +119,21 @@ class VideoStreamParser {
       }
 
       val start = offset + PACKET_HEADER_BYTES
+      val isConfig = (ptsAndFlags and FLAG_CONFIG) != 0L
       onPacket(
         VideoPacket(
           payload = buffer.copyOfRange(start, start + size),
           // Bit 63 makes the int64 negative, so mask before reading the timestamp.
           presentationTimeUs = ptsAndFlags and PTS_MASK,
-          isConfig = (ptsAndFlags and FLAG_CONFIG) != 0L,
+          isConfig = isConfig,
           isKeyFrame = (ptsAndFlags and FLAG_KEY_FRAME) != 0L,
+          // Rotation is attested only on a config packet carrying the presence bit (issue #4786).
+          rotation =
+            if (isConfig && (ptsAndFlags and FLAG_ROTATION_PRESENT) != 0L) {
+              ((ptsAndFlags and ROTATION_MASK) shr ROTATION_SHIFT).toInt()
+            } else {
+              null
+            },
         )
       )
       offset = start + size

--- a/android/desktop-core/src/test/kotlin/dev/jasonpearson/automobile/desktop/core/LiveVideoStreamTest.kt
+++ b/android/desktop-core/src/test/kotlin/dev/jasonpearson/automobile/desktop/core/LiveVideoStreamTest.kt
@@ -7,6 +7,7 @@ import androidx.compose.ui.test.runComposeUiTest
 import dev.jasonpearson.automobile.desktop.core.video.FakeVideoStreamSource
 import dev.jasonpearson.automobile.desktop.core.video.toImageBitmap
 import kotlin.test.Test
+import kotlin.test.assertEquals
 import kotlin.test.assertNull
 import kotlinx.coroutines.CompletableDeferred
 
@@ -26,6 +27,23 @@ class LiveVideoStreamTest {
     waitUntil { source.connectedDeviceId == "emulator-5554" }
     runOnUiThread { showLiveLayout.value = false }
     waitUntil { source.connectedDeviceId == null }
+  }
+
+  @Test
+  fun `populates the live frame's rotation from the decoded stream`() = runComposeUiTest {
+    // Issue #4786: the rotation attested by the stream's config packets rides through to the
+    // LiveVideoFrame so DeviceControlSession can prove the live frame's orientation.
+    val source = FakeVideoStreamSource()
+    var observedRotation: Int? = null
+
+    setContent {
+      val liveFrame = rememberLiveVideoFrame(source, "emulator-5554")
+      SideEffect { liveFrame?.let { observedRotation = it.rotation } }
+    }
+
+    source.emitFrame(width = 1, height = 1, rotation = 3)
+    waitUntil { observedRotation == 3 }
+    assertEquals(3, observedRotation)
   }
 
   @Test

--- a/android/desktop-core/src/test/kotlin/dev/jasonpearson/automobile/desktop/core/control/DeviceControlSessionTest.kt
+++ b/android/desktop-core/src/test/kotlin/dev/jasonpearson/automobile/desktop/core/control/DeviceControlSessionTest.kt
@@ -1574,6 +1574,47 @@ class DeviceControlSessionTest {
     scope.cancel()
   }
 
+  @Test
+  fun `the live frame alone re-proves orientation after a rotation`() = runTest {
+    // Issue #4786: once the video stream attests rotation, a live frame carrying the new rotation
+    // re-proves orientation on its own — before the screenshot/hierarchy sources catch up — so
+    // control does not stay blocked waiting for an observation refresh.
+    val scope = CoroutineScope(UnconfinedTestDispatcher(testScheduler))
+    val client = FakeAutoMobileClient()
+    val session = session(scope, client)
+
+    // Proven rotation 0 from a coherent observation pair.
+    session.evaluate(paired(captureSequence = 8L, sourceSequence = 11L))
+    assertTrue(session.tap(testSnapshot().copy(rotation = 0), point))
+    advanceUntilIdle()
+
+    // The device rotates to 1; only the live frame attests it (the observation sources report no
+    // rotation yet).
+    val liveProvesRotation = paired(captureSequence = 9L, sourceSequence = 12L)
+    session.evaluate(
+      liveProvesRotation.copy(
+        screenshot = liveProvesRotation.screenshot?.copy(rotation = null),
+        hierarchy = liveProvesRotation.hierarchy?.copy(rotation = null),
+        liveFrame =
+          LiveFrameFacts(
+            deviceId = "emulator-5554",
+            sequence = 900_000L,
+            receivedAtMs = 1_000L,
+            width = 1080,
+            height = 2340,
+            rotation = 1,
+          ),
+      )
+    )
+
+    // Orientation is re-proven to 1 from the live frame alone: a rotation-1 tap dispatches,
+    assertTrue(session.tap(testSnapshot().copy(rotation = 1), point))
+    advanceUntilIdle()
+    // and the stale rotation-0 orientation is no longer dispatchable.
+    assertFalse(session.tap(testSnapshot().copy(rotation = 0), point))
+    scope.cancel()
+  }
+
   /** A coherent, freshly-received screenshot+hierarchy pair sharing one capture identity. */
   private fun paired(
     captureSequence: Long,

--- a/android/desktop-core/src/test/kotlin/dev/jasonpearson/automobile/desktop/core/video/VideoStreamClientTest.kt
+++ b/android/desktop-core/src/test/kotlin/dev/jasonpearson/automobile/desktop/core/video/VideoStreamClientTest.kt
@@ -48,7 +48,8 @@ class VideoStreamClientTest {
     error: String? = null,
     payload: ByteArray? = null,
     keepOpen: Boolean = false,
-  ): FakeRelay = FakeRelay(success, error, payload, keepOpen).also { servers.add(it) }
+    rotation: Int? = null,
+  ): FakeRelay = FakeRelay(success, error, payload, keepOpen, rotation).also { servers.add(it) }
 
   @Test
   fun `subscribes with the device id and decodes frames`() = runBlocking {
@@ -82,6 +83,35 @@ class VideoStreamClientTest {
     assertTrue(state is VideoStreamState.Streaming, "expected Streaming, was $state")
     assertEquals(320, (state as VideoStreamState.Streaming).width)
     assertEquals(240, state.height)
+
+    client.dispose()
+  }
+
+  @Test
+  fun `stamps decoded frames with the rotation attested by a config packet`() = runBlocking {
+    // Issue #4786: the config packet attests rotation 3, so the decoded frame carries it
+    // end-to-end.
+    val server = relay(payload = sampleH264(), rotation = 3)
+    val client = VideoStreamClient(socketPathValue = server.socketPath.toString())
+
+    client.connect("emulator-5554")
+
+    val frame = server.awaitFirstFrameFrom(client)
+    assertEquals(3, frame.rotation)
+
+    client.dispose()
+  }
+
+  @Test
+  fun `leaves rotation null when the stream does not attest it`() = runBlocking {
+    // An unattested stream (screenrecord/iOS relay) leaves rotation unknown so control fails
+    // closed.
+    val server = relay(payload = sampleH264())
+    val client = VideoStreamClient(socketPathValue = server.socketPath.toString())
+
+    client.connect("emulator-5554")
+
+    assertEquals(null, server.awaitFirstFrameFrom(client).rotation)
 
     client.dispose()
   }
@@ -224,6 +254,9 @@ class VideoStreamClientTest {
     private val error: String?,
     private val payload: ByteArray?,
     private val keepOpen: Boolean,
+    // When set, the framed packet is flagged CONFIG and attests this rotation (issue #4786), as the
+    // daemon relay does on a parameter-set packet.
+    private val rotation: Int? = null,
   ) : AutoCloseable {
     private val tempDir: Path = Files.createTempDirectory(Path.of("/tmp"), "amvsc-")
     val socketPath: Path = tempDir.resolve("video-stream.sock")
@@ -279,8 +312,18 @@ class VideoStreamClientTest {
           .putInt(0)
           .array()
       )
+      var flags = 0L
+      rotation?.let {
+        // CONFIG (bit 63) + ROTATION_PRESENT (bit 61) + rotation (bits 59-60), matching
+        // videoStreamFraming.ts so the client stamps decoded frames with the attested rotation.
+        flags = flags or (1L shl 63) or (1L shl 61) or ((it.toLong() and 0b11L) shl 59)
+      }
       out.write(
-        ByteBuffer.allocate(12).order(ByteOrder.BIG_ENDIAN).putLong(0L).putInt(annexB.size).array()
+        ByteBuffer.allocate(12)
+          .order(ByteOrder.BIG_ENDIAN)
+          .putLong(flags)
+          .putInt(annexB.size)
+          .array()
       )
       out.write(annexB)
       out.flush()

--- a/android/desktop-core/src/test/kotlin/dev/jasonpearson/automobile/desktop/core/video/VideoStreamParserTest.kt
+++ b/android/desktop-core/src/test/kotlin/dev/jasonpearson/automobile/desktop/core/video/VideoStreamParserTest.kt
@@ -29,10 +29,16 @@ class VideoStreamParserTest {
     ptsUs: Long = 0,
     isConfig: Boolean = false,
     isKeyFrame: Boolean = false,
+    rotation: Int? = null,
   ): ByteArray {
-    var ptsAndFlags = ptsUs and ((1L shl 62) - 1)
+    var ptsAndFlags = ptsUs and ((1L shl 59) - 1)
     if (isConfig) ptsAndFlags = ptsAndFlags or (1L shl 63)
     if (isKeyFrame) ptsAndFlags = ptsAndFlags or (1L shl 62)
+    // Rotation rides bit 61 (ROTATION_PRESENT) + bits 59-60, matching videoStreamFraming.ts.
+    if (rotation != null) {
+      ptsAndFlags = ptsAndFlags or (1L shl 61)
+      ptsAndFlags = ptsAndFlags or ((rotation.toLong() and 0b11L) shl 59)
+    }
     return ByteBuffer.allocate(12 + payload.size)
       .order(ByteOrder.BIG_ENDIAN)
       .putLong(ptsAndFlags)
@@ -186,6 +192,48 @@ class VideoStreamParserTest {
 
     // 0x616d7578 is "amux", the daemon's audio-muxed variant, which this client does not decode.
     assertTrue(failure.message!!.contains("616d7578"), failure.message!!)
+  }
+
+  @Test
+  fun `decodes the attested rotation from a config packet for every value`() {
+    for (rotation in 0..3) {
+      val out =
+        feed(
+          VideoStreamParser(),
+          streamHeader() +
+            packet(byteArrayOf(0x67.toByte()), 4242, isConfig = true, rotation = rotation),
+        )
+
+      assertEquals(rotation, out.packets.single().rotation)
+      // The rotation bits must not leak into the timestamp.
+      assertEquals(4242L, out.packets.single().presentationTimeUs)
+    }
+  }
+
+  @Test
+  fun `rotation is null when the presence bit is absent`() {
+    // A config packet from a relay whose source could not attest rotation leaves rotation unknown.
+    val out =
+      feed(
+        VideoStreamParser(),
+        streamHeader() + packet(byteArrayOf(0x67.toByte()), 5, isConfig = true),
+      )
+
+    assertTrue(out.packets.single().isConfig)
+    assertEquals(null, out.packets.single().rotation)
+  }
+
+  @Test
+  fun `rotation is null on a non-config packet even when the presence bit is set`() {
+    // Only a config packet attests rotation; the parser must not read it off a key frame.
+    val out =
+      feed(
+        VideoStreamParser(),
+        streamHeader() + packet(byteArrayOf(0x65.toByte()), 9, isKeyFrame = true, rotation = 2),
+      )
+
+    assertTrue(out.packets.single().isKeyFrame)
+    assertEquals(null, out.packets.single().rotation)
   }
 
   @Test

--- a/android/video-server/src/main/kotlin/dev/jasonpearson/automobile/video/VideoServer.kt
+++ b/android/video-server/src/main/kotlin/dev/jasonpearson/automobile/video/VideoServer.kt
@@ -282,6 +282,10 @@ object VideoServer {
         height,
         audioEnabled,
         expectedToken = session.token,
+        // Attest the live display rotation on every CONFIG packet (issue #4786). Read at
+        // config-packet-write time on the encode loop, so after the #4785 rotation swap the new
+        // encoder's SPS/PPS carries the new orientation.
+        rotationProvider = { DisplayControl.getDisplayInfo().rotation },
       )
     streamWriter!!.startCommandReader { command ->
       if (command == VideoStreamProtocol.COMMAND_REQUEST_KEY_FRAME) {

--- a/android/video-server/src/main/kotlin/dev/jasonpearson/automobile/video/VideoStreamProtocol.kt
+++ b/android/video-server/src/main/kotlin/dev/jasonpearson/automobile/video/VideoStreamProtocol.kt
@@ -11,7 +11,14 @@ object VideoStreamProtocol {
   const val CODEC_ID_PCM16 = 0x7331366c
   const val TRACK_ID_VIDEO = 1
   const val TRACK_ID_AUDIO = 2
-  private const val MUX_VERSION = 1
+
+  /**
+   * Wire version advertised in the mux header. Bumped 1 -> 2 to signal v2 semantics: config packets
+   * now attest display rotation in bits 59-60 of `ptsAndFlags` (issue #4786). The legacy 12-byte
+   * header stays byte-for-byte decodable and needs no version field — the rotation bits are safe by
+   * the always-zero argument documented on [ROTATION_SHIFT].
+   */
+  const val MUX_VERSION = 2
 
   /**
    * Host→device command byte: request that the encoder emit a sync frame (IDR) as soon as possible.
@@ -41,8 +48,24 @@ object VideoStreamProtocol {
   /** Bit 61: cached packet replayed for a replacement LocalSocket client. */
   const val PACKET_FLAG_REPLAYED = 1L shl 61
 
-  /** Mask for PTS (bits 0-60). */
-  const val PTS_MASK = (1L shl 61) - 1
+  /**
+   * Low bit of the 2-bit display-rotation field (bits 59-60), carried on CONFIG packets only
+   * (issue #4786).
+   *
+   * Backward-compatible carve-out: a presentation timestamp is in microseconds, and bit 59 has
+   * place value 2^59 µs (~18 000 years), so a real PTS never sets bits 59-60. Old encoders wrote 0
+   * there (they were low PTS bits), old parsers read them as zero PTS, and narrowing [PTS_MASK] to
+   * bits 0-58 changes no observable timestamp. A v2 daemon only ever reads a matching v2 jar
+   * (jar-integrity coupling, issue #4733), so on this layer "config packet ⇒ rotation is present
+   * and valid"; no presence bit is needed.
+   */
+  const val ROTATION_SHIFT = 59
+
+  /** 2-bit mask (values 0..3) positioned at [ROTATION_SHIFT]; meaningful on CONFIG packets only. */
+  const val ROTATION_MASK = 0b11L shl ROTATION_SHIFT
+
+  /** Mask for PTS (bits 0-58); bits 59-60 are the rotation field (issue #4786). */
+  const val PTS_MASK = (1L shl ROTATION_SHIFT) - 1
 
   fun legacyHeader(width: Int, height: Int): ByteArray =
     ByteBuffer.allocate(12).putInt(CODEC_ID_H264).putInt(width).putInt(height).array()
@@ -62,16 +85,36 @@ object VideoStreamProtocol {
       .putInt(audioChannels)
       .array()
 
-  fun ptsAndFlags(presentationTimeUs: Long, isConfig: Boolean, isKeyFrame: Boolean): Long {
+  fun ptsAndFlags(presentationTimeUs: Long, isConfig: Boolean, isKeyFrame: Boolean): Long =
+    ptsAndFlags(presentationTimeUs, isConfig, isKeyFrame, rotation = 0)
+
+  /**
+   * As [ptsAndFlags], additionally attesting [rotation] (`0..3`) in bits 59-60 (issue #4786). The
+   * rotation is written ONLY on CONFIG packets (where a decoder/control gate expects it) and is
+   * clamped to 2 bits; on non-config packets it is ignored so a real PTS is never corrupted.
+   */
+  fun ptsAndFlags(
+    presentationTimeUs: Long,
+    isConfig: Boolean,
+    isKeyFrame: Boolean,
+    rotation: Int,
+  ): Long {
     var ptsAndFlags = presentationTimeUs and PTS_MASK
     if (isConfig) {
       ptsAndFlags = ptsAndFlags or PACKET_FLAG_CONFIG
+      ptsAndFlags = ptsAndFlags or ((rotation.toLong() and 0b11L) shl ROTATION_SHIFT)
     }
     if (isKeyFrame) {
       ptsAndFlags = ptsAndFlags or PACKET_FLAG_KEY_FRAME
     }
     return ptsAndFlags
   }
+
+  /**
+   * Read the attested display rotation (`0..3`) from a CONFIG packet's [ptsAndFlags]. Only
+   * meaningful when [PACKET_FLAG_CONFIG] is set; callers must gate on that.
+   */
+  fun rotationOf(ptsAndFlags: Long): Int = ((ptsAndFlags shr ROTATION_SHIFT) and 0b11L).toInt()
 
   fun replayed(ptsAndFlags: Long): Long = ptsAndFlags or PACKET_FLAG_REPLAYED
 

--- a/android/video-server/src/main/kotlin/dev/jasonpearson/automobile/video/VideoStreamWriter.kt
+++ b/android/video-server/src/main/kotlin/dev/jasonpearson/automobile/video/VideoStreamWriter.kt
@@ -101,6 +101,11 @@ class VideoStreamWriter(
   private val expectedToken: String? = null,
   private val nowMs: () -> Long = { SystemClock.elapsedRealtime() },
   private val socketFactory: VideoServerSocketFactory = LocalServerSocketFactory,
+  // Supplies the CURRENT display rotation (0..3) attested on each CONFIG packet (issue #4786). Read
+  // on the encode-loop thread at config-packet time — including the #4785 rotation swap's new
+  // config packet — so the value matches the encoder that just emitted the SPS/PPS. Defaults to a
+  // constant 0 for token-less/legacy launches and unit tests that do not exercise rotation.
+  private val rotationProvider: () -> Int = { 0 },
 ) {
   private data class CachedPacket(
     val trackId: Int,
@@ -209,7 +214,7 @@ class VideoStreamWriter(
     /** Bit 62: key frame (I-frame) */
     const val PACKET_FLAG_KEY_FRAME = VideoStreamProtocol.PACKET_FLAG_KEY_FRAME
 
-    /** Mask for PTS (bits 0-61) */
+    /** Mask for PTS (bits 0-58); bits 59-60 carry the CONFIG-packet rotation (issue #4786). */
     const val PTS_MASK = VideoStreamProtocol.PTS_MASK
   }
 
@@ -481,11 +486,17 @@ class VideoStreamWriter(
     val data = ByteArray(bufferInfo.size)
     buffer.position(bufferInfo.offset)
     buffer.get(data, 0, bufferInfo.size)
+    val isConfig = (bufferInfo.flags and MediaCodec.BUFFER_FLAG_CODEC_CONFIG) != 0
+    // Attest the CURRENT rotation only on the CONFIG packet (SPS/PPS), which is re-emitted at
+    // stream
+    // start and on every #4785 rotation-driven encoder swap; the cache remembers it so a reconnect
+    // replays the current rotation for free (issue #4786).
     val ptsAndFlags =
       VideoStreamProtocol.ptsAndFlags(
         bufferInfo.presentationTimeUs,
-        (bufferInfo.flags and MediaCodec.BUFFER_FLAG_CODEC_CONFIG) != 0,
+        isConfig,
         (bufferInfo.flags and MediaCodec.BUFFER_FLAG_KEY_FRAME) != 0,
+        rotation = if (isConfig) rotationProvider() else 0,
       )
     synchronized(lock) { packetCache.remember(CachedVideoPacket(ptsAndFlags, data)) }
     return handoff.offer(EncodedVideoFrame(ptsAndFlags, data))

--- a/android/video-server/src/test/kotlin/dev/jasonpearson/automobile/video/VideoStreamProtocolTest.kt
+++ b/android/video-server/src/test/kotlin/dev/jasonpearson/automobile/video/VideoStreamProtocolTest.kt
@@ -53,10 +53,11 @@ class VideoStreamProtocolTest {
         0x6d,
         0x75,
         0x78,
+        // MUX_VERSION = 2 (issue #4786): config packets now attest rotation in bits 59-60.
         0x00,
         0x00,
         0x00,
-        0x01,
+        0x02,
         0x00,
         0x00,
         0x00,
@@ -234,6 +235,78 @@ class VideoStreamProtocolTest {
       replayed,
     )
     assertEquals(123, replayed and VideoStreamProtocol.PTS_MASK)
+  }
+
+  @Test
+  fun configPacketAttestsRotationForEveryValueWithoutCorruptingPtsOrFlags() {
+    for (rotation in 0..3) {
+      val ptsAndFlags =
+        VideoStreamProtocol.ptsAndFlags(
+          presentationTimeUs = 4242,
+          isConfig = true,
+          isKeyFrame = true,
+          rotation = rotation,
+        )
+
+      // Rotation round-trips out of bits 59-60.
+      assertEquals(rotation, VideoStreamProtocol.rotationOf(ptsAndFlags))
+      // PTS and the other flags are untouched.
+      assertEquals(4242, ptsAndFlags and VideoStreamProtocol.PTS_MASK)
+      assertEquals(
+        VideoStreamProtocol.PACKET_FLAG_CONFIG,
+        ptsAndFlags and VideoStreamProtocol.PACKET_FLAG_CONFIG,
+      )
+      assertEquals(
+        VideoStreamProtocol.PACKET_FLAG_KEY_FRAME,
+        ptsAndFlags and VideoStreamProtocol.PACKET_FLAG_KEY_FRAME,
+      )
+    }
+  }
+
+  @Test
+  fun rotationIsNotWrittenOnNonConfigPackets() {
+    // A non-config packet must never set the rotation bits, so a real PTS is never corrupted.
+    val ptsAndFlags =
+      VideoStreamProtocol.ptsAndFlags(
+        presentationTimeUs = 99,
+        isConfig = false,
+        isKeyFrame = true,
+        rotation = 3,
+      )
+
+    assertEquals(0L, ptsAndFlags and VideoStreamProtocol.ROTATION_MASK)
+    assertEquals(99, ptsAndFlags and VideoStreamProtocol.PTS_MASK)
+  }
+
+  @Test
+  fun defaultPtsAndFlagsOverloadWritesNoRotation() {
+    // The 3-arg overload (the pre-#4786 signature) must keep producing rotation-free flags.
+    val overload =
+      VideoStreamProtocol.ptsAndFlags(presentationTimeUs = 7, isConfig = true, isKeyFrame = false)
+    val explicitZero =
+      VideoStreamProtocol.ptsAndFlags(
+        presentationTimeUs = 7,
+        isConfig = true,
+        isKeyFrame = false,
+        rotation = 0,
+      )
+
+    assertEquals(explicitZero, overload)
+    assertEquals(0, VideoStreamProtocol.rotationOf(overload))
+  }
+
+  @Test
+  fun muxVersionIsTwo() {
+    assertEquals(2, VideoStreamProtocol.MUX_VERSION)
+  }
+
+  @Test
+  fun legacyHeaderStillDecodesUnchanged() {
+    // The 12-byte legacy (video-only) header is unaffected by the v2 bump and stays byte-identical.
+    assertArrayEquals(
+      byteArrayOf(0x68, 0x32, 0x36, 0x34, 0x00, 0x00, 0x01, 0xe0.toByte(), 0x00, 0x00, 0x04, 0x10),
+      VideoStreamProtocol.legacyHeader(width = 480, height = 1040),
+    )
   }
 
   @Test

--- a/docs/design-docs/plat/android/video-stream-rotation-attestation.md
+++ b/docs/design-docs/plat/android/video-stream-rotation-attestation.md
@@ -1,0 +1,188 @@
+# Video-Stream Display-Rotation Attestation
+
+<kbd>🧭 Design</kbd>
+
+> Records the wire-format decision for carrying display rotation end-to-end
+> through the live video-stream pipeline so a device-control consumer can prove a
+> live frame's orientation. Implements the protocol/attestation half of
+> [#4786](https://github.com/kaeawc/auto-mobile/issues/4786); the capture-path
+> half (recreating the encoder on rotation) shipped in
+> [#4785](https://github.com/kaeawc/auto-mobile/issues/4785) /
+> [#4947](https://github.com/kaeawc/auto-mobile/issues/4947).
+>
+> See the [Status Glossary](../../status-glossary.md) for chip definitions.
+
+## Problem
+
+The live video-stream protocol carries no display-rotation metadata, so no
+consumer can prove a frame's orientation. `DeviceControlSession` already reads
+`liveFrame?.rotation` in its proven-rotation gate (`hasProvenRotationDifferentFrom`
+/ `provenRotations`), but `LiveVideoFrame.rotation` was never populated — the
+consumer side was built and waiting. After a mid-stream rotation, device control
+therefore stayed blocked/degraded until a screenshot/hierarchy source re-proved
+orientation.
+
+Dimensions alone cannot substitute: a WxH↔HxW swap disambiguates portrait from
+landscape but not rotation `0`-vs-`2` or `1`-vs-`3`. The control gate's
+proven-rotation model needs the full `0..3` value.
+
+## Pipeline (two protocol layers)
+
+The live-mirror path has **two** binary framing layers, each with a Kotlin
+producer and a matching parser that pin each other via contract tests:
+
+```
+device video-server ──layer 1──▶ daemon relay ──layer 2──▶ desktop VideoStreamClient
+  VideoStreamProtocol.kt         videoStreamSocketServer.ts   VideoStreamParser.kt
+  (encode)                       (re-frame)                   (decode)
+       ▲                              ▲                            │
+  VideoServerStreamParser.ts     videoStreamFraming.ts       LiveVideoFrame.rotation
+  (layer-1 decode, in daemon)    (layer-2 encode)                 │
+                                                            DeviceControlSession gate
+```
+
+- **Layer 1 (device → daemon):** `VideoStreamProtocol.kt` encodes; the daemon's
+  `VideoServerStreamParser.ts` decodes. Config packets carry SPS/PPS.
+- **Layer 2 (daemon → desktop):** the daemon re-frames the normalized Annex-B
+  stream with `videoStreamFraming.ts`; the desktop's `VideoStreamParser.kt`
+  decodes into `LiveVideoFrame`.
+
+Rotation must cross **both** layers to reach `LiveVideoFrame.rotation`.
+
+## Decision 1 — Rotation rides the CONFIG packet
+
+Rotation rides the **video CONFIG packet** (the SPS/PPS packet, `PACKET_FLAG_CONFIG`),
+not a one-shot stream-header field, because:
+
+1. A config packet is already emitted at stream start **and** on every encoder
+   swap — including [#4785](https://github.com/kaeawc/auto-mobile/issues/4785)'s
+   rotation-driven swap, which tears down the old encoder and brings up a new one
+   at the post-rotation dimensions. The new encoder's SPS/PPS is a fresh config
+   packet, so rotation is re-attested exactly when it changes.
+2. The config packet is stored in `VideoStreamWriter`'s replay cache
+   (`VideoPacketCache`). A late-attaching or reconnecting client replays the
+   **current** config packet, so it replays the current rotation for free.
+
+A one-shot stream-header rotation field would go stale after the first rotation —
+the header is written once per client attach, never re-sent mid-stream — so it
+was rejected.
+
+## Decision 2 — Encoding: 2 bits carved from `ptsAndFlags`
+
+Rotation `0..3` is carved into 2 previously-unused bits of the 64-bit
+`ptsAndFlags` word, interpreted **only on config packets**.
+
+### Layer 1 bit layout (`VideoStreamProtocol.kt` ↔ `VideoServerStreamParser.ts`)
+
+| Bit(s) | Meaning | Before | After |
+|--------|---------|--------|-------|
+| 63 | `CONFIG` | ✓ | ✓ |
+| 62 | `KEY_FRAME` | ✓ | ✓ |
+| 61 | `REPLAYED` | ✓ | ✓ |
+| 60–59 | `ROTATION` (config only) | *(part of PTS)* | **new** |
+| 58–0 | PTS (µs) | bits 0–60 | bits 0–58 (`PTS_MASK` narrowed) |
+
+`ROTATION_SHIFT = 59`, `ROTATION_MASK = 0b11 << 59`, `PTS_MASK = (1 << 59) - 1`.
+
+### Backward-compatibility argument (verified against the code)
+
+A real presentation timestamp is in **microseconds**. Bit 59 has place value
+`2^59 µs ≈ 5.76e17 µs ≈ 1.8e4 years`, so a genuine PTS never sets bits 59–60.
+Therefore:
+
+- **Old encoders** wrote `0` into bits 59–60 (they were the low PTS bits, always
+  zero for real timestamps).
+- **Old parsers** read bits 59–60 as (zero) PTS bits, so masking them off in the
+  new parser changes no observable PTS.
+- **New parsers** reading an old stream see rotation bits `0` → rotation `0`.
+
+The last point is safe on layer 1 by a stronger property than the always-zero
+argument: the daemon **always pushes and integrity-verifies its own bundled jar**
+([#4733](https://github.com/kaeawc/auto-mobile/issues/4733)), so a v2 daemon
+never reads a v1 persistent-encoder stream. Every config packet the layer-1
+parser sees is from a matching v2 jar and carries a real rotation. Non-attesting
+sources (screenrecord fallback, iOS) emit raw Annex-B with **no** layer-1 framing
+at all — they never reach `VideoServerStreamParser`. So on layer 1, "config
+packet ⇒ rotation is present and valid"; no presence bit is needed.
+
+### Layer 2 bit layout (`videoStreamFraming.ts` ↔ desktop `VideoStreamParser.kt`)
+
+The relay aggregates from possibly-**non-attesting** sources (screenrecord, iOS),
+so here rotation may be absent. Layer 2 has no `REPLAYED` flag, so **bit 61 is
+free** and is repurposed as a `ROTATION_PRESENT` marker:
+
+| Bit(s) | Meaning |
+|--------|---------|
+| 63 | `CONFIG` |
+| 62 | `KEY_FRAME` |
+| 61 | `ROTATION_PRESENT` (config only) |
+| 60–59 | `ROTATION` (config only) |
+| 58–0 | PTS (µs), `PTS_MASK = (1 << 59) - 1` (narrowed from bits 0–61) |
+
+The desktop parser returns `rotation: Int? = null` unless a config packet has bit
+61 set; only then does it read bits 59–60. This cleanly encodes "unknown" (no
+bit) distinctly from the valid value `0`. Backward compatible: the old relay
+never set bit 61 and PTS never reaches it, so old streams decode to `null`
+(control fails closed, the prior behavior).
+
+The two layers deliberately assign bit 61 different meanings (`REPLAYED` vs
+`ROTATION_PRESENT`). They are separate protocols with separate parsers and
+already-different PTS masks; the asymmetry is intentional and documented here so
+the relay never conflates them.
+
+## Decision 3 — Versioning
+
+`MUX_VERSION` is bumped **1 → 2** in the layer-1 mux header to signal v2
+semantics. The legacy 12-byte header (`legacyHeader`, video-only — the common
+case when audio is disabled) stays byte-for-byte decodable; the parser still
+accepts it unchanged.
+
+The **legacy (non-mux) path attests rotation via the same config-packet bits and
+needs no version field**, justified by the layer-1 argument above: the always-zero
+property plus the jar-integrity coupling mean a v2 daemon only ever reads a v2
+jar's config packets, whether the header is mux or legacy. Gating attestation on
+`MUX_VERSION` would have left the common video-only path un-attested, defeating
+the feature.
+
+Layer 2 needs no version field: the `ROTATION_PRESENT` bit is self-describing and
+safe by the always-zero argument.
+
+## Decision 4 — Stale header dimensions
+
+The one-shot header width/height go stale after a rotation-driven encoder swap
+(a known leftover from [#4785](https://github.com/kaeawc/auto-mobile/issues/4785)).
+Semantics are pinned as:
+
+- **Header dims = initial only.** Advisory, for sizing a surface before the first
+  keyframe. Not re-sent on rotation.
+- **Authoritative dims come from the in-band H.264 SPS**, which the decoder reads
+  and which changes on rotation (`VideoStreamState.Streaming(width, height)` is
+  already updated from the decoded frame, not the header).
+- **Rotation comes from the config-packet metadata** defined here.
+
+## Decision 5 — Replay-cache ordering
+
+`VideoStreamWriter` replays cached config + IDR to a replacement/reconnecting
+client. Because rotation rides the config packet itself, the existing replay
+already carries the current rotation — the same `VideoPacketCache` entry holds
+both the SPS/PPS bytes and the rotation bits. The rotation-swap path already
+resets the cache atomically before the new encoder's config repopulates it
+(`resetReplayCacheForResize`), so a reconnecting client can never replay a stale
+rotation paired with new parameter sets. On layer 2, the relay includes the
+current rotation in the parameter-set replay it sends a late joiner
+(`replayParameterSets`). Both are covered by tests.
+
+## Files
+
+- **Layer-1 protocol:** `android/video-server/.../VideoStreamProtocol.kt`
+- **Layer-1 producer:** `android/video-server/.../VideoStreamWriter.kt`,
+  `VideoServer.kt`
+- **Layer-1 parser (daemon):** `src/features/webrtc/VideoServerStreamParser.ts`,
+  `PersistentEncoderH264Source.ts`
+- **Layer-2 producer (daemon):** `src/daemon/videoStreamFraming.ts`,
+  `videoStreamSocketServer.ts`
+- **Layer-2 parser (desktop):** `android/desktop-core/.../video/VideoStreamParser.kt`,
+  `VideoStreamClient.kt`
+- **Consumer:** `android/desktop-core/.../AutoMobileContent.kt`
+  (`LiveVideoFrame.rotation`), consumed by
+  `control/DeviceControlSession.kt` (unchanged).

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -162,6 +162,7 @@ nav:
             - 'Overview': design-docs/plat/android/index.md
             - 'Observe': design-docs/plat/android/observe.md
             - 'Screen Streaming': design-docs/plat/android/screen-streaming.md
+            - 'Video-Stream Rotation Attestation': design-docs/plat/android/video-stream-rotation-attestation.md
             - 'Emulator Startup': design-docs/plat/android/emulator-startup.md
             - 'CtrlProxy': design-docs/plat/android/control-proxy.md
             - 'AutoMobile SDK': design-docs/plat/android/auto-mobile-sdk.md

--- a/src/daemon/videoStreamFraming.ts
+++ b/src/daemon/videoStreamFraming.ts
@@ -16,8 +16,25 @@ export const PACKET_FLAG_CONFIG = 1n << 63n;
 /** Bit 62 of `ptsAndFlags`: key frame. */
 export const PACKET_FLAG_KEY_FRAME = 1n << 62n;
 
-/** Bits 0-61 carry the presentation timestamp. */
-export const PTS_MASK = (1n << 62n) - 1n;
+/**
+ * Bit 61 of `ptsAndFlags`: ROTATION_PRESENT (issue #4786). Set on a CONFIG packet whose bits 60-59
+ * carry an attested display rotation. This layer has no REPLAYED flag, so bit 61 is free — it is a
+ * presence marker distinct from the device-side protocol's bit 61 (REPLAYED). A relay whose source
+ * cannot attest rotation (screenrecord, iOS) leaves this bit clear, and the desktop reads `null`
+ * (control fails closed).
+ */
+export const PACKET_FLAG_ROTATION_PRESENT = 1n << 61n;
+
+/** Attested display rotation (0..3) occupies bits 60-59 of a CONFIG packet (issue #4786). */
+export const ROTATION_SHIFT = 59n;
+export const ROTATION_MASK = 0b11n << ROTATION_SHIFT;
+
+/**
+ * Bits 0-58 carry the presentation timestamp. Narrowed from bits 0-61 to make room for the rotation
+ * presence bit and field; backward compatible because a real microsecond PTS never reaches bit 59
+ * (~18 000 years), so older streams wrote 0 there and older parsers read them as zero PTS.
+ */
+export const PTS_MASK = (1n << ROTATION_SHIFT) - 1n;
 
 /**
  * The 12-byte stream header: codec id, then width and height.
@@ -36,11 +53,21 @@ export function encodeStreamHeader(width: number = 0, height: number = 0): Buffe
 
 export function encodePtsAndFlags(
   presentationTimeUs: bigint,
-  { isConfig = false, isKeyFrame = false }: { isConfig?: boolean; isKeyFrame?: boolean } = {}
+  {
+    isConfig = false,
+    isKeyFrame = false,
+    rotation = null,
+  }: { isConfig?: boolean; isKeyFrame?: boolean; rotation?: number | null } = {}
 ): bigint {
   let ptsAndFlags = presentationTimeUs & PTS_MASK;
   if (isConfig) {
     ptsAndFlags |= PACKET_FLAG_CONFIG;
+    // Attest rotation ONLY on config packets, and only when the source proved it; a null rotation
+    // (screenrecord/iOS) leaves the presence bit clear so the desktop reads `null` (issue #4786).
+    if (rotation !== null) {
+      ptsAndFlags |= PACKET_FLAG_ROTATION_PRESENT;
+      ptsAndFlags |= (BigInt(rotation) & 0b11n) << ROTATION_SHIFT;
+    }
   }
   if (isKeyFrame) {
     ptsAndFlags |= PACKET_FLAG_KEY_FRAME;

--- a/src/daemon/videoStreamSocketServer.ts
+++ b/src/daemon/videoStreamSocketServer.ts
@@ -28,6 +28,8 @@ export type CaptureSourceFactory = (options: {
   device: BootedDevice;
   onData: (chunk: Buffer) => void;
   onError: (error: Error) => void;
+  /** Receives the attested display rotation (0..3) when the source can prove it (issue #4786). */
+  onRotation?: (rotation: number) => void;
   bitrateBps?: number;
   size?: { width: number; height: number };
   /** Capture rate for iOS Simulator sources; see the call site for why it is pinned. */
@@ -55,6 +57,12 @@ interface DeviceCapture {
   pps: Buffer | null;
   parser: H264AnnexBParser;
   size?: { width: number; height: number };
+  /**
+   * Latest attested display rotation (0..3) from the source, or null when the source cannot attest
+   * it (screenrecord/iOS) or none has arrived yet (issue #4786). Re-emitted on every config packet
+   * the relay writes so a late joiner or a post-rotation client sees the current orientation.
+   */
+  rotation: number | null;
 }
 
 const ANNEX_B_START_CODE = Buffer.from([0, 0, 0, 1]);
@@ -207,6 +215,7 @@ export class VideoStreamSocketServer extends BaseSocketServer {
       pps: null,
       parser: new H264AnnexBParser(),
       size: request.size,
+      rotation: null,
     };
     // Registered before start() so a chunk arriving during startup still finds its subscribers.
     this.captures.set(deviceId, capture);
@@ -216,6 +225,14 @@ export class VideoStreamSocketServer extends BaseSocketServer {
       const source = await this.deps.createCaptureSource({
         device,
         onData: chunk => this.broadcast(deviceId, chunk),
+        // Record the source's attested rotation so the next config packet re-attests it to
+        // subscribers, including a late joiner via replayParameterSets (issue #4786).
+        onRotation: rotation => {
+          const current = this.captures.get(deviceId);
+          if (current) {
+            current.rotation = rotation;
+          }
+        },
         onError: error => {
           logger.warn(`[VideoStream] capture failed for ${deviceId}: ${error}`);
           void this.stopCapture(deviceId);
@@ -274,35 +291,54 @@ export class VideoStreamSocketServer extends BaseSocketServer {
     if (type === NAL_TYPE_PPS) {capture.pps = Buffer.from(nal);}
 
     const isKeyFrame = type === NAL_TYPE_IDR;
+    // Attest the current rotation on config packets so a client can re-prove orientation from the
+    // live stream alone after a rotation (issue #4786); non-config packets carry no rotation.
+    const rotation = isConfig ? capture.rotation : null;
     const packet = encodePacket(
-      encodePtsAndFlags(this.deps.nowUs(), { isConfig, isKeyFrame }),
+      encodePtsAndFlags(this.deps.nowUs(), { isConfig, isKeyFrame, rotation }),
       Buffer.concat([ANNEX_B_START_CODE, nal])
     );
 
     for (const subscriber of capture.subscribers) {
-      if (subscriber.destroyed) {
-        this.detach(subscriber);
-        continue;
+      this.writePacketToSubscriber(deviceId, capture, subscriber, packet, isConfig, isKeyFrame);
+    }
+  }
+
+  /**
+   * Deliver one framed packet to a single subscriber, honoring the destroyed/backpressured/
+   * awaiting-keyframe gates. Extracted from [broadcastNal] so that method stays under the
+   * cyclomatic-complexity ratchet.
+   */
+  private writePacketToSubscriber(
+    deviceId: string,
+    capture: DeviceCapture,
+    subscriber: Socket,
+    packet: Buffer,
+    isConfig: boolean,
+    isKeyFrame: boolean
+  ): void {
+    if (subscriber.destroyed) {
+      this.detach(subscriber);
+      return;
+    }
+    if (capture.backpressuredSubscribers.has(subscriber)) {return;}
+    if (capture.waitingForKeyFrame.has(subscriber)) {
+      // Keep codec configuration flowing while waiting for an IDR. A late
+      // join can occur after SPS but before PPS, and suppressing PPS leaves
+      // the otherwise complete IDR undecodable.
+      if (!isKeyFrame && !isConfig) {return;}
+      if (isKeyFrame) {
+        capture.waitingForKeyFrame.delete(subscriber);
       }
-      if (capture.backpressuredSubscribers.has(subscriber)) {continue;}
-      if (capture.waitingForKeyFrame.has(subscriber)) {
-        // Keep codec configuration flowing while waiting for an IDR. A late
-        // join can occur after SPS but before PPS, and suppressing PPS leaves
-        // the otherwise complete IDR undecodable.
-        if (!isKeyFrame && !isConfig) {continue;}
-        if (isKeyFrame) {
-          capture.waitingForKeyFrame.delete(subscriber);
-        }
-      }
-      if (!subscriber.write(packet)) {
-        logger.debug(`[VideoStream] subscriber is behind on ${deviceId}; dropping to next key frame`);
-        capture.backpressuredSubscribers.add(subscriber);
-        capture.waitingForKeyFrame.add(subscriber);
-        subscriber.once("drain", () => {
-          const current = this.captures.get(deviceId);
-          current?.backpressuredSubscribers.delete(subscriber);
-        });
-      }
+    }
+    if (!subscriber.write(packet)) {
+      logger.debug(`[VideoStream] subscriber is behind on ${deviceId}; dropping to next key frame`);
+      capture.backpressuredSubscribers.add(subscriber);
+      capture.waitingForKeyFrame.add(subscriber);
+      subscriber.once("drain", () => {
+        const current = this.captures.get(deviceId);
+        current?.backpressuredSubscribers.delete(subscriber);
+      });
     }
   }
 
@@ -310,7 +346,14 @@ export class VideoStreamSocketServer extends BaseSocketServer {
     const parameterSets = [capture.sps, capture.pps].filter((nal): nal is Buffer => nal !== null);
     if (parameterSets.length === 0) {return;}
     const payload = Buffer.concat(parameterSets.flatMap(nal => [ANNEX_B_START_CODE, nal]));
-    socket.write(encodePacket(encodePtsAndFlags(this.deps.nowUs(), { isConfig: true }), payload));
+    // Replayed parameter sets carry the current rotation too, so a late joiner never applies a
+    // stale orientation before the next live config packet (issue #4786).
+    socket.write(
+      encodePacket(
+        encodePtsAndFlags(this.deps.nowUs(), { isConfig: true, rotation: capture.rotation }),
+        payload
+      )
+    );
   }
 
   private detach(socket: Socket): void {
@@ -402,7 +445,18 @@ function defaultDependencies(): VideoStreamSocketServerDependencies {
       // Resolved once per stream, off the frame path. A null jar means the Android source falls
       // back to `screenrecord`.
       const jarPath = await resolveVideoServerJar();
-      return createH264CaptureSource(options, jarPath);
+      return createH264CaptureSource(
+        {
+          device: options.device,
+          onData: options.onData,
+          onError: options.onError,
+          onRotation: options.onRotation,
+          bitrateBps: options.bitrateBps,
+          size: options.size,
+          fps: options.fps,
+        },
+        jarPath
+      );
     },
     nowUs: () => BigInt(Math.round(performance.now() * 1000)),
   };

--- a/src/features/webrtc/H264CaptureSource.ts
+++ b/src/features/webrtc/H264CaptureSource.ts
@@ -22,6 +22,12 @@ export interface H264CaptureSourceOptions {
   onData: (chunk: Buffer) => void;
   /** Called with each chunk of 8 kHz mono PCM16LE audio when audio is enabled. */
   onAudioData?: (chunk: Buffer) => void;
+  /**
+   * Called with the attested display rotation (0..3) when the source can prove it (issue #4786).
+   * Only the Android persistent encoder attests today; screenrecord and iOS sources omit it, so a
+   * consumer that never receives a call leaves rotation unknown (control fails closed).
+   */
+  onRotation?: (rotation: number) => void;
   /** Called when the source fails fatally after it has started. */
   onError?: (error: Error) => void;
   bitrateBps?: number;

--- a/src/features/webrtc/PersistentEncoderH264Source.ts
+++ b/src/features/webrtc/PersistentEncoderH264Source.ts
@@ -265,6 +265,12 @@ export interface PersistentEncoderH264SourceOptions {
   onData: (chunk: Buffer) => void;
   /** Called with each chunk of 8 kHz mono PCM16LE audio when enabled. */
   onAudioData?: (chunk: Buffer) => void;
+  /**
+   * Called with the attested display rotation (0..3) each time the device emits a CONFIG packet —
+   * at stream start and on every #4785 rotation-driven encoder swap (issue #4786). The live-mirror
+   * relay records this so it can re-attest rotation to desktop clients.
+   */
+  onRotation?: (rotation: number) => void;
   /** Called when the source fails fatally after a successful start. */
   onError?: (error: Error) => void;
   bitrateBps?: number;
@@ -1399,6 +1405,11 @@ export class PersistentEncoderH264Source implements H264CaptureSource {
         if (this.socket === socket) {
           if (packet.codecId === VIDEO_SERVER_CODEC_ID_H264) {
             this.observeVideoPacket(packet);
+            // A CONFIG packet attests the current display rotation (issue #4786). Surface it before
+            // the payload so the relay's rotation is current when the SPS/PPS reaches subscribers.
+            if (packet.config && packet.rotation !== undefined) {
+              this.options.onRotation?.(packet.rotation);
+            }
             this.options.onData(packet.data);
           } else if (packet.codecId === VIDEO_SERVER_CODEC_ID_PCM16) {
             this.options.onAudioData?.(packet.data);

--- a/src/features/webrtc/VideoServerStreamParser.ts
+++ b/src/features/webrtc/VideoServerStreamParser.ts
@@ -11,7 +11,8 @@
  *   - bit 63 of `pts_and_flags`: CONFIG (codec config / SPS+PPS)
  *   - bit 62: KEY_FRAME (IDR)
  *   - bit 61: REPLAYED (cached packet for a replacement client)
- *   - bits 0-60: presentation timestamp (microseconds)
+ *   - bits 60-59: display ROTATION (0..3), attested on CONFIG packets only (issue #4786)
+ *   - bits 0-58: presentation timestamp (microseconds)
  *
  * Each packet payload is already Annex-B (MediaCodec AVC byte-buffer output), so
  * the concatenation of payloads is a valid Annex-B elementary stream — exactly
@@ -56,7 +57,16 @@ export const MAX_TRACK_COUNT = 16;
 const FLAG_CONFIG = 1n << 63n;
 const FLAG_KEY_FRAME = 1n << 62n;
 const FLAG_REPLAYED = 1n << 61n;
-const PTS_MASK = FLAG_REPLAYED - 1n;
+/**
+ * Display rotation (0..3) occupies bits 60-59 of `ptsAndFlags`, attested on CONFIG packets only
+ * (issue #4786). A real microsecond PTS never reaches bit 59 (~18 000 years), so narrowing the PTS
+ * mask to bits 0-58 is backward compatible: old streams wrote 0 there.
+ */
+const ROTATION_SHIFT = 59n;
+const ROTATION_MASK = 0b11n << ROTATION_SHIFT;
+const PTS_MASK = (1n << ROTATION_SHIFT) - 1n;
+/** Mux header wire version whose config packets attest rotation in bits 60-59 (issue #4786). */
+export const VIDEO_SERVER_MUX_VERSION = 2;
 
 export interface VideoServerStreamHeader {
   codecId: number;
@@ -64,6 +74,8 @@ export interface VideoServerStreamHeader {
   height: number;
   muxed?: boolean;
   audio?: boolean;
+  /** Mux wire version (issue #4786); present only for the muxed header, absent for legacy. */
+  muxVersion?: number;
 }
 
 export interface VideoServerPacket {
@@ -77,6 +89,12 @@ export interface VideoServerPacket {
   keyFrame: boolean;
   /** Cached packet replayed for a replacement LocalSocket client. */
   replayed: boolean;
+  /**
+   * Attested display rotation (0..3), present ONLY on CONFIG packets (issue #4786); `undefined` on
+   * non-config packets. A config packet always carries a valid rotation, so `undefined` here means
+   * "not a config packet", never "config packet without rotation".
+   */
+  rotation?: number;
   /** Presentation timestamp in microseconds. */
   ptsUs: number;
 }
@@ -99,6 +117,17 @@ export class VideoServerStreamParser {
   private muxTracks: Map<number, { codecId: number; param1: number; param2: number }> | null = null;
 
   constructor(private readonly callbacks: VideoServerStreamParserCallbacks) {}
+
+  /**
+   * Extract the attested rotation (0..3) from a packet's flags, but only for CONFIG packets — the
+   * rotation bits are undefined on any other packet (issue #4786).
+   */
+  private static rotationFromFlags(flags: bigint): number | undefined {
+    if ((flags & FLAG_CONFIG) === 0n) {
+      return undefined;
+    }
+    return Number((flags & ROTATION_MASK) >> ROTATION_SHIFT);
+  }
 
   /**
    * Guard a size/track-count read against its cap. A declared length over the
@@ -149,7 +178,12 @@ export class VideoServerStreamParser {
           }
         }
         if (videoHeader) {
-          this.header = { ...videoHeader, muxed: true, audio: hasPcmAudioTrack };
+          this.header = {
+            ...videoHeader,
+            muxed: true,
+            audio: hasPcmAudioTrack,
+            muxVersion: fullHeader.readUInt32BE(4),
+          };
           this.callbacks.onHeader?.(this.header);
         }
         this.buffered.discard(headerBytes);
@@ -186,6 +220,7 @@ export class VideoServerStreamParser {
         config: (flags & FLAG_CONFIG) !== 0n,
         keyFrame: (flags & FLAG_KEY_FRAME) !== 0n,
         replayed: (flags & FLAG_REPLAYED) !== 0n,
+        rotation: VideoServerStreamParser.rotationFromFlags(flags),
         ptsUs: Number(flags & PTS_MASK),
       });
     }
@@ -214,6 +249,7 @@ export class VideoServerStreamParser {
         config: (flags & FLAG_CONFIG) !== 0n,
         keyFrame: (flags & FLAG_KEY_FRAME) !== 0n,
         replayed: (flags & FLAG_REPLAYED) !== 0n,
+        rotation: VideoServerStreamParser.rotationFromFlags(flags),
         ptsUs: Number(flags & PTS_MASK),
       });
     }

--- a/src/features/webrtc/androidH264CaptureSourceFactory.ts
+++ b/src/features/webrtc/androidH264CaptureSourceFactory.ts
@@ -120,6 +120,7 @@ export function createAndroidH264CaptureSource(
     device: options.device,
     onData: options.onData,
     onAudioData: options.onAudioData,
+    onRotation: options.onRotation,
     onError: options.onError,
     bitrateBps: options.bitrateBps,
     size: options.size,

--- a/test/daemon/videoStreamFraming.test.ts
+++ b/test/daemon/videoStreamFraming.test.ts
@@ -9,6 +9,10 @@ import {
   isParameterSetChunk,
   PACKET_FLAG_CONFIG,
   PACKET_FLAG_KEY_FRAME,
+  PACKET_FLAG_ROTATION_PRESENT,
+  PTS_MASK,
+  ROTATION_MASK,
+  ROTATION_SHIFT,
 } from "../../src/daemon/videoStreamFraming";
 
 /** Annex-B chunk with a 4-byte start code and the given NAL type. */
@@ -59,6 +63,34 @@ describe("videoStreamFraming", () => {
 
       expect(ptsAndFlags & PACKET_FLAG_CONFIG).toBe(0n);
       expect(ptsAndFlags).toBe(7n);
+    });
+
+    // --- Rotation attestation (issue #4786), layer 2 ---
+
+    test("a config packet attests rotation with the presence bit and a 2-bit field", () => {
+      for (const rotation of [0, 1, 2, 3]) {
+        const ptsAndFlags = encodePtsAndFlags(1000n, { isConfig: true, rotation });
+
+        expect(ptsAndFlags & PACKET_FLAG_ROTATION_PRESENT).toBe(PACKET_FLAG_ROTATION_PRESENT);
+        expect((ptsAndFlags & ROTATION_MASK) >> ROTATION_SHIFT).toBe(BigInt(rotation));
+        // The rotation field must not leak into the timestamp.
+        expect(ptsAndFlags & PTS_MASK).toBe(1000n);
+      }
+    });
+
+    test("a null rotation leaves the presence bit clear so the desktop reads unknown", () => {
+      const ptsAndFlags = encodePtsAndFlags(1000n, { isConfig: true, rotation: null });
+
+      expect(ptsAndFlags & PACKET_FLAG_ROTATION_PRESENT).toBe(0n);
+      expect(ptsAndFlags & ROTATION_MASK).toBe(0n);
+    });
+
+    test("rotation is ignored on a non-config packet", () => {
+      const ptsAndFlags = encodePtsAndFlags(1000n, { isKeyFrame: true, rotation: 3 });
+
+      expect(ptsAndFlags & PACKET_FLAG_ROTATION_PRESENT).toBe(0n);
+      expect(ptsAndFlags & ROTATION_MASK).toBe(0n);
+      expect(ptsAndFlags & PTS_MASK).toBe(1000n);
     });
   });
 

--- a/test/daemon/videoStreamSocketServer.test.ts
+++ b/test/daemon/videoStreamSocketServer.test.ts
@@ -46,6 +46,8 @@ interface Harness {
   sources: FakeCaptureSource[];
   captureOptions: Array<{ fps?: number }>;
   emit: (chunk: Buffer) => void;
+  /** Simulates the source attesting a display rotation (issue #4786). */
+  emitRotation: (rotation: number) => void;
   cleanup: () => Promise<void>;
 }
 
@@ -65,6 +67,7 @@ async function startHarness(
   const socketPath = path.join(dir, "video-stream.sock");
   const sources: FakeCaptureSource[] = [];
   let onData: ((chunk: Buffer) => void) | null = null;
+  let onRotation: ((rotation: number) => void) | null = null;
   const captureOptions: Array<{ fps?: number }> = [];
 
   const server = new VideoStreamSocketServer(
@@ -77,6 +80,7 @@ async function startHarness(
       },
       createCaptureSource: async opts => {
         onData = opts.onData;
+        onRotation = opts.onRotation ?? null;
         captureOptions.push(opts);
         const source = new FakeCaptureSource();
         source.startError = options.startError ?? null;
@@ -97,6 +101,7 @@ async function startHarness(
     sources,
     captureOptions,
     emit: chunk => onData?.(chunk),
+    emitRotation: rotation => onRotation?.(rotation),
     cleanup: async () => {
       await server.close();
       rmSync(dir, { recursive: true, force: true });
@@ -264,6 +269,7 @@ describe("VideoStreamSocketServer", () => {
           socketPath,
           sources: [source],
           emit: () => {},
+          emitRotation: () => {},
           cleanup: async () => {
             await server.close();
             rmSync(dir, { recursive: true, force: true });
@@ -315,6 +321,7 @@ describe("VideoStreamSocketServer", () => {
       socketPath,
       sources: [abandonedSource, replacementSource],
       emit: () => {},
+      emitRotation: () => {},
       cleanup: async () => {
         await server.close();
         rmSync(dir, { recursive: true, force: true });
@@ -400,6 +407,46 @@ describe("VideoStreamSocketServer", () => {
     expect(packet.readInt32BE(8)).toBe(sps.length);
     expect(packet.subarray(12, 12 + sps.length)).toEqual(sps);
     expect(packet.readBigInt64BE(0)).toBeLessThan(0n); // CONFIG flag is bit 63
+  });
+
+  test("attests the source's rotation on a config packet and its replay (issue #4786)", async () => {
+    const ROTATION_PRESENT = 1n << 61n;
+    const ROTATION_SHIFT = 59n;
+    const h = await startHarness();
+    const first = await subscribe(h.socketPath);
+    await waitFor(() => first.binary().length >= 12);
+
+    // The source attests rotation 3, then emits SPS: the config packet must carry it.
+    h.emitRotation(3);
+    const sps = Buffer.from([0x00, 0x00, 0x00, 0x01, 0x07, 0x64, 0x00]);
+    h.emit(Buffer.concat([sps, Buffer.from([0x00, 0x00, 0x00, 0x01, 0x08])]));
+    await waitFor(() => first.binary().length > 12);
+
+    const flags = BigInt.asUintN(64, first.binary().subarray(12).readBigInt64BE(0));
+    expect(flags & ROTATION_PRESENT).toBe(ROTATION_PRESENT);
+    expect((flags >> ROTATION_SHIFT) & 0b11n).toBe(3n);
+
+    // A late joiner is replayed the parameter sets and must see the current rotation there too.
+    const late = await subscribe(h.socketPath);
+    await waitFor(() => late.binary().length > 12);
+    const replayFlags = BigInt.asUintN(64, late.binary().subarray(12).readBigInt64BE(0));
+    expect(replayFlags & ROTATION_PRESENT).toBe(ROTATION_PRESENT);
+    expect((replayFlags >> ROTATION_SHIFT) & 0b11n).toBe(3n);
+  });
+
+  test("leaves the rotation-present bit clear when the source never attests rotation", async () => {
+    const ROTATION_PRESENT = 1n << 61n;
+    const h = await startHarness();
+    const client = await subscribe(h.socketPath);
+    await waitFor(() => client.binary().length >= 12);
+
+    // No emitRotation call: a screenrecord/iOS source. The config packet must not claim a rotation.
+    // The trailing start code flushes the SPS NAL through the incremental Annex-B parser.
+    h.emit(Buffer.from([0x00, 0x00, 0x00, 0x01, 0x07, 0x64, 0x00, 0x00, 0x00, 0x00, 0x01, 0x08]));
+    await waitFor(() => client.binary().length > 12);
+
+    const flags = BigInt.asUintN(64, client.binary().subarray(12).readBigInt64BE(0));
+    expect(flags & ROTATION_PRESENT).toBe(0n);
   });
 
   test("forwards a PPS that arrives after a late viewer's replayed SPS", async () => {

--- a/test/features/webrtc/PersistentEncoderH264Source.test.ts
+++ b/test/features/webrtc/PersistentEncoderH264Source.test.ts
@@ -458,6 +458,25 @@ describe("PersistentEncoderH264Source", () => {
     await ctx.source.stop();
   });
 
+  test("surfaces the attested rotation from a config packet via onRotation (issue #4786)", async () => {
+    const rotations: number[] = [];
+    const ctx = makeSource({ onRotation: (rotation: number) => rotations.push(rotation) });
+    await startReady(ctx);
+
+    const FLAG_CONFIG = 1n << 63n;
+    const rotationBits = (rotation: number): bigint => (BigInt(rotation) & 0b11n) << 59n;
+    ctx.sockets[0].feed(streamHeader(480, 1040));
+    // Config packet attesting rotation 3, then a non-config frame that must NOT report rotation.
+    ctx.sockets[0].feed(framedPacket(Buffer.from([0, 0, 0, 1, 0x67]), FLAG_CONFIG | rotationBits(3)));
+    ctx.sockets[0].feed(framedPacket(Buffer.from([0, 0, 0, 1, 0x65])));
+
+    expect(rotations).toEqual([3]);
+    // The config payload still flows to onData unchanged.
+    expect(ctx.chunks[0]).toEqual(Buffer.from([0, 0, 0, 1, 0x67]));
+
+    await ctx.source.stop();
+  });
+
   test("omits --fps when no frame rate is requested, letting the preset default apply", async () => {
     const ctx = makeSource();
     await startReady(ctx);

--- a/test/features/webrtc/VideoServerStreamParser.test.ts
+++ b/test/features/webrtc/VideoServerStreamParser.test.ts
@@ -16,7 +16,13 @@ import {
 const FLAG_CONFIG = 1n << 63n;
 const FLAG_KEY_FRAME = 1n << 62n;
 const FLAG_REPLAYED = 1n << 61n;
-const PTS_MASK = FLAG_REPLAYED - 1n;
+const ROTATION_SHIFT = 59n;
+const PTS_MASK = (1n << ROTATION_SHIFT) - 1n;
+
+/** Rotation bits (0..3) as the on-device encoder writes them into a CONFIG packet's flags. */
+function rotationBits(rotation: number): bigint {
+  return (BigInt(rotation) & 0b11n) << ROTATION_SHIFT;
+}
 
 function streamHeader(width: number, height: number): Buffer {
   const buf = Buffer.alloc(12);
@@ -87,6 +93,8 @@ describe("VideoServerStreamParser", () => {
       config: true,
       keyFrame: false,
       replayed: false,
+      // A config packet always attests rotation; 0 here (no rotation bits set) is a valid value.
+      rotation: 0,
       ptsUs: 0,
     });
     expect(packets[1]).toEqual({
@@ -164,6 +172,7 @@ describe("VideoServerStreamParser", () => {
         height: 1280,
         muxed: true,
         audio: true,
+        muxVersion: 1,
       },
     ]);
     expect(packets.map(packet => [packet.trackId, packet.codecId, packet.ptsUs])).toEqual([
@@ -288,5 +297,64 @@ describe("VideoServerStreamParser", () => {
 
     expect(headers).toEqual([]);
     expect(packets).toEqual([]);
+  });
+
+  // --- Rotation attestation (issue #4786) ---
+
+  test("decodes the attested rotation from a config packet for every value 0..3", () => {
+    for (const rotation of [0, 1, 2, 3]) {
+      const { parser, packets } = collect();
+      parser.push(streamHeader(1080, 2400));
+      parser.push(
+        packet(Buffer.from([0, 0, 0, 1, 0x67]), FLAG_CONFIG | rotationBits(rotation), 4242)
+      );
+
+      expect(packets).toHaveLength(1);
+      expect(packets[0].config).toBe(true);
+      expect(packets[0].rotation).toBe(rotation);
+      // The rotation bits must not leak into the presentation timestamp.
+      expect(packets[0].ptsUs).toBe(4242);
+    }
+  });
+
+  test("leaves rotation undefined on a non-config packet even if the pts is large", () => {
+    const { parser, packets } = collect();
+    parser.push(streamHeader(1080, 2400));
+    // A key frame is not a config packet: rotation is meaningless and must be undefined.
+    parser.push(packet(Buffer.from([0, 0, 0, 1, 0x65]), FLAG_KEY_FRAME, 123456));
+
+    expect(packets[0].config).toBe(false);
+    expect(packets[0].rotation).toBeUndefined();
+    expect(packets[0].ptsUs).toBe(123456);
+  });
+
+  test("a replayed config packet still surfaces the current rotation", () => {
+    // The device replays cached SPS/PPS to a reconnecting client; rotation rides that same config
+    // packet, so a reattaching client reads the current orientation without a fresh keyframe.
+    const { parser, packets } = collect();
+    parser.push(streamHeader(1080, 2400));
+    parser.push(
+      packet(Buffer.from([0, 0, 0, 1, 0x67]), FLAG_CONFIG | FLAG_REPLAYED | rotationBits(3), 10)
+    );
+
+    expect(packets[0]).toMatchObject({ config: true, replayed: true, rotation: 3, ptsUs: 10 });
+  });
+
+  test("a v1-shaped config packet (no rotation bits) decodes to rotation 0, not a corrupt pts", () => {
+    // Backward compatibility: an old stream wrote 0 into bits 59-60, so the narrowed PTS mask must
+    // still read the timestamp cleanly and report rotation 0.
+    const { parser, packets } = collect();
+    parser.push(streamHeader(1080, 2400));
+    parser.push(packet(Buffer.from([0, 0, 0, 1, 0x67]), FLAG_CONFIG, 987654));
+
+    expect(packets[0].rotation).toBe(0);
+    expect(packets[0].ptsUs).toBe(987654);
+  });
+
+  test("reports the mux wire version from the muxed header", () => {
+    const { parser, headers } = collect();
+    parser.push(muxHeader());
+
+    expect(headers[0].muxVersion).toBe(1);
   });
 });


### PR DESCRIPTION
## What & why

The live video-stream protocol carried no display-rotation metadata, so no consumer could prove a live frame's orientation. `DeviceControlSession` already reads `liveFrame?.rotation` in its proven-rotation gate — the consumer side was built and waiting — but `LiveVideoFrame.rotation` was never populated, so after a mid-stream rotation device control stayed blocked/degraded until a screenshot/hierarchy source re-proved orientation. Dimensions alone can't substitute: WxH↔HxW disambiguates portrait from landscape but not rotation `0`-vs-`2` or `1`-vs-`3`; the gate needs the full `0..3` value.

This is the protocol/attestation half of the rotation work. The capture-path half (recreating the encoder on rotation) shipped in #4785 / #4947.

**Design doc:** [`docs/design-docs/plat/android/video-stream-rotation-attestation.md`](docs/design-docs/plat/android/video-stream-rotation-attestation.md)

## Wire-format decision

Rotation rides the **CONFIG packet** (SPS/PPS, `PACKET_FLAG_CONFIG`), not a one-shot stream header: config is re-emitted at stream start **and** on every #4785 rotation-driven encoder swap, and it lives in `VideoStreamWriter`'s replay cache — so a reconnecting client replays the current rotation for free. A one-shot header field would go stale after the first rotation.

The pipeline has **two** framing layers, each with a Kotlin producer and a matching parser pinned by contract tests:

**Layer 1 — device → daemon** (`VideoStreamProtocol.kt` ↔ `VideoServerStreamParser.ts`)

| Bit(s) | Meaning |
|--------|---------|
| 63 | `CONFIG` |
| 62 | `KEY_FRAME` |
| 61 | `REPLAYED` |
| 60–59 | **`ROTATION` (config only)** |
| 58–0 | PTS µs (`PTS_MASK` narrowed to bits 0–58) |

**Backward-compat argument (verified against the code):** a real presentation timestamp is in microseconds and bit 59 has place value `2^59 µs ≈ 18 000 years`, so a genuine PTS never sets bits 59–60. Old encoders wrote `0` there; old parsers read them as zero PTS; narrowing the mask changes no observable timestamp. A v2 daemon only ever reads a matching v2 jar (jar-integrity coupling, #4733), and non-attesting sources (screenrecord/iOS) emit raw Annex-B with no layer-1 framing at all — so on layer 1 "config packet ⇒ rotation present and valid", no presence bit needed.

**Layer 2 — daemon → desktop** (`videoStreamFraming.ts` ↔ desktop `VideoStreamParser.kt`). The relay aggregates from possibly-non-attesting sources, so here bit 61 (free — no `REPLAYED` on this layer) is repurposed as `ROTATION_PRESENT`. The desktop reads `rotation: Int? = null` unless a config packet sets bit 61, cleanly encoding "unknown" distinct from the valid value `0` (control fails closed for screenrecord/iOS).

## Versioning

`MUX_VERSION` bumped **1 → 2** to signal v2 semantics. The legacy 12-byte header (video-only, the common audio-off case) stays byte-for-byte decodable and attests via the **same config-packet bits** — it needs no version field, safe by the always-zero argument plus the jar-integrity coupling. Gating attestation on `MUX_VERSION` would have left the common video-only path un-attested, defeating the feature.

**Stale header dims:** header dims = initial/advisory only (not re-sent on rotation); authoritative dims come from the in-band H.264 SPS; rotation comes from the config-packet metadata.

## End-to-end plumbing

- **kotlin-protocol** `VideoStreamProtocol.kt`: `MUX_VERSION=2`, `ROTATION_SHIFT`/`ROTATION_MASK`, narrowed `PTS_MASK`, a `ptsAndFlags(…, rotation)` overload (3-arg overload preserved), `rotationOf(flags)`.
- **kotlin-video-server** `VideoStreamWriter.kt` (a `rotationProvider` threaded into the config-packet write), `VideoServer.kt` (`rotationProvider = { DisplayControl.getDisplayInfo().rotation }`).
- **ts-parser** `VideoServerStreamParser.ts`: extracts rotation from config packets, masks it out of `ptsUs`, exposes `muxVersion`; v1 streams unchanged.
- **ts-source** `PersistentEncoderH264Source.ts`: new `onRotation` callback fired on each config packet.
- **ts-relay** `videoStreamFraming.ts` (`ROTATION_PRESENT` + field), `videoStreamSocketServer.ts` (per-capture `rotation`, re-attested on config packets and parameter-set replay), `H264CaptureSource.ts` / `androidH264CaptureSourceFactory.ts` (`onRotation` forwarded).
- **desktop** `VideoStreamParser.kt` (`VideoPacket.rotation`), `VideoStreamClient.kt` + `H264Decoder.kt` (`DecodedFrame.rotation`, stamped from config packets), `AutoMobileContent.kt` (`LiveVideoFrame.rotation` populated). `DeviceControlSession`'s gate is unchanged. (Production still wires `DeviceControlInputs.liveFrame = null` by the deliberate capture-identity policy — untouched.)

## Contract tests pin both sides

The Kotlin protocol tests and their TS counterparts are updated together so the parser decodes exactly what the protocol encodes:
- **Layer 1:** `VideoStreamProtocolTest.kt` and `VideoServerStreamParser.test.ts` — rotation encodes into config-packet flags for all `0..3`, round-trips, leaves PTS/other flags intact, is absent on non-config packets; `MUX_VERSION==2`; legacy header still decodes; a replayed config packet surfaces the current rotation.
- **Layer 2:** `videoStreamFraming.test.ts` / `videoStreamSocketServer.test.ts` and desktop `VideoStreamParserTest.kt` — `ROTATION_PRESENT` + field encode/decode, `null` when the source never attests, rotation ignored on non-config packets, and the relay re-attests on parameter-set replay.
- **Desktop end-to-end:** `VideoStreamClientTest.kt` decodes a rotation-attested stream into `DecodedFrame.rotation`; `LiveVideoStreamTest.kt` proves `LiveVideoFrame.rotation` is populated; `DeviceControlSessionTest.kt` proves the gate re-proves orientation **from the live frame alone** after a rotation and rejects the stale orientation.

## Gates (all run inline, JDK 21 for Kotlin)

| Gate | Result |
|------|--------|
| `bun test` webrtc/daemon suites (4 files, 128 tests) | ✅ pass |
| `bun run typecheck` | ✅ no new errors |
| ESLint on all changed TS | ✅ clean |
| `:video-server:test` | ✅ pass |
| `:video-server:detektMain` + `detektTest` | ✅ 0 violations |
| `:desktop-core:detektMain` + `detektTest` | ✅ 0 violations |
| `:desktop-core:test` (full suite) | ✅ pass |
| `scripts/ktfmt/validate_ktfmt.sh` | ✅ 0 diffs |

Closes [#4786](https://github.com/kaeawc/auto-mobile/issues/4786).
