### PR TITLE
feat(daemon): DeviceSessionRegistry — mint deviceSessionUuid per device connection epoch

### DIFF
--- a/docs/design-docs/mcp/daemon/unix-socket-api.md
+++ b/docs/design-docs/mcp/daemon/unix-socket-api.md
@@ -988,6 +988,39 @@ recovery eligibility for each pooled device.
 
 ---
 
+### `daemon/listDeviceSessions`
+
+Returns the current map of connected devices to their **device-session UUIDs**. A
+`deviceSessionUuid` identifies a device *connection epoch*: it is minted when a
+device is first booted/connected, retired on disconnect, and a fresh UUID is
+minted on same-serial reconnect. Unlike the adb serial / simulator UDID
+(`deviceId`, which a rebooted emulator reuses), the `deviceSessionUuid` is a
+stable routing key that a reused serial cannot alias — the identity stream
+consumers key on to tell "same device, stream continues" from "device rebooted,
+flush cached state". The registry is in-memory and process-scoped (epochs do not
+survive a daemon restart).
+
+**Params:** none
+
+**Result**
+
+```json
+{
+  "deviceSessions": [{
+    "deviceSessionUuid": "b1f2c3d4-0000-4000-8000-000000000001",
+    "deviceId": "emulator-5554",
+    "platform": "android",
+    "epochStartedAt": 1734300000000
+  }],
+  "totalDeviceSessions": 1
+}
+```
+
+`epochStartedAt` is the daemon-clock millisecond timestamp at which the epoch was
+minted.
+
+---
+
 ### `daemon/refreshDevices`
 
 Re-discovers connected devices and updates the pool.

--- a/src/daemon/constants.ts
+++ b/src/daemon/constants.ts
@@ -167,6 +167,14 @@ export const DAEMON_BOUND_SESSION_REPLAY_TTL_MS = 30 * 60 * 1000;
 export const DAEMON_SUBSCRIBE_NOTIFICATIONS_METHOD = "daemon/subscribe-notifications";
 
 /**
+ * Control-socket method returning the current `deviceId (serial/UDID) ↔
+ * deviceSessionUuid` map from the daemon's `DeviceSessionRegistry`. Lets a
+ * stream consumer resolve a serial to its stable connection-epoch identity
+ * (device-session-UUID routing epic #5256).
+ */
+export const DAEMON_LIST_DEVICE_SESSIONS_METHOD = "daemon/listDeviceSessions";
+
+/**
  * Whether the daemon enforces the inbound version/build-identity handshake
  * (#2744). Enabled by default; set `AUTOMOBILE_DAEMON_DISABLE_HANDSHAKE=1`
  * (or `AUTO_MOBILE_DAEMON_DISABLE_HANDSHAKE=1`) as an escape hatch if a

--- a/src/daemon/daemon.ts
+++ b/src/daemon/daemon.ts
@@ -9,6 +9,7 @@ import { SessionHeartbeatMonitor } from "./SessionHeartbeatMonitor";
 import { DevicePool, type PooledDevice } from "./devicePool";
 import { parseDeviceRecoveryPolicy } from "./poolConfig";
 import { DaemonState } from "./daemonState";
+import { DeviceSessionRegistry } from "./deviceSessionRegistry";
 import {
   DEFAULT_DAEMON_PORT,
   SOCKET_PATH,
@@ -142,6 +143,7 @@ export class Daemon {
   private stoppingRecordings: Set<string> = new Set();
   private sessionManager: SessionManager;
   private devicePool: DevicePool;
+  private deviceSessionRegistry: DeviceSessionRegistry;
   private daemonSessionId: string;
   private installedAppsRepository: InstalledAppsStore;
   private deviceSessionRepository: DeviceSessionRepository;
@@ -226,6 +228,7 @@ export class Daemon {
       `[Daemon] Device recovery policy: onLoss=${recoveryConfiguration.policy.onLoss}, ` +
       `maxAttempts=${recoveryConfiguration.policy.maxAttempts}`
     );
+    this.deviceSessionRegistry = new DeviceSessionRegistry(this.timer, this.idGenerator);
     this.devicePool = new DevicePool(
       this.sessionManager,
       this.daemonSessionId,
@@ -236,12 +239,16 @@ export class Daemon {
       this.deviceSessionRepository,
       undefined,
       (sessionId, _deviceId, releaseReason) => this.cancelAndReleaseSession(sessionId, releaseReason),
-      deviceId => this.socketServer?.evictDeviceInputCache(deviceId),
+      deviceId => this.onDeviceReadyForSessionRegistry(deviceId),
       undefined,
       recoveryConfiguration.policy,
     );
     // Initialize singleton for daemon state access
-    DaemonState.getInstance().initialize(this.sessionManager, this.devicePool);
+    DaemonState.getInstance().initialize(
+      this.sessionManager,
+      this.devicePool,
+      this.deviceSessionRegistry
+    );
 
     // Apply CLI flags to serverConfig so daemon tools respect them
     if (options.networkMockable) {
@@ -835,6 +842,27 @@ export class Daemon {
   }
 
   /**
+   * Device-ready callback wired into {@link DevicePool}. Mints (or refreshes)
+   * the device-session epoch for the connected device and preserves the
+   * pre-existing input-cache eviction. The pool fires this on every add path,
+   * so the mint is keyed on the pooled device's monotonic `incarnation` — a
+   * repeat ready-signal for the same epoch is idempotent, while a same-serial
+   * restart (new incarnation) mints a fresh `deviceSessionUuid` (epic #5256).
+   */
+  private onDeviceReadyForSessionRegistry(deviceId: string): void {
+    this.socketServer?.evictDeviceInputCache(deviceId);
+    const pooled = this.devicePool.getDevice(deviceId);
+    if (!pooled) {
+      return;
+    }
+    this.deviceSessionRegistry.onDeviceConnected({
+      deviceId: pooled.id,
+      platform: pooled.platform,
+      incarnation: pooled.incarnation,
+    });
+  }
+
+  /**
    * Set up callback for observation stream to trigger device WebSocket connections.
    * When an IDE plugin subscribes to the observation stream, we need to ensure
    * the WebSocket connections to Android devices are established so that
@@ -1244,6 +1272,9 @@ export class Daemon {
           // that never confirms is handled by the device-ready callback; the 5-min
           // idle close remains a fallback.
           this.socketServer?.evictDeviceInputCache(deviceId);
+          // Retire the device-session epoch so a stale deviceSessionUuid stops
+          // resolving and listDeviceSessions drops the gone device (epic #5256).
+          this.deviceSessionRegistry.onDeviceDisconnected(deviceId);
           if (this.devicePool.getDevice(deviceId)) {
             deviceCleanupSucceeded = false;
           }

--- a/src/daemon/daemon.ts
+++ b/src/daemon/daemon.ts
@@ -845,10 +845,10 @@ export class Daemon {
    * Device-ready callback wired into {@link DevicePool}. Mints (or refreshes)
    * the device-session epoch for the connected device and preserves the
    * pre-existing input-cache eviction. The pool fires this on the refresh,
-   * addDevice, and bind/autolock paths (a device present only at startup mints
-   * on its first refresh or bind), so the mint is keyed on the pooled device's
-   * monotonic `incarnation` — a repeat ready-signal for the same epoch is
-   * idempotent, while a same-serial restart (new incarnation) mints a fresh
+   * addDevice, and bind/autolock paths; startup-booted devices are minted
+   * directly in {@link initializeDevicePool}. The mint is keyed on the pooled
+   * device's monotonic `incarnation` — a repeat ready-signal for the same epoch
+   * is idempotent, while a same-serial restart (new incarnation) mints a fresh
    * `deviceSessionUuid` (epic #5256).
    */
   private onDeviceReadyForSessionRegistry(deviceId: string): void {
@@ -1443,6 +1443,19 @@ export class Daemon {
 
       if (bootedDevices.length > 0) {
         await this.devicePool.initializeWithDevices(bootedDevices);
+        // Mint a device-session epoch for every startup-booted device so
+        // daemon/listDeviceSessions enumerates idle devices immediately, without
+        // waiting for a first assignment/refresh. initializeWithDevices does not
+        // fire the device-ready callback (that path stays silent by contract), so
+        // mint directly here. Idempotent with the later onDeviceReady mint — the
+        // incarnation is unchanged, so it returns the same uuid (epic #5256).
+        for (const pooled of this.devicePool.getAllDevices()) {
+          this.deviceSessionRegistry.onDeviceConnected({
+            deviceId: pooled.id,
+            platform: pooled.platform,
+            incarnation: pooled.incarnation,
+          });
+        }
         logger.info(`Device pool initialized with ${bootedDevices.length} devices: ${bootedDevices.map(device => device.deviceId).join(", ")}`);
       } else {
         logger.warn("No devices detected during daemon startup. Device pool is empty.");

--- a/src/daemon/daemon.ts
+++ b/src/daemon/daemon.ts
@@ -844,10 +844,12 @@ export class Daemon {
   /**
    * Device-ready callback wired into {@link DevicePool}. Mints (or refreshes)
    * the device-session epoch for the connected device and preserves the
-   * pre-existing input-cache eviction. The pool fires this on every add path,
-   * so the mint is keyed on the pooled device's monotonic `incarnation` — a
-   * repeat ready-signal for the same epoch is idempotent, while a same-serial
-   * restart (new incarnation) mints a fresh `deviceSessionUuid` (epic #5256).
+   * pre-existing input-cache eviction. The pool fires this on the refresh,
+   * addDevice, and bind/autolock paths (a device present only at startup mints
+   * on its first refresh or bind), so the mint is keyed on the pooled device's
+   * monotonic `incarnation` — a repeat ready-signal for the same epoch is
+   * idempotent, while a same-serial restart (new incarnation) mints a fresh
+   * `deviceSessionUuid` (epic #5256).
    */
   private onDeviceReadyForSessionRegistry(deviceId: string): void {
     this.socketServer?.evictDeviceInputCache(deviceId);
@@ -1272,11 +1274,17 @@ export class Daemon {
           // that never confirms is handled by the device-ready callback; the 5-min
           // idle close remains a fallback.
           this.socketServer?.evictDeviceInputCache(deviceId);
-          // Retire the device-session epoch so a stale deviceSessionUuid stops
-          // resolving and listDeviceSessions drops the gone device (epic #5256).
-          this.deviceSessionRegistry.onDeviceDisconnected(deviceId);
           if (this.devicePool.getDevice(deviceId)) {
+            // removeDisconnectedDevice can synchronously recover a same-serial
+            // Android emulator (reboot → re-add), which mints a fresh epoch. The
+            // device is live again, so retiring here would delete that just-minted
+            // epoch; skip the retire and let cleanup fail so the monitor retries.
             deviceCleanupSucceeded = false;
+          } else {
+            // Confirmed gone: retire the device-session epoch so a stale
+            // deviceSessionUuid stops resolving and listDeviceSessions drops the
+            // device (epic #5256).
+            this.deviceSessionRegistry.onDeviceDisconnected(deviceId);
           }
           if (deviceCleanupSucceeded) {
             this.confirmedDisconnectedDeviceIds.add(deviceId);

--- a/src/daemon/daemonRequestHandlers.ts
+++ b/src/daemon/daemonRequestHandlers.ts
@@ -5,6 +5,8 @@ import type {
   DeviceRecoveryPolicy,
   PooledDevice,
 } from "./devicePool";
+import type { DeviceSessionRecord } from "./deviceSessionRegistry";
+import { DAEMON_LIST_DEVICE_SESSIONS_METHOD } from "./constants";
 
 /** Socket endpoint clients may query before sending optional newer parameters. */
 export const DAEMON_CAPABILITIES_METHOD = "daemon/capabilities";
@@ -32,6 +34,9 @@ export interface DaemonStateAccess {
       mcpSessionId: string | undefined,
       platform?: "android" | "ios"
     ): string | undefined;
+  };
+  getDeviceSessionRegistry(): {
+    list(): DeviceSessionRecord[];
   };
 }
 
@@ -193,6 +198,22 @@ export async function handleDaemonRequest(
           message: `Session ${sessionId} released`,
           device: deviceId,
           alreadyReleased: false,
+        },
+      };
+    }
+    case DAEMON_LIST_DEVICE_SESSIONS_METHOD: {
+      const registry = state.getDeviceSessionRegistry();
+      const deviceSessions = registry.list().map(record => ({
+        deviceSessionUuid: record.deviceSessionUuid,
+        deviceId: record.deviceId,
+        platform: record.platform,
+        epochStartedAt: record.epochStartedAt,
+      }));
+      return {
+        success: true,
+        result: {
+          deviceSessions,
+          totalDeviceSessions: deviceSessions.length,
         },
       };
     }

--- a/src/daemon/daemonState.ts
+++ b/src/daemon/daemonState.ts
@@ -1,10 +1,12 @@
 import { SessionManager } from "./sessionManager";
 import { DevicePool } from "./devicePool";
+import { DeviceSessionRegistry } from "./deviceSessionRegistry";
 
 export interface DaemonStateLike {
   isInitialized(): boolean;
   getSessionManager(): SessionManager;
   getDevicePool(): DevicePool;
+  getDeviceSessionRegistry(): DeviceSessionRegistry;
 }
 
 /**
@@ -17,6 +19,7 @@ export class DaemonState implements DaemonStateLike {
   private static instance: DaemonState;
   private sessionManager: SessionManager | null = null;
   private devicePool: DevicePool | null = null;
+  private deviceSessionRegistry: DeviceSessionRegistry | null = null;
 
   private constructor() {}
 
@@ -34,9 +37,14 @@ export class DaemonState implements DaemonStateLike {
    * Initialize daemon state
    * Called by Daemon after creating SessionManager and DevicePool
    */
-  initialize(sessionManager: SessionManager, devicePool: DevicePool): void {
+  initialize(
+    sessionManager: SessionManager,
+    devicePool: DevicePool,
+    deviceSessionRegistry: DeviceSessionRegistry = new DeviceSessionRegistry()
+  ): void {
     this.sessionManager = sessionManager;
     this.devicePool = devicePool;
+    this.deviceSessionRegistry = deviceSessionRegistry;
   }
 
   /**
@@ -60,10 +68,24 @@ export class DaemonState implements DaemonStateLike {
   }
 
   /**
+   * Get the DeviceSessionRegistry
+   */
+  getDeviceSessionRegistry(): DeviceSessionRegistry {
+    if (!this.deviceSessionRegistry) {
+      throw new Error("DaemonState not initialized");
+    }
+    return this.deviceSessionRegistry;
+  }
+
+  /**
    * Check if daemon state is initialized
    */
   isInitialized(): boolean {
-    return this.sessionManager !== null && this.devicePool !== null;
+    return (
+      this.sessionManager !== null &&
+      this.devicePool !== null &&
+      this.deviceSessionRegistry !== null
+    );
   }
 
   /**
@@ -72,5 +94,6 @@ export class DaemonState implements DaemonStateLike {
   reset(): void {
     this.sessionManager = null;
     this.devicePool = null;
+    this.deviceSessionRegistry = null;
   }
 }

--- a/src/daemon/daemonState.ts
+++ b/src/daemon/daemonState.ts
@@ -40,6 +40,11 @@ export class DaemonState implements DaemonStateLike {
   initialize(
     sessionManager: SessionManager,
     devicePool: DevicePool,
+    // Production MUST pass the daemon's lifecycle-wired registry (the same
+    // instance mint/retire mutate). The default exists only so the ~30 test
+    // callers that don't exercise device sessions need not construct one; a
+    // production caller relying on it would get an empty registry that no device
+    // lifecycle ever populates.
     deviceSessionRegistry: DeviceSessionRegistry = new DeviceSessionRegistry()
   ): void {
     this.sessionManager = sessionManager;

--- a/src/daemon/deviceSessionRegistry.ts
+++ b/src/daemon/deviceSessionRegistry.ts
@@ -23,13 +23,15 @@ export interface DeviceSessionRecord {
  * Input describing a device that has reached a boot-ready connection boundary.
  *
  * `incarnation` is the pool's monotonic per-connection counter
- * (`PooledDevice.incarnation`). It is the authoritative epoch boundary: a fast
- * same-serial restart bumps the incarnation without the disconnect monitor ever
- * confirming a disappearance, so keying the mint on it — rather than on the
- * presence of a prior `onDeviceDisconnected` — is what makes the reconnect case
- * correct in every path.
+ * (`PooledDevice.incarnation`), assigned whenever the pool allocates a fresh
+ * `PooledDevice`. It is the epoch boundary: keying the mint on it — rather than
+ * on the presence of a prior `onDeviceDisconnected` — re-mints a same-serial
+ * reconnect even when the disconnect monitor never confirmed the disappearance,
+ * as long as the pool re-created the entry. (A restart so fast that the pool
+ * never dropped the entry keeps the same incarnation and uuid — the pool
+ * observed no boundary, so neither do we.)
  */
-export interface DeviceConnectedInput {
+interface DeviceConnectedInput {
   deviceId: string;
   platform: Platform;
   incarnation: number;

--- a/src/daemon/deviceSessionRegistry.ts
+++ b/src/daemon/deviceSessionRegistry.ts
@@ -1,0 +1,120 @@
+import { defaultTimer, type Timer } from "../utils/SystemTimer";
+import { defaultIdGenerator, type IdGenerator } from "../utils/IdGenerator";
+import type { Platform } from "../models";
+
+/**
+ * Identity of a single device *connection epoch*.
+ *
+ * The adb serial / simulator UDID (`deviceId`) is reused across boots and its
+ * ADB `transportId` changes on reconnect, so a consumer cannot tell "same
+ * device, stream continues" from "device rebooted, flush your caches" by serial
+ * alone. `deviceSessionUuid` is minted once per epoch and retired when the
+ * device disconnects, giving every stream a stable routing key that a reused
+ * serial cannot alias.
+ */
+export interface DeviceSessionRecord {
+  deviceSessionUuid: string;
+  deviceId: string;
+  platform: Platform;
+  epochStartedAt: number;
+}
+
+/**
+ * Input describing a device that has reached a boot-ready connection boundary.
+ *
+ * `incarnation` is the pool's monotonic per-connection counter
+ * (`PooledDevice.incarnation`). It is the authoritative epoch boundary: a fast
+ * same-serial restart bumps the incarnation without the disconnect monitor ever
+ * confirming a disappearance, so keying the mint on it — rather than on the
+ * presence of a prior `onDeviceDisconnected` — is what makes the reconnect case
+ * correct in every path.
+ */
+export interface DeviceConnectedInput {
+  deviceId: string;
+  platform: Platform;
+  incarnation: number;
+}
+
+interface LiveEntry {
+  record: DeviceSessionRecord;
+  incarnation: number;
+}
+
+/**
+ * Process-lifetime map of `deviceId (serial/UDID) ↔ deviceSessionUuid`, the
+ * single source of truth for device-session identity across the daemon's
+ * stream API. Purely in-memory: an epoch is meaningless across daemon restarts,
+ * so nothing here is persisted.
+ */
+export class DeviceSessionRegistry {
+  private readonly timer: Timer;
+  private readonly idGenerator: IdGenerator;
+  private readonly byDeviceId = new Map<string, LiveEntry>();
+  private readonly uuidToDeviceId = new Map<string, string>();
+
+  constructor(timer: Timer = defaultTimer, idGenerator: IdGenerator = defaultIdGenerator) {
+    this.timer = timer;
+    this.idGenerator = idGenerator;
+  }
+
+  /**
+   * Mint (or return the existing) device-session record for a connected device.
+   *
+   * Idempotent within an epoch: a repeated connect carrying the same
+   * `incarnation` returns the existing record without minting. A changed
+   * `incarnation` (reconnect, whether or not a disconnect was observed) retires
+   * the superseded epoch and mints a fresh uuid.
+   */
+  onDeviceConnected(input: DeviceConnectedInput): DeviceSessionRecord {
+    const existing = this.byDeviceId.get(input.deviceId);
+    if (existing && existing.incarnation === input.incarnation) {
+      return existing.record;
+    }
+    if (existing) {
+      // Superseded epoch (new incarnation for the same serial) — drop its uuid
+      // so a stale reference cannot resolve to the reincarnated device.
+      this.uuidToDeviceId.delete(existing.record.deviceSessionUuid);
+    }
+
+    const record: DeviceSessionRecord = {
+      deviceSessionUuid: this.idGenerator.next(),
+      deviceId: input.deviceId,
+      platform: input.platform,
+      epochStartedAt: this.timer.now(),
+    };
+    this.byDeviceId.set(input.deviceId, { record, incarnation: input.incarnation });
+    this.uuidToDeviceId.set(record.deviceSessionUuid, input.deviceId);
+    return record;
+  }
+
+  /** Retire the live epoch for a disconnected device, if any. */
+  onDeviceDisconnected(deviceId: string): void {
+    const existing = this.byDeviceId.get(deviceId);
+    if (!existing) {
+      return;
+    }
+    this.byDeviceId.delete(deviceId);
+    this.uuidToDeviceId.delete(existing.record.deviceSessionUuid);
+  }
+
+  getByDeviceId(deviceId: string): DeviceSessionRecord | undefined {
+    return this.byDeviceId.get(deviceId)?.record;
+  }
+
+  getByUuid(deviceSessionUuid: string): DeviceSessionRecord | undefined {
+    const deviceId = this.uuidToDeviceId.get(deviceSessionUuid);
+    if (deviceId === undefined) {
+      return undefined;
+    }
+    return this.byDeviceId.get(deviceId)?.record;
+  }
+
+  /** All currently-live device sessions. */
+  list(): DeviceSessionRecord[] {
+    const records: DeviceSessionRecord[] = [];
+    for (const entry of this.byDeviceId.values()) {
+      records.push(entry.record);
+    }
+    return records;
+  }
+}

--- a/test/daemon/daemonRequestHandlers.test.ts
+++ b/test/daemon/daemonRequestHandlers.test.ts
@@ -7,6 +7,8 @@ import { SessionManager } from "../../src/daemon/sessionManager";
 import { DaemonRequest } from "../../src/daemon/types";
 import { FakeTimer } from "../fakes/FakeTimer";
 import type { DeviceRecoveryEligibility, DeviceRecoveryPolicy, PooledDevice } from "../../src/daemon/devicePool";
+import { DeviceSessionRegistry } from "../../src/daemon/deviceSessionRegistry";
+import { FakeIdGenerator } from "../fakes/FakeIdGenerator";
 
 class FakeDevicePool {
   stats: DevicePoolStats;
@@ -50,10 +52,16 @@ class FakeDevicePool {
 class FakeDaemonState {
   private sessionManager: SessionManager | null;
   private devicePool: FakeDevicePool | null;
+  private deviceSessionRegistry: DeviceSessionRegistry;
 
-  constructor(sessionManager: SessionManager | null, devicePool: FakeDevicePool | null) {
+  constructor(
+    sessionManager: SessionManager | null,
+    devicePool: FakeDevicePool | null,
+    deviceSessionRegistry: DeviceSessionRegistry = new DeviceSessionRegistry()
+  ) {
     this.sessionManager = sessionManager;
     this.devicePool = devicePool;
+    this.deviceSessionRegistry = deviceSessionRegistry;
   }
 
   isInitialized(): boolean {
@@ -72,6 +80,10 @@ class FakeDaemonState {
       throw new Error("DaemonState not initialized");
     }
     return this.devicePool;
+  }
+
+  getDeviceSessionRegistry(): DeviceSessionRegistry {
+    return this.deviceSessionRegistry;
   }
 }
 
@@ -278,5 +290,39 @@ describe("handleDaemonRequest", () => {
       recoveryPolicy: { onLoss: false, maxAttempts: 2 },
       devices: [],
     });
+  });
+
+  test("lists live device sessions with their epoch identity", async () => {
+    const devicePool = new FakeDevicePool({ total: 2, idle: 0, assigned: 2, error: 0 });
+    const registry = new DeviceSessionRegistry(fakeTimer, new FakeIdGenerator(["uuid-a", "uuid-b"]));
+    fakeTimer.setCurrentTime(5000);
+    registry.onDeviceConnected({ deviceId: "emulator-5554", platform: "android", incarnation: 1 });
+    registry.onDeviceConnected({ deviceId: "00008030-001", platform: "ios", incarnation: 1 });
+    const state = new FakeDaemonState(sessionManager, devicePool, registry);
+
+    const response = await handleDaemonRequest(
+      buildRequest("daemon/listDeviceSessions"),
+      state
+    );
+
+    expect(response.success).toBe(true);
+    expect(response.result?.totalDeviceSessions).toBe(2);
+    expect(response.result?.deviceSessions).toEqual([
+      { deviceSessionUuid: "uuid-a", deviceId: "emulator-5554", platform: "android", epochStartedAt: 5000 },
+      { deviceSessionUuid: "uuid-b", deviceId: "00008030-001", platform: "ios", epochStartedAt: 5000 },
+    ]);
+  });
+
+  test("returns an empty device-session list when no devices are connected", async () => {
+    const devicePool = new FakeDevicePool({ total: 0, idle: 0, assigned: 0, error: 0 });
+    const state = new FakeDaemonState(sessionManager, devicePool);
+
+    const response = await handleDaemonRequest(
+      buildRequest("daemon/listDeviceSessions"),
+      state
+    );
+
+    expect(response.success).toBe(true);
+    expect(response.result).toEqual({ deviceSessions: [], totalDeviceSessions: 0 });
   });
 });

--- a/test/daemon/deviceSessionRegistry.test.ts
+++ b/test/daemon/deviceSessionRegistry.test.ts
@@ -1,0 +1,107 @@
+import { describe, expect, it } from "bun:test";
+import { DeviceSessionRegistry } from "../../src/daemon/deviceSessionRegistry";
+import { FakeIdGenerator } from "../fakes/FakeIdGenerator";
+import { FakeTimer } from "../fakes/FakeTimer";
+
+function makeRegistry(scripted?: string[]) {
+  const timer = new FakeTimer();
+  const idGenerator = new FakeIdGenerator(scripted);
+  const registry = new DeviceSessionRegistry(timer, idGenerator);
+  return { registry, timer, idGenerator };
+}
+
+describe("DeviceSessionRegistry", () => {
+  it("mints a deviceSessionUuid on device-connect via the injected IdGenerator", () => {
+    const { registry } = makeRegistry(["uuid-a"]);
+
+    const record = registry.onDeviceConnected({
+      deviceId: "emulator-5554",
+      platform: "android",
+      incarnation: 1,
+    });
+
+    expect(record.deviceSessionUuid).toBe("uuid-a");
+    expect(record.deviceId).toBe("emulator-5554");
+    expect(record.platform).toBe("android");
+  });
+
+  it("stamps epochStartedAt from the injected timer", () => {
+    const { registry, timer } = makeRegistry(["uuid-a"]);
+    timer.setCurrentTime(12345);
+
+    const record = registry.onDeviceConnected({
+      deviceId: "emulator-5554",
+      platform: "android",
+      incarnation: 1,
+    });
+
+    expect(record.epochStartedAt).toBe(12345);
+  });
+
+  it("is idempotent for a repeated connect of the same incarnation (no new uuid)", () => {
+    const { registry, idGenerator } = makeRegistry(["uuid-a", "uuid-b"]);
+
+    const first = registry.onDeviceConnected({ deviceId: "emulator-5554", platform: "android", incarnation: 1 });
+    const second = registry.onDeviceConnected({ deviceId: "emulator-5554", platform: "android", incarnation: 1 });
+
+    expect(second.deviceSessionUuid).toBe(first.deviceSessionUuid);
+    // Only one uuid was consumed; the second scripted id is still pending.
+    expect(idGenerator.pendingCount()).toBe(1);
+  });
+
+  it("retires the record on disconnect (lookups return undefined)", () => {
+    const { registry } = makeRegistry(["uuid-a"]);
+    const record = registry.onDeviceConnected({ deviceId: "emulator-5554", platform: "android", incarnation: 1 });
+
+    registry.onDeviceDisconnected("emulator-5554");
+
+    expect(registry.getByDeviceId("emulator-5554")).toBeUndefined();
+    expect(registry.getByUuid(record.deviceSessionUuid)).toBeUndefined();
+  });
+
+  it("mints a NEW uuid on reconnect of the same serial (disconnect then connect)", () => {
+    const { registry } = makeRegistry(["uuid-a", "uuid-b"]);
+
+    const first = registry.onDeviceConnected({ deviceId: "emulator-5554", platform: "android", incarnation: 1 });
+    registry.onDeviceDisconnected("emulator-5554");
+    const second = registry.onDeviceConnected({ deviceId: "emulator-5554", platform: "android", incarnation: 2 });
+
+    expect(second.deviceSessionUuid).toBe("uuid-b");
+    expect(second.deviceSessionUuid).not.toBe(first.deviceSessionUuid);
+  });
+
+  it("mints a NEW uuid on a fast same-serial restart (new incarnation without an intervening disconnect)", () => {
+    const { registry } = makeRegistry(["uuid-a", "uuid-b"]);
+
+    const first = registry.onDeviceConnected({ deviceId: "emulator-5554", platform: "android", incarnation: 1 });
+    // Fast restart: the disconnect monitor never confirmed, but the pool bumped incarnation.
+    const second = registry.onDeviceConnected({ deviceId: "emulator-5554", platform: "android", incarnation: 2 });
+
+    expect(second.deviceSessionUuid).not.toBe(first.deviceSessionUuid);
+    // The superseded epoch's uuid no longer resolves.
+    expect(registry.getByUuid(first.deviceSessionUuid)).toBeUndefined();
+    expect(registry.getByDeviceId("emulator-5554")?.deviceSessionUuid).toBe(second.deviceSessionUuid);
+  });
+
+  it("supports bidirectional lookup", () => {
+    const { registry } = makeRegistry(["uuid-a"]);
+    const record = registry.onDeviceConnected({ deviceId: "emulator-5554", platform: "android", incarnation: 1 });
+
+    expect(registry.getByDeviceId("emulator-5554")).toEqual(record);
+    expect(registry.getByUuid("uuid-a")).toEqual(record);
+    expect(registry.getByDeviceId("unknown")).toBeUndefined();
+    expect(registry.getByUuid("unknown")).toBeUndefined();
+  });
+
+  it("lists all live device sessions across multiple devices", () => {
+    const { registry } = makeRegistry(["uuid-a", "uuid-b"]);
+    registry.onDeviceConnected({ deviceId: "emulator-5554", platform: "android", incarnation: 1 });
+    registry.onDeviceConnected({ deviceId: "00008030-001", platform: "ios", incarnation: 1 });
+
+    const list = registry.list();
+
+    expect(list).toHaveLength(2);
+    expect(list.map(r => r.deviceId).sort()).toEqual(["00008030-001", "emulator-5554"]);
+    expect(list.find(r => r.deviceId === "00008030-001")?.platform).toBe("ios");
+  });
+});

--- a/test/daemon/manager.test.ts
+++ b/test/daemon/manager.test.ts
@@ -25,6 +25,7 @@ import type {
   ExtractionCleaner,
 } from "../../src/daemon/manager";
 import type { DaemonStateLike } from "../../src/daemon/daemonState";
+import { DeviceSessionRegistry } from "../../src/daemon/deviceSessionRegistry";
 import type { DaemonClientLike } from "../../src/daemon/client";
 import { FakeTimer } from "../fakes/FakeTimer";
 
@@ -1099,6 +1100,9 @@ describe("Daemon manager available-devices", () => {
           },
           getSessionManager: () => {
             throw new Error("Session manager unavailable");
+          },
+          getDeviceSessionRegistry: () => {
+            throw new Error("Device session registry unavailable");
           }
         } satisfies DaemonStateLike)
       });
@@ -1148,7 +1152,8 @@ describe("Daemon manager available-devices", () => {
       getSessionManager: () => ({
         getSession: () => null,
         releaseSession: async () => null
-      } as any)
+      } as any),
+      getDeviceSessionRegistry: () => new DeviceSessionRegistry()
     };
 
     try {


### PR DESCRIPTION
## Summary

Item 1 (the keystone) of the device-session-UUID routing epic #5256. Introduces a daemon-minted
`deviceSessionUuid` that identifies a device **connection epoch**, so every downstream stream can key on
a stable identity instead of the mutable adb serial / simulator UDID (a rebooted `emulator-5554` reuses
its serial, and `transportId` changes on reconnect).

`DeviceSessionRegistry` (`src/daemon/deviceSessionRegistry.ts`) mints a UUID via the injected
`IdGenerator` when a device reaches a boot-ready connection boundary, retires it on disconnect, and mints
a **fresh** UUID on same-serial reconnect. The mint is keyed on the pool's monotonic
`PooledDevice.incarnation`, which is what makes the reconnect case correct even for a fast same-serial
restart that the disconnect monitor never confirms (the pool bumps `incarnation`, so a stale
`deviceSessionUuid` stops resolving and a new epoch is minted). The current
`deviceId ↔ deviceSessionUuid` map is exposed over the control socket via a new
`daemon/listDeviceSessions` method. The registry is purely in-memory — an epoch is meaningless across
daemon restarts, so nothing is persisted and no DB is touched.

No stream/envelope changes here; those are items 2–7 of the epic.

## Linked Issue

Closes #5257

## Validation

- [x] `bun run lint` (oxlint ratchet: no new violations; boundary-checks 13/13) + `bun test` (13109 pass, 0 fail, 13 real-device skips)
- [x] `bun run typecheck` reports no new errors (185 baseline)
- [x] `bunx turbo run build` succeeds
- [x] New code uses interface + fake (`FakeIdGenerator`) + `FakeTimer`; registry unit tests run in ~100ms and never resolve the real file-backed `getDatabase()`
- [x] Reuses the canonical `IdGenerator`/`Timer` primitives (no new `randomUUID()`/`Math.random()` path); no new dependency
- [x] Based on latest `main`

## Device Verification

N/A — internal daemon identity primitive + control-socket method; no on-device behavior change.

## Follow-ups

Items 2–7 tracked under epic #5256 (multiplexed subscriptions, envelope stamping + filter key,
auth, desktop `DaemonStreamHub`, workspace keying).
