### PR TITLE
fix(ci): align XCTestRunner derived-data path

### DIFF
--- a/.github/workflows/pull_request.yml
+++ b/.github/workflows/pull_request.yml
@@ -1669,8 +1669,10 @@ jobs:
       AUTOMOBILE_OBSERVE_MCP_TIMEOUT_MS: "150000"
       AUTOMOBILE_DAEMON_STARTUP_TIMEOUT_MS: "60000"
       # This job builds CtrlProxy into /tmp/automobile-ctrl-proxy before daemon
-      # startup. Make that local build authoritative so PR runs do not depend on
+      # startup. Pin both the build script and every restarted daemon to that
+      # path, and make the local build authoritative so PR runs do not depend on
       # a published release IPA existing for package.json's current version.
+      AUTOMOBILE_CTRL_PROXY_IOS_DERIVED_DATA: "/tmp/automobile-ctrl-proxy"
       AUTOMOBILE_SKIP_CTRL_PROXY_DOWNLOAD: "true"
     steps:
       - name: "Git Checkout"

--- a/.github/workflows/pull_request.yml
+++ b/.github/workflows/pull_request.yml
@@ -1761,6 +1761,28 @@ jobs:
           XCTESTRUN=$(find /tmp/automobile-ctrl-proxy/Build/Products -name "*.xctestrun" | head -1)
           echo "xctestrun file: ${XCTESTRUN}"
 
+      # The source build intentionally differs from the published release whose
+      # checksum is compiled into the daemon. Publish this job's exact xctest
+      # executable hash so the pre-launch TOCTOU check remains enabled and every
+      # restarted daemon verifies the artifact it is actually about to execute.
+      - name: "Pin Source-Built CtrlProxy Runner Integrity"
+        shell: bash
+        run: |
+          runner_binary="/tmp/automobile-ctrl-proxy/Build/Products/Debug-iphonesimulator/CtrlProxyUITests-Runner.app/PlugIns/CtrlProxyUITests.xctest/CtrlProxyUITests"
+          if [[ ! -f "${runner_binary}" ]]; then
+            echo "::error::Source-built CtrlProxy xctest executable not found: ${runner_binary}" >&2
+            exit 1
+          fi
+          runner_sha256="$(shasum -a 256 "${runner_binary}" | awk '{print $1}')"
+          if [[ ! "${runner_sha256}" =~ ^[a-f0-9]{64}$ ]]; then
+            echo "::error::Unable to compute a valid CtrlProxy xctest SHA256" >&2
+            exit 1
+          fi
+          {
+            echo "AUTOMOBILE_CTRL_PROXY_IOS_RUNNER_SHA256=${runner_sha256}"
+            echo "AUTOMOBILE_CTRL_PROXY_IOS_RUNNER_SHA256_TARGET=xctest"
+          } >> "${GITHUB_ENV}"
+
       # Re-sync before the test, which needs both the build artifacts and the
       # booted sim's UDID.
       - wait: ctrlproxy-simulator

--- a/src/utils/IOSCtrlProxyBuilder.ts
+++ b/src/utils/IOSCtrlProxyBuilder.ts
@@ -63,6 +63,15 @@ export const IOS_HELPER_REQUIRE_CODESIGN_ENV = "AUTOMOBILE_IOS_HELPER_REQUIRE_CO
  * canonical Team ID (issue #4760).
  */
 export const IOS_HELPER_TEAM_ID_ENV = "AUTOMOBILE_IOS_HELPER_TEAM_ID";
+/**
+ * Expected SHA256 for an explicitly supplied or source-built runner. This keeps
+ * the pre-launch integrity gate active when the local runner intentionally does
+ * not match the published release artifact selected by package.json.
+ */
+export const IOS_CTRL_PROXY_RUNNER_SHA256_ENV = "AUTOMOBILE_CTRL_PROXY_IOS_RUNNER_SHA256";
+/** Executable represented by {@link IOS_CTRL_PROXY_RUNNER_SHA256_ENV}. */
+export const IOS_CTRL_PROXY_RUNNER_SHA256_TARGET_ENV =
+  "AUTOMOBILE_CTRL_PROXY_IOS_RUNNER_SHA256_TARGET";
 
 /**
  * Turn a codesign inspection outcome into a list of human-readable problems,
@@ -837,6 +846,15 @@ export class IOSCtrlProxyBuilder {
     if (override !== null) {
       return override;
     }
+    const environmentOverride = process.env[IOS_CTRL_PROXY_RUNNER_SHA256_ENV]?.trim();
+    if (environmentOverride) {
+      if (!/^[a-f0-9]{64}$/i.test(environmentOverride)) {
+        throw new ActionableError(
+          `${IOS_CTRL_PROXY_RUNNER_SHA256_ENV} must be a 64-character hexadecimal SHA256 checksum`
+        );
+      }
+      return environmentOverride.toLowerCase();
+    }
     return resolveRunnerChecksum();
   }
 
@@ -844,6 +862,15 @@ export class IOSCtrlProxyBuilder {
     const override = IOSCtrlProxyBuilder.expectedRunnerChecksumTargetOverride;
     if (override !== null) {
       return override;
+    }
+    const environmentOverride = process.env[IOS_CTRL_PROXY_RUNNER_SHA256_TARGET_ENV]?.trim();
+    if (environmentOverride === "runner" || environmentOverride === "xctest") {
+      return environmentOverride;
+    }
+    if (environmentOverride) {
+      throw new ActionableError(
+        `${IOS_CTRL_PROXY_RUNNER_SHA256_TARGET_ENV} must be either "runner" or "xctest"`
+      );
     }
     return resolveRunnerChecksumTarget();
   }

--- a/test/scripts/xctestRunnerDerivedDataEnvironment.test.ts
+++ b/test/scripts/xctestRunnerDerivedDataEnvironment.test.ts
@@ -1,5 +1,5 @@
 import { describe, expect, test } from "bun:test";
-import { loadJobs } from "../helpers/workflowSteps";
+import { indexOfNamed, loadJobs, loadJobSteps, stepNamed } from "../helpers/workflowSteps";
 
 const WORKFLOW = ".github/workflows/pull_request.yml";
 const JOB_ID = "ios-xctest-runner-simulator-tests";
@@ -12,5 +12,21 @@ describe("#4966 XCTestRunner source-built CtrlProxy artifacts", () => {
     expect(job).toBeDefined();
     expect(job?.env?.AUTOMOBILE_CTRL_PROXY_IOS_DERIVED_DATA).toBe(SOURCE_BUILT_DERIVED_DATA);
     expect(job?.env?.AUTOMOBILE_SKIP_CTRL_PROXY_DOWNLOAD).toBe("true");
+  });
+
+  test("pins the source-built runner checksum before daemon startup", () => {
+    const steps = loadJobSteps(WORKFLOW, JOB_ID);
+    const pinIntegrity = stepNamed(steps, "Pin Source-Built CtrlProxy Runner Integrity");
+
+    expect(pinIntegrity?.run).toContain("CtrlProxyUITests.xctest/CtrlProxyUITests");
+    expect(pinIntegrity?.run).toContain("shasum -a 256");
+    expect(pinIntegrity?.run).toContain("AUTOMOBILE_CTRL_PROXY_IOS_RUNNER_SHA256");
+    expect(pinIntegrity?.run).toContain("AUTOMOBILE_CTRL_PROXY_IOS_RUNNER_SHA256_TARGET=xctest");
+    expect(indexOfNamed(steps, "Build CtrlProxy iOS for Testing")).toBeLessThan(
+      indexOfNamed(steps, "Pin Source-Built CtrlProxy Runner Integrity")
+    );
+    expect(indexOfNamed(steps, "Pin Source-Built CtrlProxy Runner Integrity")).toBeLessThan(
+      indexOfNamed(steps, "Ensure AutoMobile daemon ready (Xcode 26.5)")
+    );
   });
 });

--- a/test/scripts/xctestRunnerDerivedDataEnvironment.test.ts
+++ b/test/scripts/xctestRunnerDerivedDataEnvironment.test.ts
@@ -1,0 +1,16 @@
+import { describe, expect, test } from "bun:test";
+import { loadJobs } from "../helpers/workflowSteps";
+
+const WORKFLOW = ".github/workflows/pull_request.yml";
+const JOB_ID = "ios-xctest-runner-simulator-tests";
+const SOURCE_BUILT_DERIVED_DATA = "/tmp/automobile-ctrl-proxy";
+
+describe("#4966 XCTestRunner source-built CtrlProxy artifacts", () => {
+  test("pins the build script and restarted daemons to the same derived-data path", () => {
+    const job = loadJobs(WORKFLOW)[JOB_ID];
+
+    expect(job).toBeDefined();
+    expect(job?.env?.AUTOMOBILE_CTRL_PROXY_IOS_DERIVED_DATA).toBe(SOURCE_BUILT_DERIVED_DATA);
+    expect(job?.env?.AUTOMOBILE_SKIP_CTRL_PROXY_DOWNLOAD).toBe("true");
+  });
+});

--- a/test/utils/IOSCtrlProxyBuilder.test.ts
+++ b/test/utils/IOSCtrlProxyBuilder.test.ts
@@ -1,5 +1,9 @@
 import { afterEach, beforeEach, describe, expect, spyOn, test } from "bun:test";
-import { IOSCtrlProxyBuilder } from "../../src/utils/IOSCtrlProxyBuilder";
+import {
+  IOS_CTRL_PROXY_RUNNER_SHA256_ENV,
+  IOS_CTRL_PROXY_RUNNER_SHA256_TARGET_ENV,
+  IOSCtrlProxyBuilder
+} from "../../src/utils/IOSCtrlProxyBuilder";
 import { FakeIOSCtrlProxyBundleDownloader } from "../fakes/FakeIOSCtrlProxyBundleDownloader";
 import { FakeCtrlProxyCodesignVerifier } from "../fakes/FakeCtrlProxyCodesignVerifier";
 import { getTempDir } from "../../src/utils/tempDir";
@@ -18,6 +22,8 @@ describe("IOSCtrlProxyBuilder", function() {
   let originalIpaPath: string | undefined;
   let originalBundlePath: string | undefined;
   let originalLaunchCwd: string | undefined;
+  let originalRunnerSha256: string | undefined;
+  let originalRunnerSha256Target: string | undefined;
   let tempDir: string;
 
   beforeEach(async function() {
@@ -29,6 +35,8 @@ describe("IOSCtrlProxyBuilder", function() {
     originalIpaPath = process.env.AUTOMOBILE_CTRL_PROXY_IOS_IPA_PATH;
     originalBundlePath = process.env.AUTOMOBILE_CTRL_PROXY_IOS_BUNDLE_PATH;
     originalLaunchCwd = process.env[DAEMON_LAUNCH_CWD_ENV];
+    originalRunnerSha256 = process.env[IOS_CTRL_PROXY_RUNNER_SHA256_ENV];
+    originalRunnerSha256Target = process.env[IOS_CTRL_PROXY_RUNNER_SHA256_TARGET_ENV];
 
     // Create temp directory for tests
     tempDir = await fs.mkdtemp(path.join(os.tmpdir(), "ctrl-proxy-ios-builder-test-"));
@@ -85,6 +93,18 @@ describe("IOSCtrlProxyBuilder", function() {
       delete process.env[DAEMON_LAUNCH_CWD_ENV];
     } else {
       process.env[DAEMON_LAUNCH_CWD_ENV] = originalLaunchCwd;
+    }
+
+    if (originalRunnerSha256 === undefined) {
+      delete process.env[IOS_CTRL_PROXY_RUNNER_SHA256_ENV];
+    } else {
+      process.env[IOS_CTRL_PROXY_RUNNER_SHA256_ENV] = originalRunnerSha256;
+    }
+
+    if (originalRunnerSha256Target === undefined) {
+      delete process.env[IOS_CTRL_PROXY_RUNNER_SHA256_TARGET_ENV];
+    } else {
+      process.env[IOS_CTRL_PROXY_RUNNER_SHA256_TARGET_ENV] = originalRunnerSha256Target;
     }
 
     delete process.env.AUTOMOBILE_IOS_HELPER_REQUIRE_CODESIGN;
@@ -738,6 +758,66 @@ describe("IOSCtrlProxyBuilder", function() {
       // Must not throw, and must re-hash the runner binary (a second computeFileSha256).
       await builder.verifyRunnerBinaryBeforeLaunch("simulator");
       expect(downloader.checksummedFilePaths.length).toBeGreaterThan(before);
+    });
+
+    test("source-built runner checksum override remains enforced before launch (#4966)", async function() {
+      const derivedDataPath = path.join(tempDir, "DerivedData");
+      const cacheDir = path.join(tempDir, "cache");
+      const sourceBuiltChecksum = "a".repeat(64);
+      const downloader = new FakeIOSCtrlProxyBundleDownloader();
+      downloader.checksum = "expected-checksum";
+      downloader.runnerChecksum = sourceBuiltChecksum;
+
+      process.env[IOS_CTRL_PROXY_RUNNER_SHA256_ENV] = sourceBuiltChecksum;
+      process.env[IOS_CTRL_PROXY_RUNNER_SHA256_TARGET_ENV] = "xctest";
+      IOSCtrlProxyBuilder.setExpectedChecksumForTesting("expected-checksum");
+      IOSCtrlProxyBuilder.setExpectedRunnerChecksumForTesting(null);
+      const builder = IOSCtrlProxyBuilder.getInstance(
+        { derivedDataPath, bundleCacheDir: cacheDir },
+        { downloader }
+      );
+
+      expect((await builder.build("simulator")).success).toBe(true);
+
+      downloader.runnerChecksum = "b".repeat(64);
+      await expect(builder.verifyRunnerBinaryBeforeLaunch("simulator"))
+        .rejects.toThrow("runner binary SHA256 mismatch (pre-launch)");
+    });
+
+    test("rejects a malformed source-built runner checksum override (#4966)", async function() {
+      const downloader = new FakeIOSCtrlProxyBundleDownloader();
+      downloader.checksum = "expected-checksum";
+
+      process.env[IOS_CTRL_PROXY_RUNNER_SHA256_ENV] = "not-a-sha256";
+      process.env[IOS_CTRL_PROXY_RUNNER_SHA256_TARGET_ENV] = "xctest";
+      IOSCtrlProxyBuilder.setExpectedChecksumForTesting("expected-checksum");
+      IOSCtrlProxyBuilder.setExpectedRunnerChecksumForTesting(null);
+      const builder = IOSCtrlProxyBuilder.getInstance(
+        { derivedDataPath: path.join(tempDir, "DerivedData"), bundleCacheDir: path.join(tempDir, "cache") },
+        { downloader }
+      );
+
+      const result = await builder.build("simulator");
+      expect(result.success).toBe(false);
+      expect(result.error).toContain(`${IOS_CTRL_PROXY_RUNNER_SHA256_ENV} must be a 64-character`);
+    });
+
+    test("rejects an invalid source-built runner checksum target (#4966)", async function() {
+      const downloader = new FakeIOSCtrlProxyBundleDownloader();
+      downloader.checksum = "expected-checksum";
+
+      process.env[IOS_CTRL_PROXY_RUNNER_SHA256_ENV] = "a".repeat(64);
+      process.env[IOS_CTRL_PROXY_RUNNER_SHA256_TARGET_ENV] = "app";
+      IOSCtrlProxyBuilder.setExpectedChecksumForTesting("expected-checksum");
+      IOSCtrlProxyBuilder.setExpectedRunnerChecksumForTesting(null);
+      const builder = IOSCtrlProxyBuilder.getInstance(
+        { derivedDataPath: path.join(tempDir, "DerivedData"), bundleCacheDir: path.join(tempDir, "cache") },
+        { downloader }
+      );
+
+      const result = await builder.build("simulator");
+      expect(result.success).toBe(false);
+      expect(result.error).toContain(`${IOS_CTRL_PROXY_RUNNER_SHA256_TARGET_ENV} must be either`);
     });
 
     test("verifyRunnerBinaryBeforeLaunch refuses launch when the runner binary changed after extraction (#4759)", async function() {


### PR DESCRIPTION
## Summary

- pin the XCTestRunner Simulator Tests job to the derived-data directory populated by its source build
- keep source-built CtrlProxy artifacts authoritative for every daemon restart in the job
- hash the source-built xctest executable and preserve the daemon's pre-launch integrity verification
- add structured workflow and builder regression tests for the path, checksum, target, and TOCTOU contracts

## Root cause

The CtrlProxy build step writes simulator artifacts to `/tmp/automobile-ctrl-proxy`, but daemon startup now defaults to `~/.auto-mobile/derived-data`. Because this job also disables artifact downloads, restarted daemons could find neither the source-built files nor a published fallback. After aligning the paths, the daemon correctly found the source build but rejected it against the checksum compiled for the published release artifact.

## Impact

The build script, CLI processes, and restarted daemons now use the same job-scoped derived-data path and expected checksum. The workflow computes that checksum from the exact xctest executable it built, while the daemon still re-hashes the file immediately before launch and rejects later mutation. Secure production defaults remain unchanged outside explicit overrides such as this CI job.

Closes [#4966](https://github.com/kaeawc/auto-mobile/issues/4966).

## Validation

- `bun test test/scripts/xctestRunnerDerivedDataEnvironment.test.ts`
- `bun test test/utils/IOSCtrlProxyBuilder.test.ts`: 59 passed
- focused workflow tests: 19 passed
- `bun run validate:yaml`
- full BATS suite: 813 passed
- `bun run lint`
- `bun run typecheck`: no new errors; 196 known baseline findings
- `bun run turbo:validate`: 7/7 tasks successful; 12,594 passed, 13 device-dependent skips, 0 failures
- iOS integration workflow change guard with `run-ios`: passed
- AutoMobile code review: no findings

## Required PR verification

- `run-ios` label applied
- `XCTestRunner Simulator Tests` must pass on the current PR head
