### PR TITLE
feat(desktop): expose the app's own version at runtime (#5223)

### DIFF
--- a/android/desktop-app/build.gradle.kts
+++ b/android/desktop-app/build.gradle.kts
@@ -65,6 +65,37 @@ val desktopMacPackageVersion: String =
     "${if (major == 0) 1 else major}.$minor.$patch"
   }
 
+// --- Expose the app version to the running app (issue #5223) -------------------
+// The app needs its own version at runtime to check GitHub Releases for updates.
+// Two classpath-global carriers are written, both from the same `desktopReleaseVersion`:
+//   1) a generated `automobile-version.properties` resource (the deterministic primary source —
+//      jpackage's runtime image always includes it), and
+//   2) the jar manifest's Implementation-Version/Title (a belt-and-suspenders fallback).
+// `PackagedVersionSource` (in :desktop-core) reads the resource first, then scans manifests for
+// the one titled "AutoMobile". Neither affects the installer identity below.
+val generateVersionResource by tasks.registering {
+  val versionValue = desktopReleaseVersion
+  val outputDir = layout.buildDirectory.dir("generated/version/resources")
+  inputs.property("version", versionValue)
+  outputs.dir(outputDir)
+  doLast {
+    val file = outputDir.get().file("automobile-version.properties").asFile
+    file.parentFile.mkdirs()
+    file.writeText("version=$versionValue\ntitle=AutoMobile\n", Charsets.UTF_8)
+  }
+}
+
+sourceSets { named("main") { resources.srcDir(generateVersionResource) } }
+
+tasks.named<Jar>("jar") {
+  manifest {
+    attributes(
+      "Implementation-Title" to "AutoMobile",
+      "Implementation-Version" to desktopReleaseVersion,
+    )
+  }
+}
+
 // --- Strip bundled ffmpeg/ffprobe program executables --------------------------
 // The org.bytedeco:ffmpeg:<ver>:<platform> classifier jar ships the ffmpeg and
 // ffprobe CLI programs alongside the libav*/libjni* JNI libraries. The desktop

--- a/android/desktop-core/src/main/kotlin/dev/jasonpearson/automobile/desktop/core/di/ApplicationModule.kt
+++ b/android/desktop-core/src/main/kotlin/dev/jasonpearson/automobile/desktop/core/di/ApplicationModule.kt
@@ -2,6 +2,9 @@ package dev.jasonpearson.automobile.desktop.core.di
 
 import dev.jasonpearson.automobile.desktop.core.daemon.AutoMobileClient
 import dev.jasonpearson.automobile.desktop.core.daemon.McpClientFactory
+import dev.jasonpearson.automobile.desktop.core.platform.AppVersionProvider
+import dev.jasonpearson.automobile.desktop.core.platform.PackagedVersionSource
+import dev.jasonpearson.automobile.desktop.core.platform.RuntimeAppVersionProvider
 import dev.jasonpearson.automobile.desktop.core.settings.FileSettingsProvider
 import dev.jasonpearson.automobile.desktop.core.settings.SettingsProvider
 import dev.zacsweers.metro.ContributesTo
@@ -25,6 +28,14 @@ interface ApplicationModule {
       // Persistent (file-backed) so the first-run onboarding flag and theme survive restarts.
       // FakeSettingsProvider remains the in-memory implementation used by tests.
       return FileSettingsProvider()
+    }
+
+    @Provides
+    @SingleIn(AppScope::class)
+    fun provideAppVersionProvider(): AppVersionProvider {
+      // Reads the build-generated version resource (falling back to the jar manifest); yields
+      // AppVersion.Dev for unpackaged runs so update checks no-op in development (#5223).
+      return RuntimeAppVersionProvider(PackagedVersionSource())
     }
   }
 }

--- a/android/desktop-core/src/main/kotlin/dev/jasonpearson/automobile/desktop/core/platform/AppVersion.kt
+++ b/android/desktop-core/src/main/kotlin/dev/jasonpearson/automobile/desktop/core/platform/AppVersion.kt
@@ -1,0 +1,29 @@
+package dev.jasonpearson.automobile.desktop.core.platform
+
+/**
+ * The running desktop app's own version, resolved at runtime.
+ *
+ * [raw] preserves the exact version string the app was packaged with, including any `-SNAPSHOT` or
+ * build-metadata suffix. Semantic comparison against GitHub release tags is the update checker's
+ * concern (a later item), not this value's — this type only answers "what version am I, and am I a
+ * packaged build or a development run?".
+ */
+data class AppVersion(val raw: String, val isDevelopment: Boolean) {
+  companion object {
+    /**
+     * Sentinel for runs where no packaged version can be resolved — a Gradle `run`, the IDE, and
+     * Compose hot-reload all lack the generated version resource and the packaged jar manifest.
+     * Update checks treat [isDevelopment] as "never self-update" so development never triggers an
+     * installer download against itself.
+     */
+    val Dev: AppVersion = AppVersion(raw = "dev", isDevelopment = true)
+
+    /**
+     * Maps a raw version string to an [AppVersion]. A null or blank string (the unpackaged case)
+     * yields [Dev]; otherwise the trimmed string is preserved verbatim as a packaged version.
+     */
+    fun of(raw: String?): AppVersion =
+      raw?.trim()?.takeIf { it.isNotEmpty() }?.let { AppVersion(raw = it, isDevelopment = false) }
+        ?: Dev
+  }
+}

--- a/android/desktop-core/src/main/kotlin/dev/jasonpearson/automobile/desktop/core/platform/AppVersionProvider.kt
+++ b/android/desktop-core/src/main/kotlin/dev/jasonpearson/automobile/desktop/core/platform/AppVersionProvider.kt
@@ -1,0 +1,25 @@
+package dev.jasonpearson.automobile.desktop.core.platform
+
+/** Supplies the running app's [AppVersion]. Consumers (e.g. the update checker) depend on this. */
+fun interface AppVersionProvider {
+  fun current(): AppVersion
+}
+
+/**
+ * The raw version-string lookup seam, kept separate from [AppVersionProvider] so unit tests can
+ * feed a fixed string or null without a packaged jar or a classpath resource. The production
+ * implementation is [PackagedVersionSource].
+ */
+fun interface VersionSource {
+  /** Returns the packaged version string, or null when running unpackaged (dev/IDE/hot-reload). */
+  fun resolve(): String?
+}
+
+/**
+ * Turns a [VersionSource] into an [AppVersionProvider] by mapping its raw string through
+ * [AppVersion.of]. All the interesting behavior (blank/absent → [AppVersion.Dev], raw preserved
+ * otherwise) lives in that pure mapping so it is exercised here with a fake source.
+ */
+class RuntimeAppVersionProvider(private val source: VersionSource) : AppVersionProvider {
+  override fun current(): AppVersion = AppVersion.of(source.resolve())
+}

--- a/android/desktop-core/src/main/kotlin/dev/jasonpearson/automobile/desktop/core/platform/PackagedVersionSource.kt
+++ b/android/desktop-core/src/main/kotlin/dev/jasonpearson/automobile/desktop/core/platform/PackagedVersionSource.kt
@@ -45,12 +45,27 @@ class PackagedVersionSource(
 
   private fun fromManifests(): String? =
     try {
-      classLoader.getResources("META-INF/MANIFEST.MF").asSequence().firstNotNullOfOrNull { url ->
-        url.openStream().use { versionFromManifest(Manifest(it)) }
-      }
+      classLoader
+        .getResources("META-INF/MANIFEST.MF")
+        .asSequence()
+        .firstNotNullOfOrNull(::readManifestVersion)
     } catch (error: Exception) {
       // Best-effort: manifest enumeration failures leave us at the Dev sentinel, never a crash.
       LOG.warn("Failed to scan classpath manifests for app version: ${error.message}", error)
+      null
+    }
+
+  /**
+   * Reads one manifest's AutoMobile version. A single malformed manifest anywhere on the classpath
+   * must not abort the scan (a later jar may be ours), so its failure is swallowed here rather than
+   * by the enumeration's catch.
+   */
+  private fun readManifestVersion(url: java.net.URL): String? =
+    try {
+      url.openStream().use { versionFromManifest(Manifest(it)) }
+    } catch (error: Exception) {
+      // A broken third-party manifest is expected noise; keep scanning.
+      LOG.debug("Skipping unreadable manifest at $url: ${error.message}")
       null
     }
 }

--- a/android/desktop-core/src/main/kotlin/dev/jasonpearson/automobile/desktop/core/platform/PackagedVersionSource.kt
+++ b/android/desktop-core/src/main/kotlin/dev/jasonpearson/automobile/desktop/core/platform/PackagedVersionSource.kt
@@ -1,0 +1,70 @@
+package dev.jasonpearson.automobile.desktop.core.platform
+
+import dev.jasonpearson.automobile.desktop.core.logging.LoggerFactory
+import java.util.Properties
+import java.util.jar.Attributes
+import java.util.jar.Manifest
+
+private val LOG = LoggerFactory.getLogger("PackagedVersionSource")
+
+/** Property key written into the generated version resource by the desktop-app build. */
+private const val VERSION_PROPERTY = "version"
+
+/** Manifest attribute the desktop-app build stamps onto its jar, used to disambiguate the scan. */
+private const val MANIFEST_TITLE = "AutoMobile"
+
+/**
+ * Resolves the packaged version string, preferring the build-generated [resourceName] classpath
+ * resource (deterministic across jpackage's runtime image) and falling back to scanning classpath
+ * jar manifests for the one stamped `Implementation-Title: AutoMobile`.
+ *
+ * Both lookups are classpath-global, so this works no matter which module's jar carries the value —
+ * the reader does not couple to a specific main-class package. Returns null when neither yields a
+ * value (unpackaged runs), which [AppVersion.of] maps to [AppVersion.Dev].
+ *
+ * The [classLoader] is injectable so tests can point the manifest scan at a controlled classpath;
+ * production uses this class's own loader.
+ */
+class PackagedVersionSource(
+  private val resourceName: String = "automobile-version.properties",
+  private val classLoader: ClassLoader = PackagedVersionSource::class.java.classLoader,
+) : VersionSource {
+
+  override fun resolve(): String? = fromResource() ?: fromManifests()
+
+  private fun fromResource(): String? {
+    val stream = classLoader.getResourceAsStream(resourceName) ?: return null
+    return try {
+      stream.use { versionFromProperties(it.readBytes().decodeToString()) }
+    } catch (error: Exception) {
+      // Best-effort: a malformed resource must not crash startup — fall through to the manifest.
+      LOG.warn("Failed to read version resource '$resourceName': ${error.message}", error)
+      null
+    }
+  }
+
+  private fun fromManifests(): String? =
+    try {
+      classLoader.getResources("META-INF/MANIFEST.MF").asSequence().firstNotNullOfOrNull { url ->
+        url.openStream().use { versionFromManifest(Manifest(it)) }
+      }
+    } catch (error: Exception) {
+      // Best-effort: manifest enumeration failures leave us at the Dev sentinel, never a crash.
+      LOG.warn("Failed to scan classpath manifests for app version: ${error.message}", error)
+      null
+    }
+}
+
+/** Parses the generated `version=...` properties text. Non-blank [VERSION_PROPERTY] wins. */
+internal fun versionFromProperties(text: String): String? {
+  val parsed = Properties().apply { load(text.reader()) }
+  return parsed.getProperty(VERSION_PROPERTY)?.takeIf { it.isNotBlank() }
+}
+
+/** Reads `Implementation-Version` from a manifest, but only if it is the AutoMobile app jar. */
+internal fun versionFromManifest(manifest: Manifest): String? {
+  val attrs = manifest.mainAttributes
+  val title = attrs.getValue(Attributes.Name.IMPLEMENTATION_TITLE)
+  if (title != MANIFEST_TITLE) return null
+  return attrs.getValue(Attributes.Name.IMPLEMENTATION_VERSION)?.takeIf { it.isNotBlank() }
+}

--- a/android/desktop-core/src/test/kotlin/dev/jasonpearson/automobile/desktop/core/platform/AppVersionProviderTest.kt
+++ b/android/desktop-core/src/test/kotlin/dev/jasonpearson/automobile/desktop/core/platform/AppVersionProviderTest.kt
@@ -1,0 +1,47 @@
+package dev.jasonpearson.automobile.desktop.core.platform
+
+import kotlin.test.Test
+import kotlin.test.assertEquals
+import kotlin.test.assertFalse
+import kotlin.test.assertTrue
+
+/**
+ * Acceptance criteria for #5223: the app exposes its own version at runtime, and cleanly degrades
+ * to a development sentinel when no packaged version is present. The manifest/resource lookup is
+ * behind the [VersionSource] seam, faked here so the mapping is verified without a packaged jar.
+ */
+class AppVersionProviderTest {
+
+  private fun provider(raw: String?) = RuntimeAppVersionProvider(VersionSource { raw })
+
+  @Test
+  fun `packaged version is preserved verbatim and marked non-development`() {
+    val version = provider("0.0.52-SNAPSHOT").current()
+    assertEquals("0.0.52-SNAPSHOT", version.raw)
+    assertFalse(version.isDevelopment, "a resolved packaged version is not a development run")
+  }
+
+  @Test
+  fun `release version without a suffix is preserved`() {
+    assertEquals("0.0.52", provider("0.0.52").current().raw)
+  }
+
+  @Test
+  fun `absent version resolves to the development sentinel`() {
+    val version = provider(null).current()
+    assertEquals(AppVersion.Dev, version)
+    assertTrue(version.isDevelopment)
+  }
+
+  @Test
+  fun `blank version resolves to the development sentinel`() {
+    assertEquals(AppVersion.Dev, provider("   ").current())
+  }
+
+  @Test
+  fun `surrounding whitespace is trimmed from a packaged version`() {
+    val version = provider("  1.2.3  ").current()
+    assertEquals("1.2.3", version.raw)
+    assertFalse(version.isDevelopment)
+  }
+}

--- a/android/desktop-core/src/test/kotlin/dev/jasonpearson/automobile/desktop/core/platform/PackagedVersionSourceTest.kt
+++ b/android/desktop-core/src/test/kotlin/dev/jasonpearson/automobile/desktop/core/platform/PackagedVersionSourceTest.kt
@@ -1,0 +1,59 @@
+package dev.jasonpearson.automobile.desktop.core.platform
+
+import java.util.jar.Attributes
+import java.util.jar.Manifest
+import kotlin.test.Test
+import kotlin.test.assertEquals
+import kotlin.test.assertNull
+
+/**
+ * Verifies the real [PackagedVersionSource] lookup path chosen for #5223: read the build-generated
+ * classpath resource first, fall back to the app jar manifest, and yield null (→ [AppVersion.Dev])
+ * when neither is present. The resource read is exercised against a committed test resource so the
+ * chosen primary mechanism is actually covered, not just the fake seam.
+ */
+class PackagedVersionSourceTest {
+
+  @Test
+  fun `reads the version from the generated classpath resource`() {
+    val source = PackagedVersionSource(resourceName = "test-automobile-version.properties")
+    assertEquals("9.9.9-test", source.resolve())
+  }
+
+  @Test
+  fun `returns null when neither resource nor an AutoMobile manifest is present`() {
+    // A resource name that does not exist forces the manifest fallback; the test classpath has no
+    // jar stamped Implementation-Title: AutoMobile, so the whole chain yields null.
+    val source = PackagedVersionSource(resourceName = "no-such-version-resource.properties")
+    assertNull(source.resolve())
+  }
+
+  @Test
+  fun `versionFromProperties reads a non-blank version and rejects blank or missing`() {
+    assertEquals("1.2.3", versionFromProperties("version=1.2.3\ntitle=AutoMobile\n"))
+    assertNull(versionFromProperties("version=\n"))
+    assertNull(versionFromProperties("title=AutoMobile\n"))
+  }
+
+  @Test
+  fun `versionFromManifest reads Implementation-Version only for the AutoMobile title`() {
+    val autoMobile =
+      Manifest().apply {
+        mainAttributes.putValue("Manifest-Version", "1.0")
+        mainAttributes[Attributes.Name.IMPLEMENTATION_TITLE] = "AutoMobile"
+        mainAttributes[Attributes.Name.IMPLEMENTATION_VERSION] = "0.0.52"
+      }
+    assertEquals("0.0.52", versionFromManifest(autoMobile))
+
+    val otherJar =
+      Manifest().apply {
+        mainAttributes.putValue("Manifest-Version", "1.0")
+        mainAttributes[Attributes.Name.IMPLEMENTATION_TITLE] = "kotlinx-coroutines-core"
+        mainAttributes[Attributes.Name.IMPLEMENTATION_VERSION] = "1.9.0"
+      }
+    assertNull(
+      versionFromManifest(otherJar),
+      "a third-party jar's version must not be mistaken for ours",
+    )
+  }
+}

--- a/android/desktop-core/src/test/resources/test-automobile-version.properties
+++ b/android/desktop-core/src/test/resources/test-automobile-version.properties
@@ -1,0 +1,2 @@
+version=9.9.9-test
+title=AutoMobile


### PR DESCRIPTION
## Summary

The Compose Desktop app had no runtime knowledge of its own version — `VERSION_NAME` /
`desktopReleaseVersion` were consumed only at package time to name the jpackage installer. This PR
exposes the app's version to running Kotlin, the prerequisite for the desktop auto-update feature
(the updater must compare the running version against the latest GitHub release).

The version is written into two **classpath-global** carriers from the single `desktopReleaseVersion`
source: a build-generated `automobile-version.properties` resource (the deterministic primary —
jpackage's runtime image always includes it) and the jar manifest `Implementation-Version`/`-Title`
(a belt-and-suspenders fallback). `PackagedVersionSource` in `:desktop-core` reads the resource
first, then scans classpath manifests for the one titled `AutoMobile`; when neither is present
(Gradle `run` / IDE / hot-reload) it resolves to the `AppVersion.Dev` sentinel so update checks
no-op in development. The reader is classpath-global, so it does not couple `:desktop-core` to a
`:desktop-app` main-class package. **Installer identity (`packageVersion`) is unchanged.**

## Linked Issue

Closes #5223

First of the desktop auto-update sequence: #5223 → #5224 → #5225 → #5226 (decision: #5227).

## Validation

- [x] `scripts/all_fast_validate_checks.sh --only ktfmt` passes (Kotlin-only change)
- [x] Android changes: `:desktop-core:detektMain :desktop-core:detektTest :desktop-app:detektMain :desktop-app:detektTest` green; `:desktop-core:test :desktop-app:test` green
- [x] New code uses an interface + fake seam (`VersionSource`); unit tests run in <100ms
- [x] Verified packaging end-to-end: `-PdesktopPackageVersion=0.0.99` produces `version=0.0.99` in the resource and `Implementation-Version: 0.0.99` in the jar manifest
- [x] Rebased onto latest `main`
- [ ] `bun run typecheck` — N/A (no TypeScript touched)

## Kotlin Reuse Check

- [x] Reused `java.util.Properties` / `java.util.jar.Manifest` (JDK) and the existing `LoggerFactory`; no new dependency, no `*Util` file
- [x] Provider follows the existing `platform/` seam idiom (`FileSaver`, `SourceFileOpener`) and the `ApplicationModule` `@Provides` pattern

## Follow-ups

- Runtime resolution in the *packaged* app (resource on jpackage's classpath) is asserted here via
  the jar build; a one-time manual check on a real installer can confirm end-to-end. The next item
  (#5224, `UpdateController`) consumes this provider and will exercise it in a real run.
