### PR TITLE
fix: harden execution boundary follow-ups

### DIFF
--- a/scripts/lib/executionBoundaryAst.ts
+++ b/scripts/lib/executionBoundaryAst.ts
@@ -34,7 +34,7 @@ function propertyNameOf(name: ts.PropertyName): string | undefined {
 function unwrapTransparentExpression(expression: ts.Expression): ts.Expression {
   let current = expression;
   while (ts.isAsExpression(current) || ts.isTypeAssertionExpression(current) ||
-    ts.isNonNullExpression(current) || ts.isSatisfiesExpression(current)) {
+    ts.isNonNullExpression(current) || ts.isSatisfiesExpression(current) || ts.isParenthesizedExpression(current)) {
     current = current.expression;
   }
   return current;
@@ -139,7 +139,6 @@ export function executionBoundaryAst(source: string): ExecutionBoundaryAst {
     if (!node) {return [];}
     node = unwrapTransparentExpression(node);
     if (ts.isStringLiteralLike(node)) {return [node.text];}
-    if (ts.isParenthesizedExpression(node)) {return strings(node.expression, seen);}
     if (ts.isNoSubstitutionTemplateLiteral(node)) {return [node.text];}
     if (ts.isTaggedTemplateExpression(node) && ts.isPropertyAccessExpression(node.tag) &&
       ts.isIdentifier(node.tag.expression) && node.tag.expression.text === "String" && node.tag.name.text === "raw") {

--- a/test/lint/devicectlExecutionBoundary.test.ts
+++ b/test/lint/devicectlExecutionBoundary.test.ts
@@ -44,7 +44,7 @@ function directlyExecutesDevicectl(source: string): boolean {
       const shellDevicectl = commandValues.some(value => /(?:^|[\s;&|])xcrun\s+devicectl(?:\s|$|[;&|])/.test(value));
       const argvAlternatives = arrayArgs.length > 0 ? [arrayArgs] : ast.arrayAlternatives(call.arguments[1]) ?? [];
       const shellWrappedDevicectl = argvAlternatives.some(argv => {
-        const shellIndex = argv.findIndex(argument => ast.strings(argument).includes("-c"));
+        const shellIndex = argv.findIndex(argument => ast.strings(argument).some(value => /^-[a-z]*c[a-z]*$/i.test(value)));
         return shellIndex >= 0 && ast.strings(argv[shellIndex + 1]).some(value => /(?:^|[\s;&|])xcrun\s+devicectl(?:\s|$|[;&|])/.test(value));
       });
       const argvWrappedDevicectl = commandValues.some(value => value === "env" || value === "sudo") &&
@@ -122,6 +122,8 @@ describe("devicectl execution boundary (issue #4053)", () => {
     expect(directlyExecutesDevicectl('spawn("/usr/bin/xcrun", ["devicectl", "device", "list"]);')).toBe(true);
     expect(directlyExecutesDevicectl('spawn("/bin/sh", ["-c", "xcrun devicectl device list"]);')).toBe(true);
     expect(directlyExecutesDevicectl('Bun.spawn(["bash", "-c", "xcrun devicectl device list"]);')).toBe(true);
+    expect(directlyExecutesDevicectl('spawn("bash", ["-lc", "xcrun devicectl device list"]);')).toBe(true);
+    expect(directlyExecutesDevicectl('spawn("bash", (["-c", "xcrun devicectl device list"]));')).toBe(true);
     expect(directlyExecutesDevicectl('spawn("env", ["xcrun", "devicectl", "device", "list"]);')).toBe(true);
     expect(directlyExecutesDevicectl('execFile("sudo", ["xcrun", "devicectl", "device", "list"]);')).toBe(true);
     expect(directlyExecutesDevicectl('execFile("sudo", ["-u", "root", "xcrun", "devicectl", "device", "list"]);')).toBe(true);


### PR DESCRIPTION
Follow-up to #4830: preserve parenthesized execution contexts and combined shell command flags.\n\nValidation: focused boundary tests and lint.