### PR TITLE
feat(playground/ios): hand-drawn crayon outline primitive (#5116)

### DIFF
--- a/ios/Playground/Playground.xcodeproj/project.pbxproj
+++ b/ios/Playground/Playground.xcodeproj/project.pbxproj
@@ -10,12 +10,14 @@
 		007B2120C2735B42A20C510B /* Theme.swift in Sources */ = {isa = PBXBuildFile; fileRef = C2F4747AC5700DF138836D5F /* Theme.swift */; };
 		15B37A3EDBAFD6BD0FC98BFC /* DemosTab.swift in Sources */ = {isa = PBXBuildFile; fileRef = 25213AE8A9FD9A5B1EEFD97F /* DemosTab.swift */; };
 		327A28D4620038BBA8D02656 /* Shapes.swift in Sources */ = {isa = PBXBuildFile; fileRef = 5122FF517804CD75B0F75CBA /* Shapes.swift */; };
+		4546703D0511A96D6060F587 /* CrayonSketch.swift in Sources */ = {isa = PBXBuildFile; fileRef = C0972F015B9B7D85BD6F3270 /* CrayonSketch.swift */; };
 		5339DAC5909A688059ABBA80 /* ContentView.swift in Sources */ = {isa = PBXBuildFile; fileRef = D01BCE22E951887741F32904 /* ContentView.swift */; };
 		54C16E199D10E281E1E316CF /* SettingsTab.swift in Sources */ = {isa = PBXBuildFile; fileRef = 64FD18EC8D1B9A665615C374 /* SettingsTab.swift */; };
 		553F94B4D033BCA44B07AC4E /* PlaygroundApp.swift in Sources */ = {isa = PBXBuildFile; fileRef = C6EA6F80147865B6F32DD526 /* PlaygroundApp.swift */; };
 		619CDEE3F264DBB3415041D0 /* ShantellSans.ttf in Resources */ = {isa = PBXBuildFile; fileRef = E1B25FBAC5217DE05EA701CF /* ShantellSans.ttf */; };
 		72CDA6DB361FDC97490C3C2C /* AutoMobileSDK in Frameworks */ = {isa = PBXBuildFile; productRef = 3137B15D8D485C363DB78A3E /* AutoMobileSDK */; };
 		7C8CF515031B975C05FA2AD2 /* PlaygroundThemeTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = FBFA8ECD2DC59DBF8A6FBBF3 /* PlaygroundThemeTests.swift */; };
+		95CF2D08679D32C4A9966ACD /* CrayonSketchTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 11B156E0FBE749405E1F2D0D /* CrayonSketchTests.swift */; };
 		97CA6F2DE628A139094EF72D /* Colors.swift in Sources */ = {isa = PBXBuildFile; fileRef = 2B46870C2DDF4A2F73A5778B /* Colors.swift */; };
 		B3B613858665E331B7E7EB99 /* SdkHighlightOverlayE2ETests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 8A719AFBA1888450E8653AB6 /* SdkHighlightOverlayE2ETests.swift */; };
 		B73660170723595B44749E9F /* Typography.swift in Sources */ = {isa = PBXBuildFile; fileRef = 51580F5FC5ADCD5576885563 /* Typography.swift */; };
@@ -37,6 +39,7 @@
 
 /* Begin PBXFileReference section */
 		0C5B41C44C18F0045A6B61C2 /* Release.xcconfig */ = {isa = PBXFileReference; lastKnownFileType = text.xcconfig; path = Release.xcconfig; sourceTree = "<group>"; };
+		11B156E0FBE749405E1F2D0D /* CrayonSketchTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CrayonSketchTests.swift; sourceTree = "<group>"; };
 		25213AE8A9FD9A5B1EEFD97F /* DemosTab.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = DemosTab.swift; sourceTree = "<group>"; };
 		2B46870C2DDF4A2F73A5778B /* Colors.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = Colors.swift; sourceTree = "<group>"; };
 		5122FF517804CD75B0F75CBA /* Shapes.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = Shapes.swift; sourceTree = "<group>"; };
@@ -45,6 +48,7 @@
 		8A719AFBA1888450E8653AB6 /* SdkHighlightOverlayE2ETests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SdkHighlightOverlayE2ETests.swift; sourceTree = "<group>"; };
 		AA0EB8290A6E5436B2C8CE6F /* auto-mobile-sdk */ = {isa = PBXFileReference; lastKnownFileType = folder; name = "auto-mobile-sdk"; path = "../auto-mobile-sdk"; sourceTree = SOURCE_ROOT; };
 		BDA9169E926B14087F3B1BA2 /* Info.plist */ = {isa = PBXFileReference; lastKnownFileType = text.plist; path = Info.plist; sourceTree = "<group>"; };
+		C0972F015B9B7D85BD6F3270 /* CrayonSketch.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CrayonSketch.swift; sourceTree = "<group>"; };
 		C2F4747AC5700DF138836D5F /* Theme.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = Theme.swift; sourceTree = "<group>"; };
 		C6D8C10EFC976E6B3CCD16BD /* Debug.xcconfig */ = {isa = PBXFileReference; lastKnownFileType = text.xcconfig; path = Debug.xcconfig; sourceTree = "<group>"; };
 		C6EA6F80147865B6F32DD526 /* PlaygroundApp.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = PlaygroundApp.swift; sourceTree = "<group>"; };
@@ -91,6 +95,7 @@
 			isa = PBXGroup;
 			children = (
 				2B46870C2DDF4A2F73A5778B /* Colors.swift */,
+				C0972F015B9B7D85BD6F3270 /* CrayonSketch.swift */,
 				5122FF517804CD75B0F75CBA /* Shapes.swift */,
 				C2F4747AC5700DF138836D5F /* Theme.swift */,
 				51580F5FC5ADCD5576885563 /* Typography.swift */,
@@ -138,6 +143,7 @@
 		B500CE1A6941BEA33903C091 /* Tests */ = {
 			isa = PBXGroup;
 			children = (
+				11B156E0FBE749405E1F2D0D /* CrayonSketchTests.swift */,
 				FBFA8ECD2DC59DBF8A6FBBF3 /* PlaygroundThemeTests.swift */,
 				8A719AFBA1888450E8653AB6 /* SdkHighlightOverlayE2ETests.swift */,
 			);
@@ -279,6 +285,7 @@
 				F99EE983EC6317D09E5A3247 /* AccessibilityRotorDemo.swift in Sources */,
 				97CA6F2DE628A139094EF72D /* Colors.swift in Sources */,
 				5339DAC5909A688059ABBA80 /* ContentView.swift in Sources */,
+				4546703D0511A96D6060F587 /* CrayonSketch.swift in Sources */,
 				15B37A3EDBAFD6BD0FC98BFC /* DemosTab.swift in Sources */,
 				EA349DF37933D70B410F7135 /* DiscoverTab.swift in Sources */,
 				553F94B4D033BCA44B07AC4E /* PlaygroundApp.swift in Sources */,
@@ -293,6 +300,7 @@
 			isa = PBXSourcesBuildPhase;
 			buildActionMask = 2147483647;
 			files = (
+				95CF2D08679D32C4A9966ACD /* CrayonSketchTests.swift in Sources */,
 				7C8CF515031B975C05FA2AD2 /* PlaygroundThemeTests.swift in Sources */,
 				B3B613858665E331B7E7EB99 /* SdkHighlightOverlayE2ETests.swift in Sources */,
 			);

--- a/ios/Playground/Sources/Tabs/DiscoverTab.swift
+++ b/ios/Playground/Sources/Tabs/DiscoverTab.swift
@@ -68,6 +68,8 @@ struct VideoRowView: View {
                 .frame(width: 60, height: 40)
                 .background(theme.surfaceVariant)
                 .cornerRadius(8)
+                // Hand-drawn crayon frame on the thumbnail tile (non-destructive overlay).
+                .crayonBorder(color: theme.primary, cornerRadius: 8, seed: 17)
 
             VStack(alignment: .leading, spacing: 4) {
                 Text(video.title)

--- a/ios/Playground/Sources/Theme/CrayonSketch.swift
+++ b/ios/Playground/Sources/Theme/CrayonSketch.swift
@@ -24,16 +24,23 @@ private func roundedRectPerimeter(
     _ width: CGFloat, _ height: CGFloat, _ corner: CGFloat, _ segmentsPerEdge: Int
 ) -> [CGPoint] {
     let r = min(max(corner, 0), min(width, height) / 2)
+    // At least one straight-edge sample: a zero count skips every edge point and a
+    // negative one is a `0..<n` range precondition failure.
+    let segs = max(1, segmentsPerEdge)
     var pts: [CGPoint] = []
     func edge(_ x0: CGFloat, _ y0: CGFloat, _ x1: CGFloat, _ y1: CGFloat) {
-        for s in 0..<segmentsPerEdge {
-            let t = CGFloat(s) / CGFloat(segmentsPerEdge)
+        for s in 0..<segs {
+            let t = CGFloat(s) / CGFloat(segs)
             pts.append(CGPoint(x: x0 + (x1 - x0) * t, y: y0 + (y1 - y0) * t))
         }
     }
+    // Half-open like `edge`: emit the arc's start but not its end, so the arc's last
+    // point never duplicates the following edge's first point. A duplicated seam
+    // point gets its own jitter and shows as a knot; the dropped corner point is
+    // supplied by the next segment's start (and the final one by the closing append).
     func arc(_ cx: CGFloat, _ cy: CGFloat, _ startDeg: CGFloat) {
         let steps = 3
-        for s in 0...steps {
+        for s in 0..<steps {
             let ang = (startDeg + 90 * CGFloat(s) / CGFloat(steps)) * .pi / 180
             pts.append(CGPoint(x: cx + r * cos(ang), y: cy + r * sin(ang)))
         }

--- a/ios/Playground/Sources/Theme/CrayonSketch.swift
+++ b/ios/Playground/Sources/Theme/CrayonSketch.swift
@@ -1,0 +1,132 @@
+import SwiftUI
+
+// MARK: - Crayon sketch (iOS)
+
+// Mirror of the Android design-system `CrayonSketch`: a pure, deterministic,
+// seeded jitter of a rounded-rectangle perimeter, drawn as a doubled-up marker
+// outline. Deterministic (no `Double.random`) so it is host-testable and never
+// flakes; the loop closes exactly and the modifier attenuates the caller's alpha.
+// Native SwiftUI (Shape/Canvas) — no Metal here (that is the shader item).
+
+/// Deterministic hash noise in [-1, 1) from a seed and index.
+func crayonNoise(_ seed: UInt64, _ i: Int) -> CGFloat {
+    var h = seed ^ (UInt64(i) &* 0x9E37_79B9_7F4A_7C15)
+    h = (h ^ (h >> 33)) &* 0xFF51_AFD7_ED55_8CCD
+    h = (h ^ (h >> 33)) &* 0xC4CE_B9FE_1A85_EC53
+    h ^= (h >> 33)
+    let u = Double(h >> 11) / Double(UInt64(1) << 53) // [0, 1)
+    return CGFloat(u * 2 - 1)
+}
+
+/// Base rounded-rectangle perimeter, sampled clockwise from the top edge and
+/// closed (the last point repeats the first). Every point is within the box.
+private func roundedRectPerimeter(
+    _ width: CGFloat, _ height: CGFloat, _ corner: CGFloat, _ segmentsPerEdge: Int
+) -> [CGPoint] {
+    let r = min(max(corner, 0), min(width, height) / 2)
+    var pts: [CGPoint] = []
+    func edge(_ x0: CGFloat, _ y0: CGFloat, _ x1: CGFloat, _ y1: CGFloat) {
+        for s in 0..<segmentsPerEdge {
+            let t = CGFloat(s) / CGFloat(segmentsPerEdge)
+            pts.append(CGPoint(x: x0 + (x1 - x0) * t, y: y0 + (y1 - y0) * t))
+        }
+    }
+    func arc(_ cx: CGFloat, _ cy: CGFloat, _ startDeg: CGFloat) {
+        let steps = 3
+        for s in 0...steps {
+            let ang = (startDeg + 90 * CGFloat(s) / CGFloat(steps)) * .pi / 180
+            pts.append(CGPoint(x: cx + r * cos(ang), y: cy + r * sin(ang)))
+        }
+    }
+    edge(r, 0, width - r, 0)
+    arc(width - r, r, -90)
+    edge(width, r, width, height - r)
+    arc(width - r, height - r, 0)
+    edge(width - r, height, r, height)
+    arc(r, height - r, 90)
+    edge(0, height - r, 0, r)
+    arc(r, r, 180)
+    if let first = pts.first { pts.append(first) }
+    return pts
+}
+
+/// The hand-drawn crayon outline of a rounded rectangle: a deterministic, seeded
+/// jitter of the perimeter. Same `seed` -> identical points; jitter is bounded by
+/// `roughness`; the loop closes exactly (last point == first point).
+func crayonOutlineOffsets(
+    width: CGFloat,
+    height: CGFloat,
+    cornerRadius: CGFloat,
+    seed: UInt64,
+    roughness: CGFloat,
+    segmentsPerEdge: Int = 6
+) -> [CGPoint] {
+    let base = roundedRectPerimeter(width, height, cornerRadius, segmentsPerEdge)
+    var jittered = base.enumerated().map { i, p in
+        CGPoint(
+            x: p.x + crayonNoise(seed, i * 2) * roughness,
+            y: p.y + crayonNoise(seed, i * 2 + 1) * roughness
+        )
+    }
+    // Close the loop exactly rather than letting the closing point drift.
+    if jittered.count > 1 { jittered[jittered.count - 1] = jittered[0] }
+    return jittered
+}
+
+/// A SwiftUI `Shape` for the crayon outline of its rect.
+struct CrayonOutline: Shape {
+    var cornerRadius: CGFloat = 18
+    var seed: UInt64 = 0
+    var roughness: CGFloat = 2.5
+
+    func path(in rect: CGRect) -> Path {
+        // Sample ~1 point per 26pt of the longest edge for consistent wobble density.
+        let seg = max(6, min(48, Int(max(rect.width, rect.height) / 26)))
+        let offsets = crayonOutlineOffsets(
+            width: rect.width, height: rect.height,
+            cornerRadius: cornerRadius, seed: seed, roughness: roughness, segmentsPerEdge: seg
+        )
+        var path = Path()
+        guard let first = offsets.first else { return path }
+        path.move(to: CGPoint(x: rect.minX + first.x, y: rect.minY + first.y))
+        for p in offsets.dropFirst() {
+            path.addLine(to: CGPoint(x: rect.minX + p.x, y: rect.minY + p.y))
+        }
+        path.closeSubpath()
+        return path
+    }
+}
+
+/// Overlays a hand-drawn crayon border on a view **without** replacing its own
+/// (stateful) styling — two offset strokes give the doubled-up marker feel.
+struct CrayonBorderModifier: ViewModifier {
+    let color: Color
+    var width: CGFloat = 2.5
+    var cornerRadius: CGFloat = 18
+    var seed: UInt64 = 0
+    var roughness: CGFloat = 2.5
+
+    func body(content: Content) -> some View {
+        content.overlay {
+            ZStack {
+                // `.opacity` multiplies (attenuates) the colour's existing alpha.
+                CrayonOutline(cornerRadius: cornerRadius, seed: seed &+ 101, roughness: roughness * 1.2)
+                    .stroke(color.opacity(0.55), style: StrokeStyle(lineWidth: width * 0.8, lineCap: .round, lineJoin: .round))
+                CrayonOutline(cornerRadius: cornerRadius, seed: seed, roughness: roughness)
+                    .stroke(color, style: StrokeStyle(lineWidth: width, lineCap: .round, lineJoin: .round))
+            }
+        }
+    }
+}
+
+extension View {
+    func crayonBorder(
+        color: Color,
+        width: CGFloat = 2.5,
+        cornerRadius: CGFloat = 18,
+        seed: UInt64 = 0,
+        roughness: CGFloat = 2.5
+    ) -> some View {
+        modifier(CrayonBorderModifier(color: color, width: width, cornerRadius: cornerRadius, seed: seed, roughness: roughness))
+    }
+}

--- a/ios/Playground/Tests/CrayonSketchTests.swift
+++ b/ios/Playground/Tests/CrayonSketchTests.swift
@@ -39,6 +39,27 @@ final class CrayonSketchTests: XCTestCase {
         }
     }
 
+    func testZeroRoughnessHasNoDuplicateSeamPoints() {
+        // Each perimeter seam is sampled once: with no jitter only the closing point
+        // (last == first) may repeat — no interior consecutive duplicates. A duplicated
+        // arc/edge seam point would jitter independently and render as a knot.
+        let pts = crayonOutlineOffsets(width: w, height: h, cornerRadius: corner, seed: 3, roughness: 0)
+        for i in 1..<(pts.count - 1) {
+            XCTAssertNotEqual(pts[i], pts[i - 1], "duplicate seam point at index \(i): \(pts[i])")
+        }
+    }
+
+    func testNonPositiveSegmentsPerEdgeClampToOne() {
+        // Zero or negative segmentsPerEdge must not crash and must behave like 1.
+        let one = crayonOutlineOffsets(
+            width: w, height: h, cornerRadius: corner, seed: 8, roughness: 0, segmentsPerEdge: 1)
+        for bad in [0, -1, -7] {
+            let got = crayonOutlineOffsets(
+                width: w, height: h, cornerRadius: corner, seed: 8, roughness: 0, segmentsPerEdge: bad)
+            XCTAssertEqual(got, one, "segmentsPerEdge \(bad) should clamp to 1")
+        }
+    }
+
     func testZeroRoughnessLiesOnPerimeter() {
         let pts = crayonOutlineOffsets(width: w, height: h, cornerRadius: corner, seed: 5, roughness: 0)
         for p in pts {

--- a/ios/Playground/Tests/CrayonSketchTests.swift
+++ b/ios/Playground/Tests/CrayonSketchTests.swift
@@ -1,0 +1,60 @@
+import CoreGraphics
+import XCTest
+
+@testable import Playground
+
+/// Pins the hand-drawn crayon outline geometry (AC1), mirroring the Android
+/// `CrayonSketchTest`: deterministic + seeded, bounded, closed exactly, and a
+/// zero-roughness outline that lies on the rounded-rect perimeter.
+final class CrayonSketchTests: XCTestCase {
+
+    private let w: CGFloat = 200
+    private let h: CGFloat = 96
+    private let corner: CGFloat = 18
+    private let roughness: CGFloat = 3
+
+    func testSameSeedProducesIdenticalOutline() {
+        let a = crayonOutlineOffsets(width: w, height: h, cornerRadius: corner, seed: 42, roughness: roughness)
+        let b = crayonOutlineOffsets(width: w, height: h, cornerRadius: corner, seed: 42, roughness: roughness)
+        XCTAssertEqual(a, b)
+    }
+
+    func testDifferentSeedProducesDifferentOutline() {
+        let a = crayonOutlineOffsets(width: w, height: h, cornerRadius: corner, seed: 1, roughness: roughness)
+        let b = crayonOutlineOffsets(width: w, height: h, cornerRadius: corner, seed: 2, roughness: roughness)
+        XCTAssertNotEqual(a, b)
+    }
+
+    func testOutlineIsClosedExactly() {
+        let pts = crayonOutlineOffsets(width: w, height: h, cornerRadius: corner, seed: 7, roughness: roughness)
+        XCTAssertGreaterThanOrEqual(pts.count, 16)
+        XCTAssertEqual(pts.first, pts.last)
+    }
+
+    func testEveryPointStaysWithinRoughnessBounds() {
+        let pts = crayonOutlineOffsets(width: w, height: h, cornerRadius: corner, seed: 99, roughness: roughness)
+        for p in pts {
+            XCTAssertTrue(p.x >= -roughness - 0.001 && p.x <= w + roughness + 0.001, "x \(p.x) out of bounds")
+            XCTAssertTrue(p.y >= -roughness - 0.001 && p.y <= h + roughness + 0.001, "y \(p.y) out of bounds")
+        }
+    }
+
+    func testZeroRoughnessLiesOnPerimeter() {
+        let pts = crayonOutlineOffsets(width: w, height: h, cornerRadius: corner, seed: 5, roughness: 0)
+        for p in pts {
+            XCTAssertTrue(onPerimeter(p), "point \(p) must lie on the rounded-rect perimeter")
+        }
+    }
+
+    private func onPerimeter(_ p: CGPoint) -> Bool {
+        let r = min(max(corner, 0), min(w, h) / 2)
+        let eps: CGFloat = 0.05
+        func near(_ a: CGFloat, _ b: CGFloat) -> Bool { abs(a - b) < eps }
+        if near(p.y, 0) && p.x >= r - eps && p.x <= w - r + eps { return true }
+        if near(p.y, h) && p.x >= r - eps && p.x <= w - r + eps { return true }
+        if near(p.x, 0) && p.y >= r - eps && p.y <= h - r + eps { return true }
+        if near(p.x, w) && p.y >= r - eps && p.y <= h - r + eps { return true }
+        let centres = [CGPoint(x: r, y: r), CGPoint(x: w - r, y: r), CGPoint(x: r, y: h - r), CGPoint(x: w - r, y: h - r)]
+        return centres.contains { c in abs(hypot(p.x - c.x, p.y - c.y) - r) < eps }
+    }
+}


### PR DESCRIPTION
## Summary

Item 4 of the Playground design-system program (#5047): the **iOS mirror of the
Android hand-drawn "crayon" outline primitive**. `CrayonSketch.swift` is a pure,
deterministic, seeded jitter of a rounded-rectangle perimeter drawn as a
doubled-up marker stroke — same crayon look as Android, native SwiftUI
(`Shape`/`Canvas`), no Metal (that is item 6). It is applied as a
**non-destructive `.crayonBorder(...)` overlay** on the Discover thumbnail tiles,
so each tile keeps its own styling/state (the lesson from the item-3 review, where
replacing a component's border broke its stateful chrome).

The geometry lives in `crayonOutlineOffsets(...)` in `CGPoint` space — no
`UIBezierPath`, no `Double.random` — so it is host-testable and never flakes. It
matches the Android `crayonOutlineOffsets` contract point-for-point: exact loop
closure (last point == first), roughness-bounded jitter, and a zero-roughness
outline that lies exactly on the rounded-rect perimeter.

## Linked Issue

Closes #5116

## Validation

- [x] `xcodebuild` (Playground scheme, iOS Simulator) — **TEST SUCCEEDED**, 14
      tests incl. 5 new `CrayonSketchTests` (determinism, different-seed, exact
      closure, roughness bounds, zero-roughness-on-perimeter).
- [x] SwiftLint — clean (non-strict gate; short geometry identifiers warn only).
- [x] `Playground.xcodeproj` regenerated with the pinned xcodegen — only the
      Playground project changed; `control-proxy` identical (no drift).
- [x] Verified on the iOS Simulator via a screenshot: the doubled hand-drawn
      salmon marker outline renders on the Discover tiles.

## Device Verification

- [x] Verified on iOS Simulator; crayon border renders as intended on the
      Discover thumbnail tiles.

## Follow-ups

Tracked separately to keep this PR focused: #5098 (route iOS views through
`theme` colours + typography), #5102 (run the design-system tests in CI on both
platforms), item 6 (iOS Metal shader), item 8 (iOS view rollout).
