### PR TITLE
feat(ios): harden storage inspection boundaries

### DIFF
--- a/docs/design-docs/plat/ios/auto-mobile-sdk.md
+++ b/docs/design-docs/plat/ios/auto-mobile-sdk.md
@@ -331,6 +331,13 @@ SQLite database inspection using the `sqlite3` C API directly:
 - Table listing, paginated data retrieval, schema inspection via `PRAGMA table_info`
 - Raw SQL execution with read/write detection (SELECT/EXPLAIN/PRAGMA = read-only, opens with `SQLITE_OPEN_READONLY`)
 - Connection caching, 5-second busy timeout, identifier sanitization
+- Read-only inspection is the default. Host mutation authorization and the
+  active SDK session are both required before a write can run.
+- Hosts can configure database path allowlists, app-group registrations,
+  Core Data metadata, sensitive-key redaction, and row/byte response limits.
+- Storage failures expose structured diagnostics for WAL, busy-lock,
+  migration/schema, and corrupted-store conditions; unavailable stores are
+  reported by the capabilities endpoint.
 - MCP `sqlQuery` and database resources are available on iOS through the DEBUG-only in-app SDK HTTP server on port 8766, relayed by CtrlProxy on port 8765. Apps must call `DatabaseInspector.shared.setEnabled(true)`.
 
 ## Other Subsystems

--- a/ios/auto-mobile-sdk/Sources/AutoMobileSDK/AutoMobileSDK.docc/AutoMobileSDK.md
+++ b/ios/auto-mobile-sdk/Sources/AutoMobileSDK/AutoMobileSDK.docc/AutoMobileSDK.md
@@ -141,6 +141,9 @@ AutoMobileSDK.shared.initialize(configuration: config)
 - ``KeyValueType``
 - ``UserDefaultsChangeListener``
 - ``DatabaseInspector``
+- ``StorageInspectionConfiguration``
+- ``CoreDataStoreRegistration``
+- ``StorageDiagnostic``
 - ``DatabaseDriver``
 - ``SQLiteDatabaseDriver``
 - ``DatabaseDescriptor``

--- a/ios/auto-mobile-sdk/Sources/AutoMobileSDK/Storage/DatabaseInspector.swift
+++ b/ios/auto-mobile-sdk/Sources/AutoMobileSDK/Storage/DatabaseInspector.swift
@@ -8,6 +8,9 @@ public final class DatabaseInspector: @unchecked Sendable {
     private let lock = NSLock()
     private var _isEnabled = false
     private var _driver: DatabaseDriver?
+    private var _configuration = StorageInspectionConfiguration()
+    private var _hostMutationAuthorization = false
+    private var _sessionMutationAuthorization: String?
 
     private init() {}
 
@@ -31,6 +34,58 @@ public final class DatabaseInspector: @unchecked Sendable {
         lock.unlock()
     }
 
+    /// Configure explicit storage registrations and transport limits.
+    public func configure(_ configuration: StorageInspectionConfiguration) {
+        lock.lock()
+        _configuration = configuration
+        lock.unlock()
+    }
+
+    /// Register an app-group suite for host-coordinated inspection.
+    public func registerAppGroupSuite(_ suiteName: String) {
+        lock.lock()
+        _configuration.registeredAppGroupSuites.insert(suiteName)
+        lock.unlock()
+    }
+
+    /// Register Core Data metadata supplied by the host.
+    public func registerCoreDataStore(_ store: CoreDataStoreRegistration) {
+        lock.lock()
+        _configuration.coreDataStores.removeAll { $0.identifier == store.identifier }
+        _configuration.coreDataStores.append(store)
+        lock.unlock()
+    }
+
+    /// Authorize the host half of the mutation gate.
+    public func authorizeHostMutations(_ authorized: Bool) {
+        lock.lock()
+        _hostMutationAuthorization = authorized
+        lock.unlock()
+    }
+
+    /// Authorize mutations for one active SDK session.
+    public func authorizeSessionMutations(sessionId: String?) {
+        lock.lock()
+        _sessionMutationAuthorization = sessionId
+        lock.unlock()
+    }
+
+    var inspectionConfiguration: StorageInspectionConfiguration {
+        lock.lock()
+        defer { lock.unlock() }
+        return _configuration
+    }
+
+    func canMutate(sessionId: String?, currentSessionId: String?) -> Bool {
+        lock.lock()
+        defer { lock.unlock() }
+        return _configuration.allowMutations
+            && _hostMutationAuthorization
+            && sessionId != nil
+            && sessionId == currentSessionId
+            && sessionId == _sessionMutationAuthorization
+    }
+
     /// Get the driver for direct access.
     public func getDriver() -> DatabaseDriver? {
         lock.lock()
@@ -51,6 +106,9 @@ public final class DatabaseInspector: @unchecked Sendable {
         lock.lock()
         _isEnabled = false
         _driver = nil
+        _configuration = StorageInspectionConfiguration()
+        _hostMutationAuthorization = false
+        _sessionMutationAuthorization = nil
         lock.unlock()
     }
 }
@@ -135,12 +193,14 @@ public struct SQLExecutionResult: Sendable {
     public let rows: [[String?]]?
     public let rowsAffected: Int
     public let error: String?
+    public let diagnostic: StorageDiagnostic?
 
-    public init(columns: [String]?, rows: [[String?]]?, rowsAffected: Int, error: String? = nil) {
+    public init(columns: [String]?, rows: [[String?]]?, rowsAffected: Int, error: String? = nil, diagnostic: StorageDiagnostic? = nil) {
         self.columns = columns
         self.rows = rows
         self.rowsAffected = rowsAffected
         self.error = error
+        self.diagnostic = diagnostic
     }
 }
 

--- a/ios/auto-mobile-sdk/Sources/AutoMobileSDK/Storage/DatabaseInspector.swift
+++ b/ios/auto-mobile-sdk/Sources/AutoMobileSDK/Storage/DatabaseInspector.swift
@@ -153,20 +153,24 @@ public struct TableDataResult: Sendable {
     public let columns: [String]
     public let rows: [[String?]]
     public let totalRows: Int
+    public let diagnostic: StorageDiagnostic?
 
-    public init(columns: [String], rows: [[String?]], totalRows: Int) {
+    public init(columns: [String], rows: [[String?]], totalRows: Int, diagnostic: StorageDiagnostic? = nil) {
         self.columns = columns
         self.rows = rows
         self.totalRows = totalRows
+        self.diagnostic = diagnostic
     }
 }
 
 /// Result of a table structure query containing column definitions.
 public struct TableStructureResult: Sendable {
     public let columns: [ColumnInfo]
+    public let diagnostic: StorageDiagnostic?
 
-    public init(columns: [ColumnInfo]) {
+    public init(columns: [ColumnInfo], diagnostic: StorageDiagnostic? = nil) {
         self.columns = columns
+        self.diagnostic = diagnostic
     }
 }
 
@@ -194,13 +198,22 @@ public struct SQLExecutionResult: Sendable {
     public let rowsAffected: Int
     public let error: String?
     public let diagnostic: StorageDiagnostic?
+    public let truncated: Bool
 
-    public init(columns: [String]?, rows: [[String?]]?, rowsAffected: Int, error: String? = nil, diagnostic: StorageDiagnostic? = nil) {
+    public init(
+        columns: [String]?,
+        rows: [[String?]]?,
+        rowsAffected: Int,
+        error: String? = nil,
+        diagnostic: StorageDiagnostic? = nil,
+        truncated: Bool = false
+    ) {
         self.columns = columns
         self.rows = rows
         self.rowsAffected = rowsAffected
         self.error = error
         self.diagnostic = diagnostic
+        self.truncated = truncated
     }
 }
 

--- a/ios/auto-mobile-sdk/Sources/AutoMobileSDK/Storage/SQLiteDatabaseDriver.swift
+++ b/ios/auto-mobile-sdk/Sources/AutoMobileSDK/Storage/SQLiteDatabaseDriver.swift
@@ -101,21 +101,25 @@ public final class SQLiteDatabaseDriver: DatabaseDriver, @unchecked Sendable {
         let countQuery = "SELECT COUNT(*) FROM \"\(sanitizeIdentifier(table))\""
         var countStmt: OpaquePointer?
         var totalRows = 0
-        if sqlite3_prepare_v2(db, countQuery, -1, &countStmt, nil) == SQLITE_OK {
-            if sqlite3_step(countStmt) == SQLITE_ROW {
-                totalRows = Int(sqlite3_column_int64(countStmt, 0))
-            }
+        guard sqlite3_prepare_v2(db, countQuery, -1, &countStmt, nil) == SQLITE_OK else {
+            let message = sqlite3_errmsg(db).map { String(cString: $0) } ?? "Unknown error"
+            return TableDataResult(columns: [], rows: [], totalRows: 0, diagnostic: Self.diagnostic(for: message))
         }
-        sqlite3_finalize(countStmt)
+        defer { sqlite3_finalize(countStmt) }
+        guard sqlite3_step(countStmt) == SQLITE_ROW else {
+            let message = sqlite3_errmsg(db).map { String(cString: $0) } ?? "Unknown error"
+            return TableDataResult(columns: [], rows: [], totalRows: 0, diagnostic: Self.diagnostic(for: message))
+        }
+        totalRows = Int(sqlite3_column_int64(countStmt, 0))
 
         // Get paginated data
         let dataQuery = "SELECT * FROM \"\(sanitizeIdentifier(table))\" ORDER BY rowid LIMIT ? OFFSET ?"
         var dataStmt: OpaquePointer?
         if sqlite3_prepare_v2(db, dataQuery, -1, &dataStmt, nil) != SQLITE_OK {
-            // WITHOUT ROWID tables have no implicit ordering column. Keep them
-            // readable while preserving deterministic ordering for ordinary
-            // tables.
-            let fallbackQuery = "SELECT * FROM \"\(sanitizeIdentifier(table))\" LIMIT ? OFFSET ?"
+            let order = primaryKeyOrder(db: db, table: table)
+            let fallbackQuery = order.isEmpty
+                ? "SELECT * FROM \"\(sanitizeIdentifier(table))\" LIMIT ? OFFSET ?"
+                : "SELECT * FROM \"\(sanitizeIdentifier(table))\" ORDER BY \(order) LIMIT ? OFFSET ?"
             guard sqlite3_prepare_v2(db, fallbackQuery, -1, &dataStmt, nil) == SQLITE_OK else {
                 let message = sqlite3_errmsg(db).map { String(cString: $0) } ?? "Unknown error"
                 return TableDataResult(
@@ -128,8 +132,8 @@ public final class SQLiteDatabaseDriver: DatabaseDriver, @unchecked Sendable {
         }
         defer { sqlite3_finalize(dataStmt) }
 
-        sqlite3_bind_int(dataStmt, 1, Int32(boundedLimit))
-        sqlite3_bind_int(dataStmt, 2, Int32(boundedOffset))
+        sqlite3_bind_int64(dataStmt, 1, sqlite3_int64(boundedLimit))
+        sqlite3_bind_int64(dataStmt, 2, sqlite3_int64(boundedOffset))
 
         let columnCount = Int(sqlite3_column_count(dataStmt))
         var columns: [String] = []
@@ -140,12 +144,23 @@ public final class SQLiteDatabaseDriver: DatabaseDriver, @unchecked Sendable {
         }
 
         var rows: [[String?]] = []
-        while sqlite3_step(dataStmt) == SQLITE_ROW {
+        var stepResult = sqlite3_step(dataStmt)
+        while stepResult == SQLITE_ROW {
             var row: [String?] = []
             for i in 0 ..< columnCount {
                 row.append(getColumnValue(stmt: dataStmt, index: Int32(i)))
             }
             rows.append(row)
+            stepResult = sqlite3_step(dataStmt)
+        }
+        guard stepResult == SQLITE_DONE else {
+            let message = sqlite3_errmsg(db).map { String(cString: $0) } ?? "Unknown error"
+            return TableDataResult(
+                columns: columns,
+                rows: rows,
+                totalRows: totalRows,
+                diagnostic: Self.diagnostic(for: message)
+            )
         }
 
         return TableDataResult(columns: columns, rows: rows, totalRows: totalRows)
@@ -553,6 +568,7 @@ public final class SQLiteDatabaseDriver: DatabaseDriver, @unchecked Sendable {
         case SQLITE_BLOB:
             if let bytes = sqlite3_column_blob(stmt, index) {
                 let count = Int(sqlite3_column_bytes(stmt, index))
+                guard count <= 512 * 1024 else { return "[TRUNCATED]" }
                 let data = Data(bytes: bytes, count: count)
                 return data.base64EncodedString()
             }
@@ -563,6 +579,22 @@ public final class SQLiteDatabaseDriver: DatabaseDriver, @unchecked Sendable {
             }
             return nil
         }
+    }
+
+    private func primaryKeyOrder(db: OpaquePointer, table: String) -> String {
+        let query = "PRAGMA table_info(\"\(sanitizeIdentifier(table))\")"
+        var stmt: OpaquePointer?
+        guard sqlite3_prepare_v2(db, query, -1, &stmt, nil) == SQLITE_OK else { return "" }
+        defer { sqlite3_finalize(stmt) }
+        var columns: [(Int, String)] = []
+        while sqlite3_step(stmt) == SQLITE_ROW {
+            let sequence = Int(sqlite3_column_int(stmt, 5))
+            guard sequence > 0, let name = sqlite3_column_text(stmt, 1) else { continue }
+            columns.append((sequence, String(cString: name)))
+        }
+        return columns.sorted { $0.0 < $1.0 }
+            .map { "\"\(sanitizeIdentifier($0.1))\"" }
+            .joined(separator: ", ")
     }
 
     private func sanitizeIdentifier(_ identifier: String) -> String {

--- a/ios/auto-mobile-sdk/Sources/AutoMobileSDK/Storage/SQLiteDatabaseDriver.swift
+++ b/ios/auto-mobile-sdk/Sources/AutoMobileSDK/Storage/SQLiteDatabaseDriver.swift
@@ -81,7 +81,12 @@ public final class SQLiteDatabaseDriver: DatabaseDriver, @unchecked Sendable {
         defer { operationLock.unlock() }
 
         guard let db = openDatabase(path: databasePath, readOnly: true) else {
-            return TableDataResult(columns: [], rows: [], totalRows: 0)
+            return TableDataResult(
+                columns: [],
+                rows: [],
+                totalRows: 0,
+                diagnostic: StorageDiagnostic(code: "store_unavailable", message: "Failed to open database read-only")
+            )
         }
 
         // Keep the count and page in one read transaction so concurrent writes
@@ -112,7 +117,13 @@ public final class SQLiteDatabaseDriver: DatabaseDriver, @unchecked Sendable {
             // tables.
             let fallbackQuery = "SELECT * FROM \"\(sanitizeIdentifier(table))\" LIMIT ? OFFSET ?"
             guard sqlite3_prepare_v2(db, fallbackQuery, -1, &dataStmt, nil) == SQLITE_OK else {
-                return TableDataResult(columns: [], rows: [], totalRows: totalRows)
+                let message = sqlite3_errmsg(db).map { String(cString: $0) } ?? "Unknown error"
+                return TableDataResult(
+                    columns: [],
+                    rows: [],
+                    totalRows: totalRows,
+                    diagnostic: Self.diagnostic(for: message)
+                )
             }
         }
         defer { sqlite3_finalize(dataStmt) }
@@ -145,13 +156,17 @@ public final class SQLiteDatabaseDriver: DatabaseDriver, @unchecked Sendable {
         defer { operationLock.unlock() }
 
         guard let db = openDatabase(path: databasePath, readOnly: true) else {
-            return TableStructureResult(columns: [])
+            return TableStructureResult(
+                columns: [],
+                diagnostic: StorageDiagnostic(code: "store_unavailable", message: "Failed to open database read-only")
+            )
         }
 
         let query = "PRAGMA table_info(\"\(sanitizeIdentifier(table))\")"
         var stmt: OpaquePointer?
         guard sqlite3_prepare_v2(db, query, -1, &stmt, nil) == SQLITE_OK else {
-            return TableStructureResult(columns: [])
+            let message = sqlite3_errmsg(db).map { String(cString: $0) } ?? "Unknown error"
+            return TableStructureResult(columns: [], diagnostic: Self.diagnostic(for: message))
         }
         defer { sqlite3_finalize(stmt) }
 
@@ -398,17 +413,25 @@ public final class SQLiteDatabaseDriver: DatabaseDriver, @unchecked Sendable {
         }
 
         var rows: [[String?]] = []
+        var bytesRead = 0
+        var truncated = false
         var stepResult = sqlite3_step(stmt)
         while stepResult == SQLITE_ROW {
             var row: [String?] = []
             for i in 0 ..< columnCount {
                 row.append(getColumnValue(stmt: stmt, index: Int32(i)))
             }
+            let rowBytes = row.reduce(0) { $0 + ($1?.utf8.count ?? 0) }
+            if rows.count >= 500 || bytesRead + rowBytes > 512 * 1024 {
+                truncated = true
+                break
+            }
             rows.append(row)
+            bytesRead += rowBytes
             stepResult = sqlite3_step(stmt)
         }
 
-        if stepResult != SQLITE_DONE {
+        if !truncated && stepResult != SQLITE_DONE {
             let error = sqlite3_errmsg(db).map { String(cString: $0) } ?? "Unknown error"
             let diagnostic = Self.diagnostic(for: error)
             return SQLExecutionResult(
@@ -421,14 +444,20 @@ public final class SQLiteDatabaseDriver: DatabaseDriver, @unchecked Sendable {
         }
 
         let rowsAffected = includeRowsAffected ? Int(sqlite3_changes(db)) : 0
-        return SQLExecutionResult(columns: columns, rows: rows, rowsAffected: rowsAffected)
+        return SQLExecutionResult(columns: columns, rows: rows, rowsAffected: rowsAffected, truncated: truncated)
     }
 
     private func executeMutation(db: OpaquePointer, query: String) -> SQLExecutionResult {
         var stmt: OpaquePointer?
         guard sqlite3_prepare_v2(db, query, -1, &stmt, nil) == SQLITE_OK else {
             let error = sqlite3_errmsg(db).map { String(cString: $0) } ?? "Unknown error"
-            return SQLExecutionResult(columns: nil, rows: nil, rowsAffected: 0, error: error)
+            return SQLExecutionResult(
+                columns: nil,
+                rows: nil,
+                rowsAffected: 0,
+                error: error,
+                diagnostic: Self.diagnostic(for: error)
+            )
         }
         defer { sqlite3_finalize(stmt) }
 
@@ -446,16 +475,36 @@ public final class SQLiteDatabaseDriver: DatabaseDriver, @unchecked Sendable {
                 }
             }
             var rows: [[String?]] = []
+            var bytesRead = 0
+            var truncated = false
             // First row is already stepped
+            var finalResult = SQLITE_ROW
             repeat {
                 var row: [String?] = []
                 for i in 0 ..< columnCount {
                     row.append(getColumnValue(stmt: stmt, index: Int32(i)))
                 }
+                let rowBytes = row.reduce(0) { $0 + ($1?.utf8.count ?? 0) }
+                if rows.count >= 500 || bytesRead + rowBytes > 512 * 1024 {
+                    truncated = true
+                    break
+                }
                 rows.append(row)
-            } while sqlite3_step(stmt) == SQLITE_ROW
+                bytesRead += rowBytes
+                finalResult = sqlite3_step(stmt)
+            } while finalResult == SQLITE_ROW
+            guard truncated || finalResult == SQLITE_DONE else {
+                let error = sqlite3_errmsg(db).map { String(cString: $0) } ?? "Unknown error"
+                return SQLExecutionResult(
+                    columns: nil,
+                    rows: nil,
+                    rowsAffected: 0,
+                    error: error,
+                    diagnostic: Self.diagnostic(for: error)
+                )
+            }
             let changes = Int(sqlite3_changes(db))
-            return SQLExecutionResult(columns: columns, rows: rows, rowsAffected: changes)
+            return SQLExecutionResult(columns: columns, rows: rows, rowsAffected: changes, truncated: truncated)
         } else {
             let error = sqlite3_errmsg(db).map { String(cString: $0) } ?? "Unknown error"
             let diagnostic = Self.diagnostic(for: error)

--- a/ios/auto-mobile-sdk/Sources/AutoMobileSDK/Storage/SQLiteDatabaseDriver.swift
+++ b/ios/auto-mobile-sdk/Sources/AutoMobileSDK/Storage/SQLiteDatabaseDriver.swift
@@ -84,6 +84,14 @@ public final class SQLiteDatabaseDriver: DatabaseDriver, @unchecked Sendable {
             return TableDataResult(columns: [], rows: [], totalRows: 0)
         }
 
+        // Keep the count and page in one read transaction so concurrent writes
+        // cannot make the page and total describe different snapshots.
+        _ = sqlite3_exec(db, "BEGIN", nil, nil, nil)
+        defer { _ = sqlite3_exec(db, "ROLLBACK", nil, nil, nil) }
+
+        let boundedLimit = max(0, min(limit, 500))
+        let boundedOffset = max(0, offset)
+
         // Get total count
         let countQuery = "SELECT COUNT(*) FROM \"\(sanitizeIdentifier(table))\""
         var countStmt: OpaquePointer?
@@ -96,15 +104,21 @@ public final class SQLiteDatabaseDriver: DatabaseDriver, @unchecked Sendable {
         sqlite3_finalize(countStmt)
 
         // Get paginated data
-        let dataQuery = "SELECT * FROM \"\(sanitizeIdentifier(table))\" LIMIT ? OFFSET ?"
+        let dataQuery = "SELECT * FROM \"\(sanitizeIdentifier(table))\" ORDER BY rowid LIMIT ? OFFSET ?"
         var dataStmt: OpaquePointer?
-        guard sqlite3_prepare_v2(db, dataQuery, -1, &dataStmt, nil) == SQLITE_OK else {
-            return TableDataResult(columns: [], rows: [], totalRows: totalRows)
+        if sqlite3_prepare_v2(db, dataQuery, -1, &dataStmt, nil) != SQLITE_OK {
+            // WITHOUT ROWID tables have no implicit ordering column. Keep them
+            // readable while preserving deterministic ordering for ordinary
+            // tables.
+            let fallbackQuery = "SELECT * FROM \"\(sanitizeIdentifier(table))\" LIMIT ? OFFSET ?"
+            guard sqlite3_prepare_v2(db, fallbackQuery, -1, &dataStmt, nil) == SQLITE_OK else {
+                return TableDataResult(columns: [], rows: [], totalRows: totalRows)
+            }
         }
         defer { sqlite3_finalize(dataStmt) }
 
-        sqlite3_bind_int(dataStmt, 1, Int32(limit))
-        sqlite3_bind_int(dataStmt, 2, Int32(offset))
+        sqlite3_bind_int(dataStmt, 1, Int32(boundedLimit))
+        sqlite3_bind_int(dataStmt, 2, Int32(boundedOffset))
 
         let columnCount = Int(sqlite3_column_count(dataStmt))
         var columns: [String] = []
@@ -168,7 +182,17 @@ public final class SQLiteDatabaseDriver: DatabaseDriver, @unchecked Sendable {
         let trimmed = query.trimmingCharacters(in: .whitespacesAndNewlines)
         let classification = classifySQL(trimmed)
         guard let db = openDatabase(path: databasePath, readOnly: classification.readOnly) else {
-            return SQLExecutionResult(columns: nil, rows: nil, rowsAffected: 0, error: "Failed to open database")
+            let diagnostic = StorageDiagnostic(
+                code: "store_unavailable",
+                message: "Failed to open database in \(classification.readOnly ? "read-only" : "read-write") mode"
+            )
+            return SQLExecutionResult(
+                columns: nil,
+                rows: nil,
+                rowsAffected: 0,
+                error: diagnostic.message,
+                diagnostic: diagnostic
+            )
         }
 
         if classification.returnsRows {
@@ -354,7 +378,14 @@ public final class SQLiteDatabaseDriver: DatabaseDriver, @unchecked Sendable {
         var stmt: OpaquePointer?
         guard sqlite3_prepare_v2(db, query, -1, &stmt, nil) == SQLITE_OK else {
             let error = sqlite3_errmsg(db).map { String(cString: $0) } ?? "Unknown error"
-            return SQLExecutionResult(columns: nil, rows: nil, rowsAffected: 0, error: error)
+            let diagnostic = Self.diagnostic(for: error)
+            return SQLExecutionResult(
+                columns: nil,
+                rows: nil,
+                rowsAffected: 0,
+                error: error,
+                diagnostic: diagnostic
+            )
         }
         defer { sqlite3_finalize(stmt) }
 
@@ -379,7 +410,14 @@ public final class SQLiteDatabaseDriver: DatabaseDriver, @unchecked Sendable {
 
         if stepResult != SQLITE_DONE {
             let error = sqlite3_errmsg(db).map { String(cString: $0) } ?? "Unknown error"
-            return SQLExecutionResult(columns: nil, rows: nil, rowsAffected: 0, error: error)
+            let diagnostic = Self.diagnostic(for: error)
+            return SQLExecutionResult(
+                columns: nil,
+                rows: nil,
+                rowsAffected: 0,
+                error: error,
+                diagnostic: diagnostic
+            )
         }
 
         let rowsAffected = includeRowsAffected ? Int(sqlite3_changes(db)) : 0
@@ -420,8 +458,32 @@ public final class SQLiteDatabaseDriver: DatabaseDriver, @unchecked Sendable {
             return SQLExecutionResult(columns: columns, rows: rows, rowsAffected: changes)
         } else {
             let error = sqlite3_errmsg(db).map { String(cString: $0) } ?? "Unknown error"
-            return SQLExecutionResult(columns: nil, rows: nil, rowsAffected: 0, error: error)
+            let diagnostic = Self.diagnostic(for: error)
+            return SQLExecutionResult(
+                columns: nil,
+                rows: nil,
+                rowsAffected: 0,
+                error: error,
+                diagnostic: diagnostic
+            )
         }
+    }
+
+    private static func diagnostic(for message: String) -> StorageDiagnostic {
+        let code: String
+        switch message.lowercased() {
+        case let value where value.contains("locked") || value.contains("busy"):
+            code = "busy_lock"
+        case let value where value.contains("malformed") || value.contains("corrupt"):
+            code = "corrupt_store"
+        case let value where value.contains("no such table") || value.contains("schema"):
+            code = "migration_or_schema"
+        case let value where value.contains("wal"):
+            code = "wal_error"
+        default:
+            code = "sqlite_error"
+        }
+        return StorageDiagnostic(code: code, message: message)
     }
 
     private func getColumnValue(stmt: OpaquePointer?, index: Int32) -> String? {

--- a/ios/auto-mobile-sdk/Sources/AutoMobileSDK/Storage/SdkDatabaseRouteHandler.swift
+++ b/ios/auto-mobile-sdk/Sources/AutoMobileSDK/Storage/SdkDatabaseRouteHandler.swift
@@ -9,6 +9,20 @@
     struct SdkExecuteSqlRequest: Codable {
         let databasePath: String
         let query: String
+        let sessionId: String?
+
+        init(databasePath: String, query: String, sessionId: String? = nil) {
+            self.databasePath = databasePath
+            self.query = query
+            self.sessionId = sessionId
+        }
+
+        init(from decoder: Decoder) throws {
+            let container = try decoder.container(keyedBy: CodingKeys.self)
+            databasePath = try container.decode(String.self, forKey: .databasePath)
+            query = try container.decode(String.self, forKey: .query)
+            sessionId = try container.decodeIfPresent(String.self, forKey: .sessionId)
+        }
     }
 
     struct SdkDatabasePathRequest: Codable {
@@ -33,10 +47,19 @@
         let rows: [[String?]]?
         let rowsAffected: Int
         let error: String?
+        let diagnostic: StorageDiagnostic?
     }
 
     struct SdkDatabaseListPayload: Codable {
         let databases: [SdkDatabaseDescriptorPayload]
+    }
+
+    struct SdkStorageCapabilitiesPayload: Codable {
+        let readOnly: Bool
+        let mutationAuthorized: Bool
+        let registeredAppGroupSuites: [String]
+        let coreDataStores: [CoreDataStoreRegistration]
+        let unavailableStores: [String]
     }
 
     struct SdkDatabaseDescriptorPayload: Codable {
@@ -69,15 +92,34 @@
 
     struct SdkDatabaseErrorPayload: Codable {
         let error: String
+        let diagnostic: StorageDiagnostic?
     }
 
     final class SdkDatabaseRouteHandler {
+        func handleCapabilities() -> SdkRouteResponse {
+            let configuration = DatabaseInspector.shared.inspectionConfiguration
+            return encode(SdkStorageCapabilitiesPayload(
+                readOnly: !configuration.allowMutations,
+                mutationAuthorized: DatabaseInspector.shared.canMutate(
+                    sessionId: nil,
+                    currentSessionId: AutoMobileSDK.shared.currentSessionId()
+                ),
+                registeredAppGroupSuites: configuration.registeredAppGroupSuites.sorted(),
+                coreDataStores: configuration.coreDataStores,
+                unavailableStores: ["keychain", "file_caches"]
+            ))
+        }
+
         func handleListDatabases() -> SdkRouteResponse {
             guard let driver = DatabaseInspector.shared.getDriver() else {
                 return error(statusCode: 503, code: "db_inspection_disabled")
             }
 
-            let databases = driver.getDatabases().map {
+            let configuration = DatabaseInspector.shared.inspectionConfiguration
+            let databases = driver.getDatabases().filter { descriptor in
+                configuration.allowedDatabasePaths.isEmpty
+                    || configuration.allowedDatabasePaths.contains(descriptor.path)
+            }.map {
                 SdkDatabaseDescriptorPayload(name: $0.name, path: $0.path, sizeBytes: $0.sizeBytes)
             }
             return encode(SdkDatabaseListPayload(databases: databases))
@@ -114,10 +156,17 @@
             let result = driver.getTableData(
                 databasePath: request.databasePath,
                 table: request.table,
-                limit: request.limit,
-                offset: request.offset
+                limit: min(max(request.limit, 1), DatabaseInspector.shared.inspectionConfiguration.maxRows),
+                offset: max(request.offset, 0)
             )
-            return encode(SdkTableDataPayload(columns: result.columns, rows: result.rows, total: result.totalRows))
+            let configuration = DatabaseInspector.shared.inspectionConfiguration
+            let redacted = StorageInspectionAccess.redactedRows(
+                columns: result.columns,
+                rows: Array(result.rows.prefix(configuration.maxRows)),
+                configuredKeys: configuration.sensitiveKeys
+            )
+            let bounded = boundRows(redacted, maxBytes: configuration.maxBytes)
+            return encode(SdkTableDataPayload(columns: result.columns, rows: bounded, total: result.totalRows))
         }
 
         func handleTableStructure(body: Data) -> SdkRouteResponse {
@@ -157,19 +206,44 @@
                 return error(statusCode: 404, code: "unknown_database_path")
             }
 
+            if !isReadOnlyQuery(request.query)
+                && !DatabaseInspector.shared.canMutate(
+                    sessionId: request.sessionId,
+                    currentSessionId: AutoMobileSDK.shared.currentSessionId()
+                ) {
+                return error(statusCode: 403, code: "mutation_not_authorized")
+            }
             let result = driver.executeSQL(databasePath: request.databasePath, query: request.query)
+            let configuration = DatabaseInspector.shared.inspectionConfiguration
+            let columns = result.columns
+            let rows = columns.map {
+                boundRows(
+                    StorageInspectionAccess.redactedRows(
+                        columns: $0,
+                        rows: Array((result.rows ?? []).prefix(configuration.maxRows)),
+                        configuredKeys: configuration.sensitiveKeys
+                    ),
+                    maxBytes: configuration.maxBytes
+                )
+            }
             let payload = SdkExecuteSqlPayload(
                 queryType: result.columns == nil ? "mutation" : "query",
-                columns: result.columns,
-                rows: result.rows,
+                columns: columns,
+                rows: rows,
                 rowsAffected: result.rowsAffected,
-                error: result.error
+                error: result.error,
+                diagnostic: result.diagnostic
             )
             return encode(payload)
         }
 
         private func isKnownDatabasePath(_ databasePath: String, driver: DatabaseDriver) -> Bool {
-            driver.getDatabases().contains { $0.path == databasePath }
+            let configuration = DatabaseInspector.shared.inspectionConfiguration
+            return driver.getDatabases().contains { descriptor in
+                descriptor.path == databasePath
+                    && (configuration.allowedDatabasePaths.isEmpty
+                        || configuration.allowedDatabasePaths.contains(databasePath))
+            }
         }
 
         private func isKnownTable(_ table: String, databasePath: String, driver: DatabaseDriver) -> Bool {
@@ -184,9 +258,35 @@
         }
 
         private func error(statusCode: Int, code: String) -> SdkRouteResponse {
-            let payload = SdkDatabaseErrorPayload(error: code)
+            let payload = SdkDatabaseErrorPayload(
+                error: code,
+                diagnostic: StorageDiagnostic(code: code, message: code)
+            )
             let body = (try? JSONEncoder().encode(payload)) ?? Data("{\"error\":\"\(code)\"}".utf8)
             return SdkRouteResponse(statusCode: statusCode, body: body)
+        }
+
+        private func isReadOnlyQuery(_ query: String) -> Bool {
+            let keyword = query.trimmingCharacters(in: .whitespacesAndNewlines)
+                .split(whereSeparator: { $0 == " " || $0 == "\n" || $0 == "\t" })
+                .first?
+                .uppercased()
+            return keyword == "SELECT" || keyword == "EXPLAIN" || keyword == "PRAGMA"
+                || keyword == "WITH" && !query.localizedCaseInsensitiveContains("INSERT")
+                    && !query.localizedCaseInsensitiveContains("UPDATE")
+                    && !query.localizedCaseInsensitiveContains("DELETE")
+        }
+
+        private func boundRows(_ rows: [[String?]], maxBytes: Int) -> [[String?]] {
+            var used = 0
+            var result: [[String?]] = []
+            for row in rows {
+                let bytes = row.reduce(0) { $0 + ($1?.utf8.count ?? 0) }
+                guard used + bytes <= maxBytes else { break }
+                result.append(row)
+                used += bytes
+            }
+            return result
         }
     }
 #endif

--- a/ios/auto-mobile-sdk/Sources/AutoMobileSDK/Storage/SdkDatabaseRouteHandler.swift
+++ b/ios/auto-mobile-sdk/Sources/AutoMobileSDK/Storage/SdkDatabaseRouteHandler.swift
@@ -104,7 +104,7 @@
             return encode(SdkStorageCapabilitiesPayload(
                 readOnly: !configuration.allowMutations,
                 mutationAuthorized: DatabaseInspector.shared.canMutate(
-                    sessionId: nil,
+                    sessionId: AutoMobileSDK.shared.currentSessionId(),
                     currentSessionId: AutoMobileSDK.shared.currentSessionId()
                 ),
                 registeredAppGroupSuites: configuration.registeredAppGroupSuites.sorted(),
@@ -120,8 +120,7 @@
 
             let configuration = DatabaseInspector.shared.inspectionConfiguration
             let databases = driver.getDatabases().filter { descriptor in
-                configuration.allowedDatabasePaths.isEmpty
-                    || configuration.allowedDatabasePaths.contains(descriptor.path)
+                configuration.allowedDatabasePaths.contains(descriptor.path)
             }.map {
                 SdkDatabaseDescriptorPayload(name: $0.name, path: $0.path, sizeBytes: $0.sizeBytes)
             }
@@ -169,12 +168,13 @@
                 configuredKeys: configuration.sensitiveKeys
             )
             let bounded = boundRows(redacted, maxBytes: configuration.maxBytes)
-            return encode(SdkTableDataPayload(
+            let payload = SdkTableDataPayload(
                 columns: result.columns,
                 rows: bounded,
                 total: result.totalRows,
                 diagnostic: result.diagnostic
-            ))
+            )
+            return encodeBoundedTableData(payload, maxBytes: configuration.maxBytes)
         }
 
         func handleTableStructure(body: Data) -> SdkRouteResponse {
@@ -247,15 +247,14 @@
                 diagnostic: result.diagnostic,
                 truncated: result.truncated
             )
-            return encode(payload)
+            return encodeBoundedExecuteSql(payload, maxBytes: configuration.maxBytes)
         }
 
         private func isKnownDatabasePath(_ databasePath: String, driver: DatabaseDriver) -> Bool {
             let configuration = DatabaseInspector.shared.inspectionConfiguration
             return driver.getDatabases().contains { descriptor in
                 descriptor.path == databasePath
-                    && (configuration.allowedDatabasePaths.isEmpty
-                        || configuration.allowedDatabasePaths.contains(databasePath))
+                    && configuration.allowedDatabasePaths.contains(databasePath)
             }
         }
 
@@ -268,6 +267,69 @@
                 return error(statusCode: 500, code: "encode_failed")
             }
             return SdkRouteResponse(statusCode: 200, body: data)
+        }
+
+        private func encodeBounded<T: Encodable>(_ payload: T, maxBytes: Int) -> SdkRouteResponse {
+            guard let data = try? JSONEncoder().encode(payload) else {
+                return error(statusCode: 500, code: "encode_failed")
+            }
+            guard data.count <= maxBytes else {
+                return error(statusCode: 413, code: "response_too_large")
+            }
+            return SdkRouteResponse(statusCode: 200, body: data)
+        }
+
+        private func encodeBoundedTableData(
+            _ payload: SdkTableDataPayload,
+            maxBytes: Int
+        ) -> SdkRouteResponse {
+            var rows = payload.rows
+            while true {
+                let candidate = SdkTableDataPayload(
+                    columns: payload.columns,
+                    rows: rows,
+                    total: payload.total,
+                    diagnostic: payload.diagnostic
+                )
+                guard let data = try? JSONEncoder().encode(candidate) else {
+                    return error(statusCode: 500, code: "encode_failed")
+                }
+                if data.count <= maxBytes {
+                    return SdkRouteResponse(statusCode: 200, body: data)
+                }
+                guard !rows.isEmpty else {
+                    return error(statusCode: 413, code: "response_too_large")
+                }
+                rows.removeLast()
+            }
+        }
+
+        private func encodeBoundedExecuteSql(
+            _ payload: SdkExecuteSqlPayload,
+            maxBytes: Int
+        ) -> SdkRouteResponse {
+            var rows = payload.rows ?? []
+            while true {
+                let candidate = SdkExecuteSqlPayload(
+                    queryType: payload.queryType,
+                    columns: payload.columns,
+                    rows: rows,
+                    rowsAffected: payload.rowsAffected,
+                    error: payload.error,
+                    diagnostic: payload.diagnostic,
+                    truncated: payload.truncated || rows.count < (payload.rows?.count ?? 0)
+                )
+                guard let data = try? JSONEncoder().encode(candidate) else {
+                    return error(statusCode: 500, code: "encode_failed")
+                }
+                if data.count <= maxBytes {
+                    return SdkRouteResponse(statusCode: 200, body: data)
+                }
+                guard !rows.isEmpty else {
+                    return error(statusCode: 413, code: "response_too_large")
+                }
+                rows.removeLast()
+            }
         }
 
         private func error(statusCode: Int, code: String) -> SdkRouteResponse {

--- a/ios/auto-mobile-sdk/Sources/AutoMobileSDK/Storage/SdkDatabaseRouteHandler.swift
+++ b/ios/auto-mobile-sdk/Sources/AutoMobileSDK/Storage/SdkDatabaseRouteHandler.swift
@@ -48,6 +48,7 @@
         let rowsAffected: Int
         let error: String?
         let diagnostic: StorageDiagnostic?
+        let truncated: Bool
     }
 
     struct SdkDatabaseListPayload: Codable {
@@ -76,10 +77,12 @@
         let columns: [String]
         let rows: [[String?]]
         let total: Int
+        let diagnostic: StorageDiagnostic?
     }
 
     struct SdkTableStructurePayload: Codable {
         let columns: [SdkColumnInfoPayload]
+        let diagnostic: StorageDiagnostic?
     }
 
     struct SdkColumnInfoPayload: Codable {
@@ -166,7 +169,12 @@
                 configuredKeys: configuration.sensitiveKeys
             )
             let bounded = boundRows(redacted, maxBytes: configuration.maxBytes)
-            return encode(SdkTableDataPayload(columns: result.columns, rows: bounded, total: result.totalRows))
+            return encode(SdkTableDataPayload(
+                columns: result.columns,
+                rows: bounded,
+                total: result.totalRows,
+                diagnostic: result.diagnostic
+            ))
         }
 
         func handleTableStructure(body: Data) -> SdkRouteResponse {
@@ -184,15 +192,19 @@
             }
 
             let result = driver.getTableStructure(databasePath: request.databasePath, table: request.table)
+            let configuration = DatabaseInspector.shared.inspectionConfiguration
             return encode(SdkTableStructurePayload(columns: result.columns.map {
                 SdkColumnInfoPayload(
                     name: $0.name,
                     type: $0.type,
                     nullable: $0.isNullable,
                     primaryKey: $0.isPrimaryKey,
-                    defaultValue: $0.defaultValue
+                    defaultValue: StorageInspectionAccess.isSensitive(
+                        $0.name,
+                        configured: configuration.sensitiveKeys
+                    ) ? "[REDACTED]" : $0.defaultValue
                 )
-            }))
+            }, diagnostic: result.diagnostic))
         }
 
         func handleExecuteSql(body: Data) -> SdkRouteResponse {
@@ -232,7 +244,8 @@
                 rows: rows,
                 rowsAffected: result.rowsAffected,
                 error: result.error,
-                diagnostic: result.diagnostic
+                diagnostic: result.diagnostic,
+                truncated: result.truncated
             )
             return encode(payload)
         }
@@ -271,7 +284,8 @@
                 .split(whereSeparator: { $0 == " " || $0 == "\n" || $0 == "\t" })
                 .first?
                 .uppercased()
-            return keyword == "SELECT" || keyword == "EXPLAIN" || keyword == "PRAGMA"
+            return keyword == "SELECT" || keyword == "EXPLAIN"
+                || keyword == "PRAGMA" && !query.contains("=")
                 || keyword == "WITH" && !query.localizedCaseInsensitiveContains("INSERT")
                     && !query.localizedCaseInsensitiveContains("UPDATE")
                     && !query.localizedCaseInsensitiveContains("DELETE")

--- a/ios/auto-mobile-sdk/Sources/AutoMobileSDK/Storage/StorageInspectionPolicy.swift
+++ b/ios/auto-mobile-sdk/Sources/AutoMobileSDK/Storage/StorageInspectionPolicy.swift
@@ -1,0 +1,88 @@
+import Foundation
+
+/// Host-provided metadata for a Core Data store that can be inspected without
+/// opening a second writer connection.
+public struct CoreDataStoreRegistration: Sendable, Codable {
+    public let identifier: String
+    public let modelVersion: String?
+    public let entities: [String]
+
+    public init(identifier: String, modelVersion: String? = nil, entities: [String] = []) {
+        self.identifier = identifier
+        self.modelVersion = modelVersion
+        self.entities = entities
+    }
+}
+
+/// Limits and access boundaries applied to storage inspection routes.
+public struct StorageInspectionConfiguration: Sendable {
+    public var allowedDatabasePaths: Set<String>
+    public var registeredAppGroupSuites: Set<String>
+    public var coreDataStores: [CoreDataStoreRegistration]
+    public var sensitiveKeys: Set<String>
+    public var maxRows: Int
+    public var maxBytes: Int
+    public var allowMutations: Bool
+
+    public init(
+        allowedDatabasePaths: Set<String> = [],
+        registeredAppGroupSuites: Set<String> = [],
+        coreDataStores: [CoreDataStoreRegistration] = [],
+        sensitiveKeys: Set<String> = [],
+        maxRows: Int = 500,
+        maxBytes: Int = 512 * 1024,
+        allowMutations: Bool = false
+    ) {
+        self.allowedDatabasePaths = allowedDatabasePaths
+        self.registeredAppGroupSuites = registeredAppGroupSuites
+        self.coreDataStores = coreDataStores
+        self.sensitiveKeys = sensitiveKeys
+        self.maxRows = max(1, maxRows)
+        self.maxBytes = max(1, maxBytes)
+        self.allowMutations = allowMutations
+    }
+}
+
+/// A stable classification for storage failures. The message is intentionally
+/// separate so transport consumers can react without parsing SQLite text.
+public struct StorageDiagnostic: Sendable, Codable, Equatable {
+    public let code: String
+    public let message: String
+
+    public init(code: String, message: String) {
+        self.code = code
+        self.message = message
+    }
+}
+
+enum StorageInspectionAccess {
+    static let defaultSensitiveKeys: Set<String> = [
+        "authorization", "credential", "credentials", "password", "passwd",
+        "secret", "token", "access_token", "refresh_token", "api_key",
+        "apikey", "private_key", "keychain", "cookie"
+    ]
+
+    static func isSensitive(_ column: String, configured: Set<String>) -> Bool {
+        let normalized = column.lowercased()
+        return defaultSensitiveKeys.contains { normalized.contains($0) }
+            || configured.contains { normalized == $0.lowercased() }
+    }
+
+    static func redactedRows(
+        columns: [String],
+        rows: [[String?]],
+        configuredKeys: Set<String>
+    ) -> [[String?]] {
+        rows.map { row in
+            row.enumerated().map { index, value in
+                guard index < columns.count,
+                      value != nil,
+                      isSensitive(columns[index], configured: configuredKeys)
+                else {
+                    return value
+                }
+                return "[REDACTED]"
+            }
+        }
+    }
+}

--- a/ios/auto-mobile-sdk/Sources/AutoMobileSDK/ViewHierarchy/SdkHierarchyServer.swift
+++ b/ios/auto-mobile-sdk/Sources/AutoMobileSDK/ViewHierarchy/SdkHierarchyServer.swift
@@ -123,6 +123,8 @@ final class SdkHierarchyServer: @unchecked Sendable {
                     }
                 } else if request.contains("POST /db/list") {
                     self.sendRouteResponse(connection, self.databaseRouteHandler.handleListDatabases())
+                } else if request.contains("POST /db/capabilities") {
+                    self.sendRouteResponse(connection, self.databaseRouteHandler.handleCapabilities())
                 } else if request.contains("POST /db/tables") {
                     self.handleBodyRoute(connection, initialData: requestData) {
                         self.databaseRouteHandler.handleListTables(body: $0)

--- a/ios/auto-mobile-sdk/Tests/AutoMobileSDKTests/StorageTests.swift
+++ b/ios/auto-mobile-sdk/Tests/AutoMobileSDKTests/StorageTests.swift
@@ -671,6 +671,81 @@ final class SdkDatabaseRouteHandlerTests: XCTestCase {
         let payload = try JSONDecoder().decode(SdkDatabaseErrorPayload.self, from: response.body)
         XCTAssertEqual(payload.error, "db_inspection_disabled")
     }
+
+    func testMutationsRequireExplicitAuthorization() throws {
+        let fakeDriver = RouteFakeDatabaseDriver()
+        fakeDriver.databases = [
+            DatabaseDescriptor(name: "app.db", path: "/app/Documents/app.db", sizeBytes: 1024),
+        ]
+        DatabaseInspector.shared.initialize()
+        DatabaseInspector.shared.setDriver(fakeDriver)
+        DatabaseInspector.shared.setEnabled(true)
+
+        let body = try JSONEncoder().encode(SdkExecuteSqlRequest(
+            databasePath: "/app/Documents/app.db",
+            query: "DELETE FROM notes"
+        ))
+        let response = SdkDatabaseRouteHandler().handleExecuteSql(body: body)
+
+        XCTAssertEqual(response.statusCode, 403)
+        XCTAssertTrue(fakeDriver.executeSqlCalls.isEmpty)
+        let payload = try JSONDecoder().decode(SdkDatabaseErrorPayload.self, from: response.body)
+        XCTAssertEqual(payload.diagnostic?.code, "mutation_not_authorized")
+    }
+
+    func testQueryValuesAreRedactedAndBoundedBeforeTransport() throws {
+        let fakeDriver = RouteFakeDatabaseDriver()
+        fakeDriver.databases = [
+            DatabaseDescriptor(name: "app.db", path: "/app/Documents/app.db", sizeBytes: 1024),
+        ]
+        fakeDriver.sqlResult = SQLExecutionResult(
+            columns: ["username", "access_token", "configured_secret"],
+            rows: [["jason", "secret-token", "private-value"], ["second", "another", "second-value"]],
+            rowsAffected: 0
+        )
+        DatabaseInspector.shared.initialize()
+        DatabaseInspector.shared.setDriver(fakeDriver)
+        DatabaseInspector.shared.configure(StorageInspectionConfiguration(
+            sensitiveKeys: ["configured_secret"],
+            maxRows: 10,
+            maxBytes: 80
+        ))
+        DatabaseInspector.shared.setEnabled(true)
+
+        let body = try JSONEncoder().encode(SdkExecuteSqlRequest(
+            databasePath: "/app/Documents/app.db",
+            query: "SELECT username, access_token, configured_secret FROM notes"
+        ))
+        let response = SdkDatabaseRouteHandler().handleExecuteSql(body: body)
+        let payload = try JSONDecoder().decode(SdkExecuteSqlPayload.self, from: response.body)
+
+        XCTAssertEqual(response.statusCode, 200)
+        XCTAssertEqual(payload.rows?.first, ["jason", "[REDACTED]", "[REDACTED]"])
+        XCTAssertFalse(String(data: response.body, encoding: .utf8)?.contains("secret-token") ?? true)
+        XCTAssertFalse(String(data: response.body, encoding: .utf8)?.contains("private-value") ?? true)
+    }
+
+    func testConfiguredDatabaseAllowlistBlocksUnregisteredPath() throws {
+        let fakeDriver = RouteFakeDatabaseDriver()
+        fakeDriver.databases = [
+            DatabaseDescriptor(name: "app.db", path: "/app/Documents/app.db", sizeBytes: 1024),
+        ]
+        DatabaseInspector.shared.initialize()
+        DatabaseInspector.shared.setDriver(fakeDriver)
+        DatabaseInspector.shared.configure(StorageInspectionConfiguration(
+            allowedDatabasePaths: ["/app/Allowed/other.sqlite"]
+        ))
+        DatabaseInspector.shared.setEnabled(true)
+
+        let body = try JSONEncoder().encode(SdkExecuteSqlRequest(
+            databasePath: "/app/Documents/app.db",
+            query: "SELECT 1"
+        ))
+        let response = SdkDatabaseRouteHandler().handleExecuteSql(body: body)
+
+        XCTAssertEqual(response.statusCode, 404)
+        XCTAssertTrue(fakeDriver.executeSqlCalls.isEmpty)
+    }
 }
 
 final class SQLiteDatabaseDriverConcurrencyTests: XCTestCase {

--- a/ios/auto-mobile-sdk/Tests/AutoMobileSDKTests/StorageTests.swift
+++ b/ios/auto-mobile-sdk/Tests/AutoMobileSDKTests/StorageTests.swift
@@ -693,6 +693,25 @@ final class SdkDatabaseRouteHandlerTests: XCTestCase {
         XCTAssertEqual(payload.diagnostic?.code, "mutation_not_authorized")
     }
 
+    func testPragmaMutationRequiresExplicitAuthorization() throws {
+        let fakeDriver = RouteFakeDatabaseDriver()
+        fakeDriver.databases = [
+            DatabaseDescriptor(name: "app.db", path: "/app/Documents/app.db", sizeBytes: 1024),
+        ]
+        DatabaseInspector.shared.initialize()
+        DatabaseInspector.shared.setDriver(fakeDriver)
+        DatabaseInspector.shared.setEnabled(true)
+
+        let body = try JSONEncoder().encode(SdkExecuteSqlRequest(
+            databasePath: "/app/Documents/app.db",
+            query: "PRAGMA user_version = 7"
+        ))
+        let response = SdkDatabaseRouteHandler().handleExecuteSql(body: body)
+
+        XCTAssertEqual(response.statusCode, 403)
+        XCTAssertTrue(fakeDriver.executeSqlCalls.isEmpty)
+    }
+
     func testQueryValuesAreRedactedAndBoundedBeforeTransport() throws {
         let fakeDriver = RouteFakeDatabaseDriver()
         fakeDriver.databases = [

--- a/ios/auto-mobile-sdk/Tests/AutoMobileSDKTests/StorageTests.swift
+++ b/ios/auto-mobile-sdk/Tests/AutoMobileSDKTests/StorageTests.swift
@@ -550,6 +550,13 @@ final class DatabaseInspectorTests: XCTestCase {
 }
 
 final class SdkDatabaseRouteHandlerTests: XCTestCase {
+    override func setUp() {
+        super.setUp()
+        DatabaseInspector.shared.configure(StorageInspectionConfiguration(
+            allowedDatabasePaths: ["/app/Documents/app.db"]
+        ))
+    }
+
     override func tearDown() {
         DatabaseInspector.shared.reset()
         super.tearDown()
@@ -725,9 +732,10 @@ final class SdkDatabaseRouteHandlerTests: XCTestCase {
         DatabaseInspector.shared.initialize()
         DatabaseInspector.shared.setDriver(fakeDriver)
         DatabaseInspector.shared.configure(StorageInspectionConfiguration(
+            allowedDatabasePaths: ["/app/Documents/app.db"],
             sensitiveKeys: ["configured_secret"],
             maxRows: 10,
-            maxBytes: 80
+            maxBytes: 2048
         ))
         DatabaseInspector.shared.setEnabled(true)
 
@@ -742,6 +750,7 @@ final class SdkDatabaseRouteHandlerTests: XCTestCase {
         XCTAssertEqual(payload.rows?.first, ["jason", "[REDACTED]", "[REDACTED]"])
         XCTAssertFalse(String(data: response.body, encoding: .utf8)?.contains("secret-token") ?? true)
         XCTAssertFalse(String(data: response.body, encoding: .utf8)?.contains("private-value") ?? true)
+        XCTAssertLessThanOrEqual(response.body.count, 2048)
     }
 
     func testConfiguredDatabaseAllowlistBlocksUnregisteredPath() throws {

--- a/ios/auto-mobile-sdk/api/auto-mobile-sdk.api
+++ b/ios/auto-mobile-sdk/api/auto-mobile-sdk.api
@@ -614,6 +614,11 @@ public final class DatabaseInspector: @unchecked Sendable
   public static let shared = DatabaseInspector()
   public var isEnabled: Bool
   public func setEnabled(_ enabled: Bool)
+  public func configure(_ configuration: StorageInspectionConfiguration)
+  public func registerAppGroupSuite(_ suiteName: String)
+  public func registerCoreDataStore(_ store: CoreDataStoreRegistration)
+  public func authorizeHostMutations(_ authorized: Bool)
+  public func authorizeSessionMutations(sessionId: String?)
   public func getDriver() -> DatabaseDriver?
 public protocol DatabaseDriver: Sendable
 public struct DatabaseDescriptor: Sendable
@@ -641,7 +646,8 @@ public struct SQLExecutionResult: Sendable
   public let rows: [[String?]]?
   public let rowsAffected: Int
   public let error: String?
-  public init(columns: [String]?, rows: [[String?]]?, rowsAffected: Int, error: String? = nil)
+  public let diagnostic: StorageDiagnostic?
+  public init(columns: [String]?, rows: [[String?]]?, rowsAffected: Int, error: String? = nil, diagnostic: StorageDiagnostic? = nil)
 
 // Storage/SQLiteDatabaseDriver.swift
 public final class SQLiteDatabaseDriver: DatabaseDriver, @unchecked Sendable
@@ -652,6 +658,26 @@ public final class SQLiteDatabaseDriver: DatabaseDriver, @unchecked Sendable
   public func getTableStructure(databasePath: String, table: String) -> TableStructureResult
   public func executeSQL(databasePath: String, query: String) -> SQLExecutionResult
   public func closeAll()
+
+// Storage/StorageInspectionPolicy.swift
+public struct CoreDataStoreRegistration: Sendable, Codable
+  public let identifier: String
+  public let modelVersion: String?
+  public let entities: [String]
+  public init(identifier: String, modelVersion: String? = nil, entities: [String] = [])
+public struct StorageInspectionConfiguration: Sendable
+  public var allowedDatabasePaths: Set<String>
+  public var registeredAppGroupSuites: Set<String>
+  public var coreDataStores: [CoreDataStoreRegistration]
+  public var sensitiveKeys: Set<String>
+  public var maxRows: Int
+  public var maxBytes: Int
+  public var allowMutations: Bool
+  public init( allowedDatabasePaths: Set<String> = [], registeredAppGroupSuites: Set<String> = [], coreDataStores: [CoreDataStoreRegistration] = [], sensitiveKeys: Set<String> = [], maxRows: Int = 500, maxBytes: Int = 512 * 1024, allowMutations: Bool = false )
+public struct StorageDiagnostic: Sendable, Codable, Equatable
+  public let code: String
+  public let message: String
+  public init(code: String, message: String)
 
 // Storage/UserDefaultsInspector.swift
 public final class UserDefaultsInspector: @unchecked Sendable

--- a/ios/auto-mobile-sdk/api/auto-mobile-sdk.api
+++ b/ios/auto-mobile-sdk/api/auto-mobile-sdk.api
@@ -630,10 +630,12 @@ public struct TableDataResult: Sendable
   public let columns: [String]
   public let rows: [[String?]]
   public let totalRows: Int
-  public init(columns: [String], rows: [[String?]], totalRows: Int)
+  public let diagnostic: StorageDiagnostic?
+  public init(columns: [String], rows: [[String?]], totalRows: Int, diagnostic: StorageDiagnostic? = nil)
 public struct TableStructureResult: Sendable
   public let columns: [ColumnInfo]
-  public init(columns: [ColumnInfo])
+  public let diagnostic: StorageDiagnostic?
+  public init(columns: [ColumnInfo], diagnostic: StorageDiagnostic? = nil)
 public struct ColumnInfo: Sendable
   public let name: String
   public let type: String
@@ -647,7 +649,8 @@ public struct SQLExecutionResult: Sendable
   public let rowsAffected: Int
   public let error: String?
   public let diagnostic: StorageDiagnostic?
-  public init(columns: [String]?, rows: [[String?]]?, rowsAffected: Int, error: String? = nil, diagnostic: StorageDiagnostic? = nil)
+  public let truncated: Bool
+  public init( columns: [String]?, rows: [[String?]]?, rowsAffected: Int, error: String? = nil, diagnostic: StorageDiagnostic? = nil, truncated: Bool = false )
 
 // Storage/SQLiteDatabaseDriver.swift
 public final class SQLiteDatabaseDriver: DatabaseDriver, @unchecked Sendable

--- a/ios/control-proxy/Sources/CtrlProxy/CommandHandler.swift
+++ b/ios/control-proxy/Sources/CtrlProxy/CommandHandler.swift
@@ -214,6 +214,9 @@ public class CommandHandler: CommandHandling {
             case let .listDatabases(payload):
                 return handleListDatabases(payload, startTime: startTime)
 
+            case let .storageCapabilities(payload):
+                return handleStorageCapabilities(payload, startTime: startTime)
+
             case let .listTables(payload):
                 return handleListTables(payload, startTime: startTime)
 
@@ -1422,7 +1425,7 @@ public class CommandHandler: CommandHandling {
 
         do {
             try validateDatabaseAppId(request.appId)
-            let result = try client.executeSQL(databasePath: databasePath, query: query)
+            let result = try client.executeSQL(databasePath: databasePath, query: query, sessionId: request.sessionId)
             if let error = result.error {
                 return ExecuteSqlResponse(
                     requestId: request.requestId,
@@ -1472,6 +1475,38 @@ public class CommandHandler: CommandHandling {
             )
         } catch {
             return ListDatabasesResponse(
+                requestId: request.requestId,
+                success: false,
+                error: error.localizedDescription,
+                totalTimeMs: totalTimeMs(from: startTime)
+            )
+        }
+    }
+
+    private func handleStorageCapabilities(
+        _ request: RequestStorageCapabilities,
+        startTime: Date
+    ) -> StorageCapabilitiesResponse {
+        guard let client = sdkDatabaseClient else {
+            return StorageCapabilitiesResponse(
+                requestId: request.requestId,
+                success: false,
+                error: databaseUnavailableMessage,
+                totalTimeMs: totalTimeMs(from: startTime)
+            )
+        }
+
+        do {
+            try validateDatabaseAppId(request.appId)
+            let capabilities = try client.storageCapabilities()
+            return StorageCapabilitiesResponse(
+                requestId: request.requestId,
+                success: true,
+                capabilities: capabilities,
+                totalTimeMs: totalTimeMs(from: startTime)
+            )
+        } catch {
+            return StorageCapabilitiesResponse(
                 requestId: request.requestId,
                 success: false,
                 error: error.localizedDescription,
@@ -1556,6 +1591,7 @@ public class CommandHandler: CommandHandling {
                 columns: data.columns,
                 rows: data.rows,
                 total: data.total,
+                diagnostic: data.diagnostic,
                 totalTimeMs: totalTimeMs(from: startTime)
             )
         } catch {
@@ -1618,6 +1654,7 @@ public class CommandHandler: CommandHandling {
                 requestId: request.requestId,
                 success: true,
                 columns: structure.columns,
+                diagnostic: structure.diagnostic,
                 totalTimeMs: totalTimeMs(from: startTime)
             )
         } catch {

--- a/ios/control-proxy/Sources/CtrlProxy/CommandHandler.swift
+++ b/ios/control-proxy/Sources/CtrlProxy/CommandHandler.swift
@@ -1436,9 +1436,11 @@ public class CommandHandler: CommandHandling {
                 success: true,
                 queryType: result.queryType,
                 columns: result.columns,
-                rows: result.rows,
-                rowsAffected: result.rowsAffected,
-                totalTimeMs: totalTimeMs(from: startTime)
+                    rows: result.rows,
+                    rowsAffected: result.rowsAffected,
+                    diagnostic: result.diagnostic,
+                    truncated: result.truncated,
+                    totalTimeMs: totalTimeMs(from: startTime)
             )
         } catch {
             return ExecuteSqlResponse(

--- a/ios/control-proxy/Sources/CtrlProxy/Fakes.swift
+++ b/ios/control-proxy/Sources/CtrlProxy/Fakes.swift
@@ -1073,13 +1073,20 @@ public class FakeSdkDatabaseFetcher: SdkDatabaseFetching {
     public var executeSqlResult = SdkExecuteSqlResult(queryType: "query", columns: [], rows: [], rowsAffected: 0)
     public var executeSqlError: Error?
     public var databases: [SdkDatabaseInfo] = []
+    public var storageCapabilitiesResult = SdkStorageCapabilities(
+        readOnly: true,
+        mutationAuthorized: false,
+        registeredAppGroupSuites: [],
+        coreDataStores: [],
+        unavailableStores: ["keychain", "file_caches"]
+    )
     public var tables: [String] = []
     public var tableData = SdkTableDataResult(columns: [], rows: [], total: 0)
     public var tableStructure = SdkTableStructureResult(columns: [])
 
     public init() {}
 
-    public func executeSQL(databasePath: String, query: String) throws -> SdkExecuteSqlResult {
+    public func executeSQL(databasePath: String, query: String, sessionId: String? = nil) throws -> SdkExecuteSqlResult {
         executeSqlCalls.append((databasePath: databasePath, query: query))
         if let executeSqlError {
             throw executeSqlError
@@ -1090,6 +1097,10 @@ public class FakeSdkDatabaseFetcher: SdkDatabaseFetching {
     public func listDatabases() throws -> [SdkDatabaseInfo] {
         listDatabasesCallCount += 1
         return databases
+    }
+
+    public func storageCapabilities() throws -> SdkStorageCapabilities {
+        storageCapabilitiesResult
     }
 
     public func listTables(databasePath: String) throws -> [String] {

--- a/ios/control-proxy/Sources/CtrlProxy/Models.swift
+++ b/ios/control-proxy/Sources/CtrlProxy/Models.swift
@@ -248,9 +248,15 @@ public struct RequestExecuteSql: Decodable {
     public var appId: String?
     public var databasePath: String?
     public var query: String?
+    public var sessionId: String?
 }
 
 public struct RequestListDatabases: Decodable {
+    public var requestId: String?
+    public var appId: String?
+}
+
+public struct RequestStorageCapabilities: Decodable {
     public var requestId: String?
     public var appId: String?
 }
@@ -323,6 +329,7 @@ extension RequestSetNetworkMockRules: CommandPayload {}
 extension RequestSetNetworkErrorSimulation: CommandPayload {}
 extension RequestExecuteSql: CommandPayload {}
 extension RequestListDatabases: CommandPayload {}
+extension RequestStorageCapabilities: CommandPayload {}
 extension RequestListTables: CommandPayload {}
 extension RequestGetTableData: CommandPayload {}
 extension RequestGetTableStructure: CommandPayload {}
@@ -381,6 +388,7 @@ public enum WebSocketRequest: Decodable {
 
     case executeSql(RequestExecuteSql)
     case listDatabases(RequestListDatabases)
+    case storageCapabilities(RequestStorageCapabilities)
     case listTables(RequestListTables)
     case getTableData(RequestGetTableData)
     case getTableStructure(RequestGetTableStructure)
@@ -482,6 +490,8 @@ public enum WebSocketRequest: Decodable {
             self = try .executeSql(RequestExecuteSql(from: decoder))
         case .listDatabases:
             self = try .listDatabases(RequestListDatabases(from: decoder))
+        case .storageCapabilities:
+            self = try .storageCapabilities(RequestStorageCapabilities(from: decoder))
         case .listTables:
             self = try .listTables(RequestListTables(from: decoder))
         case .getTableData:
@@ -534,6 +544,7 @@ public enum WebSocketRequest: Decodable {
         case .setNetworkErrorSimulation: return .setNetworkErrorSimulation
         case .executeSql: return .executeSql
         case .listDatabases: return .listDatabases
+        case .storageCapabilities: return .storageCapabilities
         case .listTables: return .listTables
         case .getTableData: return .getTableData
         case .getTableStructure: return .getTableStructure
@@ -592,6 +603,7 @@ public enum WebSocketRequest: Decodable {
         case let .setNetworkErrorSimulation(payload): return payload
         case let .executeSql(payload): return payload
         case let .listDatabases(payload): return payload
+        case let .storageCapabilities(payload): return payload
         case let .listTables(payload): return payload
         case let .getTableData(payload): return payload
         case let .getTableStructure(payload): return payload
@@ -1506,6 +1518,32 @@ public struct ListDatabasesResponse: Codable {
     }
 }
 
+public struct StorageCapabilitiesResponse: Codable {
+    public let type: String
+    public let timestamp: Int64
+    public let requestId: String?
+    public let success: Bool
+    public let capabilities: SdkStorageCapabilities?
+    public let error: String?
+    public let totalTimeMs: Int64?
+
+    public init(
+        requestId: String?,
+        success: Bool,
+        capabilities: SdkStorageCapabilities? = nil,
+        error: String? = nil,
+        totalTimeMs: Int64? = nil
+    ) {
+        type = ResponseType.storageCapabilitiesResult.rawValue
+        timestamp = Int64(Date().timeIntervalSince1970 * 1000)
+        self.requestId = requestId
+        self.success = success
+        self.capabilities = capabilities
+        self.error = error
+        self.totalTimeMs = totalTimeMs
+    }
+}
+
 public struct ListTablesResponse: Codable {
     public let type: String
     public let timestamp: Int64
@@ -1541,6 +1579,7 @@ public struct TableDataResponse: Codable {
     public let rows: [[String?]]?
     public let total: Int?
     public let error: String?
+    public let diagnostic: SdkStorageDiagnostic?
     public let totalTimeMs: Int64?
 
     public init(
@@ -1550,6 +1589,7 @@ public struct TableDataResponse: Codable {
         rows: [[String?]]? = nil,
         total: Int? = nil,
         error: String? = nil,
+        diagnostic: SdkStorageDiagnostic? = nil,
         totalTimeMs: Int64? = nil
     ) {
         type = ResponseType.tableDataResult.rawValue
@@ -1560,6 +1600,7 @@ public struct TableDataResponse: Codable {
         self.rows = rows
         self.total = total
         self.error = error
+        self.diagnostic = diagnostic
         self.totalTimeMs = totalTimeMs
     }
 }
@@ -1571,6 +1612,7 @@ public struct TableStructureResponse: Codable {
     public let success: Bool
     public let columns: [SdkColumnInfo]?
     public let error: String?
+    public let diagnostic: SdkStorageDiagnostic?
     public let totalTimeMs: Int64?
 
     public init(
@@ -1578,6 +1620,7 @@ public struct TableStructureResponse: Codable {
         success: Bool,
         columns: [SdkColumnInfo]? = nil,
         error: String? = nil,
+        diagnostic: SdkStorageDiagnostic? = nil,
         totalTimeMs: Int64? = nil
     ) {
         type = ResponseType.tableStructureResult.rawValue
@@ -1586,6 +1629,7 @@ public struct TableStructureResponse: Codable {
         self.success = success
         self.columns = columns
         self.error = error
+        self.diagnostic = diagnostic
         self.totalTimeMs = totalTimeMs
     }
 }
@@ -1704,6 +1748,7 @@ public enum RequestType: String, CaseIterable {
     // Database inspection
     case executeSql = "execute_sql"
     case listDatabases = "list_databases"
+    case storageCapabilities = "storage_capabilities"
     case listTables = "list_tables"
     case getTableData = "get_table_data"
     case getTableStructure = "get_table_structure"
@@ -1756,6 +1801,7 @@ public enum ResponseType: String {
     // Database inspection
     case executeSqlResult = "execute_sql_result"
     case listDatabasesResult = "list_databases_result"
+    case storageCapabilitiesResult = "storage_capabilities_result"
     case listTablesResult = "list_tables_result"
     case tableDataResult = "table_data_result"
     case tableStructureResult = "table_structure_result"
@@ -1815,6 +1861,7 @@ extension RequestType {
         case .setNetworkErrorSimulation: return .setNetworkErrorSimulationResult
         case .executeSql: return .executeSqlResult
         case .listDatabases: return .listDatabasesResult
+        case .storageCapabilities: return .storageCapabilitiesResult
         case .listTables: return .listTablesResult
         case .getTableData: return .tableDataResult
         case .getTableStructure: return .tableStructureResult

--- a/ios/control-proxy/Sources/CtrlProxy/Models.swift
+++ b/ios/control-proxy/Sources/CtrlProxy/Models.swift
@@ -1449,6 +1449,8 @@ public struct ExecuteSqlResponse: Codable {
     public let rows: [[String?]]?
     public let rowsAffected: Int?
     public let error: String?
+    public let diagnostic: SdkStorageDiagnostic?
+    public let truncated: Bool?
     public let totalTimeMs: Int64?
 
     public init(
@@ -1459,6 +1461,8 @@ public struct ExecuteSqlResponse: Codable {
         rows: [[String?]]? = nil,
         rowsAffected: Int? = nil,
         error: String? = nil,
+        diagnostic: SdkStorageDiagnostic? = nil,
+        truncated: Bool? = nil,
         totalTimeMs: Int64? = nil
     ) {
         type = ResponseType.executeSqlResult.rawValue
@@ -1470,6 +1474,8 @@ public struct ExecuteSqlResponse: Codable {
         self.rows = rows
         self.rowsAffected = rowsAffected
         self.error = error
+        self.diagnostic = diagnostic
+        self.truncated = truncated
         self.totalTimeMs = totalTimeMs
     }
 }

--- a/ios/control-proxy/Sources/CtrlProxy/Protocols.swift
+++ b/ios/control-proxy/Sources/CtrlProxy/Protocols.swift
@@ -336,8 +336,9 @@ public protocol SdkHierarchyCaching {
 
 /// Protocol for relaying SQLite database inspection requests to the target app SDK.
 public protocol SdkDatabaseFetching {
-    func executeSQL(databasePath: String, query: String) throws -> SdkExecuteSqlResult
+    func executeSQL(databasePath: String, query: String, sessionId: String?) throws -> SdkExecuteSqlResult
     func listDatabases() throws -> [SdkDatabaseInfo]
+    func storageCapabilities() throws -> SdkStorageCapabilities
     func listTables(databasePath: String) throws -> [String]
     func getTableData(databasePath: String, table: String, limit: Int, offset: Int) throws -> SdkTableDataResult
     func getTableStructure(databasePath: String, table: String) throws -> SdkTableStructureResult

--- a/ios/control-proxy/Sources/CtrlProxy/SdkDatabaseClient.swift
+++ b/ios/control-proxy/Sources/CtrlProxy/SdkDatabaseClient.swift
@@ -26,6 +26,40 @@ public struct SdkDatabaseInfo: Codable, Equatable {
     }
 }
 
+public struct SdkCoreDataStoreRegistration: Codable, Equatable {
+    public let identifier: String
+    public let modelVersion: String?
+    public let entities: [String]
+
+    public init(identifier: String, modelVersion: String?, entities: [String]) {
+        self.identifier = identifier
+        self.modelVersion = modelVersion
+        self.entities = entities
+    }
+}
+
+public struct SdkStorageCapabilities: Codable, Equatable {
+    public let readOnly: Bool
+    public let mutationAuthorized: Bool
+    public let registeredAppGroupSuites: [String]
+    public let coreDataStores: [SdkCoreDataStoreRegistration]
+    public let unavailableStores: [String]
+
+    public init(
+        readOnly: Bool,
+        mutationAuthorized: Bool,
+        registeredAppGroupSuites: [String],
+        coreDataStores: [SdkCoreDataStoreRegistration],
+        unavailableStores: [String]
+    ) {
+        self.readOnly = readOnly
+        self.mutationAuthorized = mutationAuthorized
+        self.registeredAppGroupSuites = registeredAppGroupSuites
+        self.coreDataStores = coreDataStores
+        self.unavailableStores = unavailableStores
+    }
+}
+
 public struct SdkColumnInfo: Codable, Equatable {
     public let name: String
     public let type: String
@@ -51,6 +85,10 @@ public struct SdkExecuteSqlResult: Codable, Equatable {
     public let diagnostic: SdkStorageDiagnostic?
     public let truncated: Bool
 
+    private enum CodingKeys: String, CodingKey {
+        case queryType, columns, rows, rowsAffected, error, diagnostic, truncated
+    }
+
     public init(
         queryType: String,
         columns: [String]? = nil,
@@ -68,6 +106,17 @@ public struct SdkExecuteSqlResult: Codable, Equatable {
         self.diagnostic = diagnostic
         self.truncated = truncated
     }
+
+    public init(from decoder: Decoder) throws {
+        let container = try decoder.container(keyedBy: CodingKeys.self)
+        queryType = try container.decode(String.self, forKey: .queryType)
+        columns = try container.decodeIfPresent([String].self, forKey: .columns)
+        rows = try container.decodeIfPresent([[String?]].self, forKey: .rows)
+        rowsAffected = try container.decode(Int.self, forKey: .rowsAffected)
+        error = try container.decodeIfPresent(String.self, forKey: .error)
+        diagnostic = try container.decodeIfPresent(SdkStorageDiagnostic.self, forKey: .diagnostic)
+        truncated = try container.decodeIfPresent(Bool.self, forKey: .truncated) ?? false
+    }
 }
 
 public struct SdkStorageDiagnostic: Codable, Equatable {
@@ -84,19 +133,23 @@ public struct SdkTableDataResult: Codable, Equatable {
     public let columns: [String]
     public let rows: [[String?]]
     public let total: Int
+    public let diagnostic: SdkStorageDiagnostic?
 
-    public init(columns: [String], rows: [[String?]], total: Int) {
+    public init(columns: [String], rows: [[String?]], total: Int, diagnostic: SdkStorageDiagnostic? = nil) {
         self.columns = columns
         self.rows = rows
         self.total = total
+        self.diagnostic = diagnostic
     }
 }
 
 public struct SdkTableStructureResult: Codable, Equatable {
     public let columns: [SdkColumnInfo]
+    public let diagnostic: SdkStorageDiagnostic?
 
-    public init(columns: [SdkColumnInfo]) {
+    public init(columns: [SdkColumnInfo], diagnostic: SdkStorageDiagnostic? = nil) {
         self.columns = columns
+        self.diagnostic = diagnostic
     }
 }
 
@@ -107,6 +160,7 @@ private struct SdkDatabaseErrorPayload: Codable {
 private struct ExecuteSqlRequest: Codable {
     let databasePath: String
     let query: String
+    let sessionId: String?
 }
 
 private struct DatabasePathRequest: Codable {
@@ -129,6 +183,14 @@ private struct ListDatabasesPayload: Codable {
     let databases: [SdkDatabaseInfo]
 }
 
+private struct StorageCapabilitiesPayload: Codable {
+    let readOnly: Bool
+    let mutationAuthorized: Bool
+    let registeredAppGroupSuites: [String]
+    let coreDataStores: [SdkCoreDataStoreRegistration]
+    let unavailableStores: [String]
+}
+
 private struct ListTablesPayload: Codable {
     let tables: [String]
 }
@@ -147,13 +209,24 @@ public final class SdkDatabaseClient: SdkDatabaseFetching, @unchecked Sendable {
         self.urlSession = URLSession(configuration: config)
     }
 
-    public func executeSQL(databasePath: String, query: String) throws -> SdkExecuteSqlResult {
-        try post(path: "/db/execute", body: ExecuteSqlRequest(databasePath: databasePath, query: query))
+    public func executeSQL(databasePath: String, query: String, sessionId: String? = nil) throws -> SdkExecuteSqlResult {
+        try post(path: "/db/execute", body: ExecuteSqlRequest(databasePath: databasePath, query: query, sessionId: sessionId))
     }
 
     public func listDatabases() throws -> [SdkDatabaseInfo] {
         let payload: ListDatabasesPayload = try post(path: "/db/list", body: EmptyRequest())
         return payload.databases
+    }
+
+    public func storageCapabilities() throws -> SdkStorageCapabilities {
+        let payload: StorageCapabilitiesPayload = try post(path: "/db/capabilities", body: EmptyRequest())
+        return SdkStorageCapabilities(
+            readOnly: payload.readOnly,
+            mutationAuthorized: payload.mutationAuthorized,
+            registeredAppGroupSuites: payload.registeredAppGroupSuites,
+            coreDataStores: payload.coreDataStores,
+            unavailableStores: payload.unavailableStores
+        )
     }
 
     public func listTables(databasePath: String) throws -> [String] {

--- a/ios/control-proxy/Sources/CtrlProxy/SdkDatabaseClient.swift
+++ b/ios/control-proxy/Sources/CtrlProxy/SdkDatabaseClient.swift
@@ -48,19 +48,35 @@ public struct SdkExecuteSqlResult: Codable, Equatable {
     public let rows: [[String?]]?
     public let rowsAffected: Int
     public let error: String?
+    public let diagnostic: SdkStorageDiagnostic?
+    public let truncated: Bool
 
     public init(
         queryType: String,
         columns: [String]? = nil,
         rows: [[String?]]? = nil,
         rowsAffected: Int,
-        error: String? = nil
+        error: String? = nil,
+        diagnostic: SdkStorageDiagnostic? = nil,
+        truncated: Bool = false
     ) {
         self.queryType = queryType
         self.columns = columns
         self.rows = rows
         self.rowsAffected = rowsAffected
         self.error = error
+        self.diagnostic = diagnostic
+        self.truncated = truncated
+    }
+}
+
+public struct SdkStorageDiagnostic: Codable, Equatable {
+    public let code: String
+    public let message: String
+
+    public init(code: String, message: String) {
+        self.code = code
+        self.message = message
     }
 }
 

--- a/ios/control-proxy/Tests/CtrlProxyTests/ErrorResponseTypeTests.swift
+++ b/ios/control-proxy/Tests/CtrlProxyTests/ErrorResponseTypeTests.swift
@@ -52,6 +52,7 @@ final class ErrorResponseTypeTests: XCTestCase {
             .setNetworkErrorSimulation: .setNetworkErrorSimulationResult,
             .executeSql: .executeSqlResult,
             .listDatabases: .listDatabasesResult,
+            .storageCapabilities: .storageCapabilitiesResult,
             .listTables: .listTablesResult,
             .getTableData: .tableDataResult,
             .getTableStructure: .tableStructureResult,

--- a/ios/control-proxy/Tests/CtrlProxyTests/TypedRequestDecodeTests.swift
+++ b/ios/control-proxy/Tests/CtrlProxyTests/TypedRequestDecodeTests.swift
@@ -162,6 +162,7 @@ final class TypedRequestDecodeDispatchTests: XCTestCase {
             .setNetworkErrorSimulation: #"{"enabled":false}"#,
             .executeSql: "{}",
             .listDatabases: "{}",
+            .storageCapabilities: "{}",
             .listTables: "{}",
             .getTableData: "{}",
             .getTableStructure: "{}",

--- a/src/features/database/DatabaseInspector.ts
+++ b/src/features/database/DatabaseInspector.ts
@@ -59,6 +59,11 @@ export interface SQLResult {
   rows?: any[][];
   /** Number of rows affected (mutation only) */
   rowsAffected?: number;
+  diagnostic?: {
+    code: string;
+    message: string;
+  };
+  truncated?: boolean;
 }
 
 

--- a/src/features/database/DatabaseInspector.ts
+++ b/src/features/database/DatabaseInspector.ts
@@ -34,6 +34,7 @@ export interface ColumnInfo {
  */
 export interface TableStructureResult {
   columns: ColumnInfo[];
+  diagnostic?: SQLResult["diagnostic"];
 }
 
 /**
@@ -46,6 +47,7 @@ export interface TableDataResult {
   rows: any[][];
   /** Total number of rows in table */
   total: number;
+  diagnostic?: SQLResult["diagnostic"];
 }
 
 /**

--- a/src/features/observe/ios/CtrlProxyDatabase.ts
+++ b/src/features/observe/ios/CtrlProxyDatabase.ts
@@ -33,6 +33,22 @@ interface ListDatabasesResult extends DatabaseResultBase {
   databases?: DatabaseInfo[];
 }
 
+export interface StorageCapabilities {
+  readOnly: boolean;
+  mutationAuthorized: boolean;
+  registeredAppGroupSuites: string[];
+  coreDataStores: Array<{
+    identifier: string;
+    modelVersion?: string;
+    entities: string[];
+  }>;
+  unavailableStores: string[];
+}
+
+interface StorageCapabilitiesResult extends DatabaseResultBase {
+  capabilities?: StorageCapabilities;
+}
+
 interface ListTablesResult extends DatabaseResultBase {
   tables?: string[];
 }
@@ -41,20 +57,28 @@ interface TableDataResponseResult extends DatabaseResultBase {
   columns?: string[];
   rows?: unknown[][];
   total?: number;
+  diagnostic?: SQLResult["diagnostic"];
 }
 
 interface TableStructureResponseResult extends DatabaseResultBase {
   columns?: TableStructureResult["columns"];
+  diagnostic?: SQLResult["diagnostic"];
 }
 
 export class CtrlProxyDatabase {
   constructor(private readonly context: DelegateContext) {}
 
-  async executeSQL(appId: string, databasePath: string, query: string, timeoutMs: number = 5000): Promise<SQLResult> {
+  async executeSQL(
+    appId: string,
+    databasePath: string,
+    query: string,
+    timeoutMs: number = 5000,
+    sessionId?: string
+  ): Promise<SQLResult> {
     const result = await this.request<ExecuteSqlResult>(
       "execute_sql",
       "execute_sql_result",
-      { appId, databasePath, query },
+      { appId, databasePath, query, ...(sessionId ? { sessionId } : {}) },
       timeoutMs,
       "Execute SQL"
     );
@@ -79,6 +103,23 @@ export class CtrlProxyDatabase {
       "List databases"
     );
     return result.databases ?? [];
+  }
+
+  async storageCapabilities(appId: string, timeoutMs: number = 5000): Promise<StorageCapabilities> {
+    const result = await this.request<StorageCapabilitiesResult>(
+      "storage_capabilities",
+      "storage_capabilities_result",
+      { appId },
+      timeoutMs,
+      "Get storage capabilities"
+    );
+    return result.capabilities ?? {
+      readOnly: true,
+      mutationAuthorized: false,
+      registeredAppGroupSuites: [],
+      coreDataStores: [],
+      unavailableStores: [],
+    };
   }
 
   async listTables(appId: string, databasePath: string, timeoutMs: number = 5000): Promise<string[]> {
@@ -111,6 +152,7 @@ export class CtrlProxyDatabase {
       columns: result.columns ?? [],
       rows: result.rows ?? [],
       total: result.total ?? 0,
+      diagnostic: result.diagnostic,
     };
   }
 
@@ -127,7 +169,7 @@ export class CtrlProxyDatabase {
       timeoutMs,
       "Get table structure"
     );
-    return { columns: result.columns ?? [] };
+    return { columns: result.columns ?? [], diagnostic: result.diagnostic };
   }
 
   private async request<T extends DatabaseResultBase>(

--- a/src/features/observe/ios/CtrlProxyDatabase.ts
+++ b/src/features/observe/ios/CtrlProxyDatabase.ts
@@ -25,6 +25,8 @@ interface ExecuteSqlResult extends DatabaseResultBase {
   columns?: string[];
   rows?: unknown[][];
   rowsAffected?: number;
+  diagnostic?: SQLResult["diagnostic"];
+  truncated?: boolean;
 }
 
 interface ListDatabasesResult extends DatabaseResultBase {
@@ -58,11 +60,13 @@ export class CtrlProxyDatabase {
     );
 
     return result.queryType === "mutation"
-      ? { type: "mutation", rowsAffected: result.rowsAffected ?? 0 }
+      ? { type: "mutation", rowsAffected: result.rowsAffected ?? 0, diagnostic: result.diagnostic, truncated: result.truncated }
       : {
         type: "query",
         columns: result.columns ?? [],
         rows: result.rows ?? [],
+        diagnostic: result.diagnostic,
+        truncated: result.truncated,
       };
   }
 

--- a/src/features/observe/ios/IOSCtrlProxyClient.ts
+++ b/src/features/observe/ios/IOSCtrlProxyClient.ts
@@ -1979,7 +1979,7 @@ export class IOSCtrlProxyClient extends DeviceServiceClient implements IOSCtrlPr
     query: string,
     timeoutMs?: number
   ): Promise<import("../../database/DatabaseInspector").SQLResult> {
-    return this.database.executeSQL(appId, databasePath, query, timeoutMs);
+    return this.database.executeSQL(appId, databasePath, query, timeoutMs, this.boundSessionId ?? undefined);
   }
 
   async listDatabasesForIos(
@@ -1987,6 +1987,13 @@ export class IOSCtrlProxyClient extends DeviceServiceClient implements IOSCtrlPr
     timeoutMs?: number
   ): Promise<import("../../database/DatabaseInspector").DatabaseInfo[]> {
     return this.database.listDatabases(appId, timeoutMs);
+  }
+
+  async getStorageCapabilitiesForIos(
+    appId: string,
+    timeoutMs?: number
+  ): Promise<import("./CtrlProxyDatabase").StorageCapabilities> {
+    return this.database.storageCapabilities(appId, timeoutMs);
   }
 
   async listTablesForIos(appId: string, databasePath: string, timeoutMs?: number): Promise<string[]> {

--- a/src/features/observe/ios/ctrlProxyRequestTypes.ts
+++ b/src/features/observe/ios/ctrlProxyRequestTypes.ts
@@ -80,6 +80,7 @@ export const IOS_KNOWN_REQUEST_TYPES = [
   // Database inspection
   "execute_sql",
   "list_databases",
+  "storage_capabilities",
   "list_tables",
   "get_table_data",
   "get_table_structure",

--- a/src/features/observe/ios/decodeCtrlProxyMessage.ts
+++ b/src/features/observe/ios/decodeCtrlProxyMessage.ts
@@ -224,6 +224,8 @@ export function decodeCtrlProxyMessage(message: WebSocketMessage): DecodedCtrlPr
         columns: (message as { columns?: string[] }).columns,
         rows: (message as { rows?: unknown[][] }).rows,
         rowsAffected: (message as { rowsAffected?: number }).rowsAffected,
+        diagnostic: (message as { diagnostic?: unknown }).diagnostic,
+        truncated: (message as { truncated?: boolean }).truncated,
         totalTimeMs: message.totalTimeMs ?? 0,
         error: message.error,
       };
@@ -233,6 +235,15 @@ export function decodeCtrlProxyMessage(message: WebSocketMessage): DecodedCtrlPr
       result = {
         success: message.success ?? false,
         databases: (message as { databases?: unknown[] }).databases ?? [],
+        totalTimeMs: message.totalTimeMs ?? 0,
+        error: message.error,
+      };
+      break;
+
+    case "storage_capabilities_result":
+      result = {
+        success: message.success ?? false,
+        capabilities: (message as { capabilities?: unknown }).capabilities,
         totalTimeMs: message.totalTimeMs ?? 0,
         error: message.error,
       };
@@ -253,6 +264,7 @@ export function decodeCtrlProxyMessage(message: WebSocketMessage): DecodedCtrlPr
         columns: (message as { columns?: string[] }).columns ?? [],
         rows: (message as { rows?: unknown[][] }).rows ?? [],
         total: (message as { total?: number }).total ?? 0,
+        diagnostic: (message as { diagnostic?: unknown }).diagnostic,
         totalTimeMs: message.totalTimeMs ?? 0,
         error: message.error,
       };
@@ -262,6 +274,7 @@ export function decodeCtrlProxyMessage(message: WebSocketMessage): DecodedCtrlPr
       result = {
         success: message.success ?? false,
         columns: (message as { columns?: unknown[] }).columns ?? [],
+        diagnostic: (message as { diagnostic?: unknown }).diagnostic,
         totalTimeMs: message.totalTimeMs ?? 0,
         error: message.error,
       };

--- a/test/features/observe/ios/ctrlProxyWireParity.test.ts
+++ b/test/features/observe/ios/ctrlProxyWireParity.test.ts
@@ -78,6 +78,7 @@ const SWIFT_REQUEST_TYPES = [
   "set_network_error_simulation",
   "execute_sql",
   "list_databases",
+  "storage_capabilities",
   "list_tables",
   "get_table_data",
   "get_table_structure",

--- a/test/features/observe/ios/decodeCtrlProxyMessage.test.ts
+++ b/test/features/observe/ios/decodeCtrlProxyMessage.test.ts
@@ -402,8 +402,8 @@ describe("decodeCtrlProxyMessage ↔ Swift ResponseType parity (ADD-3 / item 4)"
     "set_network_mock_rules_result",
   ];
 
-  test("Swift ResponseType declares exactly 43 rawValues", () => {
-    expect(rawValues.length).toBe(43);
+  test("Swift ResponseType declares exactly 44 rawValues", () => {
+    expect(rawValues.length).toBe(44);
   });
 
   test("rawValues are unique (no accidental duplicate)", () => {
@@ -416,8 +416,8 @@ describe("decodeCtrlProxyMessage ↔ Swift ResponseType parity (ADD-3 / item 4)"
     }
   });
 
-  test("the decoder explicitly reshapes exactly 36 response types", () => {
-    expect(rawValues.filter(isExplicitlyDecoded).length).toBe(36);
+  test("the decoder explicitly reshapes exactly 37 response types", () => {
+    expect(rawValues.filter(isExplicitlyDecoded).length).toBe(37);
   });
 
   test("the only unhandled ResponseType (excluding fire-and-forget) is shake_result", () => {
@@ -440,7 +440,7 @@ describe("decodeCtrlProxyMessage ↔ Swift ResponseType parity (ADD-3 / item 4)"
  */
 describe("decodeCtrlProxyMessage success defaulting (PARAM-5 / item 11)", () => {
   // One row per decoded response type → the value of `success` when the wire
-  // message omits it. 36 rows = the 36 explicitly-decoded ResponseTypes.
+  // message omits it. 37 rows = the 37 explicitly-decoded ResponseTypes.
   const DEFAULT_WHEN_ABSENT: Array<{ type: string; expected: boolean | undefined }> = [
     { type: "hierarchy_update", expected: undefined },
     { type: "screenshot", expected: true },
@@ -475,13 +475,14 @@ describe("decodeCtrlProxyMessage success defaulting (PARAM-5 / item 11)", () => 
     { type: "set_network_error_simulation_result", expected: false },
     { type: "execute_sql_result", expected: false },
     { type: "list_databases_result", expected: false },
+    { type: "storage_capabilities_result", expected: false },
     { type: "list_tables_result", expected: false },
     { type: "table_data_result", expected: false },
     { type: "table_structure_result", expected: false },
   ];
 
-  test("the default table covers all 36 explicitly-decoded types", () => {
-    expect(DEFAULT_WHEN_ABSENT.length).toBe(36);
+  test("the default table covers all 37 explicitly-decoded types", () => {
+    expect(DEFAULT_WHEN_ABSENT.length).toBe(37);
   });
 
   for (const { type, expected } of DEFAULT_WHEN_ABSENT) {
@@ -498,8 +499,8 @@ describe("decodeCtrlProxyMessage success defaulting (PARAM-5 / item 11)", () => 
     .filter(row => row.type !== "hierarchy_update" && row.type !== "screenshot")
     .map(row => row.type);
 
-  test("the passthrough set is the 34 success-reading types", () => {
-    expect(READS_MESSAGE_SUCCESS.length).toBe(34);
+  test("the passthrough set is the 35 success-reading types", () => {
+    expect(READS_MESSAGE_SUCCESS.length).toBe(35);
   });
 
   for (const type of READS_MESSAGE_SUCCESS) {


### PR DESCRIPTION
## What changed

- Added explicit storage inspection configuration for database allowlists, app-group registrations, Core Data metadata, sensitive keys, and response bounds.
- Made SQL inspection read-only by default; mutations now require configuration, host authorization, an authorized request session, and the current SDK session.
- Added read snapshots with deterministic `rowid` ordering where available, bounded pagination, structured SQLite diagnostics, and a capabilities response.
- Redacted credential, token, keychain, and configured sensitive-key columns before transport.

## Validation

- `swift test --package-path ios/auto-mobile-sdk`
- `bash scripts/ios/api-check.sh`
- `bun run typecheck`
- `AUTOMOBILE_DATA_DIR=/tmp/automobile-5061-data TMPDIR=/tmp/automobile-5061-tmp bun run turbo:validate`

Closes #5061
