### PR TITLE
fix(desktop): clear Logs tail-follow on upward scroll start

### DIFF
--- a/android/desktop-core/src/main/kotlin/dev/jasonpearson/automobile/desktop/core/telemetry/LogsPanel.kt
+++ b/android/desktop-core/src/main/kotlin/dev/jasonpearson/automobile/desktop/core/telemetry/LogsPanel.kt
@@ -30,7 +30,11 @@ import androidx.compose.runtime.setValue
 import androidx.compose.runtime.snapshotFlow
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
+import androidx.compose.ui.geometry.Offset
 import androidx.compose.ui.graphics.Color
+import androidx.compose.ui.input.nestedscroll.NestedScrollConnection
+import androidx.compose.ui.input.nestedscroll.NestedScrollSource
+import androidx.compose.ui.input.nestedscroll.nestedScroll
 import androidx.compose.ui.input.pointer.PointerIcon
 import androidx.compose.ui.input.pointer.pointerHoverIcon
 import androidx.compose.ui.semantics.Role
@@ -120,6 +124,19 @@ fun filterLogs(
 }
 
 /**
+ * Whether a scroll delta should clear the panel's tail-follow intent. True only for a **user**
+ * scroll ([NestedScrollSource.UserInput] — touch drag or mouse wheel) moving toward older rows
+ * (positive `y`, i.e. content moving down / away from the tail).
+ *
+ * Deliberately excludes the panel's own programmatic re-anchor scrolls, which dispatch as
+ * [NestedScrollSource.SideEffect]: the upward `scrollToItem` after a filter narrows the list must
+ * not be mistaken for the user scrolling away, or tail-follow would defeat itself. Kept pure so the
+ * discrimination is unit-testable without Compose.
+ */
+fun clearsTailFollow(available: Offset, source: NestedScrollSource): Boolean =
+  source == NestedScrollSource.UserInput && available.y > 0f
+
+/**
  * Upper bound on retained live log rows. A high-volume device can stream logs indefinitely; without
  * a cap the buffer — and the per-append [filterLogs] cost over it — would grow until the UI stalls.
  */
@@ -169,6 +186,10 @@ fun connectionStatusText(state: ConnectionState): String? =
  * message becomes reachable. Selection is held here in composition and keyed on [activeDeviceId],
  * so it is inherently pane-local (each pane composes its own [LogsPanel]) and clears on a device
  * switch.
+ *
+ * [onFollowTailChange] observes tail-follow intent transitions (true = chasing the newest row). It
+ * is an observation seam — tests assert the intent clears on the first user upward-scroll delta
+ * rather than only when the scroll settles — and stays a no-op for real callers.
  */
 @Composable
 fun LogsPanel(
@@ -177,6 +198,7 @@ fun LogsPanel(
   platform: LogPlatform = LogPlatform.Android,
   maxRows: Int = MAX_LOG_ROWS,
   modifier: Modifier = Modifier,
+  onFollowTailChange: (Boolean) -> Unit = {},
 ) {
   val colors = SharedTheme.globalColors
   val logs = remember(activeDeviceId) { mutableStateListOf<TelemetryDisplayEvent.Log>() }
@@ -208,6 +230,19 @@ fun LogsPanel(
   // carry its scroll offset (and suppress auto-follow) into the next device.
   val listState = remember(activeDeviceId) { LazyListState() }
 
+  // Clear follow intent on the first user upward-scroll delta (see [clearsTailFollow]), so a row
+  // arriving mid-fling no longer yanks the viewport back to the tail. The settle observer below
+  // re-arms it once the user returns to the bottom. Remembered per device, like [listState].
+  val tailFollowScrollConnection =
+    remember(activeDeviceId) {
+      object : NestedScrollConnection {
+        override fun onPreScroll(available: Offset, source: NestedScrollSource): Offset {
+          if (clearsTailFollow(available, source)) followTail = false
+          return Offset.Zero
+        }
+      }
+    }
+
   LaunchedEffect(telemetryPushClient, activeDeviceId, maxRows) {
     val client = telemetryPushClient ?: return@LaunchedEffect
     client.telemetryEvents.collect { event ->
@@ -235,14 +270,17 @@ fun LogsPanel(
     client.connectionState.collect { connectionState = it }
   }
 
-  // Re-derive follow intent whenever a scroll settles: we follow iff the viewport rests at the
-  // bottom. A user drag that stops mid-list clears it; reaching the bottom (or a programmatic
-  // tail scroll) re-arms it. Filter changes do not scroll, so they never clear the intent. Keyed
-  // on activeDeviceId so a device switch restarts the observer against the reset follow state.
+  // Re-arm follow intent whenever a scroll settles: we follow iff the viewport now rests at the
+  // bottom. Immediate clearing on a user upward scroll is handled by [tailFollowScrollConnection];
+  // this settle pass re-arms once the user returns to the bottom. Filter changes do not scroll, so
+  // they never clear the intent. Keyed on activeDeviceId so a device switch restarts the observer.
   LaunchedEffect(listState, activeDeviceId) {
     snapshotFlow { listState.isScrollInProgress }
       .collect { inProgress -> if (!inProgress) followTail = !listState.canScrollForward }
   }
+
+  // Surface follow-intent transitions to the caller (observation seam; see [onFollowTailChange]).
+  LaunchedEffect(followTail) { onFollowTailChange(followTail) }
 
   // Follow the tail when following: fires on every appended row (via appendCount, which advances
   // even at the buffer cap) and on filter/platform changes (which re-anchor the list), so the
@@ -289,7 +327,10 @@ fun LogsPanel(
         Text(message, fontSize = 12.sp, color = colors.text.normal.copy(alpha = 0.4f))
       }
     } else {
-      LazyColumn(state = listState, modifier = Modifier.fillMaxSize()) {
+      LazyColumn(
+        state = listState,
+        modifier = Modifier.fillMaxSize().nestedScroll(tailFollowScrollConnection),
+      ) {
         items(
           count = filtered.size,
           key = { index ->

--- a/android/desktop-core/src/test/kotlin/dev/jasonpearson/automobile/desktop/core/telemetry/LogsPanelTest.kt
+++ b/android/desktop-core/src/test/kotlin/dev/jasonpearson/automobile/desktop/core/telemetry/LogsPanelTest.kt
@@ -6,6 +6,8 @@ import androidx.compose.foundation.layout.height
 import androidx.compose.material3.MaterialTheme
 import androidx.compose.runtime.mutableStateOf
 import androidx.compose.ui.Modifier
+import androidx.compose.ui.geometry.Offset
+import androidx.compose.ui.input.nestedscroll.NestedScrollSource
 import androidx.compose.ui.test.ExperimentalTestApi
 import androidx.compose.ui.test.assertIsDisplayed
 import androidx.compose.ui.test.assertIsNotSelected
@@ -23,11 +25,14 @@ import androidx.compose.ui.test.performClick
 import androidx.compose.ui.test.performScrollToIndex
 import androidx.compose.ui.test.performTextClearance
 import androidx.compose.ui.test.performTextInput
+import androidx.compose.ui.test.performTouchInput
 import androidx.compose.ui.test.runComposeUiTest
 import androidx.compose.ui.unit.dp
 import dev.jasonpearson.automobile.desktop.core.connection.ConnectionState
 import dev.jasonpearson.automobile.desktop.core.daemon.FakeTelemetryPushClient
 import org.junit.Assert.assertEquals
+import org.junit.Assert.assertFalse
+import org.junit.Assert.assertTrue
 import org.junit.Test
 
 @OptIn(ExperimentalTestApi::class)
@@ -140,6 +145,27 @@ class LogsPanelTest {
     // On the iOS scale level 3 = Warn and level 5 = Error (fault).
     assertEquals(listOf(logs[0]), filterLogs(logs, setOf(LogLevel.Warn), "", LogPlatform.Ios))
     assertEquals(listOf(logs[1]), filterLogs(logs, setOf(LogLevel.Error), "", LogPlatform.Ios))
+  }
+
+  // -- Tail-follow clear-decision tests (pure) --
+
+  @Test
+  fun `a user upward scroll clears tail-follow intent`() {
+    // Positive y = content moving down = scrolling toward older rows (away from the tail).
+    assertTrue(clearsTailFollow(Offset(0f, 12f), NestedScrollSource.UserInput))
+  }
+
+  @Test
+  fun `a user downward scroll does not clear tail-follow intent`() {
+    // Scrolling toward the tail must not clear the intent; reaching the bottom re-arms it instead.
+    assertFalse(clearsTailFollow(Offset(0f, -12f), NestedScrollSource.UserInput))
+  }
+
+  @Test
+  fun `a programmatic scroll never clears tail-follow intent`() {
+    // The panel's own re-anchor scrolls (e.g. the upward scrollToItem after a filter narrows the
+    // list) dispatch as SideEffect and must be ignored, or they would defeat tail-follow.
+    assertFalse(clearsTailFollow(Offset(0f, 12f), NestedScrollSource.SideEffect))
   }
 
   // -- Compose UI tests --
@@ -303,6 +329,93 @@ class LogsPanelTest {
       onAllNodesWithText("row 10").fetchSemanticsNodes().isNotEmpty()
     }
     onNodeWithText("row 10").assertIsDisplayed()
+  }
+
+  @Test
+  fun `starting an upward drag clears follow intent before the scroll settles`() =
+    runComposeUiTest {
+      val fake = FakeTelemetryPushClient()
+      val followStates = mutableListOf<Boolean>()
+      setContent {
+        MaterialTheme {
+          Box(Modifier.height(120.dp)) {
+            LogsPanel(
+              telemetryPushClient = fake,
+              activeDeviceId = "dev-1",
+              onFollowTailChange = { followStates.add(it) },
+            )
+          }
+        }
+      }
+      waitForIdle()
+      for (i in 0 until 30) {
+        fake.emitEvent(log(4, "T", "row $i", i.toLong()))
+      }
+      // Following the tail: the newest row is visible and follow intent is set.
+      waitUntil(timeoutMillis = 2_000) {
+        onAllNodesWithText("row 29").fetchSemanticsNodes().isNotEmpty()
+      }
+      followStates.clear()
+
+      // Begin a user upward scroll and hold it: finger down, then dragged down (content moves down,
+      // i.e. scrolling toward older rows) with no release, so the gesture stays in progress and
+      // never settles. The intent must clear from this first delta, not from a settle that never
+      // comes.
+      onNode(hasScrollToIndexAction()).performTouchInput {
+        down(center)
+        moveBy(Offset(0f, 250f))
+      }
+      waitForIdle()
+
+      assertTrue(
+        "user upward scroll should clear follow intent mid-gesture",
+        followStates.contains(false),
+      )
+    }
+
+  @Test
+  fun `reaching the bottom re-arms follow intent`() = runComposeUiTest {
+    val fake = FakeTelemetryPushClient()
+    setContent {
+      MaterialTheme {
+        Box(Modifier.height(120.dp)) {
+          LogsPanel(telemetryPushClient = fake, activeDeviceId = "dev-1")
+        }
+      }
+    }
+    waitForIdle()
+    for (i in 0 until 30) {
+      fake.emitEvent(log(4, "T", "row $i", i.toLong()))
+    }
+    waitUntil(timeoutMillis = 2_000) {
+      onAllNodesWithText("row 29").fetchSemanticsNodes().isNotEmpty()
+    }
+
+    // Scroll the user away from the tail (drag content down), so follow intent clears and a new row
+    // is no longer chased — it stays below the fold, uncomposed.
+    onNode(hasScrollToIndexAction()).performTouchInput {
+      down(center)
+      moveBy(Offset(0f, 250f))
+      up()
+    }
+    waitForIdle()
+    fake.emitEvent(log(4, "T", "row 30", 30L))
+    waitForIdle()
+    onNodeWithText("row 30").assertDoesNotExist()
+
+    // Return to the bottom (drag content up, overscrolling to clamp at the tail): reaching it
+    // re-arms follow, so the next live row is chased again.
+    onNode(hasScrollToIndexAction()).performTouchInput {
+      down(center)
+      moveBy(Offset(0f, -3000f))
+      up()
+    }
+    waitForIdle()
+    fake.emitEvent(log(4, "T", "row 31", 31L))
+    waitUntil(timeoutMillis = 2_000) {
+      onAllNodesWithText("row 31").fetchSemanticsNodes().isNotEmpty()
+    }
+    onNodeWithText("row 31").assertIsDisplayed()
   }
 
   @Test


### PR DESCRIPTION
## Summary

The desktop Logs facet's tail-follow only re-derived its `followTail` intent when a scroll
**settled** (`snapshotFlow { isScrollInProgress }.collect { if (!it) followTail = !canScrollForward }`).
During an in-progress upward wheel-scroll or fling, `followTail` stayed `true`, so a log arriving
mid-fling triggered the append-follow effect and re-anchored the viewport to the bottom —
interrupting the user's scroll on a busy feed.

This clears `followTail` on the **first user upward-scroll delta** instead of waiting for settle,
via a `NestedScrollConnection` on the log `LazyColumn`. The decision is a pure, unit-tested
function (`clearsTailFollow`) that fires only for `NestedScrollSource.UserInput` deltas moving
toward older rows. The panel's own programmatic re-anchor `scrollToItem` dispatches as
`SideEffect`, so it is never mistaken for the user scrolling away — the "tail-follow survives
filter changes" behavior from PR #4842 is preserved. The existing settle observer is kept, now
solely to re-arm `followTail` when the user returns to the bottom.

## Linked Issue

Closes #4849

## Bug / Regression Context

- **Prior attempts:** deferred from PR #4842 (filter-bar first cut); clearing on upward delta was
  out of scope there because it must distinguish user scrolls from the panel's own programmatic
  upward re-anchor.
- **Observed symptom:** on a continuously active feed, scrolling up to read older rows kept getting
  yanked back to the newest row.
- **Repro:** stream logs faster than you can read; scroll/fling upward; a row arriving mid-fling
  snaps the list back to the tail.

## Validation

- [x] Android change: `:desktop-core:test` green (26 tests incl. the new ones); ktfmt clean on
  touched files. Gesture-based UI tests run 3× with `--rerun-tasks` — stable, no flake.
- [ ] `scripts/all_fast_validate_checks.sh` / `bun run typecheck` — N/A, this PR touches no
  TypeScript (`android/desktop-core` Kotlin only).

## Kotlin Reuse Check

- [x] Uses Compose's `NestedScrollConnection` / `NestedScrollSource` (AndroidX/Compose) directly —
  no new helper, wrapper, `*Util`, or dependency. `clearsTailFollow` is a pure function beside the
  existing `logLevelOf` / `filterLogs` in the same file, matching the module's testable-decision
  convention.

## Acceptance criteria

1. [x] User-initiated upward scroll (wheel or drag) clears `followTail` immediately, not on settle —
   `starting an upward drag clears follow intent before the scroll settles` (held drag, never
   settles) + pure `a user upward scroll clears tail-follow intent`.
2. [x] Programmatic tail/re-anchor scrolls do NOT clear `followTail` — pure `a programmatic scroll
   never clears tail-follow intent` (`SideEffect`) + the two existing tail-follow tests, which
   depend on the programmatic upward re-anchor surviving.
3. [x] Reaching the bottom re-arms `followTail` — `reaching the bottom re-arms follow intent`.
4. [x] Existing tail-follow tests still pass (`survives filtering to an old row then clearing`,
   `keeps following once the buffer is at its cap`).
