### PR TITLE
feat(ios-screen-capture): 420v capture + VTCompressionSession H.264 encode behind --encode h264

### DIFF
--- a/ios/screen-capture/Sources/ScreenCaptureCore/AnnexBConverter.swift
+++ b/ios/screen-capture/Sources/ScreenCaptureCore/AnnexBConverter.swift
@@ -1,0 +1,89 @@
+import Foundation
+
+/// Converts VideoToolbox's length-prefixed (avcC) H.264 samples to Annex-B and
+/// assembles self-decodable access units (issue #4788). Pure and device-free:
+/// the byte manipulation is testable without a live `VTCompressionSession`, and
+/// its output payloads are pinned against #4787's shared golden vectors.
+///
+/// VideoToolbox emits each `CMSampleBuffer` as one or more NAL units, each
+/// prefixed by a big-endian length field of `nalUnitHeaderLength` bytes (from
+/// the format description; 4 in practice). The RTP path needs Annex-B start
+/// codes (`00 00 00 01`) and needs every IDR self-decodable, so SPS/PPS are
+/// prepended to every keyframe — matching ffmpeg's `-f h264` behavior.
+public enum AnnexBConverter {
+    /// The 4-byte Annex-B start code prefixed before each NAL unit.
+    public static let startCode = Data([0x00, 0x00, 0x00, 0x01])
+
+    /// The five low bits of a NAL header byte carry `nal_unit_type` (H.264
+    /// §7.3.1). IDR slices are type 5.
+    public static let nalTypeMask: UInt8 = 0x1F
+    public static let nalTypeIDR: UInt8 = 5
+
+    public enum ConversionError: Error, Equatable {
+        /// `nalUnitHeaderLength` outside the legal 1...4 range.
+        case invalidNalHeaderLength(Int)
+        /// A length prefix ran past the end of the sample (truncated / corrupt).
+        case truncatedSample
+    }
+
+    /// Convert a length-prefixed (avcC) sample to Annex-B, replacing each
+    /// `nalUnitHeaderLength`-byte big-endian length prefix with a start code.
+    /// Handles multi-NAL samples. Does NOT prepend parameter sets — see
+    /// `assembleAccessUnit`.
+    public static func annexB(fromAvcc sample: Data, nalUnitHeaderLength: Int) throws -> Data {
+        guard nalUnitHeaderLength >= 1, nalUnitHeaderLength <= 4 else {
+            throw ConversionError.invalidNalHeaderLength(nalUnitHeaderLength)
+        }
+        var output = Data()
+        // Index into the sample using its own start index so this is correct even
+        // for a `Data` slice whose indices do not begin at 0.
+        var cursor = sample.startIndex
+        let end = sample.endIndex
+        while cursor < end {
+            guard end - cursor >= nalUnitHeaderLength else {
+                throw ConversionError.truncatedSample
+            }
+            var nalLength = 0
+            for offset in 0..<nalUnitHeaderLength {
+                nalLength = (nalLength << 8) | Int(sample[cursor + offset])
+            }
+            let nalStart = cursor + nalUnitHeaderLength
+            guard nalLength > 0, end - nalStart >= nalLength else {
+                throw ConversionError.truncatedSample
+            }
+            output.append(startCode)
+            output.append(sample[nalStart..<(nalStart + nalLength)])
+            cursor = nalStart + nalLength
+        }
+        return output
+    }
+
+    /// Concatenate parameter-set NALs (SPS then PPS) as Annex-B, each prefixed
+    /// with a start code. The NALs are passed already stripped of any length
+    /// prefix (as VideoToolbox surfaces them via
+    /// `CMVideoFormatDescriptionGetH264ParameterSetAtIndex`).
+    public static func parameterSetsAnnexB(_ parameterSets: [Data]) -> Data {
+        var output = Data()
+        for nal in parameterSets where !nal.isEmpty {
+            output.append(startCode)
+            output.append(nal)
+        }
+        return output
+    }
+
+    /// Assemble one Annex-B access unit from an avcC sample. When `isKeyframe`
+    /// is true the parameter sets are prepended so the IDR is self-decodable
+    /// (the RTP path drops SPS/PPS otherwise). `parameterSets` are the raw
+    /// SPS/PPS NALs (no length prefix); pass an empty array for delta frames or
+    /// when they are unavailable.
+    public static func assembleAccessUnit(
+        fromAvcc sample: Data,
+        nalUnitHeaderLength: Int,
+        parameterSets: [Data],
+        isKeyframe: Bool
+    ) throws -> Data {
+        let slices = try annexB(fromAvcc: sample, nalUnitHeaderLength: nalUnitHeaderLength)
+        guard isKeyframe, !parameterSets.isEmpty else { return slices }
+        return parameterSetsAnnexB(parameterSets) + slices
+    }
+}

--- a/ios/screen-capture/Sources/ScreenCaptureCore/CommandLineOptions.swift
+++ b/ios/screen-capture/Sources/ScreenCaptureCore/CommandLineOptions.swift
@@ -2,11 +2,32 @@ import Foundation
 
 /// Parsed CLI arguments for the screen-capture helper.
 public struct CommandLineOptions: Equatable {
+    /// In-helper H.264 encode settings (issue #4788). Absent means the default
+    /// raw-BGRA path with zero behavior change. The bitrate *policy* stays in the
+    /// TypeScript supervisor (which flag it passes); the helper only carries the
+    /// choice and does the pixel-dimension arithmetic it alone knows pre-encode.
+    public struct EncodeSettings: Equatable {
+        public enum Bitrate: Equatable {
+            /// `--bitrate-bps <n>`: operator override, used verbatim.
+            case explicitBps(Int)
+            /// `--bits-per-pixel <x>`: bitrate computed from delivered pixels x fps.
+            case bitsPerPixel(Double)
+            /// Neither flag: let VideoToolbox pick (physical-device path, #4375).
+            case videoToolboxDefault
+        }
+
+        public let bitrate: Bitrate
+
+        public init(bitrate: Bitrate) {
+            self.bitrate = bitrate
+        }
+    }
+
     public enum Mode: Equatable {
         case listDevices
         case capture(deviceID: String?)
         case listSimulators
-        case captureSimulator(windowID: UInt32, fps: Int, audio: Bool)
+        case captureSimulator(windowID: UInt32, fps: Int, audio: Bool, encode: EncodeSettings?)
         case help
     }
 
@@ -38,6 +59,9 @@ public struct CommandLineOptions: Equatable {
         var simulatorFPS: Int?
         var audio = false
         var help = false
+        var encodeRequested = false
+        var bitrateBps: Int?
+        var bitsPerPixel: Double?
 
         while let arg = iterator.next() {
             switch arg {
@@ -72,6 +96,32 @@ public struct CommandLineOptions: Equatable {
                 simulatorFPS = parsed
             case "--audio":
                 audio = true
+            case "--encode":
+                guard let value = iterator.next() else {
+                    throw ParseError.missingValue(flag: arg)
+                }
+                // Only H.264 exists today; reject anything else so a typo fails
+                // loudly instead of silently taking the raw path.
+                guard value == "h264" else {
+                    throw ParseError.invalidValue(flag: arg, value: value)
+                }
+                encodeRequested = true
+            case "--bitrate-bps":
+                guard let value = iterator.next() else {
+                    throw ParseError.missingValue(flag: arg)
+                }
+                guard let parsed = Int(value), parsed > 0 else {
+                    throw ParseError.invalidValue(flag: arg, value: value)
+                }
+                bitrateBps = parsed
+            case "--bits-per-pixel":
+                guard let value = iterator.next() else {
+                    throw ParseError.missingValue(flag: arg)
+                }
+                guard let parsed = Double(value), parsed > 0, parsed.isFinite else {
+                    throw ParseError.invalidValue(flag: arg, value: value)
+                }
+                bitsPerPixel = parsed
             case "-h", "--help":
                 help = true
             default:
@@ -104,6 +154,31 @@ public struct CommandLineOptions: Equatable {
             throw ParseError.conflictingFlags("--audio requires --simulator-window")
         }
 
+        if bitrateBps != nil && bitsPerPixel != nil {
+            throw ParseError.conflictingFlags("--bitrate-bps and --bits-per-pixel are mutually exclusive")
+        }
+        if (bitrateBps != nil || bitsPerPixel != nil) && !encodeRequested {
+            throw ParseError.conflictingFlags("--bitrate-bps/--bits-per-pixel require --encode h264")
+        }
+        // v1 scope: in-helper encoding is wired for the Simulator (ScreenCaptureKit)
+        // path only; the device path keeps VideoToolbox out of the helper.
+        if encodeRequested && simulatorWindowID == nil {
+            throw ParseError.conflictingFlags("--encode requires --simulator-window")
+        }
+
+        var encodeSettings: EncodeSettings?
+        if encodeRequested {
+            let bitrate: EncodeSettings.Bitrate
+            if let bps = bitrateBps {
+                bitrate = .explicitBps(bps)
+            } else if let bpp = bitsPerPixel {
+                bitrate = .bitsPerPixel(bpp)
+            } else {
+                bitrate = .videoToolboxDefault
+            }
+            encodeSettings = EncodeSettings(bitrate: bitrate)
+        }
+
         if listDevices {
             return CommandLineOptions(mode: .listDevices)
         }
@@ -115,7 +190,8 @@ public struct CommandLineOptions: Equatable {
                 mode: .captureSimulator(
                     windowID: windowID,
                     fps: simulatorFPS ?? defaultSimulatorFPS,
-                    audio: audio
+                    audio: audio,
+                    encode: encodeSettings
                 )
             )
         }
@@ -142,6 +218,16 @@ public struct CommandLineOptions: Equatable {
         --simulator-fps <n>     Target frame rate (5-60, default 5). Higher
                                 values waste CPU for typical MCP workloads.
         --audio                 Capture Simulator window audio as 8 kHz mono PCM16LE.
+
+    ENCODE OPTIONS (in-helper H.264, requires --simulator-window):
+        --encode h264           Encode H.264 (Baseline 4.2) in-process instead of
+                                streaming raw BGRA. Captures 420v (NV12) and emits
+                                Annex-B encoded-video records. Default: raw BGRA.
+        --bitrate-bps <n>       Operator override for the average bitrate (bps).
+        --bits-per-pixel <x>    Compute the bitrate from the delivered pixel
+                                dimensions x fps x <x> (Simulator default 0.1).
+                                Mutually exclusive with --bitrate-bps; omit both
+                                to let VideoToolbox choose (physical-device path).
 
         -h, --help              Show this help.
 

--- a/ios/screen-capture/Sources/ScreenCaptureCore/EncoderControl.swift
+++ b/ios/screen-capture/Sources/ScreenCaptureCore/EncoderControl.swift
@@ -1,0 +1,90 @@
+import Foundation
+
+/// The helper's minimal STDIN control surface (issue #4788). Commands arrive as
+/// newline-delimited JSON; today the only verb is `forceKeyFrame`, the hook that
+/// replaces the old encoder-restart keyframe hack. Parsing is deliberately
+/// permissive — malformed or unknown lines are ignored — matching the repo's
+/// minimal-control-surface precedent so a future TS writer can add verbs without
+/// a version handshake.
+public enum EncoderControlCommand: Equatable {
+    case forceKeyFrame
+
+    /// Parse a single control line. Returns `nil` for blank, malformed, or
+    /// unknown commands (the caller ignores those rather than failing).
+    public static func parse(line: String) -> EncoderControlCommand? {
+        let trimmed = line.trimmingCharacters(in: .whitespacesAndNewlines)
+        guard !trimmed.isEmpty, let data = trimmed.data(using: .utf8) else { return nil }
+        guard
+            let object = try? JSONSerialization.jsonObject(with: data),
+            let dictionary = object as? [String: Any],
+            let cmd = dictionary["cmd"] as? String
+        else {
+            return nil
+        }
+        switch cmd {
+        case "forceKeyFrame":
+            return .forceKeyFrame
+        default:
+            return nil
+        }
+    }
+}
+
+/// Thread-safe one-shot latch coupling `{"cmd":"forceKeyFrame"}` on STDIN (any
+/// thread) to the next `encodeFrame` (capture queue). `request()` arms it;
+/// `consume()` returns `true` exactly once per arm, so the very next encoded
+/// frame is forced to an IDR and subsequent frames are not.
+public final class ForceKeyFrameLatch: @unchecked Sendable {
+    private let lock = NSLock()
+    private var pending = false
+
+    public init() {}
+
+    public func request() {
+        lock.lock()
+        pending = true
+        lock.unlock()
+    }
+
+    /// Returns `true` iff a force was pending, clearing it.
+    public func consume() -> Bool {
+        lock.lock()
+        defer { lock.unlock() }
+        guard pending else { return false }
+        pending = false
+        return true
+    }
+
+    public var isPending: Bool {
+        lock.lock()
+        defer { lock.unlock() }
+        return pending
+    }
+}
+
+/// Pure drop-policy decisions for the encoded path (issue #4788). Unlike the raw
+/// path's newest-wins replacement — which would corrupt the encoder's reference
+/// chain — encoded output drops late frames at the ENCODER INPUT when the
+/// encoder is behind, and NEVER drops an emitted encoded record. An overflowing
+/// output queue is fatal (the supervisor relaunches) rather than silently
+/// corrupting the stream.
+public enum EncoderDropPolicy {
+    /// Drop this capture frame before `encodeFrame` when the encoder already has
+    /// `maxInFlightFrames` (or more) frames submitted but not yet emitted.
+    /// Dropping the *input* leaves the already-committed reference chain intact.
+    public static func shouldDropBeforeEncode(inFlightFrames: Int, maxInFlightFrames: Int) -> Bool {
+        inFlightFrames >= maxInFlightFrames
+    }
+
+    /// Whether enqueuing `recordBytes` would overflow the bounded output queue.
+    /// Overflow is fatal for encoded output (the caller exits so the supervisor
+    /// relaunches with a fresh IDR) — the alternative, dropping an emitted
+    /// record, breaks decodability downstream.
+    public static func wouldOverflowOutputQueue(
+        queuedBytes: Int,
+        recordBytes: Int,
+        maxQueuedBytes: Int
+    ) -> Bool {
+        queuedBytes + recordBytes > maxQueuedBytes
+    }
+}

--- a/ios/screen-capture/Sources/ScreenCaptureCore/FrameWriter.swift
+++ b/ios/screen-capture/Sources/ScreenCaptureCore/FrameWriter.swift
@@ -45,18 +45,27 @@ public final class FrameWriter {
         /// buffering to one frame when stdout's consumer is slow.
         public static let defaultMaximumPendingFrameBytes = 32 * 1024 * 1024
         public static let defaultMaximumPendingAudioBytes = 64 * 1024
+        /// Bound on the ordered encoded-H.264 output queue (issue #4788). Unlike
+        /// raw frames, encoded records are never dropped — overflow is fatal — so
+        /// this ceiling is a hard backstop against unbounded growth when stdout's
+        /// consumer stalls, sized for several seconds of Baseline output.
+        public static let defaultMaximumPendingEncodedBytes = 64 * 1024 * 1024
 
         public let maximumPendingFrameBytes: Int
         public let maximumPendingAudioBytes: Int
+        public let maximumPendingEncodedBytes: Int
 
         public init(
             maximumPendingFrameBytes: Int = defaultMaximumPendingFrameBytes,
-            maximumPendingAudioBytes: Int = defaultMaximumPendingAudioBytes
+            maximumPendingAudioBytes: Int = defaultMaximumPendingAudioBytes,
+            maximumPendingEncodedBytes: Int = defaultMaximumPendingEncodedBytes
         ) {
             precondition(maximumPendingFrameBytes > 0)
             precondition(maximumPendingAudioBytes > 0)
+            precondition(maximumPendingEncodedBytes > 0)
             self.maximumPendingFrameBytes = maximumPendingFrameBytes
             self.maximumPendingAudioBytes = maximumPendingAudioBytes
+            self.maximumPendingEncodedBytes = maximumPendingEncodedBytes
         }
     }
 
@@ -70,6 +79,7 @@ public final class FrameWriter {
     private enum RecordKind {
         case frame
         case audio
+        case encoded
     }
 
     private let sink: FrameSink
@@ -80,6 +90,8 @@ public final class FrameWriter {
     private var pendingFrame: PendingRecord?
     private var pendingAudio: [PendingRecord] = []
     private var pendingAudioBytes = 0
+    private var pendingEncoded: [PendingRecord] = []
+    private var pendingEncodedBytes = 0
     private var lastWrittenRecordKind: RecordKind?
     private var outputWorkerScheduled = false
     private var droppedFrames: UInt64 = 0
@@ -179,6 +191,41 @@ public final class FrameWriter {
         }
     }
 
+    /// Queues an ordered encoded-H.264 record (header + Annex-B payload) on the
+    /// same serial writer (issue #4788). Encoded records are NEVER dropped: a
+    /// broken reference chain is worse than a stall, so overflow returns `false`
+    /// and the caller exits (the supervisor relaunches with a fresh IDR) instead
+    /// of discarding an emitted record. `header` is a `FrameProtocol`
+    /// encoded-video header; `payload` is the Annex-B access unit.
+    @discardableResult
+    public func writeEncoded(header: Data, payload: Data) -> Bool {
+        let record = PendingRecord(
+            header: header,
+            payload: payload,
+            captureTimestampMs: nil,
+            enqueuedAt: Date()
+        )
+        stateLock.lock()
+        if EncoderDropPolicy.wouldOverflowOutputQueue(
+            queuedBytes: pendingEncodedBytes,
+            recordBytes: record.payload.count,
+            maxQueuedBytes: configuration.maximumPendingEncodedBytes
+        ) {
+            stateLock.unlock()
+            return false
+        }
+        pendingEncoded.append(record)
+        pendingEncodedBytes += record.payload.count
+        highWaterMarkBytes = max(highWaterMarkBytes, queuedBytesLocked())
+        let shouldSchedule = !outputWorkerScheduled
+        outputWorkerScheduled = true
+        stateLock.unlock()
+        if shouldSchedule {
+            outputQueue.async { self.drain() }
+        }
+        return true
+    }
+
     public func metrics(now: Date = Date()) -> FrameWriterMetrics {
         stateLock.lock()
         defer { stateLock.unlock() }
@@ -239,20 +286,35 @@ public final class FrameWriter {
         stateLock.lock()
         defer { stateLock.unlock() }
 
-        if pendingFrame != nil, !pendingAudio.isEmpty {
-            if lastWrittenRecordKind == .frame {
-                return takeAudioLocked()
-            }
-            return takeFrameLocked()
+        // "Media" is a raw frame or an encoded record; only one of the two ever
+        // flows in a given run (raw path vs `--encode h264`). Alternate media
+        // with audio so neither starves — preserving the raw path's exact
+        // frame/audio ordering when no encoded records are present.
+        let mediaPending = pendingFrame != nil || !pendingEncoded.isEmpty
+        if mediaPending, !pendingAudio.isEmpty {
+            let lastWasMedia = lastWrittenRecordKind == .frame || lastWrittenRecordKind == .encoded
+            return lastWasMedia ? takeAudioLocked() : takeMediaLocked()
         }
-        if pendingFrame != nil {
-            return takeFrameLocked()
+        if mediaPending {
+            return takeMediaLocked()
         }
         if !pendingAudio.isEmpty {
             return takeAudioLocked()
         }
         outputWorkerScheduled = false
         return nil
+    }
+
+    /// Encoded records take priority over a raw frame (they never coexist), and
+    /// are emitted strictly FIFO — they must not be reordered or dropped.
+    private func takeMediaLocked() -> PendingRecord? {
+        if !pendingEncoded.isEmpty {
+            let encoded = pendingEncoded.removeFirst()
+            pendingEncodedBytes -= encoded.payload.count
+            lastWrittenRecordKind = .encoded
+            return encoded
+        }
+        return takeFrameLocked()
     }
 
     private func takeFrameLocked() -> PendingRecord? {
@@ -270,7 +332,7 @@ public final class FrameWriter {
     }
 
     private func queuedBytesLocked() -> Int {
-        (pendingFrame?.payload.count ?? 0) + pendingAudioBytes
+        (pendingFrame?.payload.count ?? 0) + pendingAudioBytes + pendingEncodedBytes
     }
 }
 

--- a/ios/screen-capture/Sources/ScreenCaptureCore/H264EncodeMath.swift
+++ b/ios/screen-capture/Sources/ScreenCaptureCore/H264EncodeMath.swift
@@ -1,0 +1,119 @@
+import Foundation
+
+/// Pure, device-free arithmetic shared by the in-helper H.264 encoder (issue
+/// #4788). Every decision the encoder makes that can be pinned without a live
+/// `VTCompressionSession` lives here so it is unit-testable and stays in
+/// lockstep with the TypeScript sender.
+///
+/// The Level 4.2 macroblock budget (`maxMacroblocksPerFrame`) and the
+/// resolution/bitrate arithmetic MUST match `src/features/webrtc/IosH264Source.ts`
+/// (`resolveIosEncoderScale`, `defaultIosBitrateBps`) and
+/// `src/features/webrtc/h264Level.ts` byte for byte — the TS side advertises
+/// Level 4.2 in the WHIP SDP, and the helper must encode within exactly that
+/// capability. The shared golden vectors in
+/// `test/fixtures/h264-level42-scale-golden-vectors.json` pin the constant and
+/// every case across both languages (mirrors #4787's record golden vectors).
+public enum H264EncodeMath {
+    /// H.264 macroblock edge, in pixels (`H264_MACROBLOCK_SIZE`).
+    public static let macroblockSize = 16
+    /// Level 4.2 per-picture macroblock ceiling (`WEBRTC_H264_MAX_MACROBLOCKS_PER_FRAME`).
+    /// RFC 6184 §8.2.2 / ITU-T H.264 Annex A.
+    public static let maxMacroblocksPerFrame = 8_192
+    /// Smallest 4:2:0 chroma-subsampled edge (`MIN_ENCODER_DIMENSION`).
+    public static let minEncoderDimension = 2
+    /// Bits budgeted per encoded pixel per frame (`IOS_WEBRTC_DEFAULT_BITS_PER_PIXEL`).
+    public static let defaultBitsPerPixel = 0.1
+
+    /// An encode resolution in pixels.
+    public struct EncoderSize: Equatable {
+        public let width: Int
+        public let height: Int
+        public init(width: Int, height: Int) {
+            self.width = width
+            self.height = height
+        }
+    }
+
+    /// Number of 16x16 macroblocks a frame occupies (`h264MacroblocksPerFrame`).
+    public static func macroblocksPerFrame(width: Int, height: Int) -> Int {
+        divCeil(width, macroblockSize) * divCeil(height, macroblockSize)
+    }
+
+    /// Resolve the encode size for a captured frame, or `nil` when the frame can
+    /// be encoded at its native size. Port of `resolveIosEncoderScale`: native
+    /// dimensions are kept when even and already inside the Level 4.2 budget, odd
+    /// dimensions round down to even (4:2:0 cannot encode an odd edge), and an
+    /// oversized capture shrinks just far enough to fit the budget with its
+    /// aspect ratio intact.
+    public static func resolveEncoderScale(_ size: EncoderSize) -> EncoderSize? {
+        let width = size.width
+        let height = size.height
+        if macroblocksPerFrame(width: width, height: height) <= maxMacroblocksPerFrame {
+            let even = EncoderSize(width: evenFloor(Double(width)), height: evenFloor(Double(height)))
+            return even.width == width && even.height == height ? nil : even
+        }
+
+        // Shrink the macroblock grid, not the pixels: flooring both axes of an
+        // area-preserving scale keeps columns*rows inside the budget by
+        // construction, so no iterative search is needed.
+        let columns = divCeil(width, macroblockSize)
+        let rows = divCeil(height, macroblockSize)
+        let factor = (Double(maxMacroblocksPerFrame) / Double(columns * rows)).squareRoot()
+        let targetRows = clampMacroblockAxis(Int((Double(rows) * factor).rounded(.down)))
+        let targetColumns = clampMacroblockAxis(
+            // An extreme aspect ratio can floor one axis to the 1-macroblock
+            // clamp, which would let the product escape the budget; re-cap.
+            min(
+                Int((Double(columns) * factor).rounded(.down)),
+                Int((Double(maxMacroblocksPerFrame) / Double(targetRows)).rounded(.down))
+            )
+        )
+        let scale = min(
+            Double(targetColumns * macroblockSize) / Double(width),
+            Double(targetRows * macroblockSize) / Double(height)
+        )
+        return EncoderSize(
+            width: evenFloor(Double(width) * scale),
+            height: evenFloor(Double(height) * scale)
+        )
+    }
+
+    /// Resolution-aware default bitrate (bps) derived from the *encoded* pixel
+    /// dimensions and declared fps. Port of `defaultIosBitrateBps`: always a
+    /// positive finite integer (a non-finite input falls back to the 1 bps
+    /// floor). See `defaultBitsPerPixel`.
+    public static func defaultBitrateBps(size: EncoderSize, fps: Int) -> Int {
+        let budget = Double(size.width) * Double(size.height) * Double(fps) * defaultBitsPerPixel
+        guard budget.isFinite else { return 1 }
+        // Match JS `Math.round` (half rounds toward +infinity), not Swift's
+        // round-half-to-even.
+        let rounded = (budget + 0.5).rounded(.down)
+        return max(1, Int(rounded))
+    }
+
+    /// Bitrate (bps) from a bits-per-pixel budget over the delivered dimensions
+    /// and fps. Same arithmetic as `defaultBitrateBps` with an operator-supplied
+    /// budget instead of the default.
+    public static func bitrateBps(width: Int, height: Int, fps: Int, bitsPerPixel: Double) -> Int {
+        let budget = Double(width) * Double(height) * Double(fps) * bitsPerPixel
+        guard budget.isFinite else { return 1 }
+        let rounded = (budget + 0.5).rounded(.down)
+        return max(1, Int(rounded))
+    }
+
+    // MARK: - Private helpers
+
+    private static func divCeil(_ numerator: Int, _ denominator: Int) -> Int {
+        Int((Double(numerator) / Double(denominator)).rounded(.up))
+    }
+
+    /// `evenFloor`: floor to the nearest even integer, but never below the 4:2:0
+    /// minimum edge.
+    private static func evenFloor(_ value: Double) -> Int {
+        max(minEncoderDimension, Int((value / 2).rounded(.down)) * 2)
+    }
+
+    private static func clampMacroblockAxis(_ value: Int) -> Int {
+        min(maxMacroblocksPerFrame, max(1, value))
+    }
+}

--- a/ios/screen-capture/Sources/ScreenCaptureHelper/ControlChannel.swift
+++ b/ios/screen-capture/Sources/ScreenCaptureHelper/ControlChannel.swift
@@ -1,0 +1,57 @@
+import Foundation
+import ScreenCaptureCore
+
+/// Reads newline-delimited JSON control commands from the helper's STDIN and
+/// dispatches them (issue #4788). Today the only verb is `{"cmd":"forceKeyFrame"}`,
+/// the hook that replaces the old encoder-restart keyframe hack. Parsing is
+/// permissive — malformed / partial / unknown lines are ignored — matching the
+/// repo's minimal-control-surface precedent.
+///
+/// Only started in `--encode h264` mode, so the default raw path never touches
+/// STDIN and its output stays byte-for-byte unchanged.
+final class ControlChannel {
+    private let handle: FileHandle
+    private let onCommand: (EncoderControlCommand) -> Void
+    private let queue = DispatchQueue(label: "automobile.screen-capture.control")
+    private var buffer = Data()
+
+    init(
+        handle: FileHandle = .standardInput,
+        onCommand: @escaping (EncoderControlCommand) -> Void
+    ) {
+        self.handle = handle
+        self.onCommand = onCommand
+    }
+
+    func start() {
+        handle.readabilityHandler = { [weak self] handle in
+            let chunk = handle.availableData
+            guard !chunk.isEmpty else {
+                // EOF: the parent closed our stdin. Stop reading; the process
+                // stays alive on the capture path until SIGTERM.
+                handle.readabilityHandler = nil
+                return
+            }
+            self?.queue.async { self?.ingest(chunk) }
+        }
+    }
+
+    func stop() {
+        handle.readabilityHandler = nil
+    }
+
+    /// Split the rolling buffer on newlines and dispatch each complete line.
+    /// Exposed (not private) so tests can drive parsing without a real pipe.
+    func ingest(_ chunk: Data) {
+        buffer.append(chunk)
+        let newline = UInt8(ascii: "\n")
+        while let index = buffer.firstIndex(of: newline) {
+            let lineData = buffer[buffer.startIndex..<index]
+            buffer.removeSubrange(buffer.startIndex...index)
+            guard let line = String(data: lineData, encoding: .utf8) else { continue }
+            if let command = EncoderControlCommand.parse(line: line) {
+                onCommand(command)
+            }
+        }
+    }
+}

--- a/ios/screen-capture/Sources/ScreenCaptureHelper/H264VideoEncoder.swift
+++ b/ios/screen-capture/Sources/ScreenCaptureHelper/H264VideoEncoder.swift
@@ -1,0 +1,347 @@
+import CoreMedia
+import CoreVideo
+import Foundation
+import ScreenCaptureCore
+import VideoToolbox
+
+/// Fatal encoder-startup failures surfaced to `main.swift`'s `error:` boundary,
+/// where the supervisor's bounded reconnect relaunches the helper (issue #4788).
+enum H264EncoderError: Error, CustomStringConvertible {
+    case sessionCreationFailed(status: OSStatus)
+    case sessionPrepareFailed(status: OSStatus)
+
+    var description: String {
+        switch self {
+        case .sessionCreationFailed(let status):
+            return "VTCompressionSessionCreate failed (status \(status))"
+        case .sessionPrepareFailed(let status):
+            return "VTCompressionSessionPrepareToEncodeFrames failed (status \(status))"
+        }
+    }
+}
+
+/// In-process H.264 encoder over `VTCompressionSession` (issue #4788).
+///
+/// DEVICE-ONLY: VideoToolbox cannot be exercised headlessly, so this glue is not
+/// unit-tested. Every decision it makes that CAN be pinned without a live
+/// session is factored into pure `ScreenCaptureCore` functions and tested there:
+///   - resolution/macroblock budget  -> `H264EncodeMath.resolveEncoderScale`
+///   - bits-per-pixel -> bitrate      -> `H264EncodeMath.bitrateBps`
+///   - avcC -> Annex-B + SPS/PPS/IDR  -> `AnnexBConverter`
+///   - force-keyframe latch decision  -> `ForceKeyFrameLatch`
+///   - drop-when-behind / overflow    -> `EncoderDropPolicy`
+///
+/// Encoder config: `kVTProfileLevel_H264_Baseline_4_2`, `AllowFrameReordering =
+/// false` (no B-frames), `RealTime = true`, `MaxKeyFrameInterval ~= 2s x fps`,
+/// and `EnableHardwareAcceleratedVideoEncoder` WITHOUT the `Require...` key so a
+/// hosted runner with no free HW encoder falls back to software (the `-allow_sw
+/// 1` semantic) rather than failing to start.
+final class H264VideoEncoder {
+    /// Target seconds between IDRs; matches the TS ffmpeg GOP
+    /// (`IOS_KEYFRAME_INTERVAL_SECONDS`).
+    static let keyFrameIntervalSeconds = 2
+    /// Frames allowed in-flight (submitted, not yet emitted) before late frames
+    /// are dropped at the encoder input. One GOP-ish of slack absorbs transient
+    /// encoder stalls without unbounding latency.
+    static let maxInFlightFrames = 3
+
+    private let writer: FrameWriter
+    private let forceKeyFrameLatch: ForceKeyFrameLatch
+    private let onFatalError: (String) -> Void
+    private let diagnosticSink: (String) -> Void
+    private let lock = NSLock()
+
+    private var session: VTCompressionSession?
+    private var inFlightFrames = 0
+    private var formatParameterSets: [Data] = []
+    private var nalUnitHeaderLength = 4
+
+    let width: Int
+    let height: Int
+    let fps: Int
+    let averageBitRateBps: Int?
+
+    /// - Parameters:
+    ///   - width/height: encode resolution (already run through the macroblock
+    ///     budget); the delivered `CVPixelBuffer` is fed directly, so this must
+    ///     match the SCK-delivered size.
+    ///   - averageBitRateBps: resolved `AverageBitRate`, or `nil` to leave the
+    ///     VideoToolbox default (physical-device path, #4375).
+    init(
+        width: Int,
+        height: Int,
+        fps: Int,
+        averageBitRateBps: Int?,
+        writer: FrameWriter,
+        forceKeyFrameLatch: ForceKeyFrameLatch,
+        diagnosticSink: @escaping (String) -> Void,
+        onFatalError: @escaping (String) -> Void
+    ) {
+        self.width = width
+        self.height = height
+        self.fps = fps
+        self.averageBitRateBps = averageBitRateBps
+        self.writer = writer
+        self.forceKeyFrameLatch = forceKeyFrameLatch
+        self.diagnosticSink = diagnosticSink
+        self.onFatalError = onFatalError
+    }
+
+    /// Create the compression session and apply the encoder config. Throws an
+    /// `ActionableError` when VideoToolbox refuses to create/prepare the session.
+    func start() throws {
+        // Prefer the hardware encoder but do NOT require it — a hosted runner
+        // whose HW encoder is absent/exhausted must fall back to software
+        // instead of failing to start (the `-allow_sw 1` semantic). The
+        // `EnableHardware...` key without the matching `RequireHardware...` key
+        // expresses exactly that preference.
+        let encoderSpecification: [CFString: Any] = [
+            kVTVideoEncoderSpecification_EnableHardwareAcceleratedVideoEncoder: kCFBooleanTrue as Any
+        ]
+        var created: VTCompressionSession?
+        let status = VTCompressionSessionCreate(
+            allocator: kCFAllocatorDefault,
+            width: Int32(width),
+            height: Int32(height),
+            codecType: kCMVideoCodecType_H264,
+            encoderSpecification: encoderSpecification as CFDictionary,
+            imageBufferAttributes: nil,
+            compressedDataAllocator: nil,
+            outputCallback: nil,
+            refcon: nil,
+            compressionSessionOut: &created
+        )
+        guard status == noErr, let session = created else {
+            throw H264EncoderError.sessionCreationFailed(status: status)
+        }
+        applyConfiguration(to: session)
+        let prepareStatus = VTCompressionSessionPrepareToEncodeFrames(session)
+        guard prepareStatus == noErr else {
+            VTCompressionSessionInvalidate(session)
+            throw H264EncoderError.sessionPrepareFailed(status: prepareStatus)
+        }
+        self.session = session
+    }
+
+    private func applyConfiguration(to session: VTCompressionSession) {
+        VTSessionSetProperty(session, key: kVTCompressionPropertyKey_RealTime, value: kCFBooleanTrue)
+        VTSessionSetProperty(
+            session,
+            key: kVTCompressionPropertyKey_ProfileLevel,
+            value: kVTProfileLevel_H264_Baseline_4_2
+        )
+        // No B-frames: the RTP path needs each frame to reference only past
+        // frames, and low latency matters more than a few percent of bitrate.
+        VTSessionSetProperty(
+            session,
+            key: kVTCompressionPropertyKey_AllowFrameReordering,
+            value: kCFBooleanFalse
+        )
+        let maxKeyFrameInterval = max(1, H264VideoEncoder.keyFrameIntervalSeconds * fps)
+        VTSessionSetProperty(
+            session,
+            key: kVTCompressionPropertyKey_MaxKeyFrameInterval,
+            value: maxKeyFrameInterval as CFNumber
+        )
+        VTSessionSetProperty(
+            session,
+            key: kVTCompressionPropertyKey_MaxKeyFrameIntervalDuration,
+            value: H264VideoEncoder.keyFrameIntervalSeconds as CFNumber
+        )
+        if let bitrate = averageBitRateBps {
+            VTSessionSetProperty(
+                session,
+                key: kVTCompressionPropertyKey_AverageBitRate,
+                value: bitrate as CFNumber
+            )
+            // DataRateLimits peak ceiling: a 1s window at ~1.5x the average
+            // caps transient spikes without starving scroll/animation bursts.
+            // Cheap to wire, so wired here rather than deferred.
+            let peakBytesPerSecond = (bitrate / 8) * 3 / 2
+            let limits = [peakBytesPerSecond as CFNumber, 1 as CFNumber] as CFArray
+            VTSessionSetProperty(
+                session,
+                key: kVTCompressionPropertyKey_DataRateLimits,
+                value: limits
+            )
+        }
+    }
+
+    /// Encode one delivered pixel buffer. Applies the drop-when-behind decision
+    /// at the input and consumes a pending force-keyframe request. Fire and
+    /// forget: encoded output arrives on the VideoToolbox callback and is written
+    /// via `FrameWriter.writeEncoded`. Returns `false` when the frame was dropped
+    /// before encode (encoder behind) so the caller can skip its bookkeeping.
+    @discardableResult
+    func encode(pixelBuffer: CVPixelBuffer, presentationTime: CMTime) -> Bool {
+        guard let session = session else { return false }
+
+        lock.lock()
+        let behind = EncoderDropPolicy.shouldDropBeforeEncode(
+            inFlightFrames: inFlightFrames,
+            maxInFlightFrames: H264VideoEncoder.maxInFlightFrames
+        )
+        if behind {
+            lock.unlock()
+            return false
+        }
+        inFlightFrames += 1
+        lock.unlock()
+
+        var frameProperties: [CFString: Any]?
+        if forceKeyFrameLatch.consume() {
+            frameProperties = [kVTEncodeFrameOptionKey_ForceKeyFrame: kCFBooleanTrue as Any]
+        }
+
+        let status = VTCompressionSessionEncodeFrame(
+            session,
+            imageBuffer: pixelBuffer,
+            presentationTimeStamp: presentationTime,
+            duration: .invalid,
+            frameProperties: frameProperties as CFDictionary?,
+            infoFlagsOut: nil
+        ) { [weak self] status, _, sampleBuffer in
+            self?.handleEncodedFrame(status: status, sampleBuffer: sampleBuffer)
+        }
+        if status != noErr {
+            lock.lock()
+            inFlightFrames = max(0, inFlightFrames - 1)
+            lock.unlock()
+            diagnosticSink("warn: VTCompressionSessionEncodeFrame failed (status \(status))\n")
+            return false
+        }
+        return true
+    }
+
+    /// VideoToolbox output callback: convert the avcC sample to Annex-B (SPS/PPS
+    /// prepended on every IDR) and emit it as an encoded-video record.
+    private func handleEncodedFrame(status: OSStatus, sampleBuffer: CMSampleBuffer?) {
+        lock.lock()
+        inFlightFrames = max(0, inFlightFrames - 1)
+        lock.unlock()
+
+        // A successful callback with a data buffer is sufficient; `contiguousData`
+        // below rejects an empty payload, so no separate sample-count check.
+        guard status == noErr, let sampleBuffer = sampleBuffer else { return }
+        let isKeyframe = H264VideoEncoder.isKeyframe(sampleBuffer)
+        if isKeyframe {
+            refreshParameterSets(from: sampleBuffer)
+        }
+        guard let sample = H264VideoEncoder.contiguousData(from: sampleBuffer) else { return }
+
+        let record: Data
+        do {
+            record = try AnnexBConverter.assembleAccessUnit(
+                fromAvcc: sample,
+                nalUnitHeaderLength: currentNalUnitHeaderLength(),
+                parameterSets: isKeyframe ? currentParameterSets() : [],
+                isKeyframe: isKeyframe
+            )
+        } catch {
+            diagnosticSink("warn: avcC->Annex-B conversion failed: \(error)\n")
+            return
+        }
+
+        let ptsMs = H264VideoEncoder.presentationTimestampMs(sampleBuffer)
+        let header = FrameProtocol.encodeEncodedVideoHeader(
+            payloadLength: record.count,
+            isKeyframe: isKeyframe,
+            presentationTimestampMs: ptsMs
+        )
+        if !writer.writeEncoded(header: header, payload: record) {
+            // Overflow of the bounded output queue is fatal: dropping an emitted
+            // record breaks decodability, so exit and let the supervisor relaunch
+            // with a fresh IDR instead.
+            onFatalError("encoded output queue overflow; refusing to drop an emitted record")
+        }
+    }
+
+    /// Invalidate the session (orderly shutdown / reconfiguration teardown).
+    func stop() {
+        guard let session = session else { return }
+        VTCompressionSessionCompleteFrames(session, untilPresentationTimeStamp: .invalid)
+        VTCompressionSessionInvalidate(session)
+        self.session = nil
+    }
+
+    // MARK: - Parameter sets
+
+    private func refreshParameterSets(from sampleBuffer: CMSampleBuffer) {
+        guard let format = CMSampleBufferGetFormatDescription(sampleBuffer) else { return }
+        var parameterSetCount = 0
+        var headerLength: Int32 = 4
+        // Query the parameter-set count and NAL header length once.
+        let probe = CMVideoFormatDescriptionGetH264ParameterSetAtIndex(
+            format, parameterSetIndex: 0, parameterSetPointerOut: nil,
+            parameterSetSizeOut: nil, parameterSetCountOut: &parameterSetCount,
+            nalUnitHeaderLengthOut: &headerLength
+        )
+        guard probe == noErr, parameterSetCount > 0 else { return }
+
+        var sets: [Data] = []
+        for index in 0..<parameterSetCount {
+            var pointer: UnsafePointer<UInt8>?
+            var size = 0
+            let status = CMVideoFormatDescriptionGetH264ParameterSetAtIndex(
+                format, parameterSetIndex: index, parameterSetPointerOut: &pointer,
+                parameterSetSizeOut: &size, parameterSetCountOut: nil, nalUnitHeaderLengthOut: nil
+            )
+            if status == noErr, let pointer = pointer, size > 0 {
+                sets.append(Data(bytes: pointer, count: size))
+            }
+        }
+        lock.lock()
+        formatParameterSets = sets
+        nalUnitHeaderLength = Int(headerLength)
+        lock.unlock()
+    }
+
+    private func currentParameterSets() -> [Data] {
+        lock.lock()
+        defer { lock.unlock() }
+        return formatParameterSets
+    }
+
+    private func currentNalUnitHeaderLength() -> Int {
+        lock.lock()
+        defer { lock.unlock() }
+        return nalUnitHeaderLength
+    }
+
+    // MARK: - CMSampleBuffer helpers
+
+    private static func isKeyframe(_ sampleBuffer: CMSampleBuffer) -> Bool {
+        guard let attachments = CMSampleBufferGetSampleAttachmentsArray(
+            sampleBuffer, createIfNecessary: false
+        ) as? [[CFString: Any]], let first = attachments.first else {
+            // No attachments array means "not-not-sync"; treat as keyframe so the
+            // decoder never waits on a missing IDR.
+            return true
+        }
+        // A frame is a keyframe unless it is explicitly marked NotSync.
+        if let notSync = first[kCMSampleAttachmentKey_NotSync] as? Bool {
+            return !notSync
+        }
+        return true
+    }
+
+    private static func contiguousData(from sampleBuffer: CMSampleBuffer) -> Data? {
+        guard let blockBuffer = CMSampleBufferGetDataBuffer(sampleBuffer) else { return nil }
+        var length = 0
+        var pointer: UnsafeMutablePointer<Int8>?
+        let status = CMBlockBufferGetDataPointer(
+            blockBuffer, atOffset: 0, lengthAtOffsetOut: nil,
+            totalLengthOut: &length, dataPointerOut: &pointer
+        )
+        guard status == noErr, let pointer = pointer, length > 0 else { return nil }
+        return Data(bytes: pointer, count: length)
+    }
+
+    private static func presentationTimestampMs(_ sampleBuffer: CMSampleBuffer) -> UInt32 {
+        let pts = CMSampleBufferGetPresentationTimeStamp(sampleBuffer)
+        guard pts.isValid, pts.isNumeric else { return 0 }
+        let seconds = CMTimeGetSeconds(pts)
+        guard seconds.isFinite, seconds >= 0 else { return 0 }
+        return UInt32(truncatingIfNeeded: UInt64(seconds * 1000))
+    }
+}

--- a/ios/screen-capture/Sources/ScreenCaptureHelper/SimulatorCaptureSession.swift
+++ b/ios/screen-capture/Sources/ScreenCaptureHelper/SimulatorCaptureSession.swift
@@ -35,6 +35,19 @@ final class SimulatorCaptureSession: NSObject, SCStreamOutput, SCStreamDelegate 
     private let writer: FrameWriter
     private let onFatalError: (Error) -> Void
     private let makeStream: StreamFactory
+    /// In-helper H.264 encode settings (issue #4788). `nil` keeps the default
+    /// raw-BGRA path byte-for-byte unchanged.
+    private let encodeSettings: CommandLineOptions.EncodeSettings?
+    /// Force-keyframe latch shared with the STDIN control channel; consumed by
+    /// the encoder on the next frame. Present even in raw mode (harmless there).
+    let forceKeyFrameLatch = ForceKeyFrameLatch()
+    /// Active encoder in `--encode h264` mode; recreated on a capture-size
+    /// change (seamless reconfig: the new session's first frame is a fresh
+    /// SPS/PPS + IDR).
+    private var encoder: H264VideoEncoder?
+    /// Pixel format requested from ScreenCaptureKit — 32BGRA for the raw path,
+    /// 420v (NV12) for the lowest-CPU encode path.
+    var configuredPixelFormat: OSType = kCVPixelFormatType_32BGRA
     /// Diagnostic lines (first-frame marker, reconfigure warnings) go here so
     /// tests can observe them; the default preserves the stderr behavior.
     private let diagnosticSink: (String) -> Void
@@ -67,20 +80,34 @@ final class SimulatorCaptureSession: NSObject, SCStreamOutput, SCStreamDelegate 
         diagnosticSink: @escaping (String) -> Void = { line in
             FileHandle.standardError.write(Data(line.utf8))
         },
+        encode: CommandLineOptions.EncodeSettings? = nil,
         onFatalError: @escaping (Error) -> Void
     ) {
         self.writer = writer
         self.makeStream = makeStream
         self.diagnosticSink = diagnosticSink
+        self.encodeSettings = encode
         self.onFatalError = onFatalError
     }
+
+    /// Whether this session encodes H.264 in-process instead of streaming raw
+    /// BGRA.
+    var isEncoding: Bool { encodeSettings != nil }
 
     func start(window: SCWindow, fps: Int, audio: Bool) async throws {
         self.fps = fps
         audioEnabled = audio
         windowID = window.windowID
+        // 420v (NV12) is the lowest-CPU encode input: the delivered
+        // IOSurface-backed CVPixelBuffer feeds VTCompressionSession directly with
+        // no color conversion. The raw path keeps 32BGRA untouched.
+        if isEncoding {
+            configuredPixelFormat = kCVPixelFormatType_420YpCbCr8BiPlanarVideoRange
+        }
         let filter = SCContentFilter(desktopIndependentWindow: window)
-        let config = SimulatorCaptureSession.makeConfiguration(window: window, fps: fps, audio: audio)
+        let config = SimulatorCaptureSession.makeConfiguration(
+            window: window, fps: fps, audio: audio, pixelFormat: configuredPixelFormat
+        )
         configuredPixelWidth = config.width
         configuredPixelHeight = config.height
 
@@ -133,6 +160,8 @@ final class SimulatorCaptureSession: NSObject, SCStreamOutput, SCStreamDelegate 
     }
 
     func stop() async {
+        encoder?.stop()
+        encoder = nil
         guard let stream = stream else { return }
         // removeStreamOutput breaks the SCStream → self retain cycle so the
         // session is collectable even before SCStream itself goes away.
@@ -167,12 +196,101 @@ final class SimulatorCaptureSession: NSObject, SCStreamOutput, SCStreamDelegate 
         guard let pixelBuffer = CMSampleBufferGetImageBuffer(sampleBuffer) else { return }
         let actualWidth = CVPixelBufferGetWidth(pixelBuffer)
         let actualHeight = CVPixelBufferGetHeight(pixelBuffer)
+
+        if isEncoding {
+            encodeScreenFrame(
+                pixelBuffer: pixelBuffer, sampleBuffer: sampleBuffer,
+                width: actualWidth, height: actualHeight
+            )
+            return
+        }
+
         if actualWidth != configuredPixelWidth || actualHeight != configuredPixelHeight {
             reconfigure(width: actualWidth, height: actualHeight)
         }
 
         if writer.write(sampleBuffer: sampleBuffer) {
             noteFrameWritten(width: actualWidth, height: actualHeight)
+        }
+    }
+
+    /// Encode-mode screen path (issue #4788). Converges the ScreenCaptureKit
+    /// output size to the Level 4.2 macroblock-budgeted encode resolution — so
+    /// SCK does the downscale, not a separate stage — then feeds the delivered
+    /// 420v buffer straight to VideoToolbox. On a size change the encoder is torn
+    /// down and recreated (seamless reconfig); the new session's first frame is a
+    /// fresh SPS/PPS + IDR.
+    private func encodeScreenFrame(
+        pixelBuffer: CVPixelBuffer,
+        sampleBuffer: CMSampleBuffer,
+        width: Int,
+        height: Int
+    ) {
+        let target = H264EncodeMath.resolveEncoderScale(
+            H264EncodeMath.EncoderSize(width: width, height: height)
+        ) ?? H264EncodeMath.EncoderSize(width: width, height: height)
+
+        // Ask SCK to deliver the encode resolution. Until it does, skip encoding
+        // rather than feed VideoToolbox a mismatched buffer size.
+        if width != target.width || height != target.height {
+            reconfigure(width: target.width, height: target.height)
+            return
+        }
+
+        // Delivered size now equals the encode target. (Re)create the encoder if
+        // absent or sized for a previous resolution.
+        if encoder == nil || encoder?.width != target.width || encoder?.height != target.height {
+            guard startEncoder(width: target.width, height: target.height) else { return }
+        }
+
+        let pts = CMSampleBufferGetPresentationTimeStamp(sampleBuffer)
+        if encoder?.encode(pixelBuffer: pixelBuffer, presentationTime: pts) == true {
+            noteFrameWritten(width: target.width, height: target.height)
+        }
+    }
+
+    /// Build and start a VideoToolbox encoder at `width`x`height`, resolving the
+    /// `AverageBitRate` from the delivered dimensions per the operator's bitrate
+    /// choice. Returns `false` (and surfaces a fatal error) when the session
+    /// cannot be created.
+    private func startEncoder(width: Int, height: Int) -> Bool {
+        encoder?.stop()
+        let bitrate = resolvedBitrateBps(width: width, height: height)
+        let newEncoder = H264VideoEncoder(
+            width: width,
+            height: height,
+            fps: fps,
+            averageBitRateBps: bitrate,
+            writer: writer,
+            forceKeyFrameLatch: forceKeyFrameLatch,
+            diagnosticSink: diagnosticSink,
+            onFatalError: { [weak self] message in
+                self?.onFatalError(EncoderOutputOverflowError(message: message))
+            }
+        )
+        do {
+            try newEncoder.start()
+        } catch {
+            onFatalError(error)
+            return false
+        }
+        encoder = newEncoder
+        return true
+    }
+
+    /// Resolve `AverageBitRate` (bps) from the delivered pixel dimensions and the
+    /// operator's bitrate choice. `nil` leaves the VideoToolbox default. The
+    /// policy (which choice) is set by the TS supervisor via CLI flags; only the
+    /// pixel-dimension arithmetic — which the helper alone knows pre-encode —
+    /// happens here, via the pure `H264EncodeMath`.
+    private func resolvedBitrateBps(width: Int, height: Int) -> Int? {
+        switch encodeSettings?.bitrate {
+        case .explicitBps(let bps):
+            return bps
+        case .bitsPerPixel(let bpp):
+            return H264EncodeMath.bitrateBps(width: width, height: height, fps: fps, bitsPerPixel: bpp)
+        case .videoToolboxDefault, .none:
+            return nil
         }
     }
 
@@ -226,7 +344,7 @@ final class SimulatorCaptureSession: NSObject, SCStreamOutput, SCStreamDelegate 
         let updated = SCStreamConfiguration()
         updated.width = width
         updated.height = height
-        updated.pixelFormat = kCVPixelFormatType_32BGRA
+        updated.pixelFormat = configuredPixelFormat
         updated.minimumFrameInterval = CMTime(value: 1, timescale: CMTimeScale(fps))
         updated.showsCursor = false
         updated.scalesToFit = false
@@ -254,14 +372,19 @@ final class SimulatorCaptureSession: NSObject, SCStreamOutput, SCStreamDelegate 
         }
     }
 
-    private static func makeConfiguration(window: SCWindow, fps: Int, audio: Bool) -> SCStreamConfiguration {
+    private static func makeConfiguration(
+        window: SCWindow,
+        fps: Int,
+        audio: Bool,
+        pixelFormat: OSType = kCVPixelFormatType_32BGRA
+    ) -> SCStreamConfiguration {
         let config = SCStreamConfiguration()
         // Logical (points) size; the delivered CVPixelBuffer is in native
         // pixels (2x/3x for Retina), and downstream consumers must use
         // CVPixelBufferGetWidth/Height — not these values — to allocate sinks.
         config.width = Int(window.frame.width)
         config.height = Int(window.frame.height)
-        config.pixelFormat = kCVPixelFormatType_32BGRA
+        config.pixelFormat = pixelFormat
         config.minimumFrameInterval = CMTime(value: 1, timescale: CMTimeScale(fps))
         config.showsCursor = false
         config.scalesToFit = false
@@ -291,6 +414,14 @@ final class SimulatorCaptureSession: NSObject, SCStreamOutput, SCStreamDelegate 
 /// the stalled startup stage (`starting-capture` seen, `capture-started`
 /// absent), letting the parent supervisor fail fast with a specific cause
 /// instead of frame starvation. See issues #4350 / #4764.
+/// Raised when the encoder's bounded output queue overflows (issue #4788). The
+/// encoded path never drops an emitted record, so overflow is fatal: `main.swift`
+/// exits and the supervisor relaunches the helper with a fresh IDR.
+struct EncoderOutputOverflowError: Error, CustomStringConvertible {
+    let message: String
+    var description: String { message }
+}
+
 struct StartCaptureTimeoutError: Error, CustomStringConvertible {
     let deadlineSeconds: TimeInterval
 

--- a/ios/screen-capture/Sources/ScreenCaptureHelper/main.swift
+++ b/ios/screen-capture/Sources/ScreenCaptureHelper/main.swift
@@ -160,7 +160,7 @@ case .listSimulators:
         exit(1)
     }
 
-case .captureSimulator(let windowID, let fps, let audio):
+case .captureSimulator(let windowID, let fps, let audio, let encode):
     guard CGPreflightScreenCaptureAccess() else {
         logError(
             "error: Screen Recording permission is required. Grant Screen Recording to your terminal/IDE in System Settings > Privacy & Security > Screen Recording."
@@ -216,14 +216,30 @@ case .captureSimulator(let windowID, let fps, let audio):
     let writer = FrameWriter(sink: sink)
     let metricsReporter = FrameMetricsReporter(writer: writer, output: logError)
     metricsReporter.start()
-    let simSession = SimulatorCaptureSession(writer: writer) { error in
-        // A mid-stream ScreenCaptureKit fatal error: exit deterministically so
-        // the supervisor's bounded reconnect re-establishes capture, rather than
-        // leaving RunLoop.main spinning on a dead stream (issue #4768).
+    let simSession = SimulatorCaptureSession(writer: writer, encode: encode) { error in
+        // A mid-stream ScreenCaptureKit fatal error (or a fatal encoded-output
+        // overflow): exit deterministically so the supervisor's bounded reconnect
+        // re-establishes capture, rather than leaving RunLoop.main spinning on a
+        // dead stream (issues #4768 / #4788).
         logError("error: ScreenCaptureKit stream stopped: \(error)")
         exit(midStreamFatalExitCode)
     }
     let firstFrameSignal = simSession.firstFrameSignal
+
+    // In encode mode, read newline-delimited JSON control commands from STDIN
+    // (today only `{"cmd":"forceKeyFrame"}`). The raw path never touches STDIN,
+    // so its output is byte-for-byte unchanged (issue #4788).
+    var controlChannel: ControlChannel?
+    if encode != nil {
+        let channel = ControlChannel { command in
+            switch command {
+            case .forceKeyFrame:
+                simSession.forceKeyFrameLatch.request()
+            }
+        }
+        channel.start()
+        controlChannel = channel
+    }
 
     // ScreenCaptureKit silently emits no frames when the host process lacks
     // Screen Recording permission — there's no error to surface. Emit a hint on
@@ -250,6 +266,7 @@ case .captureSimulator(let windowID, let fps, let audio):
     installShutdownHandlers {
         metricsReporter.stop()
         permissionHintTimer.cancel()
+        controlChannel?.stop()
         Task { @MainActor in
             await simSession.stop()
             exit(0)

--- a/ios/screen-capture/Tests/ScreenCaptureCoreTests/AnnexBConverterTests.swift
+++ b/ios/screen-capture/Tests/ScreenCaptureCoreTests/AnnexBConverterTests.swift
@@ -1,0 +1,151 @@
+import XCTest
+@testable import ScreenCaptureCore
+
+/// Pure tests for the avcC -> Annex-B conversion and SPS/PPS-on-IDR assembly
+/// (issue #4788), including a byte-for-byte pin against #4787's shared encoded
+/// record golden vectors: an avcC-wrapped golden NAL converts to the golden
+/// Annex-B payload, and the assembled record equals the golden record bytes.
+final class AnnexBConverterTests: XCTestCase {
+    private func hex(_ string: String) -> Data {
+        var data = Data(capacity: string.count / 2)
+        var index = string.startIndex
+        while index < string.endIndex {
+            let next = string.index(index, offsetBy: 2)
+            // Test fixtures are trusted; a bad byte should fail the test loudly.
+            data.append(UInt8(string[index..<next], radix: 16)!)  // swiftlint:disable:this force_unwrapping
+            index = next
+        }
+        return data
+    }
+
+    /// Wrap a raw NAL (no prefix) as a single avcC unit with a 4-byte length.
+    private func avcc4(_ nal: Data) -> Data {
+        let length = UInt32(nal.count).bigEndian
+        var out = withUnsafeBytes(of: length) { Data($0) }
+        out.append(nal)
+        return out
+    }
+
+    func testSingleNalConversion() throws {
+        let nal = hex("6742001fabcdef")
+        let converted = try AnnexBConverter.annexB(fromAvcc: avcc4(nal), nalUnitHeaderLength: 4)
+        XCTAssertEqual(converted, AnnexBConverter.startCode + nal)
+    }
+
+    func testMultiNalConversion() throws {
+        let first = hex("6742001f")
+        let second = hex("68ce3c80")
+        let third = hex("419a0102")
+        let sample = avcc4(first) + avcc4(second) + avcc4(third)
+        let converted = try AnnexBConverter.annexB(fromAvcc: sample, nalUnitHeaderLength: 4)
+        XCTAssertEqual(
+            converted,
+            AnnexBConverter.startCode + first
+                + AnnexBConverter.startCode + second
+                + AnnexBConverter.startCode + third
+        )
+    }
+
+    func testHonorsTwoByteNalHeaderLength() throws {
+        let nal = hex("419a0102030405")
+        var sample = Data([0x00, UInt8(nal.count)])  // 2-byte big-endian length
+        sample.append(nal)
+        let converted = try AnnexBConverter.annexB(fromAvcc: sample, nalUnitHeaderLength: 2)
+        XCTAssertEqual(converted, AnnexBConverter.startCode + nal)
+    }
+
+    func testConversionOnSliceWithNonZeroStartIndex() throws {
+        // A `Data` slice whose indices do not start at 0 must convert correctly.
+        let nal = hex("6742001f")
+        let padded = Data([0xAA, 0xBB]) + avcc4(nal)
+        let slice = padded[padded.index(padded.startIndex, offsetBy: 2)...]
+        let converted = try AnnexBConverter.annexB(fromAvcc: slice, nalUnitHeaderLength: 4)
+        XCTAssertEqual(converted, AnnexBConverter.startCode + nal)
+    }
+
+    func testInvalidNalHeaderLengthThrows() {
+        XCTAssertThrowsError(try AnnexBConverter.annexB(fromAvcc: Data([0, 0, 0, 1, 5]), nalUnitHeaderLength: 0)) {
+            XCTAssertEqual($0 as? AnnexBConverter.ConversionError, .invalidNalHeaderLength(0))
+        }
+        XCTAssertThrowsError(try AnnexBConverter.annexB(fromAvcc: Data(), nalUnitHeaderLength: 5)) {
+            XCTAssertEqual($0 as? AnnexBConverter.ConversionError, .invalidNalHeaderLength(5))
+        }
+    }
+
+    func testTruncatedSampleThrows() {
+        // Length prefix claims 10 bytes but only 2 follow.
+        let sample = Data([0x00, 0x00, 0x00, 0x0A, 0x01, 0x02])
+        XCTAssertThrowsError(try AnnexBConverter.annexB(fromAvcc: sample, nalUnitHeaderLength: 4)) {
+            XCTAssertEqual($0 as? AnnexBConverter.ConversionError, .truncatedSample)
+        }
+    }
+
+    func testParameterSetsPrependedOnKeyframeOnly() throws {
+        let sps = hex("6742001f")
+        let pps = hex("68ce3c80")
+        let idr = hex("65010203")
+        let sample = avcc4(idr)
+
+        let keyframe = try AnnexBConverter.assembleAccessUnit(
+            fromAvcc: sample, nalUnitHeaderLength: 4, parameterSets: [sps, pps], isKeyframe: true
+        )
+        XCTAssertEqual(
+            keyframe,
+            AnnexBConverter.startCode + sps + AnnexBConverter.startCode + pps
+                + AnnexBConverter.startCode + idr
+        )
+
+        // A delta frame does NOT get parameter sets even if provided.
+        let delta = try AnnexBConverter.assembleAccessUnit(
+            fromAvcc: sample, nalUnitHeaderLength: 4, parameterSets: [sps, pps], isKeyframe: false
+        )
+        XCTAssertEqual(delta, AnnexBConverter.startCode + idr)
+    }
+
+    // MARK: - #4787 golden-vector pin
+
+    private struct GoldenRecord: Decodable {
+        let name: String
+        let keyframe: Bool
+        let presentationTimestampMs: UInt32
+        let payloadHex: String
+        let recordHex: String
+    }
+
+    private struct Golden: Decodable {
+        let records: [GoldenRecord]
+    }
+
+    private func loadGolden() throws -> Golden {
+        var root = URL(fileURLWithPath: #filePath)
+        for _ in 0..<5 { root.deleteLastPathComponent() }
+        let fixture = root
+            .appendingPathComponent("test").appendingPathComponent("fixtures")
+            .appendingPathComponent("encoded-h264-golden-vectors.json")
+        return try JSONDecoder().decode(Golden.self, from: try Data(contentsOf: fixture))
+    }
+
+    /// Each golden payload is Annex-B `00000001` + a single NAL. Wrapping that
+    /// NAL as avcC and converting must reproduce the golden payload exactly, and
+    /// the assembled `FrameProtocol` record must equal the golden record bytes.
+    func testGoldenRecordsRebuiltFromAvcc() throws {
+        let golden = try loadGolden()
+        for record in golden.records {
+            let annexBPayload = hex(record.payloadHex)
+            let nal = annexBPayload.dropFirst(AnnexBConverter.startCode.count)
+            let sample = avcc4(Data(nal))
+
+            let converted = try AnnexBConverter.assembleAccessUnit(
+                fromAvcc: sample, nalUnitHeaderLength: 4, parameterSets: [], isKeyframe: record.keyframe
+            )
+            XCTAssertEqual(converted, annexBPayload, "avcC->Annex-B diverged for \(record.name)")
+
+            let header = FrameProtocol.encodeEncodedVideoHeader(
+                payloadLength: converted.count,
+                isKeyframe: record.keyframe,
+                presentationTimestampMs: record.presentationTimestampMs
+            )
+            XCTAssertEqual(header + converted, hex(record.recordHex), "record bytes diverged for \(record.name)")
+        }
+    }
+}

--- a/ios/screen-capture/Tests/ScreenCaptureCoreTests/CommandLineOptionsEncodeTests.swift
+++ b/ios/screen-capture/Tests/ScreenCaptureCoreTests/CommandLineOptionsEncodeTests.swift
@@ -1,0 +1,104 @@
+import XCTest
+@testable import ScreenCaptureCore
+
+/// Parsing tests for the `--encode h264` flag family (issue #4788). Without the
+/// flag the mode carries `encode: nil` — the guarantee that the raw path is
+/// unchanged starts here.
+final class CommandLineOptionsEncodeTests: XCTestCase {
+    private func parse(_ args: [String]) throws -> CommandLineOptions {
+        try CommandLineOptions.parse(["screen-capture-helper"] + args)
+    }
+
+    func testEncodeH264WithVideoToolboxDefaultBitrate() throws {
+        let opts = try parse(["--simulator-window", "7", "--encode", "h264"])
+        XCTAssertEqual(
+            opts.mode,
+            .captureSimulator(windowID: 7, fps: 5, audio: false,
+                              encode: .init(bitrate: .videoToolboxDefault))
+        )
+    }
+
+    func testEncodeWithExplicitBitrate() throws {
+        let opts = try parse(["--simulator-window", "7", "--encode", "h264", "--bitrate-bps", "2500000"])
+        XCTAssertEqual(
+            opts.mode,
+            .captureSimulator(windowID: 7, fps: 5, audio: false,
+                              encode: .init(bitrate: .explicitBps(2_500_000)))
+        )
+    }
+
+    func testEncodeWithBitsPerPixel() throws {
+        let opts = try parse(["--simulator-window", "7", "--encode", "h264", "--bits-per-pixel", "0.1"])
+        XCTAssertEqual(
+            opts.mode,
+            .captureSimulator(windowID: 7, fps: 5, audio: false,
+                              encode: .init(bitrate: .bitsPerPixel(0.1)))
+        )
+    }
+
+    func testEncodeCarriesFpsAndAudio() throws {
+        let opts = try parse([
+            "--simulator-window", "7", "--simulator-fps", "15", "--audio", "--encode", "h264"
+        ])
+        XCTAssertEqual(
+            opts.mode,
+            .captureSimulator(windowID: 7, fps: 15, audio: true,
+                              encode: .init(bitrate: .videoToolboxDefault))
+        )
+    }
+
+    func testRejectsUnknownCodec() {
+        XCTAssertThrowsError(try parse(["--simulator-window", "7", "--encode", "vp9"])) {
+            XCTAssertEqual($0 as? CommandLineOptions.ParseError, .invalidValue(flag: "--encode", value: "vp9"))
+        }
+    }
+
+    func testRejectsBitrateAndBitsPerPixelTogether() {
+        XCTAssertThrowsError(try parse([
+            "--simulator-window", "7", "--encode", "h264", "--bitrate-bps", "1000", "--bits-per-pixel", "0.1"
+        ])) {
+            guard case CommandLineOptions.ParseError.conflictingFlags = $0 else {
+                return XCTFail("expected conflictingFlags, got \($0)")
+            }
+        }
+    }
+
+    func testRejectsBitrateWithoutEncode() {
+        XCTAssertThrowsError(try parse(["--simulator-window", "7", "--bitrate-bps", "1000"])) {
+            guard case CommandLineOptions.ParseError.conflictingFlags = $0 else {
+                return XCTFail("expected conflictingFlags, got \($0)")
+            }
+        }
+    }
+
+    func testRejectsEncodeWithoutSimulatorWindow() {
+        XCTAssertThrowsError(try parse(["--encode", "h264"])) {
+            guard case CommandLineOptions.ParseError.conflictingFlags = $0 else {
+                return XCTFail("expected conflictingFlags, got \($0)")
+            }
+        }
+    }
+
+    func testRejectsNonPositiveBitrate() {
+        XCTAssertThrowsError(try parse(["--simulator-window", "7", "--encode", "h264", "--bitrate-bps", "0"])) {
+            XCTAssertEqual($0 as? CommandLineOptions.ParseError, .invalidValue(flag: "--bitrate-bps", value: "0"))
+        }
+    }
+
+    func testRejectsNonPositiveBitsPerPixel() {
+        XCTAssertThrowsError(try parse([
+            "--simulator-window", "7", "--encode", "h264", "--bits-per-pixel", "0"
+        ])) {
+            XCTAssertEqual(
+                $0 as? CommandLineOptions.ParseError,
+                .invalidValue(flag: "--bits-per-pixel", value: "0")
+            )
+        }
+    }
+
+    func testEncodeMissingCodecValueThrows() {
+        XCTAssertThrowsError(try parse(["--simulator-window", "7", "--encode"])) {
+            XCTAssertEqual($0 as? CommandLineOptions.ParseError, .missingValue(flag: "--encode"))
+        }
+    }
+}

--- a/ios/screen-capture/Tests/ScreenCaptureCoreTests/CommandLineOptionsTests.swift
+++ b/ios/screen-capture/Tests/ScreenCaptureCoreTests/CommandLineOptionsTests.swift
@@ -7,7 +7,7 @@ final class CommandLineOptionsTests: XCTestCase {
             "screen-capture-helper", "--simulator-window", "42", "--audio"
         ])
 
-        XCTAssertEqual(options.mode, .captureSimulator(windowID: 42, fps: 5, audio: true))
+        XCTAssertEqual(options.mode, .captureSimulator(windowID: 42, fps: 5, audio: true, encode: nil))
     }
 
     func testDefaultsToCaptureWithoutDeviceID() throws {
@@ -74,7 +74,8 @@ final class CommandLineOptionsTests: XCTestCase {
             .captureSimulator(
                 windowID: 98765,
                 fps: CommandLineOptions.defaultSimulatorFPS,
-                audio: false
+                audio: false,
+                encode: nil
             )
         )
     }
@@ -85,7 +86,7 @@ final class CommandLineOptionsTests: XCTestCase {
             "--simulator-window", "1",
             "--simulator-fps", "30",
         ])
-        XCTAssertEqual(opts.mode, .captureSimulator(windowID: 1, fps: 30, audio: false))
+        XCTAssertEqual(opts.mode, .captureSimulator(windowID: 1, fps: 30, audio: false, encode: nil))
     }
 
     func testRejectsSimulatorFPSBelowRange() {

--- a/ios/screen-capture/Tests/ScreenCaptureCoreTests/EncoderControlTests.swift
+++ b/ios/screen-capture/Tests/ScreenCaptureCoreTests/EncoderControlTests.swift
@@ -1,0 +1,61 @@
+import XCTest
+@testable import ScreenCaptureCore
+
+/// Pure tests for the encoder control surface (issue #4788): the STDIN command
+/// parser, the force-keyframe latch, and the drop-policy decisions.
+final class EncoderControlTests: XCTestCase {
+    func testParsesForceKeyFrame() {
+        XCTAssertEqual(EncoderControlCommand.parse(line: "{\"cmd\":\"forceKeyFrame\"}"), .forceKeyFrame)
+        // Whitespace and extra keys are tolerated.
+        XCTAssertEqual(
+            EncoderControlCommand.parse(line: "  {\"cmd\":\"forceKeyFrame\",\"seq\":7}  "),
+            .forceKeyFrame
+        )
+    }
+
+    func testIgnoresMalformedAndUnknownCommands() {
+        XCTAssertNil(EncoderControlCommand.parse(line: ""))
+        XCTAssertNil(EncoderControlCommand.parse(line: "   "))
+        XCTAssertNil(EncoderControlCommand.parse(line: "not json"))
+        XCTAssertNil(EncoderControlCommand.parse(line: "{\"cmd\":\"unknown\"}"))
+        XCTAssertNil(EncoderControlCommand.parse(line: "{\"nope\":1}"))
+        XCTAssertNil(EncoderControlCommand.parse(line: "{\"cmd\":123}"))
+        XCTAssertNil(EncoderControlCommand.parse(line: "[\"forceKeyFrame\"]"))
+    }
+
+    func testLatchConsumesExactlyOnce() {
+        let latch = ForceKeyFrameLatch()
+        XCTAssertFalse(latch.isPending)
+        XCTAssertFalse(latch.consume())
+
+        latch.request()
+        XCTAssertTrue(latch.isPending)
+        XCTAssertTrue(latch.consume(), "the next frame is forced to an IDR")
+        XCTAssertFalse(latch.consume(), "subsequent frames are not forced")
+        XCTAssertFalse(latch.isPending)
+    }
+
+    func testLatchRequestIsIdempotentUntilConsumed() {
+        let latch = ForceKeyFrameLatch()
+        latch.request()
+        latch.request()
+        XCTAssertTrue(latch.consume())
+        XCTAssertFalse(latch.consume())
+    }
+
+    func testDropsBeforeEncodeOnlyWhenBehind() {
+        XCTAssertFalse(EncoderDropPolicy.shouldDropBeforeEncode(inFlightFrames: 0, maxInFlightFrames: 3))
+        XCTAssertFalse(EncoderDropPolicy.shouldDropBeforeEncode(inFlightFrames: 2, maxInFlightFrames: 3))
+        XCTAssertTrue(EncoderDropPolicy.shouldDropBeforeEncode(inFlightFrames: 3, maxInFlightFrames: 3))
+        XCTAssertTrue(EncoderDropPolicy.shouldDropBeforeEncode(inFlightFrames: 9, maxInFlightFrames: 3))
+    }
+
+    func testOutputQueueOverflowDecision() {
+        XCTAssertFalse(
+            EncoderDropPolicy.wouldOverflowOutputQueue(queuedBytes: 10, recordBytes: 20, maxQueuedBytes: 30)
+        )
+        XCTAssertTrue(
+            EncoderDropPolicy.wouldOverflowOutputQueue(queuedBytes: 10, recordBytes: 21, maxQueuedBytes: 30)
+        )
+    }
+}

--- a/ios/screen-capture/Tests/ScreenCaptureCoreTests/FrameWriterEncodedTests.swift
+++ b/ios/screen-capture/Tests/ScreenCaptureCoreTests/FrameWriterEncodedTests.swift
@@ -1,0 +1,120 @@
+import XCTest
+@testable import ScreenCaptureCore
+
+/// Sink that blocks the drain worker on its first write until released, so a
+/// test can let records accumulate in the bounded queue.
+private final class FirstWriteBlockingSink: FrameSink {
+    private let lock = NSLock()
+    private var writeCount = 0
+    private let firstWriteStarted = DispatchSemaphore(value: 0)
+    private let release = DispatchSemaphore(value: 0)
+
+    func write(_ chunk: Data) {
+        lock.lock()
+        writeCount += 1
+        let shouldBlock = writeCount == 1
+        lock.unlock()
+        if shouldBlock {
+            firstWriteStarted.signal()
+            _ = release.wait(timeout: .now() + 1)
+        }
+    }
+
+    func waitForFirstWrite() -> Bool {
+        firstWriteStarted.wait(timeout: .now() + 1) == .success
+    }
+
+    func allowOutput() {
+        release.signal()
+    }
+}
+
+/// Tests the ordered, never-drop encoded-record output path (issue #4788).
+final class FrameWriterEncodedTests: XCTestCase {
+    private struct Record {
+        let header: Data
+        let payload: Data
+    }
+
+    private func makeRecord(_ payload: [UInt8], keyframe: Bool, pts: UInt32) -> Record {
+        let payloadData = Data(payload)
+        let header = FrameProtocol.encodeEncodedVideoHeader(
+            payloadLength: payloadData.count, isKeyframe: keyframe, presentationTimestampMs: pts
+        )
+        return Record(header: header, payload: payloadData)
+    }
+
+    func testWritesEncodedHeaderThenPayloadInOrder() {
+        let sink = BufferSink()
+        let writer = FrameWriter(sink: sink)
+        let keyframe = makeRecord([0x00, 0x00, 0x00, 0x01, 0x67], keyframe: true, pts: 100)
+        let delta = makeRecord([0x00, 0x00, 0x00, 0x01, 0x41], keyframe: false, pts: 133)
+
+        XCTAssertTrue(writer.writeEncoded(header: keyframe.header, payload: keyframe.payload))
+        XCTAssertTrue(writer.writeEncoded(header: delta.header, payload: delta.payload))
+        writer.flush()
+
+        XCTAssertEqual(sink.data, keyframe.header + keyframe.payload + delta.header + delta.payload)
+    }
+
+    func testNeverDropsEncodedRecordsUnderSlowSink() {
+        // Records queue while the sink blocks; none may be dropped or reordered.
+        let sink = BlockingPayloadSink()
+        let writer = FrameWriter(sink: sink)
+        let one = makeRecord([0xA1], keyframe: true, pts: 0)
+        let two = makeRecord([0xA2], keyframe: false, pts: 1)
+        let three = makeRecord([0xA3], keyframe: false, pts: 2)
+
+        XCTAssertTrue(writer.writeEncoded(header: one.header, payload: one.payload))
+        XCTAssertTrue(sink.waitForFirstPayload())
+        XCTAssertTrue(writer.writeEncoded(header: two.header, payload: two.payload))
+        XCTAssertTrue(writer.writeEncoded(header: three.header, payload: three.payload))
+        sink.allowOutput()
+        writer.flush()
+
+        // Every payload survived, in submission order (payloads are the even writes).
+        XCTAssertEqual(sink.payloads(), [one.payload, two.payload, three.payload])
+    }
+
+    func testEncodedOverflowReturnsFalseInsteadOfDropping() {
+        // Block the drain worker on the very first write so subsequent records
+        // accumulate in the bounded queue rather than draining one at a time.
+        let sink = FirstWriteBlockingSink()
+        let writer = FrameWriter(
+            sink: sink,
+            configuration: .init(maximumPendingEncodedBytes: 4)
+        )
+        let one = makeRecord([0x01, 0x02, 0x03], keyframe: true, pts: 0)   // 3 bytes
+        let two = makeRecord([0x04, 0x05, 0x06], keyframe: false, pts: 1)  // fits: 0+3 <= 4
+        let three = makeRecord([0x07, 0x08, 0x09], keyframe: false, pts: 2)  // 3+3 = 6 > 4
+
+        XCTAssertTrue(writer.writeEncoded(header: one.header, payload: one.payload))
+        XCTAssertTrue(sink.waitForFirstWrite())
+        // one is dequeued and blocked in the sink; two fits the 4-byte cap.
+        XCTAssertTrue(writer.writeEncoded(header: two.header, payload: two.payload))
+        // three would overflow — signalled (fatal), never a silent drop.
+        XCTAssertFalse(writer.writeEncoded(header: three.header, payload: three.payload))
+        sink.allowOutput()
+        writer.flush()
+    }
+
+    func testEncodedRecordsInterleaveWithAudioWithoutStarving() {
+        let sink = BlockingPayloadSink()
+        let writer = FrameWriter(sink: sink)
+        let one = makeRecord([0xE1], keyframe: true, pts: 0)
+        let two = makeRecord([0xE2], keyframe: false, pts: 1)
+        let audioA = Data([0xAA])
+        let audioB = Data([0xBB])
+
+        XCTAssertTrue(writer.writeEncoded(header: one.header, payload: one.payload))
+        XCTAssertTrue(sink.waitForFirstPayload())
+        writer.writeAudio(pcm16le: audioA)
+        writer.writeAudio(pcm16le: audioB)
+        XCTAssertTrue(writer.writeEncoded(header: two.header, payload: two.payload))
+        sink.allowOutput()
+        writer.flush()
+
+        // Media alternates with audio: encoded, audioA, encoded, audioB.
+        XCTAssertEqual(sink.payloads(), [one.payload, audioA, two.payload, audioB])
+    }
+}

--- a/ios/screen-capture/Tests/ScreenCaptureCoreTests/H264EncodeMathTests.swift
+++ b/ios/screen-capture/Tests/ScreenCaptureCoreTests/H264EncodeMathTests.swift
@@ -1,0 +1,130 @@
+import XCTest
+@testable import ScreenCaptureCore
+
+/// Pins the in-helper H.264 resolution/bitrate arithmetic (issue #4788) against
+/// the shared golden vectors in `test/fixtures/h264-level42-scale-golden-vectors.json`.
+/// The TypeScript sender (`resolveIosEncoderScale`, `defaultIosBitrateBps`,
+/// `WEBRTC_H264_MAX_MACROBLOCKS_PER_FRAME`) reproduces the SAME fixture, so the
+/// cross-language Level 4.2 macroblock budget advertised in the WHIP SDP cannot
+/// drift from what this helper actually encodes.
+final class H264EncodeMathTests: XCTestCase {
+    private struct Scaled: Decodable {
+        let width: Int
+        let height: Int
+    }
+
+    private struct ScaleCase: Decodable {
+        let width: Int
+        let height: Int
+        let scaled: Scaled?
+        let macroblocks: Int
+    }
+
+    private struct BitrateCase: Decodable {
+        let width: Int
+        let height: Int
+        let fps: Int
+        let bitrateBps: Int
+    }
+
+    private struct Golden: Decodable {
+        let maxMacroblocksPerFrame: Int
+        let macroblockSize: Int
+        let minEncoderDimension: Int
+        let defaultBitsPerPixel: Double
+        let scaleCases: [ScaleCase]
+        let bitrateCases: [BitrateCase]
+    }
+
+    private func loadGolden() throws -> Golden {
+        // <repo>/ios/screen-capture/Tests/ScreenCaptureCoreTests/<thisFile>.
+        var root = URL(fileURLWithPath: #filePath)
+        for _ in 0..<5 { root.deleteLastPathComponent() }
+        let fixture = root
+            .appendingPathComponent("test")
+            .appendingPathComponent("fixtures")
+            .appendingPathComponent("h264-level42-scale-golden-vectors.json")
+        let data = try Data(contentsOf: fixture)
+        return try JSONDecoder().decode(Golden.self, from: data)
+    }
+
+    /// The Level 4.2 macroblock budget and the other cross-language constants
+    /// MUST equal what the fixture (generated from the TS constants) encodes.
+    func testConstantsMatchFixture() throws {
+        let golden = try loadGolden()
+        XCTAssertEqual(H264EncodeMath.maxMacroblocksPerFrame, golden.maxMacroblocksPerFrame)
+        XCTAssertEqual(H264EncodeMath.macroblockSize, golden.macroblockSize)
+        XCTAssertEqual(H264EncodeMath.minEncoderDimension, golden.minEncoderDimension)
+        XCTAssertEqual(H264EncodeMath.defaultBitsPerPixel, golden.defaultBitsPerPixel, accuracy: 1e-12)
+    }
+
+    /// Every scale case resolves to the same size (and the same macroblock count)
+    /// as the TypeScript `resolveIosEncoderScale`.
+    func testScaleCasesMatchFixture() throws {
+        let golden = try loadGolden()
+        for testCase in golden.scaleCases {
+            XCTAssertEqual(
+                H264EncodeMath.macroblocksPerFrame(width: testCase.width, height: testCase.height),
+                testCase.macroblocks,
+                "macroblocks diverged for \(testCase.width)x\(testCase.height)"
+            )
+            let resolved = H264EncodeMath.resolveEncoderScale(
+                H264EncodeMath.EncoderSize(width: testCase.width, height: testCase.height)
+            )
+            if let scaled = testCase.scaled {
+                XCTAssertEqual(
+                    resolved,
+                    H264EncodeMath.EncoderSize(width: scaled.width, height: scaled.height),
+                    "scale diverged for \(testCase.width)x\(testCase.height)"
+                )
+            } else {
+                XCTAssertNil(resolved, "expected native size for \(testCase.width)x\(testCase.height)")
+            }
+        }
+    }
+
+    /// Every scaled result is even (4:2:0) and inside the Level 4.2 budget.
+    func testScaledResultsAreEvenAndWithinBudget() throws {
+        let golden = try loadGolden()
+        for testCase in golden.scaleCases {
+            let resolved = H264EncodeMath.resolveEncoderScale(
+                H264EncodeMath.EncoderSize(width: testCase.width, height: testCase.height)
+            ) ?? H264EncodeMath.EncoderSize(width: testCase.width, height: testCase.height)
+            XCTAssertEqual(resolved.width % 2, 0)
+            XCTAssertEqual(resolved.height % 2, 0)
+            XCTAssertLessThanOrEqual(
+                H264EncodeMath.macroblocksPerFrame(width: resolved.width, height: resolved.height),
+                H264EncodeMath.maxMacroblocksPerFrame
+            )
+        }
+    }
+
+    /// The bits-per-pixel -> bitrate arithmetic matches `defaultIosBitrateBps`
+    /// (via the default budget) and the general `bitrateBps` (with that budget).
+    func testBitrateCasesMatchFixture() throws {
+        let golden = try loadGolden()
+        for testCase in golden.bitrateCases {
+            let size = H264EncodeMath.EncoderSize(width: testCase.width, height: testCase.height)
+            XCTAssertEqual(
+                H264EncodeMath.defaultBitrateBps(size: size, fps: testCase.fps),
+                testCase.bitrateBps,
+                "default bitrate diverged for \(testCase.width)x\(testCase.height)@\(testCase.fps)"
+            )
+            XCTAssertEqual(
+                H264EncodeMath.bitrateBps(
+                    width: testCase.width, height: testCase.height,
+                    fps: testCase.fps, bitsPerPixel: golden.defaultBitsPerPixel
+                ),
+                testCase.bitrateBps
+            )
+        }
+    }
+
+    func testBitrateFloorsAtOne() {
+        // A zero-area frame still returns the positive floor rather than 0.
+        XCTAssertEqual(
+            H264EncodeMath.bitrateBps(width: 0, height: 100, fps: 30, bitsPerPixel: 0.1),
+            1
+        )
+    }
+}

--- a/ios/screen-capture/Tests/ScreenCaptureHelperTests/ControlChannelTests.swift
+++ b/ios/screen-capture/Tests/ScreenCaptureHelperTests/ControlChannelTests.swift
@@ -1,0 +1,45 @@
+import XCTest
+@testable import ScreenCaptureCore
+@testable import ScreenCaptureHelper
+
+/// Tests the STDIN control-channel framing (issue #4788): newline-delimited JSON
+/// is split and dispatched, partial lines buffer across chunks, and malformed
+/// lines are ignored. The `ingest` seam avoids needing a real pipe.
+final class ControlChannelTests: XCTestCase {
+    private func collect(_ chunks: [String]) -> [EncoderControlCommand] {
+        var received: [EncoderControlCommand] = []
+        let channel = ControlChannel { received.append($0) }
+        for chunk in chunks {
+            channel.ingest(Data(chunk.utf8))
+        }
+        return received
+    }
+
+    func testDispatchesForceKeyFrameLine() {
+        XCTAssertEqual(collect(["{\"cmd\":\"forceKeyFrame\"}\n"]), [.forceKeyFrame])
+    }
+
+    func testBuffersPartialLineAcrossChunks() {
+        let received = collect(["{\"cmd\":", "\"forceKeyFrame\"}\n"])
+        XCTAssertEqual(received, [.forceKeyFrame])
+    }
+
+    func testDispatchesMultipleLinesInOneChunk() {
+        let received = collect(["{\"cmd\":\"forceKeyFrame\"}\n{\"cmd\":\"forceKeyFrame\"}\n"])
+        XCTAssertEqual(received, [.forceKeyFrame, .forceKeyFrame])
+    }
+
+    func testIgnoresMalformedAndUnknownLines() {
+        let received = collect([
+            "garbage\n",
+            "{\"cmd\":\"unknown\"}\n",
+            "{\"cmd\":\"forceKeyFrame\"}\n",
+        ])
+        XCTAssertEqual(received, [.forceKeyFrame])
+    }
+
+    func testDoesNotDispatchUntilNewline() {
+        // No trailing newline: the command is not yet complete.
+        XCTAssertEqual(collect(["{\"cmd\":\"forceKeyFrame\"}"]), [])
+    }
+}

--- a/test/features/webrtc/h264Level42ScaleGolden.test.ts
+++ b/test/features/webrtc/h264Level42ScaleGolden.test.ts
@@ -1,0 +1,65 @@
+import { describe, expect, test } from "bun:test";
+import { readFileSync } from "node:fs";
+import { WEBRTC_H264_MAX_MACROBLOCKS_PER_FRAME, h264MacroblocksPerFrame } from "../../../src/features/webrtc/h264Level";
+import {
+  resolveIosEncoderScale,
+  defaultIosBitrateBps,
+  IOS_WEBRTC_DEFAULT_BITS_PER_PIXEL,
+} from "../../../src/features/webrtc/IosH264Source";
+
+/**
+ * Pins the H.264 Level 4.2 macroblock budget and the resolution/bitrate
+ * arithmetic against the shared golden vectors in
+ * `test/fixtures/h264-level42-scale-golden-vectors.json` (issue #4788). The
+ * Swift helper (`ScreenCaptureCore.H264EncodeMath`) asserts the SAME fixture, so
+ * the cross-language Level 4.2 capability the WHIP SDP advertises cannot drift
+ * from what the in-helper encoder produces. Regenerate with `scratch/gen.ts`.
+ */
+interface ScaleCase {
+  width: number;
+  height: number;
+  scaled: { width: number; height: number } | null;
+  macroblocks: number;
+}
+interface BitrateCase {
+  width: number;
+  height: number;
+  fps: number;
+  bitrateBps: number;
+}
+interface Golden {
+  maxMacroblocksPerFrame: number;
+  macroblockSize: number;
+  minEncoderDimension: number;
+  defaultBitsPerPixel: number;
+  scaleCases: ScaleCase[];
+  bitrateCases: BitrateCase[];
+}
+
+const golden: Golden = JSON.parse(
+  readFileSync(new URL("../../fixtures/h264-level42-scale-golden-vectors.json", import.meta.url), "utf8")
+);
+
+describe("H.264 Level 4.2 scale/bitrate golden vectors (issue #4788)", () => {
+  test("the Level 4.2 macroblock budget matches the fixture", () => {
+    expect(WEBRTC_H264_MAX_MACROBLOCKS_PER_FRAME).toBe(golden.maxMacroblocksPerFrame);
+    expect(IOS_WEBRTC_DEFAULT_BITS_PER_PIXEL).toBe(golden.defaultBitsPerPixel);
+  });
+
+  for (const scaleCase of golden.scaleCases) {
+    test(`resolveIosEncoderScale reproduces ${scaleCase.width}x${scaleCase.height}`, () => {
+      expect(h264MacroblocksPerFrame(scaleCase.width, scaleCase.height)).toBe(scaleCase.macroblocks);
+      expect(resolveIosEncoderScale({ width: scaleCase.width, height: scaleCase.height })).toEqual(
+        scaleCase.scaled
+      );
+    });
+  }
+
+  for (const bitrateCase of golden.bitrateCases) {
+    test(`defaultIosBitrateBps reproduces ${bitrateCase.width}x${bitrateCase.height}@${bitrateCase.fps}`, () => {
+      expect(
+        defaultIosBitrateBps({ width: bitrateCase.width, height: bitrateCase.height }, bitrateCase.fps)
+      ).toBe(bitrateCase.bitrateBps);
+    });
+  }
+});

--- a/test/fixtures/h264-level42-scale-golden-vectors.json
+++ b/test/fixtures/h264-level42-scale-golden-vectors.json
@@ -1,0 +1,28 @@
+{
+  "description": "Golden vectors pinning the H.264 Level 4.2 macroblock budget and the resolution/bitrate arithmetic across the TypeScript sender (src/features/webrtc/IosH264Source.ts + h264Level.ts) and the in-helper Swift encoder (ios/screen-capture ScreenCaptureCore H264EncodeMath). Both suites assert their own constant equals maxMacroblocksPerFrame and reproduce every scale/bitrate case, so the cross-language Level 4.2 capability advertised in the WHIP SDP cannot drift from what the helper actually encodes. Regenerate with scratch/gen.ts (imports the real TS functions).",
+  "maxMacroblocksPerFrame": 8192,
+  "macroblockSize": 16,
+  "minEncoderDimension": 2,
+  "defaultBitsPerPixel": 0.1,
+  "scaleCases": [
+    { "width": 1170, "height": 2532, "scaled": { "width": 974, "height": 2112 }, "macroblocks": 11766 },
+    { "width": 886, "height": 1920, "scaled": null, "macroblocks": 6720 },
+    { "width": 750, "height": 1334, "scaled": null, "macroblocks": 3948 },
+    { "width": 286, "height": 658, "scaled": null, "macroblocks": 756 },
+    { "width": 1284, "height": 2778, "scaled": { "width": 976, "height": 2110 }, "macroblocks": 14094 },
+    { "width": 3840, "height": 2160, "scaled": { "width": 1904, "height": 1072 }, "macroblocks": 32400 },
+    { "width": 1920, "height": 1080, "scaled": null, "macroblocks": 8160 },
+    { "width": 1, "height": 1, "scaled": { "width": 2, "height": 2 }, "macroblocks": 1 },
+    { "width": 3, "height": 5, "scaled": { "width": 2, "height": 4 }, "macroblocks": 1 },
+    { "width": 8192, "height": 8192, "scaled": { "width": 1440, "height": 1440 }, "macroblocks": 262144 },
+    { "width": 640, "height": 480, "scaled": null, "macroblocks": 1200 },
+    { "width": 911, "height": 1940, "scaled": { "width": 910, "height": 1940 }, "macroblocks": 6954 }
+  ],
+  "bitrateCases": [
+    { "width": 286, "height": 658, "fps": 15, "bitrateBps": 282282 },
+    { "width": 911, "height": 1940, "fps": 15, "bitrateBps": 2651010 },
+    { "width": 1170, "height": 2532, "fps": 10, "bitrateBps": 2962440 },
+    { "width": 640, "height": 480, "fps": 30, "bitrateBps": 921600 },
+    { "width": 100, "height": 100, "fps": 5, "bitrateBps": 5000 }
+  ]
+}


### PR DESCRIPTION
## What

Captures 420v (NV12) from ScreenCaptureKit and encodes H.264 **Baseline 4.2** in-process with `VTCompressionSession`, behind a new `--encode h264` flag. Builds on the encoded-record wire vocabulary from [#4949](https://github.com/kaeawc/auto-mobile/pull/4949) (`FrameProtocol.encodeEncodedVideoHeader` / `EncodedVideoRecord`) — no new record framing.

Closes [#4788](https://github.com/kaeawc/auto-mobile/issues/4788).

## No behavior change without the flag (guaranteed)

Production TS does not pass `--encode` yet, so the default raw-BGRA path is **byte-identical to today**:

- No flag ⇒ `encode: nil` ⇒ `SimulatorCaptureSession.isEncoding == false`. `makeConfiguration` keeps `kCVPixelFormatType_32BGRA`; the screen callback falls through to the unchanged `writer.write(sampleBuffer:)` raw path; `performReconfiguration` uses the stored pixel format, which is 32BGRA in raw mode (same literal as before).
- The STDIN control channel is only started when `encode != nil`, so the raw path never touches STDIN.
- `FrameWriter`'s raw frame/audio queues and their exact interleave are untouched; encoded records live in a separate queue reached only via the new `writeEncoded`. All pre-existing `FrameWriterTests` / `SimulatorCaptureSessionTests` / `CommandLineOptionsTests` still pass unchanged.

## Encoder config

`kVTProfileLevel_H264_Baseline_4_2`; `AllowFrameReordering = false` (no B-frames); `RealTime = true`; `MaxKeyFrameInterval ≈ 2s × fps` (+ `MaxKeyFrameIntervalDuration = 2s`). Hardware preferred but **not required**: `kVTVideoEncoderSpecification_EnableHardwareAcceleratedVideoEncoder` is set in the encoder specification **without** the matching `Require…` key — the `-allow_sw 1` semantic that keeps hosted runners alive when the HW encoder is absent/exhausted. The delivered IOSurface-backed 420v `CVPixelBuffer` is fed straight to `VTCompressionSessionEncodeFrame` — no `VTPixelTransferSession`, no vImage, no color conversion.

## Scale + bitrate arithmetic, and the cross-language macroblock pin

`H264EncodeMath` (pure) ports `resolveIosEncoderScale` and `defaultIosBitrateBps` from `src/features/webrtc/IosH264Source.ts` and the Level 4.2 budget from `h264Level.ts`. ScreenCaptureKit does the downscale via `SCStreamConfiguration.width/height` (no separate scaling stage); the encode target is `resolveEncoderScale(deliveredPixels)`.

The cross-language Level 4.2 macroblock budget is pinned by a **shared golden fixture** `test/fixtures/h264-level42-scale-golden-vectors.json` (generated from the real TS functions). Both sides assert against it:
- Swift `H264EncodeMathTests` asserts `H264EncodeMath.maxMacroblocksPerFrame == fixture` and reproduces every scale/bitrate case.
- TS `h264Level42ScaleGolden.test.ts` asserts `WEBRTC_H264_MAX_MACROBLOCKS_PER_FRAME == fixture` and `resolveIosEncoderScale` / `defaultIosBitrateBps` reproduce the same cases.

So the budget cannot drift from the Level 4.2 the WHIP SDP advertises.

**Bitrate policy stays in TS; only the arithmetic moved.** `--bitrate-bps N` (operator override) OR `--bits-per-pixel X` (Simulator default 0.1, #4349) OR neither (physical device ⇒ VideoToolbox default, #4375). The helper computes `AverageBitRate` from the delivered pixel dimensions — which only it knows pre-encode — via `H264EncodeMath.bitrateBps`. `DataRateLimits` peak ceiling (~1.5× average over a 1s window) is wired.

## avcC → Annex-B, SPS/PPS on every IDR

`AnnexBConverter` (pure) replaces each `NALUnitHeaderLength`-byte length prefix (read from the format description) with a start code, handling multi-NAL samples, and prepends SPS/PPS to **every IDR** (queried from the format description) so each keyframe is self-decodable — matching ffmpeg's `-f h264`. Pinned byte-for-byte against #4949's shared golden vectors: an avcC-wrapped golden NAL converts to the golden Annex-B payload and the assembled `FrameProtocol` record equals the golden record bytes.

## Drop policy (encoder input)

The raw path's newest-wins drop corrupts the encoded reference chain, so the encoded path instead (`EncoderDropPolicy`, pure): drops late frames **before** `encodeFrame` when the encoder is behind (`inFlight ≥ maxInFlight`); **never** drops an emitted encoded record; bounds the output queue (`FrameWriter.writeEncoded`) and treats overflow as **fatal** (exit ⇒ supervisor relaunches with a fresh IDR) rather than dropping a record. The raw path's drop behavior is unchanged.

## forceKeyFrame control channel

`ControlChannel` reads newline-delimited JSON from STDIN. `{"cmd":"forceKeyFrame"}` arms a thread-safe `ForceKeyFrameLatch`; the next `encodeFrame` consumes it and applies `kVTEncodeFrameOptionKey_ForceKeyFrame`. Parsing is permissive (malformed/unknown ignored), per the repo's minimal-control-surface precedent. This replaces the encoder-restart keyframe hack.

## Reconfiguration choice: seamless

On a capture-size change the VT session is torn down and recreated at the new (budgeted) size; the new session's first frame is a fresh SPS/PPS + IDR. This also handles first-frame native-pixel discovery uniformly (SCK converges its output to the encode resolution, then frames flow to VideoToolbox).

## Pure-unit-tested vs device-only

**Pure (unit-tested, headless):** macroblock budget + resolution scale, bits-per-pixel→bitrate, avcC→Annex-B + SPS/PPS-on-IDR assembly, force-keyframe latch/parse, drop-when-behind + output-overflow decisions, CLI flag parsing, the encoded `FrameWriter` queue, and the STDIN framing.

**Device-only (VideoToolbox, not exercised headlessly):** `H264VideoEncoder` (`VTCompressionSession` create/config/encode/output callback) and the encode routing inside `SimulatorCaptureSession.stream(_:didOutputSampleBuffer:of:)`.

## Gates (all run inline)

- `./scripts/ios/swift-build.sh` — PASS (screen-capture built successfully).
- `swift build -Xswiftc -warnings-as-errors` — PASS.
- `swift test` — PASS (115 tests, 0 failures, incl. all new suites).
- `bun test test/features/webrtc/h264Level42ScaleGolden.test.ts` — PASS (18/18).
- SwiftLint (non-strict, repo config) on changed files — clean (0 errors).

## Do not merge

Left for review; auto-merge not enabled.
