### PR TITLE
fix(android): exclude CtrlProxy rate limits from a11y strike counter

### DIFF
--- a/src/features/observe/android/AndroidCtrlProxyClient.ts
+++ b/src/features/observe/android/AndroidCtrlProxyClient.ts
@@ -64,6 +64,7 @@ import {
   type ScreenshotPerformanceMetadata,
 } from "../ScreenshotMetadata";
 import {
+  CTRLPROXY_RATE_LIMITED_ERROR,
   CTRLPROXY_SCREENSHOT_TIMEOUT_ERROR,
   fallbackReasonForCtrlProxyFailure,
 } from "./screenshotFallbackReason";
@@ -3396,6 +3397,11 @@ export class AndroidCtrlProxyClient extends DeviceServiceClient implements Andro
       const result = await screenshotPromise;
 
       if (!result.success || !result.data) {
+        if (result.error === CTRLPROXY_RATE_LIMITED_ERROR) {
+          this.a11yScreenshotFailures = 0;
+          return this.captureScreenshotViaAdb(fallbackReasonForCtrlProxyFailure(result.error));
+        }
+
         this.a11yScreenshotFailures++;
         if (this.a11yScreenshotSupported === null &&
             this.a11yScreenshotFailures >= AndroidCtrlProxyClient.A11Y_SCREENSHOT_MAX_FAILURES) {

--- a/test/features/observe/CtrlProxyClient.test.ts
+++ b/test/features/observe/CtrlProxyClient.test.ts
@@ -27,6 +27,7 @@ import {
 } from "../../../src/daemon/deviceDataStreamSocketServer";
 import { FakeSocket } from "../../fakes/FakeNetServer";
 import { FakeScreenshotBackoffScheduler } from "../../../src/features/observe/ScreenshotBackoffScheduler";
+import { CTRLPROXY_RATE_LIMITED_ERROR } from "../../../src/features/observe/android/screenshotFallbackReason";
 
 describe("AndroidCtrlProxyClient", function() {
   let accessibilityServiceClient: AndroidCtrlProxyClient;
@@ -606,7 +607,7 @@ describe("AndroidCtrlProxyClient", function() {
     const driveA11yScreenshot = async (
       client: AndroidCtrlProxyClient,
       socket: CapturingWebSocket,
-      resolveWith: { kind: "error" } | { kind: "success" }
+      resolveWith: { kind: "error"; error?: string } | { kind: "success" }
     ): Promise<any> => {
       const before = countScreenshotRequests(socket);
       const capturePromise = (client as any).captureScreenshotForObservationStream() as Promise<any>;
@@ -614,7 +615,11 @@ describe("AndroidCtrlProxyClient", function() {
       const request = findSentMessage(socket, "request_screenshot");
       expect(countScreenshotRequests(socket)).toBe(before + 1);
       const frame = resolveWith.kind === "error"
-        ? { type: "screenshot_error", requestId: request.requestId, error: "Runner failed to capture screenshot" }
+        ? {
+          type: "screenshot_error",
+          requestId: request.requestId,
+          error: resolveWith.error ?? "Runner failed to capture screenshot",
+        }
         : { type: "screenshot", requestId: request.requestId, data: "jpeg-base64", format: "jpeg", timestamp: 1 };
       socket.emit("message", JSON.stringify(frame));
       await flushPromises();
@@ -698,6 +703,26 @@ describe("AndroidCtrlProxyClient", function() {
       // Because the counter reset, two more failures still do not reach the latch threshold.
       await driveA11yScreenshot(client, socket, { kind: "error" });
       await driveA11yScreenshot(client, socket, { kind: "error" });
+      expect((client as any).a11yScreenshotSupported).not.toBe(false);
+    });
+
+    test("does not count rate-limited screenshots as unsupported failures", async function() {
+      const { client, socket } = await setupConnectedCapturingClient();
+
+      for (let attempt = 0; attempt < 3; attempt++) {
+        const result = await driveA11yScreenshot(client, socket, {
+          kind: "error",
+          error: CTRLPROXY_RATE_LIMITED_ERROR,
+        });
+        expect(result.screenshotFallbackReason).toBe("ctrlproxy_rate_limited");
+      }
+
+      expect((client as any).a11yScreenshotFailures).toBe(0);
+      expect((client as any).a11yScreenshotSupported).toBe(null);
+
+      const next = await driveA11yScreenshot(client, socket, { kind: "error" });
+      expect(next.screenshotFallbackReason).toBe("ctrlproxy_failed");
+      expect((client as any).a11yScreenshotFailures).toBe(1);
       expect((client as any).a11yScreenshotSupported).not.toBe(false);
     });
   });


### PR DESCRIPTION
## Summary
- keep CtrlProxy rate-limit screenshot responses out of the accessibility unsupported three-strike counter
- reset the consecutive failure counter for rate-limited responses before using the existing ADB fallback
- add regression coverage for repeated rate limits followed by a generic screenshot failure

## Validation
- `AUTOMOBILE_DATA_DIR=/private/tmp/auto-mobile-data-4997 bun test test/features/observe/CtrlProxyClient.test.ts test/features/observe/android/screenshotFallbackReason.test.ts`
- `AUTOMOBILE_DATA_DIR=/private/tmp/auto-mobile-data-4997 bun run typecheck`
- `AUTOMOBILE_DATA_DIR=/private/tmp/auto-mobile-data-4997 bun run turbo:validate`

Closes #4997