### PR TITLE
fix: scope DevicePool intentional-shutdown markers to device incarnation

### DIFF
--- a/src/daemon/devicePool.ts
+++ b/src/daemon/devicePool.ts
@@ -473,6 +473,15 @@ export class DevicePool {
       // disconnect for this incarnation arrives.
       return true;
     }
+    // Re-validate identity after the discovery await: a same-serial incarnation
+    // may have replaced `device` while we awaited (removeDisconnectedDevice does
+    // not hold assignmentMutex, cf. the sibling check below). Only the captured
+    // incarnation — or an already-empty slot — may be consumed here; a fresh
+    // replacement carries its own marker and disconnect lifecycle.
+    const current = this.devices.get(deviceId);
+    if (device && current && current !== device) {
+      return true;
+    }
     this.intentionalShutdowns.delete(deviceId);
     await this.removeDevice(deviceId);
     return true;

--- a/src/daemon/devicePool.ts
+++ b/src/daemon/devicePool.ts
@@ -82,6 +82,14 @@ export interface PooledDevice {
   avdName?: string;
   /** Source image metadata used to evaluate allocation criteria during recovery. */
   androidImage?: DeviceInfo;
+  /**
+   * Monotonic id for this pooled connection incarnation, assigned when the
+   * device is first added to the pool. A serial (`id`) can be reused across
+   * boots, so this distinguishes "the device we intentionally stopped" from a
+   * later same-serial replacement — see `intentionalShutdowns` (issue: DevicePool
+   * shutdown-marker same-serial-reuse race, follow-up to PR #5015).
+   */
+  incarnation: number;
 }
 
 interface IosLivenessSnapshot {
@@ -103,6 +111,14 @@ interface DeviceDisconnectSessionReleaser {
 interface DeviceReadyListener {
   (deviceId: string): void;
 }
+
+/**
+ * Marker incarnation used when an intentional shutdown is recorded while no
+ * pooled device is present (only an in-flight recovery). Such a marker applies
+ * to whatever incarnation the recovery produces, matching the pre-existing
+ * serial-scoped recovery-cancellation behavior (issue #4915).
+ */
+const INCARNATION_ANY = -1;
 
 /**
  * Device Pool
@@ -139,7 +155,16 @@ export class DevicePool {
   private readonly recoveringAndroidImages: Map<string, DeviceInfo> = new Map();
   private readonly recoveringAndroidDeviceIds: Set<string> = new Set();
   private readonly startedDeviceProcesses: Map<string, ChildProcess> = new Map();
-  private readonly intentionallyStoppedDeviceIds: Set<string> = new Set();
+  /**
+   * Serials the user intentionally stopped, mapped to the pooled-device
+   * incarnation that was present at mark time (or {@link INCARNATION_ANY} when
+   * only a recovery was in flight). Consuming this on a disconnect is gated on
+   * incarnation so a stale disconnect for a prior incarnation cannot remove a
+   * same-serial replacement, nor can a later crash of a replacement consume a
+   * marker that belonged to a device that is already gone.
+   */
+  private readonly intentionalShutdowns: Map<string, number> = new Map();
+  private deviceIncarnationCounter = 0;
 
   // Max consecutive errors before marking device as failed
   private readonly MAX_DEVICE_ERRORS = 5;
@@ -217,6 +242,7 @@ export class DevicePool {
         errorCount: 0,
         iosVersion: device.iosVersion,
         simulatorType: this.criteriaMatcher.getBootedDeviceSimulatorType(device),
+        incarnation: this.nextDeviceIncarnation(),
       });
       this.deviceSessionStarts.set(device.deviceId, now);
       await this.setDeviceSessionTracking(device.deviceId, now);
@@ -283,6 +309,7 @@ export class DevicePool {
             errorCount: 0,
             iosVersion: device.iosVersion,
             simulatorType: this.criteriaMatcher.getBootedDeviceSimulatorType(device),
+            incarnation: this.nextDeviceIncarnation(),
           });
           this.deviceSessionStarts.set(device.deviceId, now);
           this.refreshMissingDeviceMisses.delete(device.deviceId);
@@ -336,7 +363,7 @@ export class DevicePool {
   async addDevice(device: BootedDevice, sourceImage?: DeviceInfo): Promise<void> {
     this.clearAutoStartSuppressionForBootedDevice(device, sourceImage);
     if (sourceImage) {
-      this.intentionallyStoppedDeviceIds.delete(device.deviceId);
+      this.intentionalShutdowns.delete(device.deviceId);
     }
     const existing = this.devices.get(device.deviceId);
     if (existing) {
@@ -366,6 +393,7 @@ export class DevicePool {
         errorCount: 0,
         iosVersion: device.iosVersion,
         simulatorType: this.criteriaMatcher.getBootedDeviceSimulatorType(device),
+        incarnation: this.nextDeviceIncarnation(),
       });
       this.recordSourceAndroidAvd(device.deviceId, sourceImage);
       this.deviceSessionStarts.set(device.deviceId, now);
@@ -411,10 +439,48 @@ export class DevicePool {
     logger.info(`Removed device ${deviceId} from pool and cleared cached data`);
   }
 
+  /**
+   * Apply any intentional-shutdown marker to a disconnect, gated on the device
+   * incarnation. Returns `true` when the disconnect is fully handled here — the
+   * marked device was removed, or the signal was stale and the live device kept —
+   * and `false` when no marker applied and the caller should handle the
+   * disconnect normally.
+   */
+  private async applyIntentionalShutdownOnDisconnect(
+    deviceId: string,
+    device: PooledDevice | undefined,
+    mayBeStaleSignal: boolean,
+  ): Promise<boolean> {
+    const markerIncarnation = this.intentionalShutdowns.get(deviceId);
+    if (markerIncarnation === undefined) {
+      return false;
+    }
+    const appliesToCurrent =
+      !device ||
+      markerIncarnation === INCARNATION_ANY ||
+      markerIncarnation === device.incarnation;
+    if (!appliesToCurrent) {
+      // A different incarnation now holds this serial, so the mark belonged to a
+      // device that is already gone. Drop the stale marker instead of removing
+      // the live replacement (or suppressing its recovery), and let the caller
+      // handle this disconnect on its own merits.
+      this.intentionalShutdowns.delete(deviceId);
+      return false;
+    }
+    if (mayBeStaleSignal && device && await this.wasRebootedAndroidDeviceRediscovered(device)) {
+      // The intentionally-stopped serial is still (or again) booted, so this
+      // disconnect is stale — keep the live device and the marker until a real
+      // disconnect for this incarnation arrives.
+      return true;
+    }
+    this.intentionalShutdowns.delete(deviceId);
+    await this.removeDevice(deviceId);
+    return true;
+  }
+
   async removeDisconnectedDevice(deviceId: string, mayBeStaleSignal: boolean = true): Promise<void> {
     const device = this.devices.get(deviceId);
-    if (this.intentionallyStoppedDeviceIds.delete(deviceId)) {
-      await this.removeDevice(deviceId);
+    if (await this.applyIntentionalShutdownOnDisconnect(deviceId, device, mayBeStaleSignal)) {
       return;
     }
     if (!device || device.sessionId) {
@@ -471,14 +537,26 @@ export class DevicePool {
     return this.devices.get(device.id) === device && !rediscovered;
   }
 
+  /** Assign the next monotonic incarnation id for a newly pooled connection. */
+  private nextDeviceIncarnation(): number {
+    return ++this.deviceIncarnationCounter;
+  }
+
   markIntentionalShutdown(deviceId: string): void {
-    if (this.devices.has(deviceId) || this.recoveringAndroidDeviceIds.has(deviceId)) {
-      this.intentionallyStoppedDeviceIds.add(deviceId);
+    const device = this.devices.get(deviceId);
+    if (device) {
+      // Tie the marker to the incarnation present now, so a later same-serial
+      // replacement is not treated as intentionally stopped.
+      this.intentionalShutdowns.set(deviceId, device.incarnation);
+    } else if (this.recoveringAndroidDeviceIds.has(deviceId)) {
+      // No pooled device yet (an in-flight recovery owns the serial); the mark
+      // applies to whatever incarnation the recovery produces.
+      this.intentionalShutdowns.set(deviceId, INCARNATION_ANY);
     }
   }
 
   clearIntentionalShutdown(deviceId: string): void {
-    this.intentionallyStoppedDeviceIds.delete(deviceId);
+    this.intentionalShutdowns.delete(deviceId);
   }
 
   private async removeDevicesMissingFrom(
@@ -1215,9 +1293,13 @@ export class DevicePool {
   }
 
   private consumeIntentionalShutdown(deviceIds: ReadonlySet<string>): boolean {
+    // Recovery cancellation is deliberately serial-scoped: a user's kill of a
+    // serial cancels a pool reboot of that same serial regardless of incarnation
+    // (issue #4915). Incarnation gating applies only to the disconnect path in
+    // removeDisconnectedDevice.
     let consumed = false;
     for (const deviceId of deviceIds) {
-      consumed = this.intentionallyStoppedDeviceIds.delete(deviceId) || consumed;
+      consumed = this.intentionalShutdowns.delete(deviceId) || consumed;
     }
     return consumed;
   }

--- a/test/daemon/devicePool.test.ts
+++ b/test/daemon/devicePool.test.ts
@@ -680,6 +680,87 @@ describe("DevicePool", () => {
     });
   });
 
+  describe("intentional-shutdown marker incarnation scoping", () => {
+    const androidImage = {
+      name: "Pixel 8",
+      platform: "android" as const,
+      isRunning: false,
+      source: "local" as const,
+    };
+
+    const withRebootOnDeath = async (run: () => Promise<void>): Promise<void> => {
+      const original = process.env.AUTOMOBILE_ANDROID_REBOOT_ON_DEATH;
+      process.env.AUTOMOBILE_ANDROID_REBOOT_ON_DEATH = "1";
+      try {
+        await run();
+      } finally {
+        if (original === undefined) {
+          delete process.env.AUTOMOBILE_ANDROID_REBOOT_ON_DEATH;
+        } else {
+          process.env.AUTOMOBILE_ANDROID_REBOOT_ON_DEATH = original;
+        }
+      }
+    };
+
+    test("a stale disconnect does not remove an intentionally-stopped device that is still booted", async () => {
+      await withRebootOnDeath(async () => {
+        devicePool = new DevicePool(
+          sessionManager,
+          "test-daemon-session-id",
+          fakeTimer,
+          fakeAppsRepo,
+          fakeDeviceManager,
+          new DefaultRetryExecutor(fakeTimer),
+          undefined,
+          undefined,
+          undefined,
+          undefined,
+          undefined,
+          { onLoss: true, maxAttempts: 2 },
+        );
+        await devicePool.addDevice(createBootedDevice("emulator-5554", "android", "Pixel 8"), androidImage);
+        devicePool.markIntentionalShutdown("emulator-5554");
+        // The serial is still booted — the kill has not taken effect yet, or a
+        // same-serial device is already back. The disconnect signal is stale.
+        fakeDeviceManager.bootedDevices = [createBootedDevice("emulator-5554", "android", "Pixel 8")];
+
+        await devicePool.removeDisconnectedDevice("emulator-5554", true);
+
+        // Before the fix the marker was consumed before the rediscovery check, so
+        // this live device would be removed.
+        expect(devicePool.getDevice("emulator-5554")).not.toBeNull();
+
+        // A genuine disconnect (the serial is truly gone) still honors the mark.
+        fakeDeviceManager.bootedDevices = [];
+        await devicePool.removeDisconnectedDevice("emulator-5554", true);
+        expect(devicePool.getDevice("emulator-5554")).toBeNull();
+      });
+    });
+
+    test("assigns a fresh incarnation per pooled connection and keeps it across a reusing refresh", async () => {
+      await initializeLiveDevices([createBootedDevice("emulator-5554", "android", "Pixel 8")]);
+      const first = devicePool.getDevice("emulator-5554");
+      if (!first) {
+        throw new Error("expected pooled device");
+      }
+      const firstIncarnation = first.incarnation;
+
+      // A refresh that rediscovers the same serial reuses the entry — same
+      // incarnation, so an existing mark for it still applies.
+      await devicePool.refreshDevices();
+      expect(devicePool.getDevice("emulator-5554")?.incarnation).toBe(firstIncarnation);
+
+      // Once the serial leaves and re-appears, it is a new connection and gets a
+      // fresh incarnation, so a mark from the prior incarnation cannot match it.
+      await devicePool.removeDevice("emulator-5554");
+      fakeDeviceManager.bootedDevices = [createBootedDevice("emulator-5554", "android", "Pixel 8")];
+      await devicePool.refreshDevices();
+      const second = devicePool.getDevice("emulator-5554");
+      expect(second).not.toBeNull();
+      expect(second!.incarnation).toBeGreaterThan(firstIncarnation);
+    });
+  });
+
   describe("device-ready notifications", () => {
     test("notifies when a boot-ready device reuses an existing serial", async () => {
       const connectedDeviceIds: string[] = [];

--- a/test/daemon/devicePool.test.ts
+++ b/test/daemon/devicePool.test.ts
@@ -737,6 +737,55 @@ describe("DevicePool", () => {
       });
     });
 
+    test("does not remove a same-serial replacement that swaps in during the rediscovery await", async () => {
+      await withRebootOnDeath(async () => {
+        const deferred = new DeferredDiscoveryFakeDeviceManager();
+        fakeDeviceManager = deferred;
+        devicePool = new DevicePool(
+          sessionManager,
+          "test-daemon-session-id",
+          fakeTimer,
+          fakeAppsRepo,
+          deferred,
+          new DefaultRetryExecutor(fakeTimer),
+          undefined,
+          undefined,
+          undefined,
+          undefined,
+          undefined,
+          { onLoss: true, maxAttempts: 2 },
+        );
+        await devicePool.addDevice(createBootedDevice("emulator-5554", "android", "Pixel 8"), androidImage);
+        devicePool.markIntentionalShutdown("emulator-5554");
+        // Discovery will find nothing, so without a post-await identity re-check
+        // the disconnect would fall through to consume + remove.
+        deferred.bootedDevices = [];
+
+        // Start the disconnect; it blocks inside the rediscovery discovery await.
+        const disconnect = devicePool.removeDisconnectedDevice("emulator-5554", true);
+        await deferred.waitForDiscoveryStart();
+
+        // While the await is in flight, the marked incarnation leaves and a fresh
+        // same-serial incarnation (with its own marker) takes its place.
+        await devicePool.removeDevice("emulator-5554");
+        await devicePool.addDevice(createBootedDevice("emulator-5554", "android", "Pixel 8"), androidImage);
+        devicePool.markIntentionalShutdown("emulator-5554");
+        const replacement = devicePool.getDevice("emulator-5554");
+        if (!replacement) {
+          throw new Error("expected replacement device");
+        }
+
+        deferred.releaseDiscovery();
+        await disconnect;
+
+        // The stale disconnect for the prior incarnation must not delete the live
+        // replacement (nor consume its newly set marker).
+        const afterDisconnect = devicePool.getDevice("emulator-5554");
+        expect(afterDisconnect).not.toBeNull();
+        expect(afterDisconnect!.incarnation).toBe(replacement.incarnation);
+      });
+    });
+
     test("assigns a fresh incarnation per pooled connection and keeps it across a reusing refresh", async () => {
       await initializeLiveDevices([createBootedDevice("emulator-5554", "android", "Pixel 8")]);
       const first = devicePool.getDevice("emulator-5554");


### PR DESCRIPTION
## Purpose
Fix a same-serial-reuse race in `DevicePool`'s intentional-shutdown markers, surfaced as a Codex P2 on #5015 and scoped out of it as pre-existing (the marker mechanism predates that PR — introduced by #4915).

## Problem
`intentionalShutdowns` (previously `intentionallyStoppedDeviceIds`) was keyed by bare serial (`deviceId`). ADB serials are reused across boots, so:

1. `removeDisconnectedDevice` consumed the marker **before** the rediscovery/staleness check — a stale disconnect for a prior incarnation could remove the **live** same-serial replacement.
2. A marker set for a device that is already gone could be consumed by a later, unrelated same-serial incarnation.

## Fix
- Tag each pooled connection with a monotonic `incarnation` id at add time (`PooledDevice.incarnation`).
- `removeDisconnectedDevice` now resolves the marker via `applyIntentionalShutdownOnDisconnect`, which:
  - **gates on incarnation** — a marker whose incarnation no longer matches the pooled device is dropped rather than applied to the replacement;
  - runs the **rediscovery/staleness check before consuming** — a device that is still (or again) booted is retained, not removed.
- The recovery-cancellation path (`consumeIntentionalShutdown`, #4915) stays **serial-scoped** on purpose, so a user's kill still cancels a pool reboot of the same serial. Incarnation gating applies only to the disconnect path.

## Notes on reachability
The staleness-before-consume reorder is the **reachable** fix (see the failing-before test below). The incarnation gate is defense-in-depth for the recovery-eligible case: today `addDevice(sourceImage)` — the only path that makes a device recovery-eligible — already clears the marker, so a stale marker cannot currently attach to a recovery-eligible replacement. The gate makes the invariant explicit and future-proof.

## Tests
- `a stale disconnect does not remove an intentionally-stopped device that is still booted` — reproduces the race (verified failing without the reorder), and confirms a genuine disconnect still honors the mark.
- `assigns a fresh incarnation per pooled connection and keeps it across a reusing refresh` — locks the incarnation-assignment invariant.
- All 114 existing `devicePool` tests (recovery-cancellation, same-serial rediscovery, etc.) pass unchanged.

## Validation
- `bun test test/daemon/devicePool.test.ts` · full suite 12767 pass / 0 fail
- `bun run typecheck` · `bun run lint` (complexity kept under threshold via `applyIntentionalShutdownOnDisconnect`; no baseline growth) · `bun run build`
