### PR TITLE
fix(ios): harden simctl boot recovery

### DIFF
--- a/src/utils/ios-cmdline-tools/SimCtlClient.ts
+++ b/src/utils/ios-cmdline-tools/SimCtlClient.ts
@@ -145,7 +145,7 @@ export interface SimCtl {
    * Get the list of booted simulator UDIDs
    * @returns Promise with an array of booted devices
    */
-  getBootedSimulators(): Promise<BootedDevice[]>;
+  getBootedSimulators(timeoutMs?: number): Promise<BootedDevice[]>;
 
   /**
    * Get device information by UDID
@@ -690,7 +690,7 @@ export class SimCtlClient implements SimCtl {
     // {@link bootAndVerify}.
     perf.startOperation("bootstatus");
     try {
-      await this.bootAndVerify(udid, timeoutMs);
+      await this.bootAndVerify(udid, this.bootDeadline(timeoutMs));
     } finally {
       perf.endOperation("bootstatus");
     }
@@ -758,7 +758,7 @@ export class SimCtlClient implements SimCtl {
     // This is far more reliable than polling `simctl list devices` for state.
     perf.startOperation("bootstatus");
     try {
-      await this.bootAndVerify(udid, timeoutMs);
+      await this.bootAndVerify(udid, this.bootDeadline(timeoutMs ?? DEFAULT_DEVICE_READY_TIMEOUT_MS));
     } catch (error) {
       const message = error instanceof Error ? error.message : String(error);
       // "Invalid device" means the UDID doesn't exist at all
@@ -792,7 +792,7 @@ export class SimCtlClient implements SimCtl {
    */
   private async bootAndVerify(
     udid: string,
-    timeoutMs: number = DEFAULT_DEVICE_READY_TIMEOUT_MS
+    deadlineMs: number
   ): Promise<void> {
     const { maxAttempts, retryBackoffMs } = this.bootOptions;
     let lastFailure = "";
@@ -800,7 +800,7 @@ export class SimCtlClient implements SimCtl {
     for (let attempt = 1; attempt <= maxAttempts; attempt++) {
       let bootstatusReportedAlreadyBooted = false;
       try {
-        await this.executeCommandArgs(["bootstatus", udid, "-b"], timeoutMs);
+        await this.executeCommandArgs(["bootstatus", udid, "-b"], this.remainingBootTimeoutMs(deadlineMs));
       } catch (error) {
         // CoreSimulator can transiently reject bootstatus with error 405 while
         // reporting the requested simulator is already Booted. Verify its state
@@ -812,7 +812,7 @@ export class SimCtlClient implements SimCtl {
         bootstatusReportedAlreadyBooted = true;
       }
 
-      const state = await this.readSimulatorState(udid, timeoutMs);
+      const state = await this.readSimulatorState(udid, this.remainingBootTimeoutMs(deadlineMs));
       if (state === "Booted") {
         return;
       }
@@ -826,11 +826,11 @@ export class SimCtlClient implements SimCtl {
         // Best-effort: shutting down an already-shutdown device errors, and that
         // is fine — the next attempt re-boots from whatever state it is in.
         try {
-          await this.executeCommandArgs(["shutdown", udid], timeoutMs);
+          await this.executeCommandArgs(["shutdown", udid], this.remainingBootTimeoutMs(deadlineMs));
         } catch (error) {
           logger.debug(`[iOS] shutdown before boot retry failed for ${udid}: ${error}`);
         }
-        await this.timer.sleep(retryBackoffMs);
+        await this.timer.sleep(Math.min(retryBackoffMs, this.remainingBootTimeoutMs(deadlineMs)));
       }
     }
 
@@ -839,6 +839,18 @@ export class SimCtlClient implements SimCtl {
       "The simulator is likely wedged. Try 'xcrun simctl shutdown all' (or erase the device with " +
       `'xcrun simctl erase ${udid}') and start it again.`
     );
+  }
+
+  private bootDeadline(timeoutMs: number): number {
+    return this.timer.now() + timeoutMs;
+  }
+
+  private remainingBootTimeoutMs(deadlineMs: number): number {
+    const remainingMs = deadlineMs - this.timer.now();
+    if (remainingMs <= 0) {
+      throw new Error("Simulator boot verification timed out before the next recovery step");
+    }
+    return remainingMs;
   }
 
   /**
@@ -1028,9 +1040,9 @@ export class SimCtlClient implements SimCtl {
    * Get the list of booted simulator UDIDs
    * @returns Promise with an array of booted device UDIDs
    */
-  async getBootedSimulators(): Promise<BootedDevice[]> {
+  async getBootedSimulators(timeoutMs?: number): Promise<BootedDevice[]> {
     try {
-      return await this.getBootedSimulatorsChecked();
+      return await this.getBootedSimulatorsChecked(timeoutMs);
     } catch (error) {
       logger.debug(`Failed to get booted iOS devices: ${error}`);
       return [];
@@ -1042,8 +1054,8 @@ export class SimCtlClient implements SimCtl {
    * swallowing them into an empty list. Callers that must distinguish "no
    * simulators are booted" from "simctl discovery failed" should use this.
    */
-  async getBootedSimulatorsChecked(): Promise<BootedDevice[]> {
-    const simulatorList = await this.listSimulators();
+  async getBootedSimulatorsChecked(timeoutMs?: number): Promise<BootedDevice[]> {
+    const simulatorList = await this.listSimulators(timeoutMs);
     logger.debug(`Found simulator list: ${simulatorList}`);
     const bootedDevices: BootedDevice[] = [];
 
@@ -1109,12 +1121,13 @@ export class SimCtlClient implements SimCtl {
     // about. The old code ran a bare `simctl boot`, which does not wait for the
     // boot to finish, then slept a fixed 1s and asked whether the device had
     // shown up in the booted list -- neither a wait nor a proof of readiness.
+    const deadlineMs = this.bootDeadline(DEFAULT_DEVICE_READY_TIMEOUT_MS);
     perf.startOperation("simctlBoot");
-    await this.bootAndVerify(udid, DEFAULT_DEVICE_READY_TIMEOUT_MS);
+    await this.bootAndVerify(udid, deadlineMs);
     perf.endOperation("simctlBoot");
 
     perf.startOperation("bootRegistration");
-    const bootedSimulators = await this.getBootedSimulators();
+    const bootedSimulators = await this.getBootedSimulators(this.remainingBootTimeoutMs(deadlineMs));
     const bootedSimulator = bootedSimulators.find(device => device.deviceId === udid);
     perf.endOperation("bootRegistration");
     if (!bootedSimulator) {

--- a/src/utils/ios-cmdline-tools/SimCtlClient.ts
+++ b/src/utils/ios-cmdline-tools/SimCtlClient.ts
@@ -10,6 +10,7 @@ import { defaultTimer, Timer } from "../SystemTimer";
 import { createGlobalPerformanceTracker } from "../PerformanceTracker";
 import { DEFAULT_DEVICE_READY_TIMEOUT_MS } from "../deviceTimeouts";
 import { PlistClient, type PlistReader } from "./PlistClient";
+import { isIosSimulatorUdid } from "./iosDeviceType";
 
 export interface AppleDevice {
   udid: string;
@@ -399,10 +400,20 @@ function inferIosFormFactor(deviceTypeId: string | undefined): "phone" | "tablet
   return undefined;
 }
 
-function isAlreadyBootedCoreSimulator405(error: unknown): boolean {
-  const message = error instanceof Error ? error.message : String(error);
-  return message.includes("domain=com.apple.CoreSimulator.SimError, code=405") &&
-    message.includes("Unable to boot device in current state: Booted");
+function isAlreadyBootedCoreSimulator405(error: unknown, udid: string): boolean {
+  if (!isIosSimulatorUdid(udid) || !(error instanceof Error)) {
+    return false;
+  }
+
+  const execError = error as NodeJS.ErrnoException & { stderr?: unknown };
+  const stderr = typeof execError.stderr === "string"
+    ? execError.stderr
+    : Buffer.isBuffer(execError.stderr) ? execError.stderr.toString() : "";
+
+  return typeof execError.code === "number" &&
+    execError.code !== 0 &&
+    stderr.includes("domain=com.apple.CoreSimulator.SimError, code=405") &&
+    stderr.includes("Unable to boot device in current state: Booted");
 }
 
 /**
@@ -638,10 +649,10 @@ export class SimCtlClient implements SimCtl {
    * Get the list of all simulators and devices
    * @returns Promise with simulator list data
    */
-  private async listSimulators(): Promise<SimulatorList> {
+  private async listSimulators(timeoutMs?: number): Promise<SimulatorList> {
     const perf = createGlobalPerformanceTracker();
     perf.startOperation("simctlListDevices");
-    const result = await this.executeCommandArgs(["list", "devices", "--json"]);
+    const result = await this.executeCommandArgs(["list", "devices", "--json"], timeoutMs);
     perf.endOperation("simctlListDevices");
 
     try {
@@ -779,7 +790,10 @@ export class SimCtlClient implements SimCtl {
    * On a failed verification the device is shut down, a bounded backoff is
    * awaited through the injected {@link Timer}, and the boot is retried.
    */
-  private async bootAndVerify(udid: string, timeoutMs?: number): Promise<void> {
+  private async bootAndVerify(
+    udid: string,
+    timeoutMs: number = DEFAULT_DEVICE_READY_TIMEOUT_MS
+  ): Promise<void> {
     const { maxAttempts, retryBackoffMs } = this.bootOptions;
     let lastFailure = "";
 
@@ -791,14 +805,14 @@ export class SimCtlClient implements SimCtl {
         // CoreSimulator can transiently reject bootstatus with error 405 while
         // reporting the requested simulator is already Booted. Verify its state
         // before deciding whether the command failure is actionable.
-        if (!isAlreadyBootedCoreSimulator405(error)) {
+        if (!isAlreadyBootedCoreSimulator405(error, udid)) {
           throw error;
         }
         logger.debug(`[iOS] bootstatus returned expected CoreSimulator error 405 for ${udid}; verifying simulator state: ${error}`);
         bootstatusReportedAlreadyBooted = true;
       }
 
-      const state = await this.readSimulatorState(udid);
+      const state = await this.readSimulatorState(udid, timeoutMs);
       if (state === "Booted") {
         return;
       }
@@ -812,7 +826,7 @@ export class SimCtlClient implements SimCtl {
         // Best-effort: shutting down an already-shutdown device errors, and that
         // is fine — the next attempt re-boots from whatever state it is in.
         try {
-          await this.executeCommandArgs(["shutdown", udid]);
+          await this.executeCommandArgs(["shutdown", udid], timeoutMs);
         } catch (error) {
           logger.debug(`[iOS] shutdown before boot retry failed for ${udid}: ${error}`);
         }
@@ -906,9 +920,9 @@ export class SimCtlClient implements SimCtl {
    * @returns the state string (e.g. "Booted", "Shutdown"), or undefined when
    *          the device is absent or discovery failed.
    */
-  private async readSimulatorState(udid: string): Promise<string | undefined> {
+  private async readSimulatorState(udid: string, timeoutMs: number): Promise<string | undefined> {
     try {
-      const simulatorList = await this.listSimulators();
+      const simulatorList = await this.listSimulators(timeoutMs);
       for (const runtimeDevices of Object.values(simulatorList.devices)) {
         const match = runtimeDevices.find(device => device.udid === udid);
         if (match) {
@@ -1096,7 +1110,7 @@ export class SimCtlClient implements SimCtl {
     // boot to finish, then slept a fixed 1s and asked whether the device had
     // shown up in the booted list -- neither a wait nor a proof of readiness.
     perf.startOperation("simctlBoot");
-    await this.bootAndVerify(udid);
+    await this.bootAndVerify(udid, DEFAULT_DEVICE_READY_TIMEOUT_MS);
     perf.endOperation("simctlBoot");
 
     perf.startOperation("bootRegistration");

--- a/test/utils/ios-cmdline-tools/simctl-client.bootVerification.test.ts
+++ b/test/utils/ios-cmdline-tools/simctl-client.bootVerification.test.ts
@@ -10,13 +10,14 @@ interface Harness {
   simctl: SimCtlClient;
   timer: FakeTimer;
   calls: string[];
+  commandTimeouts: Map<string, boolean[]>;
   /**
    * States reported by successive `simctl list devices --json` calls. The last
    * entry sticks once the sequence is exhausted.
    */
   setStates(states: string[]): void;
   /** Make the next `bootstatus` invocation reject. */
-  failBootStatusWith(message: string | null): void;
+  failBootStatusWith(error: Error | null): void;
 }
 
 /**
@@ -26,14 +27,18 @@ interface Harness {
  */
 function createHarness(bootOptions: SimCtlBootOptions): Harness {
   const calls: string[] = [];
+  const commandTimeouts = new Map<string, boolean[]>();
   const timer = new FakeTimer();
   let states = ["Shutdown"];
-  let bootStatusFailures: Array<string | null> = [];
+  let bootStatusFailures: Array<Error | null> = [];
   const nextState = (): string => (states.length > 1 ? states.shift()! : states[0]);
 
-  const execAsync = async (file: string, args: string[]) => {
+  const execAsync = async (file: string, args: string[], _maxBuffer?: number, signal?: AbortSignal) => {
     const command = `${file} ${args.join(" ")}`;
     calls.push(command);
+    const timeoutUsage = commandTimeouts.get(command) ?? [];
+    timeoutUsage.push(signal !== undefined);
+    commandTimeouts.set(command, timeoutUsage);
 
     if (command === "xcrun simctl --version") {
       return createExecResult("simctl version 1.0.0", "");
@@ -41,7 +46,7 @@ function createHarness(bootOptions: SimCtlBootOptions): Harness {
     if (command === `xcrun simctl bootstatus ${UDID} -b`) {
       const bootStatusFailure = bootStatusFailures.shift() ?? null;
       if (bootStatusFailure !== null) {
-        throw new Error(bootStatusFailure);
+        throw bootStatusFailure;
       }
       // Healthy boots on macOS 26 / Xcode 26 also print this line (#4092), so it
       // must never be treated as a wedge sentinel.
@@ -79,8 +84,9 @@ function createHarness(bootOptions: SimCtlBootOptions): Harness {
     simctl,
     timer,
     calls,
+    commandTimeouts,
     setStates: next => { states = [...next]; },
-    failBootStatusWith: message => { bootStatusFailures = [message]; }
+    failBootStatusWith: error => { bootStatusFailures = [error]; }
   };
 }
 
@@ -95,6 +101,16 @@ const ALREADY_BOOTED_405 =
   "An error was encountered processing the command " +
   "(domain=com.apple.CoreSimulator.SimError, code=405): " +
   "Unable to boot device in current state: Booted";
+
+function coreSimulator405Error(stderr: string = ALREADY_BOOTED_405): Error {
+  return Object.assign(new Error("simctl bootstatus exited unsuccessfully"), {
+    code: 1,
+    stderr,
+  });
+}
+
+const commandTimeouts = (harness: Harness, command: string): boolean[] =>
+  harness.commandTimeouts.get(command) ?? [];
 
 describe("SimCtlClient boot self-verification", () => {
   test("a wedged boot (bootstatus exit 0, device Shutdown) fails with an actionable error", async () => {
@@ -128,7 +144,7 @@ describe("SimCtlClient boot self-verification", () => {
   test("accepts a CoreSimulator 405 already-Booted response after verifying the requested simulator", async () => {
     const harness = createHarness({ maxAttempts: 2, retryBackoffMs: 10 });
     harness.setStates(["Booted"]);
-    harness.failBootStatusWith(ALREADY_BOOTED_405);
+    harness.failBootStatusWith(coreSimulator405Error());
 
     const handle = await harness.timer.resolvePromise(harness.simctl.startSimulator(UDID, 5000));
 
@@ -141,7 +157,7 @@ describe("SimCtlClient boot self-verification", () => {
   test("retries a contradictory CoreSimulator 405 response when the simulator is not Booted", async () => {
     const harness = createHarness({ maxAttempts: 2, retryBackoffMs: 10 });
     harness.setStates(["Shutdown", "Booted"]);
-    harness.failBootStatusWith(ALREADY_BOOTED_405);
+    harness.failBootStatusWith(coreSimulator405Error());
 
     const handle = await harness.timer.resolvePromise(harness.simctl.startSimulator(UDID, 5000));
 
@@ -149,6 +165,38 @@ describe("SimCtlClient boot self-verification", () => {
     expect(bootstatusCalls(harness.calls).length).toBe(2);
     expect(shutdownCalls(harness.calls).length).toBe(1);
     expect(harness.timer.getSleepHistory()).toEqual([10]);
+  });
+
+  test("does not recover from a textual 405 in an unstructured error message", async () => {
+    const harness = createHarness({ maxAttempts: 2, retryBackoffMs: 10 });
+    const error = new Error(ALREADY_BOOTED_405);
+    harness.failBootStatusWith(error);
+
+    await expect(harness.simctl.startSimulator(UDID, 5000)).rejects.toBe(error);
+    expect(harness.calls).not.toContain("xcrun simctl list devices --json");
+  });
+
+  test("does not recover when a crafted non-simulator UDID appears in the error message", async () => {
+    const craftedUdid = `not-a-simulator\n${ALREADY_BOOTED_405}`;
+    const calls: string[] = [];
+    const error = Object.assign(new Error(`xcrun simctl bootstatus ${craftedUdid} -b failed`), {
+      code: 1,
+      stderr: "unrelated failure",
+    });
+    const simctl = new SimCtlClient(null, async (file, args) => {
+      const command = `${file} ${args.join(" ")}`;
+      calls.push(command);
+      if (command === "xcrun simctl --version") {
+        return createExecResult("simctl version 1.0.0", "");
+      }
+      if (args[1] === "bootstatus") {
+        throw error;
+      }
+      return createExecResult("", "");
+    }, new FakeTimer(), "darwin", undefined, undefined, { maxAttempts: 2, retryBackoffMs: 10 });
+
+    await expect(simctl.startSimulator(craftedUdid, 5000)).rejects.toBe(error);
+    expect(calls).not.toContain("xcrun simctl list devices --json");
   });
 
   test("retries a wedged boot after a shutdown and a backoff, then succeeds", async () => {
@@ -163,6 +211,17 @@ describe("SimCtlClient boot self-verification", () => {
     expect(bootstatusCalls(harness.calls).length).toBe(2);
     expect(shutdownCalls(harness.calls).length).toBe(1);
     expect(harness.timer.getSleepHistory()).toEqual([2000]);
+  });
+
+  test("time-bounds verification state reads and retry shutdown", async () => {
+    const harness = createHarness({ maxAttempts: 2, retryBackoffMs: 10 });
+    harness.setStates(["Shutdown", "Booted"]);
+
+    await harness.timer.resolvePromise(harness.simctl.startSimulator(UDID, 5000));
+
+    expect(commandTimeouts(harness, `xcrun simctl bootstatus ${UDID} -b`)).toEqual([true, true]);
+    expect(commandTimeouts(harness, "xcrun simctl list devices --json")).toEqual([true, true]);
+    expect(commandTimeouts(harness, `xcrun simctl shutdown ${UDID}`)).toEqual([true]);
   });
 
   test("stops after the bounded attempt count and reports the observed state", async () => {
@@ -183,7 +242,7 @@ describe("SimCtlClient boot self-verification", () => {
 
   test("a bootstatus failure propagates immediately without burning a retry", async () => {
     const harness = createHarness({ maxAttempts: 3, retryBackoffMs: 10 });
-    harness.failBootStatusWith("Invalid device: nope");
+    harness.failBootStatusWith(new Error("Invalid device: nope"));
 
     const error = await harness.timer.resolvePromise(
       harness.simctl.startSimulator(UDID, 5000).then(
@@ -223,6 +282,8 @@ describe("SimCtlClient boot self-verification", () => {
     expect(device.deviceId).toBe(UDID);
     expect(bootstatusCalls(harness.calls).length).toBe(2);
     expect(shutdownCalls(harness.calls).length).toBe(1);
+    expect(commandTimeouts(harness, `xcrun simctl bootstatus ${UDID} -b`).slice(0, 2)).toEqual([true, true]);
+    expect(commandTimeouts(harness, "xcrun simctl list devices --json").slice(0, 2)).toEqual([true, true]);
   });
 
   test("waitForSimulatorReady rejects a wedged boot instead of returning a device", async () => {

--- a/test/utils/ios-cmdline-tools/simctl-client.bootVerification.test.ts
+++ b/test/utils/ios-cmdline-tools/simctl-client.bootVerification.test.ts
@@ -224,6 +224,24 @@ describe("SimCtlClient boot self-verification", () => {
     expect(commandTimeouts(harness, `xcrun simctl shutdown ${UDID}`)).toEqual([true]);
   });
 
+  test("caps the complete retry sequence at the caller timeout", async () => {
+    const harness = createHarness({ maxAttempts: 3, retryBackoffMs: 10_000 });
+    const boot = harness.simctl.startSimulator(UDID, 5000).then(
+      () => null,
+      (error: unknown) => error
+    );
+
+    // Set up the first retry before advancing fake time so its deadline starts at zero.
+    await new Promise<void>(resolve => setImmediate(resolve));
+    const error = await harness.timer.resolvePromise(boot);
+
+    expect(error).toBeInstanceOf(Error);
+    expect(harness.timer.now()).toBe(5000);
+    expect(harness.timer.getSleepHistory()).toEqual([5000]);
+    expect(bootstatusCalls(harness.calls).length).toBe(1);
+    expect(shutdownCalls(harness.calls).length).toBe(1);
+  });
+
   test("stops after the bounded attempt count and reports the observed state", async () => {
     const harness = createHarness({ maxAttempts: 3, retryBackoffMs: 25 });
 
@@ -282,8 +300,8 @@ describe("SimCtlClient boot self-verification", () => {
     expect(device.deviceId).toBe(UDID);
     expect(bootstatusCalls(harness.calls).length).toBe(2);
     expect(shutdownCalls(harness.calls).length).toBe(1);
-    expect(commandTimeouts(harness, `xcrun simctl bootstatus ${UDID} -b`).slice(0, 2)).toEqual([true, true]);
-    expect(commandTimeouts(harness, "xcrun simctl list devices --json").slice(0, 2)).toEqual([true, true]);
+    expect(commandTimeouts(harness, `xcrun simctl bootstatus ${UDID} -b`)).toEqual([true, true]);
+    expect(commandTimeouts(harness, "xcrun simctl list devices --json")).toEqual([true, true, true]);
   });
 
   test("waitForSimulatorReady rejects a wedged boot instead of returning a device", async () => {


### PR DESCRIPTION
## Summary

- Require a simulator UUID plus structured `execFile` exit code and stderr fields before treating CoreSimulator error 405 as the already-Booted race.
- Apply the boot deadline to simulator-state reads and retry shutdowns, including the session auto-start path.

## Why

The merged [PR #4964](https://github.com/kaeawc/auto-mobile/pull/4964) accepted the narrow CoreSimulator 405 race after verifying the target state. This follow-up prevents text injected through a caller-provided identifier from affecting that classification and ensures the recovery loop cannot block indefinitely in its state or shutdown commands.

## Validation

- [x] `bun test test/utils/ios-cmdline-tools/simctl-client.bootVerification.test.ts`
- [x] `bun run typecheck`
- [x] `bun run lint`
