### PR TITLE
ci(release): trigger validation on tag pushes

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -2,6 +2,9 @@
 name: Release
 
 "on":
+  push:
+    tags:
+      - "*"
   workflow_dispatch:
     inputs:
       tag:
@@ -17,7 +20,7 @@ name: Release
 # integrity-checked every GitHub Release asset. The release consumes those exact
 # artifacts rather than starting a second, potentially different build.
 concurrency:
-  group: release-${{ inputs.tag }}
+  group: release-${{ inputs.tag || github.ref_name }}
   cancel-in-progress: false
 
 permissions:
@@ -39,7 +42,7 @@ jobs:
         id: validate
         shell: bash
         env:
-          TAG: ${{ inputs.tag || github.event.ref }}
+          TAG: ${{ inputs.tag || github.ref_name }}
           EVENT_NAME: ${{ github.event_name }}
           REF_TYPE: ${{ github.ref_type }}
           REF_NAME: ${{ github.ref_name }}
@@ -55,6 +58,9 @@ jobs:
             exit 1
           fi
           if [[ "$TAG" =~ ^[0-9]+\.[0-9]+\.[0-9]+([-+].*)?$ ]]; then
+            if [[ "$EVENT_NAME" == "push" ]]; then
+              echo "Tag push validated; publishing requires a Prepare Release dispatch with artifact provenance."
+            fi
             echo "is_release_tag=true" >> "$GITHUB_OUTPUT"
             exit 0
           fi
@@ -63,7 +69,9 @@ jobs:
           exit 1
 
   verify-and-release:
-    if: needs.validate-release-tag.outputs.is_release_tag == 'true'
+    # A tag push is observable and validated, but it cannot publish because it
+    # has no prepared artifact run to prove what it would release.
+    if: github.event_name == 'workflow_dispatch' && needs.validate-release-tag.outputs.is_release_tag == 'true'
     runs-on: ubuntu-latest
     needs:
       - validate-release-tag

--- a/test/bats/release-workflow-wiring.bats
+++ b/test/bats/release-workflow-wiring.bats
@@ -426,7 +426,7 @@ wiring_requires_yq() {
 
   run yq -r '.jobs."verify-and-release".if' "$workflow"
   [ "$status" -eq 0 ]
-  [[ "$output" == *"github.event_name == 'workflow_dispatch'"* ]]
+  [ "$output" = "github.event_name == 'workflow_dispatch' && needs.validate-release-tag.outputs.is_release_tag == 'true'" ]
 }
 
 @test "prepare-release dispatches release.yml on the tag with its run ID (#4686)" {

--- a/test/bats/release-workflow-wiring.bats
+++ b/test/bats/release-workflow-wiring.bats
@@ -408,6 +408,27 @@ wiring_requires_yq() {
   [ "$output" = "true" ]
 }
 
+@test "release.yml queues a validation run for hand-pushed tags without publishing (#4697)" {
+  wiring_requires_yq
+  local workflow=".github/workflows/release.yml"
+
+  run yq -r '.on.push.tags[]' "$workflow"
+  [ "$status" -eq 0 ]
+  [ "$output" = "*" ]
+
+  run yq -r '.concurrency.group' "$workflow"
+  [ "$status" -eq 0 ]
+  [ "$output" = 'release-${{ inputs.tag || github.ref_name }}' ]
+
+  run yq -r '.jobs."validate-release-tag".steps[] | select(.id == "validate") | .env.TAG' "$workflow"
+  [ "$status" -eq 0 ]
+  [ "$output" = '${{ inputs.tag || github.ref_name }}' ]
+
+  run yq -r '.jobs."verify-and-release".if' "$workflow"
+  [ "$status" -eq 0 ]
+  [[ "$output" == *"github.event_name == 'workflow_dispatch'"* ]]
+}
+
 @test "prepare-release dispatches release.yml on the tag with its run ID (#4686)" {
   wiring_requires_yq
   # Pull the one step's run script out of the parsed YAML, so comments elsewhere


### PR DESCRIPTION
## Summary

- trigger Release on tag pushes rather than every ref-creation event
- validate hand-pushed release tags without allowing them to publish without prepared-artifact provenance
- cover the tag trigger, tag-name normalization, concurrency key, and publish guard with workflow wiring tests

## Why

The previous `create`-event fallback queued Release runs for every new branch. A tag-filtered `push` trigger restricts that fallback to tags.

Release now consumes an artifact set prepared and integrity-checked by Prepare Release. A hand-pushed tag has no corresponding prepared run ID, so it must be observable and validated but cannot enter the publishing job. This keeps the provenance boundary intact instead of starting a release that would fail after publication begins.

Closes [#4697](https://github.com/kaeawc/auto-mobile/issues/4697)

## Validation

- `bats test/bats/release-workflow-wiring.bats`
- `actionlint -shellcheck= .github/workflows/release.yml`
- `bun run turbo:validate`
- `bun run typecheck`
- `git diff --check`
