### PR TITLE
fix(database): restore Android debug inspector access

### DIFF
--- a/android/auto-mobile-sdk/src/debug/AndroidManifest.xml
+++ b/android/auto-mobile-sdk/src/debug/AndroidManifest.xml
@@ -20,11 +20,11 @@
     <provider
       android:name="dev.jasonpearson.automobile.sdk.database.DatabaseInspectorProvider"
       android:authorities="${applicationId}.automobile.database"
-      android:exported="false" />
+      android:exported="true" />
 
     <provider
       android:name="dev.jasonpearson.automobile.sdk.storage.SharedPreferencesInspectorProvider"
       android:authorities="${applicationId}.automobile.sharedprefs"
-      android:exported="false" />
+      android:exported="true" />
   </application>
 </manifest>

--- a/android/auto-mobile-sdk/src/debug/kotlin/dev/jasonpearson/automobile/sdk/DebugInspectorAccess.kt
+++ b/android/auto-mobile-sdk/src/debug/kotlin/dev/jasonpearson/automobile/sdk/DebugInspectorAccess.kt
@@ -1,5 +1,6 @@
 package dev.jasonpearson.automobile.sdk
 
+import android.content.Context
 import android.os.Binder
 import android.os.Process
 
@@ -11,13 +12,22 @@ import android.os.Process
  */
 internal object DebugInspectorAccess {
 
-  fun isAuthorized(callingUid: Int, ownUid: Int): Boolean {
-    return callingUid == Process.SHELL_UID || callingUid == Process.ROOT_UID || callingUid == ownUid
+  fun isAuthorized(
+    callingUid: Int,
+    ownUid: Int,
+    callingPackages: Set<String> = emptySet(),
+  ): Boolean {
+    return callingUid == Process.SHELL_UID ||
+      callingUid == Process.ROOT_UID ||
+      callingUid == ownUid ||
+      SdkConstants.CTRL_PROXY_PACKAGE in callingPackages
   }
 
-  fun enforceCaller() {
+  fun enforceCaller(context: Context?) {
     val callingUid = Binder.getCallingUid()
-    if (!isAuthorized(callingUid, Process.myUid())) {
+    val callingPackages =
+      context?.packageManager?.getPackagesForUid(callingUid)?.toSet().orEmpty()
+    if (!isAuthorized(callingUid, Process.myUid(), callingPackages)) {
       throw SecurityException("Debug inspector access denied for uid $callingUid")
     }
   }

--- a/android/auto-mobile-sdk/src/debug/kotlin/dev/jasonpearson/automobile/sdk/DebugInspectorAccess.kt
+++ b/android/auto-mobile-sdk/src/debug/kotlin/dev/jasonpearson/automobile/sdk/DebugInspectorAccess.kt
@@ -1,0 +1,24 @@
+package dev.jasonpearson.automobile.sdk
+
+import android.os.Binder
+import android.os.Process
+
+/**
+ * Keeps the exported debug inspector providers limited to the callers that need them.
+ *
+ * The providers must be exported for `adb shell content call` on modern Android, but exporting
+ * without a provider-side check would let unrelated apps read or mutate the host app's data.
+ */
+internal object DebugInspectorAccess {
+
+  fun isAuthorized(callingUid: Int, ownUid: Int): Boolean {
+    return callingUid == Process.SHELL_UID || callingUid == Process.ROOT_UID || callingUid == ownUid
+  }
+
+  fun enforceCaller() {
+    val callingUid = Binder.getCallingUid()
+    if (!isAuthorized(callingUid, Process.myUid())) {
+      throw SecurityException("Debug inspector access denied for uid $callingUid")
+    }
+  }
+}

--- a/android/auto-mobile-sdk/src/debug/kotlin/dev/jasonpearson/automobile/sdk/DebugInspectorAccess.kt
+++ b/android/auto-mobile-sdk/src/debug/kotlin/dev/jasonpearson/automobile/sdk/DebugInspectorAccess.kt
@@ -25,8 +25,7 @@ internal object DebugInspectorAccess {
 
   fun enforceCaller(context: Context?) {
     val callingUid = Binder.getCallingUid()
-    val callingPackages =
-      context?.packageManager?.getPackagesForUid(callingUid)?.toSet().orEmpty()
+    val callingPackages = context?.packageManager?.getPackagesForUid(callingUid)?.toSet().orEmpty()
     if (!isAuthorized(callingUid, Process.myUid(), callingPackages)) {
       throw SecurityException("Debug inspector access denied for uid $callingUid")
     }

--- a/android/auto-mobile-sdk/src/debug/kotlin/dev/jasonpearson/automobile/sdk/database/DatabaseInspectorProvider.kt
+++ b/android/auto-mobile-sdk/src/debug/kotlin/dev/jasonpearson/automobile/sdk/database/DatabaseInspectorProvider.kt
@@ -6,6 +6,7 @@ import android.database.Cursor
 import android.net.Uri
 import android.os.Bundle
 import dev.jasonpearson.automobile.sdk.AutoMobileSDK
+import dev.jasonpearson.automobile.sdk.DebugInspectorAccess
 import org.json.JSONArray
 import org.json.JSONObject
 
@@ -37,6 +38,7 @@ class DatabaseInspectorProvider : ContentProvider() {
   }
 
   override fun call(method: String, arg: String?, extras: Bundle?): Bundle {
+    DebugInspectorAccess.enforceCaller()
     val result = Bundle()
 
     // Check if inspection is enabled

--- a/android/auto-mobile-sdk/src/debug/kotlin/dev/jasonpearson/automobile/sdk/database/DatabaseInspectorProvider.kt
+++ b/android/auto-mobile-sdk/src/debug/kotlin/dev/jasonpearson/automobile/sdk/database/DatabaseInspectorProvider.kt
@@ -38,7 +38,7 @@ class DatabaseInspectorProvider : ContentProvider() {
   }
 
   override fun call(method: String, arg: String?, extras: Bundle?): Bundle {
-    DebugInspectorAccess.enforceCaller()
+    DebugInspectorAccess.enforceCaller(context)
     val result = Bundle()
 
     // Check if inspection is enabled

--- a/android/auto-mobile-sdk/src/debug/kotlin/dev/jasonpearson/automobile/sdk/storage/SharedPreferencesInspectorProvider.kt
+++ b/android/auto-mobile-sdk/src/debug/kotlin/dev/jasonpearson/automobile/sdk/storage/SharedPreferencesInspectorProvider.kt
@@ -42,7 +42,7 @@ class SharedPreferencesInspectorProvider : ContentProvider() {
   }
 
   override fun call(method: String, arg: String?, extras: Bundle?): Bundle {
-    DebugInspectorAccess.enforceCaller()
+    DebugInspectorAccess.enforceCaller(context)
     val result = Bundle()
 
     // Check if inspection is enabled

--- a/android/auto-mobile-sdk/src/debug/kotlin/dev/jasonpearson/automobile/sdk/storage/SharedPreferencesInspectorProvider.kt
+++ b/android/auto-mobile-sdk/src/debug/kotlin/dev/jasonpearson/automobile/sdk/storage/SharedPreferencesInspectorProvider.kt
@@ -11,6 +11,7 @@ import dev.jasonpearson.automobile.protocol.StorageFileInfo
 import dev.jasonpearson.automobile.protocol.StorageProtocolSerializer
 import dev.jasonpearson.automobile.protocol.StorageResponse
 import dev.jasonpearson.automobile.sdk.AutoMobileSDK
+import dev.jasonpearson.automobile.sdk.DebugInspectorAccess
 import kotlinx.serialization.SerializationException
 import kotlinx.serialization.decodeFromString
 import kotlinx.serialization.encodeToString
@@ -41,6 +42,7 @@ class SharedPreferencesInspectorProvider : ContentProvider() {
   }
 
   override fun call(method: String, arg: String?, extras: Bundle?): Bundle {
+    DebugInspectorAccess.enforceCaller()
     val result = Bundle()
 
     // Check if inspection is enabled

--- a/android/auto-mobile-sdk/src/test/kotlin/dev/jasonpearson/automobile/sdk/DebugInspectorAccessTest.kt
+++ b/android/auto-mobile-sdk/src/test/kotlin/dev/jasonpearson/automobile/sdk/DebugInspectorAccessTest.kt
@@ -22,8 +22,25 @@ class DebugInspectorAccessTest {
   }
 
   @Test
+  fun `allows the CtrlProxy caller`() {
+    assertTrue(
+      DebugInspectorAccess.isAuthorized(
+        callingUid = 10_211,
+        ownUid = 10_210,
+        callingPackages = setOf(SdkConstants.CTRL_PROXY_PACKAGE),
+      )
+    )
+  }
+
+  @Test
   fun `rejects unrelated app callers`() {
-    assertFalse(DebugInspectorAccess.isAuthorized(callingUid = 10_211, ownUid = 10_210))
+    assertFalse(
+      DebugInspectorAccess.isAuthorized(
+        callingUid = 10_212,
+        ownUid = 10_210,
+        callingPackages = setOf("com.example.untrusted"),
+      )
+    )
   }
 
   private object ProcessUid {

--- a/android/auto-mobile-sdk/src/test/kotlin/dev/jasonpearson/automobile/sdk/DebugInspectorAccessTest.kt
+++ b/android/auto-mobile-sdk/src/test/kotlin/dev/jasonpearson/automobile/sdk/DebugInspectorAccessTest.kt
@@ -1,0 +1,33 @@
+package dev.jasonpearson.automobile.sdk
+
+import org.junit.Assert.assertFalse
+import org.junit.Assert.assertTrue
+import org.junit.Test
+
+class DebugInspectorAccessTest {
+
+  @Test
+  fun `allows adb shell callers`() {
+    assertTrue(DebugInspectorAccess.isAuthorized(ProcessUid.SHELL, ownUid = 10_210))
+  }
+
+  @Test
+  fun `allows root callers`() {
+    assertTrue(DebugInspectorAccess.isAuthorized(ProcessUid.ROOT, ownUid = 10_210))
+  }
+
+  @Test
+  fun `allows the host app caller`() {
+    assertTrue(DebugInspectorAccess.isAuthorized(callingUid = 10_210, ownUid = 10_210))
+  }
+
+  @Test
+  fun `rejects unrelated app callers`() {
+    assertFalse(DebugInspectorAccess.isAuthorized(callingUid = 10_211, ownUid = 10_210))
+  }
+
+  private object ProcessUid {
+    const val ROOT = 0
+    const val SHELL = 2_000
+  }
+}

--- a/src/features/database/DatabaseInspector.ts
+++ b/src/features/database/DatabaseInspector.ts
@@ -175,7 +175,10 @@ export class DatabaseInspector {
     }
 
     const result = await this.adb.executeCommand(cmd);
-    return this.parseContentCallResult<T>(result.stdout);
+    const output = [result.stdout, result.stderr]
+      .filter((part) => part.trim().length > 0)
+      .join("\n");
+    return this.parseContentCallResult<T>(output);
   }
 
   /**
@@ -216,8 +219,8 @@ export class DatabaseInspector {
    *
    * Older SDK builds emit the flat form (`errorType=...`, `error=...` as raw Bundle entries).
    * Version skew is the normal state between releases, so when there is no parseable envelope we
-   * fall back to reading the flat entries with {@link extractBundleValue}, preserving the prior
-   * behavior (and its documented ambiguity, which only the envelope form can eliminate).
+   * fall back to reading the flat entries with {@link extractBundleValue}. If neither form is
+   * present, the raw command output is retained so shell/provider failures remain actionable.
    */
   private extractError(output: string): { errorType: string; error: string } {
     const json = this.extractJsonFromBundle(output);
@@ -243,7 +246,7 @@ export class DatabaseInspector {
 
     return {
       errorType: this.extractBundleValue(output, "errorType") || "UNKNOWN",
-      error: this.extractBundleValue(output, "error") || "Unknown error"
+      error: this.extractBundleValue(output, "error") || output.trim() || "Unknown error"
     };
   }
 

--- a/test/features/database/DatabaseInspector.test.ts
+++ b/test/features/database/DatabaseInspector.test.ts
@@ -380,6 +380,12 @@ describe("DatabaseInspector", () => {
         "Database error (UNKNOWN): java.lang.SecurityException: Do not have permission in call getContentProviderExternal()"
       );
     });
+
+    test("preserves both stdout and stderr when content call writes to both", async () => {
+      const message = await errorFor("stdout failure", "stderr failure");
+
+      expect(message).toBe("Database error (UNKNOWN): stdout failure\nstderr failure");
+    });
   });
 
   describe("error handling", () => {

--- a/test/features/database/DatabaseInspector.test.ts
+++ b/test/features/database/DatabaseInspector.test.ts
@@ -274,10 +274,10 @@ describe("DatabaseInspector", () => {
       expect(message).toBe("Database error (DISABLED): Database inspection is disabled");
     });
 
-    test("falls back to UNKNOWN and Unknown error when the keys are absent", async () => {
+    test("includes raw output when the keys are absent", async () => {
       const message = await errorFor(`Bundle[{success=false}]`);
 
-      expect(message).toBe("Database error (UNKNOWN): Unknown error");
+      expect(message).toBe("Database error (UNKNOWN): Bundle[{success=false}]");
     });
 
     test("keeps flat values when an old reply's error text embeds a parseable result={}", async () => {
@@ -340,10 +340,45 @@ describe("DatabaseInspector", () => {
       expect(message).toBe("Database error (SQLiteException): disk I/O error");
     });
 
-    test("falls back to UNKNOWN when the envelope omits the fields", async () => {
+    test("includes the raw bundle when the envelope omits the fields", async () => {
       const message = await errorFor(`Bundle[{success=false, result={}}]`);
 
-      expect(message).toBe("Database error (UNKNOWN): Unknown error");
+      expect(message).toBe("Database error (UNKNOWN): Bundle[{success=false, result={}}]");
+    });
+  });
+
+  describe("raw command output diagnostics", () => {
+    const command = `shell content call --uri content://${appId}.automobile.database --method listDatabases`;
+
+    const errorFor = async (stdout: string, stderr = ""): Promise<string> => {
+      fakeAdb.setCommandResult(command, stdout, stderr);
+      try {
+        await inspector.listDatabases(appId);
+      } catch (error) {
+        return (error as Error).message;
+      }
+      throw new Error("expected listDatabases to reject");
+    };
+
+    test("includes raw stdout when content call returns an unstructured error", async () => {
+      const message = await errorFor(
+        "java.lang.SecurityException: Permission Denial: opening provider that is not exported"
+      );
+
+      expect(message).toBe(
+        "Database error (UNKNOWN): java.lang.SecurityException: Permission Denial: opening provider that is not exported"
+      );
+    });
+
+    test("includes raw stderr when content call writes an unstructured error there", async () => {
+      const message = await errorFor(
+        "",
+        "java.lang.SecurityException: Do not have permission in call getContentProviderExternal()"
+      );
+
+      expect(message).toBe(
+        "Database error (UNKNOWN): java.lang.SecurityException: Do not have permission in call getContentProviderExternal()"
+      );
     });
   });
 


### PR DESCRIPTION
## Summary

Restore Android SDK database and SharedPreferences inspector access for `adb shell content call` on modern Android, preserve raw command diagnostics when the provider cannot return a structured response, and retain provider-side authorization for the newly exported debug endpoints.

The providers are debug-only, so they are exported again to support the shell caller. Their provider-side guard accepts only the shell, root, host-app UID, or the separately installed CtrlProxy package; unrelated apps are denied. The TypeScript client now combines stdout and stderr before parsing and includes unstructured output in the actionable error instead of reducing it to `UNKNOWN / Unknown error`.

## Linked Issue

Closes [#5165](https://github.com/kaeawc/auto-mobile/issues/5165)

## Bug / Regression Context

- **Prior attempts:** This is a pre-existing issue; the providers had been non-exported since the debug-provider hardening change.
- **Observed symptom:** `sqlQuery` failed on Android API 35, including `SELECT 1`, with `Database error (UNKNOWN): Unknown error`.
- **Repro steps / conditions:** Use an embedded SDK debug build on a production Android API 35 emulator and invoke `sqlQuery`; `adb shell content call` is denied access to the non-exported provider.

## Validation

- [x] `bun run turbo:validate` passes: 7 tasks, 12,983 tests passed, 13 environment-skipped integration tests, 0 failures
- [x] `bun run typecheck` reports no new errors
- [x] `(cd android && ./gradlew :auto-mobile-sdk:testDebugUnitTest)` passes, including caller-authorization coverage
- [x] `bun test test/features/database/DatabaseInspector.test.ts` passes (29 tests)
- [x] `git diff --check` passes
- [x] Rebased onto the latest `origin/main`

## Kotlin Reuse Check

No Kotlin dependencies were added; the new debug-only caller guard reuses the existing `SdkConstants.CTRL_PROXY_PACKAGE` identity and has focused allow/deny coverage.

## Follow-ups

None identified; the provider exposure is intentionally limited to the SDK debug source set.
