### PR TITLE
iOS: pin XCTestRunner daemon package

### DIFF
--- a/docs/using/hermetic-ci-pinning.md
+++ b/docs/using/hermetic-ci-pinning.md
@@ -109,10 +109,11 @@ set `AUTOMOBILE_ALLOW_INSECURE_ASSET_URL=1` to opt back into `http://`.
    `dist/src/index.js`, XCTestRunner starts or restarts that exact checkout's daemon and
    rejects a same-release daemon from a different checkout. Set the variable explicitly
    for an embedding project or CI layout where the runner source cannot identify the
-   checkout. For a package consumer without a built checkout, XCTestRunner falls back to
-   the PATH `auto-mobile` CLI; pin the exact `@kaeawc/auto-mobile@0.0.40` there or start
-   the daemon yourself before the test job. (Embedding a package-version pin in the Swift
-   runner remains tracked by [#2746](https://github.com/kaeawc/auto-mobile/issues/2746).)
+   checkout. For a package consumer without a built checkout, XCTestRunner uses `bunx`
+   (or `npx`) to start the exact `@kaeawc/auto-mobile@0.0.40` package selected by
+   `AUTOMOBILE_VERSION`. Set `AUTOMOBILE_DAEMON_PACKAGE_VERSION` when the daemon pin must
+   intentionally differ from the shared release pin. Without either version variable, it
+   retains the PATH `auto-mobile` CLI fallback.
 2. **Vendor the IPA** so nothing is fetched or compiled at test time:
    ```bash
    export AUTOMOBILE_CTRL_PROXY_IOS_IPA_PATH=/opt/automobile/control-proxy.ipa

--- a/ios/XCTestRunner/Sources/XCTestRunner/AutoMobileEnvironment.swift
+++ b/ios/XCTestRunner/Sources/XCTestRunner/AutoMobileEnvironment.swift
@@ -98,7 +98,9 @@ enum SimulatorDetection {
 public enum DaemonStartupResult: Equatable {
     case ready
     case executableNotFound
+    case packageRunnerNotFound
     case launchFailed
+    case launchTimeout
     case readinessTimeout
     case versionSkew
     case assetVersionSkew
@@ -113,9 +115,15 @@ public enum DaemonStartupResult: Equatable {
             return "Failed to start AutoMobile Daemon: the `auto-mobile` CLI was not found "
                 + "(checked /usr/local/bin, /opt/homebrew/bin, /usr/bin, ~/.bun/bin, ~/.local/bin and PATH). "
                 + "Install it globally (`bun add -g .`) and ensure its bin directory is on PATH."
+        case .packageRunnerNotFound:
+            return "Failed to start AutoMobile Daemon: a pinned daemon requires `bunx` or `npx`, but neither "
+                + "was found on PATH. Install Bun or Node.js with npm/npx, then retry."
         case .launchFailed:
             return "Failed to start AutoMobile Daemon: `auto-mobile --daemon start` exited non-zero. "
                 + "Check the daemon logs."
+        case .launchTimeout:
+            return "Failed to start AutoMobile Daemon: the daemon launcher timed out before it completed. "
+                + "Check package-registry connectivity and daemon logs."
         case .readinessTimeout:
             return "Failed to start AutoMobile Daemon: the daemon process launched but its socket did not "
                 + "become ready before the timeout. Check the daemon logs."
@@ -137,7 +145,11 @@ protocol DaemonRuntime {
     func readDaemonAssetVersion() -> String?
     func readDaemonEntryScript() -> String?
     func readDaemonBuildId() -> String?
-    func runDaemonSubcommand(_ subcommand: String, repoRoot: String?) -> DaemonManager.DaemonSubcommandOutcome
+    func runDaemonSubcommand(
+        _ subcommand: String,
+        repoRoot: String?,
+        timeoutSeconds: TimeInterval
+    ) -> DaemonManager.DaemonSubcommandOutcome
     func waitForDaemon(timeoutSeconds: TimeInterval) -> Bool
 }
 
@@ -153,12 +165,60 @@ public enum DaemonManager {
     enum DaemonSubcommandOutcome: Equatable {
         case launched
         case executableNotFound
+        case packageRunnerNotFound
         case failed
+        case timedOut
     }
 
     enum DaemonLaunch: Equatable {
         case process(executable: String, arguments: [String])
         case executableNotFound
+        case packageRunnerNotFound
+    }
+
+    /// Injectable subprocess boundary so launcher timeouts are deterministic in unit tests.
+    protocol DaemonSubcommandLauncher {
+        func launch(
+            executable: String,
+            arguments: [String],
+            environment: [String: String],
+            timeoutSeconds: TimeInterval
+        ) -> DaemonSubcommandOutcome
+    }
+
+    private struct SystemDaemonSubcommandLauncher: DaemonSubcommandLauncher {
+        func launch(
+            executable: String,
+            arguments: [String],
+            environment: [String: String],
+            timeoutSeconds: TimeInterval
+        ) -> DaemonSubcommandOutcome {
+            let process = Process()
+            process.executableURL = URL(fileURLWithPath: executable)
+            process.arguments = arguments
+            process.environment = environment
+            process.standardOutput = FileHandle.nullDevice
+            process.standardError = FileHandle.nullDevice
+
+            do {
+                let completion = DispatchSemaphore(value: 0)
+                process.terminationHandler = { _ in completion.signal() }
+                try process.run()
+                PerfTimer.log("runDaemonSubcommand: process launched, waiting for exit")
+                guard completion.wait(timeout: .now() + timeoutSeconds) == .success else {
+                    PerfTimer.log("runDaemonSubcommand: launcher timed out after \(timeoutSeconds)s")
+                    process.terminate()
+                    process.waitUntilExit()
+                    return .timedOut
+                }
+                let status = process.terminationStatus
+                PerfTimer.log("runDaemonSubcommand: process exited with status \(status)")
+                return status == 0 ? .launched : .failed
+            } catch {
+                PerfTimer.log("runDaemonSubcommand: ERROR - failed to run process: \(error)")
+                return .failed
+            }
+        }
     }
 
     private struct SystemDaemonRuntime: DaemonRuntime {
@@ -182,8 +242,16 @@ public enum DaemonManager {
             DaemonManager.readDaemonBuildIdFromPidFile()
         }
 
-        func runDaemonSubcommand(_ subcommand: String, repoRoot: String?) -> DaemonSubcommandOutcome {
-            DaemonManager.runDaemonSubcommand(subcommand, repoRoot: repoRoot)
+        func runDaemonSubcommand(
+            _ subcommand: String,
+            repoRoot: String?,
+            timeoutSeconds: TimeInterval
+        ) -> DaemonSubcommandOutcome {
+            DaemonManager.runDaemonSubcommand(
+                subcommand,
+                repoRoot: repoRoot,
+                timeoutSeconds: timeoutSeconds
+            )
         }
 
         func waitForDaemon(timeoutSeconds: TimeInterval) -> Bool {
@@ -251,8 +319,12 @@ public enum DaemonManager {
             return nil
         case .executableNotFound:
             return .executableNotFound
+        case .packageRunnerNotFound:
+            return .packageRunnerNotFound
         case .failed:
             return .launchFailed
+        case .timedOut:
+            return .launchTimeout
         }
     }
 
@@ -263,7 +335,12 @@ public enum DaemonManager {
         return runDaemonSubcommand("restart", repoRoot: repoRoot) == .launched
     }
 
-    static func runDaemonSubcommand(_ subcommand: String, repoRoot: String? = nil) -> DaemonSubcommandOutcome {
+    static func runDaemonSubcommand(
+        _ subcommand: String,
+        repoRoot: String? = nil,
+        timeoutSeconds: TimeInterval = 15,
+        launcher: DaemonSubcommandLauncher = SystemDaemonSubcommandLauncher()
+    ) -> DaemonSubcommandOutcome {
         // When a repo root with a built entrypoint is provided, launch *that* checkout's daemon
         // (`<repoRoot>/dist/src/index.js`) rather than whatever `auto-mobile` is on PATH — so a
         // caller that knows its source build gets a version/build-matched daemon (#2744) instead of
@@ -278,15 +355,18 @@ public enum DaemonManager {
             packageRunner: findExecutable("bunx") ?? findExecutable("npx"),
             autoMobilePath: findExecutable("auto-mobile")
         )
-        let executableURL: URL
+        let executable: String
         let arguments: [String]
         switch launch {
-        case let .process(executable, launchArguments):
-            executableURL = URL(fileURLWithPath: executable)
+        case let .process(launchExecutable, launchArguments):
+            executable = launchExecutable
             arguments = launchArguments
         case .executableNotFound:
             PerfTimer.log("runDaemonSubcommand: ERROR - no compatible daemon executable found")
             return .executableNotFound
+        case .packageRunnerNotFound:
+            PerfTimer.log("runDaemonSubcommand: ERROR - pinned daemon package runner not found")
+            return .packageRunnerNotFound
         }
 
         let hasLocalBuild = localEntry != nil && runtime != nil
@@ -298,10 +378,6 @@ public enum DaemonManager {
             PerfTimer.log("runDaemonSubcommand(\(subcommand)): launching auto-mobile from PATH")
         }
 
-        let process = Process()
-        process.executableURL = executableURL
-        process.arguments = arguments
-
         // Inherit essential environment variables for device discovery
         var env = ProcessInfo.processInfo.environment
         // Ensure PATH includes /usr/bin for xcrun/simctl
@@ -309,23 +385,29 @@ public enum DaemonManager {
         if !currentPath.contains("/usr/bin") {
             env["PATH"] = "/usr/bin:/usr/local/bin:\(currentPath)"
         }
-        process.environment = env
+        return executeDaemonLaunch(
+            executable: executable,
+            arguments: arguments,
+            environment: env,
+            timeoutSeconds: timeoutSeconds,
+            launcher: launcher
+        )
+    }
 
-        PerfTimer.log("runDaemonSubcommand: launching process with args: \(process.arguments ?? [])")
-        process.standardOutput = FileHandle.nullDevice
-        process.standardError = FileHandle.nullDevice
-
-        do {
-            try process.run()
-            PerfTimer.log("runDaemonSubcommand: process launched, waiting for exit")
-            process.waitUntilExit()
-            let status = process.terminationStatus
-            PerfTimer.log("runDaemonSubcommand: process exited with status \(status)")
-            return status == 0 ? .launched : .failed
-        } catch {
-            PerfTimer.log("runDaemonSubcommand: ERROR - failed to run process: \(error)")
-            return .failed
-        }
+    static func executeDaemonLaunch(
+        executable: String,
+        arguments: [String],
+        environment: [String: String],
+        timeoutSeconds: TimeInterval,
+        launcher: DaemonSubcommandLauncher
+    ) -> DaemonSubcommandOutcome {
+        PerfTimer.log("runDaemonSubcommand: launching process with args: \(arguments)")
+        return launcher.launch(
+            executable: executable,
+            arguments: arguments,
+            environment: environment,
+            timeoutSeconds: timeoutSeconds
+        )
     }
 
     static func selectDaemonLaunch(
@@ -342,7 +424,7 @@ public enum DaemonManager {
         }
         if let packageSpecifier = resolveDaemonPackageSpecifier(packageVersion) {
             guard let packageRunner else {
-                return .executableNotFound
+                return .packageRunnerNotFound
             }
             return .process(
                 executable: packageRunner,
@@ -418,8 +500,9 @@ public enum DaemonManager {
         repoRoot: String? = nil,
         environment: [String: String] = ProcessInfo.processInfo.environment
     ) -> String {
+        let effectiveRepoRoot = repoRoot ?? findRepoRoot(startingAt: #filePath)
         return resolveDaemonClientVersion(
-            repoRootHasBuiltEntry: resolveRepoRootDaemonEntryScript(repoRoot) != nil,
+            repoRootHasBuiltEntry: resolveRepoRootDaemonEntryScript(effectiveRepoRoot) != nil,
             environment: environment
         )
     }
@@ -639,7 +722,11 @@ public enum DaemonManager {
             }
             if versionSkew || buildSkew || assetVersionSkew {
                 PerfTimer.log("ensureDaemonRunning: daemon version/build skew, restarting")
-                if let failure = startupFailure(for: runtime.runDaemonSubcommand("restart", repoRoot: repoRoot)) {
+                if let failure = startupFailure(for: runtime.runDaemonSubcommand(
+                    "restart",
+                    repoRoot: repoRoot,
+                    timeoutSeconds: timeoutSeconds
+                )) {
                     PerfTimer.log("ensureDaemonRunning: restartDaemon failed - \(failure)")
                     return failure
                 }
@@ -656,7 +743,11 @@ public enum DaemonManager {
         }
 
         PerfTimer.log("ensureDaemonRunning: starting daemon")
-        if let failure = startupFailure(for: runtime.runDaemonSubcommand("start", repoRoot: repoRoot)) {
+        if let failure = startupFailure(for: runtime.runDaemonSubcommand(
+            "start",
+            repoRoot: repoRoot,
+            timeoutSeconds: timeoutSeconds
+        )) {
             PerfTimer.log("ensureDaemonRunning: startDaemon failed - \(failure)")
             return failure
         }

--- a/ios/XCTestRunner/Sources/XCTestRunner/AutoMobileEnvironment.swift
+++ b/ios/XCTestRunner/Sources/XCTestRunner/AutoMobileEnvironment.swift
@@ -156,6 +156,11 @@ public enum DaemonManager {
         case failed
     }
 
+    enum DaemonLaunch: Equatable {
+        case process(executable: String, arguments: [String])
+        case executableNotFound
+    }
+
     private struct SystemDaemonRuntime: DaemonRuntime {
         func isDaemonRunning() -> Bool {
             DaemonManager.isDaemonRunning()
@@ -262,24 +267,35 @@ public enum DaemonManager {
         // When a repo root with a built entrypoint is provided, launch *that* checkout's daemon
         // (`<repoRoot>/dist/src/index.js`) rather than whatever `auto-mobile` is on PATH — so a
         // caller that knows its source build gets a version/build-matched daemon (#2744) instead of
-        // a same-release-but-different-checkout PATH binary. Falls back to the PATH binary otherwise.
+        // a same-release-but-different-checkout PATH binary. A concrete package pin takes the
+        // next precedence, and an unpinned launch falls back to the PATH binary.
+        let localEntry = resolveRepoRootDaemonEntryScript(repoRoot)
+        let runtime = findExecutable("bun") ?? findExecutable("node")
+        let launch = selectDaemonLaunch(
+            subcommand: subcommand,
+            localEntry: localEntry,
+            runtime: runtime,
+            packageRunner: findExecutable("bunx") ?? findExecutable("npx"),
+            autoMobilePath: findExecutable("auto-mobile")
+        )
         let executableURL: URL
         let arguments: [String]
-        if let localEntry = resolveRepoRootDaemonEntryScript(repoRoot),
-           let runtime = findExecutable("bun") ?? findExecutable("node")
-        {
-            PerfTimer.log("runDaemonSubcommand(\(subcommand)): launching local build at \(localEntry)")
-            executableURL = URL(fileURLWithPath: runtime)
-            arguments = [localEntry, "--daemon", subcommand]
+        switch launch {
+        case let .process(executable, launchArguments):
+            executableURL = URL(fileURLWithPath: executable)
+            arguments = launchArguments
+        case .executableNotFound:
+            PerfTimer.log("runDaemonSubcommand: ERROR - no compatible daemon executable found")
+            return .executableNotFound
+        }
+
+        let hasLocalBuild = localEntry != nil && runtime != nil
+        if hasLocalBuild {
+            PerfTimer.log("runDaemonSubcommand(\(subcommand)): launching local build")
+        } else if resolveDaemonPackageSpecifier(resolveDaemonPackageVersion()) != nil {
+            PerfTimer.log("runDaemonSubcommand(\(subcommand)): launching pinned package")
         } else {
-            PerfTimer.log("runDaemonSubcommand(\(subcommand)): searching for auto-mobile executable")
-            guard let autoMobilePath = findExecutable("auto-mobile") else {
-                PerfTimer.log("runDaemonSubcommand: ERROR - auto-mobile not found in PATH")
-                return .executableNotFound
-            }
-            PerfTimer.log("runDaemonSubcommand: found auto-mobile at \(autoMobilePath)")
-            executableURL = URL(fileURLWithPath: autoMobilePath)
-            arguments = ["--daemon", subcommand]
+            PerfTimer.log("runDaemonSubcommand(\(subcommand)): launching auto-mobile from PATH")
         }
 
         let process = Process()
@@ -310,6 +326,114 @@ public enum DaemonManager {
             PerfTimer.log("runDaemonSubcommand: ERROR - failed to run process: \(error)")
             return .failed
         }
+    }
+
+    static func selectDaemonLaunch(
+        subcommand: String,
+        localEntry: String?,
+        runtime: String?,
+        packageRunner: String?,
+        autoMobilePath: String?,
+        packageVersion: String? = resolveDaemonPackageVersion()
+    ) -> DaemonLaunch {
+        if let localEntry, let runtime {
+            PerfTimer.log("runDaemonSubcommand(\(subcommand)): launching local build at \(localEntry)")
+            return .process(executable: runtime, arguments: [localEntry, "--daemon", subcommand])
+        }
+        if let packageSpecifier = resolveDaemonPackageSpecifier(packageVersion) {
+            guard let packageRunner else {
+                return .executableNotFound
+            }
+            return .process(
+                executable: packageRunner,
+                arguments: packageDaemonArguments(
+                    packageRunner: packageRunner,
+                    packageSpecifier: packageSpecifier,
+                    subcommand: subcommand
+                )
+            )
+        }
+        guard let autoMobilePath else {
+            return .executableNotFound
+        }
+        return .process(executable: autoMobilePath, arguments: ["--daemon", subcommand])
+    }
+
+    /// Builds the package-runner arguments for an explicit daemon version pin. `bunx` does not
+    /// require confirmation, while `npx` needs `-y` to keep XCTest runs non-interactive.
+    static func buildPackageDaemonCommand(
+        packageRunner: String,
+        subcommand: String,
+        packageVersion: String? = resolveDaemonPackageVersion()
+    ) -> [String]? {
+        guard let packageSpecifier = resolveDaemonPackageSpecifier(packageVersion) else {
+            return nil
+        }
+
+        return packageDaemonArguments(
+            packageRunner: packageRunner,
+            packageSpecifier: packageSpecifier,
+            subcommand: subcommand
+        )
+    }
+
+    /// The package version a non-checkout XCTestRunner daemon launch should use. An explicit
+    /// daemon-package pin takes precedence over the shared release pin, matching Android.
+    static func resolveDaemonPackageVersion(
+        environment: [String: String] = ProcessInfo.processInfo.environment
+    ) -> String? {
+        let explicitPin = environment["AUTOMOBILE_DAEMON_PACKAGE_VERSION"]?
+            .trimmingCharacters(in: .whitespaces)
+        if let explicitPin, !explicitPin.isEmpty {
+            return explicitPin
+        }
+
+        let automobileVersion = environment["AUTOMOBILE_VERSION"]?.trimmingCharacters(in: .whitespaces)
+        return automobileVersion?.isEmpty == false ? automobileVersion : nil
+    }
+
+    private static func resolveDaemonPackageSpecifier(_ packageVersion: String?) -> String? {
+        guard let version = packageVersion?.trimmingCharacters(in: .whitespaces),
+              !version.isEmpty,
+              version.lowercased() != "latest",
+              version.lowercased() != "unknown"
+        else {
+            return nil
+        }
+        return "\(packageName)@\(version)"
+    }
+
+    private static func packageDaemonArguments(
+        packageRunner: String,
+        packageSpecifier: String,
+        subcommand: String
+    ) -> [String] {
+        let prefix = URL(fileURLWithPath: packageRunner).deletingPathExtension().lastPathComponent == "npx"
+            ? ["-y"]
+            : []
+        return prefix + [packageSpecifier, "--daemon", subcommand]
+    }
+
+    static func resolveDaemonClientVersion(
+        repoRoot: String? = nil,
+        environment: [String: String] = ProcessInfo.processInfo.environment
+    ) -> String {
+        return resolveDaemonClientVersion(
+            repoRootHasBuiltEntry: resolveRepoRootDaemonEntryScript(repoRoot) != nil,
+            environment: environment
+        )
+    }
+
+    static func resolveDaemonClientVersion(
+        repoRootHasBuiltEntry: Bool,
+        environment: [String: String]
+    ) -> String {
+        guard !repoRootHasBuiltEntry,
+              let packageVersion = resolveDaemonPackageSpecifier(resolveDaemonPackageVersion(environment: environment))
+        else {
+            return AutoMobileVersion.current
+        }
+        return String(packageVersion.dropFirst(packageName.count + 1))
     }
 
     /// The daemon's recorded version from its PID file, trimmed, or nil when absent/unreadable.
@@ -480,10 +604,12 @@ public enum DaemonManager {
         repoRoot: String?,
         timeoutSeconds: TimeInterval,
         runtime: DaemonRuntime,
-        callerAssetVersion: String? = resolveCallerAssetVersionPin()
+        callerAssetVersion: String? = resolveCallerAssetVersionPin(),
+        clientVersion: String? = nil
     )
         -> DaemonStartupResult
     {
+        let expectedClientVersion = clientVersion ?? resolveDaemonClientVersion(repoRoot: repoRoot)
         PerfTimer.log("ensureDaemonRunning: checking isDaemonRunning")
         if runtime.isDaemonRunning() {
             // A stale different-build daemon on the shared socket would reject this runner's
@@ -492,7 +618,7 @@ public enum DaemonManager {
             // also restart a same-release daemon started from a different checkout's entry script.
             let versionSkew = requiresVersionSkewRestart(
                 daemonVersion: runtime.readDaemonVersion(),
-                clientVersion: AutoMobileVersion.current
+                clientVersion: expectedClientVersion
             )
             let buildSkew = requiresRepoRootBuildSkew(
                 daemonBuildId: runtime.readDaemonBuildId(),
@@ -521,7 +647,8 @@ public enum DaemonManager {
                     repoRoot: repoRoot,
                     timeoutSeconds: timeoutSeconds,
                     runtime: runtime,
-                    callerAssetVersion: callerAssetVersion
+                    callerAssetVersion: callerAssetVersion,
+                    clientVersion: expectedClientVersion
                 )
             }
             PerfTimer.log("ensureDaemonRunning: daemon already running")
@@ -538,7 +665,8 @@ public enum DaemonManager {
             repoRoot: repoRoot,
             timeoutSeconds: timeoutSeconds,
             runtime: runtime,
-            callerAssetVersion: callerAssetVersion
+            callerAssetVersion: callerAssetVersion,
+            clientVersion: expectedClientVersion
         )
     }
 
@@ -552,7 +680,8 @@ public enum DaemonManager {
         repoRoot: String?,
         timeoutSeconds: TimeInterval,
         runtime: DaemonRuntime,
-        callerAssetVersion: String?
+        callerAssetVersion: String?,
+        clientVersion: String
     )
         -> DaemonStartupResult
     {
@@ -562,7 +691,7 @@ public enum DaemonManager {
         }
         if requiresVersionSkewRestart(
             daemonVersion: runtime.readDaemonVersion(),
-            clientVersion: AutoMobileVersion.current
+            clientVersion: clientVersion
         ) || requiresRepoRootBuildSkew(
             daemonBuildId: runtime.readDaemonBuildId(),
             daemonEntryScript: runtime.readDaemonEntryScript(),
@@ -680,7 +809,7 @@ public enum DaemonManager {
             "method": "daemon/releaseSession",
             "params": ["sessionId": sessionId],
             // Declared for the daemon's server-side version handshake gate (#2744).
-            "clientVersion": AutoMobileVersion.current,
+            "clientVersion": resolveDaemonClientVersion(),
         ]
 
         guard let requestData = try? JSONSerialization.data(withJSONObject: request),
@@ -725,7 +854,7 @@ public enum DaemonManager {
             "method": "daemon/refreshDevices",
             "params": [String: Any](),
             // Declared for the daemon's server-side version handshake gate (#2744).
-            "clientVersion": AutoMobileVersion.current,
+            "clientVersion": resolveDaemonClientVersion(),
         ]
 
         guard let requestData = try? JSONSerialization.data(withJSONObject: request),

--- a/ios/XCTestRunner/Sources/XCTestRunner/AutoMobileEnvironment.swift
+++ b/ios/XCTestRunner/Sources/XCTestRunner/AutoMobileEnvironment.swift
@@ -171,6 +171,7 @@ public enum DaemonManager {
         case executableNotFound
         case packageRunnerNotFound
         case failed(stderr: String? = nil)
+        case packageFailed(stderr: String? = nil)
         case timedOut
     }
 
@@ -361,13 +362,30 @@ public enum DaemonManager {
         case .packageRunnerNotFound:
             return .packageRunnerNotFound
         case let .failed(stderr):
-            guard let stderr = stderr?.trimmingCharacters(in: .whitespacesAndNewlines), !stderr.isEmpty else {
-                return .launchFailed
-            }
-            return .packageLaunchFailed(stderr: stderr)
+            return failureResult(stderr: stderr, packageRunner: false)
+        case let .packageFailed(stderr):
+            return failureResult(stderr: stderr, packageRunner: true)
         case .timedOut:
             return .launchTimeout
         }
+    }
+
+    private static func failureResult(stderr: String?, packageRunner: Bool) -> DaemonStartupResult {
+        guard let stderr = stderr?.trimmingCharacters(in: .whitespacesAndNewlines), !stderr.isEmpty else {
+            return .launchFailed
+        }
+        if packageRunner {
+            return .packageLaunchFailed(stderr: stderr)
+        }
+        return .launchFailed
+    }
+
+    static func classifyDaemonSubcommandOutcome(
+        _ outcome: DaemonSubcommandOutcome,
+        packageRunner: Bool
+    ) -> DaemonSubcommandOutcome {
+        guard packageRunner, case let .failed(stderr) = outcome else { return outcome }
+        return .packageFailed(stderr: stderr)
     }
 
     /// Restart the daemon in place — used to replace a stale different-build daemon that owns
@@ -426,12 +444,16 @@ public enum DaemonManager {
             subcommand: subcommand,
             readinessTimeoutSeconds: timeoutSeconds
         )
-        return executeDaemonLaunch(
+        let outcome = executeDaemonLaunch(
             executable: executable,
             arguments: arguments,
             environment: env,
             timeoutSeconds: launcherTimeoutSeconds,
             launcher: launcher
+        )
+        return classifyDaemonSubcommandOutcome(
+            outcome,
+            packageRunner: !hasLocalBuild && resolveDaemonPackageSpecifier(resolveDaemonPackageVersion()) != nil
         )
     }
 
@@ -459,13 +481,13 @@ public enum DaemonManager {
         readinessTimeoutSeconds: TimeInterval,
         environment: [String: String] = ProcessInfo.processInfo.environment
     ) -> TimeInterval {
-        guard subcommand == "restart" else { return readinessTimeoutSeconds }
         let configuredStartupMilliseconds = Int(environment["AUTOMOBILE_DAEMON_STARTUP_TIMEOUT_MS"] ?? "")
             ?? Int(environment["AUTO_MOBILE_DAEMON_STARTUP_TIMEOUT_MS"] ?? "")
             ?? 10_000
         let startupSeconds = configuredStartupMilliseconds > 0
             ? TimeInterval(configuredStartupMilliseconds) / 1000
             : 10
+        guard subcommand == "restart" else { return max(readinessTimeoutSeconds, startupSeconds) }
         // DaemonManager.restart allows shutdown (5s), an inter-phase delay (1s), then startup.
         return max(readinessTimeoutSeconds, 6 + startupSeconds)
     }

--- a/ios/XCTestRunner/Sources/XCTestRunner/AutoMobileEnvironment.swift
+++ b/ios/XCTestRunner/Sources/XCTestRunner/AutoMobileEnvironment.swift
@@ -698,7 +698,8 @@ public enum DaemonManager {
     )
         -> DaemonStartupResult
     {
-        let expectedClientVersion = clientVersion ?? resolveDaemonClientVersion(repoRoot: repoRoot)
+        let effectiveRepoRoot = resolveDaemonRepoRoot(repoRoot)
+        let expectedClientVersion = clientVersion ?? resolveDaemonClientVersion(repoRoot: effectiveRepoRoot)
         PerfTimer.log("ensureDaemonRunning: checking isDaemonRunning")
         if runtime.isDaemonRunning() {
             // A stale different-build daemon on the shared socket would reject this runner's
@@ -712,7 +713,7 @@ public enum DaemonManager {
             let buildSkew = requiresRepoRootBuildSkew(
                 daemonBuildId: runtime.readDaemonBuildId(),
                 daemonEntryScript: runtime.readDaemonEntryScript(),
-                repoRoot: repoRoot
+                repoRoot: effectiveRepoRoot
             )
             let assetVersionSkew = requiresAssetVersionPinFailure(
                 daemonAssetVersion: runtime.readDaemonAssetVersion(),
@@ -730,14 +731,14 @@ public enum DaemonManager {
                 PerfTimer.log("ensureDaemonRunning: daemon version/build skew, restarting")
                 if let failure = startupFailure(for: runtime.runDaemonSubcommand(
                     "restart",
-                    repoRoot: repoRoot,
+                    repoRoot: effectiveRepoRoot,
                     timeoutSeconds: timeoutSeconds
                 )) {
                     PerfTimer.log("ensureDaemonRunning: restartDaemon failed - \(failure)")
                     return failure
                 }
                 return waitForVersionMatchedDaemon(
-                    repoRoot: repoRoot,
+                    repoRoot: effectiveRepoRoot,
                     timeoutSeconds: timeoutSeconds,
                     runtime: runtime,
                     callerAssetVersion: callerAssetVersion,
@@ -751,7 +752,7 @@ public enum DaemonManager {
         PerfTimer.log("ensureDaemonRunning: starting daemon")
         if let failure = startupFailure(for: runtime.runDaemonSubcommand(
             "start",
-            repoRoot: repoRoot,
+            repoRoot: effectiveRepoRoot,
             timeoutSeconds: timeoutSeconds
         )) {
             PerfTimer.log("ensureDaemonRunning: startDaemon failed - \(failure)")
@@ -759,7 +760,7 @@ public enum DaemonManager {
         }
 
         return waitForVersionMatchedDaemon(
-            repoRoot: repoRoot,
+            repoRoot: effectiveRepoRoot,
             timeoutSeconds: timeoutSeconds,
             runtime: runtime,
             callerAssetVersion: callerAssetVersion,

--- a/ios/XCTestRunner/Sources/XCTestRunner/AutoMobileEnvironment.swift
+++ b/ios/XCTestRunner/Sources/XCTestRunner/AutoMobileEnvironment.swift
@@ -487,9 +487,14 @@ public enum DaemonManager {
         let startupSeconds = configuredStartupMilliseconds > 0
             ? TimeInterval(configuredStartupMilliseconds) / 1000
             : 10
-        guard subcommand == "restart" else { return max(readinessTimeoutSeconds, startupSeconds) }
-        // DaemonManager.restart allows shutdown (5s), an inter-phase delay (1s), then startup.
-        return max(readinessTimeoutSeconds, 6 + startupSeconds)
+        // DaemonManager can wait once for an existing lock holder and once for the lock winner's
+        // startup/retry, each with the configured startup budget.
+        let startupLifecycleSeconds = 2 * startupSeconds
+        guard subcommand == "restart" else {
+            return max(readinessTimeoutSeconds, startupLifecycleSeconds)
+        }
+        // DaemonManager.restart additionally allows shutdown (5s) and an inter-phase delay (1s).
+        return max(readinessTimeoutSeconds, 6 + startupLifecycleSeconds)
     }
 
     static func executeDaemonLaunch(

--- a/ios/XCTestRunner/Sources/XCTestRunner/AutoMobileEnvironment.swift
+++ b/ios/XCTestRunner/Sources/XCTestRunner/AutoMobileEnvironment.swift
@@ -487,9 +487,9 @@ public enum DaemonManager {
         let startupSeconds = configuredStartupMilliseconds > 0
             ? TimeInterval(configuredStartupMilliseconds) / 1000
             : 10
-        // DaemonManager can wait once for an existing lock holder and once for the lock winner's
-        // startup/retry, each with the configured startup budget.
-        let startupLifecycleSeconds = 2 * startupSeconds
+        // DaemonManager can wait for a lock holder, then make two startup attempts while
+        // recovering an incomplete package extraction, each with the configured startup budget.
+        let startupLifecycleSeconds = 3 * startupSeconds
         guard subcommand == "restart" else {
             return max(readinessTimeoutSeconds, startupLifecycleSeconds)
         }
@@ -603,7 +603,7 @@ public enum DaemonManager {
         repoRoot: String? = nil,
         environment: [String: String] = ProcessInfo.processInfo.environment
     ) -> String {
-        let effectiveRepoRoot = resolveDaemonRepoRoot(repoRoot)
+        let effectiveRepoRoot = resolveDaemonRepoRoot(repoRoot, environment: environment)
         return resolveDaemonClientVersion(
             repoRootHasBuiltEntry: resolveRepoRootDaemonEntryScript(effectiveRepoRoot) != nil,
             environment: environment
@@ -612,8 +612,15 @@ public enum DaemonManager {
 
     /// The checkout used for both daemon launch and the matching client handshake. A caller may
     /// supply a root explicitly; otherwise XCTestRunner's own source checkout is used when built.
-    static func resolveDaemonRepoRoot(_ repoRoot: String?, inferredRepoRoot: String? = nil) -> String? {
-        repoRoot ?? inferredRepoRoot ?? findRepoRoot(startingAt: #filePath)
+    static func resolveDaemonRepoRoot(
+        _ repoRoot: String?,
+        inferredRepoRoot: String? = nil,
+        environment: [String: String] = ProcessInfo.processInfo.environment
+    ) -> String? {
+        repoRoot
+            ?? inferredRepoRoot
+            ?? AutoMobileEnvironment(values: environment).firstNonEmpty(["AUTOMOBILE_REPO_ROOT"])
+            ?? findRepoRoot(startingAt: #filePath)
     }
 
     static func resolveDaemonClientVersion(

--- a/ios/XCTestRunner/Sources/XCTestRunner/AutoMobileEnvironment.swift
+++ b/ios/XCTestRunner/Sources/XCTestRunner/AutoMobileEnvironment.swift
@@ -208,7 +208,6 @@ public enum DaemonManager {
                 guard completion.wait(timeout: .now() + timeoutSeconds) == .success else {
                     PerfTimer.log("runDaemonSubcommand: launcher timed out after \(timeoutSeconds)s")
                     process.terminate()
-                    process.waitUntilExit()
                     return .timedOut
                 }
                 let status = process.terminationStatus
@@ -346,7 +345,8 @@ public enum DaemonManager {
         // caller that knows its source build gets a version/build-matched daemon (#2744) instead of
         // a same-release-but-different-checkout PATH binary. A concrete package pin takes the
         // next precedence, and an unpinned launch falls back to the PATH binary.
-        let localEntry = resolveRepoRootDaemonEntryScript(repoRoot)
+        let effectiveRepoRoot = resolveDaemonRepoRoot(repoRoot)
+        let localEntry = resolveRepoRootDaemonEntryScript(effectiveRepoRoot)
         let runtime = findExecutable("bun") ?? findExecutable("node")
         let launch = selectDaemonLaunch(
             subcommand: subcommand,
@@ -500,11 +500,17 @@ public enum DaemonManager {
         repoRoot: String? = nil,
         environment: [String: String] = ProcessInfo.processInfo.environment
     ) -> String {
-        let effectiveRepoRoot = repoRoot ?? findRepoRoot(startingAt: #filePath)
+        let effectiveRepoRoot = resolveDaemonRepoRoot(repoRoot)
         return resolveDaemonClientVersion(
             repoRootHasBuiltEntry: resolveRepoRootDaemonEntryScript(effectiveRepoRoot) != nil,
             environment: environment
         )
+    }
+
+    /// The checkout used for both daemon launch and the matching client handshake. A caller may
+    /// supply a root explicitly; otherwise XCTestRunner's own source checkout is used when built.
+    static func resolveDaemonRepoRoot(_ repoRoot: String?) -> String? {
+        repoRoot ?? findRepoRoot(startingAt: #filePath)
     }
 
     static func resolveDaemonClientVersion(

--- a/ios/XCTestRunner/Sources/XCTestRunner/AutoMobileEnvironment.swift
+++ b/ios/XCTestRunner/Sources/XCTestRunner/AutoMobileEnvironment.swift
@@ -100,6 +100,7 @@ public enum DaemonStartupResult: Equatable {
     case executableNotFound
     case packageRunnerNotFound
     case launchFailed
+    case packageLaunchFailed(stderr: String)
     case launchTimeout
     case readinessTimeout
     case versionSkew
@@ -121,6 +122,9 @@ public enum DaemonStartupResult: Equatable {
         case .launchFailed:
             return "Failed to start AutoMobile Daemon: `auto-mobile --daemon start` exited non-zero. "
                 + "Check the daemon logs."
+        case let .packageLaunchFailed(stderr):
+            return "Failed to start AutoMobile Daemon: the package runner exited non-zero. "
+                + "Package-runner error: \(stderr.trimmingCharacters(in: .whitespacesAndNewlines))."
         case .launchTimeout:
             return "Failed to start AutoMobile Daemon: the daemon launcher timed out before it completed. "
                 + "Check package-registry connectivity and daemon logs."
@@ -166,7 +170,7 @@ public enum DaemonManager {
         case launched
         case executableNotFound
         case packageRunnerNotFound
-        case failed
+        case failed(stderr: String? = nil)
         case timedOut
     }
 
@@ -186,6 +190,41 @@ public enum DaemonManager {
         ) -> DaemonSubcommandOutcome
     }
 
+    private final class BoundedStandardError {
+        private static let maximumBytes = 4096
+        private let lock = NSLock()
+        private var data = Data()
+        let pipe = Pipe()
+
+        init() {
+            pipe.fileHandleForReading.readabilityHandler = { [weak self] handle in
+                self?.append(handle.availableData)
+            }
+        }
+
+        func text() -> String? {
+            pipe.fileHandleForReading.readabilityHandler = nil
+            append(pipe.fileHandleForReading.readDataToEndOfFile())
+            lock.lock()
+            defer { lock.unlock() }
+            guard !data.isEmpty else { return nil }
+            return String(data: data, encoding: .utf8)
+        }
+
+        private func append(_ incoming: Data) {
+            guard !incoming.isEmpty else { return }
+            lock.lock()
+            defer { lock.unlock() }
+            let remaining = Self.maximumBytes - data.count
+            guard remaining > 0 else { return }
+            data.append(incoming.prefix(remaining))
+        }
+
+        deinit {
+            pipe.fileHandleForReading.readabilityHandler = nil
+        }
+    }
+
     private struct SystemDaemonSubcommandLauncher: DaemonSubcommandLauncher {
         func launch(
             executable: String,
@@ -198,7 +237,8 @@ public enum DaemonManager {
             process.arguments = arguments
             process.environment = environment
             process.standardOutput = FileHandle.nullDevice
-            process.standardError = FileHandle.nullDevice
+            let stderr = BoundedStandardError()
+            process.standardError = stderr.pipe
 
             do {
                 let completion = DispatchSemaphore(value: 0)
@@ -212,10 +252,10 @@ public enum DaemonManager {
                 }
                 let status = process.terminationStatus
                 PerfTimer.log("runDaemonSubcommand: process exited with status \(status)")
-                return status == 0 ? .launched : .failed
+                return status == 0 ? .launched : .failed(stderr: stderr.text())
             } catch {
                 PerfTimer.log("runDaemonSubcommand: ERROR - failed to run process: \(error)")
-                return .failed
+                return .failed(stderr: error.localizedDescription)
             }
         }
     }
@@ -320,8 +360,11 @@ public enum DaemonManager {
             return .executableNotFound
         case .packageRunnerNotFound:
             return .packageRunnerNotFound
-        case .failed:
-            return .launchFailed
+        case let .failed(stderr):
+            guard let stderr = stderr?.trimmingCharacters(in: .whitespacesAndNewlines), !stderr.isEmpty else {
+                return .launchFailed
+            }
+            return .packageLaunchFailed(stderr: stderr)
         case .timedOut:
             return .launchTimeout
         }
@@ -378,20 +421,53 @@ public enum DaemonManager {
             PerfTimer.log("runDaemonSubcommand(\(subcommand)): launching auto-mobile from PATH")
         }
 
-        // Inherit essential environment variables for device discovery
-        var env = ProcessInfo.processInfo.environment
-        // Ensure PATH includes /usr/bin for xcrun/simctl
-        let currentPath = env["PATH"] ?? ""
-        if !currentPath.contains("/usr/bin") {
-            env["PATH"] = "/usr/bin:/usr/local/bin:\(currentPath)"
-        }
+        let env = daemonLaunchEnvironment(executable: executable)
+        let launcherTimeoutSeconds = daemonLauncherTimeoutSeconds(
+            subcommand: subcommand,
+            readinessTimeoutSeconds: timeoutSeconds
+        )
         return executeDaemonLaunch(
             executable: executable,
             arguments: arguments,
             environment: env,
-            timeoutSeconds: timeoutSeconds,
+            timeoutSeconds: launcherTimeoutSeconds,
             launcher: launcher
         )
+    }
+
+    static func daemonLaunchEnvironment(
+        executable: String,
+        environment: [String: String] = ProcessInfo.processInfo.environment
+    ) -> [String: String] {
+        var environment = environment
+        let existingPaths = (environment["PATH"] ?? "").split(separator: ":").map(String.init)
+        let requiredPaths = [
+            URL(fileURLWithPath: executable).deletingLastPathComponent().path,
+            "/usr/bin",
+            "/usr/local/bin",
+        ]
+        environment["PATH"] = (requiredPaths + existingPaths)
+            .reduce(into: [String]()) { paths, path in
+                if !paths.contains(path) { paths.append(path) }
+            }
+            .joined(separator: ":")
+        return environment
+    }
+
+    static func daemonLauncherTimeoutSeconds(
+        subcommand: String,
+        readinessTimeoutSeconds: TimeInterval,
+        environment: [String: String] = ProcessInfo.processInfo.environment
+    ) -> TimeInterval {
+        guard subcommand == "restart" else { return readinessTimeoutSeconds }
+        let configuredStartupMilliseconds = Int(environment["AUTOMOBILE_DAEMON_STARTUP_TIMEOUT_MS"] ?? "")
+            ?? Int(environment["AUTO_MOBILE_DAEMON_STARTUP_TIMEOUT_MS"] ?? "")
+            ?? 10_000
+        let startupSeconds = configuredStartupMilliseconds > 0
+            ? TimeInterval(configuredStartupMilliseconds) / 1000
+            : 10
+        // DaemonManager.restart allows shutdown (5s), an inter-phase delay (1s), then startup.
+        return max(readinessTimeoutSeconds, 6 + startupSeconds)
     }
 
     static func executeDaemonLaunch(
@@ -509,8 +585,8 @@ public enum DaemonManager {
 
     /// The checkout used for both daemon launch and the matching client handshake. A caller may
     /// supply a root explicitly; otherwise XCTestRunner's own source checkout is used when built.
-    static func resolveDaemonRepoRoot(_ repoRoot: String?) -> String? {
-        repoRoot ?? findRepoRoot(startingAt: #filePath)
+    static func resolveDaemonRepoRoot(_ repoRoot: String?, inferredRepoRoot: String? = nil) -> String? {
+        repoRoot ?? inferredRepoRoot ?? findRepoRoot(startingAt: #filePath)
     }
 
     static func resolveDaemonClientVersion(
@@ -694,11 +770,18 @@ public enum DaemonManager {
         timeoutSeconds: TimeInterval,
         runtime: DaemonRuntime,
         callerAssetVersion: String? = resolveCallerAssetVersionPin(),
-        clientVersion: String? = nil
+        clientVersion: String? = nil,
+        inferredRepoRoot: String? = nil,
+        environment: [String: String] = ProcessInfo.processInfo.environment
     )
         -> DaemonStartupResult
     {
-        let effectiveRepoRoot = resolveDaemonRepoRoot(repoRoot)
+        let effectiveRepoRoot = resolveDaemonRepoRoot(repoRoot, inferredRepoRoot: inferredRepoRoot)
+        let launcherTimeoutSeconds = daemonLauncherTimeoutSeconds(
+            subcommand: "restart",
+            readinessTimeoutSeconds: timeoutSeconds,
+            environment: environment
+        )
         let expectedClientVersion = clientVersion ?? resolveDaemonClientVersion(repoRoot: effectiveRepoRoot)
         PerfTimer.log("ensureDaemonRunning: checking isDaemonRunning")
         if runtime.isDaemonRunning() {
@@ -732,7 +815,7 @@ public enum DaemonManager {
                 if let failure = startupFailure(for: runtime.runDaemonSubcommand(
                     "restart",
                     repoRoot: effectiveRepoRoot,
-                    timeoutSeconds: timeoutSeconds
+                    timeoutSeconds: launcherTimeoutSeconds
                 )) {
                     PerfTimer.log("ensureDaemonRunning: restartDaemon failed - \(failure)")
                     return failure

--- a/ios/XCTestRunner/Sources/XCTestRunner/AutoMobilePlanExecutor.swift
+++ b/ios/XCTestRunner/Sources/XCTestRunner/AutoMobilePlanExecutor.swift
@@ -220,14 +220,20 @@ public protocol AutoMobileMCPClient {
 public final class AutoMobileDaemonClient: AutoMobileMCPClient {
     private let socketPath: String
     private let logger: AutoMobileLogger
+    private let clientVersion: String
     private let queue = DispatchQueue(label: "AutoMobileDaemonClient")
     private var connection: NWConnection?
     private var buffer = Data()
     private var requestId: Int64 = 0
 
-    public init(socketPath: String, logger: AutoMobileLogger = StdoutLogger()) {
+    public init(
+        socketPath: String,
+        logger: AutoMobileLogger = StdoutLogger(),
+        clientVersion: String? = nil
+    ) {
         self.socketPath = socketPath
         self.logger = logger
+        self.clientVersion = clientVersion ?? DaemonManager.resolveDaemonClientVersion()
     }
 
     public func initialize(timeout: TimeInterval) throws {
@@ -327,7 +333,7 @@ public final class AutoMobileDaemonClient: AutoMobileMCPClient {
             "params": params,
             "timeoutMs": Int(timeout * 1000),
             // Declared for the daemon's server-side version handshake gate (#2744).
-            "clientVersion": AutoMobileVersion.current,
+            "clientVersion": clientVersion,
         ]
 
         let data = try JSONSerialization.data(withJSONObject: request, options: [])
@@ -840,7 +846,11 @@ public final class AutoMobilePlanExecutor {
         } else {
             switch configuration.transport {
             case let .daemonUnixSocket(path):
-                self.mcpClient = AutoMobileDaemonClient(socketPath: path, logger: logger)
+                self.mcpClient = AutoMobileDaemonClient(
+                    socketPath: path,
+                    logger: logger,
+                    clientVersion: DaemonManager.resolveDaemonClientVersion(repoRoot: configuration.daemonRepoRoot)
+                )
             case let .streamableHttp(url):
                 do {
                     self.mcpClient = try StreamableHTTPMCPClient(endpoint: url, logger: logger)

--- a/ios/XCTestRunner/Sources/XCTestRunner/AutoMobileTestCase.swift
+++ b/ios/XCTestRunner/Sources/XCTestRunner/AutoMobileTestCase.swift
@@ -345,7 +345,10 @@ open class AutoMobileTestCase: XCTestCase {
             }
             return try StreamableHTTPMCPClient(endpoint: endpointURL)
         }
-        return AutoMobileDaemonClient(socketPath: daemonSocketPath)
+        return AutoMobileDaemonClient(
+            socketPath: daemonSocketPath,
+            clientVersion: DaemonManager.resolveDaemonClientVersion(repoRoot: daemonRepoRoot)
+        )
     }
 
     private func isDaemonSocketTransport() -> Bool {

--- a/ios/XCTestRunner/Sources/XCTestRunner/AutoMobileTestCase.swift
+++ b/ios/XCTestRunner/Sources/XCTestRunner/AutoMobileTestCase.swift
@@ -428,30 +428,9 @@ open class AutoMobileTestCase: XCTestCase {
     }
 
     private func startDaemon() throws {
-        let process = Process()
-        process.executableURL = URL(fileURLWithPath: "/usr/bin/env")
-        process.arguments = ["auto-mobile", "--daemon", "start"]
-
-        let outputPipe = Pipe()
-        let errorPipe = Pipe()
-        process.standardOutput = outputPipe
-        process.standardError = errorPipe
-
-        do {
-            try process.run()
-        } catch {
+        guard DaemonManager.ensureDaemonRunning(repoRoot: daemonRepoRoot) else {
             throw AutoMobileTestCaseError.devicePoolUnavailable(
-                "Failed to start daemon: \(error.localizedDescription)"
-            )
-        }
-
-        process.waitUntilExit()
-        guard process.terminationStatus == 0 else {
-            let errorData = errorPipe.fileHandleForReading.readDataToEndOfFile()
-            let stderr = String(data: errorData, encoding: .utf8) ?? ""
-            let message = stderr.trimmingCharacters(in: .whitespacesAndNewlines)
-            throw AutoMobileTestCaseError.devicePoolUnavailable(
-                "Failed to start daemon: \(message.isEmpty ? "exit code \(process.terminationStatus)" : message)"
+                "Failed to start daemon through the configured AutoMobile launcher."
             )
         }
     }

--- a/ios/XCTestRunner/Sources/XCTestRunnerTests/AutoMobileVersionTests.swift
+++ b/ios/XCTestRunner/Sources/XCTestRunnerTests/AutoMobileVersionTests.swift
@@ -216,8 +216,18 @@ final class AutoMobileVersionTests: XCTestCase {
         XCTAssertTrue(DaemonStartupResult.packageRunnerNotFound.diagnosticMessage.contains("npx"))
         XCTAssertTrue(DaemonStartupResult.launchTimeout.diagnosticMessage.contains("timed out"))
         XCTAssertEqual(
-            DaemonManager.startupFailure(for: .failed(stderr: "npm ERR! 404 package missing")),
+            DaemonManager.startupFailure(for: DaemonManager.classifyDaemonSubcommandOutcome(
+                .failed(stderr: "npm ERR! 404 package missing"),
+                packageRunner: true
+            )),
             .packageLaunchFailed(stderr: "npm ERR! 404 package missing")
+        )
+        XCTAssertEqual(
+            DaemonManager.startupFailure(for: DaemonManager.classifyDaemonSubcommandOutcome(
+                .failed(stderr: "bun failed"),
+                packageRunner: false
+            )),
+            .launchFailed
         )
         XCTAssertTrue(DaemonStartupResult.packageLaunchFailed(
             stderr: "npm ERR! 404 package missing"
@@ -460,6 +470,11 @@ final class AutoMobileVersionTests: XCTestCase {
             readinessTimeoutSeconds: 15,
             environment: ["AUTOMOBILE_DAEMON_STARTUP_TIMEOUT_MS": "30000"]
         ), 36)
+        XCTAssertEqual(DaemonManager.daemonLauncherTimeoutSeconds(
+            subcommand: "start",
+            readinessTimeoutSeconds: 15,
+            environment: ["AUTOMOBILE_DAEMON_STARTUP_TIMEOUT_MS": "30000"]
+        ), 30)
         XCTAssertEqual(DaemonManager.daemonLauncherTimeoutSeconds(
             subcommand: "start",
             readinessTimeoutSeconds: 15,

--- a/ios/XCTestRunner/Sources/XCTestRunnerTests/AutoMobileVersionTests.swift
+++ b/ios/XCTestRunner/Sources/XCTestRunnerTests/AutoMobileVersionTests.swift
@@ -215,6 +215,13 @@ final class AutoMobileVersionTests: XCTestCase {
         XCTAssertTrue(DaemonStartupResult.packageRunnerNotFound.diagnosticMessage.contains("bunx"))
         XCTAssertTrue(DaemonStartupResult.packageRunnerNotFound.diagnosticMessage.contains("npx"))
         XCTAssertTrue(DaemonStartupResult.launchTimeout.diagnosticMessage.contains("timed out"))
+        XCTAssertEqual(
+            DaemonManager.startupFailure(for: .failed(stderr: "npm ERR! 404 package missing")),
+            .packageLaunchFailed(stderr: "npm ERR! 404 package missing")
+        )
+        XCTAssertTrue(DaemonStartupResult.packageLaunchFailed(
+            stderr: "npm ERR! 404 package missing"
+        ).diagnosticMessage.contains("404"))
     }
 
     func testDaemonLaunchPassesTimeoutToInjectedLauncher() {
@@ -406,9 +413,14 @@ final class AutoMobileVersionTests: XCTestCase {
     }
 
     func testEnsureDaemonRunningUsesInferredRootForBuildSkew() throws {
-        let repoRoot = try XCTUnwrap(DaemonManager.resolveDaemonRepoRoot(nil))
-        let entry = try XCTUnwrap(DaemonManager.resolveRepoRootDaemonEntryScript(repoRoot))
-        let currentBuildId = try XCTUnwrap(DaemonManager.computeBuildId(entry))
+        let repoRoot = URL(fileURLWithPath: NSTemporaryDirectory())
+            .appendingPathComponent("automobile-inferred-root-\(UUID().uuidString)")
+        let entry = repoRoot.appendingPathComponent("dist/src/index.js")
+        try FileManager.default.createDirectory(at: entry.deletingLastPathComponent(), withIntermediateDirectories: true)
+        try "// fixture entry".write(to: entry, atomically: true, encoding: .utf8)
+        defer { try? FileManager.default.removeItem(at: repoRoot) }
+
+        let currentBuildId = try XCTUnwrap(DaemonManager.computeBuildId(entry.path))
         let runtime = FakeDaemonRuntime(
             daemonVersion: AutoMobileVersion.current,
             daemonBuildId: "different-checkout",
@@ -420,11 +432,39 @@ final class AutoMobileVersionTests: XCTestCase {
             repoRoot: nil,
             timeoutSeconds: 0,
             runtime: runtime,
-            callerAssetVersion: nil
+            callerAssetVersion: nil,
+            inferredRepoRoot: repoRoot.path
         )
 
         XCTAssertEqual(result, .ready)
-        XCTAssertEqual(runtime.subcommands, [.init(name: "restart", repoRoot: repoRoot)])
+        XCTAssertEqual(runtime.subcommands, [.init(name: "restart", repoRoot: repoRoot.path)])
+    }
+
+    func testDaemonLaunchEnvironmentIncludesSelectedRunnerDirectory() {
+        let environment = DaemonManager.daemonLaunchEnvironment(
+            executable: "/opt/homebrew/bin/npx",
+            environment: ["PATH": "/usr/bin"]
+        )
+
+        XCTAssertEqual(environment["PATH"], "/opt/homebrew/bin:/usr/bin:/usr/local/bin")
+    }
+
+    func testRestartLauncherTimeoutIncludesDaemonLifecycleBudget() {
+        XCTAssertEqual(DaemonManager.daemonLauncherTimeoutSeconds(
+            subcommand: "restart",
+            readinessTimeoutSeconds: 15,
+            environment: [:]
+        ), 16)
+        XCTAssertEqual(DaemonManager.daemonLauncherTimeoutSeconds(
+            subcommand: "restart",
+            readinessTimeoutSeconds: 15,
+            environment: ["AUTOMOBILE_DAEMON_STARTUP_TIMEOUT_MS": "30000"]
+        ), 36)
+        XCTAssertEqual(DaemonManager.daemonLauncherTimeoutSeconds(
+            subcommand: "start",
+            readinessTimeoutSeconds: 15,
+            environment: [:]
+        ), 15)
     }
 
     func testEnsureDaemonRunningAcceptsDaemonMatchingPinnedClientVersion() {

--- a/ios/XCTestRunner/Sources/XCTestRunnerTests/AutoMobileVersionTests.swift
+++ b/ios/XCTestRunner/Sources/XCTestRunnerTests/AutoMobileVersionTests.swift
@@ -200,7 +200,40 @@ final class AutoMobileVersionTests: XCTestCase {
             packageRunner: nil,
             autoMobilePath: "/usr/local/bin/auto-mobile",
             packageVersion: "0.0.40"
-        ), .executableNotFound)
+        ), .packageRunnerNotFound)
+    }
+
+    func testStartupFailureNamesMissingPackageRunnerAndLaunchTimeout() {
+        XCTAssertEqual(
+            DaemonManager.startupFailure(for: .packageRunnerNotFound),
+            .packageRunnerNotFound
+        )
+        XCTAssertEqual(
+            DaemonManager.startupFailure(for: .timedOut),
+            .launchTimeout
+        )
+        XCTAssertTrue(DaemonStartupResult.packageRunnerNotFound.diagnosticMessage.contains("bunx"))
+        XCTAssertTrue(DaemonStartupResult.packageRunnerNotFound.diagnosticMessage.contains("npx"))
+        XCTAssertTrue(DaemonStartupResult.launchTimeout.diagnosticMessage.contains("timed out"))
+    }
+
+    func testDaemonLaunchPassesTimeoutToInjectedLauncher() {
+        let launcher = FakeDaemonSubcommandLauncher(result: .timedOut)
+
+        XCTAssertEqual(DaemonManager.executeDaemonLaunch(
+            executable: "/usr/bin/env",
+            arguments: ["auto-mobile", "--daemon", "start"],
+            environment: ["PATH": "/usr/bin"],
+            timeoutSeconds: 15,
+            launcher: launcher
+        ), .timedOut)
+        XCTAssertEqual(launcher.invocations, [
+            .init(
+                executable: "/usr/bin/env",
+                arguments: ["auto-mobile", "--daemon", "start"],
+                timeoutSeconds: 15
+            ),
+        ])
     }
 
     func testDaemonLaunchPreservesBuiltCheckoutPrecedenceOverPin() {
@@ -225,6 +258,13 @@ final class AutoMobileVersionTests: XCTestCase {
         XCTAssertEqual(DaemonManager.resolveDaemonClientVersion(
             repoRootHasBuiltEntry: true,
             environment: ["AUTOMOBILE_VERSION": "0.0.40"]
+        ), AutoMobileVersion.current)
+    }
+
+    func testResolveDaemonClientVersionKeepsCheckoutIdentityForUnscopedClients() {
+        XCTAssertEqual(DaemonManager.resolveDaemonClientVersion(
+            repoRootHasBuiltEntry: true,
+            environment: ["AUTOMOBILE_DAEMON_PACKAGE_VERSION": "0.0.40"]
         ), AutoMobileVersion.current)
     }
 
@@ -379,6 +419,35 @@ final class AutoMobileVersionTests: XCTestCase {
     }
 }
 
+private final class FakeDaemonSubcommandLauncher: DaemonManager.DaemonSubcommandLauncher {
+    struct Invocation: Equatable {
+        let executable: String
+        let arguments: [String]
+        let timeoutSeconds: TimeInterval
+    }
+
+    private let result: DaemonManager.DaemonSubcommandOutcome
+    private(set) var invocations: [Invocation] = []
+
+    init(result: DaemonManager.DaemonSubcommandOutcome) {
+        self.result = result
+    }
+
+    func launch(
+        executable: String,
+        arguments: [String],
+        environment _: [String: String],
+        timeoutSeconds: TimeInterval
+    ) -> DaemonManager.DaemonSubcommandOutcome {
+        invocations.append(.init(
+            executable: executable,
+            arguments: arguments,
+            timeoutSeconds: timeoutSeconds
+        ))
+        return result
+    }
+}
+
 private final class FakeDaemonRuntime: DaemonRuntime {
     struct Invocation: Equatable {
         let name: String
@@ -425,7 +494,8 @@ private final class FakeDaemonRuntime: DaemonRuntime {
 
     func runDaemonSubcommand(
         _ subcommand: String,
-        repoRoot: String?
+        repoRoot: String?,
+        timeoutSeconds _: TimeInterval
     )
         -> DaemonManager.DaemonSubcommandOutcome
     {

--- a/ios/XCTestRunner/Sources/XCTestRunnerTests/AutoMobileVersionTests.swift
+++ b/ios/XCTestRunner/Sources/XCTestRunnerTests/AutoMobileVersionTests.swift
@@ -285,6 +285,22 @@ final class AutoMobileVersionTests: XCTestCase {
         ), AutoMobileVersion.current)
     }
 
+    func testResolveDaemonClientVersionHonorsConfiguredRepoRoot() throws {
+        let repoRoot = URL(fileURLWithPath: NSTemporaryDirectory())
+            .appendingPathComponent("automobile-configured-root-\(UUID().uuidString)")
+        let entry = repoRoot.appendingPathComponent("dist/src/index.js")
+        try FileManager.default.createDirectory(at: entry.deletingLastPathComponent(), withIntermediateDirectories: true)
+        try "// fixture entry".write(to: entry, atomically: true, encoding: .utf8)
+        defer { try? FileManager.default.removeItem(at: repoRoot) }
+
+        XCTAssertEqual(DaemonManager.resolveDaemonClientVersion(
+            environment: [
+                "AUTOMOBILE_REPO_ROOT": repoRoot.path,
+                "AUTOMOBILE_DAEMON_PACKAGE_VERSION": "0.0.40",
+            ]
+        ), AutoMobileVersion.current)
+    }
+
     func testResolveDaemonRepoRootPrefersTheProvidedCheckout() {
         XCTAssertEqual(
             DaemonManager.resolveDaemonRepoRoot("/repo"),
@@ -464,22 +480,22 @@ final class AutoMobileVersionTests: XCTestCase {
             subcommand: "restart",
             readinessTimeoutSeconds: 15,
             environment: [:]
-        ), 26)
+        ), 36)
         XCTAssertEqual(DaemonManager.daemonLauncherTimeoutSeconds(
             subcommand: "restart",
             readinessTimeoutSeconds: 15,
             environment: ["AUTOMOBILE_DAEMON_STARTUP_TIMEOUT_MS": "30000"]
-        ), 66)
+        ), 96)
         XCTAssertEqual(DaemonManager.daemonLauncherTimeoutSeconds(
             subcommand: "start",
             readinessTimeoutSeconds: 15,
             environment: ["AUTOMOBILE_DAEMON_STARTUP_TIMEOUT_MS": "30000"]
-        ), 60)
+        ), 90)
         XCTAssertEqual(DaemonManager.daemonLauncherTimeoutSeconds(
             subcommand: "start",
             readinessTimeoutSeconds: 15,
             environment: [:]
-        ), 20)
+        ), 30)
     }
 
     func testEnsureDaemonRunningAcceptsDaemonMatchingPinnedClientVersion() {

--- a/ios/XCTestRunner/Sources/XCTestRunnerTests/AutoMobileVersionTests.swift
+++ b/ios/XCTestRunner/Sources/XCTestRunnerTests/AutoMobileVersionTests.swift
@@ -464,22 +464,22 @@ final class AutoMobileVersionTests: XCTestCase {
             subcommand: "restart",
             readinessTimeoutSeconds: 15,
             environment: [:]
-        ), 16)
+        ), 26)
         XCTAssertEqual(DaemonManager.daemonLauncherTimeoutSeconds(
             subcommand: "restart",
             readinessTimeoutSeconds: 15,
             environment: ["AUTOMOBILE_DAEMON_STARTUP_TIMEOUT_MS": "30000"]
-        ), 36)
+        ), 66)
         XCTAssertEqual(DaemonManager.daemonLauncherTimeoutSeconds(
             subcommand: "start",
             readinessTimeoutSeconds: 15,
             environment: ["AUTOMOBILE_DAEMON_STARTUP_TIMEOUT_MS": "30000"]
-        ), 30)
+        ), 60)
         XCTAssertEqual(DaemonManager.daemonLauncherTimeoutSeconds(
             subcommand: "start",
             readinessTimeoutSeconds: 15,
             environment: [:]
-        ), 15)
+        ), 20)
     }
 
     func testEnsureDaemonRunningAcceptsDaemonMatchingPinnedClientVersion() {

--- a/ios/XCTestRunner/Sources/XCTestRunnerTests/AutoMobileVersionTests.swift
+++ b/ios/XCTestRunner/Sources/XCTestRunnerTests/AutoMobileVersionTests.swift
@@ -125,6 +125,109 @@ final class AutoMobileVersionTests: XCTestCase {
         ))
     }
 
+    func testPinnedDaemonPackageCommandUsesBunxAndAutomobileVersion() throws {
+        let command = try XCTUnwrap(DaemonManager.buildPackageDaemonCommand(
+            packageRunner: "/opt/homebrew/bin/bunx",
+            subcommand: "start",
+            packageVersion: "0.0.40"
+        ))
+
+        XCTAssertEqual(command, [
+            "@kaeawc/auto-mobile@0.0.40",
+            "--daemon",
+            "start",
+        ])
+    }
+
+    func testPinnedDaemonPackageCommandUsesNpxNonInteractiveFlag() throws {
+        let command = try XCTUnwrap(DaemonManager.buildPackageDaemonCommand(
+            packageRunner: "/usr/local/bin/npx",
+            subcommand: "restart",
+            packageVersion: "0.0.40"
+        ))
+
+        XCTAssertEqual(command, [
+            "-y",
+            "@kaeawc/auto-mobile@0.0.40",
+            "--daemon",
+            "restart",
+        ])
+    }
+
+    func testResolveDaemonPackageVersionPrefersExplicitPinThenAutomobileVersion() {
+        XCTAssertEqual(DaemonManager.resolveDaemonPackageVersion(environment: [
+            "AUTOMOBILE_DAEMON_PACKAGE_VERSION": " 0.0.41 ",
+            "AUTOMOBILE_VERSION": "0.0.40",
+        ]), "0.0.41")
+        XCTAssertEqual(DaemonManager.resolveDaemonPackageVersion(environment: [
+            "AUTOMOBILE_VERSION": " 0.0.40 ",
+        ]), "0.0.40")
+        XCTAssertNil(DaemonManager.resolveDaemonPackageVersion(environment: [:]))
+    }
+
+    func testPinnedDaemonPackageCommandRejectsFloatingOrUnknownPins() {
+        XCTAssertNil(DaemonManager.buildPackageDaemonCommand(
+            packageRunner: "/opt/homebrew/bin/bunx",
+            subcommand: "start",
+            packageVersion: "latest"
+        ))
+        XCTAssertNil(DaemonManager.buildPackageDaemonCommand(
+            packageRunner: "/opt/homebrew/bin/bunx",
+            subcommand: "start",
+            packageVersion: "unknown"
+        ))
+    }
+
+    func testDaemonLaunchSelectsPinnedPackageInsteadOfPathExecutable() {
+        XCTAssertEqual(DaemonManager.selectDaemonLaunch(
+            subcommand: "start",
+            localEntry: nil,
+            runtime: nil,
+            packageRunner: "/opt/homebrew/bin/bunx",
+            autoMobilePath: "/usr/local/bin/auto-mobile",
+            packageVersion: "0.0.40"
+        ), .process(
+            executable: "/opt/homebrew/bin/bunx",
+            arguments: ["@kaeawc/auto-mobile@0.0.40", "--daemon", "start"]
+        ))
+    }
+
+    func testDaemonLaunchRejectsPinnedStartWithoutPackageRunner() {
+        XCTAssertEqual(DaemonManager.selectDaemonLaunch(
+            subcommand: "start",
+            localEntry: nil,
+            runtime: nil,
+            packageRunner: nil,
+            autoMobilePath: "/usr/local/bin/auto-mobile",
+            packageVersion: "0.0.40"
+        ), .executableNotFound)
+    }
+
+    func testDaemonLaunchPreservesBuiltCheckoutPrecedenceOverPin() {
+        XCTAssertEqual(DaemonManager.selectDaemonLaunch(
+            subcommand: "restart",
+            localEntry: "/repo/dist/src/index.js",
+            runtime: "/opt/homebrew/bin/bun",
+            packageRunner: "/opt/homebrew/bin/bunx",
+            autoMobilePath: "/usr/local/bin/auto-mobile",
+            packageVersion: "0.0.40"
+        ), .process(
+            executable: "/opt/homebrew/bin/bun",
+            arguments: ["/repo/dist/src/index.js", "--daemon", "restart"]
+        ))
+    }
+
+    func testResolveDaemonClientVersionUsesPinWithoutBuiltCheckout() {
+        XCTAssertEqual(DaemonManager.resolveDaemonClientVersion(
+            repoRootHasBuiltEntry: false,
+            environment: ["AUTOMOBILE_VERSION": "0.0.40"]
+        ), "0.0.40")
+        XCTAssertEqual(DaemonManager.resolveDaemonClientVersion(
+            repoRootHasBuiltEntry: true,
+            environment: ["AUTOMOBILE_VERSION": "0.0.40"]
+        ), AutoMobileVersion.current)
+    }
+
     func testResolveRepoRootDaemonEntryScript() throws {
         XCTAssertNil(DaemonManager.resolveRepoRootDaemonEntryScript(nil))
         XCTAssertNil(DaemonManager.resolveRepoRootDaemonEntryScript(""))
@@ -253,6 +356,26 @@ final class AutoMobileVersionTests: XCTestCase {
 
         XCTAssertEqual(result, .ready)
         XCTAssertEqual(runtime.subcommands, [.init(name: "restart", repoRoot: repoRoot.path)])
+    }
+
+    func testEnsureDaemonRunningAcceptsDaemonMatchingPinnedClientVersion() {
+        let runtime = FakeDaemonRuntime(
+            daemonVersion: "0.0.40",
+            daemonBuildId: nil,
+            daemonEntryScript: nil,
+            buildIdAfterRestart: ""
+        )
+
+        let result = DaemonManager.ensureDaemonRunningResult(
+            repoRoot: nil,
+            timeoutSeconds: 0,
+            runtime: runtime,
+            callerAssetVersion: nil,
+            clientVersion: "0.0.40"
+        )
+
+        XCTAssertEqual(result, .ready)
+        XCTAssertTrue(runtime.subcommands.isEmpty)
     }
 }
 

--- a/ios/XCTestRunner/Sources/XCTestRunnerTests/AutoMobileVersionTests.swift
+++ b/ios/XCTestRunner/Sources/XCTestRunnerTests/AutoMobileVersionTests.swift
@@ -268,6 +268,13 @@ final class AutoMobileVersionTests: XCTestCase {
         ), AutoMobileVersion.current)
     }
 
+    func testResolveDaemonRepoRootPrefersTheProvidedCheckout() {
+        XCTAssertEqual(
+            DaemonManager.resolveDaemonRepoRoot("/repo"),
+            "/repo"
+        )
+    }
+
     func testResolveRepoRootDaemonEntryScript() throws {
         XCTAssertNil(DaemonManager.resolveRepoRootDaemonEntryScript(nil))
         XCTAssertNil(DaemonManager.resolveRepoRootDaemonEntryScript(""))

--- a/ios/XCTestRunner/Sources/XCTestRunnerTests/AutoMobileVersionTests.swift
+++ b/ios/XCTestRunner/Sources/XCTestRunnerTests/AutoMobileVersionTests.swift
@@ -405,6 +405,28 @@ final class AutoMobileVersionTests: XCTestCase {
         XCTAssertEqual(runtime.subcommands, [.init(name: "restart", repoRoot: repoRoot.path)])
     }
 
+    func testEnsureDaemonRunningUsesInferredRootForBuildSkew() throws {
+        let repoRoot = try XCTUnwrap(DaemonManager.resolveDaemonRepoRoot(nil))
+        let entry = try XCTUnwrap(DaemonManager.resolveRepoRootDaemonEntryScript(repoRoot))
+        let currentBuildId = try XCTUnwrap(DaemonManager.computeBuildId(entry))
+        let runtime = FakeDaemonRuntime(
+            daemonVersion: AutoMobileVersion.current,
+            daemonBuildId: "different-checkout",
+            daemonEntryScript: "/other-checkout/dist/src/index.js",
+            buildIdAfterRestart: currentBuildId
+        )
+
+        let result = DaemonManager.ensureDaemonRunningResult(
+            repoRoot: nil,
+            timeoutSeconds: 0,
+            runtime: runtime,
+            callerAssetVersion: nil
+        )
+
+        XCTAssertEqual(result, .ready)
+        XCTAssertEqual(runtime.subcommands, [.init(name: "restart", repoRoot: repoRoot)])
+    }
+
     func testEnsureDaemonRunningAcceptsDaemonMatchingPinnedClientVersion() {
         let runtime = FakeDaemonRuntime(
             daemonVersion: "0.0.40",

--- a/ios/XCTestRunner/Sources/XCTestRunnerTests/XCTestRunnerTests.swift
+++ b/ios/XCTestRunner/Sources/XCTestRunnerTests/XCTestRunnerTests.swift
@@ -363,7 +363,15 @@ final class XCTestRunnerTests: XCTestCase {
 
     func testDaemonStartupResultReadyIsTheOnlyReadyCase() {
         XCTAssertTrue(DaemonStartupResult.ready.isReady)
-        for result: DaemonStartupResult in [.executableNotFound, .launchFailed, .readinessTimeout, .versionSkew, .assetVersionSkew] {
+        for result: DaemonStartupResult in [
+            .executableNotFound,
+            .packageRunnerNotFound,
+            .launchFailed,
+            .launchTimeout,
+            .readinessTimeout,
+            .versionSkew,
+            .assetVersionSkew,
+        ] {
             XCTAssertFalse(result.isReady, "\(result) must not report ready")
         }
     }
@@ -377,6 +385,8 @@ final class XCTestRunnerTests: XCTestCase {
         XCTAssertTrue(notFound.contains("bun add -g"))
 
         XCTAssertTrue(DaemonStartupResult.launchFailed.diagnosticMessage.contains("exited non-zero"))
+        XCTAssertTrue(DaemonStartupResult.packageRunnerNotFound.diagnosticMessage.contains("bunx"))
+        XCTAssertTrue(DaemonStartupResult.launchTimeout.diagnosticMessage.contains("timed out"))
         XCTAssertTrue(DaemonStartupResult.readinessTimeout.diagnosticMessage.contains("did not"))
         XCTAssertTrue(DaemonStartupResult.versionSkew.diagnosticMessage.contains("different-version"))
         XCTAssertTrue(DaemonStartupResult.assetVersionSkew.diagnosticMessage.contains("AUTOMOBILE_VERSION"))
@@ -384,7 +394,9 @@ final class XCTestRunnerTests: XCTestCase {
         // Each failure reason is distinct so a CI log names the specific cause.
         let messages = [
             DaemonStartupResult.executableNotFound,
+            DaemonStartupResult.packageRunnerNotFound,
             DaemonStartupResult.launchFailed,
+            DaemonStartupResult.launchTimeout,
             DaemonStartupResult.readinessTimeout,
             DaemonStartupResult.versionSkew,
             DaemonStartupResult.assetVersionSkew,

--- a/ios/XCTestRunner/Sources/XCTestRunnerTests/XCTestRunnerTests.swift
+++ b/ios/XCTestRunner/Sources/XCTestRunnerTests/XCTestRunnerTests.swift
@@ -367,6 +367,7 @@ final class XCTestRunnerTests: XCTestCase {
             .executableNotFound,
             .packageRunnerNotFound,
             .launchFailed,
+            .packageLaunchFailed(stderr: "package unavailable"),
             .launchTimeout,
             .readinessTimeout,
             .versionSkew,
@@ -385,6 +386,9 @@ final class XCTestRunnerTests: XCTestCase {
         XCTAssertTrue(notFound.contains("bun add -g"))
 
         XCTAssertTrue(DaemonStartupResult.launchFailed.diagnosticMessage.contains("exited non-zero"))
+        XCTAssertTrue(DaemonStartupResult.packageLaunchFailed(
+            stderr: "package unavailable"
+        ).diagnosticMessage.contains("package unavailable"))
         XCTAssertTrue(DaemonStartupResult.packageRunnerNotFound.diagnosticMessage.contains("bunx"))
         XCTAssertTrue(DaemonStartupResult.launchTimeout.diagnosticMessage.contains("timed out"))
         XCTAssertTrue(DaemonStartupResult.readinessTimeout.diagnosticMessage.contains("did not"))
@@ -396,6 +400,7 @@ final class XCTestRunnerTests: XCTestCase {
             DaemonStartupResult.executableNotFound,
             DaemonStartupResult.packageRunnerNotFound,
             DaemonStartupResult.launchFailed,
+            DaemonStartupResult.packageLaunchFailed(stderr: "package unavailable"),
             DaemonStartupResult.launchTimeout,
             DaemonStartupResult.readinessTimeout,
             DaemonStartupResult.versionSkew,
@@ -410,7 +415,7 @@ final class XCTestRunnerTests: XCTestCase {
         // A missing CLI and a non-zero launch must map to *distinct* causes, not collapse into one
         // (this is the switch-arm-typo guard the enum-message test can't catch).
         XCTAssertEqual(DaemonManager.startupFailure(for: .executableNotFound), .executableNotFound)
-        XCTAssertEqual(DaemonManager.startupFailure(for: .failed), .launchFailed)
+        XCTAssertEqual(DaemonManager.startupFailure(for: .failed()), .launchFailed)
     }
 
     func testExecutePlanFailureFallsBackToErrorWhenNoFailedStep() throws {


### PR DESCRIPTION
## Summary

- start a pinned XCTestRunner daemon through `bunx` or `npx` when `AUTOMOBILE_VERSION` or `AUTOMOBILE_DAEMON_PACKAGE_VERSION` is set
- use the selected package version for lifecycle reconciliation and Unix-socket daemon handshake requests
- retain built-checkout precedence and unpinned PATH behavior; fail rather than silently bypassing a concrete pin when no package runner is available
- update the hermetic iOS CI guidance

## Root cause

The iOS XCTestRunner only started the ambient `auto-mobile` executable, so an exported version pin did not control a fresh daemon spawn.

Closes #2813

## Validation

- `swift test` in `ios/XCTestRunner` (89 tests, 2 skipped)
- `bun run turbo:validate`
- `bun run typecheck`
- `git diff --check`
