### PR TITLE
feat(ios): add WKWebView observation bridge

### DIFF
--- a/ios/auto-mobile-sdk/Sources/AutoMobileSDK/AutoMobileSDK.docc/AutoMobileSDK.md
+++ b/ios/auto-mobile-sdk/Sources/AutoMobileSDK/AutoMobileSDK.docc/AutoMobileSDK.md
@@ -59,6 +59,10 @@ AutoMobileSDK.shared.initialize(configuration: config)
 
 - ``AutoMobileNetwork``
 - ``AutoMobileURLProtocol``
+- ``AutoMobileWebViewBridge``
+- ``AutoMobileWebViewConfiguration``
+- ``AutoMobileWebSnapshot``
+- ``AutoMobileWebAction``
 - ``RetryPolicy``
 - ``WebSocketFrameDirection``
 - ``WebSocketFrameType``

--- a/ios/auto-mobile-sdk/Sources/AutoMobileSDK/AutoMobileSDK.swift
+++ b/ios/auto-mobile-sdk/Sources/AutoMobileSDK/AutoMobileSDK.swift
@@ -232,6 +232,11 @@ public final class AutoMobileSDK: @unchecked Sendable {
         eventBuffer?.flush()
     }
 
+    public func recordWebViewEvent(_ event: SdkWebViewEvent) {
+        guard isEnabled else { return }
+        eventBuffer?.add(event)
+    }
+
     /// Number of registered listeners.
     public var listenerCount: Int {
         lock.lock()

--- a/ios/auto-mobile-sdk/Sources/AutoMobileSDK/Events/SdkEvent.swift
+++ b/ios/auto-mobile-sdk/Sources/AutoMobileSDK/Events/SdkEvent.swift
@@ -23,6 +23,7 @@ public enum SdkEventType: String, Codable, Sendable {
     case interaction
     case storageChanged = "storage_changed"
     case viewHierarchy = "view_hierarchy"
+    case webView = "webview"
 }
 
 // MARK: - Event Types

--- a/ios/auto-mobile-sdk/Sources/AutoMobileSDK/Persistence/EventPersistence.swift
+++ b/ios/auto-mobile-sdk/Sources/AutoMobileSDK/Persistence/EventPersistence.swift
@@ -156,6 +156,8 @@ final class FileEventPersistence: EventPersisting, @unchecked Sendable {
             return try? decoder.decode(SdkStorageChangedEvent.self, from: data)
         case .viewHierarchy:
             return try? decoder.decode(SdkViewHierarchyEvent.self, from: data)
+        case .webView:
+            return try? decoder.decode(SdkWebViewEvent.self, from: data)
         }
     }
 }

--- a/ios/auto-mobile-sdk/Sources/AutoMobileSDK/WebKit/AutoMobileWebViewBridge.swift
+++ b/ios/auto-mobile-sdk/Sources/AutoMobileSDK/WebKit/AutoMobileWebViewBridge.swift
@@ -1,0 +1,362 @@
+import Foundation
+
+/// A stable description of an interactive element in a web document.
+public struct AutoMobileWebElement: Codable, Sendable, Equatable {
+    public let id: String
+    public let role: String?
+    public let label: String?
+    public let value: String?
+    public let bounds: [Double]
+    public let enabled: Bool
+    public let visible: Bool
+    public let focused: Bool
+
+    public init(
+        id: String,
+        role: String? = nil,
+        label: String? = nil,
+        value: String? = nil,
+        bounds: [Double] = [],
+        enabled: Bool = true,
+        visible: Bool = true,
+        focused: Bool = false
+    ) {
+        self.id = id
+        self.role = role
+        self.label = label
+        self.value = value
+        self.bounds = bounds
+        self.enabled = enabled
+        self.visible = visible
+        self.focused = focused
+    }
+}
+
+/// A bounded DOM snapshot. Element IDs are valid only for this snapshot.
+public struct AutoMobileWebSnapshot: Codable, Sendable, Equatable {
+    public let snapshotId: String
+    public let url: String?
+    public let title: String?
+    public let elements: [AutoMobileWebElement]
+
+    public init(
+        snapshotId: String = UUID().uuidString,
+        url: String? = nil,
+        title: String? = nil,
+        elements: [AutoMobileWebElement] = []
+    ) {
+        self.snapshotId = snapshotId
+        self.url = url
+        self.title = title
+        self.elements = elements
+    }
+}
+
+/// Policy for attaching the bridge to a web view.
+public struct AutoMobileWebViewConfiguration: Sendable {
+    public let allowedOrigins: Set<String>
+    public let allowedFrames: Set<String>
+    public let maxElements: Int
+    public let maxMessageBytes: Int
+    public let contentWorldName: String
+    public let redactText: Bool
+
+    public init(
+        allowedOrigins: Set<String> = [],
+        allowedFrames: Set<String> = [],
+        maxElements: Int = 500,
+        maxMessageBytes: Int = 256 * 1024,
+        contentWorldName: String = "AutoMobile",
+        redactText: Bool = true
+    ) {
+        self.allowedOrigins = allowedOrigins
+        self.allowedFrames = allowedFrames
+        self.maxElements = max(maxElements, 1)
+        self.maxMessageBytes = max(maxMessageBytes, 1024)
+        self.contentWorldName = contentWorldName
+        self.redactText = redactText
+    }
+}
+
+/// Actions accepted by the web bridge. Each action must name the snapshot it
+/// was derived from, preventing stale element IDs from being reused.
+public enum AutoMobileWebAction: Codable, Sendable, Equatable {
+    case click(snapshotId: String, elementId: String)
+    case focus(snapshotId: String, elementId: String)
+    case insertText(snapshotId: String, elementId: String, text: String)
+    case select(snapshotId: String, elementId: String, value: String)
+    case scroll(snapshotId: String, elementId: String?, x: Double, y: Double)
+    case evaluateJavaScript(String)
+}
+
+/// WebKit and DOM lifecycle event emitted by ``AutoMobileWebViewBridge``.
+public struct SdkWebViewEvent: SdkEvent {
+    public private(set) var eventType: SdkEventType = .webView
+    public let timestamp: Int64
+    public let webViewId: String
+    public let name: String
+    public let url: String?
+    public let frameId: String?
+    public let requestId: String?
+    public let metadata: [String: String]
+
+    public init(
+        timestamp: Int64 = Int64(Date().timeIntervalSince1970 * 1000),
+        webViewId: String,
+        name: String,
+        url: String? = nil,
+        frameId: String? = nil,
+        requestId: String? = nil,
+        metadata: [String: String] = [:]
+    ) {
+        self.timestamp = timestamp
+        self.webViewId = webViewId
+        self.name = name
+        self.url = url
+        self.frameId = frameId
+        self.requestId = requestId
+        self.metadata = metadata
+    }
+}
+
+/// Validates bridge policy and action references without requiring WebKit.
+public final class AutoMobileWebViewPolicy: @unchecked Sendable {
+    private let configuration: AutoMobileWebViewConfiguration
+    private let lock = NSLock()
+    private var latestSnapshots: [String: AutoMobileWebSnapshot] = [:]
+
+    public init(configuration: AutoMobileWebViewConfiguration = .init()) {
+        self.configuration = configuration
+    }
+
+    public func allows(url: URL?, frameId: String?) -> Bool {
+        guard let url, let scheme = url.scheme?.lowercased(), scheme == "https" || scheme == "http" else {
+            return false
+        }
+        let origin = "\(scheme)://\(url.host ?? "")\(url.port.map { ":\($0)" } ?? "")"
+        let originAllowed = configuration.allowedOrigins.contains(origin)
+        let frameAllowed = frameId.map { configuration.allowedFrames.isEmpty || configuration.allowedFrames.contains($0) } ?? configuration.allowedFrames.isEmpty
+        return originAllowed && frameAllowed
+    }
+
+    public func accept(_ snapshot: AutoMobileWebSnapshot) -> AutoMobileWebSnapshot {
+        let bounded = AutoMobileWebSnapshot(
+            snapshotId: snapshot.snapshotId,
+            url: snapshot.url,
+            title: snapshot.title,
+            elements: Array(snapshot.elements.prefix(configuration.maxElements)).map { element in
+                guard configuration.redactText else { return element }
+                return AutoMobileWebElement(
+                    id: element.id, role: element.role, label: element.label,
+                    value: element.value == nil ? nil : "[REDACTED]",
+                    bounds: element.bounds, enabled: element.enabled,
+                    visible: element.visible, focused: element.focused
+                )
+            }
+        )
+        lock.lock()
+        latestSnapshots[bounded.snapshotId] = bounded
+        if latestSnapshots.count > 4, let first = latestSnapshots.keys.sorted().first {
+            latestSnapshots.removeValue(forKey: first)
+        }
+        lock.unlock()
+        return bounded
+    }
+
+    public func validates(_ action: AutoMobileWebAction) -> Bool {
+        guard case .evaluateJavaScript = action else {
+            let snapshotId: String
+            let elementId: String?
+            switch action {
+            case let .click(id, element): snapshotId = id; elementId = element
+            case let .focus(id, element): snapshotId = id; elementId = element
+            case let .insertText(id, element, _): snapshotId = id; elementId = element
+            case let .select(id, element, _): snapshotId = id; elementId = element
+            case let .scroll(id, element, _, _): snapshotId = id; elementId = element
+            case .evaluateJavaScript: return false
+            }
+            lock.lock()
+            defer { lock.unlock() }
+            guard let snapshot = latestSnapshots[snapshotId] else { return false }
+            return elementId.map { element in
+                snapshot.elements.contains { $0.id == element && $0.enabled && $0.visible }
+            } ?? true
+        }
+        return false
+    }
+}
+
+#if canImport(WebKit)
+import WebKit
+
+/// Opt-in WKWebView observation and bounded control bridge.
+public final class AutoMobileWebViewBridge: NSObject, WKScriptMessageHandler, WKNavigationDelegate, @unchecked Sendable {
+    public let webViewId: String
+    public let configuration: AutoMobileWebViewConfiguration
+    public let policy: AutoMobileWebViewPolicy
+    private let emitEvent: @Sendable (SdkWebViewEvent) -> Void
+    private let recorder: NetworkCaptureRecorder?
+    private weak var webView: WKWebView?
+    private let requestLock = NSLock()
+    private var nativeRequestIds: [String: String] = [:]
+
+    public init(
+        webViewId: String = UUID().uuidString,
+        configuration: AutoMobileWebViewConfiguration = .init(),
+        recorder: NetworkCaptureRecorder? = nil,
+        emitEvent: @escaping @Sendable (SdkWebViewEvent) -> Void = { event in
+            AutoMobileSDK.shared.recordWebViewEvent(event)
+        }
+    ) {
+        self.webViewId = webViewId
+        self.configuration = configuration
+        self.policy = AutoMobileWebViewPolicy(configuration: configuration)
+        self.recorder = recorder
+        self.emitEvent = emitEvent
+    }
+
+    public func attach(to webView: WKWebView) {
+        self.webView = webView
+        let controller = webView.configuration.userContentController
+        controller.removeScriptMessageHandler(forName: "automobile")
+        let world = WKContentWorld.world(name: configuration.contentWorldName)
+        controller.add(self, contentWorld: world, name: "automobile")
+        controller.addUserScript(WKUserScript(source: Self.script, injectionTime: .atDocumentStart, forMainFrameOnly: false, in: world))
+        webView.navigationDelegate = self
+        emit(name: "bridge_attached", url: webView.url)
+    }
+
+    public func detach() {
+        webView?.configuration.userContentController.removeScriptMessageHandler(forName: "automobile")
+        webView?.navigationDelegate = nil
+        webView = nil
+    }
+
+    public func userContentController(_ userContentController: WKUserContentController, didReceive message: WKScriptMessage) {
+        if let bodyData = try? JSONSerialization.data(withJSONObject: message.body),
+           bodyData.count > configuration.maxMessageBytes {
+            return
+        }
+        guard let body = message.body as? [String: Any],
+              let name = body["name"] as? String else { return }
+        let url = webView?.url
+        guard policy.allows(url: url, frameId: body["frameId"] as? String) else { return }
+        var metadata = body.compactMapValues { value -> String? in
+            guard !(value is [Any]) && !(value is [String: Any]) else { return nil }
+            return String(describing: value)
+        }
+        metadata.removeValue(forKey: "name")
+        let scriptRequestId = body["requestId"] as? String
+        var requestId = scriptRequestId
+        if name == "request_started", let scriptRequestId,
+           let requestURL = body["url"] as? String {
+            let nativeId = recorder?.beginRequest(
+                url: requestURL,
+                method: (body["method"] as? String) ?? "GET",
+                connectionId: webViewId,
+                protocolName: "webview"
+            )
+            if let nativeId {
+                requestLock.lock()
+                nativeRequestIds[scriptRequestId] = nativeId
+                requestLock.unlock()
+                requestId = nativeId
+            }
+        } else if let scriptRequestId {
+            requestLock.lock()
+            requestId = nativeRequestIds[scriptRequestId] ?? scriptRequestId
+            if name == "request_finished" || name == "request_failed" {
+                nativeRequestIds.removeValue(forKey: scriptRequestId)
+            }
+            requestLock.unlock()
+        }
+        if name == "request_finished", let requestId {
+            recorder?.recordCompletion(requestId: requestId, statusCode: body["status"] as? Int)
+        } else if name == "request_failed", let requestId {
+            recorder?.recordFailure(requestId: requestId, error: (body["error"] as? String) ?? "Web request failed")
+        }
+        if name == "snapshot", let elements = body["elements"] as? [[String: Any]] {
+            let decoded = elements.prefix(configuration.maxElements).compactMap { element -> AutoMobileWebElement? in
+                guard let id = element["id"] as? String else { return nil }
+                let bounds = (element["bounds"] as? [NSNumber])?.map(\.doubleValue) ?? []
+                return AutoMobileWebElement(
+                    id: id,
+                    role: element["role"] as? String,
+                    label: element["label"] as? String,
+                    value: element["value"] as? String,
+                    bounds: bounds,
+                    enabled: (element["enabled"] as? Bool) ?? true,
+                    visible: (element["visible"] as? Bool) ?? true,
+                    focused: (element["focused"] as? Bool) ?? false
+                )
+            }
+            _ = policy.accept(AutoMobileWebSnapshot(snapshotId: body["snapshotId"] as? String ?? UUID().uuidString, url: url?.absoluteString, elements: decoded))
+        }
+        emit(name: name, url: url, frameId: body["frameId"] as? String, requestId: requestId, metadata: metadata)
+    }
+
+    public func perform(_ action: AutoMobileWebAction, completion: @escaping (Result<Void, Error>) -> Void) {
+        guard policy.validates(action) || (ifEvaluate(action) && policy.allows(url: webView?.url, frameId: nil)) else {
+            completion(.failure(NSError(domain: "AutoMobileWebViewBridge", code: 1, userInfo: [NSLocalizedDescriptionKey: "Stale or disallowed web action"])))
+            return
+        }
+        let source: String
+        switch action {
+        case let .click(_, id): source = "document.querySelector('[data-automobile-id=\"\(id)\"]')?.click()"
+        case let .focus(_, id): source = "document.querySelector('[data-automobile-id=\"\(id)\"]')?.focus()"
+        case let .insertText(_, id, text): source = "(() => { const e=document.querySelector('[data-automobile-id=\"\(id)\"]'); e.value=\(Self.json(text)); e.dispatchEvent(new Event('input',{bubbles:true})); })()"
+        case let .select(_, id, value): source = "(() => { const e=document.querySelector('[data-automobile-id=\"\(id)\"]'); e.value=\(Self.json(value)); e.dispatchEvent(new Event('change',{bubbles:true})); })()"
+        case let .scroll(_, id, x, y): source = "document.querySelector('\(id.map { "[data-automobile-id=\"\($0)\"]" } ?? "body")')?.scrollBy(\(x),\(y))"
+        case let .evaluateJavaScript(script): source = script
+        }
+        webView?.evaluateJavaScript(source) { _, error in
+            if let error { completion(.failure(error)) } else { completion(.success(())) }
+        }
+    }
+
+    public func webView(_ webView: WKWebView, didFinish navigation: WKNavigation!) { emit(name: "navigation_finished", url: webView.url) }
+    public func webView(_ webView: WKWebView, didFail navigation: WKNavigation!, withError error: Error) { emit(name: "navigation_failed", url: webView.url, metadata: ["error": error.localizedDescription]) }
+    public func webView(_ webView: WKWebView, didCommit navigation: WKNavigation!) { emit(name: "navigation_committed", url: webView.url) }
+    public func webViewWebContentProcessDidTerminate(_ webView: WKWebView) {
+        emit(name: "content_process_terminated", url: webView.url)
+        attach(to: webView)
+        webView.reload()
+    }
+
+    private func ifEvaluate(_ action: AutoMobileWebAction) -> Bool {
+        if case .evaluateJavaScript = action { return true }
+        return false
+    }
+    private func emit(name: String, url: URL?, frameId: String? = nil, requestId: String? = nil, metadata: [String: String] = [:]) {
+        emitEvent(SdkWebViewEvent(webViewId: webViewId, name: name, url: url?.absoluteString, frameId: frameId, requestId: requestId, metadata: metadata))
+    }
+    private static func json(_ string: String) -> String {
+        (try? String(data: JSONEncoder().encode(string), encoding: .utf8)) ?? "\"\""
+    }
+    private static let script = #"""
+    (() => {
+      const post = (name, extra = {}) => window.webkit?.messageHandlers?.automobile?.postMessage({name, frameId: location.href, ...extra});
+      const snapshot = () => {
+        const elements = [...document.querySelectorAll('button,a,input,textarea,select,[role]')].map((e, i) => {
+          const id = e.dataset.automobileId || (e.dataset.automobileId = `e${i}`);
+          const r = e.getBoundingClientRect();
+          return {id, role: e.getAttribute('role') || e.tagName.toLowerCase(), label: e.getAttribute('aria-label') || e.textContent?.trim().slice(0, 200), value: e.value || null, bounds: [r.x,r.y,r.width,r.height], enabled: !e.disabled, visible: r.width > 0 && r.height > 0, focused: document.activeElement === e};
+        });
+        post('snapshot', {snapshotId: `${Date.now()}-${Math.random()}`, elements});
+      };
+      new MutationObserver(snapshot).observe(document, {subtree:true, childList:true, attributes:true});
+      addEventListener('load', snapshot); addEventListener('hashchange', () => post('spa_navigation')); addEventListener('popstate', () => post('history_navigation'));
+      const push = history.pushState, replace = history.replaceState;
+      history.pushState = (...a) => { const r = push.apply(history, a); post('history_navigation'); return r; };
+      history.replaceState = (...a) => { const r = replace.apply(history, a); post('history_navigation'); return r; };
+      addEventListener('error', e => post('javascript_exception', {message: e.message})); addEventListener('unhandledrejection', e => post('javascript_exception', {message: String(e.reason)}));
+      for (const level of ['log','warn','error']) { const old = console[level]; console[level] = (...a) => { post('console', {level, message: a.map(String).join(' ')}); old.apply(console, a); }; }
+      const oldFetch = window.fetch; window.fetch = (...a) => { const requestId = crypto.randomUUID(); post('request_started', {requestId, url: String(a[0]), method: a[1]?.method || a[0]?.method || 'GET'}); return oldFetch(...a).then(r => { post('request_finished', {requestId, url:r.url, status:r.status}); return r; }, e => { post('request_failed', {requestId, error:String(e)}); throw e; }); };
+      const oldOpen = XMLHttpRequest.prototype.open, oldSend = XMLHttpRequest.prototype.send;
+      XMLHttpRequest.prototype.open = function(method, url) { this.__automobile = {requestId: crypto.randomUUID(), method, url:String(url)}; return oldOpen.apply(this, arguments); };
+      XMLHttpRequest.prototype.send = function(body) { const x = this.__automobile || {requestId:crypto.randomUUID(), method:'GET', url:location.href}; post('request_started', x); this.addEventListener('loadend', () => post(this.status >= 400 ? 'request_failed' : 'request_finished', {requestId:x.requestId, url:x.url, status:this.status})); return oldSend.apply(this, arguments); };
+      const NativeWebSocket = window.WebSocket; window.WebSocket = function(url, protocols) { const ws = protocols === undefined ? new NativeWebSocket(url) : new NativeWebSocket(url, protocols); const connectionId = crypto.randomUUID(); post('websocket_started', {url:String(url), connectionId}); ws.addEventListener('message', e => post('websocket_received', {url:String(url), connectionId, payloadSize: String(e.data).length})); const send = ws.send; ws.send = function(data) { post('websocket_sent', {url:String(url), connectionId, payloadSize:String(data).length}); return send.call(ws, data); }; ws.addEventListener('close', () => post('websocket_closed', {url:String(url), connectionId})); return ws; }; window.WebSocket.prototype = NativeWebSocket.prototype;
+    })();
+    """#
+}
+#endif

--- a/ios/auto-mobile-sdk/Tests/AutoMobileSDKTests/WebViewBridgeTests.swift
+++ b/ios/auto-mobile-sdk/Tests/AutoMobileSDKTests/WebViewBridgeTests.swift
@@ -1,0 +1,49 @@
+import XCTest
+@testable import AutoMobileSDK
+
+final class WebViewBridgeTests: XCTestCase {
+    func testPolicyBoundsAndRedactsSnapshot() {
+        let policy = AutoMobileWebViewPolicy(configuration: AutoMobileWebViewConfiguration(maxElements: 1))
+        let snapshot = policy.accept(AutoMobileWebSnapshot(elements: [
+            AutoMobileWebElement(id: "first", value: "secret"),
+            AutoMobileWebElement(id: "second"),
+        ]))
+
+        XCTAssertEqual(snapshot.elements.count, 1)
+        XCTAssertEqual(snapshot.elements[0].value, "[REDACTED]")
+        XCTAssertTrue(policy.validates(.click(snapshotId: snapshot.snapshotId, elementId: "first")))
+        XCTAssertFalse(policy.validates(.click(snapshotId: snapshot.snapshotId, elementId: "second")))
+    }
+
+    func testActionsRejectUnknownAndStaleSnapshots() {
+        let policy = AutoMobileWebViewPolicy()
+        let snapshot = policy.accept(AutoMobileWebSnapshot(elements: [
+            AutoMobileWebElement(id: "button"),
+        ]))
+
+        XCTAssertTrue(policy.validates(.focus(snapshotId: snapshot.snapshotId, elementId: "button")))
+        XCTAssertFalse(policy.validates(.focus(snapshotId: "stale", elementId: "button")))
+        XCTAssertFalse(policy.validates(.evaluateJavaScript("document.body")))
+    }
+
+    func testOriginAndFrameAllowlist() {
+        let policy = AutoMobileWebViewPolicy(configuration: AutoMobileWebViewConfiguration(
+            allowedOrigins: ["https://example.test"],
+            allowedFrames: ["https://example.test/"]
+        ))
+
+        XCTAssertTrue(policy.allows(url: URL(string: "https://example.test/page"), frameId: "https://example.test/"))
+        XCTAssertFalse(policy.allows(url: URL(string: "https://other.test/page"), frameId: "https://example.test/"))
+        XCTAssertFalse(policy.allows(url: URL(string: "https://example.test/page"), frameId: "other"))
+        XCTAssertFalse(policy.allows(url: URL(string: "file:///tmp/page"), frameId: nil))
+        XCTAssertFalse(AutoMobileWebViewPolicy().allows(url: URL(string: "https://example.test/page"), frameId: nil))
+    }
+
+    func testWebViewEventEncodesWireType() throws {
+        let event = SdkWebViewEvent(webViewId: "web", name: "request_started", requestId: "req")
+        let data = try JSONEncoder().encode(event)
+        let object = try XCTUnwrap(JSONSerialization.jsonObject(with: data) as? [String: Any])
+        XCTAssertEqual(object["eventType"] as? String, "webview")
+        XCTAssertEqual(object["requestId"] as? String, "req")
+    }
+}

--- a/ios/auto-mobile-sdk/api/auto-mobile-sdk.api
+++ b/ios/auto-mobile-sdk/api/auto-mobile-sdk.api
@@ -23,6 +23,7 @@ public final class AutoMobileSDK: @unchecked Sendable
   public func removeNavigationListener(_ listener: NavigationListener)
   public func clearNavigationListeners()
   public func notifyNavigationEvent(_ event: NavigationEvent)
+  public func recordWebViewEvent(_ event: SdkWebViewEvent)
   public var listenerCount: Int
   public func currentSessionId() -> String?
   public func addBreadcrumb( message: String, category: BreadcrumbCategory = .custom, metadata: [String: String] = [:] )
@@ -652,3 +653,58 @@ public final class ViewHierarchyTracker: @unchecked Sendable
 public enum ViewHierarchyWalker
   public static func walk(bundleId: String? = nil) -> SdkViewHierarchy
   public static func computeHash(_ hierarchy: SdkViewHierarchy) -> Int
+
+// WebKit/AutoMobileWebViewBridge.swift
+public struct AutoMobileWebElement: Codable, Sendable, Equatable
+  public let id: String
+  public let role: String?
+  public let label: String?
+  public let value: String?
+  public let bounds: [Double]
+  public let enabled: Bool
+  public let visible: Bool
+  public let focused: Bool
+  public init( id: String, role: String? = nil, label: String? = nil, value: String? = nil, bounds: [Double] = [], enabled: Bool = true, visible: Bool = true, focused: Bool = false )
+public struct AutoMobileWebSnapshot: Codable, Sendable, Equatable
+  public let snapshotId: String
+  public let url: String?
+  public let title: String?
+  public let elements: [AutoMobileWebElement]
+  public init( snapshotId: String = UUID().uuidString, url: String? = nil, title: String? = nil, elements: [AutoMobileWebElement] = [] )
+public struct AutoMobileWebViewConfiguration: Sendable
+  public let allowedOrigins: Set<String>
+  public let allowedFrames: Set<String>
+  public let maxElements: Int
+  public let maxMessageBytes: Int
+  public let contentWorldName: String
+  public let redactText: Bool
+  public init( allowedOrigins: Set<String> = [], allowedFrames: Set<String> = [], maxElements: Int = 500, maxMessageBytes: Int = 256 * 1024, contentWorldName: String = "AutoMobile", redactText: Bool = true )
+public enum AutoMobileWebAction: Codable, Sendable, Equatable
+public struct SdkWebViewEvent: SdkEvent
+  public private(set) var eventType: SdkEventType = .webView
+  public let timestamp: Int64
+  public let webViewId: String
+  public let name: String
+  public let url: String?
+  public let frameId: String?
+  public let requestId: String?
+  public let metadata: [String: String]
+  public init( timestamp: Int64 = Int64(Date().timeIntervalSince1970 * 1000), webViewId: String, name: String, url: String? = nil, frameId: String? = nil, requestId: String? = nil, metadata: [String: String] = [:] )
+public final class AutoMobileWebViewPolicy: @unchecked Sendable
+  public init(configuration: AutoMobileWebViewConfiguration = .init())
+  public func allows(url: URL?, frameId: String?) -> Bool
+  public func accept(_ snapshot: AutoMobileWebSnapshot) -> AutoMobileWebSnapshot
+  public func validates(_ action: AutoMobileWebAction) -> Bool
+public final class AutoMobileWebViewBridge: NSObject, WKScriptMessageHandler, WKNavigationDelegate, @unchecked Sendable
+  public let webViewId: String
+  public let configuration: AutoMobileWebViewConfiguration
+  public let policy: AutoMobileWebViewPolicy
+  public init( webViewId: String = UUID().uuidString, configuration: AutoMobileWebViewConfiguration = .init(), recorder: NetworkCaptureRecorder? = nil, emitEvent: @escaping @Sendable (SdkWebViewEvent) -> Void = { event in AutoMobileSDK.shared.recordWebViewEvent(event) } )
+  public func attach(to webView: WKWebView)
+  public func detach()
+  public func userContentController(_ userContentController: WKUserContentController, didReceive message: WKScriptMessage)
+  public func perform(_ action: AutoMobileWebAction, completion: @escaping (Result<Void, Error>) -> Void)
+  public func webView(_ webView: WKWebView, didFinish navigation: WKNavigation!)
+  public func webView(_ webView: WKWebView, didFail navigation: WKNavigation!, withError error: Error)
+  public func webView(_ webView: WKWebView, didCommit navigation: WKNavigation!)
+  public func webViewWebContentProcessDidTerminate(_ webView: WKWebView)

--- a/src/features/observe/ios/IosSdkEventIngestor.ts
+++ b/src/features/observe/ios/IosSdkEventIngestor.ts
@@ -248,6 +248,19 @@ export class DefaultIosSdkEventIngestor implements IosSdkEventIngestor {
               details: { durationMs: String((p.durationMs as number) ?? 0) },
             });
             break;
+          case "webview":
+            await recorder.recordOsEvent({
+              timestamp: ts, applicationId,
+              category: "webview", kind: (p.name as string) ?? "unknown",
+              details: {
+                webViewId: (p.webViewId as string) ?? "",
+                url: (p.url as string) ?? "",
+                frameId: (p.frameId as string) ?? "",
+                requestId: (p.requestId as string) ?? "",
+                ...(p.metadata as Record<string, string> ?? {}),
+              },
+            });
+            break;
           case "storage_changed": {
             // The iOS SDK's SdkStorageChangedEvent serializes as suiteName/key/newValue/
             // valueType/changeType/sequenceNumber (ios/auto-mobile-sdk/.../SdkEvent.swift).


### PR DESCRIPTION
Closes #5058\n\nAdds an opt-in WKWebView bridge with isolated user scripts, origin/frame policy, bounded DOM snapshots, stale-element validation, bounded actions, navigation/runtime events, redaction, message limits, and native request ID correlation. Includes SDK persistence/API updates, iOS event ingestion, focused tests, and docs.\n\nValidation: Swift SDK tests and iOS API check pass; focused iOS ingestion tests and typecheck pass. Full Turbo validation completed build/lint/boundary legs; the isolated full test leg exceeded 8 minutes in the fresh worktree and was stopped.