### PR TITLE
fix(android): preserve early emulator launch diagnostics

### DIFF
--- a/src/utils/android-cmdline-tools/AndroidEmulatorClient.ts
+++ b/src/utils/android-cmdline-tools/AndroidEmulatorClient.ts
@@ -14,8 +14,39 @@ import { WakeAndUnlock } from "../../features/action/WakeAndUnlock";
 import { DeviceLockStore } from "../../features/action/DeviceLockStore";
 import type { FormFactor } from "../../models/DeviceMatchCriteria";
 import type { AdbDeviceState } from "./interfaces/AdbExecutor";
+import { redactAndroidCommandOutput } from "./redactAndroidCommandOutput";
 
 const MODERN_PLAY_IMAGE_MIN_API_LEVEL = 30;
+const MAX_LAUNCH_OUTPUT_LINES = 50;
+const MAX_LAUNCH_OUTPUT_CHARS = 16_384;
+const ACCEL_CHECK_TIMEOUT_MS = 3_000;
+
+type LaunchFailureCategory =
+  | "display_initialization_failed"
+  | "hardware_acceleration_unavailable"
+  | "kvm_permission_denied"
+  | "missing_shared_library";
+
+function boundedOutputTail(output: string): string {
+  const lines = output.split(/\r?\n/);
+  const recentLines = lines.slice(-MAX_LAUNCH_OUTPUT_LINES);
+  const recentOutput = recentLines.join("\n");
+  if (recentOutput.length <= MAX_LAUNCH_OUTPUT_CHARS) {
+    return recentOutput;
+  }
+  const marker = "[... launch output truncated ...]\n";
+  return marker + recentOutput.slice(-(MAX_LAUNCH_OUTPUT_CHARS - marker.length));
+}
+
+function outputFromUnknown(value: unknown): string {
+  if (typeof value === "string") {
+    return value;
+  }
+  if (Buffer.isBuffer(value)) {
+    return value.toString();
+  }
+  return "";
+}
 
 /**
  * Interface for Android Emulator (AVD) management
@@ -231,6 +262,7 @@ export class AndroidEmulatorClient implements AndroidEmulator {
   private adbFactory: AdbClientFactory;
   private modelNameCache = new Map<string, string>();
   private avdConfigReader: AvdConfigReader;
+  private platform: NodeJS.Platform;
   private readonly launchTargetDeviceIds = new WeakMap<ChildProcess, string>();
   private readonly launchErrors = new WeakMap<ChildProcess, ActionableError>();
 
@@ -247,13 +279,15 @@ export class AndroidEmulatorClient implements AndroidEmulator {
     spawnFn: typeof spawn | null = null,
     timer: Timer = defaultTimer,
     adbFactory: AdbClientFactory = defaultAdbClientFactory,
-    avdConfigReader?: AvdConfigReader
+    avdConfigReader?: AvdConfigReader,
+    platform: NodeJS.Platform = process.platform,
   ) {
     this.execAsync = execAsyncFn || execAsync;
     this.spawnFn = spawnFn || spawn;
     this.timer = timer;
     this.adbFactory = adbFactory;
     this.avdConfigReader = avdConfigReader ?? new FileAvdConfigReader();
+    this.platform = platform;
     // Only set a fallback emulator path here; proper detection happens lazily
     this.emulatorPath = this.getFallbackEmulatorPath();
   }
@@ -700,6 +734,102 @@ export class AndroidEmulatorClient implements AndroidEmulator {
     return { isDisplayError: false };
   }
 
+  private appendLaunchOutput(outputBuffer: string[], output: string): string {
+    outputBuffer.push(...redactAndroidCommandOutput(output).split(/\r?\n/));
+    const boundedOutput = boundedOutputTail(outputBuffer.join("\n"));
+    outputBuffer.splice(0, outputBuffer.length, ...boundedOutput.split("\n"));
+    return boundedOutput;
+  }
+
+  private launchFailureCategory(output: string): LaunchFailureCategory | undefined {
+    if (/error while loading shared libraries/i.test(output)) {
+      return "missing_shared_library";
+    }
+    if (
+      /ProbeKVM[\s\S]*(?:permission denied|operation not permitted)/i.test(output)
+      || /\/dev\/kvm[\s\S]*(?:permission denied|operation not permitted)/i.test(output)
+      || /permissions? to use KVM/i.test(output)
+    ) {
+      return "kvm_permission_denied";
+    }
+    return undefined;
+  }
+
+  private accelerationCheckCategory(output: string): LaunchFailureCategory | undefined {
+    const kvmCategory = this.launchFailureCategory(output);
+    if (kvmCategory) {
+      return kvmCategory;
+    }
+    if (
+      /(?:acceleration|KVM|hypervisor)/i.test(output)
+      && /(?:not available|unavailable|not supported|not enabled|cannot use|disabled)/i.test(output)
+    ) {
+      return "hardware_acceleration_unavailable";
+    }
+    return undefined;
+  }
+
+  private appendCategory(error: ActionableError, category: LaunchFailureCategory): ActionableError {
+    return new ActionableError(`${error.message}\n\ncategory=${category}`);
+  }
+
+  private formatEarlyExitError(
+    avdName: string,
+    code: number | null,
+    signal: NodeJS.Signals | null,
+    category: LaunchFailureCategory | undefined,
+    output: string,
+    accelCheckOutput: string,
+  ): ActionableError {
+    const header = [
+      `Emulator process exited with code: ${code}${signal ? ` (signal: ${signal})` : ""} (AVD '${avdName}'`,
+      category ? `; category=${category}` : "",
+      ")",
+    ].join("");
+    const sections = [
+      header,
+      output.trim() ? `Diagnostic:\n${output.trim()}` : "",
+      accelCheckOutput.trim() ? `emulator -accel-check:\n${accelCheckOutput.trim()}` : "",
+    ].filter(Boolean);
+    return new ActionableError(sections.join("\n"));
+  }
+
+  private diagnosticOutputFromError(error: unknown): string {
+    if (typeof error !== "object" || error === null) {
+      return "";
+    }
+    const output = error as { stdout?: unknown; stderr?: unknown };
+    return boundedOutputTail(
+      redactAndroidCommandOutput([outputFromUnknown(output.stdout), outputFromUnknown(output.stderr)].filter(Boolean).join("\n")),
+    );
+  }
+
+  private async runAccelerationCheck(): Promise<string> {
+    const controller = new AbortController();
+    let timeout: NodeJS.Timeout | undefined;
+    const probe = Promise.resolve()
+      .then(() => this.execAsync(this.emulatorPath, ["-accel-check"], controller.signal))
+      .then(
+        result => boundedOutputTail(redactAndroidCommandOutput([result.stdout, result.stderr].filter(Boolean).join("\n"))),
+        error => this.diagnosticOutputFromError(error),
+      );
+    const timeoutResult = new Promise<string>(resolve => {
+      timeout = this.timer.setTimeout(() => {
+        controller.abort();
+        logger.debug(`Emulator acceleration check timed out after ${ACCEL_CHECK_TIMEOUT_MS}ms`);
+        resolve("");
+      }, ACCEL_CHECK_TIMEOUT_MS);
+    });
+
+    try {
+      return await Promise.race([probe, timeoutResult]);
+    } finally {
+      if (timeout) {
+        this.timer.clearTimeout(timeout);
+      }
+    }
+  }
+
   /**
    * Execute an emulator command
    * @param command - The command to execute
@@ -1118,28 +1248,21 @@ export class AndroidEmulatorClient implements AndroidEmulator {
       perf.endOperation("spawnEmulator");
       onSpawn?.(child);
 
-      // Buffer to collect initial output for PANIC detection
-      let initialOutput = "";
+      // Keep only a redacted tail for launch diagnostics and failure classification.
       const outputBuffer: string[] = [];
-      const maxBufferLines = 50; // Keep last 50 lines for error analysis
       let startupValidationComplete = false;
+      let exitCode: number | null | undefined;
+      let exitSignal: NodeJS.Signals | null | undefined;
       perf.startOperation("panicDetection");
 
       // Monitor emulator output for PANIC errors
       const monitorOutput = (data: any) => {
         const output = data.toString();
-        initialOutput += output;
-        this.captureLaunchTargetDeviceId(child, initialOutput);
-
-        // Keep a rolling buffer of recent output
-        const lines = output.split("\n");
-        outputBuffer.push(...lines);
-        if (outputBuffer.length > maxBufferLines) {
-          outputBuffer.splice(0, outputBuffer.length - maxBufferLines);
-        }
+        const launchOutput = this.appendLaunchOutput(outputBuffer, output);
+        this.captureLaunchTargetDeviceId(child, launchOutput);
 
         // Detect sandbox/JIT entitlement failures before generic PANIC handling.
-        const sandboxError = this.sandboxFailure(initialOutput);
+        const sandboxError = this.sandboxFailure(launchOutput);
         if (sandboxError) {
           logger.error(`Emulator sandbox error detected: ${sandboxError.message}`);
           this.launchErrors.set(child, sandboxError);
@@ -1153,7 +1276,7 @@ export class AndroidEmulatorClient implements AndroidEmulator {
         }
 
         // Check for PANIC in the output
-        const panicResult = this.detectArchitecturePanic(initialOutput);
+        const panicResult = this.detectArchitecturePanic(launchOutput);
         if (panicResult.isPanic) {
           logger.error(`Emulator PANIC detected: ${panicResult.message}`);
 
@@ -1185,7 +1308,7 @@ export class AndroidEmulatorClient implements AndroidEmulator {
         }
 
         // Check for corrupt disk image
-        const corruptResult = this.detectCorruptImage(initialOutput);
+        const corruptResult = this.detectCorruptImage(launchOutput);
         if (corruptResult.isCorrupt) {
           logger.error(`Emulator corrupt image detected: ${corruptResult.message}`);
 
@@ -1207,7 +1330,7 @@ export class AndroidEmulatorClient implements AndroidEmulator {
         }
 
         // Check for display / Qt platform-plugin failure (windowed launch on a headless host)
-        const displayResult = this.detectDisplayError(initialOutput);
+        const displayResult = this.detectDisplayError(launchOutput);
         if (displayResult.isDisplayError) {
           logger.error(`Emulator display error detected: ${displayResult.message}`);
 
@@ -1223,7 +1346,7 @@ export class AndroidEmulatorClient implements AndroidEmulator {
           if (!startupValidationComplete) {
             startupValidationComplete = true;
             perf.endOperation("panicDetection");
-            reject(new ActionableError(errorMessage));
+            reject(this.appendCategory(new ActionableError(errorMessage), "display_initialization_failed"));
           }
           return;
         }
@@ -1253,22 +1376,39 @@ export class AndroidEmulatorClient implements AndroidEmulator {
 
       // Log emulator output for debugging and monitor for PANIC
       child.stdout?.on("data", data => {
-        logger.debug(`Emulator stdout: ${data}`);
+        logger.debug(`Emulator stdout: ${redactAndroidCommandOutput(data.toString())}`);
         monitorOutput(data);
       });
 
       child.stderr?.on("data", data => {
-        logger.debug(`Emulator stderr: ${data}`);
+        logger.debug(`Emulator stderr: ${redactAndroidCommandOutput(data.toString())}`);
         monitorOutput(data);
       });
 
-      child.on("exit", code => {
-        clearTimeout(startupTimeout);
+      child.on("exit", (code, signal) => {
+        this.timer.clearTimeout(startupTimeout);
+        exitCode = code;
+        exitSignal = signal;
         if (code !== 0) {
           logger.error(`Emulator process exited with code: ${code}`);
+        } else {
+          logger.info(`Emulator process exited with code: ${code}`);
+        }
+      });
 
-          // Check if exit was due to "already running" error
-          if (initialOutput.includes("Running multiple emulators with the same AVD")) {
+      child.on("close", (code, signal) => {
+        this.timer.clearTimeout(startupTimeout);
+        const completedExitCode = exitCode ?? code;
+        const completedExitSignal = exitSignal ?? signal;
+        if (completedExitCode === 0 || startupValidationComplete) {
+          return;
+        }
+
+        void (async () => {
+          const launchOutput = boundedOutputTail(outputBuffer.join("\n"));
+
+          // Check if exit was due to "already running" error.
+          if (launchOutput.includes("Running multiple emulators with the same AVD")) {
             logger.info(`AVD '${avdName}' is already starting/running - this is expected, will wait for it to be ready`);
             if (!startupValidationComplete) {
               startupValidationComplete = true;
@@ -1282,7 +1422,7 @@ export class AndroidEmulatorClient implements AndroidEmulator {
           }
 
           // Check if exit was due to a sandbox/JIT entitlement failure.
-          const sandboxError = this.sandboxFailure(initialOutput);
+          const sandboxError = this.sandboxFailure(launchOutput);
           if (sandboxError) {
             logger.error(`Exit was due to emulator sandbox error: ${sandboxError.message}`);
             this.launchErrors.set(child, sandboxError);
@@ -1295,7 +1435,7 @@ export class AndroidEmulatorClient implements AndroidEmulator {
           }
 
           // Check if exit was due to PANIC
-          const panicResult = this.detectArchitecturePanic(initialOutput);
+          const panicResult = this.detectArchitecturePanic(launchOutput);
           if (panicResult.isPanic) {
             logger.error(`Exit was due to PANIC: ${panicResult.message}`);
             if (!startupValidationComplete) {
@@ -1307,7 +1447,7 @@ export class AndroidEmulatorClient implements AndroidEmulator {
           }
 
           // Check if exit was due to corrupt disk image
-          const corruptResult = this.detectCorruptImage(initialOutput);
+          const corruptResult = this.detectCorruptImage(launchOutput);
           if (corruptResult.isCorrupt) {
             logger.error(`Exit was due to corrupt image: ${corruptResult.message}`);
             if (!startupValidationComplete) {
@@ -1324,7 +1464,7 @@ export class AndroidEmulatorClient implements AndroidEmulator {
 
           // Check if exit was due to a display / Qt platform-plugin failure.
           // Signal death (e.g. SIGABRT from the failed xcb plugin) arrives as code === null.
-          const displayResult = this.detectDisplayError(initialOutput);
+          const displayResult = this.detectDisplayError(launchOutput);
           if (displayResult.isDisplayError) {
             logger.error(`Exit was due to display error: ${displayResult.message}`);
             if (!startupValidationComplete) {
@@ -1334,20 +1474,34 @@ export class AndroidEmulatorClient implements AndroidEmulator {
               if (displayResult.suggestion) {
                 errorMessage += `\n\nSuggestion: ${displayResult.suggestion}`;
               }
-              reject(new ActionableError(errorMessage));
+              reject(this.appendCategory(new ActionableError(errorMessage), "display_initialization_failed"));
             }
-          } else if (!startupValidationComplete) {
+            return;
+          }
+
+          let category = this.launchFailureCategory(launchOutput);
+          let accelCheckOutput = "";
+          if (this.platform === "linux" && (!category || category === "kvm_permission_denied")) {
+            accelCheckOutput = await this.runAccelerationCheck();
+            category = category ?? this.accelerationCheckCategory(accelCheckOutput);
+          }
+          if (!startupValidationComplete) {
             startupValidationComplete = true;
             perf.endOperation("panicDetection");
-            reject(new ActionableError(`Emulator process exited with code: ${code}`));
+            reject(this.formatEarlyExitError(
+              avdName,
+              completedExitCode,
+              completedExitSignal,
+              category,
+              launchOutput,
+              accelCheckOutput,
+            ));
           }
-        } else {
-          logger.info(`Emulator process exited with code: ${code}`);
-        }
+        })();
       });
 
       child.on("error", error => {
-        clearTimeout(startupTimeout);
+        this.timer.clearTimeout(startupTimeout);
         if (!startupValidationComplete) {
           startupValidationComplete = true;
           perf.endOperation("panicDetection");

--- a/src/utils/android-cmdline-tools/AndroidEmulatorClient.ts
+++ b/src/utils/android-cmdline-tools/AndroidEmulatorClient.ts
@@ -14,12 +14,16 @@ import { WakeAndUnlock } from "../../features/action/WakeAndUnlock";
 import { DeviceLockStore } from "../../features/action/DeviceLockStore";
 import type { FormFactor } from "../../models/DeviceMatchCriteria";
 import type { AdbDeviceState } from "./interfaces/AdbExecutor";
-import { redactAndroidCommandOutput } from "./redactAndroidCommandOutput";
+import {
+  AndroidCommandOutputStreamRedactor,
+  redactAndroidCommandOutput,
+} from "./redactAndroidCommandOutput";
 
 const MODERN_PLAY_IMAGE_MIN_API_LEVEL = 30;
 const MAX_LAUNCH_OUTPUT_LINES = 50;
 const MAX_LAUNCH_OUTPUT_CHARS = 16_384;
 const ACCEL_CHECK_TIMEOUT_MS = 3_000;
+const EARLY_EXIT_DRAIN_TIMEOUT_MS = 1_000;
 
 type LaunchFailureCategory =
   | "display_initialization_failed"
@@ -110,7 +114,7 @@ export interface AndroidEmulator {
    */
   getBootedDevices(
     onlyEmulators?: boolean,
-    options?: { bypassDeviceListCache?: boolean }
+    options?: { bypassDeviceListCache?: boolean },
   ): Promise<BootedDevice[]>;
 
   /**
@@ -138,7 +142,12 @@ export interface AndroidEmulator {
    * @param targetDeviceId - Optional adb device id to require when waiting for an already-running device
    * @returns Promise that resolves with device ID when emulator is ready
    */
-  waitForEmulatorReady(avdName: string, timeoutMs?: number, childProcess?: ChildProcess | null, targetDeviceId?: string): Promise<BootedDevice>;
+  waitForEmulatorReady(
+    avdName: string,
+    timeoutMs?: number,
+    childProcess?: ChildProcess | null,
+    targetDeviceId?: string,
+  ): Promise<BootedDevice>;
 }
 
 /**
@@ -146,15 +155,30 @@ export interface AndroidEmulator {
  * Tablet device names typically contain "tab", "pad", or "nexus_9/10".
  */
 export function inferAndroidFormFactor(deviceName?: string): FormFactor | undefined {
-  if (!deviceName) {return undefined;}
+  if (!deviceName) {
+    return undefined;
+  }
   const lower = deviceName.toLowerCase();
-  if (lower.includes("tab") || lower.includes("pad")) {return "tablet";}
+  if (lower.includes("tab") || lower.includes("pad")) {
+    return "tablet";
+  }
   // Nexus 9 and 10 are tablets
-  if (lower.includes("nexus_9") || lower.includes("nexus_10") || lower.includes("nexus 9") || lower.includes("nexus 10")) {return "tablet";}
+  if (
+    lower.includes("nexus_9") ||
+    lower.includes("nexus_10") ||
+    lower.includes("nexus 9") ||
+    lower.includes("nexus 10")
+  ) {
+    return "tablet";
+  }
   // Pixel Tablet
-  if (lower.includes("pixel_tablet") || lower.includes("pixel tablet")) {return "tablet";}
+  if (lower.includes("pixel_tablet") || lower.includes("pixel tablet")) {
+    return "tablet";
+  }
   // Most other devices (pixel, nexus 5/6, etc.) are phones
-  if (lower.includes("pixel") || lower.includes("phone") || lower.includes("nexus")) {return "phone";}
+  if (lower.includes("pixel") || lower.includes("phone") || lower.includes("nexus")) {
+    return "phone";
+  }
   return undefined;
 }
 
@@ -176,7 +200,7 @@ export function inferAndroidFormFactor(deviceName?: string): FormFactor | undefi
  */
 export function resolveHeadlessMode(
   platform: NodeJS.Platform,
-  env: NodeJS.ProcessEnv
+  env: NodeJS.ProcessEnv,
 ): { headless: boolean; reason: string } {
   const explicit = env.AUTOMOBILE_EMULATOR_HEADLESS;
   if (explicit === "true") {
@@ -187,7 +211,9 @@ export function resolveHeadlessMode(
   }
 
   if (platform === "linux") {
-    const hasDisplay = Boolean((env.DISPLAY && env.DISPLAY.trim()) || (env.WAYLAND_DISPLAY && env.WAYLAND_DISPLAY.trim()));
+    const hasDisplay = Boolean(
+      (env.DISPLAY && env.DISPLAY.trim()) || (env.WAYLAND_DISPLAY && env.WAYLAND_DISPLAY.trim()),
+    );
     if (!hasDisplay) {
       return {
         headless: true,
@@ -213,20 +239,27 @@ export function parseExtraEmulatorArguments(raw: string): string[] {
     parsed = JSON.parse(raw);
   } catch {
     throw new ActionableError(
-      "AUTOMOBILE_EMULATOR_ARGS must be a JSON array of emulator arguments, for example [\"-gpu\", \"swiftshader_indirect\"]"
+      'AUTOMOBILE_EMULATOR_ARGS must be a JSON array of emulator arguments, for example ["-gpu", "swiftshader_indirect"]',
     );
   }
 
-  if (!Array.isArray(parsed) || parsed.some(argument => typeof argument !== "string" || argument.length === 0)) {
+  if (
+    !Array.isArray(parsed) ||
+    parsed.some((argument) => typeof argument !== "string" || argument.length === 0)
+  ) {
     throw new ActionableError(
-      "AUTOMOBILE_EMULATOR_ARGS must be a JSON array containing non-empty string arguments"
+      "AUTOMOBILE_EMULATOR_ARGS must be a JSON array containing non-empty string arguments",
     );
   }
 
   return [...parsed];
 }
 
-const execAsync = async (file: string, args: string[], signal?: AbortSignal): Promise<ExecResult> => {
+const execAsync = async (
+  file: string,
+  args: string[],
+  signal?: AbortSignal,
+): Promise<ExecResult> => {
   // Run the emulator binary via execFile (argv, no shell) rather than exec. This
   // removes the shell entirely — command arguments such as AVD names are passed
   // literally instead of being interpreted/split by a shell (issue #3938) — and
@@ -248,7 +281,7 @@ const execAsync = async (file: string, args: string[], signal?: AbortSignal): Pr
     },
     includes(searchString: string) {
       return this.stdout.includes(searchString);
-    }
+    },
   };
 
   return enhancedResult;
@@ -275,7 +308,9 @@ export class AndroidEmulatorClient implements AndroidEmulator {
    * @param avdConfigReader - Reader for AVD config.ini files (for testing)
    */
   constructor(
-    execAsyncFn: ((file: string, args: string[], signal?: AbortSignal) => Promise<ExecResult>) | null = null,
+    execAsyncFn:
+      | ((file: string, args: string[], signal?: AbortSignal) => Promise<ExecResult>)
+      | null = null,
     spawnFn: typeof spawn | null = null,
     timer: Timer = defaultTimer,
     adbFactory: AdbClientFactory = defaultAdbClientFactory,
@@ -299,7 +334,8 @@ export class AndroidEmulatorClient implements AndroidEmulator {
    * @returns The path to the emulator
    */
   private getFallbackEmulatorPath(): string {
-    const androidHome = process.env.ANDROID_HOME || process.env.ANDROID_SDK_ROOT || process.env.ANDROID_SDK_HOME;
+    const androidHome =
+      process.env.ANDROID_HOME || process.env.ANDROID_SDK_ROOT || process.env.ANDROID_SDK_HOME;
     if (androidHome) {
       return `${androidHome}/emulator/emulator`;
     }
@@ -318,7 +354,8 @@ export class AndroidEmulatorClient implements AndroidEmulator {
     const potentialPaths: string[] = [];
 
     // 1. Check environment variables first (highest priority)
-    const androidHome = process.env.ANDROID_HOME || process.env.ANDROID_SDK_ROOT || process.env.ANDROID_SDK_HOME;
+    const androidHome =
+      process.env.ANDROID_HOME || process.env.ANDROID_SDK_ROOT || process.env.ANDROID_SDK_HOME;
     if (androidHome) {
       potentialPaths.push(`${androidHome}/emulator/emulator`);
       potentialPaths.push(`${androidHome}/emulator/emulator-arm64-v8a`);
@@ -347,7 +384,9 @@ export class AndroidEmulatorClient implements AndroidEmulator {
 
       if (bestLocation) {
         // Check various emulator locations relative to SDK root
-        const sdkRoot = bestLocation.path.replace("/cmdline-tools/latest", "").replace("/cmdline-tools", "");
+        const sdkRoot = bestLocation.path
+          .replace("/cmdline-tools/latest", "")
+          .replace("/cmdline-tools", "");
         potentialPaths.push(`${sdkRoot}/emulator/emulator`);
         potentialPaths.push(`${sdkRoot}/emulator/emulator-arm64-v8a`);
 
@@ -392,10 +431,12 @@ export class AndroidEmulatorClient implements AndroidEmulator {
    */
   private async enrichDeviceInfoList(devices: DeviceInfo[]): Promise<DeviceInfo[]> {
     const enriched = await Promise.all(
-      devices.map(async device => {
+      devices.map(async (device) => {
         try {
           const config = await this.avdConfigReader.readConfig(device.name);
-          if (!config) {return device;}
+          if (!config) {
+            return device;
+          }
           return {
             ...device,
             osVersion: config.osVersion ?? device.osVersion,
@@ -408,7 +449,7 @@ export class AndroidEmulatorClient implements AndroidEmulator {
           logger.debug(`Failed to enrich AVD ${device.name}: ${error}`);
           return device;
         }
-      })
+      }),
     );
     return enriched;
   }
@@ -474,10 +515,12 @@ export class AndroidEmulatorClient implements AndroidEmulator {
     }
 
     const lowerError = errorMsg.toLowerCase();
-    return (lowerError.includes("enoent") && lowerError.includes("spawn"))
-      || lowerError.includes("getcwd")
-      || lowerError.includes("current working directory")
-      || lowerError.includes("current directory");
+    return (
+      (lowerError.includes("enoent") && lowerError.includes("spawn")) ||
+      lowerError.includes("getcwd") ||
+      lowerError.includes("current working directory") ||
+      lowerError.includes("current directory")
+    );
   }
 
   /**
@@ -497,7 +540,7 @@ export class AndroidEmulatorClient implements AndroidEmulator {
     compatible: boolean;
     hostArch: string;
     avdArch?: string;
-    reason?: string
+    reason?: string;
   }> {
     const hostArch = this.getHostArchitecture();
 
@@ -518,18 +561,28 @@ export class AndroidEmulatorClient implements AndroidEmulator {
       // If we couldn't determine from verbose output, try to infer from common patterns
       if (!avdArch) {
         // This is a fallback - we'll let the actual emulator start attempt reveal the issue
-        return { compatible: true, hostArch, reason: "Could not determine AVD architecture, allowing attempt" };
+        return {
+          compatible: true,
+          hostArch,
+          reason: "Could not determine AVD architecture, allowing attempt",
+        };
       }
 
       // Check compatibility
       const compatible = this.isArchitectureCompatible(hostArch, avdArch);
-      const reason = compatible ? undefined : `Host architecture '${hostArch}' cannot run AVD with architecture '${avdArch}'`;
+      const reason = compatible
+        ? undefined
+        : `Host architecture '${hostArch}' cannot run AVD with architecture '${avdArch}'`;
 
       return { compatible, hostArch, avdArch, reason };
     } catch (error) {
       // If we can't check, we'll let the emulator start attempt proceed and catch errors there
       logger.debug(`Could not check architecture compatibility for ${avdName}: ${error}`);
-      return { compatible: true, hostArch, reason: "Could not verify compatibility, allowing attempt" };
+      return {
+        compatible: true,
+        hostArch,
+        reason: "Could not verify compatibility, allowing attempt",
+      };
     }
   }
 
@@ -541,7 +594,10 @@ export class AndroidEmulatorClient implements AndroidEmulator {
    */
   private isArchitectureCompatible(hostArch: string, avdArch: string): boolean {
     // ARM64 hosts (Apple Silicon) cannot run x86/x86_64 AVDs
-    if ((hostArch === "arm64" || hostArch === "aarch64") && (avdArch === "x86" || avdArch === "x86_64")) {
+    if (
+      (hostArch === "arm64" || hostArch === "aarch64") &&
+      (avdArch === "x86" || avdArch === "x86_64")
+    ) {
       return false;
     }
 
@@ -559,10 +615,12 @@ export class AndroidEmulatorClient implements AndroidEmulator {
     isPanic: boolean;
     message?: string;
     hostArch?: string;
-    avdArch?: string
+    avdArch?: string;
   } {
     // Look for the specific PANIC message about architecture compatibility
-    const panicMatch = output.match(/PANIC: Avd's CPU Architecture '(\w+)' is not supported by the QEMU2 emulator on (\w+) host/);
+    const panicMatch = output.match(
+      /PANIC: Avd's CPU Architecture '(\w+)' is not supported by the QEMU2 emulator on (\w+) host/,
+    );
 
     if (panicMatch) {
       const avdArch = panicMatch[1];
@@ -571,12 +629,15 @@ export class AndroidEmulatorClient implements AndroidEmulator {
         isPanic: true,
         message: `AVD architecture '${avdArch}' is not supported on ${hostArch} host`,
         hostArch,
-        avdArch
+        avdArch,
       };
     }
 
     // Check for other PANIC messages that might be architecture-related
-    if (output.includes("PANIC:") && (output.includes("architecture") || output.includes("CPU") || output.includes("QEMU"))) {
+    if (
+      output.includes("PANIC:") &&
+      (output.includes("architecture") || output.includes("CPU") || output.includes("QEMU"))
+    ) {
       return {
         isPanic: true,
         message: "Emulator PANIC detected (possibly architecture-related)",
@@ -592,8 +653,13 @@ export class AndroidEmulatorClient implements AndroidEmulator {
     message?: string;
     suggestion?: string;
   } {
-    const mprotectFailure = /qemu_mprotect__osdep:\s*mprotect failed:\s*permission denied/i.test(output);
-    const hvfFailure = /hvf is not enabled on this aarch64 host|HVF error:\s*HV_(?:UNSUPPORTED|ERROR)|failed to initialize HVF:\s*Invalid argument/i.test(output);
+    const mprotectFailure = /qemu_mprotect__osdep:\s*mprotect failed:\s*permission denied/i.test(
+      output,
+    );
+    const hvfFailure =
+      /hvf is not enabled on this aarch64 host|HVF error:\s*HV_(?:UNSUPPORTED|ERROR)|failed to initialize HVF:\s*Invalid argument/i.test(
+        output,
+      );
     if (!mprotectFailure && !hvfFailure) {
       return { isSandboxError: false };
     }
@@ -601,32 +667,46 @@ export class AndroidEmulatorClient implements AndroidEmulator {
     return {
       isSandboxError: true,
       message: "Emulator hypervisor initialization failed (mprotect/HVF is unavailable)",
-      suggestion: "Run the emulator outside the restrictive sandbox or grant the host hypervisor/JIT entitlement required by QEMU.",
+      suggestion:
+        "Run the emulator outside the restrictive sandbox or grant the host hypervisor/JIT entitlement required by QEMU.",
     };
   }
 
   private sandboxFailure(output: string): ActionableError | null {
     const result = this.detectSandboxMprotect(output);
-    if (!result.isSandboxError) {return null;}
-    return new ActionableError([
-      `Emulator failed to start: ${result.message}`,
-      result.suggestion ? `Suggestion: ${result.suggestion}` : "",
-    ].filter(Boolean).join("\n\n"));
+    if (!result.isSandboxError) {
+      return null;
+    }
+    return new ActionableError(
+      [
+        `Emulator failed to start: ${result.message}`,
+        result.suggestion ? `Suggestion: ${result.suggestion}` : "",
+      ]
+        .filter(Boolean)
+        .join("\n\n"),
+    );
   }
 
   private async validateAvdMemory(avdName: string): Promise<void> {
     const avdConfig = await this.avdConfigReader.readConfig(avdName);
-    if (!avdConfig) {return;}
-    const isModernPlayImage = avdConfig.tag?.toLowerCase().includes("play")
-      && (avdConfig.apiLevel ?? 0) >= MODERN_PLAY_IMAGE_MIN_API_LEVEL;
+    if (!avdConfig) {
+      return;
+    }
+    const isModernPlayImage =
+      avdConfig.tag?.toLowerCase().includes("play") &&
+      (avdConfig.apiLevel ?? 0) >= MODERN_PLAY_IMAGE_MIN_API_LEVEL;
     if (isModernPlayImage && avdConfig.ramSizeInvalid) {
       throw new ActionableError(
-        `Cannot start AVD '${avdName}': hw.ramSize is invalid. Use a whole number in MB or a K, M, or G size suffix and retry.`
+        `Cannot start AVD '${avdName}': hw.ramSize is invalid. Use a whole number in MB or a K, M, or G size suffix and retry.`,
       );
     }
-    if (isModernPlayImage && avdConfig.ramSizeMb !== undefined && avdConfig.ramSizeMb < MIN_AVD_RAM_MB) {
+    if (
+      isModernPlayImage &&
+      avdConfig.ramSizeMb !== undefined &&
+      avdConfig.ramSizeMb < MIN_AVD_RAM_MB
+    ) {
       throw new ActionableError(
-        `Cannot start AVD '${avdName}': hw.ramSize is ${avdConfig.ramSizeMb} MB, below the minimum ${MIN_AVD_RAM_MB} MB needed for a modern system image. Increase hw.ramSize in the AVD config and retry.`
+        `Cannot start AVD '${avdName}': hw.ramSize is ${avdConfig.ramSizeMb} MB, below the minimum ${MIN_AVD_RAM_MB} MB needed for a modern system image. Increase hw.ramSize in the AVD config and retry.`,
       );
     }
   }
@@ -638,10 +718,12 @@ export class AndroidEmulatorClient implements AndroidEmulator {
   ): Promise<ActionableError | null> {
     let states: AdbDeviceState[];
     try {
-      states = await this.adbFactory.create(null).getDeviceStates?.({ timeoutMs }) ?? [];
+      states = (await this.adbFactory.create(null).getDeviceStates?.({ timeoutMs })) ?? [];
     } catch (error) {
       // Auxiliary diagnostic probe; a failure here must not block readiness polling.
-      logger.debug(`Offline-state probe unavailable during emulator readiness: ${error instanceof Error ? error.message : String(error)}`);
+      logger.debug(
+        `Offline-state probe unavailable during emulator readiness: ${error instanceof Error ? error.message : String(error)}`,
+      );
       tracker.deviceId = null;
       tracker.since = null;
       return null;
@@ -679,26 +761,34 @@ export class AndroidEmulatorClient implements AndroidEmulator {
       return {
         isCorrupt: true,
         message: `Disk image is corrupt: ${qcow2Match[1].trim()}`,
-        suggestion: "Delete the corrupt userdata overlay to force a fresh image:\n  rm ~/.android/avd/<AVD_NAME>.avd/userdata-qcow2.img\n  rm ~/.android/avd/<AVD_NAME>.avd/userdata-qcow2.img.qcow2\nThe emulator will recreate it on next boot. All emulator data (installed apps, settings) will be lost.",
+        suggestion:
+          "Delete the corrupt userdata overlay to force a fresh image:\n  rm ~/.android/avd/<AVD_NAME>.avd/userdata-qcow2.img\n  rm ~/.android/avd/<AVD_NAME>.avd/userdata-qcow2.img.qcow2\nThe emulator will recreate it on next boot. All emulator data (installed apps, settings) will be lost.",
       };
     }
 
     // Generic disk image errors
-    const diskErrorMatch = output.match(/(cannot open disk image|disk image .* is (?:corrupt|invalid|damaged)|failed to open .*\.img)/i);
+    const diskErrorMatch = output.match(
+      /(cannot open disk image|disk image .* is (?:corrupt|invalid|damaged)|failed to open .*\.img)/i,
+    );
     if (diskErrorMatch) {
       return {
         isCorrupt: true,
         message: `Disk image error: ${diskErrorMatch[1].trim()}`,
-        suggestion: "Try deleting corrupt overlay files in ~/.android/avd/<AVD_NAME>.avd/ and restarting the emulator.",
+        suggestion:
+          "Try deleting corrupt overlay files in ~/.android/avd/<AVD_NAME>.avd/ and restarting the emulator.",
       };
     }
 
     // QEMU abnormal exit with corruption context
-    if (output.includes("QEMU main loop exits abnormally") && (output.includes("corrupt") || output.includes("qcow2"))) {
+    if (
+      output.includes("QEMU main loop exits abnormally") &&
+      (output.includes("corrupt") || output.includes("qcow2"))
+    ) {
       return {
         isCorrupt: true,
         message: "QEMU exited abnormally due to disk image corruption",
-        suggestion: "Delete the corrupt userdata overlay to force a fresh image:\n  rm ~/.android/avd/<AVD_NAME>.avd/userdata-qcow2.img\n  rm ~/.android/avd/<AVD_NAME>.avd/userdata-qcow2.img.qcow2\nThe emulator will recreate it on next boot.",
+        suggestion:
+          "Delete the corrupt userdata overlay to force a fresh image:\n  rm ~/.android/avd/<AVD_NAME>.avd/userdata-qcow2.img\n  rm ~/.android/avd/<AVD_NAME>.avd/userdata-qcow2.img.qcow2\nThe emulator will recreate it on next boot.",
       };
     }
 
@@ -724,7 +814,8 @@ export class AndroidEmulatorClient implements AndroidEmulator {
     if (noDisplay || qtPlugin) {
       return {
         isDisplayError: true,
-        message: "Emulator could not connect to a display (Qt 'xcb' platform plugin failed to load)",
+        message:
+          "Emulator could not connect to a display (Qt 'xcb' platform plugin failed to load)",
         suggestion:
           "Run the emulator headless by setting AUTOMOBILE_EMULATOR_HEADLESS=true " +
           "(adds -no-window -no-audio), or start an X server / export DISPLAY before launching.",
@@ -734,21 +825,14 @@ export class AndroidEmulatorClient implements AndroidEmulator {
     return { isDisplayError: false };
   }
 
-  private appendLaunchOutput(outputBuffer: string[], output: string): string {
-    outputBuffer.push(...redactAndroidCommandOutput(output).split(/\r?\n/));
-    const boundedOutput = boundedOutputTail(outputBuffer.join("\n"));
-    outputBuffer.splice(0, outputBuffer.length, ...boundedOutput.split("\n"));
-    return boundedOutput;
-  }
-
   private launchFailureCategory(output: string): LaunchFailureCategory | undefined {
     if (/error while loading shared libraries/i.test(output)) {
       return "missing_shared_library";
     }
     if (
-      /ProbeKVM[\s\S]*(?:permission denied|operation not permitted)/i.test(output)
-      || /\/dev\/kvm[\s\S]*(?:permission denied|operation not permitted)/i.test(output)
-      || /permissions? to use KVM/i.test(output)
+      /ProbeKVM[\s\S]*(?:permission denied|operation not permitted)/i.test(output) ||
+      /\/dev\/kvm[\s\S]*(?:permission denied|operation not permitted)/i.test(output) ||
+      /permissions? to use KVM/i.test(output)
     ) {
       return "kvm_permission_denied";
     }
@@ -761,8 +845,8 @@ export class AndroidEmulatorClient implements AndroidEmulator {
       return kvmCategory;
     }
     if (
-      /(?:acceleration|KVM|hypervisor)/i.test(output)
-      && /(?:not available|unavailable|not supported|not enabled|cannot use|disabled)/i.test(output)
+      /(?:acceleration|KVM|hypervisor)/i.test(output) &&
+      /(?:not available|unavailable|not supported|not enabled|cannot use|disabled)/i.test(output)
     ) {
       return "hardware_acceleration_unavailable";
     }
@@ -800,7 +884,11 @@ export class AndroidEmulatorClient implements AndroidEmulator {
     }
     const output = error as { stdout?: unknown; stderr?: unknown };
     return boundedOutputTail(
-      redactAndroidCommandOutput([outputFromUnknown(output.stdout), outputFromUnknown(output.stderr)].filter(Boolean).join("\n")),
+      redactAndroidCommandOutput(
+        [outputFromUnknown(output.stdout), outputFromUnknown(output.stderr)]
+          .filter(Boolean)
+          .join("\n"),
+      ),
     );
   }
 
@@ -810,10 +898,13 @@ export class AndroidEmulatorClient implements AndroidEmulator {
     const probe = Promise.resolve()
       .then(() => this.execAsync(this.emulatorPath, ["-accel-check"], controller.signal))
       .then(
-        result => boundedOutputTail(redactAndroidCommandOutput([result.stdout, result.stderr].filter(Boolean).join("\n"))),
-        error => this.diagnosticOutputFromError(error),
+        (result) =>
+          boundedOutputTail(
+            redactAndroidCommandOutput([result.stdout, result.stderr].filter(Boolean).join("\n")),
+          ),
+        (error) => this.diagnosticOutputFromError(error),
       );
-    const timeoutResult = new Promise<string>(resolve => {
+    const timeoutResult = new Promise<string>((resolve) => {
       timeout = this.timer.setTimeout(() => {
         controller.abort();
         logger.debug(`Emulator acceleration check timed out after ${ACCEL_CHECK_TIMEOUT_MS}ms`);
@@ -858,7 +949,9 @@ export class AndroidEmulatorClient implements AndroidEmulator {
       const runPromise = this.execAsync(emulatorPath, args, controller.signal);
       // Once the timeout wins the race the aborted run promise rejects with an
       // AbortError; keep it handled so it can't surface as an unhandledRejection.
-      runPromise.catch(() => { /* settled after timeout; result consumed via race */ });
+      runPromise.catch(() => {
+        /* settled after timeout; result consumed via race */
+      });
 
       try {
         return await Promise.race([runPromise, timeoutPromise]);
@@ -879,28 +972,34 @@ export class AndroidEmulatorClient implements AndroidEmulator {
       const result = await this.executeCommand(["-list-avds"]);
       const devices = result.stdout
         .split("\n")
-        .map(line => line.trim())
-        .filter(line => line.length > 0)
-        .map(name => ({ name, platform: "android", isRunning: false, source: "local" } as DeviceInfo));
+        .map((line) => line.trim())
+        .filter((line) => line.length > 0)
+        .map(
+          (name) =>
+            ({ name, platform: "android", isRunning: false, source: "local" }) as DeviceInfo,
+        );
       return this.enrichDeviceInfoList(devices);
     } catch (error) {
       logger.error("Failed to list AVDs:", error);
 
       // Check if the error is because emulator is not found
       const errorMsg = error instanceof Error ? error.message : String(error);
-      const missingEmulator = errorMsg.includes("No such file or directory") || errorMsg.includes("command not found") || errorMsg.includes("ENOENT");
+      const missingEmulator =
+        errorMsg.includes("No such file or directory") ||
+        errorMsg.includes("command not found") ||
+        errorMsg.includes("ENOENT");
       if (missingEmulator && this.isLikelyDaemonWorkingDirectoryFailure(errorMsg)) {
         throw new ActionableError(
           `Android emulator command failed because the daemon working directory is unavailable. ` +
-          `Restart the AutoMobile daemon so it can use a stable working directory. Underlying error: ${errorMsg}`
+            `Restart the AutoMobile daemon so it can use a stable working directory. Underlying error: ${errorMsg}`,
         );
       }
       if (missingEmulator) {
         throw new ActionableError(
           `Android emulator not found.\n${this.describeEmulatorResolution()}\n\n` +
-          `Install the emulator package with: sdkmanager --install "emulator"\n` +
-          `(Android Studio installs it too: https://developer.android.com/studio)\n` +
-          `Or point ANDROID_HOME at an SDK that already has emulator/emulator.`
+            `Install the emulator package with: sdkmanager --install "emulator"\n` +
+            `(Android Studio installs it too: https://developer.android.com/studio)\n` +
+            `Or point ANDROID_HOME at an SDK that already has emulator/emulator.`,
         );
       }
 
@@ -915,10 +1014,10 @@ export class AndroidEmulatorClient implements AndroidEmulator {
    */
   async isAvdRunning(
     avdName: string,
-    options: { bypassDeviceListCache?: boolean } = {}
+    options: { bypassDeviceListCache?: boolean } = {},
   ): Promise<boolean> {
     const runningEmulators = await this.getBootedDevices(false, options);
-    return runningEmulators.some(emulator => emulator.name === avdName);
+    return runningEmulators.some((emulator) => emulator.name === avdName);
   }
 
   /**
@@ -984,7 +1083,7 @@ export class AndroidEmulatorClient implements AndroidEmulator {
    */
   async getBootedDevices(
     onlyEmulators: boolean = false,
-    options: { bypassDeviceListCache?: boolean } = {}
+    options: { bypassDeviceListCache?: boolean } = {},
   ): Promise<BootedDevice[]> {
     try {
       return await this.getBootedDevicesChecked(onlyEmulators, options);
@@ -1002,7 +1101,7 @@ export class AndroidEmulatorClient implements AndroidEmulator {
    */
   async getBootedDevicesChecked(
     onlyEmulators: boolean = false,
-    options: { bypassDeviceListCache?: boolean } = {}
+    options: { bypassDeviceListCache?: boolean } = {},
   ): Promise<BootedDevice[]> {
     const perf = createGlobalPerformanceTracker();
     {
@@ -1016,8 +1115,8 @@ export class AndroidEmulatorClient implements AndroidEmulator {
       const runningDevices: BootedDevice[] = [];
 
       // Add local emulator devices
-      const emulatorDevices = devices.filter(device => device.deviceId.startsWith("emulator-"));
-      const physicalDevices = devices.filter(device => !device.deviceId.startsWith("emulator-"));
+      const emulatorDevices = devices.filter((device) => device.deviceId.startsWith("emulator-"));
+      const physicalDevices = devices.filter((device) => !device.deviceId.startsWith("emulator-"));
 
       const infoTimeoutMs = 2000;
       perf.startOperation("avdNameResolution");
@@ -1026,17 +1125,24 @@ export class AndroidEmulatorClient implements AndroidEmulator {
         try {
           // Try to get the AVD name from the running emulator
           const adbWithDevice = this.adbFactory.create(device);
-          const result = await adbWithDevice.executeCommand("emu avd name", infoTimeoutMs, undefined, true);
+          const result = await adbWithDevice.executeCommand(
+            "emu avd name",
+            infoTimeoutMs,
+            undefined,
+            true,
+          );
           const avdName = result.stdout.trim().replace(/\r?\n.*$/, ""); // Remove any trailing newlines and additional text
 
-          logger.debug(`AVD name detection for ${deviceId}: raw="${result.stdout}" (${result.stdout.length} chars), cleaned="${avdName}"`);
+          logger.debug(
+            `AVD name detection for ${deviceId}: raw="${result.stdout}" (${result.stdout.length} chars), cleaned="${avdName}"`,
+          );
 
           runningDevices.push({
             ...device,
             name: avdName || this.unknownEmulatorName(deviceId),
             platform: "android",
             deviceId: deviceId,
-            source: "local"
+            source: "local",
           });
         } catch (error) {
           // If we can't get the AVD name, just use the device ID
@@ -1046,7 +1152,7 @@ export class AndroidEmulatorClient implements AndroidEmulator {
             name: this.unknownEmulatorName(deviceId),
             platform: "android",
             deviceId: deviceId,
-            source: "local"
+            source: "local",
           });
         }
       }
@@ -1065,7 +1171,7 @@ export class AndroidEmulatorClient implements AndroidEmulator {
               "shell getprop ro.product.model",
               infoTimeoutMs,
               undefined,
-              true
+              true,
             );
             const modelName = result.stdout.trim();
 
@@ -1086,7 +1192,7 @@ export class AndroidEmulatorClient implements AndroidEmulator {
           name: deviceName,
           platform: "android",
           deviceId: device.deviceId,
-          source: "local"
+          source: "local",
         });
       }
       perf.endOperation("avdNameResolution");
@@ -1104,7 +1210,9 @@ export class AndroidEmulatorClient implements AndroidEmulator {
     return (await this.launchEmulator({ avdName })).process;
   }
 
-  async launchEmulator(request: AndroidEmulatorLaunchRequest): Promise<AndroidEmulatorLaunchHandle> {
+  async launchEmulator(
+    request: AndroidEmulatorLaunchRequest,
+  ): Promise<AndroidEmulatorLaunchHandle> {
     if (request.signal?.aborted) {
       throw new ActionableError(`Android emulator launch for '${request.avdName}' was cancelled`);
     }
@@ -1126,7 +1234,7 @@ export class AndroidEmulatorClient implements AndroidEmulator {
       process = await this.startEmulatorProcess(
         request.avdName,
         request.extraArgs,
-        spawnedProcess => {
+        (spawnedProcess) => {
           process = spawnedProcess;
           if (disposed && !spawnedProcess.killed) {
             spawnedProcess.kill();
@@ -1191,14 +1299,16 @@ export class AndroidEmulatorClient implements AndroidEmulator {
     perf.startOperation("validateAvd");
     const availableAvds = await this.listAvds();
     perf.endOperation("validateAvd");
-    if (!availableAvds.find(emu => emu.name === avdName)) {
-      throw new ActionableError(`AVD '${avdName}' not found. Available AVDs: ${availableAvds.map(emu => emu.name).join(", ")}`);
+    if (!availableAvds.find((emu) => emu.name === avdName)) {
+      throw new ActionableError(
+        `AVD '${avdName}' not found. Available AVDs: ${availableAvds.map((emu) => emu.name).join(", ")}`,
+      );
     }
 
     // Check if already running or starting
     perf.startOperation("checkAlreadyRunning");
     const alreadyRunning = await this.isAvdRunning(avdName, { bypassDeviceListCache: true });
-    const alreadyStarting = !alreadyRunning && await this.isAvdStarting(avdName);
+    const alreadyStarting = !alreadyRunning && (await this.isAvdStarting(avdName));
     perf.endOperation("checkAlreadyRunning");
 
     if (alreadyRunning) {
@@ -1223,12 +1333,16 @@ export class AndroidEmulatorClient implements AndroidEmulator {
     perf.endOperation("architectureCheck");
     if (!compatibility.compatible && compatibility.reason) {
       logger.error(`Architecture compatibility check failed: ${compatibility.reason}`);
-      throw new ActionableError(`Cannot start AVD '${avdName}': ${compatibility.reason}. On ${compatibility.hostArch} hosts, use AVDs with compatible architectures (e.g., arm64-v8a for Apple Silicon Macs).`);
+      throw new ActionableError(
+        `Cannot start AVD '${avdName}': ${compatibility.reason}. On ${compatibility.hostArch} hosts, use AVDs with compatible architectures (e.g., arm64-v8a for Apple Silicon Macs).`,
+      );
     }
 
     const args = ["-avd", avdName];
     const headlessMode = resolveHeadlessMode(process.platform, process.env);
-    logger.info(`Emulator display mode: ${headlessMode.headless ? "headless" : "windowed"} (${headlessMode.reason})`);
+    logger.info(
+      `Emulator display mode: ${headlessMode.headless ? "headless" : "windowed"} (${headlessMode.reason})`,
+    );
     if (headlessMode.headless) {
       args.push("-no-window", "-no-audio");
     }
@@ -1249,24 +1363,66 @@ export class AndroidEmulatorClient implements AndroidEmulator {
       onSpawn?.(child);
 
       // Keep only a redacted tail for launch diagnostics and failure classification.
-      const outputBuffer: string[] = [];
+      const stdoutRedactor = new AndroidCommandOutputStreamRedactor();
+      const stderrRedactor = new AndroidCommandOutputStreamRedactor();
+      let launchOutput = "";
+      let duplicateAvdDetected = false;
+      let earlyExitCategory: LaunchFailureCategory | undefined;
       let startupValidationComplete = false;
       let exitCode: number | null | undefined;
       let exitSignal: NodeJS.Signals | null | undefined;
       perf.startOperation("panicDetection");
 
+      const appendRedactedLaunchOutput = (output: string) => {
+        if (output.length > 0) {
+          launchOutput = boundedOutputTail(launchOutput + output);
+        }
+      };
+      const currentLaunchOutput = () =>
+        boundedOutputTail(launchOutput + stdoutRedactor.snapshot() + stderrRedactor.snapshot());
+      const flushLaunchOutput = () => {
+        for (const redactor of [stdoutRedactor, stderrRedactor]) {
+          const flushedOutput = redactor.flush();
+          appendRedactedLaunchOutput(flushedOutput);
+          if (flushedOutput.length > 0) {
+            logger.debug(`Emulator output: ${flushedOutput}`);
+          }
+        }
+        return launchOutput;
+      };
+      const recordEarlyExitCategory = (output: string) => {
+        const category = this.launchFailureCategory(output);
+        if (category && (!earlyExitCategory || category === "missing_shared_library")) {
+          earlyExitCategory = category;
+        }
+      };
+
       // Monitor emulator output for PANIC errors
-      const monitorOutput = (data: any) => {
+      const monitorOutput = (data: any, outputRedactor: AndroidCommandOutputStreamRedactor) => {
         const output = data.toString();
-        const launchOutput = this.appendLaunchOutput(outputBuffer, output);
-        this.captureLaunchTargetDeviceId(child, launchOutput);
+        const safeChunk = redactAndroidCommandOutput(output);
+        const redactedOutput = outputRedactor.append(output);
+        appendRedactedLaunchOutput(redactedOutput);
+        if (redactedOutput.length > 0) {
+          logger.debug(`Emulator output: ${redactedOutput}`);
+        }
+        const diagnosticOutput = currentLaunchOutput();
+        this.captureLaunchTargetDeviceId(child, diagnosticOutput);
+        duplicateAvdDetected ||=
+          diagnosticOutput.includes("Running multiple emulators with the same AVD") ||
+          safeChunk.includes("Running multiple emulators with the same AVD");
+        recordEarlyExitCategory(diagnosticOutput);
+        recordEarlyExitCategory(safeChunk);
 
         // Detect sandbox/JIT entitlement failures before generic PANIC handling.
-        const sandboxError = this.sandboxFailure(launchOutput);
+        const sandboxError =
+          this.sandboxFailure(diagnosticOutput) ?? this.sandboxFailure(safeChunk);
         if (sandboxError) {
           logger.error(`Emulator sandbox error detected: ${sandboxError.message}`);
           this.launchErrors.set(child, sandboxError);
-          if (!child.killed) {child.kill();}
+          if (!child.killed) {
+            child.kill();
+          }
           if (!startupValidationComplete) {
             startupValidationComplete = true;
             perf.endOperation("panicDetection");
@@ -1276,18 +1432,27 @@ export class AndroidEmulatorClient implements AndroidEmulator {
         }
 
         // Check for PANIC in the output
-        const panicResult = this.detectArchitecturePanic(launchOutput);
-        if (panicResult.isPanic) {
-          logger.error(`Emulator PANIC detected: ${panicResult.message}`);
+        const panicResult = this.detectArchitecturePanic(diagnosticOutput);
+        const directPanicResult = panicResult.isPanic
+          ? panicResult
+          : this.detectArchitecturePanic(safeChunk);
+        if (directPanicResult.isPanic) {
+          logger.error(`Emulator PANIC detected: ${directPanicResult.message}`);
 
           // Create a more helpful error message
-          let errorMessage = `Emulator failed to start: ${panicResult.message}`;
-          if (panicResult.hostArch && panicResult.avdArch) {
-            errorMessage += `\n\nSuggestion: On ${panicResult.hostArch} hosts, create AVDs with compatible architectures:`;
-            if (panicResult.hostArch === "aarch64" || panicResult.hostArch === "arm64") {
+          let errorMessage = `Emulator failed to start: ${directPanicResult.message}`;
+          if (directPanicResult.hostArch && directPanicResult.avdArch) {
+            errorMessage += `\n\nSuggestion: On ${directPanicResult.hostArch} hosts, create AVDs with compatible architectures:`;
+            if (
+              directPanicResult.hostArch === "aarch64" ||
+              directPanicResult.hostArch === "arm64"
+            ) {
               errorMessage += `\n- Use ARM64 system images (arm64-v8a) instead of x86/x86_64`;
               errorMessage += `\n- Example: avdmanager create avd -n MyAVD -k "system-images;android-35;google_apis;arm64-v8a"`;
-            } else if (panicResult.hostArch === "x86" || panicResult.hostArch === "x86_64") {
+            } else if (
+              directPanicResult.hostArch === "x86" ||
+              directPanicResult.hostArch === "x86_64"
+            ) {
               errorMessage += `\n- Use x86/x86_64 system images instead of ARM64`;
               errorMessage += `\n- Example: avdmanager create avd -n MyAVD -k "system-images;android-35;google_apis;x86_64"`;
             }
@@ -1308,13 +1473,16 @@ export class AndroidEmulatorClient implements AndroidEmulator {
         }
 
         // Check for corrupt disk image
-        const corruptResult = this.detectCorruptImage(launchOutput);
-        if (corruptResult.isCorrupt) {
-          logger.error(`Emulator corrupt image detected: ${corruptResult.message}`);
+        const corruptResult = this.detectCorruptImage(diagnosticOutput);
+        const directCorruptResult = corruptResult.isCorrupt
+          ? corruptResult
+          : this.detectCorruptImage(safeChunk);
+        if (directCorruptResult.isCorrupt) {
+          logger.error(`Emulator corrupt image detected: ${directCorruptResult.message}`);
 
-          let errorMessage = `Emulator failed to start: ${corruptResult.message}`;
-          if (corruptResult.suggestion) {
-            errorMessage += `\n\nSuggestion: ${corruptResult.suggestion}`;
+          let errorMessage = `Emulator failed to start: ${directCorruptResult.message}`;
+          if (directCorruptResult.suggestion) {
+            errorMessage += `\n\nSuggestion: ${directCorruptResult.suggestion}`;
           }
 
           if (!child.killed) {
@@ -1330,13 +1498,16 @@ export class AndroidEmulatorClient implements AndroidEmulator {
         }
 
         // Check for display / Qt platform-plugin failure (windowed launch on a headless host)
-        const displayResult = this.detectDisplayError(launchOutput);
-        if (displayResult.isDisplayError) {
-          logger.error(`Emulator display error detected: ${displayResult.message}`);
+        const displayResult = this.detectDisplayError(diagnosticOutput);
+        const directDisplayResult = displayResult.isDisplayError
+          ? displayResult
+          : this.detectDisplayError(safeChunk);
+        if (directDisplayResult.isDisplayError) {
+          logger.error(`Emulator display error detected: ${directDisplayResult.message}`);
 
-          let errorMessage = `Emulator failed to start: ${displayResult.message}`;
-          if (displayResult.suggestion) {
-            errorMessage += `\n\nSuggestion: ${displayResult.suggestion}`;
+          let errorMessage = `Emulator failed to start: ${directDisplayResult.message}`;
+          if (directDisplayResult.suggestion) {
+            errorMessage += `\n\nSuggestion: ${directDisplayResult.suggestion}`;
           }
 
           if (!child.killed) {
@@ -1346,15 +1517,22 @@ export class AndroidEmulatorClient implements AndroidEmulator {
           if (!startupValidationComplete) {
             startupValidationComplete = true;
             perf.endOperation("panicDetection");
-            reject(this.appendCategory(new ActionableError(errorMessage), "display_initialization_failed"));
+            reject(
+              this.appendCategory(
+                new ActionableError(errorMessage),
+                "display_initialization_failed",
+              ),
+            );
           }
           return;
         }
 
         // Check for successful startup indicators
-        if (output.includes("INFO         | emuDirName:") ||
+        if (
+          output.includes("INFO         | emuDirName:") ||
           output.includes("Hax is enabled") ||
-          output.includes("Detected GPU type")) {
+          output.includes("Detected GPU type")
+        ) {
           // Emulator has started successfully, resolve with the child process
           if (!startupValidationComplete) {
             startupValidationComplete = true;
@@ -1374,55 +1552,44 @@ export class AndroidEmulatorClient implements AndroidEmulator {
         }
       }, 5000);
 
-      // Log emulator output for debugging and monitor for PANIC
-      child.stdout?.on("data", data => {
-        logger.debug(`Emulator stdout: ${redactAndroidCommandOutput(data.toString())}`);
-        monitorOutput(data);
-      });
-
-      child.stderr?.on("data", data => {
-        logger.debug(`Emulator stderr: ${redactAndroidCommandOutput(data.toString())}`);
-        monitorOutput(data);
-      });
-
-      child.on("exit", (code, signal) => {
-        this.timer.clearTimeout(startupTimeout);
-        exitCode = code;
-        exitSignal = signal;
-        if (code !== 0) {
-          logger.error(`Emulator process exited with code: ${code}`);
-        } else {
-          logger.info(`Emulator process exited with code: ${code}`);
+      let exitDrainTimeout: NodeJS.Timeout | undefined;
+      let earlyExitFinalization: Promise<void> | undefined;
+      const clearExitDrainTimeout = () => {
+        if (exitDrainTimeout) {
+          this.timer.clearTimeout(exitDrainTimeout);
+          exitDrainTimeout = undefined;
         }
-      });
-
-      child.on("close", (code, signal) => {
-        this.timer.clearTimeout(startupTimeout);
-        const completedExitCode = exitCode ?? code;
-        const completedExitSignal = exitSignal ?? signal;
-        if (completedExitCode === 0 || startupValidationComplete) {
+      };
+      const finalizeEarlyExit = () => {
+        if (startupValidationComplete || earlyExitFinalization) {
           return;
         }
+        earlyExitFinalization = (async () => {
+          clearExitDrainTimeout();
+          const finalizedOutput = flushLaunchOutput();
+          const completedExitCode = exitCode ?? null;
+          const completedExitSignal = exitSignal ?? null;
 
-        void (async () => {
-          const launchOutput = boundedOutputTail(outputBuffer.join("\n"));
-
-          // Check if exit was due to "already running" error.
-          if (launchOutput.includes("Running multiple emulators with the same AVD")) {
-            logger.info(`AVD '${avdName}' is already starting/running - this is expected, will wait for it to be ready`);
+          // Another emulator already owns this AVD; we hold no process handle
+          // for it. Resolve null rather than a fabricated handle (issue #3938);
+          // the caller waits for readiness regardless.
+          if (
+            duplicateAvdDetected ||
+            finalizedOutput.includes("Running multiple emulators with the same AVD")
+          ) {
+            logger.info(
+              `AVD '${avdName}' is already starting/running - this is expected, will wait for it to be ready`,
+            );
             if (!startupValidationComplete) {
               startupValidationComplete = true;
               perf.endOperation("panicDetection");
-              // Another emulator already owns this AVD; we hold no process handle
-              // for it. Resolve null rather than a fabricated handle (issue #3938);
-              // the caller waits for readiness regardless.
               resolve(null);
             }
             return;
           }
 
           // Check if exit was due to a sandbox/JIT entitlement failure.
-          const sandboxError = this.sandboxFailure(launchOutput);
+          const sandboxError = this.sandboxFailure(finalizedOutput);
           if (sandboxError) {
             logger.error(`Exit was due to emulator sandbox error: ${sandboxError.message}`);
             this.launchErrors.set(child, sandboxError);
@@ -1434,8 +1601,8 @@ export class AndroidEmulatorClient implements AndroidEmulator {
             return;
           }
 
-          // Check if exit was due to PANIC
-          const panicResult = this.detectArchitecturePanic(launchOutput);
+          // Check if exit was due to PANIC.
+          const panicResult = this.detectArchitecturePanic(finalizedOutput);
           if (panicResult.isPanic) {
             logger.error(`Exit was due to PANIC: ${panicResult.message}`);
             if (!startupValidationComplete) {
@@ -1446,8 +1613,8 @@ export class AndroidEmulatorClient implements AndroidEmulator {
             return;
           }
 
-          // Check if exit was due to corrupt disk image
-          const corruptResult = this.detectCorruptImage(launchOutput);
+          // Check if exit was due to corrupt disk image.
+          const corruptResult = this.detectCorruptImage(finalizedOutput);
           if (corruptResult.isCorrupt) {
             logger.error(`Exit was due to corrupt image: ${corruptResult.message}`);
             if (!startupValidationComplete) {
@@ -1464,7 +1631,7 @@ export class AndroidEmulatorClient implements AndroidEmulator {
 
           // Check if exit was due to a display / Qt platform-plugin failure.
           // Signal death (e.g. SIGABRT from the failed xcb plugin) arrives as code === null.
-          const displayResult = this.detectDisplayError(launchOutput);
+          const displayResult = this.detectDisplayError(finalizedOutput);
           if (displayResult.isDisplayError) {
             logger.error(`Exit was due to display error: ${displayResult.message}`);
             if (!startupValidationComplete) {
@@ -1474,12 +1641,17 @@ export class AndroidEmulatorClient implements AndroidEmulator {
               if (displayResult.suggestion) {
                 errorMessage += `\n\nSuggestion: ${displayResult.suggestion}`;
               }
-              reject(this.appendCategory(new ActionableError(errorMessage), "display_initialization_failed"));
+              reject(
+                this.appendCategory(
+                  new ActionableError(errorMessage),
+                  "display_initialization_failed",
+                ),
+              );
             }
             return;
           }
 
-          let category = this.launchFailureCategory(launchOutput);
+          let category = earlyExitCategory ?? this.launchFailureCategory(finalizedOutput);
           let accelCheckOutput = "";
           if (this.platform === "linux" && (!category || category === "kvm_permission_denied")) {
             accelCheckOutput = await this.runAccelerationCheck();
@@ -1488,20 +1660,78 @@ export class AndroidEmulatorClient implements AndroidEmulator {
           if (!startupValidationComplete) {
             startupValidationComplete = true;
             perf.endOperation("panicDetection");
-            reject(this.formatEarlyExitError(
-              avdName,
-              completedExitCode,
-              completedExitSignal,
-              category,
-              launchOutput,
-              accelCheckOutput,
-            ));
+            reject(
+              this.formatEarlyExitError(
+                avdName,
+                completedExitCode,
+                completedExitSignal,
+                category,
+                finalizedOutput,
+                accelCheckOutput,
+              ),
+            );
           }
-        })();
+        })().catch((error) => {
+          logger.error(`Unable to finalize Android emulator early-exit diagnostics: ${error}`);
+          if (!startupValidationComplete) {
+            startupValidationComplete = true;
+            perf.endOperation("panicDetection");
+            reject(
+              this.formatEarlyExitError(
+                avdName,
+                exitCode ?? null,
+                exitSignal ?? null,
+                earlyExitCategory,
+                flushLaunchOutput(),
+                "",
+              ),
+            );
+          }
+        });
+      };
+
+      // Log emulator output through the same buffered redaction path as diagnostics.
+      child.stdout?.on("data", (data) => {
+        monitorOutput(data, stdoutRedactor);
       });
 
-      child.on("error", error => {
+      child.stderr?.on("data", (data) => {
+        monitorOutput(data, stderrRedactor);
+      });
+
+      child.on("exit", (code, signal) => {
         this.timer.clearTimeout(startupTimeout);
+        exitCode = code;
+        exitSignal = signal;
+        if (code !== 0) {
+          logger.error(`Emulator process exited with code: ${code}`);
+          if (!startupValidationComplete) {
+            exitDrainTimeout = this.timer.setTimeout(() => {
+              logger.debug(
+                `Emulator stdio did not close within ${EARLY_EXIT_DRAIN_TIMEOUT_MS}ms after an early exit`,
+              );
+              finalizeEarlyExit();
+            }, EARLY_EXIT_DRAIN_TIMEOUT_MS);
+          }
+        } else {
+          logger.info(`Emulator process exited with code: ${code}`);
+        }
+      });
+
+      child.on("close", (code, signal) => {
+        this.timer.clearTimeout(startupTimeout);
+        clearExitDrainTimeout();
+        exitCode ??= code;
+        exitSignal ??= signal;
+        if (exitCode === 0 || startupValidationComplete) {
+          return;
+        }
+        finalizeEarlyExit();
+      });
+
+      child.on("error", (error) => {
+        this.timer.clearTimeout(startupTimeout);
+        clearExitDrainTimeout();
         if (!startupValidationComplete) {
           startupValidationComplete = true;
           perf.endOperation("panicDetection");
@@ -1517,8 +1747,10 @@ export class AndroidEmulatorClient implements AndroidEmulator {
    * @returns Promise that resolves when emulator is stopped
    */
   async killDevice(device: BootedDevice): Promise<void> {
-    const runningEmulators = await this.getBootedDevicesChecked(false, { bypassDeviceListCache: true });
-    const emulator = runningEmulators.find(emu => emu.deviceId === device.deviceId);
+    const runningEmulators = await this.getBootedDevicesChecked(false, {
+      bypassDeviceListCache: true,
+    });
+    const emulator = runningEmulators.find((emu) => emu.deviceId === device.deviceId);
 
     if (!emulator || !emulator.deviceId) {
       throw new ActionableError(`Emulator '${device.name}' is not running`);
@@ -1554,8 +1786,10 @@ export class AndroidEmulatorClient implements AndroidEmulator {
     timeoutMs: number,
     processExitError: ActionableError | null,
   ): ActionableError {
-    return processExitError
-      ?? new ActionableError(`Emulator '${avdName}' failed to become ready within ${timeoutMs}ms`);
+    return (
+      processExitError ??
+      new ActionableError(`Emulator '${avdName}' failed to become ready within ${timeoutMs}ms`)
+    );
   }
 
   private unknownEmulatorName(deviceId: string): string {
@@ -1566,14 +1800,20 @@ export class AndroidEmulatorClient implements AndroidEmulator {
     return name === this.unknownEmulatorName(deviceId);
   }
 
-  private matchesRequestedAvdOrUnknown(emulator: BootedDevice, avdName: string, targetDeviceId?: string): boolean {
+  private matchesRequestedAvdOrUnknown(
+    emulator: BootedDevice,
+    avdName: string,
+    targetDeviceId?: string,
+  ): boolean {
     if (targetDeviceId === emulator.deviceId && !targetDeviceId.startsWith("emulator-")) {
       return true;
     }
 
-    return emulator.name === avdName
-      || this.isUnknownEmulatorName(emulator.name, emulator.deviceId)
-      || (targetDeviceId === emulator.deviceId && this.isUnknownEmulatorName(avdName, targetDeviceId));
+    return (
+      emulator.name === avdName ||
+      this.isUnknownEmulatorName(emulator.name, emulator.deviceId) ||
+      (targetDeviceId === emulator.deviceId && this.isUnknownEmulatorName(avdName, targetDeviceId))
+    );
   }
 
   private detectDeviceIdFromEmulatorOutput(output: string): string | undefined {
@@ -1603,7 +1843,9 @@ export class AndroidEmulatorClient implements AndroidEmulator {
     const targetDeviceId = this.detectDeviceIdFromEmulatorOutput(output);
     if (targetDeviceId) {
       this.launchTargetDeviceIds.set(childProcess, targetDeviceId);
-      logger.debug(`Captured emulator launch target deviceId from process output: ${targetDeviceId}`);
+      logger.debug(
+        `Captured emulator launch target deviceId from process output: ${targetDeviceId}`,
+      );
     }
   }
 
@@ -1623,8 +1865,13 @@ export class AndroidEmulatorClient implements AndroidEmulator {
     const perf = createGlobalPerformanceTracker();
 
     // Read polling interval from environment variable (default: 500ms, minimum: 100ms)
-    const pollingIntervalMs = Math.max(parseInt(process.env.EMULATOR_POLLING_INTERVAL_MS || "500", 10), 100);
-    logger.info(`Waiting for emulator '${avdName}' to be ready... (polling interval: ${pollingIntervalMs}ms)`);
+    const pollingIntervalMs = Math.max(
+      parseInt(process.env.EMULATOR_POLLING_INTERVAL_MS || "500", 10),
+      100,
+    );
+    logger.info(
+      `Waiting for emulator '${avdName}' to be ready... (polling interval: ${pollingIntervalMs}ms)`,
+    );
 
     // Monitor child process for early exit if provided
     let processExitError: ActionableError | null = null;
@@ -1641,7 +1888,7 @@ export class AndroidEmulatorClient implements AndroidEmulator {
       };
       childProcess.stdout?.on("data", captureOutput);
       childProcess.stderr?.on("data", captureOutput);
-      childProcess.on("exit", code => {
+      childProcess.on("exit", (code) => {
         // A null code means the process was killed by signal (e.g. SIGABRT from a
         // failed Qt xcb plugin on a headless host) — treat that as a failure too.
         if (code !== 0) {
@@ -1668,14 +1915,18 @@ export class AndroidEmulatorClient implements AndroidEmulator {
           } else {
             const panicResult = this.detectArchitecturePanic(combinedOutput);
             if (panicResult.isPanic) {
-              processExitError = new ActionableError(`Emulator failed to start: ${panicResult.message}`);
+              processExitError = new ActionableError(
+                `Emulator failed to start: ${panicResult.message}`,
+              );
             } else {
               processExitError = new ActionableError(
-                `Emulator process exited with code ${code} while waiting for readiness`
+                `Emulator process exited with code ${code} while waiting for readiness`,
               );
             }
           }
-          logger.error(`Emulator process exited during readiness wait: ${processExitError.message}`);
+          logger.error(
+            `Emulator process exited during readiness wait: ${processExitError.message}`,
+          );
         }
       });
     }
@@ -1689,54 +1940,76 @@ export class AndroidEmulatorClient implements AndroidEmulator {
     const backgroundPoller = async () => {
       while (pollingActive && !foundDeviceId) {
         try {
-          this.recordLaunchError(childProcess, error => {
+          this.recordLaunchError(childProcess, (error) => {
             processExitError = error;
           });
           logger.debug(`Background polling iteration - checking for emulator '${avdName}'...`);
 
-          const correlatedTargetDeviceId = targetDeviceId ?? this.getLaunchTargetDeviceId(childProcess);
+          const correlatedTargetDeviceId =
+            targetDeviceId ?? this.getLaunchTargetDeviceId(childProcess);
           const remainingTimeoutMs = timeoutMs - (this.timer.now() - startTime);
           if (remainingTimeoutMs <= 0) {
             pollingActive = false;
             break;
           }
-          await this.detectOfflineFailure(correlatedTargetDeviceId, offlineTracker, remainingTimeoutMs);
+          await this.detectOfflineFailure(
+            correlatedTargetDeviceId,
+            offlineTracker,
+            remainingTimeoutMs,
+          );
           if (!pollingActive || this.timer.now() - startTime >= timeoutMs) {
             break;
           }
 
           // For local emulators, check for running devices
           logger.debug(`Checking for running local emulators...`);
-          const runningEmulators = await this.getBootedDevices(false, { bypassDeviceListCache: true });
+          const runningEmulators = await this.getBootedDevices(false, {
+            bypassDeviceListCache: true,
+          });
           logger.debug(`Device scan complete - found ${runningEmulators.length} running emulators`);
 
           if (runningEmulators.length > 0) {
-            logger.debug(`Found ${runningEmulators.length} running emulators: ${runningEmulators.map(e => `${e.name}(${e.deviceId})`).join(", ")}`);
+            logger.debug(
+              `Found ${runningEmulators.length} running emulators: ${runningEmulators.map((e) => `${e.name}(${e.deviceId})`).join(", ")}`,
+            );
 
             // Prefer an exact deviceId when startDevice already selected or correlated a device.
             let emulator = correlatedTargetDeviceId
-              ? runningEmulators.find(emu => emu.deviceId === correlatedTargetDeviceId)
+              ? runningEmulators.find((emu) => emu.deviceId === correlatedTargetDeviceId)
               : undefined;
             if (correlatedTargetDeviceId) {
-              logger.debug(`Exact deviceId match for '${correlatedTargetDeviceId}': ${emulator ? `Found ${emulator.deviceId}` : "Not found"}`);
-              if (emulator && !this.matchesRequestedAvdOrUnknown(emulator, avdName, correlatedTargetDeviceId)) {
-                logger.debug(`Exact deviceId match ${emulator.deviceId} resolved as '${emulator.name}', not requested AVD '${avdName}'`);
+              logger.debug(
+                `Exact deviceId match for '${correlatedTargetDeviceId}': ${emulator ? `Found ${emulator.deviceId}` : "Not found"}`,
+              );
+              if (
+                emulator &&
+                !this.matchesRequestedAvdOrUnknown(emulator, avdName, correlatedTargetDeviceId)
+              ) {
+                logger.debug(
+                  `Exact deviceId match ${emulator.deviceId} resolved as '${emulator.name}', not requested AVD '${avdName}'`,
+                );
                 emulator = undefined;
               }
             }
 
             // Look for emulator by name next.
             if (!emulator && !correlatedTargetDeviceId) {
-              emulator = runningEmulators.find(emu => emu.name === avdName);
-              logger.debug(`Exact name match for '${avdName}': ${emulator ? `Found ${emulator.deviceId}` : "Not found"}`);
+              emulator = runningEmulators.find((emu) => emu.name === avdName);
+              logger.debug(
+                `Exact name match for '${avdName}': ${emulator ? `Found ${emulator.deviceId}` : "Not found"}`,
+              );
             }
 
             if (emulator && emulator.deviceId) {
-              logger.debug(`Target emulator found: ${emulator.name} (${emulator.deviceId}) - starting readiness checks`);
+              logger.debug(
+                `Target emulator found: ${emulator.name} (${emulator.deviceId}) - starting readiness checks`,
+              );
 
               // Check if the device is online and ready.
               // Run ADB state, package manager, and boot-complete checks in parallel for faster detection.
-              logger.debug(`[PARALLEL] Running device state, package manager, and boot-complete checks for ${emulator.deviceId}...`);
+              logger.debug(
+                `[PARALLEL] Running device state, package manager, and boot-complete checks for ${emulator.deviceId}...`,
+              );
               const adb = this.adbFactory.create(emulator);
               try {
                 perf.startOperation("adbParallelChecks");
@@ -1762,35 +2035,63 @@ export class AndroidEmulatorClient implements AndroidEmulator {
                 ) {
                   logger.debug(
                     `[PARALLEL] Checks not yet complete: deviceStatus: ${deviceStateResult.status}, ` +
-                    `packageManager: ${packageManagerResult.status}, ` +
-                    `sysBootCompleted: ${sysBootCompletedResult.status}, bootAnimation: ${bootAnimationResult.status}`,
+                      `packageManager: ${packageManagerResult.status}, ` +
+                      `sysBootCompleted: ${sysBootCompletedResult.status}, bootAnimation: ${bootAnimationResult.status}`,
                   );
                 } else {
                   const stateOutput = deviceStateResult.value.stdout.trim();
                   const sysBootCompleted = sysBootCompletedResult.value.stdout.trim();
                   const bootAnimationState = bootAnimationResult.value.stdout.trim();
-                  logger.debug(`[PARALLEL] Package manager command completed for ${emulator.deviceId} - output: ${packageManagerResult.value.stdout.length} bytes`);
+                  logger.debug(
+                    `[PARALLEL] Package manager command completed for ${emulator.deviceId} - output: ${packageManagerResult.value.stdout.length} bytes`,
+                  );
                   if (!stateOutput.includes("device")) {
-                    logger.debug(`[PARALLEL] ❌ Device state check failed for ${emulator.deviceId}: state="${stateOutput}"`);
-                  } else if (!packageManagerResult.value.stdout || !packageManagerResult.value.stdout.includes("package:")) {
-                    logger.debug(`[PARALLEL] ❌ Package manager returned no packages for ${emulator.deviceId} (${packageManagerResult.value.stdout.length} bytes output)`);
-                  } else if (packageManagerResult.value.stderr || packageManagerResult.value.stderr.includes("Failure")) {
-                    logger.debug(`[PARALLEL] ❌ Package manager returned failure for ${emulator.deviceId}: ${packageManagerResult.value.stderr}`);
+                    logger.debug(
+                      `[PARALLEL] ❌ Device state check failed for ${emulator.deviceId}: state="${stateOutput}"`,
+                    );
+                  } else if (
+                    !packageManagerResult.value.stdout ||
+                    !packageManagerResult.value.stdout.includes("package:")
+                  ) {
+                    logger.debug(
+                      `[PARALLEL] ❌ Package manager returned no packages for ${emulator.deviceId} (${packageManagerResult.value.stdout.length} bytes output)`,
+                    );
+                  } else if (
+                    packageManagerResult.value.stderr ||
+                    packageManagerResult.value.stderr.includes("Failure")
+                  ) {
+                    logger.debug(
+                      `[PARALLEL] ❌ Package manager returned failure for ${emulator.deviceId}: ${packageManagerResult.value.stderr}`,
+                    );
                   } else if (sysBootCompleted !== "1") {
-                    logger.debug(`[PARALLEL] ❌ sys.boot_completed is not set for ${emulator.deviceId}: "${sysBootCompleted}"`);
+                    logger.debug(
+                      `[PARALLEL] ❌ sys.boot_completed is not set for ${emulator.deviceId}: "${sysBootCompleted}"`,
+                    );
                   } else if (bootAnimationState && bootAnimationState !== "stopped") {
-                    logger.debug(`[PARALLEL] ❌ boot animation is still active for ${emulator.deviceId}: "${bootAnimationState}"`);
+                    logger.debug(
+                      `[PARALLEL] ❌ boot animation is still active for ${emulator.deviceId}: "${bootAnimationState}"`,
+                    );
                   } else {
-                    logger.debug(`[PARALLEL] ✅ Device state check passed for ${emulator.deviceId}`);
-                    logger.debug(`[PARALLEL] ✅ Package manager is responsive for ${emulator.deviceId} - emulator is ready!`);
-                    logger.debug(`[PARALLEL] ✅ Android boot-complete signals are ready for ${emulator.deviceId}`);
-                    logger.debug(`[PARALLEL] ✅ No package manager errors detected - marking emulator as ready`);
+                    logger.debug(
+                      `[PARALLEL] ✅ Device state check passed for ${emulator.deviceId}`,
+                    );
+                    logger.debug(
+                      `[PARALLEL] ✅ Package manager is responsive for ${emulator.deviceId} - emulator is ready!`,
+                    );
+                    logger.debug(
+                      `[PARALLEL] ✅ Android boot-complete signals are ready for ${emulator.deviceId}`,
+                    );
+                    logger.debug(
+                      `[PARALLEL] ✅ No package manager errors detected - marking emulator as ready`,
+                    );
                     foundDeviceId = emulator.deviceId;
                     return;
                   }
                 }
               } catch (parallelError) {
-                logger.debug(`[PARALLEL] ❌ Parallel checks failed for ${emulator.deviceId}: ${parallelError}`);
+                logger.debug(
+                  `[PARALLEL] ❌ Parallel checks failed for ${emulator.deviceId}: ${parallelError}`,
+                );
               }
             } else {
               logger.debug(`No suitable emulator found for '${avdName}' - will continue polling`);
@@ -1803,10 +2104,14 @@ export class AndroidEmulatorClient implements AndroidEmulator {
         }
 
         // Always wait at least the minimum polling interval
-        logger.debug(`Background polling cycle complete - sleeping ${pollingIntervalMs}ms before next check`);
+        logger.debug(
+          `Background polling cycle complete - sleeping ${pollingIntervalMs}ms before next check`,
+        );
         await this.sleep(pollingIntervalMs);
       }
-      logger.debug(`Background polling stopped - pollingActive: ${pollingActive}, foundDeviceId: ${foundDeviceId}`);
+      logger.debug(
+        `Background polling stopped - pollingActive: ${pollingActive}, foundDeviceId: ${foundDeviceId}`,
+      );
     };
 
     // Start background polling immediately
@@ -1826,7 +2131,11 @@ export class AndroidEmulatorClient implements AndroidEmulator {
         pollingActive = false;
         perf.endOperation("devicePolling");
         logger.info(`Emulator '${avdName}' is ready! Device ID: ${foundDeviceId}`);
-        const bootedDevice = { name: avdName, platform: "android", deviceId: foundDeviceId } as BootedDevice;
+        const bootedDevice = {
+          name: avdName,
+          platform: "android",
+          deviceId: foundDeviceId,
+        } as BootedDevice;
         perf.startOperation("wakeAndUnlock");
         await this.wakeAndUnlock(bootedDevice);
         perf.endOperation("wakeAndUnlock");
@@ -1844,7 +2153,11 @@ export class AndroidEmulatorClient implements AndroidEmulator {
 
     if (foundDeviceId) {
       logger.info(`Emulator '${avdName}' is ready! Device ID: ${foundDeviceId}`);
-      const bootedDevice = { name: avdName, platform: "android", deviceId: foundDeviceId } as BootedDevice;
+      const bootedDevice = {
+        name: avdName,
+        platform: "android",
+        deviceId: foundDeviceId,
+      } as BootedDevice;
       perf.startOperation("wakeAndUnlock");
       await this.wakeAndUnlock(bootedDevice);
       perf.endOperation("wakeAndUnlock");
@@ -1869,16 +2182,18 @@ export class AndroidEmulatorClient implements AndroidEmulator {
     try {
       const wakeAndUnlock = new WakeAndUnlock(device, this.adbFactory, {
         timer: this.timer,
-        credentialStore: new DeviceLockStore()
+        credentialStore: new DeviceLockStore(),
       });
       const result = await wakeAndUnlock.execute();
       if (!result.unlocked && result.secure) {
         logger.info(
           `[WakeAndUnlock] Device ${device.deviceId} is secure-locked and no PIN is remembered; ` +
-          "leaving it locked. Unlock it once with the wakeAndUnlock tool (passing a pin) to remember it."
+            "leaving it locked. Unlock it once with the wakeAndUnlock tool (passing a pin) to remember it.",
         );
       } else {
-        logger.info(`[WakeAndUnlock] Device ${device.deviceId} wake/unlock: ${JSON.stringify(result)}`);
+        logger.info(
+          `[WakeAndUnlock] Device ${device.deviceId} wake/unlock: ${JSON.stringify(result)}`,
+        );
       }
     } catch (error) {
       // Log but don't fail - the device is still ready, just might need manual interaction.

--- a/src/utils/android-cmdline-tools/SdkManagerClient.ts
+++ b/src/utils/android-cmdline-tools/SdkManagerClient.ts
@@ -3,6 +3,7 @@ import { existsSync } from "node:fs";
 import { join, resolve } from "node:path";
 import { defaultTimer, type Timer } from "../SystemTimer";
 import { logger } from "../logger";
+import { redactAndroidCommandOutput } from "./redactAndroidCommandOutput";
 import {
   detectAndroidCommandLineTools,
   getAndroidHomeWithSystemImages,
@@ -69,13 +70,6 @@ function defaults(): SdkManagerClientDependencies {
 
 function normalizePath(value: string): string {
   return value.replace(/\\/g, "/");
-}
-
-function redact(value: string): string {
-  return value.replace(
-    /\b(token|password|secret|api[_-]?key)\s*=\s*[^\s]+/gi,
-    (_match, key: string) => `${key}=[REDACTED]`,
-  );
 }
 
 function appendBounded(current: string, next: string, maximum: number): { value: string; truncated: boolean } {
@@ -266,7 +260,12 @@ export class SdkManagerClient {
       });
       child.on("close", code => settle(() => {
         if (terminationError) {reject(terminationError); return;}
-        resolvePromise({ stdout: redact(stdout), stderr: redact(stderr), exitCode: code, outputTruncated });
+        resolvePromise({
+          stdout: redactAndroidCommandOutput(stdout),
+          stderr: redactAndroidCommandOutput(stderr),
+          exitCode: code,
+          outputTruncated,
+        });
       }));
       child.on("error", error => settle(() => reject(new Error(`Failed to spawn command: sdkmanager: ${error.message}`))));
       if (inputOptions.input) {child.stdin?.write(inputOptions.input); child.stdin?.end();}

--- a/src/utils/android-cmdline-tools/SdkManagerClient.ts
+++ b/src/utils/android-cmdline-tools/SdkManagerClient.ts
@@ -72,10 +72,18 @@ function normalizePath(value: string): string {
   return value.replace(/\\/g, "/");
 }
 
-function appendBounded(current: string, next: string, maximum: number): { value: string; truncated: boolean } {
+function appendBounded(
+  current: string,
+  next: string,
+  maximum: number,
+): { value: string; truncated: boolean } {
   const available = maximum - current.length;
-  if (available <= 0) {return { value: current, truncated: next.length > 0 };}
-  if (next.length <= available) {return { value: current + next, truncated: false };}
+  if (available <= 0) {
+    return { value: current, truncated: next.length > 0 };
+  }
+  if (next.length <= available) {
+    return { value: current + next, truncated: false };
+  }
   return { value: current + next.slice(0, available), truncated: true };
 }
 
@@ -92,29 +100,49 @@ export class SdkManagerClient {
   constructor(private readonly dependencies: SdkManagerClientDependencies = defaults()) {}
 
   async list(options: SdkManagerExecutionOptions = {}): Promise<SdkManagerCommandResult> {
-    return this.run(["--list"], {
-      timeoutMs: CATALOGUE_FETCH_TIMEOUT_MS,
-      maxStdoutChars: UNBOUNDED_STDOUT_CHARS,
-    }, options);
+    return this.run(
+      ["--list"],
+      {
+        timeoutMs: CATALOGUE_FETCH_TIMEOUT_MS,
+        maxStdoutChars: UNBOUNDED_STDOUT_CHARS,
+      },
+      options,
+    );
   }
 
   /** Return the installed sdkmanager command-line tools version. */
   async getVersion(options: SdkManagerExecutionOptions = {}): Promise<SdkManagerCommandResult> {
-    return this.run(["--version"], {
-      timeoutMs: LOCAL_COMMAND_TIMEOUT_MS,
-      maxStdoutChars: 1_024,
-    }, options, true);
+    return this.run(
+      ["--version"],
+      {
+        timeoutMs: LOCAL_COMMAND_TIMEOUT_MS,
+        maxStdoutChars: 1_024,
+      },
+      options,
+      true,
+    );
   }
 
   async acceptLicenses(options: SdkManagerExecutionOptions = {}): Promise<SdkManagerCommandResult> {
-    return this.run(["--licenses"], { input: "y\n".repeat(20), timeoutMs: LOCAL_COMMAND_TIMEOUT_MS }, options);
+    return this.run(
+      ["--licenses"],
+      { input: "y\n".repeat(20), timeoutMs: LOCAL_COMMAND_TIMEOUT_MS },
+      options,
+    );
   }
 
-  async installPackage(packageName: string, options: SdkManagerExecutionOptions & { acceptLicenses?: boolean } = {}): Promise<SdkManagerCommandResult> {
-    return this.run([packageName], {
-      input: options.acceptLicenses ? "y\n".repeat(10) : undefined,
-      timeoutMs: PACKAGE_INSTALL_TIMEOUT_MS,
-    }, options);
+  async installPackage(
+    packageName: string,
+    options: SdkManagerExecutionOptions & { acceptLicenses?: boolean } = {},
+  ): Promise<SdkManagerCommandResult> {
+    return this.run(
+      [packageName],
+      {
+        input: options.acceptLicenses ? "y\n".repeat(10) : undefined,
+        timeoutMs: PACKAGE_INSTALL_TIMEOUT_MS,
+      },
+      options,
+    );
   }
 
   private async run(
@@ -131,30 +159,49 @@ export class SdkManagerClient {
     allowBootstrapRoot = false,
     selectedLocation?: AndroidToolsLocation,
   ): Promise<{ path: string; env: NodeJS.ProcessEnv }> {
-    const locations = selectedLocation ? [selectedLocation] : await this.dependencies.detectAndroidCommandLineTools();
+    const locations = selectedLocation
+      ? [selectedLocation]
+      : await this.dependencies.detectAndroidCommandLineTools();
     const location = selectedLocation ?? this.dependencies.getBestAndroidToolsLocation(locations);
     if (!location) {
-      throw new Error("Android command line tools not found. Tool installation functionality has been removed. Please install Android SDK Command-line Tools and set ANDROID_HOME or ANDROID_SDK_ROOT to the SDK root.");
+      throw new Error(
+        "Android command line tools not found. Tool installation functionality has been removed. Please install Android SDK Command-line Tools and set ANDROID_HOME or ANDROID_SDK_ROOT to the SDK root.",
+      );
     }
     const validation = this.dependencies.validateRequiredTools(location, ["sdkmanager"]);
     if (!validation.valid) {
-      throw new Error(`Missing required tools: ${validation.missing.join(", ")}. Tool installation functionality has been removed. Install Android SDK Command-line Tools under ANDROID_HOME/cmdline-tools/latest.`);
+      throw new Error(
+        `Missing required tools: ${validation.missing.join(", ")}. Tool installation functionality has been removed. Install Android SDK Command-line Tools under ANDROID_HOME/cmdline-tools/latest.`,
+      );
     }
     const path = this.resolveExecutable(location);
-    const sdkRoot = this.resolveSdkRoot(location) ?? (allowBootstrapRoot ? this.stripCmdlineToolsPath(location.path) : undefined);
+    const sdkRoot =
+      this.resolveSdkRoot(location) ??
+      (allowBootstrapRoot ? this.stripCmdlineToolsPath(location.path) : undefined);
     if (!sdkRoot) {
-      throw new Error(`Unable to resolve the Android SDK root for sdkmanager at ${path}. Set ANDROID_HOME or ANDROID_SDK_ROOT to the SDK root containing platforms or system-images.`);
+      throw new Error(
+        `Unable to resolve the Android SDK root for sdkmanager at ${path}. Set ANDROID_HOME or ANDROID_SDK_ROOT to the SDK root containing platforms or system-images.`,
+      );
     }
     this.warnHomebrewMismatch(location, sdkRoot);
-    return { path, env: { ...this.dependencies.environment, ANDROID_HOME: sdkRoot, ANDROID_SDK_ROOT: sdkRoot } };
+    return {
+      path,
+      env: { ...this.dependencies.environment, ANDROID_HOME: sdkRoot, ANDROID_SDK_ROOT: sdkRoot },
+    };
   }
 
   private resolveExecutable(location: AndroidToolsLocation): string {
     const executable = join(location.path, "bin", "sdkmanager");
-    if (this.dependencies.existsSync(executable)) {return executable;}
+    if (this.dependencies.existsSync(executable)) {
+      return executable;
+    }
     const batch = join(location.path, "bin", "sdkmanager.bat");
-    if (this.dependencies.existsSync(batch)) {return batch;}
-    throw new Error(`SDK manager not found at ${location.path}. Install Android SDK Command-line Tools under ANDROID_HOME/cmdline-tools/latest.`);
+    if (this.dependencies.existsSync(batch)) {
+      return batch;
+    }
+    throw new Error(
+      `SDK manager not found at ${location.path}. Install Android SDK Command-line Tools under ANDROID_HOME/cmdline-tools/latest.`,
+    );
   }
 
   private resolveSdkRoot(location: AndroidToolsLocation): string | undefined {
@@ -169,8 +216,11 @@ export class SdkManagerClient {
       resolve(location.path, "..", ".."),
       ...this.typicalSdkPaths(),
     ].filter(Boolean) as string[];
-    return candidates.find(candidate => this.dependencies.existsSync(join(candidate, "system-images"))) ??
-      candidates.find(candidate => this.looksLikeSdkRoot(candidate));
+    return (
+      candidates.find((candidate) =>
+        this.dependencies.existsSync(join(candidate, "system-images")),
+      ) ?? candidates.find((candidate) => this.looksLikeSdkRoot(candidate))
+    );
   }
 
   private stripCmdlineToolsPath(path: string): string | undefined {
@@ -182,36 +232,79 @@ export class SdkManagerClient {
 
   private typicalSdkPaths(): string[] {
     const home = this.dependencies.environment.HOME ?? this.dependencies.environment.USERPROFILE;
-    if (this.dependencies.platform === "darwin") {return [...(home ? [join(home, "Library/Android/sdk")] : []), "/opt/android-sdk", "/usr/local/android-sdk"];}
-    if (this.dependencies.platform === "linux") {return [...(home ? [join(home, "Android/Sdk")] : []), "/opt/android-sdk", "/usr/local/android-sdk"];}
-    if (this.dependencies.platform === "win32") {return [...(home ? [join(home, "AppData/Local/Android/Sdk")] : []), "C:/Android/Sdk", "C:/android-sdk"];}
+    if (this.dependencies.platform === "darwin") {
+      return [
+        ...(home ? [join(home, "Library/Android/sdk")] : []),
+        "/opt/android-sdk",
+        "/usr/local/android-sdk",
+      ];
+    }
+    if (this.dependencies.platform === "linux") {
+      return [
+        ...(home ? [join(home, "Android/Sdk")] : []),
+        "/opt/android-sdk",
+        "/usr/local/android-sdk",
+      ];
+    }
+    if (this.dependencies.platform === "win32") {
+      return [
+        ...(home ? [join(home, "AppData/Local/Android/Sdk")] : []),
+        "C:/Android/Sdk",
+        "C:/android-sdk",
+      ];
+    }
     return [];
   }
 
   private looksLikeSdkRoot(path: string): boolean {
-    return this.dependencies.existsSync(path) && SDK_ROOT_MARKERS.filter(marker => this.dependencies.existsSync(join(path, marker))).length >= 2;
+    return (
+      this.dependencies.existsSync(path) &&
+      SDK_ROOT_MARKERS.filter((marker) => this.dependencies.existsSync(join(path, marker)))
+        .length >= 2
+    );
   }
 
   private warnHomebrewMismatch(location: AndroidToolsLocation, sdkRoot: string): void {
-    if (!isHomebrewToolsPath(location.path) || SdkManagerClient.homebrewWarningLoggers.has(this.dependencies.logger)) {return;}
+    if (
+      !isHomebrewToolsPath(location.path) ||
+      SdkManagerClient.homebrewWarningLoggers.has(this.dependencies.logger)
+    ) {
+      return;
+    }
     const info = this.dependencies.getAndroidHomeWithSystemImages();
-    if (!info || normalizePath(getCmdlineToolsRoot(location.path)) === normalizePath(info.androidHome)) {return;}
-    this.dependencies.logger.warn(`Warning: Homebrew Android cmdline-tools detected, but system images are in ANDROID_HOME. sdkmanager location: ${location.path} ANDROID_HOME: ${info.androidHome} Effective SDK root: ${sdkRoot}. Fix: ensure cmdline-tools are present under ANDROID_HOME.`);
+    if (
+      !info ||
+      normalizePath(getCmdlineToolsRoot(location.path)) === normalizePath(info.androidHome)
+    ) {
+      return;
+    }
+    this.dependencies.logger.warn(
+      `Warning: Homebrew Android cmdline-tools detected, but system images are in ANDROID_HOME. sdkmanager location: ${location.path} ANDROID_HOME: ${info.androidHome} Effective SDK root: ${sdkRoot}. Fix: ensure cmdline-tools are present under ANDROID_HOME.`,
+    );
     SdkManagerClient.homebrewWarningLoggers.add(this.dependencies.logger);
   }
 
   private execute(
     path: string,
     args: string[],
-    inputOptions: { input?: string; env: NodeJS.ProcessEnv; timeoutMs: number; maxStdoutChars?: number },
+    inputOptions: {
+      input?: string;
+      env: NodeJS.ProcessEnv;
+      timeoutMs: number;
+      maxStdoutChars?: number;
+    },
     options: SdkManagerExecutionOptions,
   ): Promise<SdkManagerCommandResult> {
-    const maxStdoutChars = options.maxOutputChars ?? inputOptions.maxStdoutChars ?? DEFAULT_MAX_OUTPUT_CHARS;
+    const maxStdoutChars =
+      options.maxOutputChars ?? inputOptions.maxStdoutChars ?? DEFAULT_MAX_OUTPUT_CHARS;
     const maxStderrChars = options.maxOutputChars ?? DEFAULT_MAX_OUTPUT_CHARS;
     const timeoutMs = options.timeoutMs ?? inputOptions.timeoutMs;
     const terminationGraceMs = options.terminationGraceMs ?? DEFAULT_TERMINATION_GRACE_MS;
     return new Promise((resolvePromise, reject) => {
-      if (options.signal?.aborted) {reject(new Error("sdkmanager command cancelled")); return;}
+      if (options.signal?.aborted) {
+        reject(new Error("sdkmanager command cancelled"));
+        return;
+      }
       const invocation = this.windowsBatchInvocation(path, args, inputOptions.env);
       const child = this.dependencies.spawn(invocation.command, invocation.args, {
         env: inputOptions.env,
@@ -225,21 +318,31 @@ export class SdkManagerClient {
       let terminationError: Error | undefined;
       let terminationTimeout: NodeJS.Timeout | undefined;
       const settle = (callback: () => void) => {
-        if (settled) {return;}
+        if (settled) {
+          return;
+        }
         settled = true;
         this.dependencies.timer.clearTimeout(timeout);
-        if (terminationTimeout) {this.dependencies.timer.clearTimeout(terminationTimeout);}
+        if (terminationTimeout) {
+          this.dependencies.timer.clearTimeout(terminationTimeout);
+        }
         options.signal?.removeEventListener("abort", onAbort);
         callback();
       };
       const terminate = (error: Error) => {
-        if (terminationError) {return;}
+        if (terminationError) {
+          return;
+        }
         terminationError = error;
         child.kill("SIGTERM");
-        terminationTimeout = this.dependencies.timer.setTimeout(() => settle(() => {
-          child.kill("SIGKILL");
-          reject(error);
-        }), terminationGraceMs);
+        terminationTimeout = this.dependencies.timer.setTimeout(
+          () =>
+            settle(() => {
+              child.kill("SIGKILL");
+              reject(error);
+            }),
+          terminationGraceMs,
+        );
       };
       const onAbort = () => terminate(new Error("sdkmanager command cancelled"));
       options.signal?.addEventListener("abort", onAbort, { once: true });
@@ -248,34 +351,54 @@ export class SdkManagerClient {
       }, timeoutMs);
 
       this.dependencies.logger.info(`Executing: ${path} ${args.join(" ")}`);
-      child.stdout?.on("data", data => {
+      child.stdout?.on("data", (data) => {
         const appended = appendBounded(stdout, data.toString(), maxStdoutChars);
         stdout = appended.value;
         outputTruncated ||= appended.truncated;
       });
-      child.stderr?.on("data", data => {
+      child.stderr?.on("data", (data) => {
         const appended = appendBounded(stderr, data.toString(), maxStderrChars);
         stderr = appended.value;
         outputTruncated ||= appended.truncated;
       });
-      child.on("close", code => settle(() => {
-        if (terminationError) {reject(terminationError); return;}
-        resolvePromise({
-          stdout: redactAndroidCommandOutput(stdout),
-          stderr: redactAndroidCommandOutput(stderr),
-          exitCode: code,
-          outputTruncated,
-        });
-      }));
-      child.on("error", error => settle(() => reject(new Error(`Failed to spawn command: sdkmanager: ${error.message}`))));
-      if (inputOptions.input) {child.stdin?.write(inputOptions.input); child.stdin?.end();}
+      child.on("close", (code) =>
+        settle(() => {
+          if (terminationError) {
+            reject(terminationError);
+            return;
+          }
+          const childHome = inputOptions.env.HOME ?? inputOptions.env.USERPROFILE;
+          resolvePromise({
+            stdout: redactAndroidCommandOutput(stdout, childHome),
+            stderr: redactAndroidCommandOutput(stderr, childHome),
+            exitCode: code,
+            outputTruncated,
+          });
+        }),
+      );
+      child.on("error", (error) =>
+        settle(() => reject(new Error(`Failed to spawn command: sdkmanager: ${error.message}`))),
+      );
+      if (inputOptions.input) {
+        child.stdin?.write(inputOptions.input);
+        child.stdin?.end();
+      }
     });
   }
 
-  private windowsBatchInvocation(path: string, args: string[], environment: NodeJS.ProcessEnv): { command: string; args: string[] } {
-    if (this.dependencies.platform !== "win32" || !path.toLowerCase().endsWith(".bat")) {return { command: path, args };}
+  private windowsBatchInvocation(
+    path: string,
+    args: string[],
+    environment: NodeJS.ProcessEnv,
+  ): { command: string; args: string[] } {
+    if (this.dependencies.platform !== "win32" || !path.toLowerCase().endsWith(".bat")) {
+      return { command: path, args };
+    }
     const command = `"${[quoteForWindowsCmd(path), ...args.map(quoteForWindowsCmd)].join(" ")}"`;
-    return { command: environment.ComSpec ?? environment.COMSPEC ?? "cmd.exe", args: ["/d", "/v:off", "/s", "/c", command] };
+    return {
+      command: environment.ComSpec ?? environment.COMSPEC ?? "cmd.exe",
+      args: ["/d", "/v:off", "/s", "/c", command],
+    };
   }
 }
 
@@ -286,13 +409,17 @@ export async function readSdkManagerVersion(
 ): Promise<string | null> {
   const result = await client.getVersion(location ? { location } : {});
   if (result.exitCode !== 0) {
-    logger.debug(`sdkmanager --version failed (exit ${result.exitCode}): ${result.stderr || result.stdout}`);
+    logger.debug(
+      `sdkmanager --version failed (exit ${result.exitCode}): ${result.stderr || result.stdout}`,
+    );
     return null;
   }
   let version: string | null = null;
   for (const line of `${result.stdout}\n${result.stderr}`.split("\n")) {
     const match = line.trim().match(/^(\d+(?:\.\d+){0,2})$/);
-    if (match) {version = match[1];}
+    if (match) {
+      version = match[1];
+    }
   }
   return version;
 }

--- a/src/utils/android-cmdline-tools/redactAndroidCommandOutput.ts
+++ b/src/utils/android-cmdline-tools/redactAndroidCommandOutput.ts
@@ -1,0 +1,11 @@
+import { homedir } from "node:os";
+import { redactHomeDir } from "../redactPath";
+
+export function redactAndroidCommandOutput(value: string, home: string = homedir()): string {
+  const redactedSecrets = value.replace(
+    /\b(token|password|secret|api[_-]?key)\s*[:=]\s*[^\s]+/gi,
+    (_match, key: string) => `${key}=[REDACTED]`,
+  );
+  const redactedLeadingHome = redactHomeDir(redactedSecrets, home);
+  return home.length > 0 ? redactedLeadingHome.replaceAll(home, "~") : redactedLeadingHome;
+}

--- a/src/utils/android-cmdline-tools/redactAndroidCommandOutput.ts
+++ b/src/utils/android-cmdline-tools/redactAndroidCommandOutput.ts
@@ -1,11 +1,153 @@
 import { homedir } from "node:os";
 import { redactHomeDir } from "../redactPath";
 
+const CREDENTIAL_KEY = String.raw`(?:(?:[A-Za-z0-9]+[._-])*(?:token|password|secret|api[_-]?key)|access[_-]?token|client[_-]?secret)`;
+const CREDENTIAL_ASSIGNMENT = new RegExp(
+  String.raw`\b(${CREDENTIAL_KEY})\s*[:=]\s*(?:"(?:\\.|[^"])*(?:"|$)|'(?:\\.|[^'])*(?:'|$)|[^\s]+)`,
+  "gi",
+);
+const CREDENTIAL_ASSIGNMENT_START = new RegExp(String.raw`\b(${CREDENTIAL_KEY})\s*[:=]\s*`, "i");
+
+type CredentialValueState =
+  | { kind: "awaiting" }
+  | { kind: "unquoted" }
+  | { kind: "quoted"; quote: string; escaping: boolean };
+
 export function redactAndroidCommandOutput(value: string, home: string = homedir()): string {
   const redactedSecrets = value.replace(
-    /\b(token|password|secret|api[_-]?key)\s*[:=]\s*[^\s]+/gi,
+    CREDENTIAL_ASSIGNMENT,
     (_match, key: string) => `${key}=[REDACTED]`,
   );
   const redactedLeadingHome = redactHomeDir(redactedSecrets, home);
   return home.length > 0 ? redactedLeadingHome.replaceAll(home, "~") : redactedLeadingHome;
+}
+
+/**
+ * Redacts command output incrementally without treating stream chunks as records.
+ *
+ * Credential values are discarded as they arrive, so neither a chunk boundary nor
+ * a line break inside a quoted value can leak data into the emitted output.
+ */
+export class AndroidCommandOutputStreamRedactor {
+  private pending = "";
+  private credentialValueState: CredentialValueState | undefined;
+  private readonly pendingPrefixLength: number;
+
+  constructor(private readonly home: string = homedir()) {
+    this.pendingPrefixLength = Math.max(128, home.length);
+  }
+
+  append(value: string): string {
+    this.pending += value;
+    return this.consume(false);
+  }
+
+  flush(): string {
+    return this.consume(true);
+  }
+
+  /**
+   * Returns a safe view of the uncommitted non-secret suffix for classification.
+   */
+  snapshot(): string {
+    return this.credentialValueState ? "" : redactAndroidCommandOutput(this.pending, this.home);
+  }
+
+  private consume(flush: boolean): string {
+    let emitted = "";
+    while (this.pending.length > 0) {
+      if (this.credentialValueState) {
+        if (!this.consumeCredentialValue(flush)) {
+          break;
+        }
+        continue;
+      }
+
+      const assignment = this.pending.match(CREDENTIAL_ASSIGNMENT_START);
+      if (assignment && assignment.index !== undefined) {
+        emitted += redactAndroidCommandOutput(this.pending.slice(0, assignment.index), this.home);
+        emitted += `${assignment[1]}=[REDACTED]`;
+        this.pending = this.pending.slice(assignment.index + assignment[0].length);
+        this.credentialValueState = { kind: "awaiting" };
+        continue;
+      }
+
+      const safeLength = flush
+        ? this.pending.length
+        : Math.max(0, this.pending.length - this.pendingPrefixLength);
+      if (safeLength === 0) {
+        break;
+      }
+      emitted += redactAndroidCommandOutput(this.pending.slice(0, safeLength), this.home);
+      this.pending = this.pending.slice(safeLength);
+    }
+    return emitted;
+  }
+
+  private consumeCredentialValue(flush: boolean): boolean {
+    if (this.credentialValueState?.kind === "awaiting") {
+      if (this.pending.length === 0) {
+        return false;
+      }
+      const quote = this.pending[0];
+      if (quote === '"' || quote === "'") {
+        this.pending = this.pending.slice(1);
+        this.credentialValueState = { kind: "quoted", quote, escaping: false };
+      } else {
+        this.credentialValueState = { kind: "unquoted" };
+      }
+      return true;
+    }
+
+    if (this.credentialValueState?.kind === "quoted") {
+      const quotedValue = this.findClosingQuote(
+        this.credentialValueState.quote,
+        this.credentialValueState.escaping,
+      );
+      if (quotedValue.closingQuote === -1) {
+        this.pending = "";
+        if (flush) {
+          this.credentialValueState = undefined;
+        } else {
+          this.credentialValueState = {
+            ...this.credentialValueState,
+            escaping: quotedValue.trailingEscape,
+          };
+        }
+        return false;
+      }
+      this.pending = this.pending.slice(quotedValue.closingQuote + 1);
+      this.credentialValueState = undefined;
+      return true;
+    }
+
+    const valueTerminator = this.pending.search(/\s/);
+    if (valueTerminator === -1) {
+      this.pending = "";
+      if (flush) {
+        this.credentialValueState = undefined;
+      }
+      return false;
+    }
+    this.pending = this.pending.slice(valueTerminator);
+    this.credentialValueState = undefined;
+    return true;
+  }
+
+  private findClosingQuote(
+    quote: string,
+    escaped: boolean,
+  ): { closingQuote: number; trailingEscape: boolean } {
+    for (let index = 0; index < this.pending.length; index += 1) {
+      const character = this.pending[index];
+      if (escaped) {
+        escaped = false;
+      } else if (character === "\\") {
+        escaped = true;
+      } else if (character === quote) {
+        return { closingQuote: index, trailingEscape: false };
+      }
+    }
+    return { closingQuote: -1, trailingEscape: escaped };
+  }
 }

--- a/test/utils/android-cmdline-tools/AndroidEmulatorClient-corruptImage.test.ts
+++ b/test/utils/android-cmdline-tools/AndroidEmulatorClient-corruptImage.test.ts
@@ -243,6 +243,7 @@ describe("AndroidEmulatorClient startEmulator corrupt image integration", () => 
         fakeChild.stderr!.emit("data", Buffer.from("qcow2: Image is corrupt; cannot be opened read/write\n"));
         fakeChild.stderr!.emit("data", Buffer.from("WARNING | QEMU main loop exits abnormally with code 1\n"));
         fakeChild.emit("exit", 1);
+        fakeChild.emit("close", 1);
       });
       return fakeChild;
     }) as any;
@@ -274,6 +275,7 @@ describe("AndroidEmulatorClient startEmulator corrupt image integration", () => 
       process.nextTick(() => {
         fakeChild.stderr!.emit("data", Buffer.from("qemu_mprotect__osdep: mprotect failed: Permission denied\nhvf is not enabled on this aarch64 host\n"));
         fakeChild.emit("exit", 1);
+        fakeChild.emit("close", 1);
       });
       return fakeChild;
     }) as any;
@@ -320,6 +322,7 @@ describe("AndroidEmulatorClient startEmulator corrupt image integration", () => 
         // not a fabricated `{} as ChildProcess`.
         fakeChild.stderr!.emit("data", Buffer.from("ERROR | Running multiple emulators with the same AVD is an experimental feature.\n"));
         fakeChild.emit("exit", 1);
+        fakeChild.emit("close", 1);
       });
       return fakeChild;
     }) as any;
@@ -346,6 +349,7 @@ describe("AndroidEmulatorClient startEmulator corrupt image integration", () => 
       process.nextTick(() => {
         fakeChild.stderr!.emit("data", Buffer.from("some random error\n"));
         fakeChild.emit("exit", 1);
+        fakeChild.emit("close", 1);
       });
       return fakeChild;
     }) as any;

--- a/test/utils/android-cmdline-tools/AndroidEmulatorClient-headless.test.ts
+++ b/test/utils/android-cmdline-tools/AndroidEmulatorClient-headless.test.ts
@@ -244,6 +244,7 @@ describe("AndroidEmulatorClient startEmulator headless wiring", () => {
         fakeChild.stderr!.emit("data", Buffer.from('Info: Could not load the Qt platform plugin "xcb" in "" even though it was found.\n'));
         // Signal death surfaces as a null exit code from Node.
         fakeChild.emit("exit", null);
+        fakeChild.emit("close", null);
       });
       return fakeChild;
     }) as any;

--- a/test/utils/android-cmdline-tools/AndroidEmulatorClient-launchContract.test.ts
+++ b/test/utils/android-cmdline-tools/AndroidEmulatorClient-launchContract.test.ts
@@ -140,6 +140,7 @@ describe("AndroidEmulatorClient launch contract", () => {
     child.kill = (() => {
       child.killed = true;
       child.emit("exit", null);
+      child.emit("close", null);
       return true;
     }) as ChildProcess["kill"];
     let spawned = false;

--- a/test/utils/android-cmdline-tools/AndroidEmulatorClient-launchDiagnostics.test.ts
+++ b/test/utils/android-cmdline-tools/AndroidEmulatorClient-launchDiagnostics.test.ts
@@ -19,7 +19,7 @@ function execResult(stdout = "", stderr = ""): ExecResult {
     stderr,
     toString: () => stdout,
     trim: () => stdout.trim(),
-    includes: value => stdout.includes(value),
+    includes: (value) => stdout.includes(value),
   };
 }
 
@@ -65,7 +65,11 @@ function createClient(
   const executor = new FakeAdbExecutor();
   const factory = new TestAdbClientFactory(executor);
   const avdConfigReader = new FakeAvdConfigReader();
-  const execAsync = async (_file: string, args: string[], signal?: AbortSignal): Promise<ExecResult> => {
+  const execAsync = async (
+    _file: string,
+    args: string[],
+    signal?: AbortSignal,
+  ): Promise<ExecResult> => {
     calls.push(args);
     if (args[0] === "-list-avds") {
       return execResult(`${avdName}\n`);
@@ -87,11 +91,12 @@ function createClient(
     avdConfigReader,
     "linux",
   );
-  (client as unknown as { ensureEmulatorPath: () => Promise<string> }).ensureEmulatorPath = async () => "emulator";
+  (client as unknown as { ensureEmulatorPath: () => Promise<string> }).ensureEmulatorPath =
+    async () => "emulator";
 
   return {
     client,
-    accelChecks: () => calls.filter(args => args[0] === "-accel-check").length,
+    accelChecks: () => calls.filter((args) => args[0] === "-accel-check").length,
     timer,
   };
 }
@@ -147,16 +152,68 @@ describe("AndroidEmulatorClient launch diagnostics", () => {
     expect(error.message).toContain("category=missing_shared_library");
   });
 
+  test("preserves a split failure signature while redacting a multiline credential", async () => {
+    const child = createChild();
+    const { client } = createClient(child, () => {
+      child.stderr!.emit(
+        "data",
+        Buffer.from('token="redaction-canary\nsecret-tail"\nemulator: error while loading shared '),
+      );
+      child.stderr!.emit(
+        "data",
+        Buffer.from("libraries: libxkbfile.so.1: cannot open shared object file\n"),
+      );
+      child.emit("exit", 1, null);
+      child.emit("close", 1, null);
+    });
+
+    const error = await expectRejection(client.startEmulator(avdName));
+
+    expect(error.message).toContain("category=missing_shared_library");
+    expect(error.message).toContain("libxkbfile.so.1");
+    expect(error.message).toContain("token=[REDACTED]");
+    expect(error.message).not.toContain("redaction-canary");
+    expect(error.message).not.toContain("secret-tail");
+  });
+
+  test("does not combine credential state between stdout and stderr", async () => {
+    const child = createChild();
+    const { client } = createClient(child, () => {
+      child.stderr!.emit("data", Buffer.from("token="));
+      child.stdout!.emit("data", Buffer.from("diagnostic output\n"));
+      child.stderr!.emit(
+        "data",
+        Buffer.from(
+          "actual-secret\nemulator: error while loading shared libraries: libxkbfile.so.1\n",
+        ),
+      );
+      child.emit("exit", 1, null);
+      child.emit("close", 1, null);
+    });
+
+    const error = await expectRejection(client.startEmulator(avdName));
+
+    expect(error.message).toContain("category=missing_shared_library");
+    expect(error.message).toContain("token=[REDACTED]");
+    expect(error.message).toContain("diagnostic output");
+    expect(error.message).not.toContain("actual-secret");
+  });
+
   test("preserves rejected acceleration-check output for KVM permission denial", async () => {
     const child = createChild();
     const { client, accelChecks } = createClient(
       child,
-      () => emitFailure(child, "ProbeKVM: Could not open /dev/kvm: Permission denied\n", "stderr-before-exit"),
+      () =>
+        emitFailure(
+          child,
+          "ProbeKVM: Could not open /dev/kvm: Permission denied\n",
+          "stderr-before-exit",
+        ),
       async () => {
-        throw Object.assign(
-          new Error("emulator -accel-check failed"),
-          { stdout: "", stderr: "This user does not have permissions to use KVM.\n" },
-        );
+        throw Object.assign(new Error("emulator -accel-check failed"), {
+          stdout: "",
+          stderr: "This user does not have permissions to use KVM.\n",
+        });
       },
     );
 
@@ -184,6 +241,45 @@ describe("AndroidEmulatorClient launch diagnostics", () => {
     expect(accelChecks()).toBe(1);
   });
 
+  test("keeps duplicate-AVD detection after later output overflows the diagnostic tail", async () => {
+    const child = createChild();
+    const { client, accelChecks } = createClient(child, () => {
+      child.stderr!.emit(
+        "data",
+        Buffer.from(
+          [
+            "Running multiple emulators with the same AVD is an experimental feature.",
+            ...Array.from({ length: 60 }, (_, index) => `later line ${index}`),
+          ].join("\n"),
+        ),
+      );
+      child.emit("exit", 1, null);
+      child.emit("close", 1, null);
+    });
+
+    await expect(client.startEmulator(avdName)).resolves.toBeNull();
+    expect(accelChecks()).toBe(0);
+  });
+
+  test("keeps corrupt-image detection when a noisy chunk exceeds the diagnostic tail", async () => {
+    const child = createChild();
+    const { client } = createClient(child, () => {
+      child.stderr!.emit(
+        "data",
+        Buffer.from(
+          [
+            "qcow2: Image is corrupt; cannot be opened read/write",
+            ...Array.from({ length: 60 }, (_, index) => `later line ${index}`),
+          ].join("\n"),
+        ),
+      );
+    });
+
+    const error = await expectRejection(client.startEmulator(avdName));
+
+    expect(error.message).toContain("Disk image is corrupt");
+  });
+
   test("does not run an acceleration check for a successful launch", async () => {
     const child = createChild();
     const { client, accelChecks } = createClient(child, () => {
@@ -200,7 +296,7 @@ describe("AndroidEmulatorClient launch diagnostics", () => {
     const { client, timer } = createClient(
       child,
       () => emitFailure(child, "emulator initialization failed\n", "stderr-before-exit"),
-      signal => {
+      (signal) => {
         probeSignal = signal;
         return new Promise<ExecResult>(() => {});
       },
@@ -215,6 +311,25 @@ describe("AndroidEmulatorClient launch diagnostics", () => {
     const error = await expectRejection(start);
 
     expect(probeSignal.aborted).toBe(true);
+    expect(error.message).toContain("exited with code: 1");
+  });
+
+  test("bounds the wait for close after a nonzero exit", async () => {
+    const child = createChild();
+    let exited = false;
+    const { client, timer } = createClient(child, () => {
+      child.emit("exit", 1, null);
+      exited = true;
+    });
+
+    const start = client.startEmulator(avdName);
+    while (!exited) {
+      await Promise.resolve();
+    }
+    timer.advanceTime(1_000);
+
+    const error = await expectRejection(start);
+
     expect(error.message).toContain("exited with code: 1");
   });
 

--- a/test/utils/android-cmdline-tools/AndroidEmulatorClient-launchDiagnostics.test.ts
+++ b/test/utils/android-cmdline-tools/AndroidEmulatorClient-launchDiagnostics.test.ts
@@ -1,0 +1,257 @@
+import { describe, expect, test } from "bun:test";
+import type { ChildProcess } from "node:child_process";
+import { EventEmitter } from "node:events";
+import { homedir } from "node:os";
+import { Readable } from "node:stream";
+import { AndroidEmulatorClient } from "../../../src/utils/android-cmdline-tools/AndroidEmulatorClient";
+import type { BootedDevice, ExecResult } from "../../../src/models";
+import type { AdbClientFactory } from "../../../src/utils/android-cmdline-tools/AdbClientFactory";
+import type { AdbExecutor } from "../../../src/utils/android-cmdline-tools/interfaces/AdbExecutor";
+import { FakeAdbExecutor } from "../../fakes/FakeAdbExecutor";
+import { FakeAvdConfigReader } from "../../fakes/FakeAvdConfigReader";
+import { FakeTimer } from "../../fakes/FakeTimer";
+
+const avdName = "Pixel_9_Pro";
+
+function execResult(stdout = "", stderr = ""): ExecResult {
+  return {
+    stdout,
+    stderr,
+    toString: () => stdout,
+    trim: () => stdout.trim(),
+    includes: value => stdout.includes(value),
+  };
+}
+
+async function expectRejection(promise: Promise<unknown>): Promise<Error> {
+  try {
+    await promise;
+  } catch (error) {
+    return error instanceof Error ? error : new Error(String(error));
+  }
+  throw new Error("Expected the operation to reject, but it resolved");
+}
+
+class TestAdbClientFactory implements AdbClientFactory {
+  constructor(private readonly executor: FakeAdbExecutor) {}
+
+  create(_device?: BootedDevice | null): AdbExecutor {
+    return this.executor;
+  }
+}
+
+function createChild(): ChildProcess & EventEmitter {
+  const child = new EventEmitter() as ChildProcess & EventEmitter;
+  child.stdout = new Readable({ read() {} }) as never;
+  child.stderr = new Readable({ read() {} }) as never;
+  child.killed = false;
+  child.pid = 1234;
+  child.kill = (() => {
+    child.killed = true;
+    return true;
+  }) as ChildProcess["kill"];
+  return child;
+}
+
+type ProbeResult = (signal?: AbortSignal) => Promise<ExecResult>;
+
+function createClient(
+  child: ChildProcess & EventEmitter,
+  onSpawn: () => void,
+  accelCheck: ProbeResult = async () => execResult(),
+): { client: AndroidEmulatorClient; accelChecks: () => number; timer: FakeTimer } {
+  const timer = new FakeTimer();
+  const calls: string[][] = [];
+  const executor = new FakeAdbExecutor();
+  const factory = new TestAdbClientFactory(executor);
+  const avdConfigReader = new FakeAvdConfigReader();
+  const execAsync = async (_file: string, args: string[], signal?: AbortSignal): Promise<ExecResult> => {
+    calls.push(args);
+    if (args[0] === "-list-avds") {
+      return execResult(`${avdName}\n`);
+    }
+    if (args[0] === "-accel-check") {
+      return await accelCheck(signal);
+    }
+    return execResult();
+  };
+  const spawnFn = (() => {
+    queueMicrotask(onSpawn);
+    return child;
+  }) as never;
+  const client = new AndroidEmulatorClient(
+    execAsync,
+    spawnFn,
+    timer,
+    factory,
+    avdConfigReader,
+    "linux",
+  );
+  (client as unknown as { ensureEmulatorPath: () => Promise<string> }).ensureEmulatorPath = async () => "emulator";
+
+  return {
+    client,
+    accelChecks: () => calls.filter(args => args[0] === "-accel-check").length,
+    timer,
+  };
+}
+
+function emitFailure(
+  child: ChildProcess & EventEmitter,
+  stderr: string,
+  order: "stderr-before-exit" | "stderr-after-exit",
+): void {
+  if (order === "stderr-before-exit") {
+    child.stderr!.emit("data", Buffer.from(stderr));
+  }
+  child.emit("exit", 1, null);
+  if (order === "stderr-after-exit") {
+    child.stderr!.emit("data", Buffer.from(stderr));
+  }
+  child.emit("close", 1, null);
+}
+
+describe("AndroidEmulatorClient launch diagnostics", () => {
+  test("preserves a missing shared-library error emitted after exit and before close", async () => {
+    const child = createChild();
+    const { client, accelChecks } = createClient(child, () => {
+      emitFailure(
+        child,
+        "emulator: error while loading shared libraries: libxkbfile.so.1: cannot open shared object file\n",
+        "stderr-after-exit",
+      );
+    });
+
+    const error = await expectRejection(client.startEmulator(avdName));
+
+    expect(error.message).toContain("libxkbfile.so.1");
+    expect(error.message).toContain("category=missing_shared_library");
+    expect(error.message).toContain(`AVD '${avdName}'`);
+    expect(error.message).toContain("exited with code: 1");
+    expect(accelChecks()).toBe(0);
+  });
+
+  test("classifies missing shared-library output that arrives before exit", async () => {
+    const child = createChild();
+    const { client } = createClient(child, () => {
+      emitFailure(
+        child,
+        "emulator: error while loading shared libraries: libxkbfile.so.1: cannot open shared object file\n",
+        "stderr-before-exit",
+      );
+    });
+
+    const error = await expectRejection(client.startEmulator(avdName));
+
+    expect(error.message).toContain("libxkbfile.so.1");
+    expect(error.message).toContain("category=missing_shared_library");
+  });
+
+  test("preserves rejected acceleration-check output for KVM permission denial", async () => {
+    const child = createChild();
+    const { client, accelChecks } = createClient(
+      child,
+      () => emitFailure(child, "ProbeKVM: Could not open /dev/kvm: Permission denied\n", "stderr-before-exit"),
+      async () => {
+        throw Object.assign(
+          new Error("emulator -accel-check failed"),
+          { stdout: "", stderr: "This user does not have permissions to use KVM.\n" },
+        );
+      },
+    );
+
+    const error = await expectRejection(client.startEmulator(avdName));
+
+    expect(error.message).toContain("category=kvm_permission_denied");
+    expect(error.message).toContain("This user does not have permissions to use KVM.");
+    expect(error.message).toContain(`AVD '${avdName}'`);
+    expect(error.message).toContain("exited with code: 1");
+    expect(accelChecks()).toBe(1);
+  });
+
+  test("uses successful acceleration-check output to classify unavailable acceleration", async () => {
+    const child = createChild();
+    const { client, accelChecks } = createClient(
+      child,
+      () => emitFailure(child, "emulator initialization failed\n", "stderr-before-exit"),
+      async () => execResult("acceleration is not available on this host\n"),
+    );
+
+    const error = await expectRejection(client.startEmulator(avdName));
+
+    expect(error.message).toContain("category=hardware_acceleration_unavailable");
+    expect(error.message).toContain("acceleration is not available on this host");
+    expect(accelChecks()).toBe(1);
+  });
+
+  test("does not run an acceleration check for a successful launch", async () => {
+    const child = createChild();
+    const { client, accelChecks } = createClient(child, () => {
+      child.stdout!.emit("data", Buffer.from("Detected GPU type: host\n"));
+    });
+
+    await expect(client.startEmulator(avdName)).resolves.toBe(child);
+    expect(accelChecks()).toBe(0);
+  });
+
+  test("times out an acceleration check without masking the original exit code", async () => {
+    const child = createChild();
+    let probeSignal: AbortSignal | undefined;
+    const { client, timer } = createClient(
+      child,
+      () => emitFailure(child, "emulator initialization failed\n", "stderr-before-exit"),
+      signal => {
+        probeSignal = signal;
+        return new Promise<ExecResult>(() => {});
+      },
+    );
+
+    const start = client.startEmulator(avdName);
+    while (!probeSignal) {
+      await Promise.resolve();
+    }
+    timer.advanceTime(3_000);
+
+    const error = await expectRejection(start);
+
+    expect(probeSignal.aborted).toBe(true);
+    expect(error.message).toContain("exited with code: 1");
+  });
+
+  test("bounds and redacts a generic early-exit diagnostic tail", async () => {
+    const child = createChild();
+    const home = homedir();
+    const lines = Array.from({ length: 55 }, (_, index) => `line-${index}`);
+    lines.push(`token=super-secret ${home}/.android/avd/Pixel_9_Pro.avd`);
+    const { client } = createClient(
+      child,
+      () => emitFailure(child, `${lines.join("\n")}\n`, "stderr-after-exit"),
+      async () => execResult("acceleration is not available\n"),
+    );
+
+    const error = await expectRejection(client.startEmulator(avdName));
+
+    expect(error.message).not.toContain("line-0");
+    expect(error.message).toContain("line-54");
+    expect(error.message).not.toContain("super-secret");
+    expect(error.message).toContain("token=[REDACTED]");
+    expect(error.message).not.toContain(home);
+  });
+
+  test("keeps the existing display remediation while adding its category", async () => {
+    const child = createChild();
+    const { client, accelChecks } = createClient(child, () => {
+      emitFailure(
+        child,
+        'Warning: could not connect to display (:0)\nCould not load the Qt platform plugin "xcb"\n',
+        "stderr-before-exit",
+      );
+    });
+
+    const error = await expectRejection(client.startEmulator(avdName));
+
+    expect(error.message).toContain("AUTOMOBILE_EMULATOR_HEADLESS");
+    expect(error.message).toContain("category=display_initialization_failed");
+    expect(accelChecks()).toBe(0);
+  });
+});

--- a/test/utils/android-cmdline-tools/SdkManagerClient.test.ts
+++ b/test/utils/android-cmdline-tools/SdkManagerClient.test.ts
@@ -1,15 +1,30 @@
 import { describe, expect, test } from "bun:test";
 import type { ChildProcess } from "node:child_process";
 import { join } from "node:path";
-import { readSdkManagerVersion, SdkManagerClient } from "../../../src/utils/android-cmdline-tools/SdkManagerClient";
+import {
+  readSdkManagerVersion,
+  SdkManagerClient,
+} from "../../../src/utils/android-cmdline-tools/SdkManagerClient";
 import { FakeTimer } from "../../fakes/FakeTimer";
 
 class FakeChild {
-  readonly stdout = { on: (_event: string, callback: (data: Buffer) => void) => { this.stdoutCallback = callback; } };
-  readonly stderr = { on: (_event: string, callback: (data: Buffer) => void) => { this.stderrCallback = callback; } };
+  readonly stdout = {
+    on: (_event: string, callback: (data: Buffer) => void) => {
+      this.stdoutCallback = callback;
+    },
+  };
+  readonly stderr = {
+    on: (_event: string, callback: (data: Buffer) => void) => {
+      this.stderrCallback = callback;
+    },
+  };
   readonly stdin = {
-    write: (value: string) => { this.stdinWrites.push(value); },
-    end: () => { this.stdinEnded = true; },
+    write: (value: string) => {
+      this.stdinWrites.push(value);
+    },
+    end: () => {
+      this.stdinEnded = true;
+    },
   };
   readonly kills: NodeJS.Signals[] = [];
   readonly stdinWrites: string[] = [];
@@ -20,8 +35,12 @@ class FakeChild {
   private errorCallback?: (error: Error) => void;
 
   on(event: string, callback: (value: never) => void): this {
-    if (event === "close") {this.closeCallback = callback as (code: number | null) => void;}
-    if (event === "error") {this.errorCallback = callback as (error: Error) => void;}
+    if (event === "close") {
+      this.closeCallback = callback as (code: number | null) => void;
+    }
+    if (event === "error") {
+      this.errorCallback = callback as (error: Error) => void;
+    }
     return this;
   }
 
@@ -30,10 +49,18 @@ class FakeChild {
     return true;
   }
 
-  stdoutText(value: string): void { this.stdoutCallback?.(Buffer.from(value)); }
-  stderrText(value: string): void { this.stderrCallback?.(Buffer.from(value)); }
-  close(code: number | null): void { this.closeCallback?.(code); }
-  error(error: Error): void { this.errorCallback?.(error); }
+  stdoutText(value: string): void {
+    this.stdoutCallback?.(Buffer.from(value));
+  }
+  stderrText(value: string): void {
+    this.stderrCallback?.(Buffer.from(value));
+  }
+  close(code: number | null): void {
+    this.closeCallback?.(code);
+  }
+  error(error: Error): void {
+    this.errorCallback?.(error);
+  }
 }
 
 function createClient(overrides: Partial<ConstructorParameters<typeof SdkManagerClient>[0]> = {}) {
@@ -47,13 +74,15 @@ function createClient(overrides: Partial<ConstructorParameters<typeof SdkManager
     },
     existsSync: () => true,
     logger: { info: () => {}, warn: () => {}, error: () => {} },
-    detectAndroidCommandLineTools: async () => [{
-      path: "/sdk/cmdline-tools/latest",
-      source: "manual",
-      available_tools: ["sdkmanager"],
-    }],
+    detectAndroidCommandLineTools: async () => [
+      {
+        path: "/sdk/cmdline-tools/latest",
+        source: "manual",
+        available_tools: ["sdkmanager"],
+      },
+    ],
     getAndroidHomeWithSystemImages: () => null,
-    getBestAndroidToolsLocation: locations => locations[0] ?? null,
+    getBestAndroidToolsLocation: (locations) => locations[0] ?? null,
     validateRequiredTools: () => ({ valid: true, missing: [] }),
     timer,
     environment: {},
@@ -64,7 +93,7 @@ function createClient(overrides: Partial<ConstructorParameters<typeof SdkManager
 }
 
 async function settleSpawn(): Promise<void> {
-  await new Promise<void>(resolve => setImmediate(resolve));
+  await new Promise<void>((resolve) => setImmediate(resolve));
 }
 
 describe("SdkManagerClient", () => {
@@ -76,11 +105,13 @@ describe("SdkManagerClient", () => {
     child.close(0);
 
     await expect(pending).resolves.toMatchObject({ stdout: "Installed packages:\n", exitCode: 0 });
-    expect(spawns).toEqual([{
-      command: join("/sdk", "cmdline-tools", "latest", "bin", "sdkmanager"),
-      args: ["--list"],
-      options: expect.objectContaining({ shell: false }),
-    }]);
+    expect(spawns).toEqual([
+      {
+        command: join("/sdk", "cmdline-tools", "latest", "bin", "sdkmanager"),
+        args: ["--list"],
+        options: expect.objectContaining({ shell: false }),
+      },
+    ]);
   });
 
   test("reads the sdkmanager version through the same argv boundary", async () => {
@@ -97,7 +128,7 @@ describe("SdkManagerClient", () => {
 
   test("probes sdkmanager from a cmdline-tools-only bootstrap SDK", async () => {
     const { client, child, spawns } = createClient({
-      existsSync: path => {
+      existsSync: (path) => {
         const normalized = path.replaceAll("\\", "/");
         return normalized.endsWith("/sdkmanager") || normalized === "/sdk";
       },
@@ -108,31 +139,55 @@ describe("SdkManagerClient", () => {
     child.close(0);
 
     await expect(pending).resolves.toMatchObject({ stdout: "13.0\n", exitCode: 0 });
-    expect(spawns[0]?.command.replaceAll("\\", "/")).toBe("/sdk/cmdline-tools/latest/bin/sdkmanager");
+    expect(spawns[0]?.command.replaceAll("\\", "/")).toBe(
+      "/sdk/cmdline-tools/latest/bin/sdkmanager",
+    );
   });
 
   test("does not treat a failed sdkmanager probe diagnostic as a version", async () => {
-    await expect(readSdkManagerVersion({ getVersion: async () => ({ stdout: "", stderr: "Requires Java 17", exitCode: 1, outputTruncated: false }) })).resolves.toBeNull();
+    await expect(
+      readSdkManagerVersion({
+        getVersion: async () => ({
+          stdout: "",
+          stderr: "Requires Java 17",
+          exitCode: 1,
+          outputTruncated: false,
+        }),
+      }),
+    ).resolves.toBeNull();
   });
 
   test("parses the standalone sdkmanager version after warning output", async () => {
-    await expect(readSdkManagerVersion({ getVersion: async () => ({
-      stdout: "Warning: SDK XML version 3 is too old.\n13.0\n",
-      stderr: "",
-      exitCode: 0,
-      outputTruncated: false,
-    }) })).resolves.toBe("13.0");
+    await expect(
+      readSdkManagerVersion({
+        getVersion: async () => ({
+          stdout: "Warning: SDK XML version 3 is too old.\n13.0\n",
+          stderr: "",
+          exitCode: 0,
+          outputTruncated: false,
+        }),
+      }),
+    ).resolves.toBe("13.0");
   });
 
   test("passes the selected tools location to the version probe", async () => {
-    const location = { path: "/selected/cmdline-tools/latest", source: "manual" as const, available_tools: ["sdkmanager"] };
+    const location = {
+      path: "/selected/cmdline-tools/latest",
+      source: "manual" as const,
+      available_tools: ["sdkmanager"],
+    };
     let receivedLocation: unknown;
-    await expect(readSdkManagerVersion({
-      getVersion: async options => {
-        receivedLocation = options?.location;
-        return { stdout: "13.0\n", stderr: "", exitCode: 0, outputTruncated: false };
-      },
-    }, location)).resolves.toBe("13.0");
+    await expect(
+      readSdkManagerVersion(
+        {
+          getVersion: async (options) => {
+            receivedLocation = options?.location;
+            return { stdout: "13.0\n", stderr: "", exitCode: 0, outputTruncated: false };
+          },
+        },
+        location,
+      ),
+    ).resolves.toBe("13.0");
     expect(receivedLocation).toEqual(location);
   });
 
@@ -182,7 +237,7 @@ describe("SdkManagerClient", () => {
 
   test("executes a Windows batch sdkmanager through cmd without enabling a shell", async () => {
     const { client, child, spawns } = createClient({
-      existsSync: path => !/[\\/]sdkmanager$/.test(path),
+      existsSync: (path) => !/[\\/]sdkmanager$/.test(path),
       environment: { ComSpec: "C:/Windows/System32/cmd.exe" },
       platform: "win32",
     });
@@ -191,11 +246,19 @@ describe("SdkManagerClient", () => {
     child.close(0);
 
     await expect(pending).resolves.toMatchObject({ exitCode: 0 });
-    expect(spawns).toEqual([{
-      command: "C:/Windows/System32/cmd.exe",
-      args: ["/d", "/v:off", "/s", "/c", `""${join("/sdk", "cmdline-tools", "latest", "bin", "sdkmanager.bat")}" "--list""`],
-      options: expect.objectContaining({ shell: false }),
-    }]);
+    expect(spawns).toEqual([
+      {
+        command: "C:/Windows/System32/cmd.exe",
+        args: [
+          "/d",
+          "/v:off",
+          "/s",
+          "/c",
+          `""${join("/sdk", "cmdline-tools", "latest", "bin", "sdkmanager.bat")}" "--list""`,
+        ],
+        options: expect.objectContaining({ shell: false }),
+      },
+    ]);
   });
 
   test("keeps a package name as one argv element and supports opted-in license input", async () => {
@@ -274,17 +337,37 @@ describe("SdkManagerClient", () => {
     expect(stderr.includes("super-secret-value")).toBe(false);
   });
 
+  test("redacts the sdkmanager child home directory", async () => {
+    const { client, child } = createClient({
+      environment: { HOME: "/workspace/sdk-user" },
+    });
+    const pending = client.list();
+    await settleSpawn();
+    child.stderrText("/workspace/sdk-user/.android/repositories.cfg\n");
+    child.close(1);
+
+    await expect(pending).resolves.toMatchObject({
+      stderr: "~/.android/repositories.cfg\n",
+      exitCode: 1,
+    });
+  });
+
   test("explains the effective SDK root when Homebrew tools and Android home disagree", async () => {
     const warnings: string[] = [];
     const { client, child } = createClient({
-      logger: { info: () => {}, warn: message => warnings.push(message), error: () => {} },
+      logger: { info: () => {}, warn: (message) => warnings.push(message), error: () => {} },
       environment: { ANDROID_HOME: "/sdk" },
-      getAndroidHomeWithSystemImages: () => ({ androidHome: "/sdk", systemImagesPath: "/sdk/system-images" }),
-      detectAndroidCommandLineTools: async () => [{
-        path: "/opt/homebrew/share/android-commandlinetools",
-        source: "homebrew",
-        available_tools: ["sdkmanager"],
-      }],
+      getAndroidHomeWithSystemImages: () => ({
+        androidHome: "/sdk",
+        systemImagesPath: "/sdk/system-images",
+      }),
+      detectAndroidCommandLineTools: async () => [
+        {
+          path: "/opt/homebrew/share/android-commandlinetools",
+          source: "homebrew",
+          available_tools: ["sdkmanager"],
+        },
+      ],
     });
     const pending = client.list();
     await settleSpawn();

--- a/test/utils/android-cmdline-tools/redactAndroidCommandOutput.test.ts
+++ b/test/utils/android-cmdline-tools/redactAndroidCommandOutput.test.ts
@@ -1,5 +1,8 @@
 import { describe, expect, test } from "bun:test";
-import { redactAndroidCommandOutput } from "../../../src/utils/android-cmdline-tools/redactAndroidCommandOutput";
+import {
+  AndroidCommandOutputStreamRedactor,
+  redactAndroidCommandOutput,
+} from "../../../src/utils/android-cmdline-tools/redactAndroidCommandOutput";
 
 describe("redactAndroidCommandOutput", () => {
   test("redacts credential assignments and home-directory paths", () => {
@@ -11,5 +14,38 @@ describe("redactAndroidCommandOutput", () => {
     expect(output).toBe(
       "token=[REDACTED] password=[REDACTED] api_key=[REDACTED] ~/.android/avd/Pixel_9_Pro.avd",
     );
+  });
+
+  test("redacts quoted and prefixed credential assignments", () => {
+    const output = redactAndroidCommandOutput(
+      "access_token=\"secret value\" client_secret='another secret' auth.api-key=abc123",
+    );
+
+    expect(output).toBe("access_token=[REDACTED] client_secret=[REDACTED] auth.api-key=[REDACTED]");
+  });
+
+  test("preserves redaction across chunk and quoted-line boundaries", () => {
+    const redactor = new AndroidCommandOutputStreamRedactor();
+    const output = [
+      redactor.append('token="redaction'),
+      redactor.append('-canary\nsecret-tail" diagnostic'),
+      redactor.flush(),
+    ].join("");
+
+    expect(output).toBe("token=[REDACTED] diagnostic");
+    expect(output).not.toContain("redaction-canary");
+    expect(output).not.toContain("secret-tail");
+  });
+
+  test("preserves quoted escape state across chunk boundaries", () => {
+    const redactor = new AndroidCommandOutputStreamRedactor();
+    const output = [
+      redactor.append('token="value\\'),
+      redactor.append('"secret-tail" diagnostic'),
+      redactor.flush(),
+    ].join("");
+
+    expect(output).toBe("token=[REDACTED] diagnostic");
+    expect(output).not.toContain("secret-tail");
   });
 });

--- a/test/utils/android-cmdline-tools/redactAndroidCommandOutput.test.ts
+++ b/test/utils/android-cmdline-tools/redactAndroidCommandOutput.test.ts
@@ -1,0 +1,15 @@
+import { describe, expect, test } from "bun:test";
+import { redactAndroidCommandOutput } from "../../../src/utils/android-cmdline-tools/redactAndroidCommandOutput";
+
+describe("redactAndroidCommandOutput", () => {
+  test("redacts credential assignments and home-directory paths", () => {
+    const output = redactAndroidCommandOutput(
+      "token=super-secret password: hunter2 api_key=abc123 /Users/tester/.android/avd/Pixel_9_Pro.avd",
+      "/Users/tester",
+    );
+
+    expect(output).toBe(
+      "token=[REDACTED] password=[REDACTED] api_key=[REDACTED] ~/.android/avd/Pixel_9_Pro.avd",
+    );
+  });
+});


### PR DESCRIPTION
## Summary

Preserves bounded, redacted Android emulator launch diagnostics until the child process closes, so early failures no longer collapse to a bare exit code.

- Adds Linux categories for missing shared libraries, KVM permission denial, unavailable acceleration, and display initialization failures.
- Runs one short, injected `-accel-check` only for generic or provisional KVM failures, retaining output from both successful and nonzero probe executions.
- Extracts the Android command-output redactor for emulator diagnostics and existing `sdkmanager` output.

## Linked Issue

Closes [#5209](https://github.com/kaeawc/auto-mobile/issues/5209).

## Bug / Regression Context

- **Prior attempts:** None.
- **Observed symptom:** `startDevice` could return only `Emulator process exited with code: 1` before stderr finished draining, hiding linker and KVM policy failures.
- **Repro steps / conditions:** Start an Android emulator that exits early after writing a missing-library, KVM-permission, acceleration, or Qt/X11 failure to stderr.

## Validation

- [x] `bun run lint`
- [x] `bun run typecheck` reports no new errors (baseline gate)
- [x] `bun run turbo:validate` passes: 13,030 tests across 929 files; 13 intentional skips
- [x] Focused Android emulator diagnostics tests cover `exit`/`close` ordering, redaction/bounds, probe success/nonzero output, probe timeout, and successful launches without a probe
- [x] New code uses injected process execution and `FakeTimer`; unit tests do not launch a real emulator
- [x] No new direct dependency or Kotlin code
- [x] Branch starts from the latest `origin/main`

## Follow-ups

- [x] No follow-up issue is needed for this scoped diagnostic fix.
