### PR TITLE
fix(android): resolve custom AVD registry paths

### DIFF
--- a/src/utils/android-cmdline-tools/AvdConfigReader.ts
+++ b/src/utils/android-cmdline-tools/AvdConfigReader.ts
@@ -80,11 +80,15 @@ export class FileAvdConfigReader implements AvdConfigReader {
 
   async readConfig(avdName: string): Promise<AvdConfig | null> {
     const path = require("path");
-    const configPath = path.join(this.avdHome, `${avdName}.avd`, "config.ini");
+    let configPath = path.join(this.avdHome, `${avdName}.avd`, "config.ini");
 
     if (!this.existsFn(configPath)) {
-      logger.debug(`AVD config.ini not found: ${configPath}`);
-      return null;
+      const resolvedConfigPath = await this.resolveRegistryConfigPath(avdName);
+      if (!resolvedConfigPath) {
+        logger.debug(`AVD config.ini not found: ${configPath}`);
+        return null;
+      }
+      configPath = resolvedConfigPath;
     }
 
     try {
@@ -95,12 +99,36 @@ export class FileAvdConfigReader implements AvdConfigReader {
       return null;
     }
   }
+
+  private async resolveRegistryConfigPath(avdName: string): Promise<string | null> {
+    const path = require("path");
+    const registryPath = path.join(this.avdHome, `${avdName}.ini`);
+    if (!this.existsFn(registryPath)) {return null;}
+    try {
+      const registry = parseKeyValueProperties(await this.readFileFn(registryPath, "utf-8"));
+      const candidates = registryConfigCandidates(registry, this.avdHome);
+      return candidates.find(candidate => this.existsFn(candidate)) ?? null;
+    } catch (error) {
+      logger.warn(`Failed to read AVD registry for ${avdName}: ${error}`);
+      return null;
+    }
+  }
 }
 
 /**
  * Parse AVD config.ini content into structured data.
  */
 export function parseAvdConfig(content: string): AvdConfig {
+  const props = parseKeyValueProperties(content);
+  return {
+    ...parseScreenDimensions(props),
+    ...parseRamSize(props),
+    ...parseDeviceMetadata(props),
+    ...parseApiMetadata(props),
+  };
+}
+
+function parseKeyValueProperties(content: string): Map<string, string> {
   const props = new Map<string, string>();
   for (const line of content.split("\n")) {
     const trimmed = line.trim();
@@ -109,44 +137,64 @@ export function parseAvdConfig(content: string): AvdConfig {
     if (eqIdx < 0) {continue;}
     props.set(trimmed.slice(0, eqIdx).trim(), trimmed.slice(eqIdx + 1).trim());
   }
+  return props;
+}
 
-  const config: AvdConfig = {};
-
-  // Screen dimensions
-  const width = props.get("hw.lcd.width");
-  if (width) {config.screenWidth = Number.parseInt(width, 10) || undefined;}
-
-  const height = props.get("hw.lcd.height");
-  if (height) {config.screenHeight = Number.parseInt(height, 10) || undefined;}
-
-  const density = props.get("hw.lcd.density");
-  if (density) {config.screenDensity = Number.parseInt(density, 10) || undefined;}
-
-  const ramSize = props.get("hw.ramSize");
-  if (ramSize) {
-    const parsedRamSize = Number.parseInt(ramSize, 10);
-    if (Number.isFinite(parsedRamSize)) {config.ramSizeMb = parsedRamSize;}
+function registryConfigCandidates(props: Map<string, string>, avdHome: string): string[] {
+  const path = require("path");
+  const candidates: string[] = [];
+  const absolutePath = props.get("path");
+  if (absolutePath && path.isAbsolute(absolutePath)) {
+    candidates.push(path.join(absolutePath, "config.ini"));
   }
 
-  // Device name (form factor hint)
-  const deviceName = props.get("hw.device.name");
-  if (deviceName) {config.deviceName = deviceName;}
-
-  // Tag
-  const tag = props.get("tag.id");
-  if (tag) {config.tag = tag;}
-
-  // API level from image.sysdir.1 path
-  // Typical: system-images/android-34/google_apis/arm64-v8a/
-  const sysdir = props.get("image.sysdir.1");
-  if (sysdir) {
-    const match = sysdir.match(/android-(\d+)/);
-    if (match) {
-      const level = Number.parseInt(match[1], 10);
-      config.apiLevel = level;
-      config.osVersion = apiLevelToVersion(level) ?? String(level);
+  const relativePath = props.get("path.rel");
+  if (relativePath && !path.isAbsolute(relativePath)) {
+    const relativeBase = path.resolve(path.dirname(avdHome));
+    const resolvedDirectory = path.resolve(relativeBase, relativePath);
+    const relativeToBase = path.relative(relativeBase, resolvedDirectory);
+    const escapesBase = relativeToBase === ".."
+      || relativeToBase.startsWith(`..${path.sep}`)
+      || path.isAbsolute(relativeToBase);
+    if (!escapesBase) {
+      candidates.push(path.join(resolvedDirectory, "config.ini"));
     }
   }
+  return candidates;
+}
 
-  return config;
+function parseScreenDimensions(props: Map<string, string>): Pick<AvdConfig, "screenWidth" | "screenHeight" | "screenDensity"> {
+  return {
+    screenWidth: parseDimension(props.get("hw.lcd.width")),
+    screenHeight: parseDimension(props.get("hw.lcd.height")),
+    screenDensity: parseDimension(props.get("hw.lcd.density")),
+  };
+}
+
+function parseDimension(value: string | undefined): number | undefined {
+  if (!value) {return undefined;}
+  const parsed = Number.parseInt(value, 10);
+  return parsed || undefined;
+}
+
+function parseRamSize(props: Map<string, string>): Pick<AvdConfig, "ramSizeMb"> {
+  const value = props.get("hw.ramSize");
+  if (!value) {return {};}
+  const parsed = Number.parseInt(value, 10);
+  return Number.isFinite(parsed) ? { ramSizeMb: parsed } : {};
+}
+
+function parseDeviceMetadata(props: Map<string, string>): Pick<AvdConfig, "deviceName" | "tag"> {
+  return {
+    ...(props.get("hw.device.name") ? { deviceName: props.get("hw.device.name") } : {}),
+    ...(props.get("tag.id") ? { tag: props.get("tag.id") } : {}),
+  };
+}
+
+function parseApiMetadata(props: Map<string, string>): Pick<AvdConfig, "apiLevel" | "osVersion"> {
+  const sysdir = props.get("image.sysdir.1");
+  const match = sysdir?.match(/android-(\d+)/);
+  if (!match) {return {};}
+  const level = Number.parseInt(match[1], 10);
+  return { apiLevel: level, osVersion: apiLevelToVersion(level) ?? String(level) };
 }

--- a/src/utils/android-cmdline-tools/AvdConfigReader.ts
+++ b/src/utils/android-cmdline-tools/AvdConfigReader.ts
@@ -72,20 +72,21 @@ export class FileAvdConfigReader implements AvdConfigReader {
     this.existsFn = existsFn ?? ((p: string) => fs.existsSync(p));
 
     const homeDir = process.env.HOME || process.env.USERPROFILE;
-    const androidUserHome = process.env.ANDROID_USER_HOME;
+    const androidUserHome = process.env.ANDROID_USER_HOME || undefined;
+    const avdHomeEnv = process.env.ANDROID_AVD_HOME || undefined;
     const configHome = process.env.ANDROID_EMULATOR_HOME
-      ?? androidUserHome
-      ?? (process.env.ANDROID_SDK_HOME ? path.join(process.env.ANDROID_SDK_HOME, ".android") : undefined)
-      ?? (homeDir ? path.join(homeDir, ".android") : "");
+      || androidUserHome
+      || (process.env.ANDROID_SDK_HOME ? path.join(process.env.ANDROID_SDK_HOME, ".android") : undefined)
+      || (homeDir ? path.join(homeDir, ".android") : "");
     this.avdHome = avdHome
-      ?? process.env.ANDROID_AVD_HOME
+      ?? avdHomeEnv
       ?? path.join(configHome, "avd");
     this.configHome = avdHome
       ? path.dirname(avdHome)
       : (process.env.ANDROID_EMULATOR_HOME
-        ?? androidUserHome
-        ?? (process.env.ANDROID_SDK_HOME ? path.join(process.env.ANDROID_SDK_HOME, ".android") : undefined)
-        ?? (process.env.ANDROID_AVD_HOME ? path.dirname(this.avdHome) : configHome));
+        || androidUserHome
+        || (process.env.ANDROID_SDK_HOME ? path.join(process.env.ANDROID_SDK_HOME, ".android") : undefined)
+        || (avdHomeEnv ? path.dirname(this.avdHome) : configHome));
   }
 
   async readConfig(avdName: string): Promise<AvdConfig | null> {

--- a/src/utils/android-cmdline-tools/AvdConfigReader.ts
+++ b/src/utils/android-cmdline-tools/AvdConfigReader.ts
@@ -80,7 +80,12 @@ export class FileAvdConfigReader implements AvdConfigReader {
     this.avdHome = avdHome
       ?? process.env.ANDROID_AVD_HOME
       ?? path.join(configHome, "avd");
-    this.configHome = avdHome ? path.dirname(avdHome) : configHome;
+    this.configHome = avdHome
+      ? path.dirname(avdHome)
+      : (process.env.ANDROID_EMULATOR_HOME
+        ?? androidUserHome
+        ?? (process.env.ANDROID_SDK_HOME ? path.join(process.env.ANDROID_SDK_HOME, ".android") : undefined)
+        ?? (process.env.ANDROID_AVD_HOME ? path.dirname(this.avdHome) : configHome));
   }
 
   async readConfig(avdName: string): Promise<AvdConfig | null> {

--- a/src/utils/android-cmdline-tools/AvdConfigReader.ts
+++ b/src/utils/android-cmdline-tools/AvdConfigReader.ts
@@ -59,6 +59,7 @@ export class FileAvdConfigReader implements AvdConfigReader {
   private readFileFn: (path: string, encoding: string) => Promise<string>;
   private existsFn: (path: string) => boolean;
   private avdHome: string;
+  private configHome: string;
 
   constructor(
     readFileFn?: (path: string, encoding: string) => Promise<string>,
@@ -72,10 +73,14 @@ export class FileAvdConfigReader implements AvdConfigReader {
 
     const homeDir = process.env.HOME || process.env.USERPROFILE;
     const androidUserHome = process.env.ANDROID_USER_HOME;
+    const configHome = process.env.ANDROID_EMULATOR_HOME
+      ?? androidUserHome
+      ?? (process.env.ANDROID_SDK_HOME ? path.join(process.env.ANDROID_SDK_HOME, ".android") : undefined)
+      ?? (homeDir ? path.join(homeDir, ".android") : "");
     this.avdHome = avdHome
       ?? process.env.ANDROID_AVD_HOME
-      ?? (androidUserHome ? path.join(androidUserHome, "avd") : undefined)
-      ?? (homeDir ? path.join(homeDir, ".android", "avd") : "");
+      ?? path.join(configHome, "avd");
+    this.configHome = avdHome ? path.dirname(avdHome) : configHome;
   }
 
   async readConfig(avdName: string): Promise<AvdConfig | null> {
@@ -106,7 +111,7 @@ export class FileAvdConfigReader implements AvdConfigReader {
     if (!this.existsFn(registryPath)) {return null;}
     try {
       const registry = parseKeyValueProperties(await this.readFileFn(registryPath, "utf-8"));
-      const candidates = registryConfigCandidates(registry, this.avdHome);
+      const candidates = registryConfigCandidates(registry, this.configHome);
       return candidates.find(candidate => this.existsFn(candidate)) ?? null;
     } catch (error) {
       logger.warn(`Failed to read AVD registry for ${avdName}: ${error}`);
@@ -140,7 +145,7 @@ function parseKeyValueProperties(content: string): Map<string, string> {
   return props;
 }
 
-function registryConfigCandidates(props: Map<string, string>, avdHome: string): string[] {
+function registryConfigCandidates(props: Map<string, string>, configHome: string): string[] {
   const path = require("path");
   const candidates: string[] = [];
   const absolutePath = props.get("path");
@@ -150,7 +155,7 @@ function registryConfigCandidates(props: Map<string, string>, avdHome: string): 
 
   const relativePath = props.get("path.rel");
   if (relativePath && !path.isAbsolute(relativePath)) {
-    const relativeBase = path.resolve(path.dirname(avdHome));
+    const relativeBase = path.resolve(configHome);
     const resolvedDirectory = path.resolve(relativeBase, relativePath);
     const relativeToBase = path.relative(relativeBase, resolvedDirectory);
     const escapesBase = relativeToBase === ".."

--- a/src/utils/android-cmdline-tools/AvdConfigReader.ts
+++ b/src/utils/android-cmdline-tools/AvdConfigReader.ts
@@ -85,15 +85,15 @@ export class FileAvdConfigReader implements AvdConfigReader {
 
   async readConfig(avdName: string): Promise<AvdConfig | null> {
     const path = require("path");
-    let configPath = path.join(this.avdHome, `${avdName}.avd`, "config.ini");
+    const conventionalConfigPath = path.join(this.avdHome, `${avdName}.avd`, "config.ini");
+    let configPath = conventionalConfigPath;
 
-    if (!this.existsFn(configPath)) {
-      const resolvedConfigPath = await this.resolveRegistryConfigPath(avdName);
-      if (!resolvedConfigPath) {
-        logger.debug(`AVD config.ini not found: ${configPath}`);
-        return null;
-      }
+    const resolvedConfigPath = await this.resolveRegistryConfigPath(avdName);
+    if (resolvedConfigPath) {
       configPath = resolvedConfigPath;
+    } else if (!this.existsFn(configPath)) {
+      logger.debug(`AVD config.ini not found: ${configPath}`);
+      return null;
     }
 
     try {

--- a/src/utils/android-cmdline-tools/AvdConfigReader.ts
+++ b/src/utils/android-cmdline-tools/AvdConfigReader.ts
@@ -157,13 +157,7 @@ function registryConfigCandidates(props: Map<string, string>, configHome: string
   if (relativePath && !path.isAbsolute(relativePath)) {
     const relativeBase = path.resolve(configHome);
     const resolvedDirectory = path.resolve(relativeBase, relativePath);
-    const relativeToBase = path.relative(relativeBase, resolvedDirectory);
-    const escapesBase = relativeToBase === ".."
-      || relativeToBase.startsWith(`..${path.sep}`)
-      || path.isAbsolute(relativeToBase);
-    if (!escapesBase) {
-      candidates.push(path.join(resolvedDirectory, "config.ini"));
-    }
+    candidates.push(path.join(resolvedDirectory, "config.ini"));
   }
   return candidates;
 }

--- a/test/utils/android-cmdline-tools/AndroidEmulatorClient-bootFailureDetectors.test.ts
+++ b/test/utils/android-cmdline-tools/AndroidEmulatorClient-bootFailureDetectors.test.ts
@@ -4,7 +4,7 @@ import type { ExecResult } from "../../../src/models";
 import { FakeTimer } from "../../fakes/FakeTimer";
 import { FakeAdbExecutor } from "../../fakes/FakeAdbExecutor";
 import type { AdbClientFactory } from "../../../src/utils/android-cmdline-tools/AdbClientFactory";
-import type { AvdConfigReader } from "../../../src/utils/android-cmdline-tools/AvdConfigReader";
+import { FileAvdConfigReader, type AvdConfigReader } from "../../../src/utils/android-cmdline-tools/AvdConfigReader";
 
 const result = (stdout = "", stderr = ""): ExecResult => ({
   stdout,
@@ -56,7 +56,36 @@ describe("Android emulator boot failure diagnostics", () => {
     expect(error.message).toContain("2048 MB");
   });
 
-  test("keeps a transient offline target within the readiness deadline", async () => {
+  test("applies the RAM floor when the AVD config comes from an absolute registry path", async () => {
+    const path = require("path");
+    const registryPath = path.join("/fake/avd", "Pixel_9_Pro.ini");
+    const configPath = path.join("/custom/avds", "Pixel_9_Pro.avd", "config.ini");
+    const reader = new FileAvdConfigReader(
+      async filePath => filePath === registryPath
+        ? "path=/custom/avds/Pixel_9_Pro.avd\n"
+        : "hw.ramSize=1024\nimage.sysdir.1=system-images/android-36/google_apis_playstore/arm64-v8a/\ntag.id=google_apis_playstore\n",
+      filePath => filePath === registryPath || filePath === configPath,
+      "/fake/avd",
+    );
+    const timer = new FakeTimer();
+    timer.enableAutoAdvance();
+    const client = new AndroidEmulatorClient(
+      async (_file, args) => args.includes("-list-avds") ? result("Pixel_9_Pro\n") : result(),
+      (() => { throw new Error("spawn should not be reached"); }) as any,
+      timer,
+      { create: () => new FakeAdbExecutor() } as AdbClientFactory,
+      reader,
+    );
+    (client as unknown as { isAvdRunning: () => Promise<boolean> }).isAvdRunning = async () => false;
+    (client as unknown as { isAvdStarting: () => Promise<boolean> }).isAvdStarting = async () => false;
+    (client as unknown as { checkArchitectureCompatibility: () => Promise<unknown> }).checkArchitectureCompatibility = async () => ({ compatible: true });
+
+    const error = await expectRejection(client.startEmulator("Pixel_9_Pro"));
+    expect(error.message).toContain("hw.ramSize");
+    expect(error.message).toContain("1024 MB");
+  });
+
+  test("reports a target that remains offline instead of waiting for the generic timeout", async () => {
     const timer = new FakeTimer();
     timer.enableAutoAdvance();
     const adb = new FakeAdbExecutor();

--- a/test/utils/android-cmdline-tools/AndroidEmulatorClient-bootFailureDetectors.test.ts
+++ b/test/utils/android-cmdline-tools/AndroidEmulatorClient-bootFailureDetectors.test.ts
@@ -58,14 +58,16 @@ describe("Android emulator boot failure diagnostics", () => {
 
   test("applies the RAM floor when the AVD config comes from an absolute registry path", async () => {
     const path = require("path");
-    const registryPath = path.join("/fake/avd", "Pixel_9_Pro.ini");
-    const configPath = path.join("/custom/avds", "Pixel_9_Pro.avd", "config.ini");
+    const avdHome = path.resolve("fake", "avd");
+    const relocatedAvdHome = path.resolve("custom", "avds");
+    const registryPath = path.join(avdHome, "Pixel_9_Pro.ini");
+    const configPath = path.join(relocatedAvdHome, "Pixel_9_Pro.avd", "config.ini");
     const reader = new FileAvdConfigReader(
       async filePath => filePath === registryPath
-        ? "path=/custom/avds/Pixel_9_Pro.avd\n"
+        ? `path=${path.join(relocatedAvdHome, "Pixel_9_Pro.avd")}\n`
         : "hw.ramSize=1024\nimage.sysdir.1=system-images/android-36/google_apis_playstore/arm64-v8a/\ntag.id=google_apis_playstore\n",
       filePath => filePath === registryPath || filePath === configPath,
-      "/fake/avd",
+      avdHome,
     );
     const timer = new FakeTimer();
     timer.enableAutoAdvance();

--- a/test/utils/android-cmdline-tools/AvdConfigReader.test.ts
+++ b/test/utils/android-cmdline-tools/AvdConfigReader.test.ts
@@ -146,10 +146,12 @@ describe("apiLevelToVersion", () => {
 describe("FileAvdConfigReader", () => {
   const previousAndroidAvdHome = process.env.ANDROID_AVD_HOME;
   const previousAndroidUserHome = process.env.ANDROID_USER_HOME;
+  const previousAndroidEmulatorHome = process.env.ANDROID_EMULATOR_HOME;
 
   afterEach(() => {
     if (previousAndroidAvdHome === undefined) {delete process.env.ANDROID_AVD_HOME;} else {process.env.ANDROID_AVD_HOME = previousAndroidAvdHome;}
     if (previousAndroidUserHome === undefined) {delete process.env.ANDROID_USER_HOME;} else {process.env.ANDROID_USER_HOME = previousAndroidUserHome;}
+    if (previousAndroidEmulatorHome === undefined) {delete process.env.ANDROID_EMULATOR_HOME;} else {process.env.ANDROID_EMULATOR_HOME = previousAndroidEmulatorHome;}
   });
 
   it("reads config from correct path", async () => {
@@ -242,6 +244,30 @@ describe("FileAvdConfigReader", () => {
       },
       filePath => filePath === registryPath || filePath === configPath,
       "/fake/.android/avd",
+    );
+
+    const config = await reader.readConfig("Custom");
+
+    expect(config?.ramSizeMb).toBe(3072);
+    expect(readPaths).toEqual([registryPath, configPath]);
+  });
+
+  it("resolves path.rel from config home when ANDROID_AVD_HOME is overridden", async () => {
+    const path = require("path");
+    process.env.ANDROID_AVD_HOME = "/fake/avd-data";
+    process.env.ANDROID_USER_HOME = "/fake/.android";
+    process.env.ANDROID_EMULATOR_HOME = "/fake/.android";
+    const registryPath = path.join("/fake/avd-data", "Custom.ini");
+    const configPath = path.join("/fake/.android/avd", "Custom.avd", "config.ini");
+    const readPaths: string[] = [];
+    const reader = new FileAvdConfigReader(
+      async filePath => {
+        readPaths.push(filePath);
+        if (filePath === registryPath) {return "path=/stale/Custom.avd\npath.rel=avd/Custom.avd\n";}
+        if (filePath === configPath) {return "hw.ramSize=3072\n";}
+        throw new Error(`Unexpected path: ${filePath}`);
+      },
+      filePath => filePath === registryPath || filePath === configPath,
     );
 
     const config = await reader.readConfig("Custom");

--- a/test/utils/android-cmdline-tools/AvdConfigReader.test.ts
+++ b/test/utils/android-cmdline-tools/AvdConfigReader.test.ts
@@ -212,6 +212,24 @@ describe("FileAvdConfigReader", () => {
     expect(paths[0]).toBe(path.join("/user-home", "avd", "Play.avd", "config.ini"));
   });
 
+  it("ignores an empty ANDROID_EMULATOR_HOME", async () => {
+    delete process.env.ANDROID_AVD_HOME;
+    process.env.ANDROID_EMULATOR_HOME = "";
+    process.env.ANDROID_USER_HOME = "/user-home";
+    const path = require("path");
+    const expectedConfigPath = path.join("/user-home", "avd", "Play.avd", "config.ini");
+    const reader = new FileAvdConfigReader(
+      async filePath => filePath === expectedConfigPath
+        ? "image.sysdir.1=system-images/android-34/google_apis_playstore/arm64-v8a/"
+        : "",
+      filePath => filePath === expectedConfigPath,
+    );
+
+    const config = await reader.readConfig("Play");
+
+    expect(config?.apiLevel).toBe(34);
+  });
+
   it("resolves an absolute custom path from the AVD registry", async () => {
     const path = require("path");
     const avdHome = path.resolve("fake", "avd");

--- a/test/utils/android-cmdline-tools/AvdConfigReader.test.ts
+++ b/test/utils/android-cmdline-tools/AvdConfigReader.test.ts
@@ -197,9 +197,10 @@ describe("FileAvdConfigReader", () => {
     process.env.ANDROID_USER_HOME = "/user-home";
     const path = require("path");
     const paths: string[] = [];
+    const expectedConfigPath = path.join("/user-home", "avd", "Play.avd", "config.ini");
     const reader = new FileAvdConfigReader(
       async path => { paths.push(path); return "image.sysdir.1=system-images/android-34/google_apis_playstore/arm64-v8a/"; },
-      path => path.endsWith("Play.avd/config.ini"),
+      path => path === expectedConfigPath,
     );
 
     const config = await reader.readConfig("Play");
@@ -210,18 +211,19 @@ describe("FileAvdConfigReader", () => {
 
   it("resolves an absolute custom path from the AVD registry", async () => {
     const path = require("path");
-    const registryPath = path.join("/fake/avd", "Custom.ini");
-    const configPath = path.join("/custom/avds", "Custom.avd", "config.ini");
+    const avdHome = path.resolve("fake", "avd");
+    const registryPath = path.join(avdHome, "Custom.ini");
+    const configPath = path.join(path.resolve("custom", "avds"), "Custom.avd", "config.ini");
     const readPaths: string[] = [];
     const reader = new FileAvdConfigReader(
       async filePath => {
         readPaths.push(filePath);
-        if (filePath === registryPath) {return "path=/custom/avds/Custom.avd\n";}
+        if (filePath === registryPath) {return `path=${path.dirname(configPath)}\n`;}
         if (filePath === configPath) {return "hw.ramSize=4096\nimage.sysdir.1=system-images/android-34/google_apis/arm64-v8a/";}
         throw new Error(`Unexpected path: ${filePath}`);
       },
       filePath => filePath === registryPath || filePath === configPath,
-      "/fake/avd",
+      avdHome,
     );
 
     const config = await reader.readConfig("Custom");
@@ -232,20 +234,22 @@ describe("FileAvdConfigReader", () => {
 
   it("prefers a valid registry target over a stale conventional config", async () => {
     const path = require("path");
-    const registryPath = path.join("/fake/avd", "Custom.ini");
-    const conventionalConfigPath = path.join("/fake/avd", "Custom.avd", "config.ini");
-    const relocatedConfigPath = path.join("/custom/avds", "Custom.avd", "config.ini");
+    const avdHome = path.resolve("fake", "avd");
+    const relocatedAvdHome = path.resolve("custom", "avds");
+    const registryPath = path.join(avdHome, "Custom.ini");
+    const conventionalConfigPath = path.join(avdHome, "Custom.avd", "config.ini");
+    const relocatedConfigPath = path.join(relocatedAvdHome, "Custom.avd", "config.ini");
     const readPaths: string[] = [];
     const reader = new FileAvdConfigReader(
       async filePath => {
         readPaths.push(filePath);
-        if (filePath === registryPath) {return "path=/custom/avds/Custom.avd\n";}
+        if (filePath === registryPath) {return `path=${relocatedAvdHome}/Custom.avd\n`;}
         if (filePath === relocatedConfigPath) {return "hw.ramSize=4096\n";}
         if (filePath === conventionalConfigPath) {return "hw.ramSize=1024\n";}
         throw new Error(`Unexpected path: ${filePath}`);
       },
       filePath => filePath === registryPath || filePath === conventionalConfigPath || filePath === relocatedConfigPath,
-      "/fake/avd",
+      avdHome,
     );
 
     const config = await reader.readConfig("Custom");
@@ -256,8 +260,9 @@ describe("FileAvdConfigReader", () => {
 
   it("resolves a safe relative path.rel from the Android user-home parent", async () => {
     const path = require("path");
-    const registryPath = path.join("/fake/.android/avd", "Custom.ini");
-    const configPath = path.join("/fake/.android/custom-avds", "Custom.avd", "config.ini");
+    const avdHome = path.resolve("fake", ".android", "avd");
+    const configPath = path.join(path.dirname(avdHome), "custom-avds", "Custom.avd", "config.ini");
+    const registryPath = path.join(avdHome, "Custom.ini");
     const readPaths: string[] = [];
     const reader = new FileAvdConfigReader(
       async filePath => {
@@ -267,7 +272,7 @@ describe("FileAvdConfigReader", () => {
         throw new Error(`Unexpected path: ${filePath}`);
       },
       filePath => filePath === registryPath || filePath === configPath,
-      "/fake/.android/avd",
+      avdHome,
     );
 
     const config = await reader.readConfig("Custom");
@@ -278,11 +283,13 @@ describe("FileAvdConfigReader", () => {
 
   it("resolves path.rel from config home when ANDROID_AVD_HOME is overridden", async () => {
     const path = require("path");
-    process.env.ANDROID_AVD_HOME = "/fake/avd-data";
-    process.env.ANDROID_USER_HOME = "/fake/.android";
-    process.env.ANDROID_EMULATOR_HOME = "/fake/.android";
-    const registryPath = path.join("/fake/avd-data", "Custom.ini");
-    const configPath = path.join("/fake/.android/avd", "Custom.avd", "config.ini");
+    const avdHome = path.resolve("fake", "avd-data");
+    const configHome = path.resolve("fake", ".android");
+    process.env.ANDROID_AVD_HOME = avdHome;
+    process.env.ANDROID_USER_HOME = configHome;
+    process.env.ANDROID_EMULATOR_HOME = configHome;
+    const registryPath = path.join(avdHome, "Custom.ini");
+    const configPath = path.join(configHome, "avd", "Custom.avd", "config.ini");
     const readPaths: string[] = [];
     const reader = new FileAvdConfigReader(
       async filePath => {
@@ -302,7 +309,8 @@ describe("FileAvdConfigReader", () => {
 
   it("rejects a relative registry path that escapes the Android user-home parent", async () => {
     const path = require("path");
-    const registryPath = path.join("/fake/.android/avd", "Custom.ini");
+    const avdHome = path.resolve("fake", ".android", "avd");
+    const registryPath = path.join(avdHome, "Custom.ini");
     const probedPaths: string[] = [];
     const reader = new FileAvdConfigReader(
       async filePath => {
@@ -310,7 +318,7 @@ describe("FileAvdConfigReader", () => {
         return "path.rel=../../outside/Custom.avd\n";
       },
       filePath => filePath === registryPath,
-      "/fake/.android/avd",
+      avdHome,
     );
 
     const config = await reader.readConfig("Custom");

--- a/test/utils/android-cmdline-tools/AvdConfigReader.test.ts
+++ b/test/utils/android-cmdline-tools/AvdConfigReader.test.ts
@@ -199,7 +199,7 @@ describe("FileAvdConfigReader", () => {
     const paths: string[] = [];
     const reader = new FileAvdConfigReader(
       async path => { paths.push(path); return "image.sysdir.1=system-images/android-34/google_apis_playstore/arm64-v8a/"; },
-      path => { paths.push(path); return true; },
+      path => path.endsWith("Play.avd/config.ini"),
     );
 
     const config = await reader.readConfig("Play");
@@ -228,6 +228,30 @@ describe("FileAvdConfigReader", () => {
 
     expect(config?.ramSizeMb).toBe(4096);
     expect(readPaths).toEqual([registryPath, configPath]);
+  });
+
+  it("prefers a valid registry target over a stale conventional config", async () => {
+    const path = require("path");
+    const registryPath = path.join("/fake/avd", "Custom.ini");
+    const conventionalConfigPath = path.join("/fake/avd", "Custom.avd", "config.ini");
+    const relocatedConfigPath = path.join("/custom/avds", "Custom.avd", "config.ini");
+    const readPaths: string[] = [];
+    const reader = new FileAvdConfigReader(
+      async filePath => {
+        readPaths.push(filePath);
+        if (filePath === registryPath) {return "path=/custom/avds/Custom.avd\n";}
+        if (filePath === relocatedConfigPath) {return "hw.ramSize=4096\n";}
+        if (filePath === conventionalConfigPath) {return "hw.ramSize=1024\n";}
+        throw new Error(`Unexpected path: ${filePath}`);
+      },
+      filePath => filePath === registryPath || filePath === conventionalConfigPath || filePath === relocatedConfigPath,
+      "/fake/avd",
+    );
+
+    const config = await reader.readConfig("Custom");
+
+    expect(config?.ramSizeMb).toBe(4096);
+    expect(readPaths).toEqual([registryPath, relocatedConfigPath]);
   });
 
   it("resolves a safe relative path.rel from the Android user-home parent", async () => {

--- a/test/utils/android-cmdline-tools/AvdConfigReader.test.ts
+++ b/test/utils/android-cmdline-tools/AvdConfigReader.test.ts
@@ -147,11 +147,13 @@ describe("FileAvdConfigReader", () => {
   const previousAndroidAvdHome = process.env.ANDROID_AVD_HOME;
   const previousAndroidUserHome = process.env.ANDROID_USER_HOME;
   const previousAndroidEmulatorHome = process.env.ANDROID_EMULATOR_HOME;
+  const previousAndroidSdkHome = process.env.ANDROID_SDK_HOME;
 
   afterEach(() => {
     if (previousAndroidAvdHome === undefined) {delete process.env.ANDROID_AVD_HOME;} else {process.env.ANDROID_AVD_HOME = previousAndroidAvdHome;}
     if (previousAndroidUserHome === undefined) {delete process.env.ANDROID_USER_HOME;} else {process.env.ANDROID_USER_HOME = previousAndroidUserHome;}
     if (previousAndroidEmulatorHome === undefined) {delete process.env.ANDROID_EMULATOR_HOME;} else {process.env.ANDROID_EMULATOR_HOME = previousAndroidEmulatorHome;}
+    if (previousAndroidSdkHome === undefined) {delete process.env.ANDROID_SDK_HOME;} else {process.env.ANDROID_SDK_HOME = previousAndroidSdkHome;}
   });
 
   it("reads config from correct path", async () => {
@@ -296,6 +298,33 @@ describe("FileAvdConfigReader", () => {
       async filePath => {
         readPaths.push(filePath);
         if (filePath === registryPath) {return "path=/stale/Custom.avd\npath.rel=avd/Custom.avd\n";}
+        if (filePath === configPath) {return "hw.ramSize=3072\n";}
+        throw new Error(`Unexpected path: ${filePath}`);
+      },
+      filePath => filePath === registryPath || filePath === configPath,
+    );
+
+    const config = await reader.readConfig("Custom");
+
+    expect(config?.ramSizeMb).toBe(3072);
+    expect(readPaths).toEqual([registryPath, configPath]);
+  });
+
+  it("resolves path.rel from the AVD home parent when only ANDROID_AVD_HOME is set", async () => {
+    const path = require("path");
+    const avdHome = path.resolve("fake", "avd-data");
+    const configHome = path.dirname(avdHome);
+    process.env.ANDROID_AVD_HOME = avdHome;
+    delete process.env.ANDROID_USER_HOME;
+    delete process.env.ANDROID_EMULATOR_HOME;
+    delete process.env.ANDROID_SDK_HOME;
+    const registryPath = path.join(avdHome, "Custom.ini");
+    const configPath = path.join(configHome, "custom-avds", "Custom.avd", "config.ini");
+    const readPaths: string[] = [];
+    const reader = new FileAvdConfigReader(
+      async filePath => {
+        readPaths.push(filePath);
+        if (filePath === registryPath) {return "path.rel=custom-avds/Custom.avd\n";}
         if (filePath === configPath) {return "hw.ramSize=3072\n";}
         throw new Error(`Unexpected path: ${filePath}`);
       },

--- a/test/utils/android-cmdline-tools/AvdConfigReader.test.ts
+++ b/test/utils/android-cmdline-tools/AvdConfigReader.test.ts
@@ -205,4 +205,67 @@ describe("FileAvdConfigReader", () => {
     expect(config?.apiLevel).toBe(34);
     expect(paths[0]).toBe(path.join("/user-home", "avd", "Play.avd", "config.ini"));
   });
+
+  it("resolves an absolute custom path from the AVD registry", async () => {
+    const path = require("path");
+    const registryPath = path.join("/fake/avd", "Custom.ini");
+    const configPath = path.join("/custom/avds", "Custom.avd", "config.ini");
+    const readPaths: string[] = [];
+    const reader = new FileAvdConfigReader(
+      async filePath => {
+        readPaths.push(filePath);
+        if (filePath === registryPath) {return "path=/custom/avds/Custom.avd\n";}
+        if (filePath === configPath) {return "hw.ramSize=4096\nimage.sysdir.1=system-images/android-34/google_apis/arm64-v8a/";}
+        throw new Error(`Unexpected path: ${filePath}`);
+      },
+      filePath => filePath === registryPath || filePath === configPath,
+      "/fake/avd",
+    );
+
+    const config = await reader.readConfig("Custom");
+
+    expect(config?.ramSizeMb).toBe(4096);
+    expect(readPaths).toEqual([registryPath, configPath]);
+  });
+
+  it("resolves a safe relative path.rel from the Android user-home parent", async () => {
+    const path = require("path");
+    const registryPath = path.join("/fake/.android/avd", "Custom.ini");
+    const configPath = path.join("/fake/.android/custom-avds", "Custom.avd", "config.ini");
+    const readPaths: string[] = [];
+    const reader = new FileAvdConfigReader(
+      async filePath => {
+        readPaths.push(filePath);
+        if (filePath === registryPath) {return "path.rel=custom-avds/Custom.avd\n";}
+        if (filePath === configPath) {return "hw.ramSize=3072\n";}
+        throw new Error(`Unexpected path: ${filePath}`);
+      },
+      filePath => filePath === registryPath || filePath === configPath,
+      "/fake/.android/avd",
+    );
+
+    const config = await reader.readConfig("Custom");
+
+    expect(config?.ramSizeMb).toBe(3072);
+    expect(readPaths).toEqual([registryPath, configPath]);
+  });
+
+  it("rejects a relative registry path that escapes the Android user-home parent", async () => {
+    const path = require("path");
+    const registryPath = path.join("/fake/.android/avd", "Custom.ini");
+    const probedPaths: string[] = [];
+    const reader = new FileAvdConfigReader(
+      async filePath => {
+        probedPaths.push(filePath);
+        return "path.rel=../../outside/Custom.avd\n";
+      },
+      filePath => filePath === registryPath,
+      "/fake/.android/avd",
+    );
+
+    const config = await reader.readConfig("Custom");
+
+    expect(config).toBeNull();
+    expect(probedPaths).toEqual([registryPath]);
+  });
 });

--- a/test/utils/android-cmdline-tools/AvdConfigReader.test.ts
+++ b/test/utils/android-cmdline-tools/AvdConfigReader.test.ts
@@ -194,6 +194,7 @@ describe("FileAvdConfigReader", () => {
 
   it("uses ANDROID_USER_HOME/avd when ANDROID_AVD_HOME is unset", async () => {
     delete process.env.ANDROID_AVD_HOME;
+    delete process.env.ANDROID_EMULATOR_HOME;
     process.env.ANDROID_USER_HOME = "/user-home";
     const path = require("path");
     const paths: string[] = [];
@@ -307,23 +308,26 @@ describe("FileAvdConfigReader", () => {
     expect(readPaths).toEqual([registryPath, configPath]);
   });
 
-  it("rejects a relative registry path that escapes the Android user-home parent", async () => {
+  it("resolves a parent-relative registry path from the Android user-home parent", async () => {
     const path = require("path");
     const avdHome = path.resolve("fake", ".android", "avd");
     const registryPath = path.join(avdHome, "Custom.ini");
-    const probedPaths: string[] = [];
+    const configPath = path.join(path.resolve("fake", ".android", "../..", "outside"), "Custom.avd", "config.ini");
+    const readPaths: string[] = [];
     const reader = new FileAvdConfigReader(
       async filePath => {
-        probedPaths.push(filePath);
-        return "path.rel=../../outside/Custom.avd\n";
+        readPaths.push(filePath);
+        if (filePath === registryPath) {return "path.rel=../../outside/Custom.avd\n";}
+        if (filePath === configPath) {return "hw.ramSize=3072\n";}
+        throw new Error(`Unexpected path: ${filePath}`);
       },
-      filePath => filePath === registryPath,
+      filePath => filePath === registryPath || filePath === configPath,
       avdHome,
     );
 
     const config = await reader.readConfig("Custom");
 
-    expect(config).toBeNull();
-    expect(probedPaths).toEqual([registryPath]);
+    expect(config?.ramSizeMb).toBe(3072);
+    expect(readPaths).toEqual([registryPath, configPath]);
   });
 });


### PR DESCRIPTION
## Summary

Resolve custom Android AVD registry entries before RAM preflight validation. When the conventional `<name>.avd/config.ini` is absent, `FileAvdConfigReader` now reads `<name>.ini`, supports absolute `path=` and safe parent-relative `path.rel=` targets, and parses the resolved config. Existing modern Play-image RAM validation then reports the actionable low-RAM error instead of silently skipping the check.

## Linked Issue

Closes [#4993](https://github.com/kaeawc/auto-mobile/issues/4993)

## Bug / Regression Context

- **Prior attempts:** The emulator boot diagnostics from [#4978](https://github.com/kaeawc/auto-mobile/pull/4978) only probed the conventional AVD directory.
- **Observed symptom:** Custom AVDs registered through `<name>.ini` were treated as unreadable, so undersized modern Play images could launch without the RAM preflight error.
- **Repro steps / conditions:** Remove `<name>.avd/config.ini`, register the AVD through `<name>.ini` with `path=` or `path.rel=`, and start or doctor-check a modern Play image below 2048 MB.

## Validation

- [x] `bun run turbo:validate` passes (7/7 tasks; 12,663 passed, 13 skipped)
- [x] `bun run typecheck` reports no new errors (baseline gate)
- [x] `bun run lint` and Android boundary checks pass
- [x] New code uses injected filesystem seams; focused unit tests pass in 201 ms
- [x] No new dependency; path resolution uses the Node standard library
- [x] Fresh worktree created from latest `origin/main` (`59caa18dc`)

## Follow-ups

None.
