### PR TITLE
build(video-server): pass --release to d8Dex to strip debug dex info from the pushed jar

### DIFF
--- a/android/video-server/build.gradle.kts
+++ b/android/video-server/build.gradle.kts
@@ -71,6 +71,11 @@ abstract class D8DexTask @Inject constructor(private val execOperations: ExecOpe
       commandLine(
         buildList {
           add(d8Path.get())
+          // Compile without debug dex info (line tables, local-variable data). d8 defaults to
+          // --debug; the server is launched via `app_process` from adb shell and is never attached
+          // to a jdwp debugger on-device, so the debug info has no consumer and only bloats the
+          // jar and its `adb push` payload.
+          add("--release")
           add("--output")
           add(outputJar.get().asFile.absolutePath)
           add("--min-api")


### PR DESCRIPTION
## Summary

`D8DexTask` built the `d8` command line with no `--debug`/`--release` flag, so it used
d8's default — **debug** mode — and the pushed `automobile-video.jar` carried debug dex
info (line tables, local-variable data). The video server is launched via `app_process`
from `adb shell` and is never attached to a jdwp debugger on-device, so that debug info has
no consumer; it only bloats the jar and its `adb push` payload. Adding `--release` drops it.

Measured locally on current `main` (build-tools 36.0.0 `d8`):

| | jar bytes |
|---|---|
| before (`--debug` default) | 807,517 |
| after (`--release`) | 700,700 |
| **delta** | **−106,817 (−13%)** |

No Kotlin source or runtime behavior changes.

## Linked Issue

Closes #5040

## Validation

- [x] `./gradlew :video-server:d8Dex` succeeds and produces a runnable
  `build/libs/automobile-video.jar` (verified before/after; jar present, ~13% smaller).
- [x] `./gradlew :video-server:test` — BUILD SUCCESSFUL (no behavior change).
- [x] ktfmt-clean (`scripts/ktfmt/apply_ktfmt.sh`).
- [x] Rebased onto latest `main`, diff scoped to the single build file.
- n/a `bun test` / `bun run typecheck` — this PR touches only `android/video-server/build.gradle.kts`;
  no TypeScript or Kotlin source is affected.

## Kotlin Reuse Check

- n/a — no Kotlin source changed; this is a single Gradle build-argument addition.

## Testing note

A Gradle command-line argument has no JVM unit-test seam in this repo, so the size/behavior
criteria are verified by running the `d8Dex` task and comparing jar bytes (above) rather than
by a red-green unit test.
