### PR TITLE
fix(desktop): prefer bunx and resolve runner paths for daemon launch

### DIFF
--- a/android/desktop-core/src/main/kotlin/dev/jasonpearson/automobile/desktop/core/daemon/DesktopDaemonLifecycle.kt
+++ b/android/desktop-core/src/main/kotlin/dev/jasonpearson/automobile/desktop/core/daemon/DesktopDaemonLifecycle.kt
@@ -277,26 +277,30 @@ internal class SystemDaemonPackageRunnerResolver(
 ) : DaemonPackageRunnerResolver {
   override fun resolve(osName: String): String {
     val isWindows = osName.lowercase().contains("win")
-    for (candidate in absoluteCandidates(isWindows)) {
-      if (executableAt(candidate)) return candidate
-    }
-    for (runner in listOf("bunx", "npx")) {
-      onPath(runner, isWindows)?.let { resolved ->
-        return resolved
+    // Bun-first: every `bunx` probe — absolute install locations AND the PATH lookup — must rank
+    // ahead of every `npx` probe, so a Bun supplied on PATH by mise/asdf is never passed over for
+    // an absolute npm `npx`. Only after Bun is exhausted do we fall back to Node.
+    bunAbsoluteCandidates(isWindows)
+      .firstOrNull { executableAt(it) }
+      ?.let {
+        return it
       }
+    onPath("bunx", isWindows)?.let {
+      return it
+    }
+    nodeAbsoluteCandidates(isWindows)
+      .firstOrNull { executableAt(it) }
+      ?.let {
+        return it
+      }
+    onPath("npx", isWindows)?.let {
+      return it
     }
     // Nothing resolved: emit the legacy npx name so the failure surfaces actionable guidance.
     return if (isWindows) "npx.cmd" else "npx"
   }
 
-  /**
-   * Ordered highest-precedence first. Bun (`bunx`) always outranks Node (`npx`). Among the Node
-   * fallbacks, an nvm-installed Node is resolved by scanning `~/.nvm/versions/node/<version>/bin`
-   * newest-version first — nvm only publishes a `current` symlink when `NVM_SYMLINK_CURRENT=true`
-   * (off by default), and a detached GUI process cannot observe the shell-active version, so the
-   * newest installed version is the deterministic proxy.
-   */
-  private fun absoluteCandidates(isWindows: Boolean): List<String> =
+  private fun bunAbsoluteCandidates(isWindows: Boolean): List<String> =
     if (isWindows) {
       buildList { home?.let { add("$it\\.bun\\bin\\bunx.exe") } }
     } else {
@@ -304,6 +308,20 @@ internal class SystemDaemonPackageRunnerResolver(
         home?.let { add("$it/.bun/bin/bunx") }
         add("/opt/homebrew/bin/bunx")
         add("/usr/local/bin/bunx")
+      }
+    }
+
+  /**
+   * Node `npx` fallbacks, highest-precedence first. An nvm-installed Node is resolved by scanning
+   * `~/.nvm/versions/node/<version>/bin` newest-version first — nvm only publishes a `current`
+   * symlink when `NVM_SYMLINK_CURRENT=true` (off by default), and a detached GUI process cannot
+   * observe the shell-active version, so the newest installed version is the deterministic proxy.
+   */
+  private fun nodeAbsoluteCandidates(isWindows: Boolean): List<String> =
+    if (isWindows) {
+      emptyList()
+    } else {
+      buildList {
         add("/opt/homebrew/bin/npx")
         add("/usr/local/bin/npx")
         home?.let { h ->

--- a/android/desktop-core/src/main/kotlin/dev/jasonpearson/automobile/desktop/core/daemon/DesktopDaemonLifecycle.kt
+++ b/android/desktop-core/src/main/kotlin/dev/jasonpearson/automobile/desktop/core/daemon/DesktopDaemonLifecycle.kt
@@ -384,17 +384,41 @@ internal class SystemDaemonPackageRunnerResolver(
           return null
         }
         if (process.exitValue() != 0) return null
-        process.inputStream
-          .bufferedReader()
-          .readText()
-          .lineSequence()
-          .map { it.trim() }
-          .firstOrNull { it.isNotEmpty() }
+        selectRunnerFromLookup(
+          process.inputStream.bufferedReader().readText(),
+          isWindows,
+          executableExtensions(),
+        )
       } catch (_: Exception) {
         null
       }
     }
+
+    private fun executableExtensions(): List<String> =
+      (System.getenv("PATHEXT") ?: ".COM;.EXE;.BAT;.CMD")
+        .split(';')
+        .map { it.trim() }
+        .filter { it.isNotEmpty() }
   }
+}
+
+/**
+ * Picks the runner path from a `where`/`which` listing. On Windows `where npx` lists the
+ * extensionless POSIX shell shim before `npx.cmd` (npm's cmd-shim generator emits both a `.cmd` and
+ * an `sh` script), and the daemon launch wraps the runner in `cmd.exe /c`, which can only execute a
+ * PATHEXT entry — so the first result ending in a PATHEXT extension is chosen, falling back to the
+ * first line only if none match. `which` output on POSIX is already an executable path.
+ */
+internal fun selectRunnerFromLookup(
+  output: String,
+  isWindows: Boolean,
+  executableExtensions: List<String>,
+): String? {
+  val results = output.lineSequence().map { it.trim() }.filter { it.isNotEmpty() }.toList()
+  if (!isWindows) return results.firstOrNull()
+  return results.firstOrNull { candidate ->
+    executableExtensions.any { candidate.endsWith(it, ignoreCase = true) }
+  } ?: results.firstOrNull()
 }
 
 internal sealed interface DaemonLifecycleResult {

--- a/android/desktop-core/src/main/kotlin/dev/jasonpearson/automobile/desktop/core/daemon/DesktopDaemonLifecycle.kt
+++ b/android/desktop-core/src/main/kotlin/dev/jasonpearson/automobile/desktop/core/daemon/DesktopDaemonLifecycle.kt
@@ -146,13 +146,33 @@ internal data class DaemonCommandResult(
   val cancelled: Boolean = false,
 )
 
+/** A resolved launch command plus the runner's own directory to publish onto the child `PATH`. */
+internal data class DaemonLaunchCommand(
+  val command: List<String>,
+  val runnerDirectory: String?,
+)
+
 internal interface DaemonCommandExecutor {
-  fun execute(command: List<String>): DaemonCommandResult
+  /**
+   * [runnerDirectory], when non-null, is prepended to the child's `PATH`. `npx` is a
+   * `#!/usr/bin/env node` script, so under a GUI-stripped `PATH` an absolute `npx` still exits 127
+   * because the sibling `node` is undiscoverable; publishing the runner's own directory fixes that
+   * (and is harmless for the self-contained `bunx`).
+   */
+  fun execute(command: List<String>, runnerDirectory: String? = null): DaemonCommandResult
 }
 
 internal object SystemDaemonCommandExecutor : DaemonCommandExecutor {
-  override fun execute(command: List<String>): DaemonCommandResult {
-    val process = ProcessBuilder(command).redirectErrorStream(true).start()
+  override fun execute(command: List<String>, runnerDirectory: String?): DaemonCommandResult {
+    val builder = ProcessBuilder(command).redirectErrorStream(true)
+    if (runnerDirectory != null) {
+      val environment = builder.environment()
+      val existingPath = environment["PATH"].orEmpty()
+      environment["PATH"] =
+        if (existingPath.isEmpty()) runnerDirectory
+        else "$runnerDirectory${File.pathSeparator}$existingPath"
+    }
+    val process = builder.start()
     val output = StringBuffer()
     val outputDrainer = Thread {
       process.inputStream.bufferedReader().useLines { lines ->
@@ -404,9 +424,9 @@ internal class DesktopDaemonLifecycle(
       val action = if (daemonAvailable) "restart" else "start"
       val commandResult =
         try {
-          val command =
+          val launch =
             packageDaemonCommand(expectedVersion, action, currentDaemon?.launchArguments.orEmpty())
-          commandExecutor.execute(command)
+          commandExecutor.execute(launch.command, launch.runnerDirectory)
         } catch (error: Exception) {
           return DaemonLifecycleResult.Failure(
             "Could not $action AutoMobile $expectedVersion: ${error.message ?: error.javaClass.simpleName}. " +
@@ -452,7 +472,7 @@ internal class DesktopDaemonLifecycle(
     version: String,
     action: String,
     existingOptions: List<String>,
-  ): List<String> {
+  ): DaemonLaunchCommand {
     val osName = System.getProperty("os.name", "")
     val runner = packageRunnerResolver.resolve(osName)
     val runnerArguments = buildList {
@@ -464,7 +484,8 @@ internal class DesktopDaemonLifecycle(
       add(action)
       addAll(existingOptions)
     }
-    return commandForPlatform(runnerArguments, osName)
+    // A bare runner name (the unresolved fallback) has no directory to publish onto PATH.
+    return DaemonLaunchCommand(commandForPlatform(runnerArguments, osName), File(runner).parent)
   }
 
   internal fun usesYesFlag(runner: String): Boolean =

--- a/android/desktop-core/src/main/kotlin/dev/jasonpearson/automobile/desktop/core/daemon/DesktopDaemonLifecycle.kt
+++ b/android/desktop-core/src/main/kotlin/dev/jasonpearson/automobile/desktop/core/daemon/DesktopDaemonLifecycle.kt
@@ -3,8 +3,6 @@ package dev.jasonpearson.automobile.desktop.core.daemon
 import java.io.File
 import java.net.UnixDomainSocketAddress
 import java.nio.channels.SocketChannel
-import java.nio.file.Files
-import java.nio.file.Path
 import java.util.concurrent.TimeUnit
 import kotlinx.serialization.json.Json
 import kotlinx.serialization.json.JsonArray
@@ -148,30 +146,13 @@ internal data class DaemonCommandResult(
   val cancelled: Boolean = false,
 )
 
-/** A resolved launch command plus the runner's own directory to publish onto the child `PATH`. */
-internal data class DaemonLaunchCommand(
-  val command: List<String>,
-  val runnerDirectory: String?,
-)
-
 internal interface DaemonCommandExecutor {
-  /**
-   * [runnerDirectory], when non-null, is prepended to the child's `PATH`. `npx` is a
-   * `#!/usr/bin/env node` script, so under a GUI-stripped `PATH` an absolute `npx` still exits 127
-   * because the sibling `node` is undiscoverable; publishing the runner's own directory fixes that
-   * (and is harmless for the self-contained `bunx`).
-   */
-  fun execute(command: List<String>, runnerDirectory: String? = null): DaemonCommandResult
+  fun execute(command: List<String>): DaemonCommandResult
 }
 
 internal object SystemDaemonCommandExecutor : DaemonCommandExecutor {
-  override fun execute(command: List<String>, runnerDirectory: String?): DaemonCommandResult {
-    val builder = ProcessBuilder(command).redirectErrorStream(true)
-    if (runnerDirectory != null) {
-      val environment = builder.environment()
-      environment["PATH"] = composePath(runnerDirectory, environment["PATH"])
-    }
-    val process = builder.start()
+  override fun execute(command: List<String>): DaemonCommandResult {
+    val process = ProcessBuilder(command).redirectErrorStream(true).start()
     val output = StringBuffer()
     val outputDrainer = Thread {
       process.inputStream.bufferedReader().useLines { lines ->
@@ -213,11 +194,6 @@ internal object SystemDaemonCommandExecutor : DaemonCommandExecutor {
     }
     descendants.filter(ProcessHandle::isAlive).forEach(ProcessHandle::destroyForcibly)
   }
-
-  /** Prepends [runnerDirectory] to [existingPath], preserving the caller's order after it. */
-  internal fun composePath(runnerDirectory: String, existingPath: String?): String =
-    if (existingPath.isNullOrEmpty()) runnerDirectory
-    else "$runnerDirectory${File.pathSeparator}$existingPath"
 
   internal fun commandTimeoutMillis(
     startupTimeoutOverride: String? =
@@ -262,11 +238,10 @@ internal object SystemDaemonRetryTimer : DaemonRetryTimer {
 }
 
 /**
- * Resolves the package runner used to launch the pinned daemon package. AutoMobile runs on Bun, so
- * `bunx` is preferred over `npx`. Desktop apps launched from the GUI (Finder, Dock) inherit a
- * stripped PATH that omits `~/.bun/bin` and Homebrew, so the resolver probes known absolute install
- * locations before falling back to a PATH lookup — otherwise `ProcessBuilder` fails with "Cannot
- * run program" even when Bun is installed.
+ * Resolves the `bunx` runner used to launch the pinned daemon package. AutoMobile runs exclusively
+ * on Bun. It prefers the `bunx` the user's PATH resolves (their configured install) and falls back
+ * to known absolute install locations for GUI-launched apps (Finder, Dock) whose PATH is stripped —
+ * otherwise `ProcessBuilder` fails with "Cannot run program" even when Bun is installed.
  */
 internal interface DaemonPackageRunnerResolver {
   fun resolve(osName: String): String
@@ -276,17 +251,13 @@ internal class SystemDaemonPackageRunnerResolver(
   private val home: String? =
     System.getProperty("user.home")?.takeIf { it.isNotEmpty() } ?: System.getenv("HOME"),
   private val executableAt: (String) -> Boolean = { File(it).canExecute() },
-  private val listDir: (String) -> List<String> = { File(it).list()?.toList().orEmpty() },
   private val onPath: (String, Boolean) -> String? = ::whichRunner,
-  private val fileSystem: RunnerFileSystem = SystemRunnerFileSystem,
 ) : DaemonPackageRunnerResolver {
   override fun resolve(osName: String): String {
     val isWindows = osName.lowercase().contains("win")
-    // Prefer the runner the user's PATH actually resolves — their currently configured install
-    // (e.g. via mise/asdf/Homebrew) — and use the hard-coded absolute install locations only as a
-    // fallback for GUI-launched apps whose PATH is stripped (there `which/where` returns nothing,
-    // so we still land on the known install). Bun-first throughout: every `bunx` probe ranks ahead
-    // of every `npx` probe; bunx is self-contained, so being executable is enough.
+    // Prefer the `bunx` the user's PATH resolves (their configured install, e.g. via mise/asdf),
+    // then the hard-coded absolute install locations as a fallback for GUI-launched apps whose PATH
+    // is stripped (there `which/where` returns nothing, so we still land on the known install).
     onPath("bunx", isWindows)?.let {
       return it
     }
@@ -295,24 +266,10 @@ internal class SystemDaemonPackageRunnerResolver(
       ?.let {
         return it
       }
-    // npx needs a reachable Node runtime beside it (or along its symlink chain); a stale npx with
-    // no `node` must not be selected, or it would mask a later working install and still exit 127.
-    onPath("npx", isWindows)
-      ?.takeIf { hasReachableNode(it) }
-      ?.let {
-        return it
-      }
-    nodeAbsoluteCandidates(isWindows)
-      .firstOrNull { executableAt(it) && hasReachableNode(it) }
-      ?.let {
-        return it
-      }
-    // Nothing resolved: emit the legacy npx name so the failure surfaces actionable guidance.
-    return if (isWindows) "npx.cmd" else "npx"
+    // Nothing resolved: emit the bare name so the failure surfaces actionable guidance to install
+    // Bun.
+    return if (isWindows) "bunx.exe" else "bunx"
   }
-
-  private fun hasReachableNode(npx: String): Boolean =
-    resolveRunnerDirectory(npx, fileSystem) != null
 
   private fun bunAbsoluteCandidates(isWindows: Boolean): List<String> =
     if (isWindows) {
@@ -329,60 +286,7 @@ internal class SystemDaemonPackageRunnerResolver(
       }
     }
 
-  /**
-   * Node `npx` fallbacks, highest-precedence first. An nvm-installed Node is resolved by scanning
-   * `~/.nvm/versions/node/<version>/bin` newest-version first — nvm only publishes a `current`
-   * symlink when `NVM_SYMLINK_CURRENT=true` (off by default), and a detached GUI process cannot
-   * observe the shell-active version, so the newest installed version is the deterministic proxy.
-   */
-  private fun nodeAbsoluteCandidates(isWindows: Boolean): List<String> =
-    if (isWindows) {
-      emptyList()
-    } else {
-      buildList {
-        add("/opt/homebrew/bin/npx")
-        add("/usr/local/bin/npx")
-        add("/home/linuxbrew/.linuxbrew/bin/npx")
-        home?.let { add("$it/.linuxbrew/bin/npx") }
-        home?.let { h ->
-          val nvmNodeDir = "$h/.nvm/versions/node"
-          nvmNodeVersionsNewestFirst(nvmNodeDir).forEach { version ->
-            add("$nvmNodeDir/$version/bin/npx")
-          }
-          add("$h/.volta/bin/npx")
-        }
-      }
-    }
-
-  private fun nvmNodeVersionsNewestFirst(nvmNodeDir: String): List<String> {
-    val versions = listDir(nvmNodeDir).filter { it.startsWith("v") }
-    // A prerelease dir (`v20.11.1-rc.1`) must never outrank its stable release: `versionParts`
-    // drops the `rc` identifier but keeps its trailing number, so a naive numeric sort would call
-    // the RC newer. Rank all stable releases ahead of all prereleases; keep prereleases only as a
-    // last resort so a prerelease-only install still resolves. Newest numeric version wins in each.
-    val (stable, prerelease) = versions.partition { !it.contains('-') }
-    return stable.sortedWith(NVM_VERSION_ORDER.reversed()) +
-      prerelease.sortedWith(NVM_VERSION_ORDER.reversed())
-  }
-
   private companion object {
-    /**
-     * Ascending numeric order over dotted version dirs (`v20.11.1`); unparseable parts sort as 0.
-     */
-    val NVM_VERSION_ORDER: Comparator<String> = Comparator { left, right ->
-      val leftParts = versionParts(left)
-      val rightParts = versionParts(right)
-      for (index in 0 until maxOf(leftParts.size, rightParts.size)) {
-        val difference =
-          leftParts.getOrElse(index) { 0 }.compareTo(rightParts.getOrElse(index) { 0 })
-        if (difference != 0) return@Comparator difference
-      }
-      0
-    }
-
-    private fun versionParts(version: String): List<Int> =
-      version.removePrefix("v").split('.', '-').map { it.toIntOrNull() ?: 0 }
-
     fun whichRunner(runner: String, isWindows: Boolean): String? {
       val locator = if (isWindows) "where" else "which"
       return try {
@@ -411,11 +315,10 @@ internal class SystemDaemonPackageRunnerResolver(
 }
 
 /**
- * Picks the runner path from a `where`/`which` listing. On Windows `where npx` lists the
- * extensionless POSIX shell shim before `npx.cmd` (npm's cmd-shim generator emits both a `.cmd` and
- * an `sh` script), and the daemon launch wraps the runner in `cmd.exe /c`, which can only execute a
- * PATHEXT entry — so the first result ending in a PATHEXT extension is chosen, falling back to the
- * first line only if none match. `which` output on POSIX is already an executable path.
+ * Picks the runner path from a `where`/`which` listing. The daemon launch wraps the runner in
+ * `cmd.exe /c` on Windows, which can only execute a PATHEXT entry — so only a result ending in a
+ * PATHEXT extension qualifies there, and `null` is returned when none does so the resolver falls
+ * back to the absolute `bunx.exe`. `which` output on POSIX is already an executable path.
  */
 internal fun selectRunnerFromLookup(
   output: String,
@@ -426,7 +329,7 @@ internal fun selectRunnerFromLookup(
   if (!isWindows) return results.firstOrNull()
   return results.firstOrNull { candidate ->
     executableExtensions.any { candidate.endsWith(it, ignoreCase = true) }
-  } ?: results.firstOrNull()
+  }
 }
 
 internal sealed interface DaemonLifecycleResult {
@@ -437,73 +340,6 @@ internal sealed interface DaemonLifecycleResult {
 
 internal interface DaemonLifecycleEnsurer {
   fun ensureVersionMatchedDaemon(): DaemonLifecycleResult
-}
-
-/**
- * The directory holding the runner's sibling `node`, published onto the child `PATH` for npx so its
- * `#!/usr/bin/env node` launcher resolves under a stripped GUI `PATH`. Returns the first directory
- * that actually contains a `node`, checking the runner's own directory first (Homebrew and a
- * versioned nvm/Volta bin keep `node` beside `npx`) and following at most one symlink hop after
- * that (an npx shim in `/usr/local/bin` that links into another version's bin). It deliberately
- * does NOT fully canonicalize: `npx` is itself a symlink into npm's script dir
- * (`lib/node_modules/npm/bin/npx-cli.js`), which never holds `node`. A bare runner name (the
- * unresolved fallback) has no directory to publish.
- */
-/** Injectable filesystem link operations, so [resolveRunnerDirectory] is testable without real, */
-/** privilege-gated symlinks (Windows requires elevation to create them). Path arithmetic stays */
-/** on `java.nio.file.Path`, which is pure. */
-internal interface RunnerFileSystem {
-  /** True only when [path] is an existing, *executable* file. */
-  fun isExecutable(path: Path): Boolean
-
-  fun isSymbolicLink(path: Path): Boolean
-
-  fun readSymbolicLink(path: Path): Path
-}
-
-internal object SystemRunnerFileSystem : RunnerFileSystem {
-  override fun isExecutable(path: Path): Boolean = Files.isExecutable(path)
-
-  override fun isSymbolicLink(path: Path): Boolean = Files.isSymbolicLink(path)
-
-  override fun readSymbolicLink(path: Path): Path = Files.readSymbolicLink(path)
-}
-
-internal fun resolveRunnerDirectory(
-  runner: String,
-  fileSystem: RunnerFileSystem = SystemRunnerFileSystem,
-): String? {
-  if (File(runner).parent == null) return null // bare name → nothing to publish
-  // Null when no *executable* Node exists along the chain — the caller must NOT publish such a
-  // directory (a missing or non-executable node still fails `env node`); the npx is then treated
-  // as an unusable candidate so the resolver moves on to the next one.
-  return runCatching { nodeBinDirectory(File(runner).toPath(), fileSystem) }.getOrNull()
-}
-
-private const val SYMLINK_HOP_LIMIT = 10
-
-private fun directoryHoldsNode(directory: Path, fileSystem: RunnerFileSystem): Boolean =
-  fileSystem.isExecutable(directory.resolve("node")) ||
-    fileSystem.isExecutable(directory.resolve("node.exe"))
-
-private fun nodeBinDirectory(npx: Path, fileSystem: RunnerFileSystem): String? {
-  // Follow the symlink chain first and collect each resolved target's directory. The directory npx
-  // actually points into holds the Node it was installed against, so it must outrank an unrelated
-  // `node` sitting beside the shim. The shim's own directory is kept only as a fallback — that is
-  // what makes Homebrew and direct-nvm work, where npx links into npm's node-less script dir.
-  val resolvedDirs = mutableListOf<Path>()
-  var current: Path = npx
-  var hops = 0
-  while (hops < SYMLINK_HOP_LIMIT && fileSystem.isSymbolicLink(current)) {
-    val target = fileSystem.readSymbolicLink(current)
-    current =
-      (if (target.isAbsolute) target else current.parent?.resolve(target))?.normalize() ?: break
-    current.parent?.let { resolvedDirs.add(it) }
-    hops++
-  }
-  return (resolvedDirs + listOfNotNull(npx.parent))
-    .firstOrNull { directoryHoldsNode(it, fileSystem) }
-    ?.toString()
 }
 
 /**
@@ -519,7 +355,6 @@ internal class DesktopDaemonLifecycle(
   private val timer: DaemonRetryTimer = SystemDaemonRetryTimer,
   private val packageRunnerResolver: DaemonPackageRunnerResolver =
     SystemDaemonPackageRunnerResolver(),
-  private val runnerDirectoryOf: (String) -> String? = { resolveRunnerDirectory(it) },
   private val verificationAttempts: Int = DEFAULT_VERIFICATION_ATTEMPTS,
 ) : DaemonLifecycleEnsurer {
   override fun ensureVersionMatchedDaemon(): DaemonLifecycleResult =
@@ -562,13 +397,13 @@ internal class DesktopDaemonLifecycle(
       val action = if (daemonAvailable) "restart" else "start"
       val commandResult =
         try {
-          val launch =
+          val command =
             packageDaemonCommand(expectedVersion, action, currentDaemon?.launchArguments.orEmpty())
-          commandExecutor.execute(launch.command, launch.runnerDirectory)
+          commandExecutor.execute(command)
         } catch (error: Exception) {
           return DaemonLifecycleResult.Failure(
             "Could not $action AutoMobile $expectedVersion: ${error.message ?: error.javaClass.simpleName}. " +
-              "Install Bun (recommended) or Node.js so bunx/npx is available, then try again."
+              "Install Bun so bunx is available, then try again."
           )
         }
       if (commandResult.cancelled) {
@@ -610,28 +445,20 @@ internal class DesktopDaemonLifecycle(
     version: String,
     action: String,
     existingOptions: List<String>,
-  ): DaemonLaunchCommand {
+  ): List<String> {
     val osName = System.getProperty("os.name", "")
     val runner = packageRunnerResolver.resolve(osName)
-    val isNpx = usesYesFlag(runner)
-    val runnerArguments = buildList {
-      add(runner)
-      // Bun's `bunx` auto-installs without prompting; only npm's `npx` needs `-y`.
-      if (isNpx) add("-y")
-      add("@kaeawc/auto-mobile@${DaemonSocketPaths.releaseVersion(version)}")
-      add("--daemon")
-      add(action)
-      addAll(existingOptions)
-    }
-    // Publish the runner directory onto PATH only for npx, whose `env node` shebang needs the
-    // sibling `node`. bunx is self-contained, so leave the daemon's inherited PATH order untouched
-    // to avoid shadowing user-configured bare-name tools (e.g. ffmpeg).
-    val runnerDirectory = if (isNpx) runnerDirectoryOf(runner) else null
-    return DaemonLaunchCommand(commandForPlatform(runnerArguments, osName), runnerDirectory)
+    // `bunx` auto-installs the pinned package without prompting, and is a self-contained native
+    // binary, so it needs no `-y` flag and no PATH manipulation.
+    val runnerArguments =
+      listOf(
+        runner,
+        "@kaeawc/auto-mobile@${DaemonSocketPaths.releaseVersion(version)}",
+        "--daemon",
+        action,
+      ) + existingOptions
+    return commandForPlatform(runnerArguments, osName)
   }
-
-  internal fun usesYesFlag(runner: String): Boolean =
-    File(runner).nameWithoutExtension.lowercase() == "npx"
 
   private fun readPidStateWithRetry(): DaemonPidReadResult {
     repeat(PID_READ_ATTEMPTS) { attempt ->

--- a/android/desktop-core/src/main/kotlin/dev/jasonpearson/automobile/desktop/core/daemon/DesktopDaemonLifecycle.kt
+++ b/android/desktop-core/src/main/kotlin/dev/jasonpearson/automobile/desktop/core/daemon/DesktopDaemonLifecycle.kt
@@ -237,6 +237,77 @@ internal object SystemDaemonRetryTimer : DaemonRetryTimer {
   }
 }
 
+/**
+ * Resolves the package runner used to launch the pinned daemon package. AutoMobile runs on Bun, so
+ * `bunx` is preferred over `npx`. Desktop apps launched from the GUI (Finder, Dock) inherit a
+ * stripped PATH that omits `~/.bun/bin` and Homebrew, so the resolver probes known absolute install
+ * locations before falling back to a PATH lookup — otherwise `ProcessBuilder` fails with "Cannot
+ * run program" even when Bun is installed.
+ */
+internal interface DaemonPackageRunnerResolver {
+  fun resolve(osName: String): String
+}
+
+internal class SystemDaemonPackageRunnerResolver(
+  private val home: String? =
+    System.getProperty("user.home")?.takeIf { it.isNotEmpty() } ?: System.getenv("HOME"),
+  private val executableAt: (String) -> Boolean = { File(it).canExecute() },
+  private val onPath: (String, Boolean) -> String? = ::whichRunner,
+) : DaemonPackageRunnerResolver {
+  override fun resolve(osName: String): String {
+    val isWindows = osName.lowercase().contains("win")
+    for (candidate in absoluteCandidates(isWindows)) {
+      if (executableAt(candidate)) return candidate
+    }
+    for (runner in listOf("bunx", "npx")) {
+      onPath(runner, isWindows)?.let { resolved ->
+        return resolved
+      }
+    }
+    // Nothing resolved: emit the legacy npx name so the failure surfaces actionable guidance.
+    return if (isWindows) "npx.cmd" else "npx"
+  }
+
+  private fun absoluteCandidates(isWindows: Boolean): List<String> =
+    if (isWindows) {
+      buildList { home?.let { add("$it\\.bun\\bin\\bunx.exe") } }
+    } else {
+      buildList {
+        home?.let { add("$it/.bun/bin/bunx") }
+        add("/opt/homebrew/bin/bunx")
+        add("/usr/local/bin/bunx")
+        add("/opt/homebrew/bin/npx")
+        add("/usr/local/bin/npx")
+        home?.let {
+          add("$it/.nvm/current/bin/npx")
+          add("$it/.volta/bin/npx")
+        }
+      }
+    }
+
+  private companion object {
+    fun whichRunner(runner: String, isWindows: Boolean): String? {
+      val locator = if (isWindows) "where" else "which"
+      return try {
+        val process = ProcessBuilder(locator, runner).redirectErrorStream(true).start()
+        if (!process.waitFor(2, TimeUnit.SECONDS)) {
+          process.destroy()
+          return null
+        }
+        if (process.exitValue() != 0) return null
+        process.inputStream
+          .bufferedReader()
+          .readText()
+          .lineSequence()
+          .map { it.trim() }
+          .firstOrNull { it.isNotEmpty() }
+      } catch (_: Exception) {
+        null
+      }
+    }
+  }
+}
+
 internal sealed interface DaemonLifecycleResult {
   data class Ready(val restarted: Boolean) : DaemonLifecycleResult
 
@@ -258,6 +329,8 @@ internal class DesktopDaemonLifecycle(
   private val pidFileReader: DaemonPidFileReader = JsonDaemonPidFileReader(),
   private val commandExecutor: DaemonCommandExecutor = SystemDaemonCommandExecutor,
   private val timer: DaemonRetryTimer = SystemDaemonRetryTimer,
+  private val packageRunnerResolver: DaemonPackageRunnerResolver =
+    SystemDaemonPackageRunnerResolver(),
   private val verificationAttempts: Int = DEFAULT_VERIFICATION_ATTEMPTS,
 ) : DaemonLifecycleEnsurer {
   override fun ensureVersionMatchedDaemon(): DaemonLifecycleResult =
@@ -306,7 +379,7 @@ internal class DesktopDaemonLifecycle(
         } catch (error: Exception) {
           return DaemonLifecycleResult.Failure(
             "Could not $action AutoMobile $expectedVersion: ${error.message ?: error.javaClass.simpleName}. " +
-              "Install Node.js with npx available, then try again."
+              "Install Bun (recommended) or Node.js so bunx/npx is available, then try again."
           )
         }
       if (commandResult.cancelled) {
@@ -348,17 +421,23 @@ internal class DesktopDaemonLifecycle(
     version: String,
     action: String,
     existingOptions: List<String>,
-  ): List<String> =
-    commandForPlatform(
-      listOf(
-        npxExecutable(System.getProperty("os.name", "")),
-        "-y",
-        "@kaeawc/auto-mobile@${DaemonSocketPaths.releaseVersion(version)}",
-        "--daemon",
-        action,
-      ) + existingOptions,
-      System.getProperty("os.name", ""),
-    )
+  ): List<String> {
+    val osName = System.getProperty("os.name", "")
+    val runner = packageRunnerResolver.resolve(osName)
+    val runnerArguments = buildList {
+      add(runner)
+      // Bun's `bunx` auto-installs without prompting; only npm's `npx` needs `-y`.
+      if (usesYesFlag(runner)) add("-y")
+      add("@kaeawc/auto-mobile@${DaemonSocketPaths.releaseVersion(version)}")
+      add("--daemon")
+      add(action)
+      addAll(existingOptions)
+    }
+    return commandForPlatform(runnerArguments, osName)
+  }
+
+  internal fun usesYesFlag(runner: String): Boolean =
+    File(runner).nameWithoutExtension.lowercase() == "npx"
 
   private fun readPidStateWithRetry(): DaemonPidReadResult {
     repeat(PID_READ_ATTEMPTS) { attempt ->
@@ -413,9 +492,6 @@ internal class DesktopDaemonLifecycle(
 
   private fun declaresFullVersion(version: String): Boolean =
     DaemonSocketPaths.releaseVersion(version) != version
-
-  internal fun npxExecutable(osName: String): String =
-    if (osName.lowercase().contains("win")) "npx.cmd" else "npx"
 
   internal fun commandForPlatform(command: List<String>, osName: String): List<String> {
     if (!osName.lowercase().contains("win")) return command

--- a/android/desktop-core/src/main/kotlin/dev/jasonpearson/automobile/desktop/core/daemon/DesktopDaemonLifecycle.kt
+++ b/android/desktop-core/src/main/kotlin/dev/jasonpearson/automobile/desktop/core/daemon/DesktopDaemonLifecycle.kt
@@ -390,6 +390,18 @@ internal interface DaemonLifecycleEnsurer {
 }
 
 /**
+ * The directory holding the runner's sibling `node`, published onto the child `PATH` for npx.
+ * Symlinks are resolved first — an npx shim such as `/usr/local/bin/npx ->
+ * ~/.nvm/versions/node/vX/bin/npx` must publish the real Node bin (`~/.nvm/.../bin`), not the
+ * shim's lexical parent (`/usr/local/bin`, which has no `node`), or `env node` still exits 127. A
+ * bare runner name (the unresolved fallback) has no directory to publish.
+ */
+internal fun resolveRunnerDirectory(runner: String): String? {
+  val lexicalParent = File(runner).parent ?: return null
+  return runCatching { File(runner).canonicalFile.parent }.getOrNull() ?: lexicalParent
+}
+
+/**
  * Ensures the desktop only connects to a daemon that reports the same release version as the
  * desktop jar. The socket protocol gate remains the final authority; this lifecycle makes the UI
  * restart a skewed shared daemon before that gate rejects every ordinary request.
@@ -402,6 +414,7 @@ internal class DesktopDaemonLifecycle(
   private val timer: DaemonRetryTimer = SystemDaemonRetryTimer,
   private val packageRunnerResolver: DaemonPackageRunnerResolver =
     SystemDaemonPackageRunnerResolver(),
+  private val runnerDirectoryOf: (String) -> String? = ::resolveRunnerDirectory,
   private val verificationAttempts: Int = DEFAULT_VERIFICATION_ATTEMPTS,
 ) : DaemonLifecycleEnsurer {
   override fun ensureVersionMatchedDaemon(): DaemonLifecycleResult =
@@ -507,9 +520,8 @@ internal class DesktopDaemonLifecycle(
     }
     // Publish the runner directory onto PATH only for npx, whose `env node` shebang needs the
     // sibling `node`. bunx is self-contained, so leave the daemon's inherited PATH order untouched
-    // to avoid shadowing user-configured bare-name tools (e.g. ffmpeg). A bare runner name (the
-    // unresolved fallback) likewise has no directory to publish.
-    val runnerDirectory = if (isNpx) File(runner).parent else null
+    // to avoid shadowing user-configured bare-name tools (e.g. ffmpeg).
+    val runnerDirectory = if (isNpx) runnerDirectoryOf(runner) else null
     return DaemonLaunchCommand(commandForPlatform(runnerArguments, osName), runnerDirectory)
   }
 

--- a/android/desktop-core/src/main/kotlin/dev/jasonpearson/automobile/desktop/core/daemon/DesktopDaemonLifecycle.kt
+++ b/android/desktop-core/src/main/kotlin/dev/jasonpearson/automobile/desktop/core/daemon/DesktopDaemonLifecycle.kt
@@ -485,17 +485,23 @@ private fun directoryHoldsNode(directory: Path, fileSystem: RunnerFileSystem): B
     fileSystem.isExecutable(directory.resolve("node.exe"))
 
 private fun nodeBinDirectory(npx: Path, fileSystem: RunnerFileSystem): String? {
+  // Follow the symlink chain first and collect each resolved target's directory. The directory npx
+  // actually points into holds the Node it was installed against, so it must outrank an unrelated
+  // `node` sitting beside the shim. The shim's own directory is kept only as a fallback — that is
+  // what makes Homebrew and direct-nvm work, where npx links into npm's node-less script dir.
+  val resolvedDirs = mutableListOf<Path>()
   var current: Path = npx
-  repeat(SYMLINK_HOP_LIMIT) {
-    val parent = current.parent
-    if (parent != null && directoryHoldsNode(parent, fileSystem)) return parent.toString()
-    if (!fileSystem.isSymbolicLink(current)) return null
+  var hops = 0
+  while (hops < SYMLINK_HOP_LIMIT && fileSystem.isSymbolicLink(current)) {
     val target = fileSystem.readSymbolicLink(current)
     current =
-      (if (target.isAbsolute) target else current.parent?.resolve(target))?.normalize()
-        ?: return null
+      (if (target.isAbsolute) target else current.parent?.resolve(target))?.normalize() ?: break
+    current.parent?.let { resolvedDirs.add(it) }
+    hops++
   }
-  return null
+  return (resolvedDirs + listOfNotNull(npx.parent))
+    .firstOrNull { directoryHoldsNode(it, fileSystem) }
+    ?.toString()
 }
 
 /**

--- a/android/desktop-core/src/main/kotlin/dev/jasonpearson/automobile/desktop/core/daemon/DesktopDaemonLifecycle.kt
+++ b/android/desktop-core/src/main/kotlin/dev/jasonpearson/automobile/desktop/core/daemon/DesktopDaemonLifecycle.kt
@@ -252,6 +252,7 @@ internal class SystemDaemonPackageRunnerResolver(
   private val home: String? =
     System.getProperty("user.home")?.takeIf { it.isNotEmpty() } ?: System.getenv("HOME"),
   private val executableAt: (String) -> Boolean = { File(it).canExecute() },
+  private val listDir: (String) -> List<String> = { File(it).list()?.toList().orEmpty() },
   private val onPath: (String, Boolean) -> String? = ::whichRunner,
 ) : DaemonPackageRunnerResolver {
   override fun resolve(osName: String): String {
@@ -268,6 +269,13 @@ internal class SystemDaemonPackageRunnerResolver(
     return if (isWindows) "npx.cmd" else "npx"
   }
 
+  /**
+   * Ordered highest-precedence first. Bun (`bunx`) always outranks Node (`npx`). Among the Node
+   * fallbacks, an nvm-installed Node is resolved by scanning `~/.nvm/versions/node/<version>/bin`
+   * newest-version first — nvm only publishes a `current` symlink when `NVM_SYMLINK_CURRENT=true`
+   * (off by default), and a detached GUI process cannot observe the shell-active version, so the
+   * newest installed version is the deterministic proxy.
+   */
   private fun absoluteCandidates(isWindows: Boolean): List<String> =
     if (isWindows) {
       buildList { home?.let { add("$it\\.bun\\bin\\bunx.exe") } }
@@ -278,14 +286,37 @@ internal class SystemDaemonPackageRunnerResolver(
         add("/usr/local/bin/bunx")
         add("/opt/homebrew/bin/npx")
         add("/usr/local/bin/npx")
-        home?.let {
-          add("$it/.nvm/current/bin/npx")
-          add("$it/.volta/bin/npx")
+        home?.let { h ->
+          val nvmNodeDir = "$h/.nvm/versions/node"
+          nvmNodeVersionsNewestFirst(nvmNodeDir).forEach { version ->
+            add("$nvmNodeDir/$version/bin/npx")
+          }
+          add("$h/.volta/bin/npx")
         }
       }
     }
 
+  private fun nvmNodeVersionsNewestFirst(nvmNodeDir: String): List<String> =
+    listDir(nvmNodeDir).filter { it.startsWith("v") }.sortedWith(NVM_VERSION_ORDER.reversed())
+
   private companion object {
+    /**
+     * Ascending numeric order over dotted version dirs (`v20.11.1`); unparseable parts sort as 0.
+     */
+    val NVM_VERSION_ORDER: Comparator<String> = Comparator { left, right ->
+      val leftParts = versionParts(left)
+      val rightParts = versionParts(right)
+      for (index in 0 until maxOf(leftParts.size, rightParts.size)) {
+        val difference =
+          leftParts.getOrElse(index) { 0 }.compareTo(rightParts.getOrElse(index) { 0 })
+        if (difference != 0) return@Comparator difference
+      }
+      0
+    }
+
+    private fun versionParts(version: String): List<Int> =
+      version.removePrefix("v").split('.', '-').mapNotNull { it.toIntOrNull() }
+
     fun whichRunner(runner: String, isWindows: Boolean): String? {
       val locator = if (isWindows) "where" else "which"
       return try {

--- a/android/desktop-core/src/main/kotlin/dev/jasonpearson/automobile/desktop/core/daemon/DesktopDaemonLifecycle.kt
+++ b/android/desktop-core/src/main/kotlin/dev/jasonpearson/automobile/desktop/core/daemon/DesktopDaemonLifecycle.kt
@@ -338,8 +338,16 @@ internal class SystemDaemonPackageRunnerResolver(
       }
     }
 
-  private fun nvmNodeVersionsNewestFirst(nvmNodeDir: String): List<String> =
-    listDir(nvmNodeDir).filter { it.startsWith("v") }.sortedWith(NVM_VERSION_ORDER.reversed())
+  private fun nvmNodeVersionsNewestFirst(nvmNodeDir: String): List<String> {
+    val versions = listDir(nvmNodeDir).filter { it.startsWith("v") }
+    // A prerelease dir (`v20.11.1-rc.1`) must never outrank its stable release: `versionParts`
+    // drops the `rc` identifier but keeps its trailing number, so a naive numeric sort would call
+    // the RC newer. Rank all stable releases ahead of all prereleases; keep prereleases only as a
+    // last resort so a prerelease-only install still resolves. Newest numeric version wins in each.
+    val (stable, prerelease) = versions.partition { !it.contains('-') }
+    return stable.sortedWith(NVM_VERSION_ORDER.reversed()) +
+      prerelease.sortedWith(NVM_VERSION_ORDER.reversed())
+  }
 
   private companion object {
     /**

--- a/android/desktop-core/src/main/kotlin/dev/jasonpearson/automobile/desktop/core/daemon/DesktopDaemonLifecycle.kt
+++ b/android/desktop-core/src/main/kotlin/dev/jasonpearson/automobile/desktop/core/daemon/DesktopDaemonLifecycle.kt
@@ -167,10 +167,7 @@ internal object SystemDaemonCommandExecutor : DaemonCommandExecutor {
     val builder = ProcessBuilder(command).redirectErrorStream(true)
     if (runnerDirectory != null) {
       val environment = builder.environment()
-      val existingPath = environment["PATH"].orEmpty()
-      environment["PATH"] =
-        if (existingPath.isEmpty()) runnerDirectory
-        else "$runnerDirectory${File.pathSeparator}$existingPath"
+      environment["PATH"] = composePath(runnerDirectory, environment["PATH"])
     }
     val process = builder.start()
     val output = StringBuffer()
@@ -214,6 +211,11 @@ internal object SystemDaemonCommandExecutor : DaemonCommandExecutor {
     }
     descendants.filter(ProcessHandle::isAlive).forEach(ProcessHandle::destroyForcibly)
   }
+
+  /** Prepends [runnerDirectory] to [existingPath], preserving the caller's order after it. */
+  internal fun composePath(runnerDirectory: String, existingPath: String?): String =
+    if (existingPath.isNullOrEmpty()) runnerDirectory
+    else "$runnerDirectory${File.pathSeparator}$existingPath"
 
   internal fun commandTimeoutMillis(
     startupTimeoutOverride: String? =
@@ -493,17 +495,22 @@ internal class DesktopDaemonLifecycle(
   ): DaemonLaunchCommand {
     val osName = System.getProperty("os.name", "")
     val runner = packageRunnerResolver.resolve(osName)
+    val isNpx = usesYesFlag(runner)
     val runnerArguments = buildList {
       add(runner)
       // Bun's `bunx` auto-installs without prompting; only npm's `npx` needs `-y`.
-      if (usesYesFlag(runner)) add("-y")
+      if (isNpx) add("-y")
       add("@kaeawc/auto-mobile@${DaemonSocketPaths.releaseVersion(version)}")
       add("--daemon")
       add(action)
       addAll(existingOptions)
     }
-    // A bare runner name (the unresolved fallback) has no directory to publish onto PATH.
-    return DaemonLaunchCommand(commandForPlatform(runnerArguments, osName), File(runner).parent)
+    // Publish the runner directory onto PATH only for npx, whose `env node` shebang needs the
+    // sibling `node`. bunx is self-contained, so leave the daemon's inherited PATH order untouched
+    // to avoid shadowing user-configured bare-name tools (e.g. ffmpeg). A bare runner name (the
+    // unresolved fallback) likewise has no directory to publish.
+    val runnerDirectory = if (isNpx) File(runner).parent else null
+    return DaemonLaunchCommand(commandForPlatform(runnerArguments, osName), runnerDirectory)
   }
 
   internal fun usesYesFlag(runner: String): Boolean =

--- a/android/desktop-core/src/main/kotlin/dev/jasonpearson/automobile/desktop/core/daemon/DesktopDaemonLifecycle.kt
+++ b/android/desktop-core/src/main/kotlin/dev/jasonpearson/automobile/desktop/core/daemon/DesktopDaemonLifecycle.kt
@@ -291,16 +291,24 @@ internal class SystemDaemonPackageRunnerResolver(
       val locator = if (isWindows) "where" else "which"
       return try {
         val process = ProcessBuilder(locator, runner).redirectErrorStream(true).start()
-        if (!process.waitFor(2, TimeUnit.SECONDS)) {
-          process.destroy()
-          return null
+        try {
+          if (!process.waitFor(2, TimeUnit.SECONDS)) {
+            process.destroy()
+            return null
+          }
+          if (process.exitValue() != 0) return null
+          selectRunnerFromLookup(
+            process.inputStream.bufferedReader().readText(),
+            isWindows,
+            executableExtensions(),
+          )
+        } finally {
+          // Close the locator's streams on every path — the timeout and non-zero-exit branches
+          // would otherwise leak file descriptors until GC.
+          runCatching { process.inputStream.close() }
+          runCatching { process.outputStream.close() }
+          runCatching { process.errorStream.close() }
         }
-        if (process.exitValue() != 0) return null
-        selectRunnerFromLookup(
-          process.inputStream.bufferedReader().readText(),
-          isWindows,
-          executableExtensions(),
-        )
       } catch (_: Exception) {
         null
       }

--- a/android/desktop-core/src/main/kotlin/dev/jasonpearson/automobile/desktop/core/daemon/DesktopDaemonLifecycle.kt
+++ b/android/desktop-core/src/main/kotlin/dev/jasonpearson/automobile/desktop/core/daemon/DesktopDaemonLifecycle.kt
@@ -409,24 +409,46 @@ internal interface DaemonLifecycleEnsurer {
  * (`lib/node_modules/npm/bin/npx-cli.js`), which never holds `node`. A bare runner name (the
  * unresolved fallback) has no directory to publish.
  */
-internal fun resolveRunnerDirectory(runner: String): String? {
+/** Injectable filesystem link operations, so [resolveRunnerDirectory] is testable without real, */
+/** privilege-gated symlinks (Windows requires elevation to create them). Path arithmetic stays */
+/** on `java.nio.file.Path`, which is pure. */
+internal interface RunnerFileSystem {
+  fun exists(path: Path): Boolean
+
+  fun isSymbolicLink(path: Path): Boolean
+
+  fun readSymbolicLink(path: Path): Path
+}
+
+internal object SystemRunnerFileSystem : RunnerFileSystem {
+  override fun exists(path: Path): Boolean = Files.exists(path)
+
+  override fun isSymbolicLink(path: Path): Boolean = Files.isSymbolicLink(path)
+
+  override fun readSymbolicLink(path: Path): Path = Files.readSymbolicLink(path)
+}
+
+internal fun resolveRunnerDirectory(
+  runner: String,
+  fileSystem: RunnerFileSystem = SystemRunnerFileSystem,
+): String? {
   val start = File(runner)
   val lexicalParent = start.parent ?: return null // bare name → nothing to publish
-  return runCatching { nodeBinDirectory(start.toPath()) }.getOrNull() ?: lexicalParent
+  return runCatching { nodeBinDirectory(start.toPath(), fileSystem) }.getOrNull() ?: lexicalParent
 }
 
 private const val SYMLINK_HOP_LIMIT = 10
 
-private fun directoryHoldsNode(directory: Path): Boolean =
-  Files.exists(directory.resolve("node")) || Files.exists(directory.resolve("node.exe"))
+private fun directoryHoldsNode(directory: Path, fileSystem: RunnerFileSystem): Boolean =
+  fileSystem.exists(directory.resolve("node")) || fileSystem.exists(directory.resolve("node.exe"))
 
-private fun nodeBinDirectory(npx: Path): String? {
+private fun nodeBinDirectory(npx: Path, fileSystem: RunnerFileSystem): String? {
   var current: Path = npx
   repeat(SYMLINK_HOP_LIMIT) {
     val parent = current.parent
-    if (parent != null && directoryHoldsNode(parent)) return parent.toString()
-    if (!Files.isSymbolicLink(current)) return null
-    val target = Files.readSymbolicLink(current)
+    if (parent != null && directoryHoldsNode(parent, fileSystem)) return parent.toString()
+    if (!fileSystem.isSymbolicLink(current)) return null
+    val target = fileSystem.readSymbolicLink(current)
     current =
       (if (target.isAbsolute) target else current.parent?.resolve(target))?.normalize()
         ?: return null
@@ -447,7 +469,7 @@ internal class DesktopDaemonLifecycle(
   private val timer: DaemonRetryTimer = SystemDaemonRetryTimer,
   private val packageRunnerResolver: DaemonPackageRunnerResolver =
     SystemDaemonPackageRunnerResolver(),
-  private val runnerDirectoryOf: (String) -> String? = ::resolveRunnerDirectory,
+  private val runnerDirectoryOf: (String) -> String? = { resolveRunnerDirectory(it) },
   private val verificationAttempts: Int = DEFAULT_VERIFICATION_ATTEMPTS,
 ) : DaemonLifecycleEnsurer {
   override fun ensureVersionMatchedDaemon(): DaemonLifecycleResult =

--- a/android/desktop-core/src/main/kotlin/dev/jasonpearson/automobile/desktop/core/daemon/DesktopDaemonLifecycle.kt
+++ b/android/desktop-core/src/main/kotlin/dev/jasonpearson/automobile/desktop/core/daemon/DesktopDaemonLifecycle.kt
@@ -283,34 +283,46 @@ internal class SystemDaemonPackageRunnerResolver(
         // often omits Linuxbrew, so probe its default multi-user and per-user prefixes.
         add("/home/linuxbrew/.linuxbrew/bin/bunx")
         home?.let { add("$it/.linuxbrew/bin/bunx") }
+        // Version-manager shims (mise, asdf) at their default roots — a stripped GUI PATH omits
+        // these too, so a Bun installed only through mise/asdf would otherwise be missed.
+        home?.let {
+          add("$it/.local/share/mise/shims/bunx")
+          add("$it/.asdf/shims/bunx")
+        }
       }
     }
 
   private companion object {
     fun whichRunner(runner: String, isWindows: Boolean): String? {
       val locator = if (isWindows) "where" else "which"
-      return try {
-        val process = ProcessBuilder(locator, runner).redirectErrorStream(true).start()
+      val process =
         try {
-          if (!process.waitFor(2, TimeUnit.SECONDS)) {
-            process.destroy()
-            return null
-          }
-          if (process.exitValue() != 0) return null
-          selectRunnerFromLookup(
-            process.inputStream.bufferedReader().readText(),
-            isWindows,
-            executableExtensions(),
-          )
-        } finally {
-          // Close the locator's streams on every path — the timeout and non-zero-exit branches
-          // would otherwise leak file descriptors until GC.
-          runCatching { process.inputStream.close() }
-          runCatching { process.outputStream.close() }
-          runCatching { process.errorStream.close() }
+          ProcessBuilder(locator, runner).redirectErrorStream(true).start()
+        } catch (_: Exception) {
+          return null
         }
+      return try {
+        if (!process.waitFor(2, TimeUnit.SECONDS)) return null
+        if (process.exitValue() != 0) return null
+        selectRunnerFromLookup(
+          process.inputStream.bufferedReader().readText(),
+          isWindows,
+          executableExtensions(),
+        )
+      } catch (interrupted: InterruptedException) {
+        // Preserve cancellation: don't swallow the interrupt and fall through to spawning bunx.
+        // Restore the flag and rethrow so a cancelled lifecycle call launches no daemon.
+        Thread.currentThread().interrupt()
+        throw interrupted
       } catch (_: Exception) {
         null
+      } finally {
+        // Terminate the locator and close its streams on every path — otherwise the timeout,
+        // cancellation, and non-zero-exit branches leak file descriptors until GC.
+        process.destroy()
+        runCatching { process.inputStream.close() }
+        runCatching { process.outputStream.close() }
+        runCatching { process.errorStream.close() }
       }
     }
 

--- a/android/desktop-core/src/main/kotlin/dev/jasonpearson/automobile/desktop/core/daemon/DesktopDaemonLifecycle.kt
+++ b/android/desktop-core/src/main/kotlin/dev/jasonpearson/automobile/desktop/core/daemon/DesktopDaemonLifecycle.kt
@@ -282,26 +282,28 @@ internal class SystemDaemonPackageRunnerResolver(
 ) : DaemonPackageRunnerResolver {
   override fun resolve(osName: String): String {
     val isWindows = osName.lowercase().contains("win")
-    // Bun-first: every `bunx` probe — absolute install locations AND the PATH lookup — must rank
-    // ahead of every `npx` probe, so a Bun supplied on PATH by mise/asdf is never passed over for
-    // an absolute npm `npx`. bunx is self-contained, so being executable is enough.
+    // Prefer the runner the user's PATH actually resolves — their currently configured install
+    // (e.g. via mise/asdf/Homebrew) — and use the hard-coded absolute install locations only as a
+    // fallback for GUI-launched apps whose PATH is stripped (there `which/where` returns nothing,
+    // so we still land on the known install). Bun-first throughout: every `bunx` probe ranks ahead
+    // of every `npx` probe; bunx is self-contained, so being executable is enough.
+    onPath("bunx", isWindows)?.let {
+      return it
+    }
     bunAbsoluteCandidates(isWindows)
       .firstOrNull { executableAt(it) }
       ?.let {
         return it
       }
-    onPath("bunx", isWindows)?.let {
-      return it
-    }
     // npx needs a reachable Node runtime beside it (or along its symlink chain); a stale npx with
     // no `node` must not be selected, or it would mask a later working install and still exit 127.
-    nodeAbsoluteCandidates(isWindows)
-      .firstOrNull { executableAt(it) && hasReachableNode(it) }
+    onPath("npx", isWindows)
+      ?.takeIf { hasReachableNode(it) }
       ?.let {
         return it
       }
-    onPath("npx", isWindows)
-      ?.takeIf { hasReachableNode(it) }
+    nodeAbsoluteCandidates(isWindows)
+      .firstOrNull { executableAt(it) && hasReachableNode(it) }
       ?.let {
         return it
       }

--- a/android/desktop-core/src/main/kotlin/dev/jasonpearson/automobile/desktop/core/daemon/DesktopDaemonLifecycle.kt
+++ b/android/desktop-core/src/main/kotlin/dev/jasonpearson/automobile/desktop/core/daemon/DesktopDaemonLifecycle.kt
@@ -278,12 +278,13 @@ internal class SystemDaemonPackageRunnerResolver(
   private val executableAt: (String) -> Boolean = { File(it).canExecute() },
   private val listDir: (String) -> List<String> = { File(it).list()?.toList().orEmpty() },
   private val onPath: (String, Boolean) -> String? = ::whichRunner,
+  private val fileSystem: RunnerFileSystem = SystemRunnerFileSystem,
 ) : DaemonPackageRunnerResolver {
   override fun resolve(osName: String): String {
     val isWindows = osName.lowercase().contains("win")
     // Bun-first: every `bunx` probe — absolute install locations AND the PATH lookup — must rank
     // ahead of every `npx` probe, so a Bun supplied on PATH by mise/asdf is never passed over for
-    // an absolute npm `npx`. Only after Bun is exhausted do we fall back to Node.
+    // an absolute npm `npx`. bunx is self-contained, so being executable is enough.
     bunAbsoluteCandidates(isWindows)
       .firstOrNull { executableAt(it) }
       ?.let {
@@ -292,17 +293,24 @@ internal class SystemDaemonPackageRunnerResolver(
     onPath("bunx", isWindows)?.let {
       return it
     }
+    // npx needs a reachable Node runtime beside it (or along its symlink chain); a stale npx with
+    // no `node` must not be selected, or it would mask a later working install and still exit 127.
     nodeAbsoluteCandidates(isWindows)
-      .firstOrNull { executableAt(it) }
+      .firstOrNull { executableAt(it) && hasReachableNode(it) }
       ?.let {
         return it
       }
-    onPath("npx", isWindows)?.let {
-      return it
-    }
+    onPath("npx", isWindows)
+      ?.takeIf { hasReachableNode(it) }
+      ?.let {
+        return it
+      }
     // Nothing resolved: emit the legacy npx name so the failure surfaces actionable guidance.
     return if (isWindows) "npx.cmd" else "npx"
   }
+
+  private fun hasReachableNode(npx: String): Boolean =
+    resolveRunnerDirectory(npx, fileSystem) != null
 
   private fun bunAbsoluteCandidates(isWindows: Boolean): List<String> =
     if (isWindows) {
@@ -432,9 +440,11 @@ internal fun resolveRunnerDirectory(
   runner: String,
   fileSystem: RunnerFileSystem = SystemRunnerFileSystem,
 ): String? {
-  val start = File(runner)
-  val lexicalParent = start.parent ?: return null // bare name → nothing to publish
-  return runCatching { nodeBinDirectory(start.toPath(), fileSystem) }.getOrNull() ?: lexicalParent
+  if (File(runner).parent == null) return null // bare name → nothing to publish
+  // Null when no reachable Node exists along the chain — the caller must NOT publish a node-less
+  // directory (it would still fail `env node`); a node-less npx is treated as an unusable
+  // candidate.
+  return runCatching { nodeBinDirectory(File(runner).toPath(), fileSystem) }.getOrNull()
 }
 
 private const val SYMLINK_HOP_LIMIT = 10

--- a/android/desktop-core/src/main/kotlin/dev/jasonpearson/automobile/desktop/core/daemon/DesktopDaemonLifecycle.kt
+++ b/android/desktop-core/src/main/kotlin/dev/jasonpearson/automobile/desktop/core/daemon/DesktopDaemonLifecycle.kt
@@ -320,6 +320,10 @@ internal class SystemDaemonPackageRunnerResolver(
         home?.let { add("$it/.bun/bin/bunx") }
         add("/opt/homebrew/bin/bunx")
         add("/usr/local/bin/bunx")
+        // Homebrew on Linux (Linuxbrew): the desktop ships a Linux Deb, and a desktop-session PATH
+        // often omits Linuxbrew, so probe its default multi-user and per-user prefixes.
+        add("/home/linuxbrew/.linuxbrew/bin/bunx")
+        home?.let { add("$it/.linuxbrew/bin/bunx") }
       }
     }
 
@@ -336,6 +340,8 @@ internal class SystemDaemonPackageRunnerResolver(
       buildList {
         add("/opt/homebrew/bin/npx")
         add("/usr/local/bin/npx")
+        add("/home/linuxbrew/.linuxbrew/bin/npx")
+        home?.let { add("$it/.linuxbrew/bin/npx") }
         home?.let { h ->
           val nvmNodeDir = "$h/.nvm/versions/node"
           nvmNodeVersionsNewestFirst(nvmNodeDir).forEach { version ->
@@ -445,7 +451,8 @@ internal interface DaemonLifecycleEnsurer {
 /** privilege-gated symlinks (Windows requires elevation to create them). Path arithmetic stays */
 /** on `java.nio.file.Path`, which is pure. */
 internal interface RunnerFileSystem {
-  fun exists(path: Path): Boolean
+  /** True only when [path] is an existing, *executable* file. */
+  fun isExecutable(path: Path): Boolean
 
   fun isSymbolicLink(path: Path): Boolean
 
@@ -453,7 +460,7 @@ internal interface RunnerFileSystem {
 }
 
 internal object SystemRunnerFileSystem : RunnerFileSystem {
-  override fun exists(path: Path): Boolean = Files.exists(path)
+  override fun isExecutable(path: Path): Boolean = Files.isExecutable(path)
 
   override fun isSymbolicLink(path: Path): Boolean = Files.isSymbolicLink(path)
 
@@ -465,16 +472,17 @@ internal fun resolveRunnerDirectory(
   fileSystem: RunnerFileSystem = SystemRunnerFileSystem,
 ): String? {
   if (File(runner).parent == null) return null // bare name → nothing to publish
-  // Null when no reachable Node exists along the chain — the caller must NOT publish a node-less
-  // directory (it would still fail `env node`); a node-less npx is treated as an unusable
-  // candidate.
+  // Null when no *executable* Node exists along the chain — the caller must NOT publish such a
+  // directory (a missing or non-executable node still fails `env node`); the npx is then treated
+  // as an unusable candidate so the resolver moves on to the next one.
   return runCatching { nodeBinDirectory(File(runner).toPath(), fileSystem) }.getOrNull()
 }
 
 private const val SYMLINK_HOP_LIMIT = 10
 
 private fun directoryHoldsNode(directory: Path, fileSystem: RunnerFileSystem): Boolean =
-  fileSystem.exists(directory.resolve("node")) || fileSystem.exists(directory.resolve("node.exe"))
+  fileSystem.isExecutable(directory.resolve("node")) ||
+    fileSystem.isExecutable(directory.resolve("node.exe"))
 
 private fun nodeBinDirectory(npx: Path, fileSystem: RunnerFileSystem): String? {
   var current: Path = npx

--- a/android/desktop-core/src/main/kotlin/dev/jasonpearson/automobile/desktop/core/daemon/DesktopDaemonLifecycle.kt
+++ b/android/desktop-core/src/main/kotlin/dev/jasonpearson/automobile/desktop/core/daemon/DesktopDaemonLifecycle.kt
@@ -365,7 +365,7 @@ internal class SystemDaemonPackageRunnerResolver(
     }
 
     private fun versionParts(version: String): List<Int> =
-      version.removePrefix("v").split('.', '-').mapNotNull { it.toIntOrNull() }
+      version.removePrefix("v").split('.', '-').map { it.toIntOrNull() ?: 0 }
 
     fun whichRunner(runner: String, isWindows: Boolean): String? {
       val locator = if (isWindows) "where" else "which"

--- a/android/desktop-core/src/main/kotlin/dev/jasonpearson/automobile/desktop/core/daemon/DesktopDaemonLifecycle.kt
+++ b/android/desktop-core/src/main/kotlin/dev/jasonpearson/automobile/desktop/core/daemon/DesktopDaemonLifecycle.kt
@@ -3,6 +3,8 @@ package dev.jasonpearson.automobile.desktop.core.daemon
 import java.io.File
 import java.net.UnixDomainSocketAddress
 import java.nio.channels.SocketChannel
+import java.nio.file.Files
+import java.nio.file.Path
 import java.util.concurrent.TimeUnit
 import kotlinx.serialization.json.Json
 import kotlinx.serialization.json.JsonArray
@@ -390,15 +392,38 @@ internal interface DaemonLifecycleEnsurer {
 }
 
 /**
- * The directory holding the runner's sibling `node`, published onto the child `PATH` for npx.
- * Symlinks are resolved first — an npx shim such as `/usr/local/bin/npx ->
- * ~/.nvm/versions/node/vX/bin/npx` must publish the real Node bin (`~/.nvm/.../bin`), not the
- * shim's lexical parent (`/usr/local/bin`, which has no `node`), or `env node` still exits 127. A
- * bare runner name (the unresolved fallback) has no directory to publish.
+ * The directory holding the runner's sibling `node`, published onto the child `PATH` for npx so its
+ * `#!/usr/bin/env node` launcher resolves under a stripped GUI `PATH`. Returns the first directory
+ * that actually contains a `node`, checking the runner's own directory first (Homebrew and a
+ * versioned nvm/Volta bin keep `node` beside `npx`) and following at most one symlink hop after
+ * that (an npx shim in `/usr/local/bin` that links into another version's bin). It deliberately
+ * does NOT fully canonicalize: `npx` is itself a symlink into npm's script dir
+ * (`lib/node_modules/npm/bin/npx-cli.js`), which never holds `node`. A bare runner name (the
+ * unresolved fallback) has no directory to publish.
  */
 internal fun resolveRunnerDirectory(runner: String): String? {
-  val lexicalParent = File(runner).parent ?: return null
-  return runCatching { File(runner).canonicalFile.parent }.getOrNull() ?: lexicalParent
+  val start = File(runner)
+  val lexicalParent = start.parent ?: return null // bare name → nothing to publish
+  return runCatching { nodeBinDirectory(start.toPath()) }.getOrNull() ?: lexicalParent
+}
+
+private const val SYMLINK_HOP_LIMIT = 10
+
+private fun directoryHoldsNode(directory: Path): Boolean =
+  Files.exists(directory.resolve("node")) || Files.exists(directory.resolve("node.exe"))
+
+private fun nodeBinDirectory(npx: Path): String? {
+  var current: Path = npx
+  repeat(SYMLINK_HOP_LIMIT) {
+    val parent = current.parent
+    if (parent != null && directoryHoldsNode(parent)) return parent.toString()
+    if (!Files.isSymbolicLink(current)) return null
+    val target = Files.readSymbolicLink(current)
+    current =
+      (if (target.isAbsolute) target else current.parent?.resolve(target))?.normalize()
+        ?: return null
+  }
+  return null
 }
 
 /**

--- a/android/desktop-core/src/test/kotlin/dev/jasonpearson/automobile/desktop/core/daemon/DesktopDaemonLifecycleTest.kt
+++ b/android/desktop-core/src/test/kotlin/dev/jasonpearson/automobile/desktop/core/daemon/DesktopDaemonLifecycleTest.kt
@@ -334,6 +334,22 @@ class DesktopDaemonLifecycleTest {
   }
 
   @Test
+  fun `prefers a PATH bunx over an absolute npx fallback`() {
+    // Bun supplied on PATH by mise/asdf, npx present only at an absolute Homebrew path.
+    val resolver =
+      SystemDaemonPackageRunnerResolver(
+        home = "/Users/dev",
+        executableAt = { it == "/opt/homebrew/bin/npx" },
+        listDir = { emptyList() },
+        onPath = { runner, _ ->
+          if (runner == "bunx") "/Users/dev/.local/share/mise/shims/bunx" else null
+        },
+      )
+
+    assertEquals("/Users/dev/.local/share/mise/shims/bunx", resolver.resolve("Mac OS X"))
+  }
+
+  @Test
   fun `resolves the newest nvm-installed node before the volta fallback`() {
     val resolver =
       SystemDaemonPackageRunnerResolver(

--- a/android/desktop-core/src/test/kotlin/dev/jasonpearson/automobile/desktop/core/daemon/DesktopDaemonLifecycleTest.kt
+++ b/android/desktop-core/src/test/kotlin/dev/jasonpearson/automobile/desktop/core/daemon/DesktopDaemonLifecycleTest.kt
@@ -408,6 +408,24 @@ class DesktopDaemonLifecycleTest {
   }
 
   @Test
+  fun `prefers the stable nvm release over an installed release candidate`() {
+    val resolver =
+      SystemDaemonPackageRunnerResolver(
+        home = "/Users/dev",
+        executableAt = { it.startsWith("/Users/dev/.nvm/") },
+        listDir = { dir ->
+          if (dir == "/Users/dev/.nvm/versions/node")
+            listOf("v20.11.1-rc.1", "v20.11.1", "v18.19.0")
+          else emptyList()
+        },
+        onPath = { _, _ -> null },
+      )
+
+    // The stable release must win even though the RC's trailing number would sort it "newer".
+    assertEquals("/Users/dev/.nvm/versions/node/v20.11.1/bin/npx", resolver.resolve("Mac OS X"))
+  }
+
+  @Test
   fun `falls back to a PATH runner then the npx name`() {
     val resolver =
       SystemDaemonPackageRunnerResolver(

--- a/android/desktop-core/src/test/kotlin/dev/jasonpearson/automobile/desktop/core/daemon/DesktopDaemonLifecycleTest.kt
+++ b/android/desktop-core/src/test/kotlin/dev/jasonpearson/automobile/desktop/core/daemon/DesktopDaemonLifecycleTest.kt
@@ -1,5 +1,6 @@
 package dev.jasonpearson.automobile.desktop.core.daemon
 
+import java.io.File
 import java.nio.file.Files
 import kotlin.test.Test
 import kotlin.test.assertEquals
@@ -162,17 +163,34 @@ class DesktopDaemonLifecycleTest {
   }
 
   @Test
-  fun `resolveRunnerDirectory follows npx symlinks to the real node bin`() {
+  fun `resolveRunnerDirectory resolves npx to the node bin, not npm's script dir`() {
     val temp = Files.createTempDirectory("automobile-runner")
     try {
-      val realBin = Files.createDirectories(temp.resolve("versions/node/v20/bin"))
-      val realNpx = Files.createFile(realBin.resolve("npx"))
-      val shimDir = Files.createDirectories(temp.resolve("shims"))
-      val shimNpx = Files.createSymbolicLink(shimDir.resolve("npx"), realNpx)
+      // Standard nvm layout: node lives in bin, and bin/npx is a symlink into npm's script dir.
+      val nodeBin = Files.createDirectories(temp.resolve("versions/node/v24/bin"))
+      Files.createFile(nodeBin.resolve("node"))
+      val npmBin =
+        Files.createDirectories(temp.resolve("versions/node/v24/lib/node_modules/npm/bin"))
+      val npxCli = Files.createFile(npmBin.resolve("npx-cli.js"))
+      val nvmNpx = Files.createSymbolicLink(nodeBin.resolve("npx"), npxCli)
 
-      // The symlink target's directory holds the sibling `node`; the shim's lexical parent
-      // (shimDir) does not, so publishing that would leave `node` undiscoverable.
-      assertEquals(realBin.toRealPath().toString(), resolveRunnerDirectory(shimNpx.toString()))
+      val expected = nodeBin.toFile().canonicalPath
+
+      // Direct nvm npx: node sits beside it. Must return the node bin, NOT npm/bin (the fully
+      // canonical target's parent), which has no node.
+      assertEquals(
+        expected,
+        resolveRunnerDirectory(nvmNpx.toString())!!.let { File(it).canonicalPath },
+      )
+
+      // A shim in /usr/local/bin that links into the nvm bin resolves to the nvm bin (one hop).
+      val shimDir = Files.createDirectories(temp.resolve("usr/local/bin"))
+      val shimNpx = Files.createSymbolicLink(shimDir.resolve("npx"), nvmNpx)
+      assertEquals(
+        expected,
+        resolveRunnerDirectory(shimNpx.toString())!!.let { File(it).canonicalPath },
+      )
+
       // A bare runner name (unresolved fallback) has no directory to publish.
       assertEquals(null, resolveRunnerDirectory("npx"))
     } finally {

--- a/android/desktop-core/src/test/kotlin/dev/jasonpearson/automobile/desktop/core/daemon/DesktopDaemonLifecycleTest.kt
+++ b/android/desktop-core/src/test/kotlin/dev/jasonpearson/automobile/desktop/core/daemon/DesktopDaemonLifecycleTest.kt
@@ -1,11 +1,11 @@
 package dev.jasonpearson.automobile.desktop.core.daemon
 
 import java.nio.file.Files
-import java.nio.file.Path
 import kotlin.test.Test
 import kotlin.test.assertEquals
 import kotlin.test.assertFalse
 import kotlin.test.assertIs
+import kotlin.test.assertNull
 import kotlin.test.assertTrue
 
 class DesktopDaemonLifecycleTest {
@@ -53,18 +53,10 @@ class DesktopDaemonLifecycleTest {
     assertTrue(result.restarted)
     assertEquals(
       listOf(
-        listOf(
-          "bunx",
-          "@kaeawc/auto-mobile@0.0.40",
-          "--daemon",
-          "start",
-          "--network-mockable",
-        )
+        listOf("bunx", "@kaeawc/auto-mobile@0.0.40", "--daemon", "start", "--network-mockable")
       ),
       commands.commands,
     )
-    // A bare runner name (unresolved fallback) has no directory to publish onto PATH.
-    assertEquals(listOf<String?>(null), commands.runnerDirectories)
     assertEquals(listOf(150L, 150L), timer.delays)
   }
 
@@ -129,81 +121,6 @@ class DesktopDaemonLifecycleTest {
       listOf(listOf("/opt/homebrew/bin/bunx", "@kaeawc/auto-mobile@0.0.40", "--daemon", "restart")),
       commands.commands,
     )
-    // bunx is self-contained: its directory is NOT published onto PATH, so the daemon's inherited
-    // PATH order (and its bare-name tool resolution) is left untouched.
-    assertEquals(listOf<String?>(null), commands.runnerDirectories)
-  }
-
-  @Test
-  fun `falls back to npx with the yes flag when bun is unavailable`() {
-    val commands = FakeDaemonCommandExecutor()
-    val lifecycle =
-      DesktopDaemonLifecycle(
-        expectedVersionProvider = { "0.0.40" },
-        socketChecker = FakeDaemonSocketChecker(listOf(true, true)),
-        pidFileReader = FakeDaemonPidFileReader(listOf("0.0.39", "0.0.40")),
-        commandExecutor = commands,
-        timer = FakeDaemonRetryTimer(),
-        packageRunnerResolver = FakeDaemonPackageRunnerResolver("/usr/local/bin/npx"),
-        runnerDirectoryOf = { "/usr/local/bin" },
-      )
-
-    val result = lifecycle.ensureVersionMatchedDaemon()
-
-    assertIs<DaemonLifecycleResult.Ready>(result)
-    assertEquals(
-      listOf(
-        listOf("/usr/local/bin/npx", "-y", "@kaeawc/auto-mobile@0.0.40", "--daemon", "restart")
-      ),
-      commands.commands,
-    )
-    // The npx directory is published onto the child PATH so npx's `env node` shebang finds the
-    // sibling `node` under a GUI-stripped PATH.
-    assertEquals(listOf<String?>("/usr/local/bin"), commands.runnerDirectories)
-  }
-
-  @Test
-  fun `resolveRunnerDirectory resolves npx to the node bin, not npm's script dir`() {
-    // Standard nvm layout modeled in memory (no real, privilege-gated symlinks): node lives in
-    // bin, bin/npx is a symlink into npm's script dir, and a /usr/local/bin shim links into bin.
-    val nodeBin = Path.of("/opt/nvm/versions/node/v24/bin")
-    val npmBin = Path.of("/opt/nvm/versions/node/v24/lib/node_modules/npm/bin")
-    val nvmNpx = nodeBin.resolve("npx")
-    val shimNpx = Path.of("/usr/local/bin/npx")
-    val fs =
-      FakeRunnerFileSystem(
-        executableNodes = setOf(nodeBin.resolve("node")),
-        symlinks = mapOf(nvmNpx to npmBin.resolve("npx-cli.js"), shimNpx to nvmNpx),
-      )
-
-    // Direct nvm npx: node sits beside it. Must return the node bin, NOT npm/bin (the fully
-    // canonical target's parent), which has no node.
-    assertEquals(nodeBin.toString(), resolveRunnerDirectory(nvmNpx.toString(), fs))
-    // A shim in /usr/local/bin that links into the nvm bin resolves to the nvm bin (one hop).
-    assertEquals(nodeBin.toString(), resolveRunnerDirectory(shimNpx.toString(), fs))
-    // A bare runner name (unresolved fallback) has no directory to publish.
-    assertEquals(null, resolveRunnerDirectory("npx", fs))
-    // No reachable node along the chain → null, so the caller never publishes a node-less dir.
-    val emptyFs = FakeRunnerFileSystem(executableNodes = emptySet(), symlinks = emptyMap())
-    assertEquals(null, resolveRunnerDirectory("/usr/local/bin/npx", emptyFs))
-  }
-
-  @Test
-  fun `resolveRunnerDirectory prefers the node paired with the symlinked npx`() {
-    val shimDir = Path.of("/usr/local/bin")
-    val shimNpx = shimDir.resolve("npx")
-    val nvmBin = Path.of("/Users/dev/.nvm/versions/node/v20.11.1/bin")
-    val nvmNpx = nvmBin.resolve("npx")
-    val fs =
-      FakeRunnerFileSystem(
-        // Both directories have an executable node: the shim's is unrelated/stale, and the
-        // symlink target's is the runtime this npx was installed against.
-        executableNodes = setOf(shimDir.resolve("node"), nvmBin.resolve("node")),
-        symlinks = mapOf(shimNpx to nvmNpx),
-      )
-
-    // The symlink target's node bin wins over the unrelated node beside the shim.
-    assertEquals(nvmBin.toString(), resolveRunnerDirectory(shimNpx.toString(), fs))
   }
 
   @Test
@@ -325,6 +242,24 @@ class DesktopDaemonLifecycleTest {
   }
 
   @Test
+  fun `reports actionable guidance when bunx cannot be run`() {
+    val lifecycle =
+      DesktopDaemonLifecycle(
+        expectedVersionProvider = { "0.0.40" },
+        socketChecker = FakeDaemonSocketChecker(listOf(false)),
+        pidFileReader = FakeDaemonPidFileReader(listOf(null)),
+        commandExecutor = ThrowingDaemonCommandExecutor("Cannot run program \"bunx\""),
+        timer = FakeDaemonRetryTimer(),
+        packageRunnerResolver = FakeDaemonPackageRunnerResolver("bunx"),
+      )
+
+    val result = lifecycle.ensureVersionMatchedDaemon()
+
+    assertIs<DaemonLifecycleResult.Failure>(result)
+    assertTrue(result.message.contains("Install Bun so bunx is available"))
+  }
+
+  @Test
   fun `reports an actionable error when the pinned launch command times out`() {
     val lifecycle =
       DesktopDaemonLifecycle(
@@ -347,21 +282,9 @@ class DesktopDaemonLifecycleTest {
     val lifecycle = DesktopDaemonLifecycle()
 
     assertEquals(
-      listOf("cmd.exe", "/d", "/v:off", "/s", "/c", "\"\"bunx.exe\" \"-y\"\""),
-      lifecycle.commandForPlatform(listOf("bunx.exe", "-y"), "Windows 11"),
+      listOf("cmd.exe", "/d", "/v:off", "/s", "/c", "\"\"bunx.exe\" \"restart\"\""),
+      lifecycle.commandForPlatform(listOf("bunx.exe", "restart"), "Windows 11"),
     )
-  }
-
-  @Test
-  fun `adds the yes flag only for npx runners`() {
-    val lifecycle = DesktopDaemonLifecycle()
-
-    assertFalse(lifecycle.usesYesFlag("bunx"))
-    assertFalse(lifecycle.usesYesFlag("/Users/dev/.bun/bin/bunx"))
-    assertFalse(lifecycle.usesYesFlag("bunx.exe"))
-    assertTrue(lifecycle.usesYesFlag("npx"))
-    assertTrue(lifecycle.usesYesFlag("/usr/local/bin/npx"))
-    assertTrue(lifecycle.usesYesFlag("npx.cmd"))
   }
 
   @Test
@@ -371,7 +294,6 @@ class DesktopDaemonLifecycleTest {
         home = "/Users/dev",
         // A stale hard-coded ~/.bun/bin/bunx lingers, but the user has migrated to mise.
         executableAt = { it == "/Users/dev/.bun/bin/bunx" },
-        listDir = { emptyList() },
         onPath = { runner, _ ->
           if (runner == "bunx") "/Users/dev/.local/share/mise/shims/bunx" else null
         },
@@ -387,28 +309,11 @@ class DesktopDaemonLifecycleTest {
       SystemDaemonPackageRunnerResolver(
         home = "/Users/dev",
         executableAt = { it == "/Users/dev/.bun/bin/bunx" },
-        listDir = { emptyList() },
         // GUI-launched app: where/which resolves nothing against the stripped PATH.
         onPath = { _, _ -> null },
       )
 
     assertEquals("/Users/dev/.bun/bin/bunx", resolver.resolve("Mac OS X"))
-  }
-
-  @Test
-  fun `prefers a PATH bunx over an absolute npx fallback`() {
-    // Bun supplied on PATH by mise/asdf, npx present only at an absolute Homebrew path.
-    val resolver =
-      SystemDaemonPackageRunnerResolver(
-        home = "/Users/dev",
-        executableAt = { it == "/opt/homebrew/bin/npx" },
-        listDir = { emptyList() },
-        onPath = { runner, _ ->
-          if (runner == "bunx") "/Users/dev/.local/share/mise/shims/bunx" else null
-        },
-      )
-
-    assertEquals("/Users/dev/.local/share/mise/shims/bunx", resolver.resolve("Mac OS X"))
   }
 
   @Test
@@ -419,7 +324,6 @@ class DesktopDaemonLifecycleTest {
         home = "/home/dev",
         // Bun is only under Linuxbrew, and the desktop-session PATH omits it.
         executableAt = { it == linuxbrewBunx },
-        listDir = { emptyList() },
         onPath = { _, _ -> null },
       )
 
@@ -427,113 +331,24 @@ class DesktopDaemonLifecycleTest {
   }
 
   @Test
-  fun `resolves the newest nvm-installed node before the volta fallback`() {
-    val resolver =
-      SystemDaemonPackageRunnerResolver(
-        home = "/Users/dev",
-        executableAt = { it.startsWith("/Users/dev/.nvm/") || it == "/Users/dev/.volta/bin/npx" },
-        listDir = { dir ->
-          if (dir == "/Users/dev/.nvm/versions/node") listOf("v16.20.2", "v20.11.1", "v18.19.0")
-          else emptyList()
-        },
-        onPath = { _, _ -> null },
-        fileSystem =
-          fsWithNodeIn(
-            "/Users/dev/.nvm/versions/node/v20.11.1/bin",
-            "/Users/dev/.nvm/versions/node/v18.19.0/bin",
-            "/Users/dev/.nvm/versions/node/v16.20.2/bin",
-          ),
-      )
-
-    // Newest installed version wins over older ones and the Volta fallback.
-    assertEquals("/Users/dev/.nvm/versions/node/v20.11.1/bin/npx", resolver.resolve("Mac OS X"))
-  }
-
-  @Test
-  fun `prefers the stable nvm release over an installed release candidate`() {
-    val resolver =
-      SystemDaemonPackageRunnerResolver(
-        home = "/Users/dev",
-        executableAt = { it.startsWith("/Users/dev/.nvm/") },
-        listDir = { dir ->
-          if (dir == "/Users/dev/.nvm/versions/node")
-            listOf("v20.11.1-rc.1", "v20.11.1", "v18.19.0")
-          else emptyList()
-        },
-        onPath = { _, _ -> null },
-        fileSystem =
-          fsWithNodeIn(
-            "/Users/dev/.nvm/versions/node/v20.11.1/bin",
-            "/Users/dev/.nvm/versions/node/v18.19.0/bin",
-          ),
-      )
-
-    // The stable release must win even though the RC's trailing number would sort it "newer".
-    assertEquals("/Users/dev/.nvm/versions/node/v20.11.1/bin/npx", resolver.resolve("Mac OS X"))
-  }
-
-  @Test
-  fun `skips an npx without an executable node and selects a working nvm install`() {
-    val staleNpx = "/opt/homebrew/bin/npx"
-    val nvmBin = "/Users/dev/.nvm/versions/node/v20.11.1/bin"
-    val resolver =
-      SystemDaemonPackageRunnerResolver(
-        home = "/Users/dev",
-        // Both npx binaries are executable, but only the nvm one has an executable node beside it
-        // (the Homebrew npx's node is missing or non-executable).
-        executableAt = { it == staleNpx || it == "$nvmBin/npx" },
-        listDir = { dir ->
-          if (dir == "/Users/dev/.nvm/versions/node") listOf("v20.11.1") else emptyList()
-        },
-        onPath = { _, _ -> null },
-        fileSystem = fsWithNodeIn(nvmBin),
-      )
-
-    // The stale Homebrew npx (no executable node) is skipped rather than masking the working nvm.
-    assertEquals("$nvmBin/npx", resolver.resolve("Mac OS X"))
-  }
-
-  @Test
-  fun `falls back to a PATH runner then the npx name`() {
+  fun `emits the bare bunx name when nothing resolves`() {
     val resolver =
       SystemDaemonPackageRunnerResolver(
         home = "/Users/dev",
         executableAt = { false },
-        listDir = { emptyList() },
-        onPath = { runner, _ -> if (runner == "npx") "/opt/npx" else null },
-        // node lives beside the PATH-resolved npx, so it is usable.
-        fileSystem = fsWithNodeIn("/opt"),
-      )
-
-    assertEquals("/opt/npx", resolver.resolve("Mac OS X"))
-
-    val unresolved =
-      SystemDaemonPackageRunnerResolver(
-        home = "/Users/dev",
-        executableAt = { false },
-        listDir = { emptyList() },
         onPath = { _, _ -> null },
       )
 
-    assertEquals("npx", unresolved.resolve("Mac OS X"))
-    assertEquals("npx.cmd", unresolved.resolve("Windows 11"))
+    assertEquals("bunx", resolver.resolve("Mac OS X"))
+    assertEquals("bunx.exe", resolver.resolve("Windows 11"))
   }
 
   @Test
-  fun `windows runner lookup skips the POSIX shim for the cmd shell`() {
+  fun `windows runner lookup selects a PATHEXT-executable bunx`() {
     val pathExt = listOf(".COM", ".EXE", ".BAT", ".CMD")
 
-    // `where npx` on stock Node-for-Windows lists the extensionless POSIX shim before npx.cmd;
-    // cmd.exe /c can only run the .cmd, so it must be chosen.
-    assertEquals(
-      "C:\\Program Files\\nodejs\\npx.cmd",
-      selectRunnerFromLookup(
-        "C:\\Program Files\\nodejs\\npx\nC:\\Program Files\\nodejs\\npx.cmd\n",
-        isWindows = true,
-        pathExt,
-      ),
-    )
-    // bunx.exe is chosen over any extensionless shim.
+    // `where bunx` may list an extensionless entry before bunx.exe; cmd.exe /c can only run the
+    // PATHEXT entry, so it must be chosen.
     assertEquals(
       "C:\\Users\\dev\\.bun\\bin\\bunx.exe",
       selectRunnerFromLookup(
@@ -544,32 +359,11 @@ class DesktopDaemonLifecycleTest {
     )
     // POSIX `which` returns an already-executable path; take the first.
     assertEquals(
-      "/usr/local/bin/npx",
-      selectRunnerFromLookup("/usr/local/bin/npx\n", isWindows = false, pathExt),
+      "/Users/dev/.bun/bin/bunx",
+      selectRunnerFromLookup("/Users/dev/.bun/bin/bunx\n", isWindows = false, pathExt),
     )
-    // No PATHEXT match (unusual) falls back to the first line rather than returning null.
-    assertEquals(
-      "C:\\weird\\npx",
-      selectRunnerFromLookup("C:\\weird\\npx\n", isWindows = true, pathExt),
-    )
-  }
-
-  @Test
-  fun `composes the child PATH with the runner directory first`() {
-    val separator = java.io.File.pathSeparator
-
-    assertEquals(
-      "/opt/automobile/runner-bin${separator}/custom/bin",
-      SystemDaemonCommandExecutor.composePath("/opt/automobile/runner-bin", "/custom/bin"),
-    )
-    assertEquals(
-      "/opt/automobile/runner-bin",
-      SystemDaemonCommandExecutor.composePath("/opt/automobile/runner-bin", null),
-    )
-    assertEquals(
-      "/opt/automobile/runner-bin",
-      SystemDaemonCommandExecutor.composePath("/opt/automobile/runner-bin", ""),
-    )
+    // No PATHEXT match on Windows → null, so the resolver falls back to the absolute bunx.exe.
+    assertNull(selectRunnerFromLookup("C:\\weird\\bunx\n", isWindows = true, pathExt))
   }
 
   @Test
@@ -703,36 +497,22 @@ class DesktopDaemonLifecycleTest {
     private val timedOut: Boolean = false,
   ) : DaemonCommandExecutor {
     val commands = mutableListOf<List<String>>()
-    val runnerDirectories = mutableListOf<String?>()
 
-    override fun execute(command: List<String>, runnerDirectory: String?): DaemonCommandResult {
+    override fun execute(command: List<String>): DaemonCommandResult {
       commands += command
-      runnerDirectories += runnerDirectory
       return DaemonCommandResult(exitCode = exitCode, output = output, timedOut = timedOut)
     }
+  }
+
+  private class ThrowingDaemonCommandExecutor(private val message: String) : DaemonCommandExecutor {
+    override fun execute(command: List<String>): DaemonCommandResult =
+      throw java.io.IOException(message)
   }
 
   private class FakeDaemonPackageRunnerResolver(private val runner: String) :
     DaemonPackageRunnerResolver {
     override fun resolve(osName: String): String = runner
   }
-
-  private class FakeRunnerFileSystem(
-    private val executableNodes: Set<Path>,
-    private val symlinks: Map<Path, Path>,
-  ) : RunnerFileSystem {
-    override fun isExecutable(path: Path): Boolean = path in executableNodes
-
-    override fun isSymbolicLink(path: Path): Boolean = path in symlinks
-
-    override fun readSymbolicLink(path: Path): Path = symlinks.getValue(path)
-  }
-
-  private fun fsWithNodeIn(vararg binDirs: String): FakeRunnerFileSystem =
-    FakeRunnerFileSystem(
-      executableNodes = binDirs.map { Path.of(it).resolve("node") }.toSet(),
-      symlinks = emptyMap(),
-    )
 
   private class FakeDaemonRetryTimer : DaemonRetryTimer {
     val delays = mutableListOf<Long>()

--- a/android/desktop-core/src/test/kotlin/dev/jasonpearson/automobile/desktop/core/daemon/DesktopDaemonLifecycleTest.kt
+++ b/android/desktop-core/src/test/kotlin/dev/jasonpearson/automobile/desktop/core/daemon/DesktopDaemonLifecycleTest.kt
@@ -43,6 +43,7 @@ class DesktopDaemonLifecycleTest {
           ),
         commandExecutor = commands,
         timer = timer,
+        packageRunnerResolver = FakeDaemonPackageRunnerResolver("bunx"),
       )
 
     val result = lifecycle.ensureVersionMatchedDaemon()
@@ -52,8 +53,7 @@ class DesktopDaemonLifecycleTest {
     assertEquals(
       listOf(
         listOf(
-          "npx",
-          "-y",
+          "bunx",
           "@kaeawc/auto-mobile@0.0.40",
           "--daemon",
           "start",
@@ -115,6 +115,7 @@ class DesktopDaemonLifecycleTest {
         pidFileReader = FakeDaemonPidFileReader(listOf("0.0.39", "0.0.40")),
         commandExecutor = commands,
         timer = FakeDaemonRetryTimer(),
+        packageRunnerResolver = FakeDaemonPackageRunnerResolver("bunx"),
       )
 
     val result = lifecycle.ensureVersionMatchedDaemon()
@@ -122,7 +123,31 @@ class DesktopDaemonLifecycleTest {
     assertIs<DaemonLifecycleResult.Ready>(result)
     assertTrue(result.restarted)
     assertEquals(
-      listOf(listOf("npx", "-y", "@kaeawc/auto-mobile@0.0.40", "--daemon", "restart")),
+      listOf(listOf("bunx", "@kaeawc/auto-mobile@0.0.40", "--daemon", "restart")),
+      commands.commands,
+    )
+  }
+
+  @Test
+  fun `falls back to npx with the yes flag when bun is unavailable`() {
+    val commands = FakeDaemonCommandExecutor()
+    val lifecycle =
+      DesktopDaemonLifecycle(
+        expectedVersionProvider = { "0.0.40" },
+        socketChecker = FakeDaemonSocketChecker(listOf(true, true)),
+        pidFileReader = FakeDaemonPidFileReader(listOf("0.0.39", "0.0.40")),
+        commandExecutor = commands,
+        timer = FakeDaemonRetryTimer(),
+        packageRunnerResolver = FakeDaemonPackageRunnerResolver("/usr/local/bin/npx"),
+      )
+
+    val result = lifecycle.ensureVersionMatchedDaemon()
+
+    assertIs<DaemonLifecycleResult.Ready>(result)
+    assertEquals(
+      listOf(
+        listOf("/usr/local/bin/npx", "-y", "@kaeawc/auto-mobile@0.0.40", "--daemon", "restart")
+      ),
       commands.commands,
     )
   }
@@ -141,6 +166,7 @@ class DesktopDaemonLifecycleTest {
           ),
         commandExecutor = commands,
         timer = FakeDaemonRetryTimer(),
+        packageRunnerResolver = FakeDaemonPackageRunnerResolver("bunx"),
       )
 
     val result = lifecycle.ensureVersionMatchedDaemon()
@@ -149,8 +175,7 @@ class DesktopDaemonLifecycleTest {
     assertEquals(
       listOf(
         listOf(
-          "npx",
-          "-y",
+          "bunx",
           "@kaeawc/auto-mobile@0.0.40",
           "--daemon",
           "restart",
@@ -173,6 +198,7 @@ class DesktopDaemonLifecycleTest {
         pidFileReader = FakeDaemonPidFileReader(listOf(null, "0.0.40")),
         commandExecutor = commands,
         timer = FakeDaemonRetryTimer(),
+        packageRunnerResolver = FakeDaemonPackageRunnerResolver("bunx"),
       )
 
     val result = lifecycle.ensureVersionMatchedDaemon()
@@ -180,7 +206,7 @@ class DesktopDaemonLifecycleTest {
     assertIs<DaemonLifecycleResult.Ready>(result)
     assertTrue(result.restarted)
     assertEquals(
-      listOf(listOf("npx", "-y", "@kaeawc/auto-mobile@0.0.40", "--daemon", "restart")),
+      listOf(listOf("bunx", "@kaeawc/auto-mobile@0.0.40", "--daemon", "restart")),
       commands.commands,
     )
   }
@@ -260,15 +286,64 @@ class DesktopDaemonLifecycleTest {
   }
 
   @Test
-  fun `uses the Windows npm command shim`() {
+  fun `wraps the resolved runner in the Windows command shim`() {
     val lifecycle = DesktopDaemonLifecycle()
 
-    assertEquals("npx.cmd", lifecycle.npxExecutable("Windows 11"))
-    assertEquals("npx", lifecycle.npxExecutable("Mac OS X"))
     assertEquals(
-      listOf("cmd.exe", "/d", "/v:off", "/s", "/c", "\"\"npx.cmd\" \"-y\"\""),
-      lifecycle.commandForPlatform(listOf("npx.cmd", "-y"), "Windows 11"),
+      listOf("cmd.exe", "/d", "/v:off", "/s", "/c", "\"\"bunx.exe\" \"-y\"\""),
+      lifecycle.commandForPlatform(listOf("bunx.exe", "-y"), "Windows 11"),
     )
+  }
+
+  @Test
+  fun `adds the yes flag only for npx runners`() {
+    val lifecycle = DesktopDaemonLifecycle()
+
+    assertFalse(lifecycle.usesYesFlag("bunx"))
+    assertFalse(lifecycle.usesYesFlag("/Users/dev/.bun/bin/bunx"))
+    assertFalse(lifecycle.usesYesFlag("bunx.exe"))
+    assertTrue(lifecycle.usesYesFlag("npx"))
+    assertTrue(lifecycle.usesYesFlag("/usr/local/bin/npx"))
+    assertTrue(lifecycle.usesYesFlag("npx.cmd"))
+  }
+
+  @Test
+  fun `prefers a probed bun install over PATH lookups`() {
+    val onPathQueries = mutableListOf<String>()
+    val resolver =
+      SystemDaemonPackageRunnerResolver(
+        home = "/Users/dev",
+        executableAt = { it == "/Users/dev/.bun/bin/bunx" },
+        onPath = { runner, _ ->
+          onPathQueries += runner
+          null
+        },
+      )
+
+    assertEquals("/Users/dev/.bun/bin/bunx", resolver.resolve("Mac OS X"))
+    assertTrue(onPathQueries.isEmpty())
+  }
+
+  @Test
+  fun `falls back to a PATH runner then the npx name`() {
+    val resolver =
+      SystemDaemonPackageRunnerResolver(
+        home = "/Users/dev",
+        executableAt = { false },
+        onPath = { runner, _ -> if (runner == "npx") "/opt/npx" else null },
+      )
+
+    assertEquals("/opt/npx", resolver.resolve("Mac OS X"))
+
+    val unresolved =
+      SystemDaemonPackageRunnerResolver(
+        home = "/Users/dev",
+        executableAt = { false },
+        onPath = { _, _ -> null },
+      )
+
+    assertEquals("npx", unresolved.resolve("Mac OS X"))
+    assertEquals("npx.cmd", unresolved.resolve("Windows 11"))
   }
 
   @Test
@@ -407,6 +482,11 @@ class DesktopDaemonLifecycleTest {
       commands += command
       return DaemonCommandResult(exitCode = exitCode, output = output, timedOut = timedOut)
     }
+  }
+
+  private class FakeDaemonPackageRunnerResolver(private val runner: String) :
+    DaemonPackageRunnerResolver {
+    override fun resolve(osName: String): String = runner
   }
 
   private class FakeDaemonRetryTimer : DaemonRetryTimer {

--- a/android/desktop-core/src/test/kotlin/dev/jasonpearson/automobile/desktop/core/daemon/DesktopDaemonLifecycleTest.kt
+++ b/android/desktop-core/src/test/kotlin/dev/jasonpearson/automobile/desktop/core/daemon/DesktopDaemonLifecycleTest.kt
@@ -117,7 +117,7 @@ class DesktopDaemonLifecycleTest {
         pidFileReader = FakeDaemonPidFileReader(listOf("0.0.39", "0.0.40")),
         commandExecutor = commands,
         timer = FakeDaemonRetryTimer(),
-        packageRunnerResolver = FakeDaemonPackageRunnerResolver("bunx"),
+        packageRunnerResolver = FakeDaemonPackageRunnerResolver("/opt/homebrew/bin/bunx"),
       )
 
     val result = lifecycle.ensureVersionMatchedDaemon()
@@ -125,9 +125,12 @@ class DesktopDaemonLifecycleTest {
     assertIs<DaemonLifecycleResult.Ready>(result)
     assertTrue(result.restarted)
     assertEquals(
-      listOf(listOf("bunx", "@kaeawc/auto-mobile@0.0.40", "--daemon", "restart")),
+      listOf(listOf("/opt/homebrew/bin/bunx", "@kaeawc/auto-mobile@0.0.40", "--daemon", "restart")),
       commands.commands,
     )
+    // bunx is self-contained: its directory is NOT published onto PATH, so the daemon's inherited
+    // PATH order (and its bare-name tool resolution) is left untouched.
+    assertEquals(listOf<String?>(null), commands.runnerDirectories)
   }
 
   @Test
@@ -391,17 +394,21 @@ class DesktopDaemonLifecycleTest {
   }
 
   @Test
-  fun `prepends the runner directory onto the child PATH`() {
-    if (System.getProperty("os.name", "").lowercase().contains("win")) return
+  fun `composes the child PATH with the runner directory first`() {
+    val separator = java.io.File.pathSeparator
 
-    val result =
-      SystemDaemonCommandExecutor.execute(
-        listOf("sh", "-c", "printf '%s' \"\$PATH\""),
-        runnerDirectory = "/opt/automobile/runner-bin",
-      )
-
-    assertEquals(0, result.exitCode)
-    assertTrue(result.output.trim().startsWith("/opt/automobile/runner-bin:"))
+    assertEquals(
+      "/opt/automobile/runner-bin${separator}/custom/bin",
+      SystemDaemonCommandExecutor.composePath("/opt/automobile/runner-bin", "/custom/bin"),
+    )
+    assertEquals(
+      "/opt/automobile/runner-bin",
+      SystemDaemonCommandExecutor.composePath("/opt/automobile/runner-bin", null),
+    )
+    assertEquals(
+      "/opt/automobile/runner-bin",
+      SystemDaemonCommandExecutor.composePath("/opt/automobile/runner-bin", ""),
+    )
   }
 
   @Test

--- a/android/desktop-core/src/test/kotlin/dev/jasonpearson/automobile/desktop/core/daemon/DesktopDaemonLifecycleTest.kt
+++ b/android/desktop-core/src/test/kotlin/dev/jasonpearson/automobile/desktop/core/daemon/DesktopDaemonLifecycleTest.kt
@@ -365,21 +365,34 @@ class DesktopDaemonLifecycleTest {
   }
 
   @Test
-  fun `prefers a probed bun install over PATH lookups`() {
-    val onPathQueries = mutableListOf<String>()
+  fun `prefers the PATH bunx over a hard-coded install`() {
+    val resolver =
+      SystemDaemonPackageRunnerResolver(
+        home = "/Users/dev",
+        // A stale hard-coded ~/.bun/bin/bunx lingers, but the user has migrated to mise.
+        executableAt = { it == "/Users/dev/.bun/bin/bunx" },
+        listDir = { emptyList() },
+        onPath = { runner, _ ->
+          if (runner == "bunx") "/Users/dev/.local/share/mise/shims/bunx" else null
+        },
+      )
+
+    // The PATH-configured runner wins over the hard-coded install.
+    assertEquals("/Users/dev/.local/share/mise/shims/bunx", resolver.resolve("Mac OS X"))
+  }
+
+  @Test
+  fun `falls back to a probed bun install when PATH is stripped`() {
     val resolver =
       SystemDaemonPackageRunnerResolver(
         home = "/Users/dev",
         executableAt = { it == "/Users/dev/.bun/bin/bunx" },
         listDir = { emptyList() },
-        onPath = { runner, _ ->
-          onPathQueries += runner
-          null
-        },
+        // GUI-launched app: where/which resolves nothing against the stripped PATH.
+        onPath = { _, _ -> null },
       )
 
     assertEquals("/Users/dev/.bun/bin/bunx", resolver.resolve("Mac OS X"))
-    assertTrue(onPathQueries.isEmpty())
   }
 
   @Test

--- a/android/desktop-core/src/test/kotlin/dev/jasonpearson/automobile/desktop/core/daemon/DesktopDaemonLifecycleTest.kt
+++ b/android/desktop-core/src/test/kotlin/dev/jasonpearson/automobile/desktop/core/daemon/DesktopDaemonLifecycleTest.kt
@@ -144,6 +144,7 @@ class DesktopDaemonLifecycleTest {
         commandExecutor = commands,
         timer = FakeDaemonRetryTimer(),
         packageRunnerResolver = FakeDaemonPackageRunnerResolver("/usr/local/bin/npx"),
+        runnerDirectoryOf = { "/usr/local/bin" },
       )
 
     val result = lifecycle.ensureVersionMatchedDaemon()
@@ -155,9 +156,28 @@ class DesktopDaemonLifecycleTest {
       ),
       commands.commands,
     )
-    // The runner's own directory is published onto the child PATH so npx's `env node` shebang
-    // finds the sibling `node` under a GUI-stripped PATH.
+    // The npx directory is published onto the child PATH so npx's `env node` shebang finds the
+    // sibling `node` under a GUI-stripped PATH.
     assertEquals(listOf<String?>("/usr/local/bin"), commands.runnerDirectories)
+  }
+
+  @Test
+  fun `resolveRunnerDirectory follows npx symlinks to the real node bin`() {
+    val temp = Files.createTempDirectory("automobile-runner")
+    try {
+      val realBin = Files.createDirectories(temp.resolve("versions/node/v20/bin"))
+      val realNpx = Files.createFile(realBin.resolve("npx"))
+      val shimDir = Files.createDirectories(temp.resolve("shims"))
+      val shimNpx = Files.createSymbolicLink(shimDir.resolve("npx"), realNpx)
+
+      // The symlink target's directory holds the sibling `node`; the shim's lexical parent
+      // (shimDir) does not, so publishing that would leave `node` undiscoverable.
+      assertEquals(realBin.toRealPath().toString(), resolveRunnerDirectory(shimNpx.toString()))
+      // A bare runner name (unresolved fallback) has no directory to publish.
+      assertEquals(null, resolveRunnerDirectory("npx"))
+    } finally {
+      temp.toFile().deleteRecursively()
+    }
   }
 
   @Test

--- a/android/desktop-core/src/test/kotlin/dev/jasonpearson/automobile/desktop/core/daemon/DesktopDaemonLifecycleTest.kt
+++ b/android/desktop-core/src/test/kotlin/dev/jasonpearson/automobile/desktop/core/daemon/DesktopDaemonLifecycleTest.kt
@@ -183,6 +183,9 @@ class DesktopDaemonLifecycleTest {
     assertEquals(nodeBin.toString(), resolveRunnerDirectory(shimNpx.toString(), fs))
     // A bare runner name (unresolved fallback) has no directory to publish.
     assertEquals(null, resolveRunnerDirectory("npx", fs))
+    // No reachable node along the chain → null, so the caller never publishes a node-less dir.
+    val emptyFs = FakeRunnerFileSystem(nodeFiles = emptySet(), symlinks = emptyMap())
+    assertEquals(null, resolveRunnerDirectory("/usr/local/bin/npx", emptyFs))
   }
 
   @Test
@@ -388,6 +391,12 @@ class DesktopDaemonLifecycleTest {
           else emptyList()
         },
         onPath = { _, _ -> null },
+        fileSystem =
+          fsWithNodeIn(
+            "/Users/dev/.nvm/versions/node/v20.11.1/bin",
+            "/Users/dev/.nvm/versions/node/v18.19.0/bin",
+            "/Users/dev/.nvm/versions/node/v16.20.2/bin",
+          ),
       )
 
     // Newest installed version wins over older ones and the Volta fallback.
@@ -406,10 +415,35 @@ class DesktopDaemonLifecycleTest {
           else emptyList()
         },
         onPath = { _, _ -> null },
+        fileSystem =
+          fsWithNodeIn(
+            "/Users/dev/.nvm/versions/node/v20.11.1/bin",
+            "/Users/dev/.nvm/versions/node/v18.19.0/bin",
+          ),
       )
 
     // The stable release must win even though the RC's trailing number would sort it "newer".
     assertEquals("/Users/dev/.nvm/versions/node/v20.11.1/bin/npx", resolver.resolve("Mac OS X"))
+  }
+
+  @Test
+  fun `skips a node-less npx and selects a working nvm install`() {
+    val staleNpx = "/opt/homebrew/bin/npx"
+    val nvmBin = "/Users/dev/.nvm/versions/node/v20.11.1/bin"
+    val resolver =
+      SystemDaemonPackageRunnerResolver(
+        home = "/Users/dev",
+        // Both npx binaries are executable, but only the nvm one has node beside it.
+        executableAt = { it == staleNpx || it == "$nvmBin/npx" },
+        listDir = { dir ->
+          if (dir == "/Users/dev/.nvm/versions/node") listOf("v20.11.1") else emptyList()
+        },
+        onPath = { _, _ -> null },
+        fileSystem = fsWithNodeIn(nvmBin),
+      )
+
+    // The stale Homebrew npx (no reachable node) is skipped rather than masking the working nvm.
+    assertEquals("$nvmBin/npx", resolver.resolve("Mac OS X"))
   }
 
   @Test
@@ -420,6 +454,8 @@ class DesktopDaemonLifecycleTest {
         executableAt = { false },
         listDir = { emptyList() },
         onPath = { runner, _ -> if (runner == "npx") "/opt/npx" else null },
+        // node lives beside the PATH-resolved npx, so it is usable.
+        fileSystem = fsWithNodeIn("/opt"),
       )
 
     assertEquals("/opt/npx", resolver.resolve("Mac OS X"))
@@ -609,6 +645,12 @@ class DesktopDaemonLifecycleTest {
 
     override fun readSymbolicLink(path: Path): Path = symlinks.getValue(path)
   }
+
+  private fun fsWithNodeIn(vararg binDirs: String): FakeRunnerFileSystem =
+    FakeRunnerFileSystem(
+      nodeFiles = binDirs.map { Path.of(it).resolve("node") }.toSet(),
+      symlinks = emptyMap(),
+    )
 
   private class FakeDaemonRetryTimer : DaemonRetryTimer {
     val delays = mutableListOf<Long>()

--- a/android/desktop-core/src/test/kotlin/dev/jasonpearson/automobile/desktop/core/daemon/DesktopDaemonLifecycleTest.kt
+++ b/android/desktop-core/src/test/kotlin/dev/jasonpearson/automobile/desktop/core/daemon/DesktopDaemonLifecycleTest.kt
@@ -314,6 +314,7 @@ class DesktopDaemonLifecycleTest {
       SystemDaemonPackageRunnerResolver(
         home = "/Users/dev",
         executableAt = { it == "/Users/dev/.bun/bin/bunx" },
+        listDir = { emptyList() },
         onPath = { runner, _ ->
           onPathQueries += runner
           null
@@ -325,11 +326,29 @@ class DesktopDaemonLifecycleTest {
   }
 
   @Test
+  fun `resolves the newest nvm-installed node before the volta fallback`() {
+    val resolver =
+      SystemDaemonPackageRunnerResolver(
+        home = "/Users/dev",
+        executableAt = { it.startsWith("/Users/dev/.nvm/") || it == "/Users/dev/.volta/bin/npx" },
+        listDir = { dir ->
+          if (dir == "/Users/dev/.nvm/versions/node") listOf("v16.20.2", "v20.11.1", "v18.19.0")
+          else emptyList()
+        },
+        onPath = { _, _ -> null },
+      )
+
+    // Newest installed version wins over older ones and the Volta fallback.
+    assertEquals("/Users/dev/.nvm/versions/node/v20.11.1/bin/npx", resolver.resolve("Mac OS X"))
+  }
+
+  @Test
   fun `falls back to a PATH runner then the npx name`() {
     val resolver =
       SystemDaemonPackageRunnerResolver(
         home = "/Users/dev",
         executableAt = { false },
+        listDir = { emptyList() },
         onPath = { runner, _ -> if (runner == "npx") "/opt/npx" else null },
       )
 
@@ -339,6 +358,7 @@ class DesktopDaemonLifecycleTest {
       SystemDaemonPackageRunnerResolver(
         home = "/Users/dev",
         executableAt = { false },
+        listDir = { emptyList() },
         onPath = { _, _ -> null },
       )
 

--- a/android/desktop-core/src/test/kotlin/dev/jasonpearson/automobile/desktop/core/daemon/DesktopDaemonLifecycleTest.kt
+++ b/android/desktop-core/src/test/kotlin/dev/jasonpearson/automobile/desktop/core/daemon/DesktopDaemonLifecycleTest.kt
@@ -172,7 +172,7 @@ class DesktopDaemonLifecycleTest {
     val shimNpx = Path.of("/usr/local/bin/npx")
     val fs =
       FakeRunnerFileSystem(
-        nodeFiles = setOf(nodeBin.resolve("node")),
+        executableNodes = setOf(nodeBin.resolve("node")),
         symlinks = mapOf(nvmNpx to npmBin.resolve("npx-cli.js"), shimNpx to nvmNpx),
       )
 
@@ -184,7 +184,7 @@ class DesktopDaemonLifecycleTest {
     // A bare runner name (unresolved fallback) has no directory to publish.
     assertEquals(null, resolveRunnerDirectory("npx", fs))
     // No reachable node along the chain → null, so the caller never publishes a node-less dir.
-    val emptyFs = FakeRunnerFileSystem(nodeFiles = emptySet(), symlinks = emptyMap())
+    val emptyFs = FakeRunnerFileSystem(executableNodes = emptySet(), symlinks = emptyMap())
     assertEquals(null, resolveRunnerDirectory("/usr/local/bin/npx", emptyFs))
   }
 
@@ -381,6 +381,21 @@ class DesktopDaemonLifecycleTest {
   }
 
   @Test
+  fun `discovers a linuxbrew bun install when PATH omits it`() {
+    val linuxbrewBunx = "/home/linuxbrew/.linuxbrew/bin/bunx"
+    val resolver =
+      SystemDaemonPackageRunnerResolver(
+        home = "/home/dev",
+        // Bun is only under Linuxbrew, and the desktop-session PATH omits it.
+        executableAt = { it == linuxbrewBunx },
+        listDir = { emptyList() },
+        onPath = { _, _ -> null },
+      )
+
+    assertEquals(linuxbrewBunx, resolver.resolve("Linux"))
+  }
+
+  @Test
   fun `resolves the newest nvm-installed node before the volta fallback`() {
     val resolver =
       SystemDaemonPackageRunnerResolver(
@@ -427,13 +442,14 @@ class DesktopDaemonLifecycleTest {
   }
 
   @Test
-  fun `skips a node-less npx and selects a working nvm install`() {
+  fun `skips an npx without an executable node and selects a working nvm install`() {
     val staleNpx = "/opt/homebrew/bin/npx"
     val nvmBin = "/Users/dev/.nvm/versions/node/v20.11.1/bin"
     val resolver =
       SystemDaemonPackageRunnerResolver(
         home = "/Users/dev",
-        // Both npx binaries are executable, but only the nvm one has node beside it.
+        // Both npx binaries are executable, but only the nvm one has an executable node beside it
+        // (the Homebrew npx's node is missing or non-executable).
         executableAt = { it == staleNpx || it == "$nvmBin/npx" },
         listDir = { dir ->
           if (dir == "/Users/dev/.nvm/versions/node") listOf("v20.11.1") else emptyList()
@@ -442,7 +458,7 @@ class DesktopDaemonLifecycleTest {
         fileSystem = fsWithNodeIn(nvmBin),
       )
 
-    // The stale Homebrew npx (no reachable node) is skipped rather than masking the working nvm.
+    // The stale Homebrew npx (no executable node) is skipped rather than masking the working nvm.
     assertEquals("$nvmBin/npx", resolver.resolve("Mac OS X"))
   }
 
@@ -671,10 +687,10 @@ class DesktopDaemonLifecycleTest {
   }
 
   private class FakeRunnerFileSystem(
-    private val nodeFiles: Set<Path>,
+    private val executableNodes: Set<Path>,
     private val symlinks: Map<Path, Path>,
   ) : RunnerFileSystem {
-    override fun exists(path: Path): Boolean = path in nodeFiles || path in symlinks
+    override fun isExecutable(path: Path): Boolean = path in executableNodes
 
     override fun isSymbolicLink(path: Path): Boolean = path in symlinks
 
@@ -683,7 +699,7 @@ class DesktopDaemonLifecycleTest {
 
   private fun fsWithNodeIn(vararg binDirs: String): FakeRunnerFileSystem =
     FakeRunnerFileSystem(
-      nodeFiles = binDirs.map { Path.of(it).resolve("node") }.toSet(),
+      executableNodes = binDirs.map { Path.of(it).resolve("node") }.toSet(),
       symlinks = emptyMap(),
     )
 

--- a/android/desktop-core/src/test/kotlin/dev/jasonpearson/automobile/desktop/core/daemon/DesktopDaemonLifecycleTest.kt
+++ b/android/desktop-core/src/test/kotlin/dev/jasonpearson/automobile/desktop/core/daemon/DesktopDaemonLifecycleTest.kt
@@ -331,6 +331,20 @@ class DesktopDaemonLifecycleTest {
   }
 
   @Test
+  fun `discovers a mise-shimmed bun when PATH is stripped`() {
+    val miseBunx = "/Users/dev/.local/share/mise/shims/bunx"
+    val resolver =
+      SystemDaemonPackageRunnerResolver(
+        home = "/Users/dev",
+        // Bun is installed only through mise's shims, and the GUI-session PATH omits them.
+        executableAt = { it == miseBunx },
+        onPath = { _, _ -> null },
+      )
+
+    assertEquals(miseBunx, resolver.resolve("Mac OS X"))
+  }
+
+  @Test
   fun `emits the bare bunx name when nothing resolves`() {
     val resolver =
       SystemDaemonPackageRunnerResolver(

--- a/android/desktop-core/src/test/kotlin/dev/jasonpearson/automobile/desktop/core/daemon/DesktopDaemonLifecycleTest.kt
+++ b/android/desktop-core/src/test/kotlin/dev/jasonpearson/automobile/desktop/core/daemon/DesktopDaemonLifecycleTest.kt
@@ -62,6 +62,8 @@ class DesktopDaemonLifecycleTest {
       ),
       commands.commands,
     )
+    // A bare runner name (unresolved fallback) has no directory to publish onto PATH.
+    assertEquals(listOf<String?>(null), commands.runnerDirectories)
     assertEquals(listOf(150L, 150L), timer.delays)
   }
 
@@ -150,6 +152,9 @@ class DesktopDaemonLifecycleTest {
       ),
       commands.commands,
     )
+    // The runner's own directory is published onto the child PATH so npx's `env node` shebang
+    // finds the sibling `node` under a GUI-stripped PATH.
+    assertEquals(listOf<String?>("/usr/local/bin"), commands.runnerDirectories)
   }
 
   @Test
@@ -240,6 +245,7 @@ class DesktopDaemonLifecycleTest {
         pidFileReader = FakeDaemonPidFileReader(listOf("0.0.39", "0.0.39")),
         commandExecutor = FakeDaemonCommandExecutor(),
         timer = timer,
+        packageRunnerResolver = FakeDaemonPackageRunnerResolver("bunx"),
         verificationAttempts = 2,
       )
 
@@ -260,6 +266,7 @@ class DesktopDaemonLifecycleTest {
         pidFileReader = FakeDaemonPidFileReader(listOf(null)),
         commandExecutor = FakeDaemonCommandExecutor(exitCode = 1, output = ""),
         timer = FakeDaemonRetryTimer(),
+        packageRunnerResolver = FakeDaemonPackageRunnerResolver("bunx"),
       )
 
     val result = lifecycle.ensureVersionMatchedDaemon()
@@ -277,6 +284,7 @@ class DesktopDaemonLifecycleTest {
         pidFileReader = FakeDaemonPidFileReader(listOf(null)),
         commandExecutor = FakeDaemonCommandExecutor(exitCode = -1, timedOut = true),
         timer = FakeDaemonRetryTimer(),
+        packageRunnerResolver = FakeDaemonPackageRunnerResolver("bunx"),
       )
 
     val result = lifecycle.ensureVersionMatchedDaemon()
@@ -364,6 +372,20 @@ class DesktopDaemonLifecycleTest {
 
     assertEquals("npx", unresolved.resolve("Mac OS X"))
     assertEquals("npx.cmd", unresolved.resolve("Windows 11"))
+  }
+
+  @Test
+  fun `prepends the runner directory onto the child PATH`() {
+    if (System.getProperty("os.name", "").lowercase().contains("win")) return
+
+    val result =
+      SystemDaemonCommandExecutor.execute(
+        listOf("sh", "-c", "printf '%s' \"\$PATH\""),
+        runnerDirectory = "/opt/automobile/runner-bin",
+      )
+
+    assertEquals(0, result.exitCode)
+    assertTrue(result.output.trim().startsWith("/opt/automobile/runner-bin:"))
   }
 
   @Test
@@ -497,9 +519,11 @@ class DesktopDaemonLifecycleTest {
     private val timedOut: Boolean = false,
   ) : DaemonCommandExecutor {
     val commands = mutableListOf<List<String>>()
+    val runnerDirectories = mutableListOf<String?>()
 
-    override fun execute(command: List<String>): DaemonCommandResult {
+    override fun execute(command: List<String>, runnerDirectory: String?): DaemonCommandResult {
       commands += command
+      runnerDirectories += runnerDirectory
       return DaemonCommandResult(exitCode = exitCode, output = output, timedOut = timedOut)
     }
   }

--- a/android/desktop-core/src/test/kotlin/dev/jasonpearson/automobile/desktop/core/daemon/DesktopDaemonLifecycleTest.kt
+++ b/android/desktop-core/src/test/kotlin/dev/jasonpearson/automobile/desktop/core/daemon/DesktopDaemonLifecycleTest.kt
@@ -473,6 +473,41 @@ class DesktopDaemonLifecycleTest {
   }
 
   @Test
+  fun `windows runner lookup skips the POSIX shim for the cmd shell`() {
+    val pathExt = listOf(".COM", ".EXE", ".BAT", ".CMD")
+
+    // `where npx` on stock Node-for-Windows lists the extensionless POSIX shim before npx.cmd;
+    // cmd.exe /c can only run the .cmd, so it must be chosen.
+    assertEquals(
+      "C:\\Program Files\\nodejs\\npx.cmd",
+      selectRunnerFromLookup(
+        "C:\\Program Files\\nodejs\\npx\nC:\\Program Files\\nodejs\\npx.cmd\n",
+        isWindows = true,
+        pathExt,
+      ),
+    )
+    // bunx.exe is chosen over any extensionless shim.
+    assertEquals(
+      "C:\\Users\\dev\\.bun\\bin\\bunx.exe",
+      selectRunnerFromLookup(
+        "C:\\Users\\dev\\.bun\\bin\\bunx\nC:\\Users\\dev\\.bun\\bin\\bunx.exe\n",
+        isWindows = true,
+        pathExt,
+      ),
+    )
+    // POSIX `which` returns an already-executable path; take the first.
+    assertEquals(
+      "/usr/local/bin/npx",
+      selectRunnerFromLookup("/usr/local/bin/npx\n", isWindows = false, pathExt),
+    )
+    // No PATHEXT match (unusual) falls back to the first line rather than returning null.
+    assertEquals(
+      "C:\\weird\\npx",
+      selectRunnerFromLookup("C:\\weird\\npx\n", isWindows = true, pathExt),
+    )
+  }
+
+  @Test
   fun `composes the child PATH with the runner directory first`() {
     val separator = java.io.File.pathSeparator
 

--- a/android/desktop-core/src/test/kotlin/dev/jasonpearson/automobile/desktop/core/daemon/DesktopDaemonLifecycleTest.kt
+++ b/android/desktop-core/src/test/kotlin/dev/jasonpearson/automobile/desktop/core/daemon/DesktopDaemonLifecycleTest.kt
@@ -1,7 +1,7 @@
 package dev.jasonpearson.automobile.desktop.core.daemon
 
-import java.io.File
 import java.nio.file.Files
+import java.nio.file.Path
 import kotlin.test.Test
 import kotlin.test.assertEquals
 import kotlin.test.assertFalse
@@ -164,38 +164,25 @@ class DesktopDaemonLifecycleTest {
 
   @Test
   fun `resolveRunnerDirectory resolves npx to the node bin, not npm's script dir`() {
-    val temp = Files.createTempDirectory("automobile-runner")
-    try {
-      // Standard nvm layout: node lives in bin, and bin/npx is a symlink into npm's script dir.
-      val nodeBin = Files.createDirectories(temp.resolve("versions/node/v24/bin"))
-      Files.createFile(nodeBin.resolve("node"))
-      val npmBin =
-        Files.createDirectories(temp.resolve("versions/node/v24/lib/node_modules/npm/bin"))
-      val npxCli = Files.createFile(npmBin.resolve("npx-cli.js"))
-      val nvmNpx = Files.createSymbolicLink(nodeBin.resolve("npx"), npxCli)
-
-      val expected = nodeBin.toFile().canonicalPath
-
-      // Direct nvm npx: node sits beside it. Must return the node bin, NOT npm/bin (the fully
-      // canonical target's parent), which has no node.
-      assertEquals(
-        expected,
-        resolveRunnerDirectory(nvmNpx.toString())!!.let { File(it).canonicalPath },
+    // Standard nvm layout modeled in memory (no real, privilege-gated symlinks): node lives in
+    // bin, bin/npx is a symlink into npm's script dir, and a /usr/local/bin shim links into bin.
+    val nodeBin = Path.of("/opt/nvm/versions/node/v24/bin")
+    val npmBin = Path.of("/opt/nvm/versions/node/v24/lib/node_modules/npm/bin")
+    val nvmNpx = nodeBin.resolve("npx")
+    val shimNpx = Path.of("/usr/local/bin/npx")
+    val fs =
+      FakeRunnerFileSystem(
+        nodeFiles = setOf(nodeBin.resolve("node")),
+        symlinks = mapOf(nvmNpx to npmBin.resolve("npx-cli.js"), shimNpx to nvmNpx),
       )
 
-      // A shim in /usr/local/bin that links into the nvm bin resolves to the nvm bin (one hop).
-      val shimDir = Files.createDirectories(temp.resolve("usr/local/bin"))
-      val shimNpx = Files.createSymbolicLink(shimDir.resolve("npx"), nvmNpx)
-      assertEquals(
-        expected,
-        resolveRunnerDirectory(shimNpx.toString())!!.let { File(it).canonicalPath },
-      )
-
-      // A bare runner name (unresolved fallback) has no directory to publish.
-      assertEquals(null, resolveRunnerDirectory("npx"))
-    } finally {
-      temp.toFile().deleteRecursively()
-    }
+    // Direct nvm npx: node sits beside it. Must return the node bin, NOT npm/bin (the fully
+    // canonical target's parent), which has no node.
+    assertEquals(nodeBin.toString(), resolveRunnerDirectory(nvmNpx.toString(), fs))
+    // A shim in /usr/local/bin that links into the nvm bin resolves to the nvm bin (one hop).
+    assertEquals(nodeBin.toString(), resolveRunnerDirectory(shimNpx.toString(), fs))
+    // A bare runner name (unresolved fallback) has no directory to publish.
+    assertEquals(null, resolveRunnerDirectory("npx", fs))
   }
 
   @Test
@@ -610,6 +597,17 @@ class DesktopDaemonLifecycleTest {
   private class FakeDaemonPackageRunnerResolver(private val runner: String) :
     DaemonPackageRunnerResolver {
     override fun resolve(osName: String): String = runner
+  }
+
+  private class FakeRunnerFileSystem(
+    private val nodeFiles: Set<Path>,
+    private val symlinks: Map<Path, Path>,
+  ) : RunnerFileSystem {
+    override fun exists(path: Path): Boolean = path in nodeFiles || path in symlinks
+
+    override fun isSymbolicLink(path: Path): Boolean = path in symlinks
+
+    override fun readSymbolicLink(path: Path): Path = symlinks.getValue(path)
   }
 
   private class FakeDaemonRetryTimer : DaemonRetryTimer {

--- a/android/desktop-core/src/test/kotlin/dev/jasonpearson/automobile/desktop/core/daemon/DesktopDaemonLifecycleTest.kt
+++ b/android/desktop-core/src/test/kotlin/dev/jasonpearson/automobile/desktop/core/daemon/DesktopDaemonLifecycleTest.kt
@@ -189,6 +189,24 @@ class DesktopDaemonLifecycleTest {
   }
 
   @Test
+  fun `resolveRunnerDirectory prefers the node paired with the symlinked npx`() {
+    val shimDir = Path.of("/usr/local/bin")
+    val shimNpx = shimDir.resolve("npx")
+    val nvmBin = Path.of("/Users/dev/.nvm/versions/node/v20.11.1/bin")
+    val nvmNpx = nvmBin.resolve("npx")
+    val fs =
+      FakeRunnerFileSystem(
+        // Both directories have an executable node: the shim's is unrelated/stale, and the
+        // symlink target's is the runtime this npx was installed against.
+        executableNodes = setOf(shimDir.resolve("node"), nvmBin.resolve("node")),
+        symlinks = mapOf(shimNpx to nvmNpx),
+      )
+
+    // The symlink target's node bin wins over the unrelated node beside the shim.
+    assertEquals(nvmBin.toString(), resolveRunnerDirectory(shimNpx.toString(), fs))
+  }
+
+  @Test
   fun `preserves the skewed daemon options when restarting`() {
     val commands = FakeDaemonCommandExecutor()
     val lifecycle =


### PR DESCRIPTION
## Summary

The desktop app hardcoded `npx` to launch the pinned AutoMobile daemon package. A GUI-launched macOS app (Finder/Dock) inherits a **stripped PATH** that omits `~/.bun/bin` and Homebrew, so `ProcessBuilder(["npx", ...])` failed with `Cannot run program "npx": error=2 (No such file or directory)` — even when Bun (or Node) was installed. It also used npm's `npx` rather than Bun, which is AutoMobile's runtime.

This adds an injectable `DaemonPackageRunnerResolver` (mirroring the existing junit-runner pattern in `DaemonSocketClient`) that:

- **prefers Bun's `bunx` over `npx`**; only `npx` receives the `-y` flag (`bunx` auto-installs without prompting)
- **probes known absolute install locations** (`~/.bun/bin/bunx`, `/opt/homebrew/bin`, `/usr/local/bin`, then nvm/volta `npx`) before a `which`/`where` PATH lookup, so a stripped GUI PATH no longer breaks launch
- falls back to the bare `npx`/`npx.cmd` name so failures still surface actionable guidance, updated to *"Install Bun (recommended) or Node.js so bunx/npx is available."*

## Bug / Regression Context

- **Observed symptom:** Desktop app: `Couldn't load devices: … Could not start AutoMobile 0.0.52: Cannot run program "npx": Exec failed, error: 2 (No such file or directory). Install Node.js with npx available` (thrown from `DesktopDaemonLifecycle` via `McpDaemonClient.ensureVersionMatchedDaemon`).
- **Repro steps / conditions:** Launch the desktop app from the macOS GUI (not a terminal) on a machine where Bun lives in `~/.bun/bin` and `npx` is not on the GUI PATH.

## Validation

- [x] `:desktop-core:test` — `DesktopDaemonLifecycleTest` passes (bun-first command shape, npx `-y` fallback, resolver probe-then-PATH ordering)
- [x] Kotlin sources formatted via `scripts/ktfmt/apply_ktfmt.sh`
- [x] New code uses interface + fake for the resolver; tests are deterministic and fast

## Kotlin Reuse Check

- [x] Reused the established `bunx`→`npx` resolution + `-y`-only-for-npx convention already present in `junit-runner`'s `DaemonSocketClient`; no new dependency or util file added
