### PR TITLE
feat(ios): add unified navigation lifecycle adapters

### DIFF
--- a/docs/design-docs/plat/ios/auto-mobile-sdk.md
+++ b/docs/design-docs/plat/ios/auto-mobile-sdk.md
@@ -2,7 +2,7 @@
 
 <kbd>✅ Implemented</kbd> <kbd>🧪 Tested</kbd>
 
-> **Current state:** `ios/auto-mobile-sdk/` is a Swift Package providing in-app telemetry for iOS applications. Includes navigation tracking (SwiftUI adapter), crash and signal handler capture, main-thread hang detection, handled exception recording, SwiftUI view body evaluation tracking, network request/response monitoring via URLProtocol, structured logging via `os.Logger`, tap interaction tracking, UserDefaults inspection, SQLite database inspection, biometric test injection, local notification posting, and OS-level event observation. Events flow through a disk-first persistence pipeline with retry delivery to CtrlProxy. 151 unit tests across 20 test files.
+> **Current state:** `ios/auto-mobile-sdk/` is a Swift Package providing in-app telemetry for iOS applications. Includes unified, opt-in navigation adapters for SwiftUI, UIKit, deep links, and custom routers, crash and signal handler capture, main-thread hang detection, handled exception recording, SwiftUI view body evaluation tracking, network request/response monitoring via URLProtocol, structured logging via `os.Logger`, tap interaction tracking, UserDefaults inspection, SQLite database inspection, biometric test injection, local notification posting, and OS-level event observation. Events flow through a disk-first persistence pipeline with retry delivery to CtrlProxy.
 
 See the [Status Glossary](../../status-glossary.md) for chip definitions.
 
@@ -226,7 +226,7 @@ Records non-fatal handled exceptions via `recordHandledException(_:message:curre
 
 ### Event model
 
-`NavigationEvent` contains `destination`, `source` (`NavigationSource` enum: `swiftUINavigation`, `uiKitNavigation`, `deepLink`, `custom`), millisecond timestamp, string arguments, and metadata.
+`NavigationEvent` contains `destination`, stable `screenIdentity`, `source` (`NavigationSource` enum: `swiftUINavigation`, `uiKitNavigation`, `deepLink`, `custom`), optional scene and transition identifiers, completion state, millisecond timestamp, string arguments, and metadata. Hosts configure a `NavigationDataRedacting` processor through the shared adapter hub; adapters are independently enabled and never swizzle or replace host delegates.
 
 ### Listener pattern
 
@@ -238,6 +238,16 @@ Records non-fatal handled exceptions via `recordHandledException(_:message:curre
 
 - `trackNavigation(destination:arguments:metadata:)` for manual tracking
 - `.trackNavigation(destination:)` SwiftUI `ViewModifier` that fires on `onAppear`
+- `trackSheet`, `trackTab`, and `trackSplitColumn` lifecycle helpers
+
+### UIKit, deep-link, and custom adapters
+
+`UIKitNavigationAdapter` provides explicit hooks for push, pop, presentation, tab,
+and split-column completion from existing host delegates. `DeepLinkNavigationAdapter`
+and `CustomNavigationAdapter` expose the same identity, scene, argument, and metadata
+contract for URL routes, notifications, restoration, and application-owned routers.
+Interactive transitions must call the hook only after completion, so cancelled
+transitions do not create false navigation edges.
 
 ## Network Monitoring
 

--- a/ios/auto-mobile-sdk/Sources/AutoMobileSDK/AutoMobileSDK.docc/AutoMobileSDK.md
+++ b/ios/auto-mobile-sdk/Sources/AutoMobileSDK/AutoMobileSDK.docc/AutoMobileSDK.md
@@ -44,6 +44,13 @@ AutoMobileSDK.shared.initialize(configuration: config)
 - ``BlockNavigationListener``
 - ``NavigationFrameworkAdapter``
 - ``SwiftUINavigationAdapter``
+- ``UIKitNavigationAdapter``
+- ``DeepLinkNavigationAdapter``
+- ``CustomNavigationAdapter``
+- ``NavigationAdapterHub``
+- ``NavigationScreenIdentity``
+- ``NavigationDataRedacting``
+- ``NavigationEventFactory``
 - ``TrackNavigationModifier``
 
 ### Crashes

--- a/ios/auto-mobile-sdk/Sources/AutoMobileSDK/AutoMobileSDK.swift
+++ b/ios/auto-mobile-sdk/Sources/AutoMobileSDK/AutoMobileSDK.swift
@@ -223,7 +223,11 @@ public final class AutoMobileSDK: @unchecked Sendable {
             destination: event.destination,
             source: NavigationSourceType(rawValue: event.source.rawValue) ?? .custom,
             arguments: event.arguments,
-            metadata: event.metadata
+            metadata: event.metadata,
+            screenIdentity: event.screenIdentity,
+            sceneIdentifier: event.sceneIdentifier,
+            transitionIdentifier: event.transitionIdentifier,
+            transitionCompleted: event.transitionCompleted
         )
         eventBuffer?.add(sdkEvent)
         // Navigation is control-plane state for observe/diff, not bulk telemetry.

--- a/ios/auto-mobile-sdk/Sources/AutoMobileSDK/Events/SdkEvent.swift
+++ b/ios/auto-mobile-sdk/Sources/AutoMobileSDK/Events/SdkEvent.swift
@@ -44,6 +44,10 @@ public struct SdkNavigationEvent: SdkEvent {
     public let source: NavigationSourceType
     public let arguments: [String: String]
     public let metadata: [String: String]
+    public let screenIdentity: String?
+    public let sceneIdentifier: String?
+    public let transitionIdentifier: String?
+    public let transitionCompleted: Bool
 
     public init(
         timestamp: Int64 = Int64(Date().timeIntervalSince1970 * 1000),
@@ -54,7 +58,11 @@ public struct SdkNavigationEvent: SdkEvent {
         destination: String,
         source: NavigationSourceType,
         arguments: [String: String] = [:],
-        metadata: [String: String] = [:]
+        metadata: [String: String] = [:],
+        screenIdentity: String? = nil,
+        sceneIdentifier: String? = nil,
+        transitionIdentifier: String? = nil,
+        transitionCompleted: Bool = true
     ) {
         self.timestamp = timestamp
         self.sequenceNumber = sequenceNumber
@@ -65,6 +73,34 @@ public struct SdkNavigationEvent: SdkEvent {
         self.source = source
         self.arguments = arguments
         self.metadata = metadata
+        self.screenIdentity = screenIdentity
+        self.sceneIdentifier = sceneIdentifier
+        self.transitionIdentifier = transitionIdentifier
+        self.transitionCompleted = transitionCompleted
+    }
+
+    private enum CodingKeys: String, CodingKey {
+        case eventType, timestamp, sequenceNumber, sessionId, sessionEpoch, trackingGeneration
+        case destination, source, arguments, metadata, screenIdentity, sceneIdentifier
+        case transitionIdentifier, transitionCompleted
+    }
+
+    public init(from decoder: Decoder) throws {
+        let container = try decoder.container(keyedBy: CodingKeys.self)
+        timestamp = try container.decode(Int64.self, forKey: .timestamp)
+        sequenceNumber = try container.decodeIfPresent(Int64.self, forKey: .sequenceNumber)
+        sessionId = try container.decodeIfPresent(String.self, forKey: .sessionId)
+        sessionEpoch = try container.decodeIfPresent(Int64.self, forKey: .sessionEpoch)
+        trackingGeneration = try container.decodeIfPresent(Int64.self, forKey: .trackingGeneration)
+        destination = try container.decode(String.self, forKey: .destination)
+        source = try container.decode(NavigationSourceType.self, forKey: .source)
+        arguments = try container.decodeIfPresent([String: String].self, forKey: .arguments) ?? [:]
+        metadata = try container.decodeIfPresent([String: String].self, forKey: .metadata) ?? [:]
+        screenIdentity = try container.decodeIfPresent(String.self, forKey: .screenIdentity)
+        sceneIdentifier = try container.decodeIfPresent(String.self, forKey: .sceneIdentifier)
+        transitionIdentifier = try container.decodeIfPresent(String.self, forKey: .transitionIdentifier)
+        transitionCompleted = try container.decodeIfPresent(Bool.self, forKey: .transitionCompleted) ?? true
+        eventType = .navigation
     }
 }
 

--- a/ios/auto-mobile-sdk/Sources/AutoMobileSDK/Navigation/Adapters/NavigationAdapters.swift
+++ b/ios/auto-mobile-sdk/Sources/AutoMobileSDK/Navigation/Adapters/NavigationAdapters.swift
@@ -1,0 +1,164 @@
+import Foundation
+
+/// Shared opt-in event sink for adapters that must coexist with host routers.
+public final class NavigationAdapterHub: @unchecked Sendable {
+    public static let shared = NavigationAdapterHub()
+
+    private let lock = NSLock()
+    private var activeOwners: Set<String> = []
+    private var _factory = NavigationEventFactory()
+    private init() {}
+
+    public var isActive: Bool {
+        isActive(owner: nil)
+    }
+
+    public func isActive(owner: String?) -> Bool {
+        lock.lock(); defer { lock.unlock() }
+        if let owner {
+            return activeOwners.contains(owner)
+        }
+        return !activeOwners.isEmpty
+    }
+
+    public func start(owner: String = "default", redactor: any NavigationDataRedacting = NoOpNavigationRedactor()) {
+        lock.lock()
+        _factory = NavigationEventFactory(redactor: redactor)
+        activeOwners.insert(owner)
+        lock.unlock()
+    }
+
+    public func stop(owner: String = "default") {
+        lock.lock(); activeOwners.remove(owner); lock.unlock()
+    }
+
+    public func record(
+        owner: String = "default",
+        destination: String,
+        source: NavigationSource,
+        identity: NavigationScreenIdentity? = nil,
+        sceneIdentifier: String? = nil,
+        transitionIdentifier: String? = nil,
+        transitionCompleted: Bool = true,
+        arguments: [String: String] = [:],
+        metadata: [String: String] = [:]
+    ) {
+        lock.lock()
+        let active = activeOwners.contains(owner)
+        let factory = _factory
+        lock.unlock()
+        guard active, transitionCompleted else { return }
+        AutoMobileSDK.shared.notifyNavigationEvent(factory.make(
+            destination: destination,
+            source: source,
+            identity: identity,
+            sceneIdentifier: sceneIdentifier,
+            transitionIdentifier: transitionIdentifier,
+            transitionCompleted: transitionCompleted,
+            arguments: arguments,
+            metadata: metadata
+        ))
+    }
+}
+
+/// Adapter for routers, universal links, notifications, and state restoration.
+public final class DeepLinkNavigationAdapter: NavigationFrameworkAdapter, @unchecked Sendable {
+    public static let shared = DeepLinkNavigationAdapter()
+    private init() {}
+    public var isActive: Bool { NavigationAdapterHub.shared.isActive(owner: "deep_link") }
+    public func start() { NavigationAdapterHub.shared.start(owner: "deep_link") }
+    public func stop() { NavigationAdapterHub.shared.stop(owner: "deep_link") }
+
+    public func record(
+        destination: String,
+        identity: NavigationScreenIdentity? = nil,
+        sceneIdentifier: String? = nil,
+        arguments: [String: String] = [:],
+        metadata: [String: String] = [:]
+    ) {
+        NavigationAdapterHub.shared.record(
+            owner: "deep_link",
+            destination: destination, source: .deepLink, identity: identity,
+            sceneIdentifier: sceneIdentifier, arguments: arguments, metadata: metadata
+        )
+    }
+}
+
+/// Adapter for application-owned routers that do not use UIKit or SwiftUI.
+public final class CustomNavigationAdapter: NavigationFrameworkAdapter, @unchecked Sendable {
+    public static let shared = CustomNavigationAdapter()
+    private init() {}
+    public var isActive: Bool { NavigationAdapterHub.shared.isActive(owner: "custom") }
+    public func start() { NavigationAdapterHub.shared.start(owner: "custom") }
+    public func stop() { NavigationAdapterHub.shared.stop(owner: "custom") }
+
+    public func record(
+        destination: String,
+        identity: NavigationScreenIdentity? = nil,
+        sceneIdentifier: String? = nil,
+        transitionIdentifier: String? = nil,
+        transitionCompleted: Bool = true,
+        arguments: [String: String] = [:],
+        metadata: [String: String] = [:]
+    ) {
+        NavigationAdapterHub.shared.record(
+            owner: "custom",
+            destination: destination, source: .custom, identity: identity,
+            sceneIdentifier: sceneIdentifier, transitionIdentifier: transitionIdentifier,
+            transitionCompleted: transitionCompleted, arguments: arguments, metadata: metadata
+        )
+    }
+}
+
+#if canImport(UIKit) && !os(watchOS)
+import UIKit
+
+/// UIKit lifecycle adapter. Hosts call these hooks from their existing delegates;
+/// no global swizzling or delegate replacement is performed.
+public final class UIKitNavigationAdapter: NavigationFrameworkAdapter, @unchecked Sendable {
+    public static let shared = UIKitNavigationAdapter()
+    private init() {}
+    public var isActive: Bool { NavigationAdapterHub.shared.isActive(owner: "uikit") }
+    public func start() { NavigationAdapterHub.shared.start(owner: "uikit") }
+    public func stop() { NavigationAdapterHub.shared.stop(owner: "uikit") }
+
+    public func recordPush(_ viewController: UIViewController, sceneIdentifier: String? = nil, completed: Bool = true) {
+        record(viewController, sceneIdentifier: sceneIdentifier, metadata: ["transition": "push"], completed: completed)
+    }
+
+    public func recordPop(_ viewController: UIViewController, sceneIdentifier: String? = nil, completed: Bool = true) {
+        record(viewController, sceneIdentifier: sceneIdentifier, metadata: ["transition": "pop"], completed: completed)
+    }
+
+    public func recordPresentation(_ viewController: UIViewController, sceneIdentifier: String? = nil, completed: Bool = true) {
+        record(viewController, sceneIdentifier: sceneIdentifier, metadata: ["transition": "presentation"], completed: completed)
+    }
+
+    public func recordTabSelection(_ viewController: UIViewController, sceneIdentifier: String? = nil) {
+        record(viewController, sceneIdentifier: sceneIdentifier, metadata: ["transition": "tab"])
+    }
+
+    public func recordSplitColumn(_ viewController: UIViewController, column: String, sceneIdentifier: String? = nil) {
+        record(viewController, sceneIdentifier: sceneIdentifier, metadata: ["transition": "split", "column": column])
+    }
+
+    private func record(
+        _ viewController: UIViewController,
+        sceneIdentifier: String?,
+        metadata: [String: String],
+        completed: Bool = true
+    ) {
+        let destination = String(describing: type(of: viewController))
+        NavigationAdapterHub.shared.record(
+            owner: "uikit",
+            destination: destination,
+            source: .uiKitNavigation,
+            identity: NavigationScreenIdentity(route: destination),
+            sceneIdentifier: sceneIdentifier ?? viewController.viewIfLoaded?.window?.windowScene?.session.persistentIdentifier,
+            transitionIdentifier: UUID().uuidString,
+            transitionCompleted: completed,
+            metadata: metadata
+        )
+    }
+}
+#endif

--- a/ios/auto-mobile-sdk/Sources/AutoMobileSDK/Navigation/Adapters/SwiftUINavigationAdapter.swift
+++ b/ios/auto-mobile-sdk/Sources/AutoMobileSDK/Navigation/Adapters/SwiftUINavigationAdapter.swift
@@ -12,18 +12,20 @@ public final class SwiftUINavigationAdapter: NavigationFrameworkAdapter, @unchec
     public var isActive: Bool {
         lock.lock()
         defer { lock.unlock() }
-        return _isActive
+        return _isActive && NavigationAdapterHub.shared.isActive(owner: "swiftui")
     }
 
     private init() {}
 
     public func start() {
+        NavigationAdapterHub.shared.start(owner: "swiftui")
         lock.lock()
         _isActive = true
         lock.unlock()
     }
 
     public func stop() {
+        NavigationAdapterHub.shared.stop(owner: "swiftui")
         lock.lock()
         _isActive = false
         lock.unlock()
@@ -36,13 +38,32 @@ public final class SwiftUINavigationAdapter: NavigationFrameworkAdapter, @unchec
         metadata: [String: String] = [:]
     ) {
         guard isActive else { return }
-        let event = NavigationEvent(
+        NavigationAdapterHub.shared.record(
+            owner: "swiftui",
             destination: destination,
             source: .swiftUINavigation,
+            identity: NavigationScreenIdentity(route: destination),
             arguments: arguments,
             metadata: metadata
         )
-        AutoMobileSDK.shared.notifyNavigationEvent(event)
+    }
+
+    public func trackSheet(destination: String, sceneIdentifier: String? = nil, metadata: [String: String] = [:]) {
+        NavigationAdapterHub.shared.record(owner: "swiftui", destination: destination, source: .swiftUINavigation,
+            identity: NavigationScreenIdentity(route: destination), sceneIdentifier: sceneIdentifier,
+            metadata: metadata.merging(["transition": "sheet"]) { _, new in new })
+    }
+
+    public func trackTab(destination: String, sceneIdentifier: String? = nil) {
+        NavigationAdapterHub.shared.record(owner: "swiftui", destination: destination, source: .swiftUINavigation,
+            identity: NavigationScreenIdentity(route: destination), sceneIdentifier: sceneIdentifier,
+            metadata: ["transition": "tab"])
+    }
+
+    public func trackSplitColumn(destination: String, column: String, sceneIdentifier: String? = nil) {
+        NavigationAdapterHub.shared.record(owner: "swiftui", destination: destination, source: .swiftUINavigation,
+            identity: NavigationScreenIdentity(route: destination), sceneIdentifier: sceneIdentifier,
+            metadata: ["transition": "split", "column": column])
     }
 }
 

--- a/ios/auto-mobile-sdk/Sources/AutoMobileSDK/Navigation/NavigationEvent.swift
+++ b/ios/auto-mobile-sdk/Sources/AutoMobileSDK/Navigation/NavigationEvent.swift
@@ -17,19 +17,31 @@ public struct NavigationEvent: Sendable {
 
     /// Additional metadata.
     public let metadata: [String: String]
+    public let screenIdentity: String?
+    public let sceneIdentifier: String?
+    public let transitionIdentifier: String?
+    public let transitionCompleted: Bool
 
     public init(
         destination: String,
         source: NavigationSource,
         timestamp: Int64 = Int64(Date().timeIntervalSince1970 * 1000),
         arguments: [String: String] = [:],
-        metadata: [String: String] = [:]
+        metadata: [String: String] = [:],
+        screenIdentity: String? = nil,
+        sceneIdentifier: String? = nil,
+        transitionIdentifier: String? = nil,
+        transitionCompleted: Bool = true
     ) {
         self.destination = destination
         self.source = source
         self.timestamp = timestamp
         self.arguments = arguments
         self.metadata = metadata
+        self.screenIdentity = screenIdentity
+        self.sceneIdentifier = sceneIdentifier
+        self.transitionIdentifier = transitionIdentifier
+        self.transitionCompleted = transitionCompleted
     }
 
     /// Convenience init that accepts mixed-type arguments (matching Android's Map<String, Any?>).
@@ -39,7 +51,11 @@ public struct NavigationEvent: Sendable {
         source: NavigationSource,
         timestamp: Int64 = Int64(Date().timeIntervalSince1970 * 1000),
         mixedArguments: [String: Any],
-        metadata: [String: String] = [:]
+        metadata: [String: String] = [:],
+        screenIdentity: String? = nil,
+        sceneIdentifier: String? = nil,
+        transitionIdentifier: String? = nil,
+        transitionCompleted: Bool = true
     ) {
         self.destination = destination
         self.source = source
@@ -49,5 +65,9 @@ public struct NavigationEvent: Sendable {
             return String(describing: value)
         }
         self.metadata = metadata
+        self.screenIdentity = screenIdentity
+        self.sceneIdentifier = sceneIdentifier
+        self.transitionIdentifier = transitionIdentifier
+        self.transitionCompleted = transitionCompleted
     }
 }

--- a/ios/auto-mobile-sdk/Sources/AutoMobileSDK/Navigation/NavigationIdentity.swift
+++ b/ios/auto-mobile-sdk/Sources/AutoMobileSDK/Navigation/NavigationIdentity.swift
@@ -1,0 +1,58 @@
+import Foundation
+
+/// Host-configurable redaction applied before navigation data leaves the app.
+public protocol NavigationDataRedacting: Sendable {
+    func redact(_ value: String) -> String
+}
+
+public struct NoOpNavigationRedactor: NavigationDataRedacting {
+    public init() {}
+    public func redact(_ value: String) -> String { value }
+}
+
+/// A stable route identity, separate from display text and mutable arguments.
+public struct NavigationScreenIdentity: Sendable, Equatable {
+    public let route: String
+    public let version: String?
+
+    public init(route: String, version: String? = nil) {
+        self.route = route
+        self.version = version
+    }
+
+    public var value: String {
+        guard let version, !version.isEmpty else { return route }
+        return "\(route)@\(version)"
+    }
+}
+
+/// Shared normalization used by every navigation adapter.
+public struct NavigationEventFactory: Sendable {
+    public let redactor: any NavigationDataRedacting
+
+    public init(redactor: any NavigationDataRedacting = NoOpNavigationRedactor()) {
+        self.redactor = redactor
+    }
+
+    public func make(
+        destination: String,
+        source: NavigationSource,
+        identity: NavigationScreenIdentity? = nil,
+        sceneIdentifier: String? = nil,
+        transitionIdentifier: String? = nil,
+        transitionCompleted: Bool = true,
+        arguments: [String: String] = [:],
+        metadata: [String: String] = [:]
+    ) -> NavigationEvent {
+        NavigationEvent(
+            destination: redactor.redact(destination),
+            source: source,
+            arguments: arguments.mapValues(redactor.redact),
+            metadata: metadata.mapValues(redactor.redact),
+            screenIdentity: identity?.value ?? redactor.redact(destination),
+            sceneIdentifier: sceneIdentifier.map(redactor.redact),
+            transitionIdentifier: transitionIdentifier.map(redactor.redact),
+            transitionCompleted: transitionCompleted
+        )
+    }
+}

--- a/ios/auto-mobile-sdk/Tests/AutoMobileSDKTests/NavigationTests.swift
+++ b/ios/auto-mobile-sdk/Tests/AutoMobileSDKTests/NavigationTests.swift
@@ -105,4 +105,48 @@ final class SwiftUINavigationAdapterTests: XCTestCase {
 
         XCTAssertEqual(listener.events.count, 0)
     }
+
+    func testNavigationFactoryKeepsStableIdentityAndRedactsArguments() {
+        struct Redactor: NavigationDataRedacting {
+            func redact(_ value: String) -> String { value.replacingOccurrences(of: "secret", with: "<redacted>") }
+        }
+        let factory = NavigationEventFactory(redactor: Redactor())
+        let event = factory.make(
+            destination: "profile/secret",
+            source: .custom,
+            identity: NavigationScreenIdentity(route: "profile", version: "2"),
+            sceneIdentifier: "scene-secret",
+            arguments: ["token": "secret"],
+            metadata: ["label": "secret"]
+        )
+        XCTAssertEqual(event.screenIdentity, "profile@2")
+        XCTAssertEqual(event.destination, "profile/<redacted>")
+        XCTAssertEqual(event.arguments["token"], "<redacted>")
+        XCTAssertEqual(event.sceneIdentifier, "scene-<redacted>")
+    }
+
+    func testCancelledTransitionDoesNotEmit() {
+        let listener = FakeNavigationListener()
+        AutoMobileSDK.shared.addNavigationListener(listener)
+        NavigationAdapterHub.shared.start(owner: "test")
+        NavigationAdapterHub.shared.record(
+            destination: "Cancelled",
+            source: .custom,
+            transitionCompleted: false
+        )
+        NavigationAdapterHub.shared.stop(owner: "test")
+        XCTAssertTrue(listener.events.isEmpty)
+    }
+
+    func testDeepLinkAdapterIsIndependentFromSwiftUIAdapter() {
+        SwiftUINavigationAdapter.shared.stop()
+        let listener = FakeNavigationListener()
+        AutoMobileSDK.shared.addNavigationListener(listener)
+        DeepLinkNavigationAdapter.shared.record(destination: "myapp://ignored")
+        XCTAssertTrue(listener.events.isEmpty)
+        DeepLinkNavigationAdapter.shared.start()
+        DeepLinkNavigationAdapter.shared.record(destination: "myapp://settings")
+        DeepLinkNavigationAdapter.shared.stop()
+        XCTAssertEqual(listener.events.map(\.source), [.deepLink])
+    }
 }

--- a/ios/auto-mobile-sdk/api/auto-mobile-sdk.api
+++ b/ios/auto-mobile-sdk/api/auto-mobile-sdk.api
@@ -100,7 +100,12 @@ public struct SdkNavigationEvent: SdkEvent
   public let source: NavigationSourceType
   public let arguments: [String: String]
   public let metadata: [String: String]
-  public init( timestamp: Int64 = Int64(Date().timeIntervalSince1970 * 1000), sequenceNumber: Int64? = nil, sessionId: String? = nil, sessionEpoch: Int64? = nil, trackingGeneration: Int64? = nil, destination: String, source: NavigationSourceType, arguments: [String: String] = [:], metadata: [String: String] = [:] )
+  public let screenIdentity: String?
+  public let sceneIdentifier: String?
+  public let transitionIdentifier: String?
+  public let transitionCompleted: Bool
+  public init( timestamp: Int64 = Int64(Date().timeIntervalSince1970 * 1000), sequenceNumber: Int64? = nil, sessionId: String? = nil, sessionEpoch: Int64? = nil, trackingGeneration: Int64? = nil, destination: String, source: NavigationSourceType, arguments: [String: String] = [:], metadata: [String: String] = [:], screenIdentity: String? = nil, sceneIdentifier: String? = nil, transitionIdentifier: String? = nil, transitionCompleted: Bool = true )
+  public init(from decoder: Decoder) throws
 public struct SdkHandledExceptionEvent: SdkEvent
   public private(set) var eventType: SdkEventType = .handledException
   public let timestamp: Int64
@@ -306,6 +311,37 @@ public final class AutoMobileLog: @unchecked Sendable
   public func e(_ tag: String? = nil, _ message: String)
   public func fault(_ tag: String? = nil, _ message: String)
 
+// Navigation/Adapters/NavigationAdapters.swift
+public final class NavigationAdapterHub: @unchecked Sendable
+  public static let shared = NavigationAdapterHub()
+  public var isActive: Bool
+  public func isActive(owner: String?) -> Bool
+  public func start(owner: String = "default", redactor: any NavigationDataRedacting = NoOpNavigationRedactor())
+  public func stop(owner: String = "default")
+  public func record( owner: String = "default", destination: String, source: NavigationSource, identity: NavigationScreenIdentity? = nil, sceneIdentifier: String? = nil, transitionIdentifier: String? = nil, transitionCompleted: Bool = true, arguments: [String: String] = [:], metadata: [String: String] = [:] )
+public final class DeepLinkNavigationAdapter: NavigationFrameworkAdapter, @unchecked Sendable
+  public static let shared = DeepLinkNavigationAdapter()
+  public var isActive: Bool
+  public func start()
+  public func stop()
+  public func record( destination: String, identity: NavigationScreenIdentity? = nil, sceneIdentifier: String? = nil, arguments: [String: String] = [:], metadata: [String: String] = [:] )
+public final class CustomNavigationAdapter: NavigationFrameworkAdapter, @unchecked Sendable
+  public static let shared = CustomNavigationAdapter()
+  public var isActive: Bool
+  public func start()
+  public func stop()
+  public func record( destination: String, identity: NavigationScreenIdentity? = nil, sceneIdentifier: String? = nil, transitionIdentifier: String? = nil, transitionCompleted: Bool = true, arguments: [String: String] = [:], metadata: [String: String] = [:] )
+public final class UIKitNavigationAdapter: NavigationFrameworkAdapter, @unchecked Sendable
+  public static let shared = UIKitNavigationAdapter()
+  public var isActive: Bool
+  public func start()
+  public func stop()
+  public func recordPush(_ viewController: UIViewController, sceneIdentifier: String? = nil, completed: Bool = true)
+  public func recordPop(_ viewController: UIViewController, sceneIdentifier: String? = nil, completed: Bool = true)
+  public func recordPresentation(_ viewController: UIViewController, sceneIdentifier: String? = nil, completed: Bool = true)
+  public func recordTabSelection(_ viewController: UIViewController, sceneIdentifier: String? = nil)
+  public func recordSplitColumn(_ viewController: UIViewController, column: String, sceneIdentifier: String? = nil)
+
 // Navigation/Adapters/NavigationFrameworkAdapter.swift
 public protocol NavigationFrameworkAdapter: AnyObject, Sendable
 
@@ -316,6 +352,9 @@ public final class SwiftUINavigationAdapter: NavigationFrameworkAdapter, @unchec
   public func start()
   public func stop()
   public func trackNavigation( destination: String, arguments: [String: String] = [:], metadata: [String: String] = [:] )
+  public func trackSheet(destination: String, sceneIdentifier: String? = nil, metadata: [String: String] = [:])
+  public func trackTab(destination: String, sceneIdentifier: String? = nil)
+  public func trackSplitColumn(destination: String, column: String, sceneIdentifier: String? = nil)
 public struct TrackNavigationModifier: ViewModifier
   public func body(content: Content) -> some View
 public extension View
@@ -327,8 +366,27 @@ public struct NavigationEvent: Sendable
   public let timestamp: Int64
   public let arguments: [String: String]
   public let metadata: [String: String]
-  public init( destination: String, source: NavigationSource, timestamp: Int64 = Int64(Date().timeIntervalSince1970 * 1000), arguments: [String: String] = [:], metadata: [String: String] = [:] )
-  public init( destination: String, source: NavigationSource, timestamp: Int64 = Int64(Date().timeIntervalSince1970 * 1000), mixedArguments: [String: Any], metadata: [String: String] = [:] )
+  public let screenIdentity: String?
+  public let sceneIdentifier: String?
+  public let transitionIdentifier: String?
+  public let transitionCompleted: Bool
+  public init( destination: String, source: NavigationSource, timestamp: Int64 = Int64(Date().timeIntervalSince1970 * 1000), arguments: [String: String] = [:], metadata: [String: String] = [:], screenIdentity: String? = nil, sceneIdentifier: String? = nil, transitionIdentifier: String? = nil, transitionCompleted: Bool = true )
+  public init( destination: String, source: NavigationSource, timestamp: Int64 = Int64(Date().timeIntervalSince1970 * 1000), mixedArguments: [String: Any], metadata: [String: String] = [:], screenIdentity: String? = nil, sceneIdentifier: String? = nil, transitionIdentifier: String? = nil, transitionCompleted: Bool = true )
+
+// Navigation/NavigationIdentity.swift
+public protocol NavigationDataRedacting: Sendable
+public struct NoOpNavigationRedactor: NavigationDataRedacting
+  public init()
+  public func redact(_ value: String) -> String
+public struct NavigationScreenIdentity: Sendable, Equatable
+  public let route: String
+  public let version: String?
+  public init(route: String, version: String? = nil)
+  public var value: String
+public struct NavigationEventFactory: Sendable
+  public let redactor: any NavigationDataRedacting
+  public init(redactor: any NavigationDataRedacting = NoOpNavigationRedactor())
+  public func make( destination: String, source: NavigationSource, identity: NavigationScreenIdentity? = nil, sceneIdentifier: String? = nil, transitionIdentifier: String? = nil, transitionCompleted: Bool = true, arguments: [String: String] = [:], metadata: [String: String] = [:] ) -> NavigationEvent
 
 // Navigation/NavigationListener.swift
 public protocol NavigationListener: AnyObject, Sendable


### PR DESCRIPTION
Closes #5060

## What changed

- Added a shared navigation event factory with stable screen identity, scene and transition correlation, completion state, and host-configurable argument/metadata redaction.
- Added independent opt-in adapters for UIKit, SwiftUI sheets/tabs/split columns, deep links, and custom routers.
- Added explicit lifecycle hooks that do not swizzle or replace host delegates; cancelled interactive transitions are ignored.
- Preserved decoding compatibility for navigation events written before the new optional fields.
- Updated the iOS SDK API artifact and navigation documentation.

## Validation

- `swift test --package-path ios/auto-mobile-sdk` (280 passed)
- focused navigation regression tests (19 passed)
- `bash scripts/ios/api-check.sh`
- `bun run typecheck`
- `bun run turbo:validate` (12,904 passed, 13 skipped)

## Review notes

The iOS SDK package was compiled and tested on the available macOS toolchain. A direct iOS-target compile was attempted but this host's Swift installation has no iOS standard library/sysroot; CI remains the platform-specific compile gate.
