### PR TITLE
fix(video-server): request recovery IDR after dropped frames

### DIFF
--- a/android/video-server/src/main/kotlin/dev/jasonpearson/automobile/video/FrameHandoff.kt
+++ b/android/video-server/src/main/kotlin/dev/jasonpearson/automobile/video/FrameHandoff.kt
@@ -51,6 +51,7 @@ class FrameHandoff {
   private var slot: EncodedVideoFrame? = null
   private var closed = false
   private var dropped = 0L
+  private var dropGapArmed = false
 
   /**
    * Offer an encoded packet to the writer. Never blocks the caller (the encode loop).
@@ -68,11 +69,13 @@ class FrameHandoff {
         // Sticky critical: never overwrite an unsent config/keyframe. Drop the newcomer;
         // the encoder re-emits an IDR on the next GOP boundary or keyframe request.
         dropped++
+        dropGapArmed = true
         return true
       }
       else -> {
         // Slot holds a delta; the newer packet supersedes it (drop-oldest / latest-wins).
         dropped++
+        dropGapArmed = true
         slot = frame
       }
     }
@@ -110,6 +113,20 @@ class FrameHandoff {
 
   /** Total packets discarded by the drop-oldest policy since construction. */
   fun droppedCount(): Long = lock.withLock { dropped }
+
+  /**
+   * Consume the data-loss signal raised by a discarded packet.
+   *
+   * The signal is level-triggered: a burst of drops produces one recovery request until the encode
+   * loop consumes it, while a later drop arms a new request.
+   */
+  fun consumeDropGap(): Boolean = lock.withLock {
+    if (!dropGapArmed) {
+      return false
+    }
+    dropGapArmed = false
+    true
+  }
 
   /** The currently-slotted packet without removing it; for tests and diagnostics. */
   fun peek(): EncodedVideoFrame? = lock.withLock { slot }

--- a/android/video-server/src/main/kotlin/dev/jasonpearson/automobile/video/FrameHeartbeat.kt
+++ b/android/video-server/src/main/kotlin/dev/jasonpearson/automobile/video/FrameHeartbeat.kt
@@ -61,13 +61,19 @@ class FrameHeartbeat(
     keyFrameNudges = 0
   }
 
-  /** Record a keyframe request (a relayed WHEP viewer PLI). Coalesces repeats. */
+  /**
+   * Record a keyframe request (a relayed WHEP viewer PLI). Coalesces repeats.
+   *
+   * @return true when this call created a new pending request.
+   */
   @Synchronized
-  fun onKeyFrameRequested() {
+  fun onKeyFrameRequested(): Boolean {
     if (keyFramePendingSinceMs == null) {
       keyFramePendingSinceMs = clock.nowMs()
       keyFrameNudges = 0
+      return true
     }
+    return false
   }
 
   /**

--- a/android/video-server/src/main/kotlin/dev/jasonpearson/automobile/video/VideoServer.kt
+++ b/android/video-server/src/main/kotlin/dev/jasonpearson/automobile/video/VideoServer.kt
@@ -366,6 +366,8 @@ object VideoServer {
         }
       }
 
+      recoverFromFrameDrop(currentWriter::consumeDropGap, encoder!!::requestKeyFrame, heartbeat)
+
       // Backstop the encoder's own idle repeats: if the mirror has gone quiet (or a
       // keyframe request produced nothing), nudge it into re-submitting a fresh frame.
       if (heartbeat.poll()) {
@@ -452,6 +454,24 @@ object VideoServer {
    * null-tolerance is unit-testable without the Android capture stack.
    */
   internal fun <T : Any> encodeLoopSnapshot(field: T?): T? = field
+
+  /**
+   * Request one recovery IDR after a handoff drop. The handoff signal coalesces a drop burst, while
+   * [FrameHeartbeat] coalesces concurrent keyframe requests and supplies the surface nudge.
+   */
+  internal fun recoverFromFrameDrop(
+    consumeDropGap: () -> Boolean,
+    requestKeyFrame: () -> Unit,
+    heartbeat: FrameHeartbeat,
+  ): Boolean {
+    if (!consumeDropGap()) {
+      return false
+    }
+    if (heartbeat.onKeyFrameRequested()) {
+      requestKeyFrame()
+    }
+    return true
+  }
 
   private fun shutdown() {
     running = false

--- a/android/video-server/src/main/kotlin/dev/jasonpearson/automobile/video/VideoStreamWriter.kt
+++ b/android/video-server/src/main/kotlin/dev/jasonpearson/automobile/video/VideoStreamWriter.kt
@@ -515,6 +515,9 @@ class VideoStreamWriter(
    */
   fun reconnectWindowExpired(): Boolean = reconnectWindow.isExpired()
 
+  /** Consume the handoff's coalesced data-loss signal for encode-loop recovery. */
+  internal fun consumeDropGap(): Boolean = handoff.consumeDropGap()
+
   /**
    * Atomically clear the replay cache for a device-rotation encoder swap (issue #4785).
    *

--- a/android/video-server/src/test/kotlin/dev/jasonpearson/automobile/video/FrameHandoffTest.kt
+++ b/android/video-server/src/test/kotlin/dev/jasonpearson/automobile/video/FrameHandoffTest.kt
@@ -61,6 +61,30 @@ class FrameHandoffTest {
   }
 
   @Test
+  fun droppedFrameArmsOneConsumableGap() {
+    val handoff = FrameHandoff()
+
+    handoff.offer(delta())
+    handoff.offer(delta())
+
+    assertTrue(handoff.consumeDropGap())
+    assertFalse(handoff.consumeDropGap())
+  }
+
+  @Test
+  fun eachDropAfterConsumptionArmsAnotherGap() {
+    val handoff = FrameHandoff()
+
+    handoff.offer(delta())
+    handoff.offer(delta())
+    assertTrue(handoff.consumeDropGap())
+
+    handoff.offer(delta())
+    assertTrue(handoff.consumeDropGap())
+    assertFalse(handoff.consumeDropGap())
+  }
+
+  @Test
   fun deltaNeverEvictsUnsentKeyFrame() {
     val handoff = FrameHandoff()
     val idr = keyFrame()

--- a/android/video-server/src/test/kotlin/dev/jasonpearson/automobile/video/VideoServerEncodeLoopTest.kt
+++ b/android/video-server/src/test/kotlin/dev/jasonpearson/automobile/video/VideoServerEncodeLoopTest.kt
@@ -1,6 +1,7 @@
 package dev.jasonpearson.automobile.video
 
 import org.junit.Assert.assertEquals
+import org.junit.Assert.assertFalse
 import org.junit.Assert.assertNull
 import org.junit.Assert.assertSame
 import org.junit.Assert.assertTrue
@@ -57,4 +58,69 @@ class VideoServerEncodeLoopTest {
     assertEquals("loop should run twice on the live writer before shutdown nulls it", 2, iterations)
     assertTrue("loop should exit via the null snapshot, not a deref throw", brokeOnNull)
   }
+
+  @Test
+  fun dropGapRequestsOneRecoveryKeyFramePerDropBurst() {
+    val handoff = FrameHandoff()
+    val clock = FakeClock()
+    val heartbeat =
+      FrameHeartbeat(clock, idleForceIntervalMs = 10_000, keyFrameGraceMs = 150).also { it.start() }
+    var requests = 0
+
+    handoff.offer(frame(0))
+    handoff.offer(frame(1))
+
+    assertTrue(VideoServer.recoverFromFrameDrop(handoff::consumeDropGap, { requests++ }, heartbeat))
+    assertFalse(
+      VideoServer.recoverFromFrameDrop(handoff::consumeDropGap, { requests++ }, heartbeat)
+    )
+    assertEquals(1, requests)
+
+    heartbeat.onFrameEmitted()
+    handoff.offer(frame(2))
+    assertTrue(VideoServer.recoverFromFrameDrop(handoff::consumeDropGap, { requests++ }, heartbeat))
+    assertEquals(2, requests)
+  }
+
+  @Test
+  fun noDropDoesNotRequestRecoveryKeyFrame() {
+    val handoff = FrameHandoff()
+    val heartbeat =
+      FrameHeartbeat(FakeClock(), idleForceIntervalMs = 10_000, keyFrameGraceMs = 150).also {
+        it.start()
+      }
+    var requests = 0
+
+    assertFalse(
+      VideoServer.recoverFromFrameDrop(handoff::consumeDropGap, { requests++ }, heartbeat)
+    )
+    assertEquals(0, requests)
+  }
+
+  @Test
+  fun dropRecoveryDoesNotDuplicateAnOutstandingKeyFrameRequest() {
+    val handoff = FrameHandoff()
+    val heartbeat =
+      FrameHeartbeat(FakeClock(), idleForceIntervalMs = 10_000, keyFrameGraceMs = 150).also {
+        it.start()
+      }
+    var requests = 0
+    heartbeat.onKeyFrameRequested()
+
+    handoff.offer(frame(0))
+    handoff.offer(frame(1))
+
+    assertTrue(VideoServer.recoverFromFrameDrop(handoff::consumeDropGap, { requests++ }, heartbeat))
+    assertEquals(0, requests)
+  }
+
+  private class FakeClock(var nowMs: Long = 0) : FrameHeartbeat.Clock {
+    override fun nowMs(): Long = nowMs
+  }
+
+  private fun frame(pts: Long): EncodedVideoFrame =
+    EncodedVideoFrame(
+      VideoStreamProtocol.ptsAndFlags(pts, isConfig = false, isKeyFrame = false),
+      byteArrayOf(1),
+    )
 }


### PR DESCRIPTION
## Summary

- arm a coalesced data-loss signal whenever `FrameHandoff` discards a packet
- consume the signal in the encode loop and request a recovery IDR
- coalesce recovery requests while an earlier keyframe request is outstanding
- add deterministic JVM coverage for drop-gap and burst behavior

Closes #5042

## Validation

- `bun run turbo:validate` (12,957 pass, 13 skipped)
- `bun run typecheck` (no new errors; 185 known baseline errors)
- focused `:video-server:test` for `FrameHandoffTest`, `FrameHeartbeatTest`, and `VideoServerEncodeLoopTest`
- `scripts/ktfmt/validate_ktfmt.sh`

Co-Authored-By: Codex <svc-devxp-Codex@slack-corp.com>