### PR TITLE
fix(android): calculate CPU usage over sampling intervals

### DIFF
--- a/src/features/performance/PerformanceMonitor.ts
+++ b/src/features/performance/PerformanceMonitor.ts
@@ -6,12 +6,18 @@ import {
   DEFAULT_THRESHOLDS,
   PerformancePushSocketServer,
 } from "../../daemon/performancePushSocketServer";
-import { getDeviceDataStreamServer, PerformanceStreamData } from "../../daemon/deviceDataStreamSocketServer";
+import {
+  getDeviceDataStreamServer,
+  PerformanceStreamData,
+} from "../../daemon/deviceDataStreamSocketServer";
 import { RecompositionTracker } from "./RecompositionTracker";
 import { getPerfWindowBuffer, PerfWindowBuffer } from "./PerfWindowBuffer";
 import { getSdkFrameMetricsStore, SdkFrameMetricsStore } from "./SdkFrameMetricsStore";
 import { TelemetryRecorder } from "../telemetry/TelemetryRecorder";
-import { defaultAdbClientFactory, AdbClientFactory } from "../../utils/android-cmdline-tools/AdbClientFactory";
+import {
+  defaultAdbClientFactory,
+  AdbClientFactory,
+} from "../../utils/android-cmdline-tools/AdbClientFactory";
 import { SimCtlClient, SimCtl } from "../../utils/ios-cmdline-tools/SimCtlClient";
 import { execFile } from "child_process";
 import { promisify } from "util";
@@ -28,7 +34,10 @@ export interface PerformanceTelemetryEmitter {
  * Type for the exec function used to run host commands.
  * Injected for testing.
  */
-export type ExecFileAsyncFn = (file: string, args: string[]) => Promise<{ stdout: string; stderr: string }>;
+export type ExecFileAsyncFn = (
+  file: string,
+  args: string[],
+) => Promise<{ stdout: string; stderr: string }>;
 
 /**
  * Factory interface for creating SimCtlClient instances.
@@ -78,6 +87,18 @@ interface RawJankCounters {
   jankyFrames: number | null;
 }
 
+interface CpuSample {
+  pid: string;
+  processTicks: number;
+  uptimeSeconds: number;
+}
+
+interface CpuCollectionResult {
+  cpuUsagePercent: number | null;
+  sample: CpuSample | null;
+  reset: boolean;
+}
+
 interface MonitoredDevice {
   deviceId: string;
   packageName: string;
@@ -92,6 +113,8 @@ interface MonitoredDevice {
   lastMediumTick: number;
   lastSlowTick: number;
   cachedCpu: number | null;
+  /** Previous Android CPU sample for interval-based usage calculation */
+  previousCpuSample: CpuSample | null;
   cachedMemory: number | null;
   /** Cached FPS from last interval with actual frames */
   cachedFps: number | null;
@@ -132,6 +155,7 @@ export class PerformanceMonitor {
   static readonly TICK_INTERVAL_MS = 500;
   static readonly MEDIUM_INTERVAL_MS = 2000;
   static readonly SLOW_INTERVAL_MS = 10000;
+  private static readonly CPU_CLOCK_TICKS_PER_SECOND = 100;
   /**
    * How recent an in-app SDK frame sample must be to be preferred over the
    * dumpsys scrape. The SDK broadcasts ~1/s, so a couple ticks of grace covers
@@ -211,7 +235,11 @@ export class PerformanceMonitor {
    * @param packageName - The package/bundle identifier to monitor
    * @param platform - The platform ("android" or "ios"), defaults to "android"
    */
-  startMonitoring(deviceId: string, packageName: string, platform: "android" | "ios" = "android"): void {
+  startMonitoring(
+    deviceId: string,
+    packageName: string,
+    platform: "android" | "ios" = "android",
+  ): void {
     if (this.monitoredDevices.has(deviceId)) {
       // Update package name if already monitoring this device
       const existing = this.monitoredDevices.get(deviceId)!;
@@ -220,6 +248,7 @@ export class PerformanceMonitor {
         existing.platform = platform;
         // Reset cached metrics for the new package
         existing.cachedCpu = null;
+        existing.previousCpuSample = null;
         existing.cachedMemory = null;
         existing.cachedFps = null;
         existing.cachedFrameTime = null;
@@ -236,7 +265,9 @@ export class PerformanceMonitor {
         // deviceId, so a package switch must reset it).
         this.perfWindowBuffer.clear(deviceId);
         this.frameMetricsStore.clear(deviceId);
-        logger.info(`[PerformanceMonitor] Updated monitoring to ${packageName} on ${deviceId} (${platform})`);
+        logger.info(
+          `[PerformanceMonitor] Updated monitoring to ${packageName} on ${deviceId} (${platform})`,
+        );
       }
       return;
     }
@@ -250,6 +281,7 @@ export class PerformanceMonitor {
       lastMediumTick: 0,
       lastSlowTick: 0,
       cachedCpu: null,
+      previousCpuSample: null,
       cachedMemory: null,
       cachedFps: null,
       cachedFrameTime: null,
@@ -258,7 +290,9 @@ export class PerformanceMonitor {
       cachedPid: null,
       previousMetricHealth: {},
     });
-    logger.info(`[PerformanceMonitor] Started monitoring ${packageName} on ${deviceId} (${platform})`);
+    logger.info(
+      `[PerformanceMonitor] Started monitoring ${packageName} on ${deviceId} (${platform})`,
+    );
   }
 
   /**
@@ -288,10 +322,16 @@ export class PerformanceMonitor {
    * package switch or `stopMonitoring()`, and such a stale sample must not touch
    * the current device's caches, stream, or buffer.
    */
-  private isSampleCurrent(device: MonitoredDevice, samplingPackage: string, samplingGeneration: number): boolean {
-    return this.monitoredDevices.get(device.deviceId) === device &&
+  private isSampleCurrent(
+    device: MonitoredDevice,
+    samplingPackage: string,
+    samplingGeneration: number,
+  ): boolean {
+    return (
+      this.monitoredDevices.get(device.deviceId) === device &&
       device.packageName === samplingPackage &&
-      device.monitoringGeneration === samplingGeneration;
+      device.monitoringGeneration === samplingGeneration
+    );
   }
 
   /**
@@ -345,7 +385,7 @@ export class PerformanceMonitor {
   private async sampleDevice(
     device: MonitoredDevice,
     now: number,
-    server: PerformancePushSocketServer
+    server: PerformancePushSocketServer,
   ): Promise<void> {
     try {
       if (device.platform === "ios") {
@@ -364,7 +404,7 @@ export class PerformanceMonitor {
   private async sampleAndroidDevice(
     device: MonitoredDevice,
     now: number,
-    server: PerformancePushSocketServer
+    server: PerformancePushSocketServer,
   ): Promise<void> {
     // Identity captured before any await: if the monitored package switches (or
     // monitoring stops) while these adb calls are in flight, this whole sample
@@ -381,7 +421,7 @@ export class PerformanceMonitor {
       device.deviceId,
       samplingPackage,
       now,
-      PerformanceMonitor.SDK_FRAME_TTL_MS
+      PerformanceMonitor.SDK_FRAME_TTL_MS,
     );
 
     const gfxPromise = sdkFrame ? Promise.resolve(null) : this.collectGfxMetrics(device);
@@ -394,17 +434,20 @@ export class PerformanceMonitor {
       now - device.lastMediumTick >= PerformanceMonitor.MEDIUM_INTERVAL_MS;
     const cpuPromise = shouldCollectCpu
       ? this.collectCpuMetrics(device)
-      : Promise.resolve(device.cachedCpu);
+      : Promise.resolve({
+          cpuUsagePercent: device.cachedCpu,
+          sample: null,
+          reset: false,
+        });
 
     // Collect slow metrics (memory) if interval elapsed or first collection
     const shouldCollectMemory =
-      device.lastSlowTick === 0 ||
-      now - device.lastSlowTick >= PerformanceMonitor.SLOW_INTERVAL_MS;
+      device.lastSlowTick === 0 || now - device.lastSlowTick >= PerformanceMonitor.SLOW_INTERVAL_MS;
     const memoryPromise = shouldCollectMemory
       ? this.collectMemoryMetrics(device)
       : Promise.resolve(device.cachedMemory);
 
-    const [gfx, cpu, memory] = await Promise.all([gfxPromise, cpuPromise, memoryPromise]);
+    const [gfx, cpuResult, memory] = await Promise.all([gfxPromise, cpuPromise, memoryPromise]);
 
     // Drop the whole sample if monitoring changed apps or stopped mid-collection.
     if (!this.isSampleCurrent(device, samplingPackage, samplingGeneration)) {
@@ -414,7 +457,12 @@ export class PerformanceMonitor {
     device.lastFastTick = now;
     if (shouldCollectCpu) {
       device.lastMediumTick = now;
-      device.cachedCpu = cpu;
+      device.cachedCpu = cpuResult.cpuUsagePercent;
+      if (cpuResult.reset) {
+        device.previousCpuSample = null;
+      } else if (cpuResult.sample) {
+        device.previousCpuSample = cpuResult.sample;
+      }
     }
     if (shouldCollectMemory) {
       device.lastSlowTick = now;
@@ -469,7 +517,7 @@ export class PerformanceMonitor {
       jankFrames = null;
       if (gfxData.rawJankCounters) {
         const curr = gfxData.rawJankCounters;
-        jankFrames = curr.jankyFrames ?? (curr.missedVsync + curr.slowUi + curr.deadlineMissed);
+        jankFrames = curr.jankyFrames ?? curr.missedVsync + curr.slowUi + curr.deadlineMissed;
       }
 
       const touch = this.estimateTouchLatency(gfxData, frameTimeMs, device);
@@ -489,7 +537,7 @@ export class PerformanceMonitor {
       touchLatencyMs,
       ttffMs: null,
       ttiMs,
-      cpuUsagePercent: cpu,
+      cpuUsagePercent: cpuResult.cpuUsagePercent,
       memoryUsageMb: memory,
     };
 
@@ -503,7 +551,7 @@ export class PerformanceMonitor {
       touchLatencyMs: rawTouchLatencyMs,
       // CPU/memory only when actually collected this tick (null otherwise), so
       // the window never averages a reading acquired outside it.
-      cpuUsagePercent: shouldCollectCpu ? cpu : null,
+      cpuUsagePercent: shouldCollectCpu ? cpuResult.cpuUsagePercent : null,
       memoryUsageMb: shouldCollectMemory ? memory : null,
     });
   }
@@ -518,7 +566,7 @@ export class PerformanceMonitor {
   private estimateTouchLatency(
     gfx: { totalFrames: number | null; highInputLatencyFrames: number | null },
     frameTimeMs: number | null,
-    device: MonitoredDevice
+    device: MonitoredDevice,
   ): { streamMs: number; rawMs: number | null } {
     if (gfx.totalFrames === null || gfx.totalFrames <= 0 || frameTimeMs === null) {
       // No frames this interval - assume optimal latency (idle app is responsive).
@@ -540,7 +588,7 @@ export class PerformanceMonitor {
   private async sampleIOSDevice(
     device: MonitoredDevice,
     now: number,
-    server: PerformancePushSocketServer
+    server: PerformancePushSocketServer,
   ): Promise<void> {
     // Identity captured before any await (see sampleAndroidDevice).
     const samplingPackage = device.packageName;
@@ -557,8 +605,7 @@ export class PerformanceMonitor {
 
     // Collect slow metrics (memory) if interval elapsed or first collection
     const shouldCollectMemory =
-      device.lastSlowTick === 0 ||
-      now - device.lastSlowTick >= PerformanceMonitor.SLOW_INTERVAL_MS;
+      device.lastSlowTick === 0 || now - device.lastSlowTick >= PerformanceMonitor.SLOW_INTERVAL_MS;
     const memoryPromise = shouldCollectMemory
       ? this.collectIOSMemoryMetrics(device)
       : Promise.resolve(device.cachedMemory);
@@ -638,7 +685,7 @@ export class PerformanceMonitor {
       touchLatencyMs: number | null;
       cpuUsagePercent: number | null;
       memoryUsageMb: number | null;
-    }
+    },
   ): void {
     const data: LivePerformanceData = {
       deviceId: device.deviceId,
@@ -678,7 +725,10 @@ export class PerformanceMonitor {
 
     const observationServer = getDeviceDataStreamServer();
     if (observationServer) {
-      const recompositionSummary = RecompositionTracker.getInstance().getLatestSummary(device.deviceId, device.packageName);
+      const recompositionSummary = RecompositionTracker.getInstance().getLatestSummary(
+        device.deviceId,
+        device.packageName,
+      );
       const streamData: PerformanceStreamData = {
         fps: metrics.fps ?? 0,
         frameTimeMs: metrics.frameTimeMs ?? 0,
@@ -712,7 +762,7 @@ export class PerformanceMonitor {
       memoryUsageMb: number | null;
       cpuUsagePercent: number | null;
     },
-    overallHealth: string
+    overallHealth: string,
   ): void {
     const th = DEFAULT_THRESHOLDS;
     const currentHealth: Record<string, string> = {};
@@ -720,16 +770,36 @@ export class PerformanceMonitor {
 
     // Classify each metric
     if (metrics.fps !== null) {
-      currentHealth.fps = metrics.fps < th.fpsCritical ? "critical" : metrics.fps < th.fpsWarning ? "warning" : "healthy";
+      currentHealth.fps =
+        metrics.fps < th.fpsCritical
+          ? "critical"
+          : metrics.fps < th.fpsWarning
+            ? "warning"
+            : "healthy";
     }
     if (metrics.frameTimeMs !== null) {
-      currentHealth.frameTime = metrics.frameTimeMs > th.frameTimeCritical ? "critical" : metrics.frameTimeMs > th.frameTimeWarning ? "warning" : "healthy";
+      currentHealth.frameTime =
+        metrics.frameTimeMs > th.frameTimeCritical
+          ? "critical"
+          : metrics.frameTimeMs > th.frameTimeWarning
+            ? "warning"
+            : "healthy";
     }
     if (metrics.jankFrames !== null) {
-      currentHealth.jank = metrics.jankFrames > th.jankCritical ? "critical" : metrics.jankFrames > th.jankWarning ? "warning" : "healthy";
+      currentHealth.jank =
+        metrics.jankFrames > th.jankCritical
+          ? "critical"
+          : metrics.jankFrames > th.jankWarning
+            ? "warning"
+            : "healthy";
     }
     if (metrics.touchLatencyMs !== null) {
-      currentHealth.touchLatency = metrics.touchLatencyMs > th.touchLatencyCritical ? "critical" : metrics.touchLatencyMs > th.touchLatencyWarning ? "warning" : "healthy";
+      currentHealth.touchLatency =
+        metrics.touchLatencyMs > th.touchLatencyCritical
+          ? "critical"
+          : metrics.touchLatencyMs > th.touchLatencyWarning
+            ? "warning"
+            : "healthy";
     }
     if (metrics.memoryUsageMb !== null) {
       // Classify memory into bands — emit telemetry when band changes.
@@ -779,7 +849,9 @@ export class PerformanceMonitor {
    * Resets gfxinfo after reading to get fresh data for the next interval.
    * Jank delta calculation happens in sampleDevice.
    */
-  private async collectGfxMetrics(device: MonitoredDevice): Promise<GfxMetrics & { rawJankCounters: RawJankCounters | null }> {
+  private async collectGfxMetrics(
+    device: MonitoredDevice,
+  ): Promise<GfxMetrics & { rawJankCounters: RawJankCounters | null }> {
     try {
       const adb = this.adbClientFactory.create({
         deviceId: device.deviceId,
@@ -789,7 +861,9 @@ export class PerformanceMonitor {
 
       // Read and reset gfxinfo in one command to get fresh interval data
       // The 'reset' flag clears stats after reading, so next read reflects only new frames
-      const { stdout } = await adb.executeCommand(`shell dumpsys gfxinfo ${device.packageName} reset`);
+      const { stdout } = await adb.executeCommand(
+        `shell dumpsys gfxinfo ${device.packageName} reset`,
+      );
 
       // Check if any frames were actually rendered in this interval
       const totalFramesMatch = stdout.match(/Total frames rendered:\s+(\d+)/);
@@ -805,14 +879,19 @@ export class PerformanceMonitor {
       // Parse jank counters (now reflects only jank since last reset)
       const missedVsync = parseInt(stdout.match(/Missed Vsync:\s+(\d+)/)?.[1] || "0", 10);
       const slowUi = parseInt(stdout.match(/Slow UI thread:\s+(\d+)/)?.[1] || "0", 10);
-      const deadlineMissed = parseInt(stdout.match(/Frame deadline missed:\s+(\d+)/)?.[1] || "0", 10);
+      const deadlineMissed = parseInt(
+        stdout.match(/Frame deadline missed:\s+(\d+)/)?.[1] || "0",
+        10,
+      );
       // Aggregate janky-frame count (deduplicated across causes) when present.
       const jankyMatch = stdout.match(/Janky frames:\s+(\d+)/);
       const jankyFrames = jankyMatch ? parseInt(jankyMatch[1], 10) : null;
 
       // Parse high input latency frame count
       const highInputLatencyMatch = stdout.match(/Number High input latency:\s+(\d+)/);
-      const highInputLatencyFrames = highInputLatencyMatch ? parseInt(highInputLatencyMatch[1], 10) : null;
+      const highInputLatencyFrames = highInputLatencyMatch
+        ? parseInt(highInputLatencyMatch[1], 10)
+        : null;
 
       // Calculate FPS from frame time
       const fps = frameTimeMs && frameTimeMs > 0 ? Math.min(1000 / frameTimeMs, 60) : null;
@@ -827,15 +906,22 @@ export class PerformanceMonitor {
       };
     } catch (error) {
       logger.debug(`[PerformanceMonitor] gfxinfo failed for ${device.deviceId}: ${error}`);
-      return { fps: null, frameTimeMs: null, jankFrames: null, highInputLatencyFrames: null, totalFrames: null, rawJankCounters: null };
+      return {
+        fps: null,
+        frameTimeMs: null,
+        jankFrames: null,
+        highInputLatencyFrames: null,
+        totalFrames: null,
+        rawJankCounters: null,
+      };
     }
   }
 
   /**
    * Collect CPU usage from /proc/{pid}/stat.
-   * Returns percentage of CPU time used by the process.
+   * Returns interval-based percentage of CPU time used by the process.
    */
-  private async collectCpuMetrics(device: MonitoredDevice): Promise<number | null> {
+  private async collectCpuMetrics(device: MonitoredDevice): Promise<CpuCollectionResult> {
     try {
       const adb = this.adbClientFactory.create({
         deviceId: device.deviceId,
@@ -847,7 +933,7 @@ export class PerformanceMonitor {
       const { stdout: pidOut } = await adb.executeCommand(`shell pidof ${device.packageName}`);
       const pid = pidOut.trim().split(/\s+/)[0]; // Take first PID if multiple
       if (!pid) {
-        return null;
+        return { cpuUsagePercent: null, sample: null, reset: true };
       }
 
       // Get CPU stats from /proc/stat
@@ -858,21 +944,30 @@ export class PerformanceMonitor {
 
       // Get system uptime
       const { stdout: uptimeOut } = await adb.executeCommand("shell cat /proc/uptime");
-      const uptime = parseFloat(uptimeOut.split(" ")[0] || "0");
+      const uptimeSeconds = parseFloat(uptimeOut.split(" ")[0] || "0");
+      const processTicks = utime + stime;
+      const sample = { pid, processTicks, uptimeSeconds };
+      const previous = device.previousCpuSample;
 
-      // Calculate CPU percentage
-      // Note: This is a simplified calculation - actual CPU% would need delta sampling
-      if (uptime > 0) {
-        // Clock ticks per second is typically 100 (HZ)
-        const cpuTime = utime + stime;
-        const cpuPercent = (cpuTime / (uptime * 100)) * 100;
-        return Math.min(cpuPercent, 100); // Cap at 100%
+      if (
+        previous &&
+        previous.pid === pid &&
+        uptimeSeconds > previous.uptimeSeconds &&
+        processTicks >= previous.processTicks
+      ) {
+        const elapsedTicks =
+          (uptimeSeconds - previous.uptimeSeconds) * PerformanceMonitor.CPU_CLOCK_TICKS_PER_SECOND;
+        const processDelta = processTicks - previous.processTicks;
+        if (elapsedTicks > 0) {
+          const cpuPercent = (processDelta / elapsedTicks) * 100;
+          return { cpuUsagePercent: Math.min(cpuPercent, 100), sample, reset: false };
+        }
       }
 
-      return null;
+      return { cpuUsagePercent: null, sample, reset: false };
     } catch (error) {
       logger.debug(`[PerformanceMonitor] CPU metrics failed for ${device.deviceId}: ${error}`);
-      return null;
+      return { cpuUsagePercent: null, sample: null, reset: true };
     }
   }
 
@@ -889,7 +984,7 @@ export class PerformanceMonitor {
       });
 
       const { stdout } = await adb.executeCommand(
-        `shell dumpsys meminfo ${device.packageName} | grep "TOTAL PSS"`
+        `shell dumpsys meminfo ${device.packageName} | grep "TOTAL PSS"`,
       );
 
       // Format: "TOTAL PSS:    12345"
@@ -974,7 +1069,9 @@ export class PerformanceMonitor {
 
       return null;
     } catch (error) {
-      logger.debug(`[PerformanceMonitor] iOS memory metrics failed for ${device.deviceId}: ${error}`);
+      logger.debug(
+        `[PerformanceMonitor] iOS memory metrics failed for ${device.deviceId}: ${error}`,
+      );
       return null;
     }
   }

--- a/test/features/performance/PerformanceMonitor.test.ts
+++ b/test/features/performance/PerformanceMonitor.test.ts
@@ -33,7 +33,7 @@ async function advanceTimeAndWait(timer: FakeTimer, ms: number): Promise<void> {
     const chunk = Math.min(step, remaining) || remaining;
     timer.advanceTime(chunk);
     for (let i = 0; i < 4; i += 1) {
-      await new Promise(resolve => setImmediate(resolve));
+      await new Promise((resolve) => setImmediate(resolve));
     }
     remaining -= chunk;
   } while (remaining > 0);
@@ -106,7 +106,7 @@ describe("PerformanceMonitor", () => {
         Missed Vsync: 2
         Slow UI thread: 1
         Frame deadline missed: 3
-      `
+      `,
     );
 
     // pidof response
@@ -115,7 +115,7 @@ describe("PerformanceMonitor", () => {
     // /proc/stat response
     adb.setCommandResult(
       "shell cat /proc/12345/stat",
-      "12345 (app) S 1 12345 12345 0 -1 4194560 1234 0 0 0 500 200 0 0 20 0 1 0 12345 123456789 12345 18446744073709551615 0 0 0 0 0 0 0 0 0 0 0 0 17 0 0 0 0 0 0"
+      "12345 (app) S 1 12345 12345 0 -1 4194560 1234 0 0 0 500 200 0 0 20 0 1 0 12345 123456789 12345 18446744073709551615 0 0 0 0 0 0 0 0 0 0 0 0 17 0 0 0 0 0 0",
     );
 
     // uptime response
@@ -123,8 +123,8 @@ describe("PerformanceMonitor", () => {
 
     // meminfo response
     adb.setCommandResult(
-      "shell dumpsys meminfo com.example.app | grep \"TOTAL PSS\"",
-      "        TOTAL PSS:   102400\n"
+      'shell dumpsys meminfo com.example.app | grep "TOTAL PSS"',
+      "        TOTAL PSS:   102400\n",
     );
   }
 
@@ -269,7 +269,7 @@ describe("PerformanceMonitor", () => {
       // guard must drop the second while the first is still in flight.
       fakeTimer.advanceTime(PerformanceMonitor.TICK_INTERVAL_MS * 2);
       for (let i = 0; i < 4; i += 1) {
-        await new Promise(resolve => setImmediate(resolve));
+        await new Promise((resolve) => setImmediate(resolve));
       }
 
       // Exactly one tick ran to completion — not two. (Negative control: the
@@ -402,7 +402,7 @@ describe("PerformanceMonitor", () => {
           Missed Vsync: 3
           Slow UI thread: 1
           Frame deadline missed: 1
-        `
+        `,
       );
 
       // Second tick - should report sum for this interval: 3 + 1 + 1 = 5
@@ -424,7 +424,10 @@ describe("PerformanceMonitor", () => {
     });
 
     it("should handle missing gfxinfo data gracefully", async () => {
-      fakeAdbClient.setCommandResult("shell dumpsys gfxinfo com.example.app reset", "No data available");
+      fakeAdbClient.setCommandResult(
+        "shell dumpsys gfxinfo com.example.app reset",
+        "No data available",
+      );
 
       monitor = new PerformanceMonitor(fakeTimer, fakeAdbFactory, serverGetter);
       monitor.start();
@@ -448,7 +451,7 @@ describe("PerformanceMonitor", () => {
           Missed Vsync: 0
           Slow UI thread: 0
           Frame deadline missed: 0
-        `
+        `,
       );
 
       monitor = new PerformanceMonitor(fakeTimer, fakeAdbFactory, serverGetter);
@@ -476,10 +479,65 @@ describe("PerformanceMonitor", () => {
       expect(data!.metrics.cpuUsagePercent).toBeNull();
     });
 
+    it("should report interval-based Android CPU usage after the baseline sample", async () => {
+      fakeAdbClient.setCommandResultSequence("shell cat /proc/12345/stat", [
+        {
+          stdout:
+            "12345 (app) S 1 12345 12345 0 -1 4194560 1234 0 0 0 500 200 0 0 20 0 1 0 12345 123456789 12345 18446744073709551615 0 0 0 0 0 0 0 0 0 0 0 17 0 0 0 0 0 0",
+        },
+        {
+          stdout:
+            "12345 (app) S 1 12345 12345 0 -1 4194560 1234 0 0 0 525 200 0 0 20 0 1 0 12345 123456789 12345 18446744073709551615 0 0 0 0 0 0 0 0 0 0 0 17 0 0 0 0 0 0",
+        },
+      ]);
+      fakeAdbClient.setCommandResultSequence("shell cat /proc/uptime", [
+        { stdout: "1000.00 800.00\n" },
+        { stdout: "1002.00 802.00\n" },
+      ]);
+
+      monitor = new PerformanceMonitor(fakeTimer, fakeAdbFactory, serverGetter);
+      monitor.start();
+      monitor.startMonitoring("device-1", "com.example.app");
+
+      await advanceTimeAndWait(fakeTimer, PerformanceMonitor.TICK_INTERVAL_MS);
+      expect(fakePusher.getLastPushedData()!.metrics.cpuUsagePercent).toBeNull();
+
+      await advanceTimeAndWait(fakeTimer, PerformanceMonitor.MEDIUM_INTERVAL_MS);
+      expect(fakePusher.getLastPushedData()!.metrics.cpuUsagePercent).toBe(12.5);
+    });
+
+    it("should reset the CPU baseline when the monitored package changes", async () => {
+      fakeAdbClient.setCommandResult("shell pidof com.other.app", "12345\n");
+      fakeAdbClient.setCommandResultSequence("shell cat /proc/12345/stat", [
+        {
+          stdout:
+            "12345 (app) S 1 12345 12345 0 -1 4194560 1234 0 0 0 500 200 0 0 20 0 1 0 12345 123456789 12345 18446744073709551615 0 0 0 0 0 0 0 0 0 0 0 17 0 0 0 0 0 0",
+        },
+        {
+          stdout:
+            "12345 (app) S 1 12345 12345 0 -1 4194560 1234 0 0 0 900 200 0 0 20 0 1 0 12345 123456789 12345 18446744073709551615 0 0 0 0 0 0 0 0 0 0 0 17 0 0 0 0 0 0 0",
+        },
+      ]);
+      fakeAdbClient.setCommandResultSequence("shell cat /proc/uptime", [
+        { stdout: "1000.00 800.00\n" },
+        { stdout: "1002.00 802.00\n" },
+      ]);
+
+      monitor = new PerformanceMonitor(fakeTimer, fakeAdbFactory, serverGetter);
+      monitor.start();
+      monitor.startMonitoring("device-1", "com.example.app");
+      await advanceTimeAndWait(fakeTimer, PerformanceMonitor.TICK_INTERVAL_MS);
+
+      monitor.startMonitoring("device-1", "com.other.app");
+      await advanceTimeAndWait(fakeTimer, PerformanceMonitor.MEDIUM_INTERVAL_MS);
+
+      expect(fakePusher.getLastPushedData()!.metrics.cpuUsagePercent).toBeNull();
+    });
+
     it("should handle ADB errors gracefully", async () => {
       fakeAdbClient.setCommandError(
         "shell dumpsys gfxinfo com.example.app reset",
-        new Error("ADB connection failed")
+        new Error("ADB connection failed"),
       );
 
       monitor = new PerformanceMonitor(fakeTimer, fakeAdbFactory, serverGetter);
@@ -525,18 +583,30 @@ describe("PerformanceMonitor", () => {
     it("should push data for each monitored device", async () => {
       fakeAdbClient.setCommandResult(
         "shell dumpsys gfxinfo com.app1 reset",
-        "Total frames rendered: 10\n50th percentile: 10ms"
+        "Total frames rendered: 10\n50th percentile: 10ms",
       );
       fakeAdbClient.setCommandResult(
         "shell dumpsys gfxinfo com.app2 reset",
-        "Total frames rendered: 10\n50th percentile: 12ms"
+        "Total frames rendered: 10\n50th percentile: 12ms",
       );
       fakeAdbClient.setCommandResult("shell pidof com.app1", "111");
       fakeAdbClient.setCommandResult("shell pidof com.app2", "222");
-      fakeAdbClient.setCommandResult("shell cat /proc/111/stat", "111 (app) S 0 0 0 0 0 0 0 0 0 0 100 50 0 0 20 0 1 0 0 0 0 0");
-      fakeAdbClient.setCommandResult("shell cat /proc/222/stat", "222 (app) S 0 0 0 0 0 0 0 0 0 0 200 100 0 0 20 0 1 0 0 0 0 0");
-      fakeAdbClient.setCommandResult("shell dumpsys meminfo com.app1 | grep \"TOTAL PSS\"", "TOTAL PSS: 50000");
-      fakeAdbClient.setCommandResult("shell dumpsys meminfo com.app2 | grep \"TOTAL PSS\"", "TOTAL PSS: 60000");
+      fakeAdbClient.setCommandResult(
+        "shell cat /proc/111/stat",
+        "111 (app) S 0 0 0 0 0 0 0 0 0 0 100 50 0 0 20 0 1 0 0 0 0 0",
+      );
+      fakeAdbClient.setCommandResult(
+        "shell cat /proc/222/stat",
+        "222 (app) S 0 0 0 0 0 0 0 0 0 0 200 100 0 0 20 0 1 0 0 0 0 0",
+      );
+      fakeAdbClient.setCommandResult(
+        'shell dumpsys meminfo com.app1 | grep "TOTAL PSS"',
+        "TOTAL PSS: 50000",
+      );
+      fakeAdbClient.setCommandResult(
+        'shell dumpsys meminfo com.app2 | grep "TOTAL PSS"',
+        "TOTAL PSS: 60000",
+      );
 
       monitor = new PerformanceMonitor(fakeTimer, fakeAdbFactory, serverGetter);
       monitor.start();
@@ -548,8 +618,8 @@ describe("PerformanceMonitor", () => {
       expect(fakePusher.getPushCount()).toBe(2);
 
       const allData = fakePusher.getPushedData();
-      const device1Data = allData.find(d => d.deviceId === "device-1");
-      const device2Data = allData.find(d => d.deviceId === "device-2");
+      const device1Data = allData.find((d) => d.deviceId === "device-1");
+      const device2Data = allData.find((d) => d.deviceId === "device-2");
 
       expect(device1Data).toBeDefined();
       expect(device2Data).toBeDefined();
@@ -568,7 +638,7 @@ describe("PerformanceMonitor", () => {
         undefined,
         undefined,
         undefined,
-        buffer
+        buffer,
       );
       monitor.start();
       monitor.startMonitoring("device-1", "com.example.app");
@@ -595,7 +665,7 @@ describe("PerformanceMonitor", () => {
           Missed Vsync: 2
           Slow UI thread: 1
           Frame deadline missed: 3
-        `
+        `,
       );
       monitor = new PerformanceMonitor(fakeTimer, fakeAdbFactory, serverGetter);
       monitor.start();
@@ -617,11 +687,21 @@ describe("PerformanceMonitor", () => {
 
     it("clears the buffer when the monitored package changes", async () => {
       const buffer = new PerfWindowBuffer();
-      monitor = new PerformanceMonitor(fakeTimer, fakeAdbFactory, serverGetter, undefined, undefined, undefined, buffer);
+      monitor = new PerformanceMonitor(
+        fakeTimer,
+        fakeAdbFactory,
+        serverGetter,
+        undefined,
+        undefined,
+        undefined,
+        buffer,
+      );
       monitor.start();
       monitor.startMonitoring("device-1", "com.example.app");
       await advanceTimeAndWait(fakeTimer, PerformanceMonitor.TICK_INTERVAL_MS);
-      expect(buffer.snapshot("device-1", fakeTimer.now(), 60000).sampleCount).toBeGreaterThanOrEqual(1);
+      expect(
+        buffer.snapshot("device-1", fakeTimer.now(), 60000).sampleCount,
+      ).toBeGreaterThanOrEqual(1);
 
       // Switching the monitored package must drop app A's samples so the next
       // snapshot cannot attribute them to app B.
@@ -631,11 +711,21 @@ describe("PerformanceMonitor", () => {
 
     it("clears the buffer when monitoring stops", async () => {
       const buffer = new PerfWindowBuffer();
-      monitor = new PerformanceMonitor(fakeTimer, fakeAdbFactory, serverGetter, undefined, undefined, undefined, buffer);
+      monitor = new PerformanceMonitor(
+        fakeTimer,
+        fakeAdbFactory,
+        serverGetter,
+        undefined,
+        undefined,
+        undefined,
+        buffer,
+      );
       monitor.start();
       monitor.startMonitoring("device-1", "com.example.app");
       await advanceTimeAndWait(fakeTimer, PerformanceMonitor.TICK_INTERVAL_MS);
-      expect(buffer.snapshot("device-1", fakeTimer.now(), 60000).sampleCount).toBeGreaterThanOrEqual(1);
+      expect(
+        buffer.snapshot("device-1", fakeTimer.now(), 60000).sampleCount,
+      ).toBeGreaterThanOrEqual(1);
 
       monitor.stopMonitoring("device-1");
       expect(buffer.snapshot("device-1", fakeTimer.now(), 60000).sampleCount).toBe(0);
@@ -647,9 +737,21 @@ describe("PerformanceMonitor", () => {
       // Fresh SDK sample (receivedAt 0; first tick fires at now=500, within TTL).
       // Distinctive fps=42 vs the dumpsys default (60) proves the source used.
       sdkStore.ingest("device-1", "com.example.app", {
-        fps: 42, frameTimeMs: 23.8, jankFrames: 3, receivedAt: 0,
+        fps: 42,
+        frameTimeMs: 23.8,
+        jankFrames: 3,
+        receivedAt: 0,
       });
-      monitor = new PerformanceMonitor(fakeTimer, fakeAdbFactory, serverGetter, undefined, undefined, undefined, buffer, sdkStore);
+      monitor = new PerformanceMonitor(
+        fakeTimer,
+        fakeAdbFactory,
+        serverGetter,
+        undefined,
+        undefined,
+        undefined,
+        buffer,
+        sdkStore,
+      );
       monitor.start();
       monitor.startMonitoring("device-1", "com.example.app");
 
@@ -666,9 +768,21 @@ describe("PerformanceMonitor", () => {
       const sdkStore = new SdkFrameMetricsStore();
       // receivedAt far in the past: at the first tick (now=500) this is > TTL old.
       sdkStore.ingest("device-1", "com.example.app", {
-        fps: 42, frameTimeMs: 23.8, jankFrames: 3, receivedAt: -3000,
+        fps: 42,
+        frameTimeMs: 23.8,
+        jankFrames: 3,
+        receivedAt: -3000,
       });
-      monitor = new PerformanceMonitor(fakeTimer, fakeAdbFactory, serverGetter, undefined, undefined, undefined, buffer, sdkStore);
+      monitor = new PerformanceMonitor(
+        fakeTimer,
+        fakeAdbFactory,
+        serverGetter,
+        undefined,
+        undefined,
+        undefined,
+        buffer,
+        sdkStore,
+      );
       monitor.start();
       monitor.startMonitoring("device-1", "com.example.app");
 
@@ -699,7 +813,15 @@ describe("PerformanceMonitor", () => {
         { stdout: "Total frames rendered: 0\n" },
         { stdout: "Total frames rendered: 0\n" },
       ]);
-      monitor = new PerformanceMonitor(fakeTimer, fakeAdbFactory, serverGetter, undefined, undefined, undefined, buffer);
+      monitor = new PerformanceMonitor(
+        fakeTimer,
+        fakeAdbFactory,
+        serverGetter,
+        undefined,
+        undefined,
+        undefined,
+        buffer,
+      );
       monitor.start();
       monitor.startMonitoring("device-1", "com.example.app");
       await advanceTimeAndWait(fakeTimer, PerformanceMonitor.TICK_INTERVAL_MS * 5);
@@ -755,28 +877,58 @@ class FakeSimCtl implements SimCtl {
 
   // Implement other SimCtl methods as no-ops for testing
   setDevice(): void {}
-  async isAvailable(): Promise<boolean> { return true; }
-  async isSimulatorRunning(): Promise<boolean> { return false; }
-  async startSimulator(): Promise<any> { return {}; }
+  async isAvailable(): Promise<boolean> {
+    return true;
+  }
+  async isSimulatorRunning(): Promise<boolean> {
+    return false;
+  }
+  async startSimulator(): Promise<any> {
+    return {};
+  }
   async killSimulator(): Promise<void> {}
-  async waitForSimulatorReady(): Promise<any> { return {}; }
-  async listSimulatorImages(): Promise<any[]> { return []; }
-  async getBootedSimulators(): Promise<any[]> { return []; }
-  async getDeviceInfo(): Promise<any> { return null; }
-  async bootSimulator(): Promise<any> { return {}; }
-  async getDeviceTypes(): Promise<any[]> { return []; }
-  async getRuntimes(): Promise<any[]> { return []; }
-  async createSimulator(): Promise<string> { return ""; }
+  async waitForSimulatorReady(): Promise<any> {
+    return {};
+  }
+  async listSimulatorImages(): Promise<any[]> {
+    return [];
+  }
+  async getBootedSimulators(): Promise<any[]> {
+    return [];
+  }
+  async getDeviceInfo(): Promise<any> {
+    return null;
+  }
+  async bootSimulator(): Promise<any> {
+    return {};
+  }
+  async getDeviceTypes(): Promise<any[]> {
+    return [];
+  }
+  async getRuntimes(): Promise<any[]> {
+    return [];
+  }
+  async createSimulator(): Promise<string> {
+    return "";
+  }
   async deleteSimulator(): Promise<void> {}
-  async listApps(): Promise<any[]> { return []; }
-  async launchApp(): Promise<any> { return { success: true }; }
+  async listApps(): Promise<any[]> {
+    return [];
+  }
+  async launchApp(): Promise<any> {
+    return { success: true };
+  }
   async terminateApp(): Promise<void> {}
   async installApp(): Promise<void> {}
   async uninstallApp(): Promise<void> {}
-  async getScreenSize(): Promise<any> { return { width: 390, height: 844 }; }
+  async getScreenSize(): Promise<any> {
+    return { width: 390, height: 844 };
+  }
   async setAppearance(): Promise<void> {}
   async openSimulatorApp(): Promise<void> {}
-  async pushNotification(): Promise<{ success: boolean; error?: string }> { return { success: true }; }
+  async pushNotification(): Promise<{ success: boolean; error?: string }> {
+    return { success: true };
+  }
 }
 
 /**
@@ -843,10 +995,16 @@ describe("PerformanceMonitor iOS", () => {
     const fakeExec = createFakeExecFileAsync({
       stdout: `USER     PID %CPU %MEM      VSZ    RSS   TT  STAT STARTED      TIME COMMAND
 root       1  0.0  0.0   407056   1632   ??  Ss   Mon09AM   0:01.23 /sbin/launchd
-mobile 12345 15.5  2.3  1234567  89012   ??  Ss   10:00AM   1:23.45 com.example.iosapp`
+mobile 12345 15.5  2.3  1234567  89012   ??  Ss   10:00AM   1:23.45 com.example.iosapp`,
     });
 
-    monitor = new PerformanceMonitor(fakeTimer, fakeAdbFactory, serverGetter, fakeSimCtlFactory, fakeExec);
+    monitor = new PerformanceMonitor(
+      fakeTimer,
+      fakeAdbFactory,
+      serverGetter,
+      fakeSimCtlFactory,
+      fakeExec,
+    );
     monitor.start();
     monitor.startMonitoring("ios-device-1", "com.example.iosapp", "ios");
 
@@ -863,10 +1021,16 @@ mobile 12345 15.5  2.3  1234567  89012   ??  Ss   10:00AM   1:23.45 com.example.
     // Set up fake ps aux response on the host
     const fakeExec = createFakeExecFileAsync({
       stdout: `USER     PID %CPU %MEM      VSZ    RSS   TT  STAT STARTED      TIME COMMAND
-mobile 12345 5.0  2.3  1234567 102400   ??  Ss   10:00AM   1:23.45 com.example.iosapp`
+mobile 12345 5.0  2.3  1234567 102400   ??  Ss   10:00AM   1:23.45 com.example.iosapp`,
     });
 
-    monitor = new PerformanceMonitor(fakeTimer, fakeAdbFactory, serverGetter, fakeSimCtlFactory, fakeExec);
+    monitor = new PerformanceMonitor(
+      fakeTimer,
+      fakeAdbFactory,
+      serverGetter,
+      fakeSimCtlFactory,
+      fakeExec,
+    );
     monitor.start();
     monitor.startMonitoring("ios-device-1", "com.example.iosapp", "ios");
 
@@ -881,10 +1045,16 @@ mobile 12345 5.0  2.3  1234567 102400   ??  Ss   10:00AM   1:23.45 com.example.i
 
   it("should return null FPS/frame time for iOS (not available)", async () => {
     const fakeExec = createFakeExecFileAsync({
-      stdout: `mobile 12345 5.0  2.3  1234567 102400   ??  Ss   10:00AM   1:23.45 com.example.iosapp`
+      stdout: `mobile 12345 5.0  2.3  1234567 102400   ??  Ss   10:00AM   1:23.45 com.example.iosapp`,
     });
 
-    monitor = new PerformanceMonitor(fakeTimer, fakeAdbFactory, serverGetter, fakeSimCtlFactory, fakeExec);
+    monitor = new PerformanceMonitor(
+      fakeTimer,
+      fakeAdbFactory,
+      serverGetter,
+      fakeSimCtlFactory,
+      fakeExec,
+    );
     monitor.start();
     monitor.startMonitoring("ios-device-1", "com.example.iosapp", "ios");
 
@@ -903,10 +1073,16 @@ mobile 12345 5.0  2.3  1234567 102400   ??  Ss   10:00AM   1:23.45 com.example.i
     // ps aux returns output but doesn't include our bundle ID
     const fakeExec = createFakeExecFileAsync({
       stdout: `USER     PID %CPU %MEM      VSZ    RSS   TT  STAT STARTED      TIME COMMAND
-root       1  0.0  0.0   407056   1632   ??  Ss   Mon09AM   0:01.23 /sbin/launchd`
+root       1  0.0  0.0   407056   1632   ??  Ss   Mon09AM   0:01.23 /sbin/launchd`,
     });
 
-    monitor = new PerformanceMonitor(fakeTimer, fakeAdbFactory, serverGetter, fakeSimCtlFactory, fakeExec);
+    monitor = new PerformanceMonitor(
+      fakeTimer,
+      fakeAdbFactory,
+      serverGetter,
+      fakeSimCtlFactory,
+      fakeExec,
+    );
     monitor.start();
     monitor.startMonitoring("ios-device-1", "com.example.iosapp", "ios");
 
@@ -920,10 +1096,16 @@ root       1  0.0  0.0   407056   1632   ??  Ss   Mon09AM   0:01.23 /sbin/launch
 
   it("should handle exec errors gracefully", async () => {
     const fakeExec = createFakeExecFileAsync({
-      errorToThrow: new Error("Command failed")
+      errorToThrow: new Error("Command failed"),
     });
 
-    monitor = new PerformanceMonitor(fakeTimer, fakeAdbFactory, serverGetter, fakeSimCtlFactory, fakeExec);
+    monitor = new PerformanceMonitor(
+      fakeTimer,
+      fakeAdbFactory,
+      serverGetter,
+      fakeSimCtlFactory,
+      fakeExec,
+    );
     monitor.start();
     monitor.startMonitoring("ios-device-1", "com.example.iosapp", "ios");
 
@@ -943,8 +1125,11 @@ root       1  0.0  0.0   407056   1632   ??  Ss   Mon09AM   0:01.23 /sbin/launch
 
     it("emits baseline telemetry on first sample", async () => {
       monitor = new PerformanceMonitor(
-        fakeTimer, fakeAdbFactory, serverGetter,
-        undefined, undefined,
+        fakeTimer,
+        fakeAdbFactory,
+        serverGetter,
+        undefined,
+        undefined,
         () => fakeTelemetry,
       );
       monitor.startMonitoring("emulator-5554", "com.example.app", "android");
@@ -960,8 +1145,11 @@ root       1  0.0  0.0   407056   1632   ??  Ss   Mon09AM   0:01.23 /sbin/launch
 
     it("does not emit telemetry when health unchanged", async () => {
       monitor = new PerformanceMonitor(
-        fakeTimer, fakeAdbFactory, serverGetter,
-        undefined, undefined,
+        fakeTimer,
+        fakeAdbFactory,
+        serverGetter,
+        undefined,
+        undefined,
         () => fakeTelemetry,
       );
       monitor.startMonitoring("emulator-5554", "com.example.app", "android");
@@ -978,8 +1166,11 @@ root       1  0.0  0.0   407056   1632   ??  Ss   Mon09AM   0:01.23 /sbin/launch
 
     it("emits telemetry when metric crosses threshold", async () => {
       monitor = new PerformanceMonitor(
-        fakeTimer, fakeAdbFactory, serverGetter,
-        undefined, undefined,
+        fakeTimer,
+        fakeAdbFactory,
+        serverGetter,
+        undefined,
+        undefined,
         () => fakeTelemetry,
       );
       monitor.startMonitoring("emulator-5554", "com.example.app", "android");
@@ -1001,7 +1192,7 @@ root       1  0.0  0.0   407056   1632   ??  Ss   Mon09AM   0:01.23 /sbin/launch
           Missed Vsync: 20
           Slow UI thread: 15
           Frame deadline missed: 25
-        `
+        `,
       );
 
       await advanceTimeAndWait(fakeTimer, PerformanceMonitor.TICK_INTERVAL_MS);
@@ -1012,8 +1203,11 @@ root       1  0.0  0.0   407056   1632   ??  Ss   Mon09AM   0:01.23 /sbin/launch
 
     it("sets deviceId context before emitting", async () => {
       monitor = new PerformanceMonitor(
-        fakeTimer, fakeAdbFactory, serverGetter,
-        undefined, undefined,
+        fakeTimer,
+        fakeAdbFactory,
+        serverGetter,
+        undefined,
+        undefined,
         () => fakeTelemetry,
       );
       monitor.startMonitoring("emulator-5554", "com.example.app", "android");


### PR DESCRIPTION
## Summary

Android `PerformanceMonitor` now reports CPU usage from process-tick and uptime deltas instead of cumulative process time divided by device uptime. The first sample and samples after a package or process reset remain `null` until a valid interval is available.

## Linked Issue

Closes [#5107](https://github.com/kaeawc/auto-mobile/issues/5107)

## Bug / Regression Context

- **Observed symptom:** Android CPU usage was uptime-averaged, understating recent process load on long-lived devices.
- **Repro conditions:** Collect two medium-interval samples from the same PID while process ticks and `/proc/uptime` advance.

## Validation

- [x] Focused `PerformanceMonitor` suite: 47 passed
- [x] `bun run typecheck`: no new errors
- [x] `bun run lint`: passed with existing ratcheted warnings
- [x] `scripts/all_fast_validate_checks.sh`: 32 passed
- [x] Full `bun test`: 12,916 passed, 13 skipped; the one failure was an environment-path assertion caused by the temporary `AUTOMOBILE_DATA_DIR` under `/tmp/` and the isolated test passes without that override
- [x] `git diff --check`
