### PR TITLE
feat: add transport-neutral iOS fault injection

### DIFF
--- a/ios/auto-mobile-sdk/Sources/AutoMobileSDK/Network/AutoMobileNetwork.swift
+++ b/ios/auto-mobile-sdk/Sources/AutoMobileSDK/Network/AutoMobileNetwork.swift
@@ -499,6 +499,34 @@ public class AutoMobileURLProtocol: URLProtocol {
         #if DEBUG
         if AutoMobileSDK.shared.isEnabled,
            let url = request.url,
+           let fault = NetworkMockRuleStore.shared.evaluate(
+               NetworkMockRuleStore.FaultRequest(
+                   transport: .urlSession,
+                   host: url.host,
+                   port: url.port,
+                   scheme: url.scheme,
+                   path: url.path,
+                   method: request.httpMethod ?? "GET",
+                   headers: request.allHTTPHeaderFields ?? [:],
+                   origin: request.value(forHTTPHeaderField: "Origin"),
+                   connectionId: nil,
+                   sessionId: nil
+               )
+           ),
+           !fault.dryRun
+        {
+            if let delayMs = fault.delayMs, delayMs > 0 {
+                DispatchQueue.global().asyncAfter(deadline: .now() + .milliseconds(delayMs)) { [weak self] in
+                    self?.serveFault(fault, url: url)
+                }
+            } else {
+                serveFault(fault, url: url)
+            }
+            return
+        }
+
+        if AutoMobileSDK.shared.isEnabled,
+           let url = request.url,
            let match = NetworkMockRuleStore.shared.findMatchingRule(
                host: url.host ?? "",
                path: url.path,
@@ -577,6 +605,49 @@ public class AutoMobileURLProtocol: URLProtocol {
     }
 
     #if DEBUG
+    private func serveFault(_ fault: NetworkMockRuleStore.FaultDecision, url: URL) {
+        let method = request.httpMethod ?? "GET"
+        let error: URLError
+        switch fault.errorType {
+        case "dnsFailure": error = URLError(.cannotFindHost)
+        case "connectionReset", "reset": error = URLError(.networkConnectionLost)
+        case "timeout": error = URLError(.timedOut)
+        default: error = URLError(.cannotConnectToHost)
+        }
+
+        if fault.action == .error || fault.action == .closeConnection {
+            client?.urlProtocol(self, didFailWithError: error)
+            AutoMobileNetwork.shared.recordRequest(NetworkRequestRecord(
+                url: url.absoluteString, method: method, error: "fault:\(fault.faultId):\(fault.action.rawValue)"
+            ))
+            return
+        }
+
+        let body = Data((fault.responseBody ?? "").utf8)
+        let drop = max(0, fault.dropBytes ?? 0)
+        let delivered = drop == 0 ? body : body.dropLast(min(drop, body.count))
+        var headers = fault.responseHeaders
+        if let contentType = fault.contentType {
+            headers["Content-Type"] = contentType
+        }
+        let status = fault.statusCode ?? 200
+        let response = HTTPURLResponse(
+            url: url, statusCode: status, httpVersion: "HTTP/1.1", headerFields: headers
+        )!  // swiftlint:disable:this force_unwrapping
+        client?.urlProtocol(self, didReceive: response, cacheStoragePolicy: .notAllowed)
+        if !delivered.isEmpty {
+            client?.urlProtocol(self, didLoad: Data(delivered))
+        }
+        client?.urlProtocolDidFinishLoading(self)
+        AutoMobileNetwork.shared.recordRequest(NetworkRequestRecord(
+            url: url.absoluteString, method: method, statusCode: status,
+            responseHeaders: headers, responseBodySize: delivered.count,
+            error: "fault:\(fault.faultId):\(fault.action.rawValue)",
+            responseBody: String(decoding: delivered, as: UTF8.self),
+            contentType: fault.contentType
+        ))
+    }
+
     private func capturedRequestBodyData(limit: Int?) -> Data? {
         guard let limit, limit > 0 else {
             return nil

--- a/ios/auto-mobile-sdk/Sources/AutoMobileSDK/Network/NetworkCaptureRecorder.swift
+++ b/ios/auto-mobile-sdk/Sources/AutoMobileSDK/Network/NetworkCaptureRecorder.swift
@@ -297,6 +297,20 @@ public final class URLSessionNetworkCaptureAdapter: @unchecked Sendable {
         self.recorder = recorder
     }
 
+    #if DEBUG
+    public func evaluateFault(for task: URLSessionTask, sessionId: String? = nil) -> NetworkMockRuleStore.FaultDecision? {
+        let request = task.originalRequest ?? task.currentRequest
+        guard let url = request?.url, AutoMobileSDK.shared.isEnabled else { return nil }
+        return NetworkMockRuleStore.shared.evaluate(.init(
+            transport: .urlSession, host: url.host, port: url.port, scheme: url.scheme,
+            path: url.path, method: request?.httpMethod ?? "GET",
+            headers: request?.allHTTPHeaderFields ?? [:],
+            origin: request?.value(forHTTPHeaderField: "Origin"),
+            connectionId: nil, sessionId: sessionId
+        ))
+    }
+    #endif
+
     @discardableResult
     public func begin(
         url: String,
@@ -366,6 +380,22 @@ public final class WebSocketNetworkCaptureAdapter: @unchecked Sendable {
         self.recorder = recorder
     }
 
+    #if DEBUG
+    public func evaluateFault(
+        url: String,
+        connectionId: String?,
+        direction: NetworkCaptureDirection,
+        sessionId: String? = nil
+    ) -> NetworkMockRuleStore.FaultDecision? {
+        guard AutoMobileSDK.shared.isEnabled, let parsed = URL(string: url) else { return nil }
+        return NetworkMockRuleStore.shared.evaluate(.init(
+            transport: .webSocket, host: parsed.host, port: parsed.port, scheme: parsed.scheme,
+            path: parsed.path, method: direction == .sent ? "SEND" : "RECEIVE",
+            headers: [:], origin: nil, connectionId: connectionId, sessionId: sessionId
+        ))
+    }
+    #endif
+
     public func recordFrame(
         url: String,
         connectionId: String?,
@@ -390,6 +420,21 @@ public final class NWConnectionNetworkCaptureAdapter: @unchecked Sendable {
     public init(recorder: NetworkCaptureRecorder) {
         self.recorder = recorder
     }
+
+    #if DEBUG
+    public func evaluateFault(
+        endpoint: String,
+        connectionId: String,
+        sessionId: String? = nil
+    ) -> NetworkMockRuleStore.FaultDecision? {
+        guard AutoMobileSDK.shared.isEnabled, let parsed = URL(string: endpoint) else { return nil }
+        return NetworkMockRuleStore.shared.evaluate(.init(
+            transport: .nwConnection, host: parsed.host, port: parsed.port, scheme: parsed.scheme,
+            path: parsed.path, method: "CONNECTION", headers: [:], origin: nil,
+            connectionId: connectionId, sessionId: sessionId
+        ))
+    }
+    #endif
 
     @discardableResult
     public func begin(

--- a/ios/auto-mobile-sdk/Sources/AutoMobileSDK/Network/NetworkMockRuleStore.swift
+++ b/ios/auto-mobile-sdk/Sources/AutoMobileSDK/Network/NetworkMockRuleStore.swift
@@ -21,7 +21,71 @@ struct NetworkErrorSimulationDTO: Codable, Equatable {
     let expiresAtEpochMs: Int64?
 }
 
-final class NetworkMockRuleStore: @unchecked Sendable {
+public enum NetworkFaultTransport: String, Codable, Equatable {
+    case urlSession
+    case webSocket
+    case nwConnection
+    case webView
+}
+
+public enum NetworkFaultAction: String, Codable, Equatable {
+    case response
+    case status
+    case error
+    case latency
+    case bandwidth
+    case dropBytes
+    case closeConnection
+    case rejectFrame
+}
+
+public struct NetworkFaultRuleDTO: Codable, Equatable {
+    public let faultId: String
+    public let transport: NetworkFaultTransport?
+    public let host: String?
+    public let port: Int?
+    public let scheme: String?
+    public let path: String?
+    public let method: String?
+    public let headers: [String: String]?
+    public let origin: String?
+    public let connectionId: String?
+    public let sessionId: String?
+    public let action: NetworkFaultAction
+    public let statusCode: Int?
+    public let responseHeaders: [String: String]?
+    public let responseBody: String?
+    public let contentType: String?
+    public let errorType: String?
+    public let delayMs: Int?
+    public let bandwidthBytesPerSecond: Int?
+    public let dropBytes: Int?
+    public let limit: Int?
+    public let expiresAtEpochMs: Int64?
+    public let scope: String?
+    public let dryRun: Bool
+
+    public init(
+        faultId: String, transport: NetworkFaultTransport?, host: String?, port: Int?,
+        scheme: String?, path: String?, method: String?, headers: [String: String]?,
+        origin: String?, connectionId: String?, sessionId: String?, action: NetworkFaultAction,
+        statusCode: Int?, responseHeaders: [String: String]?, responseBody: String?,
+        contentType: String?, errorType: String?, delayMs: Int?,
+        bandwidthBytesPerSecond: Int?, dropBytes: Int?, limit: Int?,
+        expiresAtEpochMs: Int64?, scope: String?, dryRun: Bool
+    ) {
+        self.faultId = faultId; self.transport = transport; self.host = host; self.port = port
+        self.scheme = scheme; self.path = path; self.method = method; self.headers = headers
+        self.origin = origin; self.connectionId = connectionId; self.sessionId = sessionId
+        self.action = action; self.statusCode = statusCode; self.responseHeaders = responseHeaders
+        self.responseBody = responseBody; self.contentType = contentType; self.errorType = errorType
+        self.delayMs = delayMs; self.bandwidthBytesPerSecond = bandwidthBytesPerSecond
+        self.dropBytes = dropBytes; self.limit = limit; self.expiresAtEpochMs = expiresAtEpochMs
+        self.scope = scope; self.dryRun = dryRun
+    }
+}
+
+public final class NetworkMockRuleStore: @unchecked Sendable {
     static let shared = NetworkMockRuleStore()
 
     struct ErrorSimulation: Equatable {
@@ -34,6 +98,39 @@ final class NetworkMockRuleStore: @unchecked Sendable {
         let responseHeaders: [String: String]
         let responseBody: String
         let contentType: String
+    }
+
+    public struct FaultDecision: Equatable {
+        public let faultId: String
+        public let action: NetworkFaultAction
+        public let statusCode: Int?
+        public let responseHeaders: [String: String]
+        public let responseBody: String?
+        public let contentType: String?
+        public let errorType: String?
+        public let delayMs: Int?
+        public let bandwidthBytesPerSecond: Int?
+        public let dropBytes: Int?
+        public let dryRun: Bool
+    }
+
+    public struct FaultRequest: Equatable {
+        public let transport: NetworkFaultTransport
+        public let host: String?
+        public let port: Int?
+        public let scheme: String?
+        public let path: String?
+        public let method: String?
+        public let headers: [String: String]
+        public let origin: String?
+        public let connectionId: String?
+        public let sessionId: String?
+
+        public init(transport: NetworkFaultTransport, host: String?, port: Int?, scheme: String?, path: String?, method: String?, headers: [String: String], origin: String?, connectionId: String?, sessionId: String?) {
+            self.transport = transport; self.host = host; self.port = port; self.scheme = scheme
+            self.path = path; self.method = method; self.headers = headers; self.origin = origin
+            self.connectionId = connectionId; self.sessionId = sessionId
+        }
     }
 
     private struct CompiledRule {
@@ -51,9 +148,16 @@ final class NetworkMockRuleStore: @unchecked Sendable {
     private let lock = NSLock()
     private let dateProvider: DateProvider
     private var rules: [CompiledRule] = []
+    private var faultRules: [CompiledFaultRule] = []
+    private var consumedConnections = Set<String>()
+    private var consumedSessions = Set<String>()
     private var errorSimulation: CompiledErrorSimulation?
 
-    init(dateProvider: DateProvider = SystemDateProvider()) {
+    public init() {
+        self.dateProvider = SystemDateProvider()
+    }
+
+    init(dateProvider: DateProvider) {
         self.dateProvider = dateProvider
     }
 
@@ -82,6 +186,63 @@ final class NetworkMockRuleStore: @unchecked Sendable {
         lock.lock()
         rules = compiled
         lock.unlock()
+    }
+
+    public func setFaultRules(_ dtos: [NetworkFaultRuleDTO]) {
+        let compiled = dtos.compactMap { dto -> CompiledFaultRule? in
+            do {
+                return CompiledFaultRule(
+                    dto: dto,
+                    host: try dto.host.map { try NSRegularExpression(pattern: $0) },
+                    path: try dto.path.map { try NSRegularExpression(pattern: $0) }
+                )
+            } catch {
+                InternalLogger.debug("[NetworkMockRuleStore] Skipping invalid fault rule \(dto.faultId): \(error)")
+                return nil
+            }
+        }
+        lock.lock()
+        faultRules = compiled
+        consumedConnections.removeAll()
+        consumedSessions.removeAll()
+        lock.unlock()
+    }
+
+    public func clearFaultRules() {
+        lock.lock()
+        faultRules.removeAll()
+        consumedConnections.removeAll()
+        consumedSessions.removeAll()
+        lock.unlock()
+    }
+
+    public func evaluate(_ request: FaultRequest) -> FaultDecision? {
+        lock.lock()
+        defer { lock.unlock() }
+        for index in faultRules.indices {
+            let rule = faultRules[index]
+            guard !isExpired(rule.expiresAtEpochMs),
+                  matches(rule, request: request) else {
+                continue
+            }
+            if !rule.dryRun, !consume(rule: &faultRules[index], request: request) {
+                continue
+            }
+            return FaultDecision(
+                faultId: rule.faultId,
+                action: rule.action,
+                statusCode: rule.statusCode,
+                responseHeaders: rule.responseHeaders,
+                responseBody: rule.responseBody,
+                contentType: rule.contentType,
+                errorType: rule.errorType,
+                delayMs: rule.delayMs,
+                bandwidthBytesPerSecond: rule.bandwidthBytesPerSecond,
+                dropBytes: rule.dropBytes,
+                dryRun: rule.dryRun
+            )
+        }
+        return nil
     }
 
     func setErrorSimulation(_ dto: NetworkErrorSimulationDTO) {
@@ -161,6 +322,120 @@ final class NetworkMockRuleStore: @unchecked Sendable {
         let errorType: String
         var remaining: Int?
         let expiresAtEpochMs: Int64?
+    }
+
+    private struct CompiledFaultRule {
+        let faultId: String
+        let transport: NetworkFaultTransport?
+        let host: NSRegularExpression?
+        let port: Int?
+        let scheme: String?
+        let path: NSRegularExpression?
+        let method: String?
+        let headers: [String: String]
+        let origin: String?
+        let connectionId: String?
+        let sessionId: String?
+        let action: NetworkFaultAction
+        let statusCode: Int?
+        let responseHeaders: [String: String]
+        let responseBody: String?
+        let contentType: String?
+        let errorType: String?
+        let delayMs: Int?
+        let bandwidthBytesPerSecond: Int?
+        let dropBytes: Int?
+        var remaining: Int?
+        let expiresAtEpochMs: Int64?
+        let scope: String?
+        let dryRun: Bool
+
+        init(dto: NetworkFaultRuleDTO, host: NSRegularExpression?, path: NSRegularExpression?) {
+            faultId = dto.faultId
+            transport = dto.transport
+            self.host = host
+            port = dto.port
+            scheme = dto.scheme
+            self.path = path
+            method = dto.method
+            headers = dto.headers ?? [:]
+            origin = dto.origin
+            connectionId = dto.connectionId
+            sessionId = dto.sessionId
+            action = dto.action
+            statusCode = dto.statusCode
+            responseHeaders = dto.responseHeaders ?? [:]
+            responseBody = dto.responseBody
+            contentType = dto.contentType
+            errorType = dto.errorType
+            delayMs = dto.delayMs
+            bandwidthBytesPerSecond = dto.bandwidthBytesPerSecond
+            dropBytes = dto.dropBytes
+            remaining = dto.limit
+            expiresAtEpochMs = dto.expiresAtEpochMs
+            scope = dto.scope
+            dryRun = dto.dryRun
+        }
+    }
+
+    private func matches(_ rule: CompiledFaultRule, request: FaultRequest) -> Bool {
+        guard rule.transport == nil || rule.transport == request.transport,
+              rule.port == nil || rule.port == request.port,
+              rule.scheme == nil || rule.scheme?.caseInsensitiveCompare(request.scheme ?? "") == .orderedSame,
+              rule.method == nil || rule.method == "*" || rule.method?.caseInsensitiveCompare(request.method ?? "") == .orderedSame,
+              rule.origin == nil || rule.origin == request.origin,
+              rule.connectionId == nil || rule.connectionId == request.connectionId,
+              rule.sessionId == nil || rule.sessionId == request.sessionId else {
+            return false
+        }
+        if let host = rule.host, !Self.matches(host, request.host ?? "") { return false }
+        if let path = rule.path, !Self.matches(path, request.path ?? "") { return false }
+        return rule.headers.allSatisfy { key, value in
+            request.headers[key]?.caseInsensitiveCompare(value) == .orderedSame
+        }
+    }
+
+    private func consume(rule: inout CompiledFaultRule, request: FaultRequest) -> Bool {
+        switch rule.scope {
+        case "connection":
+            if let id = request.connectionId,
+               consumedConnections.contains("\(rule.faultId):\(id)") {
+                return false
+            }
+        case "session":
+            if let id = request.sessionId,
+               consumedSessions.contains("\(rule.faultId):\(id)") {
+                return false
+            }
+        default:
+            break
+        }
+        if rule.scope == nil, let remaining = rule.remaining {
+            guard remaining > 0 else { return false }
+            rule.remaining = remaining - 1
+        }
+        switch rule.scope {
+        case "connection":
+            guard let id = request.connectionId else { return true }
+            return consumedConnections.insert("\(rule.faultId):\(id)").inserted
+        case "session":
+            guard let id = request.sessionId else { return true }
+            return consumedSessions.insert("\(rule.faultId):\(id)").inserted
+        default:
+            return true
+        }
+    }
+
+    public func clearSession(_ sessionId: String) {
+        lock.lock()
+        faultRules.removeAll { $0.sessionId == sessionId }
+        consumedSessions = consumedSessions.filter { !$0.hasSuffix(":\(sessionId)") }
+        lock.unlock()
+    }
+
+    private func isExpired(_ epochMs: Int64?) -> Bool {
+        guard let epochMs else { return false }
+        return currentEpochMs() >= epochMs
     }
 
     private static func matches(_ regex: NSRegularExpression, _ value: String) -> Bool {

--- a/ios/auto-mobile-sdk/Sources/AutoMobileSDK/ViewHierarchy/SdkHierarchyServer.swift
+++ b/ios/auto-mobile-sdk/Sources/AutoMobileSDK/ViewHierarchy/SdkHierarchyServer.swift
@@ -115,6 +115,8 @@ final class SdkHierarchyServer: @unchecked Sendable {
                     self.handleNetworkMock(connection, initialData: requestData)
                 } else if request.contains("POST /network/error-simulation") {
                     self.handleNetworkErrorSimulation(connection, initialData: requestData)
+                } else if request.contains("POST /network/fault-rules") {
+                    self.handleNetworkFaultRules(connection, initialData: requestData)
                 } else if request.contains("POST /highlight") {
                     self.handleHighlight(connection, initialData: requestData)
                 } else if request.contains("POST /db/execute") {
@@ -145,7 +147,11 @@ final class SdkHierarchyServer: @unchecked Sendable {
     }
 
     private func handleHealth(_ connection: NWConnection) {
-        let payload = HealthPayload(status: "ok", bundleId: tracker?.bundleId)
+        let payload = HealthPayload(
+            status: "ok",
+            bundleId: tracker?.bundleId,
+            capabilities: ["network-fault-rules"]
+        )
         guard let data = try? JSONEncoder().encode(payload) else {
             sendResponse(connection, statusCode: 500, body: Data("{\"error\":\"encode_failed\"}".utf8))
             return
@@ -207,6 +213,22 @@ final class SdkHierarchyServer: @unchecked Sendable {
                 return
             }
             NetworkMockRuleStore.shared.setErrorSimulation(payload)
+            self.sendResponse(connection, statusCode: 200, body: Data("{\"status\":\"ok\"}".utf8))
+        }
+    }
+
+    private func handleNetworkFaultRules(_ connection: NWConnection, initialData: Data) {
+        readCompleteHttpBody(connection, initialData: initialData) { [weak self] body in
+            guard let self else {
+                connection.cancel()
+                return
+            }
+            guard let body,
+                  let payload = try? JSONDecoder().decode(SetNetworkFaultRulesBody.self, from: body) else {
+                self.sendResponse(connection, statusCode: 400, body: Data("{\"error\":\"bad_request\"}".utf8))
+                return
+            }
+            NetworkMockRuleStore.shared.setFaultRules(payload.rules)
             self.sendResponse(connection, statusCode: 200, body: Data("{\"status\":\"ok\"}".utf8))
         }
     }
@@ -419,9 +441,14 @@ final class SdkHierarchyServer: @unchecked Sendable {
 private struct HealthPayload: Encodable {
     let status: String
     let bundleId: String?
+    let capabilities: Set<String>
 }
 
 private struct SetMockRulesBody: Decodable {
     let rules: [NetworkMockRuleDTO]
+}
+
+private struct SetNetworkFaultRulesBody: Decodable {
+    let rules: [NetworkFaultRuleDTO]
 }
 #endif

--- a/ios/auto-mobile-sdk/Sources/AutoMobileSDK/WebKit/AutoMobileWebViewBridge.swift
+++ b/ios/auto-mobile-sdk/Sources/AutoMobileSDK/WebKit/AutoMobileWebViewBridge.swift
@@ -250,6 +250,26 @@ public final class AutoMobileWebViewBridge: NSObject, WKScriptMessageHandler, WK
         var requestId = scriptRequestId
         if name == "request_started", let scriptRequestId,
            let requestURL = body["url"] as? String {
+            #if DEBUG
+            if let fault = NetworkMockRuleStore.shared.evaluate(.init(
+                transport: .webView,
+                host: URL(string: requestURL)?.host,
+                port: URL(string: requestURL)?.port,
+                scheme: URL(string: requestURL)?.scheme,
+                path: URL(string: requestURL)?.path,
+                method: (body["method"] as? String) ?? "GET",
+                headers: [:],
+                origin: url?.absoluteString,
+                connectionId: webViewId,
+                sessionId: nil
+            )) {
+                metadata["fault_id"] = fault.faultId
+                metadata["fault_action"] = fault.action.rawValue
+                if fault.dryRun == false, fault.action == .rejectFrame || fault.action == .closeConnection {
+                    metadata["fault_rejected"] = "true"
+                }
+            }
+            #endif
             let nativeId = recorder?.beginRequest(
                 url: requestURL,
                 method: (body["method"] as? String) ?? "GET",

--- a/ios/auto-mobile-sdk/Tests/AutoMobileSDKTests/NetworkTests.swift
+++ b/ios/auto-mobile-sdk/Tests/AutoMobileSDKTests/NetworkTests.swift
@@ -421,6 +421,150 @@ final class AutoMobileNetworkTests: XCTestCase {
         XCTAssertEqual(match?.responseBody, "ok")
     }
 
+    func testFaultRulesMatchTransportAndConsumePerConnection() {
+        let store = NetworkMockRuleStore()
+        store.setFaultRules([
+            NetworkFaultRuleDTO(
+                faultId: "reset-1",
+                transport: .nwConnection,
+                host: "api\\.example\\.com",
+                port: 443,
+                scheme: "https",
+                path: "/stream",
+                method: "CONNECTION",
+                headers: nil,
+                origin: nil,
+                connectionId: nil,
+                sessionId: nil,
+                action: .closeConnection,
+                statusCode: nil,
+                responseHeaders: nil,
+                responseBody: nil,
+                contentType: nil,
+                errorType: "connectionReset",
+                delayMs: nil,
+                bandwidthBytesPerSecond: nil,
+                dropBytes: nil,
+                limit: 1,
+                expiresAtEpochMs: nil,
+                scope: "connection",
+                dryRun: false
+            ),
+        ])
+        let request = { (id: String) in
+            NetworkMockRuleStore.FaultRequest(
+                transport: .nwConnection,
+                host: "api.example.com",
+                port: 443,
+                scheme: "https",
+                path: "/stream",
+                method: "CONNECTION",
+                headers: [:],
+                origin: nil,
+                connectionId: id,
+                sessionId: nil
+            )
+        }
+
+        XCTAssertEqual(store.evaluate(request("a"))?.faultId, "reset-1")
+        XCTAssertNil(store.evaluate(request("a")))
+        XCTAssertEqual(store.evaluate(request("b"))?.faultId, "reset-1")
+    }
+
+    func testFaultRulesHonorExpiryAndDryRunWithoutConsuming() {
+        let dateProvider = FakeDateProvider(initialDate: Date(timeIntervalSince1970: 100))
+        let store = NetworkMockRuleStore(dateProvider: dateProvider)
+        let dto = NetworkFaultRuleDTO(
+            faultId: "delay-1",
+            transport: .urlSession,
+            host: ".*",
+            port: nil,
+            scheme: nil,
+            path: ".*",
+            method: "*",
+            headers: nil,
+            origin: nil,
+            connectionId: nil,
+            sessionId: nil,
+            action: .latency,
+            statusCode: nil,
+            responseHeaders: nil,
+            responseBody: nil,
+            contentType: nil,
+            errorType: nil,
+            delayMs: 50,
+            bandwidthBytesPerSecond: nil,
+            dropBytes: nil,
+            limit: 1,
+            expiresAtEpochMs: 101_000,
+            scope: nil,
+            dryRun: true
+        )
+        store.setFaultRules([dto])
+        let request = NetworkMockRuleStore.FaultRequest(
+            transport: .urlSession, host: "api.example.com", port: 443, scheme: "https",
+            path: "/v1", method: "GET", headers: [:], origin: nil,
+            connectionId: nil, sessionId: nil
+        )
+
+        XCTAssertEqual(store.evaluate(request)?.delayMs, 50)
+        XCTAssertEqual(store.evaluate(request)?.delayMs, 50)
+        dateProvider.advance(by: 2)
+        XCTAssertNil(store.evaluate(request))
+    }
+
+    func testClearSessionDoesNotRemoveRulesForOtherSessions() {
+        let store = NetworkMockRuleStore()
+        let rule = { (sessionId: String) in
+            NetworkFaultRuleDTO(
+                faultId: "fault-\(sessionId)",
+                transport: .urlSession,
+                host: "api\\.example\\.com",
+                port: nil,
+                scheme: nil,
+                path: "/v1",
+                method: "GET",
+                headers: nil,
+                origin: nil,
+                connectionId: nil,
+                sessionId: sessionId,
+                action: .error,
+                statusCode: nil,
+                responseHeaders: nil,
+                responseBody: nil,
+                contentType: nil,
+                errorType: "timeout",
+                delayMs: nil,
+                bandwidthBytesPerSecond: nil,
+                dropBytes: nil,
+                limit: nil,
+                expiresAtEpochMs: nil,
+                scope: "session",
+                dryRun: false
+            )
+        }
+        store.setFaultRules([rule("a"), rule("b")])
+        let request = { (sessionId: String) in
+            NetworkMockRuleStore.FaultRequest(
+                transport: .urlSession,
+                host: "api.example.com",
+                port: nil,
+                scheme: "https",
+                path: "/v1",
+                method: "GET",
+                headers: [:],
+                origin: nil,
+                connectionId: nil,
+                sessionId: sessionId
+            )
+        }
+
+        store.clearSession("a")
+
+        XCTAssertNil(store.evaluate(request("a")))
+        XCTAssertEqual(store.evaluate(request("b"))?.faultId, "fault-b")
+    }
+
     func testURLProtocolServesMatchingMockResponseAndRecordsRequest() async throws {
         let collector = EventCollector()
         let buffer = SdkEventBuffer(maxBufferSize: 100, flushIntervalMs: 60000) { events in

--- a/ios/auto-mobile-sdk/api/auto-mobile-sdk.api
+++ b/ios/auto-mobile-sdk/api/auto-mobile-sdk.api
@@ -460,6 +460,7 @@ public final class NetworkCaptureRecorder: @unchecked Sendable
   public static func redactHeaders(_ headers: [String: String]) -> [String: String]
 public final class URLSessionNetworkCaptureAdapter: @unchecked Sendable
   public init(recorder: NetworkCaptureRecorder)
+  public func evaluateFault(for task: URLSessionTask, sessionId: String? = nil) -> NetworkMockRuleStore.FaultDecision?
   public func begin( url: String, method: String = "GET", connectionId: String? = nil, requestHeaders: [String: String]? = nil, requestBodySize: Int? = nil ) -> String
   public func begin( task: URLSessionTask, connectionId: String? = nil ) -> String
   public func didReceiveResponseHeaders(requestId: String, headers: [String: String])
@@ -471,9 +472,11 @@ public final class URLSessionNetworkCaptureAdapter: @unchecked Sendable
   public func didFail(requestId: String, error: Error)
 public final class WebSocketNetworkCaptureAdapter: @unchecked Sendable
   public init(recorder: NetworkCaptureRecorder)
+  public func evaluateFault( url: String, connectionId: String?, direction: NetworkCaptureDirection, sessionId: String? = nil ) -> NetworkMockRuleStore.FaultDecision?
   public func recordFrame( url: String, connectionId: String?, direction: NetworkCaptureDirection, frameType: WebSocketFrameType, payloadSize: Int? )
 public final class NWConnectionNetworkCaptureAdapter: @unchecked Sendable
   public init(recorder: NetworkCaptureRecorder)
+  public func evaluateFault( endpoint: String, connectionId: String, sessionId: String? = nil ) -> NetworkMockRuleStore.FaultDecision?
   public func begin( endpoint: String, connectionId: String ) -> String
   public func didSend(requestId: String, bytes: Int)
   public func didUpdateState(requestId: String, state: String)
@@ -481,6 +484,66 @@ public final class NWConnectionNetworkCaptureAdapter: @unchecked Sendable
   public func didComplete(requestId: String)
   public func didFail(requestId: String, error: NWError)
   public func didCancel(requestId: String)
+
+// Network/NetworkMockRuleStore.swift
+public enum NetworkFaultTransport: String, Codable, Equatable
+public enum NetworkFaultAction: String, Codable, Equatable
+public struct NetworkFaultRuleDTO: Codable, Equatable
+  public let faultId: String
+  public let transport: NetworkFaultTransport?
+  public let host: String?
+  public let port: Int?
+  public let scheme: String?
+  public let path: String?
+  public let method: String?
+  public let headers: [String: String]?
+  public let origin: String?
+  public let connectionId: String?
+  public let sessionId: String?
+  public let action: NetworkFaultAction
+  public let statusCode: Int?
+  public let responseHeaders: [String: String]?
+  public let responseBody: String?
+  public let contentType: String?
+  public let errorType: String?
+  public let delayMs: Int?
+  public let bandwidthBytesPerSecond: Int?
+  public let dropBytes: Int?
+  public let limit: Int?
+  public let expiresAtEpochMs: Int64?
+  public let scope: String?
+  public let dryRun: Bool
+  public init( faultId: String, transport: NetworkFaultTransport?, host: String?, port: Int?, scheme: String?, path: String?, method: String?, headers: [String: String]?, origin: String?, connectionId: String?, sessionId: String?, action: NetworkFaultAction, statusCode: Int?, responseHeaders: [String: String]?, responseBody: String?, contentType: String?, errorType: String?, delayMs: Int?, bandwidthBytesPerSecond: Int?, dropBytes: Int?, limit: Int?, expiresAtEpochMs: Int64?, scope: String?, dryRun: Bool )
+public final class NetworkMockRuleStore: @unchecked Sendable
+public struct FaultDecision: Equatable
+  public let faultId: String
+  public let action: NetworkFaultAction
+  public let statusCode: Int?
+  public let responseHeaders: [String: String]
+  public let responseBody: String?
+  public let contentType: String?
+  public let errorType: String?
+  public let delayMs: Int?
+  public let bandwidthBytesPerSecond: Int?
+  public let dropBytes: Int?
+  public let dryRun: Bool
+public struct FaultRequest: Equatable
+  public let transport: NetworkFaultTransport
+  public let host: String?
+  public let port: Int?
+  public let scheme: String?
+  public let path: String?
+  public let method: String?
+  public let headers: [String: String]
+  public let origin: String?
+  public let connectionId: String?
+  public let sessionId: String?
+  public init(transport: NetworkFaultTransport, host: String?, port: Int?, scheme: String?, path: String?, method: String?, headers: [String: String], origin: String?, connectionId: String?, sessionId: String?)
+  public init()
+  public func setFaultRules(_ dtos: [NetworkFaultRuleDTO])
+  public func clearFaultRules()
+  public func evaluate(_ request: FaultRequest) -> FaultDecision?
+  public func clearSession(_ sessionId: String)
 
 // Network/RetryPolicy.swift
 public struct RetryPolicy: Sendable

--- a/ios/control-proxy/Sources/CtrlProxy/CommandHandler.swift
+++ b/ios/control-proxy/Sources/CtrlProxy/CommandHandler.swift
@@ -204,6 +204,9 @@ public class CommandHandler: CommandHandling {
             case let .setNetworkMockRules(payload):
                 return try handleSetNetworkMockRules(payload, startTime: startTime)
 
+            case let .setNetworkFaultRules(payload):
+                return try handleSetNetworkFaultRules(payload, startTime: startTime)
+
             case let .setNetworkErrorSimulation(payload):
                 return try handleSetNetworkErrorSimulation(payload, startTime: startTime)
 
@@ -266,6 +269,20 @@ public class CommandHandler: CommandHandling {
         )
         let succeeded = sdkHierarchyClient?.setNetworkErrorSimulation(config) ?? false
         return SetNetworkErrorSimulationResponse(
+            requestId: request.requestId,
+            ok: succeeded,
+            totalTimeMs: totalTimeMs(from: startTime)
+        )
+    }
+
+    private func handleSetNetworkFaultRules(
+        _ request: RequestSetNetworkFaultRules,
+        startTime: Date
+    )
+        throws -> SetNetworkFaultRulesResponse
+    {
+        let succeeded = sdkHierarchyClient?.setNetworkFaultRules(request.rules) ?? false
+        return SetNetworkFaultRulesResponse(
             requestId: request.requestId,
             ok: succeeded,
             totalTimeMs: totalTimeMs(from: startTime)

--- a/ios/control-proxy/Sources/CtrlProxy/Fakes.swift
+++ b/ios/control-proxy/Sources/CtrlProxy/Fakes.swift
@@ -836,6 +836,7 @@ public class FakeSdkHierarchyFetcher: SdkHierarchyFetching {
     private var _lastHighlight: (id: String, shape: HighlightShape)?
     public var setMockRulesResult = true
     public var setNetworkErrorSimulationResult = true
+    public var setNetworkFaultRulesResult = true
     public var addHighlightResult: SdkHighlightOutcome = .unavailable
 
     public init() {}
@@ -984,6 +985,10 @@ public class FakeSdkHierarchyFetcher: SdkHierarchyFetching {
         let result = setMockRulesResult
         lock.unlock()
         return result
+    }
+
+    public func setNetworkFaultRules(_ rules: [NetworkFaultRuleDTO]) -> Bool {
+        return setNetworkFaultRulesResult
     }
 
     public func setNetworkErrorSimulation(_ config: NetworkErrorSimulationDTO) -> Bool {

--- a/ios/control-proxy/Sources/CtrlProxy/Models.swift
+++ b/ios/control-proxy/Sources/CtrlProxy/Models.swift
@@ -233,6 +233,11 @@ public struct RequestSetNetworkMockRules: Decodable {
     public var rules: [NetworkMockRuleDTO]
 }
 
+public struct RequestSetNetworkFaultRules: Decodable {
+    public var requestId: String?
+    public var rules: [NetworkFaultRuleDTO]
+}
+
 public struct RequestSetNetworkErrorSimulation: Decodable {
     public var requestId: String?
     public var enabled: Bool
@@ -326,6 +331,7 @@ extension RequestSetPreference: CommandPayload {}
 extension RequestRemovePreference: CommandPayload {}
 extension RequestClearPreferences: CommandPayload {}
 extension RequestSetNetworkMockRules: CommandPayload {}
+extension RequestSetNetworkFaultRules: CommandPayload {}
 extension RequestSetNetworkErrorSimulation: CommandPayload {}
 extension RequestExecuteSql: CommandPayload {}
 extension RequestListDatabases: CommandPayload {}
@@ -384,6 +390,7 @@ public enum WebSocketRequest: Decodable {
     case clearPreferences(RequestClearPreferences)
 
     case setNetworkMockRules(RequestSetNetworkMockRules)
+    case setNetworkFaultRules(RequestSetNetworkFaultRules)
     case setNetworkErrorSimulation(RequestSetNetworkErrorSimulation)
 
     case executeSql(RequestExecuteSql)
@@ -484,6 +491,8 @@ public enum WebSocketRequest: Decodable {
             self = try .clearPreferences(RequestClearPreferences(from: decoder))
         case .setNetworkMockRules:
             self = try .setNetworkMockRules(RequestSetNetworkMockRules(from: decoder))
+        case .setNetworkFaultRules:
+            self = try .setNetworkFaultRules(RequestSetNetworkFaultRules(from: decoder))
         case .setNetworkErrorSimulation:
             self = try .setNetworkErrorSimulation(RequestSetNetworkErrorSimulation(from: decoder))
         case .executeSql:
@@ -541,6 +550,7 @@ public enum WebSocketRequest: Decodable {
         case .removePreference: return .removePreference
         case .clearPreferences: return .clearPreferences
         case .setNetworkMockRules: return .setNetworkMockRules
+        case .setNetworkFaultRules: return .setNetworkFaultRules
         case .setNetworkErrorSimulation: return .setNetworkErrorSimulation
         case .executeSql: return .executeSql
         case .listDatabases: return .listDatabases
@@ -600,6 +610,7 @@ public enum WebSocketRequest: Decodable {
         case let .removePreference(payload): return payload
         case let .clearPreferences(payload): return payload
         case let .setNetworkMockRules(payload): return payload
+        case let .setNetworkFaultRules(payload): return payload
         case let .setNetworkErrorSimulation(payload): return payload
         case let .executeSql(payload): return payload
         case let .listDatabases(payload): return payload
@@ -665,6 +676,33 @@ public struct NetworkErrorSimulationDTO: Codable, Sendable, Equatable {
         self.limit = limit
         self.expiresAtEpochMs = expiresAtEpochMs
     }
+}
+
+public struct NetworkFaultRuleDTO: Codable, Sendable, Equatable {
+    public let faultId: String
+    public let transport: String?
+    public let host: String?
+    public let port: Int?
+    public let scheme: String?
+    public let path: String?
+    public let method: String?
+    public let headers: [String: String]?
+    public let origin: String?
+    public let connectionId: String?
+    public let sessionId: String?
+    public let action: String
+    public let statusCode: Int?
+    public let responseHeaders: [String: String]?
+    public let responseBody: String?
+    public let contentType: String?
+    public let errorType: String?
+    public let delayMs: Int?
+    public let bandwidthBytesPerSecond: Int?
+    public let dropBytes: Int?
+    public let limit: Int?
+    public let expiresAtEpochMs: Int64?
+    public let scope: String?
+    public let dryRun: Bool
 }
 
 // MARK: - Response Models (matching Android AccessibilityService)
@@ -768,6 +806,22 @@ public struct SetNetworkErrorSimulationResponse: Codable {
 
     public init(requestId: String?, ok: Bool, totalTimeMs: Int64?) {
         type = ResponseType.setNetworkErrorSimulationResult.rawValue
+        timestamp = Int64(Date().timeIntervalSince1970 * 1000)
+        self.requestId = requestId
+        self.ok = ok
+        self.totalTimeMs = totalTimeMs
+    }
+}
+
+public struct SetNetworkFaultRulesResponse: Codable {
+    public let type: String
+    public let timestamp: Int64
+    public let requestId: String?
+    public let ok: Bool
+    public let totalTimeMs: Int64?
+
+    public init(requestId: String?, ok: Bool, totalTimeMs: Int64?) {
+        type = ResponseType.setNetworkFaultRulesResult.rawValue
         timestamp = Int64(Date().timeIntervalSince1970 * 1000)
         self.requestId = requestId
         self.ok = ok
@@ -1743,6 +1797,7 @@ public enum RequestType: String, CaseIterable {
 
     /// Network mocking
     case setNetworkMockRules = "set_network_mock_rules"
+    case setNetworkFaultRules = "set_network_fault_rules"
     case setNetworkErrorSimulation = "set_network_error_simulation"
 
     // Database inspection
@@ -1796,6 +1851,7 @@ public enum ResponseType: String {
     case removePreferenceResult = "remove_preference_result"
     case clearPreferencesResult = "clear_preferences_result"
     case setNetworkMockRulesResult = "set_network_mock_rules_result"
+    case setNetworkFaultRulesResult = "set_network_fault_rules_result"
     case setNetworkErrorSimulationResult = "set_network_error_simulation_result"
 
     // Database inspection
@@ -1858,6 +1914,7 @@ extension RequestType {
         case .removePreference: return .removePreferenceResult
         case .clearPreferences: return .clearPreferencesResult
         case .setNetworkMockRules: return .setNetworkMockRulesResult
+        case .setNetworkFaultRules: return .setNetworkFaultRulesResult
         case .setNetworkErrorSimulation: return .setNetworkErrorSimulationResult
         case .executeSql: return .executeSqlResult
         case .listDatabases: return .listDatabasesResult

--- a/ios/control-proxy/Sources/CtrlProxy/Protocols.swift
+++ b/ios/control-proxy/Sources/CtrlProxy/Protocols.swift
@@ -301,6 +301,7 @@ public protocol SdkHierarchyFetching {
     func isAvailable() -> Bool
     /// Replace network mock rules in the in-app SDK.
     func setMockRules(_ rules: [NetworkMockRuleDTO]) -> Bool
+    func setNetworkFaultRules(_ rules: [NetworkFaultRuleDTO]) -> Bool
     /// Replace active network error simulation in the in-app SDK.
     func setNetworkErrorSimulation(_ config: NetworkErrorSimulationDTO) -> Bool
     /// Draw a highlight in the in-app SDK process.

--- a/ios/control-proxy/Sources/CtrlProxy/SdkHierarchyClient.swift
+++ b/ios/control-proxy/Sources/CtrlProxy/SdkHierarchyClient.swift
@@ -45,6 +45,13 @@ public final class SdkHierarchyClient: SdkHierarchyFetching, @unchecked Sendable
         return postSync(path: "/network/mock", body: body, session: urlSession)
     }
 
+    public func setNetworkFaultRules(_ rules: [NetworkFaultRuleDTO]) -> Bool {
+        guard let body = try? JSONEncoder().encode(SetNetworkFaultRulesBody(rules: rules)) else {
+            return false
+        }
+        return postSync(path: "/network/fault-rules", body: body, session: urlSession)
+    }
+
     public func setNetworkErrorSimulation(_ config: NetworkErrorSimulationDTO) -> Bool {
         guard let body = try? JSONEncoder().encode(config) else {
             return false
@@ -137,6 +144,10 @@ public final class SdkHierarchyClient: SdkHierarchyFetching, @unchecked Sendable
 
 private struct SetMockRulesBody: Encodable {
     let rules: [NetworkMockRuleDTO]
+}
+
+private struct SetNetworkFaultRulesBody: Encodable {
+    let rules: [NetworkFaultRuleDTO]
 }
 
 private struct AddHighlightBody: Encodable {

--- a/ios/control-proxy/Sources/CtrlProxy/SdkHierarchyModels.swift
+++ b/ios/control-proxy/Sources/CtrlProxy/SdkHierarchyModels.swift
@@ -53,10 +53,12 @@ public struct SdkSystemChrome: Codable, Sendable {
 public struct SdkHierarchyServerInfo: Codable, Sendable {
     public let status: String
     public let bundleId: String?
+    public let capabilities: Set<String>
 
-    public init(status: String, bundleId: String?) {
+    public init(status: String, bundleId: String?, capabilities: Set<String> = []) {
         self.status = status
         self.bundleId = bundleId
+        self.capabilities = capabilities
     }
 }
 

--- a/ios/control-proxy/Tests/CtrlProxyTests/ErrorResponseTypeTests.swift
+++ b/ios/control-proxy/Tests/CtrlProxyTests/ErrorResponseTypeTests.swift
@@ -49,6 +49,7 @@ final class ErrorResponseTypeTests: XCTestCase {
             .removePreference: .removePreferenceResult,
             .clearPreferences: .clearPreferencesResult,
             .setNetworkMockRules: .setNetworkMockRulesResult,
+            .setNetworkFaultRules: .setNetworkFaultRulesResult,
             .setNetworkErrorSimulation: .setNetworkErrorSimulationResult,
             .executeSql: .executeSqlResult,
             .listDatabases: .listDatabasesResult,

--- a/ios/control-proxy/Tests/CtrlProxyTests/TypedRequestDecodeTests.swift
+++ b/ios/control-proxy/Tests/CtrlProxyTests/TypedRequestDecodeTests.swift
@@ -159,6 +159,7 @@ final class TypedRequestDecodeDispatchTests: XCTestCase {
             .removePreference: #"{"key":"k"}"#,
             .clearPreferences: "{}",
             .setNetworkMockRules: #"{"rules":[]}"#,
+            .setNetworkFaultRules: #"{"rules":[]}"#,
             .setNetworkErrorSimulation: #"{"enabled":false}"#,
             .executeSql: "{}",
             .listDatabases: "{}",

--- a/src/features/observe/ios/ctrlProxyRequestTypes.ts
+++ b/src/features/observe/ios/ctrlProxyRequestTypes.ts
@@ -75,6 +75,7 @@ export const IOS_KNOWN_REQUEST_TYPES = [
 
   // Network mocking
   "set_network_mock_rules",
+  "set_network_fault_rules",
   "set_network_error_simulation",
 
   // Database inspection

--- a/src/features/observe/ios/decodeCtrlProxyMessage.ts
+++ b/src/features/observe/ios/decodeCtrlProxyMessage.ts
@@ -209,6 +209,7 @@ export function decodeCtrlProxyMessage(message: WebSocketMessage): DecodedCtrlPr
     case "set_preference_result":
     case "remove_preference_result":
     case "clear_preferences_result":
+    case "set_network_fault_rules_result":
     case "set_network_error_simulation_result":
       result = {
         success: message.success ?? message.ok ?? false,

--- a/test/features/observe/ios/ctrlProxyWireParity.test.ts
+++ b/test/features/observe/ios/ctrlProxyWireParity.test.ts
@@ -75,6 +75,7 @@ const SWIFT_REQUEST_TYPES = [
   "remove_preference",
   "clear_preferences",
   "set_network_mock_rules",
+  "set_network_fault_rules",
   "set_network_error_simulation",
   "execute_sql",
   "list_databases",

--- a/test/features/observe/ios/decodeCtrlProxyMessage.test.ts
+++ b/test/features/observe/ios/decodeCtrlProxyMessage.test.ts
@@ -262,6 +262,20 @@ describe("decodeCtrlProxyMessage", () => {
     });
   });
 
+  test("set_network_fault_rules_result maps ok to success", () => {
+    const decoded = decodeCtrlProxyMessage(msg({
+      type: "set_network_fault_rules_result",
+      ok: true,
+      totalTimeMs: 9,
+    }));
+
+    expect(decoded?.result).toEqual({
+      success: true,
+      totalTimeMs: 9,
+      error: undefined,
+    });
+  });
+
   test("execute_sql_result carries query fields", () => {
     const decoded = decodeCtrlProxyMessage(msg({
       type: "execute_sql_result",
@@ -400,10 +414,11 @@ describe("decodeCtrlProxyMessage ↔ Swift ResponseType parity (ADD-3 / item 4)"
     "traversal_order_result",
     "connected",
     "set_network_mock_rules_result",
+    "set_network_fault_rules_result",
   ];
 
-  test("Swift ResponseType declares exactly 44 rawValues", () => {
-    expect(rawValues.length).toBe(44);
+  test("Swift ResponseType declares exactly 45 rawValues", () => {
+    expect(rawValues.length).toBe(45);
   });
 
   test("rawValues are unique (no accidental duplicate)", () => {
@@ -416,8 +431,8 @@ describe("decodeCtrlProxyMessage ↔ Swift ResponseType parity (ADD-3 / item 4)"
     }
   });
 
-  test("the decoder explicitly reshapes exactly 37 response types", () => {
-    expect(rawValues.filter(isExplicitlyDecoded).length).toBe(37);
+  test("the decoder explicitly reshapes exactly 38 response types", () => {
+    expect(rawValues.filter(isExplicitlyDecoded).length).toBe(38);
   });
 
   test("the only unhandled ResponseType (excluding fire-and-forget) is shake_result", () => {
@@ -440,7 +455,7 @@ describe("decodeCtrlProxyMessage ↔ Swift ResponseType parity (ADD-3 / item 4)"
  */
 describe("decodeCtrlProxyMessage success defaulting (PARAM-5 / item 11)", () => {
   // One row per decoded response type → the value of `success` when the wire
-  // message omits it. 37 rows = the 37 explicitly-decoded ResponseTypes.
+  // message omits it. 38 rows = the 38 explicitly-decoded ResponseTypes.
   const DEFAULT_WHEN_ABSENT: Array<{ type: string; expected: boolean | undefined }> = [
     { type: "hierarchy_update", expected: undefined },
     { type: "screenshot", expected: true },
@@ -472,6 +487,7 @@ describe("decodeCtrlProxyMessage success defaulting (PARAM-5 / item 11)", () => 
     { type: "set_preference_result", expected: false },
     { type: "remove_preference_result", expected: false },
     { type: "clear_preferences_result", expected: false },
+    { type: "set_network_fault_rules_result", expected: false },
     { type: "set_network_error_simulation_result", expected: false },
     { type: "execute_sql_result", expected: false },
     { type: "list_databases_result", expected: false },
@@ -481,8 +497,8 @@ describe("decodeCtrlProxyMessage success defaulting (PARAM-5 / item 11)", () => 
     { type: "table_structure_result", expected: false },
   ];
 
-  test("the default table covers all 37 explicitly-decoded types", () => {
-    expect(DEFAULT_WHEN_ABSENT.length).toBe(37);
+  test("the default table covers all 38 explicitly-decoded types", () => {
+    expect(DEFAULT_WHEN_ABSENT.length).toBe(38);
   });
 
   for (const { type, expected } of DEFAULT_WHEN_ABSENT) {
@@ -499,8 +515,8 @@ describe("decodeCtrlProxyMessage success defaulting (PARAM-5 / item 11)", () => 
     .filter(row => row.type !== "hierarchy_update" && row.type !== "screenshot")
     .map(row => row.type);
 
-  test("the passthrough set is the 35 success-reading types", () => {
-    expect(READS_MESSAGE_SUCCESS.length).toBe(35);
+  test("the passthrough set is the 36 success-reading types", () => {
+    expect(READS_MESSAGE_SUCCESS.length).toBe(36);
   });
 
   for (const type of READS_MESSAGE_SUCCESS) {
@@ -519,13 +535,14 @@ describe("decodeCtrlProxyMessage success defaulting (PARAM-5 / item 11)", () => 
     expect((decoded?.result as { success?: boolean }).success).toBe(true);
   });
 
-  // The four `success ?? ok ?? false` types read the `ok` alias when `success`
+  // The five `success ?? ok ?? false` types read the `ok` alias when `success`
   // is absent (Android wire-protocol carryover), but `success` still wins when
   // both are present.
   const OK_ALIAS_TYPES = [
     "set_preference_result",
     "remove_preference_result",
     "clear_preferences_result",
+    "set_network_fault_rules_result",
     "set_network_error_simulation_result",
   ];
 


### PR DESCRIPTION
## Summary

- Adds transport-neutral deterministic fault rules for URLSession, WebSocket, NWConnection, and the supported WebView bridge.
- Exposes SDK and CtrlProxy configuration plus capability reporting.
- Adds scoped consumption, expiry, dry-run evaluation, and observable fault metadata.

Closes [#5062](https://github.com/kaeawc/auto-mobile/issues/5062)
