### PR TITLE
fix(android): move network control permission to CtrlProxy

### DIFF
--- a/.github/workflows/build-control-proxy-apk.yml
+++ b/.github/workflows/build-control-proxy-apk.yml
@@ -50,7 +50,7 @@ jobs:
 
       - uses: ./.github/actions/gradle-task-run
         with:
-          gradle-tasks: ":control-proxy:assembleDebug"
+          gradle-tasks: ":control-proxy:assembleRelease"
           gradle-project-directory: "android"
           gradle-home-directory: "~/.gradle/build-control-proxy-apk"
           reuse-configuration-cache: true
@@ -65,13 +65,14 @@ jobs:
         run: |
           # pipefail so a failing sha256sum is not masked by a succeeding cut (#4684).
           set -euo pipefail
-          APK_PATH="android/control-proxy/build/outputs/apk/debug/control-proxy-debug.apk"
+          APK_PATH="android/control-proxy/build/outputs/apk/release/control-proxy-release.apk"
           SHA256=$(sha256sum "$APK_PATH" | cut -d' ' -f1)
           echo "sha256=$SHA256" >> $GITHUB_OUTPUT
           echo "APK SHA256: $SHA256"
 
       - name: "Copy APK to /tmp"
-        run: cp android/control-proxy/build/outputs/apk/debug/control-proxy-debug.apk /tmp/control-proxy-debug.apk
+        # Preserve the public asset name while excluding debug-only manifest components.
+        run: cp android/control-proxy/build/outputs/apk/release/control-proxy-release.apk /tmp/control-proxy-debug.apk
 
       - name: "Upload CtrlProxy APK"
         if: ${{ inputs.upload-artifact }}

--- a/.github/workflows/pull_request.yml
+++ b/.github/workflows/pull_request.yml
@@ -2252,7 +2252,7 @@ jobs:
 
       - uses: ./.github/actions/gradle-task-run
         with:
-          gradle-tasks: ":control-proxy:assembleDebug"
+          gradle-tasks: ":control-proxy:assembleDebug :control-proxy:assembleRelease"
           gradle-project-directory: "android"
           gradle-home-directory: "~/.gradle/${{ github.job }}"
           reuse-configuration-cache: true

--- a/.github/workflows/pull_request.yml
+++ b/.github/workflows/pull_request.yml
@@ -2174,8 +2174,10 @@ jobs:
 
       # Run AutoMobile tests that require emulator
       - uses: ./.github/actions/android-emulator
+        env:
+          AUTOMOBILE_TOOLSET_NAVIGATION_MODELING: "1"
         with:
-          script: "../scripts/android/verify-sdk-ctrl-proxy-permission-contract.sh control-proxy/build/outputs/apk/debug/control-proxy-debug.apk && ./gradlew :playground:app:test --stacktrace --info"
+          script: "../scripts/android/verify-sdk-ctrl-proxy-permission-contract.sh control-proxy/build/outputs/apk/debug/control-proxy-debug.apk && ../scripts/android/navigation-graph-sdk-event-integration.sh && ./gradlew :playground:app:test --stacktrace --info"
           working-directory: './android/'
           accessibility-apk-path: control-proxy/build/outputs/apk/debug/control-proxy-debug.apk
           gradle-home-directory: "~/.gradle/${{ github.job }}"

--- a/.github/workflows/pull_request.yml
+++ b/.github/workflows/pull_request.yml
@@ -2175,7 +2175,7 @@ jobs:
       # Run AutoMobile tests that require emulator
       - uses: ./.github/actions/android-emulator
         with:
-          script: "./gradlew :playground:app:test --stacktrace --info"
+          script: "../scripts/android/verify-sdk-ctrl-proxy-permission-contract.sh control-proxy/build/outputs/apk/debug/control-proxy-debug.apk && ./gradlew :playground:app:test --stacktrace --info"
           working-directory: './android/'
           accessibility-apk-path: control-proxy/build/outputs/apk/debug/control-proxy-debug.apk
           gradle-home-directory: "~/.gradle/${{ github.job }}"

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -313,19 +313,9 @@ jobs:
       - name: Build TypeScript package
         run: bun run build
 
-      - name: Publish Homebrew formula
-        env:
-          GH_TOKEN: ${{ secrets.HOMEBREW_TAP_TOKEN }}
-          TAG: ${{ steps.version.outputs.tag }}
-          REPO: ${{ github.repository }}
-        run: bash scripts/release/update-brew-formula.sh
-
-      # MCP Registry, Maven Central, and the Docker image are best-effort
-      # distribution channels: a failure in any of them must not block the
-      # canonical GitHub Release (and its artifacts) that runs after them.
-      # continue-on-error neutralizes their failures so `success()` stays true
-      # for the GitHub Release step, while the failed step still shows red in the
-      # UI so the drift is visible and fixable.
+      # The MCP Registry and Docker image are best-effort distribution channels.
+      # Maven Central and npm are blocking because the released CtrlProxy and SDK
+      # artifacts must remain compatible, and Homebrew consumes npm's tarball.
       - name: Install mcp-publisher
         continue-on-error: true
         run: |
@@ -458,6 +448,13 @@ jobs:
             exit 0
           fi
           npm publish --provenance --access public
+
+      - name: Publish Homebrew formula
+        env:
+          GH_TOKEN: ${{ secrets.HOMEBREW_TAP_TOKEN }}
+          TAG: ${{ steps.version.outputs.tag }}
+          REPO: ${{ github.repository }}
+        run: bash scripts/release/update-brew-formula.sh
 
       - name: Free Disk Space
         continue-on-error: true

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -313,24 +313,6 @@ jobs:
       - name: Build TypeScript package
         run: bun run build
 
-      - name: Publish to npm
-        env:
-          VERSION: ${{ steps.version.outputs.version }}
-        run: |
-          set -euo pipefail
-          # npm publish is not idempotent: without this, a failure anywhere later
-          # in the job makes the whole release unrerunnable.
-          #
-          # Assign first, then test. Under set -e a failing command substitution
-          # inside an `if` condition does NOT abort, so testing it inline would
-          # turn the guard's fail-closed error into a silent "not published".
-          state=$(scripts/release/already-published.sh npm "$VERSION")
-          if [ "$state" = published ]; then
-            echo "npm already has $VERSION; skipping publish"
-            exit 0
-          fi
-          npm publish --provenance --access public
-
       - name: Publish Homebrew formula
         env:
           GH_TOKEN: ${{ secrets.HOMEBREW_TAP_TOKEN }}
@@ -458,6 +440,24 @@ jobs:
           ./gradlew :junit-runner:publish :auto-mobile-sdk:publish \
             -PVERSION_NAME=${{ steps.version.outputs.version }} \
             --no-configuration-cache
+
+      - name: Publish to npm
+        env:
+          VERSION: ${{ steps.version.outputs.version }}
+        run: |
+          set -euo pipefail
+          # npm publish is not idempotent: without this, a failure anywhere later
+          # in the job makes the whole release unrerunnable.
+          #
+          # Assign first, then test. Under set -e a failing command substitution
+          # inside an `if` condition does NOT abort, so testing it inline would
+          # turn the guard's fail-closed error into a silent "not published".
+          state=$(scripts/release/already-published.sh npm "$VERSION")
+          if [ "$state" = published ]; then
+            echo "npm already has $VERSION; skipping publish"
+            exit 0
+          fi
+          npm publish --provenance --access public
 
       - name: Free Disk Space
         continue-on-error: true

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -420,7 +420,6 @@ jobs:
           if-no-files-found: warn
 
       - name: Publish Android Libraries to Maven Central
-        continue-on-error: true
         env:
           VERSION: ${{ steps.version.outputs.version }}
           ORG_GRADLE_PROJECT_mavenCentralUsername:

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -313,9 +313,10 @@ jobs:
       - name: Build TypeScript package
         run: bun run build
 
+      # Publish the prepared CtrlProxy assets before any SDK distribution. Maven
+      # Central automatically releases its deployment, so a later npm/Homebrew
+      # failure must never make a new SDK selectable without its matching APK.
       # The MCP Registry and Docker image are best-effort distribution channels.
-      # Maven Central and npm are blocking because the released CtrlProxy and SDK
-      # artifacts must remain compatible, and Homebrew consumes npm's tarball.
       - name: Install mcp-publisher
         continue-on-error: true
         run: |
@@ -324,21 +325,55 @@ jobs:
           URL="$URL/mcp-publisher_linux_amd64.tar.gz"
           curl -L "$URL" | tar xz mcp-publisher
 
-      - name: Publish to MCP Registry
-        continue-on-error: true
+      - name: Create GitHub Release
+        shell: bash
         env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          REPO: ${{ github.repository }}
+          TAG: ${{ needs.validate-release-tag.outputs.tag }}
           VERSION: ${{ steps.version.outputs.version }}
         run: |
           set -euo pipefail
-          # Assign first, then test — see the npm step for why.
-          state=$(scripts/release/already-published.sh mcp "$VERSION")
-          if [ "$state" = published ]; then
-            echo "MCP Registry already has $VERSION; skipping publish"
-            exit 0
+          files=(
+            /tmp/control-proxy-debug.apk
+            /tmp/control-proxy.ipa
+            /tmp/automobile-video.jar
+            /tmp/screen-capture-helper-macos-universal.zip
+            /tmp/desktop/AutoMobile-${VERSION}-macos.dmg
+            /tmp/desktop/AutoMobile-${VERSION}-windows.msi
+            /tmp/desktop/AutoMobile-${VERSION}-linux.deb
+          )
+
+          # Use the GitHub Release API directly through gh. `gh release create`
+          # uploads through a draft before publishing, so a failed first attempt
+          # can leave a mutable draft. Only that draft is safe to repair with
+          # --clobber; never delete assets from an already-published release.
+          if gh release view "$TAG" --repo "$REPO" >/dev/null 2>&1; then
+            release_json="$(gh release view "$TAG" --repo "$REPO" --json isDraft,assets)"
+            if [ "$(jq -r '.isDraft' <<<"$release_json")" = "true" ]; then
+              gh release upload "$TAG" "${files[@]}" --repo "$REPO" --clobber
+              gh release edit "$TAG" --repo "$REPO" --title "$VERSION" \
+                --notes-file release_notes.txt --draft=false
+            else
+              missing=0
+              for file in "${files[@]}"; do
+                asset_name="${file##*/}"
+                if ! jq -e --arg name "$asset_name" \
+                  '.assets[] | select(.name == $name)' <<<"$release_json" >/dev/null; then
+                  echo "Published release $TAG is missing expected asset: $asset_name" >&2
+                  missing=1
+                fi
+              done
+              if [ "$missing" -ne 0 ]; then
+                echo "Refusing to overwrite assets on a published release." >&2
+                exit 1
+              fi
+              gh release edit "$TAG" --repo "$REPO" --title "$VERSION" --notes-file release_notes.txt
+            fi
+          else
+            gh release create "$TAG" "${files[@]}" --repo "$REPO" \
+              --title "$VERSION" --notes-file release_notes.txt --verify-tag
           fi
-          ./mcp-publisher login dns --domain jasonpearson.dev \
-            --private-key "${{ secrets.MCP_DNS_PRIVATE_KEY }}"
-          ./mcp-publisher publish
 
       - name: Set up Java
         continue-on-error: true
@@ -449,6 +484,22 @@ jobs:
           fi
           npm publish --provenance --access public
 
+      - name: Publish to MCP Registry
+        continue-on-error: true
+        env:
+          VERSION: ${{ steps.version.outputs.version }}
+        run: |
+          set -euo pipefail
+          # Assign first, then test — see the npm step for why.
+          state=$(scripts/release/already-published.sh mcp "$VERSION")
+          if [ "$state" = published ]; then
+            echo "MCP Registry already has $VERSION; skipping publish"
+            exit 0
+          fi
+          ./mcp-publisher login dns --domain jasonpearson.dev \
+            --private-key "${{ secrets.MCP_DNS_PRIVATE_KEY }}"
+          ./mcp-publisher publish
+
       - name: Publish Homebrew formula
         env:
           GH_TOKEN: ${{ secrets.HOMEBREW_TAP_TOKEN }}
@@ -510,56 +561,6 @@ jobs:
           labels: ${{ steps.docker_meta.outputs.labels }}
           cache-from: type=gha
           cache-to: type=gha,mode=max
-
-      - name: Create GitHub Release
-        shell: bash
-        env:
-          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-          REPO: ${{ github.repository }}
-          TAG: ${{ needs.validate-release-tag.outputs.tag }}
-          VERSION: ${{ steps.version.outputs.version }}
-        run: |
-          set -euo pipefail
-          files=(
-            /tmp/control-proxy-debug.apk
-            /tmp/control-proxy.ipa
-            /tmp/automobile-video.jar
-            /tmp/screen-capture-helper-macos-universal.zip
-            /tmp/desktop/AutoMobile-${VERSION}-macos.dmg
-            /tmp/desktop/AutoMobile-${VERSION}-windows.msi
-            /tmp/desktop/AutoMobile-${VERSION}-linux.deb
-          )
-
-          # Use the GitHub Release API directly through gh. `gh release create`
-          # uploads through a draft before publishing, so a failed first attempt
-          # can leave a mutable draft. Only that draft is safe to repair with
-          # --clobber; never delete assets from an already-published release.
-          if gh release view "$TAG" --repo "$REPO" >/dev/null 2>&1; then
-            release_json="$(gh release view "$TAG" --repo "$REPO" --json isDraft,assets)"
-            if [ "$(jq -r '.isDraft' <<<"$release_json")" = "true" ]; then
-              gh release upload "$TAG" "${files[@]}" --repo "$REPO" --clobber
-              gh release edit "$TAG" --repo "$REPO" --title "$VERSION" \
-                --notes-file release_notes.txt --draft=false
-            else
-              missing=0
-              for file in "${files[@]}"; do
-                asset_name="${file##*/}"
-                if ! jq -e --arg name "$asset_name" \
-                  '.assets[] | select(.name == $name)' <<<"$release_json" >/dev/null; then
-                  echo "Published release $TAG is missing expected asset: $asset_name" >&2
-                  missing=1
-                fi
-              done
-              if [ "$missing" -ne 0 ]; then
-                echo "Refusing to overwrite assets on a published release." >&2
-                exit 1
-              fi
-              gh release edit "$TAG" --repo "$REPO" --title "$VERSION" --notes-file release_notes.txt
-            fi
-          else
-            gh release create "$TAG" "${files[@]}" --repo "$REPO" \
-              --title "$VERSION" --notes-file release_notes.txt --verify-tag
-          fi
 
       - name: Summary
         env:

--- a/android/auto-mobile-sdk/src/main/AndroidManifest.xml
+++ b/android/auto-mobile-sdk/src/main/AndroidManifest.xml
@@ -1,9 +1,4 @@
 <?xml version="1.0" encoding="utf-8"?>
 <manifest xmlns:android="http://schemas.android.com/apk/res/android">
     <uses-permission android:name="android.permission.ACCESS_NETWORK_STATE" />
-
-    <!-- Signature-level permission so only same-signed apps (CtrlProxy) can send network control broadcasts -->
-    <permission
-        android:name="dev.jasonpearson.automobile.sdk.permission.NETWORK_CONTROL"
-        android:protectionLevel="signature" />
 </manifest>

--- a/android/auto-mobile-sdk/src/main/kotlin/dev/jasonpearson/automobile/sdk/FrameMetricsCollector.kt
+++ b/android/auto-mobile-sdk/src/main/kotlin/dev/jasonpearson/automobile/sdk/FrameMetricsCollector.kt
@@ -1,13 +1,10 @@
 package dev.jasonpearson.automobile.sdk
 
-import android.annotation.SuppressLint
 import android.app.Activity
 import android.app.Application
-import android.content.BroadcastReceiver
 import android.content.Context
 import android.content.Intent
 import android.content.IntentFilter
-import android.os.Build
 import android.os.Bundle
 import android.os.Handler
 import android.os.HandlerThread
@@ -48,6 +45,11 @@ internal object FrameMetricsCollector {
 
   private val enabled = AtomicBoolean(false)
   private val mainHandler = Handler(Looper.getMainLooper())
+  private val controlReceiverRegistrar = NetworkControlReceiverRegistrar { _, intent ->
+    if (intent?.action == AutoMobileSDK.ACTION_FRAME_METRICS_CONTROL) {
+      setEnabled(intent.getBooleanExtra(AutoMobileSDK.EXTRA_FRAME_METRICS_ENABLED, false))
+    }
+  }
   private var context: Context? = null
   private var application: Application? = null
 
@@ -79,11 +81,7 @@ internal object FrameMetricsCollector {
     setEnabled(false)
     val ctx = context
     if (ctx != null) {
-      try {
-        ctx.unregisterReceiver(controlReceiver)
-      } catch (_: IllegalArgumentException) {
-        // Receiver was never registered or already unregistered — safe to ignore.
-      }
+      controlReceiverRegistrar.unregister(ctx)
     }
     context = null
     application = null
@@ -247,31 +245,8 @@ internal object FrameMetricsCollector {
   // ---- remote enable/disable control --------------------------------------
 
   private fun registerControlReceiver(context: Context) {
-    val filter = IntentFilter().apply { addAction(AutoMobileSDK.ACTION_FRAME_METRICS_CONTROL) }
-    if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.TIRAMISU) {
-      context.registerReceiver(
-        controlReceiver,
-        filter,
-        SdkConstants.PERMISSION_NETWORK_CONTROL,
-        null,
-        Context.RECEIVER_EXPORTED,
-      )
-    } else {
-      @SuppressLint("UnspecifiedRegisterReceiverFlag")
-      context.registerReceiver(
-        controlReceiver,
-        filter,
-        SdkConstants.PERMISSION_NETWORK_CONTROL,
-        null,
-      )
+    controlReceiverRegistrar.register(context) {
+      IntentFilter().apply { addAction(AutoMobileSDK.ACTION_FRAME_METRICS_CONTROL) }
     }
   }
-
-  private val controlReceiver =
-    object : BroadcastReceiver() {
-      override fun onReceive(context: Context?, intent: Intent?) {
-        if (intent?.action != AutoMobileSDK.ACTION_FRAME_METRICS_CONTROL) return
-        setEnabled(intent.getBooleanExtra(AutoMobileSDK.EXTRA_FRAME_METRICS_ENABLED, false))
-      }
-    }
 }

--- a/android/auto-mobile-sdk/src/main/kotlin/dev/jasonpearson/automobile/sdk/NetworkControlReceiverRegistrar.kt
+++ b/android/auto-mobile-sdk/src/main/kotlin/dev/jasonpearson/automobile/sdk/NetworkControlReceiverRegistrar.kt
@@ -1,0 +1,79 @@
+package dev.jasonpearson.automobile.sdk
+
+import android.annotation.SuppressLint
+import android.content.BroadcastReceiver
+import android.content.Context
+import android.content.Intent
+import android.content.IntentFilter
+import android.os.Build
+
+/**
+ * Registers a control callback for both current and legacy CtrlProxy permissions.
+ *
+ * Android accepts only one sender permission per dynamically registered receiver. Separate receiver
+ * instances make the accepted permissions an OR condition. A sender that holds both permissions can
+ * deliver the same idempotent state-setting control broadcast twice.
+ */
+internal class NetworkControlReceiverRegistrar(
+  private val onControlBroadcast: (Context?, Intent?) -> Unit
+) {
+  private val receivers = mutableListOf<BroadcastReceiver>()
+
+  @Synchronized
+  fun register(context: Context, intentFilter: () -> IntentFilter) {
+    if (receivers.isNotEmpty()) return
+
+    val registeredReceivers = mutableListOf<BroadcastReceiver>()
+    try {
+      for (permission in SdkConstants.NETWORK_CONTROL_PERMISSIONS) {
+        val receiver =
+          object : BroadcastReceiver() {
+            override fun onReceive(context: Context?, intent: Intent?) =
+              onControlBroadcast(context, intent)
+          }
+        registerReceiver(context, receiver, intentFilter(), permission)
+        registeredReceivers += receiver
+      }
+      receivers += registeredReceivers
+    } catch (e: Exception) {
+      unregister(context, registeredReceivers)
+      throw e
+    }
+  }
+
+  @Synchronized
+  fun unregister(context: Context) {
+    unregister(context, receivers)
+    receivers.clear()
+  }
+
+  @SuppressLint("UnspecifiedRegisterReceiverFlag")
+  private fun registerReceiver(
+    context: Context,
+    receiver: BroadcastReceiver,
+    filter: IntentFilter,
+    permission: String,
+  ) {
+    if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.TIRAMISU) {
+      context.registerReceiver(
+        receiver,
+        filter,
+        permission,
+        null,
+        Context.RECEIVER_EXPORTED,
+      )
+    } else {
+      context.registerReceiver(receiver, filter, permission, null)
+    }
+  }
+
+  private fun unregister(context: Context, receivers: Collection<BroadcastReceiver>) {
+    for (receiver in receivers) {
+      try {
+        context.unregisterReceiver(receiver)
+      } catch (_: IllegalArgumentException) {
+        // Receiver was already unregistered by the platform.
+      }
+    }
+  }
+}

--- a/android/auto-mobile-sdk/src/main/kotlin/dev/jasonpearson/automobile/sdk/NetworkControlReceiverRegistrar.kt
+++ b/android/auto-mobile-sdk/src/main/kotlin/dev/jasonpearson/automobile/sdk/NetworkControlReceiverRegistrar.kt
@@ -7,44 +7,40 @@ import android.content.Intent
 import android.content.IntentFilter
 import android.os.Build
 
-/**
- * Registers a control callback for both current and legacy CtrlProxy permissions.
- *
- * Android accepts only one sender permission per dynamically registered receiver. Separate receiver
- * instances make the accepted permissions an OR condition. A sender that holds both permissions can
- * deliver the same idempotent state-setting control broadcast twice.
- */
+/** Registers a control callback protected by the CtrlProxy-owned signature permission. */
 internal class NetworkControlReceiverRegistrar(
   private val onControlBroadcast: (Context?, Intent?) -> Unit
 ) {
-  private val receivers = mutableListOf<BroadcastReceiver>()
+  private var receiver: BroadcastReceiver? = null
 
   @Synchronized
   fun register(context: Context, intentFilter: () -> IntentFilter) {
-    if (receivers.isNotEmpty()) return
+    if (receiver != null) return
 
-    val registeredReceivers = mutableListOf<BroadcastReceiver>()
-    try {
-      for (permission in SdkConstants.NETWORK_CONTROL_PERMISSIONS) {
-        val receiver =
-          object : BroadcastReceiver() {
-            override fun onReceive(context: Context?, intent: Intent?) =
-              onControlBroadcast(context, intent)
-          }
-        registerReceiver(context, receiver, intentFilter(), permission)
-        registeredReceivers += receiver
+    val registeredReceiver =
+      object : BroadcastReceiver() {
+        override fun onReceive(context: Context?, intent: Intent?) =
+          onControlBroadcast(context, intent)
       }
-      receivers += registeredReceivers
-    } catch (e: Exception) {
-      unregister(context, registeredReceivers)
-      throw e
-    }
+    registerReceiver(
+      context,
+      registeredReceiver,
+      intentFilter(),
+      SdkConstants.PERMISSION_NETWORK_CONTROL,
+    )
+    receiver = registeredReceiver
   }
 
   @Synchronized
   fun unregister(context: Context) {
-    unregister(context, receivers)
-    receivers.clear()
+    val registeredReceiver = receiver ?: return
+    try {
+      context.unregisterReceiver(registeredReceiver)
+    } catch (_: IllegalArgumentException) {
+      // Receiver was already unregistered by the platform.
+    } finally {
+      receiver = null
+    }
   }
 
   @SuppressLint("UnspecifiedRegisterReceiverFlag")
@@ -64,16 +60,6 @@ internal class NetworkControlReceiverRegistrar(
       )
     } else {
       context.registerReceiver(receiver, filter, permission, null)
-    }
-  }
-
-  private fun unregister(context: Context, receivers: Collection<BroadcastReceiver>) {
-    for (receiver in receivers) {
-      try {
-        context.unregisterReceiver(receiver)
-      } catch (_: IllegalArgumentException) {
-        // Receiver was already unregistered by the platform.
-      }
     }
   }
 }

--- a/android/auto-mobile-sdk/src/main/kotlin/dev/jasonpearson/automobile/sdk/RecompositionTracker.kt
+++ b/android/auto-mobile-sdk/src/main/kotlin/dev/jasonpearson/automobile/sdk/RecompositionTracker.kt
@@ -1,11 +1,8 @@
 package dev.jasonpearson.automobile.sdk
 
-import android.annotation.SuppressLint
-import android.content.BroadcastReceiver
 import android.content.Context
 import android.content.Intent
 import android.content.IntentFilter
-import android.os.Build
 import android.os.Handler
 import android.os.Looper
 import java.util.concurrent.ConcurrentHashMap
@@ -33,6 +30,11 @@ internal object RecompositionTracker {
   private val touchSequence = AtomicLong(0)
   private val enabled = AtomicBoolean(false)
   private val handler = Handler(Looper.getMainLooper())
+  private val controlReceiverRegistrar = NetworkControlReceiverRegistrar { _, intent ->
+    if (intent?.action == AutoMobileSDK.ACTION_RECOMPOSITION_CONTROL) {
+      setEnabled(intent.getBooleanExtra(AutoMobileSDK.EXTRA_RECOMPOSITION_ENABLED, false))
+    }
+  }
   private var context: Context? = null
 
   fun initialize(context: Context) {
@@ -46,11 +48,7 @@ internal object RecompositionTracker {
     setEnabled(false)
     val ctx = context
     if (ctx != null) {
-      try {
-        ctx.unregisterReceiver(controlReceiver)
-      } catch (_: IllegalArgumentException) {
-        // Receiver was never registered or already unregistered — safe to ignore.
-      }
+      controlReceiverRegistrar.unregister(ctx)
     }
     context = null
   }
@@ -161,35 +159,10 @@ internal object RecompositionTracker {
   }
 
   private fun registerControlReceiver(context: Context) {
-    val filter = IntentFilter().apply { addAction(AutoMobileSDK.ACTION_RECOMPOSITION_CONTROL) }
-
-    if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.TIRAMISU) {
-      context.registerReceiver(
-        controlReceiver,
-        filter,
-        SdkConstants.PERMISSION_NETWORK_CONTROL,
-        null,
-        Context.RECEIVER_EXPORTED,
-      )
-    } else {
-      @SuppressLint("UnspecifiedRegisterReceiverFlag")
-      context.registerReceiver(
-        controlReceiver,
-        filter,
-        SdkConstants.PERMISSION_NETWORK_CONTROL,
-        null,
-      )
+    controlReceiverRegistrar.register(context) {
+      IntentFilter().apply { addAction(AutoMobileSDK.ACTION_RECOMPOSITION_CONTROL) }
     }
   }
-
-  private val controlReceiver =
-    object : BroadcastReceiver() {
-      override fun onReceive(context: Context?, intent: Intent?) {
-        if (intent?.action != AutoMobileSDK.ACTION_RECOMPOSITION_CONTROL) return
-        val enabledFlag = intent.getBooleanExtra(AutoMobileSDK.EXTRA_RECOMPOSITION_ENABLED, false)
-        setEnabled(enabledFlag)
-      }
-    }
 
   private class Entry(val id: String) {
     /** LRU tick of the last record; read during eviction without the entry lock. */

--- a/android/auto-mobile-sdk/src/main/kotlin/dev/jasonpearson/automobile/sdk/SdkConstants.kt
+++ b/android/auto-mobile-sdk/src/main/kotlin/dev/jasonpearson/automobile/sdk/SdkConstants.kt
@@ -8,17 +8,4 @@ internal object SdkConstants {
   /** Signature-level permission for controlling SDK broadcast receivers. */
   const val PERMISSION_NETWORK_CONTROL =
     "dev.jasonpearson.automobile.ctrlproxy.permission.NETWORK_CONTROL_V2"
-
-  /** Permission held by released CtrlProxy versions before [PERMISSION_NETWORK_CONTROL]. */
-  const val LEGACY_PERMISSION_NETWORK_CONTROL =
-    "dev.jasonpearson.automobile.sdk.permission.NETWORK_CONTROL"
-
-  /**
-   * Permissions accepted from CtrlProxy control broadcasts, newest first.
-   *
-   * Dynamic receivers accept one sender permission per registration, so each permission requires a
-   * distinct receiver registration.
-   */
-  val NETWORK_CONTROL_PERMISSIONS =
-    listOf(PERMISSION_NETWORK_CONTROL, LEGACY_PERMISSION_NETWORK_CONTROL)
 }

--- a/android/auto-mobile-sdk/src/main/kotlin/dev/jasonpearson/automobile/sdk/SdkConstants.kt
+++ b/android/auto-mobile-sdk/src/main/kotlin/dev/jasonpearson/automobile/sdk/SdkConstants.kt
@@ -7,5 +7,5 @@ internal object SdkConstants {
 
   /** Signature-level permission for controlling SDK broadcast receivers. */
   const val PERMISSION_NETWORK_CONTROL =
-    "dev.jasonpearson.automobile.sdk.permission.NETWORK_CONTROL"
+    "dev.jasonpearson.automobile.ctrlproxy.permission.NETWORK_CONTROL_V2"
 }

--- a/android/auto-mobile-sdk/src/main/kotlin/dev/jasonpearson/automobile/sdk/SdkConstants.kt
+++ b/android/auto-mobile-sdk/src/main/kotlin/dev/jasonpearson/automobile/sdk/SdkConstants.kt
@@ -8,4 +8,17 @@ internal object SdkConstants {
   /** Signature-level permission for controlling SDK broadcast receivers. */
   const val PERMISSION_NETWORK_CONTROL =
     "dev.jasonpearson.automobile.ctrlproxy.permission.NETWORK_CONTROL_V2"
+
+  /** Permission held by released CtrlProxy versions before [PERMISSION_NETWORK_CONTROL]. */
+  const val LEGACY_PERMISSION_NETWORK_CONTROL =
+    "dev.jasonpearson.automobile.sdk.permission.NETWORK_CONTROL"
+
+  /**
+   * Permissions accepted from CtrlProxy control broadcasts, newest first.
+   *
+   * Dynamic receivers accept one sender permission per registration, so each permission requires a
+   * distinct receiver registration.
+   */
+  val NETWORK_CONTROL_PERMISSIONS =
+    listOf(PERMISSION_NETWORK_CONTROL, LEGACY_PERMISSION_NETWORK_CONTROL)
 }

--- a/android/auto-mobile-sdk/src/main/kotlin/dev/jasonpearson/automobile/sdk/network/NetworkMockRuleStore.kt
+++ b/android/auto-mobile-sdk/src/main/kotlin/dev/jasonpearson/automobile/sdk/network/NetworkMockRuleStore.kt
@@ -1,13 +1,11 @@
 package dev.jasonpearson.automobile.sdk.network
 
-import android.content.BroadcastReceiver
 import android.content.Context
 import android.content.Intent
 import android.content.IntentFilter
-import android.os.Build
 import dev.jasonpearson.automobile.protocol.NetworkMockRuleDto
 import dev.jasonpearson.automobile.sdk.AutoMobileSDK
-import dev.jasonpearson.automobile.sdk.SdkConstants
+import dev.jasonpearson.automobile.sdk.NetworkControlReceiverRegistrar
 import java.util.concurrent.CopyOnWriteArrayList
 import java.util.concurrent.atomic.AtomicInteger
 import kotlinx.serialization.builtins.ListSerializer
@@ -31,8 +29,6 @@ class NetworkMockRuleStore(private val clock: () -> Long = { System.currentTimeM
     const val EXTRA_ERROR_SIM_TYPE = "error_type"
     const val EXTRA_ERROR_SIM_LIMIT = "limit"
     const val EXTRA_ERROR_SIM_EXPIRES_AT = "expires_at"
-    private const val PERMISSION_NETWORK_CONTROL = SdkConstants.PERMISSION_NETWORK_CONTROL
-
     @Volatile private var instance: NetworkMockRuleStore? = null
 
     fun getInstance(): NetworkMockRuleStore {
@@ -48,11 +44,6 @@ class NetworkMockRuleStore(private val clock: () -> Long = { System.currentTimeM
       getInstance().unregisterReceiver(context)
     }
   }
-
-  // Guards against double-registration on re-init and ensures unregister runs at
-  // most once — the receiver is a process singleton, so a leaked/duplicate
-  // registration would double-handle every broadcast (#3599).
-  private var receiverRegistered = false
 
   /** Interface for the interceptor to query rules without depending on the full store. */
   interface RuleMatcher {
@@ -93,6 +84,9 @@ class NetworkMockRuleStore(private val clock: () -> Long = { System.currentTimeM
   @Volatile private var errorSimulation: ErrorSimulationConfig? = null
 
   private val json = Json { ignoreUnknownKeys = true }
+  private val controlReceiverRegistrar = NetworkControlReceiverRegistrar { _, intent ->
+    handleControlBroadcast(intent)
+  }
 
   val ruleMatcher: RuleMatcher =
     object : RuleMatcher {
@@ -206,68 +200,48 @@ class NetworkMockRuleStore(private val clock: () -> Long = { System.currentTimeM
 
   @Synchronized
   fun registerReceiver(context: Context) {
-    if (receiverRegistered) return
-    val filter =
+    controlReceiverRegistrar.register(context) {
       IntentFilter().apply {
         addAction(ACTION_NETWORK_MOCK_RULES)
         addAction(ACTION_NETWORK_ERROR_SIMULATION)
       }
-    if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.TIRAMISU) {
-      context.registerReceiver(
-        receiver,
-        filter,
-        PERMISSION_NETWORK_CONTROL,
-        null,
-        Context.RECEIVER_EXPORTED,
-      )
-    } else {
-      context.registerReceiver(receiver, filter, PERMISSION_NETWORK_CONTROL, null)
     }
-    receiverRegistered = true
     AutoMobileSDK.logger.d(TAG) {
-      "Registered broadcast receiver for network mock rules (permission-gated)"
+      "Registered broadcast receivers for network mock rules (permission-gated)"
     }
   }
 
   @Synchronized
   fun unregisterReceiver(context: Context) {
-    if (!receiverRegistered) return
-    try {
-      context.unregisterReceiver(receiver)
-    } catch (_: Exception) {}
-    receiverRegistered = false
+    controlReceiverRegistrar.unregister(context)
   }
 
-  private val receiver =
-    object : BroadcastReceiver() {
-      override fun onReceive(context: Context?, intent: Intent?) {
-        if (intent == null) return
-        when (intent.action) {
-          ACTION_NETWORK_MOCK_RULES -> {
-            val rulesJson = intent.getStringExtra(EXTRA_RULES_JSON) ?: return
-            try {
-              val dtos =
-                json.decodeFromString(
-                  ListSerializer(NetworkMockRuleDto.serializer()),
-                  rulesJson,
-                )
-              setRules(dtos)
-            } catch (e: Exception) {
-              AutoMobileSDK.logger.e(TAG) { "Failed to parse mock rules: ${e.message}" }
-            }
-          }
-          ACTION_NETWORK_ERROR_SIMULATION -> {
-            val enabled = intent.getBooleanExtra(EXTRA_ERROR_SIM_ENABLED, false)
-            val errorType = intent.getStringExtra(EXTRA_ERROR_SIM_TYPE)
-            val limit =
-              intent.getIntExtra(EXTRA_ERROR_SIM_LIMIT, -1).let { if (it == -1) null else it }
-            val expiresAt =
-              intent.getLongExtra(EXTRA_ERROR_SIM_EXPIRES_AT, -1).let {
-                if (it == -1L) null else it
-              }
-            setErrorSimulation(enabled, errorType, limit, expiresAt)
-          }
+  private fun handleControlBroadcast(intent: Intent?) {
+    if (intent == null) return
+    when (intent.action) {
+      ACTION_NETWORK_MOCK_RULES -> {
+        val rulesJson = intent.getStringExtra(EXTRA_RULES_JSON) ?: return
+        try {
+          val dtos =
+            json.decodeFromString(
+              ListSerializer(NetworkMockRuleDto.serializer()),
+              rulesJson,
+            )
+          setRules(dtos)
+        } catch (e: Exception) {
+          AutoMobileSDK.logger.e(TAG) { "Failed to parse mock rules: ${e.message}" }
         }
       }
+      ACTION_NETWORK_ERROR_SIMULATION -> {
+        val enabled = intent.getBooleanExtra(EXTRA_ERROR_SIM_ENABLED, false)
+        val errorType = intent.getStringExtra(EXTRA_ERROR_SIM_TYPE)
+        val limit = intent.getIntExtra(EXTRA_ERROR_SIM_LIMIT, -1).let { if (it == -1) null else it }
+        val expiresAt =
+          intent.getLongExtra(EXTRA_ERROR_SIM_EXPIRES_AT, -1).let {
+            if (it == -1L) null else it
+          }
+        setErrorSimulation(enabled, errorType, limit, expiresAt)
+      }
     }
+  }
 }

--- a/android/auto-mobile-sdk/src/test/kotlin/dev/jasonpearson/automobile/sdk/network/NetworkMockRuleStoreReceiverTest.kt
+++ b/android/auto-mobile-sdk/src/test/kotlin/dev/jasonpearson/automobile/sdk/network/NetworkMockRuleStoreReceiverTest.kt
@@ -10,7 +10,6 @@ import io.mockk.mockk
 import io.mockk.slot
 import io.mockk.verify
 import org.junit.Assert.assertEquals
-import org.junit.Assert.assertNotSame
 import org.junit.Test
 import org.junit.runner.RunWith
 import org.robolectric.RobolectricTestRunner
@@ -21,40 +20,24 @@ import org.robolectric.annotation.Config
 class NetworkMockRuleStoreReceiverTest {
 
   @Test
-  fun `network control receiver accepts current and legacy CtrlProxy permissions`() {
+  fun `network control receiver accepts only CtrlProxy owned V2 permission`() {
     assertEquals(
-      listOf(
-        "dev.jasonpearson.automobile.ctrlproxy.permission.NETWORK_CONTROL_V2",
-        "dev.jasonpearson.automobile.sdk.permission.NETWORK_CONTROL",
-      ),
-      SdkConstants.NETWORK_CONTROL_PERMISSIONS,
+      "dev.jasonpearson.automobile.ctrlproxy.permission.NETWORK_CONTROL_V2",
+      SdkConstants.PERMISSION_NETWORK_CONTROL,
     )
   }
 
-  /**
-   * Each permission needs a distinct receiver registration, while repeat initialization remains a
-   * no-op and teardown unregisters every registration (#3599).
-   */
+  /** Repeat initialization remains a no-op and teardown unregisters the receiver (#3599). */
   @Test
-  fun `registerReceiver is idempotent and unregisters both permission receivers`() {
+  fun `registerReceiver is idempotent and unregister allows re-register`() {
     val store = NetworkMockRuleStore()
     val context = mockk<Context>(relaxed = true)
-    val currentReceiver = slot<BroadcastReceiver>()
-    val legacyReceiver = slot<BroadcastReceiver>()
+    val receiver = slot<BroadcastReceiver>()
     every {
       context.registerReceiver(
         any<BroadcastReceiver>(),
         any<IntentFilter>(),
         SdkConstants.PERMISSION_NETWORK_CONTROL,
-        null,
-        Context.RECEIVER_EXPORTED,
-      )
-    } returns null
-    every {
-      context.registerReceiver(
-        any<BroadcastReceiver>(),
-        any<IntentFilter>(),
-        SdkConstants.LEGACY_PERMISSION_NETWORK_CONTROL,
         null,
         Context.RECEIVER_EXPORTED,
       )
@@ -65,45 +48,25 @@ class NetworkMockRuleStoreReceiverTest {
 
     verify(exactly = 1) {
       context.registerReceiver(
-        capture(currentReceiver),
+        capture(receiver),
         any<IntentFilter>(),
         SdkConstants.PERMISSION_NETWORK_CONTROL,
         null,
         Context.RECEIVER_EXPORTED,
       )
     }
-    verify(exactly = 1) {
-      context.registerReceiver(
-        capture(legacyReceiver),
-        any<IntentFilter>(),
-        SdkConstants.LEGACY_PERMISSION_NETWORK_CONTROL,
-        null,
-        Context.RECEIVER_EXPORTED,
-      )
-    }
-    assertNotSame(currentReceiver.captured, legacyReceiver.captured)
 
     store.unregisterReceiver(context)
     store.unregisterReceiver(context) // guarded no-op
-    verify(exactly = 1) { context.unregisterReceiver(currentReceiver.captured) }
-    verify(exactly = 1) { context.unregisterReceiver(legacyReceiver.captured) }
+    verify(exactly = 1) { context.unregisterReceiver(receiver.captured) }
 
-    // After unregister, both registrations can be restored.
+    // After unregister, registration can be restored.
     store.registerReceiver(context)
     verify(exactly = 2) {
       context.registerReceiver(
         any<BroadcastReceiver>(),
         any<IntentFilter>(),
         SdkConstants.PERMISSION_NETWORK_CONTROL,
-        null,
-        Context.RECEIVER_EXPORTED,
-      )
-    }
-    verify(exactly = 2) {
-      context.registerReceiver(
-        any<BroadcastReceiver>(),
-        any<IntentFilter>(),
-        SdkConstants.LEGACY_PERMISSION_NETWORK_CONTROL,
         null,
         Context.RECEIVER_EXPORTED,
       )

--- a/android/auto-mobile-sdk/src/test/kotlin/dev/jasonpearson/automobile/sdk/network/NetworkMockRuleStoreReceiverTest.kt
+++ b/android/auto-mobile-sdk/src/test/kotlin/dev/jasonpearson/automobile/sdk/network/NetworkMockRuleStoreReceiverTest.kt
@@ -7,8 +7,10 @@ import android.os.Build
 import dev.jasonpearson.automobile.sdk.SdkConstants
 import io.mockk.every
 import io.mockk.mockk
+import io.mockk.slot
 import io.mockk.verify
 import org.junit.Assert.assertEquals
+import org.junit.Assert.assertNotSame
 import org.junit.Test
 import org.junit.runner.RunWith
 import org.robolectric.RobolectricTestRunner
@@ -19,29 +21,42 @@ import org.robolectric.annotation.Config
 class NetworkMockRuleStoreReceiverTest {
 
   @Test
-  fun `network control receiver uses CtrlProxy owned versioned permission`() {
+  fun `network control receiver accepts current and legacy CtrlProxy permissions`() {
     assertEquals(
-      "dev.jasonpearson.automobile.ctrlproxy.permission.NETWORK_CONTROL_V2",
-      SdkConstants.PERMISSION_NETWORK_CONTROL,
+      listOf(
+        "dev.jasonpearson.automobile.ctrlproxy.permission.NETWORK_CONTROL_V2",
+        "dev.jasonpearson.automobile.sdk.permission.NETWORK_CONTROL",
+      ),
+      SdkConstants.NETWORK_CONTROL_PERMISSIONS,
     )
   }
 
   /**
-   * The receiver must register at most once and unregister must allow a later re-register — without
-   * the idempotency guard, re-init leaked/double-registered it so every broadcast was handled twice
-   * (#3599).
+   * Each permission needs a distinct receiver registration, while repeat initialization remains a
+   * no-op and teardown unregisters every registration (#3599).
    */
   @Test
-  fun `registerReceiver is idempotent and unregister allows re-register`() {
+  fun `registerReceiver is idempotent and unregisters both permission receivers`() {
     val store = NetworkMockRuleStore()
     val context = mockk<Context>(relaxed = true)
+    val currentReceiver = slot<BroadcastReceiver>()
+    val legacyReceiver = slot<BroadcastReceiver>()
     every {
       context.registerReceiver(
         any<BroadcastReceiver>(),
         any<IntentFilter>(),
         SdkConstants.PERMISSION_NETWORK_CONTROL,
-        any(),
-        any<Int>(),
+        null,
+        Context.RECEIVER_EXPORTED,
+      )
+    } returns null
+    every {
+      context.registerReceiver(
+        any<BroadcastReceiver>(),
+        any<IntentFilter>(),
+        SdkConstants.LEGACY_PERMISSION_NETWORK_CONTROL,
+        null,
+        Context.RECEIVER_EXPORTED,
       )
     } returns null
 
@@ -50,26 +65,47 @@ class NetworkMockRuleStoreReceiverTest {
 
     verify(exactly = 1) {
       context.registerReceiver(
-        any<BroadcastReceiver>(),
+        capture(currentReceiver),
         any<IntentFilter>(),
         SdkConstants.PERMISSION_NETWORK_CONTROL,
-        any(),
-        any<Int>(),
+        null,
+        Context.RECEIVER_EXPORTED,
       )
     }
+    verify(exactly = 1) {
+      context.registerReceiver(
+        capture(legacyReceiver),
+        any<IntentFilter>(),
+        SdkConstants.LEGACY_PERMISSION_NETWORK_CONTROL,
+        null,
+        Context.RECEIVER_EXPORTED,
+      )
+    }
+    assertNotSame(currentReceiver.captured, legacyReceiver.captured)
 
     store.unregisterReceiver(context)
-    verify(exactly = 1) { context.unregisterReceiver(any<BroadcastReceiver>()) }
+    store.unregisterReceiver(context) // guarded no-op
+    verify(exactly = 1) { context.unregisterReceiver(currentReceiver.captured) }
+    verify(exactly = 1) { context.unregisterReceiver(legacyReceiver.captured) }
 
-    // After unregister, register works again (total of two registrations).
+    // After unregister, both registrations can be restored.
     store.registerReceiver(context)
     verify(exactly = 2) {
       context.registerReceiver(
         any<BroadcastReceiver>(),
         any<IntentFilter>(),
         SdkConstants.PERMISSION_NETWORK_CONTROL,
-        any(),
-        any<Int>(),
+        null,
+        Context.RECEIVER_EXPORTED,
+      )
+    }
+    verify(exactly = 2) {
+      context.registerReceiver(
+        any<BroadcastReceiver>(),
+        any<IntentFilter>(),
+        SdkConstants.LEGACY_PERMISSION_NETWORK_CONTROL,
+        null,
+        Context.RECEIVER_EXPORTED,
       )
     }
   }

--- a/android/auto-mobile-sdk/src/test/kotlin/dev/jasonpearson/automobile/sdk/network/NetworkMockRuleStoreReceiverTest.kt
+++ b/android/auto-mobile-sdk/src/test/kotlin/dev/jasonpearson/automobile/sdk/network/NetworkMockRuleStoreReceiverTest.kt
@@ -8,6 +8,7 @@ import dev.jasonpearson.automobile.sdk.SdkConstants
 import io.mockk.every
 import io.mockk.mockk
 import io.mockk.verify
+import org.junit.Assert.assertEquals
 import org.junit.Test
 import org.junit.runner.RunWith
 import org.robolectric.RobolectricTestRunner
@@ -16,6 +17,14 @@ import org.robolectric.annotation.Config
 @RunWith(RobolectricTestRunner::class)
 @Config(sdk = [Build.VERSION_CODES.TIRAMISU])
 class NetworkMockRuleStoreReceiverTest {
+
+  @Test
+  fun `network control receiver uses CtrlProxy owned versioned permission`() {
+    assertEquals(
+      "dev.jasonpearson.automobile.ctrlproxy.permission.NETWORK_CONTROL_V2",
+      SdkConstants.PERMISSION_NETWORK_CONTROL,
+    )
+  }
 
   /**
    * The receiver must register at most once and unregister must allow a later re-register — without

--- a/android/auto-mobile-sdk/src/test/kotlin/dev/jasonpearson/automobile/sdk/network/NetworkMockRuleStoreReceiverTest.kt
+++ b/android/auto-mobile-sdk/src/test/kotlin/dev/jasonpearson/automobile/sdk/network/NetworkMockRuleStoreReceiverTest.kt
@@ -4,6 +4,7 @@ import android.content.BroadcastReceiver
 import android.content.Context
 import android.content.IntentFilter
 import android.os.Build
+import dev.jasonpearson.automobile.sdk.SdkConstants
 import io.mockk.every
 import io.mockk.mockk
 import io.mockk.verify
@@ -29,7 +30,7 @@ class NetworkMockRuleStoreReceiverTest {
       context.registerReceiver(
         any<BroadcastReceiver>(),
         any<IntentFilter>(),
-        any<String>(),
+        SdkConstants.PERMISSION_NETWORK_CONTROL,
         any(),
         any<Int>(),
       )
@@ -42,7 +43,7 @@ class NetworkMockRuleStoreReceiverTest {
       context.registerReceiver(
         any<BroadcastReceiver>(),
         any<IntentFilter>(),
-        any<String>(),
+        SdkConstants.PERMISSION_NETWORK_CONTROL,
         any(),
         any<Int>(),
       )
@@ -57,7 +58,7 @@ class NetworkMockRuleStoreReceiverTest {
       context.registerReceiver(
         any<BroadcastReceiver>(),
         any<IntentFilter>(),
-        any<String>(),
+        SdkConstants.PERMISSION_NETWORK_CONTROL,
         any(),
         any<Int>(),
       )

--- a/android/control-proxy/src/debug/AndroidManifest.xml
+++ b/android/control-proxy/src/debug/AndroidManifest.xml
@@ -1,0 +1,13 @@
+<?xml version="1.0" encoding="utf-8"?>
+<manifest xmlns:android="http://schemas.android.com/apk/res/android">
+  <application>
+    <receiver
+      android:name=".NetworkControlContractReceiver"
+      android:exported="true"
+      android:permission="android.permission.DUMP">
+      <intent-filter>
+        <action android:name="dev.jasonpearson.automobile.ctrlproxy.action.TEST_SEND_NETWORK_CONTROL" />
+      </intent-filter>
+    </receiver>
+  </application>
+</manifest>

--- a/android/control-proxy/src/debug/kotlin/dev/jasonpearson/automobile/ctrlproxy/NetworkControlContractReceiver.kt
+++ b/android/control-proxy/src/debug/kotlin/dev/jasonpearson/automobile/ctrlproxy/NetworkControlContractReceiver.kt
@@ -1,0 +1,27 @@
+package dev.jasonpearson.automobile.ctrlproxy
+
+import android.content.BroadcastReceiver
+import android.content.Context
+import android.content.Intent
+import dev.jasonpearson.automobile.sdk.network.NetworkMockRuleStore
+
+/** Debug-only trigger for the emulator contract test. */
+class NetworkControlContractReceiver : BroadcastReceiver() {
+  override fun onReceive(context: Context, intent: Intent) {
+    if (intent.action != ACTION_SEND_NETWORK_CONTROL) return
+
+    context.sendBroadcast(
+      Intent(NetworkMockRuleStore.ACTION_NETWORK_ERROR_SIMULATION).apply {
+        putExtra(NetworkMockRuleStore.EXTRA_ERROR_SIM_ENABLED, true)
+        putExtra(NetworkMockRuleStore.EXTRA_ERROR_SIM_TYPE, ERROR_TYPE)
+        putExtra(NetworkMockRuleStore.EXTRA_ERROR_SIM_EXPIRES_AT, Long.MAX_VALUE)
+      }
+    )
+  }
+
+  companion object {
+    const val ACTION_SEND_NETWORK_CONTROL =
+      "dev.jasonpearson.automobile.ctrlproxy.action.TEST_SEND_NETWORK_CONTROL"
+    const val ERROR_TYPE = "ctrlproxy-v2"
+  }
+}

--- a/android/control-proxy/src/main/AndroidManifest.xml
+++ b/android/control-proxy/src/main/AndroidManifest.xml
@@ -12,6 +12,11 @@
   <uses-permission
       android:name="android.permission.QUERY_ALL_PACKAGES"
       tools:ignore="QueryAllPackagesPermission" />
+
+  <!-- CtrlProxy owns this signature permission; SDK hosts only consume it. -->
+  <permission
+      android:name="dev.jasonpearson.automobile.sdk.permission.NETWORK_CONTROL"
+      android:protectionLevel="signature" />
   <uses-permission android:name="dev.jasonpearson.automobile.sdk.permission.NETWORK_CONTROL" />
 
   <!-- Permissions required for accessibility service -->

--- a/android/control-proxy/src/main/AndroidManifest.xml
+++ b/android/control-proxy/src/main/AndroidManifest.xml
@@ -15,9 +15,9 @@
 
   <!-- CtrlProxy owns this signature permission; SDK hosts only consume it. -->
   <permission
-      android:name="dev.jasonpearson.automobile.sdk.permission.NETWORK_CONTROL"
+      android:name="dev.jasonpearson.automobile.ctrlproxy.permission.NETWORK_CONTROL_V2"
       android:protectionLevel="signature" />
-  <uses-permission android:name="dev.jasonpearson.automobile.sdk.permission.NETWORK_CONTROL" />
+  <uses-permission android:name="dev.jasonpearson.automobile.ctrlproxy.permission.NETWORK_CONTROL_V2" />
 
   <!-- Permissions required for accessibility service -->
   <uses-permission android:name="android.permission.WRITE_EXTERNAL_STORAGE" />

--- a/android/control-proxy/src/main/AndroidManifest.xml
+++ b/android/control-proxy/src/main/AndroidManifest.xml
@@ -18,8 +18,6 @@
       android:name="dev.jasonpearson.automobile.ctrlproxy.permission.NETWORK_CONTROL_V2"
       android:protectionLevel="signature" />
   <uses-permission android:name="dev.jasonpearson.automobile.ctrlproxy.permission.NETWORK_CONTROL_V2" />
-  <!-- Legacy SDK hosts still require this permission on CtrlProxy control broadcasts. -->
-  <uses-permission android:name="dev.jasonpearson.automobile.sdk.permission.NETWORK_CONTROL" />
 
   <!-- Permissions required for accessibility service -->
   <uses-permission android:name="android.permission.WRITE_EXTERNAL_STORAGE" />

--- a/android/control-proxy/src/main/AndroidManifest.xml
+++ b/android/control-proxy/src/main/AndroidManifest.xml
@@ -18,6 +18,8 @@
       android:name="dev.jasonpearson.automobile.ctrlproxy.permission.NETWORK_CONTROL_V2"
       android:protectionLevel="signature" />
   <uses-permission android:name="dev.jasonpearson.automobile.ctrlproxy.permission.NETWORK_CONTROL_V2" />
+  <!-- Legacy SDK hosts still require this permission on CtrlProxy control broadcasts. -->
+  <uses-permission android:name="dev.jasonpearson.automobile.sdk.permission.NETWORK_CONTROL" />
 
   <!-- Permissions required for accessibility service -->
   <uses-permission android:name="android.permission.WRITE_EXTERNAL_STORAGE" />

--- a/android/control-proxy/src/main/kotlin/dev/jasonpearson/automobile/ctrlproxy/CtrlProxy.kt
+++ b/android/control-proxy/src/main/kotlin/dev/jasonpearson/automobile/ctrlproxy/CtrlProxy.kt
@@ -359,11 +359,20 @@ class CtrlProxy : AccessibilityService(), CtrlProxyActions {
     SdkEventBatchProcessor(
       scope = serviceScope,
       navigationEventAccumulator = navigationEventAccumulator,
-      awaitClientConnection = { webSocketServer.awaitClientConnection() },
       broadcastNavigationEvent = { event ->
-        broadcastNavigationEvent(event, WebSocketServer.BroadcastMode.Sync)
+        broadcastNavigationEvent(
+          event,
+          mode = WebSocketServer.BroadcastMode.Sync,
+          waitForClient = true,
+        )
       },
-      broadcastSdkEvent = { event -> broadcastSdkEvent(event, WebSocketServer.BroadcastMode.Sync) },
+      broadcastSdkEvent = { event ->
+        broadcastSdkEvent(
+          event,
+          mode = WebSocketServer.BroadcastMode.Sync,
+          waitForClient = true,
+        )
+      },
     )
   }
   private lateinit var overlayManager: OverlayManager
@@ -5603,6 +5612,7 @@ class CtrlProxy : AccessibilityService(), CtrlProxyActions {
   private suspend fun broadcastNavigationEvent(
     event: TimestampedNavigationEvent,
     mode: WebSocketServer.BroadcastMode = WebSocketServer.BroadcastMode.Async,
+    waitForClient: Boolean = false,
   ) {
     if (!::webSocketServer.isInitialized || !webSocketServer.isRunning()) {
       Log.d(TAG, "WebSocket server not running, skipping navigation event broadcast")
@@ -5612,7 +5622,7 @@ class CtrlProxy : AccessibilityService(), CtrlProxyActions {
     try {
       val response = navigationEventResponse(event)
 
-      webSocketServer.broadcast(response, mode)
+      webSocketServer.broadcast(response, mode, waitForClient)
       Log.d(
         TAG,
         "Broadcasted navigation event to ${webSocketServer.getConnectionCount()} clients: ${event.destination}",
@@ -5797,6 +5807,7 @@ class CtrlProxy : AccessibilityService(), CtrlProxyActions {
   private suspend fun broadcastSdkEvent(
     event: SdkEvent,
     mode: WebSocketServer.BroadcastMode = WebSocketServer.BroadcastMode.Async,
+    waitForClient: Boolean = false,
   ) {
     if (!::webSocketServer.isInitialized || !webSocketServer.isRunning()) return
 
@@ -5873,7 +5884,7 @@ class CtrlProxy : AccessibilityService(), CtrlProxyActions {
           is SdkEventBatch -> null
         }
 
-      response?.let { webSocketServer.broadcast(it, mode) }
+      response?.let { webSocketServer.broadcast(it, mode, waitForClient) }
     } catch (e: CancellationException) {
       // Let cooperative cancellation unwind cleanly rather than logging it as an error (#3191).
       throw e

--- a/android/control-proxy/src/main/kotlin/dev/jasonpearson/automobile/ctrlproxy/CtrlProxy.kt
+++ b/android/control-proxy/src/main/kotlin/dev/jasonpearson/automobile/ctrlproxy/CtrlProxy.kt
@@ -359,8 +359,10 @@ class CtrlProxy : AccessibilityService(), CtrlProxyActions {
     SdkEventBatchProcessor(
       scope = serviceScope,
       navigationEventAccumulator = navigationEventAccumulator,
-      broadcastNavigationEvent = ::broadcastNavigationEvent,
-      broadcastSdkEvent = ::broadcastSdkEvent,
+      broadcastNavigationEvent = { event ->
+        broadcastNavigationEvent(event, WebSocketServer.BroadcastMode.Sync)
+      },
+      broadcastSdkEvent = { event -> broadcastSdkEvent(event, WebSocketServer.BroadcastMode.Sync) },
     )
   }
   private lateinit var overlayManager: OverlayManager
@@ -1153,8 +1155,11 @@ class CtrlProxy : AccessibilityService(), CtrlProxyActions {
             }
           }
           .launchIn(serviceScope)
-      sdkEventBatchProcessor.start()
-      Log.d(TAG, "SDK event batch processor started")
+      serviceScope.launch {
+        webSocketServer.awaitFirstClientConnection()
+        sdkEventBatchProcessor.start()
+        Log.d(TAG, "SDK event batch processor started after first WebSocket client connected")
+      }
 
       // Start logcat reader for automatic log capture
       logcatReader = LogcatReader { response ->
@@ -5597,7 +5602,10 @@ class CtrlProxy : AccessibilityService(), CtrlProxyActions {
   }
 
   /** Broadcast navigation event to WebSocket clients using typed protocol */
-  private suspend fun broadcastNavigationEvent(event: TimestampedNavigationEvent) {
+  private suspend fun broadcastNavigationEvent(
+    event: TimestampedNavigationEvent,
+    mode: WebSocketServer.BroadcastMode = WebSocketServer.BroadcastMode.Async,
+  ) {
     if (!::webSocketServer.isInitialized || !webSocketServer.isRunning()) {
       Log.d(TAG, "WebSocket server not running, skipping navigation event broadcast")
       return
@@ -5606,7 +5614,7 @@ class CtrlProxy : AccessibilityService(), CtrlProxyActions {
     try {
       val response = navigationEventResponse(event)
 
-      webSocketServer.broadcast(response)
+      webSocketServer.broadcast(response, mode)
       Log.d(
         TAG,
         "Broadcasted navigation event to ${webSocketServer.getConnectionCount()} clients: ${event.destination}",
@@ -5788,7 +5796,10 @@ class CtrlProxy : AccessibilityService(), CtrlProxyActions {
   }
 
   /** Broadcast an individual SDK event from a batch to WebSocket clients. */
-  private suspend fun broadcastSdkEvent(event: SdkEvent) {
+  private suspend fun broadcastSdkEvent(
+    event: SdkEvent,
+    mode: WebSocketServer.BroadcastMode = WebSocketServer.BroadcastMode.Async,
+  ) {
     if (!::webSocketServer.isInitialized || !webSocketServer.isRunning()) return
 
     try {
@@ -5864,7 +5875,7 @@ class CtrlProxy : AccessibilityService(), CtrlProxyActions {
           is SdkEventBatch -> null
         }
 
-      response?.let { webSocketServer.broadcast(it) }
+      response?.let { webSocketServer.broadcast(it, mode) }
     } catch (e: CancellationException) {
       // Let cooperative cancellation unwind cleanly rather than logging it as an error (#3191).
       throw e

--- a/android/control-proxy/src/main/kotlin/dev/jasonpearson/automobile/ctrlproxy/CtrlProxy.kt
+++ b/android/control-proxy/src/main/kotlin/dev/jasonpearson/automobile/ctrlproxy/CtrlProxy.kt
@@ -940,6 +940,29 @@ class CtrlProxy : AccessibilityService(), CtrlProxyActions {
         registerReceiver(commandReceiver, commandFilter)
       }
 
+      // Register SDK event receivers before the slower service initialization below. The SDK
+      // sender cannot detect an absent dynamic receiver, while SdkEventBatchProcessor retains
+      // accepted events until the WebSocket starts.
+      val navigationFilter =
+        IntentFilter().apply { addAction(AutoMobileSDK.ACTION_NAVIGATION_EVENT) }
+      if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.TIRAMISU) {
+        registerReceiver(navigationEventReceiver, navigationFilter, RECEIVER_EXPORTED)
+      } else {
+        @SuppressLint("UnspecifiedRegisterReceiverFlag")
+        registerReceiver(navigationEventReceiver, navigationFilter)
+      }
+      Log.d(TAG, "Navigation event receiver registered")
+
+      val eventBatchFilter =
+        IntentFilter().apply { addAction(SdkEventSerializer.ACTION_SDK_EVENT_BATCH) }
+      if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.TIRAMISU) {
+        registerReceiver(eventBatchReceiver, eventBatchFilter, RECEIVER_EXPORTED)
+      } else {
+        @SuppressLint("UnspecifiedRegisterReceiverFlag")
+        registerReceiver(eventBatchReceiver, eventBatchFilter)
+      }
+      Log.d(TAG, "Event batch receiver registered")
+
       // Register broadcast receiver for recomposition snapshots
       val recompositionFilter =
         IntentFilter().apply { addAction(AutoMobileSDK.ACTION_RECOMPOSITION_SNAPSHOT) }
@@ -1130,26 +1153,8 @@ class CtrlProxy : AccessibilityService(), CtrlProxyActions {
             }
           }
           .launchIn(serviceScope)
-
-      val navigationFilter =
-        IntentFilter().apply { addAction(AutoMobileSDK.ACTION_NAVIGATION_EVENT) }
-      if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.TIRAMISU) {
-        registerReceiver(navigationEventReceiver, navigationFilter, RECEIVER_EXPORTED)
-      } else {
-        @SuppressLint("UnspecifiedRegisterReceiverFlag")
-        registerReceiver(navigationEventReceiver, navigationFilter)
-      }
-      Log.d(TAG, "Navigation event receiver registered")
-
-      val eventBatchFilter =
-        IntentFilter().apply { addAction(SdkEventSerializer.ACTION_SDK_EVENT_BATCH) }
-      if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.TIRAMISU) {
-        registerReceiver(eventBatchReceiver, eventBatchFilter, RECEIVER_EXPORTED)
-      } else {
-        @SuppressLint("UnspecifiedRegisterReceiverFlag")
-        registerReceiver(eventBatchReceiver, eventBatchFilter)
-      }
-      Log.d(TAG, "Event batch receiver registered")
+      sdkEventBatchProcessor.start()
+      Log.d(TAG, "SDK event batch processor started")
 
       // Start logcat reader for automatic log capture
       logcatReader = LogcatReader { response ->

--- a/android/control-proxy/src/main/kotlin/dev/jasonpearson/automobile/ctrlproxy/CtrlProxy.kt
+++ b/android/control-proxy/src/main/kotlin/dev/jasonpearson/automobile/ctrlproxy/CtrlProxy.kt
@@ -159,6 +159,20 @@ internal fun nodeActionId(action: String): Int? =
     else -> null
   }
 
+internal fun navigationEventResponse(event: TimestampedNavigationEvent): NavigationEventResponse =
+  NavigationEventResponse(
+    timestamp = event.timestamp,
+    event =
+      NavigationEventData(
+        destination = event.destination,
+        source = event.source,
+        arguments = event.arguments.takeIf { it.isNotEmpty() },
+        metadata = event.metadata.takeIf { it.isNotEmpty() },
+        applicationId = event.applicationId,
+        sequenceNumber = event.sequenceNumber,
+      ),
+  )
+
 /**
  * Main AutoMobile Accessibility Service that provides view hierarchy extraction capabilities for
  * automated testing and UI interaction.
@@ -483,6 +497,7 @@ class CtrlProxy : AccessibilityService(), CtrlProxyActions {
                 event.arguments ?: emptyMap(),
                 event.metadata ?: emptyMap(),
                 event.applicationId,
+                event.timestamp,
               )
               return
             }
@@ -860,7 +875,12 @@ class CtrlProxy : AccessibilityService(), CtrlProxyActions {
 
           serviceScope.launch {
             for (event in batch.events) {
-              broadcastSdkEvent(event)
+              if (event is SdkNavigationEvent) {
+                val navigationEvent = navigationEventAccumulator.addSdkNavigationEvent(event)
+                broadcastNavigationEvent(navigationEvent)
+              } else {
+                broadcastSdkEvent(event)
+              }
             }
           }
         } catch (e: Exception) {
@@ -5571,19 +5591,7 @@ class CtrlProxy : AccessibilityService(), CtrlProxyActions {
     }
 
     try {
-      val response =
-        NavigationEventResponse(
-          timestamp = System.currentTimeMillis(),
-          event =
-            NavigationEventData(
-              destination = event.destination,
-              source = event.source,
-              arguments = event.arguments.takeIf { it.isNotEmpty() },
-              metadata = event.metadata.takeIf { it.isNotEmpty() },
-              applicationId = event.applicationId,
-              sequenceNumber = event.sequenceNumber,
-            ),
-        )
+      val response = navigationEventResponse(event)
 
       webSocketServer.broadcast(response)
       Log.d(

--- a/android/control-proxy/src/main/kotlin/dev/jasonpearson/automobile/ctrlproxy/CtrlProxy.kt
+++ b/android/control-proxy/src/main/kotlin/dev/jasonpearson/automobile/ctrlproxy/CtrlProxy.kt
@@ -499,14 +499,18 @@ class CtrlProxy : AccessibilityService(), CtrlProxyActions {
                 TAG,
                 "Received navigation event (protocol): ${event.destination} from ${event.source} (app: ${event.applicationId})",
               )
-              sdkEventBatchProcessor.enqueueNavigationEvent(
-                destination = event.destination,
-                source = event.source.name,
-                arguments = event.arguments ?: emptyMap(),
-                metadata = event.metadata ?: emptyMap(),
-                applicationId = event.applicationId,
-                timestamp = event.timestamp,
-              )
+              if (
+                !sdkEventBatchProcessor.enqueueNavigationEvent(
+                  destination = event.destination,
+                  source = event.source.name,
+                  arguments = event.arguments ?: emptyMap(),
+                  metadata = event.metadata ?: emptyMap(),
+                  applicationId = event.applicationId,
+                  timestamp = event.timestamp,
+                )
+              ) {
+                Log.w(TAG, "Dropping navigation event because the SDK event queue is full")
+              }
               return
             }
           }
@@ -539,14 +543,18 @@ class CtrlProxy : AccessibilityService(), CtrlProxyActions {
             TAG,
             "Received navigation event (legacy): $destination from $source (app: $applicationId)",
           )
-          sdkEventBatchProcessor.enqueueNavigationEvent(
-            destination = destination,
-            source = source,
-            arguments = arguments,
-            metadata = metadata,
-            applicationId = applicationId,
-            timestamp = System.currentTimeMillis(),
-          )
+          if (
+            !sdkEventBatchProcessor.enqueueNavigationEvent(
+              destination = destination,
+              source = source,
+              arguments = arguments,
+              metadata = metadata,
+              applicationId = applicationId,
+              timestamp = System.currentTimeMillis(),
+            )
+          ) {
+            Log.w(TAG, "Dropping navigation event because the SDK event queue is full")
+          }
         } catch (e: Exception) {
           Log.e(TAG, "Error handling navigation event broadcast", e)
         }
@@ -882,7 +890,12 @@ class CtrlProxy : AccessibilityService(), CtrlProxyActions {
 
           Log.d(TAG, "Received event batch with ${batch.events.size} events")
 
-          sdkEventBatchProcessor.enqueue(batch)
+          if (!sdkEventBatchProcessor.enqueue(batch)) {
+            Log.w(
+              TAG,
+              "Dropping SDK event batch with ${batch.events.size} events because the queue is full",
+            )
+          }
         } catch (e: Exception) {
           Log.e(TAG, "Error handling event batch broadcast", e)
         }
@@ -926,18 +939,6 @@ class CtrlProxy : AccessibilityService(), CtrlProxyActions {
         @SuppressLint("UnspecifiedRegisterReceiverFlag")
         registerReceiver(commandReceiver, commandFilter)
       }
-
-      // Register broadcast receiver for navigation events
-      val navigationFilter =
-        IntentFilter().apply { addAction(AutoMobileSDK.ACTION_NAVIGATION_EVENT) }
-
-      if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.TIRAMISU) {
-        registerReceiver(navigationEventReceiver, navigationFilter, RECEIVER_EXPORTED)
-      } else {
-        @SuppressLint("UnspecifiedRegisterReceiverFlag")
-        registerReceiver(navigationEventReceiver, navigationFilter)
-      }
-      Log.d(TAG, "Navigation event receiver registered")
 
       // Register broadcast receiver for recomposition snapshots
       val recompositionFilter =
@@ -1013,18 +1014,6 @@ class CtrlProxy : AccessibilityService(), CtrlProxyActions {
       }
       Log.d(TAG, "ANR receiver registered")
 
-      // Register broadcast receiver for SDK event batches
-      val eventBatchFilter =
-        IntentFilter().apply { addAction(SdkEventSerializer.ACTION_SDK_EVENT_BATCH) }
-
-      if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.TIRAMISU) {
-        registerReceiver(eventBatchReceiver, eventBatchFilter, RECEIVER_EXPORTED)
-      } else {
-        @SuppressLint("UnspecifiedRegisterReceiverFlag")
-        registerReceiver(eventBatchReceiver, eventBatchFilter)
-      }
-      Log.d(TAG, "Event batch receiver registered")
-
       val screenStateFilter =
         IntentFilter().apply {
           addAction(Intent.ACTION_SCREEN_ON)
@@ -1032,21 +1021,6 @@ class CtrlProxy : AccessibilityService(), CtrlProxyActions {
         }
       registerReceiver(screenStateReceiver, screenStateFilter)
       Log.d(TAG, "Screen state receiver registered")
-
-      // Initialize the navigation event accumulator
-      navigationEventAccumulator.initialize()
-      Log.d(TAG, "Navigation event accumulator initialized")
-
-      // Subscribe to navigation events and broadcast them
-      navigationEventJob =
-        navigationEventAccumulator.latestEvent
-          .onEach { event ->
-            if (event != null) {
-              Log.d(TAG, "Navigation event: ${event.destination} at ${event.timestamp}")
-              broadcastNavigationEvent(event)
-            }
-          }
-          .launchIn(serviceScope)
 
       // Initialize the smart hierarchy debouncer with structural hash comparison
       hierarchyDebouncer =
@@ -1142,6 +1116,40 @@ class CtrlProxy : AccessibilityService(), CtrlProxyActions {
         )
       webSocketServer.start()
       Log.d(TAG, "WebSocket server started on port 8765")
+
+      // Start every navigation-ingestion path only after the WebSocket is ready. SDK batch
+      // events suppress latestEvent replay, so receiving one before this point would lose it.
+      navigationEventAccumulator.initialize()
+      Log.d(TAG, "Navigation event accumulator initialized")
+      navigationEventJob =
+        navigationEventAccumulator.latestEvent
+          .onEach { event ->
+            if (event != null) {
+              Log.d(TAG, "Navigation event: ${event.destination} at ${event.timestamp}")
+              broadcastNavigationEvent(event)
+            }
+          }
+          .launchIn(serviceScope)
+
+      val navigationFilter =
+        IntentFilter().apply { addAction(AutoMobileSDK.ACTION_NAVIGATION_EVENT) }
+      if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.TIRAMISU) {
+        registerReceiver(navigationEventReceiver, navigationFilter, RECEIVER_EXPORTED)
+      } else {
+        @SuppressLint("UnspecifiedRegisterReceiverFlag")
+        registerReceiver(navigationEventReceiver, navigationFilter)
+      }
+      Log.d(TAG, "Navigation event receiver registered")
+
+      val eventBatchFilter =
+        IntentFilter().apply { addAction(SdkEventSerializer.ACTION_SDK_EVENT_BATCH) }
+      if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.TIRAMISU) {
+        registerReceiver(eventBatchReceiver, eventBatchFilter, RECEIVER_EXPORTED)
+      } else {
+        @SuppressLint("UnspecifiedRegisterReceiverFlag")
+        registerReceiver(eventBatchReceiver, eventBatchFilter)
+      }
+      Log.d(TAG, "Event batch receiver registered")
 
       // Start logcat reader for automatic log capture
       logcatReader = LogcatReader { response ->

--- a/android/control-proxy/src/main/kotlin/dev/jasonpearson/automobile/ctrlproxy/CtrlProxy.kt
+++ b/android/control-proxy/src/main/kotlin/dev/jasonpearson/automobile/ctrlproxy/CtrlProxy.kt
@@ -357,6 +357,7 @@ class CtrlProxy : AccessibilityService(), CtrlProxyActions {
   private val navigationEventAccumulator = NavigationEventAccumulator()
   private val sdkEventBatchProcessor by lazy {
     SdkEventBatchProcessor(
+      scope = serviceScope,
       navigationEventAccumulator = navigationEventAccumulator,
       broadcastNavigationEvent = ::broadcastNavigationEvent,
       broadcastSdkEvent = ::broadcastSdkEvent,
@@ -880,8 +881,8 @@ class CtrlProxy : AccessibilityService(), CtrlProxyActions {
 
           Log.d(TAG, "Received event batch with ${batch.events.size} events")
 
-          serviceScope.launch {
-            sdkEventBatchProcessor.process(batch)
+          if (!sdkEventBatchProcessor.enqueue(batch)) {
+            Log.w(TAG, "Dropping SDK event batch because CtrlProxy is shutting down")
           }
         } catch (e: Exception) {
           Log.e(TAG, "Error handling event batch broadcast", e)

--- a/android/control-proxy/src/main/kotlin/dev/jasonpearson/automobile/ctrlproxy/CtrlProxy.kt
+++ b/android/control-proxy/src/main/kotlin/dev/jasonpearson/automobile/ctrlproxy/CtrlProxy.kt
@@ -881,13 +881,7 @@ class CtrlProxy : AccessibilityService(), CtrlProxyActions {
 
           Log.d(TAG, "Received event batch with ${batch.events.size} events")
 
-          if (!sdkEventBatchProcessor.enqueue(batch)) {
-            Log.w(
-              TAG,
-              "Dropping SDK event batch because the processing queue is full " +
-                "(dropped=${sdkEventBatchProcessor.droppedBatchCount})",
-            )
-          }
+          sdkEventBatchProcessor.enqueue(batch)
         } catch (e: Exception) {
           Log.e(TAG, "Error handling event batch broadcast", e)
         }

--- a/android/control-proxy/src/main/kotlin/dev/jasonpearson/automobile/ctrlproxy/CtrlProxy.kt
+++ b/android/control-proxy/src/main/kotlin/dev/jasonpearson/automobile/ctrlproxy/CtrlProxy.kt
@@ -499,13 +499,13 @@ class CtrlProxy : AccessibilityService(), CtrlProxyActions {
                 TAG,
                 "Received navigation event (protocol): ${event.destination} from ${event.source} (app: ${event.applicationId})",
               )
-              navigationEventAccumulator.addEvent(
-                event.destination,
-                event.source.name,
-                event.arguments ?: emptyMap(),
-                event.metadata ?: emptyMap(),
-                event.applicationId,
-                event.timestamp,
+              sdkEventBatchProcessor.enqueueNavigationEvent(
+                destination = event.destination,
+                source = event.source.name,
+                arguments = event.arguments ?: emptyMap(),
+                metadata = event.metadata ?: emptyMap(),
+                applicationId = event.applicationId,
+                timestamp = event.timestamp,
               )
               return
             }
@@ -539,12 +539,13 @@ class CtrlProxy : AccessibilityService(), CtrlProxyActions {
             TAG,
             "Received navigation event (legacy): $destination from $source (app: $applicationId)",
           )
-          navigationEventAccumulator.addEvent(
-            destination,
-            source,
-            arguments,
-            metadata,
-            applicationId,
+          sdkEventBatchProcessor.enqueueNavigationEvent(
+            destination = destination,
+            source = source,
+            arguments = arguments,
+            metadata = metadata,
+            applicationId = applicationId,
+            timestamp = System.currentTimeMillis(),
           )
         } catch (e: Exception) {
           Log.e(TAG, "Error handling navigation event broadcast", e)

--- a/android/control-proxy/src/main/kotlin/dev/jasonpearson/automobile/ctrlproxy/CtrlProxy.kt
+++ b/android/control-proxy/src/main/kotlin/dev/jasonpearson/automobile/ctrlproxy/CtrlProxy.kt
@@ -355,6 +355,13 @@ class CtrlProxy : AccessibilityService(), CtrlProxyActions {
   private lateinit var rotationProvenance: RotationProvenanceTracker
   private var hierarchyBroadcastThrottler: BroadcastThrottler? = null
   private val navigationEventAccumulator = NavigationEventAccumulator()
+  private val sdkEventBatchProcessor by lazy {
+    SdkEventBatchProcessor(
+      navigationEventAccumulator = navigationEventAccumulator,
+      broadcastNavigationEvent = ::broadcastNavigationEvent,
+      broadcastSdkEvent = ::broadcastSdkEvent,
+    )
+  }
   private lateinit var overlayManager: OverlayManager
   private val permissionManager by lazy { PermissionManager(this) }
   private lateinit var overlayDrawer: OverlayDrawer
@@ -874,14 +881,7 @@ class CtrlProxy : AccessibilityService(), CtrlProxyActions {
           Log.d(TAG, "Received event batch with ${batch.events.size} events")
 
           serviceScope.launch {
-            for (event in batch.events) {
-              if (event is SdkNavigationEvent) {
-                val navigationEvent = navigationEventAccumulator.addSdkNavigationEvent(event)
-                broadcastNavigationEvent(navigationEvent)
-              } else {
-                broadcastSdkEvent(event)
-              }
-            }
+            sdkEventBatchProcessor.process(batch)
           }
         } catch (e: Exception) {
           Log.e(TAG, "Error handling event batch broadcast", e)

--- a/android/control-proxy/src/main/kotlin/dev/jasonpearson/automobile/ctrlproxy/CtrlProxy.kt
+++ b/android/control-proxy/src/main/kotlin/dev/jasonpearson/automobile/ctrlproxy/CtrlProxy.kt
@@ -359,6 +359,7 @@ class CtrlProxy : AccessibilityService(), CtrlProxyActions {
     SdkEventBatchProcessor(
       scope = serviceScope,
       navigationEventAccumulator = navigationEventAccumulator,
+      awaitClientConnection = { webSocketServer.awaitClientConnection() },
       broadcastNavigationEvent = { event ->
         broadcastNavigationEvent(event, WebSocketServer.BroadcastMode.Sync)
       },
@@ -1155,11 +1156,8 @@ class CtrlProxy : AccessibilityService(), CtrlProxyActions {
             }
           }
           .launchIn(serviceScope)
-      serviceScope.launch {
-        webSocketServer.awaitFirstClientConnection()
-        sdkEventBatchProcessor.start()
-        Log.d(TAG, "SDK event batch processor started after first WebSocket client connected")
-      }
+      sdkEventBatchProcessor.start()
+      Log.d(TAG, "SDK event batch processor started")
 
       // Start logcat reader for automatic log capture
       logcatReader = LogcatReader { response ->

--- a/android/control-proxy/src/main/kotlin/dev/jasonpearson/automobile/ctrlproxy/CtrlProxy.kt
+++ b/android/control-proxy/src/main/kotlin/dev/jasonpearson/automobile/ctrlproxy/CtrlProxy.kt
@@ -882,7 +882,11 @@ class CtrlProxy : AccessibilityService(), CtrlProxyActions {
           Log.d(TAG, "Received event batch with ${batch.events.size} events")
 
           if (!sdkEventBatchProcessor.enqueue(batch)) {
-            Log.w(TAG, "Dropping SDK event batch because CtrlProxy is shutting down")
+            Log.w(
+              TAG,
+              "Dropping SDK event batch because the processing queue is full " +
+                "(dropped=${sdkEventBatchProcessor.droppedBatchCount})",
+            )
           }
         } catch (e: Exception) {
           Log.e(TAG, "Error handling event batch broadcast", e)

--- a/android/control-proxy/src/main/kotlin/dev/jasonpearson/automobile/ctrlproxy/NavigationEventAccumulator.kt
+++ b/android/control-proxy/src/main/kotlin/dev/jasonpearson/automobile/ctrlproxy/NavigationEventAccumulator.kt
@@ -1,5 +1,6 @@
 package dev.jasonpearson.automobile.ctrlproxy
 
+import dev.jasonpearson.automobile.protocol.SdkNavigationEvent
 import dev.jasonpearson.automobile.sdk.AutoMobileSDK
 import dev.jasonpearson.automobile.sdk.NavigationEvent
 import java.util.concurrent.CopyOnWriteArrayList
@@ -65,8 +66,9 @@ class NavigationEventAccumulator {
     arguments: Map<String, String>,
     metadata: Map<String, String>,
     applicationId: String? = null,
-  ) {
-    val timestamp = System.currentTimeMillis()
+    timestamp: Long = System.currentTimeMillis(),
+    publishLatestEvent: Boolean = true,
+  ): TimestampedNavigationEvent {
     val sequence = sequenceNumber.getAndIncrement()
 
     val timestampedEvent =
@@ -80,8 +82,26 @@ class NavigationEventAccumulator {
         applicationId = applicationId,
       )
 
-    appendEvent(timestampedEvent)
+    appendEvent(timestampedEvent, publishLatestEvent)
+    return timestampedEvent
   }
+
+  /**
+   * Records a navigation event emitted by the SDK's batched cross-process protocol.
+   *
+   * CtrlProxy forwards the returned event sequentially because [latestEvent] is intentionally
+   * conflating and cannot preserve every event in one batch.
+   */
+  fun addSdkNavigationEvent(event: SdkNavigationEvent): TimestampedNavigationEvent =
+    addEvent(
+      destination = event.destination,
+      source = event.source.name,
+      arguments = event.arguments ?: emptyMap(),
+      metadata = event.metadata ?: emptyMap(),
+      applicationId = event.applicationId,
+      timestamp = event.timestamp,
+      publishLatestEvent = false,
+    )
 
   /** Handle incoming navigation event from AutoMobileSDK. */
   private fun onNavigationEvent(event: NavigationEvent) {
@@ -115,14 +135,16 @@ class NavigationEventAccumulator {
   }
 
   /** Append an event and trim the circular buffer atomically, then emit updates. */
-  private fun appendEvent(event: TimestampedNavigationEvent) {
+  private fun appendEvent(event: TimestampedNavigationEvent, publishLatestEvent: Boolean = true) {
     synchronized(bufferLock) {
       events.add(event)
       if (events.size > maxEvents) {
         events.removeAt(0)
       }
     }
-    _latestEvent.value = event
+    if (publishLatestEvent) {
+      _latestEvent.value = event
+    }
     _eventCount.value = events.size
   }
 

--- a/android/control-proxy/src/main/kotlin/dev/jasonpearson/automobile/ctrlproxy/SdkEventBatchProcessor.kt
+++ b/android/control-proxy/src/main/kotlin/dev/jasonpearson/automobile/ctrlproxy/SdkEventBatchProcessor.kt
@@ -10,6 +10,7 @@ import kotlinx.coroutines.launch
 internal class SdkEventBatchProcessor(
   private val scope: CoroutineScope,
   private val navigationEventAccumulator: NavigationEventAccumulator,
+  private val awaitClientConnection: suspend () -> Unit = {},
   private val broadcastNavigationEvent: suspend (TimestampedNavigationEvent) -> Unit,
   private val broadcastSdkEvent: suspend (SdkEvent) -> Unit,
 ) {
@@ -32,11 +33,11 @@ internal class SdkEventBatchProcessor(
   private var started = false
 
   /**
-   * Begins draining batches after CtrlProxy's WebSocket is ready.
+   * Begins draining queued SDK events.
    *
    * Receivers can enqueue before this point while the accessibility service completes its remaining
-   * initialization. The bounded queue retains those startup events until a client can receive their
-   * WebSocket broadcasts.
+   * initialization. Each delivery waits for an active WebSocket client, so startup and reconnect
+   * gaps retain queued events instead of discarding them.
    */
   @Synchronized
   fun start() {
@@ -83,7 +84,7 @@ internal class SdkEventBatchProcessor(
     when (event) {
       is QueuedEvent.Batch -> process(event.batch)
       is QueuedEvent.Navigation -> {
-        broadcastNavigationEvent(
+        deliverNavigationEvent(
           navigationEventAccumulator.addEvent(
             destination = event.destination,
             source = event.source,
@@ -101,11 +102,17 @@ internal class SdkEventBatchProcessor(
   private suspend fun process(batch: SdkEventBatch) {
     for (event in batch.events) {
       if (event is SdkNavigationEvent) {
-        broadcastNavigationEvent(navigationEventAccumulator.addSdkNavigationEvent(event))
+        deliverNavigationEvent(navigationEventAccumulator.addSdkNavigationEvent(event))
       } else {
+        awaitClientConnection()
         broadcastSdkEvent(event)
       }
     }
+  }
+
+  private suspend fun deliverNavigationEvent(event: TimestampedNavigationEvent) {
+    awaitClientConnection()
+    broadcastNavigationEvent(event)
   }
 
   private companion object {

--- a/android/control-proxy/src/main/kotlin/dev/jasonpearson/automobile/ctrlproxy/SdkEventBatchProcessor.kt
+++ b/android/control-proxy/src/main/kotlin/dev/jasonpearson/automobile/ctrlproxy/SdkEventBatchProcessor.kt
@@ -3,24 +3,38 @@ package dev.jasonpearson.automobile.ctrlproxy
 import dev.jasonpearson.automobile.protocol.SdkEvent
 import dev.jasonpearson.automobile.protocol.SdkEventBatch
 import dev.jasonpearson.automobile.protocol.SdkNavigationEvent
-import kotlinx.coroutines.sync.Mutex
-import kotlinx.coroutines.sync.withLock
+import kotlinx.coroutines.CoroutineScope
+import kotlinx.coroutines.channels.Channel
+import kotlinx.coroutines.launch
 
 internal class SdkEventBatchProcessor(
+  scope: CoroutineScope,
   private val navigationEventAccumulator: NavigationEventAccumulator,
   private val broadcastNavigationEvent: suspend (TimestampedNavigationEvent) -> Unit,
   private val broadcastSdkEvent: suspend (SdkEvent) -> Unit,
 ) {
-  private val mutex = Mutex()
+  private val queuedBatches = Channel<SdkEventBatch>(Channel.UNLIMITED)
 
-  suspend fun process(batch: SdkEventBatch) {
-    mutex.withLock {
-      for (event in batch.events) {
-        if (event is SdkNavigationEvent) {
-          broadcastNavigationEvent(navigationEventAccumulator.addSdkNavigationEvent(event))
-        } else {
-          broadcastSdkEvent(event)
-        }
+  init {
+    scope.launch {
+      for (batch in queuedBatches) {
+        process(batch)
+      }
+    }
+  }
+
+  /**
+   * Queues a batch from the broadcast receiver before asynchronous dispatch so the actor preserves
+   * receiver arrival order.
+   */
+  fun enqueue(batch: SdkEventBatch): Boolean = queuedBatches.trySend(batch).isSuccess
+
+  private suspend fun process(batch: SdkEventBatch) {
+    for (event in batch.events) {
+      if (event is SdkNavigationEvent) {
+        broadcastNavigationEvent(navigationEventAccumulator.addSdkNavigationEvent(event))
+      } else {
+        broadcastSdkEvent(event)
       }
     }
   }

--- a/android/control-proxy/src/main/kotlin/dev/jasonpearson/automobile/ctrlproxy/SdkEventBatchProcessor.kt
+++ b/android/control-proxy/src/main/kotlin/dev/jasonpearson/automobile/ctrlproxy/SdkEventBatchProcessor.kt
@@ -26,7 +26,9 @@ internal class SdkEventBatchProcessor(
     ) : QueuedEvent
   }
 
-  private val queuedEvents = Channel<QueuedEvent>(Channel.UNLIMITED)
+  // BroadcastReceiver.onReceive cannot suspend. Keep a bounded handoff queue so a stalled
+  // WebSocket client cannot retain arbitrary SDK event batches in the CtrlProxy process.
+  private val queuedEvents = Channel<QueuedEvent>(QUEUE_CAPACITY)
 
   init {
     scope.launch {
@@ -38,7 +40,8 @@ internal class SdkEventBatchProcessor(
 
   /**
    * Queues a batch from the broadcast receiver before asynchronous dispatch so the actor preserves
-   * receiver arrival order without dropping navigation updates under backpressure.
+   * receiver arrival order. Returns false when the bounded queue is full; callers must log that
+   * overload because the broadcast cannot be retried synchronously.
    */
   fun enqueue(batch: SdkEventBatch): Boolean =
     queuedEvents.trySend(QueuedEvent.Batch(batch)).isSuccess
@@ -92,5 +95,9 @@ internal class SdkEventBatchProcessor(
         broadcastSdkEvent(event)
       }
     }
+  }
+
+  private companion object {
+    const val QUEUE_CAPACITY = 64
   }
 }

--- a/android/control-proxy/src/main/kotlin/dev/jasonpearson/automobile/ctrlproxy/SdkEventBatchProcessor.kt
+++ b/android/control-proxy/src/main/kotlin/dev/jasonpearson/automobile/ctrlproxy/SdkEventBatchProcessor.kt
@@ -10,7 +10,6 @@ import kotlinx.coroutines.launch
 internal class SdkEventBatchProcessor(
   private val scope: CoroutineScope,
   private val navigationEventAccumulator: NavigationEventAccumulator,
-  private val awaitClientConnection: suspend () -> Unit = {},
   private val broadcastNavigationEvent: suspend (TimestampedNavigationEvent) -> Unit,
   private val broadcastSdkEvent: suspend (SdkEvent) -> Unit,
 ) {
@@ -36,8 +35,8 @@ internal class SdkEventBatchProcessor(
    * Begins draining queued SDK events.
    *
    * Receivers can enqueue before this point while the accessibility service completes its remaining
-   * initialization. Each delivery waits for an active WebSocket client, so startup and reconnect
-   * gaps retain queued events instead of discarding them.
+   * initialization. Delivery callbacks retain queued events until a WebSocket client accepts them,
+   * so startup and reconnect gaps do not discard events.
    */
   @Synchronized
   fun start() {
@@ -104,14 +103,12 @@ internal class SdkEventBatchProcessor(
       if (event is SdkNavigationEvent) {
         deliverNavigationEvent(navigationEventAccumulator.addSdkNavigationEvent(event))
       } else {
-        awaitClientConnection()
         broadcastSdkEvent(event)
       }
     }
   }
 
   private suspend fun deliverNavigationEvent(event: TimestampedNavigationEvent) {
-    awaitClientConnection()
     broadcastNavigationEvent(event)
   }
 

--- a/android/control-proxy/src/main/kotlin/dev/jasonpearson/automobile/ctrlproxy/SdkEventBatchProcessor.kt
+++ b/android/control-proxy/src/main/kotlin/dev/jasonpearson/automobile/ctrlproxy/SdkEventBatchProcessor.kt
@@ -3,6 +3,7 @@ package dev.jasonpearson.automobile.ctrlproxy
 import dev.jasonpearson.automobile.protocol.SdkEvent
 import dev.jasonpearson.automobile.protocol.SdkEventBatch
 import dev.jasonpearson.automobile.protocol.SdkNavigationEvent
+import java.util.concurrent.atomic.AtomicLong
 import kotlinx.coroutines.CoroutineScope
 import kotlinx.coroutines.channels.Channel
 import kotlinx.coroutines.launch
@@ -12,10 +13,13 @@ internal class SdkEventBatchProcessor(
   private val navigationEventAccumulator: NavigationEventAccumulator,
   private val broadcastNavigationEvent: suspend (TimestampedNavigationEvent) -> Unit,
   private val broadcastSdkEvent: suspend (SdkEvent) -> Unit,
+  queueCapacity: Int = DEFAULT_QUEUE_CAPACITY,
 ) {
-  private val queuedBatches = Channel<SdkEventBatch>(Channel.UNLIMITED)
+  private val queuedBatches = Channel<SdkEventBatch>(queueCapacity)
+  private val droppedBatches = AtomicLong()
 
   init {
+    require(queueCapacity > 0) { "queueCapacity must be positive" }
     scope.launch {
       for (batch in queuedBatches) {
         process(batch)
@@ -27,7 +31,16 @@ internal class SdkEventBatchProcessor(
    * Queues a batch from the broadcast receiver before asynchronous dispatch so the actor preserves
    * receiver arrival order.
    */
-  fun enqueue(batch: SdkEventBatch): Boolean = queuedBatches.trySend(batch).isSuccess
+  fun enqueue(batch: SdkEventBatch): Boolean {
+    val queued = queuedBatches.trySend(batch).isSuccess
+    if (!queued) {
+      droppedBatches.incrementAndGet()
+    }
+    return queued
+  }
+
+  val droppedBatchCount: Long
+    get() = droppedBatches.get()
 
   private suspend fun process(batch: SdkEventBatch) {
     for (event in batch.events) {
@@ -37,5 +50,9 @@ internal class SdkEventBatchProcessor(
         broadcastSdkEvent(event)
       }
     }
+  }
+
+  private companion object {
+    const val DEFAULT_QUEUE_CAPACITY = 64
   }
 }

--- a/android/control-proxy/src/main/kotlin/dev/jasonpearson/automobile/ctrlproxy/SdkEventBatchProcessor.kt
+++ b/android/control-proxy/src/main/kotlin/dev/jasonpearson/automobile/ctrlproxy/SdkEventBatchProcessor.kt
@@ -1,0 +1,27 @@
+package dev.jasonpearson.automobile.ctrlproxy
+
+import dev.jasonpearson.automobile.protocol.SdkEvent
+import dev.jasonpearson.automobile.protocol.SdkEventBatch
+import dev.jasonpearson.automobile.protocol.SdkNavigationEvent
+import kotlinx.coroutines.sync.Mutex
+import kotlinx.coroutines.sync.withLock
+
+internal class SdkEventBatchProcessor(
+  private val navigationEventAccumulator: NavigationEventAccumulator,
+  private val broadcastNavigationEvent: suspend (TimestampedNavigationEvent) -> Unit,
+  private val broadcastSdkEvent: suspend (SdkEvent) -> Unit,
+) {
+  private val mutex = Mutex()
+
+  suspend fun process(batch: SdkEventBatch) {
+    mutex.withLock {
+      for (event in batch.events) {
+        if (event is SdkNavigationEvent) {
+          broadcastNavigationEvent(navigationEventAccumulator.addSdkNavigationEvent(event))
+        } else {
+          broadcastSdkEvent(event)
+        }
+      }
+    }
+  }
+}

--- a/android/control-proxy/src/main/kotlin/dev/jasonpearson/automobile/ctrlproxy/SdkEventBatchProcessor.kt
+++ b/android/control-proxy/src/main/kotlin/dev/jasonpearson/automobile/ctrlproxy/SdkEventBatchProcessor.kt
@@ -3,7 +3,6 @@ package dev.jasonpearson.automobile.ctrlproxy
 import dev.jasonpearson.automobile.protocol.SdkEvent
 import dev.jasonpearson.automobile.protocol.SdkEventBatch
 import dev.jasonpearson.automobile.protocol.SdkNavigationEvent
-import java.util.concurrent.atomic.AtomicLong
 import kotlinx.coroutines.CoroutineScope
 import kotlinx.coroutines.channels.Channel
 import kotlinx.coroutines.launch
@@ -13,13 +12,10 @@ internal class SdkEventBatchProcessor(
   private val navigationEventAccumulator: NavigationEventAccumulator,
   private val broadcastNavigationEvent: suspend (TimestampedNavigationEvent) -> Unit,
   private val broadcastSdkEvent: suspend (SdkEvent) -> Unit,
-  queueCapacity: Int = DEFAULT_QUEUE_CAPACITY,
 ) {
-  private val queuedBatches = Channel<SdkEventBatch>(queueCapacity)
-  private val droppedBatches = AtomicLong()
+  private val queuedBatches = Channel<SdkEventBatch>(Channel.UNLIMITED)
 
   init {
-    require(queueCapacity > 0) { "queueCapacity must be positive" }
     scope.launch {
       for (batch in queuedBatches) {
         process(batch)
@@ -29,18 +25,9 @@ internal class SdkEventBatchProcessor(
 
   /**
    * Queues a batch from the broadcast receiver before asynchronous dispatch so the actor preserves
-   * receiver arrival order.
+   * receiver arrival order without dropping navigation updates under backpressure.
    */
-  fun enqueue(batch: SdkEventBatch): Boolean {
-    val queued = queuedBatches.trySend(batch).isSuccess
-    if (!queued) {
-      droppedBatches.incrementAndGet()
-    }
-    return queued
-  }
-
-  val droppedBatchCount: Long
-    get() = droppedBatches.get()
+  fun enqueue(batch: SdkEventBatch): Boolean = queuedBatches.trySend(batch).isSuccess
 
   private suspend fun process(batch: SdkEventBatch) {
     for (event in batch.events) {
@@ -50,9 +37,5 @@ internal class SdkEventBatchProcessor(
         broadcastSdkEvent(event)
       }
     }
-  }
-
-  private companion object {
-    const val DEFAULT_QUEUE_CAPACITY = 64
   }
 }

--- a/android/control-proxy/src/main/kotlin/dev/jasonpearson/automobile/ctrlproxy/SdkEventBatchProcessor.kt
+++ b/android/control-proxy/src/main/kotlin/dev/jasonpearson/automobile/ctrlproxy/SdkEventBatchProcessor.kt
@@ -13,12 +13,25 @@ internal class SdkEventBatchProcessor(
   private val broadcastNavigationEvent: suspend (TimestampedNavigationEvent) -> Unit,
   private val broadcastSdkEvent: suspend (SdkEvent) -> Unit,
 ) {
-  private val queuedBatches = Channel<SdkEventBatch>(Channel.UNLIMITED)
+  private sealed interface QueuedEvent {
+    data class Batch(val batch: SdkEventBatch) : QueuedEvent
+
+    data class Navigation(
+      val destination: String,
+      val source: String,
+      val arguments: Map<String, String>,
+      val metadata: Map<String, String>,
+      val applicationId: String?,
+      val timestamp: Long,
+    ) : QueuedEvent
+  }
+
+  private val queuedEvents = Channel<QueuedEvent>(Channel.UNLIMITED)
 
   init {
     scope.launch {
-      for (batch in queuedBatches) {
-        process(batch)
+      for (event in queuedEvents) {
+        process(event)
       }
     }
   }
@@ -27,7 +40,49 @@ internal class SdkEventBatchProcessor(
    * Queues a batch from the broadcast receiver before asynchronous dispatch so the actor preserves
    * receiver arrival order without dropping navigation updates under backpressure.
    */
-  fun enqueue(batch: SdkEventBatch): Boolean = queuedBatches.trySend(batch).isSuccess
+  fun enqueue(batch: SdkEventBatch): Boolean =
+    queuedEvents.trySend(QueuedEvent.Batch(batch)).isSuccess
+
+  /** Queues a single navigation event from the legacy navigation broadcast receiver. */
+  fun enqueueNavigationEvent(
+    destination: String,
+    source: String,
+    arguments: Map<String, String>,
+    metadata: Map<String, String>,
+    applicationId: String?,
+    timestamp: Long,
+  ): Boolean =
+    queuedEvents
+      .trySend(
+        QueuedEvent.Navigation(
+          destination = destination,
+          source = source,
+          arguments = arguments,
+          metadata = metadata,
+          applicationId = applicationId,
+          timestamp = timestamp,
+        )
+      )
+      .isSuccess
+
+  private suspend fun process(event: QueuedEvent) {
+    when (event) {
+      is QueuedEvent.Batch -> process(event.batch)
+      is QueuedEvent.Navigation -> {
+        broadcastNavigationEvent(
+          navigationEventAccumulator.addEvent(
+            destination = event.destination,
+            source = event.source,
+            arguments = event.arguments,
+            metadata = event.metadata,
+            applicationId = event.applicationId,
+            timestamp = event.timestamp,
+            publishLatestEvent = false,
+          )
+        )
+      }
+    }
+  }
 
   private suspend fun process(batch: SdkEventBatch) {
     for (event in batch.events) {

--- a/android/control-proxy/src/main/kotlin/dev/jasonpearson/automobile/ctrlproxy/SdkEventBatchProcessor.kt
+++ b/android/control-proxy/src/main/kotlin/dev/jasonpearson/automobile/ctrlproxy/SdkEventBatchProcessor.kt
@@ -8,7 +8,7 @@ import kotlinx.coroutines.channels.Channel
 import kotlinx.coroutines.launch
 
 internal class SdkEventBatchProcessor(
-  scope: CoroutineScope,
+  private val scope: CoroutineScope,
   private val navigationEventAccumulator: NavigationEventAccumulator,
   private val broadcastNavigationEvent: suspend (TimestampedNavigationEvent) -> Unit,
   private val broadcastSdkEvent: suspend (SdkEvent) -> Unit,
@@ -29,8 +29,19 @@ internal class SdkEventBatchProcessor(
   // BroadcastReceiver.onReceive cannot suspend. Keep a bounded handoff queue so a stalled
   // WebSocket client cannot retain arbitrary SDK event batches in the CtrlProxy process.
   private val queuedEvents = Channel<QueuedEvent>(QUEUE_CAPACITY)
+  private var started = false
 
-  init {
+  /**
+   * Begins draining batches after CtrlProxy's WebSocket is ready.
+   *
+   * Receivers can enqueue before this point while the accessibility service completes its remaining
+   * initialization. The bounded queue retains those startup events until a client can receive their
+   * WebSocket broadcasts.
+   */
+  @Synchronized
+  fun start() {
+    if (started) return
+    started = true
     scope.launch {
       for (event in queuedEvents) {
         process(event)

--- a/android/control-proxy/src/main/kotlin/dev/jasonpearson/automobile/ctrlproxy/WebSocketServer.kt
+++ b/android/control-proxy/src/main/kotlin/dev/jasonpearson/automobile/ctrlproxy/WebSocketServer.kt
@@ -118,6 +118,7 @@ class WebSocketServer(
   private val connections = mutableSetOf<DefaultWebSocketSession>()
   private val requestConnections = mutableMapOf<String, DefaultWebSocketSession>()
   private val connectionCount = AtomicInteger(0)
+  private val firstClientConnection = CompletableDeferred<Unit>()
 
   // Flow to broadcast messages to all connected clients
   private val _messageFlow = MutableSharedFlow<String>(replay = 0, extraBufferCapacity = 10)
@@ -181,6 +182,7 @@ class WebSocketServer(
                   )
 
                   synchronized(connections) { connections.add(this) }
+                  firstClientConnection.complete(Unit)
 
                   // Listen for incoming messages
                   for (frame in incoming) {
@@ -442,6 +444,11 @@ class WebSocketServer(
   /** Get the number of active connections */
   fun getConnectionCount(): Int {
     return synchronized(connections) { connections.size }
+  }
+
+  /** Suspends until a client has completed the WebSocket handshake. */
+  suspend fun awaitFirstClientConnection() {
+    firstClientConnection.await()
   }
 
   /** Check if server is running */

--- a/android/control-proxy/src/main/kotlin/dev/jasonpearson/automobile/ctrlproxy/WebSocketServer.kt
+++ b/android/control-proxy/src/main/kotlin/dev/jasonpearson/automobile/ctrlproxy/WebSocketServer.kt
@@ -333,7 +333,11 @@ class WebSocketServer(
    * @param response The typed response object to broadcast
    * @param mode Broadcast mode - Async (default) or Sync for ordering guarantees
    */
-  suspend fun broadcast(response: WebSocketResponse, mode: BroadcastMode = BroadcastMode.Async) {
+  suspend fun broadcast(
+    response: WebSocketResponse,
+    mode: BroadcastMode = BroadcastMode.Async,
+    waitForClient: Boolean = false,
+  ) {
     val message = responseJson.encodeToString(WebSocketResponse.serializer(), response)
     val requestId = extractRequestId(message)
     if (response is ErrorResponse) {
@@ -351,9 +355,13 @@ class WebSocketServer(
       forgetRequestConnection(requestId)
     }
 
-    when (mode) {
-      BroadcastMode.Async -> _messageFlow.emit(message)
-      BroadcastMode.Sync -> broadcastToClients(message)
+    if (waitForClient) {
+      broadcastToClientsWhenClientConnected(message)
+    } else {
+      when (mode) {
+        BroadcastMode.Async -> _messageFlow.emit(message)
+        BroadcastMode.Sync -> broadcastToClients(message)
+      }
     }
   }
 
@@ -363,37 +371,65 @@ class WebSocketServer(
    * @param event The SDK event to broadcast
    * @param mode Broadcast mode - Async (default) or Sync for ordering guarantees
    */
-  suspend fun broadcast(event: SdkEvent, mode: BroadcastMode = BroadcastMode.Async) {
+  suspend fun broadcast(
+    event: SdkEvent,
+    mode: BroadcastMode = BroadcastMode.Async,
+    waitForClient: Boolean = false,
+  ) {
     val message = responseJson.encodeToString(SdkEvent.serializer(), event)
-    when (mode) {
-      BroadcastMode.Async -> _messageFlow.emit(message)
-      BroadcastMode.Sync -> broadcastToClients(message)
+    if (waitForClient) {
+      broadcastToClientsWhenClientConnected(message)
+    } else {
+      when (mode) {
+        BroadcastMode.Async -> _messageFlow.emit(message)
+        BroadcastMode.Sync -> broadcastToClients(message)
+      }
     }
   }
 
-  /** Internal method to send message to all connected clients */
-  private suspend fun broadcastToClients(message: String) {
-    val deadConnections = mutableListOf<DefaultWebSocketSession>()
+  /**
+   * Sends only after at least one current client accepts the message.
+   *
+   * A client can disconnect after a caller observes it but before the send begins. Retrying from
+   * the synchronized connection snapshot keeps queued SDK events available for a replacement.
+   */
+  private suspend fun broadcastToClientsWhenClientConnected(message: String) {
+    while (!broadcastToClients(message)) {
+      awaitClientConnection()
+    }
+  }
 
-    synchronized(connections) { connections.toList() }
-      .forEach { connection ->
-        try {
-          connection.send(Frame.Text(message))
-        } catch (e: CancellationException) {
-          // The broadcast collector is cancelled when `scope` shuts down mid-send; let it unwind
-          // rather than mis-marking a live connection as dead and continuing the loop (#3130).
-          throw e
-        } catch (e: Exception) {
-          Log.w(TAG, "Failed to send to connection, marking as dead", e)
-          deadConnections.add(connection)
-        }
+  /** Internal method to send message to all connected clients. */
+  private suspend fun broadcastToClients(message: String): Boolean {
+    val deadConnections = mutableListOf<DefaultWebSocketSession>()
+    var delivered = false
+
+    val currentConnections = synchronized(connections) { connections.toList() }
+    currentConnections.forEach { connection ->
+      try {
+        connection.send(Frame.Text(message))
+        delivered = true
+      } catch (e: CancellationException) {
+        // The broadcast collector is cancelled when `scope` shuts down mid-send; let it unwind
+        // rather than mis-marking a live connection as dead and continuing the loop (#3130).
+        throw e
+      } catch (e: Exception) {
+        Log.w(TAG, "Failed to send to connection, marking as dead", e)
+        deadConnections.add(connection)
       }
+    }
 
     // Remove dead connections
     if (deadConnections.isNotEmpty()) {
-      synchronized(connections) { connections.removeAll(deadConnections.toSet()) }
+      synchronized(connections) {
+        connections.removeAll(deadConnections.toSet())
+        if (connections.isEmpty()) {
+          activeClientConnection = CompletableDeferred()
+        }
+      }
       Log.d(TAG, "Removed ${deadConnections.size} dead connections. Active: ${connections.size}")
     }
+    return delivered
   }
 
   /** Internal method to send a message to a single client connection. */
@@ -409,6 +445,9 @@ class WebSocketServer(
       synchronized(connections) {
         connections.remove(connection)
         requestConnections.values.removeAll { it == connection }
+        if (connections.isEmpty()) {
+          activeClientConnection = CompletableDeferred()
+        }
       }
     }
   }

--- a/android/control-proxy/src/main/kotlin/dev/jasonpearson/automobile/ctrlproxy/WebSocketServer.kt
+++ b/android/control-proxy/src/main/kotlin/dev/jasonpearson/automobile/ctrlproxy/WebSocketServer.kt
@@ -119,6 +119,7 @@ class WebSocketServer(
   private val requestConnections = mutableMapOf<String, DefaultWebSocketSession>()
   private val connectionCount = AtomicInteger(0)
   private val firstClientConnection = CompletableDeferred<Unit>()
+  private var activeClientConnection = CompletableDeferred<Unit>()
 
   // Flow to broadcast messages to all connected clients
   private val _messageFlow = MutableSharedFlow<String>(replay = 0, extraBufferCapacity = 10)
@@ -181,7 +182,10 @@ class WebSocketServer(
                     )
                   )
 
-                  synchronized(connections) { connections.add(this) }
+                  synchronized(connections) {
+                    connections.add(this)
+                    activeClientConnection.complete(Unit)
+                  }
                   firstClientConnection.complete(Unit)
 
                   // Listen for incoming messages
@@ -212,6 +216,9 @@ class WebSocketServer(
                   synchronized(connections) {
                     connections.remove(this)
                     requestConnections.values.removeAll { it == this }
+                    if (connections.isEmpty()) {
+                      activeClientConnection = CompletableDeferred()
+                    }
                   }
                   Log.d(
                     TAG,
@@ -257,6 +264,7 @@ class WebSocketServer(
         }
         connections.clear()
         requestConnections.clear()
+        activeClientConnection = CompletableDeferred()
       }
 
       server?.stop(1000, 2000)
@@ -449,6 +457,15 @@ class WebSocketServer(
   /** Suspends until a client has completed the WebSocket handshake. */
   suspend fun awaitFirstClientConnection() {
     firstClientConnection.await()
+  }
+
+  /** Suspends until a client is currently connected, including after a reconnect. */
+  suspend fun awaitClientConnection() {
+    val connection =
+      synchronized(connections) {
+        if (connections.isEmpty()) activeClientConnection else null
+      }
+    connection?.await()
   }
 
   /** Check if server is running */

--- a/android/control-proxy/src/test/kotlin/dev/jasonpearson/automobile/ctrlproxy/NavigationEventAccumulatorTest.kt
+++ b/android/control-proxy/src/test/kotlin/dev/jasonpearson/automobile/ctrlproxy/NavigationEventAccumulatorTest.kt
@@ -1,5 +1,7 @@
 package dev.jasonpearson.automobile.ctrlproxy
 
+import dev.jasonpearson.automobile.protocol.NavigationSourceType
+import dev.jasonpearson.automobile.protocol.SdkNavigationEvent
 import java.util.concurrent.CopyOnWriteArrayList
 import java.util.concurrent.CountDownLatch
 import java.util.concurrent.TimeUnit
@@ -9,6 +11,62 @@ import org.junit.Assert.assertTrue
 import org.junit.Test
 
 class NavigationEventAccumulatorTest {
+
+  @Test
+  fun `SDK navigation event retains its original event data without updating latest value`() {
+    val acc = NavigationEventAccumulator()
+    val event =
+      SdkNavigationEvent(
+        timestamp = 1234L,
+        applicationId = "com.example.app",
+        destination = "profile",
+        source = NavigationSourceType.COMPOSE_NAVIGATION,
+        arguments = mapOf("userId" to "42"),
+        metadata = mapOf("origin" to "deep-link"),
+      )
+
+    val timestampedEvent = acc.addSdkNavigationEvent(event)
+
+    assertEquals(
+      TimestampedNavigationEvent(
+        destination = "profile",
+        source = "COMPOSE_NAVIGATION",
+        arguments = mapOf("userId" to "42"),
+        metadata = mapOf("origin" to "deep-link"),
+        timestamp = 1234L,
+        sequenceNumber = 0L,
+        applicationId = "com.example.app",
+      ),
+      timestampedEvent,
+    )
+    assertEquals(listOf(timestampedEvent), acc.getAllEvents())
+    assertEquals(null, acc.latestEvent.value)
+  }
+
+  @Test
+  fun `SDK navigation batch yields every event for sequential forwarding`() {
+    val acc = NavigationEventAccumulator()
+    val events =
+      listOf(
+        SdkNavigationEvent(
+          timestamp = 100L,
+          destination = "first",
+          source = NavigationSourceType.COMPOSE_NAVIGATION,
+        ),
+        SdkNavigationEvent(
+          timestamp = 200L,
+          destination = "second",
+          source = NavigationSourceType.NAVIGATION_COMPONENT,
+        ),
+      )
+
+    val forwarded = events.map(acc::addSdkNavigationEvent)
+
+    assertEquals(listOf("first", "second"), forwarded.map { it.destination })
+    assertEquals(listOf(0L, 1L), forwarded.map { it.sequenceNumber })
+    assertEquals(forwarded, acc.getAllEvents())
+    assertEquals(null, acc.latestEvent.value)
+  }
 
   @Test
   fun `single-threaded add assigns monotonic sequences and bounds the buffer`() {

--- a/android/control-proxy/src/test/kotlin/dev/jasonpearson/automobile/ctrlproxy/NavigationEventWireTest.kt
+++ b/android/control-proxy/src/test/kotlin/dev/jasonpearson/automobile/ctrlproxy/NavigationEventWireTest.kt
@@ -1,0 +1,31 @@
+package dev.jasonpearson.automobile.ctrlproxy
+
+import org.junit.Assert.assertEquals
+import org.junit.Test
+
+class NavigationEventWireTest {
+
+  @Test
+  fun `navigation response retains the SDK event timestamp`() {
+    val event =
+      TimestampedNavigationEvent(
+        destination = "profile",
+        source = "COMPOSE_NAVIGATION",
+        arguments = mapOf("userId" to "42"),
+        metadata = mapOf("origin" to "deep-link"),
+        timestamp = 1234L,
+        sequenceNumber = 5L,
+        applicationId = "com.example.app",
+      )
+
+    val response = navigationEventResponse(event)
+
+    assertEquals(1234L, response.timestamp)
+    assertEquals("profile", response.event.destination)
+    assertEquals("COMPOSE_NAVIGATION", response.event.source)
+    assertEquals(mapOf("userId" to "42"), response.event.arguments)
+    assertEquals(mapOf("origin" to "deep-link"), response.event.metadata)
+    assertEquals(5L, response.event.sequenceNumber)
+    assertEquals("com.example.app", response.event.applicationId)
+  }
+}

--- a/android/control-proxy/src/test/kotlin/dev/jasonpearson/automobile/ctrlproxy/NetworkControlPermissionManifestTest.kt
+++ b/android/control-proxy/src/test/kotlin/dev/jasonpearson/automobile/ctrlproxy/NetworkControlPermissionManifestTest.kt
@@ -27,7 +27,7 @@ class NetworkControlPermissionManifestTest {
   }
 
   @Test
-  fun `CtrlProxy owns V2 and requests V2 plus legacy network control permissions`() {
+  fun `CtrlProxy owns and requests only the V2 network control permission`() {
     val document = readManifest("control-proxy")
     val definitions = permissionDefinitions(document)
 
@@ -40,8 +40,9 @@ class NetworkControlPermissionManifestTest {
       "CtrlProxy must request $NETWORK_CONTROL_PERMISSION to send protected control broadcasts.",
       usesPermissions(document).contains(NETWORK_CONTROL_PERMISSION),
     )
-    assertTrue(
-      "CtrlProxy must retain $LEGACY_NETWORK_CONTROL_PERMISSION for compatible legacy SDK hosts.",
+    assertFalse(
+      "The legacy permission cannot provide a secure cross-signed compatibility path. Compatible " +
+        "SDK and CtrlProxy artifacts must be released together.",
       usesPermissions(document).contains(LEGACY_NETWORK_CONTROL_PERMISSION),
     )
     assertFalse(

--- a/android/control-proxy/src/test/kotlin/dev/jasonpearson/automobile/ctrlproxy/NetworkControlPermissionManifestTest.kt
+++ b/android/control-proxy/src/test/kotlin/dev/jasonpearson/automobile/ctrlproxy/NetworkControlPermissionManifestTest.kt
@@ -77,6 +77,13 @@ class NetworkControlPermissionManifestTest {
         ".NetworkControlContractProbeReceiver",
       ),
     )
+    assertEquals(
+      PLATFORM_DUMP_PERMISSION,
+      receiverPermission(
+        readManifest("playground/app", "debug"),
+        ".NavigationGraphContractReceiver",
+      ),
+    )
   }
 
   private fun readManifest(module: String, sourceSet: String = "main"): Document =

--- a/android/control-proxy/src/test/kotlin/dev/jasonpearson/automobile/ctrlproxy/NetworkControlPermissionManifestTest.kt
+++ b/android/control-proxy/src/test/kotlin/dev/jasonpearson/automobile/ctrlproxy/NetworkControlPermissionManifestTest.kt
@@ -1,0 +1,88 @@
+package dev.jasonpearson.automobile.ctrlproxy
+
+import java.io.File
+import javax.xml.parsers.DocumentBuilderFactory
+import org.junit.Assert.assertEquals
+import org.junit.Assert.assertFalse
+import org.junit.Assert.assertTrue
+import org.junit.Test
+import org.w3c.dom.Document
+import org.w3c.dom.Element
+
+class NetworkControlPermissionManifestTest {
+
+  @Test
+  fun `SDK manifest does not define network control permission`() {
+    val permissions = permissionDefinitions(readManifest("auto-mobile-sdk"))
+
+    assertFalse(
+      "The SDK library must not define $NETWORK_CONTROL_PERMISSION because every SDK host would " +
+        "become its owner after manifest merging.",
+      permissions.any { it.name == NETWORK_CONTROL_PERMISSION },
+    )
+  }
+
+  @Test
+  fun `CtrlProxy owns and requests network control permission`() {
+    val document = readManifest("control-proxy")
+    val definitions = permissionDefinitions(document)
+
+    assertEquals(
+      "CtrlProxy must be the sole signature-permission owner.",
+      listOf("signature"),
+      definitions.filter { it.name == NETWORK_CONTROL_PERMISSION }.map { it.protectionLevel },
+    )
+    assertTrue(
+      "CtrlProxy must request $NETWORK_CONTROL_PERMISSION to send protected control broadcasts.",
+      usesPermissions(document).contains(NETWORK_CONTROL_PERMISSION),
+    )
+  }
+
+  private fun readManifest(module: String): Document =
+    DocumentBuilderFactory.newInstance().run {
+      isNamespaceAware = true
+      newDocumentBuilder().parse(locateManifest(module))
+    }
+
+  private fun permissionDefinitions(document: Document): List<PermissionDefinition> =
+    elements(document, "permission").map { element ->
+      PermissionDefinition(
+        name = element.androidAttribute("name"),
+        protectionLevel = element.androidAttribute("protectionLevel"),
+      )
+    }
+
+  private fun usesPermissions(document: Document): List<String> =
+    elements(document, "uses-permission").map { it.androidAttribute("name") }
+
+  private fun elements(document: Document, tagName: String): List<Element> {
+    val nodes = document.getElementsByTagName(tagName)
+    return (0 until nodes.length).map { nodes.item(it) as Element }
+  }
+
+  private fun Element.androidAttribute(name: String): String =
+    getAttributeNS(ANDROID_NAMESPACE, name)
+
+  private fun locateManifest(module: String): File {
+    val rel = "$module/src/main/AndroidManifest.xml"
+    val direct = listOf(File("../$rel"), File(rel), File("android/$rel")).firstOrNull { it.isFile }
+    if (direct != null) return direct
+
+    var directory = File(System.getProperty("user.dir") ?: ".").absoluteFile
+    while (true) {
+      val candidate = File(directory, "android/$rel")
+      if (candidate.isFile) return candidate
+      directory = directory.parentFile ?: break
+    }
+
+    error("Could not locate $rel from user.dir=${System.getProperty("user.dir")}")
+  }
+
+  private data class PermissionDefinition(val name: String, val protectionLevel: String)
+
+  private companion object {
+    const val ANDROID_NAMESPACE = "http://schemas.android.com/apk/res/android"
+    const val NETWORK_CONTROL_PERMISSION =
+      "dev.jasonpearson.automobile.sdk.permission.NETWORK_CONTROL"
+  }
+}

--- a/android/control-proxy/src/test/kotlin/dev/jasonpearson/automobile/ctrlproxy/NetworkControlPermissionManifestTest.kt
+++ b/android/control-proxy/src/test/kotlin/dev/jasonpearson/automobile/ctrlproxy/NetworkControlPermissionManifestTest.kt
@@ -20,6 +20,10 @@ class NetworkControlPermissionManifestTest {
         "become its owner after manifest merging.",
       permissions.any { it.name == NETWORK_CONTROL_PERMISSION },
     )
+    assertFalse(
+      "The SDK library must not retain the legacy permission because released SDK hosts own it.",
+      permissions.any { it.name == LEGACY_NETWORK_CONTROL_PERMISSION },
+    )
   }
 
   @Test
@@ -35,6 +39,10 @@ class NetworkControlPermissionManifestTest {
     assertTrue(
       "CtrlProxy must request $NETWORK_CONTROL_PERMISSION to send protected control broadcasts.",
       usesPermissions(document).contains(NETWORK_CONTROL_PERMISSION),
+    )
+    assertFalse(
+      "CtrlProxy must not claim the legacy permission that released SDK hosts already own.",
+      definitions.any { it.name == LEGACY_NETWORK_CONTROL_PERMISSION },
     )
   }
 
@@ -83,6 +91,8 @@ class NetworkControlPermissionManifestTest {
   private companion object {
     const val ANDROID_NAMESPACE = "http://schemas.android.com/apk/res/android"
     const val NETWORK_CONTROL_PERMISSION =
+      "dev.jasonpearson.automobile.ctrlproxy.permission.NETWORK_CONTROL_V2"
+    const val LEGACY_NETWORK_CONTROL_PERMISSION =
       "dev.jasonpearson.automobile.sdk.permission.NETWORK_CONTROL"
   }
 }

--- a/android/control-proxy/src/test/kotlin/dev/jasonpearson/automobile/ctrlproxy/NetworkControlPermissionManifestTest.kt
+++ b/android/control-proxy/src/test/kotlin/dev/jasonpearson/automobile/ctrlproxy/NetworkControlPermissionManifestTest.kt
@@ -51,10 +51,28 @@ class NetworkControlPermissionManifestTest {
     )
   }
 
-  private fun readManifest(module: String): Document =
+  @Test
+  fun `emulator contract receivers require the platform dump permission`() {
+    assertEquals(
+      PLATFORM_DUMP_PERMISSION,
+      receiverPermission(
+        readManifest("control-proxy", "debug"),
+        ".NetworkControlContractReceiver",
+      ),
+    )
+    assertEquals(
+      PLATFORM_DUMP_PERMISSION,
+      receiverPermission(
+        readManifest("playground/app", "debug"),
+        ".NetworkControlContractProbeReceiver",
+      ),
+    )
+  }
+
+  private fun readManifest(module: String, sourceSet: String = "main"): Document =
     DocumentBuilderFactory.newInstance().run {
       isNamespaceAware = true
-      newDocumentBuilder().parse(locateManifest(module))
+      newDocumentBuilder().parse(locateManifest(module, sourceSet))
     }
 
   private fun permissionDefinitions(document: Document): List<PermissionDefinition> =
@@ -68,6 +86,11 @@ class NetworkControlPermissionManifestTest {
   private fun usesPermissions(document: Document): List<String> =
     elements(document, "uses-permission").map { it.androidAttribute("name") }
 
+  private fun receiverPermission(document: Document, name: String): String =
+    elements(document, "receiver")
+      .single { it.androidAttribute("name") == name }
+      .androidAttribute("permission")
+
   private fun elements(document: Document, tagName: String): List<Element> {
     val nodes = document.getElementsByTagName(tagName)
     return (0 until nodes.length).map { nodes.item(it) as Element }
@@ -76,8 +99,8 @@ class NetworkControlPermissionManifestTest {
   private fun Element.androidAttribute(name: String): String =
     getAttributeNS(ANDROID_NAMESPACE, name)
 
-  private fun locateManifest(module: String): File {
-    val rel = "$module/src/main/AndroidManifest.xml"
+  private fun locateManifest(module: String, sourceSet: String): File {
+    val rel = "$module/src/$sourceSet/AndroidManifest.xml"
     val direct = listOf(File("../$rel"), File(rel), File("android/$rel")).firstOrNull { it.isFile }
     if (direct != null) return direct
 
@@ -99,5 +122,6 @@ class NetworkControlPermissionManifestTest {
       "dev.jasonpearson.automobile.ctrlproxy.permission.NETWORK_CONTROL_V2"
     const val LEGACY_NETWORK_CONTROL_PERMISSION =
       "dev.jasonpearson.automobile.sdk.permission.NETWORK_CONTROL"
+    const val PLATFORM_DUMP_PERMISSION = "android.permission.DUMP"
   }
 }

--- a/android/control-proxy/src/test/kotlin/dev/jasonpearson/automobile/ctrlproxy/NetworkControlPermissionManifestTest.kt
+++ b/android/control-proxy/src/test/kotlin/dev/jasonpearson/automobile/ctrlproxy/NetworkControlPermissionManifestTest.kt
@@ -13,7 +13,9 @@ class NetworkControlPermissionManifestTest {
 
   @Test
   fun `SDK manifest does not define network control permission`() {
-    val permissions = permissionDefinitions(readManifest("auto-mobile-sdk"))
+    val document = readManifest("auto-mobile-sdk")
+    val permissions = permissionDefinitions(document)
+    val requestedPermissions = usesPermissions(document)
 
     assertFalse(
       "The SDK library must not define $NETWORK_CONTROL_PERMISSION because every SDK host would " +
@@ -23,6 +25,14 @@ class NetworkControlPermissionManifestTest {
     assertFalse(
       "The SDK library must not retain the legacy permission because released SDK hosts own it.",
       permissions.any { it.name == LEGACY_NETWORK_CONTROL_PERMISSION },
+    )
+    assertFalse(
+      "The SDK library must not request $NETWORK_CONTROL_PERMISSION.",
+      requestedPermissions.contains(NETWORK_CONTROL_PERMISSION),
+    )
+    assertFalse(
+      "The SDK library must not retain the legacy permission request.",
+      requestedPermissions.contains(LEGACY_NETWORK_CONTROL_PERMISSION),
     )
   }
 

--- a/android/control-proxy/src/test/kotlin/dev/jasonpearson/automobile/ctrlproxy/NetworkControlPermissionManifestTest.kt
+++ b/android/control-proxy/src/test/kotlin/dev/jasonpearson/automobile/ctrlproxy/NetworkControlPermissionManifestTest.kt
@@ -27,7 +27,7 @@ class NetworkControlPermissionManifestTest {
   }
 
   @Test
-  fun `CtrlProxy owns and requests network control permission`() {
+  fun `CtrlProxy owns V2 and requests V2 plus legacy network control permissions`() {
     val document = readManifest("control-proxy")
     val definitions = permissionDefinitions(document)
 
@@ -39,6 +39,10 @@ class NetworkControlPermissionManifestTest {
     assertTrue(
       "CtrlProxy must request $NETWORK_CONTROL_PERMISSION to send protected control broadcasts.",
       usesPermissions(document).contains(NETWORK_CONTROL_PERMISSION),
+    )
+    assertTrue(
+      "CtrlProxy must retain $LEGACY_NETWORK_CONTROL_PERMISSION for compatible legacy SDK hosts.",
+      usesPermissions(document).contains(LEGACY_NETWORK_CONTROL_PERMISSION),
     )
     assertFalse(
       "CtrlProxy must not claim the legacy permission that released SDK hosts already own.",

--- a/android/control-proxy/src/test/kotlin/dev/jasonpearson/automobile/ctrlproxy/SdkEventBatchProcessorTest.kt
+++ b/android/control-proxy/src/test/kotlin/dev/jasonpearson/automobile/ctrlproxy/SdkEventBatchProcessorTest.kt
@@ -1,0 +1,60 @@
+package dev.jasonpearson.automobile.ctrlproxy
+
+import dev.jasonpearson.automobile.protocol.NavigationSourceType
+import dev.jasonpearson.automobile.protocol.SdkEventBatch
+import dev.jasonpearson.automobile.protocol.SdkNavigationEvent
+import kotlinx.coroutines.CompletableDeferred
+import kotlinx.coroutines.async
+import kotlinx.coroutines.test.advanceUntilIdle
+import kotlinx.coroutines.test.runTest
+import org.junit.Assert.assertEquals
+import org.junit.Test
+
+class SdkEventBatchProcessorTest {
+
+  @Test
+  fun `does not interleave concurrent batches while a navigation broadcast suspends`() = runTest {
+    val firstBroadcastStarted = CompletableDeferred<Unit>()
+    val allowFirstBroadcastToFinish = CompletableDeferred<Unit>()
+    val broadcasts = mutableListOf<String>()
+    val processor =
+      SdkEventBatchProcessor(
+        navigationEventAccumulator = NavigationEventAccumulator(),
+        broadcastNavigationEvent = { event ->
+          broadcasts.add(event.destination)
+          if (event.destination == "first") {
+            firstBroadcastStarted.complete(Unit)
+            allowFirstBroadcastToFinish.await()
+          }
+        },
+        broadcastSdkEvent = { error("Unexpected SDK event: $it") },
+      )
+
+    val firstBatch = async { processor.process(batch("first", "second")) }
+    firstBroadcastStarted.await()
+    val secondBatch = async { processor.process(batch("third")) }
+    advanceUntilIdle()
+
+    assertEquals(listOf("first"), broadcasts)
+
+    allowFirstBroadcastToFinish.complete(Unit)
+    advanceUntilIdle()
+    firstBatch.await()
+    secondBatch.await()
+
+    assertEquals(listOf("first", "second", "third"), broadcasts)
+  }
+
+  private fun batch(vararg destinations: String): SdkEventBatch =
+    SdkEventBatch(
+      timestamp = 0L,
+      events =
+        destinations.mapIndexed { index, destination ->
+          SdkNavigationEvent(
+            timestamp = index.toLong(),
+            destination = destination,
+            source = NavigationSourceType.CUSTOM,
+          )
+        },
+    )
+}

--- a/android/control-proxy/src/test/kotlin/dev/jasonpearson/automobile/ctrlproxy/SdkEventBatchProcessorTest.kt
+++ b/android/control-proxy/src/test/kotlin/dev/jasonpearson/automobile/ctrlproxy/SdkEventBatchProcessorTest.kt
@@ -4,8 +4,6 @@ import dev.jasonpearson.automobile.protocol.NavigationSourceType
 import dev.jasonpearson.automobile.protocol.SdkEventBatch
 import dev.jasonpearson.automobile.protocol.SdkNavigationEvent
 import kotlinx.coroutines.CompletableDeferred
-import kotlinx.coroutines.async
-import kotlinx.coroutines.test.advanceUntilIdle
 import kotlinx.coroutines.test.runTest
 import org.junit.Assert.assertEquals
 import org.junit.Test
@@ -13,37 +11,39 @@ import org.junit.Test
 class SdkEventBatchProcessorTest {
 
   @Test
-  fun `does not interleave concurrent batches while a navigation broadcast suspends`() = runTest {
-    val firstBroadcastStarted = CompletableDeferred<Unit>()
-    val allowFirstBroadcastToFinish = CompletableDeferred<Unit>()
-    val broadcasts = mutableListOf<String>()
-    val processor =
-      SdkEventBatchProcessor(
-        navigationEventAccumulator = NavigationEventAccumulator(),
-        broadcastNavigationEvent = { event ->
-          broadcasts.add(event.destination)
-          if (event.destination == "first") {
-            firstBroadcastStarted.complete(Unit)
-            allowFirstBroadcastToFinish.await()
-          }
-        },
-        broadcastSdkEvent = { error("Unexpected SDK event: $it") },
-      )
+  fun `processes queued batches in broadcast arrival order while a navigation broadcast suspends`() =
+    runTest {
+      val firstBroadcastStarted = CompletableDeferred<Unit>()
+      val allowFirstBroadcastToFinish = CompletableDeferred<Unit>()
+      val thirdBroadcastFinished = CompletableDeferred<Unit>()
+      val broadcasts = mutableListOf<String>()
+      val processor =
+        SdkEventBatchProcessor(
+          scope = backgroundScope,
+          navigationEventAccumulator = NavigationEventAccumulator(),
+          broadcastNavigationEvent = { event ->
+            broadcasts.add(event.destination)
+            if (event.destination == "first") {
+              firstBroadcastStarted.complete(Unit)
+              allowFirstBroadcastToFinish.await()
+            } else if (event.destination == "third") {
+              thirdBroadcastFinished.complete(Unit)
+            }
+          },
+          broadcastSdkEvent = { error("Unexpected SDK event: $it") },
+        )
 
-    val firstBatch = async { processor.process(batch("first", "second")) }
-    firstBroadcastStarted.await()
-    val secondBatch = async { processor.process(batch("third")) }
-    advanceUntilIdle()
+      processor.enqueue(batch("first", "second"))
+      firstBroadcastStarted.await()
+      processor.enqueue(batch("third"))
 
-    assertEquals(listOf("first"), broadcasts)
+      assertEquals(listOf("first"), broadcasts)
 
-    allowFirstBroadcastToFinish.complete(Unit)
-    advanceUntilIdle()
-    firstBatch.await()
-    secondBatch.await()
+      allowFirstBroadcastToFinish.complete(Unit)
+      thirdBroadcastFinished.await()
 
-    assertEquals(listOf("first", "second", "third"), broadcasts)
-  }
+      assertEquals(listOf("first", "second", "third"), broadcasts)
+    }
 
   private fun batch(vararg destinations: String): SdkEventBatch =
     SdkEventBatch(

--- a/android/control-proxy/src/test/kotlin/dev/jasonpearson/automobile/ctrlproxy/SdkEventBatchProcessorTest.kt
+++ b/android/control-proxy/src/test/kotlin/dev/jasonpearson/automobile/ctrlproxy/SdkEventBatchProcessorTest.kt
@@ -6,6 +6,7 @@ import dev.jasonpearson.automobile.protocol.SdkNavigationEvent
 import kotlinx.coroutines.CompletableDeferred
 import kotlinx.coroutines.test.runTest
 import org.junit.Assert.assertEquals
+import org.junit.Assert.assertFalse
 import org.junit.Assert.assertTrue
 import org.junit.Test
 
@@ -47,7 +48,7 @@ class SdkEventBatchProcessorTest {
     }
 
   @Test
-  fun `preserves queued batches while a navigation broadcast suspends`() = runTest {
+  fun `rejects batches when the bounded queue is full while a navigation broadcast suspends`() = runTest {
     val firstBroadcastStarted = CompletableDeferred<Unit>()
     val allowFirstBroadcastToFinish = CompletableDeferred<Unit>()
     val finalBroadcastFinished = CompletableDeferred<Unit>()
@@ -61,7 +62,7 @@ class SdkEventBatchProcessorTest {
           if (event.destination == "first") {
             firstBroadcastStarted.complete(Unit)
             allowFirstBroadcastToFinish.await()
-          } else if (event.destination == "queued-65") {
+          } else if (event.destination == "queued-64") {
             finalBroadcastFinished.complete(Unit)
           }
         },
@@ -71,10 +72,11 @@ class SdkEventBatchProcessorTest {
     assertTrue(processor.enqueue(batch("first")))
     firstBroadcastStarted.await()
 
-    val queuedDestinations = (1..65).map { "queued-$it" }
+    val queuedDestinations = (1..64).map { "queued-$it" }
     for (destination in queuedDestinations) {
       assertTrue(processor.enqueue(batch(destination)))
     }
+    assertFalse(processor.enqueue(batch("dropped-when-full")))
 
     allowFirstBroadcastToFinish.complete(Unit)
     finalBroadcastFinished.await()

--- a/android/control-proxy/src/test/kotlin/dev/jasonpearson/automobile/ctrlproxy/SdkEventBatchProcessorTest.kt
+++ b/android/control-proxy/src/test/kotlin/dev/jasonpearson/automobile/ctrlproxy/SdkEventBatchProcessorTest.kt
@@ -6,7 +6,6 @@ import dev.jasonpearson.automobile.protocol.SdkNavigationEvent
 import kotlinx.coroutines.CompletableDeferred
 import kotlinx.coroutines.test.runTest
 import org.junit.Assert.assertEquals
-import org.junit.Assert.assertFalse
 import org.junit.Assert.assertTrue
 import org.junit.Test
 
@@ -48,37 +47,40 @@ class SdkEventBatchProcessorTest {
     }
 
   @Test
-  fun `drops batches beyond bounded queue capacity while a navigation broadcast suspends`() =
-    runTest {
-      val firstBroadcastStarted = CompletableDeferred<Unit>()
-      val allowFirstBroadcastToFinish = CompletableDeferred<Unit>()
-      val secondBroadcastFinished = CompletableDeferred<Unit>()
-      val processor =
-        SdkEventBatchProcessor(
-          scope = backgroundScope,
-          navigationEventAccumulator = NavigationEventAccumulator(),
-          broadcastNavigationEvent = { event ->
-            if (event.destination == "first") {
-              firstBroadcastStarted.complete(Unit)
-              allowFirstBroadcastToFinish.await()
-            } else if (event.destination == "second") {
-              secondBroadcastFinished.complete(Unit)
-            }
-          },
-          broadcastSdkEvent = { error("Unexpected SDK event: $it") },
-          queueCapacity = 1,
-        )
+  fun `preserves queued batches while a navigation broadcast suspends`() = runTest {
+    val firstBroadcastStarted = CompletableDeferred<Unit>()
+    val allowFirstBroadcastToFinish = CompletableDeferred<Unit>()
+    val finalBroadcastFinished = CompletableDeferred<Unit>()
+    val broadcasts = mutableListOf<String>()
+    val processor =
+      SdkEventBatchProcessor(
+        scope = backgroundScope,
+        navigationEventAccumulator = NavigationEventAccumulator(),
+        broadcastNavigationEvent = { event ->
+          broadcasts.add(event.destination)
+          if (event.destination == "first") {
+            firstBroadcastStarted.complete(Unit)
+            allowFirstBroadcastToFinish.await()
+          } else if (event.destination == "queued-65") {
+            finalBroadcastFinished.complete(Unit)
+          }
+        },
+        broadcastSdkEvent = { error("Unexpected SDK event: $it") },
+      )
 
-      assertTrue(processor.enqueue(batch("first")))
-      firstBroadcastStarted.await()
+    assertTrue(processor.enqueue(batch("first")))
+    firstBroadcastStarted.await()
 
-      assertTrue(processor.enqueue(batch("second")))
-      assertFalse(processor.enqueue(batch("third")))
-      assertEquals(1L, processor.droppedBatchCount)
-
-      allowFirstBroadcastToFinish.complete(Unit)
-      secondBroadcastFinished.await()
+    val queuedDestinations = (1..65).map { "queued-$it" }
+    for (destination in queuedDestinations) {
+      assertTrue(processor.enqueue(batch(destination)))
     }
+
+    allowFirstBroadcastToFinish.complete(Unit)
+    finalBroadcastFinished.await()
+
+    assertEquals(listOf("first") + queuedDestinations, broadcasts)
+  }
 
   private fun batch(vararg destinations: String): SdkEventBatch =
     SdkEventBatch(

--- a/android/control-proxy/src/test/kotlin/dev/jasonpearson/automobile/ctrlproxy/SdkEventBatchProcessorTest.kt
+++ b/android/control-proxy/src/test/kotlin/dev/jasonpearson/automobile/ctrlproxy/SdkEventBatchProcessorTest.kt
@@ -156,6 +156,42 @@ class SdkEventBatchProcessorTest {
     assertEquals(listOf(0L, 1L), broadcasts.map { it.sequenceNumber })
   }
 
+  @Test
+  fun `holds later queued events until a replacement client connects`() = runTest {
+    var clientConnection = CompletableDeferred<Unit>().also { it.complete(Unit) }
+    val firstBroadcastFinished = CompletableDeferred<Unit>()
+    val secondBroadcastFinished = CompletableDeferred<Unit>()
+    val broadcasts = mutableListOf<String>()
+    val processor =
+      SdkEventBatchProcessor(
+        scope = backgroundScope,
+        navigationEventAccumulator = NavigationEventAccumulator(),
+        awaitClientConnection = { clientConnection.await() },
+        broadcastNavigationEvent = { event ->
+          broadcasts.add(event.destination)
+          if (event.destination == "first") {
+            clientConnection = CompletableDeferred()
+            firstBroadcastFinished.complete(Unit)
+          } else if (event.destination == "second") {
+            secondBroadcastFinished.complete(Unit)
+          }
+        },
+        broadcastSdkEvent = { error("Unexpected SDK event: $it") },
+      )
+
+    processor.start()
+    assertTrue(processor.enqueue(batch("first", "second")))
+    firstBroadcastFinished.await()
+    advanceUntilIdle()
+
+    assertEquals(listOf("first"), broadcasts)
+
+    clientConnection.complete(Unit)
+    secondBroadcastFinished.await()
+
+    assertEquals(listOf("first", "second"), broadcasts)
+  }
+
   private fun batch(vararg destinations: String): SdkEventBatch =
     SdkEventBatch(
       timestamp = 0L,

--- a/android/control-proxy/src/test/kotlin/dev/jasonpearson/automobile/ctrlproxy/SdkEventBatchProcessorTest.kt
+++ b/android/control-proxy/src/test/kotlin/dev/jasonpearson/automobile/ctrlproxy/SdkEventBatchProcessorTest.kt
@@ -166,8 +166,8 @@ class SdkEventBatchProcessorTest {
       SdkEventBatchProcessor(
         scope = backgroundScope,
         navigationEventAccumulator = NavigationEventAccumulator(),
-        awaitClientConnection = { clientConnection.await() },
         broadcastNavigationEvent = { event ->
+          clientConnection.await()
           broadcasts.add(event.destination)
           if (event.destination == "first") {
             clientConnection = CompletableDeferred()

--- a/android/control-proxy/src/test/kotlin/dev/jasonpearson/automobile/ctrlproxy/SdkEventBatchProcessorTest.kt
+++ b/android/control-proxy/src/test/kotlin/dev/jasonpearson/automobile/ctrlproxy/SdkEventBatchProcessorTest.kt
@@ -48,41 +48,42 @@ class SdkEventBatchProcessorTest {
     }
 
   @Test
-  fun `rejects batches when the bounded queue is full while a navigation broadcast suspends`() = runTest {
-    val firstBroadcastStarted = CompletableDeferred<Unit>()
-    val allowFirstBroadcastToFinish = CompletableDeferred<Unit>()
-    val finalBroadcastFinished = CompletableDeferred<Unit>()
-    val broadcasts = mutableListOf<String>()
-    val processor =
-      SdkEventBatchProcessor(
-        scope = backgroundScope,
-        navigationEventAccumulator = NavigationEventAccumulator(),
-        broadcastNavigationEvent = { event ->
-          broadcasts.add(event.destination)
-          if (event.destination == "first") {
-            firstBroadcastStarted.complete(Unit)
-            allowFirstBroadcastToFinish.await()
-          } else if (event.destination == "queued-64") {
-            finalBroadcastFinished.complete(Unit)
-          }
-        },
-        broadcastSdkEvent = { error("Unexpected SDK event: $it") },
-      )
+  fun `rejects batches when the bounded queue is full while a navigation broadcast suspends`() =
+    runTest {
+      val firstBroadcastStarted = CompletableDeferred<Unit>()
+      val allowFirstBroadcastToFinish = CompletableDeferred<Unit>()
+      val finalBroadcastFinished = CompletableDeferred<Unit>()
+      val broadcasts = mutableListOf<String>()
+      val processor =
+        SdkEventBatchProcessor(
+          scope = backgroundScope,
+          navigationEventAccumulator = NavigationEventAccumulator(),
+          broadcastNavigationEvent = { event ->
+            broadcasts.add(event.destination)
+            if (event.destination == "first") {
+              firstBroadcastStarted.complete(Unit)
+              allowFirstBroadcastToFinish.await()
+            } else if (event.destination == "queued-64") {
+              finalBroadcastFinished.complete(Unit)
+            }
+          },
+          broadcastSdkEvent = { error("Unexpected SDK event: $it") },
+        )
 
-    assertTrue(processor.enqueue(batch("first")))
-    firstBroadcastStarted.await()
+      assertTrue(processor.enqueue(batch("first")))
+      firstBroadcastStarted.await()
 
-    val queuedDestinations = (1..64).map { "queued-$it" }
-    for (destination in queuedDestinations) {
-      assertTrue(processor.enqueue(batch(destination)))
+      val queuedDestinations = (1..64).map { "queued-$it" }
+      for (destination in queuedDestinations) {
+        assertTrue(processor.enqueue(batch(destination)))
+      }
+      assertFalse(processor.enqueue(batch("dropped-when-full")))
+
+      allowFirstBroadcastToFinish.complete(Unit)
+      finalBroadcastFinished.await()
+
+      assertEquals(listOf("first") + queuedDestinations, broadcasts)
     }
-    assertFalse(processor.enqueue(batch("dropped-when-full")))
-
-    allowFirstBroadcastToFinish.complete(Unit)
-    finalBroadcastFinished.await()
-
-    assertEquals(listOf("first") + queuedDestinations, broadcasts)
-  }
 
   @Test
   fun `processes legacy navigation before a later batch through the same actor`() = runTest {

--- a/android/control-proxy/src/test/kotlin/dev/jasonpearson/automobile/ctrlproxy/SdkEventBatchProcessorTest.kt
+++ b/android/control-proxy/src/test/kotlin/dev/jasonpearson/automobile/ctrlproxy/SdkEventBatchProcessorTest.kt
@@ -82,6 +82,48 @@ class SdkEventBatchProcessorTest {
     assertEquals(listOf("first") + queuedDestinations, broadcasts)
   }
 
+  @Test
+  fun `processes legacy navigation before a later batch through the same actor`() = runTest {
+    val legacyBroadcastStarted = CompletableDeferred<Unit>()
+    val allowLegacyBroadcastToFinish = CompletableDeferred<Unit>()
+    val batchBroadcastFinished = CompletableDeferred<Unit>()
+    val broadcasts = mutableListOf<TimestampedNavigationEvent>()
+    val processor =
+      SdkEventBatchProcessor(
+        scope = backgroundScope,
+        navigationEventAccumulator = NavigationEventAccumulator(),
+        broadcastNavigationEvent = { event ->
+          broadcasts.add(event)
+          if (event.destination == "legacy") {
+            legacyBroadcastStarted.complete(Unit)
+            allowLegacyBroadcastToFinish.await()
+          } else if (event.destination == "batched") {
+            batchBroadcastFinished.complete(Unit)
+          }
+        },
+        broadcastSdkEvent = { error("Unexpected SDK event: $it") },
+      )
+
+    assertTrue(
+      processor.enqueueNavigationEvent(
+        destination = "legacy",
+        source = "legacy",
+        arguments = emptyMap(),
+        metadata = emptyMap(),
+        applicationId = null,
+        timestamp = 0L,
+      )
+    )
+    legacyBroadcastStarted.await()
+    assertTrue(processor.enqueue(batch("batched")))
+
+    allowLegacyBroadcastToFinish.complete(Unit)
+    batchBroadcastFinished.await()
+
+    assertEquals(listOf("legacy", "batched"), broadcasts.map { it.destination })
+    assertEquals(listOf(0L, 1L), broadcasts.map { it.sequenceNumber })
+  }
+
   private fun batch(vararg destinations: String): SdkEventBatch =
     SdkEventBatch(
       timestamp = 0L,

--- a/android/control-proxy/src/test/kotlin/dev/jasonpearson/automobile/ctrlproxy/SdkEventBatchProcessorTest.kt
+++ b/android/control-proxy/src/test/kotlin/dev/jasonpearson/automobile/ctrlproxy/SdkEventBatchProcessorTest.kt
@@ -6,6 +6,8 @@ import dev.jasonpearson.automobile.protocol.SdkNavigationEvent
 import kotlinx.coroutines.CompletableDeferred
 import kotlinx.coroutines.test.runTest
 import org.junit.Assert.assertEquals
+import org.junit.Assert.assertFalse
+import org.junit.Assert.assertTrue
 import org.junit.Test
 
 class SdkEventBatchProcessorTest {
@@ -43,6 +45,35 @@ class SdkEventBatchProcessorTest {
       thirdBroadcastFinished.await()
 
       assertEquals(listOf("first", "second", "third"), broadcasts)
+    }
+
+  @Test
+  fun `drops batches beyond bounded queue capacity while a navigation broadcast suspends`() =
+    runTest {
+      val firstBroadcastStarted = CompletableDeferred<Unit>()
+      val allowFirstBroadcastToFinish = CompletableDeferred<Unit>()
+      val processor =
+        SdkEventBatchProcessor(
+          scope = backgroundScope,
+          navigationEventAccumulator = NavigationEventAccumulator(),
+          broadcastNavigationEvent = { event ->
+            if (event.destination == "first") {
+              firstBroadcastStarted.complete(Unit)
+              allowFirstBroadcastToFinish.await()
+            }
+          },
+          broadcastSdkEvent = { error("Unexpected SDK event: $it") },
+          queueCapacity = 1,
+        )
+
+      assertTrue(processor.enqueue(batch("first")))
+      firstBroadcastStarted.await()
+
+      assertTrue(processor.enqueue(batch("second")))
+      assertFalse(processor.enqueue(batch("third")))
+      assertEquals(1L, processor.droppedBatchCount)
+
+      allowFirstBroadcastToFinish.complete(Unit)
     }
 
   private fun batch(vararg destinations: String): SdkEventBatch =

--- a/android/control-proxy/src/test/kotlin/dev/jasonpearson/automobile/ctrlproxy/SdkEventBatchProcessorTest.kt
+++ b/android/control-proxy/src/test/kotlin/dev/jasonpearson/automobile/ctrlproxy/SdkEventBatchProcessorTest.kt
@@ -4,6 +4,7 @@ import dev.jasonpearson.automobile.protocol.NavigationSourceType
 import dev.jasonpearson.automobile.protocol.SdkEventBatch
 import dev.jasonpearson.automobile.protocol.SdkNavigationEvent
 import kotlinx.coroutines.CompletableDeferred
+import kotlinx.coroutines.test.advanceUntilIdle
 import kotlinx.coroutines.test.runTest
 import org.junit.Assert.assertEquals
 import org.junit.Assert.assertFalse
@@ -11,6 +12,31 @@ import org.junit.Assert.assertTrue
 import org.junit.Test
 
 class SdkEventBatchProcessorTest {
+
+  @Test
+  fun `holds a startup batch until WebSocket processing begins`() = runTest {
+    val startupBroadcastFinished = CompletableDeferred<Unit>()
+    val broadcasts = mutableListOf<String>()
+    val processor =
+      SdkEventBatchProcessor(
+        scope = backgroundScope,
+        navigationEventAccumulator = NavigationEventAccumulator(),
+        broadcastNavigationEvent = { event ->
+          broadcasts.add(event.destination)
+          startupBroadcastFinished.complete(Unit)
+        },
+        broadcastSdkEvent = { error("Unexpected SDK event: $it") },
+      )
+
+    assertTrue(processor.enqueue(batch("startup")))
+    advanceUntilIdle()
+
+    assertTrue("startup batch must wait for WebSocket readiness", broadcasts.isEmpty())
+    processor.start()
+    startupBroadcastFinished.await()
+
+    assertEquals(listOf("startup"), broadcasts)
+  }
 
   @Test
   fun `processes queued batches in broadcast arrival order while a navigation broadcast suspends`() =
@@ -35,6 +61,7 @@ class SdkEventBatchProcessorTest {
           broadcastSdkEvent = { error("Unexpected SDK event: $it") },
         )
 
+      processor.start()
       processor.enqueue(batch("first", "second"))
       firstBroadcastStarted.await()
       processor.enqueue(batch("third"))
@@ -70,6 +97,7 @@ class SdkEventBatchProcessorTest {
           broadcastSdkEvent = { error("Unexpected SDK event: $it") },
         )
 
+      processor.start()
       assertTrue(processor.enqueue(batch("first")))
       firstBroadcastStarted.await()
 
@@ -107,6 +135,7 @@ class SdkEventBatchProcessorTest {
         broadcastSdkEvent = { error("Unexpected SDK event: $it") },
       )
 
+    processor.start()
     assertTrue(
       processor.enqueueNavigationEvent(
         destination = "legacy",

--- a/android/control-proxy/src/test/kotlin/dev/jasonpearson/automobile/ctrlproxy/SdkEventBatchProcessorTest.kt
+++ b/android/control-proxy/src/test/kotlin/dev/jasonpearson/automobile/ctrlproxy/SdkEventBatchProcessorTest.kt
@@ -52,6 +52,7 @@ class SdkEventBatchProcessorTest {
     runTest {
       val firstBroadcastStarted = CompletableDeferred<Unit>()
       val allowFirstBroadcastToFinish = CompletableDeferred<Unit>()
+      val secondBroadcastFinished = CompletableDeferred<Unit>()
       val processor =
         SdkEventBatchProcessor(
           scope = backgroundScope,
@@ -60,6 +61,8 @@ class SdkEventBatchProcessorTest {
             if (event.destination == "first") {
               firstBroadcastStarted.complete(Unit)
               allowFirstBroadcastToFinish.await()
+            } else if (event.destination == "second") {
+              secondBroadcastFinished.complete(Unit)
             }
           },
           broadcastSdkEvent = { error("Unexpected SDK event: $it") },
@@ -74,6 +77,7 @@ class SdkEventBatchProcessorTest {
       assertEquals(1L, processor.droppedBatchCount)
 
       allowFirstBroadcastToFinish.complete(Unit)
+      secondBroadcastFinished.await()
     }
 
   private fun batch(vararg destinations: String): SdkEventBatch =

--- a/android/control-proxy/src/test/kotlin/dev/jasonpearson/automobile/ctrlproxy/WebSocketServerIntegrationTest.kt
+++ b/android/control-proxy/src/test/kotlin/dev/jasonpearson/automobile/ctrlproxy/WebSocketServerIntegrationTest.kt
@@ -414,6 +414,46 @@ class WebSocketServerIntegrationTest {
   }
 
   @Test
+  fun `sync broadcast waits for a client and delivers after it connects`() = runBlocking {
+    server.start()
+    val response =
+      SettingsGetResult(
+        timestamp = 1234L,
+        success = true,
+        namespace = "secure",
+        key = "setting",
+        value = "value",
+        found = true,
+        totalTimeMs = 1L,
+      )
+    val delivery = async {
+      server.broadcast(
+        response,
+        mode = WebSocketServer.BroadcastMode.Sync,
+        waitForClient = true,
+      )
+    }
+    assertFalse("Delivery must wait until a client is connected", delivery.isCompleted)
+
+    val client = HttpClient(CIO) { install(WebSockets) }
+    client.use { client ->
+      client.webSocket(
+        method = HttpMethod.Get,
+        host = "localhost",
+        port = getServerPort(),
+        path = "/ws",
+      ) {
+        incoming.receive()
+        val delivered = withTimeout(1000) { incoming.receive() } as Frame.Text
+        val payload = json.parseToJsonElement(delivered.readText()).jsonObject
+
+        assertEquals("settings_get_result", payload["type"]?.jsonPrimitive?.content)
+        withTimeout(1000) { delivery.await() }
+      }
+    }
+  }
+
+  @Test
   fun `add_highlight returns highlight response`() = runBlocking {
     server.start()
 

--- a/android/control-proxy/src/test/kotlin/dev/jasonpearson/automobile/ctrlproxy/WebSocketServerIntegrationTest.kt
+++ b/android/control-proxy/src/test/kotlin/dev/jasonpearson/automobile/ctrlproxy/WebSocketServerIntegrationTest.kt
@@ -18,6 +18,7 @@ import io.ktor.websocket.readText
 import kotlinx.coroutines.CoroutineScope
 import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.SupervisorJob
+import kotlinx.coroutines.async
 import kotlinx.coroutines.cancel
 import kotlinx.coroutines.delay
 import kotlinx.coroutines.launch
@@ -162,6 +163,9 @@ class WebSocketServerIntegrationTest {
   fun `client can connect to server`() = runBlocking {
     // Given
     server.start()
+    val firstClientConnection = async { server.awaitFirstClientConnection() }
+
+    assertFalse("No client should be ready before the handshake", firstClientConnection.isCompleted)
 
     // When
     val client = HttpClient(CIO) { install(WebSockets) }
@@ -175,6 +179,7 @@ class WebSocketServerIntegrationTest {
       ) {
         // Then - connection established
         waitFor { server.getConnectionCount() == 1 }
+        withTimeout(1000) { firstClientConnection.await() }
         assertEquals(1, server.getConnectionCount())
 
         // Receive connection message

--- a/android/control-proxy/src/test/kotlin/dev/jasonpearson/automobile/ctrlproxy/WebSocketServerIntegrationTest.kt
+++ b/android/control-proxy/src/test/kotlin/dev/jasonpearson/automobile/ctrlproxy/WebSocketServerIntegrationTest.kt
@@ -363,6 +363,57 @@ class WebSocketServerIntegrationTest {
   }
 
   @Test
+  fun `await client connection waits for a replacement client after disconnect`() = runBlocking {
+    server.start()
+
+    val client = HttpClient(CIO) { install(WebSockets) }
+    client.use { client ->
+      val firstClient = launch {
+        client.webSocket(
+          method = HttpMethod.Get,
+          host = "localhost",
+          port = getServerPort(),
+          path = "/ws",
+        ) {
+          incoming.receive()
+          delay(Long.MAX_VALUE)
+        }
+      }
+
+      waitFor { server.getConnectionCount() == 1 }
+      withTimeout(1000) { server.awaitClientConnection() }
+
+      firstClient.cancel()
+      firstClient.join()
+      waitFor { server.getConnectionCount() == 0 }
+
+      val reconnectWait = async { server.awaitClientConnection() }
+      assertFalse(
+        "A disconnected client must not satisfy the delivery gate",
+        reconnectWait.isCompleted,
+      )
+
+      val replacementClient = launch {
+        client.webSocket(
+          method = HttpMethod.Get,
+          host = "localhost",
+          port = getServerPort(),
+          path = "/ws",
+        ) {
+          incoming.receive()
+          delay(Long.MAX_VALUE)
+        }
+      }
+
+      waitFor { server.getConnectionCount() == 1 }
+      withTimeout(1000) { reconnectWait.await() }
+
+      replacementClient.cancel()
+      replacementClient.join()
+    }
+  }
+
+  @Test
   fun `add_highlight returns highlight response`() = runBlocking {
     server.start()
 

--- a/android/playground/app/src/debug/AndroidManifest.xml
+++ b/android/playground/app/src/debug/AndroidManifest.xml
@@ -9,5 +9,13 @@
         <action android:name="dev.jasonpearson.automobile.playground.action.TEST_PROBE_NETWORK_CONTROL" />
       </intent-filter>
     </receiver>
+    <receiver
+      android:name=".NavigationGraphContractReceiver"
+      android:exported="true"
+      android:permission="android.permission.DUMP">
+      <intent-filter>
+        <action android:name="dev.jasonpearson.automobile.playground.action.TEST_EMIT_SDK_NAVIGATION" />
+      </intent-filter>
+    </receiver>
   </application>
 </manifest>

--- a/android/playground/app/src/debug/AndroidManifest.xml
+++ b/android/playground/app/src/debug/AndroidManifest.xml
@@ -1,0 +1,13 @@
+<?xml version="1.0" encoding="utf-8"?>
+<manifest xmlns:android="http://schemas.android.com/apk/res/android">
+  <application>
+    <receiver
+      android:name=".NetworkControlContractProbeReceiver"
+      android:exported="true"
+      android:permission="android.permission.DUMP">
+      <intent-filter>
+        <action android:name="dev.jasonpearson.automobile.playground.action.TEST_PROBE_NETWORK_CONTROL" />
+      </intent-filter>
+    </receiver>
+  </application>
+</manifest>

--- a/android/playground/app/src/debug/kotlin/dev/jasonpearson/automobile/playground/NavigationGraphContractReceiver.kt
+++ b/android/playground/app/src/debug/kotlin/dev/jasonpearson/automobile/playground/NavigationGraphContractReceiver.kt
@@ -1,0 +1,29 @@
+package dev.jasonpearson.automobile.playground
+
+import android.content.BroadcastReceiver
+import android.content.Context
+import android.content.Intent
+import dev.jasonpearson.automobile.sdk.AutoMobileSDK
+import dev.jasonpearson.automobile.sdk.NavigationEvent
+import dev.jasonpearson.automobile.sdk.NavigationSource
+
+/** Debug-only trigger for the Android SDK navigation graph contract test. */
+class NavigationGraphContractReceiver : BroadcastReceiver() {
+  override fun onReceive(context: Context, intent: Intent) {
+    if (intent.action != ACTION_EMIT_SDK_NAVIGATION) return
+
+    val destination = intent.getStringExtra(EXTRA_DESTINATION)?.takeIf { it.isNotBlank() } ?: return
+    AutoMobileSDK.notifyNavigationEvent(
+      NavigationEvent(
+        destination = destination,
+        source = NavigationSource.CUSTOM,
+      )
+    )
+  }
+
+  companion object {
+    const val ACTION_EMIT_SDK_NAVIGATION =
+      "dev.jasonpearson.automobile.playground.action.TEST_EMIT_SDK_NAVIGATION"
+    const val EXTRA_DESTINATION = "destination"
+  }
+}

--- a/android/playground/app/src/debug/kotlin/dev/jasonpearson/automobile/playground/NetworkControlContractProbeReceiver.kt
+++ b/android/playground/app/src/debug/kotlin/dev/jasonpearson/automobile/playground/NetworkControlContractProbeReceiver.kt
@@ -10,7 +10,8 @@ class NetworkControlContractProbeReceiver : BroadcastReceiver() {
   override fun onReceive(context: Context, intent: Intent) {
     if (intent.action != ACTION_PROBE_NETWORK_CONTROL) return
 
-    val errorType = NetworkMockRuleStore.getInstance().getActiveErrorSimulation()?.errorType.orEmpty()
+    val errorType =
+      NetworkMockRuleStore.getInstance().getActiveErrorSimulation()?.errorType.orEmpty()
     context.openFileOutput(RESULT_FILE, Context.MODE_PRIVATE).bufferedWriter().use { writer ->
       writer.write(errorType)
     }

--- a/android/playground/app/src/debug/kotlin/dev/jasonpearson/automobile/playground/NetworkControlContractProbeReceiver.kt
+++ b/android/playground/app/src/debug/kotlin/dev/jasonpearson/automobile/playground/NetworkControlContractProbeReceiver.kt
@@ -1,0 +1,24 @@
+package dev.jasonpearson.automobile.playground
+
+import android.content.BroadcastReceiver
+import android.content.Context
+import android.content.Intent
+import dev.jasonpearson.automobile.sdk.network.NetworkMockRuleStore
+
+/** Debug-only probe for the emulator permission-delivery contract test. */
+class NetworkControlContractProbeReceiver : BroadcastReceiver() {
+  override fun onReceive(context: Context, intent: Intent) {
+    if (intent.action != ACTION_PROBE_NETWORK_CONTROL) return
+
+    val errorType = NetworkMockRuleStore.getInstance().getActiveErrorSimulation()?.errorType.orEmpty()
+    context.openFileOutput(RESULT_FILE, Context.MODE_PRIVATE).bufferedWriter().use { writer ->
+      writer.write(errorType)
+    }
+  }
+
+  companion object {
+    const val ACTION_PROBE_NETWORK_CONTROL =
+      "dev.jasonpearson.automobile.playground.action.TEST_PROBE_NETWORK_CONTROL"
+    const val RESULT_FILE = "automobile-network-control-contract-result"
+  }
+}

--- a/scripts/android/navigation-graph-sdk-event-integration.sh
+++ b/scripts/android/navigation-graph-sdk-event-integration.sh
@@ -1,0 +1,86 @@
+#!/usr/bin/env bash
+#
+# Verify the Android SDK broadcast reaches the public navigation graph surface
+# through the installed CtrlProxy and daemon.
+
+set -euo pipefail
+
+adb_bin="${ADB_BIN:-adb}"
+device_id="${1:-}"
+package_id="dev.jasonpearson.automobile.playground"
+emit_action="dev.jasonpearson.automobile.playground.action.TEST_EMIT_SDK_NAVIGATION"
+session_uuid="52150000-0000-4000-8000-000000000000"
+timestamp_ms="$(($(date +%s) * 1000))"
+destination="Issue5215SdkNavigation-${timestamp_ms}"
+graph=""
+
+require_command() {
+  command -v "$1" >/dev/null 2>&1 || {
+    echo "error: required command not found: $1" >&2
+    exit 1
+  }
+}
+
+require_command "$adb_bin"
+require_command auto-mobile
+require_command jq
+
+if [[ -z "$device_id" ]]; then
+  device_id="$("$adb_bin" devices | awk '$2 == "device" { print $1; exit }')"
+fi
+if [[ -z "$device_id" ]]; then
+  echo "error: no connected Android device" >&2
+  exit 1
+fi
+
+# The debug-only Playground receiver requires android.permission.DUMP. Restart
+# the selected emulator's adbd as root before launching the session it serves.
+"$adb_bin" -s "$device_id" root >/dev/null
+"$adb_bin" -s "$device_id" wait-for-device
+
+# Bind CtrlProxy's SDK-event client and the graph query to the same daemon
+# session before emitting the event. The debug-only Playground receiver invokes
+# the public AutoMobileSDK API after launch has initialized the SDK.
+if ! auto-mobile --debug --embedded-sdk --cli --session-uuid "$session_uuid" \
+  launchApp --platform android --appId "$package_id" --deviceId "$device_id" >/dev/null; then
+  echo "error: could not launch Android graph target app" >&2
+  exit 1
+fi
+if ! auto-mobile --debug --embedded-sdk --cli --session-uuid "$session_uuid" \
+  observe --platform android --deviceId "$device_id" >/dev/null; then
+  echo "error: could not bind Android SDK events to navigation graph session" >&2
+  exit 1
+fi
+
+if ! "$adb_bin" -s "$device_id" shell am broadcast \
+  -a "$emit_action" -p "$package_id" --es destination "$destination" >/dev/null; then
+  echo "error: could not trigger Android SDK navigation event" >&2
+  exit 1
+fi
+
+for attempt in 1 2 3 4 5; do
+  if ! auto-mobile --debug --embedded-sdk --cli --session-uuid "$session_uuid" \
+    observe --platform android --deviceId "$device_id" >/dev/null; then
+    echo "observe refresh attempt ${attempt} failed; retrying in 2s..." >&2
+    sleep 2
+    continue
+  fi
+  if ! graph="$(auto-mobile --debug --embedded-sdk --cli --session-uuid "$session_uuid" \
+    getNavigationGraph --platform android --deviceId "$device_id")"; then
+    echo "getNavigationGraph attempt ${attempt} failed; retrying in 2s..." >&2
+    sleep 2
+    continue
+  fi
+  if jq -e --arg destination "$destination" \
+    '(if .content? then (.content[] | select(.type == "text").text | fromjson) else . end) as $result
+      | ([$result.screens[].name] | index($destination)) != null' \
+    <<<"$graph" >/dev/null; then
+    echo "Android SDK navigation event reached getNavigationGraph on attempt ${attempt}."
+    exit 0
+  fi
+  sleep 2
+done
+
+echo "error: Android SDK navigation event did not reach getNavigationGraph" >&2
+echo "last graph response: ${graph}" >&2
+exit 1

--- a/scripts/android/navigation-graph-sdk-event-integration.sh
+++ b/scripts/android/navigation-graph-sdk-event-integration.sh
@@ -6,6 +6,10 @@
 set -euo pipefail
 
 adb_bin="${ADB_BIN:-adb}"
+script_dir="$(cd -- "$(dirname -- "${BASH_SOURCE[0]}")" && pwd)"
+repo_root="${GITHUB_WORKSPACE:-$(cd -- "${script_dir}/../.." && pwd)}"
+dist_entry="${repo_root}/dist/src/index.js"
+bun_bin_dir="${HOME}/.bun/bin"
 device_id="${1:-}"
 package_id="dev.jasonpearson.automobile.playground"
 emit_action="dev.jasonpearson.automobile.playground.action.TEST_EMIT_SDK_NAVIGATION"
@@ -21,8 +25,26 @@ require_command() {
   }
 }
 
+resolve_auto_mobile_cli() {
+  export PATH="${bun_bin_dir}:${PATH}"
+  hash -r 2>/dev/null || true
+
+  if command -v auto-mobile >/dev/null 2>&1; then
+    return
+  fi
+
+  if [[ -x "${dist_entry}" ]]; then
+    echo "auto-mobile not resolvable from global install; linking ${bun_bin_dir}/auto-mobile -> ${dist_entry}"
+    mkdir -p "${bun_bin_dir}"
+    ln -sf "${dist_entry}" "${bun_bin_dir}/auto-mobile"
+    hash -r 2>/dev/null || true
+  fi
+
+  require_command auto-mobile
+}
+
 require_command "$adb_bin"
-require_command auto-mobile
+resolve_auto_mobile_cli
 require_command jq
 
 if [[ -z "$device_id" ]]; then

--- a/scripts/android/verify-sdk-ctrl-proxy-permission-contract.sh
+++ b/scripts/android/verify-sdk-ctrl-proxy-permission-contract.sh
@@ -68,7 +68,7 @@ install_in_order() {
 
 tmp_dir="$(mktemp -d "${TMPDIR:-/tmp}/auto-mobile-sdk-host.XXXXXX")"
 host_keystore="${tmp_dir}/host.keystore"
-# shellcheck disable=SC2329 # Invoked by the EXIT trap below.
+# shellcheck disable=SC2317,SC2329 # Invoked by the EXIT trap below.
 cleanup() {
   unlink "$host_keystore" 2>/dev/null || true
   rmdir "$tmp_dir" 2>/dev/null || true

--- a/scripts/android/verify-sdk-ctrl-proxy-permission-contract.sh
+++ b/scripts/android/verify-sdk-ctrl-proxy-permission-contract.sh
@@ -74,7 +74,8 @@ verify_control_broadcast_delivery() {
 
   local attempt result
   for ((attempt = 0; attempt < 20; attempt++)); do
-    "$adb_bin" shell am broadcast -a "$send_action" -p "$ctrl_proxy_package" >/dev/null
+    # CtrlProxy has not been launched after each clean install, so its debug receiver is stopped.
+    "$adb_bin" shell am broadcast --include-stopped-packages -a "$send_action" -p "$ctrl_proxy_package" >/dev/null
     "$adb_bin" shell am broadcast -a "$probe_action" -p "$host_package" >/dev/null
     result="$("$adb_bin" shell run-as "$host_package" cat "$result_file" 2>/dev/null || true)"
     if [[ "$result" == "$expected_error_type" ]]; then

--- a/scripts/android/verify-sdk-ctrl-proxy-permission-contract.sh
+++ b/scripts/android/verify-sdk-ctrl-proxy-permission-contract.sh
@@ -1,0 +1,138 @@
+#!/usr/bin/env bash
+#
+# Verifies the CtrlProxy-owned V2 signature permission with an SDK host signed by a different key.
+
+set -euo pipefail
+
+ctrl_proxy_apk_input="${1:?usage: verify-sdk-ctrl-proxy-permission-contract.sh <ctrl-proxy-apk>}"
+ctrl_proxy_apk="$(cd "$(dirname "$ctrl_proxy_apk_input")" && pwd)/$(basename "$ctrl_proxy_apk_input")"
+script_dir="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+repo_root="$(cd "${script_dir}/../.." && pwd)"
+android_dir="${repo_root}/android"
+host_apk="${android_dir}/playground/app/build/outputs/apk/debug/playground-app-debug.apk"
+
+adb_bin="${ADB_BIN:-adb}"
+gradle_cmd="${GRADLE_CMD:-${android_dir}/gradlew}"
+keytool_bin="${KEYTOOL_BIN:-keytool}"
+sleep_bin="${SLEEP_BIN:-sleep}"
+ctrl_proxy_package="dev.jasonpearson.automobile.ctrlproxy"
+host_package="dev.jasonpearson.automobile.playground"
+result_file="files/automobile-network-control-contract-result"
+send_action="dev.jasonpearson.automobile.ctrlproxy.action.TEST_SEND_NETWORK_CONTROL"
+probe_action="dev.jasonpearson.automobile.playground.action.TEST_PROBE_NETWORK_CONTROL"
+expected_error_type="ctrlproxy-v2"
+
+resolve_apksigner() {
+  if [[ -n "${APKSIGNER_BIN:-}" ]]; then
+    printf '%s\n' "$APKSIGNER_BIN"
+    return
+  fi
+
+  if command -v apksigner >/dev/null 2>&1; then
+    command -v apksigner
+    return
+  fi
+
+  local sdk_root candidate
+  for sdk_root in "${ANDROID_HOME:-}" "${ANDROID_SDK_ROOT:-}"; do
+    [[ -n "$sdk_root" ]] || continue
+    for candidate in "$sdk_root"/build-tools/*/apksigner; do
+      if [[ -x "$candidate" ]]; then
+        printf '%s\n' "$candidate"
+        return
+      fi
+    done
+  done
+
+  echo "error: apksigner is required to verify the distinct host signature" >&2
+  return 1
+}
+
+certificate_digest() {
+  "$apksigner_bin" verify --print-certs "$1" |
+    awk -F ': ' '/Signer #1 certificate SHA-256 digest:/ { print $2; exit }'
+}
+
+cleanup_packages() {
+  "$adb_bin" uninstall "$host_package" >/dev/null 2>&1 || true
+  "$adb_bin" uninstall "$ctrl_proxy_package" >/dev/null 2>&1 || true
+}
+
+install_in_order() {
+  local first_apk="$1"
+  local second_apk="$2"
+  cleanup_packages
+  "$adb_bin" install "$first_apk" >/dev/null
+  "$adb_bin" install "$second_apk" >/dev/null
+}
+
+tmp_dir="$(mktemp -d "${TMPDIR:-/tmp}/auto-mobile-sdk-host.XXXXXX")"
+host_keystore="${tmp_dir}/host.keystore"
+# shellcheck disable=SC2329 # Invoked by the EXIT trap below.
+cleanup() {
+  unlink "$host_keystore" 2>/dev/null || true
+  rmdir "$tmp_dir" 2>/dev/null || true
+}
+trap cleanup EXIT
+
+[[ -f "$ctrl_proxy_apk" ]] || {
+  echo "error: CtrlProxy APK not found: $ctrl_proxy_apk" >&2
+  exit 1
+}
+
+"$keytool_bin" \
+  -genkeypair \
+  -keystore "$host_keystore" \
+  -storepass contract-test \
+  -keypass contract-test \
+  -alias sdk-host \
+  -keyalg RSA \
+  -keysize 2048 \
+  -validity 1 \
+  -dname "CN=AutoMobile SDK Contract"
+
+(
+  cd "$android_dir"
+  RELEASE_KEYSTORE_PATH="$host_keystore" \
+    RELEASE_KEYSTORE_PASSWORD=contract-test \
+    RELEASE_KEY_ALIAS=sdk-host \
+    RELEASE_KEY_PASSWORD=contract-test \
+    "$gradle_cmd" :playground:app:assembleDebug --console=plain
+)
+
+[[ -f "$host_apk" ]] || {
+  echo "error: SDK host APK not found: $host_apk" >&2
+  exit 1
+}
+
+apksigner_bin="$(resolve_apksigner)"
+ctrl_proxy_digest="$(certificate_digest "$ctrl_proxy_apk")"
+host_digest="$(certificate_digest "$host_apk")"
+[[ -n "$ctrl_proxy_digest" && -n "$host_digest" ]] || {
+  echo "error: could not read APK certificate digests" >&2
+  exit 1
+}
+[[ "$ctrl_proxy_digest" != "$host_digest" ]] || {
+  echo "error: CtrlProxy and SDK host must use different signing certificates" >&2
+  exit 1
+}
+
+install_in_order "$host_apk" "$ctrl_proxy_apk"
+install_in_order "$ctrl_proxy_apk" "$host_apk"
+
+"$adb_bin" shell am start -W -n "${host_package}/.MainActivity" >/dev/null
+"$adb_bin" shell run-as "$host_package" rm -f "$result_file"
+"$adb_bin" shell am broadcast -a "$send_action" -p "$ctrl_proxy_package" >/dev/null
+
+for ((attempt = 0; attempt < 20; attempt++)); do
+  "$adb_bin" shell am broadcast -a "$probe_action" -p "$host_package" >/dev/null
+  result="$("$adb_bin" shell run-as "$host_package" cat "$result_file" 2>/dev/null || true)"
+  if [[ "$result" == "$expected_error_type" ]]; then
+    echo "verified V2 control broadcast delivery to separately signed SDK host"
+    exit 0
+  fi
+  "$sleep_bin" 1
+done
+
+echo "error: CtrlProxy V2 control broadcast did not reach SDK host" >&2
+exit 1

--- a/scripts/android/verify-sdk-ctrl-proxy-permission-contract.sh
+++ b/scripts/android/verify-sdk-ctrl-proxy-permission-contract.sh
@@ -71,10 +71,10 @@ verify_control_broadcast_delivery() {
 
   "$adb_bin" shell am start -W -n "${host_package}/.MainActivity" >/dev/null
   "$adb_bin" shell run-as "$host_package" rm -f "$result_file"
-  "$adb_bin" shell am broadcast -a "$send_action" -p "$ctrl_proxy_package" >/dev/null
 
   local attempt result
   for ((attempt = 0; attempt < 20; attempt++)); do
+    "$adb_bin" shell am broadcast -a "$send_action" -p "$ctrl_proxy_package" >/dev/null
     "$adb_bin" shell am broadcast -a "$probe_action" -p "$host_package" >/dev/null
     result="$("$adb_bin" shell run-as "$host_package" cat "$result_file" 2>/dev/null || true)"
     if [[ "$result" == "$expected_error_type" ]]; then

--- a/scripts/android/verify-sdk-ctrl-proxy-permission-contract.sh
+++ b/scripts/android/verify-sdk-ctrl-proxy-permission-contract.sh
@@ -66,6 +66,28 @@ install_in_order() {
   "$adb_bin" install "$second_apk" >/dev/null
 }
 
+verify_control_broadcast_delivery() {
+  local installation_order="$1"
+
+  "$adb_bin" shell am start -W -n "${host_package}/.MainActivity" >/dev/null
+  "$adb_bin" shell run-as "$host_package" rm -f "$result_file"
+  "$adb_bin" shell am broadcast -a "$send_action" -p "$ctrl_proxy_package" >/dev/null
+
+  local attempt result
+  for ((attempt = 0; attempt < 20; attempt++)); do
+    "$adb_bin" shell am broadcast -a "$probe_action" -p "$host_package" >/dev/null
+    result="$("$adb_bin" shell run-as "$host_package" cat "$result_file" 2>/dev/null || true)"
+    if [[ "$result" == "$expected_error_type" ]]; then
+      echo "verified V2 control broadcast delivery after $installation_order"
+      return
+    fi
+    "$sleep_bin" 1
+  done
+
+  echo "error: CtrlProxy V2 control broadcast did not reach SDK host after $installation_order" >&2
+  return 1
+}
+
 tmp_dir="$(mktemp -d "${TMPDIR:-/tmp}/auto-mobile-sdk-host.XXXXXX")"
 host_keystore="${tmp_dir}/host.keystore"
 # shellcheck disable=SC2317,SC2329 # Invoked by the EXIT trap below.
@@ -118,21 +140,6 @@ host_digest="$(certificate_digest "$host_apk")"
 }
 
 install_in_order "$host_apk" "$ctrl_proxy_apk"
+verify_control_broadcast_delivery "installing the SDK host before CtrlProxy"
 install_in_order "$ctrl_proxy_apk" "$host_apk"
-
-"$adb_bin" shell am start -W -n "${host_package}/.MainActivity" >/dev/null
-"$adb_bin" shell run-as "$host_package" rm -f "$result_file"
-"$adb_bin" shell am broadcast -a "$send_action" -p "$ctrl_proxy_package" >/dev/null
-
-for ((attempt = 0; attempt < 20; attempt++)); do
-  "$adb_bin" shell am broadcast -a "$probe_action" -p "$host_package" >/dev/null
-  result="$("$adb_bin" shell run-as "$host_package" cat "$result_file" 2>/dev/null || true)"
-  if [[ "$result" == "$expected_error_type" ]]; then
-    echo "verified V2 control broadcast delivery to separately signed SDK host"
-    exit 0
-  fi
-  "$sleep_bin" 1
-done
-
-echo "error: CtrlProxy V2 control broadcast did not reach SDK host" >&2
-exit 1
+verify_control_broadcast_delivery "installing CtrlProxy before the SDK host"

--- a/scripts/android/verify-sdk-ctrl-proxy-permission-contract.sh
+++ b/scripts/android/verify-sdk-ctrl-proxy-permission-contract.sh
@@ -139,6 +139,11 @@ host_digest="$(certificate_digest "$host_apk")"
   exit 1
 }
 
+# The debug-only probe receivers require android.permission.DUMP. Restart adbd
+# as root before installing either package so their broadcasts execute with it.
+"$adb_bin" root >/dev/null
+"$adb_bin" wait-for-device
+
 install_in_order "$host_apk" "$ctrl_proxy_apk"
 verify_control_broadcast_delivery "installing the SDK host before CtrlProxy"
 install_in_order "$ctrl_proxy_apk" "$host_apk"

--- a/scripts/android/verify-sdk-ctrl-proxy-permission-contract.sh
+++ b/scripts/android/verify-sdk-ctrl-proxy-permission-contract.sh
@@ -9,7 +9,7 @@ ctrl_proxy_apk="$(cd "$(dirname "$ctrl_proxy_apk_input")" && pwd)/$(basename "$c
 script_dir="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
 repo_root="$(cd "${script_dir}/../.." && pwd)"
 android_dir="${repo_root}/android"
-host_apk="${android_dir}/playground/app/build/outputs/apk/debug/playground-app-debug.apk"
+host_apk="${android_dir}/playground/app/build/outputs/apk/debug/app-debug.apk"
 
 adb_bin="${ADB_BIN:-adb}"
 gradle_cmd="${GRADLE_CMD:-${android_dir}/gradlew}"

--- a/src/features/observe/android/AndroidCtrlProxyClient.ts
+++ b/src/features/observe/android/AndroidCtrlProxyClient.ts
@@ -963,6 +963,7 @@ export class AndroidCtrlProxyClient extends DeviceServiceClient implements Andro
   // Hierarchy navigation detector
   private hierarchyNavigationDetector: HierarchyNavigationDetector | null = null;
   private sdkNavigationAppIds: Set<string> = new Set();
+  private navigationWriteTail: Promise<void> = Promise.resolve();
 
   // Screenshot backoff scheduler
   private screenshotBackoffScheduler: ScreenshotBackoffScheduler | null = null;
@@ -2983,7 +2984,7 @@ export class AndroidCtrlProxyClient extends DeviceServiceClient implements Andro
           // (issue #2885). If the write is still in flight when the drain window
           // closes, Part 1's dialect reject-on-closed drops the row cleanly
           // (issue #2792).
-          const navWrite = this.getNavigationGraphManager().recordNavigationEvent(event);
+          const navWrite = this.enqueueNavigationGraphWrite(event);
           void getDbWriteBarrier().trackExisting(navWrite);
           await navWrite;
 
@@ -3567,6 +3568,18 @@ export class AndroidCtrlProxyClient extends DeviceServiceClient implements Andro
     } catch (error) {
       logger.warn(`[CTRL_PROXY] Failed to apply package event: ${error}`);
     }
+  }
+
+  private enqueueNavigationGraphWrite(event: NavigationEvent): Promise<void> {
+    const navigationGraphManager = this.getNavigationGraphManager();
+    const navWrite = this.navigationWriteTail.then(
+      () => navigationGraphManager.recordNavigationEvent(event),
+      () => navigationGraphManager.recordNavigationEvent(event),
+    );
+    // A failed event remains observable to its handler, but cannot permanently block later
+    // navigation frames from reaching the graph.
+    this.navigationWriteTail = navWrite.catch(() => undefined);
+    return navWrite;
   }
 
   private async handleHandledExceptionEvent(event: HandledExceptionEvent): Promise<void> {

--- a/test/bats/android-navigation-graph-sdk-event-integration.bats
+++ b/test/bats/android-navigation-graph-sdk-event-integration.bats
@@ -11,6 +11,7 @@ setup() {
   export AUTO_MOBILE_LOG="${MOCK_BIN}/auto-mobile.log"
   export SESSION_BOUND_FILE="${MOCK_BIN}/session-bound"
   export EVENT_TRIGGERED_FILE="${MOCK_BIN}/event-triggered"
+  export EVENT_DESTINATION_FILE="${MOCK_BIN}/event-destination"
   export GRAPH_ATTEMPTS_FILE="${MOCK_BIN}/graph-attempts"
   export ROOTED_FILE="${MOCK_BIN}/rooted"
   export DEVICE_READY_FILE="${MOCK_BIN}/device-ready"
@@ -63,14 +64,23 @@ if [[ "$*" == *"TEST_EMIT_SDK_NAVIGATION"* ]]; then
     echo "SDK event emitted before graph session binding" >&2
     exit 1
   fi
+  for ((index = 1; index <= $#; index++)); do
+    if [ "${!index}" = "destination" ]; then
+      next_index=$((index + 1))
+      printf "%s\n" "${!next_index}" > "$EVENT_DESTINATION_FILE"
+      break
+    fi
+  done
   touch "$EVENT_TRIGGERED_FILE"
 fi
 '
   make_mock sleep 'exit 0'
   make_mock jq '
-if [ "$1" = "-e" ]; then
+if [ "$1" = "-e" ] && [ "$2" = "--arg" ] && [ "$3" = "destination" ] &&
+  grep -Fq -- "$4"; then
   exit 0
 fi
+exit 1
 '
   make_mock auto-mobile '
 printf "%s\n" "$*" >> "$AUTO_MOBILE_LOG"
@@ -102,7 +112,8 @@ if [ "$1" = "--debug" ] && [ "$2" = "--embedded-sdk" ] && [ "$3" = "--cli" ] && 
       if [ "$attempts" -eq 1 ]; then
         exit 1
       fi
-      printf "{}\n"
+      destination="$(cat "$EVENT_DESTINATION_FILE")"
+      printf "{\"screens\":[{\"name\":\"%s\"}]}\n" "$destination"
       exit 0
       ;;
   esac
@@ -137,11 +148,24 @@ if [ "$*" = "-s emulator-5554 root" ] || [ "$*" = "-s emulator-5554 wait-for-dev
   exit 0
 fi
 if [[ "$*" == *"TEST_EMIT_SDK_NAVIGATION"* ]]; then
+  for ((index = 1; index <= $#; index++)); do
+    if [ "${!index}" = "destination" ]; then
+      next_index=$((index + 1))
+      printf "%s\n" "${!next_index}" > "$EVENT_DESTINATION_FILE"
+      break
+    fi
+  done
   touch "$EVENT_TRIGGERED_FILE"
 fi
 '
   make_mock sleep 'exit 0'
-  make_mock jq 'exit 0'
+  make_mock jq '
+if [ "$1" = "-e" ] && [ "$2" = "--arg" ] && [ "$3" = "destination" ] &&
+  grep -Fq -- "$4"; then
+  exit 0
+fi
+exit 1
+'
   mkdir -p "${GITHUB_WORKSPACE}/dist/src"
   mkdir -p "${HOME}/.bun/bin"
   ln -s "${HOME}/.bun/bin/missing-auto-mobile" "${HOME}/.bun/bin/auto-mobile"
@@ -156,7 +180,8 @@ case "$6" in
     ;;
   getNavigationGraph)
     [ -f "$EVENT_TRIGGERED_FILE" ]
-    printf "{}\n"
+    destination="$(cat "$EVENT_DESTINATION_FILE")"
+    printf "{\"screens\":[{\"name\":\"%s\"}]}\n" "$destination"
     exit 0
     ;;
 esac

--- a/test/bats/android-navigation-graph-sdk-event-integration.bats
+++ b/test/bats/android-navigation-graph-sdk-event-integration.bats
@@ -1,0 +1,118 @@
+#!/usr/bin/env bats
+
+SCRIPT="scripts/android/navigation-graph-sdk-event-integration.sh"
+
+setup() {
+  MOCK_BIN="$(mktemp -d)"
+  ORIGINAL_PATH="$PATH"
+  export ADB_LOG="${MOCK_BIN}/adb.log"
+  export AUTO_MOBILE_LOG="${MOCK_BIN}/auto-mobile.log"
+  export SESSION_BOUND_FILE="${MOCK_BIN}/session-bound"
+  export EVENT_TRIGGERED_FILE="${MOCK_BIN}/event-triggered"
+  export GRAPH_ATTEMPTS_FILE="${MOCK_BIN}/graph-attempts"
+  export ROOTED_FILE="${MOCK_BIN}/rooted"
+  export DEVICE_READY_FILE="${MOCK_BIN}/device-ready"
+}
+
+teardown() {
+  find "$MOCK_BIN" -type f -exec unlink {} \;
+  rmdir "$MOCK_BIN"
+  export PATH="$ORIGINAL_PATH"
+}
+
+make_mock() {
+  local name="$1"
+  local body="$2"
+  cat > "${MOCK_BIN}/${name}" <<SCRIPT
+#!/usr/bin/env bash
+set -euo pipefail
+${body}
+SCRIPT
+  chmod +x "${MOCK_BIN}/${name}"
+}
+
+@test "binds the Android graph session before emitting and polling an SDK navigation event" {
+  make_mock adb '
+printf "%s\n" "$*" >> "$ADB_LOG"
+if [ "$1" = "devices" ]; then
+  printf "List of devices attached\nemulator-5554\tdevice\n"
+  exit 0
+fi
+if [ "$*" = "-s emulator-5554 root" ]; then
+  touch "$ROOTED_FILE"
+  exit 0
+fi
+if [ "$*" = "-s emulator-5554 wait-for-device" ]; then
+  [ -f "$ROOTED_FILE" ] || {
+    echo "wait-for-device ran before adb root" >&2
+    exit 1
+  }
+  touch "$DEVICE_READY_FILE"
+  exit 0
+fi
+if [[ "$*" == *"TEST_EMIT_SDK_NAVIGATION"* ]]; then
+  if [ ! -f "$SESSION_BOUND_FILE" ]; then
+    echo "SDK event emitted before graph session binding" >&2
+    exit 1
+  fi
+  touch "$EVENT_TRIGGERED_FILE"
+fi
+'
+  make_mock sleep 'exit 0'
+  make_mock jq '
+if [ "$1" = "-e" ]; then
+  exit 0
+fi
+'
+  make_mock auto-mobile '
+printf "%s\n" "$*" >> "$AUTO_MOBILE_LOG"
+if [ "$1" = "--debug" ] && [ "$2" = "--embedded-sdk" ] && [ "$3" = "--cli" ] && [ "$4" = "--session-uuid" ]; then
+  case "$6" in
+    launchApp)
+      [ -f "$DEVICE_READY_FILE" ] || {
+        echo "SDK host launched before rooted device was ready" >&2
+        exit 1
+      }
+      [ "$7" = "--platform" ] && [ "$8" = "android" ] &&
+        [ "$9" = "--appId" ] && [ "${10}" = "dev.jasonpearson.automobile.playground" ] &&
+        [ "${11}" = "--deviceId" ] && [ "${12}" = "emulator-5554" ]
+      exit
+      ;;
+    observe)
+      touch "$SESSION_BOUND_FILE"
+      exit
+      ;;
+    getNavigationGraph)
+      [ -f "$EVENT_TRIGGERED_FILE" ] || {
+        echo "graph queried before event trigger" >&2
+        exit 1
+      }
+      attempts=0
+      [ -f "$GRAPH_ATTEMPTS_FILE" ] && attempts="$(cat "$GRAPH_ATTEMPTS_FILE")"
+      attempts=$((attempts + 1))
+      printf "%s\n" "$attempts" > "$GRAPH_ATTEMPTS_FILE"
+      if [ "$attempts" -eq 1 ]; then
+        exit 1
+      fi
+      printf "{}\n"
+      exit 0
+      ;;
+  esac
+fi
+echo "unexpected auto-mobile invocation: $*" >&2
+exit 1
+'
+
+  run env PATH="${MOCK_BIN}:${PATH}" bash "$SCRIPT" "emulator-5554"
+
+  [ "$status" -eq 0 ]
+  [ "$(cat "$GRAPH_ATTEMPTS_FILE")" = "2" ]
+  [[ "$output" == *"getNavigationGraph attempt 1 failed"* ]]
+  grep -Eq -- 'TEST_EMIT_SDK_NAVIGATION.*--es destination Issue5215SdkNavigation-[0-9]+' "$ADB_LOG"
+  root_line="$(grep -nFx -- '-s emulator-5554 root' "$ADB_LOG" | cut -d: -f1)"
+  wait_for_device_line="$(grep -nFx -- '-s emulator-5554 wait-for-device' "$ADB_LOG" | cut -d: -f1)"
+  launch_line="$(grep -n -- "launchApp --platform android --appId dev.jasonpearson.automobile.playground --deviceId emulator-5554" "$AUTO_MOBILE_LOG" | head -n 1 | cut -d: -f1)"
+  first_observe_line="$(grep -n -- "observe --platform android --deviceId emulator-5554" "$AUTO_MOBILE_LOG" | head -n 1 | cut -d: -f1)"
+  [ "$root_line" -lt "$wait_for_device_line" ]
+  [ "$launch_line" -lt "$first_observe_line" ]
+}

--- a/test/bats/android-navigation-graph-sdk-event-integration.bats
+++ b/test/bats/android-navigation-graph-sdk-event-integration.bats
@@ -5,6 +5,8 @@ SCRIPT="scripts/android/navigation-graph-sdk-event-integration.sh"
 setup() {
   MOCK_BIN="$(mktemp -d)"
   ORIGINAL_PATH="$PATH"
+  ORIGINAL_HOME="$HOME"
+  export HOME="${MOCK_BIN}/home"
   export ADB_LOG="${MOCK_BIN}/adb.log"
   export AUTO_MOBILE_LOG="${MOCK_BIN}/auto-mobile.log"
   export SESSION_BOUND_FILE="${MOCK_BIN}/session-bound"
@@ -15,20 +17,26 @@ setup() {
 }
 
 teardown() {
-  find "$MOCK_BIN" -type f -exec unlink {} \;
-  rmdir "$MOCK_BIN"
+  find "$MOCK_BIN" -depth -type f -exec unlink {} \;
+  find "$MOCK_BIN" -depth -type l -exec unlink {} \;
+  find "$MOCK_BIN" -depth -type d -exec rmdir {} \;
   export PATH="$ORIGINAL_PATH"
+  export HOME="$ORIGINAL_HOME"
 }
 
-make_mock() {
-  local name="$1"
+make_executable() {
+  local path="$1"
   local body="$2"
-  cat > "${MOCK_BIN}/${name}" <<SCRIPT
+  cat > "${path}" <<SCRIPT
 #!/usr/bin/env bash
 set -euo pipefail
 ${body}
 SCRIPT
-  chmod +x "${MOCK_BIN}/${name}"
+  chmod +x "${path}"
+}
+
+make_mock() {
+  make_executable "${MOCK_BIN}/$1" "$2"
 }
 
 @test "binds the Android graph session before emitting and polling an SDK navigation event" {
@@ -115,4 +123,51 @@ exit 1
   first_observe_line="$(grep -n -- "observe --platform android --deviceId emulator-5554" "$AUTO_MOBILE_LOG" | head -n 1 | cut -d: -f1)"
   [ "$root_line" -lt "$wait_for_device_line" ]
   [ "$launch_line" -lt "$first_observe_line" ]
+}
+
+@test "uses the workspace CLI entrypoint when the global auto-mobile install is unavailable" {
+  export GITHUB_WORKSPACE="${MOCK_BIN}/workspace"
+
+  make_mock adb '
+if [ "$1" = "devices" ]; then
+  printf "List of devices attached\nemulator-5554\tdevice\n"
+  exit 0
+fi
+if [ "$*" = "-s emulator-5554 root" ] || [ "$*" = "-s emulator-5554 wait-for-device" ]; then
+  exit 0
+fi
+if [[ "$*" == *"TEST_EMIT_SDK_NAVIGATION"* ]]; then
+  touch "$EVENT_TRIGGERED_FILE"
+fi
+'
+  make_mock sleep 'exit 0'
+  make_mock jq 'exit 0'
+  mkdir -p "${GITHUB_WORKSPACE}/dist/src"
+  mkdir -p "${HOME}/.bun/bin"
+  ln -s "${HOME}/.bun/bin/missing-auto-mobile" "${HOME}/.bun/bin/auto-mobile"
+  make_executable "${GITHUB_WORKSPACE}/dist/src/index.js" '
+printf "%s\n" "$*" >> "$AUTO_MOBILE_LOG"
+case "$6" in
+  launchApp)
+    exit 0
+    ;;
+  observe)
+    exit 0
+    ;;
+  getNavigationGraph)
+    [ -f "$EVENT_TRIGGERED_FILE" ]
+    printf "{}\n"
+    exit 0
+    ;;
+esac
+exit 1
+'
+
+  run env PATH="${MOCK_BIN}:/bin:/usr/bin" GITHUB_WORKSPACE="$GITHUB_WORKSPACE" HOME="$HOME" bash "$SCRIPT" "emulator-5554"
+
+  [ "$status" -eq 0 ]
+  [ -L "${HOME}/.bun/bin/auto-mobile" ]
+  [ "$(readlink "${HOME}/.bun/bin/auto-mobile")" = "${GITHUB_WORKSPACE}/dist/src/index.js" ]
+  [[ "$output" == *"linking ${HOME}/.bun/bin/auto-mobile -> ${GITHUB_WORKSPACE}/dist/src/index.js"* ]]
+  grep -q -- 'getNavigationGraph --platform android --deviceId emulator-5554' "$AUTO_MOBILE_LOG"
 }

--- a/test/bats/release-workflow-wiring.bats
+++ b/test/bats/release-workflow-wiring.bats
@@ -98,6 +98,24 @@
   [[ "$output" != *"verify-release-integrity.sh"* ]]
 }
 
+@test "release CtrlProxy APK is built from the release variant" {
+  wiring_requires_yq
+  local workflow=".github/workflows/build-control-proxy-apk.yml"
+
+  run yq -r '.jobs.build.steps[] | select(.uses == "./.github/actions/gradle-task-run") | .with."gradle-tasks"' "$workflow"
+  [ "$status" -eq 0 ]
+  [ "$output" = ":control-proxy:assembleRelease" ]
+
+  run yq -r '.jobs.build.steps[] | select(.id == "checksum") | .run' "$workflow"
+  [ "$status" -eq 0 ]
+  [[ "$output" == *"apk/release/control-proxy-release.apk"* ]]
+
+  run yq -r '.jobs.build.steps[] | select(.name == "Copy APK to /tmp") | .run' "$workflow"
+  [ "$status" -eq 0 ]
+  [[ "$output" == *"apk/release/control-proxy-release.apk"* ]]
+  [[ "$output" == *"/tmp/control-proxy-debug.apk"* ]]
+}
+
 @test "prepare-release verifies and tags the single prepared artifact set before dispatching release (#4686)" {
   wiring_requires_yq
   local workflow=".github/workflows/prepare-release.yml"

--- a/test/bats/release-workflow-wiring.bats
+++ b/test/bats/release-workflow-wiring.bats
@@ -382,7 +382,7 @@
   [ "$preflight" -lt "$publish" ]
 }
 
-@test "release.yml blocks the GitHub Release when Android Maven publication fails (#5215)" {
+@test "release.yml publishes Android libraries before exposing the matching npm version (#5215)" {
   wiring_requires_yq
   local workflow=".github/workflows/release.yml"
 
@@ -392,13 +392,16 @@
   [ "$status" -eq 0 ]
   [ "$output" = "false" ]
 
-  local names publish release
+  local names publish npm release
   names="$(yq -r '.jobs."verify-and-release".steps[].name' "$workflow")"
   publish="$(printf '%s\n' "$names" \
     | grep -nxF 'Publish Android Libraries to Maven Central' | cut -d: -f1)"
+  npm="$(printf '%s\n' "$names" | grep -nxF 'Publish to npm' | cut -d: -f1)"
   release="$(printf '%s\n' "$names" | grep -nxF 'Create GitHub Release' | cut -d: -f1)"
   [ -n "$publish" ]
+  [ -n "$npm" ]
   [ -n "$release" ]
+  [ "$publish" -lt "$npm" ]
   [ "$publish" -lt "$release" ]
 }
 

--- a/test/bats/release-workflow-wiring.bats
+++ b/test/bats/release-workflow-wiring.bats
@@ -382,7 +382,7 @@
   [ "$preflight" -lt "$publish" ]
 }
 
-@test "release.yml publishes Android libraries, npm, then Homebrew before the GitHub release (#5215)" {
+@test "release.yml publishes the CtrlProxy release before compatible SDK distributions (#5215)" {
   wiring_requires_yq
   local workflow=".github/workflows/release.yml"
 
@@ -392,20 +392,24 @@
   [ "$status" -eq 0 ]
   [ "$output" = "false" ]
 
-  local names publish npm brew release
+  local names publish npm mcp brew release
   names="$(yq -r '.jobs."verify-and-release".steps[].name' "$workflow")"
   publish="$(printf '%s\n' "$names" \
     | grep -nxF 'Publish Android Libraries to Maven Central' | cut -d: -f1)"
   npm="$(printf '%s\n' "$names" | grep -nxF 'Publish to npm' | cut -d: -f1)"
+  mcp="$(printf '%s\n' "$names" | grep -nxF 'Publish to MCP Registry' | cut -d: -f1)"
   brew="$(printf '%s\n' "$names" | grep -nxF 'Publish Homebrew formula' | cut -d: -f1)"
   release="$(printf '%s\n' "$names" | grep -nxF 'Create GitHub Release' | cut -d: -f1)"
   [ -n "$publish" ]
   [ -n "$npm" ]
+  [ -n "$mcp" ]
   [ -n "$brew" ]
   [ -n "$release" ]
+  [ "$release" -lt "$publish" ]
   [ "$publish" -lt "$npm" ]
+  [ "$npm" -lt "$mcp" ]
+  [ "$mcp" -lt "$brew" ]
   [ "$npm" -lt "$brew" ]
-  [ "$brew" -lt "$release" ]
 }
 
 @test "release.yml preflight step calls the extracted preflight script (#4853)" {

--- a/test/bats/release-workflow-wiring.bats
+++ b/test/bats/release-workflow-wiring.bats
@@ -382,6 +382,26 @@
   [ "$preflight" -lt "$publish" ]
 }
 
+@test "release.yml blocks the GitHub Release when Android Maven publication fails (#5215)" {
+  wiring_requires_yq
+  local workflow=".github/workflows/release.yml"
+
+  run yq -r '.jobs."verify-and-release".steps[]
+    | select(.name == "Publish Android Libraries to Maven Central")
+    | ."continue-on-error" // false' "$workflow"
+  [ "$status" -eq 0 ]
+  [ "$output" = "false" ]
+
+  local names publish release
+  names="$(yq -r '.jobs."verify-and-release".steps[].name' "$workflow")"
+  publish="$(printf '%s\n' "$names" \
+    | grep -nxF 'Publish Android Libraries to Maven Central' | cut -d: -f1)"
+  release="$(printf '%s\n' "$names" | grep -nxF 'Create GitHub Release' | cut -d: -f1)"
+  [ -n "$publish" ]
+  [ -n "$release" ]
+  [ "$publish" -lt "$release" ]
+}
+
 @test "release.yml preflight step calls the extracted preflight script (#4853)" {
   wiring_requires_yq
   local script

--- a/test/bats/release-workflow-wiring.bats
+++ b/test/bats/release-workflow-wiring.bats
@@ -382,7 +382,7 @@
   [ "$preflight" -lt "$publish" ]
 }
 
-@test "release.yml publishes Android libraries before exposing the matching npm version (#5215)" {
+@test "release.yml publishes Android libraries, npm, then Homebrew before the GitHub release (#5215)" {
   wiring_requires_yq
   local workflow=".github/workflows/release.yml"
 
@@ -392,17 +392,20 @@
   [ "$status" -eq 0 ]
   [ "$output" = "false" ]
 
-  local names publish npm release
+  local names publish npm brew release
   names="$(yq -r '.jobs."verify-and-release".steps[].name' "$workflow")"
   publish="$(printf '%s\n' "$names" \
     | grep -nxF 'Publish Android Libraries to Maven Central' | cut -d: -f1)"
   npm="$(printf '%s\n' "$names" | grep -nxF 'Publish to npm' | cut -d: -f1)"
+  brew="$(printf '%s\n' "$names" | grep -nxF 'Publish Homebrew formula' | cut -d: -f1)"
   release="$(printf '%s\n' "$names" | grep -nxF 'Create GitHub Release' | cut -d: -f1)"
   [ -n "$publish" ]
   [ -n "$npm" ]
+  [ -n "$brew" ]
   [ -n "$release" ]
   [ "$publish" -lt "$npm" ]
-  [ "$publish" -lt "$release" ]
+  [ "$npm" -lt "$brew" ]
+  [ "$brew" -lt "$release" ]
 }
 
 @test "release.yml preflight step calls the extracted preflight script (#4853)" {

--- a/test/bats/release-workflow-wiring.bats
+++ b/test/bats/release-workflow-wiring.bats
@@ -116,6 +116,16 @@
   [[ "$output" == *"/tmp/control-proxy-debug.apk"* ]]
 }
 
+@test "pull request CtrlProxy build compiles the release variant" {
+  wiring_requires_yq
+  local workflow=".github/workflows/pull_request.yml"
+
+  run yq -r '.jobs."build-android-control-proxy".steps[] | select(.uses == "./.github/actions/gradle-task-run") | .with."gradle-tasks"' "$workflow"
+  [ "$status" -eq 0 ]
+  [[ "$output" == *":control-proxy:assembleDebug"* ]]
+  [[ "$output" == *":control-proxy:assembleRelease"* ]]
+}
+
 @test "prepare-release verifies and tags the single prepared artifact set before dispatching release (#4686)" {
   wiring_requires_yq
   local workflow=".github/workflows/prepare-release.yml"

--- a/test/bats/verify-sdk-ctrl-proxy-permission-contract.bats
+++ b/test/bats/verify-sdk-ctrl-proxy-permission-contract.bats
@@ -87,3 +87,49 @@ fi
   [ "$proxy_first" -lt "$host_after_proxy" ]
   [ "$host_after_proxy" -lt "$second_send" ]
 }
+
+@test "retries the V2 control broadcast until the SDK host receiver is ready" {
+  make_mock keytool '
+for ((index = 1; index <= $#; index++)); do
+  if [[ "${!index}" == "-keystore" ]]; then
+    next=$((index + 1))
+    touch "${!next}"
+  fi
+done
+'
+  make_mock gradlew '
+mkdir -p playground/app/build/outputs/apk/debug
+touch playground/app/build/outputs/apk/debug/app-debug.apk
+'
+  make_mock apksigner '
+apk="${!#}"
+if [[ "$apk" == *control-proxy.apk ]]; then
+  printf "Signer #1 certificate SHA-256 digest: ctrl-proxy\n"
+else
+  printf "Signer #1 certificate SHA-256 digest: sdk-host\n"
+fi
+'
+  make_mock adb '
+printf "adb %s\n" "$*" >> "$COMMAND_LOG"
+if [[ "$*" == *"run-as dev.jasonpearson.automobile.playground cat files/automobile-network-control-contract-result"* ]]; then
+  send_command="adb shell am broadcast -a dev.jasonpearson.automobile.ctrlproxy.action.TEST_SEND_NETWORK_CONTROL -p dev.jasonpearson.automobile.ctrlproxy"
+  if [[ "$(grep -cFx "$send_command" "$COMMAND_LOG")" -ge 2 ]]; then
+    printf "ctrlproxy-v2\n"
+  fi
+fi
+'
+  make_mock sleep ':'
+
+  run env \
+    ADB_BIN="${MOCK_BIN}/adb" \
+    APKSIGNER_BIN="${MOCK_BIN}/apksigner" \
+    GRADLE_CMD="${MOCK_BIN}/gradlew" \
+    KEYTOOL_BIN="${MOCK_BIN}/keytool" \
+    SLEEP_BIN="${MOCK_BIN}/sleep" \
+    COMMAND_LOG="$COMMAND_LOG" \
+    bash "$SCRIPT" "$CTRL_PROXY_APK"
+
+  [ "$status" -eq 0 ]
+  send_command='adb shell am broadcast -a dev.jasonpearson.automobile.ctrlproxy.action.TEST_SEND_NETWORK_CONTROL -p dev.jasonpearson.automobile.ctrlproxy'
+  [ "$(grep -cFx "$send_command" "$COMMAND_LOG")" -ge 3 ]
+}

--- a/test/bats/verify-sdk-ctrl-proxy-permission-contract.bats
+++ b/test/bats/verify-sdk-ctrl-proxy-permission-contract.bats
@@ -7,8 +7,10 @@ setup() {
   ORIGINAL_PATH="$PATH"
   COMMAND_LOG="${MOCK_BIN}/commands"
   CTRL_PROXY_APK="${MOCK_BIN}/control-proxy.apk"
-  HOST_APK="$(pwd)/android/playground/app/build/outputs/apk/debug/playground-app-debug.apk"
+  HOST_APK="$(pwd)/android/playground/app/build/outputs/apk/debug/app-debug.apk"
+  LEGACY_HOST_APK="$(pwd)/android/playground/app/build/outputs/apk/debug/playground-app-debug.apk"
   touch "$CTRL_PROXY_APK"
+  unlink "$LEGACY_HOST_APK" 2>/dev/null || true
 }
 
 teardown() {
@@ -40,7 +42,7 @@ done
   make_mock gradlew '
 printf "gradlew RELEASE_KEYSTORE_PATH=%s %s\n" "${RELEASE_KEYSTORE_PATH:-}" "$*" >> "$COMMAND_LOG"
 mkdir -p playground/app/build/outputs/apk/debug
-touch playground/app/build/outputs/apk/debug/playground-app-debug.apk
+touch playground/app/build/outputs/apk/debug/app-debug.apk
 '
   make_mock apksigner '
 apk="${!#}"

--- a/test/bats/verify-sdk-ctrl-proxy-permission-contract.bats
+++ b/test/bats/verify-sdk-ctrl-proxy-permission-contract.bats
@@ -74,6 +74,8 @@ fi
   send_command='adb shell am broadcast -a dev.jasonpearson.automobile.ctrlproxy.action.TEST_SEND_NETWORK_CONTROL -p dev.jasonpearson.automobile.ctrlproxy'
   [ "$(grep -cFx "$send_command" "$COMMAND_LOG")" -eq 2 ]
 
+  root_line="$(grep -nFx 'adb root' "$COMMAND_LOG" | cut -d: -f1)"
+  wait_for_device_line="$(grep -nFx 'adb wait-for-device' "$COMMAND_LOG" | cut -d: -f1)"
   host_first="$(grep -n "adb install ${HOST_APK}" "$COMMAND_LOG" | head -n 1 | cut -d: -f1)"
   proxy_after_host="$(grep -n "adb install ${CTRL_PROXY_APK}" "$COMMAND_LOG" | head -n 1 | cut -d: -f1)"
   proxy_first="$(grep -n "adb install ${CTRL_PROXY_APK}" "$COMMAND_LOG" | tail -n 1 | cut -d: -f1)"
@@ -81,6 +83,8 @@ fi
   first_send="$(grep -nF "$send_command" "$COMMAND_LOG" | head -n 1 | cut -d: -f1)"
   second_send="$(grep -nF "$send_command" "$COMMAND_LOG" | tail -n 1 | cut -d: -f1)"
 
+  [ "$root_line" -lt "$wait_for_device_line" ]
+  [ "$wait_for_device_line" -lt "$host_first" ]
   [ "$host_first" -lt "$proxy_after_host" ]
   [ "$proxy_after_host" -lt "$first_send" ]
   [ "$first_send" -lt "$proxy_first" ]

--- a/test/bats/verify-sdk-ctrl-proxy-permission-contract.bats
+++ b/test/bats/verify-sdk-ctrl-proxy-permission-contract.bats
@@ -55,15 +55,20 @@ fi
   make_mock adb '
 printf "adb %s\n" "$*" >> "$COMMAND_LOG"
 if [[ "$*" == *"run-as dev.jasonpearson.automobile.playground cat files/automobile-network-control-contract-result"* ]]; then
-  printf "ctrlproxy-v2\n"
+  send_command="adb shell am broadcast --include-stopped-packages -a dev.jasonpearson.automobile.ctrlproxy.action.TEST_SEND_NETWORK_CONTROL -p dev.jasonpearson.automobile.ctrlproxy"
+  if [[ "$(grep -cFx "$send_command" "$COMMAND_LOG")" -ge 1 ]]; then
+    printf "ctrlproxy-v2\n"
+  fi
 fi
 '
+  make_mock sleep ':'
 
   run env \
     ADB_BIN="${MOCK_BIN}/adb" \
     APKSIGNER_BIN="${MOCK_BIN}/apksigner" \
     GRADLE_CMD="${MOCK_BIN}/gradlew" \
     KEYTOOL_BIN="${MOCK_BIN}/keytool" \
+    SLEEP_BIN="${MOCK_BIN}/sleep" \
     COMMAND_LOG="$COMMAND_LOG" \
     bash "$SCRIPT" "$CTRL_PROXY_APK"
 
@@ -71,7 +76,7 @@ fi
   [[ "$output" == *"verified V2 control broadcast delivery"* ]]
   grep -Eq '^gradlew RELEASE_KEYSTORE_PATH=.+ :playground:app:assembleDebug --console=plain$' \
     "$COMMAND_LOG"
-  send_command='adb shell am broadcast -a dev.jasonpearson.automobile.ctrlproxy.action.TEST_SEND_NETWORK_CONTROL -p dev.jasonpearson.automobile.ctrlproxy'
+  send_command='adb shell am broadcast --include-stopped-packages -a dev.jasonpearson.automobile.ctrlproxy.action.TEST_SEND_NETWORK_CONTROL -p dev.jasonpearson.automobile.ctrlproxy'
   [ "$(grep -cFx "$send_command" "$COMMAND_LOG")" -eq 2 ]
 
   root_line="$(grep -nFx 'adb root' "$COMMAND_LOG" | cut -d: -f1)"
@@ -116,7 +121,7 @@ fi
   make_mock adb '
 printf "adb %s\n" "$*" >> "$COMMAND_LOG"
 if [[ "$*" == *"run-as dev.jasonpearson.automobile.playground cat files/automobile-network-control-contract-result"* ]]; then
-  send_command="adb shell am broadcast -a dev.jasonpearson.automobile.ctrlproxy.action.TEST_SEND_NETWORK_CONTROL -p dev.jasonpearson.automobile.ctrlproxy"
+  send_command="adb shell am broadcast --include-stopped-packages -a dev.jasonpearson.automobile.ctrlproxy.action.TEST_SEND_NETWORK_CONTROL -p dev.jasonpearson.automobile.ctrlproxy"
   if [[ "$(grep -cFx "$send_command" "$COMMAND_LOG")" -ge 2 ]]; then
     printf "ctrlproxy-v2\n"
   fi
@@ -134,6 +139,6 @@ fi
     bash "$SCRIPT" "$CTRL_PROXY_APK"
 
   [ "$status" -eq 0 ]
-  send_command='adb shell am broadcast -a dev.jasonpearson.automobile.ctrlproxy.action.TEST_SEND_NETWORK_CONTROL -p dev.jasonpearson.automobile.ctrlproxy'
+  send_command='adb shell am broadcast --include-stopped-packages -a dev.jasonpearson.automobile.ctrlproxy.action.TEST_SEND_NETWORK_CONTROL -p dev.jasonpearson.automobile.ctrlproxy'
   [ "$(grep -cFx "$send_command" "$COMMAND_LOG")" -ge 3 ]
 }

--- a/test/bats/verify-sdk-ctrl-proxy-permission-contract.bats
+++ b/test/bats/verify-sdk-ctrl-proxy-permission-contract.bats
@@ -71,15 +71,19 @@ fi
   [[ "$output" == *"verified V2 control broadcast delivery"* ]]
   grep -Eq '^gradlew RELEASE_KEYSTORE_PATH=.+ :playground:app:assembleDebug --console=plain$' \
     "$COMMAND_LOG"
-  grep -qx \
-    'adb shell am broadcast -a dev.jasonpearson.automobile.ctrlproxy.action.TEST_SEND_NETWORK_CONTROL -p dev.jasonpearson.automobile.ctrlproxy' \
-    "$COMMAND_LOG"
+  send_command='adb shell am broadcast -a dev.jasonpearson.automobile.ctrlproxy.action.TEST_SEND_NETWORK_CONTROL -p dev.jasonpearson.automobile.ctrlproxy'
+  [ "$(grep -cFx "$send_command" "$COMMAND_LOG")" -eq 2 ]
 
   host_first="$(grep -n "adb install ${HOST_APK}" "$COMMAND_LOG" | head -n 1 | cut -d: -f1)"
   proxy_after_host="$(grep -n "adb install ${CTRL_PROXY_APK}" "$COMMAND_LOG" | head -n 1 | cut -d: -f1)"
   proxy_first="$(grep -n "adb install ${CTRL_PROXY_APK}" "$COMMAND_LOG" | tail -n 1 | cut -d: -f1)"
   host_after_proxy="$(grep -n "adb install ${HOST_APK}" "$COMMAND_LOG" | tail -n 1 | cut -d: -f1)"
+  first_send="$(grep -nF "$send_command" "$COMMAND_LOG" | head -n 1 | cut -d: -f1)"
+  second_send="$(grep -nF "$send_command" "$COMMAND_LOG" | tail -n 1 | cut -d: -f1)"
 
   [ "$host_first" -lt "$proxy_after_host" ]
+  [ "$proxy_after_host" -lt "$first_send" ]
+  [ "$first_send" -lt "$proxy_first" ]
   [ "$proxy_first" -lt "$host_after_proxy" ]
+  [ "$host_after_proxy" -lt "$second_send" ]
 }

--- a/test/bats/verify-sdk-ctrl-proxy-permission-contract.bats
+++ b/test/bats/verify-sdk-ctrl-proxy-permission-contract.bats
@@ -1,0 +1,83 @@
+#!/usr/bin/env bats
+
+SCRIPT="scripts/android/verify-sdk-ctrl-proxy-permission-contract.sh"
+
+setup() {
+  MOCK_BIN="$(mktemp -d)"
+  ORIGINAL_PATH="$PATH"
+  COMMAND_LOG="${MOCK_BIN}/commands"
+  CTRL_PROXY_APK="${MOCK_BIN}/control-proxy.apk"
+  HOST_APK="$(pwd)/android/playground/app/build/outputs/apk/debug/playground-app-debug.apk"
+  touch "$CTRL_PROXY_APK"
+}
+
+teardown() {
+  find "$MOCK_BIN" -type f -exec unlink {} \;
+  rmdir "$MOCK_BIN"
+  export PATH="$ORIGINAL_PATH"
+}
+
+make_mock() {
+  local name="$1"
+  local body="$2"
+  cat > "${MOCK_BIN}/${name}" <<SCRIPT
+#!/usr/bin/env bash
+set -euo pipefail
+${body}
+SCRIPT
+  chmod +x "${MOCK_BIN}/${name}"
+}
+
+@test "co-installs a separately signed SDK host in both orders and verifies a V2 control broadcast" {
+  make_mock keytool '
+for ((index = 1; index <= $#; index++)); do
+  if [[ "${!index}" == "-keystore" ]]; then
+    next=$((index + 1))
+    touch "${!next}"
+  fi
+done
+'
+  make_mock gradlew '
+printf "gradlew RELEASE_KEYSTORE_PATH=%s %s\n" "${RELEASE_KEYSTORE_PATH:-}" "$*" >> "$COMMAND_LOG"
+mkdir -p playground/app/build/outputs/apk/debug
+touch playground/app/build/outputs/apk/debug/playground-app-debug.apk
+'
+  make_mock apksigner '
+apk="${!#}"
+if [[ "$apk" == *control-proxy.apk ]]; then
+  printf "Signer #1 certificate SHA-256 digest: ctrl-proxy\n"
+else
+  printf "Signer #1 certificate SHA-256 digest: sdk-host\n"
+fi
+'
+  make_mock adb '
+printf "adb %s\n" "$*" >> "$COMMAND_LOG"
+if [[ "$*" == *"run-as dev.jasonpearson.automobile.playground cat files/automobile-network-control-contract-result"* ]]; then
+  printf "ctrlproxy-v2\n"
+fi
+'
+
+  run env \
+    ADB_BIN="${MOCK_BIN}/adb" \
+    APKSIGNER_BIN="${MOCK_BIN}/apksigner" \
+    GRADLE_CMD="${MOCK_BIN}/gradlew" \
+    KEYTOOL_BIN="${MOCK_BIN}/keytool" \
+    COMMAND_LOG="$COMMAND_LOG" \
+    bash "$SCRIPT" "$CTRL_PROXY_APK"
+
+  [ "$status" -eq 0 ]
+  [[ "$output" == *"verified V2 control broadcast delivery"* ]]
+  grep -Eq '^gradlew RELEASE_KEYSTORE_PATH=.+ :playground:app:assembleDebug --console=plain$' \
+    "$COMMAND_LOG"
+  grep -qx \
+    'adb shell am broadcast -a dev.jasonpearson.automobile.ctrlproxy.action.TEST_SEND_NETWORK_CONTROL -p dev.jasonpearson.automobile.ctrlproxy' \
+    "$COMMAND_LOG"
+
+  host_first="$(grep -n "adb install ${HOST_APK}" "$COMMAND_LOG" | head -n 1 | cut -d: -f1)"
+  proxy_after_host="$(grep -n "adb install ${CTRL_PROXY_APK}" "$COMMAND_LOG" | head -n 1 | cut -d: -f1)"
+  proxy_first="$(grep -n "adb install ${CTRL_PROXY_APK}" "$COMMAND_LOG" | tail -n 1 | cut -d: -f1)"
+  host_after_proxy="$(grep -n "adb install ${HOST_APK}" "$COMMAND_LOG" | tail -n 1 | cut -d: -f1)"
+
+  [ "$host_first" -lt "$proxy_after_host" ]
+  [ "$proxy_first" -lt "$host_after_proxy" ]
+}

--- a/test/features/observe/CtrlProxyClient.test.ts
+++ b/test/features/observe/CtrlProxyClient.test.ts
@@ -1468,6 +1468,66 @@ describe("AndroidCtrlProxyClient", function() {
       }
     });
 
+    test("serializes navigation graph writes when WebSocket frames arrive back-to-back", async function() {
+      NavigationGraphManager.resetInstance();
+      const navHarness = await installInMemoryNavManager();
+      const testTimer = new FakeTimer();
+      testTimer.enableAutoAdvance();
+      const { factory, getSocket } = createCapturingWebSocketFactory(testTimer);
+      const testClient = AndroidCtrlProxyClient.createForTesting(testDevice, fakeAdb, factory, testTimer);
+      let allowFirstWrite: (() => void) | undefined;
+      const firstWriteAllowed = new Promise<void>(resolve => {
+        allowFirstWrite = resolve;
+      });
+      const recordNavigationEvent = navHarness.manager.recordNavigationEvent.bind(navHarness.manager);
+      const recordNavigationEventSpy = spyOn(navHarness.manager, "recordNavigationEvent")
+        .mockImplementation(async event => {
+          if (event.destination === "First") {
+            await firstWriteAllowed;
+          }
+          await recordNavigationEvent(event);
+        });
+
+      try {
+        const resultPromise = testClient.getLatestHierarchy(true, 2000);
+        const socket = await waitForSocket(getSocket);
+        await waitForSocketOpen(socket);
+
+        socket!.simulateMessage(JSON.stringify({
+          type: "navigation_event",
+          event: {
+            destination: "First", source: "Start", arguments: {}, metadata: {},
+            timestamp: testTimer.now(), sequenceNumber: 1, applicationId: "com.example.app",
+          }
+        }));
+        socket!.simulateMessage(JSON.stringify({
+          type: "navigation_event",
+          event: {
+            destination: "Second", source: "First", arguments: {}, metadata: {},
+            timestamp: testTimer.now(), sequenceNumber: 2, applicationId: "com.example.app",
+          }
+        }));
+
+        await flushPromises();
+        expect(recordNavigationEventSpy).toHaveBeenCalledTimes(1);
+
+        allowFirstWrite!();
+        socket!.simulateMessage(JSON.stringify({
+          type: "hierarchy_update",
+          timestamp: testTimer.now(),
+          data: { updatedAt: testTimer.now(), packageName: "com.example.app", hierarchy: { "text": "Second" } }
+        }));
+        await resultPromise;
+        await settleNavigationHierarchyInterleaving(testTimer);
+
+        expect(recordNavigationEventSpy).toHaveBeenCalledTimes(2);
+      } finally {
+        recordNavigationEventSpy.mockRestore();
+        await testClient.close();
+        await navHarness.dispose();
+      }
+    });
+
     test("clears resolved build contexts on connection close so the next event re-resolves (#4984)", async function() {
       // While the WS has no client, a package_event has zero listeners, so an app can be
       // replaced unobserved. onConnectionClosed must invalidate cached contexts so the


### PR DESCRIPTION
## Summary

Move network-control permission ownership from the SDK library manifest to CtrlProxy. CtrlProxy defines and requests the new V2 signature permission; SDK hosts only register receivers protected by that permission.

Queue SDK event batches synchronously at broadcast receipt and process them through one actor. Delivery waits for an active WebSocket client before each event, including after a disconnect and reconnect, so queued SDK events are not lost.

Serialize Android navigation graph writes for back-to-back WebSocket frames. A failed write remains visible to its own handler without blocking later events.

Build the public CtrlProxy APK from the release variant while retaining the stable `control-proxy-debug.apk` asset name. This excludes debug-only receivers from the downloaded artifact.

## Linked Issue

Closes [#5215](https://github.com/kaeawc/auto-mobile/issues/5215)

## Validation

- `bun test test/features/observe/CtrlProxyClient.test.ts`
- `bats test/bats/release-workflow-wiring.bats`
- `GRADLE_USER_HOME=/private/tmp/auto-mobile-gradle-5215 ./gradlew :control-proxy:testDebugUnitTest --tests dev.jasonpearson.automobile.ctrlproxy.SdkEventBatchProcessorTest --tests dev.jasonpearson.automobile.ctrlproxy.WebSocketServerIntegrationTest`
- `GRADLE_USER_HOME=/private/tmp/auto-mobile-gradle-5215 ./gradlew :control-proxy:assembleRelease`
- `bun run lint`
- `bun run typecheck`
- `ktfmt --google-style --dry-run --set-exit-if-changed` for the modified Kotlin files
- `git diff --check`

`bun run turbo:validate` was also run. Its test phase has 13 failures in untouched process, Git metadata, XcodeGen, WebRTC, and FFmpeg tests that reproduce independently in this worktree.

## Release

The post-merge `Prepare Release` workflow must publish compatible Android SDK and CtrlProxy artifacts together.
