### PR TITLE
feat(android): add runtime context hooks

### DIFF
--- a/android/auto-mobile-sdk/api/auto-mobile-sdk.api
+++ b/android/auto-mobile-sdk/api/auto-mobile-sdk.api
@@ -105,6 +105,8 @@ public final class dev.jasonpearson.automobile.sdk.AutoMobileSDK {
   public final void initialize(android.content.Context, dev.jasonpearson.automobile.sdk.AutoMobileConfiguration);
   public final void addNavigationListener(dev.jasonpearson.automobile.sdk.NavigationListener);
   public final void removeNavigationListener(dev.jasonpearson.automobile.sdk.NavigationListener);
+  public final void addRuntimeContextListener(dev.jasonpearson.automobile.sdk.RuntimeContextListener);
+  public final void removeRuntimeContextListener(dev.jasonpearson.automobile.sdk.RuntimeContextListener);
   public final void clearNavigationListeners();
   public final void notifyNavigationEvent(dev.jasonpearson.automobile.sdk.NavigationEvent);
   public final void setEnabled(boolean);
@@ -118,6 +120,10 @@ public final class dev.jasonpearson.automobile.sdk.AutoMobileSDK {
   public final java.lang.String currentSessionId();
   public final void addBreadcrumb(java.lang.String, dev.jasonpearson.automobile.sdk.breadcrumbs.BreadcrumbCategory, java.util.Map<java.lang.String, java.lang.String>);
   public static void addBreadcrumb$default(dev.jasonpearson.automobile.sdk.AutoMobileSDK, java.lang.String, dev.jasonpearson.automobile.sdk.breadcrumbs.BreadcrumbCategory, java.util.Map, int, java.lang.Object);
+  public final void setCurrentScreen(java.lang.String);
+  public final void setTenantId(java.lang.String);
+  public final void recordCustomEvent(java.lang.String, java.lang.String, java.util.Map<java.lang.String, java.lang.String>);
+  public static void recordCustomEvent$default(dev.jasonpearson.automobile.sdk.AutoMobileSDK, java.lang.String, java.lang.String, java.util.Map, int, java.lang.Object);
   public final java.util.Map<dev.jasonpearson.automobile.sdk.events.DropReason, java.lang.Long> getDropReport();
   public final dev.jasonpearson.automobile.sdk.events.SdkEventBuffer getEventBuffer$auto_mobile_sdk();
   public final void setUserId(java.lang.String);
@@ -325,6 +331,10 @@ public final class dev.jasonpearson.automobile.sdk.RecompositionTracker {
   public static final void access$broadcastSnapshot(dev.jasonpearson.automobile.sdk.RecompositionTracker);
   public static final android.os.Handler access$getHandler$p();
   public static final java.util.concurrent.atomic.AtomicLong access$getTouchSequence$p();
+}
+Compiled from "RuntimeContextListener.kt"
+public interface dev.jasonpearson.automobile.sdk.RuntimeContextListener {
+  public abstract void onRuntimeContextChanged(java.lang.String, dev.jasonpearson.automobile.sdk.context.SdkContextSnapshot);
 }
 Compiled from "SdkConstants.kt"
 public final class dev.jasonpearson.automobile.sdk.SdkConstants {
@@ -641,6 +651,10 @@ public final class dev.jasonpearson.automobile.sdk.context.SdkContext {
   public final void setSessionId(java.lang.String);
   public final java.lang.String getUserId();
   public final void setUserId(java.lang.String);
+  public final java.lang.String getTenantId();
+  public final void setTenantId(java.lang.String);
+  public final java.lang.String getCurrentScreen();
+  public final void setCurrentScreen(java.lang.String);
   public final java.lang.String getAppVersion();
   public final void setAppVersion(java.lang.String);
   public final void setTag(java.lang.String, java.lang.String);
@@ -652,17 +666,23 @@ public final class dev.jasonpearson.automobile.sdk.context.SdkContext {
 Compiled from "SdkContext.kt"
 public final class dev.jasonpearson.automobile.sdk.context.SdkContextSnapshot {
   public static final int $stable;
-  public dev.jasonpearson.automobile.sdk.context.SdkContextSnapshot(java.lang.String, java.lang.String, java.lang.String, java.util.Map<java.lang.String, java.lang.String>);
+  public dev.jasonpearson.automobile.sdk.context.SdkContextSnapshot(java.lang.String, java.lang.String, java.lang.String, java.util.Map<java.lang.String, java.lang.String>, java.lang.String, java.lang.String);
+  public dev.jasonpearson.automobile.sdk.context.SdkContextSnapshot(java.lang.String, java.lang.String, java.lang.String, java.util.Map, java.lang.String, java.lang.String, int, kotlin.jvm.internal.DefaultConstructorMarker);
   public final java.lang.String getSessionId();
   public final java.lang.String getUserId();
   public final java.lang.String getAppVersion();
   public final java.util.Map<java.lang.String, java.lang.String> getTags();
+  public final java.lang.String getTenantId();
+  public final java.lang.String getCurrentScreen();
+  public dev.jasonpearson.automobile.sdk.context.SdkContextSnapshot(java.lang.String, java.lang.String, java.lang.String, java.util.Map<java.lang.String, java.lang.String>);
   public final java.lang.String component1();
   public final java.lang.String component2();
   public final java.lang.String component3();
   public final java.util.Map<java.lang.String, java.lang.String> component4();
-  public final dev.jasonpearson.automobile.sdk.context.SdkContextSnapshot copy(java.lang.String, java.lang.String, java.lang.String, java.util.Map<java.lang.String, java.lang.String>);
-  public static dev.jasonpearson.automobile.sdk.context.SdkContextSnapshot copy$default(dev.jasonpearson.automobile.sdk.context.SdkContextSnapshot, java.lang.String, java.lang.String, java.lang.String, java.util.Map, int, java.lang.Object);
+  public final java.lang.String component5();
+  public final java.lang.String component6();
+  public final dev.jasonpearson.automobile.sdk.context.SdkContextSnapshot copy(java.lang.String, java.lang.String, java.lang.String, java.util.Map<java.lang.String, java.lang.String>, java.lang.String, java.lang.String);
+  public static dev.jasonpearson.automobile.sdk.context.SdkContextSnapshot copy$default(dev.jasonpearson.automobile.sdk.context.SdkContextSnapshot, java.lang.String, java.lang.String, java.lang.String, java.util.Map, java.lang.String, java.lang.String, int, java.lang.Object);
   public java.lang.String toString();
   public int hashCode();
   public boolean equals(java.lang.Object);
@@ -1448,7 +1468,8 @@ Compiled from "AutoMobileOsEvents.kt"
 public final class dev.jasonpearson.automobile.sdk.os.AutoMobileOsEvents {
   public static final dev.jasonpearson.automobile.sdk.os.AutoMobileOsEvents INSTANCE;
   public static final int $stable;
-  public final void initialize$auto_mobile_sdk(android.content.Context, dev.jasonpearson.automobile.sdk.events.SdkEventBuffer);
+  public final void initialize$auto_mobile_sdk(android.content.Context, dev.jasonpearson.automobile.sdk.events.SdkEventBuffer, kotlin.jvm.functions.Function1<? super java.lang.String, kotlin.Unit>);
+  public static void initialize$auto_mobile_sdk$default(dev.jasonpearson.automobile.sdk.os.AutoMobileOsEvents, android.content.Context, dev.jasonpearson.automobile.sdk.events.SdkEventBuffer, kotlin.jvm.functions.Function1, int, java.lang.Object);
   public final void shutdown(android.content.Context);
   public static final void access$postEvent(dev.jasonpearson.automobile.sdk.os.AutoMobileOsEvents, java.lang.String, java.util.Map);
   public static final java.lang.String access$getLastBatteryPct$p();

--- a/android/auto-mobile-sdk/src/main/kotlin/dev/jasonpearson/automobile/sdk/AutoMobileSDK.kt
+++ b/android/auto-mobile-sdk/src/main/kotlin/dev/jasonpearson/automobile/sdk/AutoMobileSDK.kt
@@ -10,6 +10,7 @@ import androidx.lifecycle.DefaultLifecycleObserver
 import androidx.lifecycle.LifecycleOwner
 import androidx.lifecycle.ProcessLifecycleOwner
 import dev.jasonpearson.automobile.protocol.NavigationSourceType
+import dev.jasonpearson.automobile.protocol.SdkLifecycleEvent
 import dev.jasonpearson.automobile.protocol.SdkNavigationEvent
 import dev.jasonpearson.automobile.sdk.anr.AutoMobileAnr
 import dev.jasonpearson.automobile.sdk.biometrics.AutoMobileBiometrics
@@ -83,6 +84,7 @@ object AutoMobileSDK {
   @Volatile internal var logger: SdkLogger = DefaultSdkLogger()
 
   private val listeners = CopyOnWriteArrayList<NavigationListener>()
+  private val runtimeContextListeners = CopyOnWriteArrayList<RuntimeContextListener>()
   @Volatile private var _isEnabled = true
   @Volatile private var context: Context? = null
   @Volatile private var configuration: AutoMobileConfiguration? = null
@@ -207,7 +209,9 @@ object AutoMobileSDK {
     handler.post {
       // Guard: if shutdown() was called before this posted block runs, no-op.
       if (this@AutoMobileSDK.context == null) return@post
-      AutoMobileOsEvents.initialize(appContext, buffer)
+      AutoMobileOsEvents.initialize(appContext, buffer) { kind ->
+        notifyRuntimeContextChanged(kind)
+      }
 
       // Register session tracker with process lifecycle
       val observer =
@@ -252,6 +256,16 @@ object AutoMobileSDK {
   @AnyThread
   fun removeNavigationListener(listener: NavigationListener) {
     listeners.remove(listener)
+  }
+
+  /** Registers a removable listener for lifecycle and host-context changes. */
+  fun addRuntimeContextListener(listener: RuntimeContextListener) {
+    runtimeContextListeners.add(listener)
+  }
+
+  /** Removes a previously registered runtime-context listener. */
+  fun removeRuntimeContextListener(listener: RuntimeContextListener) {
+    runtimeContextListeners.remove(listener)
   }
 
   /** Removes all navigation listeners. */
@@ -382,6 +396,49 @@ object AutoMobileSDK {
     )
   }
 
+  /** Sets the current screen or route used by future diagnostics and lifecycle events. */
+  fun setCurrentScreen(screen: String?) {
+    sdkContext?.currentScreen = screen?.take(MAX_CONTEXT_VALUE_LENGTH)
+    AutoMobileCrashes.currentScreenProvider = { sdkContext?.snapshot()?.currentScreen }
+    notifyRuntimeContextChanged(if (screen == null) "screen_cleared" else "screen_changed")
+  }
+
+  /** Sets the current tenant or workspace identifier used by future diagnostics. */
+  fun setTenantId(tenantId: String?) {
+    sdkContext?.tenantId = tenantId?.take(MAX_CONTEXT_VALUE_LENGTH)
+    notifyRuntimeContextChanged(if (tenantId == null) "tenant_cleared" else "tenant_changed")
+  }
+
+  /** Records a bounded, schema-versioned application event. */
+  fun recordCustomEvent(
+    name: String,
+    schemaVersion: String = "1",
+    fields: Map<String, String> = emptyMap(),
+  ) {
+    if (!_isEnabled || name.isBlank()) return
+    val buf = eventBuffer ?: return
+    val ctx = context ?: return
+    val snapshot = sdkContext?.snapshot()
+    val details = buildMap {
+      fields.entries.take(MAX_CUSTOM_EVENT_FIELDS).forEach { (key, value) ->
+        put(key.take(MAX_CONTEXT_KEY_LENGTH), value.take(MAX_CONTEXT_VALUE_LENGTH))
+      }
+      put("name", name.take(MAX_CONTEXT_VALUE_LENGTH))
+      put("schema_version", schemaVersion.take(MAX_CONTEXT_VALUE_LENGTH))
+      snapshot?.tenantId?.let { put("tenant_id", it) }
+      snapshot?.currentScreen?.let { put("current_screen", it) }
+    }
+    buf.add(
+      SdkLifecycleEvent(
+        timestamp = System.currentTimeMillis(),
+        applicationId = ctx.packageName,
+        kind = "custom_event",
+        details = details,
+      )
+    )
+    addBreadcrumb(name, BreadcrumbCategory.CUSTOM, details)
+  }
+
   /**
    * A snapshot of drop counts by reason.
    *
@@ -395,22 +452,34 @@ object AutoMobileSDK {
 
   /** Sets the user identifier on the SDK context. */
   fun setUserId(userId: String?) {
-    sdkContext?.userId = userId
+    sdkContext?.userId = userId?.take(MAX_CONTEXT_VALUE_LENGTH)
+    notifyRuntimeContextChanged(if (userId == null) "user_cleared" else "user_changed")
   }
 
   /** Sets a tag on the SDK context. */
   fun setTag(key: String, value: String) {
-    sdkContext?.setTag(key, value)
+    if (key.isBlank()) return
+    sdkContext?.setTag(key.take(MAX_CONTEXT_KEY_LENGTH), value.take(MAX_CONTEXT_VALUE_LENGTH))
+    notifyRuntimeContextChanged("tag_changed")
   }
 
   /** Removes a tag from the SDK context. */
   fun removeTag(key: String) {
     sdkContext?.removeTag(key)
+    notifyRuntimeContextChanged("tag_removed")
   }
 
   /** An immutable snapshot of the current SDK context, or null if not initialized. */
   val contextSnapshot: SdkContextSnapshot?
     get() = sdkContext?.snapshot()
+
+  private fun notifyRuntimeContextChanged(kind: String) {
+    if (!_isEnabled) return
+    val snapshot = sdkContext?.snapshot() ?: return
+    runtimeContextListeners.forEach { listener ->
+      runCatching { listener.onRuntimeContextChanged(kind, snapshot) }
+    }
+  }
 
   /**
    * Replay pending event batches from disk (events that survived process death). Each batch is
@@ -476,6 +545,7 @@ object AutoMobileSDK {
     RecompositionTracker.reset()
     FrameMetricsCollector.reset()
     listeners.clear()
+    runtimeContextListeners.clear()
     _isEnabled = true
     AutoMobileNetwork.setCapturePolicyProvider(null)
     AutoMobileNetwork.setNetworkControlProvider(null)
@@ -487,4 +557,8 @@ object AutoMobileSDK {
 
   /** Returns the current configuration, or null if not initialized. */
   internal fun getConfiguration(): AutoMobileConfiguration? = configuration
+
+  private const val MAX_CONTEXT_KEY_LENGTH = 64
+  private const val MAX_CONTEXT_VALUE_LENGTH = 256
+  private const val MAX_CUSTOM_EVENT_FIELDS = 32
 }

--- a/android/auto-mobile-sdk/src/main/kotlin/dev/jasonpearson/automobile/sdk/RuntimeContextListener.kt
+++ b/android/auto-mobile-sdk/src/main/kotlin/dev/jasonpearson/automobile/sdk/RuntimeContextListener.kt
@@ -1,0 +1,14 @@
+package dev.jasonpearson.automobile.sdk
+
+/** Receives host-registered lifecycle and context changes. */
+fun interface RuntimeContextListener {
+  /**
+   * Called after a runtime context change or lifecycle event.
+   *
+   * The snapshot is immutable and represents the state after the event.
+   */
+  fun onRuntimeContextChanged(
+    kind: String,
+    snapshot: dev.jasonpearson.automobile.sdk.context.SdkContextSnapshot,
+  )
+}

--- a/android/auto-mobile-sdk/src/main/kotlin/dev/jasonpearson/automobile/sdk/context/SdkContext.kt
+++ b/android/auto-mobile-sdk/src/main/kotlin/dev/jasonpearson/automobile/sdk/context/SdkContext.kt
@@ -9,6 +9,8 @@ internal class SdkContext {
 
   @Volatile var sessionId: String? = null
   @Volatile var userId: String? = null
+  @Volatile var tenantId: String? = null
+  @Volatile var currentScreen: String? = null
   @Volatile var appVersion: String? = null
 
   private val _tags = mutableMapOf<String, String>()
@@ -31,6 +33,8 @@ internal class SdkContext {
       return SdkContextSnapshot(
         sessionId = sessionId,
         userId = userId,
+        tenantId = tenantId,
+        currentScreen = currentScreen,
         appVersion = appVersion,
         tags = HashMap(_tags),
       )
@@ -42,6 +46,8 @@ internal class SdkContext {
     lock.withLock {
       sessionId = null
       userId = null
+      tenantId = null
+      currentScreen = null
       appVersion = null
       _tags.clear()
     }
@@ -54,4 +60,14 @@ data class SdkContextSnapshot(
   val userId: String?,
   val appVersion: String?,
   val tags: Map<String, String>,
-)
+  val tenantId: String? = null,
+  val currentScreen: String? = null,
+) {
+  /** Preserves the pre-context-extension constructor for binary compatibility. */
+  constructor(
+    sessionId: String?,
+    userId: String?,
+    appVersion: String?,
+    tags: Map<String, String>,
+  ) : this(sessionId, userId, appVersion, tags, null, null)
+}

--- a/android/auto-mobile-sdk/src/main/kotlin/dev/jasonpearson/automobile/sdk/os/AutoMobileOsEvents.kt
+++ b/android/auto-mobile-sdk/src/main/kotlin/dev/jasonpearson/automobile/sdk/os/AutoMobileOsEvents.kt
@@ -33,6 +33,7 @@ internal object AutoMobileOsEvents {
 
   @Volatile private var buffer: SdkEventBuffer? = null
   @Volatile private var applicationId: String? = null
+  @Volatile private var onLifecycleEvent: (String) -> Unit = {}
   private var connectivityCallback: ConnectivityManager.NetworkCallback? = null
   private var batteryReceiver: BroadcastReceiver? = null
   private var screenReceiver: BroadcastReceiver? = null
@@ -42,9 +43,14 @@ internal object AutoMobileOsEvents {
   @Volatile private var lastBatteryCharging: Boolean? = null
 
   @RequiresPermission(android.Manifest.permission.ACCESS_NETWORK_STATE)
-  internal fun initialize(context: Context, buffer: SdkEventBuffer) {
+  internal fun initialize(
+    context: Context,
+    buffer: SdkEventBuffer,
+    onLifecycleEvent: (String) -> Unit = {},
+  ) {
     this.buffer = buffer
     this.applicationId = context.packageName
+    this.onLifecycleEvent = onLifecycleEvent
     registerLifecycleObserver()
     registerActivityCallbacks(context)
     registerConnectivityCallback(context)
@@ -59,9 +65,11 @@ internal object AutoMobileOsEvents {
     unregisterScreenReceiver(context)
     unregisterLifecycleObserver()
     buffer = null
+    onLifecycleEvent = {}
   }
 
   private fun postEvent(kind: String, details: Map<String, String>? = null) {
+    onLifecycleEvent(kind)
     buffer?.add(
       SdkLifecycleEvent(
         timestamp = System.currentTimeMillis(),

--- a/android/auto-mobile-sdk/src/test/kotlin/dev/jasonpearson/automobile/sdk/context/SdkContextTest.kt
+++ b/android/auto-mobile-sdk/src/test/kotlin/dev/jasonpearson/automobile/sdk/context/SdkContextTest.kt
@@ -28,11 +28,15 @@ class SdkContextTest {
   fun `set and get volatile fields`() {
     context.sessionId = "sess-1"
     context.userId = "user-42"
+    context.tenantId = "tenant-42"
+    context.currentScreen = "Home"
     context.appVersion = "1.2.3"
 
     val snap = context.snapshot()
     assertEquals("sess-1", snap.sessionId)
     assertEquals("user-42", snap.userId)
+    assertEquals("tenant-42", snap.tenantId)
+    assertEquals("Home", snap.currentScreen)
     assertEquals("1.2.3", snap.appVersion)
   }
 
@@ -81,6 +85,8 @@ class SdkContextTest {
   fun `reset clears all fields and tags`() {
     context.sessionId = "sess-1"
     context.userId = "user-42"
+    context.tenantId = "tenant-42"
+    context.currentScreen = "Home"
     context.appVersion = "1.0.0"
     context.setTag("env", "prod")
 
@@ -89,8 +95,22 @@ class SdkContextTest {
     val snap = context.snapshot()
     assertNull(snap.sessionId)
     assertNull(snap.userId)
+    assertNull(snap.tenantId)
+    assertNull(snap.currentScreen)
     assertNull(snap.appVersion)
     assertTrue(snap.tags.isEmpty())
+  }
+
+  @Test
+  fun `snapshot includes tenant and current screen`() {
+    val context = SdkContext()
+    context.tenantId = "tenant-1"
+    context.currentScreen = "Home"
+
+    val snapshot = context.snapshot()
+
+    assertEquals("tenant-1", snapshot.tenantId)
+    assertEquals("Home", snapshot.currentScreen)
   }
 
   @Test


### PR DESCRIPTION
## Summary

- Adds bounded Android current-screen and tenant context hooks.
- Adds removable runtime context listeners for host lifecycle/context observation.
- Adds schema-versioned bounded custom events and wires automatic lifecycle notifications.

## Validation

- `:auto-mobile-sdk:testDebugUnitTest`
- `:auto-mobile-sdk:apiCheck`
- `:auto-mobile-sdk:apiDump`
- `scripts/ktfmt/validate_ktfmt.sh`

Closes [#5064](https://github.com/kaeawc/auto-mobile/issues/5064)
