### PR TITLE
fix(android): throttle a11y screenshots to the platform floor + surface rate limits

### DIFF
--- a/android/control-proxy/src/main/kotlin/dev/jasonpearson/automobile/ctrlproxy/CtrlProxy.kt
+++ b/android/control-proxy/src/main/kotlin/dev/jasonpearson/automobile/ctrlproxy/CtrlProxy.kt
@@ -395,6 +395,25 @@ class CtrlProxy : AccessibilityService(), CtrlProxyActions {
     val base64Length: Int,
   )
 
+  /**
+   * Raw result of the platform takeScreenshot callback, carrying the failure code (issue #4927).
+   */
+  private sealed interface ScreenshotCallbackResult {
+    data class Captured(val bitmap: Bitmap, val rotation: Int?) : ScreenshotCallbackResult
+
+    data class Failed(val errorCode: Int?) : ScreenshotCallbackResult
+  }
+
+  /**
+   * Outcome of [takeScreenshotAsync]: an encoded payload, or a failure that retains the platform
+   * error code so the broadcast can surface a rate limit distinctly instead of a generic failure.
+   */
+  private sealed interface ScreenshotCaptureOutcome {
+    data class Success(val payload: ScreenshotCapturePayload) : ScreenshotCaptureOutcome
+
+    data class Failure(val errorCode: Int?) : ScreenshotCaptureOutcome
+  }
+
   // Job for collecting hierarchy flow results
   private var hierarchyFlowJob: Job? = null
 
@@ -2585,10 +2604,10 @@ class CtrlProxy : AccessibilityService(), CtrlProxyActions {
    * Takes a screenshot and returns it as a base64-encoded JPEG plus capture diagnostics. Requires
    * Android R (API 30) or higher. Runs on IO dispatcher to avoid blocking the main thread.
    */
-  private suspend fun takeScreenshotAsync(quality: Int = 80): ScreenshotCapturePayload? {
+  private suspend fun takeScreenshotAsync(quality: Int = 80): ScreenshotCaptureOutcome {
     if (Build.VERSION.SDK_INT < Build.VERSION_CODES.R) {
       Log.w(TAG, "Screenshot API requires Android R (API 30) or higher")
-      return null
+      return ScreenshotCaptureOutcome.Failure(null)
     }
 
     return withContext(Dispatchers.IO) {
@@ -2599,7 +2618,7 @@ class CtrlProxy : AccessibilityService(), CtrlProxyActions {
         val rotationCapture = rotationProvenance.beginCapture()
         val rotationAtCaptureStart = getRotationOrNull()
         val captured =
-          suspendCancellableCoroutine<Pair<Bitmap, Int?>?> { continuation ->
+          suspendCancellableCoroutine<ScreenshotCallbackResult> { continuation ->
             takeScreenshot(
               Display.DEFAULT_DISPLAY,
               mainExecutor,
@@ -2612,7 +2631,7 @@ class CtrlProxy : AccessibilityService(), CtrlProxyActions {
                     )
                   screenshot.hardwareBuffer.close()
                   if (hardwareBitmap == null) {
-                    continuation.resume(null)
+                    continuation.resume(ScreenshotCallbackResult.Failed(null))
                     return
                   }
                   // A display change makes the pixels' orientation ambiguous. Preserve that
@@ -2623,23 +2642,25 @@ class CtrlProxy : AccessibilityService(), CtrlProxyActions {
                       rotationAtCaptureStart,
                       getRotationOrNull(),
                     )
-                  continuation.resume(hardwareBitmap to rotation)
+                  continuation.resume(ScreenshotCallbackResult.Captured(hardwareBitmap, rotation))
                 }
 
                 override fun onFailure(errorCode: Int) {
+                  // Retain the platform error code so the broadcast can distinguish a rate limit
+                  // (ERROR_TAKE_SCREENSHOT_INTERVAL_TIME_SHORT) from a real failure (issue #4927).
                   Log.e(TAG, "Screenshot failed with error code: $errorCode")
-                  continuation.resume(null)
+                  continuation.resume(ScreenshotCallbackResult.Failed(errorCode))
                 }
               },
             )
           }
 
-        if (captured == null) {
-          Log.e(TAG, "Failed to capture screenshot bitmap")
-          return@withContext null
+        if (captured is ScreenshotCallbackResult.Failed) {
+          Log.e(TAG, "Failed to capture screenshot bitmap (errorCode=${captured.errorCode})")
+          return@withContext ScreenshotCaptureOutcome.Failure(captured.errorCode)
         }
 
-        val (bitmap, rotation) = captured
+        val (bitmap, rotation) = captured as ScreenshotCallbackResult.Captured
 
         val screenshotTime = System.currentTimeMillis() - startTime
         Log.d(TAG, "Screenshot captured in ${screenshotTime}ms (${bitmap.width}x${bitmap.height})")
@@ -2666,13 +2687,15 @@ class CtrlProxy : AccessibilityService(), CtrlProxyActions {
           "Screenshot encoded: ${jpegBytes.size} bytes -> ${base64String.length} base64 chars in ${encodeTime}ms (total: ${totalTime}ms)",
         )
 
-        ScreenshotCapturePayload(
-          base64Image = base64String,
-          rotation = rotation,
-          captureDurationMs = screenshotTime,
-          encodeDurationMs = encodeTime,
-          byteLength = jpegBytes.size,
-          base64Length = base64String.length,
+        ScreenshotCaptureOutcome.Success(
+          ScreenshotCapturePayload(
+            base64Image = base64String,
+            rotation = rotation,
+            captureDurationMs = screenshotTime,
+            encodeDurationMs = encodeTime,
+            byteLength = jpegBytes.size,
+            base64Length = base64String.length,
+          )
         )
       } catch (e: CancellationException) {
         // The awaiting caller is being cancelled — rethrow instead of converting the cancellation
@@ -2680,7 +2703,7 @@ class CtrlProxy : AccessibilityService(), CtrlProxyActions {
         throw e
       } catch (e: Exception) {
         Log.e(TAG, "Error taking screenshot", e)
-        null
+        ScreenshotCaptureOutcome.Failure(null)
       }
     }
   }
@@ -5426,33 +5449,40 @@ class CtrlProxy : AccessibilityService(), CtrlProxyActions {
     // and hanging the awaiting client until timeout (issue #3023).
     asyncActionRunner.launch(requestId, "screenshot") {
       val contextBeforeCapture = currentFrameContext()
-      val screenshot = takeScreenshotAsync()
+      val outcome = takeScreenshotAsync()
       val stableContext = contextBeforeCapture.takeIf { it == currentFrameContext() }
-      if (screenshot != null) {
-        webSocketServer.broadcast(
-          ProtocolScreenshotResult(
-            timestamp = System.currentTimeMillis(),
-            requestId = requestId,
-            data = screenshot.base64Image,
-            format = "jpeg",
-            rotation = screenshot.rotation,
-            screenshotCaptureDurationMs = screenshot.captureDurationMs,
-            screenshotEncodeDurationMs = screenshot.encodeDurationMs,
-            screenshotByteLength = screenshot.byteLength,
-            screenshotBase64Length = screenshot.base64Length,
-            frameContext = stableContext?.toString(),
+      when (outcome) {
+        is ScreenshotCaptureOutcome.Success -> {
+          val screenshot = outcome.payload
+          webSocketServer.broadcast(
+            ProtocolScreenshotResult(
+              timestamp = System.currentTimeMillis(),
+              requestId = requestId,
+              data = screenshot.base64Image,
+              format = "jpeg",
+              rotation = screenshot.rotation,
+              screenshotCaptureDurationMs = screenshot.captureDurationMs,
+              screenshotEncodeDurationMs = screenshot.encodeDurationMs,
+              screenshotByteLength = screenshot.byteLength,
+              screenshotBase64Length = screenshot.base64Length,
+              frameContext = stableContext?.toString(),
+            )
           )
-        )
-        Log.d(TAG, "Broadcasted screenshot to ${webSocketServer.getConnectionCount()} clients")
-      } else {
-        val errorMessage = buildString {
-          append("""{"type":"screenshot_error","timestamp":${System.currentTimeMillis()}""")
-          if (requestId != null) {
-            append(""","requestId":"$requestId"""")
-          }
-          append(""","error":"Failed to capture screenshot"}""")
+          Log.d(TAG, "Broadcasted screenshot to ${webSocketServer.getConnectionCount()} clients")
         }
-        webSocketServer.broadcast(errorMessage)
+        is ScreenshotCaptureOutcome.Failure -> {
+          // Surface a rate limit distinctly so the daemon classifies it as ctrlproxy_rate_limited
+          // rather than a generic capture failure (issue #4927).
+          val error = CtrlProxyScreenshotWire.errorMessageForCode(outcome.errorCode)
+          val errorMessage = buildString {
+            append("""{"type":"screenshot_error","timestamp":${System.currentTimeMillis()}""")
+            if (requestId != null) {
+              append(""","requestId":"$requestId"""")
+            }
+            append(""","error":"$error"}""")
+          }
+          webSocketServer.broadcast(errorMessage)
+        }
       }
     }
   }

--- a/android/control-proxy/src/main/kotlin/dev/jasonpearson/automobile/ctrlproxy/CtrlProxyScreenshotWire.kt
+++ b/android/control-proxy/src/main/kotlin/dev/jasonpearson/automobile/ctrlproxy/CtrlProxyScreenshotWire.kt
@@ -1,0 +1,42 @@
+package dev.jasonpearson.automobile.ctrlproxy
+
+import android.accessibilityservice.AccessibilityService
+
+/**
+ * Wire error strings for accessibility screenshot failures (issue #4927).
+ *
+ * The daemon classifies a failed CtrlProxy screenshot into a fallback reason from the error string
+ * carried on the `screenshot_error` frame. Collapsing every `takeScreenshot()` failure to one
+ * generic message hid the platform rate limit
+ * ([AccessibilityService.ERROR_TAKE_SCREENSHOT_INTERVAL_TIME_SHORT]) behind `ctrlproxy_failed`,
+ * making an animation's constant fallover to ADB screencap indistinguishable from a real failure.
+ *
+ * Kept in its own object so the mapping is unit-testable without a Robolectric harness — the
+ * [AccessibilityService] error codes are compile-time constants. The strings must stay
+ * byte-identical to the daemon's `screenshotFallbackReason.ts` constants.
+ */
+internal object CtrlProxyScreenshotWire {
+  /**
+   * Generic failure message. An older runner that predates the rate-limit classification also emits
+   * this, so the daemon maps it to `ctrlproxy_failed` — preserving backward compatibility.
+   */
+  const val GENERIC_ERROR = "Failed to capture screenshot"
+
+  /**
+   * Distinguishable message for a platform rate limit; the daemon maps it to
+   * `ctrlproxy_rate_limited`.
+   */
+  const val RATE_LIMITED_ERROR = "Screenshot rate limited"
+
+  /**
+   * Map an [AccessibilityService] `takeScreenshot` error code to its wire error string. Only a
+   * short inter-capture interval is the rate limit; every other code (and a null/unknown code)
+   * stays the generic message so nothing else changes classification.
+   */
+  fun errorMessageForCode(errorCode: Int?): String =
+    if (errorCode == AccessibilityService.ERROR_TAKE_SCREENSHOT_INTERVAL_TIME_SHORT) {
+      RATE_LIMITED_ERROR
+    } else {
+      GENERIC_ERROR
+    }
+}

--- a/android/control-proxy/src/test/kotlin/dev/jasonpearson/automobile/ctrlproxy/CtrlProxyScreenshotWireTest.kt
+++ b/android/control-proxy/src/test/kotlin/dev/jasonpearson/automobile/ctrlproxy/CtrlProxyScreenshotWireTest.kt
@@ -1,0 +1,42 @@
+package dev.jasonpearson.automobile.ctrlproxy
+
+import android.accessibilityservice.AccessibilityService
+import org.junit.Assert.assertEquals
+import org.junit.Test
+
+/**
+ * Pins the accessibility screenshot error-code → wire-error mapping (issue #4927). A short
+ * inter-capture interval is the platform rate limit; it must surface as a distinguishable wire
+ * error so the daemon can classify it as `ctrlproxy_rate_limited` instead of a generic failure —
+ * without a Robolectric harness, since [AccessibilityService] error codes are compile-time
+ * constants.
+ */
+class CtrlProxyScreenshotWireTest {
+  @Test
+  fun `rate-limit error code maps to the distinguishable wire error`() {
+    assertEquals(
+      CtrlProxyScreenshotWire.RATE_LIMITED_ERROR,
+      CtrlProxyScreenshotWire.errorMessageForCode(
+        AccessibilityService.ERROR_TAKE_SCREENSHOT_INTERVAL_TIME_SHORT
+      ),
+    )
+  }
+
+  @Test
+  fun `internal-error code stays the generic error for backward compatibility`() {
+    assertEquals(
+      CtrlProxyScreenshotWire.GENERIC_ERROR,
+      CtrlProxyScreenshotWire.errorMessageForCode(
+        AccessibilityService.ERROR_TAKE_SCREENSHOT_INTERNAL_ERROR
+      ),
+    )
+  }
+
+  @Test
+  fun `a null error code stays the generic error`() {
+    assertEquals(
+      CtrlProxyScreenshotWire.GENERIC_ERROR,
+      CtrlProxyScreenshotWire.errorMessageForCode(null),
+    )
+  }
+}

--- a/src/features/observe/ScreenshotBackoffScheduler.ts
+++ b/src/features/observe/ScreenshotBackoffScheduler.ts
@@ -87,6 +87,14 @@ export interface ScreenshotBackoffScheduler {
    * Recompute the pending keepalive timeout using the current cadence.
    */
   rescheduleKeepAlive(): void;
+
+  /**
+   * Record that a capture was just issued outside the scheduler's own timers (e.g. the direct
+   * initial-frame capture at subscriber connect). Advances the shared rate-limit floor clock so a
+   * scheduler capture armed for the same instant coalesces instead of firing a second, redundant
+   * accessibility screenshot the platform would reject as rate-limited (issue #4927).
+   */
+  noteCaptureStarted(): void;
 }
 
 /**
@@ -286,6 +294,12 @@ export class DefaultScreenshotBackoffScheduler implements ScreenshotBackoffSched
    * Whether a capture requested now would violate the rate-limit floor. False when throttling is
    * disabled or no capture has happened yet (the leading edge always fires immediately).
    */
+  noteCaptureStarted(): void {
+    // Same clock the scheduler's own captures stamp in captureAndEmit, so an external capture and a
+    // scheduler-owned one share one floor window (issue #4927).
+    this.lastCaptureStartMs = this.timer.now();
+  }
+
   private shouldDeferForFloor(): boolean {
     const floor = this.config.minCaptureIntervalMs;
     if (!floor || floor <= 0 || this.lastCaptureStartMs === null) {
@@ -466,6 +480,7 @@ export class FakeScreenshotBackoffScheduler implements ScreenshotBackoffSchedule
   public cancelPendingCapturesCalls: number = 0;
   public stopCalls: number = 0;
   public rescheduleKeepAliveCalls: number = 0;
+  public noteCaptureStartedCalls: number = 0;
   private _isActive: boolean = false;
   private _pendingCount: number = 0;
 
@@ -498,6 +513,10 @@ export class FakeScreenshotBackoffScheduler implements ScreenshotBackoffSchedule
     this.rescheduleKeepAliveCalls++;
   }
 
+  noteCaptureStarted(): void {
+    this.noteCaptureStartedCalls++;
+  }
+
   // Test helpers
   setActive(active: boolean): void {
     this._isActive = active;
@@ -512,6 +531,7 @@ export class FakeScreenshotBackoffScheduler implements ScreenshotBackoffSchedule
     this.cancelPendingCapturesCalls = 0;
     this.stopCalls = 0;
     this.rescheduleKeepAliveCalls = 0;
+    this.noteCaptureStartedCalls = 0;
     this._isActive = false;
     this._pendingCount = 0;
   }

--- a/src/features/observe/ScreenshotBackoffScheduler.ts
+++ b/src/features/observe/ScreenshotBackoffScheduler.ts
@@ -60,8 +60,18 @@ export interface ScreenshotBackoffScheduler {
   /**
    * Cancel any pending screenshot captures.
    * Called when new activity occurs (e.g., new request to accessibility service).
+   *
+   * Deliberately preserves the trailing throttle capture so a storm of sequence restarts during
+   * an animation still lands one settled frame (issue #4927). Use {@link stop} to quiesce fully.
    */
   cancelPendingCaptures(): void;
+
+  /**
+   * Fully quiesce the scheduler: cancel pending captures AND the trailing throttle capture. Unlike
+   * {@link cancelPendingCaptures}, nothing survives — call this when captures should genuinely stop
+   * (e.g. the device connection closed), not on a sequence restart (issue #4927).
+   */
+  stop(): void;
 
   /**
    * Check if a backoff sequence is currently active.
@@ -199,6 +209,18 @@ export class DefaultScreenshotBackoffScheduler implements ScreenshotBackoffSched
       logger.debug("[ScreenshotBackoff] Cancelling keepalive capture");
       this.timer.clearTimeout(this.keepAliveTimeout);
       this.keepAliveTimeout = null;
+    }
+  }
+
+  stop(): void {
+    this.cancelPendingCaptures();
+    // The trailing capture deliberately outlives cancelPendingCaptures (restart-storm survival),
+    // so it must be cleared explicitly here or a capture armed just before a disconnect fires
+    // afterward and re-bootstraps the keepalive loop (issue #4927).
+    if (this.trailingCaptureTimeout) {
+      logger.debug("[ScreenshotBackoff] Cancelling trailing throttle capture");
+      this.timer.clearTimeout(this.trailingCaptureTimeout);
+      this.trailingCaptureTimeout = null;
     }
   }
 
@@ -432,6 +454,7 @@ export class DefaultScreenshotBackoffScheduler implements ScreenshotBackoffSched
 export class FakeScreenshotBackoffScheduler implements ScreenshotBackoffScheduler {
   public startBackoffSequenceCalls: number = 0;
   public cancelPendingCapturesCalls: number = 0;
+  public stopCalls: number = 0;
   public rescheduleKeepAliveCalls: number = 0;
   private _isActive: boolean = false;
   private _pendingCount: number = 0;
@@ -446,6 +469,11 @@ export class FakeScreenshotBackoffScheduler implements ScreenshotBackoffSchedule
     this.cancelPendingCapturesCalls++;
     this._isActive = false;
     this._pendingCount = 0;
+  }
+
+  stop(): void {
+    this.stopCalls++;
+    this.cancelPendingCaptures();
   }
 
   isActive(): boolean {
@@ -472,6 +500,7 @@ export class FakeScreenshotBackoffScheduler implements ScreenshotBackoffSchedule
   reset(): void {
     this.startBackoffSequenceCalls = 0;
     this.cancelPendingCapturesCalls = 0;
+    this.stopCalls = 0;
     this.rescheduleKeepAliveCalls = 0;
     this._isActive = false;
     this._pendingCount = 0;

--- a/src/features/observe/ScreenshotBackoffScheduler.ts
+++ b/src/features/observe/ScreenshotBackoffScheduler.ts
@@ -345,6 +345,16 @@ export class DefaultScreenshotBackoffScheduler implements ScreenshotBackoffSched
       return;
     }
 
+    // A subscriber can request a keepalive cadence below the platform floor (screenshot interval
+    // clamps to 250ms, under the 350ms accessibility floor), and a burst capture may have just
+    // fired. Skip this beat rather than trip the rate limit; the reschedule below keeps liveness
+    // going at an effective cadence no faster than the floor (issue #4927).
+    if (this.shouldDeferForFloor()) {
+      logger.debug("[ScreenshotBackoff] Skipping keepalive capture - within the rate-limit floor");
+      this.scheduleKeepAliveIfIdle(sequenceId);
+      return;
+    }
+
     logger.debug(`[ScreenshotBackoff] Capturing keepalive screenshot (sequence ${sequenceId})`);
 
     try {

--- a/src/features/observe/ScreenshotBackoffScheduler.ts
+++ b/src/features/observe/ScreenshotBackoffScheduler.ts
@@ -101,6 +101,16 @@ interface ScreenshotBackoffConfig {
    * each time the next keepalive capture is scheduled.
    */
   getKeepAliveIntervalMs?: () => number | null | undefined;
+
+  /**
+   * Minimum wall-clock interval (ms) between two capture attempts. Set this to the platform's
+   * screenshot rate-limit floor so a front-loaded burst — or a storm of sequence restarts during
+   * an animation — never issues captures faster than the device allows (issue #4927). A tick that
+   * would fire within the floor of the last capture is coalesced into a single trailing capture at
+   * the floor boundary, which reflects the latest state and still lands once the UI settles.
+   * Null/undefined/<=0 disables throttling (default), preserving the raw backoff cadence.
+   */
+  minCaptureIntervalMs?: number | null;
 }
 
 type ScreenshotBackoffConfigInput = Partial<ScreenshotBackoffConfig>;
@@ -132,6 +142,13 @@ export class DefaultScreenshotBackoffScheduler implements ScreenshotBackoffSched
   private lastEmittedChecksum: string | null = null;
   private lastEmittedMetadataSignature: string | null = null;
   private sequenceId: number = 0;
+
+  // Rate-limit throttle state (issue #4927). `lastCaptureStartMs` is the wall-clock time a real
+  // capture was last issued; `trailingCaptureTimeout` is the single coalesced capture pending at
+  // the floor boundary. The trailing capture deliberately outlives a sequence restart so an
+  // animation storm still lands one settled frame after it stops.
+  private lastCaptureStartMs: number | null = null;
+  private trailingCaptureTimeout: ReturnType<Timer["setTimeout"]> | null = null;
 
   constructor(
     captureCallback: ScreenshotCaptureCallback,
@@ -225,10 +242,69 @@ export class DefaultScreenshotBackoffScheduler implements ScreenshotBackoffSched
       this.pendingTimeouts.shift();
     }
 
+    // Below the platform floor: coalesce into the single trailing capture rather than issue a
+    // capture the device would reject as rate-limited (issue #4927).
+    if (this.shouldDeferForFloor()) {
+      logger.debug(`[ScreenshotBackoff] Deferring capture at t=${interval}ms to the rate-limit floor (sequence ${sequenceId})`);
+      this.armTrailingCapture();
+      this.scheduleKeepAliveIfIdle(sequenceId);
+      return;
+    }
+
     logger.debug(`[ScreenshotBackoff] Capturing screenshot at t=${interval}ms (sequence ${sequenceId})`);
 
     try {
       await this.captureAndEmit(sequenceId, `t=${interval}ms`, false);
+    } finally {
+      this.scheduleKeepAliveIfIdle(sequenceId);
+    }
+  }
+
+  /**
+   * Whether a capture requested now would violate the rate-limit floor. False when throttling is
+   * disabled or no capture has happened yet (the leading edge always fires immediately).
+   */
+  private shouldDeferForFloor(): boolean {
+    const floor = this.config.minCaptureIntervalMs;
+    if (!floor || floor <= 0 || this.lastCaptureStartMs === null) {
+      return false;
+    }
+    return this.timer.now() - this.lastCaptureStartMs < floor;
+  }
+
+  /**
+   * Schedule a single capture at the floor boundary after the last capture. Coalesced: if one is
+   * already armed it is kept, so a dense burst or restart storm collapses to at most one capture
+   * per floor window. Not cleared by cancelPendingCaptures, so it survives sequence restarts and
+   * still fires the settled frame once activity stops.
+   */
+  private armTrailingCapture(): void {
+    const floor = this.config.minCaptureIntervalMs;
+    if (!floor || floor <= 0 || this.lastCaptureStartMs === null || this.trailingCaptureTimeout) {
+      return;
+    }
+    const dueInMs = Math.max(0, this.lastCaptureStartMs + floor - this.timer.now());
+    this.trailingCaptureTimeout = this.timer.setTimeout(() => {
+      this.trailingCaptureTimeout = null;
+      void this.fireTrailingCapture();
+    }, dueInMs);
+  }
+
+  private async fireTrailingCapture(): Promise<void> {
+    // Reflect the LATEST state: bind the current sequence so captureAndEmit does not discard this
+    // as stale, and drop entirely if nobody is watching anymore.
+    const sequenceId = this.sequenceId;
+    if (!this.shouldKeepAlive()) {
+      logger.debug("[ScreenshotBackoff] Dropping trailing capture - no active subscribers");
+      return;
+    }
+    // Activity since arming may have pushed the floor out again; re-arm instead of firing early.
+    if (this.shouldDeferForFloor()) {
+      this.armTrailingCapture();
+      return;
+    }
+    try {
+      await this.captureAndEmit(sequenceId, "throttle-trailing", false);
     } finally {
       this.scheduleKeepAliveIfIdle(sequenceId);
     }
@@ -262,6 +338,10 @@ export class DefaultScreenshotBackoffScheduler implements ScreenshotBackoffSched
     emitDuplicates: boolean
   ): Promise<void> {
     try {
+      // Stamp the capture start before issuing it so the rate-limit floor (issue #4927) is
+      // measured from when the device was actually asked — covering burst, trailing, and
+      // keepalive captures alike.
+      this.lastCaptureStartMs = this.timer.now();
       const result = await this.captureCallback();
 
       // Check again if sequence is still valid (capture might have taken time)

--- a/src/features/observe/ScreenshotMetadata.ts
+++ b/src/features/observe/ScreenshotMetadata.ts
@@ -11,6 +11,7 @@ export type ScreenshotFallbackReason =
   | "a11y_screenshot_unsupported"
   | "websocket_unavailable"
   | "ctrlproxy_failed"
+  | "ctrlproxy_rate_limited"
   | "ctrlproxy_timeout"
   | "ctrlproxy_exception";
 

--- a/src/features/observe/android/AndroidCtrlProxyClient.ts
+++ b/src/features/observe/android/AndroidCtrlProxyClient.ts
@@ -62,7 +62,10 @@ import {
   type ScreenshotMetadata,
   type ScreenshotPerformanceMetadata,
 } from "../ScreenshotMetadata";
-import { fallbackReasonForCtrlProxyFailure } from "./screenshotFallbackReason";
+import {
+  CTRLPROXY_SCREENSHOT_TIMEOUT_ERROR,
+  fallbackReasonForCtrlProxyFailure,
+} from "./screenshotFallbackReason";
 import {
   normalizeAnr,
   normalizeCrash,
@@ -2228,7 +2231,9 @@ export class AndroidCtrlProxyClient extends DeviceServiceClient implements Andro
 
   cancelScreenshotBackoff(): void {
     if (this.screenshotBackoffScheduler) {
-      this.screenshotBackoffScheduler.cancelPendingCaptures();
+      // Fully quiesce (including the trailing throttle capture) — this is a teardown/quiesce path
+      // (disconnect, pre-action), not a sequence restart, so nothing should survive (issue #4927).
+      this.screenshotBackoffScheduler.stop();
     }
   }
 
@@ -3188,7 +3193,7 @@ export class AndroidCtrlProxyClient extends DeviceServiceClient implements Andro
       this.screenshotObservationStreamSuppressions.add(requestId);
       const screenshotPromise = this.requestManager.register<ScreenshotResult>(
         requestId, "screenshot", 3000,
-        (_id, _type, _timeout) => ({ success: false, error: "Screenshot timeout" })
+        (_id, _type, _timeout) => ({ success: false, error: CTRLPROXY_SCREENSHOT_TIMEOUT_ERROR })
       );
 
       this.ws.send(message);

--- a/src/features/observe/android/AndroidCtrlProxyClient.ts
+++ b/src/features/observe/android/AndroidCtrlProxyClient.ts
@@ -62,6 +62,7 @@ import {
   type ScreenshotMetadata,
   type ScreenshotPerformanceMetadata,
 } from "../ScreenshotMetadata";
+import { fallbackReasonForCtrlProxyFailure } from "./screenshotFallbackReason";
 import {
   normalizeAnr,
   normalizeCrash,
@@ -959,6 +960,11 @@ export class AndroidCtrlProxyClient extends DeviceServiceClient implements Andro
   private a11yScreenshotSupported: boolean | null = null;
   private a11yScreenshotFailures: number = 0;
   private static readonly A11Y_SCREENSHOT_MAX_FAILURES = 3;
+  // Minimum interval between accessibility takeScreenshot() requests. The platform rate-limits
+  // calls below its floor (~333ms, ERROR_TAKE_SCREENSHOT_INTERVAL_TIME_SHORT); 350ms sits just
+  // above it so a front-loaded backoff burst or an animation's restart storm cannot trip the
+  // limit into needless ADB-screencap fallover (issue #4927).
+  private static readonly A11Y_SCREENSHOT_MIN_INTERVAL_MS = 350;
 
   // Work profile monitor for polling profiles without accessibility service
   private workProfileMonitor: WorkProfileMonitor | null = null;
@@ -3141,6 +3147,7 @@ export class AndroidCtrlProxyClient extends DeviceServiceClient implements Andro
             const server = getDeviceDataStreamServer();
             return server?.getScreenshotIntervalMsForDevice(this.device.deviceId) ?? 3000;
           },
+          minCaptureIntervalMs: AndroidCtrlProxyClient.A11Y_SCREENSHOT_MIN_INTERVAL_MS,
         },
         this.timer,
         () => {
@@ -3196,7 +3203,7 @@ export class AndroidCtrlProxyClient extends DeviceServiceClient implements Andro
             `${this.a11yScreenshotFailures} consecutive failures, falling back to ADB screencap`);
           this.a11yScreenshotSupported = false;
         }
-        return this.captureScreenshotViaAdb(this.fallbackReasonForCtrlProxyFailure(result.error));
+        return this.captureScreenshotViaAdb(fallbackReasonForCtrlProxyFailure(result.error));
       }
 
       this.a11yScreenshotFailures = 0;
@@ -3219,10 +3226,6 @@ export class AndroidCtrlProxyClient extends DeviceServiceClient implements Andro
     } finally {
       this.screenshotObservationStreamSuppressions.delete(requestId);
     }
-  }
-
-  private fallbackReasonForCtrlProxyFailure(error?: string): ScreenshotFallbackReason {
-    return error === "Screenshot timeout" ? "ctrlproxy_timeout" : "ctrlproxy_failed";
   }
 
   /**

--- a/src/features/observe/android/AndroidCtrlProxyClient.ts
+++ b/src/features/observe/android/AndroidCtrlProxyClient.ts
@@ -3196,6 +3196,10 @@ export class AndroidCtrlProxyClient extends DeviceServiceClient implements Andro
         (_id, _type, _timeout) => ({ success: false, error: CTRLPROXY_SCREENSHOT_TIMEOUT_ERROR })
       );
 
+      // Advance the shared rate-limit floor clock at the a11y-request boundary so a direct capture
+      // (e.g. the initial subscriber frame) and a scheduler-armed capture cannot both hit the
+      // accessibility screenshot API in the same floor window (issue #4927).
+      this.getScreenshotBackoffScheduler().noteCaptureStarted();
       this.ws.send(message);
 
       const result = await screenshotPromise;

--- a/src/features/observe/android/AndroidCtrlProxyClient.ts
+++ b/src/features/observe/android/AndroidCtrlProxyClient.ts
@@ -1135,9 +1135,10 @@ export class AndroidCtrlProxyClient extends DeviceServiceClient implements Andro
     deviceConnectionLostNotifier?: DeviceConnectionLostNotifier,
     sdkEventIngestor?: AndroidSdkEventIngestor,
     loggerInstance?: Logger,
-    certificateFileSystem?: CertificateFileSystem
+    certificateFileSystem?: CertificateFileSystem,
+    screenshotBackoffScheduler?: ScreenshotBackoffScheduler
   ): AndroidCtrlProxyClient {
-    return new AndroidCtrlProxyClient(
+    const client = new AndroidCtrlProxyClient(
       device,
       adb,
       webSocketFactory,
@@ -1150,6 +1151,13 @@ export class AndroidCtrlProxyClient extends DeviceServiceClient implements Andro
       loggerInstance,
       certificateFileSystem
     );
+    // Test-only seam: pre-seed the lazily-built scheduler so tests can assert shared floor
+    // accounting (noteCaptureStarted) without the live device-data-stream server. Not exposed on
+    // the production getInstance path.
+    if (screenshotBackoffScheduler) {
+      client.screenshotBackoffScheduler = screenshotBackoffScheduler;
+    }
+    return client;
   }
 
   // ===========================================================================
@@ -2050,6 +2058,13 @@ export class AndroidCtrlProxyClient extends DeviceServiceClient implements Andro
           throw new Error("WebSocket not connected");
         }
         const message = serializeCtrlProxyRequest(ctrlProxyRequests.requestScreenshot({ requestId: sentRequestId }));
+        // Shared rate-limit floor accounting (issue #4927): a one-shot screenshot (observe /
+        // junit-runner) and the observation-stream scheduler both hit the same rate-limited
+        // accessibility takeScreenshot(). Advancing the shared clock here (non-blocking) makes the
+        // stream scheduler coalesce around a one-shot instead of the two engines rate-limiting each
+        // other while a live viewer is attached. requestScreenshot always issues a real a11y capture
+        // (it has no ADB path), so the stamp is unconditionally correct.
+        this.getScreenshotBackoffScheduler().noteCaptureStarted();
         this.ws.send(message);
         logger.debug(`[CTRL_PROXY] Sent screenshot request (requestId: ${sentRequestId})`);
       });

--- a/src/features/observe/android/screenshotFallbackReason.ts
+++ b/src/features/observe/android/screenshotFallbackReason.ts
@@ -1,0 +1,32 @@
+import type { ScreenshotFallbackReason } from "../ScreenshotMetadata";
+
+/**
+ * Internal timeout sentinel set by the daemon when a CtrlProxy screenshot request never resolves.
+ * Distinct from the platform rate limit below — it is a daemon-side deadline, not a device signal.
+ */
+export const CTRLPROXY_SCREENSHOT_TIMEOUT_ERROR = "Screenshot timeout";
+
+/**
+ * Distinguishable wire error the Android CtrlProxy runner emits when
+ * `AccessibilityService.takeScreenshot()` is rate-limited (ERROR_TAKE_SCREENSHOT_INTERVAL_TIME_SHORT).
+ * Kept byte-identical to the runner's `CtrlProxyScreenshotWire.RATE_LIMITED_ERROR` so the two sides
+ * agree over the wire (issue #4927). An older runner that predates this classification emits the
+ * generic "Failed to capture screenshot" instead, which falls through to `ctrlproxy_failed`.
+ */
+export const CTRLPROXY_RATE_LIMITED_ERROR = "Screenshot rate limited";
+
+/**
+ * Classify a failed CtrlProxy screenshot into the fallback reason recorded on the ADB-screencap
+ * frame. A genuine platform rate limit is surfaced distinctly so it is not conflated with a real
+ * capture failure; anything unrecognized — including the generic message an older runner sends —
+ * stays `ctrlproxy_failed`, preserving backward compatibility (issue #4927).
+ */
+export function fallbackReasonForCtrlProxyFailure(error?: string): ScreenshotFallbackReason {
+  if (error === CTRLPROXY_SCREENSHOT_TIMEOUT_ERROR) {
+    return "ctrlproxy_timeout";
+  }
+  if (error === CTRLPROXY_RATE_LIMITED_ERROR) {
+    return "ctrlproxy_rate_limited";
+  }
+  return "ctrlproxy_failed";
+}

--- a/test/features/observe/CtrlProxyClient.test.ts
+++ b/test/features/observe/CtrlProxyClient.test.ts
@@ -26,6 +26,7 @@ import {
   stopDeviceDataStreamSocketServer,
 } from "../../../src/daemon/deviceDataStreamSocketServer";
 import { FakeSocket } from "../../fakes/FakeNetServer";
+import { FakeScreenshotBackoffScheduler } from "../../../src/features/observe/ScreenshotBackoffScheduler";
 
 describe("AndroidCtrlProxyClient", function() {
   let accessibilityServiceClient: AndroidCtrlProxyClient;
@@ -3351,6 +3352,61 @@ describe("AndroidCtrlProxyClient", function() {
         pixelHeight: null,
       });
       expect(accessibilityServiceClient.getScreenScaleMetadata()).toBeNull();
+    });
+  });
+
+  describe("shared rate-limit floor accounting (issue #4927)", function() {
+    test("one-shot requestScreenshot advances the shared floor clock so the stream scheduler coalesces around it", async function() {
+      const localTimer = new FakeTimer();
+      localTimer.enableAutoAdvance();
+      const fakeScheduler = new FakeScreenshotBackoffScheduler();
+      const { factory, getSocket } = createCapturingWebSocketFactory(localTimer);
+      // Inject the fake scheduler via the test-only createForTesting seam (positional optionals).
+      const client = AndroidCtrlProxyClient.createForTesting(
+        testDevice,
+        fakeAdb,
+        factory,
+        localTimer,
+        undefined, // installedAppsRepository
+        undefined, // retryExecutor
+        undefined, // crashEventSink
+        undefined, // deviceConnectionLostNotifier
+        undefined, // sdkEventIngestor
+        undefined, // loggerInstance
+        undefined, // certificateFileSystem
+        fakeScheduler
+      );
+      client.invalidateCache();
+      await client.ensureConnected();
+      const socket = await waitForSocket(getSocket) as CapturingWebSocket | null;
+      await waitForSocketOpen(socket);
+      if (!socket) {
+        throw new Error("Expected capturing CtrlProxy socket");
+      }
+
+      // A one-shot capture (the observe / junit-runner path) must stamp the shared clock even
+      // though it never runs the backoff scheduler itself. The stamp happens synchronously at the
+      // moment the a11y request is sent, before any await, so it is observable as soon as the
+      // request frame lands on the socket.
+      expect(fakeScheduler.noteCaptureStartedCalls).toBe(0);
+      const before = socket.sentMessages.length;
+      const capture = client.requestScreenshot(500);
+      await waitForSentMessages(socket, before + 1);
+
+      const req = socket.sentMessages
+        .map(raw => { try { return JSON.parse(raw); } catch { return null; } })
+        .reverse()
+        .find(m => m && m.type === "request_screenshot");
+      expect(req).toBeTruthy();
+      expect(fakeScheduler.noteCaptureStartedCalls).toBe(1);
+
+      // Resolve the request so the pending promise settles; the assertion above is the contract.
+      socket.emit("message", JSON.stringify({
+        type: "screenshot", requestId: req.requestId, data: "jpeg-base64", format: "jpeg", timestamp: 1,
+      }));
+      await capture.catch(() => undefined);
+
+      await client.close();
     });
   });
 });

--- a/test/features/observe/ScreenshotBackoffScheduler.test.ts
+++ b/test/features/observe/ScreenshotBackoffScheduler.test.ts
@@ -803,3 +803,50 @@ describe("DefaultScreenshotBackoffScheduler minCaptureIntervalMs throttle", () =
     expect(captureTimes).toEqual([0, 100, 300, 500, 800, 1300]);
   });
 });
+
+describe("DefaultScreenshotBackoffScheduler stop() vs cancelPendingCaptures()", () => {
+  // cancelPendingCaptures must preserve the trailing capture (restart-storm survival), but stop()
+  // must clear it so a disconnect genuinely quiesces the scheduler (issue #4927, Finding 1).
+  const FLOOR = 350;
+
+  function makeScheduler(fakeTimer: FakeTimer, captureTimes: number[]) {
+    return new DefaultScreenshotBackoffScheduler(
+      async () => {
+        captureTimes.push(fakeTimer.now());
+        return { success: true, data: `frame-${captureTimes.length}` };
+      },
+      () => {},
+      { intervals: [0, 100], keepAliveIntervalMs: null, minCaptureIntervalMs: FLOOR },
+      fakeTimer
+    );
+  }
+
+  it("cancelPendingCaptures lets an already-armed trailing capture still fire", async () => {
+    const fakeTimer = new FakeTimer();
+    const captureTimes: number[] = [];
+    const scheduler = makeScheduler(fakeTimer, captureTimes);
+
+    scheduler.startBackoffSequence();
+    await fakeTimer.advanceTimersByTimeAsync(0); // leading capture at t=0
+    await fakeTimer.advanceTimersByTimeAsync(100); // t=100 tick defers -> arms trailing at t=350
+    scheduler.cancelPendingCaptures(); // restart-storm semantics: trailing survives
+    await fakeTimer.advanceTimersByTimeAsync(300); // reach t=350
+
+    expect(captureTimes).toEqual([0, 350]);
+  });
+
+  it("stop() clears the trailing capture so nothing fires after quiesce", async () => {
+    const fakeTimer = new FakeTimer();
+    const captureTimes: number[] = [];
+    const scheduler = makeScheduler(fakeTimer, captureTimes);
+
+    scheduler.startBackoffSequence();
+    await fakeTimer.advanceTimersByTimeAsync(0); // leading capture at t=0
+    await fakeTimer.advanceTimersByTimeAsync(100); // arms trailing at t=350
+    scheduler.stop(); // disconnect semantics: trailing must NOT survive
+    await fakeTimer.advanceTimersByTimeAsync(1000);
+
+    expect(captureTimes).toEqual([0]);
+    expect(scheduler.isActive()).toBe(false);
+  });
+});

--- a/test/features/observe/ScreenshotBackoffScheduler.test.ts
+++ b/test/features/observe/ScreenshotBackoffScheduler.test.ts
@@ -881,3 +881,47 @@ describe("DefaultScreenshotBackoffScheduler keepalive respects the floor", () =>
     }
   });
 });
+
+describe("DefaultScreenshotBackoffScheduler noteCaptureStarted() (external capture participates)", () => {
+  // The initial-frame path issues a direct capture AND arms a backoff sequence; without sharing the
+  // floor clock the armed leading (t=0) capture fires a second a11y screenshot in the same window
+  // and trips the rate limit (issue #4927 P2).
+  const FLOOR = 350;
+
+  function makeScheduler(fakeTimer: FakeTimer, captureTimes: number[]) {
+    return new DefaultScreenshotBackoffScheduler(
+      async () => {
+        captureTimes.push(fakeTimer.now());
+        return { success: true, data: `frame-${captureTimes.length}` };
+      },
+      () => {},
+      { intervals: [0, 100, 300], keepAliveIntervalMs: null, minCaptureIntervalMs: FLOOR },
+      fakeTimer
+    );
+  }
+
+  it("defers the armed leading capture when an external capture was just recorded", async () => {
+    const fakeTimer = new FakeTimer();
+    const captureTimes: number[] = [];
+    const scheduler = makeScheduler(fakeTimer, captureTimes);
+
+    // Simulate the direct initial-frame capture, then the backoff armed alongside it.
+    scheduler.noteCaptureStarted();
+    scheduler.startBackoffSequence();
+    await fakeTimer.advanceTimersByTimeAsync(0); // t=0 leading tick: must DEFER, not capture
+    await fakeTimer.advanceTimersByTimeAsync(400); // reach the floor boundary -> trailing fires
+
+    expect(captureTimes).toEqual([FLOOR]); // one settled capture at the floor, no t=0 collision
+  });
+
+  it("without noteCaptureStarted the leading capture fires immediately (control)", async () => {
+    const fakeTimer = new FakeTimer();
+    const captureTimes: number[] = [];
+    const scheduler = makeScheduler(fakeTimer, captureTimes);
+
+    scheduler.startBackoffSequence();
+    await fakeTimer.advanceTimersByTimeAsync(0);
+
+    expect(captureTimes).toEqual([0]); // leading edge fires when nothing preceded it
+  });
+});

--- a/test/features/observe/ScreenshotBackoffScheduler.test.ts
+++ b/test/features/observe/ScreenshotBackoffScheduler.test.ts
@@ -850,3 +850,34 @@ describe("DefaultScreenshotBackoffScheduler stop() vs cancelPendingCaptures()", 
     expect(scheduler.isActive()).toBe(false);
   });
 });
+
+describe("DefaultScreenshotBackoffScheduler keepalive respects the floor", () => {
+  // A subscriber can request a keepalive cadence below the platform floor; keepalive captures must
+  // not bypass the throttle or they keep tripping the rate limit in steady state (issue #4927 P1).
+  const FLOOR = 350;
+
+  it("never issues keepalive captures faster than the floor even at a sub-floor cadence", async () => {
+    const fakeTimer = new FakeTimer();
+    const captureTimes: number[] = [];
+    const scheduler = new DefaultScreenshotBackoffScheduler(
+      async () => {
+        captureTimes.push(fakeTimer.now());
+        return { success: true, data: `frame-${captureTimes.length}` };
+      },
+      () => {},
+      { intervals: [0], keepAliveIntervalMs: 250, minCaptureIntervalMs: FLOOR },
+      fakeTimer
+    );
+
+    scheduler.startBackoffSequence();
+    for (let t = 0; t < 1200; t += 50) {
+      await fakeTimer.advanceTimersByTimeAsync(50);
+    }
+
+    expect(captureTimes[0]).toBe(0);
+    expect(captureTimes.length).toBeGreaterThan(1); // keepalive still provides liveness
+    for (let i = 1; i < captureTimes.length; i++) {
+      expect(captureTimes[i] - captureTimes[i - 1]).toBeGreaterThanOrEqual(FLOOR);
+    }
+  });
+});

--- a/test/features/observe/ScreenshotBackoffScheduler.test.ts
+++ b/test/features/observe/ScreenshotBackoffScheduler.test.ts
@@ -716,3 +716,90 @@ describe("DefaultScreenshotBackoffScheduler", () => {
     });
   });
 });
+
+describe("DefaultScreenshotBackoffScheduler minCaptureIntervalMs throttle", () => {
+  // The Android accessibility takeScreenshot() API rate-limits calls below a platform floor.
+  // With minCaptureIntervalMs set, the scheduler must never issue two captures closer than the
+  // floor — no matter how dense the burst intervals are or how often the sequence restarts.
+  const FLOOR = 350;
+
+  function makeThrottledScheduler(fakeTimer: FakeTimer, captureTimes: number[]) {
+    return new DefaultScreenshotBackoffScheduler(
+      async () => {
+        captureTimes.push(fakeTimer.now());
+        return { success: true, data: `frame-${captureTimes.length}` };
+      },
+      () => {},
+      {
+        intervals: [0, 100, 300, 500, 800, 1300],
+        keepAliveIntervalMs: null,
+        minCaptureIntervalMs: FLOOR,
+      },
+      fakeTimer
+    );
+  }
+
+  function assertNeverBelowFloor(captureTimes: number[]) {
+    for (let i = 1; i < captureTimes.length; i++) {
+      expect(captureTimes[i] - captureTimes[i - 1]).toBeGreaterThanOrEqual(FLOOR);
+    }
+  }
+
+  it("never captures two frames closer than the floor across a single front-loaded burst", async () => {
+    const fakeTimer = new FakeTimer();
+    const captureTimes: number[] = [];
+    const scheduler = makeThrottledScheduler(fakeTimer, captureTimes);
+
+    scheduler.startBackoffSequence();
+    for (let t = 0; t < 2000; t += 50) {
+      await fakeTimer.advanceTimersByTimeAsync(50);
+    }
+
+    expect(captureTimes.length).toBeGreaterThanOrEqual(2);
+    expect(captureTimes[0]).toBe(0); // leading edge fires immediately
+    assertNeverBelowFloor(captureTimes);
+  });
+
+  it("holds the floor through a restart storm and still captures the settled frame", async () => {
+    const fakeTimer = new FakeTimer();
+    const captureTimes: number[] = [];
+    const scheduler = makeThrottledScheduler(fakeTimer, captureTimes);
+
+    // Simulate an animation: a new hierarchy every 50ms restarts the sequence for ~1s.
+    for (let t = 0; t < 1000; t += 50) {
+      scheduler.startBackoffSequence();
+      await fakeTimer.advanceTimersByTimeAsync(50);
+    }
+    // Let the trailing (settle) capture land after the storm ends.
+    for (let t = 0; t < 800; t += 50) {
+      await fakeTimer.advanceTimersByTimeAsync(50);
+    }
+
+    expect(captureTimes.length).toBeGreaterThanOrEqual(2); // liveness during the storm
+    assertNeverBelowFloor(captureTimes);
+    // A capture must land at/after the last restart so the settled UI is not dropped.
+    expect(Math.max(...captureTimes)).toBeGreaterThanOrEqual(950);
+  });
+
+  it("does not throttle when the floor is unset (default behavior preserved)", async () => {
+    const fakeTimer = new FakeTimer();
+    const captureTimes: number[] = [];
+    const scheduler = new DefaultScreenshotBackoffScheduler(
+      async () => {
+        captureTimes.push(fakeTimer.now());
+        return { success: true, data: `frame-${captureTimes.length}` };
+      },
+      () => {},
+      { intervals: [0, 100, 300, 500, 800, 1300], keepAliveIntervalMs: null },
+      fakeTimer
+    );
+
+    scheduler.startBackoffSequence();
+    for (let t = 0; t < 1400; t += 50) {
+      await fakeTimer.advanceTimersByTimeAsync(50);
+    }
+
+    // All six front-loaded intervals fire, including sub-floor gaps (100ms, 200ms).
+    expect(captureTimes).toEqual([0, 100, 300, 500, 800, 1300]);
+  });
+});

--- a/test/features/observe/android/screenshotFallbackReason.test.ts
+++ b/test/features/observe/android/screenshotFallbackReason.test.ts
@@ -1,0 +1,30 @@
+import { describe, it, expect } from "bun:test";
+import {
+  fallbackReasonForCtrlProxyFailure,
+  CTRLPROXY_RATE_LIMITED_ERROR,
+} from "../../../../src/features/observe/android/screenshotFallbackReason";
+
+describe("fallbackReasonForCtrlProxyFailure", () => {
+  it("maps the distinguishable rate-limit wire error to ctrlproxy_rate_limited", () => {
+    // AC3: a genuine platform rate-limit must be classified distinctly, not as a generic failure.
+    expect(fallbackReasonForCtrlProxyFailure(CTRLPROXY_RATE_LIMITED_ERROR)).toBe(
+      "ctrlproxy_rate_limited"
+    );
+  });
+
+  it("maps the internal timeout sentinel to ctrlproxy_timeout", () => {
+    expect(fallbackReasonForCtrlProxyFailure("Screenshot timeout")).toBe("ctrlproxy_timeout");
+  });
+
+  it("maps a generic old-APK screenshot_error to ctrlproxy_failed (backward compatible)", () => {
+    // AC4: an older APK only emits the generic message; it must keep classifying as today's reason.
+    expect(fallbackReasonForCtrlProxyFailure("Failed to capture screenshot")).toBe(
+      "ctrlproxy_failed"
+    );
+  });
+
+  it("maps unknown/undefined errors to ctrlproxy_failed", () => {
+    expect(fallbackReasonForCtrlProxyFailure(undefined)).toBe("ctrlproxy_failed");
+    expect(fallbackReasonForCtrlProxyFailure("some other error")).toBe("ctrlproxy_failed");
+  });
+});


### PR DESCRIPTION
## Summary

On Android, CtrlProxy accessibility-service screenshots fell over to slow ADB `screencap` **constantly during animations and UI updates** (the flapping orange "Fallback capture / `ctrlproxy_failed`" badge). This was the platform **rate-limiting** `AccessibilityService.takeScreenshot()`, misclassified as a real failure.

Two coordinated fixes, in one PR:

- **Throttle (the actual fix).** The backoff burst `[0,100,300,500,800,1300]ms` restarts on every hierarchy change, so during an animation captures fire below the platform's ~333ms floor. `DefaultScreenshotBackoffScheduler` now takes a `minCaptureIntervalMs`: a tick within the floor of the last capture is coalesced into a single **trailing** capture at the floor boundary (which reflects the latest state and still lands once the UI settles). A dense burst or a storm of restarts collapses to at most one capture per floor window. The Android client wires the ~350ms floor. Throttling is off by default, so the raw cadence is unchanged for any other caller.
- **Classification (defense-in-depth).** `takeScreenshotAsync` now propagates the platform `errorCode` instead of collapsing every failure to null, and `broadcastScreenshot` emits a distinguishable `Screenshot rate limited` wire error for `ERROR_TAKE_SCREENSHOT_INTERVAL_TIME_SHORT` (via a pure, unit-tested `CtrlProxyScreenshotWire` mapping). The daemon adds a `ctrlproxy_rate_limited` fallback reason and maps the new string; the generic message an **older APK** still sends stays `ctrlproxy_failed`, so nothing else changes classification.

## Linked Issue

Closes #4927

## Bug / Regression Context

- **Observed symptom:** live view flaps to `android_adb_screencap` with reason `ctrlproxy_failed` frame-by-frame during animations.
- **Repro conditions:** a subscriber on the Android observation stream + a screen with continuous content updates. Each change restarts the front-loaded burst, so captures pour out at 100–300ms spacing — straight through the `takeScreenshot()` rate limit.
- **Root cause:** sub-floor capture cadence (restart-on-change × front-loaded intervals) × `onFailure` flattening every error code to a generic failure.

## Validation

- [x] `bun test` — full suite green (12410 pass, 0 fail)
- [x] `bun run typecheck` — no new errors (baseline gate)
- [x] `bun run lint` — clean (all boundary guards pass)
- [x] `bunx turbo run build` — success
- [x] Kotlin: ktfmt clean on touched files; `:control-proxy:testDebugUnitTest` green for the new `CtrlProxyScreenshotWireTest` **and** the source-scan guards it had to preserve (`RotationProvenanceTracker`, `AsyncActionRunnerWiring`, `BroadcastGuardAdoption`)
- [x] New code uses interfaces + fakes + FakeTimer; unit tests <100ms

### Acceptance criteria (from #4927)

- [x] Throttle prevents the a11y path from being rate-limited into ADB fallover during sustained change (never two captures below the floor).
- [x] Coalescing covered by FakeTimer unit tests (single burst + restart-storm invariants + off-by-default regression).
- [x] Genuine rate limit surfaces as `ctrlproxy_rate_limited`, distinct from `ctrlproxy_failed`.
- [x] Daemon stays backward-compatible with an APK emitting the generic `screenshot_error` (→ `ctrlproxy_failed`).
- [ ] **Follow-on (release action):** re-cut the Android CtrlProxy APK + bump its checksum so the `ctrlproxy_rate_limited` classification activates against released builds. Filed separately (see Follow-ups).

## Kotlin Reuse Check

- [x] The wire-string mapping is a small pure `object`; no new dependency. Sealed result types are private and nested next to the existing `ScreenshotCapturePayload`.

## Device Verification

- [ ] Not run on a physical device in this PR — the throttle is FakeTimer-proven and the wire classification is unit-tested. The end-to-end "stays on a11y during animation" check needs a re-cut APK (follow-on) and is best confirmed via `manual-test`.

## Follow-ups

- [ ] Re-cut the Android CtrlProxy APK + checksum bump so the runner-side rate-limit classification ships (tracked separately, links back to this PR and #4927).

---

### Review follow-on: shared rate-limit floor accounting

The one-shot screenshot path (`observe` / junit-runner `requestScreenshot`) and the observation-stream backoff scheduler both hit the same rate-limited a11y `takeScreenshot()` but tracked the floor independently, so with a live viewer attached the two engines could rate-limit each other. `requestScreenshot` now advances the shared floor clock (`noteCaptureStarted`) at the a11y-request boundary — **non-blocking**, preserving the one-shot's fresh low-latency point-query semantics while the stream scheduler coalesces around it. No effect on headless/pure-MCP/junit-runner runs beyond a timestamp write (no scheduler starts without a subscriber). Closes the "one-shot could still collide" caveat noted earlier in review.
