### PR TITLE
fix(android): calculate performance CPU usage from sample deltas

### DIFF
--- a/src/features/performance/PerformanceMonitor.ts
+++ b/src/features/performance/PerformanceMonitor.ts
@@ -78,6 +78,16 @@ interface RawJankCounters {
   jankyFrames: number | null;
 }
 
+interface PreviousCpuSample {
+  processTicks: number;
+  uptimeSeconds: number;
+}
+
+interface CpuMetricsResult {
+  cpuUsagePercent: number | null;
+  sample: PreviousCpuSample | null;
+}
+
 interface MonitoredDevice {
   deviceId: string;
   packageName: string;
@@ -103,6 +113,8 @@ interface MonitoredDevice {
   prevJankCounters: RawJankCounters | null;
   /** PID of the app process (cached for iOS since it requires a lookup) */
   cachedPid: number | null;
+  /** Previous Android process CPU sample for interval-delta calculation */
+  previousCpuSample: PreviousCpuSample | null;
   /** Previous per-metric health for detecting threshold crossings */
   previousMetricHealth: Record<string, string>;
 }
@@ -228,6 +240,7 @@ export class PerformanceMonitor {
         existing.lastMediumTick = 0;
         existing.lastSlowTick = 0;
         existing.prevJankCounters = null;
+        existing.previousCpuSample = null;
         // Bump the generation so any A→B→A in-flight sample is rejected even
         // though the package name matches again.
         existing.monitoringGeneration += 1;
@@ -256,6 +269,7 @@ export class PerformanceMonitor {
       cachedTouchLatency: null,
       prevJankCounters: null,
       cachedPid: null,
+      previousCpuSample: null,
       previousMetricHealth: {},
     });
     logger.info(`[PerformanceMonitor] Started monitoring ${packageName} on ${deviceId} (${platform})`);
@@ -394,7 +408,7 @@ export class PerformanceMonitor {
       now - device.lastMediumTick >= PerformanceMonitor.MEDIUM_INTERVAL_MS;
     const cpuPromise = shouldCollectCpu
       ? this.collectCpuMetrics(device)
-      : Promise.resolve(device.cachedCpu);
+      : Promise.resolve({ cpuUsagePercent: device.cachedCpu, sample: null });
 
     // Collect slow metrics (memory) if interval elapsed or first collection
     const shouldCollectMemory =
@@ -404,7 +418,8 @@ export class PerformanceMonitor {
       ? this.collectMemoryMetrics(device)
       : Promise.resolve(device.cachedMemory);
 
-    const [gfx, cpu, memory] = await Promise.all([gfxPromise, cpuPromise, memoryPromise]);
+    const [gfx, cpuResult, memory] = await Promise.all([gfxPromise, cpuPromise, memoryPromise]);
+    const cpu = cpuResult.cpuUsagePercent;
 
     // Drop the whole sample if monitoring changed apps or stopped mid-collection.
     if (!this.isSampleCurrent(device, samplingPackage, samplingGeneration)) {
@@ -415,6 +430,7 @@ export class PerformanceMonitor {
     if (shouldCollectCpu) {
       device.lastMediumTick = now;
       device.cachedCpu = cpu;
+      device.previousCpuSample = cpuResult.sample;
     }
     if (shouldCollectMemory) {
       device.lastSlowTick = now;
@@ -832,10 +848,10 @@ export class PerformanceMonitor {
   }
 
   /**
-   * Collect CPU usage from /proc/{pid}/stat.
-   * Returns percentage of CPU time used by the process.
+   * Collect CPU usage from /proc/{pid}/stat and /proc/uptime.
+   * Returns the interval percentage and the sample used as the next baseline.
    */
-  private async collectCpuMetrics(device: MonitoredDevice): Promise<number | null> {
+  private async collectCpuMetrics(device: MonitoredDevice): Promise<CpuMetricsResult> {
     try {
       const adb = this.adbClientFactory.create({
         deviceId: device.deviceId,
@@ -847,7 +863,7 @@ export class PerformanceMonitor {
       const { stdout: pidOut } = await adb.executeCommand(`shell pidof ${device.packageName}`);
       const pid = pidOut.trim().split(/\s+/)[0]; // Take first PID if multiple
       if (!pid) {
-        return null;
+        return { cpuUsagePercent: null, sample: null };
       }
 
       // Get CPU stats from /proc/stat
@@ -860,19 +876,30 @@ export class PerformanceMonitor {
       const { stdout: uptimeOut } = await adb.executeCommand("shell cat /proc/uptime");
       const uptime = parseFloat(uptimeOut.split(" ")[0] || "0");
 
-      // Calculate CPU percentage
-      // Note: This is a simplified calculation - actual CPU% would need delta sampling
-      if (uptime > 0) {
-        // Clock ticks per second is typically 100 (HZ)
-        const cpuTime = utime + stime;
-        const cpuPercent = (cpuTime / (uptime * 100)) * 100;
-        return Math.min(cpuPercent, 100); // Cap at 100%
+      const processTicks = utime + stime;
+      if (!Number.isFinite(processTicks) || !Number.isFinite(uptime) || uptime <= 0) {
+        return { cpuUsagePercent: null, sample: null };
       }
 
-      return null;
+      const sample = { processTicks, uptimeSeconds: uptime };
+      const previous = device.previousCpuSample;
+      if (!previous) {
+        return { cpuUsagePercent: null, sample };
+      }
+
+      const processTickDelta = processTicks - previous.processTicks;
+      const uptimeDelta = uptime - previous.uptimeSeconds;
+      if (processTickDelta < 0 || uptimeDelta <= 0) {
+        return { cpuUsagePercent: null, sample };
+      }
+
+      // Android reports process CPU time in clock ticks; 100 ticks represent one
+      // second on the supported devices. Calculate usage over the sampling interval.
+      const cpuPercent = (processTickDelta / (uptimeDelta * 100)) * 100;
+      return { cpuUsagePercent: Math.min(cpuPercent, 100), sample };
     } catch (error) {
       logger.debug(`[PerformanceMonitor] CPU metrics failed for ${device.deviceId}: ${error}`);
-      return null;
+      return { cpuUsagePercent: null, sample: null };
     }
   }
 

--- a/src/features/performance/PerformanceMonitor.ts
+++ b/src/features/performance/PerformanceMonitor.ts
@@ -430,7 +430,11 @@ export class PerformanceMonitor {
     if (shouldCollectCpu) {
       device.lastMediumTick = now;
       device.cachedCpu = cpu;
-      device.previousCpuSample = cpuResult.sample;
+      // Keep the last valid baseline across transient collection failures so the
+      // next successful sample can still measure the full interval.
+      if (cpuResult.sample) {
+        device.previousCpuSample = cpuResult.sample;
+      }
     }
     if (shouldCollectMemory) {
       device.lastSlowTick = now;

--- a/test/fakes/FakeAdbClient.ts
+++ b/test/fakes/FakeAdbClient.ts
@@ -173,10 +173,13 @@ export class FakeAdbClient implements FakeAdbClientContract {
    * Call N returns entry N; once exhausted the last entry repeats. Takes
    * precedence over {@link setCommandResult} for the same command.
    */
-  setCommandResultSequence(command: string, results: Array<{ stdout: string; stderr?: string }>): void {
+  setCommandResultSequence(command: string, results: Array<{ stdout: string; stderr?: string } | string>): void {
     this.commandResultSequences.set(
       command,
-      results.map(entry => ({ stdout: entry.stdout, stderr: entry.stderr ?? "" }))
+      results.map(entry => ({
+        stdout: typeof entry === "string" ? entry : entry.stdout,
+        stderr: typeof entry === "string" ? "" : entry.stderr ?? "",
+      }))
     );
     this.commandSequenceCursor.set(command, 0);
   }

--- a/test/features/performance/PerformanceMonitor.test.ts
+++ b/test/features/performance/PerformanceMonitor.test.ts
@@ -348,6 +348,32 @@ describe("PerformanceMonitor", () => {
       expect(fakePusher.getLastPushedData()!.metrics.cpuUsagePercent).toBe(50);
     });
 
+    it("should preserve the CPU baseline across a transient collection failure", async () => {
+      fakeAdbClient.setCommandResultSequence("shell cat /proc/12345/stat", [
+        "12345 (app) S 1 12345 12345 0 -1 4194560 1234 0 0 0 500 200 0 0 20 0 1 0 12345 123456789 12345 18446744073709551615 0 0 0 0 0 0 0 0 0 0 0 0 17 0 0 0 0 0",
+        "12345 (app) S 1 12345 12345 0 -1 4194560 1234 0 0 0 600 200 0 0 20 0 1 0 12345 123456789 12345 18446744073709551615 0 0 0 0 0 0 0 0 0 0 0 0 17 0 0 0 0 0",
+        "12345 (app) S 1 12345 12345 0 -1 4194560 1234 0 0 0 600 200 0 0 20 0 1 0 12345 123456789 12345 18446744073709551615 0 0 0 0 0 0 0 0 0 0 0 0 17 0 0 0 0 0 0 0",
+      ]);
+      fakeAdbClient.setCommandResultSequence("shell cat /proc/uptime", [
+        "1000.00 800.00\n",
+        "invalid uptime\n",
+        "1002.00 801.00\n",
+      ]);
+
+      monitor = new PerformanceMonitor(fakeTimer, fakeAdbFactory, serverGetter);
+      monitor.start();
+      monitor.startMonitoring("device-1", "com.example.app");
+
+      await advanceTimeAndWait(fakeTimer, PerformanceMonitor.TICK_INTERVAL_MS);
+      expect(fakePusher.getLastPushedData()!.metrics.cpuUsagePercent).toBeNull();
+
+      await advanceTimeAndWait(fakeTimer, PerformanceMonitor.MEDIUM_INTERVAL_MS);
+      expect(fakePusher.getLastPushedData()!.metrics.cpuUsagePercent).toBeNull();
+
+      await advanceTimeAndWait(fakeTimer, PerformanceMonitor.MEDIUM_INTERVAL_MS);
+      expect(fakePusher.getLastPushedData()!.metrics.cpuUsagePercent).toBe(50);
+    });
+
     it("should collect memory metrics only at slow intervals", async () => {
       monitor = new PerformanceMonitor(fakeTimer, fakeAdbFactory, serverGetter);
       monitor.start();

--- a/test/features/performance/PerformanceMonitor.test.ts
+++ b/test/features/performance/PerformanceMonitor.test.ts
@@ -327,6 +327,27 @@ describe("PerformanceMonitor", () => {
       expect(cpuCalls5).toBe(2);
     });
 
+    it("should calculate Android CPU from interval deltas", async () => {
+      fakeAdbClient.setCommandResultSequence("shell cat /proc/12345/stat", [
+        "12345 (app) S 1 12345 12345 0 -1 4194560 1234 0 0 0 500 200 0 0 20 0 1 0 12345 123456789 12345 18446744073709551615 0 0 0 0 0 0 0 0 0 0 0 0 17 0 0 0 0 0 0",
+        "12345 (app) S 1 12345 12345 0 -1 4194560 1234 0 0 0 600 200 0 0 20 0 1 0 12345 123456789 12345 18446744073709551615 0 0 0 0 0 0 0 0 0 0 0 0 17 0 0 0 0 0 0 0 0",
+      ]);
+      fakeAdbClient.setCommandResultSequence("shell cat /proc/uptime", [
+        "1000.00 800.00\n",
+        "1002.00 801.00\n",
+      ]);
+
+      monitor = new PerformanceMonitor(fakeTimer, fakeAdbFactory, serverGetter);
+      monitor.start();
+      monitor.startMonitoring("device-1", "com.example.app");
+
+      await advanceTimeAndWait(fakeTimer, PerformanceMonitor.TICK_INTERVAL_MS);
+      expect(fakePusher.getLastPushedData()!.metrics.cpuUsagePercent).toBeNull();
+
+      await advanceTimeAndWait(fakeTimer, PerformanceMonitor.MEDIUM_INTERVAL_MS);
+      expect(fakePusher.getLastPushedData()!.metrics.cpuUsagePercent).toBe(50);
+    });
+
     it("should collect memory metrics only at slow intervals", async () => {
       monitor = new PerformanceMonitor(fakeTimer, fakeAdbFactory, serverGetter);
       monitor.start();


### PR DESCRIPTION
## Summary
- calculate Android CPU usage from process and uptime deltas
- reset baselines when the monitored package changes
- cover first-sample and interval CPU behavior in tests

Closes #5107

Co-Authored-By: Codex <svc-devxp-Codex@slack-corp.com>