### PR TITLE
ci: gate LFS-routed files against full-blob commits

### DIFF
--- a/scripts/all_fast_validate_checks.sh
+++ b/scripts/all_fast_validate_checks.sh
@@ -57,6 +57,7 @@ add_check "archive-extraction-boundary" "bun \"$PROJECT_ROOT/scripts/check-archi
 add_check "xcodebuild-boundary" "\"$PROJECT_ROOT/scripts/check-no-new-direct-xcodebuild.sh\"" "lint,ios" "Keep xcodebuild execution behind XcodebuildClient"
 add_check "daemon-launcher-boundary" "bash \"$PROJECT_ROOT/scripts/check-daemon-launcher-boundary.sh\"" "lint,conventions" "Require DaemonLauncher ownership for daemon process execution"
 add_check "ios-ctrl-proxy-process-boundary" "bun \"$PROJECT_ROOT/scripts/check-ios-ctrl-proxy-process-boundary.ts\"" "lint,conventions" "Keep CtrlProxy PID tooling behind its lifecycle client"
+add_check "lfs-pointers" "\"$PROJECT_ROOT/scripts/check-lfs-pointers.sh\"" "lint,conventions" "Reject full blobs committed where .gitattributes requires LFS pointers"
 add_check "datetime-now-literal" "\"$PROJECT_ROOT/scripts/validate-no-datetime-now-literal.sh\"" "lint" "Reject string-literal SQL time-expression defaults in migrations"
 add_check "desktop-core-unified" "\"$PROJECT_ROOT/scripts/android/validate-no-desktop-core-unified.sh\"" "lint,android" "Reject abandoned desktop-core unified socket-client package"
 add_check "workflow-assertion-triggers" "\"$PROJECT_ROOT/scripts/ci/validate_workflow_assertion_triggers.sh\"" "config,ci" "Ensure workflow-YAML assertion tests are triggered by the paths they assert"

--- a/scripts/check-lfs-pointers.sh
+++ b/scripts/check-lfs-pointers.sh
@@ -1,0 +1,53 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+# Fail when a tracked file that .gitattributes routes through Git LFS is
+# committed as a full blob instead of an LFS pointer. This happens when a
+# commit is created without the LFS clean filter — e.g. from a jj colocated
+# checkout (jj bypasses git filters entirely, see jj-vcs/jj#80) or any clone
+# with LFS uninstalled — and would permanently bloat history once merged.
+#
+# Uses git plumbing only: attribute resolution comes from git check-attr and
+# blob inspection from git cat-file, so the check needs neither the git-lfs
+# binary nor downloaded LFS objects (CI checks out with lfs: false).
+#
+# Usage: check-lfs-pointers.sh [rev]   (defaults to HEAD)
+
+rev="${1:-HEAD}"
+pointer_prefix='version https://git-lfs.github.com/spec/v1'
+violations=()
+
+while IFS= read -r -d '' path && IFS= read -r -d '' _attr && IFS= read -r -d '' value; do
+  # Only files whose resolved filter attribute is lfs; paths where a later
+  # .gitattributes line unsets the filter (-filter) resolve to "unset".
+  [[ "$value" == "lfs" ]] || continue
+
+  # Symlinks and gitlinks have no blob content to check.
+  size="$(git cat-file -s "$rev:$path" 2>/dev/null)" || continue
+
+  # A canonical LFS pointer is a small text file; git-lfs itself only treats
+  # blobs of at most 1024 bytes as pointer candidates.
+  if (( size > 1024 )); then
+    violations+=("$path (${size}-byte blob, expected an LFS pointer)")
+    continue
+  fi
+  prefix_bytes="$(git cat-file blob "$rev:$path" | head -c "${#pointer_prefix}")"
+  if [[ "$prefix_bytes" != "$pointer_prefix" ]]; then
+    violations+=("$path (small blob but not an LFS pointer)")
+  fi
+done < <(git ls-tree -r -z --name-only "$rev" | git check-attr --stdin -z filter)
+
+if ((${#violations[@]})); then
+  {
+    printf '%s\n' "Files matched by an LFS pattern in .gitattributes are committed as full blobs:"
+    printf '  %s\n' "${violations[@]}"
+    printf '%s\n' ""
+    printf '%s\n' "This usually means the commit was created without the LFS clean filter"
+    printf '%s\n' "(jj colocated checkout, or a clone with LFS smudge disabled). Re-add the"
+    printf '%s\n' "file from an LFS-enabled git clone, or exempt it in .gitattributes if it"
+    printf '%s\n' "belongs in git directly."
+  } >&2
+  exit 1
+fi
+
+printf '%s\n' "All LFS-routed files at $rev are pointers."

--- a/test/bats/check-lfs-pointers.bats
+++ b/test/bats/check-lfs-pointers.bats
@@ -1,0 +1,110 @@
+#!/usr/bin/env bats
+
+# check-lfs-pointers.sh: files routed through LFS by .gitattributes must be
+# committed as pointer blobs, never as full content (the jj/no-clean-filter
+# hazard). The fixture repos below never install git-lfs; pointers are written
+# literally, exactly as a filterless commit path would (or would fail to).
+
+pointer_content() {
+  printf 'version https://git-lfs.github.com/spec/v1\n'
+  printf 'oid sha256:%s\n' "$1"
+  printf 'size 12345\n'
+}
+
+setup() {
+  # Hermetic git config: the developer machine may have git-lfs filters
+  # installed globally, which would clean fixture blobs into real pointers
+  # and make violations impossible to construct.
+  export GIT_CONFIG_GLOBAL=/dev/null
+  export GIT_CONFIG_SYSTEM=/dev/null
+  repo_dir="$(mktemp -d)"
+  mkdir -p "$repo_dir/scripts"
+  cp "$BATS_TEST_DIRNAME/../../scripts/check-lfs-pointers.sh" "$repo_dir/scripts/"
+  git -C "$repo_dir" init -q
+  git -C "$repo_dir" config user.email test@example.com
+  git -C "$repo_dir" config user.name test
+  printf '%s\n' '*.png filter=lfs diff=lfs merge=lfs -text' > "$repo_dir/.gitattributes"
+  printf '%s\n' 'exempt/*.png -filter -diff -merge -text' >> "$repo_dir/.gitattributes"
+}
+
+teardown() {
+  rm -rf "$repo_dir"
+}
+
+commit_all() {
+  git -C "$repo_dir" add -A
+  git -C "$repo_dir" commit -qm "$1"
+}
+
+@test "passes when every LFS-routed file is a pointer" {
+  pointer_content aaaa1111 > "$repo_dir/demo.png"
+  commit_all pointers
+
+  run bash -c 'cd "$1" && bash scripts/check-lfs-pointers.sh' _ "$repo_dir"
+
+  [ "$status" -eq 0 ]
+  [[ "$output" == *"are pointers"* ]]
+}
+
+@test "rejects a large full blob where a pointer is required" {
+  head -c 2048 /dev/zero > "$repo_dir/demo.png"
+  commit_all blob
+
+  run bash -c 'cd "$1" && bash scripts/check-lfs-pointers.sh' _ "$repo_dir"
+
+  [ "$status" -eq 1 ]
+  [[ "$output" == *"demo.png (2048-byte blob"* ]]
+}
+
+@test "rejects a small non-pointer blob where a pointer is required" {
+  printf 'tiny but real image bytes' > "$repo_dir/demo.png"
+  commit_all small-blob
+
+  run bash -c 'cd "$1" && bash scripts/check-lfs-pointers.sh' _ "$repo_dir"
+
+  [ "$status" -eq 1 ]
+  [[ "$output" == *"demo.png (small blob but not an LFS pointer)"* ]]
+}
+
+@test "ignores files whose LFS filter is unset by a later pattern" {
+  mkdir -p "$repo_dir/exempt"
+  head -c 2048 /dev/zero > "$repo_dir/exempt/icon.png"
+  commit_all exempt
+
+  run bash -c 'cd "$1" && bash scripts/check-lfs-pointers.sh' _ "$repo_dir"
+
+  [ "$status" -eq 0 ]
+}
+
+@test "ignores files not matched by any LFS pattern" {
+  head -c 2048 /dev/zero > "$repo_dir/data.bin"
+  commit_all unmatched
+
+  run bash -c 'cd "$1" && bash scripts/check-lfs-pointers.sh' _ "$repo_dir"
+
+  [ "$status" -eq 0 ]
+}
+
+@test "checks the requested rev, not the working tree" {
+  pointer_content bbbb2222 > "$repo_dir/demo.png"
+  commit_all pointer
+  head -c 2048 /dev/zero > "$repo_dir/demo.png"
+  commit_all blob
+
+  run bash -c 'cd "$1" && bash scripts/check-lfs-pointers.sh HEAD^' _ "$repo_dir"
+  [ "$status" -eq 0 ]
+
+  run bash -c 'cd "$1" && bash scripts/check-lfs-pointers.sh HEAD' _ "$repo_dir"
+  [ "$status" -eq 1 ]
+}
+
+@test "handles paths with spaces" {
+  mkdir -p "$repo_dir/docs img"
+  head -c 2048 /dev/zero > "$repo_dir/docs img/demo shot.png"
+  commit_all spaces
+
+  run bash -c 'cd "$1" && bash scripts/check-lfs-pointers.sh' _ "$repo_dir"
+
+  [ "$status" -eq 1 ]
+  [[ "$output" == *"docs img/demo shot.png"* ]]
+}


### PR DESCRIPTION
## Summary

Adds an `lfs-pointers` check to Fast Validation: every tracked file whose resolved `.gitattributes` filter attribute is `lfs` must be committed as an LFS pointer blob, never as full content.

## Why

Commits created without the LFS clean filter silently store the real binary as a regular git blob — permanent history bloat that GitHub happily accepts (only >100MB is blocked). Two realistic sources:

- **jj colocated checkouts** — jj bypasses git's clean/smudge filters entirely ([jj-vcs/jj#80](https://github.com/jj-vcs/jj/issues/80)), so any asset touched via jj commits as a full blob. We're evaluating jj for daily code work; this guard makes that experiment safe.
- Any clone with LFS uninstalled or `GIT_LFS_SKIP_SMUDGE`.

## Implementation

- `scripts/check-lfs-pointers.sh` — pure git plumbing: `git ls-tree | git check-attr --stdin -z filter` for attribute resolution (so `-filter` exemptions like the small fixture/icon PNGs are honored exactly as git resolves them), then `git cat-file` to verify each LFS-routed blob is ≤1024 bytes and starts with the canonical pointer header. Needs neither the `git-lfs` binary nor downloaded objects — CI checks out with `lfs: false` everywhere.
- Registered in `all_fast_validate_checks.sh` (`lint,conventions`), so it runs in the existing Fast Validation job.
- `test/bats/check-lfs-pointers.bats` — 7 cases: pointer pass, large/small full-blob rejection, `-filter` exemption, unmatched files, rev-vs-worktree, paths with spaces. Fixtures pin `GIT_CONFIG_GLOBAL=/dev/null` so a developer machine's globally-installed LFS filters can't clean the fixture blobs into real pointers.

## Validation

- `bats test/bats/check-lfs-pointers.bats` — 7/7
- `./scripts/all_fast_validate_checks.sh --only shellcheck,shell-portability,shell-sete,lfs-pointers` — all OK
- Against HEAD of this repo: all 30 LFS-tracked files verified as pointers
