### PR TITLE
Interactive video-pane device control + input/video latency work

### DIFF
--- a/android/desktop-app/src/main/kotlin/dev/jasonpearson/automobile/desktop/AutoMobileDesktopApp.kt
+++ b/android/desktop-app/src/main/kotlin/dev/jasonpearson/automobile/desktop/AutoMobileDesktopApp.kt
@@ -17,7 +17,9 @@ import androidx.compose.runtime.snapshotFlow
 import androidx.compose.ui.Modifier
 import dev.jasonpearson.automobile.desktop.core.connection.ConnectionState
 import dev.jasonpearson.automobile.desktop.core.daemon.AutoMobileClient
+import dev.jasonpearson.automobile.desktop.core.daemon.DaemonSocketPaths
 import dev.jasonpearson.automobile.desktop.core.daemon.DesktopDaemonSession
+import dev.jasonpearson.automobile.desktop.core.daemon.McpDaemonClient
 import dev.jasonpearson.automobile.desktop.core.di.LocalAutoMobileGraph
 import dev.jasonpearson.automobile.desktop.core.logging.LoggerFactory
 import dev.jasonpearson.automobile.desktop.core.mcp.DaemonMcpResourceClient
@@ -53,6 +55,7 @@ import dev.jasonpearson.automobile.desktop.core.workspace.picker.DevicePickerAct
 import dev.jasonpearson.automobile.desktop.core.workspace.picker.DevicePickerEffect
 import dev.jasonpearson.automobile.desktop.core.workspace.picker.DevicePickerViewModel
 import dev.jasonpearson.automobile.desktop.core.workspace.picker.RealDeviceBootController
+import dev.jasonpearson.automobile.desktop.core.workspace.rememberWorkspaceDeviceControl
 import dev.jasonpearson.automobile.desktop.core.workspace.wireName
 import dev.jasonpearson.automobile.desktop.theme.AutoMobileTheme
 import java.util.concurrent.atomic.AtomicLong
@@ -173,6 +176,18 @@ fun AutoMobileDesktopApp(
           .getOrNull()
       } else {
         null
+      }
+    }
+  // Per-tap client factory for workspace device control. The DeviceControlSession closes the client
+  // it mints per action, so this MUST return a fresh McpDaemonClient each call, never the shared
+  // graph.autoMobileClient. Non-Unix transports don't support device input, so they yield null and
+  // the pane stays a display-only mirror.
+  val workspaceControlClientProvider: () -> AutoMobileClient? =
+    remember(graph) {
+      if (graph.autoMobileClient.transportName == "Unix Socket") {
+        { McpDaemonClient(DaemonSocketPaths.socketPath()) }
+      } else {
+        { null }
       }
     }
   val sessionCleanupScope =
@@ -424,9 +439,31 @@ fun AutoMobileDesktopApp(
               // bind failed) the provider yields null and the pane shows the auth refusal, with
               // AUTOMOBILE_DAEMON_STREAM_AUTH=0 as the operator escape hatch.
               streamContent = { column ->
+                // Tap-to-control is armed ONLY for the FOCUSED pane on a Unix daemon.
+                //  - Unix: the other transports (MCP HTTP/STDIO) don't serve the direct `input/*`
+                //    helpers, so `workspaceControlClientProvider` yields null there and a tap could
+                //    never reach the device — arming would only pay for a High-fps stream + an
+                //    observation stream that drive nothing.
+                //  - Focused: only one pane is being driven at a time. Gating on focus keeps the
+                //    unfocused farm panes as cheap Low-fps mirrors (no per-pane observation stream)
+                //    and means only the focused pane requests Compose keyboard focus, so a second
+                //    pane arming can't silently steal keystrokes mid-type (#5217). Click a pane to
+                //    focus (and thus drive) it; the single-device case is always focused.
+                val controlActive =
+                  graph.autoMobileClient.transportName == "Unix Socket" &&
+                    (workspaceState as? WorkspaceUiState.Content)?.focusedDeviceId ==
+                      column.deviceId
+                val control =
+                  rememberWorkspaceDeviceControl(
+                    column = column,
+                    clientProvider = workspaceControlClientProvider,
+                    enabled = controlActive,
+                  )
                 DeviceStreamView(
                   column,
                   sessionUuidProvider = desktopDaemonSession?.sessionUuidProvider ?: { null },
+                  enableDeviceControl = controlActive,
+                  control = control,
                 )
               },
             )

--- a/android/desktop-core/src/main/kotlin/dev/jasonpearson/automobile/desktop/core/AutoMobileContent.kt
+++ b/android/desktop-core/src/main/kotlin/dev/jasonpearson/automobile/desktop/core/AutoMobileContent.kt
@@ -1882,8 +1882,8 @@ fun AutoMobileContent(
               // tap-then-swipe sequence reaches the device in the order the user made it. The
               // threshold and out-of-bounds rules live in the session's pure drag policy, not
               // here.
-              onControlSwipe = { snapshot, start, end ->
-                deviceControlSession.swipe(snapshot, start, end)
+              onControlSwipe = { snapshot, start, end, durationMs ->
+                deviceControlSession.swipe(snapshot, start, end, durationMs)
               },
               // Keyboard, text and device buttons (issue #3351) travel that SAME session too, so a
               // tap-then-type sequence reaches the device in order. The session answers whether it

--- a/android/desktop-core/src/main/kotlin/dev/jasonpearson/automobile/desktop/core/control/DeviceControlSession.kt
+++ b/android/desktop-core/src/main/kotlin/dev/jasonpearson/automobile/desktop/core/control/DeviceControlSession.kt
@@ -548,7 +548,12 @@ class DeviceControlSession(
    * ran off the frame is clamped by that policy rather than dropped. False is also returned when
    * the bounded queue is full, in which case an overload error has already been published.
    */
-  fun swipe(snapshot: DeviceFrameSnapshot, start: DevicePoint, end: DevicePoint): Boolean {
+  fun swipe(
+    snapshot: DeviceFrameSnapshot,
+    start: DevicePoint,
+    end: DevicePoint,
+    gestureDurationMs: Int? = null,
+  ): Boolean {
     if (!coordinatesAreStillDispatchable(snapshot)) return false
     val decision =
       DeviceDragGesturePolicy.evaluate(
@@ -560,6 +565,9 @@ class DeviceControlSession(
         // endpoints are in. Read from the clicked snapshot, never from current stream state.
         coordinateSpace = snapshot.coordinateSpace,
         nativeScale = snapshot.nativeScale,
+        // Replay the swipe at the speed the user flicked, so an inspector swipe flings like a real
+        // one; null (an older caller) keeps the fixed fallback duration.
+        gestureDurationMs = gestureDurationMs,
       )
     // Ignored is not a failure: it means the gesture was never a swipe. Nothing is sent, nothing is
     // surfaced, and the refresh tracker is left alone.

--- a/android/desktop-core/src/main/kotlin/dev/jasonpearson/automobile/desktop/core/layout/DeviceScreenView.kt
+++ b/android/desktop-core/src/main/kotlin/dev/jasonpearson/automobile/desktop/core/layout/DeviceScreenView.kt
@@ -237,7 +237,7 @@ private suspend fun PointerInputScope.deviceScreenDragGestures(
   controlMode: DeviceScreenControlMode,
   controlFrame: () -> Pair<DeviceFrameSnapshot, DeviceScreenGeometry>?,
   onPan: (Offset) -> Unit,
-  onSwipe: (DeviceFrameSnapshot, DevicePoint, DevicePoint) -> Unit,
+  onSwipe: (DeviceFrameSnapshot, DevicePoint, DevicePoint, Int) -> Unit,
 ) {
   awaitEachGesture {
     val down = awaitFirstDown(requireUnconsumed = false)
@@ -260,6 +260,10 @@ private suspend fun PointerInputScope.deviceScreenDragGestures(
     // it neither needs nor is affected by this delta.
     if (panning) onPan(overSlop)
     var lastPosition = change.position
+    // Track the pointer's own event timestamps so a swipe can be replayed at the speed the user
+    // flicked (issue: fling strength). `uptimeMillis` is the toolkit's monotonic event clock, so
+    // last-minus-down is the real gesture duration regardless of how many move events arrived.
+    var lastUptimeMs = change.uptimeMillis
     val completed =
       drag(change.id) { dragged ->
         // Read the delta BEFORE consuming: `positionChange()` reports Offset.Zero once the change
@@ -268,9 +272,11 @@ private suspend fun PointerInputScope.deviceScreenDragGestures(
         dragged.consume()
         if (panning) onPan(delta)
         lastPosition = dragged.position
+        lastUptimeMs = dragged.uptimeMillis
       }
     if (!completed || frame == null) return@awaitEachGesture
     val (snapshot, geometry) = frame
+    val gestureDurationMs = (lastUptimeMs - down.uptimeMillis).coerceAtLeast(0L).toInt()
     onSwipe(
       snapshot,
       DeviceScreenCoordinateMapper.viewportToDevice(
@@ -281,6 +287,7 @@ private suspend fun PointerInputScope.deviceScreenDragGestures(
         ViewportPoint(lastPosition.x, lastPosition.y),
         geometry,
       ),
+      gestureDurationMs,
     )
   }
 }
@@ -363,8 +370,12 @@ fun DeviceScreenView(
    * client shares the policy rather than reimplementing it. A null default makes control-mode drag
    * inert until a caller wires it; in inspector mode a drag still pans the viewport and this is
    * never called.
+   *
+   * The trailing `Int` is the gesture's duration in milliseconds (host pointer-down to release),
+   * which the caller feeds to the policy so the device swipe replays at the speed the user flicked
+   * — that is what makes a fast flick produce a strong fling rather than a fixed, gentle glide.
    */
-  onControlSwipe: ((DeviceFrameSnapshot, DevicePoint, DevicePoint) -> Unit)? = null,
+  onControlSwipe: ((DeviceFrameSnapshot, DevicePoint, DevicePoint, Int) -> Unit)? = null,
   /**
    * Called in [DeviceScreenControlMode.Control] for each key press this view receives **while it
    * holds keyboard focus**, with the snapshot the keystroke belongs to and the toolkit-free
@@ -815,8 +826,8 @@ fun DeviceScreenView(
                   offsetX += delta.x
                   offsetY += delta.y
                 },
-                onSwipe = { snapshot, start, end ->
-                  currentOnControlSwipe?.invoke(snapshot, start, end)
+                onSwipe = { snapshot, start, end, durationMs ->
+                  currentOnControlSwipe?.invoke(snapshot, start, end, durationMs)
                 },
               )
             }

--- a/android/desktop-core/src/main/kotlin/dev/jasonpearson/automobile/desktop/core/video/VideoStreamClient.kt
+++ b/android/desktop-core/src/main/kotlin/dev/jasonpearson/automobile/desktop/core/video/VideoStreamClient.kt
@@ -297,7 +297,8 @@ class VideoStreamClient(
       if (read <= 0) return
 
       parser.onBytes(
-        buffer.copyOf(read),
+        buffer,
+        read,
         onHeader = { header ->
           LOG.info("Live mirroring started (${header.width}x${header.height} advertised)")
         },

--- a/android/desktop-core/src/main/kotlin/dev/jasonpearson/automobile/desktop/core/video/VideoStreamParser.kt
+++ b/android/desktop-core/src/main/kotlin/dev/jasonpearson/automobile/desktop/core/video/VideoStreamParser.kt
@@ -79,22 +79,54 @@ class VideoStreamParser {
   private var headerSeen = false
 
   /**
-   * Feeds bytes, invoking [onHeader] once for the stream header and [onPacket] for each complete
-   * packet. Both may be called zero or many times per chunk.
+   * Feeds the first [length] bytes of [chunk], invoking [onHeader] once for the stream header and
+   * [onPacket] for each complete packet. Both may be called zero or many times per chunk.
+   *
+   * [length] lets a caller pass a reused read buffer without slicing it first (the reader fills a
+   * fixed 64KB buffer and only `read` bytes are valid). When there is no buffered remainder from a
+   * previous call — the common case, where a read lands on packet boundaries — this parses straight
+   * out of [chunk] and copies nothing but the per-packet payloads and any partial-packet tail. That
+   * removes two full-buffer copies per read on the 60fps hot path (the caller's slice and this
+   * parser's old `buffer + chunk` accumulation), which was steady heap churn feeding GC.
    */
   fun onBytes(
     chunk: ByteArray,
     onHeader: (VideoStreamHeader) -> Unit,
     onPacket: (VideoPacket) -> Unit,
+  ) = onBytes(chunk, chunk.size, onHeader, onPacket)
+
+  fun onBytes(
+    chunk: ByteArray,
+    length: Int,
+    onHeader: (VideoStreamHeader) -> Unit,
+    onPacket: (VideoPacket) -> Unit,
   ) {
-    if (chunk.isEmpty()) return
-    buffer = if (buffer.isEmpty()) chunk.copyOf() else buffer + chunk
+    if (length <= 0) return
+
+    // Parse source: the incoming bytes directly when nothing is buffered, otherwise the buffered
+    // remainder with the new bytes appended. `src` may be the caller's reused buffer, so every
+    // bound below is `srcLen` (valid bytes), never `src.size`.
+    val src: ByteArray
+    val srcLen: Int
+    if (buffer.isEmpty()) {
+      src = chunk
+      srcLen = length
+    } else {
+      src = ByteArray(buffer.size + length)
+      System.arraycopy(buffer, 0, src, 0, buffer.size)
+      System.arraycopy(chunk, 0, src, buffer.size, length)
+      srcLen = src.size
+      buffer = EMPTY
+    }
 
     var offset = 0
 
     if (!headerSeen) {
-      if (buffer.size - offset < STREAM_HEADER_BYTES) return
-      val view = ByteBuffer.wrap(buffer, offset, STREAM_HEADER_BYTES).order(ByteOrder.BIG_ENDIAN)
+      if (srcLen - offset < STREAM_HEADER_BYTES) {
+        buffer = src.copyOfRange(offset, srcLen)
+        return
+      }
+      val view = ByteBuffer.wrap(src, offset, STREAM_HEADER_BYTES).order(ByteOrder.BIG_ENDIAN)
       val codecId = view.int
       if (codecId != CODEC_ID_H264) {
         throw VideoStreamFormatException(
@@ -106,14 +138,14 @@ class VideoStreamParser {
       offset += STREAM_HEADER_BYTES
     }
 
-    while (buffer.size - offset >= PACKET_HEADER_BYTES) {
-      val view = ByteBuffer.wrap(buffer, offset, PACKET_HEADER_BYTES).order(ByteOrder.BIG_ENDIAN)
+    while (srcLen - offset >= PACKET_HEADER_BYTES) {
+      val view = ByteBuffer.wrap(src, offset, PACKET_HEADER_BYTES).order(ByteOrder.BIG_ENDIAN)
       val ptsAndFlags = view.long
       val size = view.int
       if (size < 0) {
         throw VideoStreamFormatException("Packet declares a negative length ($size)")
       }
-      if (buffer.size - offset - PACKET_HEADER_BYTES < size) {
+      if (srcLen - offset - PACKET_HEADER_BYTES < size) {
         // The payload has not fully arrived yet.
         break
       }
@@ -122,7 +154,7 @@ class VideoStreamParser {
       val isConfig = (ptsAndFlags and FLAG_CONFIG) != 0L
       onPacket(
         VideoPacket(
-          payload = buffer.copyOfRange(start, start + size),
+          payload = src.copyOfRange(start, start + size),
           // Bit 63 makes the int64 negative, so mask before reading the timestamp.
           presentationTimeUs = ptsAndFlags and PTS_MASK,
           isConfig = isConfig,
@@ -139,6 +171,11 @@ class VideoStreamParser {
       offset = start + size
     }
 
-    buffer = if (offset == 0) buffer else buffer.copyOfRange(offset, buffer.size)
+    // Keep only the unconsumed tail. Empty in the common case, so nothing is retained from `src`.
+    buffer = if (offset >= srcLen) EMPTY else src.copyOfRange(offset, srcLen)
+  }
+
+  private companion object {
+    val EMPTY = ByteArray(0)
   }
 }

--- a/android/desktop-core/src/main/kotlin/dev/jasonpearson/automobile/desktop/core/workspace/CrayonIcons.kt
+++ b/android/desktop-core/src/main/kotlin/dev/jasonpearson/automobile/desktop/core/workspace/CrayonIcons.kt
@@ -1,0 +1,421 @@
+package dev.jasonpearson.automobile.desktop.core.workspace
+
+import androidx.compose.foundation.Canvas
+import androidx.compose.runtime.Composable
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.geometry.Offset
+import androidx.compose.ui.graphics.Color
+import androidx.compose.ui.graphics.Path
+import androidx.compose.ui.graphics.StrokeCap
+import androidx.compose.ui.graphics.StrokeJoin
+import androidx.compose.ui.graphics.drawscope.DrawScope
+import androidx.compose.ui.graphics.drawscope.Stroke
+import kotlin.math.hypot
+
+/**
+ * The app's hand-drawn crayon/marker icon set — outline only, no fill. Every glyph is authored as a
+ * [Canvas] vector drawing (no raster assets) from gently *bowed* strokes (a line pushed off its
+ * midpoint) with round caps, so shapes read as marker-drawn rather than geometric. Bow directions
+ * are fixed, so a glyph looks identical frame to frame. Replaces the emoji glyphs across the
+ * workspace; [CrayonIcon] renders one at any size/tint.
+ */
+enum class CrayonGlyph {
+  Back,
+  Home,
+  Recent,
+  Power,
+  PointerTap, // Input mode
+  Inspect, // magnifier
+  Rotate,
+  Camera, // screenshot
+  Layers, // snapshot
+  Globe, // locale / network
+  More, // overflow dots
+  Unlock,
+  Android,
+  Apple,
+  Compass, // navigation
+  Document, // logs
+  Database, // storage
+  Flask, // test
+  Burst, // failures
+  Bolt, // performance
+  Close, // ✕
+  Shrink, // collapse pane
+  Diff, // open tool on all devices
+}
+
+/** The crayon glyph for each device-navigation button. */
+fun DeviceButton.crayon(): CrayonGlyph =
+  when (this) {
+    DeviceButton.Home -> CrayonGlyph.Home
+    DeviceButton.Back -> CrayonGlyph.Back
+    DeviceButton.Recent -> CrayonGlyph.Recent
+    DeviceButton.Power -> CrayonGlyph.Power
+  }
+
+/** The crayon glyph for each emulator control. */
+fun EmulatorControl.crayon(): CrayonGlyph =
+  when (this) {
+    EmulatorControl.Rotate -> CrayonGlyph.Rotate
+    EmulatorControl.Screenshot -> CrayonGlyph.Camera
+    EmulatorControl.Snapshot -> CrayonGlyph.Layers
+    EmulatorControl.Locale -> CrayonGlyph.Globe
+    EmulatorControl.More -> CrayonGlyph.More
+    EmulatorControl.Unlock -> CrayonGlyph.Unlock
+  }
+
+/** The crayon glyph for each facet tool. */
+fun Tool.crayon(): CrayonGlyph =
+  when (this) {
+    Tool.Navigation -> CrayonGlyph.Compass
+    Tool.Logs -> CrayonGlyph.Document
+    Tool.Storage -> CrayonGlyph.Database
+    Tool.Network -> CrayonGlyph.Globe
+    Tool.Test -> CrayonGlyph.Flask
+    Tool.Failures -> CrayonGlyph.Burst
+    Tool.Performance -> CrayonGlyph.Bolt
+  }
+
+/** The crayon glyph for each device platform. */
+fun Platform.crayon(): CrayonGlyph =
+  when (this) {
+    Platform.Android -> CrayonGlyph.Android
+    Platform.Ios -> CrayonGlyph.Apple
+  }
+
+@Composable
+fun CrayonIcon(glyph: CrayonGlyph, tint: Color, modifier: Modifier = Modifier) {
+  Canvas(modifier) {
+    val s = size.minDimension
+    val st = Stroke(width = s * 0.085f, cap = StrokeCap.Round, join = StrokeJoin.Round)
+    when (glyph) {
+      CrayonGlyph.Back -> drawBack(tint, st, s)
+      CrayonGlyph.Home -> drawHome(tint, st, s)
+      CrayonGlyph.Recent -> drawRecent(tint, st, s)
+      CrayonGlyph.Power -> drawPower(tint, st, s)
+      CrayonGlyph.PointerTap -> drawPointerTap(tint, st, s)
+      CrayonGlyph.Inspect -> drawInspect(tint, st, s)
+      CrayonGlyph.Rotate -> drawRotate(tint, st, s)
+      CrayonGlyph.Camera -> drawCamera(tint, st, s)
+      CrayonGlyph.Layers -> drawLayers(tint, st, s)
+      CrayonGlyph.Globe -> drawGlobe(tint, st, s)
+      CrayonGlyph.More -> drawMore(tint, st, s)
+      CrayonGlyph.Unlock -> drawUnlock(tint, st, s)
+      CrayonGlyph.Android -> drawAndroid(tint, st, s)
+      CrayonGlyph.Apple -> drawApple(tint, st, s)
+      CrayonGlyph.Compass -> drawCompass(tint, st, s)
+      CrayonGlyph.Document -> drawDocument(tint, st, s)
+      CrayonGlyph.Database -> drawDatabase(tint, st, s)
+      CrayonGlyph.Flask -> drawFlask(tint, st, s)
+      CrayonGlyph.Burst -> drawBurst(tint, st, s)
+      CrayonGlyph.Bolt -> drawBolt(tint, st, s)
+      CrayonGlyph.Close -> drawClose(tint, st, s)
+      CrayonGlyph.Shrink -> drawShrink(tint, st, s)
+      CrayonGlyph.Diff -> drawDiff(tint, st, s)
+    }
+  }
+}
+
+// --- drawing helpers -------------------------------------------------------------------------
+
+private fun p(s: Float, x: Float, y: Float) = Offset(x * s, y * s)
+
+/**
+ * A quadratic curve from [from] to [to] pushed [bow] perpendicular to its midpoint (hand-drawn).
+ */
+private fun bowed(from: Offset, to: Offset, bow: Float): Path {
+  val dx = to.x - from.x
+  val dy = to.y - from.y
+  val len = hypot(dx, dy).coerceAtLeast(0.0001f)
+  val nx = -dy / len
+  val ny = dx / len
+  val ctrl = Offset((from.x + to.x) / 2f + nx * bow, (from.y + to.y) / 2f + ny * bow)
+  return Path().apply {
+    moveTo(from.x, from.y)
+    quadraticTo(ctrl.x, ctrl.y, to.x, to.y)
+  }
+}
+
+private fun DrawScope.line(from: Offset, to: Offset, bow: Float, tint: Color, st: Stroke) {
+  drawPath(bowed(from, to, bow), tint, style = st)
+}
+
+/** A closed, slightly-wobbly ellipse from four bowed quarter-arcs, centered at [cx],[cy]. */
+private fun oval(cx: Float, cy: Float, rx: Float, ry: Float, bow: Float): Path {
+  val left = Offset(cx - rx, cy)
+  val top = Offset(cx, cy - ry)
+  val right = Offset(cx + rx, cy)
+  val bottom = Offset(cx, cy + ry)
+  return Path().apply {
+    addPath(bowed(top, right, -bow))
+    addPath(bowed(right, bottom, -bow))
+    addPath(bowed(bottom, left, -bow))
+    addPath(bowed(left, top, -bow))
+  }
+}
+
+private fun DrawScope.ring(cx: Float, cy: Float, rx: Float, ry: Float, tint: Color, st: Stroke) {
+  drawPath(oval(cx, cy, rx, ry, (rx + ry) * 0.06f), tint, style = st)
+}
+
+// --- glyphs ----------------------------------------------------------------------------------
+
+private fun DrawScope.drawBack(tint: Color, st: Stroke, s: Float) {
+  val w = s * 0.03f
+  line(p(s, 0.82f, 0.5f), p(s, 0.24f, 0.5f), w, tint, st)
+  line(p(s, 0.24f, 0.5f), p(s, 0.46f, 0.29f), w * 0.6f, tint, st)
+  line(p(s, 0.24f, 0.5f), p(s, 0.46f, 0.71f), -w * 0.6f, tint, st)
+}
+
+private fun DrawScope.drawHome(tint: Color, st: Stroke, s: Float) {
+  val w = s * 0.028f
+  line(p(s, 0.5f, 0.15f), p(s, 0.15f, 0.5f), w, tint, st)
+  line(p(s, 0.5f, 0.15f), p(s, 0.85f, 0.5f), -w, tint, st)
+  line(p(s, 0.25f, 0.46f), p(s, 0.25f, 0.83f), w * 0.7f, tint, st)
+  line(p(s, 0.75f, 0.46f), p(s, 0.75f, 0.83f), -w * 0.7f, tint, st)
+  line(p(s, 0.25f, 0.83f), p(s, 0.75f, 0.83f), w * 0.6f, tint, st)
+  line(p(s, 0.44f, 0.83f), p(s, 0.44f, 0.62f), -w * 0.4f, tint, st)
+  line(p(s, 0.44f, 0.62f), p(s, 0.56f, 0.62f), w * 0.4f, tint, st)
+  line(p(s, 0.56f, 0.62f), p(s, 0.56f, 0.83f), w * 0.4f, tint, st)
+}
+
+private fun DrawScope.drawRecent(tint: Color, st: Stroke, s: Float) {
+  val w = s * 0.035f
+  line(p(s, 0.26f, 0.24f), p(s, 0.74f, 0.24f), -w, tint, st)
+  line(p(s, 0.74f, 0.24f), p(s, 0.74f, 0.76f), -w, tint, st)
+  line(p(s, 0.74f, 0.76f), p(s, 0.26f, 0.76f), w, tint, st)
+  line(p(s, 0.26f, 0.76f), p(s, 0.26f, 0.24f), w, tint, st)
+}
+
+private fun DrawScope.drawPower(tint: Color, st: Stroke, s: Float) {
+  line(p(s, 0.5f, 0.18f), p(s, 0.5f, 0.5f), 0f, tint, st)
+  val w = s * 0.07f
+  line(p(s, 0.34f, 0.3f), p(s, 0.28f, 0.6f), w, tint, st)
+  line(p(s, 0.28f, 0.6f), p(s, 0.5f, 0.82f), w, tint, st)
+  line(p(s, 0.5f, 0.82f), p(s, 0.72f, 0.6f), w, tint, st)
+  line(p(s, 0.72f, 0.6f), p(s, 0.66f, 0.3f), w, tint, st)
+}
+
+private fun DrawScope.drawPointerTap(tint: Color, st: Stroke, s: Float) {
+  // A pointer/cursor arrow with two little tap ripples.
+  line(p(s, 0.34f, 0.24f), p(s, 0.34f, 0.66f), s * 0.02f, tint, st)
+  line(p(s, 0.34f, 0.24f), p(s, 0.62f, 0.52f), s * 0.02f, tint, st)
+  line(p(s, 0.62f, 0.52f), p(s, 0.44f, 0.55f), s * 0.01f, tint, st)
+  line(p(s, 0.44f, 0.55f), p(s, 0.34f, 0.66f), s * 0.01f, tint, st)
+  line(p(s, 0.68f, 0.24f), p(s, 0.78f, 0.2f), s * 0.02f, tint, st)
+  line(p(s, 0.7f, 0.36f), p(s, 0.82f, 0.34f), s * 0.02f, tint, st)
+}
+
+private fun DrawScope.drawInspect(tint: Color, st: Stroke, s: Float) {
+  ring(s * 0.44f, s * 0.44f, s * 0.22f, s * 0.22f, tint, st)
+  line(p(s, 0.6f, 0.6f), p(s, 0.82f, 0.82f), s * 0.02f, tint, st)
+}
+
+private fun DrawScope.drawRotate(tint: Color, st: Stroke, s: Float) {
+  // A ~3/4 circular arrow.
+  line(p(s, 0.72f, 0.3f), p(s, 0.3f, 0.28f), s * 0.16f, tint, st)
+  line(p(s, 0.3f, 0.28f), p(s, 0.28f, 0.72f), s * 0.16f, tint, st)
+  line(p(s, 0.28f, 0.72f), p(s, 0.6f, 0.78f), s * 0.14f, tint, st)
+  line(p(s, 0.72f, 0.3f), p(s, 0.58f, 0.2f), s * 0.02f, tint, st)
+  line(p(s, 0.72f, 0.3f), p(s, 0.82f, 0.18f), s * 0.02f, tint, st)
+}
+
+private fun DrawScope.drawCamera(tint: Color, st: Stroke, s: Float) {
+  line(p(s, 0.2f, 0.34f), p(s, 0.8f, 0.34f), -s * 0.02f, tint, st)
+  line(p(s, 0.8f, 0.34f), p(s, 0.8f, 0.74f), -s * 0.02f, tint, st)
+  line(p(s, 0.8f, 0.74f), p(s, 0.2f, 0.74f), s * 0.02f, tint, st)
+  line(p(s, 0.2f, 0.74f), p(s, 0.2f, 0.34f), s * 0.02f, tint, st)
+  line(p(s, 0.38f, 0.34f), p(s, 0.46f, 0.24f), s * 0.01f, tint, st)
+  line(p(s, 0.46f, 0.24f), p(s, 0.54f, 0.24f), s * 0.01f, tint, st)
+  line(p(s, 0.54f, 0.24f), p(s, 0.62f, 0.34f), s * 0.01f, tint, st)
+  ring(s * 0.5f, s * 0.54f, s * 0.13f, s * 0.13f, tint, st)
+}
+
+private fun DrawScope.drawLayers(tint: Color, st: Stroke, s: Float) {
+  val w = s * 0.02f
+  // two offset rounded cards
+  line(p(s, 0.32f, 0.24f), p(s, 0.78f, 0.24f), -w, tint, st)
+  line(p(s, 0.78f, 0.24f), p(s, 0.78f, 0.62f), -w, tint, st)
+  line(p(s, 0.22f, 0.4f), p(s, 0.22f, 0.78f), w, tint, st)
+  line(p(s, 0.22f, 0.78f), p(s, 0.68f, 0.78f), w, tint, st)
+  line(p(s, 0.68f, 0.78f), p(s, 0.68f, 0.4f), -w, tint, st)
+  line(p(s, 0.68f, 0.4f), p(s, 0.22f, 0.4f), -w, tint, st)
+}
+
+private fun DrawScope.drawGlobe(tint: Color, st: Stroke, s: Float) {
+  ring(s * 0.5f, s * 0.5f, s * 0.3f, s * 0.3f, tint, st)
+  line(p(s, 0.2f, 0.5f), p(s, 0.8f, 0.5f), 0f, tint, st)
+  line(p(s, 0.5f, 0.2f), p(s, 0.5f, 0.8f), 0f, tint, st)
+  line(p(s, 0.5f, 0.2f), p(s, 0.5f, 0.8f), s * 0.16f, tint, st)
+  line(p(s, 0.5f, 0.2f), p(s, 0.5f, 0.8f), -s * 0.16f, tint, st)
+}
+
+private fun DrawScope.drawMore(tint: Color, st: Stroke, s: Float) {
+  val dot = Stroke(width = s * 0.14f, cap = StrokeCap.Round)
+  drawPath(
+    Path().apply {
+      moveTo(s * 0.28f, s * 0.5f)
+      lineTo(s * 0.28f, s * 0.5f)
+    },
+    tint,
+    style = dot,
+  )
+  drawPath(
+    Path().apply {
+      moveTo(s * 0.5f, s * 0.5f)
+      lineTo(s * 0.5f, s * 0.5f)
+    },
+    tint,
+    style = dot,
+  )
+  drawPath(
+    Path().apply {
+      moveTo(s * 0.72f, s * 0.5f)
+      lineTo(s * 0.72f, s * 0.5f)
+    },
+    tint,
+    style = dot,
+  )
+}
+
+private fun DrawScope.drawUnlock(tint: Color, st: Stroke, s: Float) {
+  // body
+  line(p(s, 0.28f, 0.5f), p(s, 0.72f, 0.5f), -s * 0.015f, tint, st)
+  line(p(s, 0.72f, 0.5f), p(s, 0.72f, 0.82f), -s * 0.015f, tint, st)
+  line(p(s, 0.72f, 0.82f), p(s, 0.28f, 0.82f), s * 0.015f, tint, st)
+  line(p(s, 0.28f, 0.82f), p(s, 0.28f, 0.5f), s * 0.015f, tint, st)
+  // open shackle, swung to the left
+  line(p(s, 0.34f, 0.5f), p(s, 0.34f, 0.34f), s * 0.02f, tint, st)
+  line(p(s, 0.34f, 0.34f), p(s, 0.2f, 0.28f), s * 0.06f, tint, st)
+}
+
+private fun DrawScope.drawAndroid(tint: Color, st: Stroke, s: Float) {
+  // dome head + antennae + eyes
+  line(p(s, 0.28f, 0.56f), p(s, 0.28f, 0.44f), s * 0.02f, tint, st)
+  line(p(s, 0.28f, 0.44f), p(s, 0.72f, 0.44f), -s * 0.18f, tint, st) // dome
+  line(p(s, 0.72f, 0.44f), p(s, 0.72f, 0.56f), s * 0.02f, tint, st)
+  line(p(s, 0.28f, 0.56f), p(s, 0.72f, 0.56f), 0f, tint, st)
+  line(p(s, 0.34f, 0.34f), p(s, 0.4f, 0.42f), s * 0.005f, tint, st) // left antenna
+  line(p(s, 0.66f, 0.34f), p(s, 0.6f, 0.42f), s * 0.005f, tint, st) // right antenna
+  val eye = Stroke(width = s * 0.07f, cap = StrokeCap.Round)
+  drawPath(
+    Path().apply {
+      moveTo(s * 0.42f, s * 0.49f)
+      lineTo(s * 0.42f, s * 0.49f)
+    },
+    tint,
+    style = eye,
+  )
+  drawPath(
+    Path().apply {
+      moveTo(s * 0.58f, s * 0.49f)
+      lineTo(s * 0.58f, s * 0.49f)
+    },
+    tint,
+    style = eye,
+  )
+  // body
+  line(p(s, 0.3f, 0.58f), p(s, 0.3f, 0.76f), s * 0.015f, tint, st)
+  line(p(s, 0.3f, 0.76f), p(s, 0.7f, 0.76f), s * 0.015f, tint, st)
+  line(p(s, 0.7f, 0.76f), p(s, 0.7f, 0.58f), -s * 0.015f, tint, st)
+}
+
+private fun DrawScope.drawApple(tint: Color, st: Stroke, s: Float) {
+  // two lobes forming an apple silhouette
+  line(p(s, 0.5f, 0.34f), p(s, 0.28f, 0.5f), s * 0.1f, tint, st)
+  line(p(s, 0.28f, 0.5f), p(s, 0.42f, 0.8f), s * 0.1f, tint, st)
+  line(p(s, 0.42f, 0.8f), p(s, 0.5f, 0.72f), s * 0.03f, tint, st)
+  line(p(s, 0.5f, 0.34f), p(s, 0.72f, 0.5f), -s * 0.1f, tint, st)
+  line(p(s, 0.72f, 0.5f), p(s, 0.58f, 0.8f), -s * 0.1f, tint, st)
+  line(p(s, 0.58f, 0.8f), p(s, 0.5f, 0.72f), -s * 0.03f, tint, st)
+  line(p(s, 0.52f, 0.34f), p(s, 0.62f, 0.2f), s * 0.04f, tint, st) // leaf
+}
+
+private fun DrawScope.drawCompass(tint: Color, st: Stroke, s: Float) {
+  ring(s * 0.5f, s * 0.5f, s * 0.3f, s * 0.3f, tint, st)
+  // needle
+  line(p(s, 0.5f, 0.5f), p(s, 0.62f, 0.36f), s * 0.02f, tint, st)
+  line(p(s, 0.62f, 0.36f), p(s, 0.42f, 0.44f), s * 0.01f, tint, st)
+  line(p(s, 0.5f, 0.5f), p(s, 0.38f, 0.64f), s * 0.02f, tint, st)
+  line(p(s, 0.38f, 0.64f), p(s, 0.58f, 0.56f), s * 0.01f, tint, st)
+}
+
+private fun DrawScope.drawDocument(tint: Color, st: Stroke, s: Float) {
+  line(p(s, 0.3f, 0.2f), p(s, 0.62f, 0.2f), s * 0.01f, tint, st)
+  line(p(s, 0.62f, 0.2f), p(s, 0.72f, 0.32f), s * 0.01f, tint, st) // folded corner
+  line(p(s, 0.72f, 0.32f), p(s, 0.72f, 0.8f), -s * 0.015f, tint, st)
+  line(p(s, 0.72f, 0.8f), p(s, 0.3f, 0.8f), s * 0.015f, tint, st)
+  line(p(s, 0.3f, 0.8f), p(s, 0.3f, 0.2f), s * 0.015f, tint, st)
+  line(p(s, 0.4f, 0.44f), p(s, 0.62f, 0.44f), 0f, tint, st) // text lines
+  line(p(s, 0.4f, 0.56f), p(s, 0.62f, 0.56f), 0f, tint, st)
+  line(p(s, 0.4f, 0.68f), p(s, 0.56f, 0.68f), 0f, tint, st)
+}
+
+private fun DrawScope.drawDatabase(tint: Color, st: Stroke, s: Float) {
+  line(p(s, 0.28f, 0.3f), p(s, 0.72f, 0.3f), -s * 0.08f, tint, st) // top ellipse (front)
+  line(p(s, 0.72f, 0.3f), p(s, 0.28f, 0.3f), -s * 0.08f, tint, st) // top ellipse (back)
+  line(p(s, 0.28f, 0.3f), p(s, 0.28f, 0.7f), s * 0.015f, tint, st)
+  line(p(s, 0.72f, 0.3f), p(s, 0.72f, 0.7f), -s * 0.015f, tint, st)
+  line(p(s, 0.28f, 0.5f), p(s, 0.72f, 0.5f), -s * 0.06f, tint, st) // middle band
+  line(p(s, 0.28f, 0.7f), p(s, 0.72f, 0.7f), -s * 0.06f, tint, st) // bottom
+}
+
+private fun DrawScope.drawFlask(tint: Color, st: Stroke, s: Float) {
+  line(p(s, 0.42f, 0.2f), p(s, 0.42f, 0.44f), s * 0.005f, tint, st)
+  line(p(s, 0.58f, 0.2f), p(s, 0.58f, 0.44f), -s * 0.005f, tint, st)
+  line(p(s, 0.42f, 0.44f), p(s, 0.26f, 0.76f), s * 0.02f, tint, st)
+  line(p(s, 0.58f, 0.44f), p(s, 0.74f, 0.76f), -s * 0.02f, tint, st)
+  line(p(s, 0.26f, 0.76f), p(s, 0.74f, 0.76f), -s * 0.02f, tint, st)
+  line(p(s, 0.38f, 0.2f), p(s, 0.62f, 0.2f), 0f, tint, st) // lip
+  line(p(s, 0.34f, 0.64f), p(s, 0.66f, 0.64f), 0f, tint, st) // liquid line
+}
+
+private fun DrawScope.drawBurst(tint: Color, st: Stroke, s: Float) {
+  val c = Offset(s * 0.5f, s * 0.5f)
+  val spikes = listOf(0.0, 0.6, 1.2, 1.9, 2.5, 3.1, 3.8, 4.4, 5.0, 5.7)
+  spikes.forEach { a ->
+    val far =
+      Offset(
+        (c.x + kotlin.math.cos(a) * s * 0.3f).toFloat(),
+        (c.y + kotlin.math.sin(a) * s * 0.3f).toFloat(),
+      )
+    line(c, far, 0f, tint, st)
+  }
+}
+
+private fun DrawScope.drawClose(tint: Color, st: Stroke, s: Float) {
+  line(p(s, 0.28f, 0.28f), p(s, 0.72f, 0.72f), s * 0.02f, tint, st)
+  line(p(s, 0.72f, 0.28f), p(s, 0.28f, 0.72f), -s * 0.02f, tint, st)
+}
+
+private fun DrawScope.drawShrink(tint: Color, st: Stroke, s: Float) {
+  // Two corner brackets pulling inward.
+  line(p(s, 0.22f, 0.38f), p(s, 0.22f, 0.22f), s * 0.01f, tint, st)
+  line(p(s, 0.22f, 0.22f), p(s, 0.38f, 0.22f), s * 0.01f, tint, st)
+  line(p(s, 0.22f, 0.22f), p(s, 0.42f, 0.42f), s * 0.02f, tint, st)
+  line(p(s, 0.78f, 0.62f), p(s, 0.78f, 0.78f), s * 0.01f, tint, st)
+  line(p(s, 0.78f, 0.78f), p(s, 0.62f, 0.78f), s * 0.01f, tint, st)
+  line(p(s, 0.78f, 0.78f), p(s, 0.58f, 0.58f), s * 0.02f, tint, st)
+}
+
+private fun DrawScope.drawDiff(tint: Color, st: Stroke, s: Float) {
+  val w = s * 0.025f
+  // back card
+  line(p(s, 0.4f, 0.24f), p(s, 0.76f, 0.24f), -w, tint, st)
+  line(p(s, 0.76f, 0.24f), p(s, 0.76f, 0.6f), -w, tint, st)
+  // front card
+  line(p(s, 0.24f, 0.4f), p(s, 0.24f, 0.76f), w, tint, st)
+  line(p(s, 0.24f, 0.76f), p(s, 0.6f, 0.76f), w, tint, st)
+  line(p(s, 0.6f, 0.76f), p(s, 0.6f, 0.4f), -w, tint, st)
+  line(p(s, 0.6f, 0.4f), p(s, 0.24f, 0.4f), -w, tint, st)
+}
+
+private fun DrawScope.drawBolt(tint: Color, st: Stroke, s: Float) {
+  line(p(s, 0.58f, 0.18f), p(s, 0.36f, 0.52f), s * 0.015f, tint, st)
+  line(p(s, 0.36f, 0.52f), p(s, 0.52f, 0.52f), 0f, tint, st)
+  line(p(s, 0.52f, 0.52f), p(s, 0.44f, 0.84f), -s * 0.015f, tint, st)
+  line(p(s, 0.44f, 0.84f), p(s, 0.66f, 0.46f), s * 0.02f, tint, st)
+  line(p(s, 0.66f, 0.46f), p(s, 0.5f, 0.46f), 0f, tint, st)
+  line(p(s, 0.5f, 0.46f), p(s, 0.58f, 0.18f), s * 0.015f, tint, st)
+}

--- a/android/desktop-core/src/main/kotlin/dev/jasonpearson/automobile/desktop/core/workspace/DeviceStreamView.kt
+++ b/android/desktop-core/src/main/kotlin/dev/jasonpearson/automobile/desktop/core/workspace/DeviceStreamView.kt
@@ -12,6 +12,7 @@ import androidx.compose.material3.MaterialTheme
 import androidx.compose.material3.OutlinedButton
 import androidx.compose.material3.Text
 import androidx.compose.runtime.Composable
+import androidx.compose.runtime.LaunchedEffect
 import androidx.compose.runtime.collectAsState
 import androidx.compose.runtime.getValue
 import androidx.compose.runtime.mutableStateOf
@@ -22,6 +23,7 @@ import androidx.compose.ui.Modifier
 import androidx.compose.ui.layout.ContentScale
 import androidx.compose.ui.text.style.TextAlign
 import androidx.compose.ui.unit.dp
+import dev.jasonpearson.automobile.desktop.core.layout.DeviceScreenView
 import dev.jasonpearson.automobile.desktop.core.platform.MacScreenRecordingSettingsLauncher
 import dev.jasonpearson.automobile.desktop.core.platform.ScreenRecordingSettingsLauncher
 import dev.jasonpearson.automobile.desktop.core.rememberLiveVideoFrame
@@ -29,6 +31,7 @@ import dev.jasonpearson.automobile.desktop.core.video.VideoStreamClient
 import dev.jasonpearson.automobile.desktop.core.video.VideoStreamQuality
 import dev.jasonpearson.automobile.desktop.core.video.VideoStreamSource
 import dev.jasonpearson.automobile.desktop.core.video.VideoStreamState
+import dev.jasonpearson.automobile.desktop.domain.DeviceScreenControlMode
 
 /**
  * Live device mirror for a workspace pane's stream area: subscribes to the daemon's video-stream
@@ -49,71 +52,145 @@ import dev.jasonpearson.automobile.desktop.core.video.VideoStreamState
  *
  * [sourceFactory] is hoisted so tests inject a fake instead of opening a socket.
  */
-// Frame-rate hint for a workspace-pane live mirror. Low to keep the on-device H.264 encode cheap
-// (it
-// scales with fps); frames are decoupled from input dispatch (issue #3348), so this only bounds how
-// quickly a tap's visual result appears, not the tap itself.
-private const val PANE_MIRROR_FPS = 10
+// Frame-rate + quality hints the pane sends the relay on subscribe.
+//
+// An actively-CONTROLLED pane is one the user is driving, so it streams at [CONTROL_PANE_FPS] with
+// the High preset for the tightest, sharpest tap→visible-response. A display-only mirror instead
+// uses the cheap farm defaults — the Low preset (Android: long side ~540 + ~2 Mbps; a pane can't
+// show more pixels than that anyway, and decode cost scales with pixel count) and [MIRROR_PANE_FPS]
+// — which is what keeps dozens of concurrent farm panes affordable (#5217). Frames are decoupled
+// from input dispatch (issue #3348), so the mirror rate only bounds how quickly a tap's visual
+// result appears, never the tap itself. The relay validates the hint in [5, 60]; the first
+// subscriber's hint fixes the shared per-device encode.
+private const val CONTROL_PANE_FPS = 30
+private const val MIRROR_PANE_FPS = 10
 
 @Composable
 fun DeviceStreamView(
   column: DeviceColumn,
   sessionUuidProvider: () -> String? = { null },
-  // Workspace panes default to the `low` preset (Android: long side capped at 540 + ~2 Mbps;
-  // iOS: ~2 Mbps, resolution self-scales to Level 4.2): pane real estate can't show more pixels
-  // than that anyway, and decode cost scales with pixel count, which is what makes dozens of
-  // concurrent farm panes affordable. A low fps hint ([PANE_MIRROR_FPS]) further caps the device's
-  // H.264 encode load — its cost scales with frame rate, and device control is dispatched
-  // independently of frames (issue #3348), so a low mirror rate no longer adds input latency; it
-  // only delays the visual confirmation of a tap by at most one frame interval. Hoisted so a host
-  // that wants a full-resolution/high-rate mirror can pass VideoStreamQuality.High or a different
-  // source entirely.
+  // Device control (tap-to-input): when [control] is armed (a paired observation snapshot exists),
+  // the pane stays a live video mirror but becomes clickable — a click is mapped through the
+  // in-memory observation snapshot (device dims) and dispatched as a device tap with no
+  // frameContext. The video keeps playing; only the coordinate mapping uses the snapshot.
+  // Null/disabled ⇒ plain video mirror.
+  enableDeviceControl: Boolean = false,
+  control: WorkspaceDeviceControlState? = null,
+  // Hoisted so a host or test can pass a different quality/rate or a fake source entirely.
   sourceFactory: (deviceId: String) -> VideoStreamSource = {
-    VideoStreamClient(
-      quality = VideoStreamQuality.Low,
-      fps = PANE_MIRROR_FPS,
-      sessionUuidProvider = sessionUuidProvider,
-    )
+    if (enableDeviceControl) {
+      VideoStreamClient(
+        quality = VideoStreamQuality.High,
+        fps = CONTROL_PANE_FPS,
+        sessionUuidProvider = sessionUuidProvider,
+      )
+    } else {
+      VideoStreamClient(
+        quality = VideoStreamQuality.Low,
+        fps = MIRROR_PANE_FPS,
+        sessionUuidProvider = sessionUuidProvider,
+      )
+    }
   },
   screenRecordingSettingsLauncher: ScreenRecordingSettingsLauncher =
     MacScreenRecordingSettingsLauncher(),
 ) {
+  // The live video mirror always streams — it's what the user watches in both modes. Farm panes
+  // auto-reconnect so a dropped relay heals instead of staying "stopped" until the pane is torn
+  // down. Keyed on deviceId ONLY (not enableDeviceControl): the rate/quality preset is fixed at
+  // subscribe. Re-keying on control state to "downgrade" an unfocused pane doesn't reliably work —
+  // the daemon's per-device capture is shared and its encode is fixed by the FIRST subscriber's
+  // hint, so a fresh client that re-subscribes to a still-live capture has its new hint ignored
+  // (VideoStreamSocketServer.attach). Changing an armed pane's live rate needs server-side capture
+  // reconfiguration (follow-up); re-keying only added reconnect churn for no reliable effect.
   val source = remember(column.deviceId) { sourceFactory(column.deviceId) }
-  // Farm panes auto-reconnect: a dropped relay or a subscribe rejected while the workspace daemon
-  // session re-registers (e.g. after a daemon restart) heals itself instead of staying "stopped"
-  // until the pane is torn down.
   val liveFrame = rememberLiveVideoFrame(source, column.deviceId, autoReconnect = true)
   val state by source.state.collectAsState()
+  val controlSnapshot = control?.interactionSnapshot
   var settingsLaunchFailure by remember(column.deviceId) { mutableStateOf(false) }
-  Box(Modifier.fillMaxSize(), contentAlignment = Alignment.Center) {
-    val bitmap = liveFrame?.bitmap
-    if (bitmap != null) {
-      Image(
-        bitmap = bitmap,
-        contentDescription = "Live stream of ${column.name}",
-        modifier = Modifier.fillMaxSize(),
-        contentScale = ContentScale.Fit,
-      )
-    } else if (state is VideoStreamState.PermissionRequired) {
-      ScreenRecordingPermissionSurface(
-        approvalTarget = (state as VideoStreamState.PermissionRequired).approvalTarget,
-        settingsLaunchFailure = settingsLaunchFailure,
-        onOpenSettings = {
-          settingsLaunchFailure = screenRecordingSettingsLauncher.openScreenRecording().isFailure
-        },
-        onRetry = {
-          source.disconnect()
-          source.connect(column.deviceId)
-        },
-      )
-    } else {
-      Text(
-        streamStatusHint(state),
-        color = MaterialTheme.colorScheme.outline,
-        style = MaterialTheme.typography.bodySmall,
-        textAlign = TextAlign.Center,
-        modifier = Modifier.padding(12.dp),
-      )
+  // Perf span T3: mark each newly rendered video frame so the tracer can time the first frame after
+  // a tap (the visual-response latency). Cheap no-op unless a dispatched tap is pending.
+  LaunchedEffect(liveFrame?.sequence) {
+    if (liveFrame != null) control?.tracer?.videoFrameRendered(column.deviceId)
+  }
+  if (state is VideoStreamState.PermissionRequired) {
+    // iOS screen-recording permission gate: the relay refused the capture until the user approves
+    // Screen Recording, so there is NO live video to drive. Check this BEFORE the armed branch: on
+    // iOS the observation stream can still hand us a snapshot (arming the pane) while the video
+    // relay is refused, and taking the armed branch there would render a frozen fallback screenshot
+    // and swallow the approval UI, stranding the user with no way to recover. Android never reaches
+    // PermissionRequired (no screen-recording gate), so this reorder does not change its behavior.
+    ScreenRecordingPermissionSurface(
+      approvalTarget = (state as VideoStreamState.PermissionRequired).approvalTarget,
+      settingsLaunchFailure = settingsLaunchFailure,
+      onOpenSettings = {
+        settingsLaunchFailure = screenRecordingSettingsLauncher.openScreenRecording().isFailure
+      },
+      onRetry = {
+        source.disconnect()
+        source.connect(column.deviceId)
+      },
+    )
+  } else if (enableDeviceControl && controlSnapshot != null) {
+    // Armed: keep the SMOOTH LIVE VIDEO on screen, but map clicks through the in-memory
+    // observation
+    // snapshot (its real device dimensions + frameContext). The video and the observation
+    // screenshot
+    // are the same screen at the same aspect ratio, so a click normalized against the displayed
+    // video maps to the same device pixel. DeviceScreenView already renders a live bitmap while
+    // mapping through separate device dims — that's exactly its inspector-mode configuration,
+    // reused
+    // here with Control mode so the click dispatches instead of selecting an element.
+    val renderSnapshot = control.renderSnapshot
+    DeviceScreenView(
+      // Fallback pixels only until the first video frame decodes; liveFrame renders instead when
+      // set.
+      screenshotData = renderSnapshot?.screenshotData,
+      liveFrame = liveFrame?.bitmap,
+      screenWidth = renderSnapshot?.deviceWidth ?: 0,
+      screenHeight = renderSnapshot?.deviceHeight ?: 0,
+      rotation = renderSnapshot?.rotation ?: 0,
+      hierarchy = renderSnapshot?.hierarchy?.root,
+      selectedElementId = null,
+      hoveredElementId = null,
+      onElementSelected = {},
+      onElementHovered = {},
+      elementMap = renderSnapshot?.hierarchy?.elementMap?.takeIf { it.isNotEmpty() },
+      modifier = Modifier.fillMaxSize(),
+      controlMode = DeviceScreenControlMode.Control,
+      controlSnapshot = controlSnapshot,
+      // The view maps a click through `snapshot`'s geometry and hands back the device-mapped
+      // `point`; the dispatcher sends it to the daemon input/tap helper off the UI thread with NO
+      // frameContext, so it can never be rejected as stale (the wedge). Perf spans T0 (tap
+      // initiated) and the frame-age baseline (`capturedAtMs`) are stamped here, at the click.
+      onControlTap = { snapshot, point ->
+        control.tracer.tapInitiated(column.deviceId, snapshot.capturedAtMs)
+        control.dispatcher.tap(point)
+      },
+      onControlSwipe = { snapshot, start, end, durationMs ->
+        control.dispatcher.swipe(snapshot, start, end, durationMs)
+      },
+      onControlKey = { snapshot, stroke -> control.dispatcher.key(stroke) },
+    )
+  } else {
+    Box(Modifier.fillMaxSize(), contentAlignment = Alignment.Center) {
+      val bitmap = liveFrame?.bitmap
+      if (bitmap != null) {
+        Image(
+          bitmap = bitmap,
+          contentDescription = "Live stream of ${column.name}",
+          modifier = Modifier.fillMaxSize(),
+          contentScale = ContentScale.Fit,
+        )
+      } else {
+        Text(
+          streamStatusHint(state),
+          color = MaterialTheme.colorScheme.outline,
+          style = MaterialTheme.typography.bodySmall,
+          textAlign = TextAlign.Center,
+          modifier = Modifier.padding(12.dp),
+        )
+      }
     }
   }
 }

--- a/android/desktop-core/src/main/kotlin/dev/jasonpearson/automobile/desktop/core/workspace/EmulatorControlExecutor.kt
+++ b/android/desktop-core/src/main/kotlin/dev/jasonpearson/automobile/desktop/core/workspace/EmulatorControlExecutor.kt
@@ -1,6 +1,8 @@
 package dev.jasonpearson.automobile.desktop.core.workspace
 
+import dev.jasonpearson.automobile.desktop.core.MONOTONIC_NOW_MS
 import dev.jasonpearson.automobile.desktop.core.daemon.AutoMobileClient
+import dev.jasonpearson.automobile.desktop.core.daemon.McpConnectionException
 import dev.jasonpearson.automobile.desktop.core.logging.LoggerFactory
 import kotlinx.coroutines.CompletableDeferred
 import kotlinx.coroutines.CoroutineDispatcher
@@ -10,6 +12,10 @@ import kotlinx.serialization.json.buildJsonObject
 import kotlinx.serialization.json.put
 
 private val LOG = LoggerFactory.getLogger("EmulatorControlExecutor")
+
+// Matches [McpDaemonClient.transportName]; the only transport that serves the direct `input/*`
+// daemon helpers the fast button path uses.
+private const val UNIX_TRANSPORT_NAME = "Unix Socket"
 
 /**
  * Runs a device-mutating emulator control (Rotate, Snapshot, Unlock) against a real device. This is
@@ -126,16 +132,48 @@ class DaemonEmulatorControlExecutor(
   }
 
   override suspend fun pressButton(deviceId: String, platform: Platform, button: DeviceButton) {
-    withContext(ioDispatcher) {
-      val wire = platform.wireName()
-      client.setActiveDeviceChecked(deviceId, wire)
-      client.callToolChecked(
-        "pressButton",
-        buildJsonObject {
-          put("button", button.toolValue)
-          put("platform", wire)
-          put("deviceId", deviceId)
-        },
+    val wire = platform.wireName()
+    // Non-Unix transports (MCP HTTP/STDIO) don't implement the direct `input/*` daemon helpers, so
+    // the fast path below would always report `unsupportedInputAction`. Route those through the
+    // `pressButton` MCP tool instead — the transport-agnostic path the command bar used before the
+    // fast path landed — so Back/Home/Recent/Power keep working off a remote daemon.
+    if (client.transportName != UNIX_TRANSPORT_NAME) {
+      withContext(ioDispatcher) {
+        client.setActiveDeviceChecked(deviceId, wire)
+        client.callToolChecked(
+          "pressButton",
+          buildJsonObject {
+            put("button", button.toolValue)
+            put("platform", wire)
+            put("deviceId", deviceId)
+          },
+        )
+      }
+      return
+    }
+    // Unix fast path: single lightweight round-trip, matching the video-pane tap path.
+    // `input/pressButton` targets the deviceId directly, so the old `setActiveDeviceChecked`
+    // pre-call was redundant — and it was a whole extra (sometimes slow) daemon round-trip that
+    // dominated command-bar button latency. Dropping it and the heavier `pressButton` MCP-tool
+    // dispatch in favor of the direct `inputPressButton` wire method halves the round-trips.
+    val startMs = MONOTONIC_NOW_MS()
+    val result =
+      withContext(ioDispatcher) {
+        client.inputPressButton(
+          button = button.toolValue,
+          platform = wire,
+          deviceId = deviceId,
+          frameContext = null,
+        )
+      }
+    // Perf span for the command-bar path (previously unmeasured): click → daemon ack, including the
+    // dispatcher hop. Lets us compare button latency against the video-pane tap tracer.
+    LOG.info(
+      "button ${button.toolValue} $deviceId: dispatch=${MONOTONIC_NOW_MS() - startMs}ms success=${result.success}"
+    )
+    if (!result.success) {
+      throw McpConnectionException(
+        result.error ?: "input/pressButton failed for ${button.toolValue} on $deviceId"
       )
     }
   }

--- a/android/desktop-core/src/main/kotlin/dev/jasonpearson/automobile/desktop/core/workspace/InteractionLatencyTracer.kt
+++ b/android/desktop-core/src/main/kotlin/dev/jasonpearson/automobile/desktop/core/workspace/InteractionLatencyTracer.kt
@@ -1,0 +1,87 @@
+package dev.jasonpearson.automobile.desktop.core.workspace
+
+import dev.jasonpearson.automobile.desktop.core.MONOTONIC_NOW_MS
+import dev.jasonpearson.automobile.desktop.core.logging.LoggerFactory
+import java.util.concurrent.ConcurrentHashMap
+
+private val LOG = LoggerFactory.getLogger("InteractionLatency")
+
+/** The latency breakdown of one tap-to-visible-response interaction, all deltas in milliseconds. */
+data class InteractionLatency(
+  val deviceId: String,
+  /** How stale the mapped observation frame was when the user clicked (tap − frame-captured). */
+  val frameAgeMs: Long,
+  /** Click → the `input/tap` leaving for the daemon (dispatch queue + coordinate handoff). */
+  val queueMs: Long,
+  /** `input/tap` sent → daemon acknowledged it (daemon-side tap processing). */
+  val dispatchMs: Long,
+  /** Daemon ack → first video frame rendered after it (device react + encode + stream + decode). */
+  val visualMs: Long,
+  /** Click → first video frame after the tap; the user-perceived responsiveness. */
+  val totalMs: Long,
+) {
+  fun format(): String =
+    "tap→frame $deviceId: total=${totalMs}ms " +
+      "(frameAge=${frameAgeMs}, queue=${queueMs}, dispatch=${dispatchMs}, visual=${visualMs})"
+}
+
+/**
+ * Instruments the tap→map→dispatch→ack→first-frame loop of workspace device control so we can tune
+ * interaction latency. The workspace owns every seam this needs (the `onControlTap` callback, the
+ * per-action daemon client, the live-video frame source), so it measures the whole loop WITHOUT
+ * touching the shared [dev.jasonpearson.automobile.desktop.core.control.DeviceControlSession] or
+ * the Layout `DeviceScreenView`.
+ *
+ * One interaction per device is tracked at a time: taps dispatch in order and are effectively
+ * serial per pane, so a new tap replaces (and logs as incomplete) any prior unfinished one. A perf
+ * probe, not a correctness path — best-effort correlation is fine.
+ */
+// Monotonic clock to match the snapshot's `capturedAtMs` (also monotonic), so the frame-age delta
+// is
+// meaningful; monotonic also avoids wall-clock jumps skewing the sub-second interaction deltas.
+class InteractionLatencyTracer(private val nowMs: () -> Long = MONOTONIC_NOW_MS) {
+  private class Interaction(val frameCapturedMs: Long, val tapInitiatedMs: Long) {
+    var dispatchedMs: Long? = null
+    var ackedMs: Long? = null
+  }
+
+  private val current = ConcurrentHashMap<String, Interaction>()
+
+  /** The user clicked: [frameCapturedMs] is the mapped snapshot's `receivedAtMs`. */
+  fun tapInitiated(deviceId: String, frameCapturedMs: Long) {
+    current[deviceId] = Interaction(frameCapturedMs = frameCapturedMs, tapInitiatedMs = nowMs())
+  }
+
+  /** The `input/tap` is about to leave for the daemon. */
+  fun dispatching(deviceId: String) {
+    current[deviceId]?.let { if (it.dispatchedMs == null) it.dispatchedMs = nowMs() }
+  }
+
+  /** The daemon acknowledged the `input/tap`. */
+  fun acked(deviceId: String) {
+    current[deviceId]?.let { if (it.ackedMs == null) it.ackedMs = nowMs() }
+  }
+
+  /**
+   * A new live-video frame reached the screen. Completes the pending interaction with the first
+   * frame after dispatch; steady-state frames (no dispatched tap pending) are ignored cheaply.
+   */
+  fun videoFrameRendered(deviceId: String) {
+    val interaction = current[deviceId] ?: return
+    val dispatched = interaction.dispatchedMs ?: return
+    val rendered = nowMs()
+    current.remove(deviceId)
+    val acked = interaction.ackedMs ?: dispatched
+    LOG.info(
+      InteractionLatency(
+          deviceId = deviceId,
+          frameAgeMs = interaction.tapInitiatedMs - interaction.frameCapturedMs,
+          queueMs = dispatched - interaction.tapInitiatedMs,
+          dispatchMs = acked - dispatched,
+          visualMs = rendered - acked,
+          totalMs = rendered - interaction.tapInitiatedMs,
+        )
+        .format()
+    )
+  }
+}

--- a/android/desktop-core/src/main/kotlin/dev/jasonpearson/automobile/desktop/core/workspace/VideoInputDispatcher.kt
+++ b/android/desktop-core/src/main/kotlin/dev/jasonpearson/automobile/desktop/core/workspace/VideoInputDispatcher.kt
@@ -1,0 +1,384 @@
+package dev.jasonpearson.automobile.desktop.core.workspace
+
+import dev.jasonpearson.automobile.desktop.core.daemon.AutoMobileClient
+import dev.jasonpearson.automobile.desktop.core.daemon.InputActionResult
+import dev.jasonpearson.automobile.desktop.core.logging.LoggerFactory
+import dev.jasonpearson.automobile.desktop.domain.DeviceDragDecision
+import dev.jasonpearson.automobile.desktop.domain.DeviceDragGesturePolicy
+import dev.jasonpearson.automobile.desktop.domain.DeviceFrameSnapshot
+import dev.jasonpearson.automobile.desktop.domain.DeviceKeyStroke
+import dev.jasonpearson.automobile.desktop.domain.DeviceKeyboardDecision
+import dev.jasonpearson.automobile.desktop.domain.DeviceKeyboardInputPolicy
+import dev.jasonpearson.automobile.desktop.domain.DevicePoint
+import java.util.concurrent.ExecutorService
+import java.util.concurrent.Executors
+import java.util.concurrent.atomic.AtomicInteger
+import java.util.concurrent.atomic.AtomicLong
+import kotlinx.coroutines.CoroutineDispatcher
+import kotlinx.coroutines.CoroutineScope
+import kotlinx.coroutines.asCoroutineDispatcher
+import kotlinx.coroutines.delay
+import kotlinx.coroutines.job
+import kotlinx.coroutines.launch
+import kotlinx.coroutines.sync.Mutex
+import kotlinx.coroutines.sync.withLock
+
+private val LOG = LoggerFactory.getLogger("VideoInputDispatcher")
+
+/**
+ * Frame-identity-free input dispatch for the workspace VIDEO pane (the "disconnect the video frame
+ * from the input" path).
+ *
+ * The layout inspector routes taps through
+ * [dev.jasonpearson.automobile.desktop.core.control.DeviceControlSession], whose whole job is to
+ * keep the *clicked pixels coherent with the coordinate mapping*: it pairs a screenshot+hierarchy
+ * by capture identity, tracks coordinate-space/rotation flips, and sends each tap tagged with the
+ * snapshot's `frameContext` so the daemon can reject one mapped through a frame the device has
+ * already moved off of. That is exactly right when the user is clicking the observation screenshot.
+ *
+ * The video pane is different: the user clicks the **live H.264 video**, not the observation
+ * screenshot. The frame the tap was "mapped through" is not a capture the daemon can validate — it
+ * is just whatever video frame was on screen — so tagging the tap with an observation
+ * `frameContext` only invites a stale-context rejection. On a static screen the daemon dedupes
+ * hierarchy updates, that context ages, and the session disarms the pane ("one tap works, then it
+ * freezes"). This dispatcher removes that coupling: a tap needs only the device geometry to map
+ * through (supplied by a retained snapshot, purely for its width/height/rotation) and a client to
+ * send it. It sends with **no frameContext**, so the daemon never rejects it as stale, and the pane
+ * never wedges.
+ *
+ * Serialized through a fair [Mutex] so rapid taps reach the device in gesture order; each action
+ * uses a FRESH client, closed after the call, matching the daemon-action pattern elsewhere. The
+ * blocking daemon call runs on a DEDICATED, always-warm dispatch thread, never the UI thread.
+ *
+ * A tap must fire the instant it arrives. Dispatching onto the shared elastic [Dispatchers.IO] pool
+ * paid a thread-wakeup penalty — the pool parks its threads when idle, so a tap after a quiet
+ * moment waited ~a dozen ms just for a worker to un-park (this showed up as `queue` in the latency
+ * spans, while the socket round-trip itself measured ~0ms). A single daemon thread kept alive for
+ * the pane never parks, so the send starts immediately; being single-threaded it also serializes
+ * taps FIFO on its own, and the [Mutex] then only guards against a caller injecting a
+ * multi-threaded dispatcher.
+ *
+ * @param clientProvider mints a fresh [AutoMobileClient] per action (never the shared long-lived
+ *   client); null means nothing is connected and the action is dropped silently.
+ * @param platform daemon platform string for [deviceId] ("android" / "ios").
+ * @param tracer perf-span sink: [InteractionLatencyTracer.dispatching] is stamped at the actual
+ *   send (after the mutex wait and client mint, so those count as queue time, not dispatch time)
+ *   and [InteractionLatencyTracer.acked] when the daemon call returns.
+ * @param ioDispatcher test seam: inject a deterministic dispatcher. Null (production) owns a
+ *   dedicated single-thread executor, shut down when [scope] completes so panes don't leak threads.
+ */
+class VideoInputDispatcher(
+  private val scope: CoroutineScope,
+  private val clientProvider: () -> AutoMobileClient?,
+  private val platform: () -> String,
+  private val deviceId: String,
+  private val tracer: InteractionLatencyTracer,
+  ioDispatcher: CoroutineDispatcher? = null,
+) {
+  private val injectedDispatcher: CoroutineDispatcher? = ioDispatcher
+
+  // The warm dispatch thread is created LAZILY — on the first real dispatch, and only when no
+  // dispatcher was injected. A pane that is never driven (an unfocused farm pane whose control is
+  // gated off) therefore holds NO dispatch thread at all. [reset] retires it again when the pane
+  // deactivates, and pane disposal (scope completion) retires it for good. All access is on the
+  // Compose main thread (dispatch + reset), so the plain read-then-create needs no extra lock.
+  @Volatile private var ownedExecutor: ExecutorService? = null
+  @Volatile private var ownedDispatcher: CoroutineDispatcher? = null
+
+  init {
+    scope.coroutineContext.job.invokeOnCompletion { retireExecutor() }
+  }
+
+  private fun dispatchDispatcher(): CoroutineDispatcher {
+    injectedDispatcher?.let {
+      return it
+    }
+    ownedDispatcher?.let {
+      return it
+    }
+    val executor = Executors.newSingleThreadExecutor { runnable ->
+      Thread(runnable, "video-input-dispatch-$deviceId").apply { isDaemon = true }
+    }
+    val dispatcher = executor.asCoroutineDispatcher()
+    ownedExecutor = executor
+    ownedDispatcher = dispatcher
+    return dispatcher
+  }
+
+  private fun retireExecutor() {
+    // shutdown() (not shutdownNow) lets any queued coroutine drain — generation-stale ones drop.
+    ownedExecutor?.shutdown()
+    ownedExecutor = null
+    ownedDispatcher = null
+  }
+
+  // Fair mutex: suspended waiters acquire in suspension order, so serialized taps stay FIFO.
+  private val mutex = Mutex()
+
+  // Deactivation token. Each dispatch captures the current value; [reset] increments it. A
+  // coroutine
+  // whose captured generation no longer matches was queued before a reset and is DROPPED — even if
+  // a
+  // later reactivating input has since arrived. A per-dispatch token (not a shared flag a
+  // reactivation could clear out from under the stale work) is what makes `tap(old); reset();
+  // tap(new)` drop only `old`.
+  private val activeGeneration = AtomicLong(0L)
+
+  // Backlog bound. Each dispatch launches a coroutine that blocks on the mutex + daemon send; if
+  // the
+  // daemon stalls (or is mid-reconnect) those pile up, and on recovery a whole backlog of now-stale
+  // inputs would replay onto the device at once. Cap the in-flight+queued count and DROP once full:
+  // for best-effort live input a dropped tap during a stall is far better than a burst of stale
+  // ones
+  // firing seconds later. Generous enough that normal fast interaction never trips it.
+  private val pendingDispatches = AtomicInteger(0)
+
+  /**
+   * Send a tap at the device-mapped [point]. Returns true only when the tap was actually enqueued
+   * for dispatch. Out-of-bounds points are dropped (never tapped) and return false per the
+   * coordinate-mapping contract; a tap shed by a full dispatch backlog also returns false, so the
+   * caller withholds success feedback for a tap that never left.
+   */
+  fun tap(point: DevicePoint): Boolean {
+    if (!point.inBounds) return false
+    flushPendingText()
+    // Return the ENQUEUE result: false when the backlog shed this tap, so the pane withholds the
+    // success touch pulse for an input that never left (issue #3352 feedback contract).
+    return dispatch { client, platformName ->
+      client.inputTap(
+        x = point.x.toDouble(),
+        y = point.y.toDouble(),
+        platform = platformName,
+        deviceId = deviceId,
+        frameContext = null,
+      )
+    }
+  }
+
+  /**
+   * Send a drag from [start] to [end], both already mapped through [snapshot]'s geometry. The pure
+   * [DeviceDragGesturePolicy] decides whether the movement is a swipe at all (a sub-threshold
+   * jitter is not) and clamps an endpoint that ran off the frame; a non-swipe sends nothing.
+   * [gestureDurationMs] is how long the host flick took, which the policy turns into the swipe's
+   * velocity so a fast flick lands as a strong fling.
+   */
+  fun swipe(
+    snapshot: DeviceFrameSnapshot,
+    start: DevicePoint,
+    end: DevicePoint,
+    gestureDurationMs: Int,
+  ) {
+    val decision =
+      DeviceDragGesturePolicy.evaluate(
+        start = start,
+        end = end,
+        deviceWidth = snapshot.deviceWidth,
+        deviceHeight = snapshot.deviceHeight,
+        coordinateSpace = snapshot.coordinateSpace,
+        nativeScale = snapshot.nativeScale,
+        gestureDurationMs = gestureDurationMs,
+      )
+    if (decision !is DeviceDragDecision.Swipe) return
+    flushPendingText()
+    dispatch { client, platformName ->
+      client.inputSwipe(
+        startX = decision.start.x.toDouble(),
+        startY = decision.start.y.toDouble(),
+        endX = decision.end.x.toDouble(),
+        endY = decision.end.y.toDouble(),
+        platform = platformName,
+        deviceId = deviceId,
+        durationMs = decision.durationMs,
+        frameContext = null,
+      )
+    }
+  }
+
+  /**
+   * Forward [stroke] per the pure [DeviceKeyboardInputPolicy]: a device-meaningful key becomes one
+   * button/key press, a printable character one append-typed text, anything else nothing. Returns
+   * whether the caller should CONSUME the key (false lets an un-forwarded chord reach the host).
+   */
+  fun key(stroke: DeviceKeyStroke): Boolean {
+    when (val decision = DeviceKeyboardInputPolicy.evaluate(stroke = stroke)) {
+      is DeviceKeyboardDecision.PressButton -> {
+        flushPendingText()
+        dispatch { client, platformName ->
+          client.inputPressButton(
+            button = decision.button,
+            platform = platformName,
+            deviceId = deviceId,
+            frameContext = null,
+          )
+        }
+      }
+      is DeviceKeyboardDecision.SendKey -> {
+        flushPendingText()
+        dispatch { client, platformName ->
+          client.inputKey(
+            key = decision.key,
+            platform = platformName,
+            deviceId = deviceId,
+            frameContext = null,
+          )
+        }
+      }
+      // Printable characters are COALESCED, not sent one round-trip each. See [bufferText].
+      is DeviceKeyboardDecision.TypeText -> bufferText(decision.text)
+      is DeviceKeyboardDecision.Ignored -> return false
+    }
+    return true
+  }
+
+  // Coalesce printable typing. Each keystroke is otherwise its own daemon round-trip AND its own
+  // on-device `adb` append subprocess, so fast typing crawled and felt laggy. Buffer characters
+  // that
+  // arrive within a short window and send them as ONE `inputTypeText` — collapsing a burst's N
+  // round-trips (and the daemon's per-call injection overhead) to one. Any non-text input (a device
+  // key, tap, swipe, or button) flushes the pending text FIRST via [flushPendingText], so the
+  // device
+  // sees the exact order the user produced (typed text, THEN the key/tap).
+  private val textLock = Any()
+  private val pendingText = StringBuilder() // guarded by textLock
+  private var textFlushScheduled = false // guarded by textLock
+
+  private fun bufferText(text: String) {
+    synchronized(textLock) {
+      pendingText.append(text)
+      if (textFlushScheduled) return
+      textFlushScheduled = true
+    }
+    scope.launch {
+      delay(TEXT_FLUSH_WINDOW_MS)
+      flushPendingText()
+    }
+  }
+
+  private fun flushPendingText() {
+    val batch =
+      synchronized(textLock) {
+        textFlushScheduled = false
+        if (pendingText.isEmpty()) return
+        pendingText.toString().also { pendingText.setLength(0) }
+      }
+    dispatch { client, platformName ->
+      client.inputTypeText(
+        text = batch,
+        platform = platformName,
+        deviceId = deviceId,
+        // Always request append (real key events) rather than the daemon's default ACTION_SET_TEXT,
+        // which REPLACES the field — mirroring one keystroke at a time under SET_TEXT would leave
+        // only the last character and wipe existing text. This matches DeviceControlInputForwarder;
+        // the keyboard policy is the gate that refuses TypeText for a platform lacking append
+        // (issue #3351), so this call only fires where append is valid.
+        append = true,
+        frameContext = null,
+      )
+    }
+  }
+
+  /**
+   * Press a device/navigation button by its daemon name (Back/Home/Recent), frame-identity-free.
+   */
+  fun pressButton(button: String) {
+    flushPendingText()
+    dispatch { client, platformName ->
+      client.inputPressButton(
+        button = button,
+        platform = platformName,
+        deviceId = deviceId,
+        frameContext = null,
+      )
+    }
+  }
+
+  /**
+   * Deactivate the dispatcher when its pane loses focus/control. Drops queued and buffered input so
+   * a later state can't replay it at the no-longer-focused device, and retires the warm dispatch
+   * thread so an idle farm pane holds none. Fully reusable — the next input re-activates it and
+   * re-creates the thread on demand. Called on the Compose main thread (a focus-gate transition).
+   */
+  fun reset() {
+    activeGeneration.incrementAndGet()
+    synchronized(textLock) {
+      pendingText.setLength(0)
+      textFlushScheduled = false
+    }
+    retireExecutor()
+  }
+
+  /**
+   * Returns whether the input was ENQUEUED for dispatch. False means it was shed synchronously
+   * because the backlog is full — the caller must not report success (e.g. draw a touch pulse) for
+   * an input that never left. A true return is only the enqueue; an async provider-null or
+   * daemon-rejection is logged, not reflected in the return.
+   */
+  private inline fun dispatch(
+    crossinline send: (AutoMobileClient, String) -> InputActionResult
+  ): Boolean {
+    val platformName = platform()
+    // Capture the deactivation generation at enqueue; the coroutine drops if [reset] bumped it
+    // since
+    // (the next input after a reset re-creates the warm thread on demand via [dispatchDispatcher]).
+    val generation = activeGeneration.get()
+    // Shed load before launching once the backlog is full (see [pendingDispatches]).
+    if (pendingDispatches.incrementAndGet() > MAX_PENDING_DISPATCHES) {
+      pendingDispatches.decrementAndGet()
+      LOG.warn(
+        "dropping video input for $deviceId: dispatch backlog full ($MAX_PENDING_DISPATCHES)"
+      )
+      return false
+    }
+    // Launch DIRECTLY on the dedicated warm dispatch thread, not on [scope]'s (Compose Main,
+    // frame-aligned) dispatcher and not on the elastic IO pool. The blocking send runs off the UI
+    // thread and starts immediately — no frame-aligned hop, no IO-pool thread-wakeup penalty.
+    scope.launch(dispatchDispatcher()) {
+      try {
+        mutex.withLock {
+          // Deactivated (reset) after this was queued (pane lost focus): drop it rather than tap a
+          // device the user has moved away from — even if a later input has since reactivated us.
+          if (generation != activeGeneration.get()) return@withLock
+          val client = clientProvider() ?: return@withLock
+          // Stamp the dispatch span at the ACTUAL send, not at enqueue: the mutex wait and client
+          // mint belong to queueMs, and dispatchMs must isolate the daemon round-trip so the perf
+          // breakdown attributes latency to the right stage. A no-op unless a tap is pending.
+          tracer.dispatching(deviceId)
+          try {
+            val result = send(client, platformName)
+            if (result.success) {
+              // Only a send that actually succeeded is an ack: stamping this after a thrown or
+              // rejected send would record a failed round-trip as acknowledged and corrupt the
+              // latency breakdown.
+              tracer.acked(deviceId)
+            } else {
+              // The daemon accepted the request but reported the input failed (e.g. a transport
+              // that does not support direct input helpers). Surface it instead of silently
+              // treating it as delivered.
+              LOG.warn("video input rejected for $deviceId: ${result.error ?: result.action}")
+            }
+          } catch (error: Exception) {
+            // Best-effort input: a failed tap must never crash the pane. Log and drop — the video
+            // keeps streaming and the next tap is independent.
+            LOG.warn("video input dispatch failed for $deviceId", error)
+          } finally {
+            client.close()
+          }
+        }
+      } finally {
+        pendingDispatches.decrementAndGet()
+      }
+    }
+    return true
+  }
+
+  private companion object {
+    // Max in-flight + queued dispatches before new input is dropped rather than backlogged. Sized
+    // well above any burst a human produces so it only ever trips when the daemon has stalled.
+    const val MAX_PENDING_DISPATCHES = 64
+
+    // How long printable keystrokes are gathered before the batch is sent. Short enough that typed
+    // text still appears near-instantly (a burst lands within this window of the first key), long
+    // enough to fold a fast typist's run into a single round-trip.
+    const val TEXT_FLUSH_WINDOW_MS = 40L
+  }
+}

--- a/android/desktop-core/src/main/kotlin/dev/jasonpearson/automobile/desktop/core/workspace/WorkspaceDeviceControl.kt
+++ b/android/desktop-core/src/main/kotlin/dev/jasonpearson/automobile/desktop/core/workspace/WorkspaceDeviceControl.kt
@@ -1,0 +1,279 @@
+package dev.jasonpearson.automobile.desktop.core.workspace
+
+import androidx.compose.runtime.Composable
+import androidx.compose.runtime.LaunchedEffect
+import androidx.compose.runtime.getValue
+import androidx.compose.runtime.mutableStateOf
+import androidx.compose.runtime.remember
+import androidx.compose.runtime.rememberCoroutineScope
+import androidx.compose.runtime.rememberUpdatedState
+import androidx.compose.runtime.setValue
+import dev.jasonpearson.automobile.desktop.core.MONOTONIC_NOW_MS
+import dev.jasonpearson.automobile.desktop.core.control.DeviceControlSession
+import dev.jasonpearson.automobile.desktop.core.daemon.AutoMobileClient
+import dev.jasonpearson.automobile.desktop.core.daemon.ObservationStream
+import dev.jasonpearson.automobile.desktop.core.daemon.ObservationStreamClient
+import dev.jasonpearson.automobile.desktop.core.layout.LayoutInspectorState
+import dev.jasonpearson.automobile.desktop.core.layout.parseHierarchyFromJson
+import dev.jasonpearson.automobile.desktop.core.logging.LoggerFactory
+import dev.jasonpearson.automobile.desktop.core.rememberControlFreshnessTick
+import dev.jasonpearson.automobile.desktop.domain.ConnectionStatus
+import dev.jasonpearson.automobile.desktop.domain.DeviceControlInputs
+import dev.jasonpearson.automobile.desktop.domain.DeviceFrameSnapshot
+import kotlinx.coroutines.Dispatchers
+import kotlinx.coroutines.withContext
+
+private val LOG = LoggerFactory.getLogger("WorkspaceDeviceControl")
+
+// Ongoing paired-capture cadence requested while a pane's control is armed.
+//
+// This used to be ~1s: the OLD (frame-identity) control path needed a fresh paired
+// screenshot+hierarchy right after each input to keep the tap coordinates coherent. The decoupled
+// [VideoInputDispatcher] removed that — a tap is frame-identity-free and the device geometry it
+// maps
+// through is retained indefinitely — so fast ongoing observation is no longer needed to interact.
+// Arming itself is unaffected: the daemon pushes an INITIAL frame on subscribe
+// (`pushInitialObservationFramesForSubscriber`), so the pane still becomes clickable immediately.
+//
+// Keeping the fast cadence was costly: every tick pulls a full screenshot (tens of KB) and a
+// hierarchy over the same ADB pipe the H.264 video shares. On a USB-attached physical device that
+// steady traffic — worst during a high-motion moment like swipe-up-to-home, when the hierarchy also
+// churns — starves the video and shows up as playback lag. A much slower cadence frees that
+// bandwidth for the video; the only cost is that a device rotation (also attested by the video
+// stream) and any open Layout facet refresh less often, which is a fine trade for a control pane.
+private const val CONTROL_SCREENSHOT_INTERVAL_MS = 5_000L
+private const val CONTROL_HIERARCHY_INTERVAL_MS = 5_000L
+
+/**
+ * Per-column device-control holder for the workspace video pane.
+ *
+ * **Input is deliberately DECOUPLED from the video frame.** The observation stream (an
+ * [ObservationStreamClient] feeding a [LayoutInspectorState]) is used ONLY to learn the device
+ * *geometry* — width, height, rotation — which a click is mapped through. That geometry is a stable
+ * device property, so the last snapshot is retained INDEFINITELY: the pane stays armed and
+ * clickable forever once a first snapshot arrives, instead of disarming a few seconds after each
+ * tap when the daemon dedupes its (unchanged) hierarchy pushes.
+ *
+ * The tap itself does NOT flow through [DeviceControlSession]. That session exists to keep the
+ * *clicked observation pixels* coherent with the mapping — capture-identity pairing,
+ * coordinate-space tracking, and a `frameContext` tag the daemon can reject as stale. Here the user
+ * clicks the live **video**, not the observation screenshot, so none of that applies; tagging a
+ * video tap with an aging observation `frameContext` is precisely what froze the pane on a static
+ * screen. Taps go straight to [VideoInputDispatcher], which sends `input/tap` with no
+ * `frameContext` — the daemon never rejects it as stale, and the pane never wedges.
+ *
+ * [interactionSnapshot] is what a click maps through; [renderSnapshot] supplies the device
+ * dimensions the mapping fits against (they are the same retained snapshot here). [dispatcher]
+ * sends the mapped input.
+ */
+class WorkspaceDeviceControlState(
+  val dispatcher: VideoInputDispatcher,
+  val interactionSnapshot: DeviceFrameSnapshot?,
+  val renderSnapshot: DeviceFrameSnapshot?,
+  val tapError: String?,
+  /** Records tap→map→dispatch→ack→first-frame latency so we can tune interaction responsiveness. */
+  val tracer: InteractionLatencyTracer,
+)
+
+/**
+ * Builds the per-column control holder. [enabled] false leaves it inert (no observation stream, no
+ * snapshot) so the pane degrades to the plain video mirror. [streamFactory] is hoisted so tests
+ * inject a fake instead of opening a socket. [clientProvider] must mint a FRESH [AutoMobileClient]
+ * per call (the session closes each one after dispatch) — never the shared long-lived client.
+ */
+@Composable
+fun rememberWorkspaceDeviceControl(
+  column: DeviceColumn,
+  clientProvider: () -> AutoMobileClient?,
+  enabled: Boolean,
+  streamFactory: () -> ObservationStream = { ObservationStreamClient() },
+): WorkspaceDeviceControlState {
+  val scope = rememberCoroutineScope()
+  val layoutState = remember(column.deviceId) { LayoutInspectorState() }
+  var tapError by remember(column.deviceId) { mutableStateOf<String?>(null) }
+  val tracer = remember(column.deviceId) { InteractionLatencyTracer() }
+
+  // The provider swaps behind the long-lived holder (a daemon reconnect must not strand a queued
+  // input on a superseded client); it is read at dispatch time so the newest client is always used.
+  val controlClientProvider by rememberUpdatedState(clientProvider)
+
+  // The decoupled input path: a click on the video pane maps through the retained geometry snapshot
+  // and dispatches straight here, frame-identity-free (see [VideoInputDispatcher]). This is what
+  // makes input immune to the observation stream's dedup/staleness — the wedge the session caused.
+  val dispatcher =
+    remember(scope, column.deviceId) {
+      VideoInputDispatcher(
+        scope = scope,
+        clientProvider = { controlClientProvider.invoke() },
+        platform = { column.platform.wireName() },
+        deviceId = column.deviceId,
+        tracer = tracer,
+      )
+    }
+
+  // When the pane deactivates (loses focus, or the daemon can't serve input), retire the
+  // dispatcher:
+  // drop any queued/buffered input so it can't later fire at the no-longer-focused device, and free
+  // its warm dispatch thread instead of holding one per farm pane. Re-enabling re-activates it on
+  // the next input. `enabled` false on first composition is a no-op (nothing queued, no thread
+  // yet).
+  LaunchedEffect(dispatcher, enabled) { if (!enabled) dispatcher.reset() }
+
+  // The session is kept ONLY to turn the observation stream into a geometry snapshot
+  // ([session.renderSnapshot]); it never dispatches from the video pane, so its client/error hooks
+  // are inert. reset() on a provider swap keeps its snapshot state coherent across reconnects.
+  val session =
+    remember(scope, column.deviceId) {
+      DeviceControlSession(
+        scope = scope,
+        clientProvider = { controlClientProvider.invoke() },
+        platform = { column.platform.wireName() },
+        nowMs = MONOTONIC_NOW_MS,
+        publishError = { message -> tapError = message },
+      )
+    }
+  LaunchedEffect(clientProvider) { session.reset() }
+
+  val stream =
+    if (enabled)
+      rememberReconnectingObservationStream(
+        deviceId = column.deviceId,
+        streamFactory = streamFactory,
+      )
+    else null
+
+  // Request a fast paired capture cadence while control is armed. The daemon's default is too slow
+  // (~3s screenshots), so after a tap the retained snapshot ages out before a superseding pair
+  // arrives and control disarms — "one click works, then nothing". Mirrors the Live Layout cadence;
+  // setCadence is re-applied across reconnects by the client, and is a no-op when unchanged.
+  LaunchedEffect(stream, enabled) {
+    stream?.setCadence(
+      screenshotIntervalMs = if (enabled) CONTROL_SCREENSHOT_INTERVAL_MS else null,
+      hierarchyIntervalMs = if (enabled) CONTROL_HIERARCHY_INTERVAL_MS else null,
+    )
+  }
+
+  // Hierarchy collector — mirrors AutoMobileContent's Live Layout collector. The receipt-time hooks
+  // fire BEFORE the async parse so a scale/context flip invalidates control immediately; the frame
+  // generation is captured before the parse so a frame decoded across an invalidation is dropped.
+  LaunchedEffect(stream, column.deviceId) {
+    val active = stream ?: return@LaunchedEffect
+    active.resetLayoutReplayCache()
+    active.hierarchyUpdates.collect { update ->
+      if (update.deviceId != column.deviceId) return@collect
+      session.onObservationFrameContextDeclared(update.frameContext, update.captureSequence)
+      session.onObservationSpaceDeclared(
+        update.coordinateSpace,
+        update.captureSequence,
+        update.nativeScale,
+      )
+      val generation = layoutState.frameGeneration
+      update.data?.let { hierarchyJson ->
+        val result =
+          withContext(Dispatchers.Default) {
+            val parsed = parseHierarchyFromJson(hierarchyJson) ?: return@withContext null
+            val changed =
+              layoutState.computeChangedElements(layoutState.currentElementMap, parsed.elementMap)
+            parsed to changed
+          }
+        result?.let {
+          layoutState.updateConnectionStatus(ConnectionStatus.Connected)
+          layoutState.applyHierarchyUpdate(
+            it.first,
+            it.second,
+            deviceId = update.deviceId,
+            generation = generation,
+            captureSequence = update.captureSequence,
+            frameContext = update.frameContext,
+            coordinateSpace = update.coordinateSpace,
+            nativeScale = update.nativeScale,
+            captureRotation = update.rotation,
+          )
+        }
+      }
+    }
+  }
+
+  // Screenshot collector — same receipt-time gate + generation guard; decodes the base64 frame the
+  // control surface renders and maps clicks against.
+  LaunchedEffect(stream, column.deviceId) {
+    val active = stream ?: return@LaunchedEffect
+    active.resetLayoutReplayCache()
+    active.screenshotUpdates.collect { update ->
+      if (update.deviceId != column.deviceId) return@collect
+      session.onObservationFrameContextDeclared(update.frameContext, update.captureSequence)
+      session.onObservationSpaceDeclared(
+        update.coordinateSpace,
+        update.captureSequence,
+        update.nativeScale,
+      )
+      val generation = layoutState.frameGeneration
+      update.screenshotBase64?.let { base64 ->
+        val data = withContext(Dispatchers.Default) { java.util.Base64.getDecoder().decode(base64) }
+        layoutState.updateConnectionStatus(ConnectionStatus.Connected)
+        layoutState.updateScreenshot(
+          data = data,
+          width = update.screenWidth,
+          height = update.screenHeight,
+          timestamp = update.timestamp,
+          fallback = update.screenshotFallback ?: false,
+          fallbackReason = update.screenshotFallbackReason,
+          format = update.screenshotFormat,
+          captureSource = update.screenshotCaptureSource,
+          deviceId = update.deviceId,
+          generation = generation,
+          captureSequence = update.captureSequence,
+          frameContext = update.frameContext,
+          coordinateSpace = update.coordinateSpace,
+          nativeScale = update.nativeScale,
+          rotation = update.rotation,
+        )
+      }
+    }
+  }
+
+  // Re-evaluate on a slow ticker as well as on source updates: a stalled observation stream
+  // produces
+  // no updates, so its staleness is only visible as time passing.
+  rememberControlFreshnessTick(enabled)
+  session.evaluate(
+    DeviceControlInputs(
+      enabled = enabled,
+      realDeviceMode = true,
+      selectedDeviceId = column.deviceId,
+      transportSupportsInput = true,
+      observationStreamConnected = layoutState.connectionStatus == ConnectionStatus.Connected,
+      screenshot = layoutState.screenshotFacts,
+      hierarchy = layoutState.hierarchyFacts,
+      // WebRTC/video has no capture identity; control maps and renders the paired screenshot.
+      liveFrame = null,
+    )
+  )
+
+  // Geometry retention — the crux of the decoupling. Keep the last snapshot INDEFINITELY: device
+  // width/height/rotation is a stable property, not a per-frame capture identity, so a click can
+  // always be mapped through the most recent one and there is no freshness window to age out and
+  // disarm the pane. The daemon dedupes hierarchy_updates, so on a static screen no new pair
+  // arrives — under the old freshness gate the pane disarmed a few seconds after each tap ("one
+  // click works, then it freezes"). A real rotation DOES produce a fresh snapshot that overwrites
+  // this one, so the geometry self-heals; only the brief transient during a rotate is momentarily
+  // stale, which is vastly preferable to a hard input freeze.
+  val liveRender = session.renderSnapshot
+  val sticky = remember(column.deviceId) { mutableStateOf<DeviceFrameSnapshot?>(null) }
+  LaunchedEffect(liveRender) { if (liveRender != null) sticky.value = liveRender }
+  val geometry = liveRender ?: sticky.value
+
+  // Diagnostic: log arm/disarm transitions so a wedge is visible in the daemon-run log.
+  val armed = geometry != null
+  LaunchedEffect(column.deviceId, armed) {
+    LOG.info("device control ${if (armed) "ARMED" else "disarmed"} for ${column.deviceId}")
+  }
+
+  return WorkspaceDeviceControlState(
+    dispatcher = dispatcher,
+    interactionSnapshot = geometry,
+    renderSnapshot = geometry,
+    tapError = tapError,
+    tracer = tracer,
+  )
+}

--- a/android/desktop-core/src/main/kotlin/dev/jasonpearson/automobile/desktop/core/workspace/WorkspaceShell.kt
+++ b/android/desktop-core/src/main/kotlin/dev/jasonpearson/automobile/desktop/core/workspace/WorkspaceShell.kt
@@ -3,6 +3,8 @@ package dev.jasonpearson.automobile.desktop.core.workspace
 import androidx.compose.foundation.background
 import androidx.compose.foundation.border
 import androidx.compose.foundation.clickable
+import androidx.compose.foundation.gestures.awaitEachGesture
+import androidx.compose.foundation.gestures.awaitFirstDown
 import androidx.compose.foundation.interaction.MutableInteractionSource
 import androidx.compose.foundation.layout.Arrangement
 import androidx.compose.foundation.layout.Box
@@ -33,7 +35,10 @@ import androidx.compose.runtime.remember
 import androidx.compose.runtime.setValue
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
+import androidx.compose.ui.draw.clip
 import androidx.compose.ui.graphics.Color
+import androidx.compose.ui.input.pointer.PointerEventPass
+import androidx.compose.ui.input.pointer.pointerInput
 import androidx.compose.ui.semantics.contentDescription
 import androidx.compose.ui.semantics.semantics
 import androidx.compose.ui.text.font.FontWeight
@@ -559,10 +564,29 @@ private fun DeviceColumnView(
 ) {
   Column(
     modifier =
-      modifier.border(
-        width = if (focused) 2.dp else 1.dp,
-        color = if (focused) Accent else MaterialTheme.colorScheme.outlineVariant,
-      )
+      modifier
+        // Click anywhere in an UNFOCUSED pane to make it the focused (and thus interactive) device.
+        // Control is focus-gated — only the focused pane arms, streams High-fps, and takes keyboard
+        // focus — so without a way to move focus by clicking, every non-focused video pane would be
+        // a dead mirror (the command palette was the only focus setter). This is a two-step
+        // interaction by design: an unfocused pane renders the inert video mirror, so this focusing
+        // click only SWITCHES focus (it cannot actuate a device tap — the DeviceScreenView tap
+        // surface mounts once the pane is focused); the next click drives the device. Observed on
+        // the INITIAL pass and never consumed, so it doesn't swallow the pane's always-mounted
+        // controls (the command bar's Screenshot/nav buttons still fire on that same click). Gated
+        // on !focused so clicking the already-focused pane emits nothing.
+        .pointerInput(column.deviceId, focused) {
+          if (!focused) {
+            awaitEachGesture {
+              awaitFirstDown(requireUnconsumed = false, pass = PointerEventPass.Initial)
+              onAction(WorkspaceAction.FocusDevice(column.deviceId))
+            }
+          }
+        }
+        .border(
+          width = if (focused) 2.dp else 1.dp,
+          color = if (focused) Accent else MaterialTheme.colorScheme.outlineVariant,
+        )
   ) {
     DeviceColumnHeader(column, onAction)
     val tool = column.activeTool
@@ -695,11 +719,11 @@ private fun StreamArea(
     contentAlignment = Alignment.Center,
   ) {
     streamContent(column)
-    EmulatorControls(
+    DeviceCommandBar(
       column = column,
       onAction = onAction,
       onCaptureScreenshot = { captureRequest++ },
-      modifier = Modifier.align(Alignment.TopCenter).padding(6.dp),
+      modifier = Modifier.align(Alignment.CenterEnd).padding(6.dp),
     )
     val notice = savedNotice
     if (notice != null) {
@@ -803,41 +827,93 @@ fun WorkspaceStreamPlaceholder() {
  * pane as a confirmation) rather than being a fire-and-forget device mutation.
  */
 @Composable
-private fun EmulatorControls(
+private fun DeviceCommandBar(
   column: DeviceColumn,
   onAction: (WorkspaceAction) -> Unit,
   onCaptureScreenshot: () -> Unit,
   modifier: Modifier,
 ) {
-  Row(modifier, horizontalArrangement = Arrangement.spacedBy(4.dp)) {
-    // Unlock is gated on the pane's lock state; the rest always show. Rotate/Snapshot/Unlock are
-    // one-shot device calls; Screenshot captures to disk; Locale/More open menus.
+  Column(
+    modifier =
+      modifier
+        .clip(RoundedCornerShape(18.dp))
+        .background(Color.Black.copy(alpha = 0.32f))
+        .padding(4.dp),
+    verticalArrangement = Arrangement.spacedBy(2.dp),
+  ) {
+    // Device navigation: Back / Home / Recent.
+    listOf(DeviceButton.Back, DeviceButton.Home, DeviceButton.Recent)
+      .filter { it.isSupportedOn(column.platform, column.isVirtual) }
+      .forEach { button ->
+        CrayonButton(button.crayon(), "${button.label} ${column.name}") {
+          onAction(WorkspaceAction.PressDeviceButton(column.deviceId, button))
+        }
+      }
+    // Emulator controls: Unlock is gated on lock state; Screenshot captures to disk; Locale opens a
+    // picker; the rest are one-shot device calls. More is dropped — every device button is surfaced
+    // in this bar directly.
     EmulatorControl.entries
+      .filter { it != EmulatorControl.More }
       .filter { it != EmulatorControl.Unlock || column.locked }
       .filter { it.isSupportedOn(column.platform, column.isVirtual) }
       .forEach { control ->
         when (control) {
           EmulatorControl.Screenshot ->
-            Glyph(control.icon, "${control.label} ${column.name}", false, onCaptureScreenshot)
+            CrayonButton(
+              control.crayon(),
+              "${control.label} ${column.name}",
+              onClick = onCaptureScreenshot,
+            )
           EmulatorControl.Locale -> LocaleControl(column, onAction)
-          EmulatorControl.More -> MoreControl(column, onAction)
           else ->
-            Glyph(control.icon, "${control.label} ${column.name}", false) {
+            CrayonButton(control.crayon(), "${control.label} ${column.name}") {
               onAction(WorkspaceAction.RunControl(column.deviceId, control))
             }
         }
       }
+    // Power, at the foot of the bar.
+    if (DeviceButton.Power.isSupportedOn(column.platform, column.isVirtual)) {
+      CrayonButton(DeviceButton.Power.crayon(), "${DeviceButton.Power.label} ${column.name}") {
+        onAction(WorkspaceAction.PressDeviceButton(column.deviceId, DeviceButton.Power))
+      }
+    }
+  }
+}
+
+/** An outline crayon icon button for the device command bar — white glyph, no fill. */
+@Composable
+private fun CrayonButton(
+  glyph: CrayonGlyph,
+  description: String,
+  active: Boolean = false,
+  onClick: () -> Unit,
+) {
+  Box(
+    modifier =
+      Modifier.size(30.dp)
+        .clip(CircleShape)
+        .then(if (active) Modifier.background(Color.White.copy(alpha = 0.16f)) else Modifier)
+        .clickable(onClick = onClick)
+        .semantics { contentDescription = description }
+        .padding(6.dp),
+    contentAlignment = Alignment.Center,
+  ) {
+    CrayonIcon(glyph, tint = Color.White, modifier = Modifier.fillMaxSize())
   }
 }
 
 /**
- * 🌐 Locale control: a glyph that opens a dropdown of [COMMON_LOCALES]; a pick sets that locale.
+ * Locale control: a crayon globe that opens a dropdown of [COMMON_LOCALES]; a pick sets the locale.
  */
 @Composable
 private fun LocaleControl(column: DeviceColumn, onAction: (WorkspaceAction) -> Unit) {
   var open by remember { mutableStateOf(false) }
   Box {
-    Glyph(EmulatorControl.Locale.icon, "${EmulatorControl.Locale.label} ${column.name}", open) {
+    CrayonButton(
+      EmulatorControl.Locale.crayon(),
+      "${EmulatorControl.Locale.label} ${column.name}",
+      open,
+    ) {
       open = true
     }
     DropdownMenu(expanded = open, onDismissRequest = { open = false }) {
@@ -852,31 +928,6 @@ private fun LocaleControl(column: DeviceColumn, onAction: (WorkspaceAction) -> U
           },
         )
       }
-    }
-  }
-}
-
-/** ⋯ More control: a glyph that opens a dropdown of [DeviceButton]s; a pick presses that button. */
-@Composable
-private fun MoreControl(column: DeviceColumn, onAction: (WorkspaceAction) -> Unit) {
-  var open by remember { mutableStateOf(false) }
-  Box {
-    Glyph(EmulatorControl.More.icon, "${EmulatorControl.More.label} ${column.name}", open) {
-      open = true
-    }
-    DropdownMenu(expanded = open, onDismissRequest = { open = false }) {
-      DeviceButton.entries
-        .filter { it.isSupportedOn(column.platform, column.isVirtual) }
-        .forEach { button ->
-          DropdownMenuItem(
-            text = { Text("${button.icon}  ${button.label}") },
-            modifier = Modifier.semantics { contentDescription = "${button.label} ${column.name}" },
-            onClick = {
-              open = false
-              onAction(WorkspaceAction.PressDeviceButton(column.deviceId, button))
-            },
-          )
-        }
     }
   }
 }

--- a/android/desktop-core/src/test/kotlin/dev/jasonpearson/automobile/desktop/core/control/DeviceDragGesturePolicyTest.kt
+++ b/android/desktop-core/src/test/kotlin/dev/jasonpearson/automobile/desktop/core/control/DeviceDragGesturePolicyTest.kt
@@ -37,6 +37,41 @@ class DeviceDragGesturePolicyTest {
   }
 
   @Test
+  fun `a measured flick duration becomes the swipe duration (fling velocity)`() {
+    val swipe =
+      assertIs<DeviceDragDecision.Swipe>(
+        DeviceDragGesturePolicy.evaluate(
+          at(100, 200),
+          at(100, 1400),
+          width,
+          height,
+          gestureDurationMs = 80,
+        )
+      )
+    // A fast flick (80ms over a long distance) replays as a short, high-velocity swipe → strong
+    // fling, not the fixed fallback.
+    assertEquals(80, swipe.durationMs)
+  }
+
+  @Test
+  fun `a flick faster than the floor is clamped up, a drag slower than the ceiling clamped down`() {
+    fun durationFor(gesture: Int) =
+      assertIs<DeviceDragDecision.Swipe>(
+          DeviceDragGesturePolicy.evaluate(
+            at(100, 200),
+            at(100, 1400),
+            width,
+            height,
+            gestureDurationMs = gesture,
+          )
+        )
+        .durationMs
+
+    assertEquals(DeviceDragGesturePolicy.MIN_SWIPE_DURATION_MS, durationFor(1))
+    assertEquals(DeviceDragGesturePolicy.MAX_SWIPE_DURATION_MS, durationFor(100_000))
+  }
+
+  @Test
   fun `a drag shorter than the threshold sends nothing`() {
     val decision =
       evaluate(at(100, 200), at(100, 200 + DeviceDragGesturePolicy.MIN_SWIPE_DISTANCE - 1))

--- a/android/desktop-core/src/test/kotlin/dev/jasonpearson/automobile/desktop/core/layout/DeviceScreenViewControlTest.kt
+++ b/android/desktop-core/src/test/kotlin/dev/jasonpearson/automobile/desktop/core/layout/DeviceScreenViewControlTest.kt
@@ -137,7 +137,7 @@ class DeviceScreenViewControlTest {
     setContent {
       MaterialTheme {
         controlView(
-          onSwipe = { s, a, b -> swipes.add(Triple(s, a, b)) },
+          onSwipe = { s, a, b, _ -> swipes.add(Triple(s, a, b)) },
           onTap = { controlTaps.add(it) },
         )
       }
@@ -165,7 +165,7 @@ class DeviceScreenViewControlTest {
     setContent {
       MaterialTheme {
         controlView(
-          onSwipe = { s, a, b -> swipes.add(Triple(s, a, b)) },
+          onSwipe = { s, a, b, _ -> swipes.add(Triple(s, a, b)) },
           onTap = { controlTaps.add(it) },
         )
       }
@@ -207,7 +207,7 @@ class DeviceScreenViewControlTest {
             controlMode = DeviceScreenControlMode.Control,
             controlSnapshot = current,
             onControlTap = { _, _ -> true },
-            onControlSwipe = { s, a, b -> reported = Triple(s, a, b) },
+            onControlSwipe = { s, a, b, _ -> reported = Triple(s, a, b) },
           )
         }
       }
@@ -398,7 +398,7 @@ class DeviceScreenViewControlTest {
     var tapped: DevicePoint? = null
     runComposeUiTest {
       setContent {
-        MaterialTheme { controlView(onSwipe = { _, _, _ -> }, onTap = { tapped = it }) }
+        MaterialTheme { controlView(onSwipe = { _, _, _, _ -> }, onTap = { tapped = it }) }
       }
       onRoot().performTouchInput { click(at(this)) }
       waitForIdle()
@@ -413,7 +413,7 @@ class DeviceScreenViewControlTest {
     var start: DevicePoint? = null
     runComposeUiTest {
       setContent {
-        MaterialTheme { controlView(onSwipe = { _, a, _ -> start = a }, onTap = {}) }
+        MaterialTheme { controlView(onSwipe = { _, a, _, _ -> start = a }, onTap = {}) }
       }
       onRoot().performTouchInput { swipe(center + Offset(0f, 80f), center - Offset(0f, 80f)) }
       waitForIdle()
@@ -436,7 +436,7 @@ class DeviceScreenViewControlTest {
       MaterialTheme {
         controlView(
           mode = DeviceScreenControlMode.Inspector,
-          onSwipe = { s, a, b -> swipes.add(Triple(s, a, b)) },
+          onSwipe = { s, a, b, _ -> swipes.add(Triple(s, a, b)) },
           onTap = {},
         )
       }
@@ -453,7 +453,7 @@ class DeviceScreenViewControlTest {
   @Composable
   private fun controlView(
     mode: DeviceScreenControlMode = DeviceScreenControlMode.Control,
-    onSwipe: (DeviceFrameSnapshot, DevicePoint, DevicePoint) -> Unit,
+    onSwipe: (DeviceFrameSnapshot, DevicePoint, DevicePoint, Int) -> Unit,
     onTap: (DevicePoint) -> Unit,
   ) {
     DeviceScreenView(

--- a/android/desktop-core/src/test/kotlin/dev/jasonpearson/automobile/desktop/core/video/VideoStreamParserTest.kt
+++ b/android/desktop-core/src/test/kotlin/dev/jasonpearson/automobile/desktop/core/video/VideoStreamParserTest.kt
@@ -59,6 +59,39 @@ class VideoStreamParserTest {
   }
 
   @Test
+  fun `honors length and ignores stale bytes past it in a reused buffer`() {
+    // The reader hands its fixed 64KB buffer with only `read` bytes valid; the rest is last read's
+    // stale data. The parser must treat only the first `length` bytes as live.
+    val valid = streamHeader(720, 1280) + packet(byteArrayOf(9, 8, 7))
+    val reused = valid + ByteArray(64) { 0x5a } // trailing garbage that must never be parsed
+    val out = Collected()
+
+    VideoStreamParser().onBytes(reused, valid.size, out.headers::add, out.packets::add)
+
+    assertEquals(listOf(VideoStreamHeader(720, 1280)), out.headers)
+    assertEquals(1, out.packets.size)
+    assertContentEquals(byteArrayOf(9, 8, 7), out.packets[0].payload)
+  }
+
+  @Test
+  fun `a partial packet within length is buffered and completed on the next feed`() {
+    val parser = VideoStreamParser()
+    val whole = streamHeader() + packet(byteArrayOf(1, 2, 3, 4))
+    val out = Collected()
+    // First feed carries the header plus only part of the packet (valid length stops mid-payload);
+    // the trailing bytes of the reused buffer are the rest but must be ignored until fed as live.
+    val firstValid = whole.size - 2
+    parser.onBytes(whole, firstValid, out.headers::add, out.packets::add)
+    assertEquals(1, out.headers.size)
+    assertTrue(out.packets.isEmpty())
+
+    // Feed the final 2 bytes as their own live chunk; the buffered remainder completes the packet.
+    parser.onBytes(whole.copyOfRange(firstValid, whole.size), 2, out.headers::add, out.packets::add)
+    assertEquals(1, out.packets.size)
+    assertContentEquals(byteArrayOf(1, 2, 3, 4), out.packets[0].payload)
+  }
+
+  @Test
   fun `reads the stream header then packets`() {
     val out =
       feed(

--- a/android/desktop-core/src/test/kotlin/dev/jasonpearson/automobile/desktop/core/workspace/DaemonEmulatorControlExecutorTest.kt
+++ b/android/desktop-core/src/test/kotlin/dev/jasonpearson/automobile/desktop/core/workspace/DaemonEmulatorControlExecutorTest.kt
@@ -1,5 +1,6 @@
 package dev.jasonpearson.automobile.desktop.core.workspace
 
+import dev.jasonpearson.automobile.desktop.core.daemon.InputActionResult
 import dev.jasonpearson.automobile.desktop.core.daemon.McpConnectionException
 import dev.jasonpearson.automobile.desktop.core.testing.FakeAutoMobileClient
 import kotlinx.coroutines.ExperimentalCoroutinesApi
@@ -9,6 +10,7 @@ import kotlinx.serialization.json.JsonElement
 import kotlinx.serialization.json.buildJsonObject
 import kotlinx.serialization.json.put
 import org.junit.Assert.assertEquals
+import org.junit.Assert.assertNull
 import org.junit.Assert.assertTrue
 import org.junit.Assert.fail
 import org.junit.Test
@@ -167,10 +169,31 @@ class DaemonEmulatorControlExecutorTest {
   }
 
   @Test
-  fun `pressButton sets the active device then calls pressButton`() = runTest {
-    val client = FakeAutoMobileClient()
+  fun `pressButton sends a single inputPressButton without setActiveDevice`() = runTest {
+    // The fast path is Unix-transport only (the direct input/* helpers live there).
+    val client = FakeAutoMobileClient().apply { transportName = "Unix Socket" }
     executor(client).pressButton("emulator-5554", Platform.Android, DeviceButton.Home)
 
+    // The fast path: no setActiveDevice pre-call, no heavier pressButton MCP tool — one direct
+    // input/pressButton round-trip, exactly like the video-pane tap path.
+    assertTrue("setActiveDevice" !in client.calls)
+    assertTrue(client.toolCalls.none { it.name == "pressButton" })
+    val call = client.inputPressButtonCalls.single()
+    assertEquals("home", call.button)
+    assertEquals("android", call.platform)
+    assertEquals("emulator-5554", call.deviceId)
+    assertNull(call.frameContext)
+  }
+
+  @Test
+  fun `a non-Unix transport routes pressButton through the pressButton MCP tool`() = runTest {
+    // MCP HTTP/STDIO transports don't serve the direct input/* helpers, so the command bar must
+    // fall back to the transport-agnostic pressButton tool (its pre-fast-path behavior) instead of
+    // failing every button. transportName != "Unix Socket" selects the fallback.
+    val client = FakeAutoMobileClient().apply { transportName = "MCP HTTP" }
+    executor(client).pressButton("emulator-5554", Platform.Android, DeviceButton.Home)
+
+    assertTrue(client.inputPressButtonCalls.isEmpty())
     assertEquals("setActiveDevice", client.calls.first())
     assertTrue(
       client.toolCalls.any {
@@ -186,13 +209,14 @@ class DaemonEmulatorControlExecutorTest {
   }
 
   @Test
-  fun `tool-level failure is propagated from pressButton`() = runTest {
+  fun `an input-pressButton failure is propagated`() = runTest {
     val client =
       FakeAutoMobileClient().apply {
-        callToolResult =
-          toolResponse(
+        transportName = "Unix Socket"
+        inputPressButtonResult =
+          InputActionResult(
+            action = "input/pressButton",
             success = false,
-            message = "Pressed button home",
             error = "Unsupported button",
           )
       }
@@ -200,7 +224,7 @@ class DaemonEmulatorControlExecutorTest {
     var failureMessage: String? = null
     try {
       executor(client).pressButton("emulator-5554", Platform.Android, DeviceButton.Home)
-      fail("Expected tool failure")
+      fail("Expected input failure")
     } catch (error: McpConnectionException) {
       failureMessage = error.message
     }
@@ -285,12 +309,15 @@ class DaemonEmulatorControlExecutorTest {
           )
       }
 
+    // run() controls still bind the active device first; a bind failure must block the tool call.
+    // (pressButton no longer sets the active device — it targets deviceId directly.)
     try {
-      executor(client).pressButton("emulator-5554", Platform.Android, DeviceButton.Home)
+      executor(client)
+        .run("emulator-5554", Platform.Android, EmulatorControl.Rotate, Orientation.Landscape)
       fail("Expected active-device failure")
     } catch (error: McpConnectionException) {
       assertEquals("Device is unavailable", error.message)
-      assertTrue(client.toolCalls.none { it.name == "pressButton" })
+      assertTrue(client.toolCalls.none { it.name == "rotate" })
     }
   }
 

--- a/android/desktop-core/src/test/kotlin/dev/jasonpearson/automobile/desktop/core/workspace/DeviceStreamViewTest.kt
+++ b/android/desktop-core/src/test/kotlin/dev/jasonpearson/automobile/desktop/core/workspace/DeviceStreamViewTest.kt
@@ -11,9 +11,13 @@ import androidx.compose.ui.test.onNodeWithContentDescription
 import androidx.compose.ui.test.onNodeWithText
 import androidx.compose.ui.test.performClick
 import androidx.compose.ui.test.runComposeUiTest
+import dev.jasonpearson.automobile.desktop.core.control.testSnapshot
 import dev.jasonpearson.automobile.desktop.core.platform.ScreenRecordingSettingsLauncher
 import dev.jasonpearson.automobile.desktop.core.video.FakeVideoStreamSource
 import dev.jasonpearson.automobile.desktop.core.video.VideoStreamState
+import kotlinx.coroutines.CoroutineScope
+import kotlinx.coroutines.Dispatchers
+import kotlinx.coroutines.cancel
 import org.junit.Assert.assertEquals
 import org.junit.Assert.assertNull
 import org.junit.Test
@@ -95,6 +99,45 @@ class DeviceStreamViewTest {
       val connectsBeforeRetry = source.connectCalls
       onNodeWithText("Check again").performClick()
       waitUntil { source.connectCalls > connectsBeforeRetry }
+    }
+
+  @Test
+  fun `an armed iOS pane still surfaces Screen Recording approval over the control view`() =
+    runComposeUiTest {
+      // Regression: a refused iOS relay (PermissionRequired) must win even when device control is
+      // armed. On iOS the observation stream can hand the pane a snapshot (arming it) while the
+      // video relay is still refused; taking the armed branch there rendered a frozen fallback
+      // screenshot and hid the approval UI, stranding the user with no way to recover (#5221).
+      val source = FakeVideoStreamSource(screenRecordingRequired = true)
+      val scope = CoroutineScope(Dispatchers.Unconfined)
+      val control =
+        WorkspaceDeviceControlState(
+          dispatcher =
+            VideoInputDispatcher(
+              scope = scope,
+              clientProvider = { null },
+              platform = { "ios" },
+              deviceId = "ios-simulator",
+              tracer = InteractionLatencyTracer(),
+            ),
+          interactionSnapshot = testSnapshot(), // armed
+          renderSnapshot = testSnapshot(),
+          tapError = null,
+          tracer = InteractionLatencyTracer(),
+        )
+      setContent {
+        MaterialTheme {
+          DeviceStreamView(
+            iosCol(),
+            enableDeviceControl = true,
+            control = control,
+            sourceFactory = { source },
+          )
+        }
+      }
+
+      onNodeWithText("Screen Recording needs approval").assertIsDisplayed()
+      scope.cancel()
     }
 
   @Test

--- a/android/desktop-core/src/test/kotlin/dev/jasonpearson/automobile/desktop/core/workspace/VideoInputDispatcherTest.kt
+++ b/android/desktop-core/src/test/kotlin/dev/jasonpearson/automobile/desktop/core/workspace/VideoInputDispatcherTest.kt
@@ -1,0 +1,281 @@
+package dev.jasonpearson.automobile.desktop.core.workspace
+
+import dev.jasonpearson.automobile.desktop.core.control.testSnapshot
+import dev.jasonpearson.automobile.desktop.core.testing.FakeAutoMobileClient
+import dev.jasonpearson.automobile.desktop.domain.DeviceKeyModifiers
+import dev.jasonpearson.automobile.desktop.domain.DeviceKeyStroke
+import dev.jasonpearson.automobile.desktop.domain.DevicePoint
+import kotlin.test.Test
+import kotlin.test.assertEquals
+import kotlin.test.assertFalse
+import kotlin.test.assertNull
+import kotlin.test.assertTrue
+import kotlinx.coroutines.CoroutineScope
+import kotlinx.coroutines.ExperimentalCoroutinesApi
+import kotlinx.coroutines.cancel
+import kotlinx.coroutines.test.StandardTestDispatcher
+import kotlinx.coroutines.test.TestCoroutineScheduler
+import kotlinx.coroutines.test.UnconfinedTestDispatcher
+import kotlinx.coroutines.test.advanceUntilIdle
+import kotlinx.coroutines.test.runTest
+
+/**
+ * The frame-identity-free input path for the workspace video pane (issue: "disconnect the video
+ * frame from the input").
+ *
+ * The single property every test pins is that inputs carry **no `frameContext`** — that is what
+ * stops the daemon from ever rejecting a video-pane tap as stale, which was the wedge. Everything
+ * is injected (client, scope, IO dispatcher) so these run with no device, socket or timer.
+ */
+@OptIn(ExperimentalCoroutinesApi::class)
+class VideoInputDispatcherTest {
+
+  private val inBounds = DevicePoint(x = 360, y = 780, inBounds = true)
+  private val outOfBounds = DevicePoint(x = -1, y = -1, inBounds = false)
+
+  private fun CoroutineScope.dispatcher(
+    client: FakeAutoMobileClient,
+    scheduler: TestCoroutineScheduler,
+    platform: String = "android",
+    deviceId: String = "emulator-5554",
+  ) =
+    VideoInputDispatcher(
+      scope = this,
+      clientProvider = { client },
+      platform = { platform },
+      deviceId = deviceId,
+      tracer = InteractionLatencyTracer(),
+      ioDispatcher = UnconfinedTestDispatcher(scheduler),
+    )
+
+  @Test
+  fun `a tap sends input tap with NO frame context and a fresh client is closed`() = runTest {
+    val scope = CoroutineScope(UnconfinedTestDispatcher(testScheduler))
+    val client = FakeAutoMobileClient()
+    val accepted = scope.dispatcher(client, testScheduler).tap(inBounds)
+    advanceUntilIdle()
+
+    assertTrue(accepted)
+    val call = client.inputTapCalls.single()
+    assertEquals(360.0, call.x)
+    assertEquals(780.0, call.y)
+    assertEquals("emulator-5554", call.deviceId)
+    assertEquals("android", call.platform)
+    // The decoupling: a video-pane tap carries no observation frame identity, so the daemon can
+    // never reject it as "stale frame context" — the pane cannot wedge.
+    assertNull(call.frameContext)
+    assertTrue("close" in client.calls)
+    scope.cancel()
+  }
+
+  @Test
+  fun `drops input once the dispatch backlog is full`() = runTest {
+    // A StandardTestDispatcher queues each launch without running it, so flooding taps piles up the
+    // in-flight backlog exactly as a stalled (or mid-reconnect) daemon would. Past the cap the
+    // newest taps are shed rather than queued, so a recovery can't replay a burst of stale inputs.
+    val scope = CoroutineScope(UnconfinedTestDispatcher(testScheduler))
+    val client = FakeAutoMobileClient()
+    val d =
+      VideoInputDispatcher(
+        scope = scope,
+        clientProvider = { client },
+        platform = { "android" },
+        deviceId = "emulator-5554",
+        tracer = InteractionLatencyTracer(),
+        ioDispatcher = StandardTestDispatcher(testScheduler),
+      )
+    val results = (0 until 100).map { d.tap(DevicePoint(x = it, y = it, inBounds = true)) }
+    advanceUntilIdle()
+
+    // MAX_PENDING_DISPATCHES = 64: the first 64 dispatches are accepted, the remaining 36 dropped.
+    assertEquals(64, client.inputTapCalls.size)
+    // The shed taps report false SYNCHRONOUSLY so the pane withholds their success touch pulse.
+    assertTrue(results.take(64).all { it })
+    assertTrue(results.drop(64).none { it })
+    scope.cancel()
+  }
+
+  @Test
+  fun `reset drops input queued before it even when reactivated before the queue drains`() =
+    runTest {
+      // tap(old); reset(); tap(new) with NO drain between reset and the reactivating tap (both taps
+      // still queued on the StandardTest dispatcher). A shared quiesced flag would be cleared by
+      // tap(new), letting the pre-reset taps replay; a per-dispatch generation drops them
+      // regardless
+      // (#5221 review). The reactivating tap must still reach the device.
+      val scope = CoroutineScope(UnconfinedTestDispatcher(testScheduler))
+      val client = FakeAutoMobileClient()
+      val d =
+        VideoInputDispatcher(
+          scope = scope,
+          clientProvider = { client },
+          platform = { "android" },
+          deviceId = "emulator-5554",
+          tracer = InteractionLatencyTracer(),
+          ioDispatcher = StandardTestDispatcher(testScheduler),
+        )
+      d.tap(DevicePoint(x = 1, y = 1, inBounds = true))
+      d.tap(DevicePoint(x = 2, y = 2, inBounds = true))
+      d.reset() // pane deactivated
+      d.tap(DevicePoint(x = 3, y = 3, inBounds = true)) // reactivated before the queue drains
+      advanceUntilIdle()
+
+      // Only the post-reset tap reaches the device; the two pre-reset taps are dropped.
+      assertEquals(listOf(3.0), client.inputTapCalls.map { it.x })
+      scope.cancel()
+    }
+
+  @Test
+  fun `an out-of-bounds tap dispatches nothing and returns false`() = runTest {
+    val scope = CoroutineScope(UnconfinedTestDispatcher(testScheduler))
+    val client = FakeAutoMobileClient()
+    val accepted = scope.dispatcher(client, testScheduler).tap(outOfBounds)
+    advanceUntilIdle()
+
+    assertFalse(accepted)
+    assertTrue(client.inputTapCalls.isEmpty())
+    scope.cancel()
+  }
+
+  @Test
+  fun `rapid taps reach the device in gesture order`() = runTest {
+    val scope = CoroutineScope(UnconfinedTestDispatcher(testScheduler))
+    val client = FakeAutoMobileClient()
+    val d = scope.dispatcher(client, testScheduler)
+    d.tap(DevicePoint(x = 1, y = 1, inBounds = true))
+    d.tap(DevicePoint(x = 2, y = 2, inBounds = true))
+    d.tap(DevicePoint(x = 3, y = 3, inBounds = true))
+    advanceUntilIdle()
+
+    assertEquals(listOf(1.0, 2.0, 3.0), client.inputTapCalls.map { it.x })
+    scope.cancel()
+  }
+
+  @Test
+  fun `a printable character types text in append mode with no frame context`() = runTest {
+    val scope = CoroutineScope(UnconfinedTestDispatcher(testScheduler))
+    val client = FakeAutoMobileClient()
+    val consumed = scope.dispatcher(client, testScheduler).key(DeviceKeyStroke(character = 'a'))
+    advanceUntilIdle()
+
+    assertTrue(consumed)
+    val call = client.inputTypeTextCalls.single()
+    assertEquals("a", call.text)
+    assertTrue(call.append)
+    assertNull(call.frameContext)
+    scope.cancel()
+  }
+
+  @Test
+  fun `append mode is requested regardless of platform`() = runTest {
+    // append=true must NOT be branched on platform: the daemon's default ACTION_SET_TEXT REPLACES
+    // the field, so mirroring keystrokes one at a time without append would leave only the last
+    // character. The keyboard policy — not this dispatcher — is the gate for a platform lacking
+    // append (#3351), so the call always requests it. Mirrors DeviceControlInputForwarder.
+    val scope = CoroutineScope(UnconfinedTestDispatcher(testScheduler))
+    val client = FakeAutoMobileClient()
+    scope.dispatcher(client, testScheduler, platform = "ios").key(DeviceKeyStroke(character = 'a'))
+    advanceUntilIdle()
+
+    assertTrue(client.inputTypeTextCalls.single().append)
+    scope.cancel()
+  }
+
+  @Test
+  fun `rapid printable characters coalesce into a single typeText`() = runTest {
+    val scope = CoroutineScope(UnconfinedTestDispatcher(testScheduler))
+    val client = FakeAutoMobileClient()
+    val d = scope.dispatcher(client, testScheduler)
+    // A fast run of keys within the flush window is one round-trip, not five.
+    "hello".forEach { d.key(DeviceKeyStroke(character = it)) }
+    advanceUntilIdle()
+
+    val call = client.inputTypeTextCalls.single()
+    assertEquals("hello", call.text)
+    assertTrue(call.append)
+    scope.cancel()
+  }
+
+  @Test
+  fun `a tap flushes buffered text first, preserving order`() = runTest {
+    val scope = CoroutineScope(UnconfinedTestDispatcher(testScheduler))
+    val client = FakeAutoMobileClient()
+    val d = scope.dispatcher(client, testScheduler)
+    d.key(DeviceKeyStroke(character = 'a'))
+    d.tap(DevicePoint(x = 10, y = 10, inBounds = true))
+    advanceUntilIdle()
+
+    // The buffered text is sent (once), and it reaches the device BEFORE the tap.
+    assertEquals("a", client.inputTypeTextCalls.single().text)
+    assertEquals(1, client.inputTapCalls.size)
+    assertTrue(client.calls.indexOf("inputTypeText") < client.calls.indexOf("inputTap"))
+    scope.cancel()
+  }
+
+  @Test
+  fun `a host chord is not forwarded and is left for the host`() = runTest {
+    val scope = CoroutineScope(UnconfinedTestDispatcher(testScheduler))
+    val client = FakeAutoMobileClient()
+    val consumed =
+      scope
+        .dispatcher(client, testScheduler)
+        .key(DeviceKeyStroke(character = 'a', modifiers = DeviceKeyModifiers(meta = true)))
+    advanceUntilIdle()
+
+    assertFalse(consumed)
+    assertTrue(client.calls.none { it.startsWith("input") })
+    scope.cancel()
+  }
+
+  @Test
+  fun `a below-threshold drag sends nothing`() = runTest {
+    val scope = CoroutineScope(UnconfinedTestDispatcher(testScheduler))
+    val client = FakeAutoMobileClient()
+    scope
+      .dispatcher(client, testScheduler)
+      .swipe(
+        testSnapshot(),
+        DevicePoint(x = 100, y = 100, inBounds = true),
+        DevicePoint(x = 102, y = 101, inBounds = true),
+        gestureDurationMs = 120,
+      )
+    advanceUntilIdle()
+
+    assertTrue(client.inputSwipeCalls.isEmpty())
+    scope.cancel()
+  }
+
+  @Test
+  fun `a real drag swipes with no frame context`() = runTest {
+    val scope = CoroutineScope(UnconfinedTestDispatcher(testScheduler))
+    val client = FakeAutoMobileClient()
+    scope
+      .dispatcher(client, testScheduler)
+      .swipe(
+        testSnapshot(),
+        DevicePoint(x = 100, y = 100, inBounds = true),
+        DevicePoint(x = 700, y = 1500, inBounds = true),
+        gestureDurationMs = 90,
+      )
+    advanceUntilIdle()
+
+    val call = client.inputSwipeCalls.single()
+    assertNull(call.frameContext)
+    // The flick's own duration drives the swipe velocity (fling strength), not a fixed value.
+    assertEquals(90, call.durationMs)
+    scope.cancel()
+  }
+
+  @Test
+  fun `a device button press carries no frame context`() = runTest {
+    val scope = CoroutineScope(UnconfinedTestDispatcher(testScheduler))
+    val client = FakeAutoMobileClient()
+    scope.dispatcher(client, testScheduler).pressButton("BACK")
+    advanceUntilIdle()
+
+    val call = client.inputPressButtonCalls.single()
+    assertEquals("BACK", call.button)
+    assertNull(call.frameContext)
+    scope.cancel()
+  }
+}

--- a/android/desktop-core/src/test/kotlin/dev/jasonpearson/automobile/desktop/core/workspace/WorkspaceShellUiTest.kt
+++ b/android/desktop-core/src/test/kotlin/dev/jasonpearson/automobile/desktop/core/workspace/WorkspaceShellUiTest.kt
@@ -92,6 +92,26 @@ class WorkspaceShellUiTest {
   }
 
   @Test
+  fun `clicking a pane emits FocusDevice for that column`() = runComposeUiTest {
+    // Device control is focus-gated (only the focused pane arms + accepts input), so the user must
+    // be able to move focus by clicking a pane. Clicking anywhere in the unfocused pane 'b' focuses
+    // it; without this every non-focused video pane would be a dead mirror (#5221 review).
+    val actions = mutableListOf<WorkspaceAction>()
+    val state =
+      WorkspaceUiState.Content(
+        columns = listOf(col("a", "Pixel 8"), col("b", "iPhone 15", Platform.Ios)),
+        focusedDeviceId = "a",
+      )
+    setContent {
+      MaterialTheme {
+        WorkspaceShell(state = state, onAction = { actions += it }, onOpenPicker = {})
+      }
+    }
+    onNodeWithText("iPhone 15").performClick()
+    assertTrue(WorkspaceAction.FocusDevice("b") in actions)
+  }
+
+  @Test
   fun `two devices render both chips`() = runComposeUiTest {
     val state =
       WorkspaceUiState.Content(
@@ -208,25 +228,24 @@ class WorkspaceShellUiTest {
     }
 
   @Test
-  fun `More control opens a menu and selecting a button dispatches PressDeviceButton`() =
-    runComposeUiTest {
-      var action: WorkspaceAction? = null
-      val state =
-        WorkspaceUiState.Content(columns = listOf(col("a", "Pixel 8")), focusedDeviceId = "a")
-      setContent {
-        MaterialTheme {
-          WorkspaceShell(state = state, onAction = { action = it }, onOpenPicker = {})
-        }
+  fun `a device nav button in the command bar dispatches PressDeviceButton`() = runComposeUiTest {
+    var action: WorkspaceAction? = null
+    val state =
+      WorkspaceUiState.Content(columns = listOf(col("a", "Pixel 8")), focusedDeviceId = "a")
+    setContent {
+      MaterialTheme {
+        WorkspaceShell(state = state, onAction = { action = it }, onOpenPicker = {})
       }
-      onNodeWithContentDescription("More Pixel 8").performClick()
-      // Power shows on Android — a hardware key adb can press.
-      onNodeWithContentDescription("Power Pixel 8").assertIsDisplayed()
-      onNodeWithContentDescription("Home Pixel 8").performClick()
-      assertEquals(WorkspaceAction.PressDeviceButton("a", DeviceButton.Home), action)
     }
+    // Buttons are surfaced directly in the command bar now (no More overflow menu).
+    // Power shows on Android — a hardware key adb can press.
+    onNodeWithContentDescription("Power Pixel 8").assertIsDisplayed()
+    onNodeWithContentDescription("Home Pixel 8").performClick()
+    assertEquals(WorkspaceAction.PressDeviceButton("a", DeviceButton.Home), action)
+  }
 
   @Test
-  fun `More menu on iOS offers the navigation buttons but hides simulator-incompatible Power`() =
+  fun `iOS command bar offers the navigation buttons but hides simulator-incompatible Power`() =
     runComposeUiTest {
       val state =
         WorkspaceUiState.Content(
@@ -236,7 +255,6 @@ class WorkspaceShellUiTest {
       setContent {
         MaterialTheme { WorkspaceShell(state = state, onAction = {}, onOpenPicker = {}) }
       }
-      onNodeWithContentDescription("More iPhone 15").performClick()
       // Home/Back/Recent route through CtrlProxy on iOS; Power is physical-device-only.
       onNodeWithContentDescription("Home iPhone 15").assertIsDisplayed()
       onNodeWithContentDescription("Back iPhone 15").assertIsDisplayed()
@@ -256,7 +274,6 @@ class WorkspaceShellUiTest {
     }
 
     onNodeWithContentDescription("Locale iPhone 15").assertDoesNotExist()
-    onNodeWithContentDescription("More iPhone 15").performClick()
     onNodeWithContentDescription("Power iPhone 15").assertIsDisplayed()
   }
 
@@ -272,7 +289,6 @@ class WorkspaceShellUiTest {
     }
 
     onNodeWithContentDescription("Locale iPhone 15").assertIsDisplayed()
-    onNodeWithContentDescription("More iPhone 15").performClick()
     onNodeWithContentDescription("Power iPhone 15").assertDoesNotExist()
   }
 

--- a/android/desktop-domain/src/main/kotlin/dev/jasonpearson/automobile/desktop/domain/DeviceDragGesturePolicy.kt
+++ b/android/desktop-domain/src/main/kotlin/dev/jasonpearson/automobile/desktop/domain/DeviceDragGesturePolicy.kt
@@ -67,18 +67,42 @@ public object DeviceDragGesturePolicy {
     }
 
   /**
-   * The duration handed to `input/swipe`, in milliseconds.
-   *
-   * A fixed value keeps the same gesture independent of host pointer speed and remains inside the
-   * daemon's accepted `[1, 60000]` range.
+   * The duration handed to `input/swipe`, in milliseconds, when the client did not measure the
+   * gesture's speed. A neutral mid value; overridden whenever a real flick duration is available.
    */
   public const val SWIPE_DURATION_MS: Int = 300
+
+  /**
+   * Floor for a measured swipe duration. A flick faster than this is clamped up so the daemon still
+   * injects enough motion events to register a velocity (and to stay inside its `[1, 60000]`
+   * range), while keeping the swipe short enough to read as a strong fling.
+   */
+  public const val MIN_SWIPE_DURATION_MS: Int = 40
+
+  /**
+   * Ceiling for a measured swipe duration. Past this a gesture is a deliberate slow drag, not a
+   * fling; capping keeps a very long drag from producing an unnaturally languid device swipe.
+   */
+  public const val MAX_SWIPE_DURATION_MS: Int = 1_000
+
+  /**
+   * Resolve the `input/swipe` duration from the host gesture.
+   *
+   * Fling strength on the device is governed by the swipe's velocity — roughly distance over
+   * duration — so replaying the swipe over *the wall-clock time the user's flick actually took*
+   * reproduces the user's intent: a fast flick becomes a short, high-velocity swipe (a strong
+   * fling), a slow drag a gentle one. A missing measurement falls back to [SWIPE_DURATION_MS].
+   */
+  public fun swipeDurationMs(gestureDurationMs: Int?): Int =
+    gestureDurationMs?.coerceIn(MIN_SWIPE_DURATION_MS, MAX_SWIPE_DURATION_MS) ?: SWIPE_DURATION_MS
 
   /**
    * Decide whether a drag should become a swipe.
    *
    * [coordinateSpace] and [nativeScale] must come from the snapshot used to map both endpoints.
-   * Missing canonical-pixel scale metadata fails closed.
+   * Missing canonical-pixel scale metadata fails closed. [gestureDurationMs] is how long the host
+   * pointer was down for this gesture; when supplied it sets the swipe's velocity (see
+   * [swipeDurationMs]), otherwise a fixed [SWIPE_DURATION_MS] is used.
    */
   public fun evaluate(
     start: DevicePoint,
@@ -87,6 +111,7 @@ public object DeviceDragGesturePolicy {
     deviceHeight: Int,
     coordinateSpace: CoordinateSpace? = null,
     nativeScale: Double? = null,
+    gestureDurationMs: Int? = null,
   ): DeviceDragDecision {
     if (deviceWidth <= 0 || deviceHeight <= 0) {
       return DeviceDragDecision.Ignored(DeviceDragRejection.NoAddressableScreen)
@@ -102,7 +127,7 @@ public object DeviceDragGesturePolicy {
     return DeviceDragDecision.Swipe(
       start = start,
       end = clampedEnd,
-      durationMs = SWIPE_DURATION_MS,
+      durationMs = swipeDurationMs(gestureDurationMs),
     )
   }
 }

--- a/docs/design-docs/plat/android/desktop-app.md
+++ b/docs/design-docs/plat/android/desktop-app.md
@@ -325,6 +325,32 @@ implemented across `desktop-domain` (pure policies) and `desktop-core` (the
 User-facing docs: [Controlling a Device from the Desktop App](../../../using/screen-control.md).
 Client-author docs: [third-party client guide](../../mcp/daemon/client-screen-control.md).
 
+### Workspace video pane (second control entry point)
+
+The Layout dashboard mirror above pairs each tap with the observation screenshot it was mapped
+through (capture identity + `frameContext`). The **workspace pane** exposes a second, distinct
+control surface: the user clicks the *live H.264 video*, not the observation screenshot. That path
+deliberately **decouples input from the video frame** — a click maps only through the retained
+device geometry (width/height/rotation) and dispatches through `VideoInputDispatcher` with **no
+`frameContext`**, so the daemon can never reject a video-pane tap as stale (the "one tap works, then
+it freezes" wedge). Wiring lives in `desktop-core`'s `WorkspaceDeviceControl` +
+`VideoInputDispatcher`; the pane keeps playing smooth live video while only the click coordinate
+uses the snapshot.
+
+- **Armed only for the FOCUSED pane on a Unix daemon.** Non-Unix transports (MCP HTTP/STDIO) don't
+  serve the direct `input/*` helpers, and only one pane is driven at a time — so a workspace pane is
+  interactive only when it is both focused and Unix-backed. Click a farm pane to focus (and thus
+  drive) it; an unfocused pane runs no observation stream and no input dispatcher (its warm dispatch
+  thread is retired), and only the focused pane requests keyboard focus (so a second pane can't steal
+  keystrokes mid-type). The per-device video encode rate is fixed by the first subscriber's hint and
+  shared, so focus does NOT change a live stream's fps — doing that would need server-side capture
+  reconfiguration (follow-up).
+- **Keystrokes are coalesced** into batched `inputTypeText` (append mode) and any device key / tap /
+  swipe flushes pending text first, preserving the order the user typed.
+- **Command bar** (Back/Home/Recent/Power + emulator controls) takes the single-round-trip
+  `input/pressButton` fast path on a Unix daemon, falling back to the `pressButton` MCP tool on
+  other transports.
+
 ## See Also
 
 - [Android Overview](index.md)

--- a/docs/design-docs/plat/android/emulator-startup.md
+++ b/docs/design-docs/plat/android/emulator-startup.md
@@ -10,21 +10,29 @@ display mode based on the host and a small set of environment variables.
 
 ## Display mode auto-detection
 
-By default the emulator launches **windowed**. On a headless Linux host (a CI
-runner with no X server, a container, an SSH session with no `DISPLAY`) a
-windowed launch cannot connect to the display, fails to load the Qt `xcb`
-platform plugin, and is killed by signal in a few hundred milliseconds. Node
-reports the signal death as `code: null`, which previously collapsed into an
-opaque `Emulator process exited with code: null`.
+AutoMobile observes and streams the device screen itself, so the emulator's own
+window is never the interaction surface — it only ever adds cost or crash surface.
+Two hosts default to **headless** for that reason:
 
-To avoid this, AutoMobile resolves the display mode as follows:
+- **macOS** — the emulator's Qt window backing store segfaults on repaint under
+  CoreAnimation (`EXC_BAD_ACCESS` in `QCALayerBackingStore::beginPaint`), which
+  recurs across launches and takes the whole guest down (it reads as "input
+  stuck"). Dropping the window removes the crash surface entirely.
+- **Headless Linux** (a CI runner with no X server, a container, an SSH session
+  with no `DISPLAY`) — a windowed launch cannot connect to the display, fails to
+  load the Qt `xcb` platform plugin, and is killed by signal in a few hundred
+  milliseconds. Node reports the signal death as `code: null`, which previously
+  collapsed into an opaque `Emulator process exited with code: null`.
+
+AutoMobile resolves the display mode as follows (first matching row wins):
 
 | Condition | Mode |
 |-----------|------|
 | `AUTOMOBILE_EMULATOR_HEADLESS=true` | **headless** (any platform) |
-| `AUTOMOBILE_EMULATOR_HEADLESS=false` | **windowed** (forced, even on a Linux host with no display) |
+| `AUTOMOBILE_EMULATOR_HEADLESS=false` | **windowed** (forced, even on macOS or a Linux host with no display) |
+| macOS | **headless** (auto; opt back in with `AUTOMOBILE_EMULATOR_HEADLESS=false`) |
 | Linux with no `DISPLAY` and no `WAYLAND_DISPLAY` | **headless** (auto) |
-| Linux with `DISPLAY`/`WAYLAND_DISPLAY`, macOS, Windows | **windowed** |
+| Linux with `DISPLAY`/`WAYLAND_DISPLAY`, Windows | **windowed** |
 
 In headless mode AutoMobile appends `-no-window -no-audio` to the `emulator`
 invocation. The chosen mode and the reason are logged at `INFO`.

--- a/src/daemon/canonicalPixels.ts
+++ b/src/daemon/canonicalPixels.ts
@@ -109,8 +109,12 @@ function scaleNodeBounds(node: ViewHierarchyNode, nativeScale: number): void {
 /** Depth-first scale every node's bounds under [node] in place. */
 function scaleTreeBounds(node: ViewHierarchyNode, nativeScale: number): void {
   scaleNodeBounds(node, nativeScale);
-  if (node.node) {
-    for (const child of node.node) {
+  // `node.node` is an array for 2+ children but a bare object for a single child (the on-device
+  // XML→JSON quirk), so normalize before iterating — a raw `for..of` over the object form throws
+  // "{} is not iterable" and aborts the canonical-pixel conversion.
+  const kids = node.node;
+  if (kids) {
+    for (const child of Array.isArray(kids) ? kids : [kids]) {
       scaleTreeBounds(child, nativeScale);
     }
   }

--- a/src/daemon/hierarchyStreamDiff.ts
+++ b/src/daemon/hierarchyStreamDiff.ts
@@ -69,7 +69,23 @@ function nodeSignature(node: ViewHierarchyNode): string {
 }
 
 function children(node: ViewHierarchyNode): ViewHierarchyNode[] {
-  return node.node ?? [];
+  // A node's children arrive as an array for 2+, but the on-device XML→JSON serializes a SINGLE
+  // child as a bare object (and a childless node can even surface an empty `{}`). Left unnormalized,
+  // `for (const c of node.node)` throws "{} is not iterable" — which silently killed the whole
+  // hierarchy push on some devices, so the layout inspector and interactive-pane arming never got a
+  // frame. Match the array-or-single normalization used across the Android converter.
+  const kids = node.node;
+  if (!kids) {
+    return [];
+  }
+  if (Array.isArray(kids)) {
+    return kids;
+  }
+  // A non-array object is a SINGLE child — unless it is the empty `{}` childless placeholder, which
+  // must be zero children. Wrapping `{}` as one child would make markSubtreeAdded/countSubtree
+  // report and annotate a node that does not exist (a phantom add/remove between two otherwise
+  // identical childless frames).
+  return Object.keys(kids).length > 0 ? [kids] : [];
 }
 
 function markState(node: ViewHierarchyNode, state: HierarchyNodeDiffState): void {

--- a/src/daemon/videoStreamSocketServer.ts
+++ b/src/daemon/videoStreamSocketServer.ts
@@ -89,6 +89,13 @@ const MAX_FPS_HINT = 60;
 // cannot silently lose integer precision downstream.
 const MAX_BITRATE_KBPS = 1_000_000;
 
+// A key-frame request can be rejected when the capture source is rate-limiting them (Android and
+// raw iOS gate requests for ~3s, encoded iOS for ~500ms). When one is throttled we retry on the
+// injected timer instead of leaving the subscriber frozen until the encoder's natural GOP. The
+// interval × attempts span the widest (~3s) throttle window with headroom.
+const KEY_FRAME_RETRY_INTERVAL_MS = 500;
+const KEY_FRAME_RETRY_MAX_ATTEMPTS = 8;
+
 /**
  * Captures are shared per device and the FIRST subscriber's hints fixed the encode; a late
  * joiner's differing quality/fps/bitrate hints are silently ignored, so leave a trace for the
@@ -416,6 +423,8 @@ export class VideoStreamSocketServer extends BaseSocketServer {
     capture.subscribers.add(socket);
     if (waitForKeyFrame) {
       // A client that joins part way through a GOP must not consume inter frames before an IDR.
+      // The immediate key-frame request that unfreezes it lives in the subscribe-ack path (which
+      // runs for late joiners too); the backpressure-drain recovery is handled in the drain handler.
       capture.waitingForKeyFrame.add(socket);
     }
   }
@@ -486,9 +495,47 @@ export class VideoStreamSocketServer extends BaseSocketServer {
       capture.waitingForKeyFrame.add(subscriber);
       subscriber.once("drain", () => {
         const current = this.captures.get(deviceId);
-        current?.backpressuredSubscribers.delete(subscriber);
+        if (!current) {return;}
+        current.backpressuredSubscribers.delete(subscriber);
+        // The subscriber caught up, but it is still waiting for an IDR to resync — every inter
+        // frame is skipped until one arrives. The natural GOP can be seconds away
+        // (KEY_I_FRAME_INTERVAL), which would freeze this subscriber's video that whole time even
+        // though it is ready to receive. Ask the encoder for an immediate key frame so recovery
+        // takes ~one round-trip instead. Idempotent enough: a burst of drains just coalesces into
+        // one IDR at the encoder.
+        this.requestKeyFrameForWaitingSubscriber(deviceId, subscriber);
       });
     }
+  }
+
+  /**
+   * Ask the capture source for an immediate key frame on behalf of a subscriber waiting to resync,
+   * retrying through the injected timer while the request is throttled.
+   *
+   * `requestKeyFrame()` returns false when the source is rate-limiting requests (Android + raw iOS
+   * gate them for ~3s, encoded iOS ~500ms). Ignoring that rejection leaves the subscriber in
+   * `waitingForKeyFrame`, dropping every inter frame until the encoder's natural GOP — seconds of
+   * frozen video, the very symptom this drain recovery exists to prevent. The retry self-terminates:
+   * each attempt stops once the subscriber has resynced (left `waitingForKeyFrame`), disconnected,
+   * or the capture is gone, and attempts are bounded so a source that never honors one cannot loop.
+   */
+  private requestKeyFrameForWaitingSubscriber(
+    deviceId: string,
+    subscriber: Socket,
+    attemptsLeft: number = KEY_FRAME_RETRY_MAX_ATTEMPTS
+  ): void {
+    const capture = this.captures.get(deviceId);
+    if (!capture) {return;}
+    // Nothing to do once the subscriber left or already resynced on a key frame.
+    if (subscriber.destroyed || !capture.waitingForKeyFrame.has(subscriber)) {return;}
+    const source = capture.source;
+    // A source without requestKeyFrame can't force one; only the natural GOP recovers it.
+    if (!source?.requestKeyFrame) {return;}
+    if (source.requestKeyFrame() || attemptsLeft <= 0) {return;}
+    this.timer.setTimeout(
+      () => this.requestKeyFrameForWaitingSubscriber(deviceId, subscriber, attemptsLeft - 1),
+      KEY_FRAME_RETRY_INTERVAL_MS
+    );
   }
 
   private replayParameterSets(capture: DeviceCapture, socket: Socket): void {

--- a/src/utils/android-cmdline-tools/AndroidEmulatorClient.ts
+++ b/src/utils/android-cmdline-tools/AndroidEmulatorClient.ts
@@ -188,11 +188,18 @@ export function inferAndroidFormFactor(deviceName?: string): FormFactor | undefi
  * Resolution order:
  * 1. `AUTOMOBILE_EMULATOR_HEADLESS=true`  → always headless.
  * 2. `AUTOMOBILE_EMULATOR_HEADLESS=false` → always windowed (honor the explicit
- *    opt-out even on a Linux host with no display).
- * 3. Linux with no usable display server (`DISPLAY`/`WAYLAND_DISPLAY` unset or
+ *    opt-out on any host, e.g. someone who wants the native emulator window).
+ * 3. macOS → headless. The emulator's Qt window backing store segfaults on
+ *    repaint under CoreAnimation (`EXC_BAD_ACCESS` in
+ *    `QCALayerBackingStore::beginPaint` → `QPainter` → `QBrush`), which recurs
+ *    across launches and takes the whole guest down. AutoMobile observes and
+ *    streams the device screen, so the emulator's own window is never used —
+ *    dropping it removes the crash surface entirely. Opt back in with
+ *    `AUTOMOBILE_EMULATOR_HEADLESS=false`.
+ * 4. Linux with no usable display server (`DISPLAY`/`WAYLAND_DISPLAY` unset or
  *    blank) → headless, because a windowed launch aborts on the Qt `xcb`
  *    platform plugin (see issue #2722).
- * 4. Otherwise → windowed (macOS/Windows have a native display; Linux has one).
+ * 5. Otherwise → windowed (Windows has a native display; Linux has one).
  *
  * @param platform - `process.platform` value
  * @param env - environment variables to read
@@ -208,6 +215,13 @@ export function resolveHeadlessMode(
   }
   if (explicit === "false") {
     return { headless: false, reason: "AUTOMOBILE_EMULATOR_HEADLESS=false (windowed forced)" };
+  }
+
+  if (platform === "darwin") {
+    return {
+      headless: true,
+      reason: "macOS defaults to -no-window; the emulator's Qt/CoreAnimation window segfaults on repaint and AutoMobile streams the screen instead",
+    };
   }
 
   if (platform === "linux") {

--- a/test/daemon/hierarchyStreamDiff.test.ts
+++ b/test/daemon/hierarchyStreamDiff.test.ts
@@ -22,6 +22,30 @@ function diffState(n: ViewHierarchyNode | undefined): unknown {
 }
 
 describe("annotateHierarchyDiff", () => {
+  test("tolerates a single child serialized as a bare object, not an array", () => {
+    // The on-device XML→JSON emits `node` as an array for 2+ children but a bare object for a
+    // single child (and can surface an empty `{}`). This once threw "{} is not iterable" and killed
+    // the whole hierarchy push — leaving the interactive pane unable to arm on some devices.
+    const singleChild = { $: { class: "Root" }, node: { $: { class: "OnlyChild" } } } as unknown as ViewHierarchyNode;
+    const empty = { $: { class: "Root" }, node: {} } as unknown as ViewHierarchyNode;
+
+    // Both forms must be walked without throwing (across a first frame and a diff).
+    expect(() => annotateHierarchyDiff(null, { hierarchy: { node: singleChild } })).not.toThrow();
+    expect(() => annotateHierarchyDiff(null, { hierarchy: { node: empty } })).not.toThrow();
+
+    // And they must be walked CORRECTLY: against a childless baseline, the single-child object is one
+    // real added node, while the empty `{}` placeholder is ZERO children — not a phantom add.
+    const childlessBaseline = {
+      hierarchy: { node: { $: { class: "Root" } } as unknown as ViewHierarchyNode },
+    };
+    expect(
+      annotateHierarchyDiff(childlessBaseline, { hierarchy: { node: singleChild } }).summary.added
+    ).toBe(1);
+    expect(
+      annotateHierarchyDiff(childlessBaseline, { hierarchy: { node: empty } }).summary.added
+    ).toBe(0);
+  });
+
   test("first frame has no baseline and annotates nothing", () => {
     const current = hierarchy(node({ class: "Root" }, [node({ class: "Child", text: "a" })]));
 

--- a/test/daemon/videoStreamSocketServer.test.ts
+++ b/test/daemon/videoStreamSocketServer.test.ts
@@ -3,7 +3,8 @@ import net from "node:net";
 import { mkdtempSync, rmSync } from "node:fs";
 import { tmpdir } from "node:os";
 import path from "node:path";
-import { defaultTimer } from "../../src/utils/SystemTimer";
+import { defaultTimer, type Timer } from "../../src/utils/SystemTimer";
+import { FakeTimer } from "../fakes/FakeTimer";
 import type { BootedDevice } from "../../src/models";
 import type { H264CaptureSource } from "../../src/features/webrtc/H264CaptureSource";
 import { VideoStreamSocketServer } from "../../src/daemon/videoStreamSocketServer";
@@ -31,6 +32,9 @@ class FakeCaptureSource implements H264CaptureSource {
   startGate: Promise<void> | null = null;
   onStart: (() => void) | null = null;
   keyFrameRequests = 0;
+  // When > 0, requestKeyFrame() reports the source is throttling (returns false) this many times
+  // before it honors one — modeling the real Android/iOS key-frame rate limiter.
+  keyFrameRejectionsRemaining = 0;
 
   async start(): Promise<void> {
     await this.startGate;
@@ -47,6 +51,10 @@ class FakeCaptureSource implements H264CaptureSource {
 
   requestKeyFrame(): boolean {
     this.keyFrameRequests++;
+    if (this.keyFrameRejectionsRemaining > 0) {
+      this.keyFrameRejectionsRemaining--;
+      return false;
+    }
     return true;
   }
 }
@@ -74,6 +82,7 @@ async function startHarness(
     startData?: Buffer;
     resolveError?: Error;
     authenticator?: StreamSocketAuthenticator;
+    timer?: Timer;
   } = {}
 ): Promise<Harness> {
   const dir = mkdtempSync(path.join(tmpdir(), "amvs-"));
@@ -109,7 +118,7 @@ async function startHarness(
       nowUs: () => 1_000n,
     },
     socketPath,
-    defaultTimer,
+    options.timer ?? defaultTimer,
     options.authenticator ?? allowAllAuthenticator
   );
   await server.start();
@@ -628,6 +637,86 @@ describe("VideoStreamSocketServer", () => {
 
     expect(late.binary().includes(pps)).toBe(true);
     expect(late.binary().includes(idr)).toBe(true);
+  });
+
+  test("a drained backpressured subscriber is handed an immediate key frame, not a GOP-long freeze", async () => {
+    const h = await startHarness();
+    const client = await subscribe(h.socketPath);
+    await waitFor(() => h.sources.length > 0);
+    const source = h.sources[0];
+
+    // A fresh subscriber starts waiting-for-key-frame, so inter frames are skipped until an IDR
+    // arrives. Send one so the subscriber is actually streaming and the inter-frame flood below can
+    // reach write() and trigger backpressure.
+    h.emit(Buffer.from([0x00, 0x00, 0x00, 0x01, 0x05, 0xaa, 0x00, 0x00, 0x00, 0x01, 0x01]));
+    await waitFor(() => client.binary().includes(Buffer.from([0x05, 0xaa])));
+
+    // Stop reading so the server's write buffer fills and the subscriber is marked "behind".
+    client.socket.pause();
+
+    // Emit far more than any socket high-water mark, as large inter (non-key) frames, so a
+    // write() reports backpressure and the subscriber is parked waiting for the next key frame.
+    // Each NAL is flushed by the leading start code of the following emit; a trailing start code
+    // flushes the last.
+    const frame = Buffer.concat([
+      Buffer.from([0x00, 0x00, 0x00, 0x01, 0x01]),
+      Buffer.alloc(64 * 1024, 0xab),
+    ]);
+    for (let i = 0; i < 40; i++) {
+      h.emit(frame);
+    }
+    h.emit(Buffer.from([0x00, 0x00, 0x00, 0x01, 0x01]));
+
+    // Baseline AFTER the subscribe-time IDR request: while the subscriber is still stuck (no drain
+    // yet) the count must not climb further.
+    const before = source.keyFrameRequests;
+
+    // Resume reading: the socket drains, and the drain handler asks the encoder for an immediate IDR
+    // rather than leaving this subscriber frozen until the next natural key frame (a whole GOP away).
+    client.socket.resume();
+    await waitFor(() => source.keyFrameRequests > before);
+
+    expect(source.keyFrameRequests).toBeGreaterThan(before);
+  });
+
+  test("a key frame throttled at drain time is retried until the source honors one", async () => {
+    // The real capture sources rate-limit key-frame requests (Android + raw iOS ~3s, encoded iOS
+    // ~500ms), so a drain landing inside that window gets a `false` from requestKeyFrame(). Without
+    // a retry the subscriber stays in waitingForKeyFrame and drops every inter frame until the
+    // natural GOP — the multi-second freeze this recovery exists to prevent. Auto-advance lets the
+    // injected timer's retries fire promptly.
+    const fakeTimer = new FakeTimer();
+    fakeTimer.enableAutoAdvance();
+    const h = await startHarness({ timer: fakeTimer });
+    const client = await subscribe(h.socketPath);
+    await waitFor(() => h.sources.length > 0);
+    const source = h.sources[0];
+
+    // Get the subscriber actually streaming (as in the drain test above).
+    h.emit(Buffer.from([0x00, 0x00, 0x00, 0x01, 0x05, 0xaa, 0x00, 0x00, 0x00, 0x01, 0x01]));
+    await waitFor(() => client.binary().includes(Buffer.from([0x05, 0xaa])));
+
+    // Throttle the NEXT two key-frame requests before the source honors one. Set after the
+    // subscribe-time request so only the drain-recovery path meets the throttle.
+    source.keyFrameRejectionsRemaining = 2;
+    const before = source.keyFrameRequests;
+
+    // Backpressure, then drain the subscriber.
+    client.socket.pause();
+    const frame = Buffer.concat([
+      Buffer.from([0x00, 0x00, 0x00, 0x01, 0x01]),
+      Buffer.alloc(64 * 1024, 0xab),
+    ]);
+    for (let i = 0; i < 40; i++) {
+      h.emit(frame);
+    }
+    h.emit(Buffer.from([0x00, 0x00, 0x00, 0x01, 0x01]));
+    client.socket.resume();
+
+    // The drain handler's first request is rejected; the timer-driven retries keep asking until the
+    // source finally honors one — 2 rejections + 1 success — instead of leaving playback frozen.
+    await waitFor(() => source.keyFrameRequests >= before + 3);
+    expect(source.keyFrameRejectionsRemaining).toBe(0);
   });
 
   test("a failed capture start is reported and starts nothing", async () => {

--- a/test/utils/android-cmdline-tools/AndroidEmulatorClient-headless.test.ts
+++ b/test/utils/android-cmdline-tools/AndroidEmulatorClient-headless.test.ts
@@ -61,6 +61,11 @@ describe("resolveHeadlessMode", () => {
     expect(result.headless).toBe(false);
   });
 
+  test("AUTOMOBILE_EMULATOR_HEADLESS=false forces windowed on macOS (opt back into the native window)", () => {
+    const result = resolveHeadlessMode("darwin", { AUTOMOBILE_EMULATOR_HEADLESS: "false" });
+    expect(result.headless).toBe(false);
+  });
+
   test("Linux without DISPLAY or WAYLAND_DISPLAY defaults to headless", () => {
     const result = resolveHeadlessMode("linux", {});
     expect(result.headless).toBe(true);
@@ -82,8 +87,10 @@ describe("resolveHeadlessMode", () => {
     expect(resolveHeadlessMode("linux", { DISPLAY: "   " }).headless).toBe(true);
   });
 
-  test("macOS without DISPLAY runs windowed (native display always available)", () => {
-    expect(resolveHeadlessMode("darwin", {}).headless).toBe(false);
+  test("macOS defaults to headless (the Qt/CoreAnimation window backing store segfaults on repaint)", () => {
+    const result = resolveHeadlessMode("darwin", {});
+    expect(result.headless).toBe(true);
+    expect(result.reason.toLowerCase()).toContain("macos");
   });
 
   test("Windows without DISPLAY runs windowed", () => {


### PR DESCRIPTION
## Interactive video-pane device control + input/video latency work

Makes the desktop workspace video pane **clickable** — tap, swipe, type, and Back/Home/Recent go straight to the device while the live H.264 mirror keeps playing — then drives the input→reaction loop toward "feels instantaneous" and fixes the freezes found along the way.

### Interactive control
- **Tap-to-control on the video pane**: a click on the live video is mapped through the retained device geometry and dispatched as a device tap/swipe/key. The video keeps streaming; only the coordinate mapping uses the observation snapshot.
- **Decoupled input from the observation frame** (`VideoInputDispatcher`): the pane no longer routes taps through `DeviceControlSession`'s capture-identity `frameContext`. On a static screen the daemon dedupes its hierarchy pushes, the old `frameContext` aged out, and the pane wedged ("one tap works, then it freezes"). Taps now carry **no `frameContext`**, so the daemon can never reject one as stale, and device geometry is retained indefinitely so the surface never disarms.
- **Crayon-styled command bar** overlaying the pane: Back / Home / Recent / Power + emulator controls (rotate, screenshot, snapshot, unlock, locale).

### Input latency
- **Fire taps on a dedicated warm thread**, not the elastic IO pool (which parks idle threads and cost a thread-wakeup on the first tap after a quiet moment).
- **Command-bar buttons take the fast single round-trip path**: Back/Home/etc were doing *two* sequential daemon round-trips (`setActiveDevice` + the heavier `pressButton` MCP tool) — the redundant `setActiveDevice` dominated their latency. Now one direct `inputPressButton`, matching the tap path. Measured **~18–30ms** (was 500ms–1s).
- **Interaction-latency perf spans** (`InteractionLatencyTracer`) instrument tap→map→dispatch→ack→first-frame, with the dispatch span stamped at the real send; the command-bar path is instrumented too.

### Video latency & robustness
- **Stream the controlled pane at 60fps** (was an un-hinted 5fps — frames ~200ms apart, the dominant term in tap→visible-response latency).
- **Force an immediate key frame when a backpressured subscriber drains**: a subscriber that briefly fell behind was parked on *waiting-for-keyframe* and then starved of every frame until the next natural keyframe — up to a full GOP (~5s) of frozen video even though it was ready. This was the "video totally stops while input works" symptom. Recovery is now ~one round-trip.
- **Stop double-copying every video read off the socket**: each 60fps read allocated two throwaway full-buffer copies (reader slice + parser accumulation). Now roughly zero in the common case, cutting reader-thread heap churn.

### Platform fix
- **Default the Android emulator headless on macOS**: the emulator's Qt/CoreAnimation window backing store segfaults on repaint (`QCALayerBackingStore::beginPaint`), recurring across launches and taking the guest down — surfacing as "input stuck" because the device died underneath. AutoMobile streams the screen, so the native window is unused; `-no-window` removes the crash surface. Opt back in with `AUTOMOBILE_EMULATOR_HEADLESS=false`.
- **Basic forward compatibility for daemon/client version skew.**

### Tests
Fast unit tests cover the frame-identity-free dispatch (no `frameContext`, FIFO order, host-chord passthrough, off-screen drop), the single-round-trip button path, the headless-mode resolution, the backpressure→drain→keyframe recovery (real sockets), and the length-aware parser (ignores stale bytes past `length`). Command-bar UI tests updated to the direct-button layout.

### Notes for reviewers
- The remaining per-frame `Image.makeRaster` allocation (~2MB native, 60×/sec) is structural — Compose requires an immutable image per frame. A ring-buffered bitmap pool or a 60→30fps default are the levers, deferred as a follow-up pending on-device validation.
- Branch base is behind current `main`; happy to rebase if preferred.
