### PR TITLE
iOS: require exact daemon package pins

### DIFF
--- a/ios/XCTestRunner/Sources/XCTestRunner/AutoMobileEnvironment.swift
+++ b/ios/XCTestRunner/Sources/XCTestRunner/AutoMobileEnvironment.swift
@@ -99,6 +99,7 @@ public enum DaemonStartupResult: Equatable {
     case ready
     case executableNotFound
     case packageRunnerNotFound
+    case invalidPackageVersion(String)
     case launchFailed
     case packageLaunchFailed(stderr: String)
     case launchTimeout
@@ -119,6 +120,9 @@ public enum DaemonStartupResult: Equatable {
         case .packageRunnerNotFound:
             return "Failed to start AutoMobile Daemon: a pinned daemon requires `bunx` or `npx`, but neither "
                 + "was found on PATH. Install Bun or Node.js with npm/npx, then retry."
+        case let .invalidPackageVersion(version):
+            return "Failed to start AutoMobile Daemon: `\(version)` is not an exact package version. "
+                + "Set AUTOMOBILE_DAEMON_PACKAGE_VERSION or AUTOMOBILE_VERSION to MAJOR.MINOR.PATCH, then retry."
         case .launchFailed:
             return "Failed to start AutoMobile Daemon: `auto-mobile --daemon start` exited non-zero. "
                 + "Check the daemon logs."
@@ -170,6 +174,7 @@ public enum DaemonManager {
         case launched
         case executableNotFound
         case packageRunnerNotFound
+        case invalidPackageVersion(String)
         case failed(stderr: String? = nil)
         case packageFailed(stderr: String? = nil)
         case timedOut
@@ -179,6 +184,7 @@ public enum DaemonManager {
         case process(executable: String, arguments: [String])
         case executableNotFound
         case packageRunnerNotFound
+        case invalidPackageVersion(String)
     }
 
     /// Injectable subprocess boundary so launcher timeouts are deterministic in unit tests.
@@ -361,6 +367,8 @@ public enum DaemonManager {
             return .executableNotFound
         case .packageRunnerNotFound:
             return .packageRunnerNotFound
+        case let .invalidPackageVersion(version):
+            return .invalidPackageVersion(version)
         case let .failed(stderr):
             return failureResult(stderr: stderr, packageRunner: false)
         case let .packageFailed(stderr):
@@ -428,6 +436,9 @@ public enum DaemonManager {
         case .packageRunnerNotFound:
             PerfTimer.log("runDaemonSubcommand: ERROR - pinned daemon package runner not found")
             return .packageRunnerNotFound
+        case let .invalidPackageVersion(version):
+            PerfTimer.log("runDaemonSubcommand: ERROR - invalid pinned daemon package version: \(version)")
+            return .invalidPackageVersion(version)
         }
 
         let hasLocalBuild = localEntry != nil && runtime != nil
@@ -525,7 +536,8 @@ public enum DaemonManager {
             PerfTimer.log("runDaemonSubcommand(\(subcommand)): launching local build at \(localEntry)")
             return .process(executable: runtime, arguments: [localEntry, "--daemon", subcommand])
         }
-        if let packageSpecifier = resolveDaemonPackageSpecifier(packageVersion) {
+        switch daemonPackageVersionResolution(packageVersion) {
+        case let .valid(packageSpecifier):
             guard let packageRunner else {
                 return .packageRunnerNotFound
             }
@@ -537,6 +549,10 @@ public enum DaemonManager {
                     subcommand: subcommand
                 )
             )
+        case let .invalid(version):
+            return .invalidPackageVersion(version)
+        case .absent:
+            break
         }
         guard let autoMobilePath else {
             return .executableNotFound
@@ -577,17 +593,30 @@ public enum DaemonManager {
         return automobileVersion?.isEmpty == false ? automobileVersion : nil
     }
 
-    private static func resolveDaemonPackageSpecifier(_ packageVersion: String?) -> String? {
-        guard let version = packageVersion?.trimmingCharacters(in: .whitespaces),
-              !version.isEmpty,
-              version.range(
+    private enum DaemonPackageVersionResolution {
+        case absent
+        case valid(String)
+        case invalid(String)
+    }
+
+    private static func daemonPackageVersionResolution(_ packageVersion: String?) -> DaemonPackageVersionResolution {
+        guard let version = packageVersion?.trimmingCharacters(in: .whitespaces), !version.isEmpty else {
+            return .absent
+        }
+        guard version.range(
                   of: "^[0-9]+\\.[0-9]+\\.[0-9]+(?:-[0-9A-Za-z-]+(?:\\.[0-9A-Za-z-]+)*)?(?:\\+[0-9A-Za-z-]+(?:\\.[0-9A-Za-z-]+)*)?$",
                   options: .regularExpression
-              ) != nil
-        else {
+              ) != nil else {
+            return .invalid(version)
+        }
+        return .valid("\(packageName)@\(version)")
+    }
+
+    private static func resolveDaemonPackageSpecifier(_ packageVersion: String?) -> String? {
+        guard case let .valid(specifier) = daemonPackageVersionResolution(packageVersion) else {
             return nil
         }
-        return "\(packageName)@\(version)"
+        return specifier
     }
 
     private static func packageDaemonArguments(

--- a/ios/XCTestRunner/Sources/XCTestRunner/AutoMobileEnvironment.swift
+++ b/ios/XCTestRunner/Sources/XCTestRunner/AutoMobileEnvironment.swift
@@ -580,8 +580,10 @@ public enum DaemonManager {
     private static func resolveDaemonPackageSpecifier(_ packageVersion: String?) -> String? {
         guard let version = packageVersion?.trimmingCharacters(in: .whitespaces),
               !version.isEmpty,
-              version.lowercased() != "latest",
-              version.lowercased() != "unknown"
+              version.range(
+                  of: "^[0-9]+\\.[0-9]+\\.[0-9]+(?:-[0-9A-Za-z-]+(?:\\.[0-9A-Za-z-]+)*)?(?:\\+[0-9A-Za-z-]+(?:\\.[0-9A-Za-z-]+)*)?$",
+                  options: .regularExpression
+              ) != nil
         else {
             return nil
         }

--- a/ios/XCTestRunner/Sources/XCTestRunner/AutoMobileEnvironment.swift
+++ b/ios/XCTestRunner/Sources/XCTestRunner/AutoMobileEnvironment.swift
@@ -842,6 +842,15 @@ public enum DaemonManager {
         -> DaemonStartupResult
     {
         let effectiveRepoRoot = resolveDaemonRepoRoot(repoRoot, inferredRepoRoot: inferredRepoRoot)
+        let hasLocalBuild = resolveRepoRootDaemonEntryScript(effectiveRepoRoot) != nil
+        if !hasLocalBuild,
+           case let .invalid(version) = daemonPackageVersionResolution(
+               resolveDaemonPackageVersion(environment: environment)
+           )
+        {
+            PerfTimer.log("ensureDaemonRunning: invalid pinned daemon package version: \(version)")
+            return .invalidPackageVersion(version)
+        }
         let launcherTimeoutSeconds = daemonLauncherTimeoutSeconds(
             subcommand: "restart",
             readinessTimeoutSeconds: timeoutSeconds,

--- a/ios/XCTestRunner/Sources/XCTestRunnerTests/AutoMobileVersionTests.swift
+++ b/ios/XCTestRunner/Sources/XCTestRunnerTests/AutoMobileVersionTests.swift
@@ -205,10 +205,32 @@ final class AutoMobileVersionTests: XCTestCase {
         ), .packageRunnerNotFound)
     }
 
+    func testDaemonLaunchFailsClosedForInvalidPackagePins() {
+        for (environment, expectedVersion) in [
+            (["AUTOMOBILE_DAEMON_PACKAGE_VERSION": "next"], "next"),
+            (["AUTOMOBILE_VERSION": "^0.0.40"], "^0.0.40"),
+        ] {
+            let packageVersion = DaemonManager.resolveDaemonPackageVersion(environment: environment)
+            XCTAssertEqual(packageVersion, expectedVersion)
+            XCTAssertEqual(DaemonManager.selectDaemonLaunch(
+                subcommand: "start",
+                localEntry: nil,
+                runtime: nil,
+                packageRunner: "/opt/homebrew/bin/bunx",
+                autoMobilePath: "/usr/local/bin/auto-mobile",
+                packageVersion: packageVersion
+            ), .invalidPackageVersion(expectedVersion))
+        }
+    }
+
     func testStartupFailureNamesMissingPackageRunnerAndLaunchTimeout() {
         XCTAssertEqual(
             DaemonManager.startupFailure(for: .packageRunnerNotFound),
             .packageRunnerNotFound
+        )
+        XCTAssertEqual(
+            DaemonManager.startupFailure(for: .invalidPackageVersion("next")),
+            .invalidPackageVersion("next")
         )
         XCTAssertEqual(
             DaemonManager.startupFailure(for: .timedOut),
@@ -216,6 +238,7 @@ final class AutoMobileVersionTests: XCTestCase {
         )
         XCTAssertTrue(DaemonStartupResult.packageRunnerNotFound.diagnosticMessage.contains("bunx"))
         XCTAssertTrue(DaemonStartupResult.packageRunnerNotFound.diagnosticMessage.contains("npx"))
+        XCTAssertTrue(DaemonStartupResult.invalidPackageVersion("next").diagnosticMessage.contains("exact package version"))
         XCTAssertTrue(DaemonStartupResult.launchTimeout.diagnosticMessage.contains("timed out"))
         XCTAssertEqual(
             DaemonManager.startupFailure(for: DaemonManager.classifyDaemonSubcommandOutcome(

--- a/ios/XCTestRunner/Sources/XCTestRunnerTests/AutoMobileVersionTests.swift
+++ b/ios/XCTestRunner/Sources/XCTestRunnerTests/AutoMobileVersionTests.swift
@@ -542,6 +542,31 @@ final class AutoMobileVersionTests: XCTestCase {
         XCTAssertEqual(result, .ready)
         XCTAssertTrue(runtime.subcommands.isEmpty)
     }
+
+    func testEnsureDaemonRunningFailsClosedForInvalidPinsBeforeDaemonReuse() {
+        for (environment, expectedVersion) in [
+            (["AUTOMOBILE_DAEMON_PACKAGE_VERSION": "next"], "next"),
+            (["AUTOMOBILE_VERSION": "^0.0.40"], "^0.0.40"),
+        ] {
+            let runtime = FakeDaemonRuntime(
+                daemonVersion: AutoMobileVersion.current,
+                daemonBuildId: nil,
+                daemonEntryScript: nil,
+                buildIdAfterRestart: ""
+            )
+
+            let result = DaemonManager.ensureDaemonRunningResult(
+                repoRoot: "",
+                timeoutSeconds: 0,
+                runtime: runtime,
+                callerAssetVersion: nil,
+                environment: environment
+            )
+
+            XCTAssertEqual(result, .invalidPackageVersion(expectedVersion))
+            XCTAssertTrue(runtime.subcommands.isEmpty)
+        }
+    }
 }
 
 private final class FakeDaemonSubcommandLauncher: DaemonManager.DaemonSubcommandLauncher {

--- a/ios/XCTestRunner/Sources/XCTestRunnerTests/AutoMobileVersionTests.swift
+++ b/ios/XCTestRunner/Sources/XCTestRunnerTests/AutoMobileVersionTests.swift
@@ -166,15 +166,17 @@ final class AutoMobileVersionTests: XCTestCase {
     }
 
     func testPinnedDaemonPackageCommandRejectsFloatingOrUnknownPins() {
-        XCTAssertNil(DaemonManager.buildPackageDaemonCommand(
+        for packageVersion in ["latest", "unknown", "next", "0.0.x", "^0.0.40", "~0.0.40", ">=0.0.40"] {
+            XCTAssertNil(DaemonManager.buildPackageDaemonCommand(
+                packageRunner: "/opt/homebrew/bin/bunx",
+                subcommand: "start",
+                packageVersion: packageVersion
+            ), "\(packageVersion) must not be accepted as a hermetic package pin")
+        }
+        XCTAssertNotNil(DaemonManager.buildPackageDaemonCommand(
             packageRunner: "/opt/homebrew/bin/bunx",
             subcommand: "start",
-            packageVersion: "latest"
-        ))
-        XCTAssertNil(DaemonManager.buildPackageDaemonCommand(
-            packageRunner: "/opt/homebrew/bin/bunx",
-            subcommand: "start",
-            packageVersion: "unknown"
+            packageVersion: "0.0.40-rc.1"
         ))
     }
 

--- a/ios/XCTestRunner/Sources/XCTestRunnerTests/XCTestRunnerTests.swift
+++ b/ios/XCTestRunner/Sources/XCTestRunnerTests/XCTestRunnerTests.swift
@@ -366,6 +366,7 @@ final class XCTestRunnerTests: XCTestCase {
         for result: DaemonStartupResult in [
             .executableNotFound,
             .packageRunnerNotFound,
+            .invalidPackageVersion("next"),
             .launchFailed,
             .packageLaunchFailed(stderr: "package unavailable"),
             .launchTimeout,
@@ -390,6 +391,7 @@ final class XCTestRunnerTests: XCTestCase {
             stderr: "package unavailable"
         ).diagnosticMessage.contains("package unavailable"))
         XCTAssertTrue(DaemonStartupResult.packageRunnerNotFound.diagnosticMessage.contains("bunx"))
+        XCTAssertTrue(DaemonStartupResult.invalidPackageVersion("next").diagnosticMessage.contains("exact package version"))
         XCTAssertTrue(DaemonStartupResult.launchTimeout.diagnosticMessage.contains("timed out"))
         XCTAssertTrue(DaemonStartupResult.readinessTimeout.diagnosticMessage.contains("did not"))
         XCTAssertTrue(DaemonStartupResult.versionSkew.diagnosticMessage.contains("different-version"))
@@ -399,6 +401,7 @@ final class XCTestRunnerTests: XCTestCase {
         let messages = [
             DaemonStartupResult.executableNotFound,
             DaemonStartupResult.packageRunnerNotFound,
+            DaemonStartupResult.invalidPackageVersion("next"),
             DaemonStartupResult.launchFailed,
             DaemonStartupResult.packageLaunchFailed(stderr: "package unavailable"),
             DaemonStartupResult.launchTimeout,


### PR DESCRIPTION
## Summary

- require `AUTOMOBILE_DAEMON_PACKAGE_VERSION` and `AUTOMOBILE_VERSION` package pins to be exact SemVer selectors
- reject npm tags, ranges, and wildcards that could resolve to a different daemon release

## Why

The daemon package pin is advertised as hermetic. npm selectors such as `next` and `0.0.x` are floating, so they could silently launch a changing daemon version.

## Validation

- `swift test --filter AutoMobileVersionTests`
- `bun run turbo:validate`
- `bun run typecheck`

Depends on [PR #4971](https://github.com/kaeawc/auto-mobile/pull/4971) because this follows the pinning implementation introduced there.
