### PR TITLE
fix(ios): tolerate bootstatus error 405 for booted simulators

### DIFF
--- a/src/utils/ios-cmdline-tools/SimCtlClient.ts
+++ b/src/utils/ios-cmdline-tools/SimCtlClient.ts
@@ -399,6 +399,12 @@ function inferIosFormFactor(deviceTypeId: string | undefined): "phone" | "tablet
   return undefined;
 }
 
+function isAlreadyBootedCoreSimulator405(error: unknown): boolean {
+  const message = error instanceof Error ? error.message : String(error);
+  return message.includes("domain=com.apple.CoreSimulator.SimError, code=405") &&
+    message.includes("Unable to boot device in current state: Booted");
+}
+
 /**
  * This file provides an interface to interact with iOS simulators using simctl.
  * It allows you to list, create, boot, and delete simulators.
@@ -778,18 +784,27 @@ export class SimCtlClient implements SimCtl {
     let lastFailure = "";
 
     for (let attempt = 1; attempt <= maxAttempts; attempt++) {
-      // A bootstatus failure (nonexistent UDID, timeout, simctl error) already
-      // reports itself and has consumed the caller's timeout budget, so it
-      // propagates unchanged rather than being retried. The retry here exists
-      // for the silent case: exit 0 with a device that never became Booted.
-      await this.executeCommandArgs(["bootstatus", udid, "-b"], timeoutMs);
+      let bootstatusReportedAlreadyBooted = false;
+      try {
+        await this.executeCommandArgs(["bootstatus", udid, "-b"], timeoutMs);
+      } catch (error) {
+        // CoreSimulator can transiently reject bootstatus with error 405 while
+        // reporting the requested simulator is already Booted. Verify its state
+        // before deciding whether the command failure is actionable.
+        if (!isAlreadyBootedCoreSimulator405(error)) {
+          throw error;
+        }
+        bootstatusReportedAlreadyBooted = true;
+      }
 
       const state = await this.readSimulatorState(udid);
       if (state === "Booted") {
         return;
       }
 
-      lastFailure = `bootstatus exited 0 but device state is ${state ?? "unknown"}, not Booted`;
+      lastFailure = bootstatusReportedAlreadyBooted
+        ? `bootstatus reported CoreSimulator error 405 but device state is ${state ?? "unknown"}, not Booted`
+        : `bootstatus exited 0 but device state is ${state ?? "unknown"}, not Booted`;
       logger.warn(`[iOS] Boot verification failed for ${udid} on attempt ${attempt}/${maxAttempts}: ${lastFailure}`);
 
       if (attempt < maxAttempts) {

--- a/src/utils/ios-cmdline-tools/SimCtlClient.ts
+++ b/src/utils/ios-cmdline-tools/SimCtlClient.ts
@@ -794,6 +794,7 @@ export class SimCtlClient implements SimCtl {
         if (!isAlreadyBootedCoreSimulator405(error)) {
           throw error;
         }
+        logger.debug(`[iOS] bootstatus returned expected CoreSimulator error 405 for ${udid}; verifying simulator state: ${error}`);
         bootstatusReportedAlreadyBooted = true;
       }
 

--- a/test/utils/ios-cmdline-tools/simctl-client.bootVerification.test.ts
+++ b/test/utils/ios-cmdline-tools/simctl-client.bootVerification.test.ts
@@ -28,7 +28,7 @@ function createHarness(bootOptions: SimCtlBootOptions): Harness {
   const calls: string[] = [];
   const timer = new FakeTimer();
   let states = ["Shutdown"];
-  let bootStatusFailure: string | null = null;
+  let bootStatusFailures: Array<string | null> = [];
   const nextState = (): string => (states.length > 1 ? states.shift()! : states[0]);
 
   const execAsync = async (file: string, args: string[]) => {
@@ -39,6 +39,7 @@ function createHarness(bootOptions: SimCtlBootOptions): Harness {
       return createExecResult("simctl version 1.0.0", "");
     }
     if (command === `xcrun simctl bootstatus ${UDID} -b`) {
+      const bootStatusFailure = bootStatusFailures.shift() ?? null;
       if (bootStatusFailure !== null) {
         throw new Error(bootStatusFailure);
       }
@@ -79,7 +80,7 @@ function createHarness(bootOptions: SimCtlBootOptions): Harness {
     timer,
     calls,
     setStates: next => { states = [...next]; },
-    failBootStatusWith: message => { bootStatusFailure = message; }
+    failBootStatusWith: message => { bootStatusFailures = [message]; }
   };
 }
 
@@ -88,6 +89,12 @@ const bootstatusCalls = (calls: string[]): string[] =>
 
 const shutdownCalls = (calls: string[]): string[] =>
   calls.filter(call => call === `xcrun simctl shutdown ${UDID}`);
+
+const ALREADY_BOOTED_405 =
+  "Device boot failed\n" +
+  "An error was encountered processing the command " +
+  "(domain=com.apple.CoreSimulator.SimError, code=405): " +
+  "Unable to boot device in current state: Booted";
 
 describe("SimCtlClient boot self-verification", () => {
   test("a wedged boot (bootstatus exit 0, device Shutdown) fails with an actionable error", async () => {
@@ -116,6 +123,32 @@ describe("SimCtlClient boot self-verification", () => {
     expect(bootstatusCalls(harness.calls).length).toBe(1);
     expect(shutdownCalls(harness.calls).length).toBe(0);
     expect(harness.timer.getSleepCallCount()).toBe(0);
+  });
+
+  test("accepts a CoreSimulator 405 already-Booted response after verifying the requested simulator", async () => {
+    const harness = createHarness({ maxAttempts: 2, retryBackoffMs: 10 });
+    harness.setStates(["Booted"]);
+    harness.failBootStatusWith(ALREADY_BOOTED_405);
+
+    const handle = await harness.timer.resolvePromise(harness.simctl.startSimulator(UDID, 5000));
+
+    expect(handle).toBeDefined();
+    expect(bootstatusCalls(harness.calls).length).toBe(1);
+    expect(shutdownCalls(harness.calls).length).toBe(0);
+    expect(harness.timer.getSleepCallCount()).toBe(0);
+  });
+
+  test("retries a contradictory CoreSimulator 405 response when the simulator is not Booted", async () => {
+    const harness = createHarness({ maxAttempts: 2, retryBackoffMs: 10 });
+    harness.setStates(["Shutdown", "Booted"]);
+    harness.failBootStatusWith(ALREADY_BOOTED_405);
+
+    const handle = await harness.timer.resolvePromise(harness.simctl.startSimulator(UDID, 5000));
+
+    expect(handle).toBeDefined();
+    expect(bootstatusCalls(harness.calls).length).toBe(2);
+    expect(shutdownCalls(harness.calls).length).toBe(1);
+    expect(harness.timer.getSleepHistory()).toEqual([10]);
   });
 
   test("retries a wedged boot after a shutdown and a backoff, then succeeds", async () => {


### PR DESCRIPTION
## Summary

`SimCtlClient` now treats CoreSimulator error 405 with `Unable to boot device in current state: Booted` as a provisional result. It verifies the requested simulator state, succeeds when it is Booted, and otherwise uses the existing bounded recovery path.

This prevents a transient `simctl bootstatus -b` race from surfacing to `startDevice` consumers while preserving immediate errors for invalid UDIDs and unrelated boot failures.

## Linked Issue

Closes [#4958](https://github.com/kaeawc/auto-mobile/issues/4958)

## Bug / Regression Context

- **Prior attempts:** [#4094](https://github.com/kaeawc/auto-mobile/issues/4094) added verification for successful `bootstatus` calls whose device state is not Booted.
- **Observed symptom:** `bootstatus -b` reported CoreSimulator error 405 despite reporting the requested simulator was already Booted.
- **Repro steps / conditions:** A repeated iOS `startDevice` call encounters the CoreSimulator current-state race while `simctl list devices --json` reports the target UDID as Booted.

## Validation

- [x] `bun run lint` passes
- [x] `bun run typecheck` reports no new errors
- [x] `bun run turbo:validate` passes: 12,572 tests passed, 13 device-dependent integration tests skipped, 0 failures
- [x] Focused `simctl-client.bootVerification.test.ts` coverage uses injected execution and `FakeTimer`
- [x] No new generic dependency or helper was added
- [x] Rebased onto latest `main` before implementation
