### PR TITLE
iOS: preserve latest package sentinel

### DIFF
--- a/ios/XCTestRunner/Sources/XCTestRunner/AutoMobileEnvironment.swift
+++ b/ios/XCTestRunner/Sources/XCTestRunner/AutoMobileEnvironment.swift
@@ -589,8 +589,14 @@ public enum DaemonManager {
             return explicitPin
         }
 
-        let automobileVersion = environment["AUTOMOBILE_VERSION"]?.trimmingCharacters(in: .whitespaces)
-        return automobileVersion?.isEmpty == false ? automobileVersion : nil
+        guard let automobileVersion = environment["AUTOMOBILE_VERSION"]?.trimmingCharacters(in: .whitespaces),
+              !automobileVersion.isEmpty
+        else {
+            return nil
+        }
+        // `AUTOMOBILE_VERSION=latest` is the shared asset-version sentinel. Convert it to this
+        // runner's baked concrete release rather than passing a floating package tag to bunx/npx.
+        return automobileVersion.lowercased() == "latest" ? AutoMobileVersion.current : automobileVersion
     }
 
     private enum DaemonPackageVersionResolution {

--- a/ios/XCTestRunner/Sources/XCTestRunnerTests/AutoMobileVersionTests.swift
+++ b/ios/XCTestRunner/Sources/XCTestRunnerTests/AutoMobileVersionTests.swift
@@ -165,6 +165,30 @@ final class AutoMobileVersionTests: XCTestCase {
         XCTAssertNil(DaemonManager.resolveDaemonPackageVersion(environment: [:]))
     }
 
+    func testResolveDaemonPackageVersionNormalizesSharedLatestSentinel() {
+        XCTAssertEqual(DaemonManager.resolveDaemonPackageVersion(environment: [
+            "AUTOMOBILE_VERSION": "LATEST",
+        ]), AutoMobileVersion.current)
+        XCTAssertEqual(DaemonManager.resolveDaemonPackageVersion(environment: [
+            "AUTOMOBILE_DAEMON_PACKAGE_VERSION": "latest",
+            "AUTOMOBILE_VERSION": "0.0.40",
+        ]), "latest")
+
+        XCTAssertEqual(DaemonManager.selectDaemonLaunch(
+            subcommand: "start",
+            localEntry: nil,
+            runtime: nil,
+            packageRunner: "/opt/homebrew/bin/bunx",
+            autoMobilePath: "/usr/local/bin/auto-mobile",
+            packageVersion: DaemonManager.resolveDaemonPackageVersion(environment: [
+                "AUTOMOBILE_VERSION": "latest",
+            ])
+        ), .process(
+            executable: "/opt/homebrew/bin/bunx",
+            arguments: ["@kaeawc/auto-mobile@\(AutoMobileVersion.current)", "--daemon", "start"]
+        ))
+    }
+
     func testPinnedDaemonPackageCommandRejectsFloatingOrUnknownPins() {
         for packageVersion in ["latest", "unknown", "next", "0.0.x", "^0.0.40", "~0.0.40", ">=0.0.40"] {
             XCTAssertNil(DaemonManager.buildPackageDaemonCommand(


### PR DESCRIPTION
## Summary

- normalize the documented `AUTOMOBILE_VERSION=latest` sentinel to XCTestRunner's baked concrete release
- retain fail-closed behavior for floating `AUTOMOBILE_DAEMON_PACKAGE_VERSION` values
- cover sentinel normalization and the existing invalid-pin daemon-reuse guard

## Root cause

[PR #4981](https://github.com/kaeawc/auto-mobile/pull/4981) treated every non-SemVer package selector as invalid. That incorrectly included the shared `AUTOMOBILE_VERSION=latest` sentinel, which is documented to resolve to a concrete baked release rather than an npm tag.

## Validation

- `swift test --filter XCTestRunnerTests.AutoMobileVersionTests/testResolveDaemonPackageVersionNormalizesSharedLatestSentinel`
- `swift test --filter XCTestRunnerTests.AutoMobileVersionTests/testEnsureDaemonRunningFailsClosedForInvalidPinsBeforeDaemonReuse`
