### PR TITLE
perf(desktop): dedicated lightweight lock-state resource for the Unlock poll

### DIFF
--- a/android/desktop-app/src/main/kotlin/dev/jasonpearson/automobile/desktop/AutoMobileDesktopApp.kt
+++ b/android/desktop-app/src/main/kotlin/dev/jasonpearson/automobile/desktop/AutoMobileDesktopApp.kt
@@ -23,6 +23,7 @@ import dev.jasonpearson.automobile.desktop.core.mcp.DaemonMcpResourceClient
 import dev.jasonpearson.automobile.desktop.core.mcp.ResourceReadResult
 import dev.jasonpearson.automobile.desktop.core.settings.SettingsProvider
 import dev.jasonpearson.automobile.desktop.core.shell.MenuBarActions
+import dev.jasonpearson.automobile.desktop.core.workspace.BOOTED_DEVICES_RESOURCE_URI
 import dev.jasonpearson.automobile.desktop.core.workspace.CommandPalette
 import dev.jasonpearson.automobile.desktop.core.workspace.DEVICE_LOCK_STATES_RESOURCE_URI
 import dev.jasonpearson.automobile.desktop.core.workspace.DaemonEmulatorControlExecutor
@@ -45,6 +46,7 @@ import dev.jasonpearson.automobile.desktop.core.workspace.WorkspaceUiState
 import dev.jasonpearson.automobile.desktop.core.workspace.WorkspaceViewModel
 import dev.jasonpearson.automobile.desktop.core.workspace.buildWorkspaceCommands
 import dev.jasonpearson.automobile.desktop.core.workspace.deriveWorkspaceStatus
+import dev.jasonpearson.automobile.desktop.core.workspace.parseBootedLockStates
 import dev.jasonpearson.automobile.desktop.core.workspace.parseDeviceLockStates
 import dev.jasonpearson.automobile.desktop.core.workspace.picker.DevicePicker
 import dev.jasonpearson.automobile.desktop.core.workspace.picker.DevicePickerAction
@@ -262,8 +264,8 @@ fun AutoMobileDesktopApp(
   // Keep each pane's lock state fresh so the contextual Unlock control appears/disappears as the
   // device locks/unlocks. Untested IO poll (mirrors rememberDaemonConnectionState); the VM's
   // SetLockStates handler is the pinned behavior. Gated on observed columns so an idle workspace
-  // is silent; while panes are open it re-reads the (non-trivial) booted-devices resource — see
-  // LOCK_STATE_POLL_MS.
+  // is silent; while panes are open it re-reads the lightweight lockStates resource, falling back
+  // to the full booted-devices resource for older daemons that lack it — see LOCK_STATE_POLL_MS.
   LaunchedEffect(workspaceViewModel, resourceClient) {
     while (true) {
       val hasColumns =
@@ -278,7 +280,20 @@ fun AutoMobileDesktopApp(
                 }
             ) {
               is ResourceReadResult.Success -> parseDeviceLockStates(result.content)
-              is ResourceReadResult.Error -> emptyMap()
+              // An older daemon (reached over a non-reconciling HTTP/STDIO transport) doesn't
+              // expose the lightweight lockStates resource; fall back to the full booted-devices
+              // resource, which also carries each device's lock flag, so the Unlock control keeps
+              // tracking reality instead of going permanently stale.
+              is ResourceReadResult.Error ->
+                when (
+                  val booted =
+                    withContext(Dispatchers.IO) {
+                      resourceClient.readResource(BOOTED_DEVICES_RESOURCE_URI)
+                    }
+                ) {
+                  is ResourceReadResult.Success -> parseBootedLockStates(booted.content)
+                  is ResourceReadResult.Error -> emptyMap()
+                }
             }
           } catch (cancellation: CancellationException) {
             throw cancellation

--- a/android/desktop-app/src/main/kotlin/dev/jasonpearson/automobile/desktop/AutoMobileDesktopApp.kt
+++ b/android/desktop-app/src/main/kotlin/dev/jasonpearson/automobile/desktop/AutoMobileDesktopApp.kt
@@ -23,8 +23,8 @@ import dev.jasonpearson.automobile.desktop.core.mcp.DaemonMcpResourceClient
 import dev.jasonpearson.automobile.desktop.core.mcp.ResourceReadResult
 import dev.jasonpearson.automobile.desktop.core.settings.SettingsProvider
 import dev.jasonpearson.automobile.desktop.core.shell.MenuBarActions
-import dev.jasonpearson.automobile.desktop.core.workspace.BOOTED_DEVICES_RESOURCE_URI
 import dev.jasonpearson.automobile.desktop.core.workspace.CommandPalette
+import dev.jasonpearson.automobile.desktop.core.workspace.DEVICE_LOCK_STATES_RESOURCE_URI
 import dev.jasonpearson.automobile.desktop.core.workspace.DaemonEmulatorControlExecutor
 import dev.jasonpearson.automobile.desktop.core.workspace.DeviceColumn
 import dev.jasonpearson.automobile.desktop.core.workspace.DeviceStreamView
@@ -274,7 +274,7 @@ fun AutoMobileDesktopApp(
             when (
               val result =
                 withContext(Dispatchers.IO) {
-                  resourceClient.readResource(BOOTED_DEVICES_RESOURCE_URI)
+                  resourceClient.readResource(DEVICE_LOCK_STATES_RESOURCE_URI)
                 }
             ) {
               is ResourceReadResult.Success -> parseDeviceLockStates(result.content)

--- a/android/desktop-core/src/main/kotlin/dev/jasonpearson/automobile/desktop/core/mcp/DeviceModels.kt
+++ b/android/desktop-core/src/main/kotlin/dev/jasonpearson/automobile/desktop/core/mcp/DeviceModels.kt
@@ -95,6 +95,20 @@ data class DeviceImageInfo(
   val architecture: String? = null,
 )
 
+/** Response from the lightweight automobile:devices/lockStates resource (issue #5056). */
+@Serializable
+data class DeviceLockStatesResponse(
+  val lastUpdated: String = "",
+  val lockStates: List<DeviceLockStateInfo> = emptyList(),
+)
+
+@Serializable
+data class DeviceLockStateInfo(
+  val deviceId: String,
+  // Android keyguard state; omitted (null) when the daemon couldn't read it, or on iOS.
+  val locked: Boolean? = null,
+)
+
 /** Parser for device resource responses */
 object DeviceResourceParser {
   private val json = Json {
@@ -113,6 +127,14 @@ object DeviceResourceParser {
   fun parseDeviceImages(jsonString: String): DeviceImagesResponse? {
     return try {
       json.decodeFromString<DeviceImagesResponse>(jsonString)
+    } catch (e: Exception) {
+      null
+    }
+  }
+
+  fun parseLockStates(jsonString: String): DeviceLockStatesResponse? {
+    return try {
+      json.decodeFromString<DeviceLockStatesResponse>(jsonString)
     } catch (e: Exception) {
       null
     }

--- a/android/desktop-core/src/main/kotlin/dev/jasonpearson/automobile/desktop/core/workspace/DeviceLockStatePoll.kt
+++ b/android/desktop-core/src/main/kotlin/dev/jasonpearson/automobile/desktop/core/workspace/DeviceLockStatePoll.kt
@@ -2,18 +2,22 @@ package dev.jasonpearson.automobile.desktop.core.workspace
 
 import dev.jasonpearson.automobile.desktop.core.mcp.DeviceResourceParser
 
-/** URI of the booted-devices resource that carries each device's lock state. */
-const val BOOTED_DEVICES_RESOURCE_URI = "automobile:devices/booted"
+/**
+ * URI of the lightweight lock-state resource the host polls (issue #5056). Distinct from the full
+ * `automobile:devices/booted` resource: it runs only the keyguard probe, not the per-device service
+ * status the poll otherwise re-computed every cycle.
+ */
+const val DEVICE_LOCK_STATES_RESOURCE_URI = "automobile:devices/lockStates"
 
 /**
- * Parse a booted-devices resource payload into a `deviceId -> locked` snapshot for
+ * Parse a lock-states resource payload into a `deviceId -> locked` snapshot for
  * [WorkspaceAction.SetLockStates]. Devices whose `locked` the daemon could not read are OMITTED
  * (the field is `null`), never coerced to `false` — so a device with an unknown lock state keeps
  * its pane's current state instead of being force-unlocked. A malformed/empty payload likewise
  * yields an empty map ("no update"). Pure so the host's untested poll stays a thin IO wrapper.
  */
 fun parseDeviceLockStates(content: String): Map<String, Boolean> =
-  DeviceResourceParser.parseBootedDevices(content)
-    ?.devices
-    ?.mapNotNull { device -> device.locked?.let { device.deviceId to it } }
+  DeviceResourceParser.parseLockStates(content)
+    ?.lockStates
+    ?.mapNotNull { state -> state.locked?.let { state.deviceId to it } }
     ?.toMap() ?: emptyMap()

--- a/android/desktop-core/src/main/kotlin/dev/jasonpearson/automobile/desktop/core/workspace/DeviceLockStatePoll.kt
+++ b/android/desktop-core/src/main/kotlin/dev/jasonpearson/automobile/desktop/core/workspace/DeviceLockStatePoll.kt
@@ -10,6 +10,13 @@ import dev.jasonpearson.automobile.desktop.core.mcp.DeviceResourceParser
 const val DEVICE_LOCK_STATES_RESOURCE_URI = "automobile:devices/lockStates"
 
 /**
+ * URI of the full booted-devices resource. The poll falls back to this when a daemon does not
+ * expose [DEVICE_LOCK_STATES_RESOURCE_URI] — an older server reached over a non-reconciling HTTP or
+ * STDIO transport — since `automobile:devices/booted` also carries each device's `locked` flag.
+ */
+const val BOOTED_DEVICES_RESOURCE_URI = "automobile:devices/booted"
+
+/**
  * Parse a lock-states resource payload into a `deviceId -> locked` snapshot for
  * [WorkspaceAction.SetLockStates]. Devices whose `locked` the daemon could not read are OMITTED
  * (the field is `null`), never coerced to `false` — so a device with an unknown lock state keeps
@@ -20,4 +27,16 @@ fun parseDeviceLockStates(content: String): Map<String, Boolean> =
   DeviceResourceParser.parseLockStates(content)
     ?.lockStates
     ?.mapNotNull { state -> state.locked?.let { state.deviceId to it } }
+    ?.toMap() ?: emptyMap()
+
+/**
+ * Fallback for older daemons that lack [DEVICE_LOCK_STATES_RESOURCE_URI]: derive the same `deviceId
+ * -> locked` snapshot from the full `automobile:devices/booted` payload, whose
+ * [dev.jasonpearson.automobile.desktop.core.mcp.BootedDeviceInfo.locked] flag was added in #4694.
+ * Same omit-when-unknown / empty-on-malformed contract as [parseDeviceLockStates].
+ */
+fun parseBootedLockStates(content: String): Map<String, Boolean> =
+  DeviceResourceParser.parseBootedDevices(content)
+    ?.devices
+    ?.mapNotNull { device -> device.locked?.let { device.deviceId to it } }
     ?.toMap() ?: emptyMap()

--- a/android/desktop-core/src/test/kotlin/dev/jasonpearson/automobile/desktop/core/workspace/DeviceLockStatePollTest.kt
+++ b/android/desktop-core/src/test/kotlin/dev/jasonpearson/automobile/desktop/core/workspace/DeviceLockStatePollTest.kt
@@ -12,12 +12,9 @@ class DeviceLockStatePollTest {
     // and must be OMITTED, not coerced to false — otherwise a transient probe gap force-unlocks it.
     val payload =
       """
-      {"totalCount":2,"androidCount":2,"iosCount":0,"virtualCount":2,"physicalCount":0,
-       "lastUpdated":"x","devices":[
-         {"name":"Pixel 8","platform":"android","deviceId":"emulator-5554",
-          "source":"local","isVirtual":true,"status":"booted","locked":true},
-         {"name":"Pixel 7","platform":"android","deviceId":"emulator-5556",
-          "source":"local","isVirtual":true,"status":"booted"}]}
+      {"lastUpdated":"x","lockStates":[
+         {"deviceId":"emulator-5554","locked":true},
+         {"deviceId":"emulator-5556"}]}
       """
         .trimIndent()
     assertEquals(mapOf("emulator-5554" to true), parseDeviceLockStates(payload))
@@ -27,10 +24,7 @@ class DeviceLockStatePollTest {
   fun `maps an explicit locked false so a known-unlocked device unlocks its pane`() {
     val payload =
       """
-      {"totalCount":1,"androidCount":1,"iosCount":0,"virtualCount":1,"physicalCount":0,
-       "lastUpdated":"x","devices":[
-         {"name":"Pixel 8","platform":"android","deviceId":"emulator-5554",
-          "source":"local","isVirtual":true,"status":"booted","locked":false}]}
+      {"lastUpdated":"x","lockStates":[{"deviceId":"emulator-5554","locked":false}]}
       """
         .trimIndent()
     assertEquals(mapOf("emulator-5554" to false), parseDeviceLockStates(payload))

--- a/android/desktop-core/src/test/kotlin/dev/jasonpearson/automobile/desktop/core/workspace/DeviceLockStatePollTest.kt
+++ b/android/desktop-core/src/test/kotlin/dev/jasonpearson/automobile/desktop/core/workspace/DeviceLockStatePollTest.kt
@@ -35,4 +35,25 @@ class DeviceLockStatePollTest {
     assertTrue(parseDeviceLockStates("not json").isEmpty())
     assertTrue(parseDeviceLockStates("").isEmpty())
   }
+
+  @Test
+  fun `booted-devices fallback derives lock from the full payload, omitting unread devices`() {
+    // Older daemons expose lock only via automobile:devices/booted; the poll's fallback derives the
+    // same deviceId -> locked snapshot from its `locked` field, omitting a device that lacks it.
+    val payload =
+      """
+      {"totalCount":2,"androidCount":2,"iosCount":0,"virtualCount":2,"physicalCount":0,
+       "lastUpdated":"x","devices":[
+         {"name":"P8","platform":"android","deviceId":"emulator-5554","source":"local","isVirtual":true,"status":"booted","locked":true},
+         {"name":"P9","platform":"android","deviceId":"emulator-5556","source":"local","isVirtual":true,"status":"booted"}]}
+      """
+        .trimIndent()
+    assertEquals(mapOf("emulator-5554" to true), parseBootedLockStates(payload))
+  }
+
+  @Test
+  fun `booted-devices fallback yields an empty map for a malformed payload`() {
+    assertTrue(parseBootedLockStates("not json").isEmpty())
+    assertTrue(parseBootedLockStates("").isEmpty())
+  }
 }

--- a/src/server/bootedDeviceResources.ts
+++ b/src/server/bootedDeviceResources.ts
@@ -27,6 +27,24 @@ export const BOOTED_DEVICE_RESOURCE_URIS = {
   PLATFORM_TEMPLATE: "automobile:devices/booted/{platform}"
 } as const;
 
+// A lightweight per-device lock-state resource. The full booted-devices resource also carries
+// `locked`, but computing it there recomputes service status (isInstalled/isEnabled/sha256) for
+// every device — too heavy for the desktop's frequent lock poll (issue #5056). This resource
+// enumerates booted devices and runs ONLY the keyguard probe.
+export const DEVICE_LOCK_STATES_RESOURCE_URI = "automobile:devices/lockStates";
+
+// Per-device lock state. `locked` is Android-only (from the keyguard probe) and omitted when it
+// could not be read — a transient failure, or iOS, which has no lock probe.
+interface DeviceLockStateInfo {
+  deviceId: string;
+  locked?: boolean;
+}
+
+export interface DeviceLockStatesResourceContent {
+  lastUpdated: string;  // ISO 8601
+  lockStates: DeviceLockStateInfo[];
+}
+
 // Service status for a booted device
 interface DeviceServiceStatus {
   installed: boolean;
@@ -144,6 +162,85 @@ async function realDeviceLockProbe(device: BootedDevice): Promise<boolean | unde
   }
   const lock = await defaultAdbClientFactory.create(device).getDeviceLock();
   return lock?.locked;
+}
+
+const LOCK_STATE_TIMEOUT_MS = 3000;
+
+/** The active lock probe: an injected fake (tests) or the real adb probe when no fake manager is set. */
+function activeLockProbe(): DeviceLockProbe | null {
+  return injectedLockProbe ?? (serviceStatusEnabled ? realDeviceLockProbe : null);
+}
+
+/**
+ * Resolve a device's lock state via [lockProbe], bounded by a per-device timeout so a slow/failed
+ * read leaves it `undefined` rather than stalling the caller. Clears the losing timer when the probe
+ * wins, so a fast success never logs a spurious "timeout" on the desktop's periodic poll.
+ */
+async function probeDeviceLock(
+  device: BootedDevice,
+  lockProbe: DeviceLockProbe
+): Promise<boolean | undefined> {
+  let timeoutHandle: NodeJS.Timeout | undefined;
+  try {
+    return await Promise.race([
+      lockProbe(device),
+      new Promise<undefined>(resolve => {
+        timeoutHandle = defaultTimer.setTimeout(() => {
+          logger.warn(`[BootedDeviceResources] Lock-state timeout for ${device.deviceId}`);
+          resolve(undefined);
+        }, LOCK_STATE_TIMEOUT_MS);
+      }),
+    ]);
+  } catch (error) {
+    logger.warn(`[BootedDeviceResources] Failed to query lock state for ${device.deviceId}: ${error}`);
+    return undefined;
+  } finally {
+    if (timeoutHandle) {
+      defaultTimer.clearTimeout(timeoutHandle);
+    }
+  }
+}
+
+/**
+ * Compute the lightweight [DEVICE_LOCK_STATES_RESOURCE_URI] payload: enumerate booted devices and
+ * run ONLY the keyguard probe (no service-status), so the desktop's frequent lock poll doesn't pay
+ * for isInstalled/isEnabled/sha256 every cycle (issue #5056).
+ */
+async function computeDeviceLockStates(): Promise<DeviceLockStatesResourceContent> {
+  const devices: BootedDevice[] = [];
+  for (const platform of ["android", "ios"] as Platform[]) {
+    try {
+      const discovery = await PlatformDeviceManagerFactory.getInstance().getBootedDevicesDetailed(platform);
+      devices.push(...discovery.devices);
+    } catch (error) {
+      logger.warn(`[DeviceLockStates] Failed to enumerate ${platform} booted devices: ${error}`);
+    }
+  }
+
+  const lockStates: DeviceLockStateInfo[] = devices.map(device => ({ deviceId: device.deviceId }));
+  const lockProbe = activeLockProbe();
+  if (lockProbe) {
+    const results = await Promise.allSettled(
+      devices.map(device => probeDeviceLock(device, lockProbe))
+    );
+    for (let i = 0; i < devices.length; i++) {
+      const result = results[i];
+      if (result.status === "fulfilled" && result.value !== undefined) {
+        lockStates[i] = { deviceId: devices[i].deviceId, locked: result.value };
+      }
+    }
+  }
+
+  return { lastUpdated: new Date().toISOString(), lockStates };
+}
+
+async function getDeviceLockStates(): Promise<ResourceContent> {
+  const content = await computeDeviceLockStates();
+  return {
+    uri: DEVICE_LOCK_STATES_RESOURCE_URI,
+    mimeType: "application/json",
+    text: JSON.stringify(content, null, 2)
+  };
 }
 
 // Convert BootedDevice to BootedDeviceInfo
@@ -417,40 +514,17 @@ async function getBootedDevicesForPlatforms(platforms: Platform[]): Promise<Boot
   // only with an injected probe (tests) or a real device manager (production), never against a fake
   // manager's mock devices. Best-effort with a per-device timeout: a slow/failed read leaves `locked`
   // unset rather than stalling the whole resource.
-  const lockProbe = injectedLockProbe ?? (serviceStatusEnabled ? realDeviceLockProbe : null);
+  const lockProbe = activeLockProbe();
   if (lockProbe) {
-    const LOCK_STATE_TIMEOUT_MS = 3000;
     const lockResults = await Promise.allSettled(
-      devices.map(async device => {
-        // The adb lock probe only needs the device identity; `source` (whose BootedDeviceInfo type
-        // is wider than BootedDevice's) is irrelevant, so omit it rather than force a cast.
-        const bootedDevice: BootedDevice = {
-          name: device.name,
-          platform: device.platform,
-          deviceId: device.deviceId,
-        };
-        // Clear the timeout when the probe wins so the losing timer never fires — otherwise, on the
-        // desktop's periodic poll, a fast successful probe still logs a spurious "timeout" every cycle.
-        let timeoutHandle: NodeJS.Timeout | undefined;
-        try {
-          return await Promise.race([
-            lockProbe(bootedDevice),
-            new Promise<undefined>(resolve => {
-              timeoutHandle = defaultTimer.setTimeout(() => {
-                logger.warn(`[BootedDeviceResources] Lock-state timeout for ${device.deviceId}`);
-                resolve(undefined);
-              }, LOCK_STATE_TIMEOUT_MS);
-            }),
-          ]);
-        } catch (error) {
-          logger.warn(`[BootedDeviceResources] Failed to query lock state for ${device.deviceId}: ${error}`);
-          return undefined;
-        } finally {
-          if (timeoutHandle) {
-            defaultTimer.clearTimeout(timeoutHandle);
-          }
-        }
-      })
+      // The adb lock probe only needs the device identity; `source` (whose BootedDeviceInfo type is
+      // wider than BootedDevice's) is irrelevant, so omit it rather than force a cast.
+      devices.map(device =>
+        probeDeviceLock(
+          { name: device.name, platform: device.platform, deviceId: device.deviceId },
+          lockProbe
+        )
+      )
     );
 
     for (let i = 0; i < devices.length; i++) {
@@ -574,6 +648,15 @@ export function registerBootedDeviceResources(): void {
     "List of booted/running devices for a specific platform (android or ios).",
     "application/json",
     getBootedDevicesByPlatform
+  );
+
+  // Register the lightweight per-device lock-state resource (issue #5056).
+  ResourceRegistry.register(
+    DEVICE_LOCK_STATES_RESOURCE_URI,
+    "Device Lock States",
+    "Per-device keyguard/lock state (Android). Lightweight — enumerates booted devices and runs only the keyguard probe, without the service-status computation the full booted-devices resource does.",
+    "application/json",
+    getDeviceLockStates
   );
 
   logger.info("[BootedDeviceResources] Registered booted device resources");

--- a/src/server/bootedDeviceResources.ts
+++ b/src/server/bootedDeviceResources.ts
@@ -662,9 +662,12 @@ export function registerBootedDeviceResources(): void {
   logger.info("[BootedDeviceResources] Registered booted device resources");
 }
 
-// Send notifications for booted device resource updates
+// Send notifications for booted device resource updates. Both the full booted-devices resource and
+// the lightweight lock-states resource (#5056) enumerate the same booted inventory, so a device
+// starting/killing changes both — notify subscribers of each, not just the full resource.
 export async function notifyBootedDeviceResourcesUpdated(): Promise<void> {
   await ResourceRegistry.notifyResourcesUpdated([
-    BOOTED_DEVICE_RESOURCE_URIS.ALL_BOOTED
+    BOOTED_DEVICE_RESOURCE_URIS.ALL_BOOTED,
+    DEVICE_LOCK_STATES_RESOURCE_URI
   ]);
 }

--- a/test/server/resources/bootedDevices.test.ts
+++ b/test/server/resources/bootedDevices.test.ts
@@ -3,7 +3,7 @@ import { McpTestFixture } from "../../fixtures/mcpTestFixture";
 import { ResourceRegistry } from "../../../src/server/resourceRegistry";
 import { FakeDeviceUtils } from "../../fakes/FakeDeviceUtils";
 import { FakeTimer } from "../../fakes/FakeTimer";
-import { setDeviceManager, setDeviceLockProbe, BootedDevicesResourceContent } from "../../../src/server/bootedDeviceResources";
+import { setDeviceManager, setDeviceLockProbe, BootedDevicesResourceContent, DeviceLockStatesResourceContent } from "../../../src/server/bootedDeviceResources";
 import { BootedDevice, Platform } from "../../../src/models";
 import { DaemonState } from "../../../src/daemon/daemonState";
 import { DevicePool } from "../../../src/daemon/devicePool";
@@ -374,6 +374,66 @@ describe("MCP Booted Device Resources", () => {
 
       const data: BootedDevicesResourceContent = JSON.parse(result.contents[0].text!);
       expect(data.devices[0].locked).toBeUndefined();
+    });
+
+    test("lock-states resource surfaces per-device lock from the probe", async function() {
+      fakeDeviceUtils.setBootedDevices("android", [mockAndroidDevice1, mockAndroidDevice2]);
+      // Only the first device is locked; the probe reports the rest unlocked.
+      setDeviceLockProbe(async device => device.deviceId === mockAndroidDevice1.deviceId);
+
+      const { client } = fixture.getContext();
+
+      const readResourceResponseSchema = z.object({
+        contents: z.array(z.object({
+          uri: z.string(),
+          mimeType: z.string().optional(),
+          text: z.string().optional(),
+          blob: z.string().optional()
+        }))
+      });
+
+      const result = await client.request({
+        method: "resources/read",
+        params: {
+          uri: "automobile:devices/lockStates"
+        }
+      }, readResourceResponseSchema);
+
+      const data: DeviceLockStatesResourceContent = JSON.parse(result.contents[0].text!);
+      const locked = data.lockStates.find(s => s.deviceId === mockAndroidDevice1.deviceId);
+      const unlocked = data.lockStates.find(s => s.deviceId === mockAndroidDevice2.deviceId);
+      expect(locked?.locked).toBe(true);
+      expect(unlocked?.locked).toBe(false);
+      // A valid ISO 8601 timestamp is stamped.
+      expect(() => new Date(data.lastUpdated)).not.toThrow();
+    });
+
+    test("lock-states resource omits lock for a device the probe cannot read", async function() {
+      fakeDeviceUtils.setBootedDevices("ios", [mockIosDevice1]);
+      setDeviceLockProbe(async () => undefined);
+
+      const { client } = fixture.getContext();
+
+      const readResourceResponseSchema = z.object({
+        contents: z.array(z.object({
+          uri: z.string(),
+          mimeType: z.string().optional(),
+          text: z.string().optional(),
+          blob: z.string().optional()
+        }))
+      });
+
+      const result = await client.request({
+        method: "resources/read",
+        params: {
+          uri: "automobile:devices/lockStates"
+        }
+      }, readResourceResponseSchema);
+
+      const data: DeviceLockStatesResourceContent = JSON.parse(result.contents[0].text!);
+      expect(data.lockStates).toHaveLength(1);
+      expect(data.lockStates[0].deviceId).toBe(mockIosDevice1.deviceId);
+      expect(data.lockStates[0].locked).toBeUndefined();
     });
 
     test("should include pool status when daemon is initialized", async function() {

--- a/test/server/resources/bootedDevices.test.ts
+++ b/test/server/resources/bootedDevices.test.ts
@@ -404,8 +404,9 @@ describe("MCP Booted Device Resources", () => {
       const unlocked = data.lockStates.find(s => s.deviceId === mockAndroidDevice2.deviceId);
       expect(locked?.locked).toBe(true);
       expect(unlocked?.locked).toBe(false);
-      // A valid ISO 8601 timestamp is stamped.
-      expect(() => new Date(data.lastUpdated)).not.toThrow();
+      // lastUpdated is a canonical ISO 8601 timestamp: it round-trips through Date, proving it is a
+      // real value rather than merely non-throwing (`new Date()` does not throw on garbage input).
+      expect(data.lastUpdated).toBe(new Date(data.lastUpdated).toISOString());
     });
 
     test("lock-states resource omits lock for a device the probe cannot read", async function() {

--- a/test/server/resources/bootedDevices.test.ts
+++ b/test/server/resources/bootedDevices.test.ts
@@ -1,9 +1,9 @@
-import { afterAll, afterEach, beforeAll, beforeEach, describe, expect, test } from "bun:test";
+import { afterAll, afterEach, beforeAll, beforeEach, describe, expect, spyOn, test } from "bun:test";
 import { McpTestFixture } from "../../fixtures/mcpTestFixture";
 import { ResourceRegistry } from "../../../src/server/resourceRegistry";
 import { FakeDeviceUtils } from "../../fakes/FakeDeviceUtils";
 import { FakeTimer } from "../../fakes/FakeTimer";
-import { setDeviceManager, setDeviceLockProbe, BootedDevicesResourceContent, DeviceLockStatesResourceContent } from "../../../src/server/bootedDeviceResources";
+import { setDeviceManager, setDeviceLockProbe, notifyBootedDeviceResourcesUpdated, BootedDevicesResourceContent, DeviceLockStatesResourceContent } from "../../../src/server/bootedDeviceResources";
 import { BootedDevice, Platform } from "../../../src/models";
 import { DaemonState } from "../../../src/daemon/daemonState";
 import { DevicePool } from "../../../src/daemon/devicePool";
@@ -435,6 +435,21 @@ describe("MCP Booted Device Resources", () => {
       expect(data.lockStates).toHaveLength(1);
       expect(data.lockStates[0].deviceId).toBe(mockIosDevice1.deviceId);
       expect(data.lockStates[0].locked).toBeUndefined();
+    });
+
+    test("resource-update notification fans out to the lock-states resource, not just booted", async function() {
+      // A device start/kill changes both the full booted resource and this lightweight one, so
+      // subscribers to either must be notified — regression guard for the notify set.
+      const spy = spyOn(ResourceRegistry, "notifyResourcesUpdated").mockResolvedValue(undefined);
+      try {
+        await notifyBootedDeviceResourcesUpdated();
+        expect(spy).toHaveBeenCalledTimes(1);
+        const uris = spy.mock.calls[0][0];
+        expect(uris).toContain("automobile:devices/booted");
+        expect(uris).toContain("automobile:devices/lockStates");
+      } finally {
+        spy.mockRestore();
+      }
     });
 
     test("should include pool status when daemon is initialized", async function() {


### PR DESCRIPTION
## Summary

Cuts the adb cost of the desktop's lock-state poll (flagged in [#5053](https://github.com/kaeawc/auto-mobile/pull/5053)'s review). The host polls device lock state every 4s by re-reading the full `automobile:devices/booted` resource, which recomputes per-device **service status** (`isInstalled`/`isEnabled`/`getInstalledApkSha256`) **and** the keyguard probe for every booted device — most of that work is wasted for a lock poll.

- **New daemon resource `automobile:devices/lockStates`** — enumerates booted devices and runs **only** the keyguard probe (Android via `dumpsys window policy`; omitted on iOS / unread), reusing the injectable `DeviceLockProbe` seam from [#5053](https://github.com/kaeawc/auto-mobile/pull/5053) via a shared `probeDeviceLock` helper the full booted resource now also uses (DRY, one canonical probe path).
- **Desktop poll reads the new resource** instead of `automobile:devices/booted`, dropping ~3 adb calls per device per cycle.
- The booted resource **keeps** its `locked` field — the picker still seeds `DeviceColumn.locked` from it on observe, so that path is unchanged.

This is part 2 of [#5056](https://github.com/kaeawc/auto-mobile/issues/5056). **iOS keyguard detection (part 1)** is split to follow-up #5106: it needs a new iOS CtrlProxy **runner-protocol command** + a **runner re-cut** (the daemon downloads the pinned released runner), which is high-risk and not deliverable in this PR.

### Acceptance criteria → test

| AC | Where | Pinned by |
|----|-------|-----------|
| lighter lock query (no serviceStatus) | `bootedDeviceResources.ts` (`automobile:devices/lockStates`, `probeDeviceLock`), desktop `DeviceLockStatePoll` + host poll | `bootedDevices.test.ts` (lock-states resource: locked true/false, omitted when unread), `DeviceLockStatePollTest` (parse the new shape) |

## Linked Issue

Closes #5056

## Validation

- [x] `bun test test/server/resources/` green (55, incl. the new lock-states resource); `bun run typecheck` — no new errors; `bun run lint` green
- [x] `:desktop-core:test` + `:desktop-app:compileKotlin` green; `ktfmt` clean (CI ktfmt-0.64 jar)
- [x] No DB/migration/runner-protocol changes; reuses the existing Android lock probe

## Kotlin Reuse Check

- [x] Reused `DeviceResourceParser`, the `DeviceLockProbe` seam, and (daemon) the existing lock-probe machinery via a shared `probeDeviceLock` helper — no new dependency

Risk class: **Medium** — adds a new **public daemon resource** (additive; Android-only lock via the existing probe; no changes to existing tools/resources, DB, migrations, or the runner protocol).

---

**Review note:** `parseDeviceLockStates` and `parseBootedLockStates` are top-level public helpers in `desktop-core` by design — they are pure parsers consumed cross-module by `desktop-app` (the poll in `AutoMobileDesktopApp.kt`) and unit-tested in `desktop-core`, so they cannot be `private`. `parseBootedLockStates` mirrors its sibling exactly.