### PR TITLE
feat(desktop): auto-reconnect PerformanceFacet + hoist nav screenshot cache (#4832)

### DIFF
--- a/android/desktop-core/src/main/kotlin/dev/jasonpearson/automobile/desktop/core/navigation/NavigationScreenshotLoader.kt
+++ b/android/desktop-core/src/main/kotlin/dev/jasonpearson/automobile/desktop/core/navigation/NavigationScreenshotLoader.kt
@@ -81,6 +81,9 @@ class NavigationScreenshotLoaderRegistry {
     clientProvider: () -> AutoMobileClient,
   ): NavigationScreenshotLoader =
     byDevice.getOrPut(deviceId) { NavigationScreenshotLoader(clientProvider = clientProvider) }
+
+  /** The loader already created for [deviceId], or null if none — lets a test assert wiring. */
+  internal fun peek(deviceId: String): NavigationScreenshotLoader? = byDevice[deviceId]
 }
 
 /**

--- a/android/desktop-core/src/main/kotlin/dev/jasonpearson/automobile/desktop/core/navigation/NavigationScreenshotLoader.kt
+++ b/android/desktop-core/src/main/kotlin/dev/jasonpearson/automobile/desktop/core/navigation/NavigationScreenshotLoader.kt
@@ -66,6 +66,31 @@ class FakeScreenshotLoader : ScreenshotLoader {
 }
 
 /**
+ * Session-scoped registry of per-device [NavigationScreenshotLoader]s, held above any facet's
+ * composition so a loader's LRU cache survives the facet leaving and re-entering composition (its
+ * tool toggled off/on, or Inspect/Input mode swapping the facet out). A body-scoped `remember`
+ * would drop the cache on every toggle. Keyed by deviceId so panes for different devices stay
+ * isolated.
+ */
+class NavigationScreenshotLoaderRegistry {
+  private val byDevice = ConcurrentHashMap<String, NavigationScreenshotLoader>()
+
+  /** The loader for [deviceId], created once (with [clientProvider]) and reused thereafter. */
+  fun forDevice(
+    deviceId: String,
+    clientProvider: () -> AutoMobileClient,
+  ): NavigationScreenshotLoader =
+    byDevice.getOrPut(deviceId) { NavigationScreenshotLoader(clientProvider = clientProvider) }
+}
+
+/**
+ * Process-lifetime default registry backing [NavigationScreenshotLoader] resolution when a facet is
+ * not given an explicit provider, so the per-device cache persists for the app session across facet
+ * toggles. Tests inject their own registry/provider instead of touching this.
+ */
+internal val DefaultNavigationScreenshotLoaderRegistry = NavigationScreenshotLoaderRegistry()
+
+/**
  * Loads and caches screenshot thumbnails for navigation graph nodes. Uses an in-memory LRU cache to
  * avoid repeated MCP requests.
  */

--- a/android/desktop-core/src/main/kotlin/dev/jasonpearson/automobile/desktop/core/workspace/NavigationFacet.kt
+++ b/android/desktop-core/src/main/kotlin/dev/jasonpearson/automobile/desktop/core/workspace/NavigationFacet.kt
@@ -323,13 +323,19 @@ fun NavigationFacet(
   val clientProvider = remember { { graph.autoMobileClient } }
   // Resolve the loader from a scope that outlives this facet's composition (a session-scoped
   // registry by default) so its LRU cache survives facet open/close toggles — a body-scoped
-  // `remember` here would drop the cache every time the facet leaves composition.
+  // `remember` here would drop the cache every time the facet leaves composition. The default
+  // provider is itself remembered so its identity is stable across recompositions, letting the
+  // loader `remember` key on it (re-resolving only on an actual provider swap or device change)
+  // without re-invoking it on every recomposition.
   val loaderProvider =
     screenshotLoaderProvider
-      ?: { deviceId ->
-        DefaultNavigationScreenshotLoaderRegistry.forDevice(deviceId, clientProvider)
+      ?: remember(clientProvider) {
+        { deviceId: String ->
+          DefaultNavigationScreenshotLoaderRegistry.forDevice(deviceId, clientProvider)
+        }
       }
-  val screenshotLoader = remember(column.deviceId) { loaderProvider(column.deviceId) }
+  val screenshotLoader =
+    remember(column.deviceId, loaderProvider) { loaderProvider(column.deviceId) }
 
   when (val current = state) {
     NavigationFacetState.Loading -> NavigationFacetNote("Resolving navigation graph…")

--- a/android/desktop-core/src/main/kotlin/dev/jasonpearson/automobile/desktop/core/workspace/NavigationFacet.kt
+++ b/android/desktop-core/src/main/kotlin/dev/jasonpearson/automobile/desktop/core/workspace/NavigationFacet.kt
@@ -29,8 +29,9 @@ import dev.jasonpearson.automobile.desktop.core.datasource.RealNavigationDataSou
 import dev.jasonpearson.automobile.desktop.core.datasource.Result
 import dev.jasonpearson.automobile.desktop.core.di.LocalAutoMobileGraph
 import dev.jasonpearson.automobile.desktop.core.logging.LoggerFactory
+import dev.jasonpearson.automobile.desktop.core.navigation.DefaultNavigationScreenshotLoaderRegistry
 import dev.jasonpearson.automobile.desktop.core.navigation.NavigationDashboard
-import dev.jasonpearson.automobile.desktop.core.navigation.NavigationScreenshotLoader
+import dev.jasonpearson.automobile.desktop.core.navigation.ScreenshotLoader
 import kotlinx.coroutines.CancellationException
 import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.delay
@@ -108,6 +109,10 @@ fun NavigationFacet(
   // deterministically (e.g. awaiting a CompletableDeferred) with zero wall time instead of a real
   // 10s delay under a real-clock test dispatcher. Production uses the real delay.
   resolveTimeout: suspend () -> Unit = { delay(RESOLVE_TIMEOUT_MS) },
+  // Resolves the per-device screenshot loader from a scope that outlives this facet's composition,
+  // so its LRU cache survives facet open/close toggles. Injectable for tests; defaults to a
+  // session-scoped registry.
+  screenshotLoaderProvider: ((String) -> ScreenshotLoader)? = null,
 ) {
   val graph = LocalAutoMobileGraph.current
 
@@ -316,9 +321,15 @@ fun NavigationFacet(
   }
 
   val clientProvider = remember { { graph.autoMobileClient } }
-  // Remembered per device so its LRU cache survives facet toggles.
-  val screenshotLoader =
-    remember(column.deviceId) { NavigationScreenshotLoader(clientProvider = clientProvider) }
+  // Resolve the loader from a scope that outlives this facet's composition (a session-scoped
+  // registry by default) so its LRU cache survives facet open/close toggles — a body-scoped
+  // `remember` here would drop the cache every time the facet leaves composition.
+  val loaderProvider =
+    screenshotLoaderProvider
+      ?: { deviceId ->
+        DefaultNavigationScreenshotLoaderRegistry.forDevice(deviceId, clientProvider)
+      }
+  val screenshotLoader = remember(column.deviceId) { loaderProvider(column.deviceId) }
 
   when (val current = state) {
     NavigationFacetState.Loading -> NavigationFacetNote("Resolving navigation graph…")

--- a/android/desktop-core/src/main/kotlin/dev/jasonpearson/automobile/desktop/core/workspace/PerformanceFacet.kt
+++ b/android/desktop-core/src/main/kotlin/dev/jasonpearson/automobile/desktop/core/workspace/PerformanceFacet.kt
@@ -1,16 +1,12 @@
 package dev.jasonpearson.automobile.desktop.core.workspace
 
 import androidx.compose.runtime.Composable
-import androidx.compose.runtime.DisposableEffect
-import androidx.compose.runtime.getValue
-import androidx.compose.runtime.mutableStateOf
-import androidx.compose.runtime.remember
-import androidx.compose.runtime.setValue
 import dev.jasonpearson.automobile.desktop.core.daemon.ObservationStream
 import dev.jasonpearson.automobile.desktop.core.daemon.ObservationStreamClient
 import dev.jasonpearson.automobile.desktop.core.datasource.DataSourceMode
 import dev.jasonpearson.automobile.desktop.core.di.LocalAutoMobileGraph
 import dev.jasonpearson.automobile.desktop.core.performance.PerformanceDashboard
+import kotlinx.coroutines.delay
 
 /**
  * Docked-facet body for [Tool.Performance]: the performance dashboard scoped to a single pane's
@@ -22,7 +18,10 @@ import dev.jasonpearson.automobile.desktop.core.performance.PerformanceDashboard
  *
  * [observationStreamFactory] is injected (defaulting to a real per-device
  * [ObservationStreamClient]) so the per-device connect/dispose lifecycle can be verified with a
- * [FakeObservationStream] instead of real socket I/O.
+ * [FakeObservationStream] instead of real socket I/O. The stream reconnects automatically if it
+ * drops while the facet is open (see [rememberReconnectingObservationStream]); [backoffDelay] and
+ * [socketAvailable] are the injected timer/daemon-availability seams that let that recovery be
+ * tested with virtual time.
  *
  * Note: only the LIVE metrics here are per-device (the stream carries a deviceId). The dashboard's
  * audit-history fallback still reads via the DI graph's active-device client — device-scoping that
@@ -33,18 +32,17 @@ import dev.jasonpearson.automobile.desktop.core.performance.PerformanceDashboard
 fun PerformanceFacet(
   column: DeviceColumn,
   observationStreamFactory: (String) -> ObservationStream = { ObservationStreamClient() },
+  backoffDelay: suspend (attempt: Int) -> Unit = { attempt -> delay(reconnectBackoffMs(attempt)) },
+  socketAvailable: () -> Boolean = { ObservationStreamClient.socketExists() },
 ) {
   val graph = LocalAutoMobileGraph.current
-  var stream by remember(column.deviceId) { mutableStateOf<ObservationStream?>(null) }
-  DisposableEffect(column.deviceId) {
-    val connected =
-      observationStreamFactory(column.deviceId).also { it.connect(deviceId = column.deviceId) }
-    stream = connected
-    onDispose {
-      connected.dispose()
-      stream = null
-    }
-  }
+  val stream =
+    rememberReconnectingObservationStream(
+      deviceId = column.deviceId,
+      streamFactory = { observationStreamFactory(column.deviceId) },
+      backoffDelay = backoffDelay,
+      socketAvailable = socketAvailable,
+    )
   PerformanceDashboard(
     dataSourceMode = DataSourceMode.Real,
     clientProvider = { graph.autoMobileClient },

--- a/android/desktop-core/src/test/kotlin/dev/jasonpearson/automobile/desktop/core/navigation/NavigationScreenshotLoaderRegistryTest.kt
+++ b/android/desktop-core/src/test/kotlin/dev/jasonpearson/automobile/desktop/core/navigation/NavigationScreenshotLoaderRegistryTest.kt
@@ -1,0 +1,28 @@
+package dev.jasonpearson.automobile.desktop.core.navigation
+
+import dev.jasonpearson.automobile.desktop.core.daemon.AutoMobileClient
+import dev.jasonpearson.automobile.desktop.core.testing.FakeAutoMobileClient
+import org.junit.Assert.assertNotSame
+import org.junit.Assert.assertSame
+import org.junit.Test
+
+class NavigationScreenshotLoaderRegistryTest {
+
+  private val clientProvider: () -> AutoMobileClient = { FakeAutoMobileClient() }
+
+  @Test
+  fun `returns the same loader instance for a device so its cache survives`() {
+    val registry = NavigationScreenshotLoaderRegistry()
+    val first = registry.forDevice("dev-1", clientProvider)
+    val second = registry.forDevice("dev-1", clientProvider)
+    assertSame("a device must keep one loader (and thus one LRU cache)", first, second)
+  }
+
+  @Test
+  fun `keeps distinct loaders per device so panes stay isolated`() {
+    val registry = NavigationScreenshotLoaderRegistry()
+    val a = registry.forDevice("dev-1", clientProvider)
+    val b = registry.forDevice("dev-2", clientProvider)
+    assertNotSame("distinct devices must not share a loader", a, b)
+  }
+}

--- a/android/desktop-core/src/test/kotlin/dev/jasonpearson/automobile/desktop/core/workspace/NavigationFacetTest.kt
+++ b/android/desktop-core/src/test/kotlin/dev/jasonpearson/automobile/desktop/core/workspace/NavigationFacetTest.kt
@@ -20,7 +20,9 @@ import dev.jasonpearson.automobile.desktop.core.datasource.NavigationGraph
 import dev.jasonpearson.automobile.desktop.core.datasource.Result
 import dev.jasonpearson.automobile.desktop.core.di.AutoMobileGraphProvider
 import dev.jasonpearson.automobile.desktop.core.di.LocalAutoMobileGraph
+import dev.jasonpearson.automobile.desktop.core.navigation.NavigationScreenshotLoaderRegistry
 import dev.jasonpearson.automobile.desktop.core.navigation.ScreenNode
+import dev.jasonpearson.automobile.desktop.core.navigation.ScreenshotLoader
 import dev.jasonpearson.automobile.desktop.core.settings.FakeSettingsProvider
 import dev.jasonpearson.automobile.desktop.core.testing.FakeAutoMobileClient
 import java.util.concurrent.atomic.AtomicInteger
@@ -29,6 +31,7 @@ import kotlinx.coroutines.flow.FlowCollector
 import kotlinx.coroutines.flow.SharedFlow
 import org.junit.Assert.assertEquals
 import org.junit.Assert.assertFalse
+import org.junit.Assert.assertSame
 import org.junit.Assert.assertTrue
 import org.junit.Test
 
@@ -891,5 +894,42 @@ class NavigationFacetTest {
     assertTrue(streams.getValue("dev-1").disconnectCallCount >= 1)
     assertEquals(1, streams.getValue("dev-2").connectCallCount)
     assertEquals("dev-2", streams.getValue("dev-2").lastConnectedDeviceId)
+  }
+
+  @Test
+  fun `reuses the same screenshot loader across facet open-close toggles`() = runComposeUiTest {
+    // A registry held above the facet's composition; the facet must resolve its loader from it each
+    // mount so the LRU cache survives the facet leaving and re-entering composition.
+    val registry = NavigationScreenshotLoaderRegistry()
+    val used = mutableListOf<ScreenshotLoader>()
+    val visible = mutableStateOf(true)
+    setContent {
+      CompositionLocalProvider(LocalAutoMobileGraph provides testGraph()) {
+        MaterialTheme {
+          if (visible.value) {
+            NavigationFacet(
+              column = column(),
+              observationStreamFactory = { FakeObservationStream() },
+              screenshotLoaderProvider = { deviceId ->
+                registry.forDevice(deviceId) { FakeAutoMobileClient() }.also { used += it }
+              },
+            )
+          }
+        }
+      }
+    }
+    waitForIdle()
+    // Toggle the facet out of composition (tool switched off) and back on.
+    runOnIdle { visible.value = false }
+    waitForIdle()
+    runOnIdle { visible.value = true }
+    waitForIdle()
+
+    assertEquals(
+      "the facet must resolve its loader from the hoisted provider on each mount",
+      2,
+      used.size,
+    )
+    assertSame("the loader (and its LRU cache) must survive the toggle", used[0], used[1])
   }
 }

--- a/android/desktop-core/src/test/kotlin/dev/jasonpearson/automobile/desktop/core/workspace/NavigationFacetTest.kt
+++ b/android/desktop-core/src/test/kotlin/dev/jasonpearson/automobile/desktop/core/workspace/NavigationFacetTest.kt
@@ -33,6 +33,7 @@ import kotlinx.coroutines.flow.SharedFlow
 import org.junit.Assert.assertEquals
 import org.junit.Assert.assertFalse
 import org.junit.Assert.assertNotNull
+import org.junit.Assert.assertNotSame
 import org.junit.Assert.assertSame
 import org.junit.Assert.assertTrue
 import org.junit.Test
@@ -959,4 +960,38 @@ class NavigationFacetTest {
         DefaultNavigationScreenshotLoaderRegistry.peek(deviceId),
       )
     }
+
+  @Test
+  fun `swapping the injected loader provider re-resolves the loader`() = runComposeUiTest {
+    // Two registries hand out distinct loaders for the same device, so a provider swap must be
+    // observable. Guards that the loader `remember` keys on the provider, not just the deviceId.
+    val fromReg1 = NavigationScreenshotLoaderRegistry()
+    val fromReg2 = NavigationScreenshotLoaderRegistry()
+    val used = mutableListOf<ScreenshotLoader>()
+    val provider =
+      mutableStateOf<(String) -> ScreenshotLoader>({ id ->
+        fromReg1.forDevice(id) { FakeAutoMobileClient() }.also { used += it }
+      })
+    setContent {
+      CompositionLocalProvider(LocalAutoMobileGraph provides testGraph()) {
+        MaterialTheme {
+          NavigationFacet(
+            column = column(),
+            observationStreamFactory = { FakeObservationStream() },
+            screenshotLoaderProvider = provider.value,
+          )
+        }
+      }
+    }
+    waitForIdle()
+    runOnIdle {
+      provider.value = { id ->
+        fromReg2.forDevice(id) { FakeAutoMobileClient() }.also { used += it }
+      }
+    }
+    waitForIdle()
+
+    assertEquals("a provider swap must re-resolve the loader", 2, used.size)
+    assertNotSame("the loader must come from the new provider after a swap", used[0], used[1])
+  }
 }

--- a/android/desktop-core/src/test/kotlin/dev/jasonpearson/automobile/desktop/core/workspace/NavigationFacetTest.kt
+++ b/android/desktop-core/src/test/kotlin/dev/jasonpearson/automobile/desktop/core/workspace/NavigationFacetTest.kt
@@ -20,6 +20,7 @@ import dev.jasonpearson.automobile.desktop.core.datasource.NavigationGraph
 import dev.jasonpearson.automobile.desktop.core.datasource.Result
 import dev.jasonpearson.automobile.desktop.core.di.AutoMobileGraphProvider
 import dev.jasonpearson.automobile.desktop.core.di.LocalAutoMobileGraph
+import dev.jasonpearson.automobile.desktop.core.navigation.DefaultNavigationScreenshotLoaderRegistry
 import dev.jasonpearson.automobile.desktop.core.navigation.NavigationScreenshotLoaderRegistry
 import dev.jasonpearson.automobile.desktop.core.navigation.ScreenNode
 import dev.jasonpearson.automobile.desktop.core.navigation.ScreenshotLoader
@@ -31,6 +32,7 @@ import kotlinx.coroutines.flow.FlowCollector
 import kotlinx.coroutines.flow.SharedFlow
 import org.junit.Assert.assertEquals
 import org.junit.Assert.assertFalse
+import org.junit.Assert.assertNotNull
 import org.junit.Assert.assertSame
 import org.junit.Assert.assertTrue
 import org.junit.Test
@@ -932,4 +934,29 @@ class NavigationFacetTest {
     )
     assertSame("the loader (and its LRU cache) must survive the toggle", used[0], used[1])
   }
+
+  @Test
+  fun `default provider resolves through the session registry so real users get a surviving cache`() =
+    runComposeUiTest {
+      // Exercises the PRODUCTION default (no injected provider). A unique deviceId keeps the
+      // process-lifetime registry from colliding with other tests. Guards against a regression that
+      // reverts the default to a fresh-per-mount loader (which every provider-injecting test
+      // misses).
+      val deviceId = "default-wiring-probe-dev-4832"
+      setContent {
+        CompositionLocalProvider(LocalAutoMobileGraph provides testGraph()) {
+          MaterialTheme {
+            NavigationFacet(
+              column = column(deviceId),
+              observationStreamFactory = { FakeObservationStream() },
+            )
+          }
+        }
+      }
+      waitForIdle()
+      assertNotNull(
+        "the default provider must populate the session registry",
+        DefaultNavigationScreenshotLoaderRegistry.peek(deviceId),
+      )
+    }
 }

--- a/android/desktop-core/src/test/kotlin/dev/jasonpearson/automobile/desktop/core/workspace/PerformanceFacetTest.kt
+++ b/android/desktop-core/src/test/kotlin/dev/jasonpearson/automobile/desktop/core/workspace/PerformanceFacetTest.kt
@@ -7,6 +7,7 @@ import androidx.compose.ui.test.ExperimentalTestApi
 import androidx.compose.ui.test.assertIsDisplayed
 import androidx.compose.ui.test.onNodeWithText
 import androidx.compose.ui.test.runComposeUiTest
+import dev.jasonpearson.automobile.desktop.core.connection.ConnectionState
 import dev.jasonpearson.automobile.desktop.core.daemon.FakeObservationStream
 import dev.jasonpearson.automobile.desktop.core.daemon.PerformanceStreamUpdate
 import dev.jasonpearson.automobile.desktop.core.datasource.DefaultDataSourceFactory
@@ -14,6 +15,7 @@ import dev.jasonpearson.automobile.desktop.core.di.AutoMobileGraphProvider
 import dev.jasonpearson.automobile.desktop.core.di.LocalAutoMobileGraph
 import dev.jasonpearson.automobile.desktop.core.settings.FakeSettingsProvider
 import dev.jasonpearson.automobile.desktop.core.testing.FakeAutoMobileClient
+import kotlinx.coroutines.CompletableDeferred
 import org.junit.Assert.assertEquals
 import org.junit.Assert.assertTrue
 import org.junit.Test
@@ -105,6 +107,35 @@ class PerformanceFacetTest {
     assertEquals("dev-2", fake.lastConnectedDeviceId)
     assertEquals(2, fake.connectCallCount)
     assertTrue(fake.disconnectCallCount >= 1)
+  }
+
+  @Test
+  fun `reconnects the pane stream after a mid-session drop`() = runComposeUiTest {
+    val fake = FakeObservationStream()
+    // A gate the test releases to let the single reconnect attempt proceed with zero wall time.
+    val backoff = CompletableDeferred<Unit>()
+    setContent {
+      CompositionLocalProvider(LocalAutoMobileGraph provides fakeGraph()) {
+        MaterialTheme {
+          PerformanceFacet(
+            column = DeviceColumn(deviceId = "dev-1", name = "Pixel", platform = Platform.Android),
+            observationStreamFactory = { fake },
+            backoffDelay = { backoff.await() },
+            socketAvailable = { true },
+          )
+        }
+      }
+    }
+    waitForIdle()
+    assertEquals(1, fake.connectCallCount)
+
+    // A daemon restart / EOF surfaces as a Disconnected state; the facet must reconnect instead of
+    // staying blank (Performance had no recovery path before).
+    runOnIdle { fake.emitConnectionState(ConnectionState.Disconnected("Stream ended")) }
+    waitForIdle()
+    runOnIdle { backoff.complete(Unit) }
+    waitForIdle()
+    assertEquals("expected the perf facet to reconnect after a drop", 2, fake.connectCallCount)
   }
 
   @Test


### PR DESCRIPTION
## Summary

Two of the three per-device workspace-facet robustness follow-ups from #4832, built on the shared reconnect lifecycle landed in #4868 (`rememberReconnectingObservationStream`):

1. **PerformanceFacet auto-reconnect (part 1).** It connected its per-device `ObservationStream` exactly once and had **no** recovery — if the daemon socket was absent at mount or dropped while the facet was open, it just went blank. It now routes through `rememberReconnectingObservationStream`, recovering with backoff. `backoffDelay`/`socketAvailable` are injected seams so the reconnect is unit-tested with virtual time.
2. **Hoist the Nav screenshot cache (part 2).** `NavigationScreenshotLoader` was created via a body-scoped `remember(deviceId)` inside `NavigationFacet` — so its LRU cache was dropped every time the facet left composition (tool toggled off/on), despite a comment claiming it "survives facet toggles." It's now resolved from a session-scoped `NavigationScreenshotLoaderRegistry` held above the facet, so the cache actually survives toggles. Keyed by deviceId so panes stay isolated.

## Linked issue

Part of #4832. Two parts of #4832 are intentionally **deferred to follow-ups** to keep this reviewable (see below) — so this does not `Closes` the issue.

## Changes

- `PerformanceFacet` — route the stream through the shared reconnect helper; expose `backoffDelay`/`socketAvailable` seams.
- `NavigationScreenshotLoader.kt` — add `NavigationScreenshotLoaderRegistry` (per-device, session-scoped) + a default instance.
- `NavigationFacet` — resolve the loader from an injectable provider (default: the session registry); correct the now-false "survives toggles" comment.

## Testing

- `PerformanceFacetTest`: reconnect-after-drop (virtual-time gated backoff); existing connect/dispose/re-key/live-metric cases stay green.
- `NavigationScreenshotLoaderRegistryTest`: same loader per device, distinct across devices.
- `NavigationFacetTest`: the loader (and its cache) is the **same instance** across a facet open→close→open toggle.
- Full `:desktop-core:test` green; ktfmt clean tree-wide. (No TypeScript/Swift/schema/shell touched.)

## Deferred to follow-ups (out of scope here)

- **NavigationFacet auto-reconnect** (part 1 for Nav): Nav already has *manual* retry; migrating its `streamAttempt`-keyed state machine (+ `RESOLVE_TIMEOUT` backstop, `ConnectionError`/Retry UI) to auto-reconnect is a substantial, independently-reviewable change that risks regressing tested behavior.
- **Per-device Performance audit-history path** (part 3): already flagged in-code as "a separate follow-up (thread deviceId through `listPerformanceAuditResults`)."

## Kotlin Reuse Check

- [x] Reuses `rememberReconnectingObservationStream`/`reconnectBackoffMs` (from #4868), the existing `ObservationStream`/`FakeObservationStream`, and the existing `ScreenshotLoader` interface. The new registry is a thin `ConcurrentHashMap` keyed by deviceId — no new dependency.


### Tracked follow-ups

- NavigationFacet auto-reconnect (part 1 for Nav) — #5085
- Per-device Performance audit-history path (part 3) — #5086
- `NavigationScreenshotLoaderRegistry` unbounded growth / eviction (raised in review of this PR) — #5087

- Navigation screenshot cache serves stale images after node re-capture (no invalidate path; raised in review) — #5088
