### PR TITLE
feat(ios-webrtc): consume in-helper encoded H.264 in IosH264Source (no ffmpeg on the encoded path)

### DIFF
--- a/src/features/screen-stream/IOSScreenCaptureHelper.ts
+++ b/src/features/screen-stream/IOSScreenCaptureHelper.ts
@@ -44,12 +44,38 @@ export type HelperSpawner = (
 export type HelperProcessGroupKiller = (pid: number, signal: NodeJS.Signals) => void;
 
 /**
+ * In-helper H.264 encode settings (issue #4789). Present on a simulator target
+ * requests the helper's `--encode h264` mode (420v capture + VTCompressionSession
+ * Annex-B output) instead of streaming raw BGRA. The bitrate *policy* stays here
+ * in the supervisor — the helper only carries the chosen flag and does the
+ * pre-encode pixel arithmetic (scale + bitrate) it alone knows. Mirrors the Swift
+ * `CommandLineOptions.EncodeSettings` (issue #4788).
+ */
+export interface EncodeSettings {
+  /** Only H.264 exists today; the field pins the vocabulary for future codecs. */
+  codec: "h264";
+  bitrate: EncodeBitratePolicy;
+}
+
+/**
+ * How the helper should choose the encoder's average bitrate. `explicitBps` is an
+ * operator override (`--bitrate-bps`), `bitsPerPixel` derives it from the
+ * delivered pixels x fps (`--bits-per-pixel`, the Simulator default), and
+ * `videoToolboxDefault` passes neither flag (VideoToolbox picks — the
+ * physical-device path, #4375).
+ */
+export type EncodeBitratePolicy =
+  | { kind: "explicitBps"; bps: number }
+  | { kind: "bitsPerPixel"; bpp: number }
+  | { kind: "videoToolboxDefault" };
+
+/**
  * What the helper should capture. Either a USB-connected iOS device (via
  * AVFoundation) or a macOS iOS Simulator window (via ScreenCaptureKit).
  */
 export type CaptureTarget =
   | { kind: "device"; deviceId?: string }
-  | { kind: "simulator"; windowID: number; fps?: number; audio?: boolean };
+  | { kind: "simulator"; windowID: number; fps?: number; audio?: boolean; encode?: EncodeSettings };
 
 /** Valid range for the simulator capture frame rate, mirrors the Swift CLI. */
 export const SIMULATOR_FPS_MIN = 5;
@@ -353,6 +379,34 @@ export class IOSScreenCaptureHelper extends EventEmitter {
   }
 
   /**
+   * Ask the in-helper encoder to emit a fresh IDR on its next frame by writing
+   * `{"cmd":"forceKeyFrame"}` on the newline-delimited STDIN control channel the
+   * helper opens in `--encode h264` mode (issue #4789 / the channel added by
+   * #4788). Unlike the raw ffmpeg path — which could only get an IDR by restarting
+   * the encoder — this is a cheap in-process signal, so the caller may throttle
+   * it far more loosely. Returns false (a logged no-op) when the helper is not
+   * running or the write fails; a not-yet-started or raw-mode helper has no
+   * control channel to signal. The write is a tiny control line, so backpressure
+   * is not tracked.
+   */
+  requestKeyFrame(): boolean {
+    const proc = this.process;
+    if (proc === null || !this.isRunning) {
+      return false;
+    }
+    try {
+      proc.stdin.write(`${JSON.stringify({ cmd: "forceKeyFrame" })}\n`);
+      return true;
+    } catch (error) {
+      // The encoder restarts on the next capture frame's periodic GOP even if
+      // this control write is lost, so a failed signal is a best-effort miss,
+      // not a stream failure.
+      logger.debug(`[IOSScreenCaptureHelper] forceKeyFrame control write failed: ${error}`);
+      return false;
+    }
+  }
+
+  /**
    * Fail fast on a version-skewed pairing: a helper that never advertised the
    * encoded-video capability (an old binary pinned via
    * `AUTOMOBILE_IOS_SCREEN_CAPTURE_HELPER`) cannot produce encoded output, so
@@ -510,7 +564,32 @@ function buildArgs(target: CaptureTarget): string[] {
       if (target.audio === true) {
         args.push("--audio");
       }
+      appendEncodeArgs(args, target.encode);
       return args;
     }
+  }
+}
+
+/**
+ * Append the `--encode h264` mode flags (issue #4789). The bitrate policy is
+ * passed DOWN as helper flags so the helper does the pre-encode pixel arithmetic
+ * rather than the supervisor computing an ffmpeg `-b:v`. `videoToolboxDefault`
+ * passes neither flag (the helper lets VideoToolbox choose). Mirrors the Swift
+ * `--bitrate-bps`/`--bits-per-pixel` parsing (issue #4788).
+ */
+function appendEncodeArgs(args: string[], encode: EncodeSettings | undefined): void {
+  if (encode === undefined) {
+    return;
+  }
+  args.push("--encode", encode.codec);
+  switch (encode.bitrate.kind) {
+    case "explicitBps":
+      args.push("--bitrate-bps", String(Math.round(encode.bitrate.bps)));
+      break;
+    case "bitsPerPixel":
+      args.push("--bits-per-pixel", String(encode.bitrate.bpp));
+      break;
+    case "videoToolboxDefault":
+      break;
   }
 }

--- a/src/features/screen-stream/IOSSimulatorCaptureHelperPool.ts
+++ b/src/features/screen-stream/IOSSimulatorCaptureHelperPool.ts
@@ -12,6 +12,7 @@ import {
 } from "./IOSScreenCaptureHelper";
 import type {
   DecodedAudio,
+  DecodedEncodedVideo,
   DecodedFrame,
   MalformedFrameError,
 } from "./frameProtocol";
@@ -22,7 +23,14 @@ export interface IosSimulatorCaptureHelperLease {
   start(): void | Promise<void>;
   stop(): Promise<unknown>;
   invalidate(): Promise<void>;
+  /**
+   * Ask the in-helper encoder to emit a fresh IDR (encoded leases only). No-op on
+   * a raw-BGRA helper, which has no STDIN control channel. See issue #4789.
+   */
+  requestKeyFrame(): boolean;
   on(event: "frame", listener: (frame: DecodedFrame) => void): this;
+  on(event: "encodedVideo", listener: (video: DecodedEncodedVideo) => void): this;
+  on(event: "capability", listener: (token: string) => void): this;
   on(event: "frameMetrics", listener: (metrics: FrameQueueMetrics) => void): this;
   on(event: "captureMetrics", listener: (metrics: NativeFrameMetrics) => void): this;
   on(event: "audio", listener: (audio: DecodedAudio) => void): this;
@@ -33,7 +41,7 @@ export interface IosSimulatorCaptureHelperLease {
   on(event: "error", listener: (error: Error) => void): this;
 }
 
-type SimulatorHelper = Pick<IOSScreenCaptureHelper, "start" | "stop" | "isRunning"> & {
+type SimulatorHelper = Pick<IOSScreenCaptureHelper, "start" | "stop" | "isRunning" | "requestKeyFrame"> & {
   on<E extends keyof IosScreenCaptureHelperEvents>(
     event: E,
     listener: IosScreenCaptureHelperEvents[E]
@@ -52,7 +60,15 @@ interface HelperEntry {
   key: string;
   helper: SimulatorHelper;
   leases: Set<PooledSimulatorCaptureHelperLease>;
+  /**
+   * Raw-frame warm-start cache (raw leases only). A late lease is primed by
+   * replaying this last BGRA frame. Meaningless in encoded mode — a single cached
+   * H.264 access unit is a P-frame the new lease cannot decode — so encoded
+   * entries leave it null and force a fresh IDR on attach instead (issue #4789).
+   */
   latestFrame: DecodedFrame | null;
+  /** True when this entry's helper runs the in-helper H.264 encode path (#4789). */
+  encoded: boolean;
   idleTimer: NodeJS.Timeout | null;
   failed: boolean;
   failedStopFailed: boolean;
@@ -64,6 +80,13 @@ interface HelperEntry {
  * source gets a lease, so its ffmpeg encoder and callbacks stay stream-scoped
  * while capture survives short reconnect gaps. A new window identity never
  * retargets an active helper; it gets an independent, TTL-bounded entry.
+ *
+ * In-helper encoding (issue #4789) collapses the raw path's "capture is
+ * host-scoped, encoding is stream-scoped" separation, so on the encoded path the
+ * encoder config (mode + bitrate) becomes part of the target key — a mismatched
+ * acquire gets a new entry, never a live reconfigure — the raw-frame warm-start
+ * cache is disabled, and every lease attach forces a fresh IDR so a late lease
+ * never starts on undecodable P-frames. Raw-lease behavior is unchanged.
  */
 export class IOSSimulatorCaptureHelperPool {
   private readonly idleTtlMs: number;
@@ -104,62 +127,112 @@ export class IOSSimulatorCaptureHelperPool {
         return;
       }
       const targetKey = helperTargetKey(lease.options.target, lease.options.binaryPath);
-      let entry = this.entries.get(targetKey);
-      if (entry?.failedStopFailed) {
-        // A previous helper.stop() threw and left this entry poisoned. The
-        // failure was already surfaced once (to the awaiting invalidate/best-
-        // effort cleanup). Drop the entry now so this attach can build a fresh
-        // helper instead of re-throwing the same error forever — bounded retry,
-        // not permanent poison of the window target.
-        this.clearEntryIdleTimer(entry);
-        this.entries.delete(targetKey);
-        entry = undefined;
-      }
-      if (!entry) {
-        // A new CGWindowID proves a reboot/window recreation. Evict any idle
-        // session now rather than letting it occupy ScreenCaptureKit resources
-        // through its TTL, but never disrupt a different active simulator stream.
-        for (const candidate of this.entries.values()) {
-          if (candidate.key !== targetKey && candidate.leases.size === 0) {
-            await this.stopEntry(candidate);
-          }
-        }
-
-        if (!lease.isStarted) {
-          return;
-        }
-        const helper = this.createHelper(lease.options);
-        entry = {
-          key: targetKey,
-          helper,
-          leases: new Set(),
-          latestFrame: null,
-          idleTimer: null,
-          failed: false,
-          failedStopFailed: false,
-          failedStopError: undefined,
-        };
-        this.entries.set(targetKey, entry);
-        this.wireHelper(entry);
-      }
-
-      this.clearEntryIdleTimer(entry);
-      entry.leases.add(lease);
-      lease.entryKey = targetKey;
-      if (entry.latestFrame) {
-        lease.forward("frame", entry.latestFrame);
-      }
-      if (!entry.helper.isRunning) {
-        try {
-          entry.helper.start();
-        } catch (error) {
-          entry.leases.delete(lease);
-          lease.entryKey = null;
-          this.entries.delete(targetKey);
-          throw error;
-        }
+      const entry = await this.resolveOrCreateEntry(targetKey, lease);
+      if (entry !== null) {
+        this.finalizeAttach(entry, lease, targetKey);
       }
     });
+  }
+
+  /**
+   * Return the live entry for `targetKey`, creating (and wiring) a fresh helper
+   * when none is usable. Returns null when the lease was stopped mid-eviction.
+   */
+  private async resolveOrCreateEntry(
+    targetKey: string,
+    lease: PooledSimulatorCaptureHelperLease
+  ): Promise<HelperEntry | null> {
+    let entry = this.entries.get(targetKey);
+    if (entry?.failedStopFailed) {
+      // A previous helper.stop() threw and left this entry poisoned. The failure
+      // was already surfaced once (to the awaiting invalidate/best-effort
+      // cleanup). Drop the entry now so this attach can build a fresh helper
+      // instead of re-throwing the same error forever — bounded retry, not
+      // permanent poison of the window target.
+      this.clearEntryIdleTimer(entry);
+      this.entries.delete(targetKey);
+      entry = undefined;
+    }
+    if (entry) {
+      return entry;
+    }
+    // A new CGWindowID proves a reboot/window recreation. Evict any idle session
+    // now rather than letting it occupy ScreenCaptureKit resources through its
+    // TTL, but never disrupt a different active simulator stream.
+    for (const candidate of this.entries.values()) {
+      if (candidate.key !== targetKey && candidate.leases.size === 0) {
+        await this.stopEntry(candidate);
+      }
+    }
+    if (!lease.isStarted) {
+      return null;
+    }
+    const created: HelperEntry = {
+      key: targetKey,
+      helper: this.createHelper(lease.options),
+      leases: new Set(),
+      latestFrame: null,
+      encoded: isEncodedTarget(lease.options.target),
+      idleTimer: null,
+      failed: false,
+      failedStopFailed: false,
+      failedStopError: undefined,
+    };
+    this.entries.set(targetKey, created);
+    this.wireHelper(created);
+    return created;
+  }
+
+  /** Register the lease on the entry, start the helper if idle, and warm-start it. */
+  private finalizeAttach(
+    entry: HelperEntry,
+    lease: PooledSimulatorCaptureHelperLease,
+    targetKey: string
+  ): void {
+    this.clearEntryIdleTimer(entry);
+    entry.leases.add(lease);
+    lease.entryKey = targetKey;
+    if (!entry.encoded && entry.latestFrame) {
+      lease.forward("frame", entry.latestFrame);
+    }
+    if (!entry.helper.isRunning) {
+      try {
+        entry.helper.start();
+      } catch (error) {
+        entry.leases.delete(lease);
+        lease.entryKey = null;
+        this.entries.delete(targetKey);
+        throw error;
+      }
+    }
+    if (entry.encoded) {
+      // In-helper encoding collapses the raw path's capture-host / encoder-stream
+      // separation: a late lease attaching to a warm encoded helper would start
+      // mid-GOP on P-frames it cannot decode. Force an IDR so every attach — the
+      // first and every subsequent lease — begins on a self-decodable keyframe
+      // (issue #4789). Safe before the helper's first frame: the encoder honors
+      // the pending force on its first encoded frame.
+      entry.helper.requestKeyFrame();
+    }
+  }
+
+  /**
+   * Relay a lease's keyframe request to its warm helper's STDIN control channel
+   * (issue #4789). Synchronous best-effort: it reads the current entry directly
+   * rather than serializing through the transition chain, because a PLI-driven IDR
+   * must not queue behind a slow helper stop on an unrelated target. Returns false
+   * when the lease is detached or its helper is raw / not running.
+   */
+  requestKeyFrame(lease: PooledSimulatorCaptureHelperLease): boolean {
+    const entryKey = lease.entryKey;
+    if (!entryKey) {
+      return false;
+    }
+    const entry = this.entries.get(entryKey);
+    if (!entry || !entry.leases.has(lease)) {
+      return false;
+    }
+    return entry.helper.requestKeyFrame();
   }
 
   async detach(lease: PooledSimulatorCaptureHelperLease): Promise<void> {
@@ -207,6 +280,8 @@ export class IOSSimulatorCaptureHelperPool {
       entry.latestFrame = frame;
       this.broadcast(entry, "frame", frame);
     });
+    entry.helper.on("encodedVideo", video => this.broadcast(entry, "encodedVideo", video));
+    entry.helper.on("capability", token => this.broadcast(entry, "capability", token));
     entry.helper.on("frameMetrics", metrics => this.broadcast(entry, "frameMetrics", metrics));
     entry.helper.on("captureMetrics", metrics => this.broadcast(entry, "captureMetrics", metrics));
     entry.helper.on("audio", audio => this.broadcast(entry, "audio", audio));
@@ -371,6 +446,10 @@ class PooledSimulatorCaptureHelperLease extends EventEmitter implements IosSimul
     await this.pool.invalidate(this);
   }
 
+  requestKeyFrame(): boolean {
+    return this.started && this.pool.requestKeyFrame(this);
+  }
+
   get isStarted(): boolean {
     return this.started;
   }
@@ -389,12 +468,20 @@ function helperTargetKey(target: CaptureTarget, binaryPath: string): string {
   if (target.kind !== "simulator") {
     throw new Error("Simulator helper pool received a non-simulator target.");
   }
+  // Encoder config (mode + bitrate) is part of the identity: a lease whose encode
+  // settings differ from a warm helper's cannot adopt it (no live reconfiguration
+  // in v1), so a mismatched acquire gets an independent entry (issue #4789).
   return JSON.stringify({
     binaryPath,
     windowID: target.windowID,
     fps: target.fps,
     audio: target.audio === true,
+    encode: target.encode ?? null,
   });
+}
+
+function isEncodedTarget(target: CaptureTarget): boolean {
+  return target.kind === "simulator" && target.encode !== undefined;
 }
 
 function isFatalHelperStderr(line: string): boolean {

--- a/src/features/screen-stream/index.ts
+++ b/src/features/screen-stream/index.ts
@@ -31,6 +31,8 @@ export {
   SIMULATOR_FPS_MAX,
   SIMULATOR_FPS_MIN,
   type CaptureTarget,
+  type EncodeSettings,
+  type EncodeBitratePolicy,
   type HelperSpawner,
   type HelperProcessGroupKiller,
   type IosScreenCaptureHelperOptions,

--- a/src/features/webrtc/IosH264Source.ts
+++ b/src/features/webrtc/IosH264Source.ts
@@ -1,11 +1,17 @@
 import { existsSync } from "node:fs";
 import type { Readable, Writable } from "node:stream";
 import { ActionableError, toActionableError, type BootedDevice } from "../../models";
-import { IOSScreenCaptureHelper } from "../screen-stream/IOSScreenCaptureHelper";
+import {
+  ENCODED_VIDEO_CAPABILITY,
+  IOSScreenCaptureHelper,
+} from "../screen-stream/IOSScreenCaptureHelper";
 import type {
   CaptureTarget,
   DecodedAudio,
+  DecodedEncodedVideo,
   DecodedFrame,
+  EncodeBitratePolicy,
+  EncodeSettings,
   FrameQueueMetrics,
   IosScreenCaptureHelperOptions,
   IosScreenCaptureReadiness,
@@ -13,6 +19,7 @@ import type {
   MalformedFrameError,
   NativeFrameMetrics,
 } from "../screen-stream";
+import { isTruthyEnvValue } from "../../utils/ctrlProxyDownloadControl";
 import { LatestFrameQueue } from "../screen-stream/LatestFrameQueue";
 import {
   iosSimulatorCaptureHelperPool,
@@ -49,6 +56,15 @@ export const IOS_SCREEN_CAPTURE_HELPER_ENV = "AUTOMOBILE_IOS_SCREEN_CAPTURE_HELP
 export const IOS_SCREEN_CAPTURE_HELPER_ENV_ALIAS = "AUTO_MOBILE_IOS_SCREEN_CAPTURE_HELPER";
 export const IOS_WEBRTC_FFMPEG_ENV = "AUTOMOBILE_IOS_WEBRTC_FFMPEG";
 export const IOS_WEBRTC_FFMPEG_ENV_ALIAS = "AUTO_MOBILE_IOS_WEBRTC_FFMPEG";
+/**
+ * Escape hatch (issue #4789): force the legacy raw-BGRA + ffmpeg pipeline even on
+ * a helper that advertises in-helper H.264 encoding. Set to a truthy value
+ * (`1`/`true`) to opt a worker out of the encoded path during the hosted-lane
+ * soak, without a redeploy. Absent/false selects the encoded path when the helper
+ * supports it.
+ */
+export const IOS_WEBRTC_FORCE_RAW_ENV = "AUTOMOBILE_IOS_WEBRTC_FORCE_RAW";
+export const IOS_WEBRTC_FORCE_RAW_ENV_ALIAS = "AUTO_MOBILE_IOS_WEBRTC_FORCE_RAW";
 const DEFAULT_IOS_WEBRTC_FPS = WEBRTC_IOS_SIMULATOR_FPS_DEFAULT;
 /**
  * Deadline for the capture helper's first frame (and, when audio is on, its first
@@ -73,6 +89,20 @@ const IOS_KEYFRAME_INTERVAL_SECONDS = 2;
  * `ANDROID_FORCED_KEYFRAME_MIN_INTERVAL_MS`.
  */
 export const IOS_FORCED_KEYFRAME_MIN_INTERVAL_MS = 3000;
+/**
+ * Minimum spacing between forced IDRs on the *encoded* path (issue #4789).
+ *
+ * Much smaller than {@link IOS_FORCED_KEYFRAME_MIN_INTERVAL_MS} (3000ms) because
+ * a forced IDR no longer costs an encoder restart: on the encoded path
+ * `requestKeyFrame()` writes `{"cmd":"forceKeyFrame"}` on the helper's STDIN, and
+ * the already-running VTCompressionSession forces one IDR on its next frame — no
+ * process spawn, no VideoToolbox re-init, no SPS/PPS re-negotiation stall. The
+ * only cost is a single larger (keyframe) access unit, so the throttle only needs
+ * to keep a pathological per-packet PLI storm from forcing *every* frame to an
+ * IDR. 500ms (≈ at most 2 forced IDRs/sec) bounds that bitrate impact while
+ * staying responsive to a genuine viewer join or a resync-driven recovery.
+ */
+export const IOS_ENCODED_FORCED_KEYFRAME_MIN_INTERVAL_MS = 500;
 /**
  * Grace window granted to an outgoing ffmpeg encoder to honour SIGTERM after a
  * keyframe restart before it is escalated to SIGKILL. A slow or signal-ignoring
@@ -143,7 +173,15 @@ export interface IosFrameCaptureHelper {
   start(): void | Promise<void>;
   stop(): Promise<unknown>;
   invalidate?(): Promise<void>;
+  /**
+   * Ask the in-helper encoder to emit a fresh IDR (encoded path only). Absent on
+   * a raw-BGRA helper — the raw path signals a keyframe by restarting ffmpeg
+   * instead. See issue #4789.
+   */
+  requestKeyFrame?(): boolean;
   on(event: "frame", listener: (frame: DecodedFrame) => void): this;
+  on(event: "encodedVideo", listener: (video: DecodedEncodedVideo) => void): this;
+  on(event: "capability", listener: (token: string) => void): this;
   on(event: "frameMetrics", listener: (metrics: FrameQueueMetrics) => void): this;
   on(event: "captureMetrics", listener: (metrics: NativeFrameMetrics) => void): this;
   on(event: "audio", listener: (audio: DecodedAudio) => void): this;
@@ -240,6 +278,12 @@ export interface IosH264SourceOptions extends H264CaptureSourceOptions {
   runningReconnectMaxAttempts?: number;
   /** Backoff schedule between running-phase reconnect attempts. */
   runningReconnectBackoff?: BackoffInput;
+  /**
+   * Force the raw-BGRA + ffmpeg pipeline even on an encode-capable helper (test
+   * seam for the {@link IOS_WEBRTC_FORCE_RAW_ENV} escape hatch). When omitted the
+   * env var decides; the option wins when provided.
+   */
+  forceRawPipeline?: boolean;
 }
 
 interface SimulatorWindowInfo {
@@ -264,6 +308,14 @@ export interface ScreenCaptureHelperEnsurer {
 
 class NoFirstFrameError extends ActionableError {}
 
+/**
+ * A helper that advertised no encoded-video capability failed to start encoded
+ * capture — i.e. an outdated binary that predates `--encode h264`. Signals
+ * {@link IosH264Source.establishCapture} to fall back to the raw ffmpeg pipeline
+ * (issue #4789).
+ */
+class EncodedUnsupportedError extends ActionableError {}
+
 export class IosH264Source implements H264CaptureSource {
   private readonly helperPath?: string;
   private readonly ffmpegPath: string;
@@ -283,6 +335,23 @@ export class IosH264Source implements H264CaptureSource {
 
   private helper: IosFrameCaptureHelper | null = null;
   private captureKind: CaptureTarget["kind"] | null = null;
+  /**
+   * Output pipeline for the active capture. `"encoded"` consumes in-helper H.264
+   * Annex-B records (no ffmpeg); `"raw"` is the legacy BGRA + ffmpeg path. Decided
+   * per {@link establishCapture} from the handshake and the escape hatch (#4789).
+   */
+  private mode: "raw" | "encoded" = "raw";
+  /** Encoder policy passed DOWN to the helper as flags on the encoded path. */
+  private encodeSettings: EncodeSettings | null = null;
+  /** Set once the helper advertises the encoded-video capability this attempt. */
+  private encodedCapabilityConfirmed = false;
+  /**
+   * True once an encoded attempt fell back to raw for a version-skewed helper, so
+   * a later running-phase reconnect does not re-probe encoding against the same
+   * incapable binary on every blip.
+   */
+  private encodedFellBack = false;
+  private readonly forceRaw: boolean;
   private encoder: IosH264EncoderProcess | null = null;
   private encoderSize: EncoderSize | null = null;
   private encoderBackpressured = false;
@@ -349,6 +418,7 @@ export class IosH264Source implements H264CaptureSource {
       options.simulatorWindowResolver ??
       ((helperPath, device, audioEnabled, signal) =>
         defaultResolveSimulatorWindowId(helperPath, device, this.commandRunner, audioEnabled, signal));
+    this.forceRaw = options.forceRawPipeline ?? readForceRawPipeline(process.env);
   }
 
   /** Resolve running-phase reconnect options against their defaults. */
@@ -382,6 +452,10 @@ export class IosH264Source implements H264CaptureSource {
     this.helperFrameMetrics = null;
     this.nativeFrameMetrics = null;
     this.lastHelperFrame = null;
+    this.mode = "raw";
+    this.encodeSettings = null;
+    this.encodedFellBack = false;
+    this.encodedCapabilityConfirmed = false;
 
     try {
       await this.establishCapture();
@@ -402,13 +476,100 @@ export class IosH264Source implements H264CaptureSource {
    */
   private async establishCapture(): Promise<void> {
     const helperPath = await this.resolveHelperPath();
-    await validateFfmpegAvailability(this.ffmpegClient, this.ffmpegPath, this.options.commandRunner);
     const target = await this.resolveCaptureTarget(helperPath);
     this.captureKind = target.kind;
     if (!this.isActive()) {
       return;
     }
+    if (await this.tryEstablishEncoded(helperPath, target)) {
+      return;
+    }
+    await this.establishRaw(helperPath, target);
+  }
+
+  /**
+   * Attempt the in-helper encoded H.264 path when the target and configuration
+   * allow it (issue #4789). Returns true when encoded capture is up; returns false
+   * — having stopped the incapable helper — when the helper turns out to predate
+   * the encode handshake, so the caller falls back to raw. Any other failure
+   * propagates so a genuine misconfiguration is not masked. No ffmpeg is probed or
+   * spawned on this path.
+   */
+  private async tryEstablishEncoded(helperPath: string, target: CaptureTarget): Promise<boolean> {
+    if (!this.shouldAttemptEncoded(target)) {
+      return false;
+    }
+    this.mode = "encoded";
+    this.encodeSettings = this.resolveEncodeSettings();
+    try {
+      await this.startCaptureWithSimulatorRetry(helperPath, this.encodedTarget(target));
+      return true;
+    } catch (error) {
+      if (!(error instanceof EncodedUnsupportedError)) {
+        throw error;
+      }
+      this.encodedFellBack = true;
+      await this.stopCurrentHelper();
+      logger.warn(
+        `[IosH264Source] helper cannot encode in-process; falling back to the raw ffmpeg pipeline: ${error.message}`
+      );
+      return false;
+    }
+  }
+
+  /**
+   * The legacy raw-BGRA + ffmpeg pipeline, byte-for-byte as before the encoded
+   * cutover. ffmpeg availability is validated here — and ONLY here — so the
+   * encoded path never probes an ffmpeg it will not use (issue #4789).
+   */
+  private async establishRaw(helperPath: string, target: CaptureTarget): Promise<void> {
+    this.mode = "raw";
+    this.encodeSettings = null;
+    await validateFfmpegAvailability(this.ffmpegClient, this.ffmpegPath, this.options.commandRunner);
+    if (!this.isActive()) {
+      return;
+    }
     await this.startCaptureWithSimulatorRetry(helperPath, target);
+  }
+
+  /**
+   * Whether to attempt encoded capture. Encoded is a Simulator-only path in v1
+   * (the helper rejects `--encode` without `--simulator-window`), is disabled by
+   * the {@link IOS_WEBRTC_FORCE_RAW_ENV} escape hatch, is not re-probed after a
+   * skew fallback, and yields to an explicit encoder-size override — the helper's
+   * `--encode` mode self-scales to the Level 4.2 budget and exposes no size flag,
+   * so an explicit size can only be honored by the raw ffmpeg `-vf scale` path.
+   */
+  private shouldAttemptEncoded(target: CaptureTarget): boolean {
+    return (
+      target.kind === "simulator" &&
+      !this.forceRaw &&
+      !this.encodedFellBack &&
+      this.options.size === undefined
+    );
+  }
+
+  /**
+   * Map the bitrate policy onto helper encode flags: an operator override becomes
+   * `--bitrate-bps`, otherwise the Simulator default `--bits-per-pixel` budget is
+   * passed for the helper to apply against the delivered pixels x fps (#4375).
+   */
+  private resolveEncodeSettings(): EncodeSettings {
+    const override =
+      this.options.bitrateBps && this.options.bitrateBps > 0 ? this.options.bitrateBps : undefined;
+    const bitrate: EncodeBitratePolicy =
+      override !== undefined
+        ? { kind: "explicitBps", bps: override }
+        : { kind: "bitsPerPixel", bpp: IOS_WEBRTC_DEFAULT_BITS_PER_PIXEL };
+    return { codec: "h264", bitrate };
+  }
+
+  /** The simulator target annotated with the resolved encode settings. */
+  private encodedTarget(target: CaptureTarget): CaptureTarget {
+    if (target.kind !== "simulator" || this.encodeSettings === null) {
+      return target;
+    }
+    return { ...target, encode: this.encodeSettings };
   }
 
   async stop(): Promise<void> {
@@ -443,6 +604,39 @@ export class IosH264Source implements H264CaptureSource {
    * or after the source has stopped.
    */
   requestKeyFrame(): boolean {
+    return this.mode === "encoded" ? this.requestEncodedKeyFrame() : this.requestRawKeyFrame();
+  }
+
+  /**
+   * Encoded-path keyframe request (issue #4789): write `{"cmd":"forceKeyFrame"}`
+   * on the helper's STDIN control channel so the running VTCompressionSession
+   * forces an IDR on its next frame — no encoder restart. The PLI throttle is kept
+   * in TS for parity with Android's throttle placement, at the much shorter
+   * {@link IOS_ENCODED_FORCED_KEYFRAME_MIN_INTERVAL_MS} the cheap in-helper force
+   * allows. The throttle clock only advances on a successful signal, so a helper
+   * that momentarily has no control channel is retried on the next request.
+   */
+  private requestEncodedKeyFrame(): boolean {
+    if (this.phase !== "running" || !this.helper) {
+      return false;
+    }
+    const now = this.timer.now();
+    if (now - this.lastForcedKeyFrameMs < IOS_ENCODED_FORCED_KEYFRAME_MIN_INTERVAL_MS) {
+      return false;
+    }
+    const sent = this.helper.requestKeyFrame?.() ?? false;
+    if (sent) {
+      this.lastForcedKeyFrameMs = now;
+      logger.debug("[IosH264Source] forced keyframe requested on helper control channel");
+    }
+    return sent;
+  }
+
+  /**
+   * Raw-path keyframe request: ffmpeg cannot be signalled for a mid-stream IDR
+   * over a pipe, so restart the encoder (its first output is SPS/PPS + IDR).
+   */
+  private requestRawKeyFrame(): boolean {
     const oldEncoder = this.encoder;
     const size = this.encoderSize;
     if (
@@ -595,6 +789,11 @@ export class IosH264Source implements H264CaptureSource {
         await this.startCaptureAttempt(helperPath, currentTarget);
         return;
       } catch (error) {
+        // A version-skewed encoded attempt must reach establishCapture with its
+        // type intact so it can fall back to raw — never wrapped or retried here.
+        if (error instanceof EncodedUnsupportedError) {
+          throw error;
+        }
         if (!shouldRetryNoFirstFrame || !(error instanceof NoFirstFrameError)) {
           throw toActionableError(error, "Failed to start iOS screen capture");
         }
@@ -653,11 +852,31 @@ export class IosH264Source implements H264CaptureSource {
     this.lastReadinessPhase = null;
     const helper = this.createCaptureHelper({ binaryPath: helperPath, target });
     this.helper = helper;
+    if (this.mode === "encoded") {
+      await this.startEncodedCaptureAttempt(helper, target);
+      return;
+    }
     this.wireHelperFrames(helper);
     const firstAudio = this.options.audioEnabled ? this.waitForFirstAudio(helper) : null;
     const firstFrame = this.waitForFirstFrame(helper, target);
     await helper.start();
     await Promise.all([firstFrame, firstAudio]);
+  }
+
+  /**
+   * Bring up the encoded path to its first Annex-B record. No ffmpeg encoder is
+   * spawned; the helper's own VTCompressionSession output is forwarded to
+   * `onData`. A helper that fails before the first record without ever advertising
+   * the encode capability surfaces {@link EncodedUnsupportedError} to trigger the
+   * raw fallback (issue #4789).
+   */
+  private async startEncodedCaptureAttempt(helper: IosFrameCaptureHelper, target: CaptureTarget): Promise<void> {
+    this.encodedCapabilityConfirmed = false;
+    this.wireEncodedHelper(helper);
+    const firstAudio = this.options.audioEnabled ? this.waitForFirstAudio(helper) : null;
+    const firstRecord = this.waitForFirstEncodedRecord(helper, target);
+    await helper.start();
+    await Promise.all([firstRecord, firstAudio]);
   }
 
   private waitForFirstFrame(helper: IosFrameCaptureHelper, target: CaptureTarget): Promise<void> {
@@ -768,8 +987,133 @@ export class IosH264Source implements H264CaptureSource {
     });
   }
 
+  /**
+   * Resolve when the encoded helper delivers its first Annex-B record, mirroring
+   * {@link waitForFirstFrame}. On a startup failure the outcome is classified: a
+   * helper that never advertised the encode capability is a version skew
+   * ({@link EncodedUnsupportedError}, → raw fallback); a capable helper that failed
+   * for any other reason surfaces its real error; a timeout is a retryable
+   * {@link NoFirstFrameError}, matching the raw path. Issue #4789.
+   */
+  private waitForFirstEncodedRecord(helper: IosFrameCaptureHelper, target: CaptureTarget): Promise<void> {
+    return new Promise((resolve, reject) => {
+      let settled = false;
+      let firstRecordSeen = false;
+      const finish = (callback: () => void): void => {
+        if (settled) {
+          return;
+        }
+        settled = true;
+        this.timer.clearTimeout(timeout);
+        if (this.cancelFirstFrameWait === cancel) {
+          this.cancelFirstFrameWait = null;
+        }
+        callback();
+      };
+      const cancel = (): void => {
+        finish(resolve);
+      };
+      const rejectStartupFailure = (error: Error): void => {
+        finish(() => reject(this.encodedStartupError(error)));
+      };
+      const timeout = this.timer.setTimeout(() => {
+        finish(() => reject(makeNoFramesError(target, this.lastReadinessPhase)));
+      }, this.firstFrameTimeoutMs);
+      this.cancelFirstFrameWait = cancel;
+
+      helper.on("encodedVideo", () => {
+        if (this.helper !== helper || !this.isActive()) {
+          return;
+        }
+        firstRecordSeen = true;
+        this.phase = "running";
+        finish(resolve);
+      });
+      helper.on("stderr", line => {
+        if (this.helper !== helper || !this.isActive()) {
+          return;
+        }
+        if (isNoFramesPermissionWarning(line)) {
+          finish(() => reject(makeNoFramesError(target, this.lastReadinessPhase)));
+        } else if (isHelperError(line)) {
+          rejectStartupFailure(new Error(`screen-capture-helper reported an error: ${line}`));
+        }
+      });
+      helper.on("error", error => {
+        if (this.helper !== helper || !this.isActive()) {
+          return;
+        }
+        if (firstRecordSeen) {
+          this.failIfCurrentHelper(helper, error);
+          return;
+        }
+        rejectStartupFailure(error);
+      });
+      helper.on("exit", info => {
+        if (this.helper !== helper || !this.isActive()) {
+          return;
+        }
+        const stderr = this.lastHelperStderr === null ? "" : `; last stderr: ${this.lastHelperStderr}`;
+        const error = new Error(`screen-capture-helper exited (code=${info.code}, signal=${info.signal})${stderr}`);
+        if (firstRecordSeen) {
+          this.failIfCurrentHelper(helper, error);
+          return;
+        }
+        rejectStartupFailure(error);
+      });
+    });
+  }
+
+  /**
+   * Classify an encoded-startup failure. A helper that exited/errored WITHOUT ever
+   * advertising the encoded-video capability predates `--encode h264` (an old
+   * binary rejects the flag and exits), so return {@link EncodedUnsupportedError}
+   * to drive the raw fallback. A capable helper's failure is returned as-is.
+   */
+  private encodedStartupError(error: Error): Error {
+    if (this.encodedCapabilityConfirmed) {
+      return error;
+    }
+    return new EncodedUnsupportedError(
+      `The screen-capture-helper did not advertise the '${ENCODED_VIDEO_CAPABILITY}' capability ` +
+      `before failing to start encoded capture (${error.message}).`
+    );
+  }
+
   private wireHelperFrames(helper: IosFrameCaptureHelper): void {
     helper.on("frame", frame => this.handleFrame(frame));
+    helper.on("malformed", error => {
+      logger.warn(`[IosH264Source] malformed frame from helper: ${error.reason}`);
+    });
+    this.wireHelperDiagnostics(helper);
+  }
+
+  /**
+   * Wire the encoded-path helper (issue #4789): Annex-B records go straight to
+   * `onData`, the capability handshake is tracked so a startup failure can be
+   * classified as a version skew, and a decoder resync requests a keyframe —
+   * discarded bytes may have included reference frames, so recovery needs an IDR
+   * (a raw resync only ever costs one frame). Shares the stderr/readiness/metrics
+   * wiring with the raw path.
+   */
+  private wireEncodedHelper(helper: IosFrameCaptureHelper): void {
+    helper.on("encodedVideo", video => this.handleEncodedVideo(video));
+    helper.on("capability", token => {
+      if (token === ENCODED_VIDEO_CAPABILITY) {
+        this.encodedCapabilityConfirmed = true;
+      }
+    });
+    helper.on("malformed", error => {
+      logger.warn(
+        `[IosH264Source] malformed encoded record from helper: ${error.reason}; requesting keyframe to recover`
+      );
+      this.requestKeyFrame();
+    });
+    this.wireHelperDiagnostics(helper);
+  }
+
+  /** stderr/readiness/metrics/audio wiring shared by the raw and encoded paths. */
+  private wireHelperDiagnostics(helper: IosFrameCaptureHelper): void {
     helper.on("frameMetrics", metrics => {
       if (this.helper === helper && this.isActive()) {
         this.helperFrameMetrics = metrics;
@@ -786,9 +1130,6 @@ export class IosH264Source implements H264CaptureSource {
       if (this.isActive() && this.options.audioEnabled) {
         this.options.onAudioData?.(audio.pcm16le);
       }
-    });
-    helper.on("malformed", error => {
-      logger.warn(`[IosH264Source] malformed frame from helper: ${error.reason}`);
     });
     helper.on("stderr", line => {
       if (line.length > 0) {
@@ -839,6 +1180,21 @@ export class IosH264Source implements H264CaptureSource {
     }
 
     this.writeFrameToEncoder(frame);
+  }
+
+  /**
+   * Forward one in-helper-encoded Annex-B access unit downstream (issue #4789).
+   * The helper already produced a self-contained H.264 record (SPS/PPS prepended
+   * on keyframes), so there is no ffmpeg encoder in this path — the record is the
+   * output. The PTS-carrying header is consumed by the wire timing upstream; this
+   * source only relays the elementary-stream bytes, exactly as the ffmpeg path
+   * relays its stdout chunks.
+   */
+  private handleEncodedVideo(video: DecodedEncodedVideo): void {
+    if (!this.isActive()) {
+      return;
+    }
+    this.options.onData(video.payload);
   }
 
   /**
@@ -1444,6 +1800,14 @@ function readEnvWithLegacy(
   legacyName: string
 ): string | undefined {
   return env[primaryName] ?? env[legacyName];
+}
+
+/** True when the force-raw escape hatch is set on either the primary or alias env var. */
+function readForceRawPipeline(env: NodeJS.ProcessEnv): boolean {
+  return (
+    isTruthyEnvValue(env[IOS_WEBRTC_FORCE_RAW_ENV]) ||
+    isTruthyEnvValue(env[IOS_WEBRTC_FORCE_RAW_ENV_ALIAS])
+  );
 }
 
 async function validateFfmpegAvailability(

--- a/test/features/screen-stream/IOSScreenCaptureHelper.test.ts
+++ b/test/features/screen-stream/IOSScreenCaptureHelper.test.ts
@@ -195,6 +195,71 @@ describe("IOSScreenCaptureHelper", () => {
     expect(spawnArgs.args).toEqual(["--simulator-window", "1", "--audio"]);
   });
 
+  test("passes --encode h264 with the bits-per-pixel bitrate flag (#4789)", () => {
+    const { spawnArgs, helper } = withFakeSpawner({
+      kind: "simulator",
+      windowID: 1,
+      encode: { codec: "h264", bitrate: { kind: "bitsPerPixel", bpp: 0.1 } },
+    });
+    helper.start();
+
+    expect(spawnArgs.args).toEqual([
+      "--simulator-window",
+      "1",
+      "--encode",
+      "h264",
+      "--bits-per-pixel",
+      "0.1",
+    ]);
+  });
+
+  test("passes an explicit --bitrate-bps override for encoded capture (#4789)", () => {
+    const { spawnArgs, helper } = withFakeSpawner({
+      kind: "simulator",
+      windowID: 1,
+      encode: { codec: "h264", bitrate: { kind: "explicitBps", bps: 2_500_000 } },
+    });
+    helper.start();
+
+    expect(spawnArgs.args).toEqual([
+      "--simulator-window",
+      "1",
+      "--encode",
+      "h264",
+      "--bitrate-bps",
+      "2500000",
+    ]);
+  });
+
+  test("passes --encode with no bitrate flag under the VideoToolbox default (#4789)", () => {
+    const { spawnArgs, helper } = withFakeSpawner({
+      kind: "simulator",
+      windowID: 1,
+      encode: { codec: "h264", bitrate: { kind: "videoToolboxDefault" } },
+    });
+    helper.start();
+
+    expect(spawnArgs.args).toEqual(["--simulator-window", "1", "--encode", "h264"]);
+  });
+
+  test("requestKeyFrame writes the forceKeyFrame control command to stdin (#4789)", () => {
+    const { fake, helper } = withFakeSpawner({
+      kind: "simulator",
+      windowID: 1,
+      encode: { codec: "h264", bitrate: { kind: "bitsPerPixel", bpp: 0.1 } },
+    });
+    helper.start();
+
+    expect(helper.requestKeyFrame()).toBe(true);
+    expect(fake.getStdinData().toString("utf8")).toBe('{"cmd":"forceKeyFrame"}\n');
+  });
+
+  test("requestKeyFrame is a no-op before the helper has started (#4789)", () => {
+    const { helper } = withFakeSpawner({ kind: "simulator", windowID: 1 });
+
+    expect(helper.requestKeyFrame()).toBe(false);
+  });
+
   test("emits multiplexed PCM16LE audio without treating it as a malformed frame", async () => {
     const { fake, helper } = withFakeSpawner({ kind: "simulator", windowID: 1, audio: true });
     const audio: Buffer[] = [];

--- a/test/features/screen-stream/IOSSimulatorCaptureHelperPool.test.ts
+++ b/test/features/screen-stream/IOSSimulatorCaptureHelperPool.test.ts
@@ -14,6 +14,7 @@ import {
 class FakeSimulatorHelper extends EventEmitter {
   starts = 0;
   stops = 0;
+  keyFrameRequests = 0;
   isRunning = false;
   stopError: Error | null = null;
 
@@ -31,6 +32,11 @@ class FakeSimulatorHelper extends EventEmitter {
     return null;
   }
 
+  requestKeyFrame(): boolean {
+    this.keyFrameRequests++;
+    return true;
+  }
+
   override on<E extends keyof IosScreenCaptureHelperEvents>(
     event: E,
     listener: IosScreenCaptureHelperEvents[E]
@@ -43,6 +49,18 @@ function simulatorOptions(windowID = 42): IosScreenCaptureHelperOptions {
   return {
     binaryPath: "/fake/screen-capture-helper",
     target: { kind: "simulator", windowID, fps: 15 },
+  };
+}
+
+function encodedOptions(windowID = 42): IosScreenCaptureHelperOptions {
+  return {
+    binaryPath: "/fake/screen-capture-helper",
+    target: {
+      kind: "simulator",
+      windowID,
+      fps: 15,
+      encode: { codec: "h264", bitrate: { kind: "bitsPerPixel", bpp: 0.1 } },
+    },
   };
 }
 
@@ -344,5 +362,84 @@ describe("IOSSimulatorCaptureHelperPool", () => {
     await second.start();
     await pool.shutdown();
     expect(helpers[1].stops).toBe(1);
+  });
+
+  test("forces an IDR on every encoded lease attach and never replays a raw frame", async () => {
+    const helpers: FakeSimulatorHelper[] = [];
+    const pool = new IOSSimulatorCaptureHelperPool({
+      createHelper: () => {
+        const helper = new FakeSimulatorHelper();
+        helpers.push(helper);
+        return helper;
+      },
+    });
+
+    const first = pool.acquire(encodedOptions());
+    await first.start();
+    // The first attach forces an IDR so a fresh stream starts on a keyframe.
+    expect(helpers[0].keyFrameRequests).toBe(1);
+
+    // A late lease adopting the warm encoded helper must also force an IDR — it
+    // would otherwise begin mid-GOP on undecodable P-frames. The raw warm-start
+    // frame replay is disabled on the encoded path.
+    const replayed: number[] = [];
+    const second = pool.acquire(encodedOptions());
+    second.on("frame", frame => replayed.push(frame.header.width));
+    helpers[0].emit("encodedVideo", { keyframe: false, presentationTimestampMs: 1, payload: Buffer.from([0, 0, 0, 1, 0x41]) });
+    await second.start();
+
+    expect(helpers).toHaveLength(1);
+    expect(helpers[0].keyFrameRequests).toBe(2);
+    expect(replayed).toEqual([]);
+  });
+
+  test("forwards encoded records and the capability handshake to every lease", async () => {
+    const helpers: FakeSimulatorHelper[] = [];
+    const pool = new IOSSimulatorCaptureHelperPool({
+      createHelper: () => {
+        const helper = new FakeSimulatorHelper();
+        helpers.push(helper);
+        return helper;
+      },
+    });
+    const lease = pool.acquire(encodedOptions());
+    const records: boolean[] = [];
+    const capabilities: string[] = [];
+    lease.on("encodedVideo", video => records.push(video.keyframe));
+    lease.on("capability", token => capabilities.push(token));
+    await lease.start();
+
+    helpers[0].emit("capability", "encoded-video-h264");
+    helpers[0].emit("encodedVideo", { keyframe: true, presentationTimestampMs: 1, payload: Buffer.from([0x65]) });
+
+    expect(capabilities).toEqual(["encoded-video-h264"]);
+    expect(records).toEqual([true]);
+    await pool.shutdown();
+  });
+
+  test("gives a mismatched encoder config an independent helper entry", async () => {
+    const helpers: FakeSimulatorHelper[] = [];
+    const pool = new IOSSimulatorCaptureHelperPool({
+      createHelper: () => {
+        const helper = new FakeSimulatorHelper();
+        helpers.push(helper);
+        return helper;
+      },
+    });
+
+    // Raw and encoded leases on the same window get separate entries: encoder
+    // config is part of the pool key, and there is no live reconfiguration.
+    const raw = pool.acquire(simulatorOptions());
+    await raw.start();
+    const encoded = pool.acquire(encodedOptions());
+    await encoded.start();
+
+    expect(helpers).toHaveLength(2);
+    expect(helpers[0].starts).toBe(1);
+    expect(helpers[1].starts).toBe(1);
+    // The raw entry never had an IDR forced; only the encoded one did.
+    expect(helpers[0].keyFrameRequests).toBe(0);
+    expect(helpers[1].keyFrameRequests).toBe(1);
+    await pool.shutdown();
   });
 });

--- a/test/features/webrtc/IosH264Source.test.ts
+++ b/test/features/webrtc/IosH264Source.test.ts
@@ -10,8 +10,10 @@ import {
   IOS_SCREEN_CAPTURE_HELPER_ENV_ALIAS,
   IOS_WEBRTC_FFMPEG_ENV,
   IOS_WEBRTC_FFMPEG_ENV_ALIAS,
+  IOS_WEBRTC_FORCE_RAW_ENV,
   IOS_WEBRTC_DEFAULT_BITS_PER_PIXEL,
   IOS_FORCED_KEYFRAME_MIN_INTERVAL_MS,
+  IOS_ENCODED_FORCED_KEYFRAME_MIN_INTERVAL_MS,
   IOS_ENCODER_RESTART_GRACE_MS,
   IOS_SIMULATOR_TARGET_RESOLUTION_TIMEOUT_MS,
   IosH264Source,
@@ -26,7 +28,8 @@ import {
 } from "../../../src/features/webrtc/h264Level";
 import { IOSSimulatorCaptureHelperPool } from "../../../src/features/screen-stream/IOSSimulatorCaptureHelperPool";
 import { WEBRTC_IOS_SIMULATOR_FPS_DEFAULT } from "../../../src/features/webrtc/webrtcStreamingConfig";
-import type { CaptureTarget, DecodedFrame } from "../../../src/features/screen-stream";
+import { ENCODED_VIDEO_CAPABILITY } from "../../../src/features/screen-stream";
+import type { CaptureTarget, DecodedEncodedVideo, DecodedFrame } from "../../../src/features/screen-stream";
 
 const IOS_DEVICE: BootedDevice = {
   deviceId: "00008140-001A2B3C0AE2401E",
@@ -48,6 +51,8 @@ class FakeFrameCaptureHelper extends EventEmitter implements IosFrameCaptureHelp
   stopped = false;
   isRunning = false;
   stopError: Error | null = null;
+  keyFrameRequests = 0;
+  keyFrameRequestResult = true;
 
   start(): void {
     this.started = true;
@@ -63,8 +68,29 @@ class FakeFrameCaptureHelper extends EventEmitter implements IosFrameCaptureHelp
     return null;
   }
 
+  requestKeyFrame(): boolean {
+    this.keyFrameRequests++;
+    return this.keyFrameRequestResult;
+  }
+
   emitFrame(frame: DecodedFrame): void {
     this.emit("frame", frame);
+  }
+
+  emitEncodedVideo(video: DecodedEncodedVideo): void {
+    this.emit("encodedVideo", video);
+  }
+
+  emitCapability(token: string): void {
+    this.emit("capability", token);
+  }
+
+  emitMalformed(reason: string): void {
+    this.emit("malformed", { reason, header: { width: 0, height: 0, bytesPerRow: 0, timestampMs: 0 } });
+  }
+
+  emitExit(code: number | null, signal: NodeJS.Signals | null = null): void {
+    this.emit("exit", { code, signal });
   }
 
   emitStderr(line: string): void {
@@ -74,6 +100,14 @@ class FakeFrameCaptureHelper extends EventEmitter implements IosFrameCaptureHelp
   emitReadiness(phase: string, atMs = 0, detail?: string): void {
     this.emit("readiness", { phase, atMs, detail });
   }
+}
+
+function encodedRecord(
+  payload: number[],
+  keyframe = true,
+  presentationTimestampMs = 1
+): DecodedEncodedVideo {
+  return { keyframe, presentationTimestampMs, payload: Buffer.from(payload) };
 }
 
 class DelayedStopFrameCaptureHelper extends FakeFrameCaptureHelper {
@@ -180,6 +214,10 @@ function createHarness(
     },
     simulatorWindowResolver: async () => 42,
     commandRunner: successfulCommandRunner,
+    // These shared harnesses exercise the raw-BGRA + ffmpeg pipeline. A simulator
+    // target now defaults to the encoded path, so force raw to keep them pinned to
+    // the fallback pipeline they assert; encoded tests override this to false.
+    forceRawPipeline: true,
     ...overrides,
   });
 
@@ -202,6 +240,7 @@ function createHarnessWithOverrides(options: Partial<ConstructorParameters<typeo
     },
     simulatorWindowResolver: async () => 42,
     commandRunner: successfulCommandRunner,
+    forceRawPipeline: true,
     ...options,
   });
   return { source, helper, encoderSpawns };
@@ -235,6 +274,7 @@ function createRestartHarness(
     },
     simulatorWindowResolver: async () => 42,
     commandRunner: successfulCommandRunner,
+    forceRawPipeline: true,
     ...overrides,
   });
   return { source, helper, encoders, encoderSpawns, chunks, errors };
@@ -271,6 +311,7 @@ function createReconnectHarness(
     },
     simulatorWindowResolver: async () => 42,
     commandRunner: successfulCommandRunner,
+    forceRawPipeline: true,
     ...overrides,
   });
   return { source, helpers, encoders, encoderSpawns, chunks, errors };
@@ -296,6 +337,7 @@ function createResolverHarness(
       return helper;
     },
     spawner: () => encoder as unknown as ChildProcessWithoutNullStreams,
+    forceRawPipeline: true,
     commandRunner: async (command, args) => {
       if (command === FAKE_HELPER_PATH && args.includes("--list-simulators")) {
         return {
@@ -444,6 +486,7 @@ describe("IosH264Source", () => {
       helperPathExists: fakeHelperPathExists,
       onData: () => {},
       simulatorHelperPool: pool,
+      forceRawPipeline: true,
       spawner: () => encoder as unknown as ChildProcessWithoutNullStreams,
       simulatorWindowResolver: async () => 42,
       commandRunner: successfulCommandRunner,
@@ -478,6 +521,7 @@ describe("IosH264Source", () => {
       onData: () => {},
       firstFrameTimeoutMs: 1,
       simulatorHelperPool: pool,
+      forceRawPipeline: true,
       spawner: () => new FakeChildProcess() as unknown as ChildProcessWithoutNullStreams,
       simulatorWindowResolver: async () => 42,
       commandRunner: successfulCommandRunner,
@@ -523,6 +567,7 @@ describe("IosH264Source", () => {
       onData: () => {},
       firstFrameTimeoutMs: 1,
       simulatorHelperPool: pool,
+      forceRawPipeline: true,
       spawner: () => new FakeChildProcess() as unknown as ChildProcessWithoutNullStreams,
       simulatorWindowResolver: async () => resolvedWindowIds[resolveCalls++] ?? 99,
       commandRunner: successfulCommandRunner,
@@ -574,6 +619,7 @@ describe("IosH264Source", () => {
       onData: () => {},
       firstFrameTimeoutMs: 1,
       simulatorHelperPool: pool,
+      forceRawPipeline: true,
       spawner: () => new FakeChildProcess() as unknown as ChildProcessWithoutNullStreams,
       simulatorWindowResolver: async () => {
         resolveCalls++;
@@ -622,6 +668,7 @@ describe("IosH264Source", () => {
       helperPathExists: fakeHelperPathExists,
       onData: () => {},
       simulatorHelperPool: pool,
+      forceRawPipeline: true,
       spawner: () => new FakeChildProcess() as unknown as ChildProcessWithoutNullStreams,
       simulatorWindowResolver: async () => 42,
       commandRunner: successfulCommandRunner,
@@ -665,6 +712,7 @@ describe("IosH264Source", () => {
       helperPathExists: fakeHelperPathExists,
       onData: () => {},
       simulatorHelperPool: pool,
+      forceRawPipeline: true,
       spawner: () => new FakeChildProcess() as unknown as ChildProcessWithoutNullStreams,
       simulatorWindowResolver: async () => 42,
       commandRunner: successfulCommandRunner,
@@ -712,6 +760,7 @@ describe("IosH264Source", () => {
       onData: () => {},
       firstFrameTimeoutMs: 1,
       simulatorHelperPool: pool,
+      forceRawPipeline: true,
       spawner: () => new FakeChildProcess() as unknown as ChildProcessWithoutNullStreams,
       simulatorWindowResolver: async () => 42,
       commandRunner: successfulCommandRunner,
@@ -762,6 +811,7 @@ describe("IosH264Source", () => {
       onData: () => {},
       firstFrameTimeoutMs: 1,
       simulatorHelperPool: pool,
+      forceRawPipeline: true,
       spawner: () => new FakeChildProcess() as unknown as ChildProcessWithoutNullStreams,
       simulatorWindowResolver: async () => 42,
       commandRunner: successfulCommandRunner,
@@ -796,6 +846,7 @@ describe("IosH264Source", () => {
       onData: () => {},
       firstFrameTimeoutMs: 1,
       simulatorHelperPool: pool,
+      forceRawPipeline: true,
       spawner: () => new FakeChildProcess() as unknown as ChildProcessWithoutNullStreams,
       simulatorWindowResolver: async () => 42,
       commandRunner: successfulCommandRunner,
@@ -829,6 +880,7 @@ describe("IosH264Source", () => {
       helperPathExists: fakeHelperPathExists,
       onData: () => {},
       simulatorHelperPool: pool,
+      forceRawPipeline: true,
       spawner: () => new FakeChildProcess() as unknown as ChildProcessWithoutNullStreams,
       simulatorWindowResolver: async () => 42,
       commandRunner: successfulCommandRunner,
@@ -1038,6 +1090,7 @@ describe("IosH264Source", () => {
       helperPathExists: fakeHelperPathExists,
       fps: 15,
       onData: () => {},
+      forceRawPipeline: true,
       createHelper: options => {
         helperTargets.push(options.target);
         return helper;
@@ -2091,6 +2144,205 @@ describe("IosH264Source", () => {
         delete process.env[IOS_WEBRTC_FFMPEG_ENV_ALIAS];
       } else {
         process.env[IOS_WEBRTC_FFMPEG_ENV_ALIAS] = originalLegacy;
+      }
+    }
+  });
+});
+
+// Encoded in-helper H.264 path (issue #4789): the helper advertises the encode
+// capability and emits Annex-B records, so the source becomes a record reader with
+// no ffmpeg subprocess.
+function createEncodedHarness(
+  overrides: Partial<ConstructorParameters<typeof IosH264Source>[0]> = {}
+) {
+  const helpers: FakeFrameCaptureHelper[] = [];
+  const helperTargets: CaptureTarget[] = [];
+  const encoderSpawns: Array<{ command: string; args: string[] }> = [];
+  const commandRunnerCalls: string[][] = [];
+  const chunks: Buffer[] = [];
+  const errors: Error[] = [];
+  const source = new IosH264Source({
+    device: IOS_SIMULATOR,
+    helperPath: FAKE_HELPER_PATH,
+    helperPathExists: fakeHelperPathExists,
+    onData: chunk => chunks.push(chunk),
+    onError: error => errors.push(error),
+    forceRawPipeline: false,
+    createHelper: options => {
+      helperTargets.push(options.target);
+      const helper = new FakeFrameCaptureHelper();
+      helpers.push(helper);
+      return helper;
+    },
+    spawner: (command, args) => {
+      encoderSpawns.push({ command, args });
+      return new FakeChildProcess() as unknown as ChildProcessWithoutNullStreams;
+    },
+    simulatorWindowResolver: async () => 42,
+    commandRunner: async (command, args) => {
+      commandRunnerCalls.push(args);
+      return successfulCommandRunner(command, args);
+    },
+    ...overrides,
+  });
+  return { source, helpers, helperTargets, encoderSpawns, commandRunnerCalls, chunks, errors };
+}
+
+// The helper is built lazily inside `start()`, so drive startup through the
+// harness `helpers` array and act on helpers[0] once it has been created.
+async function startEncoded(
+  source: IosH264Source,
+  helpers: FakeFrameCaptureHelper[],
+  firstRecord: DecodedEncodedVideo = encodedRecord([0, 0, 0, 1, 0x65, 0x88])
+): Promise<void> {
+  const started = source.start();
+  await flush();
+  helpers[0].emitCapability(ENCODED_VIDEO_CAPABILITY);
+  helpers[0].emitEncodedVideo(firstRecord);
+  await started;
+}
+
+function probedEncoders(calls: string[][]): boolean {
+  return calls.some(args => args.includes("-encoders"));
+}
+
+describe("IosH264Source encoded path (#4789)", () => {
+  test("reads encoded records and forwards Annex-B without an ffmpeg subprocess", async () => {
+    const { source, helpers, encoderSpawns, commandRunnerCalls, chunks } = createEncodedHarness();
+
+    await startEncoded(source, helpers);
+    helpers[0].emitEncodedVideo(encodedRecord([0, 0, 0, 1, 0x41, 0x9a], false, 2));
+
+    expect(encoderSpawns).toHaveLength(0);
+    expect(probedEncoders(commandRunnerCalls)).toBe(false);
+    expect(chunks.map(chunk => [...chunk])).toEqual([
+      [0, 0, 0, 1, 0x65, 0x88],
+      [0, 0, 0, 1, 0x41, 0x9a],
+    ]);
+  });
+
+  test("spawns the helper with the bits-per-pixel default encode settings", async () => {
+    const { source, helpers, helperTargets } = createEncodedHarness();
+
+    await startEncoded(source, helpers);
+
+    expect(helperTargets).toEqual([
+      {
+        kind: "simulator",
+        windowID: 42,
+        fps: WEBRTC_IOS_SIMULATOR_FPS_DEFAULT,
+        encode: {
+          codec: "h264",
+          bitrate: { kind: "bitsPerPixel", bpp: IOS_WEBRTC_DEFAULT_BITS_PER_PIXEL },
+        },
+      },
+    ]);
+  });
+
+  test("passes an operator bitrate override down as explicit encode bps", async () => {
+    const { source, helpers, helperTargets } = createEncodedHarness({ bitrateBps: 1_234_000 });
+
+    await startEncoded(source, helpers);
+
+    const target = helperTargets[0];
+    expect(target.kind === "simulator" ? target.encode : undefined).toEqual({
+      codec: "h264",
+      bitrate: { kind: "explicitBps", bps: 1_234_000 },
+    });
+  });
+
+  test("requestKeyFrame sends the forceKeyFrame control command, throttled by the shorter interval", async () => {
+    const timer = new FakeTimer();
+    const { source, helpers } = createEncodedHarness({ timer });
+
+    await startEncoded(source, helpers);
+
+    expect(source.requestKeyFrame()).toBe(true);
+    expect(helpers[0].keyFrameRequests).toBe(1);
+    // A burst is collapsed inside the throttle window.
+    expect(source.requestKeyFrame()).toBe(false);
+    expect(helpers[0].keyFrameRequests).toBe(1);
+
+    timer.advanceTime(IOS_ENCODED_FORCED_KEYFRAME_MIN_INTERVAL_MS);
+    expect(source.requestKeyFrame()).toBe(true);
+    expect(helpers[0].keyFrameRequests).toBe(2);
+
+    await source.stop();
+  });
+
+  test("requests a keyframe after a decoder resync so recovery starts on an IDR", async () => {
+    const { source, helpers } = createEncodedHarness();
+
+    await startEncoded(source, helpers);
+    helpers[0].emitMalformed("header_checksum_mismatch");
+
+    expect(helpers[0].keyFrameRequests).toBe(1);
+
+    await source.stop();
+  });
+
+  test("falls back to the raw ffmpeg pipeline when the helper predates the encode handshake", async () => {
+    const { source, helpers, helperTargets, encoderSpawns, commandRunnerCalls } =
+      createEncodedHarness();
+
+    const started = source.start();
+    await flush();
+    // An outdated helper advertises no capability and rejects --encode, exiting.
+    helpers[0].emitStderr("error: unknown argument --encode");
+    await flush();
+
+    // The fallback builds a fresh raw helper; a raw frame completes raw startup.
+    expect(helpers).toHaveLength(2);
+    helpers[1].emitFrame(frame(4, 4, 0x11));
+    await started;
+
+    expect(helperTargets[0].kind === "simulator" ? helperTargets[0].encode : undefined).toBeDefined();
+    expect(helperTargets[1].kind === "simulator" ? helperTargets[1].encode : undefined).toBeUndefined();
+    // ffmpeg is spawned and probed only on the raw fallback.
+    expect(encoderSpawns).toHaveLength(1);
+    expect(probedEncoders(commandRunnerCalls)).toBe(true);
+
+    await source.stop();
+  });
+
+  test("uses the raw pipeline directly under the force-raw escape hatch, never attempting encode", async () => {
+    const { source, helpers, helperTargets, encoderSpawns, commandRunnerCalls } =
+      createEncodedHarness({ forceRawPipeline: true });
+
+    const started = source.start();
+    await flush();
+    helpers[0].emitFrame(frame(4, 4, 0x11));
+    await started;
+
+    // Exactly one helper, built directly for the raw path with no encode settings.
+    expect(helpers).toHaveLength(1);
+    expect(helperTargets[0].kind === "simulator" ? helperTargets[0].encode : undefined).toBeUndefined();
+    expect(encoderSpawns).toHaveLength(1);
+    expect(probedEncoders(commandRunnerCalls)).toBe(true);
+
+    await source.stop();
+  });
+
+  test("honors the AUTOMOBILE_IOS_WEBRTC_FORCE_RAW escape-hatch env var", async () => {
+    const original = process.env[IOS_WEBRTC_FORCE_RAW_ENV];
+    process.env[IOS_WEBRTC_FORCE_RAW_ENV] = "1";
+    try {
+      const { source, helpers, helperTargets, encoderSpawns } = createEncodedHarness({
+        forceRawPipeline: undefined,
+      });
+      const started = source.start();
+      await flush();
+      helpers[0].emitFrame(frame(4, 4, 0x11));
+      await started;
+
+      expect(helperTargets[0].kind === "simulator" ? helperTargets[0].encode : undefined).toBeUndefined();
+      expect(encoderSpawns).toHaveLength(1);
+      await source.stop();
+    } finally {
+      if (original === undefined) {
+        delete process.env[IOS_WEBRTC_FORCE_RAW_ENV];
+      } else {
+        process.env[IOS_WEBRTC_FORCE_RAW_ENV] = original;
       }
     }
   });


### PR DESCRIPTION
## Summary

Consumes the in-helper encoded H.264 output added by [#4787](https://github.com/kaeawc/auto-mobile/issues/4787) (the encoded-record wire vocabulary + `capture-capability: encoded-video-h264` handshake) and [#4788](https://github.com/kaeawc/auto-mobile/issues/4788) (the Swift helper's `--encode h264` mode + `{"cmd":"forceKeyFrame"}` stdin channel). When a capable helper is present, `IosH264Source` spawns it with `--encode h264`, reads Annex-B encoded-video records, and forwards them straight to `onData` — **no ffmpeg subprocess on that path**. The raw-BGRA + ffmpeg pipeline stays in the tree, byte-for-byte, as the fallback for old helpers and behind an escape-hatch env var.

Closes [#4789](https://github.com/kaeawc/auto-mobile/issues/4789).

## How encoded-vs-raw is gated

The Swift helper emits its capability handshake on stderr **unconditionally at startup, before argument parsing**, so the encoded decision is made optimistically with a runtime fallback:

- For a **Simulator** target (encoded is Simulator-only in v1 — the helper rejects `--encode` without `--simulator-window`), the source attempts encoded: it spawns `--encode h264` and waits for the first Annex-B record.
- If the helper delivers records → encoded path (ffmpeg is neither probed nor spawned).
- If the helper **exits/errors during encoded startup without ever advertising the `encoded-video-h264` capability**, it is an outdated binary that rejected `--encode`. That surfaces a typed `EncodedUnsupportedError`, the source stops the incapable helper and **falls back to the raw ffmpeg pipeline** (which is where ffmpeg availability is validated). A capable helper that fails for any *other* reason surfaces its real error.
- A skew fallback is remembered so a later running-phase reconnect does not re-probe the same incapable binary on every blip.

This makes the change land dark-ish: an old helper takes the raw path today, and the encoded path activates automatically once a capable helper (the re-cut release, or a local `swift build`) is present — no code change or release-version bump here.

## Escape-hatch env var

`AUTOMOBILE_IOS_WEBRTC_FORCE_RAW` (alias `AUTO_MOBILE_IOS_WEBRTC_FORCE_RAW`) — set truthy (`1`/`true`) to force the raw pipeline even on an encode-capable helper, for hosted-lane soak triage without a redeploy. A `forceRawPipeline` option provides the same override as a test seam. An explicit encoder-size override (`AUTOMOBILE_WEBRTC_MAX_SIZE`) also routes to raw, since the helper's `--encode` mode self-scales to the Level 4.2 budget and exposes no size flag.

## forceKeyFrame + resync wiring, and the new throttle

- `requestKeyFrame()` dispatches on mode. On the encoded path it writes `{"cmd":"forceKeyFrame"}` on the helper's stdin control channel — the running VTCompressionSession forces one IDR on its next frame, with **no encoder restart**. The raw path keeps its encoder-restart behavior unchanged.
- After a `FrameDecoder` resync (`malformed` event) on the encoded path, the source requests a keyframe: discarded bytes may have included reference frames, so recovery needs an IDR (a raw resync only ever costs one frame).
- **New throttle:** `IOS_ENCODED_FORCED_KEYFRAME_MIN_INTERVAL_MS = 500` (vs. the raw path's `IOS_FORCED_KEYFRAME_MIN_INTERVAL_MS = 3000`). Justification: a forced IDR no longer costs an encoder restart / VideoToolbox re-init / SPS-PPS re-negotiation stall — only one larger keyframe access unit — so the throttle only needs to keep a pathological per-packet PLI storm from forcing *every* frame to an IDR. 500ms (≈ at most 2 forced IDRs/sec) bounds that bitrate impact while staying responsive to a genuine viewer join or a resync recovery. The throttle is kept (not removed), matching Android's throttle placement.

## Bitrate policy as helper flags

The bitrate *policy* is passed down as `--encode` flags instead of an ffmpeg `-b:v`: an operator override becomes `--bitrate-bps`, otherwise the Simulator default `--bits-per-pixel 0.1` budget is passed for the helper to apply against the delivered pixels × fps. The helper does the pre-encode pixel arithmetic (`H264EncodeMath`) it alone knows.

## Pool semantics (`IOSSimulatorCaptureHelperPool`)

On the **encoded path only** (raw-lease behavior is identical):

- **IDR on every lease attach** — a late lease adopting a warm encoded helper would otherwise start mid-GOP on undecodable P-frames, so each attach forces a fresh IDR.
- **Encoder config is part of the pool key** — a mismatched acquire (different bitrate/mode) gets an independent helper entry; no live reconfiguration in v1.
- **Warm-start cache dropped for encoded leases** (decision: drop, not last-IDR cache). Justification: the raw path replays one cached BGRA frame to prime a new lease; a single cached H.264 access unit is a P-frame the new lease cannot decode, and a cached IDR could be stale/wrong-config — forcing a fresh IDR on attach gives a guaranteed-decodable start with one keyframe cost, which is simpler and strictly correct.
- `encodedVideo` + `capability` events are forwarded through the lease; a new `requestKeyFrame()` relays to the helper's control channel.

## What is unit-tested vs device-lane-only

Unit-tested (fakes only — no real helper/ffmpeg spawned):
- Encoded path reads records and forwards Annex-B with **no ffmpeg subprocess and no ffmpeg probe**; bits-per-pixel default and explicit-bps override passed as encode settings.
- `requestKeyFrame()` sends the forceKeyFrame command, throttled by the new interval; resync triggers a keyframe request.
- Old-helper skew → raw fallback (ffmpeg spawned + probed); escape-hatch env/option → raw directly, never attempting encode.
- Helper: `--encode`/`--bitrate-bps`/`--bits-per-pixel` arg building; `requestKeyFrame()` writes the stdin control line; no-op before start.
- Pool: IDR forced on every encoded attach and no raw-frame replay; encoded records + capability forwarded; mismatched config gets an independent entry.

**Device-lane / hosted-lane only (NOT measured here):** first-frame timing (the [#4345](https://github.com/kaeawc/auto-mobile/issues/4345) p95 ~15s baseline) and end-to-end device parity. I did not measure these; `IOS_FIRST_FRAME_TIMEOUT_MS` is unchanged.

## Guarantees

- Raw-BGRA + ffmpeg pipeline is **unchanged and not deleted** (deletion is [#4791](https://github.com/kaeawc/auto-mobile/issues/4791)). Existing raw tests pin it by forcing raw.
- `IOS_FIRST_FRAME_TIMEOUT_MS` not tightened.
- No change to the checksum-pinned helper asset or release version — the re-cut is a separate release step.

## Validation

- `bun test test/features/webrtc/ test/features/screen-stream/` → 520 pass, 0 fail
- `bun run typecheck` → no new type errors (196 baseline)
- `bunx eslint` on all changed files → clean; `bun run lint` gate → pass (no new suppressions; two complexity findings I introduced were resolved by extracting helpers, not baselined)
