### PR TITLE
fix(android): parse unit-suffixed AVD RAM

### DIFF
--- a/src/utils/android-cmdline-tools/AndroidEmulatorClient.ts
+++ b/src/utils/android-cmdline-tools/AndroidEmulatorClient.ts
@@ -585,6 +585,11 @@ export class AndroidEmulatorClient implements AndroidEmulator {
     if (!avdConfig) {return;}
     const isModernPlayImage = avdConfig.tag?.toLowerCase().includes("play")
       && (avdConfig.apiLevel ?? 0) >= MODERN_PLAY_IMAGE_MIN_API_LEVEL;
+    if (isModernPlayImage && avdConfig.ramSizeInvalid) {
+      throw new ActionableError(
+        `Cannot start AVD '${avdName}': hw.ramSize is invalid. Use a whole number in MB or a K, M, or G size suffix and retry.`
+      );
+    }
     if (isModernPlayImage && avdConfig.ramSizeMb !== undefined && avdConfig.ramSizeMb < MIN_AVD_RAM_MB) {
       throw new ActionableError(
         `Cannot start AVD '${avdName}': hw.ramSize is ${avdConfig.ramSizeMb} MB, below the minimum ${MIN_AVD_RAM_MB} MB needed for a modern system image. Increase hw.ramSize in the AVD config and retry.`

--- a/src/utils/android-cmdline-tools/AvdConfigReader.ts
+++ b/src/utils/android-cmdline-tools/AvdConfigReader.ts
@@ -14,6 +14,8 @@ export interface AvdConfig {
   screenDensity?: number;
   /** Configured guest memory in megabytes. */
   ramSizeMb?: number;
+  /** Whether config.ini contains an unrecognized guest-memory value. */
+  ramSizeInvalid?: boolean;
   deviceName?: string;
   tag?: string;
 }
@@ -182,13 +184,13 @@ function parseDimension(value: string | undefined): number | undefined {
   return parsed || undefined;
 }
 
-function parseRamSize(props: Map<string, string>): Pick<AvdConfig, "ramSizeMb"> {
+function parseRamSize(props: Map<string, string>): Pick<AvdConfig, "ramSizeMb" | "ramSizeInvalid"> {
   const value = props.get("hw.ramSize");
-  if (!value) {
+  if (value === undefined) {
     return {};
   }
   const match = /^(\d+)\s*(?:(k|m|g)(?:i?b)?)?$/i.exec(value);
-  if (!match) {return {};}
+  if (!match) {return { ramSizeInvalid: true };}
 
   const amount = Number(match[1]);
   const unit = match[2]?.toLowerCase();

--- a/src/utils/android-cmdline-tools/AvdConfigReader.ts
+++ b/src/utils/android-cmdline-tools/AvdConfigReader.ts
@@ -184,9 +184,17 @@ function parseDimension(value: string | undefined): number | undefined {
 
 function parseRamSize(props: Map<string, string>): Pick<AvdConfig, "ramSizeMb"> {
   const value = props.get("hw.ramSize");
-  if (!value) {return {};}
-  const parsed = Number.parseInt(value, 10);
-  return Number.isFinite(parsed) ? { ramSizeMb: parsed } : {};
+  if (!value) {
+    return {};
+  }
+  const match = /^(\d+)\s*(?:(k|m|g)(?:i?b)?)?$/i.exec(value);
+  if (!match) {return {};}
+
+  const amount = Number(match[1]);
+  const unit = match[2]?.toLowerCase();
+  const multiplier = unit === "g" ? 1024 : unit === "k" ? 1 / 1024 : 1;
+  const ramSizeMb = amount * multiplier;
+  return Number.isFinite(ramSizeMb) ? { ramSizeMb } : {};
 }
 
 function parseDeviceMetadata(props: Map<string, string>): Pick<AvdConfig, "deviceName" | "tag"> {

--- a/test/utils/android-cmdline-tools/AndroidEmulatorClient-bootFailureDetectors.test.ts
+++ b/test/utils/android-cmdline-tools/AndroidEmulatorClient-bootFailureDetectors.test.ts
@@ -56,6 +56,25 @@ describe("Android emulator boot failure diagnostics", () => {
     expect(error.message).toContain("2048 MB");
   });
 
+  test("fails before spawning an AVD with an invalid RAM setting", async () => {
+    const timer = new FakeTimer();
+    timer.enableAutoAdvance();
+    const reader: AvdConfigReader = { readConfig: async () => ({ apiLevel: 36, tag: "google_apis_playstore", ramSizeInvalid: true }) };
+    const client = new AndroidEmulatorClient(
+      async (_file, args) => args.includes("-list-avds") ? result("Pixel_9_Pro\n") : result(),
+      (() => { throw new Error("spawn should not be reached"); }) as any,
+      timer,
+      { create: () => new FakeAdbExecutor() } as AdbClientFactory,
+      reader,
+    );
+    (client as unknown as { isAvdRunning: () => Promise<boolean> }).isAvdRunning = async () => false;
+    (client as unknown as { isAvdStarting: () => Promise<boolean> }).isAvdStarting = async () => false;
+    (client as unknown as { checkArchitectureCompatibility: () => Promise<unknown> }).checkArchitectureCompatibility = async () => ({ compatible: true });
+
+    const error = await expectRejection(client.startEmulator("Pixel_9_Pro"));
+    expect(error.message).toContain("hw.ramSize is invalid");
+  });
+
   test("applies the RAM floor when the AVD config comes from an absolute registry path", async () => {
     const path = require("path");
     const avdHome = path.resolve("fake", "avd");

--- a/test/utils/android-cmdline-tools/AvdConfigReader.test.ts
+++ b/test/utils/android-cmdline-tools/AvdConfigReader.test.ts
@@ -38,6 +38,16 @@ describe("parseAvdConfig", () => {
     expect(config.ramSizeMb).toBe(1536);
   });
 
+  it("normalizes RAM size suffixes to megabytes", () => {
+    expect(parseAvdConfig("hw.ramSize=2G\n").ramSizeMb).toBe(2048);
+    expect(parseAvdConfig("hw.ramSize=2048M\n").ramSizeMb).toBe(2048);
+    expect(parseAvdConfig("hw.ramSize=2GiB\n").ramSizeMb).toBe(2048);
+  });
+
+  it("does not interpret malformed RAM sizes as partial numbers", () => {
+    expect(parseAvdConfig("hw.ramSize=2G-invalid\n").ramSizeMb).toBeUndefined();
+  });
+
   it("preserves a zero RAM value so the launch preflight can reject it", () => {
     expect(parseAvdConfig("hw.ramSize=0\n").ramSizeMb).toBe(0);
   });

--- a/test/utils/android-cmdline-tools/AvdConfigReader.test.ts
+++ b/test/utils/android-cmdline-tools/AvdConfigReader.test.ts
@@ -40,12 +40,15 @@ describe("parseAvdConfig", () => {
 
   it("normalizes RAM size suffixes to megabytes", () => {
     expect(parseAvdConfig("hw.ramSize=2G\n").ramSizeMb).toBe(2048);
+    expect(parseAvdConfig("hw.ramSize=1024KiB\n").ramSizeMb).toBe(1);
     expect(parseAvdConfig("hw.ramSize=2048M\n").ramSizeMb).toBe(2048);
     expect(parseAvdConfig("hw.ramSize=2GiB\n").ramSizeMb).toBe(2048);
   });
 
-  it("does not interpret malformed RAM sizes as partial numbers", () => {
-    expect(parseAvdConfig("hw.ramSize=2G-invalid\n").ramSizeMb).toBeUndefined();
+  it("marks malformed RAM sizes without interpreting partial numbers", () => {
+    const config = parseAvdConfig("hw.ramSize=2G-invalid\n");
+    expect(config.ramSizeMb).toBeUndefined();
+    expect(config.ramSizeInvalid).toBe(true);
   });
 
   it("preserves a zero RAM value so the launch preflight can reject it", () => {


### PR DESCRIPTION
## Summary

Normalize unit-suffixed Android AVD RAM settings before enforcing the modern Play system-image memory floor. This lets valid settings such as `hw.ramSize=2G` start correctly and rejects malformed values rather than interpreting a numeric prefix.

## Linked Issue

Closes [#5194](https://github.com/kaeawc/auto-mobile/issues/5194)

## Bug / Regression Context

- **Prior attempts:** None.
- **Observed symptom:** `startDevice` reported that a 2 GiB AVD had only 2 MB of RAM and refused to start it.
- **Repro steps / conditions:** Set `hw.ramSize=2G` in an AVD using a modern Play Store image, then call `startDevice`.

## Validation

- [x] `bun test test/utils/android-cmdline-tools/AvdConfigReader.test.ts`
- [x] `bun run lint`
- [x] `bun run build`
- [x] `bun test` (13,020 passed; 13 integration tests skipped)
- [x] `bun run typecheck` reports no new errors
- [x] `scripts/all_fast_validate_checks.sh` (33 checks passed)
- [x] No new interfaces, dependencies, or generic helpers were introduced
- [x] Branch is based on current `origin/main`
