### PR TITLE
build(android): resolve junit-runner sibling paths from own layout (0 IP problems)

### DIFF
--- a/android/junit-runner/build.gradle.kts
+++ b/android/junit-runner/build.gradle.kts
@@ -26,11 +26,19 @@ java {
 // release, scripts/ci/verify-release-integrity.sh asserts the SNAPSHOT-stripped
 // base version here matches package.json and the git tag.
 val npmPackageVersion =
-  providers.fileContents(rootProject.layout.projectDirectory.file("../package.json")).asText.map {
+  providers.fileContents(layout.projectDirectory.file("../../package.json")).asText.map {
     packageJson ->
     val parsed = JsonSlurper().parseText(packageJson) as Map<*, *>
     parsed["version"].toString()
   }
+
+// Sibling control-proxy debug APK and the repo root, resolved from this module's
+// own layout so no other project's model is read (Isolated Projects safe). The
+// `:control-proxy:assembleDebug` task dependency below still guarantees the APK
+// exists before the tests run.
+val ctrlProxyDebugApk =
+  layout.projectDirectory.file("../control-proxy/build/outputs/apk/debug/control-proxy-debug.apk")
+val repoRootPath = layout.projectDirectory.dir("../..").asFile.absolutePath
 
 dependencies {
   // Shared validation module
@@ -121,19 +129,12 @@ tasks.withType<Test> {
   // Enable parallel test execution across multiple devices
   maxParallelForks = Runtime.getRuntime().availableProcessors().coerceAtLeast(2)
   dependsOn(":control-proxy:assembleDebug")
-  val accessibilityApk =
-    project(":control-proxy")
-      .layout
-      .buildDirectory
-      .file("outputs/apk/debug/control-proxy-debug.apk")
-  environment("AUTOMOBILE_CTRL_PROXY_APK_PATH", accessibilityApk.get().asFile.absolutePath)
-  systemProperty("automobile.ctrl.proxy.apk.path", accessibilityApk.get().asFile.absolutePath)
+  val apkPath = ctrlProxyDebugApk.asFile.absolutePath
+  environment("AUTOMOBILE_CTRL_PROXY_APK_PATH", apkPath)
+  systemProperty("automobile.ctrl.proxy.apk.path", apkPath)
   systemProperty("automobile.daemon.package.version", npmPackageVersion.get())
   systemProperty("automobile.daemon.force.restart", "true")
-  systemProperty(
-    "automobile.daemon.local.project.path",
-    rootProject.rootDir.parentFile.absolutePath,
-  )
+  systemProperty("automobile.daemon.local.project.path", repoRootPath)
 
   testLogging {
     // Show standard output and error for tests

--- a/scripts/android/validate-kotlin-convention.sh
+++ b/scripts/android/validate-kotlin-convention.sh
@@ -66,4 +66,13 @@ if grep -qE '^allprojects \{' android/build.gradle.kts; then
   fail "android/build.gradle.kts still has an allprojects {} block (blocks Isolated Projects)"
 fi
 
+# 8. No module reads another project's layout model. Cross-project model access
+#    (rootProject.layout, project(":x").layout) breaks Isolated Projects; siblings
+#    must be resolved from the module's own layout. Task deps like
+#    `project(":test-plan-validation")` and `dependsOn(":control-proxy:...")` are fine.
+if grep -rnE 'rootProject\.layout|project\(":[^"]+"\)\.layout' android --include=build.gradle.kts |
+  grep -v '/build-logic/'; then
+  fail "a module accesses another project's layout model (breaks Isolated Projects)"
+fi
+
 echo "OK: Kotlin-compile convention is centralized in $CONVENTION"


### PR DESCRIPTION
## Summary

Item 4 of 5 in the `build-logic` → Isolated Projects migration (issue #5030; builds on #5070). Fixes junit-runner's cross-project model access — the **last** Isolated Projects blockers — so the migration reaches **zero** configuration-phase IP problems.

## Changes

junit-runner resolved three things through another project's model; each now resolves from junit-runner's **own** `layout` (same paths):

| what | before | after |
|---|---|---|
| package.json | `rootProject.layout.projectDirectory.file("../package.json")` | `layout.projectDirectory.file("../../package.json")` |
| control-proxy APK | `project(":control-proxy").layout.buildDirectory.file(...)` | `layout.projectDirectory.file("../control-proxy/build/...")` |
| repo root | `rootProject.rootDir.parentFile` | `layout.projectDirectory.dir("../..")` |

Cross-project **task** dependencies (`dependsOn(":control-proxy:assembleDebug")`, `api(project(":test-plan-validation"))`) are Isolated-Projects safe and unchanged — only the model *reads* were the problem.

Guard extended: rejects reintroduction of `rootProject.layout` / `project(":x").layout`.

## Verification

- **Isolated Projects dry-run: 2 → 0 unique problems.** Across the migration: 11 → 6 → 2 → **0**. Item 5 (the IP flip) is now unblocked.
- `:junit-runner:compileTestKotlin` builds; `./gradlew help` configures cleanly; ktfmt tree-wide clean; shellcheck clean; structural guard (BATS) green.

## Scope note

The issue also mentioned deduping the shared Android release-signing block. That's **independent** of the IP fix (it was not an IP violation) and release-critical, so it's split into a focused follow-up — #5072 — to keep this PR scoped and low-risk.

Closes #5030
