### PR TITLE
feat(desktop): shared reconnect lifecycle for workspace observation streams (#4868)

### DIFF
--- a/android/desktop-core/src/main/kotlin/dev/jasonpearson/automobile/desktop/core/workspace/LayoutFacet.kt
+++ b/android/desktop-core/src/main/kotlin/dev/jasonpearson/automobile/desktop/core/workspace/LayoutFacet.kt
@@ -1,15 +1,11 @@
 package dev.jasonpearson.automobile.desktop.core.workspace
 
 import androidx.compose.runtime.Composable
-import androidx.compose.runtime.DisposableEffect
-import androidx.compose.runtime.getValue
-import androidx.compose.runtime.mutableStateOf
-import androidx.compose.runtime.remember
-import androidx.compose.runtime.setValue
 import dev.jasonpearson.automobile.desktop.core.daemon.ObservationStream
 import dev.jasonpearson.automobile.desktop.core.daemon.ObservationStreamClient
 import dev.jasonpearson.automobile.desktop.core.datasource.DataSourceMode
 import dev.jasonpearson.automobile.desktop.core.layout.LayoutInspectorDashboard
+import kotlinx.coroutines.delay
 
 /**
  * Docked-facet body for the Layout Inspector, scoped to a single pane's device. An
@@ -20,22 +16,25 @@ import dev.jasonpearson.automobile.desktop.core.layout.LayoutInspectorDashboard
  *
  * [observationStreamFactory] is injected (defaulting to a real per-device
  * [ObservationStreamClient]) so the connect/dispose lifecycle can be verified with a
- * [FakeObservationStream] instead of real socket I/O.
+ * [FakeObservationStream] instead of real socket I/O. The stream reconnects automatically if it
+ * drops while the facet is open (see [rememberReconnectingObservationStream]); [backoffDelay] and
+ * [socketAvailable] are the injected timer/daemon-availability seams that let that recovery be
+ * tested with virtual time.
  */
 @Composable
 fun LayoutFacet(
   column: DeviceColumn,
   observationStreamFactory: () -> ObservationStream = { ObservationStreamClient() },
+  backoffDelay: suspend (attempt: Int) -> Unit = { attempt -> delay(reconnectBackoffMs(attempt)) },
+  socketAvailable: () -> Boolean = { ObservationStreamClient.socketExists() },
 ) {
-  var stream by remember(column.deviceId) { mutableStateOf<ObservationStream?>(null) }
-  DisposableEffect(column.deviceId) {
-    val connected = observationStreamFactory().also { it.connect(deviceId = column.deviceId) }
-    stream = connected
-    onDispose {
-      connected.dispose()
-      stream = null
-    }
-  }
+  val stream =
+    rememberReconnectingObservationStream(
+      deviceId = column.deviceId,
+      streamFactory = observationStreamFactory,
+      backoffDelay = backoffDelay,
+      socketAvailable = socketAvailable,
+    )
   stream?.let { activeStream ->
     LayoutInspectorDashboard(
       dataSourceMode = DataSourceMode.Real,

--- a/android/desktop-core/src/main/kotlin/dev/jasonpearson/automobile/desktop/core/workspace/ReconnectingObservationStream.kt
+++ b/android/desktop-core/src/main/kotlin/dev/jasonpearson/automobile/desktop/core/workspace/ReconnectingObservationStream.kt
@@ -1,0 +1,115 @@
+package dev.jasonpearson.automobile.desktop.core.workspace
+
+import androidx.compose.runtime.Composable
+import androidx.compose.runtime.DisposableEffect
+import androidx.compose.runtime.LaunchedEffect
+import androidx.compose.runtime.getValue
+import androidx.compose.runtime.mutableStateOf
+import androidx.compose.runtime.remember
+import androidx.compose.runtime.setValue
+import dev.jasonpearson.automobile.desktop.core.connection.ConnectionState
+import dev.jasonpearson.automobile.desktop.core.daemon.ObservationStream
+import dev.jasonpearson.automobile.desktop.core.daemon.ObservationStreamClient
+import kotlinx.coroutines.delay
+import kotlinx.coroutines.flow.first
+import kotlinx.coroutines.isActive
+
+/**
+ * Owns a per-device [ObservationStream] with an automatic reconnect lifecycle, shared by the
+ * workspace surfaces (Layout facet, two-device compare sides) that each drive their own stream.
+ *
+ * The stream is created via [streamFactory] and connected to [deviceId] while the caller is in
+ * composition, then disposed when it leaves composition or [deviceId] changes — the same
+ * connect/dispose lifecycle the facets had before, but with recovery added: when the stream drops
+ * (a socket-unavailable failure at mount, an EOF, or a daemon restart while the surface stays open)
+ * it reconnects the same instance with exponential backoff instead of staying dead until the user
+ * exits and re-enters. Reconnection stops when the surface leaves composition (the reconnect
+ * coroutine is cancelled).
+ *
+ * Both time and daemon-availability are injected so the retry/backoff/stop-on-dispose behavior can
+ * be verified with virtual time and a `FakeObservationStream`, per repo convention (mirroring the
+ * `resolveTimeout` seam on the navigation facet):
+ * - [backoffDelay] is the timer seam: it suspends for the backoff of the given attempt (default
+ *   [reconnectBackoffMs] via [delay]); a test supplies a gate it releases per attempt.
+ * - [socketAvailable] reports whether the daemon's observation socket exists; while it is false the
+ *   loop keeps backing off but skips the pointless [ObservationStream.connect] call, so a
+ *   daemon-down window recovers on its own once the socket returns without hammering.
+ */
+@Composable
+fun rememberReconnectingObservationStream(
+  deviceId: String,
+  streamFactory: () -> ObservationStream,
+  backoffDelay: suspend (attempt: Int) -> Unit = { attempt -> delay(reconnectBackoffMs(attempt)) },
+  socketAvailable: () -> Boolean = { ObservationStreamClient.socketExists() },
+): ObservationStream? {
+  var stream by remember(deviceId) { mutableStateOf<ObservationStream?>(null) }
+  DisposableEffect(deviceId) {
+    val connected = streamFactory().also { it.connect(deviceId = deviceId) }
+    stream = connected
+    onDispose {
+      connected.dispose()
+      stream = null
+    }
+  }
+
+  val active = stream
+  // Reconnect loop, keyed on the live stream so it restarts for a new device and is cancelled on
+  // dispose (which ends reconnection). Driven by the stream's connection state — the single source
+  // of truth the real client updates on connect success/failure and on EOF ("Stream ended").
+  LaunchedEffect(active, deviceId) {
+    val s = active ?: return@LaunchedEffect
+    var attempt = 0
+    while (isActive) {
+      when (s.connectionState.value) {
+        is ConnectionState.Connected -> {
+          // Healthy: reset the backoff and idle until the connection actually drops.
+          attempt = 0
+          s.connectionState.first { it !is ConnectionState.Connected }
+        }
+        is ConnectionState.Connecting,
+        is ConnectionState.Reconnecting -> {
+          // A connect is already in flight; wait for it to resolve rather than issuing another.
+          s.connectionState.first {
+            it !is ConnectionState.Connecting && it !is ConnectionState.Reconnecting
+          }
+        }
+        is ConnectionState.Disconnected,
+        is ConnectionState.Error -> {
+          // Dropped or failed to connect: back off, then reconnect the same instance. While the
+          // daemon socket is absent, keep backing off but skip the pointless connect so a
+          // daemon-down window recovers on its own once the socket returns.
+          attempt++
+          backoffDelay(attempt)
+          if (!isActive) break
+          if (socketAvailable()) {
+            s.connect(deviceId = deviceId)
+          }
+        }
+      }
+    }
+  }
+  return stream
+}
+
+/** Initial reconnect backoff; doubles per attempt up to [RECONNECT_MAX_DELAY_MS]. */
+internal const val RECONNECT_INITIAL_DELAY_MS = 500L
+
+/** Ceiling for the reconnect backoff so a long daemon outage still polls at a steady cadence. */
+internal const val RECONNECT_MAX_DELAY_MS = 15_000L
+
+/**
+ * Exponential backoff (base [initialMs], doubling per attempt, capped at [maxMs]) for reconnect
+ * attempt [attempt] (1-based). Pure and overflow-safe so the delay is deterministic and the timer
+ * stays injectable — no jitter, since the timing is driven by the injected seam in tests.
+ */
+internal fun reconnectBackoffMs(
+  attempt: Int,
+  initialMs: Long = RECONNECT_INITIAL_DELAY_MS,
+  maxMs: Long = RECONNECT_MAX_DELAY_MS,
+): Long {
+  val n = attempt.coerceAtLeast(1)
+  val factor = 1L shl minOf(n - 1, 20)
+  // Guard the multiply against overflow before comparing to the cap.
+  val exp = if (factor > maxMs / initialMs) maxMs else initialMs * factor
+  return minOf(exp, maxMs)
+}

--- a/android/desktop-core/src/main/kotlin/dev/jasonpearson/automobile/desktop/core/workspace/TwoDeviceCompareView.kt
+++ b/android/desktop-core/src/main/kotlin/dev/jasonpearson/automobile/desktop/core/workspace/TwoDeviceCompareView.kt
@@ -173,7 +173,9 @@ private fun CompareSide(
       socketAvailable = socketAvailable,
     )
   val activeStream = stream ?: return
-  // Reset per stream instance; a reconnect creates a fresh stream and thus a fresh token.
+  // Fresh token per stream instance (i.e. per mount / device change). A reconnect reuses the same
+  // instance, so the token and these collectors deliberately persist across it; correctness only
+  // needs the token bumped on every clearHierarchy(), which still holds.
   val generation = remember(activeStream) { AtomicInteger(0) }
   val clearHierarchy = {
     generation.incrementAndGet()

--- a/android/desktop-core/src/main/kotlin/dev/jasonpearson/automobile/desktop/core/workspace/TwoDeviceCompareView.kt
+++ b/android/desktop-core/src/main/kotlin/dev/jasonpearson/automobile/desktop/core/workspace/TwoDeviceCompareView.kt
@@ -18,7 +18,6 @@ import androidx.compose.foundation.lazy.items
 import androidx.compose.material3.MaterialTheme
 import androidx.compose.material3.Text
 import androidx.compose.runtime.Composable
-import androidx.compose.runtime.DisposableEffect
 import androidx.compose.runtime.LaunchedEffect
 import androidx.compose.runtime.getValue
 import androidx.compose.runtime.mutableStateOf
@@ -46,6 +45,7 @@ import dev.jasonpearson.automobile.desktop.core.layout.diffHierarchies
 import dev.jasonpearson.automobile.desktop.core.layout.parseHierarchyFromJson
 import java.util.concurrent.atomic.AtomicInteger
 import kotlinx.coroutines.Dispatchers
+import kotlinx.coroutines.delay
 import kotlinx.coroutines.withContext
 import kotlinx.serialization.json.JsonElement
 
@@ -78,6 +78,8 @@ fun TwoDeviceCompareView(
   columnB: DeviceColumn,
   modifier: Modifier = Modifier,
   observationStreamFactory: () -> ObservationStream = { ObservationStreamClient() },
+  backoffDelay: suspend (attempt: Int) -> Unit = { attempt -> delay(reconnectBackoffMs(attempt)) },
+  socketAvailable: () -> Boolean = { ObservationStreamClient.socketExists() },
   sideContent: @Composable (DeviceColumn, ObservationStream) -> Unit = { column, stream ->
     LayoutInspectorDashboard(
       dataSourceMode = DataSourceMode.Real,
@@ -106,6 +108,8 @@ fun TwoDeviceCompareView(
       CompareSide(
         column = columnA,
         observationStreamFactory = observationStreamFactory,
+        backoffDelay = backoffDelay,
+        socketAvailable = socketAvailable,
         sideContent = sideContent,
         parseHierarchy = parseHierarchy,
         onHierarchy = { hierarchyA = it },
@@ -114,6 +118,8 @@ fun TwoDeviceCompareView(
       CompareSide(
         column = columnB,
         observationStreamFactory = observationStreamFactory,
+        backoffDelay = backoffDelay,
+        socketAvailable = socketAvailable,
         sideContent = sideContent,
         parseHierarchy = parseHierarchy,
         onHierarchy = { hierarchyB = it },
@@ -150,20 +156,22 @@ fun TwoDeviceCompareView(
 private fun CompareSide(
   column: DeviceColumn,
   observationStreamFactory: () -> ObservationStream,
+  backoffDelay: suspend (attempt: Int) -> Unit,
+  socketAvailable: () -> Boolean,
   sideContent: @Composable (DeviceColumn, ObservationStream) -> Unit,
   parseHierarchy: suspend (JsonElement) -> ParsedHierarchy?,
   onHierarchy: (ParsedHierarchy?) -> Unit,
   modifier: Modifier,
 ) {
-  var stream by remember(column.deviceId) { mutableStateOf<ObservationStream?>(null) }
-  DisposableEffect(column.deviceId) {
-    val connected = observationStreamFactory().also { it.connect(deviceId = column.deviceId) }
-    stream = connected
-    onDispose {
-      connected.dispose()
-      stream = null
-    }
-  }
+  // Shared reconnect lifecycle: a side that drops (daemon restart / EOF while the overlay is open)
+  // reconnects instead of staying in "waiting" until the user closes and reopens compare.
+  val stream =
+    rememberReconnectingObservationStream(
+      deviceId = column.deviceId,
+      streamFactory = observationStreamFactory,
+      backoffDelay = backoffDelay,
+      socketAvailable = socketAvailable,
+    )
   val activeStream = stream ?: return
   // Reset per stream instance; a reconnect creates a fresh stream and thus a fresh token.
   val generation = remember(activeStream) { AtomicInteger(0) }

--- a/android/desktop-core/src/test/kotlin/dev/jasonpearson/automobile/desktop/core/workspace/LayoutFacetTest.kt
+++ b/android/desktop-core/src/test/kotlin/dev/jasonpearson/automobile/desktop/core/workspace/LayoutFacetTest.kt
@@ -5,8 +5,10 @@ import androidx.compose.material3.MaterialTheme
 import androidx.compose.runtime.mutableStateOf
 import androidx.compose.ui.test.ExperimentalTestApi
 import androidx.compose.ui.test.runComposeUiTest
+import dev.jasonpearson.automobile.desktop.core.connection.ConnectionState
 import dev.jasonpearson.automobile.desktop.core.daemon.FakeObservationStream
 import dev.jasonpearson.automobile.desktop.core.daemon.ObservationStream
+import kotlinx.coroutines.CompletableDeferred
 import org.junit.Assert.assertEquals
 import org.junit.Assert.assertTrue
 import org.junit.Test
@@ -99,5 +101,32 @@ class LayoutFacetTest {
     assertEquals(2, factory.created.size)
     assertEquals(setOf("dev-1", "dev-2"), factory.created.map { it.lastConnectedDeviceId }.toSet())
     assertTrue(factory.created.all { it.connectCallCount == 1 })
+  }
+
+  @Test
+  fun `reconnects the pane stream after a mid-session drop`() = runComposeUiTest {
+    val fake = FakeObservationStream()
+    // A gate the test releases to let the single reconnect attempt proceed with zero wall time.
+    val backoff = CompletableDeferred<Unit>()
+    setContent {
+      MaterialTheme {
+        LayoutFacet(
+          column = DeviceColumn(deviceId = "dev-1", name = "Pixel", platform = Platform.Android),
+          observationStreamFactory = { fake },
+          backoffDelay = { backoff.await() },
+          socketAvailable = { true },
+        )
+      }
+    }
+    waitForIdle()
+    assertEquals(1, fake.connectCallCount)
+
+    // A daemon restart / EOF surfaces as a Disconnected state; the facet must reconnect instead of
+    // staying dead until the user exits and re-enters Inspect.
+    runOnIdle { fake.emitConnectionState(ConnectionState.Disconnected("Stream ended")) }
+    waitForIdle()
+    runOnIdle { backoff.complete(Unit) }
+    waitForIdle()
+    assertEquals("expected the facet to reconnect after a drop", 2, fake.connectCallCount)
   }
 }

--- a/android/desktop-core/src/test/kotlin/dev/jasonpearson/automobile/desktop/core/workspace/ReconnectingObservationStreamTest.kt
+++ b/android/desktop-core/src/test/kotlin/dev/jasonpearson/automobile/desktop/core/workspace/ReconnectingObservationStreamTest.kt
@@ -1,0 +1,175 @@
+package dev.jasonpearson.automobile.desktop.core.workspace
+
+import androidx.compose.runtime.mutableStateOf
+import androidx.compose.ui.test.ExperimentalTestApi
+import androidx.compose.ui.test.runComposeUiTest
+import dev.jasonpearson.automobile.desktop.core.connection.ConnectionState
+import dev.jasonpearson.automobile.desktop.core.daemon.FakeObservationStream
+import java.util.concurrent.ConcurrentHashMap
+import java.util.concurrent.CopyOnWriteArrayList
+import kotlinx.coroutines.CompletableDeferred
+import org.junit.Assert.assertEquals
+import org.junit.Assert.assertTrue
+import org.junit.Test
+
+/**
+ * Virtual-time coverage of the shared reconnect lifecycle: retry-with-backoff on a failed mount,
+ * reconnect on a mid-session drop/EOF, stop-on-dispose, and skip-while-daemon-down. Time is the
+ * injected [GatedBackoff] seam (each attempt awaits a deferred the test releases), so reconnect
+ * attempts step deterministically with zero wall time and nothing touches a real socket.
+ */
+@OptIn(ExperimentalTestApi::class)
+class ReconnectingObservationStreamTest {
+
+  /** A backoff seam that records each attempt and blocks until the test releases that attempt. */
+  private class GatedBackoff {
+    val attempts = CopyOnWriteArrayList<Int>()
+    private val gates = ConcurrentHashMap<Int, CompletableDeferred<Unit>>()
+
+    private fun gate(attempt: Int) = gates.getOrPut(attempt) { CompletableDeferred() }
+
+    val seam: suspend (Int) -> Unit = { attempt ->
+      attempts += attempt
+      gate(attempt).await()
+    }
+
+    fun release(attempt: Int) {
+      gate(attempt).complete(Unit)
+    }
+  }
+
+  @Test
+  fun `retries connect with incrementing backoff when the socket is unavailable at mount`() =
+    runComposeUiTest {
+      val fake = FakeObservationStream(failConnect = true)
+      val backoff = GatedBackoff()
+      setContent {
+        rememberReconnectingObservationStream(
+          deviceId = "dev-1",
+          streamFactory = { fake },
+          backoffDelay = backoff.seam,
+          socketAvailable = { true },
+        )
+      }
+      waitForIdle()
+      // Mount connected once, failed, and the loop is now backing off before the first retry.
+      assertEquals(1, fake.connectCallCount)
+      assertTrue("expected the loop to enter backoff attempt 1", backoff.attempts.contains(1))
+
+      // Releasing the first backoff issues exactly one reconnect, then backs off again (attempt 2).
+      runOnIdle { backoff.release(1) }
+      waitForIdle()
+      assertEquals(2, fake.connectCallCount)
+      assertEquals("dev-1", fake.lastConnectedDeviceId)
+      assertTrue("expected an incrementing second backoff attempt", backoff.attempts.contains(2))
+
+      runOnIdle { backoff.release(2) }
+      waitForIdle()
+      assertEquals(3, fake.connectCallCount)
+    }
+
+  @Test
+  fun `reconnects the same stream after a mid-session drop`() = runComposeUiTest {
+    val fake = FakeObservationStream()
+    val backoff = GatedBackoff()
+    setContent {
+      rememberReconnectingObservationStream(
+        deviceId = "dev-1",
+        streamFactory = { fake },
+        backoffDelay = backoff.seam,
+        socketAvailable = { true },
+      )
+    }
+    waitForIdle()
+    // Healthy mount: connected once, no backoff yet (loop is waiting for a drop).
+    assertEquals(1, fake.connectCallCount)
+    assertTrue("a healthy stream must not back off", backoff.attempts.isEmpty())
+
+    // A daemon restart / EOF surfaces as a Disconnected connection state.
+    runOnIdle { fake.emitConnectionState(ConnectionState.Disconnected("Stream ended")) }
+    waitForIdle()
+    assertTrue("expected the drop to trigger a backoff", backoff.attempts.contains(1))
+
+    runOnIdle { backoff.release(1) }
+    waitForIdle()
+    // Reconnected on the same instance.
+    assertEquals(2, fake.connectCallCount)
+  }
+
+  @Test
+  fun `stops reconnecting once the surface leaves composition`() = runComposeUiTest {
+    val fake = FakeObservationStream(failConnect = true)
+    val backoff = GatedBackoff()
+    val visible = mutableStateOf(true)
+    setContent {
+      if (visible.value) {
+        rememberReconnectingObservationStream(
+          deviceId = "dev-1",
+          streamFactory = { fake },
+          backoffDelay = backoff.seam,
+          socketAvailable = { true },
+        )
+      }
+    }
+    waitForIdle()
+    assertEquals(1, fake.connectCallCount)
+    assertTrue(backoff.attempts.contains(1))
+
+    // Leave composition while suspended in backoff, then release the gate.
+    runOnIdle { visible.value = false }
+    waitForIdle()
+    runOnIdle { backoff.release(1) }
+    waitForIdle()
+
+    // No reconnect fired after dispose, and the stream was disposed.
+    assertEquals(1, fake.connectCallCount)
+    assertTrue("expected the stream to be disposed on removal", fake.disconnectCallCount >= 1)
+  }
+
+  @Test
+  fun `skips connect while the daemon socket is absent, then recovers when it returns`() =
+    runComposeUiTest {
+      val fake = FakeObservationStream(failConnect = true)
+      val backoff = GatedBackoff()
+      val socketUp = mutableStateOf(false)
+      setContent {
+        rememberReconnectingObservationStream(
+          deviceId = "dev-1",
+          streamFactory = { fake },
+          backoffDelay = backoff.seam,
+          socketAvailable = { socketUp.value },
+        )
+      }
+      waitForIdle()
+      assertEquals(1, fake.connectCallCount)
+
+      // Socket absent: releasing backoffs keeps looping but issues no reconnect.
+      runOnIdle { backoff.release(1) }
+      waitForIdle()
+      runOnIdle { backoff.release(2) }
+      waitForIdle()
+      assertEquals("must not connect while the socket is absent", 1, fake.connectCallCount)
+
+      // Once the daemon returns, the next backoff cycle reconnects.
+      runOnIdle { socketUp.value = true }
+      runOnIdle { backoff.release(3) }
+      waitForIdle()
+      assertTrue("expected reconnect once the socket returned", fake.connectCallCount >= 2)
+    }
+
+  @Test
+  fun `backoff grows exponentially and caps`() {
+    assertEquals(RECONNECT_INITIAL_DELAY_MS, reconnectBackoffMs(1))
+    assertEquals(RECONNECT_INITIAL_DELAY_MS * 2, reconnectBackoffMs(2))
+    assertEquals(RECONNECT_INITIAL_DELAY_MS * 4, reconnectBackoffMs(3))
+    // Monotonic non-decreasing and capped.
+    var prev = 0L
+    for (attempt in 1..40) {
+      val d = reconnectBackoffMs(attempt)
+      assertTrue("attempt $attempt not monotonic ($prev -> $d)", d >= prev)
+      assertTrue("attempt $attempt exceeds cap", d <= RECONNECT_MAX_DELAY_MS)
+      prev = d
+    }
+    assertEquals(RECONNECT_MAX_DELAY_MS, reconnectBackoffMs(40))
+  }
+}

--- a/android/desktop-core/src/test/kotlin/dev/jasonpearson/automobile/desktop/core/workspace/ReconnectingObservationStreamTest.kt
+++ b/android/desktop-core/src/test/kotlin/dev/jasonpearson/automobile/desktop/core/workspace/ReconnectingObservationStreamTest.kt
@@ -158,6 +158,41 @@ class ReconnectingObservationStreamTest {
     }
 
   @Test
+  fun `resets the backoff after a healthy reconnect`() = runComposeUiTest {
+    val fake = FakeObservationStream()
+    val backoff = GatedBackoff()
+    setContent {
+      rememberReconnectingObservationStream(
+        deviceId = "dev-1",
+        streamFactory = { fake },
+        backoffDelay = backoff.seam,
+        socketAvailable = { true },
+      )
+    }
+    waitForIdle()
+    assertEquals(1, fake.connectCallCount)
+
+    // First drop → backoff attempt 1 → reconnect succeeds.
+    runOnIdle { fake.emitConnectionState(ConnectionState.Disconnected("drop 1")) }
+    waitForIdle()
+    runOnIdle { backoff.release(1) }
+    waitForIdle()
+    assertEquals(2, fake.connectCallCount)
+    assertEquals(listOf(1), backoff.attempts.toList())
+
+    // Second drop must restart the backoff at attempt 1, not continue to 2, because the reconnect
+    // in between was healthy (Connected). A non-resetting counter would record attempt 2 here.
+    runOnIdle { fake.emitConnectionState(ConnectionState.Disconnected("drop 2")) }
+    waitForIdle()
+    assertEquals(
+      "backoff must reset to attempt 1 after a healthy reconnect",
+      listOf(1, 1),
+      backoff.attempts.toList(),
+    )
+    assertEquals(3, fake.connectCallCount)
+  }
+
+  @Test
   fun `backoff grows exponentially and caps`() {
     assertEquals(RECONNECT_INITIAL_DELAY_MS, reconnectBackoffMs(1))
     assertEquals(RECONNECT_INITIAL_DELAY_MS * 2, reconnectBackoffMs(2))

--- a/android/desktop-core/src/test/kotlin/dev/jasonpearson/automobile/desktop/core/workspace/TwoDeviceCompareViewTest.kt
+++ b/android/desktop-core/src/test/kotlin/dev/jasonpearson/automobile/desktop/core/workspace/TwoDeviceCompareViewTest.kt
@@ -8,6 +8,7 @@ import androidx.compose.ui.test.onAllNodesWithText
 import androidx.compose.ui.test.onNodeWithContentDescription
 import androidx.compose.ui.test.onNodeWithText
 import androidx.compose.ui.test.runComposeUiTest
+import dev.jasonpearson.automobile.desktop.core.connection.ConnectionState
 import dev.jasonpearson.automobile.desktop.core.daemon.DeviceStreamEvent
 import dev.jasonpearson.automobile.desktop.core.daemon.FakeObservationStream
 import dev.jasonpearson.automobile.desktop.core.daemon.HierarchyStreamUpdate
@@ -83,6 +84,36 @@ class TwoDeviceCompareViewTest {
     assertEquals(1, fakeA.connectCallCount)
     assertEquals(1, fakeB.connectCallCount)
   }
+
+  @Test
+  fun `a side reconnects after a mid-session drop instead of staying disconnected`() =
+    runComposeUiTest {
+      val fakeA = FakeObservationStream()
+      val fakeB = FakeObservationStream()
+      // Only side A drops; side B stays healthy and never touches the shared backoff gate.
+      val backoff = CompletableDeferred<Unit>()
+      setContent {
+        MaterialTheme {
+          TwoDeviceCompareView(
+            columnA = columnA(),
+            columnB = columnB(),
+            observationStreamFactory = QueuedStreamFactory(fakeA, fakeB),
+            backoffDelay = { backoff.await() },
+            socketAvailable = { true },
+            sideContent = { column, _ -> Text(column.name) },
+          )
+        }
+      }
+      waitForIdle()
+      assertEquals(1, fakeA.connectCallCount)
+
+      runOnIdle { fakeA.emitConnectionState(ConnectionState.Disconnected("Stream ended")) }
+      waitForIdle()
+      runOnIdle { backoff.complete(Unit) }
+      waitForIdle()
+      assertEquals("expected side A to reconnect after a drop", 2, fakeA.connectCallCount)
+      assertEquals("side B must not reconnect", 1, fakeB.connectCallCount)
+    }
 
   @Test
   fun `waits for both hierarchies before showing a diff`() = runComposeUiTest {


### PR DESCRIPTION
## Summary

`LayoutFacet` and the two-device compare sides each connected their per-device `ObservationStream` exactly once (a one-shot `DisposableEffect`) and never recovered if the socket was unavailable at mount, or the daemon restarted / the read loop hit EOF while the surface stayed open — the inspector stayed dead until the user exited and re-entered. `AutoMobileContent` already had a health-check reconnect loop; the workspace facets did not.

This extracts a shared `rememberReconnectingObservationStream` that owns the per-device connect/dispose lifecycle **plus** an automatic reconnect: it reuses the same stream instance and reconnects with exponential backoff, driven by the stream's `connectionState`, and stops when the surface leaves composition. Both time and daemon-availability are injected seams so the behavior is deterministically testable:

- `backoffDelay: suspend (attempt) -> Unit` — the timer seam (default `delay(reconnectBackoffMs(attempt))`), mirroring the navigation facet's `resolveTimeout` seam.
- `socketAvailable: () -> Boolean` — while the daemon socket is absent the loop keeps backing off but skips the pointless `connect()`, so a daemon-down window recovers on its own once the socket returns.

`LayoutFacet` and `TwoDeviceCompareView`'s `CompareSide` are routed through the helper.

## Linked Issue

Closes #4868

## Changes

- **New** `ReconnectingObservationStream.kt` — `rememberReconnectingObservationStream` (connectionState-driven reconnect loop) + pure `reconnectBackoffMs` (exponential, capped, overflow-safe).
- `LayoutFacet` / `TwoDeviceCompareView` — route their stream through the helper; expose the two seams (defaulted) for testing.

## Validation

- [x] `:desktop-core:test` — full module suite green
- [x] ktfmt clean tree-wide (`scripts/ktfmt/validate_ktfmt.sh`)
- [x] New code uses interface + fake (`FakeObservationStream`) + injected virtual-time seam; unit tests run in well under 100ms
- N/A: TS lint/build/typecheck (no TypeScript changed), Swift/shell/schema (none touched)

### Tests

- `ReconnectingObservationStreamTest` (virtual time): retry-with-incrementing-backoff on failed mount; reconnect on mid-session drop/EOF; stop-on-dispose; skip-while-daemon-down then recover; exponential-backoff cap.
- `LayoutFacetTest` / `TwoDeviceCompareViewTest`: reconnect-after-drop through each surface; existing connect/dispose/re-key cases still green.

## Kotlin Reuse Check

- [x] Reuses the existing `ObservationStream` interface + `FakeObservationStream`, `ConnectionState`, and the `ObservationStreamClient.socketExists()` probe already used by `AutoMobileContent`. The backoff formula is a small local pure function (no shared Kotlin `Backoff` primitive exists yet — the two push clients each carry their own `calculateBackoff`); extracting a canonical one is noted as a follow-up rather than done here to keep the diff focused.

## Follow-ups

- Apply the shared helper to the Navigation/Performance facets (replacing Nav's manual-retry-only path), plus the screenshot-cache hoist and active-device audit residue — tracked in #4832.
- `DeviceStreamView` panes want the same lifecycle — #4962 (blocked on #4957).
- `ObservationStreamClient` leaks a socket fd per reconnect (channel not closed on EOF) — surfaced by Codex review here; pre-existing on `main` via `AutoMobileContent`'s health-check loop, made repeatable by this PR's facet reconnect. Tracked in #5045.


