### PR TITLE
chore(dx): self-heal node_modules in fresh worktrees before local validation

### DIFF
--- a/scripts/all_fast_validate_checks.sh
+++ b/scripts/all_fast_validate_checks.sh
@@ -224,11 +224,6 @@ if [[ -n "${skip_list[*]-}" ]]; then
   done
 fi
 
-# A fresh git worktree has no node_modules; install before running any check so
-# the suite self-heals instead of failing with "turbo: command not found"
-# (issue #5051). No-op once deps are present, so CI is unaffected.
-ensure_node_modules "$PROJECT_ROOT"
-
 selected_indices=()
 for idx in "${!CHECK_NAMES[@]}"; do
   name="${CHECK_NAMES[$idx]}"
@@ -275,6 +270,14 @@ if ! [[ "$max_parallel" =~ ^[0-9]+$ ]]; then
   echo "--max-parallel must be a positive integer." >&2
   exit 1
 fi
+
+# All CLI options are validated and at least one check is selected. Only now do we
+# self-heal deps: a fresh git worktree has no node_modules, so any check would
+# fail with "turbo: command not found" (issue #5051). Placing this after
+# validation keeps a malformed invocation fail-fast and side-effect-free (it
+# errors without running an install). No-op once deps are present, so CI is
+# unaffected.
+ensure_node_modules "$PROJECT_ROOT"
 
 if [[ "$max_parallel" -lt 1 ]]; then
   echo "--max-parallel must be greater than 0." >&2

--- a/scripts/all_fast_validate_checks.sh
+++ b/scripts/all_fast_validate_checks.sh
@@ -18,7 +18,7 @@ set -euo pipefail
 SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
 PROJECT_ROOT="$(cd "$SCRIPT_DIR/.." && pwd)"
 
-# shellcheck source=scripts/lib/shell-core.sh
+# shellcheck source=scripts/lib/shell-core.sh disable=SC1091
 source "$SCRIPT_DIR/lib/shell-core.sh"
 
 CHECK_NAMES=()

--- a/scripts/all_fast_validate_checks.sh
+++ b/scripts/all_fast_validate_checks.sh
@@ -18,6 +18,9 @@ set -euo pipefail
 SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
 PROJECT_ROOT="$(cd "$SCRIPT_DIR/.." && pwd)"
 
+# shellcheck source=scripts/lib/shell-core.sh
+source "$SCRIPT_DIR/lib/shell-core.sh"
+
 CHECK_NAMES=()
 CHECK_COMMANDS=()
 CHECK_GROUPS=()
@@ -220,6 +223,11 @@ if [[ -n "${skip_list[*]-}" ]]; then
     fi
   done
 fi
+
+# A fresh git worktree has no node_modules; install before running any check so
+# the suite self-heals instead of failing with "turbo: command not found"
+# (issue #5051). No-op once deps are present, so CI is unaffected.
+ensure_node_modules "$PROJECT_ROOT"
 
 selected_indices=()
 for idx in "${!CHECK_NAMES[@]}"; do

--- a/scripts/codex/bootstrap-worktree.sh
+++ b/scripts/codex/bootstrap-worktree.sh
@@ -14,11 +14,8 @@ PROJECT_ROOT="$(cd "${SCRIPT_DIR}/../.." && pwd)"
 cd "${PROJECT_ROOT}"
 mkdir -p scratch
 
-if [[ ! -d node_modules || ! -x node_modules/.bin/turbo ]]; then
-  echo "Installing Bun dependencies from bun.lock..."
-  bun install --frozen-lockfile
-else
-  echo "Bun dependencies already installed."
-fi
+# shellcheck source=scripts/lib/shell-core.sh
+source "${PROJECT_ROOT}/scripts/lib/shell-core.sh"
+ensure_node_modules "${PROJECT_ROOT}"
 
 echo "Worktree bootstrap complete."

--- a/scripts/codex/bootstrap-worktree.sh
+++ b/scripts/codex/bootstrap-worktree.sh
@@ -14,7 +14,7 @@ PROJECT_ROOT="$(cd "${SCRIPT_DIR}/../.." && pwd)"
 cd "${PROJECT_ROOT}"
 mkdir -p scratch
 
-# shellcheck source=scripts/lib/shell-core.sh
+# shellcheck source=scripts/lib/shell-core.sh disable=SC1091
 source "${PROJECT_ROOT}/scripts/lib/shell-core.sh"
 ensure_node_modules "${PROJECT_ROOT}"
 

--- a/scripts/lib/shell-core.sh
+++ b/scripts/lib/shell-core.sh
@@ -25,3 +25,20 @@ detect_arch() {
     *) printf '%s\n' "unknown" ;;
   esac
 }
+
+# Ensure Bun dependencies are installed under <root> (default: current dir).
+# No-op when node_modules/.bin/turbo already exists; otherwise installs from the
+# committed lockfile. A fresh `git worktree` starts without node_modules (the
+# gitignored dir is not copied), so validation entry points call this to
+# self-heal instead of failing with a cryptic "turbo: command not found" (issue
+# #5051). It installs only when deps are absent, so it is a no-op in CI where
+# they are always present. The install runs in a subshell so the caller's
+# working directory is left unchanged.
+ensure_node_modules() {
+  local root="${1:-$PWD}"
+  if [ -x "$root/node_modules/.bin/turbo" ]; then
+    return 0
+  fi
+  echo "node_modules missing in ${root} — installing Bun dependencies from bun.lock..."
+  ( cd "$root" && bun install --frozen-lockfile )
+}

--- a/test/bats/ensure-node-modules.bats
+++ b/test/bats/ensure-node-modules.bats
@@ -1,0 +1,56 @@
+#!/usr/bin/env bats
+#
+# Pins ensure_node_modules() in scripts/lib/shell-core.sh (issue #5051): it must
+# no-op when node_modules/.bin/turbo already exists, and run
+# `bun install --frozen-lockfile` when it doesn't. `bun` is mocked on PATH so no
+# real install runs.
+
+LIB="scripts/lib/shell-core.sh"
+
+@test "ensure_node_modules is a no-op when node_modules/.bin/turbo exists" {
+  local root bindir
+  root="$(mktemp -d)"
+  mkdir -p "$root/node_modules/.bin"
+  : > "$root/node_modules/.bin/turbo"
+  chmod +x "$root/node_modules/.bin/turbo"
+  # A bun that fails loudly if called — the no-op path must not invoke it.
+  bindir="$(mktemp -d)"
+  printf '#!/usr/bin/env bash\necho CALLED_BUN\nexit 3\n' > "$bindir/bun"
+  chmod +x "$bindir/bun"
+
+  run env PATH="$bindir:$PATH" bash -c "source '$LIB'; ensure_node_modules '$root'"
+  rm -rf "$root" "$bindir"
+
+  [ "$status" -eq 0 ]
+  [[ "$output" != *"CALLED_BUN"* ]]
+}
+
+@test "ensure_node_modules installs with --frozen-lockfile when turbo is absent" {
+  local root bindir
+  root="$(mktemp -d)"   # no node_modules
+  bindir="$(mktemp -d)"
+  # A bun that echoes its args so we can assert the exact install invocation.
+  printf '#!/usr/bin/env bash\necho "bun $*"\n' > "$bindir/bun"
+  chmod +x "$bindir/bun"
+
+  run env PATH="$bindir:$PATH" bash -c "source '$LIB'; ensure_node_modules '$root'"
+  rm -rf "$root" "$bindir"
+
+  [ "$status" -eq 0 ]
+  [[ "$output" == *"bun install --frozen-lockfile"* ]]
+}
+
+@test "ensure_node_modules leaves the caller's working directory unchanged" {
+  local root bindir start
+  root="$(mktemp -d)"
+  bindir="$(mktemp -d)"
+  printf '#!/usr/bin/env bash\ntrue\n' > "$bindir/bun"
+  chmod +x "$bindir/bun"
+  start="$PWD"
+
+  run env PATH="$bindir:$PATH" bash -c "source '$LIB'; ensure_node_modules '$root'; pwd"
+  rm -rf "$root" "$bindir"
+
+  [ "$status" -eq 0 ]
+  [[ "$output" == *"$start"* ]]
+}

--- a/test/bats/ensure-node-modules.bats
+++ b/test/bats/ensure-node-modules.bats
@@ -25,12 +25,13 @@ LIB="scripts/lib/shell-core.sh"
   [[ "$output" != *"CALLED_BUN"* ]]
 }
 
-@test "ensure_node_modules installs with --frozen-lockfile when turbo is absent" {
+@test "ensure_node_modules installs with --frozen-lockfile in root when turbo is absent" {
   local root bindir
-  root="$(mktemp -d)"   # no node_modules
+  root="$(cd "$(mktemp -d)" && pwd)"   # no node_modules; canonicalized (macOS /var -> /private)
   bindir="$(mktemp -d)"
-  # A bun that echoes its args so we can assert the exact install invocation.
-  printf '#!/usr/bin/env bash\necho "bun $*"\n' > "$bindir/bun"
+  # A bun that echoes its CWD and args, so we assert both the exact install
+  # invocation AND that it runs in root (removing the `cd "$root"` must fail this).
+  printf '#!/usr/bin/env bash\necho "bun_cwd=$PWD"\necho "bun $*"\n' > "$bindir/bun"
   chmod +x "$bindir/bun"
 
   run env PATH="$bindir:$PATH" bash -c "source '$LIB'; ensure_node_modules '$root'"
@@ -38,6 +39,7 @@ LIB="scripts/lib/shell-core.sh"
 
   [ "$status" -eq 0 ]
   [[ "$output" == *"bun install --frozen-lockfile"* ]]
+  [[ "$output" == *"bun_cwd=$root"* ]]
 }
 
 @test "ensure_node_modules leaves the caller's working directory unchanged" {


### PR DESCRIPTION
## Summary

Makes local validation self-heal in fresh `git worktree`s, which start without
`node_modules` (the gitignored dir isn't copied). Previously
`scripts/all_fast_validate_checks.sh` — the pre-push entry the PR template points
at — failed cryptically (`turbo: command not found`) until you remembered to run
`bun run bootstrap:worktree` by hand.

Adds an `ensure_node_modules` helper to the existing `scripts/lib/shell-core.sh`:
no-op when `node_modules/.bin/turbo` is present, otherwise `bun install
--frozen-lockfile` (in a subshell, so the caller's CWD is untouched). It installs
only when deps are absent, so it's a **no-op in CI**. Wired into the validate
entry point, and `bootstrap-worktree.sh` now reuses it instead of duplicating the
check.

## Linked Issue

Closes #5051

## Changes

- `scripts/lib/shell-core.sh` — new `ensure_node_modules [root]` helper.
- `scripts/all_fast_validate_checks.sh` — source the lib; call
  `ensure_node_modules "$PROJECT_ROOT"` after `--list`/`--only`/`--skip` handling
  so those early-exits don't trigger installs.
- `scripts/codex/bootstrap-worktree.sh` — reuse the shared helper (removed the
  duplicated inline check).
- `test/bats/ensure-node-modules.bats` — pins both branches (present → `bun` not
  called; absent → `bun install --frozen-lockfile`) plus CWD-preservation,
  mocking `bun`.

## Validation

- [x] `bats test/bats/ensure-node-modules.bats` — 3/3
- [x] `shellcheck` clean on all three scripts
- [x] `--list` still short-circuits without installing
- [x] `turbo run lint build test` green; `bun run typecheck` no new errors
- [x] No-op in CI (deps present) — only installs in a fresh worktree

## Out of scope

- A shared/symlinked `node_modules` across worktrees (breaks per-worktree
  divergence).
- A `git`/`jj` post-checkout hook (unreliable across `worktree add` and jj).
