### PR TITLE
ci(release): temporarily skip Maven Central publish, keep npm

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -75,6 +75,13 @@ jobs:
     runs-on: ubuntu-latest
     needs:
       - validate-release-tag
+    env:
+      # Maven Central publishing is temporarily disabled. The signing key id secret
+      # (ORG_GRADLE_PROJECT_SIGNINGINMEMORYKEYID) holds a malformed GPG key id, so
+      # `signMavenPublication` fails and aborts the whole release before npm ever
+      # runs (release run 31707895940). Skip Maven so npm keeps shipping; flip this
+      # to "true" once the signing key is fixed to re-enable Maven Central.
+      PUBLISH_TO_MAVEN: "false"
 
     steps:
       - name: Checkout code
@@ -406,6 +413,7 @@ jobs:
       # the artifact-reduction work (#4851, #4852) a before/after regression
       # oracle.
       - name: Maven Central publication manifest preflight
+        if: ${{ env.PUBLISH_TO_MAVEN == 'true' }}
         continue-on-error: true
         env:
           VERSION: ${{ steps.version.outputs.version }}
@@ -419,6 +427,7 @@ jobs:
         run: scripts/release/maven-publication-manifest-preflight.sh
 
       - name: Upload Maven publication manifest
+        if: ${{ env.PUBLISH_TO_MAVEN == 'true' }}
         continue-on-error: true
         uses: actions/upload-artifact@v6
         with:
@@ -427,6 +436,7 @@ jobs:
           if-no-files-found: warn
 
       - name: Publish Android Libraries to Maven Central
+        if: ${{ env.PUBLISH_TO_MAVEN == 'true' }}
         env:
           VERSION: ${{ steps.version.outputs.version }}
           ORG_GRADLE_PROJECT_mavenCentralUsername:


### PR DESCRIPTION
## Why

The Release publish job failed for **0.0.54** ([run 31707895940](https://github.com/kaeawc/auto-mobile/actions/runs/31707895940)) at **Publish Android Libraries to Maven Central**:

```
Task :test-plan-validation:signMavenPublication FAILED
> Error while evaluating property 'signatory.keyId'
   > The key ID must be in a valid form (eg 00B5050F or 0x00B5050F), given value: ***
```

The `ORG_GRADLE_PROJECT_SIGNINGINMEMORYKEYID` secret holds a **malformed** GPG key id (non-empty, so this is a secret *value* problem — the workflow's secret *references* are correct). Because Maven runs before npm in the same `verify-and-release` job, the failure aborted the job and **npm never published** — 0.0.54 is absent from npm.

## What

Gate the three Maven Central steps (preflight, manifest upload, publish) behind a `PUBLISH_TO_MAVEN` job-level env toggle, defaulted to `"false"`. npm / MCP / GitHub Release publishing are untouched, so releases keep shipping to npm.

This is a **temporary** measure. Flip `PUBLISH_TO_MAVEN` back to `"true"` once the signing key id secret is corrected to re-enable Maven Central.

## Validation

- `scripts/all_fast_validate_checks.sh` — 33/33 pass
- YAML parses; no later step consumes the (now-skipped) Maven manifest artifact