### PR TITLE
fix(ci): speed Windows Bun 1.3.14 tests

### DIFF
--- a/.github/workflows/merge.yml
+++ b/.github/workflows/merge.yml
@@ -667,7 +667,13 @@ jobs:
         run: |
           set -euo pipefail
           mkdir -p ci-logs
-          turbo run test --output-logs=errors-only --log-order=grouped 2>&1 | tee "ci-logs/bun-test-${{ matrix.os }}.log"
+          # Bun 1.3.14 regresses per-file isolation on Windows; keep that
+          # platform's suite in one global while other platforms stay isolated.
+          if [[ "$RUNNER_OS" == "Windows" ]]; then
+            bun run test:windows 2>&1 | tee "ci-logs/bun-test-${{ matrix.os }}.log"
+          else
+            turbo run test --output-logs=errors-only --log-order=grouped 2>&1 | tee "ci-logs/bun-test-${{ matrix.os }}.log"
+          fi
 
       - name: "Upload Build/Test Logs"
         if: failure()

--- a/.github/workflows/pull_request.yml
+++ b/.github/workflows/pull_request.yml
@@ -1312,7 +1312,13 @@ jobs:
         run: |
           set -euo pipefail
           mkdir -p ci-logs
-          turbo run test --output-logs=errors-only --log-order=grouped 2>&1 | tee "ci-logs/bun-test-${{ matrix.os }}.log"
+          # Bun 1.3.14 regresses per-file isolation on Windows; keep that
+          # platform's suite in one global while other platforms stay isolated.
+          if [[ "$RUNNER_OS" == "Windows" ]]; then
+            bun run test:windows 2>&1 | tee "ci-logs/bun-test-${{ matrix.os }}.log"
+          else
+            turbo run test --output-logs=errors-only --log-order=grouped 2>&1 | tee "ci-logs/bun-test-${{ matrix.os }}.log"
+          fi
 
       - name: "Run Bun image runtime smoke"
         if: env.RUN_MCP_BUILD_TEST == 'true' && (matrix.os == 'macos-latest' || matrix.os == 'windows-latest')

--- a/package.json
+++ b/package.json
@@ -4,6 +4,7 @@
   "description": "Mobile device interaction automation via MCP",
   "scripts": {
     "test": "bun test --isolate",
+    "test:windows": "bun test",
     "test:coverage": "bun test --isolate --coverage",
     "test:fast": "bash scripts/test-fast.sh",
     "test:startup:bun": "bash scripts/ci/mcp-startup-smoke.sh",


### PR DESCRIPTION
## Summary
- retain Bun 1.3.14 and run only Windows CI tests without per-file isolation
- retain isolated tests on macOS and in coverage
- preserve Windows test logs and runtime smoke coverage

## Test plan
- [x] `bun run test:windows` (13,018 passed, 13 skipped)
- [x] `bun run check:bun-version-coherence`
- [x] `bun test test/scripts/workflowJobTimeouts.test.ts test/scripts/miscParallelSteps.test.ts test/scripts/nightlyParallelSteps.test.ts`
- [ ] Confirm the Windows GitHub Actions test duration

Made with [Cursor](https://cursor.com)