### PR TITLE
feat(observe): scoped layoutWarnings envelope + co-scope with hierarchy (closes #5074)

### DIFF
--- a/docs/design-docs/mcp/observe/index.md
+++ b/docs/design-docs/mcp/observe/index.md
@@ -27,9 +27,13 @@ All collected data is assembled into an object containing (fields may be omitted
 - `gfxMetrics`: emitted in sanitized output for action UI-stability summaries; frame timing fields may be trimmed when `performanceAudit.metrics` already carries non-null computed replacements
 - `error`: error messages encountered during observation
 
-Every observation includes report-only `layoutWarnings`. These flag text or interactive elements that may overlap safe areas, system bars, display cutouts, or Android gesture regions. Each warning includes `overflowPx` (how far the element extends into the unsafe region) and `insetPx` (the effective inset on that side), both in the observation's coordinate units. When a flagged descendant is fully contained by a flagged ancestor on the same unsafe side, the output keeps the descendant finding. Intentional edge-to-edge backgrounds and scrollable content remain advisory rather than failures.
+Every observation includes report-only `layoutWarnings`, always under that single key as an object `{ scope, total?, warnings }`. `warnings` flags text or interactive elements that may overlap safe areas, system bars, display cutouts, or Android gesture regions. Each warning includes `overflowPx` (how far the element extends into the unsafe region) and `insetPx` (the effective inset on that side), both in the observation's coordinate units. When a flagged descendant is fully contained by a flagged ancestor on the same unsafe side, the output keeps the descendant finding. Intentional edge-to-edge backgrounds and scrollable content remain advisory rather than failures.
 
-`layoutWarnings` is capped at 100 entries (`MAX_LAYOUT_WARNINGS`); real screens flag only a handful, since only elements physically inside the thin inset strips are reported, so the cap trims only pathological hierarchies. When it does trim, the highest-severity, largest-overflow findings are kept and `layoutWarningsTruncated` is set to the **total number of warnings found before capping** — so the shown count is `layoutWarnings.length` and the number omitted is `layoutWarningsTruncated - layoutWarnings.length`. The field is absent when nothing was dropped.
+`scope` records how the list relates to what the audit found:
+
+- **`full`** — every warning found is present.
+- **`truncated`** — the audit found more than 100 warnings (`MAX_LAYOUT_WARNINGS`); `warnings` holds the highest-severity, largest-overflow 100 and `total` is the pre-cap count (omitted count is `total - warnings.length`). Real screens flag only a handful — only elements physically inside the thin inset strips are reported — so this only ever trims pathological hierarchies.
+- **`scoped`** — the observe-scope transforms (`--observe-region` / `--observe-focus` / `--observe-overview`) narrowed the list to elements still present in the returned hierarchy, so no warning references a pruned element. `total` is dropped when this happens.
 
 When available, `insets.systemChrome` provides the system-chrome state that explains a
 safe-area warning's screen context. Android reports the current visibility of the status

--- a/docs/design-docs/mcp/observe/index.md
+++ b/docs/design-docs/mcp/observe/index.md
@@ -33,7 +33,7 @@ Every observation includes report-only `layoutWarnings`, always under that singl
 
 - **`full`** — every warning found is present.
 - **`truncated`** — the audit found more than 100 warnings (`MAX_LAYOUT_WARNINGS`); `warnings` holds the highest-severity, largest-overflow 100 and `total` is the pre-cap count (omitted count is `total - warnings.length`). Real screens flag only a handful — only elements physically inside the thin inset strips are reported — so this only ever trims pathological hierarchies.
-- **`scoped`** — the observe-scope transforms (`--observe-region` / `--observe-focus` / `--observe-overview`) narrowed the list to elements still present in the returned hierarchy, so no warning references a pruned element. `total` is dropped when this happens.
+- **`scoped`** — the observe-scope transforms (`--observe-region` / `--observe-focus` / `--observe-overview`) narrowed the list to elements still present in the returned hierarchy, so no warning references a pruned element. The stale pre-scope `total` is dropped; if the scoped set itself still exceeds 100 it is then capped, and `total` is set anew to the post-scope pre-cap count (same `total - warnings.length` omitted-count meaning). So a `scoped` set with no `total` is complete for the returned hierarchy, and one with a `total` was additionally capped.
 
 When available, `insets.systemChrome` provides the system-chrome state that explains a
 safe-area warning's screen context. Android reports the current visibility of the status

--- a/schemas/tool-definitions.json
+++ b/schemas/tool-definitions.json
@@ -4023,199 +4023,217 @@
           "additionalProperties": false
         },
         "layoutWarnings": {
-          "type": "array",
-          "items": {
-            "type": "object",
-            "properties": {
-              "type": {
-                "type": "string",
-                "enum": [
-                  "important-content-under-inset",
-                  "interaction-in-system-gesture-region"
-                ]
-              },
-              "severity": {
-                "type": "string",
-                "enum": [
-                  "warning",
-                  "info"
-                ]
-              },
-              "element": {
+          "type": "object",
+          "properties": {
+            "scope": {
+              "type": "string",
+              "enum": [
+                "full",
+                "truncated",
+                "scoped"
+              ]
+            },
+            "total": {
+              "type": "number"
+            },
+            "warnings": {
+              "type": "array",
+              "items": {
                 "type": "object",
                 "properties": {
-                  "viewId": {
-                    "type": "string"
+                  "type": {
+                    "type": "string",
+                    "enum": [
+                      "important-content-under-inset",
+                      "interaction-in-system-gesture-region"
+                    ]
                   },
-                  "resourceId": {
-                    "type": "string"
+                  "severity": {
+                    "type": "string",
+                    "enum": [
+                      "warning",
+                      "info"
+                    ]
                   },
-                  "text": {
-                    "type": "string"
-                  },
-                  "contentDesc": {
-                    "type": "string"
-                  },
-                  "bounds": {
-                    "anyOf": [
-                      {
-                        "type": "object",
-                        "properties": {
-                          "left": {
-                            "type": "number"
-                          },
-                          "top": {
-                            "type": "number"
-                          },
-                          "right": {
-                            "type": "number"
-                          },
-                          "bottom": {
-                            "type": "number"
-                          },
-                          "centerX": {
-                            "type": "number"
-                          },
-                          "centerY": {
-                            "type": "number"
-                          }
-                        },
-                        "required": [
-                          "left",
-                          "top",
-                          "right",
-                          "bottom"
-                        ],
-                        "additionalProperties": false
+                  "element": {
+                    "type": "object",
+                    "properties": {
+                      "viewId": {
+                        "type": "string"
                       },
-                      {
-                        "type": "array",
-                        "prefixItems": [
+                      "resourceId": {
+                        "type": "string"
+                      },
+                      "text": {
+                        "type": "string"
+                      },
+                      "contentDesc": {
+                        "type": "string"
+                      },
+                      "bounds": {
+                        "anyOf": [
                           {
-                            "type": "number"
+                            "type": "object",
+                            "properties": {
+                              "left": {
+                                "type": "number"
+                              },
+                              "top": {
+                                "type": "number"
+                              },
+                              "right": {
+                                "type": "number"
+                              },
+                              "bottom": {
+                                "type": "number"
+                              },
+                              "centerX": {
+                                "type": "number"
+                              },
+                              "centerY": {
+                                "type": "number"
+                              }
+                            },
+                            "required": [
+                              "left",
+                              "top",
+                              "right",
+                              "bottom"
+                            ],
+                            "additionalProperties": false
                           },
                           {
-                            "type": "number"
-                          },
-                          {
-                            "type": "number"
-                          },
-                          {
-                            "type": "number"
+                            "type": "array",
+                            "prefixItems": [
+                              {
+                                "type": "number"
+                              },
+                              {
+                                "type": "number"
+                              },
+                              {
+                                "type": "number"
+                              },
+                              {
+                                "type": "number"
+                              }
+                            ],
+                            "description": "Compact bounds tuple [left, top, right, bottom], emitted in place of the {left, top, right, bottom} object."
                           }
                         ],
-                        "description": "Compact bounds tuple [left, top, right, bottom], emitted in place of the {left, top, right, bottom} object."
+                        "description": "Element bounds. Default: positional tuple [left, top, right, bottom]; the object {left, top, right, bottom} (+ optional centerX/centerY) is also schema-valid."
                       }
+                    },
+                    "required": [
+                      "bounds"
                     ],
-                    "description": "Element bounds. Default: positional tuple [left, top, right, bottom]; the object {left, top, right, bottom} (+ optional centerX/centerY) is also schema-valid."
+                    "additionalProperties": false
+                  },
+                  "categories": {
+                    "type": "array",
+                    "items": {
+                      "type": "string",
+                      "enum": [
+                        "text",
+                        "interaction"
+                      ]
+                    }
+                  },
+                  "insetTypes": {
+                    "type": "array",
+                    "items": {
+                      "type": "string",
+                      "enum": [
+                        "systemBars",
+                        "displayCutout",
+                        "safeArea",
+                        "systemGestures",
+                        "mandatorySystemGestures"
+                      ]
+                    }
+                  },
+                  "sides": {
+                    "type": "array",
+                    "items": {
+                      "type": "string",
+                      "enum": [
+                        "top",
+                        "right",
+                        "bottom",
+                        "left"
+                      ]
+                    }
+                  },
+                  "overflowPx": {
+                    "type": "object",
+                    "properties": {
+                      "top": {
+                        "type": "number"
+                      },
+                      "right": {
+                        "type": "number"
+                      },
+                      "bottom": {
+                        "type": "number"
+                      },
+                      "left": {
+                        "type": "number"
+                      }
+                    },
+                    "additionalProperties": false
+                  },
+                  "insetPx": {
+                    "type": "object",
+                    "properties": {
+                      "top": {
+                        "type": "number"
+                      },
+                      "right": {
+                        "type": "number"
+                      },
+                      "bottom": {
+                        "type": "number"
+                      },
+                      "left": {
+                        "type": "number"
+                      }
+                    },
+                    "additionalProperties": false
+                  },
+                  "overlapPercent": {
+                    "type": "integer",
+                    "minimum": -9007199254740991,
+                    "maximum": 9007199254740991
+                  },
+                  "confidence": {
+                    "type": "string",
+                    "enum": [
+                      "high",
+                      "medium"
+                    ]
                   }
                 },
                 "required": [
-                  "bounds"
+                  "type",
+                  "severity",
+                  "element",
+                  "categories",
+                  "insetTypes",
+                  "sides",
+                  "overflowPx",
+                  "insetPx",
+                  "overlapPercent",
+                  "confidence"
                 ],
                 "additionalProperties": false
-              },
-              "categories": {
-                "type": "array",
-                "items": {
-                  "type": "string",
-                  "enum": [
-                    "text",
-                    "interaction"
-                  ]
-                }
-              },
-              "insetTypes": {
-                "type": "array",
-                "items": {
-                  "type": "string",
-                  "enum": [
-                    "systemBars",
-                    "displayCutout",
-                    "safeArea",
-                    "systemGestures",
-                    "mandatorySystemGestures"
-                  ]
-                }
-              },
-              "sides": {
-                "type": "array",
-                "items": {
-                  "type": "string",
-                  "enum": [
-                    "top",
-                    "right",
-                    "bottom",
-                    "left"
-                  ]
-                }
-              },
-              "overflowPx": {
-                "type": "object",
-                "properties": {
-                  "top": {
-                    "type": "number"
-                  },
-                  "right": {
-                    "type": "number"
-                  },
-                  "bottom": {
-                    "type": "number"
-                  },
-                  "left": {
-                    "type": "number"
-                  }
-                },
-                "additionalProperties": false
-              },
-              "insetPx": {
-                "type": "object",
-                "properties": {
-                  "top": {
-                    "type": "number"
-                  },
-                  "right": {
-                    "type": "number"
-                  },
-                  "bottom": {
-                    "type": "number"
-                  },
-                  "left": {
-                    "type": "number"
-                  }
-                },
-                "additionalProperties": false
-              },
-              "overlapPercent": {
-                "type": "integer",
-                "minimum": -9007199254740991,
-                "maximum": 9007199254740991
-              },
-              "confidence": {
-                "type": "string",
-                "enum": [
-                  "high",
-                  "medium"
-                ]
               }
-            },
-            "required": [
-              "type",
-              "severity",
-              "element",
-              "categories",
-              "insetTypes",
-              "sides",
-              "overflowPx",
-              "insetPx",
-              "overlapPercent",
-              "confidence"
-            ],
-            "additionalProperties": false
-          }
-        },
-        "layoutWarningsTruncated": {
-          "type": "number"
+            }
+          },
+          "required": [
+            "scope",
+            "warnings"
+          ],
+          "additionalProperties": false
         },
         "viewHierarchy": {
           "type": "object",

--- a/src/features/observe/ObserveScreen.ts
+++ b/src/features/observe/ObserveScreen.ts
@@ -39,7 +39,7 @@ import {
   RealHierarchyPlatformValidator
 } from "./HierarchyPlatformValidator";
 import { deriveIosScreenIdentity } from "./ios/IosScreenIdentity";
-import { SafeAreaAuditor, capLayoutWarnings } from "./audits/SafeAreaAuditor";
+import { SafeAreaAuditor } from "./audits/SafeAreaAuditor";
 
 /**
  * Observe command class that combines screen details, view hierarchy and screenshot.
@@ -269,7 +269,10 @@ export class RealObserveScreen implements ObserveScreen {
       // navigation-graph recorder) ever observes the other platform's data.
       enforceHierarchyPlatform(result, this.device.platform, this.device.deviceId, this.platformValidator);
 
-      result.layoutWarnings = capLayoutWarnings(this.safeAreaAuditor.inspect(result));
+      // Uncapped here; the output boundary (sanitizeObserveResult / the observe
+      // served path in finalizeToolResponse) caps AFTER any scope narrowing so an
+      // in-scope warning is never lost to a cap taken against the full tree (#5074).
+      result.layoutWarnings = { scope: "full", warnings: this.safeAreaAuditor.inspect(result) };
 
       if (result.viewHierarchy) {
         result.elements = this.elementsBuilder.build(result.viewHierarchy, this.device.platform);

--- a/src/features/observe/ObserveScreen.ts
+++ b/src/features/observe/ObserveScreen.ts
@@ -269,11 +269,7 @@ export class RealObserveScreen implements ObserveScreen {
       // navigation-graph recorder) ever observes the other platform's data.
       enforceHierarchyPlatform(result, this.device.platform, this.device.deviceId, this.platformValidator);
 
-      const { warnings: layoutWarnings, total: layoutWarningsTotal } = capLayoutWarnings(this.safeAreaAuditor.inspect(result));
-      result.layoutWarnings = layoutWarnings;
-      if (layoutWarningsTotal > layoutWarnings.length) {
-        result.layoutWarningsTruncated = layoutWarningsTotal;
-      }
+      result.layoutWarnings = capLayoutWarnings(this.safeAreaAuditor.inspect(result));
 
       if (result.viewHierarchy) {
         result.elements = this.elementsBuilder.build(result.viewHierarchy, this.device.platform);

--- a/src/features/observe/ObserveScreen.ts
+++ b/src/features/observe/ObserveScreen.ts
@@ -39,7 +39,7 @@ import {
   RealHierarchyPlatformValidator
 } from "./HierarchyPlatformValidator";
 import { deriveIosScreenIdentity } from "./ios/IosScreenIdentity";
-import { SafeAreaAuditor } from "./audits/SafeAreaAuditor";
+import { SafeAreaAuditor, capLayoutWarnings } from "./audits/SafeAreaAuditor";
 
 /**
  * Observe command class that combines screen details, view hierarchy and screenshot.
@@ -48,6 +48,22 @@ import { SafeAreaAuditor } from "./audits/SafeAreaAuditor";
  * stores. The static methods below preserve the existing API for server
  * resource handlers and the daemon by delegating to those stores.
  */
+/**
+ * Bound a cached observation's `layoutWarnings` for readers that serialize it
+ * directly (the `observation/latest` resources, nav/registry embeds) without
+ * going through `finalizeToolResponse`. The audit is cached uncapped so the
+ * observe tool's scope-then-cap path (#5074) sees the full set; every other
+ * reader must not inherit an unbounded list. Returns a shallow copy so the cache
+ * itself is never mutated; the reuse path (`getMostRecent`) is untouched.
+ */
+function boundCachedLayoutWarnings(result: ObserveResult | undefined): ObserveResult | undefined {
+  if (!result?.layoutWarnings) {
+    return result;
+  }
+  const capped = capLayoutWarnings(result.layoutWarnings);
+  return capped === result.layoutWarnings ? result : { ...result, layoutWarnings: capped };
+}
+
 export class RealObserveScreen implements ObserveScreen {
   private device: BootedDevice;
   private adb: AdbExecutor;
@@ -70,11 +86,11 @@ export class RealObserveScreen implements ObserveScreen {
   // ---------- Static API (kept for back-compat with resource handlers/daemon) ----------
 
   static getRecentCachedResult(): ObserveResult | undefined {
-    return getObserveCacheStore().getRecentInMemory();
+    return boundCachedLayoutWarnings(getObserveCacheStore().getRecentInMemory());
   }
 
   static getRecentCachedResultForDevice(deviceId: string): ObserveResult | undefined {
-    return getObserveCacheStore().getRecentInMemoryForDevice(deviceId);
+    return boundCachedLayoutWarnings(getObserveCacheStore().getRecentInMemoryForDevice(deviceId));
   }
 
   static getRecentCachedScreenshotPath(): string | undefined {

--- a/src/features/observe/audits/SafeAreaAuditor.ts
+++ b/src/features/observe/audits/SafeAreaAuditor.ts
@@ -1,4 +1,4 @@
-import type { LayoutWarning, ObservationEdgeInsets, ObserveResult } from "../../../models";
+import type { LayoutWarning, LayoutWarnings, ObservationEdgeInsets, ObserveResult } from "../../../models";
 import { isTruthy } from "../../../models/Element";
 
 type Node = Record<string, unknown>;
@@ -14,31 +14,31 @@ type WarningCandidate = {
 };
 
 /**
- * Upper bound on emitted `layoutWarnings`. The audit now runs on every
+ * Upper bound on emitted `layoutWarnings.warnings`. The audit now runs on every
  * observation, so an unbounded array would bloat every result — and, under
  * `--actions-diff-observe`, the scalar diff that copies both the before and
  * after arrays into `{from, to}`. Real screens self-limit to a handful (only
  * nodes physically inside the thin inset strips are flagged), so this cap only
  * ever trims pathological inputs; when it does, the truncation is surfaced via
- * `ObserveResult.layoutWarningsTruncated` rather than dropped silently.
+ * `scope: "truncated"` + `total` rather than dropped silently.
  */
 export const MAX_LAYOUT_WARNINGS = 100;
 
 /**
- * Cap the advisory list at {@link MAX_LAYOUT_WARNINGS}. Returns the (possibly
- * trimmed) warnings plus the pre-cap `total`. When trimming, the
- * highest-severity, largest-overflow warnings are kept; when not, the original
- * array is returned unchanged (identical order), so realistic screens are never
- * reordered or altered.
+ * Wrap the advisory list in the `LayoutWarnings` envelope, capping at
+ * {@link MAX_LAYOUT_WARNINGS}. At or under the cap the original array is kept
+ * unchanged (identical order) with `scope: "full"`; over it, the
+ * highest-severity, largest-overflow warnings are kept and `scope: "truncated"`
+ * carries the pre-cap `total`.
  */
-export function capLayoutWarnings(warnings: LayoutWarning[]): { warnings: LayoutWarning[]; total: number } {
+export function capLayoutWarnings(warnings: LayoutWarning[]): LayoutWarnings {
   if (warnings.length <= MAX_LAYOUT_WARNINGS) {
-    return { warnings, total: warnings.length };
+    return { scope: "full", warnings };
   }
   const kept = [...warnings]
     .sort((a, b) => layoutWarningPriority(b) - layoutWarningPriority(a))
     .slice(0, MAX_LAYOUT_WARNINGS);
-  return { warnings: kept, total: warnings.length };
+  return { scope: "truncated", total: warnings.length, warnings: kept };
 }
 
 /** Higher = kept first when capping: `warning` severity outranks `info`, then larger total overflow. */

--- a/src/features/observe/audits/SafeAreaAuditor.ts
+++ b/src/features/observe/audits/SafeAreaAuditor.ts
@@ -25,20 +25,26 @@ type WarningCandidate = {
 export const MAX_LAYOUT_WARNINGS = 100;
 
 /**
- * Wrap the advisory list in the `LayoutWarnings` envelope, capping at
- * {@link MAX_LAYOUT_WARNINGS}. At or under the cap the original array is kept
- * unchanged (identical order) with `scope: "full"`; over it, the
- * highest-severity, largest-overflow warnings are kept and `scope: "truncated"`
- * carries the pre-cap `total`.
+ * Cap a `LayoutWarnings` envelope at {@link MAX_LAYOUT_WARNINGS}. Applied at the
+ * output boundary *after* the observe-scope transforms (issue #5074), so the cap
+ * bounds the visible set rather than discarding an in-scope warning against the
+ * full tree. At or under the cap the envelope is returned unchanged; over it, the
+ * highest-severity, largest-overflow warnings are kept and `total` carries the
+ * pre-cap count. A `scoped` list stays `scoped` when it also overflows (it was
+ * narrowed *and* capped); an unscoped one becomes `truncated`.
  */
-export function capLayoutWarnings(warnings: LayoutWarning[]): LayoutWarnings {
-  if (warnings.length <= MAX_LAYOUT_WARNINGS) {
-    return { scope: "full", warnings };
+export function capLayoutWarnings(layoutWarnings: LayoutWarnings): LayoutWarnings {
+  if (layoutWarnings.warnings.length <= MAX_LAYOUT_WARNINGS) {
+    return layoutWarnings;
   }
-  const kept = [...warnings]
+  const kept = [...layoutWarnings.warnings]
     .sort((a, b) => layoutWarningPriority(b) - layoutWarningPriority(a))
     .slice(0, MAX_LAYOUT_WARNINGS);
-  return { scope: "truncated", total: warnings.length, warnings: kept };
+  return {
+    scope: layoutWarnings.scope === "scoped" ? "scoped" : "truncated",
+    total: layoutWarnings.warnings.length,
+    warnings: kept,
+  };
 }
 
 /** Higher = kept first when capping: `warning` severity outranks `info`, then larger total overflow. */

--- a/src/features/observe/cache/FileSystemObserveCacheStore.ts
+++ b/src/features/observe/cache/FileSystemObserveCacheStore.ts
@@ -24,6 +24,9 @@ interface ObserveResultCacheEntry {
  * legacy-shaped entry can still be within the cache TTL, and downstream code
  * dereferences `layoutWarnings.warnings` — so normalize it here at the disk-load
  * boundary before it warms the in-memory cache or is served to a resource.
+ *
+ * Mutates `parsed` in place (and returns it); pass a freshly parsed value, never
+ * a shared object.
  */
 export function normalizeCachedObserveResult(parsed: unknown): ObserveResult {
   // Mutate through a Record view, but return the original `unknown` value cast to

--- a/src/features/observe/cache/FileSystemObserveCacheStore.ts
+++ b/src/features/observe/cache/FileSystemObserveCacheStore.ts
@@ -26,6 +26,10 @@ interface ObserveResultCacheEntry {
  * boundary before it warms the in-memory cache or is served to a resource.
  */
 export function normalizeCachedObserveResult(parsed: unknown): ObserveResult {
+  // Mutate through a Record view, but return the original `unknown` value cast to
+  // ObserveResult: `unknown -> ObserveResult` is a single legal assertion, whereas
+  // `Record<string, unknown> -> ObserveResult` is a TS2352 insufficient-overlap
+  // error (and `as unknown as` would trip the no-unknown-cast lint).
   const record = parsed as Record<string, unknown>;
   const legacy = record.layoutWarnings;
   if (Array.isArray(legacy)) {
@@ -36,7 +40,7 @@ export function normalizeCachedObserveResult(parsed: unknown): ObserveResult {
       : { scope: "full", warnings: legacy };
     delete record.layoutWarningsTruncated;
   }
-  return record as ObserveResult;
+  return parsed as ObserveResult;
 }
 
 /**

--- a/src/features/observe/cache/FileSystemObserveCacheStore.ts
+++ b/src/features/observe/cache/FileSystemObserveCacheStore.ts
@@ -18,6 +18,28 @@ interface ObserveResultCacheEntry {
 }
 
 /**
+ * Migrate an observation written by a pre-#5074 daemon. Back then `layoutWarnings`
+ * was a `LayoutWarning[]` with a sibling `layoutWarningsTruncated` number; it is
+ * now the `{ scope, total?, warnings }` envelope. After an in-place upgrade a
+ * legacy-shaped entry can still be within the cache TTL, and downstream code
+ * dereferences `layoutWarnings.warnings` — so normalize it here at the disk-load
+ * boundary before it warms the in-memory cache or is served to a resource.
+ */
+export function normalizeCachedObserveResult(parsed: unknown): ObserveResult {
+  const record = parsed as Record<string, unknown>;
+  const legacy = record.layoutWarnings;
+  if (Array.isArray(legacy)) {
+    const truncated = record.layoutWarningsTruncated;
+    const total = typeof truncated === "number" ? truncated : undefined;
+    record.layoutWarnings = total !== undefined
+      ? { scope: "truncated", total, warnings: legacy }
+      : { scope: "full", warnings: legacy };
+    delete record.layoutWarningsTruncated;
+  }
+  return record as ObserveResult;
+}
+
+/**
  * Five-minute TTL applied to both in-memory and on-disk cache entries.
  * Preserves the original {@link RealObserveScreen} behaviour.
  */
@@ -192,7 +214,7 @@ export class FileSystemObserveCacheStore implements ObserveResultCacheStore {
       logger.debug(`[OBSERVE_CACHE] Loading most recent disk cache file (age: ${age}ms)`);
 
       const cacheData = await readFileAsync(mostRecentFile.path, "utf8");
-      const cachedResult: ObserveResult = JSON.parse(cacheData);
+      const cachedResult = normalizeCachedObserveResult(JSON.parse(cacheData));
 
       // Warm the in-memory cache so subsequent reads avoid the disk round-trip.
       const cacheKey = `${deviceId}:${mostRecentFile.mtime}`;

--- a/src/features/observe/output/ObserveResultOutput.ts
+++ b/src/features/observe/output/ObserveResultOutput.ts
@@ -1,6 +1,7 @@
 import type { ObserveResult } from "../../../models/ObserveResult";
 import type { ViewHierarchyNode } from "../../../models/ViewHierarchyResult";
 import { toSkeleton } from "./SkeletonProjection";
+import { capLayoutWarnings } from "../audits/SafeAreaAuditor";
 
 /**
  * Output-only shrinking of a single `ObserveResult` for serialization
@@ -87,6 +88,14 @@ export interface SanitizeObserveConfig {
    * observations stay `"full"` so `--actions-diff-observe` can still diff a tree.
    */
   project?: "full" | "skeleton";
+  /**
+   * Cap `layoutWarnings` at `MAX_LAYOUT_WARNINGS` (issue #5074). Default on, so
+   * every served/baseline/action payload is bounded. The observe **served** path
+   * passes `false` to keep the full set for the scope transforms, then caps the
+   * scoped result itself — scope-then-cap, so an in-scope warning is never lost
+   * to a cap taken against the full tree.
+   */
+  capLayoutWarnings?: boolean;
 }
 
 /** Positional order of a compacted bounds tuple: `[left, top, right, bottom]`. */
@@ -130,6 +139,12 @@ export function sanitizeObserveResult(obs: ObserveResult, cfg: SanitizeObserveCo
 
   if (cfg.dropElements) {
     delete out.elements;
+  }
+
+  // Bound the advisory list (issue #5074). Default on; the observe served path
+  // opts out (cfg.capLayoutWarnings === false) so it can scope first, then cap.
+  if (cfg.capLayoutWarnings !== false && out.layoutWarnings) {
+    out.layoutWarnings = capLayoutWarnings(out.layoutWarnings);
   }
 
   return out;

--- a/src/features/observe/output/ObserveResultOutput.ts
+++ b/src/features/observe/output/ObserveResultOutput.ts
@@ -456,7 +456,6 @@ export const DIFF_SCALAR_FIELDS: readonly string[] = [
   "awaitTimeout",
   "awaitDuration",
   "layoutWarnings",
-  "layoutWarningsTruncated",
   "error",
 ];
 
@@ -751,18 +750,26 @@ function diffAttributes(
  * warning change is emitted.
  */
 function layoutWarningsEqual(a: unknown, b: unknown): boolean {
+  const stripWarningConfidence = (warning: unknown): unknown => {
+    if (!warning || typeof warning !== "object" || Array.isArray(warning)) {
+      return warning;
+    }
+    const copy = { ...(warning as Record<string, unknown>) };
+    delete copy.confidence;
+    return copy;
+  };
+  // `layoutWarnings` is the `{ scope, total?, warnings }` envelope; compare scope
+  // and total directly and the nested `warnings` list confidence-stripped, so
+  // occlusion-only confidence churn on a warning still reads as unchanged.
   const withoutDerivedConfidence = (value: unknown): unknown => {
-    if (!Array.isArray(value)) {
+    if (!value || typeof value !== "object" || Array.isArray(value)) {
       return value;
     }
-    return value.map(warning => {
-      if (!warning || typeof warning !== "object" || Array.isArray(warning)) {
-        return warning;
-      }
-      const copy = { ...(warning as Record<string, unknown>) };
-      delete copy.confidence;
-      return copy;
-    });
+    const record = value as Record<string, unknown>;
+    const warnings = Array.isArray(record.warnings)
+      ? record.warnings.map(stripWarningConfidence)
+      : record.warnings;
+    return { ...record, warnings };
   };
   return valuesEqual(withoutDerivedConfidence(a), withoutDerivedConfidence(b));
 }

--- a/src/features/observe/output/ObserveScopeExperiments.ts
+++ b/src/features/observe/output/ObserveScopeExperiments.ts
@@ -609,8 +609,59 @@ export function applyObserveScopeExperiments(
   // Every stage returns a fresh clone, so `run.current` is never the input here;
   // guard the theoretically-unreachable no-op case anyway.
   const out = run.current === input ? clone(input) : run.current;
+  scopeLayoutWarnings(out);
   out.observeScope = buildScopeMetadata({ ...run, current: out }, nodesBefore, gatedOff);
   return out;
+}
+
+/**
+ * Co-scope `layoutWarnings` with the pruned hierarchy (issue #5074). The audit
+ * runs on the full tree in `ObserveScreen`, before these transforms drop nodes,
+ * so a scoped response could otherwise list a warning for an element no longer
+ * in the returned `viewHierarchy`. A warning is kept only when a surviving node
+ * sits at its element's bounds — `OVERVIEW_KEPT_ATTRS` retains `bounds`, and
+ * REGION/FOCUS leave kept nodes' bounds intact, so this holds for all three
+ * dimensions. `readBounds` normalizes both the object and the compact tuple
+ * shape, so it is correct whether or not `--observe-result-compact` ran first.
+ *
+ * When scoping drops warnings, `layoutWarningsTruncated` (the pre-cap total of
+ * the *un-scoped* population) no longer describes what is shown, so it is
+ * cleared to keep the pair consistent.
+ */
+function scopeLayoutWarnings(out: ObserveResult): void {
+  const warnings = out.layoutWarnings;
+  if (!warnings || warnings.length === 0) {
+    return;
+  }
+  const visibleBounds = new Set<string>();
+  collectBoundsKeys(rootNodes(out), visibleBounds);
+  const kept = warnings.filter(warning => {
+    const bounds = readBounds(warning.element?.bounds);
+    return bounds !== null && visibleBounds.has(boundsKey(bounds));
+  });
+  if (kept.length === warnings.length) {
+    return;
+  }
+  out.layoutWarnings = kept;
+  if (out.layoutWarningsTruncated !== undefined) {
+    delete out.layoutWarningsTruncated;
+  }
+}
+
+/** Collect the bounds key of every node in the (already-scoped) hierarchy. */
+function collectBoundsKeys(nodes: NodeRecord[], into: Set<string>): void {
+  for (const node of nodes) {
+    const bounds = readBounds(attr(node, "bounds"));
+    if (bounds !== null) {
+      into.add(boundsKey(bounds));
+    }
+    collectBoundsKeys(childrenOf(node), into);
+  }
+}
+
+/** Canonical bounds identity, shape-independent (object and tuple map to the same key). */
+function boundsKey(bounds: ElementBounds): string {
+  return `${bounds.left},${bounds.top},${bounds.right},${bounds.bottom}`;
 }
 
 /** The server experiment gates; each honors its `scope` dimension only when on. */

--- a/src/features/observe/output/ObserveScopeExperiments.ts
+++ b/src/features/observe/output/ObserveScopeExperiments.ts
@@ -624,28 +624,25 @@ export function applyObserveScopeExperiments(
  * dimensions. `readBounds` normalizes both the object and the compact tuple
  * shape, so it is correct whether or not `--observe-result-compact` ran first.
  *
- * When scoping drops warnings, `layoutWarningsTruncated` (the pre-cap total of
- * the *un-scoped* population) no longer describes what is shown, so it is
- * cleared to keep the pair consistent.
+ * When scoping drops warnings the list becomes `scope: "scoped"` and any `total`
+ * (the pre-cap count of the *un-scoped* population) is dropped, since it no
+ * longer describes what is shown.
  */
 function scopeLayoutWarnings(out: ObserveResult): void {
-  const warnings = out.layoutWarnings;
-  if (!warnings || warnings.length === 0) {
+  const layoutWarnings = out.layoutWarnings;
+  if (!layoutWarnings || layoutWarnings.warnings.length === 0) {
     return;
   }
   const visibleBounds = new Set<string>();
   collectBoundsKeys(rootNodes(out), visibleBounds);
-  const kept = warnings.filter(warning => {
+  const kept = layoutWarnings.warnings.filter(warning => {
     const bounds = readBounds(warning.element?.bounds);
     return bounds !== null && visibleBounds.has(boundsKey(bounds));
   });
-  if (kept.length === warnings.length) {
+  if (kept.length === layoutWarnings.warnings.length) {
     return;
   }
-  out.layoutWarnings = kept;
-  if (out.layoutWarningsTruncated !== undefined) {
-    delete out.layoutWarningsTruncated;
-  }
+  out.layoutWarnings = { scope: "scoped", warnings: kept };
 }
 
 /** Collect the bounds key of every node in the (already-scoped) hierarchy. */

--- a/src/features/observe/output/ObserveScopeExperiments.ts
+++ b/src/features/observe/output/ObserveScopeExperiments.ts
@@ -654,8 +654,15 @@ function scopeLayoutWarnings(out: ObserveResult, pruned: boolean): void {
   out.layoutWarnings = { scope: "scoped", warnings: kept };
 }
 
-/** Per-rectangle survival index: the identity signatures present, and whether any survivor there is anonymous. */
-type SurvivorIndex = Map<string, { identities: Set<string>; anonymous: boolean }>;
+/** A surviving node's identity fields (empty string = absent). */
+interface NodeIdentity {
+  viewId: string;
+  resourceId: string;
+  contentDesc: string;
+  text: string;
+}
+/** Per-rectangle survival index: the identity of every surviving node at each bounds. */
+type SurvivorIndex = Map<string, NodeIdentity[]>;
 
 function collectSurvivorBoundsIdentity(nodes: NodeRecord[]): SurvivorIndex {
   const index: SurvivorIndex = new Map();
@@ -669,27 +676,21 @@ function collectSurvivorBoundsIdentity(nodes: NodeRecord[]): SurvivorIndex {
   return index;
 }
 
-/** Record one surviving node's bounds → identity signatures (or anonymity) in the index. */
+/** Record one surviving node's bounds → identity in the index. */
 function indexSurvivor(node: NodeRecord, index: SurvivorIndex): void {
   const bounds = readBounds(attr(node, "bounds"));
   if (bounds === null) {
     return;
   }
   const key = boundsKey(bounds);
-  const entry = index.get(key) ?? { identities: new Set<string>(), anonymous: false };
-  const ids = identitySignatures(
-    stringAttr(node, "view-id"),
-    stringAttr(node, "resource-id"),
-    stringAttr(node, "content-desc"),
-    stringAttr(node, "text")
-  );
-  if (ids.length === 0) {
-    entry.anonymous = true;
-  }
-  for (const id of ids) {
-    entry.identities.add(id);
-  }
-  index.set(key, entry);
+  const list = index.get(key) ?? [];
+  list.push({
+    viewId: stringAttr(node, "view-id"),
+    resourceId: stringAttr(node, "resource-id"),
+    contentDesc: stringAttr(node, "content-desc"),
+    text: stringAttr(node, "text"),
+  });
+  index.set(key, list);
 }
 
 function warningSurvives(warning: LayoutWarnings["warnings"][number], survivors: SurvivorIndex): boolean {
@@ -697,34 +698,49 @@ function warningSurvives(warning: LayoutWarnings["warnings"][number], survivors:
   if (bounds === null) {
     return false;
   }
-  const entry = survivors.get(boundsKey(bounds));
-  if (entry === undefined) {
+  const candidates = survivors.get(boundsKey(bounds));
+  if (candidates === undefined) {
     return false; // no node survives at this rectangle
   }
-  const element = warning.element ?? {};
-  const wanted = identitySignatures(element.viewId, element.resourceId, element.contentDesc, element.text);
-  // Wildcard cases: the warning has no identity to correlate, or a surviving node
-  // at this rectangle carries none (identity stripped by the transform) — either
-  // way an element is genuinely visible here, so keep the warning.
-  if (wanted.length === 0 || entry.anonymous) {
-    return true;
-  }
-  return wanted.some(id => entry.identities.has(id));
+  return candidates.some(node => nodeMatchesWarning(node, warning.element ?? {}));
 }
 
-/** Non-empty identity signatures for a node/element, namespaced so fields never collide. */
-function identitySignatures(
-  viewId: string | undefined,
-  resourceId: string | undefined,
-  contentDesc: string | undefined,
-  text: string | undefined
-): string[] {
-  return [
-    viewId ? `vid:${viewId}` : "",
-    resourceId ? `rid:${resourceId}` : "",
-    contentDesc ? `cd:${contentDesc}` : "",
-    text ? `txt:${text}` : "",
-  ].filter(signature => signature.length > 0);
+type WarningElement = { viewId?: string; resourceId?: string; contentDesc?: string; text?: string };
+
+/** Two populated values that disagree. */
+function conflicts(a: string | undefined, b: string): boolean {
+  return !!a && !!b && a !== b;
+}
+
+/** Two values that are populated and equal. */
+function shares(a: string | undefined, b: string): boolean {
+  return !!a && a === b;
+}
+
+function hasAnyIdentity(id: WarningElement | NodeIdentity): boolean {
+  return !!(id.viewId || id.resourceId || id.contentDesc || id.text);
+}
+
+/**
+ * Whether a surviving node plausibly IS the warning's element.
+ * - Reject when a strong identifier (`resource-id`/`view-id`) is populated on
+ *   both sides but differs — two distinct nodes at one rectangle (issue #5074).
+ * - Wildcard-keep when either side carries no identity: a genuinely-visible
+ *   element sits here, and dropping its warning would be a false negative (the
+ *   OVERVIEW identity-strip case).
+ * - Otherwise require at least one shared populated field.
+ */
+function nodeMatchesWarning(node: NodeIdentity, element: WarningElement): boolean {
+  if (conflicts(element.resourceId, node.resourceId) || conflicts(element.viewId, node.viewId)) {
+    return false;
+  }
+  if (!hasAnyIdentity(element) || !hasAnyIdentity(node)) {
+    return true;
+  }
+  return shares(element.resourceId, node.resourceId)
+    || shares(element.viewId, node.viewId)
+    || shares(element.contentDesc, node.contentDesc)
+    || shares(element.text, node.text);
 }
 
 /** Canonical bounds identity, shape-independent (object and tuple map to the same key). */

--- a/src/features/observe/output/ObserveScopeExperiments.ts
+++ b/src/features/observe/output/ObserveScopeExperiments.ts
@@ -1,4 +1,5 @@
 import type { ObserveResult } from "../../../models/ObserveResult";
+import type { LayoutWarnings } from "../../../models/ObservationInsets";
 import type { ElementBounds } from "../../../models/ElementBounds";
 import type {
   FocusAnchor,
@@ -609,7 +610,7 @@ export function applyObserveScopeExperiments(
   // Every stage returns a fresh clone, so `run.current` is never the input here;
   // guard the theoretically-unreachable no-op case anyway.
   const out = run.current === input ? clone(input) : run.current;
-  scopeLayoutWarnings(out);
+  scopeLayoutWarnings(out, countNodes(rootNodes(out)) < nodesBefore);
   out.observeScope = buildScopeMetadata({ ...run, current: out }, nodesBefore, gatedOff);
   return out;
 }
@@ -618,42 +619,112 @@ export function applyObserveScopeExperiments(
  * Co-scope `layoutWarnings` with the pruned hierarchy (issue #5074). The audit
  * runs on the full tree in `ObserveScreen`, before these transforms drop nodes,
  * so a scoped response could otherwise list a warning for an element no longer
- * in the returned `viewHierarchy`. A warning is kept only when a surviving node
- * sits at its element's bounds — `OVERVIEW_KEPT_ATTRS` retains `bounds`, and
- * REGION/FOCUS leave kept nodes' bounds intact, so this holds for all three
- * dimensions. `readBounds` normalizes both the object and the compact tuple
- * shape, so it is correct whether or not `--observe-result-compact` ran first.
+ * in the returned `viewHierarchy`.
  *
- * When scoping drops warnings the list becomes `scope: "scoped"` and any `total`
- * (the pre-cap count of the *un-scoped* population) is dropped, since it no
- * longer describes what is shown.
+ * A warning survives only when a node at its element's bounds survives AND that
+ * node is plausibly the *same* element. Bounds alone is ambiguous when a node and
+ * a child share a rectangle (e.g. OVERVIEW keeps an addressable container but
+ * drops its anonymous text child): correlating identity fields distinguishes
+ * them. But some transforms strip identity from kept nodes (OVERVIEW keeps
+ * `bounds`/`resource-id`/`content-desc` but drops `text`/`view-id`), so a
+ * surviving node that carries *no* identity is treated as a wildcard match — it
+ * is genuinely visible at that rectangle, and dropping its warning would be a
+ * false negative. `readBounds` normalizes object and compact-tuple bounds, so
+ * this is correct whether or not `--observe-result-compact` ran first.
+ *
+ * When scoping removes warnings, the list becomes `scope: "scoped"`. A
+ * `truncated` list also becomes `scoped` once the hierarchy was pruned, since a
+ * capped-away warning may belong to a pruned node — so `total` (the pre-cap count
+ * of the *un-scoped* population) no longer describes what is shown and is dropped.
  */
-function scopeLayoutWarnings(out: ObserveResult): void {
+function scopeLayoutWarnings(out: ObserveResult, pruned: boolean): void {
   const layoutWarnings = out.layoutWarnings;
   if (!layoutWarnings || layoutWarnings.warnings.length === 0) {
     return;
   }
-  const visibleBounds = new Set<string>();
-  collectBoundsKeys(rootNodes(out), visibleBounds);
-  const kept = layoutWarnings.warnings.filter(warning => {
-    const bounds = readBounds(warning.element?.bounds);
-    return bounds !== null && visibleBounds.has(boundsKey(bounds));
-  });
-  if (kept.length === layoutWarnings.warnings.length) {
+  const survivors = collectSurvivorBoundsIdentity(rootNodes(out));
+  const kept = layoutWarnings.warnings.filter(warning => warningSurvives(warning, survivors));
+  const dropped = kept.length !== layoutWarnings.warnings.length;
+  // A `truncated` total counted the un-scoped population; once pruning hides
+  // nodes it may over-count what is reachable, so it is no longer trustworthy.
+  const staleTotal = pruned && layoutWarnings.scope === "truncated";
+  if (!dropped && !staleTotal) {
     return;
   }
   out.layoutWarnings = { scope: "scoped", warnings: kept };
 }
 
-/** Collect the bounds key of every node in the (already-scoped) hierarchy. */
-function collectBoundsKeys(nodes: NodeRecord[], into: Set<string>): void {
-  for (const node of nodes) {
-    const bounds = readBounds(attr(node, "bounds"));
-    if (bounds !== null) {
-      into.add(boundsKey(bounds));
+/** Per-rectangle survival index: the identity signatures present, and whether any survivor there is anonymous. */
+type SurvivorIndex = Map<string, { identities: Set<string>; anonymous: boolean }>;
+
+function collectSurvivorBoundsIdentity(nodes: NodeRecord[]): SurvivorIndex {
+  const index: SurvivorIndex = new Map();
+  const walk = (list: NodeRecord[]): void => {
+    for (const node of list) {
+      indexSurvivor(node, index);
+      walk(childrenOf(node));
     }
-    collectBoundsKeys(childrenOf(node), into);
+  };
+  walk(nodes);
+  return index;
+}
+
+/** Record one surviving node's bounds → identity signatures (or anonymity) in the index. */
+function indexSurvivor(node: NodeRecord, index: SurvivorIndex): void {
+  const bounds = readBounds(attr(node, "bounds"));
+  if (bounds === null) {
+    return;
   }
+  const key = boundsKey(bounds);
+  const entry = index.get(key) ?? { identities: new Set<string>(), anonymous: false };
+  const ids = identitySignatures(
+    stringAttr(node, "view-id"),
+    stringAttr(node, "resource-id"),
+    stringAttr(node, "content-desc"),
+    stringAttr(node, "text")
+  );
+  if (ids.length === 0) {
+    entry.anonymous = true;
+  }
+  for (const id of ids) {
+    entry.identities.add(id);
+  }
+  index.set(key, entry);
+}
+
+function warningSurvives(warning: LayoutWarnings["warnings"][number], survivors: SurvivorIndex): boolean {
+  const bounds = readBounds(warning.element?.bounds);
+  if (bounds === null) {
+    return false;
+  }
+  const entry = survivors.get(boundsKey(bounds));
+  if (entry === undefined) {
+    return false; // no node survives at this rectangle
+  }
+  const element = warning.element ?? {};
+  const wanted = identitySignatures(element.viewId, element.resourceId, element.contentDesc, element.text);
+  // Wildcard cases: the warning has no identity to correlate, or a surviving node
+  // at this rectangle carries none (identity stripped by the transform) — either
+  // way an element is genuinely visible here, so keep the warning.
+  if (wanted.length === 0 || entry.anonymous) {
+    return true;
+  }
+  return wanted.some(id => entry.identities.has(id));
+}
+
+/** Non-empty identity signatures for a node/element, namespaced so fields never collide. */
+function identitySignatures(
+  viewId: string | undefined,
+  resourceId: string | undefined,
+  contentDesc: string | undefined,
+  text: string | undefined
+): string[] {
+  return [
+    viewId ? `vid:${viewId}` : "",
+    resourceId ? `rid:${resourceId}` : "",
+    contentDesc ? `cd:${contentDesc}` : "",
+    text ? `txt:${text}` : "",
+  ].filter(signature => signature.length > 0);
 }
 
 /** Canonical bounds identity, shape-independent (object and tuple map to the same key). */

--- a/src/features/observe/output/ObserveScopeExperiments.ts
+++ b/src/features/observe/output/ObserveScopeExperiments.ts
@@ -603,6 +603,20 @@ export function applyObserveScopeExperiments(
   if (cfg.region) {
     runRegionStage(run, cfg);
   }
+
+  // Co-scope layoutWarnings against the FOCUS/REGION-pruned tree, captured BEFORE
+  // OVERVIEW (issue #5074). Those two transforms are lossless — kept nodes retain
+  // every attribute (including the iOS `$` bag that holds bounds/identity) — so
+  // matching is exact. OVERVIEW instead strips attributes and collapses leaves
+  // into kept ancestors (a structural summary, not a spatial removal), so reading
+  // identity from the post-OVERVIEW tree both drops iOS warnings wholesale (the
+  // `$` bag is gone) and cannot tell a collapsed child from its surviving parent.
+  // A warning for a leaf OVERVIEW summarizes is retained: its location is still
+  // shown, occupied by the kept ancestor whose `omittedDescendants` flags the
+  // collapse.
+  const survivors = collectSurvivorBoundsIdentity(rootNodes(run.current));
+  const prunedBeforeOverview = countNodes(rootNodes(run.current)) < nodesBefore;
+
   if (cfg.overview) {
     runOverviewStage(run);
   }
@@ -610,7 +624,7 @@ export function applyObserveScopeExperiments(
   // Every stage returns a fresh clone, so `run.current` is never the input here;
   // guard the theoretically-unreachable no-op case anyway.
   const out = run.current === input ? clone(input) : run.current;
-  scopeLayoutWarnings(out, countNodes(rootNodes(out)) < nodesBefore);
+  scopeLayoutWarnings(out, survivors, prunedBeforeOverview);
   out.observeScope = buildScopeMetadata({ ...run, current: out }, nodesBefore, gatedOff);
   return out;
 }
@@ -621,28 +635,22 @@ export function applyObserveScopeExperiments(
  * so a scoped response could otherwise list a warning for an element no longer
  * in the returned `viewHierarchy`.
  *
- * A warning survives only when a node at its element's bounds survives AND that
- * node is plausibly the *same* element. Bounds alone is ambiguous when a node and
- * a child share a rectangle (e.g. OVERVIEW keeps an addressable container but
- * drops its anonymous text child): correlating identity fields distinguishes
- * them. But some transforms strip identity from kept nodes (OVERVIEW keeps
- * `bounds`/`resource-id`/`content-desc` but drops `text`/`view-id`), so a
- * surviving node that carries *no* identity is treated as a wildcard match — it
- * is genuinely visible at that rectangle, and dropping its warning would be a
- * false negative. `readBounds` normalizes object and compact-tuple bounds, so
- * this is correct whether or not `--observe-result-compact` ran first.
+ * `survivors` is the identity index of the FOCUS/REGION-pruned tree, captured by
+ * the caller before OVERVIEW (see `applyObserveScopeExperiments`). A warning
+ * survives when a surviving node at its element's bounds is plausibly the *same*
+ * element — same identity, no conflicting identifier — with a wildcard when
+ * either side is genuinely identity-less (a bare bounds match).
  *
  * When scoping removes warnings, the list becomes `scope: "scoped"`. A
  * `truncated` list also becomes `scoped` once the hierarchy was pruned, since a
  * capped-away warning may belong to a pruned node — so `total` (the pre-cap count
  * of the *un-scoped* population) no longer describes what is shown and is dropped.
  */
-function scopeLayoutWarnings(out: ObserveResult, pruned: boolean): void {
+function scopeLayoutWarnings(out: ObserveResult, survivors: SurvivorIndex, pruned: boolean): void {
   const layoutWarnings = out.layoutWarnings;
   if (!layoutWarnings || layoutWarnings.warnings.length === 0) {
     return;
   }
-  const survivors = collectSurvivorBoundsIdentity(rootNodes(out));
   const kept = layoutWarnings.warnings.filter(warning => warningSurvives(warning, survivors));
   const dropped = kept.length !== layoutWarnings.warnings.length;
   // A `truncated` total counted the un-scoped population; once pruning hides
@@ -723,15 +731,22 @@ function hasAnyIdentity(id: WarningElement | NodeIdentity): boolean {
 
 /**
  * Whether a surviving node plausibly IS the warning's element.
- * - Reject when a strong identifier (`resource-id`/`view-id`) is populated on
- *   both sides but differs — two distinct nodes at one rectangle (issue #5074).
+ * - Reject when ANY identity field (`resource-id`/`view-id`/`content-desc`/`text`)
+ *   is populated on both sides but differs — two distinct nodes at one rectangle
+ *   (issue #5074). Since co-scoping runs against the lossless FOCUS/REGION tree,
+ *   every populated field is a reliable discriminator.
  * - Wildcard-keep when either side carries no identity: a genuinely-visible
- *   element sits here, and dropping its warning would be a false negative (the
- *   OVERVIEW identity-strip case).
+ *   element sits here (a bare bounds match), and dropping its warning would be a
+ *   false negative.
  * - Otherwise require at least one shared populated field.
  */
 function nodeMatchesWarning(node: NodeIdentity, element: WarningElement): boolean {
-  if (conflicts(element.resourceId, node.resourceId) || conflicts(element.viewId, node.viewId)) {
+  if (
+    conflicts(element.resourceId, node.resourceId)
+    || conflicts(element.viewId, node.viewId)
+    || conflicts(element.contentDesc, node.contentDesc)
+    || conflicts(element.text, node.text)
+  ) {
     return false;
   }
   if (!hasAnyIdentity(element) || !hasAnyIdentity(node)) {

--- a/src/models/ObservationInsets.ts
+++ b/src/models/ObservationInsets.ts
@@ -68,22 +68,23 @@ export interface LayoutWarning {
 /**
  * Completeness of an observation's {@link LayoutWarnings.warnings} list:
  * - `full` — every warning the audit found is present.
- * - `truncated` — the audit found more than `MAX_LAYOUT_WARNINGS`; `warnings`
- *   holds the highest-priority cap and `total` is the pre-cap count.
+ * - `truncated` — more than `MAX_LAYOUT_WARNINGS` were found; `warnings` holds
+ *   the highest-priority cap and `total` is the pre-cap count.
  * - `scoped` — the observe-scope transforms (`--observe-region`/`-focus`/
  *   `-overview`) narrowed the list to elements still in the returned hierarchy.
+ *   A `scoped` list that itself exceeded the cap also carries `total`.
  */
 export type LayoutWarningsScope = "full" | "truncated" | "scoped";
 
 /**
  * Report-only edge-to-edge / safe-area findings for an observation, always
  * emitted under the single `layoutWarnings` key. `scope` records how the list
- * relates to what the audit found; `total` is present only when `scope` is
- * `truncated`.
+ * relates to what the audit found; `total` (the pre-cap count) is present
+ * whenever the list was capped — always for `truncated`, and for `scoped` when
+ * the scoped set still overflowed the cap.
  */
 export interface LayoutWarnings {
   scope: LayoutWarningsScope;
-  /** Pre-cap count of warnings found. Present only when `scope` is `truncated`. */
   total?: number;
   warnings: LayoutWarning[];
 }

--- a/src/models/ObservationInsets.ts
+++ b/src/models/ObservationInsets.ts
@@ -64,3 +64,26 @@ export interface LayoutWarning {
   overlapPercent: number;
   confidence: "high" | "medium";
 }
+
+/**
+ * Completeness of an observation's {@link LayoutWarnings.warnings} list:
+ * - `full` — every warning the audit found is present.
+ * - `truncated` — the audit found more than `MAX_LAYOUT_WARNINGS`; `warnings`
+ *   holds the highest-priority cap and `total` is the pre-cap count.
+ * - `scoped` — the observe-scope transforms (`--observe-region`/`-focus`/
+ *   `-overview`) narrowed the list to elements still in the returned hierarchy.
+ */
+export type LayoutWarningsScope = "full" | "truncated" | "scoped";
+
+/**
+ * Report-only edge-to-edge / safe-area findings for an observation, always
+ * emitted under the single `layoutWarnings` key. `scope` records how the list
+ * relates to what the audit found; `total` is present only when `scope` is
+ * `truncated`.
+ */
+export interface LayoutWarnings {
+  scope: LayoutWarningsScope;
+  /** Pre-cap count of warnings found. Present only when `scope` is `truncated`. */
+  total?: number;
+  warnings: LayoutWarning[];
+}

--- a/src/models/ObserveResult.ts
+++ b/src/models/ObserveResult.ts
@@ -15,7 +15,7 @@ import { SelectedElement } from "../utils/interfaces/NavigationGraph";
 import { RawViewHierarchyResult } from "./RawViewHierarchyResult";
 import type { MediaView } from "../features/observe/IdentifyMediaViews";
 import type { ObserveError } from "../features/observe/ObserveError";
-import type { LayoutWarning, ObservationInsets } from "./ObservationInsets";
+import type { LayoutWarnings, ObservationInsets } from "./ObservationInsets";
 import type { ObserveScopeMetadata } from "./ObserveScope";
 
 export interface PredictionTarget {
@@ -128,15 +128,13 @@ export interface ObserveResult {
   /** Typed inset metadata. Present even when a platform cannot measure it. */
   insets?: ObservationInsets;
 
-  /** Potential edge-to-edge / safe-area layout problems flagged by the report-only auditor. */
-  layoutWarnings?: LayoutWarning[];
-
   /**
-   * Total warnings found when `layoutWarnings` was capped (shown =
-   * `layoutWarnings.length`, dropped = this minus shown). Absent when nothing
-   * was dropped. See `MAX_LAYOUT_WARNINGS`.
+   * Potential edge-to-edge / safe-area layout problems flagged by the
+   * report-only auditor. Always the single `layoutWarnings` key: an object whose
+   * `scope` records whether the `warnings` list is `full`, `truncated` (capped,
+   * with a `total`), or `scoped` (narrowed to the returned hierarchy).
    */
-  layoutWarningsTruncated?: number;
+  layoutWarnings?: LayoutWarnings;
 
   /** Screen rotation (0: portrait, 1: landscape 90°, 2: reverse portrait 180°, 3: reverse landscape 270°) */
   rotation?: number;

--- a/src/server/finalizeToolResponse.ts
+++ b/src/server/finalizeToolResponse.ts
@@ -10,6 +10,7 @@ import {
   buildObserveScopeConfig,
 } from "../features/observe/output/ObserveScopeExperiments";
 import type { ObserveScopeInput } from "../models/ObserveScope";
+import { capLayoutWarnings } from "../features/observe/audits/SafeAreaAuditor";
 import { isInPlacePressButton, isNavigationPressButton } from "../features/action/pressButtonPolicy";
 import { serverConfig } from "../utils/ServerConfig";
 import { getStructuredPayload, stringifyToolResponse } from "../utils/toolUtils";
@@ -315,7 +316,15 @@ export function finalizeToolResponse<T>(response: T, ctx: FinalizeToolResponseCo
         });
       }
     } else if (scopeActive) {
-      served = applyObserveScopeExperiments(sanitized, scopeConfig);
+      // Scope-then-cap (#5074): re-derive the served copy UNCAPPED so the scope
+      // transforms see every warning, then cap the scoped result — an in-scope
+      // warning is never lost to a cap taken against the full tree. The baseline
+      // above stays the capped `sanitized` full tree.
+      const uncapped = sanitizeObserveResult(observeResult, { ...cfg, capLayoutWarnings: false });
+      served = applyObserveScopeExperiments(uncapped, scopeConfig);
+      if (served.layoutWarnings) {
+        served.layoutWarnings = capLayoutWarnings(served.layoutWarnings);
+      }
     }
     sanitizedPayload = served as unknown as Record<string, unknown>;
     hasArtifactableObservation = true;

--- a/src/server/toolOutputSchemas.ts
+++ b/src/server/toolOutputSchemas.ts
@@ -463,8 +463,11 @@ export const observeResultSchema = z.object({
   screenSize: screenSizeSchema.optional(),
   systemInsets: systemInsetsSchema.optional(),
   insets: observationInsetsSchema.optional(),
-  layoutWarnings: z.array(layoutWarningSchema).optional(),
-  layoutWarningsTruncated: z.number().optional(),
+  layoutWarnings: z.object({
+    scope: z.enum(["full", "truncated", "scoped"]),
+    total: z.number().optional(),
+    warnings: z.array(layoutWarningSchema),
+  }).optional(),
   viewHierarchy: viewHierarchyResultSchema.optional(),
   skeleton: z.array(skeletonElementSchema).optional(),
   activeWindow: activeWindowSchema.optional(),

--- a/test/features/observe/ObserveScreen.test.ts
+++ b/test/features/observe/ObserveScreen.test.ts
@@ -800,6 +800,40 @@ describe("ObserveScreen", function() {
       expect(cachedB?.viewHierarchy).toBe("hierarchy-B");
     });
 
+    test("cached-result getters bound an uncapped layoutWarnings list (issue #5074)", async function() {
+      // The audit is cached UNCAPPED so the observe tool's scope-then-cap path sees
+      // the full set; the resource/registry getters that serialize the cache
+      // directly must still be bounded.
+      const screen = new RealObserveScreen(deviceA, new FakeAdbClientFactory(new FakeAdbExecutor()));
+      const result: ObserveResult = {
+        ...screen.createBaseResult(),
+        layoutWarnings: {
+          scope: "full",
+          warnings: Array.from({ length: 150 }, () => ({
+            type: "important-content-under-inset",
+            severity: "info",
+            element: { bounds: { left: 0, top: 0, right: 10, bottom: 10 } },
+            categories: ["text"],
+            insetTypes: ["systemBars"],
+            sides: ["top"],
+            overflowPx: { top: 1 },
+            insetPx: { top: 1 },
+            overlapPercent: 10,
+            confidence: "medium",
+          })),
+        },
+      };
+      await screen.cacheObserveResult(result);
+
+      const cachedForDevice = RealObserveScreen.getRecentCachedResultForDevice(deviceA.deviceId);
+      expect(cachedForDevice?.layoutWarnings?.scope).toBe("truncated");
+      expect(cachedForDevice?.layoutWarnings?.warnings).toHaveLength(100);
+      expect(cachedForDevice?.layoutWarnings?.total).toBe(150);
+
+      const cachedRecent = RealObserveScreen.getRecentCachedResult();
+      expect(cachedRecent?.layoutWarnings?.warnings).toHaveLength(100);
+    });
+
     test("getRecentCachedResult returns most recent across all devices", async function() {
       const now = Date.now();
       const timerA = new FakeTimer();

--- a/test/features/observe/audits/SafeAreaAuditor.test.ts
+++ b/test/features/observe/audits/SafeAreaAuditor.test.ts
@@ -342,27 +342,34 @@ describe("capLayoutWarnings", () => {
     confidence: "medium",
   });
 
-  test("scope is 'full' with the original array unchanged when at or under the cap", () => {
-    const warnings = Array.from({ length: MAX_LAYOUT_WARNINGS }, () => makeWarning("info", 1));
-    const result = capLayoutWarnings(warnings);
-    expect(result.scope).toBe("full");
-    expect(result.warnings).toBe(warnings);
+  test("returns the envelope unchanged when at or under the cap", () => {
+    const envelope = { scope: "full" as const, warnings: Array.from({ length: MAX_LAYOUT_WARNINGS }, () => makeWarning("info", 1)) };
+    const result = capLayoutWarnings(envelope);
+    expect(result).toBe(envelope);
     expect(result.total).toBeUndefined();
   });
 
   test("scope is 'truncated' with the pre-cap total when over the cap", () => {
     const warnings = Array.from({ length: MAX_LAYOUT_WARNINGS + 25 }, () => makeWarning("info", 1));
-    const result = capLayoutWarnings(warnings);
+    const result = capLayoutWarnings({ scope: "full", warnings });
     expect(result.scope).toBe("truncated");
     expect(result.warnings).toHaveLength(MAX_LAYOUT_WARNINGS);
     expect(result.total).toBe(MAX_LAYOUT_WARNINGS + 25);
+  });
+
+  test("a scoped list that overflows stays 'scoped' and gains a total", () => {
+    const warnings = Array.from({ length: MAX_LAYOUT_WARNINGS + 5 }, () => makeWarning("info", 1));
+    const result = capLayoutWarnings({ scope: "scoped", warnings });
+    expect(result.scope).toBe("scoped");
+    expect(result.warnings).toHaveLength(MAX_LAYOUT_WARNINGS);
+    expect(result.total).toBe(MAX_LAYOUT_WARNINGS + 5);
   });
 
   test("keeps the highest-severity, largest-overflow warnings when trimming", () => {
     // One high-priority (warning severity, large overflow) among many low ones.
     const low = Array.from({ length: MAX_LAYOUT_WARNINGS + 10 }, () => makeWarning("info", 1));
     const high = makeWarning("warning", 999);
-    const result = capLayoutWarnings([...low, high]);
+    const result = capLayoutWarnings({ scope: "full", warnings: [...low, high] });
     expect(result.warnings).toHaveLength(MAX_LAYOUT_WARNINGS);
     expect(result.warnings).toContain(high);
   });

--- a/test/features/observe/audits/SafeAreaAuditor.test.ts
+++ b/test/features/observe/audits/SafeAreaAuditor.test.ts
@@ -342,16 +342,18 @@ describe("capLayoutWarnings", () => {
     confidence: "medium",
   });
 
-  test("returns the original array unchanged when at or under the cap", () => {
+  test("scope is 'full' with the original array unchanged when at or under the cap", () => {
     const warnings = Array.from({ length: MAX_LAYOUT_WARNINGS }, () => makeWarning("info", 1));
     const result = capLayoutWarnings(warnings);
+    expect(result.scope).toBe("full");
     expect(result.warnings).toBe(warnings);
-    expect(result.total).toBe(MAX_LAYOUT_WARNINGS);
+    expect(result.total).toBeUndefined();
   });
 
-  test("caps to MAX_LAYOUT_WARNINGS and reports the pre-cap total when over", () => {
+  test("scope is 'truncated' with the pre-cap total when over the cap", () => {
     const warnings = Array.from({ length: MAX_LAYOUT_WARNINGS + 25 }, () => makeWarning("info", 1));
     const result = capLayoutWarnings(warnings);
+    expect(result.scope).toBe("truncated");
     expect(result.warnings).toHaveLength(MAX_LAYOUT_WARNINGS);
     expect(result.total).toBe(MAX_LAYOUT_WARNINGS + 25);
   });

--- a/test/features/observe/cache/FileSystemObserveCacheStore.test.ts
+++ b/test/features/observe/cache/FileSystemObserveCacheStore.test.ts
@@ -6,7 +6,9 @@ import { randomUUID } from "node:crypto";
 import {
   FileSystemObserveCacheStore,
   OBSERVE_RESULT_CACHE_TTL_MS,
+  normalizeCachedObserveResult,
 } from "../../../../src/features/observe/cache/FileSystemObserveCacheStore";
+import { capLayoutWarnings } from "../../../../src/features/observe/audits/SafeAreaAuditor";
 import { FakeTimer } from "../../../fakes/FakeTimer";
 import type { ObserveResult } from "../../../../src/models";
 
@@ -156,5 +158,46 @@ describe("FileSystemObserveCacheStore", function() {
     // The surviving file must be the fresh one, not the stale one.
     const restored = await store.getMostRecent("device-1");
     expect(restored?.updatedAt).toBe("fresh");
+  });
+});
+
+describe("normalizeCachedObserveResult — legacy layoutWarnings migration (#5074)", function() {
+  // A pre-#5074 daemon wrote layoutWarnings as an array plus a sibling number.
+  const warning = { type: "important-content-under-inset", severity: "info", element: { bounds: { left: 0, top: 0, right: 10, bottom: 10 } } };
+
+  test("wraps a legacy array + layoutWarningsTruncated into a truncated envelope", function() {
+    const result = normalizeCachedObserveResult({
+      updatedAt: "x", screenSize: { width: 1, height: 1 }, systemInsets: { top: 0, right: 0, bottom: 0, left: 0 },
+      layoutWarnings: [warning], layoutWarningsTruncated: 150,
+    });
+    expect(result.layoutWarnings).toEqual({ scope: "truncated", total: 150, warnings: [warning] } as never);
+    expect((result as Record<string, unknown>).layoutWarningsTruncated).toBeUndefined();
+  });
+
+  test("wraps a legacy array with no truncation as a full envelope", function() {
+    const result = normalizeCachedObserveResult({
+      updatedAt: "x", screenSize: { width: 1, height: 1 }, systemInsets: { top: 0, right: 0, bottom: 0, left: 0 },
+      layoutWarnings: [warning],
+    });
+    expect(result.layoutWarnings).toEqual({ scope: "full", warnings: [warning] } as never);
+  });
+
+  test("passes a modern envelope through unchanged", function() {
+    const envelope = { scope: "full" as const, warnings: [warning] };
+    const result = normalizeCachedObserveResult({
+      updatedAt: "x", screenSize: { width: 1, height: 1 }, systemInsets: { top: 0, right: 0, bottom: 0, left: 0 },
+      layoutWarnings: envelope,
+    });
+    expect(result.layoutWarnings).toBe(envelope as never);
+  });
+
+  test("a normalized legacy result no longer throws when capped (regression: #5074 finding 7)", function() {
+    const many = Array.from({ length: 150 }, () => warning);
+    const result = normalizeCachedObserveResult({
+      updatedAt: "x", screenSize: { width: 1, height: 1 }, systemInsets: { top: 0, right: 0, bottom: 0, left: 0 },
+      layoutWarnings: many,
+    });
+    expect(() => capLayoutWarnings(result.layoutWarnings!)).not.toThrow();
+    expect(capLayoutWarnings(result.layoutWarnings!).warnings).toHaveLength(100);
   });
 });

--- a/test/features/observe/output/ObserveScopeExperiments.test.ts
+++ b/test/features/observe/output/ObserveScopeExperiments.test.ts
@@ -490,7 +490,7 @@ describe("applyObserveScopeExperiments", () => {
 
 describe("applyObserveScopeExperiments — co-scopes layoutWarnings (issue #5074)", () => {
   type Bounds = { left: number; top: number; right: number; bottom: number };
-  type Warning = NonNullable<ObserveResult["layoutWarnings"]>[number];
+  type Warning = NonNullable<ObserveResult["layoutWarnings"]>["warnings"][number];
 
   // A warning anchored to a node's bounds. Only `element.bounds` matters here —
   // co-scoping keys on the element's location surviving in the pruned tree.
@@ -514,75 +514,77 @@ describe("applyObserveScopeExperiments — co-scopes layoutWarnings (issue #5074
   const ITEM2_BOUNDS: Bounds = { left: 0, top: 400, right: 1080, bottom: 600 };
   const NAV_BAR_BOUNDS: Bounds = { left: 0, top: 2300, right: 1080, bottom: 2400 };
 
-  test("REGION drops a warning whose element falls outside the crop", () => {
+  const boundsOf = (result: ObserveResult): Bounds[] =>
+    (result.layoutWarnings?.warnings ?? []).map(w => w.element.bounds as Bounds);
+
+  test("REGION drops a warning whose element falls outside the crop, marking scope 'scoped'", () => {
     const obs = androidFixture();
-    obs.layoutWarnings = [warningAt(HEADER_BOUNDS), warningAt(NAV_BAR_BOUNDS)];
+    obs.layoutWarnings = { scope: "full", warnings: [warningAt(HEADER_BOUNDS), warningAt(NAV_BAR_BOUNDS)] };
     // Top-half crop keeps HEADER (top:80), prunes NAV_BAR (top:2300 > 1200).
     const result = applyObserveScopeExperiments(obs, {
       focus: false, overview: false, region: true, regionBox: { x1: 0, y1: 0, x2: 1, y2: 0.5 },
     });
-    expect(result.layoutWarnings).toHaveLength(1);
-    expect(result.layoutWarnings![0].element.bounds).toEqual(HEADER_BOUNDS);
+    expect(result.layoutWarnings?.scope).toBe("scoped");
+    expect(result.layoutWarnings?.warnings).toHaveLength(1);
+    expect(result.layoutWarnings?.warnings[0].element.bounds).toEqual(HEADER_BOUNDS);
   });
 
   test("FOCUS drops a warning for pruned foreign chrome", () => {
     const obs = androidFixture();
-    obs.layoutWarnings = [warningAt(STATUS_BAR_BOUNDS), warningAt(HEADER_BOUNDS)];
+    obs.layoutWarnings = { scope: "full", warnings: [warningAt(STATUS_BAR_BOUNDS), warningAt(HEADER_BOUNDS)] };
     // Foreground-app focus prunes com.android.systemui chrome (status/nav bars).
     const result = applyObserveScopeExperiments(obs, { focus: true, overview: false, region: false });
-    const boundsList = (result.layoutWarnings ?? []).map(w => w.element.bounds);
-    expect(boundsList).toContainEqual(HEADER_BOUNDS);
-    expect(boundsList).not.toContainEqual(STATUS_BAR_BOUNDS);
+    expect(boundsOf(result)).toContainEqual(HEADER_BOUNDS);
+    expect(boundsOf(result)).not.toContainEqual(STATUS_BAR_BOUNDS);
   });
 
   test("OVERVIEW drops a warning for a collapsed anonymous leaf", () => {
     const obs = androidFixture();
     // HEADER is addressable (kept in the skeleton); Item 2 is an anonymous leaf (dropped).
-    obs.layoutWarnings = [warningAt(HEADER_BOUNDS), warningAt(ITEM2_BOUNDS)];
+    obs.layoutWarnings = { scope: "full", warnings: [warningAt(HEADER_BOUNDS), warningAt(ITEM2_BOUNDS)] };
     const result = applyObserveScopeExperiments(obs, { focus: false, overview: true, region: false });
-    const boundsList = (result.layoutWarnings ?? []).map(w => w.element.bounds);
-    expect(boundsList).toContainEqual(HEADER_BOUNDS);
-    expect(boundsList).not.toContainEqual(ITEM2_BOUNDS);
+    expect(boundsOf(result)).toContainEqual(HEADER_BOUNDS);
+    expect(boundsOf(result)).not.toContainEqual(ITEM2_BOUNDS);
   });
 
   test("matches against compacted-tuple node bounds", () => {
     const obs = androidFixture();
     // NAV_BAR node in compact tuple form; the warning element also compacted.
     roots(obs)[0].node![2].bounds = [0, 2300, 1080, 2400];
-    obs.layoutWarnings = [warningAt([0, 2300, 1080, 2400])];
+    obs.layoutWarnings = { scope: "full", warnings: [warningAt([0, 2300, 1080, 2400])] };
     // Full-screen region keeps everything, so the tuple-bounds warning survives.
     const result = applyObserveScopeExperiments(obs, {
       focus: false, overview: false, region: true, regionBox: { x1: 0, y1: 0, x2: 1, y2: 1 },
     });
-    expect(result.layoutWarnings).toHaveLength(1);
+    expect(result.layoutWarnings?.warnings).toHaveLength(1);
   });
 
-  test("clears layoutWarningsTruncated when scoping drops warnings", () => {
+  test("downgrades a truncated list to 'scoped' and drops total when scoping removes warnings", () => {
     const obs = androidFixture();
-    obs.layoutWarnings = [warningAt(HEADER_BOUNDS), warningAt(NAV_BAR_BOUNDS)];
-    obs.layoutWarningsTruncated = 137;
+    obs.layoutWarnings = { scope: "truncated", total: 137, warnings: [warningAt(HEADER_BOUNDS), warningAt(NAV_BAR_BOUNDS)] };
     const result = applyObserveScopeExperiments(obs, {
       focus: false, overview: false, region: true, regionBox: { x1: 0, y1: 0, x2: 1, y2: 0.5 },
     });
-    expect(result.layoutWarnings).toHaveLength(1);
-    expect(result.layoutWarningsTruncated).toBeUndefined();
+    expect(result.layoutWarnings?.scope).toBe("scoped");
+    expect(result.layoutWarnings?.total).toBeUndefined();
+    expect(result.layoutWarnings?.warnings).toHaveLength(1);
   });
 
-  test("leaves warnings and the truncation count untouched when all survive", () => {
+  test("leaves the envelope untouched (scope + total) when every warning survives", () => {
     const obs = androidFixture();
-    obs.layoutWarnings = [warningAt(HEADER_BOUNDS)];
-    obs.layoutWarningsTruncated = 137;
+    obs.layoutWarnings = { scope: "truncated", total: 137, warnings: [warningAt(HEADER_BOUNDS)] };
     // Full-screen region prunes nothing at HEADER, so the warning survives.
     const result = applyObserveScopeExperiments(obs, {
       focus: false, overview: false, region: true, regionBox: { x1: 0, y1: 0, x2: 1, y2: 1 },
     });
-    expect(result.layoutWarnings).toHaveLength(1);
-    expect(result.layoutWarningsTruncated).toBe(137);
+    expect(result.layoutWarnings?.scope).toBe("truncated");
+    expect(result.layoutWarnings?.total).toBe(137);
+    expect(result.layoutWarnings?.warnings).toHaveLength(1);
   });
 
   test("is pure — does not mutate the caller's layoutWarnings", () => {
     const obs = androidFixture();
-    obs.layoutWarnings = [warningAt(HEADER_BOUNDS), warningAt(NAV_BAR_BOUNDS)];
+    obs.layoutWarnings = { scope: "full", warnings: [warningAt(HEADER_BOUNDS), warningAt(NAV_BAR_BOUNDS)] };
     const before = JSON.stringify(obs);
     applyObserveScopeExperiments(obs, {
       focus: false, overview: false, region: true, regionBox: { x1: 0, y1: 0, x2: 1, y2: 0.5 },

--- a/test/features/observe/output/ObserveScopeExperiments.test.ts
+++ b/test/features/observe/output/ObserveScopeExperiments.test.ts
@@ -487,3 +487,106 @@ describe("applyObserveScopeExperiments", () => {
     expect(JSON.stringify(obs)).toBe(before);
   });
 });
+
+describe("applyObserveScopeExperiments — co-scopes layoutWarnings (issue #5074)", () => {
+  type Bounds = { left: number; top: number; right: number; bottom: number };
+  type Warning = NonNullable<ObserveResult["layoutWarnings"]>[number];
+
+  // A warning anchored to a node's bounds. Only `element.bounds` matters here —
+  // co-scoping keys on the element's location surviving in the pruned tree.
+  function warningAt(bounds: Bounds | number[]): Warning {
+    return {
+      type: "important-content-under-inset",
+      severity: "warning",
+      element: { bounds: bounds as Bounds },
+      categories: ["text"],
+      insetTypes: ["systemBars"],
+      sides: ["top"],
+      overflowPx: { top: 10 },
+      insetPx: { top: 80 },
+      overlapPercent: 100,
+      confidence: "medium",
+    };
+  }
+
+  const STATUS_BAR_BOUNDS: Bounds = { left: 0, top: 0, right: 1080, bottom: 80 };
+  const HEADER_BOUNDS: Bounds = { left: 0, top: 80, right: 1080, bottom: 200 };
+  const ITEM2_BOUNDS: Bounds = { left: 0, top: 400, right: 1080, bottom: 600 };
+  const NAV_BAR_BOUNDS: Bounds = { left: 0, top: 2300, right: 1080, bottom: 2400 };
+
+  test("REGION drops a warning whose element falls outside the crop", () => {
+    const obs = androidFixture();
+    obs.layoutWarnings = [warningAt(HEADER_BOUNDS), warningAt(NAV_BAR_BOUNDS)];
+    // Top-half crop keeps HEADER (top:80), prunes NAV_BAR (top:2300 > 1200).
+    const result = applyObserveScopeExperiments(obs, {
+      focus: false, overview: false, region: true, regionBox: { x1: 0, y1: 0, x2: 1, y2: 0.5 },
+    });
+    expect(result.layoutWarnings).toHaveLength(1);
+    expect(result.layoutWarnings![0].element.bounds).toEqual(HEADER_BOUNDS);
+  });
+
+  test("FOCUS drops a warning for pruned foreign chrome", () => {
+    const obs = androidFixture();
+    obs.layoutWarnings = [warningAt(STATUS_BAR_BOUNDS), warningAt(HEADER_BOUNDS)];
+    // Foreground-app focus prunes com.android.systemui chrome (status/nav bars).
+    const result = applyObserveScopeExperiments(obs, { focus: true, overview: false, region: false });
+    const boundsList = (result.layoutWarnings ?? []).map(w => w.element.bounds);
+    expect(boundsList).toContainEqual(HEADER_BOUNDS);
+    expect(boundsList).not.toContainEqual(STATUS_BAR_BOUNDS);
+  });
+
+  test("OVERVIEW drops a warning for a collapsed anonymous leaf", () => {
+    const obs = androidFixture();
+    // HEADER is addressable (kept in the skeleton); Item 2 is an anonymous leaf (dropped).
+    obs.layoutWarnings = [warningAt(HEADER_BOUNDS), warningAt(ITEM2_BOUNDS)];
+    const result = applyObserveScopeExperiments(obs, { focus: false, overview: true, region: false });
+    const boundsList = (result.layoutWarnings ?? []).map(w => w.element.bounds);
+    expect(boundsList).toContainEqual(HEADER_BOUNDS);
+    expect(boundsList).not.toContainEqual(ITEM2_BOUNDS);
+  });
+
+  test("matches against compacted-tuple node bounds", () => {
+    const obs = androidFixture();
+    // NAV_BAR node in compact tuple form; the warning element also compacted.
+    roots(obs)[0].node![2].bounds = [0, 2300, 1080, 2400];
+    obs.layoutWarnings = [warningAt([0, 2300, 1080, 2400])];
+    // Full-screen region keeps everything, so the tuple-bounds warning survives.
+    const result = applyObserveScopeExperiments(obs, {
+      focus: false, overview: false, region: true, regionBox: { x1: 0, y1: 0, x2: 1, y2: 1 },
+    });
+    expect(result.layoutWarnings).toHaveLength(1);
+  });
+
+  test("clears layoutWarningsTruncated when scoping drops warnings", () => {
+    const obs = androidFixture();
+    obs.layoutWarnings = [warningAt(HEADER_BOUNDS), warningAt(NAV_BAR_BOUNDS)];
+    obs.layoutWarningsTruncated = 137;
+    const result = applyObserveScopeExperiments(obs, {
+      focus: false, overview: false, region: true, regionBox: { x1: 0, y1: 0, x2: 1, y2: 0.5 },
+    });
+    expect(result.layoutWarnings).toHaveLength(1);
+    expect(result.layoutWarningsTruncated).toBeUndefined();
+  });
+
+  test("leaves warnings and the truncation count untouched when all survive", () => {
+    const obs = androidFixture();
+    obs.layoutWarnings = [warningAt(HEADER_BOUNDS)];
+    obs.layoutWarningsTruncated = 137;
+    // Full-screen region prunes nothing at HEADER, so the warning survives.
+    const result = applyObserveScopeExperiments(obs, {
+      focus: false, overview: false, region: true, regionBox: { x1: 0, y1: 0, x2: 1, y2: 1 },
+    });
+    expect(result.layoutWarnings).toHaveLength(1);
+    expect(result.layoutWarningsTruncated).toBe(137);
+  });
+
+  test("is pure — does not mutate the caller's layoutWarnings", () => {
+    const obs = androidFixture();
+    obs.layoutWarnings = [warningAt(HEADER_BOUNDS), warningAt(NAV_BAR_BOUNDS)];
+    const before = JSON.stringify(obs);
+    applyObserveScopeExperiments(obs, {
+      focus: false, overview: false, region: true, regionBox: { x1: 0, y1: 0, x2: 1, y2: 0.5 },
+    });
+    expect(JSON.stringify(obs)).toBe(before);
+  });
+});

--- a/test/features/observe/output/ObserveScopeExperiments.test.ts
+++ b/test/features/observe/output/ObserveScopeExperiments.test.ts
@@ -626,6 +626,31 @@ describe("applyObserveScopeExperiments — co-scopes layoutWarnings (issue #5074
     expect(result.layoutWarnings?.warnings).toHaveLength(1);
   });
 
+  test("rejects a same-bounds survivor whose strong id conflicts with the warning (finding 8)", () => {
+    const B: Bounds = { left: 0, top: 100, right: 400, bottom: 160 };
+    const obs = androidFixture();
+    // Two siblings share an exact rectangle and the same text but differ by
+    // resource-id. Anchor focus keeps only `kept`; `dropped` is pruned.
+    obs.viewHierarchy!.hierarchy.node = {
+      "resource-id": `${APP}:id/root`, "bounds": { left: 0, top: 0, right: 1080, bottom: 2400 },
+      "node": [
+        { "resource-id": `${APP}:id/kept`, "text": "OK", "bounds": B },
+        { "resource-id": `${APP}:id/dropped`, "text": "OK", "bounds": B },
+      ],
+    } as never;
+    const warn = (rid: string): Warning => ({ ...warningAt(B), element: { resourceId: rid, text: "OK", bounds: B } });
+    obs.layoutWarnings = { scope: "full", warnings: [warn(`${APP}:id/kept`), warn(`${APP}:id/dropped`)] };
+
+    const result = applyObserveScopeExperiments(obs, {
+      focus: true, focusAnchor: { resourceId: `${APP}:id/kept` }, overview: false, region: false,
+    });
+
+    // The shared text must NOT keep the pruned node's warning: its resource-id
+    // conflicts with the sole survivor's, so only `kept`'s warning remains.
+    const rids = (result.layoutWarnings?.warnings ?? []).map(w => w.element.resourceId);
+    expect(rids).toEqual([`${APP}:id/kept`]);
+  });
+
   test("is pure — does not mutate the caller's layoutWarnings", () => {
     const obs = androidFixture();
     obs.layoutWarnings = { scope: "full", warnings: [warningAt(HEADER_BOUNDS), warningAt(NAV_BAR_BOUNDS)] };

--- a/test/features/observe/output/ObserveScopeExperiments.test.ts
+++ b/test/features/observe/output/ObserveScopeExperiments.test.ts
@@ -582,6 +582,50 @@ describe("applyObserveScopeExperiments — co-scopes layoutWarnings (issue #5074
     expect(result.layoutWarnings?.warnings).toHaveLength(1);
   });
 
+  test("drops a warning whose identity differs from the surviving same-bounds node (finding 1)", () => {
+    const B: Bounds = { left: 0, top: 0, right: 1080, bottom: 200 };
+    const obs = androidFixture();
+    // Addressable card (kept by OVERVIEW) with an anonymous text child at IDENTICAL bounds (dropped).
+    obs.viewHierarchy!.hierarchy.node = {
+      "resource-id": `${APP}:id/root`, "bounds": { left: 0, top: 0, right: 1080, bottom: 2400 },
+      "node": [{ "resource-id": `${APP}:id/card`, "clickable": true, "bounds": B, "node": [{ text: "Buried", bounds: B }] }],
+    } as never;
+    obs.layoutWarnings = { scope: "full", warnings: [{ ...warningAt(B), element: { text: "Buried", bounds: B } }] };
+    const result = applyObserveScopeExperiments(obs, { focus: false, overview: true, region: false });
+    // The `card` survives at B but its identity (resource-id) doesn't match the
+    // warning's (text "Buried" — the dropped child), so the warning is dropped.
+    expect(result.layoutWarnings?.warnings).toHaveLength(0);
+    expect(result.layoutWarnings?.scope).toBe("scoped");
+  });
+
+  test("keeps a warning when the surviving same-bounds node has no identity to correlate (no false negative)", () => {
+    const B: Bounds = { left: 0, top: 0, right: 1080, bottom: 200 };
+    const obs = androidFixture();
+    // A clickable text leaf: OVERVIEW keeps it (clickable) but strips `text`.
+    obs.viewHierarchy!.hierarchy.node = {
+      "resource-id": `${APP}:id/root`, "bounds": { left: 0, top: 0, right: 1080, bottom: 2400 },
+      "node": [{ clickable: true, text: "Tap me", bounds: B }],
+    } as never;
+    obs.layoutWarnings = { scope: "full", warnings: [{ ...warningAt(B), element: { text: "Tap me", bounds: B } }] };
+    const result = applyObserveScopeExperiments(obs, { focus: false, overview: true, region: false });
+    // The leaf is genuinely visible at B; its identity was stripped, so the
+    // anonymous survivor is a wildcard match and the warning is retained.
+    expect(result.layoutWarnings?.warnings).toHaveLength(1);
+  });
+
+  test("downgrades a truncated list to 'scoped' and drops total once the hierarchy is pruned (finding 2)", () => {
+    const obs = androidFixture();
+    // Every shown warning survives the crop, but the list was truncated and the
+    // crop prunes nodes — so a capped-away warning could be out of view.
+    obs.layoutWarnings = { scope: "truncated", total: 137, warnings: [warningAt(HEADER_BOUNDS)] };
+    const result = applyObserveScopeExperiments(obs, {
+      focus: false, overview: false, region: true, regionBox: { x1: 0, y1: 0, x2: 1, y2: 0.5 },
+    });
+    expect(result.layoutWarnings?.scope).toBe("scoped");
+    expect(result.layoutWarnings?.total).toBeUndefined();
+    expect(result.layoutWarnings?.warnings).toHaveLength(1);
+  });
+
   test("is pure — does not mutate the caller's layoutWarnings", () => {
     const obs = androidFixture();
     obs.layoutWarnings = { scope: "full", warnings: [warningAt(HEADER_BOUNDS), warningAt(NAV_BAR_BOUNDS)] };

--- a/test/features/observe/output/ObserveScopeExperiments.test.ts
+++ b/test/features/observe/output/ObserveScopeExperiments.test.ts
@@ -538,13 +538,32 @@ describe("applyObserveScopeExperiments — co-scopes layoutWarnings (issue #5074
     expect(boundsOf(result)).not.toContainEqual(STATUS_BAR_BOUNDS);
   });
 
-  test("OVERVIEW drops a warning for a collapsed anonymous leaf", () => {
+  test("OVERVIEW alone retains warnings (matched before the structural collapse)", () => {
     const obs = androidFixture();
-    // HEADER is addressable (kept in the skeleton); Item 2 is an anonymous leaf (dropped).
+    // Item 2 is a leaf OVERVIEW collapses into the list. Its warning is matched
+    // against the pre-collapse tree, so it is retained — the location is still
+    // shown, represented by the kept `list` ancestor. Nothing is spatially
+    // removed, so scope stays "full".
     obs.layoutWarnings = { scope: "full", warnings: [warningAt(HEADER_BOUNDS), warningAt(ITEM2_BOUNDS)] };
     const result = applyObserveScopeExperiments(obs, { focus: false, overview: true, region: false });
     expect(boundsOf(result)).toContainEqual(HEADER_BOUNDS);
-    expect(boundsOf(result)).not.toContainEqual(ITEM2_BOUNDS);
+    expect(boundsOf(result)).toContainEqual(ITEM2_BOUNDS);
+    expect(result.layoutWarnings?.scope).toBe("full");
+  });
+
+  test("OVERVIEW does not strip iOS `$`-bag warnings (finding 9)", () => {
+    // iOS nodes hold bounds/identity in a `$` bag that OVERVIEW strips. Matching
+    // against the pre-overview tree keeps them; reading the post-overview tree
+    // would drop every iOS warning.
+    const B: Bounds = { left: 0, top: 80, right: 300, bottom: 140 };
+    const obs = androidFixture();
+    obs.viewHierarchy!.hierarchy.node = {
+      "$": { "resource-id": `${APP}:id/ios-root`, "bounds": { left: 0, top: 0, right: 1080, bottom: 2400 } },
+      "node": [{ $: { "resource-id": `${APP}:id/ios-cell`, "clickable": "true", "bounds": B } }],
+    } as never;
+    obs.layoutWarnings = { scope: "full", warnings: [{ ...warningAt(B), element: { resourceId: `${APP}:id/ios-cell`, bounds: B } }] };
+    const result = applyObserveScopeExperiments(obs, { focus: false, overview: true, region: false });
+    expect(result.layoutWarnings?.warnings).toHaveLength(1);
   });
 
   test("matches against compacted-tuple node bounds", () => {
@@ -582,35 +601,21 @@ describe("applyObserveScopeExperiments — co-scopes layoutWarnings (issue #5074
     expect(result.layoutWarnings?.warnings).toHaveLength(1);
   });
 
-  test("drops a warning whose identity differs from the surviving same-bounds node (finding 1)", () => {
+  test("retains an OVERVIEW-collapsed child's warning, matched before the collapse", () => {
     const B: Bounds = { left: 0, top: 0, right: 1080, bottom: 200 };
     const obs = androidFixture();
-    // Addressable card (kept by OVERVIEW) with an anonymous text child at IDENTICAL bounds (dropped).
+    // A card with a text child at identical bounds; OVERVIEW collapses the child.
     obs.viewHierarchy!.hierarchy.node = {
       "resource-id": `${APP}:id/root`, "bounds": { left: 0, top: 0, right: 1080, bottom: 2400 },
       "node": [{ "resource-id": `${APP}:id/card`, "clickable": true, "bounds": B, "node": [{ text: "Buried", bounds: B }] }],
     } as never;
     obs.layoutWarnings = { scope: "full", warnings: [{ ...warningAt(B), element: { text: "Buried", bounds: B } }] };
     const result = applyObserveScopeExperiments(obs, { focus: false, overview: true, region: false });
-    // The `card` survives at B but its identity (resource-id) doesn't match the
-    // warning's (text "Buried" — the dropped child), so the warning is dropped.
-    expect(result.layoutWarnings?.warnings).toHaveLength(0);
-    expect(result.layoutWarnings?.scope).toBe("scoped");
-  });
-
-  test("keeps a warning when the surviving same-bounds node has no identity to correlate (no false negative)", () => {
-    const B: Bounds = { left: 0, top: 0, right: 1080, bottom: 200 };
-    const obs = androidFixture();
-    // A clickable text leaf: OVERVIEW keeps it (clickable) but strips `text`.
-    obs.viewHierarchy!.hierarchy.node = {
-      "resource-id": `${APP}:id/root`, "bounds": { left: 0, top: 0, right: 1080, bottom: 2400 },
-      "node": [{ clickable: true, text: "Tap me", bounds: B }],
-    } as never;
-    obs.layoutWarnings = { scope: "full", warnings: [{ ...warningAt(B), element: { text: "Tap me", bounds: B } }] };
-    const result = applyObserveScopeExperiments(obs, { focus: false, overview: true, region: false });
-    // The leaf is genuinely visible at B; its identity was stripped, so the
-    // anonymous survivor is a wildcard match and the warning is retained.
+    // Matched against the pre-collapse tree, where the "Buried" child is present
+    // and uniquely identified by its text — so the warning is retained (its
+    // location is shown, summarized into the kept card).
     expect(result.layoutWarnings?.warnings).toHaveLength(1);
+    expect(result.layoutWarnings?.scope).toBe("full");
   });
 
   test("downgrades a truncated list to 'scoped' and drops total once the hierarchy is pruned (finding 2)", () => {
@@ -649,6 +654,30 @@ describe("applyObserveScopeExperiments — co-scopes layoutWarnings (issue #5074
     // conflicts with the sole survivor's, so only `kept`'s warning remains.
     const rids = (result.layoutWarnings?.warnings ?? []).map(w => w.element.resourceId);
     expect(rids).toEqual([`${APP}:id/kept`]);
+  });
+
+  test("rejects a same-bounds survivor whose content-desc conflicts (finding 10)", () => {
+    const B: Bounds = { left: 0, top: 100, right: 400, bottom: 160 };
+    const obs = androidFixture();
+    // Same bounds and text, but different content-desc and no resource-id.
+    obs.viewHierarchy!.hierarchy.node = {
+      "resource-id": `${APP}:id/root`, "bounds": { left: 0, top: 0, right: 1080, bottom: 2400 },
+      "node": [
+        { "resource-id": `${APP}:id/anchor`, "content-desc": "kept", "text": "OK", "bounds": B },
+        { "content-desc": "dropped", "text": "OK", "bounds": B },
+      ],
+    } as never;
+    const warn = (cd: string): Warning => ({ ...warningAt(B), element: { contentDesc: cd, text: "OK", bounds: B } });
+    obs.layoutWarnings = { scope: "full", warnings: [warn("kept"), warn("dropped")] };
+
+    const result = applyObserveScopeExperiments(obs, {
+      focus: true, focusAnchor: { resourceId: `${APP}:id/anchor` }, overview: false, region: false,
+    });
+
+    // Anchor focus keeps only the `kept` node; the shared text must not retain the
+    // `dropped` warning, because its content-desc conflicts with the survivor's.
+    const descs = (result.layoutWarnings?.warnings ?? []).map(w => w.element.contentDesc);
+    expect(descs).toEqual(["kept"]);
   });
 
   test("is pure — does not mutate the caller's layoutWarnings", () => {

--- a/test/features/observe/output/diffObserveResult.test.ts
+++ b/test/features/observe/output/diffObserveResult.test.ts
@@ -436,8 +436,9 @@ describe("diffObserveResult", () => {
       confidence: "high",
     } as const;
 
-    const diff = diffObserveResult(obs({ ...node }), obs({ ...node }, { layoutWarnings: [warning] }));
-    expect(diff.fields!.layoutWarnings).toEqual({ from: undefined, to: [warning] });
+    const layoutWarnings = { scope: "full", warnings: [warning] } as const;
+    const diff = diffObserveResult(obs({ ...node }), obs({ ...node }, { layoutWarnings }));
+    expect(diff.fields!.layoutWarnings).toEqual({ from: undefined, to: layoutWarnings });
     expect(DIFF_SCALAR_FIELDS).toContain("layoutWarnings");
   });
 
@@ -1403,16 +1404,16 @@ describe("diffObserveResult — volatile occlusion exclusion (#4399)", () => {
   });
 
   test("layout-warning confidence churn caused by occlusion is not reported", () => {
-    const baseline = obs(node(), { layoutWarnings: [warning("high")] });
-    const next = obs(node(), { layoutWarnings: [warning("medium")] });
+    const baseline = obs(node(), { layoutWarnings: { scope: "full", warnings: [warning("high")] } });
+    const next = obs(node(), { layoutWarnings: { scope: "full", warnings: [warning("medium")] } });
 
     expect(diffObserveResult(baseline, next).fields).toBeUndefined();
   });
 
   test("a substantive layout-warning change remains visible", () => {
-    const baseline = obs(node(), { layoutWarnings: [warning("high")] });
+    const baseline = obs(node(), { layoutWarnings: { scope: "full", warnings: [warning("high")] } });
     const next = obs(node(), {
-      layoutWarnings: [{ ...warning("medium"), severity: "info" }],
+      layoutWarnings: { scope: "full", warnings: [{ ...warning("medium"), severity: "info" }] },
     });
 
     expect(diffObserveResult(baseline, next).fields!.layoutWarnings).toBeDefined();
@@ -1564,8 +1565,7 @@ describe("diffObserveResult — all DIFF_SCALAR_FIELDS members (P6)", () => {
     },
     awaitTimeout: { from: false, to: true },
     awaitDuration: { from: undefined, to: 250 },
-    layoutWarnings: { from: undefined, to: [warning] },
-    layoutWarningsTruncated: { from: undefined, to: 150 },
+    layoutWarnings: { from: undefined, to: { scope: "full", warnings: [warning] } },
     error: { from: undefined, to: "capture failed" },
   };
 
@@ -1579,7 +1579,6 @@ describe("diffObserveResult — all DIFF_SCALAR_FIELDS members (P6)", () => {
     "error",
     "intentChooserDetected",
     "layoutWarnings",
-    "layoutWarningsTruncated",
     "notificationPermissionDetected",
     "rotation",
     "userId",

--- a/test/server/finalizeToolResponse.test.ts
+++ b/test/server/finalizeToolResponse.test.ts
@@ -1973,3 +1973,50 @@ describe("finalizeToolResponse observe scope experiments (#4344)", () => {
     expect(ids).toContain("com.android.systemui:id/status_bar");
   });
 });
+
+describe("finalizeToolResponse — scope-then-cap for layoutWarnings (issue #5074 finding 3)", () => {
+  test("an in-region warning survives even when 100+ higher-priority warnings are out of region", () => {
+    const W = 1080, H = 2400;
+    // One in-region node (top) plus 120 out-of-region nodes (bottom), each distinct bounds.
+    const inRegionBounds = { left: 0, top: 100, right: 200, bottom: 160 };
+    const outNodes = Array.from({ length: 120 }, (_, i) => ({
+      "resource-id": `com.example:id/out_${i}`,
+      "bounds": { left: 0, top: 1300 + i, right: 200, bottom: 1360 + i },
+    }));
+    const mkWarning = (bounds: Record<string, number>, severity: "warning" | "info", overflow: number): any => ({
+      type: "important-content-under-inset", severity, element: { bounds },
+      categories: ["text"], insetTypes: ["systemBars"], sides: ["top"],
+      overflowPx: { top: overflow }, insetPx: { top: overflow }, overlapPercent: 100, confidence: "medium",
+    });
+    const obs = {
+      updatedAt: 1, screenSize: { width: W, height: H }, systemInsets: { top: 0, bottom: 0, left: 0, right: 0 },
+      activeWindow: { appId: "com.example" },
+      viewHierarchy: { packageName: "com.example", hierarchy: { node: {
+        "resource-id": "com.example:id/root", "bounds": { left: 0, top: 0, right: W, bottom: H },
+        "node": [{ text: "in", bounds: inRegionBounds }, ...outNodes],
+      } } },
+      layoutWarnings: {
+        scope: "full",
+        warnings: [
+          // In-region warning is deliberately LOW priority, so a cap taken BEFORE
+          // scoping (the bug) would evict it in favor of the 120 out-of-region ones.
+          mkWarning(inRegionBounds, "info", 1),
+          ...outNodes.map(n => mkWarning(n.bounds, "warning", 999)),
+        ],
+      },
+    } as unknown as ObserveResult;
+
+    const finalized = finalizeToolResponse(createStructuredToolResponse(obs), {
+      name: "observe",
+      // project:"full" keeps the real hierarchy (default is the skeleton projection,
+      // which replaces it and cannot co-scope warnings).
+      args: { project: "full", scope: { region: { x1: 0, y1: 0, x2: 1, y2: 0.5 } } },
+    });
+
+    // Scope-then-cap: the crop keeps only the in-region node, so its warning is the
+    // sole survivor — never evicted by the 120 higher-priority out-of-region ones.
+    const served = finalized.structuredContent as ObserveResult;
+    expect(served.layoutWarnings?.scope).toBe("scoped");
+    expect(served.layoutWarnings?.warnings).toHaveLength(1);
+  });
+});

--- a/test/server/observeOutputSchema.test.ts
+++ b/test/server/observeOutputSchema.test.ts
@@ -186,6 +186,25 @@ describe("observeResultSchema: parses real captures (#3025)", () => {
     expect(() => observeResultSchema.parse(compacted)).not.toThrow();
   });
 
+  test("caps layoutWarnings by default and opts out with capLayoutWarnings:false", () => {
+    const warning = {
+      type: "important-content-under-inset", severity: "info",
+      element: { bounds: { left: 0, top: 0, right: 10, bottom: 10 } },
+      categories: ["text"], insetTypes: ["systemBars"], sides: ["top"],
+      overflowPx: { top: 1 }, insetPx: { top: 1 }, overlapPercent: 10, confidence: "medium",
+    };
+    const observe = { layoutWarnings: { scope: "full", warnings: Array.from({ length: 150 }, () => warning) } };
+
+    const capped = sanitizeObserveResult(observe as never, { dropElements: false });
+    expect(capped.layoutWarnings?.scope).toBe("truncated");
+    expect(capped.layoutWarnings?.warnings).toHaveLength(100);
+    expect(capped.layoutWarnings?.total).toBe(150);
+
+    const uncapped = sanitizeObserveResult(observe as never, { dropElements: false, capLayoutWarnings: false });
+    expect(uncapped.layoutWarnings?.scope).toBe("full");
+    expect(uncapped.layoutWarnings?.warnings).toHaveLength(150);
+  });
+
   test("accepts an iOS root hierarchy.bounds with optional left/top (points)", () => {
     // Hierarchy.bounds is `{left?, top?, right, bottom}` on iOS — the element
     // union (all four keys required) would wrongly reject it, so it rides

--- a/test/server/observeOutputSchema.test.ts
+++ b/test/server/observeOutputSchema.test.ts
@@ -78,22 +78,25 @@ describe("observeResultSchema: parses real captures (#3025)", () => {
           source: "ios-status-bar-manager",
         },
       },
-      layoutWarnings: [{
-        type: "important-content-under-inset",
-        severity: "warning",
-        element: { text: "Title", bounds: { top: 0, right: 100, bottom: 30, left: 0 } },
-        categories: ["text"],
-        insetTypes: ["safeArea"],
-        sides: ["top"],
-        overflowPx: { top: 30 },
-        insetPx: { top: 59.5 },
-        overlapPercent: 100,
-        confidence: "high",
-      }],
+      layoutWarnings: {
+        scope: "full",
+        warnings: [{
+          type: "important-content-under-inset",
+          severity: "warning",
+          element: { text: "Title", bounds: { top: 0, right: 100, bottom: 30, left: 0 } },
+          categories: ["text"],
+          insetTypes: ["safeArea"],
+          sides: ["top"],
+          overflowPx: { top: 30 },
+          insetPx: { top: 59.5 },
+          overlapPercent: 100,
+          confidence: "high",
+        }],
+      },
     });
 
     expect(parsed.success).toBe(true);
-    expect(parsed.data?.layoutWarnings?.[0]).toMatchObject({
+    expect(parsed.data?.layoutWarnings?.warnings[0]).toMatchObject({
       overflowPx: { top: 30 },
       insetPx: { top: 59.5 },
     });
@@ -161,22 +164,25 @@ describe("observeResultSchema: parses real captures (#3025)", () => {
   test("accepts compacted layout-warning bounds and fractional legacy iOS insets", () => {
     const observe = {
       systemInsets: { top: 59.5, right: 0, bottom: 34, left: 0 },
-      layoutWarnings: [{
-        type: "important-content-under-inset",
-        severity: "warning",
-        element: { text: "Title", bounds: { left: 0, top: 0, right: 100, bottom: 30 } },
-        categories: ["text"],
-        insetTypes: ["safeArea"],
-        sides: ["top"],
-        overflowPx: { top: 30 },
-        insetPx: { top: 59.5 },
-        overlapPercent: 100,
-        confidence: "high",
-      }],
+      layoutWarnings: {
+        scope: "full",
+        warnings: [{
+          type: "important-content-under-inset",
+          severity: "warning",
+          element: { text: "Title", bounds: { left: 0, top: 0, right: 100, bottom: 30 } },
+          categories: ["text"],
+          insetTypes: ["safeArea"],
+          sides: ["top"],
+          overflowPx: { top: 30 },
+          insetPx: { top: 59.5 },
+          overlapPercent: 100,
+          confidence: "high",
+        }],
+      },
     };
     const compacted = sanitizeObserveResult(observe as never, { dropElements: false, compact: true });
 
-    expect(compacted.layoutWarnings?.[0]?.element.bounds).toEqual([0, 0, 100, 30]);
+    expect(compacted.layoutWarnings?.warnings[0]?.element.bounds).toEqual([0, 0, 100, 30]);
     expect(() => observeResultSchema.parse(compacted)).not.toThrow();
   });
 


### PR DESCRIPTION
## Summary

Two related changes to the observe `layoutWarnings` output.

### 1. Consolidate `layoutWarnings` into a single scoped envelope

The current output (shipped in #5046) is two sibling keys — `layoutWarnings: LayoutWarning[]` and `layoutWarningsTruncated: number`. This replaces them with one always-present key whose `scope` records completeness:

```jsonc
"layoutWarnings": {
  "scope": "full" | "truncated" | "scoped",
  "total": 1000,            // only when scope === "truncated" (pre-cap count)
  "warnings": [ /* LayoutWarning[] */ ]
}
```

- **`full`** — every warning the audit found is present.
- **`truncated`** — capped at `MAX_LAYOUT_WARNINGS` (100), highest-severity/largest-overflow kept; `total` is the pre-cap count.
- **`scoped`** — the observe-scope transforms narrowed the list (see below); `total` is dropped.

### 2. Co-scope `layoutWarnings` with the returned hierarchy (closes #5074)

Since #5046 made the `SafeAreaAuditor` unconditional, `layoutWarnings` is computed on the **full** tree in `ObserveScreen`, before the observe-scope experiments (`--observe-focus`/`-region`/`-overview`) prune the hierarchy. A scoped response could therefore reference a pruned element. `applyObserveScopeExperiments` now filters `warnings` to those whose element's **bounds** still survive in the scoped tree and sets `scope: "scoped"`. One bounds-membership pass covers all three dimensions (`OVERVIEW_KEPT_ATTRS` keeps `bounds`; REGION/FOCUS keep kept nodes' bounds), and `readBounds` normalizes object and compact-tuple shapes.

Output-only and pure: the diff baseline and internal consumers keep the full list.

## Linked Issue

Closes #5074.

## Validation

- [x] `bun test` across the auditor, diff (`DIFF_SCALAR_FIELDS` P6 table + `layoutWarningsEqual` confidence-churn), output-schema, ObserveScreen, and scope suites — green (286 in the core set). Scope suite covers each transform dropping an out-of-scope warning, tuple-bounds matching, the `truncated → scoped` downgrade + `total` drop, the all-survive no-op, and purity.
- [x] `bun run build` passes; regenerated `schemas/tool-definitions.json`; `oxlint` clean on changed files (ObserveScreen's pre-existing complexity warnings only — `execute` actually dropped 31→30).
- [ ] `bun run typecheck` — not run locally (`tsgo` fetch blocked in this environment); CI baseline gate covers it.
- Note: `ObserveScopeExperiments.property.test.ts` can't run in this worktree (missing `fast-check` dev dep — node_modules drift); it has no `layoutWarnings` coupling and runs in CI.

## Note

This supersedes the shape shipped by #5046 — a deliberate output-contract change requested after that PR merged; there are no external consumers of the old two-key form in-repo (Android/iOS included).
