### PR TITLE
perf(build): cache typecheck as a turbo task + fix diff-based caching

### DIFF
--- a/package.json
+++ b/package.json
@@ -60,7 +60,8 @@
     "turbo:validate": "turbo run lint build test check:android-emulator-boundary check:ffmpeg-boundary check:host-shell-boundary check:ios-ctrl-proxy-process-boundary",
     "turbo:build": "turbo run build",
     "turbo:lint": "turbo run lint",
-    "turbo:test": "turbo run test"
+    "turbo:test": "turbo run test",
+    "turbo:typecheck": "turbo run typecheck"
   },
   "packageManager": "bun@1.3.14",
   "engines": {

--- a/test/lint/turboCachingSafety.test.ts
+++ b/test/lint/turboCachingSafety.test.ts
@@ -1,0 +1,42 @@
+import { describe, expect, test } from "bun:test";
+import { readFileSync } from "node:fs";
+import path from "node:path";
+
+/**
+ * turbo caching-safety guard (issue #5124).
+ *
+ * Two ways turbo caching silently goes wrong for this repo's gates, pinned here
+ * so a later edit can't reintroduce them:
+ *
+ *  1. `typecheck` is a cached task keyed on its declared `inputs`. Drop an input
+ *     and an unchanged-input edit can replay a stale (green) verdict for a `src/`
+ *     change that would now fail — so the full input set is asserted here.
+ *  2. `check:host-shell-boundary` compares the working tree against
+ *     `origin/main`, so its verdict depends on the base position, not just
+ *     `src/**` content. It must never be cached (`cache: false`), or turbo
+ *     replays a stale verdict when the base moves.
+ */
+const repoRoot = path.resolve(import.meta.dir, "../..");
+const turbo = JSON.parse(readFileSync(path.join(repoRoot, "turbo.json"), "utf8"));
+
+describe("turbo caching safety (#5124)", () => {
+  test("typecheck task declares its full input set", () => {
+    const task = turbo.tasks?.typecheck;
+    expect(task).toBeDefined();
+    const inputs: string[] = task.inputs ?? [];
+    const required = [
+      "src/**",
+      "tsconfig.json",
+      "scripts/typecheck-baseline.sh",
+      "scripts/typecheck-baseline.txt",
+      "package.json",
+    ];
+    for (const glob of required) {
+      expect(inputs).toContain(glob);
+    }
+  });
+
+  test("check:host-shell-boundary is not cached (diff-based, depends on origin/main)", () => {
+    expect(turbo.tasks?.["check:host-shell-boundary"]?.cache).toBe(false);
+  });
+});

--- a/turbo.json
+++ b/turbo.json
@@ -89,7 +89,15 @@
       "description": "Prevent new production host-shell execution",
       "inputs": ["src/**", "scripts/check-host-shell-boundary.ts", "package.json"],
       "outputs": [],
-      "outputLogs": "new-only"
+      "outputLogs": "new-only",
+      "cache": false
+    },
+    "typecheck": {
+      "description": "tsgo --noEmit baseline gate (scripts/typecheck-baseline.sh, issue #3001). Cached on src/** + tsconfig + the baseline so an unchanged src/ skips the ~5.6s run; a test/docs/native-only edit is a cache hit. Keyed on declared inputs, not the tsc/tsgo binary, so it is migration-neutral — a TypeScript-version bump changes package.json and the regenerated baseline and busts the hash. Only exit-0 is cached, so a red gate is never memoized.",
+      "inputs": ["src/**", "tsconfig.json", "scripts/typecheck-baseline.sh", "scripts/typecheck-baseline.txt", "package.json"],
+      "outputs": [],
+      "outputLogs": "new-only",
+      "passThroughEnv": ["CI", "GITHUB_ACTIONS"]
     },
     "test:coverage": {
       "description": "Run tests with coverage reporting to coverage/. The android/** and ios/** globs below are read off disk by cross-language source-scan guards no TS import can reach; without them a Kotlin/Swift-only diff replays a cached result and the guard never runs. turbo.json is an input so editing test's list cannot leave this hash stale. Do not narrow or drop these without updating test/lint/turboTestInputsCoverNativeSources.test.ts (issue #4351).",


### PR DESCRIPTION
## Summary

Two turbo-caching fixes for the local build pipeline:

1. **Cache `typecheck` as a turbo task.** The tsgo baseline gate
   (`scripts/typecheck-baseline.sh`) ran uncached on every `bun run typecheck`,
   even when `src/` was unchanged (common: test/docs/native-only edits). Adds a
   `typecheck` turbo task keyed on `src/**`, `tsconfig.json`, the baseline
   `.sh`+`.txt`, and `package.json`, plus a `turbo:typecheck` script. An
   unchanged `src/` is now a cache hit (`>>> FULL TURBO`, ~10ms). `bun run
   typecheck` stays as the uncached escape hatch. Migration-neutral: keyed on
   inputs, not the tsc/tsgo binary — a TS-version bump changes `package.json` +
   the regenerated baseline and busts the hash.

2. **`cache: false` on `check:host-shell-boundary`.** It compares the tree
   against `origin/main`, so its verdict depends on the *base position*, not just
   `src/**` content — caching it could replay a stale verdict. The other two
   turbo check tasks are full-tree scans and cache correctly (left as-is).

## Linked Issue

Closes #5124

## Changes

- `turbo.json` — new cached `typecheck` task; `check:host-shell-boundary`
  `cache: false`.
- `package.json` — `turbo:typecheck` script.
- `test/lint/turboCachingSafety.test.ts` — pins the `typecheck` input set (so a
  dropped input can't cause stale-cache staleness) and that
  `check:host-shell-boundary` is `cache: false`.

## Validation

- [x] Guard test 2/2
- [x] Cache behavior: rerun → hit; `test/` edit → hit; real `src/` change → miss;
  revert → hit
- [x] `turbo run lint build test typecheck` green; `bun run typecheck` no new errors
- [x] Only exit-0 is cached (turbo default), so a red gate is never memoized

## Out of scope

- Wiring CI to `turbo run typecheck` (CI still runs `bun run typecheck`; adopting
  the cached task in CI is a follow-up).
- tsgo `--incremental` buildinfo (coordinate with the TS7 tooling).
