### PR TITLE
feat(webrtc): move Android H.264 encoder to Main profile, per-source

### DIFF
--- a/android/video-server/src/main/kotlin/dev/jasonpearson/automobile/video/H264EncoderProfile.kt
+++ b/android/video-server/src/main/kotlin/dev/jasonpearson/automobile/video/H264EncoderProfile.kt
@@ -1,0 +1,22 @@
+package dev.jasonpearson.automobile.video
+
+import android.media.MediaCodecInfo
+
+/**
+ * The H.264 profile the on-device MediaCodec encoder ([VideoEncoder]) requests.
+ *
+ * Main profile (issue #4756) saves ~10-30% bitrate at equal quality versus Constrained Baseline —
+ * CABAC entropy coding with no B-frames, so no added latency — and both werift and Chromium decode
+ * it. WebRTC negotiates exactly one `profile-level-id` per WHIP session, so the host publisher
+ * advertises the matching Main `profile-level-id` (`4d002a`) and validates this encoder's SPS
+ * against it. iOS and synthetic sources keep negotiating Constrained Baseline on their own
+ * sessions; a GLOBAL Main switch was the reverted #4877 regression.
+ *
+ * These are `public static final int` constants in `android.jar` (Baseline = 0x01, Main = 0x02), so
+ * they are inlined at compile time and remain readable under the module's compile-only Android stub
+ * (no MediaCodec runtime), which lets [H264EncoderProfileTest] pin the choice.
+ */
+internal object H264EncoderProfile {
+  /** Profile passed to `MediaFormat.KEY_PROFILE`. */
+  const val KEY_PROFILE: Int = MediaCodecInfo.CodecProfileLevel.AVCProfileMain
+}

--- a/android/video-server/src/main/kotlin/dev/jasonpearson/automobile/video/VideoEncoder.kt
+++ b/android/video-server/src/main/kotlin/dev/jasonpearson/automobile/video/VideoEncoder.kt
@@ -11,7 +11,9 @@ import android.view.Surface
  * MediaCodec wrapper for H.264 encoding with Surface input.
  *
  * Configures the encoder for low-latency streaming with:
- * - H.264 Baseline profile for maximum compatibility
+ * - H.264 Main profile ([H264EncoderProfile]) — saves ~10-30% bitrate at equal quality vs
+ *   Constrained Baseline (CABAC, no B-frames, so no added latency). werift and Chromium both decode
+ *   Main. The host publisher advertises the matching `profile-level-id` per session (issue #4756).
  * - Surface input for zero-copy GPU rendering
  * - VBR bitrate mode so bursty screen content lets idle frames stay cheap and transitions borrow
  *   headroom
@@ -63,14 +65,13 @@ class VideoEncoder(
         // Repeat frame after 100ms of no changes (reduces idle bandwidth)
         setLong(MediaFormat.KEY_REPEAT_PREVIOUS_FRAME_AFTER, 100_000)
 
-        // Request baseline profile but let MediaCodec choose a supported level
-        // for this device and capture size. The publisher validates the emitted
-        // SPS before forwarding it, so an unsupported encoder level reconnects
-        // safely instead of making MediaCodec.configure() fail up front.
-        setInteger(
-          MediaFormat.KEY_PROFILE,
-          MediaCodecInfo.CodecProfileLevel.AVCProfileBaseline,
-        )
+        // Request Main profile (issue #4756) but let MediaCodec choose a supported
+        // level for this device and capture size. Main is universally supported by
+        // hardware AVC encoders on modern API levels; the host publisher validates
+        // the emitted SPS profile against the negotiated Main profile-level-id
+        // before forwarding, so a device that falls back to a different profile
+        // reconnects safely instead of making MediaCodec.configure() fail up front.
+        setInteger(MediaFormat.KEY_PROFILE, H264EncoderProfile.KEY_PROFILE)
 
         // VBR (not CBR) for bursty screen-automation content. The transport is
         // adb forward over USB, so CBR's predictable pacing buys little here while

--- a/android/video-server/src/test/kotlin/dev/jasonpearson/automobile/video/H264EncoderProfileTest.kt
+++ b/android/video-server/src/test/kotlin/dev/jasonpearson/automobile/video/H264EncoderProfileTest.kt
@@ -1,0 +1,38 @@
+package dev.jasonpearson.automobile.video
+
+import org.junit.Assert.assertEquals
+import org.junit.Assert.assertNotEquals
+import org.junit.Test
+
+/**
+ * Pins the on-device encoder to H.264 Main profile (issue #4756).
+ *
+ * `H264EncoderProfile.KEY_PROFILE` is a `const val` initialized from
+ * `MediaCodecInfo.CodecProfileLevel.AVCProfileMain`, a `public static final int` in `android.jar`.
+ * Kotlin inlines that compile-time constant, so this test can pin the numeric value without the
+ * Android stub on the test classpath (this module compiles android APIs `compileOnly` and has no
+ * MediaCodec runtime — see [VideoServerRotationSwapTest]).
+ *
+ * `MediaCodecInfo.CodecProfileLevel` defines `AVCProfileBaseline = 0x01` and `AVCProfileMain =
+ * 0x02` (stable platform constants). This is the Kotlin half of the per-source contract: the
+ * encoder emits Main, and the host publisher (`src/features/webrtc/h264Level.ts` +
+ * `h264ProfileNegotiation.test.ts`) advertises and validates Main for the Android session while
+ * keeping Baseline for iOS/synthetic sources. Reverting to Baseline here — the #4877 direction —
+ * changes the inlined constant and reddens this test.
+ */
+class H264EncoderProfileTest {
+  private companion object {
+    const val AVC_PROFILE_BASELINE = 0x01
+    const val AVC_PROFILE_MAIN = 0x02
+  }
+
+  @Test
+  fun `encoder requests Main profile`() {
+    assertEquals(AVC_PROFILE_MAIN, H264EncoderProfile.KEY_PROFILE)
+  }
+
+  @Test
+  fun `encoder no longer requests Constrained Baseline`() {
+    assertNotEquals(AVC_PROFILE_BASELINE, H264EncoderProfile.KEY_PROFILE)
+  }
+}

--- a/src/features/webrtc/WebRtcPublisher.ts
+++ b/src/features/webrtc/WebRtcPublisher.ts
@@ -13,10 +13,12 @@ import { ReconnectController, type ReconnectState } from "./ReconnectController"
 import { RtpH264TrackWriter } from "./RtpH264TrackWriter";
 import { RtpPcmuTrackWriter } from "./RtpPcmuTrackWriter";
 import {
+  DEFAULT_H264_PROFILE,
   evaluateH264SpsForSend,
-  isCompatibleConstrainedBaselineProfile,
+  h264ProfileLevelId,
+  isCompatibleProfileForSession,
   WEBRTC_H264_LEVEL_IDC,
-  WEBRTC_H264_PROFILE_LEVEL_ID,
+  type H264Profile,
 } from "./h264Level";
 import { parseTrickleIceMediaContexts, TrickleIceForwarder } from "./trickleIce";
 import { WhipClient, type WhipClientOptions } from "./WhipClient";
@@ -56,6 +58,15 @@ export interface WebRtcPublisherConfig {
   trickleIce?: boolean;
   /** Add a sendonly PCMU audio track alongside video. Defaults to false. */
   audioEnabled?: boolean;
+  /**
+   * H.264 profile this session negotiates, chosen by the capture source feeding
+   * it. The Android MediaCodec source declares `"main"`; the iOS ffmpeg and
+   * synthetic sources declare (or default to) `"constrained-baseline"`. The
+   * publisher advertises the matching `profile-level-id` in the SDP offer and
+   * validates each source SPS against THIS profile — never a global profile,
+   * which is the #4877 regression. Defaults to constrained baseline.
+   */
+  h264Profile?: H264Profile;
   /**
    * If set (> 0), while the connection is `connected` the publisher watches for
    * the frame counter to stop advancing. A source that stays alive but stops
@@ -216,6 +227,7 @@ export class WebRtcPublisher {
 
   private readonly trickleIce: boolean;
   private readonly audioEnabled: boolean;
+  private readonly h264Profile: H264Profile;
 
   private pc: RTCPeerConnection | null = null;
   private writer: RtpH264TrackWriter | null = null;
@@ -246,6 +258,7 @@ export class WebRtcPublisher {
     this.config = config;
     this.trickleIce = config.trickleIce ?? false;
     this.audioEnabled = config.audioEnabled ?? false;
+    this.h264Profile = config.h264Profile ?? DEFAULT_H264_PROFILE;
     this.timer = deps.timer ?? defaultTimer;
     this.onBeforeEstablish = deps.onBeforeEstablish;
     this.onConnected = deps.onConnected;
@@ -262,8 +275,8 @@ export class WebRtcPublisher {
           // gathers/trickles ICE candidates (RFC 9725 §4.3.2).
           bundlePolicy: "max-bundle",
           codecs: this.audioEnabled
-            ? { video: [useH264({ parameters: h264CodecParameters() })], audio: [usePCMU()] }
-            : { video: [useH264({ parameters: h264CodecParameters() })] },
+            ? { video: [useH264({ parameters: h264CodecParameters(this.h264Profile) })], audio: [usePCMU()] }
+            : { video: [useH264({ parameters: h264CodecParameters(this.h264Profile) })] },
         }));
     const createWhip = deps.createWhipClient ?? (options => new WhipClient(options));
     this.whip = createWhip({
@@ -444,7 +457,7 @@ export class WebRtcPublisher {
         mtu: this.config.mtu ?? DEFAULT_RTP_MTU,
         timer: this.timer,
         onSps: sps => {
-          const spsCompatibility = evaluateH264SpsForSend(sps);
+          const spsCompatibility = evaluateH264SpsForSend(sps, this.h264Profile);
           if (!spsCompatibility.compatible) {
             throw new Error(spsCompatibility.reason);
           }
@@ -512,9 +525,9 @@ export class WebRtcPublisher {
       // WHIP forbids a misleading partially successful ingest session: reject
       // an answer that did not accept each requested media section.
       // RFC 9725 §4.4.3: https://www.rfc-editor.org/rfc/rfc9725.html#section-4.4.3
-      assertWhipAnswerAcceptsMedia(session.answerSdp, "video", "h264");
+      assertWhipAnswerAcceptsMedia(session.answerSdp, "video", "h264", this.h264Profile);
       if (this.audioEnabled) {
-        assertWhipAnswerAcceptsMedia(session.answerSdp, "audio", "pcmu");
+        assertWhipAnswerAcceptsMedia(session.answerSdp, "audio", "pcmu", this.h264Profile);
       }
 
       this.establishing = false;
@@ -827,7 +840,8 @@ export class WebRtcPublisher {
 function assertWhipAnswerAcceptsMedia(
   answerSdp: string,
   kind: "audio" | "video",
-  codec: "h264" | "pcmu"
+  codec: "h264" | "pcmu",
+  profile: H264Profile
 ): void {
   const section = findSdpMediaSection(answerSdp, kind);
   if (!section) {
@@ -857,7 +871,7 @@ function assertWhipAnswerAcceptsMedia(
   const staticPayloadType = codec === "pcmu" ? "0" : undefined;
   const accepted =
     (staticPayloadType !== undefined && formats.has(staticPayloadType)) ||
-    attributeLines.some(line => isAcceptedCodecRtpMap(line, formats, codec, attributeLines));
+    attributeLines.some(line => isAcceptedCodecRtpMap(line, formats, codec, attributeLines, profile));
   if (!accepted) {
     throw new Error(`WHIP answer did not accept ${codec.toUpperCase()} ${kind}.`);
   }
@@ -894,7 +908,8 @@ function isAcceptedCodecRtpMap(
   line: string,
   formats: Set<string>,
   codec: string,
-  attributeLines: string[]
+  attributeLines: string[],
+  profile: H264Profile
 ): boolean {
   const match = line.match(/^a=rtpmap:(\S+)\s+([^/\s]+)\/(\d+)/i);
   if (!match || !formats.has(match[1]) || match[2].toLowerCase() !== codec) {
@@ -904,8 +919,9 @@ function isAcceptedCodecRtpMap(
     return true;
   }
   // AutoMobile packetizes H.264 at the RFC 6184 fixed 90 kHz clock rate and
-  // uses FU-A, which requires packetization-mode=1. The local werift codec is
-  // constrained-baseline 42e0xx; level may differ when asymmetry is negotiated.
+  // uses FU-A, which requires packetization-mode=1. The local werift codec's
+  // profile is this session's `profile` (Baseline 42e0xx or Main 4d00xx); level
+  // may differ when asymmetry is negotiated.
   return match[3] === "90000" && attributeLines.some(fmtp => {
     if (!fmtp.startsWith(`a=fmtp:${match[1]} `)) {
       return false;
@@ -913,16 +929,24 @@ function isAcceptedCodecRtpMap(
     const parameters = fmtp.slice(fmtp.indexOf(" ") + 1);
     const packetizationMode = /(?:^|;)\s*packetization-mode\s*=\s*1(?:;|$)/i.test(parameters);
     const profileLevelId = /(?:^|;)\s*profile-level-id\s*=\s*([0-9a-f]{6})(?:;|$)/i.exec(parameters)?.[1];
-    return packetizationMode && profileLevelId !== undefined && acceptsLocalH264Send(parameters, profileLevelId);
+    return (
+      packetizationMode &&
+      profileLevelId !== undefined &&
+      acceptsLocalH264Send(parameters, profileLevelId, profile)
+    );
   });
 }
 
-function h264CodecParameters(): string {
-  return `profile-level-id=${WEBRTC_H264_PROFILE_LEVEL_ID};packetization-mode=1;level-asymmetry-allowed=1`;
+function h264CodecParameters(profile: H264Profile): string {
+  return `profile-level-id=${h264ProfileLevelId(profile)};packetization-mode=1;level-asymmetry-allowed=1`;
 }
 
-function acceptsLocalH264Send(parameters: string, profileLevelId: string): boolean {
-  if (!isCompatibleConstrainedBaselineProfile(profileLevelId)) {
+function acceptsLocalH264Send(
+  parameters: string,
+  profileLevelId: string,
+  profile: H264Profile
+): boolean {
+  if (!isCompatibleProfileForSession(profileLevelId, profile)) {
     return false;
   }
   const answerLevelIdc = Number.parseInt(profileLevelId.slice(4, 6), 16);

--- a/src/features/webrtc/h264Level.ts
+++ b/src/features/webrtc/h264Level.ts
@@ -1,14 +1,45 @@
 /**
- * The constrained-baseline level advertised by AutoMobile's WebRTC sender.
+ * The H.264 profiles AutoMobile's WebRTC sender negotiates, per capture source.
  *
- * Level 4.2 supports 8,192 macroblocks per picture and 522,240 macroblocks
- * per second (RFC 6184 §8.2.2 and ITU-T H.264 Annex A). That covers AutoMobile's
- * 1080p/60 Android preset while keeping the SDP offer truthful.
+ * WebRTC negotiates exactly ONE `profile-level-id` per WHIP session, so the
+ * advertised profile and the SPS-acceptance gate must depend on WHICH source
+ * feeds that session — they are NOT global:
+ *
+ *  - The Android `video-server` MediaCodec encoder emits **Main** (`4d002a`).
+ *    Main saves ~10-30% bitrate at equal quality (CABAC, no B-frames, no added
+ *    latency) and both werift and Chromium decode it.
+ *  - The iOS ffmpeg source and the synthetic MediaMTX test source emit
+ *    **Constrained Baseline** (`42e02a`) and must keep negotiating Baseline.
+ *
+ * A GLOBAL Main switch is exactly the #4877 regression: it made this gate reject
+ * the Baseline SPS that the iOS and synthetic sources still produce, breaking the
+ * merge-only MediaMTX publisher integration test. The gate here is therefore
+ * always evaluated against the session's negotiated {@link H264Profile}, never a
+ * single global assumption.
+ *
+ * Level 4.2 supports 8,192 macroblocks per picture and 522,240 macroblocks per
+ * second (RFC 6184 §8.2.2 and ITU-T H.264 Annex A). That covers AutoMobile's
+ * 1080p/60 preset for both profiles while keeping the SDP offer truthful.
  * https://www.rfc-editor.org/rfc/rfc6184.html#section-8.2.2
  */
+
+/** Which H.264 profile a capture source encodes and its WHIP session negotiates. */
+export type H264Profile = "constrained-baseline" | "main";
+
+/** The profile a session negotiates when a source does not declare one. */
+export const DEFAULT_H264_PROFILE: H264Profile = "constrained-baseline";
+
+/** Constrained Baseline (profile_idc 0x42), Level 4.2 — iOS ffmpeg + synthetic sources. */
 export const WEBRTC_H264_PROFILE_LEVEL_ID = "42e02a";
+/** Main (profile_idc 0x4d, profile-iop 0x00), Level 4.2 — Android MediaCodec source. */
+export const WEBRTC_H264_MAIN_PROFILE_LEVEL_ID = "4d002a";
 export const WEBRTC_H264_LEVEL_IDC = 0x2a;
 export const WEBRTC_H264_MAX_MACROBLOCKS_PER_FRAME = 8_192;
+
+/** The `profile-level-id` AutoMobile advertises in the SDP offer for `profile`. */
+export function h264ProfileLevelId(profile: H264Profile): string {
+  return profile === "main" ? WEBRTC_H264_MAIN_PROFILE_LEVEL_ID : WEBRTC_H264_PROFILE_LEVEL_ID;
+}
 
 /** Return the number of 16x16 H.264 macroblocks needed for a frame. */
 export function h264MacroblocksPerFrame(width: number, height: number): number {
@@ -32,7 +63,7 @@ export function h264SpsLevelIdc(nal: Buffer): number | undefined {
 
 /** Result of validating an encoded SPS against the negotiated send profile. */
 export interface H264SpsSendCompatibility {
-  /** Whether the SPS may be sent over the negotiated constrained-baseline track. */
+  /** Whether the SPS may be sent over the negotiated track. */
   compatible: boolean;
   /** Human-readable reason when `compatible` is false; omitted when compatible. */
   reason?: string;
@@ -40,21 +71,26 @@ export interface H264SpsSendCompatibility {
 
 /**
  * Decide whether an encoded SPS NAL from a capture source may be sent on the
- * WHIP track, given the profile and level AutoMobile negotiates.
+ * WHIP track, given the {@link H264Profile} AutoMobile negotiated for THAT
+ * session and the level it advertises.
  *
  * This is the single source of truth for the runtime acceptance gate: the
  * publisher's `onSps` hook delegates here so the decision cannot drift between
- * the real send path and the fast profile-negotiation test. A source whose SPS
- * this function rejects will never render — that is exactly the #4877 regression
- * (a global Main-profile switch made this reject the Baseline SPS that the iOS
- * ffmpeg and synthetic sources actually emit).
+ * the real send path and the fast profile-negotiation test. Validation is
+ * per-source — a Main session accepts a Main SPS, a Baseline session accepts a
+ * Baseline SPS — so no profile a real source emits is ever globally rejected.
+ * A global rejection of Baseline is exactly the #4877 regression (a Main-only
+ * switch broke the iOS ffmpeg and synthetic sources that still emit Baseline).
  */
-export function evaluateH264SpsForSend(sps: Buffer): H264SpsSendCompatibility {
+export function evaluateH264SpsForSend(
+  sps: Buffer,
+  profile: H264Profile = DEFAULT_H264_PROFILE
+): H264SpsSendCompatibility {
   const profileLevelId = h264SpsProfileLevelId(sps);
-  if (profileLevelId && !isCompatibleConstrainedBaselineProfile(profileLevelId)) {
+  if (profileLevelId && !isCompatibleProfileForSession(profileLevelId, profile)) {
     return {
       compatible: false,
-      reason: `H.264 SPS profile ${profileLevelId.slice(0, 4)} is incompatible with negotiated constrained baseline.`,
+      reason: `H.264 SPS profile ${profileLevelId.slice(0, 4)} is incompatible with negotiated ${profile}.`,
     };
   }
   const levelIdc = h264SpsLevelIdc(sps);
@@ -67,6 +103,17 @@ export function evaluateH264SpsForSend(sps: Buffer): H264SpsSendCompatibility {
   return { compatible: true };
 }
 
+/**
+ * Whether `profileLevelId` matches the profile family a session negotiated.
+ * Dispatches per-source so Baseline and Main are each accepted only for their
+ * own session; there is no union that would let one session accept the other.
+ */
+export function isCompatibleProfileForSession(profileLevelId: string, profile: H264Profile): boolean {
+  return profile === "main"
+    ? isCompatibleMainProfile(profileLevelId)
+    : isCompatibleConstrainedBaselineProfile(profileLevelId);
+}
+
 /** Whether a profile-level-id is compatible with AutoMobile constrained baseline. */
 export function isCompatibleConstrainedBaselineProfile(profileLevelId: string): boolean {
   // Accept the whole Baseline family (profile_idc 66 / 0x42), regardless of the
@@ -76,9 +123,23 @@ export function isCompatibleConstrainedBaselineProfile(profileLevelId: string): 
   // device encoders routinely emit (`42 80 xx`, constraint_set0 only, or
   // `42 00 xx`). Because reconnecting cannot change a fixed-profile encoder, that
   // rejection turned into an endless reconnect loop that never rendered a frame.
-  // Non-Baseline profiles (Main 0x4d, High 0x64) are still rejected — those
-  // genuinely differ and are handled by the caller.
+  // Non-Baseline profiles (Main 0x4d, High 0x64) are still rejected here — those
+  // genuinely differ and are matched by their own session profile.
   // https://www.rfc-editor.org/rfc/rfc6184.html#section-8.2.2
   const profileIdc = Number.parseInt(profileLevelId.slice(0, 2), 16);
   return profileIdc === 0x42;
+}
+
+/**
+ * Whether a profile-level-id is compatible with AutoMobile's Main-profile send
+ * path (the Android MediaCodec source). Accepts the Main family (profile_idc 77
+ * / 0x4d) regardless of constraint flags. Baseline (0x42) and High (0x64) are
+ * rejected for a Main session — each source validates against its own profile,
+ * so a Main session never has to accept a foreign profile. Chromium and werift
+ * both decode Main, so advertising it does not narrow viewer compatibility.
+ * https://www.rfc-editor.org/rfc/rfc6184.html#section-8.2.2
+ */
+export function isCompatibleMainProfile(profileLevelId: string): boolean {
+  const profileIdc = Number.parseInt(profileLevelId.slice(0, 2), 16);
+  return profileIdc === 0x4d;
 }

--- a/src/server/webrtcStreamManager.ts
+++ b/src/server/webrtcStreamManager.ts
@@ -337,6 +337,10 @@ function createStreamRecord(
       bitrateBps,
       trickleIce: config.trickleIce,
       audioEnabled: config.audioEnabled,
+      // The Android video-server MediaCodec encoder emits Main (issue #4756);
+      // iOS ffmpeg and every other source stay Constrained Baseline. WebRTC
+      // negotiates one profile-level-id per session, so it must track the source.
+      h264Profile: device.platform === "android" ? "main" : "constrained-baseline",
       frameStallTimeoutMs: FRAME_STALL_TIMEOUT_MS,
     },
     {

--- a/test/daemon/webrtcStreamSocketServer.test.ts
+++ b/test/daemon/webrtcStreamSocketServer.test.ts
@@ -339,7 +339,9 @@ describe("WebRtcStreamSocketServer", () => {
           createWhipClient: (options: WhipClientOptions) =>
             new WhipClient({
               ...options,
-              fetchImpl: createSuccessfulWhipFetch(posts),
+              // ANDROID negotiates Main (issue #4756); a conformant WHIP server
+              // echoes the offered Main profile-level-id.
+              fetchImpl: createSuccessfulWhipFetch(posts, "/whip/resource/debug-1", "4d002a"),
             }),
           timer: new FakeTimer(),
         }),

--- a/test/features/webrtc/WebRtcPublisher.test.ts
+++ b/test/features/webrtc/WebRtcPublisher.test.ts
@@ -365,7 +365,7 @@ describe("WebRtcPublisher.notifySourceFailed", () => {
 
     publisher.writeH264Chunk(Buffer.from([0, 0, 0, 1, 0x67, 0x64, 0x00, 0x1f, 0, 0, 0, 1]));
 
-    expect(failure?.message).toContain("incompatible with negotiated constrained baseline");
+    expect(failure?.message).toContain("incompatible with negotiated constrained-baseline");
     await publisher.stop();
   });
 

--- a/test/features/webrtc/h264Level.test.ts
+++ b/test/features/webrtc/h264Level.test.ts
@@ -1,8 +1,14 @@
 import { describe, expect, test } from "bun:test";
 import {
+  evaluateH264SpsForSend,
+  h264ProfileLevelId,
   h264SpsLevelIdc,
   h264SpsProfileLevelId,
   isCompatibleConstrainedBaselineProfile,
+  isCompatibleMainProfile,
+  isCompatibleProfileForSession,
+  WEBRTC_H264_MAIN_PROFILE_LEVEL_ID,
+  WEBRTC_H264_PROFILE_LEVEL_ID,
 } from "../../../src/features/webrtc/h264Level";
 
 describe("H.264 SDP and SPS capability helpers", () => {
@@ -23,5 +29,54 @@ describe("H.264 SDP and SPS capability helpers", () => {
     // Main (0x4d) and High (0x64) are still rejected — genuinely different profiles.
     expect(isCompatibleConstrainedBaselineProfile("64001f")).toBe(false);
     expect(isCompatibleConstrainedBaselineProfile("4d401f")).toBe(false);
+  });
+
+  test("accepts the whole Main family but rejects a different profile (#4756)", () => {
+    // The Android MediaCodec source (issue #4756) emits Main; accept the family
+    // regardless of the profile-iop/constraint byte the device encoder writes.
+    expect(isCompatibleMainProfile("4d002a")).toBe(true);
+    expect(isCompatibleMainProfile("4d401f")).toBe(true);
+    // Baseline (0x42) and High (0x64) are rejected for a Main session.
+    expect(isCompatibleMainProfile("42e02a")).toBe(false);
+    expect(isCompatibleMainProfile("64001f")).toBe(false);
+  });
+
+  test("advertises the profile-level-id matching each session profile", () => {
+    expect(h264ProfileLevelId("constrained-baseline")).toBe(WEBRTC_H264_PROFILE_LEVEL_ID);
+    expect(h264ProfileLevelId("main")).toBe(WEBRTC_H264_MAIN_PROFILE_LEVEL_ID);
+    // Level 4.2 (level_idc 0x2a) for both profiles.
+    expect(WEBRTC_H264_PROFILE_LEVEL_ID).toBe("42e02a");
+    expect(WEBRTC_H264_MAIN_PROFILE_LEVEL_ID).toBe("4d002a");
+  });
+
+  test("per-session dispatch validates each source's SPS against its own profile", () => {
+    // No global reject: a Main session accepts Main, a Baseline session accepts
+    // Baseline, and neither accepts the other's profile (the #4877 failure mode).
+    expect(isCompatibleProfileForSession("4d002a", "main")).toBe(true);
+    expect(isCompatibleProfileForSession("42e02a", "constrained-baseline")).toBe(true);
+    expect(isCompatibleProfileForSession("42e02a", "main")).toBe(false);
+    expect(isCompatibleProfileForSession("4d002a", "constrained-baseline")).toBe(false);
+  });
+
+  test("evaluateH264SpsForSend accepts each real source's SPS under its profile", () => {
+    // Android Main SPS on a Main session; iOS/synthetic Baseline SPS on a Baseline
+    // session. The default profile is Baseline, so a bare call keeps old behavior.
+    expect(evaluateH264SpsForSend(Buffer.from([0x67, 0x4d, 0x00, 0x2a]), "main")).toEqual({
+      compatible: true,
+    });
+    expect(
+      evaluateH264SpsForSend(Buffer.from([0x67, 0x42, 0xc0, 0x1f]), "constrained-baseline")
+    ).toEqual({ compatible: true });
+    expect(evaluateH264SpsForSend(Buffer.from([0x67, 0x42, 0xc0, 0x1f]))).toEqual({
+      compatible: true,
+    });
+    // A Baseline SPS on a Main session is rejected, and vice versa.
+    expect(evaluateH264SpsForSend(Buffer.from([0x67, 0x42, 0xc0, 0x1f]), "main").compatible).toBe(
+      false
+    );
+    expect(
+      evaluateH264SpsForSend(Buffer.from([0x67, 0x4d, 0x00, 0x2a]), "constrained-baseline")
+        .compatible
+    ).toBe(false);
   });
 });

--- a/test/features/webrtc/h264ProfileNegotiation.test.ts
+++ b/test/features/webrtc/h264ProfileNegotiation.test.ts
@@ -2,127 +2,152 @@ import { describe, expect, test } from "bun:test";
 import type { RTCPeerConnection } from "werift";
 import {
   evaluateH264SpsForSend,
+  h264ProfileLevelId,
   h264SpsLevelIdc,
   h264SpsProfileLevelId,
   isCompatibleConstrainedBaselineProfile,
+  isCompatibleMainProfile,
+  isCompatibleProfileForSession,
   WEBRTC_H264_LEVEL_IDC,
+  WEBRTC_H264_MAIN_PROFILE_LEVEL_ID,
   WEBRTC_H264_PROFILE_LEVEL_ID,
+  type H264Profile,
 } from "../../../src/features/webrtc/h264Level";
 import { WebRtcPublisher } from "../../../src/features/webrtc/WebRtcPublisher";
 import type { WhipClient } from "../../../src/features/webrtc/WhipClient";
 
 /**
- * Cross-source H.264 profile-negotiation guard (issue #4884).
+ * Cross-source H.264 profile-negotiation guard (issues #4884, #4756).
  *
- * PR #4877 globally switched the advertised profile / acceptance gate to Main
- * and made the gate REJECT Baseline (`0x42`). But every real capture source
- * still emits Baseline: Android MediaCodec is configured with
- * `AVCProfileBaseline`, the iOS ffmpeg path passes `-profile:v baseline`, and
- * the synthetic MediaMTX test frames use `libx264 -profile:v baseline`. That
- * mismatch broke WebRtcPublisher -> MediaMTX and was only caught by a
- * merge-only integration job, so #4877 merged green and had to be reverted
- * (#4883).
+ * PR #4877 GLOBALLY switched the advertised profile / acceptance gate to Main
+ * and made the gate REJECT Baseline (`0x42`) for every source. But the sources
+ * do not share one profile: after #4756 the Android MediaCodec encoder emits
+ * **Main** (`0x4d`), while the iOS ffmpeg path (`-profile:v baseline`) and the
+ * synthetic MediaMTX test frames (`libx264 -profile:v baseline`) still emit
+ * **Baseline** (`0x42`). #4877's global switch broke the two Baseline sources'
+ * WHIP publish and was only caught by a merge-only integration job, so it merged
+ * green and had to be reverted (#4883).
  *
- * This test is fast, deterministic, and runs on every PR via `bun test`. It
- * asserts that BOTH the advertised offer (`WEBRTC_H264_PROFILE_LEVEL_ID`) and
- * the runtime acceptance gate accept the exact SPS each real source produces. A
- * future global-profile switch that rejects a profile a real source emits must
- * fail here on PR CI, before it can reach `main`.
+ * The durable fix is PER-SOURCE: each session negotiates the profile its source
+ * encodes, the publisher advertises that `profile-level-id`, and the runtime gate
+ * validates the SPS against THAT profile — never a global one. This test is fast,
+ * deterministic, and runs on every PR via `bun test`. It pins BOTH profiles: a
+ * Main source validates Main and a Baseline source validates Baseline, and
+ * neither session accepts the other's profile (no accept-all union).
  */
 
 /**
  * The exact H.264 profile each real capture source emits, captured as a 4-byte
  * SPS NAL: [nal header 0x67, profile_idc, profile-iop/constraint flags,
- * level_idc]. Only `profile_idc` (byte 1) is load-bearing for the acceptance
- * gate; the constraint byte is representative of what each encoder writes.
+ * level_idc]. `profile_idc` (byte 1) is what the acceptance gate keys on; the
+ * constraint byte is representative of what each encoder writes.
  *
- * profile_idc 0x42 == Baseline (profile 66). These constants are the ground
- * truth against which the gate is validated: they must NOT be derived from
- * `WEBRTC_H264_PROFILE_LEVEL_ID`, otherwise a global switch of both the offer
- * and this table would hide a real-source regression.
+ * These constants are the ground truth against which the gate is validated: they
+ * must NOT be derived from the advertised `profile-level-id` constants, otherwise
+ * a global switch of both the offer and this table would hide a real-source
+ * regression.
  */
 interface RealH264Source {
   readonly name: string;
   /** Where the encoder profile is configured, for failure triage. */
   readonly origin: string;
+  /** The profile this source's WHIP session negotiates. */
+  readonly profile: H264Profile;
+  /** Expected advertised profile-level-id in the SDP offer for this source. */
+  readonly advertisedProfileLevelId: string;
+  /** The profile_idc byte the source's SPS carries. */
+  readonly profileIdc: number;
   /** A representative SPS NAL the source's encoder emits. */
   readonly sps: Buffer;
 }
 
+const BASELINE_PROFILE_IDC = 0x42;
+const MAIN_PROFILE_IDC = 0x4d;
+
 const REAL_H264_SOURCES: readonly RealH264Source[] = [
   {
-    name: "Android MediaCodec (AVCProfileBaseline)",
-    origin: "android/video-server/.../VideoEncoder.kt",
-    // Plain Baseline as Android device encoders routinely emit it
-    // (constraint_set0 only, constraint_set1 clear), level 4.0. This is the
-    // representation #4877's gate rejected outright.
-    sps: Buffer.from([0x67, 0x42, 0x80, 0x28]),
+    name: "Android MediaCodec (AVCProfileMain, #4756)",
+    origin: "android/video-server/.../VideoEncoder.kt (H264EncoderProfile)",
+    profile: "main",
+    advertisedProfileLevelId: WEBRTC_H264_MAIN_PROFILE_LEVEL_ID,
+    profileIdc: MAIN_PROFILE_IDC,
+    // Main (profile_idc 0x4d, profile-iop 0x00) at the advertised Level 4.2.
+    sps: Buffer.from([0x67, 0x4d, 0x00, 0x2a]),
   },
   {
     name: "iOS ffmpeg (-profile:v baseline -level:v 4.2)",
     origin: "src/features/webrtc/IosH264Source.ts",
+    profile: "constrained-baseline",
+    advertisedProfileLevelId: WEBRTC_H264_PROFILE_LEVEL_ID,
+    profileIdc: BASELINE_PROFILE_IDC,
     // VideoToolbox/ffmpeg baseline at the advertised Level 4.2 ceiling.
     sps: Buffer.from([0x67, 0x42, 0xc0, 0x2a]),
   },
   {
     name: "Synthetic MediaMTX frames (libx264 -profile:v baseline -level:v 3.1)",
     origin: "test/integration/mediamtxWebRtcPublisher.integration.test.ts",
+    profile: "constrained-baseline",
+    advertisedProfileLevelId: WEBRTC_H264_PROFILE_LEVEL_ID,
+    profileIdc: BASELINE_PROFILE_IDC,
     sps: Buffer.from([0x67, 0x42, 0xc0, 0x1f]),
   },
 ] as const;
 
-/** Baseline profile_idc; the family every real source encodes and every viewer must decode. */
-const BASELINE_PROFILE_IDC = 0x42;
-
-describe("H.264 cross-source profile negotiation (#4884)", () => {
-  test("the advertised offer profile is itself Baseline and gate-compatible", () => {
-    // The offer we send viewers must advertise the same profile family our
-    // sources encode; otherwise a viewer negotiates a profile it will never
-    // actually receive. #4877 advertised Main here while sources stayed Baseline.
-    const offerProfileIdc = Number.parseInt(WEBRTC_H264_PROFILE_LEVEL_ID.slice(0, 2), 16);
-    expect(offerProfileIdc).toBe(BASELINE_PROFILE_IDC);
-    expect(isCompatibleConstrainedBaselineProfile(WEBRTC_H264_PROFILE_LEVEL_ID)).toBe(true);
+describe("H.264 cross-source profile negotiation (#4884, #4756)", () => {
+  test("Baseline sources advertise Baseline; the Main source advertises Main", () => {
+    // The offer we send viewers must advertise the same profile family the
+    // session's source encodes; otherwise a viewer negotiates a profile it will
+    // never actually receive. #4877 advertised Main for sources that stayed
+    // Baseline.
+    expect(Number.parseInt(WEBRTC_H264_PROFILE_LEVEL_ID.slice(0, 2), 16)).toBe(BASELINE_PROFILE_IDC);
+    expect(Number.parseInt(WEBRTC_H264_MAIN_PROFILE_LEVEL_ID.slice(0, 2), 16)).toBe(MAIN_PROFILE_IDC);
+    expect(h264ProfileLevelId("constrained-baseline")).toBe(WEBRTC_H264_PROFILE_LEVEL_ID);
+    expect(h264ProfileLevelId("main")).toBe(WEBRTC_H264_MAIN_PROFILE_LEVEL_ID);
   });
 
   for (const source of REAL_H264_SOURCES) {
     describe(source.name, () => {
-      test("emits a Baseline SPS (documents ground truth)", () => {
+      test("emits its declared profile at or below the negotiated level", () => {
         const profileLevelId = h264SpsProfileLevelId(source.sps);
         expect(profileLevelId).toBeDefined();
-        const profileIdc = Number.parseInt(profileLevelId!.slice(0, 2), 16);
-        expect(profileIdc).toBe(BASELINE_PROFILE_IDC);
+        expect(Number.parseInt(profileLevelId!.slice(0, 2), 16)).toBe(source.profileIdc);
         // Its encoded level must not exceed the negotiated ceiling, or onSps rejects it.
         expect(h264SpsLevelIdc(source.sps)!).toBeLessThanOrEqual(WEBRTC_H264_LEVEL_IDC);
       });
 
-      test("acceptance gate accepts the SPS it produces", () => {
-        // Direct guard: if a global switch makes the gate reject Baseline, this
-        // fails on PR CI — the durable fix for the #4877 incident.
+      test("the per-session gate accepts the SPS it produces", () => {
+        // Direct guard: the session's negotiated profile accepts this source's
+        // profile. A global switch that rejects a real source's profile fails
+        // here on PR CI — the durable fix for the #4877 incident.
         const profileLevelId = h264SpsProfileLevelId(source.sps)!;
-        expect(isCompatibleConstrainedBaselineProfile(profileLevelId)).toBe(true);
+        expect(isCompatibleProfileForSession(profileLevelId, source.profile)).toBe(true);
       });
 
-      test("runtime send guard (onSps) accepts the SPS it produces", () => {
+      test("runtime send guard (onSps) accepts the SPS under its negotiated profile", () => {
         // evaluateH264SpsForSend is the exact function WebRtcPublisher.onSps
-        // delegates to, so this exercises the runtime acceptance decision that
-        // #4877 turned into a fatal throw for Baseline sources.
-        expect(evaluateH264SpsForSend(source.sps)).toEqual({ compatible: true });
+        // delegates to; it is called with the session's negotiated profile.
+        expect(evaluateH264SpsForSend(source.sps, source.profile)).toEqual({ compatible: true });
       });
 
       test("publisher negotiates and connects for this source's advertised profile", async () => {
-        // End-to-end SDP leg: a WHEP answer echoing our offer profile must be
-        // accepted so the publisher reaches `connected`. Exercises the
-        // acceptsLocalH264Send / sdpOffersCompatibleH264 negotiation path.
+        // End-to-end SDP leg: a WHEP answer echoing this session's advertised
+        // profile must be accepted so the publisher reaches `connected`. Exercises
+        // the acceptsLocalH264Send negotiation path for this source's profile.
         const pc = new NegotiationFakePeerConnection();
         const answerSdp = [
           "v=0",
           "m=video 9 UDP/TLS/RTP/SAVPF 102",
           "a=recvonly",
           "a=rtpmap:102 H264/90000",
-          `a=fmtp:102 packetization-mode=1;profile-level-id=${WEBRTC_H264_PROFILE_LEVEL_ID}`,
+          `a=fmtp:102 packetization-mode=1;profile-level-id=${source.advertisedProfileLevelId}`,
         ].join("\r\n");
         const publisher = new WebRtcPublisher(
-          { streamId: "s", whipEndpoint: "https://coord/whip", maxReconnectAttempts: 1 },
+          {
+            streamId: "s",
+            whipEndpoint: "https://coord/whip",
+            maxReconnectAttempts: 1,
+            h264Profile: source.profile,
+          },
           {
             createPeerConnection: () => pc as unknown as RTCPeerConnection,
             createWhipClient: () =>
@@ -140,14 +165,29 @@ describe("H.264 cross-source profile negotiation (#4884)", () => {
     });
   }
 
-  test("gate still rejects a genuinely different profile a source never emits", () => {
-    // Negative control: proves the gate is discriminating, not accept-all. Main
-    // (0x4d) and High (0x64) SPS are rejected because no AutoMobile source emits
-    // them; if a source ever did, its entry above would fail first.
-    const mainProfileSps = Buffer.from([0x67, 0x4d, 0x40, 0x1f]);
-    const highProfileSps = Buffer.from([0x67, 0x64, 0x00, 0x1f]);
-    expect(evaluateH264SpsForSend(mainProfileSps).compatible).toBe(false);
-    expect(evaluateH264SpsForSend(highProfileSps).compatible).toBe(false);
+  test("a session never accepts a foreign profile (no global accept-all union)", () => {
+    // The #4877 failure mode was a union that let one profile be accepted where a
+    // different one was negotiated. Prove each session rejects the other's SPS.
+    const baselineSps = Buffer.from([0x67, 0x42, 0xc0, 0x1f]);
+    const mainSps = Buffer.from([0x67, 0x4d, 0x00, 0x2a]);
+
+    // A Baseline session rejects a Main SPS...
+    expect(evaluateH264SpsForSend(mainSps, "constrained-baseline").compatible).toBe(false);
+    // ...and a Main session rejects a Baseline SPS.
+    expect(evaluateH264SpsForSend(baselineSps, "main").compatible).toBe(false);
+
+    // High (0x64) is emitted by no source and rejected by both sessions.
+    const highSps = Buffer.from([0x67, 0x64, 0x00, 0x1f]);
+    expect(evaluateH264SpsForSend(highSps, "constrained-baseline").compatible).toBe(false);
+    expect(evaluateH264SpsForSend(highSps, "main").compatible).toBe(false);
+  });
+
+  test("profile predicates are discriminating, not accept-all", () => {
+    expect(isCompatibleConstrainedBaselineProfile("42e02a")).toBe(true);
+    expect(isCompatibleConstrainedBaselineProfile("4d002a")).toBe(false);
+    expect(isCompatibleMainProfile("4d002a")).toBe(true);
+    expect(isCompatibleMainProfile("42e02a")).toBe(false);
+    expect(isCompatibleMainProfile("64001f")).toBe(false);
   });
 });
 

--- a/test/helpers/webrtcFakes.ts
+++ b/test/helpers/webrtcFakes.ts
@@ -1,13 +1,24 @@
 import type { FetchLike } from "../../src/features/webrtc/WhipClient";
 
-export const VIDEO_ONLY_WHIP_ANSWER = [
-  "v=0",
-  "m=video 9 UDP/TLS/RTP/SAVPF 96",
-  "a=recvonly",
-  "a=rtpmap:96 H264/90000",
-  "a=fmtp:96 packetization-mode=1;profile-level-id=42e02a",
-  "",
-].join("\r\n");
+/**
+ * Build a WHEP answer that accepts a video-only H.264 ingest at the given
+ * `profile-level-id`. A conformant WHIP server echoes the profile the publisher
+ * offered, so a Main session (Android, issue #4756) must be answered with a Main
+ * profile-level-id and a Baseline session (iOS/synthetic) with a Baseline one.
+ */
+export function videoOnlyWhipAnswer(profileLevelId: string = "42e02a"): string {
+  return [
+    "v=0",
+    "m=video 9 UDP/TLS/RTP/SAVPF 96",
+    "a=recvonly",
+    "a=rtpmap:96 H264/90000",
+    `a=fmtp:96 packetization-mode=1;profile-level-id=${profileLevelId}`,
+    "",
+  ].join("\r\n");
+}
+
+/** Baseline (`42e02a`) video-only WHIP answer for constrained-baseline sessions. */
+export const VIDEO_ONLY_WHIP_ANSWER = videoOnlyWhipAnswer();
 
 export interface RecordedWhipRequest {
   url: string;
@@ -54,15 +65,19 @@ export class FakeH264Source {
 
 export function createSuccessfulWhipFetch(
   requests: RecordedWhipRequest[],
-  location: string = "/whip/resource/debug-1"
+  location: string = "/whip/resource/debug-1",
+  // Default Baseline; an Android session negotiates Main and its WHIP server
+  // must answer Main (issue #4756), so callers targeting Android pass `4d002a`.
+  profileLevelId: string = "42e02a"
 ): FetchLike {
+  const answerSdp = videoOnlyWhipAnswer(profileLevelId);
   return async (url, init) => {
     requests.push({ url, method: init.method });
     return {
       status: 201,
       ok: true,
       headers: { get: name => (name.toLowerCase() === "location" ? location : null) },
-      text: async () => VIDEO_ONLY_WHIP_ANSWER,
+      text: async () => answerSdp,
     };
   };
 }


### PR DESCRIPTION
## What

Moves the Android `video-server` MediaCodec encoder off Constrained Baseline to **Main** H.264 profile ([#4756](https://github.com/kaeawc/auto-mobile/issues/4756)), implemented **per capture source** so it does not repeat the reverted global switch of [#4877](https://github.com/kaeawc/auto-mobile/pull/4877) (reverted by [#4883](https://github.com/kaeawc/auto-mobile/pull/4883)).

Main saves ~10-30% bitrate at equal quality (CABAC entropy coding, no B-frames so no added latency). werift and Chromium both decode Main.

## Per-source design (which source advertises which profile)

WebRTC negotiates exactly one `profile-level-id` per WHIP session, so the advertised profile and the SPS-acceptance gate must depend on **which source feeds that session**. AutoMobile has three H.264 sources on one publish path:

| Source | Encoder profile | Advertised `profile-level-id` | Gate validates against |
| --- | --- | --- | --- |
| Android `video-server` MediaCodec | **Main** (`AVCProfileMain`) | **`4d002a`** (Main, Level 4.2) | Main (`0x4d`) |
| iOS ffmpeg (`-profile:v baseline`) | Constrained Baseline | `42e02a` (Baseline, Level 4.2) | Baseline (`0x42`) |
| Synthetic MediaMTX frames (`libx264 -profile:v baseline`) | Constrained Baseline | `42e02a` | Baseline (`0x42`) |

`webrtcStreamManager` picks the profile from the device platform: Android → `"main"`, everything else → `"constrained-baseline"`. `WebRtcPublisher` threads that `h264Profile` through (a) the advertised werift codec params, (b) the `onSps` runtime send gate, and (c) WHIP answer acceptance. `h264Level.ts` validates each SPS against **the session's negotiated profile** via `isCompatibleProfileForSession` — there is no global profile assumption and **no accept-all union** (a Main session rejects a Baseline SPS and vice-versa).

## Why the synthetic + iOS Baseline sources still validate (the #4877 failure mode)

#4877 flipped a **global** gate to Main and made `isCompatible*` **reject** Baseline (`0x42`) for every source. But the iOS and synthetic sources still emit Baseline, so their SPS was rejected, the WHIP publish failed, and the merge-only "WebRTC Publisher Integration (MediaMTX)" job (`publisher did not send synthetic H.264 frames`) went red — after merge, forcing the revert.

Walking the synthetic frame through the new gate (the check I want scrutinized, since local `bun test` cannot run the MediaMTX harness):

1. The MediaMTX integration test constructs `WebRtcPublisher` with **no** `h264Profile`, so it defaults to `DEFAULT_H264_PROFILE = "constrained-baseline"`.
2. Its ffmpeg emits `libx264 -profile:v baseline -level:v 3.1` → SPS `profile_idc = 0x42`, `level_idc = 0x1f` (31).
3. The publisher advertises `h264ProfileLevelId("constrained-baseline")` = `42e02a` in the offer — unchanged from before this PR.
4. On the first SPS, `evaluateH264SpsForSend(sps, "constrained-baseline")` runs `isCompatibleProfileForSession("42c01f", "constrained-baseline")` → `isCompatibleConstrainedBaselineProfile` → `0x42 === 0x42` → **accepted**; `level_idc 0x1f ≤ 0x2a` → **accepted**. Result `{ compatible: true }`, so `onSps` does not throw and the publish proceeds.
5. The iOS ffmpeg source (`-profile:v baseline -level:v 4.2`, SPS `0x42.. 0x2a`) follows the identical Baseline path.

So both Baseline sources negotiate and validate exactly as they did before this PR; only the Android session changed. The fast, per-PR guard `test/features/webrtc/h264ProfileNegotiation.test.ts` pins this ground truth for all three sources (including that neither session accepts the other's profile), so a future global switch reddens on PR CI before it can reach `main`.

## Files touched

**kotlin-encoder**
- `android/.../video/VideoEncoder.kt` — `KEY_PROFILE` now `AVCProfileMain` (via new holder).
- `android/.../video/H264EncoderProfile.kt` (new) — the profile constant, readable under the module's compile-only Android stub.
- `android/.../video/H264EncoderProfileTest.kt` (new) — pins Main / not-Baseline.

**ts-profile-gate**
- `src/features/webrtc/h264Level.ts` — `H264Profile` type, `WEBRTC_H264_MAIN_PROFILE_LEVEL_ID`, `h264ProfileLevelId`, `isCompatibleMainProfile`, `isCompatibleProfileForSession`; `evaluateH264SpsForSend(sps, profile)` (default Baseline). `isCompatibleConstrainedBaselineProfile` is unchanged.

**publisher**
- `src/features/webrtc/WebRtcPublisher.ts` — `h264Profile` config; advertises + validates per session.
- `src/server/webrtcStreamManager.ts` — Android negotiates Main, others Baseline.

**tests**
- `test/features/webrtc/h264ProfileNegotiation.test.ts` — per-source table (Android Main + iOS/synthetic Baseline), no-union negative controls.
- `test/features/webrtc/h264Level.test.ts` — Main + per-session dispatch unit tests.
- `test/features/webrtc/WebRtcPublisher.test.ts`, `test/daemon/webrtcStreamSocketServer.test.ts`, `test/helpers/webrtcFakes.ts` — Android sessions answered with Main; reason-string sync.

## Gates run locally (all pass)

- `bun test test/features/webrtc/` + manager/daemon/package webrtc — 486 pass, 0 fail.
- `bun run typecheck` — no new type errors.
- ESLint on all changed files — clean.
- `:video-server:test` + `:video-server:detektMain` + `:video-server:detektTest` (JDK 21) — BUILD SUCCESSFUL, `H264EncoderProfileTest` 2/2 pass, 0 detekt violations.
- ktfmt validator — 0 diffs.

## Deferred

Broad-decoder (werift/Chromium) **end-to-end** decoding of the Main stream on a real device is **out of CI** and needs the device-backed WebRTC integration lane. I did not run it on a device. The merge-only MediaMTX integration job (now on WebRTC-touching PRs, [#4884](https://github.com/kaeawc/auto-mobile/pull/4884)) is the regression net for the Baseline sources.

Closes [#4756](https://github.com/kaeawc/auto-mobile/issues/4756).
