### PR TITLE
test(android): isolate mocked emulator launch fixtures

### DIFF
--- a/test/fakes/FakeAvdConfigReader.ts
+++ b/test/fakes/FakeAvdConfigReader.ts
@@ -1,0 +1,13 @@
+import type { AvdConfig, AvdConfigReader } from "../../src/utils/android-cmdline-tools/AvdConfigReader";
+
+/** Deterministic AVD config reader for tests that must not inspect host state. */
+export class FakeAvdConfigReader implements AvdConfigReader {
+  readonly readConfigCalls: string[] = [];
+
+  constructor(private readonly config: AvdConfig | null = null) {}
+
+  async readConfig(avdName: string): Promise<AvdConfig | null> {
+    this.readConfigCalls.push(avdName);
+    return this.config;
+  }
+}

--- a/test/utils/android-cmdline-tools/AndroidEmulatorClient-corruptImage.test.ts
+++ b/test/utils/android-cmdline-tools/AndroidEmulatorClient-corruptImage.test.ts
@@ -259,7 +259,10 @@ describe("AndroidEmulatorClient startEmulator corrupt image integration", () => 
     skipEmulatorPathDetection(client);
 
     const error = await expectRejection(client.startEmulator("Pixel_9_Pro"));
-    expect(fakeAvdConfigReader.readConfigCalls).toContain("Pixel_9_Pro");
+    expect(fakeAvdConfigReader.readConfigCalls).toEqual([
+      "Pixel_9_Pro", // listAvds() enrichment
+      "Pixel_9_Pro", // validateAvdMemory()
+    ]);
     expect(error.message).toContain("corrupt");
     expect(error.message).toContain("Suggestion");
     expect(error.message).toContain("userdata");

--- a/test/utils/android-cmdline-tools/AndroidEmulatorClient-corruptImage.test.ts
+++ b/test/utils/android-cmdline-tools/AndroidEmulatorClient-corruptImage.test.ts
@@ -8,6 +8,7 @@ import { AdbExecutor } from "../../../src/utils/android-cmdline-tools/interfaces
 import { ChildProcess } from "child_process";
 import { EventEmitter } from "events";
 import { Readable } from "stream";
+import { FakeAvdConfigReader } from "../../fakes/FakeAvdConfigReader";
 
 /**
  * REWRITE-5: await a promise that MUST reject, returning its Error. Replaces the
@@ -215,11 +216,13 @@ describe("AndroidEmulatorClient startEmulator corrupt image integration", () => 
   let fakeTimer: FakeTimer;
   let fakeAdb: FakeAdbExecutor;
   let fakeFactory: TestAdbClientFactory;
+  let fakeAvdConfigReader: FakeAvdConfigReader;
 
   beforeEach(() => {
     fakeTimer = new FakeTimer();
     fakeAdb = new FakeAdbExecutor();
     fakeFactory = new TestAdbClientFactory(fakeAdb);
+    fakeAvdConfigReader = new FakeAvdConfigReader();
   });
 
   function createFakeChildProcess(): ChildProcess & EventEmitter {
@@ -252,10 +255,11 @@ describe("AndroidEmulatorClient startEmulator corrupt image integration", () => 
     };
 
     fakeTimer.enableAutoAdvance();
-    const client = new AndroidEmulatorClient(execAsync, spawnFn, fakeTimer, fakeFactory);
+    const client = new AndroidEmulatorClient(execAsync, spawnFn, fakeTimer, fakeFactory, fakeAvdConfigReader);
     skipEmulatorPathDetection(client);
 
     const error = await expectRejection(client.startEmulator("Pixel_9_Pro"));
+    expect(fakeAvdConfigReader.readConfigCalls).toContain("Pixel_9_Pro");
     expect(error.message).toContain("corrupt");
     expect(error.message).toContain("Suggestion");
     expect(error.message).toContain("userdata");
@@ -274,7 +278,7 @@ describe("AndroidEmulatorClient startEmulator corrupt image integration", () => 
       args.join(" ").includes("-list-avds") ? createExecResult("Pixel_9_Pro\n") : createExecResult("");
 
     fakeTimer.enableAutoAdvance();
-    const client = new AndroidEmulatorClient(execAsync, spawnFn, fakeTimer, fakeFactory);
+    const client = new AndroidEmulatorClient(execAsync, spawnFn, fakeTimer, fakeFactory, fakeAvdConfigReader);
     skipEmulatorPathDetection(client);
 
     const error = await expectRejection(client.startEmulator("Pixel_9_Pro"));
@@ -290,7 +294,7 @@ describe("AndroidEmulatorClient startEmulator corrupt image integration", () => 
       args.join(" ").includes("-list-avds") ? createExecResult("Pixel_9_Pro\n") : createExecResult("");
 
     fakeTimer.enableAutoAdvance();
-    const client = new AndroidEmulatorClient(execAsync, spawnFn, fakeTimer, fakeFactory);
+    const client = new AndroidEmulatorClient(execAsync, spawnFn, fakeTimer, fakeFactory, fakeAvdConfigReader);
     skipEmulatorPathDetection(client);
 
     const process = await client.startEmulator("Pixel_9_Pro");
@@ -325,7 +329,7 @@ describe("AndroidEmulatorClient startEmulator corrupt image integration", () => 
     };
 
     fakeTimer.enableAutoAdvance();
-    const client = new AndroidEmulatorClient(execAsync, spawnFn, fakeTimer, fakeFactory);
+    const client = new AndroidEmulatorClient(execAsync, spawnFn, fakeTimer, fakeFactory, fakeAvdConfigReader);
     skipEmulatorPathDetection(client);
 
     const result = await client.startEmulator("Pixel_9_Pro");
@@ -351,7 +355,7 @@ describe("AndroidEmulatorClient startEmulator corrupt image integration", () => 
     };
 
     fakeTimer.enableAutoAdvance();
-    const client = new AndroidEmulatorClient(execAsync, spawnFn, fakeTimer, fakeFactory);
+    const client = new AndroidEmulatorClient(execAsync, spawnFn, fakeTimer, fakeFactory, fakeAvdConfigReader);
     skipEmulatorPathDetection(client);
 
     const error = await expectRejection(client.startEmulator("Pixel_9_Pro"));
@@ -383,7 +387,7 @@ describe("AndroidEmulatorClient startEmulator corrupt image integration", () => 
     fakeAdb.setCommandResponse("shell pm list packages", createExecResult("package:android\n"));
     fakeAdb.setCommandResponse("shell getprop sys.boot_completed", createExecResult("1\n"));
     fakeAdb.setCommandResponse("shell getprop init.svc.bootanim", createExecResult("stopped\n"));
-    const client = new AndroidEmulatorClient(execAsync, spawnFn, fakeTimer, fakeFactory);
+    const client = new AndroidEmulatorClient(execAsync, spawnFn, fakeTimer, fakeFactory, fakeAvdConfigReader);
     skipEmulatorPathDetection(client);
 
     const child = await client.startEmulator("Pixel_9_Pro");

--- a/test/utils/android-cmdline-tools/AndroidEmulatorClient-headless.test.ts
+++ b/test/utils/android-cmdline-tools/AndroidEmulatorClient-headless.test.ts
@@ -191,7 +191,10 @@ describe("AndroidEmulatorClient startEmulator headless wiring", () => {
 
     try {
       await client.startEmulator("Pixel_9_Pro");
-      expect(fakeAvdConfigReader.readConfigCalls).toContain("Pixel_9_Pro");
+      expect(fakeAvdConfigReader.readConfigCalls).toEqual([
+        "Pixel_9_Pro", // listAvds() enrichment
+        "Pixel_9_Pro", // validateAvdMemory()
+      ]);
       expect(capturedArgs).toContain("-no-window");
       expect(capturedArgs).toContain("-no-audio");
     } finally {

--- a/test/utils/android-cmdline-tools/AndroidEmulatorClient-headless.test.ts
+++ b/test/utils/android-cmdline-tools/AndroidEmulatorClient-headless.test.ts
@@ -11,6 +11,7 @@ import { AdbExecutor } from "../../../src/utils/android-cmdline-tools/interfaces
 import { ChildProcess } from "child_process";
 import { EventEmitter } from "events";
 import { Readable } from "stream";
+import { FakeAvdConfigReader } from "../../fakes/FakeAvdConfigReader";
 
 /**
  * REWRITE-5: await a promise that MUST reject, returning its Error. Replaces the
@@ -136,12 +137,14 @@ describe("AndroidEmulatorClient startEmulator headless wiring", () => {
   let fakeTimer: FakeTimer;
   let fakeAdb: FakeAdbExecutor;
   let fakeFactory: TestAdbClientFactory;
+  let fakeAvdConfigReader: FakeAvdConfigReader;
   const savedHeadless = process.env.AUTOMOBILE_EMULATOR_HEADLESS;
 
   beforeEach(() => {
     fakeTimer = new FakeTimer();
     fakeAdb = new FakeAdbExecutor();
     fakeFactory = new TestAdbClientFactory(fakeAdb);
+    fakeAvdConfigReader = new FakeAvdConfigReader();
   });
 
   function restoreEnv() {
@@ -183,11 +186,12 @@ describe("AndroidEmulatorClient startEmulator headless wiring", () => {
     };
 
     fakeTimer.enableAutoAdvance();
-    const client = new AndroidEmulatorClient(execAsync, spawnFn, fakeTimer, fakeFactory);
+    const client = new AndroidEmulatorClient(execAsync, spawnFn, fakeTimer, fakeFactory, fakeAvdConfigReader);
     skipEmulatorPathDetection(client);
 
     try {
       await client.startEmulator("Pixel_9_Pro");
+      expect(fakeAvdConfigReader.readConfigCalls).toContain("Pixel_9_Pro");
       expect(capturedArgs).toContain("-no-window");
       expect(capturedArgs).toContain("-no-audio");
     } finally {
@@ -216,7 +220,7 @@ describe("AndroidEmulatorClient startEmulator headless wiring", () => {
     };
 
     fakeTimer.enableAutoAdvance();
-    const client = new AndroidEmulatorClient(execAsync, spawnFn, fakeTimer, fakeFactory);
+    const client = new AndroidEmulatorClient(execAsync, spawnFn, fakeTimer, fakeFactory, fakeAvdConfigReader);
     skipEmulatorPathDetection(client);
 
     try {
@@ -249,7 +253,7 @@ describe("AndroidEmulatorClient startEmulator headless wiring", () => {
     };
 
     fakeTimer.enableAutoAdvance();
-    const client = new AndroidEmulatorClient(execAsync, spawnFn, fakeTimer, fakeFactory);
+    const client = new AndroidEmulatorClient(execAsync, spawnFn, fakeTimer, fakeFactory, fakeAvdConfigReader);
     skipEmulatorPathDetection(client);
 
     try {
@@ -273,7 +277,7 @@ describe("AndroidEmulatorClient startEmulator headless wiring", () => {
       return createExecResult("");
     };
 
-    const client = new AndroidEmulatorClient(execAsync, null, fakeTimer, fakeFactory);
+    const client = new AndroidEmulatorClient(execAsync, null, fakeTimer, fakeFactory, fakeAvdConfigReader);
     skipEmulatorPathDetection(client);
 
     await expect(client.startEmulator("Missing_Device")).rejects.toThrow(


### PR DESCRIPTION
## Summary

Inject a deterministic `FakeAvdConfigReader` into the mocked Android emulator launch fixtures. The fixtures now record and assert config-reader usage, so sandbox, corrupt-image, and headless launch tests cannot inspect developer or runner AVD files or be diverted by host RAM settings.

## Linked Issue

Closes [#4994](https://github.com/kaeawc/auto-mobile/issues/4994)

## Bug / Regression Context

- **Prior attempts:** [PR #4978](https://github.com/kaeawc/auto-mobile/pull/4978) added AVD RAM preflight to `startEmulator()` while these mocked launch fixtures still used the default filesystem reader.
- **Observed symptom:** A real low-RAM `Pixel_9_Pro` AVD under `ANDROID_AVD_HOME` could make sandbox/corrupt-image tests fail through RAM preflight before reaching the fake process.
- **Repro steps / conditions:** Run the mocked launch tests on a host with `Pixel_9_Pro` configured as a modern Play image below the RAM floor.

## Validation

- [x] Focused Android command-line-tools suite: `bun test test/utils/android-cmdline-tools` (353 tests)
- [x] `bun run turbo:validate` (7/7 tasks; 12,673 tests across 895 files)
- [x] `bun run typecheck` (no new errors)
- [x] `bun run lint` and `git diff --check`
- [x] New test dependency uses an interface-backed fake; focused unit tests remain sub-100ms
- [x] Created from the latest `origin/main` in a fresh worktree

## Follow-ups

None.
