### PR TITLE
build(android): extract Kotlin-compile convention into build-logic

### DIFF
--- a/android/auto-mobile-sdk/build.gradle.kts
+++ b/android/auto-mobile-sdk/build.gradle.kts
@@ -5,6 +5,7 @@ import org.jetbrains.kotlin.gradle.dsl.KotlinVersion
 import org.jetbrains.kotlin.gradle.tasks.KotlinCompile
 
 plugins {
+  id("automobile.kotlin-common")
   alias(libs.plugins.android.library)
   alias(libs.plugins.compose.compiler)
   alias(libs.plugins.kotlin.serialization)

--- a/android/build-logic/build.gradle.kts
+++ b/android/build-logic/build.gradle.kts
@@ -1,0 +1,8 @@
+plugins { `kotlin-dsl` }
+
+// Precompiled convention plugins need the Kotlin Gradle plugin on the classpath so
+// they can reference KotlinCompile / the kotlin extension. The Kotlin DSL compiles
+// on the build's JDK; pin its toolchain to the project's Java target for consistency.
+kotlin { jvmToolchain(libs.versions.build.java.target.get().toInt()) }
+
+dependencies { implementation(libs.kgp) }

--- a/android/build-logic/settings.gradle.kts
+++ b/android/build-logic/settings.gradle.kts
@@ -1,0 +1,20 @@
+pluginManagement {
+  repositories {
+    gradlePluginPortal()
+    google()
+    mavenCentral()
+  }
+}
+
+dependencyResolutionManagement {
+  repositories {
+    google()
+    mavenCentral()
+    gradlePluginPortal()
+  }
+  // Reuse the root project's single version catalog so convention plugins read the
+  // same Kotlin/Java/plugin versions as the modules they configure.
+  versionCatalogs { create("libs") { from(files("../gradle/libs.versions.toml")) } }
+}
+
+rootProject.name = "build-logic"

--- a/android/build-logic/src/main/kotlin/automobile.kotlin-common.gradle.kts
+++ b/android/build-logic/src/main/kotlin/automobile.kotlin-common.gradle.kts
@@ -1,0 +1,49 @@
+import org.gradle.api.artifacts.VersionCatalogsExtension
+import org.gradle.api.plugins.JavaBasePlugin
+import org.gradle.api.plugins.JavaPluginExtension
+import org.gradle.jvm.toolchain.JavaLanguageVersion
+import org.gradle.kotlin.dsl.configure
+import org.gradle.kotlin.dsl.getByType
+import org.gradle.kotlin.dsl.withType
+import org.jetbrains.kotlin.gradle.dsl.JvmTarget
+import org.jetbrains.kotlin.gradle.dsl.KotlinVersion
+import org.jetbrains.kotlin.gradle.tasks.KotlinCompile
+
+// Shared Kotlin compiler configuration for every Kotlin module (JVM and Android).
+// This is the single source of truth for the language version, JVM target, the
+// opt-in list, and the Java toolchain -- previously duplicated in the root
+// `subprojects {}` block and re-declared in individual module build files.
+
+val libs = extensions.getByType<VersionCatalogsExtension>().named("libs")
+val kotlinLanguageVersion = libs.findVersion("build-kotlin-language").get().requiredVersion
+val javaTarget = libs.findVersion("build-java-target").get().requiredVersion
+
+// Pin compilation and unit tests to the Java toolchain so `./gradlew` works
+// regardless of the developer's default JDK. Robolectric cannot instrument newer
+// JDK bytecode (e.g. JDK 26), so without this a newer default JDK breaks the
+// Android unit tests. AGP registers JavaPluginExtension for Android modules too,
+// so this one hook covers both JVM and Android; KGP picks up the Java toolchain.
+plugins.withType<JavaBasePlugin>().configureEach {
+  extensions.configure<JavaPluginExtension> {
+    toolchain { languageVersion.set(JavaLanguageVersion.of(javaTarget.toInt())) }
+  }
+}
+
+tasks.withType<KotlinCompile>().configureEach {
+  compilerOptions {
+    languageVersion.set(KotlinVersion.fromVersion(kotlinLanguageVersion))
+    jvmTarget.set(JvmTarget.fromTarget(javaTarget))
+    // addAll (not assignment) so plugin-contributed args -- Compose, Metro, explicit
+    // API, -Xallow-unstable-dependencies, etc. -- are preserved.
+    freeCompilerArgs.addAll(
+      "-opt-in=androidx.compose.material3.ExperimentalMaterial3Api",
+      "-opt-in=androidx.media3.common.util.UnstableApi",
+      "-opt-in=kotlin.time.ExperimentalTime,kotlin.RequiresOptIn",
+      "-opt-in=kotlinx.coroutines.ExperimentalCoroutinesApi",
+      "-opt-in=kotlin.ExperimentalUnsignedTypes",
+      "-opt-in=kotlin.time.ExperimentalTime",
+      "-opt-in=kotlinx.coroutines.ExperimentalCoroutinesApi",
+      "-opt-in=kotlinx.coroutines.FlowPreview",
+    )
+  }
+}

--- a/android/build.gradle.kts
+++ b/android/build.gradle.kts
@@ -1,11 +1,6 @@
 import com.vanniktech.maven.publish.MavenPublishBaseExtension
 import dev.detekt.gradle.extensions.DetektExtension
-import org.gradle.api.plugins.JavaBasePlugin
-import org.gradle.api.plugins.JavaPluginExtension
 import org.gradle.api.publish.PublishingExtension
-import org.gradle.jvm.toolchain.JavaLanguageVersion
-import org.jetbrains.kotlin.gradle.dsl.JvmTarget
-import org.jetbrains.kotlin.gradle.dsl.KotlinVersion
 import org.jetbrains.kotlin.gradle.tasks.KotlinCompile
 
 buildscript {
@@ -129,41 +124,6 @@ subprojects {
   plugins.withId("com.android.library") {
     configure<com.android.build.api.dsl.LibraryExtension> {
       buildTypes { getByName("debug") { enableUnitTestCoverage = true } }
-    }
-  }
-
-  tasks.withType<KotlinCompile>().configureEach {
-    compilerOptions {
-      languageVersion.set(
-        KotlinVersion.valueOf(
-          "KOTLIN_${libs.versions.build.kotlin.language.get().replace(".", "_")}"
-        )
-      )
-      jvmTarget.set(JvmTarget.valueOf("JVM_${libs.versions.build.java.target.get()}"))
-      freeCompilerArgs.addAll(
-        listOf(
-          "-opt-in=androidx.compose.material3.ExperimentalMaterial3Api",
-          "-opt-in=androidx.media3.common.util.UnstableApi",
-          "-opt-in=kotlin.time.ExperimentalTime,kotlin.RequiresOptIn",
-          "-opt-in=kotlinx.coroutines.ExperimentalCoroutinesApi",
-          "-opt-in=kotlin.ExperimentalUnsignedTypes",
-          "-opt-in=kotlin.time.ExperimentalTime",
-          "-opt-in=kotlinx.coroutines.ExperimentalCoroutinesApi",
-          "-opt-in=kotlinx.coroutines.FlowPreview",
-        )
-      )
-    }
-  }
-
-  // Pin compilation and unit tests to the Java toolchain (the java.target catalog value, 21) so
-  // `./gradlew` works regardless of the developer's default JDK. Robolectric cannot instrument
-  // newer JDK bytecode (e.g. JDK 26), so without this a newer default JDK breaks the Android unit
-  // tests. CI already runs on JDK 21; the foojay resolver (settings.gradle.kts) supplies the JDK.
-  plugins.withType<JavaBasePlugin>().configureEach {
-    extensions.configure<JavaPluginExtension> {
-      toolchain {
-        languageVersion.set(JavaLanguageVersion.of(libs.versions.build.java.target.get().toInt()))
-      }
     }
   }
 }

--- a/android/control-proxy/build.gradle.kts
+++ b/android/control-proxy/build.gradle.kts
@@ -1,4 +1,5 @@
 plugins {
+  id("automobile.kotlin-common")
   alias(libs.plugins.android.application)
   alias(libs.plugins.kotlin.serialization)
   alias(libs.plugins.compose.compiler)
@@ -88,30 +89,6 @@ android {
       excludes += "/META-INF/INDEX.LIST"
       excludes += "/META-INF/*.kotlin_module"
     }
-  }
-}
-
-tasks.withType<org.jetbrains.kotlin.gradle.tasks.KotlinCompile>().configureEach {
-  compilerOptions {
-    jvmTarget.set(
-      org.jetbrains.kotlin.gradle.dsl.JvmTarget.fromTarget(libs.versions.build.java.target.get())
-    )
-    languageVersion.set(
-      org.jetbrains.kotlin.gradle.dsl.KotlinVersion.fromVersion(
-        libs.versions.build.kotlin.language.get()
-      )
-    )
-    freeCompilerArgs =
-      listOf(
-        "-opt-in=androidx.compose.material3.ExperimentalMaterial3Api",
-        "-opt-in=androidx.media3.common.util.UnstableApi",
-        "-opt-in=kotlin.time.ExperimentalTime,kotlin.RequiresOptIn",
-        "-opt-in=kotlinx.coroutines.ExperimentalCoroutinesApi",
-        "-opt-in=kotlin.ExperimentalUnsignedTypes",
-        "-opt-in=kotlin.time.ExperimentalTime",
-        "-opt-in=kotlinx.coroutines.ExperimentalCoroutinesApi",
-        "-opt-in=kotlinx.coroutines.FlowPreview",
-      )
   }
 }
 

--- a/android/desktop-app/build.gradle.kts
+++ b/android/desktop-app/build.gradle.kts
@@ -9,6 +9,7 @@ import org.jetbrains.compose.desktop.application.dsl.TargetFormat
 import org.jetbrains.compose.reload.gradle.ComposeHotRun
 
 plugins {
+  id("automobile.kotlin-common")
   kotlin("jvm")
   alias(libs.plugins.kotlin.serialization)
   kotlin("plugin.compose")

--- a/android/desktop-core/build.gradle.kts
+++ b/android/desktop-core/build.gradle.kts
@@ -1,6 +1,7 @@
 import groovy.json.JsonSlurper
 
 plugins {
+  id("automobile.kotlin-common")
   kotlin("jvm")
   alias(libs.plugins.kotlin.serialization)
   kotlin("plugin.compose")

--- a/android/desktop-domain/build.gradle.kts
+++ b/android/desktop-domain/build.gradle.kts
@@ -1,4 +1,5 @@
 plugins {
+  id("automobile.kotlin-common")
   kotlin("jvm")
   kotlin("plugin.serialization")
 }

--- a/android/ide-plugin/build.gradle.kts
+++ b/android/ide-plugin/build.gradle.kts
@@ -1,6 +1,7 @@
 import org.jetbrains.intellij.platform.gradle.extensions.intellijPlatform
 
 plugins {
+  id("automobile.kotlin-common")
   kotlin("jvm")
   alias(libs.plugins.kotlin.serialization)
   kotlin("plugin.compose")

--- a/android/junit-runner/build.gradle.kts
+++ b/android/junit-runner/build.gradle.kts
@@ -3,6 +3,7 @@ import org.jetbrains.kotlin.gradle.dsl.KotlinVersion
 import org.jetbrains.kotlin.gradle.tasks.KotlinCompile
 
 plugins {
+  id("automobile.kotlin-common")
   kotlin("jvm")
   alias(libs.plugins.kotlin.serialization)
   `java-library`

--- a/android/playground/analytics/build.gradle.kts
+++ b/android/playground/analytics/build.gradle.kts
@@ -1,4 +1,7 @@
-plugins { alias(libs.plugins.android.library) }
+plugins {
+  id("automobile.kotlin-common")
+  alias(libs.plugins.android.library)
+}
 
 android {
   namespace = "dev.jasonpearson.automobile.analytics"
@@ -20,14 +23,6 @@ android {
   compileOptions {
     sourceCompatibility = JavaVersion.toVersion(libs.versions.build.java.target.get())
     targetCompatibility = JavaVersion.toVersion(libs.versions.build.java.target.get())
-  }
-}
-
-tasks.withType<org.jetbrains.kotlin.gradle.tasks.KotlinCompile>().configureEach {
-  compilerOptions {
-    jvmTarget.set(
-      org.jetbrains.kotlin.gradle.dsl.JvmTarget.fromTarget(libs.versions.build.java.target.get())
-    )
   }
 }
 

--- a/android/playground/app/build.gradle.kts
+++ b/android/playground/app/build.gradle.kts
@@ -1,4 +1,5 @@
 plugins {
+  id("automobile.kotlin-common")
   alias(libs.plugins.android.application)
   alias(libs.plugins.compose.compiler)
   alias(libs.plugins.kotlin.serialization)
@@ -73,30 +74,6 @@ android {
     targetCompatibility = JavaVersion.toVersion(libs.versions.build.java.target.get())
   }
   buildFeatures { compose = true }
-}
-
-tasks.withType<org.jetbrains.kotlin.gradle.tasks.KotlinCompile>().configureEach {
-  compilerOptions {
-    jvmTarget.set(
-      org.jetbrains.kotlin.gradle.dsl.JvmTarget.fromTarget(libs.versions.build.java.target.get())
-    )
-    languageVersion.set(
-      org.jetbrains.kotlin.gradle.dsl.KotlinVersion.fromVersion(
-        libs.versions.build.kotlin.language.get()
-      )
-    )
-    freeCompilerArgs =
-      listOf(
-        "-opt-in=androidx.compose.material3.ExperimentalMaterial3Api",
-        "-opt-in=androidx.media3.common.util.UnstableApi",
-        "-opt-in=kotlin.time.ExperimentalTime,kotlin.RequiresOptIn",
-        "-opt-in=kotlinx.coroutines.ExperimentalCoroutinesApi",
-        "-opt-in=kotlin.ExperimentalUnsignedTypes",
-        "-opt-in=kotlin.time.ExperimentalTime",
-        "-opt-in=kotlinx.coroutines.ExperimentalCoroutinesApi",
-        "-opt-in=kotlinx.coroutines.FlowPreview",
-      )
-  }
 }
 
 dependencies {

--- a/android/playground/demos/build.gradle.kts
+++ b/android/playground/demos/build.gradle.kts
@@ -1,4 +1,5 @@
 plugins {
+  id("automobile.kotlin-common")
   alias(libs.plugins.android.library)
   alias(libs.plugins.compose.compiler)
 }
@@ -25,19 +26,6 @@ android {
     targetCompatibility = JavaVersion.toVersion(libs.versions.build.java.target.get())
   }
   buildFeatures { compose = true }
-}
-
-tasks.withType<org.jetbrains.kotlin.gradle.tasks.KotlinCompile>().configureEach {
-  compilerOptions {
-    jvmTarget.set(
-      org.jetbrains.kotlin.gradle.dsl.JvmTarget.fromTarget(libs.versions.build.java.target.get())
-    )
-    languageVersion.set(
-      org.jetbrains.kotlin.gradle.dsl.KotlinVersion.fromVersion(
-        libs.versions.build.kotlin.language.get()
-      )
-    )
-  }
 }
 
 dependencies {

--- a/android/playground/design/assets/build.gradle.kts
+++ b/android/playground/design/assets/build.gradle.kts
@@ -1,4 +1,7 @@
-plugins { alias(libs.plugins.android.library) }
+plugins {
+  id("automobile.kotlin-common")
+  alias(libs.plugins.android.library)
+}
 
 android {
   namespace = "dev.jasonpearson.automobile.design.assets"

--- a/android/playground/design/system/build.gradle.kts
+++ b/android/playground/design/system/build.gradle.kts
@@ -1,4 +1,5 @@
 plugins {
+  id("automobile.kotlin-common")
   alias(libs.plugins.android.library)
   alias(libs.plugins.compose.compiler)
 }
@@ -25,19 +26,6 @@ android {
     targetCompatibility = JavaVersion.toVersion(libs.versions.build.java.target.get())
   }
   buildFeatures { compose = true }
-}
-
-tasks.withType<org.jetbrains.kotlin.gradle.tasks.KotlinCompile>().configureEach {
-  compilerOptions {
-    jvmTarget.set(
-      org.jetbrains.kotlin.gradle.dsl.JvmTarget.fromTarget(libs.versions.build.java.target.get())
-    )
-    languageVersion.set(
-      org.jetbrains.kotlin.gradle.dsl.KotlinVersion.fromVersion(
-        libs.versions.build.kotlin.language.get()
-      )
-    )
-  }
 }
 
 dependencies {

--- a/android/playground/discover/build.gradle.kts
+++ b/android/playground/discover/build.gradle.kts
@@ -1,4 +1,5 @@
 plugins {
+  id("automobile.kotlin-common")
   alias(libs.plugins.android.library)
   alias(libs.plugins.compose.compiler)
   alias(libs.plugins.kotlin.serialization)
@@ -26,30 +27,6 @@ android {
     targetCompatibility = JavaVersion.toVersion(libs.versions.build.java.target.get())
   }
   buildFeatures { compose = true }
-}
-
-tasks.withType<org.jetbrains.kotlin.gradle.tasks.KotlinCompile>().configureEach {
-  compilerOptions {
-    jvmTarget.set(
-      org.jetbrains.kotlin.gradle.dsl.JvmTarget.fromTarget(libs.versions.build.java.target.get())
-    )
-    languageVersion.set(
-      org.jetbrains.kotlin.gradle.dsl.KotlinVersion.fromVersion(
-        libs.versions.build.kotlin.language.get()
-      )
-    )
-    freeCompilerArgs =
-      listOf(
-        "-opt-in=androidx.compose.material3.ExperimentalMaterial3Api",
-        "-opt-in=androidx.media3.common.util.UnstableApi",
-        "-opt-in=kotlin.time.ExperimentalTime,kotlin.RequiresOptIn",
-        "-opt-in=kotlinx.coroutines.ExperimentalCoroutinesApi",
-        "-opt-in=kotlin.ExperimentalUnsignedTypes",
-        "-opt-in=kotlin.time.ExperimentalTime",
-        "-opt-in=kotlinx.coroutines.ExperimentalCoroutinesApi",
-        "-opt-in=kotlinx.coroutines.FlowPreview",
-      )
-  }
 }
 
 dependencies {

--- a/android/playground/experimentation/build.gradle.kts
+++ b/android/playground/experimentation/build.gradle.kts
@@ -1,4 +1,5 @@
 plugins {
+  id("automobile.kotlin-common")
   alias(libs.plugins.android.library)
   alias(libs.plugins.compose.compiler)
 }
@@ -25,19 +26,6 @@ android {
     targetCompatibility = JavaVersion.toVersion(libs.versions.build.java.target.get())
   }
   buildFeatures { compose = true }
-}
-
-tasks.withType<org.jetbrains.kotlin.gradle.tasks.KotlinCompile>().configureEach {
-  compilerOptions {
-    jvmTarget.set(
-      org.jetbrains.kotlin.gradle.dsl.JvmTarget.fromTarget(libs.versions.build.java.target.get())
-    )
-    languageVersion.set(
-      org.jetbrains.kotlin.gradle.dsl.KotlinVersion.fromVersion(
-        libs.versions.build.kotlin.language.get()
-      )
-    )
-  }
 }
 
 dependencies {

--- a/android/playground/home/build.gradle.kts
+++ b/android/playground/home/build.gradle.kts
@@ -1,4 +1,5 @@
 plugins {
+  id("automobile.kotlin-common")
   alias(libs.plugins.android.library)
   alias(libs.plugins.compose.compiler)
 }
@@ -25,19 +26,6 @@ android {
     targetCompatibility = JavaVersion.toVersion(libs.versions.build.java.target.get())
   }
   buildFeatures { compose = true }
-}
-
-tasks.withType<org.jetbrains.kotlin.gradle.tasks.KotlinCompile>().configureEach {
-  compilerOptions {
-    jvmTarget.set(
-      org.jetbrains.kotlin.gradle.dsl.JvmTarget.fromTarget(libs.versions.build.java.target.get())
-    )
-    languageVersion.set(
-      org.jetbrains.kotlin.gradle.dsl.KotlinVersion.fromVersion(
-        libs.versions.build.kotlin.language.get()
-      )
-    )
-  }
 }
 
 dependencies {

--- a/android/playground/login/build.gradle.kts
+++ b/android/playground/login/build.gradle.kts
@@ -1,4 +1,5 @@
 plugins {
+  id("automobile.kotlin-common")
   alias(libs.plugins.android.library)
   alias(libs.plugins.compose.compiler)
 }
@@ -25,19 +26,6 @@ android {
     targetCompatibility = JavaVersion.toVersion(libs.versions.build.java.target.get())
   }
   buildFeatures { compose = true }
-}
-
-tasks.withType<org.jetbrains.kotlin.gradle.tasks.KotlinCompile>().configureEach {
-  compilerOptions {
-    jvmTarget.set(
-      org.jetbrains.kotlin.gradle.dsl.JvmTarget.fromTarget(libs.versions.build.java.target.get())
-    )
-    languageVersion.set(
-      org.jetbrains.kotlin.gradle.dsl.KotlinVersion.fromVersion(
-        libs.versions.build.kotlin.language.get()
-      )
-    )
-  }
 }
 
 dependencies {

--- a/android/playground/mediaplayer/build.gradle.kts
+++ b/android/playground/mediaplayer/build.gradle.kts
@@ -1,4 +1,5 @@
 plugins {
+  id("automobile.kotlin-common")
   alias(libs.plugins.android.library)
   alias(libs.plugins.compose.compiler)
 }
@@ -30,28 +31,6 @@ android {
     // Disable UnsafeOptInUsageError since we've already configured the Kotlin compiler
     // to opt-in to Media3's UnstableApi via freeCompilerArgs
     disable += "UnsafeOptInUsageError"
-  }
-}
-
-tasks.withType<org.jetbrains.kotlin.gradle.tasks.KotlinCompile>().configureEach {
-  compilerOptions {
-    jvmTarget.set(
-      org.jetbrains.kotlin.gradle.dsl.JvmTarget.fromTarget(libs.versions.build.java.target.get())
-    )
-    languageVersion.set(
-      org.jetbrains.kotlin.gradle.dsl.KotlinVersion.fromVersion(
-        libs.versions.build.kotlin.language.get()
-      )
-    )
-    freeCompilerArgs =
-      listOf(
-        "-opt-in=kotlin.time.ExperimentalTime,kotlin.RequiresOptIn",
-        "-opt-in=kotlinx.coroutines.ExperimentalCoroutinesApi",
-        "-opt-in=kotlin.ExperimentalUnsignedTypes",
-        "-opt-in=kotlin.time.ExperimentalTime",
-        "-opt-in=kotlinx.coroutines.ExperimentalCoroutinesApi",
-        "-opt-in=kotlinx.coroutines.FlowPreview",
-      )
   }
 }
 

--- a/android/playground/onboarding/build.gradle.kts
+++ b/android/playground/onboarding/build.gradle.kts
@@ -1,4 +1,5 @@
 plugins {
+  id("automobile.kotlin-common")
   alias(libs.plugins.android.library)
   alias(libs.plugins.compose.compiler)
 }
@@ -25,19 +26,6 @@ android {
     targetCompatibility = JavaVersion.toVersion(libs.versions.build.java.target.get())
   }
   buildFeatures { compose = true }
-}
-
-tasks.withType<org.jetbrains.kotlin.gradle.tasks.KotlinCompile>().configureEach {
-  compilerOptions {
-    jvmTarget.set(
-      org.jetbrains.kotlin.gradle.dsl.JvmTarget.fromTarget(libs.versions.build.java.target.get())
-    )
-    languageVersion.set(
-      org.jetbrains.kotlin.gradle.dsl.KotlinVersion.fromVersion(
-        libs.versions.build.kotlin.language.get()
-      )
-    )
-  }
 }
 
 dependencies {

--- a/android/playground/settings/build.gradle.kts
+++ b/android/playground/settings/build.gradle.kts
@@ -1,4 +1,5 @@
 plugins {
+  id("automobile.kotlin-common")
   alias(libs.plugins.android.library)
   alias(libs.plugins.compose.compiler)
 }
@@ -25,19 +26,6 @@ android {
     targetCompatibility = JavaVersion.toVersion(libs.versions.build.java.target.get())
   }
   buildFeatures { compose = true }
-}
-
-tasks.withType<org.jetbrains.kotlin.gradle.tasks.KotlinCompile>().configureEach {
-  compilerOptions {
-    jvmTarget.set(
-      org.jetbrains.kotlin.gradle.dsl.JvmTarget.fromTarget(libs.versions.build.java.target.get())
-    )
-    languageVersion.set(
-      org.jetbrains.kotlin.gradle.dsl.KotlinVersion.fromVersion(
-        libs.versions.build.kotlin.language.get()
-      )
-    )
-  }
 }
 
 dependencies {

--- a/android/playground/slides/build.gradle.kts
+++ b/android/playground/slides/build.gradle.kts
@@ -1,4 +1,5 @@
 plugins {
+  id("automobile.kotlin-common")
   alias(libs.plugins.android.library)
   alias(libs.plugins.compose.compiler)
 }
@@ -33,30 +34,6 @@ android {
     // Disable UnsafeOptInUsageError since we've already configured the Kotlin compiler
     // to opt-in to Media3's UnstableApi via freeCompilerArgs
     disable += "UnsafeOptInUsageError"
-  }
-}
-
-tasks.withType<org.jetbrains.kotlin.gradle.tasks.KotlinCompile>().configureEach {
-  compilerOptions {
-    jvmTarget.set(
-      org.jetbrains.kotlin.gradle.dsl.JvmTarget.fromTarget(libs.versions.build.java.target.get())
-    )
-    languageVersion.set(
-      org.jetbrains.kotlin.gradle.dsl.KotlinVersion.fromVersion(
-        libs.versions.build.kotlin.language.get()
-      )
-    )
-    freeCompilerArgs =
-      listOf(
-        "-opt-in=androidx.compose.material3.ExperimentalMaterial3Api",
-        "-opt-in=androidx.media3.common.util.UnstableApi",
-        "-opt-in=kotlin.time.ExperimentalTime,kotlin.RequiresOptIn",
-        "-opt-in=kotlinx.coroutines.ExperimentalCoroutinesApi",
-        "-opt-in=kotlin.ExperimentalUnsignedTypes",
-        "-opt-in=kotlin.time.ExperimentalTime",
-        "-opt-in=kotlinx.coroutines.ExperimentalCoroutinesApi",
-        "-opt-in=kotlinx.coroutines.FlowPreview",
-      )
   }
 }
 

--- a/android/playground/storage/build.gradle.kts
+++ b/android/playground/storage/build.gradle.kts
@@ -1,4 +1,7 @@
-plugins { alias(libs.plugins.android.library) }
+plugins {
+  id("automobile.kotlin-common")
+  alias(libs.plugins.android.library)
+}
 
 android {
   namespace = "dev.jasonpearson.automobile.storage"
@@ -20,19 +23,6 @@ android {
   compileOptions {
     sourceCompatibility = JavaVersion.toVersion(libs.versions.build.java.target.get())
     targetCompatibility = JavaVersion.toVersion(libs.versions.build.java.target.get())
-  }
-}
-
-tasks.withType<org.jetbrains.kotlin.gradle.tasks.KotlinCompile>().configureEach {
-  compilerOptions {
-    jvmTarget.set(
-      org.jetbrains.kotlin.gradle.dsl.JvmTarget.fromTarget(libs.versions.build.java.target.get())
-    )
-    languageVersion.set(
-      org.jetbrains.kotlin.gradle.dsl.KotlinVersion.fromVersion(
-        libs.versions.build.kotlin.language.get()
-      )
-    )
   }
 }
 

--- a/android/protocol/build.gradle.kts
+++ b/android/protocol/build.gradle.kts
@@ -2,6 +2,7 @@ import org.jetbrains.kotlin.gradle.dsl.KotlinVersion
 import org.jetbrains.kotlin.gradle.tasks.KotlinCompile
 
 plugins {
+  id("automobile.kotlin-common")
   kotlin("jvm")
   alias(libs.plugins.kotlin.serialization)
   `java-library`

--- a/android/settings.gradle.kts
+++ b/android/settings.gradle.kts
@@ -10,6 +10,9 @@ dependencyResolutionManagement {
 }
 
 pluginManagement {
+  // Convention plugins (e.g. automobile.kotlin-common) live in the build-logic
+  // included build.
+  includeBuild("build-logic")
   repositories {
     google {
       content {

--- a/android/test-plan-validation/build.gradle.kts
+++ b/android/test-plan-validation/build.gradle.kts
@@ -2,6 +2,7 @@ import org.jetbrains.kotlin.gradle.dsl.KotlinVersion
 import org.jetbrains.kotlin.gradle.tasks.KotlinCompile
 
 plugins {
+  id("automobile.kotlin-common")
   kotlin("jvm")
   alias(libs.plugins.kotlin.serialization)
   `java-library`

--- a/android/video-server/build.gradle.kts
+++ b/android/video-server/build.gradle.kts
@@ -3,6 +3,7 @@ import org.jetbrains.kotlin.gradle.dsl.KotlinVersion
 import org.jetbrains.kotlin.gradle.tasks.KotlinCompile
 
 plugins {
+  id("automobile.kotlin-common")
   kotlin("jvm")
   `java-library`
 }

--- a/scripts/android/validate-kotlin-convention.sh
+++ b/scripts/android/validate-kotlin-convention.sh
@@ -1,0 +1,50 @@
+#!/usr/bin/env bash
+#
+# Guards the Kotlin-compile convention extraction (issue #5027).
+#
+# The Kotlin compiler options (language version, JVM target, the shared opt-in
+# list) and the Java/Kotlin toolchain must live in ONE build-logic convention
+# plugin, not be duplicated across module build files or reconstructed in the
+# root `subprojects {}` block. This guard fails if that duplication returns.
+set -euo pipefail
+
+# Resolve repo root (this script lives in scripts/android/).
+ROOT="$(cd "$(dirname "${BASH_SOURCE[0]}")/../.." && pwd)"
+cd "$ROOT"
+
+CONVENTION="android/build-logic/src/main/kotlin/automobile.kotlin-common.gradle.kts"
+SETTINGS="android/settings.gradle.kts"
+OPTIN_MARKER="opt-in=androidx.compose.material3.ExperimentalMaterial3Api"
+KOTLIN_COMPILE_BLOCK="tasks.withType<org.jetbrains.kotlin.gradle.tasks.KotlinCompile>"
+
+fail() {
+  echo "FAIL: $*" >&2
+  exit 1
+}
+
+# 1. build-logic is an included build and the convention plugin exists.
+[ -f "android/build-logic/settings.gradle.kts" ] ||
+  fail "android/build-logic is not an included build (missing settings.gradle.kts)"
+[ -f "$CONVENTION" ] || fail "missing convention plugin: $CONVENTION"
+
+# 2. The root settings wires the included build.
+grep -q 'includeBuild("build-logic")' "$SETTINGS" ||
+  fail "$SETTINGS does not includeBuild(\"build-logic\")"
+
+# 3. The shared opt-in list lives in exactly one build file: the convention.
+optin_files="$(grep -rl "$OPTIN_MARKER" android --include='*.gradle.kts' | sort || true)"
+optin_count="$(printf '%s\n' "$optin_files" | grep -c . || true)"
+if [ "$optin_count" -ne 1 ] || [ "$optin_files" != "$CONVENTION" ]; then
+  fail "opt-in list must live only in $CONVENTION; found in: ${optin_files:-none}"
+fi
+
+# 4. No module build file re-declares a KotlinCompile compiler-options block.
+#    The root build.gradle.kts is excluded: it retains an unrelated KotlinCompile
+#    use (publication moduleName) that a later item removes.
+module_dups="$(grep -rl "$KOTLIN_COMPILE_BLOCK" android --include=build.gradle.kts |
+  grep -vE '^android/build\.gradle\.kts$' || true)"
+if [ -n "$module_dups" ]; then
+  fail "module build files still declare a KotlinCompile block:"$'\n'"$module_dups"
+fi
+
+echo "OK: Kotlin-compile convention is centralized in $CONVENTION"

--- a/test/bats/android-kotlin-convention.bats
+++ b/test/bats/android-kotlin-convention.bats
@@ -1,0 +1,30 @@
+#!/usr/bin/env bats
+#
+# Tests for scripts/android/validate-kotlin-convention.sh (issue #5027).
+
+SCRIPT="scripts/android/validate-kotlin-convention.sh"
+CONVENTION="android/build-logic/src/main/kotlin/automobile.kotlin-common.gradle.kts"
+FIXTURE="android/zzz-convention-guard-fixture.gradle.kts"
+
+teardown() {
+  rm -f "$FIXTURE"
+}
+
+@test "passes on the real tree with the convention centralized" {
+  run bash "$SCRIPT"
+
+  [ "$status" -eq 0 ]
+  [[ "$output" == *"centralized in $CONVENTION"* ]]
+}
+
+@test "fails when the opt-in list is duplicated into another build file" {
+  printf '%s\n' \
+    'tasks.withType<Nothing> {' \
+    '  freeCompilerArgs.add("-opt-in=androidx.compose.material3.ExperimentalMaterial3Api")' \
+    '}' > "$FIXTURE"
+
+  run bash "$SCRIPT"
+
+  [ "$status" -ne 0 ]
+  [[ "$output" == *"opt-in list must live only"* ]]
+}


### PR DESCRIPTION
## Summary

First step of the `build-logic` → Isolated Projects migration (item 1 of 5, issue #5027).

Introduces an `android/build-logic` included build with one `automobile.kotlin-common` convention plugin that owns the Kotlin **language version, JVM target, the shared opt-in list, and the Java toolchain**. It is applied to all 24 Kotlin modules, and the **14 duplicated `KotlinCompile.configureEach` blocks** plus the root `subprojects {}` compile/toolchain configuration are deleted.

Motivation: this is the largest source of per-module build duplication, and the root `subprojects {}` cross-project configuration is a Gradle Isolated Projects blocker. An IP dry-run (`-Dorg.gradle.unsafe.isolated-projects=true`) confirmed the endpoint is reachable with **zero plugin incompatibilities**; the blockers are entirely our own build scripts.

## Changes

- `android/build-logic/` — new included build (`settings.gradle.kts` importing the root version catalog, `build.gradle.kts` with `kotlin-dsl` + `libs.kgp`, and the `automobile.kotlin-common` precompiled convention).
- `android/settings.gradle.kts` — `includeBuild("build-logic")`.
- 24 module build files — apply `id("automobile.kotlin-common")`, remove the duplicated `KotlinCompile` blocks.
- `android/build.gradle.kts` — remove the `subprojects {}` `KotlinCompile` block and the `JavaBasePlugin` toolchain block (+ now-unused imports).
- `scripts/android/validate-kotlin-convention.sh` + `test/bats/android-kotlin-convention.bats` — structural guard.

## Behavior preservation (how it was verified)

Dumped every module's **effective** Kotlin compiler args (jvmTarget, languageVersion, sorted freeCompilerArgs) before and after via an init script. All 24 modules are **byte-identical** with one deliberate exception:

- `:playground:mediaplayer` previously **replaced** `freeCompilerArgs` via assignment and so silently dropped the shared `material3`/`media3` opt-ins. The convention uses `addAll`, so mediaplayer now **gains** those two opt-ins — a safe superset (an unused `-opt-in` marker is a no-op). This corrects a latent inconsistency.

Plugin-contributed args (Compose, Metro `-Xcompiler-plugin-order`, `-Xexplicit-api=strict` on desktop-domain, `-Xallow-unstable-dependencies`) are preserved everywhere because the convention appends rather than assigns.

## Testing / Acceptance criteria

- [x] `build-logic` included build exists; convention applied to all 24 Kotlin modules
- [x] No module retains a hand-rolled `KotlinCompile` block; root no longer configures compile/toolchain via `subprojects {}`
- [x] Compiler args unchanged (per-module before/after dump; only the documented mediaplayer normalization differs)
- [x] `./gradlew help` configures cleanly; representative real compiles pass (`:desktop-core`, `:control-proxy`, `:protocol`, `:playground:mediaplayer`)
- [x] ktfmt tree-wide clean, shellcheck clean, structural guard (BATS) green

No `src/`/TypeScript, DB, runner-protocol, or public-schema surface touched.

Closes #5027
