### PR TITLE
fix(ios): allow xcodebuild runner preflight to warm up

### DIFF
--- a/src/utils/ios-cmdline-tools/XcodebuildClient.ts
+++ b/src/utils/ios-cmdline-tools/XcodebuildClient.ts
@@ -5,6 +5,7 @@ import { logger } from "../logger";
 import { createExecResult } from "../execResult";
 import { defaultTimer, Timer } from "../SystemTimer";
 import { getAbortSignal } from "../AbortContext";
+import { DEFAULT_RUNNER_READINESS_TIMEOUT_MS } from "../runnerReadinessConfig";
 
 export interface XcodebuildCommandOptions {
   timeoutMs?: number;
@@ -138,7 +139,7 @@ export class XcodebuildClient implements Xcodebuild {
     options: XcodebuildStreamingOptions = {}
   ): Promise<ChildProcess> {
     const signal = options.signal ?? getAbortSignal();
-    if (!(await this.isAvailableWithin(options.timeoutMs ?? 5000, signal))) {
+    if (!(await this.isAvailableWithin(options.timeoutMs ?? DEFAULT_RUNNER_READINESS_TIMEOUT_MS, signal))) {
       throw new ActionableError("xcodebuild is not available. Please install Xcode to continue.");
     }
 

--- a/test/utils/ios-cmdline-tools/XcodebuildClient.test.ts
+++ b/test/utils/ios-cmdline-tools/XcodebuildClient.test.ts
@@ -188,8 +188,8 @@ describe("XcodebuildClient streaming runner", () => {
     );
 
     const promise = client.startStreaming(["test-without-building"]);
-    while (!resolveAvailability) {
-      await Promise.resolve();
+    if (!resolveAvailability) {
+      throw new Error("Availability probe did not start");
     }
 
     timer.advanceTime(5001);

--- a/test/utils/ios-cmdline-tools/XcodebuildClient.test.ts
+++ b/test/utils/ios-cmdline-tools/XcodebuildClient.test.ts
@@ -2,6 +2,7 @@ import { describe, expect, test } from "bun:test";
 import { XcodebuildClient } from "../../../src/utils/ios-cmdline-tools/XcodebuildClient";
 import type { ExecResult } from "../../../src/models";
 import { createExecResult } from "../../../src/utils/execResult";
+import { DEFAULT_RUNNER_READINESS_TIMEOUT_MS } from "../../../src/utils/runnerReadinessConfig";
 import { FakeTimer } from "../../fakes/FakeTimer";
 import { FakeChildProcess } from "../../fakes/FakeChildProcess";
 
@@ -168,6 +169,36 @@ describe("XcodebuildClient streaming runner", () => {
     await expect(client.startStreaming(["test-without-building"])).rejects.toThrow(
       "xcodebuild is not available"
     );
+  });
+
+  test("uses the runner-readiness budget for a no-options availability probe", async () => {
+    const timer = new FakeTimer();
+    const child = new FakeChildProcess();
+    let resolveAvailability: (() => void) | undefined;
+    let spawned = false;
+    const client = new XcodebuildClient(
+      async () => new Promise<ExecResult>(resolve => {
+        resolveAvailability = () => resolve(createExecResult("Xcode 26.5", ""));
+      }),
+      timer,
+      () => {
+        spawned = true;
+        return child as never;
+      }
+    );
+
+    const promise = client.startStreaming(["test-without-building"]);
+    while (!resolveAvailability) {
+      await Promise.resolve();
+    }
+
+    timer.advanceTime(5001);
+    expect(spawned).toBe(false);
+    expect(timer.getPendingTimeouts()).toEqual([DEFAULT_RUNNER_READINESS_TIMEOUT_MS]);
+
+    resolveAvailability();
+    await expect(promise).resolves.toBe(child);
+    expect(timer.getPendingTimeoutCount()).toBe(0);
   });
 
   test("startStreaming releases the availability-probe timer handle", async () => {


### PR DESCRIPTION
## Summary

Use AutoMobile's existing 30-second runner-readiness budget when an iOS
`xcodebuild` streaming runner does not provide its own availability-probe
timeout. This removes the unrelated five-second cap that failed otherwise
recoverable simulator setup while `startDevice` still had remaining budget.

## Linked Issue

Follow-up to #5238.

## Bug / Regression Context

- **Prior attempts:** #5238 made `startDevice` wait for iOS runner readiness.
- **Observed symptom:** A consumer's device creation failed with `xcodebuild availability check timed out after 5000ms`, despite a five-minute `startDevice` request timeout.
- **Repro steps / conditions:** Start an iOS device when the first `xcodebuild -version` probe needs more than five seconds during runner setup.

## Validation

- [x] Targeted Xcodebuild client tests pass, including a FakeTimer regression that advances past five seconds and releases the readiness timeout handle.
- [x] TypeScript production build passes.
- [x] Lint and boundary checks pass with no new ratchet violations.
- [x] No new dependency or generic helper was added.
- [x] Branch is based on the current `origin/main`.

## Follow-ups

- [x] No additional follow-up required for this timeout mismatch.

