### PR TITLE
feat(daemon): make managed-device sessions explicit

### DIFF
--- a/docs/design-docs/mcp/daemon/index.md
+++ b/docs/design-docs/mcp/daemon/index.md
@@ -53,6 +53,33 @@ The daemon exposes a full [Unix Socket API](unix-socket-api.md) for IDE plugins 
 - **MCP proxy** — `tools/list`, `tools/call`, `resources/list`, `resources/read`
 - **Daemon management** — device pool queries, session lifecycle
 
+## MCP Device-Session Routing
+
+An MCP connection can be bound to an already-allocated device-pool session at
+startup. Integrations create their proxy with
+`createProxyMcpServer({ proxyConfig: { initialSessionUuid } })` before the
+first `tools/list`. That binding scopes discovery and every device-aware call
+without relying on mutable active-device state, and remains specific to that
+connection across daemon transport recreation.
+
+The device-pool session is separate from the MCP transport session and from a
+tool-capability profile. When the bound device session is released, the
+connection binding is removed; later sessionless calls do not recreate it.
+`setActiveDevice` remains available as a migration compatibility API, but new
+multi-client integrations should use connection-bound device-pool sessions.
+
+If a confirmed device loss cancels an active call, the MCP result is an error
+with `structuredContent` and text JSON of this form:
+
+```json
+{
+  "code": "device_lost",
+  "deviceId": "emulator-5554",
+  "sessionUuid": "device-session-1",
+  "reason": "confirmed-unavailable"
+}
+```
+
 ## Session Heartbeats
 
 The daemon reclaims sessions whose client heartbeat has gone stale. Sessions using the default heartbeat policy that never send their first heartbeat are reclaimed after a short grace period, while custom-heartbeat sessions, including autolock sessions, keep using their configured heartbeat timeout.

--- a/docs/design-docs/mcp/daemon/index.md
+++ b/docs/design-docs/mcp/daemon/index.md
@@ -61,6 +61,8 @@ startup. Integrations create their proxy with
 first `tools/list`. That binding scopes discovery and every device-aware call
 without relying on mutable active-device state, and remains specific to that
 connection across daemon transport recreation.
+The packaged stdio entrypoint accepts the same binding as
+`--initial-session-uuid <uuid>`.
 
 The device-pool session is separate from the MCP transport session and from a
 tool-capability profile. When the bound device session is released, the
@@ -69,7 +71,9 @@ connection binding is removed; later sessionless calls do not recreate it.
 multi-client integrations should use connection-bound device-pool sessions.
 
 If a confirmed device loss cancels an active call, the MCP result is an error
-with `structuredContent` and text JSON of this form:
+whose first text content item is machine-readable JSON of this form. It does
+not include `structuredContent`, because the device-loss envelope is independent
+of the interrupted tool's output schema:
 
 ```json
 {

--- a/docs/design-docs/mcp/daemon/unix-socket-api.md
+++ b/docs/design-docs/mcp/daemon/unix-socket-api.md
@@ -949,7 +949,8 @@ The list is intentionally extensible; clients must ignore capability strings the
 
 ### `daemon/availableDevices`
 
-Returns current device pool statistics.
+Returns current device-pool statistics, its startup-fixed recovery policy, and
+recovery eligibility for each pooled device.
 
 **Params:** none
 
@@ -966,7 +967,13 @@ Returns current device pool statistics.
     "idle": 3,
     "assigned": 1,
     "error": 0
-  }
+  },
+  "recoveryPolicy": { "onLoss": true, "maxAttempts": 2 },
+  "devices": [{
+    "deviceId": "emulator-5554",
+    "platform": "android",
+    "recoveryEligibility": { "eligible": true, "action": "restart" }
+  }]
 }
 ```
 

--- a/docs/design-docs/mcp/tools.md
+++ b/docs/design-docs/mcp/tools.md
@@ -144,7 +144,9 @@ cat "$APP_CONTAINER/Documents/fixtures/hello.txt"
 - 📋 Device inventory and pool status are exposed via the `automobile:devices/booted` resource.
 - 🚀 `startDevice` starts a device with the specified device image.
 - ❌ `killDevice` terminates a running device.
-- 🔧 `setActiveDevice` sets the active device for subsequent operations.
+- 🔧 `setActiveDevice` sets the active device for subsequent operations. It is a
+  compatibility API; new multi-client daemon integrations should bind a
+  device-pool session when the MCP connection starts.
 
 #### Testing & Debugging {#testing-debugging}
 

--- a/docs/install.md
+++ b/docs/install.md
@@ -26,21 +26,22 @@ Verify the install:
 auto-mobile --cli help
 ```
 
-## Android emulator crash recovery
+## Managed-device crash recovery
 
-To let a pool-started Android emulator recover from a mid-session process exit
-or confirmed ADB disconnect, set this environment variable on the process that
-starts the AutoMobile daemon:
+To let AutoMobile recover an owned virtual device after a mid-session process
+exit or confirmed disconnect, set this on the process that starts the daemon:
 
 ``` bash
-AUTOMOBILE_ANDROID_REBOOT_ON_DEATH=1 auto-mobile --daemon restart
+AUTOMOBILE_DEVICE_RECOVERY_ON_LOSS=1 \
+AUTOMOBILE_DEVICE_RECOVERY_MAX_ATTEMPTS=2 \
+auto-mobile --daemon restart
 ```
 
-`AUTO_MOBILE_ANDROID_REBOOT_ON_DEATH=1` is supported as a compatibility alias.
-Only the exact value `1` enables recovery. AutoMobile retries the same AVD at
-most twice per daemon lifetime, with backoff; after that budget is exhausted it
-removes and suppresses the device as it normally would. This does not recover
-externally started emulators or iOS simulators.
+Only exact `1` enables recovery. The attempt budget is a strict integer from
+`1` to `10` and defaults to two. The legacy
+`AUTOMOBILE_ANDROID_REBOOT_ON_DEATH=1` setting remains a compatibility fallback.
+AutoMobile recovers only virtual devices it started itself; physical devices and
+externally managed devices are never restarted.
 
 ## Uninstalling
 

--- a/docs/using/environment-variables.md
+++ b/docs/using/environment-variables.md
@@ -119,14 +119,23 @@ Created devices are named `AutoMobile-<model>-<id>` so they are easy to find and
 clean up (`xcrun simctl delete <udid>` / `avdmanager delete avd -n <name>`), and
 the resolved device type and runtime are logged at creation time.
 
-## Device-pool Android recovery
+## Managed-device recovery
 
 | Variable | Legacy alias | Purpose | Default |
 |----------|--------------|---------|---------|
-| `AUTOMOBILE_ANDROID_REBOOT_ON_DEATH` | `AUTO_MOBILE_ANDROID_REBOOT_ON_DEATH` | When exactly `1`, restarts a pool-owned Android emulator after its process exits or ADB confirms it disappeared. The same AVD receives at most two recovery launches per daemon lifetime; exhaustion falls back to device removal and start suppression. | unset (off) |
+| `AUTOMOBILE_DEVICE_RECOVERY_ON_LOSS` | `AUTO_MOBILE_DEVICE_RECOVERY_ON_LOSS` | Enables managed-device recovery after confirmed loss. Only exact `1` enables it; exact `0` disables it. Invalid values warn and disable recovery. | `0` |
+| `AUTOMOBILE_DEVICE_RECOVERY_MAX_ATTEMPTS` | `AUTO_MOBILE_DEVICE_RECOVERY_MAX_ATTEMPTS` | Canonical positive decimal attempt budget per stable AutoMobile-owned device identity. Values are bounded to `1` through `10`; invalid values warn and use the default. | `2` |
 
-Set this on the process that starts the AutoMobile daemon. It does not apply to
-externally started emulators or iOS simulators.
+These settings are read once when the daemon starts, logged with their effective
+values, and reported by device-pool status. Existing
+`AUTOMOBILE_ANDROID_REBOOT_ON_DEATH` / `AUTO_MOBILE_ANDROID_REBOOT_ON_DEATH`
+remain migration fallbacks for the enablement setting.
+
+Only AutoMobile-owned virtual devices are eligible. Android restarts its owned
+AVD today; externally started emulators, physical devices, and iOS simulators
+are never restarted. A confirmed device loss cancels and releases the active
+session and returns the machine-readable `device_lost` tool outcome rather than
+continuing the in-flight operation.
 
 ## WebRTC screen streaming (`AUTOMOBILE_WEBRTC_*`)
 

--- a/src/cli/parseArgs.ts
+++ b/src/cli/parseArgs.ts
@@ -38,6 +38,7 @@ export function parseArgs(args: string[], log: ParseLogger) {
   const hasFlag = (name: string) => values[name] === true;
   let daemonPort: number | undefined;
   let daemonHost: string | undefined;
+  let initialSessionUuid: string | undefined;
   const cliMode = hasFlag("cli");
   const daemonMode = hasFlag("daemon-mode");
   const noProxy = hasFlag("no-proxy") || hasFlag("direct");
@@ -127,6 +128,14 @@ export function parseArgs(args: string[], log: ParseLogger) {
       const host = args[i + 1];
       if (host && !host.startsWith("--")) {daemonHost = host;} else {log.warn(`Invalid host: ${host}`);}
       i++;
+    } else if (arg === "--initial-session-uuid") {
+      const sessionUuid = args[i + 1];
+      if (sessionUuid && !sessionUuid.startsWith("--")) {
+        initialSessionUuid = sessionUuid;
+      } else {
+        log.warn(`Invalid initial session UUID: ${sessionUuid}`);
+      }
+      i++;
     } else if (arg === "--a11y-level") {
       a11yLevel = args[++i];
     } else if (arg === "--a11y-failure-mode") {
@@ -148,5 +157,5 @@ export function parseArgs(args: string[], log: ParseLogger) {
       const value = parsePositiveNumber(args[++i], "video max archive size", true); if (value !== undefined) {videoRecordingDefaults.maxArchiveSizeMb = value;}
     }
   }
-  return { cliMode, cliArgs, daemonPort, daemonHost, debugPerf, debug, uiPerfMode, memPerfAuditMode, a11yAuditMode, a11yLevel, a11yFailureMode, a11yMinSeverity, a11yUseBaseline, predictiveUi, rawElementSearch, planExecutionLockScope, videoRecordingDefaults, daemonMode, daemonCommand, daemonArgs, skipCtrlProxyDownload, embeddedSdk, networkMockable, dismissKeyboardAfterInput, eventAllMarkers, eventAllMarkersCliOverride, mcpRecording, navigationScreenshots, noWaitForPollingOverhead, noProxy, noDaemon, noA11yIncludeNotImportantViews, noA11yReportViewIds, noA11yRetrieveInteractiveWindows, noOcclusion, safeAreaWarnings, outputReduction, toolOutputsDir };
+  return { cliMode, cliArgs, daemonPort, daemonHost, initialSessionUuid, debugPerf, debug, uiPerfMode, memPerfAuditMode, a11yAuditMode, a11yLevel, a11yFailureMode, a11yMinSeverity, a11yUseBaseline, predictiveUi, rawElementSearch, planExecutionLockScope, videoRecordingDefaults, daemonMode, daemonCommand, daemonArgs, skipCtrlProxyDownload, embeddedSdk, networkMockable, dismissKeyboardAfterInput, eventAllMarkers, eventAllMarkersCliOverride, mcpRecording, navigationScreenshots, noWaitForPollingOverhead, noProxy, noDaemon, noA11yIncludeNotImportantViews, noA11yReportViewIds, noA11yRetrieveInteractiveWindows, noOcclusion, safeAreaWarnings, outputReduction, toolOutputsDir };
 }

--- a/src/daemon/client.ts
+++ b/src/daemon/client.ts
@@ -405,8 +405,8 @@ export class DaemonClient {
   /**
    * Read a resource from the daemon
    */
-  async readResource(uri: string): Promise<any> {
-    return this.sendRequest("resources/read", { uri });
+  async readResource(uri: string, params: Record<string, any> = {}): Promise<any> {
+    return this.sendRequest("resources/read", { uri, ...params });
   }
 
   private async sendRequest(method: string, params: Record<string, any>): Promise<any> {
@@ -539,7 +539,7 @@ export interface DaemonClientLike {
   connect(): Promise<void>;
   close(): Promise<void>;
   callTool(toolName: string, params: Record<string, any>): Promise<any>;
-  readResource(uri: string): Promise<any>;
+  readResource(uri: string, params?: Record<string, any>): Promise<any>;
   callDaemonMethod(method: string, params: Record<string, any>): Promise<any>;
   /**
    * Optional daemon-push capability (issue #3223). Clients that cannot surface

--- a/src/daemon/constants.ts
+++ b/src/daemon/constants.ts
@@ -142,6 +142,12 @@ export const DAEMON_CAPABILITY_PROFILE_HEADER = "x-auto-mobile-capability-profil
 export const DAEMON_CAPABILITY_PROFILE_PARAM = "__autoMobileCapabilityProfileUuid";
 
 /**
+ * Socket RPC field identifying a session UUID injected from a connection-bound
+ * route rather than explicitly selected by the caller.
+ */
+export const DAEMON_BOUND_SESSION_PARAM = "__autoMobileBoundSessionUuid";
+
+/**
  * How long the proxy will keep replaying a remembered session binding on
  * sessionless calls before treating it as retired (issue #4610). It mirrors the
  * daemon's session idle timeout (`SessionManager.SESSION_TIMEOUT_MS`, 30 min):

--- a/src/daemon/daemon.ts
+++ b/src/daemon/daemon.ts
@@ -166,7 +166,8 @@ export class Daemon {
     databaseInitializer: DatabaseInitializer = new DefaultDatabaseInitializer(),
     startupFailureTracker: StartupFailureTracker = new DefaultStartupFailureTracker(),
     databaseHealthProbe: DatabaseHealthProbe = new DefaultDatabaseHealthProbe({ timer }),
-    recoverFromDatabaseHealthFailure?: DatabaseHealthFailureRecovery
+    recoverFromDatabaseHealthFailure?: DatabaseHealthFailureRecovery,
+    recoveryPolicyEnvironment: NodeJS.ProcessEnv = process.env,
   ) {
     this.options = { ...options };
     this.port = options.port || DEFAULT_DAEMON_PORT;
@@ -209,7 +210,7 @@ export class Daemon {
       SessionReleaseBroadcaster.emit(sessionId);
     });
     this.installedAppsRepository = installedAppsRepository ?? new InstalledAppsRepository();
-    const recoveryConfiguration = parseDeviceRecoveryPolicy(process.env);
+    const recoveryConfiguration = parseDeviceRecoveryPolicy(recoveryPolicyEnvironment);
     for (const warning of recoveryConfiguration.warnings) {
       logger.warn(`[Daemon] ${warning}`);
     }

--- a/src/daemon/daemon.ts
+++ b/src/daemon/daemon.ts
@@ -7,6 +7,7 @@ import { UnixSocketServer } from "./socketServer";
 import { SessionManager } from "./sessionManager";
 import { SessionHeartbeatMonitor } from "./SessionHeartbeatMonitor";
 import { DevicePool, type PooledDevice } from "./devicePool";
+import { parseDeviceRecoveryPolicy } from "./poolConfig";
 import { DaemonState } from "./daemonState";
 import {
   DEFAULT_DAEMON_PORT,
@@ -208,6 +209,14 @@ export class Daemon {
       SessionReleaseBroadcaster.emit(sessionId);
     });
     this.installedAppsRepository = installedAppsRepository ?? new InstalledAppsRepository();
+    const recoveryConfiguration = parseDeviceRecoveryPolicy(process.env);
+    for (const warning of recoveryConfiguration.warnings) {
+      logger.warn(`[Daemon] ${warning}`);
+    }
+    logger.info(
+      `[Daemon] Device recovery policy: onLoss=${recoveryConfiguration.policy.onLoss}, ` +
+      `maxAttempts=${recoveryConfiguration.policy.maxAttempts}`
+    );
     this.devicePool = new DevicePool(
       this.sessionManager,
       this.daemonSessionId,
@@ -218,7 +227,9 @@ export class Daemon {
       this.deviceSessionRepository,
       undefined,
       (sessionId, _deviceId, releaseReason) => this.cancelAndReleaseSession(sessionId, releaseReason),
-      deviceId => this.socketServer?.evictDeviceInputCache(deviceId)
+      deviceId => this.socketServer?.evictDeviceInputCache(deviceId),
+      undefined,
+      recoveryConfiguration.policy,
     );
     // Initialize singleton for daemon state access
     DaemonState.getInstance().initialize(this.sessionManager, this.devicePool);

--- a/src/daemon/daemonMcpProxy.ts
+++ b/src/daemon/daemonMcpProxy.ts
@@ -360,6 +360,9 @@ export class DaemonMcpProxy {
   // refreshing it, the remembered UUID is treated as retired so a sessionless
   // call is not rewritten to a released session (issue #4610).
   private boundSessionUuidAt: number | undefined;
+  // Startup bindings remain authoritative until the daemon signals release.
+  // Replay expiration only protects bindings inferred from ordinary calls.
+  private initialSessionBindingConfigured = false;
   // A connection-level capability profile is not a daemon device session. It
   // survives executePlan's device-session release and is forwarded through the
   // socket only when no explicit/remembered routing session is in use.
@@ -411,8 +414,9 @@ export class DaemonMcpProxy {
     ));
     this.timer = config.timer ?? defaultTimer;
     if (typeof config.initialSessionUuid === "string" && config.initialSessionUuid.trim().length > 0) {
-      this.boundSessionUuid = config.initialSessionUuid;
+      this.boundSessionUuid = config.initialSessionUuid.trim();
       this.boundSessionUuidAt = this.timer.now();
+      this.initialSessionBindingConfigured = true;
     }
     this.buildIdentity = config.buildIdentity ?? getCurrentBuildIdentity();
     this.clientVersion = config.clientVersion ?? DAEMON_VERSION;
@@ -1058,7 +1062,11 @@ export class DaemonMcpProxy {
   }
 
   private isBoundSessionReplayExpired(): boolean {
-    if (this.boundSessionUuid === undefined || this.boundSessionUuidAt === undefined) {
+    if (
+      this.initialSessionBindingConfigured ||
+      this.boundSessionUuid === undefined ||
+      this.boundSessionUuidAt === undefined
+    ) {
       return false;
     }
     return this.timer.now() - this.boundSessionUuidAt >= DAEMON_BOUND_SESSION_REPLAY_TTL_MS;
@@ -1067,6 +1075,7 @@ export class DaemonMcpProxy {
   private clearBoundSessionUuid(): void {
     this.boundSessionUuid = undefined;
     this.boundSessionUuidAt = undefined;
+    this.initialSessionBindingConfigured = false;
   }
 
   // Record that the daemon released a specific session UUID, advancing the global
@@ -1235,7 +1244,9 @@ export class DaemonMcpProxy {
    * Read a resource from the daemon
    */
   async readResource(uri: string): Promise<any> {
-    return await this.withRecoverableReconnect(() => this.client!.readResource(uri));
+    return await this.withRecoverableReconnect(() =>
+      this.client!.readResource(uri, this.withBoundSessionUuid({}))
+    );
   }
 
   /**

--- a/src/daemon/daemonMcpProxy.ts
+++ b/src/daemon/daemonMcpProxy.ts
@@ -872,7 +872,19 @@ export class DaemonMcpProxy {
       );
       await this.resetConnection();
       await this.ensureConnected();
-      return await operation();
+      try {
+        return await operation();
+      } catch (retryError) {
+        // A configured binding normally survives beyond the replay TTL, because
+        // only an actual daemon release may retire it. If the release push was
+        // missed, two authoritative "Session not found" responses prove the
+        // configured session is gone, so unblock an explicit replacement.
+        if (this.initialSessionBindingConfigured && this.isDaemonSessionNotFoundError(retryError)) {
+          this.discoveryEpoch += 1;
+          this.clearBoundSessionUuid();
+        }
+        throw retryError;
+      }
     }
   }
 
@@ -881,12 +893,16 @@ export class DaemonMcpProxy {
       return true;
     }
 
-    const message = error instanceof Error ? error.message : String(error);
     // "Unknown tool" means the frontend advertised a tool the daemon rejects —
     // typically a wrong-build daemon serving this frontend. Reconnecting drops the
     // stale tool cache and re-runs the build-identity handshake (which restarts the
     // daemon to the correct build on skew), so retry once before giving up.
-    return message.includes("Session not found") || this.isUnknownToolError(error);
+    return this.isDaemonSessionNotFoundError(error) || this.isUnknownToolError(error);
+  }
+
+  private isDaemonSessionNotFoundError(error: unknown): boolean {
+    const message = error instanceof Error ? error.message : String(error);
+    return message.includes("Session not found");
   }
 
   private isUnknownToolError(error: unknown): boolean {
@@ -1022,11 +1038,14 @@ export class DaemonMcpProxy {
     if (!this.boundSessionUuid || explicitSessionUuid === this.boundSessionUuid) {
       return args;
     }
-    if (explicitSessionUuid) {
+    if (explicitSessionUuid && this.initialSessionBindingConfigured) {
       throw new Error(
         `MCP connection is bound to device session ${this.boundSessionUuid}; ` +
         `cannot route this call to ${explicitSessionUuid} until the binding is released.`
       );
+    }
+    if (explicitSessionUuid) {
+      return args;
     }
     return {
       ...args,

--- a/src/daemon/daemonMcpProxy.ts
+++ b/src/daemon/daemonMcpProxy.ts
@@ -176,6 +176,8 @@ export interface DaemonMcpProxyConfig {
   buildIdentity?: BuildIdentity;
   /** This client's version for the daemon version gate (defaults to DAEMON_VERSION; injectable for testing) */
   clientVersion?: string;
+  /** Existing device-pool session bound before the first discovery request. */
+  initialSessionUuid?: string;
 }
 
 /**
@@ -399,6 +401,10 @@ export class DaemonMcpProxy {
       this.config.connectionTimeoutMs
     ));
     this.timer = config.timer ?? defaultTimer;
+    if (typeof config.initialSessionUuid === "string" && config.initialSessionUuid.trim().length > 0) {
+      this.boundSessionUuid = config.initialSessionUuid;
+      this.boundSessionUuidAt = this.timer.now();
+    }
     this.buildIdentity = config.buildIdentity ?? getCurrentBuildIdentity();
     this.clientVersion = config.clientVersion ?? DAEMON_VERSION;
     this.clientAssetVersion = isExplicitPin()

--- a/src/daemon/daemonMcpProxy.ts
+++ b/src/daemon/daemonMcpProxy.ts
@@ -1,7 +1,16 @@
 import { DaemonClient, DaemonUnavailableError, type DaemonClientLike, type DaemonClientFactory } from "./client";
 import { DaemonManager, type DaemonManagerLike } from "./manager";
 import { logger } from "../utils/logger";
-import { SOCKET_PATH, DAEMON_STARTUP_TIMEOUT_MS, CONNECTION_TIMEOUT_MS, DAEMON_VERSION, DAEMON_VERSION_RESTART_COOLDOWN_MS, DAEMON_BOUND_SESSION_REPLAY_TTL_MS, DAEMON_CAPABILITY_PROFILE_PARAM } from "./constants";
+import {
+  SOCKET_PATH,
+  DAEMON_STARTUP_TIMEOUT_MS,
+  CONNECTION_TIMEOUT_MS,
+  DAEMON_VERSION,
+  DAEMON_VERSION_RESTART_COOLDOWN_MS,
+  DAEMON_BOUND_SESSION_REPLAY_TTL_MS,
+  DAEMON_CAPABILITY_PROFILE_PARAM,
+  DAEMON_BOUND_SESSION_PARAM,
+} from "./constants";
 import type { DaemonNotification, DaemonOptions } from "./types";
 import { listChangedKindForMethod, type ListChangedKind } from "../server/listChangedBroadcast";
 import { SESSION_RELEASED_NOTIFICATION_METHOD } from "../server/sessionReleaseBroadcast";
@@ -1003,16 +1012,23 @@ export class DaemonMcpProxy {
     if (this.isBoundSessionReplayExpired()) {
       this.clearBoundSessionUuid();
     }
-    // Only a caller-provided NON-EMPTY STRING sessionUuid counts as an explicit
-    // session selection that bypasses the retained binding. A blank/null/number/
-    // object sessionUuid is not explicit, so the bound UUID is still injected.
-    if (
-      !this.boundSessionUuid ||
-      (typeof args.sessionUuid === "string" && args.sessionUuid.trim().length > 0)
-    ) {
+    const explicitSessionUuid = typeof args.sessionUuid === "string" && args.sessionUuid.trim().length > 0
+      ? args.sessionUuid
+      : undefined;
+    if (!this.boundSessionUuid || explicitSessionUuid === this.boundSessionUuid) {
       return args;
     }
-    return { ...args, sessionUuid: this.boundSessionUuid };
+    if (explicitSessionUuid) {
+      throw new Error(
+        `MCP connection is bound to device session ${this.boundSessionUuid}; ` +
+        `cannot route this call to ${explicitSessionUuid} until the binding is released.`
+      );
+    }
+    return {
+      ...args,
+      sessionUuid: this.boundSessionUuid,
+      [DAEMON_BOUND_SESSION_PARAM]: this.boundSessionUuid,
+    };
   }
 
   private withCapabilityProfile(args: Record<string, unknown>): Record<string, unknown> {

--- a/src/daemon/daemonRequestHandlers.ts
+++ b/src/daemon/daemonRequestHandlers.ts
@@ -1,5 +1,10 @@
 import { DaemonRequest } from "./types";
 import { DeviceLabelMap, Session } from "./sessionManager";
+import type {
+  DeviceRecoveryEligibility,
+  DeviceRecoveryPolicy,
+  PooledDevice,
+} from "./devicePool";
 
 /** Socket endpoint clients may query before sending optional newer parameters. */
 export const DAEMON_CAPABILITIES_METHOD = "daemon/capabilities";
@@ -20,6 +25,9 @@ export interface DaemonStateAccess {
     refreshDevices(): Promise<number>;
     getStats(): DevicePoolStats;
     releaseDevice(deviceId: string): Promise<void>;
+    getAllDevices?(): PooledDevice[];
+    getRecoveryPolicy?(): DeviceRecoveryPolicy;
+    getRecoveryEligibility?(deviceId: string): DeviceRecoveryEligibility;
     resolveAutolockSessionForMcpSession?(
       mcpSessionId: string | undefined,
       platform?: "android" | "ios"
@@ -106,6 +114,12 @@ export async function handleDaemonRequest(
     case "daemon/availableDevices": {
       const pool = state.getDevicePool();
       const stats = pool.getStats();
+      const recoveryPolicy = pool.getRecoveryPolicy?.();
+      const devices = pool.getAllDevices?.().map(device => ({
+        deviceId: device.id,
+        platform: device.platform,
+        recoveryEligibility: pool.getRecoveryEligibility?.(device.id),
+      }));
       return {
         success: true,
         result: {
@@ -114,6 +128,8 @@ export async function handleDaemonRequest(
           assignedDevices: stats.assigned,
           errorDevices: stats.error,
           stats,
+          ...(recoveryPolicy ? { recoveryPolicy } : {}),
+          ...(devices ? { devices } : {}),
         },
       };
     }

--- a/src/daemon/devicePool.ts
+++ b/src/daemon/devicePool.ts
@@ -135,7 +135,7 @@ export class DevicePool {
   private readonly releaseSessionForDisconnectedDevice: DeviceDisconnectSessionReleaser;
   private readonly onDeviceReady: DeviceReadyListener | undefined;
   private readonly androidDeviceReboot: AndroidDeviceReboot;
-  private readonly recoveryPolicy: DeviceRecoveryPolicy | undefined;
+  private readonly recoveryPolicy: DeviceRecoveryPolicy;
   private readonly recoveringAndroidImages: Map<string, DeviceInfo> = new Map();
   private readonly recoveringAndroidDeviceIds: Set<string> = new Set();
   private readonly startedDeviceProcesses: Map<string, ChildProcess> = new Map();
@@ -172,10 +172,12 @@ export class DevicePool {
     this.deviceSessionRepository = deviceSessionRepository;
     this.criteriaMatcher = criteriaMatcher;
     this.onDeviceReady = onDeviceReady;
-    this.recoveryPolicy = recoveryPolicy;
+    // Resolve recovery policy once so retries and status agree even if the
+    // process environment changes after construction.
+    this.recoveryPolicy = { ...(recoveryPolicy ?? getDeviceRecoveryPolicy()) };
     this.androidDeviceReboot = androidDeviceReboot ?? new BoundedAndroidDeviceReboot(
       timer,
-      recoveryPolicy?.maxAttempts,
+      this.recoveryPolicy.maxAttempts,
     );
     this.releaseSessionForDisconnectedDevice = releaseSessionForDisconnectedDevice ?? (async (
       sessionId,
@@ -2208,7 +2210,7 @@ export class DevicePool {
 
   /** Effective daemon-startup policy, copied so callers cannot mutate pool state. */
   getRecoveryPolicy(): DeviceRecoveryPolicy {
-    return { ...(this.recoveryPolicy ?? getDeviceRecoveryPolicy()) };
+    return { ...this.recoveryPolicy };
   }
 
   getRecoveryEligibility(deviceId: string): DeviceRecoveryEligibility {

--- a/src/daemon/devicePool.ts
+++ b/src/daemon/devicePool.ts
@@ -11,7 +11,8 @@ import { InstalledAppsRepository } from "../db/installedAppsRepository";
 import { RetryExecutor, defaultRetryExecutor } from "../utils/retry/RetryExecutor";
 import { createGlobalPerformanceTracker } from "../utils/PerformanceTracker";
 import {
-  isAndroidRebootOnDeathEnabled,
+  getDeviceRecoveryPolicy,
+  type DeviceRecoveryPolicy,
   isDevicePoolAutolockEnabled,
   getDevicePoolTimeoutMs,
 } from "./poolConfig";
@@ -31,6 +32,7 @@ import { getInstalledAppsCacheWriteCoordinator } from "../db/installedAppsCacheW
 import { getDbWriteBarrier } from "../db/dbWriteBarrier";
 
 export type { DeviceAllocationCriteria, DeviceAllocationRequest } from "./DeviceCriteriaMatcher";
+export type { DeviceRecoveryPolicy } from "./poolConfig";
 
 /**
  * Error class for device pool operations with retryability flag.
@@ -49,6 +51,15 @@ export class DevicePoolError extends Error {
  * Pooled Device Status
  */
 export type DeviceStatus = "idle" | "busy" | "error";
+export type DeviceRecoveryIneligibilityReason =
+  | "disabled"
+  | "not-automobile-owned"
+  | "unsupported-platform"
+  | "not-in-pool";
+
+export type DeviceRecoveryEligibility =
+  | { eligible: true; action: "restart" }
+  | { eligible: false; reason: DeviceRecoveryIneligibilityReason };
 
 /**
  * Pooled Device
@@ -124,6 +135,7 @@ export class DevicePool {
   private readonly releaseSessionForDisconnectedDevice: DeviceDisconnectSessionReleaser;
   private readonly onDeviceReady: DeviceReadyListener | undefined;
   private readonly androidDeviceReboot: AndroidDeviceReboot;
+  private readonly recoveryPolicy: DeviceRecoveryPolicy | undefined;
   private readonly recoveringAndroidImages: Map<string, DeviceInfo> = new Map();
   private readonly recoveringAndroidDeviceIds: Set<string> = new Set();
   private readonly startedDeviceProcesses: Map<string, ChildProcess> = new Map();
@@ -148,7 +160,8 @@ export class DevicePool {
     criteriaMatcher: DeviceCriteriaMatcher = new DeviceCriteriaMatcher(),
     releaseSessionForDisconnectedDevice?: DeviceDisconnectSessionReleaser,
     onDeviceReady?: DeviceReadyListener,
-    androidDeviceReboot?: AndroidDeviceReboot
+    androidDeviceReboot?: AndroidDeviceReboot,
+    recoveryPolicy?: DeviceRecoveryPolicy,
   ) {
     this.sessionManager = sessionManager;
     this.daemonSessionId = daemonSessionId;
@@ -159,7 +172,11 @@ export class DevicePool {
     this.deviceSessionRepository = deviceSessionRepository;
     this.criteriaMatcher = criteriaMatcher;
     this.onDeviceReady = onDeviceReady;
-    this.androidDeviceReboot = androidDeviceReboot ?? new BoundedAndroidDeviceReboot(timer);
+    this.recoveryPolicy = recoveryPolicy;
+    this.androidDeviceReboot = androidDeviceReboot ?? new BoundedAndroidDeviceReboot(
+      timer,
+      recoveryPolicy?.maxAttempts,
+    );
     this.releaseSessionForDisconnectedDevice = releaseSessionForDisconnectedDevice ?? (async (
       sessionId,
       _deviceId,
@@ -418,7 +435,7 @@ export class DevicePool {
   }
 
   private async wasRebootedAndroidDeviceRediscovered(device: PooledDevice): Promise<boolean> {
-    if (!isAndroidRebootOnDeathEnabled() || device.platform !== "android" || !device.avdName) {
+    if (!this.getRecoveryPolicy().onLoss || !this.isAutoMobileOwnedAndroidVirtualDevice(device)) {
       return false;
     }
     const avdName = device.avdName;
@@ -1102,9 +1119,8 @@ export class DevicePool {
     device: PooledDevice
   ): device is PooledDevice & { avdName: string } {
     return (
-      isAndroidRebootOnDeathEnabled() &&
-      device.platform === "android" &&
-      typeof device.avdName === "string" &&
+      this.getRecoveryPolicy().onLoss &&
+      this.isAutoMobileOwnedAndroidVirtualDevice(device) &&
       !this.recoveringAndroidImages.has(device.avdName)
     );
   }
@@ -2188,6 +2204,39 @@ export class DevicePool {
    */
   getAllDevices(): PooledDevice[] {
     return Array.from(this.devices.values());
+  }
+
+  /** Effective daemon-startup policy, copied so callers cannot mutate pool state. */
+  getRecoveryPolicy(): DeviceRecoveryPolicy {
+    return { ...(this.recoveryPolicy ?? getDeviceRecoveryPolicy()) };
+  }
+
+  getRecoveryEligibility(deviceId: string): DeviceRecoveryEligibility {
+    const device = this.devices.get(deviceId);
+    if (!device) {
+      return { eligible: false, reason: "not-in-pool" };
+    }
+    if (!this.getRecoveryPolicy().onLoss) {
+      return { eligible: false, reason: "disabled" };
+    }
+    if (device.platform !== "android") {
+      return { eligible: false, reason: "unsupported-platform" };
+    }
+    if (!this.isAutoMobileOwnedAndroidVirtualDevice(device)) {
+      return { eligible: false, reason: "not-automobile-owned" };
+    }
+    return { eligible: true, action: "restart" };
+  }
+
+  private isAutoMobileOwnedAndroidVirtualDevice(
+    device: PooledDevice
+  ): device is PooledDevice & { avdName: string; androidImage: DeviceInfo } {
+    return (
+      device.platform === "android" &&
+      consolePortFromSerial(device.id) !== null &&
+      typeof device.avdName === "string" &&
+      device.androidImage !== undefined
+    );
   }
 
   private getDevicesMatchingCriteria(criteria?: DeviceAllocationCriteria): PooledDevice[] {

--- a/src/daemon/manager.ts
+++ b/src/daemon/manager.ts
@@ -1378,21 +1378,33 @@ export async function runDaemonCommand(
       }
 
       case "available-devices": {
-        const formatPoolStats = (stats?: { idle: number; assigned: number; error: number; total: number }) => (
-          JSON.stringify({
-            availableDevices: stats?.idle ?? 0,
-            totalDevices: stats?.total ?? 0,
-            assignedDevices: stats?.assigned ?? 0,
-            errorDevices: stats?.error ?? 0,
-          })
-        );
+        const formatPoolStats = (
+          stats?: { idle: number; assigned: number; error: number; total: number },
+          recoveryPolicy?: { onLoss: boolean; maxAttempts: number },
+          devices?: Array<{ deviceId: string; platform: string; recoveryEligibility?: unknown }>,
+        ) => JSON.stringify({
+          availableDevices: stats?.idle ?? 0,
+          totalDevices: stats?.total ?? 0,
+          assignedDevices: stats?.assigned ?? 0,
+          errorDevices: stats?.error ?? 0,
+          ...(recoveryPolicy ? { recoveryPolicy } : {}),
+          ...(devices ? { devices } : {}),
+        });
 
         // Check if running in daemon process
         const daemonState = manager.getDaemonState();
         if (daemonState.isInitialized()) {
           // Running inside daemon process
           const pool = daemonState.getDevicePool();
-          console.log(formatPoolStats(pool.getStats()));
+          console.log(formatPoolStats(
+            pool.getStats(),
+            pool.getRecoveryPolicy(),
+            pool.getAllDevices().map(device => ({
+              deviceId: device.id,
+              platform: device.platform,
+              recoveryEligibility: pool.getRecoveryEligibility(device.id),
+            })),
+          ));
         } else {
           // Running from CLI - query daemon via socket
           const client = manager.createClient();
@@ -1404,7 +1416,19 @@ export async function runDaemonCommand(
               console.log(formatPoolStats());
             } else {
               const data = JSON.parse(content);
-              console.log(formatPoolStats(data?.poolStatus));
+              console.log(formatPoolStats(
+                data?.poolStatus,
+                data?.poolStatus?.recoveryPolicy,
+                data?.devices?.map((device: {
+                  deviceId: string;
+                  platform: string;
+                  recoveryEligibility?: unknown;
+                }) => ({
+                  deviceId: device.deviceId,
+                  platform: device.platform,
+                  recoveryEligibility: device.recoveryEligibility,
+                })),
+              ));
             }
             await client.close();
           } catch (error) {

--- a/src/daemon/poolConfig.ts
+++ b/src/daemon/poolConfig.ts
@@ -1,5 +1,87 @@
 import type { MatchingStrategy } from "../models/DeviceMatchCriteria";
 
+export const DEFAULT_DEVICE_RECOVERY_MAX_ATTEMPTS = 2;
+export const MAX_DEVICE_RECOVERY_ATTEMPTS = 10;
+
+export interface DeviceRecoveryPolicy {
+  onLoss: boolean;
+  maxAttempts: number;
+}
+
+export interface DeviceRecoveryPolicyParseResult {
+  policy: DeviceRecoveryPolicy;
+  warnings: string[];
+}
+
+type Environment = Record<string, string | undefined>;
+
+function firstDefined(env: Environment, keys: readonly string[]): string | undefined {
+  for (const key of keys) {
+    if (env[key] !== undefined) {
+      return env[key];
+    }
+  }
+  return undefined;
+}
+
+/**
+ * Resolves recovery once when the daemon starts. The legacy Android setting is
+ * retained as a migration fallback, but new clients must use the platform-neutral
+ * recovery variables.
+ */
+export function parseDeviceRecoveryPolicy(env: Environment): DeviceRecoveryPolicyParseResult {
+  const warnings: string[] = [];
+  const onLossValue = firstDefined(env, [
+    "AUTOMOBILE_DEVICE_RECOVERY_ON_LOSS",
+    "AUTO_MOBILE_DEVICE_RECOVERY_ON_LOSS",
+    "AUTOMOBILE_ANDROID_REBOOT_ON_DEATH",
+    "AUTO_MOBILE_ANDROID_REBOOT_ON_DEATH",
+  ]);
+  let onLoss = false;
+  if (onLossValue !== undefined) {
+    if (onLossValue === "1") {
+      onLoss = true;
+    } else if (onLossValue !== "0") {
+      warnings.push(
+        `Invalid AUTOMOBILE_DEVICE_RECOVERY_ON_LOSS value ${JSON.stringify(onLossValue)}; using 0.`
+      );
+    }
+  }
+
+  const maxAttemptsValue = firstDefined(env, [
+    "AUTOMOBILE_DEVICE_RECOVERY_MAX_ATTEMPTS",
+    "AUTO_MOBILE_DEVICE_RECOVERY_MAX_ATTEMPTS",
+  ]);
+  let maxAttempts = DEFAULT_DEVICE_RECOVERY_MAX_ATTEMPTS;
+  if (maxAttemptsValue !== undefined) {
+    if (/^[1-9]\d*$/.test(maxAttemptsValue)) {
+      const parsed = Number(maxAttemptsValue);
+      if (parsed <= MAX_DEVICE_RECOVERY_ATTEMPTS) {
+        maxAttempts = parsed;
+      } else {
+        warnings.push(
+          `Invalid AUTOMOBILE_DEVICE_RECOVERY_MAX_ATTEMPTS value ${JSON.stringify(maxAttemptsValue)}; ` +
+          `using ${DEFAULT_DEVICE_RECOVERY_MAX_ATTEMPTS}.`
+        );
+      }
+    } else {
+      warnings.push(
+        `Invalid AUTOMOBILE_DEVICE_RECOVERY_MAX_ATTEMPTS value ${JSON.stringify(maxAttemptsValue)}; ` +
+        `using ${DEFAULT_DEVICE_RECOVERY_MAX_ATTEMPTS}.`
+      );
+    }
+  }
+
+  return {
+    policy: { onLoss, maxAttempts },
+    warnings,
+  };
+}
+
+export function getDeviceRecoveryPolicy(): DeviceRecoveryPolicy {
+  return parseDeviceRecoveryPolicy(process.env).policy;
+}
+
 /**
  * Device pool matching strategy.
  * Controls how a device is selected when multiple candidates match.

--- a/src/daemon/socketServer.ts
+++ b/src/daemon/socketServer.ts
@@ -792,8 +792,7 @@ export class UnixSocketServer {
     }
 
     if (request.method === "resources/read") {
-      const uri = request.params?.uri;
-      return this.sharedMcpForwardRoute(typeof uri === "string" ? `resource:${uri}` : "resource:unknown");
+      return this.getResourceReadForwardRoute(request, socketSessionId);
     }
 
     return this.sharedMcpForwardRoute(`method:${request.method}`);
@@ -819,6 +818,18 @@ export class UnixSocketServer {
       return boundRoute ? { ...boundRoute, executionKey } : this.sharedMcpForwardRoute(executionKey);
     }
     return boundRoute ?? this.sharedMcpForwardRoute(`method:${request.method}`);
+  }
+
+  private getResourceReadForwardRoute(
+    request: DaemonRequest,
+    socketSessionId: string,
+  ): McpForwardRoute {
+    const sessionUuid = this.getSessionUuid(request.params);
+    if (sessionUuid && !this.isReleasedBoundSession(request.params)) {
+      return this.sessionScopedForwardRoute(socketSessionId, sessionUuid, undefined);
+    }
+    const uri = request.params?.uri;
+    return this.sharedMcpForwardRoute(typeof uri === "string" ? `resource:${uri}` : "resource:unknown");
   }
 
   private getToolsCallForwardRoute(args: unknown, socketSessionId: string): McpForwardRoute {

--- a/src/daemon/socketServer.ts
+++ b/src/daemon/socketServer.ts
@@ -25,6 +25,7 @@ import {
   DAEMON_SESSION_TOOL_BINDING_HEADER,
   DAEMON_CAPABILITY_PROFILE_HEADER,
   DAEMON_CAPABILITY_PROFILE_PARAM,
+  DAEMON_BOUND_SESSION_PARAM,
   DAEMON_VERSION,
 } from "./constants";
 import {
@@ -777,7 +778,7 @@ export class UnixSocketServer {
       // the proxy-side reconnect seeding (issue #4610).
       const listSessionUuid = this.getSessionUuid(request.params);
       const capabilityProfileUuid = this.getCapabilityProfileUuid(request.params);
-      if (listSessionUuid) {
+      if (listSessionUuid && !this.isReleasedBoundSession(request.params)) {
         return this.sessionScopedForwardRoute(socketSessionId, listSessionUuid, undefined, capabilityProfileUuid);
       }
       if (capabilityProfileUuid) {
@@ -825,7 +826,7 @@ export class UnixSocketServer {
     const boundRoute = this.getBoundMcpClientRoute(socketSessionId);
     const sessionUuid = this.getSessionUuid(args);
     const capabilityProfileUuid = this.getCapabilityProfileUuid(args) ?? boundRoute?.capabilityProfileUuid;
-    if (sessionUuid) {
+    if (sessionUuid && !this.isReleasedBoundSession(args)) {
       return this.sessionScopedForwardRoute(socketSessionId, sessionUuid, scopedKey, capabilityProfileUuid);
     }
     if (capabilityProfileUuid) {
@@ -915,9 +916,31 @@ export class UnixSocketServer {
       this.recordGeneratedCapabilityProfile(request, response, socketSessionId, route);
       return;
     }
+    this.recordSessionBoundMcpClientKey(
+      socketSessionId,
+      route,
+      sessionUuid,
+      sessionWasActiveBeforeForward,
+      request.params?.name,
+      request.params?.arguments,
+    );
+  }
+
+  private recordSessionBoundMcpClientKey(
+    socketSessionId: string,
+    route: McpForwardRoute,
+    sessionUuid: string,
+    sessionWasActiveBeforeForward: boolean,
+    toolName: unknown,
+    args: unknown,
+  ): void {
+    if (this.isReleasedBoundSession(args)) {
+      this.clearBoundMcpClientKey(socketSessionId);
+      return;
+    }
     const sessionIsActiveAfterForward = this.hasActiveDaemonSession(sessionUuid);
     if (
-      (sessionWasActiveBeforeForward || request.params?.name === "executePlan")
+      (sessionWasActiveBeforeForward || toolName === "executePlan")
       && !sessionIsActiveAfterForward
     ) {
       this.clearBoundMcpClientKey(socketSessionId);
@@ -1042,6 +1065,19 @@ export class UnixSocketServer {
     }
     const sessionUuid = (args as Record<string, unknown>).sessionUuid;
     return isNonBlankSessionUuid(sessionUuid) ? sessionUuid : undefined;
+  }
+
+  private isReleasedBoundSession(args: unknown): boolean {
+    if (!args || typeof args !== "object" || Array.isArray(args) || !this.daemonState.isInitialized()) {
+      return false;
+    }
+    const record = args as Record<string, unknown>;
+    const sessionUuid = this.getSessionUuid(record);
+    return (
+      sessionUuid !== undefined &&
+      record[DAEMON_BOUND_SESSION_PARAM] === sessionUuid &&
+      !this.hasActiveDaemonSession(sessionUuid)
+    );
   }
 
   private getRequestArgumentScopeKey(args: unknown): string | undefined {
@@ -2362,6 +2398,15 @@ export class UnixSocketServer {
 
     const forwardedArgs = { ...args } as Record<string, unknown>;
     delete forwardedArgs[DAEMON_CAPABILITY_PROFILE_PARAM];
+    const boundSessionUuid = this.getSessionUuid(forwardedArgs);
+    const usesBoundSession = forwardedArgs[DAEMON_BOUND_SESSION_PARAM] === boundSessionUuid;
+    delete forwardedArgs[DAEMON_BOUND_SESSION_PARAM];
+    // Connection-bound sessions are carried by the loopback transport header.
+    // Never let a stale injected UUID reach ToolExecutionContext, whose legacy
+    // explicit-session contract would otherwise create a replacement session.
+    if (usesBoundSession) {
+      delete forwardedArgs.sessionUuid;
+    }
     return {
       ...forwardedArgs,
       __mcpSessionId: socketSessionId,

--- a/src/index.ts
+++ b/src/index.ts
@@ -141,6 +141,7 @@ async function main() {
       cliArgs,
       daemonPort,
       daemonHost,
+      initialSessionUuid,
       debugPerf,
       debug,
       uiPerfMode,
@@ -505,7 +506,11 @@ async function main() {
       try {
         if (useProxyMode) {
           const result = createProxyMcpServer({
-            proxyConfig: { autoStartDaemon: !noDaemon, daemonOptions: daemonStartupOptions }
+            proxyConfig: {
+              autoStartDaemon: !noDaemon,
+              daemonOptions: daemonStartupOptions,
+              initialSessionUuid,
+            }
           });
           server = result.server;
           stdioProxy = result.proxy;

--- a/src/server/SessionToolBinding.ts
+++ b/src/server/SessionToolBinding.ts
@@ -21,11 +21,23 @@ export class SessionToolBinding {
     const explicit = params && typeof params === "object" && !Array.isArray(params)
       ? (params as Record<string, unknown>).sessionUuid
       : undefined;
-    return typeof explicit === "string" && explicit.trim().length > 0
+    const explicitSessionUuid = typeof explicit === "string" && explicit.trim().length > 0
       ? explicit
-      : mcpSessionId
-        ? this.boundDeviceSessions.get(mcpSessionId) ?? this.initialSessionUuid
-        : this.initialSessionUuid;
+      : undefined;
+    const boundSessionUuid = mcpSessionId
+      ? this.boundDeviceSessions.get(mcpSessionId) ?? this.initialSessionUuid
+      : this.initialSessionUuid;
+    if (
+      this.initialSessionUuid &&
+      explicitSessionUuid &&
+      explicitSessionUuid !== this.initialSessionUuid
+    ) {
+      throw new Error(
+        `MCP connection is bound to device session ${this.initialSessionUuid}; ` +
+        `cannot route this call to ${explicitSessionUuid} until the binding is released.`
+      );
+    }
+    return explicitSessionUuid ?? boundSessionUuid;
   }
 
   /**
@@ -50,6 +62,9 @@ export class SessionToolBinding {
       return false;
     }
     if (!mcpSessionId) {
+      return false;
+    }
+    if (this.initialSessionUuid && sessionUuid !== this.initialSessionUuid) {
       return false;
     }
     if (this.boundDeviceSessions.get(mcpSessionId) === sessionUuid) {

--- a/src/server/bootedDeviceResources.ts
+++ b/src/server/bootedDeviceResources.ts
@@ -5,7 +5,11 @@ import { logger } from "../utils/logger";
 import { BootedDevice, Platform } from "../models";
 import { DaemonState } from "../daemon/daemonState";
 import type { Session } from "../daemon/sessionManager";
-import type { DevicePool } from "../daemon/devicePool";
+import type {
+  DevicePool,
+  DeviceRecoveryEligibility,
+  DeviceRecoveryPolicy,
+} from "../daemon/devicePool";
 import { AndroidCtrlProxyManager } from "../utils/CtrlProxyManager";
 import { IOSCtrlProxyManager } from "../utils/IOSCtrlProxyManager";
 import { IOSCtrlProxyBuilder } from "../utils/IOSCtrlProxyBuilder";
@@ -49,6 +53,7 @@ interface BootedDeviceInfo {
   status: "booted";
   poolStatus?: PoolDeviceStatus;
   assignedSession?: string;
+  recoveryEligibility?: DeviceRecoveryEligibility;
   session?: DeviceSessionInfo;
   serviceStatus?: DeviceServiceStatus;
 }
@@ -73,6 +78,7 @@ interface PoolStatusSummary {
   assigned: number;
   error: number;
   total: number;
+  recoveryPolicy: DeviceRecoveryPolicy;
 }
 
 interface DeviceSessionInfo {
@@ -88,6 +94,7 @@ interface DeviceSessionInfo {
 interface PoolDeviceInfo {
   poolStatus: PoolDeviceStatus;
   assignedSession?: string;
+  recoveryEligibility: DeviceRecoveryEligibility;
 }
 
 /**
@@ -129,7 +136,8 @@ function toBootedDeviceInfo(
     ...info,
     ...(poolInfo ? {
       poolStatus: poolInfo.poolStatus,
-      ...(poolInfo.assignedSession ? { assignedSession: poolInfo.assignedSession } : {})
+      ...(poolInfo.assignedSession ? { assignedSession: poolInfo.assignedSession } : {}),
+      recoveryEligibility: poolInfo.recoveryEligibility,
     } : {}),
     ...(sessionInfo ? { session: sessionInfo } : {})
   };
@@ -159,7 +167,8 @@ function getPoolDeviceInfo(devicePool: DevicePool | null, deviceId: string): Poo
 
   return {
     poolStatus,
-    assignedSession: pooledDevice.sessionId || undefined
+    assignedSession: pooledDevice.sessionId || undefined,
+    recoveryEligibility: devicePool.getRecoveryEligibility(deviceId),
   };
 }
 
@@ -203,7 +212,8 @@ function summarizePoolStatus(
     idle,
     assigned,
     error,
-    total: idle + assigned + error
+    total: idle + assigned + error,
+    recoveryPolicy: devicePool.getRecoveryPolicy(),
   };
 }
 
@@ -270,7 +280,8 @@ async function getBootedDevicesForPlatforms(platforms: Platform[]): Promise<Boot
         idle: 0,
         assigned: 0,
         error: 0,
-        total: 0
+        total: 0,
+        recoveryPolicy: devicePool.getRecoveryPolicy(),
       };
     } catch (error) {
       logger.warn(`[BootedDeviceResources] Failed to read device pool status: ${error}`);

--- a/src/server/deviceLossOutcome.ts
+++ b/src/server/deviceLossOutcome.ts
@@ -1,5 +1,9 @@
 export const DEVICE_LOSS_OUTCOME_CODE = "device_lost";
-const deviceLossByAbortSignal = new WeakMap<AbortSignal, DeviceLostError>();
+const DEVICE_LOSS_ABORT_ERROR = Symbol.for("automobile.device-loss-error");
+
+type DeviceLossAwareAbortSignal = AbortSignal & {
+  [DEVICE_LOSS_ABORT_ERROR]?: DeviceLostError;
+};
 
 export interface DeviceLossOutcome {
   code: typeof DEVICE_LOSS_OUTCOME_CODE;
@@ -42,11 +46,13 @@ export function deviceLostErrorFromCancellationReason(reason: string): DeviceLos
  * infrastructure outcome in that runtime path.
  */
 export function rememberDeviceLossAbort(signal: AbortSignal, error: DeviceLostError): void {
-  deviceLossByAbortSignal.set(signal, error);
+  (signal as DeviceLossAwareAbortSignal)[DEVICE_LOSS_ABORT_ERROR] = error;
 }
 
 export function deviceLostErrorFromAbortSignal(signal: AbortSignal): DeviceLostError | undefined {
-  return isDeviceLostError(signal.reason) ? signal.reason : deviceLossByAbortSignal.get(signal);
+  return isDeviceLostError(signal.reason)
+    ? signal.reason
+    : (signal as DeviceLossAwareAbortSignal)[DEVICE_LOSS_ABORT_ERROR];
 }
 
 export function deviceLossOutcomeFromError(

--- a/src/server/deviceLossOutcome.ts
+++ b/src/server/deviceLossOutcome.ts
@@ -1,4 +1,5 @@
 export const DEVICE_LOSS_OUTCOME_CODE = "device_lost";
+const deviceLossByAbortSignal = new WeakMap<AbortSignal, DeviceLostError>();
 
 export interface DeviceLossOutcome {
   code: typeof DEVICE_LOSS_OUTCOME_CODE;
@@ -33,6 +34,19 @@ export function deviceLostErrorFromCancellationReason(reason: string): DeviceLos
     ? reason.slice("device-disconnected:".length)
     : "";
   return deviceId ? new DeviceLostError(deviceId, reason) : undefined;
+}
+
+/**
+ * Bun can report an aborted signal while temporarily hiding `signal.reason`.
+ * Track the typed reason by signal so downstream cancellation checks retain the
+ * infrastructure outcome in that runtime path.
+ */
+export function rememberDeviceLossAbort(signal: AbortSignal, error: DeviceLostError): void {
+  deviceLossByAbortSignal.set(signal, error);
+}
+
+export function deviceLostErrorFromAbortSignal(signal: AbortSignal): DeviceLostError | undefined {
+  return isDeviceLostError(signal.reason) ? signal.reason : deviceLossByAbortSignal.get(signal);
 }
 
 export function deviceLossOutcomeFromError(

--- a/src/server/deviceLossOutcome.ts
+++ b/src/server/deviceLossOutcome.ts
@@ -1,0 +1,51 @@
+export const DEVICE_LOSS_OUTCOME_CODE = "device_lost";
+
+export interface DeviceLossOutcome {
+  code: typeof DEVICE_LOSS_OUTCOME_CODE;
+  deviceId: string;
+  sessionUuid?: string;
+  reason: "confirmed-unavailable";
+}
+
+/**
+ * A device-loss cancellation is infrastructure failure, not an application or
+ * tool failure. Keep the original cancellation reason as the error message so
+ * existing logs remain searchable.
+ */
+export class DeviceLostError extends Error {
+  readonly code = DEVICE_LOSS_OUTCOME_CODE;
+
+  constructor(
+    readonly deviceId: string,
+    reason: string,
+  ) {
+    super(reason);
+    this.name = "DeviceLostError";
+  }
+}
+
+export function isDeviceLostError(error: unknown): error is DeviceLostError {
+  return error instanceof DeviceLostError;
+}
+
+export function deviceLostErrorFromCancellationReason(reason: string): DeviceLostError | undefined {
+  const deviceId = reason.startsWith("device-disconnected:")
+    ? reason.slice("device-disconnected:".length)
+    : "";
+  return deviceId ? new DeviceLostError(deviceId, reason) : undefined;
+}
+
+export function deviceLossOutcomeFromError(
+  error: unknown,
+  sessionUuid?: string,
+): DeviceLossOutcome | undefined {
+  if (!isDeviceLostError(error)) {
+    return undefined;
+  }
+  return {
+    code: DEVICE_LOSS_OUTCOME_CODE,
+    deviceId: error.deviceId,
+    ...(sessionUuid ? { sessionUuid } : {}),
+    reason: "confirmed-unavailable",
+  };
+}

--- a/src/server/executionTracker.ts
+++ b/src/server/executionTracker.ts
@@ -1,6 +1,7 @@
 import { logger } from "../utils/logger";
 import { defaultTimer, type Timer } from "../utils/SystemTimer";
 import { defaultIdGenerator, type IdGenerator } from "../utils/IdGenerator";
+import { deviceLostErrorFromCancellationReason } from "./deviceLossOutcome";
 
 interface ActiveExecution {
   id: string;
@@ -178,7 +179,7 @@ export class ExecutionTracker {
         // authoritative `cancelReason` is set synchronously with the counted cancellation
         // regardless of how the runtime surfaces `signal.reason` (issue #3909). The same
         // Error instance is passed to abort() so consumers reading the signal still match.
-        const reasonError = new Error(cancelReason);
+        const reasonError = deviceLostErrorFromCancellationReason(cancelReason) ?? new Error(cancelReason);
         execution.cancelReason = reasonError;
         execution.abortController.abort(reasonError);
       } else {

--- a/src/server/executionTracker.ts
+++ b/src/server/executionTracker.ts
@@ -1,7 +1,11 @@
 import { logger } from "../utils/logger";
 import { defaultTimer, type Timer } from "../utils/SystemTimer";
 import { defaultIdGenerator, type IdGenerator } from "../utils/IdGenerator";
-import { deviceLostErrorFromCancellationReason } from "./deviceLossOutcome";
+import {
+  deviceLostErrorFromCancellationReason,
+  isDeviceLostError,
+  rememberDeviceLossAbort,
+} from "./deviceLossOutcome";
 
 interface ActiveExecution {
   id: string;
@@ -181,6 +185,9 @@ export class ExecutionTracker {
         // Error instance is passed to abort() so consumers reading the signal still match.
         const reasonError = deviceLostErrorFromCancellationReason(cancelReason) ?? new Error(cancelReason);
         execution.cancelReason = reasonError;
+        if (isDeviceLostError(reasonError)) {
+          rememberDeviceLossAbort(execution.abortController.signal, reasonError);
+        }
         execution.abortController.abort(reasonError);
       } else {
         execution.abortController.abort();

--- a/src/server/index.ts
+++ b/src/server/index.ts
@@ -12,6 +12,7 @@ import { runWithAbortSignal } from "../utils/AbortContext";
 import { createDefaultPlanExecutionLock, type PlanExecutionLock } from "./PlanExecutionLock";
 import { SessionToolBinding } from "./SessionToolBinding";
 import { SessionReleaseBroadcaster } from "./sessionReleaseBroadcast";
+import { deviceLossOutcomeFromError } from "./deviceLossOutcome";
 
 // Import the tool registry
 import { ToolRegistry, toolHasOutputSchema } from "./toolRegistry";
@@ -543,6 +544,16 @@ export const createMcpServer = (options: McpServerOptions = {}): McpServer => {
         logger.debug("[MCP] Omitted structuredContent", { tool: name, reason: omissionReason });
       }
       return stripToolResultStructuredContent(result, omissionReason);
+    } catch (error) {
+      const deviceLoss = deviceLossOutcomeFromError(error, providedSessionUuid ?? routingSessionUuid);
+      if (deviceLoss) {
+        return {
+          content: [{ type: "text" as const, text: JSON.stringify(deviceLoss) }],
+          structuredContent: deviceLoss,
+          isError: true,
+        };
+      }
+      throw error;
     } finally {
       executionTracker.endExecution(execution.id);
     }

--- a/src/server/index.ts
+++ b/src/server/index.ts
@@ -12,7 +12,7 @@ import { runWithAbortSignal } from "../utils/AbortContext";
 import { createDefaultPlanExecutionLock, type PlanExecutionLock } from "./PlanExecutionLock";
 import { SessionToolBinding } from "./SessionToolBinding";
 import { SessionReleaseBroadcaster } from "./sessionReleaseBroadcast";
-import { deviceLossOutcomeFromError } from "./deviceLossOutcome";
+import { deviceLostErrorFromAbortSignal, deviceLossOutcomeFromError } from "./deviceLossOutcome";
 
 // Import the tool registry
 import { ToolRegistry, toolHasOutputSchema } from "./toolRegistry";
@@ -479,7 +479,8 @@ export const createMcpServer = (options: McpServerOptions = {}): McpServer => {
       throw new ActionableError(`Invalid parameters for tool ${name}: ${formatToolParamError(name, error)}`);
     }
 
-    const execution = executionTracker.startExecution(name, sessionId, providedSessionUuid ?? routingSessionUuid);
+    const executionSessionUuid = derivedLabelSessionUuid ?? providedSessionUuid ?? routingSessionUuid;
+    const execution = executionTracker.startExecution(name, sessionId, executionSessionUuid);
     const handlerParams = implicitAutolockMcpSessionId && parsedParams && typeof parsedParams === "object"
       ? { ...parsedParams, [INTERNAL_MCP_SESSION_PARAM]: implicitAutolockMcpSessionId }
       : parsedParams;
@@ -545,11 +546,14 @@ export const createMcpServer = (options: McpServerOptions = {}): McpServer => {
       }
       return stripToolResultStructuredContent(result, omissionReason);
     } catch (error) {
-      const deviceLoss = deviceLossOutcomeFromError(error, providedSessionUuid ?? routingSessionUuid);
+      const deviceLoss = deviceLossOutcomeFromError(error, executionSessionUuid)
+        ?? deviceLossOutcomeFromError(
+          deviceLostErrorFromAbortSignal(execution.abortController.signal),
+          executionSessionUuid,
+        );
       if (deviceLoss) {
         return {
           content: [{ type: "text" as const, text: JSON.stringify(deviceLoss) }],
-          structuredContent: deviceLoss,
           isError: true,
         };
       }

--- a/src/server/planExecutionOrchestrator.ts
+++ b/src/server/planExecutionOrchestrator.ts
@@ -25,6 +25,7 @@ import { defaultTimer, Timer } from "../utils/SystemTimer";
 import { logger } from "../utils/logger";
 import { ProgressCallback } from "./toolRegistry";
 import type { Plan } from "../models/Plan";
+import { isDeviceLostError } from "./deviceLossOutcome";
 
 /**
  * Test metadata captured per-execution for the test-execution timing repository.
@@ -113,6 +114,12 @@ const getDeviceType = (device: BootedDevice): "emulator" | "simulator" | "device
 };
 
 const sharedTestExecutionRepository = new TestExecutionRepository();
+
+const rethrowDeviceLoss = (error: unknown): void => {
+  if (isDeviceLostError(error)) {
+    throw error;
+  }
+};
 
 /**
  * Converts debug step traces from PlanExecutor into the row shape expected by
@@ -242,8 +249,9 @@ export class PlanExecutionOrchestrator {
   }
 
   /**
-   * Run all phases, always returning a structured ExecutePlanResult.
-   * Never throws — failures are converted into `success: false` responses.
+   * Run all phases, returning a structured ExecutePlanResult for ordinary plan
+   * failures. Device-loss cancellation is rethrown for the MCP boundary to
+   * report as an infrastructure outcome.
    */
   async execute(): Promise<ExecutePlanResult> {
     const startTime = this.timer.now();
@@ -317,6 +325,7 @@ export class PlanExecutionOrchestrator {
       this.perfLog(`Returning from executePlanTool (deviceId=${this.device.deviceId})`);
       return response;
     } catch (error) {
+      rethrowDeviceLoss(error);
       logger.error(`[PERF] Failed to execute plan: ${error}`);
 
       await this.recordExecution("failed", startTime, {

--- a/src/server/proxyServer.ts
+++ b/src/server/proxyServer.ts
@@ -14,7 +14,7 @@ import { getMcpServerVersion } from "../utils/mcpVersion";
 /**
  * Options for creating a proxy MCP server
  */
-interface ProxyMcpServerOptions {
+export interface ProxyMcpServerOptions {
   /** Configuration for the daemon proxy */
   proxyConfig?: DaemonMcpProxyConfig;
   /** Session context for tracking */

--- a/src/server/toolRegistry.ts
+++ b/src/server/toolRegistry.ts
@@ -46,6 +46,7 @@ import {
   getToolCapabilityContext,
   runWithToolCapabilityContext,
 } from "../features/toolCapabilities/toolCapabilityContext";
+import { isDeviceLostError } from "./deviceLossOutcome";
 
 // Re-exported for backward compatibility; the implementation now lives in
 // ./TopLevelUnionFlattener so the schema-flattening concern is independently testable.
@@ -1034,7 +1035,7 @@ export class ToolRegistryClass {
               toolDurationMs = afterToolCallResult.durationMs;
               return afterToolCallResult.finalizedResponse;
             } catch (error) {
-              if (error instanceof ActionableError) {
+              if (error instanceof ActionableError || isDeviceLostError(error)) {
                 throw error;
               }
               const deviceContext = resolvedTarget.device ? ` on device ${resolvedTarget.device.deviceId}` : "";

--- a/src/utils/plan/PlanExecutor.ts
+++ b/src/utils/plan/PlanExecutor.ts
@@ -22,6 +22,7 @@ import { DaemonState } from "../../daemon/daemonState";
 import { Timer, defaultTimer } from "../SystemTimer";
 import type { FailureObservationSummary } from "../../models/FailureObservation";
 import { ScreenshotJobTracker } from "../ScreenshotJobTracker";
+import { isDeviceLostError } from "../../server/deviceLossOutcome";
 import {
   summarizeObserveResultForFailure,
   trimObservationForStepCapture,
@@ -500,6 +501,9 @@ export class DefaultPlanExecutor implements PlanExecutor {
         details,
       };
     } catch (error) {
+      if (isDeviceLostError(error)) {
+        throw error;
+      }
       const errorMessage = `${error}`;
       if (step.optional && !context.signal?.aborted && !(error instanceof ZodError)) {
         this.logger.warn(`${context.logPrefix} optional step ${step.tool} threw; returning skipped status`, error);
@@ -714,6 +718,9 @@ export class DefaultPlanExecutor implements PlanExecutor {
       };
 
     } catch (error) {
+      if (isDeviceLostError(error)) {
+        throw error;
+      }
       logger.error(`Plan execution failed: ${error}`);
 
       debugSteps.push({
@@ -849,6 +856,9 @@ export class DefaultPlanExecutor implements PlanExecutor {
 
         return result;
       } catch (error) {
+        if (isDeviceLostError(error)) {
+          throw error;
+        }
         const errorMessage = error instanceof Error ? error.message : String(error);
         logger.error(`[PARALLEL_EXEC][${device}] Unexpected error: ${errorMessage}`);
 
@@ -1050,6 +1060,9 @@ export class DefaultPlanExecutor implements PlanExecutor {
         skippedSteps,
       };
     } catch (error) {
+      if (isDeviceLostError(error)) {
+        throw error;
+      }
       const errorMessage = error instanceof Error ? error.message : String(error);
       logger.error(`[PARALLEL_EXEC][${device}] Track execution error: ${errorMessage}`);
 

--- a/src/utils/toolUtils.ts
+++ b/src/utils/toolUtils.ts
@@ -3,6 +3,7 @@
  */
 import { OPERATION_CANCELLED_MESSAGE } from "./constants";
 import { serverConfig } from "./ServerConfig";
+import { deviceLostErrorFromAbortSignal } from "../server/deviceLossOutcome";
 
 const stripAccessibilityExtras = (key: string, value: unknown): unknown => {
   if (key === "extras") {
@@ -211,8 +212,9 @@ export const getStructuredField = <TPayload, K extends keyof TPayload & string>(
 
 export const throwIfAborted = (signal?: AbortSignal): void => {
   if (signal?.aborted) {
-    if (signal.reason instanceof Error && signal.reason.name === "DeviceLostError") {
-      throw signal.reason;
+    const deviceLoss = deviceLostErrorFromAbortSignal(signal);
+    if (deviceLoss) {
+      throw deviceLoss;
     }
     throw new Error(OPERATION_CANCELLED_MESSAGE);
   }

--- a/src/utils/toolUtils.ts
+++ b/src/utils/toolUtils.ts
@@ -211,6 +211,9 @@ export const getStructuredField = <TPayload, K extends keyof TPayload & string>(
 
 export const throwIfAborted = (signal?: AbortSignal): void => {
   if (signal?.aborted) {
+    if (signal.reason instanceof Error && signal.reason.name === "DeviceLostError") {
+      throw signal.reason;
+    }
     throw new Error(OPERATION_CANCELLED_MESSAGE);
   }
 };

--- a/test/cli/parseArgs.test.ts
+++ b/test/cli/parseArgs.test.ts
@@ -22,4 +22,10 @@ describe("parseArgs (#4277)", () => {
     expect(parsed.embeddedSdk).toBe(false);
     expect(parsed.networkMockable).toBe(false);
   });
+
+  test("parses an initial device-session binding for proxy mode", () => {
+    const parsed = parseArgs(["--initial-session-uuid", "device-session-a"], logger);
+
+    expect(parsed.initialSessionUuid).toBe("device-session-a");
+  });
 });

--- a/test/daemon/daemonMcpProxy.test.ts
+++ b/test/daemon/daemonMcpProxy.test.ts
@@ -43,6 +43,7 @@ const matchingDaemonManager = (): FakeDaemonManager => {
 class ScriptedDaemonClient implements DaemonClientLike {
   readonly callToolCalls: Array<{ toolName: string; params: Record<string, any> }> = [];
   readonly readResourceCalls: string[] = [];
+  readonly readResourceParams: Array<Record<string, any>> = [];
   readonly callDaemonMethodCalls: Array<{ method: string; params: Record<string, any> }> = [];
   connectCallCount = 0;
   closeCallCount = 0;
@@ -81,8 +82,11 @@ class ScriptedDaemonClient implements DaemonClientLike {
     return this.behavior.toolResult ?? { content: [{ type: "text", text: "success" }] };
   }
 
-  async readResource(uri: string): Promise<any> {
+  async readResource(uri: string, params: Record<string, any> = {}): Promise<any> {
     this.readResourceCalls.push(uri);
+    const recordedParams = { ...params };
+    delete recordedParams.__autoMobileBoundSessionUuid;
+    this.readResourceParams.push(recordedParams);
     if (this.behavior.resourceError) {
       throw this.behavior.resourceError;
     }
@@ -1274,12 +1278,13 @@ describe("DaemonMcpProxy", () => {
       }
     });
 
-    test("readResource forwards to daemon", async () => {
+    test("readResource forwards a trimmed initial binding to the daemon", async () => {
       const expectedResult = { contents: [{ uri: "automobile:test", text: "data" }] };
       const fakeClient = new FakeDaemonClient({ resourceResult: expectedResult });
       const isAvailableSpy = spyOn(DaemonClient, "isAvailable").mockResolvedValue(true);
 
       const proxy = new DaemonMcpProxy({
+        initialSessionUuid: " session-a ",
         clientFactory: () => fakeClient,
         daemonManager: matchingDaemonManager(),
         autoStartDaemon: false
@@ -1290,13 +1295,14 @@ describe("DaemonMcpProxy", () => {
 
         expect(result).toEqual(expectedResult);
         expect(fakeClient.readResourceCalls).toContain("automobile:devices/booted");
+        expect(fakeClient.readResourceParams).toEqual([{ sessionUuid: "session-a" }]);
       } finally {
         isAvailableSpy.mockRestore();
         await proxy.close();
       }
     });
 
-    test("readResource reconnects and retries once when daemon session is stale", async () => {
+    test("readResource reconnects and retries once with its initial session binding", async () => {
       const recoveredResult = { contents: [{ uri: "automobile:devices/booted", text: "[]" }] };
       const staleClient = new ScriptedDaemonClient({
         resourceError: new Error("MCP error -32603: Failed to read resource from daemon: Session not found"),
@@ -1308,6 +1314,7 @@ describe("DaemonMcpProxy", () => {
       const isAvailableSpy = spyOn(DaemonClient, "isAvailable").mockResolvedValue(true);
 
       const proxy = new DaemonMcpProxy({
+        initialSessionUuid: "session-a",
         clientFactory: () => clients.shift()!,
         daemonManager: matchingDaemonManager(),
         autoStartDaemon: false
@@ -1320,8 +1327,10 @@ describe("DaemonMcpProxy", () => {
         expect(staleClient.connectCallCount).toBe(1);
         expect(staleClient.closeCallCount).toBe(1);
         expect(staleClient.readResourceCalls).toEqual(["automobile:devices/booted"]);
+        expect(staleClient.readResourceParams).toEqual([{ sessionUuid: "session-a" }]);
         expect(freshClient.connectCallCount).toBe(1);
         expect(freshClient.readResourceCalls).toEqual(["automobile:devices/booted"]);
+        expect(freshClient.readResourceParams).toEqual([{ sessionUuid: "session-a" }]);
       } finally {
         isAvailableSpy.mockRestore();
         await proxy.close();
@@ -2067,6 +2076,31 @@ describe("DaemonMcpProxy", () => {
         expect(fakeClient.callToolCalls).toEqual([
           { toolName: "observe", params: { sessionUuid: "session-a", deviceId: "device-a" } },
           { toolName: "observe", params: { deviceId: "device-a" } },
+        ]);
+      } finally {
+        isAvailableSpy.mockRestore();
+        await proxy.close();
+      }
+    });
+
+    test("does not expire a configured initial binding before its release signal", async () => {
+      const timer = new FakeTimer();
+      const fakeClient = new FakeDaemonClient();
+      const isAvailableSpy = spyOn(DaemonClient, "isAvailable").mockResolvedValue(true);
+      const proxy = new DaemonMcpProxy({
+        initialSessionUuid: "session-a",
+        clientFactory: () => fakeClient,
+        daemonManager: matchingDaemonManager(),
+        autoStartDaemon: false,
+        timer,
+      });
+
+      try {
+        timer.advanceTime(DAEMON_BOUND_SESSION_REPLAY_TTL_MS);
+        await proxy.callTool("observe", { deviceId: "device-a" });
+
+        expect(fakeClient.callToolCalls).toEqual([
+          { toolName: "observe", params: { deviceId: "device-a", sessionUuid: "session-a" } },
         ]);
       } finally {
         isAvailableSpy.mockRestore();

--- a/test/daemon/daemonMcpProxy.test.ts
+++ b/test/daemon/daemonMcpProxy.test.ts
@@ -1608,6 +1608,31 @@ describe("DaemonMcpProxy", () => {
       }
     });
 
+    test("allows a learned binding to retarget to a later explicit session", async () => {
+      const client = new FakeDaemonClient();
+      const isAvailableSpy = spyOn(DaemonClient, "isAvailable").mockResolvedValue(true);
+      const proxy = new DaemonMcpProxy({
+        clientFactory: () => client,
+        daemonManager: matchingDaemonManager(),
+        autoStartDaemon: false,
+      });
+
+      try {
+        await proxy.callTool("observe", { sessionUuid: "session-a", deviceId: "device-a" });
+        await proxy.callTool("observe", { sessionUuid: "session-b", deviceId: "device-b" });
+        await proxy.callTool("observe", { deviceId: "device-b" });
+
+        expect(client.callToolCalls).toEqual([
+          { toolName: "observe", params: { sessionUuid: "session-a", deviceId: "device-a" } },
+          { toolName: "observe", params: { sessionUuid: "session-b", deviceId: "device-b" } },
+          { toolName: "observe", params: { sessionUuid: "session-b", deviceId: "device-b" } },
+        ]);
+      } finally {
+        isAvailableSpy.mockRestore();
+        await proxy.close();
+      }
+    });
+
     test("keeps replaying a bound session across continuous implicit activity beyond one TTL", async () => {
       // Continuous implicit (sessionless) calls forward the bound UUID and extend
       // the live daemon session, so the replay lease must refresh off the forwarded
@@ -2101,6 +2126,37 @@ describe("DaemonMcpProxy", () => {
 
         expect(fakeClient.callToolCalls).toEqual([
           { toolName: "observe", params: { deviceId: "device-a", sessionUuid: "session-a" } },
+        ]);
+      } finally {
+        isAvailableSpy.mockRestore();
+        await proxy.close();
+      }
+    });
+
+    test("clears a configured binding after a confirmed missing-session fallback", async () => {
+      const firstClient = new ScriptedDaemonClient({
+        toolError: new Error("Session not found"),
+      });
+      const retryClient = new ScriptedDaemonClient({
+        toolError: new Error("Session not found"),
+      });
+      const replacementClient = new FakeDaemonClient();
+      const clients: DaemonClientLike[] = [firstClient, retryClient, replacementClient];
+      const isAvailableSpy = spyOn(DaemonClient, "isAvailable").mockResolvedValue(true);
+      const proxy = new DaemonMcpProxy({
+        initialSessionUuid: "session-a",
+        clientFactory: () => clients.shift()!,
+        daemonManager: matchingDaemonManager(),
+        autoStartDaemon: false,
+      });
+
+      try {
+        await expect(proxy.callTool("observe", { deviceId: "device-a" })).rejects.toThrow("Session not found");
+        await proxy.close();
+        await proxy.callTool("observe", { sessionUuid: "session-b", deviceId: "device-b" });
+
+        expect(replacementClient.callToolCalls).toEqual([
+          { toolName: "observe", params: { sessionUuid: "session-b", deviceId: "device-b" } },
         ]);
       } finally {
         isAvailableSpy.mockRestore();

--- a/test/daemon/daemonMcpProxy.test.ts
+++ b/test/daemon/daemonMcpProxy.test.ts
@@ -7,7 +7,12 @@ import {
 } from "../../src/daemon/daemonMcpProxy";
 import { DaemonClient, DaemonUnavailableError, type DaemonClientLike } from "../../src/daemon/client";
 import { ActionableError } from "../../src/models";
-import { DAEMON_VERSION, DAEMON_VERSION_RESTART_COOLDOWN_MS, DAEMON_BOUND_SESSION_REPLAY_TTL_MS, DAEMON_CAPABILITY_PROFILE_PARAM } from "../../src/daemon/constants";
+import {
+  DAEMON_VERSION,
+  DAEMON_VERSION_RESTART_COOLDOWN_MS,
+  DAEMON_BOUND_SESSION_REPLAY_TTL_MS,
+  DAEMON_CAPABILITY_PROFILE_PARAM,
+} from "../../src/daemon/constants";
 import { logger } from "../../src/utils/logger";
 import { FakeDaemonManager } from "../fakes/FakeDaemonManager";
 import { FakeDaemonClient } from "../fakes/FakeDaemonClient";
@@ -63,7 +68,9 @@ class ScriptedDaemonClient implements DaemonClientLike {
   }
 
   async callTool(toolName: string, params: Record<string, any>): Promise<any> {
-    this.callToolCalls.push({ toolName, params });
+    const recordedParams = { ...params };
+    delete recordedParams.__autoMobileBoundSessionUuid;
+    this.callToolCalls.push({ toolName, params: recordedParams });
     const perToolError = this.behavior.toolErrorByName?.get(toolName);
     if (perToolError) {
       throw perToolError;
@@ -83,7 +90,9 @@ class ScriptedDaemonClient implements DaemonClientLike {
   }
 
   async callDaemonMethod(method: string, params: Record<string, any>): Promise<any> {
-    this.callDaemonMethodCalls.push({ method, params });
+    const recordedParams = { ...params };
+    delete recordedParams.__autoMobileBoundSessionUuid;
+    this.callDaemonMethodCalls.push({ method, params: recordedParams });
     if (this.behavior.daemonMethodError) {
       throw this.behavior.daemonMethodError;
     }
@@ -1368,7 +1377,9 @@ describe("DaemonMcpProxy", () => {
       const originalCallTool = staleClient.callTool.bind(staleClient);
       staleClient.callTool = async (toolName, params) => {
         if (staleClient.callToolCalls.length === 1) {
-          staleClient.callToolCalls.push({ toolName, params });
+          const recordedParams = { ...params };
+          delete recordedParams.__autoMobileBoundSessionUuid;
+          staleClient.callToolCalls.push({ toolName, params: recordedParams });
           throw new DaemonUnavailableError("Daemon socket connection lost: connection closed");
         }
         return await originalCallTool(toolName, params);
@@ -1927,44 +1938,32 @@ describe("DaemonMcpProxy", () => {
       }
     });
 
-    test("a release of an UNRELATED session mid-call does not block remembering the forwarded session (#4655)", async () => {
-      // Regression for the global-generation guard: the proxy is bound to
-      // session-a while an EXPLICIT session-b call is in flight; session-a (NOT
-      // the session this call forwarded) is released mid-flight. The old guard
-      // bumped one global counter on ANY binding clear, so the completing
-      // session-b call saw "a binding changed" and declined to remember session-b
-      // — even though session-b was never released. Scoped to the forwarded UUID,
-      // the release of the unrelated session-a must NOT block remembering
-      // session-b.
-      let callCount = 0;
-      const fakeClient: FakeDaemonClient = new FakeDaemonClient({
+    test("does not let a bound connection retarget a different device session", async () => {
+      const fakeClient = new FakeDaemonClient({
         toolResult: { content: [{ type: "text", text: "ok" }] },
-        onCallTool: () => {
-          callCount += 1;
-          if (callCount === 2) {
-            fakeClient.emitNotification(SESSION_RELEASED_NOTIFICATION_METHOD, "session-a");
-          }
-        },
       });
       const isAvailableSpy = spyOn(DaemonClient, "isAvailable").mockResolvedValue(true);
       const proxy = new DaemonMcpProxy({
+        initialSessionUuid: "session-a",
         clientFactory: () => fakeClient,
         daemonManager: matchingDaemonManager(),
         autoStartDaemon: false,
       });
 
       try {
-        // Bind session-a.
-        await proxy.callTool("observe", { sessionUuid: "session-a", deviceId: "device-a" });
-        // Explicit session-b call; the unrelated session-a is released mid-flight.
-        await proxy.callTool("observe", { sessionUuid: "session-b", deviceId: "device-b" });
-        // The next sessionless call must be rewritten to session-b (never released).
-        await proxy.callTool("observe", { deviceId: "device-b" });
+        await expect(
+          proxy.callTool("observe", { sessionUuid: "session-b", deviceId: "device-b" }),
+        ).rejects.toThrow("MCP connection is bound to device session session-a");
+        await proxy.callTool("observe", { deviceId: "device-a" });
 
         expect(fakeClient.callToolCalls).toEqual([
-          { toolName: "observe", params: { sessionUuid: "session-a", deviceId: "device-a" } },
-          { toolName: "observe", params: { sessionUuid: "session-b", deviceId: "device-b" } },
-          { toolName: "observe", params: { deviceId: "device-b", sessionUuid: "session-b" } },
+          {
+            toolName: "observe",
+            params: {
+              deviceId: "device-a",
+              sessionUuid: "session-a",
+            },
+          },
         ]);
       } finally {
         isAvailableSpy.mockRestore();

--- a/test/daemon/daemonMcpProxy.test.ts
+++ b/test/daemon/daemonMcpProxy.test.ts
@@ -129,6 +129,62 @@ describe("DaemonMcpProxy", () => {
       }
     });
 
+    test("scopes first discovery and device-aware calls to the configured initial session", async () => {
+      const firstClient = new ScriptedDaemonClient({
+        toolResult: { content: [{ type: "text", text: "first" }] },
+        daemonMethodResults: new Map([
+          ["tools/list", { tools: [{ name: "firstScopedTool", inputSchema: {} }] }],
+        ]),
+      });
+      const secondClient = new ScriptedDaemonClient({
+        toolResult: { content: [{ type: "text", text: "second" }] },
+        daemonMethodResults: new Map([
+          ["tools/list", { tools: [{ name: "secondScopedTool", inputSchema: {} }] }],
+        ]),
+      });
+      const isAvailableSpy = spyOn(DaemonClient, "isAvailable").mockResolvedValue(true);
+      const firstProxy = new DaemonMcpProxy({
+        initialSessionUuid: "device-session-a",
+        clientFactory: () => firstClient,
+        daemonManager: matchingDaemonManager(),
+        autoStartDaemon: false,
+      });
+      const secondProxy = new DaemonMcpProxy({
+        initialSessionUuid: "device-session-b",
+        clientFactory: () => secondClient,
+        daemonManager: matchingDaemonManager(),
+        autoStartDaemon: false,
+      });
+
+      try {
+        await Promise.all([
+          firstProxy.listTools(),
+          secondProxy.listTools(),
+        ]);
+        await Promise.all([
+          firstProxy.callTool("observe", { deviceId: "device-a" }),
+          secondProxy.callTool("observe", { deviceId: "device-b" }),
+        ]);
+
+        expect(firstClient.callDaemonMethodCalls).toEqual([
+          { method: "tools/list", params: { sessionUuid: "device-session-a" } },
+        ]);
+        expect(secondClient.callDaemonMethodCalls).toEqual([
+          { method: "tools/list", params: { sessionUuid: "device-session-b" } },
+        ]);
+        expect(firstClient.callToolCalls).toEqual([
+          { toolName: "observe", params: { deviceId: "device-a", sessionUuid: "device-session-a" } },
+        ]);
+        expect(secondClient.callToolCalls).toEqual([
+          { toolName: "observe", params: { deviceId: "device-b", sessionUuid: "device-session-b" } },
+        ]);
+      } finally {
+        isAvailableSpy.mockRestore();
+        await firstProxy.close();
+        await secondProxy.close();
+      }
+    });
+
     test("auto-starts daemon when not running", async () => {
       const fakeClient = new FakeDaemonClient({
         daemonMethodResults: new Map([
@@ -1366,7 +1422,7 @@ describe("DaemonMcpProxy", () => {
       }
     });
 
-    test("listTools re-seeds the bound session on a reconnect so discovery stays session-scoped", async () => {
+    test("listTools re-seeds an initial session binding on reconnect so discovery stays session-scoped", async () => {
       // listTools forwards to a shared transport. A reconnect mid-listTools would
       // otherwise retry tools/list with empty params against the fresh unseeded
       // transport, returning the full unfiltered tool list instead of the
@@ -1384,15 +1440,13 @@ describe("DaemonMcpProxy", () => {
       const clients = [staleClient, freshClient];
       const isAvailableSpy = spyOn(DaemonClient, "isAvailable").mockResolvedValue(true);
       const proxy = new DaemonMcpProxy({
+        initialSessionUuid: "session-a",
         clientFactory: () => clients.shift()!,
         daemonManager: matchingDaemonManager(),
         autoStartDaemon: false,
       });
 
       try {
-        // Bind the proxy to session-a via a successful tool call.
-        await proxy.callTool("observe", { sessionUuid: "session-a", deviceId: "device-a" });
-
         const tools = await proxy.listTools();
 
         expect(tools).toEqual([{ name: "scopedTool", inputSchema: {} }]);
@@ -1773,20 +1827,21 @@ describe("DaemonMcpProxy", () => {
     // instead of waiting out the replay-TTL guess. The TTL stays as a
     // dropped-frame backstop.
 
-    test("a released signal for the bound UUID clears the binding", async () => {
+    test("a released signal clears an initial binding before a later sessionless call", async () => {
       const fakeClient = new FakeDaemonClient({
         toolResult: { content: [{ type: "text", text: "ok" }] },
       });
       const isAvailableSpy = spyOn(DaemonClient, "isAvailable").mockResolvedValue(true);
       const proxy = new DaemonMcpProxy({
+        initialSessionUuid: "session-a",
         clientFactory: () => fakeClient,
         daemonManager: matchingDaemonManager(),
         autoStartDaemon: false,
       });
 
       try {
-        // Bind session-a via an explicit call, then the daemon releases it.
-        await proxy.callTool("observe", { sessionUuid: "session-a", deviceId: "device-a" });
+        // The initial routing binding scopes calls before any mutable device selection.
+        await proxy.callTool("observe", { deviceId: "device-a" });
         fakeClient.emitNotification(SESSION_RELEASED_NOTIFICATION_METHOD, "session-a");
         // The next sessionless call must NOT be rewritten to the retired UUID.
         await proxy.callTool("observe", { deviceId: "device-a" });

--- a/test/daemon/daemonRecoveryPolicyStartup.test.ts
+++ b/test/daemon/daemonRecoveryPolicyStartup.test.ts
@@ -6,29 +6,13 @@ import { logger } from "../../src/utils/logger";
 import { FakeTimer } from "../fakes/FakeTimer";
 
 describe("daemon device recovery policy startup", () => {
-  const envNames = [
-    "AUTOMOBILE_DEVICE_RECOVERY_ON_LOSS",
-    "AUTOMOBILE_DEVICE_RECOVERY_MAX_ATTEMPTS",
-  ] as const;
-  const originalEnv = new Map(envNames.map(name => [name, process.env[name]]));
-
   afterEach(() => {
-    for (const name of envNames) {
-      const original = originalEnv.get(name);
-      if (original === undefined) {
-        delete process.env[name];
-      } else {
-        process.env[name] = original;
-      }
-    }
     if (DaemonState.getInstance().isInitialized()) {
       DaemonState.getInstance().reset();
     }
   });
 
   test("parses once, logs the effective policy, and warns before falling back", () => {
-    process.env.AUTOMOBILE_DEVICE_RECOVERY_ON_LOSS = "true";
-    process.env.AUTOMOBILE_DEVICE_RECOVERY_MAX_ATTEMPTS = "999";
     const warnSpy = spyOn(logger, "warn").mockImplementation(() => {});
     const infoSpy = spyOn(logger, "info").mockImplementation(() => {});
 
@@ -38,9 +22,16 @@ describe("daemon device recovery policy startup", () => {
         undefined,
         new FakeTimer(),
         new DeviceSessionRepository(),
+        undefined,
+        undefined,
+        undefined,
+        undefined,
+        undefined,
+        {
+          AUTOMOBILE_DEVICE_RECOVERY_ON_LOSS: "true",
+          AUTOMOBILE_DEVICE_RECOVERY_MAX_ATTEMPTS: "999",
+        },
       );
-      delete process.env.AUTOMOBILE_DEVICE_RECOVERY_ON_LOSS;
-      process.env.AUTOMOBILE_DEVICE_RECOVERY_MAX_ATTEMPTS = "1";
 
       expect(daemon.getDevicePool().getRecoveryPolicy()).toEqual({
         onLoss: false,

--- a/test/daemon/daemonRecoveryPolicyStartup.test.ts
+++ b/test/daemon/daemonRecoveryPolicyStartup.test.ts
@@ -1,0 +1,61 @@
+import { afterEach, describe, expect, spyOn, test } from "bun:test";
+import { DeviceSessionRepository } from "../../src/db/deviceSessionRepository";
+import { Daemon } from "../../src/daemon/daemon";
+import { DaemonState } from "../../src/daemon/daemonState";
+import { logger } from "../../src/utils/logger";
+import { FakeTimer } from "../fakes/FakeTimer";
+
+describe("daemon device recovery policy startup", () => {
+  const envNames = [
+    "AUTOMOBILE_DEVICE_RECOVERY_ON_LOSS",
+    "AUTOMOBILE_DEVICE_RECOVERY_MAX_ATTEMPTS",
+  ] as const;
+  const originalEnv = new Map(envNames.map(name => [name, process.env[name]]));
+
+  afterEach(() => {
+    for (const name of envNames) {
+      const original = originalEnv.get(name);
+      if (original === undefined) {
+        delete process.env[name];
+      } else {
+        process.env[name] = original;
+      }
+    }
+    if (DaemonState.getInstance().isInitialized()) {
+      DaemonState.getInstance().reset();
+    }
+  });
+
+  test("parses once, logs the effective policy, and warns before falling back", () => {
+    process.env.AUTOMOBILE_DEVICE_RECOVERY_ON_LOSS = "true";
+    process.env.AUTOMOBILE_DEVICE_RECOVERY_MAX_ATTEMPTS = "999";
+    const warnSpy = spyOn(logger, "warn").mockImplementation(() => {});
+    const infoSpy = spyOn(logger, "info").mockImplementation(() => {});
+
+    try {
+      const daemon = new Daemon(
+        {},
+        undefined,
+        new FakeTimer(),
+        new DeviceSessionRepository(),
+      );
+      delete process.env.AUTOMOBILE_DEVICE_RECOVERY_ON_LOSS;
+      process.env.AUTOMOBILE_DEVICE_RECOVERY_MAX_ATTEMPTS = "1";
+
+      expect(daemon.getDevicePool().getRecoveryPolicy()).toEqual({
+        onLoss: false,
+        maxAttempts: 2,
+      });
+      expect(warnSpy.mock.calls.map(call => call[0])).toEqual(expect.arrayContaining([
+        expect.stringContaining("Invalid AUTOMOBILE_DEVICE_RECOVERY_ON_LOSS"),
+        expect.stringContaining("Invalid AUTOMOBILE_DEVICE_RECOVERY_MAX_ATTEMPTS"),
+      ]));
+      expect(infoSpy.mock.calls.map(call => call[0])).toContain(
+        "[Daemon] Device recovery policy: onLoss=false, maxAttempts=2"
+      );
+    } finally {
+      warnSpy.mockRestore();
+      infoSpy.mockRestore();
+    }
+  });
+});

--- a/test/daemon/daemonRequestHandlers.test.ts
+++ b/test/daemon/daemonRequestHandlers.test.ts
@@ -6,12 +6,15 @@ import {
 import { SessionManager } from "../../src/daemon/sessionManager";
 import { DaemonRequest } from "../../src/daemon/types";
 import { FakeTimer } from "../fakes/FakeTimer";
+import type { DeviceRecoveryEligibility, DeviceRecoveryPolicy, PooledDevice } from "../../src/daemon/devicePool";
 
 class FakeDevicePool {
   stats: DevicePoolStats;
   refreshedCount = 0;
   releasedDevices: string[] = [];
   addedDevices: number;
+  recoveryPolicy: DeviceRecoveryPolicy = { onLoss: false, maxAttempts: 2 };
+  devices: PooledDevice[] = [];
 
   constructor(stats: DevicePoolStats, addedDevices: number = 0) {
     this.stats = stats;
@@ -29,6 +32,18 @@ class FakeDevicePool {
 
   async releaseDevice(deviceId: string): Promise<void> {
     this.releasedDevices.push(deviceId);
+  }
+
+  getRecoveryPolicy(): DeviceRecoveryPolicy {
+    return this.recoveryPolicy;
+  }
+
+  getAllDevices(): PooledDevice[] {
+    return this.devices;
+  }
+
+  getRecoveryEligibility(_deviceId: string): DeviceRecoveryEligibility {
+    return { eligible: false, reason: "disabled" };
   }
 }
 
@@ -260,6 +275,8 @@ describe("handleDaemonRequest", () => {
       assignedDevices: 1,
       errorDevices: 0,
       stats: devicePool.stats,
+      recoveryPolicy: { onLoss: false, maxAttempts: 2 },
+      devices: [],
     });
   });
 });

--- a/test/daemon/devicePool.test.ts
+++ b/test/daemon/devicePool.test.ts
@@ -431,6 +431,20 @@ describe("DevicePool", () => {
       process.env.AUTOMOBILE_ANDROID_REBOOT_ON_DEATH = "1";
       const ready = createBootedDevice("emulator-5554", "android", "Pixel");
       try {
+        devicePool = new DevicePool(
+          sessionManager,
+          "test-daemon-session-id",
+          fakeTimer,
+          fakeAppsRepo,
+          fakeDeviceManager,
+          new DefaultRetryExecutor(fakeTimer),
+          undefined,
+          undefined,
+          undefined,
+          undefined,
+          undefined,
+          { onLoss: true, maxAttempts: 2 },
+        );
         await devicePool.addDevice(ready, {
           name: "Pixel 8",
           platform: "android",
@@ -503,6 +517,20 @@ describe("DevicePool", () => {
       process.env.AUTOMOBILE_ANDROID_REBOOT_ON_DEATH = "1";
       const ready = createBootedDevice("emulator-5554", "android", "Pixel 8");
       try {
+        devicePool = new DevicePool(
+          sessionManager,
+          "test-daemon-session-id",
+          fakeTimer,
+          fakeAppsRepo,
+          fakeDeviceManager,
+          new DefaultRetryExecutor(fakeTimer),
+          undefined,
+          undefined,
+          undefined,
+          undefined,
+          undefined,
+          { onLoss: true, maxAttempts: 2 },
+        );
         await devicePool.addDevice(ready, {
           name: "Pixel 8",
           platform: "android",

--- a/test/daemon/devicePoolRecoveryPolicy.test.ts
+++ b/test/daemon/devicePoolRecoveryPolicy.test.ts
@@ -1,0 +1,63 @@
+import { describe, expect, test } from "bun:test";
+import { DevicePool } from "../../src/daemon/devicePool";
+import { SessionManager } from "../../src/daemon/sessionManager";
+import { FakeTimer } from "../fakes/FakeTimer";
+import { FakeInstalledAppsRepository } from "../fakes/FakeInstalledAppsRepository";
+import { FakeDeviceManager } from "../fakes/FakeDeviceManager";
+
+describe("DevicePool recovery eligibility", () => {
+  test("only reports AutoMobile-started Android virtual devices as recovery eligible", async () => {
+    const timer = new FakeTimer();
+    const pool = new DevicePool(
+      new SessionManager(timer),
+      "daemon-session",
+      timer,
+      new FakeInstalledAppsRepository(),
+      new FakeDeviceManager(),
+      undefined,
+      undefined,
+      undefined,
+      undefined,
+      undefined,
+      undefined,
+      { onLoss: true, maxAttempts: 1 },
+    );
+
+    await pool.initializeWithDevices([{
+      name: "External Pixel",
+      platform: "android",
+      deviceId: "emulator-5554",
+    }, {
+      name: "Physical iPhone",
+      platform: "ios",
+      deviceId: "physical-ios-device",
+    }]);
+    await pool.addDevice(
+      {
+        name: "AutoMobile Pixel",
+        platform: "android",
+        deviceId: "emulator-5556",
+      },
+      {
+        name: "AutoMobile Pixel",
+        platform: "android",
+        isRunning: false,
+        source: "local",
+      },
+    );
+
+    expect(pool.getRecoveryPolicy()).toEqual({ onLoss: true, maxAttempts: 1 });
+    expect(pool.getRecoveryEligibility("emulator-5554")).toEqual({
+      eligible: false,
+      reason: "not-automobile-owned",
+    });
+    expect(pool.getRecoveryEligibility("physical-ios-device")).toEqual({
+      eligible: false,
+      reason: "unsupported-platform",
+    });
+    expect(pool.getRecoveryEligibility("emulator-5556")).toEqual({
+      eligible: true,
+      action: "restart",
+    });
+  });
+});

--- a/test/daemon/deviceRecoveryPolicy.test.ts
+++ b/test/daemon/deviceRecoveryPolicy.test.ts
@@ -1,0 +1,70 @@
+import { describe, expect, test } from "bun:test";
+import {
+  DEFAULT_DEVICE_RECOVERY_MAX_ATTEMPTS,
+  parseDeviceRecoveryPolicy,
+} from "../../src/daemon/poolConfig";
+
+describe("device recovery policy", () => {
+  test("defaults to disabled recovery with the existing two-attempt budget", () => {
+    expect(parseDeviceRecoveryPolicy({})).toEqual({
+      policy: {
+        onLoss: false,
+        maxAttempts: DEFAULT_DEVICE_RECOVERY_MAX_ATTEMPTS,
+      },
+      warnings: [],
+    });
+  });
+
+  test("accepts only strict binary and base-ten integer values", () => {
+    expect(parseDeviceRecoveryPolicy({
+      AUTOMOBILE_DEVICE_RECOVERY_ON_LOSS: "1",
+      AUTOMOBILE_DEVICE_RECOVERY_MAX_ATTEMPTS: "3",
+    })).toEqual({
+      policy: {
+        onLoss: true,
+        maxAttempts: 3,
+      },
+      warnings: [],
+    });
+  });
+
+  test.each([
+    {
+      name: "padded enablement value",
+      env: { AUTOMOBILE_DEVICE_RECOVERY_ON_LOSS: " 1 " },
+    },
+    {
+      name: "boolean word",
+      env: { AUTOMOBILE_DEVICE_RECOVERY_ON_LOSS: "true" },
+    },
+    {
+      name: "fractional attempt budget",
+      env: { AUTOMOBILE_DEVICE_RECOVERY_MAX_ATTEMPTS: "1.5" },
+    },
+    {
+      name: "zero attempt budget",
+      env: { AUTOMOBILE_DEVICE_RECOVERY_MAX_ATTEMPTS: "0" },
+    },
+    {
+      name: "unbounded attempt budget",
+      env: { AUTOMOBILE_DEVICE_RECOVERY_MAX_ATTEMPTS: "999" },
+    },
+  ])("falls back safely and reports a warning for $name", ({ env }) => {
+    const result = parseDeviceRecoveryPolicy(env);
+
+    expect(result.policy).toEqual({
+      onLoss: false,
+      maxAttempts: DEFAULT_DEVICE_RECOVERY_MAX_ATTEMPTS,
+    });
+    expect(result.warnings).toHaveLength(1);
+  });
+
+  test("honors the legacy Android recovery setting during migration", () => {
+    expect(parseDeviceRecoveryPolicy({
+      AUTOMOBILE_ANDROID_REBOOT_ON_DEATH: "1",
+    }).policy).toEqual({
+      onLoss: true,
+      maxAttempts: DEFAULT_DEVICE_RECOVERY_MAX_ATTEMPTS,
+    });
+  });
+});

--- a/test/daemon/manager.test.ts
+++ b/test/daemon/manager.test.ts
@@ -1064,8 +1064,14 @@ describe("Daemon manager available-devices", () => {
               idle: 2,
               assigned: 1,
               error: 0,
-              total: 3
-            }
+              total: 3,
+              recoveryPolicy: { onLoss: true, maxAttempts: 2 },
+            },
+            devices: [{
+              deviceId: "emulator-5554",
+              platform: "android",
+              recoveryEligibility: { eligible: true, action: "restart" },
+            }],
           })
         }
       ]
@@ -1099,7 +1105,13 @@ describe("Daemon manager available-devices", () => {
       availableDevices: 2,
       totalDevices: 3,
       assignedDevices: 1,
-      errorDevices: 0
+      errorDevices: 0,
+      recoveryPolicy: { onLoss: true, maxAttempts: 2 },
+      devices: [{
+        deviceId: "emulator-5554",
+        platform: "android",
+        recoveryEligibility: { eligible: true, action: "restart" },
+      }],
     }));
   });
 
@@ -1118,7 +1130,13 @@ describe("Daemon manager available-devices", () => {
           assigned: 2,
           error: 1,
           total: 4
-        })
+        }),
+        getRecoveryPolicy: () => ({ onLoss: false, maxAttempts: 2 }),
+        getAllDevices: () => [{
+          id: "physical-ios-device",
+          platform: "ios",
+        }],
+        getRecoveryEligibility: () => ({ eligible: false, reason: "unsupported-platform" }),
       } as any),
       getSessionManager: () => ({
         getSession: () => null,
@@ -1140,7 +1158,13 @@ describe("Daemon manager available-devices", () => {
       availableDevices: 1,
       totalDevices: 4,
       assignedDevices: 2,
-      errorDevices: 1
+      errorDevices: 1,
+      recoveryPolicy: { onLoss: false, maxAttempts: 2 },
+      devices: [{
+        deviceId: "physical-ios-device",
+        platform: "ios",
+        recoveryEligibility: { eligible: false, reason: "unsupported-platform" },
+      }],
     }));
   });
 });

--- a/test/daemon/socketServerMcpForwardSerialization.test.ts
+++ b/test/daemon/socketServerMcpForwardSerialization.test.ts
@@ -824,6 +824,36 @@ describe("UnixSocketServer MCP forward serialization", () => {
     })]);
   });
 
+  test("routes a bound resources/read call through its session-scoped MCP client", async () => {
+    sessionDevices.set("session-a", "device-a");
+    const clientBindings: Array<string | undefined> = [];
+    server.mcpClientFactory = async boundSessionUuid => {
+      clientBindings.push(boundSessionUuid);
+      return {
+        listTools: async () => ({ tools: [] }),
+        callTool: async () => ({ content: [] }),
+        listResources: async () => ({ resources: [] }),
+        readResource: async () => ({ contents: [{ uri: "automobile:devices/booted", text: "[]" }] }),
+        listResourceTemplates: async () => ({ resourceTemplates: [] }),
+        close: async () => {},
+      };
+    };
+
+    const response = await sendRequest(socketPath, {
+      id: randomUUID(),
+      type: "mcp_request",
+      method: "resources/read",
+      params: {
+        uri: "automobile:devices/booted",
+        sessionUuid: "session-a",
+        [DAEMON_BOUND_SESSION_PARAM]: "session-a",
+      },
+    });
+
+    expect(response.success).toBe(true);
+    expect(clientBindings).toEqual(["session-a"]);
+  });
+
   test("retains a bound socket transport past the idle client deadline", async () => {
     sessionDevices.set("session-a", "device-a");
     let closeCalls = 0;

--- a/test/daemon/socketServerMcpForwardSerialization.test.ts
+++ b/test/daemon/socketServerMcpForwardSerialization.test.ts
@@ -6,7 +6,10 @@ import { unlink } from "node:fs/promises";
 import { tmpdir } from "node:os";
 import { join } from "node:path";
 import { UnixSocketServer } from "../../src/daemon/socketServer";
-import { DAEMON_CAPABILITY_PROFILE_PARAM } from "../../src/daemon/constants";
+import {
+  DAEMON_BOUND_SESSION_PARAM,
+  DAEMON_CAPABILITY_PROFILE_PARAM,
+} from "../../src/daemon/constants";
 import { FakeTimer } from "../fakes/FakeTimer";
 import type { DaemonRequest, DaemonResponse } from "../../src/daemon/types";
 import type { DeviceLabelMap, Session } from "../../src/daemon/sessionManager";
@@ -787,6 +790,38 @@ describe("UnixSocketServer MCP forward serialization", () => {
       firstSocket.close();
       secondSocket.close();
     }
+  });
+
+  test("does not recreate a released session from an implicit proxy binding", async () => {
+    const clientBindings: Array<string | undefined> = [];
+    const forwardedArguments: Array<Record<string, unknown>> = [];
+    server.mcpClientFactory = async boundSessionUuid => {
+      clientBindings.push(boundSessionUuid);
+      return {
+        listTools: async () => ({ tools: [] }),
+        callTool: async (...args: unknown[]) => {
+          const request = args[0] as { arguments?: Record<string, unknown> };
+          forwardedArguments.push(request.arguments ?? {});
+          return { content: [] };
+        },
+        listResources: async () => ({ resources: [] }),
+        readResource: async () => ({ contents: [] }),
+        listResourceTemplates: async () => ({ resourceTemplates: [] }),
+        close: async () => {},
+      };
+    };
+
+    const response = await sendToolsCallWithArgs(socketPath, "observe", {
+      sessionUuid: "released-session",
+      [DAEMON_BOUND_SESSION_PARAM]: "released-session",
+    });
+
+    expect(response.success).toBe(true);
+    expect(clientBindings).toEqual([undefined]);
+    expect(forwardedArguments).toEqual([expect.not.objectContaining({
+      sessionUuid: expect.anything(),
+      [DAEMON_BOUND_SESSION_PARAM]: expect.anything(),
+    })]);
   });
 
   test("retains a bound socket transport past the idle client deadline", async () => {

--- a/test/fakes/FakeDaemonClient.ts
+++ b/test/fakes/FakeDaemonClient.ts
@@ -21,6 +21,7 @@ export interface FakeDaemonClientOptions {
 export class FakeDaemonClient implements DaemonClientLike {
   readonly callToolCalls: Array<{ toolName: string; params: Record<string, any> }> = [];
   readonly readResourceCalls: string[] = [];
+  readonly readResourceParams: Array<Record<string, any>> = [];
   readonly callDaemonMethodCalls: Array<{ method: string; params: Record<string, any> }> = [];
   private connected = false;
   private toolResult: any;
@@ -62,8 +63,11 @@ export class FakeDaemonClient implements DaemonClientLike {
     return this.toolResult;
   }
 
-  async readResource(uri: string): Promise<any> {
+  async readResource(uri: string, params: Record<string, any> = {}): Promise<any> {
     this.readResourceCalls.push(uri);
+    const recordedParams = { ...params };
+    delete recordedParams[DAEMON_BOUND_SESSION_PARAM];
+    this.readResourceParams.push(recordedParams);
     return this.resourceResult;
   }
 

--- a/test/fakes/FakeDaemonClient.ts
+++ b/test/fakes/FakeDaemonClient.ts
@@ -1,5 +1,6 @@
 import type { DaemonClientLike } from "../../src/daemon/client";
 import { DaemonUnavailableError } from "../../src/daemon/client";
+import { DAEMON_BOUND_SESSION_PARAM } from "../../src/daemon/constants";
 import type { DaemonNotification } from "../../src/daemon/types";
 
 export interface FakeDaemonClientOptions {
@@ -52,7 +53,9 @@ export class FakeDaemonClient implements DaemonClientLike {
   }
 
   async callTool(toolName: string, params: Record<string, any>): Promise<any> {
-    this.callToolCalls.push({ toolName, params });
+    const recordedParams = { ...params };
+    delete recordedParams[DAEMON_BOUND_SESSION_PARAM];
+    this.callToolCalls.push({ toolName, params: recordedParams });
     if (this.onCallTool) {
       await this.onCallTool(toolName, params);
     }
@@ -65,7 +68,9 @@ export class FakeDaemonClient implements DaemonClientLike {
   }
 
   async callDaemonMethod(method: string, params: Record<string, any>): Promise<any> {
-    this.callDaemonMethodCalls.push({ method, params });
+    const recordedParams = { ...params };
+    delete recordedParams[DAEMON_BOUND_SESSION_PARAM];
+    this.callDaemonMethodCalls.push({ method, params: recordedParams });
     if (this.onCallDaemonMethod) {
       await this.onCallDaemonMethod(method, params);
     }

--- a/test/plan/planExecutorExecuteStepRefactor.test.ts
+++ b/test/plan/planExecutorExecuteStepRefactor.test.ts
@@ -8,6 +8,7 @@ import { createStructuredToolResponse } from "../../src/utils/toolUtils";
 import { INTERNAL_NO_DIFF_PARAM } from "../../src/server/internalToolCall";
 import { OPERATION_CANCELLED_MESSAGE } from "../../src/utils/constants";
 import { defaultTimer } from "../../src/utils/SystemTimer";
+import { DeviceLostError } from "../../src/server/deviceLossOutcome";
 import type { SessionToolProfileService } from "../../src/features/toolCapabilities/SessionToolProfileService";
 
 interface CapturedCall {
@@ -147,6 +148,38 @@ describe("PlanExecutor executeStep refactor", () => {
     expect(result.failedStep?.error).toBe("button missing");
     expect(result.failedStep?.failureObservation?.visibleTextsSample).toContain("Failure Screen");
     expect(result.perDeviceResults?.get("device-a")?.failedStep?.failureObservation).toBeDefined();
+  });
+
+  test("propagates confirmed device loss through sequential and parallel plans", async () => {
+    ToolRegistry.register(
+      "executeStepRefactorDeviceLost",
+      "loses its device",
+      z.object({
+        platform: z.string().optional(),
+        device: z.string().optional(),
+        deviceId: z.string().optional(),
+        sessionUuid: z.string().optional(),
+      }),
+      mock(async () => {
+        throw new DeviceLostError("emulator-5554", "device-disconnected:emulator-5554");
+      }),
+    );
+    (ToolRegistry.getTool("executeStepRefactorDeviceLost") as { requiresDevice: boolean }).requiresDevice = true;
+
+    await expect(
+      planExecutor.executePlan({
+        name: "sequential-device-lost",
+        steps: [{ tool: "executeStepRefactorDeviceLost", params: {} }],
+      }, 0, "android", "emulator-5554", "session-a"),
+    ).rejects.toThrow("device-disconnected:emulator-5554");
+
+    await expect(
+      planExecutor.executePlan({
+        name: "parallel-device-lost",
+        devices: ["device-a"],
+        steps: [{ tool: "executeStepRefactorDeviceLost", params: { device: "device-a" } }],
+      }, 0, "android", "emulator-5554", "session-a"),
+    ).rejects.toThrow("device-disconnected:emulator-5554");
   });
 
   test("multi-device immediate abort uses AbortSignal.any and cancels sibling tracks", async () => {

--- a/test/server/deviceLossOutcome.test.ts
+++ b/test/server/deviceLossOutcome.test.ts
@@ -1,0 +1,20 @@
+import { describe, expect, test } from "bun:test";
+import {
+  DEVICE_LOSS_OUTCOME_CODE,
+  DeviceLostError,
+  deviceLossOutcomeFromError,
+} from "../../src/server/deviceLossOutcome";
+
+describe("device-loss outcome", () => {
+  test("makes confirmed device loss distinguishable from an ordinary tool failure", () => {
+    const error = new DeviceLostError("emulator-5554", "device-disconnected:emulator-5554");
+
+    expect(deviceLossOutcomeFromError(error, "session-a")).toEqual({
+      code: DEVICE_LOSS_OUTCOME_CODE,
+      deviceId: "emulator-5554",
+      sessionUuid: "session-a",
+      reason: "confirmed-unavailable",
+    });
+    expect(deviceLossOutcomeFromError(new Error("tap failed"), "session-a")).toBeUndefined();
+  });
+});

--- a/test/server/deviceLossOutcomeWire.test.ts
+++ b/test/server/deviceLossOutcomeWire.test.ts
@@ -1,0 +1,83 @@
+import { afterEach, describe, expect, test } from "bun:test";
+import { z } from "zod";
+import type { BootedDevice } from "../../src/models";
+import { DeviceLostError } from "../../src/server/deviceLossOutcome";
+import { ToolRegistry } from "../../src/server/toolRegistry";
+import { McpTestFixture } from "../fixtures/mcpTestFixture";
+
+describe("device loss MCP outcome", () => {
+  const toolName = "__device_lost_wire_probe__";
+  const device: BootedDevice = {
+    deviceId: "emulator-5554",
+    name: "Pixel",
+    platform: "android",
+  };
+  let restorePipelineOverrides: (() => void) | undefined;
+  let fixture: McpTestFixture | undefined;
+
+  afterEach(async () => {
+    if (fixture) {
+      await fixture.teardown();
+      fixture = undefined;
+    }
+    restorePipelineOverrides?.();
+    restorePipelineOverrides = undefined;
+    ToolRegistry.unregister(toolName);
+  });
+
+  test("returns a typed device_lost result for an aborted device-aware call", async () => {
+    restorePipelineOverrides = ToolRegistry.setPipelineOverridesForTesting({
+      executionTargetResolver: {
+        async resolveExecutionTarget(input) {
+          return {
+            args: input.args,
+            baseSessionUuid: "device-session-a",
+            device,
+            internalCall: false,
+            sessionUuid: "device-session-a",
+            shouldResolveDevice: true,
+          };
+        },
+      },
+      auditRunner: {
+        async run(input) {
+          return await input.handler(input.device, input.args, input.progress, input.signal);
+        },
+      },
+      afterToolCall: {
+        async handle() {
+          throw new Error("device-loss probe should not finalize");
+        },
+      },
+      planLifecycleManager: {
+        async afterExecution() {},
+      },
+    });
+    ToolRegistry.registerDeviceAware(
+      toolName,
+      "device loss wire probe",
+      z.object({}),
+      async () => {
+        throw new DeviceLostError("emulator-5554", "device-disconnected:emulator-5554");
+      },
+    );
+    fixture = new McpTestFixture({
+      sessionContext: {
+        sessionId: "transport-a",
+        initialSessionToolBinding: "device-session-a",
+      },
+    });
+    await fixture.setup();
+
+    const result: any = await fixture.client.callTool({ name: toolName, arguments: {} });
+
+    expect(result.isError).toBe(true);
+    expect(result.structuredContent).toEqual({
+      code: "device_lost",
+      deviceId: "emulator-5554",
+      sessionUuid: "device-session-a",
+      reason: "confirmed-unavailable",
+    });
+    expect(JSON.parse(result.content[0].text)).toEqual(result.structuredContent);
+  });
+});

--- a/test/server/deviceLossOutcomeWire.test.ts
+++ b/test/server/deviceLossOutcomeWire.test.ts
@@ -1,7 +1,8 @@
 import { afterEach, describe, expect, test } from "bun:test";
 import { z } from "zod";
 import type { BootedDevice } from "../../src/models";
-import { DeviceLostError } from "../../src/server/deviceLossOutcome";
+import { ActionableError } from "../../src/models";
+import { DeviceLostError, rememberDeviceLossAbort } from "../../src/server/deviceLossOutcome";
 import { ToolRegistry } from "../../src/server/toolRegistry";
 import { McpTestFixture } from "../fixtures/mcpTestFixture";
 
@@ -25,7 +26,7 @@ describe("device loss MCP outcome", () => {
     ToolRegistry.unregister(toolName);
   });
 
-  test("returns a typed device_lost result for an aborted device-aware call", async () => {
+  test("returns schema-independent device_lost text for an aborted device-aware call", async () => {
     restorePipelineOverrides = ToolRegistry.setPipelineOverridesForTesting({
       executionTargetResolver: {
         async resolveExecutionTarget(input) {
@@ -60,6 +61,11 @@ describe("device loss MCP outcome", () => {
       async () => {
         throw new DeviceLostError("emulator-5554", "device-disconnected:emulator-5554");
       },
+      {
+        outputSchema: z.object({
+          success: z.boolean(),
+        }),
+      },
     );
     fixture = new McpTestFixture({
       sessionContext: {
@@ -72,12 +78,76 @@ describe("device loss MCP outcome", () => {
     const result: any = await fixture.client.callTool({ name: toolName, arguments: {} });
 
     expect(result.isError).toBe(true);
-    expect(result.structuredContent).toEqual({
+    expect(result.structuredContent).toBeUndefined();
+    expect(JSON.parse(result.content[0].text)).toEqual({
       code: "device_lost",
       deviceId: "emulator-5554",
       sessionUuid: "device-session-a",
       reason: "confirmed-unavailable",
     });
-    expect(JSON.parse(result.content[0].text)).toEqual(result.structuredContent);
+  });
+
+  test("recovers device loss from an abort signal when a handler wraps cancellation", async () => {
+    restorePipelineOverrides = ToolRegistry.setPipelineOverridesForTesting({
+      executionTargetResolver: {
+        async resolveExecutionTarget(input) {
+          return {
+            args: input.args,
+            baseSessionUuid: "device-session-a",
+            device,
+            internalCall: false,
+            sessionUuid: "device-session-a",
+            shouldResolveDevice: true,
+          };
+        },
+      },
+      auditRunner: {
+        async run(input) {
+          return await input.handler(input.device, input.args, input.progress, input.signal);
+        },
+      },
+      afterToolCall: {
+        async handle() {
+          throw new Error("wrapped device-loss probe should not finalize");
+        },
+      },
+      planLifecycleManager: {
+        async afterExecution() {},
+      },
+    });
+    ToolRegistry.registerDeviceAware(
+      toolName,
+      "wrapped device loss wire probe",
+      z.object({}),
+      async (_device, _args, _progress, signal) => {
+        rememberDeviceLossAbort(
+          signal!,
+          new DeviceLostError("emulator-5554", "device-disconnected:emulator-5554"),
+        );
+        throw new ActionableError("Failed to install app: operation cancelled");
+      },
+      {
+        outputSchema: z.object({
+          success: z.boolean(),
+        }),
+      },
+    );
+    fixture = new McpTestFixture({
+      sessionContext: {
+        sessionId: "transport-a",
+        initialSessionToolBinding: "device-session-a",
+      },
+    });
+    await fixture.setup();
+
+    const result: any = await fixture.client.callTool({ name: toolName, arguments: {} });
+
+    expect(result.isError).toBe(true);
+    expect(result.structuredContent).toBeUndefined();
+    expect(JSON.parse(result.content[0].text)).toMatchObject({
+      code: "device_lost",
+      deviceId: "emulator-5554",
+      sessionUuid: "device-session-a",
+    });
   });
 });

--- a/test/server/executionTracker.test.ts
+++ b/test/server/executionTracker.test.ts
@@ -1,5 +1,6 @@
 import { describe, expect, test } from "bun:test";
 import { ExecutionTracker, type ExecutionScopeOptions } from "../../src/server/executionTracker";
+import { DeviceLostError } from "../../src/server/deviceLossOutcome";
 import { FakeIdGenerator } from "../fakes/FakeIdGenerator";
 import { FakeTimer } from "../fakes/FakeTimer";
 
@@ -20,7 +21,7 @@ describe("ExecutionTracker", function() {
   // (a Bun `AbortSignal.reason` observability quirk, not a logic race — the abort is dispatched
   // synchronously). We assert the tracker's own `cancelReason`, recorded synchronously at
   // cancellation, which is deterministic across runtimes, plus that the signal did abort.
-  test("records the custom cancellation reason for a device-disconnected cancel", async function() {
+  test("records a typed device-loss reason for a device-disconnected cancel", async function() {
     const tracker = new ExecutionTracker(new FakeTimer(), new FakeIdGenerator(["execution-1"]));
     const execution = tracker.startExecution("tapOn", undefined, "session-uuid");
 
@@ -31,7 +32,11 @@ describe("ExecutionTracker", function() {
 
     expect(cancelled).toBe(1);
     expect(execution.abortController.signal.aborted).toBe(true);
-    expect(execution.cancelReason).toEqual(new Error("device-disconnected:emulator-5554"));
+    expect(execution.cancelReason).toBeInstanceOf(DeviceLostError);
+    expect(execution.cancelReason).toMatchObject({
+      deviceId: "emulator-5554",
+      message: "device-disconnected:emulator-5554",
+    });
   });
 
   test("keeps transport cancellation reasons log-only", async function() {

--- a/test/server/planTools.executePlanThrow.test.ts
+++ b/test/server/planTools.executePlanThrow.test.ts
@@ -1,6 +1,7 @@
 import { describe, expect, test, beforeAll, mock } from "bun:test";
 import { registerPlanTools } from "../../src/server/planTools";
 import { ToolRegistry } from "../../src/server/toolRegistry";
+import { DeviceLostError } from "../../src/server/deviceLossOutcome";
 
 // Mock planUtils so executePlan throws while importPlanFromYaml works normally.
 // This is safe because no other test imports from "../../src/utils/planUtils" via
@@ -78,5 +79,20 @@ describe("executePlanTool — executePlan throws", () => {
 
     // Verify the response contains the specific error message from executePlan
     expect(payload.error).toContain("device disconnected");
+  });
+
+  test("rethrows confirmed device loss for the MCP boundary", async () => {
+    mockExecutePlan.mockImplementationOnce(() =>
+      Promise.reject(new DeviceLostError("emulator-5554", "device-disconnected:emulator-5554"))
+    );
+    const tool = ToolRegistry.getTool("executePlan");
+    expect(tool).toBeDefined();
+
+    await expect(tool!.deviceAwareHandler!(mockDevice, {
+      planContent: VALID_PLAN_YAML,
+      startStep: 0,
+      platform: "android",
+      deviceAllocationTimeoutMs: 5000,
+    })).rejects.toThrow("device-disconnected:emulator-5554");
   });
 });

--- a/test/server/resources/bootedDevices.test.ts
+++ b/test/server/resources/bootedDevices.test.ts
@@ -359,7 +359,8 @@ describe("MCP Booted Device Resources", () => {
         idle: 1,
         assigned: 1,
         error: 0,
-        total: 2
+        total: 2,
+        recoveryPolicy: { onLoss: false, maxAttempts: 2 }
       });
 
       const assignedDevice = data.devices.find(device => device.assignedSession === sessionId);
@@ -413,7 +414,8 @@ describe("MCP Booted Device Resources", () => {
         idle: 0,
         assigned: 0,
         error: 0,
-        total: 0
+        total: 0,
+        recoveryPolicy: { onLoss: false, maxAttempts: 2 }
       });
 
       sessionManager.stopCleanupTimer();
@@ -470,7 +472,8 @@ describe("MCP Booted Device Resources", () => {
         idle: 0,
         assigned: 1,
         error: 0,
-        total: 1
+        total: 1,
+        recoveryPolicy: { onLoss: false, maxAttempts: 2 }
       });
 
       sessionManager.stopCleanupTimer();

--- a/test/server/sessionToolDiscovery.test.ts
+++ b/test/server/sessionToolDiscovery.test.ts
@@ -46,8 +46,12 @@ describe("session-scoped tool discovery", () => {
     expect(binding.effectiveSessionUuid("recreated-transport")).toBe("device-session-a");
     expect(binding.bind("recreated-transport", "device-session-a")).toBe(true);
     expect(binding.bind("recreated-transport", "device-session-a")).toBe(false);
-    expect(binding.bind("recreated-transport", "device-session-b")).toBe(true);
-    expect(binding.effectiveSessionUuid("recreated-transport")).toBe("device-session-b");
+    expect(binding.bind("recreated-transport", "device-session-b")).toBe(false);
+    expect(() => binding.effectiveSessionUuid(
+      "recreated-transport",
+      { sessionUuid: "device-session-b" },
+    )).toThrow("MCP connection is bound");
+    expect(binding.effectiveSessionUuid("recreated-transport")).toBe("device-session-a");
   });
 
   test.each(["", "   "])("uses the bound session when an explicit session UUID is %p", sessionUuid => {

--- a/test/utils/throwIfAborted.test.ts
+++ b/test/utils/throwIfAborted.test.ts
@@ -1,12 +1,21 @@
 import { describe, expect, test } from "bun:test";
 import { throwIfAborted } from "../../src/utils/toolUtils";
 import { OPERATION_CANCELLED_MESSAGE } from "../../src/utils/constants";
+import { DeviceLostError } from "../../src/server/deviceLossOutcome";
 
 describe("throwIfAborted", () => {
   test("throws the cancellation error when the signal is already aborted", () => {
     const controller = new AbortController();
     controller.abort();
     expect(() => throwIfAborted(controller.signal)).toThrow(OPERATION_CANCELLED_MESSAGE);
+  });
+
+  test("preserves the typed device-loss cancellation reason", () => {
+    const controller = new AbortController();
+    const deviceLoss = new DeviceLostError("emulator-5554", "device-disconnected:emulator-5554");
+    controller.abort(deviceLoss);
+
+    expect(() => throwIfAborted(controller.signal)).toThrow(deviceLoss);
   });
 
   test("does not throw when the signal is not aborted", () => {

--- a/test/utils/throwIfAborted.test.ts
+++ b/test/utils/throwIfAborted.test.ts
@@ -2,6 +2,9 @@ import { describe, expect, test } from "bun:test";
 import { throwIfAborted } from "../../src/utils/toolUtils";
 import { OPERATION_CANCELLED_MESSAGE } from "../../src/utils/constants";
 import { DeviceLostError } from "../../src/server/deviceLossOutcome";
+import { ExecutionTracker } from "../../src/server/executionTracker";
+import { FakeIdGenerator } from "../fakes/FakeIdGenerator";
+import { FakeTimer } from "../fakes/FakeTimer";
 
 describe("throwIfAborted", () => {
   test("throws the cancellation error when the signal is already aborted", () => {
@@ -16,6 +19,24 @@ describe("throwIfAborted", () => {
     controller.abort(deviceLoss);
 
     expect(() => throwIfAborted(controller.signal)).toThrow(deviceLoss);
+  });
+
+  test("preserves tracked device loss when AbortSignal.reason is unavailable", async () => {
+    const tracker = new ExecutionTracker(new FakeTimer(), new FakeIdGenerator(["execution-1"]));
+    const execution = tracker.startExecution("observe", undefined, "session-a");
+    await tracker.cancelSessionUuidExecutions("session-a", "device-disconnected:emulator-5554");
+    Object.defineProperty(execution.abortController.signal, "reason", {
+      configurable: true,
+      value: undefined,
+    });
+
+    let thrown: unknown;
+    try {
+      throwIfAborted(execution.abortController.signal);
+    } catch (error) {
+      thrown = error;
+    }
+    expect(thrown).toBeInstanceOf(DeviceLostError);
   });
 
   test("does not throw when the signal is not aborted", () => {


### PR DESCRIPTION
## Summary

Bind daemon MCP connections to a known device-pool session before discovery. `tools/list`, resource reads, and device-aware calls retain that connection-local route across daemon transport recreation, while released sessions cannot be reused by later sessionless calls. `setActiveDevice` remains a compatibility API.

Add startup-fixed managed-device recovery policy with strict parsing, bounded attempts, warning logs, daemon status visibility, and eligibility restricted to AutoMobile-owned Android virtual devices. A confirmed device loss cancels and releases the active session, returning a schema-independent `device_lost` MCP result instead of an application or tool failure.

## Linked Issue

Closes [#4979](https://github.com/kaeawc/auto-mobile/issues/4979)

## Validation

- [x] `bun run lint`
- [x] `bun run turbo:validate` passes: 12,615 passed, 13 device-dependent skipped
- [x] `bun run typecheck` reports no new errors: 196 existing baseline errors
- [x] Focused daemon routing, device-loss, and device-pool suites pass
- [x] Unit coverage uses repository fakes and `FakeTimer`; no new dependency added

## Device Verification

Not applicable: the supported recovery path is covered through deterministic daemon and device-pool fakes.
