### PR TITLE
fix(ios): normalize OSLogReader log levels to the SDK scale

### DIFF
--- a/ios/control-proxy/CtrlProxy.xcodeproj/project.pbxproj
+++ b/ios/control-proxy/CtrlProxy.xcodeproj/project.pbxproj
@@ -85,6 +85,7 @@
 		D0C171171348407EBFF5BAB7 /* PerfProvider.swift in Sources */ = {isa = PBXBuildFile; fileRef = A284B6FFBE969931BB03A2FF /* PerfProvider.swift */; };
 		D9EF3A486E53F97C1CCB7A3B /* GesturePerformer.swift in Sources */ = {isa = PBXBuildFile; fileRef = F2144B84CD70DB35A1030624 /* GesturePerformer.swift */; };
 		DFEE186C8B4CD32EF76D995A /* AppDelegate.swift in Sources */ = {isa = PBXBuildFile; fileRef = 878A53A7F0EDDABDF2435E7F /* AppDelegate.swift */; };
+		E48A38EAE6AD5408BB7007CE /* OSLogReaderTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = DB4D52EC87CA484C4BC98756 /* OSLogReaderTests.swift */; };
 		E75D4EFAF582079165A67B66 /* VoiceOverStateProvider.swift in Sources */ = {isa = PBXBuildFile; fileRef = 10362B68AB9153544B411CCA /* VoiceOverStateProvider.swift */; };
 		E8327D679D58C8F804C064B1 /* PerformanceMetrics.swift in Sources */ = {isa = PBXBuildFile; fileRef = B136EAD78CC0B932F258C265 /* PerformanceMetrics.swift */; };
 		E8B2051927387427E1F14EC2 /* ElementLocatorTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = B7BE98EA2924A42A6CD22993 /* ElementLocatorTests.swift */; };
@@ -230,6 +231,7 @@
 		CD4BE559FB2C03A096815C9F /* FrameContext.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = FrameContext.swift; sourceTree = "<group>"; };
 		D219492B8663B05AFF608428 /* ObjCExceptionCatcher.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = ObjCExceptionCatcher.h; sourceTree = "<group>"; };
 		D81453AD074F2A392251CFC3 /* Models.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = Models.swift; sourceTree = "<group>"; };
+		DB4D52EC87CA484C4BC98756 /* OSLogReaderTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = OSLogReaderTests.swift; sourceTree = "<group>"; };
 		DBA97A6C3A1240A055D9876C /* OSLogReader.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = OSLogReader.swift; sourceTree = "<group>"; };
 		DEF454F64F7AF11BD79DB97D /* PerfProviderTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = PerfProviderTests.swift; sourceTree = "<group>"; };
 		E30D131E590A0CF8F9674B0E /* ClipboardResolutionTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ClipboardResolutionTests.swift; sourceTree = "<group>"; };
@@ -304,6 +306,7 @@
 				184CFC1280E0802EBF53965F /* ModelsTests.swift */,
 				FD1A7B72077B573AA4582DF2 /* MultiFingerSwipeDiagnosticsTests.swift */,
 				649A3185201F07E4D152CED6 /* ObjCExceptionBridgeTests.swift */,
+				DB4D52EC87CA484C4BC98756 /* OSLogReaderTests.swift */,
 				DEF454F64F7AF11BD79DB97D /* PerfProviderTests.swift */,
 				6FC3D01763F51CE349F7E923 /* PinchFallbackTests.swift */,
 				4EE070E3D058AF5F67D2E1F3 /* PinchGeometryTests.swift */,
@@ -648,6 +651,7 @@
 				CFCA362E1EF1F3251B19BC1B /* HierarchyMergerTests.swift in Sources */,
 				F7B78DBB0517EC004EF4ECF6 /* ModelsTests.swift in Sources */,
 				CA9CCB8B41C9BFF6FB797CA6 /* MultiFingerSwipeDiagnosticsTests.swift in Sources */,
+				E48A38EAE6AD5408BB7007CE /* OSLogReaderTests.swift in Sources */,
 				6733CA6A1FABC8D7C34F9327 /* ObjCExceptionBridgeTests.swift in Sources */,
 				0E8A9A62BEF9C4E672D09764 /* PerfProviderTests.swift in Sources */,
 				F428A1892AAF5D4F83AD4C1B /* PinchFallbackTests.swift in Sources */,

--- a/ios/control-proxy/Sources/CtrlProxy/OSLogReader.swift
+++ b/ios/control-proxy/Sources/CtrlProxy/OSLogReader.swift
@@ -98,7 +98,7 @@ public final class OSLogReader {
                 guard entry.date > lastEntryDate else { continue }
 
                 if let logEntry = entry as? OSLogEntryLog {
-                    let level = mapLevel(logEntry.level)
+                    let level = Self.mapLevel(logEntry.level)
                     let tag = logEntry.subsystem.isEmpty ? nil : logEntry.subsystem
                     let message: String
                     if logEntry.category.isEmpty {
@@ -137,28 +137,35 @@ public final class OSLogReader {
         }
     }
 
-    /// Map OSLogEntryLog.Level to Android-compatible log level integers.
-    /// - `.debug` -> 3 (D)
-    /// - `.info` -> 4 (I)
-    /// - `.notice` -> 4 (I)
-    /// - `.error` -> 6 (E)
-    /// - `.fault` -> 7 (F)
-    private func mapLevel(_ level: OSLogEntryLog.Level) -> Int {
+    /// Map `OSLogEntryLog.Level` to the AutoMobile SDK's `LogLevel` scale
+    /// (`verbose=0, debug=1, info=2, warning=3, error=4, fault=5`), the same scale
+    /// `SdkLogEvent.level` uses. OSLog entries are served on the SDK-events endpoint
+    /// alongside SDK log events and share one numeric scale downstream, so they must
+    /// use the SDK scale — not an Android-style one — or the desktop Logs facet
+    /// mis-buckets them (issue #4847). OSLog has no "warning" severity, so `.notice`
+    /// (its default level) folds into `info`.
+    /// - `.debug`  -> 1 (debug)
+    /// - `.info`   -> 2 (info)
+    /// - `.notice` -> 2 (info)
+    /// - `.error`  -> 4 (error)
+    /// - `.fault`  -> 5 (fault)
+    /// - `.undefined` / unknown -> 2 (info)
+    static func mapLevel(_ level: OSLogEntryLog.Level) -> Int {
         switch level {
         case .undefined:
-            return 4
+            return 2
         case .debug:
-            return 3
+            return 1
         case .info:
-            return 4
+            return 2
         case .notice:
-            return 4
+            return 2
         case .error:
-            return 6
-        case .fault:
-            return 7
-        @unknown default:
             return 4
+        case .fault:
+            return 5
+        @unknown default:
+            return 2
         }
     }
 }

--- a/ios/control-proxy/Tests/CtrlProxyTests/OSLogReaderTests.swift
+++ b/ios/control-proxy/Tests/CtrlProxyTests/OSLogReaderTests.swift
@@ -1,0 +1,34 @@
+@testable import CtrlProxy
+import OSLog
+import XCTest
+
+/// OSLog entries are served on the SDK-events endpoint alongside AutoMobile SDK log
+/// events and share one numeric level scale downstream (the desktop Logs facet buckets
+/// every iOS row on the SDK `LogLevel` scale). So `OSLogReader.mapLevel` must emit the
+/// SDK scale (`verbose=0, debug=1, info=2, warning=3, error=4, fault=5`) — not an
+/// Android-style one — or OSLog rows mis-bucket against SDK rows in the same stream
+/// (issue #4847).
+@available(iOS 15.0, macOS 12.0, *)
+final class OSLogReaderTests: XCTestCase {
+    func testMapsEachOSLogLevelToTheSdkScale() {
+        XCTAssertEqual(OSLogReader.mapLevel(.debug), 1, "debug -> SDK debug (1)")
+        XCTAssertEqual(OSLogReader.mapLevel(.info), 2, "info -> SDK info (2)")
+        // OSLog has no warning severity; .notice is its default level, closest to info.
+        XCTAssertEqual(OSLogReader.mapLevel(.notice), 2, "notice -> SDK info (2)")
+        XCTAssertEqual(OSLogReader.mapLevel(.error), 4, "error -> SDK error (4)")
+        XCTAssertEqual(OSLogReader.mapLevel(.fault), 5, "fault -> SDK fault (5)")
+        // Unknown severities default to info rather than a high level, so an
+        // unrecognized entry is never surfaced as an error.
+        XCTAssertEqual(OSLogReader.mapLevel(.undefined), 2, "undefined -> SDK info (2)")
+    }
+
+    /// The desktop buckets an iOS row by folding its SDK-scale level through the same
+    /// thresholds for both sources: 0->Verbose, 1->Debug, 2->Info, 3->Warn, 4/5->Error.
+    /// These are the buckets an OSLog error and fault must land in once normalized, so an
+    /// OSLog error and an SDK fault both read as Error in one stream.
+    func testNormalizedLevelsLandInTheExpectedDesktopBuckets() {
+        XCTAssertLessThanOrEqual(OSLogReader.mapLevel(.debug), 1) // Debug or below
+        XCTAssertEqual(OSLogReader.mapLevel(.error), 4) // Error bucket (>=4)
+        XCTAssertGreaterThanOrEqual(OSLogReader.mapLevel(.fault), 4) // Error bucket
+    }
+}


### PR DESCRIPTION
## Summary

`OSLogReader` (iOS control-proxy runner) mapped `OSLogEntryLog.Level` to **Android-style**
integers (`.debug→3, .info/.notice→4, .error→6, .fault→7`). But its entries are served on the
same `GET /sdk-events` endpoint as AutoMobile **SDK** log events, and the desktop Logs facet
buckets every iOS row on the **SDK `LogLevel` scale** (`verbose=0 … fault=5`). So OSLog rows
mis-bucketed — e.g. an OSLog `.info` (4) rendered as **Error**, a `.debug` (3) as **Warn**.

This maps OSLog levels onto the SDK scale at the source (`.debug=1, .info/.notice=2, .error=4,
.fault=5`, unknown→info), so both iOS log sources share one scale and the existing per-pane iOS
bucketing is correct for both. This also makes `OSLogReader` honor its own file header, which
already calls its entries "SdkLogEvent-compatible". OSLog has no "warning" severity, so `.notice`
(its default level) folds into `info`.

## Linked Issue

Closes #4847

## Approach note (deviation from the issue's acceptance criteria — pre-approved)

The issue's ACs prescribe adding a **per-row `source` discriminator** (SDK vs OSLogReader) through
the telemetry wire envelope + desktop model, then selecting the scale per row. The end-to-end trace
showed the two sources become **structurally identical** at `WebSocketServer.swift` (`GET
/sdk-events` merges them; same `eventType:"log"`, same key set) and are indistinguishable at every
layer after — so the daemon cannot tag them without a Swift change **anyway**.

Given a Swift change to the runner is unavoidable for *any* correct fix, the chosen approach
**normalizes the levels at the source** instead of adding a wire-schema discriminator. It fixes the
reported mis-bucketing with one Swift file (no wire-envelope change, no TS change, no desktop model
change), at materially lower risk. Trade-off: it does not add a `source` field, so it does not
enable future source-aware UI (filter/label by origin); if that becomes desired it can be a separate
enhancement. This deviation was reviewed and approved before implementation.

## ⚠️ Delivery: requires an iOS runner re-cut

This changes `ios/control-proxy/Sources/**`, which ships as the **pinned, checksummed iOS
control-proxy runner** the daemon downloads (`src/constants/release.ts`). The fix is **not effective
in the field until the iOS runner is re-cut** (nightly/release rebuilds the runner, recomputes the
sha256, and bumps the pin). This PR does not itself re-cut the runner. **Merge is a hand-off
decision** (higher-risk: runner source), and the re-cut is a required sequenced follow-on.

## Validation

- [x] `swift test --filter OSLogReaderTests` — red→green; full `CtrlProxyTests` suite **453 tests, 0
  failures** (no regression).
- [x] SwiftLint (the iOS PR gate) clean on both files. (SwiftFormat is not a CI gate here.)
- [x] `xcodegen` regenerated `CtrlProxy.xcodeproj` for the new test file (pinned 2.46.0); drift check
  in sync. Diff is exactly the 4 lines registering `OSLogReaderTests.swift`.
- [x] Confirmed no TS/Kotlin/test anywhere is coupled to the old Android-style OSLog levels — the
  only consumer of an iOS log level is the desktop `logLevelOf(Ios)`, now consistent. No wire/schema
  change, so Android and SDK-iOS paths are undisturbed.
- [ ] `bun`/desktop suites — N/A, this PR touches no TypeScript or Kotlin.

## Acceptance criteria mapping

- AC1/AC2 (add `source` discriminator + per-row scale selection): **intentionally not implemented** —
  the approved approach resolves the ambiguity at the source instead (see Approach note).
- AC3 (a test covers both iOS sources bucketing correctly): `OSLogReaderTests` pins OSLog→SDK-scale
  mapping; combined with the existing desktop `logLevelOf(Ios)` / `filterLogs` iOS tests, an OSLog
  error (now 4) and an SDK fault (5) both bucket to Error on the one iOS scale.
