### PR TITLE
fix(perf): refine perfSnapshot windowing

### DIFF
--- a/src/features/performance/PerformanceMonitor.ts
+++ b/src/features/performance/PerformanceMonitor.ts
@@ -403,7 +403,6 @@ export class PerformanceMonitor {
     );
 
     const gfxPromise = sdkFrame ? Promise.resolve(null) : this.collectGfxMetrics(device);
-    const recordFrameMetrics = sdkFrame !== null || device.gfxPrimed;
 
     // Collect medium metrics (CPU) if interval elapsed or first collection. The
     // collect calls do NOT mutate `device` — caches/timestamps are updated only
@@ -432,9 +431,6 @@ export class PerformanceMonitor {
     }
 
     device.lastFastTick = now;
-    if (!sdkFrame && gfx?.resetSucceeded) {
-      device.gfxPrimed = true;
-    }
     if (shouldCollectCpu) {
       device.lastMediumTick = now;
       device.cachedCpu = cpu;
@@ -507,6 +503,15 @@ export class PerformanceMonitor {
       rawFrameTimeMs = gfxData.frameTimeMs;
     }
 
+    // The first gfxinfo read is cumulative since app launch rather than since
+    // monitoring started. Keep it for the live stream, but do not let it seed
+    // the windowed snapshot. SDK samples are already interval-scoped.
+    const recordGfxWindowSample = this.consumeGfxPriming(
+      device,
+      sdkFrame,
+      gfx?.resetSucceeded ?? false,
+    );
+
     // Get TTI from the global store if available
     const ttiMs = getLastTtiMs(device.packageName);
 
@@ -526,10 +531,10 @@ export class PerformanceMonitor {
     // flicker to 0, but the buffer must NOT re-record a stale reading every idle
     // tick — that would keep an old fps dominating the percentiles.
     this.pushMetrics(device, now, metrics, jankFrames, server, {
-      fps: recordFrameMetrics ? rawFps : null,
-      frameTimeMs: recordFrameMetrics ? rawFrameTimeMs : null,
-      jankFrames: recordFrameMetrics ? jankFrames : null,
-      touchLatencyMs: recordFrameMetrics ? rawTouchLatencyMs : null,
+      fps: recordGfxWindowSample ? rawFps : null,
+      frameTimeMs: recordGfxWindowSample ? rawFrameTimeMs : null,
+      jankFrames: recordGfxWindowSample ? jankFrames : null,
+      touchLatencyMs: recordGfxWindowSample ? rawTouchLatencyMs : null,
       // CPU/memory only when actually collected this tick (null otherwise), so
       // the window never averages a reading acquired outside it.
       cpuUsagePercent: shouldCollectCpu ? cpu : null,
@@ -726,6 +731,24 @@ export class PerformanceMonitor {
       };
       observationServer.pushPerformanceUpdate(device.deviceId, streamData);
     }
+  }
+
+  private consumeGfxPriming(device: MonitoredDevice, sdkFrame: unknown, resetSucceeded: boolean): boolean {
+    const hasSdkFrame = sdkFrame !== null;
+    if (hasSdkFrame) {
+      // SDK samples are interval-scoped. A later fallback must still be treated
+      // as its first cumulative read after the SDK feed goes stale.
+      device.gfxPrimed = false;
+      return true;
+    }
+    if (!resetSucceeded) {
+      // A caught ADB error did not establish a reset baseline. Keep priming
+      // pending so the first successful reset is also excluded.
+      return false;
+    }
+    const shouldRecord = device.gfxPrimed;
+    device.gfxPrimed = true;
+    return shouldRecord;
   }
 
   /**

--- a/test/features/performance/PerformanceMonitor.test.ts
+++ b/test/features/performance/PerformanceMonitor.test.ts
@@ -627,7 +627,30 @@ describe("PerformanceMonitor", () => {
       const snap = buffer.snapshot("device-1", fakeTimer.now(), 60000);
       expect(snap.sampleCount).toBeGreaterThanOrEqual(1);
       expect(snap.fps).not.toBeNull();
-      expect(snap.memoryMb).not.toBeNull();
+    });
+
+    it("primes the first cumulative gfxinfo sample without recording it in the window", async () => {
+      const buffer = new PerfWindowBuffer();
+      monitor = new PerformanceMonitor(
+        fakeTimer,
+        fakeAdbFactory,
+        serverGetter,
+        undefined,
+        undefined,
+        undefined,
+        buffer
+      );
+      monitor.start();
+      monitor.startMonitoring("device-1", "com.example.app");
+
+      await advanceTimeAndWait(fakeTimer, PerformanceMonitor.TICK_INTERVAL_MS);
+
+      expect(fakePusher.getPushCount()).toBe(1);
+      expect(buffer.snapshot("device-1", fakeTimer.now(), 60000).sampleCount).toBe(0);
+
+      await advanceTimeAndWait(fakeTimer, PerformanceMonitor.TICK_INTERVAL_MS);
+
+      expect(buffer.snapshot("device-1", fakeTimer.now(), 60000).sampleCount).toBe(1);
     });
 
     it("primes the first gfxinfo sample without recording cumulative frame metrics", async () => {
@@ -756,7 +779,7 @@ describe("PerformanceMonitor", () => {
       monitor = new PerformanceMonitor(fakeTimer, fakeAdbFactory, serverGetter, undefined, undefined, undefined, buffer);
       monitor.start();
       monitor.startMonitoring("device-1", "com.example.app");
-      await advanceTimeAndWait(fakeTimer, PerformanceMonitor.TICK_INTERVAL_MS);
+      await advanceTimeAndWait(fakeTimer, PerformanceMonitor.TICK_INTERVAL_MS * 2);
       expect(buffer.snapshot("device-1", fakeTimer.now(), 60000).sampleCount).toBeGreaterThanOrEqual(1);
 
       // Switching the monitored package must drop app A's samples so the next
@@ -770,7 +793,7 @@ describe("PerformanceMonitor", () => {
       monitor = new PerformanceMonitor(fakeTimer, fakeAdbFactory, serverGetter, undefined, undefined, undefined, buffer);
       monitor.start();
       monitor.startMonitoring("device-1", "com.example.app");
-      await advanceTimeAndWait(fakeTimer, PerformanceMonitor.TICK_INTERVAL_MS);
+      await advanceTimeAndWait(fakeTimer, PerformanceMonitor.TICK_INTERVAL_MS * 2);
       expect(buffer.snapshot("device-1", fakeTimer.now(), 60000).sampleCount).toBeGreaterThanOrEqual(1);
 
       monitor.stopMonitoring("device-1");

--- a/test/features/performance/PerformanceMonitor.test.ts
+++ b/test/features/performance/PerformanceMonitor.test.ts
@@ -629,7 +629,7 @@ describe("PerformanceMonitor", () => {
       expect(snap.fps).not.toBeNull();
     });
 
-    it("primes the first cumulative gfxinfo sample without recording it in the window", async () => {
+    it("primes gfxinfo while preserving non-gfx metrics from the first tick", async () => {
       const buffer = new PerfWindowBuffer();
       monitor = new PerformanceMonitor(
         fakeTimer,
@@ -646,11 +646,17 @@ describe("PerformanceMonitor", () => {
       await advanceTimeAndWait(fakeTimer, PerformanceMonitor.TICK_INTERVAL_MS);
 
       expect(fakePusher.getPushCount()).toBe(1);
-      expect(buffer.snapshot("device-1", fakeTimer.now(), 60000).sampleCount).toBe(0);
+      const firstSnapshot = buffer.snapshot("device-1", fakeTimer.now(), 60000);
+      expect(firstSnapshot.sampleCount).toBe(1);
+      expect(firstSnapshot.fps).toBeNull();
+      expect(firstSnapshot.jank).toBeNull();
+      expect(firstSnapshot.memoryMb?.latest).toBe(100);
 
       await advanceTimeAndWait(fakeTimer, PerformanceMonitor.TICK_INTERVAL_MS);
 
-      expect(buffer.snapshot("device-1", fakeTimer.now(), 60000).sampleCount).toBe(1);
+      const secondSnapshot = buffer.snapshot("device-1", fakeTimer.now(), 60000);
+      expect(secondSnapshot.sampleCount).toBe(2);
+      expect(secondSnapshot.fps).not.toBeNull();
     });
 
     it("primes the first gfxinfo sample without recording cumulative frame metrics", async () => {
@@ -835,6 +841,50 @@ describe("PerformanceMonitor", () => {
 
       // dumpsys default gfxinfo → fps derived from 8.5ms p50, capped at 60.
       expect(fakePusher.getLastPushedData()?.metrics.fps).toBe(60);
+    });
+
+    it("re-primes the first dumpsys sample after an SDK interval", async () => {
+      const buffer = new PerfWindowBuffer();
+      const sdkStore = new SdkFrameMetricsStore();
+      monitor = new PerformanceMonitor(fakeTimer, fakeAdbFactory, serverGetter, undefined, undefined, undefined, buffer, sdkStore);
+      monitor.start();
+      monitor.startMonitoring("device-1", "com.example.app");
+
+      await advanceTimeAndWait(fakeTimer, PerformanceMonitor.TICK_INTERVAL_MS);
+      sdkStore.ingest("device-1", "com.example.app", {
+        fps: 42, frameTimeMs: 23.8, jankFrames: 3, receivedAt: fakeTimer.now(),
+      });
+      await advanceTimeAndWait(fakeTimer, PerformanceMonitor.TICK_INTERVAL_MS);
+      expect(buffer.snapshot("device-1", fakeTimer.now(), 60000).sampleCount).toBe(2);
+
+      sdkStore.clear("device-1");
+      await advanceTimeAndWait(fakeTimer, PerformanceMonitor.TICK_INTERVAL_MS);
+      const afterFallbackBaseline = buffer.snapshot("device-1", fakeTimer.now(), 60000);
+      expect(afterFallbackBaseline.sampleCount).toBe(3);
+      expect(afterFallbackBaseline.fps?.p50).toBe(42);
+
+      await advanceTimeAndWait(fakeTimer, PerformanceMonitor.TICK_INTERVAL_MS);
+      expect(buffer.snapshot("device-1", fakeTimer.now(), 60000).sampleCount).toBe(4);
+    });
+
+    it("does not prime gfxinfo after a failed reset", async () => {
+      const buffer = new PerfWindowBuffer();
+      const gfxCommand = "shell dumpsys gfxinfo com.example.app reset";
+      fakeAdbClient.setCommandError(gfxCommand, new Error("ADB connection failed"));
+      monitor = new PerformanceMonitor(fakeTimer, fakeAdbFactory, serverGetter, undefined, undefined, undefined, buffer);
+      monitor.start();
+      monitor.startMonitoring("device-1", "com.example.app");
+
+      await advanceTimeAndWait(fakeTimer, PerformanceMonitor.TICK_INTERVAL_MS);
+      fakeAdbClient.clearCommandError(gfxCommand);
+      await advanceTimeAndWait(fakeTimer, PerformanceMonitor.TICK_INTERVAL_MS);
+
+      const afterFirstSuccess = buffer.snapshot("device-1", fakeTimer.now(), 60000);
+      expect(afterFirstSuccess.sampleCount).toBe(2);
+      expect(afterFirstSuccess.fps).toBeNull();
+
+      await advanceTimeAndWait(fakeTimer, PerformanceMonitor.TICK_INTERVAL_MS);
+      expect(buffer.snapshot("device-1", fakeTimer.now(), 60000).fps).not.toBeNull();
     });
 
     it("records raw null fps for idle intervals, not the cached stream value", async () => {


### PR DESCRIPTION
## Summary

- Prime Android `gfxinfo` before recording windowed performance samples so cumulative-since-launch data does not inflate the first `perfSnapshot`.
- Exclude the sample exactly at the left window boundary from jank totals and rates while preserving it for other window metrics.
- Add focused regression coverage for both behaviors.

## Validation

- `bun test test/features/performance/PerfWindowBuffer.test.ts test/features/performance/PerformanceMonitor.test.ts`
- `bun run turbo:validate`
- `bun run typecheck`

Closes #5110
