### PR TITLE
feat(ios): in-helper H.264 encode for the physical-device capture path

### DIFF
--- a/ios/screen-capture/Sources/ScreenCaptureCore/CommandLineOptions.swift
+++ b/ios/screen-capture/Sources/ScreenCaptureCore/CommandLineOptions.swift
@@ -25,7 +25,9 @@ public struct CommandLineOptions: Equatable {
 
     public enum Mode: Equatable {
         case listDevices
-        case capture(deviceID: String?)
+        /// Physical USB-connected iOS device capture (AVFoundation). `encode` is
+        /// absent on the raw-BGRA path and present under `--encode h264` (#4790).
+        case capture(deviceID: String?, encode: EncodeSettings?)
         case listSimulators
         case captureSimulator(windowID: UInt32, fps: Int, audio: Bool, encode: EncodeSettings?)
         case help
@@ -160,10 +162,12 @@ public struct CommandLineOptions: Equatable {
         if (bitrateBps != nil || bitsPerPixel != nil) && !encodeRequested {
             throw ParseError.conflictingFlags("--bitrate-bps/--bits-per-pixel require --encode h264")
         }
-        // v1 scope: in-helper encoding is wired for the Simulator (ScreenCaptureKit)
-        // path only; the device path keeps VideoToolbox out of the helper.
-        if encodeRequested && simulatorWindowID == nil {
-            throw ParseError.conflictingFlags("--encode requires --simulator-window")
+        // In-helper encoding is wired for both the Simulator (ScreenCaptureKit) and
+        // the physical-device (AVFoundation) capture paths (issues #4788 / #4790).
+        // It is only meaningful for a capture mode, so reject it on the discovery
+        // (`--list-*`) modes.
+        if encodeRequested && (listDevices || listSimulators) {
+            throw ParseError.conflictingFlags("--encode requires a capture mode, not --list-devices/--list-simulators")
         }
 
         var encodeSettings: EncodeSettings?
@@ -195,7 +199,7 @@ public struct CommandLineOptions: Equatable {
                 )
             )
         }
-        return CommandLineOptions(mode: .capture(deviceID: deviceID))
+        return CommandLineOptions(mode: .capture(deviceID: deviceID, encode: encodeSettings))
     }
 
     public static let helpText = """
@@ -219,15 +223,19 @@ public struct CommandLineOptions: Equatable {
                                 values waste CPU for typical MCP workloads.
         --audio                 Capture Simulator window audio as 8 kHz mono PCM16LE.
 
-    ENCODE OPTIONS (in-helper H.264, requires --simulator-window):
+    ENCODE OPTIONS (in-helper H.264; works with --simulator-window or a device):
         --encode h264           Encode H.264 (Baseline 4.2) in-process instead of
                                 streaming raw BGRA. Captures 420v (NV12) and emits
                                 Annex-B encoded-video records. Default: raw BGRA.
         --bitrate-bps <n>       Operator override for the average bitrate (bps).
+                                Honored for both the Simulator and device paths.
         --bits-per-pixel <x>    Compute the bitrate from the delivered pixel
                                 dimensions x fps x <x> (Simulator default 0.1).
-                                Mutually exclusive with --bitrate-bps; omit both
-                                to let VideoToolbox choose (physical-device path).
+                                Simulator-only: on a physical device this budget is
+                                skipped and VideoToolbox picks its own default,
+                                because the 0.1 figure was measured from Simulator
+                                screen content. Mutually exclusive with
+                                --bitrate-bps; omit both to let VideoToolbox choose.
 
         -h, --help              Show this help.
 

--- a/ios/screen-capture/Sources/ScreenCaptureCore/H264EncodeMath.swift
+++ b/ios/screen-capture/Sources/ScreenCaptureCore/H264EncodeMath.swift
@@ -101,6 +101,56 @@ public enum H264EncodeMath {
         return max(1, Int(rounded))
     }
 
+    // MARK: - Source-aware bitrate resolution (issue #4790)
+
+    /// Which capture source drives the encode. The only behavior this forks is the
+    /// bits-per-pixel budget: the `defaultBitsPerPixel` (0.1) figure was measured
+    /// entirely from Simulator screen content (issue #4349) and does not describe a
+    /// physical device, so a device NEVER applies it (issue #4375).
+    public enum CaptureSource: Equatable {
+        case simulator
+        case device
+    }
+
+    /// Resolve the `AverageBitRate` (bps) VideoToolbox should target — or `nil` to
+    /// leave VideoToolbox's own default — from the operator's bitrate choice, the
+    /// capture source, and the delivered pixel dimensions. Pure so the
+    /// Simulator-only bits-per-pixel gating and the physical-device fallback are
+    /// unit-tested without a live `VTCompressionSession`:
+    ///
+    ///   - `.explicitBps`: honored verbatim for BOTH sources (operator override).
+    ///   - `.bitsPerPixel`: Simulator-only. On a device it is skipped and the
+    ///     result falls back to the VideoToolbox default (`nil`), because the
+    ///     bits-per-pixel budget was justified from Simulator measurements alone.
+    ///   - `.videoToolboxDefault`: VideoToolbox default (`nil`) for both.
+    ///
+    /// Unlike the arithmetic above, this is NOT part of the cross-language golden
+    /// vectors — it encodes a Swift-side policy the TypeScript sender applies by
+    /// choosing which flags to pass per source.
+    public static func resolveAverageBitRateBps(
+        source: CaptureSource,
+        bitrate: CommandLineOptions.EncodeSettings.Bitrate,
+        width: Int,
+        height: Int,
+        fps: Int
+    ) -> Int? {
+        switch bitrate {
+        case .explicitBps(let bps):
+            return bps
+        case .bitsPerPixel(let bpp):
+            switch source {
+            case .simulator:
+                return bitrateBps(width: width, height: height, fps: fps, bitsPerPixel: bpp)
+            case .device:
+                // Skip the Simulator-derived bpp budget on a device; VideoToolbox
+                // picks its own default instead (issues #4349 / #4375).
+                return nil
+            }
+        case .videoToolboxDefault:
+            return nil
+        }
+    }
+
     // MARK: - Private helpers
 
     private static func divCeil(_ numerator: Int, _ denominator: Int) -> Int {

--- a/ios/screen-capture/Sources/ScreenCaptureHelper/DeviceCaptureSession.swift
+++ b/ios/screen-capture/Sources/ScreenCaptureHelper/DeviceCaptureSession.swift
@@ -3,25 +3,55 @@ import CoreVideo
 import Foundation
 import ScreenCaptureCore
 
-/// Wraps an `AVCaptureSession` configured to deliver BGRA frames from an iOS
-/// device to a `FrameWriter`.
+/// Wraps an `AVCaptureSession` configured to stream frames from a USB-connected
+/// iOS device to a `FrameWriter`.
+///
+/// Two paths (issue #4790): the default raw path delivers 32BGRA and streams it
+/// byte-for-byte as before; `--encode h264` delivers 420v (NV12) and feeds the
+/// delivered `CVPixelBuffer` straight into the SAME `EncodePipeline` /
+/// `H264VideoEncoder` stage the Simulator path uses, emitting Annex-B
+/// encoded-video records. AVFoundation accepts 420v directly with no color
+/// conversion, so the encode input is the lowest-CPU form.
 final class DeviceCaptureSession: NSObject, AVCaptureVideoDataOutputSampleBufferDelegate {
     private let session = AVCaptureSession()
     private let output = AVCaptureVideoDataOutput()
     private let writer: FrameWriter
     private let onFatalError: (Error) -> Void
+    private let diagnosticSink: (String) -> Void
+    /// In-helper H.264 encode settings (issue #4790). `nil` keeps the raw-BGRA
+    /// path byte-for-byte unchanged.
+    private let encodeSettings: CommandLineOptions.EncodeSettings?
+    /// Force-keyframe latch shared with the STDIN control channel; consumed by the
+    /// encoder on the next frame. Present even in raw mode (harmless there).
+    let forceKeyFrameLatch = ForceKeyFrameLatch()
+    /// Shared in-helper encode wiring in `--encode h264` mode; `nil` on the raw
+    /// path. Identical `EncodePipeline` type as the Simulator session.
+    private var pipeline: EncodePipeline?
     private let queue = DispatchQueue(label: "automobile.screen-capture.frames")
     private var observers: [NSObjectProtocol] = []
     private var stopping = false
 
-    init(writer: FrameWriter, onFatalError: @escaping (Error) -> Void) {
+    init(
+        writer: FrameWriter,
+        encode: CommandLineOptions.EncodeSettings? = nil,
+        diagnosticSink: @escaping (String) -> Void = { line in
+            FileHandle.standardError.write(Data(line.utf8))
+        },
+        onFatalError: @escaping (Error) -> Void
+    ) {
         self.writer = writer
+        self.encodeSettings = encode
+        self.diagnosticSink = diagnosticSink
         self.onFatalError = onFatalError
     }
 
     deinit {
         removeObservers()
     }
+
+    /// Whether this session encodes H.264 in-process instead of streaming raw
+    /// BGRA.
+    var isEncoding: Bool { encodeSettings != nil }
 
     func start(device: AVCaptureDevice) throws {
         let input = try AVCaptureDeviceInput(device: device)
@@ -32,10 +62,42 @@ final class DeviceCaptureSession: NSObject, AVCaptureVideoDataOutputSampleBuffer
             throw CaptureError.couldNotAddInput
         }
         session.addInput(input)
-        output.alwaysDiscardsLateVideoFrames = true
-        output.videoSettings = [
-            kCVPixelBufferPixelFormatTypeKey as String: kCVPixelFormatType_32BGRA
-        ]
+
+        if let encodeSettings = encodeSettings {
+            // 420v (NV12) feeds VideoToolbox directly with no color conversion.
+            output.videoSettings = [
+                kCVPixelBufferPixelFormatTypeKey as String:
+                    kCVPixelFormatType_420YpCbCr8BiPlanarVideoRange
+            ]
+            // Drop policy (issue #4790): the encode path relies SOLELY on #4788's
+            // encoder-input drop (`EncoderDropPolicy.shouldDropBeforeEncode`), which
+            // is the only backpressure that can see the real encoder state
+            // (in-flight frames) and always drops BEFORE encode, leaving the encoded
+            // reference chain intact. `alwaysDiscardsLateVideoFrames` is therefore
+            // turned OFF here so we do NOT stack a second, encoder-blind drop layer
+            // at the capture edge that could over-drop frames the encoder was ready
+            // to accept. The delegate never blocks (VideoToolbox encode is
+            // fire-and-forget and the input drop returns immediately when behind), so
+            // AVFoundation does not accumulate late frames without the discard.
+            output.alwaysDiscardsLateVideoFrames = false
+            pipeline = EncodePipeline(
+                writer: writer,
+                fps: DeviceCaptureSession.deviceFPS,
+                source: .device,
+                bitrate: encodeSettings.bitrate,
+                forceKeyFrameLatch: forceKeyFrameLatch,
+                diagnosticSink: diagnosticSink,
+                onFatalError: onFatalError
+            )
+        } else {
+            // Raw path unchanged: newest-wins late-frame discard at the capture
+            // edge, 32BGRA delivery.
+            output.alwaysDiscardsLateVideoFrames = true
+            output.videoSettings = [
+                kCVPixelBufferPixelFormatTypeKey as String: kCVPixelFormatType_32BGRA
+            ]
+        }
+
         output.setSampleBufferDelegate(self, queue: queue)
         guard session.canAddOutput(output) else {
             session.commitConfiguration()
@@ -54,6 +116,8 @@ final class DeviceCaptureSession: NSObject, AVCaptureVideoDataOutputSampleBuffer
         stopping = true
         removeObservers()
         session.stopRunning()
+        pipeline?.stop()
+        pipeline = nil
     }
 
     private func installObservers() {
@@ -112,6 +176,35 @@ final class DeviceCaptureSession: NSObject, AVCaptureVideoDataOutputSampleBuffer
         didOutput sampleBuffer: CMSampleBuffer,
         from connection: AVCaptureConnection
     ) {
+        if let pipeline = pipeline {
+            encodeFrame(pipeline: pipeline, sampleBuffer: sampleBuffer)
+            return
+        }
         writer.write(sampleBuffer: sampleBuffer)
     }
+
+    /// Encode-mode frame path (issue #4790). Unlike the Simulator path — which
+    /// asks ScreenCaptureKit to deliver the Level 4.2 macroblock-budgeted size —
+    /// AVFoundation cannot reshape its delivery size, so the encoder is sized to
+    /// the budgeted target and VideoToolbox scales the native buffer into it. On a
+    /// delivered-size change the encoder is torn down and recreated (the new
+    /// session's first frame is a fresh SPS/PPS + IDR).
+    private func encodeFrame(pipeline: EncodePipeline, sampleBuffer: CMSampleBuffer) {
+        guard let pixelBuffer = CMSampleBufferGetImageBuffer(sampleBuffer) else { return }
+        let width = CVPixelBufferGetWidth(pixelBuffer)
+        let height = CVPixelBufferGetHeight(pixelBuffer)
+        let target = H264EncodeMath.resolveEncoderScale(
+            H264EncodeMath.EncoderSize(width: width, height: height)
+        ) ?? H264EncodeMath.EncoderSize(width: width, height: height)
+
+        guard pipeline.ensureEncoder(width: target.width, height: target.height) else { return }
+        let pts = CMSampleBufferGetPresentationTimeStamp(sampleBuffer)
+        pipeline.encode(pixelBuffer: pixelBuffer, presentationTime: pts)
+    }
+
+    /// Frame rate declared to the encoder for `MaxKeyFrameInterval` /
+    /// bitrate arithmetic. AVFoundation device capture is not FPS-throttled by the
+    /// helper (the device pushes frames at its own cadence), so this mirrors the
+    /// Simulator default used elsewhere rather than a negotiated rate.
+    static let deviceFPS = CommandLineOptions.defaultSimulatorFPS
 }

--- a/ios/screen-capture/Sources/ScreenCaptureHelper/EncodePipeline.swift
+++ b/ios/screen-capture/Sources/ScreenCaptureHelper/EncodePipeline.swift
@@ -1,0 +1,116 @@
+import CoreMedia
+import CoreVideo
+import Foundation
+import ScreenCaptureCore
+
+/// Shared in-helper H.264 encode wiring (issues #4788 / #4790).
+///
+/// Both the Simulator (`SimulatorCaptureSession`, ScreenCaptureKit) and the
+/// physical-device (`DeviceCaptureSession`, AVFoundation) capture sessions feed
+/// this ONE stage instead of each duplicating the VideoToolbox glue. It owns:
+///   - the `H264VideoEncoder` lifecycle (create / resize-recreate / stop),
+///   - the source-aware `AverageBitRate` resolution (via the pure
+///     `H264EncodeMath.resolveAverageBitRateBps`), and
+///   - the force-keyframe latch handoff to the encoder.
+///
+/// The pipeline is deliberately capture-source-agnostic about *sizing*: each
+/// caller resolves the encode-target size itself — the Simulator reconfigures
+/// ScreenCaptureKit to deliver exactly that size, while the device leaves the
+/// native buffer as-is and lets VideoToolbox scale it — then hands the pipeline a
+/// ready target and pixel buffer. The only source-dependent decision the pipeline
+/// makes is the bitrate policy, which it delegates to the pure math layer so the
+/// Simulator-only bits-per-pixel gating stays unit-tested.
+final class EncodePipeline {
+    private let writer: FrameWriter
+    private let fps: Int
+    private let source: H264EncodeMath.CaptureSource
+    private let bitrate: CommandLineOptions.EncodeSettings.Bitrate
+    private let forceKeyFrameLatch: ForceKeyFrameLatch
+    private let diagnosticSink: (String) -> Void
+    private let onFatalError: (Error) -> Void
+    private var encoder: H264VideoEncoder?
+
+    init(
+        writer: FrameWriter,
+        fps: Int,
+        source: H264EncodeMath.CaptureSource,
+        bitrate: CommandLineOptions.EncodeSettings.Bitrate,
+        forceKeyFrameLatch: ForceKeyFrameLatch,
+        diagnosticSink: @escaping (String) -> Void,
+        onFatalError: @escaping (Error) -> Void
+    ) {
+        self.writer = writer
+        self.fps = fps
+        self.source = source
+        self.bitrate = bitrate
+        self.forceKeyFrameLatch = forceKeyFrameLatch
+        self.diagnosticSink = diagnosticSink
+        self.onFatalError = onFatalError
+    }
+
+    /// The size the active encoder was created for, or `nil` when no encoder is
+    /// running. Callers compare it against their resolved target to decide whether
+    /// a resize-recreate is needed.
+    var encoderSize: H264EncodeMath.EncoderSize? {
+        guard let encoder = encoder else { return nil }
+        return H264EncodeMath.EncoderSize(width: encoder.width, height: encoder.height)
+    }
+
+    /// Ensure an encoder sized exactly `width`x`height` exists, (re)creating it on
+    /// a size change (a seamless reconfig: the new session's first frame is a fresh
+    /// SPS/PPS + IDR). Returns `false` — after surfacing the fatal error — when the
+    /// VideoToolbox session cannot be created or prepared.
+    func ensureEncoder(width: Int, height: Int) -> Bool {
+        if let encoder = encoder, encoder.width == width, encoder.height == height {
+            return true
+        }
+        return startEncoder(width: width, height: height)
+    }
+
+    /// Encode one delivered pixel buffer through the active encoder. Fire and
+    /// forget: encoded output arrives on the VideoToolbox callback and is written
+    /// via `FrameWriter.writeEncoded`. Returns `false` when there is no encoder or
+    /// the frame was dropped before encode (encoder behind), so the caller can
+    /// skip its bookkeeping.
+    @discardableResult
+    func encode(pixelBuffer: CVPixelBuffer, presentationTime: CMTime) -> Bool {
+        encoder?.encode(pixelBuffer: pixelBuffer, presentationTime: presentationTime) == true
+    }
+
+    /// Tear the encoder down (orderly shutdown / reconfiguration teardown).
+    func stop() {
+        encoder?.stop()
+        encoder = nil
+    }
+
+    private func startEncoder(width: Int, height: Int) -> Bool {
+        encoder?.stop()
+        let resolvedBitrate = H264EncodeMath.resolveAverageBitRateBps(
+            source: source,
+            bitrate: bitrate,
+            width: width,
+            height: height,
+            fps: fps
+        )
+        let newEncoder = H264VideoEncoder(
+            width: width,
+            height: height,
+            fps: fps,
+            averageBitRateBps: resolvedBitrate,
+            writer: writer,
+            forceKeyFrameLatch: forceKeyFrameLatch,
+            diagnosticSink: diagnosticSink,
+            onFatalError: { [weak self] message in
+                self?.onFatalError(EncoderOutputOverflowError(message: message))
+            }
+        )
+        do {
+            try newEncoder.start()
+        } catch {
+            onFatalError(error)
+            return false
+        }
+        encoder = newEncoder
+        return true
+    }
+}

--- a/ios/screen-capture/Sources/ScreenCaptureHelper/SimulatorCaptureSession.swift
+++ b/ios/screen-capture/Sources/ScreenCaptureHelper/SimulatorCaptureSession.swift
@@ -41,10 +41,11 @@ final class SimulatorCaptureSession: NSObject, SCStreamOutput, SCStreamDelegate 
     /// Force-keyframe latch shared with the STDIN control channel; consumed by
     /// the encoder on the next frame. Present even in raw mode (harmless there).
     let forceKeyFrameLatch = ForceKeyFrameLatch()
-    /// Active encoder in `--encode h264` mode; recreated on a capture-size
-    /// change (seamless reconfig: the new session's first frame is a fresh
-    /// SPS/PPS + IDR).
-    private var encoder: H264VideoEncoder?
+    /// Shared in-helper encode wiring in `--encode h264` mode (issues #4788 /
+    /// #4790). `nil` in the raw-BGRA path. The same `EncodePipeline` type backs the
+    /// physical-device capture session, so the VideoToolbox glue lives in exactly
+    /// one place.
+    private var pipeline: EncodePipeline?
     /// Pixel format requested from ScreenCaptureKit — 32BGRA for the raw path,
     /// 420v (NV12) for the lowest-CPU encode path.
     var configuredPixelFormat: OSType = kCVPixelFormatType_32BGRA
@@ -101,8 +102,17 @@ final class SimulatorCaptureSession: NSObject, SCStreamOutput, SCStreamDelegate 
         // 420v (NV12) is the lowest-CPU encode input: the delivered
         // IOSurface-backed CVPixelBuffer feeds VTCompressionSession directly with
         // no color conversion. The raw path keeps 32BGRA untouched.
-        if isEncoding {
+        if let encodeSettings = encodeSettings {
             configuredPixelFormat = kCVPixelFormatType_420YpCbCr8BiPlanarVideoRange
+            pipeline = EncodePipeline(
+                writer: writer,
+                fps: fps,
+                source: .simulator,
+                bitrate: encodeSettings.bitrate,
+                forceKeyFrameLatch: forceKeyFrameLatch,
+                diagnosticSink: diagnosticSink,
+                onFatalError: onFatalError
+            )
         }
         let filter = SCContentFilter(desktopIndependentWindow: window)
         let config = SimulatorCaptureSession.makeConfiguration(
@@ -160,8 +170,8 @@ final class SimulatorCaptureSession: NSObject, SCStreamOutput, SCStreamDelegate 
     }
 
     func stop() async {
-        encoder?.stop()
-        encoder = nil
+        pipeline?.stop()
+        pipeline = nil
         guard let stream = stream else { return }
         // removeStreamOutput breaks the SCStream → self retain cycle so the
         // session is collectable even before SCStream itself goes away.
@@ -226,12 +236,16 @@ final class SimulatorCaptureSession: NSObject, SCStreamOutput, SCStreamDelegate 
         width: Int,
         height: Int
     ) {
+        guard let pipeline = pipeline else { return }
         let target = H264EncodeMath.resolveEncoderScale(
             H264EncodeMath.EncoderSize(width: width, height: height)
         ) ?? H264EncodeMath.EncoderSize(width: width, height: height)
 
         // Ask SCK to deliver the encode resolution. Until it does, skip encoding
-        // rather than feed VideoToolbox a mismatched buffer size.
+        // rather than feed VideoToolbox a mismatched buffer size. (The device path
+        // cannot reshape its delivery size, so it instead sizes the encoder to the
+        // target and lets VideoToolbox scale the native buffer — the divergence the
+        // shared pipeline is designed around.)
         if width != target.width || height != target.height {
             reconfigure(width: target.width, height: target.height)
             return
@@ -239,58 +253,11 @@ final class SimulatorCaptureSession: NSObject, SCStreamOutput, SCStreamDelegate 
 
         // Delivered size now equals the encode target. (Re)create the encoder if
         // absent or sized for a previous resolution.
-        if encoder == nil || encoder?.width != target.width || encoder?.height != target.height {
-            guard startEncoder(width: target.width, height: target.height) else { return }
-        }
+        guard pipeline.ensureEncoder(width: target.width, height: target.height) else { return }
 
         let pts = CMSampleBufferGetPresentationTimeStamp(sampleBuffer)
-        if encoder?.encode(pixelBuffer: pixelBuffer, presentationTime: pts) == true {
+        if pipeline.encode(pixelBuffer: pixelBuffer, presentationTime: pts) {
             noteFrameWritten(width: target.width, height: target.height)
-        }
-    }
-
-    /// Build and start a VideoToolbox encoder at `width`x`height`, resolving the
-    /// `AverageBitRate` from the delivered dimensions per the operator's bitrate
-    /// choice. Returns `false` (and surfaces a fatal error) when the session
-    /// cannot be created.
-    private func startEncoder(width: Int, height: Int) -> Bool {
-        encoder?.stop()
-        let bitrate = resolvedBitrateBps(width: width, height: height)
-        let newEncoder = H264VideoEncoder(
-            width: width,
-            height: height,
-            fps: fps,
-            averageBitRateBps: bitrate,
-            writer: writer,
-            forceKeyFrameLatch: forceKeyFrameLatch,
-            diagnosticSink: diagnosticSink,
-            onFatalError: { [weak self] message in
-                self?.onFatalError(EncoderOutputOverflowError(message: message))
-            }
-        )
-        do {
-            try newEncoder.start()
-        } catch {
-            onFatalError(error)
-            return false
-        }
-        encoder = newEncoder
-        return true
-    }
-
-    /// Resolve `AverageBitRate` (bps) from the delivered pixel dimensions and the
-    /// operator's bitrate choice. `nil` leaves the VideoToolbox default. The
-    /// policy (which choice) is set by the TS supervisor via CLI flags; only the
-    /// pixel-dimension arithmetic — which the helper alone knows pre-encode —
-    /// happens here, via the pure `H264EncodeMath`.
-    private func resolvedBitrateBps(width: Int, height: Int) -> Int? {
-        switch encodeSettings?.bitrate {
-        case .explicitBps(let bps):
-            return bps
-        case .bitsPerPixel(let bpp):
-            return H264EncodeMath.bitrateBps(width: width, height: height, fps: fps, bitsPerPixel: bpp)
-        case .videoToolboxDefault, .none:
-            return nil
         }
     }
 

--- a/ios/screen-capture/Sources/ScreenCaptureHelper/main.swift
+++ b/ios/screen-capture/Sources/ScreenCaptureHelper/main.swift
@@ -288,7 +288,7 @@ case .captureSimulator(let windowID, let fps, let audio, let encode):
     }
     RunLoop.main.run()
 
-case .capture(let deviceID):
+case .capture(let deviceID, let encode):
     CMIOSystem.enableScreenCaptureDevices()
     // Poll briefly for the requested device to register instead of an
     // unconditional 0.5s sleep; return as soon as it enumerates (issue #4737).
@@ -319,13 +319,28 @@ case .capture(let deviceID):
     let writer = FrameWriter(sink: sink)
     let metricsReporter = FrameMetricsReporter(writer: writer, output: logError)
     metricsReporter.start()
-    let captureSession = DeviceCaptureSession(writer: writer) { error in
+    let captureSession = DeviceCaptureSession(writer: writer, encode: encode) { error in
         // A mid-stream AVCaptureSession fatal error (runtime error / interruption
-        // once running): exit deterministically so the supervisor's bounded
-        // reconnect re-establishes capture instead of leaving a dead session
-        // spinning RunLoop.main (issue #4768).
+        // once running) or a fatal encoded-output overflow: exit deterministically
+        // so the supervisor's bounded reconnect re-establishes capture instead of
+        // leaving a dead session spinning RunLoop.main (issues #4768 / #4790).
         logError("error: iOS device capture failed: \(error)")
         exit(midStreamFatalExitCode)
+    }
+
+    // In encode mode, read newline-delimited JSON control commands from STDIN
+    // (today only `{"cmd":"forceKeyFrame"}`). The raw path never touches STDIN, so
+    // its stdout is byte-for-byte unchanged (issues #4788 / #4790).
+    var deviceControlChannel: ControlChannel?
+    if encode != nil {
+        let channel = ControlChannel { command in
+            switch command {
+            case .forceKeyFrame:
+                captureSession.forceKeyFrameLatch.request()
+            }
+        }
+        channel.start()
+        deviceControlChannel = channel
     }
 
     do {
@@ -337,6 +352,7 @@ case .capture(let deviceID):
 
     installShutdownHandlers {
         metricsReporter.stop()
+        deviceControlChannel?.stop()
         captureSession.stop()
         exit(0)
     }

--- a/ios/screen-capture/Tests/ScreenCaptureCoreTests/CommandLineOptionsEncodeTests.swift
+++ b/ios/screen-capture/Tests/ScreenCaptureCoreTests/CommandLineOptionsEncodeTests.swift
@@ -71,8 +71,46 @@ final class CommandLineOptionsEncodeTests: XCTestCase {
         }
     }
 
-    func testRejectsEncodeWithoutSimulatorWindow() {
-        XCTAssertThrowsError(try parse(["--encode", "h264"])) {
+    // MARK: - Physical-device encode path (issue #4790)
+
+    func testEncodeWithoutSimulatorWindowIsDeviceCapture() throws {
+        // `--encode h264` with no simulator window is the physical-device path, not
+        // an error: it carries the encode settings onto the AVFoundation capture.
+        let opts = try parse(["--encode", "h264"])
+        XCTAssertEqual(
+            opts.mode,
+            .capture(deviceID: nil, encode: .init(bitrate: .videoToolboxDefault))
+        )
+    }
+
+    func testDeviceEncodeWithDeviceIDAndExplicitBitrate() throws {
+        let opts = try parse(["--device-id", "ABC123", "--encode", "h264", "--bitrate-bps", "3000000"])
+        XCTAssertEqual(
+            opts.mode,
+            .capture(deviceID: "ABC123", encode: .init(bitrate: .explicitBps(3_000_000)))
+        )
+    }
+
+    func testDeviceEncodeCarriesBitsPerPixelChoice() throws {
+        // Parsing still records the choice; the Simulator-only gating happens in the
+        // pure `H264EncodeMath.resolveAverageBitRateBps` layer, not at parse time.
+        let opts = try parse(["--encode", "h264", "--bits-per-pixel", "0.1"])
+        XCTAssertEqual(
+            opts.mode,
+            .capture(deviceID: nil, encode: .init(bitrate: .bitsPerPixel(0.1)))
+        )
+    }
+
+    func testRejectsEncodeWithListDevices() {
+        XCTAssertThrowsError(try parse(["--list-devices", "--encode", "h264"])) {
+            guard case CommandLineOptions.ParseError.conflictingFlags = $0 else {
+                return XCTFail("expected conflictingFlags, got \($0)")
+            }
+        }
+    }
+
+    func testRejectsEncodeWithListSimulators() {
+        XCTAssertThrowsError(try parse(["--list-simulators", "--encode", "h264"])) {
             guard case CommandLineOptions.ParseError.conflictingFlags = $0 else {
                 return XCTFail("expected conflictingFlags, got \($0)")
             }

--- a/ios/screen-capture/Tests/ScreenCaptureCoreTests/CommandLineOptionsTests.swift
+++ b/ios/screen-capture/Tests/ScreenCaptureCoreTests/CommandLineOptionsTests.swift
@@ -12,14 +12,14 @@ final class CommandLineOptionsTests: XCTestCase {
 
     func testDefaultsToCaptureWithoutDeviceID() throws {
         let opts = try CommandLineOptions.parse(["screen-capture-helper"])
-        XCTAssertEqual(opts.mode, .capture(deviceID: nil))
+        XCTAssertEqual(opts.mode, .capture(deviceID: nil, encode: nil))
     }
 
     func testParsesDeviceID() throws {
         let opts = try CommandLineOptions.parse([
             "screen-capture-helper", "--device-id", "ABC123"
         ])
-        XCTAssertEqual(opts.mode, .capture(deviceID: "ABC123"))
+        XCTAssertEqual(opts.mode, .capture(deviceID: "ABC123", encode: nil))
     }
 
     func testParsesListDevices() throws {

--- a/ios/screen-capture/Tests/ScreenCaptureCoreTests/H264EncodeMathTests.swift
+++ b/ios/screen-capture/Tests/ScreenCaptureCoreTests/H264EncodeMathTests.swift
@@ -127,4 +127,59 @@ final class H264EncodeMathTests: XCTestCase {
             1
         )
     }
+
+    // MARK: - Source-aware bitrate resolution (issue #4790)
+
+    /// An explicit operator override is honored verbatim on BOTH sources — the
+    /// #4375 decision to always respect `--bitrate-bps`.
+    func testResolveExplicitBpsHonoredForBothSources() {
+        for source in [H264EncodeMath.CaptureSource.simulator, .device] {
+            XCTAssertEqual(
+                H264EncodeMath.resolveAverageBitRateBps(
+                    source: source, bitrate: .explicitBps(2_500_000),
+                    width: 800, height: 600, fps: 30
+                ),
+                2_500_000,
+                "explicit bps must be honored for \(source)"
+            )
+        }
+    }
+
+    /// On the Simulator the bits-per-pixel budget is applied — same arithmetic as
+    /// the pure `bitrateBps`.
+    func testResolveBitsPerPixelAppliedForSimulator() {
+        let resolved = H264EncodeMath.resolveAverageBitRateBps(
+            source: .simulator, bitrate: .bitsPerPixel(0.1),
+            width: 800, height: 600, fps: 30
+        )
+        XCTAssertEqual(
+            resolved,
+            H264EncodeMath.bitrateBps(width: 800, height: 600, fps: 30, bitsPerPixel: 0.1)
+        )
+    }
+
+    /// The key #4790 branch: on a physical device the bits-per-pixel budget is
+    /// SKIPPED (it was measured from Simulator screen content, #4349), so the
+    /// resolver returns `nil` and VideoToolbox picks its own default.
+    func testResolveBitsPerPixelSkippedForDevice() {
+        XCTAssertNil(
+            H264EncodeMath.resolveAverageBitRateBps(
+                source: .device, bitrate: .bitsPerPixel(0.1),
+                width: 800, height: 600, fps: 30
+            )
+        )
+    }
+
+    /// Neither flag leaves the VideoToolbox default (`nil`) on both sources.
+    func testResolveVideoToolboxDefaultIsNilForBothSources() {
+        for source in [H264EncodeMath.CaptureSource.simulator, .device] {
+            XCTAssertNil(
+                H264EncodeMath.resolveAverageBitRateBps(
+                    source: source, bitrate: .videoToolboxDefault,
+                    width: 800, height: 600, fps: 30
+                ),
+                "videoToolboxDefault must resolve to nil for \(source)"
+            )
+        }
+    }
 }


### PR DESCRIPTION
## What

Extends the in-helper `VTCompressionSession` H.264 encode (shipped for the Simulator in [#4788](https://github.com/kaeawc/auto-mobile/issues/4788)) to the physical-device capture path (`DeviceCaptureSession`, AVFoundation). Closes [#4790](https://github.com/kaeawc/auto-mobile/issues/4790).

The encode stage is **reused, not forked** — the VideoToolbox glue that #4788 left coupled inside `SimulatorCaptureSession` is extracted into a shared unit both sessions call.

## The shared encode-stage seam: `EncodePipeline`

New `Sources/ScreenCaptureHelper/EncodePipeline.swift` owns the encode wiring both capture sessions now share:
- the `H264VideoEncoder` lifecycle (create / resize-recreate / stop),
- the source-aware `AverageBitRate` resolution (delegated to the pure math layer), and
- the force-keyframe latch handoff to the encoder.

It is deliberately agnostic about *sizing*: each caller resolves the encode-target size itself and hands the pipeline a ready target + pixel buffer. `SimulatorCaptureSession`'s `encoder`/`startEncoder`/`resolvedBitrateBps` were deleted and replaced with `pipeline`, so the VT glue lives in exactly one place. Same `FrameProtocol` encoded-video records, same `AnnexBConverter` (SPS/PPS on every IDR), same `EncoderControl` STDIN `forceKeyFrame` channel.

## 420v device capture

Under `--encode h264`, `DeviceCaptureSession` sets `AVCaptureVideoDataOutput.videoSettings` to `kCVPixelFormatType_420YpCbCr8BiPlanarVideoRange` (AVFoundation accepts 420v directly, no color conversion) and feeds the delivered `CVPixelBuffer` into the pipeline. Because AVFoundation cannot reshape its delivery size, the encoder is sized to the Level 4.2 macroblock-budgeted target (`H264EncodeMath.resolveEncoderScale`) and VideoToolbox scales the native buffer into it — the divergence from the Simulator path (which reconfigures ScreenCaptureKit to the target) that the shared pipeline is built around.

## Device bitrate policy (no bpp default)

A physical device gets **no** bits-per-pixel default — the `0.1` bpp budget was justified entirely from Simulator screen-content measurements ([#4349](https://github.com/kaeawc/auto-mobile/issues/4349)), so it must not apply to a device (preserves the [#4375](https://github.com/kaeawc/auto-mobile/issues/4375) decision). The new pure `H264EncodeMath.resolveAverageBitRateBps(source:bitrate:width:height:fps:)`:
- `.explicitBps` -> honored verbatim for **both** sources;
- `.bitsPerPixel` -> **Simulator-only**; on `.device` it is skipped, falling back to the VideoToolbox default (`nil`);
- `.videoToolboxDefault` -> `nil` for both.

Unit-tested in the pure layer (no live `VTCompressionSession`).

## Drop-policy decision (no double-drop)

The device encode path relies **solely** on #4788's encoder-input drop (`EncoderDropPolicy.shouldDropBeforeEncode`) — the only backpressure that can see real encoder state (in-flight frames) and that always drops *before* encode, leaving the encoded reference chain intact. So `alwaysDiscardsLateVideoFrames` is turned **off** under encode, to avoid stacking a second, encoder-blind drop layer at the capture edge that could over-drop frames the encoder was ready to accept. The delegate never blocks (VideoToolbox encode is fire-and-forget; the input drop returns immediately when behind), so AVFoundation does not accumulate late frames without the capture-edge discard. The **raw path keeps `alwaysDiscardsLateVideoFrames = true` unchanged**.

## Raw path unchanged (byte-identical)

Without `--encode h264`, `DeviceCaptureSession` keeps 32BGRA delivery, `alwaysDiscardsLateVideoFrames = true`, and `captureOutput` calls exactly `writer.write(sampleBuffer:)` — no STDIN control channel, no new stderr, identical stdout. Confirmed by inspection: the non-encode branch is the original code path unchanged.

## Pure-tested vs device-only

- **Pure-tested (CI):** the source-aware bitrate resolution branch (`H264EncodeMathTests`, incl. the device-skips-bpp case) and CLI parsing of `--encode` on the device path (`CommandLineOptionsEncodeTests`). The Level 4.2 scale/bitrate golden vectors from #4787/#4788 continue to pin the pure logic.
- **Device-only (out-of-CI):** the AVFoundation/VideoToolbox glue — no hosted lane covers a USB-connected iOS device. **Not verified on a physical device**; needs manual on-device verification before relying on the stream.

## Gates

- `swift build -Xswiftc -warnings-as-errors` — PASS
- `swift test -Xswiftc -warnings-as-errors` — PASS (123 tests)
- SwiftLint on changed files — clean (0 serious; the one non-serious warning is the pre-existing `CommandLineOptions.parse` cyclomatic-complexity notice, error threshold 200, CI runs non-strict)

Scope is Swift-only; the TS supervisor's device-encode cutover is a separate step.
