### PR TITLE
feat(desktop): status-bar 'update ready' button in the lower-left corner (#5225)

### DIFF
--- a/android/desktop-app/src/main/kotlin/dev/jasonpearson/automobile/desktop/AutoMobileDesktopApp.kt
+++ b/android/desktop-app/src/main/kotlin/dev/jasonpearson/automobile/desktop/AutoMobileDesktopApp.kt
@@ -15,7 +15,10 @@ import androidx.compose.runtime.remember
 import androidx.compose.runtime.rememberCoroutineScope
 import androidx.compose.runtime.setValue
 import androidx.compose.runtime.snapshotFlow
+import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
+import androidx.compose.ui.platform.LocalDensity
+import androidx.compose.ui.unit.IntOffset
 import androidx.compose.ui.unit.dp
 import androidx.compose.ui.window.Popup
 import androidx.compose.ui.window.PopupProperties
@@ -149,6 +152,17 @@ fun AutoMobileDesktopApp(
   openPaletteRequest: Int = 0,
 ) {
   val graph = LocalAutoMobileGraph.current
+
+  // Update availability (#5225): collect the controller and run one check at app startup — hoisted
+  // above the surface switch so it runs regardless of the launch surface (onboarding, picker, or
+  // workspace), not only after a device is observed. Keyed to the controller so a graph change
+  // re-checks exactly once, rather than on every workspace re-entry. Dev / -SNAPSHOT builds no-op
+  // it.
+  val updateController = graph.updateController
+  val updateStatus by updateController.status.collectAsState()
+  var showUpdateDetails by remember { mutableStateOf(false) }
+  LaunchedEffect(updateController) { updateController.checkForUpdate() }
+
   val settings = remember(graph) { ObservableSettingsProvider(graph.settingsProvider) }
   val scope = rememberCoroutineScope()
   val controlExecutor = remember(graph) { DaemonEmulatorControlExecutor(graph.autoMobileClient) }
@@ -418,12 +432,6 @@ fun AutoMobileDesktopApp(
                 deriveWorkspaceStatus(daemon = daemonState, devices = emptyList())
               }
 
-            // Update availability (#5225): observe the controller and run one check at startup.
-            // Dev / -SNAPSHOT builds no-op the check, so the pill never appears in development.
-            val updateStatus by graph.updateController.status.collectAsState()
-            var showUpdateDetails by remember { mutableStateOf(false) }
-            LaunchedEffect(Unit) { graph.updateController.checkForUpdate() }
-
             WorkspaceShell(
               state = workspaceState,
               onAction = workspaceViewModel::onAction,
@@ -464,7 +472,15 @@ fun AutoMobileDesktopApp(
             // install action inside is disabled.
             val availableUpdate = updateStatus as? UpdateStatus.UpdateAvailable
             if (showUpdateDetails && availableUpdate != null) {
+              // Anchor the popup under the top-right pill (below the 40dp top bar) rather than the
+              // window's default top-left, so it reads as coming from its trigger.
+              val popupOffset =
+                with(LocalDensity.current) {
+                  IntOffset(x = -8.dp.roundToPx(), y = 44.dp.roundToPx())
+                }
               Popup(
+                alignment = Alignment.TopEnd,
+                offset = popupOffset,
                 onDismissRequest = { showUpdateDetails = false },
                 properties = PopupProperties(focusable = true),
               ) {

--- a/android/desktop-app/src/main/kotlin/dev/jasonpearson/automobile/desktop/AutoMobileDesktopApp.kt
+++ b/android/desktop-app/src/main/kotlin/dev/jasonpearson/automobile/desktop/AutoMobileDesktopApp.kt
@@ -2,6 +2,7 @@ package dev.jasonpearson.automobile.desktop
 
 import androidx.compose.foundation.layout.Box
 import androidx.compose.foundation.layout.fillMaxSize
+import androidx.compose.foundation.shape.RoundedCornerShape
 import androidx.compose.material3.MaterialTheme
 import androidx.compose.material3.Surface
 import androidx.compose.runtime.Composable
@@ -15,6 +16,9 @@ import androidx.compose.runtime.rememberCoroutineScope
 import androidx.compose.runtime.setValue
 import androidx.compose.runtime.snapshotFlow
 import androidx.compose.ui.Modifier
+import androidx.compose.ui.unit.dp
+import androidx.compose.ui.window.Popup
+import androidx.compose.ui.window.PopupProperties
 import dev.jasonpearson.automobile.desktop.core.connection.ConnectionState
 import dev.jasonpearson.automobile.desktop.core.daemon.AutoMobileClient
 import dev.jasonpearson.automobile.desktop.core.daemon.DesktopDaemonSession
@@ -24,6 +28,9 @@ import dev.jasonpearson.automobile.desktop.core.mcp.DaemonMcpResourceClient
 import dev.jasonpearson.automobile.desktop.core.mcp.ResourceReadResult
 import dev.jasonpearson.automobile.desktop.core.settings.SettingsProvider
 import dev.jasonpearson.automobile.desktop.core.shell.MenuBarActions
+import dev.jasonpearson.automobile.desktop.core.shell.UpdateDetailsContent
+import dev.jasonpearson.automobile.desktop.core.shell.openReleaseNotesInBrowser
+import dev.jasonpearson.automobile.desktop.core.update.UpdateStatus
 import dev.jasonpearson.automobile.desktop.core.workspace.BOOTED_DEVICES_RESOURCE_URI
 import dev.jasonpearson.automobile.desktop.core.workspace.CommandPalette
 import dev.jasonpearson.automobile.desktop.core.workspace.DEVICE_LOCK_STATES_RESOURCE_URI
@@ -410,6 +417,13 @@ fun AutoMobileDesktopApp(
               remember(daemonState) {
                 deriveWorkspaceStatus(daemon = daemonState, devices = emptyList())
               }
+
+            // Update availability (#5225): observe the controller and run one check at startup.
+            // Dev / -SNAPSHOT builds no-op the check, so the pill never appears in development.
+            val updateStatus by graph.updateController.status.collectAsState()
+            var showUpdateDetails by remember { mutableStateOf(false) }
+            LaunchedEffect(Unit) { graph.updateController.checkForUpdate() }
+
             WorkspaceShell(
               state = workspaceState,
               onAction = workspaceViewModel::onAction,
@@ -417,6 +431,8 @@ fun AutoMobileDesktopApp(
               onOpenPalette = { paletteOpen = true },
               status = workspaceStatus.status,
               statusDetail = workspaceStatus.detail,
+              updateStatus = updateStatus,
+              onUpdateClick = { showUpdateDetails = true },
               facetContent = { column, tool -> WorkspaceFacet(column, tool) },
               // Live device mirror in each pane's stream area, fed by the daemon's video-stream
               // relay. The pane authenticates with the workspace daemon session (#4977) bound to
@@ -440,6 +456,32 @@ fun AutoMobileDesktopApp(
                   ),
                 onDismiss = { paletteOpen = false },
               )
+            }
+
+            // Details popup for the top-bar update pill (#5225). `as?` closes it automatically if
+            // the
+            // status leaves UpdateAvailable while open. Applying the update is a later item, so the
+            // install action inside is disabled.
+            val availableUpdate = updateStatus as? UpdateStatus.UpdateAvailable
+            if (showUpdateDetails && availableUpdate != null) {
+              Popup(
+                onDismissRequest = { showUpdateDetails = false },
+                properties = PopupProperties(focusable = true),
+              ) {
+                Surface(
+                  shape = RoundedCornerShape(6.dp),
+                  color = MaterialTheme.colorScheme.surface,
+                  shadowElevation = 8.dp,
+                ) {
+                  UpdateDetailsContent(
+                    update = availableUpdate,
+                    currentVersion = graph.appVersionProvider.current().raw,
+                    onOpenReleaseNotes = {
+                      availableUpdate.releaseNotesUrl?.let { openReleaseNotesInBrowser(it) }
+                    },
+                  )
+                }
+              }
             }
           }
       }

--- a/android/desktop-app/src/main/kotlin/dev/jasonpearson/automobile/desktop/di/AutoMobileGraph.kt
+++ b/android/desktop-app/src/main/kotlin/dev/jasonpearson/automobile/desktop/di/AutoMobileGraph.kt
@@ -5,7 +5,9 @@ import dev.jasonpearson.automobile.desktop.core.datasource.DataSourceFactory
 import dev.jasonpearson.automobile.desktop.core.di.AppScope
 import dev.jasonpearson.automobile.desktop.core.di.AutoMobileGraphProvider
 import dev.jasonpearson.automobile.desktop.core.di.SingleIn
+import dev.jasonpearson.automobile.desktop.core.platform.AppVersionProvider
 import dev.jasonpearson.automobile.desktop.core.settings.SettingsProvider
+import dev.jasonpearson.automobile.desktop.core.update.UpdateController
 import dev.zacsweers.metro.DependencyGraph
 
 /**
@@ -26,6 +28,12 @@ interface AutoMobileGraph : AutoMobileGraphProvider {
 
   /** Factory for creating data source instances. */
   override val dataSourceFactory: DataSourceFactory
+
+  /** Checks GitHub Releases for a newer desktop build (#5224). */
+  override val updateController: UpdateController
+
+  /** The running app's own version (#5223). */
+  override val appVersionProvider: AppVersionProvider
 
   /** Factory for creating the graph. Metro generates the implementation. */
   @DependencyGraph.Factory

--- a/android/desktop-core/src/main/kotlin/dev/jasonpearson/automobile/desktop/core/di/AutoMobileGraphProvider.kt
+++ b/android/desktop-core/src/main/kotlin/dev/jasonpearson/automobile/desktop/core/di/AutoMobileGraphProvider.kt
@@ -2,7 +2,9 @@ package dev.jasonpearson.automobile.desktop.core.di
 
 import dev.jasonpearson.automobile.desktop.core.daemon.AutoMobileClient
 import dev.jasonpearson.automobile.desktop.core.datasource.DataSourceFactory
+import dev.jasonpearson.automobile.desktop.core.platform.AppVersionProvider
 import dev.jasonpearson.automobile.desktop.core.settings.SettingsProvider
+import dev.jasonpearson.automobile.desktop.core.update.UpdateController
 
 /**
  * Interface exposing the dependencies the UI layer needs from the DI graph.
@@ -19,4 +21,10 @@ interface AutoMobileGraphProvider {
 
   /** Factory for creating data source instances. */
   val dataSourceFactory: DataSourceFactory
+
+  /** Checks GitHub Releases for a newer desktop build; drives the status-bar update affordance. */
+  val updateController: UpdateController
+
+  /** The running app's own version, used to show "you're on X" and to gate update checks. */
+  val appVersionProvider: AppVersionProvider
 }

--- a/android/desktop-core/src/main/kotlin/dev/jasonpearson/automobile/desktop/core/di/LocalAutoMobileGraph.kt
+++ b/android/desktop-core/src/main/kotlin/dev/jasonpearson/automobile/desktop/core/di/LocalAutoMobileGraph.kt
@@ -3,7 +3,11 @@ package dev.jasonpearson.automobile.desktop.core.di
 import androidx.compose.runtime.staticCompositionLocalOf
 import dev.jasonpearson.automobile.desktop.core.daemon.McpClientFactory
 import dev.jasonpearson.automobile.desktop.core.datasource.DefaultDataSourceFactory
+import dev.jasonpearson.automobile.desktop.core.platform.PackagedVersionSource
+import dev.jasonpearson.automobile.desktop.core.platform.RuntimeAppVersionProvider
 import dev.jasonpearson.automobile.desktop.core.settings.FakeSettingsProvider
+import dev.jasonpearson.automobile.desktop.core.update.GitHubReleaseSource
+import dev.jasonpearson.automobile.desktop.core.update.RealUpdateController
 
 /**
  * CompositionLocal providing the DI graph to the Compose UI tree.
@@ -14,9 +18,12 @@ import dev.jasonpearson.automobile.desktop.core.settings.FakeSettingsProvider
 val LocalAutoMobileGraph =
   staticCompositionLocalOf<AutoMobileGraphProvider> {
     val client = McpClientFactory.createPreferred()
+    val versionProvider = RuntimeAppVersionProvider(PackagedVersionSource())
     object : AutoMobileGraphProvider {
       override val autoMobileClient = client
       override val settingsProvider = FakeSettingsProvider()
       override val dataSourceFactory = DefaultDataSourceFactory(client)
+      override val appVersionProvider = versionProvider
+      override val updateController = RealUpdateController(GitHubReleaseSource(), versionProvider)
     }
   }

--- a/android/desktop-core/src/main/kotlin/dev/jasonpearson/automobile/desktop/core/shell/ThreePaneShell.kt
+++ b/android/desktop-core/src/main/kotlin/dev/jasonpearson/automobile/desktop/core/shell/ThreePaneShell.kt
@@ -20,9 +20,12 @@ import androidx.compose.foundation.layout.fillMaxWidth
 import androidx.compose.foundation.layout.height
 import androidx.compose.foundation.layout.padding
 import androidx.compose.foundation.layout.width
+import androidx.compose.foundation.shape.RoundedCornerShape
+import androidx.compose.material3.Surface
 import androidx.compose.material3.Text
 import androidx.compose.runtime.Composable
 import androidx.compose.runtime.LaunchedEffect
+import androidx.compose.runtime.collectAsState
 import androidx.compose.runtime.getValue
 import androidx.compose.runtime.mutableStateOf
 import androidx.compose.runtime.remember
@@ -48,7 +51,11 @@ import androidx.compose.ui.platform.LocalDensity
 import androidx.compose.ui.unit.Dp
 import androidx.compose.ui.unit.dp
 import androidx.compose.ui.unit.sp
+import androidx.compose.ui.window.Popup
+import androidx.compose.ui.window.PopupProperties
+import dev.jasonpearson.automobile.desktop.core.di.LocalAutoMobileGraph
 import dev.jasonpearson.automobile.desktop.core.theme.SharedTheme
+import dev.jasonpearson.automobile.desktop.core.update.UpdateStatus
 import kotlinx.coroutines.delay
 
 /** Represents which pane currently has keyboard focus. */
@@ -163,6 +170,13 @@ fun ThreePaneShell(
   // Modal overlays
   var showCheatSheet by remember { mutableStateOf(false) }
   var showQuickJump by remember { mutableStateOf(false) }
+
+  // Update availability — observe the controller (item #5224) and run one check at startup. Dev /
+  // -SNAPSHOT builds no-op the check, so the pill never appears in development.
+  val autoMobileGraph = LocalAutoMobileGraph.current
+  val updateStatus by autoMobileGraph.updateController.status.collectAsState()
+  var showUpdateDetails by remember { mutableStateOf(false) }
+  LaunchedEffect(Unit) { autoMobileGraph.updateController.checkForUpdate() }
 
   // Observe menu bar triggers for overlays
   if (menuBarActions != null) {
@@ -363,7 +377,31 @@ fun ThreePaneShell(
             networkReqPerSec = networkReqPerSec,
             connectionStartTime = connectionStartTime,
             cpuUsagePercent = cpuUsagePercent,
+            updateStatus = updateStatus,
+            onUpdateClick = { showUpdateDetails = true },
           )
+        }
+
+        val availableUpdate = updateStatus as? UpdateStatus.UpdateAvailable
+        if (showUpdateDetails && availableUpdate != null) {
+          Popup(
+            onDismissRequest = { showUpdateDetails = false },
+            properties = PopupProperties(focusable = true),
+          ) {
+            Surface(
+              shape = RoundedCornerShape(6.dp),
+              color = SharedTheme.globalColors.panelBackground,
+              shadowElevation = 8.dp,
+            ) {
+              UpdateDetailsContent(
+                update = availableUpdate,
+                currentVersion = autoMobileGraph.appVersionProvider.current().raw,
+                onOpenReleaseNotes = {
+                  availableUpdate.releaseNotesUrl?.let { openReleaseNotesInBrowser(it) }
+                },
+              )
+            }
+          }
         }
 
         // Right inspector (collapsible)
@@ -529,6 +567,8 @@ private fun StatusBarStub(
   networkReqPerSec: Float? = null,
   connectionStartTime: Long? = null,
   cpuUsagePercent: Float? = null,
+  updateStatus: UpdateStatus = UpdateStatus.Idle,
+  onUpdateClick: () -> Unit = {},
 ) {
   val colors = SharedTheme.globalColors
   val totalFailures = crashCount + anrCount + nonFatalCount + toolFailureCount
@@ -553,6 +593,12 @@ private fun StatusBarStub(
       .padding(horizontal = 8.dp),
     verticalAlignment = Alignment.CenterVertically,
   ) {
+    // Update-ready affordance — lower-left corner; visible only when an update is available.
+    UpdateReadyButton(status = updateStatus, onClick = onUpdateClick)
+    if (updateStatus is UpdateStatus.UpdateAvailable) {
+      Spacer(Modifier.width(8.dp))
+    }
+
     // Connection indicator — clickable segment
     val connColor =
       if (isDaemonConnected) Color(0xFF4CAF50) else colors.text.normal.copy(alpha = 0.3f)

--- a/android/desktop-core/src/main/kotlin/dev/jasonpearson/automobile/desktop/core/shell/ThreePaneShell.kt
+++ b/android/desktop-core/src/main/kotlin/dev/jasonpearson/automobile/desktop/core/shell/ThreePaneShell.kt
@@ -20,12 +20,9 @@ import androidx.compose.foundation.layout.fillMaxWidth
 import androidx.compose.foundation.layout.height
 import androidx.compose.foundation.layout.padding
 import androidx.compose.foundation.layout.width
-import androidx.compose.foundation.shape.RoundedCornerShape
-import androidx.compose.material3.Surface
 import androidx.compose.material3.Text
 import androidx.compose.runtime.Composable
 import androidx.compose.runtime.LaunchedEffect
-import androidx.compose.runtime.collectAsState
 import androidx.compose.runtime.getValue
 import androidx.compose.runtime.mutableStateOf
 import androidx.compose.runtime.remember
@@ -51,11 +48,7 @@ import androidx.compose.ui.platform.LocalDensity
 import androidx.compose.ui.unit.Dp
 import androidx.compose.ui.unit.dp
 import androidx.compose.ui.unit.sp
-import androidx.compose.ui.window.Popup
-import androidx.compose.ui.window.PopupProperties
-import dev.jasonpearson.automobile.desktop.core.di.LocalAutoMobileGraph
 import dev.jasonpearson.automobile.desktop.core.theme.SharedTheme
-import dev.jasonpearson.automobile.desktop.core.update.UpdateStatus
 import kotlinx.coroutines.delay
 
 /** Represents which pane currently has keyboard focus. */
@@ -170,13 +163,6 @@ fun ThreePaneShell(
   // Modal overlays
   var showCheatSheet by remember { mutableStateOf(false) }
   var showQuickJump by remember { mutableStateOf(false) }
-
-  // Update availability — observe the controller (item #5224) and run one check at startup. Dev /
-  // -SNAPSHOT builds no-op the check, so the pill never appears in development.
-  val autoMobileGraph = LocalAutoMobileGraph.current
-  val updateStatus by autoMobileGraph.updateController.status.collectAsState()
-  var showUpdateDetails by remember { mutableStateOf(false) }
-  LaunchedEffect(Unit) { autoMobileGraph.updateController.checkForUpdate() }
 
   // Observe menu bar triggers for overlays
   if (menuBarActions != null) {
@@ -377,31 +363,7 @@ fun ThreePaneShell(
             networkReqPerSec = networkReqPerSec,
             connectionStartTime = connectionStartTime,
             cpuUsagePercent = cpuUsagePercent,
-            updateStatus = updateStatus,
-            onUpdateClick = { showUpdateDetails = true },
           )
-        }
-
-        val availableUpdate = updateStatus as? UpdateStatus.UpdateAvailable
-        if (showUpdateDetails && availableUpdate != null) {
-          Popup(
-            onDismissRequest = { showUpdateDetails = false },
-            properties = PopupProperties(focusable = true),
-          ) {
-            Surface(
-              shape = RoundedCornerShape(6.dp),
-              color = SharedTheme.globalColors.panelBackground,
-              shadowElevation = 8.dp,
-            ) {
-              UpdateDetailsContent(
-                update = availableUpdate,
-                currentVersion = autoMobileGraph.appVersionProvider.current().raw,
-                onOpenReleaseNotes = {
-                  availableUpdate.releaseNotesUrl?.let { openReleaseNotesInBrowser(it) }
-                },
-              )
-            }
-          }
         }
 
         // Right inspector (collapsible)
@@ -567,8 +529,6 @@ private fun StatusBarStub(
   networkReqPerSec: Float? = null,
   connectionStartTime: Long? = null,
   cpuUsagePercent: Float? = null,
-  updateStatus: UpdateStatus = UpdateStatus.Idle,
-  onUpdateClick: () -> Unit = {},
 ) {
   val colors = SharedTheme.globalColors
   val totalFailures = crashCount + anrCount + nonFatalCount + toolFailureCount
@@ -593,12 +553,6 @@ private fun StatusBarStub(
       .padding(horizontal = 8.dp),
     verticalAlignment = Alignment.CenterVertically,
   ) {
-    // Update-ready affordance — lower-left corner; visible only when an update is available.
-    UpdateReadyButton(status = updateStatus, onClick = onUpdateClick)
-    if (updateStatus is UpdateStatus.UpdateAvailable) {
-      Spacer(Modifier.width(8.dp))
-    }
-
     // Connection indicator — clickable segment
     val connColor =
       if (isDaemonConnected) Color(0xFF4CAF50) else colors.text.normal.copy(alpha = 0.3f)

--- a/android/desktop-core/src/main/kotlin/dev/jasonpearson/automobile/desktop/core/shell/UpdateReadyButton.kt
+++ b/android/desktop-core/src/main/kotlin/dev/jasonpearson/automobile/desktop/core/shell/UpdateReadyButton.kt
@@ -9,12 +9,12 @@ import androidx.compose.foundation.layout.Spacer
 import androidx.compose.foundation.layout.padding
 import androidx.compose.foundation.layout.width
 import androidx.compose.foundation.shape.RoundedCornerShape
-import androidx.compose.material3.Icon
-import androidx.compose.material3.Text
-import androidx.compose.material3.TextButton
 import androidx.compose.material.icons.Icons
 import androidx.compose.material.icons.filled.Download
 import androidx.compose.material.icons.filled.SystemUpdateAlt
+import androidx.compose.material3.Icon
+import androidx.compose.material3.Text
+import androidx.compose.material3.TextButton
 import androidx.compose.runtime.Composable
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
@@ -34,7 +34,7 @@ private val UpdateAccent = Color(0xFF4CAF50)
 private val LOG = LoggerFactory.getLogger("UpdateReadyButton")
 
 /** Opens [url] in the user's default browser. Best-effort — a failure is logged, not surfaced. */
-internal fun openReleaseNotesInBrowser(url: String) {
+fun openReleaseNotesInBrowser(url: String) {
   try {
     Desktop.getDesktop().browse(URI(url))
   } catch (error: Exception) {
@@ -44,8 +44,8 @@ internal fun openReleaseNotesInBrowser(url: String) {
 
 /**
  * The lower-left status-bar affordance that appears only when an update is available. Pure: it
- * renders from [status] and calls [onClick]; it performs no network work and does not reach into the
- * DI graph (the shell observes the controller and passes state down).
+ * renders from [status] and calls [onClick]; it performs no network work and does not reach into
+ * the DI graph (the shell observes the controller and passes state down).
  */
 @Composable
 fun UpdateReadyButton(
@@ -72,7 +72,12 @@ fun UpdateReadyButton(
       tint = UpdateAccent,
       modifier = Modifier.width(12.dp),
     )
-    Text(text = "Update ready", style = DesktopTypography.label, color = UpdateAccent, lineHeight = 10.sp)
+    Text(
+      text = "Update ready",
+      style = DesktopTypography.label,
+      color = UpdateAccent,
+      lineHeight = 10.sp,
+    )
   }
 }
 

--- a/android/desktop-core/src/main/kotlin/dev/jasonpearson/automobile/desktop/core/shell/UpdateReadyButton.kt
+++ b/android/desktop-core/src/main/kotlin/dev/jasonpearson/automobile/desktop/core/shell/UpdateReadyButton.kt
@@ -13,6 +13,7 @@ import androidx.compose.material.icons.Icons
 import androidx.compose.material.icons.filled.Download
 import androidx.compose.material.icons.filled.SystemUpdateAlt
 import androidx.compose.material3.Icon
+import androidx.compose.material3.MaterialTheme
 import androidx.compose.material3.Text
 import androidx.compose.material3.TextButton
 import androidx.compose.runtime.Composable
@@ -28,9 +29,6 @@ import dev.jasonpearson.automobile.desktop.core.update.UpdateStatus
 import java.awt.Desktop
 import java.net.URI
 
-/** Accent used for the update affordance — a calm green that reads as "good news, optional". */
-private val UpdateAccent = Color(0xFF4CAF50)
-
 private val LOG = LoggerFactory.getLogger("UpdateReadyButton")
 
 /** Opens [url] in the user's default browser. Best-effort — a failure is logged, not surfaced. */
@@ -43,9 +41,10 @@ fun openReleaseNotesInBrowser(url: String) {
 }
 
 /**
- * The lower-left status-bar affordance that appears only when an update is available. Pure: it
- * renders from [status] and calls [onClick]; it performs no network work and does not reach into
- * the DI graph (the shell observes the controller and passes state down).
+ * The status-bar affordance that appears only when an update is available. Pure: it renders from
+ * [status] and calls [onClick]; it performs no network work and does not reach into the DI graph
+ * (the shell observes the controller and passes state down). Uses Material's `secondaryContainer` /
+ * `onSecondaryContainer` pair so text and icon meet contrast in both light and dark themes.
  */
 @Composable
 fun UpdateReadyButton(
@@ -61,7 +60,7 @@ fun UpdateReadyButton(
       modifier
         .clip(RoundedCornerShape(4.dp))
         .clickable(onClick = onClick)
-        .background(UpdateAccent.copy(alpha = 0.15f))
+        .background(MaterialTheme.colorScheme.secondaryContainer)
         .padding(horizontal = 6.dp, vertical = 1.dp),
     verticalAlignment = Alignment.CenterVertically,
     horizontalArrangement = Arrangement.spacedBy(4.dp),
@@ -69,13 +68,13 @@ fun UpdateReadyButton(
     Icon(
       imageVector = Icons.Filled.SystemUpdateAlt,
       contentDescription = null,
-      tint = UpdateAccent,
+      tint = MaterialTheme.colorScheme.onSecondaryContainer,
       modifier = Modifier.width(12.dp),
     )
     Text(
       text = "Update ready",
       style = DesktopTypography.label,
-      color = UpdateAccent,
+      color = MaterialTheme.colorScheme.onSecondaryContainer,
       lineHeight = 10.sp,
     )
   }

--- a/android/desktop-core/src/main/kotlin/dev/jasonpearson/automobile/desktop/core/shell/UpdateReadyButton.kt
+++ b/android/desktop-core/src/main/kotlin/dev/jasonpearson/automobile/desktop/core/shell/UpdateReadyButton.kt
@@ -20,7 +20,6 @@ import androidx.compose.runtime.Composable
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.draw.clip
-import androidx.compose.ui.graphics.Color
 import androidx.compose.ui.unit.dp
 import androidx.compose.ui.unit.sp
 import dev.jasonpearson.automobile.desktop.core.logging.LoggerFactory
@@ -97,7 +96,11 @@ fun UpdateDetailsContent(
     verticalArrangement = Arrangement.spacedBy(6.dp),
   ) {
     Text(text = "Version ${update.version} is available", fontSize = 13.sp)
-    Text(text = "You're on $currentVersion", fontSize = 11.sp, color = Color.Gray)
+    Text(
+      text = "You're on $currentVersion",
+      fontSize = 11.sp,
+      color = MaterialTheme.colorScheme.onSurfaceVariant,
+    )
 
     if (update.releaseNotesUrl != null) {
       TextButton(onClick = onOpenReleaseNotes) { Text("Release notes") }

--- a/android/desktop-core/src/main/kotlin/dev/jasonpearson/automobile/desktop/core/shell/UpdateReadyButton.kt
+++ b/android/desktop-core/src/main/kotlin/dev/jasonpearson/automobile/desktop/core/shell/UpdateReadyButton.kt
@@ -1,0 +1,116 @@
+package dev.jasonpearson.automobile.desktop.core.shell
+
+import androidx.compose.foundation.background
+import androidx.compose.foundation.clickable
+import androidx.compose.foundation.layout.Arrangement
+import androidx.compose.foundation.layout.Column
+import androidx.compose.foundation.layout.Row
+import androidx.compose.foundation.layout.Spacer
+import androidx.compose.foundation.layout.padding
+import androidx.compose.foundation.layout.width
+import androidx.compose.foundation.shape.RoundedCornerShape
+import androidx.compose.material3.Icon
+import androidx.compose.material3.Text
+import androidx.compose.material3.TextButton
+import androidx.compose.material.icons.Icons
+import androidx.compose.material.icons.filled.Download
+import androidx.compose.material.icons.filled.SystemUpdateAlt
+import androidx.compose.runtime.Composable
+import androidx.compose.ui.Alignment
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.draw.clip
+import androidx.compose.ui.graphics.Color
+import androidx.compose.ui.unit.dp
+import androidx.compose.ui.unit.sp
+import dev.jasonpearson.automobile.desktop.core.logging.LoggerFactory
+import dev.jasonpearson.automobile.desktop.core.theme.DesktopTypography
+import dev.jasonpearson.automobile.desktop.core.update.UpdateStatus
+import java.awt.Desktop
+import java.net.URI
+
+/** Accent used for the update affordance — a calm green that reads as "good news, optional". */
+private val UpdateAccent = Color(0xFF4CAF50)
+
+private val LOG = LoggerFactory.getLogger("UpdateReadyButton")
+
+/** Opens [url] in the user's default browser. Best-effort — a failure is logged, not surfaced. */
+internal fun openReleaseNotesInBrowser(url: String) {
+  try {
+    Desktop.getDesktop().browse(URI(url))
+  } catch (error: Exception) {
+    LOG.warn("Failed to open release notes $url: ${error.message}", error)
+  }
+}
+
+/**
+ * The lower-left status-bar affordance that appears only when an update is available. Pure: it
+ * renders from [status] and calls [onClick]; it performs no network work and does not reach into the
+ * DI graph (the shell observes the controller and passes state down).
+ */
+@Composable
+fun UpdateReadyButton(
+  status: UpdateStatus,
+  onClick: () -> Unit,
+  modifier: Modifier = Modifier,
+) {
+  // Only a genuine update surfaces the pill; every other state stays silent.
+  if (status !is UpdateStatus.UpdateAvailable) return
+
+  Row(
+    modifier =
+      modifier
+        .clip(RoundedCornerShape(4.dp))
+        .clickable(onClick = onClick)
+        .background(UpdateAccent.copy(alpha = 0.15f))
+        .padding(horizontal = 6.dp, vertical = 1.dp),
+    verticalAlignment = Alignment.CenterVertically,
+    horizontalArrangement = Arrangement.spacedBy(4.dp),
+  ) {
+    Icon(
+      imageVector = Icons.Filled.SystemUpdateAlt,
+      contentDescription = null,
+      tint = UpdateAccent,
+      modifier = Modifier.width(12.dp),
+    )
+    Text(text = "Update ready", style = DesktopTypography.label, color = UpdateAccent, lineHeight = 10.sp)
+  }
+}
+
+/**
+ * The compact details surface shown when the update pill is clicked: the available version, the
+ * running version, a link to the release notes, and a (disabled here) install action delivered by a
+ * later item. Pure content — the shell wraps it in a Popup.
+ */
+@Composable
+fun UpdateDetailsContent(
+  update: UpdateStatus.UpdateAvailable,
+  currentVersion: String,
+  onOpenReleaseNotes: () -> Unit,
+  modifier: Modifier = Modifier,
+) {
+  Column(
+    modifier = modifier.padding(12.dp),
+    verticalArrangement = Arrangement.spacedBy(6.dp),
+  ) {
+    Text(text = "Version ${update.version} is available", fontSize = 13.sp)
+    Text(text = "You're on $currentVersion", fontSize = 11.sp, color = Color.Gray)
+
+    if (update.releaseNotesUrl != null) {
+      TextButton(onClick = onOpenReleaseNotes) { Text("Release notes") }
+    }
+
+    Row(verticalAlignment = Alignment.CenterVertically) {
+      // Applying the update (download + install + restart) is delivered by a later item, so the
+      // action is present but not yet enabled.
+      TextButton(onClick = {}, enabled = false) {
+        Icon(
+          imageVector = Icons.Filled.Download,
+          contentDescription = null,
+          modifier = Modifier.width(14.dp),
+        )
+        Spacer(Modifier.width(4.dp))
+        Text("Install & restart")
+      }
+    }
+  }
+}

--- a/android/desktop-core/src/main/kotlin/dev/jasonpearson/automobile/desktop/core/workspace/WorkspaceShell.kt
+++ b/android/desktop-core/src/main/kotlin/dev/jasonpearson/automobile/desktop/core/workspace/WorkspaceShell.kt
@@ -47,7 +47,9 @@ import dev.jasonpearson.automobile.desktop.core.logging.LoggerFactory
 import dev.jasonpearson.automobile.desktop.core.mcp.McpConnectionType
 import dev.jasonpearson.automobile.desktop.core.mcp.McpProcess
 import dev.jasonpearson.automobile.desktop.core.mcp.RealMcpProcessDetector
+import dev.jasonpearson.automobile.desktop.core.shell.UpdateReadyButton
 import dev.jasonpearson.automobile.desktop.core.theme.PlatformIcons
+import dev.jasonpearson.automobile.desktop.core.update.UpdateStatus
 import java.util.Base64
 import kotlinx.coroutines.CancellationException
 import kotlinx.coroutines.Dispatchers
@@ -87,6 +89,9 @@ fun WorkspaceShell(
   status: WorkspaceStatus = WorkspaceStatus.Green,
   // A terse reason for a non-green status, shown inline next to the dot ("yellow = one line").
   statusDetail: String? = null,
+  // Update-availability state (#5225): the top bar shows a pill only when an update is available.
+  updateStatus: UpdateStatus = UpdateStatus.Idle,
+  onUpdateClick: () -> Unit = {},
   onOpenPalette: () -> Unit = {},
   modifier: Modifier = Modifier,
   // Renders the docked facet body for a pane's active tool. Hoisted so the host can supply real
@@ -138,6 +143,8 @@ fun WorkspaceShell(
       TopBar(
         status = status,
         statusDetail = statusDetail,
+        updateStatus = updateStatus,
+        onUpdateClick = onUpdateClick,
         onOpenPicker = onOpenPicker,
         onOpenPalette = onOpenPalette,
         onStatusClick = { showHealthSheet = true },
@@ -227,6 +234,8 @@ internal fun compareColumns(content: WorkspaceUiState.Content): Pair<DeviceColum
 private fun TopBar(
   status: WorkspaceStatus,
   statusDetail: String?,
+  updateStatus: UpdateStatus,
+  onUpdateClick: () -> Unit,
   onOpenPicker: () -> Unit,
   onOpenPalette: () -> Unit,
   onStatusClick: () -> Unit,
@@ -299,6 +308,13 @@ private fun TopBar(
             .padding(horizontal = 8.dp, vertical = 4.dp),
       )
     }
+    // Update-ready affordance — sits just before the status dot; visible only when an update is
+    // available (#5225).
+    UpdateReadyButton(status = updateStatus, onClick = onUpdateClick)
+    if (updateStatus is UpdateStatus.UpdateAvailable) {
+      Spacer(Modifier.width(8.dp))
+    }
+
     // Visible dot stays 12dp; the clickable target is enlarged to 32dp. For a green status (no
     // inline line) the dot is the only entry point to the health sheet.
     Box(

--- a/android/desktop-core/src/test/kotlin/dev/jasonpearson/automobile/desktop/core/shell/UpdateReadyButtonUiTest.kt
+++ b/android/desktop-core/src/test/kotlin/dev/jasonpearson/automobile/desktop/core/shell/UpdateReadyButtonUiTest.kt
@@ -1,0 +1,90 @@
+package dev.jasonpearson.automobile.desktop.core.shell
+
+import androidx.compose.material3.MaterialTheme
+import androidx.compose.ui.test.ExperimentalTestApi
+import androidx.compose.ui.test.assertIsDisplayed
+import androidx.compose.ui.test.assertIsNotEnabled
+import androidx.compose.ui.test.onNodeWithText
+import androidx.compose.ui.test.performClick
+import androidx.compose.ui.test.runComposeUiTest
+import dev.jasonpearson.automobile.desktop.core.update.ReleaseAsset
+import dev.jasonpearson.automobile.desktop.core.update.UpdateStatus
+import kotlin.test.assertEquals
+import kotlin.test.assertTrue
+import org.junit.Test
+
+@OptIn(ExperimentalTestApi::class)
+class UpdateReadyButtonUiTest {
+
+  private val available =
+    UpdateStatus.UpdateAvailable(
+      version = "0.0.53",
+      asset = ReleaseAsset("AutoMobile-0.0.53-macos.dmg", "https://x/dmg", 10),
+      releaseNotesUrl = "https://notes",
+    )
+
+  @Test
+  fun `pill is shown only when an update is available`() = runComposeUiTest {
+    setContent { MaterialTheme { UpdateReadyButton(status = available, onClick = {}) } }
+    onNodeWithText("Update ready").assertIsDisplayed()
+  }
+
+  @Test
+  fun `pill is hidden for non-available states`() {
+    for (status in
+      listOf(
+        UpdateStatus.Idle,
+        UpdateStatus.Checking,
+        UpdateStatus.UpToDate,
+        UpdateStatus.Failed("boom"),
+      )) {
+      runComposeUiTest {
+        setContent { MaterialTheme { UpdateReadyButton(status = status, onClick = {}) } }
+        onNodeWithText("Update ready").assertDoesNotExist()
+      }
+    }
+  }
+
+  @Test
+  fun `clicking the pill invokes onClick`() = runComposeUiTest {
+    var clicks = 0
+    setContent { MaterialTheme { UpdateReadyButton(status = available, onClick = { clicks++ }) } }
+    onNodeWithText("Update ready").performClick()
+    assertEquals(1, clicks)
+  }
+
+  @Test
+  fun `details content shows available and current versions and a notes link`() = runComposeUiTest {
+    var notesOpened = 0
+    setContent {
+      MaterialTheme {
+        UpdateDetailsContent(
+          update = available,
+          currentVersion = "0.0.52",
+          onOpenReleaseNotes = { notesOpened++ },
+        )
+      }
+    }
+    // The available version and current version are both surfaced.
+    onNodeWithText("0.0.53", substring = true).assertIsDisplayed()
+    onNodeWithText("0.0.52", substring = true).assertIsDisplayed()
+    // The release-notes affordance is present and wired.
+    onNodeWithText("Release notes", substring = true).performClick()
+    assertTrue(notesOpened == 1)
+  }
+
+  @Test
+  fun `install action is present but disabled in this item`() = runComposeUiTest {
+    setContent {
+      MaterialTheme {
+        UpdateDetailsContent(
+          update = available,
+          currentVersion = "0.0.52",
+          onOpenReleaseNotes = {},
+        )
+      }
+    }
+    // The install affordance exists but is not yet actionable (delivered by a later item).
+    onNodeWithText("Install", substring = true).assertIsNotEnabled()
+  }
+}

--- a/android/desktop-core/src/test/kotlin/dev/jasonpearson/automobile/desktop/core/update/FakeUpdateController.kt
+++ b/android/desktop-core/src/test/kotlin/dev/jasonpearson/automobile/desktop/core/update/FakeUpdateController.kt
@@ -1,0 +1,18 @@
+package dev.jasonpearson.automobile.desktop.core.update
+
+import kotlinx.coroutines.flow.MutableStateFlow
+import kotlinx.coroutines.flow.StateFlow
+import kotlinx.coroutines.flow.asStateFlow
+
+/**
+ * A no-op [UpdateController] for tests and previews: it holds a fixed [status] and never performs a
+ * network check. Use it to satisfy the DI surface in tests that don't exercise update behavior.
+ */
+class FakeUpdateController(initial: UpdateStatus = UpdateStatus.Idle) : UpdateController {
+  private val state = MutableStateFlow(initial)
+  override val status: StateFlow<UpdateStatus> = state.asStateFlow()
+
+  override suspend fun checkForUpdate() {
+    // No-op: the fixed status stands in for a real check.
+  }
+}

--- a/android/desktop-core/src/test/kotlin/dev/jasonpearson/automobile/desktop/core/workspace/NavigationFacetTest.kt
+++ b/android/desktop-core/src/test/kotlin/dev/jasonpearson/automobile/desktop/core/workspace/NavigationFacetTest.kt
@@ -24,8 +24,11 @@ import dev.jasonpearson.automobile.desktop.core.navigation.DefaultNavigationScre
 import dev.jasonpearson.automobile.desktop.core.navigation.NavigationScreenshotLoaderRegistry
 import dev.jasonpearson.automobile.desktop.core.navigation.ScreenNode
 import dev.jasonpearson.automobile.desktop.core.navigation.ScreenshotLoader
+import dev.jasonpearson.automobile.desktop.core.platform.AppVersion
+import dev.jasonpearson.automobile.desktop.core.platform.AppVersionProvider
 import dev.jasonpearson.automobile.desktop.core.settings.FakeSettingsProvider
 import dev.jasonpearson.automobile.desktop.core.testing.FakeAutoMobileClient
+import dev.jasonpearson.automobile.desktop.core.update.FakeUpdateController
 import java.util.concurrent.atomic.AtomicInteger
 import kotlinx.coroutines.CompletableDeferred
 import kotlinx.coroutines.flow.FlowCollector
@@ -48,6 +51,8 @@ class NavigationFacetTest {
       override val autoMobileClient = client
       override val settingsProvider = FakeSettingsProvider()
       override val dataSourceFactory = DefaultDataSourceFactory(client)
+      override val updateController = FakeUpdateController()
+      override val appVersionProvider = AppVersionProvider { AppVersion.Dev }
     }
   }
 
@@ -837,6 +842,8 @@ class NavigationFacetTest {
         override val autoMobileClient = client
         override val settingsProvider = settings
         override val dataSourceFactory = DefaultDataSourceFactory(client)
+        override val updateController = FakeUpdateController()
+        override val appVersionProvider = AppVersionProvider { AppVersion.Dev }
       }
     val fake = FakeObservationStream()
     setContent {

--- a/android/desktop-core/src/test/kotlin/dev/jasonpearson/automobile/desktop/core/workspace/OfflineNavigationBrowserTest.kt
+++ b/android/desktop-core/src/test/kotlin/dev/jasonpearson/automobile/desktop/core/workspace/OfflineNavigationBrowserTest.kt
@@ -18,8 +18,11 @@ import dev.jasonpearson.automobile.desktop.core.di.AutoMobileGraphProvider
 import dev.jasonpearson.automobile.desktop.core.di.LocalAutoMobileGraph
 import dev.jasonpearson.automobile.desktop.core.navigation.NavigationDashboard
 import dev.jasonpearson.automobile.desktop.core.navigation.ScreenNode
+import dev.jasonpearson.automobile.desktop.core.platform.AppVersion
+import dev.jasonpearson.automobile.desktop.core.platform.AppVersionProvider
 import dev.jasonpearson.automobile.desktop.core.settings.FakeSettingsProvider
 import dev.jasonpearson.automobile.desktop.core.testing.FakeAutoMobileClient
+import dev.jasonpearson.automobile.desktop.core.update.FakeUpdateController
 import java.util.concurrent.atomic.AtomicInteger
 import org.junit.Assert.assertTrue
 import org.junit.Test
@@ -33,6 +36,8 @@ class OfflineNavigationBrowserTest {
       override val autoMobileClient = client
       override val settingsProvider = FakeSettingsProvider()
       override val dataSourceFactory = DefaultDataSourceFactory(client)
+      override val updateController = FakeUpdateController()
+      override val appVersionProvider = AppVersionProvider { AppVersion.Dev }
     }
   }
 
@@ -312,6 +317,8 @@ class OfflineNavigationBrowserTest {
         override val autoMobileClient = client
         override val settingsProvider = FakeSettingsProvider()
         override val dataSourceFactory = DefaultDataSourceFactory(client)
+        override val updateController = FakeUpdateController()
+        override val appVersionProvider = AppVersionProvider { AppVersion.Dev }
       }
     val nodeWithShot =
       screen("Alpha").copy(screenshotUri = "automobile:navigation/nodes/1/screenshot")

--- a/android/desktop-core/src/test/kotlin/dev/jasonpearson/automobile/desktop/core/workspace/PerformanceFacetTest.kt
+++ b/android/desktop-core/src/test/kotlin/dev/jasonpearson/automobile/desktop/core/workspace/PerformanceFacetTest.kt
@@ -13,8 +13,11 @@ import dev.jasonpearson.automobile.desktop.core.daemon.PerformanceStreamUpdate
 import dev.jasonpearson.automobile.desktop.core.datasource.DefaultDataSourceFactory
 import dev.jasonpearson.automobile.desktop.core.di.AutoMobileGraphProvider
 import dev.jasonpearson.automobile.desktop.core.di.LocalAutoMobileGraph
+import dev.jasonpearson.automobile.desktop.core.platform.AppVersion
+import dev.jasonpearson.automobile.desktop.core.platform.AppVersionProvider
 import dev.jasonpearson.automobile.desktop.core.settings.FakeSettingsProvider
 import dev.jasonpearson.automobile.desktop.core.testing.FakeAutoMobileClient
+import dev.jasonpearson.automobile.desktop.core.update.FakeUpdateController
 import kotlinx.coroutines.CompletableDeferred
 import org.junit.Assert.assertEquals
 import org.junit.Assert.assertTrue
@@ -34,6 +37,8 @@ class PerformanceFacetTest {
       override val autoMobileClient = client
       override val settingsProvider = FakeSettingsProvider()
       override val dataSourceFactory = DefaultDataSourceFactory(client)
+      override val updateController = FakeUpdateController()
+      override val appVersionProvider = AppVersionProvider { AppVersion.Dev }
     }
   }
 

--- a/android/desktop-core/src/test/kotlin/dev/jasonpearson/automobile/desktop/core/workspace/WorkspaceShellUiTest.kt
+++ b/android/desktop-core/src/test/kotlin/dev/jasonpearson/automobile/desktop/core/workspace/WorkspaceShellUiTest.kt
@@ -11,6 +11,8 @@ import androidx.compose.ui.test.performClick
 import androidx.compose.ui.test.runComposeUiTest
 import dev.jasonpearson.automobile.desktop.core.daemon.FakeObservationStream
 import dev.jasonpearson.automobile.desktop.core.daemon.ScreenshotStreamUpdate
+import dev.jasonpearson.automobile.desktop.core.update.ReleaseAsset
+import dev.jasonpearson.automobile.desktop.core.update.UpdateStatus
 import java.util.Base64
 import org.junit.Assert.assertEquals
 import org.junit.Assert.assertTrue
@@ -37,6 +39,61 @@ class WorkspaceShellUiTest {
     }
     onNodeWithContentDescription("Open command palette").performClick()
     assertTrue(opened)
+  }
+
+  private val availableUpdate =
+    UpdateStatus.UpdateAvailable(
+      version = "0.0.53",
+      asset = ReleaseAsset("AutoMobile-0.0.53-macos.dmg", "https://x/dmg", 1),
+      releaseNotesUrl = "https://notes",
+    )
+
+  @Test
+  fun `top bar shows the update pill only when an update is available`() = runComposeUiTest {
+    setContent {
+      MaterialTheme {
+        WorkspaceShell(
+          state = WorkspaceUiState.Empty,
+          onAction = {},
+          onOpenPicker = {},
+          updateStatus = availableUpdate,
+        )
+      }
+    }
+    onNodeWithText("Update ready").assertIsDisplayed()
+  }
+
+  @Test
+  fun `top bar hides the update pill when up to date`() = runComposeUiTest {
+    setContent {
+      MaterialTheme {
+        WorkspaceShell(
+          state = WorkspaceUiState.Empty,
+          onAction = {},
+          onOpenPicker = {},
+          updateStatus = UpdateStatus.UpToDate,
+        )
+      }
+    }
+    onNodeWithText("Update ready").assertDoesNotExist()
+  }
+
+  @Test
+  fun `clicking the update pill invokes onUpdateClick`() = runComposeUiTest {
+    var clicks = 0
+    setContent {
+      MaterialTheme {
+        WorkspaceShell(
+          state = WorkspaceUiState.Empty,
+          onAction = {},
+          onOpenPicker = {},
+          updateStatus = availableUpdate,
+          onUpdateClick = { clicks++ },
+        )
+      }
+    }
+    onNodeWithText("Update ready").performClick()
+    assertEquals(1, clicks)
   }
 
   @Test

--- a/android/desktop-core/src/test/kotlin/dev/jasonpearson/automobile/desktop/core/workspace/WorkspaceShellUiTest.kt
+++ b/android/desktop-core/src/test/kotlin/dev/jasonpearson/automobile/desktop/core/workspace/WorkspaceShellUiTest.kt
@@ -64,18 +64,28 @@ class WorkspaceShellUiTest {
   }
 
   @Test
-  fun `top bar hides the update pill when up to date`() = runComposeUiTest {
-    setContent {
-      MaterialTheme {
-        WorkspaceShell(
-          state = WorkspaceUiState.Empty,
-          onAction = {},
-          onOpenPicker = {},
-          updateStatus = UpdateStatus.UpToDate,
-        )
+  fun `top bar hides the update pill for every non-available state`() {
+    for (hidden in
+      listOf(
+        UpdateStatus.Idle,
+        UpdateStatus.Checking,
+        UpdateStatus.UpToDate,
+        UpdateStatus.Failed("boom"),
+      )) {
+      runComposeUiTest {
+        setContent {
+          MaterialTheme {
+            WorkspaceShell(
+              state = WorkspaceUiState.Empty,
+              onAction = {},
+              onOpenPicker = {},
+              updateStatus = hidden,
+            )
+          }
+        }
+        onNodeWithText("Update ready").assertDoesNotExist()
       }
     }
-    onNodeWithText("Update ready").assertDoesNotExist()
   }
 
   @Test


### PR DESCRIPTION
## Summary

Surfaces item #5224's `UpdateController` state as a **lower-left status-bar pill** that appears only
when a newer GitHub release is available. Clicking it opens a compact details popup — the available
version, the running version, and a link to the release notes. The download/install action is
present but **disabled**; applying the update (download → installer → restart) is #5226.

Item 3 of the desktop auto-update sequence. Depends on #5223 (version) and #5224 (controller), both
merged.

## Changes

- **`UpdateReadyButton`** — pure composable; renders the pill only for `UpdateStatus.UpdateAvailable`,
  nothing for `Idle`/`Checking`/`UpToDate`/`Failed`.
- **`UpdateDetailsContent`** — pure composable; shows both versions + release-notes link + a disabled
  "Install & restart" action. Notes open via `java.awt.Desktop` (best-effort, logged on failure).
- **DI** — exposes `updateController` + `appVersionProvider` on `AutoMobileGraphProvider`, the Metro
  `AutoMobileGraph`, and the `LocalAutoMobileGraph` default fallback.
- **`ThreePaneShell`** — observes `updateController.status` via `collectAsState`, runs one
  `checkForUpdate()` at first composition (dev/`-SNAPSHOT` builds no-op it, so the pill never shows in
  development), threads the state into `StatusBarStub`'s lower-left segment, and hosts the details
  `Popup`.

## Linked Issue

Closes #5225

Sequence: #5223 ✅ → #5224 ✅ → **#5225 (this)** → #5226 (apply, hand-off) · deferred: #5227 (Conveyor).

## Testing

- [x] `UpdateReadyButtonUiTest` (5 tests, `runComposeUiTest`): pill shown only for `UpdateAvailable`;
  hidden for Idle/Checking/UpToDate/Failed; click invokes `onClick`; details show both versions + a
  wired notes link; install action disabled.
- [x] `:desktop-core:test :desktop-app:test` green (Metro graph resolves the new members)
- [x] `:desktop-core:detektMain :desktop-core:detektTest` green
- [x] `scripts/all_fast_validate_checks.sh --only ktfmt` passes (Kotlin-only change)
- [ ] `bun run typecheck` — N/A (no TypeScript touched)

## Notes / scope

- The pure composables are unit-tested; the `ThreePaneShell` DI wiring + `Popup` are an integration
  point (untested glue, matching the existing `StatusBarStub`).
- No polling/timer here — a single startup check is the minimum to make the pill appear; a periodic
  re-check could be a later follow-up.
