### PR TITLE
feat(dx): add a fail-fast validate-loop pre-push command (loop)

### DIFF
--- a/package.json
+++ b/package.json
@@ -63,6 +63,7 @@
     "turbo:lint": "turbo run lint",
     "turbo:test": "turbo run test",
     "turbo:typecheck": "turbo run typecheck",
+    "turbo:gate": "turbo run lint build typecheck --output-logs=errors-only",
     "loop": "bash scripts/validate-loop.sh"
   },
   "packageManager": "bun@1.3.14",

--- a/package.json
+++ b/package.json
@@ -62,7 +62,8 @@
     "turbo:build": "turbo run build",
     "turbo:lint": "turbo run lint",
     "turbo:test": "turbo run test",
-    "turbo:typecheck": "turbo run typecheck"
+    "turbo:typecheck": "turbo run typecheck",
+    "loop": "bash scripts/validate-loop.sh"
   },
   "packageManager": "bun@1.3.14",
   "engines": {

--- a/scripts/validate-loop.sh
+++ b/scripts/validate-loop.sh
@@ -26,14 +26,13 @@ cd "$ROOT" || exit 1
 source "$ROOT/scripts/lib/shell-core.sh"
 ensure_node_modules "$ROOT"
 
-# ensure_node_modules may have just installed node_modules/.bin/turbo; when this
-# script is run directly (not via `bun run`, which does this for us) that dir is
-# not on PATH, so a bare `turbo` would be "command not found". Put it on PATH so
-# the self-healing direct entry point actually works.
-export PATH="$ROOT/node_modules/.bin:$PATH"
-
-gate_cmd="${VALIDATE_LOOP_GATE_CMD:-turbo run lint build typecheck --output-logs=errors-only}"
-test_cmd="${VALIDATE_LOOP_TEST_CMD:-bash scripts/test-fast.sh}"
+# Route the gate and tests through `bun run` package scripts (not bare `turbo`):
+# turbo is a local dependency that may not be on PATH, and the repo contract
+# (AGENTS.md) requires invoking it via `bun run turbo:*`. `bun run` also puts
+# node_modules/.bin on PATH for the child, so the self-healing direct entry point
+# works with no global turbo.
+gate_cmd="${VALIDATE_LOOP_GATE_CMD:-bun run turbo:gate}"
+test_cmd="${VALIDATE_LOOP_TEST_CMD:-bun run test:fast}"
 
 # Run the (trusted) gate/test strings through a shell so quoted arguments survive
 # — a bare `${cmd}` word-split would mangle any command with quoted args.

--- a/scripts/validate-loop.sh
+++ b/scripts/validate-loop.sh
@@ -1,0 +1,41 @@
+#!/usr/bin/env bash
+#
+# scripts/validate-loop.sh — one fail-fast local pre-push command (issue #5149).
+#
+# Composes the fast local primitives added across the build/test optimization
+# set:
+#   1. self-heal deps (ensure_node_modules, #5051) so a fresh worktree just works;
+#   2. run the cheap gate — `turbo run lint build typecheck` — where turbo
+#      parallelizes the three tasks. `lint` already includes the parallel
+#      boundary-check runner (#5121); `typecheck` is the cached tsgo gate (#5124);
+#   3. run the fast parallel test suite (`test:fast`, bun test --parallel, #5033)
+#      ONLY if the gate passed.
+#
+# Tests run AFTER the gate rather than alongside it: `test:fast` already uses
+# cores-2 workers, so overlapping it with the gate would oversubscribe the CPU.
+# A gate failure exits in a few seconds without paying for the ~20s test run.
+#
+# bash-3.2 safe. Two env seams let the BATS test inject controlled gate/test
+# commands (trusted test-only input; never wire from an untrusted source).
+set -uo pipefail
+
+ROOT="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
+cd "$ROOT" || exit 1
+
+# shellcheck source=scripts/lib/shell-core.sh disable=SC1091
+source "$ROOT/scripts/lib/shell-core.sh"
+ensure_node_modules "$ROOT"
+
+gate_cmd="${VALIDATE_LOOP_GATE_CMD:-turbo run lint build typecheck --output-logs=errors-only}"
+test_cmd="${VALIDATE_LOOP_TEST_CMD:-bash scripts/test-fast.sh}"
+
+echo "==> gate: ${gate_cmd}"
+# shellcheck disable=SC2086 # intentional word-split of the command string
+if ! ${gate_cmd}; then
+  echo "==> gate failed — skipping tests" >&2
+  exit 1
+fi
+
+echo "==> gate passed; running tests: ${test_cmd}"
+# shellcheck disable=SC2086 # intentional word-split of the command string
+exec ${test_cmd}

--- a/scripts/validate-loop.sh
+++ b/scripts/validate-loop.sh
@@ -24,7 +24,10 @@ cd "$ROOT" || exit 1
 
 # shellcheck source=scripts/lib/shell-core.sh disable=SC1091
 source "$ROOT/scripts/lib/shell-core.sh"
-ensure_node_modules "$ROOT"
+if ! ensure_node_modules "$ROOT"; then
+  echo "==> dependency bootstrap failed — aborting" >&2
+  exit 1
+fi
 
 # Route the gate and tests through `bun run` package scripts (not bare `turbo`):
 # turbo is a local dependency that may not be on PATH, and the repo contract

--- a/scripts/validate-loop.sh
+++ b/scripts/validate-loop.sh
@@ -26,16 +26,22 @@ cd "$ROOT" || exit 1
 source "$ROOT/scripts/lib/shell-core.sh"
 ensure_node_modules "$ROOT"
 
+# ensure_node_modules may have just installed node_modules/.bin/turbo; when this
+# script is run directly (not via `bun run`, which does this for us) that dir is
+# not on PATH, so a bare `turbo` would be "command not found". Put it on PATH so
+# the self-healing direct entry point actually works.
+export PATH="$ROOT/node_modules/.bin:$PATH"
+
 gate_cmd="${VALIDATE_LOOP_GATE_CMD:-turbo run lint build typecheck --output-logs=errors-only}"
 test_cmd="${VALIDATE_LOOP_TEST_CMD:-bash scripts/test-fast.sh}"
 
+# Run the (trusted) gate/test strings through a shell so quoted arguments survive
+# — a bare `${cmd}` word-split would mangle any command with quoted args.
 echo "==> gate: ${gate_cmd}"
-# shellcheck disable=SC2086 # intentional word-split of the command string
-if ! ${gate_cmd}; then
+if ! bash -c "$gate_cmd"; then
   echo "==> gate failed — skipping tests" >&2
   exit 1
 fi
 
 echo "==> gate passed; running tests: ${test_cmd}"
-# shellcheck disable=SC2086 # intentional word-split of the command string
-exec ${test_cmd}
+exec bash -c "$test_cmd"

--- a/test/bats/validate-loop.bats
+++ b/test/bats/validate-loop.bats
@@ -7,16 +7,33 @@
 
 SCRIPT="scripts/validate-loop.sh"
 
-@test "runs tests when the gate passes" {
-  run env VALIDATE_LOOP_GATE_CMD=true VALIDATE_LOOP_TEST_CMD="echo TESTS_RAN" bash "$SCRIPT"
-  [ "$status" -eq 0 ]
-  [[ "$output" == *"TESTS_RAN"* ]]
+# A test-command fixture whose marker (TEST_CHILD_MARKER) is absent from its
+# invocation, so an assertion on the marker proves the child actually ran rather
+# than matching the command line the script echoes.
+_test_fixture() {
+  local dir
+  dir="$(mktemp -d)"
+  printf '#!/usr/bin/env bash\necho TEST_CHILD_MARKER\n' > "$dir/t.sh"
+  chmod +x "$dir/t.sh"
+  echo "$dir"
 }
 
-@test "skips tests and exits non-zero when the gate fails" {
-  run env VALIDATE_LOOP_GATE_CMD=false VALIDATE_LOOP_TEST_CMD="echo TESTS_RAN" bash "$SCRIPT"
+@test "runs the test command when the gate passes" {
+  local dir
+  dir="$(_test_fixture)"
+  run env VALIDATE_LOOP_GATE_CMD=true VALIDATE_LOOP_TEST_CMD="bash $dir/t.sh" bash "$SCRIPT"
+  rm -rf "$dir"
+  [ "$status" -eq 0 ]
+  [[ "$output" == *"TEST_CHILD_MARKER"* ]]
+}
+
+@test "skips the test command and exits non-zero when the gate fails" {
+  local dir
+  dir="$(_test_fixture)"
+  run env VALIDATE_LOOP_GATE_CMD=false VALIDATE_LOOP_TEST_CMD="bash $dir/t.sh" bash "$SCRIPT"
+  rm -rf "$dir"
   [ "$status" -ne 0 ]
-  [[ "$output" != *"TESTS_RAN"* ]]
+  [[ "$output" != *"TEST_CHILD_MARKER"* ]]
   [[ "$output" == *"gate failed"* ]]
 }
 

--- a/test/bats/validate-loop.bats
+++ b/test/bats/validate-loop.bats
@@ -1,0 +1,28 @@
+#!/usr/bin/env bats
+#
+# Pins the fail-fast contract of scripts/validate-loop.sh (issue #5149): tests run
+# only when the gate passes, and never when it fails. The gate and test commands
+# are injected via env seams so the contract is exercised without running real
+# turbo/tests.
+
+SCRIPT="scripts/validate-loop.sh"
+
+@test "runs tests when the gate passes" {
+  run env VALIDATE_LOOP_GATE_CMD=true VALIDATE_LOOP_TEST_CMD="echo TESTS_RAN" bash "$SCRIPT"
+  [ "$status" -eq 0 ]
+  [[ "$output" == *"TESTS_RAN"* ]]
+}
+
+@test "skips tests and exits non-zero when the gate fails" {
+  run env VALIDATE_LOOP_GATE_CMD=false VALIDATE_LOOP_TEST_CMD="echo TESTS_RAN" bash "$SCRIPT"
+  [ "$status" -ne 0 ]
+  [[ "$output" != *"TESTS_RAN"* ]]
+  [[ "$output" == *"gate failed"* ]]
+}
+
+@test "forwards the gate's failure without running tests" {
+  run env VALIDATE_LOOP_GATE_CMD="sh -c 'echo GATE_OUTPUT; exit 1'" VALIDATE_LOOP_TEST_CMD="echo TESTS_RAN" bash "$SCRIPT"
+  [ "$status" -ne 0 ]
+  [[ "$output" == *"GATE_OUTPUT"* ]]
+  [[ "$output" != *"TESTS_RAN"* ]]
+}

--- a/test/bats/validate-loop.bats
+++ b/test/bats/validate-loop.bats
@@ -20,9 +20,17 @@ SCRIPT="scripts/validate-loop.sh"
   [[ "$output" == *"gate failed"* ]]
 }
 
-@test "forwards the gate's failure without running tests" {
-  run env VALIDATE_LOOP_GATE_CMD="sh -c 'echo GATE_OUTPUT; exit 1'" VALIDATE_LOOP_TEST_CMD="echo TESTS_RAN" bash "$SCRIPT"
+@test "forwards the gate's child output and skips tests on failure" {
+  local dir
+  dir="$(mktemp -d)"
+  # A failing gate fixture whose output marker (CHILD_MARKER) is absent from its
+  # invocation, so the assertion passes only if the child actually ran and its
+  # output was forwarded — not because the script echoed the command line.
+  printf '#!/usr/bin/env bash\necho CHILD_MARKER\nexit 1\n' > "$dir/gate.sh"
+  chmod +x "$dir/gate.sh"
+  run env VALIDATE_LOOP_GATE_CMD="bash $dir/gate.sh" VALIDATE_LOOP_TEST_CMD="echo TESTS_RAN" bash "$SCRIPT"
+  rm -rf "$dir"
   [ "$status" -ne 0 ]
-  [[ "$output" == *"GATE_OUTPUT"* ]]
+  [[ "$output" == *"CHILD_MARKER"* ]]
   [[ "$output" != *"TESTS_RAN"* ]]
 }


### PR DESCRIPTION
## Summary

Adds `scripts/validate-loop.sh` + a `loop` npm script — one fail-fast local
pre-push command that composes the primitives added across this optimization set:

1. **self-heal** deps via `ensure_node_modules` (#5051) so a fresh worktree works;
2. **gate:** `turbo run lint build typecheck` — turbo parallelizes the three;
   `lint` already runs the parallel boundary-check runner (#5121), `typecheck` is
   the cached tsgo task (#5124);
3. **tests only if the gate passed:** `bash scripts/test-fast.sh`
   (`bun test --parallel`, #5033) — ~20s instead of the ~186s `--isolate` run.

Tests run *after* the gate (not alongside): `test:fast` already uses cores-2
workers, so overlapping would oversubscribe the CPU. A gate failure exits in a
few seconds without paying for the test run.

## Linked Issue

Closes #5149

## Changes

- `scripts/validate-loop.sh` — self-heal → gate → conditional test:fast; two env
  seams (`VALIDATE_LOOP_GATE_CMD`, `VALIDATE_LOOP_TEST_CMD`) for testing.
- `package.json` — `loop` script.
- `test/bats/validate-loop.bats` — pins the fail-fast contract (gate-pass → tests
  run; gate-fail → tests skipped + non-zero; gate output forwarded).

## Validation

- [x] `bats test/bats/validate-loop.bats` — 3/3
- [x] `shellcheck` clean; bash-3.2 safe
- [x] `bun run loop` end-to-end: gate green → test:fast runs
- [x] `turbo run lint build test typecheck` green

## Out of scope

- Replacing `turbo run lint build test` in CLAUDE.md / CI (additive local
  convenience).
