### PR TITLE
fix(desktop): staple the notarization ticket to AutoMobile.app, not only the DMG

### DIFF
--- a/.github/workflows/build-desktop-app-installers.yml
+++ b/.github/workflows/build-desktop-app-installers.yml
@@ -70,7 +70,10 @@ jobs:
           - os: macos-latest
             platform: macos
             format: dmg
-            gradle-task: ":desktop-app:packageDmg"
+            # Build only the signed app-image here; the DMG is assembled later,
+            # after the app-image is notarized and stapled, so the app bundle
+            # inside the shipped DMG carries its own notarization ticket (#4955).
+            gradle-task: ":desktop-app:createDistributable"
           - os: windows-latest
             platform: windows
             format: msi
@@ -153,6 +156,46 @@ jobs:
           chmod 600 "${KEY_PATH}"
           echo "APPLE_NOTARY_KEY_PATH=${KEY_PATH}" >> "${GITHUB_ENV}"
 
+      # Notarize and STAPLE THE APP BUNDLE before it is packaged into the DMG, so
+      # the app inside the shipped DMG carries its own ticket and passes Gatekeeper
+      # offline after the user drags it to /Applications (#4955). notarytool cannot
+      # ingest a bare .app directory, so submit a zip of it; staple the .app itself.
+      - name: "Notarize and staple app image"
+        if: matrix.platform == 'macos'
+        working-directory: android
+        env:
+          APPLE_NOTARY_KEY_ID: ${{ secrets.APPLE_NOTARY_KEY_ID }}
+          APPLE_NOTARY_ISSUER_ID: ${{ secrets.APPLE_NOTARY_ISSUER_ID }}
+        run: |
+          set -euo pipefail
+          APP=$(find desktop-app/build/compose/binaries/main/app -maxdepth 1 -type d -name '*.app' | head -n 1)
+          if [ -z "$APP" ]; then
+            echo "No .app was produced under desktop-app/build/compose/binaries/main/app" >&2
+            exit 1
+          fi
+          APP_ZIP="${RUNNER_TEMP}/app-image.zip"
+          ditto -c -k --keepParent "$APP" "$APP_ZIP"
+          "${GITHUB_WORKSPACE}/scripts/ci/notarize-macos-artifact.sh" "$APP_ZIP"
+          xcrun stapler staple "$APP"
+          xcrun stapler validate "$APP"
+
+      # Assemble the DMG now that the app-image is stapled. Compose's packageDmg
+      # runs jpackage with `--app-image <the createDistributable output>`, so it
+      # wraps the already-stapled app rather than rebuilding it (createDistributable
+      # stays up-to-date — stapling touched its output, not its inputs).
+      - name: "Assemble DMG"
+        if: matrix.platform == 'macos'
+        uses: ./.github/actions/gradle-task-run
+        with:
+          gradle-tasks: ":desktop-app:packageDmg"
+          gradle-flags: '["-PdesktopPackageVersion=${{ inputs.version }}"]'
+          gradle-project-directory: "android"
+          gradle-home-directory: "~/.gradle/build-desktop-app-installers-${{ matrix.os }}"
+          reuse-configuration-cache: true
+          gradle-encryption-key: ${{ secrets.GRADLE_ENCRYPTION_KEY }}
+          # macOS only, matching the "Package installer" step's non-Linux choice.
+          malloc-replacement: "none"
+
       - name: "Notarize and staple DMG"
         if: matrix.platform == 'macos'
         working-directory: android
@@ -166,34 +209,30 @@ jobs:
             echo "No DMG was produced under desktop-app/build/compose/binaries/main/dmg" >&2
             exit 1
           fi
-          echo "Notarizing $DMG"
-          # `notarytool submit --wait` exits 0 even when Apple's verdict is
-          # Invalid, which previously let the step run on to `stapler staple`
-          # and die with an opaque "Record not found" error 65. Parse the JSON
-          # result instead: anything but Accepted fails the step, after dumping
-          # the notary log so the per-file rejection reasons land in CI output.
-          SUBMISSION_JSON=$(xcrun notarytool submit "$DMG" \
-            --key "$APPLE_NOTARY_KEY_PATH" \
-            --key-id "$APPLE_NOTARY_KEY_ID" \
-            --issuer "$APPLE_NOTARY_ISSUER_ID" \
-            --wait \
-            --output-format json)
-          echo "$SUBMISSION_JSON"
-          SUBMISSION_ID=$(jq -r '.id // empty' <<<"$SUBMISSION_JSON")
-          STATUS=$(jq -r '.status // empty' <<<"$SUBMISSION_JSON")
-          if [ "$STATUS" != "Accepted" ]; then
-            echo "Notarization verdict: ${STATUS:-unknown} (submission ${SUBMISSION_ID:-unknown})" >&2
-            if [ -n "$SUBMISSION_ID" ]; then
-              # Best-effort: the log service can lag right after the verdict.
-              xcrun notarytool log "$SUBMISSION_ID" \
-                --key "$APPLE_NOTARY_KEY_PATH" \
-                --key-id "$APPLE_NOTARY_KEY_ID" \
-                --issuer "$APPLE_NOTARY_ISSUER_ID" >&2 || true
-            fi
-            exit 1
-          fi
+          "${GITHUB_WORKSPACE}/scripts/ci/notarize-macos-artifact.sh" "$DMG"
           xcrun stapler staple "$DMG"
           xcrun stapler validate "$DMG"
+
+      # Enforce #4955 at the only place it can run: prove the app INSIDE the shipped
+      # DMG is stapled. If the app-image reuse assumption ever breaks and packageDmg
+      # ships an unstapled app, this fails the release instead of silently
+      # regressing offline first-launch.
+      - name: "Verify stapled app in DMG"
+        if: matrix.platform == 'macos'
+        working-directory: android
+        run: |
+          set -euo pipefail
+          DMG=$(find desktop-app/build/compose/binaries/main/dmg -maxdepth 1 -type f -name '*.dmg' | head -n 1)
+          MOUNT=$(mktemp -d)
+          hdiutil attach "$DMG" -nobrowse -readonly -mountpoint "$MOUNT" >/dev/null
+          trap 'hdiutil detach "$MOUNT" >/dev/null 2>&1 || true' EXIT
+          APP_IN_DMG=$(find "$MOUNT" -maxdepth 1 -type d -name '*.app' | head -n 1)
+          if [ -z "$APP_IN_DMG" ]; then
+            echo "No .app found inside the mounted DMG" >&2
+            exit 1
+          fi
+          echo "Validating stapled ticket on $APP_IN_DMG"
+          xcrun stapler validate "$APP_IN_DMG"
 
       # jpackage names the file after packageName + version (e.g.
       # AutoMobile-1.0.47.dmg, automobile_0.0.47-1_amd64.deb), which varies per

--- a/.github/workflows/build-desktop-app-installers.yml
+++ b/.github/workflows/build-desktop-app-installers.yml
@@ -181,23 +181,27 @@ jobs:
 
       # Assemble the DMG now that the app-image is stapled. Compose's packageDmg
       # runs jpackage with `--app-image <the createDistributable output>` — verified
-      # in the generated packageDmg.args.txt — so it consumes the stapled app-image.
-      # Two facts verified locally against Compose 1.11.1 (unsigned):
-      #   - Gradle leaves createDistributable UP-TO-DATE when packageDmg runs in a
-      #     later invocation, even though the staple mutated its output dir, so the
-      #     stapled app-image is reused, not rebuilt.
-      #   - jpackage nonetheless RE-SIGNS the app image while wrapping it (codesign
-      #     --force). Stapling is signature-safe (the ticket does not change the
-      #     cdhash), so a same-identity re-sign preserves the notarization, but this
-      #     is the one link that cannot be exercised without real signing/notary
-      #     creds — the "Verify stapled app in DMG" step below is the authoritative
-      #     release-time check that the ticket actually survived into the DMG.
+      # in the generated packageDmg.args.txt — so it wraps the on-disk app-image.
+      #
+      # `-x :desktop-app:createDistributable` EXCLUDES the producer from this
+      # invocation, so Gradle can neither re-run nor cache-restore it and thereby
+      # replace the stapled bundle. Verified locally (Compose 1.11.1): with the
+      # exclusion, a probe file added to the app-image survives into packageDmg's
+      # input, and createDistributable reports "excluded". (It also stayed
+      # UP-TO-DATE without the exclusion, but excluding removes all doubt, including
+      # any build-cache restore on the CI runner's shared gradle home.)
+      #
+      # jpackage still RE-SIGNS the app image while wrapping it (codesign --force).
+      # Stapling is signature-safe (the ticket does not change the cdhash), so a
+      # same-identity re-sign preserves the notarization — but that one link cannot
+      # be exercised without real signing/notary creds, so the "Verify stapled app
+      # in DMG" step below is the authoritative release-time check.
       - name: "Assemble DMG"
         if: matrix.platform == 'macos'
         uses: ./.github/actions/gradle-task-run
         with:
           gradle-tasks: ":desktop-app:packageDmg"
-          gradle-flags: '["-PdesktopPackageVersion=${{ inputs.version }}"]'
+          gradle-flags: '["-PdesktopPackageVersion=${{ inputs.version }}", "-x", ":desktop-app:createDistributable"]'
           gradle-project-directory: "android"
           gradle-home-directory: "~/.gradle/build-desktop-app-installers-${{ matrix.os }}"
           reuse-configuration-cache: true
@@ -232,6 +236,10 @@ jobs:
         run: |
           set -euo pipefail
           DMG=$(find desktop-app/build/compose/binaries/main/dmg -maxdepth 1 -type f -name '*.dmg' | head -n 1)
+          if [ -z "$DMG" ]; then
+            echo "No DMG was produced under desktop-app/build/compose/binaries/main/dmg" >&2
+            exit 1
+          fi
           MOUNT=$(mktemp -d)
           hdiutil attach "$DMG" -nobrowse -readonly -mountpoint "$MOUNT" >/dev/null
           trap 'hdiutil detach "$MOUNT" >/dev/null 2>&1 || true' EXIT

--- a/.github/workflows/build-desktop-app-installers.yml
+++ b/.github/workflows/build-desktop-app-installers.yml
@@ -180,9 +180,18 @@ jobs:
           xcrun stapler validate "$APP"
 
       # Assemble the DMG now that the app-image is stapled. Compose's packageDmg
-      # runs jpackage with `--app-image <the createDistributable output>`, so it
-      # wraps the already-stapled app rather than rebuilding it (createDistributable
-      # stays up-to-date — stapling touched its output, not its inputs).
+      # runs jpackage with `--app-image <the createDistributable output>` — verified
+      # in the generated packageDmg.args.txt — so it consumes the stapled app-image.
+      # Two facts verified locally against Compose 1.11.1 (unsigned):
+      #   - Gradle leaves createDistributable UP-TO-DATE when packageDmg runs in a
+      #     later invocation, even though the staple mutated its output dir, so the
+      #     stapled app-image is reused, not rebuilt.
+      #   - jpackage nonetheless RE-SIGNS the app image while wrapping it (codesign
+      #     --force). Stapling is signature-safe (the ticket does not change the
+      #     cdhash), so a same-identity re-sign preserves the notarization, but this
+      #     is the one link that cannot be exercised without real signing/notary
+      #     creds — the "Verify stapled app in DMG" step below is the authoritative
+      #     release-time check that the ticket actually survived into the DMG.
       - name: "Assemble DMG"
         if: matrix.platform == 'macos'
         uses: ./.github/actions/gradle-task-run

--- a/scripts/ci/notarize-macos-artifact.sh
+++ b/scripts/ci/notarize-macos-artifact.sh
@@ -1,0 +1,60 @@
+#!/usr/bin/env bash
+#
+# Notarize a single macOS artifact (a .zip, .dmg, or .pkg that `notarytool`
+# accepts) and fail unless Apple's verdict is "Accepted".
+#
+# `xcrun notarytool submit --wait` exits 0 even when the verdict is Invalid,
+# which previously let callers run on to `stapler staple` and die with an opaque
+# "Record not found" (error 65). This script parses the JSON verdict instead:
+# anything but Accepted is a hard failure, after dumping the notary log so the
+# per-file rejection reasons land in CI output.
+#
+# Stapling is intentionally NOT done here — the caller staples the artifact it
+# actually ships (the app bundle, then the DMG) after notarization succeeds.
+#
+# Usage:  notarize-macos-artifact.sh <artifact-path>
+# Env:    APPLE_NOTARY_KEY_PATH, APPLE_NOTARY_KEY_ID, APPLE_NOTARY_ISSUER_ID
+#         XCRUN (optional) — override the `xcrun` binary, for tests.
+set -euo pipefail
+
+artifact="${1:-}"
+if [ -z "${artifact}" ]; then
+  echo "usage: notarize-macos-artifact.sh <artifact-path>" >&2
+  exit 2
+fi
+if [ ! -e "${artifact}" ]; then
+  echo "notarize-macos-artifact: artifact not found: ${artifact}" >&2
+  exit 2
+fi
+
+: "${APPLE_NOTARY_KEY_PATH:?APPLE_NOTARY_KEY_PATH is required}"
+: "${APPLE_NOTARY_KEY_ID:?APPLE_NOTARY_KEY_ID is required}"
+: "${APPLE_NOTARY_ISSUER_ID:?APPLE_NOTARY_ISSUER_ID is required}"
+
+xcrun_bin="${XCRUN:-xcrun}"
+
+echo "Notarizing ${artifact}"
+submission_json=$("${xcrun_bin}" notarytool submit "${artifact}" \
+  --key "${APPLE_NOTARY_KEY_PATH}" \
+  --key-id "${APPLE_NOTARY_KEY_ID}" \
+  --issuer "${APPLE_NOTARY_ISSUER_ID}" \
+  --wait \
+  --output-format json)
+echo "${submission_json}"
+
+submission_id=$(jq -r '.id // empty' <<<"${submission_json}")
+status=$(jq -r '.status // empty' <<<"${submission_json}")
+
+if [ "${status}" != "Accepted" ]; then
+  echo "Notarization verdict: ${status:-unknown} (submission ${submission_id:-unknown})" >&2
+  if [ -n "${submission_id}" ]; then
+    # Best-effort: the log service can lag right after the verdict.
+    "${xcrun_bin}" notarytool log "${submission_id}" \
+      --key "${APPLE_NOTARY_KEY_PATH}" \
+      --key-id "${APPLE_NOTARY_KEY_ID}" \
+      --issuer "${APPLE_NOTARY_ISSUER_ID}" >&2 || true
+  fi
+  exit 1
+fi
+
+echo "Notarization accepted (submission ${submission_id:-unknown})"

--- a/test/bats/desktop-installer-app-staple.bats
+++ b/test/bats/desktop-installer-app-staple.bats
@@ -60,6 +60,13 @@ wiring_requires_yq() {
   run yq -r '.jobs.build.steps[] | select(.name == "Assemble DMG") | .with["gradle-tasks"]' "$WORKFLOW"
   [ "$status" -eq 0 ]
   [[ "$output" == *":desktop-app:packageDmg"* ]]
+
+  # The producer is EXCLUDED from this invocation (-x), so Gradle cannot re-run or
+  # cache-restore createDistributable and replace the stapled bundle.
+  run yq -r '.jobs.build.steps[] | select(.name == "Assemble DMG") | .with["gradle-flags"]' "$WORKFLOW"
+  [ "$status" -eq 0 ]
+  [[ "$output" == *"-x"* ]]
+  [[ "$output" == *":desktop-app:createDistributable"* ]]
 }
 
 @test "the release verifies the app inside the shipped DMG is stapled (AC-1 enforcement)" {

--- a/test/bats/desktop-installer-app-staple.bats
+++ b/test/bats/desktop-installer-app-staple.bats
@@ -1,0 +1,91 @@
+#!/usr/bin/env bats
+#
+# Regression guard for #4955: the macOS DMG packaging must staple the
+# notarization ticket to AutoMobile.app *inside* the DMG, not only to the DMG
+# container. A ticket stapled only to the DMG does not travel when the user drags
+# the app to /Applications, so offline first-launch falls back to an online
+# notarization check.
+#
+# That requires: build the signed app-image (createDistributable) -> notarize and
+# staple the app-image -> assemble the DMG from the stapled app-image
+# (packageDmg wraps the app-image via jpackage --app-image) -> notarize and staple
+# the DMG -> verify the app inside the shipped DMG is actually stapled, so a
+# regression fails the release instead of shipping an unstapled app.
+#
+# Parsed with yq (the repo's canonical workflow parser, see
+# release-workflow-wiring.bats), not grepped, so a value in a comment or another
+# job cannot satisfy these assertions.
+
+WORKFLOW=".github/workflows/build-desktop-app-installers.yml"
+
+wiring_requires_yq() {
+  command -v yq >/dev/null 2>&1 && return 0
+  if [[ -n "${CI:-}" ]]; then
+    echo "yq is required in CI to verify desktop installer workflow wiring" >&2
+    return 1
+  fi
+  skip "yq not installed"
+}
+
+@test "macOS packaging builds the app-image (createDistributable), not packageDmg directly" {
+  wiring_requires_yq
+  run yq -r '.jobs.build.strategy.matrix.include[] | select(.format == "dmg") | .["gradle-task"]' "$WORKFLOW"
+  [ "$status" -eq 0 ]
+  [[ "$output" == ":desktop-app:createDistributable" ]]
+}
+
+@test "the app image is notarized and stapled before the DMG is assembled" {
+  wiring_requires_yq
+
+  run yq -r '.jobs.build.steps[] | select(.name == "Notarize and staple app image") | .run' "$WORKFLOW"
+  [ "$status" -eq 0 ]
+  [[ "$output" == *"stapler staple"* ]]
+  [[ "$output" == *"binaries/main/app"* ]]
+
+  local app_idx dmg_assemble_idx dmg_staple_idx
+  app_idx="$(yq -r '.jobs.build.steps | to_entries[] | select(.value.name == "Notarize and staple app image") | .key' "$WORKFLOW")"
+  dmg_assemble_idx="$(yq -r '.jobs.build.steps | to_entries[] | select(.value.name == "Assemble DMG") | .key' "$WORKFLOW")"
+  dmg_staple_idx="$(yq -r '.jobs.build.steps | to_entries[] | select(.value.name == "Notarize and staple DMG") | .key' "$WORKFLOW")"
+  [ -n "$app_idx" ]
+  [ -n "$dmg_assemble_idx" ]
+  [ -n "$dmg_staple_idx" ]
+  # app-image staple happens before the DMG is assembled, which happens before the
+  # DMG is notarized/stapled.
+  [ "$app_idx" -lt "$dmg_assemble_idx" ]
+  [ "$dmg_assemble_idx" -lt "$dmg_staple_idx" ]
+}
+
+@test "the DMG is assembled with packageDmg from the already-stapled app image" {
+  wiring_requires_yq
+  run yq -r '.jobs.build.steps[] | select(.name == "Assemble DMG") | .with["gradle-tasks"]' "$WORKFLOW"
+  [ "$status" -eq 0 ]
+  [[ "$output" == *":desktop-app:packageDmg"* ]]
+}
+
+@test "the release verifies the app inside the shipped DMG is stapled (AC-1 enforcement)" {
+  wiring_requires_yq
+  # A dedicated step mounts the built DMG and stapler-validates the app INSIDE it,
+  # so a regression that ships an unstapled app fails the release rather than
+  # silently regressing offline first-launch.
+  local run_block
+  run_block="$(yq -r '.jobs.build.steps[] | select(.name == "Verify stapled app in DMG") | .run' "$WORKFLOW")"
+  [ -n "$run_block" ]
+  # Mounts the DMG, locates the .app inside the mount, and staples-validates it.
+  [[ "$run_block" == *"hdiutil attach"* ]]
+  [[ "$run_block" == *".app"* ]]
+  [[ "$run_block" == *"stapler validate"* ]]
+
+  # It runs after the DMG has been assembled and stapled.
+  local dmg_staple_idx verify_idx
+  dmg_staple_idx="$(yq -r '.jobs.build.steps | to_entries[] | select(.value.name == "Notarize and staple DMG") | .key' "$WORKFLOW")"
+  verify_idx="$(yq -r '.jobs.build.steps | to_entries[] | select(.value.name == "Verify stapled app in DMG") | .key' "$WORKFLOW")"
+  [ -n "$verify_idx" ]
+  [ "$dmg_staple_idx" -lt "$verify_idx" ]
+}
+
+@test "the existing DMG notarize + staple is retained (AC-3: no regression)" {
+  wiring_requires_yq
+  run yq -r '.jobs.build.steps[] | select(.name == "Notarize and staple DMG") | .run' "$WORKFLOW"
+  [ "$status" -eq 0 ]
+  [[ "$output" == *'stapler staple "$DMG"'* ]]
+}

--- a/test/bats/notarize-macos-artifact.bats
+++ b/test/bats/notarize-macos-artifact.bats
@@ -1,0 +1,84 @@
+#!/usr/bin/env bats
+#
+# Unit tests for scripts/ci/notarize-macos-artifact.sh — the shared macOS
+# notarization-verdict gate used by the desktop installer workflow for both the
+# app bundle and the DMG (#4955). `xcrun` is mocked via the XCRUN override so no
+# network / Apple credentials are needed.
+
+SCRIPT="scripts/ci/notarize-macos-artifact.sh"
+
+setup() {
+  TEST_ROOT="$(mktemp -d)"
+  ARTIFACT="${TEST_ROOT}/thing.zip"
+  echo "artifact bytes" >"${ARTIFACT}"
+  XCRUN_LOG="${TEST_ROOT}/xcrun.log"
+
+  export APPLE_NOTARY_KEY_PATH="${TEST_ROOT}/key.p8"
+  export APPLE_NOTARY_KEY_ID="KEYID"
+  export APPLE_NOTARY_ISSUER_ID="ISSUER"
+  echo "key" >"${APPLE_NOTARY_KEY_PATH}"
+}
+
+teardown() {
+  rm -rf "${TEST_ROOT}"
+}
+
+# Write a fake `xcrun` whose `notarytool submit` prints the given verdict JSON.
+make_fake_xcrun() {
+  local status="$1"
+  cat >"${TEST_ROOT}/xcrun" <<FAKE
+#!/usr/bin/env bash
+echo "\$@" >> "${XCRUN_LOG}"
+case "\$2" in
+  submit) echo '{"id":"sub-123","status":"${status}"}' ;;
+  log)    echo '{"issues":[{"message":"example"}]}' ;;
+esac
+FAKE
+  chmod +x "${TEST_ROOT}/xcrun"
+  export XCRUN="${TEST_ROOT}/xcrun"
+}
+
+@test "exits 0 when the notary verdict is Accepted" {
+  make_fake_xcrun "Accepted"
+  run bash "${SCRIPT}" "${ARTIFACT}"
+  [ "$status" -eq 0 ]
+  [[ "$output" == *"Notarization accepted"* ]]
+  # It must not have queried the failure log on success.
+  ! grep -q "^notarytool log" "${XCRUN_LOG}"
+}
+
+@test "fails when the verdict is Invalid and dumps the notary log" {
+  make_fake_xcrun "Invalid"
+  run bash "${SCRIPT}" "${ARTIFACT}"
+  [ "$status" -eq 1 ]
+  [[ "$output" == *"Notarization verdict: Invalid"* ]]
+  # It fetched the per-file rejection log for the failed submission.
+  grep -q "notarytool log sub-123" "${XCRUN_LOG}"
+}
+
+@test "fails when the verdict is missing (treated as not Accepted)" {
+  make_fake_xcrun ""
+  run bash "${SCRIPT}" "${ARTIFACT}"
+  [ "$status" -eq 1 ]
+}
+
+@test "errors with usage when no artifact is given" {
+  make_fake_xcrun "Accepted"
+  run bash "${SCRIPT}"
+  [ "$status" -eq 2 ]
+  [[ "$output" == *"usage:"* ]]
+}
+
+@test "errors when the artifact path does not exist" {
+  make_fake_xcrun "Accepted"
+  run bash "${SCRIPT}" "${TEST_ROOT}/nope.zip"
+  [ "$status" -eq 2 ]
+  [[ "$output" == *"not found"* ]]
+}
+
+@test "errors when a required notary credential env var is unset" {
+  make_fake_xcrun "Accepted"
+  unset APPLE_NOTARY_KEY_ID
+  run bash "${SCRIPT}" "${ARTIFACT}"
+  [ "$status" -ne 0 ]
+}


### PR DESCRIPTION
## Summary

The macOS desktop installer notarized and stapled only the **DMG container**; the
`AutoMobile.app` bundle inside never received its own ticket. A DMG-stapled ticket
does not travel when the user drags the app to `/Applications`, so an offline
first launch fell back to an online notarization check. Online users (effectively
all users) were unaffected — this closes the offline gap.

Closes #4955

## Changes

- `.github/workflows/build-desktop-app-installers.yml` — rework the macOS DMG path:
  - the macOS matrix row now builds `:desktop-app:createDistributable` (the signed
    app-image) instead of `:desktop-app:packageDmg` directly;
  - **new** step notarizes + staples the app-image *before* the DMG exists;
  - **new** step assembles the DMG with `:desktop-app:packageDmg`, which wraps the
    already-stapled app-image via `jpackage --app-image` (createDistributable stays
    up-to-date — stapling touches its output, not its inputs — so its stapled
    output is reused, not rebuilt);
  - the DMG is notarized + stapled as before;
  - **new** step mounts the shipped DMG and `stapler validate`s the app **inside**
    it, so a regression fails the release instead of shipping an unstapled app.
- `scripts/ci/notarize-macos-artifact.sh` — extract the notarize-verdict gate
  (`notarytool submit --wait`, fail on any verdict but `Accepted`, dump the notary
  log) into a shared script, now used by both the app-image and DMG steps
  (previously inline in the DMG step only). `xcrun` is overridable via `$XCRUN`.
- `test/bats/notarize-macos-artifact.bats` — unit tests for that script with a
  mocked `xcrun` (Accepted → 0; Invalid → 1 + log fetch; missing verdict/args).
- `test/bats/desktop-installer-app-staple.bats` — structural guard (yq-parsed)
  that the workflow builds the app-image, stapls it before assembling the DMG,
  and verifies the inner app is stapled.

## Acceptance criteria

- [x] **AC-1** — the app inside the shipped DMG is stapled: enforced at release by
  the "Verify stapled app in DMG" step (`stapler validate` on the mounted app), and
  pinned structurally by BATS.
- [x] **AC-2** — `spctl -a -t exec` stays `Accepted`: the app-image is notarized
  (verdict-gated) before stapling, so notarization is unchanged in kind.
- [x] **AC-3** — no change to the Developer ID signature, hardened runtime, or DMG
  staple: Compose signing is untouched; the DMG notarize+staple is preserved
  (BATS asserts it remains).

## Testing

- `bats test/bats/desktop-installer-app-staple.bats test/bats/notarize-macos-artifact.bats` — 11/11
- Full `bats test/bats/` — 813 pass (no regression to existing workflow-structural tests)
- `scripts/shellcheck/validate_shell_scripts.sh` / `validate_shell_portability.sh` / `validate_shell_sete.sh` — all clean
- `bun run typecheck` — no new errors; no TS touched
- YAML parses

## Validation caveat (important)

This workflow is `workflow_call`-only (invoked from `prepare-release.yml`) and runs
with Apple Developer secrets on a macOS runner — it does **not** run on PRs, and
notarization cannot be exercised locally. So the actual staple/notarize behavior is
verified only at the **next release cut**. Pre-merge coverage is therefore
structural (BATS/yq) + the mocked-`xcrun` unit tests + shellcheck; the real AC-1
check is the in-workflow "Verify stapled app in DMG" step, which fails the release
if the app ships unstapled.

## Risk

Higher-risk release-engineering (signed-release packaging path, only exercised at
release). The load-bearing assumption — that `packageDmg` reuses the stapled
app-image rather than rebuilding it — rests on the Compose plugin passing
`--app-image <createDistributable output>` (confirmed in the plugin bytecode) and
is backstopped by the release-time inner-app validation.
