### PR TITLE
perf(test): add test:fast (bun test --parallel) for a ~9x-faster local loop

### DIFF
--- a/package.json
+++ b/package.json
@@ -5,6 +5,7 @@
   "scripts": {
     "test": "bun test --isolate",
     "test:coverage": "bun test --isolate --coverage",
+    "test:fast": "bash scripts/test-fast.sh",
     "test:startup:bun": "bash scripts/ci/mcp-startup-smoke.sh",
     "test:image:bun": "bun scripts/ci/image-runtime-smoke.ts",
     "test:image:sharp-bun-repro": "bash scripts/validate-sharp-bun-repro.sh",

--- a/scripts/test-fast.sh
+++ b/scripts/test-fast.sh
@@ -1,0 +1,31 @@
+#!/usr/bin/env bash
+#
+# Fast local test loop: run the suite with bun's multi-process parallelism
+# (`bun test --parallel=N`, which implies `--isolate`) instead of the near-
+# sequential default `bun test --isolate`. Measured ~9x faster on a 16-core
+# machine (186s -> ~20s). See issue #5033.
+#
+# Worker count = cores - 2 (floor 1). Leaving two cores free keeps a co-running
+# editor/emulator from starving a worker past bun's default per-test timeout,
+# which is how a fast fake-based unit test can spuriously time out under load.
+#
+# Extra arguments are forwarded to `bun test` (e.g. a file path to run a subset
+# in parallel). Set TEST_FAST_PRINT_CMD=1 to print the resolved invocation
+# instead of running it (used by test/bats/test-fast.bats).
+set -euo pipefail
+
+# Portable CPU count: nproc (GNU) is absent on stock macOS, where an empty
+# `$(nproc)` breaks arithmetic. Fall back to sysctl/getconf (#3653).
+cores="$(nproc 2>/dev/null || sysctl -n hw.ncpu 2>/dev/null || getconf _NPROCESSORS_ONLN 2>/dev/null || echo 4)"
+
+workers=$((cores - 2))
+if [ "$workers" -lt 1 ]; then
+  workers=1
+fi
+
+if [ "${TEST_FAST_PRINT_CMD:-}" = "1" ]; then
+  echo "bun test --parallel=${workers} $*"
+  exit 0
+fi
+
+exec bun test --parallel="${workers}" "$@"

--- a/test/bats/test-fast.bats
+++ b/test/bats/test-fast.bats
@@ -1,0 +1,77 @@
+#!/usr/bin/env bats
+#
+# Pins the worker-count math of scripts/test-fast.sh (issue #5033) without
+# spawning the real suite: the script honors TEST_FAST_PRINT_CMD=1 to print the
+# resolved `bun test --parallel=N ...` invocation instead of exec'ing it. CPU
+# detection is mocked by shadowing `nproc`/`sysctl` on PATH.
+
+SCRIPT="scripts/test-fast.sh"
+
+# Write an executable `nproc` into a fresh temp dir that echoes $2, print the dir.
+_mock_nproc() {
+  local dir
+  dir="$(mktemp -d)"
+  {
+    echo '#!/usr/bin/env bash'
+    echo "echo $1"
+  } > "$dir/nproc"
+  chmod +x "$dir/nproc"
+  echo "$dir"
+}
+
+@test "uses cores-2 workers when there are plenty of cores" {
+  local dir
+  dir="$(_mock_nproc 16)"
+  run env PATH="$dir:$PATH" TEST_FAST_PRINT_CMD=1 bash "$SCRIPT"
+  rm -rf "$dir"
+  [ "$status" -eq 0 ]
+  [[ "$output" == *"--parallel=14"* ]]
+}
+
+@test "clamps to at least 1 worker on a 2-core machine" {
+  local dir
+  dir="$(_mock_nproc 2)"
+  run env PATH="$dir:$PATH" TEST_FAST_PRINT_CMD=1 bash "$SCRIPT"
+  rm -rf "$dir"
+  [ "$status" -eq 0 ]
+  [[ "$output" == *"--parallel=1"* ]]
+}
+
+@test "clamps to at least 1 worker on a single-core machine" {
+  local dir
+  dir="$(_mock_nproc 1)"
+  run env PATH="$dir:$PATH" TEST_FAST_PRINT_CMD=1 bash "$SCRIPT"
+  rm -rf "$dir"
+  [ "$status" -eq 0 ]
+  [[ "$output" == *"--parallel=1"* ]]
+}
+
+@test "passes through extra arguments to bun test" {
+  local dir
+  dir="$(_mock_nproc 8)"
+  run env PATH="$dir:$PATH" TEST_FAST_PRINT_CMD=1 bash "$SCRIPT" test/features/foo.test.ts
+  rm -rf "$dir"
+  [ "$status" -eq 0 ]
+  [[ "$output" == *"--parallel=6"* ]]
+  [[ "$output" == *"test/features/foo.test.ts"* ]]
+}
+
+@test "falls back to sysctl when nproc is unavailable" {
+  local dir
+  dir="$(mktemp -d)"
+  # A failing `nproc` (shadowing any real one) forces the fallback; the sysctl
+  # mock supplies the core count. The real PATH is appended so `bash` resolves.
+  {
+    echo '#!/usr/bin/env bash'
+    echo 'exit 1'
+  } > "$dir/nproc"
+  {
+    echo '#!/usr/bin/env bash'
+    echo 'if [ "$1" = "-n" ] && [ "$2" = "hw.ncpu" ]; then echo 10; fi'
+  } > "$dir/sysctl"
+  chmod +x "$dir/nproc" "$dir/sysctl"
+  run env PATH="$dir:$PATH" TEST_FAST_PRINT_CMD=1 bash "$SCRIPT"
+  rm -rf "$dir"
+  [ "$status" -eq 0 ]
+  [[ "$output" == *"--parallel=8"* ]]
+}


### PR DESCRIPTION
## Summary

Adds an opt-in `test:fast` script that runs the test suite with bun's
multi-process parallelism instead of the near-sequential default. `bun test
--isolate` was measured at **186s / ~139% CPU** for 12,764 tests on a 16-core
machine; `bun test --parallel` (which **implies `--isolate`**, preserving the
per-worker module isolation, real-DB guard, and telemetry-neutralizing preload)
runs the same suite in **~20s / 0 fail** — ~9x faster.

`scripts/test-fast.sh` picks a worker count of `cores - 2` (floor 1) using the
repo's portable core-count pattern (`nproc || sysctl -n hw.ncpu || getconf`,
#3653). Leaving two cores free keeps a co-running editor/emulator from starving a
worker past bun's default per-test timeout — the one flake mode observed, where a
fast fake-based unit test timed out only under extreme CPU oversubscription.

The default `test` and `test:coverage` scripts are unchanged (`--isolate`).
Flipping the default to `--parallel` is intentionally deferred.

## Linked Issue

Closes #5033

## Changes

- `scripts/test-fast.sh` — `bun test --parallel=$((cores-2))`, floor 1, forwards
  extra args (`bun run test:fast <file>`); `TEST_FAST_PRINT_CMD=1` dry-run seam.
- `package.json` — new `test:fast` script.
- `test/bats/test-fast.bats` — pins the worker-count math (cores-2, clamp ≥1,
  arg passthrough, sysctl fallback) without spawning the suite.

## Validation

- [x] `bats test/bats/test-fast.bats` — 5/5 pass
- [x] `shellcheck scripts/test-fast.sh` — clean
- [x] `bun run test:fast` dogfoods correctly (16 cores → `14x PARALLEL`, 0 fail)
- [x] `turbo run lint build test` green; `bun run typecheck` no new errors
- [x] Reuses the existing #3653 core-count pattern; no new dependency

## Out of scope (deferred)

- Flipping the default `test` to `--parallel` (needs a multi-run flake streak +
  a CI Bun version confirmed to accept `--parallel`).
- CI adoption of `--parallel` / `--shard`.
