### PR TITLE
fix(daemon): preserve live daemon during auto-start

### DIFF
--- a/src/daemon/manager.ts
+++ b/src/daemon/manager.ts
@@ -503,56 +503,35 @@ export class DaemonManager implements DaemonManagerLike {
    * Internal start implementation (caller must hold lock).
    */
   private async startUnlocked(options: DaemonOptions): Promise<void> {
-    // Check for any running daemon processes from ANY worktree
-    const otherDaemons = this.findLiveDaemonProcesses();
-    if (otherDaemons.length > 0) {
-      stderrLog(
-        `\nWARNING: Found ${otherDaemons.length} other auto-mobile daemon process(es) running:`
-      );
-      for (const pid of otherDaemons) {
-        stderrLog(`  - PID ${pid}`);
-      }
-      stderrLog(
-        `\nThese may be from other worktrees and can cause device pool conflicts.`
-      );
-      stderrLog(`Stopping all other daemons before starting new one...`);
-
-      for (const pid of otherDaemons) {
-        try {
-          process.kill(pid, "SIGTERM");
-          stderrLog(`  Sent SIGTERM to PID ${pid}`);
-        } catch (error) {
-          stderrLog(`  Failed to stop PID ${pid}: ${error instanceof Error ? error.message : String(error)}`);
-        }
-      }
-
-      // Wait for processes to terminate
-      await this.timer.sleep(1000);
-
-      const remainingDaemonPids = new Set(this.findLiveDaemonProcesses());
-      for (const pid of otherDaemons) {
-        if (!remainingDaemonPids.has(pid)) {
-          continue;
-        }
-        try {
-          process.kill(pid, "SIGKILL");
-          stderrLog(`  Sent SIGKILL to PID ${pid}`);
-        } catch (error) {
-          stderrLog(`  Failed to kill PID ${pid}: ${error instanceof Error ? error.message : String(error)}`);
-        }
-      }
-    }
-
-    // Enforce single daemon policy: stop any existing daemon before starting
-    // This ensures only one daemon runs on the host system (per user)
     const status = await this.status();
     if (status.running) {
+      stderrLog(`Daemon is already running (PID ${status.pid}, port ${status.port})`);
+      return;
+    }
+
+    // A missing or stale PID record must not turn an ordinary start request into
+    // permission to terminate a live daemon. This happens when a second client
+    // reaches the shared socket during a long-running tool call and races a
+    // transient availability probe. Reuse a responsive daemon; require an
+    // explicit restart for a live but unreachable process.
+    const liveDaemons = this.findLiveDaemonProcesses();
+    if (liveDaemons.length > 0) {
       stderrLog(
-        `Found existing daemon (PID ${status.pid}, port ${status.port}), stopping it...`
+        `Found ${liveDaemons.length} live auto-mobile daemon process(es) without a usable PID record; waiting for one to become ready...`
       );
-      await this.stop();
-      // Wait briefly for cleanup
-      await this.timer.sleep(500);
+      for (const pid of liveDaemons) {
+        stderrLog(`  - PID ${pid}`);
+      }
+      if (await this.waitForExistingDaemon(DAEMON_STARTUP_TIMEOUT_MS)) {
+        stderrLog("Reusing existing responsive daemon");
+        return;
+      }
+
+      throw new ActionableError(
+        `Found live AutoMobile daemon process(es) (${liveDaemons.join(", ")}) but none became reachable within ` +
+        `${DAEMON_STARTUP_TIMEOUT_MS}ms. Refusing to terminate a live daemon during start; ` +
+        `inspect it or run \`bunx ${resolveDaemonInstallSpecifier()} --daemon restart\` explicitly.`
+      );
     }
 
     // Clean up stale socket and PID files from previous sessions
@@ -999,6 +978,20 @@ export class DaemonManager implements DaemonManagerLike {
       `Daemon readiness probe timed out after ${this.timer.now() - startTime}ms ` +
       `(${pollCount} polls; socket ${socketObserved ? "observed" : "not observed"})`
     );
+    return false;
+  }
+
+  private async waitForExistingDaemon(timeout: number): Promise<boolean> {
+    const startTime = this.timer.now();
+    const pollInterval = 100;
+
+    while (this.timer.now() - startTime < timeout) {
+      if (await this.verifyDaemonConnection()) {
+        return true;
+      }
+      await this.timer.sleep(pollInterval);
+    }
+
     return false;
   }
 

--- a/test/daemon/manager.test.ts
+++ b/test/daemon/manager.test.ts
@@ -555,14 +555,14 @@ describe("Daemon manager process detection", () => {
     expect(() => manager.findAllDaemonProcesses()).toThrow("Failed to inspect daemon process table: spawn ENOBUFS");
   });
 
-  test("start takeover escalates to SIGKILL when another live daemon is not the PID-file owner", async () => {
+  test("start reuses a responsive live daemon when its PID record is unavailable", async () => {
     const dir = mkdtempSync(join(tmpdir(), "daemon-manager-takeover-test-"));
     process.env.AUTOMOBILE_DATA_DIR = dir;
     const pidFilePath = join(dir, "daemon.pid");
-    writeDaemonPidFile(pidFilePath, 201);
     const fakeTimer = new FakeTimer();
     fakeTimer.enableAutoAdvance();
     const killCalls: Array<{ pid: number; signal: NodeJS.Signals | number | undefined }> = [];
+    let spawnCalls = 0;
     const processFinder = new FakeDaemonProcessFinder([
       {
         pid: 301,
@@ -572,7 +572,10 @@ describe("Daemon manager process detection", () => {
     ], new Set([301]));
     const processSpawner: DaemonProcessSpawner = {
       spawn: (_command: string, _args: string[], _options: SpawnOptions) => ({
-        unref() {},
+        get unref() {
+          spawnCalls++;
+          return () => {};
+        },
         once() { return this; },
         off() { return this; },
       }) as ChildProcess,
@@ -596,7 +599,7 @@ describe("Daemon manager process detection", () => {
 
     try {
       const manager = new TestDaemonManager(
-        undefined,
+        () => new FakeDaemonClient({}),
         undefined,
         fakeTimer,
         join(dir, "daemon.lock"),
@@ -608,46 +611,37 @@ describe("Daemon manager process detection", () => {
 
       await manager.start();
 
-      expect(killCalls).toEqual([
-        { pid: 301, signal: "SIGTERM" },
-        { pid: 301, signal: "SIGKILL" },
-      ]);
+      expect(killCalls).toEqual([]);
+      expect(spawnCalls).toBe(0);
     } finally {
       killSpy.mockRestore();
       rmSync(dir, { recursive: true, force: true });
     }
   });
 
-  test("start takeover does not SIGKILL when daemon identity is no longer confirmed", async () => {
+  test("start refuses to signal a live daemon that never becomes reachable", async () => {
     const dir = mkdtempSync(join(tmpdir(), "daemon-manager-takeover-revalidate-test-"));
     process.env.AUTOMOBILE_DATA_DIR = dir;
     const pidFilePath = join(dir, "daemon.pid");
-    writeDaemonPidFile(pidFilePath, 301);
     const fakeTimer = new FakeTimer();
     fakeTimer.enableAutoAdvance();
     const killCalls: Array<{ pid: number; signal: NodeJS.Signals | number | undefined }> = [];
-    let findCalls = 0;
     const processFinder: DaemonProcessFinder & DaemonProcessLivenessChecker = {
       findDaemonProcesses() {
-        findCalls++;
-        return findCalls === 1 ? [
-          {
-            pid: 301,
-            ppid: 1,
-            command: `bun /worktree-b/dist/src/index.js --daemon-mode`,
-          },
-        ] : [];
+        return [{
+          pid: 301,
+          ppid: 1,
+          command: `bun /worktree-b/dist/src/index.js --daemon-mode`,
+        }];
       },
       isProcessRunning(pid: number) {
         return pid === 301;
       },
     };
     const processSpawner: DaemonProcessSpawner = {
-      spawn: (_command: string, _args: string[], _options: SpawnOptions) => ({
-        unref() {},
-        once() { return this; },
-        off() { return this; },
-      }) as ChildProcess,
+      spawn: () => {
+        throw new Error("should not spawn while a live daemon exists");
+      },
     };
     const killSpy = spyOn(process, "kill").mockImplementation(((pid: number, signal?: NodeJS.Signals | number) => {
       if (pid === 301) {
@@ -668,7 +662,21 @@ describe("Daemon manager process detection", () => {
 
     try {
       const manager = new TestDaemonManager(
-        undefined,
+        () => ({
+          async connect() {
+            throw new Error("connection refused");
+          },
+          async close() {},
+          async callTool() {
+            return {};
+          },
+          async readResource() {
+            return {};
+          },
+          async callDaemonMethod() {
+            return {};
+          },
+        }),
         undefined,
         fakeTimer,
         join(dir, "daemon.lock"),
@@ -678,12 +686,11 @@ describe("Daemon manager process detection", () => {
         processSpawner
       );
 
-      await manager.start();
+      await expect(manager.start()).rejects.toThrow(
+        "Refusing to terminate a live daemon during start"
+      );
 
-      expect(killCalls).toEqual([
-        { pid: 301, signal: "SIGTERM" },
-      ]);
-      expect(findCalls).toBe(2);
+      expect(killCalls).toEqual([]);
     } finally {
       killSpy.mockRestore();
       rmSync(dir, { recursive: true, force: true });


### PR DESCRIPTION
## Summary

Prevent an ordinary daemon auto-start from terminating a live AutoMobile daemon when its PID record is unavailable. A competing client now waits for the existing daemon to become responsive and reuses it; if the daemon remains unreachable, it fails with an explicit recovery instruction instead of sending `SIGTERM` or `SIGKILL`.

## Bug / Regression Context

- **Prior attempts:** The iOS CtrlProxy readiness-budget fix released in `0.0.58` keeps slow CtrlProxy startup alive.
- **Observed symptom:** A live iOS daemon handling `startDevice` received `SIGTERM` while CtrlProxy still had more than 116 seconds remaining in its readiness budget, closing the MCP request and making the managed device unhealthy.
- **Repro steps / conditions:** A second client reaches daemon auto-start while a long-running tool call has a transient socket-availability result and the live daemon lacks a usable PID record. The previous takeover policy discovers the process and terminates it before spawning another daemon.

## Validation

- [x] `bun test test/daemon/manager.test.ts` - covers reusing a responsive live daemon without signals and refusing to kill an unreachable live daemon.
- [x] `bun run build` - TypeScript build completed.
- [x] `bun run lint` - lint and boundary checks completed.
- [x] `bun run turbo:validate` - 13,099 passed, 13 intentionally skipped, 0 failed.
- [x] Rebased onto latest `main`, conflicts resolved.

## Device Verification

- [ ] Deferred intentionally. The follow-up manual iOS device-create test should run against this PR before any release.
