### PR TITLE
build(android): move detekt/test/coverage into conventions; add maxParallelForks

### DIFF
--- a/android/build-logic/build.gradle.kts
+++ b/android/build-logic/build.gradle.kts
@@ -1,8 +1,13 @@
 plugins { `kotlin-dsl` }
 
-// Precompiled convention plugins need the Kotlin Gradle plugin on the classpath so
-// they can reference KotlinCompile / the kotlin extension. The Kotlin DSL compiles
-// on the build's JDK; pin its toolchain to the project's Java target for consistency.
+// Precompiled convention plugins need the Kotlin Gradle plugin, AGP, and the
+// detekt plugin on the classpath so they can reference KotlinCompile, the Android
+// extensions, and DetektExtension. The Kotlin DSL compiles on the build's JDK;
+// pin its toolchain to the project's Java target for consistency.
 kotlin { jvmToolchain(libs.versions.build.java.target.get().toInt()) }
 
-dependencies { implementation(libs.kgp) }
+dependencies {
+  implementation(libs.kgp)
+  implementation(libs.agp)
+  implementation("dev.detekt:detekt-gradle-plugin:${libs.versions.detekt.get()}")
+}

--- a/android/build-logic/src/main/kotlin/automobile.detekt.gradle.kts
+++ b/android/build-logic/src/main/kotlin/automobile.detekt.gradle.kts
@@ -1,0 +1,31 @@
+import dev.detekt.gradle.extensions.DetektExtension
+import org.gradle.kotlin.dsl.configure
+
+// Applies and configures detekt for every Kotlin/Android module. Replaces the
+// root `subprojects {}` detekt wiring so no cross-project configuration remains
+// (a prerequisite for Gradle Isolated Projects).
+listOf(
+    "org.jetbrains.kotlin.jvm",
+    "org.jetbrains.kotlin.android",
+    "com.android.application",
+    "com.android.library",
+  )
+  .forEach { pluginId -> pluginManager.withPlugin(pluginId) { pluginManager.apply("dev.detekt") } }
+
+pluginManager.withPlugin("dev.detekt") {
+  extensions.configure<DetektExtension> {
+    // Resolve the shared config from the root project directory without touching
+    // the rootProject model (rootDir is build-level info, Isolated-Projects safe).
+    config.setFrom(files(rootDir.resolve("config/detekt/detekt.yml")))
+    buildUponDefaultConfig = true
+    // Analyze files across threads within a single detekt task. Gradle's
+    // org.gradle.parallel only parallelizes across projects, so without this a
+    // large module analyzes single-threaded.
+    parallel = true
+    // On Android modules `detektMain` fans out to one task per build type, so
+    // `release` re-analyzes the same `main` sources `debug` already covered.
+    // Skipping release halves Android analysis and avoids compiling the release
+    // variant classpath purely to feed detekt.
+    ignoredBuildTypes = listOf("release")
+  }
+}

--- a/android/build-logic/src/main/kotlin/automobile.kotlin-common.gradle.kts
+++ b/android/build-logic/src/main/kotlin/automobile.kotlin-common.gradle.kts
@@ -14,6 +14,13 @@ import org.jetbrains.kotlin.gradle.tasks.KotlinCompile
 // opt-in list, and the Java toolchain -- previously duplicated in the root
 // `subprojects {}` block and re-declared in individual module build files.
 
+// Apply the sibling module-default conventions so every Kotlin module gets the
+// same detekt, test, Jacoco, and coverage configuration -- without the root
+// cross-project `subprojects {}` wiring that blocks Isolated Projects.
+pluginManager.apply("automobile.detekt")
+
+pluginManager.apply("automobile.test-defaults")
+
 val libs = extensions.getByType<VersionCatalogsExtension>().named("libs")
 val kotlinLanguageVersion = libs.findVersion("build-kotlin-language").get().requiredVersion
 val javaTarget = libs.findVersion("build-java-target").get().requiredVersion

--- a/android/build-logic/src/main/kotlin/automobile.test-defaults.gradle.kts
+++ b/android/build-logic/src/main/kotlin/automobile.test-defaults.gradle.kts
@@ -1,0 +1,43 @@
+import com.android.build.api.dsl.ApplicationExtension
+import com.android.build.api.dsl.LibraryExtension
+import org.gradle.api.tasks.testing.Test
+import org.gradle.kotlin.dsl.apply
+import org.gradle.kotlin.dsl.configure
+import org.gradle.kotlin.dsl.withType
+import org.gradle.testing.jacoco.tasks.JacocoReport
+
+// Test worker JVM args, local test-fork parallelism, Jacoco XML-only reports, and
+// Android debug unit-test coverage. Replaces the root `subprojects {}` wiring.
+
+val workerJvmArgs = providers.gradleProperty("org.gradle.testWorker.jvmargs").getOrElse("")
+
+tasks.withType<Test>().configureEach {
+  if (workerJvmArgs.isNotBlank()) {
+    jvmArgs(workerJvmArgs.split(" ").filter { it.isNotBlank() })
+  }
+  // Robolectric-heavy modules otherwise run a single fork. Cross-module tasks
+  // already parallelize via org.gradle.parallel; this parallelizes within a module.
+  maxParallelForks = (Runtime.getRuntime().availableProcessors() / 2).coerceAtLeast(1)
+}
+
+pluginManager.withPlugin("java") {
+  apply(plugin = "jacoco")
+  tasks.withType<JacocoReport>().configureEach {
+    reports {
+      xml.required.set(true)
+      html.required.set(false)
+    }
+  }
+}
+
+pluginManager.withPlugin("com.android.application") {
+  extensions.configure<ApplicationExtension> {
+    buildTypes { getByName("debug") { enableUnitTestCoverage = true } }
+  }
+}
+
+pluginManager.withPlugin("com.android.library") {
+  extensions.configure<LibraryExtension> {
+    buildTypes { getByName("debug") { enableUnitTestCoverage = true } }
+  }
+}

--- a/android/build.gradle.kts
+++ b/android/build.gradle.kts
@@ -1,5 +1,4 @@
 import com.vanniktech.maven.publish.MavenPublishBaseExtension
-import dev.detekt.gradle.extensions.DetektExtension
 import org.gradle.api.publish.PublishingExtension
 import org.jetbrains.kotlin.gradle.tasks.KotlinCompile
 
@@ -72,58 +71,6 @@ allprojects {
           }
         }
       }
-    }
-  }
-}
-
-val gradleWorkerJvmArgs = providers.gradleProperty("org.gradle.testWorker.jvmargs").get()
-
-subprojects {
-  pluginManager.withPlugin("org.jetbrains.kotlin.jvm") { apply(plugin = "dev.detekt") }
-  pluginManager.withPlugin("org.jetbrains.kotlin.android") { apply(plugin = "dev.detekt") }
-  pluginManager.withPlugin("com.android.application") { apply(plugin = "dev.detekt") }
-  pluginManager.withPlugin("com.android.library") { apply(plugin = "dev.detekt") }
-  pluginManager.withPlugin("dev.detekt") {
-    extensions.configure<DetektExtension> {
-      config.setFrom(rootProject.files("config/detekt/detekt.yml"))
-      buildUponDefaultConfig = true
-      // Analyze files across threads within a single detekt task. Gradle's
-      // org.gradle.parallel only parallelizes across projects, so without this a
-      // large module analyzes single-threaded.
-      parallel = true
-      // On Android modules `detektMain` fans out to one task per build type, so
-      // `release` re-analyzes the exact same `main` sources `debug` already
-      // covered -- no module has a `src/release` source set, and the only
-      // build-type source set in the project is `auto-mobile-sdk/src/debug`.
-      // Skipping release halves the Android analysis and, more importantly,
-      // avoids compiling the release variant classpath purely to feed detekt.
-      ignoredBuildTypes = listOf("release")
-    }
-  }
-
-  tasks.withType<Test>().configureEach {
-    jvmArgs(gradleWorkerJvmArgs.split(" ").filter { it.isNotBlank() })
-  }
-
-  plugins.withId("java") {
-    apply(plugin = "jacoco")
-    tasks.withType<JacocoReport> {
-      reports {
-        xml.required.set(true)
-        html.required.set(false)
-      }
-    }
-  }
-
-  plugins.withId("com.android.application") {
-    configure<com.android.build.api.dsl.ApplicationExtension> {
-      buildTypes { getByName("debug") { enableUnitTestCoverage = true } }
-    }
-  }
-
-  plugins.withId("com.android.library") {
-    configure<com.android.build.api.dsl.LibraryExtension> {
-      buildTypes { getByName("debug") { enableUnitTestCoverage = true } }
     }
   }
 }

--- a/scripts/android/validate-kotlin-convention.sh
+++ b/scripts/android/validate-kotlin-convention.sh
@@ -47,4 +47,17 @@ if [ -n "$module_dups" ]; then
   fail "module build files still declare a KotlinCompile block:"$'\n'"$module_dups"
 fi
 
+# 5. The root build no longer uses `subprojects {}` cross-project configuration
+#    (its detekt/test/jacoco/coverage wiring moved into convention plugins). The
+#    remaining `allprojects {}` blocks are removed by a later item.
+if grep -qE '^subprojects \{' android/build.gradle.kts; then
+  fail "android/build.gradle.kts still has a subprojects {} block (blocks Isolated Projects)"
+fi
+
+# 6. The detekt and test-defaults conventions exist.
+for conv in automobile.detekt automobile.test-defaults; do
+  [ -f "android/build-logic/src/main/kotlin/$conv.gradle.kts" ] ||
+    fail "missing convention plugin: android/build-logic/src/main/kotlin/$conv.gradle.kts"
+done
+
 echo "OK: Kotlin-compile convention is centralized in $CONVENTION"


### PR DESCRIPTION
## Summary

Item 2 of 5 in the `build-logic` → Isolated Projects migration (issue #5028; builds on #5037).

Moves the remaining root `subprojects {}` configuration into convention plugins and adds per-module test-fork parallelism. After this, the only cross-project configuration left is the two `allprojects {}` blocks (item 3) and junit-runner's `layout` access (item 4).

## Changes

- New `automobile.detekt` convention — applies + configures detekt (shared config resolved via `rootDir`, not the `rootProject` model; `parallel`, release skipping preserved).
- New `automobile.test-defaults` convention — Test worker JVM args, Jacoco XML-only reports, Android debug unit-test coverage, **and `maxParallelForks = (cores/2).coerceAtLeast(1)`**.
- `automobile.kotlin-common` applies both siblings, so every module picks them up with **zero per-module edits**.
- Root `android/build.gradle.kts` — the entire `subprojects {}` block (and the `gradleWorkerJvmArgs` val + unused `DetektExtension` import) removed.
- `build-logic` gains AGP + the detekt Gradle plugin on its classpath.
- Structural guard extended: fails if `subprojects {}` returns or a convention is missing.

## Verification

- **Isolated Projects dry-run: 11 → 6 unique problems.** The five `subprojects{}` problems (apply/extensions/pluginManager/plugins/tasks) are gone; remaining are the `allprojects` ones (item 3) and junit-runner (item 4).
- **Test parallelism confirmed:** module test tasks now report `maxParallelForks=8` on a 16-core host with the worker JVM args preserved; `:junit-runner` keeps its own explicit `16`.
- detekt runs (`:protocol:detekt` green), config resolves from `rootDir`.
- `./gradlew help` configures cleanly; ktfmt tree-wide clean; shellcheck clean; structural guard (BATS) green.

## Notes

- **Behavior change (intended, per the issue):** unit-test tasks now run multiple forks instead of one. This is the test-parallelism win; it does not change test outcomes.
- No `src/`/TypeScript, DB, runner-protocol, or public-schema surface touched. detekt/Jacoco/coverage config is byte-equivalent to the previous root wiring.

Closes #5028
