### PR TITLE
fix(db): recover partial owner-session migration

### DIFF
--- a/docs/design-docs/mcp/daemon/client-frame-snapshot.md
+++ b/docs/design-docs/mcp/daemon/client-frame-snapshot.md
@@ -205,7 +205,7 @@ non-null contexts alongside `captureSequence`, then echoes that exact value on
 request. The token is opaque, device-specific, and must never be synthesized or
 compared across reconnects.
 
-The default `0.0.48` CtrlProxy artifacts predate this protocol. A client must
+The default `0.0.49` CtrlProxy artifacts predate this protocol. A client must
 treat those artifacts as legacy and remain in inspector mode until its runner
 publishes `frameContext`.
 

--- a/docs/design-docs/mcp/daemon/client-screen-control.md
+++ b/docs/design-docs/mcp/daemon/client-screen-control.md
@@ -224,7 +224,7 @@ also what lets the retained-frame rule below notice a transition *into* an unkno
   snapshot. Keep its mirror in inspector mode rather than omitting `frameContext` from an input
   request and guessing. The optional field remains compatible with generic, non-screen-control
   socket clients that do not have an observation snapshot.
-- **Release availability:** the default `0.0.48` CtrlProxy artifacts predate `frameContext`
+- **Release availability:** the default `0.0.49` CtrlProxy artifacts predate `frameContext`
   support. Use runners built from a revision that publishes the field before enabling this control
   flow; otherwise treat the runner as legacy and keep the mirror in inspector mode.
 - **Active device:** every message's `deviceId` identifies its device. Subscribe with the selected

--- a/docs/design-docs/mcp/daemon/unix-socket-api.md
+++ b/docs/design-docs/mcp/daemon/unix-socket-api.md
@@ -379,7 +379,7 @@ after the response frame is printed. A screen-control client must replace
 `android-generation-42` with the opaque `frameContext` from its paired screenshot
 and hierarchy; it is illustrative and cannot be reused for another frame.
 These `frameContext` examples require a runner that publishes the field; the
-default `0.0.48` CtrlProxy artifacts are legacy and cannot supply one.
+default `0.0.49` CtrlProxy artifacts are legacy and cannot supply one.
 
 ```bash
 export AUTOMOBILE_DAEMON_SOCKET_PATH="${AUTOMOBILE_DAEMON_SOCKET_PATH:-/tmp/auto-mobile-daemon-$(id -u).sock}"

--- a/scripts/versioning/bump-versions.sh
+++ b/scripts/versioning/bump-versions.sh
@@ -180,6 +180,46 @@ PY
 }
 update_marketplace_plugin_version ".claude-plugin/marketplace.json" "$new_version" "$dry_run"
 
+# Keep daemon consumer documentation aligned with the CtrlProxy artifacts that
+# ship in the release. These references are intentionally updated as part of
+# the same atomic version bump so prepare-release cannot leave main with a
+# stale docs-test fixture.
+update_ctrl_proxy_docs_version() {
+  local version="$1"
+  local dry="$2"
+  local path
+  local docs=(
+    "docs/design-docs/mcp/daemon/client-screen-control.md"
+    "docs/design-docs/mcp/daemon/client-frame-snapshot.md"
+    "docs/design-docs/mcp/daemon/unix-socket-api.md"
+  )
+
+  for path in "${docs[@]}"; do
+    if [[ "$dry" == true ]]; then
+      echo "Would update CtrlProxy version references to $version in $path"
+      continue
+    fi
+    python3 - "$path" "$version" <<'PY'
+import re
+import sys
+from pathlib import Path
+
+path = Path(sys.argv[1])
+version = sys.argv[2]
+text = path.read_text(encoding="utf-8")
+updated, count = re.subn(
+    r"(default `)[^`]+(` CtrlProxy artifacts)",
+    rf"\g<1>{version}\g<2>",
+    text,
+)
+if count == 0:
+    raise SystemExit(f"no default CtrlProxy version reference found in {path}")
+path.write_text(updated, encoding="utf-8")
+PY
+  done
+}
+update_ctrl_proxy_docs_version "$new_version" "$dry_run"
+
 # Keep the iOS XCTestRunner's baked client version in sync (mirrors Android's jar
 # Implementation-Version). The daemon's version handshake compares the release portion,
 # so this carries the plain MAJOR.MINOR.PATCH with no SNAPSHOT suffix.

--- a/src/db/migrations/2026_07_31_000_video_recordings_owner_session.ts
+++ b/src/db/migrations/2026_07_31_000_video_recordings_owner_session.ts
@@ -1,4 +1,4 @@
-import type { Kysely } from "kysely";
+import { sql, type Kysely } from "kysely";
 
 /**
  * Session-scope the video recording archive (issue #4752).
@@ -12,10 +12,17 @@ import type { Kysely } from "kysely";
  * existing archive.
  */
 export async function up(db: Kysely<unknown>): Promise<void> {
-  await db.schema
-    .alterTable("video_recordings")
-    .addColumn("owner_session_uuid", "text")
-    .execute();
+  const existingColumn = await sql<{ name: string }>`
+    SELECT name FROM pragma_table_info('video_recordings')
+    WHERE name = 'owner_session_uuid'
+  `.execute(db);
+
+  if (existingColumn.rows.length === 0) {
+    await db.schema
+      .alterTable("video_recordings")
+      .addColumn("owner_session_uuid", "text")
+      .execute();
+  }
 
   await db.schema
     .createIndex("idx_video_recordings_owner_session")

--- a/test/bats/bump-versions.bats
+++ b/test/bats/bump-versions.bats
@@ -15,6 +15,7 @@ setup() {
   mkdir -p "${TEST_ROOT}/.claude-plugin" \
     "${TEST_ROOT}/android/junit-runner" \
     "${TEST_ROOT}/android/playground/app" \
+    "${TEST_ROOT}/docs/design-docs/mcp/daemon" \
     "${TEST_ROOT}/ios/XCTestRunner/Sources/XCTestRunner" \
     "$BIN_DIR"
   write_fake_rg
@@ -52,6 +53,16 @@ EOF
 
   cat > "${TEST_ROOT}/server.json" <<'EOF'
 { "version": "0.0.1", "packages": [ { "identifier": "@kaeawc/auto-mobile", "version": "0.0.1" } ] }
+EOF
+
+  cat > "${TEST_ROOT}/docs/design-docs/mcp/daemon/client-screen-control.md" <<'EOF'
+- **Release availability:** the default `0.0.1` CtrlProxy artifacts predate `frameContext`
+EOF
+  cat > "${TEST_ROOT}/docs/design-docs/mcp/daemon/client-frame-snapshot.md" <<'EOF'
+The default `0.0.1` CtrlProxy artifacts predate this protocol.
+EOF
+  cat > "${TEST_ROOT}/docs/design-docs/mcp/daemon/unix-socket-api.md" <<'EOF'
+default `0.0.1` CtrlProxy artifacts are legacy and cannot supply one.
 EOF
 
   cat > "${TEST_ROOT}/android/gradle.properties" <<'EOF'
@@ -105,6 +116,12 @@ run_bump() {
   grep -q "^VERSION_NAME=${VERSION}-SNAPSHOT$" "${TEST_ROOT}/android/gradle.properties"
   grep -q "^version = \"${VERSION}-SNAPSHOT\"$" "${TEST_ROOT}/android/junit-runner/build.gradle.kts"
   grep -q "versionName = \"${VERSION}-SNAPSHOT\"" "${TEST_ROOT}/android/playground/app/build.gradle.kts"
+  grep -q "default \`${VERSION}\` CtrlProxy artifacts" \
+    "${TEST_ROOT}/docs/design-docs/mcp/daemon/client-screen-control.md"
+  grep -q "default \`${VERSION}\` CtrlProxy artifacts" \
+    "${TEST_ROOT}/docs/design-docs/mcp/daemon/client-frame-snapshot.md"
+  grep -q "default \`${VERSION}\` CtrlProxy artifacts" \
+    "${TEST_ROOT}/docs/design-docs/mcp/daemon/unix-socket-api.md"
   # The Swift constant must be *regenerated* (not regex-edited in place): assert
   # the generator's output markers so a regression back to an in-place edit fails.
   grep -q "public static let current = \"${VERSION}\"" \

--- a/test/db/videoRecordingsOwnerSessionMigration.test.ts
+++ b/test/db/videoRecordingsOwnerSessionMigration.test.ts
@@ -1,0 +1,86 @@
+import { afterEach, beforeEach, describe, expect, test } from "bun:test";
+import { Database as BunDatabase } from "bun:sqlite";
+import { Kysely, sql } from "kysely";
+import type { MigrationProvider } from "kysely/migration";
+import { BunSqliteDialect } from "../../src/db/bunSqliteDialect";
+import { up as ownerSessionMigration } from "../../src/db/migrations/2026_07_31_000_video_recordings_owner_session";
+import { runMigrations } from "../../src/db/migrator";
+
+const MIGRATION_NAME = "2026_07_31_000_video_recordings_owner_session";
+
+function provider(): MigrationProvider {
+  return {
+    async getMigrations() {
+      return { [MIGRATION_NAME]: { up: ownerSessionMigration } };
+    },
+  };
+}
+
+describe("video recordings owner-session migration", () => {
+  let db: Kysely<unknown>;
+
+  beforeEach(() => {
+    db = new Kysely<unknown>({
+      dialect: new BunSqliteDialect({ database: new BunDatabase(":memory:") }),
+    });
+  });
+
+  afterEach(async () => {
+    await db.destroy();
+  });
+
+  test("recovers when the schema change already exists without migration history", async () => {
+    await db.schema
+      .createTable("video_recordings")
+      .addColumn("id", "integer", column => column.primaryKey())
+      .addColumn("owner_session_uuid", "text")
+      .execute();
+    await db.schema
+      .createIndex("idx_video_recordings_owner_session")
+      .on("video_recordings")
+      .column("owner_session_uuid")
+      .execute();
+
+    await runMigrations(db, { provider: provider(), env: {} });
+
+    const migration = await db
+      .selectFrom("kysely_migration" as any)
+      .select("name")
+      .where("name", "=", MIGRATION_NAME)
+      .executeTakeFirst();
+    expect(migration?.name).toBe(MIGRATION_NAME);
+
+    const columns = await sql<{ name: string }>`
+      select name from pragma_table_info('video_recordings')
+      where name = 'owner_session_uuid'
+    `.execute(db);
+    expect(columns.rows).toHaveLength(1);
+
+    const index = await sql<{ name: string }>`
+      select name from sqlite_master
+      where type = 'index' and name = 'idx_video_recordings_owner_session'
+    `.execute(db);
+    expect(index.rows).toHaveLength(1);
+  });
+
+  test("creates the column and index on a fresh schema", async () => {
+    await db.schema
+      .createTable("video_recordings")
+      .addColumn("id", "integer", column => column.primaryKey())
+      .execute();
+
+    await runMigrations(db, { provider: provider(), env: {} });
+
+    const columns = await sql<{ name: string }>`
+      select name from pragma_table_info('video_recordings')
+      where name = 'owner_session_uuid'
+    `.execute(db);
+    expect(columns.rows).toHaveLength(1);
+
+    const index = await sql<{ name: string }>`
+      select name from sqlite_master
+      where type = 'index' and name = 'idx_video_recordings_owner_session'
+    `.execute(db);
+    expect(index.rows).toHaveLength(1);
+  });
+});


### PR DESCRIPTION
Closes #5004
Closes #5006

## What changed

- Make the `2026_07_31_000_video_recordings_owner_session` migration check for the existing `owner_session_uuid` column before adding it.
- Preserve the existing idempotent index creation.
- Add regression coverage for a partially applied schema and a fresh schema.
- Update release versioning to synchronize the daemon CtrlProxy documentation references and add a BATS regression test.

## Why

A database can contain the column and index while missing the Kysely migration ledger row. Re-running the migration previously failed with `duplicate column name: owner_session_uuid`, preventing daemon startup. The guarded column addition lets the migration finish and record its ledger row.

Release version bumps also update the documentation references atomically, so required docs tests cannot fail on `main` after a release changes the default CtrlProxy version.

## Validation

- `bun test test/db/videoRecordingsOwnerSessionMigration.test.ts` — passed (2 tests)
- `bun test test/docs/daemonInputApiExamples.test.ts` — passed (7 tests)
- `bats test/bats/bump-versions.bats` — passed (5 tests)
- `shellcheck scripts/versioning/bump-versions.sh` — passed
- `bun run typecheck` — passed; no new type errors
- `bun run lint` and boundary checks — passed
- `bun run turbo:validate` — passed (12,670 tests, 13 skipped)
