### PR TITLE
feat(desktop): UpdateController — detect a newer GitHub release (#5224)

### DIFF
--- a/android/desktop-core/src/main/kotlin/dev/jasonpearson/automobile/desktop/core/di/ApplicationModule.kt
+++ b/android/desktop-core/src/main/kotlin/dev/jasonpearson/automobile/desktop/core/di/ApplicationModule.kt
@@ -7,6 +7,9 @@ import dev.jasonpearson.automobile.desktop.core.platform.PackagedVersionSource
 import dev.jasonpearson.automobile.desktop.core.platform.RuntimeAppVersionProvider
 import dev.jasonpearson.automobile.desktop.core.settings.FileSettingsProvider
 import dev.jasonpearson.automobile.desktop.core.settings.SettingsProvider
+import dev.jasonpearson.automobile.desktop.core.update.GitHubReleaseSource
+import dev.jasonpearson.automobile.desktop.core.update.RealUpdateController
+import dev.jasonpearson.automobile.desktop.core.update.UpdateController
 import dev.zacsweers.metro.ContributesTo
 import dev.zacsweers.metro.Provides
 
@@ -36,6 +39,14 @@ interface ApplicationModule {
       // Reads the build-generated version resource (falling back to the jar manifest); yields
       // AppVersion.Dev for unpackaged runs so update checks no-op in development (#5223).
       return RuntimeAppVersionProvider(PackagedVersionSource())
+    }
+
+    @Provides
+    @SingleIn(AppScope::class)
+    fun provideUpdateController(appVersionProvider: AppVersionProvider): UpdateController {
+      // Checks GitHub Releases against the running version (#5224). Purely reactive — nothing
+      // fetches until a caller invokes checkForUpdate().
+      return RealUpdateController(GitHubReleaseSource(), appVersionProvider)
     }
   }
 }

--- a/android/desktop-core/src/main/kotlin/dev/jasonpearson/automobile/desktop/core/platform/AppVersion.kt
+++ b/android/desktop-core/src/main/kotlin/dev/jasonpearson/automobile/desktop/core/platform/AppVersion.kt
@@ -11,19 +11,30 @@ package dev.jasonpearson.automobile.desktop.core.platform
 data class AppVersion(val raw: String, val isDevelopment: Boolean) {
   companion object {
     /**
-     * Sentinel for runs where no packaged version can be resolved — a Gradle `run`, the IDE, and
-     * Compose hot-reload all lack the generated version resource and the packaged jar manifest.
-     * Update checks treat [isDevelopment] as "never self-update" so development never triggers an
-     * installer download against itself.
+     * Sentinel for runs where no version string can be resolved at all. Update checks treat
+     * [isDevelopment] as "never self-update" so development never triggers an installer download
+     * against itself.
      */
     val Dev: AppVersion = AppVersion(raw = "dev", isDevelopment = true)
 
     /**
-     * Maps a raw version string to an [AppVersion]. A null or blank string (the unpackaged case)
-     * yields [Dev]; otherwise the trimmed string is preserved verbatim as a packaged version.
+     * Marks source/local builds. Release installers are packaged with a plain, unsuffixed semver.
      */
-    fun of(raw: String?): AppVersion =
-      raw?.trim()?.takeIf { it.isNotEmpty() }?.let { AppVersion(raw = it, isDevelopment = false) }
-        ?: Dev
+    private const val SNAPSHOT_SUFFIX = "-SNAPSHOT"
+
+    /**
+     * Maps a raw version string to an [AppVersion]. A null or blank string yields [Dev]. A
+     * `-SNAPSHOT` version is a source/local build (the generated version resource is present in
+     * ordinary Gradle/IDE runs, so absence of the resource is *not* a reliable dev signal — the
+     * SNAPSHOT qualifier is), so it is marked `isDevelopment = true` while preserving [raw]. Only a
+     * plain, unsuffixed version — what the release workflow packages — is treated as a real
+     * installed build eligible for updates.
+     */
+    fun of(raw: String?): AppVersion {
+      val trimmed = raw?.trim()
+      if (trimmed.isNullOrEmpty()) return Dev
+      val isSnapshot = trimmed.endsWith(SNAPSHOT_SUFFIX, ignoreCase = true)
+      return AppVersion(raw = trimmed, isDevelopment = isSnapshot)
+    }
   }
 }

--- a/android/desktop-core/src/main/kotlin/dev/jasonpearson/automobile/desktop/core/update/GitHubReleaseSource.kt
+++ b/android/desktop-core/src/main/kotlin/dev/jasonpearson/automobile/desktop/core/update/GitHubReleaseSource.kt
@@ -95,8 +95,10 @@ internal fun parseLatestRelease(body: String): ReleaseInfo {
       ?: throw ReleaseFetchException("Release JSON is missing tag_name")
   val assets =
     release.assets.mapNotNull { asset ->
-      val name = asset.name ?: return@mapNotNull null
-      val url = asset.browser_download_url ?: return@mapNotNull null
+      // Drop assets missing OR blank a name/URL — a blank download URL would otherwise become an
+      // UpdateAvailable with nothing to download.
+      val name = asset.name?.takeIf { it.isNotBlank() } ?: return@mapNotNull null
+      val url = asset.browser_download_url?.takeIf { it.isNotBlank() } ?: return@mapNotNull null
       ReleaseAsset(name = name, downloadUrl = url, sizeBytes = asset.size)
     }
   return ReleaseInfo(

--- a/android/desktop-core/src/main/kotlin/dev/jasonpearson/automobile/desktop/core/update/GitHubReleaseSource.kt
+++ b/android/desktop-core/src/main/kotlin/dev/jasonpearson/automobile/desktop/core/update/GitHubReleaseSource.kt
@@ -1,0 +1,99 @@
+package dev.jasonpearson.automobile.desktop.core.update
+
+import java.io.IOException
+import java.net.URI
+import java.net.http.HttpClient
+import java.net.http.HttpRequest
+import java.net.http.HttpResponse
+import kotlinx.coroutines.Dispatchers
+import kotlinx.coroutines.withContext
+import kotlinx.serialization.Serializable
+import kotlinx.serialization.SerializationException
+import kotlinx.serialization.json.Json
+
+/**
+ * [ReleaseSource] backed by the GitHub REST API `releases/latest` endpoint (unauthenticated — the
+ * repo is public). Uses the JDK [HttpClient] already used elsewhere in this module; the blocking
+ * `send` is confined to [Dispatchers.IO]. Non-2xx responses (notably 403 rate-limit) and malformed
+ * bodies are converted to [ReleaseFetchException].
+ */
+class GitHubReleaseSource(
+  private val repo: String = "kaeawc/auto-mobile",
+  private val httpClient: HttpClient = HttpClient.newBuilder().build(),
+) : ReleaseSource {
+
+  override suspend fun fetchLatestRelease(): ReleaseInfo =
+    withContext(Dispatchers.IO) {
+      val uri = URI.create("https://api.github.com/repos/$repo/releases/latest")
+      val request =
+        HttpRequest.newBuilder(uri)
+          .header("Accept", "application/vnd.github+json")
+          .header("X-GitHub-Api-Version", "2022-11-28")
+          .GET()
+          .build()
+
+      val response =
+        try {
+          httpClient.send(request, HttpResponse.BodyHandlers.ofString())
+        } catch (error: IOException) {
+          throw ReleaseFetchException("Failed to reach GitHub: ${error.message}", error)
+        } catch (error: InterruptedException) {
+          Thread.currentThread().interrupt()
+          throw ReleaseFetchException("Update check was interrupted", error)
+        }
+
+      when (val code = response.statusCode()) {
+        in 200..299 -> parseLatestRelease(response.body())
+        403 -> throw ReleaseFetchException("GitHub API rate limit or access forbidden (403)")
+        else -> throw ReleaseFetchException("GitHub API returned HTTP $code")
+      }
+    }
+}
+
+private val releaseJson = Json { ignoreUnknownKeys = true }
+
+@Serializable
+private data class GitHubRelease(
+  val tag_name: String? = null,
+  val draft: Boolean = false,
+  val prerelease: Boolean = false,
+  val html_url: String? = null,
+  val assets: List<GitHubAsset> = emptyList(),
+)
+
+@Serializable
+private data class GitHubAsset(
+  val name: String? = null,
+  val browser_download_url: String? = null,
+  val size: Long = 0,
+)
+
+/**
+ * Parses a GitHub `releases/latest` JSON body into a [ReleaseInfo]. Assets missing a name or
+ * download URL are dropped rather than surfaced as half-populated. A body without `tag_name` is a
+ * failure. Extracted (and internal) so the parse is unit-tested without a network round-trip.
+ */
+internal fun parseLatestRelease(body: String): ReleaseInfo {
+  val release =
+    try {
+      releaseJson.decodeFromString<GitHubRelease>(body)
+    } catch (error: SerializationException) {
+      throw ReleaseFetchException("Malformed release JSON: ${error.message}", error)
+    }
+  val tag =
+    release.tag_name?.takeIf { it.isNotBlank() }
+      ?: throw ReleaseFetchException("Release JSON is missing tag_name")
+  val assets =
+    release.assets.mapNotNull { asset ->
+      val name = asset.name ?: return@mapNotNull null
+      val url = asset.browser_download_url ?: return@mapNotNull null
+      ReleaseAsset(name = name, downloadUrl = url, sizeBytes = asset.size)
+    }
+  return ReleaseInfo(
+    tagName = tag,
+    isDraft = release.draft,
+    isPrerelease = release.prerelease,
+    htmlUrl = release.html_url,
+    assets = assets,
+  )
+}

--- a/android/desktop-core/src/main/kotlin/dev/jasonpearson/automobile/desktop/core/update/GitHubReleaseSource.kt
+++ b/android/desktop-core/src/main/kotlin/dev/jasonpearson/automobile/desktop/core/update/GitHubReleaseSource.kt
@@ -7,7 +7,7 @@ import java.net.http.HttpRequest
 import java.net.http.HttpResponse
 import java.time.Duration
 import kotlinx.coroutines.Dispatchers
-import kotlinx.coroutines.withContext
+import kotlinx.coroutines.runInterruptible
 import kotlinx.serialization.Serializable
 import kotlinx.serialization.SerializationException
 import kotlinx.serialization.json.Json
@@ -17,9 +17,11 @@ private val REQUEST_TIMEOUT: Duration = Duration.ofSeconds(20)
 
 /**
  * [ReleaseSource] backed by the GitHub REST API `releases/latest` endpoint (unauthenticated — the
- * repo is public). Uses the JDK [HttpClient] already used elsewhere in this module; the blocking
- * `send` is confined to [Dispatchers.IO]. Non-2xx responses (notably 403 rate-limit) and malformed
- * bodies are converted to [ReleaseFetchException].
+ * repo is public). Uses the JDK [HttpClient] already used elsewhere in this module. The blocking
+ * `send` runs inside [runInterruptible] on [Dispatchers.IO], so coroutine cancellation interrupts
+ * the request promptly (rather than waiting out the request timeout while holding the check's
+ * lock). Non-2xx responses (notably 403 rate-limit) and malformed bodies become
+ * [ReleaseFetchException].
  */
 class GitHubReleaseSource(
   private val repo: String = "kaeawc/auto-mobile",
@@ -27,35 +29,35 @@ class GitHubReleaseSource(
     HttpClient.newBuilder().connectTimeout(CONNECT_TIMEOUT).build(),
 ) : ReleaseSource {
 
-  override suspend fun fetchLatestRelease(): ReleaseInfo =
-    withContext(Dispatchers.IO) {
-      val uri = URI.create("https://api.github.com/repos/$repo/releases/latest")
-      val request =
-        HttpRequest.newBuilder(uri)
-          .header("Accept", "application/vnd.github+json")
-          .header("X-GitHub-Api-Version", "2022-11-28")
-          // Bound the request so a stalled/blackholed connection surfaces as a timeout (an
-          // IOException → ReleaseFetchException → Failed) instead of pinning status at Checking.
-          .timeout(REQUEST_TIMEOUT)
-          .GET()
-          .build()
+  override suspend fun fetchLatestRelease(): ReleaseInfo {
+    val uri = URI.create("https://api.github.com/repos/$repo/releases/latest")
+    val request =
+      HttpRequest.newBuilder(uri)
+        .header("Accept", "application/vnd.github+json")
+        .header("X-GitHub-Api-Version", "2022-11-28")
+        // Bound the request so a stalled/blackholed connection surfaces as a timeout (an
+        // IOException → ReleaseFetchException → Failed) instead of pinning status at Checking.
+        .timeout(REQUEST_TIMEOUT)
+        .GET()
+        .build()
 
-      val response =
-        try {
+    val response =
+      try {
+        // runInterruptible converts coroutine cancellation into a thread interrupt, so a cancelled
+        // check aborts the blocking send at once instead of holding the mutex until the timeout.
+        runInterruptible(Dispatchers.IO) {
           httpClient.send(request, HttpResponse.BodyHandlers.ofString())
-        } catch (error: IOException) {
-          throw ReleaseFetchException("Failed to reach GitHub: ${error.message}", error)
-        } catch (error: InterruptedException) {
-          Thread.currentThread().interrupt()
-          throw ReleaseFetchException("Update check was interrupted", error)
         }
-
-      when (val code = response.statusCode()) {
-        in 200..299 -> parseLatestRelease(response.body())
-        403 -> throw ReleaseFetchException("GitHub API rate limit or access forbidden (403)")
-        else -> throw ReleaseFetchException("GitHub API returned HTTP $code")
+      } catch (error: IOException) {
+        throw ReleaseFetchException("Failed to reach GitHub: ${error.message}", error)
       }
+
+    return when (val code = response.statusCode()) {
+      in 200..299 -> parseLatestRelease(response.body())
+      403 -> throw ReleaseFetchException("GitHub API rate limit or access forbidden (403)")
+      else -> throw ReleaseFetchException("GitHub API returned HTTP $code")
     }
+  }
 }
 
 private val releaseJson = Json { ignoreUnknownKeys = true }

--- a/android/desktop-core/src/main/kotlin/dev/jasonpearson/automobile/desktop/core/update/GitHubReleaseSource.kt
+++ b/android/desktop-core/src/main/kotlin/dev/jasonpearson/automobile/desktop/core/update/GitHubReleaseSource.kt
@@ -5,11 +5,15 @@ import java.net.URI
 import java.net.http.HttpClient
 import java.net.http.HttpRequest
 import java.net.http.HttpResponse
+import java.time.Duration
 import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.withContext
 import kotlinx.serialization.Serializable
 import kotlinx.serialization.SerializationException
 import kotlinx.serialization.json.Json
+
+private val CONNECT_TIMEOUT: Duration = Duration.ofSeconds(10)
+private val REQUEST_TIMEOUT: Duration = Duration.ofSeconds(20)
 
 /**
  * [ReleaseSource] backed by the GitHub REST API `releases/latest` endpoint (unauthenticated — the
@@ -19,7 +23,8 @@ import kotlinx.serialization.json.Json
  */
 class GitHubReleaseSource(
   private val repo: String = "kaeawc/auto-mobile",
-  private val httpClient: HttpClient = HttpClient.newBuilder().build(),
+  private val httpClient: HttpClient =
+    HttpClient.newBuilder().connectTimeout(CONNECT_TIMEOUT).build(),
 ) : ReleaseSource {
 
   override suspend fun fetchLatestRelease(): ReleaseInfo =
@@ -29,6 +34,9 @@ class GitHubReleaseSource(
         HttpRequest.newBuilder(uri)
           .header("Accept", "application/vnd.github+json")
           .header("X-GitHub-Api-Version", "2022-11-28")
+          // Bound the request so a stalled/blackholed connection surfaces as a timeout (an
+          // IOException → ReleaseFetchException → Failed) instead of pinning status at Checking.
+          .timeout(REQUEST_TIMEOUT)
           .GET()
           .build()
 

--- a/android/desktop-core/src/main/kotlin/dev/jasonpearson/automobile/desktop/core/update/HostPlatform.kt
+++ b/android/desktop-core/src/main/kotlin/dev/jasonpearson/automobile/desktop/core/update/HostPlatform.kt
@@ -1,0 +1,26 @@
+package dev.jasonpearson.automobile.desktop.core.update
+
+/**
+ * The host OS, paired with the release-asset filename suffix its installer uses. The release
+ * workflow attaches `AutoMobile-<version>-macos.dmg`, `-windows.msi`, and `-linux.deb`, so an asset
+ * is resolved by matching [assetSuffix] rather than reconstructing the whole version-dependent
+ * name.
+ */
+enum class HostPlatform(val assetSuffix: String) {
+  MAC("-macos.dmg"),
+  WINDOWS("-windows.msi"),
+  LINUX("-linux.deb");
+
+  companion object {
+    /** Detects the current platform, or null for an OS we do not ship an installer for. */
+    fun current(osName: String = System.getProperty("os.name") ?: ""): HostPlatform? {
+      val normalized = osName.lowercase()
+      return when {
+        normalized.contains("mac") || normalized.contains("darwin") -> MAC
+        normalized.contains("win") -> WINDOWS
+        normalized.contains("nux") || normalized.contains("nix") -> LINUX
+        else -> null
+      }
+    }
+  }
+}

--- a/android/desktop-core/src/main/kotlin/dev/jasonpearson/automobile/desktop/core/update/RealUpdateController.kt
+++ b/android/desktop-core/src/main/kotlin/dev/jasonpearson/automobile/desktop/core/update/RealUpdateController.kt
@@ -1,0 +1,79 @@
+package dev.jasonpearson.automobile.desktop.core.update
+
+import dev.jasonpearson.automobile.desktop.core.logging.LoggerFactory
+import dev.jasonpearson.automobile.desktop.core.platform.AppVersionProvider
+import kotlinx.coroutines.CancellationException
+import kotlinx.coroutines.flow.MutableStateFlow
+import kotlinx.coroutines.flow.StateFlow
+import kotlinx.coroutines.flow.asStateFlow
+
+private val LOG = LoggerFactory.getLogger("UpdateController")
+
+/**
+ * Checks GitHub Releases for a build newer than the running one. Purely reactive: it performs no
+ * network work until [checkForUpdate] is called, and never on construction. A development build
+ * (the [AppVersion.Dev] sentinel from the version provider) and an OS with no installer both
+ * resolve to [UpdateStatus.UpToDate] without a fetch, so nothing self-updates in development.
+ */
+class RealUpdateController(
+  private val releaseSource: ReleaseSource,
+  private val appVersionProvider: AppVersionProvider,
+  private val platform: HostPlatform? = HostPlatform.current(),
+) : UpdateController {
+
+  private val mutableStatus = MutableStateFlow<UpdateStatus>(UpdateStatus.Idle)
+  override val status: StateFlow<UpdateStatus> = mutableStatus.asStateFlow()
+
+  override suspend fun checkForUpdate() {
+    val appVersion = appVersionProvider.current()
+    // A development build (no packaged version) and an OS we don't ship an installer for both mean
+    // "there is nothing we could apply" — resolve without any network work so dev never
+    // self-updates.
+    if (appVersion.isDevelopment) {
+      mutableStatus.value = UpdateStatus.UpToDate
+      return
+    }
+    val hostPlatform = platform
+    if (hostPlatform == null) {
+      mutableStatus.value = UpdateStatus.UpToDate
+      return
+    }
+
+    mutableStatus.value = UpdateStatus.Checking
+    val release =
+      try {
+        releaseSource.fetchLatestRelease()
+      } catch (cancellation: CancellationException) {
+        throw cancellation
+      } catch (error: Exception) {
+        // Typed failure surfaced to the UI; the check is best-effort and must never crash the app.
+        LOG.warn("Update check failed: ${error.message}", error)
+        mutableStatus.value = UpdateStatus.Failed(error.message ?: "Update check failed")
+        return
+      }
+
+    if (release.isDraft || release.isPrerelease) {
+      mutableStatus.value = UpdateStatus.UpToDate
+      return
+    }
+    if (!isNewerVersion(release.tagName, appVersion.raw)) {
+      mutableStatus.value = UpdateStatus.UpToDate
+      return
+    }
+    val asset = resolveAsset(release.assets, hostPlatform)
+    if (asset == null) {
+      // A newer release exists but ships no installer for this OS — stay quiet, but leave a trace.
+      LOG.warn(
+        "Release ${release.tagName} is newer but has no ${hostPlatform.assetSuffix} asset; staying UpToDate"
+      )
+      mutableStatus.value = UpdateStatus.UpToDate
+      return
+    }
+    mutableStatus.value =
+      UpdateStatus.UpdateAvailable(
+        version = release.tagName.trim().removePrefix("v").removePrefix("V"),
+        asset = asset,
+        releaseNotesUrl = release.htmlUrl,
+      )
+  }
+}

--- a/android/desktop-core/src/main/kotlin/dev/jasonpearson/automobile/desktop/core/update/RealUpdateController.kt
+++ b/android/desktop-core/src/main/kotlin/dev/jasonpearson/automobile/desktop/core/update/RealUpdateController.kt
@@ -6,6 +6,8 @@ import kotlinx.coroutines.CancellationException
 import kotlinx.coroutines.flow.MutableStateFlow
 import kotlinx.coroutines.flow.StateFlow
 import kotlinx.coroutines.flow.asStateFlow
+import kotlinx.coroutines.sync.Mutex
+import kotlinx.coroutines.sync.withLock
 
 private val LOG = LoggerFactory.getLogger("UpdateController")
 
@@ -24,7 +26,16 @@ class RealUpdateController(
   private val mutableStatus = MutableStateFlow<UpdateStatus>(UpdateStatus.Idle)
   override val status: StateFlow<UpdateStatus> = mutableStatus.asStateFlow()
 
-  override suspend fun checkForUpdate() {
+  // Serializes checks so overlapping callers (a startup check racing a manual one) never interleave
+  // their status writes — the previous-state capture below is only correct with one check in
+  // flight.
+  private val checkMutex = Mutex()
+
+  override suspend fun checkForUpdate(): Unit = checkMutex.withLock {
+    runCheck()
+  }
+
+  private suspend fun runCheck() {
     val appVersion = appVersionProvider.current()
     // A development build (no packaged version) and an OS we don't ship an installer for both mean
     // "there is nothing we could apply" — resolve without any network work so dev never

--- a/android/desktop-core/src/main/kotlin/dev/jasonpearson/automobile/desktop/core/update/RealUpdateController.kt
+++ b/android/desktop-core/src/main/kotlin/dev/jasonpearson/automobile/desktop/core/update/RealUpdateController.kt
@@ -39,11 +39,15 @@ class RealUpdateController(
       return
     }
 
+    // Captured so a cancelled check restores the last stable state rather than pinning the shared
+    // singleton StateFlow at Checking for every collector.
+    val previousStatus = mutableStatus.value
     mutableStatus.value = UpdateStatus.Checking
     val release =
       try {
         releaseSource.fetchLatestRelease()
       } catch (cancellation: CancellationException) {
+        mutableStatus.value = previousStatus
         throw cancellation
       } catch (error: Exception) {
         // Typed failure surfaced to the UI; the check is best-effort and must never crash the app.

--- a/android/desktop-core/src/main/kotlin/dev/jasonpearson/automobile/desktop/core/update/ReleaseSource.kt
+++ b/android/desktop-core/src/main/kotlin/dev/jasonpearson/automobile/desktop/core/update/ReleaseSource.kt
@@ -1,0 +1,22 @@
+package dev.jasonpearson.automobile.desktop.core.update
+
+/** A published release's fields relevant to the update check. */
+data class ReleaseInfo(
+  val tagName: String,
+  val isDraft: Boolean,
+  val isPrerelease: Boolean,
+  val htmlUrl: String?,
+  val assets: List<ReleaseAsset>,
+)
+
+/**
+ * Fetches the latest release. The network implementation is [GitHubReleaseSource]; tests supply a
+ * fake. Any failure (network, non-2xx, malformed body) is signalled by throwing
+ * [ReleaseFetchException] so the controller can map it to [UpdateStatus.Failed].
+ */
+fun interface ReleaseSource {
+  suspend fun fetchLatestRelease(): ReleaseInfo
+}
+
+/** Raised by a [ReleaseSource] when the latest release cannot be retrieved or parsed. */
+class ReleaseFetchException(message: String, cause: Throwable? = null) : Exception(message, cause)

--- a/android/desktop-core/src/main/kotlin/dev/jasonpearson/automobile/desktop/core/update/UpdateController.kt
+++ b/android/desktop-core/src/main/kotlin/dev/jasonpearson/automobile/desktop/core/update/UpdateController.kt
@@ -12,8 +12,9 @@ interface UpdateController {
   val status: StateFlow<UpdateStatus>
 
   /**
-   * Runs one update check, transitioning [status]. Never throws — failures land in
-   * [UpdateStatus.Failed].
+   * Runs one update check, transitioning [status]. A release-fetch failure transitions [status] to
+   * [UpdateStatus.Failed] rather than throwing; coroutine cancellation propagates to the caller,
+   * leaving [status] at its prior stable value.
    */
   suspend fun checkForUpdate()
 }

--- a/android/desktop-core/src/main/kotlin/dev/jasonpearson/automobile/desktop/core/update/UpdateController.kt
+++ b/android/desktop-core/src/main/kotlin/dev/jasonpearson/automobile/desktop/core/update/UpdateController.kt
@@ -1,0 +1,19 @@
+package dev.jasonpearson.automobile.desktop.core.update
+
+import kotlinx.coroutines.flow.StateFlow
+
+/**
+ * Observes whether a newer desktop release is available. The UI collects [status]; nothing checks
+ * automatically — a caller (the app shell, a manual "check now" action) invokes [checkForUpdate].
+ * This item performs the *check* only; downloading and installing an update is a later item.
+ */
+interface UpdateController {
+  /** Current update state. Starts at [UpdateStatus.Idle] until the first [checkForUpdate]. */
+  val status: StateFlow<UpdateStatus>
+
+  /**
+   * Runs one update check, transitioning [status]. Never throws — failures land in
+   * [UpdateStatus.Failed].
+   */
+  suspend fun checkForUpdate()
+}

--- a/android/desktop-core/src/main/kotlin/dev/jasonpearson/automobile/desktop/core/update/UpdateStatus.kt
+++ b/android/desktop-core/src/main/kotlin/dev/jasonpearson/automobile/desktop/core/update/UpdateStatus.kt
@@ -1,0 +1,35 @@
+package dev.jasonpearson.automobile.desktop.core.update
+
+/**
+ * A downloadable installer attached to a GitHub release, resolved for the running OS. [downloadUrl]
+ * is the `browser_download_url`; applying it (download + launch) is a later item — this item only
+ * identifies which asset would be used.
+ */
+data class ReleaseAsset(val name: String, val downloadUrl: String, val sizeBytes: Long)
+
+/**
+ * The desktop app's update state, surfaced as a `StateFlow` so the UI can render an "update ready"
+ * affordance without performing any network work itself.
+ */
+sealed interface UpdateStatus {
+  /** No check has run yet. */
+  data object Idle : UpdateStatus
+
+  /** A check is in flight. */
+  data object Checking : UpdateStatus
+
+  /**
+   * The running build is current (or nothing installable applies to this OS / this is a dev run).
+   */
+  data object UpToDate : UpdateStatus
+
+  /** A newer release exists with an installer for this OS. */
+  data class UpdateAvailable(
+    val version: String,
+    val asset: ReleaseAsset,
+    val releaseNotesUrl: String?,
+  ) : UpdateStatus
+
+  /** The check could not complete (network, rate limit, malformed response). */
+  data class Failed(val reason: String) : UpdateStatus
+}

--- a/android/desktop-core/src/main/kotlin/dev/jasonpearson/automobile/desktop/core/update/UpdateVersioning.kt
+++ b/android/desktop-core/src/main/kotlin/dev/jasonpearson/automobile/desktop/core/update/UpdateVersioning.kt
@@ -1,10 +1,13 @@
 package dev.jasonpearson.automobile.desktop.core.update
 
+import java.math.BigInteger
+
 /**
  * True when [candidate] is a strictly newer release than [current]. Both may carry a leading `v`
  * and a `-prerelease` / `+build` suffix. Numeric core segments compare left to right; when cores
- * are equal a final release outranks a prerelease, and two prereleases compare lexically. Anything
- * unparseable in a segment is treated as 0 so a malformed tag never reads as "newer".
+ * are equal a final release outranks a prerelease. A version that is not valid SemVer never reads
+ * as newer. Numeric identifiers compare as arbitrary-precision integers, so a value that would
+ * overflow a machine `Int` still orders correctly.
  */
 internal fun isNewerVersion(candidate: String, current: String): Boolean {
   // A version we cannot fully parse (e.g. "v1.bad.0", "nightly") must never read as newer, or a
@@ -13,9 +16,10 @@ internal fun isNewerVersion(candidate: String, current: String): Boolean {
   val b = parseVersion(current) ?: return false
   val segments = maxOf(a.numbers.size, b.numbers.size)
   for (i in 0 until segments) {
-    val left = a.numbers.getOrElse(i) { 0 }
-    val right = b.numbers.getOrElse(i) { 0 }
-    if (left != right) return left > right
+    val left = a.numbers.getOrElse(i) { BigInteger.ZERO }
+    val right = b.numbers.getOrElse(i) { BigInteger.ZERO }
+    val comparison = left.compareTo(right)
+    if (comparison != 0) return comparison > 0
   }
   // Numeric cores are equal: order by prerelease precedence (release outranks any prerelease).
   return comparePrerelease(a.prerelease, b.prerelease) > 0
@@ -23,9 +27,9 @@ internal fun isNewerVersion(candidate: String, current: String): Boolean {
 
 /**
  * SemVer prerelease precedence. A null prerelease (a final release) outranks any prerelease.
- * Otherwise dot-separated identifiers compare left to right: numeric identifiers numerically,
- * numeric below alphanumeric, alphanumeric lexically; a larger set of identifiers outranks a prefix
- * of it. So `rc.10` > `rc.9` (numeric), not the lexical `"rc.10" < "rc.9"`.
+ * Otherwise dot-separated identifiers compare left to right: numeric identifiers numerically (as
+ * [BigInteger], so arbitrarily large values order correctly), numeric below alphanumeric,
+ * alphanumeric lexically; a larger set of identifiers outranks a prefix of it. So `rc.10` > `rc.9`.
  */
 private fun comparePrerelease(a: String?, b: String?): Int {
   if (a == null && b == null) return 0
@@ -36,8 +40,8 @@ private fun comparePrerelease(a: String?, b: String?): Int {
   for (i in 0 until maxOf(aIds.size, bIds.size)) {
     val x = aIds.getOrNull(i) ?: return -1
     val y = bIds.getOrNull(i) ?: return 1
-    val xn = x.toIntOrNull()
-    val yn = y.toIntOrNull()
+    val xn = x.toBigIntegerOrNull()
+    val yn = y.toBigIntegerOrNull()
     val cmp =
       when {
         xn != null && yn != null -> xn.compareTo(yn)
@@ -58,7 +62,7 @@ internal fun resolveAsset(assets: List<ReleaseAsset>, platform: HostPlatform): R
     it.name.endsWith(platform.assetSuffix, ignoreCase = true)
   }
 
-private data class ParsedVersion(val numbers: List<Int>, val prerelease: String?)
+private data class ParsedVersion(val numbers: List<BigInteger>, val prerelease: String?)
 
 /**
  * The canonical SemVer 2.0.0 grammar (semver.org). Validates the whole string in one place —
@@ -81,11 +85,12 @@ private fun parseVersion(raw: String): ParsedVersion? {
   val normalized = raw.trim().removePrefix("v").removePrefix("V")
   val match = SEMVER.matchEntire(normalized) ?: return null
   val (major, minor, patch, prerelease) = match.destructured
+  // The regex already constrained these to digit strings; BigInteger avoids any Int overflow.
   val numbers =
     listOf(
-      major.toIntOrNull() ?: return null,
-      minor.toIntOrNull() ?: return null,
-      patch.toIntOrNull() ?: return null,
+      major.toBigIntegerOrNull() ?: return null,
+      minor.toBigIntegerOrNull() ?: return null,
+      patch.toBigIntegerOrNull() ?: return null,
     )
   return ParsedVersion(numbers, prerelease.ifEmpty { null })
 }

--- a/android/desktop-core/src/main/kotlin/dev/jasonpearson/automobile/desktop/core/update/UpdateVersioning.kt
+++ b/android/desktop-core/src/main/kotlin/dev/jasonpearson/automobile/desktop/core/update/UpdateVersioning.kt
@@ -7,22 +7,47 @@ package dev.jasonpearson.automobile.desktop.core.update
  * unparseable in a segment is treated as 0 so a malformed tag never reads as "newer".
  */
 internal fun isNewerVersion(candidate: String, current: String): Boolean {
-  val a = parseVersion(candidate)
-  val b = parseVersion(current)
+  // A version we cannot fully parse (e.g. "v1.bad.0", "nightly") must never read as newer, or a
+  // malformed tag could surface a bogus update. parseVersion returns null for such input.
+  val a = parseVersion(candidate) ?: return false
+  val b = parseVersion(current) ?: return false
   val segments = maxOf(a.numbers.size, b.numbers.size)
   for (i in 0 until segments) {
     val left = a.numbers.getOrElse(i) { 0 }
     val right = b.numbers.getOrElse(i) { 0 }
     if (left != right) return left > right
   }
-  // Numeric cores are equal: a final release outranks a prerelease; two prereleases compare
-  // lexically.
-  return when {
-    a.prerelease == null && b.prerelease == null -> false
-    a.prerelease == null -> true
-    b.prerelease == null -> false
-    else -> a.prerelease > b.prerelease
+  // Numeric cores are equal: order by prerelease precedence (release outranks any prerelease).
+  return comparePrerelease(a.prerelease, b.prerelease) > 0
+}
+
+/**
+ * SemVer prerelease precedence. A null prerelease (a final release) outranks any prerelease.
+ * Otherwise dot-separated identifiers compare left to right: numeric identifiers numerically,
+ * numeric below alphanumeric, alphanumeric lexically; a larger set of identifiers outranks a prefix
+ * of it. So `rc.10` > `rc.9` (numeric), not the lexical `"rc.10" < "rc.9"`.
+ */
+private fun comparePrerelease(a: String?, b: String?): Int {
+  if (a == null && b == null) return 0
+  if (a == null) return 1
+  if (b == null) return -1
+  val aIds = a.split('.')
+  val bIds = b.split('.')
+  for (i in 0 until maxOf(aIds.size, bIds.size)) {
+    val x = aIds.getOrNull(i) ?: return -1
+    val y = bIds.getOrNull(i) ?: return 1
+    val xn = x.toIntOrNull()
+    val yn = y.toIntOrNull()
+    val cmp =
+      when {
+        xn != null && yn != null -> xn.compareTo(yn)
+        xn != null -> -1
+        yn != null -> 1
+        else -> x.compareTo(y)
+      }
+    if (cmp != 0) return cmp
   }
+  return 0
 }
 
 /**
@@ -35,12 +60,19 @@ internal fun resolveAsset(assets: List<ReleaseAsset>, platform: HostPlatform): R
 
 private data class ParsedVersion(val numbers: List<Int>, val prerelease: String?)
 
-private fun parseVersion(raw: String): ParsedVersion {
+/**
+ * Parses `[v]MAJOR.MINOR.PATCH[-prerelease][+build]`, or null if any core segment is non-numeric.
+ */
+private fun parseVersion(raw: String): ParsedVersion? {
   val withoutPrefix = raw.trim().removePrefix("v").removePrefix("V")
   val withoutBuild = withoutPrefix.substringBefore('+')
   val dash = withoutBuild.indexOf('-')
   val core = if (dash >= 0) withoutBuild.substring(0, dash) else withoutBuild
   val prerelease = if (dash >= 0) withoutBuild.substring(dash + 1) else null
-  val numbers = core.split('.').map { it.toIntOrNull() ?: 0 }
+  val numbers = ArrayList<Int>()
+  for (segment in core.split('.')) {
+    // A non-numeric core segment means we cannot trust the version — reject the whole string.
+    numbers.add(segment.toIntOrNull() ?: return null)
+  }
   return ParsedVersion(numbers, prerelease)
 }

--- a/android/desktop-core/src/main/kotlin/dev/jasonpearson/automobile/desktop/core/update/UpdateVersioning.kt
+++ b/android/desktop-core/src/main/kotlin/dev/jasonpearson/automobile/desktop/core/update/UpdateVersioning.kt
@@ -1,0 +1,46 @@
+package dev.jasonpearson.automobile.desktop.core.update
+
+/**
+ * True when [candidate] is a strictly newer release than [current]. Both may carry a leading `v`
+ * and a `-prerelease` / `+build` suffix. Numeric core segments compare left to right; when cores
+ * are equal a final release outranks a prerelease, and two prereleases compare lexically. Anything
+ * unparseable in a segment is treated as 0 so a malformed tag never reads as "newer".
+ */
+internal fun isNewerVersion(candidate: String, current: String): Boolean {
+  val a = parseVersion(candidate)
+  val b = parseVersion(current)
+  val segments = maxOf(a.numbers.size, b.numbers.size)
+  for (i in 0 until segments) {
+    val left = a.numbers.getOrElse(i) { 0 }
+    val right = b.numbers.getOrElse(i) { 0 }
+    if (left != right) return left > right
+  }
+  // Numeric cores are equal: a final release outranks a prerelease; two prereleases compare
+  // lexically.
+  return when {
+    a.prerelease == null && b.prerelease == null -> false
+    a.prerelease == null -> true
+    b.prerelease == null -> false
+    else -> a.prerelease > b.prerelease
+  }
+}
+
+/**
+ * Resolves the installer asset for [platform] by suffix match, or null if the release lacks one.
+ */
+internal fun resolveAsset(assets: List<ReleaseAsset>, platform: HostPlatform): ReleaseAsset? =
+  assets.firstOrNull {
+    it.name.endsWith(platform.assetSuffix, ignoreCase = true)
+  }
+
+private data class ParsedVersion(val numbers: List<Int>, val prerelease: String?)
+
+private fun parseVersion(raw: String): ParsedVersion {
+  val withoutPrefix = raw.trim().removePrefix("v").removePrefix("V")
+  val withoutBuild = withoutPrefix.substringBefore('+')
+  val dash = withoutBuild.indexOf('-')
+  val core = if (dash >= 0) withoutBuild.substring(0, dash) else withoutBuild
+  val prerelease = if (dash >= 0) withoutBuild.substring(dash + 1) else null
+  val numbers = core.split('.').map { it.toIntOrNull() ?: 0 }
+  return ParsedVersion(numbers, prerelease)
+}

--- a/android/desktop-core/src/main/kotlin/dev/jasonpearson/automobile/desktop/core/update/UpdateVersioning.kt
+++ b/android/desktop-core/src/main/kotlin/dev/jasonpearson/automobile/desktop/core/update/UpdateVersioning.kt
@@ -60,29 +60,32 @@ internal fun resolveAsset(assets: List<ReleaseAsset>, platform: HostPlatform): R
 
 private data class ParsedVersion(val numbers: List<Int>, val prerelease: String?)
 
-/** A SemVer prerelease identifier: one or more ASCII alphanumerics or hyphens. */
-private val PRERELEASE_IDENTIFIER = Regex("[0-9A-Za-z-]+")
+/**
+ * The canonical SemVer 2.0.0 grammar (semver.org). Validates the whole string in one place —
+ * numeric core (no leading zeros), prerelease identifiers, and build metadata — so a malformed tag
+ * in any portion (`1.bad.0`, `1.0.1-`, `1.0.1-alpha..1`, `0.0.54+bad..meta`) fails to match rather
+ * than being best-effort-parsed into something that could read as newer.
+ */
+private val SEMVER =
+  Regex(
+    "^(0|[1-9]\\d*)\\.(0|[1-9]\\d*)\\.(0|[1-9]\\d*)" +
+      "(?:-((?:0|[1-9]\\d*|\\d*[a-zA-Z-][0-9a-zA-Z-]*)(?:\\.(?:0|[1-9]\\d*|\\d*[a-zA-Z-][0-9a-zA-Z-]*))*))?" +
+      "(?:\\+([0-9a-zA-Z-]+(?:\\.[0-9a-zA-Z-]+)*))?$"
+  )
 
 /**
- * Parses `[v]MAJOR.MINOR.PATCH[-prerelease][+build]`, or null if any core segment is non-numeric or
- * the prerelease contains an empty/invalid identifier (`1.0.1-`, `1.0.1-alpha..1`). Rejecting
- * rather than best-effort-parsing keeps a malformed tag from ever reading as newer.
+ * Parses `[v]MAJOR.MINOR.PATCH[-prerelease][+build]`, or null if the string is not valid SemVer.
+ * Build metadata is validated then discarded (it never affects precedence, per the spec).
  */
 private fun parseVersion(raw: String): ParsedVersion? {
-  val withoutPrefix = raw.trim().removePrefix("v").removePrefix("V")
-  val withoutBuild = withoutPrefix.substringBefore('+')
-  val dash = withoutBuild.indexOf('-')
-  val core = if (dash >= 0) withoutBuild.substring(0, dash) else withoutBuild
-  val prerelease = if (dash >= 0) withoutBuild.substring(dash + 1) else null
-  val numbers = ArrayList<Int>()
-  for (segment in core.split('.')) {
-    // A non-numeric core segment means we cannot trust the version — reject the whole string.
-    numbers.add(segment.toIntOrNull() ?: return null)
-  }
-  if (prerelease != null && !isValidPrerelease(prerelease)) return null
-  return ParsedVersion(numbers, prerelease)
+  val normalized = raw.trim().removePrefix("v").removePrefix("V")
+  val match = SEMVER.matchEntire(normalized) ?: return null
+  val (major, minor, patch, prerelease) = match.destructured
+  val numbers =
+    listOf(
+      major.toIntOrNull() ?: return null,
+      minor.toIntOrNull() ?: return null,
+      patch.toIntOrNull() ?: return null,
+    )
+  return ParsedVersion(numbers, prerelease.ifEmpty { null })
 }
-
-/** True when every dot-separated prerelease identifier is non-empty and uses the SemVer charset. */
-private fun isValidPrerelease(prerelease: String): Boolean =
-  prerelease.split('.').all { it.isNotEmpty() && PRERELEASE_IDENTIFIER.matches(it) }

--- a/android/desktop-core/src/main/kotlin/dev/jasonpearson/automobile/desktop/core/update/UpdateVersioning.kt
+++ b/android/desktop-core/src/main/kotlin/dev/jasonpearson/automobile/desktop/core/update/UpdateVersioning.kt
@@ -60,8 +60,13 @@ internal fun resolveAsset(assets: List<ReleaseAsset>, platform: HostPlatform): R
 
 private data class ParsedVersion(val numbers: List<Int>, val prerelease: String?)
 
+/** A SemVer prerelease identifier: one or more ASCII alphanumerics or hyphens. */
+private val PRERELEASE_IDENTIFIER = Regex("[0-9A-Za-z-]+")
+
 /**
- * Parses `[v]MAJOR.MINOR.PATCH[-prerelease][+build]`, or null if any core segment is non-numeric.
+ * Parses `[v]MAJOR.MINOR.PATCH[-prerelease][+build]`, or null if any core segment is non-numeric or
+ * the prerelease contains an empty/invalid identifier (`1.0.1-`, `1.0.1-alpha..1`). Rejecting
+ * rather than best-effort-parsing keeps a malformed tag from ever reading as newer.
  */
 private fun parseVersion(raw: String): ParsedVersion? {
   val withoutPrefix = raw.trim().removePrefix("v").removePrefix("V")
@@ -74,5 +79,10 @@ private fun parseVersion(raw: String): ParsedVersion? {
     // A non-numeric core segment means we cannot trust the version — reject the whole string.
     numbers.add(segment.toIntOrNull() ?: return null)
   }
+  if (prerelease != null && !isValidPrerelease(prerelease)) return null
   return ParsedVersion(numbers, prerelease)
 }
+
+/** True when every dot-separated prerelease identifier is non-empty and uses the SemVer charset. */
+private fun isValidPrerelease(prerelease: String): Boolean =
+  prerelease.split('.').all { it.isNotEmpty() && PRERELEASE_IDENTIFIER.matches(it) }

--- a/android/desktop-core/src/test/kotlin/dev/jasonpearson/automobile/desktop/core/platform/AppVersionProviderTest.kt
+++ b/android/desktop-core/src/test/kotlin/dev/jasonpearson/automobile/desktop/core/platform/AppVersionProviderTest.kt
@@ -15,15 +15,19 @@ class AppVersionProviderTest {
   private fun provider(raw: String?) = RuntimeAppVersionProvider(VersionSource { raw })
 
   @Test
-  fun `packaged version is preserved verbatim and marked non-development`() {
-    val version = provider("0.0.52-SNAPSHOT").current()
-    assertEquals("0.0.52-SNAPSHOT", version.raw)
-    assertFalse(version.isDevelopment, "a resolved packaged version is not a development run")
+  fun `a plain unsuffixed version is a real installed build eligible for updates`() {
+    val version = provider("0.0.52").current()
+    assertEquals("0.0.52", version.raw)
+    assertFalse(version.isDevelopment, "a packaged release version is not a development run")
   }
 
   @Test
-  fun `release version without a suffix is preserved`() {
-    assertEquals("0.0.52", provider("0.0.52").current().raw)
+  fun `a SNAPSHOT version is a source build and marked development`() {
+    // The generated version resource is present even in Gradle/IDE runs, so the SNAPSHOT qualifier
+    // — not the resource's absence — is the reliable source-build signal (#5224 review).
+    val version = provider("0.0.53-SNAPSHOT").current()
+    assertEquals("0.0.53-SNAPSHOT", version.raw, "raw is preserved for diagnostics")
+    assertTrue(version.isDevelopment, "a -SNAPSHOT build must never self-update")
   }
 
   @Test

--- a/android/desktop-core/src/test/kotlin/dev/jasonpearson/automobile/desktop/core/update/GitHubReleaseParsingTest.kt
+++ b/android/desktop-core/src/test/kotlin/dev/jasonpearson/automobile/desktop/core/update/GitHubReleaseParsingTest.kt
@@ -40,12 +40,14 @@ class GitHubReleaseParsingTest {
   }
 
   @Test
-  fun `drops assets missing a name or download url`() {
+  fun `drops assets missing or blank a name or download url`() {
     val partial =
       """
       {"tag_name":"v1.0.0","assets":[
         {"name":"only-name.dmg"},
         {"browser_download_url":"https://x/nameless"},
+        {"name":"blank-url.dmg","browser_download_url":"","size":1},
+        {"name":"","browser_download_url":"https://x/blank-name","size":2},
         {"name":"AutoMobile-1.0.0-linux.deb","browser_download_url":"https://x/deb","size":9}
       ]}
       """

--- a/android/desktop-core/src/test/kotlin/dev/jasonpearson/automobile/desktop/core/update/GitHubReleaseParsingTest.kt
+++ b/android/desktop-core/src/test/kotlin/dev/jasonpearson/automobile/desktop/core/update/GitHubReleaseParsingTest.kt
@@ -1,0 +1,73 @@
+package dev.jasonpearson.automobile.desktop.core.update
+
+import kotlin.test.Test
+import kotlin.test.assertEquals
+import kotlin.test.assertFailsWith
+import kotlin.test.assertFalse
+import kotlin.test.assertTrue
+
+/** Parsing of the GitHub `releases/latest` body (AC2/AC4) without a network round-trip. */
+class GitHubReleaseParsingTest {
+
+  private val body =
+    """
+    {
+      "tag_name": "v0.0.53",
+      "draft": false,
+      "prerelease": false,
+      "html_url": "https://github.com/kaeawc/auto-mobile/releases/tag/v0.0.53",
+      "assets": [
+        {"name": "AutoMobile-0.0.53-macos.dmg", "browser_download_url": "https://x/dmg", "size": 111, "extra": "ignored"},
+        {"name": "AutoMobile-0.0.53-windows.msi", "browser_download_url": "https://x/msi", "size": 222},
+        {"name": "AutoMobile-0.0.53-linux.deb", "browser_download_url": "https://x/deb", "size": 333}
+      ],
+      "unknown_top_level": true
+    }
+    """
+      .trimIndent()
+
+  @Test
+  fun `parses tag, flags, notes url, and assets, ignoring unknown fields`() {
+    val info = parseLatestRelease(body)
+    assertEquals("v0.0.53", info.tagName)
+    assertFalse(info.isDraft)
+    assertFalse(info.isPrerelease)
+    assertEquals("https://github.com/kaeawc/auto-mobile/releases/tag/v0.0.53", info.htmlUrl)
+    assertEquals(3, info.assets.size)
+    val mac = info.assets.first { it.name.endsWith("macos.dmg") }
+    assertEquals("https://x/dmg", mac.downloadUrl)
+    assertEquals(111L, mac.sizeBytes)
+  }
+
+  @Test
+  fun `drops assets missing a name or download url`() {
+    val partial =
+      """
+      {"tag_name":"v1.0.0","assets":[
+        {"name":"only-name.dmg"},
+        {"browser_download_url":"https://x/nameless"},
+        {"name":"AutoMobile-1.0.0-linux.deb","browser_download_url":"https://x/deb","size":9}
+      ]}
+      """
+        .trimIndent()
+    val info = parseLatestRelease(partial)
+    assertEquals(1, info.assets.size)
+    assertEquals("AutoMobile-1.0.0-linux.deb", info.assets.single().name)
+  }
+
+  @Test
+  fun `a body without tag_name is a fetch failure`() {
+    assertFailsWith<ReleaseFetchException> { parseLatestRelease("""{"draft":false}""") }
+  }
+
+  @Test
+  fun `malformed json is a fetch failure`() {
+    assertFailsWith<ReleaseFetchException> { parseLatestRelease("not json at all") }
+  }
+
+  @Test
+  fun `prerelease flag is carried through`() {
+    val info = parseLatestRelease("""{"tag_name":"v2.0.0-rc.1","prerelease":true}""")
+    assertTrue(info.isPrerelease)
+  }
+}

--- a/android/desktop-core/src/test/kotlin/dev/jasonpearson/automobile/desktop/core/update/RealUpdateControllerTest.kt
+++ b/android/desktop-core/src/test/kotlin/dev/jasonpearson/automobile/desktop/core/update/RealUpdateControllerTest.kt
@@ -7,6 +7,10 @@ import kotlin.test.assertEquals
 import kotlin.test.assertFalse
 import kotlin.test.assertIs
 import kotlin.test.assertTrue
+import kotlinx.coroutines.CompletableDeferred
+import kotlinx.coroutines.awaitCancellation
+import kotlinx.coroutines.cancelAndJoin
+import kotlinx.coroutines.launch
 import kotlinx.coroutines.test.runTest
 
 /** State-machine behavior of the update check (AC1–AC5) against a fake release source. */
@@ -129,6 +133,29 @@ class RealUpdateControllerTest {
       )
     pre.checkForUpdate()
     assertEquals(UpdateStatus.UpToDate, pre.status.value)
+  }
+
+  @Test
+  fun `a cancelled check restores the previous status instead of pinning Checking`() = runTest {
+    val entered = CompletableDeferred<Unit>()
+    val source =
+      object : ReleaseSource {
+        override suspend fun fetchLatestRelease(): ReleaseInfo {
+          entered.complete(Unit)
+          awaitCancellation()
+        }
+      }
+    val controller = RealUpdateController(source, versionProvider(packaged), HostPlatform.MAC)
+
+    val job = launch { controller.checkForUpdate() }
+    entered.await()
+    assertEquals(UpdateStatus.Checking, controller.status.value)
+
+    job.cancelAndJoin()
+
+    // Previous stable state was Idle; a cancelled check must not leave collectors stuck at
+    // Checking.
+    assertEquals(UpdateStatus.Idle, controller.status.value)
   }
 
   @Test

--- a/android/desktop-core/src/test/kotlin/dev/jasonpearson/automobile/desktop/core/update/RealUpdateControllerTest.kt
+++ b/android/desktop-core/src/test/kotlin/dev/jasonpearson/automobile/desktop/core/update/RealUpdateControllerTest.kt
@@ -1,0 +1,144 @@
+package dev.jasonpearson.automobile.desktop.core.update
+
+import dev.jasonpearson.automobile.desktop.core.platform.AppVersion
+import dev.jasonpearson.automobile.desktop.core.platform.AppVersionProvider
+import kotlin.test.Test
+import kotlin.test.assertEquals
+import kotlin.test.assertFalse
+import kotlin.test.assertIs
+import kotlin.test.assertTrue
+import kotlinx.coroutines.test.runTest
+
+/** State-machine behavior of the update check (AC1–AC5) against a fake release source. */
+class RealUpdateControllerTest {
+
+  /** Fake [ReleaseSource] that returns a canned release or throws, recording whether it was hit. */
+  private class FakeReleaseSource(
+    private val release: ReleaseInfo? = null,
+    private val error: ReleaseFetchException? = null,
+  ) : ReleaseSource {
+    var fetched = false
+      private set
+
+    override suspend fun fetchLatestRelease(): ReleaseInfo {
+      fetched = true
+      error?.let { throw it }
+      return release ?: error("test misconfigured: no release and no error")
+    }
+  }
+
+  private fun versionProvider(version: AppVersion) = AppVersionProvider { version }
+
+  private val packaged = AppVersion(raw = "0.0.52", isDevelopment = false)
+
+  private fun release(
+    tag: String,
+    assets: List<ReleaseAsset> = listOf(ReleaseAsset("AutoMobile-x-macos.dmg", "https://x/dmg", 1)),
+    draft: Boolean = false,
+    prerelease: Boolean = false,
+  ) = ReleaseInfo(tag, draft, prerelease, "https://notes", assets)
+
+  @Test
+  fun `newer release with a matching asset yields UpdateAvailable`() = runTest {
+    val source = FakeReleaseSource(release("v0.0.53"))
+    val controller = RealUpdateController(source, versionProvider(packaged), HostPlatform.MAC)
+
+    controller.checkForUpdate()
+
+    val status = controller.status.value
+    assertIs<UpdateStatus.UpdateAvailable>(status)
+    assertEquals("0.0.53", status.version)
+    assertEquals("AutoMobile-x-macos.dmg", status.asset.name)
+    assertEquals("https://notes", status.releaseNotesUrl)
+  }
+
+  @Test
+  fun `equal version yields UpToDate`() = runTest {
+    val controller =
+      RealUpdateController(
+        FakeReleaseSource(release("v0.0.52")),
+        versionProvider(packaged),
+        HostPlatform.MAC,
+      )
+    controller.checkForUpdate()
+    assertEquals(UpdateStatus.UpToDate, controller.status.value)
+  }
+
+  @Test
+  fun `older version yields UpToDate`() = runTest {
+    val controller =
+      RealUpdateController(
+        FakeReleaseSource(release("v0.0.51")),
+        versionProvider(packaged),
+        HostPlatform.MAC,
+      )
+    controller.checkForUpdate()
+    assertEquals(UpdateStatus.UpToDate, controller.status.value)
+  }
+
+  @Test
+  fun `development build never checks and stays UpToDate`() = runTest {
+    val source = FakeReleaseSource(release("v9.9.9"))
+    val controller = RealUpdateController(source, versionProvider(AppVersion.Dev), HostPlatform.MAC)
+
+    controller.checkForUpdate()
+
+    assertEquals(UpdateStatus.UpToDate, controller.status.value)
+    assertFalse(source.fetched, "a dev build must not hit the network")
+  }
+
+  @Test
+  fun `fetch failure yields Failed with the reason`() = runTest {
+    val source = FakeReleaseSource(error = ReleaseFetchException("rate limited (403)"))
+    val controller = RealUpdateController(source, versionProvider(packaged), HostPlatform.MAC)
+
+    controller.checkForUpdate()
+
+    val status = controller.status.value
+    assertIs<UpdateStatus.Failed>(status)
+    assertTrue(status.reason.contains("403"))
+  }
+
+  @Test
+  fun `newer release without an asset for this OS stays UpToDate`() = runTest {
+    // Only a macOS asset, but we are on Windows.
+    val source = FakeReleaseSource(release("v0.0.53"))
+    val controller = RealUpdateController(source, versionProvider(packaged), HostPlatform.WINDOWS)
+
+    controller.checkForUpdate()
+
+    assertEquals(UpdateStatus.UpToDate, controller.status.value)
+  }
+
+  @Test
+  fun `draft and prerelease latest releases are ignored`() = runTest {
+    val draft =
+      RealUpdateController(
+        FakeReleaseSource(release("v0.0.53", draft = true)),
+        versionProvider(packaged),
+        HostPlatform.MAC,
+      )
+    draft.checkForUpdate()
+    assertEquals(UpdateStatus.UpToDate, draft.status.value)
+
+    val pre =
+      RealUpdateController(
+        FakeReleaseSource(release("v0.0.53", prerelease = true)),
+        versionProvider(packaged),
+        HostPlatform.MAC,
+      )
+    pre.checkForUpdate()
+    assertEquals(UpdateStatus.UpToDate, pre.status.value)
+  }
+
+  @Test
+  fun `unknown host platform stays UpToDate without checking`() = runTest {
+    val source = FakeReleaseSource(release("v9.9.9"))
+    val controller = RealUpdateController(source, versionProvider(packaged), platform = null)
+
+    controller.checkForUpdate()
+
+    assertEquals(UpdateStatus.UpToDate, controller.status.value)
+    assertFalse(source.fetched, "an unshipped OS must not hit the network")
+  }
+}

--- a/android/desktop-core/src/test/kotlin/dev/jasonpearson/automobile/desktop/core/update/RealUpdateControllerTest.kt
+++ b/android/desktop-core/src/test/kotlin/dev/jasonpearson/automobile/desktop/core/update/RealUpdateControllerTest.kt
@@ -2,6 +2,7 @@ package dev.jasonpearson.automobile.desktop.core.update
 
 import dev.jasonpearson.automobile.desktop.core.platform.AppVersion
 import dev.jasonpearson.automobile.desktop.core.platform.AppVersionProvider
+import java.util.concurrent.atomic.AtomicInteger
 import kotlin.test.Test
 import kotlin.test.assertEquals
 import kotlin.test.assertFalse
@@ -12,6 +13,7 @@ import kotlinx.coroutines.awaitCancellation
 import kotlinx.coroutines.cancelAndJoin
 import kotlinx.coroutines.launch
 import kotlinx.coroutines.test.runTest
+import kotlinx.coroutines.yield
 
 /** State-machine behavior of the update check (AC1–AC5) against a fake release source. */
 class RealUpdateControllerTest {
@@ -156,6 +158,31 @@ class RealUpdateControllerTest {
     // Previous stable state was Idle; a cancelled check must not leave collectors stuck at
     // Checking.
     assertEquals(UpdateStatus.Idle, controller.status.value)
+  }
+
+  @Test
+  fun `overlapping checks are serialized, never running the fetch concurrently`() = runTest {
+    val inFlight = AtomicInteger(0)
+    val maxConcurrent = AtomicInteger(0)
+    val source =
+      object : ReleaseSource {
+        override suspend fun fetchLatestRelease(): ReleaseInfo {
+          val now = inFlight.incrementAndGet()
+          maxConcurrent.updateAndGet { maxOf(it, now) }
+          yield() // give any overlapping check a chance to enter before we finish
+          inFlight.decrementAndGet()
+          return release("v0.0.53")
+        }
+      }
+    val controller = RealUpdateController(source, versionProvider(packaged), HostPlatform.MAC)
+
+    val first = launch { controller.checkForUpdate() }
+    val second = launch { controller.checkForUpdate() }
+    first.join()
+    second.join()
+
+    assertEquals(1, maxConcurrent.get(), "the fetch must never run for two checks at once")
+    assertIs<UpdateStatus.UpdateAvailable>(controller.status.value)
   }
 
   @Test

--- a/android/desktop-core/src/test/kotlin/dev/jasonpearson/automobile/desktop/core/update/UpdateVersioningTest.kt
+++ b/android/desktop-core/src/test/kotlin/dev/jasonpearson/automobile/desktop/core/update/UpdateVersioningTest.kt
@@ -38,6 +38,23 @@ class UpdateVersioningTest {
   }
 
   @Test
+  fun `prerelease numeric identifiers compare numerically, not lexically`() {
+    // "rc.10" vs "rc.9": lexical compare would wrongly rank rc.10 below rc.9.
+    assertTrue(isNewerVersion("1.0.0-rc.10", "1.0.0-rc.9"))
+    assertFalse(isNewerVersion("1.0.0-rc.9", "1.0.0-rc.10"))
+    // Alphanumeric identifiers still compare lexically; numeric ranks below alphanumeric.
+    assertTrue(isNewerVersion("1.0.0-beta", "1.0.0-alpha"))
+    assertTrue(isNewerVersion("1.0.0-rc", "1.0.0-1"))
+  }
+
+  @Test
+  fun `a malformed candidate is never considered newer`() {
+    assertFalse(isNewerVersion("v1.bad.0", "0.0.52"))
+    assertFalse(isNewerVersion("nightly", "0.0.52"))
+    assertFalse(isNewerVersion("", "0.0.52"))
+  }
+
+  @Test
   fun `resolveAsset matches the platform suffix and returns null when absent`() {
     val assets =
       listOf(

--- a/android/desktop-core/src/test/kotlin/dev/jasonpearson/automobile/desktop/core/update/UpdateVersioningTest.kt
+++ b/android/desktop-core/src/test/kotlin/dev/jasonpearson/automobile/desktop/core/update/UpdateVersioningTest.kt
@@ -1,0 +1,61 @@
+package dev.jasonpearson.automobile.desktop.core.update
+
+import kotlin.test.Test
+import kotlin.test.assertEquals
+import kotlin.test.assertFalse
+import kotlin.test.assertNull
+import kotlin.test.assertTrue
+
+/** Semver comparison (AC3) and OS asset resolution (AC4) for #5224, as pure functions. */
+class UpdateVersioningTest {
+
+  @Test
+  fun `newer numeric versions are detected, including multi-digit segments`() {
+    assertTrue(isNewerVersion("0.0.53", "0.0.52"))
+    assertTrue(isNewerVersion("0.1.0", "0.0.52"))
+    assertTrue(isNewerVersion("1.0.0", "0.9.9"))
+    // 10 > 9 numerically, not lexically — the string compare "1.2.10" < "1.2.9" would be wrong.
+    assertTrue(isNewerVersion("1.2.10", "1.2.9"))
+  }
+
+  @Test
+  fun `equal or older versions are not newer`() {
+    assertFalse(isNewerVersion("0.0.52", "0.0.52"))
+    assertFalse(isNewerVersion("0.0.51", "0.0.52"))
+    assertFalse(isNewerVersion("1.2.9", "1.2.10"))
+  }
+
+  @Test
+  fun `a leading v is ignored on either side`() {
+    assertTrue(isNewerVersion("v0.0.53", "0.0.52"))
+    assertFalse(isNewerVersion("v0.0.52", "0.0.52"))
+  }
+
+  @Test
+  fun `a release outranks its own prerelease and snapshot`() {
+    assertTrue(isNewerVersion("0.0.52", "0.0.52-SNAPSHOT"))
+    assertFalse(isNewerVersion("0.0.52-SNAPSHOT", "0.0.52"))
+  }
+
+  @Test
+  fun `resolveAsset matches the platform suffix and returns null when absent`() {
+    val assets =
+      listOf(
+        ReleaseAsset("AutoMobile-0.0.53-macos.dmg", "https://x/dmg", 10),
+        ReleaseAsset("AutoMobile-0.0.53-windows.msi", "https://x/msi", 20),
+        ReleaseAsset("AutoMobile-0.0.53-linux.deb", "https://x/deb", 30),
+      )
+    assertEquals("AutoMobile-0.0.53-macos.dmg", resolveAsset(assets, HostPlatform.MAC)?.name)
+    assertEquals("AutoMobile-0.0.53-windows.msi", resolveAsset(assets, HostPlatform.WINDOWS)?.name)
+    assertEquals("AutoMobile-0.0.53-linux.deb", resolveAsset(assets, HostPlatform.LINUX)?.name)
+    assertNull(resolveAsset(assets.take(1), HostPlatform.WINDOWS))
+  }
+
+  @Test
+  fun `host platform detection maps os_name strings`() {
+    assertEquals(HostPlatform.MAC, HostPlatform.current("Mac OS X"))
+    assertEquals(HostPlatform.WINDOWS, HostPlatform.current("Windows 11"))
+    assertEquals(HostPlatform.LINUX, HostPlatform.current("Linux"))
+    assertNull(HostPlatform.current("SunOS"))
+  }
+}

--- a/android/desktop-core/src/test/kotlin/dev/jasonpearson/automobile/desktop/core/update/UpdateVersioningTest.kt
+++ b/android/desktop-core/src/test/kotlin/dev/jasonpearson/automobile/desktop/core/update/UpdateVersioningTest.kt
@@ -64,6 +64,21 @@ class UpdateVersioningTest {
   }
 
   @Test
+  fun `build metadata is validated then ignored for precedence`() {
+    // Malformed build metadata (empty identifier) rejects the whole version.
+    assertFalse(isNewerVersion("0.0.54+bad..meta", "0.0.53"))
+    // Well-formed build metadata is ignored: 0.0.54 is still newer than 0.0.53.
+    assertTrue(isNewerVersion("0.0.54+build.1", "0.0.53"))
+    // Build metadata does not affect precedence between two otherwise-equal versions.
+    assertFalse(isNewerVersion("0.0.54+build.2", "0.0.54+build.1"))
+  }
+
+  @Test
+  fun `versions with leading-zero segments are rejected`() {
+    assertFalse(isNewerVersion("01.0.0", "0.0.52"))
+  }
+
+  @Test
   fun `resolveAsset matches the platform suffix and returns null when absent`() {
     val assets =
       listOf(

--- a/android/desktop-core/src/test/kotlin/dev/jasonpearson/automobile/desktop/core/update/UpdateVersioningTest.kt
+++ b/android/desktop-core/src/test/kotlin/dev/jasonpearson/automobile/desktop/core/update/UpdateVersioningTest.kt
@@ -55,6 +55,15 @@ class UpdateVersioningTest {
   }
 
   @Test
+  fun `a malformed prerelease suffix is rejected, not treated as newer`() {
+    // Empty prerelease identifiers: "1.0.1-" and "1.0.1-alpha..1" are not valid SemVer.
+    assertFalse(isNewerVersion("1.0.1-", "1.0.0"))
+    assertFalse(isNewerVersion("1.0.1-alpha..1", "1.0.0"))
+    // A well-formed prerelease on a higher core is still newer.
+    assertTrue(isNewerVersion("0.0.53-rc.1", "0.0.52"))
+  }
+
+  @Test
   fun `resolveAsset matches the platform suffix and returns null when absent`() {
     val assets =
       listOf(

--- a/android/desktop-core/src/test/kotlin/dev/jasonpearson/automobile/desktop/core/update/UpdateVersioningTest.kt
+++ b/android/desktop-core/src/test/kotlin/dev/jasonpearson/automobile/desktop/core/update/UpdateVersioningTest.kt
@@ -79,6 +79,16 @@ class UpdateVersioningTest {
   }
 
   @Test
+  fun `numeric identifiers above Int MAX_VALUE compare numerically, not lexically`() {
+    // Core segments beyond Int.MAX_VALUE (2147483647) must not overflow or reject.
+    assertTrue(isNewerVersion("2147483648.0.0", "2147483647.0.0"))
+    assertTrue(isNewerVersion("100000000000.0.0", "1.0.0"))
+    // Oversized numeric prerelease identifiers: "10000000000" > "9999999999" numerically.
+    assertTrue(isNewerVersion("1.0.0-10000000000", "1.0.0-9999999999"))
+    assertFalse(isNewerVersion("1.0.0-9999999999", "1.0.0-10000000000"))
+  }
+
+  @Test
   fun `resolveAsset matches the platform suffix and returns null when absent`() {
     val assets =
       listOf(


### PR DESCRIPTION
## Summary

Adds the core "is there a newer release?" logic for the desktop auto-update feature, fully behind a
testable seam and with **no UI and no side effects** (no downloading, no installer execution — those
are item #5226). Item 2 of the sequence; consumes the runtime `AppVersionProvider` from #5223.

`UpdateController` exposes update state as a `StateFlow<UpdateStatus>`
(`Idle`/`Checking`/`UpToDate`/`UpdateAvailable(version, asset, releaseNotesUrl)`/`Failed(reason)`) and a
`suspend fun checkForUpdate()`. `RealUpdateController` is **purely reactive** — nothing fetches on
construction or startup; a caller (item #5225's button) drives the check. A development build (the
`AppVersion.Dev` sentinel) and an OS we don't ship an installer for both resolve to `UpToDate`
**without any network call**, so nothing self-updates in dev.

The check queries `GET /repos/kaeawc/auto-mobile/releases/latest` via the JDK `HttpClient` (the
pattern already used by `McpHttpClient`; no new dependency), does real semver comparison (multi-digit
segments, `v` prefix, a final release outranks its `-SNAPSHOT`/prerelease), ignores draft/prerelease
`latest` releases, and resolves the current-OS asset by filename **suffix**
(`-macos.dmg`/`-windows.msi`/`-linux.deb`), robust to version formatting.

Per the issue's open question, a newer release that ships **no asset for this OS** resolves to
`UpToDate` (quiet) with a warning log, rather than `Failed`.

## Linked Issue

Closes #5224

Sequence: #5223 (merged) → **#5224 (this)** → #5225 → #5226 (decision: #5227).

## Validation

- [x] `scripts/all_fast_validate_checks.sh --only ktfmt` passes (Kotlin-only change)
- [x] `:desktop-core:detektMain :desktop-core:detektTest` green; `:desktop-core:test :desktop-app:test` green
- [x] New network access is behind the `ReleaseSource` interface + `FakeReleaseSource`; unit tests run <100ms with no real network (19 tests: semver, asset resolution, OS detection, JSON parsing, and the full controller state machine)
- [x] Metro `AppScope` graph resolves the new `UpdateController` binding (built via `:desktop-app:test`)
- [ ] `bun run typecheck` — N/A (no TypeScript touched)

## Kotlin Reuse Check

- [x] Reused JDK `java.net.http.HttpClient` (as `McpHttpClient` does) and existing `kotlinx.serialization`/`coroutines`; **no new dependency**
- [x] No existing "is B newer than A" comparator existed (`DesktopDaemonLifecycle.versionsMatch` is equality-only), so a small tested `isNewerVersion` was added

## Follow-ups

- The status-bar "update ready" button that triggers `checkForUpdate()` and renders `UpdateAvailable` is #5225 (next).
- Applying the update (download → open installer → quit) is #5226.
