### PR TITLE
Desktop workspace: enable Storage facet for iOS panes (fix key-value mutation routing)

### DIFF
--- a/android/desktop-app/src/main/kotlin/dev/jasonpearson/automobile/desktop/AutoMobileDesktopApp.kt
+++ b/android/desktop-app/src/main/kotlin/dev/jasonpearson/automobile/desktop/AutoMobileDesktopApp.kt
@@ -231,8 +231,7 @@ fun AutoMobileDesktopApp(
 private fun WorkspaceFacet(column: DeviceColumn, tool: Tool) {
   when (tool) {
     Tool.Logs -> LogsFacet(column)
-    // Storage works on both platforms: iOS key-value mutations now carry the platform through to
-    // the
+    // Storage works on both platforms now that iOS key-value mutations carry the platform to the
     // daemon and target the correct iOS device (#4708).
     Tool.Storage -> StorageFacet(column)
     // Network reads per-device via the getNetworkGraph MCP tool call (deviceId is an argument),

--- a/android/desktop-app/src/main/kotlin/dev/jasonpearson/automobile/desktop/AutoMobileDesktopApp.kt
+++ b/android/desktop-app/src/main/kotlin/dev/jasonpearson/automobile/desktop/AutoMobileDesktopApp.kt
@@ -28,7 +28,6 @@ import dev.jasonpearson.automobile.desktop.core.workspace.NavigationFacet
 import dev.jasonpearson.automobile.desktop.core.workspace.NetworkFacet
 import dev.jasonpearson.automobile.desktop.core.workspace.OnboardingScreen
 import dev.jasonpearson.automobile.desktop.core.workspace.PerformanceFacet
-import dev.jasonpearson.automobile.desktop.core.workspace.Platform
 import dev.jasonpearson.automobile.desktop.core.workspace.StorageFacet
 import dev.jasonpearson.automobile.desktop.core.workspace.Tool
 import dev.jasonpearson.automobile.desktop.core.workspace.WorkspaceAction
@@ -222,7 +221,7 @@ fun AutoMobileDesktopApp(
 
 /**
  * Real docked-facet content for a pane, wired to the per-device facets in desktop-core: Logs
- * (telemetry), Storage (auto-resolved app, Android-only), Network (per-device `getNetworkGraph`
+ * (telemetry), Storage (auto-resolved app, Android + iOS), Network (per-device `getNetworkGraph`
  * tool call), Performance (per-device observation stream, filtered by deviceId), Failures
  * (cross-device aggregate), and Navigation (#4837 Phase C — app-scoped graph pulled by the pane
  * device's foreground app). Test (per-device daemon resource, #4715) falls back to the placeholder
@@ -232,11 +231,10 @@ fun AutoMobileDesktopApp(
 private fun WorkspaceFacet(column: DeviceColumn, tool: Tool) {
   when (tool) {
     Tool.Logs -> LogsFacet(column)
-    // Storage is Android-only for now: iOS key-value mutations misroute to Android-only daemon
-    // handlers (#4708). iOS panes fall back to the placeholder until that lands.
-    Tool.Storage ->
-      if (column.platform == Platform.Android) StorageFacet(column)
-      else WorkspaceFacetPlaceholder(tool)
+    // Storage works on both platforms: iOS key-value mutations now carry the platform through to
+    // the
+    // daemon and target the correct iOS device (#4708).
+    Tool.Storage -> StorageFacet(column)
     // Network reads per-device via the getNetworkGraph MCP tool call (deviceId is an argument),
     // not the broadcast observation stream, so panes don't cross-contaminate.
     Tool.Network -> NetworkFacet(column)

--- a/android/desktop-core/src/main/kotlin/dev/jasonpearson/automobile/desktop/core/daemon/AutoMobileClient.kt
+++ b/android/desktop-core/src/main/kotlin/dev/jasonpearson/automobile/desktop/core/daemon/AutoMobileClient.kt
@@ -133,6 +133,7 @@ interface AutoMobileClient {
     key: String,
     value: String?,
     type: String,
+    platform: String = "android",
   ): SetKeyValueResult
 
   fun removeKeyValue(
@@ -140,12 +141,14 @@ interface AutoMobileClient {
     appId: String,
     fileName: String,
     key: String,
+    platform: String = "android",
   ): RemoveKeyValueResult
 
   fun clearKeyValueFile(
     deviceId: String,
     appId: String,
     fileName: String,
+    platform: String = "android",
   ): ClearKeyValueResult
 
   fun callTool(name: String, arguments: JsonObject): JsonElement

--- a/android/desktop-core/src/main/kotlin/dev/jasonpearson/automobile/desktop/core/daemon/McpDaemonClient.kt
+++ b/android/desktop-core/src/main/kotlin/dev/jasonpearson/automobile/desktop/core/daemon/McpDaemonClient.kt
@@ -438,12 +438,14 @@ class McpDaemonClient(
     key: String,
     value: String?,
     type: String,
+    platform: String,
   ): SetKeyValueResult {
     val response =
       sendRequest(
         "ide/setKeyValue",
         buildJsonObject {
           put("deviceId", JsonPrimitive(deviceId))
+          put("platform", JsonPrimitive(platform))
           put("appId", JsonPrimitive(appId))
           put("fileName", JsonPrimitive(fileName))
           put("key", JsonPrimitive(key))
@@ -464,12 +466,14 @@ class McpDaemonClient(
     appId: String,
     fileName: String,
     key: String,
+    platform: String,
   ): RemoveKeyValueResult {
     val response =
       sendRequest(
         "ide/removeKeyValue",
         buildJsonObject {
           put("deviceId", JsonPrimitive(deviceId))
+          put("platform", JsonPrimitive(platform))
           put("appId", JsonPrimitive(appId))
           put("fileName", JsonPrimitive(fileName))
           put("key", JsonPrimitive(key))
@@ -487,12 +491,14 @@ class McpDaemonClient(
     deviceId: String,
     appId: String,
     fileName: String,
+    platform: String,
   ): ClearKeyValueResult {
     val response =
       sendRequest(
         "ide/clearKeyValueFile",
         buildJsonObject {
           put("deviceId", JsonPrimitive(deviceId))
+          put("platform", JsonPrimitive(platform))
           put("appId", JsonPrimitive(appId))
           put("fileName", JsonPrimitive(fileName))
         },

--- a/android/desktop-core/src/main/kotlin/dev/jasonpearson/automobile/desktop/core/daemon/McpHttpClient.kt
+++ b/android/desktop-core/src/main/kotlin/dev/jasonpearson/automobile/desktop/core/daemon/McpHttpClient.kt
@@ -269,13 +269,14 @@ class McpHttpClient(
     key: String,
     value: String?,
     type: String,
+    platform: String,
   ): SetKeyValueResult {
     val response =
       callTool(
         "setKeyValue",
         buildJsonObject {
           put("deviceId", JsonPrimitive(deviceId))
-          put("platform", JsonPrimitive("android"))
+          put("platform", JsonPrimitive(platform))
           put("appId", JsonPrimitive(appId))
           put("fileName", JsonPrimitive(fileName))
           put("key", JsonPrimitive(key))
@@ -296,13 +297,14 @@ class McpHttpClient(
     appId: String,
     fileName: String,
     key: String,
+    platform: String,
   ): RemoveKeyValueResult {
     val response =
       callTool(
         "removeKeyValue",
         buildJsonObject {
           put("deviceId", JsonPrimitive(deviceId))
-          put("platform", JsonPrimitive("android"))
+          put("platform", JsonPrimitive(platform))
           put("appId", JsonPrimitive(appId))
           put("fileName", JsonPrimitive(fileName))
           put("key", JsonPrimitive(key))
@@ -320,13 +322,14 @@ class McpHttpClient(
     deviceId: String,
     appId: String,
     fileName: String,
+    platform: String,
   ): ClearKeyValueResult {
     val response =
       callTool(
         "clearKeyValueFile",
         buildJsonObject {
           put("deviceId", JsonPrimitive(deviceId))
-          put("platform", JsonPrimitive("android"))
+          put("platform", JsonPrimitive(platform))
           put("appId", JsonPrimitive(appId))
           put("fileName", JsonPrimitive(fileName))
         },

--- a/android/desktop-core/src/main/kotlin/dev/jasonpearson/automobile/desktop/core/daemon/McpStdioClient.kt
+++ b/android/desktop-core/src/main/kotlin/dev/jasonpearson/automobile/desktop/core/daemon/McpStdioClient.kt
@@ -277,13 +277,14 @@ class McpStdioClient(
     key: String,
     value: String?,
     type: String,
+    platform: String,
   ): SetKeyValueResult {
     val response =
       callTool(
         "setKeyValue",
         buildJsonObject {
           put("deviceId", JsonPrimitive(deviceId))
-          put("platform", JsonPrimitive("android"))
+          put("platform", JsonPrimitive(platform))
           put("appId", JsonPrimitive(appId))
           put("fileName", JsonPrimitive(fileName))
           put("key", JsonPrimitive(key))
@@ -306,13 +307,14 @@ class McpStdioClient(
     appId: String,
     fileName: String,
     key: String,
+    platform: String,
   ): RemoveKeyValueResult {
     val response =
       callTool(
         "removeKeyValue",
         buildJsonObject {
           put("deviceId", JsonPrimitive(deviceId))
-          put("platform", JsonPrimitive("android"))
+          put("platform", JsonPrimitive(platform))
           put("appId", JsonPrimitive(appId))
           put("fileName", JsonPrimitive(fileName))
           put("key", JsonPrimitive(key))
@@ -329,13 +331,14 @@ class McpStdioClient(
     deviceId: String,
     appId: String,
     fileName: String,
+    platform: String,
   ): ClearKeyValueResult {
     val response =
       callTool(
         "clearKeyValueFile",
         buildJsonObject {
           put("deviceId", JsonPrimitive(deviceId))
-          put("platform", JsonPrimitive("android"))
+          put("platform", JsonPrimitive(platform))
           put("appId", JsonPrimitive(appId))
           put("fileName", JsonPrimitive(fileName))
         },

--- a/android/desktop-core/src/main/kotlin/dev/jasonpearson/automobile/desktop/core/datasource/RealStorageDataSource.kt
+++ b/android/desktop-core/src/main/kotlin/dev/jasonpearson/automobile/desktop/core/datasource/RealStorageDataSource.kt
@@ -357,7 +357,16 @@ class RealStorageDataSource(
     return try {
       val client = provider()
       withContext(Dispatchers.IO) {
-        val result = client.setKeyValue(device, pkg, fileName, key, value, type.protocolName)
+        val result =
+          client.setKeyValue(
+            device,
+            pkg,
+            fileName,
+            key,
+            value,
+            type.protocolName,
+            platform.protocolName,
+          )
         if (result.success) Result.Success(Unit)
         else Result.Error(RuntimeException(result.message ?: "Failed to set key value"))
       }
@@ -377,7 +386,7 @@ class RealStorageDataSource(
     return try {
       val client = provider()
       withContext(Dispatchers.IO) {
-        val result = client.removeKeyValue(device, pkg, fileName, key)
+        val result = client.removeKeyValue(device, pkg, fileName, key, platform.protocolName)
         if (result.success) Result.Success(Unit)
         else Result.Error(RuntimeException(result.message ?: "Failed to remove key value"))
       }
@@ -397,7 +406,7 @@ class RealStorageDataSource(
     return try {
       val client = provider()
       withContext(Dispatchers.IO) {
-        val result = client.clearKeyValueFile(device, pkg, fileName)
+        val result = client.clearKeyValueFile(device, pkg, fileName, platform.protocolName)
         if (result.success) Result.Success(Unit)
         else Result.Error(RuntimeException(result.message ?: "Failed to clear key value file"))
       }

--- a/android/desktop-core/src/main/kotlin/dev/jasonpearson/automobile/desktop/core/testing/FakeAutoMobileClient.kt
+++ b/android/desktop-core/src/main/kotlin/dev/jasonpearson/automobile/desktop/core/testing/FakeAutoMobileClient.kt
@@ -113,6 +113,7 @@ class FakeAutoMobileClient : AutoMobileClient {
     val key: String,
     val value: String?,
     val type: String,
+    val platform: String = "android",
   )
 
   data class RemoveKeyValueCall(
@@ -120,12 +121,14 @@ class FakeAutoMobileClient : AutoMobileClient {
     val appId: String,
     val fileName: String,
     val key: String,
+    val platform: String = "android",
   )
 
   data class ClearKeyValueFileCall(
     val deviceId: String,
     val appId: String,
     val fileName: String,
+    val platform: String = "android",
   )
 
   data class InputTapCall(
@@ -374,9 +377,10 @@ class FakeAutoMobileClient : AutoMobileClient {
     key: String,
     value: String?,
     type: String,
+    platform: String,
   ): SetKeyValueResult {
     calls.add("setKeyValue")
-    setKeyValueCalls.add(SetKeyValueCall(deviceId, appId, fileName, key, value, type))
+    setKeyValueCalls.add(SetKeyValueCall(deviceId, appId, fileName, key, value, type, platform))
     return setKeyValueResult
   }
 
@@ -385,9 +389,10 @@ class FakeAutoMobileClient : AutoMobileClient {
     appId: String,
     fileName: String,
     key: String,
+    platform: String,
   ): RemoveKeyValueResult {
     calls.add("removeKeyValue")
-    removeKeyValueCalls.add(RemoveKeyValueCall(deviceId, appId, fileName, key))
+    removeKeyValueCalls.add(RemoveKeyValueCall(deviceId, appId, fileName, key, platform))
     return removeKeyValueResult
   }
 
@@ -395,9 +400,10 @@ class FakeAutoMobileClient : AutoMobileClient {
     deviceId: String,
     appId: String,
     fileName: String,
+    platform: String,
   ): ClearKeyValueResult {
     calls.add("clearKeyValueFile")
-    clearKeyValueFileCalls.add(ClearKeyValueFileCall(deviceId, appId, fileName))
+    clearKeyValueFileCalls.add(ClearKeyValueFileCall(deviceId, appId, fileName, platform))
     return clearKeyValueFileResult
   }
 

--- a/android/desktop-core/src/test/kotlin/dev/jasonpearson/automobile/desktop/core/daemon/McpDaemonClientInputTest.kt
+++ b/android/desktop-core/src/test/kotlin/dev/jasonpearson/automobile/desktop/core/daemon/McpDaemonClientInputTest.kt
@@ -509,6 +509,63 @@ class McpDaemonClientInputTest {
   }
 
   @Test
+  fun `setKeyValue carries the platform through to the ide socket request (#4708)`() {
+    TestDaemonSocket(resultJson = """{ "success": true }""").use { server ->
+      McpDaemonClient(socketPathValue = server.socketPath.toString())
+        .setKeyValue(
+          deviceId = "ios-sim-1",
+          appId = "com.example.app",
+          fileName = "prefs",
+          key = "theme",
+          value = "dark",
+          type = "STRING",
+          platform = "ios",
+        )
+
+      val request = server.awaitRequest()
+      assertEquals("ide/setKeyValue", request.method)
+      assertEquals("ios", request.params.getValue("platform").jsonPrimitive.content)
+      assertEquals("ios-sim-1", request.params.getValue("deviceId").jsonPrimitive.content)
+    }
+  }
+
+  @Test
+  fun `removeKeyValue and clearKeyValueFile carry the platform on the wire (#4708)`() {
+    TestDaemonSocket(
+        responses =
+          listOf(
+            SocketResponse(resultJson = """{ "success": true }"""),
+            SocketResponse(resultJson = """{ "success": true }"""),
+          )
+      )
+      .use { server ->
+        McpDaemonClient(socketPathValue = server.socketPath.toString())
+          .removeKeyValue(
+            deviceId = "ios-sim-1",
+            appId = "com.example.app",
+            fileName = "prefs",
+            key = "theme",
+            platform = "ios",
+          )
+        McpDaemonClient(socketPathValue = server.socketPath.toString())
+          .clearKeyValueFile(
+            deviceId = "ios-sim-1",
+            appId = "com.example.app",
+            fileName = "prefs",
+            platform = "ios",
+          )
+
+        val requests = server.awaitRequests()
+        assertEquals(
+          listOf("ide/removeKeyValue", "ide/clearKeyValueFile"),
+          requests.map { it.method },
+        )
+        assertEquals("ios", requests[0].params.getValue("platform").jsonPrimitive.content)
+        assertEquals("ios", requests[1].params.getValue("platform").jsonPrimitive.content)
+      }
+  }
+
+  @Test
   fun `input helpers reject malformed success payloads`() {
     TestDaemonSocket(resultJson = "{}", error = null).use { server ->
       assertFailsWith<SerializationException> {

--- a/android/desktop-core/src/test/kotlin/dev/jasonpearson/automobile/desktop/core/datasource/RealStorageDataSourceTest.kt
+++ b/android/desktop-core/src/test/kotlin/dev/jasonpearson/automobile/desktop/core/datasource/RealStorageDataSourceTest.kt
@@ -468,6 +468,59 @@ class RealStorageDataSourceTest {
     assertEquals("theme", call.key)
     assertEquals("dark", call.value)
     assertEquals("STRING", call.type)
+    // Defaults to Android when the pane platform is unspecified.
+    assertEquals("android", call.platform)
+  }
+
+  @Test
+  fun `setKeyValue carries the iOS platform through to the client (#4708)`() = runBlocking {
+    val client = FakeAutoMobileClient()
+    val dataSource =
+      RealStorageDataSource(
+        clientProvider = { client },
+        deviceId = "ios-sim-1",
+        packageName = "com.example.app",
+        platform = StoragePlatform.iOS,
+      )
+
+    val result = dataSource.setKeyValue("app_prefs", "theme", "dark", KeyValueType.String)
+
+    assertTrue(result is Result.Success)
+    assertEquals("ios", client.setKeyValueCalls.single().platform)
+  }
+
+  @Test
+  fun `removeKeyValue carries the iOS platform through to the client (#4708)`() = runBlocking {
+    val client = FakeAutoMobileClient()
+    val dataSource =
+      RealStorageDataSource(
+        clientProvider = { client },
+        deviceId = "ios-sim-1",
+        packageName = "com.example.app",
+        platform = StoragePlatform.iOS,
+      )
+
+    val result = dataSource.removeKeyValue("app_prefs", "theme")
+
+    assertTrue(result is Result.Success)
+    assertEquals("ios", client.removeKeyValueCalls.single().platform)
+  }
+
+  @Test
+  fun `clearKeyValueFile carries the iOS platform through to the client (#4708)`() = runBlocking {
+    val client = FakeAutoMobileClient()
+    val dataSource =
+      RealStorageDataSource(
+        clientProvider = { client },
+        deviceId = "ios-sim-1",
+        packageName = "com.example.app",
+        platform = StoragePlatform.iOS,
+      )
+
+    val result = dataSource.clearKeyValueFile("app_prefs")
+
+    assertTrue(result is Result.Success)
+    assertEquals("ios", client.clearKeyValueFileCalls.single().platform)
   }
 
   @Test

--- a/android/desktop-core/src/test/kotlin/dev/jasonpearson/automobile/desktop/core/navigation/NavigationScreenshotLoaderTest.kt
+++ b/android/desktop-core/src/test/kotlin/dev/jasonpearson/automobile/desktop/core/navigation/NavigationScreenshotLoaderTest.kt
@@ -481,13 +481,23 @@ class FakeAutoMobileClient : AutoMobileClient {
     key: String,
     value: String?,
     type: String,
+    platform: String,
   ) = notImplemented()
 
-  override fun removeKeyValue(deviceId: String, appId: String, fileName: String, key: String) =
-    notImplemented()
+  override fun removeKeyValue(
+    deviceId: String,
+    appId: String,
+    fileName: String,
+    key: String,
+    platform: String,
+  ) = notImplemented()
 
-  override fun clearKeyValueFile(deviceId: String, appId: String, fileName: String) =
-    notImplemented()
+  override fun clearKeyValueFile(
+    deviceId: String,
+    appId: String,
+    fileName: String,
+    platform: String,
+  ) = notImplemented()
 
   override fun callTool(name: String, arguments: kotlinx.serialization.json.JsonObject) =
     notImplemented()

--- a/android/desktop-core/src/test/kotlin/dev/jasonpearson/automobile/desktop/core/workspace/StorageFacetTest.kt
+++ b/android/desktop-core/src/test/kotlin/dev/jasonpearson/automobile/desktop/core/workspace/StorageFacetTest.kt
@@ -56,6 +56,22 @@ class StorageFacetTest {
   }
 
   @Test
+  fun `handles an iOS pane without an Android-only gate (#4708)`() = runComposeUiTest {
+    // The facet is no longer gated to Android: an iOS column runs the same resolution path.
+    setContent {
+      MaterialTheme {
+        StorageFacet(
+          column =
+            DeviceColumn(deviceId = "ios-sim-1", name = "iPhone 16", platform = Platform.Ios),
+          loadInstalledApps = { Result.Success(emptyList()) },
+        )
+      }
+    }
+    waitForIdle()
+    onNodeWithText("No app found", substring = true).assertIsDisplayed()
+  }
+
+  @Test
   fun `surfaces a retryable error when the app list fails to load`() = runComposeUiTest {
     setContent {
       MaterialTheme {

--- a/android/desktop-domain/src/main/kotlin/dev/jasonpearson/automobile/desktop/domain/StorageModels.kt
+++ b/android/desktop-domain/src/main/kotlin/dev/jasonpearson/automobile/desktop/domain/StorageModels.kt
@@ -82,9 +82,9 @@ public enum class KeyValueType(public val protocolName: kotlin.String) {
   }
 }
 
-public enum class StoragePlatform {
-  Android,
-  iOS,
+public enum class StoragePlatform(public val protocolName: kotlin.String) {
+  Android("android"),
+  iOS("ios"),
 }
 
 public enum class DatabaseViewMode {

--- a/src/daemon/socketServer.ts
+++ b/src/daemon/socketServer.ts
@@ -175,6 +175,23 @@ const isNonBlankSessionUuid = (value: unknown): value is string =>
   typeof value === "string" && value.trim().length > 0;
 
 /**
+ * The narrow key-value mutation surface the `ide/*` handlers need from a
+ * platform CtrlProxy client. Both AndroidCtrlProxyClient and IOSCtrlProxyClient
+ * satisfy it structurally (#4708).
+ */
+interface KeyValueMutationClient {
+  setPreference(
+    packageName: string,
+    fileName: string,
+    key: string,
+    value: string,
+    type: KeyValueType
+  ): Promise<void>;
+  removePreference(packageName: string, fileName: string, key: string): Promise<void>;
+  clearPreferenceStore(packageName: string, fileName: string): Promise<void>;
+}
+
+/**
  * Preserve the normal failed socket envelope while carrying append progress for
  * a client that can safely retry only the unsent suffix.
  */
@@ -1322,6 +1339,7 @@ export class UnixSocketServer {
       }
       case "ide/setKeyValue": {
         const args = request.params as {
+          platform?: string;
           deviceId?: string;
           appId?: string;
           fileName?: string;
@@ -1333,12 +1351,7 @@ export class UnixSocketServer {
           throw new Error("setKeyValue requires deviceId, appId, fileName, key, and type params");
         }
         await this.assertSocketToolEnabled(args.deviceId, "setKeyValue");
-        const bootedDevices = await PlatformDeviceManagerFactory.getInstance().getBootedDevices("android");
-        const targetDevice = bootedDevices.find(d => d.deviceId === args.deviceId);
-        if (!targetDevice) {
-          throw new Error(`Device not found: ${args.deviceId}`);
-        }
-        const client = AndroidCtrlProxyClient.getInstance(targetDevice, defaultAdbClientFactory);
+        const client = await this.resolveKeyValueMutationClient(args.platform, args.deviceId);
         if (args.value === null || args.value === undefined) {
           await client.removePreference(args.appId, args.fileName, args.key);
         } else {
@@ -1354,6 +1367,7 @@ export class UnixSocketServer {
       }
       case "ide/removeKeyValue": {
         const args = request.params as {
+          platform?: string;
           deviceId?: string;
           appId?: string;
           fileName?: string;
@@ -1363,17 +1377,13 @@ export class UnixSocketServer {
           throw new Error("removeKeyValue requires deviceId, appId, fileName, and key params");
         }
         await this.assertSocketToolEnabled(args.deviceId, "removeKeyValue");
-        const bootedDevices = await PlatformDeviceManagerFactory.getInstance().getBootedDevices("android");
-        const targetDevice = bootedDevices.find(d => d.deviceId === args.deviceId);
-        if (!targetDevice) {
-          throw new Error(`Device not found: ${args.deviceId}`);
-        }
-        const client = AndroidCtrlProxyClient.getInstance(targetDevice, defaultAdbClientFactory);
+        const client = await this.resolveKeyValueMutationClient(args.platform, args.deviceId);
         await client.removePreference(args.appId, args.fileName, args.key);
         return { success: true };
       }
       case "ide/clearKeyValueFile": {
         const args = request.params as {
+          platform?: string;
           deviceId?: string;
           appId?: string;
           fileName?: string;
@@ -1382,18 +1392,37 @@ export class UnixSocketServer {
           throw new Error("clearKeyValueFile requires deviceId, appId, and fileName params");
         }
         await this.assertSocketToolEnabled(args.deviceId, "clearKeyValueFile");
-        const bootedDevices = await PlatformDeviceManagerFactory.getInstance().getBootedDevices("android");
-        const targetDevice = bootedDevices.find(d => d.deviceId === args.deviceId);
-        if (!targetDevice) {
-          throw new Error(`Device not found: ${args.deviceId}`);
-        }
-        const client = AndroidCtrlProxyClient.getInstance(targetDevice, defaultAdbClientFactory);
+        const client = await this.resolveKeyValueMutationClient(args.platform, args.deviceId);
         await client.clearPreferenceStore(args.appId, args.fileName);
         return { success: true };
       }
       default:
         return undefined;
     }
+  }
+
+  /**
+   * Resolve the platform-appropriate storage-mutation client for a key-value
+   * `ide/*` request. iOS Storage-facet edits carry `platform: "ios"` so the pane
+   * targets the iOS simulator + IOSCtrlProxyClient; a missing platform defaults
+   * to Android for backward compatibility with older desktop clients (#4708).
+   */
+  private async resolveKeyValueMutationClient(
+    platformValue: string | undefined,
+    deviceId: string
+  ): Promise<KeyValueMutationClient> {
+    const platform = platformValue ?? "android";
+    if (platform !== "android" && platform !== "ios") {
+      throw new Error(`Invalid platform: ${platform}. Must be 'android' or 'ios'.`);
+    }
+    const bootedDevices = await PlatformDeviceManagerFactory.getInstance().getBootedDevices(platform);
+    const targetDevice = bootedDevices.find(d => d.deviceId === deviceId);
+    if (!targetDevice) {
+      throw new Error(`Device not found: ${deviceId}`);
+    }
+    return platform === "ios"
+      ? IOSCtrlProxyClient.getInstance(targetDevice)
+      : AndroidCtrlProxyClient.getInstance(targetDevice, defaultAdbClientFactory);
   }
 
   private async assertSocketToolEnabled(deviceId: string, toolName: string): Promise<void> {

--- a/test/daemon/socketServerKeyValue.test.ts
+++ b/test/daemon/socketServerKeyValue.test.ts
@@ -1,0 +1,238 @@
+import { afterEach, beforeEach, describe, expect, mock, test } from "bun:test";
+import { Socket } from "node:net";
+import { existsSync } from "node:fs";
+import { unlink } from "node:fs/promises";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import { randomUUID } from "node:crypto";
+import { UnixSocketServer } from "../../src/daemon/socketServer";
+import { AndroidCtrlProxyClient } from "../../src/features/observe/android";
+import { IOSCtrlProxyClient } from "../../src/features/observe/ios";
+import { PlatformDeviceManagerFactory } from "../../src/utils/factories/PlatformDeviceManagerFactory";
+import { FakeTimer } from "../fakes/FakeTimer";
+import type { SessionToolProfileService } from "../../src/features/toolCapabilities/SessionToolProfileService";
+import type { DaemonResponse } from "../../src/daemon/types";
+import type { BootedDevice } from "../../src/models";
+
+/**
+ * Key-value mutation routing across platforms (issue #4708). The desktop Storage
+ * facet edits key-value entries through the daemon's `ide/*` socket methods. iOS
+ * panes must route to the iOS device + IOSCtrlProxyClient; before #4708 the
+ * handlers hardcoded Android discovery + AndroidCtrlProxyClient, so an iOS edit
+ * failed with the iOS device reported "not found".
+ */
+
+const androidDevice: BootedDevice = {
+  deviceId: "emulator-5554",
+  name: "Pixel",
+  platform: "android",
+};
+
+const iosDevice: BootedDevice = {
+  deviceId: "ios-sim-1",
+  name: "iPhone 16",
+  platform: "ios",
+};
+
+function createDaemonState() {
+  return {
+    isInitialized: () => true,
+    getSessionManager: () => ({
+      getSession: () => null,
+      getSessionForDevice: () => null,
+      getDeviceLabels: () => undefined,
+      releaseSession: async () => null,
+    }),
+    getDevicePool: () => ({
+      refreshDevices: async () => 0,
+      getStats: () => ({ total: 0, idle: 0, assigned: 0, error: 0 }),
+      releaseDevice: async () => {},
+    }),
+  };
+}
+
+function sendRequest(socketPath: string, method: string, params: Record<string, unknown>): Promise<DaemonResponse> {
+  return new Promise((resolve, reject) => {
+    const socket = new Socket();
+    let buffer = "";
+    socket.connect(socketPath, () => {
+      socket.write(JSON.stringify({
+        id: randomUUID(),
+        type: "mcp_request",
+        method,
+        params,
+      }) + "\n");
+    });
+    socket.on("data", data => {
+      buffer += data.toString();
+      const line = buffer.split("\n").find(value => value.trim());
+      if (line) {
+        socket.destroy();
+        resolve(JSON.parse(line) as DaemonResponse);
+      }
+    });
+    socket.on("error", reject);
+  });
+}
+
+describe("UnixSocketServer key-value mutation platform routing (#4708)", () => {
+  let socketPath: string;
+  let server: UnixSocketServer;
+  let originalAndroidGetInstance: typeof AndroidCtrlProxyClient.getInstance;
+  let originalIosGetInstance: typeof IOSCtrlProxyClient.getInstance;
+  let androidSetPreference: ReturnType<typeof mock>;
+  let androidRemovePreference: ReturnType<typeof mock>;
+  let androidClearPreferenceStore: ReturnType<typeof mock>;
+  let iosSetPreference: ReturnType<typeof mock>;
+  let iosRemovePreference: ReturnType<typeof mock>;
+  let iosClearPreferenceStore: ReturnType<typeof mock>;
+
+  beforeEach(async () => {
+    socketPath = join(tmpdir(), `kv-routing-${randomUUID()}.sock`);
+
+    // Only the two platform-specific booted devices exist; discovery is scoped
+    // by the platform the handler asks for.
+    PlatformDeviceManagerFactory.setInstance({
+      getBootedDevices: async (platform: "android" | "ios" | "either") =>
+        platform === "ios"
+          ? [iosDevice]
+          : platform === "android"
+            ? [androidDevice]
+            : [androidDevice, iosDevice],
+    } as unknown as ReturnType<typeof PlatformDeviceManagerFactory.getInstance>);
+
+    androidSetPreference = mock(async () => {});
+    androidRemovePreference = mock(async () => {});
+    androidClearPreferenceStore = mock(async () => {});
+    iosSetPreference = mock(async () => {});
+    iosRemovePreference = mock(async () => {});
+    iosClearPreferenceStore = mock(async () => {});
+
+    originalAndroidGetInstance = AndroidCtrlProxyClient.getInstance;
+    originalIosGetInstance = IOSCtrlProxyClient.getInstance;
+    AndroidCtrlProxyClient.getInstance = mock(() => ({
+      setPreference: androidSetPreference,
+      removePreference: androidRemovePreference,
+      clearPreferenceStore: androidClearPreferenceStore,
+    })) as unknown as typeof AndroidCtrlProxyClient.getInstance;
+    IOSCtrlProxyClient.getInstance = mock(() => ({
+      setPreference: iosSetPreference,
+      removePreference: iosRemovePreference,
+      clearPreferenceStore: iosClearPreferenceStore,
+    })) as unknown as typeof IOSCtrlProxyClient.getInstance;
+
+    const profileService: Pick<SessionToolProfileService, "isEnabled" | "setEnabled"> = {
+      isEnabled: async () => true,
+      setEnabled: async () => {},
+    };
+
+    server = new UnixSocketServer(
+      socketPath,
+      "http://localhost:0/mcp",
+      createDaemonState(),
+      new FakeTimer(),
+      null,
+      { sessionToolProfileService: profileService }
+    );
+    await server.start();
+  });
+
+  afterEach(async () => {
+    await server.close();
+    AndroidCtrlProxyClient.getInstance = originalAndroidGetInstance;
+    IOSCtrlProxyClient.getInstance = originalIosGetInstance;
+    PlatformDeviceManagerFactory.setInstance(null);
+    if (existsSync(socketPath)) {
+      await unlink(socketPath);
+    }
+  });
+
+  test("ide/setKeyValue with platform 'ios' targets the iOS device via IOSCtrlProxyClient", async () => {
+    const response = await sendRequest(socketPath, "ide/setKeyValue", {
+      platform: "ios",
+      deviceId: iosDevice.deviceId,
+      appId: "com.example.app",
+      fileName: "prefs",
+      key: "theme",
+      value: "dark",
+      type: "STRING",
+    });
+
+    expect(response.success).toBe(true);
+    expect(iosSetPreference).toHaveBeenCalledWith("com.example.app", "prefs", "theme", "dark", "STRING");
+    expect(androidSetPreference).not.toHaveBeenCalled();
+  });
+
+  test("ide/setKeyValue with a null value routes to removePreference on iOS", async () => {
+    const response = await sendRequest(socketPath, "ide/setKeyValue", {
+      platform: "ios",
+      deviceId: iosDevice.deviceId,
+      appId: "com.example.app",
+      fileName: "prefs",
+      key: "theme",
+      value: null,
+      type: "STRING",
+    });
+
+    expect(response.success).toBe(true);
+    expect(iosRemovePreference).toHaveBeenCalledWith("com.example.app", "prefs", "theme");
+    expect(iosSetPreference).not.toHaveBeenCalled();
+  });
+
+  test("ide/removeKeyValue with platform 'ios' targets the iOS device", async () => {
+    const response = await sendRequest(socketPath, "ide/removeKeyValue", {
+      platform: "ios",
+      deviceId: iosDevice.deviceId,
+      appId: "com.example.app",
+      fileName: "prefs",
+      key: "theme",
+    });
+
+    expect(response.success).toBe(true);
+    expect(iosRemovePreference).toHaveBeenCalledWith("com.example.app", "prefs", "theme");
+    expect(androidRemovePreference).not.toHaveBeenCalled();
+  });
+
+  test("ide/clearKeyValueFile with platform 'ios' targets the iOS device", async () => {
+    const response = await sendRequest(socketPath, "ide/clearKeyValueFile", {
+      platform: "ios",
+      deviceId: iosDevice.deviceId,
+      appId: "com.example.app",
+      fileName: "prefs",
+    });
+
+    expect(response.success).toBe(true);
+    expect(iosClearPreferenceStore).toHaveBeenCalledWith("com.example.app", "prefs");
+    expect(androidClearPreferenceStore).not.toHaveBeenCalled();
+  });
+
+  test("ide/setKeyValue still routes to Android when platform is omitted (back-compat default)", async () => {
+    const response = await sendRequest(socketPath, "ide/setKeyValue", {
+      deviceId: androidDevice.deviceId,
+      appId: "com.example.app",
+      fileName: "prefs",
+      key: "theme",
+      value: "dark",
+      type: "STRING",
+    });
+
+    expect(response.success).toBe(true);
+    expect(androidSetPreference).toHaveBeenCalledWith("com.example.app", "prefs", "theme", "dark", "STRING");
+    expect(iosSetPreference).not.toHaveBeenCalled();
+  });
+
+  test("ide/setKeyValue rejects an unknown platform", async () => {
+    const response = await sendRequest(socketPath, "ide/setKeyValue", {
+      platform: "windows",
+      deviceId: iosDevice.deviceId,
+      appId: "com.example.app",
+      fileName: "prefs",
+      key: "theme",
+      value: "dark",
+      type: "STRING",
+    });
+
+    expect(response.success).toBe(false);
+    expect(response.error).toContain("Invalid platform");
+  });
+});


### PR DESCRIPTION
## Summary

Enable the workspace **Storage facet for iOS panes**. It was gated to Android because iOS key-value **mutations** misrouted: the daemon's `ide/setKeyValue` / `ide/removeKeyValue` / `ide/clearKeyValueFile` handlers hardcoded Android device discovery + `AndroidCtrlProxyClient`, so an iOS edit failed with the iOS device reported missing. Reads already routed by platform. This threads the pane's platform through the desktop → daemon path and removes the Android-only gate.

## Linked Issue

Closes #4708

## Bug / Regression Context

- **Prior attempts:** Raised in review of the Storage-facet PR for #4706, which deliberately deferred this cross-layer routing fix.
- **Observed symptom:** An iOS Storage-facet key-value edit failed with `Device not found: <ios-udid>` — the daemon searched only Android devices.
- **Repro steps / conditions:** Open a Storage facet on an iOS simulator pane and edit/remove/clear a key-value entry.

## Changes

- **Daemon (TS, `src/daemon/socketServer.ts`):** the three `ide/*` key-value handlers accept an optional `platform` (defaults to `android` for backward compatibility with older desktop clients), resolve the device on that platform, and dispatch through the platform-appropriate CtrlProxy client via a shared `resolveKeyValueMutationClient` helper. An unknown platform is rejected.
- **Client (Kotlin):** `AutoMobileClient.setKeyValue`/`removeKeyValue`/`clearKeyValueFile` carry a `platform` argument (default `android`); `McpDaemonClient` sends it in the `ide/*` params; `McpHttpClient`/`McpStdioClient` forward the real platform instead of a hardcoded `"android"`. `RealStorageDataSource` threads the pane's `StoragePlatform` through (new `StoragePlatform.protocolName`).
- **UI (Kotlin, `AutoMobileDesktopApp`):** `Tool.Storage` maps to `StorageFacet` for both platforms; the Android-only gate and its now-unused `Platform` import are removed.

## Acceptance criteria

1. **iOS mutations carry the platform to the daemon and target the iOS device** — `test/daemon/socketServerKeyValue.test.ts` (iOS `ide/*` route to `IOSCtrlProxyClient`; Android back-compat default; null value → `removePreference`; unknown platform rejected); `RealStorageDataSourceTest` (platform threaded to the client call); `McpDaemonClientInputTest` (platform on the wire). ✅
2. **`StorageFacet` wired for iOS (gate removed)** — `StorageFacetTest` (iOS pane runs the resolution path; `Platform.Ios.toStoragePlatform() == iOS`); gate removal verified by compilation. ✅
3. **Reads and writes verified on an iOS simulator pane** — requires live GUI verification of the desktop app against an iOS simulator; **not yet run.** See Device Verification below.

## Validation

- [x] `bun run lint` + `bun test` (only pre-existing `fast-check` install-drift property tests fail locally; unrelated to this change)
- [x] `bun run typecheck` reports no new errors (baseline gate)
- [x] Android changes: `:desktop-domain:test :desktop-core:test :desktop-app:compileKotlin` green; `scripts/ktfmt/validate_ktfmt.sh` clean
- [x] New code uses interfaces + fakes; unit tests run in <100ms
- [x] Reuses existing helpers/conventions (mirrors the `updateService` platform-routing and the storage-read platform branching)

## Kotlin Reuse Check

- [x] Reused `IOSCtrlProxyClient`/`AndroidCtrlProxyClient`, existing `StorageClient` surface, and the established platform-routing pattern; added only `StoragePlatform.protocolName` (mirrors `KeyValueType.protocolName`)
- [x] No new dependencies

## Device Verification

- [ ] AC3: verify reads + writes on an iOS simulator pane via the desktop app (live GUI check, pending)

## Follow-ups

- [ ] None identified beyond AC3's live verification.
