### PR TITLE
feat(db): (app,build) nav Phase 1 — build-key provenance schema (#4984)

### DIFF
--- a/scripts/typecheck-baseline.txt
+++ b/scripts/typecheck-baseline.txt
@@ -306,7 +306,6 @@ src/utils/plan/PlanSchemaValidator.ts: error TS1343: The 'import.meta' meta-prop
 # swap-fp: 7 :: src/features/action/swipeon/SwipeOn.ts: error TS2322: Type '(block: (observeResult: ObserveResult) => Promise<any>, options: ObservedChangeOptions) => Promise<any>' is not assignable to type '<T>(action: (observeResult: ObserveResult) => Promise<T>, options: { changeExpected: boolean; timeoutMs: number; progress?: unknown; perf?: PerformanceTracker | undefined; skipPreviousObserve?: boolean | undefined; queryOptions?: { ...; } | undefined; predictionContext?: { ...; } | undefined; }) => Promise<...>'.
 # swap-fp: 7 :: src/features/action/swipeon/SwipeOn.ts: error TS2322: Type 'AndroidCtrlProxyClient' is not assignable to type 'ScrollAccessibilityService'.
 # swap-fp: 7 :: src/features/navigation/NavigateTo.ts: error TS2345: Argument of type 'NavigationGraphService' is not assignable to parameter of type 'NavigationGraphManager'.
-# swap-fp: 7 :: src/features/navigation/NavigationGraphManager.ts: error TS2345: Argument of type 'number | undefined' is not assignable to parameter of type 'number'.
 # swap-fp: 7 :: src/features/observe/Idle.ts: error TS2741: Property 'updatedPrevTotalFrames' is missing in type '{ isStable: false; shouldUpdateLastNonIdleTime: true; updatedPrevMissedVsync: null; updatedPrevSlowUiThread: null; updatedPrevFrameDeadlineMissed: null; updatedFirstGfxInfoLog: false; }' but required in type 'UiStabilityResult'.
 # swap-fp: 7 :: src/index.ts: error TS2322: Type '["debug", boolean, string]' is not assignable to type '[FeatureFlagKey, boolean, string, Record<string, unknown> | null | undefined]'.
 # swap-fp: 7 :: src/index.ts: error TS2322: Type '["debug-perf", boolean, string]' is not assignable to type '[FeatureFlagKey, boolean, string, Record<string, unknown> | null | undefined]'.
@@ -325,6 +324,7 @@ src/utils/plan/PlanSchemaValidator.ts: error TS1343: The 'import.meta' meta-prop
 # swap-fp: 88 :: src/server/testRunResources.ts: error TS2345: Argument of type 'string' is not assignable to parameter of type '"latestOnly" | "limit" | "lookbackDays" | "orderDirection" | "testClass" | "testMethod"'.
 # swap-fp: 9 :: src/daemon/manager.ts: error TS18048: 'signal' is possibly 'undefined'.
 # swap-fp: 9 :: src/features/action/LaunchApp.ts: error TS2322: Type 'boolean | null' is not assignable to type 'boolean'.
+# swap-fp: 9 :: src/features/navigation/NavigationGraphManager.ts: error TS2345: Argument of type 'number | undefined' is not assignable to parameter of type 'number'.
 # swap-fp: 9 :: src/features/observe/android/CtrlProxyHighlights.ts: error TS2322: Type 'null | undefined' is not assignable to type 'NormalizedHighlightBounds | undefined'.
 # swap-fp: 9 :: src/server/networkGraph.ts: error TS2322: Type 'null | string | undefined' is not assignable to type 'null | string'.
 # swap-fp: 9,12 :: src/server/interactionTools.ts: error TS18048: 'searchStats' is possibly 'undefined'.

--- a/src/daemon/daemon.ts
+++ b/src/daemon/daemon.ts
@@ -200,6 +200,14 @@ export class Daemon {
     this.sessionManager.onSessionRelease((sessionId, deviceId) => {
       NavigationGraphManager.releaseSession(sessionId);
       RealObserveScreen.clearCache(deviceId);
+      // Clear the per-device CtrlProxy client's binding to the released session
+      // (#4984) so a nav/hierarchy event arriving before the next session binds the
+      // still-connected device is never attributed to the ended session, and its
+      // cached hierarchy detector (which retains the released session's manager) is
+      // dropped. Central here so it covers EVERY release path — explicit, idle,
+      // heartbeat, device-switch, and derived `${base}:${label}` sessions alike.
+      AndroidCtrlProxyClient.getExistingInstance(deviceId)?.releaseSessionBinding(sessionId);
+      IOSCtrlProxyClient.getExistingInstance(deviceId)?.releaseSessionBinding(sessionId);
     });
     // Emit a real "session released" signal so a connected DaemonMcpProxy clears
     // its remembered session binding the moment the daemon releases the session

--- a/src/db/migrations/2026_08_02_000_navigation_provenance.ts
+++ b/src/db/migrations/2026_08_02_000_navigation_provenance.ts
@@ -1,0 +1,149 @@
+import { type Kysely, sql } from "kysely";
+
+/**
+ * Phase 1 of the (app, build) navigation model (#4837, issue #4984).
+ *
+ * Adds a build-key provenance dimension to the app-level union navigation graph.
+ * The union tables (navigation_apps / navigation_nodes / navigation_edges) are
+ * left untouched — the build key is provenance ON each node/edge, recorded as
+ * separate observation rows, NOT a separate-graph partition. A node/edge can have
+ * many observation records (reached by many builds/devices/sessions).
+ *
+ * Backward-compat (AC4): existing single-build rows are backfilled to a DEFAULT
+ * build key per app (version_code=0, content_hash='') with non-null legacy
+ * sentinels for device_id/session_uuid, so today's behavior falls out as the
+ * degenerate one-build case with no data loss.
+ */
+export async function up(db: Kysely<unknown>): Promise<void> {
+  // Build-key dimension: (packageId=app_id, versionCode, contentHash). Normalized
+  // so observation rows carry a cheap int reference instead of repeating strings.
+  await db.schema
+    .createTable("navigation_build_keys")
+    .ifNotExists()
+    .addColumn("id", "integer", col => col.primaryKey().autoIncrement())
+    .addColumn("app_id", "text", col =>
+      col.notNull().references("navigation_apps.app_id").onDelete("cascade")
+    )
+    .addColumn("version_code", "integer", col => col.notNull())
+    .addColumn("content_hash", "text", col => col.notNull())
+    .addColumn("created_at", "text", col => col.notNull().defaultTo(sql`(datetime('now'))`))
+    .execute();
+
+  await db.schema
+    .createIndex("idx_navigation_build_keys_unique")
+    .ifNotExists()
+    .on("navigation_build_keys")
+    .columns(["app_id", "version_code", "content_hash"])
+    .unique()
+    .execute();
+
+  // Per-node observation records: {buildKey, deviceId, sessionUuid, firstSeen, lastSeen}.
+  await db.schema
+    .createTable("navigation_node_observations")
+    .ifNotExists()
+    .addColumn("id", "integer", col => col.primaryKey().autoIncrement())
+    .addColumn("node_id", "integer", col =>
+      col.notNull().references("navigation_nodes.id").onDelete("cascade")
+    )
+    .addColumn("build_key_id", "integer", col =>
+      col.notNull().references("navigation_build_keys.id").onDelete("cascade")
+    )
+    .addColumn("device_id", "text", col => col.notNull())
+    .addColumn("session_uuid", "text", col => col.notNull())
+    .addColumn("first_seen_at", "integer", col => col.notNull())
+    .addColumn("last_seen_at", "integer", col => col.notNull())
+    .addColumn("created_at", "text", col => col.notNull().defaultTo(sql`(datetime('now'))`))
+    .execute();
+
+  await db.schema
+    .createIndex("idx_navigation_node_observations_unique")
+    .ifNotExists()
+    .on("navigation_node_observations")
+    .columns(["node_id", "build_key_id", "device_id", "session_uuid"])
+    .unique()
+    .execute();
+
+  await db.schema
+    .createIndex("idx_navigation_node_observations_build")
+    .ifNotExists()
+    .on("navigation_node_observations")
+    .column("build_key_id")
+    .execute();
+
+  await db.schema
+    .createIndex("idx_navigation_node_observations_device")
+    .ifNotExists()
+    .on("navigation_node_observations")
+    .column("device_id")
+    .execute();
+
+  // Per-edge observation records (symmetric to nodes).
+  await db.schema
+    .createTable("navigation_edge_observations")
+    .ifNotExists()
+    .addColumn("id", "integer", col => col.primaryKey().autoIncrement())
+    .addColumn("edge_id", "integer", col =>
+      col.notNull().references("navigation_edges.id").onDelete("cascade")
+    )
+    .addColumn("build_key_id", "integer", col =>
+      col.notNull().references("navigation_build_keys.id").onDelete("cascade")
+    )
+    .addColumn("device_id", "text", col => col.notNull())
+    .addColumn("session_uuid", "text", col => col.notNull())
+    .addColumn("first_seen_at", "integer", col => col.notNull())
+    .addColumn("last_seen_at", "integer", col => col.notNull())
+    .addColumn("created_at", "text", col => col.notNull().defaultTo(sql`(datetime('now'))`))
+    .execute();
+
+  await db.schema
+    .createIndex("idx_navigation_edge_observations_unique")
+    .ifNotExists()
+    .on("navigation_edge_observations")
+    .columns(["edge_id", "build_key_id", "device_id", "session_uuid"])
+    .unique()
+    .execute();
+
+  await db.schema
+    .createIndex("idx_navigation_edge_observations_build")
+    .ifNotExists()
+    .on("navigation_edge_observations")
+    .column("build_key_id")
+    .execute();
+
+  await db.schema
+    .createIndex("idx_navigation_edge_observations_device")
+    .ifNotExists()
+    .on("navigation_edge_observations")
+    .column("device_id")
+    .execute();
+
+  // --- Backfill (AC4): one DEFAULT build key per app, one observation per row. ---
+  await sql`
+    INSERT INTO navigation_build_keys (app_id, version_code, content_hash)
+    SELECT app_id, 0, '' FROM navigation_apps
+  `.execute(db);
+
+  await sql`
+    INSERT INTO navigation_node_observations
+      (node_id, build_key_id, device_id, session_uuid, first_seen_at, last_seen_at)
+    SELECT n.id, bk.id, 'legacy', 'legacy', n.first_seen_at, n.last_seen_at
+    FROM navigation_nodes n
+    JOIN navigation_build_keys bk
+      ON bk.app_id = n.app_id AND bk.version_code = 0 AND bk.content_hash = ''
+  `.execute(db);
+
+  await sql`
+    INSERT INTO navigation_edge_observations
+      (edge_id, build_key_id, device_id, session_uuid, first_seen_at, last_seen_at)
+    SELECT e.id, bk.id, 'legacy', 'legacy', e.timestamp, e.timestamp
+    FROM navigation_edges e
+    JOIN navigation_build_keys bk
+      ON bk.app_id = e.app_id AND bk.version_code = 0 AND bk.content_hash = ''
+  `.execute(db);
+}
+
+export async function down(db: Kysely<unknown>): Promise<void> {
+  await db.schema.dropTable("navigation_edge_observations").execute();
+  await db.schema.dropTable("navigation_node_observations").execute();
+  await db.schema.dropTable("navigation_build_keys").execute();
+}

--- a/src/db/migrations/2026_08_02_000_navigation_provenance.ts
+++ b/src/db/migrations/2026_08_02_000_navigation_provenance.ts
@@ -118,13 +118,18 @@ export async function up(db: Kysely<unknown>): Promise<void> {
     .execute();
 
   // --- Backfill (AC4): one DEFAULT build key per app, one observation per row. ---
+  // Kysely's SqliteAdapter reports supportsTransactionalDdl = false, so this up()
+  // is NOT wrapped in a transaction. If a later statement fails after an earlier
+  // insert, the migration is not recorded and reruns from the top — so every
+  // backfill uses INSERT OR IGNORE (safe against its UNIQUE index) to stay
+  // idempotent and retry-safe rather than wedging on a duplicate-key violation.
   await sql`
-    INSERT INTO navigation_build_keys (app_id, version_code, content_hash)
+    INSERT OR IGNORE INTO navigation_build_keys (app_id, version_code, content_hash)
     SELECT app_id, 0, '' FROM navigation_apps
   `.execute(db);
 
   await sql`
-    INSERT INTO navigation_node_observations
+    INSERT OR IGNORE INTO navigation_node_observations
       (node_id, build_key_id, device_id, session_uuid, first_seen_at, last_seen_at)
     SELECT n.id, bk.id, 'legacy', 'legacy', n.first_seen_at, n.last_seen_at
     FROM navigation_nodes n
@@ -133,7 +138,7 @@ export async function up(db: Kysely<unknown>): Promise<void> {
   `.execute(db);
 
   await sql`
-    INSERT INTO navigation_edge_observations
+    INSERT OR IGNORE INTO navigation_edge_observations
       (edge_id, build_key_id, device_id, session_uuid, first_seen_at, last_seen_at)
     SELECT e.id, bk.id, 'legacy', 'legacy', e.timestamp, e.timestamp
     FROM navigation_edges e

--- a/src/db/migrations/2026_08_02_000_navigation_provenance.ts
+++ b/src/db/migrations/2026_08_02_000_navigation_provenance.ts
@@ -128,10 +128,15 @@ export async function up(db: Kysely<unknown>): Promise<void> {
     SELECT app_id, 0, '' FROM navigation_apps
   `.execute(db);
 
+  // Normalize with min/max: legacy getOrCreateNode replaced last_seen_at
+  // unconditionally, so out-of-order commits could leave first_seen_at > last_seen_at
+  // on existing rows. Copying those verbatim would carry the inversion into the
+  // observation window (the runtime upserts only keep FUTURE writes monotonic).
   await sql`
     INSERT OR IGNORE INTO navigation_node_observations
       (node_id, build_key_id, device_id, session_uuid, first_seen_at, last_seen_at)
-    SELECT n.id, bk.id, 'legacy', 'legacy', n.first_seen_at, n.last_seen_at
+    SELECT n.id, bk.id, 'legacy', 'legacy',
+      min(n.first_seen_at, n.last_seen_at), max(n.first_seen_at, n.last_seen_at)
     FROM navigation_nodes n
     JOIN navigation_build_keys bk
       ON bk.app_id = n.app_id AND bk.version_code = 0 AND bk.content_hash = ''

--- a/src/db/navigationRepository.ts
+++ b/src/db/navigationRepository.ts
@@ -18,6 +18,10 @@ import type {
   NewNavigationNodeFingerprint,
   NavigationSuggestion,
   NewNavigationSuggestion,
+  NavigationBuildKey,
+  NewNavigationBuildKey,
+  NewNavigationNodeObservation,
+  NewNavigationEdgeObservation,
 } from "./types";
 import { logger } from "../utils/logger";
 
@@ -1078,6 +1082,108 @@ export class NavigationRepository {
       .where("app_id", "=", appId)
       .where("promoted_to_fingerprint_id", "is", null)
       .orderBy("occurrence_count", "desc")
+      .execute();
+  }
+
+  // ==========================================
+  // Build-key + provenance observation methods (#4984)
+  // ==========================================
+
+  /**
+   * Get or create the build-key row for (app_id, version_code, content_hash).
+   *
+   * Atomic upsert on UNIQUE(app_id, version_code, content_hash)
+   * (idx_navigation_build_keys_unique) so a concurrent first-create doesn't throw
+   * a UNIQUE collision. The conflict path is a no-op touch (app_id set to its own
+   * value) so RETURNING still yields the existing row without mutating it.
+   */
+  async getOrCreateBuildKey(
+    appId: string,
+    versionCode: number,
+    contentHash: string
+  ): Promise<NavigationBuildKey> {
+    const db = this.getDb();
+    const newBuildKey: NewNavigationBuildKey = {
+      app_id: appId,
+      version_code: versionCode,
+      content_hash: contentHash,
+    };
+
+    return db
+      .insertInto("navigation_build_keys")
+      .values(newBuildKey)
+      .onConflict(oc =>
+        oc.columns(["app_id", "version_code", "content_hash"]).doUpdateSet(eb => ({
+          app_id: eb.ref("navigation_build_keys.app_id"),
+        }))
+      )
+      .returningAll()
+      .executeTakeFirstOrThrow();
+  }
+
+  /**
+   * Record a per-node provenance observation.
+   *
+   * Atomic upsert on UNIQUE(node_id, build_key_id, device_id, session_uuid): a
+   * revisit within the same (build, device, session) bumps last_seen_at in SQL;
+   * a new tuple inserts a new row. first_seen_at is left untouched on conflict.
+   */
+  async recordNodeObservation(
+    nodeId: number,
+    buildKeyId: number,
+    deviceId: string,
+    sessionUuid: string,
+    seenAt: number
+  ): Promise<void> {
+    const db = this.getDb();
+    const observation: NewNavigationNodeObservation = {
+      node_id: nodeId,
+      build_key_id: buildKeyId,
+      device_id: deviceId,
+      session_uuid: sessionUuid,
+      first_seen_at: seenAt,
+      last_seen_at: seenAt,
+    };
+
+    await db
+      .insertInto("navigation_node_observations")
+      .values(observation)
+      .onConflict(oc =>
+        oc
+          .columns(["node_id", "build_key_id", "device_id", "session_uuid"])
+          .doUpdateSet({ last_seen_at: seenAt })
+      )
+      .execute();
+  }
+
+  /**
+   * Record a per-edge provenance observation (symmetric to recordNodeObservation).
+   */
+  async recordEdgeObservation(
+    edgeId: number,
+    buildKeyId: number,
+    deviceId: string,
+    sessionUuid: string,
+    seenAt: number
+  ): Promise<void> {
+    const db = this.getDb();
+    const observation: NewNavigationEdgeObservation = {
+      edge_id: edgeId,
+      build_key_id: buildKeyId,
+      device_id: deviceId,
+      session_uuid: sessionUuid,
+      first_seen_at: seenAt,
+      last_seen_at: seenAt,
+    };
+
+    await db
+      .insertInto("navigation_edge_observations")
+      .values(observation)
+      .onConflict(oc =>
+        oc
+          .columns(["edge_id", "build_key_id", "device_id", "session_uuid"])
+          .doUpdateSet({ last_seen_at: seenAt })
+      )
       .execute();
   }
 

--- a/src/db/navigationRepository.ts
+++ b/src/db/navigationRepository.ts
@@ -1,4 +1,4 @@
-import type { Kysely } from "kysely";
+import { sql, type Kysely } from "kysely";
 import { getDatabase } from "./database";
 import type {
   Database,
@@ -1125,8 +1125,10 @@ export class NavigationRepository {
    * Record a per-node provenance observation.
    *
    * Atomic upsert on UNIQUE(node_id, build_key_id, device_id, session_uuid): a
-   * revisit within the same (build, device, session) bumps last_seen_at in SQL;
-   * a new tuple inserts a new row. first_seen_at is left untouched on conflict.
+   * revisit within the same (build, device, session) widens the seen window in SQL.
+   * Android WS handlers are not serialized, so an out-of-order commit could make
+   * first_seen_at > last_seen_at — hence MIN/MAX rather than an unconditional set,
+   * keeping the bounds monotonic regardless of arrival order.
    */
   async recordNodeObservation(
     nodeId: number,
@@ -1151,13 +1153,17 @@ export class NavigationRepository {
       .onConflict(oc =>
         oc
           .columns(["node_id", "build_key_id", "device_id", "session_uuid"])
-          .doUpdateSet({ last_seen_at: seenAt })
+          .doUpdateSet({
+            first_seen_at: sql`min(navigation_node_observations.first_seen_at, ${seenAt})`,
+            last_seen_at: sql`max(navigation_node_observations.last_seen_at, ${seenAt})`,
+          })
       )
       .execute();
   }
 
   /**
-   * Record a per-edge provenance observation (symmetric to recordNodeObservation).
+   * Record a per-edge provenance observation (symmetric to recordNodeObservation),
+   * with the same MIN/MAX monotonic-window handling for out-of-order commits.
    */
   async recordEdgeObservation(
     edgeId: number,
@@ -1182,7 +1188,10 @@ export class NavigationRepository {
       .onConflict(oc =>
         oc
           .columns(["edge_id", "build_key_id", "device_id", "session_uuid"])
-          .doUpdateSet({ last_seen_at: seenAt })
+          .doUpdateSet({
+            first_seen_at: sql`min(navigation_edge_observations.first_seen_at, ${seenAt})`,
+            last_seen_at: sql`max(navigation_edge_observations.last_seen_at, ${seenAt})`,
+          })
       )
       .execute();
   }

--- a/src/db/types.ts
+++ b/src/db/types.ts
@@ -154,6 +154,40 @@ export interface ScrollPositionsTable {
   created_at: Generated<string>;
 }
 
+// Navigation build-key dimension (#4984): (packageId=app_id, versionCode, contentHash).
+// Provenance on the app-level union graph, not a separate-graph partition.
+export interface NavigationBuildKeysTable {
+  id: Generated<number>;
+  app_id: string;
+  version_code: number;
+  content_hash: string;
+  created_at: Generated<string>;
+}
+
+// Per-node observation records (#4984): a screen reached by many builds/devices/sessions.
+export interface NavigationNodeObservationsTable {
+  id: Generated<number>;
+  node_id: number;
+  build_key_id: number;
+  device_id: string;
+  session_uuid: string;
+  first_seen_at: number;
+  last_seen_at: number;
+  created_at: Generated<string>;
+}
+
+// Per-edge observation records (#4984), symmetric to node observations.
+export interface NavigationEdgeObservationsTable {
+  id: Generated<number>;
+  edge_id: number;
+  build_key_id: number;
+  device_id: string;
+  session_uuid: string;
+  first_seen_at: number;
+  last_seen_at: number;
+  created_at: Generated<string>;
+}
+
 // Navigation node fingerprints table - tracks fingerprints associated with named nodes
 interface NavigationNodeFingerprintsTable {
   id: Generated<number>;
@@ -704,6 +738,9 @@ export interface Database {
   anrs: AnrsTable;
   navigation_node_fingerprints: NavigationNodeFingerprintsTable;
   navigation_suggestions: NavigationSuggestionsTable;
+  navigation_build_keys: NavigationBuildKeysTable;
+  navigation_node_observations: NavigationNodeObservationsTable;
+  navigation_edge_observations: NavigationEdgeObservationsTable;
   network_events: NetworkEventsTable;
   log_events: LogEventsTable;
 
@@ -739,6 +776,15 @@ export type NewNavigationNode = Insertable<NavigationNodesTable>;
 
 export type NavigationEdge = Selectable<NavigationEdgesTable>;
 export type NewNavigationEdge = Insertable<NavigationEdgesTable>;
+
+export type NavigationBuildKey = Selectable<NavigationBuildKeysTable>;
+export type NewNavigationBuildKey = Insertable<NavigationBuildKeysTable>;
+
+export type NavigationNodeObservation = Selectable<NavigationNodeObservationsTable>;
+export type NewNavigationNodeObservation = Insertable<NavigationNodeObservationsTable>;
+
+export type NavigationEdgeObservation = Selectable<NavigationEdgeObservationsTable>;
+export type NewNavigationEdgeObservation = Insertable<NavigationEdgeObservationsTable>;
 
 export type UIElement = Selectable<UIElementsTable>;
 export type NewUIElement = Insertable<UIElementsTable>;

--- a/src/features/navigation/NavigationGraphManager.ts
+++ b/src/features/navigation/NavigationGraphManager.ts
@@ -256,6 +256,17 @@ export class NavigationGraphManager implements NavigationGraphService {
   }
 
   /**
+   * Clear a session's released-tombstone (#4984). Session UUIDs are normally not
+   * reused, but `setActiveDevice` releases an existing session and immediately
+   * re-creates it with the SAME uuid on another device — so when a session is
+   * (re)bound, drop any tombstone so getInstanceForSession builds it a real manager
+   * again instead of routing it to the unattributed global.
+   */
+  public static clearReleasedSession(sessionId: string): void {
+    NavigationGraphManager.releasedSessions.delete(sessionId);
+  }
+
+  /**
    * Release a session-scoped instance and its transient state.
    */
   public static releaseSession(sessionId: string): void {

--- a/src/features/navigation/NavigationGraphManager.ts
+++ b/src/features/navigation/NavigationGraphManager.ts
@@ -53,7 +53,8 @@ export interface NavigationGraphService extends NavigationGraph, NavigationGraph
   getCurrentAppId(): string | null;
 
   // Build/device provenance (#4984)
-  setBuildContext(context: NavigationBuildContext | null): void;
+  setBuildContext(context: NavigationBuildContext): void;
+  clearBuildContext(appId: string): void;
 
   // Screen tracking
   getCurrentScreen(): string | null;
@@ -125,6 +126,14 @@ export interface NavigationBuildContext {
 /** Non-null legacy sentinel used when a provenance dimension is unknown (#4984). */
 const LEGACY_PROVENANCE_SENTINEL = "legacy";
 
+/** Immutable provenance snapshot captured once per event and shared by its writes (#4984). */
+interface ResolvedProvenance {
+  versionCode: number;
+  contentHash: string;
+  deviceId: string;
+  sessionUuid: string;
+}
+
 /**
  * Manages the navigation graph with SQLite persistence.
  * Tracks screen visits and correlates navigation events with tool calls.
@@ -143,12 +152,14 @@ export class NavigationGraphManager implements NavigationGraphService {
 
   // Session + build/device provenance (#4984). sessionUuid identifies the owning
   // agent session; the build context (deviceId, versionCode, contentHash) is set
-  // by the CtrlProxy client that binds a device. When the build context is unset
+  // per app by the CtrlProxy client that binds a device. Keyed by app_id so a
+  // context resolved for one app is never applied to another when a session
+  // observes multiple apps on a device. When no context exists for the current app
   // (no device bound yet, or an unresolved content hash), mutations record under
   // the default build key so a write never blocks on — or fails because of —
   // provenance resolution.
   private sessionUuid: string | null;
-  private currentBuildContext: NavigationBuildContext | null = null;
+  private buildContexts: Map<string, NavigationBuildContext> = new Map();
 
   // Tool call history kept in memory for correlation (transient data)
   private toolCallHistory: ToolCallInteraction[] = [];
@@ -187,13 +198,22 @@ export class NavigationGraphManager implements NavigationGraphService {
   }
 
   /**
-   * Set the build/device provenance context for subsequent graph mutations
-   * (#4984). Called by the CtrlProxy client that owns the device; the content hash
-   * is resolved eagerly (and cached) at bind time so nav events that arrive later
-   * record under the real build key. Pass `null` to clear.
+   * Set the build/device provenance context for `context.appId` (#4984). Called by
+   * the CtrlProxy client that owns the device; the content hash is resolved eagerly
+   * (and cached) at bind time so nav events that arrive later record under the real
+   * build key. Stored per app so switching apps never applies one app's context to
+   * another.
    */
-  public setBuildContext(context: NavigationBuildContext | null): void {
-    this.currentBuildContext = context;
+  public setBuildContext(context: NavigationBuildContext): void {
+    this.buildContexts.set(context.appId, context);
+  }
+
+  /**
+   * Drop the build context for an app (#4984), so its next mutation falls to the
+   * default key until re-resolved. Called on a package update/reinstall/removal.
+   */
+  public clearBuildContext(appId: string): void {
+    this.buildContexts.delete(appId);
   }
 
   /**
@@ -360,23 +380,22 @@ export class NavigationGraphManager implements NavigationGraphService {
   }
 
   /**
-   * Resolve the provenance dimensions for a mutation (#4984): the build key
-   * (versionCode + contentHash), the deviceId, and the sessionUuid. When no build
-   * context is set the mutation records under the default build key with non-null
-   * legacy sentinels — today's single-build behavior as the degenerate default.
+   * Resolve the provenance dimensions for the current app (#4984): the build key
+   * (versionCode + contentHash), the deviceId, and the sessionUuid. Looked up by
+   * app_id, so a context resolved for a different app is never applied here. When
+   * no context exists for the current app the mutation records under the default
+   * build key with non-null legacy sentinels — today's single-build behavior as the
+   * degenerate default.
+   *
+   * Capture ONE snapshot per event (before opening the transaction) and thread it
+   * into both the node and edge writes: a fire-and-forget hash resolution can call
+   * setBuildContext mid-transaction, and resolving separately per observation would
+   * split a single transition across two build keys.
    */
-  private resolveProvenance(): {
-    versionCode: number;
-    contentHash: string;
-    deviceId: string;
-    sessionUuid: string;
-    } {
-    const ctx = this.currentBuildContext;
+  private resolveProvenance(): ResolvedProvenance {
     const sessionUuid = this.sessionUuid ?? LEGACY_PROVENANCE_SENTINEL;
-    // Only apply the context to the app it was resolved for; a context for a
-    // different (or unset) app falls back to the default key rather than stamping
-    // this app's provenance with another build's version/hash.
-    if (ctx && ctx.appId === this.currentAppId) {
+    const ctx = this.currentAppId ? this.buildContexts.get(this.currentAppId) : undefined;
+    if (ctx) {
       return {
         versionCode: ctx.versionCode,
         contentHash: ctx.contentHash,
@@ -394,31 +413,32 @@ export class NavigationGraphManager implements NavigationGraphService {
   /**
    * Record a per-node provenance observation inside the caller's transaction
    * (#4984). Must run on the transaction-bound repository so it commits atomically
-   * with the node mutation.
+   * with the node mutation, using the caller's pre-captured provenance snapshot.
    */
   private async recordNodeProvenance(
     repository: NavigationRepository,
     appId: string,
     nodeId: number,
-    timestamp: number
+    timestamp: number,
+    provenance: ResolvedProvenance
   ): Promise<void> {
-    const p = this.resolveProvenance();
-    const buildKey = await repository.getOrCreateBuildKey(appId, p.versionCode, p.contentHash);
-    await repository.recordNodeObservation(nodeId, buildKey.id, p.deviceId, p.sessionUuid, timestamp);
+    const buildKey = await repository.getOrCreateBuildKey(appId, provenance.versionCode, provenance.contentHash);
+    await repository.recordNodeObservation(nodeId, buildKey.id, provenance.deviceId, provenance.sessionUuid, timestamp);
   }
 
   /**
-   * Record a per-edge provenance observation inside the caller's transaction (#4984).
+   * Record a per-edge provenance observation inside the caller's transaction (#4984),
+   * using the same provenance snapshot as the node write for that transition.
    */
   private async recordEdgeProvenance(
     repository: NavigationRepository,
     appId: string,
     edgeId: number,
-    timestamp: number
+    timestamp: number,
+    provenance: ResolvedProvenance
   ): Promise<void> {
-    const p = this.resolveProvenance();
-    const buildKey = await repository.getOrCreateBuildKey(appId, p.versionCode, p.contentHash);
-    await repository.recordEdgeObservation(edgeId, buildKey.id, p.deviceId, p.sessionUuid, timestamp);
+    const buildKey = await repository.getOrCreateBuildKey(appId, provenance.versionCode, provenance.contentHash);
+    await repository.recordEdgeObservation(edgeId, buildKey.id, provenance.deviceId, provenance.sessionUuid, timestamp);
   }
 
   /**
@@ -484,6 +504,10 @@ export class NavigationGraphManager implements NavigationGraphService {
     const recentToolCall = this.findCorrelatedToolCall(timestamp);
     const currentModalStack = recentToolCall?.uiState?.modalStack;
 
+    // Snapshot provenance ONCE for this transition so the node and edge observations
+    // share one build key even if a fire-and-forget hash lands mid-transaction (#4984).
+    const provenance = this.resolveProvenance();
+
     // Persist the whole graph write atomically across BOTH repos via the shared helper,
     // which owns the assertSharedConnection() precondition and the bind-both-repos
     // preamble (#3075). Every read and write inside the callback runs on the transaction
@@ -498,7 +522,7 @@ export class NavigationGraphManager implements NavigationGraphService {
 
       // Record per-node provenance for the current build/device/session (#4984),
       // in the same transaction as the node mutation.
-      await this.recordNodeProvenance(repository, appId, n.id, timestamp);
+      await this.recordNodeProvenance(repository, appId, n.id, timestamp, provenance);
 
       // Record node visit for test coverage if session is active
       if (this.activeTestSession) {
@@ -535,8 +559,8 @@ export class NavigationGraphManager implements NavigationGraphService {
           timestamp
         );
 
-        // Record per-edge provenance for the current build/device/session (#4984).
-        await this.recordEdgeProvenance(repository, appId, edge.id, timestamp);
+        // Record per-edge provenance using the SAME snapshot as the node (#4984).
+        await this.recordEdgeProvenance(repository, appId, edge.id, timestamp, provenance);
 
         // Record edge traversal for test coverage if session is active
         if (this.activeTestSession) {
@@ -705,6 +729,7 @@ export class NavigationGraphManager implements NavigationGraphService {
     const existingNode = await this.repository.getNodeByFingerprint(this.currentAppId, fingerprintHash);
     if (existingNode) {
       const appId = this.currentAppId;
+      const provenance = this.resolveProvenance();
 
       // Persist the counter writes atomically across BOTH repos via the shared helper,
       // which owns the assertSharedConnection() precondition and the bind-both-repos
@@ -719,7 +744,7 @@ export class NavigationGraphManager implements NavigationGraphService {
         await repository.updateNodeVisit(existingNode.id, timestamp);
 
         // Record per-node provenance for this reach (#4984), same transaction.
-        await this.recordNodeProvenance(repository, appId, existingNode.id, timestamp);
+        await this.recordNodeProvenance(repository, appId, existingNode.id, timestamp, provenance);
 
         // Record node visit for test coverage if session is active
         if (this.activeTestSession) {

--- a/src/features/navigation/NavigationGraphManager.ts
+++ b/src/features/navigation/NavigationGraphManager.ts
@@ -52,6 +52,9 @@ export interface NavigationGraphService extends NavigationGraph, NavigationGraph
   setCurrentApp(appId: string): Promise<void>;
   getCurrentAppId(): string | null;
 
+  // Build/device provenance (#4984)
+  setBuildContext(context: NavigationBuildContext | null): void;
+
   // Screen tracking
   getCurrentScreen(): string | null;
   recordBackStack(backStack: BackStackInfo): Promise<void>;
@@ -106,6 +109,20 @@ type HistoryCursor = {
 };
 
 /**
+ * Build/device provenance context for a graph mutation (#4984). The build key is
+ * (packageId=current app, versionCode, contentHash); deviceId names the device
+ * the mutation was observed on.
+ */
+export interface NavigationBuildContext {
+  deviceId: string;
+  versionCode: number;
+  contentHash: string;
+}
+
+/** Non-null legacy sentinel used when a provenance dimension is unknown (#4984). */
+const LEGACY_PROVENANCE_SENTINEL = "legacy";
+
+/**
  * Manages the navigation graph with SQLite persistence.
  * Tracks screen visits and correlates navigation events with tool calls.
  */
@@ -120,6 +137,15 @@ export class NavigationGraphManager implements NavigationGraphService {
   private currentAppId: string | null = null;
   private currentScreen: string | null = null;
   private graphUpdateListeners: Array<() => void | Promise<void>> = [];
+
+  // Session + build/device provenance (#4984). sessionUuid identifies the owning
+  // agent session; the build context (deviceId, versionCode, contentHash) is set
+  // by the CtrlProxy client that binds a device. When the build context is unset
+  // (no device bound yet, or an unresolved content hash), mutations record under
+  // the default build key so a write never blocks on — or fails because of —
+  // provenance resolution.
+  private sessionUuid: string | null;
+  private currentBuildContext: NavigationBuildContext | null = null;
 
   // Tool call history kept in memory for correlation (transient data)
   private toolCallHistory: ToolCallInteraction[] = [];
@@ -148,11 +174,23 @@ export class NavigationGraphManager implements NavigationGraphService {
   constructor(
     repository?: NavigationRepository,
     testCoverageRepository?: TestCoverageRepository,
-    timer: Timer = defaultTimer
+    timer: Timer = defaultTimer,
+    sessionUuid: string | null = null
   ) {
     this.repository = repository ?? new NavigationRepository();
     this.testCoverageRepository = testCoverageRepository ?? new TestCoverageRepository();
     this.timer = timer;
+    this.sessionUuid = sessionUuid;
+  }
+
+  /**
+   * Set the build/device provenance context for subsequent graph mutations
+   * (#4984). Called by the CtrlProxy client that owns the device; the content hash
+   * is resolved eagerly (and cached) at bind time so nav events that arrive later
+   * record under the real build key. Pass `null` to clear.
+   */
+  public setBuildContext(context: NavigationBuildContext | null): void {
+    this.currentBuildContext = context;
   }
 
   /**
@@ -174,7 +212,7 @@ export class NavigationGraphManager implements NavigationGraphService {
   public static getInstanceForSession(sessionId: string): NavigationGraphManager {
     let instance = NavigationGraphManager.sessionInstances.get(sessionId);
     if (!instance) {
-      instance = new NavigationGraphManager();
+      instance = new NavigationGraphManager(undefined, undefined, undefined, sessionId);
       NavigationGraphManager.sessionInstances.set(sessionId, instance);
     }
     return instance;
@@ -249,9 +287,10 @@ export class NavigationGraphManager implements NavigationGraphService {
   public static createForTesting(
     repository?: NavigationRepository,
     testCoverageRepository?: TestCoverageRepository,
-    timer?: Timer
+    timer?: Timer,
+    sessionUuid?: string
   ): NavigationGraphManager {
-    return new NavigationGraphManager(repository, testCoverageRepository, timer);
+    return new NavigationGraphManager(repository, testCoverageRepository, timer, sessionUuid ?? null);
   }
 
   /**
@@ -318,6 +357,65 @@ export class NavigationGraphManager implements NavigationGraphService {
   }
 
   /**
+   * Resolve the provenance dimensions for a mutation (#4984): the build key
+   * (versionCode + contentHash), the deviceId, and the sessionUuid. When no build
+   * context is set the mutation records under the default build key with non-null
+   * legacy sentinels — today's single-build behavior as the degenerate default.
+   */
+  private resolveProvenance(): {
+    versionCode: number;
+    contentHash: string;
+    deviceId: string;
+    sessionUuid: string;
+    } {
+    const ctx = this.currentBuildContext;
+    const sessionUuid = this.sessionUuid ?? LEGACY_PROVENANCE_SENTINEL;
+    if (ctx) {
+      return {
+        versionCode: ctx.versionCode,
+        contentHash: ctx.contentHash,
+        deviceId: ctx.deviceId,
+        sessionUuid,
+      };
+    }
+    logger.debug(
+      `[NAVIGATION_GRAPH] No build context set for ${this.currentAppId ?? "?"}; ` +
+      `recording provenance under the default build key`
+    );
+    return { versionCode: 0, contentHash: "", deviceId: LEGACY_PROVENANCE_SENTINEL, sessionUuid };
+  }
+
+  /**
+   * Record a per-node provenance observation inside the caller's transaction
+   * (#4984). Must run on the transaction-bound repository so it commits atomically
+   * with the node mutation.
+   */
+  private async recordNodeProvenance(
+    repository: NavigationRepository,
+    appId: string,
+    nodeId: number,
+    timestamp: number
+  ): Promise<void> {
+    const p = this.resolveProvenance();
+    const buildKey = await repository.getOrCreateBuildKey(appId, p.versionCode, p.contentHash);
+    await repository.recordNodeObservation(nodeId, buildKey.id, p.deviceId, p.sessionUuid, timestamp);
+  }
+
+  /**
+   * Record a per-edge provenance observation inside the caller's transaction (#4984).
+   */
+  private async recordEdgeProvenance(
+    repository: NavigationRepository,
+    appId: string,
+    edgeId: number,
+    timestamp: number
+  ): Promise<void> {
+    const p = this.resolveProvenance();
+    const buildKey = await repository.getOrCreateBuildKey(appId, p.versionCode, p.contentHash);
+    await repository.recordEdgeObservation(edgeId, buildKey.id, p.deviceId, p.sessionUuid, timestamp);
+  }
+
+  /**
    * Record back stack information for the current screen.
    * Updates the current node with back stack depth and task ID.
    */
@@ -327,15 +425,25 @@ export class NavigationGraphManager implements NavigationGraphService {
       return;
     }
 
-    await this.repository.updateNodeBackStack(
-      this.currentAppId,
-      this.currentScreen,
-      backStack.depth,
-      backStack.currentTaskId
-    );
+    const appId = this.currentAppId;
+    const screenName = this.currentScreen;
+
+    // Persist the back-stack update + app touch atomically (#4931): both run on the
+    // transaction-bound repository so a throw rolls back together and the exclusive
+    // connection is never held across non-DB work.
+    await this.repository.runInTransaction(async trx => {
+      const repository = this.repository.withExecutor(trx);
+      await repository.updateNodeBackStack(
+        appId,
+        screenName,
+        backStack.depth,
+        backStack.currentTaskId
+      );
+      await repository.touchApp(appId);
+    });
 
     logger.debug(
-      `[NAVIGATION_GRAPH] Updated back stack for ${this.currentScreen}: ` +
+      `[NAVIGATION_GRAPH] Updated back stack for ${screenName}: ` +
       `depth=${backStack.depth}, taskId=${backStack.currentTaskId}`
     );
   }
@@ -382,6 +490,10 @@ export class NavigationGraphManager implements NavigationGraphService {
       // Get or create node and update visit count
       const n = await repository.getOrCreateNode(appId, screenName, timestamp);
 
+      // Record per-node provenance for the current build/device/session (#4984),
+      // in the same transaction as the node mutation.
+      await this.recordNodeProvenance(repository, appId, n.id, timestamp);
+
       // Record node visit for test coverage if session is active
       if (this.activeTestSession) {
         await testCoverageRepository.recordNodeVisit(
@@ -416,6 +528,9 @@ export class NavigationGraphManager implements NavigationGraphService {
           toolArgs,
           timestamp
         );
+
+        // Record per-edge provenance for the current build/device/session (#4984).
+        await this.recordEdgeProvenance(repository, appId, edge.id, timestamp);
 
         // Record edge traversal for test coverage if session is active
         if (this.activeTestSession) {
@@ -596,6 +711,9 @@ export class NavigationGraphManager implements NavigationGraphService {
       await this.runBothReposInTransaction(async (repository, testCoverageRepository) => {
         // Update the existing node's visit count and last_seen_at
         await repository.updateNodeVisit(existingNode.id, timestamp);
+
+        // Record per-node provenance for this reach (#4984), same transaction.
+        await this.recordNodeProvenance(repository, appId, existingNode.id, timestamp);
 
         // Record node visit for test coverage if session is active
         if (this.activeTestSession) {
@@ -1496,7 +1614,14 @@ export class NavigationGraphManager implements NavigationGraphService {
     screenName: string,
     screenshotPath: string | null
   ): Promise<void> {
-    await this.repository.updateNodeScreenshot(appId, screenName, screenshotPath);
+    // #4931: touch navigation_apps.updated_at atomically with the screenshot write.
+    // This is enrichment, not a device reach, so it records NO provenance observation
+    // (observations are reach events; see #4984 decision).
+    await this.repository.runInTransaction(async trx => {
+      const repository = this.repository.withExecutor(trx);
+      await repository.updateNodeScreenshot(appId, screenName, screenshotPath);
+      await repository.touchApp(appId);
+    });
     logger.debug(`[NAVIGATION_GRAPH] Updated screenshot for ${screenName}: ${screenshotPath}`);
     this.notifyGraphUpdated();
   }
@@ -1550,6 +1675,9 @@ export class NavigationGraphManager implements NavigationGraphService {
 
       // Promote the suggestion (creates fingerprint and links suggestion)
       await repository.promoteSuggestion(suggestionId, node.id, timestamp);
+
+      // #4931: touch navigation_apps.updated_at atomically with the promotion.
+      await repository.touchApp(appId);
     });
 
     logger.info(

--- a/src/features/navigation/NavigationGraphManager.ts
+++ b/src/features/navigation/NavigationGraphManager.ts
@@ -1719,6 +1719,7 @@ export class NavigationGraphManager implements NavigationGraphService {
 
     const appId = this.currentAppId;
     const timestamp = this.timer.now();
+    const provenance = this.resolveProvenance(appId);
 
     // Persist the node creation + suggestion promotion atomically. repository.promoteSuggestion
     // does getOrCreateFingerprint + an UPDATE to link the suggestion; without a transaction a
@@ -1737,6 +1738,11 @@ export class NavigationGraphManager implements NavigationGraphService {
 
       // Promote the suggestion (creates fingerprint and links suggestion)
       await repository.promoteSuggestion(suggestionId, node.id, timestamp);
+
+      // Record provenance for the promoted node (#4984): promotion is a reach the
+      // suggestion captured, so the node must appear in build/device-scoped analysis
+      // rather than having a visit count but no observation until reached again.
+      await this.recordNodeProvenance(repository, appId, node.id, timestamp, provenance);
 
       // #4931: touch navigation_apps.updated_at atomically with the promotion.
       await repository.touchApp(appId);

--- a/src/features/navigation/NavigationGraphManager.ts
+++ b/src/features/navigation/NavigationGraphManager.ts
@@ -110,10 +110,13 @@ type HistoryCursor = {
 
 /**
  * Build/device provenance context for a graph mutation (#4984). The build key is
- * (packageId=current app, versionCode, contentHash); deviceId names the device
- * the mutation was observed on.
+ * (packageId=appId, versionCode, contentHash); deviceId names the device the
+ * mutation was observed on. appId is carried so a context resolved for one app is
+ * never applied to another when a session observes multiple apps on a device —
+ * a stale context falls back to the default build key instead of mis-stamping.
  */
 export interface NavigationBuildContext {
+  appId: string;
   deviceId: string;
   versionCode: number;
   contentHash: string;
@@ -370,7 +373,10 @@ export class NavigationGraphManager implements NavigationGraphService {
     } {
     const ctx = this.currentBuildContext;
     const sessionUuid = this.sessionUuid ?? LEGACY_PROVENANCE_SENTINEL;
-    if (ctx) {
+    // Only apply the context to the app it was resolved for; a context for a
+    // different (or unset) app falls back to the default key rather than stamping
+    // this app's provenance with another build's version/hash.
+    if (ctx && ctx.appId === this.currentAppId) {
       return {
         versionCode: ctx.versionCode,
         contentHash: ctx.contentHash,
@@ -379,7 +385,7 @@ export class NavigationGraphManager implements NavigationGraphService {
       };
     }
     logger.debug(
-      `[NAVIGATION_GRAPH] No build context set for ${this.currentAppId ?? "?"}; ` +
+      `[NAVIGATION_GRAPH] No matching build context for ${this.currentAppId ?? "?"}; ` +
       `recording provenance under the default build key`
     );
     return { versionCode: 0, contentHash: "", deviceId: LEGACY_PROVENANCE_SENTINEL, sessionUuid };

--- a/src/features/navigation/NavigationGraphManager.ts
+++ b/src/features/navigation/NavigationGraphManager.ts
@@ -763,15 +763,19 @@ export class NavigationGraphManager implements NavigationGraphService {
     const fingerprintData = event.fingerprintData || JSON.stringify({ hash: fingerprintHash });
     const timestamp = event.timestamp;
 
-    // Capture the app ONCE before the awaited fingerprint lookup: if an app switch
-    // lands during the await, the matched node belongs to THIS app, so its provenance
-    // must resolve for this app too — not whatever currentAppId became (#4984).
+    // Snapshot the FULL provenance (app + device + build key) ONCE before the first
+    // await: reading only appId early but re-reading the mutable build/device context
+    // after the fingerprint lookup would let a concurrent event (a second unbound
+    // device routing through the global manager) swap the context mid-lookup, stamping
+    // this reach with another device's identity/hash. Capturing everything up front and
+    // threading the immutable snapshot means no code path re-reads mutable state after
+    // any await (#4984).
     const appId = this.currentAppId;
+    const provenance = this.resolveProvenance(appId);
 
     // Case 1: Check if fingerprint is already correlated to a named node (scoped to this app)
     const existingNode = await this.repository.getNodeByFingerprint(appId, fingerprintHash);
     if (existingNode) {
-      const provenance = this.resolveProvenance(appId);
 
       // Persist the counter writes atomically across BOTH repos via the shared helper,
       // which owns the assertSharedConnection() precondition and the bind-both-repos
@@ -1730,7 +1734,19 @@ export class NavigationGraphManager implements NavigationGraphService {
 
     const appId = this.currentAppId;
     const timestamp = this.timer.now();
-    const provenance = this.resolveProvenance(appId);
+    // Record the promoted node under the DEFAULT/unknown build key, NOT the current
+    // (promotion-time) build/device (#4984). The suggestion's original reaches were
+    // captured under whatever build saw them, but `navigation_suggestions` stores no
+    // provenance, so stamping promotion-time identity would falsely claim the promoting
+    // build/device did the historical reach. Recording under the default key makes the
+    // promoted node visible without a false claim; transferring real suggestion
+    // provenance is a follow-up (needs a suggestions-schema change).
+    const provenance: ResolvedProvenance = {
+      versionCode: 0,
+      contentHash: "",
+      deviceId: LEGACY_PROVENANCE_SENTINEL,
+      sessionUuid: this.sessionUuid ?? LEGACY_PROVENANCE_SENTINEL,
+    };
 
     // Persist the node creation + suggestion promotion atomically. repository.promoteSuggestion
     // does getOrCreateFingerprint + an UPDATE to link the suggestion; without a transaction a
@@ -1750,9 +1766,9 @@ export class NavigationGraphManager implements NavigationGraphService {
       // Promote the suggestion (creates fingerprint and links suggestion)
       await repository.promoteSuggestion(suggestionId, node.id, timestamp);
 
-      // Record provenance for the promoted node (#4984): promotion is a reach the
-      // suggestion captured, so the node must appear in build/device-scoped analysis
-      // rather than having a visit count but no observation until reached again.
+      // Record an observation for the promoted node under the default/unknown key
+      // (see the provenance snapshot above), so it is visible in analysis rather than
+      // having a visit count but no observation, without a false build/device claim.
       await this.recordNodeProvenance(repository, appId, node.id, timestamp, provenance);
 
       // #4931: touch navigation_apps.updated_at atomically with the promotion.

--- a/src/features/navigation/NavigationGraphManager.ts
+++ b/src/features/navigation/NavigationGraphManager.ts
@@ -142,6 +142,13 @@ export class NavigationGraphManager implements NavigationGraphService {
   private static instance: NavigationGraphManager | null = null;
   // Per-session instances for multi-agent isolation
   private static sessionInstances: Map<string, NavigationGraphManager> = new Map();
+  // Session UUIDs that have been released (#4984). Session UUIDs are never reused, so
+  // a getInstanceForSession() for a released id is a post-release stray event — it
+  // must resolve to the unattributed global singleton, never recreate a manager that
+  // would attribute the observation to the ended session. Bounded to avoid unbounded
+  // growth over a long-lived daemon.
+  private static releasedSessions: Set<string> = new Set();
+  private static readonly RELEASED_SESSIONS_CAP = 4096;
 
   private repository: NavigationRepository;
   private testCoverageRepository: TestCoverageRepository;
@@ -235,6 +242,13 @@ export class NavigationGraphManager implements NavigationGraphService {
   public static getInstanceForSession(sessionId: string): NavigationGraphManager {
     let instance = NavigationGraphManager.sessionInstances.get(sessionId);
     if (!instance) {
+      // A released session never legitimately returns (UUIDs are unique), so a
+      // request for one here is a stray post-release event: route it to the
+      // unattributed global singleton instead of minting a manager that would
+      // attribute the observation to the ended session (#4984).
+      if (NavigationGraphManager.releasedSessions.has(sessionId)) {
+        return NavigationGraphManager.getInstance();
+      }
       instance = new NavigationGraphManager(undefined, undefined, undefined, sessionId);
       NavigationGraphManager.sessionInstances.set(sessionId, instance);
     }
@@ -254,6 +268,16 @@ export class NavigationGraphManager implements NavigationGraphService {
       NavigationGraphManager.sessionInstances.delete(sessionId);
       logger.debug(`[NAV_GRAPH] Released session instance: ${sessionId}`);
     }
+    // Mark released even if no instance existed yet, so a later stray event for this
+    // session resolves to the unattributed global rather than minting a manager for
+    // the ended session (#4984). Bounded FIFO to cap long-daemon growth.
+    NavigationGraphManager.releasedSessions.add(sessionId);
+    if (NavigationGraphManager.releasedSessions.size > NavigationGraphManager.RELEASED_SESSIONS_CAP) {
+      const oldest = NavigationGraphManager.releasedSessions.values().next().value;
+      if (oldest !== undefined) {
+        NavigationGraphManager.releasedSessions.delete(oldest);
+      }
+    }
   }
 
   /**
@@ -262,6 +286,7 @@ export class NavigationGraphManager implements NavigationGraphService {
   public static resetInstance(): void {
     NavigationGraphManager.instance = null;
     NavigationGraphManager.sessionInstances.clear();
+    NavigationGraphManager.releasedSessions.clear();
   }
 
   /**
@@ -288,6 +313,8 @@ export class NavigationGraphManager implements NavigationGraphService {
     sessionId: string,
     instance: NavigationGraphManager
   ): void {
+    // Installing an instance clears any released-mark so the id resolves to it.
+    NavigationGraphManager.releasedSessions.delete(sessionId);
     NavigationGraphManager.sessionInstances.set(sessionId, instance);
   }
 

--- a/src/features/navigation/NavigationGraphManager.ts
+++ b/src/features/navigation/NavigationGraphManager.ts
@@ -392,9 +392,9 @@ export class NavigationGraphManager implements NavigationGraphService {
    * setBuildContext mid-transaction, and resolving separately per observation would
    * split a single transition across two build keys.
    */
-  private resolveProvenance(): ResolvedProvenance {
+  private resolveProvenance(appId: string | null): ResolvedProvenance {
     const sessionUuid = this.sessionUuid ?? LEGACY_PROVENANCE_SENTINEL;
-    const ctx = this.currentAppId ? this.buildContexts.get(this.currentAppId) : undefined;
+    const ctx = appId ? this.buildContexts.get(appId) : undefined;
     if (ctx) {
       return {
         versionCode: ctx.versionCode,
@@ -404,7 +404,7 @@ export class NavigationGraphManager implements NavigationGraphService {
       };
     }
     logger.debug(
-      `[NAVIGATION_GRAPH] No matching build context for ${this.currentAppId ?? "?"}; ` +
+      `[NAVIGATION_GRAPH] No matching build context for ${appId ?? "?"}; ` +
       `recording provenance under the default build key`
     );
     return { versionCode: 0, contentHash: "", deviceId: LEGACY_PROVENANCE_SENTINEL, sessionUuid };
@@ -506,7 +506,7 @@ export class NavigationGraphManager implements NavigationGraphService {
 
     // Snapshot provenance ONCE for this transition so the node and edge observations
     // share one build key even if a fire-and-forget hash lands mid-transaction (#4984).
-    const provenance = this.resolveProvenance();
+    const provenance = this.resolveProvenance(appId);
 
     // Persist the whole graph write atomically across BOTH repos via the shared helper,
     // which owns the assertSharedConnection() precondition and the bind-both-repos
@@ -725,11 +725,15 @@ export class NavigationGraphManager implements NavigationGraphService {
     const fingerprintData = event.fingerprintData || JSON.stringify({ hash: fingerprintHash });
     const timestamp = event.timestamp;
 
+    // Capture the app ONCE before the awaited fingerprint lookup: if an app switch
+    // lands during the await, the matched node belongs to THIS app, so its provenance
+    // must resolve for this app too — not whatever currentAppId became (#4984).
+    const appId = this.currentAppId;
+
     // Case 1: Check if fingerprint is already correlated to a named node (scoped to this app)
-    const existingNode = await this.repository.getNodeByFingerprint(this.currentAppId, fingerprintHash);
+    const existingNode = await this.repository.getNodeByFingerprint(appId, fingerprintHash);
     if (existingNode) {
-      const appId = this.currentAppId;
-      const provenance = this.resolveProvenance();
+      const provenance = this.resolveProvenance(appId);
 
       // Persist the counter writes atomically across BOTH repos via the shared helper,
       // which owns the assertSharedConnection() precondition and the bind-both-repos

--- a/src/features/observe/android/AndroidCtrlProxyClient.ts
+++ b/src/features/observe/android/AndroidCtrlProxyClient.ts
@@ -1130,6 +1130,13 @@ export class AndroidCtrlProxyClient extends DeviceServiceClient implements Andro
       this.getNavigationGraphManager().setBuildContext(resolved);
       return;
     }
+    // No resolved context on THIS client for the app: clear it from the currently
+    // selected manager so a context left by a previous binding/selection (e.g. set on
+    // the global manager while unbound, then not cleared when a later package_event
+    // invalidated only the bound manager) is never served as stale (#4984). Falls to
+    // the default/unattributed key until (re)resolution lands. Synchronous, so it
+    // takes effect before this event's write reads provenance.
+    this.getNavigationGraphManager().clearBuildContext(appId);
     if (this.buildContextInFlight.has(appId)) {
       return;
     }
@@ -1500,8 +1507,26 @@ export class AndroidCtrlProxyClient extends DeviceServiceClient implements Andro
       this.hierarchyNavigationDetector = null;
     }
 
+    // Revalidate build/device provenance across a disconnect (#4984): while the WS has
+    // no client, a package_event has zero listeners, so an app could be replaced
+    // unobserved. Invalidate every known app's cached context — clearing the resolved
+    // context, the provider's hash cache, and bumping the generation so any in-flight
+    // resolution is discarded — so the next nav event after reconnect re-resolves the
+    // hash instead of attributing to the pre-update build indefinitely.
+    for (const appId of this.knownBuildContextApps()) {
+      this.invalidateBuildContext(appId);
+    }
+
     // Stop work profile monitor when connection closes
     this.stopWorkProfileMonitor();
+  }
+
+  /** Every app id with cached or in-flight build-context state (#4984). */
+  private knownBuildContextApps(): string[] {
+    return Array.from(new Set([
+      ...this.resolvedBuildContexts.keys(),
+      ...this.buildContextInFlight,
+    ]));
   }
 
   protected async setupBeforeConnect(perf: PerformanceTracker): Promise<void> {

--- a/src/features/observe/android/AndroidCtrlProxyClient.ts
+++ b/src/features/observe/android/AndroidCtrlProxyClient.ts
@@ -1087,6 +1087,22 @@ export class AndroidCtrlProxyClient extends DeviceServiceClient implements Andro
   }
 
   /**
+   * Release this client's binding to a session that has ended (#4984). If still
+   * bound to `sessionId`, drop the binding and dispose the cached hierarchy detector
+   * so a post-release event (before any new session binds the still-connected
+   * device) routes to the unattributed global manager, never the ended session's.
+   */
+  public releaseSessionBinding(sessionId: string): void {
+    if (this.boundSessionId === sessionId) {
+      this.boundSessionId = null;
+      if (this.hierarchyNavigationDetector) {
+        this.hierarchyNavigationDetector.dispose();
+        this.hierarchyNavigationDetector = null;
+      }
+    }
+  }
+
+  /**
    * Get the NavigationGraphManager for the bound session, or the global singleton.
    */
   private getNavigationGraphManager(): NavigationGraphManager {

--- a/src/features/observe/android/AndroidCtrlProxyClient.ts
+++ b/src/features/observe/android/AndroidCtrlProxyClient.ts
@@ -3389,6 +3389,15 @@ export class AndroidCtrlProxyClient extends DeviceServiceClient implements Andro
     const eventTimestamp = typeof timestamp === "number" ? timestamp : this.timer.now();
     const repo = this.getInstalledAppsRepository();
 
+    // Invalidate cached build/content-hash provenance for this package (#4984) so the
+    // next nav event re-resolves the hash. A rebuild+reinstall — INCLUDING the
+    // same-versionCode/different-content daily-dev case — must not keep recording
+    // against the previous build's hash. Clears the re-lookup guard, the provider's
+    // (device,package) cache across all versionCodes, and the manager's context.
+    this.buildContextResolvedApps.delete(event.packageName);
+    this.contentHashProvider?.invalidate(deviceId, event.packageName);
+    this.getNavigationGraphManager().clearBuildContext(event.packageName);
+
     try {
       if (event.action === "removed") {
         if (event.removedForAllUsers) {

--- a/src/features/observe/android/AndroidCtrlProxyClient.ts
+++ b/src/features/observe/android/AndroidCtrlProxyClient.ts
@@ -1054,6 +1054,10 @@ export class AndroidCtrlProxyClient extends DeviceServiceClient implements Andro
    * Called when a tool execution context binds a session to this device.
    */
   public bindSession(sessionId: string): void {
+    // Binding means this session is live again — clear any released-tombstone so a
+    // reused uuid (e.g. setActiveDevice re-creating the session on another device)
+    // gets its own manager rather than the unattributed global (#4984).
+    NavigationGraphManager.clearReleasedSession(sessionId);
     if (this.boundSessionId !== sessionId) {
       // A per-device client routes nav events to whichever session bound last.
       // That is correct under the pool's one-device-one-live-session invariant

--- a/src/features/observe/android/AndroidCtrlProxyClient.ts
+++ b/src/features/observe/android/AndroidCtrlProxyClient.ts
@@ -37,6 +37,7 @@ import { AndroidCtrlProxyManager } from "../../../utils/CtrlProxyManager";
 import { PerformanceTracker, NoOpPerformanceTracker } from "../../../utils/PerformanceTracker";
 import { Timer, defaultTimer } from "../../../utils/SystemTimer";
 import { NavigationGraphManager, NavigationEvent } from "../../navigation/NavigationGraphManager";
+import { createContentHashProvider, type ContentHashProvider } from "../../../utils/ContentHashProvider";
 import { NavigationScreenshotManager } from "../../navigation/NavigationScreenshotManager";
 import { HierarchyNavigationDetector } from "../../navigation/HierarchyNavigationDetector";
 import { InstalledAppsRepository, InstalledAppsStore } from "../../../db/installedAppsRepository";
@@ -905,6 +906,12 @@ export class AndroidCtrlProxyClient extends DeviceServiceClient implements Andro
   // Session binding for multi-agent isolation
   private boundSessionId: string | null = null;
 
+  // Build/device provenance (#4984): lazily-built content-hash provider (cached by
+  // (deviceId, packageId, versionCode)) and the set of app ids whose build context
+  // resolution has already been kicked off, so we resolve once per install.
+  private contentHashProvider: ContentHashProvider | null = null;
+  private buildContextResolvedApps: Set<string> = new Set();
+
   // Hierarchy caching (accessed by delegates via context)
   private cachedHierarchy: CachedHierarchy | null = null;
 
@@ -1081,6 +1088,51 @@ export class AndroidCtrlProxyClient extends DeviceServiceClient implements Andro
     return this.boundSessionId
       ? NavigationGraphManager.getInstanceForSession(this.boundSessionId)
       : NavigationGraphManager.getInstance();
+  }
+
+  /**
+   * Eagerly resolve the build/device provenance context for an app and set it on
+   * the session's navigation manager (#4984). Non-blocking and idempotent: the
+   * content hash resolves once per install (cached), so a nav event that arrives
+   * before it lands records under the default build key. Only sets a full build
+   * context once a real content hash is available.
+   */
+  private ensureBuildContext(appId: string): void {
+    if (this.buildContextResolvedApps.has(appId)) {
+      return;
+    }
+    this.buildContextResolvedApps.add(appId);
+
+    const resolve = async (): Promise<void> => {
+      try {
+        const info = await this.requestPackageInfo(appId, { includePermissions: false }, 4000);
+        const versionCode = info.success && typeof info.versionCode === "number" ? info.versionCode : 0;
+        if (!this.contentHashProvider) {
+          this.contentHashProvider = createContentHashProvider(this.device);
+        }
+        const contentHash = await this.contentHashProvider.resolveContentHash(this.device, appId, versionCode);
+        if (contentHash === null) {
+          // Unresolved hash: leave the default build key in effect and retry on a
+          // later event (drop the memo so ensureBuildContext runs again).
+          this.buildContextResolvedApps.delete(appId);
+          return;
+        }
+        this.getNavigationGraphManager().setBuildContext({
+          deviceId: this.device.deviceId,
+          versionCode,
+          contentHash,
+        });
+      } catch (error) {
+        // Best-effort provenance: log and let mutations fall back to the default key.
+        this.buildContextResolvedApps.delete(appId);
+        logger.debug(`[CTRL_PROXY] Build-context resolution failed for ${appId}: ${error}`);
+      }
+    };
+
+    // Fire-and-forget: resolution only sets in-memory build context (no DB write),
+    // so it is NOT enlisted in the DB-write shutdown barrier. Errors are handled
+    // inside resolve().
+    void resolve();
   }
 
   /**
@@ -2772,6 +2824,10 @@ export class AndroidCtrlProxyClient extends DeviceServiceClient implements Andro
           }
           if (event.applicationId) {
             this.sdkNavigationAppIds.add(event.applicationId);
+            // Eagerly resolve build/device provenance for this app (#4984).
+            // Non-blocking: later events pick up the resolved build key; this
+            // event may still record under the default key.
+            this.ensureBuildContext(event.applicationId);
           }
           // Attach last interaction for telemetry correlation
           if (this.lastInteraction) {

--- a/src/features/observe/android/AndroidCtrlProxyClient.ts
+++ b/src/features/observe/android/AndroidCtrlProxyClient.ts
@@ -1128,7 +1128,9 @@ export class AndroidCtrlProxyClient extends DeviceServiceClient implements Andro
         }
         const versionCode = info.versionCode;
         if (!this.contentHashProvider) {
-          this.contentHashProvider = createContentHashProvider(this.device);
+          // Use the injected executor so tests with a fake adb never launch real
+          // `adb`, and custom production executors aren't bypassed (#4984).
+          this.contentHashProvider = createContentHashProvider(this.device, this.adb);
         }
         const contentHash = await this.contentHashProvider.resolveContentHash(this.device, appId, versionCode);
         // Discard if a package change invalidated this app while we were resolving —

--- a/src/features/observe/android/AndroidCtrlProxyClient.ts
+++ b/src/features/observe/android/AndroidCtrlProxyClient.ts
@@ -1119,7 +1119,14 @@ export class AndroidCtrlProxyClient extends DeviceServiceClient implements Andro
     const resolve = async (): Promise<void> => {
       try {
         const info = await this.requestPackageInfo(appId, { includePermissions: false }, 4000);
-        const versionCode = info.success && typeof info.versionCode === "number" ? info.versionCode : 0;
+        // A transient package-info failure (timeout / success:false) must NOT be
+        // cached as version 0 — that would attribute the whole install to a bogus
+        // version until a package event. Defer; a later event retries.
+        if (!info.success || typeof info.versionCode !== "number") {
+          logger.debug(`[CTRL_PROXY] Package info unavailable for ${appId}; deferring build-context resolution`);
+          return;
+        }
+        const versionCode = info.versionCode;
         if (!this.contentHashProvider) {
           this.contentHashProvider = createContentHashProvider(this.device);
         }
@@ -3073,6 +3080,12 @@ export class AndroidCtrlProxyClient extends DeviceServiceClient implements Andro
     } else if (!this.shouldUseHierarchyNavigation(data.packageName)) {
       logger.debug(`[CTRL_PROXY] Skipping hierarchy navigation for SDK app: ${data.packageName}`);
     } else {
+      // Resolve build/device provenance for hierarchy-driven reaches too (#4984):
+      // non-SDK apps never emit navigation_event, so this is the only path that gives
+      // them a real build key instead of the default/legacy one.
+      if (data.packageName) {
+        this.ensureBuildContext(data.packageName);
+      }
       this.getHierarchyNavigationDetector().onHierarchyUpdate(data);
     }
   }

--- a/src/features/observe/android/AndroidCtrlProxyClient.ts
+++ b/src/features/observe/android/AndroidCtrlProxyClient.ts
@@ -1175,10 +1175,16 @@ export class AndroidCtrlProxyClient extends DeviceServiceClient implements Andro
       }
     };
 
+    // Defer the resolution to a macrotask so NO work runs inline with the current
+    // WebSocket message handler (#4984/#2885). resolve() would otherwise call
+    // requestPackageInfo synchronously — a WS send plus a RequestManager timeout
+    // timer — which reorders the barrier-tracked navigation-graph write and the
+    // socket-close cache invalidation on differently-scheduled runners (macOS/Windows
+    // CI). Scheduling on the injected timer keeps the event handler's barrier
+    // registration synchronous and first, with the hash resolving out-of-band.
     // Fire-and-forget: resolution only sets in-memory build context (no DB write),
-    // so it is NOT enlisted in the DB-write shutdown barrier. Errors are handled
-    // inside resolve().
-    void resolve();
+    // so it is NOT enlisted in the DB-write shutdown barrier.
+    this.timer.setTimeout(() => { void resolve(); }, 0);
   }
 
   /**

--- a/src/features/observe/android/AndroidCtrlProxyClient.ts
+++ b/src/features/observe/android/AndroidCtrlProxyClient.ts
@@ -36,7 +36,7 @@ import { readScreenScaleMetadata } from "../../../models/ScreenScaleMetadata";
 import { AndroidCtrlProxyManager } from "../../../utils/CtrlProxyManager";
 import { PerformanceTracker, NoOpPerformanceTracker } from "../../../utils/PerformanceTracker";
 import { Timer, defaultTimer } from "../../../utils/SystemTimer";
-import { NavigationGraphManager, NavigationEvent } from "../../navigation/NavigationGraphManager";
+import { NavigationGraphManager, NavigationEvent, type NavigationBuildContext } from "../../navigation/NavigationGraphManager";
 import { createContentHashProvider, type ContentHashProvider } from "../../../utils/ContentHashProvider";
 import { NavigationScreenshotManager } from "../../navigation/NavigationScreenshotManager";
 import { HierarchyNavigationDetector } from "../../navigation/HierarchyNavigationDetector";
@@ -907,10 +907,15 @@ export class AndroidCtrlProxyClient extends DeviceServiceClient implements Andro
   private boundSessionId: string | null = null;
 
   // Build/device provenance (#4984): lazily-built content-hash provider (cached by
-  // (deviceId, packageId, versionCode)) and the set of app ids whose build context
-  // resolution has already been kicked off, so we resolve once per install.
+  // (deviceId, packageId, versionCode)), the resolved build context per app (kept on
+  // the per-device client so it survives session rebinds and is re-applied to the
+  // current session's manager on every event), the set of apps whose resolution is
+  // in flight, and a per-app generation bumped on package changes so a resolution
+  // that started before an update can't apply a stale build.
   private contentHashProvider: ContentHashProvider | null = null;
-  private buildContextResolvedApps: Set<string> = new Set();
+  private resolvedBuildContexts: Map<string, NavigationBuildContext> = new Map();
+  private buildContextInFlight: Set<string> = new Set();
+  private buildContextGeneration: Map<string, number> = new Map();
 
   // Hierarchy caching (accessed by delegates via context)
   private cachedHierarchy: CachedHierarchy | null = null;
@@ -1091,17 +1096,25 @@ export class AndroidCtrlProxyClient extends DeviceServiceClient implements Andro
   }
 
   /**
-   * Eagerly resolve the build/device provenance context for an app and set it on
-   * the session's navigation manager (#4984). Non-blocking and idempotent: the
-   * content hash resolves once per install (cached), so a nav event that arrives
-   * before it lands records under the default build key. Only sets a full build
-   * context once a real content hash is available.
+   * Ensure the build/device provenance context for an app is applied to the CURRENT
+   * session's navigation manager (#4984). Non-blocking.
+   *
+   * Re-applies an already-resolved context on every event: the per-device client
+   * outlives session rebinds, so a context resolved under session A must still be
+   * set on session B's fresh manager. Otherwise it kicks off a one-in-flight
+   * resolution; a nav event arriving before it lands records under the default key.
    */
   private ensureBuildContext(appId: string): void {
-    if (this.buildContextResolvedApps.has(appId)) {
+    const resolved = this.resolvedBuildContexts.get(appId);
+    if (resolved) {
+      this.getNavigationGraphManager().setBuildContext(resolved);
       return;
     }
-    this.buildContextResolvedApps.add(appId);
+    if (this.buildContextInFlight.has(appId)) {
+      return;
+    }
+    this.buildContextInFlight.add(appId);
+    const startGeneration = this.buildContextGeneration.get(appId) ?? 0;
 
     const resolve = async (): Promise<void> => {
       try {
@@ -1111,22 +1124,29 @@ export class AndroidCtrlProxyClient extends DeviceServiceClient implements Andro
           this.contentHashProvider = createContentHashProvider(this.device);
         }
         const contentHash = await this.contentHashProvider.resolveContentHash(this.device, appId, versionCode);
-        if (contentHash === null) {
-          // Unresolved hash: leave the default build key in effect and retry on a
-          // later event (drop the memo so ensureBuildContext runs again).
-          this.buildContextResolvedApps.delete(appId);
+        // Discard if a package change invalidated this app while we were resolving —
+        // applying now would stamp observations with the pre-update build's hash.
+        if ((this.buildContextGeneration.get(appId) ?? 0) !== startGeneration) {
           return;
         }
-        this.getNavigationGraphManager().setBuildContext({
+        if (contentHash === null) {
+          // Unresolved hash: leave the default build key; a later event retries.
+          return;
+        }
+        const context: NavigationBuildContext = {
           appId,
           deviceId: this.device.deviceId,
           versionCode,
           contentHash,
-        });
+        };
+        this.resolvedBuildContexts.set(appId, context);
+        this.getNavigationGraphManager().setBuildContext(context);
       } catch (error) {
-        // Best-effort provenance: log and let mutations fall back to the default key.
-        this.buildContextResolvedApps.delete(appId);
-        logger.debug(`[CTRL_PROXY] Build-context resolution failed for ${appId}: ${error}`);
+        // Best-effort provenance: log at warn (unexpected failure of a diagnostic
+        // path per CLAUDE.md) and let mutations fall back to the default key.
+        logger.warn(`[CTRL_PROXY] Build-context resolution failed for ${appId}: ${error}`);
+      } finally {
+        this.buildContextInFlight.delete(appId);
       }
     };
 
@@ -1134,6 +1154,20 @@ export class AndroidCtrlProxyClient extends DeviceServiceClient implements Andro
     // so it is NOT enlisted in the DB-write shutdown barrier. Errors are handled
     // inside resolve().
     void resolve();
+  }
+
+  /**
+   * Invalidate all cached build/content-hash provenance for an app (#4984), so its
+   * next nav event re-resolves the hash. Called on a package add/replace/remove — a
+   * rebuild+reinstall (including same-versionCode/different-content) must not keep
+   * recording against the old build. Bumps the generation so an in-flight resolution
+   * that started before the change is discarded rather than applying a stale build.
+   */
+  private invalidateBuildContext(appId: string): void {
+    this.buildContextGeneration.set(appId, (this.buildContextGeneration.get(appId) ?? 0) + 1);
+    this.resolvedBuildContexts.delete(appId);
+    this.contentHashProvider?.invalidate(this.device.deviceId, appId);
+    this.getNavigationGraphManager().clearBuildContext(appId);
   }
 
   /**
@@ -3390,13 +3424,10 @@ export class AndroidCtrlProxyClient extends DeviceServiceClient implements Andro
     const repo = this.getInstalledAppsRepository();
 
     // Invalidate cached build/content-hash provenance for this package (#4984) so the
-    // next nav event re-resolves the hash. A rebuild+reinstall — INCLUDING the
-    // same-versionCode/different-content daily-dev case — must not keep recording
-    // against the previous build's hash. Clears the re-lookup guard, the provider's
-    // (device,package) cache across all versionCodes, and the manager's context.
-    this.buildContextResolvedApps.delete(event.packageName);
-    this.contentHashProvider?.invalidate(deviceId, event.packageName);
-    this.getNavigationGraphManager().clearBuildContext(event.packageName);
+    // next nav event re-resolves the hash. Fires for every action (add/replace/remove)
+    // — a rebuild+reinstall, INCLUDING the same-versionCode/different-content daily-dev
+    // case, must not keep recording against the previous build's hash.
+    this.invalidateBuildContext(event.packageName);
 
     try {
       if (event.action === "removed") {

--- a/src/features/observe/android/AndroidCtrlProxyClient.ts
+++ b/src/features/observe/android/AndroidCtrlProxyClient.ts
@@ -1118,6 +1118,7 @@ export class AndroidCtrlProxyClient extends DeviceServiceClient implements Andro
           return;
         }
         this.getNavigationGraphManager().setBuildContext({
+          appId,
           deviceId: this.device.deviceId,
           versionCode,
           contentHash,

--- a/src/features/observe/android/CtrlProxyPackages.ts
+++ b/src/features/observe/android/CtrlProxyPackages.ts
@@ -14,6 +14,7 @@ import type {
   A11yLaunchIntentResult,
 } from "./types";
 import { ctrlProxyRequests, serializeCtrlProxyRequest } from "./ctrlProxyProtocol";
+import { logger } from "../../../utils/logger";
 
 export interface PackageInfoOptions {
   includePermissions?: boolean;
@@ -48,6 +49,14 @@ export class CtrlProxyPackages {
         };
       }
 
+      // Check the socket is OPEN BEFORE registering, so an already-closed socket
+      // never leaves a registered request orphaned (a later cancelAll would reject
+      // an un-awaited promise as an unhandled rejection).
+      const ws = this.context.getWebSocket();
+      if (!ws || ws.readyState !== WebSocket.OPEN) {
+        throw new Error("WebSocket not connected");
+      }
+
       const requestId = `installed_packages_${this.context.timer.now()}_${generateSecureId()}`;
       const resultPromise = this.context.requestManager.register<A11yInstalledPackagesResult>(
         requestId,
@@ -62,15 +71,21 @@ export class CtrlProxyPackages {
         })
       );
 
-      const ws = this.context.getWebSocket();
-      if (!ws || ws.readyState !== WebSocket.OPEN) {
-        throw new Error("WebSocket not connected");
+      try {
+        ws.send(
+          serializeCtrlProxyRequest(
+            ctrlProxyRequests.requestInstalledPackages({ requestId, includeSystem, userId })
+          )
+        );
+      } catch (sendError) {
+        // Settle the registered request rather than orphaning it (see requestPackageInfo).
+        logger.warn(`[CtrlProxyPackages] installed_packages send failed: ${sendError}`);
+        this.context.requestManager.resolveError(
+          requestId,
+          `${sendError}`,
+          this.context.timer.now() - startTime
+        );
       }
-      ws.send(
-        serializeCtrlProxyRequest(
-          ctrlProxyRequests.requestInstalledPackages({ requestId, includeSystem, userId })
-        )
-      );
 
       return await resultPromise;
     } catch (error) {
@@ -146,6 +161,7 @@ export class CtrlProxyPackages {
         // Settle the just-registered request rather than orphaning it, so the
         // always-awaited resultPromise below returns the failure instead of a later
         // cancelAll surfacing an unhandled rejection.
+        logger.warn(`[CtrlProxyPackages] package_info send failed for ${packageName}: ${sendError}`);
         this.context.requestManager.resolveError(
           requestId,
           `${sendError}`,
@@ -187,6 +203,14 @@ export class CtrlProxyPackages {
         };
       }
 
+      // Check the socket is OPEN BEFORE registering, so an already-closed socket
+      // never leaves a registered request orphaned (a later cancelAll would reject
+      // an un-awaited promise as an unhandled rejection).
+      const ws = this.context.getWebSocket();
+      if (!ws || ws.readyState !== WebSocket.OPEN) {
+        throw new Error("WebSocket not connected");
+      }
+
       const requestId = `launch_intent_${this.context.timer.now()}_${generateSecureId()}`;
       const resultPromise = this.context.requestManager.register<A11yLaunchIntentResult>(
         requestId,
@@ -200,13 +224,19 @@ export class CtrlProxyPackages {
         })
       );
 
-      const ws = this.context.getWebSocket();
-      if (!ws || ws.readyState !== WebSocket.OPEN) {
-        throw new Error("WebSocket not connected");
+      try {
+        ws.send(
+          serializeCtrlProxyRequest(ctrlProxyRequests.requestLaunchIntent({ requestId, packageName }))
+        );
+      } catch (sendError) {
+        // Settle the registered request rather than orphaning it (see requestPackageInfo).
+        logger.warn(`[CtrlProxyPackages] launch_intent send failed for ${packageName}: ${sendError}`);
+        this.context.requestManager.resolveError(
+          requestId,
+          `${sendError}`,
+          this.context.timer.now() - startTime
+        );
       }
-      ws.send(
-        serializeCtrlProxyRequest(ctrlProxyRequests.requestLaunchIntent({ requestId, packageName }))
-      );
 
       return await resultPromise;
     } catch (error) {

--- a/src/features/observe/android/CtrlProxyPackages.ts
+++ b/src/features/observe/android/CtrlProxyPackages.ts
@@ -108,6 +108,14 @@ export class CtrlProxyPackages {
         };
       }
 
+      // Check the socket is OPEN BEFORE registering, so an already-closed socket
+      // never leaves a registered request orphaned (a later cancelAll would reject
+      // an un-awaited promise as an unhandled rejection).
+      const ws = this.context.getWebSocket();
+      if (!ws || ws.readyState !== WebSocket.OPEN) {
+        throw new Error("WebSocket not connected");
+      }
+
       const requestId = `package_info_${this.context.timer.now()}_${generateSecureId()}`;
       const resultPromise = this.context.requestManager.register<A11yPackageInfoResult>(
         requestId,
@@ -124,19 +132,26 @@ export class CtrlProxyPackages {
         })
       );
 
-      const ws = this.context.getWebSocket();
-      if (!ws || ws.readyState !== WebSocket.OPEN) {
-        throw new Error("WebSocket not connected");
+      try {
+        ws.send(
+          serializeCtrlProxyRequest(
+            ctrlProxyRequests.requestPackageInfo({
+              requestId,
+              packageName,
+              includePermissions: options.includePermissions ?? true,
+            })
+          )
+        );
+      } catch (sendError) {
+        // Settle the just-registered request rather than orphaning it, so the
+        // always-awaited resultPromise below returns the failure instead of a later
+        // cancelAll surfacing an unhandled rejection.
+        this.context.requestManager.resolveError(
+          requestId,
+          `${sendError}`,
+          this.context.timer.now() - startTime
+        );
       }
-      ws.send(
-        serializeCtrlProxyRequest(
-          ctrlProxyRequests.requestPackageInfo({
-            requestId,
-            packageName,
-            includePermissions: options.includePermissions ?? true,
-          })
-        )
-      );
 
       return await resultPromise;
     } catch (error) {

--- a/src/features/observe/ios/IOSCtrlProxyClient.ts
+++ b/src/features/observe/ios/IOSCtrlProxyClient.ts
@@ -653,6 +653,22 @@ export class IOSCtrlProxyClient extends DeviceServiceClient implements IOSCtrlPr
   }
 
   /**
+   * Release this client's binding to a session that has ended (#4984). If still
+   * bound to `sessionId`, drop the binding and dispose the cached hierarchy detector
+   * so a post-release event routes to the unattributed global manager, never the
+   * ended session's. Mirrors AndroidCtrlProxyClient.releaseSessionBinding.
+   */
+  public releaseSessionBinding(sessionId: string): void {
+    if (this.boundSessionId === sessionId) {
+      this.boundSessionId = null;
+      if (this.hierarchyNavigationDetector) {
+        this.hierarchyNavigationDetector.dispose();
+        this.hierarchyNavigationDetector = null;
+      }
+    }
+  }
+
+  /**
    * Get the NavigationGraphManager for the bound session, or the global singleton.
    */
   private getNavigationGraphManager(): NavigationGraphManager {

--- a/src/features/observe/ios/IOSCtrlProxyClient.ts
+++ b/src/features/observe/ios/IOSCtrlProxyClient.ts
@@ -624,6 +624,10 @@ export class IOSCtrlProxyClient extends DeviceServiceClient implements IOSCtrlPr
    * Bind this client to a session for multi-agent NavigationGraphManager isolation.
    */
   public bindSession(sessionId: string): void {
+    // Binding means this session is live again — clear any released-tombstone so a
+    // reused uuid (e.g. setActiveDevice re-creating the session on another device)
+    // gets its own manager rather than the unattributed global (#4984).
+    NavigationGraphManager.clearReleasedSession(sessionId);
     if (this.boundSessionId !== sessionId) {
       // See AndroidCtrlProxyClient.bindSession: a per-device client is
       // last-writer-wins. Trace a transition off a previously-bound session so a

--- a/src/server/deviceLabelMapping.ts
+++ b/src/server/deviceLabelMapping.ts
@@ -113,7 +113,11 @@ export const releaseDeviceLabelSessions = async (baseSessionUuid: string): Promi
       continue;
     }
     const deviceId = session.assignedDevice;
-    sessionManager.releaseSession(sessionUuid);
+    // Await the release so its central onSessionRelease cleanup (CtrlProxy binding +
+    // build-context/detector) completes BEFORE the device is returned to the pool and
+    // possibly reassigned — otherwise hierarchy/nav broadcasts during the release get
+    // recorded under the ended session's uuid. Mirrors the base-session path (#4984).
+    await sessionManager.releaseSession(sessionUuid);
     await devicePool.releaseDevice(deviceId);
     released.push(sessionUuid);
   }

--- a/src/server/toolRegistry.ts
+++ b/src/server/toolRegistry.ts
@@ -820,7 +820,10 @@ export class DefaultPlanLifecycleManager implements PlanLifecycleManager {
         const session = releaseSessionUuid ? sessionManager.getSession(releaseSessionUuid) : null;
         if (session) {
           const deviceId = session.assignedDevice;
-          sessionManager.releaseSession(session.sessionId);
+          // Await the release so its onSessionRelease callbacks (CtrlProxy binding +
+          // detector cleanup) complete — and any rejection is caught by this try —
+          // before the device is freed (#4984).
+          await sessionManager.releaseSession(session.sessionId);
           await devicePool.releaseDevice(deviceId);
           NavigationGraphManager.releaseSession(releaseSessionUuid);
           // CtrlProxy client binding + detector cleanup for the released session is

--- a/src/server/toolRegistry.ts
+++ b/src/server/toolRegistry.ts
@@ -823,11 +823,9 @@ export class DefaultPlanLifecycleManager implements PlanLifecycleManager {
           sessionManager.releaseSession(session.sessionId);
           await devicePool.releaseDevice(deviceId);
           NavigationGraphManager.releaseSession(releaseSessionUuid);
-          // Clear the per-device CtrlProxy client's binding to the released session
-          // (#4984) so a nav/hierarchy event arriving before the next session binds
-          // the still-connected device is not attributed to the ended session.
-          AndroidCtrlProxyClient.getExistingInstance(deviceId)?.releaseSessionBinding(releaseSessionUuid);
-          IOSCtrlProxyClient.getExistingInstance(deviceId)?.releaseSessionBinding(releaseSessionUuid);
+          // CtrlProxy client binding + detector cleanup for the released session is
+          // handled centrally in the daemon's onSessionRelease hook (#4984), which
+          // covers every release path and each derived label session on its device.
           RealObserveScreen.clearCache(deviceId);
           releasedSessionUuids.push(releaseSessionUuid);
           logger.info(`Auto-released session ${session.sessionId} and freed device ${deviceId} after executePlan`);

--- a/src/server/toolRegistry.ts
+++ b/src/server/toolRegistry.ts
@@ -823,6 +823,11 @@ export class DefaultPlanLifecycleManager implements PlanLifecycleManager {
           sessionManager.releaseSession(session.sessionId);
           await devicePool.releaseDevice(deviceId);
           NavigationGraphManager.releaseSession(releaseSessionUuid);
+          // Clear the per-device CtrlProxy client's binding to the released session
+          // (#4984) so a nav/hierarchy event arriving before the next session binds
+          // the still-connected device is not attributed to the ended session.
+          AndroidCtrlProxyClient.getExistingInstance(deviceId)?.releaseSessionBinding(releaseSessionUuid);
+          IOSCtrlProxyClient.getExistingInstance(deviceId)?.releaseSessionBinding(releaseSessionUuid);
           RealObserveScreen.clearCache(deviceId);
           releasedSessionUuids.push(releaseSessionUuid);
           logger.info(`Auto-released session ${session.sessionId} and freed device ${deviceId} after executePlan`);

--- a/src/utils/ContentHashProvider.ts
+++ b/src/utils/ContentHashProvider.ts
@@ -50,6 +50,10 @@ export interface AppContentHasher {
  */
 export class CachingContentHashProvider implements ContentHashProvider {
   private readonly cache = new Map<string, string>();
+  // Per-(device,package) generation, bumped by invalidate(). A computeHash that
+  // started before an invalidate must NOT repopulate the cache with a stale hash,
+  // so a result is only cached when the generation is unchanged since it began.
+  private readonly generation = new Map<string, number>();
 
   constructor(private readonly hasher: AppContentHasher) {}
 
@@ -63,9 +67,15 @@ export class CachingContentHashProvider implements ContentHashProvider {
     if (cached !== undefined) {
       return cached;
     }
+    const genKey = `${device.deviceId}::${packageId}`;
+    const startGeneration = this.generation.get(genKey) ?? 0;
     try {
       const hash = await this.hasher.computeHash(device, packageId, versionCode);
-      this.cache.set(key, hash);
+      // Only cache if the package wasn't invalidated (updated/reinstalled) while
+      // this computation was in flight — otherwise the entry would be stale.
+      if ((this.generation.get(genKey) ?? 0) === startGeneration) {
+        this.cache.set(key, hash);
+      }
       return hash;
     } catch (error) {
       // Best-effort: log and fall back to the default build key (never hard-fail).
@@ -75,7 +85,9 @@ export class CachingContentHashProvider implements ContentHashProvider {
   }
 
   invalidate(deviceId: string, packageId: string): void {
-    const prefix = `${deviceId}::${packageId}::`;
+    const genKey = `${deviceId}::${packageId}`;
+    this.generation.set(genKey, (this.generation.get(genKey) ?? 0) + 1);
+    const prefix = `${genKey}::`;
     for (const key of this.cache.keys()) {
       if (key.startsWith(prefix)) {
         this.cache.delete(key);

--- a/src/utils/ContentHashProvider.ts
+++ b/src/utils/ContentHashProvider.ts
@@ -25,6 +25,13 @@ export interface ContentHashProvider {
     packageId: string,
     versionCode: number
   ): Promise<string | null>;
+
+  /**
+   * Drop every cached hash for `(deviceId, packageId)` across all versionCodes, so
+   * the next resolution recomputes. Called on a package update/reinstall/removal —
+   * a same-versionCode rebuild with different content must not reuse the old hash.
+   */
+  invalidate(deviceId: string, packageId: string): void;
 }
 
 /**
@@ -66,6 +73,15 @@ export class CachingContentHashProvider implements ContentHashProvider {
       return null;
     }
   }
+
+  invalidate(deviceId: string, packageId: string): void {
+    const prefix = `${deviceId}::${packageId}::`;
+    for (const key of this.cache.keys()) {
+      if (key.startsWith(prefix)) {
+        this.cache.delete(key);
+      }
+    }
+  }
 }
 
 const SHA256_HEX = /^[0-9a-f]{64}$/i;
@@ -99,37 +115,48 @@ export function combineApkDigests(sha256sumStdout: string): string {
   return hash.digest("hex");
 }
 
+/** Parse `adb shell pm path <pkg>` output into the installed APK paths (base + splits). */
+export function parsePmPathOutput(stdout: string): string[] {
+  return stdout
+    .split("\n")
+    .map(line => line.trim())
+    .filter(line => line.startsWith("package:"))
+    .map(line => line.slice("package:".length).trim())
+    .filter(path => path.endsWith(".apk"))
+    .sort();
+}
+
 /**
- * Android: hash the installed APK set. Prefers on-device `sha256sum` (no byte
- * transfer); falls back to `adb pull` + local hashing when `sha256sum` is absent.
- * Uses `codePath` (the installed APK directory) — never `lastUpdateTime`.
+ * Android: hash the installed APK set (base + splits). APK paths come from
+ * `pm path <pkg>` — which works on every path, unlike `GetAppMetadata.installPath`
+ * that is empty when the WebSocket PackageManager call succeeds (only the dumpsys
+ * fallback populates `codePath`). Prefers on-device `sha256sum` (no byte transfer);
+ * falls back to `adb pull` + local hashing when `sha256sum` is absent. Derived from
+ * APK bytes only — never `lastUpdateTime`. versionCode is a cache key, not hashed.
  */
 export class AndroidApkContentHasher implements AppContentHasher {
   constructor(
     private readonly adb: AdbExecutor,
-    private readonly metadata: GetAppMetadata,
     private readonly checksum: ChecksumCalculator = new DefaultChecksumCalculator()
   ) {}
 
   async computeHash(_device: BootedDevice, packageId: string): Promise<string> {
-    const meta = await this.metadata.execute(packageId);
-    const codePath = meta?.installPath;
-    if (!codePath) {
+    const apkPaths = await this.resolveApkPaths(packageId);
+    if (apkPaths.length === 0) {
       throw toActionableError(
-        new Error(`No installPath (codePath) for ${packageId}`),
+        new Error(`pm path returned no APKs for ${packageId}`),
         `Cannot resolve APK path for ${packageId}`
       );
     }
 
-    // On-device digest of every .apk in the code path (base + splits). Guard both
-    // the throw case (modern adb propagates a non-zero exit when sha256sum is
-    // absent) and the empty/garbage-stdout case, so the pull fallback is reachable
-    // and a "sha256sum: not found" line is never hashed as a real digest.
+    // On-device digest of every APK. Guard both the throw case (modern adb
+    // propagates a non-zero exit when sha256sum is absent) and the empty/garbage
+    // -stdout case, so the pull fallback is reachable and a "sha256sum: not found"
+    // line (a legacy adb can merge stderr into stdout) is never hashed as a digest.
     let combined = "";
     try {
-      const onDevice = await this.adb.executeCommand(
-        `shell sh -c 'for f in "${codePath}"/*.apk; do sha256sum "$f"; done'`
-      );
+      const script = apkPaths.map(p => `sha256sum "${p}"`).join("; ");
+      const onDevice = await this.adb.executeCommand(`shell sh -c '${script}'`);
       combined = combineApkDigests(onDevice.stdout ?? "");
     } catch (error) {
       logger.debug(`[ContentHash] on-device sha256sum failed for ${packageId}: ${error}`);
@@ -139,23 +166,15 @@ export class AndroidApkContentHasher implements AppContentHasher {
     }
 
     logger.warn(`[ContentHash] on-device sha256sum unavailable for ${packageId}; using adb pull (slow path)`);
-    return this.computeViaPull(codePath, packageId);
+    return this.computeViaPull(apkPaths, packageId);
   }
 
-  private async computeViaPull(codePath: string, packageId: string): Promise<string> {
-    const listing = await this.adb.executeCommand(`shell ls "${codePath}"/*.apk`);
-    const remotePaths = (listing.stdout ?? "")
-      .split("\n")
-      .map(p => p.trim())
-      .filter(p => p.endsWith(".apk"))
-      .sort();
-    if (remotePaths.length === 0) {
-      throw toActionableError(
-        new Error(`No APK files under ${codePath}`),
-        `Cannot hash APKs for ${packageId}`
-      );
-    }
+  private async resolveApkPaths(packageId: string): Promise<string[]> {
+    const listing = await this.adb.executeCommand(`shell pm path ${packageId}`);
+    return parsePmPathOutput(listing.stdout ?? "");
+  }
 
+  private async computeViaPull(remotePaths: string[], packageId: string): Promise<string> {
     const workDir = await fs.mkdtemp(join(tmpdir(), "automobile-apk-"));
     try {
       const digests: string[] = [];
@@ -208,11 +227,11 @@ export function createContentHashProvider(
   adbFactory: AdbClientFactory = defaultAdbClientFactory,
   iosSource: IosAppMetadataSource | null = null
 ): ContentHashProvider {
-  const metadata = new GetAppMetadata(device, adbFactory, iosSource);
   if (device.platform === "android") {
     return new CachingContentHashProvider(
-      new AndroidApkContentHasher(adbFactory.create(device), metadata)
+      new AndroidApkContentHasher(adbFactory.create(device))
     );
   }
+  const metadata = new GetAppMetadata(device, adbFactory, iosSource);
   return new CachingContentHashProvider(new IosBundleContentHasher(metadata));
 }

--- a/src/utils/ContentHashProvider.ts
+++ b/src/utils/ContentHashProvider.ts
@@ -1,0 +1,195 @@
+import { createHash } from "crypto";
+import { promises as fs } from "fs";
+import { tmpdir } from "os";
+import { join } from "path";
+import type { BootedDevice } from "../models";
+import type { AdbExecutor } from "./android-cmdline-tools/interfaces/AdbExecutor";
+import { GetAppMetadata, type IosAppMetadataSource } from "../features/observe/GetAppMetadata";
+import { hashAppBundle } from "./ios-cmdline-tools/AppBundleHasher";
+import { DefaultChecksumCalculator, type ChecksumCalculator } from "./ChecksumCalculator";
+import { AdbClientFactory, defaultAdbClientFactory } from "./android-cmdline-tools/AdbClientFactory";
+import { toActionableError } from "../models/ActionableError";
+import { logger } from "./logger";
+
+/**
+ * Derives the content hash of an installed app from its installed bytes (#4984).
+ *
+ * The hash must be identical for identical content across reinstalls/rebuilds, so
+ * it is derived from APK/IPA bytes only — never from install-time signals such as
+ * Android `lastUpdateTime`. Resolution returns `null` on failure so the caller
+ * records provenance under the default build key instead of hard-failing.
+ */
+export interface ContentHashProvider {
+  resolveContentHash(
+    device: BootedDevice,
+    packageId: string,
+    versionCode: number
+  ): Promise<string | null>;
+}
+
+/**
+ * Platform-specific step that hashes the installed app's bytes. Injected so the
+ * caching + fallback contract in {@link CachingContentHashProvider} is unit-tested
+ * with a fake; the real Android/iOS implementations are integration-only.
+ */
+export interface AppContentHasher {
+  computeHash(device: BootedDevice, packageId: string, versionCode: number): Promise<string>;
+}
+
+/**
+ * Caches by `(deviceId, packageId, versionCode)` (computed once per install) and
+ * degrades to `null` on any hashing failure so a mutation never blocks on — or
+ * fails because of — content hashing.
+ */
+export class CachingContentHashProvider implements ContentHashProvider {
+  private readonly cache = new Map<string, string>();
+
+  constructor(private readonly hasher: AppContentHasher) {}
+
+  async resolveContentHash(
+    device: BootedDevice,
+    packageId: string,
+    versionCode: number
+  ): Promise<string | null> {
+    const key = `${device.deviceId}::${packageId}::${versionCode}`;
+    const cached = this.cache.get(key);
+    if (cached !== undefined) {
+      return cached;
+    }
+    try {
+      const hash = await this.hasher.computeHash(device, packageId, versionCode);
+      this.cache.set(key, hash);
+      return hash;
+    } catch (error) {
+      // Best-effort: log and fall back to the default build key (never hard-fail).
+      logger.warn(`[ContentHash] Failed to hash ${packageId} on ${device.deviceId}: ${error}`, error);
+      return null;
+    }
+  }
+}
+
+/**
+ * Combine per-APK SHA-256 digests (from `sha256sum` output: `<hex>  <path>` per
+ * line) into a single content hash. Sorted so split-APK ordering does not affect
+ * the result, and derived from digests only (no filesystem timestamps/metadata).
+ */
+export function combineApkDigests(sha256sumStdout: string): string {
+  const digests = sha256sumStdout
+    .split("\n")
+    .map(line => line.trim())
+    .filter(line => line.length > 0)
+    .map(line => line.split(/\s+/)[0])
+    .filter((digest): digest is string => Boolean(digest))
+    .sort();
+  const hash = createHash("sha256");
+  for (const digest of digests) {
+    hash.update(digest);
+    hash.update("\0");
+  }
+  return hash.digest("hex");
+}
+
+/**
+ * Android: hash the installed APK set. Prefers on-device `sha256sum` (no byte
+ * transfer); falls back to `adb pull` + local hashing when `sha256sum` is absent.
+ * Uses `codePath` (the installed APK directory) — never `lastUpdateTime`.
+ */
+export class AndroidApkContentHasher implements AppContentHasher {
+  constructor(
+    private readonly adb: AdbExecutor,
+    private readonly metadata: GetAppMetadata,
+    private readonly checksum: ChecksumCalculator = new DefaultChecksumCalculator()
+  ) {}
+
+  async computeHash(_device: BootedDevice, packageId: string): Promise<string> {
+    const meta = await this.metadata.execute(packageId);
+    const codePath = meta?.installPath;
+    if (!codePath) {
+      throw toActionableError(
+        new Error(`No installPath (codePath) for ${packageId}`),
+        `Cannot resolve APK path for ${packageId}`
+      );
+    }
+
+    // On-device digest of every .apk in the code path (base + splits).
+    const onDevice = await this.adb.executeCommand(
+      `shell sh -c 'for f in "${codePath}"/*.apk; do sha256sum "$f"; done'`
+    );
+    const stdout = onDevice.stdout ?? "";
+    const stderr = onDevice.stderr ?? "";
+    const sha256sumMissing = /not found|no such tool|inaccessible|permission denied/i.test(stderr);
+    if (stdout.trim() && !sha256sumMissing) {
+      return combineApkDigests(stdout);
+    }
+
+    logger.warn(`[ContentHash] on-device sha256sum unavailable for ${packageId}; using adb pull (slow path)`);
+    return this.computeViaPull(codePath, packageId);
+  }
+
+  private async computeViaPull(codePath: string, packageId: string): Promise<string> {
+    const listing = await this.adb.executeCommand(`shell ls "${codePath}"/*.apk`);
+    const remotePaths = (listing.stdout ?? "")
+      .split("\n")
+      .map(p => p.trim())
+      .filter(p => p.endsWith(".apk"))
+      .sort();
+    if (remotePaths.length === 0) {
+      throw toActionableError(
+        new Error(`No APK files under ${codePath}`),
+        `Cannot hash APKs for ${packageId}`
+      );
+    }
+
+    const workDir = await fs.mkdtemp(join(tmpdir(), "automobile-apk-"));
+    try {
+      const digests: string[] = [];
+      for (const remote of remotePaths) {
+        const localPath = join(workDir, `${digests.length}.apk`);
+        await this.adb.executeCommand(`pull "${remote}" "${localPath}"`);
+        const { checksum } = await this.checksum.computeFileSha256(localPath);
+        digests.push(`${checksum}  ${remote}`);
+      }
+      return combineApkDigests(digests.join("\n"));
+    } finally {
+      await fs.rm(workDir, { recursive: true, force: true });
+    }
+  }
+}
+
+/**
+ * iOS: hash the installed app bundle bytes via the shared {@link hashAppBundle}
+ * (which already excludes signature/provisioning files, so re-signing identical
+ * content yields the same hash). Simulator bundles are host-filesystem dirs.
+ */
+export class IosBundleContentHasher implements AppContentHasher {
+  constructor(private readonly metadata: GetAppMetadata) {}
+
+  async computeHash(_device: BootedDevice, packageId: string): Promise<string> {
+    const meta = await this.metadata.execute(packageId);
+    const bundlePath = meta?.installPath;
+    if (!bundlePath) {
+      throw toActionableError(
+        new Error(`No bundlePath for ${packageId}`),
+        `Cannot resolve app bundle path for ${packageId}`
+      );
+    }
+    return hashAppBundle(bundlePath);
+  }
+}
+
+/**
+ * Build a caching content-hash provider for a device, picking the platform hasher.
+ */
+export function createContentHashProvider(
+  device: BootedDevice,
+  adbFactory: AdbClientFactory = defaultAdbClientFactory,
+  iosSource: IosAppMetadataSource | null = null
+): ContentHashProvider {
+  const metadata = new GetAppMetadata(device, adbFactory, iosSource);
+  if (device.platform === "android") {
+    return new CachingContentHashProvider(
+      new AndroidApkContentHasher(adbFactory.create(device), metadata)
+    );
+  }
+  return new CachingContentHashProvider(new IosBundleContentHasher(metadata));
+}

--- a/src/utils/ContentHashProvider.ts
+++ b/src/utils/ContentHashProvider.ts
@@ -7,7 +7,7 @@ import type { AdbExecutor } from "./android-cmdline-tools/interfaces/AdbExecutor
 import { GetAppMetadata, type IosAppMetadataSource } from "../features/observe/GetAppMetadata";
 import { hashAppBundle } from "./ios-cmdline-tools/AppBundleHasher";
 import { DefaultChecksumCalculator, type ChecksumCalculator } from "./ChecksumCalculator";
-import { AdbClientFactory, defaultAdbClientFactory } from "./android-cmdline-tools/AdbClientFactory";
+import { defaultAdbClientFactory } from "./android-cmdline-tools/AdbClientFactory";
 import { toActionableError } from "../models/ActionableError";
 import { logger } from "./logger";
 
@@ -247,17 +247,21 @@ export class IosBundleContentHasher implements AppContentHasher {
 
 /**
  * Build a caching content-hash provider for a device, picking the platform hasher.
+ *
+ * The Android hasher runs on the supplied `AdbExecutor` — callers MUST pass their
+ * injected executor (e.g. a CtrlProxy client's `this.adb`) so tests with a fake adb
+ * never launch a real `adb` subprocess and custom production executors aren't
+ * bypassed. Defaults to the real factory only when no executor is given.
  */
 export function createContentHashProvider(
   device: BootedDevice,
-  adbFactory: AdbClientFactory = defaultAdbClientFactory,
+  adb: AdbExecutor = defaultAdbClientFactory.create(device),
   iosSource: IosAppMetadataSource | null = null
 ): ContentHashProvider {
   if (device.platform === "android") {
-    return new CachingContentHashProvider(
-      new AndroidApkContentHasher(adbFactory.create(device))
-    );
+    return new CachingContentHashProvider(new AndroidApkContentHasher(adb));
   }
-  const metadata = new GetAppMetadata(device, adbFactory, iosSource);
+  // iOS resolves the bundle path via iosSource (adb is unused for iOS metadata).
+  const metadata = new GetAppMetadata(device, defaultAdbClientFactory, iosSource);
   return new CachingContentHashProvider(new IosBundleContentHasher(metadata));
 }

--- a/src/utils/ContentHashProvider.ts
+++ b/src/utils/ContentHashProvider.ts
@@ -99,23 +99,32 @@ export class CachingContentHashProvider implements ContentHashProvider {
 const SHA256_HEX = /^[0-9a-f]{64}$/i;
 
 /**
- * Combine per-APK SHA-256 digests (from `sha256sum` output: `<hex>  <path>` per
- * line) into a single content hash. Sorted so split-APK ordering does not affect
- * the result, and derived from digests only (no filesystem timestamps/metadata).
- *
- * Only lines whose first token is a valid 64-char hex SHA-256 are used; other
- * lines (e.g. a legacy `adb shell` merging `sha256sum: not found` into stdout) are
- * ignored. Returns `""` when no valid digest is present, so the caller can fall
- * back to the pull path instead of caching a meaningless hash.
+ * Extract the valid 64-char hex SHA-256 digests from `sha256sum` output
+ * (`<hex>  <path>` per line), sorted. Lines whose first token is not a valid hex
+ * digest — e.g. a legacy `adb shell` merging `sha256sum: not found` into stdout, or
+ * a per-file error for an unreadable split — are dropped, so the caller can compare
+ * the count against the expected number of APKs.
  */
-export function combineApkDigests(sha256sumStdout: string): string {
-  const digests = sha256sumStdout
+export function extractApkDigests(sha256sumStdout: string): string[] {
+  return sha256sumStdout
     .split("\n")
     .map(line => line.trim())
     .filter(line => line.length > 0)
     .map(line => line.split(/\s+/)[0])
     .filter((digest): digest is string => Boolean(digest) && SHA256_HEX.test(digest))
     .sort();
+}
+
+/**
+ * Combine per-APK SHA-256 digests into a single content hash. Sorted so split-APK
+ * ordering does not affect the result, and derived from digests only (no filesystem
+ * timestamps/metadata). Returns `""` when no valid digest is present.
+ */
+export function combineApkDigests(sha256sumStdout: string): string {
+  return hashDigestList(extractApkDigests(sha256sumStdout));
+}
+
+function hashDigestList(digests: string[]): string {
   if (digests.length === 0) {
     return "";
   }
@@ -161,23 +170,28 @@ export class AndroidApkContentHasher implements AppContentHasher {
       );
     }
 
-    // On-device digest of every APK. Guard both the throw case (modern adb
-    // propagates a non-zero exit when sha256sum is absent) and the empty/garbage
-    // -stdout case, so the pull fallback is reachable and a "sha256sum: not found"
-    // line (a legacy adb can merge stderr into stdout) is never hashed as a digest.
-    let combined = "";
+    // On-device digest of every APK. Require exactly ONE valid digest per APK path:
+    // the `;`-joined commands let one split fail (unreadable / sha256sum absent) while
+    // another still prints a valid digest, and accepting that partial hash would
+    // conflate builds differing only in the failing split. A count mismatch (also the
+    // throw case — modern adb propagates a non-zero exit — and the "sha256sum: not
+    // found" merged-stderr case) falls back to the pull path.
+    let digests: string[] = [];
     try {
       const script = apkPaths.map(p => `sha256sum "${p}"`).join("; ");
       const onDevice = await this.adb.executeCommand(`shell sh -c '${script}'`);
-      combined = combineApkDigests(onDevice.stdout ?? "");
+      digests = extractApkDigests(onDevice.stdout ?? "");
     } catch (error) {
       logger.debug(`[ContentHash] on-device sha256sum failed for ${packageId}: ${error}`);
     }
-    if (combined) {
-      return combined;
+    if (digests.length === apkPaths.length) {
+      return combineApkDigests(digests.join("\n"));
     }
 
-    logger.warn(`[ContentHash] on-device sha256sum unavailable for ${packageId}; using adb pull (slow path)`);
+    logger.warn(
+      `[ContentHash] on-device sha256sum incomplete for ${packageId} ` +
+      `(${digests.length}/${apkPaths.length} APKs); using adb pull (slow path)`
+    );
     return this.computeViaPull(apkPaths, packageId);
   }
 

--- a/src/utils/ContentHashProvider.ts
+++ b/src/utils/ContentHashProvider.ts
@@ -68,10 +68,17 @@ export class CachingContentHashProvider implements ContentHashProvider {
   }
 }
 
+const SHA256_HEX = /^[0-9a-f]{64}$/i;
+
 /**
  * Combine per-APK SHA-256 digests (from `sha256sum` output: `<hex>  <path>` per
  * line) into a single content hash. Sorted so split-APK ordering does not affect
  * the result, and derived from digests only (no filesystem timestamps/metadata).
+ *
+ * Only lines whose first token is a valid 64-char hex SHA-256 are used; other
+ * lines (e.g. a legacy `adb shell` merging `sha256sum: not found` into stdout) are
+ * ignored. Returns `""` when no valid digest is present, so the caller can fall
+ * back to the pull path instead of caching a meaningless hash.
  */
 export function combineApkDigests(sha256sumStdout: string): string {
   const digests = sha256sumStdout
@@ -79,8 +86,11 @@ export function combineApkDigests(sha256sumStdout: string): string {
     .map(line => line.trim())
     .filter(line => line.length > 0)
     .map(line => line.split(/\s+/)[0])
-    .filter((digest): digest is string => Boolean(digest))
+    .filter((digest): digest is string => Boolean(digest) && SHA256_HEX.test(digest))
     .sort();
+  if (digests.length === 0) {
+    return "";
+  }
   const hash = createHash("sha256");
   for (const digest of digests) {
     hash.update(digest);
@@ -111,15 +121,21 @@ export class AndroidApkContentHasher implements AppContentHasher {
       );
     }
 
-    // On-device digest of every .apk in the code path (base + splits).
-    const onDevice = await this.adb.executeCommand(
-      `shell sh -c 'for f in "${codePath}"/*.apk; do sha256sum "$f"; done'`
-    );
-    const stdout = onDevice.stdout ?? "";
-    const stderr = onDevice.stderr ?? "";
-    const sha256sumMissing = /not found|no such tool|inaccessible|permission denied/i.test(stderr);
-    if (stdout.trim() && !sha256sumMissing) {
-      return combineApkDigests(stdout);
+    // On-device digest of every .apk in the code path (base + splits). Guard both
+    // the throw case (modern adb propagates a non-zero exit when sha256sum is
+    // absent) and the empty/garbage-stdout case, so the pull fallback is reachable
+    // and a "sha256sum: not found" line is never hashed as a real digest.
+    let combined = "";
+    try {
+      const onDevice = await this.adb.executeCommand(
+        `shell sh -c 'for f in "${codePath}"/*.apk; do sha256sum "$f"; done'`
+      );
+      combined = combineApkDigests(onDevice.stdout ?? "");
+    } catch (error) {
+      logger.debug(`[ContentHash] on-device sha256sum failed for ${packageId}: ${error}`);
+    }
+    if (combined) {
+      return combined;
     }
 
     logger.warn(`[ContentHash] on-device sha256sum unavailable for ${packageId}; using adb pull (slow path)`);
@@ -149,7 +165,14 @@ export class AndroidApkContentHasher implements AppContentHasher {
         const { checksum } = await this.checksum.computeFileSha256(localPath);
         digests.push(`${checksum}  ${remote}`);
       }
-      return combineApkDigests(digests.join("\n"));
+      const combined = combineApkDigests(digests.join("\n"));
+      if (!combined) {
+        throw toActionableError(
+          new Error(`No valid APK digests computed for ${packageId}`),
+          `Cannot hash APKs for ${packageId}`
+        );
+      }
+      return combined;
     } finally {
       await fs.rm(workDir, { recursive: true, force: true });
     }

--- a/test/db/navigationProvenanceLifecycle.test.ts
+++ b/test/db/navigationProvenanceLifecycle.test.ts
@@ -1,0 +1,46 @@
+import { afterEach, beforeEach, describe, expect, test } from "bun:test";
+import type { Kysely } from "kysely";
+import { sql } from "kysely";
+import { createFileBackedDbHarness } from "./withFileBackedDb";
+import { WINDOWS_FILE_DB_TEST_TIMEOUT_MS } from "./fileBackedDbTestTimeout";
+
+/**
+ * AC4/AC5 coverage for #4984: the provenance migration applies cleanly as part of
+ * the FULL migration chain against a real file-backed DB (not just an isolated
+ * up()). Uses the shared file-backed harness so the Windows flake-avoidance
+ * ordering is inherited (issue #3046).
+ */
+describe("navigation provenance migration — file-backed lifecycle", () => {
+  let harness = createFileBackedDbHarness();
+
+  beforeEach(() => {
+    harness = createFileBackedDbHarness();
+  });
+
+  afterEach(async () => {
+    await harness.cleanup();
+  });
+
+  test(
+    "full migration chain creates the provenance tables on a real file DB",
+    async () => {
+      const lifecycle = await harness.openLifecycleTestDb("nav-provenance-");
+      try {
+        const db = lifecycle.module.getDatabase() as Kysely<unknown>;
+        const rows = await sql<{ name: string }>`
+          SELECT name FROM sqlite_master WHERE type = 'table' AND name IN
+          ('navigation_build_keys','navigation_node_observations','navigation_edge_observations')
+        `.execute(db);
+        const names = rows.rows.map(r => r.name).sort();
+        expect(names).toEqual([
+          "navigation_build_keys",
+          "navigation_edge_observations",
+          "navigation_node_observations",
+        ]);
+      } finally {
+        await lifecycle.close();
+      }
+    },
+    WINDOWS_FILE_DB_TEST_TIMEOUT_MS
+  );
+});

--- a/test/db/navigationProvenanceMigration.test.ts
+++ b/test/db/navigationProvenanceMigration.test.ts
@@ -1,0 +1,119 @@
+import { afterEach, beforeEach, describe, expect, test } from "bun:test";
+import { Database as BunDatabase } from "bun:sqlite";
+import { Kysely, sql } from "kysely";
+import { BunSqliteDialect } from "../../src/db/bunSqliteDialect";
+import type { Database } from "../../src/db/types";
+import { up as navGraphUp } from "../../src/db/migrations/2025_12_30_001_navigation_graph";
+import {
+  up as provenanceUp,
+  down as provenanceDown,
+} from "../../src/db/migrations/2026_08_02_000_navigation_provenance";
+
+/**
+ * Migration coverage for #4984 Phase 1 (nav (app,build) provenance).
+ *
+ * Builds the base navigation schema, seeds legacy single-build nodes/edges, then
+ * runs the provenance migration and asserts AC1 (build-key + observation tables)
+ * and AC4 (backward-compatible backfill: existing rows map to a DEFAULT build key
+ * with non-null sentinels, no data loss). foreign_keys is ON so the FK/cascade
+ * wiring is exercised for real.
+ */
+describe("2026_08_02_000_navigation_provenance migration", () => {
+  let bunDb: BunDatabase;
+  let db: Kysely<Database>;
+
+  beforeEach(async () => {
+    bunDb = new BunDatabase(":memory:");
+    bunDb.exec("PRAGMA foreign_keys = ON;");
+    db = new Kysely<Database>({ dialect: new BunSqliteDialect({ database: bunDb }) });
+    await navGraphUp(db as unknown as Kysely<unknown>);
+  });
+
+  afterEach(async () => {
+    await db.destroy();
+  });
+
+  async function seedLegacyGraph(): Promise<void> {
+    await db.insertInto("navigation_apps").values({ app_id: "com.example.app", updated_at: "2026-01-01T00:00:00.000Z" }).execute();
+    await db
+      .insertInto("navigation_nodes")
+      .values([
+        { app_id: "com.example.app", screen_name: "Home", first_seen_at: 100, last_seen_at: 200, visit_count: 2 },
+        { app_id: "com.example.app", screen_name: "Details", first_seen_at: 150, last_seen_at: 150, visit_count: 1 },
+      ])
+      .execute();
+    await db
+      .insertInto("navigation_edges")
+      .values([
+        { app_id: "com.example.app", from_screen: "Home", to_screen: "Details", tool_name: "tapOn", tool_args: null, timestamp: 150 },
+      ])
+      .execute();
+  }
+
+  async function tableNames(): Promise<string[]> {
+    const rows = await sql<{ name: string }>`SELECT name FROM sqlite_master WHERE type = 'table'`.execute(db);
+    return rows.rows.map(r => r.name);
+  }
+
+  test("AC1: creates build-key + node/edge observation tables", async () => {
+    await provenanceUp(db as unknown as Kysely<unknown>);
+    const names = await tableNames();
+    expect(names).toContain("navigation_build_keys");
+    expect(names).toContain("navigation_node_observations");
+    expect(names).toContain("navigation_edge_observations");
+  });
+
+  test("AC4: backfills a default build key + one observation per existing node/edge (no data loss)", async () => {
+    await seedLegacyGraph();
+    await provenanceUp(db as unknown as Kysely<unknown>);
+
+    // Existing rows are untouched.
+    const nodes = await db.selectFrom("navigation_nodes").selectAll().execute();
+    const edges = await db.selectFrom("navigation_edges").selectAll().execute();
+    expect(nodes).toHaveLength(2);
+    expect(edges).toHaveLength(1);
+
+    // One default build key per app, with non-null sentinels (version_code=0, content_hash='').
+    const buildKeys = await db.selectFrom("navigation_build_keys").selectAll().execute();
+    expect(buildKeys).toHaveLength(1);
+    expect(buildKeys[0].app_id).toBe("com.example.app");
+    expect(buildKeys[0].version_code).toBe(0);
+    expect(buildKeys[0].content_hash).toBe("");
+
+    // One node observation per node, carrying legacy sentinels + source timestamps.
+    const nodeObs = await db
+      .selectFrom("navigation_node_observations")
+      .selectAll()
+      .orderBy("node_id", "asc")
+      .execute();
+    expect(nodeObs).toHaveLength(2);
+    for (const o of nodeObs) {
+      expect(o.build_key_id).toBe(buildKeys[0].id);
+      expect(o.device_id).toBe("legacy");
+      expect(o.session_uuid).toBe("legacy");
+    }
+    const home = nodes.find(n => n.screen_name === "Home")!;
+    const homeObs = nodeObs.find(o => o.node_id === home.id)!;
+    expect(homeObs.first_seen_at).toBe(100);
+    expect(homeObs.last_seen_at).toBe(200);
+
+    // One edge observation per edge, using the edge timestamp for both seen fields.
+    const edgeObs = await db.selectFrom("navigation_edge_observations").selectAll().execute();
+    expect(edgeObs).toHaveLength(1);
+    expect(edgeObs[0].edge_id).toBe(edges[0].id);
+    expect(edgeObs[0].build_key_id).toBe(buildKeys[0].id);
+    expect(edgeObs[0].device_id).toBe("legacy");
+    expect(edgeObs[0].session_uuid).toBe("legacy");
+    expect(edgeObs[0].first_seen_at).toBe(150);
+    expect(edgeObs[0].last_seen_at).toBe(150);
+  });
+
+  test("down() drops the provenance tables", async () => {
+    await provenanceUp(db as unknown as Kysely<unknown>);
+    await provenanceDown(db as unknown as Kysely<unknown>);
+    const names = await tableNames();
+    expect(names).not.toContain("navigation_build_keys");
+    expect(names).not.toContain("navigation_node_observations");
+    expect(names).not.toContain("navigation_edge_observations");
+  });
+});

--- a/test/db/navigationProvenanceMigration.test.ts
+++ b/test/db/navigationProvenanceMigration.test.ts
@@ -108,6 +108,19 @@ describe("2026_08_02_000_navigation_provenance migration", () => {
     expect(edgeObs[0].last_seen_at).toBe(150);
   });
 
+  test("up() is idempotent / retry-safe (re-running does not violate UNIQUE)", async () => {
+    // SqliteAdapter is non-transactional-DDL, so a failed backfill reruns up() from
+    // the top on restart. Re-running must not throw a duplicate-key error, and must
+    // not duplicate the backfilled rows.
+    await seedLegacyGraph();
+    await provenanceUp(db as unknown as Kysely<unknown>);
+    await provenanceUp(db as unknown as Kysely<unknown>); // rerun
+
+    expect(await db.selectFrom("navigation_build_keys").selectAll().execute()).toHaveLength(1);
+    expect(await db.selectFrom("navigation_node_observations").selectAll().execute()).toHaveLength(2);
+    expect(await db.selectFrom("navigation_edge_observations").selectAll().execute()).toHaveLength(1);
+  });
+
   test("down() drops the provenance tables", async () => {
     await provenanceUp(db as unknown as Kysely<unknown>);
     await provenanceDown(db as unknown as Kysely<unknown>);

--- a/test/db/navigationProvenanceMigration.test.ts
+++ b/test/db/navigationProvenanceMigration.test.ts
@@ -108,6 +108,22 @@ describe("2026_08_02_000_navigation_provenance migration", () => {
     expect(edgeObs[0].last_seen_at).toBe(150);
   });
 
+  test("backfill normalizes inverted legacy node bounds (first_seen > last_seen)", async () => {
+    await db.insertInto("navigation_apps").values({ app_id: "com.example.app", updated_at: "2026-01-01T00:00:00.000Z" }).execute();
+    // Legacy getOrCreateNode replaced last_seen_at unconditionally, so an out-of-order
+    // commit could leave first_seen_at (200) > last_seen_at (100).
+    await db
+      .insertInto("navigation_nodes")
+      .values({ app_id: "com.example.app", screen_name: "Home", first_seen_at: 200, last_seen_at: 100, visit_count: 2 })
+      .execute();
+
+    await provenanceUp(db as unknown as Kysely<unknown>);
+
+    const obs = await db.selectFrom("navigation_node_observations").selectAll().executeTakeFirstOrThrow();
+    expect(obs.first_seen_at).toBe(100);
+    expect(obs.last_seen_at).toBe(200);
+  });
+
   test("up() is idempotent / retry-safe (re-running does not violate UNIQUE)", async () => {
     // SqliteAdapter is non-transactional-DDL, so a failed backfill reruns up() from
     // the top on restart. Re-running must not throw a duplicate-key error, and must

--- a/test/db/navigationProvenanceRepository.test.ts
+++ b/test/db/navigationProvenanceRepository.test.ts
@@ -1,0 +1,85 @@
+import { afterEach, beforeEach, describe, expect, test } from "bun:test";
+import type { Kysely } from "kysely";
+import { createTestDatabase } from "./testDbHelper";
+import type { Database } from "../../src/db/types";
+import { NavigationRepository } from "../../src/db/navigationRepository";
+
+/**
+ * AC1 coverage for #4984: per-node/edge observation records keyed by
+ * (buildKey, deviceId, sessionUuid). Multiple records per node/edge; re-recording
+ * the same tuple updates last_seen rather than inserting a duplicate.
+ */
+describe("NavigationRepository provenance observations", () => {
+  let db: Kysely<Database>;
+  let repo: NavigationRepository;
+
+  beforeEach(async () => {
+    db = await createTestDatabase();
+    repo = new NavigationRepository(db);
+    await repo.getOrCreateApp("com.example.app");
+  });
+
+  afterEach(async () => {
+    await db.destroy();
+  });
+
+  test("getOrCreateBuildKey is an atomic upsert on (app_id, version_code, content_hash)", async () => {
+    const a = await repo.getOrCreateBuildKey("com.example.app", 42, "hashA");
+    const again = await repo.getOrCreateBuildKey("com.example.app", 42, "hashA");
+    const different = await repo.getOrCreateBuildKey("com.example.app", 42, "hashB");
+    expect(again.id).toBe(a.id);
+    expect(different.id).not.toBe(a.id);
+  });
+
+  test("multiple node observations per node across builds/devices/sessions", async () => {
+    const node = await repo.getOrCreateNode("com.example.app", "Home", 100);
+    const buildA = await repo.getOrCreateBuildKey("com.example.app", 1, "hashA");
+    const buildB = await repo.getOrCreateBuildKey("com.example.app", 2, "hashB");
+
+    await repo.recordNodeObservation(node.id, buildA.id, "device-1", "session-1", 100);
+    await repo.recordNodeObservation(node.id, buildB.id, "device-1", "session-1", 110);
+    await repo.recordNodeObservation(node.id, buildA.id, "device-2", "session-1", 120);
+    await repo.recordNodeObservation(node.id, buildA.id, "device-1", "session-2", 130);
+
+    const obs = await db
+      .selectFrom("navigation_node_observations")
+      .selectAll()
+      .where("node_id", "=", node.id)
+      .execute();
+    expect(obs).toHaveLength(4);
+  });
+
+  test("re-recording the same node observation tuple updates last_seen (no duplicate)", async () => {
+    const node = await repo.getOrCreateNode("com.example.app", "Home", 100);
+    const build = await repo.getOrCreateBuildKey("com.example.app", 1, "hashA");
+
+    await repo.recordNodeObservation(node.id, build.id, "device-1", "session-1", 100);
+    await repo.recordNodeObservation(node.id, build.id, "device-1", "session-1", 250);
+
+    const obs = await db
+      .selectFrom("navigation_node_observations")
+      .selectAll()
+      .where("node_id", "=", node.id)
+      .execute();
+    expect(obs).toHaveLength(1);
+    expect(obs[0].first_seen_at).toBe(100);
+    expect(obs[0].last_seen_at).toBe(250);
+  });
+
+  test("edge observations dedup on (edge, build, device, session)", async () => {
+    const edge = await repo.createEdge("com.example.app", "Home", "Details", "tapOn", null, 150);
+    const build = await repo.getOrCreateBuildKey("com.example.app", 1, "hashA");
+
+    await repo.recordEdgeObservation(edge.id, build.id, "device-1", "session-1", 150);
+    await repo.recordEdgeObservation(edge.id, build.id, "device-1", "session-1", 400);
+
+    const obs = await db
+      .selectFrom("navigation_edge_observations")
+      .selectAll()
+      .where("edge_id", "=", edge.id)
+      .execute();
+    expect(obs).toHaveLength(1);
+    expect(obs[0].first_seen_at).toBe(150);
+    expect(obs[0].last_seen_at).toBe(400);
+  });
+});

--- a/test/db/navigationProvenanceRepository.test.ts
+++ b/test/db/navigationProvenanceRepository.test.ts
@@ -66,6 +66,40 @@ describe("NavigationRepository provenance observations", () => {
     expect(obs[0].last_seen_at).toBe(250);
   });
 
+  test("out-of-order node observations keep first_seen <= last_seen (MIN/MAX)", async () => {
+    const node = await repo.getOrCreateNode("com.example.app", "Home", 100);
+    const build = await repo.getOrCreateBuildKey("com.example.app", 1, "hashA");
+
+    // Arrivals out of order: later timestamp first, then an earlier one.
+    await repo.recordNodeObservation(node.id, build.id, "device-1", "session-1", 200);
+    await repo.recordNodeObservation(node.id, build.id, "device-1", "session-1", 50);
+    await repo.recordNodeObservation(node.id, build.id, "device-1", "session-1", 120);
+
+    const obs = await db
+      .selectFrom("navigation_node_observations")
+      .selectAll()
+      .where("node_id", "=", node.id)
+      .executeTakeFirstOrThrow();
+    expect(obs.first_seen_at).toBe(50);
+    expect(obs.last_seen_at).toBe(200);
+  });
+
+  test("out-of-order edge observations keep first_seen <= last_seen (MIN/MAX)", async () => {
+    const edge = await repo.createEdge("com.example.app", "Home", "Details", "tapOn", null, 150);
+    const build = await repo.getOrCreateBuildKey("com.example.app", 1, "hashA");
+
+    await repo.recordEdgeObservation(edge.id, build.id, "device-1", "session-1", 300);
+    await repo.recordEdgeObservation(edge.id, build.id, "device-1", "session-1", 100);
+
+    const obs = await db
+      .selectFrom("navigation_edge_observations")
+      .selectAll()
+      .where("edge_id", "=", edge.id)
+      .executeTakeFirstOrThrow();
+    expect(obs.first_seen_at).toBe(100);
+    expect(obs.last_seen_at).toBe(300);
+  });
+
   test("edge observations dedup on (edge, build, device, session)", async () => {
     const edge = await repo.createEdge("com.example.app", "Home", "Details", "tapOn", null, 150);
     const build = await repo.getOrCreateBuildKey("com.example.app", 1, "hashA");

--- a/test/features/navigation/NavigationGraphManager.test.ts
+++ b/test/features/navigation/NavigationGraphManager.test.ts
@@ -99,6 +99,22 @@ describe("NavigationGraphManager", () => {
 
       NavigationGraphManager.resetInstance();
     });
+
+    test("clearReleasedSession lets a reused uuid (setActiveDevice) get a real manager again", () => {
+      NavigationGraphManager.resetInstance();
+      const global = NavigationGraphManager.getInstance();
+      NavigationGraphManager.getInstanceForSession("session-A");
+      NavigationGraphManager.releaseSession("session-A");
+      expect(NavigationGraphManager.getInstanceForSession("session-A")).toBe(global);
+
+      // setActiveDevice re-creates the session with the same uuid; bindSession clears
+      // the tombstone, so the live replacement gets its own manager, not the global.
+      NavigationGraphManager.clearReleasedSession("session-A");
+      const revived = NavigationGraphManager.getInstanceForSession("session-A");
+      expect(revived).not.toBe(global);
+
+      NavigationGraphManager.resetInstance();
+    });
   });
 
   describe("listAppsWithGraph", () => {

--- a/test/features/navigation/NavigationGraphManager.test.ts
+++ b/test/features/navigation/NavigationGraphManager.test.ts
@@ -79,6 +79,28 @@ describe("NavigationGraphManager", () => {
     });
   });
 
+  describe("session lifecycle (#4984)", () => {
+    test("a released session's stray event resolves to the unattributed global, not a recreated session manager", () => {
+      NavigationGraphManager.resetInstance();
+      const global = NavigationGraphManager.getInstance();
+      const a = NavigationGraphManager.getInstanceForSession("session-A");
+      expect(a).not.toBe(global);
+
+      NavigationGraphManager.releaseSession("session-A");
+
+      // A stray post-release event must NOT mint a new manager attributed to A.
+      const strayA = NavigationGraphManager.getInstanceForSession("session-A");
+      expect(strayA).toBe(global);
+
+      // A genuinely new session still gets its own dedicated manager.
+      const b = NavigationGraphManager.getInstanceForSession("session-B");
+      expect(b).not.toBe(global);
+      expect(b).not.toBe(a);
+
+      NavigationGraphManager.resetInstance();
+    });
+  });
+
   describe("listAppsWithGraph", () => {
     test("maps persisted apps with nodes to summaries and omits display name", async () => {
       const repo = new NavigationRepository(harness.db);

--- a/test/features/navigation/navigationProvenanceWritePath.test.ts
+++ b/test/features/navigation/navigationProvenanceWritePath.test.ts
@@ -102,6 +102,51 @@ describe("NavigationGraphManager provenance write path", () => {
     expect(nodeObs[0].device_id).toBe("legacy");
   });
 
+  test("node and edge of one transition share a single build key (snapshot per event)", async () => {
+    await manager.setCurrentApp(APP);
+    manager.setBuildContext({ appId: APP, deviceId: "emu-1", versionCode: 7, contentHash: "hashA" });
+    await manager.recordNavigationEvent(navEvent("Home", 100));
+    await manager.recordNavigationEvent(navEvent("Details", 200));
+
+    const edgeObs = await db.selectFrom("navigation_edge_observations").selectAll().executeTakeFirstOrThrow();
+    const nodeObs = await db.selectFrom("navigation_node_observations").selectAll().execute();
+    // Every node observation and the edge observation resolve to the same build key.
+    for (const o of nodeObs) {
+      expect(o.build_key_id).toBe(edgeObs.build_key_id);
+    }
+  });
+
+  test("build context is per-app: app B with no context records under default even when app A has one", async () => {
+    await manager.setCurrentApp(APP);
+    manager.setBuildContext({ appId: APP, deviceId: "emu-1", versionCode: 7, contentHash: "hashA" });
+    await manager.recordNavigationEvent(navEvent("Home", 100));
+
+    // Switch to app B whose hash has not resolved yet.
+    await manager.setCurrentApp("com.other.app");
+    await manager.recordNavigationEvent({ ...navEvent("BScreen", 300), applicationId: "com.other.app" });
+
+    const aKey = await db.selectFrom("navigation_build_keys").selectAll().where("app_id", "=", APP).executeTakeFirstOrThrow();
+    expect(aKey.version_code).toBe(7);
+    const bKey = await db.selectFrom("navigation_build_keys").selectAll().where("app_id", "=", "com.other.app").executeTakeFirstOrThrow();
+    // B falls to the default key — never app A's version/hash.
+    expect(bKey.version_code).toBe(0);
+    expect(bKey.content_hash).toBe("");
+  });
+
+  test("returning to app A after app B resolves still uses app A's context (not B's)", async () => {
+    await manager.setCurrentApp(APP);
+    manager.setBuildContext({ appId: APP, deviceId: "emu-1", versionCode: 7, contentHash: "hashA" });
+    manager.setBuildContext({ appId: "com.other.app", deviceId: "emu-1", versionCode: 99, contentHash: "hashB" });
+
+    // Back to A: its observation must carry A's build key, not B's.
+    await manager.setCurrentApp(APP);
+    await manager.recordNavigationEvent(navEvent("Home", 400));
+
+    const aKey = await db.selectFrom("navigation_build_keys").selectAll().where("app_id", "=", APP).executeTakeFirstOrThrow();
+    expect(aKey.version_code).toBe(7);
+    expect(aKey.content_hash).toBe("hashA");
+  });
+
   test("falls back to the default build key when no build context is set", async () => {
     await manager.setCurrentApp(APP);
     await manager.recordNavigationEvent(navEvent("Home", 100));

--- a/test/features/navigation/navigationProvenanceWritePath.test.ts
+++ b/test/features/navigation/navigationProvenanceWritePath.test.ts
@@ -147,6 +147,52 @@ describe("NavigationGraphManager provenance write path", () => {
     expect(aKey.content_hash).toBe("hashA");
   });
 
+  test("fingerprint path: an app switch during the lookup does not cross-link A's node to B's build key", async () => {
+    // Repo whose getNodeByFingerprint switches the current app mid-await, simulating
+    // an app switch landing during the awaited fingerprint lookup.
+    class SwitchingRepo extends NavigationRepository {
+      public onLookup: (() => Promise<void>) | undefined;
+      async getNodeByFingerprint(appId: string, hash: string) {
+        if (this.onLookup) { await this.onLookup(); }
+        return super.getNodeByFingerprint(appId, hash);
+      }
+    }
+    const switchingRepo = new SwitchingRepo(db);
+    const coverageRepo = new TestCoverageRepository(undefined, db);
+    const m = NavigationGraphManager.createForTesting(switchingRepo, coverageRepo, undefined, SESSION);
+
+    await m.setCurrentApp(APP);
+    m.setBuildContext({ appId: APP, deviceId: "emu-1", versionCode: 7, contentHash: "hashA" });
+    m.setBuildContext({ appId: "com.other.app", deviceId: "emu-1", versionCode: 99, contentHash: "hashB" });
+
+    // Seed a named node + correlated fingerprint for APP.
+    const node = await switchingRepo.getOrCreateNode(APP, "Home", 100);
+    await switchingRepo.getOrCreateFingerprint(APP, node.id, "fp-1", "{}", 100);
+
+    switchingRepo.onLookup = async () => { await m.setCurrentApp("com.other.app"); };
+
+    await m.recordHierarchyNavigation({
+      fromFingerprint: null,
+      toFingerprint: "fp-1",
+      packageName: APP,
+      timestamp: 200,
+    } as never);
+
+    const obs = await db
+      .selectFrom("navigation_node_observations")
+      .selectAll()
+      .where("node_id", "=", node.id)
+      .executeTakeFirstOrThrow();
+    const bk = await db
+      .selectFrom("navigation_build_keys")
+      .selectAll()
+      .where("id", "=", obs.build_key_id)
+      .executeTakeFirstOrThrow();
+    // A's node is recorded under A's build key (v7), not B's (v99).
+    expect(bk.app_id).toBe(APP);
+    expect(bk.version_code).toBe(7);
+  });
+
   test("falls back to the default build key when no build context is set", async () => {
     await manager.setCurrentApp(APP);
     await manager.recordNavigationEvent(navEvent("Home", 100));

--- a/test/features/navigation/navigationProvenanceWritePath.test.ts
+++ b/test/features/navigation/navigationProvenanceWritePath.test.ts
@@ -64,7 +64,7 @@ describe("NavigationGraphManager provenance write path", () => {
 
   test("records node + edge observations under the current build key/device/session", async () => {
     await manager.setCurrentApp(APP);
-    manager.setBuildContext({ deviceId: "emu-1", versionCode: 7, contentHash: "hashA" });
+    manager.setBuildContext({ appId: APP, deviceId: "emu-1", versionCode: 7, contentHash: "hashA" });
 
     await manager.recordNavigationEvent(navEvent("Home", 100));
     await manager.recordNavigationEvent(navEvent("Details", 200));
@@ -86,6 +86,20 @@ describe("NavigationGraphManager provenance write path", () => {
     expect(edgeObs).toHaveLength(1);
     expect(edgeObs[0].device_id).toBe("emu-1");
     expect(edgeObs[0].session_uuid).toBe(SESSION);
+  });
+
+  test("falls back to the default build key when the build context is for a different app", async () => {
+    await manager.setCurrentApp(APP);
+    // Context resolved for another app must not stamp APP's provenance.
+    manager.setBuildContext({ appId: "com.other.app", deviceId: "emu-1", versionCode: 9, contentHash: "hashOther" });
+    await manager.recordNavigationEvent(navEvent("Home", 100));
+
+    const buildKeys = await db.selectFrom("navigation_build_keys").selectAll().execute();
+    expect(buildKeys).toHaveLength(1);
+    expect(buildKeys[0].version_code).toBe(0);
+    expect(buildKeys[0].content_hash).toBe("");
+    const nodeObs = await db.selectFrom("navigation_node_observations").selectAll().execute();
+    expect(nodeObs[0].device_id).toBe("legacy");
   });
 
   test("falls back to the default build key when no build context is set", async () => {

--- a/test/features/navigation/navigationProvenanceWritePath.test.ts
+++ b/test/features/navigation/navigationProvenanceWritePath.test.ts
@@ -193,6 +193,45 @@ describe("NavigationGraphManager provenance write path", () => {
     expect(bk.version_code).toBe(7);
   });
 
+  test("fingerprint path: a build-context swap during the lookup does not change the recorded build/device", async () => {
+    // A second unbound device routing through the same manager swaps app P's context
+    // mid-lookup; the reach must keep the device+hash captured BEFORE the await.
+    class SwitchingRepo extends NavigationRepository {
+      public onLookup: (() => void) | undefined;
+      async getNodeByFingerprint(appId: string, hash: string) {
+        if (this.onLookup) { this.onLookup(); }
+        return super.getNodeByFingerprint(appId, hash);
+      }
+    }
+    const switchingRepo = new SwitchingRepo(db);
+    const coverageRepo = new TestCoverageRepository(undefined, db);
+    const m = NavigationGraphManager.createForTesting(switchingRepo, coverageRepo, undefined, SESSION);
+
+    await m.setCurrentApp(APP);
+    m.setBuildContext({ appId: APP, deviceId: "device-A", versionCode: 7, contentHash: "hashA" });
+    const node = await switchingRepo.getOrCreateNode(APP, "Home", 100);
+    await switchingRepo.getOrCreateFingerprint(APP, node.id, "fp-1", "{}", 100);
+
+    // Device B swaps APP's context in the manager during the awaited lookup.
+    switchingRepo.onLookup = () => {
+      m.setBuildContext({ appId: APP, deviceId: "device-B", versionCode: 99, contentHash: "hashB" });
+    };
+
+    await m.recordHierarchyNavigation({
+      fromFingerprint: null, toFingerprint: "fp-1", packageName: APP, timestamp: 200,
+    } as never);
+
+    const obs = await db
+      .selectFrom("navigation_node_observations")
+      .selectAll()
+      .where("node_id", "=", node.id)
+      .executeTakeFirstOrThrow();
+    expect(obs.device_id).toBe("device-A"); // snapshot before await, not B
+    const bk = await db.selectFrom("navigation_build_keys").selectAll().where("id", "=", obs.build_key_id).executeTakeFirstOrThrow();
+    expect(bk.version_code).toBe(7);
+    expect(bk.content_hash).toBe("hashA");
+  });
+
   test("falls back to the default build key when no build context is set", async () => {
     await manager.setCurrentApp(APP);
     await manager.recordNavigationEvent(navEvent("Home", 100));
@@ -228,8 +267,10 @@ describe("NavigationGraphManager provenance write path", () => {
     expect(after).toHaveLength(before.length);
   });
 
-  test("#4931: promoteSuggestion touches updated_at and records a node observation", async () => {
+  test("#4931: promoteSuggestion touches updated_at and records the node under the DEFAULT key", async () => {
     await manager.setCurrentApp(APP);
+    // Even with a current (promotion-time) build context, the promoted observation must
+    // NOT claim that build — the suggestion stores no provenance (#4984).
     manager.setBuildContext({ appId: APP, deviceId: "emu-1", versionCode: 7, contentHash: "hashA" });
     const repo = new NavigationRepository(db);
     const suggestion = await repo.addOrUpdateSuggestion(APP, "fp-hash", "{}", 100);
@@ -238,8 +279,7 @@ describe("NavigationGraphManager provenance write path", () => {
     await manager.promoteSuggestion(suggestion.id, "Home");
 
     expect(await updatedAt()).not.toBe(old);
-    // The promoted node is visible in build/device-scoped analysis (#4984), not just
-    // a bare visit count.
+    // The promoted node is visible, but under the default/unknown key — not v7.
     const node = await repo.getNode(APP, "Home");
     const obs = await db
       .selectFrom("navigation_node_observations")
@@ -247,7 +287,9 @@ describe("NavigationGraphManager provenance write path", () => {
       .where("node_id", "=", node!.id)
       .execute();
     expect(obs).toHaveLength(1);
+    expect(obs[0].device_id).toBe("legacy");
     const bk = await db.selectFrom("navigation_build_keys").selectAll().where("id", "=", obs[0].build_key_id).executeTakeFirstOrThrow();
-    expect(bk.version_code).toBe(7);
+    expect(bk.version_code).toBe(0);
+    expect(bk.content_hash).toBe("");
   });
 });

--- a/test/features/navigation/navigationProvenanceWritePath.test.ts
+++ b/test/features/navigation/navigationProvenanceWritePath.test.ts
@@ -1,0 +1,136 @@
+import { afterEach, beforeEach, describe, expect, spyOn, test } from "bun:test";
+import type { Kysely } from "kysely";
+import { createTestDatabase } from "../../db/testDbHelper";
+import type { Database } from "../../../src/db/types";
+import { NavigationRepository } from "../../../src/db/navigationRepository";
+import { TestCoverageRepository } from "../../../src/db/testCoverageRepository";
+import { NavigationGraphManager } from "../../../src/features/navigation/NavigationGraphManager";
+import { TelemetryRecorder } from "../../../src/features/telemetry/TelemetryRecorder";
+import type { NavigationEvent } from "../../../src/utils/interfaces/NavigationGraph";
+
+/**
+ * AC3 coverage for #4984: every graph mutation records provenance
+ * (buildKey + deviceId + sessionUuid + seenAt) in the SAME transaction as the
+ * mutation, and the #4931 fold-in touches navigation_apps.updated_at on
+ * promoteSuggestion / recordBackStack / updateNodeScreenshot.
+ */
+const APP = "com.example.app";
+const SESSION = "session-xyz";
+
+function navEvent(destination: string, timestamp: number): NavigationEvent {
+  return {
+    destination,
+    source: "prev",
+    arguments: {},
+    metadata: {},
+    timestamp,
+    sequenceNumber: timestamp,
+    applicationId: APP,
+  };
+}
+
+describe("NavigationGraphManager provenance write path", () => {
+  let db: Kysely<Database>;
+  let manager: NavigationGraphManager;
+  let telemetrySpy: ReturnType<typeof spyOn>;
+
+  beforeEach(async () => {
+    db = await createTestDatabase();
+    const navRepo = new NavigationRepository(db);
+    const coverageRepo = new TestCoverageRepository(undefined, db);
+    manager = NavigationGraphManager.createForTesting(navRepo, coverageRepo, undefined, SESSION);
+    NavigationGraphManager.setInstanceForTesting(manager);
+    TelemetryRecorder.resetInstance();
+    telemetrySpy = spyOn(TelemetryRecorder.getInstance(), "recordNavigationEvent").mockResolvedValue(undefined);
+  });
+
+  afterEach(async () => {
+    telemetrySpy.mockRestore();
+    TelemetryRecorder.resetInstance();
+    NavigationGraphManager.resetInstance();
+    await db.destroy();
+  });
+
+  async function ageUpdatedAt(): Promise<string> {
+    const old = "2000-01-01T00:00:00.000Z";
+    await db.updateTable("navigation_apps").set({ updated_at: old }).where("app_id", "=", APP).execute();
+    return old;
+  }
+
+  async function updatedAt(): Promise<string> {
+    const row = await db.selectFrom("navigation_apps").select("updated_at").where("app_id", "=", APP).executeTakeFirstOrThrow();
+    return row.updated_at;
+  }
+
+  test("records node + edge observations under the current build key/device/session", async () => {
+    await manager.setCurrentApp(APP);
+    manager.setBuildContext({ deviceId: "emu-1", versionCode: 7, contentHash: "hashA" });
+
+    await manager.recordNavigationEvent(navEvent("Home", 100));
+    await manager.recordNavigationEvent(navEvent("Details", 200));
+
+    const buildKeys = await db.selectFrom("navigation_build_keys").selectAll().execute();
+    expect(buildKeys).toHaveLength(1);
+    expect(buildKeys[0].version_code).toBe(7);
+    expect(buildKeys[0].content_hash).toBe("hashA");
+
+    const nodeObs = await db.selectFrom("navigation_node_observations").selectAll().execute();
+    expect(nodeObs.length).toBeGreaterThanOrEqual(2);
+    for (const o of nodeObs) {
+      expect(o.build_key_id).toBe(buildKeys[0].id);
+      expect(o.device_id).toBe("emu-1");
+      expect(o.session_uuid).toBe(SESSION);
+    }
+
+    const edgeObs = await db.selectFrom("navigation_edge_observations").selectAll().execute();
+    expect(edgeObs).toHaveLength(1);
+    expect(edgeObs[0].device_id).toBe("emu-1");
+    expect(edgeObs[0].session_uuid).toBe(SESSION);
+  });
+
+  test("falls back to the default build key when no build context is set", async () => {
+    await manager.setCurrentApp(APP);
+    await manager.recordNavigationEvent(navEvent("Home", 100));
+
+    const buildKeys = await db.selectFrom("navigation_build_keys").selectAll().execute();
+    expect(buildKeys).toHaveLength(1);
+    expect(buildKeys[0].version_code).toBe(0);
+    expect(buildKeys[0].content_hash).toBe("");
+
+    const nodeObs = await db.selectFrom("navigation_node_observations").selectAll().execute();
+    expect(nodeObs.length).toBeGreaterThanOrEqual(1);
+    expect(nodeObs[0].device_id).toBe("legacy");
+  });
+
+  test("#4931: recordBackStack touches navigation_apps.updated_at", async () => {
+    await manager.setCurrentApp(APP);
+    await manager.recordNavigationEvent(navEvent("Home", 100)); // sets currentScreen
+    const old = await ageUpdatedAt();
+    await manager.recordBackStack({ depth: 1, currentTaskId: 1 });
+    expect(await updatedAt()).not.toBe(old);
+  });
+
+  test("#4931: updateNodeScreenshot touches updated_at but records NO reach observation", async () => {
+    await manager.setCurrentApp(APP);
+    await manager.recordNavigationEvent(navEvent("Home", 100));
+    const before = await db.selectFrom("navigation_node_observations").selectAll().execute();
+    const old = await ageUpdatedAt();
+
+    await manager.updateNodeScreenshot(APP, "Home", "/tmp/home.png");
+
+    expect(await updatedAt()).not.toBe(old);
+    const after = await db.selectFrom("navigation_node_observations").selectAll().execute();
+    expect(after).toHaveLength(before.length);
+  });
+
+  test("#4931: promoteSuggestion touches updated_at", async () => {
+    await manager.setCurrentApp(APP);
+    const repo = new NavigationRepository(db);
+    const suggestion = await repo.addOrUpdateSuggestion(APP, "fp-hash", "{}", 100);
+    const old = await ageUpdatedAt();
+
+    await manager.promoteSuggestion(suggestion.id, "Home");
+
+    expect(await updatedAt()).not.toBe(old);
+  });
+});

--- a/test/features/navigation/navigationProvenanceWritePath.test.ts
+++ b/test/features/navigation/navigationProvenanceWritePath.test.ts
@@ -228,8 +228,9 @@ describe("NavigationGraphManager provenance write path", () => {
     expect(after).toHaveLength(before.length);
   });
 
-  test("#4931: promoteSuggestion touches updated_at", async () => {
+  test("#4931: promoteSuggestion touches updated_at and records a node observation", async () => {
     await manager.setCurrentApp(APP);
+    manager.setBuildContext({ appId: APP, deviceId: "emu-1", versionCode: 7, contentHash: "hashA" });
     const repo = new NavigationRepository(db);
     const suggestion = await repo.addOrUpdateSuggestion(APP, "fp-hash", "{}", 100);
     const old = await ageUpdatedAt();
@@ -237,5 +238,16 @@ describe("NavigationGraphManager provenance write path", () => {
     await manager.promoteSuggestion(suggestion.id, "Home");
 
     expect(await updatedAt()).not.toBe(old);
+    // The promoted node is visible in build/device-scoped analysis (#4984), not just
+    // a bare visit count.
+    const node = await repo.getNode(APP, "Home");
+    const obs = await db
+      .selectFrom("navigation_node_observations")
+      .selectAll()
+      .where("node_id", "=", node!.id)
+      .execute();
+    expect(obs).toHaveLength(1);
+    const bk = await db.selectFrom("navigation_build_keys").selectAll().where("id", "=", obs[0].build_key_id).executeTakeFirstOrThrow();
+    expect(bk.version_code).toBe(7);
   });
 });

--- a/test/features/observe/CtrlProxyClient.test.ts
+++ b/test/features/observe/CtrlProxyClient.test.ts
@@ -1306,6 +1306,8 @@ describe("AndroidCtrlProxyClient", function() {
 
         expect(pkgInfoSpy).toHaveBeenCalled();
         expect(pkgInfoSpy.mock.calls[0][0]).toBe("com.example.nosdk");
+        // Content hashing runs on the INJECTED fake adb, never a real subprocess.
+        expect(fakeAdb.wasCommandExecuted("pm path")).toBe(true);
       } finally {
         pkgInfoSpy.mockRestore();
         await testClient.close();

--- a/test/features/observe/CtrlProxyClient.test.ts
+++ b/test/features/observe/CtrlProxyClient.test.ts
@@ -1390,6 +1390,58 @@ describe("AndroidCtrlProxyClient", function() {
       }
     });
 
+    test("build-context resolution is deferred out-of-band, not run inline with the message handler (#2885/#4984)", async function() {
+      // Regression guard for the macOS/Windows-CI-only #2885 failure: ensureBuildContext
+      // must NOT call requestPackageInfo (a WS send + RequestManager timeout timer)
+      // synchronously inside the WS message handler, or it reorders the barrier-tracked
+      // nav write vs the socket-close cache invalidation on differently-scheduled runners.
+      NavigationGraphManager.resetInstance();
+      const navHarness = await installInMemoryNavManager();
+      const testTimer = new FakeTimer();
+      testTimer.enableAutoAdvance();
+      const { factory, getSocket } = createCapturingWebSocketFactory(testTimer);
+      const testClient = AndroidCtrlProxyClient.createForTesting(testDevice, fakeAdb, factory, testTimer);
+      const pkgInfoSpy = spyOn(testClient, "requestPackageInfo").mockResolvedValue({ success: false } as never);
+
+      try {
+        const resultPromise = testClient.getLatestHierarchy(true, 2000);
+        const socket = await waitForSocket(getSocket);
+        await waitForSocketOpen(socket);
+
+        socket!.simulateMessage(JSON.stringify({
+          type: "navigation_event",
+          event: {
+            destination: "Home", source: "Start", arguments: {}, metadata: {},
+            timestamp: testTimer.now(), sequenceNumber: 1, applicationId: "com.example.app",
+          }
+        }));
+
+        // Drain MICROTASKS only (never setImmediate): the deferred resolution is
+        // dispatched on a macrotask, so if it ran inline requestPackageInfo would
+        // already have fired here. It must not have.
+        for (let i = 0; i < 5; i++) { await Promise.resolve(); }
+        expect(pkgInfoSpy).not.toHaveBeenCalled();
+
+        // Let getLatestHierarchy resolve, then allow macrotasks: the deferred
+        // resolution now runs and consults requestPackageInfo out-of-band.
+        socket!.simulateMessage(JSON.stringify({
+          type: "hierarchy_update",
+          timestamp: testTimer.now(),
+          data: { updatedAt: testTimer.now(), packageName: "com.example.app", hierarchy: { "text": "Home" } }
+        }));
+        await resultPromise;
+        for (let i = 0; i < 10; i++) {
+          await new Promise<void>(resolve => setImmediate(resolve));
+          await testTimer.advanceTimersByTimeAsync(1);
+        }
+        expect(pkgInfoSpy).toHaveBeenCalled();
+      } finally {
+        pkgInfoSpy.mockRestore();
+        await testClient.close();
+        await navHarness.dispose();
+      }
+    });
+
     test("routes the navigation-graph write through the DB-write barrier for shutdown drain (#2885)", async function() {
       resetDbWriteBarrier();
       // The Android handler resolves getDbWriteBarrier() per write (#2912), so a

--- a/test/features/observe/CtrlProxyClient.test.ts
+++ b/test/features/observe/CtrlProxyClient.test.ts
@@ -1269,6 +1269,95 @@ describe("AndroidCtrlProxyClient", function() {
       }
     });
 
+    test("resolves build/device provenance on the hierarchy path for a non-SDK app (#4984)", async function() {
+      // Apps without the AutoMobile SDK never emit navigation_event, so the hierarchy
+      // path must kick off build-context resolution — otherwise every reach records
+      // under the default/legacy build. Asserting requestPackageInfo is consulted
+      // proves ensureBuildContext ran on this path.
+      NavigationGraphManager.resetInstance();
+      const navHarness = await installInMemoryNavManager();
+
+      const testTimer = new FakeTimer();
+      testTimer.enableAutoAdvance();
+      const { factory, getSocket } = createCapturingWebSocketFactory(testTimer);
+      const testClient = AndroidCtrlProxyClient.createForTesting(testDevice, fakeAdb, factory, testTimer);
+      const pkgInfoSpy = spyOn(testClient, "requestPackageInfo").mockResolvedValue({ success: true, versionCode: 42 } as never);
+
+      try {
+        const resultPromise = testClient.getLatestHierarchy(true, 2000);
+        const socket = await waitForSocket(getSocket);
+        await waitForSocketOpen(socket);
+
+        socket!.simulateMessage(JSON.stringify({
+          type: "hierarchy_update",
+          timestamp: testTimer.now(),
+          data: {
+            updatedAt: testTimer.now(),
+            packageName: "com.example.nosdk",
+            hierarchy: { "text": "Home", "resource-id": "com.example.nosdk:id/home" },
+          }
+        }));
+
+        await resultPromise;
+        for (let i = 0; i < 10; i++) {
+          await new Promise<void>(resolve => setImmediate(resolve));
+          await testTimer.advanceTimersByTimeAsync(1);
+        }
+
+        expect(pkgInfoSpy).toHaveBeenCalled();
+        expect(pkgInfoSpy.mock.calls[0][0]).toBe("com.example.nosdk");
+      } finally {
+        pkgInfoSpy.mockRestore();
+        await testClient.close();
+        await navHarness.dispose();
+      }
+    });
+
+    test("does not apply a build context built from a failed package-info result (#4984)", async function() {
+      // A transient package-info failure must NOT be persisted as version 0 — defer
+      // instead, so a later event retries. setBuildContext must not be called.
+      NavigationGraphManager.resetInstance();
+      const navHarness = await installInMemoryNavManager();
+      const setCtxSpy = spyOn(navHarness.manager, "setBuildContext");
+
+      const testTimer = new FakeTimer();
+      testTimer.enableAutoAdvance();
+      const { factory, getSocket } = createCapturingWebSocketFactory(testTimer);
+      const testClient = AndroidCtrlProxyClient.createForTesting(testDevice, fakeAdb, factory, testTimer);
+      const pkgInfoSpy = spyOn(testClient, "requestPackageInfo").mockResolvedValue({ success: false } as never);
+
+      try {
+        const resultPromise = testClient.getLatestHierarchy(true, 2000);
+        const socket = await waitForSocket(getSocket);
+        await waitForSocketOpen(socket);
+
+        socket!.simulateMessage(JSON.stringify({
+          type: "hierarchy_update",
+          timestamp: testTimer.now(),
+          data: {
+            updatedAt: testTimer.now(),
+            packageName: "com.example.nosdk",
+            hierarchy: { "text": "Home", "resource-id": "com.example.nosdk:id/home" },
+          }
+        }));
+
+        await resultPromise;
+        for (let i = 0; i < 10; i++) {
+          await new Promise<void>(resolve => setImmediate(resolve));
+          await testTimer.advanceTimersByTimeAsync(1);
+        }
+
+        expect(pkgInfoSpy).toHaveBeenCalled();
+        // Failed metadata → deferred → no (bogus version-0) context applied.
+        expect(setCtxSpy).not.toHaveBeenCalled();
+      } finally {
+        pkgInfoSpy.mockRestore();
+        setCtxSpy.mockRestore();
+        await testClient.close();
+        await navHarness.dispose();
+      }
+    });
+
     test("routes the navigation-graph write through the DB-write barrier for shutdown drain (#2885)", async function() {
       resetDbWriteBarrier();
       // The Android handler resolves getDbWriteBarrier() per write (#2912), so a

--- a/test/features/observe/CtrlProxyClient.test.ts
+++ b/test/features/observe/CtrlProxyClient.test.ts
@@ -1442,6 +1442,60 @@ describe("AndroidCtrlProxyClient", function() {
       }
     });
 
+    test("clears resolved build contexts on connection close so the next event re-resolves (#4984)", async function() {
+      // While the WS has no client, a package_event has zero listeners, so an app can be
+      // replaced unobserved. onConnectionClosed must invalidate cached contexts so the
+      // next event after reconnect re-resolves the hash instead of using the stale build.
+      NavigationGraphManager.resetInstance();
+      const navHarness = await installInMemoryNavManager();
+      const testTimer = new FakeTimer();
+      testTimer.enableAutoAdvance();
+      const { factory, getSocket } = createCapturingWebSocketFactory(testTimer);
+      const testClient = AndroidCtrlProxyClient.createForTesting(testDevice, fakeAdb, factory, testTimer);
+      const DIGEST = "a".repeat(64);
+      fakeAdb.setCommandResponse("pm path", { stdout: "package:/a/base.apk", stderr: "" });
+      fakeAdb.setCommandResponse("sha256sum", { stdout: `${DIGEST}  /a/base.apk`, stderr: "" });
+      const pkgSpy = spyOn(testClient, "requestPackageInfo").mockResolvedValue({ success: true, versionCode: 5 } as never);
+      const settle = async (): Promise<void> => {
+        for (let i = 0; i < 10; i++) { await new Promise<void>(r => setImmediate(r)); await testTimer.advanceTimersByTimeAsync(1); }
+      };
+      const navEvent = (dest: string): void => socket!.simulateMessage(JSON.stringify({
+        type: "navigation_event",
+        event: { destination: dest, source: "s", arguments: {}, metadata: {}, timestamp: testTimer.now(), sequenceNumber: 1, applicationId: "com.example.app" }
+      }));
+      let socket: Awaited<ReturnType<typeof waitForSocket>>;
+
+      try {
+        const resultPromise = testClient.getLatestHierarchy(true, 2000);
+        socket = await waitForSocket(getSocket);
+        await waitForSocketOpen(socket);
+
+        navEvent("Home");
+        socket!.simulateMessage(JSON.stringify({
+          type: "hierarchy_update", timestamp: testTimer.now(),
+          data: { updatedAt: testTimer.now(), packageName: "com.example.app", hierarchy: { "text": "Home" } }
+        }));
+        await resultPromise;
+        await settle();
+        expect(pkgSpy).toHaveBeenCalledTimes(1); // resolved once
+
+        navEvent("Details");
+        await settle();
+        expect(pkgSpy).toHaveBeenCalledTimes(1); // cached — no re-resolution
+
+        // Connection drops (app may be replaced unobserved), then a later event arrives.
+        (testClient as unknown as { onConnectionClosed: () => void }).onConnectionClosed();
+
+        navEvent("Home2");
+        await settle();
+        expect(pkgSpy).toHaveBeenCalledTimes(2); // re-resolved after close
+      } finally {
+        pkgSpy.mockRestore();
+        await testClient.close();
+        await navHarness.dispose();
+      }
+    });
+
     test("routes the navigation-graph write through the DB-write barrier for shutdown drain (#2885)", async function() {
       resetDbWriteBarrier();
       // The Android handler resolves getDbWriteBarrier() per write (#2912), so a

--- a/test/features/observe/CtrlProxyClient.test.ts
+++ b/test/features/observe/CtrlProxyClient.test.ts
@@ -1360,6 +1360,36 @@ describe("AndroidCtrlProxyClient", function() {
       }
     });
 
+    test("releaseSessionBinding clears the binding and cached detector for the released session (#4984)", async function() {
+      NavigationGraphManager.resetInstance();
+      const navHarness = await installInMemoryNavManager();
+      const testTimer = new FakeTimer();
+      testTimer.enableAutoAdvance();
+      const { factory } = createCapturingWebSocketFactory(testTimer);
+      const testClient = AndroidCtrlProxyClient.createForTesting(testDevice, fakeAdb, factory, testTimer);
+
+      try {
+        testClient.bindSession("session-A");
+        expect(testClient.getBoundSessionIdForTesting()).toBe("session-A");
+        const detectorBoundToA = testClient.getHierarchyNavigationDetector();
+
+        testClient.releaseSessionBinding("session-A");
+
+        // Binding cleared and the cached detector dropped (recreated on next access),
+        // so post-release events route to the unattributed global manager, not A's.
+        expect(testClient.getBoundSessionIdForTesting()).toBeNull();
+        expect(testClient.getHierarchyNavigationDetector()).not.toBe(detectorBoundToA);
+
+        // A non-matching release is a no-op once a new session has bound.
+        testClient.bindSession("session-B");
+        testClient.releaseSessionBinding("session-A");
+        expect(testClient.getBoundSessionIdForTesting()).toBe("session-B");
+      } finally {
+        await testClient.close();
+        await navHarness.dispose();
+      }
+    });
+
     test("routes the navigation-graph write through the DB-write barrier for shutdown drain (#2885)", async function() {
       resetDbWriteBarrier();
       // The Android handler resolves getDbWriteBarrier() per write (#2912), so a

--- a/test/server/deviceLabelSessionReleaseOrdering.test.ts
+++ b/test/server/deviceLabelSessionReleaseOrdering.test.ts
@@ -1,0 +1,64 @@
+import { afterEach, describe, expect, spyOn, test } from "bun:test";
+import { Daemon } from "../../src/daemon/daemon";
+import { DaemonState } from "../../src/daemon/daemonState";
+import { DeviceSessionRepository } from "../../src/db/deviceSessionRepository";
+import { createTestDatabase } from "../db/testDbHelper";
+import { releaseDeviceLabelSessions } from "../../src/server/deviceLabelMapping";
+
+// #4984: releasing a derived device-label session must await the session release
+// (so its central onSessionRelease cleanup — CtrlProxy binding + build context —
+// completes) BEFORE the device is returned to the pool, mirroring the base-session
+// path. Otherwise nav/hierarchy broadcasts during the release's async tail are
+// recorded under the ended session's uuid.
+
+describe("releaseDeviceLabelSessions ordering", () => {
+  afterEach(() => {
+    if (DaemonState.getInstance().isInitialized()) {
+      DaemonState.getInstance().reset();
+    }
+  });
+
+  test("awaits the derived session release before freeing its device", async () => {
+    const db = await createTestDatabase();
+    // Constructing the Daemon initializes the global DaemonState; read the exact
+    // collaborators releaseDeviceLabelSessions resolves through DaemonState.getInstance().
+    new Daemon({}, undefined, undefined, new DeviceSessionRepository(db));
+    const sessionManager = DaemonState.getInstance().getSessionManager();
+    const devicePool = DaemonState.getInstance().getDevicePool();
+
+    const base = "base-sess";
+    const derived = `${base}:B`;
+
+    // Model the release's async tail (persistence / central cleanup) so the ordering
+    // is observable: releaseDevice must not run until this has fully resolved.
+    let releaseSettled = false;
+    const releaseSpy = spyOn(sessionManager, "releaseSession").mockImplementation(async () => {
+      await new Promise<void>(resolve => setImmediate(resolve));
+      releaseSettled = true;
+      return "emulator-5554";
+    });
+    let releasedFirst: boolean | null = null;
+    const deviceSpy = spyOn(devicePool, "releaseDevice").mockImplementation(async () => {
+      releasedFirst = releaseSettled;
+    });
+
+    try {
+      // The base session must exist for its device-label map to persist; the derived
+      // session is the one releaseDeviceLabelSessions frees.
+      await sessionManager.createSession(base, "emulator-5554", "android");
+      await sessionManager.createSession(derived, "emulator-5555", "android");
+      sessionManager.setDeviceLabels(base, { A: base, B: derived });
+
+      const released = await releaseDeviceLabelSessions(base);
+
+      expect(released).toEqual([derived]);
+      expect(releaseSpy).toHaveBeenCalledWith(derived);
+      // The device was freed only AFTER the session release fully settled.
+      expect(releasedFirst).toBe(true);
+    } finally {
+      releaseSpy.mockRestore();
+      deviceSpy.mockRestore();
+      sessionManager.stopCleanupTimer();
+    }
+  });
+});

--- a/test/utils/contentHashProvider.test.ts
+++ b/test/utils/contentHashProvider.test.ts
@@ -132,6 +132,33 @@ describe("CachingContentHashProvider", () => {
     await provider.resolveContentHash(fakeDevice("emu-1"), "com.other.app", 5);
     expect(hasher.calls).toHaveLength(5);
   });
+
+  test("an in-flight resolution started before invalidate does not repopulate the cache", async () => {
+    // Interleave: start resolve (blocks), invalidate, then let the old computation
+    // finish — it must NOT poison the cache with the pre-update hash.
+    let release: (value: string) => void = () => {};
+    let computeCalls = 0;
+    const hasher: AppContentHasher = {
+      async computeHash() {
+        computeCalls += 1;
+        if (computeCalls === 1) {
+          return new Promise<string>(resolve => { release = resolve; });
+        }
+        return "sha256:FRESH";
+      },
+    } as unknown as AppContentHasher;
+    const provider = new CachingContentHashProvider(hasher);
+
+    const pending = provider.resolveContentHash(fakeDevice("emu-1"), "com.example.app", 5);
+    provider.invalidate("emu-1", "com.example.app"); // package updated mid-flight
+    release("sha256:STALE");
+    expect(await pending).toBe("sha256:STALE"); // returned to its caller, but not cached
+
+    // A fresh resolution recomputes instead of serving the stale value from cache.
+    const result = await provider.resolveContentHash(fakeDevice("emu-1"), "com.example.app", 5);
+    expect(result).toBe("sha256:FRESH");
+    expect(computeCalls).toBe(2);
+  });
 });
 
 describe("parsePmPathOutput", () => {

--- a/test/utils/contentHashProvider.test.ts
+++ b/test/utils/contentHashProvider.test.ts
@@ -35,17 +35,34 @@ class FakeHasher implements AppContentHasher {
   }
 }
 
+const DIGEST_A = "a".repeat(64);
+const DIGEST_B = "b".repeat(64);
+const DIGEST_Z = "f".repeat(64);
+
 describe("combineApkDigests", () => {
   test("is order-independent and content-derived (split APKs)", () => {
-    const a = combineApkDigests("aaa  /data/app/base.apk\nbbb  /data/app/split_config.apk\n");
-    const reordered = combineApkDigests("bbb  /data/app/split_config.apk\naaa  /data/app/base.apk\n");
+    const a = combineApkDigests(`${DIGEST_A}  /data/app/base.apk\n${DIGEST_B}  /data/app/split_config.apk\n`);
+    const reordered = combineApkDigests(`${DIGEST_B}  /data/app/split_config.apk\n${DIGEST_A}  /data/app/base.apk\n`);
     expect(a).toBe(reordered);
   });
 
   test("changes when any APK's content digest changes", () => {
-    const a = combineApkDigests("aaa  /data/app/base.apk\n");
-    const b = combineApkDigests("zzz  /data/app/base.apk\n");
+    const a = combineApkDigests(`${DIGEST_A}  /data/app/base.apk\n`);
+    const b = combineApkDigests(`${DIGEST_Z}  /data/app/base.apk\n`);
     expect(a).not.toBe(b);
+  });
+
+  test("returns empty string when no valid sha256 digest is present", () => {
+    // A legacy adb shell can merge stderr into stdout; such lines must not be hashed.
+    expect(combineApkDigests("sha256sum: not found\n")).toBe("");
+    expect(combineApkDigests("")).toBe("");
+    expect(combineApkDigests("/system/bin/sh: sha256sum: inaccessible or not found\n")).toBe("");
+  });
+
+  test("ignores non-digest lines mixed with a valid digest", () => {
+    const mixed = combineApkDigests(`sha256sum: not found\n${DIGEST_A}  /data/app/base.apk\n`);
+    const clean = combineApkDigests(`${DIGEST_A}  /data/app/base.apk\n`);
+    expect(mixed).toBe(clean);
   });
 });
 

--- a/test/utils/contentHashProvider.test.ts
+++ b/test/utils/contentHashProvider.test.ts
@@ -1,6 +1,7 @@
 import { describe, expect, test } from "bun:test";
 import type { BootedDevice, ExecResult } from "../../src/models";
 import type { AdbExecutor } from "../../src/utils/android-cmdline-tools/interfaces/AdbExecutor";
+import type { ChecksumCalculator } from "../../src/utils/ChecksumCalculator";
 import {
   AndroidApkContentHasher,
   CachingContentHashProvider,
@@ -210,5 +211,33 @@ describe("AndroidApkContentHasher (pm path resolution)", () => {
     const adb = fakeAdb(() => ok("Unable to find package\n"));
     const hasher = new AndroidApkContentHasher(adb);
     await expect(hasher.computeHash(fakeDevice("emu-1"), "com.missing.app", 0)).rejects.toThrow();
+  });
+
+  test("falls back to pull when the on-device digest count is incomplete (one split failed)", async () => {
+    // 2 APKs but on-device sha256sum yields only 1 valid digest (the split errored):
+    // accepting that partial would conflate builds differing only in the failing split.
+    let pullChecksums = 0;
+    const checksum: ChecksumCalculator = {
+      async computeFileSha256() {
+        pullChecksums += 1;
+        return { checksum: pullChecksums === 1 ? DIGEST_B : DIGEST_Z, source: "node" as const };
+      },
+    };
+    const adb = fakeAdb(command => {
+      if (command.includes("pm path")) {
+        return ok("package:/a/base.apk\npackage:/a/split.apk\n");
+      }
+      if (command.includes("sha256sum")) {
+        return ok(`${DIGEST_A}  /a/base.apk\nsha256sum: /a/split.apk: No such file or directory\n`);
+      }
+      return ok(""); // pull
+    });
+    const hasher = new AndroidApkContentHasher(adb, checksum);
+    const hash = await hasher.computeHash(fakeDevice("emu-1"), "com.example.app", 0);
+
+    // Fell back to pull (hashed both APKs), NOT the partial single on-device digest.
+    expect(pullChecksums).toBe(2);
+    expect(hash).toBe(combineApkDigests(`${DIGEST_B}  /a/base.apk\n${DIGEST_Z}  /a/split.apk`));
+    expect(hash).not.toBe(combineApkDigests(`${DIGEST_A}  /a/base.apk`));
   });
 });

--- a/test/utils/contentHashProvider.test.ts
+++ b/test/utils/contentHashProvider.test.ts
@@ -1,8 +1,11 @@
 import { describe, expect, test } from "bun:test";
-import type { BootedDevice } from "../../src/models";
+import type { BootedDevice, ExecResult } from "../../src/models";
+import type { AdbExecutor } from "../../src/utils/android-cmdline-tools/interfaces/AdbExecutor";
 import {
+  AndroidApkContentHasher,
   CachingContentHashProvider,
   combineApkDigests,
+  parsePmPathOutput,
   type AppContentHasher,
 } from "../../src/utils/ContentHashProvider";
 
@@ -105,5 +108,80 @@ describe("CachingContentHashProvider", () => {
     const provider = new CachingContentHashProvider(new FakeHasher(new Map()));
     const result = await provider.resolveContentHash(fakeDevice("emu-1"), "com.example.app", 5);
     expect(result).toBeNull();
+  });
+
+  test("invalidate drops every cached versionCode for (device, package) so it recomputes", async () => {
+    const hasher = new FakeHasher(
+      new Map([
+        ["emu-1::com.example.app::5", "V5"],
+        ["emu-1::com.example.app::6", "V6"],
+        ["emu-1::com.other.app::5", "OTHER"],
+      ])
+    );
+    const provider = new CachingContentHashProvider(hasher);
+    await provider.resolveContentHash(fakeDevice("emu-1"), "com.example.app", 5);
+    await provider.resolveContentHash(fakeDevice("emu-1"), "com.example.app", 6);
+    await provider.resolveContentHash(fakeDevice("emu-1"), "com.other.app", 5);
+    expect(hasher.calls).toHaveLength(3);
+
+    provider.invalidate("emu-1", "com.example.app");
+
+    // Both versionCodes of the invalidated package recompute; the other package stays cached.
+    await provider.resolveContentHash(fakeDevice("emu-1"), "com.example.app", 5);
+    await provider.resolveContentHash(fakeDevice("emu-1"), "com.example.app", 6);
+    await provider.resolveContentHash(fakeDevice("emu-1"), "com.other.app", 5);
+    expect(hasher.calls).toHaveLength(5);
+  });
+});
+
+describe("parsePmPathOutput", () => {
+  test("extracts base + split APK paths, stripping the package: prefix", () => {
+    const out = "package:/data/app/~~x==/com.example.app-1/base.apk\npackage:/data/app/~~x==/com.example.app-1/split_config.en.apk\n";
+    expect(parsePmPathOutput(out)).toEqual([
+      "/data/app/~~x==/com.example.app-1/base.apk",
+      "/data/app/~~x==/com.example.app-1/split_config.en.apk",
+    ]);
+  });
+
+  test("returns empty for no package: lines", () => {
+    expect(parsePmPathOutput("")).toEqual([]);
+    expect(parsePmPathOutput("Unable to find package\n")).toEqual([]);
+  });
+});
+
+/** Minimal AdbExecutor fake routing by command substring. */
+function fakeAdb(routes: (command: string) => ExecResult): AdbExecutor {
+  return {
+    executeCommand: async (command: string) => routes(command),
+  } as unknown as AdbExecutor;
+}
+
+function ok(stdout: string): ExecResult {
+  return { stdout, stderr: "", exitCode: 0, success: true } as unknown as ExecResult;
+}
+
+describe("AndroidApkContentHasher (pm path resolution)", () => {
+  test("resolves APK paths via pm path and returns a non-null hash (installPath-independent)", async () => {
+    // This is the WS-package-info-success case: GetAppMetadata would return installPath=""
+    // but pm path still yields the APKs, so hashing succeeds on the normal path.
+    const adb = fakeAdb(command => {
+      if (command.includes("pm path")) {
+        return ok("package:/data/app/com.example.app-1/base.apk\n");
+      }
+      if (command.includes("sha256sum")) {
+        return ok(`${DIGEST_A}  /data/app/com.example.app-1/base.apk\n`);
+      }
+      return ok("");
+    });
+    const hasher = new AndroidApkContentHasher(adb);
+    const hash = await hasher.computeHash(fakeDevice("emu-1"), "com.example.app", 0);
+    expect(hash).toBe(combineApkDigests(`${DIGEST_A}  x\n`));
+    expect(hash).not.toBe("");
+  });
+
+  test("throws when pm path returns no APKs", async () => {
+    const adb = fakeAdb(() => ok("Unable to find package\n"));
+    const hasher = new AndroidApkContentHasher(adb);
+    await expect(hasher.computeHash(fakeDevice("emu-1"), "com.missing.app", 0)).rejects.toThrow();
   });
 });

--- a/test/utils/contentHashProvider.test.ts
+++ b/test/utils/contentHashProvider.test.ts
@@ -1,0 +1,92 @@
+import { describe, expect, test } from "bun:test";
+import type { BootedDevice } from "../../src/models";
+import {
+  CachingContentHashProvider,
+  combineApkDigests,
+  type AppContentHasher,
+} from "../../src/utils/ContentHashProvider";
+
+/**
+ * AC2 coverage for #4984: contentHash is derived from installed app *bytes*,
+ * cached by (deviceId, packageId, versionCode), and never depends on install-time
+ * signals (lastUpdateTime). A failure resolves to null so the caller falls back
+ * to the default build key instead of hard-failing.
+ *
+ * The real Android on-device `sha256sum` / `adb pull` and iOS bundle-FS walk are
+ * integration-only; here the platform hasher is a fake so the caching + fallback
+ * contract is unit-tested deterministically (<100ms).
+ */
+function fakeDevice(deviceId: string, platform: "android" | "ios" = "android"): BootedDevice {
+  return { deviceId, platform, name: deviceId } as unknown as BootedDevice;
+}
+
+class FakeHasher implements AppContentHasher {
+  public calls: Array<{ deviceId: string; packageId: string; versionCode: number }> = [];
+  constructor(private readonly bytesByInstall: Map<string, string>) {}
+  async computeHash(device: BootedDevice, packageId: string, versionCode: number): Promise<string> {
+    this.calls.push({ deviceId: device.deviceId, packageId, versionCode });
+    const key = `${device.deviceId}::${packageId}::${versionCode}`;
+    const bytes = this.bytesByInstall.get(key);
+    if (bytes === undefined) {
+      throw new Error(`no bytes for ${key}`);
+    }
+    // Deterministic hash of the "bytes" — depends only on content, not metadata.
+    return `sha256:${bytes}`;
+  }
+}
+
+describe("combineApkDigests", () => {
+  test("is order-independent and content-derived (split APKs)", () => {
+    const a = combineApkDigests("aaa  /data/app/base.apk\nbbb  /data/app/split_config.apk\n");
+    const reordered = combineApkDigests("bbb  /data/app/split_config.apk\naaa  /data/app/base.apk\n");
+    expect(a).toBe(reordered);
+  });
+
+  test("changes when any APK's content digest changes", () => {
+    const a = combineApkDigests("aaa  /data/app/base.apk\n");
+    const b = combineApkDigests("zzz  /data/app/base.apk\n");
+    expect(a).not.toBe(b);
+  });
+});
+
+describe("CachingContentHashProvider", () => {
+  test("identical installed bytes resolve to the same hash", async () => {
+    const bytes = new Map([["emu-1::com.example.app::5", "IDENTICAL"]]);
+    const provider = new CachingContentHashProvider(new FakeHasher(bytes));
+    const first = await provider.resolveContentHash(fakeDevice("emu-1"), "com.example.app", 5);
+    // Fresh provider = fresh cache, same bytes -> same hash (models a reinstall of identical content).
+    const provider2 = new CachingContentHashProvider(new FakeHasher(bytes));
+    const second = await provider2.resolveContentHash(fakeDevice("emu-1"), "com.example.app", 5);
+    expect(first).toBe(second);
+    expect(first).toBe("sha256:IDENTICAL");
+  });
+
+  test("caches by (deviceId, packageId, versionCode): computes once", async () => {
+    const hasher = new FakeHasher(new Map([["emu-1::com.example.app::5", "X"]]));
+    const provider = new CachingContentHashProvider(hasher);
+    await provider.resolveContentHash(fakeDevice("emu-1"), "com.example.app", 5);
+    await provider.resolveContentHash(fakeDevice("emu-1"), "com.example.app", 5);
+    expect(hasher.calls).toHaveLength(1);
+  });
+
+  test("a different versionCode is a distinct cache entry", async () => {
+    const hasher = new FakeHasher(
+      new Map([
+        ["emu-1::com.example.app::5", "V5"],
+        ["emu-1::com.example.app::6", "V6"],
+      ])
+    );
+    const provider = new CachingContentHashProvider(hasher);
+    const v5 = await provider.resolveContentHash(fakeDevice("emu-1"), "com.example.app", 5);
+    const v6 = await provider.resolveContentHash(fakeDevice("emu-1"), "com.example.app", 6);
+    expect(v5).toBe("sha256:V5");
+    expect(v6).toBe("sha256:V6");
+    expect(hasher.calls).toHaveLength(2);
+  });
+
+  test("returns null when the hasher fails (caller falls back to default build key)", async () => {
+    const provider = new CachingContentHashProvider(new FakeHasher(new Map()));
+    const result = await provider.resolveContentHash(fakeDevice("emu-1"), "com.example.app", 5);
+    expect(result).toBeNull();
+  });
+});


### PR DESCRIPTION
## Summary

Phase 1 of the `(app, build)` navigation model ([#4837](https://github.com/kaeawc/auto-mobile/issues/4837)): a **build-key provenance dimension** on the app-level union navigation graph. The graph stays a single union per app — the build key is provenance recorded on each node/edge, **not** a separate-graph partition. Identical rebuild → same content hash → data reused; a different build → isolated provenance.

## Linked Issue

Closes #4984

## Changes

- **Migration `2026_08_02_000_navigation_provenance`** (next free slot; passes the filename-ordering guard; only `sql` runtime import):
  - `navigation_build_keys` — `(app_id, version_code, content_hash)`, `UNIQUE(app_id, version_code, content_hash)`.
  - `navigation_node_observations` / `navigation_edge_observations` — `{buildKey, deviceId, sessionUuid, firstSeen, lastSeen}`, `UNIQUE(node/edge, build_key, device_id, session_uuid)` so multiple observation records exist per node/edge, with indexes on `build_key_id` and `device_id` for the Phase-2 lens.
  - The existing union tables (`navigation_apps`/`navigation_nodes`/`navigation_edges`) are left untouched.
- **`ContentHashProvider`** (`src/utils/ContentHashProvider.ts`) — derives the content hash from installed APK/IPA **bytes**, cached by `(deviceId, packageId, versionCode)`:
  - Android: on-device `sha256sum` of the APK set (base + splits), with an `adb pull` + local-hash fallback when `sha256sum` is unavailable (logged slow path).
  - iOS: reuses the existing `AppBundleHasher` (already excludes signature/provisioning files).
  - Never derived from install-time signals (`lastUpdateTime`), so an identical rebuild resolves to the same hash. Resolution failures return `null` → caller records under the default build key.
- **Write-path provenance** (`NavigationGraphManager`) — records node/edge observations **in the same transaction** as each reach mutation (`recordNavigationEvent`, `recordHierarchyNavigation`). `setBuildContext(...)` receives `(deviceId, versionCode, contentHash)`; `sessionUuid` is carried on the per-session manager.
- **[#4931](https://github.com/kaeawc/auto-mobile/issues/4931) fold-in** — `promoteSuggestion` / `recordBackStack` / `updateNodeScreenshot` now touch `navigation_apps.updated_at` atomically (the last two are now wrapped in a transaction). `updateNodeScreenshot` is enrichment, so it touches only — no reach observation.
- **Android CtrlProxy** eagerly and non-blockingly resolves the build context on nav events and calls `setBuildContext`; a nav event that races an unresolved hash records under the default key.

## Migration / backward-compat

Backward-compatible and gated. The migration backfills, per app, one **default build key** (`version_code = 0`, `content_hash = ''`) and one observation per existing node/edge using non-null legacy sentinels (`device_id`/`session_uuid = 'legacy'`) and the source rows' timestamps (edges use `timestamp` for both seen fields). Existing rows are never modified or deleted — today's single-build behavior falls out as the degenerate one-build default, with no data loss. `down()` drops only the three new tables.

## Testing

- `test/db/navigationProvenanceMigration.test.ts` — AC1 table creation + AC4 backfill/no-data-loss (in-memory, direct `up()`, foreign_keys ON).
- `test/db/navigationProvenanceLifecycle.test.ts` — AC4/AC5 full migration chain against a real file DB via the shared `openLifecycleTestDb` harness.
- `test/db/navigationProvenanceRepository.test.ts` — AC1 multi-record observations + upsert-dedup + `getOrCreateBuildKey`.
- `test/utils/contentHashProvider.test.ts` — AC2 caching by `(deviceId, packageId, versionCode)`, content-derived determinism, metadata-independence, and null-fallback (fakes; real device paths are integration-only).
- `test/features/navigation/navigationProvenanceWritePath.test.ts` — AC3 in-transaction node/edge provenance, default-key fallback, and the #4931 `updated_at` touches.
- Full suite: **12649 pass / 0 fail**. `bun run typecheck`: no new errors (baseline line-shift refreshed). `bun run lint` + `bun run build`: green.

## Acceptance criteria

1. Build-key dimension + per-node/edge observation records — **done** (schema + repo + tests).
2. contentHash from installed bytes, cached by `(deviceId, packageId, versionCode)`, not install-time signals — **done** (`ContentHashProvider`, Android + iOS derivation).
3. Provenance recorded on every reach mutation in-transaction + #4931 `updated_at` touches — **done**.
4. Backward-compatible migration, default build key, no data loss — **done**.
5. Interface + fake in-memory DB unit tests (<100ms) + file-backed lifecycle test — **done**.

## Risk

DB **migration** on a public data surface → **hand-off merge** (no auto-merge). Requested the maintainer make the merge decision.

## Follow-ups

- **iOS CtrlProxy eager build-context hook** is deferred: the derivation layer (`IosBundleContentHasher`) and the platform-agnostic write path both support iOS, but the iOS client lacks a readily-available metadata source to resolve the bundle version/path at bind time, so iOS nav events currently record under the default build key until this hook lands. Will file a follow-up linking this PR and #4984.
