### PR TITLE
feat(android): add SDK capability discovery and policy control

### DIFF
--- a/android/auto-mobile-sdk/README.md
+++ b/android/auto-mobile-sdk/README.md
@@ -226,7 +226,7 @@ AutoMobileSDK.updateCapturePolicy(
 ```
 
 Capability snapshots are versioned and distinguish `NOT_INITIALIZED`, `DISABLED`, `UNSUPPORTED`,
-`PERMISSION_DENIED`, and `SUPPORTED`. Removing an optional capability restores its unsupported
+`PERMISSION_DENIED`, `SUPPORTED`, and `UNKNOWN`. Removing an optional capability restores its unsupported
 descriptor and revokes any policy field that depends on it. Older clients should ignore unknown
 capability fields and use the schema version to select compatible behavior.
 

--- a/android/auto-mobile-sdk/README.md
+++ b/android/auto-mobile-sdk/README.md
@@ -187,7 +187,8 @@ Notes:
 
 ### AutoMobileSDK
 
-Main SDK class for registering navigation listeners.
+Main SDK class for registering navigation listeners and discovering the host integration's
+capabilities and policy.
 
 ```kotlin
 // Add a navigation listener
@@ -209,7 +210,25 @@ val isEnabled = AutoMobileSDK.isTrackingEnabled
 
 // Get listener count
 val count = AutoMobileSDK.listenerCount
+
+// Discover available SDK capabilities and their reasons when unavailable.
+val capabilities = AutoMobileSDK.capabilities
+
+// Register an optional host hook, such as a storage mutation driver.
+AutoMobileSDK.registerCapability(
+    SdkCapabilityDescriptor("storage.mutation", SdkCapabilityState.SUPPORTED)
+)
+
+// Sensitive capture and mutation access is opt-in and validated atomically.
+AutoMobileSDK.updateCapturePolicy(
+    SdkCapturePolicy(captureHeaders = true, captureBodies = true)
+)
 ```
+
+Capability snapshots are versioned and distinguish `NOT_INITIALIZED`, `DISABLED`, `UNSUPPORTED`,
+`PERMISSION_DENIED`, and `SUPPORTED`. Removing an optional capability restores its unsupported
+descriptor and revokes any policy field that depends on it. Older clients should ignore unknown
+capability fields and use the schema version to select compatible behavior.
 
 ### NavigationEvent
 

--- a/android/auto-mobile-sdk/api/auto-mobile-sdk.api
+++ b/android/auto-mobile-sdk/api/auto-mobile-sdk.api
@@ -74,7 +74,7 @@ public final class dev.jasonpearson.automobile.sdk.AutoMobileSDK$WhenMappings {
   public static final int[] $EnumSwitchMapping$0;
 }
 Compiled from "AutoMobileSDK.kt"
-public final class dev.jasonpearson.automobile.sdk.AutoMobileSDK$initialize$4$observer$1 implements androidx.lifecycle.DefaultLifecycleObserver {
+public final class dev.jasonpearson.automobile.sdk.AutoMobileSDK$initialize$5$observer$1 implements androidx.lifecycle.DefaultLifecycleObserver {
   public void onStart(androidx.lifecycle.LifecycleOwner);
   public void onStop(androidx.lifecycle.LifecycleOwner);
   public void onCreate(androidx.lifecycle.LifecycleOwner);
@@ -106,6 +106,7 @@ public final class dev.jasonpearson.automobile.sdk.AutoMobileSDK {
   public final void setEnabled(boolean);
   public final dev.jasonpearson.automobile.sdk.capabilities.SdkCapabilityDocument getCapabilities();
   public final void registerCapability(dev.jasonpearson.automobile.sdk.capabilities.SdkCapabilityDescriptor);
+  public final boolean isCapabilitySupported$auto_mobile_sdk(java.lang.String);
   public final void unregisterCapability(java.lang.String);
   public final void updateCapturePolicy(dev.jasonpearson.automobile.sdk.capabilities.SdkCapturePolicy);
   public final boolean isTrackingEnabled();
@@ -528,6 +529,7 @@ public final class dev.jasonpearson.automobile.sdk.capabilities.SdkCapabilityReg
   public final void updatePolicy(dev.jasonpearson.automobile.sdk.capabilities.SdkCapturePolicy);
   public final dev.jasonpearson.automobile.sdk.capabilities.SdkCapabilityDocument snapshot();
   public final dev.jasonpearson.automobile.sdk.capabilities.SdkCapturePolicy currentPolicy();
+  public final boolean isCapabilitySupported(java.lang.String);
   public static final java.util.Set access$getHostManagedCapabilities$cp();
   public static final java.util.LinkedHashMap access$getDefaultDescriptors$cp();
   public static final java.util.Set access$getReservedCapabilities$cp();
@@ -1106,6 +1108,7 @@ public final class dev.jasonpearson.automobile.sdk.network.AutoMobileNetwork {
   public final void initialize$auto_mobile_sdk(java.lang.String, dev.jasonpearson.automobile.sdk.events.SdkEventBuffer, dev.jasonpearson.automobile.sdk.network.NetworkMockRuleStore$RuleMatcher);
   public static void initialize$auto_mobile_sdk$default(dev.jasonpearson.automobile.sdk.network.AutoMobileNetwork, java.lang.String, dev.jasonpearson.automobile.sdk.events.SdkEventBuffer, dev.jasonpearson.automobile.sdk.network.NetworkMockRuleStore$RuleMatcher, int, java.lang.Object);
   public final void setCapturePolicyProvider$auto_mobile_sdk(kotlin.jvm.functions.Function0<dev.jasonpearson.automobile.sdk.capabilities.SdkCapturePolicy>);
+  public final void setNetworkControlProvider$auto_mobile_sdk(kotlin.jvm.functions.Function0<java.lang.Boolean>);
   public final okhttp3.Interceptor interceptor(boolean, boolean);
   public static okhttp3.Interceptor interceptor$default(dev.jasonpearson.automobile.sdk.network.AutoMobileNetwork, boolean, boolean, int, java.lang.Object);
   public final void recordRequest(dev.jasonpearson.automobile.sdk.network.NetworkRequestRecord, boolean, boolean);
@@ -1123,8 +1126,8 @@ public final class dev.jasonpearson.automobile.sdk.network.AutoMobileNetworkInte
   public static final dev.jasonpearson.automobile.sdk.network.AutoMobileNetworkInterceptor$Companion Companion;
   public static final int $stable;
   public static final long MAX_BODY_BYTES;
-  public dev.jasonpearson.automobile.sdk.network.AutoMobileNetworkInterceptor(dev.jasonpearson.automobile.sdk.events.SdkEventBuffer, java.lang.String, boolean, boolean, long, dev.jasonpearson.automobile.sdk.network.NetworkMockRuleStore$RuleMatcher, kotlin.jvm.functions.Function0<dev.jasonpearson.automobile.sdk.capabilities.SdkCapturePolicy>);
-  public dev.jasonpearson.automobile.sdk.network.AutoMobileNetworkInterceptor(dev.jasonpearson.automobile.sdk.events.SdkEventBuffer, java.lang.String, boolean, boolean, long, dev.jasonpearson.automobile.sdk.network.NetworkMockRuleStore$RuleMatcher, kotlin.jvm.functions.Function0, int, kotlin.jvm.internal.DefaultConstructorMarker);
+  public dev.jasonpearson.automobile.sdk.network.AutoMobileNetworkInterceptor(dev.jasonpearson.automobile.sdk.events.SdkEventBuffer, java.lang.String, boolean, boolean, long, dev.jasonpearson.automobile.sdk.network.NetworkMockRuleStore$RuleMatcher, kotlin.jvm.functions.Function0<dev.jasonpearson.automobile.sdk.capabilities.SdkCapturePolicy>, kotlin.jvm.functions.Function0<java.lang.Boolean>);
+  public dev.jasonpearson.automobile.sdk.network.AutoMobileNetworkInterceptor(dev.jasonpearson.automobile.sdk.events.SdkEventBuffer, java.lang.String, boolean, boolean, long, dev.jasonpearson.automobile.sdk.network.NetworkMockRuleStore$RuleMatcher, kotlin.jvm.functions.Function0, kotlin.jvm.functions.Function0, int, kotlin.jvm.internal.DefaultConstructorMarker);
   public okhttp3.Response intercept(okhttp3.Interceptor$Chain);
   public static final java.util.Set access$getTEXT_CONTENT_TYPES$cp();
 }

--- a/android/auto-mobile-sdk/api/auto-mobile-sdk.api
+++ b/android/auto-mobile-sdk/api/auto-mobile-sdk.api
@@ -74,7 +74,7 @@ public final class dev.jasonpearson.automobile.sdk.AutoMobileSDK$WhenMappings {
   public static final int[] $EnumSwitchMapping$0;
 }
 Compiled from "AutoMobileSDK.kt"
-public final class dev.jasonpearson.automobile.sdk.AutoMobileSDK$initialize$3$observer$1 implements androidx.lifecycle.DefaultLifecycleObserver {
+public final class dev.jasonpearson.automobile.sdk.AutoMobileSDK$initialize$4$observer$1 implements androidx.lifecycle.DefaultLifecycleObserver {
   public void onStart(androidx.lifecycle.LifecycleOwner);
   public void onStop(androidx.lifecycle.LifecycleOwner);
   public void onCreate(androidx.lifecycle.LifecycleOwner);
@@ -493,6 +493,7 @@ public final class dev.jasonpearson.automobile.sdk.capabilities.SdkCapabilityDoc
   public dev.jasonpearson.automobile.sdk.capabilities.SdkCapabilityDocument(int, java.util.List<dev.jasonpearson.automobile.sdk.capabilities.SdkCapabilityDescriptor>, dev.jasonpearson.automobile.sdk.capabilities.SdkCapturePolicy);
   public dev.jasonpearson.automobile.sdk.capabilities.SdkCapabilityDocument(int, java.util.List, dev.jasonpearson.automobile.sdk.capabilities.SdkCapturePolicy, int, kotlin.jvm.internal.DefaultConstructorMarker);
   public final int getSchemaVersion();
+  public static void getSchemaVersion$annotations();
   public final java.util.List<dev.jasonpearson.automobile.sdk.capabilities.SdkCapabilityDescriptor> getCapabilities();
   public final dev.jasonpearson.automobile.sdk.capabilities.SdkCapturePolicy getPolicy();
   public final int component1();
@@ -508,16 +509,28 @@ public final class dev.jasonpearson.automobile.sdk.capabilities.SdkCapabilityDoc
   public static final kotlin.Lazy[] access$get$childSerializers$cp();
 }
 Compiled from "SdkCapabilities.kt"
+final class dev.jasonpearson.automobile.sdk.capabilities.SdkCapabilityRegistry$Companion {
+  public final java.util.Set<java.lang.String> getHostManagedCapabilities();
+  public final java.util.LinkedHashMap<java.lang.String, dev.jasonpearson.automobile.sdk.capabilities.SdkCapabilityDescriptor> getDefaultDescriptors();
+  public final java.util.Set<java.lang.String> getReservedCapabilities();
+  public dev.jasonpearson.automobile.sdk.capabilities.SdkCapabilityRegistry$Companion(kotlin.jvm.internal.DefaultConstructorMarker);
+}
+Compiled from "SdkCapabilities.kt"
 public final class dev.jasonpearson.automobile.sdk.capabilities.SdkCapabilityRegistry {
   public static final int $stable;
   public dev.jasonpearson.automobile.sdk.capabilities.SdkCapabilityRegistry();
   public final void markInitialized();
+  public final void markLifecycleReady();
   public final void markShutdown();
   public final void setEnabled(boolean);
   public final void register(dev.jasonpearson.automobile.sdk.capabilities.SdkCapabilityDescriptor);
   public final void unregister(java.lang.String);
   public final void updatePolicy(dev.jasonpearson.automobile.sdk.capabilities.SdkCapturePolicy);
   public final dev.jasonpearson.automobile.sdk.capabilities.SdkCapabilityDocument snapshot();
+  public final dev.jasonpearson.automobile.sdk.capabilities.SdkCapturePolicy currentPolicy();
+  public static final java.util.Set access$getHostManagedCapabilities$cp();
+  public static final java.util.LinkedHashMap access$getDefaultDescriptors$cp();
+  public static final java.util.Set access$getReservedCapabilities$cp();
 }
 Compiled from "SdkCapabilities.kt"
 public final class dev.jasonpearson.automobile.sdk.capabilities.SdkCapabilityState$Companion {
@@ -532,6 +545,7 @@ public final class dev.jasonpearson.automobile.sdk.capabilities.SdkCapabilitySta
   public static final dev.jasonpearson.automobile.sdk.capabilities.SdkCapabilityState UNSUPPORTED;
   public static final dev.jasonpearson.automobile.sdk.capabilities.SdkCapabilityState PERMISSION_DENIED;
   public static final dev.jasonpearson.automobile.sdk.capabilities.SdkCapabilityState NOT_INITIALIZED;
+  public static final dev.jasonpearson.automobile.sdk.capabilities.SdkCapabilityState UNKNOWN;
   public static dev.jasonpearson.automobile.sdk.capabilities.SdkCapabilityState[] values();
   public static dev.jasonpearson.automobile.sdk.capabilities.SdkCapabilityState valueOf(java.lang.String);
   public static kotlin.enums.EnumEntries<dev.jasonpearson.automobile.sdk.capabilities.SdkCapabilityState> getEntries();
@@ -549,8 +563,11 @@ public final class dev.jasonpearson.automobile.sdk.capabilities.SdkCapturePolicy
   public dev.jasonpearson.automobile.sdk.capabilities.SdkCapturePolicy(boolean, boolean, boolean);
   public dev.jasonpearson.automobile.sdk.capabilities.SdkCapturePolicy(boolean, boolean, boolean, int, kotlin.jvm.internal.DefaultConstructorMarker);
   public final boolean getCaptureHeaders();
+  public static void getCaptureHeaders$annotations();
   public final boolean getCaptureBodies();
+  public static void getCaptureBodies$annotations();
   public final boolean getAllowMutations();
+  public static void getAllowMutations$annotations();
   public final boolean component1();
   public final boolean component2();
   public final boolean component3();
@@ -1082,6 +1099,7 @@ public final class dev.jasonpearson.automobile.sdk.network.AutoMobileNetwork {
   public static final int $stable;
   public final void initialize$auto_mobile_sdk(java.lang.String, dev.jasonpearson.automobile.sdk.events.SdkEventBuffer, dev.jasonpearson.automobile.sdk.network.NetworkMockRuleStore$RuleMatcher);
   public static void initialize$auto_mobile_sdk$default(dev.jasonpearson.automobile.sdk.network.AutoMobileNetwork, java.lang.String, dev.jasonpearson.automobile.sdk.events.SdkEventBuffer, dev.jasonpearson.automobile.sdk.network.NetworkMockRuleStore$RuleMatcher, int, java.lang.Object);
+  public final void setCapturePolicyProvider$auto_mobile_sdk(kotlin.jvm.functions.Function0<dev.jasonpearson.automobile.sdk.capabilities.SdkCapturePolicy>);
   public final okhttp3.Interceptor interceptor(boolean, boolean);
   public static okhttp3.Interceptor interceptor$default(dev.jasonpearson.automobile.sdk.network.AutoMobileNetwork, boolean, boolean, int, java.lang.Object);
   public final void recordRequest(dev.jasonpearson.automobile.sdk.network.NetworkRequestRecord, boolean, boolean);
@@ -1099,8 +1117,8 @@ public final class dev.jasonpearson.automobile.sdk.network.AutoMobileNetworkInte
   public static final dev.jasonpearson.automobile.sdk.network.AutoMobileNetworkInterceptor$Companion Companion;
   public static final int $stable;
   public static final long MAX_BODY_BYTES;
-  public dev.jasonpearson.automobile.sdk.network.AutoMobileNetworkInterceptor(dev.jasonpearson.automobile.sdk.events.SdkEventBuffer, java.lang.String, boolean, boolean, long, dev.jasonpearson.automobile.sdk.network.NetworkMockRuleStore$RuleMatcher);
-  public dev.jasonpearson.automobile.sdk.network.AutoMobileNetworkInterceptor(dev.jasonpearson.automobile.sdk.events.SdkEventBuffer, java.lang.String, boolean, boolean, long, dev.jasonpearson.automobile.sdk.network.NetworkMockRuleStore$RuleMatcher, int, kotlin.jvm.internal.DefaultConstructorMarker);
+  public dev.jasonpearson.automobile.sdk.network.AutoMobileNetworkInterceptor(dev.jasonpearson.automobile.sdk.events.SdkEventBuffer, java.lang.String, boolean, boolean, long, dev.jasonpearson.automobile.sdk.network.NetworkMockRuleStore$RuleMatcher, kotlin.jvm.functions.Function0<dev.jasonpearson.automobile.sdk.capabilities.SdkCapturePolicy>);
+  public dev.jasonpearson.automobile.sdk.network.AutoMobileNetworkInterceptor(dev.jasonpearson.automobile.sdk.events.SdkEventBuffer, java.lang.String, boolean, boolean, long, dev.jasonpearson.automobile.sdk.network.NetworkMockRuleStore$RuleMatcher, kotlin.jvm.functions.Function0, int, kotlin.jvm.internal.DefaultConstructorMarker);
   public okhttp3.Response intercept(okhttp3.Interceptor$Chain);
   public static final java.util.Set access$getTEXT_CONTENT_TYPES$cp();
 }

--- a/android/auto-mobile-sdk/api/auto-mobile-sdk.api
+++ b/android/auto-mobile-sdk/api/auto-mobile-sdk.api
@@ -695,6 +695,11 @@ public final class dev.jasonpearson.automobile.sdk.database.DatabaseError$Invali
   public dev.jasonpearson.automobile.sdk.database.DatabaseError$InvalidPath(java.lang.String);
 }
 Compiled from "DatabaseError.kt"
+public final class dev.jasonpearson.automobile.sdk.database.DatabaseError$MutationNotAllowed extends dev.jasonpearson.automobile.sdk.database.DatabaseError {
+  public static final int $stable;
+  public dev.jasonpearson.automobile.sdk.database.DatabaseError$MutationNotAllowed();
+}
+Compiled from "DatabaseError.kt"
 public final class dev.jasonpearson.automobile.sdk.database.DatabaseError$NotFound extends dev.jasonpearson.automobile.sdk.database.DatabaseError {
   public static final int $stable;
   public dev.jasonpearson.automobile.sdk.database.DatabaseError$NotFound(java.lang.String);
@@ -770,6 +775,7 @@ public final class dev.jasonpearson.automobile.sdk.database.SQLiteDatabaseDriver
   public dev.jasonpearson.automobile.sdk.database.TableDataResult getTableData(java.lang.String, java.lang.String, int, int);
   public dev.jasonpearson.automobile.sdk.database.TableStructureResult getTableStructure(java.lang.String, java.lang.String);
   public dev.jasonpearson.automobile.sdk.database.SQLExecutionResult executeSQL(java.lang.String, java.lang.String);
+  public final boolean isMutationQuery$auto_mobile_sdk(java.lang.String);
   public final void closeAll();
 }
 Compiled from "DatabaseDriver.kt"
@@ -1580,6 +1586,11 @@ Compiled from "SharedPreferencesError.kt"
 public final class dev.jasonpearson.automobile.sdk.storage.SharedPreferencesError$InvalidType extends dev.jasonpearson.automobile.sdk.storage.SharedPreferencesError {
   public static final int $stable;
   public dev.jasonpearson.automobile.sdk.storage.SharedPreferencesError$InvalidType(java.lang.String, java.lang.String);
+}
+Compiled from "SharedPreferencesError.kt"
+public final class dev.jasonpearson.automobile.sdk.storage.SharedPreferencesError$MutationNotAllowed extends dev.jasonpearson.automobile.sdk.storage.SharedPreferencesError {
+  public static final int $stable;
+  public dev.jasonpearson.automobile.sdk.storage.SharedPreferencesError$MutationNotAllowed();
 }
 Compiled from "SharedPreferencesError.kt"
 public final class dev.jasonpearson.automobile.sdk.storage.SharedPreferencesError$NotInitialized extends dev.jasonpearson.automobile.sdk.storage.SharedPreferencesError {

--- a/android/auto-mobile-sdk/api/auto-mobile-sdk.api
+++ b/android/auto-mobile-sdk/api/auto-mobile-sdk.api
@@ -104,6 +104,10 @@ public final class dev.jasonpearson.automobile.sdk.AutoMobileSDK {
   public final void clearNavigationListeners();
   public final void notifyNavigationEvent(dev.jasonpearson.automobile.sdk.NavigationEvent);
   public final void setEnabled(boolean);
+  public final dev.jasonpearson.automobile.sdk.capabilities.SdkCapabilityDocument getCapabilities();
+  public final void registerCapability(dev.jasonpearson.automobile.sdk.capabilities.SdkCapabilityDescriptor);
+  public final void unregisterCapability(java.lang.String);
+  public final void updateCapturePolicy(dev.jasonpearson.automobile.sdk.capabilities.SdkCapturePolicy);
   public final boolean isTrackingEnabled();
   public final int getListenerCount();
   public final java.lang.String currentSessionId();
@@ -173,22 +177,23 @@ public interface dev.jasonpearson.automobile.sdk.NavigationListener {
   public abstract void onNavigationEvent(dev.jasonpearson.automobile.sdk.NavigationEvent);
 }
 Compiled from "NavigationEvent.kt"
+public final class dev.jasonpearson.automobile.sdk.NavigationSource$Companion {
+  public final dev.jasonpearson.automobile.sdk.NavigationSource fromWireValue(java.lang.String);
+  public dev.jasonpearson.automobile.sdk.NavigationSource$Companion(kotlin.jvm.internal.DefaultConstructorMarker);
+}
+Compiled from "NavigationEvent.kt"
 public final class dev.jasonpearson.automobile.sdk.NavigationSource extends java.lang.Enum<dev.jasonpearson.automobile.sdk.NavigationSource> {
+  public static final dev.jasonpearson.automobile.sdk.NavigationSource$Companion Companion;
   public static final dev.jasonpearson.automobile.sdk.NavigationSource NAVIGATION_COMPONENT;
   public static final dev.jasonpearson.automobile.sdk.NavigationSource COMPOSE_NAVIGATION;
   public static final dev.jasonpearson.automobile.sdk.NavigationSource CIRCUIT;
   public static final dev.jasonpearson.automobile.sdk.NavigationSource CUSTOM;
   public static final dev.jasonpearson.automobile.sdk.NavigationSource DEEP_LINK;
   public static final dev.jasonpearson.automobile.sdk.NavigationSource ACTIVITY;
-  public static final dev.jasonpearson.automobile.sdk.NavigationSource$Companion Companion;
   public final java.lang.String getWireValue();
   public static dev.jasonpearson.automobile.sdk.NavigationSource[] values();
   public static dev.jasonpearson.automobile.sdk.NavigationSource valueOf(java.lang.String);
   public static kotlin.enums.EnumEntries<dev.jasonpearson.automobile.sdk.NavigationSource> getEntries();
-}
-Compiled from "NavigationEvent.kt"
-public final class dev.jasonpearson.automobile.sdk.NavigationSource$Companion {
-  public final dev.jasonpearson.automobile.sdk.NavigationSource fromWireValue(java.lang.String);
 }
 Compiled from "AutoMobileNotifications.kt"
 public final class dev.jasonpearson.automobile.sdk.NotificationAction {
@@ -232,9 +237,11 @@ Compiled from "RecompositionTracker.kt"
 final class dev.jasonpearson.automobile.sdk.RecompositionTracker$Entry {
   public dev.jasonpearson.automobile.sdk.RecompositionTracker$Entry(java.lang.String);
   public final java.lang.String getId();
+  public final long getLastTouch();
+  public final void setLastTouch(long);
   public final synchronized void record(java.lang.String, java.lang.String, java.lang.String, java.util.List<java.lang.String>, java.lang.Boolean, java.lang.Integer, java.lang.String);
   public final synchronized void recordDuration(double);
-  public final org.json.JSONObject toJson();
+  public final synchronized org.json.JSONObject toJson();
 }
 Compiled from "RecompositionTracker.kt"
 final class dev.jasonpearson.automobile.sdk.RecompositionTracker$RollingAverage {
@@ -261,9 +268,11 @@ public final class dev.jasonpearson.automobile.sdk.RecompositionTracker {
   public final void recordDuration(java.lang.String, double);
   public final boolean isEnabled$auto_mobile_sdk();
   public final void setEnabled$auto_mobile_sdk(boolean);
+  public final java.lang.String buildSnapshotJson$auto_mobile_sdk(java.lang.String);
   public static final java.util.concurrent.atomic.AtomicBoolean access$getEnabled$p();
   public static final void access$broadcastSnapshot(dev.jasonpearson.automobile.sdk.RecompositionTracker);
   public static final android.os.Handler access$getHandler$p();
+  public static final java.util.concurrent.atomic.AtomicLong access$getTouchSequence$p();
 }
 Compiled from "SdkConstants.kt"
 public final class dev.jasonpearson.automobile.sdk.SdkConstants {
@@ -271,6 +280,17 @@ public final class dev.jasonpearson.automobile.sdk.SdkConstants {
   public static final java.lang.String CTRL_PROXY_PACKAGE;
   public static final java.lang.String PERMISSION_NETWORK_CONTROL;
   public static final int $stable;
+}
+Compiled from "CircuitAdapter.kt"
+final class dev.jasonpearson.automobile.sdk.adapters.CircuitAdapter$CircuitNavigationEventListener implements com.slack.circuitx.navigation.intercepting.NavigationEventListener {
+  public dev.jasonpearson.automobile.sdk.adapters.CircuitAdapter$CircuitNavigationEventListener(androidx.compose.runtime.State<? extends kotlin.jvm.functions.Function1<? super com.slack.circuit.runtime.screen.Screen, ? extends java.util.Map<java.lang.String, ? extends java.lang.Object>>>, androidx.compose.runtime.State<? extends kotlin.jvm.functions.Function1<? super com.slack.circuit.runtime.screen.Screen, ? extends java.util.Map<java.lang.String, java.lang.String>>>);
+  public void onNavStackChanged(com.slack.circuit.runtime.navigation.NavStackList<com.slack.circuit.runtime.screen.Screen>, com.slack.circuitx.navigation.intercepting.NavigationContext);
+  public void onBackStackChanged(java.util.List<? extends com.slack.circuit.runtime.screen.Screen>, com.slack.circuitx.navigation.intercepting.NavigationContext);
+  public void goTo(com.slack.circuit.runtime.screen.Screen, com.slack.circuitx.navigation.intercepting.NavigationContext);
+  public void pop(com.slack.circuit.runtime.screen.PopResult, com.slack.circuitx.navigation.intercepting.NavigationContext);
+  public void forward(com.slack.circuitx.navigation.intercepting.NavigationContext);
+  public void backward(com.slack.circuitx.navigation.intercepting.NavigationContext);
+  public void resetRoot(com.slack.circuit.runtime.screen.Screen, com.slack.circuit.runtime.Navigator$StateOptions, com.slack.circuitx.navigation.intercepting.NavigationContext);
 }
 Compiled from "CircuitAdapter.kt"
 public final class dev.jasonpearson.automobile.sdk.adapters.CircuitAdapter implements dev.jasonpearson.automobile.sdk.adapters.NavigationFrameworkAdapter {
@@ -350,6 +370,7 @@ public final class dev.jasonpearson.automobile.sdk.biometrics.AutoMobileBiometri
   public final boolean getHasOverride();
   public final void clearOverride();
   public final dev.jasonpearson.automobile.sdk.biometrics.BiometricResult consumeOverride();
+  public final synchronized void shutdown();
   public final void handleBroadcastIntent$auto_mobile_sdk(android.content.Intent);
 }
 Compiled from "BiometricResult.kt"
@@ -433,6 +454,114 @@ public final class dev.jasonpearson.automobile.sdk.breadcrumbs.BreadcrumbTrail i
   public java.util.List<dev.jasonpearson.automobile.sdk.breadcrumbs.Breadcrumb> snapshot();
   public void clear();
   public dev.jasonpearson.automobile.sdk.breadcrumbs.BreadcrumbTrail();
+}
+Compiled from "SdkCapabilities.kt"
+public final class dev.jasonpearson.automobile.sdk.capabilities.SdkCapabilityDescriptor$Companion {
+  public final kotlinx.serialization.KSerializer<dev.jasonpearson.automobile.sdk.capabilities.SdkCapabilityDescriptor> serializer();
+  public dev.jasonpearson.automobile.sdk.capabilities.SdkCapabilityDescriptor$Companion(kotlin.jvm.internal.DefaultConstructorMarker);
+}
+Compiled from "SdkCapabilities.kt"
+public final class dev.jasonpearson.automobile.sdk.capabilities.SdkCapabilityDescriptor {
+  public static final dev.jasonpearson.automobile.sdk.capabilities.SdkCapabilityDescriptor$Companion Companion;
+  public static final int $stable;
+  public dev.jasonpearson.automobile.sdk.capabilities.SdkCapabilityDescriptor(java.lang.String, dev.jasonpearson.automobile.sdk.capabilities.SdkCapabilityState, java.lang.String);
+  public dev.jasonpearson.automobile.sdk.capabilities.SdkCapabilityDescriptor(java.lang.String, dev.jasonpearson.automobile.sdk.capabilities.SdkCapabilityState, java.lang.String, int, kotlin.jvm.internal.DefaultConstructorMarker);
+  public final java.lang.String getId();
+  public final dev.jasonpearson.automobile.sdk.capabilities.SdkCapabilityState getState();
+  public final java.lang.String getReason();
+  public final java.lang.String component1();
+  public final dev.jasonpearson.automobile.sdk.capabilities.SdkCapabilityState component2();
+  public final java.lang.String component3();
+  public final dev.jasonpearson.automobile.sdk.capabilities.SdkCapabilityDescriptor copy(java.lang.String, dev.jasonpearson.automobile.sdk.capabilities.SdkCapabilityState, java.lang.String);
+  public static dev.jasonpearson.automobile.sdk.capabilities.SdkCapabilityDescriptor copy$default(dev.jasonpearson.automobile.sdk.capabilities.SdkCapabilityDescriptor, java.lang.String, dev.jasonpearson.automobile.sdk.capabilities.SdkCapabilityState, java.lang.String, int, java.lang.Object);
+  public java.lang.String toString();
+  public int hashCode();
+  public boolean equals(java.lang.Object);
+  public static final void write$Self$auto_mobile_sdk(dev.jasonpearson.automobile.sdk.capabilities.SdkCapabilityDescriptor, kotlinx.serialization.encoding.CompositeEncoder, kotlinx.serialization.descriptors.SerialDescriptor);
+  public dev.jasonpearson.automobile.sdk.capabilities.SdkCapabilityDescriptor(int, java.lang.String, dev.jasonpearson.automobile.sdk.capabilities.SdkCapabilityState, java.lang.String, kotlinx.serialization.internal.SerializationConstructorMarker);
+  public static final kotlin.Lazy[] access$get$childSerializers$cp();
+}
+Compiled from "SdkCapabilities.kt"
+public final class dev.jasonpearson.automobile.sdk.capabilities.SdkCapabilityDocument$Companion {
+  public final kotlinx.serialization.KSerializer<dev.jasonpearson.automobile.sdk.capabilities.SdkCapabilityDocument> serializer();
+  public dev.jasonpearson.automobile.sdk.capabilities.SdkCapabilityDocument$Companion(kotlin.jvm.internal.DefaultConstructorMarker);
+}
+Compiled from "SdkCapabilities.kt"
+public final class dev.jasonpearson.automobile.sdk.capabilities.SdkCapabilityDocument {
+  public static final dev.jasonpearson.automobile.sdk.capabilities.SdkCapabilityDocument$Companion Companion;
+  public static final int $stable;
+  public dev.jasonpearson.automobile.sdk.capabilities.SdkCapabilityDocument(int, java.util.List<dev.jasonpearson.automobile.sdk.capabilities.SdkCapabilityDescriptor>, dev.jasonpearson.automobile.sdk.capabilities.SdkCapturePolicy);
+  public dev.jasonpearson.automobile.sdk.capabilities.SdkCapabilityDocument(int, java.util.List, dev.jasonpearson.automobile.sdk.capabilities.SdkCapturePolicy, int, kotlin.jvm.internal.DefaultConstructorMarker);
+  public final int getSchemaVersion();
+  public final java.util.List<dev.jasonpearson.automobile.sdk.capabilities.SdkCapabilityDescriptor> getCapabilities();
+  public final dev.jasonpearson.automobile.sdk.capabilities.SdkCapturePolicy getPolicy();
+  public final int component1();
+  public final java.util.List<dev.jasonpearson.automobile.sdk.capabilities.SdkCapabilityDescriptor> component2();
+  public final dev.jasonpearson.automobile.sdk.capabilities.SdkCapturePolicy component3();
+  public final dev.jasonpearson.automobile.sdk.capabilities.SdkCapabilityDocument copy(int, java.util.List<dev.jasonpearson.automobile.sdk.capabilities.SdkCapabilityDescriptor>, dev.jasonpearson.automobile.sdk.capabilities.SdkCapturePolicy);
+  public static dev.jasonpearson.automobile.sdk.capabilities.SdkCapabilityDocument copy$default(dev.jasonpearson.automobile.sdk.capabilities.SdkCapabilityDocument, int, java.util.List, dev.jasonpearson.automobile.sdk.capabilities.SdkCapturePolicy, int, java.lang.Object);
+  public java.lang.String toString();
+  public int hashCode();
+  public boolean equals(java.lang.Object);
+  public static final void write$Self$auto_mobile_sdk(dev.jasonpearson.automobile.sdk.capabilities.SdkCapabilityDocument, kotlinx.serialization.encoding.CompositeEncoder, kotlinx.serialization.descriptors.SerialDescriptor);
+  public dev.jasonpearson.automobile.sdk.capabilities.SdkCapabilityDocument(int, int, java.util.List, dev.jasonpearson.automobile.sdk.capabilities.SdkCapturePolicy, kotlinx.serialization.internal.SerializationConstructorMarker);
+  public static final kotlin.Lazy[] access$get$childSerializers$cp();
+}
+Compiled from "SdkCapabilities.kt"
+public final class dev.jasonpearson.automobile.sdk.capabilities.SdkCapabilityRegistry {
+  public static final int $stable;
+  public dev.jasonpearson.automobile.sdk.capabilities.SdkCapabilityRegistry();
+  public final void markInitialized();
+  public final void markShutdown();
+  public final void setEnabled(boolean);
+  public final void register(dev.jasonpearson.automobile.sdk.capabilities.SdkCapabilityDescriptor);
+  public final void unregister(java.lang.String);
+  public final void updatePolicy(dev.jasonpearson.automobile.sdk.capabilities.SdkCapturePolicy);
+  public final dev.jasonpearson.automobile.sdk.capabilities.SdkCapabilityDocument snapshot();
+}
+Compiled from "SdkCapabilities.kt"
+public final class dev.jasonpearson.automobile.sdk.capabilities.SdkCapabilityState$Companion {
+  public final kotlinx.serialization.KSerializer<dev.jasonpearson.automobile.sdk.capabilities.SdkCapabilityState> serializer();
+  public dev.jasonpearson.automobile.sdk.capabilities.SdkCapabilityState$Companion(kotlin.jvm.internal.DefaultConstructorMarker);
+}
+Compiled from "SdkCapabilities.kt"
+public final class dev.jasonpearson.automobile.sdk.capabilities.SdkCapabilityState extends java.lang.Enum<dev.jasonpearson.automobile.sdk.capabilities.SdkCapabilityState> {
+  public static final dev.jasonpearson.automobile.sdk.capabilities.SdkCapabilityState$Companion Companion;
+  public static final dev.jasonpearson.automobile.sdk.capabilities.SdkCapabilityState SUPPORTED;
+  public static final dev.jasonpearson.automobile.sdk.capabilities.SdkCapabilityState DISABLED;
+  public static final dev.jasonpearson.automobile.sdk.capabilities.SdkCapabilityState UNSUPPORTED;
+  public static final dev.jasonpearson.automobile.sdk.capabilities.SdkCapabilityState PERMISSION_DENIED;
+  public static final dev.jasonpearson.automobile.sdk.capabilities.SdkCapabilityState NOT_INITIALIZED;
+  public static dev.jasonpearson.automobile.sdk.capabilities.SdkCapabilityState[] values();
+  public static dev.jasonpearson.automobile.sdk.capabilities.SdkCapabilityState valueOf(java.lang.String);
+  public static kotlin.enums.EnumEntries<dev.jasonpearson.automobile.sdk.capabilities.SdkCapabilityState> getEntries();
+  public static final kotlin.Lazy access$get$cachedSerializer$delegate$cp();
+}
+Compiled from "SdkCapabilities.kt"
+public final class dev.jasonpearson.automobile.sdk.capabilities.SdkCapturePolicy$Companion {
+  public final kotlinx.serialization.KSerializer<dev.jasonpearson.automobile.sdk.capabilities.SdkCapturePolicy> serializer();
+  public dev.jasonpearson.automobile.sdk.capabilities.SdkCapturePolicy$Companion(kotlin.jvm.internal.DefaultConstructorMarker);
+}
+Compiled from "SdkCapabilities.kt"
+public final class dev.jasonpearson.automobile.sdk.capabilities.SdkCapturePolicy {
+  public static final dev.jasonpearson.automobile.sdk.capabilities.SdkCapturePolicy$Companion Companion;
+  public static final int $stable;
+  public dev.jasonpearson.automobile.sdk.capabilities.SdkCapturePolicy(boolean, boolean, boolean);
+  public dev.jasonpearson.automobile.sdk.capabilities.SdkCapturePolicy(boolean, boolean, boolean, int, kotlin.jvm.internal.DefaultConstructorMarker);
+  public final boolean getCaptureHeaders();
+  public final boolean getCaptureBodies();
+  public final boolean getAllowMutations();
+  public final boolean component1();
+  public final boolean component2();
+  public final boolean component3();
+  public final dev.jasonpearson.automobile.sdk.capabilities.SdkCapturePolicy copy(boolean, boolean, boolean);
+  public static dev.jasonpearson.automobile.sdk.capabilities.SdkCapturePolicy copy$default(dev.jasonpearson.automobile.sdk.capabilities.SdkCapturePolicy, boolean, boolean, boolean, int, java.lang.Object);
+  public java.lang.String toString();
+  public int hashCode();
+  public boolean equals(java.lang.Object);
+  public static final void write$Self$auto_mobile_sdk(dev.jasonpearson.automobile.sdk.capabilities.SdkCapturePolicy, kotlinx.serialization.encoding.CompositeEncoder, kotlinx.serialization.descriptors.SerialDescriptor);
+  public dev.jasonpearson.automobile.sdk.capabilities.SdkCapturePolicy(int, boolean, boolean, boolean, kotlinx.serialization.internal.SerializationConstructorMarker);
+  public dev.jasonpearson.automobile.sdk.capabilities.SdkCapturePolicy();
 }
 Compiled from "SdkContext.kt"
 public final class dev.jasonpearson.automobile.sdk.context.SdkContext {
@@ -878,6 +1007,10 @@ public final class dev.jasonpearson.automobile.sdk.logging.AutoMobileLog {
   public static final dev.jasonpearson.automobile.sdk.logging.AutoMobileLog INSTANCE;
   public static final int $stable;
   public final void initialize$auto_mobile_sdk();
+  public final void addFilter(java.lang.String, kotlin.text.Regex, kotlin.text.Regex, int);
+  public static void addFilter$default(dev.jasonpearson.automobile.sdk.logging.AutoMobileLog, java.lang.String, kotlin.text.Regex, kotlin.text.Regex, int, int, java.lang.Object);
+  public final void removeFilter(java.lang.String);
+  public final void clearFilters();
   public final int v(java.lang.String, java.lang.String);
   public final int v(java.lang.String, java.lang.String, java.lang.Throwable);
   public final int d(java.lang.String, java.lang.String);
@@ -890,6 +1023,26 @@ public final class dev.jasonpearson.automobile.sdk.logging.AutoMobileLog {
   public final int e(java.lang.String, java.lang.String, java.lang.Throwable);
   public final int wtf(java.lang.String, java.lang.String);
   public final int wtf(java.lang.String, java.lang.String, java.lang.Throwable);
+}
+Compiled from "CompiledLogFilter.kt"
+public final class dev.jasonpearson.automobile.sdk.logging.CompiledLogFilter {
+  public static final int $stable;
+  public dev.jasonpearson.automobile.sdk.logging.CompiledLogFilter(java.lang.String, kotlin.text.Regex, kotlin.text.Regex, int);
+  public dev.jasonpearson.automobile.sdk.logging.CompiledLogFilter(java.lang.String, kotlin.text.Regex, kotlin.text.Regex, int, int, kotlin.jvm.internal.DefaultConstructorMarker);
+  public final java.lang.String getName();
+  public final kotlin.text.Regex getTagPattern();
+  public final kotlin.text.Regex getMessagePattern();
+  public final int getMinLevel();
+  public final boolean matches(java.lang.String, java.lang.String, int);
+  public final java.lang.String component1();
+  public final kotlin.text.Regex component2();
+  public final kotlin.text.Regex component3();
+  public final int component4();
+  public final dev.jasonpearson.automobile.sdk.logging.CompiledLogFilter copy(java.lang.String, kotlin.text.Regex, kotlin.text.Regex, int);
+  public static dev.jasonpearson.automobile.sdk.logging.CompiledLogFilter copy$default(dev.jasonpearson.automobile.sdk.logging.CompiledLogFilter, java.lang.String, kotlin.text.Regex, kotlin.text.Regex, int, int, java.lang.Object);
+  public java.lang.String toString();
+  public int hashCode();
+  public boolean equals(java.lang.Object);
 }
 Compiled from "SdkLogger.kt"
 public final class dev.jasonpearson.automobile.sdk.logging.DefaultSdkLogger implements dev.jasonpearson.automobile.sdk.logging.SdkLogger {
@@ -931,7 +1084,10 @@ public final class dev.jasonpearson.automobile.sdk.network.AutoMobileNetwork {
   public static void initialize$auto_mobile_sdk$default(dev.jasonpearson.automobile.sdk.network.AutoMobileNetwork, java.lang.String, dev.jasonpearson.automobile.sdk.events.SdkEventBuffer, dev.jasonpearson.automobile.sdk.network.NetworkMockRuleStore$RuleMatcher, int, java.lang.Object);
   public final okhttp3.Interceptor interceptor(boolean, boolean);
   public static okhttp3.Interceptor interceptor$default(dev.jasonpearson.automobile.sdk.network.AutoMobileNetwork, boolean, boolean, int, java.lang.Object);
+  public final void recordRequest(dev.jasonpearson.automobile.sdk.network.NetworkRequestRecord, boolean, boolean);
+  public static void recordRequest$default(dev.jasonpearson.automobile.sdk.network.AutoMobileNetwork, dev.jasonpearson.automobile.sdk.network.NetworkRequestRecord, boolean, boolean, int, java.lang.Object);
   public final okhttp3.WebSocketListener wrapWebSocketListener(okhttp3.WebSocketListener, java.lang.String);
+  public final void reset$auto_mobile_sdk();
 }
 Compiled from "AutoMobileNetworkInterceptor.kt"
 public final class dev.jasonpearson.automobile.sdk.network.AutoMobileNetworkInterceptor$Companion {
@@ -964,6 +1120,7 @@ Compiled from "NetworkMockRuleStore.kt"
 public final class dev.jasonpearson.automobile.sdk.network.NetworkMockRuleStore$Companion {
   public final dev.jasonpearson.automobile.sdk.network.NetworkMockRuleStore getInstance();
   public final void initialize(android.content.Context);
+  public final void shutdown(android.content.Context);
   public dev.jasonpearson.automobile.sdk.network.NetworkMockRuleStore$Companion(kotlin.jvm.internal.DefaultConstructorMarker);
 }
 Compiled from "NetworkMockRuleStore.kt"
@@ -1068,12 +1225,51 @@ public final class dev.jasonpearson.automobile.sdk.network.NetworkMockRuleStore 
   public final dev.jasonpearson.automobile.sdk.network.NetworkMockRuleStore$ErrorSimulationConfig getActiveErrorSimulation();
   public final void clear();
   public final int getRuleCount();
-  public final void registerReceiver(android.content.Context);
-  public final void unregisterReceiver(android.content.Context);
+  public final synchronized void registerReceiver(android.content.Context);
+  public final synchronized void unregisterReceiver(android.content.Context);
   public dev.jasonpearson.automobile.sdk.network.NetworkMockRuleStore();
   public static final dev.jasonpearson.automobile.sdk.network.NetworkMockRuleStore access$getInstance$cp();
   public static final void access$setInstance$cp(dev.jasonpearson.automobile.sdk.network.NetworkMockRuleStore);
   public static final kotlinx.serialization.json.Json access$getJson$p(dev.jasonpearson.automobile.sdk.network.NetworkMockRuleStore);
+}
+Compiled from "AutoMobileNetwork.kt"
+public final class dev.jasonpearson.automobile.sdk.network.NetworkRequestRecord {
+  public static final int $stable;
+  public dev.jasonpearson.automobile.sdk.network.NetworkRequestRecord(java.lang.String, java.lang.String, java.util.Map<java.lang.String, java.lang.String>, long, int, java.util.Map<java.lang.String, java.lang.String>, long, long, java.lang.String, java.lang.String, java.lang.String, java.lang.String, java.lang.String, java.lang.String);
+  public dev.jasonpearson.automobile.sdk.network.NetworkRequestRecord(java.lang.String, java.lang.String, java.util.Map, long, int, java.util.Map, long, long, java.lang.String, java.lang.String, java.lang.String, java.lang.String, java.lang.String, java.lang.String, int, kotlin.jvm.internal.DefaultConstructorMarker);
+  public final java.lang.String getUrl();
+  public final java.lang.String getMethod();
+  public final java.util.Map<java.lang.String, java.lang.String> getRequestHeaders();
+  public final long getRequestBodySize();
+  public final int getStatusCode();
+  public final java.util.Map<java.lang.String, java.lang.String> getResponseHeaders();
+  public final long getResponseBodySize();
+  public final long getDurationMs();
+  public final java.lang.String getError();
+  public final java.lang.String getHost();
+  public final java.lang.String getPath();
+  public final java.lang.String getRequestBody();
+  public final java.lang.String getResponseBody();
+  public final java.lang.String getContentType();
+  public final java.lang.String component1();
+  public final java.lang.String component2();
+  public final java.util.Map<java.lang.String, java.lang.String> component3();
+  public final long component4();
+  public final int component5();
+  public final java.util.Map<java.lang.String, java.lang.String> component6();
+  public final long component7();
+  public final long component8();
+  public final java.lang.String component9();
+  public final java.lang.String component10();
+  public final java.lang.String component11();
+  public final java.lang.String component12();
+  public final java.lang.String component13();
+  public final java.lang.String component14();
+  public final dev.jasonpearson.automobile.sdk.network.NetworkRequestRecord copy(java.lang.String, java.lang.String, java.util.Map<java.lang.String, java.lang.String>, long, int, java.util.Map<java.lang.String, java.lang.String>, long, long, java.lang.String, java.lang.String, java.lang.String, java.lang.String, java.lang.String, java.lang.String);
+  public static dev.jasonpearson.automobile.sdk.network.NetworkRequestRecord copy$default(dev.jasonpearson.automobile.sdk.network.NetworkRequestRecord, java.lang.String, java.lang.String, java.util.Map, long, int, java.util.Map, long, long, java.lang.String, java.lang.String, java.lang.String, java.lang.String, java.lang.String, java.lang.String, int, java.lang.Object);
+  public java.lang.String toString();
+  public int hashCode();
+  public boolean equals(java.lang.Object);
 }
 Compiled from "NoOpDropCounter.kt"
 public final class dev.jasonpearson.automobile.sdk.noop.NoOpDropCounter implements dev.jasonpearson.automobile.sdk.events.DropCounter {
@@ -1113,6 +1309,7 @@ public final class dev.jasonpearson.automobile.sdk.os.AutoMobileBroadcastInterce
   public static final dev.jasonpearson.automobile.sdk.os.AutoMobileBroadcastInterceptor INSTANCE;
   public static final int $stable;
   public final void initialize$auto_mobile_sdk(android.content.Context, dev.jasonpearson.automobile.sdk.events.SdkEventBuffer);
+  public final java.util.List<android.content.IntentFilter> buildFilters$auto_mobile_sdk();
   public final void shutdown(android.content.Context);
   public static final java.lang.String access$getApplicationId$p();
 }

--- a/android/auto-mobile-sdk/src/debug/kotlin/dev/jasonpearson/automobile/sdk/database/DatabaseInspectorProvider.kt
+++ b/android/auto-mobile-sdk/src/debug/kotlin/dev/jasonpearson/automobile/sdk/database/DatabaseInspectorProvider.kt
@@ -175,7 +175,8 @@ class DatabaseInspectorProvider : ContentProvider() {
     val query = extras.getString("query") ?: throw IllegalArgumentException("query required")
     if (driver is SQLiteDatabaseDriver &&
         driver.isMutationQuery(query) &&
-        !AutoMobileSDK.capabilities.policy.allowMutations) {
+        !AutoMobileSDK.capabilities.policy.allowMutations ||
+        !AutoMobileSDK.isCapabilitySupported("storage.mutation")) {
       throw DatabaseError.MutationNotAllowed()
     }
 

--- a/android/auto-mobile-sdk/src/debug/kotlin/dev/jasonpearson/automobile/sdk/database/DatabaseInspectorProvider.kt
+++ b/android/auto-mobile-sdk/src/debug/kotlin/dev/jasonpearson/automobile/sdk/database/DatabaseInspectorProvider.kt
@@ -173,10 +173,12 @@ class DatabaseInspectorProvider : ContentProvider() {
     val databasePath =
       extras?.getString("databasePath") ?: throw IllegalArgumentException("databasePath required")
     val query = extras.getString("query") ?: throw IllegalArgumentException("query required")
-    if (driver is SQLiteDatabaseDriver &&
+    if (
+      driver is SQLiteDatabaseDriver &&
         driver.isMutationQuery(query) &&
         !AutoMobileSDK.capabilities.policy.allowMutations ||
-        !AutoMobileSDK.isCapabilitySupported("storage.mutation")) {
+        !AutoMobileSDK.isCapabilitySupported("storage.mutation")
+    ) {
       throw DatabaseError.MutationNotAllowed()
     }
 

--- a/android/auto-mobile-sdk/src/debug/kotlin/dev/jasonpearson/automobile/sdk/database/DatabaseInspectorProvider.kt
+++ b/android/auto-mobile-sdk/src/debug/kotlin/dev/jasonpearson/automobile/sdk/database/DatabaseInspectorProvider.kt
@@ -5,6 +5,7 @@ import android.content.ContentValues
 import android.database.Cursor
 import android.net.Uri
 import android.os.Bundle
+import dev.jasonpearson.automobile.sdk.AutoMobileSDK
 import org.json.JSONArray
 import org.json.JSONObject
 
@@ -172,6 +173,11 @@ class DatabaseInspectorProvider : ContentProvider() {
     val databasePath =
       extras?.getString("databasePath") ?: throw IllegalArgumentException("databasePath required")
     val query = extras.getString("query") ?: throw IllegalArgumentException("query required")
+    if (driver is SQLiteDatabaseDriver &&
+        driver.isMutationQuery(query) &&
+        !AutoMobileSDK.capabilities.policy.allowMutations) {
+      throw DatabaseError.MutationNotAllowed()
+    }
 
     return when (val result = driver.executeSQL(databasePath, query)) {
       is SQLExecutionResult.Query -> {

--- a/android/auto-mobile-sdk/src/debug/kotlin/dev/jasonpearson/automobile/sdk/storage/SharedPreferencesInspectorProvider.kt
+++ b/android/auto-mobile-sdk/src/debug/kotlin/dev/jasonpearson/automobile/sdk/storage/SharedPreferencesInspectorProvider.kt
@@ -5,12 +5,12 @@ import android.content.ContentValues
 import android.database.Cursor
 import android.net.Uri
 import android.os.Bundle
-import dev.jasonpearson.automobile.sdk.AutoMobileSDK
 import dev.jasonpearson.automobile.protocol.StorageChangeEvent
 import dev.jasonpearson.automobile.protocol.StorageEntry
 import dev.jasonpearson.automobile.protocol.StorageFileInfo
 import dev.jasonpearson.automobile.protocol.StorageProtocolSerializer
 import dev.jasonpearson.automobile.protocol.StorageResponse
+import dev.jasonpearson.automobile.sdk.AutoMobileSDK
 import kotlinx.serialization.SerializationException
 import kotlinx.serialization.decodeFromString
 import kotlinx.serialization.encodeToString
@@ -104,8 +104,10 @@ class SharedPreferencesInspectorProvider : ContentProvider() {
   }
 
   private fun requireMutationsAllowed() {
-    if (!AutoMobileSDK.capabilities.policy.allowMutations ||
-        !AutoMobileSDK.isCapabilitySupported("storage.mutation")) {
+    if (
+      !AutoMobileSDK.capabilities.policy.allowMutations ||
+        !AutoMobileSDK.isCapabilitySupported("storage.mutation")
+    ) {
       throw SharedPreferencesError.MutationNotAllowed()
     }
   }

--- a/android/auto-mobile-sdk/src/debug/kotlin/dev/jasonpearson/automobile/sdk/storage/SharedPreferencesInspectorProvider.kt
+++ b/android/auto-mobile-sdk/src/debug/kotlin/dev/jasonpearson/automobile/sdk/storage/SharedPreferencesInspectorProvider.kt
@@ -104,7 +104,8 @@ class SharedPreferencesInspectorProvider : ContentProvider() {
   }
 
   private fun requireMutationsAllowed() {
-    if (!AutoMobileSDK.capabilities.policy.allowMutations) {
+    if (!AutoMobileSDK.capabilities.policy.allowMutations ||
+        !AutoMobileSDK.isCapabilitySupported("storage.mutation")) {
       throw SharedPreferencesError.MutationNotAllowed()
     }
   }

--- a/android/auto-mobile-sdk/src/debug/kotlin/dev/jasonpearson/automobile/sdk/storage/SharedPreferencesInspectorProvider.kt
+++ b/android/auto-mobile-sdk/src/debug/kotlin/dev/jasonpearson/automobile/sdk/storage/SharedPreferencesInspectorProvider.kt
@@ -5,6 +5,7 @@ import android.content.ContentValues
 import android.database.Cursor
 import android.net.Uri
 import android.os.Bundle
+import dev.jasonpearson.automobile.sdk.AutoMobileSDK
 import dev.jasonpearson.automobile.protocol.StorageChangeEvent
 import dev.jasonpearson.automobile.protocol.StorageEntry
 import dev.jasonpearson.automobile.protocol.StorageFileInfo
@@ -65,9 +66,18 @@ class SharedPreferencesInspectorProvider : ContentProvider() {
           "listFiles" -> handleListFiles(driver)
           "getPreferences" -> handleGetPreferences(driver, extras)
           "getPreference" -> handleGetPreference(driver, extras)
-          "setValue" -> handleSetValue(driver, extras)
-          "removeValue" -> handleRemoveValue(driver, extras)
-          "clearFile" -> handleClearFile(driver, extras)
+          "setValue" -> {
+            requireMutationsAllowed()
+            handleSetValue(driver, extras)
+          }
+          "removeValue" -> {
+            requireMutationsAllowed()
+            handleRemoveValue(driver, extras)
+          }
+          "clearFile" -> {
+            requireMutationsAllowed()
+            handleClearFile(driver, extras)
+          }
           "subscribeToFile" -> handleSubscribeToFile(driver, extras)
           "unsubscribeFromFile" -> handleUnsubscribeFromFile(driver, extras)
           "getChanges" -> handleGetChanges(driver, extras)
@@ -91,6 +101,12 @@ class SharedPreferencesInspectorProvider : ContentProvider() {
     }
 
     return result
+  }
+
+  private fun requireMutationsAllowed() {
+    if (!AutoMobileSDK.capabilities.policy.allowMutations) {
+      throw SharedPreferencesError.MutationNotAllowed()
+    }
   }
 
   private fun handleListFiles(driver: SharedPreferencesDriver): String {

--- a/android/auto-mobile-sdk/src/main/kotlin/dev/jasonpearson/automobile/sdk/AutoMobileSDK.kt
+++ b/android/auto-mobile-sdk/src/main/kotlin/dev/jasonpearson/automobile/sdk/AutoMobileSDK.kt
@@ -128,6 +128,7 @@ object AutoMobileSDK {
     this.context = context.applicationContext
     this.configuration = configuration
     capabilityRegistry.markInitialized()
+    AutoMobileNetwork.setCapturePolicyProvider { capabilityRegistry.currentPolicy() }
     val appContext = this.context!!
 
     // Create disk persistence for events
@@ -214,6 +215,7 @@ object AutoMobileSDK {
         }
       sessionLifecycleObserver = observer
       ProcessLifecycleOwner.get().lifecycle.addObserver(observer)
+      capabilityRegistry.markLifecycleReady()
       RecompositionTracker.initialize(appContext)
       RecompositionTracker.setEnabled(_isEnabled)
       AutoMobileNotifications.initialize(appContext)
@@ -460,6 +462,7 @@ object AutoMobileSDK {
     RecompositionTracker.reset()
     listeners.clear()
     _isEnabled = true
+    AutoMobileNetwork.setCapturePolicyProvider(null)
     capabilityRegistry.markShutdown()
     configuration = null
     context = null

--- a/android/auto-mobile-sdk/src/main/kotlin/dev/jasonpearson/automobile/sdk/AutoMobileSDK.kt
+++ b/android/auto-mobile-sdk/src/main/kotlin/dev/jasonpearson/automobile/sdk/AutoMobileSDK.kt
@@ -470,4 +470,5 @@ object AutoMobileSDK {
 
   /** Returns the current configuration, or null if not initialized. */
   internal fun getConfiguration(): AutoMobileConfiguration? = configuration
+
 }

--- a/android/auto-mobile-sdk/src/main/kotlin/dev/jasonpearson/automobile/sdk/AutoMobileSDK.kt
+++ b/android/auto-mobile-sdk/src/main/kotlin/dev/jasonpearson/automobile/sdk/AutoMobileSDK.kt
@@ -479,5 +479,4 @@ object AutoMobileSDK {
 
   /** Returns the current configuration, or null if not initialized. */
   internal fun getConfiguration(): AutoMobileConfiguration? = configuration
-
 }

--- a/android/auto-mobile-sdk/src/main/kotlin/dev/jasonpearson/automobile/sdk/AutoMobileSDK.kt
+++ b/android/auto-mobile-sdk/src/main/kotlin/dev/jasonpearson/automobile/sdk/AutoMobileSDK.kt
@@ -16,6 +16,10 @@ import dev.jasonpearson.automobile.sdk.biometrics.AutoMobileBiometrics
 import dev.jasonpearson.automobile.sdk.breadcrumbs.Breadcrumb
 import dev.jasonpearson.automobile.sdk.breadcrumbs.BreadcrumbCategory
 import dev.jasonpearson.automobile.sdk.breadcrumbs.BreadcrumbTrail
+import dev.jasonpearson.automobile.sdk.capabilities.SdkCapabilityDescriptor
+import dev.jasonpearson.automobile.sdk.capabilities.SdkCapabilityDocument
+import dev.jasonpearson.automobile.sdk.capabilities.SdkCapabilityRegistry
+import dev.jasonpearson.automobile.sdk.capabilities.SdkCapturePolicy
 import dev.jasonpearson.automobile.sdk.context.SdkContext
 import dev.jasonpearson.automobile.sdk.context.SdkContextSnapshot
 import dev.jasonpearson.automobile.sdk.crashes.AutoMobileCrashes
@@ -90,6 +94,7 @@ object AutoMobileSDK {
   @Volatile private var sdkContext: SdkContext? = null
   @Volatile private var breadcrumbTrail: BreadcrumbTrail? = null
   @Volatile private var dropCounter: DropCounter? = null
+  private val capabilityRegistry = SdkCapabilityRegistry()
 
   const val ACTION_NAVIGATION_EVENT = "dev.jasonpearson.automobile.sdk.NAVIGATION_EVENT"
   const val EXTRA_DESTINATION = "destination"
@@ -122,6 +127,7 @@ object AutoMobileSDK {
   fun initialize(context: Context, configuration: AutoMobileConfiguration) {
     this.context = context.applicationContext
     this.configuration = configuration
+    capabilityRegistry.markInitialized()
     val appContext = this.context!!
 
     // Create disk persistence for events
@@ -304,6 +310,26 @@ object AutoMobileSDK {
     _isEnabled = enabled
     eventBuffer?.isEnabled = enabled
     RecompositionTracker.setEnabled(enabled)
+    capabilityRegistry.setEnabled(enabled)
+  }
+
+  /** Returns the versioned capability and policy snapshot for this SDK integration. */
+  val capabilities: SdkCapabilityDocument
+    get() = capabilityRegistry.snapshot()
+
+  /** Registers or replaces an optional host-provided capability. */
+  fun registerCapability(descriptor: SdkCapabilityDescriptor) {
+    capabilityRegistry.register(descriptor)
+  }
+
+  /** Removes an optional host-provided capability. */
+  fun unregisterCapability(id: String) {
+    capabilityRegistry.unregister(id)
+  }
+
+  /** Atomically replaces the capture and mutation policy after capability validation. */
+  fun updateCapturePolicy(policy: SdkCapturePolicy) {
+    capabilityRegistry.updatePolicy(policy)
   }
 
   /** Whether navigation tracking is currently enabled. */
@@ -434,6 +460,7 @@ object AutoMobileSDK {
     RecompositionTracker.reset()
     listeners.clear()
     _isEnabled = true
+    capabilityRegistry.markShutdown()
     configuration = null
     context = null
   }

--- a/android/auto-mobile-sdk/src/main/kotlin/dev/jasonpearson/automobile/sdk/AutoMobileSDK.kt
+++ b/android/auto-mobile-sdk/src/main/kotlin/dev/jasonpearson/automobile/sdk/AutoMobileSDK.kt
@@ -129,6 +129,9 @@ object AutoMobileSDK {
     this.configuration = configuration
     capabilityRegistry.markInitialized()
     AutoMobileNetwork.setCapturePolicyProvider { capabilityRegistry.currentPolicy() }
+    AutoMobileNetwork.setNetworkControlProvider {
+      capabilityRegistry.isCapabilitySupported("network.control")
+    }
     val appContext = this.context!!
 
     // Create disk persistence for events
@@ -324,6 +327,10 @@ object AutoMobileSDK {
     capabilityRegistry.register(descriptor)
   }
 
+  /** Returns whether a capability is currently supported and usable. */
+  internal fun isCapabilitySupported(id: String): Boolean =
+    capabilityRegistry.isCapabilitySupported(id)
+
   /** Removes an optional host-provided capability. */
   fun unregisterCapability(id: String) {
     capabilityRegistry.unregister(id)
@@ -463,6 +470,8 @@ object AutoMobileSDK {
     listeners.clear()
     _isEnabled = true
     AutoMobileNetwork.setCapturePolicyProvider(null)
+    AutoMobileNetwork.setNetworkControlProvider(null)
+    AutoMobileNetwork.reset()
     capabilityRegistry.markShutdown()
     configuration = null
     context = null

--- a/android/auto-mobile-sdk/src/main/kotlin/dev/jasonpearson/automobile/sdk/capabilities/SdkCapabilities.kt
+++ b/android/auto-mobile-sdk/src/main/kotlin/dev/jasonpearson/automobile/sdk/capabilities/SdkCapabilities.kt
@@ -183,7 +183,11 @@ internal class SdkCapabilityRegistry {
         "network.capture" to
           SdkCapabilityDescriptor("network.capture", SdkCapabilityState.SUPPORTED),
         "storage.read" to
-          SdkCapabilityDescriptor("storage.read", SdkCapabilityState.SUPPORTED),
+          SdkCapabilityDescriptor(
+            "storage.read",
+            SdkCapabilityState.UNSUPPORTED,
+            "No application-provided storage driver is registered",
+          ),
         "storage.mutation" to
           SdkCapabilityDescriptor(
             "storage.mutation",

--- a/android/auto-mobile-sdk/src/main/kotlin/dev/jasonpearson/automobile/sdk/capabilities/SdkCapabilities.kt
+++ b/android/auto-mobile-sdk/src/main/kotlin/dev/jasonpearson/automobile/sdk/capabilities/SdkCapabilities.kt
@@ -1,8 +1,8 @@
 package dev.jasonpearson.automobile.sdk.capabilities
 
-import kotlinx.serialization.Serializable
-import kotlinx.serialization.EncodeDefault
 import java.util.LinkedHashMap
+import kotlinx.serialization.EncodeDefault
+import kotlinx.serialization.Serializable
 
 /** The lifecycle or availability state of an SDK capability. */
 @Serializable
@@ -26,19 +26,15 @@ data class SdkCapabilityDescriptor(
 /** Explicit controls for potentially sensitive capture and mutation behavior. */
 @Serializable
 data class SdkCapturePolicy(
-  @EncodeDefault(EncodeDefault.Mode.ALWAYS)
-  val captureHeaders: Boolean = false,
-  @EncodeDefault(EncodeDefault.Mode.ALWAYS)
-  val captureBodies: Boolean = false,
-  @EncodeDefault(EncodeDefault.Mode.ALWAYS)
-  val allowMutations: Boolean = false,
+  @EncodeDefault(EncodeDefault.Mode.ALWAYS) val captureHeaders: Boolean = false,
+  @EncodeDefault(EncodeDefault.Mode.ALWAYS) val captureBodies: Boolean = false,
+  @EncodeDefault(EncodeDefault.Mode.ALWAYS) val allowMutations: Boolean = false,
 )
 
 /** Versioned machine-readable description of the SDK integration. */
 @Serializable
 data class SdkCapabilityDocument(
-  @EncodeDefault(EncodeDefault.Mode.ALWAYS)
-  val schemaVersion: Int = 1,
+  @EncodeDefault(EncodeDefault.Mode.ALWAYS) val schemaVersion: Int = 1,
   val capabilities: List<SdkCapabilityDescriptor>,
   val policy: SdkCapturePolicy,
 )
@@ -161,9 +157,9 @@ internal class SdkCapabilityRegistry {
   private fun revokePolicyFor(id: String) {
     policy =
       when (id) {
-        "network.capture" ->
-          policy.copy(captureHeaders = false, captureBodies = false)
-        "storage.mutation", "network.control" ->
+        "network.capture" -> policy.copy(captureHeaders = false, captureBodies = false)
+        "storage.mutation",
+        "network.control" ->
           if (isSupported("storage.mutation") || isSupported("network.control")) policy
           else policy.copy(allowMutations = false)
         else -> policy

--- a/android/auto-mobile-sdk/src/main/kotlin/dev/jasonpearson/automobile/sdk/capabilities/SdkCapabilities.kt
+++ b/android/auto-mobile-sdk/src/main/kotlin/dev/jasonpearson/automobile/sdk/capabilities/SdkCapabilities.kt
@@ -1,0 +1,162 @@
+package dev.jasonpearson.automobile.sdk.capabilities
+
+import kotlinx.serialization.Serializable
+import java.util.LinkedHashMap
+
+/** The lifecycle or availability state of an SDK capability. */
+@Serializable
+enum class SdkCapabilityState {
+  SUPPORTED,
+  DISABLED,
+  UNSUPPORTED,
+  PERMISSION_DENIED,
+  NOT_INITIALIZED,
+}
+
+/** A stable identifier and current availability state for one SDK capability. */
+@Serializable
+data class SdkCapabilityDescriptor(
+  val id: String,
+  val state: SdkCapabilityState,
+  val reason: String? = null,
+)
+
+/** Explicit controls for potentially sensitive capture and mutation behavior. */
+@Serializable
+data class SdkCapturePolicy(
+  val captureHeaders: Boolean = false,
+  val captureBodies: Boolean = false,
+  val allowMutations: Boolean = false,
+)
+
+/** Versioned machine-readable description of the SDK integration. */
+@Serializable
+data class SdkCapabilityDocument(
+  val schemaVersion: Int = 1,
+  val capabilities: List<SdkCapabilityDescriptor>,
+  val policy: SdkCapturePolicy,
+)
+
+/**
+ * Thread-safe capability and policy registry.
+ *
+ * Registration replaces an existing descriptor with the same id. Policy changes replace the
+ * complete immutable policy snapshot after validating that sensitive access has an available
+ * capability.
+ */
+internal class SdkCapabilityRegistry {
+  private val lock = Any()
+  private val descriptors = LinkedHashMap<String, SdkCapabilityDescriptor>()
+  private var initialized = false
+  private var enabled = true
+  private var policy = SdkCapturePolicy()
+
+  init {
+    registerDefaults()
+  }
+
+  fun markInitialized() {
+    synchronized(lock) { initialized = true }
+  }
+
+  fun markShutdown() {
+    synchronized(lock) {
+      initialized = false
+      enabled = true
+      policy = SdkCapturePolicy()
+      descriptors.clear()
+      registerDefaults()
+    }
+  }
+
+  fun setEnabled(value: Boolean) {
+    synchronized(lock) { enabled = value }
+  }
+
+  fun register(descriptor: SdkCapabilityDescriptor) {
+    require(descriptor.id.isNotBlank()) { "Capability id must not be blank" }
+    synchronized(lock) { descriptors[descriptor.id] = descriptor }
+  }
+
+  fun unregister(id: String) {
+    synchronized(lock) { descriptors.remove(id) }
+  }
+
+  fun updatePolicy(next: SdkCapturePolicy) {
+    synchronized(lock) {
+      if (next.allowMutations) {
+        require(isSupported("storage.mutation")) {
+          "Mutation access requires the storage.mutation capability"
+        }
+      }
+      if (next.captureHeaders || next.captureBodies) {
+        require(isSupported("network.capture")) {
+          "Payload or header capture requires the network.capture capability"
+        }
+      }
+      policy = next
+    }
+  }
+
+  fun snapshot(): SdkCapabilityDocument {
+    synchronized(lock) {
+      val visible =
+        descriptors.values.map { descriptor ->
+          when {
+            !initialized && descriptor.state != SdkCapabilityState.UNSUPPORTED ->
+              descriptor.copy(
+                state = SdkCapabilityState.NOT_INITIALIZED,
+                reason = "SDK has not been initialized",
+              )
+            !enabled && descriptor.state == SdkCapabilityState.SUPPORTED ->
+              descriptor.copy(
+                state = SdkCapabilityState.DISABLED,
+                reason = "SDK tracking is disabled",
+              )
+            else -> descriptor
+          }
+        }
+      return SdkCapabilityDocument(capabilities = visible, policy = policy)
+    }
+  }
+
+  private fun isSupported(id: String): Boolean {
+    val descriptor = descriptors[id]
+    return initialized && enabled && descriptor?.state == SdkCapabilityState.SUPPORTED
+  }
+
+  private fun registerDefaults() {
+    descriptors["events.navigation"] =
+      SdkCapabilityDescriptor("events.navigation", SdkCapabilityState.SUPPORTED)
+    descriptors["events.lifecycle"] =
+      SdkCapabilityDescriptor("events.lifecycle", SdkCapabilityState.SUPPORTED)
+    descriptors["network.capture"] =
+      SdkCapabilityDescriptor("network.capture", SdkCapabilityState.SUPPORTED)
+    descriptors["storage.read"] =
+      SdkCapabilityDescriptor("storage.read", SdkCapabilityState.SUPPORTED)
+    descriptors["storage.mutation"] =
+      SdkCapabilityDescriptor(
+        "storage.mutation",
+        SdkCapabilityState.UNSUPPORTED,
+        "No application-provided storage driver is registered",
+      )
+    descriptors["ui.observe"] =
+      SdkCapabilityDescriptor(
+        "ui.observe",
+        SdkCapabilityState.UNSUPPORTED,
+        "No UI observation hook is registered",
+      )
+    descriptors["ui.control"] =
+      SdkCapabilityDescriptor(
+        "ui.control",
+        SdkCapabilityState.UNSUPPORTED,
+        "No UI control hook is registered",
+      )
+    descriptors["network.control"] =
+      SdkCapabilityDescriptor(
+        "network.control",
+        SdkCapabilityState.UNSUPPORTED,
+        "No network control hook is registered",
+      )
+  }
+}

--- a/android/auto-mobile-sdk/src/main/kotlin/dev/jasonpearson/automobile/sdk/capabilities/SdkCapabilities.kt
+++ b/android/auto-mobile-sdk/src/main/kotlin/dev/jasonpearson/automobile/sdk/capabilities/SdkCapabilities.kt
@@ -110,8 +110,8 @@ internal class SdkCapabilityRegistry {
   fun updatePolicy(next: SdkCapturePolicy) {
     synchronized(lock) {
       if (next.allowMutations) {
-        require(isSupported("storage.mutation")) {
-          "Mutation access requires the storage.mutation capability"
+        require(isSupported("storage.mutation") || isSupported("network.control")) {
+          "Mutation access requires a storage.mutation or network.control capability"
         }
       }
       if (next.captureHeaders || next.captureBodies) {
@@ -152,6 +152,8 @@ internal class SdkCapabilityRegistry {
     return initialized && enabled && descriptor?.state == SdkCapabilityState.SUPPORTED
   }
 
+  fun isCapabilitySupported(id: String): Boolean = synchronized(lock) { isSupported(id) }
+
   private fun registerDefaults() {
     defaultDescriptors.forEach { (id, descriptor) -> descriptors[id] = descriptor }
   }
@@ -162,7 +164,8 @@ internal class SdkCapabilityRegistry {
         "network.capture" ->
           policy.copy(captureHeaders = false, captureBodies = false)
         "storage.mutation", "network.control" ->
-          policy.copy(allowMutations = false)
+          if (isSupported("storage.mutation") || isSupported("network.control")) policy
+          else policy.copy(allowMutations = false)
         else -> policy
       }
   }

--- a/android/auto-mobile-sdk/src/main/kotlin/dev/jasonpearson/automobile/sdk/capabilities/SdkCapabilities.kt
+++ b/android/auto-mobile-sdk/src/main/kotlin/dev/jasonpearson/automobile/sdk/capabilities/SdkCapabilities.kt
@@ -1,6 +1,7 @@
 package dev.jasonpearson.automobile.sdk.capabilities
 
 import kotlinx.serialization.Serializable
+import kotlinx.serialization.EncodeDefault
 import java.util.LinkedHashMap
 
 /** The lifecycle or availability state of an SDK capability. */
@@ -11,6 +12,7 @@ enum class SdkCapabilityState {
   UNSUPPORTED,
   PERMISSION_DENIED,
   NOT_INITIALIZED,
+  UNKNOWN,
 }
 
 /** A stable identifier and current availability state for one SDK capability. */
@@ -24,14 +26,18 @@ data class SdkCapabilityDescriptor(
 /** Explicit controls for potentially sensitive capture and mutation behavior. */
 @Serializable
 data class SdkCapturePolicy(
+  @EncodeDefault(EncodeDefault.Mode.ALWAYS)
   val captureHeaders: Boolean = false,
+  @EncodeDefault(EncodeDefault.Mode.ALWAYS)
   val captureBodies: Boolean = false,
+  @EncodeDefault(EncodeDefault.Mode.ALWAYS)
   val allowMutations: Boolean = false,
 )
 
 /** Versioned machine-readable description of the SDK integration. */
 @Serializable
 data class SdkCapabilityDocument(
+  @EncodeDefault(EncodeDefault.Mode.ALWAYS)
   val schemaVersion: Int = 1,
   val capabilities: List<SdkCapabilityDescriptor>,
   val policy: SdkCapturePolicy,
@@ -59,6 +65,13 @@ internal class SdkCapabilityRegistry {
     synchronized(lock) { initialized = true }
   }
 
+  fun markLifecycleReady() {
+    synchronized(lock) {
+      descriptors["events.lifecycle"] =
+        SdkCapabilityDescriptor("events.lifecycle", SdkCapabilityState.SUPPORTED)
+    }
+  }
+
   fun markShutdown() {
     synchronized(lock) {
       initialized = false
@@ -75,11 +88,23 @@ internal class SdkCapabilityRegistry {
 
   fun register(descriptor: SdkCapabilityDescriptor) {
     require(descriptor.id.isNotBlank()) { "Capability id must not be blank" }
-    synchronized(lock) { descriptors[descriptor.id] = descriptor }
+    synchronized(lock) {
+      require(descriptor.id !in reservedCapabilities || descriptor.id in hostManagedCapabilities) {
+        "Capability ${descriptor.id} is managed by the SDK"
+      }
+      descriptors[descriptor.id] = descriptor
+    }
   }
 
   fun unregister(id: String) {
-    synchronized(lock) { descriptors.remove(id) }
+    synchronized(lock) {
+      if (id in defaultDescriptors) {
+        descriptors[id] = defaultDescriptors.getValue(id)
+        revokePolicyFor(id)
+      } else {
+        descriptors.remove(id)
+      }
+    }
   }
 
   fun updatePolicy(next: SdkCapturePolicy) {
@@ -120,43 +145,70 @@ internal class SdkCapabilityRegistry {
     }
   }
 
+  fun currentPolicy(): SdkCapturePolicy = synchronized(lock) { policy }
+
   private fun isSupported(id: String): Boolean {
     val descriptor = descriptors[id]
     return initialized && enabled && descriptor?.state == SdkCapabilityState.SUPPORTED
   }
 
   private fun registerDefaults() {
-    descriptors["events.navigation"] =
-      SdkCapabilityDescriptor("events.navigation", SdkCapabilityState.SUPPORTED)
-    descriptors["events.lifecycle"] =
-      SdkCapabilityDescriptor("events.lifecycle", SdkCapabilityState.SUPPORTED)
-    descriptors["network.capture"] =
-      SdkCapabilityDescriptor("network.capture", SdkCapabilityState.SUPPORTED)
-    descriptors["storage.read"] =
-      SdkCapabilityDescriptor("storage.read", SdkCapabilityState.SUPPORTED)
-    descriptors["storage.mutation"] =
-      SdkCapabilityDescriptor(
-        "storage.mutation",
-        SdkCapabilityState.UNSUPPORTED,
-        "No application-provided storage driver is registered",
+    defaultDescriptors.forEach { (id, descriptor) -> descriptors[id] = descriptor }
+  }
+
+  private fun revokePolicyFor(id: String) {
+    policy =
+      when (id) {
+        "network.capture" ->
+          policy.copy(captureHeaders = false, captureBodies = false)
+        "storage.mutation", "network.control" ->
+          policy.copy(allowMutations = false)
+        else -> policy
+      }
+  }
+
+  private companion object {
+    val hostManagedCapabilities =
+      setOf("storage.mutation", "ui.observe", "ui.control", "network.control")
+    val defaultDescriptors =
+      linkedMapOf(
+        "events.navigation" to
+          SdkCapabilityDescriptor("events.navigation", SdkCapabilityState.SUPPORTED),
+        "events.lifecycle" to
+          SdkCapabilityDescriptor(
+            "events.lifecycle",
+            SdkCapabilityState.UNSUPPORTED,
+            "Lifecycle hook has not been installed",
+          ),
+        "network.capture" to
+          SdkCapabilityDescriptor("network.capture", SdkCapabilityState.SUPPORTED),
+        "storage.read" to
+          SdkCapabilityDescriptor("storage.read", SdkCapabilityState.SUPPORTED),
+        "storage.mutation" to
+          SdkCapabilityDescriptor(
+            "storage.mutation",
+            SdkCapabilityState.UNSUPPORTED,
+            "No application-provided storage driver is registered",
+          ),
+        "ui.observe" to
+          SdkCapabilityDescriptor(
+            "ui.observe",
+            SdkCapabilityState.UNSUPPORTED,
+            "No UI observation hook is registered",
+          ),
+        "ui.control" to
+          SdkCapabilityDescriptor(
+            "ui.control",
+            SdkCapabilityState.UNSUPPORTED,
+            "No UI control hook is registered",
+          ),
+        "network.control" to
+          SdkCapabilityDescriptor(
+            "network.control",
+            SdkCapabilityState.UNSUPPORTED,
+            "No network control hook is registered",
+          ),
       )
-    descriptors["ui.observe"] =
-      SdkCapabilityDescriptor(
-        "ui.observe",
-        SdkCapabilityState.UNSUPPORTED,
-        "No UI observation hook is registered",
-      )
-    descriptors["ui.control"] =
-      SdkCapabilityDescriptor(
-        "ui.control",
-        SdkCapabilityState.UNSUPPORTED,
-        "No UI control hook is registered",
-      )
-    descriptors["network.control"] =
-      SdkCapabilityDescriptor(
-        "network.control",
-        SdkCapabilityState.UNSUPPORTED,
-        "No network control hook is registered",
-      )
+    val reservedCapabilities = defaultDescriptors.keys
   }
 }

--- a/android/auto-mobile-sdk/src/main/kotlin/dev/jasonpearson/automobile/sdk/database/DatabaseError.kt
+++ b/android/auto-mobile-sdk/src/main/kotlin/dev/jasonpearson/automobile/sdk/database/DatabaseError.kt
@@ -16,4 +16,7 @@ sealed class DatabaseError(message: String) : Exception(message) {
 
   /** Database path is outside the app's data directory. */
   class InvalidPath(path: String) : DatabaseError("Invalid database path: $path")
+
+  /** A mutating statement was rejected by the SDK capture policy. */
+  class MutationNotAllowed : DatabaseError("Database mutations are disabled by SDK policy")
 }

--- a/android/auto-mobile-sdk/src/main/kotlin/dev/jasonpearson/automobile/sdk/database/SQLiteDatabaseDriver.kt
+++ b/android/auto-mobile-sdk/src/main/kotlin/dev/jasonpearson/automobile/sdk/database/SQLiteDatabaseDriver.kt
@@ -161,6 +161,12 @@ class SQLiteDatabaseDriver(private val context: Context) : DatabaseDriver {
     }
   }
 
+  /** Returns whether executing this statement can mutate the database. */
+  internal fun isMutationQuery(query: String): Boolean {
+    val (returnsRows, readOnly) = classifySQL(query.trim())
+    return !returnsRows && !readOnly
+  }
+
   private fun classifySQL(query: String): Pair<Boolean, Boolean> {
     val statement = findTopLevelStatement(query)
     val keyword = statement?.first ?: return Pair(false, false)

--- a/android/auto-mobile-sdk/src/main/kotlin/dev/jasonpearson/automobile/sdk/network/AutoMobileNetwork.kt
+++ b/android/auto-mobile-sdk/src/main/kotlin/dev/jasonpearson/automobile/sdk/network/AutoMobileNetwork.kt
@@ -2,6 +2,7 @@ package dev.jasonpearson.automobile.sdk.network
 
 import dev.jasonpearson.automobile.protocol.SdkNetworkRequestEvent
 import dev.jasonpearson.automobile.sdk.events.SdkEventBuffer
+import dev.jasonpearson.automobile.sdk.capabilities.SdkCapturePolicy
 import okhttp3.Interceptor
 import okhttp3.WebSocketListener
 
@@ -62,6 +63,7 @@ object AutoMobileNetwork {
   @Volatile private var buffer: SdkEventBuffer? = null
   @Volatile private var applicationId: String? = null
   @Volatile private var ruleStore: NetworkMockRuleStore.RuleMatcher? = null
+  @Volatile private var capturePolicyProvider: (() -> SdkCapturePolicy)? = null
 
   /**
    * Initialize the network module with a shared event buffer.
@@ -78,6 +80,10 @@ object AutoMobileNetwork {
     this.applicationId = applicationId
     this.buffer = buffer
     this.ruleStore = ruleStore
+  }
+
+  internal fun setCapturePolicyProvider(provider: (() -> SdkCapturePolicy)?) {
+    capturePolicyProvider = provider
   }
 
   /**
@@ -102,6 +108,7 @@ object AutoMobileNetwork {
       captureHeaders,
       captureBodies,
       ruleStore = ruleStore,
+      policyProvider = capturePolicyProvider,
     )
   }
 
@@ -121,6 +128,9 @@ object AutoMobileNetwork {
     captureBodies: Boolean = false,
   ) {
     val buf = buffer ?: return
+    val policy = capturePolicyProvider?.invoke()
+    val headersEnabled = captureHeaders && (policy?.captureHeaders ?: true)
+    val bodiesEnabled = captureBodies && (policy?.captureBodies ?: true)
     val parsedUrl =
       if (record.host == null || record.path == null) {
         try {
@@ -144,10 +154,10 @@ object AutoMobileNetwork {
         host = host,
         path = path,
         error = record.error,
-        requestHeaders = if (captureHeaders) record.requestHeaders else null,
-        responseHeaders = if (captureHeaders) record.responseHeaders else null,
-        requestBody = if (captureBodies) record.requestBody else null,
-        responseBody = if (captureBodies) record.responseBody else null,
+        requestHeaders = if (headersEnabled) record.requestHeaders else null,
+        responseHeaders = if (headersEnabled) record.responseHeaders else null,
+        requestBody = if (bodiesEnabled) record.requestBody else null,
+        responseBody = if (bodiesEnabled) record.responseBody else null,
         contentType = record.contentType,
       )
     )
@@ -170,5 +180,6 @@ object AutoMobileNetwork {
     buffer = null
     applicationId = null
     ruleStore = null
+    capturePolicyProvider = null
   }
 }

--- a/android/auto-mobile-sdk/src/main/kotlin/dev/jasonpearson/automobile/sdk/network/AutoMobileNetwork.kt
+++ b/android/auto-mobile-sdk/src/main/kotlin/dev/jasonpearson/automobile/sdk/network/AutoMobileNetwork.kt
@@ -1,8 +1,8 @@
 package dev.jasonpearson.automobile.sdk.network
 
 import dev.jasonpearson.automobile.protocol.SdkNetworkRequestEvent
-import dev.jasonpearson.automobile.sdk.events.SdkEventBuffer
 import dev.jasonpearson.automobile.sdk.capabilities.SdkCapturePolicy
+import dev.jasonpearson.automobile.sdk.events.SdkEventBuffer
 import okhttp3.Interceptor
 import okhttp3.WebSocketListener
 

--- a/android/auto-mobile-sdk/src/main/kotlin/dev/jasonpearson/automobile/sdk/network/AutoMobileNetwork.kt
+++ b/android/auto-mobile-sdk/src/main/kotlin/dev/jasonpearson/automobile/sdk/network/AutoMobileNetwork.kt
@@ -64,6 +64,7 @@ object AutoMobileNetwork {
   @Volatile private var applicationId: String? = null
   @Volatile private var ruleStore: NetworkMockRuleStore.RuleMatcher? = null
   @Volatile private var capturePolicyProvider: (() -> SdkCapturePolicy)? = null
+  @Volatile private var networkControlProvider: (() -> Boolean)? = null
 
   /**
    * Initialize the network module with a shared event buffer.
@@ -84,6 +85,10 @@ object AutoMobileNetwork {
 
   internal fun setCapturePolicyProvider(provider: (() -> SdkCapturePolicy)?) {
     capturePolicyProvider = provider
+  }
+
+  internal fun setNetworkControlProvider(provider: (() -> Boolean)?) {
+    networkControlProvider = provider
   }
 
   /**
@@ -109,6 +114,7 @@ object AutoMobileNetwork {
       captureBodies,
       ruleStore = ruleStore,
       policyProvider = capturePolicyProvider,
+      networkControlProvider = networkControlProvider,
     )
   }
 
@@ -181,5 +187,6 @@ object AutoMobileNetwork {
     applicationId = null
     ruleStore = null
     capturePolicyProvider = null
+    networkControlProvider = null
   }
 }

--- a/android/auto-mobile-sdk/src/main/kotlin/dev/jasonpearson/automobile/sdk/network/AutoMobileNetworkInterceptor.kt
+++ b/android/auto-mobile-sdk/src/main/kotlin/dev/jasonpearson/automobile/sdk/network/AutoMobileNetworkInterceptor.kt
@@ -40,6 +40,7 @@ internal class AutoMobileNetworkInterceptor(
   /** Optional rule store for mock enforcement and error simulation */
   private val ruleStore: NetworkMockRuleStore.RuleMatcher? = null,
   private val policyProvider: (() -> SdkCapturePolicy)? = null,
+  private val networkControlProvider: (() -> Boolean)? = null,
 ) : Interceptor {
 
   companion object {
@@ -70,6 +71,8 @@ internal class AutoMobileNetworkInterceptor(
     val headersEnabled = captureHeaders && (policy?.captureHeaders ?: true)
     val bodiesEnabled = captureBodies && (policy?.captureBodies ?: true)
     val mutationsEnabled = policy?.allowMutations ?: true
+    val networkControlEnabled =
+      if (policy == null) true else networkControlProvider?.invoke() == true
 
     // Capture request headers — include OkHttp defaults that will be added later
     val reqHeaders =
@@ -88,7 +91,7 @@ internal class AutoMobileNetworkInterceptor(
 
     // --- Mock rule enforcement ---
     val mockRule =
-      if (mutationsEnabled) {
+      if (mutationsEnabled && networkControlEnabled) {
         ruleStore?.findMatchingRule(request.url.host, request.url.encodedPath, request.method)
       } else null
     if (mockRule != null) {
@@ -116,7 +119,8 @@ internal class AutoMobileNetworkInterceptor(
     }
 
     // --- Error simulation enforcement ---
-    val errorSim = if (mutationsEnabled) ruleStore?.getErrorSimulation() else null
+    val errorSim =
+      if (mutationsEnabled && networkControlEnabled) ruleStore?.getErrorSimulation() else null
     if (errorSim != null) {
       val durationMs = System.currentTimeMillis() - startMs
       return handleErrorSimulation(request, errorSim, startMs, durationMs, reqHeaders, reqBody)

--- a/android/auto-mobile-sdk/src/main/kotlin/dev/jasonpearson/automobile/sdk/network/AutoMobileNetworkInterceptor.kt
+++ b/android/auto-mobile-sdk/src/main/kotlin/dev/jasonpearson/automobile/sdk/network/AutoMobileNetworkInterceptor.kt
@@ -1,8 +1,8 @@
 package dev.jasonpearson.automobile.sdk.network
 
 import dev.jasonpearson.automobile.protocol.SdkNetworkRequestEvent
-import dev.jasonpearson.automobile.sdk.events.SdkEventBuffer
 import dev.jasonpearson.automobile.sdk.capabilities.SdkCapturePolicy
+import dev.jasonpearson.automobile.sdk.events.SdkEventBuffer
 import java.net.ConnectException
 import java.net.SocketTimeoutException
 import java.net.UnknownHostException

--- a/android/auto-mobile-sdk/src/main/kotlin/dev/jasonpearson/automobile/sdk/network/AutoMobileNetworkInterceptor.kt
+++ b/android/auto-mobile-sdk/src/main/kotlin/dev/jasonpearson/automobile/sdk/network/AutoMobileNetworkInterceptor.kt
@@ -111,7 +111,7 @@ internal class AutoMobileNetworkInterceptor(
           error = "mocked:${mockRule.mockId}",
           requestHeaders = reqHeaders,
           requestBody = reqBody,
-          responseBody = mockRule.responseBody,
+          responseBody = if (bodiesEnabled) mockRule.responseBody else null,
           contentType = mockRule.contentType,
         )
       )

--- a/android/auto-mobile-sdk/src/main/kotlin/dev/jasonpearson/automobile/sdk/network/AutoMobileNetworkInterceptor.kt
+++ b/android/auto-mobile-sdk/src/main/kotlin/dev/jasonpearson/automobile/sdk/network/AutoMobileNetworkInterceptor.kt
@@ -2,6 +2,7 @@ package dev.jasonpearson.automobile.sdk.network
 
 import dev.jasonpearson.automobile.protocol.SdkNetworkRequestEvent
 import dev.jasonpearson.automobile.sdk.events.SdkEventBuffer
+import dev.jasonpearson.automobile.sdk.capabilities.SdkCapturePolicy
 import java.net.ConnectException
 import java.net.SocketTimeoutException
 import java.net.UnknownHostException
@@ -38,6 +39,7 @@ internal class AutoMobileNetworkInterceptor(
   private val maxBodyBytes: Long = MAX_BODY_BYTES,
   /** Optional rule store for mock enforcement and error simulation */
   private val ruleStore: NetworkMockRuleStore.RuleMatcher? = null,
+  private val policyProvider: (() -> SdkCapturePolicy)? = null,
 ) : Interceptor {
 
   companion object {
@@ -64,10 +66,14 @@ internal class AutoMobileNetworkInterceptor(
   override fun intercept(chain: Interceptor.Chain): Response {
     val request = chain.request()
     val startMs = System.currentTimeMillis()
+    val policy = policyProvider?.invoke()
+    val headersEnabled = captureHeaders && (policy?.captureHeaders ?: true)
+    val bodiesEnabled = captureBodies && (policy?.captureBodies ?: true)
+    val mutationsEnabled = policy?.allowMutations ?: true
 
     // Capture request headers — include OkHttp defaults that will be added later
     val reqHeaders =
-      if (captureHeaders) {
+      if (headersEnabled) {
         val headers = request.headers.toHeaderMap().toMutableMap()
         if ("Host" !in headers) headers["Host"] = request.url.host
         if ("User-Agent" !in headers) headers["User-Agent"] = "okhttp/${okhttp3.OkHttp.VERSION}"
@@ -76,13 +82,15 @@ internal class AutoMobileNetworkInterceptor(
 
     // Capture request body
     val reqBody =
-      if (captureBodies && request.body != null) {
+      if (bodiesEnabled && request.body != null) {
         captureRequestBody(request)
       } else null
 
     // --- Mock rule enforcement ---
     val mockRule =
-      ruleStore?.findMatchingRule(request.url.host, request.url.encodedPath, request.method)
+      if (mutationsEnabled) {
+        ruleStore?.findMatchingRule(request.url.host, request.url.encodedPath, request.method)
+      } else null
     if (mockRule != null) {
       val durationMs = System.currentTimeMillis() - startMs
       buffer.add(
@@ -108,7 +116,7 @@ internal class AutoMobileNetworkInterceptor(
     }
 
     // --- Error simulation enforcement ---
-    val errorSim = ruleStore?.getErrorSimulation()
+    val errorSim = if (mutationsEnabled) ruleStore?.getErrorSimulation() else null
     if (errorSim != null) {
       val durationMs = System.currentTimeMillis() - startMs
       return handleErrorSimulation(request, errorSim, startMs, durationMs, reqHeaders, reqBody)
@@ -144,17 +152,17 @@ internal class AutoMobileNetworkInterceptor(
     val responseContentType = response.header("Content-Type")
 
     val finalReqHeaders =
-      if (captureHeaders) {
+      if (headersEnabled) {
         response.request.headers.toHeaderMap()
       } else reqHeaders
 
     val respHeaders =
-      if (captureHeaders) {
+      if (headersEnabled) {
         response.headers.toHeaderMap()
       } else null
 
     val respBody =
-      if (captureBodies && isTextContentType(responseContentType)) {
+      if (bodiesEnabled && isTextContentType(responseContentType)) {
         try {
           response.peekBody(maxBodyBytes).string()
         } catch (_: Exception) {

--- a/android/auto-mobile-sdk/src/main/kotlin/dev/jasonpearson/automobile/sdk/storage/SharedPreferencesError.kt
+++ b/android/auto-mobile-sdk/src/main/kotlin/dev/jasonpearson/automobile/sdk/storage/SharedPreferencesError.kt
@@ -18,4 +18,8 @@ sealed class SharedPreferencesError(message: String) : Exception(message) {
   /** Invalid type for value. */
   class InvalidType(type: String, reason: String) :
     SharedPreferencesError("Invalid type $type: $reason")
+
+  /** A mutating operation was rejected by the SDK capture policy. */
+  class MutationNotAllowed :
+    SharedPreferencesError("SharedPreferences mutations are disabled by SDK policy")
 }

--- a/android/auto-mobile-sdk/src/test/kotlin/dev/jasonpearson/automobile/sdk/capabilities/SdkCapabilityRegistryTest.kt
+++ b/android/auto-mobile-sdk/src/test/kotlin/dev/jasonpearson/automobile/sdk/capabilities/SdkCapabilityRegistryTest.kt
@@ -1,10 +1,10 @@
 package dev.jasonpearson.automobile.sdk.capabilities
 
+import kotlinx.serialization.encodeToString
+import kotlinx.serialization.json.Json
 import org.junit.Assert.assertEquals
 import org.junit.Assert.assertFalse
 import org.junit.Assert.assertTrue
-import kotlinx.serialization.encodeToString
-import kotlinx.serialization.json.Json
 import org.junit.Test
 
 class SdkCapabilityRegistryTest {
@@ -90,7 +90,8 @@ class SdkCapabilityRegistryTest {
 
   @Test
   fun `default serialization includes the schema version and false policy values`() {
-    val json = Json.encodeToString(SdkCapabilityDocument.serializer(), SdkCapabilityRegistry().snapshot())
+    val json =
+      Json.encodeToString(SdkCapabilityDocument.serializer(), SdkCapabilityRegistry().snapshot())
 
     assertTrue(json.contains("\"schemaVersion\":1"))
     assertTrue(json.contains("\"captureHeaders\":false"))

--- a/android/auto-mobile-sdk/src/test/kotlin/dev/jasonpearson/automobile/sdk/capabilities/SdkCapabilityRegistryTest.kt
+++ b/android/auto-mobile-sdk/src/test/kotlin/dev/jasonpearson/automobile/sdk/capabilities/SdkCapabilityRegistryTest.kt
@@ -1,0 +1,92 @@
+package dev.jasonpearson.automobile.sdk.capabilities
+
+import org.junit.Assert.assertEquals
+import org.junit.Assert.assertFalse
+import org.junit.Assert.assertTrue
+import org.junit.Test
+
+class SdkCapabilityRegistryTest {
+  @Test
+  fun `capabilities are distinct before and after initialization`() {
+    val registry = SdkCapabilityRegistry()
+
+    assertEquals(
+      SdkCapabilityState.NOT_INITIALIZED,
+      registry.snapshot().capabilities.first { it.id == "network.capture" }.state,
+    )
+
+    registry.markInitialized()
+
+    assertEquals(
+      SdkCapabilityState.SUPPORTED,
+      registry.snapshot().capabilities.first { it.id == "network.capture" }.state,
+    )
+  }
+
+  @Test
+  fun `disabled state is distinct from unsupported state`() {
+    val registry = SdkCapabilityRegistry()
+    registry.markInitialized()
+    registry.setEnabled(false)
+
+    assertEquals(
+      SdkCapabilityState.DISABLED,
+      registry.snapshot().capabilities.first { it.id == "network.capture" }.state,
+    )
+    assertEquals(
+      SdkCapabilityState.UNSUPPORTED,
+      registry.snapshot().capabilities.first { it.id == "ui.observe" }.state,
+    )
+  }
+
+  @Test
+  fun `registration and removal update the document`() {
+    val registry = SdkCapabilityRegistry()
+    registry.markInitialized()
+    registry.register(SdkCapabilityDescriptor("navigation.compose", SdkCapabilityState.SUPPORTED))
+
+    assertTrue(registry.snapshot().capabilities.any { it.id == "navigation.compose" })
+
+    registry.unregister("navigation.compose")
+
+    assertFalse(registry.snapshot().capabilities.any { it.id == "navigation.compose" })
+  }
+
+  @Test
+  fun `policy changes are complete atomic snapshots`() {
+    val registry = SdkCapabilityRegistry()
+    registry.markInitialized()
+
+    registry.updatePolicy(SdkCapturePolicy(captureHeaders = true, captureBodies = true))
+
+    assertEquals(
+      SdkCapturePolicy(captureHeaders = true, captureBodies = true),
+      registry.snapshot().policy,
+    )
+  }
+
+  @Test(expected = IllegalArgumentException::class)
+  fun `mutation policy requires a registered mutation capability`() {
+    val registry = SdkCapabilityRegistry()
+    registry.markInitialized()
+
+    registry.updatePolicy(SdkCapturePolicy(allowMutations = true))
+  }
+
+  @Test
+  fun `registered permission denial is preserved`() {
+    val registry = SdkCapabilityRegistry()
+    registry.markInitialized()
+    registry.register(
+      SdkCapabilityDescriptor(
+        "network.control",
+        SdkCapabilityState.PERMISSION_DENIED,
+        "Host did not grant control permission",
+      )
+    )
+
+    val descriptor = registry.snapshot().capabilities.first { it.id == "network.control" }
+    assertEquals(SdkCapabilityState.PERMISSION_DENIED, descriptor.state)
+    assertEquals("Host did not grant control permission", descriptor.reason)
+  }
+}

--- a/android/auto-mobile-sdk/src/test/kotlin/dev/jasonpearson/automobile/sdk/capabilities/SdkCapabilityRegistryTest.kt
+++ b/android/auto-mobile-sdk/src/test/kotlin/dev/jasonpearson/automobile/sdk/capabilities/SdkCapabilityRegistryTest.kt
@@ -3,6 +3,8 @@ package dev.jasonpearson.automobile.sdk.capabilities
 import org.junit.Assert.assertEquals
 import org.junit.Assert.assertFalse
 import org.junit.Assert.assertTrue
+import kotlinx.serialization.encodeToString
+import kotlinx.serialization.json.Json
 import org.junit.Test
 
 class SdkCapabilityRegistryTest {
@@ -50,6 +52,46 @@ class SdkCapabilityRegistryTest {
     registry.unregister("navigation.compose")
 
     assertFalse(registry.snapshot().capabilities.any { it.id == "navigation.compose" })
+  }
+
+  @Test
+  fun `removing a capability revokes its policy`() {
+    val registry = SdkCapabilityRegistry()
+    registry.markInitialized()
+    registry.register(SdkCapabilityDescriptor("storage.mutation", SdkCapabilityState.SUPPORTED))
+    registry.updatePolicy(SdkCapturePolicy(allowMutations = true))
+
+    registry.unregister("storage.mutation")
+
+    assertFalse(registry.snapshot().policy.allowMutations)
+  }
+
+  @Test
+  fun `lifecycle remains unavailable until its hook is installed`() {
+    val registry = SdkCapabilityRegistry()
+    registry.markInitialized()
+
+    assertEquals(
+      SdkCapabilityState.UNSUPPORTED,
+      registry.snapshot().capabilities.first { it.id == "events.lifecycle" }.state,
+    )
+
+    registry.markLifecycleReady()
+
+    assertEquals(
+      SdkCapabilityState.SUPPORTED,
+      registry.snapshot().capabilities.first { it.id == "events.lifecycle" }.state,
+    )
+  }
+
+  @Test
+  fun `default serialization includes the schema version and false policy values`() {
+    val json = Json.encodeToString(SdkCapabilityDocument.serializer(), SdkCapabilityRegistry().snapshot())
+
+    assertTrue(json.contains("\"schemaVersion\":1"))
+    assertTrue(json.contains("\"captureHeaders\":false"))
+    assertTrue(json.contains("\"captureBodies\":false"))
+    assertTrue(json.contains("\"allowMutations\":false"))
   }
 
   @Test

--- a/android/auto-mobile-sdk/src/test/kotlin/dev/jasonpearson/automobile/sdk/capabilities/SdkCapabilityRegistryTest.kt
+++ b/android/auto-mobile-sdk/src/test/kotlin/dev/jasonpearson/automobile/sdk/capabilities/SdkCapabilityRegistryTest.kt
@@ -39,6 +39,10 @@ class SdkCapabilityRegistryTest {
       SdkCapabilityState.UNSUPPORTED,
       registry.snapshot().capabilities.first { it.id == "ui.observe" }.state,
     )
+    assertEquals(
+      SdkCapabilityState.UNSUPPORTED,
+      registry.snapshot().capabilities.first { it.id == "storage.read" }.state,
+    )
   }
 
   @Test

--- a/android/auto-mobile-sdk/src/test/kotlin/dev/jasonpearson/automobile/sdk/capabilities/SdkCapabilityRegistryTest.kt
+++ b/android/auto-mobile-sdk/src/test/kotlin/dev/jasonpearson/automobile/sdk/capabilities/SdkCapabilityRegistryTest.kt
@@ -120,6 +120,17 @@ class SdkCapabilityRegistryTest {
   }
 
   @Test
+  fun `network control can authorize mutation policy independently`() {
+    val registry = SdkCapabilityRegistry()
+    registry.markInitialized()
+    registry.register(SdkCapabilityDescriptor("network.control", SdkCapabilityState.SUPPORTED))
+
+    registry.updatePolicy(SdkCapturePolicy(allowMutations = true))
+
+    assertTrue(registry.snapshot().policy.allowMutations)
+  }
+
+  @Test
   fun `registered permission denial is preserved`() {
     val registry = SdkCapabilityRegistry()
     registry.markInitialized()

--- a/android/auto-mobile-sdk/src/test/kotlin/dev/jasonpearson/automobile/sdk/network/AutoMobileNetworkTest.kt
+++ b/android/auto-mobile-sdk/src/test/kotlin/dev/jasonpearson/automobile/sdk/network/AutoMobileNetworkTest.kt
@@ -3,6 +3,7 @@ package dev.jasonpearson.automobile.sdk.network
 import dev.jasonpearson.automobile.protocol.SdkEvent
 import dev.jasonpearson.automobile.protocol.SdkNetworkRequestEvent
 import dev.jasonpearson.automobile.sdk.events.SdkEventBuffer
+import dev.jasonpearson.automobile.sdk.capabilities.SdkCapturePolicy
 import java.util.concurrent.Executors
 import kotlin.test.assertEquals
 import kotlin.test.assertNull
@@ -137,6 +138,29 @@ class AutoMobileNetworkTest {
     assertEquals(mapOf("X-Request-Id" to "abc"), event.responseHeaders)
     assertEquals("{\"name\":\"test\"}", event.requestBody)
     assertEquals("{\"id\":1}", event.responseBody)
+  }
+
+  @Test
+  fun `registered capture policy overrides per-call capture flags`() {
+    val (buffer, flushed) = collectingBuffer()
+    AutoMobileNetwork.initialize("com.example", buffer)
+    AutoMobileNetwork.setCapturePolicyProvider { SdkCapturePolicy() }
+
+    AutoMobileNetwork.recordRequest(
+      NetworkRequestRecord(
+        url = "https://api.example.com/users",
+        method = "POST",
+        requestHeaders = mapOf("Authorization" to "Bearer token"),
+        requestBody = "{\"name\":\"test\"}",
+      ),
+      captureHeaders = true,
+      captureBodies = true,
+    )
+    buffer.flush()
+
+    val event = flushed[0][0] as SdkNetworkRequestEvent
+    assertNull(event.requestHeaders)
+    assertNull(event.requestBody)
   }
 
   @Test

--- a/android/auto-mobile-sdk/src/test/kotlin/dev/jasonpearson/automobile/sdk/network/AutoMobileNetworkTest.kt
+++ b/android/auto-mobile-sdk/src/test/kotlin/dev/jasonpearson/automobile/sdk/network/AutoMobileNetworkTest.kt
@@ -2,8 +2,8 @@ package dev.jasonpearson.automobile.sdk.network
 
 import dev.jasonpearson.automobile.protocol.SdkEvent
 import dev.jasonpearson.automobile.protocol.SdkNetworkRequestEvent
-import dev.jasonpearson.automobile.sdk.events.SdkEventBuffer
 import dev.jasonpearson.automobile.sdk.capabilities.SdkCapturePolicy
+import dev.jasonpearson.automobile.sdk.events.SdkEventBuffer
 import java.util.concurrent.Executors
 import kotlin.test.assertEquals
 import kotlin.test.assertNull

--- a/docs/design-docs/plat/android/auto-mobile-sdk.md
+++ b/docs/design-docs/plat/android/auto-mobile-sdk.md
@@ -90,8 +90,8 @@ All builder parameters are validated with `require(value > 0)` at build time.
 
 `AutoMobileSDK.capabilities` returns a versioned, machine-readable snapshot of the integration.
 Each descriptor has a stable identifier, an availability state, and an optional reason. The
-states distinguish `NOT_INITIALIZED`, `DISABLED`, `UNSUPPORTED`, `PERMISSION_DENIED`, and
-`SUPPORTED`.
+states distinguish `NOT_INITIALIZED`, `DISABLED`, `UNSUPPORTED`, `PERMISSION_DENIED`, `SUPPORTED`,
+and `UNKNOWN`.
 
 Host integrations can register and remove optional descriptors with
 `registerCapability()` and `unregisterCapability()`. Capture and mutation controls are replaced

--- a/docs/design-docs/plat/android/auto-mobile-sdk.md
+++ b/docs/design-docs/plat/android/auto-mobile-sdk.md
@@ -96,8 +96,9 @@ and `UNKNOWN`.
 Host integrations can register and remove optional descriptors with
 `registerCapability()` and `unregisterCapability()`. Capture and mutation controls are replaced
 atomically through `updateCapturePolicy()`. Header and body capture default to disabled, and
-mutation access is rejected unless the host explicitly registers the `storage.mutation`
-capability. The default descriptors cover navigation and lifecycle events, network capture, and
+mutation access is rejected unless the host explicitly registers the capability for the operation:
+`storage.mutation` for storage providers or `network.control` for network mocks and error
+simulation. The default descriptors cover navigation and lifecycle events, network capture, and
 storage reads; optional UI, control, and storage-mutation capabilities start as unsupported.
 
 ## 2. Initialization and Lifecycle

--- a/docs/design-docs/plat/android/auto-mobile-sdk.md
+++ b/docs/design-docs/plat/android/auto-mobile-sdk.md
@@ -86,6 +86,20 @@ All builder parameters are validated with `require(value > 0)` at build time.
 | `AutoMobileConfiguration` | Builder-pattern config with validated defaults | <kbd>✅ Implemented</kbd> |
 | `AutoMobileConfiguration.Builder` | Fluent builder with `bufferSize`, `flushIntervalMs`, `maxBreadcrumbs`, `sessionTimeoutMs` | <kbd>✅ Implemented</kbd> |
 
+### Capability discovery and policy
+
+`AutoMobileSDK.capabilities` returns a versioned, machine-readable snapshot of the integration.
+Each descriptor has a stable identifier, an availability state, and an optional reason. The
+states distinguish `NOT_INITIALIZED`, `DISABLED`, `UNSUPPORTED`, `PERMISSION_DENIED`, and
+`SUPPORTED`.
+
+Host integrations can register and remove optional descriptors with
+`registerCapability()` and `unregisterCapability()`. Capture and mutation controls are replaced
+atomically through `updateCapturePolicy()`. Header and body capture default to disabled, and
+mutation access is rejected unless the host explicitly registers the `storage.mutation`
+capability. The default descriptors cover navigation and lifecycle events, network capture, and
+storage reads; optional UI, control, and storage-mutation capabilities start as unsupported.
+
 ## 2. Initialization and Lifecycle
 
 `AutoMobileSDK` is a Kotlin `object` (singleton). Initialization is split into two phases:


### PR DESCRIPTION
Closes #5063

Adds a versioned Android SDK capability document, optional capability registration/removal, distinct availability states, and atomic capture/mutation policy validation.

Validation:
- `:auto-mobile-sdk:testDebugUnitTest`
- `:auto-mobile-sdk:apiCheck`
- `bun run typecheck`
- `bun run turbo:validate`
- Android lint remains blocked by the pre-existing `SdkEventBuffer.kt:98` API-level warning.