### PR TITLE
feat(desktop): live device mirror in the workspace + farm-scale video pipeline

### DIFF
--- a/android/desktop-app/src/main/kotlin/dev/jasonpearson/automobile/desktop/AutoMobileDesktopApp.kt
+++ b/android/desktop-app/src/main/kotlin/dev/jasonpearson/automobile/desktop/AutoMobileDesktopApp.kt
@@ -31,6 +31,7 @@ import dev.jasonpearson.automobile.desktop.core.workspace.NavigationFacet
 import dev.jasonpearson.automobile.desktop.core.workspace.NetworkFacet
 import dev.jasonpearson.automobile.desktop.core.workspace.OnboardingScreen
 import dev.jasonpearson.automobile.desktop.core.workspace.PerformanceFacet
+import dev.jasonpearson.automobile.desktop.core.workspace.Platform
 import dev.jasonpearson.automobile.desktop.core.workspace.StorageFacet
 import dev.jasonpearson.automobile.desktop.core.workspace.Tool
 import dev.jasonpearson.automobile.desktop.core.workspace.WorkspaceAction
@@ -166,14 +167,15 @@ fun AutoMobileDesktopApp(
     }
   }
 
-  // Register + bind the session to the FOCUSED device. Stream auth then admits every pane: the
-  // focused device is owned by this session, and each other observed device is unowned (its
-  // subscribe passes the auth's unowned-device branch). Binding is idempotent and re-runs when the
-  // focus changes; a bind failure only means that pane shows the refusal reason. `boundDeviceId`
-  // tracks whether the session is actually registered with the daemon yet — the daemon creates a
-  // session lazily on the first tool call that carries its UUID (here, setActiveDevice), so a
-  // heartbeat before that would be rejected as "Session not found".
-  var boundDeviceId by remember(desktopDaemonSession) { mutableStateOf<String?>(null) }
+  // Register + bind the session to the FOCUSED device, then heartbeat it, then RE-register whenever
+  // the heartbeat detects the session died — which is exactly what a daemon restart looks like: the
+  // registry is wiped, so the stream sockets reject the (now-unknown) session until it is
+  // recreated.
+  // One loop owns the whole lifecycle so a restart self-heals: re-register (setActiveDevice lazily
+  // recreates the session under the same stable UUID) → the panes' auto-reconnect then
+  // re-subscribes
+  // successfully. Stream auth admits every pane: the focused device is owned by this session; each
+  // other observed device is unowned, so its subscribe passes the unowned-device branch.
   val focusedColumn =
     (workspaceState as? WorkspaceUiState.Content)?.let { content ->
       content.columns.firstOrNull { it.deviceId == content.focusedDeviceId }
@@ -182,23 +184,27 @@ fun AutoMobileDesktopApp(
     val session = desktopDaemonSession ?: return@LaunchedEffect
     val column = focusedColumn ?: return@LaunchedEffect
     val platform = if (column.platform == Platform.Ios) "ios" else "android"
-    runCatching {
-      withContext(Dispatchers.IO) { session.client.setActiveDevice(column.deviceId, platform) }
-    }
-      .onSuccess { boundDeviceId = column.deviceId }
-      .onFailure { LOG.warn("Failed to bind desktop session to ${column.deviceId}: ${it.message}") }
-  }
-
-  // Keep the session alive against the daemon's idle watchdog — but only once it is registered
-  // (bound), otherwise every heartbeat is a "Session not found" against a session the daemon has
-  // not created yet.
-  LaunchedEffect(desktopDaemonSession, boundDeviceId) {
-    val session = desktopDaemonSession ?: return@LaunchedEffect
-    if (boundDeviceId == null) return@LaunchedEffect
     while (isActive) {
-      delay(DESKTOP_SESSION_HEARTBEAT_MS)
-      runCatching { withContext(Dispatchers.IO) { session.heartbeat() } }
-        .onFailure { LOG.warn("Failed to refresh desktop daemon session: ${it.message}") }
+      val registered = runCatching {
+        withContext(Dispatchers.IO) { session.client.setActiveDevice(column.deviceId, platform) }
+      }
+        .onFailure {
+          LOG.warn("Failed to bind desktop session to ${column.deviceId}: ${it.message}")
+        }
+        .isSuccess
+      if (!registered) {
+        delay(DESKTOP_SESSION_HEARTBEAT_MS)
+        continue
+      }
+      // Registered: heartbeat until one fails, then fall through to re-register.
+      var alive = true
+      while (isActive && alive) {
+        delay(DESKTOP_SESSION_HEARTBEAT_MS)
+        alive =
+          runCatching { withContext(Dispatchers.IO) { session.heartbeat() } }
+            .onFailure { LOG.warn("Desktop daemon session lapsed, re-registering: ${it.message}") }
+            .isSuccess
+      }
     }
   }
 

--- a/android/desktop-app/src/main/kotlin/dev/jasonpearson/automobile/desktop/AutoMobileDesktopApp.kt
+++ b/android/desktop-app/src/main/kotlin/dev/jasonpearson/automobile/desktop/AutoMobileDesktopApp.kt
@@ -22,6 +22,7 @@ import dev.jasonpearson.automobile.desktop.core.settings.SettingsProvider
 import dev.jasonpearson.automobile.desktop.core.shell.MenuBarActions
 import dev.jasonpearson.automobile.desktop.core.workspace.CommandPalette
 import dev.jasonpearson.automobile.desktop.core.workspace.DeviceColumn
+import dev.jasonpearson.automobile.desktop.core.workspace.DeviceStreamView
 import dev.jasonpearson.automobile.desktop.core.workspace.FailuresFacet
 import dev.jasonpearson.automobile.desktop.core.workspace.LogsFacet
 import dev.jasonpearson.automobile.desktop.core.workspace.NavigationFacet
@@ -201,6 +202,11 @@ fun AutoMobileDesktopApp(
               status = workspaceStatus.status,
               statusDetail = workspaceStatus.detail,
               facetContent = { column, tool -> WorkspaceFacet(column, tool) },
+              // Live device mirror in each pane's stream area, fed by the daemon's video-stream
+              // relay. Until the desktop can supply a daemon sessionUuid (#4924), a daemon with
+              // stream-socket auth at its default (on, #4751) refuses the subscribe and the pane
+              // shows the reason; AUTOMOBILE_DAEMON_STREAM_AUTH=0 is the interim escape hatch.
+              streamContent = { column -> DeviceStreamView(column) },
             )
             if (paletteOpen) {
               CommandPalette(

--- a/android/desktop-app/src/main/kotlin/dev/jasonpearson/automobile/desktop/AutoMobileDesktopApp.kt
+++ b/android/desktop-app/src/main/kotlin/dev/jasonpearson/automobile/desktop/AutoMobileDesktopApp.kt
@@ -169,7 +169,11 @@ fun AutoMobileDesktopApp(
   // Register + bind the session to the FOCUSED device. Stream auth then admits every pane: the
   // focused device is owned by this session, and each other observed device is unowned (its
   // subscribe passes the auth's unowned-device branch). Binding is idempotent and re-runs when the
-  // focus changes; a bind failure only means that pane shows the refusal reason.
+  // focus changes; a bind failure only means that pane shows the refusal reason. `boundDeviceId`
+  // tracks whether the session is actually registered with the daemon yet — the daemon creates a
+  // session lazily on the first tool call that carries its UUID (here, setActiveDevice), so a
+  // heartbeat before that would be rejected as "Session not found".
+  var boundDeviceId by remember(desktopDaemonSession) { mutableStateOf<String?>(null) }
   val focusedColumn =
     (workspaceState as? WorkspaceUiState.Content)?.let { content ->
       content.columns.firstOrNull { it.deviceId == content.focusedDeviceId }
@@ -179,14 +183,18 @@ fun AutoMobileDesktopApp(
     val column = focusedColumn ?: return@LaunchedEffect
     val platform = if (column.platform == Platform.Ios) "ios" else "android"
     runCatching {
-        withContext(Dispatchers.IO) { session.client.setActiveDevice(column.deviceId, platform) }
-      }
+      withContext(Dispatchers.IO) { session.client.setActiveDevice(column.deviceId, platform) }
+    }
+      .onSuccess { boundDeviceId = column.deviceId }
       .onFailure { LOG.warn("Failed to bind desktop session to ${column.deviceId}: ${it.message}") }
   }
 
-  // Keep the session alive against the daemon's idle watchdog while the workspace is open.
-  LaunchedEffect(desktopDaemonSession) {
+  // Keep the session alive against the daemon's idle watchdog — but only once it is registered
+  // (bound), otherwise every heartbeat is a "Session not found" against a session the daemon has
+  // not created yet.
+  LaunchedEffect(desktopDaemonSession, boundDeviceId) {
     val session = desktopDaemonSession ?: return@LaunchedEffect
+    if (boundDeviceId == null) return@LaunchedEffect
     while (isActive) {
       delay(DESKTOP_SESSION_HEARTBEAT_MS)
       runCatching { withContext(Dispatchers.IO) { session.heartbeat() } }

--- a/android/desktop-app/src/main/kotlin/dev/jasonpearson/automobile/desktop/AutoMobileDesktopApp.kt
+++ b/android/desktop-app/src/main/kotlin/dev/jasonpearson/automobile/desktop/AutoMobileDesktopApp.kt
@@ -48,6 +48,7 @@ import dev.jasonpearson.automobile.desktop.core.workspace.picker.DevicePickerEff
 import dev.jasonpearson.automobile.desktop.core.workspace.picker.DevicePickerViewModel
 import dev.jasonpearson.automobile.desktop.core.workspace.picker.RealDeviceBootController
 import dev.jasonpearson.automobile.desktop.theme.AutoMobileTheme
+import java.util.concurrent.atomic.AtomicLong
 import kotlinx.coroutines.CancellationException
 import kotlinx.coroutines.CoroutineScope
 import kotlinx.coroutines.Dispatchers
@@ -56,6 +57,8 @@ import kotlinx.coroutines.cancel
 import kotlinx.coroutines.delay
 import kotlinx.coroutines.isActive
 import kotlinx.coroutines.launch
+import kotlinx.coroutines.sync.Mutex
+import kotlinx.coroutines.sync.withLock
 import kotlinx.coroutines.withContext
 
 private val LOG = LoggerFactory.getLogger("AutoMobileDesktopApp")
@@ -180,18 +183,31 @@ fun AutoMobileDesktopApp(
     (workspaceState as? WorkspaceUiState.Content)?.let { content ->
       content.columns.firstOrNull { it.deviceId == content.focusedDeviceId }
     }
+  // A focus change cancels this effect, but the cancellation cannot interrupt an in-flight
+  // synchronous setActiveDevice on Dispatchers.IO. Serialize binds through a mutex and gate each on
+  // a generation token so a stale bind that finishes after its replacement cannot leave the session
+  // pinned to the previously-focused device (mirrors AutoMobileContent's binding path).
+  val bindingMutex = remember(desktopDaemonSession) { Mutex() }
+  val bindingGeneration = remember(desktopDaemonSession) { AtomicLong(0L) }
   LaunchedEffect(desktopDaemonSession, focusedColumn?.deviceId, focusedColumn?.platform) {
     val session = desktopDaemonSession ?: return@LaunchedEffect
     val column = focusedColumn ?: return@LaunchedEffect
     val platform = if (column.platform == Platform.Ios) "ios" else "android"
+    val generation = bindingGeneration.incrementAndGet()
     while (isActive) {
       val registered = runCatching {
-        withContext(Dispatchers.IO) { session.client.setActiveDevice(column.deviceId, platform) }
+        bindingMutex.withLock {
+          // A newer focus superseded us while we waited for the lock — abandon quietly.
+          if (bindingGeneration.get() != generation) return@LaunchedEffect
+          withContext(Dispatchers.IO) { session.client.setActiveDevice(column.deviceId, platform) }
+        }
       }
         .onFailure {
           LOG.warn("Failed to bind desktop session to ${column.deviceId}: ${it.message}")
         }
         .isSuccess
+      // Do not keep or heartbeat a binding a newer focus already replaced.
+      if (bindingGeneration.get() != generation) return@LaunchedEffect
       if (!registered) {
         delay(DESKTOP_SESSION_HEARTBEAT_MS)
         continue

--- a/android/desktop-app/src/main/kotlin/dev/jasonpearson/automobile/desktop/AutoMobileDesktopApp.kt
+++ b/android/desktop-app/src/main/kotlin/dev/jasonpearson/automobile/desktop/AutoMobileDesktopApp.kt
@@ -5,6 +5,7 @@ import androidx.compose.foundation.layout.fillMaxSize
 import androidx.compose.material3.MaterialTheme
 import androidx.compose.material3.Surface
 import androidx.compose.runtime.Composable
+import androidx.compose.runtime.DisposableEffect
 import androidx.compose.runtime.LaunchedEffect
 import androidx.compose.runtime.collectAsState
 import androidx.compose.runtime.getValue
@@ -15,6 +16,7 @@ import androidx.compose.runtime.setValue
 import androidx.compose.ui.Modifier
 import dev.jasonpearson.automobile.desktop.core.connection.ConnectionState
 import dev.jasonpearson.automobile.desktop.core.daemon.AutoMobileClient
+import dev.jasonpearson.automobile.desktop.core.daemon.DesktopDaemonSession
 import dev.jasonpearson.automobile.desktop.core.di.LocalAutoMobileGraph
 import dev.jasonpearson.automobile.desktop.core.logging.LoggerFactory
 import dev.jasonpearson.automobile.desktop.core.mcp.DaemonMcpResourceClient
@@ -35,6 +37,7 @@ import dev.jasonpearson.automobile.desktop.core.workspace.WorkspaceAction
 import dev.jasonpearson.automobile.desktop.core.workspace.WorkspaceEffect
 import dev.jasonpearson.automobile.desktop.core.workspace.WorkspaceFacetPlaceholder
 import dev.jasonpearson.automobile.desktop.core.workspace.WorkspaceShell
+import dev.jasonpearson.automobile.desktop.core.workspace.WorkspaceUiState
 import dev.jasonpearson.automobile.desktop.core.workspace.WorkspaceViewModel
 import dev.jasonpearson.automobile.desktop.core.workspace.buildWorkspaceCommands
 import dev.jasonpearson.automobile.desktop.core.workspace.deriveWorkspaceStatus
@@ -45,11 +48,20 @@ import dev.jasonpearson.automobile.desktop.core.workspace.picker.DevicePickerVie
 import dev.jasonpearson.automobile.desktop.core.workspace.picker.RealDeviceBootController
 import dev.jasonpearson.automobile.desktop.theme.AutoMobileTheme
 import kotlinx.coroutines.CancellationException
+import kotlinx.coroutines.CoroutineScope
 import kotlinx.coroutines.Dispatchers
+import kotlinx.coroutines.SupervisorJob
+import kotlinx.coroutines.cancel
 import kotlinx.coroutines.delay
+import kotlinx.coroutines.isActive
+import kotlinx.coroutines.launch
 import kotlinx.coroutines.withContext
 
 private val LOG = LoggerFactory.getLogger("AutoMobileDesktopApp")
+
+// How often the workspace refreshes its daemon session so the idle watchdog does not reap it.
+// Matches AutoMobileContent's binding heartbeat cadence.
+private const val DESKTOP_SESSION_HEARTBEAT_MS = 2_000L
 
 // How often the top-bar status dot re-probes daemon connectivity. Matches the health sheet's
 // read-only refresh cadence (WorkspaceShell.HEALTH_SHEET_REFRESH_MS).
@@ -122,6 +134,65 @@ fun AutoMobileDesktopApp(
   var pickerOpen by remember { mutableStateOf(false) }
   var paletteOpen by remember { mutableStateOf(false) }
   var showOnboarding by remember { mutableStateOf(!settings.hasSeenOnboarding) }
+
+  // One stable daemon session per app run, used to authenticate the stream sockets (#4751/#4977).
+  // The stream socket's getSession check is read-only, so the session must first be REGISTERED by
+  // a main-socket tool call — done below by binding the focused device with setActiveDevice.
+  // Unix-daemon only; other transports leave it null and the panes fall back to the auth escape
+  // hatch. `getOrNull` so a construction failure (no reachable daemon) degrades to a null provider.
+  val desktopDaemonSession =
+    remember(graph) {
+      if (graph.autoMobileClient.transportName == "Unix Socket") {
+        runCatching { DesktopDaemonSession.create() }
+          .onFailure { LOG.warn("Could not create a desktop daemon session: ${it.message}") }
+          .getOrNull()
+      } else {
+        null
+      }
+    }
+  val sessionCleanupScope =
+    remember(desktopDaemonSession) {
+      desktopDaemonSession?.let { CoroutineScope(SupervisorJob() + Dispatchers.IO) }
+    }
+  DisposableEffect(desktopDaemonSession, sessionCleanupScope) {
+    onDispose {
+      if (desktopDaemonSession != null && sessionCleanupScope != null) {
+        sessionCleanupScope.launch {
+          runCatching { desktopDaemonSession.release() }
+            .onFailure { LOG.warn("Failed to release desktop daemon session: ${it.message}") }
+          sessionCleanupScope.cancel()
+        }
+      }
+    }
+  }
+
+  // Register + bind the session to the FOCUSED device. Stream auth then admits every pane: the
+  // focused device is owned by this session, and each other observed device is unowned (its
+  // subscribe passes the auth's unowned-device branch). Binding is idempotent and re-runs when the
+  // focus changes; a bind failure only means that pane shows the refusal reason.
+  val focusedColumn =
+    (workspaceState as? WorkspaceUiState.Content)?.let { content ->
+      content.columns.firstOrNull { it.deviceId == content.focusedDeviceId }
+    }
+  LaunchedEffect(desktopDaemonSession, focusedColumn?.deviceId, focusedColumn?.platform) {
+    val session = desktopDaemonSession ?: return@LaunchedEffect
+    val column = focusedColumn ?: return@LaunchedEffect
+    val platform = if (column.platform == Platform.Ios) "ios" else "android"
+    runCatching {
+        withContext(Dispatchers.IO) { session.client.setActiveDevice(column.deviceId, platform) }
+      }
+      .onFailure { LOG.warn("Failed to bind desktop session to ${column.deviceId}: ${it.message}") }
+  }
+
+  // Keep the session alive against the daemon's idle watchdog while the workspace is open.
+  LaunchedEffect(desktopDaemonSession) {
+    val session = desktopDaemonSession ?: return@LaunchedEffect
+    while (isActive) {
+      delay(DESKTOP_SESSION_HEARTBEAT_MS)
+      runCatching { withContext(Dispatchers.IO) { session.heartbeat() } }
+        .onFailure { LOG.warn("Failed to refresh desktop daemon session: ${it.message}") }
+    }
+  }
 
   // Window-level ⌘K/Ctrl+K (Main.kt) bumps openPaletteRequest; open the palette in response, but
   // only while the workspace is showing — onboarding and the device picker own the screen and have
@@ -203,10 +274,16 @@ fun AutoMobileDesktopApp(
               statusDetail = workspaceStatus.detail,
               facetContent = { column, tool -> WorkspaceFacet(column, tool) },
               // Live device mirror in each pane's stream area, fed by the daemon's video-stream
-              // relay. Until the desktop can supply a daemon sessionUuid (#4924), a daemon with
-              // stream-socket auth at its default (on, #4751) refuses the subscribe and the pane
-              // shows the reason; AUTOMOBILE_DAEMON_STREAM_AUTH=0 is the interim escape hatch.
-              streamContent = { column -> DeviceStreamView(column) },
+              // relay. The pane authenticates with the workspace daemon session (#4977) bound to
+              // the focused device above; when no session is available (non-Unix daemon, or the
+              // bind failed) the provider yields null and the pane shows the auth refusal, with
+              // AUTOMOBILE_DAEMON_STREAM_AUTH=0 as the operator escape hatch.
+              streamContent = { column ->
+                DeviceStreamView(
+                  column,
+                  sessionUuidProvider = desktopDaemonSession?.sessionUuidProvider ?: { null },
+                )
+              },
             )
             if (paletteOpen) {
               CommandPalette(

--- a/android/desktop-core/src/main/kotlin/dev/jasonpearson/automobile/desktop/core/AutoMobileContent.kt
+++ b/android/desktop-core/src/main/kotlin/dev/jasonpearson/automobile/desktop/core/AutoMobileContent.kt
@@ -166,6 +166,7 @@ import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.SupervisorJob
 import kotlinx.coroutines.cancel
 import kotlinx.coroutines.delay
+import kotlinx.coroutines.flow.collectLatest
 import kotlinx.coroutines.flow.conflate
 import kotlinx.coroutines.isActive
 import kotlinx.coroutines.launch
@@ -246,21 +247,26 @@ internal fun rememberLiveVideoFrame(
 
   LaunchedEffect(source, deviceId, autoReconnect) {
     if (source == null) return@LaunchedEffect
-    var backoffMs = reconnectInitialMs
-    source.state.collect { state ->
-      when (state) {
-        is VideoStreamState.Streaming -> backoffMs = LIVE_RECONNECT_INITIAL_MS
-        is VideoStreamState.Unavailable -> {
-          liveFrame = null
-          if (autoReconnect && deviceId != null) {
-            // Cancelled by composition disposal, so a torn-down pane never reconnects. connect()
-            // no-ops while a reader is already active, so a spurious retry cannot double-subscribe.
+    // collectLatest (not collect) is load-bearing for the retry: when the socket is absent,
+    // connect() re-assigns the SAME Unavailable value, which MutableStateFlow suppresses — so a
+    // plain collector would receive no further event and retry only once. Under collectLatest the
+    // per-state block below is cancelled only by a genuine transition (Connecting/Streaming after
+    // a successful connect, or disposal), so a stuck-Unavailable stream keeps retrying on its own
+    // timer while a recovered one stops cleanly.
+    source.state.collectLatest { state ->
+      if (state is VideoStreamState.Unavailable) {
+        liveFrame = null
+        if (autoReconnect && deviceId != null) {
+          var backoffMs = reconnectInitialMs
+          while (isActive) {
+            // Cancelled by composition disposal or a real state change, so a torn-down or
+            // recovered pane stops. connect() no-ops while a reader is already active, so a
+            // spurious retry cannot double-subscribe.
             delay(backoffMs)
             backoffMs = (backoffMs * 2).coerceAtMost(LIVE_RECONNECT_MAX_MS)
             source.connect(deviceId)
           }
         }
-        else -> {}
       }
     }
   }

--- a/android/desktop-core/src/main/kotlin/dev/jasonpearson/automobile/desktop/core/AutoMobileContent.kt
+++ b/android/desktop-core/src/main/kotlin/dev/jasonpearson/automobile/desktop/core/AutoMobileContent.kt
@@ -201,6 +201,10 @@ internal fun isActiveDeviceStreamFrame(deviceId: String?, activeDeviceId: String
  * into that policy, which decides on frame *provenance* rather than on dimensions.
  */
 
+/** Reconnect backoff bounds for [rememberLiveVideoFrame] when [autoReconnect] is on. */
+internal const val LIVE_RECONNECT_INITIAL_MS = 1_000L
+internal const val LIVE_RECONNECT_MAX_MS = 15_000L
+
 /**
  * Connects a live-mirroring source for this composition and exposes only its newest frame.
  *
@@ -208,11 +212,19 @@ internal fun isActiveDeviceStreamFrame(deviceId: String?, activeDeviceId: String
  * thread (issues #3348/#4786) — so this only conflates to the newest and gates on the stream state:
  * a frame that raced the relay's death must not restore a dead mirror. A refused or unavailable
  * relay clears the frame, allowing [DeviceScreenView] to continue rendering screenshot updates.
+ *
+ * With [autoReconnect] on, an `Unavailable` state (relay dropped, "Live mirroring stopped", or a
+ * transient subscribe rejection while the daemon session re-registers) triggers a bounded
+ * exponential-backoff [VideoStreamSource.connect] retry rather than staying dead until the pane is
+ * torn down and rebuilt. Off (the default) preserves the original clear-and-stop behavior for the
+ * IDE-plugin/`AutoMobileContent` path, which blends in screenshot updates instead.
  */
 @Composable
 internal fun rememberLiveVideoFrame(
   source: VideoStreamSource?,
   deviceId: String?,
+  autoReconnect: Boolean = false,
+  reconnectInitialMs: Long = LIVE_RECONNECT_INITIAL_MS,
 ): LiveVideoFrame? {
   var liveFrame by remember(source, deviceId) { mutableStateOf<LiveVideoFrame?>(null) }
 
@@ -232,9 +244,24 @@ internal fun rememberLiveVideoFrame(
     }
   }
 
-  LaunchedEffect(source) {
-    source?.state?.collect { state ->
-      if (state is VideoStreamState.Unavailable) liveFrame = null
+  LaunchedEffect(source, deviceId, autoReconnect) {
+    if (source == null) return@LaunchedEffect
+    var backoffMs = reconnectInitialMs
+    source.state.collect { state ->
+      when (state) {
+        is VideoStreamState.Streaming -> backoffMs = LIVE_RECONNECT_INITIAL_MS
+        is VideoStreamState.Unavailable -> {
+          liveFrame = null
+          if (autoReconnect && deviceId != null) {
+            // Cancelled by composition disposal, so a torn-down pane never reconnects. connect()
+            // no-ops while a reader is already active, so a spurious retry cannot double-subscribe.
+            delay(backoffMs)
+            backoffMs = (backoffMs * 2).coerceAtMost(LIVE_RECONNECT_MAX_MS)
+            source.connect(deviceId)
+          }
+        }
+        else -> {}
+      }
     }
   }
 

--- a/android/desktop-core/src/main/kotlin/dev/jasonpearson/automobile/desktop/core/AutoMobileContent.kt
+++ b/android/desktop-core/src/main/kotlin/dev/jasonpearson/automobile/desktop/core/AutoMobileContent.kt
@@ -157,7 +157,6 @@ import dev.jasonpearson.automobile.desktop.core.video.LiveVideoFrame
 import dev.jasonpearson.automobile.desktop.core.video.VideoStreamClient
 import dev.jasonpearson.automobile.desktop.core.video.VideoStreamSource
 import dev.jasonpearson.automobile.desktop.core.video.VideoStreamState
-import dev.jasonpearson.automobile.desktop.core.video.toImageBitmap
 import dev.jasonpearson.automobile.desktop.domain.DeviceControlDecision
 import dev.jasonpearson.automobile.desktop.domain.DeviceControlInputs
 import dev.jasonpearson.automobile.desktop.domain.DeviceScreenControlMode
@@ -203,30 +202,19 @@ internal fun isActiveDeviceStreamFrame(deviceId: String?, activeDeviceId: String
  */
 
 /**
- * Connects a live-mirroring source for this composition and exposes only its newest decoded frame.
+ * Connects a live-mirroring source for this composition and exposes only its newest frame.
  *
- * The source already drops old decoded frames; conflation here also prevents Compose conversion
- * from accumulating work when the relay runs faster than the UI can draw. A refused or unavailable
+ * Frames arrive ready to draw — the client converts, sequences, and timestamps them on its reader
+ * thread (issues #3348/#4786) — so this only conflates to the newest and gates on the stream state:
+ * a frame that raced the relay's death must not restore a dead mirror. A refused or unavailable
  * relay clears the frame, allowing [DeviceScreenView] to continue rendering screenshot updates.
  */
 @Composable
 internal fun rememberLiveVideoFrame(
   source: VideoStreamSource?,
   deviceId: String?,
-  nowMs: () -> Long = MONOTONIC_NOW_MS,
-  frameConverter:
-    suspend (
-      dev.jasonpearson.automobile.desktop.core.video.DecodedFrame
-    ) -> androidx.compose.ui.graphics.ImageBitmap =
-    { frame ->
-      withContext(Dispatchers.Default) { frame.toImageBitmap() }
-    },
 ): LiveVideoFrame? {
   var liveFrame by remember(source, deviceId) { mutableStateOf<LiveVideoFrame?>(null) }
-  // Monotonic per (source, deviceId): identifies which decoded frame is on screen so a stalled
-  // relay — which keeps its socket, its Streaming state and its last bitmap — is distinguishable
-  // from a live one (issue #3348).
-  val frameSequence = remember(source, deviceId) { java.util.concurrent.atomic.AtomicLong(0L) }
 
   DisposableEffect(source, deviceId) {
     if (source != null && deviceId != null) source.connect(deviceId)
@@ -239,18 +227,7 @@ internal fun rememberLiveVideoFrame(
   LaunchedEffect(source) {
     source?.frames?.conflate()?.collect { frame ->
       if (source.state.value is VideoStreamState.Streaming) {
-        val decodedFrame = frameConverter(frame)
-        if (source.state.value is VideoStreamState.Streaming) {
-          liveFrame =
-            LiveVideoFrame(
-              bitmap = decodedFrame,
-              sequence = frameSequence.incrementAndGet(),
-              receivedAtMs = nowMs(),
-              // The stream's config packets attest the display rotation; carrying it here lets
-              // DeviceControlSession re-prove orientation from the live frame alone (issue #4786).
-              rotation = frame.rotation,
-            )
-        }
+        liveFrame = frame
       }
     }
   }
@@ -810,7 +787,7 @@ fun AutoMobileContent(
         null
       }
     }
-  val liveVideoFrame = rememberLiveVideoFrame(liveVideoSource, activeDeviceId, MONOTONIC_NOW_MS)
+  val liveVideoFrame = rememberLiveVideoFrame(liveVideoSource, activeDeviceId)
   // Forces the control-availability decision to be re-evaluated on a timer, not only when an
   // observation source produces an update (issue #3348). A stalled observation stream produces
   // nothing at all — its staleness is visible only as time passing — so without this a frozen

--- a/android/desktop-core/src/main/kotlin/dev/jasonpearson/automobile/desktop/core/video/H264Decoder.kt
+++ b/android/desktop-core/src/main/kotlin/dev/jasonpearson/automobile/desktop/core/video/H264Decoder.kt
@@ -63,6 +63,10 @@ class H264Decoder : AutoCloseable {
   private var scaledHeight = 0
   private var closed = false
 
+  // Reused across frames (reallocated only on a size change) so a long-running stream
+  // allocates nothing per frame — this is why DecodedFrame is only valid during onFrame.
+  private var out = ByteArray(0)
+
   init {
     if (avcodec.avcodec_open2(context, codec, null as PointerPointer<*>?) < 0) {
       close()
@@ -189,7 +193,9 @@ class H264Decoder : AutoCloseable {
 
     val stride = bgraFrame.linesize(0)
     val rowBytes = width * 4
-    val out = ByteArray(rowBytes * height)
+    if (out.size != rowBytes * height) {
+      out = ByteArray(rowBytes * height)
+    }
     val plane = bgraFrame.data(0)
     if (stride == rowBytes) {
       plane.position(0).get(out, 0, out.size)

--- a/android/desktop-core/src/main/kotlin/dev/jasonpearson/automobile/desktop/core/video/VideoStreamClient.kt
+++ b/android/desktop-core/src/main/kotlin/dev/jasonpearson/automobile/desktop/core/video/VideoStreamClient.kt
@@ -52,9 +52,12 @@ sealed class VideoStreamState {
 
 /**
  * Resolution/bitrate preset for a subscription, matching the daemon relay's `quality` hint (and,
- * transitively, the on-device `QualityPreset`): the capture's LONGER dimension is capped at
- * 540/720/1080 with the other side scaled proportionally. Lower presets shrink decode cost
- * quadratically, which is what makes dozens of concurrent farm panes affordable.
+ * transitively, the on-device `QualityPreset`): on Android the capture's LONGER dimension is capped
+ * at 540/720/1080 with the other side scaled proportionally; iOS honors the preset's bitrate but
+ * self-scales resolution to Level 4.2. Lower presets shrink decode cost quadratically, which is
+ * what makes dozens of concurrent farm panes affordable. Captures are shared per device on the
+ * daemon: the FIRST subscriber's hints fix the encode, and a late joiner's differing preset is
+ * ignored.
  */
 enum class VideoStreamQuality(internal val wire: String) {
   Low("low"),
@@ -170,7 +173,12 @@ class VideoStreamClient(
     }
 
     _state.value = VideoStreamState.Connecting
-    readerJob = scope.launch { runSession(deviceId) }
+    readerJob = scope.launch {
+      // Name the dedicated thread per target so a farm's dozens of readers are tellable
+      // apart in a thread dump.
+      Thread.currentThread().name = "video-stream-reader-${deviceId ?: "default"}"
+      runSession(deviceId)
+    }
   }
 
   override fun disconnect() {

--- a/android/desktop-core/src/main/kotlin/dev/jasonpearson/automobile/desktop/core/video/VideoStreamClient.kt
+++ b/android/desktop-core/src/main/kotlin/dev/jasonpearson/automobile/desktop/core/video/VideoStreamClient.kt
@@ -14,9 +14,9 @@ import java.nio.charset.StandardCharsets
 import java.nio.file.Files
 import java.util.UUID
 import kotlinx.coroutines.CoroutineScope
-import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.Job
 import kotlinx.coroutines.SupervisorJob
+import kotlinx.coroutines.asCoroutineDispatcher
 import kotlinx.coroutines.channels.BufferOverflow
 import kotlinx.coroutines.flow.MutableSharedFlow
 import kotlinx.coroutines.flow.MutableStateFlow
@@ -50,9 +50,21 @@ sealed class VideoStreamState {
   data class Unavailable(val reason: String) : VideoStreamState()
 }
 
+/**
+ * Resolution/bitrate preset for a subscription, matching the daemon relay's `quality` hint (and,
+ * transitively, the on-device `QualityPreset`): the capture's LONGER dimension is capped at
+ * 540/720/1080 with the other side scaled proportionally. Lower presets shrink decode cost
+ * quadratically, which is what makes dozens of concurrent farm panes affordable.
+ */
+enum class VideoStreamQuality(internal val wire: String) {
+  Low("low"),
+  Medium("medium"),
+  High("high"),
+}
+
 /** A live view of a device's screen. */
 interface VideoStreamSource {
-  val frames: SharedFlow<DecodedFrame>
+  val frames: SharedFlow<LiveVideoFrame>
   val state: StateFlow<VideoStreamState>
 
   fun connect(deviceId: String?)
@@ -79,11 +91,17 @@ fun DecodedFrame.toImageBitmap(): ImageBitmap =
  * Streams a device's screen from `~/.auto-mobile/video-stream.sock` and decodes it to frames.
  *
  * The handshake is one JSON line each way; everything after is the binary framing handled by
- * [VideoStreamParser]. Decoding happens on the reader thread, which is deliberate: it applies
- * backpressure to the socket rather than letting undecoded packets pile up in memory.
+ * [VideoStreamParser]. Decoding AND bitmap conversion happen on the reader thread, which is
+ * deliberate: it applies backpressure to the socket rather than letting undecoded packets pile up
+ * in memory, and it keeps the per-frame work off the UI's dispatchers entirely. The reader is a
+ * dedicated per-client thread rather than a `Dispatchers.IO` slot so a farm of dozens of streams
+ * cannot exhaust the shared 64-thread IO pool for every other IO consumer in the process.
  *
- * [frames] drops the oldest frame when a collector falls behind. For live video a stale frame is
- * worthless, and an unbounded buffer would trade latency for memory and lose on both.
+ * [frames] carries ready-to-draw [LiveVideoFrame]s (immutable Skia rasters — no tearing, no
+ * consumer-side conversion) and drops the oldest when a collector falls behind. For live video a
+ * stale frame is worthless, and an unbounded buffer would trade latency for memory and lose on
+ * both. Steady-state the pipeline allocates no JVM-heap frame buffers: the decoder reuses its BGRA
+ * buffer and the only per-frame cost is the native raster copy inside [toImageBitmap].
  */
 class VideoStreamClient(
   private val socketPathValue: String = AutoMobileSocketPaths.socketPath(VIDEO_STREAM_SOCKET_FILE),
@@ -104,17 +122,37 @@ class VideoStreamClient(
    * `DesktopDaemonSession` for Unix-daemon connections.
    */
   private val sessionUuidProvider: () -> String? = { null },
+  /** Resolution/bitrate preset hint sent on subscribe; null keeps the capture's default. */
+  private val quality: VideoStreamQuality? = null,
+  /** Capture frame-rate hint sent on subscribe; null keeps the relay's pinned default. */
+  private val fps: Int? = null,
+  /** Encoder bitrate hint (kbps) sent on subscribe; null keeps the preset's default. */
+  private val bitrateKbps: Int? = null,
+  /**
+   * Monotonic clock stamping [LiveVideoFrame.receivedAtMs]. Must share a time base with the
+   * consumer-side freshness checks (`MONOTONIC_NOW_MS`, issue #3348), hence the same
+   * `System.nanoTime()` source by default; injectable for deterministic tests.
+   */
+  private val nowMs: () -> Long = { System.nanoTime() / 1_000_000L },
 ) : VideoStreamSource {
 
-  private val scope = CoroutineScope(SupervisorJob() + Dispatchers.IO)
+  // One dedicated reader thread per client (see the class doc for why not Dispatchers.IO).
+  private val readerDispatcher =
+    java.util.concurrent.Executors.newSingleThreadExecutor { runnable ->
+        Thread(runnable, "video-stream-reader").apply { isDaemon = true }
+      }
+      .asCoroutineDispatcher()
+  private val scope = CoroutineScope(SupervisorJob() + readerDispatcher)
+
+  private val frameSequence = java.util.concurrent.atomic.AtomicLong(0L)
 
   private val _frames =
-    MutableSharedFlow<DecodedFrame>(
+    MutableSharedFlow<LiveVideoFrame>(
       replay = 1,
       extraBufferCapacity = 2,
       onBufferOverflow = BufferOverflow.DROP_OLDEST,
     )
-  override val frames: SharedFlow<DecodedFrame> = _frames.asSharedFlow()
+  override val frames: SharedFlow<LiveVideoFrame> = _frames.asSharedFlow()
 
   private val _state = MutableStateFlow<VideoStreamState>(VideoStreamState.Idle)
   override val state: StateFlow<VideoStreamState> = _state.asStateFlow()
@@ -146,6 +184,7 @@ class VideoStreamClient(
   override fun dispose() {
     disconnect()
     scope.coroutineContext[Job]?.cancel()
+    readerDispatcher.close()
   }
 
   private fun runSession(deviceId: String?) {
@@ -174,6 +213,9 @@ class VideoStreamClient(
               id = UUID.randomUUID().toString(),
               sessionUuid = sessionUuidProvider(),
               deviceId = deviceId,
+              quality = quality?.wire,
+              fps = fps,
+              bitrateKbps = bitrateKbps,
             ),
           )
         )
@@ -253,9 +295,20 @@ class VideoStreamClient(
               // device rotation.
               _state.value = VideoStreamState.Streaming(frame.width, frame.height)
             }
-            // The decoder reuses its buffer, so the frame must be copied before it leaves here.
+            // Present here, on the reader thread, while the decoder's reused buffer is valid:
+            // the immutable raster produced by toImageBitmap is the only per-frame copy, and
+            // consumers receive a ready-to-draw frame with no conversion (or allocation) of
+            // their own.
             _frames.tryEmit(
-              DecodedFrame(frame.width, frame.height, frame.bgra.copyOf(), currentRotation)
+              LiveVideoFrame(
+                bitmap = frame.toImageBitmap(),
+                sequence = frameSequence.incrementAndGet(),
+                receivedAtMs = nowMs(),
+                // The stream's config packets attest the display rotation; carrying it here
+                // lets DeviceControlSession re-prove orientation from the live frame alone
+                // (issue #4786).
+                rotation = currentRotation,
+              )
             )
           }
         },
@@ -284,6 +337,12 @@ internal data class VideoStreamRequest(
    */
   val sessionUuid: String? = null,
   val deviceId: String? = null,
+  /** Resolution/bitrate preset hint (`low`/`medium`/`high`); see [VideoStreamQuality]. */
+  val quality: String? = null,
+  /** Capture frame-rate hint; the relay pins its own default when omitted. */
+  val fps: Int? = null,
+  /** Encoder bitrate hint in kbps; the preset's default applies when omitted. */
+  val bitrateKbps: Int? = null,
 )
 
 @Serializable
@@ -300,14 +359,17 @@ internal data class VideoStreamResponse(
 class FakeVideoStreamSource(
   private val available: Boolean = true,
   private val refuseWith: String? = null,
+  private val nowMs: () -> Long = { 0L },
 ) : VideoStreamSource {
+  private val fakeSequence = java.util.concurrent.atomic.AtomicLong(0L)
+
   private val _frames =
-    MutableSharedFlow<DecodedFrame>(
+    MutableSharedFlow<LiveVideoFrame>(
       replay = 1,
       extraBufferCapacity = 2,
       onBufferOverflow = BufferOverflow.DROP_OLDEST,
     )
-  override val frames: SharedFlow<DecodedFrame> = _frames.asSharedFlow()
+  override val frames: SharedFlow<LiveVideoFrame> = _frames.asSharedFlow()
 
   private val _state = MutableStateFlow<VideoStreamState>(VideoStreamState.Idle)
   override val state: StateFlow<VideoStreamState> = _state.asStateFlow()
@@ -341,8 +403,15 @@ class FakeVideoStreamSource(
     _state.value = VideoStreamState.Unavailable(reason)
   }
 
-  /** Publishes a frame to collectors, as the real client would. */
+  /** Publishes a ready-to-draw frame to collectors, as the real client would. */
   fun emitFrame(width: Int = 1080, height: Int = 2400, rotation: Int? = null) {
-    _frames.tryEmit(DecodedFrame(width, height, ByteArray(width * height * 4), rotation))
+    _frames.tryEmit(
+      LiveVideoFrame(
+        bitmap = ImageBitmap(width, height),
+        sequence = fakeSequence.incrementAndGet(),
+        receivedAtMs = nowMs(),
+        rotation = rotation,
+      )
+    )
   }
 }

--- a/android/desktop-core/src/main/kotlin/dev/jasonpearson/automobile/desktop/core/workspace/DeviceStreamView.kt
+++ b/android/desktop-core/src/main/kotlin/dev/jasonpearson/automobile/desktop/core/workspace/DeviceStreamView.kt
@@ -40,10 +40,11 @@ import dev.jasonpearson.automobile.desktop.core.video.VideoStreamState
 @Composable
 fun DeviceStreamView(
   column: DeviceColumn,
-  // Workspace panes default to the `low` preset (long side capped at 540, ~2 Mbps): pane real
-  // estate can't show more pixels than that anyway, and decode cost scales with pixel count, which
-  // is what makes dozens of concurrent farm panes affordable. Hoisted so a host that wants a
-  // full-resolution mirror can pass VideoStreamQuality.High or a different source entirely.
+  // Workspace panes default to the `low` preset (Android: long side capped at 540 + ~2 Mbps;
+  // iOS: ~2 Mbps, resolution self-scales to Level 4.2): pane real estate can't show more pixels
+  // than that anyway, and decode cost scales with pixel count, which is what makes dozens of
+  // concurrent farm panes affordable. Hoisted so a host that wants a full-resolution mirror can
+  // pass VideoStreamQuality.High or a different source entirely.
   sourceFactory: (deviceId: String) -> VideoStreamSource = {
     VideoStreamClient(quality = VideoStreamQuality.Low)
   },

--- a/android/desktop-core/src/main/kotlin/dev/jasonpearson/automobile/desktop/core/workspace/DeviceStreamView.kt
+++ b/android/desktop-core/src/main/kotlin/dev/jasonpearson/automobile/desktop/core/workspace/DeviceStreamView.kt
@@ -54,7 +54,10 @@ fun DeviceStreamView(
   },
 ) {
   val source = remember(column.deviceId) { sourceFactory(column.deviceId) }
-  val liveFrame = rememberLiveVideoFrame(source, column.deviceId)
+  // Farm panes auto-reconnect: a dropped relay or a subscribe rejected while the workspace daemon
+  // session re-registers (e.g. after a daemon restart) heals itself instead of staying "stopped"
+  // until the pane is torn down.
+  val liveFrame = rememberLiveVideoFrame(source, column.deviceId, autoReconnect = true)
   val state by source.state.collectAsState()
   Box(Modifier.fillMaxSize(), contentAlignment = Alignment.Center) {
     val bitmap = liveFrame?.bitmap

--- a/android/desktop-core/src/main/kotlin/dev/jasonpearson/automobile/desktop/core/workspace/DeviceStreamView.kt
+++ b/android/desktop-core/src/main/kotlin/dev/jasonpearson/automobile/desktop/core/workspace/DeviceStreamView.kt
@@ -31,22 +31,26 @@ import dev.jasonpearson.automobile.desktop.core.video.VideoStreamState
  * disposes it when the pane leaves the composition, so closing a column or flipping it to Inspect
  * mode tears the relay subscription down.
  *
- * [sourceFactory] is hoisted so tests inject a fake instead of opening a socket. The default real
- * client sends no `sessionUuid` yet (#4924 tracks the desktop session-identity design); until that
- * lands, a daemon enforcing stream-socket auth (#4751, on by default) refuses the subscribe and
- * this pane shows the refusal reason — the interim operator escape hatch is
- * `AUTOMOBILE_DAEMON_STREAM_AUTH=0`.
+ * [sessionUuidProvider] authenticates the subscribe against the stream-socket session guard
+ * (#4751): the host supplies a provider from its `DesktopDaemonSession` (#4977). The workspace
+ * session binds only the focused device, so this pane's subscribe passes either as the session's
+ * own device or — for every other observed device — via the auth's unowned-device branch. When the
+ * provider yields null (no session, or a non-Unix daemon) the subscribe is refused and the pane
+ * shows the reason; the operator escape hatch remains `AUTOMOBILE_DAEMON_STREAM_AUTH=0`.
+ *
+ * [sourceFactory] is hoisted so tests inject a fake instead of opening a socket.
  */
 @Composable
 fun DeviceStreamView(
   column: DeviceColumn,
+  sessionUuidProvider: () -> String? = { null },
   // Workspace panes default to the `low` preset (Android: long side capped at 540 + ~2 Mbps;
   // iOS: ~2 Mbps, resolution self-scales to Level 4.2): pane real estate can't show more pixels
   // than that anyway, and decode cost scales with pixel count, which is what makes dozens of
   // concurrent farm panes affordable. Hoisted so a host that wants a full-resolution mirror can
   // pass VideoStreamQuality.High or a different source entirely.
   sourceFactory: (deviceId: String) -> VideoStreamSource = {
-    VideoStreamClient(quality = VideoStreamQuality.Low)
+    VideoStreamClient(quality = VideoStreamQuality.Low, sessionUuidProvider = sessionUuidProvider)
   },
 ) {
   val source = remember(column.deviceId) { sourceFactory(column.deviceId) }

--- a/android/desktop-core/src/main/kotlin/dev/jasonpearson/automobile/desktop/core/workspace/DeviceStreamView.kt
+++ b/android/desktop-core/src/main/kotlin/dev/jasonpearson/automobile/desktop/core/workspace/DeviceStreamView.kt
@@ -17,6 +17,7 @@ import androidx.compose.ui.text.style.TextAlign
 import androidx.compose.ui.unit.dp
 import dev.jasonpearson.automobile.desktop.core.rememberLiveVideoFrame
 import dev.jasonpearson.automobile.desktop.core.video.VideoStreamClient
+import dev.jasonpearson.automobile.desktop.core.video.VideoStreamQuality
 import dev.jasonpearson.automobile.desktop.core.video.VideoStreamSource
 import dev.jasonpearson.automobile.desktop.core.video.VideoStreamState
 
@@ -39,7 +40,13 @@ import dev.jasonpearson.automobile.desktop.core.video.VideoStreamState
 @Composable
 fun DeviceStreamView(
   column: DeviceColumn,
-  sourceFactory: (deviceId: String) -> VideoStreamSource = { VideoStreamClient() },
+  // Workspace panes default to the `low` preset (long side capped at 540, ~2 Mbps): pane real
+  // estate can't show more pixels than that anyway, and decode cost scales with pixel count, which
+  // is what makes dozens of concurrent farm panes affordable. Hoisted so a host that wants a
+  // full-resolution mirror can pass VideoStreamQuality.High or a different source entirely.
+  sourceFactory: (deviceId: String) -> VideoStreamSource = {
+    VideoStreamClient(quality = VideoStreamQuality.Low)
+  },
 ) {
   val source = remember(column.deviceId) { sourceFactory(column.deviceId) }
   val liveFrame = rememberLiveVideoFrame(source, column.deviceId)

--- a/android/desktop-core/src/main/kotlin/dev/jasonpearson/automobile/desktop/core/workspace/DeviceStreamView.kt
+++ b/android/desktop-core/src/main/kotlin/dev/jasonpearson/automobile/desktop/core/workspace/DeviceStreamView.kt
@@ -1,0 +1,79 @@
+package dev.jasonpearson.automobile.desktop.core.workspace
+
+import androidx.compose.foundation.Image
+import androidx.compose.foundation.layout.Box
+import androidx.compose.foundation.layout.fillMaxSize
+import androidx.compose.foundation.layout.padding
+import androidx.compose.material3.MaterialTheme
+import androidx.compose.material3.Text
+import androidx.compose.runtime.Composable
+import androidx.compose.runtime.collectAsState
+import androidx.compose.runtime.getValue
+import androidx.compose.runtime.remember
+import androidx.compose.ui.Alignment
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.layout.ContentScale
+import androidx.compose.ui.text.style.TextAlign
+import androidx.compose.ui.unit.dp
+import dev.jasonpearson.automobile.desktop.core.rememberLiveVideoFrame
+import dev.jasonpearson.automobile.desktop.core.video.VideoStreamClient
+import dev.jasonpearson.automobile.desktop.core.video.VideoStreamSource
+import dev.jasonpearson.automobile.desktop.core.video.VideoStreamState
+
+/**
+ * Live device mirror for a workspace pane's stream area: subscribes to the daemon's video-stream
+ * relay for this pane's device and draws the newest decoded frame, aspect-fit. Until a frame
+ * arrives (or when the relay is refused/unavailable) a one-line status hint renders instead, so a
+ * daemon without the relay degrades to a quiet placeholder rather than an error wall.
+ *
+ * One source lives per pane, keyed by deviceId: [rememberLiveVideoFrame] connects it on entry and
+ * disposes it when the pane leaves the composition, so closing a column or flipping it to Inspect
+ * mode tears the relay subscription down.
+ *
+ * [sourceFactory] is hoisted so tests inject a fake instead of opening a socket. The default real
+ * client sends no `sessionUuid` yet (#4924 tracks the desktop session-identity design); until that
+ * lands, a daemon enforcing stream-socket auth (#4751, on by default) refuses the subscribe and
+ * this pane shows the refusal reason — the interim operator escape hatch is
+ * `AUTOMOBILE_DAEMON_STREAM_AUTH=0`.
+ */
+@Composable
+fun DeviceStreamView(
+  column: DeviceColumn,
+  sourceFactory: (deviceId: String) -> VideoStreamSource = { VideoStreamClient() },
+) {
+  val source = remember(column.deviceId) { sourceFactory(column.deviceId) }
+  val liveFrame = rememberLiveVideoFrame(source, column.deviceId)
+  val state by source.state.collectAsState()
+  Box(Modifier.fillMaxSize(), contentAlignment = Alignment.Center) {
+    val bitmap = liveFrame?.bitmap
+    if (bitmap != null) {
+      Image(
+        bitmap = bitmap,
+        contentDescription = "Live stream of ${column.name}",
+        modifier = Modifier.fillMaxSize(),
+        contentScale = ContentScale.Fit,
+      )
+    } else {
+      Text(
+        streamStatusHint(state),
+        color = MaterialTheme.colorScheme.outline,
+        style = MaterialTheme.typography.bodySmall,
+        textAlign = TextAlign.Center,
+        modifier = Modifier.padding(12.dp),
+      )
+    }
+  }
+}
+
+/**
+ * One-line hint for a stream that has no frame on screen. `internal` (not `private`) so the
+ * same-module pure test can pin the wording without composing the view.
+ */
+internal fun streamStatusHint(state: VideoStreamState): String =
+  when (state) {
+    is VideoStreamState.Idle -> "Live mirror idle"
+    is VideoStreamState.Connecting -> "Connecting to live mirror…"
+    // Streaming with no frame yet: the subscribe was accepted but nothing has decoded.
+    is VideoStreamState.Streaming -> "Waiting for the first frame…"
+    is VideoStreamState.Unavailable -> state.reason
+  }

--- a/android/desktop-core/src/main/kotlin/dev/jasonpearson/automobile/desktop/core/workspace/WorkspaceShell.kt
+++ b/android/desktop-core/src/main/kotlin/dev/jasonpearson/automobile/desktop/core/workspace/WorkspaceShell.kt
@@ -77,6 +77,10 @@ fun WorkspaceShell(
   // hierarchy + device mirror) replaces the stream. Hoisted like [facetContent] so a test can drive
   // it with a fake; the default is the real [LayoutFacet], so the host needs no extra wiring.
   inspectContent: @Composable (DeviceColumn) -> Unit = { LayoutFacet(it) },
+  // Body of the pane's stream area while a column is in Input mode. Hoisted like [facetContent] —
+  // and defaulting to the inert placeholder for the same reason — so composing the shell in a unit
+  // test or preview never opens a relay socket. The host passes the real [DeviceStreamView].
+  streamContent: @Composable (DeviceColumn) -> Unit = { WorkspaceStreamPlaceholder() },
   // Body of the health sheet opened by clicking the status dot. Hoisted like [facetContent] so the
   // host (or a test) can substitute content; defaults to the live [DiagnosticsDashboard].
   healthSheetContent: @Composable () -> Unit = { DefaultHealthSheetBody() },
@@ -134,6 +138,7 @@ fun WorkspaceShell(
                   onAction = onAction,
                   facetContent = facetContent,
                   inspectContent = inspectContent,
+                  streamContent = streamContent,
                   canDiff = canDiff,
                   modifier = Modifier.weight(1f).fillMaxHeight(),
                 )
@@ -517,6 +522,7 @@ private fun DeviceColumnView(
   onAction: (WorkspaceAction) -> Unit,
   facetContent: @Composable (DeviceColumn, Tool) -> Unit,
   inspectContent: @Composable (DeviceColumn) -> Unit,
+  streamContent: @Composable (DeviceColumn) -> Unit,
   canDiff: Boolean,
   modifier: Modifier,
 ) {
@@ -530,12 +536,18 @@ private fun DeviceColumnView(
     DeviceColumnHeader(column, onAction)
     val tool = column.activeTool
     if (tool == null) {
-      PaneMainContent(column, onAction, inspectContent, Modifier.weight(1f))
+      PaneMainContent(column, onAction, inspectContent, streamContent, Modifier.weight(1f))
     } else {
       // With a tool active the pane splits main content + docked facet; ⤡ shrink flips the split so
       // the main content collapses to grow the facet.
       val facetFraction = facetHeightFraction(column.shrunk)
-      PaneMainContent(column, onAction, inspectContent, Modifier.weight(1f - facetFraction))
+      PaneMainContent(
+        column,
+        onAction,
+        inspectContent,
+        streamContent,
+        Modifier.weight(1f - facetFraction),
+      )
       DockedFacet(column, tool, onAction, facetContent, canDiff, Modifier.weight(facetFraction))
     }
   }
@@ -551,30 +563,32 @@ private fun PaneMainContent(
   column: DeviceColumn,
   onAction: (WorkspaceAction) -> Unit,
   inspectContent: @Composable (DeviceColumn) -> Unit,
+  streamContent: @Composable (DeviceColumn) -> Unit,
   modifier: Modifier,
 ) {
   if (column.mode == InteractionMode.Inspect) {
     Box(modifier.fillMaxWidth()) { inspectContent(column) }
   } else {
-    StreamArea(column, onAction, modifier)
+    StreamArea(column, onAction, streamContent, modifier)
   }
 }
 
 /**
- * Placeholder device stream with the emulator controls floating on it. The real WebRTC stream lands
- * in a later PR.
+ * The pane's device stream area: the hoisted [streamContent] body (the host's [DeviceStreamView],
+ * or the placeholder default) with the emulator controls floating on it.
  */
 @Composable
 private fun StreamArea(
   column: DeviceColumn,
   onAction: (WorkspaceAction) -> Unit,
+  streamContent: @Composable (DeviceColumn) -> Unit,
   modifier: Modifier,
 ) {
   Box(
     modifier = modifier.fillMaxWidth().background(MaterialTheme.colorScheme.surfaceVariant),
     contentAlignment = Alignment.Center,
   ) {
-    Text("stream", color = MaterialTheme.colorScheme.outline)
+    streamContent(column)
     EmulatorControls(
       column = column,
       onAction = onAction,
@@ -646,6 +660,16 @@ fun WorkspaceFacetPlaceholder(tool: Tool) {
   Box(Modifier.fillMaxSize(), contentAlignment = Alignment.Center) {
     Text("${tool.label} — coming soon", color = MaterialTheme.colorScheme.outline)
   }
+}
+
+/**
+ * Default stream-area body: the inert pre-live placeholder. Hosts swap in [DeviceStreamView] via
+ * [WorkspaceShell]'s `streamContent` slot; tests and previews keep this so composing the shell
+ * never opens a relay socket.
+ */
+@Composable
+fun WorkspaceStreamPlaceholder() {
+  Text("stream", color = MaterialTheme.colorScheme.outline)
 }
 
 /**

--- a/android/desktop-core/src/test/kotlin/dev/jasonpearson/automobile/desktop/core/LiveVideoStreamTest.kt
+++ b/android/desktop-core/src/test/kotlin/dev/jasonpearson/automobile/desktop/core/LiveVideoStreamTest.kt
@@ -5,9 +5,11 @@ import androidx.compose.runtime.mutableStateOf
 import androidx.compose.ui.test.ExperimentalTestApi
 import androidx.compose.ui.test.runComposeUiTest
 import dev.jasonpearson.automobile.desktop.core.video.FakeVideoStreamSource
+import dev.jasonpearson.automobile.desktop.core.video.VideoStreamState
 import kotlin.test.Test
 import kotlin.test.assertEquals
 import kotlin.test.assertNull
+import kotlin.test.assertTrue
 
 @OptIn(ExperimentalTestApi::class)
 class LiveVideoStreamTest {
@@ -63,6 +65,32 @@ class LiveVideoStreamTest {
     source.emitFrame(width = 1, height = 1)
     waitForIdle()
     assertNull(observedFrame)
+  }
+
+  @Test
+  fun `auto-reconnect re-subscribes after the relay drops`() = runComposeUiTest {
+    // A dropped relay ("Live mirroring stopped") must heal itself rather than stay dead until the
+    // pane is torn down. With autoReconnect on, an Unavailable state triggers a connect() retry —
+    // the only path back to Streaming here, since the test never calls connect() again itself.
+    val source = FakeVideoStreamSource()
+    setContent {
+      rememberLiveVideoFrame(source, "emulator-5554", autoReconnect = true, reconnectInitialMs = 10)
+    }
+    waitUntil { source.state.value is VideoStreamState.Streaming }
+
+    source.becomeUnavailable("Live mirroring stopped")
+    waitUntil(timeoutMillis = 2_000) { source.state.value is VideoStreamState.Streaming }
+  }
+
+  @Test
+  fun `without auto-reconnect a dropped relay stays unavailable`() = runComposeUiTest {
+    val source = FakeVideoStreamSource()
+    setContent { rememberLiveVideoFrame(source, "emulator-5554") }
+    waitUntil { source.state.value is VideoStreamState.Streaming }
+
+    source.becomeUnavailable("Live mirroring stopped")
+    waitForIdle()
+    assertTrue(source.state.value is VideoStreamState.Unavailable)
   }
 
   @Test

--- a/android/desktop-core/src/test/kotlin/dev/jasonpearson/automobile/desktop/core/LiveVideoStreamTest.kt
+++ b/android/desktop-core/src/test/kotlin/dev/jasonpearson/automobile/desktop/core/LiveVideoStreamTest.kt
@@ -5,11 +5,9 @@ import androidx.compose.runtime.mutableStateOf
 import androidx.compose.ui.test.ExperimentalTestApi
 import androidx.compose.ui.test.runComposeUiTest
 import dev.jasonpearson.automobile.desktop.core.video.FakeVideoStreamSource
-import dev.jasonpearson.automobile.desktop.core.video.toImageBitmap
 import kotlin.test.Test
 import kotlin.test.assertEquals
 import kotlin.test.assertNull
-import kotlinx.coroutines.CompletableDeferred
 
 @OptIn(ExperimentalTestApi::class)
 class LiveVideoStreamTest {
@@ -68,28 +66,19 @@ class LiveVideoStreamTest {
   }
 
   @Test
-  fun `does not restore a frame decoded after the relay becomes unavailable`() = runComposeUiTest {
+  fun `does not adopt a frame emitted after the relay becomes unavailable`() = runComposeUiTest {
+    // A frame can race the relay's death (it was decoded just before, delivered just after). The
+    // collector gates on the CURRENT stream state, so the dead mirror stays cleared.
     val source = FakeVideoStreamSource()
-    val decodingStarted = CompletableDeferred<Unit>()
-    val allowDecodingToFinish = CompletableDeferred<Unit>()
     var observedFrame: androidx.compose.ui.graphics.ImageBitmap? = null
 
     setContent {
-      val liveFrame =
-        rememberLiveVideoFrame(source, "emulator-5554") { frame ->
-          decodingStarted.complete(Unit)
-          allowDecodingToFinish.await()
-          frame.toImageBitmap()
-        }
+      val liveFrame = rememberLiveVideoFrame(source, "emulator-5554")
       SideEffect { observedFrame = liveFrame?.bitmap }
     }
 
-    source.emitFrame(width = 1, height = 1)
-    decodingStarted.await()
     source.becomeUnavailable()
-    waitUntil { observedFrame == null }
-
-    allowDecodingToFinish.complete(Unit)
+    source.emitFrame(width = 1, height = 1)
     waitForIdle()
     assertNull(observedFrame)
   }

--- a/android/desktop-core/src/test/kotlin/dev/jasonpearson/automobile/desktop/core/video/VideoStreamClientTest.kt
+++ b/android/desktop-core/src/test/kotlin/dev/jasonpearson/automobile/desktop/core/video/VideoStreamClientTest.kt
@@ -59,13 +59,52 @@ class VideoStreamClientTest {
     client.connect("emulator-5554")
 
     val frame = server.awaitFirstFrameFrom(client)
-    assertEquals(320, frame.width)
-    assertEquals(240, frame.height)
-    assertEquals(320 * 240 * 4, frame.bgra.size)
+    assertEquals(320, frame.bitmap.width)
+    assertEquals(240, frame.bitmap.height)
+    // The replay cache holds the NEWEST frame; the sample stream decodes several.
+    assertTrue(frame.sequence >= 1L, "expected a stamped sequence, was ${frame.sequence}")
 
     val request = server.awaitRequest()
     assertEquals("subscribe", request["action"]?.jsonPrimitive?.content)
     assertEquals("emulator-5554", request["deviceId"]?.jsonPrimitive?.content)
+
+    client.dispose()
+  }
+
+  @Test
+  fun `subscribes with quality, fps and bitrate hints when configured`() = runBlocking {
+    val server = relay(payload = sampleH264())
+    val client =
+      VideoStreamClient(
+        socketPathValue = server.socketPath.toString(),
+        quality = VideoStreamQuality.Low,
+        fps = 15,
+        bitrateKbps = 1_500,
+      )
+
+    client.connect("emulator-5554")
+    server.awaitFirstFrameFrom(client)
+
+    val request = server.awaitRequest()
+    assertEquals("low", request["quality"]?.jsonPrimitive?.content)
+    assertEquals("15", request["fps"]?.jsonPrimitive?.content)
+    assertEquals("1500", request["bitrateKbps"]?.jsonPrimitive?.content)
+
+    client.dispose()
+  }
+
+  @Test
+  fun `omits the quality hints by default`() = runBlocking {
+    val server = relay(payload = sampleH264())
+    val client = VideoStreamClient(socketPathValue = server.socketPath.toString())
+
+    client.connect("emulator-5554")
+    server.awaitFirstFrameFrom(client)
+
+    val request = server.awaitRequest()
+    assertTrue(!request.containsKey("quality"))
+    assertTrue(!request.containsKey("fps"))
+    assertTrue(!request.containsKey("bitrateKbps"))
 
     client.dispose()
   }
@@ -238,8 +277,8 @@ class VideoStreamClientTest {
     throw AssertionError("Timed out waiting for condition")
   }
 
-  private suspend fun FakeRelay.awaitFirstFrameFrom(client: VideoStreamClient): DecodedFrame {
-    var frame: DecodedFrame? = null
+  private suspend fun FakeRelay.awaitFirstFrameFrom(client: VideoStreamClient): LiveVideoFrame {
+    var frame: LiveVideoFrame? = null
     val deadline = System.currentTimeMillis() + 10_000
     while (System.currentTimeMillis() < deadline && frame == null) {
       frame = client.frames.replayCache.firstOrNull()

--- a/android/desktop-core/src/test/kotlin/dev/jasonpearson/automobile/desktop/core/workspace/DeviceStreamViewTest.kt
+++ b/android/desktop-core/src/test/kotlin/dev/jasonpearson/automobile/desktop/core/workspace/DeviceStreamViewTest.kt
@@ -1,0 +1,80 @@
+package dev.jasonpearson.automobile.desktop.core.workspace
+
+import androidx.compose.material3.MaterialTheme
+import androidx.compose.runtime.mutableStateOf
+import androidx.compose.ui.test.ExperimentalTestApi
+import androidx.compose.ui.test.assertIsDisplayed
+import androidx.compose.ui.test.onAllNodesWithContentDescription
+import androidx.compose.ui.test.onNodeWithContentDescription
+import androidx.compose.ui.test.onNodeWithText
+import androidx.compose.ui.test.runComposeUiTest
+import dev.jasonpearson.automobile.desktop.core.video.FakeVideoStreamSource
+import dev.jasonpearson.automobile.desktop.core.video.VideoStreamState
+import org.junit.Assert.assertEquals
+import org.junit.Assert.assertNull
+import org.junit.Test
+
+@OptIn(ExperimentalTestApi::class)
+class DeviceStreamViewTest {
+
+  private fun col(id: String = "emulator-5554", name: String = "Pixel 8") =
+    DeviceColumn(deviceId = id, name = name, platform = Platform.Android)
+
+  @Test
+  fun `connects the source for the pane's device`() = runComposeUiTest {
+    val source = FakeVideoStreamSource()
+    setContent { MaterialTheme { DeviceStreamView(col(), sourceFactory = { source }) } }
+    waitUntil { source.connectedDeviceId == "emulator-5554" }
+  }
+
+  @Test
+  fun `draws the newest decoded frame as the live mirror`() = runComposeUiTest {
+    val source = FakeVideoStreamSource()
+    setContent { MaterialTheme { DeviceStreamView(col(), sourceFactory = { source }) } }
+    waitUntil { source.connectedDeviceId != null }
+    source.emitFrame(width = 1, height = 1)
+    waitUntil {
+      onAllNodesWithContentDescription("Live stream of Pixel 8").fetchSemanticsNodes().isNotEmpty()
+    }
+    onNodeWithContentDescription("Live stream of Pixel 8").assertIsDisplayed()
+  }
+
+  @Test
+  fun `shows the refusal reason when the relay is unavailable`() = runComposeUiTest {
+    val source = FakeVideoStreamSource(refuseWith = "Live mirroring was refused")
+    setContent { MaterialTheme { DeviceStreamView(col(), sourceFactory = { source }) } }
+    onNodeWithText("Live mirroring was refused").assertIsDisplayed()
+  }
+
+  @Test
+  fun `shows a waiting hint while streaming before the first frame decodes`() = runComposeUiTest {
+    // The fake reports Streaming immediately on connect but emits no frame.
+    val source = FakeVideoStreamSource()
+    setContent { MaterialTheme { DeviceStreamView(col(), sourceFactory = { source }) } }
+    onNodeWithText("Waiting for the first frame…").assertIsDisplayed()
+  }
+
+  @Test
+  fun `disposes the source when the pane leaves the composition`() = runComposeUiTest {
+    val source = FakeVideoStreamSource()
+    val show = mutableStateOf(true)
+    setContent {
+      MaterialTheme { if (show.value) DeviceStreamView(col(), sourceFactory = { source }) }
+    }
+    waitUntil { source.connectedDeviceId == "emulator-5554" }
+    runOnUiThread { show.value = false }
+    waitUntil { source.connectedDeviceId == null }
+    assertNull(source.connectedDeviceId)
+  }
+
+  @Test
+  fun `status hints are pinned per state`() {
+    assertEquals("Live mirror idle", streamStatusHint(VideoStreamState.Idle))
+    assertEquals("Connecting to live mirror…", streamStatusHint(VideoStreamState.Connecting))
+    assertEquals(
+      "Waiting for the first frame…",
+      streamStatusHint(VideoStreamState.Streaming(1080, 2400)),
+    )
+    assertEquals("relay down", streamStatusHint(VideoStreamState.Unavailable("relay down")))
+  }
+}

--- a/android/desktop-core/src/test/kotlin/dev/jasonpearson/automobile/desktop/core/workspace/WorkspaceShellUiTest.kt
+++ b/android/desktop-core/src/test/kotlin/dev/jasonpearson/automobile/desktop/core/workspace/WorkspaceShellUiTest.kt
@@ -307,6 +307,51 @@ class WorkspaceShellUiTest {
     }
 
   @Test
+  fun `Input mode renders the injected stream content per pane device`() = runComposeUiTest {
+    val state =
+      WorkspaceUiState.Content(
+        columns = listOf(col("a", "Pixel 8"), col("b", "Pixel 9")),
+        focusedDeviceId = "a",
+      )
+    setContent {
+      MaterialTheme {
+        WorkspaceShell(
+          state = state,
+          onAction = {},
+          onOpenPicker = {},
+          streamContent = { column -> Text("stream-slot:${column.deviceId}") },
+        )
+      }
+    }
+    onNodeWithText("stream-slot:a").assertIsDisplayed()
+    onNodeWithText("stream-slot:b").assertIsDisplayed()
+    // The injected body replaces the default placeholder.
+    onNodeWithText("stream").assertDoesNotExist()
+  }
+
+  @Test
+  fun `Inspect mode does not render the injected stream content`() = runComposeUiTest {
+    val state =
+      WorkspaceUiState.Content(
+        columns = listOf(col("a", "Pixel 8").copy(mode = InteractionMode.Inspect)),
+        focusedDeviceId = "a",
+      )
+    setContent {
+      MaterialTheme {
+        WorkspaceShell(
+          state = state,
+          onAction = {},
+          onOpenPicker = {},
+          inspectContent = { Text("inspect-slot") },
+          streamContent = { Text("stream-slot") },
+        )
+      }
+    }
+    onNodeWithText("inspect-slot").assertIsDisplayed()
+    onNodeWithText("stream-slot").assertDoesNotExist()
+  }
+
+  @Test
   fun `Input mode renders the stream and not the inspect content`() = runComposeUiTest {
     val state =
       WorkspaceUiState.Content(columns = listOf(col("a", "Pixel 8")), focusedDeviceId = "a")

--- a/docs/design-docs/mcp/observe/screen-streaming.md
+++ b/docs/design-docs/mcp/observe/screen-streaming.md
@@ -91,10 +91,23 @@ New Unix socket: `~/.auto-mobile/video-stream.sock`
 
 ### Connection Handshake
 
+One JSON line each way; everything after the acknowledgement is binary framing.
+
 ```
-Client → Server: { "command": "subscribe", "deviceId": "<optional>" }
-Server → Client: { "type": "stream_started", "deviceId": "...", "platform": "android|ios" }
+Client → Server: { "action": "subscribe", "id": "<uuid>", "sessionUuid": "<daemon session>",
+                   "deviceId": "<optional>", "quality": "low|medium|high", "fps": 30,
+                   "bitrateKbps": 2000, "size": { "width": 720, "height": 1280 } }
+Server → Client: { "type": "video_stream_response", "success": true, "action": "subscribe",
+                   "deviceId": "...", "framing": "h264" }
 ```
+
+All hint fields are optional and validated server-side (an unknown `quality` or non-positive
+`fps`/`bitrateKbps` refuses the subscribe). Captures are shared per device: the first
+subscriber's hints fix the encode and a late joiner's differing hints are ignored. `quality`
+selects the on-device preset (low=540p/2Mbps, medium=720p/4Mbps, high=1080p/8Mbps); on iOS
+only the preset's bitrate applies (resolution self-scales to Level 4.2). `sessionUuid`
+authenticates against the daemon session registry (#4751); `AUTOMOBILE_DAEMON_STREAM_AUTH=0`
+disables the check.
 
 ### Frame Data
 
@@ -120,11 +133,9 @@ self-describing, so corruption recovery is deterministic (issue #4270).
 
 ### Stream Control
 
-```
-Client → Server: { "command": "set_quality", "quality": "low|medium|high" }
-Client → Server: { "command": "unsubscribe" }
-Server → Client: { "type": "stream_stopped", "reason": "..." }
-```
+There is no mid-stream control channel: quality is fixed at subscribe time (first subscriber
+wins for a shared capture) and a client stops by closing its connection. The capture stops
+when the last subscriber for a device disconnects.
 
 ## Quality Presets
 

--- a/docs/design-docs/mcp/observe/screen-streaming.md
+++ b/docs/design-docs/mcp/observe/screen-streaming.md
@@ -107,18 +107,23 @@ the capture backends' shared 5–60 range, or a non-positive/oversized `bitrateK
 subscribe). Captures are shared per device: the first subscriber's hints fix the encode and a
 late joiner's differing hints are ignored. `quality` selects the on-device preset
 (low=540p/2Mbps, medium=720p/4Mbps, high=1080p/8Mbps); on iOS only the preset's bitrate applies
-(resolution self-scales to Level 4.2), and `fps` is honored only by the Android persistent
-encoder — the `screenrecord` fallback captures at the display's native rate. `sessionUuid`
-authenticates against the daemon session registry (#4751); when auth is on (the default) a
-subscribe without a live session is refused. The desktop workspace client does not yet supply
-one (#4924), so it relies on `AUTOMOBILE_DAEMON_STREAM_AUTH=0` in the interim; the IDE-plugin
-and future clients that hold a daemon session send `sessionUuid`.
+(resolution self-scales to Level 4.2). `fps` is honored by the Android persistent encoder
+(`--fps`) and the iOS Simulator (`--simulator-fps`) — farm clients should send it on both — but
+**not** by the Android `screenrecord` fallback (native display rate) or physical iOS (its own
+AVFoundation rate). `sessionUuid` authenticates against the daemon session registry (#4751); when
+auth is on (the default) a subscribe without a live session is refused. The desktop workspace
+client authenticates by binding a `DesktopDaemonSession` to its focused device (#4977) and passing
+that session UUID to every pane, so it works against a default (auth-on) daemon;
+`AUTOMOBILE_DAEMON_STREAM_AUTH=0` remains only an operator fallback for setups whose clients cannot
+supply a session.
 
 ### Frame Data
 
-Binary frames with platform-specific headers:
+The **relay wire is always H.264** (`framing: "h264"`) regardless of platform — a subscriber
+parses the same framing for Android and iOS. iOS captures raw BGRA internally and the daemon
+re-encodes it to H.264 before it reaches the relay, so relay clients never see raw frames:
 
-**Android (H.264):**
+**Relay wire (both platforms, H.264):**
 ```
 ┌─────────────────┬─────────────────┬─────────────────┐
 │ codec_id (4)    │ width (4)       │ height (4)      │
@@ -126,7 +131,7 @@ Binary frames with platform-specific headers:
 Then per-packet: pts_flags (8) + size (4) + H.264 data
 ```
 
-**iOS (Raw BGRA):**
+**Internal only — iOS capture-helper → daemon (raw BGRA, NOT the relay wire):**
 ```
 ┌──────────┬─────────────┬──────────┬───────────┬─────────────┬───────────┐
 │ magic(4) │ checksum(4) │ width(4) │ height(4) │ bytesPerRow │ timestamp │
@@ -134,7 +139,8 @@ Then per-packet: pts_flags (8) + size (4) + H.264 data
 Then: height * bytesPerRow bytes of BGRA pixel data
 ```
 `magic` ("AMF1") + CRC-32 `checksum` over the field bytes make frame boundaries
-self-describing, so corruption recovery is deterministic (issue #4270).
+self-describing, so corruption recovery is deterministic (issue #4270). This format is consumed
+by the daemon's iOS H.264 encoder and is never sent to relay subscribers.
 
 ### Stream Control
 
@@ -167,7 +173,7 @@ When video streaming is unavailable:
 | Audio streaming | Include audio for complete mirroring |
 | Touch input | Plan for it, implement later |
 | Quality auto-adjustment | Automatically lower quality on frame drops |
-| Multiple devices | Single device streaming at a time |
+| Multiple devices | Concurrent per-device streams — one shared capture per device, fanned out to its subscribers, so the desktop workspace mirrors many device panes at once |
 | Android decoder | `org.bytedeco:ffmpeg` (in-process JNI), host-platform classifier only. Klarity was the original choice but cannot consume a live stream — its API takes file paths only. No FFmpeg *subprocess* fallback. |
 | iOS Swift integration | Swift-to-Node bridge |
 | macOS permissions | User handles permission prompts |

--- a/docs/design-docs/mcp/observe/screen-streaming.md
+++ b/docs/design-docs/mcp/observe/screen-streaming.md
@@ -22,7 +22,8 @@ constructing MCP tool payloads directly.
 - Support USB-connected physical devices and emulators/simulators
 - Include audio streaming for complete mirroring
 - Integrate with existing observation architecture
-- Single device streaming at a time (no multi-device simultaneous streams)
+- Concurrent per-device streams: one shared capture per device, fanned out to multiple
+  subscribers, so the desktop workspace can mirror many device panes at once
 
 ## Architecture
 
@@ -93,7 +94,7 @@ New Unix socket: `~/.auto-mobile/video-stream.sock`
 
 One JSON line each way; everything after the acknowledgement is binary framing.
 
-```
+```text
 Client → Server: { "action": "subscribe", "id": "<uuid>", "sessionUuid": "<daemon session>",
                    "deviceId": "<optional>", "quality": "low|medium|high", "fps": 30,
                    "bitrateKbps": 2000, "size": { "width": 720, "height": 1280 } }
@@ -101,13 +102,17 @@ Server → Client: { "type": "video_stream_response", "success": true, "action":
                    "deviceId": "...", "framing": "h264" }
 ```
 
-All hint fields are optional and validated server-side (an unknown `quality` or non-positive
-`fps`/`bitrateKbps` refuses the subscribe). Captures are shared per device: the first
-subscriber's hints fix the encode and a late joiner's differing hints are ignored. `quality`
-selects the on-device preset (low=540p/2Mbps, medium=720p/4Mbps, high=1080p/8Mbps); on iOS
-only the preset's bitrate applies (resolution self-scales to Level 4.2). `sessionUuid`
-authenticates against the daemon session registry (#4751); `AUTOMOBILE_DAEMON_STREAM_AUTH=0`
-disables the check.
+All hint fields are optional and validated server-side (an unknown `quality`, an `fps` outside
+the capture backends' shared 5–60 range, or a non-positive/oversized `bitrateKbps` refuses the
+subscribe). Captures are shared per device: the first subscriber's hints fix the encode and a
+late joiner's differing hints are ignored. `quality` selects the on-device preset
+(low=540p/2Mbps, medium=720p/4Mbps, high=1080p/8Mbps); on iOS only the preset's bitrate applies
+(resolution self-scales to Level 4.2), and `fps` is honored only by the Android persistent
+encoder — the `screenrecord` fallback captures at the display's native rate. `sessionUuid`
+authenticates against the daemon session registry (#4751); when auth is on (the default) a
+subscribe without a live session is refused. The desktop workspace client does not yet supply
+one (#4924), so it relies on `AUTOMOBILE_DAEMON_STREAM_AUTH=0` in the interim; the IDE-plugin
+and future clients that hold a daemon session send `sessionUuid`.
 
 ### Frame Data
 

--- a/docs/design-docs/plat/android/screen-streaming.md
+++ b/docs/design-docs/plat/android/screen-streaming.md
@@ -4,7 +4,7 @@
 
 > **Current state:** The Android `video-server` module (`android/video-server/`) is fully implemented — `VideoServer.kt` captures via VirtualDisplay, encodes H.264 with MediaCodec, and streams over a LocalSocket. The `videoRecording` MCP tool (record-to-file) uses this server and is <kbd>✅ Implemented</kbd> <kbd>🧪 Tested</kbd>.
 >
-> The **live screen mirroring** pipeline (daemon `video-stream.sock` relay → desktop `DeviceScreenView`) is in progress. Milestones 1–3 are complete: the video-server JAR, the daemon relay (#3994), and the desktop decoder and stream client (#4008). Milestone 4 is outstanding — nothing supplies a live frame to the device view yet, so behaviour is unchanged for users. Tracked in #3995.
+> The **live screen mirroring** pipeline (daemon `video-stream.sock` relay → desktop) is wired end-to-end: the video-server JAR, the daemon relay (#3994), the desktop decoder and stream client (#4008), and the desktop workspace's per-device stream panes (`DeviceStreamView`, #4957) which subscribe with the `low` quality preset for farm-scale viewing. Subscribe-time `quality`/`fps`/`bitrateKbps` hints select the capture preset; captures are shared per device with first-subscriber-wins semantics.
 >
 > Note the decoder is **bytedeco FFmpeg**, not Klarity as originally designed; see [Video Decoder](#video-decoder-bytedeco-ffmpeg) for why.
 >

--- a/src/daemon/videoStreamSocketServer.ts
+++ b/src/daemon/videoStreamSocketServer.ts
@@ -32,6 +32,8 @@ export type CaptureSourceFactory = (options: {
   onRotation?: (rotation: number) => void;
   bitrateBps?: number;
   size?: { width: number; height: number };
+  /** Aspect-preserving resolution/bitrate preset; see `VideoStreamSocketRequest.quality`. */
+  quality?: "low" | "medium" | "high";
   /** Capture rate for iOS Simulator sources; see the call site for why it is pinned. */
   fps?: number;
 }) => Promise<H264CaptureSource>;
@@ -239,11 +241,13 @@ export class VideoStreamSocketServer extends BaseSocketServer {
         },
         bitrateBps: request.bitrateKbps ? request.bitrateKbps * 1000 : undefined,
         size: request.size,
-        // Pin the observation rate explicitly. This relay borrows the WebRTC
-        // capture sources, so without this it would silently inherit whatever
-        // the *WebRTC* iOS Simulator default happens to be — a knob that is
-        // tuned for an interactive WHEP feed and is not configurable here.
-        fps: SIMULATOR_FPS_DEFAULT,
+        quality: request.quality,
+        // Pin the observation rate explicitly when the client sent no hint. This
+        // relay borrows the WebRTC capture sources, so without this it would
+        // silently inherit whatever the *WebRTC* iOS Simulator default happens
+        // to be — a knob that is tuned for an interactive WHEP feed. A client
+        // hint wins so farm viewers can lower the rate across many streams.
+        fps: request.fps ?? SIMULATOR_FPS_DEFAULT,
       });
       // The final subscriber may disconnect while source construction is in
       // flight. Do not attach an unreachable capture process to a removed entry.
@@ -453,6 +457,7 @@ function defaultDependencies(): VideoStreamSocketServerDependencies {
           onRotation: options.onRotation,
           bitrateBps: options.bitrateBps,
           size: options.size,
+          quality: options.quality,
           fps: options.fps,
         },
         jarPath

--- a/src/daemon/videoStreamSocketServer.ts
+++ b/src/daemon/videoStreamSocketServer.ts
@@ -70,8 +70,17 @@ interface DeviceCapture {
 const ANNEX_B_START_CODE = Buffer.from([0, 0, 0, 1]);
 
 const SUPPORTED_QUALITIES = new Set(["low", "medium", "high"]);
-/** Sanity ceiling for a capture-rate hint; no supported device captures faster. */
-const MAX_FPS_HINT = 120;
+// The relay resolves the device only after this validation, so it bounds fps to the range every
+// capture backend can honor rather than a per-platform limit. The iOS Simulator helper is the
+// tightest at [5, 60] (SIMULATOR_FPS_MIN/MAX); the Android video-server accepts any positive
+// rate, so [5, 60] is the safe universal window — a hint outside it would pass here and then throw
+// at iOS capture startup.
+const MIN_FPS_HINT = 5;
+const MAX_FPS_HINT = 60;
+// A generous encoder ceiling (~1 Gbps) that still leaves headroom below Number.MAX_SAFE_INTEGER
+// after the kbps→bps ×1000 conversion at the capture-options boundary, so a huge-but-finite hint
+// cannot silently lose integer precision downstream.
+const MAX_BITRATE_KBPS = 1_000_000;
 
 /**
  * Captures are shared per device and the FIRST subscriber's hints fixed the encode; a late
@@ -98,15 +107,15 @@ function validateQuality(quality: VideoStreamSocketRequest["quality"]): string |
 }
 
 function validateFps(fps: VideoStreamSocketRequest["fps"]): string | null {
-  return fps === undefined || isIntegerInRange(fps, 1, MAX_FPS_HINT)
+  return fps === undefined || isIntegerInRange(fps, MIN_FPS_HINT, MAX_FPS_HINT)
     ? null
-    : `Invalid fps ${fps}; expected an integer between 1 and ${MAX_FPS_HINT}.`;
+    : `Invalid fps ${fps}; expected an integer between ${MIN_FPS_HINT} and ${MAX_FPS_HINT}.`;
 }
 
 function validateBitrate(bitrateKbps: VideoStreamSocketRequest["bitrateKbps"]): string | null {
-  return bitrateKbps === undefined || isIntegerInRange(bitrateKbps, 1, Number.MAX_SAFE_INTEGER)
+  return bitrateKbps === undefined || isIntegerInRange(bitrateKbps, 1, MAX_BITRATE_KBPS)
     ? null
-    : `Invalid bitrateKbps ${bitrateKbps}; expected a positive integer.`;
+    : `Invalid bitrateKbps ${bitrateKbps}; expected an integer between 1 and ${MAX_BITRATE_KBPS}.`;
 }
 
 function validateSize(size: VideoStreamSocketRequest["size"]): string | null {

--- a/src/daemon/videoStreamSocketServer.ts
+++ b/src/daemon/videoStreamSocketServer.ts
@@ -69,6 +69,71 @@ interface DeviceCapture {
 
 const ANNEX_B_START_CODE = Buffer.from([0, 0, 0, 1]);
 
+const SUPPORTED_QUALITIES = new Set(["low", "medium", "high"]);
+/** Sanity ceiling for a capture-rate hint; no supported device captures faster. */
+const MAX_FPS_HINT = 120;
+
+/**
+ * Captures are shared per device and the FIRST subscriber's hints fixed the encode; a late
+ * joiner's differing quality/fps/bitrate hints are silently ignored, so leave a trace for the
+ * viewer wondering why its preset didn't apply.
+ */
+function logIgnoredLateHints(deviceId: string, request: VideoStreamSocketRequest): void {
+  if (request.quality || request.fps || request.bitrateKbps) {
+    logger.debug(
+      `[VideoStream] ${deviceId} already captured; ignoring late subscriber hints ` +
+        `(quality=${request.quality}, fps=${request.fps}, bitrateKbps=${request.bitrateKbps})`
+    );
+  }
+}
+
+function isIntegerInRange(value: number, min: number, max: number): boolean {
+  return Number.isInteger(value) && value >= min && value <= max;
+}
+
+function validateQuality(quality: VideoStreamSocketRequest["quality"]): string | null {
+  return quality === undefined || SUPPORTED_QUALITIES.has(quality)
+    ? null
+    : `Unsupported quality "${quality}"; expected low, medium, or high.`;
+}
+
+function validateFps(fps: VideoStreamSocketRequest["fps"]): string | null {
+  return fps === undefined || isIntegerInRange(fps, 1, MAX_FPS_HINT)
+    ? null
+    : `Invalid fps ${fps}; expected an integer between 1 and ${MAX_FPS_HINT}.`;
+}
+
+function validateBitrate(bitrateKbps: VideoStreamSocketRequest["bitrateKbps"]): string | null {
+  return bitrateKbps === undefined || isIntegerInRange(bitrateKbps, 1, Number.MAX_SAFE_INTEGER)
+    ? null
+    : `Invalid bitrateKbps ${bitrateKbps}; expected a positive integer.`;
+}
+
+function validateSize(size: VideoStreamSocketRequest["size"]): string | null {
+  if (size === undefined) {
+    return null;
+  }
+  const { width, height } = size ?? {};
+  return isIntegerInRange(width, 2, Number.MAX_SAFE_INTEGER) &&
+    isIntegerInRange(height, 2, Number.MAX_SAFE_INTEGER)
+    ? null
+    : `Invalid size ${JSON.stringify(size)}; expected integer width/height >= 2.`;
+}
+
+/**
+ * Validate the optional capture hints on a subscribe request, returning an error message for the
+ * first invalid field or null when all hints are usable. TypeScript's wire types are erased at
+ * runtime, so this is the only thing standing between a malformed hint and the encoder argv.
+ */
+export function validateCaptureHints(request: VideoStreamSocketRequest): string | null {
+  return (
+    validateQuality(request.quality) ??
+    validateFps(request.fps) ??
+    validateBitrate(request.bitrateKbps) ??
+    validateSize(request.size)
+  );
+}
+
 /**
  * Relays a device's live H.264 stream to local clients over `~/.auto-mobile/video-stream.sock`.
  *
@@ -151,6 +216,22 @@ export class VideoStreamSocketServer extends BaseSocketServer {
       return;
     }
 
+    // parseJson is a cast, not a validator: a hostile or skewed client can put anything in the
+    // hint fields. An unknown quality would NaN out capToQualityPreset into `--size 0xundefined`
+    // (dead capture, confusing error) and a non-positive fps/bitrate would reach the encoders
+    // verbatim, so refuse the subscribe up front with a message naming the bad field.
+    const hintError = validateCaptureHints(request);
+    if (hintError) {
+      this.sendJson(socket, {
+        id: request.id,
+        type: "video_stream_response",
+        success: false,
+        error: hintError,
+      } satisfies VideoStreamSocketResponse);
+      socket.end();
+      return;
+    }
+
     try {
       // Authenticate before starting or attaching to any capture (issue #4751):
       // an unauthenticated or cross-session subscribe is rejected here so it can
@@ -201,6 +282,7 @@ export class VideoStreamSocketServer extends BaseSocketServer {
     const deviceId = device.deviceId;
     const existing = this.captures.get(deviceId);
     if (existing) {
+      logIgnoredLateHints(deviceId, request);
       existing.subscribers.add(socket);
       // A client that joins part way through a GOP must not consume inter frames before an IDR.
       existing.waitingForKeyFrame.add(socket);

--- a/src/daemon/videoStreamSocketTypes.ts
+++ b/src/daemon/videoStreamSocketTypes.ts
@@ -35,7 +35,11 @@ export interface VideoStreamSocketRequest {
    * aspect-preserving resolution cap and default bitrate (see the device
    * `QualityPreset`: low=540p/2Mbps, medium=720p/4Mbps, high=1080p/8Mbps). The
    * right knob for many-stream farm viewers, which want lower decode cost per
-   * pane; an explicit `size` wins over the preset's cap.
+   * pane; an explicit `size` wins over the preset's cap. Captures are shared
+   * per device: the first subscriber's hints fix the encode, and a late
+   * joiner's differing hints are ignored (logged at debug). Android-only for
+   * resolution today; iOS honors the preset's bitrate but self-scales
+   * resolution to Level 4.2.
    */
   quality?: "low" | "medium" | "high";
   /**

--- a/src/daemon/videoStreamSocketTypes.ts
+++ b/src/daemon/videoStreamSocketTypes.ts
@@ -30,6 +30,20 @@ export interface VideoStreamSocketRequest {
   bitrateKbps?: number;
   /** Capture size hint. Decoders read true dimensions from the in-band SPS regardless. */
   size?: { width: number; height: number };
+  /**
+   * Capture quality preset, passed through to the capture source. Selects an
+   * aspect-preserving resolution cap and default bitrate (see the device
+   * `QualityPreset`: low=540p/2Mbps, medium=720p/4Mbps, high=1080p/8Mbps). The
+   * right knob for many-stream farm viewers, which want lower decode cost per
+   * pane; an explicit `size` wins over the preset's cap.
+   */
+  quality?: "low" | "medium" | "high";
+  /**
+   * Capture frame-rate hint, passed through to the capture source. When omitted
+   * the relay pins its existing per-platform default; farm viewers can lower it
+   * to shed encode + decode load across dozens of streams.
+   */
+  fps?: number;
 }
 
 export interface VideoStreamSocketResponse {

--- a/src/features/webrtc/AndroidH264Source.ts
+++ b/src/features/webrtc/AndroidH264Source.ts
@@ -8,6 +8,7 @@ import {
 import type { AdbProcess } from "../../utils/android-cmdline-tools/interfaces/AdbExecutor";
 import { ANDROID_SCREENRECORD_MAX_SECONDS } from "../video/androidScreenrecord";
 import { h264MacroblocksPerFrame, WEBRTC_H264_MAX_MACROBLOCKS_PER_FRAME } from "./h264Level";
+import { qualityPresetBitrateBps } from "./qualityPresets";
 import type { H264CaptureSource, H264CaptureSourceOptions } from "./H264CaptureSource";
 
 export type { ProcessSpawner, SpawnedProcess } from "./processSpawner";
@@ -148,8 +149,16 @@ export class AndroidH264Source implements H264CaptureSource {
       "--time-limit",
       String(this.segmentTimeLimitSeconds),
     ];
-    if (this.options.bitrateBps && this.options.bitrateBps > 0) {
-      args.push("--bit-rate", String(Math.round(this.options.bitrateBps)));
+    // An explicit bitrate wins; otherwise the quality preset's default applies, mirroring what
+    // the persistent encoder does on-device — without this, a `low` farm subscriber on the
+    // screenrecord fallback would get 540p at screenrecord's own default (~20 Mbps), shipping
+    // the preset's resolution but not its bandwidth.
+    const bitrateBps =
+      this.options.bitrateBps && this.options.bitrateBps > 0
+        ? this.options.bitrateBps
+        : qualityPresetBitrateBps(this.options.quality);
+    if (bitrateBps !== undefined) {
+      args.push("--bit-rate", String(Math.round(bitrateBps)));
     }
     args.push("--size", `${size.width}x${size.height}`);
     args.push("-");
@@ -299,6 +308,7 @@ const QUALITY_PRESET_MAX_LONG_SIDE: Record<"low" | "medium" | "high", number> = 
   medium: 720,
   high: 1080,
 };
+
 
 /**
  * Scale [size] down (never up) so its longer side fits the [quality] preset,

--- a/src/features/webrtc/AndroidH264Source.ts
+++ b/src/features/webrtc/AndroidH264Source.ts
@@ -269,7 +269,9 @@ export class AndroidH264Source implements H264CaptureSource {
       const { stdout } = await adb.executeCommand("shell wm size");
       const match = /Physical size:\s*(\d+)x(\d+)/.exec(stdout);
       if (match) {
-        this.resolvedSize = capToLevel42({ width: Number(match[1]), height: Number(match[2]) });
+        this.resolvedSize = capToLevel42(
+          capToQualityPreset({ width: Number(match[1]), height: Number(match[2]) }, this.options.quality)
+        );
         return this.resolvedSize;
       }
     } catch (error) {
@@ -278,9 +280,47 @@ export class AndroidH264Source implements H264CaptureSource {
     // `wm size` is unavailable on a few older/restricted devices. Keep that
     // fallback within the Level 4.2 SDP capability instead of emitting native
     // display resolution with an unbounded SPS level.
-    this.resolvedSize = DEFAULT_SCREENRECORD_SIZE;
+    this.resolvedSize = capToQualityPreset(DEFAULT_SCREENRECORD_SIZE, this.options.quality);
     return this.resolvedSize;
   }
+}
+
+/**
+ * Aspect-preserving resolution caps mirroring the on-device video-server
+ * presets (`android/video-server/.../QualityPreset.kt`). The persistent encoder
+ * applies its preset on-device (`VideoServer.calculateOutputDimensions` caps
+ * the LONGER dimension and scales the other proportionally); this applies the
+ * same bound to the `screenrecord` fallback so a farm viewer that asked for
+ * `low` does not silently pay full-resolution decode when the persistent
+ * encoder is absent.
+ */
+const QUALITY_PRESET_MAX_LONG_SIDE: Record<"low" | "medium" | "high", number> = {
+  low: 540,
+  medium: 720,
+  high: 1080,
+};
+
+/**
+ * Scale [size] down (never up) so its longer side fits the [quality] preset,
+ * truncating to even pixels exactly as the on-device scaler does.
+ */
+export function capToQualityPreset(
+  size: { width: number; height: number },
+  quality: "low" | "medium" | "high" | undefined
+): { width: number; height: number } {
+  if (!quality) {
+    return size;
+  }
+  const maxLongSide = QUALITY_PRESET_MAX_LONG_SIDE[quality];
+  const longSide = Math.max(size.width, size.height);
+  if (longSide <= maxLongSide) {
+    return { width: size.width & ~1, height: size.height & ~1 };
+  }
+  const scale = maxLongSide / longSide;
+  if (size.height >= size.width) {
+    return { width: Math.trunc(size.width * scale) & ~1, height: maxLongSide };
+  }
+  return { width: maxLongSide, height: Math.trunc(size.height * scale) & ~1 };
 }
 
 function capToLevel42(size: { width: number; height: number }): { width: number; height: number } {

--- a/src/features/webrtc/AndroidH264Source.ts
+++ b/src/features/webrtc/AndroidH264Source.ts
@@ -309,7 +309,6 @@ const QUALITY_PRESET_MAX_LONG_SIDE: Record<"low" | "medium" | "high", number> = 
   high: 1080,
 };
 
-
 /**
  * Scale [size] down (never up) so its longer side fits the [quality] preset,
  * truncating to even pixels exactly as the on-device scaler does.

--- a/src/features/webrtc/H264CaptureSource.ts
+++ b/src/features/webrtc/H264CaptureSource.ts
@@ -45,11 +45,14 @@ export interface H264CaptureSourceOptions {
   /**
    * Capture frame rate.
    *
-   * On Android it is forwarded to the video-server as `--fps`, overriding the
-   * quality preset's default (carrying `WebRtcStreamingConfig.androidFps`). On
-   * iOS Simulator it requests a capture rate (carrying
-   * `WebRtcStreamingConfig.iosSimulatorFps`); physical iOS captures at its own
-   * AVFoundation rate but still takes its declared rawvideo input rate and GOP
+   * On Android it is forwarded to the persistent video-server as `--fps`,
+   * overriding the quality preset's default (carrying
+   * `WebRtcStreamingConfig.androidFps`). The `screenrecord` fallback
+   * (`AndroidH264Source`) has no frame-rate flag and captures at the display's
+   * native rate, so the hint is a no-op there. On iOS Simulator it requests a
+   * capture rate (carrying `WebRtcStreamingConfig.iosSimulatorFps`); physical
+   * iOS captures at its own AVFoundation rate but still takes its declared
+   * rawvideo input rate and GOP
    * length from it.
    */
   fps?: number;

--- a/src/features/webrtc/H264CaptureSource.ts
+++ b/src/features/webrtc/H264CaptureSource.ts
@@ -33,10 +33,13 @@ export interface H264CaptureSourceOptions {
   bitrateBps?: number;
   size?: { width: number; height: number };
   /**
-   * Device video-server quality preset. Selects resolution and default bitrate;
-   * the persistent Android encoder forwards it as `--quality`. Frame rate is
-   * carried separately by {@link fps} so it can be tuned independently. When
-   * omitted the device defaults to `medium`.
+   * Device video-server quality preset. Selects resolution and default bitrate:
+   * the persistent Android encoder forwards it as `--quality`, the Android
+   * `screenrecord` fallback mirrors the same resolution cap and bitrate
+   * host-side, and the iOS sources honor the preset's bitrate only (their
+   * resolution self-scales to Level 4.2). Frame rate is carried separately by
+   * {@link fps} so it can be tuned independently. When omitted the device
+   * defaults to `medium`.
    */
   quality?: "low" | "medium" | "high";
   /**

--- a/src/features/webrtc/IosH264Source.ts
+++ b/src/features/webrtc/IosH264Source.ts
@@ -29,6 +29,7 @@ import {
 import { ScreenCaptureHelperProvider } from "../screen-stream/ScreenCaptureHelperProvider";
 import { isIosSimulatorUdid } from "../../utils/ios-cmdline-tools/iosDeviceType";
 import { logger } from "../../utils/logger";
+import { qualityPresetBitrateBps } from "./qualityPresets";
 import {
   DefaultFfmpegClient,
   resolveFfmpegBinary,
@@ -555,8 +556,13 @@ export class IosH264Source implements H264CaptureSource {
    * passed for the helper to apply against the delivered pixels x fps (#4375).
    */
   private resolveEncodeSettings(): EncodeSettings {
+    // Explicit override > quality preset > bits-per-pixel budget. The preset's resolution cap
+    // cannot be honored here (the helper's --encode self-scales to Level 4.2 with no size flag),
+    // so mapping its bitrate is the half of the preset contract this path can keep.
     const override =
-      this.options.bitrateBps && this.options.bitrateBps > 0 ? this.options.bitrateBps : undefined;
+      this.options.bitrateBps && this.options.bitrateBps > 0
+        ? this.options.bitrateBps
+        : qualityPresetBitrateBps(this.options.quality);
     const bitrate: EncodeBitratePolicy =
       override !== undefined
         ? { kind: "explicitBps", bps: override }
@@ -1464,8 +1470,12 @@ export class IosH264Source implements H264CaptureSource {
     const encodedSize = scale ?? size;
     const explicitBitrateBps =
       this.options.bitrateBps && this.options.bitrateBps > 0 ? this.options.bitrateBps : undefined;
+    // Explicit override > quality preset > resolution-aware Simulator default. iOS cannot honor
+    // the preset's resolution cap (the encoded path self-scales to Level 4.2 and exposes no size
+    // flag), so the preset's bitrate is the half of the contract this source can keep.
     const bitrateBps =
       explicitBitrateBps ??
+      qualityPresetBitrateBps(this.options.quality) ??
       (this.captureKind === "simulator" ? defaultIosBitrateBps(encodedSize, this.fps) : undefined);
     if (bitrateBps !== undefined) {
       args.push("-b:v", String(Math.round(bitrateBps)));

--- a/src/features/webrtc/qualityPresets.ts
+++ b/src/features/webrtc/qualityPresets.ts
@@ -1,0 +1,23 @@
+/**
+ * Host-side mirror of the on-device video-server quality presets
+ * (`android/video-server/.../QualityPreset.kt`): low=540p/2Mbps, medium=720p/4Mbps,
+ * high=1080p/8Mbps. The persistent Android encoder applies the preset on-device; capture
+ * sources that cannot (the Android `screenrecord` fallback, the iOS sources) use this table
+ * so a preset hint means the same thing on every backend.
+ */
+
+export type CaptureQualityPreset = "low" | "medium" | "high";
+
+/** Default encoder bitrates per preset, mirroring the on-device `QualityPreset` table. */
+const QUALITY_PRESET_BITRATE_BPS: Record<CaptureQualityPreset, number> = {
+  low: 2_000_000,
+  medium: 4_000_000,
+  high: 8_000_000,
+};
+
+/** The preset's default bitrate, or undefined when no preset was requested. */
+export function qualityPresetBitrateBps(
+  quality: CaptureQualityPreset | undefined
+): number | undefined {
+  return quality ? QUALITY_PRESET_BITRATE_BPS[quality] : undefined;
+}

--- a/test/daemon/videoStreamSocketServer.test.ts
+++ b/test/daemon/videoStreamSocketServer.test.ts
@@ -258,6 +258,38 @@ describe("VideoStreamSocketServer", () => {
     expect(h.captureOptions).toHaveLength(0);
   });
 
+  test("refuses an fps outside the backends' shared 5-60 range", async () => {
+    const h = await startHarness();
+
+    // 2 fps passes a naive positivity check but throws at iOS Simulator capture
+    // (the helper enforces [5, 60]); 90 fps exceeds every backend.
+    for (const fps of [2, 90]) {
+      const { ack } = await subscribe(h.socketPath, {
+        action: "subscribe",
+        deviceId: DEVICE.deviceId,
+        fps,
+      });
+      expect(ack.success).toBe(false);
+      expect(String(ack.error)).toContain("Invalid fps");
+    }
+    expect(h.captureOptions).toHaveLength(0);
+  });
+
+  test("refuses a bitrate that would lose integer precision after the kbps->bps conversion", async () => {
+    const h = await startHarness();
+
+    // A huge-but-finite kbps passes Number.isInteger yet overflows past
+    // MAX_SAFE_INTEGER once multiplied by 1000 downstream.
+    const { ack } = await subscribe(h.socketPath, {
+      action: "subscribe",
+      deviceId: DEVICE.deviceId,
+      bitrateKbps: 9_000_000_000_000,
+    });
+    expect(ack.success).toBe(false);
+    expect(String(ack.error)).toContain("Invalid bitrateKbps");
+    expect(h.captureOptions).toHaveLength(0);
+  });
+
   test("sends the stream header immediately after the ack", async () => {
     const h = await startHarness();
 

--- a/test/daemon/videoStreamSocketServer.test.ts
+++ b/test/daemon/videoStreamSocketServer.test.ts
@@ -44,7 +44,7 @@ interface Harness {
   server: VideoStreamSocketServer;
   socketPath: string;
   sources: FakeCaptureSource[];
-  captureOptions: Array<{ fps?: number }>;
+  captureOptions: Array<{ fps?: number; quality?: string }>;
   emit: (chunk: Buffer) => void;
   /** Simulates the source attesting a display rotation (issue #4786). */
   emitRotation: (rotation: number) => void;
@@ -68,7 +68,7 @@ async function startHarness(
   const sources: FakeCaptureSource[] = [];
   let onData: ((chunk: Buffer) => void) | null = null;
   let onRotation: ((rotation: number) => void) | null = null;
-  const captureOptions: Array<{ fps?: number }> = [];
+  const captureOptions: Array<{ fps?: number; quality?: string }> = [];
 
   const server = new VideoStreamSocketServer(
     {
@@ -190,6 +190,22 @@ describe("VideoStreamSocketServer", () => {
     // silently adopt whatever the interactive WHEP default happens to be.
     expect(h.captureOptions[0].fps).toBe(SIMULATOR_FPS_DEFAULT);
     expect(SIMULATOR_FPS_DEFAULT).not.toBe(WEBRTC_IOS_SIMULATOR_FPS_DEFAULT);
+  });
+
+  test("forwards client quality and fps hints to the capture source", async () => {
+    const h = await startHarness();
+
+    // A farm viewer lowers per-stream decode cost by requesting a preset and
+    // rate; the client hint must win over the pinned observation default.
+    await subscribe(h.socketPath, {
+      action: "subscribe",
+      deviceId: DEVICE.deviceId,
+      quality: "low",
+      fps: 15,
+    });
+
+    expect(h.captureOptions[0].quality).toBe("low");
+    expect(h.captureOptions[0].fps).toBe(15);
   });
 
   test("sends the stream header immediately after the ack", async () => {

--- a/test/daemon/videoStreamSocketServer.test.ts
+++ b/test/daemon/videoStreamSocketServer.test.ts
@@ -208,6 +208,56 @@ describe("VideoStreamSocketServer", () => {
     expect(h.captureOptions[0].fps).toBe(15);
   });
 
+  test("refuses a subscribe carrying an unknown quality instead of NaN-ing the capture", async () => {
+    const h = await startHarness();
+
+    const { ack } = await subscribe(h.socketPath, {
+      action: "subscribe",
+      deviceId: DEVICE.deviceId,
+      quality: "ultra",
+    });
+
+    expect(ack.success).toBe(false);
+    expect(String(ack.error)).toContain('Unsupported quality "ultra"');
+    expect(h.captureOptions).toHaveLength(0);
+  });
+
+  test("refuses non-positive or absurd fps and bitrate hints", async () => {
+    const h = await startHarness();
+
+    const zeroFps = await subscribe(h.socketPath, {
+      action: "subscribe",
+      deviceId: DEVICE.deviceId,
+      fps: 0,
+    });
+    expect(zeroFps.ack.success).toBe(false);
+    expect(String(zeroFps.ack.error)).toContain("Invalid fps");
+
+    const negativeBitrate = await subscribe(h.socketPath, {
+      action: "subscribe",
+      deviceId: DEVICE.deviceId,
+      bitrateKbps: -5,
+    });
+    expect(negativeBitrate.ack.success).toBe(false);
+    expect(String(negativeBitrate.ack.error)).toContain("Invalid bitrateKbps");
+
+    expect(h.captureOptions).toHaveLength(0);
+  });
+
+  test("refuses a malformed size hint", async () => {
+    const h = await startHarness();
+
+    const { ack } = await subscribe(h.socketPath, {
+      action: "subscribe",
+      deviceId: DEVICE.deviceId,
+      size: { width: 0, height: "tall" },
+    });
+
+    expect(ack.success).toBe(false);
+    expect(String(ack.error)).toContain("Invalid size");
+    expect(h.captureOptions).toHaveLength(0);
+  });
+
   test("sends the stream header immediately after the ack", async () => {
     const h = await startHarness();
 

--- a/test/features/webrtc/AndroidH264Source.test.ts
+++ b/test/features/webrtc/AndroidH264Source.test.ts
@@ -4,6 +4,7 @@ import { PassThrough } from "node:stream";
 import {
   ANDROID_FORCED_KEYFRAME_MIN_INTERVAL_MS,
   AndroidH264Source,
+  capToQualityPreset,
   type SpawnedProcess,
 } from "../../../src/features/webrtc/AndroidH264Source";
 import type { AdbClientFactory } from "../../../src/utils/android-cmdline-tools/AdbClientFactory";
@@ -97,6 +98,26 @@ describe("AndroidH264Source", () => {
     const size = spawnArgs[0][spawnArgs[0].indexOf("--size") + 1];
     const [width, height] = size.split("x").map(Number);
     expect(Math.ceil(width / 16) * Math.ceil(height / 16)).toBeLessThanOrEqual(8192);
+    await source.stop();
+  });
+
+  test("caps the resolved display size to the quality preset's long side", async () => {
+    // Mirrors the on-device VideoServer.calculateOutputDimensions semantics:
+    // low caps the LONGER dimension at 540, scaling the other to even pixels.
+    const { source, spawnArgs } = makeSource({ quality: "low" }, "Physical size: 1080x2400\n");
+    await source.start();
+    const args = spawnArgs[0].join(" ");
+    expect(args).toContain("--size 242x540");
+    await source.stop();
+  });
+
+  test("an explicit size wins over the quality preset", async () => {
+    const { source, spawnArgs } = makeSource({
+      quality: "low",
+      size: { width: 720, height: 1280 },
+    });
+    await source.start();
+    expect(spawnArgs[0].join(" ")).toContain("--size 720x1280");
     await source.stop();
   });
 
@@ -254,5 +275,35 @@ describe("AndroidH264Source", () => {
     expect(captured).not.toBeNull();
     expect((captured as unknown as Error).message).toBe("adb not found");
     expect(source.isRunning).toBe(false);
+  });
+});
+
+describe("capToQualityPreset", () => {
+  test("caps a portrait display by height, matching the on-device scaler", () => {
+    expect(capToQualityPreset({ width: 1080, height: 2400 }, "low")).toEqual({
+      width: 242,
+      height: 540,
+    });
+  });
+
+  test("caps a landscape display by width", () => {
+    expect(capToQualityPreset({ width: 2400, height: 1080 }, "low")).toEqual({
+      width: 540,
+      height: 242,
+    });
+  });
+
+  test("never upscales a display already within the preset", () => {
+    expect(capToQualityPreset({ width: 320, height: 480 }, "low")).toEqual({
+      width: 320,
+      height: 480,
+    });
+  });
+
+  test("passes the size through unchanged without a preset", () => {
+    expect(capToQualityPreset({ width: 1440, height: 3200 }, undefined)).toEqual({
+      width: 1440,
+      height: 3200,
+    });
   });
 });

--- a/test/features/webrtc/AndroidH264Source.test.ts
+++ b/test/features/webrtc/AndroidH264Source.test.ts
@@ -111,6 +111,27 @@ describe("AndroidH264Source", () => {
     await source.stop();
   });
 
+  test("the quality preset supplies the screenrecord bitrate when none is explicit", async () => {
+    // Mirrors the on-device preset's bandwidth half: without this, `low` would cap resolution
+    // but leave screenrecord's own (much fatter) default bitrate.
+    const { source, spawnArgs } = makeSource({ quality: "low" }, "Physical size: 1080x2400\n");
+    await source.start();
+    expect(spawnArgs[0].join(" ")).toContain("--bit-rate 2000000");
+    await source.stop();
+  });
+
+  test("an explicit bitrate wins over the quality preset's default", async () => {
+    const { source, spawnArgs } = makeSource(
+      { quality: "low", bitrateBps: 1_000_000 },
+      "Physical size: 1080x2400\n"
+    );
+    await source.start();
+    const args = spawnArgs[0].join(" ");
+    expect(args).toContain("--bit-rate 1000000");
+    expect(args).not.toContain("--bit-rate 2000000");
+    await source.stop();
+  });
+
   test("an explicit size wins over the quality preset", async () => {
     const { source, spawnArgs } = makeSource({
       quality: "low",

--- a/test/features/webrtc/IosH264Source.test.ts
+++ b/test/features/webrtc/IosH264Source.test.ts
@@ -1184,6 +1184,18 @@ describe("IosH264Source", () => {
     );
   });
 
+  test("the quality preset supplies the bitrate when no explicit override is set", async () => {
+    // iOS cannot honor the preset's resolution cap (Level 4.2 self-scaling), so the preset's
+    // bitrate is the half of the contract this source keeps.
+    const { source, helper, encoderSpawns } = createHarnessWithOverrides({ quality: "low" });
+
+    await startWithFrame(source, helper, frame(750, 1334, 0x11));
+
+    const rateIndex = encoderSpawns[0].args.indexOf("-b:v");
+    expect(rateIndex).toBeGreaterThanOrEqual(0);
+    expect(encoderSpawns[0].args[rateIndex + 1]).toBe("2000000");
+  });
+
   test("does not apply the resolution-derived default bitrate to a physical device (#4375)", async () => {
     // #4349 justified the 0.1 bpp default entirely from Simulator screen-content
     // measurements, so a physical iPhone must not inherit it — with no operator


### PR DESCRIPTION
## Summary

Two commits that take the desktop workspace from a `stream` placeholder to a live device mirror built for **farm scale** (dozens of concurrent panes at reduced resolution).

### 1. Wire the live device mirror into the workspace stream area

- `WorkspaceShell` gains a hoisted `streamContent` slot (placeholder default, matching the `facetContent` pattern, so composing the shell in tests never opens a relay socket).
- New `DeviceStreamView` subscribes to the daemon's `video-stream.sock` relay per pane device via the existing `VideoStreamSource` machinery, draws the newest decoded frame aspect-fit, and renders one-line hints for connecting/waiting/refused states. Teardown is automatic when a column closes or flips to Inspect mode.
- Session auth: the client still sends no `sessionUuid` ([#4924](https://github.com/kaeawc/auto-mobile/issues/4924) tracks the desktop session-identity design); with stream-socket auth on by default ([#4751](https://github.com/kaeawc/auto-mobile/issues/4751)) the pane surfaces the refusal reason, and `AUTOMOBILE_DAEMON_STREAM_AUTH=0` remains the interim escape hatch.

### 2. Farm-scale performance pass over the whole pipeline

- **Quality/fps subscribe hints end-to-end** (dominant win, ~10× fewer pixels per pane): the relay forwards the client's `quality`/`fps` hints; the persistent encoder already honors `--quality` on-device, and the `screenrecord` fallback now applies the identical aspect-preserving long-side cap (`capToQualityPreset`, mirroring `VideoServer.calculateOutputDimensions`). Workspace panes default to `low` (540 long side, ~2 Mbps). A client `fps` hint wins over the relay's pinned observation default.
- **Zero-allocation frame path**: the decoder reuses its BGRA buffer and the client converts to an immutable Skia raster on the reader thread, emitting ready-to-draw `LiveVideoFrame`s. Kills the per-frame `ByteArray` allocation + defensive `copyOf` + consumer-side `makeRaster` hop (~30 MB/frame of JVM churn at 1080p → one native raster copy) and removes the `Dispatchers.Default` conversion hop in `rememberLiveVideoFrame`.
- **Reader isolation**: each client runs its blocking socket read on a dedicated daemon thread instead of a `Dispatchers.IO` slot, so dozens of streams cannot exhaust the shared 64-thread IO pool.

**Deliberately rejected**: mutable pooled bitmaps (write-in-place `installPixels`) would save only the one remaining native copy (~500 KB/frame at post-cap resolutions) while introducing tearing races between the decoder thread and Compose's draw pass.

Known behavior: relay captures are shared per device and the first subscriber's hints win — consistent for a farm of `low` panes; a full-res viewer joining an already-mirrored device inherits the active preset.

## Validation

- `:desktop-core:test` (1,156 tests) + `:desktop-core:detektMain` + `:desktop-app:build` green (JDK 21)
- `bun test` daemon/webrtc suites (452 tests), `bun run typecheck` (no new errors), `bun run lint` green
- ktfmt applied via `scripts/ktfmt/apply_ktfmt.sh`
