### PR TITLE
feat(desktop): execute emulator-control intents against the real device

### DIFF
--- a/android/desktop-app/src/main/kotlin/dev/jasonpearson/automobile/desktop/AutoMobileDesktopApp.kt
+++ b/android/desktop-app/src/main/kotlin/dev/jasonpearson/automobile/desktop/AutoMobileDesktopApp.kt
@@ -20,9 +20,12 @@ import dev.jasonpearson.automobile.desktop.core.daemon.DesktopDaemonSession
 import dev.jasonpearson.automobile.desktop.core.di.LocalAutoMobileGraph
 import dev.jasonpearson.automobile.desktop.core.logging.LoggerFactory
 import dev.jasonpearson.automobile.desktop.core.mcp.DaemonMcpResourceClient
+import dev.jasonpearson.automobile.desktop.core.mcp.ResourceReadResult
 import dev.jasonpearson.automobile.desktop.core.settings.SettingsProvider
 import dev.jasonpearson.automobile.desktop.core.shell.MenuBarActions
+import dev.jasonpearson.automobile.desktop.core.workspace.BOOTED_DEVICES_RESOURCE_URI
 import dev.jasonpearson.automobile.desktop.core.workspace.CommandPalette
+import dev.jasonpearson.automobile.desktop.core.workspace.DaemonEmulatorControlExecutor
 import dev.jasonpearson.automobile.desktop.core.workspace.DeviceColumn
 import dev.jasonpearson.automobile.desktop.core.workspace.DeviceStreamView
 import dev.jasonpearson.automobile.desktop.core.workspace.FailuresFacet
@@ -42,6 +45,7 @@ import dev.jasonpearson.automobile.desktop.core.workspace.WorkspaceUiState
 import dev.jasonpearson.automobile.desktop.core.workspace.WorkspaceViewModel
 import dev.jasonpearson.automobile.desktop.core.workspace.buildWorkspaceCommands
 import dev.jasonpearson.automobile.desktop.core.workspace.deriveWorkspaceStatus
+import dev.jasonpearson.automobile.desktop.core.workspace.parseDeviceLockStates
 import dev.jasonpearson.automobile.desktop.core.workspace.picker.DevicePicker
 import dev.jasonpearson.automobile.desktop.core.workspace.picker.DevicePickerAction
 import dev.jasonpearson.automobile.desktop.core.workspace.picker.DevicePickerEffect
@@ -70,6 +74,13 @@ private const val DESKTOP_SESSION_HEARTBEAT_MS = 2_000L
 // How often the top-bar status dot re-probes daemon connectivity. Matches the health sheet's
 // read-only refresh cadence (WorkspaceShell.HEALTH_SHEET_REFRESH_MS).
 private const val DAEMON_STATUS_POLL_MS = 5_000L
+
+// How often each observed pane's lock state is re-read so the contextual Unlock control appears or
+// disappears as the device locks/unlocks. Runs only while at least one device is observed. NOTE:
+// it re-reads the whole booted-devices resource, which recomputes service status AND the keyguard
+// probe for every booted device — not a free read. A lighter dedicated lock-state feed is a
+// follow-up (see #4694); until then this cadence trades adb load for Unlock responsiveness.
+private const val LOCK_STATE_POLL_MS = 4_000L
 
 /**
  * Live daemon connectivity as a [ConnectionState], polled from [AutoMobileClient.getDaemonStatus].
@@ -125,7 +136,9 @@ fun AutoMobileDesktopApp(
   val graph = LocalAutoMobileGraph.current
   val settings = remember(graph) { ObservableSettingsProvider(graph.settingsProvider) }
   val scope = rememberCoroutineScope()
-  val workspaceViewModel = remember(scope) { WorkspaceViewModel(scope) }
+  val controlExecutor = remember(graph) { DaemonEmulatorControlExecutor(graph.autoMobileClient) }
+  val workspaceViewModel =
+    remember(scope, controlExecutor) { WorkspaceViewModel(scope, controlExecutor) }
   val workspaceState by workspaceViewModel.state.collectAsState()
 
   val resourceClient = remember(graph) { DaemonMcpResourceClient(graph.autoMobileClient) }
@@ -242,14 +255,42 @@ fun AutoMobileDesktopApp(
           pickerViewModel.onAction(DevicePickerAction.Refresh)
           pickerOpen = true
         }
-        // Emulator-control execution is deferred to #4694; drain + log the intent for now so the
-        // effect channel doesn't back up. The control UI + intent contract ships in this PR.
-        is WorkspaceEffect.RunControl ->
-          LOG.info(
-            "Emulator control ${effect.control} requested for ${effect.deviceId} " +
-              "(${effect.platform}); execution deferred to #4694"
-          )
       }
+    }
+  }
+
+  // Keep each pane's lock state fresh so the contextual Unlock control appears/disappears as the
+  // device locks/unlocks. Untested IO poll (mirrors rememberDaemonConnectionState); the VM's
+  // SetLockStates handler is the pinned behavior. Gated on observed columns so an idle workspace
+  // is silent; while panes are open it re-reads the (non-trivial) booted-devices resource — see
+  // LOCK_STATE_POLL_MS.
+  LaunchedEffect(workspaceViewModel, resourceClient) {
+    while (true) {
+      val hasColumns =
+        (workspaceViewModel.state.value as? WorkspaceUiState.Content)?.columns?.isNotEmpty() == true
+      if (hasColumns) {
+        val states =
+          try {
+            when (
+              val result =
+                withContext(Dispatchers.IO) {
+                  resourceClient.readResource(BOOTED_DEVICES_RESOURCE_URI)
+                }
+            ) {
+              is ResourceReadResult.Success -> parseDeviceLockStates(result.content)
+              is ResourceReadResult.Error -> emptyMap()
+            }
+          } catch (cancellation: CancellationException) {
+            throw cancellation
+          } catch (error: Exception) {
+            LOG.warn("Lock-state poll failed: ${error.message}", error)
+            emptyMap()
+          }
+        if (states.isNotEmpty()) {
+          workspaceViewModel.onAction(WorkspaceAction.SetLockStates(states))
+        }
+      }
+      delay(LOCK_STATE_POLL_MS)
     }
   }
   LaunchedEffect(pickerViewModel) {

--- a/android/desktop-core/src/main/kotlin/dev/jasonpearson/automobile/desktop/core/daemon/FakeObservationStream.kt
+++ b/android/desktop-core/src/main/kotlin/dev/jasonpearson/automobile/desktop/core/daemon/FakeObservationStream.kt
@@ -62,6 +62,12 @@ class FakeObservationStream(private val failConnect: Boolean = false) : Observat
   var lastNavigationAppId: String? = null
     private set
 
+  var observationRequestCount = 0
+    private set
+
+  var lastObservationDeviceId: String? = null
+    private set
+
   override fun connect(deviceId: String?) {
     connectCallCount++
     lastConnectedDeviceId = deviceId
@@ -100,9 +106,14 @@ class FakeObservationStream(private val failConnect: Boolean = false) : Observat
     lastNavigationAppId = appId
   }
 
-  override fun requestObservation(deviceId: String?) = Unit
+  override fun requestObservation(deviceId: String?) {
+    observationRequestCount++
+    lastObservationDeviceId = deviceId
+  }
 
   // -- Test helpers: push updates onto the flows --
+  fun emitScreenshot(update: ScreenshotStreamUpdate): Boolean = _screenshotUpdates.tryEmit(update)
+
   fun emitNavigation(update: NavigationGraphStreamUpdate): Boolean =
     _navigationUpdates.tryEmit(update)
 

--- a/android/desktop-core/src/main/kotlin/dev/jasonpearson/automobile/desktop/core/mcp/DeviceModels.kt
+++ b/android/desktop-core/src/main/kotlin/dev/jasonpearson/automobile/desktop/core/mcp/DeviceModels.kt
@@ -36,6 +36,12 @@ data class BootedDeviceInfo(
   val serviceStatus: DeviceServiceStatus? = null,
   val batteryLevel: Int? = null, // 0-100, null if unknown
   val connectionType: String? = null, // "usb", "wifi", or null if unknown
+  // Whether the device's keyguard/lock screen is currently obscuring the app. Android-only (from
+  // `dumpsys window policy`). The daemon deliberately OMITS this when it can't read it — a
+  // transient
+  // probe timeout, or iOS — so `null` means "unknown, keep the pane's current state" rather than
+  // "unlocked". A non-null value gates the pane Unlock control.
+  val locked: Boolean? = null,
 )
 
 @Serializable

--- a/android/desktop-core/src/main/kotlin/dev/jasonpearson/automobile/desktop/core/workspace/DeviceLockStatePoll.kt
+++ b/android/desktop-core/src/main/kotlin/dev/jasonpearson/automobile/desktop/core/workspace/DeviceLockStatePoll.kt
@@ -1,0 +1,19 @@
+package dev.jasonpearson.automobile.desktop.core.workspace
+
+import dev.jasonpearson.automobile.desktop.core.mcp.DeviceResourceParser
+
+/** URI of the booted-devices resource that carries each device's lock state. */
+const val BOOTED_DEVICES_RESOURCE_URI = "automobile:devices/booted"
+
+/**
+ * Parse a booted-devices resource payload into a `deviceId -> locked` snapshot for
+ * [WorkspaceAction.SetLockStates]. Devices whose `locked` the daemon could not read are OMITTED
+ * (the field is `null`), never coerced to `false` — so a device with an unknown lock state keeps
+ * its pane's current state instead of being force-unlocked. A malformed/empty payload likewise
+ * yields an empty map ("no update"). Pure so the host's untested poll stays a thin IO wrapper.
+ */
+fun parseDeviceLockStates(content: String): Map<String, Boolean> =
+  DeviceResourceParser.parseBootedDevices(content)
+    ?.devices
+    ?.mapNotNull { device -> device.locked?.let { device.deviceId to it } }
+    ?.toMap() ?: emptyMap()

--- a/android/desktop-core/src/main/kotlin/dev/jasonpearson/automobile/desktop/core/workspace/EmulatorControlExecutor.kt
+++ b/android/desktop-core/src/main/kotlin/dev/jasonpearson/automobile/desktop/core/workspace/EmulatorControlExecutor.kt
@@ -1,0 +1,125 @@
+package dev.jasonpearson.automobile.desktop.core.workspace
+
+import dev.jasonpearson.automobile.desktop.core.daemon.AutoMobileClient
+import kotlinx.coroutines.CoroutineDispatcher
+import kotlinx.coroutines.Dispatchers
+import kotlinx.coroutines.withContext
+import kotlinx.serialization.json.buildJsonObject
+import kotlinx.serialization.json.put
+
+/**
+ * Runs a device-mutating emulator control (Rotate, Snapshot, Unlock) against a real device. This is
+ * the seam #4694 wires: the [WorkspaceViewModel] resolves the target column and invokes this off
+ * the UI thread, exactly as the picker's [DevicePickerViewModel] drives its `McpResourceClient`.
+ * The real implementation is untested IO (see [DaemonEmulatorControlExecutor]); behavior is pinned
+ * at the ViewModel boundary with [FakeEmulatorControlExecutor].
+ *
+ * Screenshot is intentionally NOT a device mutation here — it captures and surfaces a PNG in the
+ * pane via the observation stream, so it is handled UI-side rather than through this
+ * fire-and-forget seam.
+ */
+interface EmulatorControlExecutor {
+  /**
+   * Run [control] against [deviceId] on [platform]. [orientation] is the target orientation, used
+   * only by [EmulatorControl.Rotate]. Suspends until the device call completes (or throws).
+   */
+  suspend fun run(
+    deviceId: String,
+    platform: Platform,
+    control: EmulatorControl,
+    orientation: Orientation,
+  )
+}
+
+/** No-op seam for hosts/tests that don't wire real device execution. */
+object NoOpEmulatorControlExecutor : EmulatorControlExecutor {
+  override suspend fun run(
+    deviceId: String,
+    platform: Platform,
+    control: EmulatorControl,
+    orientation: Orientation,
+  ) = Unit
+}
+
+/**
+ * Real executor backed by the daemon [AutoMobileClient]. Sets the active device first, then invokes
+ * the control's MCP tool with the resolved platform + deviceId, enabling the tool's server
+ * capability where one gates it. Untested IO seam (mirrors `DaemonMcpResourceClient`).
+ */
+class DaemonEmulatorControlExecutor(
+  private val client: AutoMobileClient,
+  private val ioDispatcher: CoroutineDispatcher = Dispatchers.IO,
+) : EmulatorControlExecutor {
+  override suspend fun run(
+    deviceId: String,
+    platform: Platform,
+    control: EmulatorControl,
+    orientation: Orientation,
+  ) {
+    withContext(ioDispatcher) {
+      val wire = platform.wireName()
+      // Target the pane's device explicitly (belt-and-suspenders with the deviceId arg below), so a
+      // control never races onto whichever device happened to be active.
+      client.setActiveDevice(deviceId, wire)
+      when (control) {
+        EmulatorControl.Rotate -> {
+          // `rotate` lives behind the advanced-interaction capability.
+          client.enableToolCapability("advanced-interaction")
+          client.callTool(
+            "rotate",
+            buildJsonObject {
+              put("orientation", orientation.toolValue)
+              put("platform", wire)
+              put("deviceId", deviceId)
+            },
+          )
+        }
+        EmulatorControl.Snapshot -> {
+          // `deviceSnapshot` lives behind the screen-artifacts capability.
+          client.enableToolCapability("screen-artifacts")
+          client.callTool(
+            "deviceSnapshot",
+            buildJsonObject {
+              put("action", "capture")
+              put("platform", wire)
+              put("deviceId", deviceId)
+            },
+          )
+        }
+        EmulatorControl.Unlock ->
+          client.callTool(
+            "wakeAndUnlock",
+            buildJsonObject {
+              put("platform", wire)
+              put("deviceId", deviceId)
+            },
+          )
+        // Handled UI-side via the observation stream, not as a fire-and-forget device call.
+        EmulatorControl.Screenshot -> Unit
+      }
+    }
+  }
+}
+
+/** Records requests for tests; optionally throws to exercise the ViewModel's failure handling. */
+class FakeEmulatorControlExecutor : EmulatorControlExecutor {
+  data class Request(
+    val deviceId: String,
+    val platform: Platform,
+    val control: EmulatorControl,
+    val orientation: Orientation,
+  )
+
+  val requests: MutableList<Request> = mutableListOf()
+  var error: Throwable? = null
+
+  override suspend fun run(
+    deviceId: String,
+    platform: Platform,
+    control: EmulatorControl,
+    orientation: Orientation,
+  ) {
+    error?.let { throw it }
+    requests += Request(deviceId, platform, control, orientation)
+  }
+}

--- a/android/desktop-core/src/main/kotlin/dev/jasonpearson/automobile/desktop/core/workspace/ScreenshotSaver.kt
+++ b/android/desktop-core/src/main/kotlin/dev/jasonpearson/automobile/desktop/core/workspace/ScreenshotSaver.kt
@@ -1,0 +1,37 @@
+package dev.jasonpearson.automobile.desktop.core.workspace
+
+import java.io.File
+
+/**
+ * Writes a captured device-screen PNG to disk for the Screenshot control (#4694 AC3). The pane
+ * already shows the device live (the workspace stream mirror), so Screenshot is a capture-to-file,
+ * not an on-screen preview: it persists the current frame and reports where it landed.
+ *
+ * A `fun interface` so a test can supply a lambda that records the bytes without touching the disk;
+ * the real implementation is [RealScreenshotSaver].
+ */
+fun interface ScreenshotSaver {
+  /** Persist [pngBytes] captured from [deviceName]'s screen; returns the saved file's path. */
+  fun save(deviceName: String, pngBytes: ByteArray): String
+}
+
+/**
+ * Saves screenshots as `<sanitized-device-name>-<timestamp>.png` under [directory] (by default
+ * `~/.auto-mobile/screenshots`). [clock] is injectable so the filename is deterministic in tests.
+ */
+class RealScreenshotSaver(
+  private val directory: File = File(System.getProperty("user.home"), ".auto-mobile/screenshots"),
+  private val clock: () -> Long = System::currentTimeMillis,
+) : ScreenshotSaver {
+  override fun save(deviceName: String, pngBytes: ByteArray): String {
+    directory.mkdirs()
+    val safeName = deviceName.replace(UNSAFE_FILENAME_CHARS, "_").ifBlank { "device" }
+    val file = File(directory, "$safeName-${clock()}.png")
+    file.writeBytes(pngBytes)
+    return file.absolutePath
+  }
+
+  private companion object {
+    val UNSAFE_FILENAME_CHARS = Regex("[^A-Za-z0-9._-]")
+  }
+}

--- a/android/desktop-core/src/main/kotlin/dev/jasonpearson/automobile/desktop/core/workspace/WorkspaceModels.kt
+++ b/android/desktop-core/src/main/kotlin/dev/jasonpearson/automobile/desktop/core/workspace/WorkspaceModels.kt
@@ -6,10 +6,27 @@ enum class Platform(val emoji: String) {
   Ios("🍎"), // 🍎
 }
 
+/** The `platform` string the daemon/MCP tools expect ("android"/"ios"). */
+fun Platform.wireName(): String = if (this == Platform.Ios) "ios" else "android"
+
 /** Per-column interaction mode. The header toggle flips between the two (forgiving both ways). */
 enum class InteractionMode {
   Input,
   Inspect,
+}
+
+/**
+ * Per-column device orientation. The workspace tracks this because the `rotate` MCP tool requires
+ * an explicit target orientation (∈ {portrait, landscape}) rather than a relative "rotate" verb;
+ * the Rotate control toggles this and passes the new value. [toolValue] is the exact string the
+ * tool expects.
+ */
+enum class Orientation(val toolValue: String) {
+  Portrait("portrait"),
+  Landscape("landscape");
+
+  /** The other orientation — what a single Rotate tap flips to. */
+  fun toggled(): Orientation = if (this == Portrait) Landscape else Portrait
 }
 
 /**
@@ -60,4 +77,6 @@ data class DeviceColumn(
   val activeTool: Tool? = null,
   val shrunk: Boolean = false,
   val locked: Boolean = false,
+  /** Current orientation; the Rotate control toggles it and drives the `rotate` tool value. */
+  val orientation: Orientation = Orientation.Portrait,
 )

--- a/android/desktop-core/src/main/kotlin/dev/jasonpearson/automobile/desktop/core/workspace/WorkspaceShell.kt
+++ b/android/desktop-core/src/main/kotlin/dev/jasonpearson/automobile/desktop/core/workspace/WorkspaceShell.kt
@@ -36,22 +36,39 @@ import androidx.compose.ui.semantics.semantics
 import androidx.compose.ui.text.font.FontWeight
 import androidx.compose.ui.text.style.TextOverflow
 import androidx.compose.ui.unit.dp
+import dev.jasonpearson.automobile.desktop.core.daemon.ObservationStream
+import dev.jasonpearson.automobile.desktop.core.daemon.ObservationStreamClient
 import dev.jasonpearson.automobile.desktop.core.datasource.DataSourceMode
 import dev.jasonpearson.automobile.desktop.core.diagnostics.DiagnosticsDashboard
+import dev.jasonpearson.automobile.desktop.core.logging.LoggerFactory
 import dev.jasonpearson.automobile.desktop.core.mcp.McpConnectionType
 import dev.jasonpearson.automobile.desktop.core.mcp.McpProcess
 import dev.jasonpearson.automobile.desktop.core.mcp.RealMcpProcessDetector
+import java.util.Base64
+import kotlinx.coroutines.CancellationException
 import kotlinx.coroutines.Dispatchers
+import kotlinx.coroutines.NonCancellable
 import kotlinx.coroutines.delay
+import kotlinx.coroutines.flow.first
 import kotlinx.coroutines.withContext
+import kotlinx.coroutines.withTimeoutOrNull
 
 private val StatusGreen = Color(0xFF40C057)
 private val StatusYellow = Color(0xFFF0C000)
 private val StatusRed = Color(0xFFFA5252)
 private val Accent = Color(0xFF4DABF7)
 
+private val LOG = LoggerFactory.getLogger("WorkspaceShell")
+
 // How often the open health sheet re-scans for the daemon process (read-only).
 private const val HEALTH_SHEET_REFRESH_MS = 5_000L
+
+// How long a Screenshot capture waits for the observation stream to deliver a frame before giving
+// up, so a gone/unresponsive device can't leave the capture coroutine hanging.
+private const val SCREENSHOT_CAPTURE_TIMEOUT_MS = 10_000L
+
+// How long the "saved to …" confirmation stays on the pane after a Screenshot capture.
+private const val SCREENSHOT_NOTICE_MS = 4_000L
 
 /**
  * Root of the device-tab workspace. Device identity lives in each column header (no top tab bar); a
@@ -81,6 +98,12 @@ fun WorkspaceShell(
   // and defaulting to the inert placeholder for the same reason — so composing the shell in a unit
   // test or preview never opens a relay socket. The host passes the real [DeviceStreamView].
   streamContent: @Composable (DeviceColumn) -> Unit = { WorkspaceStreamPlaceholder() },
+  // Per-device observation stream + saver used by the Screenshot control to capture a frame on
+  // demand and write it to disk (#4694 AC3). Hoisted (defaulting to the real per-device
+  // [ObservationStreamClient] / [RealScreenshotSaver]) so a test can drive the capture with a
+  // [dev.jasonpearson.automobile.desktop.core.daemon.FakeObservationStream] and a fake saver.
+  observationStreamFactory: (String) -> ObservationStream = { ObservationStreamClient() },
+  screenshotSaver: ScreenshotSaver = RealScreenshotSaver(),
   // Body of the health sheet opened by clicking the status dot. Hoisted like [facetContent] so the
   // host (or a test) can substitute content; defaults to the live [DiagnosticsDashboard].
   healthSheetContent: @Composable () -> Unit = { DefaultHealthSheetBody() },
@@ -139,6 +162,8 @@ fun WorkspaceShell(
                   facetContent = facetContent,
                   inspectContent = inspectContent,
                   streamContent = streamContent,
+                  observationStreamFactory = observationStreamFactory,
+                  screenshotSaver = screenshotSaver,
                   canDiff = canDiff,
                   modifier = Modifier.weight(1f).fillMaxHeight(),
                 )
@@ -523,6 +548,8 @@ private fun DeviceColumnView(
   facetContent: @Composable (DeviceColumn, Tool) -> Unit,
   inspectContent: @Composable (DeviceColumn) -> Unit,
   streamContent: @Composable (DeviceColumn) -> Unit,
+  observationStreamFactory: (String) -> ObservationStream,
+  screenshotSaver: ScreenshotSaver,
   canDiff: Boolean,
   modifier: Modifier,
 ) {
@@ -536,7 +563,15 @@ private fun DeviceColumnView(
     DeviceColumnHeader(column, onAction)
     val tool = column.activeTool
     if (tool == null) {
-      PaneMainContent(column, onAction, inspectContent, streamContent, Modifier.weight(1f))
+      PaneMainContent(
+        column,
+        onAction,
+        inspectContent,
+        streamContent,
+        observationStreamFactory,
+        screenshotSaver,
+        Modifier.weight(1f),
+      )
     } else {
       // With a tool active the pane splits main content + docked facet; ⤡ shrink flips the split so
       // the main content collapses to grow the facet.
@@ -546,6 +581,8 @@ private fun DeviceColumnView(
         onAction,
         inspectContent,
         streamContent,
+        observationStreamFactory,
+        screenshotSaver,
         Modifier.weight(1f - facetFraction),
       )
       DockedFacet(column, tool, onAction, facetContent, canDiff, Modifier.weight(facetFraction))
@@ -564,26 +601,91 @@ private fun PaneMainContent(
   onAction: (WorkspaceAction) -> Unit,
   inspectContent: @Composable (DeviceColumn) -> Unit,
   streamContent: @Composable (DeviceColumn) -> Unit,
+  observationStreamFactory: (String) -> ObservationStream,
+  screenshotSaver: ScreenshotSaver,
   modifier: Modifier,
 ) {
   if (column.mode == InteractionMode.Inspect) {
     Box(modifier.fillMaxWidth()) { inspectContent(column) }
   } else {
-    StreamArea(column, onAction, streamContent, modifier)
+    StreamArea(column, onAction, streamContent, observationStreamFactory, screenshotSaver, modifier)
   }
 }
 
 /**
- * The pane's device stream area: the hoisted [streamContent] body (the host's [DeviceStreamView],
- * or the placeholder default) with the emulator controls floating on it.
+ * The pane's device stream area: the hoisted [streamContent] body (the host's live
+ * [DeviceStreamView], or the placeholder default) with the emulator controls floating on it. The
+ * Screenshot control captures the current frame off the observation stream and writes it to disk
+ * via [screenshotSaver] — the pane already shows the device live, so Screenshot persists a still
+ * rather than previewing one (#4694 AC3) — then flashes a transient "saved to …" confirmation.
  */
 @Composable
 private fun StreamArea(
   column: DeviceColumn,
   onAction: (WorkspaceAction) -> Unit,
   streamContent: @Composable (DeviceColumn) -> Unit,
+  observationStreamFactory: (String) -> ObservationStream,
+  screenshotSaver: ScreenshotSaver,
   modifier: Modifier,
 ) {
+  // Result of the latest capture + a monotonically increasing request token. Keyed on deviceId so a
+  // pane reused for a different device (panes are keyed by id, so this is defensive) starts clean.
+  var savedNotice by remember(column.deviceId) { mutableStateOf<String?>(null) }
+  var captureRequest by remember(column.deviceId) { mutableStateOf(0) }
+
+  // Each Screenshot tap bumps captureRequest, re-running this effect: open a fresh per-device
+  // stream,
+  // ask for an observation, take the first screenshot frame the subscription delivers, write its
+  // PNG
+  // bytes to disk, and report where. Bounded by a timeout so a gone device can't hang the
+  // coroutine,
+  // and the stream is always disposed — including on cancellation when the pane closes or a newer
+  // tap
+  // supersedes it.
+  LaunchedEffect(column.deviceId, captureRequest) {
+    if (captureRequest == 0) return@LaunchedEffect
+    val stream = observationStreamFactory(column.deviceId)
+    try {
+      val base64 =
+        withContext(Dispatchers.IO) {
+          // Connect/subscribe are blocking socket writes — keep them off the UI thread.
+          stream.connect(column.deviceId)
+          stream.requestObservation(column.deviceId)
+          withTimeoutOrNull(SCREENSHOT_CAPTURE_TIMEOUT_MS) {
+            stream.screenshotUpdates.first { !it.screenshotBase64.isNullOrEmpty() }.screenshotBase64
+          }
+        }
+      savedNotice =
+        if (base64 != null) {
+          val path =
+            withContext(Dispatchers.IO) {
+              screenshotSaver.save(column.name, Base64.getDecoder().decode(base64))
+            }
+          "Saved $path"
+        } else {
+          LOG.warn("Screenshot capture timed out for ${column.deviceId}")
+          "Screenshot timed out"
+        }
+    } catch (cancellation: CancellationException) {
+      throw cancellation
+    } catch (error: Exception) {
+      LOG.warn("Screenshot save failed for ${column.deviceId}: ${error.message}", error)
+      savedNotice = "Screenshot failed"
+    } finally {
+      // NonCancellable so the socket is still closed when this coroutine is cancelled (pane close /
+      // superseded capture); IO so the unsubscribe write + close don't run on the UI thread.
+      withContext(NonCancellable + Dispatchers.IO) { stream.dispose() }
+    }
+  }
+
+  // Auto-dismiss the confirmation after a short while.
+  LaunchedEffect(savedNotice) {
+    if (savedNotice != null) {
+      delay(SCREENSHOT_NOTICE_MS)
+      savedNotice = null
+    }
+  }
+
   Box(
     modifier = modifier.fillMaxWidth().background(MaterialTheme.colorScheme.surfaceVariant),
     contentAlignment = Alignment.Center,
@@ -592,8 +694,25 @@ private fun StreamArea(
     EmulatorControls(
       column = column,
       onAction = onAction,
+      onCaptureScreenshot = { captureRequest++ },
       modifier = Modifier.align(Alignment.TopCenter).padding(6.dp),
     )
+    val notice = savedNotice
+    if (notice != null) {
+      Text(
+        notice,
+        style = MaterialTheme.typography.labelSmall,
+        color = MaterialTheme.colorScheme.onSurface,
+        maxLines = 1,
+        overflow = TextOverflow.Ellipsis,
+        modifier =
+          Modifier.align(Alignment.BottomCenter)
+            .padding(6.dp)
+            .background(MaterialTheme.colorScheme.surface, RoundedCornerShape(4.dp))
+            .padding(horizontal = 6.dp, vertical = 3.dp)
+            .semantics { contentDescription = "Screenshot status ${column.name}" },
+      )
+    }
   }
 }
 
@@ -674,18 +793,20 @@ fun WorkspaceStreamPlaceholder() {
 
 /**
  * Emulator controls floating on a device stream: rotate · screenshot · snapshot, plus a contextual
- * 🔓 Unlock shown only when the device is locked. Each is a one-shot [WorkspaceAction.RunControl].
+ * 🔓 Unlock shown only when the device is locked (fed by the host's lock-state poll, #4694 AC0).
+ * Rotate/Snapshot/Unlock are one-shot [WorkspaceAction.RunControl] device calls; Screenshot instead
+ * triggers [onCaptureScreenshot], because it captures the current frame to disk (surfaced in the
+ * pane as a confirmation) rather than being a fire-and-forget device mutation.
  */
 @Composable
 private fun EmulatorControls(
   column: DeviceColumn,
   onAction: (WorkspaceAction) -> Unit,
+  onCaptureScreenshot: () -> Unit,
   modifier: Modifier,
 ) {
   Row(modifier, horizontalArrangement = Arrangement.spacedBy(4.dp)) {
-    // Unlock is gated on the pane's lock state; rotate/screenshot/snapshot always show. Production
-    // does not yet feed DeviceColumn.locked (that needs device-state plumbing), so Unlock only
-    // becomes reachable once #4694 wires the observed lock state in.
+    // Unlock is gated on the pane's lock state; rotate/screenshot/snapshot always show.
     EmulatorControl.entries
       .filter { it != EmulatorControl.Unlock || column.locked }
       .forEach { control ->
@@ -693,7 +814,13 @@ private fun EmulatorControls(
           text = control.icon,
           description = "${control.label} ${column.name}",
           active = false,
-          onClick = { onAction(WorkspaceAction.RunControl(column.deviceId, control)) },
+          onClick = {
+            if (control == EmulatorControl.Screenshot) {
+              onCaptureScreenshot()
+            } else {
+              onAction(WorkspaceAction.RunControl(column.deviceId, control))
+            }
+          },
         )
       }
   }

--- a/android/desktop-core/src/main/kotlin/dev/jasonpearson/automobile/desktop/core/workspace/WorkspaceViewModel.kt
+++ b/android/desktop-core/src/main/kotlin/dev/jasonpearson/automobile/desktop/core/workspace/WorkspaceViewModel.kt
@@ -1,6 +1,7 @@
 package dev.jasonpearson.automobile.desktop.core.workspace
 
 import dev.jasonpearson.automobile.desktop.core.logging.LoggerFactory
+import kotlinx.coroutines.CancellationException
 import kotlinx.coroutines.CoroutineScope
 import kotlinx.coroutines.channels.Channel
 import kotlinx.coroutines.flow.MutableStateFlow
@@ -40,6 +41,13 @@ sealed interface WorkspaceAction {
   /** Run an emulator control against a device pane (rotate, screenshot, snapshot, unlock). */
   data class RunControl(val deviceId: String, val control: EmulatorControl) : WorkspaceAction
 
+  /**
+   * Update panes' lock state from an observed snapshot (deviceId -> locked). A device absent from
+   * [locked] keeps its current state, so a transient empty read never spuriously unlocks a pane.
+   * Fed by the host's periodic lock-state poll; gates the contextual Unlock control.
+   */
+  data class SetLockStates(val locked: Map<String, Boolean>) : WorkspaceAction
+
   /** Open [tool] on every observed pane for like-for-like comparison (the facet ⧉ Diff control). */
   data class DiffTool(val tool: Tool) : WorkspaceAction
 }
@@ -48,24 +56,21 @@ sealed interface WorkspaceAction {
 sealed interface WorkspaceEffect {
   /** Open the device picker. Wired to a real screen in a later PR. */
   data object OpenPicker : WorkspaceEffect
-
-  /**
-   * Run an emulator [control] against the device. Carries the resolved [platform] so the host can
-   * dispatch the right device call without re-reading workspace state.
-   */
-  data class RunControl(
-    val deviceId: String,
-    val platform: Platform,
-    val control: EmulatorControl,
-  ) : WorkspaceEffect
 }
 
 /**
  * ViewModel for the device-tab workspace. Owns the set of observed device columns and which one is
  * focused, independent of Compose. Mirrors the repo's sealed [WorkspaceUiState]/[WorkspaceAction]/
  * [WorkspaceEffect] + [StateFlow]/[Channel] convention (cf. `NavigationViewModel`).
+ *
+ * [controlExecutor] runs emulator controls against the real device — injected like the picker's
+ * `McpResourceClient`, so behavior is pinned here with a fake while the real socket call stays
+ * untested (#4694).
  */
-class WorkspaceViewModel(private val scope: CoroutineScope) {
+class WorkspaceViewModel(
+  private val scope: CoroutineScope,
+  private val controlExecutor: EmulatorControlExecutor = NoOpEmulatorControlExecutor,
+) {
   private val _state = MutableStateFlow<WorkspaceUiState>(WorkspaceUiState.Empty)
   val state: StateFlow<WorkspaceUiState> = _state.asStateFlow()
 
@@ -81,7 +86,23 @@ class WorkspaceViewModel(private val scope: CoroutineScope) {
       is WorkspaceAction.ToggleShrink -> mutate(action.deviceId) { it.copy(shrunk = !it.shrunk) }
       is WorkspaceAction.SelectTool -> mutate(action.deviceId) { it.copy(activeTool = action.tool) }
       is WorkspaceAction.RunControl -> runControl(action.deviceId, action.control)
+      is WorkspaceAction.SetLockStates -> setLockStates(action.locked)
       is WorkspaceAction.DiffTool -> diffTool(action.tool)
+    }
+  }
+
+  /** Reflect an observed lock-state snapshot onto the columns; absent devices keep their state. */
+  private fun setLockStates(locked: Map<String, Boolean>) {
+    if (locked.isEmpty()) return
+    _state.update { current ->
+      val content = current as? WorkspaceUiState.Content ?: return@update current
+      content.copy(
+        columns =
+          content.columns.map { column ->
+            val next = locked[column.deviceId] ?: return@map column
+            if (next == column.locked) column else column.copy(locked = next)
+          }
+      )
     }
   }
 
@@ -125,11 +146,30 @@ class WorkspaceViewModel(private val scope: CoroutineScope) {
     }
   }
 
-  /** Emit a [WorkspaceEffect.RunControl] for the targeted column; unknown ids are a no-op. */
+  /**
+   * Run an emulator [control] against the targeted column off the UI thread; unknown ids are a
+   * no-op. Rotate first toggles the tracked per-column orientation and drives the tool with the new
+   * value. Failures are logged, not swallowed — a device call that throws must not crash the
+   * workspace or leave the effect path wedged (repo error-handling convention: log-and-continue for
+   * best-effort UI actions).
+   */
   private fun runControl(deviceId: String, control: EmulatorControl) {
     val content = _state.value as? WorkspaceUiState.Content ?: return
     val column = content.columns.firstOrNull { it.deviceId == deviceId } ?: return
-    scope.launch { _effect.send(WorkspaceEffect.RunControl(deviceId, column.platform, control)) }
+    val orientation =
+      if (control == EmulatorControl.Rotate) column.orientation.toggled() else column.orientation
+    if (control == EmulatorControl.Rotate) {
+      mutate(deviceId) { it.copy(orientation = orientation) }
+    }
+    scope.launch {
+      try {
+        controlExecutor.run(deviceId, column.platform, control, orientation)
+      } catch (cancellation: CancellationException) {
+        throw cancellation
+      } catch (error: Exception) {
+        LOG.warn("Emulator control $control failed for $deviceId: ${error.message}", error)
+      }
+    }
   }
 
   private fun focus(deviceId: String) {

--- a/android/desktop-core/src/main/kotlin/dev/jasonpearson/automobile/desktop/core/workspace/picker/DeviceBootController.kt
+++ b/android/desktop-core/src/main/kotlin/dev/jasonpearson/automobile/desktop/core/workspace/picker/DeviceBootController.kt
@@ -2,7 +2,7 @@ package dev.jasonpearson.automobile.desktop.core.workspace.picker
 
 import dev.jasonpearson.automobile.desktop.core.daemon.AutoMobileClient
 import dev.jasonpearson.automobile.desktop.core.logging.LoggerFactory
-import dev.jasonpearson.automobile.desktop.core.workspace.Platform
+import dev.jasonpearson.automobile.desktop.core.workspace.wireName
 import kotlinx.coroutines.CancellationException
 import kotlinx.coroutines.CompletableDeferred
 import kotlinx.coroutines.CoroutineDispatcher
@@ -25,8 +25,6 @@ interface DeviceBootController {
 }
 
 private val LOG = LoggerFactory.getLogger("DeviceBootController")
-
-private fun Platform.wireName(): String = if (this == Platform.Ios) "ios" else "android"
 
 /**
  * Real boot controller backed by the daemon [AutoMobileClient]. The picker's device id is the AVD

--- a/android/desktop-core/src/main/kotlin/dev/jasonpearson/automobile/desktop/core/workspace/picker/DevicePickerViewModel.kt
+++ b/android/desktop-core/src/main/kotlin/dev/jasonpearson/automobile/desktop/core/workspace/picker/DevicePickerViewModel.kt
@@ -343,7 +343,10 @@ class DevicePickerViewModel(
     val columns =
       content.devices
         .filter { it.id in selectedIds && it.state == DeviceState.Booted }
-        .map { DeviceColumn(deviceId = it.id, name = it.name, platform = it.platform) }
+        .map {
+          // Seed the pane's lock state from the booted snapshot; the host's poll keeps it fresh.
+          DeviceColumn(deviceId = it.id, name = it.name, platform = it.platform, locked = it.locked)
+        }
     if (columns.isNotEmpty()) {
       scope.launch { _effect.send(DevicePickerEffect.Observe(columns)) }
     }

--- a/android/desktop-core/src/main/kotlin/dev/jasonpearson/automobile/desktop/core/workspace/picker/PickerModels.kt
+++ b/android/desktop-core/src/main/kotlin/dev/jasonpearson/automobile/desktop/core/workspace/picker/PickerModels.kt
@@ -28,6 +28,8 @@ data class PickerDevice(
   val osLabel: String? = null,
   /** CPU architecture ("arm64"/"x86_64"); only iOS images currently carry it. */
   val architecture: String? = null,
+  /** Whether the booted device's keyguard is up (from the booted resource). Shutdown -> false. */
+  val locked: Boolean = false,
 )
 
 private val ANDROID_TARGET = Regex("android-(\\d+)")
@@ -91,6 +93,8 @@ fun buildPickerDevices(
       osKey = api,
       osLabel = api?.let { "API $it" },
       architecture = null,
+      // Seed value only; an unknown (null) lock state seeds unlocked and the host poll refines it.
+      locked = device.locked == true,
     )
   }
 

--- a/android/desktop-core/src/test/kotlin/dev/jasonpearson/automobile/desktop/core/workspace/DaemonEmulatorControlExecutorTest.kt
+++ b/android/desktop-core/src/test/kotlin/dev/jasonpearson/automobile/desktop/core/workspace/DaemonEmulatorControlExecutorTest.kt
@@ -1,0 +1,103 @@
+package dev.jasonpearson.automobile.desktop.core.workspace
+
+import dev.jasonpearson.automobile.desktop.core.testing.FakeAutoMobileClient
+import kotlinx.coroutines.ExperimentalCoroutinesApi
+import kotlinx.coroutines.test.UnconfinedTestDispatcher
+import kotlinx.coroutines.test.runTest
+import kotlinx.serialization.json.buildJsonObject
+import kotlinx.serialization.json.put
+import org.junit.Assert.assertEquals
+import org.junit.Assert.assertTrue
+import org.junit.Test
+
+/**
+ * Pins the [DaemonEmulatorControlExecutor]'s tool-argument construction (the correctness-critical
+ * part of the otherwise-untested IO seam) against a [FakeAutoMobileClient]. The real socket
+ * transport stays untested, consistent with `DaemonMcpResourceClient`.
+ */
+@OptIn(ExperimentalCoroutinesApi::class)
+class DaemonEmulatorControlExecutorTest {
+
+  private fun executor(client: FakeAutoMobileClient) =
+    DaemonEmulatorControlExecutor(client, UnconfinedTestDispatcher())
+
+  @Test
+  fun `rotate sets the active device then calls rotate with the target orientation`() = runTest {
+    val client = FakeAutoMobileClient()
+    executor(client)
+      .run("emulator-5554", Platform.Android, EmulatorControl.Rotate, Orientation.Landscape)
+
+    // Active device is set before any tool call.
+    assertEquals("setActiveDevice", client.calls.first())
+    assertTrue(
+      "rotate needs the advanced-interaction capability",
+      client.toolCalls.any {
+        it.name == "setToolCapability" &&
+          it.arguments ==
+            buildJsonObject {
+              put("capability", "advanced-interaction")
+              put("enabled", true)
+            }
+      },
+    )
+    assertTrue(
+      client.toolCalls.any {
+        it.name == "rotate" &&
+          it.arguments ==
+            buildJsonObject {
+              put("orientation", "landscape")
+              put("platform", "android")
+              put("deviceId", "emulator-5554")
+            }
+      }
+    )
+  }
+
+  @Test
+  fun `snapshot enables screen-artifacts and captures on the target device`() = runTest {
+    val client = FakeAutoMobileClient()
+    executor(client)
+      .run("emulator-5554", Platform.Android, EmulatorControl.Snapshot, Orientation.Portrait)
+
+    assertEquals("setActiveDevice", client.calls.first())
+    assertTrue(
+      client.toolCalls.any {
+        it.name == "setToolCapability" &&
+          it.arguments ==
+            buildJsonObject {
+              put("capability", "screen-artifacts")
+              put("enabled", true)
+            }
+      }
+    )
+    assertTrue(
+      client.toolCalls.any {
+        it.name == "deviceSnapshot" &&
+          it.arguments ==
+            buildJsonObject {
+              put("action", "capture")
+              put("platform", "android")
+              put("deviceId", "emulator-5554")
+            }
+      }
+    )
+  }
+
+  @Test
+  fun `unlock calls wakeAndUnlock with the ios platform`() = runTest {
+    val client = FakeAutoMobileClient()
+    executor(client).run("booted-ipad", Platform.Ios, EmulatorControl.Unlock, Orientation.Portrait)
+
+    assertEquals("setActiveDevice", client.calls.first())
+    assertTrue(
+      client.toolCalls.any {
+        it.name == "wakeAndUnlock" &&
+          it.arguments ==
+            buildJsonObject {
+              put("platform", "ios")
+              put("deviceId", "booted-ipad")
+            }
+      }
+    )
+  }
+}

--- a/android/desktop-core/src/test/kotlin/dev/jasonpearson/automobile/desktop/core/workspace/DeviceLockStatePollTest.kt
+++ b/android/desktop-core/src/test/kotlin/dev/jasonpearson/automobile/desktop/core/workspace/DeviceLockStatePollTest.kt
@@ -1,0 +1,44 @@
+package dev.jasonpearson.automobile.desktop.core.workspace
+
+import org.junit.Assert.assertEquals
+import org.junit.Assert.assertTrue
+import org.junit.Test
+
+class DeviceLockStatePollTest {
+
+  @Test
+  fun `maps devices with a known lock state and omits those whose locked was not read`() {
+    // Device 1 reports locked; device 2 (locked field absent) is a state the daemon could not read
+    // and must be OMITTED, not coerced to false — otherwise a transient probe gap force-unlocks it.
+    val payload =
+      """
+      {"totalCount":2,"androidCount":2,"iosCount":0,"virtualCount":2,"physicalCount":0,
+       "lastUpdated":"x","devices":[
+         {"name":"Pixel 8","platform":"android","deviceId":"emulator-5554",
+          "source":"local","isVirtual":true,"status":"booted","locked":true},
+         {"name":"Pixel 7","platform":"android","deviceId":"emulator-5556",
+          "source":"local","isVirtual":true,"status":"booted"}]}
+      """
+        .trimIndent()
+    assertEquals(mapOf("emulator-5554" to true), parseDeviceLockStates(payload))
+  }
+
+  @Test
+  fun `maps an explicit locked false so a known-unlocked device unlocks its pane`() {
+    val payload =
+      """
+      {"totalCount":1,"androidCount":1,"iosCount":0,"virtualCount":1,"physicalCount":0,
+       "lastUpdated":"x","devices":[
+         {"name":"Pixel 8","platform":"android","deviceId":"emulator-5554",
+          "source":"local","isVirtual":true,"status":"booted","locked":false}]}
+      """
+        .trimIndent()
+    assertEquals(mapOf("emulator-5554" to false), parseDeviceLockStates(payload))
+  }
+
+  @Test
+  fun `malformed payload yields an empty map so the poll is a no-op`() {
+    assertTrue(parseDeviceLockStates("not json").isEmpty())
+    assertTrue(parseDeviceLockStates("").isEmpty())
+  }
+}

--- a/android/desktop-core/src/test/kotlin/dev/jasonpearson/automobile/desktop/core/workspace/WorkspaceShellUiTest.kt
+++ b/android/desktop-core/src/test/kotlin/dev/jasonpearson/automobile/desktop/core/workspace/WorkspaceShellUiTest.kt
@@ -9,6 +9,9 @@ import androidx.compose.ui.test.onNodeWithContentDescription
 import androidx.compose.ui.test.onNodeWithText
 import androidx.compose.ui.test.performClick
 import androidx.compose.ui.test.runComposeUiTest
+import dev.jasonpearson.automobile.desktop.core.daemon.FakeObservationStream
+import dev.jasonpearson.automobile.desktop.core.daemon.ScreenshotStreamUpdate
+import java.util.Base64
 import org.junit.Assert.assertEquals
 import org.junit.Assert.assertTrue
 import org.junit.Test
@@ -130,16 +133,63 @@ class WorkspaceShellUiTest {
   }
 
   @Test
-  fun `clicking a control dispatches RunControl for that column`() = runComposeUiTest {
-    var action: WorkspaceAction? = null
-    val state =
-      WorkspaceUiState.Content(columns = listOf(col("a", "Pixel 8")), focusedDeviceId = "a")
-    setContent {
-      MaterialTheme { WorkspaceShell(state = state, onAction = { action = it }, onOpenPicker = {}) }
+  fun `clicking a device-mutating control dispatches RunControl for that column`() =
+    runComposeUiTest {
+      var action: WorkspaceAction? = null
+      val state =
+        WorkspaceUiState.Content(columns = listOf(col("a", "Pixel 8")), focusedDeviceId = "a")
+      setContent {
+        MaterialTheme {
+          WorkspaceShell(state = state, onAction = { action = it }, onOpenPicker = {})
+        }
+      }
+      onNodeWithContentDescription("Snapshot Pixel 8").performClick()
+      assertEquals(WorkspaceAction.RunControl("a", EmulatorControl.Snapshot), action)
     }
-    onNodeWithContentDescription("Screenshot Pixel 8").performClick()
-    assertEquals(WorkspaceAction.RunControl("a", EmulatorControl.Screenshot), action)
-  }
+
+  @Test
+  fun `clicking Screenshot captures a frame, saves it, and confirms in the pane`() =
+    runComposeUiTest {
+      val onePxPng =
+        "iVBORw0KGgoAAAANSUhEUgAAAAEAAAABCAQAAAC1HAwCAAAAC0lEQVR42mNkYPhfDwAChwGA60e6kgAAAABJRU5ErkJggg=="
+      val fake = FakeObservationStream()
+      var savedDeviceName: String? = null
+      var savedBytes: ByteArray? = null
+      var dispatched: WorkspaceAction? = null
+      val state =
+        WorkspaceUiState.Content(columns = listOf(col("a", "Pixel 8")), focusedDeviceId = "a")
+      setContent {
+        MaterialTheme {
+          WorkspaceShell(
+            state = state,
+            onAction = { dispatched = it },
+            onOpenPicker = {},
+            observationStreamFactory = { fake },
+            screenshotSaver =
+              ScreenshotSaver { name, bytes ->
+                savedDeviceName = name
+                savedBytes = bytes
+                "/tmp/shots/$name.png"
+              },
+          )
+        }
+      }
+
+      onNodeWithContentDescription("Screenshot Pixel 8").performClick()
+
+      // Screenshot is NOT a RunControl device mutation — it requests an observation on the stream.
+      waitUntil(timeoutMillis = 5_000L) { fake.observationRequestCount == 1 }
+      assertEquals(null, dispatched)
+      assertEquals("a", fake.lastConnectedDeviceId)
+      assertEquals("a", fake.lastObservationDeviceId)
+
+      // The returned frame's PNG bytes are written via the saver, and the pane confirms where.
+      fake.emitScreenshot(ScreenshotStreamUpdate("a", 0L, onePxPng, 1, 1))
+      waitUntil(timeoutMillis = 5_000L) { savedBytes != null }
+      assertEquals("Pixel 8", savedDeviceName)
+      assertEquals(Base64.getDecoder().decode(onePxPng).toList(), savedBytes!!.toList())
+      onNodeWithContentDescription("Screenshot status Pixel 8").assertIsDisplayed()
+    }
 
   @Test
   fun `active tool renders a docked facet with a close control`() = runComposeUiTest {

--- a/android/desktop-core/src/test/kotlin/dev/jasonpearson/automobile/desktop/core/workspace/WorkspaceViewModelTest.kt
+++ b/android/desktop-core/src/test/kotlin/dev/jasonpearson/automobile/desktop/core/workspace/WorkspaceViewModelTest.kt
@@ -1,6 +1,5 @@
 package dev.jasonpearson.automobile.desktop.core.workspace
 
-import app.cash.turbine.test
 import kotlinx.coroutines.ExperimentalCoroutinesApi
 import kotlinx.coroutines.test.TestScope
 import kotlinx.coroutines.test.UnconfinedTestDispatcher
@@ -109,20 +108,54 @@ class WorkspaceViewModelTest {
   }
 
   @Test
-  fun `RunControl emits an effect carrying the target device platform`() = testScope.runTest {
-    val vm = WorkspaceViewModel(this)
-    vm.onAction(WorkspaceAction.ObserveDevice(column("a", Platform.Ios)))
-    vm.effect.test {
-      vm.onAction(WorkspaceAction.RunControl("a", EmulatorControl.Rotate))
-      val effect = awaitItem()
-      assertTrue("Expected RunControl but was $effect", effect is WorkspaceEffect.RunControl)
-      effect as WorkspaceEffect.RunControl
-      assertEquals("a", effect.deviceId)
-      assertEquals(Platform.Ios, effect.platform)
-      assertEquals(EmulatorControl.Rotate, effect.control)
-      cancelAndIgnoreRemainingEvents()
+  fun `RunControl runs the control against the targeted device with its platform`() =
+    testScope.runTest {
+      val exec = FakeEmulatorControlExecutor()
+      val vm = WorkspaceViewModel(this, exec)
+      vm.onAction(WorkspaceAction.ObserveDevice(column("a", Platform.Ios)))
+      vm.onAction(WorkspaceAction.RunControl("a", EmulatorControl.Snapshot))
+      assertEquals(
+        listOf(
+          FakeEmulatorControlExecutor.Request(
+            "a",
+            Platform.Ios,
+            EmulatorControl.Snapshot,
+            Orientation.Portrait,
+          )
+        ),
+        exec.requests,
+      )
     }
-  }
+
+  @Test
+  fun `RunControl Rotate toggles the tracked orientation and passes the new value`() =
+    testScope.runTest {
+      val exec = FakeEmulatorControlExecutor()
+      val vm = WorkspaceViewModel(this, exec)
+      vm.onAction(WorkspaceAction.ObserveDevice(column("a")))
+
+      vm.onAction(WorkspaceAction.RunControl("a", EmulatorControl.Rotate))
+      var col = (vm.state.value as WorkspaceUiState.Content).columns.first { it.deviceId == "a" }
+      assertEquals(Orientation.Landscape, col.orientation)
+      assertEquals(Orientation.Landscape, exec.requests.last().orientation)
+
+      // A second Rotate flips back to Portrait — and passes that new value on.
+      vm.onAction(WorkspaceAction.RunControl("a", EmulatorControl.Rotate))
+      col = (vm.state.value as WorkspaceUiState.Content).columns.first { it.deviceId == "a" }
+      assertEquals(Orientation.Portrait, col.orientation)
+      assertEquals(Orientation.Portrait, exec.requests.last().orientation)
+    }
+
+  @Test
+  fun `RunControl swallows an executor failure without crashing the workspace`() =
+    testScope.runTest {
+      val exec = FakeEmulatorControlExecutor().apply { error = RuntimeException("boom") }
+      val vm = WorkspaceViewModel(this, exec)
+      vm.onAction(WorkspaceAction.ObserveDevice(column("a")))
+      vm.onAction(WorkspaceAction.RunControl("a", EmulatorControl.Unlock))
+      // The failure is caught + logged, not propagated: state stays intact.
+      assertTrue(vm.state.value is WorkspaceUiState.Content)
+    }
 
   @Test
   fun `DiffTool opens the tool on every observed column`() = testScope.runTest {
@@ -139,13 +172,37 @@ class WorkspaceViewModelTest {
   }
 
   @Test
-  fun `RunControl for an unknown device emits nothing`() = testScope.runTest {
-    val vm = WorkspaceViewModel(this)
+  fun `RunControl for an unknown device runs nothing`() = testScope.runTest {
+    val exec = FakeEmulatorControlExecutor()
+    val vm = WorkspaceViewModel(this, exec)
     vm.onAction(WorkspaceAction.ObserveDevice(column("a")))
-    vm.effect.test {
-      vm.onAction(WorkspaceAction.RunControl("nope", EmulatorControl.Screenshot))
-      expectNoEvents()
-      cancelAndIgnoreRemainingEvents()
-    }
+    vm.onAction(WorkspaceAction.RunControl("nope", EmulatorControl.Snapshot))
+    assertTrue(exec.requests.isEmpty())
   }
+
+  @Test
+  fun `SetLockStates updates matched columns and leaves absent devices unchanged`() =
+    testScope.runTest {
+      val vm = WorkspaceViewModel(this)
+      vm.onAction(WorkspaceAction.ObserveDevice(column("a")))
+      vm.onAction(WorkspaceAction.ObserveDevice(column("b")))
+
+      // "a" is reported locked; "b" is absent from the snapshot and must keep its current state.
+      vm.onAction(WorkspaceAction.SetLockStates(mapOf("a" to true)))
+      var state = vm.state.value as WorkspaceUiState.Content
+      assertTrue("a should be locked", state.columns.first { it.deviceId == "a" }.locked)
+      assertTrue("b should stay unlocked", !state.columns.first { it.deviceId == "b" }.locked)
+
+      // A later snapshot flips both — an explicit false unlocks, an explicit true locks.
+      vm.onAction(WorkspaceAction.SetLockStates(mapOf("a" to false, "b" to true)))
+      state = vm.state.value as WorkspaceUiState.Content
+      assertTrue("a should unlock", !state.columns.first { it.deviceId == "a" }.locked)
+      assertTrue("b should lock", state.columns.first { it.deviceId == "b" }.locked)
+
+      // An empty snapshot (e.g. a transient read gap) leaves every column unchanged.
+      vm.onAction(WorkspaceAction.SetLockStates(emptyMap()))
+      state = vm.state.value as WorkspaceUiState.Content
+      assertTrue("a still unlocked", !state.columns.first { it.deviceId == "a" }.locked)
+      assertTrue("b still locked", state.columns.first { it.deviceId == "b" }.locked)
+    }
 }

--- a/android/desktop-core/src/test/kotlin/dev/jasonpearson/automobile/desktop/core/workspace/picker/DevicePickerViewModelTest.kt
+++ b/android/desktop-core/src/test/kotlin/dev/jasonpearson/automobile/desktop/core/workspace/picker/DevicePickerViewModelTest.kt
@@ -101,6 +101,31 @@ class DevicePickerViewModelTest {
   }
 
   @Test
+  fun `observe selected seeds the column lock state from the booted snapshot`() =
+    testScope.runTest {
+      val locked =
+        fake().apply {
+          bootedDevicesResponse =
+            """
+            {"totalCount":1,"androidCount":1,"iosCount":0,"virtualCount":1,"physicalCount":0,
+             "lastUpdated":"x","devices":[
+               {"name":"Pixel 8 API 35","platform":"android","deviceId":"emulator-5554",
+                "source":"local","isVirtual":true,"status":"booted","locked":true}]}
+            """
+              .trimIndent()
+        }
+      val vm =
+        DevicePickerViewModel(locked, FakeDeviceBootController(), this, UnconfinedTestDispatcher())
+      vm.effect.test {
+        vm.onAction(DevicePickerAction.ToggleSelect("emulator-5554"))
+        vm.onAction(DevicePickerAction.ObserveSelected)
+        val columns = (awaitItem() as DevicePickerEffect.Observe).columns
+        assertTrue("column should be seeded locked", columns.single().locked)
+        cancelAndIgnoreRemainingEvents()
+      }
+    }
+
+  @Test
   fun `clear filter resets that dimension`() = testScope.runTest {
     val vm =
       DevicePickerViewModel(fake(), FakeDeviceBootController(), this, UnconfinedTestDispatcher())

--- a/src/server/bootedDeviceResources.ts
+++ b/src/server/bootedDeviceResources.ts
@@ -10,6 +10,7 @@ import type {
   DeviceRecoveryEligibility,
   DeviceRecoveryPolicy,
 } from "../daemon/devicePool";
+import { defaultAdbClientFactory } from "../utils/android-cmdline-tools/AdbClientFactory";
 import { AndroidCtrlProxyManager } from "../utils/CtrlProxyManager";
 import { IOSCtrlProxyManager } from "../utils/IOSCtrlProxyManager";
 import { IOSCtrlProxyBuilder } from "../utils/IOSCtrlProxyBuilder";
@@ -56,6 +57,12 @@ interface BootedDeviceInfo {
   recoveryEligibility?: DeviceRecoveryEligibility;
   session?: DeviceSessionInfo;
   serviceStatus?: DeviceServiceStatus;
+  /**
+   * Whether the device's keyguard/lock screen currently obscures the app. Android only (from
+   * `dumpsys window policy`); omitted when unread or on iOS, where no lock-state probe exists yet.
+   * Consumed by the desktop workspace to gate the contextual Unlock control (issue #4694).
+   */
+  locked?: boolean;
 }
 
 // Resource content schema
@@ -112,6 +119,32 @@ export function setDeviceManager(manager: PlatformDeviceManager | null): void {
 // Controls whether service status is queried for each device.
 // Disabled automatically when a test device manager is injected.
 let serviceStatusEnabled = true;
+
+/** Probes a device's lock state; returns `undefined` when it can't be determined. */
+export type DeviceLockProbe = (device: BootedDevice) => Promise<boolean | undefined>;
+
+// Injected only by tests, which need a deterministic lock state without real adb. When null, the
+// real adb-backed probe runs — but only while `serviceStatusEnabled` (i.e. no fake manager), so a
+// test that injects a fake device manager never triggers a real `dumpsys` unless it opts in here.
+let injectedLockProbe: DeviceLockProbe | null = null;
+
+/** Inject a fake lock probe for tests (or null to restore the real adb-backed probe). */
+export function setDeviceLockProbe(probe: DeviceLockProbe | null): void {
+  injectedLockProbe = probe;
+}
+
+/**
+ * Real lock-state probe: reads the Android keyguard via `dumpsys window policy` (issue #4235). iOS
+ * has no lock-state probe yet, so it returns `undefined` (the field is then omitted). A failed read
+ * also yields `undefined` — lock state is advisory, never fatal to the resource.
+ */
+async function realDeviceLockProbe(device: BootedDevice): Promise<boolean | undefined> {
+  if (device.platform !== "android") {
+    return undefined;
+  }
+  const lock = await defaultAdbClientFactory.create(device).getDeviceLock();
+  return lock?.locked;
+}
 
 // Convert BootedDevice to BootedDeviceInfo
 function toBootedDeviceInfo(
@@ -376,6 +409,54 @@ async function getBootedDevicesForPlatforms(platforms: Platform[]): Promise<Boot
       const result = serviceStatusResults[i];
       if (result.status === "fulfilled" && result.value) {
         devices[i] = { ...devices[i], serviceStatus: result.value };
+      }
+    }
+  }
+
+  // Query per-device lock state so the desktop can gate its contextual Unlock control (#4694). Runs
+  // only with an injected probe (tests) or a real device manager (production), never against a fake
+  // manager's mock devices. Best-effort with a per-device timeout: a slow/failed read leaves `locked`
+  // unset rather than stalling the whole resource.
+  const lockProbe = injectedLockProbe ?? (serviceStatusEnabled ? realDeviceLockProbe : null);
+  if (lockProbe) {
+    const LOCK_STATE_TIMEOUT_MS = 3000;
+    const lockResults = await Promise.allSettled(
+      devices.map(async device => {
+        // The adb lock probe only needs the device identity; `source` (whose BootedDeviceInfo type
+        // is wider than BootedDevice's) is irrelevant, so omit it rather than force a cast.
+        const bootedDevice: BootedDevice = {
+          name: device.name,
+          platform: device.platform,
+          deviceId: device.deviceId,
+        };
+        // Clear the timeout when the probe wins so the losing timer never fires — otherwise, on the
+        // desktop's periodic poll, a fast successful probe still logs a spurious "timeout" every cycle.
+        let timeoutHandle: NodeJS.Timeout | undefined;
+        try {
+          return await Promise.race([
+            lockProbe(bootedDevice),
+            new Promise<undefined>(resolve => {
+              timeoutHandle = defaultTimer.setTimeout(() => {
+                logger.warn(`[BootedDeviceResources] Lock-state timeout for ${device.deviceId}`);
+                resolve(undefined);
+              }, LOCK_STATE_TIMEOUT_MS);
+            }),
+          ]);
+        } catch (error) {
+          logger.warn(`[BootedDeviceResources] Failed to query lock state for ${device.deviceId}: ${error}`);
+          return undefined;
+        } finally {
+          if (timeoutHandle) {
+            defaultTimer.clearTimeout(timeoutHandle);
+          }
+        }
+      })
+    );
+
+    for (let i = 0; i < devices.length; i++) {
+      const result = lockResults[i];
+      if (result.status === "fulfilled" && result.value !== undefined) {
+        devices[i] = { ...devices[i], locked: result.value };
       }
     }
   }

--- a/test/server/resources/bootedDevices.test.ts
+++ b/test/server/resources/bootedDevices.test.ts
@@ -3,7 +3,7 @@ import { McpTestFixture } from "../../fixtures/mcpTestFixture";
 import { ResourceRegistry } from "../../../src/server/resourceRegistry";
 import { FakeDeviceUtils } from "../../fakes/FakeDeviceUtils";
 import { FakeTimer } from "../../fakes/FakeTimer";
-import { setDeviceManager, BootedDevicesResourceContent } from "../../../src/server/bootedDeviceResources";
+import { setDeviceManager, setDeviceLockProbe, BootedDevicesResourceContent } from "../../../src/server/bootedDeviceResources";
 import { BootedDevice, Platform } from "../../../src/models";
 import { DaemonState } from "../../../src/daemon/daemonState";
 import { DevicePool } from "../../../src/daemon/devicePool";
@@ -58,6 +58,8 @@ describe("MCP Booted Device Resources", () => {
     if (DaemonState.getInstance().isInitialized()) {
       DaemonState.getInstance().reset();
     }
+    // Restore the real (adb-backed) lock probe so a test's fake never leaks into the next.
+    setDeviceLockProbe(null);
   });
 
   afterAll(async () => {
@@ -315,6 +317,63 @@ describe("MCP Booted Device Resources", () => {
       expect(device.source).toBe("local");
       expect(device.isVirtual).toBe(true);
       expect(device.poolStatus).toBeUndefined();
+    });
+
+    test("includes per-device lock state from the lock probe", async function() {
+      fakeDeviceUtils.setBootedDevices("android", [mockAndroidDevice1, mockAndroidDevice2]);
+      // Only the first device is locked; the probe reports the rest unlocked.
+      setDeviceLockProbe(async device => device.deviceId === mockAndroidDevice1.deviceId);
+
+      const { client } = fixture.getContext();
+
+      const readResourceResponseSchema = z.object({
+        contents: z.array(z.object({
+          uri: z.string(),
+          mimeType: z.string().optional(),
+          text: z.string().optional(),
+          blob: z.string().optional()
+        }))
+      });
+
+      const result = await client.request({
+        method: "resources/read",
+        params: {
+          uri: "automobile:devices/booted"
+        }
+      }, readResourceResponseSchema);
+
+      const data: BootedDevicesResourceContent = JSON.parse(result.contents[0].text!);
+      const locked = data.devices.find(device => device.deviceId === mockAndroidDevice1.deviceId);
+      const unlocked = data.devices.find(device => device.deviceId === mockAndroidDevice2.deviceId);
+      expect(locked?.locked).toBe(true);
+      expect(unlocked?.locked).toBe(false);
+    });
+
+    test("omits lock state for a device the probe cannot read", async function() {
+      fakeDeviceUtils.setBootedDevices("ios", [mockIosDevice1]);
+      // iOS (and any unreadable device) yields undefined — the field is then omitted entirely.
+      setDeviceLockProbe(async () => undefined);
+
+      const { client } = fixture.getContext();
+
+      const readResourceResponseSchema = z.object({
+        contents: z.array(z.object({
+          uri: z.string(),
+          mimeType: z.string().optional(),
+          text: z.string().optional(),
+          blob: z.string().optional()
+        }))
+      });
+
+      const result = await client.request({
+        method: "resources/read",
+        params: {
+          uri: "automobile:devices/booted"
+        }
+      }, readResourceResponseSchema);
+
+      const data: BootedDevicesResourceContent = JSON.parse(result.contents[0].text!);
+      expect(data.devices[0].locked).toBeUndefined();
     });
 
     test("should include pool status when daemon is initialized", async function() {


### PR DESCRIPTION
## Summary

The desktop workspace's emulator-control cluster (rotate · screenshot · snapshot + a contextual Unlock) shipped in [#4690](https://github.com/kaeawc/auto-mobile/pull/4690) as UI plus a `WorkspaceEffect.RunControl` intent that the host only **drained and logged**. This PR wires real execution against the targeted device.

- **Rotate / Snapshot / Unlock** run through a new `EmulatorControlExecutor` seam injected into `WorkspaceViewModel` — mirroring how the picker injects `McpResourceClient` into `DevicePickerViewModel`. The real impl sets the active device, then calls the matching MCP tool (`rotate`, `deviceSnapshot`, `wakeAndUnlock`) off the UI thread (enabling each tool's server capability). Failures are logged, not swallowed. The socket path is untested IO; behavior is pinned at the ViewModel boundary with `FakeEmulatorControlExecutor` (AC1, AC4).
- **Rotate** toggles a tracked per-column `DeviceColumn.orientation` (new, default portrait) and drives `rotate` with the new value (AC2).
- **Screenshot** has no one-shot MCP tool — capture is only an `observe` side effect — so it captures the current frame via the per-device `ObservationStream` (`requestObservation`) and writes the PNG to disk through an injectable `ScreenshotSaver`, flashing a transient "saved to …" confirmation on the pane (AC3). Rebased onto the live-device-mirror work that landed on main ([#4957](https://github.com/kaeawc/auto-mobile/pull/4957)): since the pane now shows the device live, Screenshot persists a still rather than previewing one.
- **Contextual Unlock** is now reachable in production: the booted-devices resource carries a per-device `locked` flag (Android keyguard via `dumpsys window policy`, reusing `AdbClient.getDeviceLock`; best-effort and omitted on iOS, which has no lock probe yet), the picker seeds `DeviceColumn.locked` in `observeSelected`, and a host poll refreshes each pane so Unlock renders as the device locks/unlocks (AC0).

### Acceptance criteria → test

| AC | Where | Pinned by |
|----|-------|-----------|
| AC0 lock feed | `bootedDeviceResources.ts` (`locked` + injectable probe), `PickerModels`, `DevicePickerViewModel.observeSelected`, host poll + `WorkspaceAction.SetLockStates` | `bootedDevices.test.ts` (locked/omitted), `DevicePickerViewModelTest` (seed), `WorkspaceViewModelTest` (SetLockStates), `DeviceLockStatePollTest` (parse) |
| AC1 snapshot+unlock exec | `EmulatorControlExecutor` + `WorkspaceViewModel.runControl` | `WorkspaceViewModelTest` (control→executor), `DaemonEmulatorControlExecutorTest` (tool args), failure-caught test |
| AC2 rotate orientation | `Orientation`, `DeviceColumn.orientation`, `runControl` | `WorkspaceViewModelTest` (toggle + new value) |
| AC3 screenshot capture→file | `WorkspaceShell` StreamArea + `ObservationStream` + `ScreenshotSaver` | `WorkspaceShellUiTest` (captures a frame, saves the PNG bytes, confirms) |
| AC4 IO seam consistency | executor real impl untested; fake pins VM boundary | the VM/UI tests above |

## Linked Issue

Closes #4694

## Validation

- [x] Android desktop: `:desktop-core:test` + `:desktop-app:compileKotlin` green; `ktfmt` clean
- [x] `bun run typecheck` reports no new errors (baseline gate)
- [x] `bun run lint` + `bun run build` green; `bun test test/server/` green (1658 pass, incl. new lock tests)
- [x] New code uses interfaces + fakes; ViewModel/parse unit tests run in <100ms
- [x] New generic code reuses existing helpers (`AdbClient.getDeviceLock`, `ObservationStream`, `Platform.wireName`); no new dependency
- [x] Rebased onto latest `main`, conflicts resolved

## Kotlin Reuse Check

- [x] Reused `AdbClient.getDeviceLock` (keyguard), the per-device `ObservationStream` (screenshot), and consolidated the scattered `Platform` → wire-name conversions into a single `Platform.wireName()` (removing a private duplicate in `DeviceBootController`)
- [x] `EmulatorControlExecutor` follows the established injected-seam + fake pattern; no new dependency

## Device Verification

Execution is exercised by unit + Compose UI tests with fakes. The real device-call and observation-stream paths are the untested IO seam by design (AC4), so no live-device run was performed in this PR.

## Follow-ups

Filed and out of scope here:
- #5056 — desktop lock-state feed: iOS keyguard detection (iOS `locked` is currently omitted, so iOS Unlock stays hidden) + a lighter dedicated lock query (the 4s poll re-reads the full booted-devices resource, recomputing service status + keyguard per device — flagged in review)
- #5055 — desktop `locale` + `more` emulator controls (the non-one-shot cluster items deferred from [#4690](https://github.com/kaeawc/auto-mobile/pull/4690))
