### PR TITLE
fix(android): harden eventOnly device timestamp fallback

### DIFF
--- a/src/features/action/InputText.ts
+++ b/src/features/action/InputText.ts
@@ -29,6 +29,8 @@ import { Keyboard } from "./Keyboard";
 
 export type InputTextMode = "a11y" | "eventLast" | "eventAll" | "eventOnly" | "append";
 
+const DEVICE_TIMESTAMP_SECOND_GRANULARITY_MARGIN_MS = 1000;
+
 export type AppendKeyEventValidator = (timeoutMs?: number) => Promise<{ success: boolean; error?: string }>;
 
 interface KeyboardCloser {
@@ -665,10 +667,19 @@ export class InputText extends BaseVisualChange {
     // clock (`this.timer.now()`) lets a device clock running ahead of the host
     // accept an older cached focused hierarchy as fresh, defeating the freshness
     // guarantee (issue #4617). Derive the fallback from the device clock via
-    // `getDeviceTimestampMs`, the same source the rest of the freshness logic uses.
-    const minTimestamp = typeof viewHierarchy.updatedAt === "number"
-      ? viewHierarchy.updatedAt + 1
-      : await this.adb.getDeviceTimestampMs();
+    // `getDeviceTimestampMsWithSource`, and reject degraded host-clock results.
+    let minTimestamp: number;
+    if (typeof viewHierarchy.updatedAt === "number") {
+      minTimestamp = viewHierarchy.updatedAt + 1;
+    } else {
+      const timestampResult = await this.adb.getDeviceTimestampMsWithSource();
+      if (timestampResult.source === "host") {
+        return undefined;
+      }
+      minTimestamp = timestampResult.source === "device-seconds"
+        ? timestampResult.timestampMs + DEVICE_TIMESTAMP_SECOND_GRANULARITY_MARGIN_MS
+        : timestampResult.timestampMs;
+    }
     const refreshedObserveResult = await this.observeScreen.execute({
       skipWaitForFresh: false,
       minTimestamp

--- a/src/utils/android-cmdline-tools/AdbClient.ts
+++ b/src/utils/android-cmdline-tools/AdbClient.ts
@@ -577,8 +577,9 @@ export class AdbClient implements AdbExecutor {
       const trimmed = result.stdout.trim();
       if (/^\d+$/.test(trimmed)) {
         const parsed = Number(trimmed);
-        if (Number.isSafeInteger(parsed) && parsed > 0) {
-          return { timestampMs: parsed * 1000, source: "device-seconds" };
+        const timestampMs = parsed * 1000;
+        if (Number.isSafeInteger(parsed) && parsed > 0 && Number.isSafeInteger(timestampMs)) {
+          return { timestampMs, source: "device-seconds" };
         }
       }
     } catch (error) {

--- a/src/utils/android-cmdline-tools/AdbClient.ts
+++ b/src/utils/android-cmdline-tools/AdbClient.ts
@@ -13,6 +13,7 @@ import {
   type AdbExecuteOptions,
   type AdbProcess,
   type AdbSpawnOptions,
+  type DeviceTimestampResult,
 } from "./interfaces/AdbExecutor";
 import { getAbortSignal } from "../AbortContext";
 import { OPERATION_CANCELLED_MESSAGE } from "../constants";
@@ -549,12 +550,23 @@ export class AdbClient implements AdbExecutor {
    * Falls back to host time if the device timestamp cannot be retrieved.
    */
   async getDeviceTimestampMs(): Promise<number> {
+    const result = await this.getDeviceTimestampMsWithSource();
+    return result.timestampMs;
+  }
+
+  /**
+   * Get device time in milliseconds since epoch and identify its clock source.
+   * Falls back to host time if the device timestamp cannot be retrieved.
+   */
+  async getDeviceTimestampMsWithSource(): Promise<DeviceTimestampResult> {
     try {
       const result = await this.executeCommand("shell date +%s%3N");
       const trimmed = result.stdout.trim();
-      const parsed = parseInt(trimmed, 10);
-      if (!Number.isNaN(parsed) && parsed > 0) {
-        return parsed;
+      if (/^\d+$/.test(trimmed)) {
+        const parsed = Number(trimmed);
+        if (Number.isSafeInteger(parsed) && parsed > 0) {
+          return { timestampMs: parsed, source: "device-ms" };
+        }
       }
     } catch (error) {
       logger.debug(`[ADB] Failed to read device time with ms precision: ${error}`);
@@ -563,16 +575,18 @@ export class AdbClient implements AdbExecutor {
     try {
       const result = await this.executeCommand("shell date +%s");
       const trimmed = result.stdout.trim();
-      const parsed = parseInt(trimmed, 10);
-      if (!Number.isNaN(parsed) && parsed > 0) {
-        return parsed * 1000;
+      if (/^\d+$/.test(trimmed)) {
+        const parsed = Number(trimmed);
+        if (Number.isSafeInteger(parsed) && parsed > 0) {
+          return { timestampMs: parsed * 1000, source: "device-seconds" };
+        }
       }
     } catch (error) {
       logger.debug(`[ADB] Failed to read device time in seconds: ${error}`);
     }
 
     logger.debug("[ADB] Falling back to host time for device timestamp");
-    return this.timer.now();
+    return { timestampMs: this.timer.now(), source: "host" };
   }
 
   /**

--- a/src/utils/android-cmdline-tools/interfaces/AdbExecutor.ts
+++ b/src/utils/android-cmdline-tools/interfaces/AdbExecutor.ts
@@ -39,6 +39,13 @@ export interface AdbSpawnOptions {
   signal?: AbortSignal;
 }
 
+export type DeviceTimestampSource = "device-ms" | "device-seconds" | "host";
+
+export interface DeviceTimestampResult {
+  timestampMs: number;
+  source: DeviceTimestampSource;
+}
+
 /**
  * Interface for executing ADB commands
  * Enables dependency injection and testing with fakes
@@ -70,6 +77,12 @@ export interface AdbExecutor {
    * Falls back to the host time when device time cannot be retrieved.
    */
   getDeviceTimestampMs(): Promise<number>;
+
+  /**
+   * Get the device time with the clock source used to derive it.
+   * Host fallback is retained for callers that accept a best-effort timestamp.
+   */
+  getDeviceTimestampMsWithSource(): Promise<DeviceTimestampResult>;
 
   /**
    * Get the list of booted Android devices

--- a/test/fakes/FakeAdbClient.ts
+++ b/test/fakes/FakeAdbClient.ts
@@ -3,13 +3,15 @@ import type {
   AdbExecutor,
   AdbProcess,
   AdbSpawnOptions,
+  DeviceTimestampSource,
+  DeviceTimestampResult,
 } from "../../src/utils/android-cmdline-tools/interfaces/AdbExecutor";
 import type { ExecResult } from "../../src/models";
 import { FakeAdbProcess } from "./FakeAdbProcess";
 
 type FakeAdbClientContract = Pick<
   AdbExecutor,
-  "execute" | "executeCommand" | "getForegroundApp" | "getDeviceTimestampMs" | "listUsers" | "spawn"
+  "execute" | "executeCommand" | "getForegroundApp" | "getDeviceTimestampMs" | "getDeviceTimestampMsWithSource" | "listUsers" | "spawn"
 >;
 
 /** How a spawned command should terminate, keyed by a substring of its argv. */
@@ -42,6 +44,7 @@ export class FakeAdbClient implements FakeAdbClientContract {
   private hangingCommandPatterns: string[] = [];
   private users: Array<{ userId: number; name: string; flags?: number; running?: boolean }> = [];
   private deviceTimestampMs: number | null = null;
+  private deviceTimestampSource: DeviceTimestampSource = "device-ms";
   private spawnCalls: string[][] = [];
   private spawnBehaviors: SpawnBehavior[] = [];
 
@@ -240,6 +243,10 @@ export class FakeAdbClient implements FakeAdbClientContract {
     this.deviceTimestampMs = timestampMs;
   }
 
+  setDeviceTimestampSource(source: DeviceTimestampSource): void {
+    this.deviceTimestampSource = source;
+  }
+
   /**
    * Return the configured device time (device-authored clock domain), or a
    * deterministic `0` when unset. `0` is the faithful fake equivalent of the
@@ -249,6 +256,13 @@ export class FakeAdbClient implements FakeAdbClientContract {
    */
   async getDeviceTimestampMs(): Promise<number> {
     return this.deviceTimestampMs ?? 0;
+  }
+
+  async getDeviceTimestampMsWithSource(): Promise<DeviceTimestampResult> {
+    return {
+      timestampMs: this.deviceTimestampMs ?? 0,
+      source: this.deviceTimestampSource,
+    };
   }
 
   /**

--- a/test/fakes/FakeAdbExecutor.ts
+++ b/test/fakes/FakeAdbExecutor.ts
@@ -1,4 +1,8 @@
-import { AdbExecutor, type AdbExecuteOptions } from "../../src/utils/android-cmdline-tools/interfaces/AdbExecutor";
+import {
+  AdbExecutor,
+  type AdbExecuteOptions,
+  type DeviceTimestampResult,
+} from "../../src/utils/android-cmdline-tools/interfaces/AdbExecutor";
 import { BootedDevice, ExecResult, AndroidUser, DeviceLockState } from "../../src/models";
 
 /**
@@ -316,6 +320,14 @@ export class FakeAdbExecutor implements AdbExecutor {
 
   async getDeviceTimestampMs(): Promise<number> {
     return this.deviceTimestampMs ?? Date.now();
+  }
+
+  async getDeviceTimestampMsWithSource(): Promise<DeviceTimestampResult> {
+    const timestampMs = await this.getDeviceTimestampMs();
+    return {
+      timestampMs,
+      source: this.deviceTimestampMs === null ? "host" : "device-ms",
+    };
   }
 
   async getAdbPathOnly(): Promise<string> {

--- a/test/features/action/InputText.test.ts
+++ b/test/features/action/InputText.test.ts
@@ -2,6 +2,7 @@ import { afterEach, beforeEach, describe, expect, test } from "bun:test";
 import { InputText } from "../../../src/features/action/InputText";
 import { AndroidCtrlProxyClient } from "../../../src/features/observe/android";
 import { FakeAdbClientFactory } from "../../fakes/FakeAdbClientFactory";
+import { FakeAdbClient } from "../../fakes/FakeAdbClient";
 import { FakeAdbExecutor } from "../../fakes/FakeAdbExecutor";
 import { FakeObserveScreen } from "../../fakes/FakeObserveScreen";
 import { FakeTimer } from "../../fakes/FakeTimer";
@@ -669,6 +670,79 @@ describe("InputText", () => {
     expect(result.success).toBe(false);
     expect(result.error).toBe("eventOnly requires a focused editable field");
     expect(observeExecuteOptions[0]?.minTimestamp).toBe(deviceNowMs);
+    expect(inputCommands(factory)).toEqual([]);
+  });
+
+  test("eventOnly advances a second-granularity lower bound past the current second", async () => {
+    const fakeAdb = new FakeAdbClient();
+    fakeAdb.setDeviceTimestampMs(1_700_000_000_000);
+    fakeAdb.setDeviceTimestampSource("device-seconds");
+    const factory = new FakeAdbClientFactory(fakeAdb);
+    const inputText = new InputText(androidDevice, factory as AdbClientFactory);
+    const observeExecuteOptions: ObserveScreenExecuteOptions[] = [];
+    inputText.observeScreen = {
+      execute: async (options?: ObserveScreenExecuteOptions): Promise<ObserveResult> => {
+        observeExecuteOptions.push({ ...(options ?? {}) });
+        const lowerBound = options?.minTimestamp ?? 0;
+        const actualTimestamp = 1_700_000_000_500;
+        return {
+          viewHierarchy: observeResultWithFocusedText("old").viewHierarchy,
+          freshness: {
+            requestedAfter: lowerBound,
+            actualTimestamp,
+            isFresh: actualTimestamp >= lowerBound,
+            staleDurationMs: Math.max(0, lowerBound - actualTimestamp),
+          },
+        } as ObserveResult;
+      },
+    } as unknown as ObserveScreen;
+
+    const result = await testInputText(inputText).executeAndroidTextInput(
+      "next",
+      undefined,
+      false,
+      "eventOnly",
+      { viewHierarchy: { hierarchy: { node: { class: "android.view.View" } } } } as ObserveResult
+    );
+
+    expect(result.success).toBe(false);
+    expect(result.error).toBe("eventOnly requires a focused editable field");
+    expect(observeExecuteOptions[0]?.minTimestamp).toBe(1_700_000_001_000);
+    expect(inputCommands(factory)).toEqual([]);
+  });
+
+  test("eventOnly fails closed when the device timestamp falls back to the host clock", async () => {
+    const fakeAdb = new FakeAdbClient();
+    fakeAdb.setDeviceTimestampMs(0);
+    fakeAdb.setDeviceTimestampSource("host");
+    const factory = new FakeAdbClientFactory(fakeAdb);
+    const inputText = new InputText(androidDevice, factory as AdbClientFactory);
+    const observeExecuteOptions: ObserveScreenExecuteOptions[] = [];
+    inputText.observeScreen = {
+      execute: async (options?: ObserveScreenExecuteOptions): Promise<ObserveResult> => {
+        observeExecuteOptions.push({ ...(options ?? {}) });
+        return {
+          viewHierarchy: observeResultWithFocusedText("old").viewHierarchy,
+          freshness: {
+            requestedAfter: options?.minTimestamp ?? 0,
+            actualTimestamp: 1,
+            isFresh: true,
+          },
+        } as ObserveResult;
+      },
+    } as unknown as ObserveScreen;
+
+    const result = await testInputText(inputText).executeAndroidTextInput(
+      "next",
+      undefined,
+      false,
+      "eventOnly",
+      { viewHierarchy: { hierarchy: { node: { class: "android.view.View" } } } } as ObserveResult
+    );
+
+    expect(result.success).toBe(false);
+    expect(result.error).toBe("eventOnly requires a focused editable field");
+    expect(observeExecuteOptions).toEqual([]);
     expect(inputCommands(factory)).toEqual([]);
   });
 

--- a/test/utils/AccessibilityDetector.test.ts
+++ b/test/utils/AccessibilityDetector.test.ts
@@ -17,6 +17,10 @@ class FakeAdbExecutor implements AdbExecutor {
     return 0;
   }
 
+  async getDeviceTimestampMsWithSource(): Promise<{ timestampMs: number; source: "device-ms" }> {
+    return { timestampMs: 0, source: "device-ms" };
+  }
+
   setResponse(output: string): void {
     this.responses.set("default", output);
   }
@@ -62,10 +66,6 @@ class FakeAdbExecutor implements AdbExecutor {
 
   async getForegroundApp(): Promise<{ packageName: string; userId: number } | null> {
     return null;
-  }
-
-  async getDeviceTimestampMs(): Promise<number> {
-    return 0;
   }
 
   async getAdbPathOnly(): Promise<string> {

--- a/test/utils/android-cmdline-tools/AdbClient-executionContract.test.ts
+++ b/test/utils/android-cmdline-tools/AdbClient-executionContract.test.ts
@@ -262,6 +262,26 @@ describe("AdbClient.getDeviceTimestampMs three-tier fallback", () => {
     expect(await client.getDeviceTimestampMs()).toBe(1700000000000);
   });
 
+  test("rejects seconds values whose millisecond conversion is not safe", async () => {
+    const timer = new FakeTimer();
+    timer.setCurrentTime(1_650_000_000_000);
+    const exec = (command: string): Promise<ExecResult> => {
+      if (command.includes("+%s%3N")) {
+        return Promise.resolve(ok(""));
+      }
+      if (command.includes("+%s")) {
+        return Promise.resolve(ok("9007199254740991"));
+      }
+      return Promise.resolve(ok(""));
+    };
+    const client = new AdbClient(DEVICE, exec, null, defaultRetryExecutor, timer);
+
+    expect(await client.getDeviceTimestampMsWithSource()).toEqual({
+      timestampMs: 1_650_000_000_000,
+      source: "host",
+    });
+  });
+
   test("falls back to the host clock when both device tiers fail", async () => {
     const timer = new FakeTimer();
     timer.setCurrentTime(1_650_000_000_000);

--- a/test/utils/android-cmdline-tools/AdbClient-executionContract.test.ts
+++ b/test/utils/android-cmdline-tools/AdbClient-executionContract.test.ts
@@ -221,6 +221,29 @@ describe("AdbClient.getDeviceTimestampMs three-tier fallback", () => {
     const client = new AdbClient(DEVICE, exec, null, defaultRetryExecutor, new FakeTimer());
 
     expect(await client.getDeviceTimestampMs()).toBe(1700000000123);
+    expect(await client.getDeviceTimestampMsWithSource()).toEqual({
+      timestampMs: 1700000000123,
+      source: "device-ms",
+    });
+  });
+
+  test("rejects literal %3N suffixes instead of treating seconds as milliseconds", async () => {
+    const exec = (command: string): Promise<ExecResult> => {
+      if (command.includes("+%s%3N")) {
+        return Promise.resolve(ok("1754063999%3N"));
+      }
+      if (command.includes("+%s")) {
+        return Promise.resolve(ok("1700000000"));
+      }
+      return Promise.resolve(ok(""));
+    };
+    const client = new AdbClient(DEVICE, exec, null, defaultRetryExecutor, new FakeTimer());
+
+    expect(await client.getDeviceTimestampMs()).toBe(1700000000000);
+    expect(await client.getDeviceTimestampMsWithSource()).toEqual({
+      timestampMs: 1700000000000,
+      source: "device-seconds",
+    });
   });
 
   test("scales seconds to milliseconds when the millisecond tier yields nothing usable", async () => {
@@ -246,6 +269,10 @@ describe("AdbClient.getDeviceTimestampMs three-tier fallback", () => {
     const client = new AdbClient(DEVICE, exec, null, defaultRetryExecutor, timer);
 
     expect(await client.getDeviceTimestampMs()).toBe(1_650_000_000_000);
+    expect(await client.getDeviceTimestampMsWithSource()).toEqual({
+      timestampMs: 1_650_000_000_000,
+      source: "host",
+    });
   });
 });
 


### PR DESCRIPTION
## Summary

Hardens the Android `inputText` `eventOnly` fresh-focus fallback for degraded device timestamp modes.

Closes [#4720](https://github.com/kaeawc/auto-mobile/issues/4720)

## Root cause

`getDeviceTimestampMs()` accepted partially numeric `%s%3N` output such as `1754063999%3N`, returned second-granularity timestamps without identifying the loss of precision, and finally fell back to the host clock. The eventOnly freshness consumer could therefore accept stale device-authored hierarchies.

## Changes

- Strictly validate both device timestamp probes and report whether the result came from device milliseconds, device seconds, or the host fallback.
- Reject seconds values whose conversion to milliseconds exceeds JavaScript's safe-integer range.
- Preserve `getDeviceTimestampMs()` as a compatibility wrapper for existing consumers.
- Make the eventOnly no-`updatedAt` refresh reject host-clock fallback and advance second-granularity bounds by 1000 ms.
- Extend the existing fakes and add deterministic regression coverage for all three degraded modes.

## Validation

- `bun test test/features/action/InputText.test.ts test/utils/android-cmdline-tools/AdbClient-executionContract.test.ts test/lint/fakeHygiene.test.ts` — 169 pass / 0 fail
- `bun run lint` — passed
- `bun run build` — passed
- `bun run typecheck` — no new errors
- `git diff --check` — passed
- `bun run turbo:validate` was attempted; its repository-wide test phase remained CPU-bound for 10 minutes because of unrelated long-running test processes in other worktrees and was stopped without a result. Focused and static gates are green.
