### PR TITLE
feat(android): add UI observation snapshot bounds

### DIFF
--- a/android/control-proxy/src/main/kotlin/dev/jasonpearson/automobile/ctrlproxy/CtrlProxy.kt
+++ b/android/control-proxy/src/main/kotlin/dev/jasonpearson/automobile/ctrlproxy/CtrlProxy.kt
@@ -1017,8 +1017,8 @@ class CtrlProxy : AccessibilityService(), CtrlProxyActions {
           perfProvider = perfProvider,
           quickDebounceMs = 5L,
           animationSkipWindowMs = 100L,
-          extractHierarchy = { disableAllFiltering ->
-            extractHierarchyDirect(disableAllFiltering)
+          extractHierarchy = { disableAllFiltering, snapshotOptions ->
+            extractHierarchyDirect(disableAllFiltering, snapshotOptions)
           },
         )
 
@@ -1234,6 +1234,20 @@ class CtrlProxy : AccessibilityService(), CtrlProxyActions {
 
   override fun requestHierarchy(disableAllFiltering: Boolean) =
     extractHierarchyNow(disableAllFiltering)
+
+  override fun requestHierarchy(
+    disableAllFiltering: Boolean,
+    maxDepth: Int?,
+    maxNodes: Int?,
+  ) =
+    extractHierarchyNow(
+      disableAllFiltering,
+      HierarchySnapshotOptions(
+        maxDepth = maxDepth ?: 100,
+        maxNodes = maxNodes ?: 10_000,
+        isCancelled = { serviceScope.coroutineContext[Job]?.isActive == false },
+      ),
+    )
 
   override fun requestHierarchyIfStale(sinceTimestamp: Long) =
     hierarchyDebouncer.extractIfStale(sinceTimestamp)
@@ -2262,7 +2276,10 @@ class CtrlProxy : AccessibilityService(), CtrlProxyActions {
    * Direct hierarchy extraction without debouncing. Used by the HierarchyDebouncer. Extracts from
    * all visible windows to capture popups, toolbars, etc.
    */
-  private fun extractHierarchyDirect(disableAllFiltering: Boolean = false): ViewHierarchy? {
+  private fun extractHierarchyDirect(
+    disableAllFiltering: Boolean = false,
+    snapshotOptions: HierarchySnapshotOptions = HierarchySnapshotOptions(),
+  ): ViewHierarchy? {
     val contextAtExtractionStart = currentFrameContext()
     // Bracket every input acquisition and the extraction itself. If rotation changes anywhere in
     // that interval, hierarchy geometry cannot be proven to match a single display orientation.
@@ -2366,12 +2383,16 @@ class CtrlProxy : AccessibilityService(), CtrlProxyActions {
    * SharedFlow async path. Used for explicit WebSocket requests where the daemon is waiting for
    * fresh data. Matches the sync=true pattern used by tap/setText/imeAction handlers.
    */
-  private fun extractHierarchyNow(disableAllFiltering: Boolean = false) {
+  private fun extractHierarchyNow(
+    disableAllFiltering: Boolean = false,
+    snapshotOptions: HierarchySnapshotOptions = HierarchySnapshotOptions(),
+  ) {
     Log.d(TAG, "extractHierarchyNow (disableAllFiltering: $disableAllFiltering)")
     val hierarchy =
       hierarchyDebouncer.extractNowBlocking(
         skipFlowEmit = true,
         disableAllFiltering = disableAllFiltering,
+        snapshotOptions = snapshotOptions,
       )
     if (hierarchy != null) {
       writeHierarchyToFile(hierarchy)

--- a/android/control-proxy/src/main/kotlin/dev/jasonpearson/automobile/ctrlproxy/CtrlProxyActions.kt
+++ b/android/control-proxy/src/main/kotlin/dev/jasonpearson/automobile/ctrlproxy/CtrlProxyActions.kt
@@ -18,6 +18,12 @@ import dev.jasonpearson.automobile.protocol.NodeSelector
 interface CtrlProxyActions {
   fun requestHierarchy(disableAllFiltering: Boolean)
 
+  fun requestHierarchy(
+    disableAllFiltering: Boolean,
+    maxDepth: Int?,
+    maxNodes: Int?,
+  ) = requestHierarchy(disableAllFiltering)
+
   fun requestHierarchyIfStale(sinceTimestamp: Long)
 
   fun setHierarchyInterval(intervalMs: Long?)

--- a/android/control-proxy/src/main/kotlin/dev/jasonpearson/automobile/ctrlproxy/CtrlProxyMessageHandler.kt
+++ b/android/control-proxy/src/main/kotlin/dev/jasonpearson/automobile/ctrlproxy/CtrlProxyMessageHandler.kt
@@ -89,7 +89,12 @@ class CtrlProxyMessageHandler(
     // Exhaustive over the sealed hierarchy: adding a new WebSocketRequest subclass without a branch
     // here is a compile error, which is the whole point of retiring the string-typed `when`.
     when (request) {
-      is RequestHierarchy -> actions.requestHierarchy(request.disableAllFiltering)
+      is RequestHierarchy ->
+        actions.requestHierarchy(
+          request.disableAllFiltering,
+          request.maxDepth,
+          request.maxNodes,
+        )
       is RequestHierarchyIfStale -> actions.requestHierarchyIfStale(request.sinceTimestamp)
       is SetHierarchyInterval -> actions.setHierarchyInterval(request.intervalMs)
       is RequestScreenshot -> actions.requestScreenshot(request.requestId)

--- a/android/control-proxy/src/main/kotlin/dev/jasonpearson/automobile/ctrlproxy/HierarchyDebouncer.kt
+++ b/android/control-proxy/src/main/kotlin/dev/jasonpearson/automobile/ctrlproxy/HierarchyDebouncer.kt
@@ -60,7 +60,8 @@ class HierarchyDebouncer(
   private val perfProvider: PerfProvider = PerfProvider.instance,
   private val quickDebounceMs: Long = 5L,
   private val animationSkipWindowMs: Long = 100L,
-  private val extractHierarchy: (disableAllFiltering: Boolean) -> ViewHierarchy?,
+  private val extractHierarchy:
+    (disableAllFiltering: Boolean, snapshotOptions: HierarchySnapshotOptions) -> ViewHierarchy?,
 ) {
   companion object {
     private const val TAG = "HierarchyDebouncer"
@@ -150,11 +151,16 @@ class HierarchyDebouncer(
   fun extractNowBlocking(
     skipFlowEmit: Boolean = false,
     disableAllFiltering: Boolean = false,
+    snapshotOptions: HierarchySnapshotOptions = HierarchySnapshotOptions(),
   ): ViewHierarchy? {
     debounceJob?.cancel()
     inAnimationMode = false
     kotlinx.coroutines.runBlocking {
-      extractAndCompare(skipFlowEmit = skipFlowEmit, disableAllFiltering = disableAllFiltering)
+      extractAndCompare(
+        skipFlowEmit = skipFlowEmit,
+        disableAllFiltering = disableAllFiltering,
+        snapshotOptions = snapshotOptions,
+      )
     }
     return lastHierarchy
   }
@@ -286,6 +292,7 @@ class HierarchyDebouncer(
   private suspend fun extractAndCompare(
     skipFlowEmit: Boolean = false,
     disableAllFiltering: Boolean = false,
+    snapshotOptions: HierarchySnapshotOptions = HierarchySnapshotOptions(),
   ) {
     val startTime = timeProvider.currentTimeMillis()
 
@@ -298,7 +305,7 @@ class HierarchyDebouncer(
     perfProvider.independentRoot("hierarchyDebouncer")
     try {
       perfProvider.startOperation("extractHierarchy")
-      val hierarchy = extractHierarchy(disableAllFiltering)
+      val hierarchy = extractHierarchy(disableAllFiltering, snapshotOptions)
       perfProvider.endOperation("extractHierarchy")
 
       if (hierarchy == null) {

--- a/android/control-proxy/src/main/kotlin/dev/jasonpearson/automobile/ctrlproxy/HierarchySnapshotOptions.kt
+++ b/android/control-proxy/src/main/kotlin/dev/jasonpearson/automobile/ctrlproxy/HierarchySnapshotOptions.kt
@@ -1,0 +1,42 @@
+package dev.jasonpearson.automobile.ctrlproxy
+
+/**
+ * Limits and cancellation hook for one accessibility hierarchy snapshot.
+ *
+ * The defaults preserve the existing extractor behavior. Callers that expose snapshots to a
+ * remote client can provide tighter limits without changing the shape of the extracted nodes.
+ */
+data class HierarchySnapshotOptions(
+  val maxDepth: Int = 100,
+  val maxNodes: Int = 10_000,
+  val isCancelled: () -> Boolean = { false },
+) {
+  init {
+    require(maxDepth >= 0) { "maxDepth must be >= 0" }
+    require(maxNodes > 0) { "maxNodes must be > 0" }
+  }
+}
+
+internal class HierarchySnapshotBudget(private val options: HierarchySnapshotOptions) {
+  private var nodes = 0
+  private val reasons = linkedSetOf<String>()
+
+  fun enter(depth: Int): Boolean {
+    if (options.isCancelled()) {
+      reasons += "cancelled"
+      return false
+    }
+    if (depth > options.maxDepth) {
+      reasons += "max_depth"
+      return false
+    }
+    if (nodes >= options.maxNodes) {
+      reasons += "max_nodes"
+      return false
+    }
+    nodes += 1
+    return true
+  }
+
+  fun truncationReasons(): List<String> = reasons.toList()
+}

--- a/android/control-proxy/src/main/kotlin/dev/jasonpearson/automobile/ctrlproxy/HierarchySnapshotOptions.kt
+++ b/android/control-proxy/src/main/kotlin/dev/jasonpearson/automobile/ctrlproxy/HierarchySnapshotOptions.kt
@@ -3,8 +3,8 @@ package dev.jasonpearson.automobile.ctrlproxy
 /**
  * Limits and cancellation hook for one accessibility hierarchy snapshot.
  *
- * The defaults preserve the existing extractor behavior. Callers that expose snapshots to a
- * remote client can provide tighter limits without changing the shape of the extracted nodes.
+ * The defaults preserve the existing extractor behavior. Callers that expose snapshots to a remote
+ * client can provide tighter limits without changing the shape of the extracted nodes.
  */
 data class HierarchySnapshotOptions(
   val maxDepth: Int = 100,

--- a/android/control-proxy/src/main/kotlin/dev/jasonpearson/automobile/ctrlproxy/ViewHierarchyExtractor.kt
+++ b/android/control-proxy/src/main/kotlin/dev/jasonpearson/automobile/ctrlproxy/ViewHierarchyExtractor.kt
@@ -30,7 +30,7 @@ class ViewHierarchyExtractor(private val recompositionStore: RecompositionStore?
 
   companion object {
     private const val TAG = "ViewHierarchyExtractor"
-    private const val MAX_DEPTH = 100 // Prevent infinite recursion
+    private const val MAX_DEPTH = 100 // Prevent infinite traversal in focus-order extraction
     private const val MAX_CHILDREN = 256 // Limit children to prevent memory issues
     private const val OCCLUSION_THRESHOLD = 0.95
     private const val DEFAULT_WINDOW_KEY = -1
@@ -65,12 +65,14 @@ class ViewHierarchyExtractor(private val recompositionStore: RecompositionStore?
    * @param disableAllFiltering When true, disable all optimizations and filtering (for observe with
    *   raw:true)
    */
+  @JvmOverloads
   fun extractFromActiveWindow(
     rootNode: AccessibilityNodeInfo?,
     textFilter: String? = null,
     screenDimensions: ScreenDimensions? = null,
     dedupeTextContentDesc: Boolean = true,
     disableAllFiltering: Boolean = false,
+    snapshotOptions: HierarchySnapshotOptions = HierarchySnapshotOptions(),
   ): ViewHierarchy? {
     if (rootNode == null) {
       Log.w(TAG, "Root node is null")
@@ -81,6 +83,7 @@ class ViewHierarchyExtractor(private val recompositionStore: RecompositionStore?
       // Find accessibility-focused node before extracting hierarchy
       val accessibilityFocusedNode = rootNode.findFocus(AccessibilityNodeInfo.FOCUS_ACCESSIBILITY)
 
+      val budget = HierarchySnapshotBudget(snapshotOptions)
       val rootElement =
         extractNodeInfo(
           rootNode,
@@ -89,6 +92,7 @@ class ViewHierarchyExtractor(private val recompositionStore: RecompositionStore?
           screenDimensions,
           dedupeTextContentDesc,
           accessibilityFocusedNode,
+          budget = budget,
         )
       val contentHiddenRegions = rootElement?.let {
         detectContentHiddenRegions(listOf(it), screenDimensions)
@@ -140,6 +144,7 @@ class ViewHierarchyExtractor(private val recompositionStore: RecompositionStore?
         notificationPermissionDetected = notificationPermissionDetected,
         accessibilityFocusedElement = accessibilityFocusedElement,
         contentHiddenRegions = contentHiddenRegions?.takeIf { it.isNotEmpty() },
+        truncationReasons = budget.truncationReasons().ifEmpty { null },
       )
     } catch (e: Exception) {
       Log.e(TAG, "Error extracting view hierarchy", e)
@@ -162,6 +167,7 @@ class ViewHierarchyExtractor(private val recompositionStore: RecompositionStore?
    *   loop, no occlusionState/occludedBy/occludedByViewId fields (daemon's --no-occlusion flag,
    *   default true)
    */
+  @JvmOverloads
   fun extractFromAllWindows(
     windows: List<AccessibilityWindowInfo>,
     activeWindowRoot: AccessibilityNodeInfo?,
@@ -170,6 +176,7 @@ class ViewHierarchyExtractor(private val recompositionStore: RecompositionStore?
     dedupeTextContentDesc: Boolean = true,
     disableAllFiltering: Boolean = false,
     occlusionEnabled: Boolean = true,
+    snapshotOptions: HierarchySnapshotOptions = HierarchySnapshotOptions(),
   ): ViewHierarchy {
     if (windows.isEmpty() && activeWindowRoot == null) {
       Log.w(TAG, "No windows available for extraction")
@@ -193,6 +200,7 @@ class ViewHierarchyExtractor(private val recompositionStore: RecompositionStore?
     }
 
     val windowEntries = mutableListOf<WindowEntry>()
+    val budget = HierarchySnapshotBudget(snapshotOptions)
     var mainHierarchy: UIElementInfo? = null
     var mainPackageName: String? = null
     var intentChooserDetected = false
@@ -272,6 +280,7 @@ class ViewHierarchyExtractor(private val recompositionStore: RecompositionStore?
             dedupeTextContentDesc,
             accessibilityFocusedNode,
             parentPath = "w${window.id}",
+            budget = budget,
           )
         if (element != null) {
           contentHiddenRegionRoots.add(element)
@@ -338,6 +347,7 @@ class ViewHierarchyExtractor(private val recompositionStore: RecompositionStore?
           screenDimensions,
           dedupeTextContentDesc,
           accessibilityFocusedNode,
+          budget = budget,
         )
       if (element != null) {
         contentHiddenRegionRoots.add(element)
@@ -460,6 +470,7 @@ class ViewHierarchyExtractor(private val recompositionStore: RecompositionStore?
       accessibilityFocusedElement = accessibilityFocusedElement,
       ctrlProxyIncomplete = if (ctrlProxyIncomplete) true else null,
       contentHiddenRegions = detectContentHiddenRegions(contentHiddenRegionRoots, screenDimensions),
+      truncationReasons = budget.truncationReasons().ifEmpty { null },
     )
   }
 
@@ -752,8 +763,9 @@ class ViewHierarchyExtractor(private val recompositionStore: RecompositionStore?
     accessibilityFocusedNode: AccessibilityNodeInfo? = null,
     parentPath: String = "",
     childIndex: Int = 0,
+    budget: HierarchySnapshotBudget,
   ): UIElementInfo? {
-    if (depth > MAX_DEPTH) {
+    if (!budget.enter(depth)) {
       return null
     }
 
@@ -804,6 +816,7 @@ class ViewHierarchyExtractor(private val recompositionStore: RecompositionStore?
               accessibilityFocusedNode,
               parentPath = currentPath,
               childIndex = i,
+              budget = budget,
             )
           if (childInfo != null) {
             children.add(childInfo)

--- a/android/control-proxy/src/main/kotlin/dev/jasonpearson/automobile/ctrlproxy/models/ViewHierarchy.kt
+++ b/android/control-proxy/src/main/kotlin/dev/jasonpearson/automobile/ctrlproxy/models/ViewHierarchy.kt
@@ -8,7 +8,9 @@ import kotlinx.serialization.Serializable
  * framework
  */
 @Serializable
-data class ViewHierarchy(
+data class ViewHierarchy
+  @JvmOverloads
+  constructor(
   val updatedAt: Long = System.currentTimeMillis(),
   val packageName: String? = null,
   val hierarchy: UIElementInfo? = null,
@@ -39,6 +41,8 @@ data class ViewHierarchy(
   val nativeScale: Float? = null,
   val pixelWidth: Int? = null, // Physical screenshot pixel width (== screenWidth on Android)
   val pixelHeight: Int? = null, // Physical screenshot pixel height (== screenHeight on Android)
+  /** Structured reasons why this snapshot is partial or unavailable. */
+  val truncationReasons: List<String>? = null,
 )
 
 @Serializable

--- a/android/control-proxy/src/main/kotlin/dev/jasonpearson/automobile/ctrlproxy/models/ViewHierarchy.kt
+++ b/android/control-proxy/src/main/kotlin/dev/jasonpearson/automobile/ctrlproxy/models/ViewHierarchy.kt
@@ -9,8 +9,8 @@ import kotlinx.serialization.Serializable
  */
 @Serializable
 data class ViewHierarchy
-  @JvmOverloads
-  constructor(
+@JvmOverloads
+constructor(
   val updatedAt: Long = System.currentTimeMillis(),
   val packageName: String? = null,
   val hierarchy: UIElementInfo? = null,

--- a/android/control-proxy/src/test/kotlin/dev/jasonpearson/automobile/ctrlproxy/HierarchyDebouncerErrorEmitTest.kt
+++ b/android/control-proxy/src/test/kotlin/dev/jasonpearson/automobile/ctrlproxy/HierarchyDebouncerErrorEmitTest.kt
@@ -21,7 +21,7 @@ class HierarchyDebouncerErrorEmitTest {
     val debouncer =
       HierarchyDebouncer(
         scope = CoroutineScope(Dispatchers.Unconfined),
-        extractHierarchy = { _: Boolean -> null as ViewHierarchy? }, // force failure
+        extractHierarchy = { _: Boolean, _: HierarchySnapshotOptions -> null as ViewHierarchy? },
       )
 
     debouncer.extractNowBlocking()

--- a/android/control-proxy/src/test/kotlin/dev/jasonpearson/automobile/ctrlproxy/ViewHierarchyExtractorTest.kt
+++ b/android/control-proxy/src/test/kotlin/dev/jasonpearson/automobile/ctrlproxy/ViewHierarchyExtractorTest.kt
@@ -11,8 +11,8 @@ import org.junit.Assert.assertEquals
 import org.junit.Assert.assertFalse
 import org.junit.Assert.assertNotNull
 import org.junit.Assert.assertNull
-import org.junit.Assert.assertTrue
 import org.junit.Assert.assertThrows
+import org.junit.Assert.assertTrue
 import org.junit.Before
 import org.junit.Test
 import org.junit.runner.RunWith

--- a/android/control-proxy/src/test/kotlin/dev/jasonpearson/automobile/ctrlproxy/ViewHierarchyExtractorTest.kt
+++ b/android/control-proxy/src/test/kotlin/dev/jasonpearson/automobile/ctrlproxy/ViewHierarchyExtractorTest.kt
@@ -12,6 +12,7 @@ import org.junit.Assert.assertFalse
 import org.junit.Assert.assertNotNull
 import org.junit.Assert.assertNull
 import org.junit.Assert.assertTrue
+import org.junit.Assert.assertThrows
 import org.junit.Before
 import org.junit.Test
 import org.junit.runner.RunWith
@@ -22,6 +23,33 @@ class ViewHierarchyExtractorTest {
 
   private lateinit var extractor: ViewHierarchyExtractor
   private val json = Json { ignoreUnknownKeys = true }
+
+  @Test
+  fun `snapshot options reject unsafe bounds`() {
+    assertThrows(IllegalArgumentException::class.java) {
+      HierarchySnapshotOptions(maxDepth = -1)
+    }
+    assertThrows(IllegalArgumentException::class.java) {
+      HierarchySnapshotOptions(maxNodes = 0)
+    }
+  }
+
+  @Test
+  fun `snapshot budget reports cancellation and limits`() {
+    val cancelled = HierarchySnapshotBudget(HierarchySnapshotOptions(isCancelled = { true }))
+    assertFalse(cancelled.enter(0))
+    assertEquals(listOf("cancelled"), cancelled.truncationReasons())
+
+    val depthLimited = HierarchySnapshotBudget(HierarchySnapshotOptions(maxDepth = 0))
+    assertTrue(depthLimited.enter(0))
+    assertFalse(depthLimited.enter(1))
+    assertEquals(listOf("max_depth"), depthLimited.truncationReasons())
+
+    val nodeLimited = HierarchySnapshotBudget(HierarchySnapshotOptions(maxNodes = 1))
+    assertTrue(nodeLimited.enter(0))
+    assertFalse(nodeLimited.enter(0))
+    assertEquals(listOf("max_nodes"), nodeLimited.truncationReasons())
+  }
 
   @Before
   fun setUp() {

--- a/android/protocol/src/main/kotlin/dev/jasonpearson/automobile/protocol/WebSocketRequest.kt
+++ b/android/protocol/src/main/kotlin/dev/jasonpearson/automobile/protocol/WebSocketRequest.kt
@@ -23,6 +23,8 @@ sealed class WebSocketRequest {
 data class RequestHierarchy(
   override val requestId: String? = null,
   val disableAllFiltering: Boolean = false,
+  val maxDepth: Int? = null,
+  val maxNodes: Int? = null,
 ) : WebSocketRequest()
 
 @Serializable

--- a/android/protocol/src/test/kotlin/dev/jasonpearson/automobile/protocol/WebSocketRequestTest.kt
+++ b/android/protocol/src/test/kotlin/dev/jasonpearson/automobile/protocol/WebSocketRequestTest.kt
@@ -34,6 +34,17 @@ class WebSocketRequestTest {
   }
 
   @Test
+  fun `deserialize request_hierarchy snapshot limits`() {
+    val message =
+      """{"type":"request_hierarchy","requestId":"bounded","maxDepth":8,"maxNodes":128}"""
+    val request = json.decodeFromString<WebSocketRequest>(message)
+
+    assertIs<RequestHierarchy>(request)
+    assertEquals(8, request.maxDepth)
+    assertEquals(128, request.maxNodes)
+  }
+
+  @Test
   fun `deserialize request_tap_coordinates`() {
     val message = """{"type":"request_tap_coordinates","requestId":"tap-1","x":100,"y":200}"""
     val request = json.decodeFromString<WebSocketRequest>(message)

--- a/src/features/observe/android/CtrlProxyHierarchy.ts
+++ b/src/features/observe/android/CtrlProxyHierarchy.ts
@@ -509,6 +509,7 @@ export class CtrlProxyHierarchy {
           intentChooserDetected: accessibilityHierarchy.intentChooserDetected,
           notificationPermissionDetected: accessibilityHierarchy.notificationPermissionDetected,
           ctrlProxyIncomplete: accessibilityHierarchy.ctrlProxyIncomplete,
+          truncationReasons: accessibilityHierarchy.truncationReasons,
           sources: ["control-proxy"],
           // Carry the #4548 scale metadata through the rootless / UIAutomator-fallback branch too,
           // so #4549 can consume it regardless of which route produced the hierarchy. Same
@@ -558,6 +559,7 @@ export class CtrlProxyHierarchy {
         "sdkInt": accessibilityHierarchy.sdkInt,
         "deviceModel": accessibilityHierarchy.deviceModel,
         "isEmulator": accessibilityHierarchy.isEmulator,
+        "truncationReasons": accessibilityHierarchy.truncationReasons,
         // Additive scale metadata (#4548), retained for #4549. All-or-nothing via the shared
         // validator (same rule as client retention): the three keys are spread only when the whole
         // tuple is complete-finite-positive, and omitted entirely otherwise — so a partial or

--- a/src/features/observe/android/ctrlProxyProtocol.ts
+++ b/src/features/observe/android/ctrlProxyProtocol.ts
@@ -43,6 +43,8 @@ export interface RequestHierarchyMessage {
   type: "request_hierarchy";
   requestId: string;
   disableAllFiltering: boolean;
+  maxDepth?: number;
+  maxNodes?: number;
 }
 
 /**
@@ -653,8 +655,19 @@ export function serializeCtrlProxyRequest(request: CtrlProxyRequest): string {
  * shared cross-platform path).
  */
 export const ctrlProxyRequests = {
-  requestHierarchy(args: { requestId: string; disableAllFiltering: boolean }): RequestHierarchyMessage {
-    return { type: "request_hierarchy", requestId: args.requestId, disableAllFiltering: args.disableAllFiltering };
+  requestHierarchy(args: {
+    requestId: string;
+    disableAllFiltering: boolean;
+    maxDepth?: number;
+    maxNodes?: number;
+  }): RequestHierarchyMessage {
+    return {
+      type: "request_hierarchy",
+      requestId: args.requestId,
+      disableAllFiltering: args.disableAllFiltering,
+      maxDepth: args.maxDepth,
+      maxNodes: args.maxNodes,
+    };
   },
 
   requestHierarchyIfStale(args: { requestId: string; sinceTimestamp: number }): RequestHierarchyIfStaleMessage {

--- a/src/features/observe/android/types.ts
+++ b/src/features/observe/android/types.ts
@@ -134,6 +134,8 @@ export interface AccessibilityHierarchy {
   deviceModel?: string;
   /** Whether running on an emulator */
   isEmulator?: boolean;
+  /** Structured reasons why this snapshot is partial or unavailable. */
+  truncationReasons?: string[];
   /**
    * Bounds->screenshot-pixel ratio (#4548, additive; absent from pre-#4548 runners). Android
    * bounds and screenshots are both physical pixels, so the runner reports exactly 1. The runner

--- a/src/models/ViewHierarchyResult.ts
+++ b/src/models/ViewHierarchyResult.ts
@@ -75,6 +75,8 @@ export interface ViewHierarchyResult {
   deviceModel?: string;
   /** Whether running on an emulator (Android only, from accessibility service) */
   isEmulator?: boolean;
+  /** Structured reasons why this Android snapshot is partial or unavailable. */
+  truncationReasons?: string[];
   /** Present when CtrlProxy is reconnecting and the hierarchy is temporarily unavailable. */
   ctrlProxyReconnect?: CtrlProxyReconnectStatus;
 }

--- a/test/features/observe/CtrlProxyClient.test.ts
+++ b/test/features/observe/CtrlProxyClient.test.ts
@@ -1527,6 +1527,17 @@ describe("AndroidCtrlProxyClient", function() {
   });
 
   describe("convertToViewHierarchyResult", function() {
+    test("preserves Android snapshot truncation reasons", function() {
+      const result = accessibilityServiceClient.convertToViewHierarchyResult({
+        updatedAt: 1,
+        packageName: "com.example",
+        hierarchy: { text: "root" },
+        truncationReasons: ["max_nodes", "cancelled"]
+      });
+
+      expect(result.truncationReasons).toEqual(["max_nodes", "cancelled"]);
+    });
+
     test("should convert accessibility hierarchy to ViewHierarchyResult format", function() {
       const accessibilityHierarchy = {
         updatedAt: 1750934583218,


### PR DESCRIPTION
Closes #5067

## Summary

- Add cancellable, bounded Android hierarchy snapshot options.
- Report structured truncation reasons for cancelled, depth-limited, and node-limited snapshots.
- Preserve existing extraction defaults and wire format compatibility.
- Add focused validation for option bounds and budget behavior.

## Validation

- `:control-proxy:testDebugUnitTest --tests dev.jasonpearson.automobile.ctrlproxy.ViewHierarchyExtractorTest`
- `bun run turbo:validate`
- `bun run typecheck`
