### PR TITLE
ci(test): raise macos Node TS per-test timeout to stop runner-contention flakes

### DIFF
--- a/.github/workflows/pull_request.yml
+++ b/.github/workflows/pull_request.yml
@@ -1317,7 +1317,18 @@ jobs:
           if [[ "$RUNNER_OS" == "Windows" ]]; then
             bun run test:windows 2>&1 | tee "ci-logs/bun-test-${{ matrix.os }}.log"
           else
-            turbo run test --output-logs=errors-only --log-order=grouped 2>&1 | tee "ci-logs/bun-test-${{ matrix.os }}.log"
+            # macOS-only (this job's matrix is macos + windows; the ubuntu Node TS
+            # suite is a SEPARATE job that keeps the tight 5s ceiling). The hosted
+            # macos runner is markedly slower / more contended than the Linux lane,
+            # so this ~13k-test --isolate suite intermittently trips bun's default
+            # 5s per-test / 10s hook ceiling by a hair (observed 5002/5004ms on
+            # fully-faked tests; a 10052ms beforeEach/afterEach hook) — a pure
+            # runner-contention flake, macos-only (ubuntu + windows had zero). Raise
+            # bun's timeout to give that headroom; --timeout covers BOTH the test and
+            # hook budgets (verified). Bypass turbo like the Windows branch so the
+            # flag applies directly (macos then always runs, which also keeps the
+            # native-source-scan guard tests from ever replaying a cached result).
+            bun test --isolate --timeout 20000 2>&1 | tee "ci-logs/bun-test-${{ matrix.os }}.log"
           fi
 
       - name: "Run Bun image runtime smoke"


### PR DESCRIPTION
## Problem

The **Node TypeScript Build and Test (macos-latest)** lane flakes intermittently — and it is **not** a broken test. Every genuine failure is a per-test or per-hook **timeout** that trips bun's defaults by a hair, on a *different* (often fully-faked) test each run:

| Test | Kind | ms | ceiling |
|---|---|---|---|
| `PinchOn vision fallback > does not call vision when no container specified` (recurs) | test-body | 5002 / 5004 | 5000 |
| `HandleIntentChooser > … 'always' preference` | test-body | 5018 | 5000 |
| `MCP Resources List > (unnamed)` | **beforeEach/afterEach hook** | 10052 | ~10000 |

Across ~65 recent macos job observations, **ubuntu-latest and windows-latest had zero timeout flakes** — only the slower/more-contended hosted **macos** runner, on a ~13k-test `--isolate` suite, occasionally stalls a normally-instant test past bun's tight 5s ceiling. The same PR failed on two *different* tests across two runs (same code) — the signature of runner contention, not a test bug. No `--timeout` is set anywhere, so bun's 5s test / 10s hook defaults apply.

## Fix

Raise bun's `--timeout` to **20s on the macos branch only**. Verified empirically that `--timeout` covers **both** the test-body and hook budgets, so this single change fixes the whole class in one shot.

- This job's matrix is **macos + windows**; the **ubuntu** Node TS suite is a **separate job** that keeps the tight 5s ceiling as a genuine safety net — nothing is loosened there.
- Bypasses turbo like the existing Windows branch so the flag applies directly (macos then always runs, which also keeps the native-source-scan guard tests from replaying a cached result).

This is a legitimate root-cause fix, not masking: GitHub's hosted macos runners are simply slower, and a 5s ceiling on an instant faked test is too tight for their worst-case contention. (Masking would be blind retries or `continue-on-error`.)

## Validation

- `scripts/all_fast_validate_checks.sh --only yaml,workflow-assertion-triggers` — pass.
- shellcheck of the inline `Run Tests` bash — clean.
- No test pins the old macos step string.

## Follow-up (not in this PR)

The recurring PinchOn victim uses `FakeTimer.enableAutoAdvance()`, whose loop is driven by the **real** scheduler (the #3144 poll-flake class), so it sits near the wall-clock ceiling under load. A bounded auto-advance budget would harden it independently of this timeout raise.