### PR TITLE
build(android): de-cross-project group/version + centralManifest repo

### DIFF
--- a/android/build-logic/src/main/kotlin/automobile.kotlin-common.gradle.kts
+++ b/android/build-logic/src/main/kotlin/automobile.kotlin-common.gradle.kts
@@ -21,6 +21,16 @@ pluginManager.apply("automobile.detekt")
 
 pluginManager.apply("automobile.test-defaults")
 
+pluginManager.apply("automobile.maven-central-manifest")
+
+// Project coordinates for every module, sourced from the root gradle.properties.
+// Publishable modules read `project.version` in their mavenPublishing coordinates,
+// and sibling POM dependency GAVs use each module's group/version -- so these must
+// be set on all modules. Previously done by the root `allprojects {}` block.
+group = providers.gradleProperty("GROUP").get()
+
+version = providers.gradleProperty("VERSION_NAME").get()
+
 val libs = extensions.getByType<VersionCatalogsExtension>().named("libs")
 val kotlinLanguageVersion = libs.findVersion("build-kotlin-language").get().requiredVersion
 val javaTarget = libs.findVersion("build-java-target").get().requiredVersion

--- a/android/build-logic/src/main/kotlin/automobile.maven-central-manifest.gradle.kts
+++ b/android/build-logic/src/main/kotlin/automobile.maven-central-manifest.gradle.kts
@@ -1,0 +1,25 @@
+import org.gradle.api.publish.PublishingExtension
+import org.gradle.kotlin.dsl.configure
+
+// Preflight-only local Maven repository (issue #4853). When `-PmavenManifestStaging`
+// is set, publishing stages the exact release file set into
+// <rootDir>/build/central-manifest so the manifest preflight can enumerate it
+// deterministically -- no Maven Central credentials, no remote publish. The gate
+// keeps this off the real release path, whose `publish` lifecycle would otherwise
+// also write here.
+//
+// Resolving the staging dir from `rootDir` (build-level info) rather than the
+// `rootProject` model keeps this Isolated-Projects safe; it is the same
+// android/build/central-manifest directory the preflight script reads.
+pluginManager.withPlugin("com.vanniktech.maven.publish") {
+  if (providers.gradleProperty("mavenManifestStaging").isPresent) {
+    extensions.configure<PublishingExtension> {
+      repositories {
+        maven {
+          name = "centralManifest"
+          url = rootDir.resolve("build/central-manifest").toURI()
+        }
+      }
+    }
+  }
+}

--- a/android/build.gradle.kts
+++ b/android/build.gradle.kts
@@ -1,5 +1,4 @@
 import com.vanniktech.maven.publish.MavenPublishBaseExtension
-import org.gradle.api.publish.PublishingExtension
 import org.jetbrains.kotlin.gradle.tasks.KotlinCompile
 
 buildscript {
@@ -23,14 +22,12 @@ plugins {
   alias(libs.plugins.detekt) apply false
 }
 
-// Read version from gradle.properties
-val versionName: String = property("VERSION_NAME") as String
-val groupName: String = property("GROUP") as String
+// Read version from gradle.properties. Modules get their group/version from the
+// automobile.kotlin-common convention; the root project sets its own here (the
+// former `allprojects {}` block was an Isolated Projects blocker).
+group = property("GROUP") as String
 
-allprojects {
-  group = groupName
-  version = versionName
-}
+version = property("VERSION_NAME") as String
 
 plugins.withId(libs.plugins.mavenPublish.get().pluginId) {
   if (project.path != ":compiler") {
@@ -49,28 +46,6 @@ plugins.withId(libs.plugins.mavenPublish.get().pluginId) {
   }
 }
 
-// Local file repository used only by the Maven publication manifest preflight
-// (issue #4853). Publishing to it stages the exact set of files a release would
-// upload to Maven Central -- primary artifacts, POM, Gradle module metadata,
-// sources and javadoc jars, PGP signatures, and checksums -- into one directory
-// so the preflight can enumerate them deterministically, without Maven Central
-// credentials or a remote publish. It never uploads anywhere and has no effect on
-// the real Central publication path (publishAllPublicationsToMavenCentral...).
-allprojects {
-  plugins.withId("com.vanniktech.maven.publish") {
-    // Register only when the preflight asks for it (-PmavenManifestStaging). The
-    // production `publish` lifecycle task depends on the publish task of EVERY
-    // configured repository, so registering this unconditionally would make the
-    // real release also write to the local repo. Gating keeps it off that path.
-    if (providers.gradleProperty("mavenManifestStaging").isPresent) {
-      configure<PublishingExtension> {
-        repositories {
-          maven {
-            name = "centralManifest"
-            url = rootProject.layout.buildDirectory.dir("central-manifest").get().asFile.toURI()
-          }
-        }
-      }
-    }
-  }
-}
+// The Maven publication manifest preflight's local `centralManifest` repository
+// (issue #4853) moved to the automobile.maven-central-manifest convention so no
+// cross-project `allprojects {}` configuration remains here.

--- a/scripts/android/validate-kotlin-convention.sh
+++ b/scripts/android/validate-kotlin-convention.sh
@@ -54,10 +54,16 @@ if grep -qE '^subprojects \{' android/build.gradle.kts; then
   fail "android/build.gradle.kts still has a subprojects {} block (blocks Isolated Projects)"
 fi
 
-# 6. The detekt and test-defaults conventions exist.
-for conv in automobile.detekt automobile.test-defaults; do
+# 6. The detekt, test-defaults, and central-manifest conventions exist.
+for conv in automobile.detekt automobile.test-defaults automobile.maven-central-manifest; do
   [ -f "android/build-logic/src/main/kotlin/$conv.gradle.kts" ] ||
     fail "missing convention plugin: android/build-logic/src/main/kotlin/$conv.gradle.kts"
 done
+
+# 7. The root build no longer uses `allprojects {}` cross-project configuration
+#    (group/version + the centralManifest repo moved into conventions).
+if grep -qE '^allprojects \{' android/build.gradle.kts; then
+  fail "android/build.gradle.kts still has an allprojects {} block (blocks Isolated Projects)"
+fi
 
 echo "OK: Kotlin-compile convention is centralized in $CONVENTION"


### PR DESCRIPTION
## Summary

Item 3 of 5 in the `build-logic` → Isolated Projects migration (issue #5029; builds on #5054). Removes both root `allprojects {}` blocks — the last cross-project configuration besides junit-runner (item 4).

**⚠️ This one touches the Maven publishing / release path**, so it was validated with a byte-level oracle (below) rather than relying on CI (no required check covers publishing).

## Changes

- **group/version** — set on every module by the `automobile.kotlin-common` convention (from the root `gradle.properties` `GROUP`/`VERSION_NAME`); the root project sets its own at top level. Required because publishable modules read `project.version` in their `mavenPublishing` coordinates and sibling POM dependency GAVs use each module's group/version.
- **centralManifest preflight repo (#4853)** — moved into a new `automobile.maven-central-manifest` convention, resolving the staging dir from `rootDir` (build-level info, IP-safe) instead of the `rootProject` model. Same `android/build/central-manifest` directory the preflight reads.
- The inert root `plugins.withId("com.vanniktech.maven.publish")` block is **left untouched** — it's root-project scoped (root doesn't apply the plugin) and is not an IP violation. Empirically confirmed module publishing is driven by `gradle.properties` (`mavenCentralPublishing`/`RELEASE_SIGNING_ENABLED`) + each module's own `mavenPublishing{}` block, not by that block (e.g. `:protocol` has no dokka yet publishes a complete signed artifact set).

## Verification

- **Isolated Projects dry-run: 6 → 2 unique problems.** Both `allprojects` problems (group/version/plugins/providers) gone; only junit-runner's `layout` accesses remain (item 4).
- **`publishToMavenLocal` byte-identical:** `.pom` and `.module` for `:protocol` and `:junit-runner` are byte-for-byte identical to `main` — coordinates and inter-module dependency GAVs unchanged.
- **Manifest preflight passes:** `maven-publication-manifest-preflight.sh` stages all 4 publishable coordinates (240 files) to `android/build/central-manifest` via the new convention and ends `BUDGET OK`.
- `./gradlew help` configures cleanly; ktfmt tree-wide clean; shellcheck clean; structural guard (BATS) green.

## Notes

- No `src/`/TypeScript, DB, runner-protocol, or public-schema surface. No change to published artifact content (proven byte-identical).
- Unrelated context: "Publish Android Libraries Snapshot" has been failing on `main` independently of this migration (a CI signing-secret issue); this PR does not affect it either way.

Closes #5029
