### PR TITLE
refactor(video-server): share session token validation regex

### DIFF
--- a/android/video-server/src/main/kotlin/dev/jasonpearson/automobile/video/VideoHandshake.kt
+++ b/android/video-server/src/main/kotlin/dev/jasonpearson/automobile/video/VideoHandshake.kt
@@ -49,9 +49,6 @@ object VideoHandshake {
   const val MIN_TOKEN_LENGTH = 8
   const val MAX_TOKEN_LENGTH = 80
 
-  /** Mirrors `VideoSessionArguments.SAFE_TOKEN`; the on-wire token must satisfy the same shape. */
-  private val SAFE_TOKEN = Regex("[A-Za-z0-9-]{8,80}")
-
   sealed interface Result {
     /** A well-formed handshake carrying the expected token arrived. */
     object Accepted : Result
@@ -95,7 +92,7 @@ object VideoHandshake {
       connection.readFully(tokenLength, remainingMs)
         ?: return Result.Rejected("token-timeout-or-eof")
     val token = String(tokenBytes, Charsets.US_ASCII)
-    if (!SAFE_TOKEN.matches(token)) {
+    if (!VideoSessionArguments.SAFE_TOKEN.matches(token)) {
       return Result.Rejected("unsafe-token")
     }
     // MessageDigest.isEqual is the JDK's constant-time byte-array compare: it does not

--- a/android/video-server/src/main/kotlin/dev/jasonpearson/automobile/video/VideoSessionLease.kt
+++ b/android/video-server/src/main/kotlin/dev/jasonpearson/automobile/video/VideoSessionLease.kt
@@ -75,7 +75,7 @@ internal fun sessionTokenSha256Hex(token: String): String =
 object VideoSessionArguments {
   private const val DEFAULT_SOCKET_NAME = "automobile_video"
   private val SAFE_SOCKET_NAME = Regex("[A-Za-z0-9_.-]{1,100}")
-  private val SAFE_TOKEN = Regex("[A-Za-z0-9-]{8,80}")
+  internal val SAFE_TOKEN = Regex("[A-Za-z0-9-]{8,80}")
 
   fun parse(args: Array<String>): VideoSessionOptions {
     val socketName = valueAfter(args, "--socket-name") ?: DEFAULT_SOCKET_NAME


### PR DESCRIPTION
## Summary

- make `VideoSessionArguments.SAFE_TOKEN` the single token-shape definition
- reuse it for on-wire handshake validation
- preserve existing token acceptance and rejection behavior

Closes #5041

## Validation

- `./gradlew --no-daemon -Dorg.gradle.java.home=/Library/Java/JavaVirtualMachines/cached-bazel-jdk/Contents/Home -Dorg.gradle.jvmargs="-Xmx3g -Xms512m -Dfile.encoding=UTF-8" :video-server:test --tests "dev.jasonpearson.automobile.video.VideoHandshakeTest" --tests "dev.jasonpearson.automobile.video.VideoServerArgumentsTest"`
- `scripts/ktfmt/validate_ktfmt.sh`

Co-Authored-By: Codex <svc-devxp-Codex@slack-corp.com>