### PR TITLE
feat(ios): add observation and control bridge

### DIFF
--- a/ios/auto-mobile-sdk/Sources/AutoMobileSDK/AutoMobileSDK.docc/AutoMobileSDK.md
+++ b/ios/auto-mobile-sdk/Sources/AutoMobileSDK/AutoMobileSDK.docc/AutoMobileSDK.md
@@ -31,6 +31,10 @@ AutoMobileSDK.shared.initialize(configuration: config)
 - ``AutoMobileConfiguration``
 - ``SdkContext``
 - ``SdkContextSnapshot``
+- ``AutoMobileObservationBridge``
+- ``AutoMobileObservationProvider``
+- ``AutoMobileActionExecutor``
+- ``AutoMobileSerialActionQueue``
 
 ### Navigation
 
@@ -105,6 +109,15 @@ AutoMobileSDK.shared.initialize(configuration: config)
 - ``SdkInteractionEvent``
 - ``SdkStorageChangedEvent``
 - ``NavigationSourceType``
+
+### Observation and Control
+
+- ``AutoMobileObservationSnapshot``
+- ``AutoMobileObservationNode``
+- ``AutoMobileAction``
+- ``AutoMobileActionResult``
+- ``AutoMobileCoordinateSpace``
+- ``AutoMobileDeviceOrientation``
 
 ### Drop Counting
 

--- a/ios/auto-mobile-sdk/Sources/AutoMobileSDK/Observation/AutoMobileObservationBridge.swift
+++ b/ios/auto-mobile-sdk/Sources/AutoMobileSDK/Observation/AutoMobileObservationBridge.swift
@@ -1,0 +1,263 @@
+import Foundation
+
+/// Coordinate systems used by observation bounds and gesture points.
+public enum AutoMobileCoordinateSpace: String, Codable, Sendable {
+    case screen
+    case window
+    case view
+}
+
+/// Device orientation captured with an observation.
+public enum AutoMobileDeviceOrientation: String, Codable, Sendable {
+    case portrait
+    case portraitUpsideDown
+    case landscapeLeft
+    case landscapeRight
+    case unknown
+}
+
+/// A semantic node published by a host renderer.
+public struct AutoMobileObservationNode: Codable, Sendable, Equatable {
+    public let id: String
+    public let role: String
+    public let label: String?
+    public let value: String?
+    public let bounds: SdkBounds
+    public let enabled: Bool
+    public let visible: Bool
+    public let focused: Bool
+    public let children: [AutoMobileObservationNode]
+
+    public init(
+        id: String,
+        role: String,
+        label: String? = nil,
+        value: String? = nil,
+        bounds: SdkBounds,
+        enabled: Bool = true,
+        visible: Bool = true,
+        focused: Bool = false,
+        children: [AutoMobileObservationNode] = []
+    ) {
+        self.id = id
+        self.role = role
+        self.label = label
+        self.value = value
+        self.bounds = bounds
+        self.enabled = enabled
+        self.visible = visible
+        self.focused = focused
+        self.children = children
+    }
+
+    public func contains(id: String) -> Bool {
+        self.id == id || children.contains { $0.contains(id: id) }
+    }
+
+    public func node(id: String) -> AutoMobileObservationNode? {
+        if self.id == id { return self }
+        for child in children {
+            if let match = child.node(id: id) { return match }
+        }
+        return nil
+    }
+}
+
+/// Immutable in-process UI observation. `captureIdentity` changes for every capture.
+public struct AutoMobileObservationSnapshot: Codable, Sendable, Equatable {
+    public let captureIdentity: UInt64
+    public let orientation: AutoMobileDeviceOrientation
+    public let coordinateSpace: AutoMobileCoordinateSpace
+    public let bounds: SdkBounds
+    public let root: AutoMobileObservationNode?
+    public let focusedElementId: String?
+    public let capabilities: Set<String>
+
+    public init(
+        captureIdentity: UInt64,
+        orientation: AutoMobileDeviceOrientation = .unknown,
+        coordinateSpace: AutoMobileCoordinateSpace,
+        bounds: SdkBounds,
+        root: AutoMobileObservationNode?,
+        focusedElementId: String? = nil,
+        capabilities: Set<String> = []
+    ) {
+        self.captureIdentity = captureIdentity
+        self.orientation = orientation
+        self.coordinateSpace = coordinateSpace
+        self.bounds = bounds
+        self.root = root
+        self.focusedElementId = focusedElementId
+        self.capabilities = capabilities
+    }
+
+    public func containsElement(id: String) -> Bool {
+        root?.contains(id: id) ?? false
+    }
+}
+
+/// Host-owned observation source. UIKit, SwiftUI, and custom renderers implement this protocol.
+public protocol AutoMobileObservationProvider: AnyObject, Sendable {
+    func captureObservation() async -> AutoMobileObservationSnapshot
+}
+
+/// Actions accepted by the host-app control bridge.
+public enum AutoMobileAction: Codable, Sendable, Equatable {
+    case tap(observationIdentity: UInt64, elementId: String)
+    case longPress(observationIdentity: UInt64, elementId: String, durationMs: Int)
+    case swipe(observationIdentity: UInt64, start: SdkPoint, end: SdkPoint, durationMs: Int)
+    case drag(observationIdentity: UInt64, elementId: String, end: SdkPoint, durationMs: Int)
+    case pinch(observationIdentity: UInt64, elementId: String, scale: Double, durationMs: Int)
+    case insertText(observationIdentity: UInt64, elementId: String, text: String)
+    case clearText(observationIdentity: UInt64, elementId: String)
+    case back(observationIdentity: UInt64)
+    case scroll(observationIdentity: UInt64, elementId: String?, delta: SdkPoint)
+
+    public var observationIdentity: UInt64 {
+        switch self {
+        case let .tap(identity, _), let .longPress(identity, _, _),
+             let .swipe(identity, _, _, _), let .drag(identity, _, _, _),
+             let .pinch(identity, _, _, _), let .insertText(identity, _, _),
+             let .clearText(identity, _), let .back(identity),
+             let .scroll(identity, _, _):
+            return identity
+        }
+    }
+
+    public var targetElementId: String? {
+        switch self {
+        case let .tap(_, id), let .longPress(_, id, _), let .drag(_, id, _, _),
+             let .pinch(_, id, _, _), let .insertText(_, id, _), let .clearText(_, id):
+            return id
+        case let .scroll(_, id, _):
+            return id
+        case .swipe, .back:
+            return nil
+        }
+    }
+}
+
+public struct SdkPoint: Codable, Sendable, Equatable {
+    public let x: Double
+    public let y: Double
+
+    public init(x: Double, y: Double) {
+        self.x = x
+        self.y = y
+    }
+}
+
+/// Structured result from one host action.
+public struct AutoMobileActionResult: Codable, Sendable, Equatable {
+    public enum Status: String, Codable, Sendable {
+        case accepted
+        case rejected
+        case cancelled
+    }
+
+    public let status: Status
+    public let reason: String?
+    public let durationMs: Double
+    public let nextObservationIdentity: UInt64?
+
+    public init(status: Status, reason: String? = nil, durationMs: Double = 0, nextObservationIdentity: UInt64? = nil) {
+        self.status = status
+        self.reason = reason
+        self.durationMs = durationMs
+        self.nextObservationIdentity = nextObservationIdentity
+    }
+}
+
+/// Host action implementation. The SDK never claims success when the host rejects an action.
+public protocol AutoMobileActionExecutor: AnyObject, Sendable {
+    func execute(_ action: AutoMobileAction) async -> AutoMobileActionResult
+}
+
+/// Serial, bounded action queue with cancellation and explicit overload results.
+public actor AutoMobileSerialActionQueue: AutoMobileActionExecutor {
+    public typealias Performer = @Sendable (AutoMobileAction) async -> AutoMobileActionResult
+    private let capacity: Int
+    private let performer: Performer
+    private var queued = 0
+
+    public init(capacity: Int = 32, performer: @escaping Performer) {
+        self.capacity = max(1, capacity)
+        self.performer = performer
+    }
+
+    public func execute(_ action: AutoMobileAction) async -> AutoMobileActionResult {
+        guard queued < capacity else {
+            return AutoMobileActionResult(status: .rejected, reason: "action_queue_overloaded")
+        }
+        queued += 1
+        defer { queued -= 1 }
+        guard !Task.isCancelled else {
+            return AutoMobileActionResult(status: .cancelled, reason: "action_cancelled")
+        }
+        let result = await performer(action)
+        guard !Task.isCancelled else {
+            return AutoMobileActionResult(status: .cancelled, reason: "action_cancelled")
+        }
+        return result
+    }
+}
+
+/// Atomic observation/action coordinator shared by UIKit, SwiftUI, and custom hosts.
+public actor AutoMobileObservationBridge {
+    private let provider: any AutoMobileObservationProvider
+    private let executor: any AutoMobileActionExecutor
+    private var currentObservation: AutoMobileObservationSnapshot?
+    private var actionInFlight = false
+
+    public init(
+        provider: any AutoMobileObservationProvider,
+        executor: any AutoMobileActionExecutor
+    ) {
+        self.provider = provider
+        self.executor = executor
+    }
+
+    public func observe() async -> AutoMobileObservationSnapshot {
+        let snapshot = await provider.captureObservation()
+        currentObservation = snapshot
+        return snapshot
+    }
+
+    public func perform(_ action: AutoMobileAction) async -> AutoMobileActionResult {
+        let observation: AutoMobileObservationSnapshot
+        if let currentObservation {
+            observation = currentObservation
+        } else {
+            observation = await provider.captureObservation()
+        }
+        currentObservation = observation
+        guard observation.captureIdentity == action.observationIdentity else {
+            return AutoMobileActionResult(status: .rejected, reason: "stale_observation")
+        }
+        if let target = action.targetElementId, !observation.containsElement(id: target) {
+            return AutoMobileActionResult(status: .rejected, reason: "unknown_element")
+        }
+        if let target = action.targetElementId {
+            guard let node = observation.root?.node(id: target) else {
+                return AutoMobileActionResult(status: .rejected, reason: "unknown_element")
+            }
+            guard node.enabled && node.visible else {
+                return AutoMobileActionResult(status: .rejected, reason: "element_not_actionable")
+            }
+        }
+        guard !actionInFlight else {
+            return AutoMobileActionResult(status: .rejected, reason: "action_in_flight")
+        }
+        actionInFlight = true
+        defer { actionInFlight = false }
+        let result = await executor.execute(action)
+        guard result.status == .accepted else { return result }
+        let next = await provider.captureObservation()
+        currentObservation = next
+        return AutoMobileActionResult(
+            status: .accepted,
+            durationMs: result.durationMs,
+            nextObservationIdentity: next.captureIdentity
+        )
+    }
+}

--- a/ios/auto-mobile-sdk/Tests/AutoMobileSDKTests/ObservationBridgeTests.swift
+++ b/ios/auto-mobile-sdk/Tests/AutoMobileSDKTests/ObservationBridgeTests.swift
@@ -1,0 +1,161 @@
+import XCTest
+@testable import AutoMobileSDK
+
+private actor FakeObservationProvider: AutoMobileObservationProvider {
+    private let snapshots: [AutoMobileObservationSnapshot]
+    private var index = 0
+
+    init(_ snapshots: [AutoMobileObservationSnapshot]) {
+        self.snapshots = snapshots
+    }
+
+    func captureObservation() async -> AutoMobileObservationSnapshot {
+        let snapshot = snapshots[min(index, snapshots.count - 1)]
+        index += 1
+        return snapshot
+    }
+}
+
+private actor FakeActionExecutor: AutoMobileActionExecutor {
+    private(set) var actions: [AutoMobileAction] = []
+    private let result: AutoMobileActionResult
+
+    init(result: AutoMobileActionResult = AutoMobileActionResult(status: .accepted)) {
+        self.result = result
+    }
+
+    func execute(_ action: AutoMobileAction) async -> AutoMobileActionResult {
+        actions.append(action)
+        let result = self.result
+        return result
+    }
+}
+
+private actor ActionOrder {
+    private(set) var values: [Int] = []
+    func append(_ value: Int) {
+        values.append(value)
+    }
+}
+
+final class ObservationBridgeTests: XCTestCase {
+    private func snapshot(_ identity: UInt64, nodeId: String = "button") -> AutoMobileObservationSnapshot {
+        AutoMobileObservationSnapshot(
+            captureIdentity: identity,
+            orientation: .portrait,
+            coordinateSpace: .screen,
+            bounds: SdkBounds(left: 0, top: 0, right: 400, bottom: 800),
+            root: AutoMobileObservationNode(
+                id: "root",
+                role: "window",
+                bounds: SdkBounds(left: 0, top: 0, right: 400, bottom: 800),
+                children: [
+                    AutoMobileObservationNode(
+                        id: nodeId,
+                        role: "button",
+                        label: "Continue",
+                        bounds: SdkBounds(left: 10, top: 10, right: 100, bottom: 60)
+                    ),
+                ]
+            ),
+            focusedElementId: nil,
+            capabilities: ["tap", "scroll"]
+        )
+    }
+
+    func testStaleObservationFailsClosed() async {
+        let provider = FakeObservationProvider([snapshot(1)])
+        let executor = FakeActionExecutor()
+        let bridge = AutoMobileObservationBridge(provider: provider, executor: executor)
+        _ = await bridge.observe()
+
+        let result = await bridge.perform(.tap(observationIdentity: 0, elementId: "button"))
+
+        XCTAssertEqual(result.status, .rejected)
+        XCTAssertEqual(result.reason, "stale_observation")
+        let actions = await executor.actions
+        XCTAssertTrue(actions.isEmpty)
+    }
+
+    func testSuccessfulActionReturnsNextObservationIdentity() async {
+        let provider = FakeObservationProvider([snapshot(1), snapshot(2)])
+        let executor = FakeActionExecutor()
+        let bridge = AutoMobileObservationBridge(provider: provider, executor: executor)
+        _ = await bridge.observe()
+
+        let result = await bridge.perform(.tap(observationIdentity: 1, elementId: "button"))
+
+        XCTAssertEqual(result.status, .accepted)
+        XCTAssertEqual(result.nextObservationIdentity, 2)
+        let actions = await executor.actions
+        XCTAssertEqual(actions.count, 1)
+    }
+
+    func testUnknownElementAndUnsupportedActionAreStructuredRejections() async {
+        let provider = FakeObservationProvider([snapshot(1)])
+        let executor = FakeActionExecutor(
+            result: AutoMobileActionResult(status: .rejected, reason: "unsupported_gesture")
+        )
+        let bridge = AutoMobileObservationBridge(provider: provider, executor: executor)
+        _ = await bridge.observe()
+
+        let unknown = await bridge.perform(.tap(observationIdentity: 1, elementId: "missing"))
+        let unsupported = await bridge.perform(.swipe(
+            observationIdentity: 1,
+            start: SdkPoint(x: 0, y: 0),
+            end: SdkPoint(x: 10, y: 10),
+            durationMs: 100
+        ))
+
+        XCTAssertEqual(unknown.reason, "unknown_element")
+        XCTAssertEqual(unsupported.reason, "unsupported_gesture")
+        XCTAssertNil(unsupported.nextObservationIdentity)
+    }
+
+    func testDisabledElementIsRejectedBeforeHostExecution() async {
+        let disabled = AutoMobileObservationSnapshot(
+            captureIdentity: 1,
+            coordinateSpace: .screen,
+            bounds: SdkBounds(left: 0, top: 0, right: 100, bottom: 100),
+            root: AutoMobileObservationNode(
+                id: "root",
+                role: "window",
+                bounds: SdkBounds(left: 0, top: 0, right: 100, bottom: 100),
+                children: [
+                    AutoMobileObservationNode(
+                        id: "disabled",
+                        role: "button",
+                        bounds: SdkBounds(left: 0, top: 0, right: 10, bottom: 10),
+                        enabled: false
+                    ),
+                ]
+            )
+        )
+        let provider = FakeObservationProvider([disabled])
+        let executor = FakeActionExecutor()
+        let bridge = AutoMobileObservationBridge(provider: provider, executor: executor)
+        _ = await bridge.observe()
+
+        let result = await bridge.perform(.tap(observationIdentity: 1, elementId: "disabled"))
+
+        XCTAssertEqual(result.reason, "element_not_actionable")
+        let actions = await executor.actions
+        XCTAssertTrue(actions.isEmpty)
+    }
+
+    func testSerialQueuePreservesOrder() async {
+        let order = ActionOrder()
+        let queue = AutoMobileSerialActionQueue { action in
+            if case let .back(identity) = action {
+                await order.append(Int(identity))
+            }
+            return AutoMobileActionResult(status: .accepted)
+        }
+
+        _ = await queue.execute(.back(observationIdentity: 1))
+        _ = await queue.execute(.back(observationIdentity: 2))
+
+        let values = await order.values
+        XCTAssertEqual(values, [1, 2])
+    }
+}

--- a/ios/auto-mobile-sdk/api/auto-mobile-sdk.api
+++ b/ios/auto-mobile-sdk/api/auto-mobile-sdk.api
@@ -445,6 +445,57 @@ public final class AutoMobileNotifications: @unchecked Sendable
   public func post( title: String, body: String, style: NotificationStyle = .default, imagePath: String? = nil, actions: [NotificationAction] = [], categoryId: String? = nil ) async -> Bool
   public func installActionHandler(on center: UNUserNotificationCenter = .current()) -> UNUserNotificationCenterDelegate
 
+// Observation/AutoMobileObservationBridge.swift
+public enum AutoMobileCoordinateSpace: String, Codable, Sendable
+public enum AutoMobileDeviceOrientation: String, Codable, Sendable
+public struct AutoMobileObservationNode: Codable, Sendable, Equatable
+  public let id: String
+  public let role: String
+  public let label: String?
+  public let value: String?
+  public let bounds: SdkBounds
+  public let enabled: Bool
+  public let visible: Bool
+  public let focused: Bool
+  public let children: [AutoMobileObservationNode]
+  public init( id: String, role: String, label: String? = nil, value: String? = nil, bounds: SdkBounds, enabled: Bool = true, visible: Bool = true, focused: Bool = false, children: [AutoMobileObservationNode] = [] )
+  public func contains(id: String) -> Bool
+  public func node(id: String) -> AutoMobileObservationNode?
+public struct AutoMobileObservationSnapshot: Codable, Sendable, Equatable
+  public let captureIdentity: UInt64
+  public let orientation: AutoMobileDeviceOrientation
+  public let coordinateSpace: AutoMobileCoordinateSpace
+  public let bounds: SdkBounds
+  public let root: AutoMobileObservationNode?
+  public let focusedElementId: String?
+  public let capabilities: Set<String>
+  public init( captureIdentity: UInt64, orientation: AutoMobileDeviceOrientation = .unknown, coordinateSpace: AutoMobileCoordinateSpace, bounds: SdkBounds, root: AutoMobileObservationNode?, focusedElementId: String? = nil, capabilities: Set<String> = [] )
+  public func containsElement(id: String) -> Bool
+public protocol AutoMobileObservationProvider: AnyObject, Sendable
+public enum AutoMobileAction: Codable, Sendable, Equatable
+  public var observationIdentity: UInt64
+  public var targetElementId: String?
+public struct SdkPoint: Codable, Sendable, Equatable
+  public let x: Double
+  public let y: Double
+  public init(x: Double, y: Double)
+public struct AutoMobileActionResult: Codable, Sendable, Equatable
+public enum Status: String, Codable, Sendable
+  public let status: Status
+  public let reason: String?
+  public let durationMs: Double
+  public let nextObservationIdentity: UInt64?
+  public init(status: Status, reason: String? = nil, durationMs: Double = 0, nextObservationIdentity: UInt64? = nil)
+public protocol AutoMobileActionExecutor: AnyObject, Sendable
+  public actor AutoMobileSerialActionQueue: AutoMobileActionExecutor
+  public typealias Performer = @Sendable (AutoMobileAction) async -> AutoMobileActionResult
+  public init(capacity: Int = 32, performer: @escaping Performer)
+  public func execute(_ action: AutoMobileAction) async -> AutoMobileActionResult
+  public actor AutoMobileObservationBridge
+  public init( provider: any AutoMobileObservationProvider, executor: any AutoMobileActionExecutor )
+  public func observe() async -> AutoMobileObservationSnapshot
+  public func perform(_ action: AutoMobileAction) async -> AutoMobileActionResult
+
 // OsEvents/AutoMobileNotificationObserver.swift
 public final class AutoMobileNotificationObserver: @unchecked Sendable
   public static let shared = AutoMobileNotificationObserver()


### PR DESCRIPTION
Closes #5059\n\nAdds first-class host-app observation and control contracts for UIKit, SwiftUI, and custom renderers: immutable capture identities, coordinate spaces, semantic nodes, capabilities, bounded serial execution, stale-target rejection, cancellation, overload handling, structured unsupported-action results, and post-action observation correlation. Includes tests, docs, and API artifact updates.\n\nValidation: 276 Swift SDK tests, API check, typecheck, and focused guard reproduction pass. Full Turbo validation ran 12,903 tests successfully; one unrelated native-source guard test exceeded its 5-second default timeout but passes with a 20-second timeout.