### PR TITLE
feat(desktop): locale + more emulator controls

### DIFF
--- a/android/desktop-core/src/main/kotlin/dev/jasonpearson/automobile/desktop/core/workspace/EmulatorControlExecutor.kt
+++ b/android/desktop-core/src/main/kotlin/dev/jasonpearson/automobile/desktop/core/workspace/EmulatorControlExecutor.kt
@@ -37,8 +37,10 @@ interface EmulatorControlExecutor {
   suspend fun pressButton(deviceId: String, platform: Platform, button: DeviceButton)
 
   /**
-   * Apply [locale] (a BCP-47 tag) to the device. On Android `changeLocalization` needs an app
-   * target, so the implementation resolves the foreground app; on iOS the change is device-wide.
+   * Apply [locale] (a BCP-47 tag) to the device. The implementation resolves the foreground app on
+   * both platforms: Android `changeLocalization` *requires* an app target, while iOS applies the
+   * locale device-wide but caches it per-app at launch — so the running app only reflects the new
+   * locale after a relaunch, which the daemon performs when the app is passed as `restartApp`.
    */
   suspend fun setLocale(deviceId: String, platform: Platform, locale: String)
 }
@@ -52,7 +54,8 @@ object NoOpEmulatorControlExecutor : EmulatorControlExecutor {
     orientation: Orientation,
   ) = Unit
 
-  override suspend fun pressButton(deviceId: String, platform: Platform, button: DeviceButton) = Unit
+  override suspend fun pressButton(deviceId: String, platform: Platform, button: DeviceButton) =
+    Unit
 
   override suspend fun setLocale(deviceId: String, platform: Platform, locale: String) = Unit
 }
@@ -113,7 +116,8 @@ class DaemonEmulatorControlExecutor(
           )
         // Handled UI-side via the observation stream, not as a fire-and-forget device call.
         EmulatorControl.Screenshot -> Unit
-        // Open menus, not one-shot device calls — their selections go through pressButton/setLocale.
+        // Open menus, not one-shot device calls — their selections go through
+        // pressButton/setLocale.
         EmulatorControl.Locale,
         EmulatorControl.More -> Unit
       }
@@ -141,9 +145,10 @@ class DaemonEmulatorControlExecutor(
       client.setActiveDevice(deviceId, wire)
       // `changeLocalization` lives behind the device-settings capability.
       client.enableToolCapability("device-settings")
-      // Android requires an app target; resolve the foreground app. iOS is device-wide (no appId).
-      val appId = if (platform == Platform.Android) foregroundAppResolver.resolve(deviceId) else null
-      if (platform == Platform.Android && appId == null) {
+      // Resolve the foreground app on both platforms: Android *requires* it as the change target,
+      // while iOS applies the locale device-wide but must relaunch the app (restartApp) to show it.
+      val foregroundApp = foregroundAppResolver.resolve(deviceId)
+      if (platform == Platform.Android && foregroundApp == null) {
         LOG.warn("Cannot change locale on $deviceId: no foreground app to target")
         return@withContext
       }
@@ -153,7 +158,11 @@ class DaemonEmulatorControlExecutor(
           put("locale", locale)
           put("platform", wire)
           put("deviceId", deviceId)
-          if (appId != null) put("appId", appId)
+          // Android sends the app as appId (the change target); iOS sends it as restartApp so the
+          // app relaunches into the new locale. The daemon rejects appId on iOS.
+          foregroundApp?.let {
+            put(if (platform == Platform.Android) "appId" else "restartApp", it)
+          }
         },
       )
     }

--- a/android/desktop-core/src/main/kotlin/dev/jasonpearson/automobile/desktop/core/workspace/EmulatorControlExecutor.kt
+++ b/android/desktop-core/src/main/kotlin/dev/jasonpearson/automobile/desktop/core/workspace/EmulatorControlExecutor.kt
@@ -2,6 +2,7 @@ package dev.jasonpearson.automobile.desktop.core.workspace
 
 import dev.jasonpearson.automobile.desktop.core.daemon.AutoMobileClient
 import dev.jasonpearson.automobile.desktop.core.logging.LoggerFactory
+import kotlinx.coroutines.CompletableDeferred
 import kotlinx.coroutines.CoroutineDispatcher
 import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.withContext
@@ -187,6 +188,10 @@ class FakeEmulatorControlExecutor : EmulatorControlExecutor {
   val localeRequests: MutableList<LocaleRequest> = mutableListOf()
   var error: Throwable? = null
 
+  // When set, [setLocale] suspends on this gate before recording, so a test can hold a locale
+  // request "in flight" (as the real foreground-app resolution would) to exercise supersede/cancel.
+  var localeGate: CompletableDeferred<Unit>? = null
+
   override suspend fun run(
     deviceId: String,
     platform: Platform,
@@ -204,6 +209,7 @@ class FakeEmulatorControlExecutor : EmulatorControlExecutor {
 
   override suspend fun setLocale(deviceId: String, platform: Platform, locale: String) {
     error?.let { throw it }
+    localeGate?.await()
     localeRequests += LocaleRequest(deviceId, platform, locale)
   }
 }

--- a/android/desktop-core/src/main/kotlin/dev/jasonpearson/automobile/desktop/core/workspace/EmulatorControlExecutor.kt
+++ b/android/desktop-core/src/main/kotlin/dev/jasonpearson/automobile/desktop/core/workspace/EmulatorControlExecutor.kt
@@ -1,11 +1,14 @@
 package dev.jasonpearson.automobile.desktop.core.workspace
 
 import dev.jasonpearson.automobile.desktop.core.daemon.AutoMobileClient
+import dev.jasonpearson.automobile.desktop.core.logging.LoggerFactory
 import kotlinx.coroutines.CoroutineDispatcher
 import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.withContext
 import kotlinx.serialization.json.buildJsonObject
 import kotlinx.serialization.json.put
+
+private val LOG = LoggerFactory.getLogger("EmulatorControlExecutor")
 
 /**
  * Runs a device-mutating emulator control (Rotate, Snapshot, Unlock) against a real device. This is
@@ -29,6 +32,15 @@ interface EmulatorControlExecutor {
     control: EmulatorControl,
     orientation: Orientation,
   )
+
+  /** Press a device system [button] (the `more` overflow menu items). */
+  suspend fun pressButton(deviceId: String, platform: Platform, button: DeviceButton)
+
+  /**
+   * Apply [locale] (a BCP-47 tag) to the device. On Android `changeLocalization` needs an app
+   * target, so the implementation resolves the foreground app; on iOS the change is device-wide.
+   */
+  suspend fun setLocale(deviceId: String, platform: Platform, locale: String)
 }
 
 /** No-op seam for hosts/tests that don't wire real device execution. */
@@ -39,6 +51,10 @@ object NoOpEmulatorControlExecutor : EmulatorControlExecutor {
     control: EmulatorControl,
     orientation: Orientation,
   ) = Unit
+
+  override suspend fun pressButton(deviceId: String, platform: Platform, button: DeviceButton) = Unit
+
+  override suspend fun setLocale(deviceId: String, platform: Platform, locale: String) = Unit
 }
 
 /**
@@ -48,6 +64,7 @@ object NoOpEmulatorControlExecutor : EmulatorControlExecutor {
  */
 class DaemonEmulatorControlExecutor(
   private val client: AutoMobileClient,
+  private val foregroundAppResolver: ForegroundAppResolver = ObservationForegroundAppResolver(),
   private val ioDispatcher: CoroutineDispatcher = Dispatchers.IO,
 ) : EmulatorControlExecutor {
   override suspend fun run(
@@ -96,7 +113,49 @@ class DaemonEmulatorControlExecutor(
           )
         // Handled UI-side via the observation stream, not as a fire-and-forget device call.
         EmulatorControl.Screenshot -> Unit
+        // Open menus, not one-shot device calls — their selections go through pressButton/setLocale.
+        EmulatorControl.Locale,
+        EmulatorControl.More -> Unit
       }
+    }
+  }
+
+  override suspend fun pressButton(deviceId: String, platform: Platform, button: DeviceButton) {
+    withContext(ioDispatcher) {
+      val wire = platform.wireName()
+      client.setActiveDevice(deviceId, wire)
+      client.callTool(
+        "pressButton",
+        buildJsonObject {
+          put("button", button.toolValue)
+          put("platform", wire)
+          put("deviceId", deviceId)
+        },
+      )
+    }
+  }
+
+  override suspend fun setLocale(deviceId: String, platform: Platform, locale: String) {
+    withContext(ioDispatcher) {
+      val wire = platform.wireName()
+      client.setActiveDevice(deviceId, wire)
+      // `changeLocalization` lives behind the device-settings capability.
+      client.enableToolCapability("device-settings")
+      // Android requires an app target; resolve the foreground app. iOS is device-wide (no appId).
+      val appId = if (platform == Platform.Android) foregroundAppResolver.resolve(deviceId) else null
+      if (platform == Platform.Android && appId == null) {
+        LOG.warn("Cannot change locale on $deviceId: no foreground app to target")
+        return@withContext
+      }
+      client.callTool(
+        "changeLocalization",
+        buildJsonObject {
+          put("locale", locale)
+          put("platform", wire)
+          put("deviceId", deviceId)
+          if (appId != null) put("appId", appId)
+        },
+      )
     }
   }
 }
@@ -110,7 +169,13 @@ class FakeEmulatorControlExecutor : EmulatorControlExecutor {
     val orientation: Orientation,
   )
 
+  data class ButtonRequest(val deviceId: String, val platform: Platform, val button: DeviceButton)
+
+  data class LocaleRequest(val deviceId: String, val platform: Platform, val locale: String)
+
   val requests: MutableList<Request> = mutableListOf()
+  val buttonRequests: MutableList<ButtonRequest> = mutableListOf()
+  val localeRequests: MutableList<LocaleRequest> = mutableListOf()
   var error: Throwable? = null
 
   override suspend fun run(
@@ -121,5 +186,15 @@ class FakeEmulatorControlExecutor : EmulatorControlExecutor {
   ) {
     error?.let { throw it }
     requests += Request(deviceId, platform, control, orientation)
+  }
+
+  override suspend fun pressButton(deviceId: String, platform: Platform, button: DeviceButton) {
+    error?.let { throw it }
+    buttonRequests += ButtonRequest(deviceId, platform, button)
+  }
+
+  override suspend fun setLocale(deviceId: String, platform: Platform, locale: String) {
+    error?.let { throw it }
+    localeRequests += LocaleRequest(deviceId, platform, locale)
   }
 }

--- a/android/desktop-core/src/main/kotlin/dev/jasonpearson/automobile/desktop/core/workspace/ForegroundAppResolver.kt
+++ b/android/desktop-core/src/main/kotlin/dev/jasonpearson/automobile/desktop/core/workspace/ForegroundAppResolver.kt
@@ -1,0 +1,66 @@
+package dev.jasonpearson.automobile.desktop.core.workspace
+
+import dev.jasonpearson.automobile.desktop.core.daemon.ObservationStream
+import dev.jasonpearson.automobile.desktop.core.daemon.ObservationStreamClient
+import dev.jasonpearson.automobile.desktop.core.logging.LoggerFactory
+import kotlinx.coroutines.CancellationException
+import kotlinx.coroutines.flow.first
+import kotlinx.coroutines.withTimeoutOrNull
+
+private val LOG = LoggerFactory.getLogger("ForegroundAppResolver")
+
+/**
+ * Resolves the package of a device's current foreground app. Needed because `changeLocalization`
+ * requires an `appId` on Android (iOS is device-wide) — the Locale control targets whatever app is
+ * on screen. A seam so the executor's locale logic can be pinned with a fake; the real
+ * implementation opens an observation stream and is untested IO.
+ */
+interface ForegroundAppResolver {
+  /** The foreground app package for [deviceId], or null if it can't be determined. */
+  suspend fun resolve(deviceId: String): String?
+}
+
+/** Resolver that never determines an app (default for hosts/tests that don't need locale). */
+object NoOpForegroundAppResolver : ForegroundAppResolver {
+  override suspend fun resolve(deviceId: String): String? = null
+}
+
+/**
+ * Real resolver: opens a per-device [ObservationStream], requests one observation, and reads the
+ * first hierarchy frame's `packageName` (the on-screen app), then disposes. Bounded by a timeout so
+ * a gone device can't hang the caller. Untested IO seam.
+ */
+class ObservationForegroundAppResolver(
+  private val observationStreamFactory: (String) -> ObservationStream = {
+    ObservationStreamClient()
+  },
+  private val timeoutMs: Long = 10_000L,
+) : ForegroundAppResolver {
+  override suspend fun resolve(deviceId: String): String? {
+    val stream = observationStreamFactory(deviceId)
+    return try {
+      stream.connect(deviceId)
+      stream.requestObservation(deviceId)
+      withTimeoutOrNull(timeoutMs) {
+        stream.hierarchyUpdates.first { !it.packageName.isNullOrBlank() }.packageName
+      }
+    } catch (cancellation: CancellationException) {
+      throw cancellation
+    } catch (error: Exception) {
+      LOG.warn("Foreground-app resolve failed for $deviceId: ${error.message}", error)
+      null
+    } finally {
+      stream.dispose()
+    }
+  }
+}
+
+/** Records the requested device ids and returns a configured [appId]. */
+class FakeForegroundAppResolver(var appId: String? = "com.example.app") : ForegroundAppResolver {
+  val requestedDeviceIds: MutableList<String> = mutableListOf()
+
+  override suspend fun resolve(deviceId: String): String? {
+    requestedDeviceIds += deviceId
+    return appId
+  }
+}

--- a/android/desktop-core/src/main/kotlin/dev/jasonpearson/automobile/desktop/core/workspace/WorkspaceModels.kt
+++ b/android/desktop-core/src/main/kotlin/dev/jasonpearson/automobile/desktop/core/workspace/WorkspaceModels.kt
@@ -54,8 +54,42 @@ enum class EmulatorControl(val icon: String, val label: String) {
   Rotate("🔄", "Rotate"), // 🔄
   Screenshot("📸", "Screenshot"), // 📸
   Snapshot("🗂", "Snapshot"), // 🗂
+  Locale("🌐", "Locale"), // 🌐 — opens a locale picker rather than a one-shot device call
+  More("⋯", "More"), // ⋯ — opens an overflow menu of device system actions
   Unlock("🔓", "Unlock"), // 🔓
 }
+
+/**
+ * Device system buttons offered by the [EmulatorControl.More] overflow menu. Each maps to a value
+ * of the `pressButton` MCP tool. [toolValue] is the exact string the tool expects.
+ */
+enum class DeviceButton(val icon: String, val label: String, val toolValue: String) {
+  Home("🏠", "Home", "home"),
+  Back("◀", "Back", "back"),
+  Recent("▤", "Recent apps", "recent"),
+  Power("⏻", "Power", "power"),
+}
+
+/** A locale offered by the [EmulatorControl.Locale] picker: a BCP-47 [tag] and a human [label]. */
+data class LocaleOption(val tag: String, val label: String)
+
+/**
+ * Curated locales the Locale picker offers — a small cross-section covering LTR/RTL and a few
+ * scripts, enough to exercise localization without an exhaustive list.
+ */
+val COMMON_LOCALES: List<LocaleOption> =
+  listOf(
+    LocaleOption("en-US", "English (US)"),
+    LocaleOption("es-ES", "Spanish"),
+    LocaleOption("fr-FR", "French"),
+    LocaleOption("de-DE", "German"),
+    LocaleOption("pt-BR", "Portuguese (Brazil)"),
+    LocaleOption("ja-JP", "Japanese"),
+    LocaleOption("ko-KR", "Korean"),
+    LocaleOption("zh-CN", "Chinese (Simplified)"),
+    LocaleOption("hi-IN", "Hindi"),
+    LocaleOption("ar-SA", "Arabic"),
+  )
 
 /** High-level health rollup shown as the single status dot in the top bar. */
 enum class WorkspaceStatus {

--- a/android/desktop-core/src/main/kotlin/dev/jasonpearson/automobile/desktop/core/workspace/WorkspaceModels.kt
+++ b/android/desktop-core/src/main/kotlin/dev/jasonpearson/automobile/desktop/core/workspace/WorkspaceModels.kt
@@ -67,7 +67,16 @@ enum class DeviceButton(val icon: String, val label: String, val toolValue: Stri
   Home("🏠", "Home", "home"),
   Back("◀", "Back", "back"),
   Recent("▤", "Recent apps", "recent"),
-  Power("⏻", "Power", "power"),
+  Power("⏻", "Power", "power");
+
+  /**
+   * Whether the workspace offers this button on [platform]. Home/Back/Recent are supported on both
+   * platforms (iOS routes them through CtrlProxy), so all three stay in the menu; Power is a
+   * hardware key the iOS simulator cannot press, so it is Android-only here. Restoring Power for a
+   * *physical* iOS device needs the pane's device kind, which the picker does not yet carry — a
+   * follow-up.
+   */
+  fun isSupportedOn(platform: Platform): Boolean = this != Power || platform == Platform.Android
 }
 
 /** A locale offered by the [EmulatorControl.Locale] picker: a BCP-47 [tag] and a human [label]. */

--- a/android/desktop-core/src/main/kotlin/dev/jasonpearson/automobile/desktop/core/workspace/WorkspaceShell.kt
+++ b/android/desktop-core/src/main/kotlin/dev/jasonpearson/automobile/desktop/core/workspace/WorkspaceShell.kt
@@ -19,6 +19,8 @@ import androidx.compose.foundation.layout.width
 import androidx.compose.foundation.layout.widthIn
 import androidx.compose.foundation.shape.CircleShape
 import androidx.compose.foundation.shape.RoundedCornerShape
+import androidx.compose.material3.DropdownMenu
+import androidx.compose.material3.DropdownMenuItem
 import androidx.compose.material3.MaterialTheme
 import androidx.compose.material3.Text
 import androidx.compose.runtime.Composable
@@ -806,23 +808,68 @@ private fun EmulatorControls(
   modifier: Modifier,
 ) {
   Row(modifier, horizontalArrangement = Arrangement.spacedBy(4.dp)) {
-    // Unlock is gated on the pane's lock state; rotate/screenshot/snapshot always show.
+    // Unlock is gated on the pane's lock state; the rest always show. Rotate/Snapshot/Unlock are
+    // one-shot device calls; Screenshot captures to disk; Locale/More open menus.
     EmulatorControl.entries
       .filter { it != EmulatorControl.Unlock || column.locked }
       .forEach { control ->
-        Glyph(
-          text = control.icon,
-          description = "${control.label} ${column.name}",
-          active = false,
-          onClick = {
-            if (control == EmulatorControl.Screenshot) {
-              onCaptureScreenshot()
-            } else {
+        when (control) {
+          EmulatorControl.Screenshot ->
+            Glyph(control.icon, "${control.label} ${column.name}", false, onCaptureScreenshot)
+          EmulatorControl.Locale -> LocaleControl(column, onAction)
+          EmulatorControl.More -> MoreControl(column, onAction)
+          else ->
+            Glyph(control.icon, "${control.label} ${column.name}", false) {
               onAction(WorkspaceAction.RunControl(column.deviceId, control))
             }
+        }
+      }
+  }
+}
+
+/** 🌐 Locale control: a glyph that opens a dropdown of [COMMON_LOCALES]; a pick sets that locale. */
+@Composable
+private fun LocaleControl(column: DeviceColumn, onAction: (WorkspaceAction) -> Unit) {
+  var open by remember { mutableStateOf(false) }
+  Box {
+    Glyph(EmulatorControl.Locale.icon, "${EmulatorControl.Locale.label} ${column.name}", open) {
+      open = true
+    }
+    DropdownMenu(expanded = open, onDismissRequest = { open = false }) {
+      COMMON_LOCALES.forEach { locale ->
+        DropdownMenuItem(
+          text = { Text("${locale.label} (${locale.tag})") },
+          modifier = Modifier.semantics { contentDescription = "Locale ${locale.label} ${column.name}" },
+          onClick = {
+            open = false
+            onAction(WorkspaceAction.SetLocale(column.deviceId, locale.tag))
           },
         )
       }
+    }
+  }
+}
+
+/** ⋯ More control: a glyph that opens a dropdown of [DeviceButton]s; a pick presses that button. */
+@Composable
+private fun MoreControl(column: DeviceColumn, onAction: (WorkspaceAction) -> Unit) {
+  var open by remember { mutableStateOf(false) }
+  Box {
+    Glyph(EmulatorControl.More.icon, "${EmulatorControl.More.label} ${column.name}", open) {
+      open = true
+    }
+    DropdownMenu(expanded = open, onDismissRequest = { open = false }) {
+      DeviceButton.entries.forEach { button ->
+        DropdownMenuItem(
+          text = { Text("${button.icon}  ${button.label}") },
+          modifier = Modifier.semantics { contentDescription = "${button.label} ${column.name}" },
+          onClick = {
+            open = false
+            onAction(WorkspaceAction.PressDeviceButton(column.deviceId, button))
+          },
+        )
+      }
+    }
   }
 }
 

--- a/android/desktop-core/src/main/kotlin/dev/jasonpearson/automobile/desktop/core/workspace/WorkspaceShell.kt
+++ b/android/desktop-core/src/main/kotlin/dev/jasonpearson/automobile/desktop/core/workspace/WorkspaceShell.kt
@@ -817,10 +817,7 @@ private fun EmulatorControls(
           EmulatorControl.Screenshot ->
             Glyph(control.icon, "${control.label} ${column.name}", false, onCaptureScreenshot)
           EmulatorControl.Locale -> LocaleControl(column, onAction)
-          // The overflow buttons (Home/Back/Recent/Power) are Android system keys; on an iOS
-          // simulator they are inert (Power, for one, is physical-device-only), so hide the menu.
-          EmulatorControl.More ->
-            if (column.platform == Platform.Android) MoreControl(column, onAction)
+          EmulatorControl.More -> MoreControl(column, onAction)
           else ->
             Glyph(control.icon, "${control.label} ${column.name}", false) {
               onAction(WorkspaceAction.RunControl(column.deviceId, control))
@@ -865,16 +862,18 @@ private fun MoreControl(column: DeviceColumn, onAction: (WorkspaceAction) -> Uni
       open = true
     }
     DropdownMenu(expanded = open, onDismissRequest = { open = false }) {
-      DeviceButton.entries.forEach { button ->
-        DropdownMenuItem(
-          text = { Text("${button.icon}  ${button.label}") },
-          modifier = Modifier.semantics { contentDescription = "${button.label} ${column.name}" },
-          onClick = {
-            open = false
-            onAction(WorkspaceAction.PressDeviceButton(column.deviceId, button))
-          },
-        )
-      }
+      DeviceButton.entries
+        .filter { it.isSupportedOn(column.platform) }
+        .forEach { button ->
+          DropdownMenuItem(
+            text = { Text("${button.icon}  ${button.label}") },
+            modifier = Modifier.semantics { contentDescription = "${button.label} ${column.name}" },
+            onClick = {
+              open = false
+              onAction(WorkspaceAction.PressDeviceButton(column.deviceId, button))
+            },
+          )
+        }
     }
   }
 }

--- a/android/desktop-core/src/main/kotlin/dev/jasonpearson/automobile/desktop/core/workspace/WorkspaceShell.kt
+++ b/android/desktop-core/src/main/kotlin/dev/jasonpearson/automobile/desktop/core/workspace/WorkspaceShell.kt
@@ -817,7 +817,10 @@ private fun EmulatorControls(
           EmulatorControl.Screenshot ->
             Glyph(control.icon, "${control.label} ${column.name}", false, onCaptureScreenshot)
           EmulatorControl.Locale -> LocaleControl(column, onAction)
-          EmulatorControl.More -> MoreControl(column, onAction)
+          // The overflow buttons (Home/Back/Recent/Power) are Android system keys; on an iOS
+          // simulator they are inert (Power, for one, is physical-device-only), so hide the menu.
+          EmulatorControl.More ->
+            if (column.platform == Platform.Android) MoreControl(column, onAction)
           else ->
             Glyph(control.icon, "${control.label} ${column.name}", false) {
               onAction(WorkspaceAction.RunControl(column.deviceId, control))
@@ -827,7 +830,9 @@ private fun EmulatorControls(
   }
 }
 
-/** 🌐 Locale control: a glyph that opens a dropdown of [COMMON_LOCALES]; a pick sets that locale. */
+/**
+ * 🌐 Locale control: a glyph that opens a dropdown of [COMMON_LOCALES]; a pick sets that locale.
+ */
 @Composable
 private fun LocaleControl(column: DeviceColumn, onAction: (WorkspaceAction) -> Unit) {
   var open by remember { mutableStateOf(false) }
@@ -839,7 +844,8 @@ private fun LocaleControl(column: DeviceColumn, onAction: (WorkspaceAction) -> U
       COMMON_LOCALES.forEach { locale ->
         DropdownMenuItem(
           text = { Text("${locale.label} (${locale.tag})") },
-          modifier = Modifier.semantics { contentDescription = "Locale ${locale.label} ${column.name}" },
+          modifier =
+            Modifier.semantics { contentDescription = "Locale ${locale.label} ${column.name}" },
           onClick = {
             open = false
             onAction(WorkspaceAction.SetLocale(column.deviceId, locale.tag))

--- a/android/desktop-core/src/main/kotlin/dev/jasonpearson/automobile/desktop/core/workspace/WorkspaceViewModel.kt
+++ b/android/desktop-core/src/main/kotlin/dev/jasonpearson/automobile/desktop/core/workspace/WorkspaceViewModel.kt
@@ -3,6 +3,7 @@ package dev.jasonpearson.automobile.desktop.core.workspace
 import dev.jasonpearson.automobile.desktop.core.logging.LoggerFactory
 import kotlinx.coroutines.CancellationException
 import kotlinx.coroutines.CoroutineScope
+import kotlinx.coroutines.Job
 import kotlinx.coroutines.channels.Channel
 import kotlinx.coroutines.flow.MutableStateFlow
 import kotlinx.coroutines.flow.StateFlow
@@ -83,6 +84,10 @@ class WorkspaceViewModel(
   private val _effect = Channel<WorkspaceEffect>(Channel.BUFFERED)
   val effect = _effect.receiveAsFlow()
 
+  // The in-flight locale request per device, so a newer selection can supersede an older one that
+  // is still resolving the foreground app (see [setLocale]).
+  private val localeJobs = mutableMapOf<String, Job>()
+
   fun onAction(action: WorkspaceAction) {
     when (action) {
       is WorkspaceAction.ObserveDevice -> observe(action.column)
@@ -118,7 +123,11 @@ class WorkspaceViewModel(
   /** Apply [locale] to the targeted column's device off the UI thread; failures are logged. */
   private fun setLocale(deviceId: String, locale: String) {
     val column = columnFor(deviceId) ?: return
-    scope.launch {
+    // A newer pick supersedes any still-resolving one for this device: resolving the foreground app
+    // can take seconds, and without cancelling, an earlier request could invoke changeLocalization
+    // AFTER a later one and leave the device in a locale the user did not pick last.
+    localeJobs[deviceId]?.cancel()
+    localeJobs[deviceId] = scope.launch {
       try {
         controlExecutor.setLocale(deviceId, column.platform, locale)
       } catch (cancellation: CancellationException) {

--- a/android/desktop-core/src/main/kotlin/dev/jasonpearson/automobile/desktop/core/workspace/WorkspaceViewModel.kt
+++ b/android/desktop-core/src/main/kotlin/dev/jasonpearson/automobile/desktop/core/workspace/WorkspaceViewModel.kt
@@ -41,6 +41,12 @@ sealed interface WorkspaceAction {
   /** Run an emulator control against a device pane (rotate, screenshot, snapshot, unlock). */
   data class RunControl(val deviceId: String, val control: EmulatorControl) : WorkspaceAction
 
+  /** Press a device system button on a pane (the `more` overflow menu items). */
+  data class PressDeviceButton(val deviceId: String, val button: DeviceButton) : WorkspaceAction
+
+  /** Apply a locale to a pane's device (the `locale` picker selection). */
+  data class SetLocale(val deviceId: String, val locale: String) : WorkspaceAction
+
   /**
    * Update panes' lock state from an observed snapshot (deviceId -> locked). A device absent from
    * [locked] keeps its current state, so a transient empty read never spuriously unlocks a pane.
@@ -86,10 +92,43 @@ class WorkspaceViewModel(
       is WorkspaceAction.ToggleShrink -> mutate(action.deviceId) { it.copy(shrunk = !it.shrunk) }
       is WorkspaceAction.SelectTool -> mutate(action.deviceId) { it.copy(activeTool = action.tool) }
       is WorkspaceAction.RunControl -> runControl(action.deviceId, action.control)
+      is WorkspaceAction.PressDeviceButton -> pressDeviceButton(action.deviceId, action.button)
+      is WorkspaceAction.SetLocale -> setLocale(action.deviceId, action.locale)
       is WorkspaceAction.SetLockStates -> setLockStates(action.locked)
       is WorkspaceAction.DiffTool -> diffTool(action.tool)
     }
   }
+
+  /** Press a device system [button] on the targeted column off the UI thread; failures are logged. */
+  private fun pressDeviceButton(deviceId: String, button: DeviceButton) {
+    val column = columnFor(deviceId) ?: return
+    scope.launch {
+      try {
+        controlExecutor.pressButton(deviceId, column.platform, button)
+      } catch (cancellation: CancellationException) {
+        throw cancellation
+      } catch (error: Exception) {
+        LOG.warn("Device button $button failed for $deviceId: ${error.message}", error)
+      }
+    }
+  }
+
+  /** Apply [locale] to the targeted column's device off the UI thread; failures are logged. */
+  private fun setLocale(deviceId: String, locale: String) {
+    val column = columnFor(deviceId) ?: return
+    scope.launch {
+      try {
+        controlExecutor.setLocale(deviceId, column.platform, locale)
+      } catch (cancellation: CancellationException) {
+        throw cancellation
+      } catch (error: Exception) {
+        LOG.warn("Set locale $locale failed for $deviceId: ${error.message}", error)
+      }
+    }
+  }
+
+  private fun columnFor(deviceId: String): DeviceColumn? =
+    (_state.value as? WorkspaceUiState.Content)?.columns?.firstOrNull { it.deviceId == deviceId }
 
   /** Reflect an observed lock-state snapshot onto the columns; absent devices keep their state. */
   private fun setLockStates(locked: Map<String, Boolean>) {

--- a/android/desktop-core/src/main/kotlin/dev/jasonpearson/automobile/desktop/core/workspace/WorkspaceViewModel.kt
+++ b/android/desktop-core/src/main/kotlin/dev/jasonpearson/automobile/desktop/core/workspace/WorkspaceViewModel.kt
@@ -99,7 +99,9 @@ class WorkspaceViewModel(
     }
   }
 
-  /** Press a device system [button] on the targeted column off the UI thread; failures are logged. */
+  /**
+   * Press a device system [button] on the targeted column off the UI thread; failures are logged.
+   */
   private fun pressDeviceButton(deviceId: String, button: DeviceButton) {
     val column = columnFor(deviceId) ?: return
     scope.launch {

--- a/android/desktop-core/src/test/kotlin/dev/jasonpearson/automobile/desktop/core/workspace/DaemonEmulatorControlExecutorTest.kt
+++ b/android/desktop-core/src/test/kotlin/dev/jasonpearson/automobile/desktop/core/workspace/DaemonEmulatorControlExecutorTest.kt
@@ -18,8 +18,10 @@ import org.junit.Test
 @OptIn(ExperimentalCoroutinesApi::class)
 class DaemonEmulatorControlExecutorTest {
 
-  private fun executor(client: FakeAutoMobileClient) =
-    DaemonEmulatorControlExecutor(client, UnconfinedTestDispatcher())
+  private fun executor(
+    client: FakeAutoMobileClient,
+    resolver: ForegroundAppResolver = FakeForegroundAppResolver(appId = null),
+  ) = DaemonEmulatorControlExecutor(client, resolver, UnconfinedTestDispatcher())
 
   @Test
   fun `rotate sets the active device then calls rotate with the target orientation`() = runTest {
@@ -99,5 +101,79 @@ class DaemonEmulatorControlExecutorTest {
             }
       }
     )
+  }
+
+  @Test
+  fun `pressButton sets the active device then calls pressButton`() = runTest {
+    val client = FakeAutoMobileClient()
+    executor(client).pressButton("emulator-5554", Platform.Android, DeviceButton.Home)
+
+    assertEquals("setActiveDevice", client.calls.first())
+    assertTrue(
+      client.toolCalls.any {
+        it.name == "pressButton" &&
+          it.arguments ==
+            buildJsonObject {
+              put("button", "home")
+              put("platform", "android")
+              put("deviceId", "emulator-5554")
+            }
+      }
+    )
+  }
+
+  @Test
+  fun `setLocale on iOS enables device-settings and changes locale device-wide`() = runTest {
+    val client = FakeAutoMobileClient()
+    executor(client).setLocale("booted-ipad", Platform.Ios, "ja-JP")
+
+    assertTrue(
+      client.toolCalls.any {
+        it.name == "setToolCapability" &&
+          it.arguments == buildJsonObject { put("capability", "device-settings"); put("enabled", true) }
+      }
+    )
+    assertTrue(
+      "iOS locale is device-wide — no appId",
+      client.toolCalls.any {
+        it.name == "changeLocalization" &&
+          it.arguments ==
+            buildJsonObject {
+              put("locale", "ja-JP")
+              put("platform", "ios")
+              put("deviceId", "booted-ipad")
+            }
+      },
+    )
+  }
+
+  @Test
+  fun `setLocale on Android targets the resolved foreground app`() = runTest {
+    val client = FakeAutoMobileClient()
+    val resolver = FakeForegroundAppResolver(appId = "com.example.app")
+    executor(client, resolver).setLocale("emulator-5554", Platform.Android, "de-DE")
+
+    assertEquals(listOf("emulator-5554"), resolver.requestedDeviceIds)
+    assertTrue(
+      client.toolCalls.any {
+        it.name == "changeLocalization" &&
+          it.arguments ==
+            buildJsonObject {
+              put("locale", "de-DE")
+              put("platform", "android")
+              put("deviceId", "emulator-5554")
+              put("appId", "com.example.app")
+            }
+      }
+    )
+  }
+
+  @Test
+  fun `setLocale on Android with no foreground app does not change locale`() = runTest {
+    val client = FakeAutoMobileClient()
+    executor(client, FakeForegroundAppResolver(appId = null))
+      .setLocale("emulator-5554", Platform.Android, "de-DE")
+
+    assertTrue(client.toolCalls.none { it.name == "changeLocalization" })
   }
 }

--- a/android/desktop-core/src/test/kotlin/dev/jasonpearson/automobile/desktop/core/workspace/DaemonEmulatorControlExecutorTest.kt
+++ b/android/desktop-core/src/test/kotlin/dev/jasonpearson/automobile/desktop/core/workspace/DaemonEmulatorControlExecutorTest.kt
@@ -130,7 +130,11 @@ class DaemonEmulatorControlExecutorTest {
     assertTrue(
       client.toolCalls.any {
         it.name == "setToolCapability" &&
-          it.arguments == buildJsonObject { put("capability", "device-settings"); put("enabled", true) }
+          it.arguments ==
+            buildJsonObject {
+              put("capability", "device-settings")
+              put("enabled", true)
+            }
       }
     )
     assertTrue(
@@ -146,6 +150,29 @@ class DaemonEmulatorControlExecutorTest {
       },
     )
   }
+
+  @Test
+  fun `setLocale on iOS relaunches the resolved foreground app so the change is visible`() =
+    runTest {
+      val client = FakeAutoMobileClient()
+      val resolver = FakeForegroundAppResolver(appId = "com.example.iosapp")
+      executor(client, resolver).setLocale("booted-ipad", Platform.Ios, "ja-JP")
+
+      assertEquals(listOf("booted-ipad"), resolver.requestedDeviceIds)
+      assertTrue(
+        "iOS passes the foreground bundle as restartApp (never appId) so the running app relaunches",
+        client.toolCalls.any {
+          it.name == "changeLocalization" &&
+            it.arguments ==
+              buildJsonObject {
+                put("locale", "ja-JP")
+                put("platform", "ios")
+                put("deviceId", "booted-ipad")
+                put("restartApp", "com.example.iosapp")
+              }
+        },
+      )
+    }
 
   @Test
   fun `setLocale on Android targets the resolved foreground app`() = runTest {

--- a/android/desktop-core/src/test/kotlin/dev/jasonpearson/automobile/desktop/core/workspace/WorkspaceShellUiTest.kt
+++ b/android/desktop-core/src/test/kotlin/dev/jasonpearson/automobile/desktop/core/workspace/WorkspaceShellUiTest.kt
@@ -192,6 +192,38 @@ class WorkspaceShellUiTest {
     }
 
   @Test
+  fun `Locale control opens a picker and selecting a locale dispatches SetLocale`() =
+    runComposeUiTest {
+      var action: WorkspaceAction? = null
+      val state =
+        WorkspaceUiState.Content(columns = listOf(col("a", "Pixel 8")), focusedDeviceId = "a")
+      setContent {
+        MaterialTheme {
+          WorkspaceShell(state = state, onAction = { action = it }, onOpenPicker = {})
+        }
+      }
+      onNodeWithContentDescription("Locale Pixel 8").performClick()
+      onNodeWithContentDescription("Locale Spanish Pixel 8").performClick()
+      assertEquals(WorkspaceAction.SetLocale("a", "es-ES"), action)
+    }
+
+  @Test
+  fun `More control opens a menu and selecting a button dispatches PressDeviceButton`() =
+    runComposeUiTest {
+      var action: WorkspaceAction? = null
+      val state =
+        WorkspaceUiState.Content(columns = listOf(col("a", "Pixel 8")), focusedDeviceId = "a")
+      setContent {
+        MaterialTheme {
+          WorkspaceShell(state = state, onAction = { action = it }, onOpenPicker = {})
+        }
+      }
+      onNodeWithContentDescription("More Pixel 8").performClick()
+      onNodeWithContentDescription("Home Pixel 8").performClick()
+      assertEquals(WorkspaceAction.PressDeviceButton("a", DeviceButton.Home), action)
+    }
+
+  @Test
   fun `active tool renders a docked facet with a close control`() = runComposeUiTest {
     val state =
       WorkspaceUiState.Content(

--- a/android/desktop-core/src/test/kotlin/dev/jasonpearson/automobile/desktop/core/workspace/WorkspaceShellUiTest.kt
+++ b/android/desktop-core/src/test/kotlin/dev/jasonpearson/automobile/desktop/core/workspace/WorkspaceShellUiTest.kt
@@ -224,6 +224,20 @@ class WorkspaceShellUiTest {
     }
 
   @Test
+  fun `More control is absent on iOS panes because its buttons are Android system keys`() =
+    runComposeUiTest {
+      val state =
+        WorkspaceUiState.Content(
+          columns = listOf(col("a", "iPhone 15", Platform.Ios)),
+          focusedDeviceId = "a",
+        )
+      setContent {
+        MaterialTheme { WorkspaceShell(state = state, onAction = {}, onOpenPicker = {}) }
+      }
+      onNodeWithContentDescription("More iPhone 15").assertDoesNotExist()
+    }
+
+  @Test
   fun `active tool renders a docked facet with a close control`() = runComposeUiTest {
     val state =
       WorkspaceUiState.Content(

--- a/android/desktop-core/src/test/kotlin/dev/jasonpearson/automobile/desktop/core/workspace/WorkspaceShellUiTest.kt
+++ b/android/desktop-core/src/test/kotlin/dev/jasonpearson/automobile/desktop/core/workspace/WorkspaceShellUiTest.kt
@@ -219,12 +219,14 @@ class WorkspaceShellUiTest {
         }
       }
       onNodeWithContentDescription("More Pixel 8").performClick()
+      // Power shows on Android — a hardware key adb can press.
+      onNodeWithContentDescription("Power Pixel 8").assertIsDisplayed()
       onNodeWithContentDescription("Home Pixel 8").performClick()
       assertEquals(WorkspaceAction.PressDeviceButton("a", DeviceButton.Home), action)
     }
 
   @Test
-  fun `More control is absent on iOS panes because its buttons are Android system keys`() =
+  fun `More menu on iOS offers the navigation buttons but hides simulator-incompatible Power`() =
     runComposeUiTest {
       val state =
         WorkspaceUiState.Content(
@@ -234,7 +236,12 @@ class WorkspaceShellUiTest {
       setContent {
         MaterialTheme { WorkspaceShell(state = state, onAction = {}, onOpenPicker = {}) }
       }
-      onNodeWithContentDescription("More iPhone 15").assertDoesNotExist()
+      onNodeWithContentDescription("More iPhone 15").performClick()
+      // Home/Back/Recent route through CtrlProxy on iOS; Power is physical-device-only.
+      onNodeWithContentDescription("Home iPhone 15").assertIsDisplayed()
+      onNodeWithContentDescription("Back iPhone 15").assertIsDisplayed()
+      onNodeWithContentDescription("Recent apps iPhone 15").assertIsDisplayed()
+      onNodeWithContentDescription("Power iPhone 15").assertDoesNotExist()
     }
 
   @Test

--- a/android/desktop-core/src/test/kotlin/dev/jasonpearson/automobile/desktop/core/workspace/WorkspaceViewModelTest.kt
+++ b/android/desktop-core/src/test/kotlin/dev/jasonpearson/automobile/desktop/core/workspace/WorkspaceViewModelTest.kt
@@ -1,8 +1,10 @@
 package dev.jasonpearson.automobile.desktop.core.workspace
 
+import kotlinx.coroutines.CompletableDeferred
 import kotlinx.coroutines.ExperimentalCoroutinesApi
 import kotlinx.coroutines.test.TestScope
 import kotlinx.coroutines.test.UnconfinedTestDispatcher
+import kotlinx.coroutines.test.advanceUntilIdle
 import kotlinx.coroutines.test.runTest
 import org.junit.Assert.assertEquals
 import org.junit.Assert.assertNull
@@ -204,6 +206,22 @@ class WorkspaceViewModelTest {
         listOf(FakeEmulatorControlExecutor.LocaleRequest("a", Platform.Ios, "ja-JP")),
         exec.localeRequests,
       )
+    }
+
+  @Test
+  fun `a later locale pick supersedes a still-resolving one on the same device`() =
+    testScope.runTest {
+      val gate = CompletableDeferred<Unit>()
+      val exec = FakeEmulatorControlExecutor().apply { localeGate = gate }
+      val vm = WorkspaceViewModel(this, exec)
+      vm.onAction(WorkspaceAction.ObserveDevice(column("a")))
+      // The first pick parks while resolving the foreground app; the second must cancel it so the
+      // device ends in the last-picked locale rather than whichever request happens to finish last.
+      vm.onAction(WorkspaceAction.SetLocale("a", "es-ES"))
+      vm.onAction(WorkspaceAction.SetLocale("a", "de-DE"))
+      gate.complete(Unit)
+      advanceUntilIdle()
+      assertEquals(listOf("de-DE"), exec.localeRequests.map { it.locale })
     }
 
   @Test

--- a/android/desktop-core/src/test/kotlin/dev/jasonpearson/automobile/desktop/core/workspace/WorkspaceViewModelTest.kt
+++ b/android/desktop-core/src/test/kotlin/dev/jasonpearson/automobile/desktop/core/workspace/WorkspaceViewModelTest.kt
@@ -181,6 +181,42 @@ class WorkspaceViewModelTest {
   }
 
   @Test
+  fun `PressDeviceButton invokes the executor with the button and target platform`() =
+    testScope.runTest {
+      val exec = FakeEmulatorControlExecutor()
+      val vm = WorkspaceViewModel(this, exec)
+      vm.onAction(WorkspaceAction.ObserveDevice(column("a", Platform.Android)))
+      vm.onAction(WorkspaceAction.PressDeviceButton("a", DeviceButton.Home))
+      assertEquals(
+        listOf(FakeEmulatorControlExecutor.ButtonRequest("a", Platform.Android, DeviceButton.Home)),
+        exec.buttonRequests,
+      )
+    }
+
+  @Test
+  fun `SetLocale invokes the executor with the locale tag and target platform`() =
+    testScope.runTest {
+      val exec = FakeEmulatorControlExecutor()
+      val vm = WorkspaceViewModel(this, exec)
+      vm.onAction(WorkspaceAction.ObserveDevice(column("a", Platform.Ios)))
+      vm.onAction(WorkspaceAction.SetLocale("a", "ja-JP"))
+      assertEquals(
+        listOf(FakeEmulatorControlExecutor.LocaleRequest("a", Platform.Ios, "ja-JP")),
+        exec.localeRequests,
+      )
+    }
+
+  @Test
+  fun `PressDeviceButton and SetLocale for an unknown device run nothing`() = testScope.runTest {
+    val exec = FakeEmulatorControlExecutor()
+    val vm = WorkspaceViewModel(this, exec)
+    vm.onAction(WorkspaceAction.ObserveDevice(column("a")))
+    vm.onAction(WorkspaceAction.PressDeviceButton("nope", DeviceButton.Back))
+    vm.onAction(WorkspaceAction.SetLocale("nope", "de-DE"))
+    assertTrue(exec.buttonRequests.isEmpty() && exec.localeRequests.isEmpty())
+  }
+
+  @Test
   fun `SetLockStates updates matched columns and leaves absent devices unchanged`() =
     testScope.runTest {
       val vm = WorkspaceViewModel(this)


### PR DESCRIPTION
## Summary

Completes the Compose Desktop emulator-control cluster the wireframe specifies (rotate · screenshot · snapshot · **locale** · **more** · contextual Unlock) by wiring the two remaining non-one-shot controls, deferred from [#4690](https://github.com/kaeawc/auto-mobile/pull/4690)/[#4694](https://github.com/kaeawc/auto-mobile/issues/4694) — PR [#5053](https://github.com/kaeawc/auto-mobile/pull/5053) wired the one-shot ones.

- **`more`** — a glyph that opens an overflow dropdown of device system actions (Home, Back, Recent apps, Power) → `WorkspaceAction.PressDeviceButton` → executor `callTool("pressButton", …)`.
- **`locale`** — a glyph that opens a curated locale picker → `WorkspaceAction.SetLocale` → executor `callTool("changeLocalization", …)` (behind the `device-settings` capability). `changeLocalization` requires an app target on Android, so the executor resolves the pane device's foreground app via a new `ForegroundAppResolver` seam (reads the first hierarchy frame's `packageName` off the observation stream, untested IO); iOS is device-wide.

Same slice pattern as [#5053](https://github.com/kaeawc/auto-mobile/pull/5053): stateless Compose control + `WorkspaceViewModel` intent + the injected `EmulatorControlExecutor` seam; behavior pinned at the ViewModel/UI boundary with fakes, the real socket call untested.

### Acceptance criteria → test

| AC | Where | Pinned by |
|----|-------|-----------|
| `more` menu | `EmulatorControl.More`, `DeviceButton`, `MoreControl` dropdown, `PressDeviceButton` → executor | `WorkspaceViewModelTest` (button→executor), `DaemonEmulatorControlExecutorTest` (pressButton args), `WorkspaceShellUiTest` (menu opens + dispatches) |
| `locale` picker | `EmulatorControl.Locale`, `COMMON_LOCALES`, `LocaleControl` dropdown, `SetLocale` → executor + `ForegroundAppResolver` | `WorkspaceViewModelTest` (locale→executor), `DaemonEmulatorControlExecutorTest` (iOS device-wide vs Android foreground-app appId, no-app → no call), `WorkspaceShellUiTest` (picker opens + dispatches) |

## Linked Issue

Closes #5055

## Validation

- [x] `:desktop-core:test` + `:desktop-app:compileKotlin` green; `ktfmt` clean (formatted with CI's ktfmt-0.64 jar)
- [x] `bun run typecheck` — no new errors (Kotlin-only change; no `src/`/TS touched)
- [x] New code uses interfaces + fakes; ViewModel/executor unit tests run in <100ms

## Kotlin Reuse Check

- [x] Reused the `EmulatorControlExecutor` seam, `ObservationStream`, `Platform.wireName`, and existing MCP tools (`pressButton`, `changeLocalization`); the one new seam (`ForegroundAppResolver`) exists because `changeLocalization` needs an Android app target and no reusable foreground-app resolver existed

Risk class: **Low** — self-contained `desktop-core` UI + executor extension, reuses existing tools, no DB/migration/runner-protocol/public-tool-schema changes.
