### PR TITLE
fix(ios): preserve CtrlProxy health budget

### DIFF
--- a/src/utils/IOSCtrlProxyManager.ts
+++ b/src/utils/IOSCtrlProxyManager.ts
@@ -53,6 +53,7 @@ interface SharedCtrlProxyStart {
   healthPollDeadlineMs: number | null;
   defaultHealthPollDeadlineMs: number | null;
   callerHealthPollDeadlinesMs: Map<symbol, number>;
+  teardownCommitted: boolean;
   waitingCallers: number;
   completed: boolean;
 }
@@ -723,22 +724,7 @@ export class IOSCtrlProxyManager implements CtrlProxyIosManager {
       throw options.signal.reason ?? new Error("iOS CtrlProxy startup was aborted");
     }
 
-    let sharedStart = this.sharedStart;
-    if (sharedStart?.controller.signal.aborted) {
-      logger.info("[IOSCtrlProxy] Waiting for aborted startup to settle before retrying");
-      const abortedStart = sharedStart;
-      try {
-        await this.waitForSharedStart(abortedStart, options.signal);
-      } catch (error) {
-        if (options.signal?.aborted) {
-          throw error;
-        }
-      }
-      if (this.sharedStart === abortedStart) {
-        this.sharedStart = null;
-      }
-      sharedStart = this.sharedStart;
-    }
+    let sharedStart = await this.waitForNonJoinableStart(options.signal);
     if (sharedStart) {
       logger.info("[IOSCtrlProxy] Start already in progress, waiting for it to complete");
     } else {
@@ -749,6 +735,7 @@ export class IOSCtrlProxyManager implements CtrlProxyIosManager {
         healthPollDeadlineMs: null,
         defaultHealthPollDeadlineMs: null,
         callerHealthPollDeadlinesMs: new Map(),
+        teardownCommitted: false,
         waitingCallers: 0,
         completed: false,
       };
@@ -770,6 +757,26 @@ export class IOSCtrlProxyManager implements CtrlProxyIosManager {
       options.minimumHealthPollDurationMs,
     );
     return this.waitForSharedStart(sharedStart, options.signal, callerId);
+  }
+
+  private async waitForNonJoinableStart(signal: AbortSignal | undefined): Promise<SharedCtrlProxyStart | null> {
+    const sharedStart = this.sharedStart;
+    if (!sharedStart ||
+      (!sharedStart.controller.signal.aborted && !sharedStart.teardownCommitted)) {
+      return sharedStart;
+    }
+    logger.info("[IOSCtrlProxy] Waiting for a non-joinable startup to settle before retrying");
+    try {
+      await this.waitForSharedStart(sharedStart, signal);
+    } catch (error) {
+      if (signal?.aborted) {
+        throw error;
+      }
+    }
+    if (this.sharedStart === sharedStart) {
+      this.sharedStart = null;
+    }
+    return this.sharedStart;
   }
 
   /**
@@ -968,6 +975,7 @@ export class IOSCtrlProxyManager implements CtrlProxyIosManager {
       if (await this.completeHealthStartupIfDeadlineExtended(sharedStart, perf, delayMs)) {
         return;
       }
+      sharedStart.teardownCommitted = true;
       // Suppress the exit-handler auto-restart across the kill + child-exit event only.
       this.isStopping = true;
       try {

--- a/src/utils/IOSCtrlProxyManager.ts
+++ b/src/utils/IOSCtrlProxyManager.ts
@@ -37,11 +37,12 @@ export interface CtrlProxyIosSetupResult extends ProxySetupResult {
 
 export interface CtrlProxyStartOptions {
   /**
-   * Upper bound for health polling after the runner has launched. startDevice
-   * supplies its remaining readiness budget so a fixed manager default cannot
-   * fail a still-starting runner early.
+   * Minimum health-poll duration after the runner has launched. startDevice
+   * supplies its remaining readiness duration so a fixed manager default cannot
+   * fail a still-starting runner early. The caller's AbortSignal is the upper
+   * bound.
    */
-  healthCheckTimeoutMs?: number;
+  minimumHealthPollDurationMs?: number;
   signal?: AbortSignal;
 }
 
@@ -54,7 +55,7 @@ export interface CtrlProxyIosManager extends ProxyManager {
     force?: boolean,
     perf?: PerformanceTracker,
     signal?: AbortSignal,
-    healthCheckTimeoutMs?: number,
+    minimumHealthPollDurationMs?: number,
   ): Promise<CtrlProxyIosSetupResult>;
   isRunning(): Promise<boolean>;
   start(options?: CtrlProxyStartOptions): Promise<void>;
@@ -858,7 +859,7 @@ export class IOSCtrlProxyManager implements CtrlProxyIosManager {
     // coming up, which then triggers a kill+respawn livelock (#2834).
     const delayMs = 500;
     const maxAttempts = IOSCtrlProxyManager.resolveHealthPollMaxAttempts(
-      options.healthCheckTimeoutMs,
+      options.minimumHealthPollDurationMs,
       delayMs,
     );
     const timeoutSeconds = Math.round((maxAttempts * delayMs) / 1000);
@@ -1088,7 +1089,7 @@ export class IOSCtrlProxyManager implements CtrlProxyIosManager {
     force: boolean = false,
     perf: PerformanceTracker = new NoOpPerformanceTracker(),
     signal?: AbortSignal,
-    healthCheckTimeoutMs?: number,
+    minimumHealthPollDurationMs?: number,
   ): Promise<CtrlProxyIosSetupResult> {
     perf.serial("xcTestServiceSetup");
 
@@ -1179,7 +1180,7 @@ export class IOSCtrlProxyManager implements CtrlProxyIosManager {
 
       // Start the service
       await perf.track("startService", () =>
-        this.start({ healthCheckTimeoutMs, signal }),
+        this.start({ minimumHealthPollDurationMs, signal }),
       );
 
       perf.end();
@@ -1587,7 +1588,7 @@ export class IOSCtrlProxyManager implements CtrlProxyIosManager {
    * cold-start routinely exceeds the default) can extend it without a code change.
    */
   private static resolveHealthPollMaxAttempts(
-    healthCheckTimeoutMs?: number,
+    minimumHealthPollDurationMs?: number,
     delayMs: number = 500,
   ): number {
     const raw = process.env.AUTOMOBILE_CTRL_PROXY_HEALTH_MAX_ATTEMPTS
@@ -1599,10 +1600,10 @@ export class IOSCtrlProxyManager implements CtrlProxyIosManager {
         configuredAttempts = parsed;
       }
     }
-    if (!healthCheckTimeoutMs || healthCheckTimeoutMs <= 0) {
+    if (!minimumHealthPollDurationMs || minimumHealthPollDurationMs <= 0) {
       return configuredAttempts;
     }
-    return Math.max(configuredAttempts, Math.ceil(healthCheckTimeoutMs / delayMs));
+    return Math.max(configuredAttempts, Math.ceil(minimumHealthPollDurationMs / delayMs));
   }
 
   private async sleepForHealthPoll(delayMs: number, signal?: AbortSignal): Promise<void> {

--- a/src/utils/IOSCtrlProxyManager.ts
+++ b/src/utils/IOSCtrlProxyManager.ts
@@ -723,11 +723,19 @@ export class IOSCtrlProxyManager implements CtrlProxyIosManager {
 
     let sharedStart = this.sharedStart;
     if (sharedStart?.controller.signal.aborted) {
-      logger.info("[IOSCtrlProxy] Discarding aborted startup before retrying");
-      if (this.sharedStart === sharedStart) {
+      logger.info("[IOSCtrlProxy] Waiting for aborted startup to settle before retrying");
+      const abortedStart = sharedStart;
+      try {
+        await this.waitForSharedStart(abortedStart, options.signal);
+      } catch (error) {
+        if (options.signal?.aborted) {
+          throw error;
+        }
+      }
+      if (this.sharedStart === abortedStart) {
         this.sharedStart = null;
       }
-      sharedStart = null;
+      sharedStart = this.sharedStart;
     }
     if (sharedStart) {
       logger.info("[IOSCtrlProxy] Start already in progress, waiting for it to complete");
@@ -902,43 +910,10 @@ export class IOSCtrlProxyManager implements CtrlProxyIosManager {
       (sharedStart.healthPollDeadlineMs - this.timer.now()) / 1000,
     );
 
-    perf.startOperation("healthPolling");
-    let attempts = 0;
-    for (;;) {
-      if (sharedStart.controller.signal.aborted) {
-        throw sharedStart.controller.signal.reason ?? new Error("iOS CtrlProxy startup was aborted");
-      }
-      attempts++;
-      if (await this.checkHealthEndpoint()) {
-        perf.endOperation("healthPolling");
-        logger.info("[IOSCtrlProxy] HTTP health endpoint is ready");
-        this.clearCaches();
-        await this.startProcessSupervision();
-
-        // Wait additional time for WebSocket server to be ready
-        // The HTTP server can respond before WebSocket is fully initialized
-        logger.info("[IOSCtrlProxy] Waiting for WebSocket server initialization");
-        perf.startOperation("websocketInit");
-        await this.sleepForHealthPoll(500, sharedStart.controller.signal);
-        perf.endOperation("websocketInit");
-
-        if (!this.isSimulator()) {
-          await this.iproxySupervisor.start();
-        }
-        return;
-      }
-      if (attempts > 1 && attempts % 10 === 0) {
-        logger.info(
-          `[IOSCtrlProxy] Still waiting for service... (attempt ${attempts}, ` +
-          `${Math.max(0, sharedStart.healthPollDeadlineMs - this.timer.now())}ms remaining)`,
-        );
-      }
-      if (this.timer.now() + delayMs >= sharedStart.healthPollDeadlineMs) {
-        break;
-      }
-      await this.sleepForHealthPoll(delayMs, sharedStart.controller.signal);
+    if (await this.waitForHealthEndpoint(sharedStart, perf, delayMs)) {
+      await this.completeHealthStartup(sharedStart, perf);
+      return;
     }
-    perf.endOperation("healthPolling");
 
     if (waitedForStartingRunner && this.xcTestProcessId !== null) {
       // Before giving up, adopt the runner if it actually came up healthy on CtrlProxy's
@@ -957,6 +932,9 @@ export class IOSCtrlProxyManager implements CtrlProxyIosManager {
         // Mirror the normal success path's WebSocket-init settle (#2834 review — MINOR-3).
         await this.sleepForHealthPoll(500, sharedStart.controller.signal);
         await this.startProcessSupervision();
+        return;
+      }
+      if (await this.completeHealthStartupIfDeadlineExtended(sharedStart, perf, delayMs)) {
         return;
       }
       // Otherwise it is genuinely hung. Merely un-tracking it is NOT enough: the process
@@ -980,6 +958,9 @@ export class IOSCtrlProxyManager implements CtrlProxyIosManager {
       // pid-match enforcement is tracked as a follow-up.
       const hungPid = this.xcTestProcessId;
       const stillOurs = await this.isOwnRunnerProcessAlive();
+      if (await this.completeHealthStartupIfDeadlineExtended(sharedStart, perf, delayMs)) {
+        return;
+      }
       // Suppress the exit-handler auto-restart across the kill + child-exit event only.
       this.isStopping = true;
       try {
@@ -1033,6 +1014,9 @@ export class IOSCtrlProxyManager implements CtrlProxyIosManager {
     }
 
     const heldProcesses = await this.findListeningProcessesOnPort(this.servicePort);
+    if (await this.completeHealthStartupIfDeadlineExtended(sharedStart, perf, delayMs)) {
+      return;
+    }
     if (heldProcesses.length > 0) {
       throw new Error(
         `CtrlProxy failed to start within timeout (${timeoutSeconds}s); port ${this.servicePort} ` +
@@ -1660,6 +1644,74 @@ export class IOSCtrlProxyManager implements CtrlProxyIosManager {
       sharedStart.healthPollDeadlineMs ?? 0,
       this.timer.now() + minimumHealthPollDurationMs,
     );
+  }
+
+  private async waitForHealthEndpoint(
+    sharedStart: SharedCtrlProxyStart,
+    perf: PerformanceTracker,
+    delayMs: number,
+  ): Promise<boolean> {
+    perf.startOperation("healthPolling");
+    let attempts = 0;
+    for (;;) {
+      if (sharedStart.controller.signal.aborted) {
+        throw sharedStart.controller.signal.reason ?? new Error("iOS CtrlProxy startup was aborted");
+      }
+      attempts++;
+      if (await this.checkHealthEndpoint()) {
+        perf.endOperation("healthPolling");
+        return true;
+      }
+      if (attempts > 1 && attempts % 10 === 0) {
+        logger.info(
+          `[IOSCtrlProxy] Still waiting for service... (attempt ${attempts}, ` +
+          `${Math.max(0, (sharedStart.healthPollDeadlineMs ?? 0) - this.timer.now())}ms remaining)`,
+        );
+      }
+      const remainingPollMs = (sharedStart.healthPollDeadlineMs ?? 0) - this.timer.now();
+      if (remainingPollMs <= 0) {
+        perf.endOperation("healthPolling");
+        return false;
+      }
+      await this.sleepForHealthPoll(
+        Math.min(delayMs, remainingPollMs),
+        sharedStart.controller.signal,
+      );
+    }
+  }
+
+  private async completeHealthStartup(
+    sharedStart: SharedCtrlProxyStart,
+    perf: PerformanceTracker,
+  ): Promise<void> {
+    logger.info("[IOSCtrlProxy] HTTP health endpoint is ready");
+    this.clearCaches();
+    await this.startProcessSupervision();
+
+    // The HTTP server can respond before the WebSocket server is initialized.
+    logger.info("[IOSCtrlProxy] Waiting for WebSocket server initialization");
+    perf.startOperation("websocketInit");
+    await this.sleepForHealthPoll(500, sharedStart.controller.signal);
+    perf.endOperation("websocketInit");
+
+    if (!this.isSimulator()) {
+      await this.iproxySupervisor.start();
+    }
+  }
+
+  private async completeHealthStartupIfDeadlineExtended(
+    sharedStart: SharedCtrlProxyStart,
+    perf: PerformanceTracker,
+    delayMs: number,
+  ): Promise<boolean> {
+    if ((sharedStart.healthPollDeadlineMs ?? 0) <= this.timer.now()) {
+      return false;
+    }
+    if (!await this.waitForHealthEndpoint(sharedStart, perf, delayMs)) {
+      return false;
+    }
+    await this.completeHealthStartup(sharedStart, perf);
+    return true;
   }
 
   private waitForSharedStart(

--- a/src/utils/IOSCtrlProxyManager.ts
+++ b/src/utils/IOSCtrlProxyManager.ts
@@ -51,6 +51,8 @@ interface SharedCtrlProxyStart {
   controller: AbortController;
   completion: Promise<void>;
   healthPollDeadlineMs: number | null;
+  defaultHealthPollDeadlineMs: number | null;
+  callerHealthPollDeadlinesMs: Map<symbol, number>;
   waitingCallers: number;
   completed: boolean;
 }
@@ -739,17 +741,17 @@ export class IOSCtrlProxyManager implements CtrlProxyIosManager {
     }
     if (sharedStart) {
       logger.info("[IOSCtrlProxy] Start already in progress, waiting for it to complete");
-      this.extendHealthPollDeadline(sharedStart, options.minimumHealthPollDurationMs);
     } else {
       const controller = new AbortController();
       const createdStart: SharedCtrlProxyStart = {
         controller,
         completion: Promise.resolve(),
         healthPollDeadlineMs: null,
+        defaultHealthPollDeadlineMs: null,
+        callerHealthPollDeadlinesMs: new Map(),
         waitingCallers: 0,
         completed: false,
       };
-      this.extendHealthPollDeadline(createdStart, options.minimumHealthPollDurationMs);
       this.sharedStart = createdStart;
       createdStart.completion = this.startInternal(createdStart);
       void createdStart.completion.finally(() => {
@@ -761,7 +763,13 @@ export class IOSCtrlProxyManager implements CtrlProxyIosManager {
       sharedStart = createdStart;
     }
 
-    return this.waitForSharedStart(sharedStart, options.signal);
+    const callerId = Symbol("CtrlProxy startup caller");
+    this.extendHealthPollDeadline(
+      sharedStart,
+      callerId,
+      options.minimumHealthPollDurationMs,
+    );
+    return this.waitForSharedStart(sharedStart, options.signal, callerId);
   }
 
   /**
@@ -902,12 +910,11 @@ export class IOSCtrlProxyManager implements CtrlProxyIosManager {
     const delayMs = 500;
     const defaultHealthPollDurationMs =
       IOSCtrlProxyManager.resolveHealthPollMaxAttempts() * delayMs;
-    sharedStart.healthPollDeadlineMs = Math.max(
-      sharedStart.healthPollDeadlineMs ?? 0,
-      this.timer.now() + defaultHealthPollDurationMs,
-    );
+    sharedStart.defaultHealthPollDeadlineMs =
+      this.timer.now() + defaultHealthPollDurationMs;
+    this.refreshHealthPollDeadline(sharedStart);
     const timeoutSeconds = Math.round(
-      (sharedStart.healthPollDeadlineMs - this.timer.now()) / 1000,
+      ((sharedStart.healthPollDeadlineMs ?? 0) - this.timer.now()) / 1000,
     );
 
     if (await this.waitForHealthEndpoint(sharedStart, perf, delayMs)) {
@@ -1635,14 +1642,34 @@ export class IOSCtrlProxyManager implements CtrlProxyIosManager {
 
   private extendHealthPollDeadline(
     sharedStart: SharedCtrlProxyStart,
+    callerId: symbol,
     minimumHealthPollDurationMs: number | undefined,
   ): void {
     if (!minimumHealthPollDurationMs || minimumHealthPollDurationMs <= 0) {
       return;
     }
-    sharedStart.healthPollDeadlineMs = Math.max(
-      sharedStart.healthPollDeadlineMs ?? 0,
+    sharedStart.callerHealthPollDeadlinesMs.set(
+      callerId,
       this.timer.now() + minimumHealthPollDurationMs,
+    );
+    this.refreshHealthPollDeadline(sharedStart);
+  }
+
+  private removeHealthPollDeadline(
+    sharedStart: SharedCtrlProxyStart,
+    callerId: symbol | undefined,
+  ): void {
+    if (!callerId) {
+      return;
+    }
+    sharedStart.callerHealthPollDeadlinesMs.delete(callerId);
+    this.refreshHealthPollDeadline(sharedStart);
+  }
+
+  private refreshHealthPollDeadline(sharedStart: SharedCtrlProxyStart): void {
+    sharedStart.healthPollDeadlineMs = Math.max(
+      sharedStart.defaultHealthPollDeadlineMs ?? 0,
+      ...sharedStart.callerHealthPollDeadlinesMs.values(),
     );
   }
 
@@ -1717,6 +1744,7 @@ export class IOSCtrlProxyManager implements CtrlProxyIosManager {
   private waitForSharedStart(
     sharedStart: SharedCtrlProxyStart,
     signal: AbortSignal | undefined,
+    callerId?: symbol,
   ): Promise<void> {
     sharedStart.waitingCallers++;
     return new Promise<void>((resolve, reject) => {
@@ -1728,6 +1756,7 @@ export class IOSCtrlProxyManager implements CtrlProxyIosManager {
         settled = true;
         signal?.removeEventListener("abort", onAbort);
         sharedStart.waitingCallers--;
+        this.removeHealthPollDeadline(sharedStart, callerId);
         if (!sharedStart.completed && sharedStart.waitingCallers === 0) {
           sharedStart.controller.abort(
             signal?.reason ?? new Error("iOS CtrlProxy startup has no remaining callers"),

--- a/src/utils/IOSCtrlProxyManager.ts
+++ b/src/utils/IOSCtrlProxyManager.ts
@@ -39,11 +39,20 @@ export interface CtrlProxyStartOptions {
   /**
    * Minimum health-poll duration after the runner has launched. startDevice
    * supplies its remaining readiness duration so a fixed manager default cannot
-   * fail a still-starting runner early. The caller's AbortSignal is the upper
-   * bound.
+   * fail a still-starting runner early. A concurrent caller can extend an
+   * in-progress shared startup poll.
    */
   minimumHealthPollDurationMs?: number;
+  /** Cancels only this caller's wait for shared startup. */
   signal?: AbortSignal;
+}
+
+interface SharedCtrlProxyStart {
+  controller: AbortController;
+  completion: Promise<void>;
+  healthPollDeadlineMs: number | null;
+  waitingCallers: number;
+  completed: boolean;
 }
 
 /**
@@ -219,8 +228,8 @@ export class IOSCtrlProxyManager implements CtrlProxyIosManager {
   private iproxyDevicePort: number | null = null;
   private isStopping: boolean = false;
 
-  // Mutex to prevent concurrent start() calls from spawning multiple processes
-  private startPromise: Promise<void> | null = null;
+  // Shared process startup prevents concurrent callers from launching duplicate runners.
+  private sharedStart: SharedCtrlProxyStart | null = null;
 
   // Target app bundle ID for CtrlProxy to observe (instead of SpringBoard)
   private targetBundleId: string | null = null;
@@ -708,24 +717,42 @@ export class IOSCtrlProxyManager implements CtrlProxyIosManager {
    * Start CtrlProxy
    */
   public async start(options: CtrlProxyStartOptions = {}): Promise<void> {
-    // Use mutex to prevent concurrent start() calls from spawning multiple processes
-    if (this.startPromise) {
-      logger.info("[IOSCtrlProxy] Start already in progress, waiting for it to complete");
-      return this.startPromise;
+    if (options.signal?.aborted) {
+      throw options.signal.reason ?? new Error("iOS CtrlProxy startup was aborted");
     }
 
-    this.startPromise = this.startInternal(options);
-    try {
-      await this.startPromise;
-    } finally {
-      this.startPromise = null;
+    let sharedStart = this.sharedStart;
+    if (sharedStart) {
+      logger.info("[IOSCtrlProxy] Start already in progress, waiting for it to complete");
+      this.extendHealthPollDeadline(sharedStart, options.minimumHealthPollDurationMs);
+    } else {
+      const controller = new AbortController();
+      const createdStart: SharedCtrlProxyStart = {
+        controller,
+        completion: Promise.resolve(),
+        healthPollDeadlineMs: null,
+        waitingCallers: 0,
+        completed: false,
+      };
+      this.extendHealthPollDeadline(createdStart, options.minimumHealthPollDurationMs);
+      this.sharedStart = createdStart;
+      createdStart.completion = this.startInternal(createdStart);
+      void createdStart.completion.finally(() => {
+        createdStart.completed = true;
+        if (this.sharedStart === createdStart) {
+          this.sharedStart = null;
+        }
+      }).catch(() => {});
+      sharedStart = createdStart;
     }
+
+    return this.waitForSharedStart(sharedStart, options.signal);
   }
 
   /**
    * Internal start implementation (called within mutex)
    */
-  private async startInternal(options: CtrlProxyStartOptions): Promise<void> {
+  private async startInternal(sharedStart: SharedCtrlProxyStart): Promise<void> {
     // Authoritative fail-closed gate (#4221): this is the single chokepoint every
     // launch path funnels through (startDevice, session-reuse in toolRegistry, and
     // discovery-pooled devices that never hit verifyIosDevice/ensureCtrlProxyReady).
@@ -858,14 +885,23 @@ export class IOSCtrlProxyManager implements CtrlProxyIosManager {
     // generous — too short a budget declares failure while the runner is still
     // coming up, which then triggers a kill+respawn livelock (#2834).
     const delayMs = 500;
-    const maxAttempts = IOSCtrlProxyManager.resolveHealthPollMaxAttempts(
-      options.minimumHealthPollDurationMs,
-      delayMs,
+    const defaultHealthPollDurationMs =
+      IOSCtrlProxyManager.resolveHealthPollMaxAttempts() * delayMs;
+    sharedStart.healthPollDeadlineMs = Math.max(
+      sharedStart.healthPollDeadlineMs ?? 0,
+      this.timer.now() + defaultHealthPollDurationMs,
     );
-    const timeoutSeconds = Math.round((maxAttempts * delayMs) / 1000);
+    const timeoutSeconds = Math.round(
+      (sharedStart.healthPollDeadlineMs - this.timer.now()) / 1000,
+    );
 
     perf.startOperation("healthPolling");
-    for (let i = 0; i < maxAttempts; i++) {
+    let attempts = 0;
+    for (;;) {
+      if (sharedStart.controller.signal.aborted) {
+        throw sharedStart.controller.signal.reason ?? new Error("iOS CtrlProxy startup was aborted");
+      }
+      attempts++;
       if (await this.checkHealthEndpoint()) {
         perf.endOperation("healthPolling");
         logger.info("[IOSCtrlProxy] HTTP health endpoint is ready");
@@ -876,7 +912,7 @@ export class IOSCtrlProxyManager implements CtrlProxyIosManager {
         // The HTTP server can respond before WebSocket is fully initialized
         logger.info("[IOSCtrlProxy] Waiting for WebSocket server initialization");
         perf.startOperation("websocketInit");
-        await this.sleepForHealthPoll(500, options.signal);
+        await this.sleepForHealthPoll(500, sharedStart.controller.signal);
         perf.endOperation("websocketInit");
 
         if (!this.isSimulator()) {
@@ -884,10 +920,16 @@ export class IOSCtrlProxyManager implements CtrlProxyIosManager {
         }
         return;
       }
-      if (i > 0 && i % 10 === 0) {
-        logger.info(`[IOSCtrlProxy] Still waiting for service... (attempt ${i}/${maxAttempts})`);
+      if (attempts > 1 && attempts % 10 === 0) {
+        logger.info(
+          `[IOSCtrlProxy] Still waiting for service... (attempt ${attempts}, ` +
+          `${Math.max(0, sharedStart.healthPollDeadlineMs - this.timer.now())}ms remaining)`,
+        );
       }
-      await this.sleepForHealthPoll(delayMs, options.signal);
+      if (this.timer.now() + delayMs >= sharedStart.healthPollDeadlineMs) {
+        break;
+      }
+      await this.sleepForHealthPoll(delayMs, sharedStart.controller.signal);
     }
     perf.endOperation("healthPolling");
 
@@ -906,7 +948,7 @@ export class IOSCtrlProxyManager implements CtrlProxyIosManager {
         this.adoptServicePort(IOSCtrlProxyManager.DEFAULT_PORT);
         this.clearCaches();
         // Mirror the normal success path's WebSocket-init settle (#2834 review — MINOR-3).
-        await this.sleepForHealthPoll(500, options.signal);
+        await this.sleepForHealthPoll(500, sharedStart.controller.signal);
         await this.startProcessSupervision();
         return;
       }
@@ -1587,10 +1629,7 @@ export class IOSCtrlProxyManager implements CtrlProxyIosManager {
    * Resolve the health-poll attempt budget. Env-overridable so CI (where XCUITest
    * cold-start routinely exceeds the default) can extend it without a code change.
    */
-  private static resolveHealthPollMaxAttempts(
-    minimumHealthPollDurationMs?: number,
-    delayMs: number = 500,
-  ): number {
+  private static resolveHealthPollMaxAttempts(): number {
     const raw = process.env.AUTOMOBILE_CTRL_PROXY_HEALTH_MAX_ATTEMPTS
       ?? process.env.AUTO_MOBILE_CTRL_PROXY_HEALTH_MAX_ATTEMPTS;
     let configuredAttempts = IOSCtrlProxyManager.DEFAULT_HEALTH_POLL_MAX_ATTEMPTS;
@@ -1600,10 +1639,57 @@ export class IOSCtrlProxyManager implements CtrlProxyIosManager {
         configuredAttempts = parsed;
       }
     }
+    return configuredAttempts;
+  }
+
+  private extendHealthPollDeadline(
+    sharedStart: SharedCtrlProxyStart,
+    minimumHealthPollDurationMs: number | undefined,
+  ): void {
     if (!minimumHealthPollDurationMs || minimumHealthPollDurationMs <= 0) {
-      return configuredAttempts;
+      return;
     }
-    return Math.max(configuredAttempts, Math.ceil(minimumHealthPollDurationMs / delayMs));
+    sharedStart.healthPollDeadlineMs = Math.max(
+      sharedStart.healthPollDeadlineMs ?? 0,
+      this.timer.now() + minimumHealthPollDurationMs,
+    );
+  }
+
+  private waitForSharedStart(
+    sharedStart: SharedCtrlProxyStart,
+    signal: AbortSignal | undefined,
+  ): Promise<void> {
+    sharedStart.waitingCallers++;
+    return new Promise<void>((resolve, reject) => {
+      let settled = false;
+      const settle = (callback: () => void) => {
+        if (settled) {
+          return;
+        }
+        settled = true;
+        signal?.removeEventListener("abort", onAbort);
+        sharedStart.waitingCallers--;
+        if (!sharedStart.completed && sharedStart.waitingCallers === 0) {
+          sharedStart.controller.abort(
+            signal?.reason ?? new Error("iOS CtrlProxy startup has no remaining callers"),
+          );
+        }
+        callback();
+      };
+      const onAbort = () => settle(() => {
+        reject(signal?.reason ?? new Error("iOS CtrlProxy startup was aborted"));
+      });
+
+      if (signal?.aborted) {
+        onAbort();
+        return;
+      }
+      signal?.addEventListener("abort", onAbort, { once: true });
+      void sharedStart.completion.then(
+        () => settle(resolve),
+        (error) => settle(() => reject(error)),
+      );
+    });
   }
 
   private async sleepForHealthPoll(delayMs: number, signal?: AbortSignal): Promise<void> {

--- a/src/utils/IOSCtrlProxyManager.ts
+++ b/src/utils/IOSCtrlProxyManager.ts
@@ -722,6 +722,13 @@ export class IOSCtrlProxyManager implements CtrlProxyIosManager {
     }
 
     let sharedStart = this.sharedStart;
+    if (sharedStart?.controller.signal.aborted) {
+      logger.info("[IOSCtrlProxy] Discarding aborted startup before retrying");
+      if (this.sharedStart === sharedStart) {
+        this.sharedStart = null;
+      }
+      sharedStart = null;
+    }
     if (sharedStart) {
       logger.info("[IOSCtrlProxy] Start already in progress, waiting for it to complete");
       this.extendHealthPollDeadline(sharedStart, options.minimumHealthPollDurationMs);

--- a/src/utils/IOSCtrlProxyManager.ts
+++ b/src/utils/IOSCtrlProxyManager.ts
@@ -35,14 +35,29 @@ export interface CtrlProxyIosSetupResult extends ProxySetupResult {
   buildResult?: CtrlProxyIosBuildResult;
 }
 
+export interface CtrlProxyStartOptions {
+  /**
+   * Upper bound for health polling after the runner has launched. startDevice
+   * supplies its remaining readiness budget so a fixed manager default cannot
+   * fail a still-starting runner early.
+   */
+  healthCheckTimeoutMs?: number;
+  signal?: AbortSignal;
+}
+
 /**
  * iOS-specific runner process lifecycle, extending the platform-agnostic
  * {@link ProxyManager}.
  */
 export interface CtrlProxyIosManager extends ProxyManager {
-  setup(force?: boolean, perf?: PerformanceTracker): Promise<CtrlProxyIosSetupResult>;
+  setup(
+    force?: boolean,
+    perf?: PerformanceTracker,
+    signal?: AbortSignal,
+    healthCheckTimeoutMs?: number,
+  ): Promise<CtrlProxyIosSetupResult>;
   isRunning(): Promise<boolean>;
-  start(): Promise<void>;
+  start(options?: CtrlProxyStartOptions): Promise<void>;
   stop(): Promise<void>;
   getServicePort(): number;
   getReportedRunnerPort(): Promise<number | null>;
@@ -691,14 +706,14 @@ export class IOSCtrlProxyManager implements CtrlProxyIosManager {
   /**
    * Start CtrlProxy
    */
-  public async start(): Promise<void> {
+  public async start(options: CtrlProxyStartOptions = {}): Promise<void> {
     // Use mutex to prevent concurrent start() calls from spawning multiple processes
     if (this.startPromise) {
       logger.info("[IOSCtrlProxy] Start already in progress, waiting for it to complete");
       return this.startPromise;
     }
 
-    this.startPromise = this.startInternal();
+    this.startPromise = this.startInternal(options);
     try {
       await this.startPromise;
     } finally {
@@ -709,7 +724,7 @@ export class IOSCtrlProxyManager implements CtrlProxyIosManager {
   /**
    * Internal start implementation (called within mutex)
    */
-  private async startInternal(): Promise<void> {
+  private async startInternal(options: CtrlProxyStartOptions): Promise<void> {
     // Authoritative fail-closed gate (#4221): this is the single chokepoint every
     // launch path funnels through (startDevice, session-reuse in toolRegistry, and
     // discovery-pooled devices that never hit verifyIosDevice/ensureCtrlProxyReady).
@@ -842,7 +857,10 @@ export class IOSCtrlProxyManager implements CtrlProxyIosManager {
     // generous — too short a budget declares failure while the runner is still
     // coming up, which then triggers a kill+respawn livelock (#2834).
     const delayMs = 500;
-    const maxAttempts = IOSCtrlProxyManager.resolveHealthPollMaxAttempts();
+    const maxAttempts = IOSCtrlProxyManager.resolveHealthPollMaxAttempts(
+      options.healthCheckTimeoutMs,
+      delayMs,
+    );
     const timeoutSeconds = Math.round((maxAttempts * delayMs) / 1000);
 
     perf.startOperation("healthPolling");
@@ -857,7 +875,7 @@ export class IOSCtrlProxyManager implements CtrlProxyIosManager {
         // The HTTP server can respond before WebSocket is fully initialized
         logger.info("[IOSCtrlProxy] Waiting for WebSocket server initialization");
         perf.startOperation("websocketInit");
-        await this.timer.sleep(500);
+        await this.sleepForHealthPoll(500, options.signal);
         perf.endOperation("websocketInit");
 
         if (!this.isSimulator()) {
@@ -868,7 +886,7 @@ export class IOSCtrlProxyManager implements CtrlProxyIosManager {
       if (i > 0 && i % 10 === 0) {
         logger.info(`[IOSCtrlProxy] Still waiting for service... (attempt ${i}/${maxAttempts})`);
       }
-      await this.timer.sleep(delayMs);
+      await this.sleepForHealthPoll(delayMs, options.signal);
     }
     perf.endOperation("healthPolling");
 
@@ -887,7 +905,7 @@ export class IOSCtrlProxyManager implements CtrlProxyIosManager {
         this.adoptServicePort(IOSCtrlProxyManager.DEFAULT_PORT);
         this.clearCaches();
         // Mirror the normal success path's WebSocket-init settle (#2834 review — MINOR-3).
-        await this.timer.sleep(500);
+        await this.sleepForHealthPoll(500, options.signal);
         await this.startProcessSupervision();
         return;
       }
@@ -1068,7 +1086,9 @@ export class IOSCtrlProxyManager implements CtrlProxyIosManager {
 
   public async setup(
     force: boolean = false,
-    perf: PerformanceTracker = new NoOpPerformanceTracker()
+    perf: PerformanceTracker = new NoOpPerformanceTracker(),
+    signal?: AbortSignal,
+    healthCheckTimeoutMs?: number,
   ): Promise<CtrlProxyIosSetupResult> {
     perf.serial("xcTestServiceSetup");
 
@@ -1158,7 +1178,9 @@ export class IOSCtrlProxyManager implements CtrlProxyIosManager {
       }
 
       // Start the service
-      await perf.track("startService", () => this.start());
+      await perf.track("startService", () =>
+        this.start({ healthCheckTimeoutMs, signal }),
+      );
 
       perf.end();
       return {
@@ -1564,16 +1586,52 @@ export class IOSCtrlProxyManager implements CtrlProxyIosManager {
    * Resolve the health-poll attempt budget. Env-overridable so CI (where XCUITest
    * cold-start routinely exceeds the default) can extend it without a code change.
    */
-  private static resolveHealthPollMaxAttempts(): number {
+  private static resolveHealthPollMaxAttempts(
+    healthCheckTimeoutMs?: number,
+    delayMs: number = 500,
+  ): number {
     const raw = process.env.AUTOMOBILE_CTRL_PROXY_HEALTH_MAX_ATTEMPTS
       ?? process.env.AUTO_MOBILE_CTRL_PROXY_HEALTH_MAX_ATTEMPTS;
+    let configuredAttempts = IOSCtrlProxyManager.DEFAULT_HEALTH_POLL_MAX_ATTEMPTS;
     if (raw !== undefined) {
       const parsed = Number.parseInt(raw, 10);
       if (Number.isFinite(parsed) && parsed > 0) {
-        return parsed;
+        configuredAttempts = parsed;
       }
     }
-    return IOSCtrlProxyManager.DEFAULT_HEALTH_POLL_MAX_ATTEMPTS;
+    if (!healthCheckTimeoutMs || healthCheckTimeoutMs <= 0) {
+      return configuredAttempts;
+    }
+    return Math.max(configuredAttempts, Math.ceil(healthCheckTimeoutMs / delayMs));
+  }
+
+  private async sleepForHealthPoll(delayMs: number, signal?: AbortSignal): Promise<void> {
+    if (!signal) {
+      await this.timer.sleep(delayMs);
+      return;
+    }
+    if (signal.aborted) {
+      throw signal.reason ?? new Error("iOS CtrlProxy startup was aborted");
+    }
+    await new Promise<void>((resolve, reject) => {
+      let settled = false;
+      const settle = (callback: () => void) => {
+        if (settled) {
+          return;
+        }
+        settled = true;
+        signal.removeEventListener("abort", onAbort);
+        callback();
+      };
+      const onAbort = () => settle(() => {
+        reject(signal.reason ?? new Error("iOS CtrlProxy startup was aborted"));
+      });
+      signal.addEventListener("abort", onAbort, { once: true });
+      void this.timer.sleep(delayMs).then(
+        () => settle(resolve),
+        (error) => settle(() => reject(error)),
+      );
+    });
   }
 
   /**

--- a/src/utils/RunnerReadinessService.ts
+++ b/src/utils/RunnerReadinessService.ts
@@ -61,13 +61,13 @@ export interface ReadinessIosManager {
   isInstalled(): Promise<boolean>;
   start(options?: {
     signal?: AbortSignal;
-    healthCheckTimeoutMs?: number;
+    minimumHealthPollDurationMs?: number;
   }): Promise<void>;
   setup(
     force?: boolean,
     perf?: PerformanceTracker,
     signal?: AbortSignal,
-    healthCheckTimeoutMs?: number,
+    minimumHealthPollDurationMs?: number,
   ): Promise<ProxySetupResult>;
   getServicePort(): number;
 }
@@ -421,7 +421,7 @@ export class RunnerReadinessService {
     await this.runPhase(context, "runner-setup", 1, (signal) =>
       manager.start({
         signal,
-        healthCheckTimeoutMs: this.remaining(context),
+        minimumHealthPollDurationMs: this.remaining(context),
       }),
     );
     await this.waitForResponsiveClient(context, client);

--- a/src/utils/RunnerReadinessService.ts
+++ b/src/utils/RunnerReadinessService.ts
@@ -59,11 +59,15 @@ export interface ReadinessAndroidManager {
 
 export interface ReadinessIosManager {
   isInstalled(): Promise<boolean>;
-  start(): Promise<void>;
+  start(options?: {
+    signal?: AbortSignal;
+    healthCheckTimeoutMs?: number;
+  }): Promise<void>;
   setup(
     force?: boolean,
     perf?: PerformanceTracker,
     signal?: AbortSignal,
+    healthCheckTimeoutMs?: number,
   ): Promise<ProxySetupResult>;
   getServicePort(): number;
 }
@@ -392,7 +396,7 @@ export class RunnerReadinessService {
     }
 
     const setup = await this.runPhase(context, "runner-setup", 1, (signal) =>
-      manager.setup(false, context.perf, signal),
+      manager.setup(false, context.perf, signal, this.remaining(context)),
     );
     if (!setup.success) {
       this.fail(context, "runner-setup", 1, setup.error ?? setup.message);
@@ -414,7 +418,12 @@ export class RunnerReadinessService {
         "CtrlProxy iOS runner is not installed and runner downloads are disabled",
       );
     }
-    await this.runPhase(context, "runner-setup", 1, () => manager.start());
+    await this.runPhase(context, "runner-setup", 1, (signal) =>
+      manager.start({
+        signal,
+        healthCheckTimeoutMs: this.remaining(context),
+      }),
+    );
     await this.waitForResponsiveClient(context, client);
   }
 

--- a/test/utils/IOSCtrlProxyManager.test.ts
+++ b/test/utils/IOSCtrlProxyManager.test.ts
@@ -1054,7 +1054,7 @@ describe("IOSCtrlProxyManager", function() {
         if (curlCalls === 3) {
           return firstHealthPoll;
         }
-        return createExecResult(curlCalls >= 6 ? "ok" : "", "");
+        return createExecResult(curlCalls >= 7 ? "ok" : "", "");
       });
 
       await withHealthBudget("3", async () => {
@@ -1071,7 +1071,7 @@ describe("IOSCtrlProxyManager", function() {
         await Promise.all([defaultStart, readinessStart]);
       });
 
-      expect(curlCalls).toBe(6);
+      expect(curlCalls).toBe(7);
       expect(fakeExecutor.getSpawnedProcesses()).toHaveLength(0);
     });
 
@@ -1146,6 +1146,48 @@ describe("IOSCtrlProxyManager", function() {
 
       expect(curlCalls).toBe(4);
       expect(fakeExecutor.getSpawnedProcesses()).toHaveLength(0);
+    });
+
+    test("a caller arriving during hung-runner teardown starts fresh after it settles", async function() {
+      const manager = IOSCtrlProxyManager.createForTestingWithDeps(
+        testDevice, fakeTimer, createFakeBuilder(), fakeExecutor
+      );
+      (manager as unknown as { xcTestProcessId: number }).xcTestProcessId = 12345;
+      installListeningProcessFakes(fakeExecutor, [ownRunnerProcess(12345)]);
+
+      let healthyAfterTeardown = false;
+      fakeExecutor.setCommandHandler("curl -s", () =>
+        createExecResult(healthyAfterTeardown ? "ok" : "", "")
+      );
+
+      const teardownEntered = deferred();
+      const releaseTeardown = deferred();
+      const processClient = (manager as unknown as {
+        processClient: IOSCtrlProxyProcessClient;
+      }).processClient;
+      const terminateProcessTree = processClient.terminateProcessTree.bind(processClient);
+      processClient.terminateProcessTree = async pid => {
+        teardownEntered.resolve();
+        await releaseTeardown.promise;
+        await terminateProcessTree(pid);
+      };
+
+      await withHealthBudget("1", async () => {
+        fakeTimer.enableAutoAdvance();
+        const originalStart = manager.start();
+        await teardownEntered.promise;
+
+        const retryStart = manager.start({ minimumHealthPollDurationMs: 2_000 });
+        await new Promise(resolve => setImmediate(resolve));
+        expect(fakeExecutor.getSpawnedProcesses()).toHaveLength(0);
+
+        releaseTeardown.resolve();
+        await expect(originalStart).rejects.toThrow("CtrlProxy failed to start within timeout");
+        healthyAfterTeardown = true;
+        await retryStart;
+      });
+
+      expect(fakeExecutor.getSpawnedProcesses()).toHaveLength(1);
     });
 
     test("a retry starts fresh after the prior sole caller aborts", async function() {

--- a/test/utils/IOSCtrlProxyManager.test.ts
+++ b/test/utils/IOSCtrlProxyManager.test.ts
@@ -1016,6 +1016,27 @@ describe("IOSCtrlProxyManager", function() {
       expect((manager as unknown as { xcTestProcessId: number | null }).xcTestProcessId).toBe(12345);
     });
 
+    test("start() honors a caller readiness budget beyond the configured health-poll default", async function() {
+      const manager = IOSCtrlProxyManager.createForTestingWithDeps(
+        testDevice, fakeTimer, undefined, fakeExecutor
+      );
+      (manager as unknown as { xcTestProcessId: number }).xcTestProcessId = 12345;
+      installListeningProcessFakes(fakeExecutor, [ownRunnerProcess(12345)]);
+
+      let curlCalls = 0;
+      fakeExecutor.setCommandHandler("curl -s", () => {
+        curlCalls++;
+        return createExecResult(curlCalls > 4 ? "ok" : "", "");
+      });
+
+      await withHealthBudget("3", async () => {
+        fakeTimer.enableAutoAdvance();
+        await manager.start({ healthCheckTimeoutMs: 2_000 });
+      });
+
+      expect(curlCalls).toBe(5);
+    });
+
     // Directly exercise the PID-reuse guard added in review (thread 2). Testing the
     // predicate rather than a full start() keeps it precise and avoids spawning a
     // runner (whose background monitor would leak into later tests under autoAdvance).

--- a/test/utils/IOSCtrlProxyManager.test.ts
+++ b/test/utils/IOSCtrlProxyManager.test.ts
@@ -1037,6 +1037,73 @@ describe("IOSCtrlProxyManager", function() {
       expect(curlCalls).toBe(6);
     });
 
+    test("joining readiness caller extends a default startup poll without spawning another runner", async function() {
+      const manager = IOSCtrlProxyManager.createForTestingWithDeps(
+        testDevice, fakeTimer, undefined, fakeExecutor
+      );
+      (manager as unknown as { xcTestProcessId: number }).xcTestProcessId = 12345;
+      installListeningProcessFakes(fakeExecutor, [ownRunnerProcess(12345)]);
+
+      let curlCalls = 0;
+      let releaseFirstHealthPoll: ((result: ExecResult) => void) | undefined;
+      const firstHealthPoll = new Promise<ExecResult>((resolve) => {
+        releaseFirstHealthPoll = resolve;
+      });
+      fakeExecutor.setCommandHandler("curl -s", () => {
+        curlCalls++;
+        if (curlCalls === 3) {
+          return firstHealthPoll;
+        }
+        return createExecResult(curlCalls >= 6 ? "ok" : "", "");
+      });
+
+      await withHealthBudget("3", async () => {
+        fakeTimer.enableAutoAdvance();
+        const defaultStart = manager.start();
+        for (let i = 0; i < 5 && !releaseFirstHealthPoll; i++) {
+          await new Promise(resolve => setImmediate(resolve));
+        }
+        expect(releaseFirstHealthPoll).toBeDefined();
+
+        const readinessStart = manager.start({ minimumHealthPollDurationMs: 2_000 });
+        releaseFirstHealthPoll!(createExecResult("", ""));
+
+        await Promise.all([defaultStart, readinessStart]);
+      });
+
+      expect(curlCalls).toBe(6);
+      expect(fakeExecutor.getSpawnedProcesses()).toHaveLength(0);
+    });
+
+    test("an aborted caller does not cancel an independent shared-start waiter", async function() {
+      const manager = IOSCtrlProxyManager.createForTestingWithDeps(
+        testDevice, fakeTimer, undefined, fakeExecutor
+      );
+      (manager as unknown as { xcTestProcessId: number }).xcTestProcessId = 12345;
+      installListeningProcessFakes(fakeExecutor, [ownRunnerProcess(12345)]);
+
+      let curlCalls = 0;
+      fakeExecutor.setCommandHandler("curl -s", () => {
+        curlCalls++;
+        return createExecResult(curlCalls >= 6 ? "ok" : "", "");
+      });
+
+      await withHealthBudget("3", async () => {
+        fakeTimer.enableAutoAdvance();
+        const controller = new AbortController();
+        const abortedStart = manager.start({ signal: controller.signal });
+        const independentStart = manager.start({ minimumHealthPollDurationMs: 2_000 });
+
+        controller.abort(new Error("caller cancelled"));
+
+        await expect(abortedStart).rejects.toThrow("caller cancelled");
+        await independentStart;
+      });
+
+      expect(curlCalls).toBe(6);
+      expect(fakeExecutor.getSpawnedProcesses()).toHaveLength(0);
+    });
+
     // Directly exercise the PID-reuse guard added in review (thread 2). Testing the
     // predicate rather than a full start() keeps it precise and avoids spawning a
     // runner (whose background monitor would leak into later tests under autoAdvance).

--- a/test/utils/IOSCtrlProxyManager.test.ts
+++ b/test/utils/IOSCtrlProxyManager.test.ts
@@ -1026,7 +1026,7 @@ describe("IOSCtrlProxyManager", function() {
       let curlCalls = 0;
       fakeExecutor.setCommandHandler("curl -s", () => {
         curlCalls++;
-        return createExecResult(curlCalls > 4 ? "ok" : "", "");
+        return createExecResult(curlCalls > 5 ? "ok" : "", "");
       });
 
       await withHealthBudget("3", async () => {
@@ -1034,7 +1034,7 @@ describe("IOSCtrlProxyManager", function() {
         await manager.start({ healthCheckTimeoutMs: 2_000 });
       });
 
-      expect(curlCalls).toBe(5);
+      expect(curlCalls).toBe(6);
     });
 
     // Directly exercise the PID-reuse guard added in review (thread 2). Testing the

--- a/test/utils/IOSCtrlProxyManager.test.ts
+++ b/test/utils/IOSCtrlProxyManager.test.ts
@@ -1031,7 +1031,7 @@ describe("IOSCtrlProxyManager", function() {
 
       await withHealthBudget("3", async () => {
         fakeTimer.enableAutoAdvance();
-        await manager.start({ healthCheckTimeoutMs: 2_000 });
+        await manager.start({ minimumHealthPollDurationMs: 2_000 });
       });
 
       expect(curlCalls).toBe(6);

--- a/test/utils/IOSCtrlProxyManager.test.ts
+++ b/test/utils/IOSCtrlProxyManager.test.ts
@@ -1104,6 +1104,50 @@ describe("IOSCtrlProxyManager", function() {
       expect(fakeExecutor.getSpawnedProcesses()).toHaveLength(0);
     });
 
+    test("an aborted caller removes its readiness extension from a shared startup", async function() {
+      const manager = IOSCtrlProxyManager.createForTestingWithDeps(
+        testDevice, fakeTimer, undefined, fakeExecutor
+      );
+      (manager as unknown as { xcTestProcessId: number }).xcTestProcessId = 12345;
+      installListeningProcessFakes(fakeExecutor, [ownRunnerProcess(12345)]);
+
+      let curlCalls = 0;
+      let releaseFirstHealthPoll: ((result: ExecResult) => void) | undefined;
+      const firstHealthPoll = new Promise<ExecResult>((resolve) => {
+        releaseFirstHealthPoll = resolve;
+      });
+      fakeExecutor.setCommandHandler("curl -s", () => {
+        curlCalls++;
+        if (curlCalls === 3) {
+          return firstHealthPoll;
+        }
+        return createExecResult(curlCalls >= 5 ? "ok" : "", "");
+      });
+
+      await withHealthBudget("1", async () => {
+        fakeTimer.enableAutoAdvance();
+        const defaultStart = manager.start();
+        for (let i = 0; i < 5 && curlCalls < 3; i++) {
+          await new Promise(resolve => setImmediate(resolve));
+        }
+        expect(curlCalls).toBe(3);
+
+        const controller = new AbortController();
+        const extendedStart = manager.start({
+          minimumHealthPollDurationMs: 2_000,
+          signal: controller.signal,
+        });
+        controller.abort(new Error("caller cancelled"));
+        await expect(extendedStart).rejects.toThrow("caller cancelled");
+
+        releaseFirstHealthPoll!(createExecResult("", ""));
+        await expect(defaultStart).rejects.toThrow("CtrlProxy failed to start within timeout");
+      });
+
+      expect(curlCalls).toBe(4);
+      expect(fakeExecutor.getSpawnedProcesses()).toHaveLength(0);
+    });
+
     test("a retry starts fresh after the prior sole caller aborts", async function() {
       const manager = IOSCtrlProxyManager.createForTestingWithDeps(
         testDevice, fakeTimer, undefined, fakeExecutor

--- a/test/utils/IOSCtrlProxyManager.test.ts
+++ b/test/utils/IOSCtrlProxyManager.test.ts
@@ -1026,7 +1026,7 @@ describe("IOSCtrlProxyManager", function() {
       let curlCalls = 0;
       fakeExecutor.setCommandHandler("curl -s", () => {
         curlCalls++;
-        return createExecResult(curlCalls > 5 ? "ok" : "", "");
+        return createExecResult(curlCalls > 6 ? "ok" : "", "");
       });
 
       await withHealthBudget("3", async () => {
@@ -1034,7 +1034,7 @@ describe("IOSCtrlProxyManager", function() {
         await manager.start({ minimumHealthPollDurationMs: 2_000 });
       });
 
-      expect(curlCalls).toBe(6);
+      expect(curlCalls).toBe(7);
     });
 
     test("joining readiness caller extends a default startup poll without spawning another runner", async function() {
@@ -1060,10 +1060,10 @@ describe("IOSCtrlProxyManager", function() {
       await withHealthBudget("3", async () => {
         fakeTimer.enableAutoAdvance();
         const defaultStart = manager.start();
-        for (let i = 0; i < 5 && !releaseFirstHealthPoll; i++) {
+        for (let i = 0; i < 5 && curlCalls < 3; i++) {
           await new Promise(resolve => setImmediate(resolve));
         }
-        expect(releaseFirstHealthPoll).toBeDefined();
+        expect(curlCalls).toBe(3);
 
         const readinessStart = manager.start({ minimumHealthPollDurationMs: 2_000 });
         releaseFirstHealthPoll!(createExecResult("", ""));
@@ -1118,7 +1118,7 @@ describe("IOSCtrlProxyManager", function() {
       });
       fakeExecutor.setCommandHandler("curl -s", () => {
         curlCalls++;
-        if (curlCalls === 3) {
+        if (curlCalls === 1) {
           return firstHealthPoll;
         }
         return createExecResult("ok", "");
@@ -1126,15 +1126,17 @@ describe("IOSCtrlProxyManager", function() {
 
       const controller = new AbortController();
       const abortedStart = manager.start({ signal: controller.signal });
-      for (let i = 0; i < 5 && !releaseFirstHealthPoll; i++) {
+      for (let i = 0; i < 5 && curlCalls < 1; i++) {
         await new Promise(resolve => setImmediate(resolve));
       }
-      expect(releaseFirstHealthPoll).toBeDefined();
+      expect(curlCalls).toBe(1);
 
       controller.abort(new Error("caller cancelled"));
       await expect(abortedStart).rejects.toThrow("caller cancelled");
 
       const retry = manager.start();
+      await new Promise(resolve => setImmediate(resolve));
+      expect(curlCalls).toBe(1);
       releaseFirstHealthPoll!(createExecResult("", ""));
       await retry;
 

--- a/test/utils/IOSCtrlProxyManager.test.ts
+++ b/test/utils/IOSCtrlProxyManager.test.ts
@@ -1104,6 +1104,43 @@ describe("IOSCtrlProxyManager", function() {
       expect(fakeExecutor.getSpawnedProcesses()).toHaveLength(0);
     });
 
+    test("a retry starts fresh after the prior sole caller aborts", async function() {
+      const manager = IOSCtrlProxyManager.createForTestingWithDeps(
+        testDevice, fakeTimer, undefined, fakeExecutor
+      );
+      (manager as unknown as { xcTestProcessId: number }).xcTestProcessId = 12345;
+      installListeningProcessFakes(fakeExecutor, [ownRunnerProcess(12345)]);
+
+      let curlCalls = 0;
+      let releaseFirstHealthPoll: ((result: ExecResult) => void) | undefined;
+      const firstHealthPoll = new Promise<ExecResult>((resolve) => {
+        releaseFirstHealthPoll = resolve;
+      });
+      fakeExecutor.setCommandHandler("curl -s", () => {
+        curlCalls++;
+        if (curlCalls === 3) {
+          return firstHealthPoll;
+        }
+        return createExecResult("ok", "");
+      });
+
+      const controller = new AbortController();
+      const abortedStart = manager.start({ signal: controller.signal });
+      for (let i = 0; i < 5 && !releaseFirstHealthPoll; i++) {
+        await new Promise(resolve => setImmediate(resolve));
+      }
+      expect(releaseFirstHealthPoll).toBeDefined();
+
+      controller.abort(new Error("caller cancelled"));
+      await expect(abortedStart).rejects.toThrow("caller cancelled");
+
+      const retry = manager.start();
+      releaseFirstHealthPoll!(createExecResult("", ""));
+      await retry;
+
+      expect(fakeExecutor.getSpawnedProcesses()).toHaveLength(0);
+    });
+
     // Directly exercise the PID-reuse guard added in review (thread 2). Testing the
     // predicate rather than a full start() keeps it precise and avoids spawning a
     // runner (whose background monitor would leak into later tests under autoAdvance).

--- a/test/utils/RunnerReadinessService.test.ts
+++ b/test/utils/RunnerReadinessService.test.ts
@@ -91,14 +91,14 @@ class FakeIosManager implements ReadinessIosManager {
   setupCalls = 0;
   startCalls = 0;
   setupSignal: AbortSignal | undefined;
-  setupHealthCheckTimeoutMs: number | undefined;
-  startOptions: { signal?: AbortSignal; healthCheckTimeoutMs?: number } | undefined;
+  setupMinimumHealthPollDurationMs: number | undefined;
+  startOptions: { signal?: AbortSignal; minimumHealthPollDurationMs?: number } | undefined;
 
   async isInstalled(): Promise<boolean> {
     return this.installed;
   }
 
-  async start(options?: { signal?: AbortSignal; healthCheckTimeoutMs?: number }): Promise<void> {
+  async start(options?: { signal?: AbortSignal; minimumHealthPollDurationMs?: number }): Promise<void> {
     this.startCalls++;
     this.startOptions = options;
   }
@@ -107,11 +107,11 @@ class FakeIosManager implements ReadinessIosManager {
     _force?: boolean,
     _perf?: unknown,
     signal?: AbortSignal,
-    healthCheckTimeoutMs?: number,
+    minimumHealthPollDurationMs?: number,
   ) {
     this.setupCalls++;
     this.setupSignal = signal;
-    this.setupHealthCheckTimeoutMs = healthCheckTimeoutMs;
+    this.setupMinimumHealthPollDurationMs = minimumHealthPollDurationMs;
     return this.setupResult;
   }
 
@@ -128,6 +128,7 @@ function createService(
     iosManager?: FakeIosManager;
     iosClient?: FakeReadinessClient;
     autoAdvance?: boolean;
+    awaitIosStartupMaintenance?: () => Promise<void>;
   } = {},
 ) {
   const timer = options.timer ?? new FakeTimer();
@@ -151,7 +152,7 @@ function createService(
       getIosManager: () => iosManager,
       getIosClient: () => iosClient,
       checkIosOverride: async () => ({ present: false, usable: true }),
-      awaitIosStartupMaintenance: async () => {},
+      awaitIosStartupMaintenance: options.awaitIosStartupMaintenance ?? (async () => {}),
     }),
   };
 }
@@ -296,7 +297,15 @@ describe("RunnerReadinessService", () => {
     const iosManager = new FakeIosManager();
     const iosClient = new FakeReadinessClient();
     iosClient.connected = false;
-    const { service } = createService({ iosManager, iosClient });
+    const timer = new FakeTimer();
+    const { service } = createService({
+      timer,
+      iosManager,
+      iosClient,
+      awaitIosStartupMaintenance: async () => {
+        timer.advanceTime(10_000);
+      },
+    });
 
     await service.ensureReady({
       device: iosDevice,
@@ -305,7 +314,7 @@ describe("RunnerReadinessService", () => {
       readinessTimeoutMs: 120_000,
     });
 
-    expect(iosManager.setupHealthCheckTimeoutMs).toBe(120_000);
+    expect(iosManager.setupMinimumHealthPollDurationMs).toBe(110_000);
     expect(iosManager.setupSignal).toBeDefined();
   });
 
@@ -324,7 +333,7 @@ describe("RunnerReadinessService", () => {
     });
 
     expect(iosManager.startCalls).toBe(1);
-    expect(iosManager.startOptions?.healthCheckTimeoutMs).toBe(30_000);
+    expect(iosManager.startOptions?.minimumHealthPollDurationMs).toBe(30_000);
     expect(iosManager.startOptions?.signal).toBeDefined();
     expect(iosManager.setupCalls).toBe(0);
     expect(iosClient.healthCalls).toBe(1);

--- a/test/utils/RunnerReadinessService.test.ts
+++ b/test/utils/RunnerReadinessService.test.ts
@@ -90,17 +90,28 @@ class FakeIosManager implements ReadinessIosManager {
   setupResult = { success: true, message: "ready" };
   setupCalls = 0;
   startCalls = 0;
+  setupSignal: AbortSignal | undefined;
+  setupHealthCheckTimeoutMs: number | undefined;
+  startOptions: { signal?: AbortSignal; healthCheckTimeoutMs?: number } | undefined;
 
   async isInstalled(): Promise<boolean> {
     return this.installed;
   }
 
-  async start(): Promise<void> {
+  async start(options?: { signal?: AbortSignal; healthCheckTimeoutMs?: number }): Promise<void> {
     this.startCalls++;
+    this.startOptions = options;
   }
 
-  async setup() {
+  async setup(
+    _force?: boolean,
+    _perf?: unknown,
+    signal?: AbortSignal,
+    healthCheckTimeoutMs?: number,
+  ) {
     this.setupCalls++;
+    this.setupSignal = signal;
+    this.setupHealthCheckTimeoutMs = healthCheckTimeoutMs;
     return this.setupResult;
   }
 
@@ -281,6 +292,23 @@ describe("RunnerReadinessService", () => {
     ).rejects.toThrow(/phase=runner-setup.*xcodebuild exited 65/);
   });
 
+  test("passes the remaining readiness budget to iOS CtrlProxy setup", async () => {
+    const iosManager = new FakeIosManager();
+    const iosClient = new FakeReadinessClient();
+    iosClient.connected = false;
+    const { service } = createService({ iosManager, iosClient });
+
+    await service.ensureReady({
+      device: iosDevice,
+      requestedIdentity: "platform=ios deviceId=IOS-UDID",
+      totalDeadlineMs: 120_000,
+      readinessTimeoutMs: 120_000,
+    });
+
+    expect(iosManager.setupHealthCheckTimeoutMs).toBe(120_000);
+    expect(iosManager.setupSignal).toBeDefined();
+  });
+
   test("starts only the cached iOS runner when downloads are disabled", async () => {
     const iosManager = new FakeIosManager();
     const iosClient = new FakeReadinessClient();
@@ -296,6 +324,8 @@ describe("RunnerReadinessService", () => {
     });
 
     expect(iosManager.startCalls).toBe(1);
+    expect(iosManager.startOptions?.healthCheckTimeoutMs).toBe(30_000);
+    expect(iosManager.startOptions?.signal).toBeDefined();
     expect(iosManager.setupCalls).toBe(0);
     expect(iosClient.healthCalls).toBe(1);
   });


### PR DESCRIPTION
## Summary

Propagate `startDevice`'s remaining iOS readiness budget into `IOSCtrlProxyManager` health polling.

The dev worker running AutoMobile `0.0.57` started the iOS runner successfully but failed creation after the manager's fixed 30-second poll loop, despite roughly 184 seconds remaining in the enclosing request.

The manager now expands its health-poll limit to the supplied remaining budget and makes poll/settle waits observe the enclosing abort signal. Calls without a readiness budget retain the existing configured default.

## Validation

- Focused iOS manager and readiness-service tests cover passing the remaining deadline and extending a configured three-attempt poll to a two-second caller budget.
- `bun run typecheck` completed with no new errors; the existing 185-error baseline is unchanged.
- `bun run lint` passed.
- `bun run turbo:validate` passed: 13,094 tests passed, 13 intentional skips, 0 failures.
