### PR TITLE
fix(desktop): keep the video pane on live video and unwedge stalled video/input

### DIFF
--- a/android/desktop-app/src/main/kotlin/dev/jasonpearson/automobile/desktop/AutoMobileDesktopApp.kt
+++ b/android/desktop-app/src/main/kotlin/dev/jasonpearson/automobile/desktop/AutoMobileDesktopApp.kt
@@ -33,6 +33,7 @@ import dev.jasonpearson.automobile.desktop.core.workspace.DaemonEmulatorControlE
 import dev.jasonpearson.automobile.desktop.core.workspace.DeviceColumn
 import dev.jasonpearson.automobile.desktop.core.workspace.DeviceStreamView
 import dev.jasonpearson.automobile.desktop.core.workspace.FailuresFacet
+import dev.jasonpearson.automobile.desktop.core.workspace.LayoutFacet
 import dev.jasonpearson.automobile.desktop.core.workspace.LogsFacet
 import dev.jasonpearson.automobile.desktop.core.workspace.NavigationFacet
 import dev.jasonpearson.automobile.desktop.core.workspace.NetworkFacet
@@ -408,8 +409,6 @@ fun AutoMobileDesktopApp(
             state = pickerState,
             onAction = pickerViewModel::onAction,
             onClose = { pickerOpen = false },
-            // Authenticates each grid card's live-video subscribe against the daemon session guard.
-            sessionUuidProvider = desktopDaemonSession?.sessionUuidProvider ?: { null },
             // Only offer Close when there is an observed workspace to return to.
             canClose = workspaceState is WorkspaceUiState.Content,
           )
@@ -433,6 +432,15 @@ fun AutoMobileDesktopApp(
               status = workspaceStatus.status,
               statusDetail = workspaceStatus.detail,
               facetContent = { column, tool -> WorkspaceFacet(column, tool) },
+              // Inspect mode's Layout inspector renders live video for its pixels; the session
+              // provider authenticates that subscribe against the stream-socket guard (#4751),
+              // exactly as the stream pane below.
+              inspectContent = { column ->
+                LayoutFacet(
+                  column,
+                  sessionUuidProvider = desktopDaemonSession?.sessionUuidProvider ?: { null },
+                )
+              },
               // Live device mirror in each pane's stream area, fed by the daemon's video-stream
               // relay. The pane authenticates with the workspace daemon session (#4977) bound to
               // the focused device above; when no session is available (non-Unix daemon, or the

--- a/android/desktop-core/src/main/kotlin/dev/jasonpearson/automobile/desktop/core/AutoMobileContent.kt
+++ b/android/desktop-core/src/main/kotlin/dev/jasonpearson/automobile/desktop/core/AutoMobileContent.kt
@@ -209,6 +209,19 @@ internal const val LIVE_RECONNECT_INITIAL_MS = 1_000L
 internal const val LIVE_RECONNECT_MAX_MS = 15_000L
 
 /**
+ * Stall watchdog for [rememberLiveVideoFrame] when [autoReconnect] is on: force a reconnect after
+ * this long in `Streaming` with no frame progress. A relay that stalls with its socket OPEN (device
+ * capture silently dead, half-open socket, subscriber wedged waiting for a key frame the encoder
+ * never produced) keeps the state at `Streaming`, so the Unavailable-driven reconnect never fires
+ * and the mirror silently freezes. A healthy-but-idle Android stream emits ~1 fps heartbeat frames
+ * (FrameHeartbeat's 1s idle nudge), so ten missed seconds is decisively a stall, not idleness. The
+ * reconnect is visually free: the last frame is retained while the fresh subscribe (which requests
+ * an immediate key frame) replaces it.
+ */
+internal const val LIVE_STALL_RECONNECT_MS = 10_000L
+internal const val LIVE_STALL_CHECK_INTERVAL_MS = 2_000L
+
+/**
  * Connects a live-mirroring source for this composition and exposes only its newest frame.
  *
  * Frames arrive ready to draw — the client converts, sequences, and timestamps them on its reader
@@ -228,6 +241,9 @@ internal fun rememberLiveVideoFrame(
   deviceId: String?,
   autoReconnect: Boolean = false,
   reconnectInitialMs: Long = LIVE_RECONNECT_INITIAL_MS,
+  nowMs: () -> Long = MONOTONIC_NOW_MS,
+  stallReconnectMs: Long = LIVE_STALL_RECONNECT_MS,
+  stallCheckIntervalMs: Long = LIVE_STALL_CHECK_INTERVAL_MS,
 ): LiveVideoFrame? {
   var liveFrame by remember(source, deviceId) { mutableStateOf<LiveVideoFrame?>(null) }
 
@@ -257,7 +273,14 @@ internal fun rememberLiveVideoFrame(
     // timer while a recovered one stops cleanly.
     source.state.collectLatest { state ->
       if (state is VideoStreamState.Unavailable || state is VideoStreamState.PermissionRequired) {
-        liveFrame = null
+        // Auto-reconnecting consumers (the workspace video pane) RETAIN the last decoded frame
+        // across a relay drop: the pane keeps rendering the freshest video it ever had while the
+        // retry below re-subscribes, instead of flashing a non-video fallback for the whole
+        // backoff window ("video pane switches to screenshots"). Freshness gating is the frame
+        // consumer's job (receivedAtMs); rendering never falls back to observation screenshots.
+        // The plain path (IDE plugin / AutoMobileContent) keeps the original clear-and-blend
+        // semantics, where screenshot updates ARE the designed fallback surface.
+        if (!autoReconnect) liveFrame = null
         if (autoReconnect && deviceId != null) {
           var backoffMs = reconnectInitialMs
           while (isActive) {
@@ -269,6 +292,39 @@ internal fun rememberLiveVideoFrame(
             source.connect(deviceId)
           }
         }
+      }
+    }
+  }
+
+  // Stall watchdog (see LIVE_STALL_RECONNECT_MS): a relay that stops delivering frames while its
+  // socket stays open never leaves `Streaming`, so the Unavailable-driven reconnect above cannot
+  // catch it — the only observable signal is frame progress ceasing. Watch it and reconnect.
+  LaunchedEffect(source, deviceId, autoReconnect) {
+    if (source == null || deviceId == null || !autoReconnect) return@LaunchedEffect
+    var lastProgressMs = nowMs()
+    var lastSeenSequence = -1L
+    while (isActive) {
+      delay(stallCheckIntervalMs)
+      if (source.state.value !is VideoStreamState.Streaming) {
+        // Not streaming: connect/reconnect paths own recovery; restart the stall clock so a
+        // fresh session gets a full window before being judged.
+        lastProgressMs = nowMs()
+        continue
+      }
+      val frame = liveFrame
+      if (frame != null && frame.sequence != lastSeenSequence) {
+        lastSeenSequence = frame.sequence
+        lastProgressMs = frame.receivedAtMs
+        continue
+      }
+      if (nowMs() - lastProgressMs >= stallReconnectMs) {
+        LOG.info(
+          "Live mirror for $deviceId made no frame progress for ${stallReconnectMs}ms " +
+            "while Streaming; reconnecting"
+        )
+        lastProgressMs = nowMs()
+        source.disconnect()
+        source.connect(deviceId)
       }
     }
   }

--- a/android/desktop-core/src/main/kotlin/dev/jasonpearson/automobile/desktop/core/AutoMobileContent.kt
+++ b/android/desktop-core/src/main/kotlin/dev/jasonpearson/automobile/desktop/core/AutoMobileContent.kt
@@ -209,17 +209,31 @@ internal const val LIVE_RECONNECT_INITIAL_MS = 1_000L
 internal const val LIVE_RECONNECT_MAX_MS = 15_000L
 
 /**
- * Stall watchdog for [rememberLiveVideoFrame] when [autoReconnect] is on: force a reconnect after
- * this long in `Streaming` with no frame progress. A relay that stalls with its socket OPEN (device
- * capture silently dead, half-open socket, subscriber wedged waiting for a key frame the encoder
- * never produced) keeps the state at `Streaming`, so the Unavailable-driven reconnect never fires
- * and the mirror silently freezes. A healthy-but-idle Android stream emits ~1 fps heartbeat frames
- * (FrameHeartbeat's 1s idle nudge), so ten missed seconds is decisively a stall, not idleness. The
- * reconnect is visually free: the last frame is retained while the fresh subscribe (which requests
- * an immediate key frame) replaces it.
+ * Streaming-stall reconnect window for [rememberLiveVideoFrame]: force a reconnect after this long
+ * in `Streaming` with no frame progress. A relay that stalls with its socket OPEN (device capture
+ * silently dead, half-open socket) stays `Streaming`, so the Unavailable-driven reconnect never
+ * fires and the mirror silently freezes; frame progress ceasing is the only signal.
+ *
+ * This is ONLY valid for sources that emit idle heartbeat frames, so "no progress" unambiguously
+ * means "stalled" rather than "static screen": the Android video-server's FrameHeartbeat re-submits
+ * ~1 fps while idle. The iOS ScreenCaptureKit capture deliberately DROPS idle buffers (`status !=
+ * .complete`), so a healthy static iOS screen makes no decoded-frame progress — those callers pass
+ * `stallReconnectMs = null` to disable this watchdog and rely on the first-frame deadline plus the
+ * Unavailable retry instead. The reconnect is visually free: the last frame is retained while the
+ * fresh subscribe (which re-requests a key frame) replaces it.
  */
 internal const val LIVE_STALL_RECONNECT_MS = 10_000L
 internal const val LIVE_STALL_CHECK_INTERVAL_MS = 2_000L
+
+/**
+ * First-frame deadline for [rememberLiveVideoFrame]: reconnect if the source sits in
+ * `Connecting`/`Idle` (subscribe accepted or connecting) this long without ever delivering a
+ * decodable first frame. This catches the key-frame wedge that never leaves `Connecting` — which
+ * neither the Streaming-stall watchdog nor the Unavailable retry can see — on BOTH platforms
+ * (unlike the Streaming-stall window, an idle static screen has no bearing here: there is no frame
+ * yet at all). Generous, since iOS startup + first key frame is legitimately several seconds.
+ */
+internal const val LIVE_FIRST_FRAME_TIMEOUT_MS = 15_000L
 
 /**
  * Connects a live-mirroring source for this composition and exposes only its newest frame.
@@ -242,7 +256,10 @@ internal fun rememberLiveVideoFrame(
   autoReconnect: Boolean = false,
   reconnectInitialMs: Long = LIVE_RECONNECT_INITIAL_MS,
   nowMs: () -> Long = MONOTONIC_NOW_MS,
-  stallReconnectMs: Long = LIVE_STALL_RECONNECT_MS,
+  // Null disables the Streaming-stall reconnect; iOS (idle-frame-dropping) callers pass null.
+  stallReconnectMs: Long? = LIVE_STALL_RECONNECT_MS,
+  // Null disables the first-frame deadline.
+  firstFrameTimeoutMs: Long? = LIVE_FIRST_FRAME_TIMEOUT_MS,
   stallCheckIntervalMs: Long = LIVE_STALL_CHECK_INTERVAL_MS,
 ): LiveVideoFrame? {
   var liveFrame by remember(source, deviceId) { mutableStateOf<LiveVideoFrame?>(null) }
@@ -296,35 +313,51 @@ internal fun rememberLiveVideoFrame(
     }
   }
 
-  // Stall watchdog (see LIVE_STALL_RECONNECT_MS): a relay that stops delivering frames while its
-  // socket stays open never leaves `Streaming`, so the Unavailable-driven reconnect above cannot
-  // catch it — the only observable signal is frame progress ceasing. Watch it and reconnect.
+  // Progress watchdog: recovers the two silent freezes the Unavailable-driven retry can't see —
+  //  - a `Streaming` relay that stops delivering frames (stall), for heartbeat-capable sources; and
+  //  - a `Connecting` subscribe that never yields a decodable first frame (the key-frame wedge).
+  // Both re-subscribe (disconnect+connect), which re-requests a key frame; the retained last frame
+  // keeps rendering across it. Idle static screens are handled correctly: on iOS stallReconnectMs
+  // is null so an idle `Streaming` stream is left alone, and the first-frame deadline only applies
+  // BEFORE the first frame, where a static screen is irrelevant.
   LaunchedEffect(source, deviceId, autoReconnect) {
     if (source == null || deviceId == null || !autoReconnect) return@LaunchedEffect
-    var lastProgressMs = nowMs()
+    if (stallReconnectMs == null && firstFrameTimeoutMs == null) return@LaunchedEffect
+    var noProgressSinceMs = nowMs()
     var lastSeenSequence = -1L
+    fun reconnect(reason: String) {
+      LOG.info("Live mirror for $deviceId reconnecting: $reason")
+      noProgressSinceMs = nowMs()
+      lastSeenSequence = -1L
+      source.disconnect()
+      source.connect(deviceId)
+    }
     while (isActive) {
       delay(stallCheckIntervalMs)
-      if (source.state.value !is VideoStreamState.Streaming) {
-        // Not streaming: connect/reconnect paths own recovery; restart the stall clock so a
-        // fresh session gets a full window before being judged.
-        lastProgressMs = nowMs()
-        continue
-      }
-      val frame = liveFrame
-      if (frame != null && frame.sequence != lastSeenSequence) {
-        lastSeenSequence = frame.sequence
-        lastProgressMs = frame.receivedAtMs
-        continue
-      }
-      if (nowMs() - lastProgressMs >= stallReconnectMs) {
-        LOG.info(
-          "Live mirror for $deviceId made no frame progress for ${stallReconnectMs}ms " +
-            "while Streaming; reconnecting"
-        )
-        lastProgressMs = nowMs()
-        source.disconnect()
-        source.connect(deviceId)
+      when (source.state.value) {
+        is VideoStreamState.Streaming -> {
+          val frame = liveFrame
+          if (frame != null && frame.sequence != lastSeenSequence) {
+            lastSeenSequence = frame.sequence
+            noProgressSinceMs = frame.receivedAtMs
+          } else if (stallReconnectMs != null && nowMs() - noProgressSinceMs >= stallReconnectMs) {
+            reconnect("no frame progress for ${stallReconnectMs}ms while Streaming")
+          }
+        }
+        is VideoStreamState.Connecting,
+        is VideoStreamState.Idle -> {
+          // No first frame yet. Do NOT reset the clock here — elapsed non-Streaming time is
+          // exactly what the first-frame deadline bounds.
+          if (firstFrameTimeoutMs != null && nowMs() - noProgressSinceMs >= firstFrameTimeoutMs) {
+            reconnect("no first frame within ${firstFrameTimeoutMs}ms")
+          }
+        }
+        else -> {
+          // Unavailable / PermissionRequired: the Unavailable-driven retry owns recovery. Keep the
+          // clock fresh so a recovered session gets a full window before being judged.
+          noProgressSinceMs = nowMs()
+          lastSeenSequence = -1L
+        }
       }
     }
   }

--- a/android/desktop-core/src/main/kotlin/dev/jasonpearson/automobile/desktop/core/daemon/McpDaemonClient.kt
+++ b/android/desktop-core/src/main/kotlin/dev/jasonpearson/automobile/desktop/core/daemon/McpDaemonClient.kt
@@ -44,17 +44,16 @@ class McpDaemonClient(
   private val clientVersion: String? = DaemonSocketPaths.resolveClientVersion(),
   val sessionUuid: String? = null,
   /**
-   * Hang ceiling for one daemon round-trip. The request socket is a BLOCKING [SocketChannel] —
-   * which supports no read timeout — so without a deadline a daemon that accepts the connection but
-   * never replies (wedged event loop, half-open socket after sleep/wake) hangs the calling thread
-   * FOREVER. For the video-pane input path that thread is the pane's single dispatch thread, held
-   * inside its FIFO mutex: one hung call silently killed ALL further input ("input stops working").
-   * A watchdog closes the channel at the deadline, failing the one call so the caller sheds it and
-   * the next input proceeds on a fresh connection. Generous defaults — these are hang detectors,
-   * not latency budgets; a healthy round-trip is ~milliseconds.
+   * Hang ceiling for the input helpers (tap/swipe/key) ONLY. The request socket is a BLOCKING
+   * [SocketChannel] — which supports no connect/read timeout — so without a deadline a daemon that
+   * accepts but never replies (wedged event loop, half-open socket after sleep/wake) hangs the
+   * calling thread FOREVER. For the video pane that thread is the single dispatch thread, held in
+   * its FIFO mutex: one hung input call silently killed ALL further input. A watchdog fails the one
+   * call at this deadline so the dispatcher sheds it and the next input proceeds on a fresh
+   * connection. A hang detector, not a latency budget — a healthy input round-trip is ~ms. Ordinary
+   * tool calls are deliberately UNBOUNDED (see [sendRequest]) so the daemon's long-running-tool
+   * timeout floors are honored.
    */
-  private val requestTimeoutMs: Long = DEFAULT_REQUEST_TIMEOUT_MS,
-  /** Tighter ceiling for the input helpers (tap/swipe/key), where a hang freezes interaction. */
   private val inputRequestTimeoutMs: Long = INPUT_REQUEST_TIMEOUT_MS,
 ) : AutoMobileClient {
   private var daemonLifecycle: DaemonLifecycleEnsurer? =
@@ -703,34 +702,50 @@ class McpDaemonClient(
     }
   }
 
+  /**
+   * Send one request. [timeoutMs] is a HANG ceiling, not a latency budget, and is OPT-IN: null
+   * (ordinary tool calls) leaves the request unbounded, because the daemon deliberately grants
+   * long-running tools multi-minute floors (executePlan 600s, startDevice/launchApp/observe 90s;
+   * see src/daemon/mcpRequestTimeout.ts) and a blanket client ceiling would disconnect a valid slow
+   * call while it is still running. Only the input helpers pass a value, where a hang freezes the
+   * video pane's single dispatch thread.
+   */
   private fun sendRequest(
     method: String,
     params: JsonObject = JsonObject(emptyMap()),
-    timeoutMs: Long = requestTimeoutMs,
+    timeoutMs: Long? = null,
   ): DaemonResponse {
     ensureVersionMatchedDaemon()
     ensureSocketExists()
 
     val address = UnixDomainSocketAddress.of(socketPathValue)
-    SocketChannel.open(address).use { channel ->
-      // Deadline watchdog: a blocking SocketChannel has no read timeout, so a daemon that
-      // accepts but never replies would hang the calling thread forever (see the constructor
-      // doc — for video-pane input that meant ALL input died). Closing the channel from the
-      // watchdog thread makes the blocked read throw, which the catch below reports as a
-      // timeout. Cancelled on completion, so a healthy round-trip never touches it.
-      val watchdog =
+    // Open the channel UNCONNECTED so the deadline can be armed BEFORE the blocking connect(): a
+    // wedged daemon whose accept backlog is full would otherwise hang in connect() before any
+    // watchdog exists.
+    SocketChannel.open(java.net.StandardProtocolFamily.UNIX).use { channel ->
+      // Deadline watchdog. A blocking SocketChannel has no connect/read timeout, so a daemon that
+      // never accepts or never replies would hang the calling thread forever (for video-pane
+      // input that meant ALL input died). The watchdog closes the channel, which makes the blocked
+      // connect/read throw; `expired` is set BEFORE the close so the request thread
+      // deterministically
+      // reports the deadline rather than the incidental ClosedChannelException the close raced in.
+      val expired = java.util.concurrent.atomic.AtomicBoolean(false)
+      val watchdog = timeoutMs?.let { deadline ->
         requestWatchdog.schedule(
           {
+            expired.set(true)
             try {
               channel.close()
             } catch (_: Exception) {
               // Best-effort close; the request thread owns the definitive close via use{}.
             }
           },
-          timeoutMs,
+          deadline,
           java.util.concurrent.TimeUnit.MILLISECONDS,
         )
+      }
       try {
+        channel.connect(address)
         val reader =
           BufferedReader(
             InputStreamReader(Channels.newInputStream(channel), StandardCharsets.UTF_8)
@@ -756,16 +771,14 @@ class McpDaemonClient(
         val line = reader.readLine() ?: throw DaemonUnavailableException("Daemon closed the socket")
         return json.decodeFromString(line)
       } catch (e: Exception) {
-        // The watchdog having FIRED (not been cancelled) means the failure is our own forced
-        // close — report the timeout, not the incidental closed-channel exception it caused.
-        if (watchdog.isDone && !watchdog.isCancelled) {
+        if (expired.get()) {
           throw DaemonUnavailableException(
             "Daemon request '$method' timed out after ${timeoutMs}ms"
           )
         }
         throw e
       } finally {
-        watchdog.cancel(false)
+        watchdog?.cancel(false)
       }
     }
   }
@@ -823,8 +836,6 @@ class McpDaemonClient(
 
   companion object {
     /** Hang ceiling for ordinary daemon requests (tool calls can legitimately take tens of s). */
-    const val DEFAULT_REQUEST_TIMEOUT_MS = 60_000L
-
     /** Hang ceiling for the input helpers; a healthy input round-trip is ~milliseconds. */
     const val INPUT_REQUEST_TIMEOUT_MS = 5_000L
 

--- a/android/desktop-core/src/main/kotlin/dev/jasonpearson/automobile/desktop/core/daemon/McpDaemonClient.kt
+++ b/android/desktop-core/src/main/kotlin/dev/jasonpearson/automobile/desktop/core/daemon/McpDaemonClient.kt
@@ -43,6 +43,19 @@ class McpDaemonClient(
   private val json: Json = DaemonJson,
   private val clientVersion: String? = DaemonSocketPaths.resolveClientVersion(),
   val sessionUuid: String? = null,
+  /**
+   * Hang ceiling for one daemon round-trip. The request socket is a BLOCKING [SocketChannel] —
+   * which supports no read timeout — so without a deadline a daemon that accepts the connection but
+   * never replies (wedged event loop, half-open socket after sleep/wake) hangs the calling thread
+   * FOREVER. For the video-pane input path that thread is the pane's single dispatch thread, held
+   * inside its FIFO mutex: one hung call silently killed ALL further input ("input stops working").
+   * A watchdog closes the channel at the deadline, failing the one call so the caller sheds it and
+   * the next input proceeds on a fresh connection. Generous defaults — these are hang detectors,
+   * not latency budgets; a healthy round-trip is ~milliseconds.
+   */
+  private val requestTimeoutMs: Long = DEFAULT_REQUEST_TIMEOUT_MS,
+  /** Tighter ceiling for the input helpers (tap/swipe/key), where a hang freezes interaction. */
+  private val inputRequestTimeoutMs: Long = INPUT_REQUEST_TIMEOUT_MS,
 ) : AutoMobileClient {
   private var daemonLifecycle: DaemonLifecycleEnsurer? =
     if (socketPathValue == DaemonSocketPaths.socketPath()) DesktopDaemonLifecycle() else null
@@ -585,7 +598,10 @@ class McpDaemonClient(
   }
 
   private fun sendInputRequest(method: String, params: JsonObject): InputActionResult {
-    val response = sendRequest(method, params)
+    // Input rides the tighter deadline: a hung input/* call froze the pane's whole input path
+    // (single dispatch thread + FIFO mutex), and live interaction would rather shed one tap
+    // after 5s than sit dead for a minute.
+    val response = sendRequest(method, params, timeoutMs = inputRequestTimeoutMs)
     if (!response.success) {
       return InputActionResult(action = method, success = false, error = response.error)
     }
@@ -690,34 +706,67 @@ class McpDaemonClient(
   private fun sendRequest(
     method: String,
     params: JsonObject = JsonObject(emptyMap()),
+    timeoutMs: Long = requestTimeoutMs,
   ): DaemonResponse {
     ensureVersionMatchedDaemon()
     ensureSocketExists()
 
     val address = UnixDomainSocketAddress.of(socketPathValue)
     SocketChannel.open(address).use { channel ->
-      val reader =
-        BufferedReader(InputStreamReader(Channels.newInputStream(channel), StandardCharsets.UTF_8))
-      val writer =
-        BufferedWriter(
-          OutputStreamWriter(Channels.newOutputStream(channel), StandardCharsets.UTF_8)
+      // Deadline watchdog: a blocking SocketChannel has no read timeout, so a daemon that
+      // accepts but never replies would hang the calling thread forever (see the constructor
+      // doc — for video-pane input that meant ALL input died). Closing the channel from the
+      // watchdog thread makes the blocked read throw, which the catch below reports as a
+      // timeout. Cancelled on completion, so a healthy round-trip never touches it.
+      val watchdog =
+        requestWatchdog.schedule(
+          {
+            try {
+              channel.close()
+            } catch (_: Exception) {
+              // Best-effort close; the request thread owns the definitive close via use{}.
+            }
+          },
+          timeoutMs,
+          java.util.concurrent.TimeUnit.MILLISECONDS,
         )
+      try {
+        val reader =
+          BufferedReader(
+            InputStreamReader(Channels.newInputStream(channel), StandardCharsets.UTF_8)
+          )
+        val writer =
+          BufferedWriter(
+            OutputStreamWriter(Channels.newOutputStream(channel), StandardCharsets.UTF_8)
+          )
 
-      val request =
-        DaemonRequest(
-          id = UUID.randomUUID().toString(),
-          type = "mcp_request",
-          method = method,
-          params = params,
-          clientVersion = clientVersion,
-        )
+        val request =
+          DaemonRequest(
+            id = UUID.randomUUID().toString(),
+            type = "mcp_request",
+            method = method,
+            params = params,
+            clientVersion = clientVersion,
+          )
 
-      writer.write(json.encodeToString(request))
-      writer.newLine()
-      writer.flush()
+        writer.write(json.encodeToString(request))
+        writer.newLine()
+        writer.flush()
 
-      val line = reader.readLine() ?: throw DaemonUnavailableException("Daemon closed the socket")
-      return json.decodeFromString(line)
+        val line = reader.readLine() ?: throw DaemonUnavailableException("Daemon closed the socket")
+        return json.decodeFromString(line)
+      } catch (e: Exception) {
+        // The watchdog having FIRED (not been cancelled) means the failure is our own forced
+        // close — report the timeout, not the incidental closed-channel exception it caused.
+        if (watchdog.isDone && !watchdog.isCancelled) {
+          throw DaemonUnavailableException(
+            "Daemon request '$method' timed out after ${timeoutMs}ms"
+          )
+        }
+        throw e
+      } finally {
+        watchdog.cancel(false)
+      }
     }
   }
 
@@ -770,6 +819,21 @@ class McpDaemonClient(
     if (value != null) {
       put(key, JsonPrimitive(value))
     }
+  }
+
+  companion object {
+    /** Hang ceiling for ordinary daemon requests (tool calls can legitimately take tens of s). */
+    const val DEFAULT_REQUEST_TIMEOUT_MS = 60_000L
+
+    /** Hang ceiling for the input helpers; a healthy input round-trip is ~milliseconds. */
+    const val INPUT_REQUEST_TIMEOUT_MS = 5_000L
+
+    // One shared daemon thread arms/cancels every request deadline. It only ever runs a
+    // channel.close() for a request that overran its ceiling, so it stays idle in normal use.
+    private val requestWatchdog =
+      java.util.concurrent.Executors.newSingleThreadScheduledExecutor { runnable ->
+        Thread(runnable, "daemon-request-watchdog").apply { isDaemon = true }
+      }
   }
 }
 

--- a/android/desktop-core/src/main/kotlin/dev/jasonpearson/automobile/desktop/core/layout/LayoutInspectorDashboard.kt
+++ b/android/desktop-core/src/main/kotlin/dev/jasonpearson/automobile/desktop/core/layout/LayoutInspectorDashboard.kt
@@ -44,6 +44,13 @@ fun LayoutInspectorDashboard(
   deviceId: String? = null, // Pane's device; tags applied frames and scopes the initial request
   platform: String = "android", // Device platform ("android" or "ios")
   onRestartDaemon: (() -> Unit)? = null,
+  /**
+   * A decoded live-mirror frame for the device panel's PIXELS. When present it renders instead of
+   * the observation screenshot, so the inspector shows the live screen; the screenshot remains the
+   * pre-video bootstrap and — always — the capture the hierarchy overlay/selection maps against.
+   * Null keeps the original screenshot-only rendering (the IDE-plugin dashboard path).
+   */
+  liveFrame: androidx.compose.ui.graphics.ImageBitmap? = null,
 ) {
   val state = rememberLayoutInspectorState()
   val colors = SharedTheme.globalColors
@@ -226,6 +233,7 @@ fun LayoutInspectorDashboard(
     ) {
       DeviceScreenView(
         screenshotData = state.screenshotData,
+        liveFrame = liveFrame,
         screenWidth = state.screenWidth,
         screenHeight = state.screenHeight,
         rotation = state.rotation,
@@ -246,13 +254,17 @@ fun LayoutInspectorDashboard(
         refitTrigger = refitTrigger, // Trigger refit when panels toggle
       )
 
-      ScreenshotMetadataOverlay(
-        fallback = state.screenshotFallback,
-        fallbackReason = state.screenshotFallbackReason,
-        format = state.screenshotFormat,
-        captureSource = state.screenshotCaptureSource,
-        modifier = Modifier.align(Alignment.TopStart).padding(8.dp),
-      )
+      // The metadata badge describes the SCREENSHOT pixels (format/fallback/capture source), so it
+      // only applies while the screenshot is what's on screen — live video renders instead of it.
+      if (liveFrame == null) {
+        ScreenshotMetadataOverlay(
+          fallback = state.screenshotFallback,
+          fallbackReason = state.screenshotFallbackReason,
+          format = state.screenshotFormat,
+          captureSource = state.screenshotCaptureSource,
+          modifier = Modifier.align(Alignment.TopStart).padding(8.dp),
+        )
+      }
     }
 
     // Center panel: View Hierarchy (collapsible + resizable)

--- a/android/desktop-core/src/main/kotlin/dev/jasonpearson/automobile/desktop/core/video/VideoStreamClient.kt
+++ b/android/desktop-core/src/main/kotlin/dev/jasonpearson/automobile/desktop/core/video/VideoStreamClient.kt
@@ -403,6 +403,11 @@ class FakeVideoStreamSource(
   private var screenRecordingRequired: Boolean = false,
   private val screenRecordingApprovalTarget: String = "AutoMobile",
   private val nowMs: () -> Long = { 0L },
+  /**
+   * When true, [connect] stays in [VideoStreamState.Connecting] (never reaches Streaming) — for
+   * exercising the first-frame-deadline watchdog.
+   */
+  private val holdConnecting: Boolean = false,
 ) : VideoStreamSource {
   private val fakeSequence = java.util.concurrent.atomic.AtomicLong(0L)
 
@@ -437,6 +442,7 @@ class FakeVideoStreamSource(
             screenRecordingApprovalTarget,
           )
         refuseWith != null -> VideoStreamState.Unavailable(refuseWith)
+        holdConnecting -> VideoStreamState.Connecting
         else -> VideoStreamState.Streaming(1080, 2400)
       }
   }
@@ -453,6 +459,14 @@ class FakeVideoStreamSource(
   /** Simulates an unavailable relay after a stream has started. */
   fun becomeUnavailable(reason: String = "Live mirroring is unavailable on this daemon") {
     _state.value = VideoStreamState.Unavailable(reason)
+  }
+
+  /**
+   * Forces the Streaming state directly, independent of [connect] (which a `refuseWith` fake keeps
+   * routing to Unavailable) — used to stage a retained-frame-then-drop scenario.
+   */
+  fun becomeStreaming(width: Int = 1080, height: Int = 2400) {
+    _state.value = VideoStreamState.Streaming(width, height)
   }
 
   /** Simulates granting the macOS permission after the Settings flow. */

--- a/android/desktop-core/src/main/kotlin/dev/jasonpearson/automobile/desktop/core/workspace/DeviceStreamView.kt
+++ b/android/desktop-core/src/main/kotlin/dev/jasonpearson/automobile/desktop/core/workspace/DeviceStreamView.kt
@@ -24,6 +24,7 @@ import androidx.compose.ui.layout.ContentScale
 import androidx.compose.ui.platform.testTag
 import androidx.compose.ui.text.style.TextAlign
 import androidx.compose.ui.unit.dp
+import dev.jasonpearson.automobile.desktop.core.LIVE_STALL_RECONNECT_MS
 import dev.jasonpearson.automobile.desktop.core.layout.DeviceScreenView
 import dev.jasonpearson.automobile.desktop.core.platform.MacScreenRecordingSettingsLauncher
 import dev.jasonpearson.automobile.desktop.core.platform.ScreenRecordingSettingsLauncher
@@ -108,7 +109,16 @@ fun DeviceStreamView(
   // (VideoStreamSocketServer.attach). Changing an armed pane's live rate needs server-side capture
   // reconfiguration (follow-up); re-keying only added reconnect churn for no reliable effect.
   val source = remember(column.deviceId) { sourceFactory(column.deviceId) }
-  val liveFrame = rememberLiveVideoFrame(source, column.deviceId, autoReconnect = true)
+  val liveFrame =
+    rememberLiveVideoFrame(
+      source,
+      column.deviceId,
+      autoReconnect = true,
+      // The Streaming-stall reconnect is only valid for idle-heartbeat sources (Android). The iOS
+      // capture drops idle buffers, so a healthy static screen makes no frame progress and must
+      // NOT be reconnected; the first-frame deadline still catches a never-first-frame wedge.
+      stallReconnectMs = if (column.platform == Platform.Android) LIVE_STALL_RECONNECT_MS else null,
+    )
   val state by source.state.collectAsState()
   val controlSnapshot = control?.interactionSnapshot
   var settingsLaunchFailure by remember(column.deviceId) { mutableStateOf(false) }
@@ -135,12 +145,18 @@ fun DeviceStreamView(
         source.connect(column.deviceId)
       },
     )
-  } else if (enableDeviceControl && controlSnapshot != null && liveFrame != null) {
+  } else if (
+    enableDeviceControl &&
+      controlSnapshot != null &&
+      liveFrame != null &&
+      state is VideoStreamState.Streaming
+  ) {
     // Armed WITH live video: the pane's pixels are ALWAYS the live H.264 mirror — never the
-    // observation screenshot. The armed surface therefore also requires a decoded frame: before
-    // the first frame (or in the rare case video never arrives) the pane falls through to the
-    // mirror branch below and shows the status hint, instead of interacting against a stale
-    // still. Clicks map through the in-memory observation snapshot (its real device dimensions);
+    // observation screenshot. The armed surface requires a decoded frame AND a currently-Streaming
+    // relay: before the first frame the pane shows the status hint, and once the relay drops the
+    // last frame is still RENDERED (mirror branch below) but control DISARMS — a retained-but-stale
+    // frame must not stay clickable while untagged taps land on a device whose UI may have moved.
+    // Clicks map through the in-memory observation snapshot (its real device dimensions);
     // video and observation cover the same screen at the same aspect ratio, so a click normalized
     // against the displayed video maps to the same device pixel. DeviceScreenView already renders
     // a live bitmap while mapping through separate device dims — its inspector-mode

--- a/android/desktop-core/src/main/kotlin/dev/jasonpearson/automobile/desktop/core/workspace/DeviceStreamView.kt
+++ b/android/desktop-core/src/main/kotlin/dev/jasonpearson/automobile/desktop/core/workspace/DeviceStreamView.kt
@@ -21,6 +21,7 @@ import androidx.compose.runtime.setValue
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.layout.ContentScale
+import androidx.compose.ui.platform.testTag
 import androidx.compose.ui.text.style.TextAlign
 import androidx.compose.ui.unit.dp
 import dev.jasonpearson.automobile.desktop.core.layout.DeviceScreenView
@@ -64,6 +65,9 @@ import dev.jasonpearson.automobile.desktop.domain.DeviceScreenControlMode
 // subscriber's hint fixes the shared per-device encode.
 private const val CONTROL_PANE_FPS = 30
 private const val MIRROR_PANE_FPS = 10
+
+/** Test tag on the armed interactive-video surface, so tests can pin which branch rendered. */
+internal const val DEVICE_CONTROL_SURFACE_TEST_TAG = "device-control-surface"
 
 @Composable
 fun DeviceStreamView(
@@ -131,22 +135,23 @@ fun DeviceStreamView(
         source.connect(column.deviceId)
       },
     )
-  } else if (enableDeviceControl && controlSnapshot != null) {
-    // Armed: keep the SMOOTH LIVE VIDEO on screen, but map clicks through the in-memory
-    // observation
-    // snapshot (its real device dimensions + frameContext). The video and the observation
-    // screenshot
-    // are the same screen at the same aspect ratio, so a click normalized against the displayed
-    // video maps to the same device pixel. DeviceScreenView already renders a live bitmap while
-    // mapping through separate device dims — that's exactly its inspector-mode configuration,
-    // reused
-    // here with Control mode so the click dispatches instead of selecting an element.
+  } else if (enableDeviceControl && controlSnapshot != null && liveFrame != null) {
+    // Armed WITH live video: the pane's pixels are ALWAYS the live H.264 mirror — never the
+    // observation screenshot. The armed surface therefore also requires a decoded frame: before
+    // the first frame (or in the rare case video never arrives) the pane falls through to the
+    // mirror branch below and shows the status hint, instead of interacting against a stale
+    // still. Clicks map through the in-memory observation snapshot (its real device dimensions);
+    // video and observation cover the same screen at the same aspect ratio, so a click normalized
+    // against the displayed video maps to the same device pixel. DeviceScreenView already renders
+    // a live bitmap while mapping through separate device dims — its inspector-mode
+    // configuration, reused here with Control mode so the click dispatches instead of selecting.
     val renderSnapshot = control.renderSnapshot
     DeviceScreenView(
-      // Fallback pixels only until the first video frame decodes; liveFrame renders instead when
-      // set.
-      screenshotData = renderSnapshot?.screenshotData,
-      liveFrame = liveFrame?.bitmap,
+      // Deliberately null: observation screenshots are for geometry/inspection, not pane pixels.
+      // Passing them here is what made the pane visibly "switch over to screenshots" whenever the
+      // relay dropped a frame source; the retained live frame now covers those windows.
+      screenshotData = null,
+      liveFrame = liveFrame.bitmap,
       screenWidth = renderSnapshot?.deviceWidth ?: 0,
       screenHeight = renderSnapshot?.deviceHeight ?: 0,
       rotation = renderSnapshot?.rotation ?: 0,
@@ -156,7 +161,8 @@ fun DeviceStreamView(
       onElementSelected = {},
       onElementHovered = {},
       elementMap = renderSnapshot?.hierarchy?.elementMap?.takeIf { it.isNotEmpty() },
-      modifier = Modifier.fillMaxSize(),
+      // Tagged so tests can pin WHICH surface rendered (interactive video vs. hint/mirror).
+      modifier = Modifier.fillMaxSize().testTag(DEVICE_CONTROL_SURFACE_TEST_TAG),
       controlMode = DeviceScreenControlMode.Control,
       controlSnapshot = controlSnapshot,
       // The view maps a click through `snapshot`'s geometry and hands back the device-mapped

--- a/android/desktop-core/src/main/kotlin/dev/jasonpearson/automobile/desktop/core/workspace/LayoutFacet.kt
+++ b/android/desktop-core/src/main/kotlin/dev/jasonpearson/automobile/desktop/core/workspace/LayoutFacet.kt
@@ -2,6 +2,7 @@ package dev.jasonpearson.automobile.desktop.core.workspace
 
 import androidx.compose.runtime.Composable
 import androidx.compose.runtime.remember
+import dev.jasonpearson.automobile.desktop.core.LIVE_STALL_RECONNECT_MS
 import dev.jasonpearson.automobile.desktop.core.daemon.ObservationStream
 import dev.jasonpearson.automobile.desktop.core.daemon.ObservationStreamClient
 import dev.jasonpearson.automobile.desktop.core.datasource.DataSourceMode
@@ -63,7 +64,15 @@ fun LayoutFacet(
       socketAvailable = socketAvailable,
     )
   val videoSource = remember(column.deviceId) { videoSourceFactory(column.deviceId) }
-  val liveFrame = rememberLiveVideoFrame(videoSource, column.deviceId, autoReconnect = true)
+  val liveFrame =
+    rememberLiveVideoFrame(
+      videoSource,
+      column.deviceId,
+      autoReconnect = true,
+      // Streaming-stall reconnect only for idle-heartbeat sources (Android); the iOS capture drops
+      // idle buffers, so a static inspected screen legitimately makes no frame progress.
+      stallReconnectMs = if (column.platform == Platform.Android) LIVE_STALL_RECONNECT_MS else null,
+    )
   stream?.let { activeStream ->
     LayoutInspectorDashboard(
       dataSourceMode = DataSourceMode.Real,

--- a/android/desktop-core/src/main/kotlin/dev/jasonpearson/automobile/desktop/core/workspace/LayoutFacet.kt
+++ b/android/desktop-core/src/main/kotlin/dev/jasonpearson/automobile/desktop/core/workspace/LayoutFacet.kt
@@ -1,11 +1,23 @@
 package dev.jasonpearson.automobile.desktop.core.workspace
 
 import androidx.compose.runtime.Composable
+import androidx.compose.runtime.remember
 import dev.jasonpearson.automobile.desktop.core.daemon.ObservationStream
 import dev.jasonpearson.automobile.desktop.core.daemon.ObservationStreamClient
 import dev.jasonpearson.automobile.desktop.core.datasource.DataSourceMode
 import dev.jasonpearson.automobile.desktop.core.layout.LayoutInspectorDashboard
+import dev.jasonpearson.automobile.desktop.core.rememberLiveVideoFrame
+import dev.jasonpearson.automobile.desktop.core.video.VideoStreamClient
+import dev.jasonpearson.automobile.desktop.core.video.VideoStreamQuality
+import dev.jasonpearson.automobile.desktop.core.video.VideoStreamSource
 import kotlinx.coroutines.delay
+
+// Stream hints for the inspector's live mirror. Inspection wants CRISP pixels (element bounds are
+// read against them) but is mostly static, so High quality at a low rate is the right trade. When
+// this facet is the device's only subscriber (Inspect mode replaces the pane's stream area) its
+// hints fix the shared encode; when a pane already streams the device, the daemon keeps the first
+// subscriber's encode and these hints are ignored.
+private const val INSPECTOR_PANE_FPS = 10
 
 /**
  * Docked-facet body for the Layout Inspector, scoped to a single pane's device. An
@@ -14,12 +26,19 @@ import kotlinx.coroutines.delay
  * same per-device connect/dispose lifecycle as [LogsFacet]. Each pane therefore drives its own
  * stream and mirror, rather than following the app's active device.
  *
+ * The inspector's device panel renders LIVE VIDEO for its pixels (like the workspace video pane): a
+ * [VideoStreamSource] is owned per device with the same retain-across-drops reconnect semantics, so
+ * the panel never regresses to screenshots mid-session. The observation screenshot remains the
+ * pre-video bootstrap and the capture the hierarchy overlay/selection maps against.
+ *
  * [observationStreamFactory] is injected (defaulting to a real per-device
  * [ObservationStreamClient]) so the connect/dispose lifecycle can be verified with a
  * [FakeObservationStream] instead of real socket I/O. The stream reconnects automatically if it
  * drops while the facet is open (see [rememberReconnectingObservationStream]); [backoffDelay] and
  * [socketAvailable] are the injected timer/daemon-availability seams that let that recovery be
- * tested with virtual time.
+ * tested with virtual time. [videoSourceFactory] is the same seam for the live mirror, and
+ * [sessionUuidProvider] authenticates its subscribe against the stream-socket session guard (#4751)
+ * — the host supplies it from its `DesktopDaemonSession`.
  */
 @Composable
 fun LayoutFacet(
@@ -27,6 +46,14 @@ fun LayoutFacet(
   observationStreamFactory: () -> ObservationStream = { ObservationStreamClient() },
   backoffDelay: suspend (attempt: Int) -> Unit = { attempt -> delay(reconnectBackoffMs(attempt)) },
   socketAvailable: () -> Boolean = { ObservationStreamClient.socketExists() },
+  sessionUuidProvider: () -> String? = { null },
+  videoSourceFactory: (deviceId: String) -> VideoStreamSource = {
+    VideoStreamClient(
+      quality = VideoStreamQuality.High,
+      fps = INSPECTOR_PANE_FPS,
+      sessionUuidProvider = sessionUuidProvider,
+    )
+  },
 ) {
   val stream =
     rememberReconnectingObservationStream(
@@ -35,12 +62,15 @@ fun LayoutFacet(
       backoffDelay = backoffDelay,
       socketAvailable = socketAvailable,
     )
+  val videoSource = remember(column.deviceId) { videoSourceFactory(column.deviceId) }
+  val liveFrame = rememberLiveVideoFrame(videoSource, column.deviceId, autoReconnect = true)
   stream?.let { activeStream ->
     LayoutInspectorDashboard(
       dataSourceMode = DataSourceMode.Real,
       observationStream = activeStream,
       deviceId = column.deviceId,
       platform = if (column.platform == Platform.Ios) "ios" else "android",
+      liveFrame = liveFrame?.bitmap,
     )
   }
 }

--- a/android/desktop-core/src/main/kotlin/dev/jasonpearson/automobile/desktop/core/workspace/picker/DevicePicker.kt
+++ b/android/desktop-core/src/main/kotlin/dev/jasonpearson/automobile/desktop/core/workspace/picker/DevicePicker.kt
@@ -55,20 +55,17 @@ fun DevicePicker(
   onAction: (DevicePickerAction) -> Unit,
   onClose: () -> Unit,
   modifier: Modifier = Modifier,
-  // Authenticates each card's live-video subscribe against the daemon stream-socket session guard
-  // (#4751); the host supplies it from its DesktopDaemonSession. Null yields no live thumbnails.
-  sessionUuidProvider: () -> String? = { null },
   // Whether the "Close" affordance is offered. False when the grid is the app's home surface (no
   // observed workspace to return to); true when opened over an existing workspace ("Devices +").
   canClose: Boolean = true,
-  // The per-card device thumbnail. Hoisted (default = the live [DeviceThumbnail]) so a test can
-  // stub
-  // it and never open a video/observation socket while composing the grid.
+  // The per-card device thumbnail. Hoisted (default = the screenshot [DeviceThumbnail]) so a test
+  // can stub it and never open an observation socket while composing the grid. Thumbnails are
+  // stills by design — a per-card live-video subscription would put a standing capture/decode cost
+  // on every booted tile of a potentially huge grid.
   thumbnail: @Composable (device: PickerDevice, booting: Boolean) -> Unit = { device, booting ->
     DeviceThumbnail(
       device = device,
       booting = booting,
-      sessionUuidProvider = sessionUuidProvider,
       modifier = Modifier.fillMaxWidth().height(DeviceThumbnailHeight),
     )
   },

--- a/android/desktop-core/src/main/kotlin/dev/jasonpearson/automobile/desktop/core/workspace/picker/DeviceThumbnail.kt
+++ b/android/desktop-core/src/main/kotlin/dev/jasonpearson/automobile/desktop/core/workspace/picker/DeviceThumbnail.kt
@@ -9,7 +9,6 @@ import androidx.compose.foundation.shape.RoundedCornerShape
 import androidx.compose.material3.Text
 import androidx.compose.runtime.Composable
 import androidx.compose.runtime.LaunchedEffect
-import androidx.compose.runtime.collectAsState
 import androidx.compose.runtime.getValue
 import androidx.compose.runtime.mutableStateOf
 import androidx.compose.runtime.remember
@@ -29,17 +28,11 @@ import androidx.compose.ui.unit.sp
 import dev.jasonpearson.automobile.desktop.core.daemon.ObservationStream
 import dev.jasonpearson.automobile.desktop.core.daemon.ObservationStreamClient
 import dev.jasonpearson.automobile.desktop.core.logging.LoggerFactory
-import dev.jasonpearson.automobile.desktop.core.rememberLiveVideoFrame
-import dev.jasonpearson.automobile.desktop.core.video.VideoStreamClient
-import dev.jasonpearson.automobile.desktop.core.video.VideoStreamQuality
-import dev.jasonpearson.automobile.desktop.core.video.VideoStreamSource
-import dev.jasonpearson.automobile.desktop.core.video.VideoStreamState
 import java.util.Base64
 import kotlinx.coroutines.CancellationException
 import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.NonCancellable
 import kotlinx.coroutines.delay
-import kotlinx.coroutines.flow.StateFlow
 import kotlinx.coroutines.flow.first
 import kotlinx.coroutines.withContext
 import kotlinx.coroutines.withTimeoutOrNull
@@ -50,27 +43,17 @@ private val LOG = LoggerFactory.getLogger("DeviceThumbnail")
 /** Height of a grid device thumbnail; the frame is aspect-fit centered on black inside it. */
 private val THUMBNAIL_HEIGHT = 132.dp
 
-// Frame-rate hint for a grid thumbnail's live mirror. Even lower than a workspace pane: thumbnails
-// are glanceable, non-interactive previews, so a slow rate keeps a farm of dozens of concurrent
-// on-device H.264 encodes cheap. (Captures are shared per device on the daemon and the first
-// subscriber fixes the encode, so a device also open in a higher-rate pane keeps the pane's rate.)
-private const val THUMBNAIL_FPS = 5
-
-// Backoff bounds for the screenshot-fallback capture retry (see captureScreenshotWithRetry).
+// Backoff bounds for the screenshot capture retry (see captureScreenshotWithRetry).
 private const val SCREENSHOT_RETRY_INITIAL_MS = 1_000L
 private const val SCREENSHOT_RETRY_MAX_MS = 15_000L
 
 /**
- * Capture a fallback still, retrying with bounded exponential backoff until one succeeds. Each
- * attempt first waits for the live relay to be unavailable or need Screen Recording approval —
- * there is no point capturing an observation still while live video works (the caller prefers the
- * frame), so a recovered relay pauses retries. A single timed-out or too-early capture therefore no
- * longer leaves the card stuck on "No preview": when the observation service becomes ready, the
- * next attempt succeeds. The caller cancels this by leaving the composition. [delayMs] is
- * injectable so a test can drive the cadence without real time.
+ * Capture the thumbnail still, retrying with bounded exponential backoff until one succeeds. A
+ * single timed-out or too-early capture must not leave the card stuck on its hint: when the
+ * observation service becomes ready, the next attempt succeeds. The caller cancels this by leaving
+ * the composition. [delayMs] is injectable so a test can drive the cadence without real time.
  */
 internal suspend fun captureScreenshotWithRetry(
-  state: StateFlow<VideoStreamState>,
   deviceId: String,
   source: DeviceThumbnailScreenshotSource,
   initialBackoffMs: Long = SCREENSHOT_RETRY_INITIAL_MS,
@@ -79,9 +62,6 @@ internal suspend fun captureScreenshotWithRetry(
 ): ImageBitmap {
   var backoff = initialBackoffMs
   while (true) {
-    state.first {
-      it is VideoStreamState.Unavailable || it is VideoStreamState.PermissionRequired
-    }
     source.latest(deviceId)?.let {
       return it
     }
@@ -93,9 +73,9 @@ internal suspend fun captureScreenshotWithRetry(
 /**
  * The static label a non-booted card shows over its black thumbnail: `"Booting"` while a boot is in
  * flight (its id is in the picker's `bootingIds`), `"Shutdown"` for a shut-down device, and null
- * for a booted device (its live video / screenshot renders instead). Pure so a same-module test can
- * pin the wording without composing the view. `bootingIds` is a subset of the shut-down ids, so a
- * booted device never reads as booting.
+ * for a booted device (its last screenshot renders instead). Pure so a same-module test can pin the
+ * wording without composing the view. `bootingIds` is a subset of the shut-down ids, so a booted
+ * device never reads as booting.
  *
  * A future "shutting down" transient (the grid has no kill path today) plugs in as one more branch
  * ahead of the shut-down case.
@@ -107,9 +87,7 @@ internal fun thumbnailPlaceholder(state: DeviceState, booting: Boolean): String?
     else -> null
   }
 
-/**
- * A last-known screenshot for a device, used as the thumbnail fallback when live video is absent.
- */
+/** A last-known screenshot for a device, rendered as the grid thumbnail. */
 interface DeviceThumbnailScreenshotSource {
   /** The most recent screenshot for [deviceId], or null when none can be captured. */
   suspend fun latest(deviceId: String): ImageBitmap?
@@ -117,29 +95,20 @@ interface DeviceThumbnailScreenshotSource {
 
 /**
  * Device thumbnail for a picker grid card.
- * - **Booted** → the daemon's live video relay (a `low`-quality [VideoStreamClient] per card,
- *   shared captures on the daemon make many cards affordable), aspect-fit on black.
- * - **Booted but no live frame** (relay predates this daemon or the subscribe was refused) → the
- *   last available screenshot from [screenshotSource], fetched lazily only once the relay reports
- *   `Unavailable`, so the fallback stays cheap.
+ * - **Booted** → the last observation screenshot, captured once per card via [screenshotSource] and
+ *   aspect-fit on black. DELIBERATELY not live video: the grid can show hundreds of devices, and a
+ *   per-card H.264 subscription would start a device capture/encode on the daemon and a decoder in
+ *   the desktop for every booted tile — a glanceable preview is not worth that standing cost. Live
+ *   video belongs to the workspace panes a device is actually opened into.
  * - **Shut-down / booting** → a solid black box with a centered "Shutdown" / "Booting" label.
  *
- * [videoSourceFactory] and [screenshotSource] are hoisted so a test drives this with a
- * `FakeVideoStreamSource` and a fake screenshot source instead of opening sockets.
+ * [screenshotSource] is hoisted so a test drives this with a fake instead of opening sockets.
  */
 @Composable
 fun DeviceThumbnail(
   device: PickerDevice,
   booting: Boolean,
-  sessionUuidProvider: () -> String?,
   modifier: Modifier = Modifier,
-  videoSourceFactory: (deviceId: String) -> VideoStreamSource = { deviceId ->
-    VideoStreamClient(
-      quality = VideoStreamQuality.Low,
-      fps = THUMBNAIL_FPS,
-      sessionUuidProvider = sessionUuidProvider,
-    )
-  },
   screenshotSource: DeviceThumbnailScreenshotSource? = ObservationScreenshotSource,
 ) {
   Box(
@@ -153,81 +122,52 @@ fun DeviceThumbnail(
     if (placeholder != null) {
       Text(placeholder, color = Color.White.copy(alpha = 0.6f), fontSize = 12.sp)
     } else {
-      LiveThumbnail(device.id, device.name, videoSourceFactory, screenshotSource)
+      ScreenshotThumbnail(device.id, device.name, screenshotSource)
     }
   }
 }
 
 @Composable
-private fun LiveThumbnail(
+private fun ScreenshotThumbnail(
   deviceId: String,
   deviceName: String,
-  videoSourceFactory: (deviceId: String) -> VideoStreamSource,
   screenshotSource: DeviceThumbnailScreenshotSource?,
 ) {
-  val source = remember(deviceId) { videoSourceFactory(deviceId) }
-  val liveFrame = rememberLiveVideoFrame(source, deviceId, autoReconnect = true)
-  val state by source.state.collectAsState()
-  val bitmap = liveFrame?.bitmap
-
-  // Fetch the screenshot fallback while the relay is unavailable or needs Screen Recording
-  // approval, retrying with backoff until it yields a still — so a daemon that predates the relay
-  // (or the pristine home grid before a session is registered) still shows a frame, and a single
-  // timed-out/early capture doesn't leave the card stuck on "No preview" once the observation
-  // service recovers. Keyed on deviceId only (NOT the live stream state): auto-reconnect cycles
-  // Connecting<->Unavailable, and keying on the full state would cancel and restart the capture on
-  // every flip. The retry pauses while live video works, and the `when` below still prefers a live
-  // frame if one arrives.
+  // One still per card mount, retried with backoff until the observation service yields one. Keyed
+  // on deviceId: a rebooted device unmounts through the "Shutdown"/"Booting" placeholder, so a
+  // fresh boot captures a fresh still rather than showing the previous boot's screen.
   var screenshot by remember(deviceId) { mutableStateOf<ImageBitmap?>(null) }
   LaunchedEffect(deviceId, screenshotSource) {
     if (screenshotSource != null && screenshot == null) {
-      screenshot = captureScreenshotWithRetry(source.state, deviceId, screenshotSource)
+      screenshot = captureScreenshotWithRetry(deviceId, screenshotSource)
     }
   }
 
-  val fallback = screenshot
-  when {
-    bitmap != null ->
-      Image(
-        bitmap = bitmap,
-        contentDescription = "Live thumbnail of $deviceName",
-        modifier = Modifier.fillMaxSize(),
-        contentScale = ContentScale.Fit,
-      )
-    fallback != null ->
-      Image(
-        bitmap = fallback,
-        contentDescription = "Screenshot of $deviceName",
-        modifier = Modifier.fillMaxSize(),
-        contentScale = ContentScale.Fit,
-      )
-    else ->
-      Text(
-        liveHint(state),
-        color = Color.White.copy(alpha = 0.5f),
-        fontSize = 11.sp,
-        textAlign = TextAlign.Center,
-        modifier = Modifier.padding(8.dp),
-      )
+  val still = screenshot
+  if (still != null) {
+    Image(
+      bitmap = still,
+      contentDescription = "Screenshot of $deviceName",
+      modifier = Modifier.fillMaxSize(),
+      contentScale = ContentScale.Fit,
+    )
+  } else {
+    Text(
+      "No preview yet",
+      color = Color.White.copy(alpha = 0.5f),
+      fontSize = 11.sp,
+      textAlign = TextAlign.Center,
+      modifier = Modifier.padding(8.dp),
+    )
   }
 }
-
-/** One-line hint shown on a booted card that has neither a live frame nor a screenshot yet. */
-private fun liveHint(state: VideoStreamState): String =
-  when (state) {
-    is VideoStreamState.Idle,
-    is VideoStreamState.Connecting -> "Connecting…"
-    is VideoStreamState.Streaming -> "Waiting for frame…"
-    is VideoStreamState.PermissionRequired -> "Screen Recording needs approval"
-    is VideoStreamState.Unavailable -> "No preview"
-  }
 
 /** Fixed thumbnail height, exposed so the card lays out the row above/below it consistently. */
 internal val DeviceThumbnailHeight = THUMBNAIL_HEIGHT
 
 /**
- * Screenshot fallback backed by a one-shot [ObservationStream] observation. Deliberately does NOT
- * cache across calls: the caller ([LiveThumbnail]) already holds the captured still in per-deviceId
+ * Thumbnail still backed by a one-shot [ObservationStream] observation. Deliberately does NOT cache
+ * across calls: the caller ([ScreenshotThumbnail]) already holds the captured still in per-deviceId
  * composition state, and a booted card unmounts through the "Shutdown"/"Booting" placeholder on a
  * reboot — so a rebooted device (same AVD/simulator id) captures a fresh still rather than showing
  * the previous boot's screen indefinitely (which a process-lifetime cache keyed only by deviceId
@@ -258,7 +198,7 @@ object ObservationScreenshotSource : DeviceThumbnailScreenshotSource {
     } catch (cancellation: CancellationException) {
       throw cancellation
     } catch (error: Exception) {
-      LOG.warn("Thumbnail screenshot fallback failed for $deviceId: ${error.message}", error)
+      LOG.warn("Thumbnail screenshot capture failed for $deviceId: ${error.message}", error)
       null
     } finally {
       withContext(NonCancellable + Dispatchers.IO) { stream.dispose() }

--- a/android/desktop-core/src/test/kotlin/dev/jasonpearson/automobile/desktop/core/LiveVideoStreamTest.kt
+++ b/android/desktop-core/src/test/kotlin/dev/jasonpearson/automobile/desktop/core/LiveVideoStreamTest.kt
@@ -68,6 +68,69 @@ class LiveVideoStreamTest {
   }
 
   @Test
+  fun `auto-reconnect retains the last frame across a relay drop`() = runComposeUiTest {
+    // The workspace video pane must never regress to a non-video surface while the relay
+    // re-subscribes: with autoReconnect on, the last decoded frame is RETAINED through
+    // Unavailable instead of cleared (the plain path above keeps its clear-and-blend contract).
+    val source = FakeVideoStreamSource()
+    var observedFrame: androidx.compose.ui.graphics.ImageBitmap? = null
+
+    setContent {
+      val liveFrame =
+        rememberLiveVideoFrame(
+          source,
+          "emulator-5554",
+          autoReconnect = true,
+          reconnectInitialMs = 10,
+        )
+      SideEffect { observedFrame = liveFrame?.bitmap }
+    }
+
+    source.emitFrame(width = 1, height = 1)
+    waitUntil { observedFrame != null }
+
+    source.becomeUnavailable("Live mirroring stopped")
+    // The retry re-subscribes on its own; the fake emits NO new frame afterwards, so a frame
+    // that had been cleared would still read null here — non-null proves retention.
+    waitUntil(timeoutMillis = 2_000) { source.state.value is VideoStreamState.Streaming }
+    waitForIdle()
+    assertTrue(observedFrame != null)
+  }
+
+  @Test
+  fun `reconnects when a Streaming relay stops delivering frames`() = runComposeUiTest {
+    // A relay that stalls with its socket OPEN never leaves Streaming, so the Unavailable-driven
+    // retry above cannot fire — frame progress ceasing is the only signal. The stall watchdog
+    // must reconnect, and the stale frame must stay rendered while it does.
+    val monotonic = { System.nanoTime() / 1_000_000L }
+    val source = FakeVideoStreamSource(nowMs = monotonic)
+    var observedFrame: androidx.compose.ui.graphics.ImageBitmap? = null
+
+    setContent {
+      val liveFrame =
+        rememberLiveVideoFrame(
+          source,
+          "emulator-5554",
+          autoReconnect = true,
+          reconnectInitialMs = 10,
+          nowMs = monotonic,
+          stallReconnectMs = 100,
+          stallCheckIntervalMs = 20,
+        )
+      SideEffect { observedFrame = liveFrame?.bitmap }
+    }
+
+    waitUntil { source.connectCalls >= 1 }
+    source.emitFrame(width = 1, height = 1)
+    waitUntil { observedFrame != null }
+
+    // No further frames arrive: the watchdog must tear down and re-subscribe on its own.
+    waitUntil(timeoutMillis = 5_000) { source.connectCalls >= 2 }
+    waitForIdle()
+    assertTrue(observedFrame != null)
+  }
+
+  @Test
   fun `auto-reconnect re-subscribes after the relay drops`() = runComposeUiTest {
     // A dropped relay ("Live mirroring stopped") must heal itself rather than stay dead until the
     // pane is torn down. With autoReconnect on, an Unavailable state triggers a connect() retry —

--- a/android/desktop-core/src/test/kotlin/dev/jasonpearson/automobile/desktop/core/LiveVideoStreamTest.kt
+++ b/android/desktop-core/src/test/kotlin/dev/jasonpearson/automobile/desktop/core/LiveVideoStreamTest.kt
@@ -131,6 +131,57 @@ class LiveVideoStreamTest {
   }
 
   @Test
+  fun `an idle-heartbeat-less source is NOT reconnected while idle-Streaming`() = runComposeUiTest {
+    // iOS drops idle ScreenCaptureKit buffers, so a healthy static screen makes no frame progress.
+    // With stallReconnectMs = null the watchdog must leave a Streaming-but-idle stream alone rather
+    // than churn a healthy capture (#5255 review). connectCalls stays at the initial subscribe.
+    val monotonic = { System.nanoTime() / 1_000_000L }
+    val source = FakeVideoStreamSource(nowMs = monotonic)
+    setContent {
+      rememberLiveVideoFrame(
+        source,
+        "ios-simulator",
+        autoReconnect = true,
+        reconnectInitialMs = 10,
+        nowMs = monotonic,
+        stallReconnectMs = null, // iOS
+        firstFrameTimeoutMs = 100,
+        stallCheckIntervalMs = 20,
+      )
+    }
+    waitUntil { source.connectCalls >= 1 }
+    source.emitFrame(width = 1, height = 1) // first frame arrives → Streaming, then idle forever
+    // Wait well past both the first-frame deadline and several stall-check intervals.
+    Thread.sleep(400)
+    waitForIdle()
+    assertEquals(1, source.connectCalls) // idle Streaming is healthy; never reconnected
+  }
+
+  @Test
+  fun `reconnects a stream stuck in Connecting past the first-frame deadline`() = runComposeUiTest {
+    // A subscribe accepted (or connecting) that never yields a decodable first frame is the
+    // key-frame wedge; neither the Streaming-stall watchdog nor the Unavailable retry can see it.
+    // The first-frame deadline must re-subscribe (#5255 review).
+    val monotonic = { System.nanoTime() / 1_000_000L }
+    val source = FakeVideoStreamSource(nowMs = monotonic, holdConnecting = true)
+    setContent {
+      rememberLiveVideoFrame(
+        source,
+        "emulator-5554",
+        autoReconnect = true,
+        reconnectInitialMs = 10,
+        nowMs = monotonic,
+        stallReconnectMs = null,
+        firstFrameTimeoutMs = 100,
+        stallCheckIntervalMs = 20,
+      )
+    }
+    waitUntil { source.connectCalls >= 1 }
+    // Never leaves Connecting; the first-frame deadline must force a re-subscribe.
+    waitUntil(timeoutMillis = 5_000) { source.connectCalls >= 2 }
+  }
+
+  @Test
   fun `auto-reconnect re-subscribes after the relay drops`() = runComposeUiTest {
     // A dropped relay ("Live mirroring stopped") must heal itself rather than stay dead until the
     // pane is torn down. With autoReconnect on, an Unavailable state triggers a connect() retry —

--- a/android/desktop-core/src/test/kotlin/dev/jasonpearson/automobile/desktop/core/daemon/McpDaemonClientInputTest.kt
+++ b/android/desktop-core/src/test/kotlin/dev/jasonpearson/automobile/desktop/core/daemon/McpDaemonClientInputTest.kt
@@ -610,7 +610,9 @@ class McpDaemonClientInputTest {
     // loop, half-open socket) hung the caller forever — for the video pane that meant one hung
     // call froze ALL input behind its single dispatch thread ("input stops working"). The
     // deadline must fail just that call, quickly and with a clear message.
-    val socketDir = Files.createTempDirectory("am-hang-test")
+    // Bind under /tmp like TestDaemonSocket: a Unix-socket path has a ~104-byte platform limit and
+    // macOS's default temp dir (/var/folders/...) can exceed it, failing the bind.
+    val socketDir = Files.createTempDirectory(Path.of("/tmp"), "am-hang-")
     val socketPath = socketDir.resolve("daemon.sock")
     val server = ServerSocketChannel.open(StandardProtocolFamily.UNIX)
     server.bind(UnixDomainSocketAddress.of(socketPath))

--- a/android/desktop-core/src/test/kotlin/dev/jasonpearson/automobile/desktop/core/daemon/McpDaemonClientInputTest.kt
+++ b/android/desktop-core/src/test/kotlin/dev/jasonpearson/automobile/desktop/core/daemon/McpDaemonClientInputTest.kt
@@ -14,6 +14,7 @@ import java.nio.file.Path
 import kotlin.test.Test
 import kotlin.test.assertFailsWith
 import kotlin.test.assertNull
+import kotlin.test.assertTrue
 import kotlinx.serialization.SerializationException
 import kotlinx.serialization.json.Json
 import kotlinx.serialization.json.JsonObject
@@ -600,6 +601,57 @@ class McpDaemonClientInputTest {
     assertEquals(false, stdioResult.success)
     assertEquals("input/tap", stdioResult.action)
     assertEquals("MCP STDIO does not support direct daemon input helpers", stdioResult.error)
+  }
+
+  @Test
+  fun `a daemon that accepts but never replies fails the input call at its deadline`() {
+    // The request socket is a blocking SocketChannel, which has NO read timeout: without the
+    // request watchdog a daemon that accepts the connection but never answers (wedged event
+    // loop, half-open socket) hung the caller forever — for the video pane that meant one hung
+    // call froze ALL input behind its single dispatch thread ("input stops working"). The
+    // deadline must fail just that call, quickly and with a clear message.
+    val socketDir = Files.createTempDirectory("am-hang-test")
+    val socketPath = socketDir.resolve("daemon.sock")
+    val server = ServerSocketChannel.open(StandardProtocolFamily.UNIX)
+    server.bind(UnixDomainSocketAddress.of(socketPath))
+    var accepted: java.nio.channels.SocketChannel? = null
+    val accepter = Thread {
+      try {
+        accepted = server.accept() // Hold the connection open and never reply.
+        while (!Thread.currentThread().isInterrupted) Thread.sleep(50)
+      } catch (_: Exception) {
+        // Server/channel closed by the test's cleanup: the hang is over.
+      }
+    }
+      .apply {
+        isDaemon = true
+        start()
+      }
+    try {
+      val client =
+        McpDaemonClient(
+          socketPathValue = socketPath.toString(),
+          inputRequestTimeoutMs = 100,
+        )
+      val error =
+        assertFailsWith<DaemonUnavailableException> {
+          client.inputTap(
+            x = 1.0,
+            y = 2.0,
+            platform = "android",
+            deviceId = "emulator-5554",
+            duration = null,
+            frameContext = null,
+          )
+        }
+      assertTrue(error.message.orEmpty().contains("timed out"))
+    } finally {
+      accepter.interrupt()
+      accepted?.close()
+      server.close()
+      Files.deleteIfExists(socketPath)
+      Files.deleteIfExists(socketDir)
+    }
   }
 
   private fun captureInputRequest(

--- a/android/desktop-core/src/test/kotlin/dev/jasonpearson/automobile/desktop/core/workspace/DeviceStreamViewTest.kt
+++ b/android/desktop-core/src/test/kotlin/dev/jasonpearson/automobile/desktop/core/workspace/DeviceStreamViewTest.kt
@@ -168,6 +168,40 @@ class DeviceStreamViewTest {
   }
 
   @Test
+  fun `armed control disarms when the relay drops, but the retained frame keeps rendering`() =
+    runComposeUiTest {
+      // Retention keeps the last video frame on screen across a drop, but a stale frame must NOT
+      // stay clickable — untagged taps would land on a device whose UI may have moved (#5255
+      // review). refuseWith keeps the auto-reconnect from racing the state back to Streaming.
+      val source =
+        FakeVideoStreamSource(refuseWith = "dropped", nowMs = { System.nanoTime() / 1_000_000L })
+      val scope = CoroutineScope(Dispatchers.Unconfined)
+      setContent {
+        MaterialTheme {
+          DeviceStreamView(
+            col(),
+            enableDeviceControl = true,
+            control = armedControlState(scope),
+            sourceFactory = { source },
+          )
+        }
+      }
+      // Stage a live frame: force Streaming, emit, and confirm the armed interactive surface.
+      runOnUiThread { source.becomeStreaming() }
+      source.emitFrame()
+      waitUntilExactlyOneExists(hasTestTag(DEVICE_CONTROL_SURFACE_TEST_TAG))
+
+      // Relay drops: control disarms (surface gone) but the retained frame still renders as a
+      // plain mirror image.
+      runOnUiThread { source.becomeUnavailable("dropped") }
+      waitUntil {
+        onAllNodesWithTag(DEVICE_CONTROL_SURFACE_TEST_TAG).fetchSemanticsNodes().isEmpty()
+      }
+      onNodeWithContentDescription("Live stream of Pixel 8").assertIsDisplayed()
+      scope.cancel()
+    }
+
+  @Test
   fun `an armed iOS pane still surfaces Screen Recording approval over the control view`() =
     runComposeUiTest {
       // Regression: a refused iOS relay (PermissionRequired) must win even when device control is

--- a/android/desktop-core/src/test/kotlin/dev/jasonpearson/automobile/desktop/core/workspace/DeviceStreamViewTest.kt
+++ b/android/desktop-core/src/test/kotlin/dev/jasonpearson/automobile/desktop/core/workspace/DeviceStreamViewTest.kt
@@ -5,12 +5,15 @@ import androidx.compose.runtime.mutableStateOf
 import androidx.compose.ui.test.ExperimentalTestApi
 import androidx.compose.ui.test.assertCountEquals
 import androidx.compose.ui.test.assertIsDisplayed
+import androidx.compose.ui.test.hasTestTag
 import androidx.compose.ui.test.onAllNodesWithContentDescription
+import androidx.compose.ui.test.onAllNodesWithTag
 import androidx.compose.ui.test.onAllNodesWithText
 import androidx.compose.ui.test.onNodeWithContentDescription
 import androidx.compose.ui.test.onNodeWithText
 import androidx.compose.ui.test.performClick
 import androidx.compose.ui.test.runComposeUiTest
+import androidx.compose.ui.test.waitUntilExactlyOneExists
 import dev.jasonpearson.automobile.desktop.core.control.testSnapshot
 import dev.jasonpearson.automobile.desktop.core.platform.ScreenRecordingSettingsLauncher
 import dev.jasonpearson.automobile.desktop.core.video.FakeVideoStreamSource
@@ -100,6 +103,69 @@ class DeviceStreamViewTest {
       onNodeWithText("Check again").performClick()
       waitUntil { source.connectCalls > connectsBeforeRetry }
     }
+
+  /** A minimal armed control state whose dispatcher never reaches a daemon. */
+  private fun armedControlState(scope: CoroutineScope) =
+    WorkspaceDeviceControlState(
+      dispatcher =
+        VideoInputDispatcher(
+          scope = scope,
+          clientProvider = { null },
+          platform = { "android" },
+          deviceId = "emulator-5554",
+          tracer = InteractionLatencyTracer(),
+        ),
+      interactionSnapshot = testSnapshot(),
+      renderSnapshot = testSnapshot(),
+      tapError = null,
+      tracer = InteractionLatencyTracer(),
+    )
+
+  @Test
+  fun `an armed pane without video yet shows the waiting hint, not a screenshot surface`() =
+    runComposeUiTest {
+      // The pane's pixels are ALWAYS live video. Before the first decoded frame the armed branch
+      // must fall through to the status hint instead of rendering the observation screenshot as an
+      // interactive still — the "pane switches over to screenshots" regression (#3348 family).
+      val source = FakeVideoStreamSource()
+      val scope = CoroutineScope(Dispatchers.Unconfined)
+      setContent {
+        MaterialTheme {
+          DeviceStreamView(
+            col(),
+            enableDeviceControl = true,
+            control = armedControlState(scope),
+            sourceFactory = { source },
+          )
+        }
+      }
+
+      onNodeWithText("Waiting for the first frame…").assertIsDisplayed()
+      onAllNodesWithTag(DEVICE_CONTROL_SURFACE_TEST_TAG).assertCountEquals(0)
+      scope.cancel()
+    }
+
+  @Test
+  fun `an armed pane with live video renders the interactive video surface`() = runComposeUiTest {
+    val source = FakeVideoStreamSource(nowMs = { System.nanoTime() / 1_000_000L })
+    val scope = CoroutineScope(Dispatchers.Unconfined)
+    setContent {
+      MaterialTheme {
+        DeviceStreamView(
+          col(),
+          enableDeviceControl = true,
+          control = armedControlState(scope),
+          sourceFactory = { source },
+        )
+      }
+    }
+
+    waitUntil { source.connectedDeviceId == "emulator-5554" }
+    source.emitFrame()
+    waitUntilExactlyOneExists(hasTestTag(DEVICE_CONTROL_SURFACE_TEST_TAG))
+    onAllNodesWithText("Waiting for the first frame…").assertCountEquals(0)
+    scope.cancel()
+  }
 
   @Test
   fun `an armed iOS pane still surfaces Screen Recording approval over the control view`() =

--- a/android/desktop-core/src/test/kotlin/dev/jasonpearson/automobile/desktop/core/workspace/LayoutFacetTest.kt
+++ b/android/desktop-core/src/test/kotlin/dev/jasonpearson/automobile/desktop/core/workspace/LayoutFacetTest.kt
@@ -8,6 +8,7 @@ import androidx.compose.ui.test.runComposeUiTest
 import dev.jasonpearson.automobile.desktop.core.connection.ConnectionState
 import dev.jasonpearson.automobile.desktop.core.daemon.FakeObservationStream
 import dev.jasonpearson.automobile.desktop.core.daemon.ObservationStream
+import dev.jasonpearson.automobile.desktop.core.video.FakeVideoStreamSource
 import kotlinx.coroutines.CompletableDeferred
 import org.junit.Assert.assertEquals
 import org.junit.Assert.assertTrue
@@ -33,6 +34,7 @@ class LayoutFacetTest {
           LayoutFacet(
             column = DeviceColumn(deviceId = "dev-1", name = "Pixel", platform = Platform.Android),
             observationStreamFactory = { fake },
+            videoSourceFactory = { FakeVideoStreamSource() },
           )
         }
       }
@@ -59,6 +61,7 @@ class LayoutFacetTest {
             column =
               DeviceColumn(deviceId = deviceId.value, name = "Pixel", platform = Platform.Android),
             observationStreamFactory = factory,
+            videoSourceFactory = { FakeVideoStreamSource() },
           )
         }
       }
@@ -88,10 +91,12 @@ class LayoutFacetTest {
           LayoutFacet(
             column = DeviceColumn(deviceId = "dev-1", name = "Pixel", platform = Platform.Android),
             observationStreamFactory = factory,
+            videoSourceFactory = { FakeVideoStreamSource() },
           )
           LayoutFacet(
             column = DeviceColumn(deviceId = "dev-2", name = "iPhone", platform = Platform.Ios),
             observationStreamFactory = factory,
+            videoSourceFactory = { FakeVideoStreamSource() },
           )
         }
       }
@@ -115,6 +120,7 @@ class LayoutFacetTest {
           observationStreamFactory = { fake },
           backoffDelay = { backoff.await() },
           socketAvailable = { true },
+          videoSourceFactory = { FakeVideoStreamSource() },
         )
       }
     }
@@ -129,4 +135,30 @@ class LayoutFacetTest {
     waitForIdle()
     assertEquals("expected the facet to reconnect after a drop", 2, fake.connectCallCount)
   }
+
+  @Test
+  fun `owns a live video mirror scoped to the pane device and disposes it on removal`() =
+    runComposeUiTest {
+      // The inspector's device panel renders LIVE VIDEO for its pixels (screenshots are only the
+      // pre-video bootstrap + the capture selection maps against), so the facet owns a per-device
+      // video source with the pane's connect/dispose lifecycle.
+      val video = FakeVideoStreamSource()
+      val visible = mutableStateOf(true)
+      setContent {
+        MaterialTheme {
+          if (visible.value) {
+            LayoutFacet(
+              column =
+                DeviceColumn(deviceId = "dev-1", name = "Pixel", platform = Platform.Android),
+              observationStreamFactory = { FakeObservationStream() },
+              videoSourceFactory = { video },
+            )
+          }
+        }
+      }
+      waitUntil { video.connectedDeviceId == "dev-1" }
+
+      runOnIdle { visible.value = false }
+      waitUntil { video.connectedDeviceId == null }
+    }
 }

--- a/android/desktop-core/src/test/kotlin/dev/jasonpearson/automobile/desktop/core/workspace/picker/DeviceThumbnailTest.kt
+++ b/android/desktop-core/src/test/kotlin/dev/jasonpearson/automobile/desktop/core/workspace/picker/DeviceThumbnailTest.kt
@@ -8,14 +8,9 @@ import androidx.compose.ui.test.onAllNodesWithContentDescription
 import androidx.compose.ui.test.onNodeWithContentDescription
 import androidx.compose.ui.test.onNodeWithText
 import androidx.compose.ui.test.runComposeUiTest
-import dev.jasonpearson.automobile.desktop.core.video.FakeVideoStreamSource
-import dev.jasonpearson.automobile.desktop.core.video.VideoStreamPermission
-import dev.jasonpearson.automobile.desktop.core.video.VideoStreamState
 import dev.jasonpearson.automobile.desktop.core.workspace.Platform
 import kotlinx.coroutines.ExperimentalCoroutinesApi
-import kotlinx.coroutines.flow.MutableStateFlow
 import kotlinx.coroutines.test.runTest
-import kotlinx.coroutines.withTimeout
 import org.junit.Assert.assertEquals
 import org.junit.Assert.assertNotNull
 import org.junit.Assert.assertNull
@@ -29,7 +24,6 @@ class DeviceThumbnailTest {
 
   @Test
   fun `screenshot capture retries with backoff until it yields a still`() = runTest {
-    val state = MutableStateFlow<VideoStreamState>(VideoStreamState.Unavailable("no relay"))
     var attempts = 0
     val source =
       object : DeviceThumbnailScreenshotSource {
@@ -41,7 +35,6 @@ class DeviceThumbnailTest {
     val delays = mutableListOf<Long>()
     val shot =
       captureScreenshotWithRetry(
-        state,
         "d",
         source,
         initialBackoffMs = 1_000L,
@@ -54,26 +47,6 @@ class DeviceThumbnailTest {
   }
 
   @Test
-  fun `screenshot capture uses the fallback while Screen Recording approval is pending`() =
-    runTest {
-      val state =
-        MutableStateFlow<VideoStreamState>(
-          VideoStreamState.PermissionRequired(
-            VideoStreamPermission.ScreenRecordingNeedsApproval,
-            "AutoMobile",
-          )
-        )
-      val source =
-        object : DeviceThumbnailScreenshotSource {
-          override suspend fun latest(deviceId: String): ImageBitmap = ImageBitmap(1, 1)
-        }
-
-      val shot = withTimeout(100) { captureScreenshotWithRetry(state, "d", source) }
-
-      assertNotNull(shot)
-    }
-
-  @Test
   fun `placeholder label reflects device state`() {
     assertEquals("Booting", thumbnailPlaceholder(DeviceState.Shutdown, booting = true))
     assertEquals("Shutdown", thumbnailPlaceholder(DeviceState.Shutdown, booting = false))
@@ -83,14 +56,7 @@ class DeviceThumbnailTest {
   @Test
   fun `a shut-down device shows the Shutdown placeholder`() = runComposeUiTest {
     setContent {
-      MaterialTheme {
-        DeviceThumbnail(
-          shutdown,
-          booting = false,
-          sessionUuidProvider = { null },
-          screenshotSource = null,
-        )
-      }
+      MaterialTheme { DeviceThumbnail(shutdown, booting = false, screenshotSource = null) }
     }
     onNodeWithText("Shutdown").assertIsDisplayed()
   }
@@ -98,98 +64,34 @@ class DeviceThumbnailTest {
   @Test
   fun `a booting device shows the Booting placeholder`() = runComposeUiTest {
     setContent {
-      MaterialTheme {
-        DeviceThumbnail(
-          shutdown,
-          booting = true,
-          sessionUuidProvider = { null },
-          screenshotSource = null,
-        )
-      }
+      MaterialTheme { DeviceThumbnail(shutdown, booting = true, screenshotSource = null) }
     }
     onNodeWithText("Booting").assertIsDisplayed()
   }
 
   @Test
-  fun `a booted device renders the live video frame`() = runComposeUiTest {
-    val source = FakeVideoStreamSource()
-    setContent {
-      MaterialTheme {
-        DeviceThumbnail(
-          booted,
-          booting = false,
-          sessionUuidProvider = { null },
-          videoSourceFactory = { source },
-          screenshotSource = null,
-        )
+  fun `a booted device renders the last screenshot`() = runComposeUiTest {
+    // Thumbnails are stills BY DESIGN: a per-card live-video subscription would put a standing
+    // device capture + decoder cost on every booted tile of a potentially huge grid. The card
+    // renders the observation screenshot and never opens a video socket.
+    val screenshot =
+      object : DeviceThumbnailScreenshotSource {
+        override suspend fun latest(deviceId: String): ImageBitmap? = ImageBitmap(1, 1)
       }
+    setContent {
+      MaterialTheme { DeviceThumbnail(booted, booting = false, screenshotSource = screenshot) }
     }
-    waitUntil { source.connectedDeviceId != null }
-    source.emitFrame(width = 1, height = 1)
     waitUntil {
-      onAllNodesWithContentDescription("Live thumbnail of Pixel 8")
-        .fetchSemanticsNodes()
-        .isNotEmpty()
+      onAllNodesWithContentDescription("Screenshot of Pixel 8").fetchSemanticsNodes().isNotEmpty()
     }
-    onNodeWithContentDescription("Live thumbnail of Pixel 8").assertIsDisplayed()
+    onNodeWithContentDescription("Screenshot of Pixel 8").assertIsDisplayed()
   }
 
   @Test
-  fun `a booted iOS device names a pending Screen Recording approval`() = runComposeUiTest {
-    val source = FakeVideoStreamSource(screenRecordingRequired = true)
+  fun `a booted device with no screenshot yet shows the pending hint`() = runComposeUiTest {
     setContent {
-      MaterialTheme {
-        DeviceThumbnail(
-          PickerDevice("ios-simulator", "iPhone 16", Platform.Ios, DeviceState.Booted),
-          booting = false,
-          sessionUuidProvider = { null },
-          videoSourceFactory = { source },
-          screenshotSource = null,
-        )
-      }
+      MaterialTheme { DeviceThumbnail(booted, booting = false, screenshotSource = null) }
     }
-
-    onNodeWithText("Screen Recording needs approval").assertIsDisplayed()
+    onNodeWithText("No preview yet").assertIsDisplayed()
   }
-
-  @Test
-  fun `a booted device falls back to the last screenshot when the relay is unavailable`() =
-    runComposeUiTest {
-      val screenshot =
-        object : DeviceThumbnailScreenshotSource {
-          override suspend fun latest(deviceId: String): ImageBitmap? = ImageBitmap(1, 1)
-        }
-      setContent {
-        MaterialTheme {
-          DeviceThumbnail(
-            booted,
-            booting = false,
-            sessionUuidProvider = { null },
-            videoSourceFactory = { FakeVideoStreamSource(refuseWith = "no relay") },
-            screenshotSource = screenshot,
-          )
-        }
-      }
-      waitUntil {
-        onAllNodesWithContentDescription("Screenshot of Pixel 8").fetchSemanticsNodes().isNotEmpty()
-      }
-      onNodeWithContentDescription("Screenshot of Pixel 8").assertIsDisplayed()
-    }
-
-  @Test
-  fun `a booted device with no relay and no screenshot shows a no-preview hint`() =
-    runComposeUiTest {
-      setContent {
-        MaterialTheme {
-          DeviceThumbnail(
-            booted,
-            booting = false,
-            sessionUuidProvider = { null },
-            videoSourceFactory = { FakeVideoStreamSource(refuseWith = "no relay") },
-            screenshotSource = null,
-          )
-        }
-      }
-      onNodeWithText("No preview").assertIsDisplayed()
-    }
 }

--- a/src/daemon/videoStreamSocketServer.ts
+++ b/src/daemon/videoStreamSocketServer.ts
@@ -306,8 +306,12 @@ export class VideoStreamSocketServer extends BaseSocketServer {
       this.replayParameterSets(capture, socket);
       // Startup can synchronously emit an IDR before the acknowledgement makes this socket
       // eligible for binary data. Gate the subscriber and ask for a post-ack keyframe so it
-      // never begins on an undecodable inter-frame.
-      capture.source?.requestKeyFrame?.();
+      // never begins on an undecodable inter-frame. Retried through the injected timer when the
+      // source throttles the request (same helper as the drain path): a bare call that lands
+      // inside the throttle window (~3s Android/raw-iOS) would leave this just-promoted
+      // subscriber parked in waitingForKeyFrame until the encoder's natural GOP — which on an
+      // idle screen is exactly the frozen-pane-on-reconnect symptom.
+      this.requestKeyFrameForWaitingSubscriber(device.deviceId, socket);
     } catch (error) {
       logger.warn(`[VideoStream] subscribe failed: ${error}`);
       this.detach(socket);

--- a/test/daemon/videoStreamSocketServer.test.ts
+++ b/test/daemon/videoStreamSocketServer.test.ts
@@ -83,6 +83,8 @@ async function startHarness(
     resolveError?: Error;
     authenticator?: StreamSocketAuthenticator;
     timer?: Timer;
+    /** Pre-arms each created source to throttle this many key-frame requests. */
+    keyFrameRejections?: number;
   } = {}
 ): Promise<Harness> {
   const dir = mkdtempSync(path.join(tmpdir(), "amvs-"));
@@ -107,6 +109,7 @@ async function startHarness(
         const source = new FakeCaptureSource();
         source.startError = options.startError ?? null;
         source.startGate = options.startGate ?? null;
+        source.keyFrameRejectionsRemaining = options.keyFrameRejections ?? 0;
         source.onStart = () => {
           if (options.startData) {
             onData?.(options.startData);
@@ -677,6 +680,24 @@ describe("VideoStreamSocketServer", () => {
     await waitFor(() => source.keyFrameRequests > before);
 
     expect(source.keyFrameRequests).toBeGreaterThan(before);
+  });
+
+  test("a key frame throttled at subscribe time is retried until the source honors one", async () => {
+    // The subscribe-ack path asks the source for an immediate IDR so a (re)joining subscriber never
+    // starts on an undecodable inter-frame. When that request lands inside the source's throttle
+    // window (~3s on Android/raw-iOS) a bare call is silently rejected and the subscriber sits in
+    // waitingForKeyFrame until the natural GOP — the frozen-pane-on-reconnect symptom. The retrying
+    // helper must keep asking through the injected timer until the source honors one.
+    const fakeTimer = new FakeTimer();
+    fakeTimer.enableAutoAdvance();
+    const h = await startHarness({ timer: fakeTimer, keyFrameRejections: 2 });
+    await subscribe(h.socketPath);
+    await waitFor(() => h.sources.length > 0);
+    const source = h.sources[0];
+
+    // 2 throttled attempts + the honored one. Without the retry the count would stay at 1.
+    await waitFor(() => source.keyFrameRequests >= 3);
+    expect(source.keyFrameRejectionsRemaining).toBe(0);
   });
 
   test("a key frame throttled at drain time is retried until the source honors one", async () => {


### PR DESCRIPTION
Fixes three user-reported correctness issues in the interactive video pane (0.0.55 / #5221), each traced to a verified mechanism. No latency regressions: the changes are render-only plus watchdogs that fire only when something is already hung.

## 1. "Pane switches over to screenshots" — eliminated

- `rememberLiveVideoFrame` **retains the last decoded frame** across a relay drop on the auto-reconnect (workspace) path, instead of clearing it and letting the pane regress to the observation screenshot for the whole 1–15s reconnect backoff. The IDE-plugin path keeps its original clear-and-blend contract.
- The armed control surface now passes `screenshotData = null` — observation screenshots are for geometry/inspection, **never pane pixels** — and requires a decoded frame; until the first frame the pane shows the status hint rather than an interactive stale still.

## 2. "Video sometimes stops" — both wedge classes fixed

- **Client stall watchdog:** a relay stalled with its socket open never leaves `Streaming`, so the `Unavailable`-driven reconnect could never fire. The pane now reconnects after 10s without frame progress (healthy-idle Android heartbeats ~1fps, so 10 missed seconds is decisively a stall). With frame retention the reconnect is visually seamless.
- **Daemon subscribe-keyframe retry:** the subscribe-ack path ignored a throttled `requestKeyFrame()` while the just-promoted subscriber sat in `waitingForKeyFrame` — a reconnecting client landing inside the ~3s throttle window froze until the natural GOP. Subscribe now uses the same retrying helper #5245 added for the drain path.

## 3. "Input sometimes stops" — permanent wedge removed

`McpDaemonClient.sendRequest` did a blocking `SocketChannel` read with **no deadline** (SocketChannel has no read-timeout support). A daemon that accepted the connection but never replied hung the calling thread forever — and for the video pane that thread is the single input-dispatch thread inside its FIFO mutex, so one hung call silently killed **all** input until the pane was rebuilt. A shared watchdog now closes the channel at a deadline (**5s input helpers / 60s ordinary requests** — hang ceilings, not latency budgets; a healthy round-trip stays ~ms), failing the one call so the dispatcher sheds it and the next input proceeds on a fresh connection.

## Tests

- Frame retention across a relay drop; stall-watchdog reconnect (both against `FakeVideoStreamSource`)
- Armed pane: hint until first frame, interactive video surface with a frame (new `testTag` pins branch selection)
- Accept-but-never-reply daemon fails `inputTap` at its deadline (real Unix socket)
- Subscribe-time throttled keyframe retry over a real relay socket (rejecting fake + FakeTimer)

Full `desktop-core` suite + detekt green; TS video suite 37 pass; typecheck/oxlint clean. The daemon change is in the WHEP paths-filter, so both device lanes run on this PR.

## Follow-up commit: surface policy for the inspector + picker

- **Layout inspector renders live video**: `LayoutFacet` owns a per-device video source (High quality / 10fps) with the same retain-across-drops semantics; the observation screenshot stays as pre-video bootstrap + the capture selection maps against, and the screenshot metadata badge hides while video renders. The app plumbs the session uuid so the subscribe passes stream auth.
- **Picker thumbnails are stills by design**: each booted card previously opened its own Low/5fps video subscription — a standing capture/encode+decode cost per tile that does not scale to a grid of hundreds of devices. Cards now render the last observation screenshot only and never open a video socket; live video belongs to the panes a device is opened into.
