### PR TITLE
fix(desktop): bind stream clients to an app session

### DIFF
--- a/android/desktop-core/src/main/kotlin/dev/jasonpearson/automobile/desktop/core/AutoMobileContent.kt
+++ b/android/desktop-core/src/main/kotlin/dev/jasonpearson/automobile/desktop/core/AutoMobileContent.kt
@@ -71,6 +71,7 @@ import dev.jasonpearson.automobile.desktop.core.daemon.AppearanceClient
 import dev.jasonpearson.automobile.desktop.core.daemon.AppearanceSocketClient
 import dev.jasonpearson.automobile.desktop.core.daemon.AutoMobileClient
 import dev.jasonpearson.automobile.desktop.core.daemon.DaemonSocketPaths
+import dev.jasonpearson.automobile.desktop.core.daemon.DesktopDaemonSession
 import dev.jasonpearson.automobile.desktop.core.daemon.DeviceSnapshotActions
 import dev.jasonpearson.automobile.desktop.core.daemon.DeviceSnapshotConfigClient
 import dev.jasonpearson.automobile.desktop.core.daemon.DeviceSnapshotSocketClient
@@ -160,9 +161,17 @@ import dev.jasonpearson.automobile.desktop.core.video.toImageBitmap
 import dev.jasonpearson.automobile.desktop.domain.DeviceControlDecision
 import dev.jasonpearson.automobile.desktop.domain.DeviceControlInputs
 import dev.jasonpearson.automobile.desktop.domain.DeviceScreenControlMode
+import java.util.concurrent.atomic.AtomicLong
+import kotlinx.coroutines.CoroutineScope
 import kotlinx.coroutines.Dispatchers
+import kotlinx.coroutines.SupervisorJob
+import kotlinx.coroutines.cancel
+import kotlinx.coroutines.delay
 import kotlinx.coroutines.flow.conflate
+import kotlinx.coroutines.isActive
 import kotlinx.coroutines.launch
+import kotlinx.coroutines.sync.Mutex
+import kotlinx.coroutines.sync.withLock
 import kotlinx.coroutines.withContext
 import kotlinx.serialization.json.buildJsonArray
 import kotlinx.serialization.json.buildJsonObject
@@ -416,7 +425,7 @@ fun AutoMobileContent(
   notificationHandler: NotificationHandler = NoOpNotificationHandler,
   onOpenSource: ((String, Int, String) -> Unit)? = null,
   menuBarActions: MenuBarActions? = null,
-  videoStreamSourceFactory: () -> VideoStreamSource = { VideoStreamClient() },
+  videoStreamSourceFactory: (() -> VideoStreamSource)? = null,
   /**
    * Opt-in device control for the live layout view (issue #3347). When true, a click on the
    * mirrored device screen in live-layout mode is mapped to a device coordinate and forwarded to
@@ -544,20 +553,6 @@ fun AutoMobileContent(
 
   // Data source mode (Fake/Real) - global toggle for all dashboards
   var dataSourceMode by remember { mutableStateOf(DataSourceMode.Real) }
-  val liveVideoSource =
-    remember(activeDeviceId, dataSourceMode, isLiveLayoutMode) {
-      if (dataSourceMode == DataSourceMode.Real && isLiveLayoutMode && activeDeviceId != null) {
-        videoStreamSourceFactory()
-      } else {
-        null
-      }
-    }
-  val liveVideoFrame = rememberLiveVideoFrame(liveVideoSource, activeDeviceId, MONOTONIC_NOW_MS)
-  // Forces the control-availability decision to be re-evaluated on a timer, not only when an
-  // observation source produces an update (issue #3348). A stalled observation stream produces
-  // nothing at all — its staleness is visible only as time passing — so without this a frozen
-  // screenshot would stay clickable until some unrelated recomposition happened to run.
-  val controlFreshnessTick = rememberControlFreshnessTick(enableDeviceControl && isLiveLayoutMode)
 
   // Pending failure ID for deep linking from notifications
   var pendingFailureId by remember { mutableStateOf<String?>(null) }
@@ -638,19 +633,52 @@ fun AutoMobileContent(
     }
   }
 
+  // One stable identity and long-lived client per connected Unix daemon. The stream sockets only
+  // read the daemon session registry; they never create or bind a session themselves.
+  val desktopDaemonSession: DesktopDaemonSession? =
+    remember(connectedMcpProcess, dataSourceMode) {
+      val process = connectedMcpProcess
+      if (
+        dataSourceMode == DataSourceMode.Real &&
+          process?.connectionType == McpConnectionType.UnixSocket
+      ) {
+        DesktopDaemonSession.create(process.socketPath ?: DaemonSocketPaths.socketPath())
+      } else {
+        null
+      }
+    }
+
+  val desktopSessionCleanupScope =
+    remember(desktopDaemonSession) {
+      desktopDaemonSession?.let { CoroutineScope(SupervisorJob() + Dispatchers.IO) }
+    }
+
+  DisposableEffect(desktopDaemonSession, desktopSessionCleanupScope) {
+    onDispose {
+      if (desktopDaemonSession != null && desktopSessionCleanupScope != null) {
+        desktopSessionCleanupScope.launch {
+          runCatching { desktopDaemonSession.release() }
+            .onFailure { error ->
+              LOG.warn("Failed to release desktop daemon session: ${error.message}")
+            }
+          desktopSessionCleanupScope.cancel()
+        }
+      }
+    }
+  }
+
   // Client provider function for dashboards to access MCP data
   val clientProvider: (() -> AutoMobileClient)? =
-    remember(connectedMcpProcess) {
+    remember(connectedMcpProcess, dataSourceMode, desktopDaemonSession) {
       LOG.info(
         "clientProvider being computed, connectedMcpProcess=${connectedMcpProcess?.let { "${it.name} (PID ${it.pid})" } ?: "null"}"
       )
       connectedMcpProcess?.let { process ->
         {
           when (process.connectionType) {
-            McpConnectionType.UnixSocket -> {
-              val socketPath = process.socketPath ?: DaemonSocketPaths.socketPath()
-              McpDaemonClient(socketPath)
-            }
+            McpConnectionType.UnixSocket ->
+              desktopDaemonSession?.client
+                ?: McpDaemonClient(process.socketPath ?: DaemonSocketPaths.socketPath())
             McpConnectionType.StreamableHttp -> {
               val port = process.port ?: 3000
               McpHttpClient("http://localhost:$port/auto-mobile/streamable")
@@ -662,6 +690,72 @@ fun AutoMobileContent(
         }
       }
     }
+
+  var desktopSessionBoundDeviceId by
+    remember(desktopDaemonSession) {
+      mutableStateOf<String?>(null)
+    }
+  val desktopSessionBindingMutex = remember(desktopDaemonSession) { Mutex() }
+  val desktopSessionBindingGeneration = remember(desktopDaemonSession) { AtomicLong(0L) }
+  val desktopSessionReady = desktopSessionBoundDeviceId == activeDeviceId && activeDeviceId != null
+
+  LaunchedEffect(desktopDaemonSession, desktopSessionBoundDeviceId) {
+    if (desktopDaemonSession == null || desktopSessionBoundDeviceId == null) return@LaunchedEffect
+    while (isActive) {
+      delay(2_000)
+      runCatching {
+        withContext(Dispatchers.IO) { desktopDaemonSession.heartbeat() }
+      }
+        .onFailure { error ->
+          LOG.warn("Failed to refresh desktop daemon session: ${error.message}")
+        }
+    }
+  }
+
+  // Register and bind the selected device before creating authenticated stream clients. A
+  // stream-socket getSession lookup is read-only, so the main-socket tool call must happen first.
+  LaunchedEffect(dataSourceMode, activeDeviceId, realDevice, clientProvider, desktopDaemonSession) {
+    val bindingGeneration = desktopSessionBindingGeneration.incrementAndGet()
+    val selectedDeviceId = activeDeviceId
+    desktopSessionBoundDeviceId = null
+    if (
+      dataSourceMode != DataSourceMode.Real || selectedDeviceId == null || clientProvider == null
+    ) {
+      return@LaunchedEffect
+    }
+
+    if (desktopDaemonSession == null) {
+      // Non-Unix transports retain their existing behavior; stream auth is a Unix-daemon concern.
+      desktopSessionBoundDeviceId = selectedDeviceId
+      return@LaunchedEffect
+    }
+
+    val platform =
+      if (
+        realDevice?.type == DeviceType.iOSSimulator || realDevice?.type == DeviceType.iOSPhysical
+      ) {
+        "ios"
+      } else {
+        "android"
+      }
+    try {
+      // Socket calls are synchronous and cannot be interrupted while a daemon is responding.
+      // Serialize them so a cancelled, stale request cannot overwrite a newer device binding.
+      desktopSessionBindingMutex.withLock {
+        kotlinx.coroutines.withContext(Dispatchers.IO) {
+          clientProvider.invoke().setActiveDevice(selectedDeviceId, platform)
+        }
+      }
+      if (desktopSessionBindingGeneration.get() == bindingGeneration) {
+        desktopSessionBoundDeviceId = selectedDeviceId
+      }
+      LOG.info(
+        "Registered desktop daemon session ${desktopDaemonSession.sessionUuid} for device $selectedDeviceId"
+      )
+    } catch (error: Exception) {
+      LOG.warn("Failed to register desktop daemon session for $selectedDeviceId: ${error.message}")
+    }
+  }
 
   // Device snapshots span two transports: the verbs are MCP tool/resource calls, while the
   // retention config is its own Unix socket. Both are null in Fake mode so the dashboard renders
@@ -687,9 +781,41 @@ fun AutoMobileContent(
     remember(clientProvider) { clientProvider?.let { McpVideoRecordingActions(it) } }
   // Screen sharing is daemon-side publishing, so it needs no MCP client -- just the socket.
   val webRtcStreamClient: WebRtcStreamClient? =
-    remember(dataSourceMode) {
-      if (dataSourceMode == DataSourceMode.Real) WebRtcStreamSocketClient() else null
+    remember(dataSourceMode, desktopDaemonSession, desktopSessionReady) {
+      if (
+        dataSourceMode == DataSourceMode.Real &&
+          (desktopDaemonSession == null || desktopSessionReady)
+      ) {
+        WebRtcStreamSocketClient(
+          sessionUuidProvider = desktopDaemonSession?.sessionUuidProvider ?: { null }
+        )
+      } else {
+        null
+      }
     }
+
+  val liveVideoSource =
+    remember(activeDeviceId, dataSourceMode, isLiveLayoutMode, desktopSessionReady) {
+      if (
+        dataSourceMode == DataSourceMode.Real &&
+          isLiveLayoutMode &&
+          activeDeviceId != null &&
+          desktopSessionReady
+      ) {
+        videoStreamSourceFactory?.invoke()
+          ?: VideoStreamClient(
+            sessionUuidProvider = desktopDaemonSession?.sessionUuidProvider ?: { null }
+          )
+      } else {
+        null
+      }
+    }
+  val liveVideoFrame = rememberLiveVideoFrame(liveVideoSource, activeDeviceId, MONOTONIC_NOW_MS)
+  // Forces the control-availability decision to be re-evaluated on a timer, not only when an
+  // observation source produces an update (issue #3348). A stalled observation stream produces
+  // nothing at all — its staleness is visible only as time passing — so without this a frozen
+  // screenshot would stay clickable until some unrelated recomposition happened to run.
+  val controlFreshnessTick = rememberControlFreshnessTick(enableDeviceControl && isLiveLayoutMode)
 
   // Take-screenshot is driven from both the native menu bar and the in-app menu.
   // Run it on a composition-scoped coroutine (not GlobalScope) so the call and its

--- a/android/desktop-core/src/main/kotlin/dev/jasonpearson/automobile/desktop/core/daemon/DesktopDaemonSession.kt
+++ b/android/desktop-core/src/main/kotlin/dev/jasonpearson/automobile/desktop/core/daemon/DesktopDaemonSession.kt
@@ -1,0 +1,46 @@
+package dev.jasonpearson.automobile.desktop.core.daemon
+
+import java.util.UUID
+import java.util.concurrent.atomic.AtomicBoolean
+
+/**
+ * Owns the daemon session used by one desktop app run against one Unix-socket daemon.
+ *
+ * The UUID is deliberately stable for the lifetime of the holder. Main-socket tool calls and the
+ * separate stream sockets therefore authenticate as the same owner. Releasing is idempotent so a
+ * Compose disposal and an explicit process swap cannot double-release the daemon session.
+ */
+class DesktopDaemonSession(val client: McpDaemonClient) : AutoCloseable {
+
+  val sessionUuid: String =
+    requireNotNull(client.sessionUuid) { "DesktopDaemonSession requires a session-bound client" }
+
+  private val released = AtomicBoolean(false)
+
+  /** Provider passed to stream clients; released sessions fail closed by omitting the UUID. */
+  val sessionUuidProvider: () -> String?
+    get() = { sessionUuid.takeUnless { released.get() } }
+
+  fun release() {
+    if (released.compareAndSet(false, true)) {
+      client.releaseSession()
+    }
+  }
+
+  fun heartbeat() {
+    if (!released.get()) {
+      client.heartbeatSession()
+    }
+  }
+
+  override fun close() = release()
+
+  companion object {
+    fun create(socketPath: String = DaemonSocketPaths.socketPath()): DesktopDaemonSession {
+      val sessionUuid = UUID.randomUUID().toString()
+      return DesktopDaemonSession(
+        McpDaemonClient(socketPathValue = socketPath, sessionUuid = sessionUuid)
+      )
+    }
+  }
+}

--- a/android/desktop-core/src/main/kotlin/dev/jasonpearson/automobile/desktop/core/daemon/McpDaemonClient.kt
+++ b/android/desktop-core/src/main/kotlin/dev/jasonpearson/automobile/desktop/core/daemon/McpDaemonClient.kt
@@ -45,6 +45,7 @@ class McpDaemonClient(
   private val socketPathValue: String = DaemonSocketPaths.socketPath(),
   private val json: Json = DaemonJson,
   private val clientVersion: String? = DaemonSocketPaths.resolveClientVersion(),
+  val sessionUuid: String? = null,
 ) : AutoMobileClient {
   private var daemonLifecycle: DaemonLifecycleEnsurer? =
     if (socketPathValue == DaemonSocketPaths.socketPath()) DesktopDaemonLifecycle() else null
@@ -505,12 +506,23 @@ class McpDaemonClient(
   }
 
   override fun callTool(name: String, arguments: JsonObject): JsonElement {
-    val profileUuid = capabilityProfileUuid
-    val routedArguments =
-      if (name == SET_TOOL_CAPABILITY_TOOL_NAME || profileUuid == null) arguments
-      else
+    val sessionArguments =
+      if (
+        sessionUuid != null && name != SET_TOOL_CAPABILITY_TOOL_NAME && "sessionUuid" !in arguments
+      ) {
         buildJsonObject {
           arguments.forEach { (key, value) -> put(key, value) }
+          put("sessionUuid", JsonPrimitive(sessionUuid))
+        }
+      } else {
+        arguments
+      }
+    val profileUuid = capabilityProfileUuid
+    val routedArguments =
+      if (name == SET_TOOL_CAPABILITY_TOOL_NAME || profileUuid == null) sessionArguments
+      else
+        buildJsonObject {
+          sessionArguments.forEach { (key, value) -> put(key, value) }
           put(DAEMON_CAPABILITY_PROFILE_PARAM, JsonPrimitive(profileUuid))
         }
     val response =
@@ -523,6 +535,28 @@ class McpDaemonClient(
       )
     ensureSuccess(response)
     return response.result ?: JsonObject(emptyMap())
+  }
+
+  /** Releases this client's daemon session, if it owns one. */
+  internal fun releaseSession() {
+    val sessionId = sessionUuid ?: return
+    val response =
+      sendRequest(
+        "daemon/releaseSession",
+        buildJsonObject { put("sessionId", JsonPrimitive(sessionId)) },
+      )
+    ensureSuccess(response)
+  }
+
+  /** Refreshes the heartbeat for this client's daemon session, if it owns one. */
+  internal fun heartbeatSession() {
+    val sessionId = sessionUuid ?: return
+    val response =
+      sendRequest(
+        "daemon/heartbeat",
+        buildJsonObject { put("sessionId", JsonPrimitive(sessionId)) },
+      )
+    ensureSuccess(response)
   }
 
   override fun enableToolCapability(capability: String) {

--- a/android/desktop-core/src/main/kotlin/dev/jasonpearson/automobile/desktop/core/daemon/WebRtcStreamSocketClient.kt
+++ b/android/desktop-core/src/main/kotlin/dev/jasonpearson/automobile/desktop/core/daemon/WebRtcStreamSocketClient.kt
@@ -101,8 +101,8 @@ interface WebRtcStreamClient {
  * request so a session established after this client is constructed is still picked up. When it
  * returns null the `sessionUuid` field is omitted from the wire request (`DaemonJson` drops nulls);
  * the daemon then rejects the request unless it was started with `AUTOMOBILE_DAEMON_STREAM_AUTH=0`.
- * The default provider returns null because the desktop does not yet hold a daemon session identity
- * to send -- see [WebRtcStreamSocketRequest.sessionUuid] and issue #4924.
+ * The default provider returns null for callers that do not own a session-bound desktop app run;
+ * the desktop host supplies a provider from `DesktopDaemonSession` for Unix-daemon connections.
  */
 class WebRtcStreamSocketClient(
   private val socketPathValue: String = AutoMobileSocketPaths.socketPath(WEBRTC_STREAM_SOCKET_FILE),

--- a/android/desktop-core/src/main/kotlin/dev/jasonpearson/automobile/desktop/core/video/VideoStreamClient.kt
+++ b/android/desktop-core/src/main/kotlin/dev/jasonpearson/automobile/desktop/core/video/VideoStreamClient.kt
@@ -100,7 +100,8 @@ class VideoStreamClient(
    * stream-socket session guard (issue #4751). Resolved at connect time so a session established
    * after construction is still used. Null (the default) omits the `sessionUuid` field via
    * [explicitNulls] = false, so the daemon rejects the subscribe unless it was started with
-   * `AUTOMOBILE_DAEMON_STREAM_AUTH=0`. The desktop cannot yet populate it -- see issue #4924.
+   * `AUTOMOBILE_DAEMON_STREAM_AUTH=0`. The desktop host supplies a provider from
+   * `DesktopDaemonSession` for Unix-daemon connections.
    */
   private val sessionUuidProvider: () -> String? = { null },
 ) : VideoStreamSource {

--- a/android/desktop-core/src/test/kotlin/dev/jasonpearson/automobile/desktop/core/daemon/McpDaemonClientInputTest.kt
+++ b/android/desktop-core/src/test/kotlin/dev/jasonpearson/automobile/desktop/core/daemon/McpDaemonClientInputTest.kt
@@ -13,6 +13,7 @@ import java.nio.file.Files
 import java.nio.file.Path
 import kotlin.test.Test
 import kotlin.test.assertFailsWith
+import kotlin.test.assertNull
 import kotlinx.serialization.SerializationException
 import kotlinx.serialization.json.Json
 import kotlinx.serialization.json.JsonObject
@@ -70,6 +71,82 @@ class McpDaemonClientInputTest {
         assertEquals(
           "profile-a",
           arguments?.get("__autoMobileCapabilityProfileUuid")?.jsonPrimitive?.content,
+        )
+      }
+  }
+
+  @Test
+  fun `desktop session uuid is injected into tool calls without overriding explicit routing`() {
+    TestDaemonSocket(
+        responses =
+          listOf(
+            SocketResponse(resultJson = "{}"),
+            SocketResponse(resultJson = "{}"),
+            SocketResponse(resultJson = "{}"),
+          )
+      )
+      .use { server ->
+        val client =
+          McpDaemonClient(
+            socketPathValue = server.socketPath.toString(),
+            sessionUuid = "desktop-session",
+          )
+
+        client.callTool("observe", JsonObject(emptyMap()))
+        client.callTool(
+          "observe",
+          JsonObject(mapOf("sessionUuid" to JsonPrimitive("explicit-session"))),
+        )
+        client.callTool("setToolCapability", JsonObject(emptyMap()))
+
+        val requests = server.awaitRequests()
+        assertEquals(
+          "desktop-session",
+          requests[0].params["arguments"]?.jsonObject?.get("sessionUuid")?.jsonPrimitive?.content,
+        )
+        assertEquals(
+          "explicit-session",
+          requests[1].params["arguments"]?.jsonObject?.get("sessionUuid")?.jsonPrimitive?.content,
+        )
+        assertFalse(
+          "sessionUuid" in (requests[2].params["arguments"]?.jsonObject ?: JsonObject(emptyMap()))
+        )
+      }
+  }
+
+  @Test
+  fun `desktop daemon session exposes one identity and releases it only once`() {
+    TestDaemonSocket(
+        responses =
+          listOf(
+            SocketResponse(resultJson = "{\"heartbeat\":true}"),
+            SocketResponse(resultJson = "{\"released\":true}"),
+          )
+      )
+      .use { server ->
+        val session =
+          DesktopDaemonSession(
+            McpDaemonClient(
+              socketPathValue = server.socketPath.toString(),
+              sessionUuid = "desktop-session",
+            )
+          )
+
+        assertEquals("desktop-session", session.sessionUuid)
+        assertEquals("desktop-session", session.sessionUuidProvider())
+        session.heartbeat()
+        session.release()
+        assertNull(session.sessionUuidProvider())
+        session.release()
+
+        val requests = server.awaitRequests()
+        assertEquals(
+          listOf("daemon/heartbeat", "daemon/releaseSession"),
+          requests.map { it.method },
+        )
+        assertEquals(
+          "desktop-session",
+          requests[1].params["sessionId"]?.jsonPrimitive?.content,
         )
       }
   }

--- a/docs/design-docs/plat/android/desktop-app.md
+++ b/docs/design-docs/plat/android/desktop-app.md
@@ -110,6 +110,30 @@ graph LR
     class D ext;
 ```
 
+### Unix-daemon session ownership
+
+When the desktop connects to a Unix-socket daemon, `AutoMobileContent` creates one
+`DesktopDaemonSession` for that app run. It generates a UUID once and keeps one
+long-lived `McpDaemonClient` bound to it. Device-aware main-socket tool calls
+automatically carry that UUID (unless a call explicitly supplies another session),
+and the selected device is bound with `setActiveDevice` before authenticated stream
+clients are exposed.
+
+The WebRTC and H.264 stream clients receive the same UUID through their
+`sessionUuidProvider`. This ordering is required because the stream sockets only
+read the daemon session registry; they do not create sessions. On daemon disconnect,
+transport change, or Compose disposal, the holder sends `daemon/releaseSession` once
+so device ownership is reclaimed. While the selected device is bound, the desktop
+sends `daemon/heartbeat` every two seconds; this keeps the daemon's default heartbeat
+lease alive even when the viewer is idle. A failed release is harmless because the
+daemon's normal session-expiry path remains authoritative.
+
+This deliberately gives the desktop exclusive ownership of its selected device while
+it is connected. A concurrent CLI or agent receives the daemon's existing
+"already assigned" error instead of bypassing ownership. Non-Unix transports retain
+their prior behavior, and operators can still use `AUTOMOBILE_DAEMON_STREAM_AUTH=0`
+while migrating older clients.
+
 ### Transport Implementations
 
 | Client | Transport | Session Management | Retry |

--- a/src/daemon/daemonRequestHandlers.ts
+++ b/src/daemon/daemonRequestHandlers.ts
@@ -11,6 +11,7 @@ export interface DaemonStateAccess {
   isInitialized(): boolean;
   getSessionManager(): {
     getSession(sessionId: string): Session | null;
+    recordHeartbeat?(sessionId: string): void;
     getSessionForDevice?(deviceId: string): string | null;
     getDeviceLabels(sessionId: string): DeviceLabelMap | undefined;
     releaseSession(sessionId: string): Promise<string | null>;
@@ -70,6 +71,24 @@ export async function handleDaemonRequest(
   }
 
   switch (request.method) {
+    case "daemon/heartbeat": {
+      const sessionId = (request.params as { sessionId?: string } | undefined)?.sessionId;
+      if (!sessionId) {
+        return {
+          success: false,
+          error: "sessionId parameter required",
+        };
+      }
+      const manager = state.getSessionManager();
+      if (!manager.getSession(sessionId)) {
+        return {
+          success: false,
+          error: `Session not found: ${sessionId}`,
+        };
+      }
+      manager.recordHeartbeat?.(sessionId);
+      return { success: true, result: { sessionId } };
+    }
     case "daemon/refreshDevices": {
       const pool = state.getDevicePool();
       const addedCount = await pool.refreshDevices();

--- a/test/daemon/daemonRequestHandlers.test.ts
+++ b/test/daemon/daemonRequestHandlers.test.ts
@@ -138,6 +138,31 @@ describe("handleDaemonRequest", () => {
     });
   });
 
+  test("records a heartbeat for an active session", async () => {
+    const devicePool = new FakeDevicePool({
+      total: 1,
+      idle: 0,
+      assigned: 1,
+      error: 0,
+    });
+    const state = new FakeDaemonState(sessionManager, devicePool);
+    const sessionId = "heartbeat-session";
+    const session = await sessionManager.createSession(sessionId, "emulator-5554", "android");
+    const initialHeartbeat = session.lastHeartbeat;
+    fakeTimer.advanceTime(1_000);
+
+    const response = await handleDaemonRequest(
+      buildRequest("daemon/heartbeat", { sessionId }),
+      state
+    );
+
+    expect(response).toEqual({
+      success: true,
+      result: { sessionId },
+    });
+    expect(sessionManager.getSession(sessionId)?.lastHeartbeat).toBeGreaterThan(initialHeartbeat);
+  });
+
   test("returns error when sessionId is missing", async () => {
     const devicePool = new FakeDevicePool({
       total: 0,


### PR DESCRIPTION
Closes [#4924](https://github.com/kaeawc/auto-mobile/issues/4924)

## Summary

- create one stable session identity for each Unix-daemon desktop app run
- inject that identity into main-socket tool calls while preserving explicit session routing and non-Unix behavior
- bind the selected device before exposing WebRTC/video stream clients, keep the lease alive with daemon heartbeats, and release the session when the app run ends
- serialize rapid device switches and move session cleanup off the Compose/UI thread
- cover session injection, release, and lifecycle ownership with focused tests and document the ownership model

This completes the session-identity seam described alongside [#4923](https://github.com/kaeawc/auto-mobile/pull/4923) and [#4926](https://github.com/kaeawc/auto-mobile/pull/4926).

## Validation

- `./gradlew :desktop-core:test`
- `./gradlew :desktop-core:detektMain :desktop-core:detektTest --no-configuration-cache`
- `bun run turbo:validate`
- `bun run typecheck`
- `git diff --check`

Live device/browser end-to-end streaming was not run because the active daemon and device sessions belong to another checkout; the focused stream-client and session-registration tests cover the changed wire contract.
