### PR TITLE
feat(android): add storage driver hooks

### DIFF
--- a/android/auto-mobile-sdk/api/auto-mobile-sdk.api
+++ b/android/auto-mobile-sdk/api/auto-mobile-sdk.api
@@ -763,6 +763,11 @@ public interface dev.jasonpearson.automobile.sdk.database.DatabaseDriver {
   public abstract dev.jasonpearson.automobile.sdk.database.SQLExecutionResult executeSQL(java.lang.String, java.lang.String);
 }
 Compiled from "DatabaseError.kt"
+public final class dev.jasonpearson.automobile.sdk.database.DatabaseError$DriverNotFound extends dev.jasonpearson.automobile.sdk.database.DatabaseError {
+  public static final int $stable;
+  public dev.jasonpearson.automobile.sdk.database.DatabaseError$DriverNotFound(java.lang.String);
+}
+Compiled from "DatabaseError.kt"
 public final class dev.jasonpearson.automobile.sdk.database.DatabaseError$InvalidPath extends dev.jasonpearson.automobile.sdk.database.DatabaseError {
   public static final int $stable;
   public dev.jasonpearson.automobile.sdk.database.DatabaseError$InvalidPath(java.lang.String);
@@ -804,7 +809,11 @@ public final class dev.jasonpearson.automobile.sdk.database.DatabaseInspector {
   public final void initialize$auto_mobile_sdk(android.content.Context);
   public final boolean isEnabled();
   public final void setEnabled(boolean);
-  public final dev.jasonpearson.automobile.sdk.database.DatabaseDriver getDriver$auto_mobile_sdk();
+  public final void registerDriver(java.lang.String, dev.jasonpearson.automobile.sdk.database.DatabaseDriver);
+  public final boolean unregisterDriver(java.lang.String);
+  public final java.util.Set<java.lang.String> registeredDriverNames();
+  public final dev.jasonpearson.automobile.sdk.database.DatabaseDriver getDriver$auto_mobile_sdk(java.lang.String);
+  public static dev.jasonpearson.automobile.sdk.database.DatabaseDriver getDriver$auto_mobile_sdk$default(dev.jasonpearson.automobile.sdk.database.DatabaseInspector, java.lang.String, int, java.lang.Object);
   public final void closeAll();
   public final void reset$auto_mobile_sdk();
 }
@@ -1669,6 +1678,11 @@ public final class dev.jasonpearson.automobile.sdk.storage.SharedPreferencesDriv
   public void clear(java.lang.String);
 }
 Compiled from "SharedPreferencesError.kt"
+public final class dev.jasonpearson.automobile.sdk.storage.SharedPreferencesError$DriverNotFound extends dev.jasonpearson.automobile.sdk.storage.SharedPreferencesError {
+  public static final int $stable;
+  public dev.jasonpearson.automobile.sdk.storage.SharedPreferencesError$DriverNotFound(java.lang.String);
+}
+Compiled from "SharedPreferencesError.kt"
 public final class dev.jasonpearson.automobile.sdk.storage.SharedPreferencesError$FileNotFound extends dev.jasonpearson.automobile.sdk.storage.SharedPreferencesError {
   public static final int $stable;
   public dev.jasonpearson.automobile.sdk.storage.SharedPreferencesError$FileNotFound(java.lang.String);
@@ -1710,7 +1724,11 @@ public final class dev.jasonpearson.automobile.sdk.storage.SharedPreferencesInsp
   public final void initialize$auto_mobile_sdk(android.content.Context);
   public final boolean isEnabled();
   public final void setEnabled(boolean);
-  public final dev.jasonpearson.automobile.sdk.storage.SharedPreferencesDriver getDriver$auto_mobile_sdk();
+  public final void registerDriver(java.lang.String, dev.jasonpearson.automobile.sdk.storage.SharedPreferencesDriver);
+  public final boolean unregisterDriver(java.lang.String);
+  public final java.util.Set<java.lang.String> registeredDriverNames();
+  public final dev.jasonpearson.automobile.sdk.storage.SharedPreferencesDriver getDriver$auto_mobile_sdk(java.lang.String);
+  public static dev.jasonpearson.automobile.sdk.storage.SharedPreferencesDriver getDriver$auto_mobile_sdk$default(dev.jasonpearson.automobile.sdk.storage.SharedPreferencesInspector, java.lang.String, int, java.lang.Object);
   public final void reset$auto_mobile_sdk();
 }
 Compiled from "ConfigurationOverrideHelper.kt"

--- a/android/auto-mobile-sdk/src/debug/kotlin/dev/jasonpearson/automobile/sdk/database/DatabaseInspectorProvider.kt
+++ b/android/auto-mobile-sdk/src/debug/kotlin/dev/jasonpearson/automobile/sdk/database/DatabaseInspectorProvider.kt
@@ -46,7 +46,7 @@ class DatabaseInspectorProvider : ContentProvider() {
     }
 
     try {
-      val driver = DatabaseInspector.getDriver()
+      val driver = DatabaseInspector.getDriver(extras?.getString("storeName"))
       val response =
         when (method) {
           "listDatabases" -> handleListDatabases(driver)

--- a/android/auto-mobile-sdk/src/debug/kotlin/dev/jasonpearson/automobile/sdk/storage/SharedPreferencesInspectorProvider.kt
+++ b/android/auto-mobile-sdk/src/debug/kotlin/dev/jasonpearson/automobile/sdk/storage/SharedPreferencesInspectorProvider.kt
@@ -60,7 +60,7 @@ class SharedPreferencesInspectorProvider : ContentProvider() {
         return result
       }
 
-      val driver = SharedPreferencesInspector.getDriver()
+      val driver = SharedPreferencesInspector.getDriver(extras?.getString("storeName"))
       val responseJson =
         when (method) {
           "listFiles" -> handleListFiles(driver)

--- a/android/auto-mobile-sdk/src/main/kotlin/dev/jasonpearson/automobile/sdk/database/DatabaseError.kt
+++ b/android/auto-mobile-sdk/src/main/kotlin/dev/jasonpearson/automobile/sdk/database/DatabaseError.kt
@@ -14,6 +14,9 @@ sealed class DatabaseError(message: String) : Exception(message) {
   /** DatabaseInspector was not initialized with a context. */
   class NotInitialized : DatabaseError("DatabaseInspector not initialized")
 
+  /** A named application-provided driver was not registered. */
+  class DriverNotFound(name: String) : DatabaseError("Database driver not found: $name")
+
   /** Database path is outside the app's data directory. */
   class InvalidPath(path: String) : DatabaseError("Invalid database path: $path")
 

--- a/android/auto-mobile-sdk/src/main/kotlin/dev/jasonpearson/automobile/sdk/database/DatabaseInspector.kt
+++ b/android/auto-mobile-sdk/src/main/kotlin/dev/jasonpearson/automobile/sdk/database/DatabaseInspector.kt
@@ -1,6 +1,7 @@
 package dev.jasonpearson.automobile.sdk.database
 
 import android.content.Context
+import java.util.concurrent.ConcurrentHashMap
 
 /**
  * Public API for database inspection.
@@ -23,6 +24,7 @@ object DatabaseInspector {
   private var context: Context? = null
   private var _enabled: Boolean = false
   private var _driver: SQLiteDatabaseDriver? = null
+  private val customDrivers = ConcurrentHashMap<String, DatabaseDriver>()
 
   /**
    * Initialize the DatabaseInspector with application context.
@@ -55,12 +57,27 @@ object DatabaseInspector {
     }
   }
 
+  /** Registers an application-owned database driver under a stable store name. */
+  fun registerDriver(name: String, driver: DatabaseDriver) {
+    require(name.isNotBlank()) { "driver name must not be blank" }
+    customDrivers[name] = driver
+  }
+
+  /** Removes an application-owned database driver and returns whether it was registered. */
+  fun unregisterDriver(name: String): Boolean = customDrivers.remove(name) != null
+
+  /** Returns the names of all application-owned database drivers. */
+  fun registeredDriverNames(): Set<String> = customDrivers.keys.toSet()
+
   /**
    * Get the database driver instance.
    *
    * @throws DatabaseError.NotInitialized if initialize() has not been called
    */
-  internal fun getDriver(): DatabaseDriver {
+  internal fun getDriver(name: String? = null): DatabaseDriver {
+    name?.let {
+      return customDrivers[it] ?: throw DatabaseError.DriverNotFound(it)
+    }
     val ctx = context ?: throw DatabaseError.NotInitialized()
 
     // Create driver lazily
@@ -83,6 +100,7 @@ object DatabaseInspector {
    */
   internal fun reset() {
     _driver?.closeAll()
+    customDrivers.clear()
     _driver = null
     _enabled = false
     context = null

--- a/android/auto-mobile-sdk/src/main/kotlin/dev/jasonpearson/automobile/sdk/storage/SharedPreferencesError.kt
+++ b/android/auto-mobile-sdk/src/main/kotlin/dev/jasonpearson/automobile/sdk/storage/SharedPreferencesError.kt
@@ -12,6 +12,9 @@ sealed class SharedPreferencesError(message: String) : Exception(message) {
   /** SharedPreferencesInspector was not initialized with a context. */
   class NotInitialized : SharedPreferencesError("SharedPreferencesInspector not initialized")
 
+  /** A named application-provided driver was not registered. */
+  class DriverNotFound(name: String) : SharedPreferencesError("Storage driver not found: $name")
+
   /** Error reading preferences. */
   class ReadError(cause: String) : SharedPreferencesError("Read error: $cause")
 

--- a/android/auto-mobile-sdk/src/main/kotlin/dev/jasonpearson/automobile/sdk/storage/SharedPreferencesInspector.kt
+++ b/android/auto-mobile-sdk/src/main/kotlin/dev/jasonpearson/automobile/sdk/storage/SharedPreferencesInspector.kt
@@ -1,6 +1,7 @@
 package dev.jasonpearson.automobile.sdk.storage
 
 import android.content.Context
+import java.util.concurrent.ConcurrentHashMap
 
 /**
  * Public API for SharedPreferences inspection.
@@ -23,6 +24,7 @@ object SharedPreferencesInspector {
   private var context: Context? = null
   private var _enabled: Boolean = false
   private var _driver: SharedPreferencesDriverImpl? = null
+  private val customDrivers = ConcurrentHashMap<String, SharedPreferencesDriver>()
 
   /**
    * Initialize the SharedPreferencesInspector with application context.
@@ -55,12 +57,27 @@ object SharedPreferencesInspector {
     }
   }
 
+  /** Registers an application-owned key-value driver under a stable store name. */
+  fun registerDriver(name: String, driver: SharedPreferencesDriver) {
+    require(name.isNotBlank()) { "driver name must not be blank" }
+    customDrivers[name] = driver
+  }
+
+  /** Removes an application-owned key-value driver and returns whether it was registered. */
+  fun unregisterDriver(name: String): Boolean = customDrivers.remove(name) != null
+
+  /** Returns the names of all application-owned key-value drivers. */
+  fun registeredDriverNames(): Set<String> = customDrivers.keys.toSet()
+
   /**
    * Get the SharedPreferences driver instance.
    *
    * @throws SharedPreferencesError.NotInitialized if initialize() has not been called
    */
-  internal fun getDriver(): SharedPreferencesDriver {
+  internal fun getDriver(name: String? = null): SharedPreferencesDriver {
+    name?.let {
+      return customDrivers[it] ?: throw SharedPreferencesError.DriverNotFound(it)
+    }
     val ctx = context ?: throw SharedPreferencesError.NotInitialized()
 
     // Create driver lazily
@@ -78,6 +95,7 @@ object SharedPreferencesInspector {
    */
   internal fun reset() {
     _driver?.stopAllListening()
+    customDrivers.clear()
     _driver = null
     _enabled = false
     context = null

--- a/android/auto-mobile-sdk/src/test/kotlin/dev/jasonpearson/automobile/sdk/database/DatabaseInspectorTest.kt
+++ b/android/auto-mobile-sdk/src/test/kotlin/dev/jasonpearson/automobile/sdk/database/DatabaseInspectorTest.kt
@@ -1,0 +1,49 @@
+package dev.jasonpearson.automobile.sdk.database
+
+import org.junit.Assert.assertEquals
+import org.junit.Assert.assertFalse
+import org.junit.Assert.assertTrue
+import org.junit.Before
+import org.junit.Test
+
+class DatabaseInspectorTest {
+  private val fakeDriver =
+    object : DatabaseDriver {
+      override fun getDatabases() = emptyList<DatabaseDescriptor>()
+
+      override fun getTables(databasePath: String) = emptyList<String>()
+
+      override fun getTableData(databasePath: String, table: String, limit: Int, offset: Int) =
+        TableDataResult(emptyList(), emptyList(), 0)
+
+      override fun getTableStructure(databasePath: String, table: String) =
+        TableStructureResult(emptyList())
+
+      override fun executeSQL(databasePath: String, query: String) =
+        SQLExecutionResult.Query(emptyList(), emptyList())
+    }
+
+  @Before
+  fun setUp() {
+    DatabaseInspector.reset()
+  }
+
+  @Test
+  fun `registered driver names are removable`() {
+    DatabaseInspector.registerDriver("room", fakeDriver)
+
+    assertEquals(setOf("room"), DatabaseInspector.registeredDriverNames())
+    assertTrue(DatabaseInspector.unregisterDriver("room"))
+    assertFalse(DatabaseInspector.unregisterDriver("room"))
+  }
+
+  @Test
+  fun `unknown named driver does not fall back to default`() {
+    try {
+      DatabaseInspector.getDriver("missing")
+      throw AssertionError("Expected DatabaseError.DriverNotFound")
+    } catch (error: DatabaseError.DriverNotFound) {
+      assertTrue(error.message!!.contains("missing"))
+    }
+  }
+}

--- a/android/auto-mobile-sdk/src/test/kotlin/dev/jasonpearson/automobile/sdk/storage/SharedPreferencesInspectorTest.kt
+++ b/android/auto-mobile-sdk/src/test/kotlin/dev/jasonpearson/automobile/sdk/storage/SharedPreferencesInspectorTest.kt
@@ -5,6 +5,24 @@ import org.junit.Before
 import org.junit.Test
 
 class SharedPreferencesInspectorTest {
+  private val fakeDriver =
+    object : SharedPreferencesDriver {
+      override fun getPreferenceFiles() = emptyList<PreferenceFileDescriptor>()
+
+      override fun getPreferences(fileName: String) = emptyList<KeyValuePair>()
+
+      override fun registerOnChangeListener(listener: OnPreferenceChangeListener) = Unit
+
+      override fun unregisterOnChangeListener(listener: OnPreferenceChangeListener) = Unit
+
+      override fun getPreference(fileName: String, key: String) = null
+
+      override fun setValue(fileName: String, key: String, value: Any?, type: KeyValueType) = Unit
+
+      override fun removeValue(fileName: String, key: String) = Unit
+
+      override fun clear(fileName: String) = Unit
+    }
 
   @Before
   fun setUp() {
@@ -44,5 +62,24 @@ class SharedPreferencesInspectorTest {
     SharedPreferencesInspector.reset()
 
     assertFalse(SharedPreferencesInspector.isEnabled())
+  }
+
+  @Test
+  fun `registered driver names are removable`() {
+    SharedPreferencesInspector.registerDriver("datastore", fakeDriver)
+
+    assertEquals(setOf("datastore"), SharedPreferencesInspector.registeredDriverNames())
+    assertTrue(SharedPreferencesInspector.unregisterDriver("datastore"))
+    assertFalse(SharedPreferencesInspector.unregisterDriver("datastore"))
+  }
+
+  @Test
+  fun `unknown named driver does not fall back to default`() {
+    try {
+      SharedPreferencesInspector.getDriver("missing")
+      fail("Expected SharedPreferencesError.DriverNotFound")
+    } catch (error: SharedPreferencesError.DriverNotFound) {
+      assertTrue(error.message!!.contains("missing"))
+    }
   }
 }


### PR DESCRIPTION
## Summary

- Adds named application-owned database and key-value driver registries.
- Routes debug inspector calls through an optional `storeName`.
- Preserves the existing filesystem drivers as defaults and clears injected drivers on reset.

## Validation

- `:auto-mobile-sdk:testDebugUnitTest --tests ...DatabaseInspectorTest --tests ...SharedPreferencesInspectorTest`
- `:auto-mobile-sdk:apiDump`
- `:auto-mobile-sdk:apiCheck`
- `scripts/ktfmt/validate_ktfmt.sh`

Closes [#5065](https://github.com/kaeawc/auto-mobile/issues/5065)
