### PR TITLE
feat(android): add transport-neutral network capture

### DIFF
--- a/android/auto-mobile-sdk/api/auto-mobile-sdk.api
+++ b/android/auto-mobile-sdk/api/auto-mobile-sdk.api
@@ -156,6 +156,53 @@ public final class dev.jasonpearson.automobile.sdk.ComposeRecompositionKt {
   public static final void TrackRecomposition(java.lang.String, java.lang.String, java.lang.String, java.lang.String, java.util.List<java.lang.String>, java.lang.Boolean, java.lang.Integer, java.lang.String, androidx.compose.runtime.Composer, int, int);
   public static final void TrackRecomposition(java.lang.String, java.lang.String, java.lang.String, java.lang.String, java.util.List<java.lang.String>, java.lang.Boolean, java.lang.Integer, java.lang.String, kotlin.jvm.functions.Function2<? super androidx.compose.runtime.Composer, ? super java.lang.Integer, kotlin.Unit>, androidx.compose.runtime.Composer, int, int);
 }
+Compiled from "FrameMetricsCollector.kt"
+public final class dev.jasonpearson.automobile.sdk.FrameMetricsCollector$FrameSample {
+  public static final int $stable;
+  public dev.jasonpearson.automobile.sdk.FrameMetricsCollector$FrameSample(long, double);
+  public final long getT();
+  public final double getDurationMs();
+  public final long component1();
+  public final double component2();
+  public final dev.jasonpearson.automobile.sdk.FrameMetricsCollector$FrameSample copy(long, double);
+  public static dev.jasonpearson.automobile.sdk.FrameMetricsCollector$FrameSample copy$default(dev.jasonpearson.automobile.sdk.FrameMetricsCollector$FrameSample, long, double, int, java.lang.Object);
+  public java.lang.String toString();
+  public int hashCode();
+  public boolean equals(java.lang.Object);
+}
+Compiled from "FrameMetricsCollector.kt"
+public final class dev.jasonpearson.automobile.sdk.FrameMetricsCollector$activityCallbacks$1 implements android.app.Application$ActivityLifecycleCallbacks {
+  public void onActivityStarted(android.app.Activity);
+  public void onActivityStopped(android.app.Activity);
+  public void onActivityCreated(android.app.Activity, android.os.Bundle);
+  public void onActivityResumed(android.app.Activity);
+  public void onActivityPaused(android.app.Activity);
+  public void onActivitySaveInstanceState(android.app.Activity, android.os.Bundle);
+  public void onActivityDestroyed(android.app.Activity);
+}
+Compiled from "FrameMetricsCollector.kt"
+public final class dev.jasonpearson.automobile.sdk.FrameMetricsCollector$controlReceiver$1 extends android.content.BroadcastReceiver {
+  public void onReceive(android.content.Context, android.content.Intent);
+}
+Compiled from "FrameMetricsCollector.kt"
+public final class dev.jasonpearson.automobile.sdk.FrameMetricsCollector$scheduleBroadcast$1 implements java.lang.Runnable {
+  public void run();
+}
+Compiled from "FrameMetricsCollector.kt"
+public final class dev.jasonpearson.automobile.sdk.FrameMetricsCollector {
+  public static final dev.jasonpearson.automobile.sdk.FrameMetricsCollector INSTANCE;
+  public static final int $stable;
+  public final void initialize(android.content.Context);
+  public final void reset();
+  public final boolean isEnabled$auto_mobile_sdk();
+  public final void setEnabled$auto_mobile_sdk(boolean);
+  public final java.lang.String buildSnapshotJson$auto_mobile_sdk(java.lang.String, java.util.List<dev.jasonpearson.automobile.sdk.FrameMetricsCollector$FrameSample>, long);
+  public static final java.util.concurrent.atomic.AtomicBoolean access$getEnabled$p();
+  public static final void access$broadcastSnapshot(dev.jasonpearson.automobile.sdk.FrameMetricsCollector);
+  public static final android.os.Handler access$getMainHandler$p();
+  public static final void access$attachWindow(dev.jasonpearson.automobile.sdk.FrameMetricsCollector, android.view.Window);
+  public static final void access$detachWindow(dev.jasonpearson.automobile.sdk.FrameMetricsCollector, android.view.Window);
+}
 Compiled from "NavigationEvent.kt"
 public final class dev.jasonpearson.automobile.sdk.NavigationEvent {
   public static final int $stable;
@@ -1117,6 +1164,8 @@ public final class dev.jasonpearson.automobile.sdk.network.AutoMobileNetwork {
   public static okhttp3.Interceptor interceptor$default(dev.jasonpearson.automobile.sdk.network.AutoMobileNetwork, boolean, boolean, int, java.lang.Object);
   public final void recordRequest(dev.jasonpearson.automobile.sdk.network.NetworkRequestRecord, boolean, boolean);
   public static void recordRequest$default(dev.jasonpearson.automobile.sdk.network.AutoMobileNetwork, dev.jasonpearson.automobile.sdk.network.NetworkRequestRecord, boolean, boolean, int, java.lang.Object);
+  public final dev.jasonpearson.automobile.sdk.network.NetworkCaptureSession startCapture(java.lang.String, java.lang.String, java.lang.String, java.util.Map<java.lang.String, java.lang.String>, long, boolean, boolean);
+  public static dev.jasonpearson.automobile.sdk.network.NetworkCaptureSession startCapture$default(dev.jasonpearson.automobile.sdk.network.AutoMobileNetwork, java.lang.String, java.lang.String, java.lang.String, java.util.Map, long, boolean, boolean, int, java.lang.Object);
   public final okhttp3.WebSocketListener wrapWebSocketListener(okhttp3.WebSocketListener, java.lang.String);
   public final void reset$auto_mobile_sdk();
 }
@@ -1146,6 +1195,23 @@ public final class dev.jasonpearson.automobile.sdk.network.AutoMobileWebSocketLi
   public void onClosing(okhttp3.WebSocket, int, java.lang.String);
   public void onClosed(okhttp3.WebSocket, int, java.lang.String);
   public void onFailure(okhttp3.WebSocket, java.lang.Throwable, okhttp3.Response);
+}
+Compiled from "AutoMobileNetwork.kt"
+public final class dev.jasonpearson.automobile.sdk.network.NetworkCaptureSession$Companion {
+  public final dev.jasonpearson.automobile.sdk.network.NetworkCaptureSession create(java.lang.String, java.lang.String, java.lang.String, java.util.Map<java.lang.String, java.lang.String>, long, boolean, boolean);
+  public dev.jasonpearson.automobile.sdk.network.NetworkCaptureSession$Companion(kotlin.jvm.internal.DefaultConstructorMarker);
+}
+Compiled from "AutoMobileNetwork.kt"
+public final class dev.jasonpearson.automobile.sdk.network.NetworkCaptureSession {
+  public static final dev.jasonpearson.automobile.sdk.network.NetworkCaptureSession$Companion Companion;
+  public static final int $stable;
+  public final void complete(int, java.util.Map<java.lang.String, java.lang.String>, long, java.lang.String, java.lang.String, long);
+  public static void complete$default(dev.jasonpearson.automobile.sdk.network.NetworkCaptureSession, int, java.util.Map, long, java.lang.String, java.lang.String, long, int, java.lang.Object);
+  public final void fail(java.lang.Throwable, long);
+  public static void fail$default(dev.jasonpearson.automobile.sdk.network.NetworkCaptureSession, java.lang.Throwable, long, int, java.lang.Object);
+  public final void cancel(long);
+  public static void cancel$default(dev.jasonpearson.automobile.sdk.network.NetworkCaptureSession, long, int, java.lang.Object);
+  public dev.jasonpearson.automobile.sdk.network.NetworkCaptureSession(java.lang.String, java.lang.String, java.lang.String, java.util.Map, long, boolean, boolean, kotlin.jvm.internal.DefaultConstructorMarker);
 }
 Compiled from "NetworkMockRuleStore.kt"
 public final class dev.jasonpearson.automobile.sdk.network.NetworkMockRuleStore$Companion {
@@ -1266,13 +1332,14 @@ public final class dev.jasonpearson.automobile.sdk.network.NetworkMockRuleStore 
 Compiled from "AutoMobileNetwork.kt"
 public final class dev.jasonpearson.automobile.sdk.network.NetworkRequestRecord {
   public static final int $stable;
-  public dev.jasonpearson.automobile.sdk.network.NetworkRequestRecord(java.lang.String, java.lang.String, java.util.Map<java.lang.String, java.lang.String>, long, int, java.util.Map<java.lang.String, java.lang.String>, long, long, java.lang.String, java.lang.String, java.lang.String, java.lang.String, java.lang.String, java.lang.String);
-  public dev.jasonpearson.automobile.sdk.network.NetworkRequestRecord(java.lang.String, java.lang.String, java.util.Map, long, int, java.util.Map, long, long, java.lang.String, java.lang.String, java.lang.String, java.lang.String, java.lang.String, java.lang.String, int, kotlin.jvm.internal.DefaultConstructorMarker);
+  public dev.jasonpearson.automobile.sdk.network.NetworkRequestRecord(java.lang.String, java.lang.String, java.util.Map<java.lang.String, java.lang.String>, long, int, java.lang.String, java.util.Map<java.lang.String, java.lang.String>, long, long, java.lang.String, java.lang.String, java.lang.String, java.lang.String, java.lang.String, java.lang.String);
+  public dev.jasonpearson.automobile.sdk.network.NetworkRequestRecord(java.lang.String, java.lang.String, java.util.Map, long, int, java.lang.String, java.util.Map, long, long, java.lang.String, java.lang.String, java.lang.String, java.lang.String, java.lang.String, java.lang.String, int, kotlin.jvm.internal.DefaultConstructorMarker);
   public final java.lang.String getUrl();
   public final java.lang.String getMethod();
   public final java.util.Map<java.lang.String, java.lang.String> getRequestHeaders();
   public final long getRequestBodySize();
   public final int getStatusCode();
+  public final java.lang.String getProtocol();
   public final java.util.Map<java.lang.String, java.lang.String> getResponseHeaders();
   public final long getResponseBodySize();
   public final long getDurationMs();
@@ -1287,17 +1354,18 @@ public final class dev.jasonpearson.automobile.sdk.network.NetworkRequestRecord 
   public final java.util.Map<java.lang.String, java.lang.String> component3();
   public final long component4();
   public final int component5();
-  public final java.util.Map<java.lang.String, java.lang.String> component6();
-  public final long component7();
+  public final java.lang.String component6();
+  public final java.util.Map<java.lang.String, java.lang.String> component7();
   public final long component8();
-  public final java.lang.String component9();
+  public final long component9();
   public final java.lang.String component10();
   public final java.lang.String component11();
   public final java.lang.String component12();
   public final java.lang.String component13();
   public final java.lang.String component14();
-  public final dev.jasonpearson.automobile.sdk.network.NetworkRequestRecord copy(java.lang.String, java.lang.String, java.util.Map<java.lang.String, java.lang.String>, long, int, java.util.Map<java.lang.String, java.lang.String>, long, long, java.lang.String, java.lang.String, java.lang.String, java.lang.String, java.lang.String, java.lang.String);
-  public static dev.jasonpearson.automobile.sdk.network.NetworkRequestRecord copy$default(dev.jasonpearson.automobile.sdk.network.NetworkRequestRecord, java.lang.String, java.lang.String, java.util.Map, long, int, java.util.Map, long, long, java.lang.String, java.lang.String, java.lang.String, java.lang.String, java.lang.String, java.lang.String, int, java.lang.Object);
+  public final java.lang.String component15();
+  public final dev.jasonpearson.automobile.sdk.network.NetworkRequestRecord copy(java.lang.String, java.lang.String, java.util.Map<java.lang.String, java.lang.String>, long, int, java.lang.String, java.util.Map<java.lang.String, java.lang.String>, long, long, java.lang.String, java.lang.String, java.lang.String, java.lang.String, java.lang.String, java.lang.String);
+  public static dev.jasonpearson.automobile.sdk.network.NetworkRequestRecord copy$default(dev.jasonpearson.automobile.sdk.network.NetworkRequestRecord, java.lang.String, java.lang.String, java.util.Map, long, int, java.lang.String, java.util.Map, long, long, java.lang.String, java.lang.String, java.lang.String, java.lang.String, java.lang.String, java.lang.String, int, java.lang.Object);
   public java.lang.String toString();
   public int hashCode();
   public boolean equals(java.lang.Object);

--- a/android/auto-mobile-sdk/src/main/kotlin/dev/jasonpearson/automobile/sdk/network/AutoMobileNetwork.kt
+++ b/android/auto-mobile-sdk/src/main/kotlin/dev/jasonpearson/automobile/sdk/network/AutoMobileNetwork.kt
@@ -3,9 +3,9 @@ package dev.jasonpearson.automobile.sdk.network
 import dev.jasonpearson.automobile.protocol.SdkNetworkRequestEvent
 import dev.jasonpearson.automobile.sdk.capabilities.SdkCapturePolicy
 import dev.jasonpearson.automobile.sdk.events.SdkEventBuffer
+import java.util.concurrent.atomic.AtomicBoolean
 import okhttp3.Interceptor
 import okhttp3.WebSocketListener
-import java.util.concurrent.atomic.AtomicBoolean
 
 /**
  * Grouped parameters for recording a network request/response manually.
@@ -55,7 +55,8 @@ data class NetworkRequestRecord(
  * separately. The first terminal callback wins, so retries and late callbacks cannot emit duplicate
  * events.
  */
-class NetworkCaptureSession private constructor(
+class NetworkCaptureSession
+private constructor(
   private val url: String,
   private val method: String,
   private val protocol: String?,
@@ -122,15 +123,16 @@ class NetworkCaptureSession private constructor(
       requestBodySize: Long,
       captureHeaders: Boolean,
       captureBodies: Boolean,
-    ) = NetworkCaptureSession(
-      url,
-      method,
-      protocol,
-      requestHeaders,
-      requestBodySize,
-      captureHeaders,
-      captureBodies,
-    )
+    ) =
+      NetworkCaptureSession(
+        url,
+        method,
+        protocol,
+        requestHeaders,
+        requestBodySize,
+        captureHeaders,
+        captureBodies,
+      )
   }
 }
 

--- a/android/auto-mobile-sdk/src/main/kotlin/dev/jasonpearson/automobile/sdk/network/AutoMobileNetwork.kt
+++ b/android/auto-mobile-sdk/src/main/kotlin/dev/jasonpearson/automobile/sdk/network/AutoMobileNetwork.kt
@@ -5,6 +5,7 @@ import dev.jasonpearson.automobile.sdk.capabilities.SdkCapturePolicy
 import dev.jasonpearson.automobile.sdk.events.SdkEventBuffer
 import okhttp3.Interceptor
 import okhttp3.WebSocketListener
+import java.util.concurrent.atomic.AtomicBoolean
 
 /**
  * Grouped parameters for recording a network request/response manually.
@@ -17,6 +18,7 @@ import okhttp3.WebSocketListener
  * @property requestHeaders Optional request headers. Only recorded when header capture is enabled.
  * @property requestBodySize Size of the request body in bytes, or -1 if unknown.
  * @property statusCode HTTP status code of the response (e.g. 200, 404), or 0 on failure.
+ * @property protocol Transport or protocol name (for example "cronet" or "http/1.1").
  * @property responseHeaders Optional response headers. Only recorded when header capture is
  *   enabled.
  * @property responseBodySize Size of the response body in bytes, or -1 if unknown.
@@ -36,6 +38,7 @@ data class NetworkRequestRecord(
   val requestHeaders: Map<String, String>? = null,
   val requestBodySize: Long = -1,
   val statusCode: Int = 0,
+  val protocol: String? = null,
   val responseHeaders: Map<String, String>? = null,
   val responseBodySize: Long = -1,
   val durationMs: Long = 0,
@@ -46,6 +49,90 @@ data class NetworkRequestRecord(
   val responseBody: String? = null,
   val contentType: String? = null,
 )
+
+/**
+ * A cancellation-safe lifecycle handle for transports that report request and response callbacks
+ * separately. The first terminal callback wins, so retries and late callbacks cannot emit duplicate
+ * events.
+ */
+class NetworkCaptureSession private constructor(
+  private val url: String,
+  private val method: String,
+  private val protocol: String?,
+  private val requestHeaders: Map<String, String>?,
+  private val requestBodySize: Long,
+  private val captureHeaders: Boolean,
+  private val captureBodies: Boolean,
+) {
+  private val terminal = AtomicBoolean(false)
+
+  fun complete(
+    statusCode: Int,
+    responseHeaders: Map<String, String>? = null,
+    responseBodySize: Long = -1,
+    responseBody: String? = null,
+    contentType: String? = null,
+    durationMs: Long = 0,
+  ) {
+    if (!terminal.compareAndSet(false, true)) return
+    AutoMobileNetwork.recordRequest(
+      NetworkRequestRecord(
+        url = url,
+        method = method,
+        protocol = protocol,
+        requestHeaders = requestHeaders,
+        requestBodySize = requestBodySize,
+        statusCode = statusCode,
+        responseHeaders = responseHeaders,
+        responseBodySize = responseBodySize,
+        responseBody = responseBody,
+        contentType = contentType,
+        durationMs = durationMs,
+      ),
+      captureHeaders = captureHeaders,
+      captureBodies = captureBodies,
+    )
+  }
+
+  fun fail(error: Throwable, durationMs: Long = 0) {
+    if (!terminal.compareAndSet(false, true)) return
+    AutoMobileNetwork.recordRequest(
+      NetworkRequestRecord(
+        url = url,
+        method = method,
+        protocol = protocol,
+        requestHeaders = requestHeaders,
+        requestBodySize = requestBodySize,
+        error = error.message ?: error::class.simpleName,
+        durationMs = durationMs,
+      ),
+      captureHeaders = captureHeaders,
+      captureBodies = captureBodies,
+    )
+  }
+
+  fun cancel(durationMs: Long = 0) = fail(IllegalStateException("cancelled"), durationMs)
+
+  internal companion object {
+    fun create(
+      url: String,
+      method: String,
+      protocol: String?,
+      requestHeaders: Map<String, String>?,
+      requestBodySize: Long,
+      captureHeaders: Boolean,
+      captureBodies: Boolean,
+    ) = NetworkCaptureSession(
+      url,
+      method,
+      protocol,
+      requestHeaders,
+      requestBodySize,
+      captureHeaders,
+      captureBodies,
+    )
+  }
+}
 
 /**
  * Public API for network interception.
@@ -155,6 +242,7 @@ object AutoMobileNetwork {
         method = record.method,
         statusCode = record.statusCode,
         durationMs = record.durationMs,
+        protocol = record.protocol,
         requestBodySize = record.requestBodySize,
         responseBodySize = record.responseBodySize,
         host = host,
@@ -166,6 +254,31 @@ object AutoMobileNetwork {
         responseBody = if (bodiesEnabled) record.responseBody else null,
         contentType = record.contentType,
       )
+    )
+  }
+
+  /**
+   * Start a transport-neutral capture lifecycle. Use the returned handle from success, failure,
+   * timeout, cancellation, and retry callbacks. Each handle emits at most one event.
+   */
+  fun startCapture(
+    url: String,
+    method: String = "GET",
+    protocol: String? = null,
+    requestHeaders: Map<String, String>? = null,
+    requestBodySize: Long = -1,
+    captureHeaders: Boolean = false,
+    captureBodies: Boolean = false,
+  ): NetworkCaptureSession? {
+    if (buffer == null) return null
+    return NetworkCaptureSession.create(
+      url,
+      method,
+      protocol,
+      requestHeaders,
+      requestBodySize,
+      captureHeaders,
+      captureBodies,
     )
   }
 

--- a/android/auto-mobile-sdk/src/test/kotlin/dev/jasonpearson/automobile/sdk/network/AutoMobileNetworkTest.kt
+++ b/android/auto-mobile-sdk/src/test/kotlin/dev/jasonpearson/automobile/sdk/network/AutoMobileNetworkTest.kt
@@ -38,6 +38,7 @@ class AutoMobileNetworkTest {
       NetworkRequestRecord(
         url = "https://api.example.com/users?page=1",
         method = "GET",
+        protocol = "cronet",
         statusCode = 200,
         durationMs = 42,
         responseBodySize = 1024,
@@ -51,6 +52,7 @@ class AutoMobileNetworkTest {
     val event = flushed[0][0] as SdkNetworkRequestEvent
     assertEquals("https://api.example.com/users?page=1", event.url)
     assertEquals("GET", event.method)
+    assertEquals("cronet", event.protocol)
     assertEquals(200, event.statusCode)
     assertEquals(42L, event.durationMs)
     assertEquals(1024L, event.responseBodySize)
@@ -178,5 +180,55 @@ class AutoMobileNetworkTest {
     assertNull(record.requestBody)
     assertNull(record.responseBody)
     assertNull(record.contentType)
+  }
+
+  @Test
+  fun `startCapture emits exactly one terminal event across racing callbacks`() {
+    val (buffer, flushed) = collectingBuffer()
+    AutoMobileNetwork.initialize("com.example", buffer)
+
+    val session =
+      AutoMobileNetwork.startCapture(
+        url = "https://api.example.com/items",
+        method = "GET",
+        protocol = "httpurlconnection",
+      )!!
+
+    session.complete(statusCode = 200, durationMs = 12)
+    session.fail(IllegalStateException("late failure"))
+    session.cancel()
+    buffer.flush()
+
+    assertEquals(1, flushed.size)
+    val event = flushed[0][0] as SdkNetworkRequestEvent
+    assertEquals(200, event.statusCode)
+    assertEquals("httpurlconnection", event.protocol)
+    assertNull(event.error)
+  }
+
+  @Test
+  fun `startCapture preserves opt in payload policy`() {
+    val (buffer, flushed) = collectingBuffer()
+    AutoMobileNetwork.initialize("com.example", buffer)
+    val session =
+      AutoMobileNetwork.startCapture(
+        url = "https://api.example.com/items",
+        method = "POST",
+        requestHeaders = mapOf("Authorization" to "secret"),
+        captureHeaders = true,
+        captureBodies = true,
+      )!!
+
+    session.complete(
+      statusCode = 201,
+      responseHeaders = mapOf("X-Request-Id" to "abc"),
+      responseBody = "{\"ok\":true}",
+    )
+    buffer.flush()
+
+    val event = flushed[0][0] as SdkNetworkRequestEvent
+    assertEquals(mapOf("Authorization" to "secret"), event.requestHeaders)
+    assertEquals(mapOf("X-Request-Id" to "abc"), event.responseHeaders)
+    assertEquals("{\"ok\":true}", event.responseBody)
   }
 }


### PR DESCRIPTION
## Summary

- Adds a cancellation-safe `NetworkCaptureSession` lifecycle for non-OkHttp transports.
- Centralizes completion, failure, cancellation, bounded header/body policy, and duplicate-terminal suppression.
- Carries transport/protocol metadata through the existing network event schema and regenerates the Android SDK API surface.

Closes [#5068](https://github.com/kaeawc/auto-mobile/issues/5068)