### PR TITLE
fix(ios): omit undefined from codesign warning

### DIFF
--- a/src/utils/IOSCtrlProxyBuilder.ts
+++ b/src/utils/IOSCtrlProxyBuilder.ts
@@ -1243,12 +1243,14 @@ export class IOSCtrlProxyBuilder {
         `${summary} Refusing to launch because ${IOS_HELPER_REQUIRE_CODESIGN_ENV} is set.`
       );
     }
-    logger.warn(
-      `[IOSCtrlProxyBuilder] ${summary} Proceeding anyway — code signing is not OS-enforced on the ` +
+    const message = `[IOSCtrlProxyBuilder] ${summary} Proceeding anyway — code signing is not OS-enforced on the ` +
       `simulator, and the #4759 SHA-256 check already covers integrity. Set ` +
-      `${IOS_HELPER_REQUIRE_CODESIGN_ENV}=1 to refuse launch, and ${IOS_HELPER_TEAM_ID_ENV} to pin a Team ID.`,
-      cause
-    );
+      `${IOS_HELPER_REQUIRE_CODESIGN_ENV}=1 to refuse launch, and ${IOS_HELPER_TEAM_ID_ENV} to pin a Team ID.`;
+    if (cause === undefined) {
+      logger.warn(message);
+      return;
+    }
+    logger.warn(message, cause);
   }
 
   /** Path to the extracted runner `.app` bundle codesign verifies (issue #4760). */

--- a/test/utils/IOSCtrlProxyBuilder.test.ts
+++ b/test/utils/IOSCtrlProxyBuilder.test.ts
@@ -8,6 +8,7 @@ import * as path from "path";
 import os from "os";
 import { DAEMON_LAUNCH_CWD_ENV } from "../../src/utils/workingDirectory";
 import { parsePlist } from "../../src/utils/ios-cmdline-tools/XctestrunPlist";
+import { logger } from "../../src/utils/logger";
 
 describe("IOSCtrlProxyBuilder", function() {
   let originalProjectRoot: string | undefined;
@@ -844,9 +845,16 @@ describe("IOSCtrlProxyBuilder", function() {
       const { builder, verifier } = await buildForCodesign();
       verifier.outcome = { verified: false, notarized: true, teamId: "ABCDE12345", detail: "bad seal" };
 
-      // DEFAULT = warn-and-proceed: no throw.
-      await builder.verifyRunnerBinaryBeforeLaunch("simulator");
-      expect(verifier.verifiedPaths).toHaveLength(1);
+      const warn = spyOn(logger, "warn");
+      try {
+        // DEFAULT = warn-and-proceed: no throw.
+        await builder.verifyRunnerBinaryBeforeLaunch("simulator");
+
+        expect(verifier.verifiedPaths).toHaveLength(1);
+        expect(warn).toHaveBeenCalledWith(expect.stringContaining("Code-signing verification issues"));
+      } finally {
+        warn.mockRestore();
+      }
     });
 
     test("codesign --verify failure refuses launch when require flag is set (#4760)", async function() {


### PR DESCRIPTION
## Summary

Removes the stray literal `undefined` from the iOS CtrlProxy codesign warn-and-proceed diagnostic. The warn path now forwards an error cause only when one exists; genuine causes remain logged unchanged.

## Linked Issue

Closes [#4954](https://github.com/kaeawc/auto-mobile/issues/4954)

## Bug / Regression Context

- **Prior attempts:** The codesign warn-gate was added in [#4938](https://github.com/kaeawc/auto-mobile/pull/4938).
- **Observed symptom:** A simulator runner codesign warning ended with a misleading literal `undefined`.
- **Root cause:** `applyCodesignPolicy` always passed its optional `cause` as a variadic logger argument, including when it was `undefined`.

## Validation

- [x] `bun test test/utils/IOSCtrlProxyBuilder.test.ts` (56 passing)
- [x] `bun run turbo:validate` (12,585 passing; 13 expected skips)
- [x] `bun run typecheck` (no new errors; 196 baseline)
- [x] `git diff --check`
