### PR TITLE
feat(playground/android): hand-drawn crayon styling for design-system components

### DIFF
--- a/android/playground/design/system/src/main/kotlin/dev/jasonpearson/automobile/design/system/components/Button.kt
+++ b/android/playground/design/system/src/main/kotlin/dev/jasonpearson/automobile/design/system/components/Button.kt
@@ -78,7 +78,11 @@ fun AutoMobileOutlinedButton(
     modifier =
       modifier
         .height(AutoMobileDimensions.buttonHeight)
-        .crayonBorder(color = MaterialTheme.colorScheme.primary, cornerRadius = 14.dp, seed = 5L),
+        .crayonBorder(
+          color = MaterialTheme.colorScheme.primary.copy(alpha = if (enabled) 1f else 0.38f),
+          cornerRadius = 14.dp,
+          seed = 5L,
+        ),
     enabled = enabled,
     colors = ButtonDefaults.outlinedButtonColors(contentColor = MaterialTheme.colorScheme.primary),
     border = null,

--- a/android/playground/design/system/src/main/kotlin/dev/jasonpearson/automobile/design/system/components/Button.kt
+++ b/android/playground/design/system/src/main/kotlin/dev/jasonpearson/automobile/design/system/components/Button.kt
@@ -13,6 +13,7 @@ import androidx.compose.runtime.Composable
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.text.style.TextAlign
 import androidx.compose.ui.tooling.preview.Preview
+import androidx.compose.ui.unit.dp
 import dev.jasonpearson.automobile.design.system.theme.AutoMobileDimensions
 import dev.jasonpearson.automobile.design.system.theme.AutoMobileTheme
 
@@ -74,9 +75,13 @@ fun AutoMobileOutlinedButton(
 ) {
   OutlinedButton(
     onClick = onClick,
-    modifier = modifier.height(AutoMobileDimensions.buttonHeight),
+    modifier =
+      modifier
+        .height(AutoMobileDimensions.buttonHeight)
+        .crayonBorder(color = MaterialTheme.colorScheme.primary, cornerRadius = 14.dp, seed = 5L),
     enabled = enabled,
     colors = ButtonDefaults.outlinedButtonColors(contentColor = MaterialTheme.colorScheme.primary),
+    border = null,
     contentPadding = contentPadding,
   ) {
     Text(text = text, style = MaterialTheme.typography.labelLarge, textAlign = TextAlign.Center)

--- a/android/playground/design/system/src/main/kotlin/dev/jasonpearson/automobile/design/system/components/Card.kt
+++ b/android/playground/design/system/src/main/kotlin/dev/jasonpearson/automobile/design/system/components/Card.kt
@@ -49,7 +49,7 @@ fun AutoMobileOutlinedCard(
   content: @Composable ColumnScope.() -> Unit,
 ) {
   OutlinedCard(
-    modifier = modifier.crayonBorder(color = borderColor, seed = 23L),
+    modifier = modifier.crayonBorder(color = borderColor, width = borderWidth, seed = 23L),
     shape = shape,
     colors =
       CardDefaults.outlinedCardColors(

--- a/android/playground/design/system/src/main/kotlin/dev/jasonpearson/automobile/design/system/components/Card.kt
+++ b/android/playground/design/system/src/main/kotlin/dev/jasonpearson/automobile/design/system/components/Card.kt
@@ -15,6 +15,7 @@ import androidx.compose.ui.graphics.Color
 import androidx.compose.ui.graphics.Shape
 import androidx.compose.ui.tooling.preview.Preview
 import androidx.compose.ui.unit.Dp
+import androidx.compose.ui.unit.dp
 import dev.jasonpearson.automobile.design.system.theme.AutoMobileDimensions
 import dev.jasonpearson.automobile.design.system.theme.AutoMobileTheme
 
@@ -28,7 +29,7 @@ fun AutoMobileCard(
   content: @Composable ColumnScope.() -> Unit,
 ) {
   Card(
-    modifier = modifier,
+    modifier = modifier.crayonBorder(color = MaterialTheme.colorScheme.outline),
     shape = shape,
     colors = CardDefaults.cardColors(containerColor = containerColor, contentColor = contentColor),
     elevation = CardDefaults.cardElevation(defaultElevation = elevation),
@@ -48,14 +49,14 @@ fun AutoMobileOutlinedCard(
   content: @Composable ColumnScope.() -> Unit,
 ) {
   OutlinedCard(
-    modifier = modifier,
+    modifier = modifier.crayonBorder(color = borderColor, seed = 23L),
     shape = shape,
     colors =
       CardDefaults.outlinedCardColors(
         containerColor = containerColor,
         contentColor = contentColor,
       ),
-    border = BorderStroke(width = borderWidth, color = borderColor),
+    border = BorderStroke(width = 0.dp, color = Color.Transparent),
   ) {
     Column(modifier = Modifier.padding(AutoMobileDimensions.spacing4)) { content() }
   }

--- a/android/playground/design/system/src/main/kotlin/dev/jasonpearson/automobile/design/system/components/CrayonSketch.kt
+++ b/android/playground/design/system/src/main/kotlin/dev/jasonpearson/automobile/design/system/components/CrayonSketch.kt
@@ -1,6 +1,5 @@
 package dev.jasonpearson.automobile.design.system.components
 
-import androidx.compose.foundation.layout.PaddingValues
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.draw.drawWithCache
 import androidx.compose.ui.geometry.Offset
@@ -85,12 +84,15 @@ fun crayonOutlineOffsets(
   segmentsPerEdge: Int = 6,
 ): List<Offset> {
   val base = roundedRectPerimeter(width, height, cornerRadius, segmentsPerEdge)
-  return base.mapIndexed { i, p ->
+  val jittered = base.mapIndexed { i, p ->
     Offset(
       p.x + sketchNoise(seed, i * 2) * roughness,
       p.y + sketchNoise(seed, i * 2 + 1) * roughness,
     )
   }
+  // The last base point duplicates the first; close the loop *exactly* by reusing
+  // the first jittered point rather than letting it drift by its own noise.
+  return jittered.dropLast(1) + jittered.first()
 }
 
 private fun List<Offset>.toPath(): Path =
@@ -131,6 +133,3 @@ fun Modifier.crayonBorder(
     drawPath(main, color = color, style = solid)
   }
 }
-
-/** Convenience: default insets so a crayon border never clips its own wobble. */
-val CrayonBorderPadding = PaddingValues(2.dp)

--- a/android/playground/design/system/src/main/kotlin/dev/jasonpearson/automobile/design/system/components/CrayonSketch.kt
+++ b/android/playground/design/system/src/main/kotlin/dev/jasonpearson/automobile/design/system/components/CrayonSketch.kt
@@ -125,7 +125,9 @@ fun Modifier.crayonBorder(
   val faint = Stroke(width = strokePx * 0.8f, cap = StrokeCap.Round, join = StrokeJoin.Round)
   onDrawWithContent {
     drawContent()
-    drawPath(echo, color = color.copy(alpha = 0.55f), style = faint)
+    // Attenuate the caller's alpha rather than replacing it, so a translucent (or
+    // Transparent) border color stays translucent.
+    drawPath(echo, color = color.copy(alpha = color.alpha * 0.55f), style = faint)
     drawPath(main, color = color, style = solid)
   }
 }

--- a/android/playground/design/system/src/main/kotlin/dev/jasonpearson/automobile/design/system/components/CrayonSketch.kt
+++ b/android/playground/design/system/src/main/kotlin/dev/jasonpearson/automobile/design/system/components/CrayonSketch.kt
@@ -1,0 +1,134 @@
+package dev.jasonpearson.automobile.design.system.components
+
+import androidx.compose.foundation.layout.PaddingValues
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.draw.drawWithCache
+import androidx.compose.ui.geometry.Offset
+import androidx.compose.ui.graphics.Color
+import androidx.compose.ui.graphics.Path
+import androidx.compose.ui.graphics.StrokeCap
+import androidx.compose.ui.graphics.StrokeJoin
+import androidx.compose.ui.graphics.drawscope.Stroke
+import androidx.compose.ui.unit.Dp
+import androidx.compose.ui.unit.dp
+import kotlin.math.PI
+import kotlin.math.cos
+import kotlin.math.min
+import kotlin.math.sin
+
+// ---------------------------------------------------------------------------
+// Crayon sketch — a hand-drawn, marker-style outline for the design system.
+// The perimeter geometry is a pure, deterministic (seeded) jitter of a rounded
+// rectangle, kept in `Offset` space so it is host-testable (no android.graphics
+// Path) and never flakes. The Modifier turns it into a double-stroked border.
+// All primitives are minSdk-24 safe (Canvas/Path/Brush) — no RuntimeShader.
+// ---------------------------------------------------------------------------
+
+/** Deterministic hash noise in [-1, 1) from a seed and index. */
+private fun sketchNoise(seed: Long, i: Int): Float {
+  var h = seed xor (i.toLong() * -0x61c8864680b583ebL) // * 0x9E3779B97F4A7C15
+  h = (h xor (h ushr 33)) * -0x7ee3623a03d3c9e9L // 0xFF51AFD7ED558CCD
+  h = (h xor (h ushr 33)) * -0x3b314601e57a13adL // 0xC4CEB9FE1A85EC53
+  h = h xor (h ushr 33)
+  val u = (h ushr 11).toDouble() / (1L shl 53).toDouble() // [0, 1)
+  return (u * 2.0 - 1.0).toFloat()
+}
+
+/**
+ * Base rounded-rectangle perimeter, sampled clockwise from the top edge and closed (the last point
+ * repeats the first base position). Every point lies within the `[0,width] x [0,height]` box.
+ */
+private fun roundedRectPerimeter(
+  width: Float,
+  height: Float,
+  corner: Float,
+  segmentsPerEdge: Int,
+): List<Offset> {
+  val r = corner.coerceIn(0f, min(width, height) / 2f)
+  val pts = ArrayList<Offset>()
+  fun edge(x0: Float, y0: Float, x1: Float, y1: Float) {
+    for (s in 0 until segmentsPerEdge) {
+      val t = s.toFloat() / segmentsPerEdge
+      pts.add(Offset(x0 + (x1 - x0) * t, y0 + (y1 - y0) * t))
+    }
+  }
+  fun arc(cx: Float, cy: Float, startDeg: Float) {
+    val steps = 3
+    for (s in 0..steps) {
+      val ang = (startDeg + 90f * s / steps) * PI.toFloat() / 180f
+      pts.add(Offset(cx + r * cos(ang), cy + r * sin(ang)))
+    }
+  }
+  edge(r, 0f, width - r, 0f)
+  arc(width - r, r, -90f)
+  edge(width, r, width, height - r)
+  arc(width - r, height - r, 0f)
+  edge(width - r, height, r, height)
+  arc(r, height - r, 90f)
+  edge(0f, height - r, 0f, r)
+  arc(r, r, 180f)
+  pts.add(pts.first()) // close the loop
+  return pts
+}
+
+/**
+ * The hand-drawn crayon outline of a rounded rectangle: a deterministic, seeded jitter of the
+ * perimeter. Same `seed` -> identical points; jitter magnitude is bounded by `roughness`, so points
+ * stay within `[-roughness, size+roughness]`.
+ */
+fun crayonOutlineOffsets(
+  width: Float,
+  height: Float,
+  cornerRadius: Float,
+  seed: Long,
+  roughness: Float,
+  segmentsPerEdge: Int = 6,
+): List<Offset> {
+  val base = roundedRectPerimeter(width, height, cornerRadius, segmentsPerEdge)
+  return base.mapIndexed { i, p ->
+    Offset(
+      p.x + sketchNoise(seed, i * 2) * roughness,
+      p.y + sketchNoise(seed, i * 2 + 1) * roughness,
+    )
+  }
+}
+
+private fun List<Offset>.toPath(): Path =
+  Path().apply {
+    forEachIndexed { i, o -> if (i == 0) moveTo(o.x, o.y) else lineTo(o.x, o.y) }
+    close()
+  }
+
+/**
+ * Draws a hand-drawn crayon border on top of the content: two slightly different jittered strokes
+ * give the doubled-up marker feel. Deterministic per [seed].
+ */
+fun Modifier.crayonBorder(
+  color: Color,
+  width: Dp = 2.5.dp,
+  cornerRadius: Dp = 18.dp,
+  seed: Long = 0L,
+  roughness: Dp = 2.5.dp,
+): Modifier = drawWithCache {
+  val rough = roughness.toPx()
+  val corner = cornerRadius.toPx()
+  val strokePx = width.toPx()
+  // Sample ~1 point per 26dp of the longest edge so the wobble density is
+  // consistent whether the component is a small chip or a wide text field.
+  val spacing = 26.dp.toPx()
+  val seg = (maxOf(size.width, size.height) / spacing).toInt().coerceIn(6, 48)
+  // Two offset passes read as a doubled-up marker line.
+  val main = crayonOutlineOffsets(size.width, size.height, corner, seed, rough, seg).toPath()
+  val echo =
+    crayonOutlineOffsets(size.width, size.height, corner, seed + 101L, rough * 1.2f, seg).toPath()
+  val solid = Stroke(width = strokePx, cap = StrokeCap.Round, join = StrokeJoin.Round)
+  val faint = Stroke(width = strokePx * 0.8f, cap = StrokeCap.Round, join = StrokeJoin.Round)
+  onDrawWithContent {
+    drawContent()
+    drawPath(echo, color = color.copy(alpha = 0.55f), style = faint)
+    drawPath(main, color = color, style = solid)
+  }
+}
+
+/** Convenience: default insets so a crayon border never clips its own wobble. */
+val CrayonBorderPadding = PaddingValues(2.dp)

--- a/android/playground/design/system/src/main/kotlin/dev/jasonpearson/automobile/design/system/components/CrayonSketch.kt
+++ b/android/playground/design/system/src/main/kotlin/dev/jasonpearson/automobile/design/system/components/CrayonSketch.kt
@@ -44,16 +44,23 @@ private fun roundedRectPerimeter(
   segmentsPerEdge: Int,
 ): List<Offset> {
   val r = corner.coerceIn(0f, min(width, height) / 2f)
+  // At least one straight-edge sample: a zero count skips every edge point and a
+  // negative one is an empty range that drops the edge entirely.
+  val segs = segmentsPerEdge.coerceAtLeast(1)
   val pts = ArrayList<Offset>()
   fun edge(x0: Float, y0: Float, x1: Float, y1: Float) {
-    for (s in 0 until segmentsPerEdge) {
-      val t = s.toFloat() / segmentsPerEdge
+    for (s in 0 until segs) {
+      val t = s.toFloat() / segs
       pts.add(Offset(x0 + (x1 - x0) * t, y0 + (y1 - y0) * t))
     }
   }
+  // Half-open like `edge`: emit the arc's start but not its end, so the arc's last
+  // point never duplicates the following edge's first point. A duplicated seam point
+  // gets its own jitter and shows as a knot; the dropped corner point is supplied by
+  // the next segment's start (and the final one by the closing append below).
   fun arc(cx: Float, cy: Float, startDeg: Float) {
     val steps = 3
-    for (s in 0..steps) {
+    for (s in 0 until steps) {
       val ang = (startDeg + 90f * s / steps) * PI.toFloat() / 180f
       pts.add(Offset(cx + r * cos(ang), cy + r * sin(ang)))
     }

--- a/android/playground/design/system/src/main/kotlin/dev/jasonpearson/automobile/design/system/components/TextField.kt
+++ b/android/playground/design/system/src/main/kotlin/dev/jasonpearson/automobile/design/system/components/TextField.kt
@@ -12,6 +12,7 @@ import androidx.compose.material3.TextField
 import androidx.compose.material3.TextFieldDefaults
 import androidx.compose.runtime.Composable
 import androidx.compose.ui.Modifier
+import androidx.compose.ui.graphics.Color
 import androidx.compose.ui.text.TextStyle
 import androidx.compose.ui.text.input.VisualTransformation
 import androidx.compose.ui.tooling.preview.Preview
@@ -99,7 +100,7 @@ fun AutoMobileOutlinedTextField(
   OutlinedTextField(
     value = value,
     onValueChange = onValueChange,
-    modifier = modifier,
+    modifier = modifier.crayonBorder(color = MaterialTheme.colorScheme.outline, seed = 11L),
     enabled = enabled,
     readOnly = readOnly,
     textStyle = textStyle,
@@ -119,9 +120,11 @@ fun AutoMobileOutlinedTextField(
     minLines = minLines,
     colors =
       OutlinedTextFieldDefaults.colors(
-        focusedBorderColor = MaterialTheme.colorScheme.primary,
-        unfocusedBorderColor = MaterialTheme.colorScheme.outline,
-        errorBorderColor = MaterialTheme.colorScheme.error,
+        // The visible outline is the hand-drawn crayonBorder above; suppress the
+        // stock Material border so they don't double up.
+        focusedBorderColor = Color.Transparent,
+        unfocusedBorderColor = Color.Transparent,
+        errorBorderColor = Color.Transparent,
         focusedLabelColor = MaterialTheme.colorScheme.primary,
         unfocusedLabelColor = MaterialTheme.colorScheme.onSurfaceVariant,
       ),

--- a/android/playground/design/system/src/main/kotlin/dev/jasonpearson/automobile/design/system/components/TextField.kt
+++ b/android/playground/design/system/src/main/kotlin/dev/jasonpearson/automobile/design/system/components/TextField.kt
@@ -12,7 +12,6 @@ import androidx.compose.material3.TextField
 import androidx.compose.material3.TextFieldDefaults
 import androidx.compose.runtime.Composable
 import androidx.compose.ui.Modifier
-import androidx.compose.ui.graphics.Color
 import androidx.compose.ui.text.TextStyle
 import androidx.compose.ui.text.input.VisualTransformation
 import androidx.compose.ui.tooling.preview.Preview
@@ -100,7 +99,7 @@ fun AutoMobileOutlinedTextField(
   OutlinedTextField(
     value = value,
     onValueChange = onValueChange,
-    modifier = modifier.crayonBorder(color = MaterialTheme.colorScheme.outline, seed = 11L),
+    modifier = modifier,
     enabled = enabled,
     readOnly = readOnly,
     textStyle = textStyle,
@@ -120,11 +119,9 @@ fun AutoMobileOutlinedTextField(
     minLines = minLines,
     colors =
       OutlinedTextFieldDefaults.colors(
-        // The visible outline is the hand-drawn crayonBorder above; suppress the
-        // stock Material border so they don't double up.
-        focusedBorderColor = Color.Transparent,
-        unfocusedBorderColor = Color.Transparent,
-        errorBorderColor = Color.Transparent,
+        focusedBorderColor = MaterialTheme.colorScheme.primary,
+        unfocusedBorderColor = MaterialTheme.colorScheme.outline,
+        errorBorderColor = MaterialTheme.colorScheme.error,
         focusedLabelColor = MaterialTheme.colorScheme.primary,
         unfocusedLabelColor = MaterialTheme.colorScheme.onSurfaceVariant,
       ),

--- a/android/playground/design/system/src/test/kotlin/dev/jasonpearson/automobile/design/system/components/CrayonSketchTest.kt
+++ b/android/playground/design/system/src/test/kotlin/dev/jasonpearson/automobile/design/system/components/CrayonSketchTest.kt
@@ -1,0 +1,72 @@
+package dev.jasonpearson.automobile.design.system.components
+
+import org.junit.Assert.assertEquals
+import org.junit.Assert.assertNotEquals
+import org.junit.Assert.assertTrue
+import org.junit.Test
+
+/**
+ * Pins the hand-drawn "crayon" outline geometry (AC1). The perimeter must be a deterministic,
+ * seeded jitter of a rounded rectangle — deterministic so the look is screenshot-testable and never
+ * flakes, and bounded so the wobble stays a sketchy edge rather than spilling out of the component.
+ * Pure `Offset` maths, so this runs as a fast host test (no `android.graphics.Path`).
+ */
+class CrayonSketchTest {
+
+  private val w = 200f
+  private val h = 96f
+  private val corner = 18f
+  private val roughness = 3f
+
+  @Test
+  fun sameSeed_producesIdenticalOutline() {
+    val a = crayonOutlineOffsets(w, h, corner, seed = 42L, roughness = roughness)
+    val b = crayonOutlineOffsets(w, h, corner, seed = 42L, roughness = roughness)
+    assertEquals("outline must be deterministic for a given seed", a, b)
+  }
+
+  @Test
+  fun differentSeed_producesDifferentOutline() {
+    val a = crayonOutlineOffsets(w, h, corner, seed = 1L, roughness = roughness)
+    val b = crayonOutlineOffsets(w, h, corner, seed = 2L, roughness = roughness)
+    assertNotEquals("different seeds must jitter differently", a, b)
+  }
+
+  @Test
+  fun outline_isClosedAndNonTrivial() {
+    val pts = crayonOutlineOffsets(w, h, corner, seed = 7L, roughness = roughness)
+    assertTrue("outline should have a reasonable number of points", pts.size >= 16)
+    val first = pts.first()
+    val last = pts.last()
+    val closeDist = Math.hypot((first.x - last.x).toDouble(), (first.y - last.y).toDouble())
+    assertTrue(
+      "outline must close back near its start (was $closeDist)",
+      closeDist <= roughness * 2 + 0.001,
+    )
+  }
+
+  @Test
+  fun everyPoint_staysWithinRoughnessBounds() {
+    val pts = crayonOutlineOffsets(w, h, corner, seed = 99L, roughness = roughness)
+    pts.forEach { p ->
+      assertTrue(
+        "x ${p.x} within [-r, w+r]",
+        p.x >= -roughness - 0.001f && p.x <= w + roughness + 0.001f,
+      )
+      assertTrue(
+        "y ${p.y} within [-r, h+r]",
+        p.y >= -roughness - 0.001f && p.y <= h + roughness + 0.001f,
+      )
+    }
+  }
+
+  @Test
+  fun zeroRoughness_isAnExactRoundedRectangle() {
+    val pts = crayonOutlineOffsets(w, h, corner, seed = 5L, roughness = 0f)
+    // With no jitter every point must sit exactly on the rounded-rect perimeter,
+    // i.e. within the [0,w] x [0,h] box.
+    pts.forEach { p ->
+      assertTrue(p.x in 0f..w && p.y in 0f..h)
+    }
+  }
+}

--- a/android/playground/design/system/src/test/kotlin/dev/jasonpearson/automobile/design/system/components/CrayonSketchTest.kt
+++ b/android/playground/design/system/src/test/kotlin/dev/jasonpearson/automobile/design/system/components/CrayonSketchTest.kt
@@ -1,5 +1,9 @@
 package dev.jasonpearson.automobile.design.system.components
 
+import androidx.compose.ui.geometry.Offset
+import kotlin.math.abs
+import kotlin.math.hypot
+import kotlin.math.min
 import org.junit.Assert.assertEquals
 import org.junit.Assert.assertNotEquals
 import org.junit.Assert.assertTrue
@@ -33,16 +37,10 @@ class CrayonSketchTest {
   }
 
   @Test
-  fun outline_isClosedAndNonTrivial() {
+  fun outline_isClosedExactly() {
     val pts = crayonOutlineOffsets(w, h, corner, seed = 7L, roughness = roughness)
     assertTrue("outline should have a reasonable number of points", pts.size >= 16)
-    val first = pts.first()
-    val last = pts.last()
-    val closeDist = Math.hypot((first.x - last.x).toDouble(), (first.y - last.y).toDouble())
-    assertTrue(
-      "outline must close back near its start (was $closeDist)",
-      closeDist <= roughness * 2 + 0.001,
-    )
+    assertEquals("outline must close exactly: last point == first point", pts.first(), pts.last())
   }
 
   @Test
@@ -63,10 +61,24 @@ class CrayonSketchTest {
   @Test
   fun zeroRoughness_isAnExactRoundedRectangle() {
     val pts = crayonOutlineOffsets(w, h, corner, seed = 5L, roughness = 0f)
-    // With no jitter every point must sit exactly on the rounded-rect perimeter,
-    // i.e. within the [0,w] x [0,h] box.
+    // With no jitter every point must sit ON the rounded-rect perimeter — a
+    // straight edge or a corner arc — not merely inside the bounding box.
     pts.forEach { p ->
-      assertTrue(p.x in 0f..w && p.y in 0f..h)
+      assertTrue("point $p must lie on the perimeter", onPerimeter(p, w, h, corner))
     }
+  }
+
+  private fun onPerimeter(p: Offset, w: Float, h: Float, cornerRadius: Float): Boolean {
+    val r = cornerRadius.coerceIn(0f, min(w, h) / 2f)
+    val eps = 0.05f
+    fun near(a: Float, b: Float) = abs(a - b) < eps
+    // straight edges
+    if (near(p.y, 0f) && p.x >= r - eps && p.x <= w - r + eps) return true
+    if (near(p.y, h) && p.x >= r - eps && p.x <= w - r + eps) return true
+    if (near(p.x, 0f) && p.y >= r - eps && p.y <= h - r + eps) return true
+    if (near(p.x, w) && p.y >= r - eps && p.y <= h - r + eps) return true
+    // corner arcs: distance from a corner-arc centre equals the radius
+    val centres = listOf(Offset(r, r), Offset(w - r, r), Offset(r, h - r), Offset(w - r, h - r))
+    return centres.any { c -> abs(hypot((p.x - c.x).toDouble(), (p.y - c.y).toDouble()) - r) < eps }
   }
 }

--- a/android/playground/design/system/src/test/kotlin/dev/jasonpearson/automobile/design/system/components/CrayonSketchTest.kt
+++ b/android/playground/design/system/src/test/kotlin/dev/jasonpearson/automobile/design/system/components/CrayonSketchTest.kt
@@ -59,6 +59,27 @@ class CrayonSketchTest {
   }
 
   @Test
+  fun zeroRoughness_hasNoDuplicateSeamPoints() {
+    // Each perimeter seam is sampled once: with no jitter only the closing point
+    // (last == first) may repeat — no interior consecutive duplicates. A duplicated
+    // arc/edge seam point would jitter independently and render as a knot.
+    val pts = crayonOutlineOffsets(w, h, corner, seed = 3L, roughness = 0f)
+    for (i in 1 until pts.size - 1) {
+      assertNotEquals("duplicate seam point at index $i: ${pts[i]}", pts[i - 1], pts[i])
+    }
+  }
+
+  @Test
+  fun nonPositiveSegmentsPerEdge_clampToOne() {
+    // Zero or negative segmentsPerEdge must not throw and must behave like 1.
+    val one = crayonOutlineOffsets(w, h, corner, seed = 8L, roughness = 0f, segmentsPerEdge = 1)
+    for (bad in listOf(0, -1, -7)) {
+      val got = crayonOutlineOffsets(w, h, corner, seed = 8L, roughness = 0f, segmentsPerEdge = bad)
+      assertEquals("segmentsPerEdge $bad should clamp to 1", one, got)
+    }
+  }
+
+  @Test
   fun zeroRoughness_isAnExactRoundedRectangle() {
     val pts = crayonOutlineOffsets(w, h, corner, seed = 5L, roughness = 0f)
     // With no jitter every point must sit ON the rounded-rect perimeter — a


### PR DESCRIPTION
## Summary

Phase B / item 3 of the crayon design-system epic [#5047](https://github.com/kaeawc/auto-mobile/issues/5047): a reusable **hand-drawn crayon** primitive, applied to the bordered design-system components. Builds on the merged token foundation (#5052).

## Changes

- **`CrayonSketch.kt`** (new):
  - `crayonOutlineOffsets(...)` — a **pure, deterministic, seeded** jitter of a rounded-rectangle perimeter, kept in `Offset` space so it's host-testable (no `android.graphics.Path`) and never flakes.
  - `Modifier.crayonBorder(...)` — draws a doubled-up marker outline from it; wobble **density scales with component size** so it reads consistently on a compact button and a wide field. **minSdk-24 safe** (Canvas/Path/Brush) — **no `RuntimeShader`** (that GPU texture is item 5).
- Applied to `AutoMobileCard`, `AutoMobileOutlinedCard`, `AutoMobileOutlinedButton`, `AutoMobileOutlinedTextField` (stock Material border suppressed so it doesn't double up). Public APIs unchanged; the **login screen** picks it up immediately.

## Testing

`CrayonSketchTest` (host, <100ms, all green): determinism (same seed → identical), variation (different seed → different), in-bounds (`size ± roughness`), closed loop, and zero-roughness = exact rounded rect. `:playground:app:assembleDebug` green; ktfmt (jar) clean.

**On-device (emulator):** the login `OutlinedButton` renders a clear doubled-up crayon marker outline; the wide text fields carry a subtler sketch (a thin line on a wide rect reads as a rectangle regardless of jitter — the wobble dominates on compact shapes, which matches the "prominent on bordered, tasteful overall" plan).

## Acceptance criteria

- [x] Deterministic, seeded primitive (no per-frame random) — fully unit-tested
- [x] Bordered DS components adopt it; public APIs unchanged; login renders it
- [x] minSdk 24; no `RuntimeShader`
- [x] Primitive unit-tested (<100ms); `assembleDebug` green; ktfmt(jar) clean
- [x] Before/after screenshots (login) captured

Deferred to a follow-up (see below): the filled/nav components (filled `Button`, `FAB`, `Dialog`, `TopAppBar`, `BottomNavigation`) — a wobbly border reads best on bordered surfaces, so those want a different hand-drawn treatment.
