### PR TITLE
fix(release): allow synchronized docs in version bump

### DIFF
--- a/.github/workflows/prepare-release.yml
+++ b/.github/workflows/prepare-release.yml
@@ -77,6 +77,9 @@ jobs:
               CHANGELOG.md | \
               android/gradle.properties | \
               android/*/build.gradle.kts | \
+              docs/design-docs/mcp/daemon/client-frame-snapshot.md | \
+              docs/design-docs/mcp/daemon/client-screen-control.md | \
+              docs/design-docs/mcp/daemon/unix-socket-api.md | \
               ios/XCTestRunner/Sources/XCTestRunner/AutoMobileVersion.swift | \
               package.json | \
               server.json)

--- a/test/bats/release-workflow-wiring.bats
+++ b/test/bats/release-workflow-wiring.bats
@@ -165,6 +165,18 @@
   [[ "$final_commit" != *'git push origin HEAD:main'* ]]
 }
 
+@test "prepare-release allows version-synchronized CtrlProxy docs" {
+  wiring_requires_yq
+  local commit_step
+  commit_step="$(yq -r '.jobs."prepare-version".steps[] | select(.id == "commit") | .run' .github/workflows/prepare-release.yml)"
+  for path in \
+    "docs/design-docs/mcp/daemon/client-frame-snapshot.md" \
+    "docs/design-docs/mcp/daemon/client-screen-control.md" \
+    "docs/design-docs/mcp/daemon/unix-socket-api.md"; do
+    [[ "$commit_step" == *"$path"* ]]
+  done
+}
+
 @test "prepared release artifacts survive delayed publication retries (#4686)" {
   wiring_requires_yq
   local workflow


### PR DESCRIPTION
Closes #5006

## Summary

The failed [Prepare Release run](https://github.com/kaeawc/auto-mobile/actions/runs/30817916667) generated three documentation changes when bumping to `0.0.50`, then rejected them as unexpected versioned files.

This allowlists the three daemon documentation files that `scripts/versioning/bump-versions.sh` updates for CtrlProxy release-version synchronization. A BATS regression test ensures the release workflow keeps accepting those files.

## Validation

- `bats test/bats/release-workflow-wiring.bats` — passed (37 tests)
- `git diff --check` — passed
