### PR TITLE
fix: expose structured already-stopped device errors

### DIFF
--- a/android/desktop-core/src/main/kotlin/dev/jasonpearson/automobile/desktop/core/AutoMobileContent.kt
+++ b/android/desktop-core/src/main/kotlin/dev/jasonpearson/automobile/desktop/core/AutoMobileContent.kt
@@ -2108,7 +2108,10 @@ fun AutoMobileContent(
                           LOG.info(
                             "Killing device ${device.name} (${device.id}) via ${client?.transportName}"
                           )
-                          client?.killDevice(device.name, device.id, platform)
+                          val result = client?.killDevice(device.name, device.id, platform)
+                          if (result?.success == false) {
+                            LOG.info("Failed to kill device: ${result.message}")
+                          }
                         } catch (e: Exception) {
                           LOG.info("Failed to kill device: ${e.message}")
                         }

--- a/android/test-plan-validation/src/main/kotlin/dev/jasonpearson/automobile/validation/ToolResultParser.kt
+++ b/android/test-plan-validation/src/main/kotlin/dev/jasonpearson/automobile/validation/ToolResultParser.kt
@@ -27,8 +27,20 @@ object ToolResultParser {
     val error =
       objectElement["error"]?.let { errorElement ->
         when (errorElement) {
-          is JsonObject ->
-            errorElement["message"]?.jsonPrimitive?.content ?: errorElement.toString()
+          // A structured `{ code, message }` error (e.g. the killDevice
+          // `device_already_stopped` envelope) is flattened to `code: message`,
+          // matching how the TypeScript plan/critical-section paths render it, so
+          // Kotlin consumers keep the machine-readable code without reparsing the
+          // raw payload.
+          is JsonObject -> {
+            val code = errorElement["code"]?.jsonPrimitive?.content
+            val message = errorElement["message"]?.jsonPrimitive?.content
+            when {
+              code != null && message != null -> "$code: $message"
+              message != null -> message
+              else -> errorElement.toString()
+            }
+          }
           else -> errorElement.jsonPrimitive.content
         }
       }

--- a/android/test-plan-validation/src/main/kotlin/dev/jasonpearson/automobile/validation/ToolResultParser.kt
+++ b/android/test-plan-validation/src/main/kotlin/dev/jasonpearson/automobile/validation/ToolResultParser.kt
@@ -24,7 +24,14 @@ object ToolResultParser {
       element as? JsonObject ?: throw SerializationException("Tool result is not a JSON object")
 
     val success = inferSuccess(objectElement)
-    val error = objectElement["error"]?.jsonPrimitive?.content
+    val error =
+      objectElement["error"]?.let { errorElement ->
+        when (errorElement) {
+          is JsonObject ->
+            errorElement["message"]?.jsonPrimitive?.content ?: errorElement.toString()
+          else -> errorElement.jsonPrimitive.content
+        }
+      }
 
     val response =
       when (toolName) {

--- a/android/test-plan-validation/src/test/kotlin/dev/jasonpearson/automobile/validation/ToolResultParserTest.kt
+++ b/android/test-plan-validation/src/test/kotlin/dev/jasonpearson/automobile/validation/ToolResultParserTest.kt
@@ -124,7 +124,7 @@ class ToolResultParserTest {
   }
 
   @Test
-  fun `parse structured error object without losing its message`() {
+  fun `parse structured error object preserves the code and message`() {
     val result =
       ToolResultParser.parseToolResult(
         0,
@@ -143,10 +143,31 @@ class ToolResultParserTest {
       )
 
     assertTrue(!result.success)
+    // The machine-readable code is retained as a `code: message` prefix so
+    // consumers can distinguish idempotent shutdown from other kill failures.
     assertEquals(
-      "Failed to kill android device: device already stopped",
+      "device_already_stopped: Failed to kill android device: device already stopped",
       result.error,
     )
+  }
+
+  @Test
+  fun `parse structured error object without a code falls back to the message`() {
+    val result =
+      ToolResultParser.parseToolResult(
+        0,
+        "killDevice",
+        """
+        {
+          "success": false,
+          "error": { "message": "Some other failure" }
+        }
+        """
+          .trimIndent(),
+      )
+
+    assertTrue(!result.success)
+    assertEquals("Some other failure", result.error)
   }
 
   @Test

--- a/android/test-plan-validation/src/test/kotlin/dev/jasonpearson/automobile/validation/ToolResultParserTest.kt
+++ b/android/test-plan-validation/src/test/kotlin/dev/jasonpearson/automobile/validation/ToolResultParserTest.kt
@@ -124,6 +124,32 @@ class ToolResultParserTest {
   }
 
   @Test
+  fun `parse structured error object without losing its message`() {
+    val result =
+      ToolResultParser.parseToolResult(
+        0,
+        "killDevice",
+        """
+        {
+          "success": false,
+          "message": "Failed to kill android device: device already stopped",
+          "error": {
+            "code": "device_already_stopped",
+            "message": "Failed to kill android device: device already stopped"
+          }
+        }
+        """
+          .trimIndent(),
+      )
+
+    assertTrue(!result.success)
+    assertEquals(
+      "Failed to kill android device: device already stopped",
+      result.error,
+    )
+  }
+
+  @Test
   fun `parse MCP response wrapper`() {
     val payload =
       """

--- a/src/server/criticalSectionTools.ts
+++ b/src/server/criticalSectionTools.ts
@@ -74,6 +74,53 @@ const criticalSectionSchema = addDeviceTargetingToSchema(z.object({
 
 type CriticalSectionParams = z.infer<typeof criticalSectionSchema>;
 
+function unwrapCriticalSectionResult(result: unknown): Record<string, unknown> | undefined {
+  if (!result || typeof result !== "object") {
+    return undefined;
+  }
+  const directResult = result as Record<string, unknown>;
+  if ("success" in directResult) {
+    return directResult;
+  }
+  const content = directResult.content;
+  const firstContent = Array.isArray(content) ? content[0] : undefined;
+  if (!firstContent || typeof firstContent !== "object") {
+    return undefined;
+  }
+  const text = (firstContent as Record<string, unknown>).text;
+  if (typeof text !== "string") {
+    return undefined;
+  }
+  try {
+    const parsed = JSON.parse(text);
+    return parsed && typeof parsed === "object" ? parsed as Record<string, unknown> : undefined;
+  } catch (error) {
+    logger.debug(`Failed to parse nested critical-section tool response: ${error}`);
+    return undefined;
+  }
+}
+
+function formatCriticalSectionError(result: Record<string, unknown>, tool: string): string {
+  const error = result.error;
+  if (typeof error === "string") {
+    return error;
+  }
+  if (error && typeof error === "object") {
+    const structuredError = error as Record<string, unknown>;
+    const code = typeof structuredError.code === "string" ? structuredError.code : undefined;
+    const message = typeof structuredError.message === "string" ? structuredError.message : undefined;
+    if (code && message) {
+      return `${code}: ${message}`;
+    }
+    if (message) {
+      return message;
+    }
+  }
+  return typeof result.message === "string"
+    ? result.message
+    : `Tool "${tool}" returned failure status`;
+}
+
 /**
  * Critical section tool handler.
  * Coordinates multiple devices to execute steps serially at a synchronization point.
@@ -159,10 +206,11 @@ const criticalSectionHandler = async (
           { forPlan: true, targetDevice: device },
         );
 
-        // Check if tool returned failure
-        if (result?.success === false) {
-          const errorMsg =
-						result.error || `Tool "${step.tool}" returned failure status`;
+        // Internal tool calls can return an MCP envelope whose JSON payload
+        // contains the actual success/error fields.
+        const toolResult = unwrapCriticalSectionResult(result);
+        if (toolResult?.success === false) {
+          const errorMsg = formatCriticalSectionError(toolResult, step.tool);
           throw new ActionableError(errorMsg);
         }
 

--- a/src/server/criticalSectionTools.ts
+++ b/src/server/criticalSectionTools.ts
@@ -6,6 +6,7 @@ import { createJSONToolResponse, throwIfAborted } from "../utils/toolUtils";
 import { CriticalSectionCoordinator } from "./CriticalSectionCoordinator";
 import { PlanNormalizer } from "../utils/plan/PlanNormalizer";
 import { addDeviceTargetingToSchema } from "./toolSchemaHelpers";
+import { formatStructuredToolError } from "../utils/formatStructuredToolError";
 
 // Schema for steps inside critical section.
 // Every sub-step MUST declare a target `device` — there is no routing
@@ -101,24 +102,10 @@ function unwrapCriticalSectionResult(result: unknown): Record<string, unknown> |
 }
 
 function formatCriticalSectionError(result: Record<string, unknown>, tool: string): string {
-  const error = result.error;
-  if (typeof error === "string") {
-    return error;
-  }
-  if (error && typeof error === "object") {
-    const structuredError = error as Record<string, unknown>;
-    const code = typeof structuredError.code === "string" ? structuredError.code : undefined;
-    const message = typeof structuredError.message === "string" ? structuredError.message : undefined;
-    if (code && message) {
-      return `${code}: ${message}`;
-    }
-    if (message) {
-      return message;
-    }
-  }
-  return typeof result.message === "string"
-    ? result.message
-    : `Tool "${tool}" returned failure status`;
+  return formatStructuredToolError(result.error)
+    ?? (typeof result.message === "string"
+      ? result.message
+      : `Tool "${tool}" returned failure status`);
 }
 
 /**

--- a/src/server/deviceTools.ts
+++ b/src/server/deviceTools.ts
@@ -92,7 +92,8 @@ function isAlreadyStoppedDeviceError(platform: SomePlatform, error: unknown): bo
       message.includes("already shut down") ||
       message.includes("already shutdown") ||
       message.includes("not booted") ||
-      message.includes("invalid device state")
+      message.includes("invalid device state") ||
+      message.includes("current state: shutdown")
     );
   }
   return false;

--- a/src/server/deviceTools.ts
+++ b/src/server/deviceTools.ts
@@ -103,7 +103,7 @@ function createToolErrorResponse(code: string, message: string) {
     isError: true,
     content: [{
       type: "text" as const,
-      text: JSON.stringify({ success: false, error: { code, message } }),
+      text: JSON.stringify({ success: false, message, error: { code, message } }),
     }],
   };
 }
@@ -525,10 +525,10 @@ export function registerDeviceTools() {
       try {
         await deviceUtils.killDevice(args.device);
       } catch (error) {
-        devicePool?.clearIntentionalShutdown(args.device.deviceId);
         if (isAlreadyStoppedDeviceError(args.device.platform, error)) {
           alreadyStoppedMessage = `Failed to kill ${args.device.platform} device: ${error}`;
         } else {
+          devicePool?.clearIntentionalShutdown(args.device.deviceId);
           throw error;
         }
       }

--- a/src/server/deviceTools.ts
+++ b/src/server/deviceTools.ts
@@ -101,7 +101,10 @@ function isAlreadyStoppedDeviceError(platform: SomePlatform, error: unknown): bo
 function createToolErrorResponse(code: string, message: string) {
   return {
     isError: true,
-    content: [{ type: "text" as const, text: JSON.stringify({ error: { code, message } }) }],
+    content: [{
+      type: "text" as const,
+      text: JSON.stringify({ success: false, error: { code, message } }),
+    }],
   };
 }
 
@@ -501,6 +504,12 @@ export function registerDeviceTools() {
         await deviceUtils.killDevice(args.device);
       } catch (error) {
         devicePool?.clearIntentionalShutdown(args.device.deviceId);
+        if (isAlreadyStoppedDeviceError(args.device.platform, error)) {
+          return createToolErrorResponse(
+            DEVICE_ALREADY_STOPPED_ERROR_CODE,
+            `Failed to kill ${args.device.platform} device: ${error}`,
+          );
+        }
         throw error;
       }
       perf.endOperation("killProcess");
@@ -524,12 +533,6 @@ export function registerDeviceTools() {
         platform: args.device.platform
       });
     } catch (error) {
-      if (isAlreadyStoppedDeviceError(args.device.platform, error)) {
-        return createToolErrorResponse(
-          DEVICE_ALREADY_STOPPED_ERROR_CODE,
-          `Failed to kill ${args.device.platform} device: ${error}`,
-        );
-      }
       throw new ActionableError(`Failed to kill ${args.device.platform} device: ${error}`);
     }
   };

--- a/src/server/deviceTools.ts
+++ b/src/server/deviceTools.ts
@@ -80,6 +80,31 @@ export const killDeviceSchema = z.object({
   })
 });
 
+export const DEVICE_ALREADY_STOPPED_ERROR_CODE = "device_already_stopped";
+
+function isAlreadyStoppedDeviceError(platform: SomePlatform, error: unknown): boolean {
+  const message = String(error instanceof Error ? error.message : error).toLowerCase();
+  if (platform === "android") {
+    return message.includes("not running") && message.includes("emulator");
+  }
+  if (platform === "ios") {
+    return (
+      message.includes("already shut down") ||
+      message.includes("already shutdown") ||
+      message.includes("not booted") ||
+      message.includes("invalid device state")
+    );
+  }
+  return false;
+}
+
+function createToolErrorResponse(code: string, message: string) {
+  return {
+    isError: true,
+    content: [{ type: "text" as const, text: JSON.stringify({ error: { code, message } }) }],
+  };
+}
+
 // Export interfaces for type safety
 export interface StartDeviceArgs {
   platform: "android" | "ios";
@@ -499,6 +524,12 @@ export function registerDeviceTools() {
         platform: args.device.platform
       });
     } catch (error) {
+      if (isAlreadyStoppedDeviceError(args.device.platform, error)) {
+        return createToolErrorResponse(
+          DEVICE_ALREADY_STOPPED_ERROR_CODE,
+          `Failed to kill ${args.device.platform} device: ${error}`,
+        );
+      }
       throw new ActionableError(`Failed to kill ${args.device.platform} device: ${error}`);
     }
   };

--- a/src/server/deviceTools.ts
+++ b/src/server/deviceTools.ts
@@ -108,6 +108,27 @@ function createToolErrorResponse(code: string, message: string) {
   };
 }
 
+function createKillDeviceResponse(
+  args: KillDeviceArgs,
+  timing: unknown,
+  alreadyStoppedMessage?: string,
+) {
+  if (alreadyStoppedMessage !== undefined) {
+    return createToolErrorResponse(
+      DEVICE_ALREADY_STOPPED_ERROR_CODE,
+      alreadyStoppedMessage,
+    );
+  }
+
+  return createJSONToolResponse({
+    message: `${args.device.platform} '${args.device.name}' shutdown successfully`,
+    udid: args.device.deviceId,
+    name: args.device.name,
+    timing,
+    platform: args.device.platform
+  });
+}
+
 // Export interfaces for type safety
 export interface StartDeviceArgs {
   platform: "android" | "ios";
@@ -500,17 +521,16 @@ export function registerDeviceTools() {
       if (args.device.platform === "android") {
         devicePool?.markIntentionalShutdown(args.device.deviceId);
       }
+      let alreadyStoppedMessage: string | undefined;
       try {
         await deviceUtils.killDevice(args.device);
       } catch (error) {
         devicePool?.clearIntentionalShutdown(args.device.deviceId);
         if (isAlreadyStoppedDeviceError(args.device.platform, error)) {
-          return createToolErrorResponse(
-            DEVICE_ALREADY_STOPPED_ERROR_CODE,
-            `Failed to kill ${args.device.platform} device: ${error}`,
-          );
+          alreadyStoppedMessage = `Failed to kill ${args.device.platform} device: ${error}`;
+        } else {
+          throw error;
         }
-        throw error;
       }
       perf.endOperation("killProcess");
 
@@ -525,13 +545,7 @@ export function registerDeviceTools() {
       perf.end();
       const timing = perf.getTimings();
 
-      return createJSONToolResponse({
-        message: `${args.device.platform} '${args.device.name}' shutdown successfully`,
-        udid: args.device.deviceId,
-        name: args.device.name,
-        timing,
-        platform: args.device.platform
-      });
+      return createKillDeviceResponse(args, timing, alreadyStoppedMessage);
     } catch (error) {
       throw new ActionableError(`Failed to kill ${args.device.platform} device: ${error}`);
     }

--- a/src/server/deviceTools.ts
+++ b/src/server/deviceTools.ts
@@ -24,6 +24,7 @@ import { DaemonState } from "../daemon/daemonState";
 import { DeviceBootService } from "../utils/deviceBootService";
 import { getInstalledAppsCacheWriteCoordinator } from "../db/installedAppsCacheWriteCoordinator";
 import { getDbWriteBarrier } from "../db/dbWriteBarrier";
+import { isAdbMissingDeviceError } from "../utils/android-cmdline-tools/AdbDeviceHealth";
 
 // Schema definitions
 export const listDeviceImagesSchema = z.object({
@@ -82,10 +83,17 @@ export const killDeviceSchema = z.object({
 
 export const DEVICE_ALREADY_STOPPED_ERROR_CODE = "device_already_stopped";
 
-function isAlreadyStoppedDeviceError(platform: SomePlatform, error: unknown): boolean {
+function isAlreadyStoppedDeviceError(
+  platform: SomePlatform,
+  deviceId: string,
+  error: unknown,
+): boolean {
   const message = String(error instanceof Error ? error.message : error).toLowerCase();
   if (platform === "android") {
-    return message.includes("not running") && message.includes("emulator");
+    return (
+      (message.includes("not running") && message.includes("emulator")) ||
+      isAdbMissingDeviceError(error, deviceId)
+    );
   }
   if (platform === "ios") {
     return (
@@ -526,7 +534,7 @@ export function registerDeviceTools() {
       try {
         await deviceUtils.killDevice(args.device);
       } catch (error) {
-        if (isAlreadyStoppedDeviceError(args.device.platform, error)) {
+        if (isAlreadyStoppedDeviceError(args.device.platform, args.device.deviceId, error)) {
           alreadyStoppedMessage = `Failed to kill ${args.device.platform} device: ${error}`;
         } else {
           devicePool?.clearIntentionalShutdown(args.device.deviceId);

--- a/src/server/toolRegistry.ts
+++ b/src/server/toolRegistry.ts
@@ -23,6 +23,7 @@ import { isDebugModeEnabled } from "../utils/debug";
 import { defaultTimer, type Timer } from "../utils/SystemTimer";
 import { getMcpRecorder } from "./mcpRecordingManager";
 import { formatToolResultLog } from "./toolResultLog";
+import { formatStructuredToolError } from "../utils/formatStructuredToolError";
 import { flattenTopLevelUnion } from "./TopLevelUnionFlattener";
 import { advertiseBoundsForCompact } from "./compactBoundsAdvertisement";
 import { finalizeToolResponse, type ObservationArtifactWriter, type ObservationBaselineStore } from "./finalizeToolResponse";
@@ -685,13 +686,13 @@ export class DefaultAfterToolCallHandler implements AfterToolCallHandler {
       ? unwrapped.success !== false
       : true;
     const toolError = unwrapped && typeof unwrapped === "object" && "error" in unwrapped
-      ? String(unwrapped.error || "")
+      ? formatStructuredToolError(unwrapped.error) ?? String(unwrapped.error ?? "")
       : null;
     if (unwrapped && typeof unwrapped === "object" && "success" in unwrapped) {
       const resultLog = formatToolResultLog({
         toolName: name,
         success: unwrapped.success !== false,
-        error: unwrapped.error,
+        error: toolError ?? unwrapped.error,
         callerTimedOut: signal?.aborted ?? false,
       });
       logger[resultLog.level](resultLog.message);

--- a/src/utils/android-cmdline-tools/AdbClient.ts
+++ b/src/utils/android-cmdline-tools/AdbClient.ts
@@ -45,6 +45,13 @@ export class AdbCommandTimeoutError extends Error {
   }
 }
 
+export class AdbUnavailableError extends Error {
+  constructor(message: string) {
+    super(message);
+    this.name = "AdbUnavailableError";
+  }
+}
+
 // Module-level cache configuration and instances
 const moduleTimer: Timer = defaultTimer;
 let deviceListCache: TTLCache<string, BootedDevice[]> | null = null;
@@ -945,14 +952,21 @@ export class AdbClient implements AdbExecutor {
    * Get the list of connected devices
    * @returns Promise with an array of device IDs
    */
-  async getBootedAndroidDevices(options: { bypassCache?: boolean } = {}): Promise<BootedDevice[]> {
+  async getBootedAndroidDevices(
+    options: { bypassCache?: boolean; throwOnMissingAdb?: boolean } = {}
+  ): Promise<BootedDevice[]> {
     if (this.shouldSkipMissingAdbProbe()) {
+      if (options.throwOnMissingAdb) {
+        throw new AdbUnavailableError("ADB executable is unavailable");
+      }
       return [];
     }
 
     // Check cache first - TTLCache handles expiration automatically
     const cache = getDeviceListCache();
-    const cachedDevices = options.bypassCache ? undefined : cache.get("devices");
+    const cachedDevices = options.bypassCache || options.throwOnMissingAdb
+      ? undefined
+      : cache.get("devices");
     if (cachedDevices) {
       logger.debug("Getting list of connected devices (cached)");
       return cachedDevices;
@@ -970,6 +984,9 @@ export class AdbClient implements AdbExecutor {
     } catch (error) {
       if (this.isMissingExecutableError(error)) {
         this.recordMissingAdbProbe();
+        if (options.throwOnMissingAdb) {
+          throw new AdbUnavailableError(`ADB executable is unavailable: ${(error as Error).message}`);
+        }
         return [];
       }
       throw error;

--- a/src/utils/android-cmdline-tools/AdbClient.ts
+++ b/src/utils/android-cmdline-tools/AdbClient.ts
@@ -964,9 +964,7 @@ export class AdbClient implements AdbExecutor {
 
     // Check cache first - TTLCache handles expiration automatically
     const cache = getDeviceListCache();
-    const cachedDevices = options.bypassCache || options.throwOnMissingAdb
-      ? undefined
-      : cache.get("devices");
+    const cachedDevices = options.bypassCache ? undefined : cache.get("devices");
     if (cachedDevices) {
       logger.debug("Getting list of connected devices (cached)");
       return cachedDevices;

--- a/src/utils/android-cmdline-tools/AndroidEmulatorClient.ts
+++ b/src/utils/android-cmdline-tools/AndroidEmulatorClient.ts
@@ -1346,7 +1346,7 @@ export class AndroidEmulatorClient implements AndroidEmulator {
    * @returns Promise that resolves when emulator is stopped
    */
   async killDevice(device: BootedDevice): Promise<void> {
-    const runningEmulators = await this.getBootedDevices();
+    const runningEmulators = await this.getBootedDevicesChecked();
     const emulator = runningEmulators.find(emu => emu.deviceId === device.deviceId);
 
     if (!emulator || !emulator.deviceId) {

--- a/src/utils/android-cmdline-tools/AndroidEmulatorClient.ts
+++ b/src/utils/android-cmdline-tools/AndroidEmulatorClient.ts
@@ -64,7 +64,7 @@ export interface AndroidEmulator {
    * @param avdName - The AVD name to check
    * @returns Promise with boolean indicating if the AVD is running
    */
-  isAvdRunning(avdName: string): Promise<boolean>;
+  isAvdRunning(avdName: string, options?: { bypassDeviceListCache?: boolean }): Promise<boolean>;
 
   /**
    * Check if a specific AVD is currently starting (booting up)
@@ -77,7 +77,10 @@ export interface AndroidEmulator {
    * Check if any emulator is currently running
    * @returns Promise with array of running emulator info
    */
-  getBootedDevices(onlyEmulators?: boolean): Promise<BootedDevice[]>;
+  getBootedDevices(
+    onlyEmulators?: boolean,
+    options?: { bypassDeviceListCache?: boolean }
+  ): Promise<BootedDevice[]>;
 
   /**
    * Start an emulator with the specified AVD
@@ -775,8 +778,11 @@ export class AndroidEmulatorClient implements AndroidEmulator {
    * @param avdName - The AVD name to check
    * @returns Promise with boolean indicating if the AVD is running
    */
-  async isAvdRunning(avdName: string): Promise<boolean> {
-    const runningEmulators = await this.getBootedDevices();
+  async isAvdRunning(
+    avdName: string,
+    options: { bypassDeviceListCache?: boolean } = {}
+  ): Promise<boolean> {
+    const runningEmulators = await this.getBootedDevices(false, options);
     return runningEmulators.some(emulator => emulator.name === avdName);
   }
 
@@ -841,9 +847,12 @@ export class AndroidEmulatorClient implements AndroidEmulator {
    * Check if any emulator is currently running
    * @returns Promise with array of running emulator info
    */
-  async getBootedDevices(onlyEmulators: boolean = false): Promise<BootedDevice[]> {
+  async getBootedDevices(
+    onlyEmulators: boolean = false,
+    options: { bypassDeviceListCache?: boolean } = {}
+  ): Promise<BootedDevice[]> {
     try {
-      return await this.getBootedDevicesChecked(onlyEmulators);
+      return await this.getBootedDevicesChecked(onlyEmulators, options);
     } catch (error) {
       logger.debug(`[DeviceListTimeout] Failed to get running emulators: ${error}`);
       return [];
@@ -1053,7 +1062,7 @@ export class AndroidEmulatorClient implements AndroidEmulator {
 
     // Check if already running or starting
     perf.startOperation("checkAlreadyRunning");
-    const alreadyRunning = await this.isAvdRunning(avdName);
+    const alreadyRunning = await this.isAvdRunning(avdName, { bypassDeviceListCache: true });
     const alreadyStarting = !alreadyRunning && await this.isAvdStarting(avdName);
     perf.endOperation("checkAlreadyRunning");
 
@@ -1349,7 +1358,7 @@ export class AndroidEmulatorClient implements AndroidEmulator {
    * @returns Promise that resolves when emulator is stopped
    */
   async killDevice(device: BootedDevice): Promise<void> {
-    const runningEmulators = await this.getBootedDevicesChecked();
+    const runningEmulators = await this.getBootedDevicesChecked(false, { bypassDeviceListCache: true });
     const emulator = runningEmulators.find(emu => emu.deviceId === device.deviceId);
 
     if (!emulator || !emulator.deviceId) {
@@ -1539,7 +1548,7 @@ export class AndroidEmulatorClient implements AndroidEmulator {
 
           // For local emulators, check for running devices
           logger.debug(`Checking for running local emulators...`);
-          const runningEmulators = await this.getBootedDevices();
+          const runningEmulators = await this.getBootedDevices(false, { bypassDeviceListCache: true });
           logger.debug(`Device scan complete - found ${runningEmulators.length} running emulators`);
 
           if (runningEmulators.length > 0) {

--- a/src/utils/android-cmdline-tools/AndroidEmulatorClient.ts
+++ b/src/utils/android-cmdline-tools/AndroidEmulatorClient.ts
@@ -864,7 +864,10 @@ export class AndroidEmulatorClient implements AndroidEmulator {
     {
       const adb = this.adbFactory.create(null);
       perf.startOperation("adbDeviceScan");
-      const devices = await adb.getBootedAndroidDevices({ bypassCache: options.bypassDeviceListCache });
+      const devices = await adb.getBootedAndroidDevices({
+        bypassCache: options.bypassDeviceListCache,
+        throwOnMissingAdb: true,
+      });
       perf.endOperation("adbDeviceScan");
       const runningDevices: BootedDevice[] = [];
 

--- a/src/utils/android-cmdline-tools/interfaces/AdbExecutor.ts
+++ b/src/utils/android-cmdline-tools/interfaces/AdbExecutor.ts
@@ -94,7 +94,10 @@ export interface AdbExecutor {
    * Get the list of booted Android devices
    * @returns Promise with array of booted devices
    */
-  getBootedAndroidDevices(options?: { bypassCache?: boolean }): Promise<BootedDevice[]>;
+  getBootedAndroidDevices(options?: {
+    bypassCache?: boolean;
+    throwOnMissingAdb?: boolean;
+  }): Promise<BootedDevice[]>;
 
   /** Return raw ADB device states, including `offline` and `unauthorized` rows. */
   getDeviceStates?(options?: { timeoutMs?: number; signal?: AbortSignal }): Promise<AdbDeviceState[]>;

--- a/src/utils/formatStructuredToolError.ts
+++ b/src/utils/formatStructuredToolError.ts
@@ -1,0 +1,29 @@
+/**
+ * Render a tool-result `error` value into a single human-readable string.
+ *
+ * A tool failure may carry `error` as a plain string or as the structured
+ * `{ code, message }` envelope introduced for stable machine-readable codes
+ * (e.g. `device_already_stopped`). Every layer that logs, records, or surfaces
+ * such an error must flatten it the same way, or the object stringifies to
+ * `[object Object]` (issue #1678 follow-up).
+ *
+ * Returns `undefined` when `error` carries no usable text, so callers can apply
+ * their own fallback (a top-level `message`, a tool-named default, `String(err)`).
+ */
+export function formatStructuredToolError(error: unknown): string | undefined {
+  if (typeof error === "string") {
+    return error;
+  }
+  if (error && typeof error === "object") {
+    const details = error as Record<string, unknown>;
+    const code = typeof details.code === "string" ? details.code : undefined;
+    const message = typeof details.message === "string" ? details.message : undefined;
+    if (code && message) {
+      return `${code}: ${message}`;
+    }
+    if (message) {
+      return message;
+    }
+  }
+  return undefined;
+}

--- a/src/utils/plan/PlanExecutor.ts
+++ b/src/utils/plan/PlanExecutor.ts
@@ -23,19 +23,14 @@ import { Timer, defaultTimer } from "../SystemTimer";
 import type { FailureObservationSummary } from "../../models/FailureObservation";
 import { ScreenshotJobTracker } from "../ScreenshotJobTracker";
 import { isDeviceLostError } from "../../server/deviceLossOutcome";
+import { formatStructuredToolError } from "../formatStructuredToolError";
 import {
   summarizeObserveResultForFailure,
   trimObservationForStepCapture,
 } from "./summarizeFailureObservation";
 
 function formatToolError(error: unknown): string {
-  if (error && typeof error === "object") {
-    const details = error as Record<string, unknown>;
-    if (typeof details.code === "string" && typeof details.message === "string") {
-      return `${details.code}: ${details.message}`;
-    }
-  }
-  return String(error);
+  return formatStructuredToolError(error) ?? String(error);
 }
 
 type StepExecutionStatus = "completed" | "failed" | "skipped";

--- a/src/utils/plan/PlanExecutor.ts
+++ b/src/utils/plan/PlanExecutor.ts
@@ -28,6 +28,16 @@ import {
   trimObservationForStepCapture,
 } from "./summarizeFailureObservation";
 
+function formatToolError(error: unknown): string {
+  if (error && typeof error === "object") {
+    const details = error as Record<string, unknown>;
+    if (typeof details.code === "string" && typeof details.message === "string") {
+      return `${details.code}: ${details.message}`;
+    }
+  }
+  return String(error);
+}
+
 type StepExecutionStatus = "completed" | "failed" | "skipped";
 
 interface StepExecutionContext {
@@ -421,7 +431,7 @@ export class DefaultPlanExecutor implements PlanExecutor {
         "success" in checkResult &&
         checkResult.success === false
       ) {
-        const error = "error" in checkResult ? String(checkResult.error) : "Tool execution failed";
+        const error = "error" in checkResult ? formatToolError(checkResult.error) : "Tool execution failed";
         if (step.optional) {
           return {
             status: "skipped",

--- a/test/server/criticalSectionTools.test.ts
+++ b/test/server/criticalSectionTools.test.ts
@@ -587,6 +587,44 @@ describe("criticalSection tool", () => {
     expect(executionLog).toEqual(["step1", "failure"]);
   });
 
+  test("fails when a nested tool returns a structured MCP error envelope", async () => {
+    const tool = ToolRegistry.getToolForPlan("criticalSection");
+    expect(tool).toBeDefined();
+
+    const fakeDevice: BootedDevice = {
+      platform: "android",
+      deviceId: "test-device-structured-failure",
+      name: "Test Device Structured Failure",
+    };
+
+    ToolRegistry.register("mockStructuredFailure", "structured failure", z.object({}), async () => ({
+      isError: true,
+      content: [{
+        type: "text" as const,
+        text: JSON.stringify({
+          success: false,
+          message: "Failed to kill android device: Emulator is not running",
+          error: {
+            code: "device_already_stopped",
+            message: "Failed to kill android device: Emulator is not running",
+          },
+        }),
+      }],
+    }));
+
+    CriticalSectionCoordinator.getInstance().registerExpectedDevices("structured-failure-lock", 1);
+
+    await expect(
+      tool!.deviceAwareHandler!(fakeDevice, {
+        lock: "structured-failure-lock",
+        deviceCount: 1,
+        steps: [{ tool: "mockStructuredFailure", params: {} }],
+      }, undefined, undefined)
+    ).rejects.toThrow(
+      /device_already_stopped: Failed to kill android device: Emulator is not running/
+    );
+  });
+
   test("wraps a step failure with the documented device + step context", async () => {
     const tool = ToolRegistry.getToolForPlan("criticalSection");
     expect(tool).toBeDefined();

--- a/test/server/deviceTools.killDevice.test.ts
+++ b/test/server/deviceTools.killDevice.test.ts
@@ -235,10 +235,39 @@ describe("killDevice handler", () => {
 
     expect(response.isError).toBe(true);
     expect(JSON.parse(response.content[0].text)).toEqual({
+      success: false,
       error: {
         code: "device_already_stopped",
         message: expect.stringContaining(message),
       },
     });
+  });
+
+  test("keeps recording-list failures as actionable errors", async () => {
+    await setVideoRecordingManagerDependencies({
+      videoRecorderService: {} as never,
+      recordingRepository: {
+        listRecordings: async () => {
+          throw new Error("Emulator 'forge-ivory-crown' is not running");
+        },
+      } as never,
+      configRepository: {} as never,
+      highlightClient: {} as never,
+      timer: new FakeTimer(),
+      now: () => new Date(0),
+    });
+
+    const tool = ToolRegistry.getTool("killDevice");
+    if (!tool) {
+      throw new Error("killDevice not registered");
+    }
+
+    await expect(tool.handler({
+      device: {
+        name: "Pixel 8",
+        platform: "android",
+        deviceId: "emulator-5554",
+      },
+    })).rejects.toThrow("Failed to kill android device");
   });
 });

--- a/test/server/deviceTools.killDevice.test.ts
+++ b/test/server/deviceTools.killDevice.test.ts
@@ -213,8 +213,20 @@ describe("killDevice handler", () => {
   ] as const)("returns a structured terminal error for an already-stopped %s device", async (platform, message) => {
     let cleanupCalled = false;
     let notifyCalled = false;
+    let markedIntentionalShutdown = 0;
+    let clearedIntentionalShutdown = 0;
     const stoppedManager = new AlreadyStoppedKillDeviceManager(message);
     manager = stoppedManager;
+    if (platform === "android") {
+      DaemonState.getInstance().initialize({} as SessionManager, {
+        markIntentionalShutdown: () => {
+          markedIntentionalShutdown++;
+        },
+        clearIntentionalShutdown: () => {
+          clearedIntentionalShutdown++;
+        },
+      } as never);
+    }
     setDeviceToolsDependencies({
       deviceManagerFactory: () => stoppedManager,
       notifyResourcesChanged: async () => {
@@ -242,6 +254,7 @@ describe("killDevice handler", () => {
     expect(response.isError).toBe(true);
     expect(JSON.parse(response.content[0].text)).toEqual({
       success: false,
+      message: expect.stringContaining(message),
       error: {
         code: "device_already_stopped",
         message: expect.stringContaining(message),
@@ -249,6 +262,10 @@ describe("killDevice handler", () => {
     });
     expect(cleanupCalled).toBe(true);
     expect(notifyCalled).toBe(true);
+    if (platform === "android") {
+      expect(markedIntentionalShutdown).toBe(1);
+      expect(clearedIntentionalShutdown).toBe(0);
+    }
   });
 
   test("keeps recording-list failures as actionable errors", async () => {

--- a/test/server/deviceTools.killDevice.test.ts
+++ b/test/server/deviceTools.killDevice.test.ts
@@ -211,13 +211,19 @@ describe("killDevice handler", () => {
     ["android", "Emulator 'forge-ivory-crown' is not running"],
     ["ios", "Unable to shutdown device: device is already shut down"],
   ] as const)("returns a structured terminal error for an already-stopped %s device", async (platform, message) => {
+    let cleanupCalled = false;
+    let notifyCalled = false;
     const stoppedManager = new AlreadyStoppedKillDeviceManager(message);
     manager = stoppedManager;
     setDeviceToolsDependencies({
       deviceManagerFactory: () => stoppedManager,
-      notifyResourcesChanged: async () => {},
+      notifyResourcesChanged: async () => {
+        notifyCalled = true;
+      },
       ensureCtrlProxyReady: async () => {},
-      clearInstalledAppsForDevice: async () => {},
+      clearInstalledAppsForDevice: async () => {
+        cleanupCalled = true;
+      },
     });
     registerDeviceTools();
 
@@ -241,6 +247,8 @@ describe("killDevice handler", () => {
         message: expect.stringContaining(message),
       },
     });
+    expect(cleanupCalled).toBe(true);
+    expect(notifyCalled).toBe(true);
   });
 
   test("keeps recording-list failures as actionable errors", async () => {

--- a/test/server/deviceTools.killDevice.test.ts
+++ b/test/server/deviceTools.killDevice.test.ts
@@ -48,6 +48,16 @@ class SuccessfulKillDeviceManager extends FailingKillDeviceManager {
   override async killDevice(): Promise<void> {}
 }
 
+class AlreadyStoppedKillDeviceManager extends FailingKillDeviceManager {
+  constructor(private readonly message: string) {
+    super();
+  }
+
+  override async killDevice(): Promise<void> {
+    throw new Error(this.message);
+  }
+}
+
 class FakeDeviceSessionRepository extends DeviceSessionRepository {
   override async upsertActiveSession(): Promise<void> {}
   override async markReleased(): Promise<void> {}
@@ -195,5 +205,40 @@ describe("killDevice handler", () => {
 
     expect(successfulManager.getCallCount("startDevice")).toBe(1);
     expect(pool.getDevice("emulator-5554")).toBeNull();
+  });
+
+  test.each([
+    ["android", "Emulator 'forge-ivory-crown' is not running"],
+    ["ios", "Unable to shutdown device: device is already shut down"],
+  ] as const)("returns a structured terminal error for an already-stopped %s device", async (platform, message) => {
+    const stoppedManager = new AlreadyStoppedKillDeviceManager(message);
+    manager = stoppedManager;
+    setDeviceToolsDependencies({
+      deviceManagerFactory: () => stoppedManager,
+      notifyResourcesChanged: async () => {},
+      ensureCtrlProxyReady: async () => {},
+      clearInstalledAppsForDevice: async () => {},
+    });
+    registerDeviceTools();
+
+    const tool = ToolRegistry.getTool("killDevice");
+    if (!tool) {
+      throw new Error("killDevice not registered");
+    }
+    const response = await tool.handler({
+      device: {
+        name: platform === "android" ? "Pixel 8" : "iPhone 16",
+        platform,
+        deviceId: platform === "android" ? "emulator-5554" : "IOS-UDID",
+      },
+    });
+
+    expect(response.isError).toBe(true);
+    expect(JSON.parse(response.content[0].text)).toEqual({
+      error: {
+        code: "device_already_stopped",
+        message: expect.stringContaining(message),
+      },
+    });
   });
 });

--- a/test/server/deviceTools.killDevice.test.ts
+++ b/test/server/deviceTools.killDevice.test.ts
@@ -209,6 +209,7 @@ describe("killDevice handler", () => {
 
   test.each([
     ["android", "Emulator 'forge-ivory-crown' is not running"],
+    ["android", "adb: device 'emulator-5554' not found"],
     ["ios", "Unable to shutdown device: device is already shut down"],
   ] as const)("returns a structured terminal error for an already-stopped %s device", async (platform, message) => {
     let cleanupCalled = false;

--- a/test/server/toolRegistry.pipeline.test.ts
+++ b/test/server/toolRegistry.pipeline.test.ts
@@ -458,4 +458,56 @@ describe("DefaultAfterToolCallHandler observation artifact config path", () => {
       (TelemetryRecorder as any).getInstance = originalGetInstance;
     }
   });
+
+  test("records a structured tool error as its code:message, not [object Object]", async () => {
+    const telemetryEvents: Array<{ success: boolean; error: unknown }> = [];
+    const originalGetInstance = (TelemetryRecorder as any).getInstance;
+    (TelemetryRecorder as any).getInstance = () => ({
+      recordToolCallEvent(event: { success: boolean; error: unknown }) {
+        telemetryEvents.push(event);
+      },
+    });
+    const timer = new FakeTimer();
+    timer.setCurrentTime(25);
+
+    try {
+      const handler = new DefaultAfterToolCallHandler();
+      // The already-stopped killDevice envelope (issue #1678): the failure code
+      // and message live inside a nested `error` object.
+      const response = {
+        isError: true,
+        content: [{
+          type: "text" as const,
+          text: JSON.stringify({
+            success: false,
+            message: "Failed to kill android device: Emulator is not running",
+            error: {
+              code: "device_already_stopped",
+              message: "Failed to kill android device: Emulator is not running",
+            },
+          }),
+        }],
+      };
+
+      await handler.handle({
+        name: "killDevice",
+        args: {},
+        device: undefined,
+        internalCall: false,
+        response,
+        sessionUuid: "session-1",
+        shouldResolveDevice: false,
+        timer,
+        toolStartMs: 20,
+      });
+
+      expect(telemetryEvents).toHaveLength(1);
+      expect(telemetryEvents[0].success).toBe(false);
+      expect(telemetryEvents[0].error).toBe(
+        "device_already_stopped: Failed to kill android device: Emulator is not running"
+      );
+    } finally {
+      (TelemetryRecorder as any).getInstance = originalGetInstance;
+    }
+  });
 });

--- a/test/utils/android-cmdline-tools/AdbClient-getBootedAndroidDevices.test.ts
+++ b/test/utils/android-cmdline-tools/AdbClient-getBootedAndroidDevices.test.ts
@@ -1,7 +1,11 @@
 import { afterEach, beforeEach, describe, expect, test } from "bun:test";
 import { EventEmitter } from "events";
 import { PassThrough } from "stream";
-import { AdbClient, resetAdbClientCaches } from "../../../src/utils/android-cmdline-tools/AdbClient";
+import {
+  AdbClient,
+  AdbUnavailableError,
+  resetAdbClientCaches,
+} from "../../../src/utils/android-cmdline-tools/AdbClient";
 import type { ExecResult } from "../../../src/models";
 import { isAdbMissingDeviceError } from "../../../src/utils/android-cmdline-tools/AdbDeviceHealth";
 
@@ -87,6 +91,30 @@ describe("AdbClient.getBootedAndroidDevices", () => {
     expect(await adb.getBootedAndroidDevices()).toMatchObject([{ transportId: "1" }]);
     expect(await adb.getBootedAndroidDevices({ bypassCache: true })).toMatchObject([{ transportId: "2" }]);
     expect(calls).toBe(2);
+  });
+
+  test("can rethrow when adb is unavailable for strict discovery", async () => {
+    const adb = new AdbClient(null, async () => {
+      throw new Error("spawn adb ENOENT");
+    });
+
+    await expect(
+      adb.getBootedAndroidDevices({ throwOnMissingAdb: true })
+    ).rejects.toBeInstanceOf(AdbUnavailableError);
+  });
+
+  test("bypasses the device-list cache for strict discovery", async () => {
+    const availableAdb = new AdbClient(null, async () => createExecResult(
+      "List of devices attached\n"
+    ));
+    await expect(availableAdb.getBootedAndroidDevices()).resolves.toEqual([]);
+
+    const unavailableAdb = new AdbClient(null, async () => {
+      throw new Error("spawn adb ENOENT");
+    });
+    await expect(
+      unavailableAdb.getBootedAndroidDevices({ throwOnMissingAdb: true })
+    ).rejects.toBeInstanceOf(AdbUnavailableError);
   });
 
   test("does not retry commands when adb reports the target serial is gone", async () => {

--- a/test/utils/android-cmdline-tools/AdbClient-getBootedAndroidDevices.test.ts
+++ b/test/utils/android-cmdline-tools/AdbClient-getBootedAndroidDevices.test.ts
@@ -103,17 +103,27 @@ describe("AdbClient.getBootedAndroidDevices", () => {
     ).rejects.toBeInstanceOf(AdbUnavailableError);
   });
 
-  test("bypasses the device-list cache for strict discovery", async () => {
-    const availableAdb = new AdbClient(null, async () => createExecResult(
-      "List of devices attached\n"
-    ));
-    await expect(availableAdb.getBootedAndroidDevices()).resolves.toEqual([]);
+  test("serves the device-list cache for strict discovery unless the caller bypasses it", async () => {
+    const availableAdb = new AdbClient(null, async () => createExecResult([
+      "List of devices attached",
+      "emulator-5554\tdevice",
+      "",
+    ].join("\n")));
+    await expect(availableAdb.getBootedAndroidDevices()).resolves.toMatchObject([
+      { deviceId: "emulator-5554" },
+    ]);
 
+    // Strict discovery only changes how a missing adb is reported; hot read
+    // paths keep the shared cache. Boot/terminate flows opt into fresh data
+    // with bypassCache.
     const unavailableAdb = new AdbClient(null, async () => {
       throw new Error("spawn adb ENOENT");
     });
     await expect(
       unavailableAdb.getBootedAndroidDevices({ throwOnMissingAdb: true })
+    ).resolves.toMatchObject([{ deviceId: "emulator-5554" }]);
+    await expect(
+      unavailableAdb.getBootedAndroidDevices({ throwOnMissingAdb: true, bypassCache: true })
     ).rejects.toBeInstanceOf(AdbUnavailableError);
   });
 

--- a/test/utils/android-cmdline-tools/AndroidEmulatorClient-getBootedDevices.test.ts
+++ b/test/utils/android-cmdline-tools/AndroidEmulatorClient-getBootedDevices.test.ts
@@ -11,6 +11,17 @@ class FailingDiscoveryAdbExecutor extends FakeAdbExecutor {
   }
 }
 
+class RecordingAdbExecutor extends FakeAdbExecutor {
+  lastDiscoveryOptions: { bypassCache?: boolean; throwOnMissingAdb?: boolean } | undefined;
+
+  override async getBootedAndroidDevices(
+    options?: { bypassCache?: boolean; throwOnMissingAdb?: boolean }
+  ): Promise<BootedDevice[]> {
+    this.lastDiscoveryOptions = options;
+    return super.getBootedAndroidDevices();
+  }
+}
+
 describe("AndroidEmulatorClient.getBootedDevicesChecked", () => {
   test("preserves transport identity when AVD-name lookup fails", async () => {
     const adb = new FakeAdbExecutor();
@@ -30,6 +41,30 @@ describe("AndroidEmulatorClient.getBootedDevicesChecked", () => {
       transportId: "42",
       source: "local",
     }]);
+  });
+
+  test("bypasses the device-list cache only when terminating", async () => {
+    const adb = new RecordingAdbExecutor();
+    adb.setDevices([{
+      name: "Pixel 8",
+      platform: "android",
+      deviceId: "emulator-5554",
+    } satisfies BootedDevice]);
+    const client = new AndroidEmulatorClient(null, null, new FakeTimer(), new FakeAdbClientFactory(adb));
+
+    await client.getBootedDevices();
+    expect(adb.lastDiscoveryOptions).toMatchObject({ throwOnMissingAdb: true });
+    expect(adb.lastDiscoveryOptions?.bypassCache).toBeFalsy();
+
+    await client.killDevice({
+      name: "Pixel 8",
+      platform: "android",
+      deviceId: "emulator-5554",
+    });
+    expect(adb.lastDiscoveryOptions).toMatchObject({
+      bypassCache: true,
+      throwOnMissingAdb: true,
+    });
   });
 
   test("propagates discovery failures during shutdown", async () => {

--- a/test/utils/android-cmdline-tools/AndroidEmulatorClient-getBootedDevices.test.ts
+++ b/test/utils/android-cmdline-tools/AndroidEmulatorClient-getBootedDevices.test.ts
@@ -5,6 +5,12 @@ import { FakeAdbClientFactory } from "../../fakes/FakeAdbClientFactory";
 import { FakeAdbExecutor } from "../../fakes/FakeAdbExecutor";
 import { FakeTimer } from "../../fakes/FakeTimer";
 
+class FailingDiscoveryAdbExecutor extends FakeAdbExecutor {
+  override async getBootedAndroidDevices(): Promise<BootedDevice[]> {
+    throw new Error("adb server unavailable");
+  }
+}
+
 describe("AndroidEmulatorClient.getBootedDevicesChecked", () => {
   test("preserves transport identity when AVD-name lookup fails", async () => {
     const adb = new FakeAdbExecutor();
@@ -24,5 +30,16 @@ describe("AndroidEmulatorClient.getBootedDevicesChecked", () => {
       transportId: "42",
       source: "local",
     }]);
+  });
+
+  test("propagates discovery failures during shutdown", async () => {
+    const adb = new FailingDiscoveryAdbExecutor();
+    const client = new AndroidEmulatorClient(null, null, new FakeTimer(), new FakeAdbClientFactory(adb));
+
+    await expect(client.killDevice({
+      name: "Pixel 8",
+      platform: "android",
+      deviceId: "emulator-5554",
+    })).rejects.toThrow("adb server unavailable");
   });
 });

--- a/test/utils/formatStructuredToolError.test.ts
+++ b/test/utils/formatStructuredToolError.test.ts
@@ -1,0 +1,29 @@
+import { describe, expect, test } from "bun:test";
+import { formatStructuredToolError } from "../../src/utils/formatStructuredToolError";
+
+describe("formatStructuredToolError", () => {
+  test("renders a structured {code, message} error as 'code: message'", () => {
+    expect(formatStructuredToolError({
+      code: "device_already_stopped",
+      message: "Emulator is not running",
+    })).toBe("device_already_stopped: Emulator is not running");
+  });
+
+  test("returns a plain string error unchanged", () => {
+    expect(formatStructuredToolError("boom")).toBe("boom");
+  });
+
+  test("falls back to message-only when code is absent", () => {
+    expect(formatStructuredToolError({ message: "just a message" })).toBe("just a message");
+  });
+
+  test("returns undefined for a shapeless object so callers can pick their own fallback", () => {
+    expect(formatStructuredToolError({ detail: 42 })).toBeUndefined();
+  });
+
+  test("returns undefined for null/undefined/non-string primitives", () => {
+    expect(formatStructuredToolError(null)).toBeUndefined();
+    expect(formatStructuredToolError(undefined)).toBeUndefined();
+    expect(formatStructuredToolError(42)).toBeUndefined();
+  });
+});

--- a/test/utils/planExecutorCatchLogging.test.ts
+++ b/test/utils/planExecutorCatchLogging.test.ts
@@ -92,6 +92,7 @@ describe("PlanExecutor catch logging", () => {
     expect(result.failedStep).toMatchObject({
       stepIndex: 0,
       tool: "structuredFailureTool",
+      error: "device_already_stopped: The device is already stopped",
     });
   });
 });

--- a/test/utils/planExecutorCatchLogging.test.ts
+++ b/test/utils/planExecutorCatchLogging.test.ts
@@ -16,6 +16,27 @@ function registerThrowingTool(name: string): void {
   );
 }
 
+function registerStructuredFailureTool(name: string): void {
+  ToolRegistry.register(
+    name,
+    "Returns a structured failure for plan execution tests",
+    z.object({}),
+    async () => ({
+      isError: true,
+      content: [{
+        type: "text" as const,
+        text: JSON.stringify({
+          success: false,
+          error: {
+            code: "device_already_stopped",
+            message: "The device is already stopped",
+          },
+        }),
+      }],
+    })
+  );
+}
+
 afterEach(() => {
   ToolRegistry.clearTools();
 });
@@ -55,5 +76,22 @@ describe("PlanExecutor catch logging", () => {
       message: "[PLAN_STEP_1] step requiredThrowingTool threw; returning failed status",
       args: [expect.objectContaining({ message: "requiredThrowingTool boom" })],
     }));
+  });
+
+  test("returns a failed status for a structured failure envelope", async () => {
+    registerStructuredFailureTool("structuredFailureTool");
+    const executor = new DefaultPlanExecutor(undefined, new FakeLogger());
+    const plan: Plan = {
+      name: "structured failure",
+      steps: [{ tool: "structuredFailureTool", params: {} }],
+    };
+
+    const result = await executor.executePlan(plan, 0);
+
+    expect(result.success).toBe(false);
+    expect(result.failedStep).toMatchObject({
+      stepIndex: 0,
+      tool: "structuredFailureTool",
+    });
   });
 });


### PR DESCRIPTION
## Purpose
Expose a stable machine-readable AutoMobile error for idempotent device shutdowns.

## Changes
- Return `device_already_stopped` as an MCP tool error for already-stopped Android and iOS devices.
- Preserve all other killDevice failures as actionable errors.
- Add representative Android and iOS wire-shape coverage.

## Validation
- `bun test --isolate test/server/deviceTools.killDevice.test.ts`
