### PR TITLE
feat(nav): tiered TTL + global LRU retention for (app,build) nav data (#4986)

### DIFF
--- a/docs/design-docs/mcp/nav/graph-structure.md
+++ b/docs/design-docs/mcp/nav/graph-structure.md
@@ -41,3 +41,35 @@ Edges record the method of navigation in terms of UI interaction:
   avgDuration: number     // Average transition time
 }
 ```
+
+## Retention
+
+The persisted graph accumulates cross-build/device/session data over time
+(the `(app, build)` provenance observation rows, plus heavy assets like node
+screenshots). A background pass bounds it with a tiered policy keyed on each
+row's `last_seen_at` recency, running every 6 hours in the daemon.
+
+The pass is **conservative** — the most-recently-seen build key per app (the
+active context) is never age-deleted or orphan-swept, and its newest
+observation is never evicted by the size cap:
+
+- **Screenshots (short TTL)** — a node's stored screenshot pointer is cleared
+  and the file unlinked once the node has not been seen for the screenshot TTL.
+  The light node row survives.
+- **Provenance / structure (long TTL)** — observation rows older than the
+  structure TTL are pruned, and build keys left with no observations are swept.
+- **Size cap (backstop)** — a per-app **and** a global budget on observation
+  rows; when over budget the oldest rows by `last_seen_at` are evicted.
+
+### Configuration
+
+All thresholds are overridable via environment variables (positive integers;
+an invalid value falls back to the default):
+
+| Variable | Default | Meaning |
+| --- | --- | --- |
+| `AUTOMOBILE_NAV_RETENTION_SCREENSHOT_TTL_MS` | `604800000` (7 days) | Max age of a node screenshot before its pointer is cleared. |
+| `AUTOMOBILE_NAV_RETENTION_STRUCTURE_TTL_MS` | `7776000000` (90 days) | Max age of an observation row before it is pruned. |
+| `AUTOMOBILE_NAV_RETENTION_PER_APP_MAX_OBSERVATIONS` | `50000` | Max observation rows kept per app before the LRU cap evicts oldest. |
+| `AUTOMOBILE_NAV_RETENTION_GLOBAL_MAX_OBSERVATIONS` | `500000` | Max observation rows kept across all apps. |
+| `AUTOMOBILE_NAV_RETENTION_INTERVAL_MS` | `21600000` (6 hours) | How often the background retention pass runs. |

--- a/src/daemon/NavigationRetentionMonitor.ts
+++ b/src/daemon/NavigationRetentionMonitor.ts
@@ -1,0 +1,75 @@
+import { Timer, defaultTimer } from "../utils/SystemTimer";
+import { logger } from "../utils/logger";
+import {
+  type NavigationRetention,
+  type NavigationRetentionSummary,
+  resolveNavigationRetentionIntervalMs,
+} from "../db/navigationRetention";
+
+/**
+ * Background scheduler for {@link NavigationRetention} (nav (app,build) Phase 3,
+ * #4986). Fires a prune pass on a fixed interval, dropping overlapping ticks so a
+ * slow pass never stacks. Extracted from the daemon so the cadence + skip guard
+ * can be driven deterministically with an injected {@link Timer} in tests; the
+ * daemon passes its default timer in production.
+ */
+export class NavigationRetentionMonitor {
+  private timerHandle: NodeJS.Timeout | null = null;
+  private running = false;
+  private readonly intervalMs: number;
+  private lastSummary: NavigationRetentionSummary | null = null;
+
+  constructor(
+    private readonly retention: NavigationRetention,
+    private readonly timer: Timer = defaultTimer,
+    intervalMs?: number
+  ) {
+    this.intervalMs = resolveNavigationRetentionIntervalMs(intervalMs);
+  }
+
+  start(): void {
+    if (this.timerHandle) {
+      return;
+    }
+    this.timerHandle = this.timer.setInterval(() => {
+      void this.tick();
+    }, this.intervalMs);
+
+    // Never keep the process alive for a best-effort cleanup pass.
+    const handle = this.timerHandle as { unref?: () => void };
+    if (handle && typeof handle.unref === "function") {
+      handle.unref();
+    }
+  }
+
+  stop(): void {
+    if (this.timerHandle) {
+      this.timer.clearInterval(this.timerHandle);
+      this.timerHandle = null;
+    }
+  }
+
+  /** The most recent prune summary, for a storage indicator / diagnostics. */
+  getLastSummary(): NavigationRetentionSummary | null {
+    return this.lastSummary;
+  }
+
+  /**
+   * Run a single prune pass. Exposed for deterministic testing; also invoked on
+   * each interval tick. Overlapping invocations are dropped, and any failure is
+   * logged and swallowed — retention is best-effort and must not crash the daemon.
+   */
+  async tick(): Promise<void> {
+    if (this.running) {
+      return;
+    }
+    this.running = true;
+    try {
+      this.lastSummary = await this.retention.prune(this.timer.now());
+    } catch (error) {
+      logger.warn(`Navigation retention pass failed: ${error}`, error);
+    } finally {
+      this.running = false;
+    }
+  }
+}

--- a/src/daemon/NavigationRetentionMonitor.ts
+++ b/src/daemon/NavigationRetentionMonitor.ts
@@ -1,5 +1,6 @@
 import { Timer, defaultTimer } from "../utils/SystemTimer";
 import { logger } from "../utils/logger";
+import { getDbWriteBarrier } from "../db";
 import {
   type NavigationRetention,
   type NavigationRetentionSummary,
@@ -58,6 +59,11 @@ export class NavigationRetentionMonitor {
    * Run a single prune pass. Exposed for deterministic testing; also invoked on
    * each interval tick. Overlapping invocations are dropped, and any failure is
    * logged and swallowed — retention is best-effort and must not crash the daemon.
+   *
+   * The pass is registered with the DB write barrier so an in-flight prune DRAINS
+   * within the shutdown budget (`Daemon.stop()` → barrier.drain → closeDatabase),
+   * rather than racing the connection close. When the barrier is already draining,
+   * `track` short-circuits (returns undefined) and the pass is skipped.
    */
   async tick(): Promise<void> {
     if (this.running) {
@@ -65,7 +71,12 @@ export class NavigationRetentionMonitor {
     }
     this.running = true;
     try {
-      this.lastSummary = await this.retention.prune(this.timer.now());
+      const summary = await getDbWriteBarrier().track(() =>
+        this.retention.prune(this.timer.now())
+      );
+      if (summary) {
+        this.lastSummary = summary;
+      }
     } catch (error) {
       logger.warn(`Navigation retention pass failed: ${error}`, error);
     } finally {

--- a/src/daemon/daemon.ts
+++ b/src/daemon/daemon.ts
@@ -31,9 +31,13 @@ import { SessionReleaseBroadcaster } from "../server/sessionReleaseBroadcast";
 import {
   awaitInFlightMigrations,
   closeDatabase,
+  getDatabase,
   getDatabasePath,
   getDbWriteBarrier,
 } from "../db";
+import { NavigationRetention } from "../db/navigationRetention";
+import { NavigationRetentionMonitor } from "./NavigationRetentionMonitor";
+import { DefaultFileSystem } from "../utils/filesystem/DefaultFileSystem";
 import { DatabaseInitializer, DefaultDatabaseInitializer } from "../db/DatabaseInitializer";
 import { DatabaseHealthProbe, DefaultDatabaseHealthProbe } from "../db/DatabaseHealthProbe";
 import { StartupFailureTracker, DefaultStartupFailureTracker } from "./DaemonStartupFailureTracker";
@@ -139,6 +143,7 @@ export class Daemon {
   private debug: boolean;
   private healthCheckTimer: NodeJS.Timeout | null = null;
   private heartbeatMonitor: SessionHeartbeatMonitor | null = null;
+  private navigationRetentionMonitor: NavigationRetentionMonitor | null = null;
   private deviceDisconnectMonitor: SingleFlightInterval | null = null;
   private pidFileWritten = false;
   private deviceDisconnectMisses: Map<string, number> = new Map();
@@ -423,6 +428,7 @@ export class Daemon {
     // Start health check timer (every 30 seconds)
     this.startHealthCheckTimer();
     this.startHeartbeatMonitor();
+    this.startNavigationRetentionMonitor();
 
     startupBenchmark.emit("daemon", {
       host: this.host,
@@ -1195,6 +1201,23 @@ export class Daemon {
     this.heartbeatMonitor.start();
   }
 
+  /**
+   * Start the periodic navigation-data retention pass (nav (app,build) Phase 3,
+   * #4986). Bounds accumulated cross-build/device/session observation rows and
+   * stale node screenshots. Best-effort: a failed pass is logged and swallowed,
+   * and its writes are tracked by the DB write barrier drained on shutdown.
+   */
+  private startNavigationRetentionMonitor(): void {
+    const fileSystem = new DefaultFileSystem();
+    const retention = new NavigationRetention(
+      getDatabase(),
+      {},
+      filePath => fileSystem.unlink(filePath),
+    );
+    this.navigationRetentionMonitor = new NavigationRetentionMonitor(retention, this.timer);
+    this.navigationRetentionMonitor.start();
+  }
+
   private startDeviceDisconnectMonitor(): void {
     if (this.deviceDisconnectMonitor) {
       return;
@@ -1638,6 +1661,8 @@ export class Daemon {
 
     const heartbeatMonitor = this.heartbeatMonitor;
     this.heartbeatMonitor = null;
+    const navigationRetentionMonitor = this.navigationRetentionMonitor;
+    this.navigationRetentionMonitor = null;
     const deviceDisconnectMonitor = this.deviceDisconnectMonitor;
     this.deviceDisconnectMonitor = null;
     await runShutdownCleanupStages(
@@ -1649,6 +1674,9 @@ export class Daemon {
         {
           name: "shutdown monitors",
           run: async () => {
+            // The navigation retention monitor's in-flight pass drains via the DB
+            // write-barrier stage below; here we only cancel its next scheduled tick.
+            navigationRetentionMonitor?.stop();
             const [heartbeatSettled, disconnectSettled] = await Promise.all([
               heartbeatMonitor ? heartbeatMonitor.stop().then(() => true) : true,
               deviceDisconnectMonitor ? deviceDisconnectMonitor.stop() : true,

--- a/src/db/navigationRetention.ts
+++ b/src/db/navigationRetention.ts
@@ -29,6 +29,15 @@
 // in one transaction (atomic, no torn graph); observations are deleted before
 // their orphaned build keys (FK-safe order), and file unlinks run AFTER commit as
 // side effects (never inside the txn).
+//
+// SQLite scale safety: every statement in this module keeps its bound-parameter
+// count and expression-tree depth bounded regardless of DB size. Row-count id
+// lists (stale screenshots, evicted observations) are processed in batches capped
+// at `evictionChunkSize` (<= MAX_EVICTION_CHUNK_SIZE, well under bun:sqlite's
+// MAX_VARIABLE_NUMBER of 250_000). App/build-key filters bind at most one param
+// per app (`protectedIds`, `activeIds`) or use a join on `app_id` (no id list at
+// all), and the active-row lookup is a relational max-join, never a per-row OR
+// chain. See the per-helper notes below.
 
 import type { Kysely } from "kysely";
 import type { Database } from "./types";
@@ -45,10 +54,9 @@ export interface NavigationRetentionConfig {
   /** Backstop: max observation rows kept across all apps. */
   globalMaxObservations: number;
   /**
-   * Max victim ids bound in one DELETE. Kept well under bun:sqlite's
-   * `MAX_VARIABLE_NUMBER` (250_000) so a runaway eviction can never overflow the
-   * bind limit and roll back the whole retention transaction. Overridable mainly
-   * so tests can exercise the batching loop without a quarter-million rows.
+   * Max ids bound in one batched DELETE/UPDATE. Clamped to
+   * {@link MAX_EVICTION_CHUNK_SIZE} so a misconfigured value can never approach
+   * bun:sqlite's `MAX_VARIABLE_NUMBER` (250_000) and defeat the batching.
    */
   evictionChunkSize: number;
 }
@@ -67,6 +75,15 @@ export const DEFAULT_EVICTION_CHUNK_SIZE = 5_000;
 /** Default cadence of the background pass: every 6 hours. */
 export const DEFAULT_NAV_RETENTION_INTERVAL_MS = 6 * 60 * 60 * 1000;
 
+// Hard SQLite/runtime ceilings the config is validated against.
+// A single DELETE/UPDATE binds at most this many ids — comfortably under
+// bun:sqlite's MAX_VARIABLE_NUMBER (250_000), and small enough that each batch
+// statement stays cheap.
+export const MAX_EVICTION_CHUNK_SIZE = 10_000;
+// setInterval delays above the signed-32-bit max are silently clamped to 1ms by
+// the runtime, so an interval over this is treated as invalid and defaulted.
+export const MAX_INTERVAL_MS = 2_147_483_647;
+
 /**
  * Deletes a screenshot file previously referenced by a pruned node. Injected so
  * unit tests observe the calls without touching disk; production wires the
@@ -84,6 +101,12 @@ export interface NavigationRetentionSummary {
   prunedAt: number;
 }
 
+/** The newest observation-row ids per protected build key, kept out of eviction. */
+export interface ActiveObservationIds {
+  nodeIds: number[];
+  edgeIds: number[];
+}
+
 function emptySummary(prunedAt: number): NavigationRetentionSummary {
   return {
     screenshotsCleared: 0,
@@ -94,38 +117,46 @@ function emptySummary(prunedAt: number): NavigationRetentionSummary {
   };
 }
 
-/** A positive safe integer, or undefined for anything else (0, negative, NaN, float). */
-function sanitizePositiveInt(value: number | undefined): number | undefined {
+/** A positive safe integer within `[1, max]`, else undefined (0/neg/NaN/float/too-big). */
+function sanitizePositiveInt(
+  value: number | undefined,
+  max: number = Number.MAX_SAFE_INTEGER
+): number | undefined {
   if (value === undefined) {
     return undefined;
   }
-  return Number.isSafeInteger(value) && value > 0 ? value : undefined;
+  return Number.isSafeInteger(value) && value > 0 && value <= max ? value : undefined;
 }
 
 /**
  * Strict env read: the ENTIRE trimmed value must be a run of digits, so partial
  * parses that `Number.parseInt` would silently accept ("1e6" -> 1, "12abc" -> 12)
  * are rejected and fall back to the default rather than becoming a 1ms interval.
+ * The parsed value is then bounded by `max`.
  */
-function readPositiveIntEnv(name: string): number | undefined {
+function readPositiveIntEnv(name: string, max: number = Number.MAX_SAFE_INTEGER): number | undefined {
   const raw = process.env[name]?.trim();
   if (!raw || !/^\d+$/.test(raw)) {
     return undefined;
   }
-  return sanitizePositiveInt(Number.parseInt(raw, 10));
+  return sanitizePositiveInt(Number.parseInt(raw, 10), max);
 }
 
 /**
  * Resolve the retention config from explicit overrides, then env, then the
- * conservative defaults. Every source is validated the same way (positive safe
- * integer), so a stray `perAppMaxObservations: 0` or `NaN` override falls back to
- * the default instead of evicting everything / no-op'ing.
+ * conservative defaults. Every source is validated against its REAL ceiling — not
+ * just positivity — so a stray `perAppMaxObservations: 0`, a float, or an
+ * oversized chunk falls back / clamps rather than corrupting the pass.
  */
 export function resolveNavigationRetentionConfig(
   overrides: Partial<NavigationRetentionConfig> = {}
 ): NavigationRetentionConfig {
-  const resolve = (override: number | undefined, envName: string, def: number): number =>
-    sanitizePositiveInt(override) ?? readPositiveIntEnv(envName) ?? def;
+  const resolve = (
+    override: number | undefined,
+    envName: string,
+    def: number,
+    max: number = Number.MAX_SAFE_INTEGER
+  ): number => sanitizePositiveInt(override, max) ?? readPositiveIntEnv(envName, max) ?? def;
 
   return {
     screenshotTtlMs: resolve(
@@ -148,19 +179,28 @@ export function resolveNavigationRetentionConfig(
       "AUTOMOBILE_NAV_RETENTION_GLOBAL_MAX_OBSERVATIONS",
       DEFAULT_GLOBAL_MAX_OBSERVATIONS
     ),
-    evictionChunkSize: resolve(
-      overrides.evictionChunkSize,
-      "AUTOMOBILE_NAV_RETENTION_EVICTION_CHUNK_SIZE",
-      DEFAULT_EVICTION_CHUNK_SIZE
+    // Resolve as a positive integer, then clamp to the hard batch ceiling so any
+    // configured value keeps the batching effective.
+    evictionChunkSize: Math.min(
+      resolve(
+        overrides.evictionChunkSize,
+        "AUTOMOBILE_NAV_RETENTION_EVICTION_CHUNK_SIZE",
+        DEFAULT_EVICTION_CHUNK_SIZE
+      ),
+      MAX_EVICTION_CHUNK_SIZE
     ),
   };
 }
 
-/** Resolve the background-pass interval (ms) from override, env, or the default. */
+/**
+ * Resolve the background-pass interval (ms) from override, env, or the default,
+ * bounded by the signed-32-bit setInterval ceiling (a larger value would be
+ * clamped to 1ms by the runtime, so it is rejected and defaulted).
+ */
 export function resolveNavigationRetentionIntervalMs(override?: number): number {
   return (
-    sanitizePositiveInt(override)
-    ?? readPositiveIntEnv("AUTOMOBILE_NAV_RETENTION_INTERVAL_MS")
+    sanitizePositiveInt(override, MAX_INTERVAL_MS)
+    ?? readPositiveIntEnv("AUTOMOBILE_NAV_RETENTION_INTERVAL_MS", MAX_INTERVAL_MS)
     ?? DEFAULT_NAV_RETENTION_INTERVAL_MS
   );
 }
@@ -176,10 +216,9 @@ interface EvictionCandidate {
   lastSeenAt: number;
 }
 
-/** The newest observation-row ids per protected build key, kept out of eviction. */
-interface ActiveObservationIds {
-  nodeIds: number[];
-  edgeIds: number[];
+interface ObservationRow {
+  id: number;
+  lastSeenAt: number;
 }
 
 /**
@@ -248,6 +287,11 @@ export class NavigationRetention {
    * SHORT tier: clear `screenshot_path` on nodes last seen before the cutoff,
    * unless the node is still observed under the active (protected) build. Returns
    * the file paths whose pointers were cleared, for post-commit unlinking.
+   *
+   * Batched: node cardinality is NOT bounded by the observation caps, so a large
+   * stale set is cleared in chunks of `evictionChunkSize` — each UPDATE binds at
+   * most that many ids. Clearing the pointer removes rows from the next batch's
+   * predicate, so the loop terminates.
    */
   private async pruneScreenshots(
     trx: Kysely<Database>,
@@ -256,45 +300,58 @@ export class NavigationRetention {
     summary: NavigationRetentionSummary
   ): Promise<string[]> {
     const cutoff = now - this.config.screenshotTtlMs;
+    const chunk = this.config.evictionChunkSize;
+    const paths: string[] = [];
 
-    let query = trx
-      .selectFrom("navigation_nodes")
-      .select(["id", "screenshot_path"])
-      .where("screenshot_path", "is not", null)
-      .where("last_seen_at", "<", cutoff);
+    for (;;) {
+      let query = trx
+        .selectFrom("navigation_nodes")
+        .select(["id", "screenshot_path"])
+        .where("screenshot_path", "is not", null)
+        .where("last_seen_at", "<", cutoff);
 
-    if (protectedIds.length > 0) {
-      // Keep the screenshot if the node has any observation under a protected
-      // build key (i.e. it is part of the active context).
-      query = query.where("id", "not in", eb =>
-        eb
-          .selectFrom("navigation_node_observations")
-          .select("node_id")
-          .where("build_key_id", "in", protectedIds)
-      );
+      if (protectedIds.length > 0) {
+        // Keep the screenshot if the node has any observation under a protected
+        // build key (i.e. it is part of the active context).
+        query = query.where("id", "not in", eb =>
+          eb
+            .selectFrom("navigation_node_observations")
+            .select("node_id")
+            .where("build_key_id", "in", protectedIds)
+        );
+      }
+
+      const batch = await query.limit(chunk).execute();
+      if (batch.length === 0) {
+        break;
+      }
+
+      const ids = batch.map(row => row.id);
+      await trx
+        .updateTable("navigation_nodes")
+        .set({ screenshot_path: null })
+        .where("id", "in", ids)
+        .execute();
+
+      summary.screenshotsCleared += ids.length;
+      for (const row of batch) {
+        if (row.screenshot_path !== null) {
+          paths.push(row.screenshot_path);
+        }
+      }
+
+      if (batch.length < chunk) {
+        break;
+      }
     }
 
-    const stale = await query.execute();
-    if (stale.length === 0) {
-      return [];
-    }
-
-    const ids = stale.map(row => row.id);
-    await trx
-      .updateTable("navigation_nodes")
-      .set({ screenshot_path: null })
-      .where("id", "in", ids)
-      .execute();
-
-    summary.screenshotsCleared += ids.length;
-    return stale
-      .map(row => row.screenshot_path)
-      .filter((p): p is string => p !== null);
+    return paths;
   }
 
   /**
    * LONG tier: delete observation rows last seen before the cutoff, except those
-   * on a protected (active) build key.
+   * on a protected (active) build key. A single DELETE by predicate — it binds
+   * only the (per-app-bounded) protected id list, never one param per matched row.
    */
   private async pruneObservationsByTtl(
     trx: Kysely<Database>,
@@ -327,6 +384,10 @@ export class NavigationRetention {
    * the oldest observation rows by `last_seen_at`. The budgets count ALL of an
    * app's rows (so a single-build app is still bounded), but the newest row of
    * each protected build key is shielded so the active context is never evicted.
+   *
+   * Per-app scope is expressed as a join on `app_id` (binds one param, the app id)
+   * rather than an id list of the app's build keys, so it stays bounded no matter
+   * how many builds an app accumulates.
    */
   private async enforceCaps(
     trx: Kysely<Database>,
@@ -336,18 +397,12 @@ export class NavigationRetention {
   ): Promise<void> {
     const activeIds = await computeActiveObservationIds(trx, protectedIds);
 
-    const buildKeysByApp = new Map<string, number[]>();
-    for (const bk of buildKeys) {
-      const list = buildKeysByApp.get(bk.appId) ?? [];
-      list.push(bk.id);
-      buildKeysByApp.set(bk.appId, list);
-    }
-
-    for (const [, ids] of buildKeysByApp) {
-      const count = await countObservations(trx, ids);
+    const appIds = Array.from(new Set(buildKeys.map(bk => bk.appId)));
+    for (const appId of appIds) {
+      const count = await countObservations(trx, appId);
       const overflow = count - this.config.perAppMaxObservations;
       if (overflow > 0) {
-        await this.evictOldest(trx, ids, activeIds, overflow, summary);
+        await this.evictOldest(trx, appId, activeIds, overflow, summary);
       }
     }
 
@@ -359,10 +414,11 @@ export class NavigationRetention {
   }
 
   /**
-   * Evict `count` oldest observation rows in scope, in bounded batches so a single
-   * DELETE never binds more ids than {@link NavigationRetentionConfig.evictionChunkSize}.
-   * The loop terminates when the target is met or no evictable rows remain (the
-   * active rows are excluded, so a scope can be irreducible below its active set).
+   * Evict `count` oldest observation rows in scope (`appId === null` == global),
+   * in bounded batches so a single DELETE never binds more ids than
+   * `evictionChunkSize`. The loop terminates when the target is met or no
+   * evictable rows remain (active rows are excluded, so a scope can be irreducible
+   * below its active set).
    *
    * Perf note: each batch does an ordered scan of the observation tables. A
    * `(build_key_id, last_seen_at)` index would turn this into an index range scan;
@@ -370,7 +426,7 @@ export class NavigationRetention {
    */
   private async evictOldest(
     trx: Kysely<Database>,
-    scopeBuildKeyIds: number[] | null,
+    appId: string | null,
     activeIds: ActiveObservationIds,
     count: number,
     summary: NavigationRetentionSummary
@@ -378,7 +434,7 @@ export class NavigationRetention {
     let remaining = count;
     while (remaining > 0) {
       const batch = Math.min(remaining, this.config.evictionChunkSize);
-      const victims = await collectOldestEvictable(trx, scopeBuildKeyIds, activeIds, batch);
+      const victims = await collectOldestEvictable(trx, appId, activeIds, batch);
       if (victims.length === 0) {
         return;
       }
@@ -406,7 +462,9 @@ export class NavigationRetention {
   /**
    * Sweep build keys left with no observations (except protected ones). Runs
    * after observation deletes so the FK-safe order holds even with foreign_keys
-   * ON (deleting a still-referenced build key would cascade-wipe its rows).
+   * ON (deleting a still-referenced build key would cascade-wipe its rows). The
+   * "no observations" test is a correlated subquery (binds O(1)); only the
+   * per-app-bounded protected id list is bound directly.
    */
   private async pruneOrphanBuildKeys(
     trx: Kysely<Database>,
@@ -505,10 +563,14 @@ async function loadMaxSeenByBuildKey(db: Kysely<Database>): Promise<Map<number, 
 /**
  * For each protected build key, the observation-row ids whose `last_seen_at` is
  * that build key's maximum, per table — the "active" rows the size cap must never
- * evict (ties keep all rows at the max instant). Small: at most a few rows per
- * protected build key, and protected build keys number ~one per app.
+ * evict (ties keep all rows at the max instant).
+ *
+ * Relational form: a join against a `GROUP BY build_key_id` max subquery, so the
+ * only bound parameters are the (per-app-bounded) protected id list — NO per-row
+ * `(build_key_id=? AND last_seen_at=?) OR …` chain, which would blow the
+ * expression-tree depth at high app counts.
  */
-async function computeActiveObservationIds(
+export async function computeActiveObservationIds(
   trx: Kysely<Database>,
   protectedIds: number[]
 ): Promise<ActiveObservationIds> {
@@ -516,128 +578,99 @@ async function computeActiveObservationIds(
     return { nodeIds: [], edgeIds: [] };
   }
 
-  const nodeMax = await trx
-    .selectFrom("navigation_node_observations")
-    .select(eb => ["build_key_id", eb.fn.max("last_seen_at").as("m")])
-    .where("build_key_id", "in", protectedIds)
-    .groupBy("build_key_id")
+  const nodeRows = await trx
+    .selectFrom("navigation_node_observations as o")
+    .innerJoin(
+      eb =>
+        eb
+          .selectFrom("navigation_node_observations")
+          .select(sb => ["build_key_id", sb.fn.max("last_seen_at").as("m")])
+          .where("build_key_id", "in", protectedIds)
+          .groupBy("build_key_id")
+          .as("mx"),
+      join =>
+        join
+          .onRef("mx.build_key_id", "=", "o.build_key_id")
+          .onRef("mx.m", "=", "o.last_seen_at")
+    )
+    .select("o.id as id")
     .execute();
-  const nodeIds = nodeMax.length === 0
-    ? []
-    : (await trx
-        .selectFrom("navigation_node_observations")
-        .select("id")
-        .where(eb =>
-          eb.or(
-            nodeMax.map(r =>
-              eb.and([
-                eb("build_key_id", "=", r.build_key_id),
-                eb("last_seen_at", "=", Number(r.m)),
-              ])
-            )
-          )
-        )
-        .execute()).map(r => r.id);
 
-  const edgeMax = await trx
-    .selectFrom("navigation_edge_observations")
-    .select(eb => ["build_key_id", eb.fn.max("last_seen_at").as("m")])
-    .where("build_key_id", "in", protectedIds)
-    .groupBy("build_key_id")
+  const edgeRows = await trx
+    .selectFrom("navigation_edge_observations as o")
+    .innerJoin(
+      eb =>
+        eb
+          .selectFrom("navigation_edge_observations")
+          .select(sb => ["build_key_id", sb.fn.max("last_seen_at").as("m")])
+          .where("build_key_id", "in", protectedIds)
+          .groupBy("build_key_id")
+          .as("mx"),
+      join =>
+        join
+          .onRef("mx.build_key_id", "=", "o.build_key_id")
+          .onRef("mx.m", "=", "o.last_seen_at")
+    )
+    .select("o.id as id")
     .execute();
-  const edgeIds = edgeMax.length === 0
-    ? []
-    : (await trx
-        .selectFrom("navigation_edge_observations")
-        .select("id")
-        .where(eb =>
-          eb.or(
-            edgeMax.map(r =>
-              eb.and([
-                eb("build_key_id", "=", r.build_key_id),
-                eb("last_seen_at", "=", Number(r.m)),
-              ])
-            )
-          )
-        )
-        .execute()).map(r => r.id);
 
-  return { nodeIds, edgeIds };
+  return { nodeIds: nodeRows.map(r => r.id), edgeIds: edgeRows.map(r => r.id) };
 }
 
 /**
- * Count observation rows (node + edge). `scopeBuildKeyIds === null` counts every
- * row (global); otherwise only rows whose build key is in the list (one app).
+ * Count observation rows (node + edge). `appId === null` counts every row
+ * (global); otherwise it joins on `app_id` (one bound param) rather than an id
+ * list of the app's build keys.
  */
 async function countObservations(
   trx: Kysely<Database>,
-  scopeBuildKeyIds: number[] | null
+  appId: string | null
 ): Promise<number> {
-  if (scopeBuildKeyIds !== null && scopeBuildKeyIds.length === 0) {
-    return 0;
+  if (appId === null) {
+    const nodeRow = await trx
+      .selectFrom("navigation_node_observations")
+      .select(eb => eb.fn.countAll<number>().as("c"))
+      .executeTakeFirst();
+    const edgeRow = await trx
+      .selectFrom("navigation_edge_observations")
+      .select(eb => eb.fn.countAll<number>().as("c"))
+      .executeTakeFirst();
+    return Number(nodeRow?.c ?? 0) + Number(edgeRow?.c ?? 0);
   }
 
-  let nodeQuery = trx
-    .selectFrom("navigation_node_observations")
-    .select(eb => eb.fn.countAll<number>().as("c"));
-  let edgeQuery = trx
-    .selectFrom("navigation_edge_observations")
-    .select(eb => eb.fn.countAll<number>().as("c"));
-  if (scopeBuildKeyIds !== null) {
-    nodeQuery = nodeQuery.where("build_key_id", "in", scopeBuildKeyIds);
-    edgeQuery = edgeQuery.where("build_key_id", "in", scopeBuildKeyIds);
-  }
-
-  const nodeRow = await nodeQuery.executeTakeFirst();
-  const edgeRow = await edgeQuery.executeTakeFirst();
+  const nodeRow = await trx
+    .selectFrom("navigation_node_observations as o")
+    .innerJoin("navigation_build_keys as bk", "bk.id", "o.build_key_id")
+    .select(eb => eb.fn.countAll<number>().as("c"))
+    .where("bk.app_id", "=", appId)
+    .executeTakeFirst();
+  const edgeRow = await trx
+    .selectFrom("navigation_edge_observations as o")
+    .innerJoin("navigation_build_keys as bk", "bk.id", "o.build_key_id")
+    .select(eb => eb.fn.countAll<number>().as("c"))
+    .where("bk.app_id", "=", appId)
+    .executeTakeFirst();
   return Number(nodeRow?.c ?? 0) + Number(edgeRow?.c ?? 0);
 }
 
 /**
  * Collect the `limit` oldest evictable observation rows (by last_seen_at, then
- * id), optionally scoped to one app's build keys, excluding the active rows.
- * Fetches at most `limit` rows per table then merges, so it never loads the whole
- * table — only the batch being evicted.
+ * id), optionally scoped to one app (via an `app_id` join), excluding the active
+ * rows. Fetches at most `limit` rows per table then merges, so it never loads the
+ * whole table — only the batch being evicted.
  */
 async function collectOldestEvictable(
   trx: Kysely<Database>,
-  scopeBuildKeyIds: number[] | null,
+  appId: string | null,
   activeIds: ActiveObservationIds,
   limit: number
 ): Promise<EvictionCandidate[]> {
-  let nodeQuery = trx
-    .selectFrom("navigation_node_observations")
-    .select(["id", "last_seen_at"]);
-  if (scopeBuildKeyIds !== null) {
-    nodeQuery = nodeQuery.where("build_key_id", "in", scopeBuildKeyIds);
-  }
-  if (activeIds.nodeIds.length > 0) {
-    nodeQuery = nodeQuery.where("id", "not in", activeIds.nodeIds);
-  }
-  const nodeRows = await nodeQuery
-    .orderBy("last_seen_at", "asc")
-    .orderBy("id", "asc")
-    .limit(limit)
-    .execute();
-
-  let edgeQuery = trx
-    .selectFrom("navigation_edge_observations")
-    .select(["id", "last_seen_at"]);
-  if (scopeBuildKeyIds !== null) {
-    edgeQuery = edgeQuery.where("build_key_id", "in", scopeBuildKeyIds);
-  }
-  if (activeIds.edgeIds.length > 0) {
-    edgeQuery = edgeQuery.where("id", "not in", activeIds.edgeIds);
-  }
-  const edgeRows = await edgeQuery
-    .orderBy("last_seen_at", "asc")
-    .orderBy("id", "asc")
-    .limit(limit)
-    .execute();
+  const nodeRows = await oldestNodeObservations(trx, appId, activeIds.nodeIds, limit);
+  const edgeRows = await oldestEdgeObservations(trx, appId, activeIds.edgeIds, limit);
 
   const candidates: EvictionCandidate[] = [
-    ...nodeRows.map(row => ({ isNode: true, id: row.id, lastSeenAt: row.last_seen_at })),
-    ...edgeRows.map(row => ({ isNode: false, id: row.id, lastSeenAt: row.last_seen_at })),
+    ...nodeRows.map(row => ({ isNode: true, id: row.id, lastSeenAt: row.lastSeenAt })),
+    ...edgeRows.map(row => ({ isNode: false, id: row.id, lastSeenAt: row.lastSeenAt })),
   ];
   // Oldest first; break ties by table (nodes before edges) then id for determinism.
   candidates.sort(
@@ -647,4 +680,78 @@ async function collectOldestEvictable(
       || a.id - b.id
   );
   return candidates.slice(0, limit);
+}
+
+async function oldestNodeObservations(
+  trx: Kysely<Database>,
+  appId: string | null,
+  excludeIds: number[],
+  limit: number
+): Promise<ObservationRow[]> {
+  if (appId === null) {
+    let query = trx
+      .selectFrom("navigation_node_observations")
+      .select(["id", "last_seen_at"]);
+    if (excludeIds.length > 0) {
+      query = query.where("id", "not in", excludeIds);
+    }
+    const rows = await query
+      .orderBy("last_seen_at", "asc")
+      .orderBy("id", "asc")
+      .limit(limit)
+      .execute();
+    return rows.map(r => ({ id: r.id, lastSeenAt: r.last_seen_at }));
+  }
+
+  let query = trx
+    .selectFrom("navigation_node_observations as o")
+    .innerJoin("navigation_build_keys as bk", "bk.id", "o.build_key_id")
+    .select(["o.id as id", "o.last_seen_at as last_seen_at"])
+    .where("bk.app_id", "=", appId);
+  if (excludeIds.length > 0) {
+    query = query.where("o.id", "not in", excludeIds);
+  }
+  const rows = await query
+    .orderBy("o.last_seen_at", "asc")
+    .orderBy("o.id", "asc")
+    .limit(limit)
+    .execute();
+  return rows.map(r => ({ id: r.id, lastSeenAt: r.last_seen_at }));
+}
+
+async function oldestEdgeObservations(
+  trx: Kysely<Database>,
+  appId: string | null,
+  excludeIds: number[],
+  limit: number
+): Promise<ObservationRow[]> {
+  if (appId === null) {
+    let query = trx
+      .selectFrom("navigation_edge_observations")
+      .select(["id", "last_seen_at"]);
+    if (excludeIds.length > 0) {
+      query = query.where("id", "not in", excludeIds);
+    }
+    const rows = await query
+      .orderBy("last_seen_at", "asc")
+      .orderBy("id", "asc")
+      .limit(limit)
+      .execute();
+    return rows.map(r => ({ id: r.id, lastSeenAt: r.last_seen_at }));
+  }
+
+  let query = trx
+    .selectFrom("navigation_edge_observations as o")
+    .innerJoin("navigation_build_keys as bk", "bk.id", "o.build_key_id")
+    .select(["o.id as id", "o.last_seen_at as last_seen_at"])
+    .where("bk.app_id", "=", appId);
+  if (excludeIds.length > 0) {
+    query = query.where("o.id", "not in", excludeIds);
+  }
+  const rows = await query
+    .orderBy("o.last_seen_at", "asc")
+    .orderBy("o.id", "asc")
+    .limit(limit)
+    .execute();
+  return rows.map(r => ({ id: r.id, lastSeenAt: r.last_seen_at }));
 }

--- a/src/db/navigationRetention.ts
+++ b/src/db/navigationRetention.ts
@@ -13,17 +13,22 @@
 //      unbounded surface — one row per (build, device, session) per node/edge —
 //      so they are pruned by age, and build keys orphaned by that prune are
 //      swept. Nodes/edges themselves are bounded (one per screen/transition) and
-//      durable, so they are intentionally NOT age-deleted here.
+//      durable, so they are intentionally NOT age-deleted here. The TTL tier
+//      spares the active build key entirely (never age-delete what is current).
 //   3. Global LRU size cap — a backstop enforcing a per-app AND a global budget
-//      on the (evictable) observation rows, evicting oldest by `last_seen_at`.
+//      on the observation rows, evicting oldest by `last_seen_at`. Unlike the TTL
+//      tier, the cap counts the active build key's rows too (otherwise a
+//      continuously-used single-build app would never be bounded), but it never
+//      evicts the *active* rows themselves — see `computeActiveObservationIds`.
 //
-// Active-data safety (AC3): the most-recently-seen build key per app is treated
-// as the active context and NEVER pruned by any tier. Because in-flight writes
-// land on the current build key (which has the newest `last_seen_at`), this
-// protects whatever is being observed right now without a separate liveness
-// signal. The whole pass runs in one transaction (atomic, no torn graph);
-// observations are deleted before their orphaned build keys (FK-safe order), and
-// file unlinks run AFTER commit as side effects (never inside the txn).
+// Active-data safety (AC3): the most-recently-seen build key per app is the
+// active context. The TTL tier and the orphan-build-key sweep never touch it, and
+// the size cap never evicts its newest observation(s). Because in-flight writes
+// land on the current build key (newest `last_seen_at`), this protects whatever is
+// being observed right now without a separate liveness signal. The whole pass runs
+// in one transaction (atomic, no torn graph); observations are deleted before
+// their orphaned build keys (FK-safe order), and file unlinks run AFTER commit as
+// side effects (never inside the txn).
 
 import type { Kysely } from "kysely";
 import type { Database } from "./types";
@@ -35,10 +40,17 @@ export interface NavigationRetentionConfig {
   screenshotTtlMs: number;
   /** LONG tier: max age of an observation row before it is pruned. */
   structureTtlMs: number;
-  /** Backstop: max evictable observation rows kept per app. */
+  /** Backstop: max observation rows kept per app. */
   perAppMaxObservations: number;
-  /** Backstop: max evictable observation rows kept across all apps. */
+  /** Backstop: max observation rows kept across all apps. */
   globalMaxObservations: number;
+  /**
+   * Max victim ids bound in one DELETE. Kept well under bun:sqlite's
+   * `MAX_VARIABLE_NUMBER` (250_000) so a runaway eviction can never overflow the
+   * bind limit and roll back the whole retention transaction. Overridable mainly
+   * so tests can exercise the batching loop without a quarter-million rows.
+   */
+  evictionChunkSize: number;
 }
 
 const DAY_MS = 24 * 60 * 60 * 1000;
@@ -50,6 +62,7 @@ export const DEFAULT_SCREENSHOT_TTL_MS = 7 * DAY_MS; // 7 days
 export const DEFAULT_STRUCTURE_TTL_MS = 90 * DAY_MS; // ~3 months
 export const DEFAULT_PER_APP_MAX_OBSERVATIONS = 50_000;
 export const DEFAULT_GLOBAL_MAX_OBSERVATIONS = 500_000;
+export const DEFAULT_EVICTION_CHUNK_SIZE = 5_000;
 
 /** Default cadence of the background pass: every 6 hours. */
 export const DEFAULT_NAV_RETENTION_INTERVAL_MS = 6 * 60 * 60 * 1000;
@@ -81,46 +94,72 @@ function emptySummary(prunedAt: number): NavigationRetentionSummary {
   };
 }
 
-function readPositiveIntEnv(name: string): number | undefined {
-  const raw = process.env[name];
-  if (!raw) {
+/** A positive safe integer, or undefined for anything else (0, negative, NaN, float). */
+function sanitizePositiveInt(value: number | undefined): number | undefined {
+  if (value === undefined) {
     return undefined;
   }
-  const parsed = Number.parseInt(raw, 10);
-  return Number.isFinite(parsed) && parsed > 0 ? parsed : undefined;
+  return Number.isSafeInteger(value) && value > 0 ? value : undefined;
+}
+
+/**
+ * Strict env read: the ENTIRE trimmed value must be a run of digits, so partial
+ * parses that `Number.parseInt` would silently accept ("1e6" -> 1, "12abc" -> 12)
+ * are rejected and fall back to the default rather than becoming a 1ms interval.
+ */
+function readPositiveIntEnv(name: string): number | undefined {
+  const raw = process.env[name]?.trim();
+  if (!raw || !/^\d+$/.test(raw)) {
+    return undefined;
+  }
+  return sanitizePositiveInt(Number.parseInt(raw, 10));
 }
 
 /**
  * Resolve the retention config from explicit overrides, then env, then the
- * conservative defaults above. Overrides win so tests stay hermetic.
+ * conservative defaults. Every source is validated the same way (positive safe
+ * integer), so a stray `perAppMaxObservations: 0` or `NaN` override falls back to
+ * the default instead of evicting everything / no-op'ing.
  */
 export function resolveNavigationRetentionConfig(
   overrides: Partial<NavigationRetentionConfig> = {}
 ): NavigationRetentionConfig {
+  const resolve = (override: number | undefined, envName: string, def: number): number =>
+    sanitizePositiveInt(override) ?? readPositiveIntEnv(envName) ?? def;
+
   return {
-    screenshotTtlMs:
-      overrides.screenshotTtlMs
-      ?? readPositiveIntEnv("AUTOMOBILE_NAV_RETENTION_SCREENSHOT_TTL_MS")
-      ?? DEFAULT_SCREENSHOT_TTL_MS,
-    structureTtlMs:
-      overrides.structureTtlMs
-      ?? readPositiveIntEnv("AUTOMOBILE_NAV_RETENTION_STRUCTURE_TTL_MS")
-      ?? DEFAULT_STRUCTURE_TTL_MS,
-    perAppMaxObservations:
-      overrides.perAppMaxObservations
-      ?? readPositiveIntEnv("AUTOMOBILE_NAV_RETENTION_PER_APP_MAX_OBSERVATIONS")
-      ?? DEFAULT_PER_APP_MAX_OBSERVATIONS,
-    globalMaxObservations:
-      overrides.globalMaxObservations
-      ?? readPositiveIntEnv("AUTOMOBILE_NAV_RETENTION_GLOBAL_MAX_OBSERVATIONS")
-      ?? DEFAULT_GLOBAL_MAX_OBSERVATIONS,
+    screenshotTtlMs: resolve(
+      overrides.screenshotTtlMs,
+      "AUTOMOBILE_NAV_RETENTION_SCREENSHOT_TTL_MS",
+      DEFAULT_SCREENSHOT_TTL_MS
+    ),
+    structureTtlMs: resolve(
+      overrides.structureTtlMs,
+      "AUTOMOBILE_NAV_RETENTION_STRUCTURE_TTL_MS",
+      DEFAULT_STRUCTURE_TTL_MS
+    ),
+    perAppMaxObservations: resolve(
+      overrides.perAppMaxObservations,
+      "AUTOMOBILE_NAV_RETENTION_PER_APP_MAX_OBSERVATIONS",
+      DEFAULT_PER_APP_MAX_OBSERVATIONS
+    ),
+    globalMaxObservations: resolve(
+      overrides.globalMaxObservations,
+      "AUTOMOBILE_NAV_RETENTION_GLOBAL_MAX_OBSERVATIONS",
+      DEFAULT_GLOBAL_MAX_OBSERVATIONS
+    ),
+    evictionChunkSize: resolve(
+      overrides.evictionChunkSize,
+      "AUTOMOBILE_NAV_RETENTION_EVICTION_CHUNK_SIZE",
+      DEFAULT_EVICTION_CHUNK_SIZE
+    ),
   };
 }
 
-/** Resolve the background-pass interval (ms) from env or the default. */
+/** Resolve the background-pass interval (ms) from override, env, or the default. */
 export function resolveNavigationRetentionIntervalMs(override?: number): number {
   return (
-    override
+    sanitizePositiveInt(override)
     ?? readPositiveIntEnv("AUTOMOBILE_NAV_RETENTION_INTERVAL_MS")
     ?? DEFAULT_NAV_RETENTION_INTERVAL_MS
   );
@@ -135,6 +174,12 @@ interface EvictionCandidate {
   isNode: boolean;
   id: number;
   lastSeenAt: number;
+}
+
+/** The newest observation-row ids per protected build key, kept out of eviction. */
+interface ActiveObservationIds {
+  nodeIds: number[];
+  edgeIds: number[];
 }
 
 /**
@@ -158,10 +203,6 @@ export class NavigationRetention {
     this.config = resolveNavigationRetentionConfig(config);
   }
 
-  getConfig(): NavigationRetentionConfig {
-    return this.config;
-  }
-
   /**
    * Run every tier once against `now` (ms). Returns a per-pass summary. All DB
    * work is a single transaction; screenshot files are unlinked AFTER commit so
@@ -177,11 +218,10 @@ export class NavigationRetention {
       // newest between the read and the deletes.
       const buildKeys = await loadBuildKeys(trx);
       const protectedIds = await computeProtectedBuildKeyIds(trx, buildKeys);
-      const protectedSet = new Set(protectedIds);
 
       filesToRemove = await this.pruneScreenshots(trx, now, protectedIds, summary);
       await this.pruneObservationsByTtl(trx, now, protectedIds, summary);
-      await this.enforceCaps(trx, buildKeys, protectedSet, summary);
+      await this.enforceCaps(trx, buildKeys, protectedIds, summary);
       await this.pruneOrphanBuildKeys(trx, protectedIds, summary);
     });
 
@@ -284,69 +324,82 @@ export class NavigationRetention {
 
   /**
    * Backstop: enforce the per-app budget first, then the global budget, evicting
-   * the oldest evictable observation rows by `last_seen_at`.
+   * the oldest observation rows by `last_seen_at`. The budgets count ALL of an
+   * app's rows (so a single-build app is still bounded), but the newest row of
+   * each protected build key is shielded so the active context is never evicted.
    */
   private async enforceCaps(
     trx: Kysely<Database>,
     buildKeys: BuildKeyRow[],
-    protectedSet: Set<number>,
+    protectedIds: number[],
     summary: NavigationRetentionSummary
   ): Promise<void> {
-    // Per-app: each app's evictable build keys (its own keys minus the protected
-    // one). Observations are scoped by `build_key_id IN (...)`, so no join needed.
-    const evictableByApp = new Map<string, number[]>();
+    const activeIds = await computeActiveObservationIds(trx, protectedIds);
+
+    const buildKeysByApp = new Map<string, number[]>();
     for (const bk of buildKeys) {
-      if (protectedSet.has(bk.id)) {
-        continue;
-      }
-      const list = evictableByApp.get(bk.appId) ?? [];
+      const list = buildKeysByApp.get(bk.appId) ?? [];
       list.push(bk.id);
-      evictableByApp.set(bk.appId, list);
+      buildKeysByApp.set(bk.appId, list);
     }
 
-    for (const [, buildKeyIds] of evictableByApp) {
-      const count = await countObservations(trx, buildKeyIds);
+    for (const [, ids] of buildKeysByApp) {
+      const count = await countObservations(trx, ids);
       const overflow = count - this.config.perAppMaxObservations;
       if (overflow > 0) {
-        await this.evictOldest(trx, buildKeyIds, overflow, summary);
+        await this.evictOldest(trx, ids, activeIds, overflow, summary);
       }
     }
 
-    // Global: every evictable build key across all apps.
-    const globalEvictable = buildKeys.filter(bk => !protectedSet.has(bk.id)).map(bk => bk.id);
-    const globalCount = await countObservations(trx, globalEvictable);
+    const globalCount = await countObservations(trx, null);
     const globalOverflow = globalCount - this.config.globalMaxObservations;
     if (globalOverflow > 0) {
-      await this.evictOldest(trx, globalEvictable, globalOverflow, summary);
+      await this.evictOldest(trx, null, activeIds, globalOverflow, summary);
     }
   }
 
+  /**
+   * Evict `count` oldest observation rows in scope, in bounded batches so a single
+   * DELETE never binds more ids than {@link NavigationRetentionConfig.evictionChunkSize}.
+   * The loop terminates when the target is met or no evictable rows remain (the
+   * active rows are excluded, so a scope can be irreducible below its active set).
+   *
+   * Perf note: each batch does an ordered scan of the observation tables. A
+   * `(build_key_id, last_seen_at)` index would turn this into an index range scan;
+   * deferred as a small follow-up migration (issue #5309).
+   */
   private async evictOldest(
     trx: Kysely<Database>,
-    buildKeyIds: number[],
+    scopeBuildKeyIds: number[] | null,
+    activeIds: ActiveObservationIds,
     count: number,
     summary: NavigationRetentionSummary
   ): Promise<void> {
-    if (buildKeyIds.length === 0 || count <= 0) {
-      return;
-    }
-    const victims = await collectOldestEvictable(trx, buildKeyIds, count);
+    let remaining = count;
+    while (remaining > 0) {
+      const batch = Math.min(remaining, this.config.evictionChunkSize);
+      const victims = await collectOldestEvictable(trx, scopeBuildKeyIds, activeIds, batch);
+      if (victims.length === 0) {
+        return;
+      }
 
-    const nodeIds = victims.filter(v => v.isNode).map(v => v.id);
-    const edgeIds = victims.filter(v => !v.isNode).map(v => v.id);
-    if (nodeIds.length > 0) {
-      const deleted = await trx
-        .deleteFrom("navigation_node_observations")
-        .where("id", "in", nodeIds)
-        .executeTakeFirst();
-      summary.nodeObservationsDeleted += Number(deleted.numDeletedRows ?? 0);
-    }
-    if (edgeIds.length > 0) {
-      const deleted = await trx
-        .deleteFrom("navigation_edge_observations")
-        .where("id", "in", edgeIds)
-        .executeTakeFirst();
-      summary.edgeObservationsDeleted += Number(deleted.numDeletedRows ?? 0);
+      const nodeIds = victims.filter(v => v.isNode).map(v => v.id);
+      const edgeIds = victims.filter(v => !v.isNode).map(v => v.id);
+      if (nodeIds.length > 0) {
+        const deleted = await trx
+          .deleteFrom("navigation_node_observations")
+          .where("id", "in", nodeIds)
+          .executeTakeFirst();
+        summary.nodeObservationsDeleted += Number(deleted.numDeletedRows ?? 0);
+      }
+      if (edgeIds.length > 0) {
+        const deleted = await trx
+          .deleteFrom("navigation_edge_observations")
+          .where("id", "in", edgeIds)
+          .executeTakeFirst();
+        summary.edgeObservationsDeleted += Number(deleted.numDeletedRows ?? 0);
+      }
+      remaining -= victims.length;
     }
   }
 
@@ -390,7 +443,7 @@ async function loadBuildKeys(db: Kysely<Database>): Promise<BuildKeyRow[]> {
 /**
  * The active/most-recent build key per app: the one whose observations have the
  * greatest `last_seen_at` (ties and no-observation apps fall back to the newest
- * build-key id). These are never pruned.
+ * build-key id). These are never age-pruned or orphan-swept.
  */
 export async function computeProtectedBuildKeyIds(
   db: Kysely<Database>,
@@ -449,50 +502,134 @@ async function loadMaxSeenByBuildKey(db: Kysely<Database>): Promise<Map<number, 
   return maxSeen;
 }
 
-/** Count observation rows (node + edge) whose build key is in `buildKeyIds`. */
+/**
+ * For each protected build key, the observation-row ids whose `last_seen_at` is
+ * that build key's maximum, per table — the "active" rows the size cap must never
+ * evict (ties keep all rows at the max instant). Small: at most a few rows per
+ * protected build key, and protected build keys number ~one per app.
+ */
+async function computeActiveObservationIds(
+  trx: Kysely<Database>,
+  protectedIds: number[]
+): Promise<ActiveObservationIds> {
+  if (protectedIds.length === 0) {
+    return { nodeIds: [], edgeIds: [] };
+  }
+
+  const nodeMax = await trx
+    .selectFrom("navigation_node_observations")
+    .select(eb => ["build_key_id", eb.fn.max("last_seen_at").as("m")])
+    .where("build_key_id", "in", protectedIds)
+    .groupBy("build_key_id")
+    .execute();
+  const nodeIds = nodeMax.length === 0
+    ? []
+    : (await trx
+        .selectFrom("navigation_node_observations")
+        .select("id")
+        .where(eb =>
+          eb.or(
+            nodeMax.map(r =>
+              eb.and([
+                eb("build_key_id", "=", r.build_key_id),
+                eb("last_seen_at", "=", Number(r.m)),
+              ])
+            )
+          )
+        )
+        .execute()).map(r => r.id);
+
+  const edgeMax = await trx
+    .selectFrom("navigation_edge_observations")
+    .select(eb => ["build_key_id", eb.fn.max("last_seen_at").as("m")])
+    .where("build_key_id", "in", protectedIds)
+    .groupBy("build_key_id")
+    .execute();
+  const edgeIds = edgeMax.length === 0
+    ? []
+    : (await trx
+        .selectFrom("navigation_edge_observations")
+        .select("id")
+        .where(eb =>
+          eb.or(
+            edgeMax.map(r =>
+              eb.and([
+                eb("build_key_id", "=", r.build_key_id),
+                eb("last_seen_at", "=", Number(r.m)),
+              ])
+            )
+          )
+        )
+        .execute()).map(r => r.id);
+
+  return { nodeIds, edgeIds };
+}
+
+/**
+ * Count observation rows (node + edge). `scopeBuildKeyIds === null` counts every
+ * row (global); otherwise only rows whose build key is in the list (one app).
+ */
 async function countObservations(
   trx: Kysely<Database>,
-  buildKeyIds: number[]
+  scopeBuildKeyIds: number[] | null
 ): Promise<number> {
-  if (buildKeyIds.length === 0) {
+  if (scopeBuildKeyIds !== null && scopeBuildKeyIds.length === 0) {
     return 0;
   }
-  const nodeRow = await trx
+
+  let nodeQuery = trx
     .selectFrom("navigation_node_observations")
-    .select(eb => eb.fn.countAll<number>().as("c"))
-    .where("build_key_id", "in", buildKeyIds)
-    .executeTakeFirst();
-  const edgeRow = await trx
+    .select(eb => eb.fn.countAll<number>().as("c"));
+  let edgeQuery = trx
     .selectFrom("navigation_edge_observations")
-    .select(eb => eb.fn.countAll<number>().as("c"))
-    .where("build_key_id", "in", buildKeyIds)
-    .executeTakeFirst();
+    .select(eb => eb.fn.countAll<number>().as("c"));
+  if (scopeBuildKeyIds !== null) {
+    nodeQuery = nodeQuery.where("build_key_id", "in", scopeBuildKeyIds);
+    edgeQuery = edgeQuery.where("build_key_id", "in", scopeBuildKeyIds);
+  }
+
+  const nodeRow = await nodeQuery.executeTakeFirst();
+  const edgeRow = await edgeQuery.executeTakeFirst();
   return Number(nodeRow?.c ?? 0) + Number(edgeRow?.c ?? 0);
 }
 
 /**
  * Collect the `limit` oldest evictable observation rows (by last_seen_at, then
- * id) whose build key is in `buildKeyIds`. Fetches at most `limit` rows per table
- * then merges, so it never loads the whole table — only the overflow being
- * evicted.
+ * id), optionally scoped to one app's build keys, excluding the active rows.
+ * Fetches at most `limit` rows per table then merges, so it never loads the whole
+ * table — only the batch being evicted.
  */
 async function collectOldestEvictable(
   trx: Kysely<Database>,
-  buildKeyIds: number[],
+  scopeBuildKeyIds: number[] | null,
+  activeIds: ActiveObservationIds,
   limit: number
 ): Promise<EvictionCandidate[]> {
-  const nodeRows = await trx
+  let nodeQuery = trx
     .selectFrom("navigation_node_observations")
-    .select(["id", "last_seen_at"])
-    .where("build_key_id", "in", buildKeyIds)
+    .select(["id", "last_seen_at"]);
+  if (scopeBuildKeyIds !== null) {
+    nodeQuery = nodeQuery.where("build_key_id", "in", scopeBuildKeyIds);
+  }
+  if (activeIds.nodeIds.length > 0) {
+    nodeQuery = nodeQuery.where("id", "not in", activeIds.nodeIds);
+  }
+  const nodeRows = await nodeQuery
     .orderBy("last_seen_at", "asc")
     .orderBy("id", "asc")
     .limit(limit)
     .execute();
-  const edgeRows = await trx
+
+  let edgeQuery = trx
     .selectFrom("navigation_edge_observations")
-    .select(["id", "last_seen_at"])
-    .where("build_key_id", "in", buildKeyIds)
+    .select(["id", "last_seen_at"]);
+  if (scopeBuildKeyIds !== null) {
+    edgeQuery = edgeQuery.where("build_key_id", "in", scopeBuildKeyIds);
+  }
+  if (activeIds.edgeIds.length > 0) {
+    edgeQuery = edgeQuery.where("id", "not in", activeIds.edgeIds);
+  }
+  const edgeRows = await edgeQuery
     .orderBy("last_seen_at", "asc")
     .orderBy("id", "asc")
     .limit(limit)

--- a/src/db/navigationRetention.ts
+++ b/src/db/navigationRetention.ts
@@ -1,0 +1,513 @@
+// nav (app,build) Phase 3: tiered TTL + global LRU size-cap retention (#4986).
+//
+// Bounds the accumulated cross-build/device/session navigation data written by
+// Phases 1/2. Two tiers, plus a size-cap backstop, all keyed on the same
+// `last_seen_at` recency signal that drives Phase 2's provenance fade:
+//
+//   1. SHORT TTL — heavy transient assets. The only heavy asset the nav DB
+//      references is a node's `screenshot_path`. Stale screenshots have their
+//      pointer cleared (and the file best-effort unlinked); the light node row
+//      itself survives under the long tier.
+//   2. LONG TTL — nav-graph structure + provenance. The per-observation rows
+//      (navigation_node_observations / navigation_edge_observations) are the
+//      unbounded surface — one row per (build, device, session) per node/edge —
+//      so they are pruned by age, and build keys orphaned by that prune are
+//      swept. Nodes/edges themselves are bounded (one per screen/transition) and
+//      durable, so they are intentionally NOT age-deleted here.
+//   3. Global LRU size cap — a backstop enforcing a per-app AND a global budget
+//      on the (evictable) observation rows, evicting oldest by `last_seen_at`.
+//
+// Active-data safety (AC3): the most-recently-seen build key per app is treated
+// as the active context and NEVER pruned by any tier. Because in-flight writes
+// land on the current build key (which has the newest `last_seen_at`), this
+// protects whatever is being observed right now without a separate liveness
+// signal. The whole pass runs in one transaction (atomic, no torn graph);
+// observations are deleted before their orphaned build keys (FK-safe order), and
+// file unlinks run AFTER commit as side effects (never inside the txn).
+
+import type { Kysely } from "kysely";
+import type { Database } from "./types";
+import { logger as defaultLogger, type Logger } from "../utils/logger";
+
+/** Tunable retention thresholds. All durations are milliseconds. */
+export interface NavigationRetentionConfig {
+  /** SHORT tier: max age of a node screenshot before its pointer is cleared. */
+  screenshotTtlMs: number;
+  /** LONG tier: max age of an observation row before it is pruned. */
+  structureTtlMs: number;
+  /** Backstop: max evictable observation rows kept per app. */
+  perAppMaxObservations: number;
+  /** Backstop: max evictable observation rows kept across all apps. */
+  globalMaxObservations: number;
+}
+
+const DAY_MS = 24 * 60 * 60 * 1000;
+
+// Conservative defaults (hand-off merge — the maintainer owns the final policy):
+// nothing surprising should be deleted, so screenshots live a week and structure
+// three months, with generous size caps that only trip on genuine runaway growth.
+export const DEFAULT_SCREENSHOT_TTL_MS = 7 * DAY_MS; // 7 days
+export const DEFAULT_STRUCTURE_TTL_MS = 90 * DAY_MS; // ~3 months
+export const DEFAULT_PER_APP_MAX_OBSERVATIONS = 50_000;
+export const DEFAULT_GLOBAL_MAX_OBSERVATIONS = 500_000;
+
+/** Default cadence of the background pass: every 6 hours. */
+export const DEFAULT_NAV_RETENTION_INTERVAL_MS = 6 * 60 * 60 * 1000;
+
+/**
+ * Deletes a screenshot file previously referenced by a pruned node. Injected so
+ * unit tests observe the calls without touching disk; production wires the
+ * canonical filesystem unlink.
+ */
+export type ScreenshotFileRemover = (filePath: string) => Promise<void>;
+
+/** Outcome of a single prune pass, surfaced for logging / a storage indicator. */
+export interface NavigationRetentionSummary {
+  screenshotsCleared: number;
+  nodeObservationsDeleted: number;
+  edgeObservationsDeleted: number;
+  buildKeysDeleted: number;
+  /** Clock time (ms) the pass ran at. */
+  prunedAt: number;
+}
+
+function emptySummary(prunedAt: number): NavigationRetentionSummary {
+  return {
+    screenshotsCleared: 0,
+    nodeObservationsDeleted: 0,
+    edgeObservationsDeleted: 0,
+    buildKeysDeleted: 0,
+    prunedAt,
+  };
+}
+
+function readPositiveIntEnv(name: string): number | undefined {
+  const raw = process.env[name];
+  if (!raw) {
+    return undefined;
+  }
+  const parsed = Number.parseInt(raw, 10);
+  return Number.isFinite(parsed) && parsed > 0 ? parsed : undefined;
+}
+
+/**
+ * Resolve the retention config from explicit overrides, then env, then the
+ * conservative defaults above. Overrides win so tests stay hermetic.
+ */
+export function resolveNavigationRetentionConfig(
+  overrides: Partial<NavigationRetentionConfig> = {}
+): NavigationRetentionConfig {
+  return {
+    screenshotTtlMs:
+      overrides.screenshotTtlMs
+      ?? readPositiveIntEnv("AUTOMOBILE_NAV_RETENTION_SCREENSHOT_TTL_MS")
+      ?? DEFAULT_SCREENSHOT_TTL_MS,
+    structureTtlMs:
+      overrides.structureTtlMs
+      ?? readPositiveIntEnv("AUTOMOBILE_NAV_RETENTION_STRUCTURE_TTL_MS")
+      ?? DEFAULT_STRUCTURE_TTL_MS,
+    perAppMaxObservations:
+      overrides.perAppMaxObservations
+      ?? readPositiveIntEnv("AUTOMOBILE_NAV_RETENTION_PER_APP_MAX_OBSERVATIONS")
+      ?? DEFAULT_PER_APP_MAX_OBSERVATIONS,
+    globalMaxObservations:
+      overrides.globalMaxObservations
+      ?? readPositiveIntEnv("AUTOMOBILE_NAV_RETENTION_GLOBAL_MAX_OBSERVATIONS")
+      ?? DEFAULT_GLOBAL_MAX_OBSERVATIONS,
+  };
+}
+
+/** Resolve the background-pass interval (ms) from env or the default. */
+export function resolveNavigationRetentionIntervalMs(override?: number): number {
+  return (
+    override
+    ?? readPositiveIntEnv("AUTOMOBILE_NAV_RETENTION_INTERVAL_MS")
+    ?? DEFAULT_NAV_RETENTION_INTERVAL_MS
+  );
+}
+
+interface BuildKeyRow {
+  id: number;
+  appId: string;
+}
+
+interface EvictionCandidate {
+  isNode: boolean;
+  id: number;
+  lastSeenAt: number;
+}
+
+/**
+ * Prunes the persisted nav data in one atomic pass. Stateless and recency-based:
+ * inject the clock `now` and (optionally) a file remover so the whole thing is
+ * deterministic under FakeTimer + an in-memory DB.
+ *
+ * The two observation tables are handled by explicit node/edge branches rather
+ * than a table-name variable: their relevant columns are identical, but keeping
+ * the table a literal lets Kysely fully type every query (no `any`).
+ */
+export class NavigationRetention {
+  private readonly config: NavigationRetentionConfig;
+
+  constructor(
+    private readonly db: Kysely<Database>,
+    config: Partial<NavigationRetentionConfig> = {},
+    private readonly removeScreenshotFile?: ScreenshotFileRemover,
+    private readonly logger: Logger = defaultLogger
+  ) {
+    this.config = resolveNavigationRetentionConfig(config);
+  }
+
+  getConfig(): NavigationRetentionConfig {
+    return this.config;
+  }
+
+  /**
+   * Run every tier once against `now` (ms). Returns a per-pass summary. All DB
+   * work is a single transaction; screenshot files are unlinked AFTER commit so
+   * a slow/failed unlink can never hold the daemon's one connection.
+   */
+  async prune(now: number): Promise<NavigationRetentionSummary> {
+    const summary = emptySummary(now);
+    let filesToRemove: string[] = [];
+
+    await this.db.transaction().execute(async trx => {
+      // Read the build keys + protected set INSIDE the txn: it holds the single
+      // connection exclusively, so no concurrent write can shift which build is
+      // newest between the read and the deletes.
+      const buildKeys = await loadBuildKeys(trx);
+      const protectedIds = await computeProtectedBuildKeyIds(trx, buildKeys);
+      const protectedSet = new Set(protectedIds);
+
+      filesToRemove = await this.pruneScreenshots(trx, now, protectedIds, summary);
+      await this.pruneObservationsByTtl(trx, now, protectedIds, summary);
+      await this.enforceCaps(trx, buildKeys, protectedSet, summary);
+      await this.pruneOrphanBuildKeys(trx, protectedIds, summary);
+    });
+
+    await this.removeFiles(filesToRemove);
+    return summary;
+  }
+
+  private async removeFiles(filePaths: string[]): Promise<void> {
+    if (!this.removeScreenshotFile) {
+      return;
+    }
+    for (const filePath of filePaths) {
+      try {
+        await this.removeScreenshotFile(filePath);
+      } catch (error) {
+        // Best-effort: the DB pointer is already cleared, so a leftover file is
+        // just an orphan the screenshot cache's own LRU will reclaim later.
+        this.logger.debug(`nav retention: failed to unlink screenshot ${filePath}: ${error}`);
+      }
+    }
+  }
+
+  /**
+   * SHORT tier: clear `screenshot_path` on nodes last seen before the cutoff,
+   * unless the node is still observed under the active (protected) build. Returns
+   * the file paths whose pointers were cleared, for post-commit unlinking.
+   */
+  private async pruneScreenshots(
+    trx: Kysely<Database>,
+    now: number,
+    protectedIds: number[],
+    summary: NavigationRetentionSummary
+  ): Promise<string[]> {
+    const cutoff = now - this.config.screenshotTtlMs;
+
+    let query = trx
+      .selectFrom("navigation_nodes")
+      .select(["id", "screenshot_path"])
+      .where("screenshot_path", "is not", null)
+      .where("last_seen_at", "<", cutoff);
+
+    if (protectedIds.length > 0) {
+      // Keep the screenshot if the node has any observation under a protected
+      // build key (i.e. it is part of the active context).
+      query = query.where("id", "not in", eb =>
+        eb
+          .selectFrom("navigation_node_observations")
+          .select("node_id")
+          .where("build_key_id", "in", protectedIds)
+      );
+    }
+
+    const stale = await query.execute();
+    if (stale.length === 0) {
+      return [];
+    }
+
+    const ids = stale.map(row => row.id);
+    await trx
+      .updateTable("navigation_nodes")
+      .set({ screenshot_path: null })
+      .where("id", "in", ids)
+      .execute();
+
+    summary.screenshotsCleared += ids.length;
+    return stale
+      .map(row => row.screenshot_path)
+      .filter((p): p is string => p !== null);
+  }
+
+  /**
+   * LONG tier: delete observation rows last seen before the cutoff, except those
+   * on a protected (active) build key.
+   */
+  private async pruneObservationsByTtl(
+    trx: Kysely<Database>,
+    now: number,
+    protectedIds: number[],
+    summary: NavigationRetentionSummary
+  ): Promise<void> {
+    const cutoff = now - this.config.structureTtlMs;
+
+    {
+      let query = trx.deleteFrom("navigation_node_observations").where("last_seen_at", "<", cutoff);
+      if (protectedIds.length > 0) {
+        query = query.where("build_key_id", "not in", protectedIds);
+      }
+      const result = await query.executeTakeFirst();
+      summary.nodeObservationsDeleted += Number(result.numDeletedRows ?? 0);
+    }
+    {
+      let query = trx.deleteFrom("navigation_edge_observations").where("last_seen_at", "<", cutoff);
+      if (protectedIds.length > 0) {
+        query = query.where("build_key_id", "not in", protectedIds);
+      }
+      const result = await query.executeTakeFirst();
+      summary.edgeObservationsDeleted += Number(result.numDeletedRows ?? 0);
+    }
+  }
+
+  /**
+   * Backstop: enforce the per-app budget first, then the global budget, evicting
+   * the oldest evictable observation rows by `last_seen_at`.
+   */
+  private async enforceCaps(
+    trx: Kysely<Database>,
+    buildKeys: BuildKeyRow[],
+    protectedSet: Set<number>,
+    summary: NavigationRetentionSummary
+  ): Promise<void> {
+    // Per-app: each app's evictable build keys (its own keys minus the protected
+    // one). Observations are scoped by `build_key_id IN (...)`, so no join needed.
+    const evictableByApp = new Map<string, number[]>();
+    for (const bk of buildKeys) {
+      if (protectedSet.has(bk.id)) {
+        continue;
+      }
+      const list = evictableByApp.get(bk.appId) ?? [];
+      list.push(bk.id);
+      evictableByApp.set(bk.appId, list);
+    }
+
+    for (const [, buildKeyIds] of evictableByApp) {
+      const count = await countObservations(trx, buildKeyIds);
+      const overflow = count - this.config.perAppMaxObservations;
+      if (overflow > 0) {
+        await this.evictOldest(trx, buildKeyIds, overflow, summary);
+      }
+    }
+
+    // Global: every evictable build key across all apps.
+    const globalEvictable = buildKeys.filter(bk => !protectedSet.has(bk.id)).map(bk => bk.id);
+    const globalCount = await countObservations(trx, globalEvictable);
+    const globalOverflow = globalCount - this.config.globalMaxObservations;
+    if (globalOverflow > 0) {
+      await this.evictOldest(trx, globalEvictable, globalOverflow, summary);
+    }
+  }
+
+  private async evictOldest(
+    trx: Kysely<Database>,
+    buildKeyIds: number[],
+    count: number,
+    summary: NavigationRetentionSummary
+  ): Promise<void> {
+    if (buildKeyIds.length === 0 || count <= 0) {
+      return;
+    }
+    const victims = await collectOldestEvictable(trx, buildKeyIds, count);
+
+    const nodeIds = victims.filter(v => v.isNode).map(v => v.id);
+    const edgeIds = victims.filter(v => !v.isNode).map(v => v.id);
+    if (nodeIds.length > 0) {
+      const deleted = await trx
+        .deleteFrom("navigation_node_observations")
+        .where("id", "in", nodeIds)
+        .executeTakeFirst();
+      summary.nodeObservationsDeleted += Number(deleted.numDeletedRows ?? 0);
+    }
+    if (edgeIds.length > 0) {
+      const deleted = await trx
+        .deleteFrom("navigation_edge_observations")
+        .where("id", "in", edgeIds)
+        .executeTakeFirst();
+      summary.edgeObservationsDeleted += Number(deleted.numDeletedRows ?? 0);
+    }
+  }
+
+  /**
+   * Sweep build keys left with no observations (except protected ones). Runs
+   * after observation deletes so the FK-safe order holds even with foreign_keys
+   * ON (deleting a still-referenced build key would cascade-wipe its rows).
+   */
+  private async pruneOrphanBuildKeys(
+    trx: Kysely<Database>,
+    protectedIds: number[],
+    summary: NavigationRetentionSummary
+  ): Promise<void> {
+    let query = trx
+      .deleteFrom("navigation_build_keys")
+      .where("id", "not in", eb =>
+        eb.selectFrom("navigation_node_observations").select("build_key_id")
+      )
+      .where("id", "not in", eb =>
+        eb.selectFrom("navigation_edge_observations").select("build_key_id")
+      );
+
+    if (protectedIds.length > 0) {
+      query = query.where("id", "not in", protectedIds);
+    }
+
+    const deleted = await query.executeTakeFirst();
+    summary.buildKeysDeleted += Number(deleted.numDeletedRows ?? 0);
+  }
+}
+
+// ---------------------------------------------------------------------------
+// Free helpers (kept small so the class methods stay under the complexity gate).
+// ---------------------------------------------------------------------------
+
+async function loadBuildKeys(db: Kysely<Database>): Promise<BuildKeyRow[]> {
+  const rows = await db.selectFrom("navigation_build_keys").select(["id", "app_id"]).execute();
+  return rows.map(row => ({ id: row.id, appId: row.app_id }));
+}
+
+/**
+ * The active/most-recent build key per app: the one whose observations have the
+ * greatest `last_seen_at` (ties and no-observation apps fall back to the newest
+ * build-key id). These are never pruned.
+ */
+export async function computeProtectedBuildKeyIds(
+  db: Kysely<Database>,
+  buildKeys?: BuildKeyRow[]
+): Promise<number[]> {
+  const keys = buildKeys ?? (await loadBuildKeys(db));
+  if (keys.length === 0) {
+    return [];
+  }
+  const maxSeen = await loadMaxSeenByBuildKey(db);
+
+  // Per app, pick the build key with the greatest (lastSeen, id).
+  const best = new Map<string, { id: number; seen: number }>();
+  for (const bk of keys) {
+    const seen = maxSeen.get(bk.id) ?? Number.NEGATIVE_INFINITY;
+    if (isNewerBuild(best.get(bk.appId), bk.id, seen)) {
+      best.set(bk.appId, { id: bk.id, seen });
+    }
+  }
+
+  return Array.from(best.values(), entry => entry.id);
+}
+
+function isNewerBuild(
+  current: { id: number; seen: number } | undefined,
+  id: number,
+  seen: number
+): boolean {
+  if (current === undefined) {
+    return true;
+  }
+  return seen > current.seen || (seen === current.seen && id > current.id);
+}
+
+/** Greatest `last_seen_at` per build key across both observation tables. */
+async function loadMaxSeenByBuildKey(db: Kysely<Database>): Promise<Map<number, number>> {
+  const nodeMax = await db
+    .selectFrom("navigation_node_observations")
+    .select(eb => ["build_key_id", eb.fn.max("last_seen_at").as("max_seen")])
+    .groupBy("build_key_id")
+    .execute();
+  const edgeMax = await db
+    .selectFrom("navigation_edge_observations")
+    .select(eb => ["build_key_id", eb.fn.max("last_seen_at").as("max_seen")])
+    .groupBy("build_key_id")
+    .execute();
+
+  const maxSeen = new Map<number, number>();
+  for (const row of [...nodeMax, ...edgeMax]) {
+    const seen = Number(row.max_seen ?? 0);
+    const prev = maxSeen.get(row.build_key_id);
+    if (prev === undefined || seen > prev) {
+      maxSeen.set(row.build_key_id, seen);
+    }
+  }
+  return maxSeen;
+}
+
+/** Count observation rows (node + edge) whose build key is in `buildKeyIds`. */
+async function countObservations(
+  trx: Kysely<Database>,
+  buildKeyIds: number[]
+): Promise<number> {
+  if (buildKeyIds.length === 0) {
+    return 0;
+  }
+  const nodeRow = await trx
+    .selectFrom("navigation_node_observations")
+    .select(eb => eb.fn.countAll<number>().as("c"))
+    .where("build_key_id", "in", buildKeyIds)
+    .executeTakeFirst();
+  const edgeRow = await trx
+    .selectFrom("navigation_edge_observations")
+    .select(eb => eb.fn.countAll<number>().as("c"))
+    .where("build_key_id", "in", buildKeyIds)
+    .executeTakeFirst();
+  return Number(nodeRow?.c ?? 0) + Number(edgeRow?.c ?? 0);
+}
+
+/**
+ * Collect the `limit` oldest evictable observation rows (by last_seen_at, then
+ * id) whose build key is in `buildKeyIds`. Fetches at most `limit` rows per table
+ * then merges, so it never loads the whole table — only the overflow being
+ * evicted.
+ */
+async function collectOldestEvictable(
+  trx: Kysely<Database>,
+  buildKeyIds: number[],
+  limit: number
+): Promise<EvictionCandidate[]> {
+  const nodeRows = await trx
+    .selectFrom("navigation_node_observations")
+    .select(["id", "last_seen_at"])
+    .where("build_key_id", "in", buildKeyIds)
+    .orderBy("last_seen_at", "asc")
+    .orderBy("id", "asc")
+    .limit(limit)
+    .execute();
+  const edgeRows = await trx
+    .selectFrom("navigation_edge_observations")
+    .select(["id", "last_seen_at"])
+    .where("build_key_id", "in", buildKeyIds)
+    .orderBy("last_seen_at", "asc")
+    .orderBy("id", "asc")
+    .limit(limit)
+    .execute();
+
+  const candidates: EvictionCandidate[] = [
+    ...nodeRows.map(row => ({ isNode: true, id: row.id, lastSeenAt: row.last_seen_at })),
+    ...edgeRows.map(row => ({ isNode: false, id: row.id, lastSeenAt: row.last_seen_at })),
+  ];
+  // Oldest first; break ties by table (nodes before edges) then id for determinism.
+  candidates.sort(
+    (a, b) =>
+      a.lastSeenAt - b.lastSeenAt
+      || Number(b.isNode) - Number(a.isNode)
+      || a.id - b.id
+  );
+  return candidates.slice(0, limit);
+}

--- a/src/db/navigationRetention.ts
+++ b/src/db/navigationRetention.ts
@@ -19,7 +19,8 @@
 //      on the observation rows, evicting oldest by `last_seen_at`. Unlike the TTL
 //      tier, the cap counts the active build key's rows too (otherwise a
 //      continuously-used single-build app would never be bounded), but it never
-//      evicts the *active* rows themselves — see `computeActiveObservationIds`.
+//      evicts the *active* rows themselves — the newest `last_seen_at` per
+//      protected build key is excluded relationally (see the eviction queries).
 //
 // Active-data safety (AC3): the most-recently-seen build key per app is the
 // active context. The TTL tier and the orphan-build-key sweep never touch it, and
@@ -99,12 +100,6 @@ export interface NavigationRetentionSummary {
   buildKeysDeleted: number;
   /** Clock time (ms) the pass ran at. */
   prunedAt: number;
-}
-
-/** The newest observation-row ids per protected build key, kept out of eviction. */
-export interface ActiveObservationIds {
-  nodeIds: number[];
-  edgeIds: number[];
 }
 
 function emptySummary(prunedAt: number): NavigationRetentionSummary {
@@ -212,11 +207,6 @@ interface BuildKeyRow {
 
 interface EvictionCandidate {
   isNode: boolean;
-  id: number;
-  lastSeenAt: number;
-}
-
-interface ObservationRow {
   id: number;
   lastSeenAt: number;
 }
@@ -395,21 +385,19 @@ export class NavigationRetention {
     protectedIds: number[],
     summary: NavigationRetentionSummary
   ): Promise<void> {
-    const activeIds = await computeActiveObservationIds(trx, protectedIds);
-
     const appIds = Array.from(new Set(buildKeys.map(bk => bk.appId)));
     for (const appId of appIds) {
       const count = await countObservations(trx, appId);
       const overflow = count - this.config.perAppMaxObservations;
       if (overflow > 0) {
-        await this.evictOldest(trx, appId, activeIds, overflow, summary);
+        await this.evictOldest(trx, appId, protectedIds, overflow, summary);
       }
     }
 
     const globalCount = await countObservations(trx, null);
     const globalOverflow = globalCount - this.config.globalMaxObservations;
     if (globalOverflow > 0) {
-      await this.evictOldest(trx, null, activeIds, globalOverflow, summary);
+      await this.evictOldest(trx, null, protectedIds, globalOverflow, summary);
     }
   }
 
@@ -417,8 +405,8 @@ export class NavigationRetention {
    * Evict `count` oldest observation rows in scope (`appId === null` == global),
    * in bounded batches so a single DELETE never binds more ids than
    * `evictionChunkSize`. The loop terminates when the target is met or no
-   * evictable rows remain (active rows are excluded, so a scope can be irreducible
-   * below its active set).
+   * evictable rows remain (active rows are excluded relationally, so a scope can
+   * be irreducible below its active set).
    *
    * Perf note: each batch does an ordered scan of the observation tables. A
    * `(build_key_id, last_seen_at)` index would turn this into an index range scan;
@@ -427,14 +415,14 @@ export class NavigationRetention {
   private async evictOldest(
     trx: Kysely<Database>,
     appId: string | null,
-    activeIds: ActiveObservationIds,
+    protectedIds: number[],
     count: number,
     summary: NavigationRetentionSummary
   ): Promise<void> {
     let remaining = count;
     while (remaining > 0) {
       const batch = Math.min(remaining, this.config.evictionChunkSize);
-      const victims = await collectOldestEvictable(trx, appId, activeIds, batch);
+      const victims = await collectOldestEvictable(trx, appId, protectedIds, batch);
       if (victims.length === 0) {
         return;
       }
@@ -561,63 +549,6 @@ async function loadMaxSeenByBuildKey(db: Kysely<Database>): Promise<Map<number, 
 }
 
 /**
- * For each protected build key, the observation-row ids whose `last_seen_at` is
- * that build key's maximum, per table — the "active" rows the size cap must never
- * evict (ties keep all rows at the max instant).
- *
- * Relational form: a join against a `GROUP BY build_key_id` max subquery, so the
- * only bound parameters are the (per-app-bounded) protected id list — NO per-row
- * `(build_key_id=? AND last_seen_at=?) OR …` chain, which would blow the
- * expression-tree depth at high app counts.
- */
-export async function computeActiveObservationIds(
-  trx: Kysely<Database>,
-  protectedIds: number[]
-): Promise<ActiveObservationIds> {
-  if (protectedIds.length === 0) {
-    return { nodeIds: [], edgeIds: [] };
-  }
-
-  const nodeRows = await trx
-    .selectFrom("navigation_node_observations as o")
-    .innerJoin(
-      eb =>
-        eb
-          .selectFrom("navigation_node_observations")
-          .select(sb => ["build_key_id", sb.fn.max("last_seen_at").as("m")])
-          .where("build_key_id", "in", protectedIds)
-          .groupBy("build_key_id")
-          .as("mx"),
-      join =>
-        join
-          .onRef("mx.build_key_id", "=", "o.build_key_id")
-          .onRef("mx.m", "=", "o.last_seen_at")
-    )
-    .select("o.id as id")
-    .execute();
-
-  const edgeRows = await trx
-    .selectFrom("navigation_edge_observations as o")
-    .innerJoin(
-      eb =>
-        eb
-          .selectFrom("navigation_edge_observations")
-          .select(sb => ["build_key_id", sb.fn.max("last_seen_at").as("m")])
-          .where("build_key_id", "in", protectedIds)
-          .groupBy("build_key_id")
-          .as("mx"),
-      join =>
-        join
-          .onRef("mx.build_key_id", "=", "o.build_key_id")
-          .onRef("mx.m", "=", "o.last_seen_at")
-    )
-    .select("o.id as id")
-    .execute();
-
-  return { nodeIds: nodeRows.map(r => r.id), edgeIds: edgeRows.map(r => r.id) };
-}
-
-/**
  * Count observation rows (node + edge). `appId === null` counts every row
  * (global); otherwise it joins on `app_id` (one bound param) rather than an id
  * list of the app's build keys.
@@ -655,22 +586,22 @@ async function countObservations(
 
 /**
  * Collect the `limit` oldest evictable observation rows (by last_seen_at, then
- * id), optionally scoped to one app (via an `app_id` join), excluding the active
- * rows. Fetches at most `limit` rows per table then merges, so it never loads the
- * whole table — only the batch being evicted.
+ * id), optionally scoped to one app, excluding the active rows RELATIONALLY.
+ * Fetches at most `limit` rows per table then merges, so it never loads the whole
+ * table — only the batch being evicted.
  */
 async function collectOldestEvictable(
   trx: Kysely<Database>,
   appId: string | null,
-  activeIds: ActiveObservationIds,
+  protectedIds: number[],
   limit: number
 ): Promise<EvictionCandidate[]> {
-  const nodeRows = await oldestNodeObservations(trx, appId, activeIds.nodeIds, limit);
-  const edgeRows = await oldestEdgeObservations(trx, appId, activeIds.edgeIds, limit);
+  const nodeRows = await buildOldestNodeEvictableQuery(trx, appId, protectedIds, limit).execute();
+  const edgeRows = await buildOldestEdgeEvictableQuery(trx, appId, protectedIds, limit).execute();
 
   const candidates: EvictionCandidate[] = [
-    ...nodeRows.map(row => ({ isNode: true, id: row.id, lastSeenAt: row.lastSeenAt })),
-    ...edgeRows.map(row => ({ isNode: false, id: row.id, lastSeenAt: row.lastSeenAt })),
+    ...nodeRows.map(row => ({ isNode: true, id: row.id, lastSeenAt: row.last_seen_at })),
+    ...edgeRows.map(row => ({ isNode: false, id: row.id, lastSeenAt: row.last_seen_at })),
   ];
   // Oldest first; break ties by table (nodes before edges) then id for determinism.
   candidates.sort(
@@ -682,76 +613,78 @@ async function collectOldestEvictable(
   return candidates.slice(0, limit);
 }
 
-async function oldestNodeObservations(
-  trx: Kysely<Database>,
+/**
+ * Build the "oldest evictable node observations" query. Scope and active-row
+ * exclusion are BOTH expressed relationally, so the bound-parameter count stays
+ * O(protected apps) regardless of how many observations (or active rows) exist:
+ *
+ * - App scope: `build_key_id IN (SELECT id FROM navigation_build_keys WHERE
+ *   app_id = ?)` — binds the app id only, not the app's build-key ids.
+ * - Active-row exclusion: keep a row unless its build key is protected AND its
+ *   `last_seen_at` equals that build key's max (a correlated scalar subquery). No
+ *   materialized `NOT IN (activeIds)` list, which could otherwise exceed
+ *   bun:sqlite's MAX_VARIABLE_NUMBER when many rows tie at the max instant or many
+ *   apps are protected.
+ *
+ * Exported so a test can compile it and assert the O(apps) bind shape.
+ */
+export function buildOldestNodeEvictableQuery(
+  db: Kysely<Database>,
   appId: string | null,
-  excludeIds: number[],
+  protectedIds: number[],
   limit: number
-): Promise<ObservationRow[]> {
-  if (appId === null) {
-    let query = trx
-      .selectFrom("navigation_node_observations")
-      .select(["id", "last_seen_at"]);
-    if (excludeIds.length > 0) {
-      query = query.where("id", "not in", excludeIds);
-    }
-    const rows = await query
-      .orderBy("last_seen_at", "asc")
-      .orderBy("id", "asc")
-      .limit(limit)
-      .execute();
-    return rows.map(r => ({ id: r.id, lastSeenAt: r.last_seen_at }));
+) {
+  let query = db.selectFrom("navigation_node_observations").select(["id", "last_seen_at"]);
+  if (appId !== null) {
+    query = query.where("build_key_id", "in", eb =>
+      eb.selectFrom("navigation_build_keys").select("id").where("app_id", "=", appId)
+    );
   }
-
-  let query = trx
-    .selectFrom("navigation_node_observations as o")
-    .innerJoin("navigation_build_keys as bk", "bk.id", "o.build_key_id")
-    .select(["o.id as id", "o.last_seen_at as last_seen_at"])
-    .where("bk.app_id", "=", appId);
-  if (excludeIds.length > 0) {
-    query = query.where("o.id", "not in", excludeIds);
+  if (protectedIds.length > 0) {
+    query = query.where(eb =>
+      eb.or([
+        eb("build_key_id", "not in", protectedIds),
+        eb(
+          "last_seen_at",
+          "<>",
+          eb
+            .selectFrom("navigation_node_observations as t")
+            .select(sb => sb.fn.max("t.last_seen_at").as("m"))
+            .whereRef("t.build_key_id", "=", "navigation_node_observations.build_key_id")
+        ),
+      ])
+    );
   }
-  const rows = await query
-    .orderBy("o.last_seen_at", "asc")
-    .orderBy("o.id", "asc")
-    .limit(limit)
-    .execute();
-  return rows.map(r => ({ id: r.id, lastSeenAt: r.last_seen_at }));
+  return query.orderBy("last_seen_at", "asc").orderBy("id", "asc").limit(limit);
 }
 
-async function oldestEdgeObservations(
-  trx: Kysely<Database>,
+/** Edge-table counterpart of {@link buildOldestNodeEvictableQuery}. */
+export function buildOldestEdgeEvictableQuery(
+  db: Kysely<Database>,
   appId: string | null,
-  excludeIds: number[],
+  protectedIds: number[],
   limit: number
-): Promise<ObservationRow[]> {
-  if (appId === null) {
-    let query = trx
-      .selectFrom("navigation_edge_observations")
-      .select(["id", "last_seen_at"]);
-    if (excludeIds.length > 0) {
-      query = query.where("id", "not in", excludeIds);
-    }
-    const rows = await query
-      .orderBy("last_seen_at", "asc")
-      .orderBy("id", "asc")
-      .limit(limit)
-      .execute();
-    return rows.map(r => ({ id: r.id, lastSeenAt: r.last_seen_at }));
+) {
+  let query = db.selectFrom("navigation_edge_observations").select(["id", "last_seen_at"]);
+  if (appId !== null) {
+    query = query.where("build_key_id", "in", eb =>
+      eb.selectFrom("navigation_build_keys").select("id").where("app_id", "=", appId)
+    );
   }
-
-  let query = trx
-    .selectFrom("navigation_edge_observations as o")
-    .innerJoin("navigation_build_keys as bk", "bk.id", "o.build_key_id")
-    .select(["o.id as id", "o.last_seen_at as last_seen_at"])
-    .where("bk.app_id", "=", appId);
-  if (excludeIds.length > 0) {
-    query = query.where("o.id", "not in", excludeIds);
+  if (protectedIds.length > 0) {
+    query = query.where(eb =>
+      eb.or([
+        eb("build_key_id", "not in", protectedIds),
+        eb(
+          "last_seen_at",
+          "<>",
+          eb
+            .selectFrom("navigation_edge_observations as t")
+            .select(sb => sb.fn.max("t.last_seen_at").as("m"))
+            .whereRef("t.build_key_id", "=", "navigation_edge_observations.build_key_id")
+        ),
+      ])
+    );
   }
-  const rows = await query
-    .orderBy("o.last_seen_at", "asc")
-    .orderBy("o.id", "asc")
-    .limit(limit)
-    .execute();
-  return rows.map(r => ({ id: r.id, lastSeenAt: r.last_seen_at }));
+  return query.orderBy("last_seen_at", "asc").orderBy("id", "asc").limit(limit);
 }

--- a/test/daemon/NavigationRetentionMonitor.test.ts
+++ b/test/daemon/NavigationRetentionMonitor.test.ts
@@ -1,0 +1,115 @@
+import { describe, expect, test } from "bun:test";
+import { NavigationRetentionMonitor } from "../../src/daemon/NavigationRetentionMonitor";
+import { FakeTimer } from "../fakes/FakeTimer";
+import type {
+  NavigationRetention,
+  NavigationRetentionSummary,
+} from "../../src/db/navigationRetention";
+
+/**
+ * Minimal stand-in for {@link NavigationRetention} that records the clock values
+ * it was pruned at, so the monitor's cadence + guard can be driven purely with a
+ * FakeTimer (no DB, no real waits).
+ */
+function fakeRetention(options: { onPrune?: () => void; throwOnce?: boolean } = {}): {
+  retention: NavigationRetention;
+  prunedAt: number[];
+} {
+  const prunedAt: number[] = [];
+  let thrown = false;
+  const retention = {
+    async prune(now: number): Promise<NavigationRetentionSummary> {
+      options.onPrune?.();
+      if (options.throwOnce && !thrown) {
+        thrown = true;
+        throw new Error("boom");
+      }
+      prunedAt.push(now);
+      return {
+        screenshotsCleared: 0,
+        nodeObservationsDeleted: 0,
+        edgeObservationsDeleted: 0,
+        buildKeysDeleted: 0,
+        prunedAt: now,
+      };
+    },
+  } as unknown as NavigationRetention;
+  return { retention, prunedAt };
+}
+
+describe("NavigationRetentionMonitor", () => {
+  test("fires prune once per interval using the injected clock", async () => {
+    const timer = new FakeTimer();
+    const { retention, prunedAt } = fakeRetention();
+    const monitor = new NavigationRetentionMonitor(retention, timer, 1_000);
+    monitor.start();
+
+    expect(prunedAt).toEqual([]);
+    await timer.advanceTimersByTimeAsync(1_000);
+    await timer.advanceTimersByTimeAsync(1_000);
+    monitor.stop();
+
+    expect(prunedAt.length).toBe(2);
+    // now() advances with the fake clock, proving the clock is the seam.
+    expect(prunedAt[0]).toBe(1_000);
+    expect(prunedAt[1]).toBe(2_000);
+  });
+
+  test("stop() halts further passes", async () => {
+    const timer = new FakeTimer();
+    const { retention, prunedAt } = fakeRetention();
+    const monitor = new NavigationRetentionMonitor(retention, timer, 1_000);
+    monitor.start();
+    await timer.advanceTimersByTimeAsync(1_000);
+    monitor.stop();
+    await timer.advanceTimersByTimeAsync(5_000);
+    expect(prunedAt.length).toBe(1);
+  });
+
+  test("drops overlapping ticks while a pass is in flight", async () => {
+    const timer = new FakeTimer();
+    let release: (() => void) | undefined;
+    const gate = new Promise<void>(resolve => {
+      release = resolve;
+    });
+    let calls = 0;
+    const retention = {
+      async prune(now: number): Promise<NavigationRetentionSummary> {
+        calls++;
+        await gate; // hold the first pass open across the next tick
+        return {
+          screenshotsCleared: 0,
+          nodeObservationsDeleted: 0,
+          edgeObservationsDeleted: 0,
+          buildKeysDeleted: 0,
+          prunedAt: now,
+        };
+      },
+    } as unknown as NavigationRetention;
+
+    const monitor = new NavigationRetentionMonitor(retention, timer, 1_000);
+    monitor.start();
+    const pass1 = monitor.tick(); // pass #1, blocks on gate
+    await Promise.resolve();
+    await monitor.tick(); // dropped: still running
+    expect(calls).toBe(1);
+
+    release?.();
+    await pass1; // let pass #1 finish and clear the running guard
+    await monitor.tick(); // now allowed again
+    expect(calls).toBe(2);
+    monitor.stop();
+  });
+
+  test("swallows a failing pass and keeps running", async () => {
+    const timer = new FakeTimer();
+    const { retention, prunedAt } = fakeRetention({ throwOnce: true });
+    const monitor = new NavigationRetentionMonitor(retention, timer, 1_000);
+
+    await monitor.tick(); // throws internally, swallowed
+    expect(monitor.getLastSummary()).toBeNull();
+    await monitor.tick(); // recovers
+    expect(prunedAt.length).toBe(1);
+    expect(monitor.getLastSummary()).not.toBeNull();
+  });
+});

--- a/test/daemon/NavigationRetentionMonitor.test.ts
+++ b/test/daemon/NavigationRetentionMonitor.test.ts
@@ -1,10 +1,17 @@
-import { describe, expect, test } from "bun:test";
+import { afterEach, beforeEach, describe, expect, test } from "bun:test";
 import { NavigationRetentionMonitor } from "../../src/daemon/NavigationRetentionMonitor";
 import { FakeTimer } from "../fakes/FakeTimer";
+import { resetDbWriteBarrier } from "../../src/db/dbWriteBarrier";
 import type {
   NavigationRetention,
   NavigationRetentionSummary,
 } from "../../src/db/navigationRetention";
+
+// The monitor registers each pass with the shared DB write barrier; reset it
+// around every test so a barrier left draining by another suite can't skip our
+// (fake) prune, and so we don't leak state to later suites.
+beforeEach(() => resetDbWriteBarrier());
+afterEach(() => resetDbWriteBarrier());
 
 /**
  * Minimal stand-in for {@link NavigationRetention} that records the clock values

--- a/test/db/navigationRetention.test.ts
+++ b/test/db/navigationRetention.test.ts
@@ -1,0 +1,339 @@
+import { afterEach, beforeEach, describe, expect, test } from "bun:test";
+import type { Kysely } from "kysely";
+import { createTestDatabase } from "./testDbHelper";
+import type { Database } from "../../src/db/types";
+import { NavigationRepository } from "../../src/db/navigationRepository";
+import {
+  NavigationRetention,
+  resolveNavigationRetentionConfig,
+  computeProtectedBuildKeyIds,
+  DEFAULT_SCREENSHOT_TTL_MS,
+  DEFAULT_STRUCTURE_TTL_MS,
+  DEFAULT_PER_APP_MAX_OBSERVATIONS,
+  DEFAULT_GLOBAL_MAX_OBSERVATIONS,
+} from "../../src/db/navigationRetention";
+
+const APP = "com.example.app";
+const APP2 = "com.example.other";
+
+// Small TTLs so an explicit `now` (the injected fake clock) crosses them without
+// any real waiting. Caps default huge unless a test overrides them.
+const CONFIG = {
+  screenshotTtlMs: 1_000,
+  structureTtlMs: 5_000,
+  perAppMaxObservations: 1_000,
+  globalMaxObservations: 10_000,
+};
+
+describe("navigationRetention config", () => {
+  const ENV_KEYS = [
+    "AUTOMOBILE_NAV_RETENTION_SCREENSHOT_TTL_MS",
+    "AUTOMOBILE_NAV_RETENTION_STRUCTURE_TTL_MS",
+    "AUTOMOBILE_NAV_RETENTION_PER_APP_MAX_OBSERVATIONS",
+    "AUTOMOBILE_NAV_RETENTION_GLOBAL_MAX_OBSERVATIONS",
+  ];
+  const saved: Record<string, string | undefined> = {};
+
+  beforeEach(() => {
+    for (const key of ENV_KEYS) {
+      saved[key] = process.env[key];
+      delete process.env[key];
+    }
+  });
+  afterEach(() => {
+    for (const key of ENV_KEYS) {
+      if (saved[key] === undefined) {
+        delete process.env[key];
+      } else {
+        process.env[key] = saved[key];
+      }
+    }
+  });
+
+  test("falls back to conservative defaults", () => {
+    const config = resolveNavigationRetentionConfig();
+    expect(config.screenshotTtlMs).toBe(DEFAULT_SCREENSHOT_TTL_MS);
+    expect(config.structureTtlMs).toBe(DEFAULT_STRUCTURE_TTL_MS);
+    expect(config.perAppMaxObservations).toBe(DEFAULT_PER_APP_MAX_OBSERVATIONS);
+    expect(config.globalMaxObservations).toBe(DEFAULT_GLOBAL_MAX_OBSERVATIONS);
+    // Defaults are the intended conservative policy (weeks/months, generous caps).
+    expect(config.screenshotTtlMs).toBe(7 * 24 * 60 * 60 * 1000);
+    expect(config.structureTtlMs).toBe(90 * 24 * 60 * 60 * 1000);
+  });
+
+  test("env overrides defaults; explicit overrides win over env", () => {
+    process.env.AUTOMOBILE_NAV_RETENTION_STRUCTURE_TTL_MS = "42";
+    expect(resolveNavigationRetentionConfig().structureTtlMs).toBe(42);
+    expect(resolveNavigationRetentionConfig({ structureTtlMs: 7 }).structureTtlMs).toBe(7);
+  });
+
+  test("rejects non-positive / non-numeric env values", () => {
+    process.env.AUTOMOBILE_NAV_RETENTION_PER_APP_MAX_OBSERVATIONS = "-5";
+    expect(resolveNavigationRetentionConfig().perAppMaxObservations).toBe(
+      DEFAULT_PER_APP_MAX_OBSERVATIONS
+    );
+    process.env.AUTOMOBILE_NAV_RETENTION_PER_APP_MAX_OBSERVATIONS = "abc";
+    expect(resolveNavigationRetentionConfig().perAppMaxObservations).toBe(
+      DEFAULT_PER_APP_MAX_OBSERVATIONS
+    );
+  });
+});
+
+describe("NavigationRetention prune", () => {
+  let db: Kysely<Database>;
+  let repo: NavigationRepository;
+  let removed: string[];
+
+  beforeEach(async () => {
+    db = await createTestDatabase({ foreignKeys: true });
+    repo = new NavigationRepository(db);
+    removed = [];
+  });
+  afterEach(async () => {
+    await db.destroy();
+  });
+
+  function retention(config = CONFIG): NavigationRetention {
+    return new NavigationRetention(db, config, async filePath => {
+      removed.push(filePath);
+    });
+  }
+
+  async function seedNode(screen: string, timestamp: number): Promise<number> {
+    await repo.getOrCreateApp(APP);
+    const node = await repo.getOrCreateNode(APP, screen, timestamp);
+    return node.id;
+  }
+
+  async function buildKey(app: string, versionCode: number): Promise<number> {
+    await repo.getOrCreateApp(app);
+    const bk = await repo.getOrCreateBuildKey(app, versionCode, `hash-${versionCode}`);
+    return bk.id;
+  }
+
+  async function nodeObs(
+    nodeId: number,
+    buildKeyId: number,
+    session: string,
+    seenAt: number
+  ): Promise<void> {
+    await repo.recordNodeObservation(nodeId, buildKeyId, "device-1", session, seenAt);
+  }
+
+  async function countNodeObs(): Promise<number> {
+    const row = await db
+      .selectFrom("navigation_node_observations")
+      .select(eb => eb.fn.countAll<number>().as("c"))
+      .executeTakeFirst();
+    return Number(row?.c ?? 0);
+  }
+
+  // ---- Active-context protection (AC3) ----
+
+  test("never prunes the most-recent build even when all data is past TTL", async () => {
+    const nodeId = await seedNode("Home", 100);
+    const bkOld = await buildKey(APP, 1);
+    const bkNew = await buildKey(APP, 2);
+    await nodeObs(nodeId, bkOld, "s-old", 100);
+    await nodeObs(nodeId, bkNew, "s-new", 200); // newest -> protected
+
+    // now far beyond structureTtlMs for BOTH observations.
+    const summary = await retention().prune(1_000_000);
+
+    // Old build's observation pruned; protected (newest) build's kept.
+    expect(summary.nodeObservationsDeleted).toBe(1);
+    const remaining = await db
+      .selectFrom("navigation_node_observations")
+      .innerJoin("navigation_build_keys as bk", "bk.id", "navigation_node_observations.build_key_id")
+      .select("bk.version_code as v")
+      .execute();
+    expect(remaining.map(r => r.v)).toEqual([2]);
+  });
+
+  test("computeProtectedBuildKeyIds picks the newest-seen build per app", async () => {
+    const nodeId = await seedNode("Home", 100);
+    const bk1 = await buildKey(APP, 1);
+    const bk2 = await buildKey(APP, 2);
+    await nodeObs(nodeId, bk1, "s1", 500);
+    await nodeObs(nodeId, bk2, "s2", 100); // older last_seen despite higher version
+    const protectedIds = await computeProtectedBuildKeyIds(db);
+    expect(protectedIds).toEqual([bk1]); // argmax by last_seen, not version
+  });
+
+  // ---- SHORT tier: screenshots ----
+
+  test("clears stale screenshot pointer and unlinks the file", async () => {
+    const nodeId = await seedNode("Home", 100);
+    await repo.updateNodeScreenshotById(nodeId, "/tmp/shot-home.webp");
+
+    const summary = await retention().prune(10_000); // node.last_seen 100 < 10000-1000
+
+    expect(summary.screenshotsCleared).toBe(1);
+    expect(removed).toEqual(["/tmp/shot-home.webp"]);
+    const node = await repo.getNodeById(APP, nodeId);
+    expect(node?.screenshot_path).toBeNull();
+    // The light node row itself survives.
+    expect(node).toBeDefined();
+  });
+
+  test("keeps screenshot for a node in the active (protected) build", async () => {
+    const nodeId = await seedNode("Home", 100);
+    await repo.updateNodeScreenshotById(nodeId, "/tmp/shot-home.webp");
+    const bkNew = await buildKey(APP, 2);
+    await nodeObs(nodeId, bkNew, "s-new", 100); // node belongs to the only/protected build
+
+    const summary = await retention().prune(10_000);
+
+    expect(summary.screenshotsCleared).toBe(0);
+    expect(removed).toEqual([]);
+    const node = await repo.getNodeById(APP, nodeId);
+    expect(node?.screenshot_path).toBe("/tmp/shot-home.webp");
+  });
+
+  test("keeps a recent screenshot (within short TTL)", async () => {
+    const nodeId = await seedNode("Home", 9_500);
+    await repo.updateNodeScreenshotById(nodeId, "/tmp/shot-home.webp");
+    const summary = await retention().prune(10_000); // 9500 >= 10000-1000
+    expect(summary.screenshotsCleared).toBe(0);
+    const node = await repo.getNodeById(APP, nodeId);
+    expect(node?.screenshot_path).toBe("/tmp/shot-home.webp");
+  });
+
+  // ---- LONG tier: observation TTL ----
+
+  test("prunes old node + edge observations, keeps recent ones", async () => {
+    const nodeId = await seedNode("Home", 100);
+    const edge = await repo.createEdge(APP, "Home", "Detail", "tapOn", null, 100);
+    const bkOld = await buildKey(APP, 1);
+    const bkNew = await buildKey(APP, 2);
+    await nodeObs(nodeId, bkOld, "s-old", 100);
+    await nodeObs(nodeId, bkNew, "s-new", 100_000); // newest -> protected
+    await repo.recordEdgeObservation(edge.id, bkOld, "device-1", "s-old", 100);
+    await repo.recordEdgeObservation(edge.id, bkNew, "device-1", "s-new", 100_000);
+
+    const summary = await retention().prune(50_000); // cutoff 45000
+
+    expect(summary.nodeObservationsDeleted).toBe(1);
+    expect(summary.edgeObservationsDeleted).toBe(1);
+    const nodeCount = await countNodeObs();
+    const edgeCount = await db
+      .selectFrom("navigation_edge_observations")
+      .select(eb => eb.fn.countAll<number>().as("c"))
+      .executeTakeFirst();
+    expect(nodeCount).toBe(1);
+    expect(Number(edgeCount?.c)).toBe(1);
+  });
+
+  // ---- LRU size cap (backstop) ----
+
+  test("per-app LRU cap evicts oldest evictable observations by last_seen", async () => {
+    const nodeId = await seedNode("Home", 1);
+    const bkOld = await buildKey(APP, 1);
+    const bkNew = await buildKey(APP, 2);
+    await nodeObs(nodeId, bkNew, "protected", 10_000); // protected
+    // 5 evictable observations, recent (within TTL) so only the cap can evict them.
+    for (let i = 0; i < 5; i++) {
+      await nodeObs(nodeId, bkOld, `s${i}`, 1_000 + i);
+    }
+
+    // structureTtl huge so only the cap can evict (isolates the LRU backstop).
+    const summary = await retention({
+      ...CONFIG,
+      structureTtlMs: 10_000_000,
+      perAppMaxObservations: 2,
+    }).prune(11_000);
+
+    // 5 evictable - cap 2 = 3 oldest evicted; protected untouched.
+    expect(summary.nodeObservationsDeleted).toBe(3);
+    const remaining = await db
+      .selectFrom("navigation_node_observations")
+      .select(["session_uuid", "last_seen_at"])
+      .orderBy("last_seen_at", "asc")
+      .execute();
+    const sessions = remaining.map(r => r.session_uuid).sort();
+    expect(sessions).toEqual(["protected", "s3", "s4"]); // oldest s0,s1,s2 gone
+  });
+
+  test("global LRU cap evicts oldest across apps, sparing protected builds", async () => {
+    // App 1
+    const n1 = await seedNode("A", 1);
+    const bk1old = await buildKey(APP, 1);
+    const bk1new = await buildKey(APP, 2);
+    await nodeObs(n1, bk1new, "p1", 9_000);
+    await nodeObs(n1, bk1old, "a-100", 100);
+    await nodeObs(n1, bk1old, "a-300", 300);
+    // App 2
+    await repo.getOrCreateApp(APP2);
+    const n2 = await repo.getOrCreateNode(APP2, "B", 1);
+    const bk2old = await buildKey(APP2, 1);
+    const bk2new = await buildKey(APP2, 2);
+    await repo.recordNodeObservation(n2.id, bk2new, "d", "p2", 9_500);
+    await repo.recordNodeObservation(n2.id, bk2old, "d", "b-200", 200);
+
+    // 3 evictable rows total (a-100, a-300, b-200); global cap 2 -> evict 1 oldest (a-100).
+    const summary = await retention({
+      ...CONFIG,
+      structureTtlMs: 10_000_000, // isolate the global cap from the TTL tier
+      perAppMaxObservations: 1_000,
+      globalMaxObservations: 2,
+    }).prune(10_000);
+
+    expect(summary.nodeObservationsDeleted).toBe(1);
+    const rows = await db
+      .selectFrom("navigation_node_observations")
+      .select("session_uuid")
+      .execute();
+    const sessions = rows.map(r => r.session_uuid).sort();
+    expect(sessions).toEqual(["a-300", "b-200", "p1", "p2"]);
+  });
+
+  // ---- FK-safe orphan build-key cleanup + idempotency ----
+
+  test("sweeps orphaned build keys after pruning observations (FK-safe), keeps protected", async () => {
+    const nodeId = await seedNode("Home", 100);
+    const bkOld = await buildKey(APP, 1);
+    const bkNew = await buildKey(APP, 2);
+    await nodeObs(nodeId, bkOld, "s-old", 100);
+    await nodeObs(nodeId, bkNew, "s-new", 100_000);
+
+    const summary = await retention().prune(1_000_000);
+
+    // bkOld's only observation pruned -> bkOld orphaned and swept; bkNew protected.
+    expect(summary.buildKeysDeleted).toBe(1);
+    const keys = await db.selectFrom("navigation_build_keys").select("id").execute();
+    expect(keys.map(k => k.id)).toEqual([bkNew]);
+  });
+
+  test("is idempotent: a second pass at the same clock deletes nothing", async () => {
+    const nodeId = await seedNode("Home", 100);
+    const bkOld = await buildKey(APP, 1);
+    const bkNew = await buildKey(APP, 2);
+    await nodeObs(nodeId, bkOld, "s-old", 100);
+    await nodeObs(nodeId, bkNew, "s-new", 100_000);
+    await repo.updateNodeScreenshotById(nodeId, "/tmp/x.webp");
+
+    const first = await retention().prune(1_000_000);
+    expect(first.nodeObservationsDeleted + first.buildKeysDeleted + first.screenshotsCleared)
+      .toBeGreaterThan(0);
+
+    removed.length = 0;
+    const second = await retention().prune(1_000_000);
+    expect(second).toMatchObject({
+      screenshotsCleared: 0,
+      nodeObservationsDeleted: 0,
+      edgeObservationsDeleted: 0,
+      buildKeysDeleted: 0,
+    });
+    expect(removed).toEqual([]);
+  });
+
+  test("no-ops cleanly on an empty database", async () => {
+    const summary = await retention().prune(1_000_000);
+    expect(summary).toMatchObject({
+      screenshotsCleared: 0,
+      nodeObservationsDeleted: 0,
+      edgeObservationsDeleted: 0,
+      buildKeysDeleted: 0,
+    });
+  });
+});

--- a/test/db/navigationRetention.test.ts
+++ b/test/db/navigationRetention.test.ts
@@ -8,11 +8,15 @@ import {
   resolveNavigationRetentionConfig,
   resolveNavigationRetentionIntervalMs,
   computeProtectedBuildKeyIds,
+  computeActiveObservationIds,
   DEFAULT_SCREENSHOT_TTL_MS,
   DEFAULT_STRUCTURE_TTL_MS,
   DEFAULT_PER_APP_MAX_OBSERVATIONS,
   DEFAULT_GLOBAL_MAX_OBSERVATIONS,
   DEFAULT_NAV_RETENTION_INTERVAL_MS,
+  DEFAULT_EVICTION_CHUNK_SIZE,
+  MAX_EVICTION_CHUNK_SIZE,
+  MAX_INTERVAL_MS,
 } from "../../src/db/navigationRetention";
 
 const APP = "com.example.app";
@@ -107,6 +111,24 @@ describe("navigationRetention config", () => {
     );
     // A valid override still wins.
     expect(resolveNavigationRetentionConfig({ perAppMaxObservations: 7 }).perAppMaxObservations).toBe(7);
+  });
+
+  test("rejects an interval above the Int32 setInterval ceiling (would clamp to 1ms)", () => {
+    process.env.AUTOMOBILE_NAV_RETENTION_INTERVAL_MS = String(MAX_INTERVAL_MS + 1);
+    expect(resolveNavigationRetentionIntervalMs()).toBe(DEFAULT_NAV_RETENTION_INTERVAL_MS);
+    expect(resolveNavigationRetentionIntervalMs(3_000_000_000)).toBe(DEFAULT_NAV_RETENTION_INTERVAL_MS);
+    // A large-but-in-range interval is honored.
+    expect(resolveNavigationRetentionIntervalMs(MAX_INTERVAL_MS)).toBe(MAX_INTERVAL_MS);
+  });
+
+  test("clamps evictionChunkSize to the safe batch ceiling (env and override)", () => {
+    expect(resolveNavigationRetentionConfig({ evictionChunkSize: 300_000 }).evictionChunkSize).toBe(
+      MAX_EVICTION_CHUNK_SIZE
+    );
+    expect(resolveNavigationRetentionConfig({ evictionChunkSize: 2 }).evictionChunkSize).toBe(2);
+    expect(resolveNavigationRetentionConfig().evictionChunkSize).toBe(DEFAULT_EVICTION_CHUNK_SIZE);
+    process.env.AUTOMOBILE_NAV_RETENTION_EVICTION_CHUNK_SIZE = "999999";
+    expect(resolveNavigationRetentionConfig().evictionChunkSize).toBe(MAX_EVICTION_CHUNK_SIZE);
   });
 });
 
@@ -219,6 +241,25 @@ describe("NavigationRetention prune", () => {
     expect(removed).toEqual([]);
     const node = await repo.getNodeById(APP, nodeId);
     expect(node?.screenshot_path).toBe("/tmp/shot-home.webp");
+  });
+
+  test("clears stale screenshots in bounded batches (oversized UPDATE cannot form)", async () => {
+    // Node cardinality is not bounded by the observation caps, so the stale-
+    // screenshot UPDATE must batch. chunkSize 2 forces several UPDATEs of <= 2 ids.
+    await repo.getOrCreateApp(APP);
+    const paths: string[] = [];
+    for (let i = 0; i < 5; i++) {
+      const node = await repo.getOrCreateNode(APP, `S${i}`, 100);
+      await repo.updateNodeScreenshotById(node.id, `/tmp/shot-${i}.webp`);
+      paths.push(`/tmp/shot-${i}.webp`);
+    }
+
+    const summary = await retention({ ...CONFIG, evictionChunkSize: 2 }).prune(10_000);
+
+    expect(summary.screenshotsCleared).toBe(5);
+    expect(removed.sort()).toEqual(paths.sort());
+    const remaining = await db.selectFrom("navigation_nodes").select("screenshot_path").execute();
+    expect(remaining.every(r => r.screenshot_path === null)).toBe(true);
   });
 
   test("keeps a recent screenshot (within short TTL)", async () => {
@@ -443,5 +484,51 @@ describe("NavigationRetention prune", () => {
       edgeObservationsDeleted: 0,
       buildKeysDeleted: 0,
     });
+  });
+});
+
+describe("computeActiveObservationIds at scale", () => {
+  let db: Kysely<Database>;
+
+  beforeEach(async () => {
+    db = await createTestDatabase();
+  });
+  afterEach(async () => {
+    await db.destroy();
+  });
+
+  test("handles >1000 protected build keys with one relational query (no OR-depth blowup)", async () => {
+    // A per-row `(build_key_id=? AND last_seen_at=?) OR …` chain would exceed
+    // SQLite's expression-tree depth (~1000) here and throw; the relational
+    // max-join form must not. Bulk-insert stays well under MAX_VARIABLE_NUMBER.
+    const N = 1_200;
+    const buildKeyRows = Array.from({ length: N }, (_, i) => ({
+      app_id: `app.${i}`,
+      version_code: 1,
+      content_hash: `h${i}`,
+    }));
+    await db.insertInto("navigation_build_keys").values(buildKeyRows).execute();
+
+    const bks = await db
+      .selectFrom("navigation_build_keys")
+      .select("id")
+      .orderBy("id", "asc")
+      .execute();
+    const obsRows = bks.map((bk, i) => ({
+      node_id: i + 1,
+      build_key_id: bk.id,
+      device_id: "d",
+      session_uuid: "s",
+      first_seen_at: 100,
+      last_seen_at: 100,
+    }));
+    await db.insertInto("navigation_node_observations").values(obsRows).execute();
+
+    const protectedIds = bks.map(b => b.id);
+    const active = await computeActiveObservationIds(db, protectedIds);
+
+    // One active (max-last_seen) node observation per protected build key.
+    expect(active.nodeIds.length).toBe(N);
+    expect(active.edgeIds.length).toBe(0);
   });
 });

--- a/test/db/navigationRetention.test.ts
+++ b/test/db/navigationRetention.test.ts
@@ -6,11 +6,13 @@ import { NavigationRepository } from "../../src/db/navigationRepository";
 import {
   NavigationRetention,
   resolveNavigationRetentionConfig,
+  resolveNavigationRetentionIntervalMs,
   computeProtectedBuildKeyIds,
   DEFAULT_SCREENSHOT_TTL_MS,
   DEFAULT_STRUCTURE_TTL_MS,
   DEFAULT_PER_APP_MAX_OBSERVATIONS,
   DEFAULT_GLOBAL_MAX_OBSERVATIONS,
+  DEFAULT_NAV_RETENTION_INTERVAL_MS,
 } from "../../src/db/navigationRetention";
 
 const APP = "com.example.app";
@@ -31,6 +33,8 @@ describe("navigationRetention config", () => {
     "AUTOMOBILE_NAV_RETENTION_STRUCTURE_TTL_MS",
     "AUTOMOBILE_NAV_RETENTION_PER_APP_MAX_OBSERVATIONS",
     "AUTOMOBILE_NAV_RETENTION_GLOBAL_MAX_OBSERVATIONS",
+    "AUTOMOBILE_NAV_RETENTION_EVICTION_CHUNK_SIZE",
+    "AUTOMOBILE_NAV_RETENTION_INTERVAL_MS",
   ];
   const saved: Record<string, string | undefined> = {};
 
@@ -76,6 +80,33 @@ describe("navigationRetention config", () => {
     expect(resolveNavigationRetentionConfig().perAppMaxObservations).toBe(
       DEFAULT_PER_APP_MAX_OBSERVATIONS
     );
+  });
+
+  test("rejects partial-parse env values (strict full-string integer)", () => {
+    // Number.parseInt would accept these as 1 / 12 — strict validation must not.
+    process.env.AUTOMOBILE_NAV_RETENTION_STRUCTURE_TTL_MS = "1e6";
+    expect(resolveNavigationRetentionConfig().structureTtlMs).toBe(DEFAULT_STRUCTURE_TTL_MS);
+    process.env.AUTOMOBILE_NAV_RETENTION_STRUCTURE_TTL_MS = "12abc";
+    expect(resolveNavigationRetentionConfig().structureTtlMs).toBe(DEFAULT_STRUCTURE_TTL_MS);
+    process.env.AUTOMOBILE_NAV_RETENTION_INTERVAL_MS = "1e6";
+    expect(resolveNavigationRetentionIntervalMs()).toBe(DEFAULT_NAV_RETENTION_INTERVAL_MS);
+  });
+
+  test("rejects invalid EXPLICIT overrides (0 / negative / NaN / float) -> default", () => {
+    expect(resolveNavigationRetentionConfig({ perAppMaxObservations: 0 }).perAppMaxObservations).toBe(
+      DEFAULT_PER_APP_MAX_OBSERVATIONS
+    );
+    expect(
+      resolveNavigationRetentionConfig({ perAppMaxObservations: -3 }).perAppMaxObservations
+    ).toBe(DEFAULT_PER_APP_MAX_OBSERVATIONS);
+    expect(
+      resolveNavigationRetentionConfig({ globalMaxObservations: Number.NaN }).globalMaxObservations
+    ).toBe(DEFAULT_GLOBAL_MAX_OBSERVATIONS);
+    expect(resolveNavigationRetentionConfig({ structureTtlMs: 1.5 }).structureTtlMs).toBe(
+      DEFAULT_STRUCTURE_TTL_MS
+    );
+    // A valid override still wins.
+    expect(resolveNavigationRetentionConfig({ perAppMaxObservations: 7 }).perAppMaxObservations).toBe(7);
   });
 });
 
@@ -226,35 +257,110 @@ describe("NavigationRetention prune", () => {
 
   // ---- LRU size cap (backstop) ----
 
-  test("per-app LRU cap evicts oldest evictable observations by last_seen", async () => {
+  test("per-app LRU cap evicts oldest observations by last_seen, keeps the active row", async () => {
     const nodeId = await seedNode("Home", 1);
     const bkOld = await buildKey(APP, 1);
     const bkNew = await buildKey(APP, 2);
-    await nodeObs(nodeId, bkNew, "protected", 10_000); // protected
-    // 5 evictable observations, recent (within TTL) so only the cap can evict them.
+    await nodeObs(nodeId, bkNew, "active", 10_000); // newest -> active, protected build
     for (let i = 0; i < 5; i++) {
       await nodeObs(nodeId, bkOld, `s${i}`, 1_000 + i);
     }
 
     // structureTtl huge so only the cap can evict (isolates the LRU backstop).
+    // Cap counts ALL 6 rows; overflow 4 evicts the 4 oldest; the active row and
+    // the newest evictable row survive.
     const summary = await retention({
       ...CONFIG,
       structureTtlMs: 10_000_000,
       perAppMaxObservations: 2,
     }).prune(11_000);
 
-    // 5 evictable - cap 2 = 3 oldest evicted; protected untouched.
-    expect(summary.nodeObservationsDeleted).toBe(3);
+    expect(summary.nodeObservationsDeleted).toBe(4);
     const remaining = await db
       .selectFrom("navigation_node_observations")
       .select(["session_uuid", "last_seen_at"])
       .orderBy("last_seen_at", "asc")
       .execute();
     const sessions = remaining.map(r => r.session_uuid).sort();
-    expect(sessions).toEqual(["protected", "s3", "s4"]); // oldest s0,s1,s2 gone
+    expect(sessions).toEqual(["active", "s4"]); // oldest s0..s3 gone; newest kept
   });
 
-  test("global LRU cap evicts oldest across apps, sparing protected builds", async () => {
+  test("cap bounds a continuously-used SINGLE-build app, keeping the most recent", async () => {
+    // Regression: the cap must bound an app whose only build key is the protected
+    // one — otherwise a single-build app grows unbounded until the long TTL.
+    const nodeId = await seedNode("Home", 1);
+    const bk = await buildKey(APP, 1); // the ONLY build key => it is the protected one
+    for (let i = 0; i < 6; i++) {
+      await nodeObs(nodeId, bk, `s${i}`, 100 + i);
+    }
+
+    const summary = await retention({
+      ...CONFIG,
+      structureTtlMs: 10_000_000,
+      perAppMaxObservations: 3,
+    }).prune(1_000_000);
+
+    // total 6, cap 3 -> evict 3 oldest; the 3 newest (incl active s5) survive.
+    expect(summary.nodeObservationsDeleted).toBe(3);
+    const remaining = await db
+      .selectFrom("navigation_node_observations")
+      .select("session_uuid")
+      .execute();
+    expect(remaining.map(r => r.session_uuid).sort()).toEqual(["s3", "s4", "s5"]);
+    // (c) the protected build key is never orphan-swept even after thinning.
+    const keys = await db.selectFrom("navigation_build_keys").select("id").execute();
+    expect(keys.map(k => k.id)).toEqual([bk]);
+  });
+
+  test("never evicts the active row even under an aggressive cap", async () => {
+    const nodeId = await seedNode("Home", 1);
+    const bk = await buildKey(APP, 1);
+    await nodeObs(nodeId, bk, "old1", 100);
+    await nodeObs(nodeId, bk, "old2", 200);
+    await nodeObs(nodeId, bk, "active", 300); // newest -> active
+
+    // total 3, cap 1 -> overflow 2 evicts old1/old2; the active row is shielded
+    // even though the app still exceeds the cap afterward.
+    const summary = await retention({
+      ...CONFIG,
+      structureTtlMs: 10_000_000,
+      perAppMaxObservations: 1,
+    }).prune(1_000_000);
+
+    expect(summary.nodeObservationsDeleted).toBe(2);
+    const remaining = await db
+      .selectFrom("navigation_node_observations")
+      .select("session_uuid")
+      .execute();
+    expect(remaining.map(r => r.session_uuid)).toEqual(["active"]);
+  });
+
+  test("evicts in bounded batches (chunk loop) without missing rows", async () => {
+    const nodeId = await seedNode("Home", 1);
+    const bk = await buildKey(APP, 1);
+    for (let i = 0; i < 7; i++) {
+      await nodeObs(nodeId, bk, `s${i}`, 100 + i);
+    }
+
+    // chunkSize 2 forces several batches; each DELETE binds <= 2 ids. cap 1 ->
+    // evict 6 oldest, keep the active row (s6). Proves the loop deletes the full
+    // victim set without exceeding the per-statement variable limit.
+    const summary = await retention({
+      ...CONFIG,
+      structureTtlMs: 10_000_000,
+      perAppMaxObservations: 1,
+      evictionChunkSize: 2,
+    }).prune(1_000_000);
+
+    expect(summary.nodeObservationsDeleted).toBe(6);
+    const remaining = await db
+      .selectFrom("navigation_node_observations")
+      .select("session_uuid")
+      .execute();
+    expect(remaining.map(r => r.session_uuid)).toEqual(["s6"]);
+  });
+
+  test("global LRU cap evicts oldest across apps, sparing each app's active build", async () => {
     // App 1
     const n1 = await seedNode("A", 1);
     const bk1old = await buildKey(APP, 1);
@@ -270,21 +376,23 @@ describe("NavigationRetention prune", () => {
     await repo.recordNodeObservation(n2.id, bk2new, "d", "p2", 9_500);
     await repo.recordNodeObservation(n2.id, bk2old, "d", "b-200", 200);
 
-    // 3 evictable rows total (a-100, a-300, b-200); global cap 2 -> evict 1 oldest (a-100).
+    // total 5; global cap 2 -> overflow 3 evicts the 3 oldest non-active rows
+    // (a-100, b-200, a-300). Each app's active build (p1, p2) is shielded even
+    // though p1 is globally older than app 2's p2.
     const summary = await retention({
       ...CONFIG,
-      structureTtlMs: 10_000_000, // isolate the global cap from the TTL tier
+      structureTtlMs: 10_000_000,
       perAppMaxObservations: 1_000,
       globalMaxObservations: 2,
     }).prune(10_000);
 
-    expect(summary.nodeObservationsDeleted).toBe(1);
+    expect(summary.nodeObservationsDeleted).toBe(3);
     const rows = await db
       .selectFrom("navigation_node_observations")
       .select("session_uuid")
       .execute();
     const sessions = rows.map(r => r.session_uuid).sort();
-    expect(sessions).toEqual(["a-300", "b-200", "p1", "p2"]);
+    expect(sessions).toEqual(["p1", "p2"]);
   });
 
   // ---- FK-safe orphan build-key cleanup + idempotency ----

--- a/test/db/navigationRetention.test.ts
+++ b/test/db/navigationRetention.test.ts
@@ -8,7 +8,7 @@ import {
   resolveNavigationRetentionConfig,
   resolveNavigationRetentionIntervalMs,
   computeProtectedBuildKeyIds,
-  computeActiveObservationIds,
+  buildOldestNodeEvictableQuery,
   DEFAULT_SCREENSHOT_TTL_MS,
   DEFAULT_STRUCTURE_TTL_MS,
   DEFAULT_PER_APP_MAX_OBSERVATIONS,
@@ -487,48 +487,60 @@ describe("NavigationRetention prune", () => {
   });
 });
 
-describe("computeActiveObservationIds at scale", () => {
+describe("eviction active-row exclusion is relational (bounded bind params)", () => {
   let db: Kysely<Database>;
 
   beforeEach(async () => {
-    db = await createTestDatabase();
+    db = await createTestDatabase({ foreignKeys: true });
   });
   afterEach(async () => {
     await db.destroy();
   });
 
-  test("handles >1000 protected build keys with one relational query (no OR-depth blowup)", async () => {
-    // A per-row `(build_key_id=? AND last_seen_at=?) OR …` chain would exceed
-    // SQLite's expression-tree depth (~1000) here and throw; the relational
-    // max-join form must not. Bulk-insert stays well under MAX_VARIABLE_NUMBER.
-    const N = 1_200;
-    const buildKeyRows = Array.from({ length: N }, (_, i) => ({
-      app_id: `app.${i}`,
-      version_code: 1,
-      content_hash: `h${i}`,
-    }));
-    await db.insertInto("navigation_build_keys").values(buildKeyRows).execute();
+  test("the oldest-evictable query binds O(protected apps), not O(active rows)", () => {
+    // Compile the actual eviction-selection query. Its bound parameters must be
+    // just the app scope + the protected id list + limit — NEVER one param per
+    // active/observation row (which a `NOT IN (activeIds)` list would produce and
+    // could exceed bun:sqlite's MAX_VARIABLE_NUMBER of 250_000).
+    const protectedIds = [1, 2, 3, 4, 5];
+    const compiled = buildOldestNodeEvictableQuery(db, "com.example.app", protectedIds, 100).compile();
+    // app id (1) + protectedIds (5) + limit (1) = 7; the correlated max subquery
+    // and the app-scope subquery bind no per-row params.
+    expect(compiled.parameters.length).toBe(protectedIds.length + 2);
+    // Bind shape does not depend on active-row count: a larger protected set grows
+    // the param count by exactly its own size, nothing more.
+    const bigger = buildOldestNodeEvictableQuery(db, "com.example.app", [1, 2, 3, 4, 5, 6, 7], 100).compile();
+    expect(bigger.parameters.length).toBe(7 + 2);
+  });
 
-    const bks = await db
-      .selectFrom("navigation_build_keys")
-      .select("id")
-      .orderBy("id", "asc")
+  test("never evicts active rows even when MANY tie at the build key's max last_seen", async () => {
+    const repo = new NavigationRepository(db);
+    await repo.getOrCreateApp(APP);
+    const node = await repo.getOrCreateNode(APP, "Home", 1);
+    const bk = await repo.getOrCreateBuildKey(APP, 1, "h"); // only build key -> protected
+
+    // 300 observations all tied at the max instant (all "active") + 5 older rows.
+    for (let i = 0; i < 300; i++) {
+      await repo.recordNodeObservation(node.id, bk.id, "d", `active-${i}`, 10_000);
+    }
+    for (let i = 0; i < 5; i++) {
+      await repo.recordNodeObservation(node.id, bk.id, "d", `old-${i}`, 1_000 + i);
+    }
+
+    // Aggressive cap; structure TTL huge so only the cap acts. All 300 tied-max
+    // rows are active and must survive; the 5 older rows are evicted.
+    const summary = await new NavigationRetention(db, {
+      ...CONFIG,
+      structureTtlMs: 10_000_000,
+      perAppMaxObservations: 1,
+    }).prune(1_000_000);
+
+    expect(summary.nodeObservationsDeleted).toBe(5);
+    const survivors = await db
+      .selectFrom("navigation_node_observations")
+      .select(["session_uuid", "last_seen_at"])
       .execute();
-    const obsRows = bks.map((bk, i) => ({
-      node_id: i + 1,
-      build_key_id: bk.id,
-      device_id: "d",
-      session_uuid: "s",
-      first_seen_at: 100,
-      last_seen_at: 100,
-    }));
-    await db.insertInto("navigation_node_observations").values(obsRows).execute();
-
-    const protectedIds = bks.map(b => b.id);
-    const active = await computeActiveObservationIds(db, protectedIds);
-
-    // One active (max-last_seen) node observation per protected build key.
-    expect(active.nodeIds.length).toBe(N);
-    expect(active.edgeIds.length).toBe(0);
+    expect(survivors.length).toBe(300);
+    expect(survivors.every(r => r.last_seen_at === 10_000)).toBe(true);
   });
 });


### PR DESCRIPTION
Closes #4986

## Summary

Phase 3 of the `(app, build)` navigation model ([#4837](https://github.com/kaeawc/auto-mobile/issues/4837)). Bounds the accumulated cross-build/device/session navigation data written by Phases 1/2 with a stateless, recency-based pruner (`NavigationRetention`) and a periodic background pass (`NavigationRetentionMonitor`) wired into the daemon lifecycle.

Everything is keyed on the same `last_seen_at` recency signal that already drives Phase 2's provenance fade. No schema/migration change was needed — retention is stateless (nothing to persist).

> [!IMPORTANT]
> **Hand-off merge.** This deletes persisted data on a public data surface. Please review the retention policy below and confirm the defaults before merging. I have **not** enabled auto-merge.

## Retention defaults — maintainer confirm

All values are conservative (nothing surprising should be deleted) and overridable via env. Please confirm or adjust:

| Concern | Default | Env override |
| --- | --- | --- |
| SHORT TTL — node screenshots | **7 days** | `AUTOMOBILE_NAV_RETENTION_SCREENSHOT_TTL_MS` |
| LONG TTL — observation rows (provenance) | **90 days (~3 months)** | `AUTOMOBILE_NAV_RETENTION_STRUCTURE_TTL_MS` |
| Per-app observation cap (LRU backstop) | **50,000 rows** | `AUTOMOBILE_NAV_RETENTION_PER_APP_MAX_OBSERVATIONS` |
| Global observation cap (LRU backstop) | **500,000 rows** | `AUTOMOBILE_NAV_RETENTION_GLOBAL_MAX_OBSERVATIONS` |
| Background pass interval | **6 hours** | `AUTOMOBILE_NAV_RETENTION_INTERVAL_MS` |

Config resolution order: explicit override → env → default. Non-positive / non-numeric env values fall back to the default.

## Changes

**Tiered TTL by weight (AC1):**
- **SHORT tier — heavy transient assets.** The only heavy asset the nav DB references is a node's `screenshot_path`. Stale screenshots have their pointer cleared and the file best-effort unlinked (via an injected remover); the light node row survives under the long tier.
- **LONG tier — structure + provenance.** The per-observation rows (`navigation_node_observations` / `navigation_edge_observations`) are the unbounded surface — one row per (build, device, session) per node/edge — so they are pruned by age, and build keys left orphaned by that prune are swept. `navigation_nodes` / `navigation_edges` are bounded (one per screen/transition) and durable, so they are intentionally **not** age-deleted — see "Scope decisions".

**Global LRU size cap (AC2):** a per-app budget **and** a global budget over the evictable observation rows; when over budget, the oldest rows by `last_seen_at` are evicted (per-app enforced first, then global). Only the amount over budget is fetched, so a pass never loads a whole table.

**Periodic / atomic / active-data safe (AC3):**
- `NavigationRetentionMonitor` runs the pass on a fixed interval (default 6h) with an overlap guard (a slow pass never stacks), `unref` (never keeps the process alive), and a swallow-and-log failure path. It is started in `Daemon.start()` and stopped in `Daemon.stop()` alongside the heartbeat monitor; its writes are tracked by the DB write barrier drained on shutdown.
- The whole pass is **one transaction** (atomic, no torn graph). Observations are deleted **before** their now-orphaned build keys (**FK-safe** order — proven under `foreign_keys = ON`). Screenshot-file unlinks run **after** commit so a slow/failed unlink can never hold the daemon's single connection.
- **Active-data protection:** the most-recently-seen build key per app (argmax `last_seen_at`, tie-broken by newest id) is treated as the active context and is **never** pruned by any tier. Because in-flight writes land on the current build key — which carries the newest `last_seen_at` — this protects whatever is being observed right now without a separate liveness signal.

**Configurable defaults (AC4):** see the table above.

## Scope decisions (please sanity-check)

- **Structural nodes/edges are kept, not age-deleted.** The accumulating surface is the observation rows (unbounded in build×device×session); nodes/edges are bounded and durable, and deleting a node whose `screen_name` is still an edge endpoint would tear the graph (edges reference screens by text, not FK). Keeping them is the conservative choice and satisfies "structure = light + durable + long TTL" in practice. Happy to add guarded structural pruning as a follow-up if you want it.
- **AC5 (desktop storage indicator) is deferred.** The pruner already produces a per-pass `NavigationRetentionSummary` and the monitor exposes `getLastSummary()`, so the data is available; the desktop wiring is not in this PR. Can spin off a follow-up.

## Testing

- `test/db/navigationRetention.test.ts` (14 tests): config defaults/env/override precedence + validation; SHORT-tier screenshot clear + protected/recent keep; LONG-tier node+edge TTL prune; per-app and global LRU eviction of oldest; **active/most-recent build never pruned even when all data is past TTL**; `computeProtectedBuildKeyIds` argmax-by-recency; FK-safe orphan build-key sweep (`foreign_keys = ON`); idempotency (second pass at same clock deletes nothing); empty-DB no-op.
- `test/daemon/NavigationRetentionMonitor.test.ts` (4 tests): FakeTimer-driven cadence using the injected clock; `stop()` halts; overlap guard drops in-flight ticks; failing pass swallowed and recovers.
- All TTL expiry is driven by an injected fake clock (explicit `now` / FakeTimer) — no real waits. In-memory DB via `createTestDatabase()` — never the real file-backed `getDatabase()`.
- Full suite green (`bun test`: 13137 pass, 0 fail), `bun run typecheck` (no new errors), `bun run lint` (no new violations), `bun run build`.

## Acceptance criteria

- [x] AC1 — tiered TTL by weight (screenshots SHORT, structure/provenance LONG)
- [x] AC2 — per-app + global LRU size cap, evicting oldest by `last_seen_at`
- [x] AC3 — periodic background pass, atomic/FK-safe, never deletes active/most-recent-build data
- [x] AC4 — configurable defaults (stated above)
- [ ] AC5 — desktop storage indicator (deferred; summary data is exposed for it)
- [x] AC6 — unit-tested with fake clock + in-memory DB; correctness + budget enforcement covered
