### PR TITLE
chore: align package.json Bun pin to 1.3.9 to match CI

### DIFF
--- a/package.json
+++ b/package.json
@@ -57,9 +57,9 @@
     "turbo:lint": "turbo run lint",
     "turbo:test": "turbo run test"
   },
-  "packageManager": "bun@1.3.6",
+  "packageManager": "bun@1.3.9",
   "engines": {
-    "bun": ">=1.3.6"
+    "bun": ">=1.3.9"
   },
   "keywords": [
     "adb",

--- a/test/packaging/bunPinConsistency.test.ts
+++ b/test/packaging/bunPinConsistency.test.ts
@@ -1,0 +1,37 @@
+import { describe, expect, test } from "bun:test";
+import { readFileSync } from "node:fs";
+import path from "node:path";
+
+/**
+ * Drift-guard for the declared Bun version (issue #5026).
+ *
+ * `packageManager: "bun@X"` and `engines.bun: ">=X"` must name the SAME version.
+ * They drifted once already (packageManager pinned 1.3.6 while the toolchain and
+ * engines floor moved on), which is exactly the failure this pins. The test
+ * asserts the two stay in lock-step rather than hard-coding a specific version,
+ * so a legitimate future bump that moves BOTH lines together keeps it green while
+ * a bump that touches only one goes red. The specific value (1.3.9, matching the
+ * CI `setup-bun` pin) is locked from the CI side by
+ * test/bats/release-workflow-wiring.bats.
+ */
+describe("Bun version pin consistency", () => {
+  const repoRoot = path.resolve(import.meta.dir, "../..");
+  const pkg = JSON.parse(readFileSync(path.join(repoRoot, "package.json"), "utf8"));
+
+  test("packageManager declares bun", () => {
+    expect(typeof pkg.packageManager).toBe("string");
+    expect(pkg.packageManager.startsWith("bun@")).toBe(true);
+  });
+
+  test("engines.bun is a >= floor", () => {
+    expect(typeof pkg.engines?.bun).toBe("string");
+    expect(pkg.engines.bun.startsWith(">=")).toBe(true);
+  });
+
+  test("packageManager version matches the engines.bun floor", () => {
+    const packageManagerVersion = pkg.packageManager.slice("bun@".length);
+    // Strip any leading range operator(s) (>=, >, ^, ~) from the engines floor.
+    const enginesFloor = pkg.engines.bun.replace(/^[>=~^\s]+/, "");
+    expect(packageManagerVersion).toBe(enginesFloor);
+  });
+});


### PR DESCRIPTION
## Summary

Aligns the declared Bun version so `package.json` matches the version CI actually
validates against. `packageManager` and `engines.bun` both moved from `1.3.6` to
`1.3.9` — the pin every CI `setup-bun` step (release, merge, nightly,
pull_request, prepare-release, and the `setup-auto-mobile-npm-package` action)
already uses. The declared floor was stale (older than what CI tests on).

Adds a small drift-guard unit test that keeps `packageManager` and `engines.bun`
in lock-step, so this exact drift can't silently recur. The test pins the
*invariant* (the two versions must match) rather than hard-coding `1.3.9`, so a
future bump that moves both lines together stays green; the specific `1.3.9`
value is already locked from the CI side by
`test/bats/release-workflow-wiring.bats`.

## Linked Issue

Closes #5026

## Validation

- [x] `turbo run lint build test` green (3m15s, no regressions)
- [x] `bun run typecheck` — no new errors (195 baseline)
- [x] New drift-guard test: 3 assertions, <2ms, parses `package.json` only
- [x] Reuses stdlib (`readFileSync`/`JSON.parse`); no new dependency
- [x] Branch cut from latest `origin/main`; no `bun.lock` churn

## Out of scope (deferred)

The repo-wide CI `setup-bun` `1.3.9`→`1.3.14` bump is coupled to adopting
`bun test --parallel` as the default runner (which needs a CI Bun known to accept
`--parallel`) and is deferred with that work.
