### PR TITLE
feat(video-server): emit periodic VIDEO_STATS lines

### DIFF
--- a/android/video-server/src/main/kotlin/dev/jasonpearson/automobile/video/VideoServer.kt
+++ b/android/video-server/src/main/kotlin/dev/jasonpearson/automobile/video/VideoServer.kt
@@ -272,6 +272,13 @@ object VideoServer {
     val heartbeat =
       FrameHeartbeat(clock = FrameHeartbeat.Clock { android.os.SystemClock.uptimeMillis() })
     heartbeat.start()
+    val stats =
+      VideoStatsAccumulator(
+          socketName = session.socketName,
+          clock = VideoStatsAccumulator.Clock { android.os.SystemClock.uptimeMillis() },
+          droppedCount = { streamWriter?.droppedCount() ?: 0L },
+        )
+        .also { it.start() }
 
     // The writer keeps the encoder alive while its LocalSocket client reconnects, replays cached
     // decoder state, and requests a new IDR at attach.
@@ -355,6 +362,13 @@ object VideoServer {
             println("Client disconnected")
             break
           }
+          if (
+            shouldCountVideoStatsFrame(
+              isCodecConfig = (bufferInfo.flags and MediaCodec.BUFFER_FLAG_CODEC_CONFIG) != 0
+            )
+          ) {
+            stats.onFrame(bufferInfo.size)
+          }
         }
         encoder!!.releaseOutputBuffer(index)
         heartbeat.onFrameEmitted()
@@ -373,6 +387,8 @@ object VideoServer {
       if (heartbeat.poll()) {
         capture?.forceFrame()
       }
+
+      stats.poll()?.let(::println)
 
       if (currentWriter.reconnectWindowExpired()) {
         println("VIDEO_CLIENT_RECONNECT_EXPIRED socket=${session.socketName}")
@@ -454,6 +470,8 @@ object VideoServer {
    * null-tolerance is unit-testable without the Android capture stack.
    */
   internal fun <T : Any> encodeLoopSnapshot(field: T?): T? = field
+
+  internal fun shouldCountVideoStatsFrame(isCodecConfig: Boolean): Boolean = !isCodecConfig
 
   /**
    * Request one recovery IDR after a handoff drop. The handoff signal coalesces a drop burst, while

--- a/android/video-server/src/main/kotlin/dev/jasonpearson/automobile/video/VideoStatsAccumulator.kt
+++ b/android/video-server/src/main/kotlin/dev/jasonpearson/automobile/video/VideoStatsAccumulator.kt
@@ -1,0 +1,82 @@
+package dev.jasonpearson.automobile.video
+
+import java.util.Locale
+
+/**
+ * Pure, clock-injected stream-health accounting for the machine-parseable `VIDEO_STATS` line.
+ *
+ * The line is emitted every [intervalMs] at an exact interval boundary: `VIDEO_STATS socket=<name>
+ * fps=<interval fps> bytesOut=<cumulative bytes> dropped=<cumulative drops> uptimeMs=<elapsed
+ * uptime>`.
+ */
+class VideoStatsAccumulator(
+  private val socketName: String,
+  private val clock: Clock,
+  private val intervalMs: Long = DEFAULT_INTERVAL_MS,
+  private val droppedCount: () -> Long,
+) {
+  fun interface Clock {
+    fun nowMs(): Long
+  }
+
+  private var startedAtMs = 0L
+  private var intervalStartedAtMs = 0L
+  private var intervalFrames = 0L
+  private var bytesOut = 0L
+  private var started = false
+
+  init {
+    require(intervalMs > 0) { "intervalMs must be positive" }
+  }
+
+  /** Baseline uptime so the first stats line is emitted only after a full interval. */
+  fun start() {
+    startedAtMs = clock.nowMs()
+    intervalStartedAtMs = startedAtMs
+    intervalFrames = 0
+    bytesOut = 0
+    started = true
+  }
+
+  /** Record one encoded output frame and its payload size. */
+  fun onFrame(bytes: Int) {
+    check(started) { "VideoStatsAccumulator must be started before recording frames" }
+    require(bytes >= 0) { "frame bytes must be non-negative" }
+    intervalFrames++
+    bytesOut += bytes
+  }
+
+  /**
+   * Return one stable stats line once the current interval has elapsed, otherwise null.
+   *
+   * Frame rate is calculated over the elapsed interval; bytes and drops are cumulative for the
+   * session. Polling after a long scheduling gap emits one line and starts the next interval at the
+   * current clock value.
+   */
+  fun poll(): String? {
+    check(started) { "VideoStatsAccumulator must be started before polling" }
+    val nowMs = clock.nowMs()
+    val elapsedMs = nowMs - intervalStartedAtMs
+    if (elapsedMs < intervalMs) {
+      return null
+    }
+    val fps = intervalFrames * 1_000.0 / elapsedMs
+    val line =
+      String.format(
+        Locale.US,
+        "VIDEO_STATS socket=%s fps=%.2f bytesOut=%d dropped=%d uptimeMs=%d",
+        socketName,
+        fps,
+        bytesOut,
+        droppedCount(),
+        nowMs - startedAtMs,
+      )
+    intervalStartedAtMs = nowMs
+    intervalFrames = 0
+    return line
+  }
+
+  companion object {
+    const val DEFAULT_INTERVAL_MS = 5_000L
+  }
+}

--- a/android/video-server/src/main/kotlin/dev/jasonpearson/automobile/video/VideoStreamWriter.kt
+++ b/android/video-server/src/main/kotlin/dev/jasonpearson/automobile/video/VideoStreamWriter.kt
@@ -518,6 +518,9 @@ class VideoStreamWriter(
   /** Consume the handoff's coalesced data-loss signal for encode-loop recovery. */
   internal fun consumeDropGap(): Boolean = handoff.consumeDropGap()
 
+  /** Total packets discarded by the transport handoff. */
+  internal fun droppedCount(): Long = handoff.droppedCount()
+
   /**
    * Atomically clear the replay cache for a device-rotation encoder swap (issue #4785).
    *

--- a/android/video-server/src/test/kotlin/dev/jasonpearson/automobile/video/VideoServerEncodeLoopTest.kt
+++ b/android/video-server/src/test/kotlin/dev/jasonpearson/automobile/video/VideoServerEncodeLoopTest.kt
@@ -60,6 +60,12 @@ class VideoServerEncodeLoopTest {
   }
 
   @Test
+  fun codecConfigBuffersDoNotCountAsVideoStatsFrames() {
+    assertFalse(VideoServer.shouldCountVideoStatsFrame(isCodecConfig = true))
+    assertTrue(VideoServer.shouldCountVideoStatsFrame(isCodecConfig = false))
+  }
+
+  @Test
   fun dropGapRequestsOneRecoveryKeyFramePerDropBurst() {
     val handoff = FrameHandoff()
     val clock = FakeClock()

--- a/android/video-server/src/test/kotlin/dev/jasonpearson/automobile/video/VideoStatsAccumulatorTest.kt
+++ b/android/video-server/src/test/kotlin/dev/jasonpearson/automobile/video/VideoStatsAccumulatorTest.kt
@@ -1,0 +1,78 @@
+package dev.jasonpearson.automobile.video
+
+import org.junit.Assert.assertEquals
+import org.junit.Assert.assertNull
+import org.junit.Test
+
+class VideoStatsAccumulatorTest {
+  private class FakeClock(var nowMs: Long = 0) : VideoStatsAccumulator.Clock {
+    override fun nowMs(): Long = nowMs
+  }
+
+  @Test
+  fun doesNotEmitBeforeTheIntervalAndFormatsTheExactBoundary() {
+    val clock = FakeClock()
+    var dropped = 4L
+    val stats =
+      VideoStatsAccumulator("video-1", clock, intervalMs = 5_000) { dropped }
+        .also {
+          it.start()
+        }
+
+    stats.onFrame(100)
+    stats.onFrame(200)
+    clock.nowMs = 4_999
+    assertNull(stats.poll())
+
+    clock.nowMs = 5_000
+    assertEquals(
+      "VIDEO_STATS socket=video-1 fps=0.40 bytesOut=300 dropped=4 uptimeMs=5000",
+      stats.poll(),
+    )
+  }
+
+  @Test
+  fun bytesAreCumulativeButFpsUsesOnlyTheCurrentInterval() {
+    val clock = FakeClock()
+    var dropped = 1L
+    val stats =
+      VideoStatsAccumulator("video-1", clock, intervalMs = 5_000) { dropped }
+        .also {
+          it.start()
+        }
+
+    stats.onFrame(100)
+    clock.nowMs = 5_000
+    assertEquals(
+      "VIDEO_STATS socket=video-1 fps=0.20 bytesOut=100 dropped=1 uptimeMs=5000",
+      stats.poll(),
+    )
+
+    stats.onFrame(250)
+    dropped = 2
+    clock.nowMs = 7_500
+    assertNull(stats.poll())
+
+    clock.nowMs = 10_000
+    assertEquals(
+      "VIDEO_STATS socket=video-1 fps=0.20 bytesOut=350 dropped=2 uptimeMs=10000",
+      stats.poll(),
+    )
+  }
+
+  @Test
+  fun zeroFramesStillEmitsAHealthLine() {
+    val clock = FakeClock()
+    val stats =
+      VideoStatsAccumulator("video-1", clock, intervalMs = 5_000) { 0L }
+        .also {
+          it.start()
+        }
+
+    clock.nowMs = 5_000
+    assertEquals(
+      "VIDEO_STATS socket=video-1 fps=0.00 bytesOut=0 dropped=0 uptimeMs=5000",
+      stats.poll(),
+    )
+  }
+}


### PR DESCRIPTION
## Summary
- add a clock-injected video stats accumulator with exact interval polling
- report interval FPS plus cumulative bytes and handoff drops
- wire stats into the Android video encode loop and add deterministic tests

Closes #5043

## Validation
- `:video-server:test`
- `../scripts/ktfmt/validate_ktfmt.sh`
- `bun run typecheck`
- root `bun run turbo:validate` emitted passing test output but did not terminate under Bun 1.3.14; stopped after 8m54s with no failure output