### PR TITLE
feat(ios-playground): add inspectable SQLite fixture

### DIFF
--- a/ios/Playground/Playground.xcodeproj/project.pbxproj
+++ b/ios/Playground/Playground.xcodeproj/project.pbxproj
@@ -15,10 +15,12 @@
 		54C16E199D10E281E1E316CF /* SettingsTab.swift in Sources */ = {isa = PBXBuildFile; fileRef = 64FD18EC8D1B9A665615C374 /* SettingsTab.swift */; };
 		553F94B4D033BCA44B07AC4E /* PlaygroundApp.swift in Sources */ = {isa = PBXBuildFile; fileRef = C6EA6F80147865B6F32DD526 /* PlaygroundApp.swift */; };
 		619CDEE3F264DBB3415041D0 /* ShantellSans.ttf in Resources */ = {isa = PBXBuildFile; fileRef = E1B25FBAC5217DE05EA701CF /* ShantellSans.ttf */; };
+		A5167F2B3C4D5E6F708192A3 /* PlaygroundDatabaseFixture.swift in Sources */ = {isa = PBXBuildFile; fileRef = B5167F2B3C4D5E6F708192A3 /* PlaygroundDatabaseFixture.swift */; };
 		72CDA6DB361FDC97490C3C2C /* AutoMobileSDK in Frameworks */ = {isa = PBXBuildFile; productRef = 3137B15D8D485C363DB78A3E /* AutoMobileSDK */; };
 		7C8CF515031B975C05FA2AD2 /* PlaygroundThemeTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = FBFA8ECD2DC59DBF8A6FBBF3 /* PlaygroundThemeTests.swift */; };
 		95CF2D08679D32C4A9966ACD /* CrayonSketchTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 11B156E0FBE749405E1F2D0D /* CrayonSketchTests.swift */; };
 		97CA6F2DE628A139094EF72D /* Colors.swift in Sources */ = {isa = PBXBuildFile; fileRef = 2B46870C2DDF4A2F73A5778B /* Colors.swift */; };
+		A5167F1A2C3D4E5F60718293 /* PlaygroundDatabaseFixtureTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = B5167F1A2C3D4E5F60718293 /* PlaygroundDatabaseFixtureTests.swift */; };
 		B3B613858665E331B7E7EB99 /* SdkHighlightOverlayE2ETests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 8A719AFBA1888450E8653AB6 /* SdkHighlightOverlayE2ETests.swift */; };
 		B73660170723595B44749E9F /* Typography.swift in Sources */ = {isa = PBXBuildFile; fileRef = 51580F5FC5ADCD5576885563 /* Typography.swift */; };
 		C437D38FD2B064F815AE6F33 /* Assets.xcassets in Resources */ = {isa = PBXBuildFile; fileRef = CAC67DC1CDDC454A7BB7870A /* Assets.xcassets */; };
@@ -48,6 +50,8 @@
 		8A719AFBA1888450E8653AB6 /* SdkHighlightOverlayE2ETests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SdkHighlightOverlayE2ETests.swift; sourceTree = "<group>"; };
 		AA0EB8290A6E5436B2C8CE6F /* auto-mobile-sdk */ = {isa = PBXFileReference; lastKnownFileType = folder; name = "auto-mobile-sdk"; path = "../auto-mobile-sdk"; sourceTree = SOURCE_ROOT; };
 		BDA9169E926B14087F3B1BA2 /* Info.plist */ = {isa = PBXFileReference; lastKnownFileType = text.plist; path = Info.plist; sourceTree = "<group>"; };
+		B5167F2B3C4D5E6F708192A3 /* PlaygroundDatabaseFixture.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = PlaygroundDatabaseFixture.swift; sourceTree = "<group>"; };
+		B5167F1A2C3D4E5F60718293 /* PlaygroundDatabaseFixtureTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = PlaygroundDatabaseFixtureTests.swift; sourceTree = "<group>"; };
 		C0972F015B9B7D85BD6F3270 /* CrayonSketch.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CrayonSketch.swift; sourceTree = "<group>"; };
 		C2F4747AC5700DF138836D5F /* Theme.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = Theme.swift; sourceTree = "<group>"; };
 		C6D8C10EFC976E6B3CCD16BD /* Debug.xcconfig */ = {isa = PBXFileReference; lastKnownFileType = text.xcconfig; path = Debug.xcconfig; sourceTree = "<group>"; };
@@ -124,6 +128,7 @@
 			children = (
 				D01BCE22E951887741F32904 /* ContentView.swift */,
 				BDA9169E926B14087F3B1BA2 /* Info.plist */,
+				B5167F2B3C4D5E6F708192A3 /* PlaygroundDatabaseFixture.swift */,
 				C6EA6F80147865B6F32DD526 /* PlaygroundApp.swift */,
 				83925D121AF0F0A28F781607 /* Resources */,
 				EAF2D62F55B68E2361617BFC /* Tabs */,
@@ -144,6 +149,7 @@
 			isa = PBXGroup;
 			children = (
 				11B156E0FBE749405E1F2D0D /* CrayonSketchTests.swift */,
+				B5167F1A2C3D4E5F60718293 /* PlaygroundDatabaseFixtureTests.swift */,
 				FBFA8ECD2DC59DBF8A6FBBF3 /* PlaygroundThemeTests.swift */,
 				8A719AFBA1888450E8653AB6 /* SdkHighlightOverlayE2ETests.swift */,
 			);
@@ -288,6 +294,7 @@
 				4546703D0511A96D6060F587 /* CrayonSketch.swift in Sources */,
 				15B37A3EDBAFD6BD0FC98BFC /* DemosTab.swift in Sources */,
 				EA349DF37933D70B410F7135 /* DiscoverTab.swift in Sources */,
+				A5167F2B3C4D5E6F708192A3 /* PlaygroundDatabaseFixture.swift in Sources */,
 				553F94B4D033BCA44B07AC4E /* PlaygroundApp.swift in Sources */,
 				54C16E199D10E281E1E316CF /* SettingsTab.swift in Sources */,
 				327A28D4620038BBA8D02656 /* Shapes.swift in Sources */,
@@ -301,6 +308,7 @@
 			buildActionMask = 2147483647;
 			files = (
 				95CF2D08679D32C4A9966ACD /* CrayonSketchTests.swift in Sources */,
+				A5167F1A2C3D4E5F60718293 /* PlaygroundDatabaseFixtureTests.swift in Sources */,
 				7C8CF515031B975C05FA2AD2 /* PlaygroundThemeTests.swift in Sources */,
 				B3B613858665E331B7E7EB99 /* SdkHighlightOverlayE2ETests.swift in Sources */,
 			);

--- a/ios/Playground/Playground.xcodeproj/project.pbxproj
+++ b/ios/Playground/Playground.xcodeproj/project.pbxproj
@@ -11,19 +11,19 @@
 		15B37A3EDBAFD6BD0FC98BFC /* DemosTab.swift in Sources */ = {isa = PBXBuildFile; fileRef = 25213AE8A9FD9A5B1EEFD97F /* DemosTab.swift */; };
 		327A28D4620038BBA8D02656 /* Shapes.swift in Sources */ = {isa = PBXBuildFile; fileRef = 5122FF517804CD75B0F75CBA /* Shapes.swift */; };
 		4546703D0511A96D6060F587 /* CrayonSketch.swift in Sources */ = {isa = PBXBuildFile; fileRef = C0972F015B9B7D85BD6F3270 /* CrayonSketch.swift */; };
+		4E220C88A805ED0A7AFDEE38 /* PlaygroundDatabaseFixtureTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = A14ADB69D8A746CDB99D61DE /* PlaygroundDatabaseFixtureTests.swift */; };
 		5339DAC5909A688059ABBA80 /* ContentView.swift in Sources */ = {isa = PBXBuildFile; fileRef = D01BCE22E951887741F32904 /* ContentView.swift */; };
 		54C16E199D10E281E1E316CF /* SettingsTab.swift in Sources */ = {isa = PBXBuildFile; fileRef = 64FD18EC8D1B9A665615C374 /* SettingsTab.swift */; };
 		553F94B4D033BCA44B07AC4E /* PlaygroundApp.swift in Sources */ = {isa = PBXBuildFile; fileRef = C6EA6F80147865B6F32DD526 /* PlaygroundApp.swift */; };
 		619CDEE3F264DBB3415041D0 /* ShantellSans.ttf in Resources */ = {isa = PBXBuildFile; fileRef = E1B25FBAC5217DE05EA701CF /* ShantellSans.ttf */; };
-		A5167F2B3C4D5E6F708192A3 /* PlaygroundDatabaseFixture.swift in Sources */ = {isa = PBXBuildFile; fileRef = B5167F2B3C4D5E6F708192A3 /* PlaygroundDatabaseFixture.swift */; };
 		72CDA6DB361FDC97490C3C2C /* AutoMobileSDK in Frameworks */ = {isa = PBXBuildFile; productRef = 3137B15D8D485C363DB78A3E /* AutoMobileSDK */; };
 		7C8CF515031B975C05FA2AD2 /* PlaygroundThemeTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = FBFA8ECD2DC59DBF8A6FBBF3 /* PlaygroundThemeTests.swift */; };
 		95CF2D08679D32C4A9966ACD /* CrayonSketchTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 11B156E0FBE749405E1F2D0D /* CrayonSketchTests.swift */; };
 		97CA6F2DE628A139094EF72D /* Colors.swift in Sources */ = {isa = PBXBuildFile; fileRef = 2B46870C2DDF4A2F73A5778B /* Colors.swift */; };
-		A5167F1A2C3D4E5F60718293 /* PlaygroundDatabaseFixtureTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = B5167F1A2C3D4E5F60718293 /* PlaygroundDatabaseFixtureTests.swift */; };
 		B3B613858665E331B7E7EB99 /* SdkHighlightOverlayE2ETests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 8A719AFBA1888450E8653AB6 /* SdkHighlightOverlayE2ETests.swift */; };
 		B73660170723595B44749E9F /* Typography.swift in Sources */ = {isa = PBXBuildFile; fileRef = 51580F5FC5ADCD5576885563 /* Typography.swift */; };
 		C437D38FD2B064F815AE6F33 /* Assets.xcassets in Resources */ = {isa = PBXBuildFile; fileRef = CAC67DC1CDDC454A7BB7870A /* Assets.xcassets */; };
+		C9A1977492B71CC9FE85DA16 /* PlaygroundDatabaseFixture.swift in Sources */ = {isa = PBXBuildFile; fileRef = 3CF899DC96DC92471BB6FC81 /* PlaygroundDatabaseFixture.swift */; };
 		E46744897A309BECE20573D9 /* AutoMobileSDK in Frameworks */ = {isa = PBXBuildFile; productRef = 5B1F96DAE2D3DE50DD89C21C /* AutoMobileSDK */; };
 		EA349DF37933D70B410F7135 /* DiscoverTab.swift in Sources */ = {isa = PBXBuildFile; fileRef = FF86B8E1368C9B39424F13C0 /* DiscoverTab.swift */; };
 		F99EE983EC6317D09E5A3247 /* AccessibilityRotorDemo.swift in Sources */ = {isa = PBXBuildFile; fileRef = D61225B3155981050B6A59A6 /* AccessibilityRotorDemo.swift */; };
@@ -44,14 +44,14 @@
 		11B156E0FBE749405E1F2D0D /* CrayonSketchTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CrayonSketchTests.swift; sourceTree = "<group>"; };
 		25213AE8A9FD9A5B1EEFD97F /* DemosTab.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = DemosTab.swift; sourceTree = "<group>"; };
 		2B46870C2DDF4A2F73A5778B /* Colors.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = Colors.swift; sourceTree = "<group>"; };
+		3CF899DC96DC92471BB6FC81 /* PlaygroundDatabaseFixture.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = PlaygroundDatabaseFixture.swift; sourceTree = "<group>"; };
 		5122FF517804CD75B0F75CBA /* Shapes.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = Shapes.swift; sourceTree = "<group>"; };
 		51580F5FC5ADCD5576885563 /* Typography.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = Typography.swift; sourceTree = "<group>"; };
 		64FD18EC8D1B9A665615C374 /* SettingsTab.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SettingsTab.swift; sourceTree = "<group>"; };
 		8A719AFBA1888450E8653AB6 /* SdkHighlightOverlayE2ETests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SdkHighlightOverlayE2ETests.swift; sourceTree = "<group>"; };
+		A14ADB69D8A746CDB99D61DE /* PlaygroundDatabaseFixtureTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = PlaygroundDatabaseFixtureTests.swift; sourceTree = "<group>"; };
 		AA0EB8290A6E5436B2C8CE6F /* auto-mobile-sdk */ = {isa = PBXFileReference; lastKnownFileType = folder; name = "auto-mobile-sdk"; path = "../auto-mobile-sdk"; sourceTree = SOURCE_ROOT; };
 		BDA9169E926B14087F3B1BA2 /* Info.plist */ = {isa = PBXFileReference; lastKnownFileType = text.plist; path = Info.plist; sourceTree = "<group>"; };
-		B5167F2B3C4D5E6F708192A3 /* PlaygroundDatabaseFixture.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = PlaygroundDatabaseFixture.swift; sourceTree = "<group>"; };
-		B5167F1A2C3D4E5F60718293 /* PlaygroundDatabaseFixtureTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = PlaygroundDatabaseFixtureTests.swift; sourceTree = "<group>"; };
 		C0972F015B9B7D85BD6F3270 /* CrayonSketch.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CrayonSketch.swift; sourceTree = "<group>"; };
 		C2F4747AC5700DF138836D5F /* Theme.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = Theme.swift; sourceTree = "<group>"; };
 		C6D8C10EFC976E6B3CCD16BD /* Debug.xcconfig */ = {isa = PBXFileReference; lastKnownFileType = text.xcconfig; path = Debug.xcconfig; sourceTree = "<group>"; };
@@ -128,8 +128,8 @@
 			children = (
 				D01BCE22E951887741F32904 /* ContentView.swift */,
 				BDA9169E926B14087F3B1BA2 /* Info.plist */,
-				B5167F2B3C4D5E6F708192A3 /* PlaygroundDatabaseFixture.swift */,
 				C6EA6F80147865B6F32DD526 /* PlaygroundApp.swift */,
+				3CF899DC96DC92471BB6FC81 /* PlaygroundDatabaseFixture.swift */,
 				83925D121AF0F0A28F781607 /* Resources */,
 				EAF2D62F55B68E2361617BFC /* Tabs */,
 				6BB7FE49E94ED3C6DF5E9D08 /* Theme */,
@@ -149,7 +149,7 @@
 			isa = PBXGroup;
 			children = (
 				11B156E0FBE749405E1F2D0D /* CrayonSketchTests.swift */,
-				B5167F1A2C3D4E5F60718293 /* PlaygroundDatabaseFixtureTests.swift */,
+				A14ADB69D8A746CDB99D61DE /* PlaygroundDatabaseFixtureTests.swift */,
 				FBFA8ECD2DC59DBF8A6FBBF3 /* PlaygroundThemeTests.swift */,
 				8A719AFBA1888450E8653AB6 /* SdkHighlightOverlayE2ETests.swift */,
 			);
@@ -294,8 +294,8 @@
 				4546703D0511A96D6060F587 /* CrayonSketch.swift in Sources */,
 				15B37A3EDBAFD6BD0FC98BFC /* DemosTab.swift in Sources */,
 				EA349DF37933D70B410F7135 /* DiscoverTab.swift in Sources */,
-				A5167F2B3C4D5E6F708192A3 /* PlaygroundDatabaseFixture.swift in Sources */,
 				553F94B4D033BCA44B07AC4E /* PlaygroundApp.swift in Sources */,
+				C9A1977492B71CC9FE85DA16 /* PlaygroundDatabaseFixture.swift in Sources */,
 				54C16E199D10E281E1E316CF /* SettingsTab.swift in Sources */,
 				327A28D4620038BBA8D02656 /* Shapes.swift in Sources */,
 				007B2120C2735B42A20C510B /* Theme.swift in Sources */,
@@ -308,7 +308,7 @@
 			buildActionMask = 2147483647;
 			files = (
 				95CF2D08679D32C4A9966ACD /* CrayonSketchTests.swift in Sources */,
-				A5167F1A2C3D4E5F60718293 /* PlaygroundDatabaseFixtureTests.swift in Sources */,
+				4E220C88A805ED0A7AFDEE38 /* PlaygroundDatabaseFixtureTests.swift in Sources */,
 				7C8CF515031B975C05FA2AD2 /* PlaygroundThemeTests.swift in Sources */,
 				B3B613858665E331B7E7EB99 /* SdkHighlightOverlayE2ETests.swift in Sources */,
 			);

--- a/ios/Playground/Sources/PlaygroundApp.swift
+++ b/ios/Playground/Sources/PlaygroundApp.swift
@@ -9,8 +9,8 @@ struct PlaygroundApp: App {
 
         // Enable storage inspection in debug builds
         #if DEBUG
-        UserDefaultsInspector.shared.setEnabled(true)
-        DatabaseInspector.shared.setEnabled(true)
+            UserDefaultsInspector.shared.setEnabled(true)
+            PlaygroundDatabaseFixture().install()
         #endif
 
         AutoMobileLog.shared.i("PlaygroundApp", "app_launched")

--- a/ios/Playground/Sources/PlaygroundApp.swift
+++ b/ios/Playground/Sources/PlaygroundApp.swift
@@ -10,7 +10,11 @@ struct PlaygroundApp: App {
         // Enable storage inspection in debug builds
         #if DEBUG
             UserDefaultsInspector.shared.setEnabled(true)
-            PlaygroundDatabaseFixture().install()
+            do {
+                try PlaygroundDatabaseFixture().install()
+            } catch {
+                AutoMobileLog.shared.e("PlaygroundApp", "database_fixture_failed error=\(error.localizedDescription)")
+            }
         #endif
 
         AutoMobileLog.shared.i("PlaygroundApp", "app_launched")

--- a/ios/Playground/Sources/PlaygroundDatabaseFixture.swift
+++ b/ios/Playground/Sources/PlaygroundDatabaseFixture.swift
@@ -1,0 +1,108 @@
+import AutoMobileSDK
+import Foundation
+
+protocol PlaygroundFileSystem {
+    var applicationSupportDirectory: URL? { get }
+
+    func createDirectory(at url: URL) throws
+    func fileExists(atPath path: String) -> Bool
+}
+
+protocol PlaygroundDatabaseInspecting {
+    func configure(_ configuration: StorageInspectionConfiguration)
+    func setEnabled(_ enabled: Bool)
+    func getDriver() -> DatabaseDriver?
+}
+
+struct PlaygroundDatabaseFixture {
+    static let databaseFileName = "sessions.sqlite"
+
+    private static let seedStatements = [
+        """
+        CREATE TABLE sessions (
+            id INTEGER PRIMARY KEY AUTOINCREMENT,
+            session_id TEXT NOT NULL,
+            started_at INTEGER NOT NULL,
+            app_version TEXT,
+            device_model TEXT,
+            os_version TEXT
+        )
+        """,
+        """
+        INSERT INTO sessions (session_id, started_at, app_version, device_model, os_version)
+        VALUES ('ios-playground-seed-001', 1704067200000, '0.0.50', 'iPhone Simulator', 'iOS 17.0')
+        """,
+    ]
+
+    private let fileSystem: any PlaygroundFileSystem
+    private let inspector: any PlaygroundDatabaseInspecting
+
+    init(
+        fileSystem: any PlaygroundFileSystem = DefaultPlaygroundFileSystem(),
+        inspector: any PlaygroundDatabaseInspecting = DefaultPlaygroundDatabaseInspector()
+    ) {
+        self.fileSystem = fileSystem
+        self.inspector = inspector
+    }
+
+    var databaseURL: URL? {
+        fileSystem.applicationSupportDirectory?
+            .appendingPathComponent("Playground", isDirectory: true)
+            .appendingPathComponent(Self.databaseFileName, isDirectory: false)
+    }
+
+    @discardableResult
+    func install() -> URL? {
+        guard let databaseURL else { return nil }
+
+        do {
+            try fileSystem.createDirectory(at: databaseURL.deletingLastPathComponent())
+        } catch {
+            return nil
+        }
+
+        inspector.configure(StorageInspectionConfiguration(allowedDatabasePaths: [databaseURL.path]))
+        inspector.setEnabled(true)
+
+        guard !fileSystem.fileExists(atPath: databaseURL.path),
+              let driver = inspector.getDriver()
+        else {
+            return databaseURL
+        }
+
+        for statement in Self.seedStatements {
+            let result = driver.executeSQL(databasePath: databaseURL.path, query: statement)
+            guard result.error == nil else { break }
+        }
+
+        return databaseURL
+    }
+}
+
+private struct DefaultPlaygroundFileSystem: PlaygroundFileSystem {
+    var applicationSupportDirectory: URL? {
+        FileManager.default.urls(for: .applicationSupportDirectory, in: .userDomainMask).first
+    }
+
+    func createDirectory(at url: URL) throws {
+        try FileManager.default.createDirectory(at: url, withIntermediateDirectories: true)
+    }
+
+    func fileExists(atPath path: String) -> Bool {
+        FileManager.default.fileExists(atPath: path)
+    }
+}
+
+private struct DefaultPlaygroundDatabaseInspector: PlaygroundDatabaseInspecting {
+    func configure(_ configuration: StorageInspectionConfiguration) {
+        DatabaseInspector.shared.configure(configuration)
+    }
+
+    func setEnabled(_ enabled: Bool) {
+        DatabaseInspector.shared.setEnabled(enabled)
+    }
+
+    func getDriver() -> DatabaseDriver? {
+        DatabaseInspector.shared.getDriver()
+    }
+}

--- a/ios/Playground/Sources/PlaygroundDatabaseFixture.swift
+++ b/ios/Playground/Sources/PlaygroundDatabaseFixture.swift
@@ -5,13 +5,25 @@ protocol PlaygroundFileSystem {
     var applicationSupportDirectory: URL? { get }
 
     func createDirectory(at url: URL) throws
-    func fileExists(atPath path: String) -> Bool
 }
 
 protocol PlaygroundDatabaseInspecting {
     func configure(_ configuration: StorageInspectionConfiguration)
     func setEnabled(_ enabled: Bool)
-    func getDriver() -> DatabaseDriver?
+}
+
+enum PlaygroundDatabaseFixtureError: LocalizedError {
+    case applicationSupportDirectoryUnavailable
+    case sqlExecutionFailed(String)
+
+    var errorDescription: String? {
+        switch self {
+        case .applicationSupportDirectoryUnavailable:
+            "Application Support directory is unavailable"
+        case let .sqlExecutionFailed(message):
+            "Failed to seed Playground database: \(message)"
+        }
+    }
 }
 
 struct PlaygroundDatabaseFixture {
@@ -19,7 +31,7 @@ struct PlaygroundDatabaseFixture {
 
     private static let seedStatements = [
         """
-        CREATE TABLE sessions (
+        CREATE TABLE IF NOT EXISTS sessions (
             id INTEGER PRIMARY KEY AUTOINCREMENT,
             session_id TEXT NOT NULL,
             started_at INTEGER NOT NULL,
@@ -30,19 +42,25 @@ struct PlaygroundDatabaseFixture {
         """,
         """
         INSERT INTO sessions (session_id, started_at, app_version, device_model, os_version)
-        VALUES ('ios-playground-seed-001', 1704067200000, '0.0.50', 'iPhone Simulator', 'iOS 17.0')
+        SELECT 'ios-playground-seed-001', 1704067200000, '0.0.50', 'iPhone Simulator', 'iOS 17.0'
+        WHERE NOT EXISTS (
+            SELECT 1 FROM sessions WHERE session_id = 'ios-playground-seed-001'
+        )
         """,
     ]
 
     private let fileSystem: any PlaygroundFileSystem
     private let inspector: any PlaygroundDatabaseInspecting
+    private let seedDriver: any DatabaseDriver
 
     init(
         fileSystem: any PlaygroundFileSystem = DefaultPlaygroundFileSystem(),
-        inspector: any PlaygroundDatabaseInspecting = DefaultPlaygroundDatabaseInspector()
+        inspector: any PlaygroundDatabaseInspecting = DefaultPlaygroundDatabaseInspector(),
+        seedDriver: any DatabaseDriver = SQLiteDatabaseDriver()
     ) {
         self.fileSystem = fileSystem
         self.inspector = inspector
+        self.seedDriver = seedDriver
     }
 
     var databaseURL: URL? {
@@ -52,30 +70,37 @@ struct PlaygroundDatabaseFixture {
     }
 
     @discardableResult
-    func install() -> URL? {
-        guard let databaseURL else { return nil }
-
-        do {
-            try fileSystem.createDirectory(at: databaseURL.deletingLastPathComponent())
-        } catch {
-            return nil
+    func install() throws -> URL {
+        guard let databaseURL else {
+            throw PlaygroundDatabaseFixtureError.applicationSupportDirectoryUnavailable
         }
+        try fileSystem.createDirectory(at: databaseURL.deletingLastPathComponent())
+
+        try execute("BEGIN IMMEDIATE TRANSACTION", databaseURL: databaseURL)
+        var committed = false
+        defer {
+            if !committed {
+                _ = seedDriver.executeSQL(databasePath: databaseURL.path, query: "ROLLBACK")
+            }
+        }
+
+        for statement in Self.seedStatements {
+            try execute(statement, databaseURL: databaseURL)
+        }
+        try execute("COMMIT", databaseURL: databaseURL)
+        committed = true
 
         inspector.configure(StorageInspectionConfiguration(allowedDatabasePaths: [databaseURL.path]))
         inspector.setEnabled(true)
 
-        guard !fileSystem.fileExists(atPath: databaseURL.path),
-              let driver = inspector.getDriver()
-        else {
-            return databaseURL
-        }
-
-        for statement in Self.seedStatements {
-            let result = driver.executeSQL(databasePath: databaseURL.path, query: statement)
-            guard result.error == nil else { break }
-        }
-
         return databaseURL
+    }
+
+    private func execute(_ statement: String, databaseURL: URL) throws {
+        let result = seedDriver.executeSQL(databasePath: databaseURL.path, query: statement)
+        if let error = result.error {
+            throw PlaygroundDatabaseFixtureError.sqlExecutionFailed(error)
+        }
     }
 }
 
@@ -87,10 +112,6 @@ private struct DefaultPlaygroundFileSystem: PlaygroundFileSystem {
     func createDirectory(at url: URL) throws {
         try FileManager.default.createDirectory(at: url, withIntermediateDirectories: true)
     }
-
-    func fileExists(atPath path: String) -> Bool {
-        FileManager.default.fileExists(atPath: path)
-    }
 }
 
 private struct DefaultPlaygroundDatabaseInspector: PlaygroundDatabaseInspecting {
@@ -100,9 +121,5 @@ private struct DefaultPlaygroundDatabaseInspector: PlaygroundDatabaseInspecting 
 
     func setEnabled(_ enabled: Bool) {
         DatabaseInspector.shared.setEnabled(enabled)
-    }
-
-    func getDriver() -> DatabaseDriver? {
-        DatabaseInspector.shared.getDriver()
     }
 }

--- a/ios/Playground/Tests/PlaygroundDatabaseFixtureTests.swift
+++ b/ios/Playground/Tests/PlaygroundDatabaseFixtureTests.swift
@@ -1,0 +1,103 @@
+import AutoMobileSDK
+import XCTest
+
+@testable import Playground
+
+/// Pins the iOS Playground database fixture used by manual SQL inspection tests.
+final class PlaygroundDatabaseFixtureTests: XCTestCase {
+    func testInstallConfiguresInspectionAndSeedsNewDatabase() throws {
+        let fileSystem = FakePlaygroundFileSystem()
+        let driver = FakeDatabaseDriver()
+        let inspector = FakePlaygroundDatabaseInspector(driver: driver)
+        let fixture = PlaygroundDatabaseFixture(fileSystem: fileSystem, inspector: inspector)
+
+        let databaseURL = try XCTUnwrap(fixture.install())
+
+        XCTAssertEqual(
+            inspector.configuration.allowedDatabasePaths,
+            [databaseURL.path]
+        )
+        XCTAssertTrue(inspector.isEnabled)
+        XCTAssertEqual(fileSystem.createdDirectories.map(\.path), [databaseURL.deletingLastPathComponent().path])
+        XCTAssertEqual(driver.executedQueries.count, 2)
+        XCTAssertTrue(driver.executedQueries[0].contains("CREATE TABLE sessions"))
+        XCTAssertTrue(driver.executedQueries[1].contains("ios-playground-seed-001"))
+        XCTAssertTrue(driver.executedQueries[1].contains("iPhone Simulator"))
+    }
+
+    func testInstallDoesNotReseedExistingDatabase() throws {
+        let fileSystem = FakePlaygroundFileSystem()
+        let driver = FakeDatabaseDriver()
+        let inspector = FakePlaygroundDatabaseInspector(driver: driver)
+        let fixture = PlaygroundDatabaseFixture(fileSystem: fileSystem, inspector: inspector)
+        let expectedURL = try XCTUnwrap(fixture.databaseURL)
+        fileSystem.existingPaths.insert(expectedURL.path)
+
+        let databaseURL = try XCTUnwrap(fixture.install())
+
+        XCTAssertEqual(databaseURL, expectedURL)
+        XCTAssertTrue(inspector.isEnabled)
+        XCTAssertTrue(driver.executedQueries.isEmpty)
+    }
+}
+
+private final class FakePlaygroundFileSystem: PlaygroundFileSystem {
+    let applicationSupportDirectory: URL? = URL(fileURLWithPath: "/tmp/playground-fixture-tests", isDirectory: true)
+    var existingPaths = Set<String>()
+    var createdDirectories: [URL] = []
+
+    func createDirectory(at url: URL) throws {
+        createdDirectories.append(url)
+    }
+
+    func fileExists(atPath path: String) -> Bool {
+        existingPaths.contains(path)
+    }
+}
+
+private final class FakePlaygroundDatabaseInspector: PlaygroundDatabaseInspecting {
+    let driver: DatabaseDriver
+    private(set) var configuration = StorageInspectionConfiguration()
+    private(set) var isEnabled = false
+
+    init(driver: DatabaseDriver) {
+        self.driver = driver
+    }
+
+    func configure(_ configuration: StorageInspectionConfiguration) {
+        self.configuration = configuration
+    }
+
+    func setEnabled(_ enabled: Bool) {
+        isEnabled = enabled
+    }
+
+    func getDriver() -> DatabaseDriver? {
+        driver
+    }
+}
+
+private final class FakeDatabaseDriver: DatabaseDriver, @unchecked Sendable {
+    var executedQueries: [String] = []
+
+    func getDatabases() -> [DatabaseDescriptor] {
+        []
+    }
+
+    func getTables(databasePath _: String) -> [String] {
+        []
+    }
+
+    func getTableData(databasePath _: String, table _: String, limit _: Int, offset _: Int) -> TableDataResult {
+        TableDataResult(columns: [], rows: [], totalRows: 0)
+    }
+
+    func getTableStructure(databasePath _: String, table _: String) -> TableStructureResult {
+        TableStructureResult(columns: [])
+    }
+
+    func executeSQL(databasePath _: String, query: String) -> SQLExecutionResult {
+        executedQueries.append(query)
+        return SQLExecutionResult(columns: nil, rows: nil, rowsAffected: 0)
+    }
+}

--- a/ios/Playground/Tests/PlaygroundDatabaseFixtureTests.swift
+++ b/ios/Playground/Tests/PlaygroundDatabaseFixtureTests.swift
@@ -8,10 +8,14 @@ final class PlaygroundDatabaseFixtureTests: XCTestCase {
     func testInstallConfiguresInspectionAndSeedsNewDatabase() throws {
         let fileSystem = FakePlaygroundFileSystem()
         let driver = FakeDatabaseDriver()
-        let inspector = FakePlaygroundDatabaseInspector(driver: driver)
-        let fixture = PlaygroundDatabaseFixture(fileSystem: fileSystem, inspector: inspector)
+        let inspector = FakePlaygroundDatabaseInspector()
+        let fixture = PlaygroundDatabaseFixture(
+            fileSystem: fileSystem,
+            inspector: inspector,
+            seedDriver: driver
+        )
 
-        let databaseURL = try XCTUnwrap(fixture.install())
+        let databaseURL = try fixture.install()
 
         XCTAssertEqual(
             inspector.configuration.allowedDatabasePaths,
@@ -19,50 +23,119 @@ final class PlaygroundDatabaseFixtureTests: XCTestCase {
         )
         XCTAssertTrue(inspector.isEnabled)
         XCTAssertEqual(fileSystem.createdDirectories.map(\.path), [databaseURL.deletingLastPathComponent().path])
-        XCTAssertEqual(driver.executedQueries.count, 2)
-        XCTAssertTrue(driver.executedQueries[0].contains("CREATE TABLE sessions"))
-        XCTAssertTrue(driver.executedQueries[1].contains("ios-playground-seed-001"))
-        XCTAssertTrue(driver.executedQueries[1].contains("iPhone Simulator"))
+        XCTAssertEqual(driver.executedQueries.count, 4)
+        XCTAssertEqual(driver.executedQueries[0], "BEGIN IMMEDIATE TRANSACTION")
+        XCTAssertTrue(driver.executedQueries[1].contains("CREATE TABLE IF NOT EXISTS sessions"))
+        XCTAssertTrue(driver.executedQueries[2].contains("ios-playground-seed-001"))
+        XCTAssertTrue(driver.executedQueries[2].contains("WHERE NOT EXISTS"))
+        XCTAssertEqual(driver.executedQueries[3], "COMMIT")
     }
 
-    func testInstallDoesNotReseedExistingDatabase() throws {
+    func testInstallFailureRollsBackWithoutEnablingInspectionAndCanRetry() throws {
         let fileSystem = FakePlaygroundFileSystem()
-        let driver = FakeDatabaseDriver()
-        let inspector = FakePlaygroundDatabaseInspector(driver: driver)
-        let fixture = PlaygroundDatabaseFixture(fileSystem: fileSystem, inspector: inspector)
-        let expectedURL = try XCTUnwrap(fixture.databaseURL)
-        fileSystem.existingPaths.insert(expectedURL.path)
+        let driver = FakeDatabaseDriver(failingQuery: "INSERT")
+        let inspector = FakePlaygroundDatabaseInspector()
+        let fixture = PlaygroundDatabaseFixture(
+            fileSystem: fileSystem,
+            inspector: inspector,
+            seedDriver: driver
+        )
 
-        let databaseURL = try XCTUnwrap(fixture.install())
+        XCTAssertThrowsError(try fixture.install()) { error in
+            XCTAssertEqual(
+                error.localizedDescription,
+                "Failed to seed Playground database: seed failed"
+            )
+        }
+        XCTAssertFalse(inspector.isEnabled)
+        XCTAssertTrue(inspector.configuration.allowedDatabasePaths.isEmpty)
+        XCTAssertEqual(driver.executedQueries.last, "ROLLBACK")
 
-        XCTAssertEqual(databaseURL, expectedURL)
+        driver.failingQuery = nil
+        _ = try fixture.install()
+
         XCTAssertTrue(inspector.isEnabled)
+        XCTAssertEqual(driver.executedQueries[4], "BEGIN IMMEDIATE TRANSACTION")
+        XCTAssertEqual(driver.executedQueries[7], "COMMIT")
+    }
+
+    func testInstallWithoutApplicationSupportDoesNotSeedOrEnableInspection() {
+        let fileSystem = FakePlaygroundFileSystem(applicationSupportDirectory: nil)
+        let driver = FakeDatabaseDriver()
+        let inspector = FakePlaygroundDatabaseInspector()
+        let fixture = PlaygroundDatabaseFixture(
+            fileSystem: fileSystem,
+            inspector: inspector,
+            seedDriver: driver
+        )
+
+        XCTAssertThrowsError(try fixture.install()) { error in
+            XCTAssertEqual(error.localizedDescription, "Application Support directory is unavailable")
+        }
         XCTAssertTrue(driver.executedQueries.isEmpty)
+        XCTAssertFalse(inspector.isEnabled)
+        XCTAssertTrue(inspector.configuration.allowedDatabasePaths.isEmpty)
+    }
+
+    func testInstallIsIdempotentWithRealSQLiteDriver() throws {
+        let applicationSupportURL = FileManager.default.temporaryDirectory
+            .appendingPathComponent(UUID().uuidString, isDirectory: true)
+        let fileSystem = RealPlaygroundFileSystem(applicationSupportDirectory: applicationSupportURL)
+        let inspector = FakePlaygroundDatabaseInspector()
+        let driver = SQLiteDatabaseDriver()
+        let fixture = PlaygroundDatabaseFixture(
+            fileSystem: fileSystem,
+            inspector: inspector,
+            seedDriver: driver
+        )
+        defer {
+            driver.closeAll()
+            try? FileManager.default.removeItem(at: applicationSupportURL)
+        }
+
+        let databaseURL = try fixture.install()
+        _ = try fixture.install()
+        let tableData = driver.getTableData(
+            databasePath: databaseURL.path,
+            table: "sessions",
+            limit: 10,
+            offset: 0
+        )
+
+        XCTAssertEqual(tableData.totalRows, 1)
+        XCTAssertEqual(tableData.rows.first?[1], "ios-playground-seed-001")
     }
 }
 
 private final class FakePlaygroundFileSystem: PlaygroundFileSystem {
-    let applicationSupportDirectory: URL? = URL(fileURLWithPath: "/tmp/playground-fixture-tests", isDirectory: true)
-    var existingPaths = Set<String>()
+    let applicationSupportDirectory: URL?
     var createdDirectories: [URL] = []
+
+    init(
+        applicationSupportDirectory: URL? = URL(
+            fileURLWithPath: "/tmp/playground-fixture-tests",
+            isDirectory: true
+        )
+    ) {
+        self.applicationSupportDirectory = applicationSupportDirectory
+    }
 
     func createDirectory(at url: URL) throws {
         createdDirectories.append(url)
     }
+}
 
-    func fileExists(atPath path: String) -> Bool {
-        existingPaths.contains(path)
+private struct RealPlaygroundFileSystem: PlaygroundFileSystem {
+    let applicationSupportDirectory: URL?
+
+    func createDirectory(at url: URL) throws {
+        try FileManager.default.createDirectory(at: url, withIntermediateDirectories: true)
     }
 }
 
 private final class FakePlaygroundDatabaseInspector: PlaygroundDatabaseInspecting {
-    let driver: DatabaseDriver
     private(set) var configuration = StorageInspectionConfiguration()
     private(set) var isEnabled = false
-
-    init(driver: DatabaseDriver) {
-        self.driver = driver
-    }
 
     func configure(_ configuration: StorageInspectionConfiguration) {
         self.configuration = configuration
@@ -71,14 +144,15 @@ private final class FakePlaygroundDatabaseInspector: PlaygroundDatabaseInspectin
     func setEnabled(_ enabled: Bool) {
         isEnabled = enabled
     }
-
-    func getDriver() -> DatabaseDriver? {
-        driver
-    }
 }
 
 private final class FakeDatabaseDriver: DatabaseDriver, @unchecked Sendable {
+    var failingQuery: String?
     var executedQueries: [String] = []
+
+    init(failingQuery: String? = nil) {
+        self.failingQuery = failingQuery
+    }
 
     func getDatabases() -> [DatabaseDescriptor] {
         []
@@ -98,6 +172,9 @@ private final class FakeDatabaseDriver: DatabaseDriver, @unchecked Sendable {
 
     func executeSQL(databasePath _: String, query: String) -> SQLExecutionResult {
         executedQueries.append(query)
+        if let failingQuery, query.contains(failingQuery) {
+            return SQLExecutionResult(columns: nil, rows: nil, rowsAffected: 0, error: "seed failed")
+        }
         return SQLExecutionResult(columns: nil, rows: nil, rowsAffected: 0)
     }
 }

--- a/ios/auto-mobile-sdk/Sources/AutoMobileSDK/Storage/SQLiteDatabaseDriver.swift
+++ b/ios/auto-mobile-sdk/Sources/AutoMobileSDK/Storage/SQLiteDatabaseDriver.swift
@@ -7,9 +7,20 @@ import SQLite3
 public final class SQLiteDatabaseDriver: DatabaseDriver, @unchecked Sendable {
     private let lock = NSLock()
     private let operationLock = NSLock()
+    private let searchPaths: [String]
     private var openDatabases: [String: OpaquePointer] = [:]
 
-    public init() {}
+    public init() {
+        searchPaths = [
+            NSSearchPathForDirectoriesInDomains(.documentDirectory, .userDomainMask, true),
+            NSSearchPathForDirectoriesInDomains(.libraryDirectory, .userDomainMask, true),
+            NSSearchPathForDirectoriesInDomains(.applicationSupportDirectory, .userDomainMask, true),
+        ].flatMap { $0 }
+    }
+
+    init(searchPaths: [String]) {
+        self.searchPaths = searchPaths
+    }
 
     deinit {
         closeAll()
@@ -19,15 +30,10 @@ public final class SQLiteDatabaseDriver: DatabaseDriver, @unchecked Sendable {
 
     public func getDatabases() -> [DatabaseDescriptor] {
         var databases: [DatabaseDescriptor] = []
+        var seenPaths = Set<String>()
         let fileManager = FileManager.default
         let extensions = ["sqlite", "db", "sqlite3"]
         let journalSuffixes = ["-journal", "-wal", "-shm"]
-
-        let searchPaths: [String] = [
-            NSSearchPathForDirectoriesInDomains(.documentDirectory, .userDomainMask, true),
-            NSSearchPathForDirectoriesInDomains(.libraryDirectory, .userDomainMask, true),
-            NSSearchPathForDirectoriesInDomains(.applicationSupportDirectory, .userDomainMask, true),
-        ].flatMap { $0 }
 
         for basePath in searchPaths {
             guard let enumerator = fileManager.enumerator(atPath: basePath) else { continue }
@@ -39,6 +45,7 @@ public final class SQLiteDatabaseDriver: DatabaseDriver, @unchecked Sendable {
                 guard extensions.contains(ext) else { continue }
 
                 let fullPath = (basePath as NSString).appendingPathComponent(file)
+                guard seenPaths.insert(fullPath).inserted else { continue }
                 let attrs = try? fileManager.attributesOfItem(atPath: fullPath)
                 let size = attrs?[.size] as? Int64 ?? 0
                 databases.append(DatabaseDescriptor(
@@ -249,7 +256,9 @@ public final class SQLiteDatabaseDriver: DatabaseDriver, @unchecked Sendable {
 
         var db: OpaquePointer?
         guard sqlite3_open_v2(path, &db, flags, nil) == SQLITE_OK else {
-            if let db = db { sqlite3_close(db) }
+            if let db = db {
+                sqlite3_close(db)
+            }
             return nil
         }
 

--- a/ios/auto-mobile-sdk/Tests/AutoMobileSDKTests/SQLiteDatabaseDriverTests.swift
+++ b/ios/auto-mobile-sdk/Tests/AutoMobileSDKTests/SQLiteDatabaseDriverTests.swift
@@ -38,6 +38,27 @@ final class SQLiteDatabaseDriverTests: XCTestCase {
         XCTAssertEqual(result.rowsAffected, 1)
     }
 
+    func testGetDatabasesDeduplicatesOverlappingSearchPaths() throws {
+        let rootURL = FileManager.default.temporaryDirectory
+            .appendingPathComponent(UUID().uuidString, isDirectory: true)
+        let nestedURL = rootURL
+            .appendingPathComponent("Library", isDirectory: true)
+            .appendingPathComponent("Application Support", isDirectory: true)
+        let databaseURL = nestedURL.appendingPathComponent("nested.sqlite")
+        try FileManager.default.createDirectory(at: nestedURL, withIntermediateDirectories: true)
+        defer { try? FileManager.default.removeItem(at: rootURL) }
+        FileManager.default.createFile(atPath: databaseURL.path, contents: Data())
+
+        let driver = SQLiteDatabaseDriver(searchPaths: [
+            rootURL.appendingPathComponent("Library", isDirectory: true).path,
+            nestedURL.path,
+        ])
+
+        let matches = driver.getDatabases().filter { $0.path == databaseURL.path }
+
+        XCTAssertEqual(matches.count, 1)
+    }
+
     func testUpdateReturningAppliesMutationAndReturnsChangedRow() {
         let result = driver.executeSQL(
             databasePath: databaseURL.path,


### PR DESCRIPTION
## Summary

- Add a DEBUG-only iOS Playground SQLite fixture at `Library/Application Support/Playground/sessions.sqlite`.
- Seed a deterministic `sessions` row in a retryable transaction before registering and enabling database inspection.
- Register only the exact fixture path with `StorageInspectionConfiguration.allowedDatabasePaths`.
- Deduplicate SQLite discovery across the overlapping Library and Application Support search roots.
- Cover successful installation, rollback/retry, missing-directory behavior, real SQLite idempotence, and overlapping-path discovery with injected seams and fakes.

## Root cause

The iOS Playground enabled `DatabaseInspector` without registering any database path. After the storage-boundary hardening in [#5128](https://github.com/kaeawc/auto-mobile/pull/5128), the empty allowlist correctly made every iOS database request unavailable, leaving the inspection surface without an end-to-end fixture.

## Validation

- Focused fixture tests: 4 passed.
- Full iOS Playground test target: 20 passed.
- SQLite database driver tests: 8 passed.
- Fresh simulator install verified `/db/list`, `/db/tables`, `/db/table-data`, `/db/table-structure`, and `/db/execute` against the exact allowlisted fixture; relaunch preserved exactly one seed row.
- Debug and Release simulator builds passed, verifying the fixture remains DEBUG-only.
- `bun run turbo:validate` passed: 12,984 passed, 13 skipped, 0 failed.
- `bun run typecheck` passed with no new errors.
- `bash scripts/ios/swift-build.sh` passed.
- XcodeGen drift validation passed.
- Full SwiftLint passed with 0 errors; touched-file SwiftFormat passed and touched-file SwiftLint reported only pre-existing warnings.
- Repository-wide SwiftFormat still reports pre-existing violations outside this change.

Closes [#5167](https://github.com/kaeawc/auto-mobile/issues/5167)
