### PR TITLE
fix(dx): reject --max-parallel 0 before self-healing deps

### DIFF
--- a/scripts/all_fast_validate_checks.sh
+++ b/scripts/all_fast_validate_checks.sh
@@ -271,14 +271,6 @@ if ! [[ "$max_parallel" =~ ^[0-9]+$ ]]; then
   exit 1
 fi
 
-# All CLI options are validated and at least one check is selected. Only now do we
-# self-heal deps: a fresh git worktree has no node_modules, so any check would
-# fail with "turbo: command not found" (issue #5051). Placing this after
-# validation keeps a malformed invocation fail-fast and side-effect-free (it
-# errors without running an install). No-op once deps are present, so CI is
-# unaffected.
-ensure_node_modules "$PROJECT_ROOT"
-
 if [[ "$max_parallel" -lt 1 ]]; then
   echo "--max-parallel must be greater than 0." >&2
   exit 1
@@ -287,6 +279,14 @@ fi
 if [[ "$parallel_enabled" -eq 0 ]]; then
   max_parallel=1
 fi
+
+# Every CLI option is now validated and at least one check is selected. Only now
+# self-heal deps: a fresh git worktree has no node_modules, so any check would
+# fail with "turbo: command not found" (issue #5051). Running this after all
+# validation keeps a malformed invocation (bad --only/--skip/--group, or a
+# non-numeric / < 1 --max-parallel) fail-fast and side-effect-free. No-op once
+# deps are present, so CI is unaffected.
+ensure_node_modules "$PROJECT_ROOT"
 
 mkdir -p "$PROJECT_ROOT/scratch"
 run_id="$(date +%Y%m%dT%H%M%S)"


### PR DESCRIPTION
## Summary

Follow-up to #5117 addressing a CodeRabbit review point that landed after that PR
auto-merged. `--max-parallel 0` passes the numeric `^[0-9]+$` regex but is
rejected by the later `-lt 1` positivity check — which sat *after*
`ensure_node_modules`. So in a fresh worktree, `--max-parallel 0` (or a bad
`--group`) would run `bun install --frozen-lockfile` before reporting the CLI
error.

Moves the `ensure_node_modules` call past **all** validation (numeric regex,
`< 1`, and the `parallel_enabled` adjustment), right before real work begins, so
every malformed invocation stays fail-fast and side-effect-free.

## Linked Issue

Follow-up to #5117 (issue #5051).

## Validation

- [x] `shellcheck scripts/all_fast_validate_checks.sh` (per-file, CI-style) — clean
- [x] `--only shellcheck,shell-portability,shell-sete` — 3/3 pass
- [x] `--max-parallel 0` → "must be greater than 0" (exit 1, no install)
- [x] `--max-parallel nope` → "must be a positive integer" (exit 1, no install)
- [x] Valid invocations unchanged; self-heal still fires after validation
