### PR TITLE
fix(release): tighten iOS simulator continuity proof (follow-up to #5120)

### DIFF
--- a/docs/release/ios-simulator-continuity.md
+++ b/docs/release/ios-simulator-continuity.md
@@ -106,7 +106,7 @@ these fields (all in the issue's required pre/post-deploy evidence list):
 | `hostIdentity` | `scutil --get LocalHostName` (or your stable host id) |
 | `automobileVersion` | AutoMobile package/version reported by the daemon |
 | `workerIncarnation` | worker process incarnation id (changes on replacement) |
-| `processSupervisor`, `processIds` | `launchctl` / `ps` for daemon, runner, `com.apple.CoreSimulator.CoreSimulatorService` |
+| `processSupervisor`, `processIds` | `launchctl` / `ps`. `processIds` **must** include positive-integer PIDs for the keys `daemon`, `runner`, and `coreSimulatorService` (`com.apple.CoreSimulator.CoreSimulatorService`); a missing role is `incomplete-evidence` |
 | `coreSimulatorDataRoot` | `~/Library/Developer/CoreSimulator/Devices/<udid>/data` |
 | `bootedSince` | boot time of the current session (used to detect a mid-window reboot) — **required for a proven verdict**: without it a reboot cannot be ruled out, so the result is `incomplete-evidence` |
 | `lifecycleState` | `booted` / `shutdown` / … from `simctl list` |

--- a/docs/release/ios-simulator-continuity.md
+++ b/docs/release/ios-simulator-continuity.md
@@ -108,7 +108,7 @@ these fields (all in the issue's required pre/post-deploy evidence list):
 | `workerIncarnation` | worker process incarnation id (changes on replacement) |
 | `processSupervisor`, `processIds` | `launchctl` / `ps`. `processIds` **must** include positive-integer PIDs for the keys `daemon`, `runner`, and `coreSimulatorService` (`com.apple.CoreSimulator.CoreSimulatorService`); a missing role is `incomplete-evidence` |
 | `coreSimulatorDataRoot` | `~/Library/Developer/CoreSimulator/Devices/<udid>/data` |
-| `bootedSince` | boot time of the current session (used to detect a mid-window reboot) — **required for a proven verdict**: without it a reboot cannot be ruled out, so the result is `incomplete-evidence` |
+| `bootedSince` | boot time of the current session (used to detect a boot-session change between the before and after captures) — **required for a proven verdict**: without it a reboot cannot be ruled out, so the result is `incomplete-evidence` |
 | `lifecycleState` | `booted` / `shutdown` / … from `simctl list` |
 | `responsive` | result of a responsiveness probe against the device |
 | `reportingStatus` | `reporting` / `delayed` / `lost` from the worker/AutoMobile status |
@@ -142,7 +142,7 @@ one verdict:
 | --- | --- | --- | --- |
 | `same-device-continuity` | Same UDID + data root, booted/responsive throughout, reporting restored. | yes | available |
 | `controlled-replacement` | Declared replacement; new device booted and responsive. | yes | available |
-| `boot-recovery` | Same UDID + data, but rebooted during the window (data safe, booted session did not survive). | no | maintenance |
+| `boot-recovery` | Same UDID + data, but the boot session changed between the before/after captures — a reboot at any point after the pre-deploy capture (data safe, booted session did not survive). | no | maintenance |
 | `shutdown` | Same device is no longer booted and did not recover. | no | maintenance |
 | `reporting-delay` | Device continuous but worker reporting delayed/lost. | no | maintenance |
 | `orphaned-or-erased-state` | UDID, data root, or host identity changed with no declared replacement (also: a controlled replacement of a device that had active work). | no | maintenance |

--- a/src/utils/iosSimulatorContinuity.ts
+++ b/src/utils/iosSimulatorContinuity.ts
@@ -182,7 +182,9 @@ const ISO_8601 =
 
 /** True when (year, month, day) is a real calendar date that Date.parse would not normalize. */
 function isRealCalendarDate(year: number, month: number, day: number): boolean {
-  const utc = new Date(Date.UTC(year, month - 1, day));
+  // setUTCFullYear (not Date.UTC) so years 0-99 are not remapped to 1900-1999.
+  const utc = new Date(0);
+  utc.setUTCFullYear(year, month - 1, day);
   return (
     utc.getUTCFullYear() === year && utc.getUTCMonth() === month - 1 && utc.getUTCDate() === day
   );
@@ -234,13 +236,15 @@ function sessionSurvival(
   after: ContinuitySnapshot,
   deploy: DeploymentWindow,
 ): RuleHit | null {
-  if (!isValidTimestamp(before.bootedSince)) {
+  if (!isValidTimestamp(before.bootedSince) || !isValidTimestamp(after.bootedSince)) {
     return hit(
       "incomplete-evidence",
-      "Pre-deploy boot-session time (bootedSince) is missing or invalid; survival of the booted session cannot be proven.",
+      "Boot-session time (bootedSince) is missing or invalid; survival of the booted session cannot be proven.",
     );
   }
-  if (before.bootedSince !== after.bootedSince) {
+  // Compare the parsed instants, not the raw strings, so equivalent ISO
+  // spellings of the same instant (e.g. `09:00:00Z` vs `09:00:00.000Z`) match.
+  if (Date.parse(before.bootedSince) !== Date.parse(after.bootedSince)) {
     return hit(
       "boot-recovery",
       "The boot session changed between the pre- and post-deploy captures; CoreSimulator data was preserved but the booted session did not survive.",

--- a/src/utils/iosSimulatorContinuity.ts
+++ b/src/utils/iosSimulatorContinuity.ts
@@ -153,15 +153,18 @@ const REQUIRED_PROCESS_ROLES: readonly string[] = ["daemon", "runner", "coreSimu
 
 /**
  * True when the process-identifier map is real evidence: each required role
- * (daemon, runner, CoreSimulator service) is present with a positive integer PID.
- * Rejects a missing role and junk values (`{ daemon: 0 }`, `{ daemon: 1.5 }`) or
- * an unrelated placeholder (`{ placeholder: 1 }`).
+ * (daemon, runner, CoreSimulator service) is present with a positive integer PID,
+ * and the three PIDs are distinct (they are contemporaneous processes, so a
+ * reused PID means malformed evidence). Rejects a missing role, junk values
+ * (`{ daemon: 0 }`, `{ daemon: 1.5 }`), an unrelated placeholder
+ * (`{ placeholder: 1 }`), and duplicates (`{ daemon: 1, runner: 1, ... }`).
  */
 function hasValidProcessIds(processIds: Readonly<Record<string, number>>): boolean {
-  return REQUIRED_PROCESS_ROLES.every((role) => {
-    const pid = processIds[role];
-    return typeof pid === "number" && Number.isInteger(pid) && pid > 0;
-  });
+  const pids = REQUIRED_PROCESS_ROLES.map((role) => processIds[role]);
+  if (!pids.every((pid) => typeof pid === "number" && Number.isInteger(pid) && pid > 0)) {
+    return false;
+  }
+  return new Set(pids).size === pids.length;
 }
 
 /** Identity/context fields that must be present for evidence to be usable. */
@@ -262,13 +265,21 @@ function sessionSurvival(
   }
   // Compare the parsed instants, not the raw strings, so equivalent ISO
   // spellings of the same instant (e.g. `09:00:00Z` vs `09:00:00.000Z`) match.
-  if (Date.parse(before.bootedSince) !== Date.parse(after.bootedSince)) {
+  const beforeBoot = Date.parse(before.bootedSince);
+  const afterBoot = Date.parse(after.bootedSince);
+  if (afterBoot < beforeBoot) {
+    return hit(
+      "incomplete-evidence",
+      "The post-deploy boot instant precedes the pre-deploy one; the evidence is contradictory or clock-skewed, so survival cannot be proven.",
+    );
+  }
+  if (beforeBoot !== afterBoot) {
     return hit(
       "boot-recovery",
       "The boot session changed between the pre- and post-deploy captures; CoreSimulator data was preserved but the booted session did not survive.",
     );
   }
-  if (Date.parse(before.bootedSince) >= Date.parse(deploy.startedAt)) {
+  if (beforeBoot >= Date.parse(deploy.startedAt)) {
     return hit(
       "boot-recovery",
       "The booted session began at or after the deploy start, so no pre-deploy session survived.",

--- a/src/utils/iosSimulatorContinuity.ts
+++ b/src/utils/iosSimulatorContinuity.ts
@@ -156,6 +156,9 @@ function hasRequiredIdentity(snapshot: ContinuitySnapshot): boolean {
     snapshot.automobileVersion.trim().length > 0 &&
     snapshot.workerIncarnation.trim().length > 0 &&
     snapshot.processSupervisor.trim().length > 0 &&
+    // The issue lists process identifiers as required evidence; an empty map
+    // means the daemon/runner/CoreSimulator PID capture is missing.
+    Object.keys(snapshot.processIds).length > 0 &&
     snapshot.coreSimulatorDataRoot.trim().length > 0 &&
     snapshot.reportingStatus !== "unknown"
   );
@@ -174,11 +177,31 @@ function hit(verdict: ContinuityVerdict, reason: string): RuleHit {
 // Strict ISO-8601 date-time with a timezone: `2026-08-07T10:00:00(.000)?(Z|±hh:mm)`.
 // Permissive Date.parse alone accepts junk like "0"/"1" as valid dates, which
 // would let malformed evidence read as proven — so the shape is checked too.
-const ISO_8601 = /^\d{4}-\d{2}-\d{2}T\d{2}:\d{2}:\d{2}(?:\.\d{1,3})?(?:Z|[+-]\d{2}:\d{2})$/;
+const ISO_8601 =
+  /^(\d{4})-(\d{2})-(\d{2})T(\d{2}):(\d{2}):(\d{2})(?:\.\d{1,3})?(?:Z|[+-]\d{2}:\d{2})$/;
 
-/** True when the value is a strict ISO-8601 timestamp with a real calendar value. */
+/** True when (year, month, day) is a real calendar date that Date.parse would not normalize. */
+function isRealCalendarDate(year: number, month: number, day: number): boolean {
+  const utc = new Date(Date.UTC(year, month - 1, day));
+  return (
+    utc.getUTCFullYear() === year && utc.getUTCMonth() === month - 1 && utc.getUTCDate() === day
+  );
+}
+
+/**
+ * True when the value is a strict ISO-8601 timestamp with a real calendar value.
+ * The regex fixes the shape (rejecting `"0"`/`"1"`) and the calendar round-trip
+ * rejects impossible dates that Date.parse silently normalizes (e.g. `02-30`).
+ */
 function isValidTimestamp(value: string | undefined): value is string {
-  return typeof value === "string" && ISO_8601.test(value) && !Number.isNaN(Date.parse(value));
+  if (typeof value !== "string") {
+    return false;
+  }
+  const match = ISO_8601.exec(value);
+  if (match === null || Number.isNaN(Date.parse(value))) {
+    return false;
+  }
+  return isRealCalendarDate(Number(match[1]), Number(match[2]), Number(match[3]));
 }
 
 /** True when all identity/context evidence and the deploy window are present and well-formed. */
@@ -199,25 +222,37 @@ function evidenceComplete(
 }
 
 /**
- * A boot-recovery verdict when the current boot session began at or after the
- * deploy started (so the pre-deploy booted session did not survive), or null when
- * it began before the deploy (the session survived). A boot at or after the start
- * is not proven regardless of whether it lands inside or after the window — a
- * post-window reboot before capture still means the session did not survive — but
- * the reason distinguishes the two. Reached only after the isValidTimestamp gates.
+ * Prove the *same* booted session bracketed the deploy. The boot instant must be
+ * a valid pre-deploy timestamp, identical in the before and after snapshots, and
+ * predate the window — a changed instant (before ≠ after) means it rebooted at
+ * some point, and an instant at/after the deploy start means no pre-deploy session
+ * survived. Returns a not-proven hit, or null when survival is proven. The
+ * after-timestamp is already validated by {@link postStateShortfall}.
  */
-function bootRecovery(after: ContinuitySnapshot, deploy: DeploymentWindow): RuleHit | null {
-  const bootedAt = Date.parse(after.bootedSince as string);
-  if (bootedAt < Date.parse(deploy.startedAt)) {
-    return null;
+function sessionSurvival(
+  before: ContinuitySnapshot,
+  after: ContinuitySnapshot,
+  deploy: DeploymentWindow,
+): RuleHit | null {
+  if (!isValidTimestamp(before.bootedSince)) {
+    return hit(
+      "incomplete-evidence",
+      "Pre-deploy boot-session time (bootedSince) is missing or invalid; survival of the booted session cannot be proven.",
+    );
   }
-  const duringWindow = bootedAt <= Date.parse(deploy.completedAt);
-  return hit(
-    "boot-recovery",
-    duringWindow
-      ? "Simulator rebooted during the deploy window; CoreSimulator data was preserved but the booted session did not survive."
-      : "Simulator's boot session began after the deploy completed but before capture; the pre-deploy booted session did not survive.",
-  );
+  if (before.bootedSince !== after.bootedSince) {
+    return hit(
+      "boot-recovery",
+      "The boot session changed between the pre- and post-deploy captures; CoreSimulator data was preserved but the booted session did not survive.",
+    );
+  }
+  if (Date.parse(before.bootedSince) >= Date.parse(deploy.startedAt)) {
+    return hit(
+      "boot-recovery",
+      "The booted session began at or after the deploy start, so no pre-deploy session survived.",
+    );
+  }
+  return null;
 }
 
 /**
@@ -309,7 +344,7 @@ function classifySameDevice(
     return shortfall;
   }
   // After-state is fully proven; now the survival-specific checks.
-  const recovery = bootRecovery(after, deploy);
+  const recovery = sessionSurvival(before, after, deploy);
   if (recovery) {
     return recovery;
   }

--- a/src/utils/iosSimulatorContinuity.ts
+++ b/src/utils/iosSimulatorContinuity.ts
@@ -147,6 +147,19 @@ const PROVEN_VERDICTS: ReadonlySet<ContinuityVerdict> = new Set<ContinuityVerdic
   "controlled-replacement",
 ]);
 
+/**
+ * True when the process-identifier map is real evidence: at least one entry, and
+ * every entry a non-blank process name mapped to a positive integer PID. Rejects
+ * a nonempty-but-junk map (`{ daemon: 0 }`, `{ daemon: -1 }`, `{ daemon: 1.5 }`).
+ */
+function hasValidProcessIds(processIds: Readonly<Record<string, number>>): boolean {
+  const entries = Object.entries(processIds);
+  return (
+    entries.length > 0 &&
+    entries.every(([name, pid]) => name.trim().length > 0 && Number.isInteger(pid) && pid > 0)
+  );
+}
+
 /** Identity/context fields that must be present for evidence to be usable. */
 function hasRequiredIdentity(snapshot: ContinuitySnapshot): boolean {
   return (
@@ -156,9 +169,9 @@ function hasRequiredIdentity(snapshot: ContinuitySnapshot): boolean {
     snapshot.automobileVersion.trim().length > 0 &&
     snapshot.workerIncarnation.trim().length > 0 &&
     snapshot.processSupervisor.trim().length > 0 &&
-    // The issue lists process identifiers as required evidence; an empty map
-    // means the daemon/runner/CoreSimulator PID capture is missing.
-    Object.keys(snapshot.processIds).length > 0 &&
+    // The issue lists process identifiers as required evidence; a missing or
+    // junk PID capture (no daemon/runner/CoreSimulator PIDs) is not evidence.
+    hasValidProcessIds(snapshot.processIds) &&
     snapshot.coreSimulatorDataRoot.trim().length > 0 &&
     snapshot.reportingStatus !== "unknown"
   );
@@ -347,16 +360,20 @@ function classifySameDevice(
   if (shortfall) {
     return shortfall;
   }
-  // After-state is fully proven; now the survival-specific checks.
-  const recovery = sessionSurvival(before, after, deploy);
-  if (recovery) {
-    return recovery;
-  }
+  // Establish a healthy pre-deploy baseline before reasoning about survival —
+  // an unhealthy `before` cannot prove a healthy device was preserved, whatever
+  // the boot instants show.
   if (before.lifecycleState !== "booted" || !before.responsive) {
     return hit(
       "incomplete-evidence",
       "Pre-deploy baseline was not a booted, responsive simulator; continuity of a healthy device cannot be proven.",
     );
+  }
+  // Baseline is healthy and the after-state is fully proven; now that the same
+  // booted session survived.
+  const recovery = sessionSurvival(before, after, deploy);
+  if (recovery) {
+    return recovery;
   }
   return hit(
     "same-device-continuity",

--- a/src/utils/iosSimulatorContinuity.ts
+++ b/src/utils/iosSimulatorContinuity.ts
@@ -147,17 +147,21 @@ const PROVEN_VERDICTS: ReadonlySet<ContinuityVerdict> = new Set<ContinuityVerdic
   "controlled-replacement",
 ]);
 
+// The process roles the runbook requires every capture to record — the
+// supervised processes whose survival the evidence is meant to prove.
+const REQUIRED_PROCESS_ROLES: readonly string[] = ["daemon", "runner", "coreSimulatorService"];
+
 /**
- * True when the process-identifier map is real evidence: at least one entry, and
- * every entry a non-blank process name mapped to a positive integer PID. Rejects
- * a nonempty-but-junk map (`{ daemon: 0 }`, `{ daemon: -1 }`, `{ daemon: 1.5 }`).
+ * True when the process-identifier map is real evidence: each required role
+ * (daemon, runner, CoreSimulator service) is present with a positive integer PID.
+ * Rejects a missing role and junk values (`{ daemon: 0 }`, `{ daemon: 1.5 }`) or
+ * an unrelated placeholder (`{ placeholder: 1 }`).
  */
 function hasValidProcessIds(processIds: Readonly<Record<string, number>>): boolean {
-  const entries = Object.entries(processIds);
-  return (
-    entries.length > 0 &&
-    entries.every(([name, pid]) => name.trim().length > 0 && Number.isInteger(pid) && pid > 0)
-  );
+  return REQUIRED_PROCESS_ROLES.every((role) => {
+    const pid = processIds[role];
+    return typeof pid === "number" && Number.isInteger(pid) && pid > 0;
+  });
 }
 
 /** Identity/context fields that must be present for evidence to be usable. */
@@ -169,8 +173,9 @@ function hasRequiredIdentity(snapshot: ContinuitySnapshot): boolean {
     snapshot.automobileVersion.trim().length > 0 &&
     snapshot.workerIncarnation.trim().length > 0 &&
     snapshot.processSupervisor.trim().length > 0 &&
-    // The issue lists process identifiers as required evidence; a missing or
-    // junk PID capture (no daemon/runner/CoreSimulator PIDs) is not evidence.
+    // The issue lists process identifiers as required evidence; a capture
+    // missing the daemon/runner/CoreSimulator PIDs (or with junk values) is not
+    // evidence that the supervised processes are accounted for.
     hasValidProcessIds(snapshot.processIds) &&
     snapshot.coreSimulatorDataRoot.trim().length > 0 &&
     snapshot.reportingStatus !== "unknown"

--- a/test/utils/iosSimulatorContinuity.test.ts
+++ b/test/utils/iosSimulatorContinuity.test.ts
@@ -175,9 +175,15 @@ describe("classifyContinuity — distinguishes the required states (AC5)", () =>
     expect(result.proven).toBe(false);
   });
 
-  it("junk process ids (non-positive or non-integer) → incomplete-evidence", () => {
-    for (const bad of [{ daemon: 0 }, { daemon: -1 }, { daemon: 1.5 }, { "": 4201 }]) {
-      const result = classifyContinuity(snapshot({ processIds: bad }), snapshot(), DEPLOY);
+  it("junk or role-incomplete process ids → incomplete-evidence", () => {
+    const bad = [
+      { daemon: 0, runner: 4310, coreSimulatorService: 512 }, // non-positive PID
+      { daemon: 1.5, runner: 4310, coreSimulatorService: 512 }, // non-integer PID
+      { placeholder: 1 }, // unrelated role, none of the required ones
+      { daemon: 4201, runner: 4310 }, // missing coreSimulatorService
+    ];
+    for (const processIds of bad) {
+      const result = classifyContinuity(snapshot({ processIds }), snapshot(), DEPLOY);
       expect(result.verdict).toBe("incomplete-evidence");
       expect(result.proven).toBe(false);
     }

--- a/test/utils/iosSimulatorContinuity.test.ts
+++ b/test/utils/iosSimulatorContinuity.test.ts
@@ -87,11 +87,21 @@ describe("classifyContinuity — distinguishes the required states (AC5)", () =>
     expect(result.verdict).toBe("boot-recovery");
   });
 
-  it("a boot before the window start is survival, not a reboot → same-device-continuity", () => {
-    const after = snapshot({ bootedSince: "2026-08-07T09:59:59.000Z" });
-    const result = classifyContinuity(snapshot(), after, DEPLOY);
+  it("an identical boot session (before === after) predating the window → same-device-continuity", () => {
+    const boot = { bootedSince: "2026-08-07T09:30:00.000Z" };
+    const result = classifyContinuity(snapshot(boot), snapshot(boot), DEPLOY);
     expect(result.verdict).toBe("same-device-continuity");
     expect(result.proven).toBe(true);
+  });
+
+  it("a changed boot session across the deploy (before !== after) → boot-recovery", () => {
+    // before booted 09:00, after booted 09:59 — the session changed even though
+    // both predate the window; the original booted session did not survive.
+    const before = snapshot({ bootedSince: "2026-08-07T09:00:00.000Z" });
+    const after = snapshot({ bootedSince: "2026-08-07T09:59:00.000Z" });
+    const result = classifyContinuity(before, after, DEPLOY);
+    expect(result.verdict).toBe("boot-recovery");
+    expect(result.proven).toBe(false);
   });
 
   it("device continuous but worker reporting lost → reporting-delay", () => {
@@ -136,6 +146,12 @@ describe("classifyContinuity — distinguishes the required states (AC5)", () =>
   it("an unhealthy pre-deploy baseline (booted but unresponsive) cannot prove continuity → incomplete-evidence", () => {
     const before = snapshot({ responsive: false });
     const result = classifyContinuity(before, snapshot(), DEPLOY);
+    expect(result.verdict).toBe("incomplete-evidence");
+    expect(result.proven).toBe(false);
+  });
+
+  it("no process-identifier evidence (empty processIds) → incomplete-evidence", () => {
+    const result = classifyContinuity(snapshot({ processIds: {} }), snapshot(), DEPLOY);
     expect(result.verdict).toBe("incomplete-evidence");
     expect(result.proven).toBe(false);
   });
@@ -258,6 +274,15 @@ describe("classifyContinuity — malformed evidence and windows are not proven",
         completedAt: "2",
       },
     );
+    expect(result.verdict).toBe("incomplete-evidence");
+    expect(result.proven).toBe(false);
+  });
+
+  it("an impossible calendar date Date.parse would normalize (2026-02-30) → incomplete-evidence", () => {
+    const result = classifyContinuity(snapshot(), snapshot(), {
+      startedAt: "2026-02-30T10:00:00.000Z",
+      completedAt: "2026-02-30T10:05:00.000Z",
+    });
     expect(result.verdict).toBe("incomplete-evidence");
     expect(result.proven).toBe(false);
   });

--- a/test/utils/iosSimulatorContinuity.test.ts
+++ b/test/utils/iosSimulatorContinuity.test.ts
@@ -94,6 +94,25 @@ describe("classifyContinuity — distinguishes the required states (AC5)", () =>
     expect(result.proven).toBe(true);
   });
 
+  it("equivalent ISO spellings of the same boot instant are the same session → same-device-continuity", () => {
+    const before = snapshot({ bootedSince: "2026-08-07T09:00:00Z" });
+    const after = snapshot({ bootedSince: "2026-08-07T09:00:00.000Z" });
+    const result = classifyContinuity(before, after, DEPLOY);
+    expect(result.verdict).toBe("same-device-continuity");
+    expect(result.proven).toBe(true);
+  });
+
+  it("a real leap day is accepted, not falsely rejected as an impossible date", () => {
+    const boot = { bootedSince: "2028-02-29T09:00:00.000Z" };
+    const window: DeploymentWindow = {
+      startedAt: "2028-02-29T10:00:00.000Z",
+      completedAt: "2028-02-29T10:05:00.000Z",
+    };
+    const result = classifyContinuity(snapshot(boot), snapshot(boot), window);
+    expect(result.verdict).toBe("same-device-continuity");
+    expect(result.proven).toBe(true);
+  });
+
   it("a changed boot session across the deploy (before !== after) → boot-recovery", () => {
     // before booted 09:00, after booted 09:59 — the session changed even though
     // both predate the window; the original booted session did not survive.

--- a/test/utils/iosSimulatorContinuity.test.ts
+++ b/test/utils/iosSimulatorContinuity.test.ts
@@ -189,6 +189,21 @@ describe("classifyContinuity — distinguishes the required states (AC5)", () =>
     }
   });
 
+  it("the same PID reused across the three required roles → incomplete-evidence", () => {
+    const processIds = { daemon: 1, runner: 1, coreSimulatorService: 1 };
+    const result = classifyContinuity(snapshot({ processIds }), snapshot({ processIds }), DEPLOY);
+    expect(result.verdict).toBe("incomplete-evidence");
+    expect(result.proven).toBe(false);
+  });
+
+  it("a backwards boot instant (after earlier than before) → incomplete-evidence, not boot-recovery", () => {
+    const before = snapshot({ bootedSince: "2026-08-07T09:00:00.000Z" });
+    const after = snapshot({ bootedSince: "2026-08-07T08:00:00.000Z" });
+    const result = classifyContinuity(before, after, DEPLOY);
+    expect(result.verdict).toBe("incomplete-evidence");
+    expect(result.proven).toBe(false);
+  });
+
   it("an unhealthy baseline outranks a changed boot instant → incomplete-evidence, not boot-recovery", () => {
     // before is shutdown (unhealthy) yet carries a boot time; after is healthy
     // with a different instant. Baseline health is checked first.

--- a/test/utils/iosSimulatorContinuity.test.ts
+++ b/test/utils/iosSimulatorContinuity.test.ts
@@ -174,6 +174,27 @@ describe("classifyContinuity — distinguishes the required states (AC5)", () =>
     expect(result.verdict).toBe("incomplete-evidence");
     expect(result.proven).toBe(false);
   });
+
+  it("junk process ids (non-positive or non-integer) → incomplete-evidence", () => {
+    for (const bad of [{ daemon: 0 }, { daemon: -1 }, { daemon: 1.5 }, { "": 4201 }]) {
+      const result = classifyContinuity(snapshot({ processIds: bad }), snapshot(), DEPLOY);
+      expect(result.verdict).toBe("incomplete-evidence");
+      expect(result.proven).toBe(false);
+    }
+  });
+
+  it("an unhealthy baseline outranks a changed boot instant → incomplete-evidence, not boot-recovery", () => {
+    // before is shutdown (unhealthy) yet carries a boot time; after is healthy
+    // with a different instant. Baseline health is checked first.
+    const before = snapshot({
+      lifecycleState: "shutdown",
+      bootedSince: "2026-08-07T08:00:00.000Z",
+    });
+    const after = snapshot({ bootedSince: "2026-08-07T09:00:00.000Z" });
+    const result = classifyContinuity(before, after, DEPLOY);
+    expect(result.verdict).toBe("incomplete-evidence");
+    expect(result.proven).toBe(false);
+  });
 });
 
 describe("classifyContinuity — cannot silently erase/orphan managed state (AC3)", () => {


### PR DESCRIPTION
## Summary

Follow-up to [#5120](https://github.com/kaeawc/auto-mobile/pull/5120) (merged),
landing the final code-review round for issue
[#5104](https://github.com/kaeawc/auto-mobile/issues/5104). Those fixes were
committed just after #5120 auto-merged, so they missed the squash and are landed
here. Scope is confined to the continuity classifier — no other surface changes.

## Changes (`src/utils/iosSimulatorContinuity.ts`)

Three Codex findings on #5120, all hardening the *proof* the gate makes:

- **Prove the same boot session (P1).** `same-device-continuity` now requires
  `before.bootedSince` to be a valid pre-deploy timestamp, **identical** to
  `after.bootedSince`, and to predate the window. A boot session that changed
  between the before/after captures — even a reboot *before* the window — is
  `boot-recovery`; a missing pre-deploy boot time is `incomplete-evidence`. This
  replaces the earlier after-only window comparison, which read a device that
  rebooted before the deploy as continuous.
- **Reject impossible calendar dates (P2).** `isValidTimestamp` now rejects
  values `Date.parse` silently normalizes (e.g. `2026-02-30` → Mar 2) via a UTC
  round-trip, in addition to the strict ISO-8601 shape check.
- **Require process-identifier evidence (P2).** `hasRequiredIdentity` now
  requires a non-empty `processIds` map — the issue lists process identifiers as
  required pre/post-deploy evidence, so an empty capture is `incomplete-evidence`.

## Testing

- [x] `bun test test/utils/iosSimulatorContinuity.test.ts` — 37 pass, 0 fail (<150ms); new cases for same-vs-changed boot instant, impossible calendar dates, and empty process-id evidence
- [x] `bun run typecheck` — no new errors (baseline gate)
- [x] `bun run lint` — oxlint + ratchet + boundaries clean
- [x] `bun run build` — ok

## Context

#5120 auto-merged at its round-4 head while this round-5 was being prepared. The
merged version already satisfies every acceptance criterion; this PR is a pure
soundness tightening of the classifier.
