### PR TITLE
chore(ios): remove phantom AccessibilityService/AXeAutomation package refs

### DIFF
--- a/ios/README.md
+++ b/ios/README.md
@@ -93,10 +93,10 @@ swift test
 
 ```bash
 # Build a specific component
-./scripts/local/build-ios-component.sh AccessibilityService
+./scripts/local/build-ios-component.sh XCTestRunner
 
 # Test a specific component
-./scripts/local/test-ios-component.sh AccessibilityService
+./scripts/local/test-ios-component.sh XCTestRunner
 ```
 
 ### Manual Build
@@ -124,7 +124,7 @@ bun install && bun run build
 ./scripts/local/validate-ios.sh
 
 # Work on specific component
-cd ios/AccessibilityService
+cd ios/XCTestRunner
 swift build
 swift test
 ```
@@ -135,7 +135,7 @@ swift test
 # Boot iOS simulator
 xcrun simctl boot "iPhone 15 Pro"
 
-# Install and launch AccessibilityService on simulator
+# Install and launch CtrlProxy on simulator
 # (requires Xcode project setup)
 ```
 

--- a/scripts/ci/validate-ios-swift.sh
+++ b/scripts/ci/validate-ios-swift.sh
@@ -43,8 +43,6 @@ echo ""
 
 # Component directories
 COMPONENTS=(
-  "ios/AccessibilityService"
-  "ios/AXeAutomation"
   "ios/XCTestRunner"
 )
 

--- a/scripts/ios/swift-build.sh
+++ b/scripts/ios/swift-build.sh
@@ -15,17 +15,8 @@ NC='\033[0m' # No Color
 
 # Script directory
 SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
-# shellcheck source=scripts/ios/local-sim-build-args.sh disable=SC1091
-source "${SCRIPT_DIR}/local-sim-build-args.sh"
 PROJECT_ROOT="$(cd "${SCRIPT_DIR}/../.." && pwd)"
 IOS_DIR="${PROJECT_ROOT}/ios"
-
-# On a local arm64 host, build only the arch the simulator runs and skip the
-# index store; empty in CI / on Intel so those keep building universal (#5024).
-LOCAL_SIM_ARGS=()
-while IFS= read -r _arg; do
-    [ -n "${_arg}" ] && LOCAL_SIM_ARGS+=("${_arg}")
-done < <(local_sim_build_args)
 
 echo -e "${CYAN}========================================${NC}"
 echo -e "${CYAN}  Swift Package Build${NC}"
@@ -74,11 +65,6 @@ IOS_MACOS_PACKAGES=(
     "XCTestRunner"
 )
 
-# iOS-only packages (need to be built for iOS simulator)
-IOS_ONLY_PACKAGES=(
-    "AccessibilityService"
-)
-
 # Build macOS packages
 echo -e "${BLUE}Building macOS packages...${NC}"
 for package in "${MACOS_PACKAGES[@]}"; do
@@ -119,25 +105,6 @@ for package in "${IOS_MACOS_PACKAGES[@]}"; do
             print_status 0 "${package} built successfully"
         else
             print_status 1 "${package} build failed"
-            FAILED_PACKAGES+=("${package}")
-        fi
-    else
-        print_info "Skipping ${package} (no Package.swift)"
-    fi
-done
-echo ""
-
-# Build iOS-only packages for iOS simulator
-echo -e "${BLUE}Building iOS-only packages for simulator...${NC}"
-for package in "${IOS_ONLY_PACKAGES[@]}"; do
-    PACKAGE_DIR="${IOS_DIR}/${package}"
-    if [ -f "${PACKAGE_DIR}/Package.swift" ]; then
-        echo -e "  Building ${package} for iOS simulator..."
-        # Use xcodebuild to build for iOS simulator since swift build doesn't support cross-compilation
-        if (cd "${PACKAGE_DIR}" && xcodebuild -scheme "${package}" -destination 'generic/platform=iOS Simulator' "${LOCAL_SIM_ARGS[@]}" -quiet build 2>&1); then
-            print_status 0 "${package} built successfully for iOS simulator"
-        else
-            print_status 1 "${package} build failed for iOS simulator"
             FAILED_PACKAGES+=("${package}")
         fi
     else

--- a/scripts/ios/swift-test.sh
+++ b/scripts/ios/swift-test.sh
@@ -64,7 +64,6 @@ print_info "Swift version: ${SWIFT_VERSION}"
 echo ""
 
 # Packages that can be tested on macOS (either macOS-only or cross-platform)
-# Note: iOS-only packages cannot run tests on macOS without a simulator
 # control-proxy has unit tests that can run on macOS
 # XCTestRunner unit tests run on macOS (integration tests are handled by xctestrunner-integration-tests.sh)
 TESTABLE_PACKAGES=(
@@ -72,11 +71,6 @@ TESTABLE_PACKAGES=(
     "control-proxy"
     "XCTestRunner"
     "screen-capture"
-)
-
-# iOS-only packages (tests require iOS simulator - skip in basic test run)
-IOS_ONLY_PACKAGES=(
-    "AccessibilityService"
 )
 
 # Total tests executed in a `swift test` transcript.
@@ -130,14 +124,6 @@ for package in "${TESTABLE_PACKAGES[@]}"; do
         print_info "Skipping ${package} (no Package.swift)"
         SKIPPED_PACKAGES+=("${package} (no Package.swift)")
     fi
-done
-echo ""
-
-# Note about iOS-only packages
-echo -e "${BLUE}iOS-only packages (tests skipped - require simulator):${NC}"
-for package in "${IOS_ONLY_PACKAGES[@]}"; do
-    print_warning "${package} - tests require iOS simulator"
-    SKIPPED_PACKAGES+=("${package} (iOS-only)")
 done
 echo ""
 

--- a/scripts/local/build-ios-component.sh
+++ b/scripts/local/build-ios-component.sh
@@ -12,8 +12,6 @@ if [[ $# -eq 0 ]]; then
   echo "Usage: $0 <component-name>"
   echo ""
   echo "Available components:"
-  echo "  AccessibilityService"
-  echo "  AXeAutomation"
   echo "  SimctlIntegration"
   echo "  XCTestRunner"
   exit 1

--- a/scripts/local/test-ios-component.sh
+++ b/scripts/local/test-ios-component.sh
@@ -12,8 +12,6 @@ if [[ $# -eq 0 ]]; then
   echo "Usage: $0 <component-name>"
   echo ""
   echo "Available components:"
-  echo "  AccessibilityService"
-  echo "  AXeAutomation"
   echo "  SimctlIntegration"
   echo "  XCTestRunner"
   exit 1

--- a/scripts/local/validate-ios.sh
+++ b/scripts/local/validate-ios.sh
@@ -70,8 +70,6 @@ echo "========================================="
 echo ""
 
 SWIFT_COMPONENTS=(
-  "ios/AccessibilityService"
-  "ios/AXeAutomation"
   "ios/XCTestRunner"
 )
 

--- a/test/bats/local-sim-build-args.bats
+++ b/test/bats/local-sim-build-args.bats
@@ -77,8 +77,10 @@ EOF
   grep -q "local_sim_build_args" "$REPO_ROOT/scripts/ios/xcode-test.sh"
 }
 
-@test "swift-build.sh consults local_sim_build_args" {
-  grep -q "local_sim_build_args" "$REPO_ROOT/scripts/ios/swift-build.sh"
+# swift-build.sh's only xcodebuild call was the phantom iOS-only package loop,
+# removed in #5080; with no simulator build left it no longer consults the helper.
+@test "swift-build.sh does NOT consult local_sim_build_args (no xcodebuild left)" {
+  ! grep -q "local_sim_build_args" "$REPO_ROOT/scripts/ios/swift-build.sh"
 }
 
 # --- The release IPA path must stay universal: it must NOT consult the helper. ---

--- a/test/bats/no-phantom-ios-packages.bats
+++ b/test/bats/no-phantom-ios-packages.bats
@@ -1,0 +1,55 @@
+#!/usr/bin/env bats
+#
+# Guard against reintroducing phantom iOS Swift packages (issue #5080).
+#
+# `ios/AccessibilityService` and `ios/AXeAutomation` were referenced across the
+# iOS build/validate tooling but never existed in the repo. Each site skipped
+# them with a directory-existence guard, so they were harmless but misleading —
+# a contributor reads them as real components. These assertions fail if either
+# phantom name creeps back into the tooling that lists buildable components.
+
+setup() {
+  REPO_ROOT="$(cd "$(dirname "$BATS_TEST_FILENAME")/../.." && pwd)"
+}
+
+# Assert $1 (repo-relative path) does not contain any of the remaining tokens.
+refute_tokens() {
+  local rel="$1"; shift
+  local file="$REPO_ROOT/$rel"
+  [ -f "$file" ] || { echo "missing file: $rel"; return 1; }
+  local tok
+  for tok in "$@"; do
+    if grep -q "$tok" "$file"; then
+      echo "phantom reference '$tok' still present in $rel"
+      return 1
+    fi
+  done
+}
+
+@test "swift-build.sh has no AccessibilityService reference" {
+  refute_tokens "scripts/ios/swift-build.sh" "AccessibilityService"
+}
+
+@test "swift-test.sh has no AccessibilityService reference" {
+  refute_tokens "scripts/ios/swift-test.sh" "AccessibilityService"
+}
+
+@test "validate-ios-swift.sh lists no phantom Swift components" {
+  refute_tokens "scripts/ci/validate-ios-swift.sh" "AccessibilityService" "AXeAutomation"
+}
+
+@test "validate-ios.sh lists no phantom Swift components" {
+  refute_tokens "scripts/local/validate-ios.sh" "AccessibilityService" "AXeAutomation"
+}
+
+@test "build-ios-component.sh help lists no phantom components" {
+  refute_tokens "scripts/local/build-ios-component.sh" "AccessibilityService" "AXeAutomation"
+}
+
+@test "test-ios-component.sh help lists no phantom components" {
+  refute_tokens "scripts/local/test-ios-component.sh" "AccessibilityService" "AXeAutomation"
+}
+
+@test "ios/README.md no longer uses AccessibilityService as an example component" {
+  refute_tokens "ios/README.md" "AccessibilityService"
+}


### PR DESCRIPTION
## Summary

`ios/AccessibilityService` and `ios/AXeAutomation` are referenced throughout the
iOS build/validate tooling but were never created. The real `ios/` Swift
components are `auto-mobile-sdk`, `control-proxy`, `screen-capture`, and
`XCTestRunner`. Every reference site skipped the phantoms with a
directory-existence guard, so they were harmless but misleading — a contributor
reads them as real components and a CI/validate script lists packages it can
never build.

This removes every stale `AccessibilityService`/`AXeAutomation` reference from the
iOS tooling. Because `swift-build.sh`'s only `xcodebuild` call was the phantom
iOS-only-package loop, removing it also orphaned the `local-sim-build-args.sh`
wiring added in #5024 — so that is removed from this one script (the other three
consumers keep it).

## Linked Issue

Closes #5080

## Changes

- `scripts/ios/swift-build.sh` — remove the iOS-only package loop + the now-unused
  `local-sim-build-args.sh` source/`LOCAL_SIM_ARGS` block.
- `scripts/ios/swift-test.sh` — remove `IOS_ONLY_PACKAGES` + the skipped-note loop.
- `scripts/ci/validate-ios-swift.sh`, `scripts/local/validate-ios.sh` — drop both
  phantoms from the Swift component lists.
- `scripts/local/build-ios-component.sh`, `scripts/local/test-ios-component.sh` —
  drop the two phantoms from the "Available components" help text.
- `ios/README.md` — use real components (`XCTestRunner` / `CtrlProxy`) in examples.

## Validation

- [x] New `test/bats/no-phantom-ios-packages.bats` (7 cases) guards against
      reintroduction; written red-first.
- [x] Updated the #5024 wiring test — `swift-build.sh` no longer consults the
      helper; the other three consumers still asserted.
- [x] `shellcheck` clean on all touched scripts
- [x] `validate_shell_sete.sh` + `validate_shell_portability.sh` green
- [x] No dangling `IOS_ONLY_PACKAGES` / `LOCAL_SIM_ARGS` references;
      `swift-build.sh` still builds the real macOS/iOS+macOS packages via
      `swift build`

## Follow-ups

- [ ] `ios/SimctlIntegration` is a third phantom (a TypeScript component with its
      own `scripts/ci/validate-ios-typescript.sh`); left for a separate cleanup.
