### PR TITLE
Desktop workspace: telemetry-event selection + detail in the Logs facet

### DIFF
--- a/android/desktop-core/src/main/kotlin/dev/jasonpearson/automobile/desktop/core/telemetry/LogsPanel.kt
+++ b/android/desktop-core/src/main/kotlin/dev/jasonpearson/automobile/desktop/core/telemetry/LogsPanel.kt
@@ -17,6 +17,7 @@ import androidx.compose.foundation.lazy.LazyColumn
 import androidx.compose.foundation.lazy.LazyListState
 import androidx.compose.foundation.rememberScrollState
 import androidx.compose.foundation.shape.RoundedCornerShape
+import androidx.compose.foundation.text.selection.SelectionContainer
 import androidx.compose.material3.Text
 import androidx.compose.runtime.Composable
 import androidx.compose.runtime.LaunchedEffect
@@ -37,6 +38,7 @@ import androidx.compose.ui.semantics.clearAndSetSemantics
 import androidx.compose.ui.semantics.contentDescription
 import androidx.compose.ui.semantics.role
 import androidx.compose.ui.semantics.selected
+import androidx.compose.ui.semantics.semantics
 import androidx.compose.ui.semantics.stateDescription
 import androidx.compose.ui.text.font.FontFamily
 import androidx.compose.ui.text.font.FontWeight
@@ -46,6 +48,9 @@ import dev.jasonpearson.automobile.desktop.core.components.SearchBar
 import dev.jasonpearson.automobile.desktop.core.connection.ConnectionState
 import dev.jasonpearson.automobile.desktop.core.daemon.TelemetryPushClient
 import dev.jasonpearson.automobile.desktop.core.theme.SharedTheme
+import java.text.SimpleDateFormat
+import java.util.Date
+import java.util.Locale
 
 /**
  * A log severity bucket surfaced as an always-on filter chip. Android's raw priority ints
@@ -158,6 +163,12 @@ fun connectionStatusText(state: ConnectionState): String? =
  * The client is owned by the caller (the facet connects/disposes it per device). Streamed rows are
  * kept per [activeDeviceId] (capped at [maxRows]); switching devices clears the buffer. [platform]
  * selects the numeric log-level scale used to bucket rows into filter chips (see [logLevelOf]).
+ *
+ * Clicking a row selects it (highlight) and expands an inline detail surface directly beneath it —
+ * the docked facet has no separate inspector pane, so this is where the full, single-line-truncated
+ * message becomes reachable. Selection is held here in composition and keyed on [activeDeviceId],
+ * so it is inherently pane-local (each pane composes its own [LogsPanel]) and clears on a device
+ * switch.
  */
 @Composable
 fun LogsPanel(
@@ -169,6 +180,11 @@ fun LogsPanel(
 ) {
   val colors = SharedTheme.globalColors
   val logs = remember(activeDeviceId) { mutableStateListOf<TelemetryDisplayEvent.Log>() }
+  val timeFormat = remember { SimpleDateFormat("HH:mm:ss.SSS", Locale.US) }
+  // Pane-local selected row; cleared on device switch (a switch also swaps the buffer for a fresh
+  // list, so a stale selection could never re-match anyway). Holds the row instance for referential
+  // identity — filterLogs preserves instances, so `===` stays valid across recompositions.
+  var selectedEvent by remember(activeDeviceId) { mutableStateOf<TelemetryDisplayEvent.Log?>(null) }
   var query by remember { mutableStateOf("") }
   var enabledLevels by remember { mutableStateOf(LogLevel.entries.toSet()) }
   var connectionState by remember(activeDeviceId) { mutableStateOf<ConnectionState?>(null) }
@@ -272,7 +288,20 @@ fun LogsPanel(
             "${event.timestamp}_${System.identityHashCode(event)}"
           },
         ) { index ->
-          LogRow(filtered[index], colors.text.normal, platform)
+          val event = filtered[index]
+          val isSelected = event === selectedEvent
+          Column {
+            LogRow(
+              event = event,
+              textColor = colors.text.normal,
+              platform = platform,
+              isSelected = isSelected,
+              onClick = { selectedEvent = if (isSelected) null else event },
+            )
+            if (isSelected) {
+              LogEventDetail(event, colors.text.normal, platform, timeFormat)
+            }
+          }
         }
       }
     }
@@ -351,12 +380,28 @@ private fun LevelChip(level: LogLevel, isEnabled: Boolean, onToggle: () -> Unit)
   }
 }
 
-/** Single log row: level letter, tag, and message, matching the dashboard's compact styling. */
+/**
+ * Single log row: level letter, tag, and message, matching the dashboard's compact styling. The
+ * whole row is a clickable, selectable node — clicking it toggles selection; [isSelected] adds a
+ * highlight background and the `selected` semantics that assistive tech (and tests) read.
+ */
 @Composable
-private fun LogRow(event: TelemetryDisplayEvent.Log, textColor: Color, platform: LogPlatform) {
+private fun LogRow(
+  event: TelemetryDisplayEvent.Log,
+  textColor: Color,
+  platform: LogPlatform,
+  isSelected: Boolean,
+  onClick: () -> Unit,
+) {
   val level = logLevelOf(event.level, platform)
   Row(
-    modifier = Modifier.fillMaxWidth().padding(horizontal = 8.dp, vertical = 2.dp),
+    modifier =
+      Modifier.fillMaxWidth()
+        .then(if (isSelected) Modifier.background(textColor.copy(alpha = 0.08f)) else Modifier)
+        .clickable(onClick = onClick)
+        .pointerHoverIcon(PointerIcon.Hand)
+        .semantics { selected = isSelected }
+        .padding(horizontal = 8.dp, vertical = 2.dp),
     verticalAlignment = Alignment.Top,
   ) {
     Text(
@@ -388,5 +433,45 @@ private fun LogRow(event: TelemetryDisplayEvent.Log, textColor: Color, platform:
       maxLines = 1,
       modifier = Modifier.weight(1f),
     )
+  }
+}
+
+/**
+ * Inline detail surface for the selected log row, rendered directly beneath it. The compact
+ * single-line [LogRow] truncates the message and the docked facet has no separate inspector pane,
+ * so this is where the row's full content becomes reachable: the timestamp/level/tag header plus
+ * the complete, wrapping message in a [SelectionContainer] so it can be selected and copied.
+ */
+@Composable
+private fun LogEventDetail(
+  event: TelemetryDisplayEvent.Log,
+  textColor: Color,
+  platform: LogPlatform,
+  timeFormat: SimpleDateFormat,
+) {
+  val level = logLevelOf(event.level, platform)
+  val formattedTime = remember(event.timestamp) { timeFormat.format(Date(event.timestamp)) }
+  Column(
+    modifier =
+      Modifier.fillMaxWidth()
+        .background(textColor.copy(alpha = 0.04f))
+        .padding(horizontal = 12.dp, vertical = 8.dp)
+        .semantics { contentDescription = "Log event detail" },
+    verticalArrangement = Arrangement.spacedBy(4.dp),
+  ) {
+    Text(
+      "$formattedTime  ${level.label}  ${event.tag}",
+      fontSize = 10.sp,
+      fontFamily = FontFamily.Monospace,
+      color = textColor.copy(alpha = 0.6f),
+    )
+    SelectionContainer {
+      Text(
+        event.message,
+        fontSize = 11.sp,
+        fontFamily = FontFamily.Monospace,
+        color = textColor.copy(alpha = 0.9f),
+      )
+    }
   }
 }

--- a/android/desktop-core/src/main/kotlin/dev/jasonpearson/automobile/desktop/core/telemetry/LogsPanel.kt
+++ b/android/desktop-core/src/main/kotlin/dev/jasonpearson/automobile/desktop/core/telemetry/LogsPanel.kt
@@ -212,8 +212,17 @@ fun LogsPanel(
     val client = telemetryPushClient ?: return@LaunchedEffect
     client.telemetryEvents.collect { event ->
       if (event is TelemetryDisplayEvent.Log) {
+        // The append can drop the oldest row (front) once the buffer is at its cap. If that
+        // dropped row is the current selection, clear it — otherwise its highlight/detail vanish
+        // from view while `selectedEvent` keeps a stale, now-invisible reference the user can no
+        // longer toggle off. Steady-state eviction is a single front row (maxRows is fixed per
+        // panel), so this O(1) identity check is enough.
+        val evicted = if (logs.size >= maxRows) logs.firstOrNull() else null
         appendBounded(logs, event, maxRows)
         appendCount++
+        if (evicted != null && evicted === selectedEvent) {
+          selectedEvent = null
+        }
       }
     }
   }
@@ -400,7 +409,13 @@ private fun LogRow(
         .then(if (isSelected) Modifier.background(textColor.copy(alpha = 0.08f)) else Modifier)
         .clickable(onClick = onClick)
         .pointerHoverIcon(PointerIcon.Hand)
-        .semantics { selected = isSelected }
+        .semantics {
+          // Announce the row as an activatable target whose on/off selection state is spoken,
+          // rather than a bare unlabeled node — a step up from the legacy selectable row, which
+          // emitted no `selected` semantics at all.
+          selected = isSelected
+          role = Role.Button
+        }
         .padding(horizontal = 8.dp, vertical = 2.dp),
     verticalAlignment = Alignment.Top,
   ) {

--- a/android/desktop-core/src/test/kotlin/dev/jasonpearson/automobile/desktop/core/telemetry/LogsPanelTest.kt
+++ b/android/desktop-core/src/test/kotlin/dev/jasonpearson/automobile/desktop/core/telemetry/LogsPanelTest.kt
@@ -1,6 +1,7 @@
 package dev.jasonpearson.automobile.desktop.core.telemetry
 
 import androidx.compose.foundation.layout.Box
+import androidx.compose.foundation.layout.Column
 import androidx.compose.foundation.layout.height
 import androidx.compose.material3.MaterialTheme
 import androidx.compose.runtime.mutableStateOf
@@ -9,8 +10,10 @@ import androidx.compose.ui.test.ExperimentalTestApi
 import androidx.compose.ui.test.assertIsDisplayed
 import androidx.compose.ui.test.assertIsNotSelected
 import androidx.compose.ui.test.assertIsSelected
+import androidx.compose.ui.test.hasClickAction
 import androidx.compose.ui.test.hasScrollToIndexAction
 import androidx.compose.ui.test.hasSetTextAction
+import androidx.compose.ui.test.hasText
 import androidx.compose.ui.test.onAllNodesWithText
 import androidx.compose.ui.test.onNodeWithContentDescription
 import androidx.compose.ui.test.onNodeWithText
@@ -396,4 +399,85 @@ class LogsPanelTest {
       }
       onNodeWithText("b-row 29").assertIsDisplayed()
     }
+
+  // -- Selection + detail (issue #4705) --
+
+  @Test
+  fun `clicking a log row selects and highlights it, clicking again clears it`() =
+    runComposeUiTest {
+      val fake = FakeTelemetryPushClient()
+      setContent {
+        MaterialTheme { LogsPanel(telemetryPushClient = fake, activeDeviceId = "dev-1") }
+      }
+      waitForIdle()
+      fake.emitEvent(log(4, "Net", "selectable row", 10))
+      waitUntil(timeoutMillis = 2_000) {
+        onAllNodesWithText("selectable row").fetchSemanticsNodes().isNotEmpty()
+      }
+
+      // The row is the clickable node carrying the message text. It starts unselected.
+      val row = onNode(hasText("selectable row") and hasClickAction())
+      row.assertIsNotSelected()
+
+      // Clicking selects it (row highlights via the `selected` semantics).
+      row.performClick()
+      onNode(hasText("selectable row") and hasClickAction()).assertIsSelected()
+
+      // Clicking the selected row again clears the selection.
+      onNode(hasText("selectable row") and hasClickAction()).performClick()
+      onNode(hasText("selectable row") and hasClickAction()).assertIsNotSelected()
+    }
+
+  @Test
+  fun `selecting a log row reveals a detail surface with the full content`() = runComposeUiTest {
+    val fake = FakeTelemetryPushClient()
+    setContent { MaterialTheme { LogsPanel(telemetryPushClient = fake, activeDeviceId = "dev-1") } }
+    waitForIdle()
+    fake.emitEvent(log(6, "Crash", "the full message body reachable only via detail", 10))
+    waitUntil(timeoutMillis = 2_000) {
+      onAllNodesWithText("the full message body reachable only via detail", substring = true)
+        .fetchSemanticsNodes()
+        .isNotEmpty()
+    }
+
+    // No detail surface before a row is selected.
+    onNodeWithContentDescription("Log event detail").assertDoesNotExist()
+
+    // Selecting the row opens an inline detail surface inside the docked facet.
+    onNode(hasText("the full message body reachable only via detail") and hasClickAction())
+      .performClick()
+    onNodeWithContentDescription("Log event detail").assertIsDisplayed()
+  }
+
+  @Test
+  fun `selection is pane-local — two panels do not share selection`() = runComposeUiTest {
+    val fakeA = FakeTelemetryPushClient()
+    val fakeB = FakeTelemetryPushClient()
+    setContent {
+      MaterialTheme {
+        Column {
+          Box(Modifier.height(200.dp)) {
+            LogsPanel(telemetryPushClient = fakeA, activeDeviceId = "dev-A")
+          }
+          Box(Modifier.height(200.dp)) {
+            LogsPanel(telemetryPushClient = fakeB, activeDeviceId = "dev-B")
+          }
+        }
+      }
+    }
+    waitForIdle()
+    fakeA.emitEvent(log(4, "T", "pane A row", 1))
+    fakeB.emitEvent(log(4, "T", "pane B row", 2))
+    waitUntil(timeoutMillis = 2_000) {
+      onAllNodesWithText("pane A row").fetchSemanticsNodes().isNotEmpty() &&
+        onAllNodesWithText("pane B row").fetchSemanticsNodes().isNotEmpty()
+    }
+
+    // Select pane A's row.
+    onNode(hasText("pane A row") and hasClickAction()).performClick()
+    onNode(hasText("pane A row") and hasClickAction()).assertIsSelected()
+
+    // Pane B's row must remain unselected — selection did not leak across panes.
+    onNode(hasText("pane B row") and hasClickAction()).assertIsNotSelected()
+  }
 }

--- a/android/desktop-core/src/test/kotlin/dev/jasonpearson/automobile/desktop/core/telemetry/LogsPanelTest.kt
+++ b/android/desktop-core/src/test/kotlin/dev/jasonpearson/automobile/desktop/core/telemetry/LogsPanelTest.kt
@@ -10,7 +10,9 @@ import androidx.compose.ui.test.ExperimentalTestApi
 import androidx.compose.ui.test.assertIsDisplayed
 import androidx.compose.ui.test.assertIsNotSelected
 import androidx.compose.ui.test.assertIsSelected
+import androidx.compose.ui.test.hasAnyAncestor
 import androidx.compose.ui.test.hasClickAction
+import androidx.compose.ui.test.hasContentDescription
 import androidx.compose.ui.test.hasScrollToIndexAction
 import androidx.compose.ui.test.hasSetTextAction
 import androidx.compose.ui.test.hasText
@@ -447,7 +449,48 @@ class LogsPanelTest {
     onNode(hasText("the full message body reachable only via detail") and hasClickAction())
       .performClick()
     onNodeWithContentDescription("Log event detail").assertIsDisplayed()
+
+    // The full message is present *inside* the detail surface — not just that the container exists.
+    // The compact row also exposes the whole string in semantics despite `maxLines = 1`, so we pin
+    // the message to a node whose ancestor is the detail container; truncating/emptying the detail
+    // message would break this even though the row lookup stays green.
+    onNode(
+        hasText("the full message body reachable only via detail") and
+          hasAnyAncestor(hasContentDescription("Log event detail"))
+      )
+      .assertIsDisplayed()
   }
+
+  @Test
+  fun `evicting the selected row from the bounded buffer clears the selection`() =
+    runComposeUiTest {
+      val fake = FakeTelemetryPushClient()
+      setContent {
+        MaterialTheme {
+          // Cap of 1 so the very next row evicts the selected one from the front of the buffer.
+          LogsPanel(telemetryPushClient = fake, activeDeviceId = "dev-1", maxRows = 1)
+        }
+      }
+      waitForIdle()
+      fake.emitEvent(log(4, "T", "row A", 1))
+      waitUntil(timeoutMillis = 2_000) {
+        onAllNodesWithText("row A").fetchSemanticsNodes().isNotEmpty()
+      }
+
+      // Select row A — it highlights and opens its detail.
+      onNode(hasText("row A") and hasClickAction()).performClick()
+      onNode(hasText("row A") and hasClickAction()).assertIsSelected()
+      onNodeWithContentDescription("Log event detail").assertIsDisplayed()
+
+      // Emitting row B evicts row A from the cap-1 buffer. The stale selection must clear, so no
+      // detail surface lingers and the new row is not spuriously selected.
+      fake.emitEvent(log(4, "T", "row B", 2))
+      waitUntil(timeoutMillis = 2_000) {
+        onAllNodesWithText("row A").fetchSemanticsNodes().isEmpty()
+      }
+      onNodeWithContentDescription("Log event detail").assertDoesNotExist()
+      onNode(hasText("row B") and hasClickAction()).assertIsNotSelected()
+    }
 
   @Test
   fun `selection is pane-local — two panels do not share selection`() = runComposeUiTest {


### PR DESCRIPTION
## Summary

Wires telemetry-event **selection + detail** into the workspace Logs facet. The docked Logs facet renders `LogsPanel` (a logs-only stream), whose rows were not clickable and whose message was truncated to a single line via `maxLines = 1` — so a row's full content was unreachable. Unlike the legacy `AutoMobileContent` host, the workspace pane has no right-inspector panel to open a detail surface in.

Each `LogRow` is now a clickable, selectable node. Clicking toggles a **per-pane** selection (highlight background + `selected` semantics), and the selected row expands an **inline detail surface** directly beneath it — the timestamp/level/tag header plus the full, wrapping message in a `SelectionContainer` (selectable/copyable). Selection is held in composition keyed on `activeDeviceId`, so it is pane-local (each pane composes its own `LogsPanel`) and clears on a device switch.

> Note: the issue body predates a refactor and refers to `TelemetryDashboard`; the facet that actually shipped in #4704 renders `LogsPanel`, so the wiring lives there.

## Linked Issue

Closes #4705

## Acceptance criteria

1. **Clicking a telemetry row selects it (row highlights).** → `LogRow` is clickable, carries `selected` semantics, and paints a highlight when selected. Pinned by `clicking a log row selects and highlights it, clicking again clears it`.
2. **The selected event's full content is reachable.** → inline detail surface (`contentDescription = "Log event detail"`) shows the full wrapping/selectable message + metadata. Pinned by `selecting a log row reveals a detail surface with the full content`.
3. **Selection state is per pane.** → selection lives in each `LogsPanel`'s composition (`remember(activeDeviceId)`), no shared holder. Pinned by `selection is pane-local — two panels do not share selection`.

## Validation

- [x] `:desktop-core:test` green (21 tests incl. 3 new selection/detail tests)
- [x] `:desktop-core:detektMain` green
- [x] `:desktop-app:compileKotlin` green
- [x] `scripts/ktfmt/validate_ktfmt.sh` — all files formatted

## Kotlin Reuse Check

- [x] Reused existing primitives (`logLevelOf`, `LogLevel`, `SelectionContainer`, Compose `semantics`) — no new helpers, wrappers, or dependencies.

## Device Verification

UI-only change in a Compose desktop module; covered by Compose UI tests. No on-device tool behavior affected.
