### PR TITLE
fix(desktop): surface tool operation failures

### DIFF
--- a/android/desktop-core/src/main/kotlin/dev/jasonpearson/automobile/desktop/core/daemon/AutoMobileClient.kt
+++ b/android/desktop-core/src/main/kotlin/dev/jasonpearson/automobile/desktop/core/daemon/AutoMobileClient.kt
@@ -187,8 +187,8 @@ interface AutoMobileClient {
     val success = payloadObject["success"]?.jsonPrimitive?.booleanOrNull
     if (envelopeError || success == false) {
       val message =
-        payloadObject["message"]?.jsonPrimitive?.contentOrNull
-          ?: payloadObject["error"]?.jsonPrimitive?.contentOrNull
+        payloadObject["error"]?.jsonPrimitive?.contentOrNull
+          ?: payloadObject["message"]?.jsonPrimitive?.contentOrNull
           ?: payloadObject["reason"]?.jsonPrimitive?.contentOrNull
           ?: payloadObject["code"]?.jsonPrimitive?.contentOrNull
           ?: "Tool operation failed"

--- a/android/desktop-core/src/main/kotlin/dev/jasonpearson/automobile/desktop/core/daemon/AutoMobileClient.kt
+++ b/android/desktop-core/src/main/kotlin/dev/jasonpearson/automobile/desktop/core/daemon/AutoMobileClient.kt
@@ -169,43 +169,21 @@ interface AutoMobileClient {
    * transport errors.
    */
   fun callToolChecked(name: String, arguments: JsonObject): JsonElement {
-    val response =
-      callTool(name, arguments) as? JsonObject
-        ?: throw McpConnectionException("Tool response was not an object")
-    val envelopeError = response["isError"]?.jsonPrimitive?.booleanOrNull == true
-    val text =
-      response["content"]
-        ?.let { content ->
-          (content as? JsonArray)?.firstOrNull { item ->
-            (item as? JsonObject)?.get("type")?.jsonPrimitive?.content == "text"
-          }
-        }
-        ?.let { (it as? JsonObject)?.get("text")?.jsonPrimitive?.content }
-        ?: throw McpConnectionException("Tool response missing text content")
-    val payload = DaemonJson.decodeFromString<JsonElement>(text)
-    val payloadObject = payload as? JsonObject ?: return payload
-    val success = payloadObject["success"]?.jsonPrimitive?.booleanOrNull
-    if (envelopeError || success == false) {
-      val message =
-        payloadObject["error"]?.jsonPrimitive?.contentOrNull
-          ?: payloadObject["message"]?.jsonPrimitive?.contentOrNull
-          ?: payloadObject["reason"]?.jsonPrimitive?.contentOrNull
-          ?: payloadObject["code"]?.jsonPrimitive?.contentOrNull
-          ?: "Tool operation failed"
-      throw McpConnectionException(message)
-    }
-    return payload
+    return checkToolResponse(callTool(name, arguments), DaemonJson)
   }
 
   /** Enable one optional server capability for this client connection. */
   fun enableToolCapability(capability: String) {
     try {
-      callTool(
-        "setToolCapability",
-        buildJsonObject {
-          put("capability", capability)
-          put("enabled", true)
-        },
+      checkToolResponse(
+        callTool(
+          "setToolCapability",
+          buildJsonObject {
+            put("capability", capability)
+            put("enabled", true)
+          },
+        ),
+        DaemonJson,
       )
     } catch (error: McpConnectionException) {
       if (error.message?.contains("unknown tool", ignoreCase = true) != true) throw error
@@ -213,6 +191,37 @@ interface AutoMobileClient {
   }
 
   fun close() {}
+}
+
+private fun checkToolResponse(responseElement: JsonElement, json: Json): JsonElement {
+  val response =
+    responseElement as? JsonObject
+      ?: throw McpConnectionException("Tool response was not an object")
+  val envelopeError = (response["isError"] as? JsonPrimitive)?.booleanOrNull == true
+  val text =
+    response["content"]
+      ?.let { content ->
+        (content as? JsonArray)?.firstOrNull { item ->
+          (item as? JsonObject)?.get("type")?.jsonPrimitive?.content == "text"
+        }
+      }
+      ?.let { ((it as? JsonObject)?.get("text") as? JsonPrimitive)?.contentOrNull }
+      ?: throw McpConnectionException("Tool response missing text content")
+  val payload =
+    try {
+      json.decodeFromString<JsonElement>(text)
+    } catch (error: Exception) {
+      if (envelopeError) {
+        throw McpConnectionException(toolErrorMessage(json, text), error)
+      }
+      throw McpConnectionException("Tool response contained invalid JSON", error)
+    }
+  val payloadObject = payload as? JsonObject
+  val success = (payloadObject?.get("success") as? JsonPrimitive)?.booleanOrNull
+  if (envelopeError || success == false) {
+    throw McpConnectionException(toolErrorMessage(json, text))
+  }
+  return payload
 }
 
 @Serializable
@@ -343,7 +352,11 @@ data class McpToolContent(
   val text: String? = null,
 )
 
-@Serializable data class McpToolResponse(val content: List<McpToolContent>)
+@Serializable
+data class McpToolResponse(
+  val content: List<McpToolContent>,
+  val isError: Boolean = false,
+)
 
 @Serializable
 data class FeatureFlagState(
@@ -446,7 +459,24 @@ internal fun <T> decodeToolResponse(
   val text =
     response.content.firstOrNull { it.type == "text" }?.text
       ?: throw McpConnectionException("Tool response missing text content")
+  if (response.isError) {
+    throw McpConnectionException(toolErrorMessage(json, text))
+  }
   return json.decodeFromString(serializer, text)
+}
+
+private fun toolErrorMessage(json: Json, text: String): String {
+  val payload = runCatching { json.decodeFromString<JsonElement>(text) }.getOrNull()
+  val payloadObject = payload as? JsonObject
+  val structuredMessage =
+    payloadObject?.let {
+      (it["error"] as? JsonPrimitive)?.contentOrNull
+        ?: (it["message"] as? JsonPrimitive)?.contentOrNull
+        ?: (it["reason"] as? JsonPrimitive)?.contentOrNull
+        ?: (it["code"] as? JsonPrimitive)?.contentOrNull
+    }
+  return structuredMessage
+    ?: text.removePrefix("Error:").trim().ifBlank { "Tool operation failed" }
 }
 
 internal fun <T> decodeResourceResponse(

--- a/android/desktop-core/src/main/kotlin/dev/jasonpearson/automobile/desktop/core/daemon/AutoMobileClient.kt
+++ b/android/desktop-core/src/main/kotlin/dev/jasonpearson/automobile/desktop/core/daemon/AutoMobileClient.kt
@@ -468,15 +468,13 @@ internal fun <T> decodeToolResponse(
 private fun toolErrorMessage(json: Json, text: String): String {
   val payload = runCatching { json.decodeFromString<JsonElement>(text) }.getOrNull()
   val payloadObject = payload as? JsonObject
-  val structuredMessage =
-    payloadObject?.let {
-      (it["error"] as? JsonPrimitive)?.contentOrNull
-        ?: (it["message"] as? JsonPrimitive)?.contentOrNull
-        ?: (it["reason"] as? JsonPrimitive)?.contentOrNull
-        ?: (it["code"] as? JsonPrimitive)?.contentOrNull
-    }
-  return structuredMessage
-    ?: text.removePrefix("Error:").trim().ifBlank { "Tool operation failed" }
+  val structuredMessage = payloadObject?.let {
+    (it["error"] as? JsonPrimitive)?.contentOrNull
+      ?: (it["message"] as? JsonPrimitive)?.contentOrNull
+      ?: (it["reason"] as? JsonPrimitive)?.contentOrNull
+      ?: (it["code"] as? JsonPrimitive)?.contentOrNull
+  }
+  return structuredMessage ?: text.removePrefix("Error:").trim().ifBlank { "Tool operation failed" }
 }
 
 internal fun <T> decodeResourceResponse(

--- a/android/desktop-core/src/main/kotlin/dev/jasonpearson/automobile/desktop/core/daemon/AutoMobileClient.kt
+++ b/android/desktop-core/src/main/kotlin/dev/jasonpearson/automobile/desktop/core/daemon/AutoMobileClient.kt
@@ -6,10 +6,13 @@ import kotlinx.serialization.SerialName
 import kotlinx.serialization.Serializable
 import kotlinx.serialization.decodeFromString
 import kotlinx.serialization.json.Json
+import kotlinx.serialization.json.JsonArray
 import kotlinx.serialization.json.JsonElement
 import kotlinx.serialization.json.JsonObject
 import kotlinx.serialization.json.JsonPrimitive
+import kotlinx.serialization.json.booleanOrNull
 import kotlinx.serialization.json.buildJsonObject
+import kotlinx.serialization.json.contentOrNull
 import kotlinx.serialization.json.decodeFromJsonElement
 import kotlinx.serialization.json.jsonPrimitive
 import kotlinx.serialization.json.put
@@ -67,6 +70,13 @@ interface AutoMobileClient {
   ): StartDeviceResult
 
   fun setActiveDevice(deviceId: String, platform: String): SetActiveDeviceResult
+
+  fun setActiveDeviceChecked(deviceId: String, platform: String) {
+    val result = setActiveDevice(deviceId, platform)
+    if (!result.success) {
+      throw McpConnectionException(result.message ?: "Failed to set active device")
+    }
+  }
 
   fun observe(platform: String = "android"): ObserveResult
 
@@ -152,6 +162,40 @@ interface AutoMobileClient {
   ): ClearKeyValueResult
 
   fun callTool(name: String, arguments: JsonObject): JsonElement
+
+  /**
+   * Calls a tool whose JSON payload follows the daemon's `{success, message}` operation-result
+   * convention and turns operational or MCP envelope failures into the same exception path as
+   * transport errors.
+   */
+  fun callToolChecked(name: String, arguments: JsonObject): JsonElement {
+    val response =
+      callTool(name, arguments) as? JsonObject
+        ?: throw McpConnectionException("Tool response was not an object")
+    val envelopeError = response["isError"]?.jsonPrimitive?.booleanOrNull == true
+    val text =
+      response["content"]
+        ?.let { content ->
+          (content as? JsonArray)?.firstOrNull { item ->
+            (item as? JsonObject)?.get("type")?.jsonPrimitive?.content == "text"
+          }
+        }
+        ?.let { (it as? JsonObject)?.get("text")?.jsonPrimitive?.content }
+        ?: throw McpConnectionException("Tool response missing text content")
+    val payload = DaemonJson.decodeFromString<JsonElement>(text)
+    val payloadObject = payload as? JsonObject ?: return payload
+    val success = payloadObject["success"]?.jsonPrimitive?.booleanOrNull
+    if (envelopeError || success == false) {
+      val message =
+        payloadObject["message"]?.jsonPrimitive?.contentOrNull
+          ?: payloadObject["error"]?.jsonPrimitive?.contentOrNull
+          ?: payloadObject["reason"]?.jsonPrimitive?.contentOrNull
+          ?: payloadObject["code"]?.jsonPrimitive?.contentOrNull
+          ?: "Tool operation failed"
+      throw McpConnectionException(message)
+    }
+    return payload
+  }
 
   /** Enable one optional server capability for this client connection. */
   fun enableToolCapability(capability: String) {

--- a/android/desktop-core/src/main/kotlin/dev/jasonpearson/automobile/desktop/core/daemon/McpDaemonClient.kt
+++ b/android/desktop-core/src/main/kotlin/dev/jasonpearson/automobile/desktop/core/daemon/McpDaemonClient.kt
@@ -26,8 +26,6 @@ import kotlinx.serialization.json.JsonPrimitive
 import kotlinx.serialization.json.buildJsonObject
 import kotlinx.serialization.json.contentOrNull
 import kotlinx.serialization.json.decodeFromJsonElement
-import kotlinx.serialization.json.jsonArray
-import kotlinx.serialization.json.jsonObject
 import kotlinx.serialization.json.jsonPrimitive
 import kotlinx.serialization.serializer
 
@@ -582,10 +580,7 @@ class McpDaemonClient(
         return
       }
     capabilityProfileUuid =
-      (response as? JsonObject)
-        ?.get("sessionUuid")
-        ?.jsonPrimitive
-        ?.contentOrNull
+      (response as? JsonObject)?.get("sessionUuid")?.jsonPrimitive?.contentOrNull
         ?: throw DaemonUnavailableException("Capability control response missing profile UUID")
   }
 

--- a/android/desktop-core/src/main/kotlin/dev/jasonpearson/automobile/desktop/core/daemon/McpDaemonClient.kt
+++ b/android/desktop-core/src/main/kotlin/dev/jasonpearson/automobile/desktop/core/daemon/McpDaemonClient.kt
@@ -24,6 +24,7 @@ import kotlinx.serialization.json.JsonObject
 import kotlinx.serialization.json.JsonObjectBuilder
 import kotlinx.serialization.json.JsonPrimitive
 import kotlinx.serialization.json.buildJsonObject
+import kotlinx.serialization.json.contentOrNull
 import kotlinx.serialization.json.decodeFromJsonElement
 import kotlinx.serialization.json.jsonArray
 import kotlinx.serialization.json.jsonObject
@@ -38,8 +39,6 @@ private const val UNSUPPORTED_APPEND_MODE_ERROR =
   "The connected daemon does not support input/typeText mode:append. Restart or update the daemon before typing into the device."
 private const val SET_TOOL_CAPABILITY_TOOL_NAME = "setToolCapability"
 private const val DAEMON_CAPABILITY_PROFILE_PARAM = "__autoMobileCapabilityProfileUuid"
-
-@Serializable private data class CapabilityProfileResponse(val sessionUuid: String)
 
 class McpDaemonClient(
   private val socketPathValue: String = DaemonSocketPaths.socketPath(),
@@ -568,7 +567,7 @@ class McpDaemonClient(
   override fun enableToolCapability(capability: String) {
     val response =
       try {
-        callTool(
+        callToolChecked(
           SET_TOOL_CAPABILITY_TOOL_NAME,
           buildJsonObject {
             put("capability", JsonPrimitive(capability))
@@ -582,16 +581,12 @@ class McpDaemonClient(
         if (error.message?.contains("unknown tool", ignoreCase = true) != true) throw error
         return
       }
-    val text =
-      response.jsonObject["content"]
-        ?.jsonArray
-        ?.firstOrNull { it.jsonObject["type"]?.jsonPrimitive?.content == "text" }
-        ?.jsonObject
-        ?.get("text")
+    capabilityProfileUuid =
+      (response as? JsonObject)
+        ?.get("sessionUuid")
         ?.jsonPrimitive
-        ?.content
+        ?.contentOrNull
         ?: throw DaemonUnavailableException("Capability control response missing profile UUID")
-    capabilityProfileUuid = json.decodeFromString<CapabilityProfileResponse>(text).sessionUuid
   }
 
   private fun sendInputRequest(method: String, params: JsonObject): InputActionResult {

--- a/android/desktop-core/src/main/kotlin/dev/jasonpearson/automobile/desktop/core/workspace/EmulatorControlExecutor.kt
+++ b/android/desktop-core/src/main/kotlin/dev/jasonpearson/automobile/desktop/core/workspace/EmulatorControlExecutor.kt
@@ -81,12 +81,12 @@ class DaemonEmulatorControlExecutor(
       val wire = platform.wireName()
       // Target the pane's device explicitly (belt-and-suspenders with the deviceId arg below), so a
       // control never races onto whichever device happened to be active.
-      client.setActiveDevice(deviceId, wire)
+      client.setActiveDeviceChecked(deviceId, wire)
       when (control) {
         EmulatorControl.Rotate -> {
           // `rotate` lives behind the advanced-interaction capability.
           client.enableToolCapability("advanced-interaction")
-          client.callTool(
+          client.callToolChecked(
             "rotate",
             buildJsonObject {
               put("orientation", orientation.toolValue)
@@ -98,7 +98,7 @@ class DaemonEmulatorControlExecutor(
         EmulatorControl.Snapshot -> {
           // `deviceSnapshot` lives behind the screen-artifacts capability.
           client.enableToolCapability("screen-artifacts")
-          client.callTool(
+          client.callToolChecked(
             "deviceSnapshot",
             buildJsonObject {
               put("action", "capture")
@@ -108,7 +108,7 @@ class DaemonEmulatorControlExecutor(
           )
         }
         EmulatorControl.Unlock ->
-          client.callTool(
+          client.callToolChecked(
             "wakeAndUnlock",
             buildJsonObject {
               put("platform", wire)
@@ -128,8 +128,8 @@ class DaemonEmulatorControlExecutor(
   override suspend fun pressButton(deviceId: String, platform: Platform, button: DeviceButton) {
     withContext(ioDispatcher) {
       val wire = platform.wireName()
-      client.setActiveDevice(deviceId, wire)
-      client.callTool(
+      client.setActiveDeviceChecked(deviceId, wire)
+      client.callToolChecked(
         "pressButton",
         buildJsonObject {
           put("button", button.toolValue)
@@ -143,7 +143,7 @@ class DaemonEmulatorControlExecutor(
   override suspend fun setLocale(deviceId: String, platform: Platform, locale: String) {
     withContext(ioDispatcher) {
       val wire = platform.wireName()
-      client.setActiveDevice(deviceId, wire)
+      client.setActiveDeviceChecked(deviceId, wire)
       // `changeLocalization` lives behind the device-settings capability.
       client.enableToolCapability("device-settings")
       // Resolve the foreground app on both platforms: Android *requires* it as the change target,
@@ -153,7 +153,7 @@ class DaemonEmulatorControlExecutor(
         LOG.warn("Cannot change locale on $deviceId: no foreground app to target")
         return@withContext
       }
-      client.callTool(
+      client.callToolChecked(
         "changeLocalization",
         buildJsonObject {
           put("locale", locale)

--- a/android/desktop-core/src/test/kotlin/dev/jasonpearson/automobile/desktop/core/daemon/McpHttpClientIntegrationTest.kt
+++ b/android/desktop-core/src/test/kotlin/dev/jasonpearson/automobile/desktop/core/daemon/McpHttpClientIntegrationTest.kt
@@ -31,20 +31,21 @@ class McpHttpClientIntegrationTest {
   }
 
   /** Build an MCP tool response wrapping the given JSON text. */
-  private fun mcpToolResponse(textJson: String, isError: Boolean = false): JsonElement = buildJsonObject {
-    if (isError) put("isError", true)
-    put(
-      "content",
-      buildJsonArray {
-        add(
-          buildJsonObject {
-            put("type", "text")
-            put("text", textJson)
-          }
-        )
-      },
-    )
-  }
+  private fun mcpToolResponse(textJson: String, isError: Boolean = false): JsonElement =
+    buildJsonObject {
+      if (isError) put("isError", true)
+      put(
+        "content",
+        buildJsonArray {
+          add(
+            buildJsonObject {
+              put("type", "text")
+              put("text", textJson)
+            }
+          )
+        },
+      )
+    }
 
   @Test
   fun `ping initializes session and records calls`() {

--- a/android/desktop-core/src/test/kotlin/dev/jasonpearson/automobile/desktop/core/daemon/McpHttpClientIntegrationTest.kt
+++ b/android/desktop-core/src/test/kotlin/dev/jasonpearson/automobile/desktop/core/daemon/McpHttpClientIntegrationTest.kt
@@ -31,7 +31,8 @@ class McpHttpClientIntegrationTest {
   }
 
   /** Build an MCP tool response wrapping the given JSON text. */
-  private fun mcpToolResponse(textJson: String): JsonElement = buildJsonObject {
+  private fun mcpToolResponse(textJson: String, isError: Boolean = false): JsonElement = buildJsonObject {
+    if (isError) put("isError", true)
     put(
       "content",
       buildJsonArray {
@@ -159,5 +160,21 @@ class McpHttpClientIntegrationTest {
     assertTrue(result.success)
     assertEquals("started", result.message)
     assertTrue(daemon.calls.contains("tools/call:startDevice"))
+  }
+
+  @Test
+  fun `typed tool results preserve MCP error envelopes`() {
+    daemon.setToolResponse(
+      "setActiveDevice",
+      mcpToolResponse(
+        """{"code":"device_lost","reason":"confirmed-unavailable"}""",
+        isError = true,
+      ),
+    )
+
+    val result = client.setActiveDevice("emulator-5554", "android")
+
+    assertEquals(false, result.success)
+    assertEquals("confirmed-unavailable", result.message)
   }
 }

--- a/android/desktop-core/src/test/kotlin/dev/jasonpearson/automobile/desktop/core/workspace/DaemonEmulatorControlExecutorTest.kt
+++ b/android/desktop-core/src/test/kotlin/dev/jasonpearson/automobile/desktop/core/workspace/DaemonEmulatorControlExecutorTest.kt
@@ -4,10 +4,12 @@ import dev.jasonpearson.automobile.desktop.core.testing.FakeAutoMobileClient
 import kotlinx.coroutines.ExperimentalCoroutinesApi
 import kotlinx.coroutines.test.UnconfinedTestDispatcher
 import kotlinx.coroutines.test.runTest
+import kotlinx.serialization.json.JsonElement
 import kotlinx.serialization.json.buildJsonObject
 import kotlinx.serialization.json.put
 import org.junit.Assert.assertEquals
 import org.junit.Assert.assertTrue
+import org.junit.Assert.fail
 import org.junit.Test
 
 /**
@@ -18,10 +20,47 @@ import org.junit.Test
 @OptIn(ExperimentalCoroutinesApi::class)
 class DaemonEmulatorControlExecutorTest {
 
+  private fun toolResponse(success: Boolean, message: String): JsonElement = buildJsonObject {
+    put(
+      "content",
+      kotlinx.serialization.json.buildJsonArray {
+        add(
+          buildJsonObject {
+            put("type", "text")
+            put(
+              "text",
+              """{"success":$success,"message":"$message"}""",
+            )
+          }
+        )
+      },
+    )
+  }
+
+  private fun deviceLossToolResponse(): JsonElement = buildJsonObject {
+    put("isError", true)
+    put(
+      "content",
+      kotlinx.serialization.json.buildJsonArray {
+        add(
+          buildJsonObject {
+            put("type", "text")
+            put("text", """{"code":"device_lost","reason":"confirmed-unavailable"}""")
+          }
+        )
+      },
+    )
+  }
+
   private fun executor(
     client: FakeAutoMobileClient,
     resolver: ForegroundAppResolver = FakeForegroundAppResolver(appId = null),
-  ) = DaemonEmulatorControlExecutor(client, resolver, UnconfinedTestDispatcher())
+  ): DaemonEmulatorControlExecutor {
+    if (client.callToolResult == kotlinx.serialization.json.JsonObject(emptyMap())) {
+      client.callToolResult = toolResponse(success = true, message = "")
+    }
+    return DaemonEmulatorControlExecutor(client, resolver, UnconfinedTestDispatcher())
+  }
 
   @Test
   fun `rotate sets the active device then calls rotate with the target orientation`() = runTest {
@@ -120,6 +159,62 @@ class DaemonEmulatorControlExecutorTest {
             }
       }
     )
+  }
+
+  @Test
+  fun `tool-level failure is propagated from pressButton`() = runTest {
+    val client =
+      FakeAutoMobileClient().apply {
+        callToolResult = toolResponse(success = false, message = "Unsupported button")
+      }
+
+    try {
+      executor(client).pressButton("emulator-5554", Platform.Android, DeviceButton.Home)
+      fail("Expected tool failure")
+    } catch (error: Exception) {
+      assertEquals("Unsupported button", error.message)
+    }
+  }
+
+  @Test
+  fun `MCP error envelope is propagated from device control`() = runTest {
+    val client =
+      FakeAutoMobileClient().apply {
+        callToolResult = deviceLossToolResponse()
+      }
+
+    try {
+      executor(client)
+        .run(
+          "emulator-5554",
+          Platform.Android,
+          EmulatorControl.Unlock,
+          Orientation.Portrait,
+        )
+      fail("Expected MCP tool failure")
+    } catch (error: Exception) {
+      assertEquals("confirmed-unavailable", error.message)
+    }
+  }
+
+  @Test
+  fun `active-device failure prevents the control tool call`() = runTest {
+    val client =
+      FakeAutoMobileClient().apply {
+        setActiveDeviceResult =
+          dev.jasonpearson.automobile.desktop.core.daemon.SetActiveDeviceResult(
+            success = false,
+            message = "Device is unavailable",
+          )
+      }
+
+    try {
+      executor(client).pressButton("emulator-5554", Platform.Android, DeviceButton.Home)
+      fail("Expected active-device failure")
+    } catch (error: Exception) {
+      assertEquals("Device is unavailable", error.message)
+      assertTrue(client.toolCalls.none { it.name == "pressButton" })
+    }
   }
 
   @Test

--- a/android/desktop-core/src/test/kotlin/dev/jasonpearson/automobile/desktop/core/workspace/DaemonEmulatorControlExecutorTest.kt
+++ b/android/desktop-core/src/test/kotlin/dev/jasonpearson/automobile/desktop/core/workspace/DaemonEmulatorControlExecutorTest.kt
@@ -61,6 +61,21 @@ class DaemonEmulatorControlExecutorTest {
     )
   }
 
+  private fun plainTextToolErrorResponse(text: String): JsonElement = buildJsonObject {
+    put("isError", true)
+    put(
+      "content",
+      kotlinx.serialization.json.buildJsonArray {
+        add(
+          buildJsonObject {
+            put("type", "text")
+            put("text", text)
+          }
+        )
+      },
+    )
+  }
+
   private fun executor(
     client: FakeAutoMobileClient,
     resolver: ForegroundAppResolver = FakeForegroundAppResolver(appId = null),
@@ -209,8 +224,53 @@ class DaemonEmulatorControlExecutorTest {
           Orientation.Portrait,
         )
       fail("Expected MCP tool failure")
-    } catch (error: Exception) {
+    } catch (error: McpConnectionException) {
       assertEquals("confirmed-unavailable", error.message)
+    }
+  }
+
+  @Test
+  fun `plain text MCP error preserves the proxy message`() {
+    val client =
+      FakeAutoMobileClient().apply {
+        callToolResult = plainTextToolErrorResponse("Error: rotate failed")
+      }
+
+    try {
+      client.callToolChecked("rotate", buildJsonObject {})
+      fail("Expected MCP tool failure")
+    } catch (error: McpConnectionException) {
+      assertEquals("rotate failed", error.message)
+    }
+  }
+
+  @Test
+  fun `non-object MCP error payload is not treated as success`() {
+    val client =
+      FakeAutoMobileClient().apply {
+        callToolResult = plainTextToolErrorResponse("[]")
+      }
+
+    try {
+      client.callToolChecked("rotate", buildJsonObject {})
+      fail("Expected MCP tool failure")
+    } catch (error: McpConnectionException) {
+      assertEquals("[]", error.message)
+    }
+  }
+
+  @Test
+  fun `capability failure is not silently ignored`() {
+    val client =
+      FakeAutoMobileClient().apply {
+        callToolResult = plainTextToolErrorResponse("Error: capability denied")
+      }
+
+    try {
+      client.enableToolCapability("advanced-interaction")
+      fail("Expected capability failure")
+    } catch (error: McpConnectionException) {
+      assertEquals("capability denied", error.message)
     }
   }
 
@@ -228,7 +288,7 @@ class DaemonEmulatorControlExecutorTest {
     try {
       executor(client).pressButton("emulator-5554", Platform.Android, DeviceButton.Home)
       fail("Expected active-device failure")
-    } catch (error: Exception) {
+    } catch (error: McpConnectionException) {
       assertEquals("Device is unavailable", error.message)
       assertTrue(client.toolCalls.none { it.name == "pressButton" })
     }

--- a/android/desktop-core/src/test/kotlin/dev/jasonpearson/automobile/desktop/core/workspace/DaemonEmulatorControlExecutorTest.kt
+++ b/android/desktop-core/src/test/kotlin/dev/jasonpearson/automobile/desktop/core/workspace/DaemonEmulatorControlExecutorTest.kt
@@ -1,5 +1,6 @@
 package dev.jasonpearson.automobile.desktop.core.workspace
 
+import dev.jasonpearson.automobile.desktop.core.daemon.McpConnectionException
 import dev.jasonpearson.automobile.desktop.core.testing.FakeAutoMobileClient
 import kotlinx.coroutines.ExperimentalCoroutinesApi
 import kotlinx.coroutines.test.UnconfinedTestDispatcher
@@ -20,21 +21,29 @@ import org.junit.Test
 @OptIn(ExperimentalCoroutinesApi::class)
 class DaemonEmulatorControlExecutorTest {
 
-  private fun toolResponse(success: Boolean, message: String): JsonElement = buildJsonObject {
-    put(
-      "content",
-      kotlinx.serialization.json.buildJsonArray {
-        add(
-          buildJsonObject {
-            put("type", "text")
-            put(
-              "text",
-              """{"success":$success,"message":"$message"}""",
-            )
-          }
-        )
-      },
-    )
+  private fun toolResponse(
+    success: Boolean,
+    message: String,
+    error: String? = null,
+  ): JsonElement {
+    val payload = buildJsonObject {
+      put("success", success)
+      put("message", message)
+      error?.let { put("error", it) }
+    }
+    return buildJsonObject {
+      put(
+        "content",
+        kotlinx.serialization.json.buildJsonArray {
+          add(
+            buildJsonObject {
+              put("type", "text")
+              put("text", payload.toString())
+            }
+          )
+        },
+      )
+    }
   }
 
   private fun deviceLossToolResponse(): JsonElement = buildJsonObject {
@@ -165,15 +174,23 @@ class DaemonEmulatorControlExecutorTest {
   fun `tool-level failure is propagated from pressButton`() = runTest {
     val client =
       FakeAutoMobileClient().apply {
-        callToolResult = toolResponse(success = false, message = "Unsupported button")
+        callToolResult =
+          toolResponse(
+            success = false,
+            message = "Pressed button home",
+            error = "Unsupported button",
+          )
       }
 
+    var failureMessage: String? = null
     try {
       executor(client).pressButton("emulator-5554", Platform.Android, DeviceButton.Home)
       fail("Expected tool failure")
-    } catch (error: Exception) {
-      assertEquals("Unsupported button", error.message)
+    } catch (error: McpConnectionException) {
+      failureMessage = error.message
     }
+
+    assertEquals("Unsupported button", failureMessage)
   }
 
   @Test


### PR DESCRIPTION
Closes #5111

## What changed

- Added a typed `AutoMobileClient.callToolChecked` operation for daemon tool payloads using the `{success, message}` convention.
- Propagated `success: false`, MCP `isError: true`, and failed active-device selection as `McpConnectionException`, preserving the existing `WorkspaceViewModel` error path.
- Routed active-device selection plus rotate, snapshot, unlock, press-button, and locale controls through checked operations.
- Added regression tests using `FakeAutoMobileClient` for tool-level, MCP-envelope, and active-device failure propagation.

## Validation

- `:desktop-core:test`
- `scripts/all_fast_validate_checks.sh --only ktfmt`
