### PR TITLE
docs(observe): document the layoutWarnings cap and truncation field

### DIFF
--- a/docs/design-docs/mcp/observe/index.md
+++ b/docs/design-docs/mcp/observe/index.md
@@ -29,6 +29,8 @@ All collected data is assembled into an object containing (fields may be omitted
 
 Every observation includes report-only `layoutWarnings`. These flag text or interactive elements that may overlap safe areas, system bars, display cutouts, or Android gesture regions. Each warning includes `overflowPx` (how far the element extends into the unsafe region) and `insetPx` (the effective inset on that side), both in the observation's coordinate units. When a flagged descendant is fully contained by a flagged ancestor on the same unsafe side, the output keeps the descendant finding. Intentional edge-to-edge backgrounds and scrollable content remain advisory rather than failures.
 
+`layoutWarnings` is capped at 100 entries (`MAX_LAYOUT_WARNINGS`); real screens flag only a handful, since only elements physically inside the thin inset strips are reported, so the cap trims only pathological hierarchies. When it does trim, the highest-severity, largest-overflow findings are kept and `layoutWarningsTruncated` is set to the **total number of warnings found before capping** — so the shown count is `layoutWarnings.length` and the number omitted is `layoutWarningsTruncated - layoutWarnings.length`. The field is absent when nothing was dropped.
+
 When available, `insets.systemChrome` provides the system-chrome state that explains a
 safe-area warning's screen context. Android reports the current visibility of the status
 and navigation bars from `WindowInsets`; hidden bars do not become additional unsafe


### PR DESCRIPTION
## Summary

Follow-up to [#5046](https://github.com/kaeawc/auto-mobile/pull/5046), which added the `layoutWarnings` cap (`MAX_LAYOUT_WARNINGS = 100`) and the `layoutWarningsTruncated` field but auto-merged before the documentation for them landed. This documents both in the observe reference:

- `layoutWarnings` is capped at 100 (real screens flag only a handful, so the cap trims only pathological hierarchies).
- `layoutWarningsTruncated` is the **total warnings found before capping**, so `shown = layoutWarnings.length` and `dropped = layoutWarningsTruncated - layoutWarnings.length`; absent when nothing was dropped.

Docs-only; no code change.

## Linked Issue

Documents behavior shipped in #5046. Related follow-up: #5074 (co-scope layoutWarnings under the observe-scope experiments).

## Validation

- [x] Docs-only change; no code, tests, or generated artifacts affected.
