### PR TITLE
perf(ios): pin local simulator builds to arm64 + skip index store

### DIFF
--- a/scripts/ios/ctrl-proxy-build-for-testing.sh
+++ b/scripts/ios/ctrl-proxy-build-for-testing.sh
@@ -39,8 +39,17 @@ NC='\033[0m' # No Color
 SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
 # shellcheck source=scripts/ios/xcodegen_version.sh disable=SC1091
 source "${SCRIPT_DIR}/xcodegen_version.sh"
+# shellcheck source=scripts/ios/local-sim-build-args.sh disable=SC1091
+source "${SCRIPT_DIR}/local-sim-build-args.sh"
 PROJECT_ROOT="$(cd "${SCRIPT_DIR}/../.." && pwd)"
 CTRL_PROXY_IOS_DIR="${PROJECT_ROOT}/ios/control-proxy"
+
+# On a local arm64 host, build only the arch the simulator runs and skip the
+# index store; empty in CI / on Intel so those keep building universal (#5024).
+LOCAL_SIM_ARGS=()
+while IFS= read -r _arg; do
+    [ -n "${_arg}" ] && LOCAL_SIM_ARGS+=("${_arg}")
+done < <(local_sim_build_args)
 XCODEPROJ="${CTRL_PROXY_IOS_DIR}/CtrlProxy.xcodeproj"
 
 # Default derived data path (matches IOSCtrlProxyBuilder.ts)
@@ -111,7 +120,8 @@ run_xcodebuild() {
         -configuration Debug \
         CODE_SIGN_IDENTITY="-" \
         CODE_SIGNING_REQUIRED=NO \
-        CODE_SIGNING_ALLOWED=NO
+        CODE_SIGNING_ALLOWED=NO \
+        "${LOCAL_SIM_ARGS[@]}"
 }
 
 if command -v xcpretty >/dev/null 2>&1; then

--- a/scripts/ios/local-sim-build-args.sh
+++ b/scripts/ios/local-sim-build-args.sh
@@ -1,0 +1,37 @@
+#!/bin/bash
+#
+# Extra xcodebuild build settings for LOCAL iOS Simulator builds (issue #5024).
+#
+# `generic/platform=iOS Simulator` with no arch pin builds a fat x86_64+arm64
+# binary. On an Apple Silicon host the simulator runs arm64, so the x86_64 slice
+# is compiled, linked, and thrown away — every file built twice. These headless
+# script builds also never feed Xcode's index, so the default index-store pass
+# is wasted work.
+#
+# `local_sim_build_args` emits (one per line) the settings that trim a build to
+# the arch the local simulator actually runs and skip the index store — but ONLY
+# on a local arm64 host. It emits nothing under CI (where universal artifacts may
+# be wanted) or on a non-arm64 host (Intel simulators need x86_64), so those
+# paths keep building universal. The release IPA path
+# (ctrl-proxy-create-ipa.sh) deliberately does not consult this helper.
+#
+# Side-effect free and safe to source. Callers collect the lines into an array,
+# e.g.:
+#   EXTRA_ARGS=()
+#   while IFS= read -r a; do [ -n "$a" ] && EXTRA_ARGS+=("$a"); done \
+#     < <(local_sim_build_args)
+#   xcodebuild ... "${EXTRA_ARGS[@]}"
+
+# shellcheck source=scripts/lib/shell-core.sh disable=SC1091
+source "$(cd "$(dirname "${BASH_SOURCE[0]}")/../lib" && pwd)/shell-core.sh"
+
+local_sim_build_args() {
+    # CI may want universal simulator artifacts; leave the build untouched.
+    [ -n "${CI:-}" ] && return 0
+    # Intel hosts run x86_64 simulators; only arm64 hosts can drop a slice.
+    [ "$(detect_arch)" = "arm64" ] || return 0
+    printf '%s\n' \
+        "ONLY_ACTIVE_ARCH=YES" \
+        "ARCHS=arm64" \
+        "COMPILER_INDEX_STORE_ENABLE=NO"
+}

--- a/scripts/ios/swift-build.sh
+++ b/scripts/ios/swift-build.sh
@@ -15,8 +15,17 @@ NC='\033[0m' # No Color
 
 # Script directory
 SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+# shellcheck source=scripts/ios/local-sim-build-args.sh disable=SC1091
+source "${SCRIPT_DIR}/local-sim-build-args.sh"
 PROJECT_ROOT="$(cd "${SCRIPT_DIR}/../.." && pwd)"
 IOS_DIR="${PROJECT_ROOT}/ios"
+
+# On a local arm64 host, build only the arch the simulator runs and skip the
+# index store; empty in CI / on Intel so those keep building universal (#5024).
+LOCAL_SIM_ARGS=()
+while IFS= read -r _arg; do
+    [ -n "${_arg}" ] && LOCAL_SIM_ARGS+=("${_arg}")
+done < <(local_sim_build_args)
 
 echo -e "${CYAN}========================================${NC}"
 echo -e "${CYAN}  Swift Package Build${NC}"
@@ -125,7 +134,7 @@ for package in "${IOS_ONLY_PACKAGES[@]}"; do
     if [ -f "${PACKAGE_DIR}/Package.swift" ]; then
         echo -e "  Building ${package} for iOS simulator..."
         # Use xcodebuild to build for iOS simulator since swift build doesn't support cross-compilation
-        if (cd "${PACKAGE_DIR}" && xcodebuild -scheme "${package}" -destination 'generic/platform=iOS Simulator' -quiet build 2>&1); then
+        if (cd "${PACKAGE_DIR}" && xcodebuild -scheme "${package}" -destination 'generic/platform=iOS Simulator' "${LOCAL_SIM_ARGS[@]}" -quiet build 2>&1); then
             print_status 0 "${package} built successfully for iOS simulator"
         else
             print_status 1 "${package} build failed for iOS simulator"

--- a/scripts/ios/xcode-build.sh
+++ b/scripts/ios/xcode-build.sh
@@ -30,8 +30,17 @@ NC='\033[0m' # No Color
 SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
 # shellcheck source=scripts/ios/xcodegen_version.sh disable=SC1091
 source "${SCRIPT_DIR}/xcodegen_version.sh"
+# shellcheck source=scripts/ios/local-sim-build-args.sh disable=SC1091
+source "${SCRIPT_DIR}/local-sim-build-args.sh"
 PROJECT_ROOT="$(cd "${SCRIPT_DIR}/../.." && pwd)"
 IOS_DIR="${PROJECT_ROOT}/ios"
+
+# On a local arm64 host, build only the arch the simulator runs and skip the
+# index store; empty in CI / on Intel so those keep building universal (#5024).
+LOCAL_SIM_ARGS=()
+while IFS= read -r _arg; do
+    [ -n "${_arg}" ] && LOCAL_SIM_ARGS+=("${_arg}")
+done < <(local_sim_build_args)
 
 echo -e "${CYAN}========================================${NC}"
 echo -e "${CYAN}  Xcode Project Build${NC}"
@@ -190,6 +199,7 @@ for xcodeproj in "${XCODEPROJ_ARRAY[@]}"; do
                 CODE_SIGN_IDENTITY="-" \
                 CODE_SIGNING_REQUIRED=NO \
                 CODE_SIGNING_ALLOWED=NO \
+                "${LOCAL_SIM_ARGS[@]}" \
                 build 2>&1)
             XCODE_EXIT=$?
             set -e

--- a/scripts/ios/xcode-test.sh
+++ b/scripts/ios/xcode-test.sh
@@ -16,8 +16,17 @@ NC='\033[0m' # No Color
 
 # Script directory
 SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+# shellcheck source=scripts/ios/local-sim-build-args.sh disable=SC1091
+source "${SCRIPT_DIR}/local-sim-build-args.sh"
 PROJECT_ROOT="$(cd "${SCRIPT_DIR}/../.." && pwd)"
 IOS_DIR="${PROJECT_ROOT}/ios"
+
+# On a local arm64 host, build only the arch the simulator runs and skip the
+# index store; empty in CI / on Intel so those keep building universal (#5024).
+LOCAL_SIM_ARGS=()
+while IFS= read -r _arg; do
+    [ -n "${_arg}" ] && LOCAL_SIM_ARGS+=("${_arg}")
+done < <(local_sim_build_args)
 
 echo -e "${CYAN}========================================${NC}"
 echo -e "${CYAN}  Xcode Project Tests${NC}"
@@ -138,6 +147,7 @@ for xcodeproj in ${XCODEPROJ_DIRS}; do
             -destination "${DESTINATION}" \
             -configuration Debug \
             -quiet \
+            "${LOCAL_SIM_ARGS[@]}" \
             test 2>&1; then
             echo -e "    ${GREEN}✓${NC} ${FIRST_SCHEME} tests passed"
             TESTS_RAN=true

--- a/test/bats/local-sim-build-args.bats
+++ b/test/bats/local-sim-build-args.bats
@@ -58,7 +58,9 @@ EOF
   stub_uname arm64
   run bash -c "source '$HELPER'; echo sourced-ok"
   [ "$status" -eq 0 ]
-  [ "${lines[-1]}" = "sourced-ok" ]
+  # Negative array subscripts (${lines[-1]}) need bash 4.3+; the macOS CI runner
+  # rejects them, so index the last line explicitly to stay bash-3.2 portable.
+  [ "${lines[$((${#lines[@]} - 1))]}" = "sourced-ok" ]
 }
 
 # --- Wiring: the four local build/test scripts must consult the helper. ---

--- a/test/bats/local-sim-build-args.bats
+++ b/test/bats/local-sim-build-args.bats
@@ -1,0 +1,86 @@
+#!/usr/bin/env bats
+#
+# Tests for scripts/ios/local-sim-build-args.sh (issue #5024).
+#
+# Local iOS simulator builds on Apple Silicon default to a fat x86_64+arm64
+# binary; the x86_64 slice never runs on an arm64 simulator, so every file is
+# compiled and linked twice for nothing. `local_sim_build_args` emits the
+# xcodebuild settings that trim a local build to the arch the simulator actually
+# runs (arm64) and skip the index store that only an interactive Xcode needs —
+# but ONLY on a local arm64 host, so CI and Intel machines keep building
+# universal. `uname` is stubbed on PATH so these never depend on the real host.
+
+setup() {
+  REPO_ROOT="$(cd "$(dirname "$BATS_TEST_FILENAME")/../.." && pwd)"
+  HELPER="$REPO_ROOT/scripts/ios/local-sim-build-args.sh"
+  STUB_DIR="$BATS_TEST_TMPDIR/stubs"
+  mkdir -p "$STUB_DIR"
+  # Neutral default: unset CI so the "local" branch is exercised unless a test
+  # opts back into CI. BATS may run under CI itself.
+  unset CI
+}
+
+# Fake `uname` on PATH reporting $1 for `uname -m` (and a sane -s otherwise).
+stub_uname() {
+  cat > "$STUB_DIR/uname" <<EOF
+#!/bin/bash
+if [ "\$1" = "-m" ]; then echo "$1"; else echo "Darwin"; fi
+EOF
+  chmod +x "$STUB_DIR/uname"
+  PATH="$STUB_DIR:$PATH"
+}
+
+@test "local arm64 host (CI unset) emits arm64-only + no-index settings" {
+  stub_uname arm64
+  run bash -c "source '$HELPER'; local_sim_build_args"
+  [ "$status" -eq 0 ]
+  [ "${lines[0]}" = "ONLY_ACTIVE_ARCH=YES" ]
+  [ "${lines[1]}" = "ARCHS=arm64" ]
+  [ "${lines[2]}" = "COMPILER_INDEX_STORE_ENABLE=NO" ]
+  [ "${#lines[@]}" -eq 3 ]
+}
+
+@test "CI set (arm64) emits nothing — CI keeps building universal" {
+  stub_uname arm64
+  run bash -c "export CI=1; source '$HELPER'; local_sim_build_args"
+  [ "$status" -eq 0 ]
+  [ -z "$output" ]
+}
+
+@test "non-arm64 host (x86_64, CI unset) emits nothing — Intel keeps universal" {
+  stub_uname x86_64
+  run bash -c "source '$HELPER'; local_sim_build_args"
+  [ "$status" -eq 0 ]
+  [ -z "$output" ]
+}
+
+@test "helper is side-effect free to source" {
+  stub_uname arm64
+  run bash -c "source '$HELPER'; echo sourced-ok"
+  [ "$status" -eq 0 ]
+  [ "${lines[-1]}" = "sourced-ok" ]
+}
+
+# --- Wiring: the four local build/test scripts must consult the helper. ---
+
+@test "ctrl-proxy-build-for-testing.sh consults local_sim_build_args" {
+  grep -q "local_sim_build_args" "$REPO_ROOT/scripts/ios/ctrl-proxy-build-for-testing.sh"
+}
+
+@test "xcode-build.sh consults local_sim_build_args" {
+  grep -q "local_sim_build_args" "$REPO_ROOT/scripts/ios/xcode-build.sh"
+}
+
+@test "xcode-test.sh consults local_sim_build_args" {
+  grep -q "local_sim_build_args" "$REPO_ROOT/scripts/ios/xcode-test.sh"
+}
+
+@test "swift-build.sh consults local_sim_build_args" {
+  grep -q "local_sim_build_args" "$REPO_ROOT/scripts/ios/swift-build.sh"
+}
+
+# --- The release IPA path must stay universal: it must NOT consult the helper. ---
+
+@test "ctrl-proxy-create-ipa.sh does NOT consult local_sim_build_args (stays universal)" {
+  ! grep -q "local_sim_build_args" "$REPO_ROOT/scripts/ios/ctrl-proxy-create-ipa.sh"
+}


### PR DESCRIPTION
## Summary

Local iOS `xcodebuild` runs target `generic/platform=iOS Simulator` with no arch
pin, so on Apple Silicon they build a fat **x86_64 + arm64** binary. The x86_64
slice never runs on an arm64 simulator — every file is compiled and linked twice
for nothing. These headless script builds also never feed Xcode's index, so the
default index-store pass is wasted.

This adds `scripts/ios/local-sim-build-args.sh`, a side-effect-free helper that
emits `ONLY_ACTIVE_ARCH=YES ARCHS=arm64 COMPILER_INDEX_STORE_ENABLE=NO` — **only
on a local arm64 host**. It emits nothing under `$CI` or on a non-arm64 host, so
CI and Intel machines keep building universal. Wired into the four local
build/test scripts. The release IPA path (`ctrl-proxy-create-ipa.sh`) is
deliberately left untouched so the shipped, checksummed artifact stays universal.

Measured `build-for-testing` on an M3 Max (Xcode 26.3): arm64-only products,
~29% faster with warm caches (10.5s → 7.5s), roughly half the compile+link work
on a cold build.

## Linked Issue

Closes #5024

## Validation

- [x] `shellcheck` clean on all five scripts
- [x] `scripts/shellcheck/validate_shell_sete.sh` green (no new set -e findings)
- [x] `scripts/shellcheck/validate_shell_portability.sh` green
- [x] New BATS suite `test/bats/local-sim-build-args.bats` (9 cases) + coupled
      `ctrl-proxy-ui-test-runner-icon.bats` pass
- [x] Ran `ctrl-proxy-build-for-testing.sh` locally: products are **arm64-only**
      (`lipo -archs` → `arm64`), full build+icon-patch pipeline green
- [x] Empty-array (CI/Intel) path verified safe on macOS bash 3.2.57
- No TypeScript touched → lint/build/typecheck unaffected

## Notes

- The `local_sim_build_args` gate is env/host-driven; BATS pins it hermetically
  by stubbing `uname` and setting `CI`, reusing `detect_arch` from
  `scripts/lib/shell-core.sh` (no test-only production knob).
