### PR TITLE
feat(android): capture outbound WebSocket frames

### DIFF
--- a/android/auto-mobile-sdk/api/auto-mobile-sdk.api
+++ b/android/auto-mobile-sdk/api/auto-mobile-sdk.api
@@ -1196,8 +1196,9 @@ public final class dev.jasonpearson.automobile.sdk.network.AutoMobileNetwork {
   public final dev.jasonpearson.automobile.sdk.network.NetworkCaptureSession startCapture(java.lang.String, java.lang.String, java.lang.String, java.util.Map<java.lang.String, java.lang.String>, long, boolean, boolean);
   public static dev.jasonpearson.automobile.sdk.network.NetworkCaptureSession startCapture$default(dev.jasonpearson.automobile.sdk.network.AutoMobileNetwork, java.lang.String, java.lang.String, java.lang.String, java.util.Map, long, boolean, boolean, int, java.lang.Object);
   public final okhttp3.WebSocketListener wrapWebSocketListener(okhttp3.WebSocketListener, java.lang.String);
-  public final okhttp3.WebSocket wrapWebSocket(okhttp3.WebSocket, java.lang.String, dev.jasonpearson.automobile.sdk.network.WebSocketSendController);
-  public static okhttp3.WebSocket wrapWebSocket$default(dev.jasonpearson.automobile.sdk.network.AutoMobileNetwork, okhttp3.WebSocket, java.lang.String, dev.jasonpearson.automobile.sdk.network.WebSocketSendController, int, java.lang.Object);
+  public final okhttp3.WebSocketListener wrapWebSocketListener(okhttp3.WebSocketListener, java.lang.String, java.lang.String);
+  public final okhttp3.WebSocket wrapWebSocket(okhttp3.WebSocket, java.lang.String, dev.jasonpearson.automobile.sdk.network.WebSocketSendController, java.lang.String);
+  public static okhttp3.WebSocket wrapWebSocket$default(dev.jasonpearson.automobile.sdk.network.AutoMobileNetwork, okhttp3.WebSocket, java.lang.String, dev.jasonpearson.automobile.sdk.network.WebSocketSendController, java.lang.String, int, java.lang.Object);
   public final void reset$auto_mobile_sdk();
 }
 Compiled from "AutoMobileNetworkInterceptor.kt"

--- a/android/auto-mobile-sdk/api/auto-mobile-sdk.api
+++ b/android/auto-mobile-sdk/api/auto-mobile-sdk.api
@@ -1196,6 +1196,8 @@ public final class dev.jasonpearson.automobile.sdk.network.AutoMobileNetwork {
   public final dev.jasonpearson.automobile.sdk.network.NetworkCaptureSession startCapture(java.lang.String, java.lang.String, java.lang.String, java.util.Map<java.lang.String, java.lang.String>, long, boolean, boolean);
   public static dev.jasonpearson.automobile.sdk.network.NetworkCaptureSession startCapture$default(dev.jasonpearson.automobile.sdk.network.AutoMobileNetwork, java.lang.String, java.lang.String, java.lang.String, java.util.Map, long, boolean, boolean, int, java.lang.Object);
   public final okhttp3.WebSocketListener wrapWebSocketListener(okhttp3.WebSocketListener, java.lang.String);
+  public final okhttp3.WebSocket wrapWebSocket(okhttp3.WebSocket, java.lang.String, dev.jasonpearson.automobile.sdk.network.WebSocketSendController);
+  public static okhttp3.WebSocket wrapWebSocket$default(dev.jasonpearson.automobile.sdk.network.AutoMobileNetwork, okhttp3.WebSocket, java.lang.String, dev.jasonpearson.automobile.sdk.network.WebSocketSendController, int, java.lang.Object);
   public final void reset$auto_mobile_sdk();
 }
 Compiled from "AutoMobileNetworkInterceptor.kt"
@@ -1212,6 +1214,18 @@ public final class dev.jasonpearson.automobile.sdk.network.AutoMobileNetworkInte
   public dev.jasonpearson.automobile.sdk.network.AutoMobileNetworkInterceptor(dev.jasonpearson.automobile.sdk.events.SdkEventBuffer, java.lang.String, boolean, boolean, long, dev.jasonpearson.automobile.sdk.network.NetworkMockRuleStore$RuleMatcher, kotlin.jvm.functions.Function0, kotlin.jvm.functions.Function0, int, kotlin.jvm.internal.DefaultConstructorMarker);
   public okhttp3.Response intercept(okhttp3.Interceptor$Chain);
   public static final java.util.Set access$getTEXT_CONTENT_TYPES$cp();
+}
+Compiled from "AutoMobileWebSocket.kt"
+public final class dev.jasonpearson.automobile.sdk.network.AutoMobileWebSocket implements okhttp3.WebSocket {
+  public static final int $stable;
+  public dev.jasonpearson.automobile.sdk.network.AutoMobileWebSocket(okhttp3.WebSocket, java.lang.String, dev.jasonpearson.automobile.sdk.events.SdkEventBuffer, java.lang.String, dev.jasonpearson.automobile.sdk.network.WebSocketSendController, java.lang.String);
+  public dev.jasonpearson.automobile.sdk.network.AutoMobileWebSocket(okhttp3.WebSocket, java.lang.String, dev.jasonpearson.automobile.sdk.events.SdkEventBuffer, java.lang.String, dev.jasonpearson.automobile.sdk.network.WebSocketSendController, java.lang.String, int, kotlin.jvm.internal.DefaultConstructorMarker);
+  public okhttp3.Request request();
+  public long queueSize();
+  public boolean send(java.lang.String);
+  public boolean send(okio.ByteString);
+  public boolean close(int, java.lang.String);
+  public void cancel();
 }
 Compiled from "AutoMobileWebSocketListener.kt"
 public final class dev.jasonpearson.automobile.sdk.network.AutoMobileWebSocketListener extends okhttp3.WebSocketListener {
@@ -1398,6 +1412,10 @@ public final class dev.jasonpearson.automobile.sdk.network.NetworkRequestRecord 
   public java.lang.String toString();
   public int hashCode();
   public boolean equals(java.lang.Object);
+}
+Compiled from "WebSocketSendController.kt"
+public interface dev.jasonpearson.automobile.sdk.network.WebSocketSendController {
+  public abstract boolean allow(dev.jasonpearson.automobile.protocol.WebSocketFrameType, long);
 }
 Compiled from "NoOpDropCounter.kt"
 public final class dev.jasonpearson.automobile.sdk.noop.NoOpDropCounter implements dev.jasonpearson.automobile.sdk.events.DropCounter {

--- a/android/auto-mobile-sdk/src/main/kotlin/dev/jasonpearson/automobile/sdk/network/AutoMobileNetwork.kt
+++ b/android/auto-mobile-sdk/src/main/kotlin/dev/jasonpearson/automobile/sdk/network/AutoMobileNetwork.kt
@@ -3,6 +3,7 @@ package dev.jasonpearson.automobile.sdk.network
 import dev.jasonpearson.automobile.protocol.SdkNetworkRequestEvent
 import dev.jasonpearson.automobile.sdk.capabilities.SdkCapturePolicy
 import dev.jasonpearson.automobile.sdk.events.SdkEventBuffer
+import java.util.UUID
 import java.util.concurrent.atomic.AtomicBoolean
 import okhttp3.Interceptor
 import okhttp3.WebSocketListener
@@ -291,9 +292,17 @@ object AutoMobileNetwork {
    * @param url The WebSocket URL for identification in recorded events
    * @return A wrapping listener that records frame events and delegates to the original
    */
-  fun wrapWebSocketListener(delegate: WebSocketListener, url: String): WebSocketListener {
+  fun wrapWebSocketListener(delegate: WebSocketListener, url: String): WebSocketListener =
+    wrapWebSocketListener(delegate, url, UUID.randomUUID().toString().take(8))
+
+  /** Wrap a WebSocket listener with an explicit connection ID shared with [wrapWebSocket]. */
+  fun wrapWebSocketListener(
+    delegate: WebSocketListener,
+    url: String,
+    connectionId: String,
+  ): WebSocketListener {
     val buf = buffer ?: return delegate
-    return AutoMobileWebSocketListener(delegate, url, buf, applicationId)
+    return AutoMobileWebSocketListener(delegate, url, buf, applicationId, connectionId)
   }
 
   /**
@@ -305,9 +314,10 @@ object AutoMobileNetwork {
     webSocket: okhttp3.WebSocket,
     url: String,
     controller: WebSocketSendController? = null,
+    connectionId: String = UUID.randomUUID().toString().take(8),
   ): okhttp3.WebSocket {
     val buf = buffer ?: return webSocket
-    return AutoMobileWebSocket(webSocket, url, buf, applicationId, controller)
+    return AutoMobileWebSocket(webSocket, url, buf, applicationId, controller, connectionId)
   }
 
   /** Reset internal state. Visible for testing only. */

--- a/android/auto-mobile-sdk/src/main/kotlin/dev/jasonpearson/automobile/sdk/network/AutoMobileNetwork.kt
+++ b/android/auto-mobile-sdk/src/main/kotlin/dev/jasonpearson/automobile/sdk/network/AutoMobileNetwork.kt
@@ -296,6 +296,20 @@ object AutoMobileNetwork {
     return AutoMobileWebSocketListener(delegate, url, buf, applicationId)
   }
 
+  /**
+   * Wrap an opened WebSocket to capture outbound text and binary frames.
+   *
+   * The optional controller can block sends for deterministic debug/test fault injection.
+   */
+  fun wrapWebSocket(
+    webSocket: okhttp3.WebSocket,
+    url: String,
+    controller: WebSocketSendController? = null,
+  ): okhttp3.WebSocket {
+    val buf = buffer ?: return webSocket
+    return AutoMobileWebSocket(webSocket, url, buf, applicationId, controller)
+  }
+
   /** Reset internal state. Visible for testing only. */
   internal fun reset() {
     buffer = null

--- a/android/auto-mobile-sdk/src/main/kotlin/dev/jasonpearson/automobile/sdk/network/AutoMobileWebSocket.kt
+++ b/android/auto-mobile-sdk/src/main/kotlin/dev/jasonpearson/automobile/sdk/network/AutoMobileWebSocket.kt
@@ -33,26 +33,29 @@ internal class AutoMobileWebSocket(
   }
 
   override fun close(code: Int, reason: String?): Boolean {
+    val success = delegate.close(code, reason)
     recordFrame(
       WebSocketFrameDirection.SENT,
       WebSocketFrameType.CLOSE,
       reason?.toByteArray(Charsets.UTF_8)?.size?.toLong() ?: 0,
+      success,
     )
-    return delegate.close(code, reason)
+    return success
   }
 
   override fun cancel() = delegate.cancel()
 
   private fun send(type: WebSocketFrameType, size: Long, action: () -> Boolean): Boolean {
-    recordFrame(WebSocketFrameDirection.SENT, type, size)
-    if (controller?.allow(type, size) == false) return false
-    return action()
+    val success = controller?.allow(type, size) != false && action()
+    recordFrame(WebSocketFrameDirection.SENT, type, size, success)
+    return success
   }
 
   private fun recordFrame(
     direction: WebSocketFrameDirection,
     type: WebSocketFrameType,
     size: Long,
+    success: Boolean,
   ) {
     buffer.add(
       SdkWebSocketFrameEvent(
@@ -63,6 +66,7 @@ internal class AutoMobileWebSocket(
         direction = direction,
         frameType = type,
         payloadSize = size,
+        success = success,
       )
     )
   }

--- a/android/auto-mobile-sdk/src/main/kotlin/dev/jasonpearson/automobile/sdk/network/AutoMobileWebSocket.kt
+++ b/android/auto-mobile-sdk/src/main/kotlin/dev/jasonpearson/automobile/sdk/network/AutoMobileWebSocket.kt
@@ -1,0 +1,69 @@
+package dev.jasonpearson.automobile.sdk.network
+
+import dev.jasonpearson.automobile.protocol.SdkWebSocketFrameEvent
+import dev.jasonpearson.automobile.protocol.WebSocketFrameDirection
+import dev.jasonpearson.automobile.protocol.WebSocketFrameType
+import dev.jasonpearson.automobile.sdk.events.SdkEventBuffer
+import java.util.UUID
+import okhttp3.Request
+import okhttp3.WebSocket
+import okio.ByteString
+
+/** WebSocket decorator that observes and optionally gates outbound frames. */
+internal class AutoMobileWebSocket(
+  private val delegate: WebSocket,
+  private val url: String,
+  private val buffer: SdkEventBuffer,
+  private val applicationId: String?,
+  private val controller: WebSocketSendController?,
+  private val connectionId: String = UUID.randomUUID().toString().take(8),
+) : WebSocket {
+  override fun request(): Request = delegate.request()
+
+  override fun queueSize(): Long = delegate.queueSize()
+
+  override fun send(text: String): Boolean {
+    return send(WebSocketFrameType.TEXT, text.toByteArray(Charsets.UTF_8).size.toLong()) {
+      delegate.send(text)
+    }
+  }
+
+  override fun send(bytes: ByteString): Boolean {
+    return send(WebSocketFrameType.BINARY, bytes.size.toLong()) { delegate.send(bytes) }
+  }
+
+  override fun close(code: Int, reason: String?): Boolean {
+    recordFrame(
+      WebSocketFrameDirection.SENT,
+      WebSocketFrameType.CLOSE,
+      reason?.toByteArray(Charsets.UTF_8)?.size?.toLong() ?: 0,
+    )
+    return delegate.close(code, reason)
+  }
+
+  override fun cancel() = delegate.cancel()
+
+  private fun send(type: WebSocketFrameType, size: Long, action: () -> Boolean): Boolean {
+    recordFrame(WebSocketFrameDirection.SENT, type, size)
+    if (controller?.allow(type, size) == false) return false
+    return action()
+  }
+
+  private fun recordFrame(
+    direction: WebSocketFrameDirection,
+    type: WebSocketFrameType,
+    size: Long,
+  ) {
+    buffer.add(
+      SdkWebSocketFrameEvent(
+        timestamp = System.currentTimeMillis(),
+        applicationId = applicationId,
+        connectionId = connectionId,
+        url = url,
+        direction = direction,
+        frameType = type,
+        payloadSize = size,
+      )
+    )
+  }
+}

--- a/android/auto-mobile-sdk/src/main/kotlin/dev/jasonpearson/automobile/sdk/network/AutoMobileWebSocketListener.kt
+++ b/android/auto-mobile-sdk/src/main/kotlin/dev/jasonpearson/automobile/sdk/network/AutoMobileWebSocketListener.kt
@@ -20,7 +20,7 @@ import okio.ByteString
  * @param url The WebSocket URL for identification
  * @param buffer The event buffer to post events to
  * @param applicationId Optional application ID
- * @param connectionId Unique ID for this WebSocket connection (auto-generated)
+ * @param connectionId Unique ID for this WebSocket connection
  */
 internal class AutoMobileWebSocketListener(
   private val delegate: WebSocketListener,
@@ -71,6 +71,7 @@ internal class AutoMobileWebSocketListener(
         direction = direction,
         frameType = type,
         payloadSize = size,
+        success = true,
       )
     )
   }

--- a/android/auto-mobile-sdk/src/main/kotlin/dev/jasonpearson/automobile/sdk/network/WebSocketSendController.kt
+++ b/android/auto-mobile-sdk/src/main/kotlin/dev/jasonpearson/automobile/sdk/network/WebSocketSendController.kt
@@ -1,0 +1,13 @@
+package dev.jasonpearson.automobile.sdk.network
+
+import dev.jasonpearson.automobile.protocol.WebSocketFrameType
+
+/** Optional debug/test hook evaluated before an outbound WebSocket frame is sent. */
+fun interface WebSocketSendController {
+  /**
+   * Returns whether the frame should be sent.
+   *
+   * Returning false blocks the application send and still records the attempted frame.
+   */
+  fun allow(type: WebSocketFrameType, payloadSize: Long): Boolean
+}

--- a/android/auto-mobile-sdk/src/main/kotlin/dev/jasonpearson/automobile/sdk/persistence/EventPersistence.kt
+++ b/android/auto-mobile-sdk/src/main/kotlin/dev/jasonpearson/automobile/sdk/persistence/EventPersistence.kt
@@ -173,6 +173,7 @@ internal class FileEventPersistence(
           obj.put("direction", event.direction.name)
           obj.put("frameType", event.frameType.name)
           obj.put("payloadSize", event.payloadSize)
+          obj.put("success", event.success)
         }
         is SdkLogEvent -> {
           obj.put("level", event.level)
@@ -351,6 +352,7 @@ internal class FileEventPersistence(
           direction = direction,
           frameType = frameType,
           payloadSize = obj.optLong("payloadSize"),
+          success = obj.optBoolean("success", true),
         )
       }
       "log" ->

--- a/android/auto-mobile-sdk/src/test/kotlin/dev/jasonpearson/automobile/sdk/network/AutoMobileWebSocketTest.kt
+++ b/android/auto-mobile-sdk/src/test/kotlin/dev/jasonpearson/automobile/sdk/network/AutoMobileWebSocketTest.kt
@@ -1,0 +1,155 @@
+package dev.jasonpearson.automobile.sdk.network
+
+import dev.jasonpearson.automobile.protocol.SdkEvent
+import dev.jasonpearson.automobile.protocol.SdkWebSocketFrameEvent
+import dev.jasonpearson.automobile.protocol.WebSocketFrameDirection
+import dev.jasonpearson.automobile.protocol.WebSocketFrameType
+import dev.jasonpearson.automobile.sdk.events.SdkEventBuffer
+import java.util.concurrent.Executors
+import kotlin.test.assertEquals
+import kotlin.test.assertFalse
+import kotlin.test.assertTrue
+import okhttp3.Request
+import okhttp3.WebSocket
+import okio.ByteString
+import okio.ByteString.Companion.encodeUtf8
+import org.junit.Test
+
+class AutoMobileWebSocketTest {
+
+  private fun collectingBuffer(): Pair<SdkEventBuffer, MutableList<SdkEvent>> {
+    val events = mutableListOf<SdkEvent>()
+    val buffer =
+      SdkEventBuffer(
+        maxBufferSize = 1,
+        flushIntervalMs = 60_000,
+        onFlush = { events.addAll(it) },
+        executor = Executors.newSingleThreadScheduledExecutor(),
+      )
+    return buffer to events
+  }
+
+  @Test
+  fun `captures outbound text with byte size and stable connection metadata`() {
+    val (buffer, events) = collectingBuffer()
+    val delegate = FakeWebSocket(sendResult = true)
+    val webSocket =
+      AutoMobileWebSocket(
+        delegate = delegate,
+        url = "wss://example.com/ws",
+        buffer = buffer,
+        applicationId = "com.example.app",
+        controller = null,
+        connectionId = "connection-1",
+      )
+
+    assertTrue(webSocket.send("hé"))
+
+    val event = events.single() as SdkWebSocketFrameEvent
+    assertEquals(WebSocketFrameDirection.SENT, event.direction)
+    assertEquals(WebSocketFrameType.TEXT, event.frameType)
+    assertEquals(3L, event.payloadSize)
+    assertEquals("wss://example.com/ws", event.url)
+    assertEquals("connection-1", event.connectionId)
+    assertEquals("com.example.app", event.applicationId)
+    assertEquals(listOf("hé"), delegate.textSends)
+  }
+
+  @Test
+  fun `captures outbound binary and preserves delegate result`() {
+    val (buffer, events) = collectingBuffer()
+    val delegate = FakeWebSocket(sendResult = false)
+    val webSocket =
+      AutoMobileWebSocket(
+        delegate,
+        "wss://x",
+        buffer,
+        applicationId = null,
+        controller = null,
+        connectionId = "c1",
+      )
+    val bytes = "binary".encodeUtf8()
+
+    assertFalse(webSocket.send(bytes))
+
+    val event = events.single() as SdkWebSocketFrameEvent
+    assertEquals(WebSocketFrameType.BINARY, event.frameType)
+    assertEquals(bytes.size.toLong(), event.payloadSize)
+    assertEquals(listOf(bytes), delegate.binarySends)
+  }
+
+  @Test
+  fun `blocked send records attempted frame without calling delegate`() {
+    val (buffer, events) = collectingBuffer()
+    val delegate = FakeWebSocket(sendResult = true)
+    val controller = WebSocketSendController { _, _ -> false }
+    val webSocket =
+      AutoMobileWebSocket(
+        delegate,
+        "wss://x",
+        buffer,
+        applicationId = null,
+        controller = controller,
+        connectionId = "c1",
+      )
+
+    assertFalse(webSocket.send("blocked"))
+
+    assertTrue(delegate.textSends.isEmpty())
+    val event = events.single() as SdkWebSocketFrameEvent
+    assertEquals(WebSocketFrameDirection.SENT, event.direction)
+    assertEquals(WebSocketFrameType.TEXT, event.frameType)
+  }
+
+  @Test
+  fun `captures close and delegates close operation`() {
+    val (buffer, events) = collectingBuffer()
+    val delegate = FakeWebSocket(sendResult = true, closeResult = true)
+    val webSocket =
+      AutoMobileWebSocket(
+        delegate,
+        "wss://x",
+        buffer,
+        applicationId = null,
+        controller = null,
+        connectionId = "c1",
+      )
+
+    assertTrue(webSocket.close(1000, "adiós"))
+
+    assertEquals(1000 to "adiós", delegate.closeCalls.single())
+    val event = events.single() as SdkWebSocketFrameEvent
+    assertEquals(WebSocketFrameType.CLOSE, event.frameType)
+    assertEquals(6L, event.payloadSize)
+  }
+
+  private class FakeWebSocket(
+    private val sendResult: Boolean,
+    private val closeResult: Boolean = false,
+  ) : WebSocket {
+    val textSends = mutableListOf<String>()
+    val binarySends = mutableListOf<ByteString>()
+    val closeCalls = mutableListOf<Pair<Int, String?>>()
+
+    override fun request(): Request = Request.Builder().url("https://fake").build()
+
+    override fun queueSize(): Long = 0
+
+    override fun send(text: String): Boolean {
+      textSends.add(text)
+      return sendResult
+    }
+
+    override fun send(bytes: ByteString): Boolean {
+      binarySends.add(bytes)
+      return sendResult
+    }
+
+    override fun close(code: Int, reason: String?): Boolean {
+      closeCalls.add(code to reason)
+      return closeResult
+    }
+
+    override fun cancel() {}
+  }
+}

--- a/android/auto-mobile-sdk/src/test/kotlin/dev/jasonpearson/automobile/sdk/network/AutoMobileWebSocketTest.kt
+++ b/android/auto-mobile-sdk/src/test/kotlin/dev/jasonpearson/automobile/sdk/network/AutoMobileWebSocketTest.kt
@@ -76,6 +76,7 @@ class AutoMobileWebSocketTest {
     assertEquals(WebSocketFrameType.BINARY, event.frameType)
     assertEquals(bytes.size.toLong(), event.payloadSize)
     assertEquals(listOf(bytes), delegate.binarySends)
+    assertEquals(false, event.success)
   }
 
   @Test
@@ -99,6 +100,7 @@ class AutoMobileWebSocketTest {
     val event = events.single() as SdkWebSocketFrameEvent
     assertEquals(WebSocketFrameDirection.SENT, event.direction)
     assertEquals(WebSocketFrameType.TEXT, event.frameType)
+    assertEquals(false, event.success)
   }
 
   @Test
@@ -121,6 +123,38 @@ class AutoMobileWebSocketTest {
     val event = events.single() as SdkWebSocketFrameEvent
     assertEquals(WebSocketFrameType.CLOSE, event.frameType)
     assertEquals(6L, event.payloadSize)
+    assertEquals(true, event.success)
+  }
+
+  @Test
+  fun `shared connection id correlates listener and websocket events`() {
+    val (buffer, events) = collectingBuffer()
+    val delegate = FakeWebSocket(sendResult = true)
+    val connectionId = "shared-connection"
+    val listener =
+      AutoMobileWebSocketListener(
+        delegate = object : okhttp3.WebSocketListener() {},
+        url = "wss://x",
+        buffer = buffer,
+        connectionId = connectionId,
+      )
+    val webSocket =
+      AutoMobileWebSocket(
+        delegate,
+        "wss://x",
+        buffer,
+        applicationId = null,
+        controller = null,
+        connectionId = connectionId,
+      )
+
+    listener.onMessage(delegate, "received")
+    webSocket.send("sent")
+
+    assertEquals(
+      listOf(connectionId, connectionId),
+      events.map { (it as SdkWebSocketFrameEvent).connectionId },
+    )
   }
 
   private class FakeWebSocket(

--- a/android/control-proxy/src/main/kotlin/dev/jasonpearson/automobile/ctrlproxy/CtrlProxy.kt
+++ b/android/control-proxy/src/main/kotlin/dev/jasonpearson/automobile/ctrlproxy/CtrlProxy.kt
@@ -5755,6 +5755,7 @@ class CtrlProxy : AccessibilityService(), CtrlProxyActions {
                   direction = event.direction.name.lowercase(),
                   frameType = event.frameType.name.lowercase(),
                   payloadSize = event.payloadSize,
+                  success = event.success,
                   applicationId = event.applicationId,
                 ),
             )

--- a/android/protocol/src/main/kotlin/dev/jasonpearson/automobile/protocol/SdkEvent.kt
+++ b/android/protocol/src/main/kotlin/dev/jasonpearson/automobile/protocol/SdkEvent.kt
@@ -253,6 +253,8 @@ data class SdkWebSocketFrameEvent(
   val frameType: WebSocketFrameType,
   /** Frame payload size in bytes */
   val payloadSize: Long = 0,
+  /** Whether the operation succeeded */
+  val success: Boolean = true,
 ) : SdkEvent()
 
 // =============================================================================

--- a/android/protocol/src/main/kotlin/dev/jasonpearson/automobile/protocol/WebSocketResponse.kt
+++ b/android/protocol/src/main/kotlin/dev/jasonpearson/automobile/protocol/WebSocketResponse.kt
@@ -167,6 +167,7 @@ data class WebSocketFrameData(
   val direction: String,
   val frameType: String,
   val payloadSize: Long = 0,
+  val success: Boolean = true,
   val applicationId: String? = null,
 )
 

--- a/src/features/observe/android/AndroidCtrlProxyClient.ts
+++ b/src/features/observe/android/AndroidCtrlProxyClient.ts
@@ -586,6 +586,7 @@ interface WsWebSocketFrameEventMessage extends WsMessageBase {
     url?: string;
     direction?: string;
     payloadSize?: number;
+    success?: boolean;
   };
 }
 

--- a/src/features/observe/android/AndroidSdkEventIngestor.ts
+++ b/src/features/observe/android/AndroidSdkEventIngestor.ts
@@ -188,6 +188,7 @@ export class DefaultAndroidSdkEventIngestor implements AndroidSdkEventIngestor {
               url: (event.url as string) ?? "",
               direction: (event.direction as string) ?? "",
               payloadSize: String((event.payloadSize as number) ?? 0),
+              success: String((event.success as boolean) ?? true),
             },
           });
           break;


### PR DESCRIPTION
## Summary

- Add an OkHttp WebSocket decorator that records outbound text, binary, and close frames.
- Preserve the delegated WebSocket behavior and expose an optional send-blocking controller for deterministic test/debug faults.
- Record UTF-8 byte sizes, operation outcomes, stable connection identifiers, URLs, application IDs, and update the Android API dump.
- Allow the listener and WebSocket decorators to share an explicit connection ID for inbound/outbound correlation.

## Validation

- Focused `auto-mobile-sdk` unit tests, including fake WebSocket send results and blocked sends
- `:auto-mobile-sdk:apiDump`
- `:auto-mobile-sdk:apiCheck`
- Touched Kotlin ktfmt validation
- `bun run typecheck`
- `bun run turbo:validate`

Closes [#5066](https://github.com/kaeawc/auto-mobile/issues/5066)
