### PR TITLE
fix(database): allow Android read-only sqlQuery

### DIFF
--- a/android/auto-mobile-sdk/api/auto-mobile-sdk.api
+++ b/android/auto-mobile-sdk/api/auto-mobile-sdk.api
@@ -857,6 +857,7 @@ public final class dev.jasonpearson.automobile.sdk.database.SQLiteDatabaseDriver
   public dev.jasonpearson.automobile.sdk.database.TableDataResult getTableData(java.lang.String, java.lang.String, int, int);
   public dev.jasonpearson.automobile.sdk.database.TableStructureResult getTableStructure(java.lang.String, java.lang.String);
   public dev.jasonpearson.automobile.sdk.database.SQLExecutionResult executeSQL(java.lang.String, java.lang.String);
+  public final dev.jasonpearson.automobile.sdk.database.SQLExecutionResult$Query executeReadOnlySQL$auto_mobile_sdk(java.lang.String, java.lang.String);
   public final boolean isMutationQuery$auto_mobile_sdk(java.lang.String);
   public final void closeAll();
 }

--- a/android/auto-mobile-sdk/src/debug/kotlin/dev/jasonpearson/automobile/sdk/database/DatabaseInspectorProvider.kt
+++ b/android/auto-mobile-sdk/src/debug/kotlin/dev/jasonpearson/automobile/sdk/database/DatabaseInspectorProvider.kt
@@ -7,6 +7,8 @@ import android.net.Uri
 import android.os.Bundle
 import dev.jasonpearson.automobile.sdk.AutoMobileSDK
 import dev.jasonpearson.automobile.sdk.DebugInspectorAccess
+import dev.jasonpearson.automobile.sdk.capabilities.SdkCapabilityDocument
+import dev.jasonpearson.automobile.sdk.capabilities.SdkCapabilityState
 import org.json.JSONArray
 import org.json.JSONObject
 
@@ -171,13 +173,19 @@ class DatabaseInspectorProvider : ContentProvider() {
     return JSONObject().put("columns", columnsArray)
   }
 
-  internal fun handleExecuteSQL(driver: DatabaseDriver, extras: Bundle?): JSONObject {
+  internal fun handleExecuteSQL(
+    driver: DatabaseDriver,
+    extras: Bundle?,
+    capabilities: SdkCapabilityDocument = AutoMobileSDK.capabilities,
+  ): JSONObject {
     val databasePath =
       extras?.getString("databasePath") ?: throw IllegalArgumentException("databasePath required")
     val query = extras.getString("query") ?: throw IllegalArgumentException("query required")
     val mutationsAllowed =
-      AutoMobileSDK.capabilities.policy.allowMutations &&
-        AutoMobileSDK.isCapabilitySupported("storage.mutation")
+      capabilities.policy.allowMutations &&
+        capabilities.capabilities.any {
+          it.id == "storage.mutation" && it.state == SdkCapabilityState.SUPPORTED
+        }
     val execution =
       when {
         mutationsAllowed -> driver.executeSQL(databasePath, query)

--- a/android/auto-mobile-sdk/src/debug/kotlin/dev/jasonpearson/automobile/sdk/database/DatabaseInspectorProvider.kt
+++ b/android/auto-mobile-sdk/src/debug/kotlin/dev/jasonpearson/automobile/sdk/database/DatabaseInspectorProvider.kt
@@ -171,20 +171,21 @@ class DatabaseInspectorProvider : ContentProvider() {
     return JSONObject().put("columns", columnsArray)
   }
 
-  private fun handleExecuteSQL(driver: DatabaseDriver, extras: Bundle?): JSONObject {
+  internal fun handleExecuteSQL(driver: DatabaseDriver, extras: Bundle?): JSONObject {
     val databasePath =
       extras?.getString("databasePath") ?: throw IllegalArgumentException("databasePath required")
     val query = extras.getString("query") ?: throw IllegalArgumentException("query required")
-    if (
-      driver is SQLiteDatabaseDriver &&
-        driver.isMutationQuery(query) &&
-        !AutoMobileSDK.capabilities.policy.allowMutations ||
-        !AutoMobileSDK.isCapabilitySupported("storage.mutation")
-    ) {
-      throw DatabaseError.MutationNotAllowed()
-    }
+    val mutationsAllowed =
+      AutoMobileSDK.capabilities.policy.allowMutations &&
+        AutoMobileSDK.isCapabilitySupported("storage.mutation")
+    val execution =
+      when {
+        mutationsAllowed -> driver.executeSQL(databasePath, query)
+        driver is SQLiteDatabaseDriver -> driver.executeReadOnlySQL(databasePath, query)
+        else -> throw DatabaseError.MutationNotAllowed()
+      }
 
-    return when (val result = driver.executeSQL(databasePath, query)) {
+    return when (val result = execution) {
       is SQLExecutionResult.Query -> {
         val columnsArray = JSONArray()
         result.columns.forEach { columnsArray.put(it) }

--- a/android/auto-mobile-sdk/src/main/kotlin/dev/jasonpearson/automobile/sdk/database/SQLiteDatabaseDriver.kt
+++ b/android/auto-mobile-sdk/src/main/kotlin/dev/jasonpearson/automobile/sdk/database/SQLiteDatabaseDriver.kt
@@ -152,7 +152,7 @@ class SQLiteDatabaseDriver(private val context: Context) : DatabaseDriver {
   override fun executeSQL(databasePath: String, query: String): SQLExecutionResult {
     synchronized(databaseLock) {
       val trimmedQuery = query.trim()
-      val (returnsRows, readOnly) = classifySQL(trimmedQuery)
+      val (returnsRows, readOnly) = classifySQL(stripLeadingSqlComments(trimmedQuery))
 
       return if (returnsRows) {
         executeQuery(databasePath, trimmedQuery, readOnly = readOnly)
@@ -191,8 +191,12 @@ class SQLiteDatabaseDriver(private val context: Context) : DatabaseDriver {
     val keyword = statement?.first ?: return Pair(false, false)
     val statementIndex = statement.second
 
-    if (keyword == "SELECT" || keyword == "VALUES" || keyword == "PRAGMA" || keyword == "EXPLAIN") {
+    if (keyword == "SELECT" || keyword == "VALUES" || keyword == "EXPLAIN") {
       return Pair(true, true)
+    }
+
+    if (keyword == "PRAGMA") {
+      return Pair(true, isReadOnlyPragma(query, statementIndex))
     }
 
     if (keyword == "INSERT" || keyword == "UPDATE" || keyword == "DELETE") {
@@ -202,6 +206,84 @@ class SQLiteDatabaseDriver(private val context: Context) : DatabaseDriver {
     }
 
     return Pair(false, false)
+  }
+
+  private fun isReadOnlyPragma(query: String, statementIndex: Int): Boolean {
+    var index = statementIndex + "PRAGMA".length
+    while (query.getOrNull(index)?.isWhitespace() == true) index++
+
+    val firstIdentifier = readIdentifier(query, index) ?: return false
+    var pragmaName = firstIdentifier.first
+    index = firstIdentifier.second
+
+    if (query.getOrNull(index) == '.') {
+      val pragmaIdentifier = readIdentifier(query, index + 1) ?: return false
+      pragmaName = pragmaIdentifier.first
+      index = pragmaIdentifier.second
+    }
+
+    pragmaName = pragmaName.lowercase()
+    if (!isObservablePragma(pragmaName)) return false
+
+    val suffix = query.substring(index).trim()
+    if (suffix.isEmpty() || suffix == ";") return true
+
+    return suffix.startsWith('(') && isObservablePragmaWithArgument(pragmaName)
+  }
+
+  // OPEN_READONLY blocks database-file writes, but some PRAGMAs mutate connection or process
+  // state. Keep policy-enforced access to an explicit observation allowlist.
+  private fun isObservablePragma(pragmaName: String): Boolean =
+    when (pragmaName) {
+      "application_id",
+      "collation_list",
+      "compile_options",
+      "data_version",
+      "database_list",
+      "encoding",
+      "foreign_key_check",
+      "foreign_key_list",
+      "freelist_count",
+      "function_list",
+      "index_info",
+      "index_list",
+      "index_xinfo",
+      "integrity_check",
+      "module_list",
+      "page_count",
+      "page_size",
+      "pragma_list",
+      "quick_check",
+      "schema_version",
+      "table_info",
+      "table_list",
+      "table_xinfo",
+      "user_version" -> true
+      else -> false
+    }
+
+  private fun isObservablePragmaWithArgument(pragmaName: String): Boolean =
+    when (pragmaName) {
+      "foreign_key_check",
+      "foreign_key_list",
+      "index_info",
+      "index_list",
+      "index_xinfo",
+      "integrity_check",
+      "quick_check",
+      "table_info",
+      "table_list",
+      "table_xinfo" -> true
+      else -> false
+    }
+
+  private fun readIdentifier(query: String, startIndex: Int): Pair<String, Int>? {
+    var index = startIndex
+    while (query.getOrNull(index)?.isWhitespace() == true) index++
+    val identifierStart = index
+    while (query.getOrNull(index)?.let(::isWordChar) == true) index++
+    if (identifierStart == index) return null
+    return Pair(query.substring(identifierStart, index), index)
   }
 
   private fun startsWithKeyword(text: String, keyword: String): Boolean =

--- a/android/auto-mobile-sdk/src/main/kotlin/dev/jasonpearson/automobile/sdk/database/SQLiteDatabaseDriver.kt
+++ b/android/auto-mobile-sdk/src/main/kotlin/dev/jasonpearson/automobile/sdk/database/SQLiteDatabaseDriver.kt
@@ -191,8 +191,12 @@ class SQLiteDatabaseDriver(private val context: Context) : DatabaseDriver {
     val keyword = statement?.first ?: return Pair(false, false)
     val statementIndex = statement.second
 
-    if (keyword == "SELECT" || keyword == "VALUES" || keyword == "EXPLAIN") {
+    if (keyword == "SELECT" || keyword == "VALUES") {
       return Pair(true, true)
+    }
+
+    if (keyword == "EXPLAIN") {
+      return Pair(true, isReadOnlyExplain(query, statementIndex))
     }
 
     if (keyword == "PRAGMA") {
@@ -206,6 +210,18 @@ class SQLiteDatabaseDriver(private val context: Context) : DatabaseDriver {
     }
 
     return Pair(false, false)
+  }
+
+  private fun isReadOnlyExplain(query: String, statementIndex: Int): Boolean {
+    var explainedIndex = skipSqlTrivia(query, statementIndex + "EXPLAIN".length) ?: return false
+    if (matchesKeywordAt(query, explainedIndex, "QUERY")) {
+      explainedIndex = skipSqlTrivia(query, explainedIndex + "QUERY".length) ?: return false
+      if (!matchesKeywordAt(query, explainedIndex, "PLAN")) return false
+      explainedIndex = skipSqlTrivia(query, explainedIndex + "PLAN".length) ?: return false
+    }
+
+    val (_, explainedReadOnly) = classifySQL(query.substring(explainedIndex))
+    return explainedReadOnly
   }
 
   private fun isReadOnlyPragma(query: String, statementIndex: Int): Boolean {

--- a/android/auto-mobile-sdk/src/main/kotlin/dev/jasonpearson/automobile/sdk/database/SQLiteDatabaseDriver.kt
+++ b/android/auto-mobile-sdk/src/main/kotlin/dev/jasonpearson/automobile/sdk/database/SQLiteDatabaseDriver.kt
@@ -209,17 +209,16 @@ class SQLiteDatabaseDriver(private val context: Context) : DatabaseDriver {
   }
 
   private fun isReadOnlyPragma(query: String, statementIndex: Int): Boolean {
-    var index = statementIndex + "PRAGMA".length
-    while (query.getOrNull(index)?.isWhitespace() == true) index++
+    var index = skipSqlTrivia(query, statementIndex + "PRAGMA".length) ?: return false
 
     val firstIdentifier = readIdentifier(query, index) ?: return false
     var pragmaName = firstIdentifier.first
-    index = firstIdentifier.second
+    index = skipSqlTrivia(query, firstIdentifier.second) ?: return false
 
     if (query.getOrNull(index) == '.') {
       val pragmaIdentifier = readIdentifier(query, index + 1) ?: return false
       pragmaName = pragmaIdentifier.first
-      index = pragmaIdentifier.second
+      index = skipSqlTrivia(query, pragmaIdentifier.second) ?: return false
     }
 
     pragmaName = pragmaName.lowercase()
@@ -308,12 +307,58 @@ class SQLiteDatabaseDriver(private val context: Context) : DatabaseDriver {
     }
 
   private fun readIdentifier(query: String, startIndex: Int): Pair<String, Int>? {
-    var index = startIndex
-    while (query.getOrNull(index)?.isWhitespace() == true) index++
+    var index = skipSqlTrivia(query, startIndex) ?: return null
+    val quoteEnd =
+      when (query.getOrNull(index)) {
+        '"' -> '"'
+        '`' -> '`'
+        '[' -> ']'
+        else -> null
+      }
+    if (quoteEnd != null) {
+      val identifier = StringBuilder()
+      index++
+      while (index < query.length) {
+        val char = query[index]
+        if (char == quoteEnd) {
+          if (quoteEnd != ']' && query.getOrNull(index + 1) == quoteEnd) {
+            identifier.append(quoteEnd)
+            index += 2
+            continue
+          }
+          return Pair(identifier.toString(), index + 1)
+        }
+        identifier.append(char)
+        index++
+      }
+      return null
+    }
+
     val identifierStart = index
     while (query.getOrNull(index)?.let(::isWordChar) == true) index++
     if (identifierStart == index) return null
     return Pair(query.substring(identifierStart, index), index)
+  }
+
+  private fun skipSqlTrivia(query: String, startIndex: Int): Int? {
+    var index = startIndex
+    while (index < query.length) {
+      while (query.getOrNull(index)?.isWhitespace() == true) index++
+      when {
+        query.startsWith("--", index) -> {
+          val lineEnd = query.indexOfAny(charArrayOf('\n', '\r'), startIndex = index + 2)
+          if (lineEnd < 0) return query.length
+          index = lineEnd + 1
+        }
+        query.startsWith("/*", index) -> {
+          val commentEnd = query.indexOf("*/", startIndex = index + 2)
+          if (commentEnd < 0) return null
+          index = commentEnd + 2
+        }
+        else -> return index
+      }
+    }
+    return index
   }
 
   private fun startsWithKeyword(text: String, keyword: String): Boolean =

--- a/android/auto-mobile-sdk/src/main/kotlin/dev/jasonpearson/automobile/sdk/database/SQLiteDatabaseDriver.kt
+++ b/android/auto-mobile-sdk/src/main/kotlin/dev/jasonpearson/automobile/sdk/database/SQLiteDatabaseDriver.kt
@@ -174,6 +174,7 @@ class SQLiteDatabaseDriver(private val context: Context) : DatabaseDriver {
         databasePath,
         trimmedQuery,
         readOnly = true,
+        requireExactReadOnly = true,
         mapReadOnlyFailureToPolicyError = true,
       )
     }
@@ -327,9 +328,15 @@ class SQLiteDatabaseDriver(private val context: Context) : DatabaseDriver {
     databasePath: String,
     query: String,
     readOnly: Boolean,
+    requireExactReadOnly: Boolean = false,
     mapReadOnlyFailureToPolicyError: Boolean = false,
   ): SQLExecutionResult.Query {
-    val db = openDatabase(databasePath, readOnly = readOnly)
+    val db =
+      openDatabase(
+        databasePath,
+        readOnly = readOnly,
+        requireExactReadOnly = requireExactReadOnly,
+      )
     val columns = mutableListOf<String>()
     val rows = mutableListOf<List<Any?>>()
 
@@ -375,13 +382,19 @@ class SQLiteDatabaseDriver(private val context: Context) : DatabaseDriver {
     }
   }
 
-  private fun openDatabase(path: String, readOnly: Boolean): SQLiteDatabase {
+  private fun openDatabase(
+    path: String,
+    readOnly: Boolean,
+    requireExactReadOnly: Boolean = false,
+  ): SQLiteDatabase {
     validatePath(path)
 
     // Check if we have a cached connection with compatible mode
     val cached = openDatabases[path]
     if (cached != null && cached.isOpen) {
-      if (cached.isReadOnly != readOnly) {
+      val needsWritableConnection = !readOnly && cached.isReadOnly
+      val needsExactReadOnlyConnection = readOnly && requireExactReadOnly && !cached.isReadOnly
+      if (needsWritableConnection || needsExactReadOnlyConnection) {
         cached.close()
         openDatabases.remove(path)
       } else {

--- a/android/auto-mobile-sdk/src/main/kotlin/dev/jasonpearson/automobile/sdk/database/SQLiteDatabaseDriver.kt
+++ b/android/auto-mobile-sdk/src/main/kotlin/dev/jasonpearson/automobile/sdk/database/SQLiteDatabaseDriver.kt
@@ -220,8 +220,11 @@ class SQLiteDatabaseDriver(private val context: Context) : DatabaseDriver {
       explainedIndex = skipSqlTrivia(query, explainedIndex + "PLAN".length) ?: return false
     }
 
-    val (_, explainedReadOnly) = classifySQL(query.substring(explainedIndex))
-    return explainedReadOnly
+    val explainedQuery = query.substring(explainedIndex)
+    val explainedStatement = findTopLevelStatement(explainedQuery)
+    if (explainedStatement?.first != "PRAGMA") return true
+
+    return isReadOnlyPragma(explainedQuery, explainedStatement.second)
   }
 
   private fun isReadOnlyPragma(query: String, statementIndex: Int): Boolean {
@@ -434,7 +437,8 @@ class SQLiteDatabaseDriver(private val context: Context) : DatabaseDriver {
     return nextChar == null || !isWordChar(nextChar)
   }
 
-  private fun isWordChar(char: Char): Boolean = char.isLetterOrDigit() || char == '_' || char == '$'
+  private fun isWordChar(char: Char): Boolean =
+    char.isLetterOrDigit() || char == '_' || char == '$' || char.code >= 0x80
 
   private fun stripLeadingSqlComments(query: String): String {
     var index = 0

--- a/android/auto-mobile-sdk/src/main/kotlin/dev/jasonpearson/automobile/sdk/database/SQLiteDatabaseDriver.kt
+++ b/android/auto-mobile-sdk/src/main/kotlin/dev/jasonpearson/automobile/sdk/database/SQLiteDatabaseDriver.kt
@@ -226,9 +226,39 @@ class SQLiteDatabaseDriver(private val context: Context) : DatabaseDriver {
     if (!isObservablePragma(pragmaName)) return false
 
     val suffix = query.substring(index).trim()
-    if (suffix.isEmpty() || suffix == ";") return true
+    if (hasOnlyPragmaTerminatorAndComments(suffix)) return true
 
     return suffix.startsWith('(') && isObservablePragmaWithArgument(pragmaName)
+  }
+
+  private fun hasOnlyPragmaTerminatorAndComments(suffix: String): Boolean {
+    var index = 0
+    var hasTerminator = false
+
+    while (index < suffix.length) {
+      while (suffix.getOrNull(index)?.isWhitespace() == true) index++
+      if (index >= suffix.length) return true
+
+      when {
+        suffix.startsWith("--", index) -> {
+          val lineEnd = suffix.indexOfAny(charArrayOf('\n', '\r'), startIndex = index + 2)
+          if (lineEnd < 0) return true
+          index = lineEnd + 1
+        }
+        suffix.startsWith("/*", index) -> {
+          val commentEnd = suffix.indexOf("*/", startIndex = index + 2)
+          if (commentEnd < 0) return false
+          index = commentEnd + 2
+        }
+        suffix[index] == ';' && !hasTerminator -> {
+          hasTerminator = true
+          index++
+        }
+        else -> return false
+      }
+    }
+
+    return true
   }
 
   // OPEN_READONLY blocks database-file writes, but some PRAGMAs mutate connection or process

--- a/android/auto-mobile-sdk/src/main/kotlin/dev/jasonpearson/automobile/sdk/database/SQLiteDatabaseDriver.kt
+++ b/android/auto-mobile-sdk/src/main/kotlin/dev/jasonpearson/automobile/sdk/database/SQLiteDatabaseDriver.kt
@@ -3,6 +3,7 @@ package dev.jasonpearson.automobile.sdk.database
 import android.content.Context
 import android.database.Cursor
 import android.database.sqlite.SQLiteDatabase
+import android.database.sqlite.SQLiteReadOnlyDatabaseException
 import java.io.File
 import java.util.concurrent.ConcurrentHashMap
 
@@ -161,10 +162,27 @@ class SQLiteDatabaseDriver(private val context: Context) : DatabaseDriver {
     }
   }
 
-  /** Returns whether executing this statement can mutate the database. */
+  /** Executes arbitrary SQL without granting the statement a writable database handle. */
+  @JvmSynthetic
+  internal fun executeReadOnlySQL(databasePath: String, query: String): SQLExecutionResult.Query {
+    synchronized(databaseLock) {
+      val trimmedQuery = query.trim()
+      val (_, classifiedReadOnly) = classifySQL(stripLeadingSqlComments(trimmedQuery))
+      if (!classifiedReadOnly) throw DatabaseError.MutationNotAllowed()
+
+      return executeQuery(
+        databasePath,
+        trimmedQuery,
+        readOnly = true,
+        mapReadOnlyFailureToPolicyError = true,
+      )
+    }
+  }
+
+  /** Returns whether the coarse statement family is in the read-only allowlist. */
   internal fun isMutationQuery(query: String): Boolean {
-    val (returnsRows, readOnly) = classifySQL(query.trim())
-    return !returnsRows && !readOnly
+    val (_, classifiedReadOnly) = classifySQL(stripLeadingSqlComments(query.trim()))
+    return !classifiedReadOnly
   }
 
   private fun classifySQL(query: String): Pair<Boolean, Boolean> {
@@ -172,7 +190,7 @@ class SQLiteDatabaseDriver(private val context: Context) : DatabaseDriver {
     val keyword = statement?.first ?: return Pair(false, false)
     val statementIndex = statement.second
 
-    if (keyword == "SELECT" || keyword == "PRAGMA" || keyword == "EXPLAIN") {
+    if (keyword == "SELECT" || keyword == "VALUES" || keyword == "PRAGMA" || keyword == "EXPLAIN") {
       return Pair(true, true)
     }
 
@@ -197,8 +215,29 @@ class SQLiteDatabaseDriver(private val context: Context) : DatabaseDriver {
 
   private fun isWordChar(char: Char): Boolean = char.isLetterOrDigit() || char == '_'
 
+  private fun stripLeadingSqlComments(query: String): String {
+    var index = 0
+    while (index < query.length) {
+      while (query.getOrNull(index)?.isWhitespace() == true) index++
+      when {
+        query.startsWith("--", index) -> {
+          val lineEnd = query.indexOfAny(charArrayOf('\n', '\r'), startIndex = index + 2)
+          if (lineEnd < 0) return ""
+          index = lineEnd + 1
+        }
+        query.startsWith("/*", index) -> {
+          val commentEnd = query.indexOf("*/", startIndex = index + 2)
+          if (commentEnd < 0) return ""
+          index = commentEnd + 2
+        }
+        else -> return query.substring(index)
+      }
+    }
+    return ""
+  }
+
   private fun findTopLevelStatement(query: String): Pair<String, Int>? {
-    val keywords = listOf("SELECT", "PRAGMA", "EXPLAIN", "INSERT", "UPDATE", "DELETE")
+    val keywords = listOf("SELECT", "VALUES", "PRAGMA", "EXPLAIN", "INSERT", "UPDATE", "DELETE")
     if (!startsWithKeyword(query, "WITH")) {
       return keywords
         .firstOrNull { keyword -> startsWithKeyword(query, keyword) }
@@ -288,6 +327,7 @@ class SQLiteDatabaseDriver(private val context: Context) : DatabaseDriver {
     databasePath: String,
     query: String,
     readOnly: Boolean,
+    mapReadOnlyFailureToPolicyError: Boolean = false,
   ): SQLExecutionResult.Query {
     val db = openDatabase(databasePath, readOnly = readOnly)
     val columns = mutableListOf<String>()
@@ -301,6 +341,9 @@ class SQLiteDatabaseDriver(private val context: Context) : DatabaseDriver {
           rows.add((0 until cursor.columnCount).map { getColumnValue(cursor, it) })
         }
       }
+    } catch (e: SQLiteReadOnlyDatabaseException) {
+      if (mapReadOnlyFailureToPolicyError) throw DatabaseError.MutationNotAllowed()
+      throw DatabaseError.SqlError(e.message ?: "Unknown SQL error")
     } catch (e: Exception) {
       throw DatabaseError.SqlError(e.message ?: "Unknown SQL error")
     }
@@ -338,8 +381,7 @@ class SQLiteDatabaseDriver(private val context: Context) : DatabaseDriver {
     // Check if we have a cached connection with compatible mode
     val cached = openDatabases[path]
     if (cached != null && cached.isOpen) {
-      // If we need write access but have read-only, close and reopen
-      if (!readOnly && cached.isReadOnly) {
+      if (cached.isReadOnly != readOnly) {
         cached.close()
         openDatabases.remove(path)
       } else {

--- a/android/auto-mobile-sdk/src/main/kotlin/dev/jasonpearson/automobile/sdk/database/SQLiteDatabaseDriver.kt
+++ b/android/auto-mobile-sdk/src/main/kotlin/dev/jasonpearson/automobile/sdk/database/SQLiteDatabaseDriver.kt
@@ -291,9 +291,44 @@ class SQLiteDatabaseDriver(private val context: Context) : DatabaseDriver {
       return null
     }
 
+    if (
+      text.getOrNull(index)?.isDigit() == true ||
+        (text.getOrNull(index) == '.' && text.getOrNull(index + 1)?.isDigit() == true)
+    ) {
+      return readNumericLiteralEnd(text, index)
+    }
+
     val valueStart = index
     while (text.getOrNull(index)?.let(::isWordChar) == true) index++
     return index.takeIf { it > valueStart }
+  }
+
+  private fun readNumericLiteralEnd(text: String, startIndex: Int): Int? {
+    var index = startIndex
+    var hasDigits = false
+
+    while (text.getOrNull(index)?.isDigit() == true) {
+      hasDigits = true
+      index++
+    }
+    if (text.getOrNull(index) == '.') {
+      index++
+      while (text.getOrNull(index)?.isDigit() == true) {
+        hasDigits = true
+        index++
+      }
+    }
+    if (!hasDigits) return null
+
+    if (text.getOrNull(index)?.let { it == 'e' || it == 'E' } == true) {
+      index++
+      if (text.getOrNull(index)?.let { it == '+' || it == '-' } == true) index++
+      val exponentStart = index
+      while (text.getOrNull(index)?.isDigit() == true) index++
+      if (index == exponentStart) return null
+    }
+
+    return index
   }
 
   private fun hasOnlyPragmaTerminatorAndComments(suffix: String): Boolean {
@@ -475,6 +510,7 @@ class SQLiteDatabaseDriver(private val context: Context) : DatabaseDriver {
       query,
       "WITH".length,
       keywords,
+      requireCompletedGroupSinceLastComma = true,
     )
   }
 
@@ -482,8 +518,10 @@ class SQLiteDatabaseDriver(private val context: Context) : DatabaseDriver {
     query: String,
     startIndex: Int,
     keywords: List<String>,
+    requireCompletedGroupSinceLastComma: Boolean = false,
   ): Pair<String, Int>? {
     var depth = 0
+    var completedGroupSinceLastComma = false
     var i = startIndex
     var inSingleQuote = false
     var inDoubleQuote = false
@@ -533,8 +571,12 @@ class SQLiteDatabaseDriver(private val context: Context) : DatabaseDriver {
         char == '`' -> inBacktickQuote = true
         char == '[' -> inBracketQuote = true
         char == '(' -> depth++
-        char == ')' && depth > 0 -> depth--
-        depth == 0 -> {
+        char == ')' && depth > 0 -> {
+          depth--
+          if (depth == 0) completedGroupSinceLastComma = true
+        }
+        char == ',' && depth == 0 -> completedGroupSinceLastComma = false
+        depth == 0 && (!requireCompletedGroupSinceLastComma || completedGroupSinceLastComma) -> {
           for (keyword in keywords) {
             if (matchesKeywordAt(query, i, keyword)) {
               return Pair(keyword, i)

--- a/android/auto-mobile-sdk/src/main/kotlin/dev/jasonpearson/automobile/sdk/database/SQLiteDatabaseDriver.kt
+++ b/android/auto-mobile-sdk/src/main/kotlin/dev/jasonpearson/automobile/sdk/database/SQLiteDatabaseDriver.kt
@@ -444,7 +444,7 @@ class SQLiteDatabaseDriver(private val context: Context) : DatabaseDriver {
   private fun skipSqlTrivia(query: String, startIndex: Int): Int? {
     var index = startIndex
     while (index < query.length) {
-      while (query.getOrNull(index)?.isWhitespace() == true) index++
+      while (query.getOrNull(index)?.let(::isSqlTriviaWhitespace) == true) index++
       when {
         query.startsWith("--", index) -> {
           val lineEnd = query.indexOfAny(charArrayOf('\n', '\r'), startIndex = index + 2)
@@ -473,17 +473,14 @@ class SQLiteDatabaseDriver(private val context: Context) : DatabaseDriver {
   }
 
   private fun isWordChar(char: Char): Boolean =
-    char.isLetterOrDigit() || char == '_' || char == '$' || char.code >= 0x80
+    char != '\uFEFF' && (char.isLetterOrDigit() || char == '_' || char == '$' || char.code >= 0x80)
+
+  private fun isSqlTriviaWhitespace(char: Char): Boolean = char.isWhitespace() || char == '\uFEFF'
 
   private fun stripLeadingSqlComments(query: String): String {
     var index = 0
     while (index < query.length) {
-      while (
-        query.getOrNull(index)?.isWhitespace() == true ||
-          (index == 0 && query.getOrNull(index) == '\uFEFF')
-      ) {
-        index++
-      }
+      while (query.getOrNull(index)?.let(::isSqlTriviaWhitespace) == true) index++
       when {
         query.startsWith("--", index) -> {
           val lineEnd = query.indexOfAny(charArrayOf('\n', '\r'), startIndex = index + 2)

--- a/android/auto-mobile-sdk/src/main/kotlin/dev/jasonpearson/automobile/sdk/database/SQLiteDatabaseDriver.kt
+++ b/android/auto-mobile-sdk/src/main/kotlin/dev/jasonpearson/automobile/sdk/database/SQLiteDatabaseDriver.kt
@@ -478,7 +478,12 @@ class SQLiteDatabaseDriver(private val context: Context) : DatabaseDriver {
   private fun stripLeadingSqlComments(query: String): String {
     var index = 0
     while (index < query.length) {
-      while (query.getOrNull(index)?.isWhitespace() == true) index++
+      while (
+        query.getOrNull(index)?.isWhitespace() == true ||
+          (index == 0 && query.getOrNull(index) == '\uFEFF')
+      ) {
+        index++
+      }
       when {
         query.startsWith("--", index) -> {
           val lineEnd = query.indexOfAny(charArrayOf('\n', '\r'), startIndex = index + 2)

--- a/android/auto-mobile-sdk/src/main/kotlin/dev/jasonpearson/automobile/sdk/database/SQLiteDatabaseDriver.kt
+++ b/android/auto-mobile-sdk/src/main/kotlin/dev/jasonpearson/automobile/sdk/database/SQLiteDatabaseDriver.kt
@@ -227,7 +227,54 @@ class SQLiteDatabaseDriver(private val context: Context) : DatabaseDriver {
     val suffix = query.substring(index).trim()
     if (hasOnlyPragmaTerminatorAndComments(suffix)) return true
 
-    return suffix.startsWith('(') && isObservablePragmaWithArgument(pragmaName)
+    return isObservablePragmaWithArgument(pragmaName) && hasSinglePragmaArgument(suffix)
+  }
+
+  private fun hasSinglePragmaArgument(suffix: String): Boolean {
+    val parenthesized = suffix.startsWith('(')
+    if (!parenthesized && !suffix.startsWith('=')) return false
+
+    var index = skipSqlTrivia(suffix, 1) ?: return false
+    if (suffix.getOrNull(index) == '+' || suffix.getOrNull(index) == '-') index++
+    index = readPragmaValueEnd(suffix, index) ?: return false
+    index = skipSqlTrivia(suffix, index) ?: return false
+
+    if (parenthesized) {
+      if (suffix.getOrNull(index) != ')') return false
+      index++
+    }
+
+    return hasOnlyPragmaTerminatorAndComments(suffix.substring(index))
+  }
+
+  private fun readPragmaValueEnd(text: String, startIndex: Int): Int? {
+    var index = startIndex
+    val quoteEnd =
+      when (text.getOrNull(index)) {
+        '\'',
+        '"' -> text[index]
+        '`' -> '`'
+        '[' -> ']'
+        else -> null
+      }
+    if (quoteEnd != null) {
+      index++
+      while (index < text.length) {
+        if (text[index] == quoteEnd) {
+          if (quoteEnd != ']' && text.getOrNull(index + 1) == quoteEnd) {
+            index += 2
+            continue
+          }
+          return index + 1
+        }
+        index++
+      }
+      return null
+    }
+
+    val valueStart = index
+    while (text.getOrNull(index)?.let(::isWordChar) == true) index++
+    return index.takeIf { it > valueStart }
   }
 
   private fun hasOnlyPragmaTerminatorAndComments(suffix: String): Boolean {
@@ -371,7 +418,7 @@ class SQLiteDatabaseDriver(private val context: Context) : DatabaseDriver {
     return nextChar == null || !isWordChar(nextChar)
   }
 
-  private fun isWordChar(char: Char): Boolean = char.isLetterOrDigit() || char == '_'
+  private fun isWordChar(char: Char): Boolean = char.isLetterOrDigit() || char == '_' || char == '$'
 
   private fun stripLeadingSqlComments(query: String): String {
     var index = 0

--- a/android/auto-mobile-sdk/src/test/kotlin/dev/jasonpearson/automobile/sdk/database/DatabaseInspectorProviderTest.kt
+++ b/android/auto-mobile-sdk/src/test/kotlin/dev/jasonpearson/automobile/sdk/database/DatabaseInspectorProviderTest.kt
@@ -1,0 +1,210 @@
+package dev.jasonpearson.automobile.sdk.database
+
+import android.content.Context
+import android.database.sqlite.SQLiteDatabase
+import android.os.Bundle
+import dev.jasonpearson.automobile.sdk.AutoMobileSDK
+import java.io.File
+import org.junit.After
+import org.junit.Assert.assertEquals
+import org.junit.Assert.assertTrue
+import org.junit.Before
+import org.junit.Test
+import org.junit.runner.RunWith
+import org.robolectric.RobolectricTestRunner
+import org.robolectric.RuntimeEnvironment
+
+@RunWith(RobolectricTestRunner::class)
+class DatabaseInspectorProviderTest {
+  private lateinit var context: Context
+  private lateinit var databasePath: String
+  private lateinit var driver: SQLiteDatabaseDriver
+  private lateinit var attachedDatabaseFile: File
+  private lateinit var vacuumCopyFile: File
+  private val provider = DatabaseInspectorProvider()
+
+  @Before
+  fun setUp() {
+    AutoMobileSDK.shutdown()
+    context = RuntimeEnvironment.getApplication()
+    val databaseFile = context.getDatabasePath("database-inspector-provider-test.db")
+    databaseFile.parentFile?.mkdirs()
+    databaseFile.delete()
+    SQLiteDatabase.openOrCreateDatabase(databaseFile, null).use { database ->
+      database.execSQL("CREATE TABLE notes (id INTEGER PRIMARY KEY, body TEXT NOT NULL)")
+      database.execSQL("INSERT INTO notes (id, body) VALUES (1, 'hello')")
+      database.execSQL("CREATE INDEX notes_body_idx ON notes(body)")
+    }
+    databasePath = databaseFile.absolutePath
+    attachedDatabaseFile = context.getDatabasePath("database-inspector-attached-test.db")
+    vacuumCopyFile = context.getDatabasePath("database-inspector-vacuum-test.db")
+    attachedDatabaseFile.delete()
+    vacuumCopyFile.delete()
+    driver = SQLiteDatabaseDriver(context)
+  }
+
+  @After
+  fun tearDown() {
+    driver.closeAll()
+    context.getDatabasePath("database-inspector-provider-test.db").delete()
+    attachedDatabaseFile.delete()
+    vacuumCopyFile.delete()
+    AutoMobileSDK.shutdown()
+  }
+
+  @Test
+  fun `read-only select is allowed when mutation capability is unsupported`() {
+    val response = provider.handleExecuteSQL(driver, executeSqlExtras("SELECT 1 AS one"))
+
+    assertEquals("query", response.getString("type"))
+    assertEquals("one", response.getJSONArray("columns").getString(0))
+    assertEquals(1, response.getJSONArray("rows").getJSONArray(0).getInt(0))
+  }
+
+  @Test
+  fun `read-only values query is allowed when mutation capability is unsupported`() {
+    val response = provider.handleExecuteSQL(driver, executeSqlExtras("VALUES (1)"))
+
+    assertEquals("query", response.getString("type"))
+    assertEquals(1, response.getJSONArray("rows").getJSONArray(0).getInt(0))
+  }
+
+  @Test
+  fun `read-only SQL does not depend on comment-aware classification`() {
+    val response =
+      provider.handleExecuteSQL(
+        driver,
+        executeSqlExtras("-- note(foo)\nPRAGMA user_version"),
+      )
+
+    assertEquals("query", response.getString("type"))
+    assertEquals("user_version", response.getJSONArray("columns").getString(0))
+    assertEquals(0, response.getJSONArray("rows").getJSONArray(0).getInt(0))
+  }
+
+  @Test
+  fun `read-only CTE is allowed when mutation capability is unsupported`() {
+    val response =
+      provider.handleExecuteSQL(
+        driver,
+        executeSqlExtras("WITH result(value) AS (SELECT 1) SELECT value FROM result"),
+      )
+
+    assertEquals("query", response.getString("type"))
+    assertEquals(1, response.getJSONArray("rows").getJSONArray(0).getInt(0))
+  }
+
+  @Test
+  fun `argument-taking read-only pragma is allowed when mutation capability is unsupported`() {
+    val tableInfo = provider.handleExecuteSQL(driver, executeSqlExtras("PRAGMA table_info(notes)"))
+    val indexInfo =
+      provider.handleExecuteSQL(driver, executeSqlExtras("PRAGMA index_info(notes_body_idx)"))
+
+    assertEquals("query", tableInfo.getString("type"))
+    assertEquals("name", tableInfo.getJSONArray("columns").getString(1))
+    assertEquals("id", tableInfo.getJSONArray("rows").getJSONArray(0).getString(1))
+    assertEquals("body", indexInfo.getJSONArray("rows").getJSONArray(0).getString(2))
+  }
+
+  @Test
+  fun `writable pragmas are blocked by an actual read-only connection`() {
+    driver.executeSQL(databasePath, "UPDATE notes SET body = body WHERE id = 1")
+
+    listOf(
+        "PRAGMA user_version=42",
+        "PRAGMA user_version(42)",
+      )
+      .forEach { query ->
+        val error = runCatching {
+          provider.handleExecuteSQL(driver, executeSqlExtras(query))
+        }
+          .exceptionOrNull()
+
+        assertTrue(
+          "Expected MutationNotAllowed for $query, got $error",
+          error is DatabaseError.MutationNotAllowed,
+        )
+      }
+  }
+
+  @Test
+  fun `non-query SQL is rejected before it can mutate the database or filesystem`() {
+    listOf(
+        "INSERT INTO notes (id, body) VALUES (2, 'blocked')",
+        "CREATE TABLE blocked (id INTEGER)",
+        "VACUUM INTO '${vacuumCopyFile.sqlPath()}'",
+        "ATTACH DATABASE '${attachedDatabaseFile.sqlPath()}' AS attached",
+      )
+      .forEach { query ->
+        val error = runCatching {
+          provider.handleExecuteSQL(driver, executeSqlExtras(query))
+        }
+          .exceptionOrNull()
+
+        assertTrue(
+          "Expected MutationNotAllowed for $query, got $error",
+          error is DatabaseError.MutationNotAllowed,
+        )
+      }
+
+    assertTrue(!vacuumCopyFile.exists())
+    assertTrue(!attachedDatabaseFile.exists())
+  }
+
+  @Test
+  fun `row-returning mutation cannot write through the read-only policy path`() {
+    val query = "INSERT INTO notes (id, body) VALUES (2, 'blocked') RETURNING id"
+
+    val error = runCatching {
+      provider.handleExecuteSQL(driver, executeSqlExtras(query))
+    }
+      .exceptionOrNull()
+    val rows =
+      provider.handleExecuteSQL(driver, executeSqlExtras("SELECT id FROM notes ORDER BY id"))
+
+    assertTrue(error is DatabaseError.MutationNotAllowed)
+    assertEquals(1, rows.getJSONArray("rows").length())
+    assertEquals(1, rows.getJSONArray("rows").getJSONArray(0).getInt(0))
+  }
+
+  @Test
+  fun `custom driver SQL is blocked when mutation capability is unsupported`() {
+    val customDriver = RecordingDatabaseDriver()
+
+    val error = runCatching {
+      provider.handleExecuteSQL(customDriver, executeSqlExtras("SELECT 1 AS one"))
+    }
+      .exceptionOrNull()
+
+    assertTrue(error is DatabaseError.MutationNotAllowed)
+    assertEquals(0, customDriver.executeSqlCallCount)
+  }
+
+  private fun executeSqlExtras(query: String) =
+    Bundle().apply {
+      putString("databasePath", databasePath)
+      putString("query", query)
+    }
+
+  private fun File.sqlPath(): String = absolutePath.replace("'", "''")
+
+  private class RecordingDatabaseDriver : DatabaseDriver {
+    var executeSqlCallCount = 0
+      private set
+
+    override fun getDatabases() = emptyList<DatabaseDescriptor>()
+
+    override fun getTables(databasePath: String) = emptyList<String>()
+
+    override fun getTableData(databasePath: String, table: String, limit: Int, offset: Int) =
+      TableDataResult(emptyList(), emptyList(), 0)
+
+    override fun getTableStructure(databasePath: String, table: String) =
+      TableStructureResult(emptyList())
+
+    override fun executeSQL(databasePath: String, query: String): SQLExecutionResult {
+      executeSqlCallCount++
+      return SQLExecutionResult.Query(emptyList(), emptyList())
+    }
+  }
+}

--- a/android/auto-mobile-sdk/src/test/kotlin/dev/jasonpearson/automobile/sdk/database/DatabaseInspectorProviderTest.kt
+++ b/android/auto-mobile-sdk/src/test/kotlin/dev/jasonpearson/automobile/sdk/database/DatabaseInspectorProviderTest.kt
@@ -128,6 +128,19 @@ class DatabaseInspectorProviderTest {
   }
 
   @Test
+  fun `permitted follow-up read preserves writable connection session`() {
+    driver.executeSQL(databasePath, "CREATE TEMP TABLE session_notes (body TEXT NOT NULL)")
+    driver.executeSQL(databasePath, "INSERT INTO session_notes (body) VALUES ('still here')")
+
+    val result = driver.executeSQL(databasePath, "SELECT body FROM session_notes")
+
+    assertEquals(
+      listOf(listOf("still here")),
+      (result as SQLExecutionResult.Query).rows,
+    )
+  }
+
+  @Test
   fun `non-query SQL is rejected before it can mutate the database or filesystem`() {
     listOf(
         "INSERT INTO notes (id, body) VALUES (2, 'blocked')",

--- a/android/auto-mobile-sdk/src/testDebug/kotlin/dev/jasonpearson/automobile/sdk/database/DatabaseInspectorProviderTest.kt
+++ b/android/auto-mobile-sdk/src/testDebug/kotlin/dev/jasonpearson/automobile/sdk/database/DatabaseInspectorProviderTest.kt
@@ -83,6 +83,23 @@ class DatabaseInspectorProviderTest {
   }
 
   @Test
+  fun `explain allows DML plans without executing the mutation`() {
+    listOf(
+        "EXPLAIN INSERT INTO notes (id, body) VALUES (2, 'not executed')",
+        "EXPLAIN QUERY PLAN DELETE FROM notes WHERE id = 1",
+      )
+      .forEach { query ->
+        val response = provider.handleExecuteSQL(driver, executeSqlExtras(query))
+        assertEquals("Expected query response for $query", "query", response.getString("type"))
+      }
+
+    val rows =
+      provider.handleExecuteSQL(driver, executeSqlExtras("SELECT id FROM notes ORDER BY id"))
+    assertEquals(1, rows.getJSONArray("rows").length())
+    assertEquals(1, rows.getJSONArray("rows").getJSONArray(0).getInt(0))
+  }
+
+  @Test
   fun `read-only SQL does not depend on comment-aware classification`() {
     val response =
       provider.handleExecuteSQL(
@@ -151,6 +168,18 @@ class DatabaseInspectorProviderTest {
       provider.handleExecuteSQL(
         driver,
         executeSqlExtras("WITH foo\$update AS (VALUES(1)) SELECT * FROM foo\$update"),
+      )
+
+    assertEquals("query", response.getString("type"))
+    assertEquals(1, response.getJSONArray("rows").getJSONArray(0).getInt(0))
+  }
+
+  @Test
+  fun `read-only CTE treats non-ASCII characters as identifier characters`() {
+    val response =
+      provider.handleExecuteSQL(
+        driver,
+        executeSqlExtras("WITH foo😀update AS (VALUES(1)) SELECT * FROM foo😀update"),
       )
 
     assertEquals("query", response.getString("type"))

--- a/android/auto-mobile-sdk/src/testDebug/kotlin/dev/jasonpearson/automobile/sdk/database/DatabaseInspectorProviderTest.kt
+++ b/android/auto-mobile-sdk/src/testDebug/kotlin/dev/jasonpearson/automobile/sdk/database/DatabaseInspectorProviderTest.kt
@@ -97,6 +97,21 @@ class DatabaseInspectorProviderTest {
   }
 
   @Test
+  fun `observational pragmas allow inter-token comments and quoted identifiers`() {
+    listOf(
+        "PRAGMA /* inspect */ user_version",
+        "PRAGMA \"user_version\"",
+        "PRAGMA [user_version]",
+        "PRAGMA `user_version`",
+      )
+      .forEach { query ->
+        val response = provider.handleExecuteSQL(driver, executeSqlExtras(query))
+
+        assertEquals("Expected query response for $query", "query", response.getString("type"))
+      }
+  }
+
+  @Test
   fun `unrestricted leading-comment select returns query rows`() {
     val result = driver.executeSQL(databasePath, "-- inspect\nSELECT 1 AS one")
 
@@ -137,6 +152,7 @@ class DatabaseInspectorProviderTest {
     listOf(
         "PRAGMA user_version=42",
         "PRAGMA user_version(42)",
+        "PRAGMA /* blocked */ \"user_version\"=42",
       )
       .forEach { query ->
         val error = runCatching {
@@ -155,6 +171,7 @@ class DatabaseInspectorProviderTest {
   fun `process-mutating pragmas fail the read-only admission gate`() {
     assertTrue(driver.isMutationQuery("PRAGMA hard_heap_limit=1"))
     assertTrue(driver.isMutationQuery("PRAGMA hard_heap_limit(1)"))
+    assertTrue(driver.isMutationQuery("PRAGMA [hard_heap_limit]=1"))
     assertTrue(driver.isMutationQuery("PRAGMA shrink_memory"))
   }
 

--- a/android/auto-mobile-sdk/src/testDebug/kotlin/dev/jasonpearson/automobile/sdk/database/DatabaseInspectorProviderTest.kt
+++ b/android/auto-mobile-sdk/src/testDebug/kotlin/dev/jasonpearson/automobile/sdk/database/DatabaseInspectorProviderTest.kt
@@ -71,6 +71,18 @@ class DatabaseInspectorProviderTest {
   }
 
   @Test
+  fun `explain applies the read-only admission policy to its statement`() {
+    listOf(
+        "EXPLAIN SELECT 1",
+        "EXPLAIN QUERY PLAN SELECT 1",
+        "EXPLAIN PRAGMA user_version",
+      )
+      .forEach { query ->
+        assertTrue("Expected read-only classification for $query", !driver.isMutationQuery(query))
+      }
+  }
+
+  @Test
   fun `read-only SQL does not depend on comment-aware classification`() {
     val response =
       provider.handleExecuteSQL(
@@ -192,6 +204,7 @@ class DatabaseInspectorProviderTest {
         "PRAGMA hard_heap_limit(1)",
         "PRAGMA [hard_heap_limit]=1",
         "PRAGMA shrink_memory",
+        "EXPLAIN PRAGMA hard_heap_limit=1",
       )
       .forEach { query ->
         assertTrue(driver.isMutationQuery(query))

--- a/android/auto-mobile-sdk/src/testDebug/kotlin/dev/jasonpearson/automobile/sdk/database/DatabaseInspectorProviderTest.kt
+++ b/android/auto-mobile-sdk/src/testDebug/kotlin/dev/jasonpearson/automobile/sdk/database/DatabaseInspectorProviderTest.kt
@@ -4,6 +4,10 @@ import android.content.Context
 import android.database.sqlite.SQLiteDatabase
 import android.os.Bundle
 import dev.jasonpearson.automobile.sdk.AutoMobileSDK
+import dev.jasonpearson.automobile.sdk.capabilities.SdkCapabilityDescriptor
+import dev.jasonpearson.automobile.sdk.capabilities.SdkCapabilityDocument
+import dev.jasonpearson.automobile.sdk.capabilities.SdkCapabilityState
+import dev.jasonpearson.automobile.sdk.capabilities.SdkCapturePolicy
 import java.io.File
 import org.junit.After
 import org.junit.Assert.assertEquals
@@ -259,6 +263,7 @@ class DatabaseInspectorProviderTest {
         "PRAGMA [hard_heap_limit]=1",
         "PRAGMA shrink_memory",
         "EXPLAIN PRAGMA hard_heap_limit=1",
+        "EXPLAIN \uFEFFPRAGMA hard_heap_limit=1",
       )
       .forEach { query ->
         assertTrue(driver.isMutationQuery(query))
@@ -380,6 +385,52 @@ class DatabaseInspectorProviderTest {
     assertTrue(error is DatabaseError.MutationNotAllowed)
     assertEquals(0, customDriver.executeSqlCallCount)
   }
+
+  @Test
+  fun `disabled mutation policy enforces read-only SQL when capability is supported`() {
+    val capabilities = mutationCapabilities(allowMutations = false)
+
+    val queryResponse =
+      provider.handleExecuteSQL(
+        driver,
+        executeSqlExtras("SELECT id FROM notes ORDER BY id"),
+        capabilities,
+      )
+    val mutationError = runCatching {
+      provider.handleExecuteSQL(
+        driver,
+        executeSqlExtras("INSERT INTO notes (id, body) VALUES (2, 'blocked')"),
+        capabilities,
+      )
+    }
+      .exceptionOrNull()
+
+    assertEquals("query", queryResponse.getString("type"))
+    assertEquals(1, queryResponse.getJSONArray("rows").length())
+    assertTrue(mutationError is DatabaseError.MutationNotAllowed)
+  }
+
+  @Test
+  fun `enabled mutation policy uses writable SQL when capability is supported`() {
+    val capabilities = mutationCapabilities(allowMutations = true)
+
+    val response =
+      provider.handleExecuteSQL(
+        driver,
+        executeSqlExtras("INSERT INTO notes (id, body) VALUES (2, 'allowed')"),
+        capabilities,
+      )
+
+    assertEquals("mutation", response.getString("type"))
+    assertEquals(1, response.getInt("rowsAffected"))
+  }
+
+  private fun mutationCapabilities(allowMutations: Boolean) =
+    SdkCapabilityDocument(
+      capabilities =
+        listOf(SdkCapabilityDescriptor("storage.mutation", SdkCapabilityState.SUPPORTED)),
+      policy = SdkCapturePolicy(allowMutations = allowMutations),
+    )
 
   private fun executeSqlExtras(query: String) =
     Bundle().apply {

--- a/android/auto-mobile-sdk/src/testDebug/kotlin/dev/jasonpearson/automobile/sdk/database/DatabaseInspectorProviderTest.kt
+++ b/android/auto-mobile-sdk/src/testDebug/kotlin/dev/jasonpearson/automobile/sdk/database/DatabaseInspectorProviderTest.kt
@@ -84,6 +84,19 @@ class DatabaseInspectorProviderTest {
   }
 
   @Test
+  fun `observational pragmas allow trailing comments`() {
+    listOf(
+        "PRAGMA user_version; -- inspect",
+        "PRAGMA application_id /* read */",
+      )
+      .forEach { query ->
+        val response = provider.handleExecuteSQL(driver, executeSqlExtras(query))
+
+        assertEquals("Expected query response for $query", "query", response.getString("type"))
+      }
+  }
+
+  @Test
   fun `unrestricted leading-comment select returns query rows`() {
     val result = driver.executeSQL(databasePath, "-- inspect\nSELECT 1 AS one")
 

--- a/android/auto-mobile-sdk/src/testDebug/kotlin/dev/jasonpearson/automobile/sdk/database/DatabaseInspectorProviderTest.kt
+++ b/android/auto-mobile-sdk/src/testDebug/kotlin/dev/jasonpearson/automobile/sdk/database/DatabaseInspectorProviderTest.kt
@@ -113,6 +113,14 @@ class DatabaseInspectorProviderTest {
   }
 
   @Test
+  fun `read-only SQL allows a leading byte order mark`() {
+    val response = provider.handleExecuteSQL(driver, executeSqlExtras("\uFEFFSELECT 1 AS one"))
+
+    assertEquals("query", response.getString("type"))
+    assertEquals(1, response.getJSONArray("rows").getJSONArray(0).getInt(0))
+  }
+
+  @Test
   fun `observational pragmas allow trailing comments`() {
     listOf(
         "PRAGMA user_version; -- inspect",

--- a/android/auto-mobile-sdk/src/testDebug/kotlin/dev/jasonpearson/automobile/sdk/database/DatabaseInspectorProviderTest.kt
+++ b/android/auto-mobile-sdk/src/testDebug/kotlin/dev/jasonpearson/automobile/sdk/database/DatabaseInspectorProviderTest.kt
@@ -134,14 +134,32 @@ class DatabaseInspectorProviderTest {
   }
 
   @Test
+  fun `read-only CTE treats dollar signs as identifier characters`() {
+    val response =
+      provider.handleExecuteSQL(
+        driver,
+        executeSqlExtras("WITH foo\$update AS (VALUES(1)) SELECT * FROM foo\$update"),
+      )
+
+    assertEquals("query", response.getString("type"))
+    assertEquals(1, response.getJSONArray("rows").getJSONArray(0).getInt(0))
+  }
+
+  @Test
   fun `argument-taking read-only pragma is allowed when mutation capability is unsupported`() {
     val tableInfo = provider.handleExecuteSQL(driver, executeSqlExtras("PRAGMA table_info(notes)"))
+    val equalsTableInfo =
+      provider.handleExecuteSQL(driver, executeSqlExtras("PRAGMA table_info = notes"))
+    val quotedEqualsTableInfo =
+      provider.handleExecuteSQL(driver, executeSqlExtras("PRAGMA table_info = 'notes'"))
     val indexInfo =
       provider.handleExecuteSQL(driver, executeSqlExtras("PRAGMA index_info(notes_body_idx)"))
 
     assertEquals("query", tableInfo.getString("type"))
     assertEquals("name", tableInfo.getJSONArray("columns").getString(1))
     assertEquals("id", tableInfo.getJSONArray("rows").getJSONArray(0).getString(1))
+    assertEquals(tableInfo.toString(), equalsTableInfo.toString())
+    assertEquals(tableInfo.toString(), quotedEqualsTableInfo.toString())
     assertEquals("body", indexInfo.getJSONArray("rows").getJSONArray(0).getString(2))
   }
 
@@ -169,10 +187,46 @@ class DatabaseInspectorProviderTest {
 
   @Test
   fun `process-mutating pragmas fail the read-only admission gate`() {
-    assertTrue(driver.isMutationQuery("PRAGMA hard_heap_limit=1"))
-    assertTrue(driver.isMutationQuery("PRAGMA hard_heap_limit(1)"))
-    assertTrue(driver.isMutationQuery("PRAGMA [hard_heap_limit]=1"))
-    assertTrue(driver.isMutationQuery("PRAGMA shrink_memory"))
+    listOf(
+        "PRAGMA hard_heap_limit=1",
+        "PRAGMA hard_heap_limit(1)",
+        "PRAGMA [hard_heap_limit]=1",
+        "PRAGMA shrink_memory",
+      )
+      .forEach { query ->
+        assertTrue(driver.isMutationQuery(query))
+
+        val error = runCatching {
+          provider.handleExecuteSQL(driver, executeSqlExtras(query))
+        }
+          .exceptionOrNull()
+        assertTrue(
+          "Expected MutationNotAllowed for $query, got $error",
+          error is DatabaseError.MutationNotAllowed,
+        )
+      }
+  }
+
+  @Test
+  fun `observational pragma arguments fail closed on extra or missing syntax`() {
+    listOf(
+        "PRAGMA table_info =",
+        "PRAGMA table_info = notes extra",
+        "PRAGMA table_info(notes) extra",
+        "PRAGMA table_info = notes; SELECT 1",
+      )
+      .forEach { query ->
+        assertTrue("Expected mutation classification for $query", driver.isMutationQuery(query))
+
+        val error = runCatching {
+          provider.handleExecuteSQL(driver, executeSqlExtras(query))
+        }
+          .exceptionOrNull()
+        assertTrue(
+          "Expected MutationNotAllowed for $query, got $error",
+          error is DatabaseError.MutationNotAllowed,
+        )
+      }
   }
 
   @Test
@@ -222,6 +276,11 @@ class DatabaseInspectorProviderTest {
 
     assertTrue(!vacuumCopyFile.exists())
     assertTrue(!attachedDatabaseFile.exists())
+    val rows =
+      provider.handleExecuteSQL(driver, executeSqlExtras("SELECT id FROM notes ORDER BY id"))
+    assertEquals(1, rows.getJSONArray("rows").length())
+    assertEquals(1, rows.getJSONArray("rows").getJSONArray(0).getInt(0))
+    assertTrue("blocked" !in driver.getTables(databasePath))
   }
 
   @Test

--- a/android/auto-mobile-sdk/src/testDebug/kotlin/dev/jasonpearson/automobile/sdk/database/DatabaseInspectorProviderTest.kt
+++ b/android/auto-mobile-sdk/src/testDebug/kotlin/dev/jasonpearson/automobile/sdk/database/DatabaseInspectorProviderTest.kt
@@ -14,6 +14,7 @@ import org.junit.runner.RunWith
 import org.robolectric.RobolectricTestRunner
 import org.robolectric.RuntimeEnvironment
 
+/** Regression coverage for the debug-only database inspector provider. */
 @RunWith(RobolectricTestRunner::class)
 class DatabaseInspectorProviderTest {
   private lateinit var context: Context
@@ -83,6 +84,16 @@ class DatabaseInspectorProviderTest {
   }
 
   @Test
+  fun `unrestricted leading-comment select returns query rows`() {
+    val result = driver.executeSQL(databasePath, "-- inspect\nSELECT 1 AS one")
+
+    assertEquals(
+      listOf(listOf(1L)),
+      (result as SQLExecutionResult.Query).rows,
+    )
+  }
+
+  @Test
   fun `read-only CTE is allowed when mutation capability is unsupported`() {
     val response =
       provider.handleExecuteSQL(
@@ -125,6 +136,25 @@ class DatabaseInspectorProviderTest {
           error is DatabaseError.MutationNotAllowed,
         )
       }
+  }
+
+  @Test
+  fun `process-mutating pragmas fail the read-only admission gate`() {
+    assertTrue(driver.isMutationQuery("PRAGMA hard_heap_limit=1"))
+    assertTrue(driver.isMutationQuery("PRAGMA hard_heap_limit(1)"))
+    assertTrue(driver.isMutationQuery("PRAGMA shrink_memory"))
+  }
+
+  @Test
+  fun `authorized pragma setter uses the writable connection`() {
+    driver.executeSQL(databasePath, "PRAGMA user_version=42")
+
+    val result = driver.executeSQL(databasePath, "PRAGMA user_version")
+
+    assertEquals(
+      listOf(listOf(42L)),
+      (result as SQLExecutionResult.Query).rows,
+    )
   }
 
   @Test

--- a/android/auto-mobile-sdk/src/testDebug/kotlin/dev/jasonpearson/automobile/sdk/database/DatabaseInspectorProviderTest.kt
+++ b/android/auto-mobile-sdk/src/testDebug/kotlin/dev/jasonpearson/automobile/sdk/database/DatabaseInspectorProviderTest.kt
@@ -187,6 +187,18 @@ class DatabaseInspectorProviderTest {
   }
 
   @Test
+  fun `read-only CTE may use a statement keyword as its identifier`() {
+    val response =
+      provider.handleExecuteSQL(
+        driver,
+        executeSqlExtras("WITH pragma(value) AS (VALUES(1)) SELECT value FROM pragma"),
+      )
+
+    assertEquals("query", response.getString("type"))
+    assertEquals(1, response.getJSONArray("rows").getJSONArray(0).getInt(0))
+  }
+
+  @Test
   fun `argument-taking read-only pragma is allowed when mutation capability is unsupported`() {
     val tableInfo = provider.handleExecuteSQL(driver, executeSqlExtras("PRAGMA table_info(notes)"))
     val equalsTableInfo =
@@ -195,6 +207,11 @@ class DatabaseInspectorProviderTest {
       provider.handleExecuteSQL(driver, executeSqlExtras("PRAGMA table_info = 'notes'"))
     val indexInfo =
       provider.handleExecuteSQL(driver, executeSqlExtras("PRAGMA index_info(notes_body_idx)"))
+
+    listOf("PRAGMA quick_check(1.0)", "PRAGMA quick_check(1e1)").forEach { query ->
+      val response = provider.handleExecuteSQL(driver, executeSqlExtras(query))
+      assertEquals("Expected query response for $query", "query", response.getString("type"))
+    }
 
     assertEquals("query", tableInfo.getString("type"))
     assertEquals("name", tableInfo.getJSONArray("columns").getString(1))
@@ -256,6 +273,8 @@ class DatabaseInspectorProviderTest {
         "PRAGMA table_info = notes extra",
         "PRAGMA table_info(notes) extra",
         "PRAGMA table_info = notes; SELECT 1",
+        "PRAGMA quick_check(1e)",
+        "PRAGMA quick_check(.)",
       )
       .forEach { query ->
         assertTrue("Expected mutation classification for $query", driver.isMutationQuery(query))


### PR DESCRIPTION
## Summary

Fix the Android debug database inspector's mutation-policy guard so unsupported mutation capability or disabled mutation policy still permits SQLite read/query families (`SELECT`, `VALUES`, `EXPLAIN`, and explicitly observational `PRAGMA` forms). The handwritten classifier is only a coarse allowlist: policy-enforced reads execute through an exact `OPEN_READONLY` SQLite handle, while PRAGMA setters and side-effect-only PRAGMAs fail closed before SQLite sees them. DML, DDL, `VACUUM`, `ATTACH`, and custom drivers also fail closed before execution. Ordinary authorized reads continue reusing a cached writable handle so connection-scoped state such as temporary tables is preserved.

## Linked Issue

Closes [#5180](https://github.com/kaeawc/auto-mobile/issues/5180)

Closes [#5182](https://github.com/kaeawc/auto-mobile/issues/5182)

Closes [#5183](https://github.com/kaeawc/auto-mobile/issues/5183)

Closes [#5184](https://github.com/kaeawc/auto-mobile/issues/5184)

Closes [#5185](https://github.com/kaeawc/auto-mobile/issues/5185)

Closes [#5186](https://github.com/kaeawc/auto-mobile/issues/5186)

## Bug / Regression Context

- **Prior attempts:** [#5166](https://github.com/kaeawc/auto-mobile/pull/5166) restored access to the debug provider, exposing this previously masked guard-precedence bug.
- **Observed symptom:** Android `sqlQuery` rejected `SELECT 1` with `MutationNotAllowed` when `storage.mutation` was unsupported.
- **Repro steps / conditions:** Invoke `executeSQL` with read-only SQL while the SDK has its default read-only capture policy and no supported `storage.mutation` capability.

## Validation

- [x] `ONLY_TOUCHED_FILES=false scripts/ktfmt/validate_ktfmt.sh`
- [x] `bun run turbo:validate`
- [x] `bun run typecheck` (no new errors; 185 baseline errors)
- [x] `(cd android && ./gradlew :auto-mobile-sdk:testDebugUnitTest)`
- [x] `(cd android && ./gradlew -Dorg.gradle.unsafe.isolated-projects=false --no-configuration-cache :auto-mobile-sdk:apiCheck)`
- [x] Focused regression test: `(cd android && ./gradlew :auto-mobile-sdk:testDebugUnitTest --tests 'dev.jasonpearson.automobile.sdk.database.DatabaseInspectorProviderTest')`
- [x] `git diff --check`
- [x] Exact-head [Pull Request workflow](https://github.com/kaeawc/auto-mobile/actions/runs/31302291409) (attempt 2 green after two unrelated test flakes) and [WebRTC companion workflow](https://github.com/kaeawc/auto-mobile/actions/runs/31302291411)

## Kotlin Reuse Check

No dependency was added. The implementation reuses the existing SQLite statement-family classifier only for coarse admission, Kotlin standard-library string operations for leading-comment normalization, and Android's `OPEN_READONLY` enforcement. The tests reuse `SQLiteDatabaseDriver` plus a narrow `DatabaseDriver` fake for the custom-driver fail-closed path.

## Follow-ups

None identified.
