### PR TITLE
feat(ios): add transport-neutral network capture adapters

### DIFF
--- a/docs/design-docs/api-surface/cross-platform-parity.md
+++ b/docs/design-docs/api-surface/cross-platform-parity.md
@@ -110,6 +110,7 @@ Side-by-side comparison of every public API symbol on Android and iOS.
 | `interceptor` | `interceptor()` (OkHttp) | -- | Android-only: OkHttp interceptor |
 | `protocolClass` | -- | `protocolClass()` (URLProtocol) | iOS-only: URLSession protocol |
 | `recordRequest` | -- | `recordRequest(...)` | iOS manual recording; Android uses interceptor |
+| `captureRecorder` | -- | `captureRecorder()` | iOS transport-neutral lifecycle recorder for custom HTTP, WebSocket, and Network.framework adapters |
 | `recordWebSocketFrame` | -- | `recordWebSocketFrame(...)` | iOS manual; Android wraps listener |
 | `wrapWebSocketListener` | `wrapWebSocketListener(...)` | -- | Android-only |
 | `setCaptureHeaders` | -- | `setCaptureHeaders(Bool)` | iOS-only config |

--- a/docs/design-docs/plat/ios/auto-mobile-sdk.md
+++ b/docs/design-docs/plat/ios/auto-mobile-sdk.md
@@ -247,6 +247,18 @@ Records non-fatal handled exceptions via `recordHandledException(_:message:curre
 
 2. **Manual recording** -- `recordRequest(url:method:...)` for cases where URLProtocol cannot be used. `recordWebSocketFrame(url:direction:frameType:payloadSize:)` for WebSocket tracking.
 
+3. **Transport-neutral lifecycle recording** -- `AutoMobileNetwork.shared.captureRecorder()` provides
+   thread-safe `beginRequest`, header/body chunk, completion, and failure methods for custom
+   `URLSession` delegates, `URLSessionWebSocketTask`, `NWConnection`, and third-party clients.
+   `URLSessionNetworkCaptureAdapter`, `WebSocketNetworkCaptureAdapter`, and
+   `NWConnectionNetworkCaptureAdapter` are explicit integrations; they do not swizzle global
+   networking behavior or install a proxy. Each completed request has a stable request ID and
+   optional connection ID. Completion is idempotent, payload text is bounded, and common
+   credential headers are redacted before emission. Set `samplingRate` or `isEnabled` on a
+   recorder when the host needs bounded collection. Apps must still provide any transport
+   metadata that the system does not expose to the adapter, and unsupported third-party
+   transports require the manual adapter.
+
 Body capture is always disabled in release builds to prevent leaking credentials or PII.
 
 ## Logging

--- a/ios/auto-mobile-sdk/Sources/AutoMobileSDK/Events/SdkEvent.swift
+++ b/ios/auto-mobile-sdk/Sources/AutoMobileSDK/Events/SdkEvent.swift
@@ -163,6 +163,12 @@ public struct SdkNetworkRequestEvent: SdkEvent {
     public let timestamp: Int64
     public let url: String
     public let method: String
+    public let requestId: String?
+    public let connectionId: String?
+    public let direction: NetworkCaptureDirection?
+    public let protocolName: String?
+    public let metadata: [String: String]?
+    public let sequenceNumber: UInt64?
     public let requestHeaders: [String: String]?
     public let requestBodySize: Int?
     public let statusCode: Int?
@@ -180,6 +186,12 @@ public struct SdkNetworkRequestEvent: SdkEvent {
         timestamp: Int64 = Int64(Date().timeIntervalSince1970 * 1000),
         url: String,
         method: String,
+        requestId: String? = nil,
+        connectionId: String? = nil,
+        direction: NetworkCaptureDirection? = nil,
+        protocolName: String? = nil,
+        metadata: [String: String]? = nil,
+        sequenceNumber: UInt64? = nil,
         requestHeaders: [String: String]? = nil,
         requestBodySize: Int? = nil,
         statusCode: Int? = nil,
@@ -196,6 +208,12 @@ public struct SdkNetworkRequestEvent: SdkEvent {
         self.timestamp = timestamp
         self.url = url
         self.method = method
+        self.requestId = requestId
+        self.connectionId = connectionId
+        self.direction = direction
+        self.protocolName = protocolName
+        self.metadata = metadata
+        self.sequenceNumber = sequenceNumber
         self.requestHeaders = requestHeaders
         self.requestBodySize = requestBodySize
         self.statusCode = statusCode

--- a/ios/auto-mobile-sdk/Sources/AutoMobileSDK/Network/AutoMobileNetwork.swift
+++ b/ios/auto-mobile-sdk/Sources/AutoMobileSDK/Network/AutoMobileNetwork.swift
@@ -5,6 +5,18 @@ import Foundation
 /// Use this struct with ``AutoMobileNetwork/recordRequest(_:)`` instead of
 /// passing individual parameters.
 public struct NetworkRequestRecord: Sendable {
+    /// Stable identifier for this request lifecycle.
+    public var requestId: String?
+    /// Identifier shared by requests on the same transport connection.
+    public var connectionId: String?
+    /// Direction or lifecycle protocol represented by this record.
+    public var direction: NetworkCaptureDirection?
+    /// Transport name, such as `http`, `websocket`, or `nwconnection`.
+    public var protocolName: String?
+    /// Adapter-supplied lifecycle metadata such as redirect and auth details.
+    public var metadata: [String: String]?
+    /// Monotonic recorder order assigned when the event is emitted.
+    public var sequenceNumber: UInt64?
     /// The full request URL (e.g. "https://api.example.com/users?page=1").
     public let url: String
     /// HTTP method (e.g. "GET", "POST").
@@ -33,6 +45,12 @@ public struct NetworkRequestRecord: Sendable {
     public init(
         url: String,
         method: String,
+        requestId: String? = nil,
+        connectionId: String? = nil,
+        direction: NetworkCaptureDirection? = nil,
+        protocolName: String? = nil,
+        metadata: [String: String]? = nil,
+        sequenceNumber: UInt64? = nil,
         requestHeaders: [String: String]? = nil,
         requestBodySize: Int? = nil,
         statusCode: Int? = nil,
@@ -44,6 +62,12 @@ public struct NetworkRequestRecord: Sendable {
         responseBody: String? = nil,
         contentType: String? = nil
     ) {
+        self.requestId = requestId
+        self.connectionId = connectionId
+        self.direction = direction
+        self.protocolName = protocolName
+        self.metadata = metadata
+        self.sequenceNumber = sequenceNumber
         self.url = url
         self.method = method
         self.requestHeaders = requestHeaders
@@ -174,6 +198,22 @@ public final class AutoMobileNetwork: @unchecked Sendable {
         return AutoMobileURLProtocol.self
     }
 
+    /// Creates a recorder for custom transports that cannot install a URLProtocol.
+    public func captureRecorder() -> NetworkCaptureRecorder {
+        NetworkCaptureRecorder(
+            emit: { [weak self] record in
+                self?.recordRequest(record)
+            },
+            maxBodyBytes: maxBodyBytes,
+            isEnabled: { [weak self] in
+                self?.isEnabled ?? false
+            },
+            isBodyCaptureEnabled: { [weak self] in
+                self?.requestBodyCaptureLimit != nil
+            }
+        )
+    }
+
     /// Record a network request/response manually using a ``NetworkRequestRecord``.
     ///
     /// Use this when you cannot use the ``protocolClass()`` approach (e.g. custom
@@ -204,6 +244,12 @@ public final class AutoMobileNetwork: @unchecked Sendable {
         let event = SdkNetworkRequestEvent(
             url: record.url,
             method: record.method,
+            requestId: record.requestId,
+            connectionId: record.connectionId,
+            direction: record.direction,
+            protocolName: record.protocolName,
+            metadata: record.metadata,
+            sequenceNumber: record.sequenceNumber,
             requestHeaders: captureHeaders ? record.requestHeaders : nil,
             requestBodySize: record.requestBodySize,
             statusCode: record.statusCode,

--- a/ios/auto-mobile-sdk/Sources/AutoMobileSDK/Network/NetworkCaptureRecorder.swift
+++ b/ios/auto-mobile-sdk/Sources/AutoMobileSDK/Network/NetworkCaptureRecorder.swift
@@ -1,0 +1,430 @@
+import Foundation
+import Network
+
+/// The direction of a captured transport event.
+public enum NetworkCaptureDirection: String, Codable, Sendable {
+    case request
+    case response
+    case sent
+    case received
+}
+
+/// Thread-safe lifecycle recorder for transports that cannot use `URLProtocol`.
+///
+/// Adapters call the lifecycle methods from their delegate or connection queues.
+/// The recorder emits at most one terminal `NetworkRequestRecord` per request.
+public final class NetworkCaptureRecorder: @unchecked Sendable {
+    public typealias Emit = @Sendable (NetworkRequestRecord) -> Void
+    public typealias IDGenerator = @Sendable () -> String
+
+    private struct InFlightRequest {
+        let requestId: String
+        let url: String
+        let method: String
+        let connectionId: String?
+        let protocolName: String
+        var metadata: [String: String] = [:]
+        var requestHeaders: [String: String]?
+        var requestBodySize: Int?
+        var requestBody: String?
+        var responseHeaders: [String: String]?
+        var responseBodySize: Int = 0
+        var responseBody: String?
+        var terminal = false
+        let sampled: Bool
+    }
+
+    private let lock = NSLock()
+    private let emit: Emit
+    private let emissionLock = NSLock()
+    private let idGenerator: IDGenerator
+    private let isEnabled: @Sendable () -> Bool
+    private let isBodyCaptureEnabled: @Sendable () -> Bool
+    private let samplingRate: Double
+    private let sampler: @Sendable () -> Double
+    private let headerRedactor: @Sendable ([String: String]) -> [String: String]
+    private var requests: [String: InFlightRequest] = [:]
+    private var nextSequenceNumber: UInt64 = 0
+    private let maxBodyBytes: Int
+
+    public init(
+        emit: @escaping Emit,
+        maxBodyBytes: Int = 32 * 1024,
+        idGenerator: @escaping IDGenerator = { UUID().uuidString },
+        isEnabled: @escaping @Sendable () -> Bool = { true },
+        isBodyCaptureEnabled: @escaping @Sendable () -> Bool = { true },
+        samplingRate: Double = 1,
+        sampler: @escaping @Sendable () -> Double = { Double.random(in: 0..<1) },
+        headerRedactor: @escaping @Sendable ([String: String]) -> [String: String] = {
+            NetworkCaptureRecorder.redactHeaders($0)
+        }
+    ) {
+        self.emit = emit
+        self.maxBodyBytes = max(0, maxBodyBytes)
+        self.idGenerator = idGenerator
+        self.isEnabled = isEnabled
+        self.isBodyCaptureEnabled = isBodyCaptureEnabled
+        self.samplingRate = min(max(samplingRate, 0), 1)
+        self.sampler = sampler
+        self.headerRedactor = headerRedactor
+    }
+
+    /// Starts a request lifecycle and returns its stable request identifier.
+    @discardableResult
+    public func beginRequest(
+        url: String,
+        method: String = "GET",
+        connectionId: String? = nil,
+        protocolName: String = "http",
+        requestHeaders: [String: String]? = nil,
+        requestBodySize: Int? = nil,
+        requestBody: String? = nil
+    ) -> String {
+        let requestId = nextRequestId()
+        let sampled = isEnabled() && sampler() < samplingRate
+        let request = InFlightRequest(
+            requestId: requestId,
+            url: url,
+            method: method,
+            connectionId: connectionId,
+            protocolName: protocolName,
+            requestHeaders: requestHeaders.map(headerRedactor),
+            requestBodySize: requestBodySize,
+            requestBody: truncate(requestBody),
+            responseHeaders: nil,
+            sampled: sampled
+        )
+        lock.lock()
+        requests[requestId] = request
+        lock.unlock()
+        return requestId
+    }
+
+    public func recordRequestHeaders(
+        requestId: String,
+        headers: [String: String]
+    ) {
+        update(requestId) { request in
+            request.requestHeaders = headerRedactor(headers)
+        }
+    }
+
+    public func recordResponseHeaders(
+        requestId: String,
+        headers: [String: String]
+    ) {
+        update(requestId) { request in
+            request.responseHeaders = headerRedactor(headers)
+        }
+    }
+
+    public func recordMetadata(requestId: String, key: String, value: String) {
+        update(requestId) { request in
+            request.metadata[key] = value
+        }
+    }
+
+    public func recordRequestBodyChunk(
+        requestId: String,
+        bytes: Int,
+        text: String? = nil
+    ) {
+        update(requestId) { request in
+            request.requestBodySize = (request.requestBodySize ?? 0) + max(0, bytes)
+            request.requestBody = append(request.requestBody, text)
+        }
+    }
+
+    public func recordResponseBodyChunk(
+        requestId: String,
+        bytes: Int,
+        text: String? = nil
+    ) {
+        update(requestId) { request in
+            request.responseBodySize += max(0, bytes)
+            request.responseBody = append(request.responseBody, text)
+        }
+    }
+
+    public func recordCompletion(
+        requestId: String,
+        statusCode: Int? = nil,
+        responseHeaders: [String: String]? = nil,
+        responseBodySize: Int? = nil
+    ) {
+        update(requestId) { request in
+            request.responseHeaders = responseHeaders.map(headerRedactor) ?? request.responseHeaders
+            if let responseBodySize {
+                request.responseBodySize = responseBodySize
+            }
+        }
+        finish(requestId) { request in
+            return NetworkRequestRecord(
+                url: request.url,
+                method: request.method,
+                requestId: request.requestId,
+                connectionId: request.connectionId,
+                direction: .response,
+                protocolName: request.protocolName,
+                metadata: request.metadata.isEmpty ? nil : request.metadata,
+                requestHeaders: request.requestHeaders,
+                requestBodySize: request.requestBodySize,
+                statusCode: statusCode,
+                responseHeaders: request.responseHeaders,
+                responseBodySize: request.responseBodySize == 0 ? nil : request.responseBodySize,
+                requestBody: request.requestBody,
+                responseBody: request.responseBody
+            )
+        }
+    }
+
+    public func recordFailure(requestId: String, error: Error) {
+        recordFailure(requestId: requestId, error: error.localizedDescription)
+    }
+
+    public func recordFailure(requestId: String, error: String) {
+        finish(requestId) { request in
+            NetworkRequestRecord(
+                url: request.url,
+                method: request.method,
+                requestId: request.requestId,
+                connectionId: request.connectionId,
+                direction: .response,
+                protocolName: request.protocolName,
+                metadata: request.metadata.isEmpty ? nil : request.metadata,
+                requestHeaders: request.requestHeaders,
+                requestBodySize: request.requestBodySize,
+                responseHeaders: request.responseHeaders,
+                responseBodySize: request.responseBodySize == 0 ? nil : request.responseBodySize,
+                error: error,
+                requestBody: request.requestBody,
+                responseBody: request.responseBody
+            )
+        }
+    }
+
+    /// Records one WebSocket message or control frame as a transport event.
+    public func recordWebSocketFrame(
+        url: String,
+        connectionId: String?,
+        direction: NetworkCaptureDirection,
+        frameType: WebSocketFrameType,
+        payloadSize: Int?
+    ) {
+        guard isEnabled(), sampler() < samplingRate else {
+            return
+        }
+        emitRecord(NetworkRequestRecord(
+            url: url,
+            method: frameType.rawValue,
+            requestId: nextRequestId(),
+            connectionId: connectionId,
+            direction: direction,
+            protocolName: "websocket",
+            requestBodySize: direction == .sent ? payloadSize : nil,
+            responseBodySize: direction == .received ? payloadSize : nil
+        ))
+    }
+
+    private func nextRequestId() -> String {
+        idGenerator()
+    }
+
+    private func update(_ requestId: String, _ body: (inout InFlightRequest) -> Void) {
+        lock.lock()
+        guard var request = requests[requestId], !request.terminal else {
+            lock.unlock()
+            return
+        }
+        body(&request)
+        requests[requestId] = request
+        lock.unlock()
+    }
+
+    private func finish(
+        _ requestId: String,
+        _ makeRecord: (InFlightRequest) -> NetworkRequestRecord
+    ) {
+        lock.lock()
+        guard var request = requests.removeValue(forKey: requestId), !request.terminal else {
+            lock.unlock()
+            return
+        }
+        request.terminal = true
+        lock.unlock()
+        guard request.sampled else { return }
+        emitRecord(makeRecord(request))
+    }
+
+    private func emitRecord(_ record: NetworkRequestRecord) {
+        emissionLock.lock()
+        nextSequenceNumber += 1
+        var sequencedRecord = record
+        sequencedRecord.sequenceNumber = nextSequenceNumber
+        emit(sequencedRecord)
+        emissionLock.unlock()
+    }
+
+    private func truncate(_ value: String?) -> String? {
+        guard isBodyCaptureEnabled(), let value, maxBodyBytes > 0 else { return nil }
+        return String(decoding: value.utf8.prefix(maxBodyBytes), as: UTF8.self)
+    }
+
+    private func append(_ current: String?, _ next: String?) -> String? {
+        guard isBodyCaptureEnabled(), let next, maxBodyBytes > 0 else { return current }
+        return truncate((current ?? "") + next)
+    }
+
+    /// Redacts headers that commonly carry credentials or user identity.
+    public static func redactHeaders(_ headers: [String: String]) -> [String: String] {
+        let sensitiveNames: Set<String> = [
+            "authorization", "proxy-authorization", "cookie", "set-cookie",
+            "x-api-key", "x-auth-token", "x-csrf-token",
+        ]
+        var redacted = headers
+        for key in headers.keys where sensitiveNames.contains(key.lowercased()) {
+            redacted[key] = "<redacted>"
+        }
+        return redacted
+    }
+}
+
+/// Adapter for URLSession delegates that already receive lifecycle callbacks.
+public final class URLSessionNetworkCaptureAdapter: @unchecked Sendable {
+    private let recorder: NetworkCaptureRecorder
+
+    public init(recorder: NetworkCaptureRecorder) {
+        self.recorder = recorder
+    }
+
+    @discardableResult
+    public func begin(
+        url: String,
+        method: String = "GET",
+        connectionId: String? = nil,
+        requestHeaders: [String: String]? = nil,
+        requestBodySize: Int? = nil
+    ) -> String {
+        recorder.beginRequest(
+            url: url,
+            method: method,
+            connectionId: connectionId,
+            requestHeaders: requestHeaders,
+            requestBodySize: requestBodySize
+        )
+    }
+
+    @discardableResult
+    public func begin(
+        task: URLSessionTask,
+        connectionId: String? = nil
+    ) -> String {
+        let request = task.originalRequest ?? task.currentRequest
+        return begin(
+            url: request?.url?.absoluteString ?? "",
+            method: request?.httpMethod ?? "GET",
+            connectionId: connectionId,
+            requestHeaders: request?.allHTTPHeaderFields,
+            requestBodySize: request?.httpBody?.count
+        )
+    }
+
+    public func didReceiveResponseHeaders(requestId: String, headers: [String: String]) {
+        recorder.recordResponseHeaders(requestId: requestId, headers: headers)
+    }
+
+    public func didReceiveBody(requestId: String, bytes: Int, text: String? = nil) {
+        recorder.recordResponseBodyChunk(requestId: requestId, bytes: bytes, text: text)
+    }
+
+    public func didReceiveMetrics(requestId: String, durationMs: Double) {
+        recorder.recordMetadata(requestId: requestId, key: "duration_ms", value: String(durationMs))
+    }
+
+    public func didRedirect(requestId: String, url: String) {
+        recorder.recordMetadata(requestId: requestId, key: "redirect_url", value: url)
+    }
+
+    public func didAuthenticate(requestId: String, method: String) {
+        recorder.recordMetadata(requestId: requestId, key: "authentication_method", value: method)
+    }
+
+    public func didComplete(requestId: String, statusCode: Int? = nil) {
+        recorder.recordCompletion(requestId: requestId, statusCode: statusCode)
+    }
+
+    public func didFail(requestId: String, error: Error) {
+        recorder.recordFailure(requestId: requestId, error: error)
+    }
+}
+
+/// Adapter for URLSessionWebSocketTask message and close callbacks.
+public final class WebSocketNetworkCaptureAdapter: @unchecked Sendable {
+    private let recorder: NetworkCaptureRecorder
+
+    public init(recorder: NetworkCaptureRecorder) {
+        self.recorder = recorder
+    }
+
+    public func recordFrame(
+        url: String,
+        connectionId: String?,
+        direction: NetworkCaptureDirection,
+        frameType: WebSocketFrameType,
+        payloadSize: Int?
+    ) {
+        recorder.recordWebSocketFrame(
+            url: url,
+            connectionId: connectionId,
+            direction: direction,
+            frameType: frameType,
+            payloadSize: payloadSize
+        )
+    }
+}
+
+/// Adapter for Network.framework connection state and byte callbacks.
+public final class NWConnectionNetworkCaptureAdapter: @unchecked Sendable {
+    private let recorder: NetworkCaptureRecorder
+
+    public init(recorder: NetworkCaptureRecorder) {
+        self.recorder = recorder
+    }
+
+    @discardableResult
+    public func begin(
+        endpoint: String,
+        connectionId: String
+    ) -> String {
+        recorder.beginRequest(
+            url: endpoint,
+            method: "CONNECTION",
+            connectionId: connectionId,
+            protocolName: "nwconnection"
+        )
+    }
+
+    public func didSend(requestId: String, bytes: Int) {
+        recorder.recordRequestBodyChunk(requestId: requestId, bytes: bytes)
+    }
+
+    public func didUpdateState(requestId: String, state: String) {
+        recorder.recordMetadata(requestId: requestId, key: "connection_state", value: state)
+    }
+
+    public func didReceive(requestId: String, bytes: Int, text: String? = nil) {
+        recorder.recordResponseBodyChunk(requestId: requestId, bytes: bytes, text: text)
+    }
+
+    public func didComplete(requestId: String) {
+        recorder.recordCompletion(requestId: requestId)
+    }
+
+    public func didFail(requestId: String, error: NWError) {
+        recorder.recordFailure(requestId: requestId, error: String(describing: error))
+    }
+
+    public func didCancel(requestId: String) {
+        recorder.recordFailure(requestId: requestId, error: "cancelled")
+    }
+}

--- a/ios/auto-mobile-sdk/Sources/AutoMobileSDK/Public/AutoMobileNetworkAPI.swift
+++ b/ios/auto-mobile-sdk/Sources/AutoMobileSDK/Public/AutoMobileNetworkAPI.swift
@@ -3,6 +3,7 @@ import Foundation
 /// Fine-grained DI surface for the SDK's network subsystem.
 public protocol AutoMobileNetworkAPI: AnyObject, Sendable {
     func recordRequest(_ record: NetworkRequestRecord)
+    func captureRecorder() -> NetworkCaptureRecorder
     func setCaptureHeaders(_ enabled: Bool)
     func setCaptureBodies(_ enabled: Bool)
 }
@@ -15,6 +16,10 @@ public final class DefaultAutoMobileNetworkAPI: AutoMobileNetworkAPI, @unchecked
 
     public func recordRequest(_ record: NetworkRequestRecord) {
         network.recordRequest(record)
+    }
+
+    public func captureRecorder() -> NetworkCaptureRecorder {
+        network.captureRecorder()
     }
 
     public func setCaptureHeaders(_ enabled: Bool) {

--- a/ios/auto-mobile-sdk/Tests/AutoMobileSDKTests/NetworkTests.swift
+++ b/ios/auto-mobile-sdk/Tests/AutoMobileSDKTests/NetworkTests.swift
@@ -11,6 +11,23 @@ private final class EventCollector: @unchecked Sendable {
     func collect(_ events: [any SdkEvent]) { lock.lock(); _events = events; lock.unlock() }
 }
 
+private final class NetworkRecordCollector: @unchecked Sendable {
+    private let lock = NSLock()
+    private var _records: [NetworkRequestRecord] = []
+
+    var records: [NetworkRequestRecord] {
+        lock.lock()
+        defer { lock.unlock() }
+        return _records
+    }
+
+    func append(_ record: NetworkRequestRecord) {
+        lock.lock()
+        _records.append(record)
+        lock.unlock()
+    }
+}
+
 final class AutoMobileNetworkTests: XCTestCase {
     override func tearDown() {
         AutoMobileNetwork.shared.reset()
@@ -604,4 +621,159 @@ final class AutoMobileNetworkTests: XCTestCase {
         }
     }
     #endif
+}
+
+final class NetworkCaptureRecorderTests: XCTestCase {
+    func testRecorderEmitsOneCompletedRequestWithStableIdentityAndBoundedBody() {
+        let collector = NetworkRecordCollector()
+        let recorder = NetworkCaptureRecorder(
+            emit: { collector.append($0) },
+            maxBodyBytes: 6,
+            idGenerator: { "request-1" },
+        )
+
+        let requestId = recorder.beginRequest(
+            url: "https://api.example.com/items",
+            method: "POST",
+            connectionId: "connection-1",
+            requestHeaders: ["Authorization": "Bearer secret"],
+            requestBodySize: 32,
+            requestBody: "{\"item\":\"created\"}"
+        )
+        recorder.recordResponseHeaders(
+            requestId: requestId,
+            headers: ["Content-Type": "application/json"]
+        )
+        recorder.recordResponseBodyChunk(
+            requestId: requestId,
+            bytes: 6,
+            text: "{\"ok\":true}"
+        )
+        recorder.recordCompletion(requestId: requestId, statusCode: 201)
+        recorder.recordCompletion(requestId: requestId, statusCode: 500)
+
+        XCTAssertEqual(collector.records.count, 1)
+        XCTAssertEqual(collector.records[0].requestId, "request-1")
+        XCTAssertEqual(collector.records[0].connectionId, "connection-1")
+        XCTAssertEqual(collector.records[0].statusCode, 201)
+        XCTAssertEqual(collector.records[0].requestHeaders?["Authorization"], "<redacted>")
+        XCTAssertEqual(collector.records[0].responseHeaders?["Content-Type"], "application/json")
+        XCTAssertEqual(collector.records[0].responseBodySize, 6)
+        XCTAssertEqual(collector.records[0].responseBody, "{\"ok\":")
+    }
+
+    func testRecorderRejectsEventsAfterCompletionAndSupportsConcurrentRequests() {
+        let collector = NetworkRecordCollector()
+        let recorder = NetworkCaptureRecorder(
+            emit: { collector.append($0) },
+            idGenerator: { UUID().uuidString }
+        )
+        let group = DispatchGroup()
+        let queue = DispatchQueue(label: "network-recorder-test", attributes: .concurrent)
+
+        for index in 0..<20 {
+            group.enter()
+            queue.async {
+                let requestId = recorder.beginRequest(
+                    url: "https://api.example.com/\(index)",
+                    connectionId: "connection-\(index)"
+                )
+                recorder.recordResponseBodyChunk(requestId: requestId, bytes: 1)
+                recorder.recordCompletion(requestId: requestId, statusCode: 200)
+                recorder.recordFailure(requestId: requestId, error: "late failure")
+                group.leave()
+            }
+        }
+        group.wait()
+
+        XCTAssertEqual(collector.records.count, 20)
+        XCTAssertEqual(Set(collector.records.map(\.requestId)).count, 20)
+        XCTAssertTrue(collector.records.allSatisfy { $0.statusCode == 200 && $0.error == nil })
+    }
+
+    func testAdaptersForwardTaskAndWebSocketLifecycleToRecorder() {
+        let collector = NetworkRecordCollector()
+        let recorder = NetworkCaptureRecorder(
+            emit: { collector.append($0) },
+            idGenerator: { "adapter-request" }
+        )
+        let taskAdapter = URLSessionNetworkCaptureAdapter(recorder: recorder)
+        let requestId = taskAdapter.begin(
+            url: "https://api.example.com/task",
+            method: "GET",
+            connectionId: "session-1"
+        )
+        taskAdapter.didReceiveResponseHeaders(requestId: requestId, headers: ["x-test": "true"])
+        taskAdapter.didReceiveMetrics(requestId: requestId, durationMs: 12.5)
+        taskAdapter.didRedirect(requestId: requestId, url: "https://api.example.com/redirected")
+        taskAdapter.didAuthenticate(requestId: requestId, method: "server-trust")
+        taskAdapter.didComplete(requestId: requestId, statusCode: 204)
+
+        let socketAdapter = WebSocketNetworkCaptureAdapter(recorder: recorder)
+        socketAdapter.recordFrame(
+            url: "wss://api.example.com/socket",
+            connectionId: "socket-1",
+            direction: .sent,
+            frameType: .text,
+            payloadSize: 4
+        )
+
+        XCTAssertEqual(collector.records.count, 2)
+        XCTAssertEqual(collector.records[0].statusCode, 204)
+        XCTAssertEqual(collector.records[0].sequenceNumber, 1)
+        XCTAssertEqual(collector.records[0].metadata?["duration_ms"], "12.5")
+        XCTAssertEqual(collector.records[0].metadata?["redirect_url"], "https://api.example.com/redirected")
+        XCTAssertEqual(collector.records[0].metadata?["authentication_method"], "server-trust")
+        XCTAssertEqual(collector.records[1].connectionId, "socket-1")
+        XCTAssertEqual(collector.records[1].sequenceNumber, 2)
+        XCTAssertEqual(collector.records[1].direction, .sent)
+        XCTAssertEqual(collector.records[1].protocolName, "websocket")
+    }
+
+    func testRecorderDoesNotEmitWhenDisabledOrSampledOut() {
+        let collector = NetworkRecordCollector()
+        let disabled = NetworkCaptureRecorder(
+            emit: { collector.append($0) },
+            isEnabled: { false },
+            sampler: { 0 }
+        )
+        let disabledId = disabled.beginRequest(url: "https://example.com/disabled")
+        disabled.recordCompletion(requestId: disabledId, statusCode: 200)
+
+        let sampledOut = NetworkCaptureRecorder(
+            emit: { collector.append($0) },
+            samplingRate: 0,
+            sampler: { 0 }
+        )
+        let sampledId = sampledOut.beginRequest(url: "https://example.com/sampled")
+        sampledOut.recordCompletion(requestId: sampledId, statusCode: 200)
+
+        XCTAssertTrue(collector.records.isEmpty)
+    }
+
+    func testRecorderDoesNotRetainBodyWhenPayloadCaptureIsDisabled() {
+        let collector = NetworkRecordCollector()
+        let recorder = NetworkCaptureRecorder(
+            emit: { collector.append($0) },
+            maxBodyBytes: 32,
+            isBodyCaptureEnabled: { false }
+        )
+
+        let requestId = recorder.beginRequest(
+            url: "https://example.com/no-body",
+            requestBody: "secret request"
+        )
+        recorder.recordResponseBodyChunk(
+            requestId: requestId,
+            bytes: 13,
+            text: "secret response"
+        )
+        recorder.recordCompletion(requestId: requestId, statusCode: 200)
+
+        XCTAssertEqual(collector.records.count, 1)
+        XCTAssertNil(collector.records.first?.requestBody)
+        XCTAssertNil(collector.records.first?.responseBody)
+        XCTAssertNil(collector.records.first?.requestBodySize)
+        XCTAssertEqual(collector.records.first?.responseBodySize, 13)
+    }
 }

--- a/ios/auto-mobile-sdk/api/auto-mobile-sdk.api
+++ b/ios/auto-mobile-sdk/api/auto-mobile-sdk.api
@@ -135,6 +135,12 @@ public struct SdkNetworkRequestEvent: SdkEvent
   public let timestamp: Int64
   public let url: String
   public let method: String
+  public let requestId: String?
+  public let connectionId: String?
+  public let direction: NetworkCaptureDirection?
+  public let protocolName: String?
+  public let metadata: [String: String]?
+  public let sequenceNumber: UInt64?
   public let requestHeaders: [String: String]?
   public let requestBodySize: Int?
   public let statusCode: Int?
@@ -147,7 +153,7 @@ public struct SdkNetworkRequestEvent: SdkEvent
   public let requestBody: String?
   public let responseBody: String?
   public let contentType: String?
-  public init( timestamp: Int64 = Int64(Date().timeIntervalSince1970 * 1000), url: String, method: String, requestHeaders: [String: String]? = nil, requestBodySize: Int? = nil, statusCode: Int? = nil, responseHeaders: [String: String]? = nil, responseBodySize: Int? = nil, durationMs: Double? = nil, error: String? = nil, host: String? = nil, path: String? = nil, requestBody: String? = nil, responseBody: String? = nil, contentType: String? = nil )
+  public init( timestamp: Int64 = Int64(Date().timeIntervalSince1970 * 1000), url: String, method: String, requestId: String? = nil, connectionId: String? = nil, direction: NetworkCaptureDirection? = nil, protocolName: String? = nil, metadata: [String: String]? = nil, sequenceNumber: UInt64? = nil, requestHeaders: [String: String]? = nil, requestBodySize: Int? = nil, statusCode: Int? = nil, responseHeaders: [String: String]? = nil, responseBodySize: Int? = nil, durationMs: Double? = nil, error: String? = nil, host: String? = nil, path: String? = nil, requestBody: String? = nil, responseBody: String? = nil, contentType: String? = nil )
 public struct SdkWebSocketFrameEvent: SdkEvent
   public private(set) var eventType: SdkEventType = .webSocketFrame
   public let timestamp: Int64
@@ -334,6 +340,12 @@ public enum NavigationSource: String, Sendable, CaseIterable
 
 // Network/AutoMobileNetwork.swift
 public struct NetworkRequestRecord: Sendable
+  public var requestId: String?
+  public var connectionId: String?
+  public var direction: NetworkCaptureDirection?
+  public var protocolName: String?
+  public var metadata: [String: String]?
+  public var sequenceNumber: UInt64?
   public let url: String
   public let method: String
   public var requestHeaders: [String: String]?
@@ -346,7 +358,7 @@ public struct NetworkRequestRecord: Sendable
   public var requestBody: String?
   public var responseBody: String?
   public var contentType: String?
-  public init( url: String, method: String, requestHeaders: [String: String]? = nil, requestBodySize: Int? = nil, statusCode: Int? = nil, responseHeaders: [String: String]? = nil, responseBodySize: Int? = nil, durationMs: Double? = nil, error: String? = nil, requestBody: String? = nil, responseBody: String? = nil, contentType: String? = nil )
+  public init( url: String, method: String, requestId: String? = nil, connectionId: String? = nil, direction: NetworkCaptureDirection? = nil, protocolName: String? = nil, metadata: [String: String]? = nil, sequenceNumber: UInt64? = nil, requestHeaders: [String: String]? = nil, requestBodySize: Int? = nil, statusCode: Int? = nil, responseHeaders: [String: String]? = nil, responseBodySize: Int? = nil, durationMs: Double? = nil, error: String? = nil, requestBody: String? = nil, responseBody: String? = nil, contentType: String? = nil )
 public final class AutoMobileNetwork: @unchecked Sendable
   public static let shared = AutoMobileNetwork()
   public static func isTextContentType(_ contentType: String?) -> Bool
@@ -356,6 +368,7 @@ public final class AutoMobileNetwork: @unchecked Sendable
   public func setCaptureBodies(_ capture: Bool)
   public func setMaxBodyBytes(_ bytes: Int)
   public func protocolClass() -> AnyClass
+  public func captureRecorder() -> NetworkCaptureRecorder
   public func recordRequest(_ record: NetworkRequestRecord)
   public func recordRequest( url: String, method: String, requestHeaders: [String: String]? = nil, requestBodySize: Int? = nil, statusCode: Int? = nil, responseHeaders: [String: String]? = nil, responseBodySize: Int? = nil, durationMs: Double? = nil, error: String? = nil, requestBody: String? = nil, responseBody: String? = nil, contentType: String? = nil )
   public func recordFromTask( _ task: URLSessionTask, startTime: Date, receivedData: Data?, error: Error? )
@@ -368,6 +381,47 @@ public class AutoMobileURLProtocol: URLProtocol
   public func urlSession( _ session: URLSession, dataTask: URLSessionDataTask, didReceive response: URLResponse, completionHandler: @escaping (URLSession.ResponseDisposition) -> Void )
   public func urlSession(_ session: URLSession, dataTask: URLSessionDataTask, didReceive data: Data)
   public func urlSession(_ session: URLSession, task: URLSessionTask, didCompleteWithError error: Error?)
+
+// Network/NetworkCaptureRecorder.swift
+public enum NetworkCaptureDirection: String, Codable, Sendable
+public final class NetworkCaptureRecorder: @unchecked Sendable
+  public typealias Emit = @Sendable (NetworkRequestRecord) -> Void
+  public typealias IDGenerator = @Sendable () -> String
+  public init( emit: @escaping Emit, maxBodyBytes: Int = 32 * 1024, idGenerator: @escaping IDGenerator = { UUID().uuidString }, isEnabled: @escaping @Sendable () -> Bool = { true }, isBodyCaptureEnabled: @escaping @Sendable () -> Bool = { true }, samplingRate: Double = 1, sampler: @escaping @Sendable () -> Double = { Double.random(in: 0..<1) }, headerRedactor: @escaping @Sendable ([String: String]) -> [String: String] = { NetworkCaptureRecorder.redactHeaders($0) } )
+  public func beginRequest( url: String, method: String = "GET", connectionId: String? = nil, protocolName: String = "http", requestHeaders: [String: String]? = nil, requestBodySize: Int? = nil, requestBody: String? = nil ) -> String
+  public func recordRequestHeaders( requestId: String, headers: [String: String] )
+  public func recordResponseHeaders( requestId: String, headers: [String: String] )
+  public func recordMetadata(requestId: String, key: String, value: String)
+  public func recordRequestBodyChunk( requestId: String, bytes: Int, text: String? = nil )
+  public func recordResponseBodyChunk( requestId: String, bytes: Int, text: String? = nil )
+  public func recordCompletion( requestId: String, statusCode: Int? = nil, responseHeaders: [String: String]? = nil, responseBodySize: Int? = nil )
+  public func recordFailure(requestId: String, error: Error)
+  public func recordFailure(requestId: String, error: String)
+  public func recordWebSocketFrame( url: String, connectionId: String?, direction: NetworkCaptureDirection, frameType: WebSocketFrameType, payloadSize: Int? )
+  public static func redactHeaders(_ headers: [String: String]) -> [String: String]
+public final class URLSessionNetworkCaptureAdapter: @unchecked Sendable
+  public init(recorder: NetworkCaptureRecorder)
+  public func begin( url: String, method: String = "GET", connectionId: String? = nil, requestHeaders: [String: String]? = nil, requestBodySize: Int? = nil ) -> String
+  public func begin( task: URLSessionTask, connectionId: String? = nil ) -> String
+  public func didReceiveResponseHeaders(requestId: String, headers: [String: String])
+  public func didReceiveBody(requestId: String, bytes: Int, text: String? = nil)
+  public func didReceiveMetrics(requestId: String, durationMs: Double)
+  public func didRedirect(requestId: String, url: String)
+  public func didAuthenticate(requestId: String, method: String)
+  public func didComplete(requestId: String, statusCode: Int? = nil)
+  public func didFail(requestId: String, error: Error)
+public final class WebSocketNetworkCaptureAdapter: @unchecked Sendable
+  public init(recorder: NetworkCaptureRecorder)
+  public func recordFrame( url: String, connectionId: String?, direction: NetworkCaptureDirection, frameType: WebSocketFrameType, payloadSize: Int? )
+public final class NWConnectionNetworkCaptureAdapter: @unchecked Sendable
+  public init(recorder: NetworkCaptureRecorder)
+  public func begin( endpoint: String, connectionId: String ) -> String
+  public func didSend(requestId: String, bytes: Int)
+  public func didUpdateState(requestId: String, state: String)
+  public func didReceive(requestId: String, bytes: Int, text: String? = nil)
+  public func didComplete(requestId: String)
+  public func didFail(requestId: String, error: NWError)
+  public func didCancel(requestId: String)
 
 // Network/RetryPolicy.swift
 public struct RetryPolicy: Sendable
@@ -417,6 +471,7 @@ public protocol AutoMobileNetworkAPI: AnyObject, Sendable
 public final class DefaultAutoMobileNetworkAPI: AutoMobileNetworkAPI, @unchecked Sendable
   public init()
   public func recordRequest(_ record: NetworkRequestRecord)
+  public func captureRecorder() -> NetworkCaptureRecorder
   public func setCaptureHeaders(_ enabled: Bool)
   public func setCaptureBodies(_ enabled: Bool)
 


### PR DESCRIPTION
## Summary

- Add a thread-safe, transport-neutral iOS network capture recorder.
- Add explicit URLSession, WebSocket, and NWConnection adapters with stable correlation, ordering, redaction, bounded payloads, sampling, disabled mode, and idempotent terminal events.
- Preserve existing URLProtocol and manual recording APIs and document third-party/manual coverage boundaries.

## Validation

- `bash scripts/ios/swift-build.sh`
- `bash scripts/ios/swift-test.sh`
- `bash scripts/ios/api-check.sh`
- `bun run typecheck`
- Focused `NetworkCaptureRecorderTests`
- `git diff --check`

The repository-wide Turbo gate ran 12,803 tests successfully but encountered unrelated existing/flaky failures in `IOSCtrlProxyBuilder` under a `/private/tmp` test data path and `throwIfAborted`; both pass in isolation with the repository-compatible temporary path. The changed iOS SDK and API surfaces are green.

Closes #5057
