### PR TITLE
fix(release): single-source the prepare-release allow-list from bump-versions.sh

### DIFF
--- a/.github/workflows/prepare-release.yml
+++ b/.github/workflows/prepare-release.yml
@@ -71,13 +71,14 @@ jobs:
           )
           # The bump script owns the list of files it rewrites; consume it so
           # the allow-list cannot drift from the script again (#5008).
-          mapfile -t allowed_patterns < <(
+          managed_paths_output="$(
             bash scripts/versioning/bump-versions.sh --print-managed-paths
-          )
-          if ((${#allowed_patterns[@]} == 0)); then
+          )"
+          if [[ -z "$managed_paths_output" ]]; then
             echo "Failed to read managed paths from bump-versions.sh" >&2
             exit 1
           fi
+          mapfile -t allowed_patterns <<< "$managed_paths_output"
           # CHANGELOG.md is written by the changelog step, not the version bump.
           allowed_patterns+=("CHANGELOG.md")
 

--- a/.github/workflows/prepare-release.yml
+++ b/.github/workflows/prepare-release.yml
@@ -69,25 +69,32 @@ jobs:
           mapfile -t changed_files < <(
             { git diff --name-only HEAD; git ls-files --others --exclude-standard; } | sort -u
           )
+          # The bump script owns the list of files it rewrites; consume it so
+          # the allow-list cannot drift from the script again (#5008).
+          mapfile -t allowed_patterns < <(
+            bash scripts/versioning/bump-versions.sh --print-managed-paths
+          )
+          if ((${#allowed_patterns[@]} == 0)); then
+            echo "Failed to read managed paths from bump-versions.sh" >&2
+            exit 1
+          fi
+          # CHANGELOG.md is written by the changelog step, not the version bump.
+          allowed_patterns+=("CHANGELOG.md")
+
           unexpected_files=()
           for path in "${changed_files[@]}"; do
-            case "$path" in
-              .claude-plugin/marketplace.json | \
-              .claude-plugin/plugin.json | \
-              CHANGELOG.md | \
-              android/gradle.properties | \
-              android/*/build.gradle.kts | \
-              docs/design-docs/mcp/daemon/client-frame-snapshot.md | \
-              docs/design-docs/mcp/daemon/client-screen-control.md | \
-              docs/design-docs/mcp/daemon/unix-socket-api.md | \
-              ios/XCTestRunner/Sources/XCTestRunner/AutoMobileVersion.swift | \
-              package.json | \
-              server.json)
-                ;;
-              *)
-                unexpected_files+=("$path")
-                ;;
-            esac
+            allowed=false
+            for pattern in "${allowed_patterns[@]}"; do
+              # Pattern intentionally unquoted: entries like
+              # android/*/build.gradle.kts must glob-match.
+              if [[ "$path" == $pattern ]]; then
+                allowed=true
+                break
+              fi
+            done
+            if [[ "$allowed" == false ]]; then
+              unexpected_files+=("$path")
+            fi
           done
 
           if ((${#unexpected_files[@]} > 0)); then

--- a/scripts/versioning/bump-versions.sh
+++ b/scripts/versioning/bump-versions.sh
@@ -2,6 +2,24 @@
 
 set -euo pipefail
 
+# Every path (or glob pattern) this script may rewrite. The prepare-release
+# workflow's versioned-tree guard consumes this list via --print-managed-paths,
+# so a new managed file added here extends the release allow-list automatically
+# instead of tripping the guard on the next release run (#5008). Patterns use
+# bash [[ == ]] semantics, where `*` also matches `/`.
+managed_path_patterns=(
+  ".claude-plugin/marketplace.json"
+  ".claude-plugin/plugin.json"
+  "android/gradle.properties"
+  "android/*/build.gradle.kts"
+  "docs/design-docs/mcp/daemon/client-frame-snapshot.md"
+  "docs/design-docs/mcp/daemon/client-screen-control.md"
+  "docs/design-docs/mcp/daemon/unix-socket-api.md"
+  "ios/XCTestRunner/Sources/XCTestRunner/AutoMobileVersion.swift"
+  "package.json"
+  "server.json"
+)
+
 new_version=""
 dry_run=false
 
@@ -14,6 +32,10 @@ while [[ $# -gt 0 ]]; do
     --dry-run)
       dry_run=true
       shift
+      ;;
+    --print-managed-paths)
+      printf '%s\n' "${managed_path_patterns[@]}"
+      exit 0
       ;;
     *)
       echo "Unknown argument: $1" >&2

--- a/test/bats/bump-versions.bats
+++ b/test/bats/bump-versions.bats
@@ -161,12 +161,15 @@ run_bump() {
 }
 
 @test "--print-managed-paths lists patterns without requiring a version or writing files (#5008)" {
+  local marker="${TEST_ROOT}/.print-managed-paths-started"
+  touch "$marker"
   run bash -c "cd '${TEST_ROOT}' && bash '${SCRIPT_ABS}' --print-managed-paths"
   [ "$status" -eq 0 ]
   [[ "$output" == *"package.json"* ]]
   [[ "$output" == *"android/*/build.gradle.kts"* ]]
-  # No file may be modified by a print-only invocation.
-  [ "$(json_field "${TEST_ROOT}/package.json" 'data["version"]')" = "0.0.1" ]
+  # No fixture file may be modified by a print-only invocation.
+  ! find "${TEST_ROOT}" -type f -newer "$marker" \
+    ! -path "$marker" -print -quit | grep -q .
 }
 
 @test "every file the bump rewrites matches a managed path pattern (#5008)" {
@@ -178,8 +181,10 @@ run_bump() {
   run_bump
   [ "$status" -eq 0 ]
 
-  local patterns
-  mapfile -t patterns < <(bash "${SCRIPT_ABS}" --print-managed-paths)
+  local patterns=()
+  while IFS= read -r pattern; do
+    patterns+=("$pattern")
+  done < <(bash "${SCRIPT_ABS}" --print-managed-paths)
   (("${#patterns[@]}" > 0))
 
   local file rel pattern matched rewritten_count=0

--- a/test/bats/bump-versions.bats
+++ b/test/bats/bump-versions.bats
@@ -159,3 +159,48 @@ run_bump() {
   run bash -c "cd '${TEST_ROOT}' && bash '${SCRIPT_ABS}' --new-version '1.2.3-beta.1' --dry-run"
   [ "$status" -eq 0 ]
 }
+
+@test "--print-managed-paths lists patterns without requiring a version or writing files (#5008)" {
+  run bash -c "cd '${TEST_ROOT}' && bash '${SCRIPT_ABS}' --print-managed-paths"
+  [ "$status" -eq 0 ]
+  [[ "$output" == *"package.json"* ]]
+  [[ "$output" == *"android/*/build.gradle.kts"* ]]
+  # No file may be modified by a print-only invocation.
+  [ "$(json_field "${TEST_ROOT}/package.json" 'data["version"]')" = "0.0.1" ]
+}
+
+@test "every file the bump rewrites matches a managed path pattern (#5008)" {
+  # The prepare-release guard allow-lists exactly the patterns from
+  # --print-managed-paths; a bump that writes an unlisted file would fail the
+  # next release run, so catch the drift here instead.
+  local marker="${TEST_ROOT}/.bump-started"
+  touch "$marker"
+  run_bump
+  [ "$status" -eq 0 ]
+
+  local patterns
+  mapfile -t patterns < <(bash "${SCRIPT_ABS}" --print-managed-paths)
+  (("${#patterns[@]}" > 0))
+
+  local file rel pattern matched rewritten_count=0
+  while IFS= read -r file; do
+    rel="${file#"${TEST_ROOT}"/}"
+    [[ "$rel" == bin/* ]] && continue
+    rewritten_count=$((rewritten_count + 1))
+    matched=false
+    for pattern in "${patterns[@]}"; do
+      # shellcheck disable=SC2053  # unquoted RHS: patterns must glob-match
+      if [[ "$rel" == $pattern ]]; then
+        matched=true
+        break
+      fi
+    done
+    if [[ "$matched" == false ]]; then
+      echo "bump rewrote unmanaged file: $rel" >&2
+      return 1
+    fi
+  done < <(find "${TEST_ROOT}" -type f -newer "$marker" ! -name "$(basename "$marker")")
+
+  # Guard against a vacuous pass: the bump must have visibly rewritten files.
+  (("$rewritten_count" > 0))
+}

--- a/test/bats/release-workflow-wiring.bats
+++ b/test/bats/release-workflow-wiring.bats
@@ -168,15 +168,24 @@
   [[ "$final_commit" != *'git push origin HEAD:main'* ]]
 }
 
-@test "prepare-release allows version-synchronized CtrlProxy docs" {
+@test "prepare-release consumes the bump script's managed-path allow-list (#5008)" {
   wiring_requires_yq
   local commit_step
   commit_step="$(yq -r '.jobs."prepare-version".steps[] | select(.id == "commit") | .run' .github/workflows/prepare-release.yml)"
+  # The allow-list is owned by bump-versions.sh, not restated in the workflow.
+  [[ "$commit_step" == *'bump-versions.sh --print-managed-paths'* ]]
+  # CHANGELOG.md is written by the changelog step, so the workflow appends it.
+  [[ "$commit_step" == *'allowed_patterns+=("CHANGELOG.md")'* ]]
+}
+
+@test "bump script managed paths cover the version-synchronized CtrlProxy docs" {
+  local managed
+  managed="$(bash scripts/versioning/bump-versions.sh --print-managed-paths)"
   for path in \
     "docs/design-docs/mcp/daemon/client-frame-snapshot.md" \
     "docs/design-docs/mcp/daemon/client-screen-control.md" \
     "docs/design-docs/mcp/daemon/unix-socket-api.md"; do
-    [[ "$commit_step" == *"$path"* ]]
+    [[ "$managed" == *"$path"* ]]
   done
 }
 

--- a/test/bats/release-workflow-wiring.bats
+++ b/test/bats/release-workflow-wiring.bats
@@ -174,6 +174,12 @@
   commit_step="$(yq -r '.jobs."prepare-version".steps[] | select(.id == "commit") | .run' .github/workflows/prepare-release.yml)"
   # The allow-list is owned by bump-versions.sh, not restated in the workflow.
   [[ "$commit_step" == *'bump-versions.sh --print-managed-paths'* ]]
+  # Capture the producer status directly; process substitution would hide a
+  # partial-output failure and let the release guard continue.
+  [[ "$commit_step" == *'managed_paths_output='* ]]
+  [[ "$commit_step" == *'if [[ -z "$managed_paths_output" ]]; then'* ]]
+  [[ "$commit_step" == *'mapfile -t allowed_patterns <<< "$managed_paths_output"'* ]]
+  [[ "$commit_step" != *'mapfile -t allowed_patterns < <('* ]]
   # CHANGELOG.md is written by the changelog step, so the workflow appends it.
   [[ "$commit_step" == *'allowed_patterns+=("CHANGELOG.md")'* ]]
 }


### PR DESCRIPTION
Closes #5008

## Summary

The 0.0.50 Prepare Release failure happened because `scripts/versioning/bump-versions.sh` learned to rewrite three docs files while the workflow's versioned-tree allow-list still hardcoded the old file set. [#5007](https://github.com/kaeawc/auto-mobile/pull/5007) patched the list; this PR removes the duplicated knowledge so the next managed-file addition cannot desynchronize the two again.

- `bump-versions.sh` now owns a `managed_path_patterns` array (everything the bump may rewrite, including the `android/*/build.gradle.kts` glob) and exposes it via `--print-managed-paths` — a print-only flag that requires no `--new-version` and writes nothing.
- The `prepare-version` commit step consumes that list instead of restating it in a `case` block, appending only `CHANGELOG.md` (written by the changelog step, not the bump). An empty list fails closed. Pattern matching keeps the same `case`-style glob semantics via `[[ "$path" == $pattern ]]`.
- BATS coverage on both sides:
  - `bump-versions.bats`: `--print-managed-paths` prints patterns without touching files; and a drift ratchet — every file the fixture bump actually rewrites must match a managed pattern (with a vacuity guard), so "script writes a new file but the list wasn't updated" now fails locally/CI instead of on the next release run.
  - `release-workflow-wiring.bats`: the commit step must consume `--print-managed-paths` and append `CHANGELOG.md`; the CtrlProxy docs paths are asserted through the script's list (replaces the workflow-text assertion from #5007, which this PR's workflow change would otherwise redden).

## Validation

- [x] `bats test/bats/bump-versions.bats test/bats/release-workflow-wiring.bats` — 7/7 and 45/45 green
- [x] `shellcheck scripts/versioning/bump-versions.sh` — clean
- [x] `scripts/all_fast_validate_checks.sh` — 31/31 passed (yaml, shellcheck, workflow guards)

## Not in this PR

- Re-dispatching Prepare Release for 0.0.50 (remediation step 2 of #5008) — release action, done from the Actions UI after this merges.
