### PR TITLE
feat(daemon): device-scope the test-run resource (#4715)

### DIFF
--- a/scripts/typecheck-baseline.txt
+++ b/scripts/typecheck-baseline.txt
@@ -179,7 +179,6 @@ src/server/observeTools.ts: error TS2322: Type 'TimingData' is not assignable to
 src/server/observeTools.ts: error TS2339: Property 'sessionUuid' does not exist on type 'IdentifyInteractionsOptions'.
 src/server/observeTools.ts: error TS2339: Property 'sessionUuid' does not exist on type 'IdentifyInteractionsOptions'.
 src/server/observeTools.ts: error TS2488: Type 'TimingData' must have a '[Symbol.iterator]()' method that returns an iterator.
-src/server/testRunResources.ts: error TS2345: Argument of type 'string' is not assignable to parameter of type '"latestOnly" | "limit" | "lookbackDays" | "orderDirection" | "testClass" | "testMethod"'.
 src/server/testTimingResources.ts: error TS2345: Argument of type 'string' is not assignable to parameter of type '"appVersion" | "deviceId" | "deviceName" | "devicePlatform" | "deviceType" | "gitCommit" | "jdkVersion" | "limit" | "sessionUuid" | "targetSdk" | "testClass" | "testMethod" | ... 6 more ... | "orderDirection"'.
 src/utils/Backoff.ts: error TS2322: Type 'BackoffPolicy | readonly number[]' is not assignable to type 'BackoffPolicy'.
 src/utils/DeepLinkManager.ts: error TS2339: Property 'toString' does not exist on type 'never'.
@@ -321,7 +320,6 @@ src/utils/plan/PlanSchemaValidator.ts: error TS1343: The 'import.meta' meta-prop
 # swap-fp: 74,75,76,77,77 :: src/features/action/SetUIState.ts: error TS2554: Expected 0-1 arguments, but got 5.
 # swap-fp: 8,8 :: src/db/migrations/2026_01_30_000_performance_live_metrics.ts: error TS2339: Property 'raw' does not exist on type 'Kysely<unknown>'.
 # swap-fp: 85 :: src/daemon/socketServer.ts: error TS2554: Expected 1-2 arguments, but got 3.
-# swap-fp: 88 :: src/server/testRunResources.ts: error TS2345: Argument of type 'string' is not assignable to parameter of type '"latestOnly" | "limit" | "lookbackDays" | "orderDirection" | "testClass" | "testMethod"'.
 # swap-fp: 9 :: src/daemon/manager.ts: error TS18048: 'signal' is possibly 'undefined'.
 # swap-fp: 9 :: src/features/action/LaunchApp.ts: error TS2322: Type 'boolean | null' is not assignable to type 'boolean'.
 # swap-fp: 9 :: src/features/navigation/NavigationGraphManager.ts: error TS2345: Argument of type 'number | undefined' is not assignable to parameter of type 'number'.

--- a/src/db/testExecutionRepository.ts
+++ b/src/db/testExecutionRepository.ts
@@ -120,6 +120,7 @@ export interface TestRun {
 export interface TestRunQueryOptions {
   testClass?: string;
   testMethod?: string;
+  deviceId?: string;
   lookbackDays?: number;
   limit?: number;
   orderDirection?: "asc" | "desc";
@@ -255,6 +256,10 @@ export class TestExecutionRepository {
 
     if (options.testMethod) {
       query = query.where("test_method", "=", options.testMethod);
+    }
+
+    if (options.deviceId) {
+      query = query.where("device_id", "=", options.deviceId);
     }
 
     const orderDirection = options.orderDirection ?? "desc";

--- a/src/server/testRunResources.ts
+++ b/src/server/testRunResources.ts
@@ -12,20 +12,22 @@ const TEST_RUN_LIMIT_MAX = 500;
 const TEST_RUN_LOOKBACK_DAYS_DEFAULT = 30;
 
 const TEST_RUN_QUERY_TEMPLATE = `${TEST_RUN_RESOURCE_URIS.BASE}?{params}`;
-const TEST_RUN_QUERY_PARAM_KEYS = new Set([
+const TEST_RUN_QUERY_PARAM_KEYS = new Set<string>([
   "lookbackDays",
   "limit",
   "testClass",
   "testMethod",
+  "deviceId",
   "orderDirection",
   "latestOnly",
-] as const);
+]);
 
 interface TestRunQueryArgs {
   lookbackDays?: number;
   limit?: number;
   testClass?: string;
   testMethod?: string;
+  deviceId?: string;
   orderDirection?: "asc" | "desc";
   latestOnly?: boolean;
 }
@@ -74,7 +76,7 @@ interface TestRunResponse {
   filters: Record<string, unknown>;
 }
 
-function parseTestRunParams(params: Record<string, string>): TestRunQueryArgs {
+export function parseTestRunParams(params: Record<string, string>): TestRunQueryArgs {
   const unknownKeys = Object.keys(params).filter(key => !TEST_RUN_QUERY_PARAM_KEYS.has(key));
   if (unknownKeys.length > 0) {
     throw new Error(`Unknown query parameters: ${unknownKeys.join(", ")}`);
@@ -85,12 +87,13 @@ function parseTestRunParams(params: Record<string, string>): TestRunQueryArgs {
     limit: optionalInteger(params.limit, "limit", { min: 1, max: TEST_RUN_LIMIT_MAX }),
     testClass: optionalString(params.testClass),
     testMethod: optionalString(params.testMethod),
+    deviceId: optionalString(params.deviceId),
     orderDirection: optionalEnum(params.orderDirection, "orderDirection", ["asc", "desc"]),
     latestOnly: optionalBoolean(params.latestOnly, "latestOnly"),
   };
 }
 
-function buildTestRunUri(options: TestRunQueryArgs): string {
+export function buildTestRunUri(options: TestRunQueryArgs): string {
   const query = new URLSearchParams();
   if (options.lookbackDays !== undefined) {
     query.set("lookbackDays", options.lookbackDays.toString());
@@ -103,6 +106,9 @@ function buildTestRunUri(options: TestRunQueryArgs): string {
   }
   if (options.testMethod) {
     query.set("testMethod", options.testMethod);
+  }
+  if (options.deviceId) {
+    query.set("deviceId", options.deviceId);
   }
   if (options.orderDirection) {
     query.set("orderDirection", options.orderDirection);
@@ -150,9 +156,25 @@ export function convertToResponseEntry(run: TestRun, sampleSize: number): TestRu
   };
 }
 
-async function buildTestRunResponse(args: TestRunQueryArgs): Promise<TestRunResponse> {
-  const repository = new TestExecutionRepository();
+/** Echo the active filters back to the client, omitting unset dimensions. */
+function buildTestRunFilters(args: TestRunQueryArgs): Record<string, unknown> {
+  const filters: Record<string, unknown> = {};
+  if (args.testClass) {
+    filters.testClass = args.testClass;
+  }
+  if (args.testMethod) {
+    filters.testMethod = args.testMethod;
+  }
+  if (args.deviceId) {
+    filters.deviceId = args.deviceId;
+  }
+  return filters;
+}
 
+export async function buildTestRunResponse(
+  args: TestRunQueryArgs,
+  repository: TestExecutionRepository = new TestExecutionRepository()
+): Promise<TestRunResponse> {
   const lookbackDays = args.lookbackDays ?? TEST_RUN_LOOKBACK_DAYS_DEFAULT;
   const limit = args.limit ?? TEST_RUN_LIMIT_DEFAULT;
   const orderDirection = args.orderDirection ?? "desc";
@@ -164,6 +186,7 @@ async function buildTestRunResponse(args: TestRunQueryArgs): Promise<TestRunResp
     limit: latestOnly ? limit * 5 : limit,
     testClass: args.testClass,
     testMethod: args.testMethod,
+    deviceId: args.deviceId,
     orderDirection,
   };
 
@@ -198,13 +221,7 @@ async function buildTestRunResponse(args: TestRunQueryArgs): Promise<TestRunResp
     return convertToResponseEntry(run, sampleSize);
   });
 
-  const filters: Record<string, unknown> = {};
-  if (args.testClass) {
-    filters.testClass = args.testClass;
-  }
-  if (args.testMethod) {
-    filters.testMethod = args.testMethod;
-  }
+  const filters = buildTestRunFilters(args);
 
   return {
     testRuns,

--- a/test/db/testExecutionRepository.test.ts
+++ b/test/db/testExecutionRepository.test.ts
@@ -384,6 +384,23 @@ describe("TestExecutionRepository", () => {
       expect(runs[0].testClass).toBe("LoginTest");
       expect(runs[0].testMethod).toBe("testLogin");
     });
+
+    test("filters by deviceId", async () => {
+      await repo.recordExecution(makeExecution({ deviceId: "device-a" }));
+      await repo.recordExecution(makeExecution({ deviceId: "device-b" }));
+
+      const runs = await repo.getTestRuns({ deviceId: "device-a" });
+      expect(runs).toHaveLength(1);
+      expect(runs[0].deviceId).toBe("device-a");
+    });
+
+    test("returns runs across all devices when deviceId is omitted", async () => {
+      await repo.recordExecution(makeExecution({ deviceId: "device-a" }));
+      await repo.recordExecution(makeExecution({ deviceId: "device-b" }));
+
+      const runs = await repo.getTestRuns();
+      expect(runs).toHaveLength(2);
+    });
   });
 
   describe("getTestRuns with lookbackDays", () => {

--- a/test/server/testRunResources.test.ts
+++ b/test/server/testRunResources.test.ts
@@ -1,11 +1,13 @@
-import { describe, test, expect, beforeAll, afterAll, beforeEach } from "bun:test";
-import { convertToResponseEntry } from "../../src/server/testRunResources";
-import type { TestRun } from "../../src/db/testExecutionRepository";
+import { describe, test, expect, beforeAll, afterAll, beforeEach, afterEach } from "bun:test";
+import { convertToResponseEntry, buildTestRunResponse, parseTestRunParams, buildTestRunUri } from "../../src/server/testRunResources";
+import { TestExecutionRepository, type TestRun } from "../../src/db/testExecutionRepository";
 import { Database as BunDatabase } from "bun:sqlite";
 import { Kysely } from "kysely";
 import { BunSqliteDialect } from "../../src/db/bunSqliteDialect";
 import type { Database as DatabaseSchema, NewTestExecution, NewTestExecutionStep, NewTestExecutionScreen } from "../../src/db/types";
 import { runMigrations } from "../../src/db/migrator";
+import { createTestDatabase } from "../db/testDbHelper";
+import { FakeTimer } from "../fakes/FakeTimer";
 
 describe("testRunResources", () => {
   test("exposes step details in test run resource entries", () => {
@@ -48,6 +50,75 @@ describe("testRunResources", () => {
       trackIndex: 0,
       optional: true,
     });
+  });
+});
+
+describe("testRunResources deviceId scoping", () => {
+  let db: Kysely<DatabaseSchema>;
+  let repo: TestExecutionRepository;
+
+  beforeEach(async () => {
+    db = await createTestDatabase();
+    repo = new TestExecutionRepository(new FakeTimer(), db);
+  });
+
+  afterEach(async () => {
+    await db.destroy();
+  });
+
+  test("buildTestRunResponse filters runs to the requested deviceId", async () => {
+    await repo.recordExecution({
+      testClass: "com.example.LoginTest",
+      testMethod: "testLogin",
+      durationMs: 100,
+      status: "passed",
+      timestamp: 1000,
+      deviceId: "device-a",
+    });
+    await repo.recordExecution({
+      testClass: "com.example.HomeTest",
+      testMethod: "testHome",
+      durationMs: 100,
+      status: "passed",
+      timestamp: 2000,
+      deviceId: "device-b",
+    });
+
+    const response = await buildTestRunResponse({ deviceId: "device-a" }, repo);
+
+    expect(response.testRuns).toHaveLength(1);
+    expect(response.testRuns[0].deviceId).toBe("device-a");
+    expect(response.filters.deviceId).toBe("device-a");
+  });
+
+  test("buildTestRunResponse returns all devices when deviceId is omitted", async () => {
+    await repo.recordExecution({
+      testClass: "com.example.LoginTest",
+      testMethod: "testLogin",
+      durationMs: 100,
+      status: "passed",
+      timestamp: 1000,
+      deviceId: "device-a",
+    });
+    await repo.recordExecution({
+      testClass: "com.example.HomeTest",
+      testMethod: "testHome",
+      durationMs: 100,
+      status: "passed",
+      timestamp: 2000,
+      deviceId: "device-b",
+    });
+
+    const response = await buildTestRunResponse({}, repo);
+
+    expect(response.testRuns).toHaveLength(2);
+    expect(response.filters.deviceId).toBeUndefined();
+  });
+
+  test("parseTestRunParams accepts deviceId and buildTestRunUri round-trips it", () => {
+    const args = parseTestRunParams({ deviceId: "emulator-5554" });
+    expect(args.deviceId).toBe("emulator-5554");
+    expect(buildTestRunUri(args)).toContain("deviceId=emulator-5554");
   });
 });
 


### PR DESCRIPTION
## Summary

Adds a `deviceId` dimension to the test-run daemon resource so a per-device
workspace pane can fetch its own device's runs instead of the daemon's single
active device. This completes the last missing piece of the **deviceId-scoped
daemon resources** that issue #4715 tracks.

`#4715` is a tracking issue for per-device facet infrastructure. Most of it
already shipped through other PRs:

- **Work item 1** (`ObservationStream` interface + `FakeObservationStream`):
  done in #4781.
- **Work item 3** (Network facet, net-new): done in #4834 / #4840 / #4865.
- **Work item 2** (per-device daemon resources): Navigation (app-sourced facet
  #4912), Layout (per-device streams #4867), and Performance
  (`performanceResources` already had `deviceId`) all landed. The **Test-run
  resource was the only remaining gap** — `TestRun` already carried a
  `deviceId`, but there was no way to filter by it.

Failures is intentionally left cross-device (the issue itself notes it is
"cross-device by design"), and wiring the desktop **Test facet** UI onto this
new query param is a separate consumer task — see Follow-ups.

## Changes

- `TestExecutionRepository`: `TestRunQueryOptions` gains `deviceId`, and
  `getTestRuns` applies a `device_id` filter. This mirrors the existing
  `getTimingStats` deviceId filter exactly — **no schema migration** (the
  `device_id` column already exists on `test_executions`).
- `testRunResources`: `automobile:test-runs?deviceId=` is now an accepted query
  parameter — parsed, round-tripped through the URI builder, threaded into the
  repository query, and echoed back in the response `filters`. Additive and
  backward-compatible; not an MCP tool-schema change.
- `buildTestRunResponse` is now exported and repository-injectable (mirroring
  `performanceData.buildPerformanceAuditResponse`), so it is unit-testable with
  an in-memory DB instead of resolving the real file-backed `getDatabase()`.
- Fixed a pre-existing baselined `tsc` error on the param-key `Set` (now typed
  `Set<string>`) and ratcheted `scripts/typecheck-baseline.txt` down by one.

## Linked Issue

Closes #4715

## Validation

- [x] `scripts/all_fast_validate_checks.sh` equivalents pass (`bun run lint` + `bun test`: 12756 pass, 0 fail)
- [x] `bun run typecheck` reports no new errors (baseline gate; shrank by 1)
- [x] New code uses interfaces + fakes + FakeTimer; unit tests run in <100ms
- [x] New generic code reuses existing project helpers (no new dependency)

## Acceptance criteria (issue work item 2 — Test bullet)

- [x] `getTestRuns` / `TestRunQuery` filter by `deviceId` — pinned by
  `test/db/testExecutionRepository.test.ts` ("filters by deviceId", "returns
  runs across all devices when deviceId is omitted").
- [x] `automobile:test-runs?deviceId=` resource honors the filter — pinned by
  `test/server/testRunResources.test.ts` (end-to-end `buildTestRunResponse`
  filtering + `filters.deviceId`, and `parseTestRunParams`/`buildTestRunUri`
  round-trip).

## Follow-ups

- [ ] Wire the desktop **Test facet** UI to consume `automobile:test-runs?deviceId=` (separate consumer task; filed as a follow-up).
