### PR TITLE
fix(android): keep transient offline emulators within readiness deadline

### DIFF
--- a/src/utils/android-cmdline-tools/AndroidEmulatorClient.ts
+++ b/src/utils/android-cmdline-tools/AndroidEmulatorClient.ts
@@ -16,7 +16,6 @@ import type { FormFactor } from "../../models/DeviceMatchCriteria";
 import type { AdbDeviceState } from "./interfaces/AdbExecutor";
 
 const MODERN_PLAY_IMAGE_MIN_API_LEVEL = 30;
-const OFFLINE_DEVICE_THRESHOLD_MS = 15_000;
 
 /**
  * Interface for Android Emulator (AVD) management
@@ -591,7 +590,6 @@ export class AndroidEmulatorClient implements AndroidEmulator {
   }
 
   private async detectOfflineFailure(
-    avdName: string,
     deviceId: string | undefined,
     tracker: { deviceId: string | null; since: number | null },
     timeoutMs?: number,
@@ -618,11 +616,9 @@ export class AndroidEmulatorClient implements AndroidEmulator {
       tracker.deviceId = targetState.deviceId;
       tracker.since = this.timer.now();
     }
-    if (tracker.since !== null && this.timer.now() - tracker.since >= OFFLINE_DEVICE_THRESHOLD_MS) {
-      return new ActionableError(
-        `Emulator '${avdName}' (${targetState.deviceId}) has remained offline for ${OFFLINE_DEVICE_THRESHOLD_MS / 1000} seconds. Restart it outside the restrictive sandbox and verify that adb can reach the emulator.`
-      );
-    }
+    // An offline ADB state is transient during normal emulator startup. Keep
+    // tracking it for diagnostics, but wait for the caller's readiness deadline
+    // unless the emulator process provides definitive failure evidence.
     return null;
   }
 
@@ -1385,21 +1381,10 @@ export class AndroidEmulatorClient implements AndroidEmulator {
   private readinessTimeoutError(
     avdName: string,
     timeoutMs: number,
-    offlineFailure: ActionableError | null,
     processExitError: ActionableError | null,
   ): ActionableError {
     return processExitError
-      ?? offlineFailure
       ?? new ActionableError(`Emulator '${avdName}' failed to become ready within ${timeoutMs}ms`);
-  }
-
-  private shouldStopReadinessPolling(
-    pollingActive: boolean,
-    elapsedMs: number,
-    timeoutMs: number,
-    offlineFailure: ActionableError | null,
-  ): boolean {
-    return !pollingActive || elapsedMs >= timeoutMs || offlineFailure !== null;
   }
 
   private unknownEmulatorName(deviceId: string): string {
@@ -1527,7 +1512,6 @@ export class AndroidEmulatorClient implements AndroidEmulator {
     // Start background polling immediately with configurable intervals
     let pollingActive = true;
     let foundDeviceId: string | null = null;
-    let offlineFailure: ActionableError | null = null;
     const offlineTracker = { deviceId: null as string | null, since: null as number | null };
 
     perf.startOperation("devicePolling");
@@ -1545,8 +1529,8 @@ export class AndroidEmulatorClient implements AndroidEmulator {
             pollingActive = false;
             break;
           }
-          offlineFailure = await this.detectOfflineFailure(avdName, correlatedTargetDeviceId, offlineTracker, remainingTimeoutMs);
-          if (this.shouldStopReadinessPolling(pollingActive, this.timer.now() - startTime, timeoutMs, offlineFailure)) {
+          await this.detectOfflineFailure(correlatedTargetDeviceId, offlineTracker, remainingTimeoutMs);
+          if (!pollingActive || this.timer.now() - startTime >= timeoutMs) {
             break;
           }
 
@@ -1659,7 +1643,7 @@ export class AndroidEmulatorClient implements AndroidEmulator {
 
     // Main timeout loop
     while (this.timer.now() - startTime < timeoutMs) {
-      const readinessFailure = processExitError ?? offlineFailure;
+      const readinessFailure = processExitError;
       if (readinessFailure) {
         pollingActive = false;
         await pollingPromise;
@@ -1696,7 +1680,7 @@ export class AndroidEmulatorClient implements AndroidEmulator {
       return bootedDevice;
     }
 
-    throw this.readinessTimeoutError(avdName, timeoutMs, offlineFailure, processExitError);
+    throw this.readinessTimeoutError(avdName, timeoutMs, processExitError);
   }
 
   /**

--- a/test/utils/android-cmdline-tools/AndroidEmulatorClient-bootFailureDetectors.test.ts
+++ b/test/utils/android-cmdline-tools/AndroidEmulatorClient-bootFailureDetectors.test.ts
@@ -56,11 +56,22 @@ describe("Android emulator boot failure diagnostics", () => {
     expect(error.message).toContain("2048 MB");
   });
 
-  test("reports a target that remains offline instead of waiting for the generic timeout", async () => {
+  test("keeps a transient offline target within the readiness deadline", async () => {
     const timer = new FakeTimer();
     timer.enableAutoAdvance();
     const adb = new FakeAdbExecutor();
-    adb.setDeviceStates([{ deviceId: "emulator-5554", state: "offline" }]);
+    adb.getDeviceStates = async () => {
+      if (timer.now() < 16_000) {
+        return [{ deviceId: "emulator-5554", state: "offline" }];
+      }
+
+      adb.setDevices([{ name: "Pixel_9_Pro", platform: "android", deviceId: "emulator-5554" }]);
+      adb.setCommandResponse("get-state", result("device"));
+      adb.setCommandResponse("shell pm list packages", result("package:com.example\n"));
+      adb.setCommandResponse("shell getprop sys.boot_completed", result("1"));
+      adb.setCommandResponse("shell getprop init.svc.bootanim", result("stopped"));
+      return [{ deviceId: "emulator-5554", state: "device" }];
+    };
     const client = new AndroidEmulatorClient(
       async () => result(),
       null,
@@ -71,9 +82,8 @@ describe("Android emulator boot failure diagnostics", () => {
     process.env.EMULATOR_POLLING_INTERVAL_MS = "500";
 
     try {
-      const error = await expectRejection(client.waitForEmulatorReady("Pixel_9_Pro", 20_000, null, "emulator-5554"));
-      expect(error.message).toContain("offline");
-      expect(error.message).toContain("15 seconds");
+      const booted = await client.waitForEmulatorReady("Pixel_9_Pro", 20_000, null, "emulator-5554");
+      expect(booted.deviceId).toBe("emulator-5554");
     } finally {
       if (previousPollingInterval === undefined) {
         delete process.env.EMULATOR_POLLING_INTERVAL_MS;
@@ -110,7 +120,6 @@ describe("Android emulator boot failure diagnostics", () => {
     const client = new AndroidEmulatorClient(async () => result(), null, timer, { create: () => adb } as AdbClientFactory);
     const detectOfflineFailure = (client as unknown as {
       detectOfflineFailure: (
-        avdName: string,
         deviceId: string | undefined,
         tracker: { deviceId: string | null; since: number | null },
       ) => Promise<Error | null>;
@@ -118,13 +127,14 @@ describe("Android emulator boot failure diagnostics", () => {
     const tracker = { deviceId: null as string | null, since: null as number | null };
 
     adb.setDeviceStates([{ deviceId: "emulator-5554", state: "offline" }]);
-    await detectOfflineFailure("Pixel_9_Pro", "emulator-5554", tracker);
+    await detectOfflineFailure("emulator-5554", tracker);
     timer.advanceTime(15_000);
-    const offlineFailure = await detectOfflineFailure("Pixel_9_Pro", "emulator-5554", tracker);
-    expect(offlineFailure?.message).toContain("offline");
+    const offlineFailure = await detectOfflineFailure("emulator-5554", tracker);
+    expect(offlineFailure).toBeNull();
+    expect(tracker.since).toBe(0);
 
     adb.setDeviceStates([{ deviceId: "emulator-5554", state: "device" }]);
-    const recoveredFailure = await detectOfflineFailure("Pixel_9_Pro", "emulator-5554", tracker);
+    const recoveredFailure = await detectOfflineFailure("emulator-5554", tracker);
     expect(recoveredFailure).toBeNull();
     expect(tracker.since).toBeNull();
   });


### PR DESCRIPTION
## Summary

Keep Android emulator `offline` ADB states transient during readiness polling. The readiness waiter now continues until the caller-supplied deadline, while child-process exits and confirmed sandbox/HVF failures still fail early with actionable diagnostics.

## Linked Issue

Closes [#4992](https://github.com/kaeawc/auto-mobile/issues/4992)

## Bug / Regression Context

- **Prior attempts:** The 15-second offline heuristic was introduced by [PR #4978](https://github.com/kaeawc/auto-mobile/pull/4978) and carried through the follow-up [PR #4982](https://github.com/kaeawc/auto-mobile/pull/4982).
- **Observed symptom:** A slow emulator could recover before the readiness deadline, but the 15-second heuristic aborted first and reported misleading sandbox guidance.
- **Repro steps / conditions:** Keep the target emulator in ADB's `offline` state for more than 15 seconds, then recover it before the caller's readiness timeout.

## Validation

- [x] `bun run turbo:validate -- --concurrency=1` passes (12,659 tests, 13 skipped, 0 failed; lint, build, and boundary checks passed)
- [x] `bun run typecheck` reports no new errors (baseline gate)
- [x] Targeted Android emulator readiness and failure-diagnostic tests pass
- [x] New code uses existing interfaces, fakes, and `FakeTimer`
- [x] `git diff --check` passes
- [x] Rebased onto latest `main` via a fresh `origin/main` worktree

## Follow-ups

None.
