### PR TITLE
fix(performance): refine perfSnapshot windowing

### DIFF
--- a/src/features/performance/PerfWindowBuffer.ts
+++ b/src/features/performance/PerfWindowBuffer.ts
@@ -100,7 +100,9 @@ export class PerfWindowBuffer {
       sampleCount: inWindow.length,
       oldestSampleAgeMs: oldest !== null ? now - oldest.t : null,
       fps: percentileSummary(collect(inWindow, s => s.fps)),
-      jank: jankSummary(inWindow),
+      // A jank sample describes the interval ending at its timestamp. A
+      // sample exactly on the cutoff therefore began before this window.
+      jank: jankSummary(inWindow.filter(sample => sample.t > cutoff)),
       touchLatencyMs: touchLatencySummary(inWindow),
       cpu: averageLatestSummary(collect(inWindow, s => s.cpuUsagePercent)),
       memoryMb: averageLatestSummary(collect(inWindow, s => s.memoryUsageMb)),

--- a/src/features/performance/PerformanceMonitor.ts
+++ b/src/features/performance/PerformanceMonitor.ts
@@ -115,6 +115,8 @@ interface MonitoredDevice {
   cachedPid: number | null;
   /** Previous Android process CPU sample for interval-delta calculation */
   previousCpuSample: PreviousCpuSample | null;
+  /** Whether the cumulative first gfxinfo sample has already been primed */
+  gfxPrimed: boolean;
   /** Previous per-metric health for detecting threshold crossings */
   previousMetricHealth: Record<string, string>;
 }
@@ -241,6 +243,7 @@ export class PerformanceMonitor {
         existing.lastSlowTick = 0;
         existing.prevJankCounters = null;
         existing.previousCpuSample = null;
+        existing.gfxPrimed = false;
         // Bump the generation so any A→B→A in-flight sample is rejected even
         // though the package name matches again.
         existing.monitoringGeneration += 1;
@@ -270,6 +273,7 @@ export class PerformanceMonitor {
       prevJankCounters: null,
       cachedPid: null,
       previousCpuSample: null,
+      gfxPrimed: false,
       previousMetricHealth: {},
     });
     logger.info(`[PerformanceMonitor] Started monitoring ${packageName} on ${deviceId} (${platform})`);
@@ -399,6 +403,7 @@ export class PerformanceMonitor {
     );
 
     const gfxPromise = sdkFrame ? Promise.resolve(null) : this.collectGfxMetrics(device);
+    const recordFrameMetrics = sdkFrame !== null || device.gfxPrimed;
 
     // Collect medium metrics (CPU) if interval elapsed or first collection. The
     // collect calls do NOT mutate `device` — caches/timestamps are updated only
@@ -427,6 +432,9 @@ export class PerformanceMonitor {
     }
 
     device.lastFastTick = now;
+    if (!sdkFrame) {
+      device.gfxPrimed = true;
+    }
     if (shouldCollectCpu) {
       device.lastMediumTick = now;
       device.cachedCpu = cpu;
@@ -518,9 +526,10 @@ export class PerformanceMonitor {
     // flicker to 0, but the buffer must NOT re-record a stale reading every idle
     // tick — that would keep an old fps dominating the percentiles.
     this.pushMetrics(device, now, metrics, jankFrames, server, {
-      fps: rawFps,
-      frameTimeMs: rawFrameTimeMs,
-      touchLatencyMs: rawTouchLatencyMs,
+      fps: recordFrameMetrics ? rawFps : null,
+      frameTimeMs: recordFrameMetrics ? rawFrameTimeMs : null,
+      jankFrames: recordFrameMetrics ? jankFrames : null,
+      touchLatencyMs: recordFrameMetrics ? rawTouchLatencyMs : null,
       // CPU/memory only when actually collected this tick (null otherwise), so
       // the window never averages a reading acquired outside it.
       cpuUsagePercent: shouldCollectCpu ? cpu : null,
@@ -624,6 +633,7 @@ export class PerformanceMonitor {
     this.pushMetrics(device, now, metrics, jankFrames, server, {
       fps,
       frameTimeMs,
+      jankFrames: null,
       touchLatencyMs: null,
       cpuUsagePercent: shouldCollectCpu ? cpu : null,
       memoryUsageMb: shouldCollectMemory ? memory : null,
@@ -655,6 +665,7 @@ export class PerformanceMonitor {
     raw: {
       fps: number | null;
       frameTimeMs: number | null;
+      jankFrames: number | null;
       touchLatencyMs: number | null;
       cpuUsagePercent: number | null;
       memoryUsageMb: number | null;
@@ -681,7 +692,7 @@ export class PerformanceMonitor {
       t: now,
       fps: raw.fps,
       frameTimeMs: raw.frameTimeMs,
-      jankFrames: metrics.jankFrames,
+      jankFrames: raw.jankFrames,
       touchLatencyMs: raw.touchLatencyMs,
       cpuUsagePercent: raw.cpuUsagePercent,
       memoryUsageMb: raw.memoryUsageMb,

--- a/src/features/performance/PerformanceMonitor.ts
+++ b/src/features/performance/PerformanceMonitor.ts
@@ -432,7 +432,7 @@ export class PerformanceMonitor {
     }
 
     device.lastFastTick = now;
-    if (!sdkFrame) {
+    if (!sdkFrame && gfx?.resetSucceeded) {
       device.gfxPrimed = true;
     }
     if (shouldCollectCpu) {
@@ -810,7 +810,9 @@ export class PerformanceMonitor {
    * Resets gfxinfo after reading to get fresh data for the next interval.
    * Jank delta calculation happens in sampleDevice.
    */
-  private async collectGfxMetrics(device: MonitoredDevice): Promise<GfxMetrics & { rawJankCounters: RawJankCounters | null }> {
+  private async collectGfxMetrics(
+    device: MonitoredDevice
+  ): Promise<GfxMetrics & { rawJankCounters: RawJankCounters | null; resetSucceeded: boolean }> {
     try {
       const adb = this.adbClientFactory.create({
         deviceId: device.deviceId,
@@ -855,10 +857,19 @@ export class PerformanceMonitor {
         highInputLatencyFrames,
         totalFrames,
         rawJankCounters: { missedVsync, slowUi, deadlineMissed, jankyFrames },
+        resetSucceeded: true,
       };
     } catch (error) {
       logger.debug(`[PerformanceMonitor] gfxinfo failed for ${device.deviceId}: ${error}`);
-      return { fps: null, frameTimeMs: null, jankFrames: null, highInputLatencyFrames: null, totalFrames: null, rawJankCounters: null };
+      return {
+        fps: null,
+        frameTimeMs: null,
+        jankFrames: null,
+        highInputLatencyFrames: null,
+        totalFrames: null,
+        rawJankCounters: null,
+        resetSucceeded: false,
+      };
     }
   }
 

--- a/test/fakes/FakeAdbClient.ts
+++ b/test/fakes/FakeAdbClient.ts
@@ -191,6 +191,10 @@ export class FakeAdbClient implements FakeAdbClientContract {
     this.commandErrors.set(command, error);
   }
 
+  clearCommandError(command: string): void {
+    this.commandErrors.delete(command);
+  }
+
   /**
    * Configure the current foreground app
    */

--- a/test/features/performance/PerfWindowBuffer.test.ts
+++ b/test/features/performance/PerfWindowBuffer.test.ts
@@ -151,6 +151,18 @@ describe("PerfWindowBuffer", () => {
       expect(snap.jank!.total).toBe(4);
       expect(snap.jank!.perSecond).toBeNull();
     });
+
+    it("excludes the sample exactly at the window cutoff from jank", () => {
+      const buffer = new PerfWindowBuffer();
+      buffer.record("device-1", sample({ t: 1000, jankFrames: 2 }));
+      buffer.record("device-1", sample({ t: 1500, jankFrames: 3 }));
+      buffer.record("device-1", sample({ t: 2000, jankFrames: 5 }));
+
+      const snap = buffer.snapshot("device-1", 2000, 1000);
+      expect(snap.sampleCount).toBe(3);
+      expect(snap.jank!.total).toBe(8);
+      expect(snap.jank!.perSecond).toBe(8);
+    });
   });
 
   describe("touch latency, cpu, memory", () => {

--- a/test/features/performance/PerformanceMonitor.test.ts
+++ b/test/features/performance/PerformanceMonitor.test.ts
@@ -620,7 +620,7 @@ describe("PerformanceMonitor", () => {
       monitor.start();
       monitor.startMonitoring("device-1", "com.example.app");
 
-      await advanceTimeAndWait(fakeTimer, PerformanceMonitor.TICK_INTERVAL_MS);
+      await advanceTimeAndWait(fakeTimer, PerformanceMonitor.TICK_INTERVAL_MS * 2);
 
       // The tick pushed metrics, so the buffer holds at least one sample and the
       // snapshot exposes the gfxinfo-derived fps and dumpsys-derived cpu/memory.
@@ -628,6 +628,65 @@ describe("PerformanceMonitor", () => {
       expect(snap.sampleCount).toBeGreaterThanOrEqual(1);
       expect(snap.fps).not.toBeNull();
       expect(snap.memoryMb).not.toBeNull();
+    });
+
+    it("primes the first gfxinfo sample without recording cumulative frame metrics", async () => {
+      const buffer = new PerfWindowBuffer();
+      monitor = new PerformanceMonitor(
+        fakeTimer,
+        fakeAdbFactory,
+        serverGetter,
+        undefined,
+        undefined,
+        undefined,
+        buffer
+      );
+      monitor.start();
+      monitor.startMonitoring("device-1", "com.example.app");
+
+      await advanceTimeAndWait(fakeTimer, PerformanceMonitor.TICK_INTERVAL_MS);
+      const first = buffer.snapshot("device-1", fakeTimer.now(), 60000);
+      expect(first.sampleCount).toBe(1);
+      expect(first.fps).toBeNull();
+      expect(first.jank).toBeNull();
+
+      await advanceTimeAndWait(fakeTimer, PerformanceMonitor.TICK_INTERVAL_MS);
+      const second = buffer.snapshot("device-1", fakeTimer.now(), 60000);
+      expect(second.fps?.p50).toBe(60);
+      expect(second.jank?.total).toBe(6);
+    });
+
+    it("re-primes gfxinfo after switching the monitored package", async () => {
+      const buffer = new PerfWindowBuffer();
+      fakeAdbClient.setCommandResult(
+        "shell dumpsys gfxinfo com.other.app reset",
+        `
+          Total frames rendered: 100
+          50th percentile: 8.5ms
+          Missed Vsync: 2
+          Slow UI thread: 1
+          Frame deadline missed: 3
+        `
+      );
+      monitor = new PerformanceMonitor(
+        fakeTimer,
+        fakeAdbFactory,
+        serverGetter,
+        undefined,
+        undefined,
+        undefined,
+        buffer
+      );
+      monitor.start();
+      monitor.startMonitoring("device-1", "com.example.app");
+      await advanceTimeAndWait(fakeTimer, PerformanceMonitor.TICK_INTERVAL_MS * 2);
+
+      monitor.startMonitoring("device-1", "com.other.app");
+      await advanceTimeAndWait(fakeTimer, PerformanceMonitor.TICK_INTERVAL_MS);
+
+      const firstOtherPackageSample = buffer.snapshot("device-1", fakeTimer.now(), 60000);
+      expect(firstOtherPackageSample.fps).toBeNull();
+      expect(firstOtherPackageSample.jank).toBeNull();
     });
 
     it("prefers gfxinfo's aggregate Janky frames over summing overlapping causes", async () => {

--- a/test/features/performance/PerformanceMonitor.test.ts
+++ b/test/features/performance/PerformanceMonitor.test.ts
@@ -656,6 +656,36 @@ describe("PerformanceMonitor", () => {
       expect(second.jank?.total).toBe(6);
     });
 
+    it("keeps priming after an initial gfxinfo collection failure", async () => {
+      const buffer = new PerfWindowBuffer();
+      const gfxinfoCommand = "shell dumpsys gfxinfo com.example.app reset";
+      fakeAdbClient.setCommandError(gfxinfoCommand, new Error("temporary ADB failure"));
+      monitor = new PerformanceMonitor(
+        fakeTimer,
+        fakeAdbFactory,
+        serverGetter,
+        undefined,
+        undefined,
+        undefined,
+        buffer
+      );
+      monitor.start();
+      monitor.startMonitoring("device-1", "com.example.app");
+
+      await advanceTimeAndWait(fakeTimer, PerformanceMonitor.TICK_INTERVAL_MS);
+      fakeAdbClient.clearCommandError(gfxinfoCommand);
+      await advanceTimeAndWait(fakeTimer, PerformanceMonitor.TICK_INTERVAL_MS);
+
+      const firstSuccessfulSample = buffer.snapshot("device-1", fakeTimer.now(), 60000);
+      expect(firstSuccessfulSample.fps).toBeNull();
+      expect(firstSuccessfulSample.jank).toBeNull();
+
+      await advanceTimeAndWait(fakeTimer, PerformanceMonitor.TICK_INTERVAL_MS);
+      const secondSuccessfulSample = buffer.snapshot("device-1", fakeTimer.now(), 60000);
+      expect(secondSuccessfulSample.fps?.p50).toBe(60);
+      expect(secondSuccessfulSample.jank?.total).toBe(6);
+    });
+
     it("re-primes gfxinfo after switching the monitored package", async () => {
       const buffer = new PerfWindowBuffer();
       fakeAdbClient.setCommandResult(


### PR DESCRIPTION
## Summary
- prime the first cumulative gfxinfo sample for each monitoring generation
- preserve raw jank values for window aggregation
- exclude the cutoff interval from jank summaries

## Validation
- `bun test test/features/performance/PerformanceMonitor.test.ts test/features/performance/PerfWindowBuffer.test.ts` (65 pass)
- `bun run typecheck` (no new errors; 185 baseline errors)
- `git diff --check`
- Turbo lint/build/boundary tasks completed; the repository-wide test task was stopped after a 26-minute CPU-bound Bun run without a result

Closes #5110