### PR TITLE
fix(desktop): guard video session identity and bound the append capability probe

### DIFF
--- a/android/desktop-core/src/main/kotlin/dev/jasonpearson/automobile/desktop/core/daemon/McpDaemonClient.kt
+++ b/android/desktop-core/src/main/kotlin/dev/jasonpearson/automobile/desktop/core/daemon/McpDaemonClient.kt
@@ -657,7 +657,11 @@ class McpDaemonClient(
   }
 
   private fun queryDaemonCapabilities(identity: SocketIdentity?): DaemonCapabilitiesProbe {
-    val response = sendRequest(DAEMON_CAPABILITIES_METHOD)
+    // This probe runs on the keyboard input path (inputTypeText append=true), which shares the
+    // video pane's single FIFO dispatch thread. Bound it with the same input hang ceiling so a
+    // never-replying daemon can't freeze keystrokes forever — the taps/keys deadline is useless if
+    // its prerequisite blocks unbounded.
+    val response = sendRequest(DAEMON_CAPABILITIES_METHOD, timeoutMs = inputRequestTimeoutMs)
     if (!response.success) {
       if (response.error == OLD_DAEMON_CAPABILITIES_ERROR) return DaemonCapabilitiesProbe.Legacy
       return DaemonCapabilitiesProbe.Failure(response.error ?: "Daemon capability probe failed.")

--- a/android/desktop-core/src/main/kotlin/dev/jasonpearson/automobile/desktop/core/video/VideoStreamClient.kt
+++ b/android/desktop-core/src/main/kotlin/dev/jasonpearson/automobile/desktop/core/video/VideoStreamClient.kt
@@ -174,6 +174,14 @@ class VideoStreamClient(
   private var channel: SocketChannel? = null
   private var readerJob: Job? = null
 
+  // Session identity so a superseded reader's teardown can't clobber a newer session's state. A
+  // rapid disconnect()+connect() (the stall / first-frame watchdog) installs the replacement reader
+  // before the cancelled one unwinds; a stale reader that checked the mutable readerJob would see
+  // the fresh job as active and publish its own Unavailable over the new session's Connecting,
+  // wedging the stream. Keyed on this id every state write is dropped unless the reader is current.
+  private val sessionIds = java.util.concurrent.atomic.AtomicLong(0L)
+  @Volatile private var activeSessionId = 0L
+
   override fun isAvailable(): Boolean = Files.exists(File(socketPathValue).toPath())
 
   override fun connect(deviceId: String?) {
@@ -183,16 +191,21 @@ class VideoStreamClient(
       return
     }
 
+    val sessionId = sessionIds.incrementAndGet()
+    activeSessionId = sessionId
     _state.value = VideoStreamState.Connecting
     readerJob = scope.launch {
       // Name the dedicated thread per target so a farm's dozens of readers are tellable
       // apart in a thread dump.
       Thread.currentThread().name = "video-stream-reader-${deviceId ?: "default"}"
-      runSession(deviceId)
+      runSession(deviceId, sessionId)
     }
   }
 
   override fun disconnect() {
+    // Invalidate the current session first so the cancelled reader's terminal state write is
+    // dropped rather than racing an Unavailable over a subsequent Idle/Connecting.
+    activeSessionId = sessionIds.incrementAndGet()
     readerJob?.cancel()
     readerJob = null
     closeChannel()
@@ -206,19 +219,26 @@ class VideoStreamClient(
     readerDispatcher.close()
   }
 
-  private fun runSession(deviceId: String?) {
+  private fun runSession(deviceId: String?, sessionId: Long) {
+    // Only the current session may touch shared state; a reader superseded by a reconnect (or a
+    // disconnect) publishes nothing, so its late teardown can't clobber the live session.
+    fun isCurrent() = sessionId == activeSessionId
+    fun publish(state: VideoStreamState) {
+      if (isCurrent()) _state.value = state
+    }
+
     val decoder =
       try {
         decoderFactory()
       } catch (e: Exception) {
         LOG.warn("Could not create the H.264 decoder: ${e.message}", e)
-        _state.value = VideoStreamState.Unavailable(e.message ?: "No H.264 decoder available")
+        publish(VideoStreamState.Unavailable(e.message ?: "No H.264 decoder available"))
         return
       }
 
     try {
       SocketChannel.open(UnixDomainSocketAddress.of(socketPathValue)).use { socket ->
-        channel = socket
+        if (isCurrent()) channel = socket
         val input = Channels.newInputStream(socket)
         val writer =
           BufferedWriter(
@@ -244,26 +264,26 @@ class VideoStreamClient(
         val ackLine = readAckLine(input)
         val ack = json.decodeFromString(serializer<VideoStreamResponse>(), ackLine)
         if (!ack.success) {
-          _state.value =
+          publish(
             ack.permission.toPermissionState()
               ?: VideoStreamState.Unavailable(ack.error ?: "Live mirroring was refused")
+          )
           return
         }
 
-        pumpFrames(input, decoder)
-        if (readerJob?.isActive == true) {
-          _state.value = VideoStreamState.Unavailable("Live mirroring stopped")
-        }
+        pumpFrames(input, decoder, sessionId)
+        publish(VideoStreamState.Unavailable("Live mirroring stopped"))
       }
     } catch (e: Exception) {
-      // Cancellation arrives as an exception on the blocking read; that is a normal disconnect.
-      if (readerJob?.isActive == true) {
+      // Cancellation (from disconnect / a watchdog reconnect) supersedes this session, so publish()
+      // drops the terminal state; a genuine read error on the still-current session surfaces it.
+      if (isCurrent()) {
         LOG.warn("Live mirroring stopped: ${e.message}", e)
-        _state.value = VideoStreamState.Unavailable(e.message ?: "Live mirroring stopped")
+        publish(VideoStreamState.Unavailable(e.message ?: "Live mirroring stopped"))
       }
     } finally {
       decoder.close()
-      channel = null
+      if (isCurrent()) channel = null
     }
   }
 
@@ -283,7 +303,7 @@ class VideoStreamClient(
     }
   }
 
-  private fun pumpFrames(input: java.io.InputStream, decoder: H264Decoder) {
+  private fun pumpFrames(input: java.io.InputStream, decoder: H264Decoder, sessionId: Long) {
     val parser = VideoStreamParser()
     val buffer = ByteArray(64 * 1024)
     // Latest attested rotation, updated by each config packet that carries it (issue #4786). A
@@ -307,6 +327,9 @@ class VideoStreamClient(
             currentRotation = packet.rotation
           }
           decoder.decode(packet.payload) { frame ->
+            // A reader superseded by a reconnect must not publish frames or Streaming onto the new
+            // session's state; drop this frame once we are no longer the current session.
+            if (sessionId != activeSessionId) return@decode
             val current = _state.value
             if (
               current !is VideoStreamState.Streaming ||

--- a/android/desktop-core/src/test/kotlin/dev/jasonpearson/automobile/desktop/core/daemon/McpDaemonClientInputTest.kt
+++ b/android/desktop-core/src/test/kotlin/dev/jasonpearson/automobile/desktop/core/daemon/McpDaemonClientInputTest.kt
@@ -656,6 +656,49 @@ class McpDaemonClientInputTest {
     }
   }
 
+  @Test
+  fun `a daemon that never answers the append capability probe fails typing at its deadline`() {
+    // The keyboard append path first probes daemon/capabilities, then sends input/typeText. That
+    // probe rode an UNBOUNDED sendRequest, so a wedged daemon hung it forever — freezing the video
+    // pane's single dispatch thread exactly like a hung tap, which the tap/key deadline was
+    // supposed to prevent. The input deadline must bound the prerequisite probe too.
+    val socketDir = Files.createTempDirectory(Path.of("/tmp"), "am-hang-cap-")
+    val socketPath = socketDir.resolve("daemon.sock")
+    val server = ServerSocketChannel.open(StandardProtocolFamily.UNIX)
+    server.bind(UnixDomainSocketAddress.of(socketPath))
+    var accepted: java.nio.channels.SocketChannel? = null
+    val accepter = Thread {
+      try {
+        accepted = server.accept() // Accept the capability probe, then never reply.
+        while (!Thread.currentThread().isInterrupted) Thread.sleep(50)
+      } catch (_: Exception) {
+        // Server/channel closed by the test's cleanup: the hang is over.
+      }
+    }
+      .apply {
+        isDaemon = true
+        start()
+      }
+    try {
+      val client =
+        McpDaemonClient(
+          socketPathValue = socketPath.toString(),
+          inputRequestTimeoutMs = 100,
+        )
+      val error =
+        assertFailsWith<DaemonUnavailableException> {
+          client.inputTypeText(text = "hello", platform = "android", append = true)
+        }
+      assertTrue(error.message.orEmpty().contains("timed out"))
+    } finally {
+      accepter.interrupt()
+      accepted?.close()
+      server.close()
+      Files.deleteIfExists(socketPath)
+      Files.deleteIfExists(socketDir)
+    }
+  }
+
   private fun captureInputRequest(
     resultJson: String? = null,
     error: String? = null,

--- a/android/desktop-core/src/test/kotlin/dev/jasonpearson/automobile/desktop/core/video/VideoStreamClientTest.kt
+++ b/android/desktop-core/src/test/kotlin/dev/jasonpearson/automobile/desktop/core/video/VideoStreamClientTest.kt
@@ -50,8 +50,11 @@ class VideoStreamClientTest {
     payload: ByteArray? = null,
     keepOpen: Boolean = false,
     rotation: Int? = null,
+    maxConnections: Int = 1,
   ): FakeRelay =
-    FakeRelay(success, error, permissionJson, payload, keepOpen, rotation).also { servers.add(it) }
+    FakeRelay(success, error, permissionJson, payload, keepOpen, rotation, maxConnections).also {
+      servers.add(it)
+    }
 
   @Test
   fun `subscribes with the device id and decodes frames`() = runBlocking {
@@ -294,6 +297,34 @@ class VideoStreamClientTest {
     client.dispose()
   }
 
+  @Test
+  fun `a rapid reconnect is not wedged by the superseded reader's teardown`() = runBlocking {
+    // The stall / first-frame watchdog reconnects with disconnect()+connect() back-to-back. The
+    // cancelled reader's channel-close throws on its blocking read AFTER the replacement reader is
+    // already installed; keyed only on the mutable readerJob it would publish its terminal
+    // Unavailable over the new session's Streaming and wedge the pane. Session identity must drop
+    // that stale write. Cycled several times to widen the interleaving window against real IO
+    // threads.
+    val server = relay(payload = sampleH264(), keepOpen = true, maxConnections = 8)
+    val client = VideoStreamClient(socketPathValue = server.socketPath.toString())
+
+    repeat(6) {
+      client.connect("emulator-5554")
+      server.awaitFirstFrameFrom(client)
+      client.disconnect()
+    }
+
+    // Final session must settle on live video, never a stale Unavailable from a prior reader.
+    client.connect("emulator-5554")
+    server.awaitFirstFrameFrom(client)
+    waitUntil { client.state.value is VideoStreamState.Streaming }
+    assertTrue(
+      client.state.value is VideoStreamState.Streaming,
+      "expected Streaming, was ${client.state.value}",
+    )
+    client.dispose()
+  }
+
   private suspend fun waitUntil(timeoutMs: Long = 5_000, predicate: () -> Boolean) {
     val deadline = System.currentTimeMillis() + timeoutMs
     while (System.currentTimeMillis() < deadline) {
@@ -313,7 +344,7 @@ class VideoStreamClientTest {
     return frame ?: throw AssertionError("No frame decoded before timeout")
   }
 
-  /** A one-connection relay speaking the daemon's handshake then its binary framing. */
+  /** A relay speaking the daemon's handshake then its binary framing over up to N connections. */
   private inner class FakeRelay(
     private val success: Boolean,
     private val error: String?,
@@ -323,6 +354,10 @@ class VideoStreamClientTest {
     // When set, the framed packet is flagged CONFIG and attests this rotation (issue #4786), as the
     // daemon relay does on a parameter-set packet.
     private val rotation: Int? = null,
+    // How many sequential subscribe connections to serve. >1 lets a reconnect (disconnect+connect)
+    // be exercised against one relay; each connection is handled on its own daemon thread so a
+    // keepOpen session never blocks the accept loop.
+    private val maxConnections: Int = 1,
   ) : AutoCloseable {
     private val tempDir: Path = Files.createTempDirectory(Path.of("/tmp"), "amvsc-")
     val socketPath: Path = tempDir.resolve("video-stream.sock")
@@ -332,40 +367,57 @@ class VideoStreamClientTest {
         .bind(UnixDomainSocketAddress.of(socketPath))
 
     @Volatile private var captured: kotlinx.serialization.json.JsonObject? = null
+    private val handlers = mutableListOf<Thread>()
+
+    private fun handle(socket: java.nio.channels.SocketChannel) {
+      socket.use {
+        val reader =
+          BufferedReader(InputStreamReader(Channels.newInputStream(socket), StandardCharsets.UTF_8))
+        val out = Channels.newOutputStream(socket)
+        captured = json.parseToJsonElement(reader.readLine()).jsonObject
+
+        val ack =
+          if (success) {
+            """{"id":"1","type":"video_stream_response","success":true,"framing":"h264"}"""
+          } else {
+            buildString {
+              append("""{"id":"1","type":"video_stream_response","success":false""")
+              if (error != null) append(""","error":"$error"""")
+              if (permissionJson != null) append(""","permission":$permissionJson""")
+              append("}")
+            }
+          }
+        out.write((ack + "\n").toByteArray(StandardCharsets.UTF_8))
+        out.flush()
+
+        if (success && payload != null) {
+          writeStream(out, payload)
+        }
+        while (keepOpen && !Thread.currentThread().isInterrupted) {
+          Thread.sleep(1000)
+        }
+      }
+    }
 
     private val thread = Thread {
       try {
-        serverChannel.accept().use { socket ->
-          val reader =
-            BufferedReader(
-              InputStreamReader(Channels.newInputStream(socket), StandardCharsets.UTF_8)
-            )
-          val out = Channels.newOutputStream(socket)
-          captured = json.parseToJsonElement(reader.readLine()).jsonObject
-
-          val ack =
-            if (success) {
-              """{"id":"1","type":"video_stream_response","success":true,"framing":"h264"}"""
-            } else {
-              buildString {
-                append("""{"id":"1","type":"video_stream_response","success":false""")
-                if (error != null) append(""","error":"$error"""")
-                if (permissionJson != null) append(""","permission":$permissionJson""")
-                append("}")
-              }
+        repeat(maxConnections) {
+          val socket = serverChannel.accept()
+          val handler = Thread {
+            try {
+              handle(socket)
+            } catch (_: Throwable) {
+              // The client disconnecting mid-stream is the normal end of a handler.
             }
-          out.write((ack + "\n").toByteArray(StandardCharsets.UTF_8))
-          out.flush()
-
-          if (success && payload != null) {
-            writeStream(out, payload)
           }
-          while (keepOpen && !Thread.currentThread().isInterrupted) {
-            Thread.sleep(1000)
-          }
+            .also {
+              it.isDaemon = true
+              it.start()
+            }
+          synchronized(handlers) { handlers.add(handler) }
         }
       } catch (_: Throwable) {
-        // The client disconnecting mid-stream is the normal end of this thread.
+        // The server channel closing on teardown ends the accept loop.
       }
     }
       .also {
@@ -413,6 +465,7 @@ class VideoStreamClientTest {
 
     override fun close() {
       thread.interrupt()
+      synchronized(handlers) { handlers.forEach { it.interrupt() } }
       serverChannel.close()
       Files.deleteIfExists(socketPath)
       Files.deleteIfExists(tempDir)


### PR DESCRIPTION
Follow-up to #5255 (already merged): two correctness fixes surfaced in that PR's final review round, relanded on top of main.

## 1. Video session-identity guard (`VideoStreamClient`)
The stall / first-frame watchdog reconnects with `disconnect()` + `connect()` back-to-back. The cancelled reader's channel-close throws on its blocking read *after* the replacement reader is already installed. Keyed only on the mutable `readerJob`, the stale reader saw the fresh job as active and published its terminal `Unavailable` over the new session's `Connecting`/`Streaming` — wedging the pane in "unavailable" until the next manual reconnect.

Every state write in `runSession`/`pumpFrames` is now keyed on a monotonic per-session id (bumped in both `connect()` and `disconnect()`), so a superseded reader's teardown is dropped instead of clobbering the live session. This is the standard identity-over-presence guard (`CLAUDE.md`: *"a callback firing for a superseded encoder. Guard by identity, not presence."*).

## 2. Bound the append capability probe (`McpDaemonClient`)
`inputTypeText(append=true)` first probes `daemon/capabilities` before typing, and that probe rode an **unbounded** `sendRequest`. A wedged daemon (half-open socket, stalled event loop) froze keystrokes forever — the exact hang the tap/key input deadline was added to prevent, but on the keyboard path that shares the video pane's single FIFO dispatch thread. The probe now shares the input hang ceiling (`inputRequestTimeoutMs`), so a never-replying daemon fails the keystroke quickly with a clear message instead of blocking all input behind it.

## Tests
- `VideoStreamClientTest`: a rapid reconnect cycle (multi-connection fake relay) settles on `Streaming` and is never wedged by a superseded reader's teardown.
- `McpDaemonClientInputTest`: a daemon that accepts the capability probe but never replies fails `inputTypeText(append=true)` at its deadline rather than hanging.

## Validation
- `:desktop-core:test` (full) + `:desktop-core:detektMain :desktop-core:detektTest` green
- `test/daemon/videoStreamSocketServer.test.ts` — 37 pass
- ktfmt formatted with the pinned CI jar