### PR TITLE
feat(release): macOS host contract for managed iOS simulator continuity (#5104)

### DIFF
--- a/docs/release/ios-simulator-continuity.md
+++ b/docs/release/ios-simulator-continuity.md
@@ -88,6 +88,13 @@ The gate is `bun run validate:ios-continuity`
 evidence snapshot for one managed simulator, classifies the outcome, prints a
 redacted summary, and **exits non-zero unless continuity is proven**.
 
+Run it from a **source checkout of the auto-mobile repo** on the managed host —
+like the repo's other `validate:*` / `check:*` scripts, it is release-engineering
+tooling and is not shipped in the published npm package. The deployment owner
+already has the repo (they build/cut AutoMobile), so `bun install && bun run
+validate:ios-continuity …` from that checkout is the intended invocation. All
+timestamps must be strict ISO-8601 with a timezone (e.g. `2026-08-07T10:00:00Z`).
+
 ### Evidence to capture (before and after the deploy)
 
 For each managed simulator selected for validation, capture a JSON snapshot with

--- a/docs/release/ios-simulator-continuity.md
+++ b/docs/release/ios-simulator-continuity.md
@@ -1,0 +1,161 @@
+# macOS host contract for managed iOS simulator continuity
+
+Tracking issue: #5104.
+
+An iOS simulator appearing available after a deployment does **not** prove that
+the same simulator process, simulator identity, or CoreSimulator data survived
+the rollout. This document defines the host contract that a managed macOS worker
+must satisfy so that continuity — or a controlled replacement — is *provable*,
+and gives the repeatable validation that proves it before and after a real
+deploy. A successful `simctl list` alone is never continuity evidence.
+
+> **Redaction note.** This is a public document, so it uses **placeholders** for
+> the managed host name, simulator UDIDs, process identifiers, and the owning
+> team. Fill these in your internal deployment record, not here. The validation
+> command emits a redacted artifact (see [Evidence retention](#evidence-retention-and-redaction))
+> precisely so evidence can be retained and shared without exposing those values.
+
+## 1. Host and deployment ownership boundary
+
+Record the following in your internal deployment record (one row per managed
+host). The bracketed values are placeholders.
+
+| Field | Value | Notes |
+| --- | --- | --- |
+| Managed macOS host | `<host-identity>` | Hostname or stable host id of the worker. |
+| Owning team | `<team>` | Who is paged when continuity fails. |
+| Deployment trigger | `<rollout-trigger>` | What starts a rollout (CI job, orchestrator, manual). |
+| Process supervisor | `launchd` (typical) | Supervises the AutoMobile daemon, iOS control runner, and worker process. |
+| AutoMobile data root | `~/.auto-mobile` | Stable per-user base; see §3. |
+| CoreSimulator data boundary | `~/Library/Developer/CoreSimulator` | Owned by the macOS `CoreSimulator` service, **outside** any package/temp extraction path. |
+
+The four processes in scope are the **AutoMobile daemon**, the **iOS control
+runner**, the **worker process** that drives leases, and the macOS
+**CoreSimulator service** that owns simulator state. Continuity is a property of
+the simulator + its CoreSimulator data across a rollout of the first three.
+
+## 2. Supported continuity contract
+
+A rollout of the worker or AutoMobile on a managed host must do exactly one of:
+
+- **Preserve the booted simulator and its CoreSimulator data** — same UDID, same
+  data root, booted and responsive throughout, worker reporting restored after
+  the rollout completes. This is `same-device-continuity`.
+- **Perform a controlled replacement of one idle simulator at a time** — an
+  explicit lifecycle transition to a new/re-created device, declared as
+  `plannedReplacement`, where the replacement device is booted and responsive
+  before it is marked leaseable. This is `controlled-replacement`.
+
+Everything else is a continuity failure and is enumerated as its own outcome so
+it can be distinguished (see §5): `boot-recovery`, `shutdown`, `reporting-delay`,
+`orphaned-or-erased-state`, `failed-probe`, `incomplete-evidence`.
+
+A controlled replacement must operate on an **idle** simulator (no active lease,
+execution, or drain). Never replace a device that has active work.
+
+## 3. Why replacement cannot silently erase or orphan state
+
+Two invariants keep a worker/AutoMobile process replacement from destroying
+managed CoreSimulator state:
+
+1. **AutoMobile's on-disk state has a stable, non-ephemeral root.**
+   `resolveAutoMobileBaseDir` (`src/utils/tempDir.ts`) resolves
+   `~/.auto-mobile` (overridable via `AUTOMOBILE_DATA_DIR`) and *deliberately*
+   does not derive the base from `TMPDIR`/`TMP`/`TEMP`, which a package runner
+   such as `bunx` may point at an ephemeral extraction dir (issue #2724). A
+   process replaced from a fresh extraction therefore reattaches to the same
+   daemon socket and data — it does not orphan a new tree.
+2. **CoreSimulator data is owned by macOS, not by AutoMobile.** Simulator state
+   lives under `~/Library/Developer/CoreSimulator/Devices/<UDID>/data`, owned by
+   the `CoreSimulator` service. A rollout **must not** run `simctl erase`,
+   `simctl delete`, or wipe that tree as part of replacing the worker or
+   AutoMobile. Erasing a device is only permitted as the *explicit* first step of
+   a declared controlled replacement of an idle device.
+
+The validation in §4 makes a violation of either invariant observable: a changed
+UDID or a changed CoreSimulator data root **without** a declared
+`plannedReplacement` classifies as `orphaned-or-erased-state` and fails the gate.
+
+## 4. Repeatable validation
+
+The gate is `bun run validate:ios-continuity`
+(`scripts/validate-ios-simulator-continuity.ts`), wrapping the pure classifier in
+`src/utils/iosSimulatorContinuity.ts`. It reads a **before** and **after**
+evidence snapshot for one managed simulator, classifies the outcome, prints a
+redacted summary, and **exits non-zero unless continuity is proven**.
+
+### Evidence to capture (before and after the deploy)
+
+For each managed simulator selected for validation, capture a JSON snapshot with
+these fields (all in the issue's required pre/post-deploy evidence list):
+
+| Field | Example source |
+| --- | --- |
+| `udid`, `runtimeDeviceType` | `xcrun simctl list devices --json` |
+| `hostIdentity` | `scutil --get LocalHostName` (or your stable host id) |
+| `automobileVersion` | AutoMobile package/version reported by the daemon |
+| `workerIncarnation` | worker process incarnation id (changes on replacement) |
+| `processSupervisor`, `processIds` | `launchctl` / `ps` for daemon, runner, `com.apple.CoreSimulator.CoreSimulatorService` |
+| `coreSimulatorDataRoot` | `~/Library/Developer/CoreSimulator/Devices/<udid>/data` |
+| `bootedSince` | boot time of the current session (used to detect a mid-window reboot) |
+| `lifecycleState` | `booted` / `shutdown` / … from `simctl list` |
+| `responsive` | result of a responsiveness probe against the device |
+| `reportingStatus` | `reporting` / `delayed` / `lost` from the worker/AutoMobile status |
+| `activeWork` | whether a lease, execution, or drain was present |
+
+Also capture a `deploy` window: `startedAt`, `completedAt`, and
+`plannedReplacement` (true only for a declared controlled replacement).
+
+### Run the gate
+
+```bash
+bun run validate:ios-continuity \
+  --before before.json \
+  --after after.json \
+  --deploy deploy.json \
+  --out redacted-evidence.json
+```
+
+Exit codes: `0` continuity proven, `1` not proven (verdict printed), `2` usage
+error. Wire the non-zero exit into the deploy so an unproven rollout fails.
+
+## 5. Distinguished outcomes
+
+The classifier never conflates "listed" with "continuous". It reports exactly
+one verdict:
+
+| Verdict | Meaning | Proven? | Recommended state |
+| --- | --- | --- | --- |
+| `same-device-continuity` | Same UDID + data root, booted/responsive throughout, reporting restored. | yes | available |
+| `controlled-replacement` | Declared replacement; new device booted and responsive. | yes | available |
+| `boot-recovery` | Same UDID + data, but rebooted during the window (data safe, booted session did not survive). | no | maintenance |
+| `shutdown` | Same device is no longer booted and did not recover. | no | maintenance |
+| `reporting-delay` | Device continuous but worker reporting delayed/lost. | no | maintenance |
+| `orphaned-or-erased-state` | UDID or data root changed with no declared replacement. | no | maintenance |
+| `failed-probe` | Post-deploy state or responsiveness could not be determined. | no | maintenance |
+| `incomplete-evidence` | Required identity/context evidence missing. | no | maintenance |
+
+## 6. Failure and rollback
+
+When the gate returns non-zero:
+
+1. Leave the affected simulator **visibly unavailable / in maintenance** — its
+   recommended state is `maintenance`. A worker process that merely restarted
+   must **not** report the device as leaseable until fresh evidence proves
+   continuity. A failed replacement stays unavailable, not silently re-listed.
+2. Do not re-mark the device available on the strength of an inventory listing.
+   Only a `same-device-continuity` or `controlled-replacement` verdict from a new
+   before/after capture returns it to `available`.
+3. For `orphaned-or-erased-state`, treat managed CoreSimulator data as
+   potentially lost: recover from your device provisioning source and re-run the
+   validation before returning the host to the pool.
+
+## Evidence retention and redaction
+
+The `--out` artifact is a **redacted** evidence record: host identity, UDIDs,
+process ids, and home-dir paths are replaced with deterministic one-way tokens
+that preserve equality (so a reader can still tell "same device before and after"
+or "the worker was replaced") without exposing raw values. Non-sensitive fields
+(runtime/device type, AutoMobile version, lifecycle, reporting, timestamps) are
+kept verbatim. Retain this redacted artifact with the deployment record; it is
+safe to attach to a public issue.

--- a/docs/release/ios-simulator-continuity.md
+++ b/docs/release/ios-simulator-continuity.md
@@ -43,8 +43,9 @@ A rollout of the worker or AutoMobile on a managed host must do exactly one of:
   the rollout completes. This is `same-device-continuity`.
 - **Perform a controlled replacement of one idle simulator at a time** — an
   explicit lifecycle transition to a new/re-created device, declared as
-  `plannedReplacement`, where the replacement device is booted and responsive
-  before it is marked leaseable. This is `controlled-replacement`.
+  `plannedReplacement`. The replacement must clear the **same post-deploy proof**
+  as a survival (booted, responsive, reporting, with a valid boot-session time)
+  and stay **on the same managed host**; only then is it `controlled-replacement`.
 
 Everything else is a continuity failure and is enumerated as its own outcome so
 it can be distinguished (see §5): `boot-recovery`, `shutdown`, `reporting-delay`,

--- a/docs/release/ios-simulator-continuity.md
+++ b/docs/release/ios-simulator-continuity.md
@@ -100,7 +100,7 @@ these fields (all in the issue's required pre/post-deploy evidence list):
 | `workerIncarnation` | worker process incarnation id (changes on replacement) |
 | `processSupervisor`, `processIds` | `launchctl` / `ps` for daemon, runner, `com.apple.CoreSimulator.CoreSimulatorService` |
 | `coreSimulatorDataRoot` | `~/Library/Developer/CoreSimulator/Devices/<udid>/data` |
-| `bootedSince` | boot time of the current session (used to detect a mid-window reboot) — **capture it**: without it a reboot inside the window cannot be proven, so a rebooted device may read as `same-device-continuity` |
+| `bootedSince` | boot time of the current session (used to detect a mid-window reboot) — **required for a proven verdict**: without it a reboot cannot be ruled out, so the result is `incomplete-evidence` |
 | `lifecycleState` | `booted` / `shutdown` / … from `simctl list` |
 | `responsive` | result of a responsiveness probe against the device |
 | `reportingStatus` | `reporting` / `delayed` / `lost` from the worker/AutoMobile status |
@@ -137,9 +137,15 @@ one verdict:
 | `boot-recovery` | Same UDID + data, but rebooted during the window (data safe, booted session did not survive). | no | maintenance |
 | `shutdown` | Same device is no longer booted and did not recover. | no | maintenance |
 | `reporting-delay` | Device continuous but worker reporting delayed/lost. | no | maintenance |
-| `orphaned-or-erased-state` | UDID or data root changed with no declared replacement. | no | maintenance |
+| `orphaned-or-erased-state` | UDID, data root, or host identity changed with no declared replacement (also: a controlled replacement of a device that had active work). | no | maintenance |
 | `failed-probe` | Post-deploy state or responsiveness could not be determined. | no | maintenance |
-| `incomplete-evidence` | Required identity/context evidence missing. | no | maintenance |
+| `incomplete-evidence` | Required identity/context evidence missing, `bootedSince` absent, or the pre-deploy baseline was not booted+responsive — continuity of a healthy device cannot be proven. | no | maintenance |
+
+The gate proves continuity, so it holds evidence to a high bar: the before/after
+pair must be from the **same managed host** (a differing `hostIdentity` reads as
+`orphaned-or-erased-state`), the **pre-deploy baseline must itself be healthy**
+(booted + responsive), and `bootedSince` must be present to rule out a reboot.
+Anything short of that is not proven, not silently accepted.
 
 ## 6. Failure and rollback
 

--- a/docs/release/ios-simulator-continuity.md
+++ b/docs/release/ios-simulator-continuity.md
@@ -51,7 +51,10 @@ it can be distinguished (see §5): `boot-recovery`, `shutdown`, `reporting-delay
 `orphaned-or-erased-state`, `failed-probe`, `incomplete-evidence`.
 
 A controlled replacement must operate on an **idle** simulator (no active lease,
-execution, or drain). Never replace a device that has active work.
+execution, or drain). Never replace a device that has active work — the validation
+enforces this: a declared replacement of a device whose before-snapshot has
+`activeWork: true` classifies as `orphaned-or-erased-state` (not proven), because
+replacing a busy device destroys its in-flight state.
 
 ## 3. Why replacement cannot silently erase or orphan state
 
@@ -97,7 +100,7 @@ these fields (all in the issue's required pre/post-deploy evidence list):
 | `workerIncarnation` | worker process incarnation id (changes on replacement) |
 | `processSupervisor`, `processIds` | `launchctl` / `ps` for daemon, runner, `com.apple.CoreSimulator.CoreSimulatorService` |
 | `coreSimulatorDataRoot` | `~/Library/Developer/CoreSimulator/Devices/<udid>/data` |
-| `bootedSince` | boot time of the current session (used to detect a mid-window reboot) |
+| `bootedSince` | boot time of the current session (used to detect a mid-window reboot) — **capture it**: without it a reboot inside the window cannot be proven, so a rebooted device may read as `same-device-continuity` |
 | `lifecycleState` | `booted` / `shutdown` / … from `simctl list` |
 | `responsive` | result of a responsiveness probe against the device |
 | `reportingStatus` | `reporting` / `delayed` / `lost` from the worker/AutoMobile status |
@@ -116,8 +119,11 @@ bun run validate:ios-continuity \
   --out redacted-evidence.json
 ```
 
-Exit codes: `0` continuity proven, `1` not proven (verdict printed), `2` usage
-error. Wire the non-zero exit into the deploy so an unproven rollout fails.
+`--deploy` is **required**: reboot detection is only meaningful against a real
+deploy window, so there is no sound default for it. Exit codes: `0` continuity
+proven, `1` not proven (verdict printed), `2` usage error or bad input (missing
+file / malformed JSON, kept distinct from a not-proven result). Wire the non-zero
+exit into the deploy so an unproven rollout fails.
 
 ## 5. Distinguished outcomes
 
@@ -153,9 +159,13 @@ When the gate returns non-zero:
 ## Evidence retention and redaction
 
 The `--out` artifact is a **redacted** evidence record: host identity, UDIDs,
-process ids, and home-dir paths are replaced with deterministic one-way tokens
-that preserve equality (so a reader can still tell "same device before and after"
-or "the worker was replaced") without exposing raw values. Non-sensitive fields
-(runtime/device type, AutoMobile version, lifecycle, reporting, timestamps) are
-kept verbatim. Retain this redacted artifact with the deployment record; it is
-safe to attach to a public issue.
+process ids, and home-dir paths are replaced with one-way tokens that preserve
+equality **within the artifact** (so a reader can still tell "same device before
+and after" or "the worker was replaced") without exposing raw values. Each artifact
+uses a **fresh random salt**, so the tokens cannot be de-anonymized by
+precomputing hashes for guessable inputs such as PIDs or predictable host names —
+a fixed, committed salt would not protect those low-entropy fields. The trade-off
+is that tokens do not correlate across separate artifacts (not needed here).
+Non-sensitive fields (runtime/device type, AutoMobile version, lifecycle,
+reporting, timestamps) are kept verbatim. Retain this redacted artifact with the
+deployment record; it is safe to attach to a public issue.

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -221,6 +221,7 @@ nav:
       - 'Apple Signing & Notarization': release/apple-signing-setup.md
       - 'Windows & Linux Signing (research)': release/windows-linux-signing-research.md
       - 'Maven Publication Manifest': release/maven-publication-manifest.md
+      - 'iOS Simulator Continuity Contract': release/ios-simulator-continuity.md
       - 'Dependency Decisions':
           - 'fast-check': decisions/fast-check.md
           - 'TypeScript 7 (tsgo)': decisions/typescript-native-preview.md

--- a/package.json
+++ b/package.json
@@ -36,6 +36,7 @@
     "profile:memory": "bun --expose-gc --inspect scripts/detect-memory-leaks.ts --mode=profile",
     "profile:heap": "bun --expose-gc --heap-prof scripts/stress-test.ts",
     "validate:yaml": "bun scripts/validate-yaml.ts",
+    "validate:ios-continuity": "bun scripts/validate-ios-simulator-continuity.ts",
     "check:bun-version-coherence": "bun scripts/check-bun-version-coherence.ts",
     "check:stdlib-first": "bash scripts/check-stdlib-first.sh",
     "check:host-shell-boundary": "bun scripts/check-host-shell-boundary.ts",

--- a/scripts/validate-ios-simulator-continuity.ts
+++ b/scripts/validate-ios-simulator-continuity.ts
@@ -73,6 +73,16 @@ function bool(rec: Record<string, unknown>, key: string): boolean {
   return rec[key] === true;
 }
 
+function requireBool(rec: Record<string, unknown>, key: string, source: string): boolean {
+  const value = rec[key];
+  if (typeof value !== "boolean") {
+    // Absence must not silently read as false: a missing `activeWork` would let a
+    // busy device pass as idle, and a missing `responsive` as unresponsive.
+    throw new Error(`${source}: "${key}" must be present and a boolean`);
+  }
+  return value;
+}
+
 const LIFECYCLE_STATES: ReadonlySet<string> = new Set([
   "booted",
   "shutdown",
@@ -118,9 +128,9 @@ function parseSnapshot(raw: unknown, source: string): ContinuitySnapshot {
     coreSimulatorDataRoot: str(rec, "coreSimulatorDataRoot"),
     bootedSince: optionalStr(rec, "bootedSince"),
     lifecycleState: lifecycle(rec),
-    responsive: bool(rec, "responsive"),
+    responsive: requireBool(rec, "responsive", source),
     reportingStatus: reporting(rec),
-    activeWork: bool(rec, "activeWork"),
+    activeWork: requireBool(rec, "activeWork", source),
   };
 }
 

--- a/scripts/validate-ios-simulator-continuity.ts
+++ b/scripts/validate-ios-simulator-continuity.ts
@@ -11,11 +11,11 @@
  *
  * Usage:
  *   bun scripts/validate-ios-simulator-continuity.ts \
- *     --before before.json --after after.json [--deploy deploy.json] [--out redacted.json]
+ *     --before before.json --after after.json --deploy deploy.json [--out redacted.json]
  *
  * before.json / after.json are ContinuitySnapshot records; deploy.json is a
- * DeploymentWindow (defaults to a window bracketing "now" with no planned
- * replacement when omitted).
+ * DeploymentWindow. --deploy is required: reboot detection is only meaningful
+ * against a real deploy window, so there is no sound default for it.
  */
 
 import { readFileSync, writeFileSync } from "node:fs";
@@ -137,20 +137,29 @@ function readJson(file: string): unknown {
   return JSON.parse(readFileSync(file, "utf8"));
 }
 
+const USAGE =
+  "Usage: bun scripts/validate-ios-simulator-continuity.ts --before <file> --after <file> --deploy <file> [--out <file>]";
+
 function main(): number {
   const args = parseArgs(process.argv.slice(2));
-  if (!args.before || !args.after) {
-    console.error(
-      "Usage: bun scripts/validate-ios-simulator-continuity.ts --before <file> --after <file> [--deploy <file>] [--out <file>]",
-    );
+  if (!args.before || !args.after || !args.deploy) {
+    console.error(USAGE);
     return 2;
   }
 
-  const before = parseSnapshot(readJson(args.before), args.before);
-  const after = parseSnapshot(readJson(args.after), args.after);
-  const deploy: DeploymentWindow = args.deploy
-    ? parseDeploy(readJson(args.deploy), args.deploy)
-    : { startedAt: before.bootedSince ?? "", completedAt: "", plannedReplacement: false };
+  let before: ContinuitySnapshot;
+  let after: ContinuitySnapshot;
+  let deploy: DeploymentWindow;
+  try {
+    before = parseSnapshot(readJson(args.before), args.before);
+    after = parseSnapshot(readJson(args.after), args.after);
+    deploy = parseDeploy(readJson(args.deploy), args.deploy);
+  } catch (error) {
+    // Bad input (missing file / malformed JSON) is a usage error (exit 2), kept
+    // distinct from a well-formed "continuity not proven" result (exit 1).
+    console.error(`${error instanceof Error ? error.message : String(error)}\n${USAGE}`);
+    return 2;
+  }
 
   const result = classifyContinuity(before, after, deploy);
   const redacted = redactContinuityEvidence({ before, after, deploy, result });

--- a/scripts/validate-ios-simulator-continuity.ts
+++ b/scripts/validate-ios-simulator-continuity.ts
@@ -1,0 +1,175 @@
+#!/usr/bin/env bun
+
+/**
+ * Deploy-continuity gate for managed iOS simulators (issue #5104).
+ *
+ * Reads the before/after evidence captured around a worker/AutoMobile rollout
+ * (see docs/release/ios-simulator-continuity.md for the capture commands),
+ * classifies what happened to the simulator, prints a redacted summary safe to
+ * retain with the deployment record, and exits non-zero unless continuity is
+ * proven — so a rollout that cannot prove continuity fails the deploy loudly.
+ *
+ * Usage:
+ *   bun scripts/validate-ios-simulator-continuity.ts \
+ *     --before before.json --after after.json [--deploy deploy.json] [--out redacted.json]
+ *
+ * before.json / after.json are ContinuitySnapshot records; deploy.json is a
+ * DeploymentWindow (defaults to a window bracketing "now" with no planned
+ * replacement when omitted).
+ */
+
+import { readFileSync, writeFileSync } from "node:fs";
+import {
+  classifyContinuity,
+  continuityExitCode,
+  redactContinuityEvidence,
+  type ContinuitySnapshot,
+  type DeploymentWindow,
+  type SimulatorLifecycleState,
+  type ReportingStatus,
+} from "../src/utils/iosSimulatorContinuity";
+
+interface Args {
+  readonly before?: string;
+  readonly after?: string;
+  readonly deploy?: string;
+  readonly out?: string;
+}
+
+function parseArgs(argv: readonly string[]): Args {
+  const args: Record<string, string> = {};
+  for (let i = 0; i < argv.length; i++) {
+    const flag = argv[i];
+    if (flag.startsWith("--")) {
+      const key = flag.slice(2);
+      const value = argv[i + 1];
+      if (value !== undefined && !value.startsWith("--")) {
+        args[key] = value;
+        i++;
+      }
+    }
+  }
+  return { before: args.before, after: args.after, deploy: args.deploy, out: args.out };
+}
+
+function asRecord(value: unknown, source: string): Record<string, unknown> {
+  if (typeof value !== "object" || value === null || Array.isArray(value)) {
+    throw new Error(`${source} must be a JSON object`);
+  }
+  return value as Record<string, unknown>;
+}
+
+function str(rec: Record<string, unknown>, key: string): string {
+  const value = rec[key];
+  return typeof value === "string" ? value : "";
+}
+
+function optionalStr(rec: Record<string, unknown>, key: string): string | undefined {
+  const value = rec[key];
+  return typeof value === "string" ? value : undefined;
+}
+
+function bool(rec: Record<string, unknown>, key: string): boolean {
+  return rec[key] === true;
+}
+
+const LIFECYCLE_STATES: ReadonlySet<string> = new Set([
+  "booted",
+  "shutdown",
+  "booting",
+  "shutting-down",
+  "unknown",
+]);
+const REPORTING_STATES: ReadonlySet<string> = new Set(["reporting", "delayed", "lost", "unknown"]);
+
+function lifecycle(rec: Record<string, unknown>): SimulatorLifecycleState {
+  const value = str(rec, "lifecycleState");
+  return LIFECYCLE_STATES.has(value) ? (value as SimulatorLifecycleState) : "unknown";
+}
+
+function reporting(rec: Record<string, unknown>): ReportingStatus {
+  const value = str(rec, "reportingStatus");
+  return REPORTING_STATES.has(value) ? (value as ReportingStatus) : "unknown";
+}
+
+function processIds(rec: Record<string, unknown>): Record<string, number> {
+  const raw = rec.processIds;
+  const out: Record<string, number> = {};
+  if (typeof raw === "object" && raw !== null && !Array.isArray(raw)) {
+    for (const [name, pid] of Object.entries(raw)) {
+      if (typeof pid === "number" && Number.isFinite(pid)) {
+        out[name] = pid;
+      }
+    }
+  }
+  return out;
+}
+
+function parseSnapshot(raw: unknown, source: string): ContinuitySnapshot {
+  const rec = asRecord(raw, source);
+  return {
+    udid: str(rec, "udid"),
+    runtimeDeviceType: str(rec, "runtimeDeviceType"),
+    hostIdentity: str(rec, "hostIdentity"),
+    automobileVersion: str(rec, "automobileVersion"),
+    workerIncarnation: str(rec, "workerIncarnation"),
+    processSupervisor: str(rec, "processSupervisor"),
+    processIds: processIds(rec),
+    coreSimulatorDataRoot: str(rec, "coreSimulatorDataRoot"),
+    bootedSince: optionalStr(rec, "bootedSince"),
+    lifecycleState: lifecycle(rec),
+    responsive: bool(rec, "responsive"),
+    reportingStatus: reporting(rec),
+    activeWork: bool(rec, "activeWork"),
+  };
+}
+
+function parseDeploy(raw: unknown, source: string): DeploymentWindow {
+  const rec = asRecord(raw, source);
+  return {
+    startedAt: str(rec, "startedAt"),
+    completedAt: str(rec, "completedAt"),
+    plannedReplacement: bool(rec, "plannedReplacement"),
+  };
+}
+
+function readJson(file: string): unknown {
+  return JSON.parse(readFileSync(file, "utf8"));
+}
+
+function main(): number {
+  const args = parseArgs(process.argv.slice(2));
+  if (!args.before || !args.after) {
+    console.error(
+      "Usage: bun scripts/validate-ios-simulator-continuity.ts --before <file> --after <file> [--deploy <file>] [--out <file>]",
+    );
+    return 2;
+  }
+
+  const before = parseSnapshot(readJson(args.before), args.before);
+  const after = parseSnapshot(readJson(args.after), args.after);
+  const deploy: DeploymentWindow = args.deploy
+    ? parseDeploy(readJson(args.deploy), args.deploy)
+    : { startedAt: before.bootedSince ?? "", completedAt: "", plannedReplacement: false };
+
+  const result = classifyContinuity(before, after, deploy);
+  const redacted = redactContinuityEvidence({ before, after, deploy, result });
+  const serialized = JSON.stringify(redacted, null, 2);
+
+  console.log(serialized);
+  console.log(`\nverdict: ${result.verdict}`);
+  console.log(`proven: ${result.proven}`);
+  console.log(`recommended state: ${result.recommendedState}`);
+  for (const reason of result.reasons) {
+    console.log(`  - ${reason}`);
+  }
+
+  if (args.out) {
+    writeFileSync(args.out, serialized);
+    console.log(`\nredacted evidence written to ${args.out}`);
+  }
+
+  return continuityExitCode(result);
+}
+
+process.exit(main());

--- a/src/utils/iosSimulatorContinuity.ts
+++ b/src/utils/iosSimulatorContinuity.ts
@@ -54,8 +54,9 @@ export interface ContinuitySnapshot {
   /**
    * ISO timestamp of when the *current* boot session began. If this falls
    * inside the deploy window the running simulator did not survive even when the
-   * UDID and data root did — that is boot recovery, not continuity. Optional
-   * because not every host can report it; when absent a reboot cannot be proven.
+   * UDID and data root did — that is boot recovery, not continuity. Optional in
+   * the shape, but a *proven* same-device-continuity verdict requires it: when
+   * absent, a reboot cannot be ruled out, so the result is `incomplete-evidence`.
    */
   readonly bootedSince?: string;
   /** Simulator lifecycle state. */
@@ -188,9 +189,23 @@ function hit(verdict: ContinuityVerdict, reason: string): RuleHit {
   return { verdict, reason };
 }
 
-/** True when the after-snapshot identity or CoreSimulator data root changed. */
+/**
+ * True when the after-snapshot identity changed vs before: UDID, CoreSimulator
+ * data root, or host identity. The contract is scoped to one managed host, so a
+ * host-identity change means the before/after evidence was captured on different
+ * machines — that is not continuity of the same device.
+ */
 function identityChanged(before: ContinuitySnapshot, after: ContinuitySnapshot): boolean {
-  return after.udid !== before.udid || after.coreSimulatorDataRoot !== before.coreSimulatorDataRoot;
+  return (
+    after.udid !== before.udid ||
+    after.coreSimulatorDataRoot !== before.coreSimulatorDataRoot ||
+    after.hostIdentity !== before.hostIdentity
+  );
+}
+
+/** True when the pre-deploy baseline was a healthy, booted, responsive device. */
+function healthyBaseline(before: ContinuitySnapshot): boolean {
+  return before.lifecycleState === "booted" && before.responsive;
 }
 
 /**
@@ -239,13 +254,13 @@ const CONTINUITY_RULES: readonly ContinuityRule[] = [
           "Deploy was declared a controlled replacement but the replacement simulator is not booted and responsive.",
         );
   },
-  // 4. Orphaned/erased state — identity or CoreSimulator data changed with no
-  //    planned replacement to explain it. This is the AC3 guard.
+  // 4. Orphaned/erased state — identity, CoreSimulator data, or host changed
+  //    with no planned replacement to explain it. This is the AC3 guard.
   (before, after) =>
     identityChanged(before, after)
       ? hit(
           "orphaned-or-erased-state",
-          "Simulator UDID or CoreSimulator data root changed without a declared controlled replacement.",
+          "Simulator UDID, CoreSimulator data root, or host identity changed without a declared controlled replacement.",
         )
       : null,
   // From here the UDID and data root are unchanged.
@@ -282,6 +297,26 @@ const CONTINUITY_RULES: readonly ContinuityRule[] = [
       : hit(
           "reporting-delay",
           `Simulator is continuous but worker reporting is ${after.reportingStatus}.`,
+        ),
+  // 9. Provability guards for the clean-continuity claim. Same-device-continuity
+  //    asserts "booted and responsive throughout", so the pre-deploy baseline
+  //    must itself have been healthy — an unhealthy `before` cannot prove a
+  //    healthy device was preserved.
+  (before) =>
+    healthyBaseline(before)
+      ? null
+      : hit(
+          "incomplete-evidence",
+          "Pre-deploy baseline was not a booted, responsive simulator; continuity of a healthy device cannot be proven.",
+        ),
+  // 10. Boot-session time is required to rule out a reboot during the window; a
+  //     rollout that cannot prove the booted session survived is not proven.
+  (_before, after) =>
+    after.bootedSince
+      ? null
+      : hit(
+          "incomplete-evidence",
+          "Boot-session time (bootedSince) is required to prove the running simulator survived; without it a reboot cannot be ruled out.",
         ),
 ];
 

--- a/src/utils/iosSimulatorContinuity.ts
+++ b/src/utils/iosSimulatorContinuity.ts
@@ -1,4 +1,4 @@
-import { createHash } from "node:crypto";
+import { createHash, randomBytes } from "node:crypto";
 import { redactHomeDir } from "./redactPath";
 
 /**
@@ -216,9 +216,18 @@ const CONTINUITY_RULES: readonly ContinuityRule[] = [
       : null,
   // 3. Explicit, controlled replacement — the only case where a changed identity
   //    or data root is acceptable, and only if the new device is actually up.
-  (_before, after, deploy) => {
+  //    A replacement must operate on an *idle* device: replacing one that had an
+  //    active lease/execution/drain destroys that in-flight state, so it is
+  //    flagged as orphaned/erased rather than certified as controlled.
+  (before, after, deploy) => {
     if (!deploy.plannedReplacement) {
       return null;
+    }
+    if (before.activeWork) {
+      return hit(
+        "orphaned-or-erased-state",
+        "Deploy was declared a controlled replacement but the simulator had active work (lease/execution/drain); replacement must operate on an idle device.",
+      );
     }
     return after.lifecycleState === "booted" && after.responsive
       ? hit(
@@ -309,32 +318,38 @@ export function continuityExitCode(result: ContinuityResult): number {
   return result.proven ? 0 : 1;
 }
 
-// A fixed salt so redaction tokens are deterministic within and across runs
-// (needed to compare retained evidence) while still not being the raw value.
-const REDACTION_SALT = "auto-mobile:ios-continuity:v1";
+/**
+ * A fresh random salt for one redaction pass. A *fixed*, committed salt would
+ * be worthless for enumerable inputs — with the salt public, PIDs and predictable
+ * host names can be recovered by precomputing tokens offline. A per-artifact
+ * random salt makes precomputation impossible while still preserving equality
+ * *within* the artifact (same value → same token, because one salt is used for
+ * the whole record). Cross-artifact correlation is intentionally not offered;
+ * issue #5104 never requires correlating tokens across separate records.
+ */
+export function generateRedactionSalt(): string {
+  return randomBytes(16).toString("hex");
+}
 
-/** One-way, correlation-preserving token for a sensitive value. */
-function token(prefix: string, value: string): string {
-  const digest = createHash("sha256")
-    .update(`${REDACTION_SALT}:${value}`)
-    .digest("hex")
-    .slice(0, 12);
+/** One-way, within-artifact-correlation-preserving token for a sensitive value. */
+function token(prefix: string, value: string, salt: string): string {
+  const digest = createHash("sha256").update(`${salt}:${value}`).digest("hex").slice(0, 12);
   return `${prefix}:${digest}`;
 }
 
-function redactSnapshot(snapshot: ContinuitySnapshot): RedactedContinuitySnapshot {
+function redactSnapshot(snapshot: ContinuitySnapshot, salt: string): RedactedContinuitySnapshot {
   const redactedPids: Record<string, string> = {};
   for (const [name, pid] of Object.entries(snapshot.processIds)) {
     // PIDs are not exposed; keep per-process correlation via a stable token.
-    redactedPids[name] = token("pid", String(pid));
+    redactedPids[name] = token("pid", String(pid), salt);
   }
   return {
     ...snapshot,
-    udid: token("sim", snapshot.udid),
-    hostIdentity: token("host", snapshot.hostIdentity),
-    workerIncarnation: token("worker", snapshot.workerIncarnation),
+    udid: token("sim", snapshot.udid, salt),
+    hostIdentity: token("host", snapshot.hostIdentity, salt),
+    workerIncarnation: token("worker", snapshot.workerIncarnation, salt),
     // The data root embeds the UDID and a home prefix; tokenize the whole path.
-    coreSimulatorDataRoot: token("dataroot", snapshot.coreSimulatorDataRoot),
+    coreSimulatorDataRoot: token("dataroot", snapshot.coreSimulatorDataRoot, salt),
     processIds: redactedPids,
   };
 }
@@ -342,20 +357,29 @@ function redactSnapshot(snapshot: ContinuitySnapshot): RedactedContinuitySnapsho
 /**
  * Produce a redacted copy of an evidence record safe to retain with a
  * deployment record or share in a public issue (issue #5104, AC7). Host names,
- * UDIDs, PIDs, and home-dir paths are replaced with deterministic one-way tokens
- * that preserve equality — so a reader can still tell "same device before and
- * after" or "the worker was replaced" — without exposing the raw values. The
+ * UDIDs, PIDs, and home-dir paths are replaced with one-way tokens that preserve
+ * equality *within this record* — so a reader can still tell "same device before
+ * and after" or "the worker was replaced" — without exposing the raw values. The
  * non-sensitive fields (runtime/device type, version, lifecycle, reporting,
  * timestamps) are kept verbatim so the evidence stays readable.
+ *
+ * @param salt - Injectable redaction salt. Defaults to a fresh random salt per
+ *   call so tokens cannot be precomputed from a known salt; pass a fixed salt in
+ *   tests to assert token stability.
  */
-export function redactContinuityEvidence(evidence: ContinuityEvidence): RedactedContinuityEvidence {
-  // redactHomeDir is applied first for any residual path leakage in reasons.
+export function redactContinuityEvidence(
+  evidence: ContinuityEvidence,
+  salt: string = generateRedactionSalt(),
+): RedactedContinuityEvidence {
+  // reasons only interpolate lifecycle/reporting enums today; redactHomeDir is a
+  // cheap guard against a future reason that embeds a path, not a load-bearing
+  // control.
   const redactedResult = evidence.result
     ? { ...evidence.result, reasons: evidence.result.reasons.map((r) => redactHomeDir(r)) }
     : undefined;
   return {
-    before: redactSnapshot(evidence.before),
-    after: redactSnapshot(evidence.after),
+    before: redactSnapshot(evidence.before, salt),
+    after: redactSnapshot(evidence.after, salt),
     deploy: evidence.deploy,
     ...(redactedResult ? { result: redactedResult } : {}),
   };

--- a/src/utils/iosSimulatorContinuity.ts
+++ b/src/utils/iosSimulatorContinuity.ts
@@ -171,9 +171,14 @@ function hit(verdict: ContinuityVerdict, reason: string): RuleHit {
   return { verdict, reason };
 }
 
-/** True when the value is a non-empty, parseable ISO timestamp. */
+// Strict ISO-8601 date-time with a timezone: `2026-08-07T10:00:00(.000)?(Z|±hh:mm)`.
+// Permissive Date.parse alone accepts junk like "0"/"1" as valid dates, which
+// would let malformed evidence read as proven — so the shape is checked too.
+const ISO_8601 = /^\d{4}-\d{2}-\d{2}T\d{2}:\d{2}:\d{2}(?:\.\d{1,3})?(?:Z|[+-]\d{2}:\d{2})$/;
+
+/** True when the value is a strict ISO-8601 timestamp with a real calendar value. */
 function isValidTimestamp(value: string | undefined): value is string {
-  return typeof value === "string" && value.length > 0 && !Number.isNaN(Date.parse(value));
+  return typeof value === "string" && ISO_8601.test(value) && !Number.isNaN(Date.parse(value));
 }
 
 /** True when all identity/context evidence and the deploy window are present and well-formed. */
@@ -193,10 +198,26 @@ function evidenceComplete(
   );
 }
 
-/** True when the device's current boot session began at or after the deploy window start. */
-function rebootedDuringWindow(after: ContinuitySnapshot, deploy: DeploymentWindow): boolean {
-  // Reached only after isValidTimestamp gates, so both parse.
-  return Date.parse(after.bootedSince as string) >= Date.parse(deploy.startedAt);
+/**
+ * A boot-recovery verdict when the current boot session began at or after the
+ * deploy started (so the pre-deploy booted session did not survive), or null when
+ * it began before the deploy (the session survived). A boot at or after the start
+ * is not proven regardless of whether it lands inside or after the window — a
+ * post-window reboot before capture still means the session did not survive — but
+ * the reason distinguishes the two. Reached only after the isValidTimestamp gates.
+ */
+function bootRecovery(after: ContinuitySnapshot, deploy: DeploymentWindow): RuleHit | null {
+  const bootedAt = Date.parse(after.bootedSince as string);
+  if (bootedAt < Date.parse(deploy.startedAt)) {
+    return null;
+  }
+  const duringWindow = bootedAt <= Date.parse(deploy.completedAt);
+  return hit(
+    "boot-recovery",
+    duringWindow
+      ? "Simulator rebooted during the deploy window; CoreSimulator data was preserved but the booted session did not survive."
+      : "Simulator's boot session began after the deploy completed but before capture; the pre-deploy booted session did not survive.",
+  );
 }
 
 /**
@@ -288,11 +309,9 @@ function classifySameDevice(
     return shortfall;
   }
   // After-state is fully proven; now the survival-specific checks.
-  if (rebootedDuringWindow(after, deploy)) {
-    return hit(
-      "boot-recovery",
-      "Simulator rebooted during the deploy window; CoreSimulator data was preserved but the booted session did not survive.",
-    );
+  const recovery = bootRecovery(after, deploy);
+  if (recovery) {
+    return recovery;
   }
   if (before.lifecycleState !== "booted" || !before.responsive) {
     return hit(

--- a/src/utils/iosSimulatorContinuity.ts
+++ b/src/utils/iosSimulatorContinuity.ts
@@ -161,32 +161,42 @@ function hasRequiredIdentity(snapshot: ContinuitySnapshot): boolean {
   );
 }
 
-/** True when the device's current boot session began inside the deploy window. */
-function rebootedDuringWindow(after: ContinuitySnapshot, deploy: DeploymentWindow): boolean {
-  if (!after.bootedSince) {
-    return false;
-  }
-  const bootedAt = Date.parse(after.bootedSince);
-  const windowStart = Date.parse(deploy.startedAt);
-  if (Number.isNaN(bootedAt) || Number.isNaN(windowStart)) {
-    return false;
-  }
-  return bootedAt >= windowStart;
-}
-
-/** A verdict plus its reason, or null when a rule does not apply. */
+/** A verdict plus its reason. */
 interface RuleHit {
   readonly verdict: ContinuityVerdict;
   readonly reason: string;
 }
-type ContinuityRule = (
-  before: ContinuitySnapshot,
-  after: ContinuitySnapshot,
-  deploy: DeploymentWindow,
-) => RuleHit | null;
 
 function hit(verdict: ContinuityVerdict, reason: string): RuleHit {
   return { verdict, reason };
+}
+
+/** True when the value is a non-empty, parseable ISO timestamp. */
+function isValidTimestamp(value: string | undefined): value is string {
+  return typeof value === "string" && value.length > 0 && !Number.isNaN(Date.parse(value));
+}
+
+/** True when all identity/context evidence and the deploy window are present and well-formed. */
+function evidenceComplete(
+  before: ContinuitySnapshot,
+  after: ContinuitySnapshot,
+  deploy: DeploymentWindow,
+): boolean {
+  if (!hasRequiredIdentity(before) || !hasRequiredIdentity(after)) {
+    return false;
+  }
+  // A well-formed, non-inverted deploy window is required to reason about it.
+  return (
+    isValidTimestamp(deploy.startedAt) &&
+    isValidTimestamp(deploy.completedAt) &&
+    Date.parse(deploy.startedAt) <= Date.parse(deploy.completedAt)
+  );
+}
+
+/** True when the device's current boot session began at or after the deploy window start. */
+function rebootedDuringWindow(after: ContinuitySnapshot, deploy: DeploymentWindow): boolean {
+  // Reached only after isValidTimestamp gates, so both parse.
+  return Date.parse(after.bootedSince as string) >= Date.parse(deploy.startedAt);
 }
 
 /**
@@ -203,141 +213,122 @@ function identityChanged(before: ContinuitySnapshot, after: ContinuitySnapshot):
   );
 }
 
-/** True when the pre-deploy baseline was a healthy, booted, responsive device. */
-function healthyBaseline(before: ContinuitySnapshot): boolean {
-  return before.lifecycleState === "booted" && before.responsive;
+/**
+ * Post-deploy proof shared by both the continuity and the controlled-replacement
+ * paths: whatever device is present after the deploy must be booted, responsive,
+ * reporting, and carry a valid boot-session time. Returns the first shortfall as
+ * a not-proven verdict, or null when the after-state is fully proven.
+ */
+function postStateShortfall(after: ContinuitySnapshot): RuleHit | null {
+  if (after.lifecycleState === "unknown") {
+    return hit("failed-probe", "Post-deploy simulator lifecycle state could not be determined.");
+  }
+  if (after.lifecycleState !== "booted") {
+    return hit(
+      "shutdown",
+      `Simulator is ${after.lifecycleState} after the deploy and did not recover.`,
+    );
+  }
+  if (!after.responsive) {
+    return hit(
+      "failed-probe",
+      "Simulator is booted after the deploy but did not answer a responsiveness probe.",
+    );
+  }
+  if (!isValidTimestamp(after.bootedSince)) {
+    return hit(
+      "incomplete-evidence",
+      "Boot-session time (bootedSince) is missing or invalid; the booted session cannot be proven.",
+    );
+  }
+  if (after.reportingStatus !== "reporting") {
+    return hit("reporting-delay", `Worker reporting is ${after.reportingStatus} after the deploy.`);
+  }
+  return null;
+}
+
+/** Classify an explicit, controlled replacement: idle old device, same host, replacement fully up. */
+function classifyReplacement(before: ContinuitySnapshot, after: ContinuitySnapshot): RuleHit {
+  if (before.activeWork) {
+    return hit(
+      "orphaned-or-erased-state",
+      "Declared controlled replacement but the simulator had active work (lease/execution/drain); replacement must operate on an idle device.",
+    );
+  }
+  if (before.hostIdentity !== after.hostIdentity) {
+    return hit(
+      "orphaned-or-erased-state",
+      "Declared controlled replacement but the before/after evidence is from different hosts; a replacement must stay on the same managed host.",
+    );
+  }
+  const shortfall = postStateShortfall(after);
+  if (shortfall) {
+    return shortfall;
+  }
+  return hit(
+    "controlled-replacement",
+    "Explicit controlled replacement; the replacement simulator is booted, responsive, and reporting on the same host.",
+  );
+}
+
+/** Classify a non-replacement deploy: the same device must have survived intact. */
+function classifySameDevice(
+  before: ContinuitySnapshot,
+  after: ContinuitySnapshot,
+  deploy: DeploymentWindow,
+): RuleHit {
+  if (identityChanged(before, after)) {
+    return hit(
+      "orphaned-or-erased-state",
+      "Simulator UDID, CoreSimulator data root, or host identity changed without a declared controlled replacement.",
+    );
+  }
+  const shortfall = postStateShortfall(after);
+  if (shortfall) {
+    return shortfall;
+  }
+  // After-state is fully proven; now the survival-specific checks.
+  if (rebootedDuringWindow(after, deploy)) {
+    return hit(
+      "boot-recovery",
+      "Simulator rebooted during the deploy window; CoreSimulator data was preserved but the booted session did not survive.",
+    );
+  }
+  if (before.lifecycleState !== "booted" || !before.responsive) {
+    return hit(
+      "incomplete-evidence",
+      "Pre-deploy baseline was not a booted, responsive simulator; continuity of a healthy device cannot be proven.",
+    );
+  }
+  return hit(
+    "same-device-continuity",
+    "Same UDID, data root, and host; booted and responsive throughout, worker reporting restored.",
+  );
 }
 
 /**
- * Ordered rules, from "cannot tell" to "clean continuity". The first rule that
- * fires wins, so an earlier, more serious finding takes precedence: incomplete
- * evidence and failed probes short-circuit before any continuity claim, and an
- * unexplained identity/data change is flagged as orphaned state (the AC3 guard)
- * rather than silently accepted. If no rule fires it is same-device continuity.
- */
-const CONTINUITY_RULES: readonly ContinuityRule[] = [
-  // 1. Incomplete evidence — required identity/context missing on either side.
-  (before, after) =>
-    hasRequiredIdentity(before) && hasRequiredIdentity(after)
-      ? null
-      : hit(
-          "incomplete-evidence",
-          "Required identity/context evidence is missing before or after the deploy.",
-        ),
-  // 2. Failed probe — the post-deploy device-state probe was indeterminate.
-  (_before, after) =>
-    after.lifecycleState === "unknown"
-      ? hit("failed-probe", "Post-deploy simulator lifecycle state could not be determined.")
-      : null,
-  // 3. Explicit, controlled replacement — the only case where a changed identity
-  //    or data root is acceptable, and only if the new device is actually up.
-  //    A replacement must operate on an *idle* device: replacing one that had an
-  //    active lease/execution/drain destroys that in-flight state, so it is
-  //    flagged as orphaned/erased rather than certified as controlled.
-  (before, after, deploy) => {
-    if (!deploy.plannedReplacement) {
-      return null;
-    }
-    if (before.activeWork) {
-      return hit(
-        "orphaned-or-erased-state",
-        "Deploy was declared a controlled replacement but the simulator had active work (lease/execution/drain); replacement must operate on an idle device.",
-      );
-    }
-    return after.lifecycleState === "booted" && after.responsive
-      ? hit(
-          "controlled-replacement",
-          "Deploy was an explicit controlled replacement; the replacement simulator is booted and responsive.",
-        )
-      : hit(
-          "failed-probe",
-          "Deploy was declared a controlled replacement but the replacement simulator is not booted and responsive.",
-        );
-  },
-  // 4. Orphaned/erased state — identity, CoreSimulator data, or host changed
-  //    with no planned replacement to explain it. This is the AC3 guard.
-  (before, after) =>
-    identityChanged(before, after)
-      ? hit(
-          "orphaned-or-erased-state",
-          "Simulator UDID, CoreSimulator data root, or host identity changed without a declared controlled replacement.",
-        )
-      : null,
-  // From here the UDID and data root are unchanged.
-  // 5. Shutdown — the same device is no longer booted.
-  (_before, after) =>
-    after.lifecycleState !== "booted"
-      ? hit(
-          "shutdown",
-          `Simulator is ${after.lifecycleState} after the deploy and did not recover.`,
-        )
-      : null,
-  // 6. Failed probe — booted but responsiveness could not be proven.
-  (_before, after) =>
-    after.responsive
-      ? null
-      : hit(
-          "failed-probe",
-          "Simulator is booted after the deploy but did not answer a responsiveness probe.",
-        ),
-  // 7. Boot recovery — same identity and data, but it rebooted mid-window, so
-  //    the running simulator did not survive even though its data did.
-  (_before, after, deploy) =>
-    rebootedDuringWindow(after, deploy)
-      ? hit(
-          "boot-recovery",
-          "Simulator rebooted during the deploy window; CoreSimulator data was preserved but the booted session did not survive.",
-        )
-      : null,
-  // 8. Reporting delay/loss — device is continuous but the worker is not
-  //    reporting for it. A restarted worker must not read as leaseable.
-  (_before, after) =>
-    after.reportingStatus === "reporting"
-      ? null
-      : hit(
-          "reporting-delay",
-          `Simulator is continuous but worker reporting is ${after.reportingStatus}.`,
-        ),
-  // 9. Provability guards for the clean-continuity claim. Same-device-continuity
-  //    asserts "booted and responsive throughout", so the pre-deploy baseline
-  //    must itself have been healthy — an unhealthy `before` cannot prove a
-  //    healthy device was preserved.
-  (before) =>
-    healthyBaseline(before)
-      ? null
-      : hit(
-          "incomplete-evidence",
-          "Pre-deploy baseline was not a booted, responsive simulator; continuity of a healthy device cannot be proven.",
-        ),
-  // 10. Boot-session time is required to rule out a reboot during the window; a
-  //     rollout that cannot prove the booted session survived is not proven.
-  (_before, after) =>
-    after.bootedSince
-      ? null
-      : hit(
-          "incomplete-evidence",
-          "Boot-session time (bootedSince) is required to prove the running simulator survived; without it a reboot cannot be ruled out.",
-        ),
-];
-
-/**
- * Classify what happened to one managed simulator across a deploy window by
- * running the ordered {@link CONTINUITY_RULES}; the first rule that fires wins.
+ * Classify what happened to one managed simulator across a deploy window.
+ *
+ * Both a controlled replacement and a same-device survival must clear the same
+ * post-deploy proof ({@link postStateShortfall} — booted, responsive, reporting,
+ * valid boot time); they differ only in what a legitimate identity change means
+ * and whether the running session had to survive. Incomplete or malformed
+ * evidence short-circuits before any continuity claim.
  */
 export function classifyContinuity(
   before: ContinuitySnapshot,
   after: ContinuitySnapshot,
   deploy: DeploymentWindow,
 ): ContinuityResult {
-  for (const rule of CONTINUITY_RULES) {
-    const fired = rule(before, after, deploy);
-    if (fired) {
-      return result(fired.verdict, [fired.reason]);
-    }
+  if (!evidenceComplete(before, after, deploy)) {
+    return result("incomplete-evidence", [
+      "Required identity/context evidence is missing, or the deploy window timestamps are absent, malformed, or inverted.",
+    ]);
   }
-  return result("same-device-continuity", [
-    "Same UDID and CoreSimulator data root, booted and responsive throughout, worker reporting restored.",
-  ]);
+  const fired = deploy.plannedReplacement
+    ? classifyReplacement(before, after)
+    : classifySameDevice(before, after, deploy);
+  return result(fired.verdict, [fired.reason]);
 }
 
 function result(verdict: ContinuityVerdict, reasons: readonly string[]): ContinuityResult {

--- a/src/utils/iosSimulatorContinuity.ts
+++ b/src/utils/iosSimulatorContinuity.ts
@@ -1,0 +1,362 @@
+import { createHash } from "node:crypto";
+import { redactHomeDir } from "./redactPath";
+
+/**
+ * macOS host contract for managed iOS simulator continuity (issue #5104).
+ *
+ * These are the pure decision functions behind the deployment-continuity
+ * validation: given the evidence captured for one managed simulator before and
+ * after a worker/AutoMobile rollout, classify what actually happened and decide
+ * whether continuity was *proven* (and therefore whether the deploy gate should
+ * pass). "A successful inventory listing alone is not continuity evidence" — so
+ * identity, boot state, responsiveness, reporting, and the CoreSimulator data
+ * root are all weighed, not just presence in a device list.
+ *
+ * The capture side (shelling to `simctl`, reading host identity, etc.) lives in
+ * the runbook and the CLI that wraps these functions; keeping the classifier
+ * pure is what lets it be unit-tested deterministically and run in CI.
+ */
+
+/** Lifecycle state of a managed simulator at a point in time. */
+export type SimulatorLifecycleState =
+  | "booted"
+  | "shutdown"
+  | "booting"
+  | "shutting-down"
+  | "unknown";
+
+/** Whether AutoMobile/worker reporting was observed for the device. */
+export type ReportingStatus = "reporting" | "delayed" | "lost" | "unknown";
+
+/**
+ * A point-in-time capture of one managed simulator plus the host/worker context
+ * needed to prove continuity. Every field in the issue's "Required Pre/Post
+ * Deploy Evidence" list is represented so the same shape is captured before and
+ * after a deploy.
+ */
+export interface ContinuitySnapshot {
+  /** Simulator UDID (the 8-4-4-4-12 CoreSimulator identity). */
+  readonly udid: string;
+  /** Runtime + device type, e.g. "iOS 17.5 / iPhone 15". */
+  readonly runtimeDeviceType: string;
+  /** Managed host identity (hostname or stable host id). */
+  readonly hostIdentity: string;
+  /** AutoMobile package/version, e.g. "@kaeawc/auto-mobile@0.0.45". */
+  readonly automobileVersion: string;
+  /** Worker incarnation id — changes when the worker process is replaced. */
+  readonly workerIncarnation: string;
+  /** Process supervisor, e.g. "launchd". */
+  readonly processSupervisor: string;
+  /** Relevant process identifiers (daemon, runner, CoreSimulator service...). */
+  readonly processIds: Readonly<Record<string, number>>;
+  /** CoreSimulator data root / stable storage identity for this device. */
+  readonly coreSimulatorDataRoot: string;
+  /**
+   * ISO timestamp of when the *current* boot session began. If this falls
+   * inside the deploy window the running simulator did not survive even when the
+   * UDID and data root did — that is boot recovery, not continuity. Optional
+   * because not every host can report it; when absent a reboot cannot be proven.
+   */
+  readonly bootedSince?: string;
+  /** Simulator lifecycle state. */
+  readonly lifecycleState: SimulatorLifecycleState;
+  /** Whether the simulator answered a responsiveness probe. */
+  readonly responsive: boolean;
+  /** AutoMobile/worker reporting status. */
+  readonly reportingStatus: ReportingStatus;
+  /** Whether an active lease, execution, or drain was present. */
+  readonly activeWork: boolean;
+}
+
+/** The deployment window the evidence brackets. */
+export interface DeploymentWindow {
+  /** ISO timestamp the deploy started. */
+  readonly startedAt: string;
+  /** ISO timestamp the deploy completed. */
+  readonly completedAt: string;
+  /**
+   * The operator declared this deploy an intentional, controlled replacement of
+   * this device. A new UDID / data root is only acceptable continuity when this
+   * is set — otherwise a changed identity is treated as orphaned/erased state.
+   */
+  readonly plannedReplacement?: boolean;
+}
+
+/** The distinguished continuity outcomes (issue #5104, AC5). */
+export type ContinuityVerdict =
+  | "same-device-continuity"
+  | "controlled-replacement"
+  | "boot-recovery"
+  | "shutdown"
+  | "reporting-delay"
+  | "orphaned-or-erased-state"
+  | "failed-probe"
+  | "incomplete-evidence";
+
+/** Whether the recommended post-deploy state is leaseable or held out. */
+export type RecommendedState = "available" | "maintenance";
+
+/** The outcome of classifying one before/after pair. */
+export interface ContinuityResult {
+  readonly verdict: ContinuityVerdict;
+  /** True only when acceptable continuity is *proven*. */
+  readonly proven: boolean;
+  /** What the device should be marked as until fresh evidence exists. */
+  readonly recommendedState: RecommendedState;
+  /** Human-readable reasons behind the verdict. */
+  readonly reasons: readonly string[];
+}
+
+/** A full evidence record for one managed simulator across a deploy. */
+export interface ContinuityEvidence {
+  readonly before: ContinuitySnapshot;
+  readonly after: ContinuitySnapshot;
+  readonly deploy: DeploymentWindow;
+  /** Optional attached classification result. */
+  readonly result?: ContinuityResult;
+}
+
+/**
+ * A snapshot with sensitive fields replaced by one-way tokens. The token fields
+ * are strings (not the raw UDID/host/PIDs) because that is what redaction
+ * produces; keeping a distinct type avoids pretending a token is still a PID.
+ */
+export interface RedactedContinuitySnapshot extends Omit<
+  ContinuitySnapshot,
+  "udid" | "hostIdentity" | "workerIncarnation" | "coreSimulatorDataRoot" | "processIds"
+> {
+  readonly udid: string;
+  readonly hostIdentity: string;
+  readonly workerIncarnation: string;
+  readonly coreSimulatorDataRoot: string;
+  readonly processIds: Readonly<Record<string, string>>;
+}
+
+/** A redacted evidence record safe to retain or share. */
+export interface RedactedContinuityEvidence {
+  readonly before: RedactedContinuitySnapshot;
+  readonly after: RedactedContinuitySnapshot;
+  readonly deploy: DeploymentWindow;
+  readonly result?: ContinuityResult;
+}
+
+/** Verdicts that count as acceptable, proven continuity. */
+const PROVEN_VERDICTS: ReadonlySet<ContinuityVerdict> = new Set<ContinuityVerdict>([
+  "same-device-continuity",
+  "controlled-replacement",
+]);
+
+/** Identity/context fields that must be present for evidence to be usable. */
+function hasRequiredIdentity(snapshot: ContinuitySnapshot): boolean {
+  return (
+    snapshot.udid.trim().length > 0 &&
+    snapshot.runtimeDeviceType.trim().length > 0 &&
+    snapshot.hostIdentity.trim().length > 0 &&
+    snapshot.automobileVersion.trim().length > 0 &&
+    snapshot.workerIncarnation.trim().length > 0 &&
+    snapshot.processSupervisor.trim().length > 0 &&
+    snapshot.coreSimulatorDataRoot.trim().length > 0 &&
+    snapshot.reportingStatus !== "unknown"
+  );
+}
+
+/** True when the device's current boot session began inside the deploy window. */
+function rebootedDuringWindow(after: ContinuitySnapshot, deploy: DeploymentWindow): boolean {
+  if (!after.bootedSince) {
+    return false;
+  }
+  const bootedAt = Date.parse(after.bootedSince);
+  const windowStart = Date.parse(deploy.startedAt);
+  if (Number.isNaN(bootedAt) || Number.isNaN(windowStart)) {
+    return false;
+  }
+  return bootedAt >= windowStart;
+}
+
+/** A verdict plus its reason, or null when a rule does not apply. */
+interface RuleHit {
+  readonly verdict: ContinuityVerdict;
+  readonly reason: string;
+}
+type ContinuityRule = (
+  before: ContinuitySnapshot,
+  after: ContinuitySnapshot,
+  deploy: DeploymentWindow,
+) => RuleHit | null;
+
+function hit(verdict: ContinuityVerdict, reason: string): RuleHit {
+  return { verdict, reason };
+}
+
+/** True when the after-snapshot identity or CoreSimulator data root changed. */
+function identityChanged(before: ContinuitySnapshot, after: ContinuitySnapshot): boolean {
+  return after.udid !== before.udid || after.coreSimulatorDataRoot !== before.coreSimulatorDataRoot;
+}
+
+/**
+ * Ordered rules, from "cannot tell" to "clean continuity". The first rule that
+ * fires wins, so an earlier, more serious finding takes precedence: incomplete
+ * evidence and failed probes short-circuit before any continuity claim, and an
+ * unexplained identity/data change is flagged as orphaned state (the AC3 guard)
+ * rather than silently accepted. If no rule fires it is same-device continuity.
+ */
+const CONTINUITY_RULES: readonly ContinuityRule[] = [
+  // 1. Incomplete evidence — required identity/context missing on either side.
+  (before, after) =>
+    hasRequiredIdentity(before) && hasRequiredIdentity(after)
+      ? null
+      : hit(
+          "incomplete-evidence",
+          "Required identity/context evidence is missing before or after the deploy.",
+        ),
+  // 2. Failed probe — the post-deploy device-state probe was indeterminate.
+  (_before, after) =>
+    after.lifecycleState === "unknown"
+      ? hit("failed-probe", "Post-deploy simulator lifecycle state could not be determined.")
+      : null,
+  // 3. Explicit, controlled replacement — the only case where a changed identity
+  //    or data root is acceptable, and only if the new device is actually up.
+  (_before, after, deploy) => {
+    if (!deploy.plannedReplacement) {
+      return null;
+    }
+    return after.lifecycleState === "booted" && after.responsive
+      ? hit(
+          "controlled-replacement",
+          "Deploy was an explicit controlled replacement; the replacement simulator is booted and responsive.",
+        )
+      : hit(
+          "failed-probe",
+          "Deploy was declared a controlled replacement but the replacement simulator is not booted and responsive.",
+        );
+  },
+  // 4. Orphaned/erased state — identity or CoreSimulator data changed with no
+  //    planned replacement to explain it. This is the AC3 guard.
+  (before, after) =>
+    identityChanged(before, after)
+      ? hit(
+          "orphaned-or-erased-state",
+          "Simulator UDID or CoreSimulator data root changed without a declared controlled replacement.",
+        )
+      : null,
+  // From here the UDID and data root are unchanged.
+  // 5. Shutdown — the same device is no longer booted.
+  (_before, after) =>
+    after.lifecycleState !== "booted"
+      ? hit(
+          "shutdown",
+          `Simulator is ${after.lifecycleState} after the deploy and did not recover.`,
+        )
+      : null,
+  // 6. Failed probe — booted but responsiveness could not be proven.
+  (_before, after) =>
+    after.responsive
+      ? null
+      : hit(
+          "failed-probe",
+          "Simulator is booted after the deploy but did not answer a responsiveness probe.",
+        ),
+  // 7. Boot recovery — same identity and data, but it rebooted mid-window, so
+  //    the running simulator did not survive even though its data did.
+  (_before, after, deploy) =>
+    rebootedDuringWindow(after, deploy)
+      ? hit(
+          "boot-recovery",
+          "Simulator rebooted during the deploy window; CoreSimulator data was preserved but the booted session did not survive.",
+        )
+      : null,
+  // 8. Reporting delay/loss — device is continuous but the worker is not
+  //    reporting for it. A restarted worker must not read as leaseable.
+  (_before, after) =>
+    after.reportingStatus === "reporting"
+      ? null
+      : hit(
+          "reporting-delay",
+          `Simulator is continuous but worker reporting is ${after.reportingStatus}.`,
+        ),
+];
+
+/**
+ * Classify what happened to one managed simulator across a deploy window by
+ * running the ordered {@link CONTINUITY_RULES}; the first rule that fires wins.
+ */
+export function classifyContinuity(
+  before: ContinuitySnapshot,
+  after: ContinuitySnapshot,
+  deploy: DeploymentWindow,
+): ContinuityResult {
+  for (const rule of CONTINUITY_RULES) {
+    const fired = rule(before, after, deploy);
+    if (fired) {
+      return result(fired.verdict, [fired.reason]);
+    }
+  }
+  return result("same-device-continuity", [
+    "Same UDID and CoreSimulator data root, booted and responsive throughout, worker reporting restored.",
+  ]);
+}
+
+function result(verdict: ContinuityVerdict, reasons: readonly string[]): ContinuityResult {
+  const proven = PROVEN_VERDICTS.has(verdict);
+  return { verdict, proven, recommendedState: proven ? "available" : "maintenance", reasons };
+}
+
+/**
+ * Process exit code for the deploy gate: 0 only when continuity is proven,
+ * non-zero otherwise so a rollout that cannot prove continuity fails loudly.
+ */
+export function continuityExitCode(result: ContinuityResult): number {
+  return result.proven ? 0 : 1;
+}
+
+// A fixed salt so redaction tokens are deterministic within and across runs
+// (needed to compare retained evidence) while still not being the raw value.
+const REDACTION_SALT = "auto-mobile:ios-continuity:v1";
+
+/** One-way, correlation-preserving token for a sensitive value. */
+function token(prefix: string, value: string): string {
+  const digest = createHash("sha256")
+    .update(`${REDACTION_SALT}:${value}`)
+    .digest("hex")
+    .slice(0, 12);
+  return `${prefix}:${digest}`;
+}
+
+function redactSnapshot(snapshot: ContinuitySnapshot): RedactedContinuitySnapshot {
+  const redactedPids: Record<string, string> = {};
+  for (const [name, pid] of Object.entries(snapshot.processIds)) {
+    // PIDs are not exposed; keep per-process correlation via a stable token.
+    redactedPids[name] = token("pid", String(pid));
+  }
+  return {
+    ...snapshot,
+    udid: token("sim", snapshot.udid),
+    hostIdentity: token("host", snapshot.hostIdentity),
+    workerIncarnation: token("worker", snapshot.workerIncarnation),
+    // The data root embeds the UDID and a home prefix; tokenize the whole path.
+    coreSimulatorDataRoot: token("dataroot", snapshot.coreSimulatorDataRoot),
+    processIds: redactedPids,
+  };
+}
+
+/**
+ * Produce a redacted copy of an evidence record safe to retain with a
+ * deployment record or share in a public issue (issue #5104, AC7). Host names,
+ * UDIDs, PIDs, and home-dir paths are replaced with deterministic one-way tokens
+ * that preserve equality — so a reader can still tell "same device before and
+ * after" or "the worker was replaced" — without exposing the raw values. The
+ * non-sensitive fields (runtime/device type, version, lifecycle, reporting,
+ * timestamps) are kept verbatim so the evidence stays readable.
+ */
+export function redactContinuityEvidence(evidence: ContinuityEvidence): RedactedContinuityEvidence {
+  // redactHomeDir is applied first for any residual path leakage in reasons.
+  const redactedResult = evidence.result
+    ? { ...evidence.result, reasons: evidence.result.reasons.map((r) => redactHomeDir(r)) }
+    : undefined;
+  return {
+    before: redactSnapshot(evidence.before),
+    after: redactSnapshot(evidence.after),
+    deploy: evidence.deploy,
+    ...(redactedResult ? { result: redactedResult } : {}),
+  };
+}

--- a/test/utils/iosSimulatorContinuity.test.ts
+++ b/test/utils/iosSimulatorContinuity.test.ts
@@ -1,0 +1,222 @@
+import { describe, it, expect } from "bun:test";
+import {
+  classifyContinuity,
+  continuityExitCode,
+  redactContinuityEvidence,
+  type ContinuitySnapshot,
+  type DeploymentWindow,
+  type ContinuityEvidence,
+} from "../../src/utils/iosSimulatorContinuity";
+
+// A deploy window used across tests. The simulator that was booted *before*
+// this window began is what continuity has to preserve.
+const DEPLOY: DeploymentWindow = {
+  startedAt: "2026-08-07T10:00:00.000Z",
+  completedAt: "2026-08-07T10:05:00.000Z",
+};
+
+// A fully-populated, healthy snapshot. Tests clone-and-tweak this so each case
+// isolates the one field that drives its verdict.
+function snapshot(overrides: Partial<ContinuitySnapshot> = {}): ContinuitySnapshot {
+  return {
+    udid: "AAAAAAAA-BBBB-CCCC-DDDD-EEEEEEEEEEEE",
+    runtimeDeviceType: "iOS 17.5 / iPhone 15",
+    hostIdentity: "mac-worker-07.internal",
+    automobileVersion: "@kaeawc/auto-mobile@0.0.45",
+    workerIncarnation: "worker-incarnation-1",
+    processSupervisor: "launchd",
+    processIds: { daemon: 4201, runner: 4310, coreSimulatorService: 512 },
+    coreSimulatorDataRoot:
+      "/Users/ci/Library/Developer/CoreSimulator/Devices/AAAAAAAA-BBBB-CCCC-DDDD-EEEEEEEEEEEE/data",
+    // Booted an hour before the deploy window opened — i.e. it survived.
+    bootedSince: "2026-08-07T09:00:00.000Z",
+    lifecycleState: "booted",
+    responsive: true,
+    reportingStatus: "reporting",
+    activeWork: false,
+    ...overrides,
+  };
+}
+
+describe("classifyContinuity — distinguishes the required states (AC5)", () => {
+  it("same UDID + same data + booted+responsive+reporting throughout → same-device-continuity", () => {
+    const result = classifyContinuity(snapshot(), snapshot(), DEPLOY);
+    expect(result.verdict).toBe("same-device-continuity");
+    expect(result.proven).toBe(true);
+    expect(result.recommendedState).toBe("available");
+  });
+
+  it("explicit planned replacement with a new, healthy device → controlled-replacement", () => {
+    const before = snapshot();
+    const after = snapshot({
+      udid: "11111111-2222-3333-4444-555555555555",
+      coreSimulatorDataRoot:
+        "/Users/ci/Library/Developer/CoreSimulator/Devices/11111111-2222-3333-4444-555555555555/data",
+      bootedSince: "2026-08-07T10:04:00.000Z",
+    });
+    const result = classifyContinuity(before, after, { ...DEPLOY, plannedReplacement: true });
+    expect(result.verdict).toBe("controlled-replacement");
+    expect(result.proven).toBe(true);
+    expect(result.recommendedState).toBe("available");
+  });
+
+  it("same device but shut down and not recovered → shutdown", () => {
+    const result = classifyContinuity(
+      snapshot(),
+      snapshot({ lifecycleState: "shutdown", responsive: false }),
+      DEPLOY,
+    );
+    expect(result.verdict).toBe("shutdown");
+    expect(result.proven).toBe(false);
+    expect(result.recommendedState).toBe("maintenance");
+  });
+
+  it("same UDID + same data but rebooted during the window → boot-recovery", () => {
+    // Booted timestamp falls inside the deploy window: the running sim did not
+    // survive even though its data did.
+    const after = snapshot({ bootedSince: "2026-08-07T10:02:00.000Z" });
+    const result = classifyContinuity(snapshot(), after, DEPLOY);
+    expect(result.verdict).toBe("boot-recovery");
+    expect(result.proven).toBe(false);
+    expect(result.recommendedState).toBe("maintenance");
+  });
+
+  it("device continuous but worker reporting lost → reporting-delay", () => {
+    const result = classifyContinuity(snapshot(), snapshot({ reportingStatus: "lost" }), DEPLOY);
+    expect(result.verdict).toBe("reporting-delay");
+    expect(result.proven).toBe(false);
+    expect(result.recommendedState).toBe("maintenance");
+  });
+
+  it("device continuous but worker reporting delayed → reporting-delay", () => {
+    const result = classifyContinuity(snapshot(), snapshot({ reportingStatus: "delayed" }), DEPLOY);
+    expect(result.verdict).toBe("reporting-delay");
+    expect(result.proven).toBe(false);
+  });
+
+  it("a probe that could not determine device state → failed-probe", () => {
+    const result = classifyContinuity(snapshot(), snapshot({ lifecycleState: "unknown" }), DEPLOY);
+    expect(result.verdict).toBe("failed-probe");
+    expect(result.proven).toBe(false);
+    expect(result.recommendedState).toBe("maintenance");
+  });
+
+  it("booted but unresponsive after → failed-probe (responsiveness not proven)", () => {
+    const result = classifyContinuity(snapshot(), snapshot({ responsive: false }), DEPLOY);
+    expect(result.verdict).toBe("failed-probe");
+    expect(result.proven).toBe(false);
+  });
+
+  it("missing required identity/context fields → incomplete-evidence", () => {
+    const result = classifyContinuity(snapshot(), snapshot({ coreSimulatorDataRoot: "" }), DEPLOY);
+    expect(result.verdict).toBe("incomplete-evidence");
+    expect(result.proven).toBe(false);
+    expect(result.recommendedState).toBe("maintenance");
+  });
+});
+
+describe("classifyContinuity — cannot silently erase/orphan managed state (AC3)", () => {
+  it("UDID vanished/changed without a planned replacement → orphaned-or-erased-state", () => {
+    const after = snapshot({
+      udid: "99999999-8888-7777-6666-555555555555",
+      coreSimulatorDataRoot:
+        "/Users/ci/Library/Developer/CoreSimulator/Devices/99999999-8888-7777-6666-555555555555/data",
+    });
+    const result = classifyContinuity(snapshot(), after, DEPLOY);
+    expect(result.verdict).toBe("orphaned-or-erased-state");
+    expect(result.proven).toBe(false);
+    expect(result.recommendedState).toBe("maintenance");
+  });
+
+  it("CoreSimulator data root changed under the same UDID (erased/relocated) → orphaned-or-erased-state", () => {
+    const after = snapshot({
+      coreSimulatorDataRoot: "/private/tmp/ephemeral-extract/CoreSimulator/Devices/x/data",
+    });
+    const result = classifyContinuity(snapshot(), after, DEPLOY);
+    expect(result.verdict).toBe("orphaned-or-erased-state");
+    expect(result.proven).toBe(false);
+  });
+
+  it("a data-root change IS allowed when the deploy is an explicit planned replacement", () => {
+    const after = snapshot({
+      udid: "11111111-2222-3333-4444-555555555555",
+      coreSimulatorDataRoot:
+        "/Users/ci/Library/Developer/CoreSimulator/Devices/11111111-2222-3333-4444-555555555555/data",
+    });
+    const result = classifyContinuity(snapshot(), after, { ...DEPLOY, plannedReplacement: true });
+    expect(result.verdict).toBe("controlled-replacement");
+  });
+});
+
+describe("continuityExitCode — gate exits non-zero unless continuity is proven", () => {
+  it("returns 0 only for proven outcomes", () => {
+    expect(continuityExitCode(classifyContinuity(snapshot(), snapshot(), DEPLOY))).toBe(0);
+  });
+
+  it("returns non-zero when continuity is not proven", () => {
+    const shutdown = classifyContinuity(
+      snapshot(),
+      snapshot({ lifecycleState: "shutdown", responsive: false }),
+      DEPLOY,
+    );
+    expect(continuityExitCode(shutdown)).not.toBe(0);
+  });
+});
+
+describe("redactContinuityEvidence — retains a shareable, redacted result (AC7)", () => {
+  const evidence: ContinuityEvidence = {
+    before: snapshot(),
+    after: snapshot(),
+    deploy: DEPLOY,
+  };
+
+  it("removes host identity, UDIDs, PIDs, and home-dir paths from the shared artifact", () => {
+    const redacted = redactContinuityEvidence(evidence);
+    const serialized = JSON.stringify(redacted);
+
+    expect(serialized).not.toContain("mac-worker-07.internal");
+    expect(serialized).not.toContain("AAAAAAAA-BBBB-CCCC-DDDD-EEEEEEEEEEEE");
+    expect(serialized).not.toContain("/Users/ci");
+    expect(serialized).not.toContain("4201");
+    expect(serialized).not.toContain("4310");
+  });
+
+  it("keeps the non-sensitive fields needed to read the evidence", () => {
+    const redacted = redactContinuityEvidence(evidence);
+    expect(redacted.after.runtimeDeviceType).toBe("iOS 17.5 / iPhone 15");
+    expect(redacted.after.automobileVersion).toBe("@kaeawc/auto-mobile@0.0.45");
+    expect(redacted.after.lifecycleState).toBe("booted");
+    expect(redacted.after.reportingStatus).toBe("reporting");
+    expect(redacted.deploy.startedAt).toBe(DEPLOY.startedAt);
+  });
+
+  it("is deterministic and preserves same-device correlation across before/after", () => {
+    const a = redactContinuityEvidence(evidence);
+    const b = redactContinuityEvidence(evidence);
+    // Deterministic: same input → identical redacted output.
+    expect(JSON.stringify(a)).toBe(JSON.stringify(b));
+    // Correlation preserved: identical raw UDID before/after → identical token,
+    // so a reader can still tell it was the same device.
+    expect(a.before.udid).toBe(a.after.udid);
+  });
+
+  it("maps a changed UDID to a different token (replacement stays visible)", () => {
+    const replaced: ContinuityEvidence = {
+      before: snapshot(),
+      after: snapshot({ udid: "11111111-2222-3333-4444-555555555555" }),
+      deploy: DEPLOY,
+    };
+    const redacted = redactContinuityEvidence(replaced);
+    expect(redacted.before.udid).not.toBe(redacted.after.udid);
+  });
+
+  it("carries the classification result when one is attached", () => {
+    const withResult: ContinuityEvidence = {
+      ...evidence,
+      result: classifyContinuity(evidence.before, evidence.after, evidence.deploy),
+    };
+    const redacted = redactContinuityEvidence(withResult);
+    expect(redacted.result?.verdict).toBe("same-device-continuity");
+    expect(redacted.result?.proven).toBe(true);
+  });
+});

--- a/test/utils/iosSimulatorContinuity.test.ts
+++ b/test/utils/iosSimulatorContinuity.test.ts
@@ -248,6 +248,27 @@ describe("classifyContinuity — malformed evidence and windows are not proven",
     expect(result.verdict).toBe("incomplete-evidence");
     expect(result.proven).toBe(false);
   });
+
+  it("non-ISO timestamps that Date.parse would accept (e.g. '0') → incomplete-evidence", () => {
+    const result = classifyContinuity(
+      snapshot({ bootedSince: "0" }),
+      snapshot({ bootedSince: "1" }),
+      {
+        startedAt: "1",
+        completedAt: "2",
+      },
+    );
+    expect(result.verdict).toBe("incomplete-evidence");
+    expect(result.proven).toBe(false);
+  });
+
+  it("a reboot after the deploy completed (before capture) is still not proven → boot-recovery", () => {
+    // Window is 10:00–10:05; the boot session began at 10:06, after completion.
+    const after = snapshot({ bootedSince: "2026-08-07T10:06:00.000Z" });
+    const result = classifyContinuity(snapshot(), after, DEPLOY);
+    expect(result.verdict).toBe("boot-recovery");
+    expect(result.proven).toBe(false);
+  });
 });
 
 describe("continuityExitCode — gate exits non-zero unless continuity is proven", () => {

--- a/test/utils/iosSimulatorContinuity.test.ts
+++ b/test/utils/iosSimulatorContinuity.test.ts
@@ -81,6 +81,19 @@ describe("classifyContinuity — distinguishes the required states (AC5)", () =>
     expect(result.recommendedState).toBe("maintenance");
   });
 
+  it("a boot exactly at the window start counts as a reboot (inclusive boundary)", () => {
+    const after = snapshot({ bootedSince: DEPLOY.startedAt });
+    const result = classifyContinuity(snapshot(), after, DEPLOY);
+    expect(result.verdict).toBe("boot-recovery");
+  });
+
+  it("a boot before the window start is survival, not a reboot → same-device-continuity", () => {
+    const after = snapshot({ bootedSince: "2026-08-07T09:59:59.000Z" });
+    const result = classifyContinuity(snapshot(), after, DEPLOY);
+    expect(result.verdict).toBe("same-device-continuity");
+    expect(result.proven).toBe(true);
+  });
+
   it("device continuous but worker reporting lost → reporting-delay", () => {
     const result = classifyContinuity(snapshot(), snapshot({ reportingStatus: "lost" }), DEPLOY);
     expect(result.verdict).toBe("reporting-delay");
@@ -146,6 +159,19 @@ describe("classifyContinuity — cannot silently erase/orphan managed state (AC3
     const result = classifyContinuity(snapshot(), after, { ...DEPLOY, plannedReplacement: true });
     expect(result.verdict).toBe("controlled-replacement");
   });
+
+  it("a planned replacement of a device that had active work is NOT certified (idle-only)", () => {
+    const before = snapshot({ activeWork: true });
+    const after = snapshot({
+      udid: "11111111-2222-3333-4444-555555555555",
+      coreSimulatorDataRoot:
+        "/Users/ci/Library/Developer/CoreSimulator/Devices/11111111-2222-3333-4444-555555555555/data",
+    });
+    const result = classifyContinuity(before, after, { ...DEPLOY, plannedReplacement: true });
+    expect(result.verdict).toBe("orphaned-or-erased-state");
+    expect(result.proven).toBe(false);
+    expect(result.recommendedState).toBe("maintenance");
+  });
 });
 
 describe("continuityExitCode — gate exits non-zero unless continuity is proven", () => {
@@ -190,14 +216,23 @@ describe("redactContinuityEvidence — retains a shareable, redacted result (AC7
     expect(redacted.deploy.startedAt).toBe(DEPLOY.startedAt);
   });
 
-  it("is deterministic and preserves same-device correlation across before/after", () => {
-    const a = redactContinuityEvidence(evidence);
-    const b = redactContinuityEvidence(evidence);
-    // Deterministic: same input → identical redacted output.
+  it("preserves same-device correlation within one artifact, stable under a fixed salt", () => {
+    const salt = "fixed-test-salt";
+    const a = redactContinuityEvidence(evidence, salt);
+    const b = redactContinuityEvidence(evidence, salt);
+    // Same salt + same input → identical redacted output.
     expect(JSON.stringify(a)).toBe(JSON.stringify(b));
     // Correlation preserved: identical raw UDID before/after → identical token,
     // so a reader can still tell it was the same device.
     expect(a.before.udid).toBe(a.after.udid);
+  });
+
+  it("uses a fresh random salt per call so tokens cannot be precomputed", () => {
+    // Without an injected salt, two passes over identical input yield different
+    // tokens — defeating offline precomputation against a known salt.
+    const a = redactContinuityEvidence(evidence);
+    const b = redactContinuityEvidence(evidence);
+    expect(a.before.udid).not.toBe(b.before.udid);
   });
 
   it("maps a changed UDID to a different token (replacement stays visible)", () => {

--- a/test/utils/iosSimulatorContinuity.test.ts
+++ b/test/utils/iosSimulatorContinuity.test.ts
@@ -192,6 +192,62 @@ describe("classifyContinuity — cannot silently erase/orphan managed state (AC3
     expect(result.proven).toBe(false);
     expect(result.recommendedState).toBe("maintenance");
   });
+
+  it("a planned replacement across different hosts is NOT certified", () => {
+    const after = snapshot({
+      udid: "11111111-2222-3333-4444-555555555555",
+      hostIdentity: "mac-worker-09.internal",
+    });
+    const result = classifyContinuity(snapshot(), after, { ...DEPLOY, plannedReplacement: true });
+    expect(result.verdict).toBe("orphaned-or-erased-state");
+    expect(result.proven).toBe(false);
+  });
+
+  it("a planned replacement whose new device is not reporting is NOT certified", () => {
+    const after = snapshot({
+      udid: "11111111-2222-3333-4444-555555555555",
+      reportingStatus: "lost",
+    });
+    const result = classifyContinuity(snapshot(), after, { ...DEPLOY, plannedReplacement: true });
+    expect(result.verdict).toBe("reporting-delay");
+    expect(result.proven).toBe(false);
+  });
+
+  it("a planned replacement with no boot-session time is NOT certified", () => {
+    const after = snapshot({
+      udid: "11111111-2222-3333-4444-555555555555",
+      bootedSince: undefined,
+    });
+    const result = classifyContinuity(snapshot(), after, { ...DEPLOY, plannedReplacement: true });
+    expect(result.verdict).toBe("incomplete-evidence");
+    expect(result.proven).toBe(false);
+  });
+});
+
+describe("classifyContinuity — malformed evidence and windows are not proven", () => {
+  it("a malformed after.bootedSince → incomplete-evidence (not silently 'no reboot')", () => {
+    const result = classifyContinuity(snapshot(), snapshot({ bootedSince: "not-a-date" }), DEPLOY);
+    expect(result.verdict).toBe("incomplete-evidence");
+    expect(result.proven).toBe(false);
+  });
+
+  it("a malformed deploy window (missing/invalid timestamps) → incomplete-evidence", () => {
+    const result = classifyContinuity(snapshot(), snapshot(), {
+      startedAt: "",
+      completedAt: "",
+    });
+    expect(result.verdict).toBe("incomplete-evidence");
+    expect(result.proven).toBe(false);
+  });
+
+  it("an inverted deploy window (completed before started) → incomplete-evidence", () => {
+    const result = classifyContinuity(snapshot(), snapshot(), {
+      startedAt: "2026-08-07T10:05:00.000Z",
+      completedAt: "2026-08-07T10:00:00.000Z",
+    });
+    expect(result.verdict).toBe("incomplete-evidence");
+    expect(result.proven).toBe(false);
+  });
 });
 
 describe("continuityExitCode — gate exits non-zero unless continuity is proven", () => {

--- a/test/utils/iosSimulatorContinuity.test.ts
+++ b/test/utils/iosSimulatorContinuity.test.ts
@@ -126,6 +126,19 @@ describe("classifyContinuity — distinguishes the required states (AC5)", () =>
     expect(result.proven).toBe(false);
     expect(result.recommendedState).toBe("maintenance");
   });
+
+  it("an otherwise-clean device with no bootedSince → incomplete-evidence (reboot cannot be ruled out)", () => {
+    const result = classifyContinuity(snapshot(), snapshot({ bootedSince: undefined }), DEPLOY);
+    expect(result.verdict).toBe("incomplete-evidence");
+    expect(result.proven).toBe(false);
+  });
+
+  it("an unhealthy pre-deploy baseline (booted but unresponsive) cannot prove continuity → incomplete-evidence", () => {
+    const before = snapshot({ responsive: false });
+    const result = classifyContinuity(before, snapshot(), DEPLOY);
+    expect(result.verdict).toBe("incomplete-evidence");
+    expect(result.proven).toBe(false);
+  });
 });
 
 describe("classifyContinuity — cannot silently erase/orphan managed state (AC3)", () => {
@@ -145,6 +158,13 @@ describe("classifyContinuity — cannot silently erase/orphan managed state (AC3
     const after = snapshot({
       coreSimulatorDataRoot: "/private/tmp/ephemeral-extract/CoreSimulator/Devices/x/data",
     });
+    const result = classifyContinuity(snapshot(), after, DEPLOY);
+    expect(result.verdict).toBe("orphaned-or-erased-state");
+    expect(result.proven).toBe(false);
+  });
+
+  it("before/after captured on different hosts (same UDID) is not continuity → orphaned-or-erased-state", () => {
+    const after = snapshot({ hostIdentity: "mac-worker-09.internal" });
     const result = classifyContinuity(snapshot(), after, DEPLOY);
     expect(result.verdict).toBe("orphaned-or-erased-state");
     expect(result.proven).toBe(false);


### PR DESCRIPTION
## Summary

Defines and *proves* the macOS host contract that keeps managed iOS simulators
and their CoreSimulator data continuous across worker/AutoMobile deploys. An iOS
simulator appearing in `simctl list` after a deploy does not prove the same
process, identity, or CoreSimulator data survived — so this PR adds a documented
contract plus a pure, tested validation that classifies what actually happened
and gates the deploy on it.

## Linked Issue

Closes #5104

## Changes

- **`docs/release/ios-simulator-continuity.md`** — the contract/runbook: managed
  host & ownership boundary (with redaction placeholders — the issue's non-goals
  forbid exposing real host names/UDIDs/PIDs), the supported continuity vs
  controlled-replacement behavior, why worker/AutoMobile replacement cannot
  silently erase or orphan CoreSimulator state, the validation runbook, the
  distinguished outcomes, failure/rollback, and evidence retention/redaction.
- **`src/utils/iosSimulatorContinuity.ts`** — pure decision logic:
  - `classifyContinuity(before, after, deploy)` distinguishes
    `same-device-continuity`, `controlled-replacement`, `boot-recovery`,
    `shutdown`, `reporting-delay`, `orphaned-or-erased-state`, `failed-probe`,
    and `incomplete-evidence` (ordered rule pipeline, first match wins).
  - `redactContinuityEvidence(...)` replaces hostnames, UDIDs, PIDs and home
    paths with deterministic one-way tokens that **preserve equality** (a reader
    can still tell "same device before/after" or "worker was replaced") — safe to
    retain with a deployment record or attach to a public issue.
  - `continuityExitCode(...)` returns 0 only when continuity is proven.
- **`scripts/validate-ios-simulator-continuity.ts`** (`bun run validate:ios-continuity`)
  — thin CLI: reads before/after (+ optional deploy) evidence JSON, classifies,
  prints the redacted artifact, and **exits non-zero unless continuity is
  proven**. Exit codes: `0` proven, `1` not proven, `2` usage.

## Acceptance criteria

| AC | Where |
| --- | --- |
| 1. Host/trigger/supervisor/data-boundary/team documented | doc §1 |
| 2. Continuity / controlled-replacement documented | doc §2 |
| 3. Replacement cannot silently erase/orphan state | doc §3 (stable `~/.auto-mobile` root via `resolveAutoMobileBaseDir`, CoreSimulator data owned by macOS) + `orphaned-or-erased-state` verdict |
| 4. Repeatable validation captures the required pre/post evidence | `ContinuitySnapshot` model + CLI; classifier requires the fields |
| 5. Distinguishes continuity / replacement / shutdown / recovery / reporting delay | `classifyContinuity` — one unit test per state |
| 6. Failure/rollback leaves sim unavailable until fresh evidence | doc §6 + `recommendedState: "maintenance"` for every non-proven verdict |
| 7. Redacted validation result retained with the deploy record | `redactContinuityEvidence` + CLI `--out`; determinism/redaction tests |

## Validation

- [x] `bun test` — full suite green (12901 pass, 0 fail); 19 new unit tests <100ms, no DB
- [x] `bun run lint` — oxlint + ratchet clean (no new violations)
- [x] `bun run typecheck` — no new errors (baseline gate)
- [x] `bun run build` — ok
- [x] `oxfmt --check` on the new files; `validate_mkdocs_nav.sh`; `check:stdlib-first`
- [x] New code uses pure functions + injected values (salt/home dir); unit tests run in <100ms

## Follow-ups

The one part that cannot be done from a PR is executing the validation against a
**real production deploy** and attaching the redacted evidence to the deployment
record (the operational tail of ACs 6/7). This PR delivers the mechanism, gate,
and runbook; the real-deploy run is an operational action for the deployment
owner. Tracked as a follow-up rather than expanding this PR.
