### PR TITLE
feat(desktop): gate locale and power by device kind

### DIFF
--- a/android/desktop-core/src/main/kotlin/dev/jasonpearson/automobile/desktop/core/workspace/WorkspaceModels.kt
+++ b/android/desktop-core/src/main/kotlin/dev/jasonpearson/automobile/desktop/core/workspace/WorkspaceModels.kt
@@ -59,6 +59,10 @@ enum class EmulatorControl(val icon: String, val label: String) {
   Unlock("🔓", "Unlock"), // 🔓
 }
 
+/** Whether this control is meaningful for the platform and device kind in a workspace column. */
+fun EmulatorControl.isSupportedOn(platform: Platform, isVirtual: Boolean): Boolean =
+  this != EmulatorControl.Locale || platform != Platform.Ios || isVirtual
+
 /**
  * Device system buttons offered by the [EmulatorControl.More] overflow menu. Each maps to a value
  * of the `pressButton` MCP tool. [toolValue] is the exact string the tool expects.
@@ -69,14 +73,9 @@ enum class DeviceButton(val icon: String, val label: String, val toolValue: Stri
   Recent("▤", "Recent apps", "recent"),
   Power("⏻", "Power", "power");
 
-  /**
-   * Whether the workspace offers this button on [platform]. Home/Back/Recent are supported on both
-   * platforms (iOS routes them through CtrlProxy), so all three stay in the menu; Power is a
-   * hardware key the iOS simulator cannot press, so it is Android-only here. Restoring Power for a
-   * *physical* iOS device needs the pane's device kind, which the picker does not yet carry — a
-   * follow-up.
-   */
-  fun isSupportedOn(platform: Platform): Boolean = this != Power || platform == Platform.Android
+  /** Whether the workspace offers this button on the platform and device kind. */
+  fun isSupportedOn(platform: Platform, isVirtual: Boolean = true): Boolean =
+    this != Power || platform == Platform.Android || !isVirtual
 }
 
 /** A locale offered by the [EmulatorControl.Locale] picker: a BCP-47 [tag] and a human [label]. */
@@ -122,4 +121,6 @@ data class DeviceColumn(
   val locked: Boolean = false,
   /** Current orientation; the Rotate control toggles it and drives the `rotate` tool value. */
   val orientation: Orientation = Orientation.Portrait,
+  /** Whether this is a simulator/emulator rather than a physical device. */
+  val isVirtual: Boolean = true,
 )

--- a/android/desktop-core/src/main/kotlin/dev/jasonpearson/automobile/desktop/core/workspace/WorkspaceShell.kt
+++ b/android/desktop-core/src/main/kotlin/dev/jasonpearson/automobile/desktop/core/workspace/WorkspaceShell.kt
@@ -812,6 +812,7 @@ private fun EmulatorControls(
     // one-shot device calls; Screenshot captures to disk; Locale/More open menus.
     EmulatorControl.entries
       .filter { it != EmulatorControl.Unlock || column.locked }
+      .filter { it.isSupportedOn(column.platform, column.isVirtual) }
       .forEach { control ->
         when (control) {
           EmulatorControl.Screenshot ->
@@ -863,7 +864,7 @@ private fun MoreControl(column: DeviceColumn, onAction: (WorkspaceAction) -> Uni
     }
     DropdownMenu(expanded = open, onDismissRequest = { open = false }) {
       DeviceButton.entries
-        .filter { it.isSupportedOn(column.platform) }
+        .filter { it.isSupportedOn(column.platform, column.isVirtual) }
         .forEach { button ->
           DropdownMenuItem(
             text = { Text("${button.icon}  ${button.label}") },

--- a/android/desktop-core/src/main/kotlin/dev/jasonpearson/automobile/desktop/core/workspace/picker/DevicePickerViewModel.kt
+++ b/android/desktop-core/src/main/kotlin/dev/jasonpearson/automobile/desktop/core/workspace/picker/DevicePickerViewModel.kt
@@ -345,7 +345,13 @@ class DevicePickerViewModel(
         .filter { it.id in selectedIds && it.state == DeviceState.Booted }
         .map {
           // Seed the pane's lock state from the booted snapshot; the host's poll keeps it fresh.
-          DeviceColumn(deviceId = it.id, name = it.name, platform = it.platform, locked = it.locked)
+          DeviceColumn(
+            deviceId = it.id,
+            name = it.name,
+            platform = it.platform,
+            locked = it.locked,
+            isVirtual = it.isVirtual,
+          )
         }
     if (columns.isNotEmpty()) {
       scope.launch { _effect.send(DevicePickerEffect.Observe(columns)) }

--- a/android/desktop-core/src/main/kotlin/dev/jasonpearson/automobile/desktop/core/workspace/picker/PickerModels.kt
+++ b/android/desktop-core/src/main/kotlin/dev/jasonpearson/automobile/desktop/core/workspace/picker/PickerModels.kt
@@ -30,6 +30,8 @@ data class PickerDevice(
   val architecture: String? = null,
   /** Whether the booted device's keyguard is up (from the booted resource). Shutdown -> false. */
   val locked: Boolean = false,
+  /** Whether the device is virtual; shutdown images are simulator/emulator definitions. */
+  val isVirtual: Boolean = true,
 )
 
 private val ANDROID_TARGET = Regex("android-(\\d+)")
@@ -95,6 +97,7 @@ fun buildPickerDevices(
       architecture = null,
       // Seed value only; an unknown (null) lock state seeds unlocked and the host poll refines it.
       locked = device.locked == true,
+      isVirtual = device.isVirtual,
     )
   }
 

--- a/android/desktop-core/src/test/kotlin/dev/jasonpearson/automobile/desktop/core/workspace/WorkspaceShellUiTest.kt
+++ b/android/desktop-core/src/test/kotlin/dev/jasonpearson/automobile/desktop/core/workspace/WorkspaceShellUiTest.kt
@@ -245,6 +245,38 @@ class WorkspaceShellUiTest {
     }
 
   @Test
+  fun `physical iOS offers Power and hides Locale`() = runComposeUiTest {
+    val state =
+      WorkspaceUiState.Content(
+        columns = listOf(col("a", "iPhone 15", Platform.Ios).copy(isVirtual = false)),
+        focusedDeviceId = "a",
+      )
+    setContent {
+      MaterialTheme { WorkspaceShell(state = state, onAction = {}, onOpenPicker = {}) }
+    }
+
+    onNodeWithContentDescription("Locale iPhone 15").assertDoesNotExist()
+    onNodeWithContentDescription("More iPhone 15").performClick()
+    onNodeWithContentDescription("Power iPhone 15").assertIsDisplayed()
+  }
+
+  @Test
+  fun `iOS simulator offers Locale and hides Power`() = runComposeUiTest {
+    val state =
+      WorkspaceUiState.Content(
+        columns = listOf(col("a", "iPhone 15", Platform.Ios).copy(isVirtual = true)),
+        focusedDeviceId = "a",
+      )
+    setContent {
+      MaterialTheme { WorkspaceShell(state = state, onAction = {}, onOpenPicker = {}) }
+    }
+
+    onNodeWithContentDescription("Locale iPhone 15").assertIsDisplayed()
+    onNodeWithContentDescription("More iPhone 15").performClick()
+    onNodeWithContentDescription("Power iPhone 15").assertDoesNotExist()
+  }
+
+  @Test
   fun `active tool renders a docked facet with a close control`() = runComposeUiTest {
     val state =
       WorkspaceUiState.Content(

--- a/android/desktop-core/src/test/kotlin/dev/jasonpearson/automobile/desktop/core/workspace/picker/DevicePickerViewModelTest.kt
+++ b/android/desktop-core/src/test/kotlin/dev/jasonpearson/automobile/desktop/core/workspace/picker/DevicePickerViewModelTest.kt
@@ -96,6 +96,7 @@ class DevicePickerViewModelTest {
       val columns = (effect as DevicePickerEffect.Observe).columns
       assertEquals(listOf("emulator-5554"), columns.map { it.deviceId })
       assertEquals(Platform.Android, columns.first().platform)
+      assertTrue(columns.first().isVirtual)
       cancelAndIgnoreRemainingEvents()
     }
   }

--- a/android/desktop-core/src/test/kotlin/dev/jasonpearson/automobile/desktop/core/workspace/picker/PickerModelsTest.kt
+++ b/android/desktop-core/src/test/kotlin/dev/jasonpearson/automobile/desktop/core/workspace/picker/PickerModelsTest.kt
@@ -71,4 +71,25 @@ class PickerModelsTest {
     assertEquals(listOf("udid-1"), devices.map { it.id })
     assertTrue(devices.single().state == DeviceState.Booted)
   }
+
+  @Test
+  fun `booted device preserves its virtual kind for workspace controls`() {
+    val physical =
+      buildPickerDevices(
+        booted =
+          listOf(
+            BootedDeviceInfo(
+              name = "iPhone 15",
+              platform = "ios",
+              deviceId = "udid-1",
+              source = "local",
+              isVirtual = false,
+              status = "booted",
+            )
+          ),
+        images = emptyList(),
+      )
+
+    assertEquals(false, physical.single().isVirtual)
+  }
 }


### PR DESCRIPTION
## Summary

- thread `isVirtual` from booted picker devices into workspace columns
- show Locale on Android and iOS simulators, but not physical iOS
- show Power on Android and physical iOS, but not iOS simulators
- add picker and workspace UI coverage

Closes #5112

## Validation

- `bun run turbo:validate`
- `bun run typecheck`
- `scripts/all_fast_validate_checks.sh --only ktfmt`