### PR TITLE
build(desktop): Conveyor Gradle plugin + conveyor.conf (POC, coexists with jpackage) [C1]

### DIFF
--- a/android/conveyor.conf
+++ b/android/conveyor.conf
@@ -1,0 +1,33 @@
+// Conveyor packaging + auto-update — LOCAL PROOF-OF-CONCEPT (PR-C1, see #5227).
+//
+// This coexists with the jpackage `compose.desktop` block in desktop-app/build.gradle.kts; it does
+// not replace it yet. Run from the `android/` directory with the Conveyor CLI:
+//   conveyor make site        # builds packages + update site into ./output (no upload)
+// The CLI is a separate download (https://hydraulic.dev); it is NOT a Gradle dependency. The
+// Gradle-side integration (the printConveyorConfig task this file includes) can be validated without
+// the CLI via:  ./gradlew :desktop-app:printConveyorConfig
+
+// Pull the app's main class, JVM args, and resolved runtime classpath from the Gradle build.
+include "#!./gradlew -q :desktop-app:printConveyorConfig"
+
+app {
+  display-name = "AutoMobile"
+  // Stable package identity across releases (macOS bundle id / Windows MSIX upgrade identity).
+  rdns-name = "dev.jasonpearson.automobile.desktop"
+  vendor = "AutoMobile"
+
+  // POC override: the repo version is 0.0.x-SNAPSHOT, but Conveyor requires a purely-numeric
+  // version with macOS major >= 1. Real versioning is a migration decision (#5227); 1.0.0 here just
+  // lets the POC build.
+  version = "1.0.0"
+
+  // Publish the update site to localhost so Conveyor stays in its free tier for the POC (no license
+  // key, no real upload). The GitHub-Releases site (app.vcs-url + app.site.copy-to) comes in PR-C3.
+  site.base-url = "localhost:3000"
+
+  icons = "desktop-app/src/main/resources/icons/app-icon.png"
+
+  // No code signing for the local POC — validates packaging config without certs. Real signing
+  // (macOS Developer ID reuse + a new Windows cert) is PR-C3.
+  sign = false
+}

--- a/android/desktop-app/build.gradle.kts
+++ b/android/desktop-app/build.gradle.kts
@@ -16,6 +16,10 @@ plugins {
   alias(libs.plugins.compose.multiplatform)
   alias(libs.plugins.compose.hot.reload)
   alias(libs.plugins.metro)
+  // Conveyor packaging + auto-update (POC, coexists with the jpackage `compose.desktop` block
+  // below). Adds the printConveyorConfig / writeConveyorConfig tasks and feeds the runtime
+  // classpath to `conveyor make`. See conveyor.conf and #5227.
+  alias(libs.plugins.conveyor)
 }
 
 repositories {

--- a/android/gradle/libs.versions.toml
+++ b/android/gradle/libs.versions.toml
@@ -78,6 +78,7 @@ dokka = "2.2.0"
 compose-multiplatform = "1.11.1"
 compose-hot-reload = "1.2.0"
 metro = "1.4.1"
+conveyor = "2.0"
 
 [plugins]
 compose-compiler = { id = "org.jetbrains.kotlin.plugin.compose", version.ref = "build-kotlin" }
@@ -91,6 +92,7 @@ compose-multiplatform = { id = "org.jetbrains.compose", version.ref = "compose-m
 compose-hot-reload = { id = "org.jetbrains.compose.hot-reload", version.ref = "compose-hot-reload" }
 metro = { id = "dev.zacsweers.metro", version.ref = "metro" }
 detekt = { id = "dev.detekt", version.ref = "detekt" }
+conveyor = { id = "dev.hydraulic.conveyor", version.ref = "conveyor" }
 
 [libraries]
 # H.264 decoding for the live device view. Deliberately org.bytedeco:ffmpeg and NOT


### PR DESCRIPTION
## Summary

**PR-C1 of the Conveyor pivot** ([#5227](https://github.com/kaeawc/auto-mobile/issues/5227)) — a
non-disruptive scaffold + local proof-of-concept. Adds the `dev.hydraulic.conveyor` 2.0 Gradle
plugin to `:desktop-app` and a POC `android/conveyor.conf`, **coexisting** with the existing jpackage
`compose.desktop` block. This does not replace jpackage or change publishing; it validates that
Conveyor can read this build.

Context: this supersedes the paused DIY apply (#5226). Conveyor gives signed, delta, self-updating
packages + a real in-app update API, replacing the hand-rolled download→install→quit.

## Changes

- `gradle/libs.versions.toml`: add `conveyor = "2.0"` + the `dev.hydraulic.conveyor` plugin.
- `desktop-app/build.gradle.kts`: apply `alias(libs.plugins.conveyor)` (adds `printConveyorConfig` /
  `writeConveyorConfig`; feeds the runtime classpath to `conveyor make`).
- `android/conveyor.conf`: POC config — localhost update site (free tier), unsigned, `version = 1.0.0`
  override, main class/classpath pulled from Gradle via the `printConveyorConfig` include.

## What's validated (Gradle-side, no CLI)

- Plugin applies and **coexists with jpackage** — `createDistributable` / `packageDmg` intact,
  `:desktop-app:test` green.
- `./gradlew :desktop-app:printConveyorConfig` emits correct config: `app.jvm.gui.main-class =
  dev.jasonpearson.automobile.desktop.MainKt`, the runtime classpath as `app.inputs`, plus
  description / vendor / rdns-name.

## Findings for later PRs (C2/C3)

1. **ffmpeg transform clash** — Conveyor resolves `runtimeClasspath` eagerly, and this repo's
   `StripFfmpegProgramsTransform` fails on any project jar not yet built (its non-ffmpeg passthrough
   does `outputs.file(input)`). `conveyor make` needs the jars pre-built, or the transform changed to
   *copy* instead of reference. Fix in C2/C3.
2. **Versioning** — the plugin emits `app.version = 0.0.58-SNAPSHOT`; Conveyor requires a purely
   numeric version (no `-SNAPSHOT`) with macOS major ≥ 1. `conveyor.conf` pins `1.0.0` for the POC;
   the real numeric-≥1.0 decision is part of the migration.
3. **Cross-platform natives** — Skiko (`compose.desktop.currentOs`) + ffmpeg (bytedeco) are per-OS;
   cross-building all three platforms needs them declared in Conveyor's per-machine configs
   (`macAmd64` / `windowsAmd64` / `linuxAmd64`). Real work for the CI cutover (C3).

## Not done here

- Actual `conveyor make site` packaging (build real .dmg/.msi/.deb + confirm the app launches from a
  Conveyor bundle and `SoftwareUpdateController` resolves) requires the **Conveyor CLI** — a direct
  `.zip` download from downloads.hydraulic.dev, not Homebrew. Deferred.
- Signing (macOS Developer ID reuse + a new Windows Authenticode cert) and the GitHub-Releases update
  site are PR-C3.

## Linked

Part of the Conveyor migration plan on #5227. Follow-ups: PR-C2 (control-API rewire of the merged
`UpdateController`/`AppVersion`), PR-C3 (CI cutover + signing), PR-C4 (retire jpackage + cleanup).

## Validation

- [x] `:desktop-app:test` green with the plugin applied
- [x] jpackage tasks (`createDistributable`, `packageDmg`) still present (coexistence)
- [x] `printConveyorConfig` emits valid config
- [x] `scripts/all_fast_validate_checks.sh --only ktfmt` passes
- [ ] `conveyor make site` — needs the CLI (deferred)
