### PR TITLE
docs(agents): direct Claude and Codex to use jj in colocated checkouts

### DIFF
--- a/.claude/settings.json
+++ b/.claude/settings.json
@@ -6,6 +6,12 @@
       "Bash(bun run test)",
       "Bash(bun run test -- --grep:*)",
       "Bash(bun install)",
+      "Bash(jj st)",
+      "Bash(jj status)",
+      "Bash(jj diff:*)",
+      "Bash(jj log:*)",
+      "Bash(jj show:*)",
+      "Bash(jj op log:*)",
       "mcp__auto-mobile__*"
     ]
   },

--- a/.gitignore
+++ b/.gitignore
@@ -48,6 +48,8 @@ docs/contributing.md
 /.cache
 .mcp.json
 .mcp.local.json
+.claude/settings.local.json
+CLAUDE.local.md
 *.pid
 *.pem
 # IntelliJ Platform Gradle plugin artifacts

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -124,6 +124,32 @@ The `systemTray` tool handles this automatically. See
 `com.android.systemui` nodes. Collapsed groups mark child text as
 not visible even though they are present in the shade.
 
+# Version Control: jj colocated checkouts
+
+If a `.jj/` directory exists at the repo root, this checkout is managed by
+jj (Jujutsu), colocated with git. Use jj for all history-mutating VCS work;
+plain `git` stays fine for read-only queries (`git log`, `git diff`, `gh`).
+
+- Do NOT run mutating git commands (`git commit`, `git rebase`, `git stash`,
+  `git checkout <branch>`) — they fight jj's working-copy snapshotting.
+- Command mapping: status `jj st` · diff `jj diff` · commit `jj commit -m`
+  (or `jj describe -m` + `jj new`) · amend `jj squash` · rebase
+  `jj rebase -d main` · undo anything `jj undo`.
+- PR flow: `jj bookmark create work/<name> -r @-`, then
+  `jj git push --allow-new --bookmark work/<name>`, then `gh pr create`
+  as usual. Update a PR by editing the change and `jj git push`.
+- Git hooks do not run under jj. Always run the relevant validation
+  commands (`turbo run lint build test`, `scripts/all_fast_validate_checks.sh`)
+  before pushing — nothing else will.
+- **Never add or modify binary assets** (images, video, fonts, archives —
+  anything `.gitattributes` routes through LFS) in a jj checkout: jj bypasses
+  git's LFS filters and would commit the full blob. `snapshot.auto-track`
+  leaves such files untracked on purpose; do not `jj file track` them. Do
+  asset work from a plain-git LFS-enabled clone. CI (`lfs-pointers` in Fast
+  Validation) rejects violations.
+- Do not create `git worktree`s of a jj checkout. For parallel work use
+  `jj workspace add ../<name>` instead.
+
 # Codex specific
 
 - GitHub interactions use the GitHub CLI (`gh`).

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -231,3 +231,29 @@ The `systemTray` tool handles this automatically. See
 `com.android.systemui` nodes. Collapsed groups mark child text nodes as
 not visible even though they are present in the shade. Without this bypass,
 notification text cannot be matched at all.
+
+# Version Control: jj colocated checkouts
+
+If a `.jj/` directory exists at the repo root, this checkout is managed by
+jj (Jujutsu), colocated with git. Use jj for all history-mutating VCS work;
+plain `git` stays fine for read-only queries (`git log`, `git diff`, `gh`).
+
+- Do NOT run mutating git commands (`git commit`, `git rebase`, `git stash`,
+  `git checkout <branch>`) — they fight jj's working-copy snapshotting.
+- Command mapping: status `jj st` · diff `jj diff` · commit `jj commit -m`
+  (or `jj describe -m` + `jj new`) · amend `jj squash` · rebase
+  `jj rebase -d main` · undo anything `jj undo`.
+- PR flow: `jj bookmark create work/<name> -r @-`, then
+  `jj git push --allow-new --bookmark work/<name>`, then `gh pr create`
+  as usual. Update a PR by editing the change and `jj git push`.
+- Git hooks do not run under jj. Always run the relevant validation
+  commands (`turbo run lint build test`, `scripts/all_fast_validate_checks.sh`)
+  before pushing — nothing else will.
+- **Never add or modify binary assets** (images, video, fonts, archives —
+  anything `.gitattributes` routes through LFS) in a jj checkout: jj bypasses
+  git's LFS filters and would commit the full blob. `snapshot.auto-track`
+  leaves such files untracked on purpose; do not `jj file track` them. Do
+  asset work from a plain-git LFS-enabled clone. CI (`lfs-pointers` in Fast
+  Validation) rejects violations.
+- Do not create `git worktree`s of a jj checkout. For parallel work use
+  `jj workspace add ../<name>` instead.


### PR DESCRIPTION
## Summary

Teaches both agent surfaces (Claude Code via `CLAUDE.md`, Codex via `AGENTS.md`) how to work in a jj (Jujutsu) colocated checkout, plus the supporting config.

Companion to #4953 (the `lfs-pointers` CI guard); together they make the jj evaluation safe for agent-driven work.

## Changes

- **`CLAUDE.md` + `AGENTS.md`**: identical new section "Version Control: jj colocated checkouts", gated on `.jj/` existing at the repo root — so it is inert in plain-git clones and worktrees. Covers: no mutating git commands under jj, a git→jj command mapping, the bookmark + `jj git push` + `gh pr create` PR flow, running validations explicitly (git hooks never fire under jj), the LFS hazard (never add/modify binary assets from a jj checkout; jj bypasses the LFS clean filter), and jj workspaces instead of `git worktree`.
- **`.claude/settings.json`**: allow read-only jj commands (`st`, `status`, `diff`, `log`, `show`, `op log`). Mutating commands and `jj git push` still prompt; broader grants belong in per-clone `settings.local.json`.
- **`.gitignore`**: add `.claude/settings.local.json` and `CLAUDE.local.md`. In a colocated clone jj auto-tracks new files, so without these entries local agent config would be silently snapshotted into commits.

## Validation

- `all_fast_validate_checks.sh --only codex-skills,claude-plugin,lychee,mkdocs-nav` — all OK
- `.claude/settings.json` parses
- Verified in the colocated eval clone: with the exclude entries present, a `settings.local.json` on disk leaves `jj st` clean
