### PR TITLE
fix: verify desktop release installers

### DIFF
--- a/.github/workflows/prepare-release.yml
+++ b/.github/workflows/prepare-release.yml
@@ -312,6 +312,24 @@ jobs:
           name: screen-capture-helper
           path: /tmp
 
+      - name: "Download desktop macOS DMG"
+        uses: actions/download-artifact@v7
+        with:
+          name: automobile-desktop-macos
+          path: /tmp/desktop
+
+      - name: "Download desktop Windows MSI"
+        uses: actions/download-artifact@v7
+        with:
+          name: automobile-desktop-windows
+          path: /tmp/desktop
+
+      - name: "Download desktop Linux Deb"
+        uses: actions/download-artifact@v7
+        with:
+          name: automobile-desktop-linux
+          path: /tmp/desktop
+
       - name: Verify prepared release artifacts
         env:
           VERSION: ${{ inputs.version }}
@@ -322,6 +340,7 @@ jobs:
           bash scripts/ci/verify-artifact-sha256.sh /tmp/automobile-video.jar videojar
           bash scripts/ci/verify-artifact-sha256.sh /tmp/screen-capture-helper-macos-universal.zip screencapturehelper
           bash scripts/ci/verify-release-integrity.sh "$VERSION" /tmp/control-proxy.ipa
+          bash scripts/ci/verify-desktop-installer-assets.sh "$VERSION" /tmp/desktop
 
       - name: Promote verified release and create tag
         shell: bash

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -223,6 +223,11 @@ jobs:
           repository: ${{ github.repository }}
           run-id: ${{ inputs.prepare_run_id }}
 
+      - name: Verify prepared desktop installers
+        env:
+          VERSION: ${{ steps.version.outputs.version }}
+        run: bash scripts/ci/verify-desktop-installer-assets.sh "$VERSION" /tmp/desktop
+
       - name: Read checksums prepared for this release
         id: prepared_checksums
         env:
@@ -503,27 +508,54 @@ jobs:
           cache-to: type=gha,mode=max
 
       - name: Create GitHub Release
-        uses: softprops/action-gh-release@v2
-        with:
-          # Explicit, not derived from github.ref. The action throws "GitHub
-          # Releases requires a tag" on a non-tag ref, and this step runs after
-          # npm/Homebrew/MCP/Maven/Docker have already published irreversibly.
-          tag_name: ${{ needs.validate-release-tag.outputs.tag }}
-          # Plain semver title (e.g. "0.0.47") to match every prior release.
-          name: ${{ steps.version.outputs.version }}
-          body_path: release_notes.txt
-          files: |
+        shell: bash
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          REPO: ${{ github.repository }}
+          TAG: ${{ needs.validate-release-tag.outputs.tag }}
+          VERSION: ${{ steps.version.outputs.version }}
+        run: |
+          set -euo pipefail
+          files=(
             /tmp/control-proxy-debug.apk
             /tmp/control-proxy.ipa
             /tmp/automobile-video.jar
             /tmp/screen-capture-helper-macos-universal.zip
-            /tmp/desktop/AutoMobile-*-macos.dmg
-            /tmp/desktop/AutoMobile-*-windows.msi
-            /tmp/desktop/AutoMobile-*-linux.deb
-          draft: false
-          prerelease: false
-        env:
-          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+            /tmp/desktop/AutoMobile-${VERSION}-macos.dmg
+            /tmp/desktop/AutoMobile-${VERSION}-windows.msi
+            /tmp/desktop/AutoMobile-${VERSION}-linux.deb
+          )
+
+          # Use the GitHub Release API directly through gh. `gh release create`
+          # uploads through a draft before publishing, so a failed first attempt
+          # can leave a mutable draft. Only that draft is safe to repair with
+          # --clobber; never delete assets from an already-published release.
+          if gh release view "$TAG" --repo "$REPO" >/dev/null 2>&1; then
+            release_json="$(gh release view "$TAG" --repo "$REPO" --json isDraft,assets)"
+            if [ "$(jq -r '.isDraft' <<<"$release_json")" = "true" ]; then
+              gh release upload "$TAG" "${files[@]}" --repo "$REPO" --clobber
+              gh release edit "$TAG" --repo "$REPO" --title "$VERSION" \
+                --notes-file release_notes.txt --draft=false
+            else
+              missing=0
+              for file in "${files[@]}"; do
+                asset_name="${file##*/}"
+                if ! jq -e --arg name "$asset_name" \
+                  '.assets[] | select(.name == $name)' <<<"$release_json" >/dev/null; then
+                  echo "Published release $TAG is missing expected asset: $asset_name" >&2
+                  missing=1
+                fi
+              done
+              if [ "$missing" -ne 0 ]; then
+                echo "Refusing to overwrite assets on a published release." >&2
+                exit 1
+              fi
+              gh release edit "$TAG" --repo "$REPO" --title "$VERSION" --notes-file release_notes.txt
+            fi
+          else
+            gh release create "$TAG" "${files[@]}" --repo "$REPO" \
+              --title "$VERSION" --notes-file release_notes.txt --verify-tag
+          fi
 
       - name: Summary
         env:

--- a/scripts/ci/verify-desktop-installer-assets.sh
+++ b/scripts/ci/verify-desktop-installer-assets.sh
@@ -1,0 +1,44 @@
+#!/usr/bin/env bash
+# Verify that the prepared desktop installers use the stable release-asset names.
+#
+# Usage: verify-desktop-installer-assets.sh <version> <directory>
+#
+# Desktop installers are direct downloads, so they deliberately have no
+# RELEASE_CHECKSUM_REGISTRY entries. Their release contract is instead the
+# prepared-run provenance plus these exact, versioned filenames.
+set -euo pipefail
+
+VERSION="${1:?Usage: verify-desktop-installer-assets.sh <version> <directory>}"
+DIRECTORY="${2:?Usage: verify-desktop-installer-assets.sh <version> <directory>}"
+
+if [[ ! "$VERSION" =~ ^[0-9]+\.[0-9]+\.[0-9]+([-+][0-9A-Za-z.-]+)?$ ]]; then
+  echo "ERROR: invalid desktop installer version: $VERSION" >&2
+  exit 1
+fi
+
+if [ ! -d "$DIRECTORY" ]; then
+  echo "ERROR: desktop installer directory not found: $DIRECTORY" >&2
+  exit 1
+fi
+
+expected_assets=(
+  "AutoMobile-${VERSION}-macos.dmg"
+  "AutoMobile-${VERSION}-windows.msi"
+  "AutoMobile-${VERSION}-linux.deb"
+)
+
+missing=0
+for asset in "${expected_assets[@]}"; do
+  if [ ! -s "$DIRECTORY/$asset" ]; then
+    echo "ERROR: required desktop installer is missing or empty: $DIRECTORY/$asset" >&2
+    missing=1
+  else
+    echo "  OK  $asset"
+  fi
+done
+
+if [ "$missing" -ne 0 ]; then
+  exit 1
+fi
+
+echo "Desktop installer assets verified for version $VERSION."

--- a/test/bats/release-workflow-wiring.bats
+++ b/test/bats/release-workflow-wiring.bats
@@ -455,13 +455,40 @@ wiring_requires_yq() {
 # action-gh-release throws "GitHub Releases requires a tag" when github.ref is not
 # a tag ref, and that step runs after npm/Homebrew/MCP/Maven/Docker have already
 # published irreversibly. The tag must be explicit, never inferred from the ref.
-@test "release.yml passes an explicit tag_name to action-gh-release (#4157)" {
+@test "release.yml creates the explicitly validated tag through the GitHub Release API (#4157)" {
   wiring_requires_yq
   run yq -r '.jobs."verify-and-release".steps[]
-    | select(.uses != null and (.uses | test("^softprops/action-gh-release")))
-    | .with.tag_name' ".github/workflows/release.yml"
+    | select(.name == "Create GitHub Release") | .run' ".github/workflows/release.yml"
   [ "$status" -eq 0 ]
-  [ "$output" = '${{ needs.validate-release-tag.outputs.tag }}' ]
+  [[ "$output" == *'gh release create "$TAG"'* ]]
+  [[ "$output" == *'--verify-tag'* ]]
+  [[ "$output" == *'gh release upload "$TAG"'* ]]
+  [[ "$output" == *'--clobber'* ]]
+  [[ "$output" == *'--json isDraft,assets'* ]]
+  [[ "$output" == *'--draft=false'* ]]
+  [[ "$output" == *'Refusing to overwrite assets on a published release.'* ]]
+  [[ "$output" == *'AutoMobile-${VERSION}-macos.dmg'* ]]
+  [[ "$output" != *'AutoMobile-*-macos.dmg'* ]]
+}
+
+@test "desktop installer verification requires the stable versioned asset names" {
+  local script="scripts/ci/verify-desktop-installer-assets.sh"
+  [ -x "$script" ]
+
+  local fixture
+  fixture="$(mktemp -d)"
+  printf 'installer\n' > "$fixture/AutoMobile-1.2.3-macos.dmg"
+  printf 'installer\n' > "$fixture/AutoMobile-1.2.3-windows.msi"
+  printf 'installer\n' > "$fixture/AutoMobile-1.2.3-linux.deb"
+
+  run bash "$script" "1.2.3" "$fixture"
+  [ "$status" -eq 0 ]
+
+  rm "$fixture/AutoMobile-1.2.3-linux.deb"
+  run bash "$script" "1.2.3" "$fixture"
+  [ "$status" -ne 0 ]
+  [[ "$output" == *"AutoMobile-1.2.3-linux.deb"* ]]
+  rm -rf "$fixture"
 }
 
 # release.yml publishes to six targets in one job and npm publish is not


### PR DESCRIPTION
## Summary

- verify the prepared macOS, Windows, and Linux desktop installers by their stable versioned release-asset names before tagging and before publication
- create releases through the GitHub Release API via `gh`, with safe retry handling for partial draft creation and published releases
- add regression coverage for the workflow contract and desktop installer verifier

## Why

Desktop installers had no release-time verification despite being attached from a prepared artifact run. The previous release action also obscured the API behavior needed to safely recover a partial upload.

## Validation

- `bats test/bats/release-workflow-wiring.bats`
- `shellcheck scripts/ci/verify-desktop-installer-assets.sh`
- `actionlint -shellcheck='' .github/workflows/release.yml .github/workflows/prepare-release.yml`
- `bun run turbo:validate`
- `bun run typecheck`

Closes #4685.
