### PR TITLE
fix(android): read AVD architecture without launching emulator

### DIFF
--- a/src/utils/android-cmdline-tools/AndroidEmulatorClient.ts
+++ b/src/utils/android-cmdline-tools/AndroidEmulatorClient.ts
@@ -8,7 +8,7 @@ import { arch } from "os";
 import { detectAndroidCommandLineTools, getBestAndroidToolsLocation } from "./detection";
 import { defaultTimer, Timer } from "../SystemTimer";
 import { createGlobalPerformanceTracker } from "../PerformanceTracker";
-import type { AvdConfigReader } from "./AvdConfigReader";
+import type { AvdConfig, AvdConfigReader } from "./AvdConfigReader";
 import { FileAvdConfigReader, MIN_AVD_RAM_MB } from "./AvdConfigReader";
 import { WakeAndUnlock } from "../../features/action/WakeAndUnlock";
 import { DeviceLockStore } from "../../features/action/DeviceLockStore";
@@ -310,6 +310,7 @@ export class AndroidEmulatorClient implements AndroidEmulator {
   private modelNameCache = new Map<string, string>();
   private avdConfigReader: AvdConfigReader;
   private platform: NodeJS.Platform;
+  private hostArchitecture: string;
   private readonly launchTargetDeviceIds = new WeakMap<ChildProcess, string>();
   private readonly launchErrors = new WeakMap<ChildProcess, ActionableError>();
 
@@ -320,6 +321,8 @@ export class AndroidEmulatorClient implements AndroidEmulator {
    * @param timer - Timer for delays
    * @param adbFactory - Factory for creating AdbClient instances (for testing)
    * @param avdConfigReader - Reader for AVD config.ini files (for testing)
+   * @param platform - Host platform (for testing)
+   * @param hostArchitecture - Host CPU architecture (for testing)
    */
   constructor(
     execAsyncFn:
@@ -330,6 +333,7 @@ export class AndroidEmulatorClient implements AndroidEmulator {
     adbFactory: AdbClientFactory = defaultAdbClientFactory,
     avdConfigReader?: AvdConfigReader,
     platform: NodeJS.Platform = process.platform,
+    hostArchitecture: string = arch(),
   ) {
     this.execAsync = execAsyncFn || execAsync;
     this.spawnFn = spawnFn || spawn;
@@ -337,6 +341,7 @@ export class AndroidEmulatorClient implements AndroidEmulator {
     this.adbFactory = adbFactory;
     this.avdConfigReader = avdConfigReader ?? new FileAvdConfigReader();
     this.platform = platform;
+    this.hostArchitecture = hostArchitecture;
     // Only set a fallback emulator path here; proper detection happens lazily
     this.emulatorPath = this.getFallbackEmulatorPath();
   }
@@ -542,7 +547,7 @@ export class AndroidEmulatorClient implements AndroidEmulator {
    * @returns The host architecture string
    */
   private getHostArchitecture(): string {
-    return arch();
+    return this.hostArchitecture;
   }
 
   /**
@@ -550,7 +555,7 @@ export class AndroidEmulatorClient implements AndroidEmulator {
    * @param avdName - The AVD name to check
    * @returns Promise with compatibility result
    */
-  private async checkArchitectureCompatibility(avdName: string): Promise<{
+  private async checkArchitectureCompatibility(avdName: string, avdConfig?: AvdConfig | null): Promise<{
     compatible: boolean;
     hostArch: string;
     avdArch?: string;
@@ -559,22 +564,11 @@ export class AndroidEmulatorClient implements AndroidEmulator {
     const hostArch = this.getHostArchitecture();
 
     try {
-      // Get AVD config to determine its architecture
-      const result = await this.executeCommand(["-avd", avdName, "-verbose"], 3000);
-      const output = result.stdout + result.stderr;
-
-      // Look for architecture information in the output
-      let avdArch: string | undefined;
-
-      // Check for target architecture in verbose output
-      const archMatch = output.match(/Found AVD target architecture: (\w+)/);
-      if (archMatch) {
-        avdArch = archMatch[1];
-      }
-
-      // If we couldn't determine from verbose output, try to infer from common patterns
+      const config =
+        avdConfig === undefined ? await this.avdConfigReader.readConfig(avdName) : avdConfig;
+      const avdArch = config?.architecture;
       if (!avdArch) {
-        // This is a fallback - we'll let the actual emulator start attempt reveal the issue
+        // Missing config metadata is non-fatal; the launch attempt provides definitive diagnostics.
         return {
           compatible: true,
           hostArch,
@@ -701,8 +695,7 @@ export class AndroidEmulatorClient implements AndroidEmulator {
     );
   }
 
-  private async validateAvdMemory(avdName: string): Promise<void> {
-    const avdConfig = await this.avdConfigReader.readConfig(avdName);
+  private validateAvdMemory(avdName: string, avdConfig: AvdConfig | null): void {
     if (!avdConfig) {
       return;
     }
@@ -1339,11 +1332,12 @@ export class AndroidEmulatorClient implements AndroidEmulator {
       return null;
     }
 
-    await this.validateAvdMemory(avdName);
+    const avdConfig = await this.avdConfigReader.readConfig(avdName);
+    this.validateAvdMemory(avdName, avdConfig);
 
     // Check architecture compatibility before attempting to start
     perf.startOperation("architectureCheck");
-    const compatibility = await this.checkArchitectureCompatibility(avdName);
+    const compatibility = await this.checkArchitectureCompatibility(avdName, avdConfig);
     perf.endOperation("architectureCheck");
     if (!compatibility.compatible && compatibility.reason) {
       logger.error(`Architecture compatibility check failed: ${compatibility.reason}`);

--- a/src/utils/android-cmdline-tools/AndroidEmulatorClient.ts
+++ b/src/utils/android-cmdline-tools/AndroidEmulatorClient.ts
@@ -555,7 +555,10 @@ export class AndroidEmulatorClient implements AndroidEmulator {
    * @param avdName - The AVD name to check
    * @returns Promise with compatibility result
    */
-  private async checkArchitectureCompatibility(avdName: string, avdConfig?: AvdConfig | null): Promise<{
+  private async checkArchitectureCompatibility(
+    avdName: string,
+    avdConfig?: AvdConfig | null,
+  ): Promise<{
     compatible: boolean;
     hostArch: string;
     avdArch?: string;

--- a/src/utils/android-cmdline-tools/AvdConfigReader.ts
+++ b/src/utils/android-cmdline-tools/AvdConfigReader.ts
@@ -9,6 +9,8 @@ export const MIN_AVD_RAM_MB = 2048;
 export interface AvdConfig {
   apiLevel?: number;
   osVersion?: string;
+  /** System-image ABI used by the AVD. */
+  architecture?: string;
   screenWidth?: number;
   screenHeight?: number;
   screenDensity?: number;
@@ -138,6 +140,7 @@ export function parseAvdConfig(content: string): AvdConfig {
     ...parseRamSize(props),
     ...parseDeviceMetadata(props),
     ...parseApiMetadata(props),
+    ...parseArchitecture(props),
   };
 }
 
@@ -212,4 +215,15 @@ function parseApiMetadata(props: Map<string, string>): Pick<AvdConfig, "apiLevel
   if (!match) {return {};}
   const level = Number.parseInt(match[1], 10);
   return { apiLevel: level, osVersion: apiLevelToVersion(level) ?? String(level) };
+}
+
+function parseArchitecture(props: Map<string, string>): Pick<AvdConfig, "architecture"> {
+  const configuredAbi = props.get("abi.type");
+  if (configuredAbi) {
+    return { architecture: configuredAbi };
+  }
+
+  const imagePathSegments = props.get("image.sysdir.1")?.split(/[\\/]/).filter(Boolean);
+  const architecture = imagePathSegments?.at(-1);
+  return architecture ? { architecture } : {};
 }

--- a/src/utils/android-cmdline-tools/AvdConfigReader.ts
+++ b/src/utils/android-cmdline-tools/AvdConfigReader.ts
@@ -9,7 +9,7 @@ export const MIN_AVD_RAM_MB = 2048;
 export interface AvdConfig {
   apiLevel?: number;
   osVersion?: string;
-  /** System-image ABI used by the AVD. */
+  /** Normalized emulator CPU architecture used by the AVD. */
   architecture?: string;
   screenWidth?: number;
   screenHeight?: number;
@@ -218,12 +218,36 @@ function parseApiMetadata(props: Map<string, string>): Pick<AvdConfig, "apiLevel
 }
 
 function parseArchitecture(props: Map<string, string>): Pick<AvdConfig, "architecture"> {
-  const configuredAbi = props.get("abi.type");
-  if (configuredAbi) {
-    return { architecture: configuredAbi };
-  }
-
   const imagePathSegments = props.get("image.sysdir.1")?.split(/[\\/]/).filter(Boolean);
-  const architecture = imagePathSegments?.at(-1);
-  return architecture ? { architecture } : {};
+  const candidates = [
+    props.get("hw.cpu.arch"),
+    props.get("abi.type"),
+    imagePathSegments?.at(-1),
+  ];
+  for (const candidate of candidates) {
+    const architecture = normalizeArchitecture(candidate);
+    if (architecture) {
+      return { architecture };
+    }
+  }
+  return {};
+}
+
+function normalizeArchitecture(value: string | undefined): string | undefined {
+  switch (value?.trim().toLowerCase()) {
+    case "arm64":
+    case "arm64-v8a":
+    case "aarch64":
+      return "arm64";
+    case "arm":
+    case "armeabi":
+    case "armeabi-v7a":
+      return "arm";
+    case "x86":
+      return "x86";
+    case "x86_64":
+      return "x86_64";
+    default:
+      return undefined;
+  }
 }

--- a/test/utils/android-cmdline-tools/AndroidEmulatorClient-architectureCompatibility.test.ts
+++ b/test/utils/android-cmdline-tools/AndroidEmulatorClient-architectureCompatibility.test.ts
@@ -51,13 +51,13 @@ function createClient(config: AvdConfig | null, hostArchitecture: string) {
 
 describe("AndroidEmulatorClient architecture compatibility", () => {
   test("reads compatible AVD architecture from config without launching an emulator probe", async () => {
-    const { client, commandCalls, reader } = createClient({ architecture: "arm64-v8a" }, "arm64");
+    const { client, commandCalls, reader } = createClient({ architecture: "arm64" }, "arm64");
 
     const compatibility = await client.checkArchitectureCompatibility("Pixel_9");
 
     expect(compatibility.compatible).toBe(true);
     expect(compatibility.hostArch).toBe("arm64");
-    expect(compatibility.avdArch).toBe("arm64-v8a");
+    expect(compatibility.avdArch).toBe("arm64");
     expect(reader.readConfigCalls).toEqual(["Pixel_9"]);
     expect(commandCalls).toEqual([]);
   });

--- a/test/utils/android-cmdline-tools/AndroidEmulatorClient-architectureCompatibility.test.ts
+++ b/test/utils/android-cmdline-tools/AndroidEmulatorClient-architectureCompatibility.test.ts
@@ -1,0 +1,85 @@
+import { describe, expect, test } from "bun:test";
+import { AndroidEmulatorClient } from "../../../src/utils/android-cmdline-tools/AndroidEmulatorClient";
+import type { AvdConfig } from "../../../src/utils/android-cmdline-tools/AvdConfigReader";
+import type { ExecResult } from "../../../src/models";
+import { FakeAvdConfigReader } from "../../fakes/FakeAvdConfigReader";
+import { FakeTimer } from "../../fakes/FakeTimer";
+
+interface ArchitectureCompatibilityResult {
+  compatible: boolean;
+  hostArch: string;
+  avdArch?: string;
+  reason?: string;
+}
+
+interface ArchitectureCompatibilityClient {
+  checkArchitectureCompatibility(avdName: string): Promise<ArchitectureCompatibilityResult>;
+}
+
+const result = (): ExecResult => ({
+  stdout: "",
+  stderr: "",
+  toString: () => "",
+  trim: () => "",
+  includes: () => false,
+});
+
+function createClient(config: AvdConfig | null, hostArchitecture: string) {
+  const commandCalls: string[][] = [];
+  const reader = new FakeAvdConfigReader(config);
+  const client = new AndroidEmulatorClient(
+    async (_file, args) => {
+      commandCalls.push(args);
+      return result();
+    },
+    null,
+    new FakeTimer(),
+    undefined,
+    reader,
+    "linux",
+    hostArchitecture,
+  );
+  (client as unknown as { ensureEmulatorPath: () => Promise<string> }).ensureEmulatorPath =
+    async () => "emulator";
+
+  return {
+    client: client as unknown as ArchitectureCompatibilityClient,
+    commandCalls,
+    reader,
+  };
+}
+
+describe("AndroidEmulatorClient architecture compatibility", () => {
+  test("reads compatible AVD architecture from config without launching an emulator probe", async () => {
+    const { client, commandCalls, reader } = createClient({ architecture: "arm64-v8a" }, "arm64");
+
+    const compatibility = await client.checkArchitectureCompatibility("Pixel_9");
+
+    expect(compatibility.compatible).toBe(true);
+    expect(compatibility.hostArch).toBe("arm64");
+    expect(compatibility.avdArch).toBe("arm64-v8a");
+    expect(reader.readConfigCalls).toEqual(["Pixel_9"]);
+    expect(commandCalls).toEqual([]);
+  });
+
+  test("rejects an incompatible configured architecture without spawning a probe", async () => {
+    const { client, commandCalls } = createClient({ architecture: "x86_64" }, "arm64");
+
+    const compatibility = await client.checkArchitectureCompatibility("Pixel_9");
+
+    expect(compatibility.compatible).toBe(false);
+    expect(compatibility.reason).toContain("x86_64");
+    expect(commandCalls).toEqual([]);
+  });
+
+  test("allows launch when config architecture is unavailable without spawning a probe", async () => {
+    const { client, commandCalls, reader } = createClient(null, "arm64");
+
+    const compatibility = await client.checkArchitectureCompatibility("Pixel_9");
+
+    expect(compatibility.compatible).toBe(true);
+    expect(compatibility.avdArch).toBeUndefined();
+    expect(reader.readConfigCalls).toEqual(["Pixel_9"]);
+    expect(commandCalls).toEqual([]);
+  });
+});

--- a/test/utils/android-cmdline-tools/AvdConfigReader.test.ts
+++ b/test/utils/android-cmdline-tools/AvdConfigReader.test.ts
@@ -22,12 +22,23 @@ describe("parseAvdConfig", () => {
     expect(config.osVersion).toBe("14");
   });
 
-  it("parses architecture from abi.type", () => {
+  it("prefers the emulator CPU architecture over conflicting ABI metadata", () => {
     const config = parseAvdConfig(
-      "abi.type=arm64-v8a\nimage.sysdir.1=system-images/android-34/google_apis/x86_64/",
+      [
+        "hw.cpu.arch=x86_64",
+        "abi.type=arm64-v8a",
+        "image.sysdir.1=system-images/android-34/google_apis/arm64-v8a/",
+      ].join("\n"),
     );
 
-    expect(config.architecture).toBe("arm64-v8a");
+    expect(config.architecture).toBe("x86_64");
+  });
+
+  it("normalizes supported ABI aliases when hw.cpu.arch is absent", () => {
+    expect(parseAvdConfig("abi.type=ARM64-V8A").architecture).toBe("arm64");
+    expect(parseAvdConfig("abi.type=aarch64").architecture).toBe("arm64");
+    expect(parseAvdConfig("abi.type=armeabi-v7a").architecture).toBe("arm");
+    expect(parseAvdConfig("abi.type=X86_64").architecture).toBe("x86_64");
   });
 
   it("falls back to image.sysdir.1 when abi.type is absent", () => {
@@ -36,6 +47,14 @@ describe("parseAvdConfig", () => {
     );
 
     expect(config.architecture).toBe("x86_64");
+  });
+
+  it("ignores malformed architecture metadata", () => {
+    const config = parseAvdConfig(
+      "hw.cpu.arch=unknown\nabi.type=also-unknown\nimage.sysdir.1=not/a/system/image/",
+    );
+
+    expect(config.architecture).toBeUndefined();
   });
 
   it("parses device name and tag", () => {
@@ -127,6 +146,7 @@ describe("parseAvdConfig", () => {
     const config = parseAvdConfig(content);
     expect(config.apiLevel).toBe(34);
     expect(config.osVersion).toBe("14");
+    expect(config.architecture).toBe("arm64");
     expect(config.screenWidth).toBe(1080);
     expect(config.screenHeight).toBe(2400);
     expect(config.screenDensity).toBe(420);

--- a/test/utils/android-cmdline-tools/AvdConfigReader.test.ts
+++ b/test/utils/android-cmdline-tools/AvdConfigReader.test.ts
@@ -22,6 +22,22 @@ describe("parseAvdConfig", () => {
     expect(config.osVersion).toBe("14");
   });
 
+  it("parses architecture from abi.type", () => {
+    const config = parseAvdConfig(
+      "abi.type=arm64-v8a\nimage.sysdir.1=system-images/android-34/google_apis/x86_64/",
+    );
+
+    expect(config.architecture).toBe("arm64-v8a");
+  });
+
+  it("falls back to image.sysdir.1 when abi.type is absent", () => {
+    const config = parseAvdConfig(
+      "image.sysdir.1=system-images/android-34/google_apis_playstore/x86_64/",
+    );
+
+    expect(config.architecture).toBe("x86_64");
+  });
+
   it("parses device name and tag", () => {
     const content = [
       "hw.device.name=pixel_6",


### PR DESCRIPTION
## Summary

Read an Android AVD's architecture from its existing `config.ini` metadata instead of launching `emulator -avd <name> -verbose` as a probe. This prevents architecture preflight from creating a QEMU lock that blocks the real launch, while preserving incompatible-architecture rejection and the existing fail-open behavior when metadata is unavailable.

## Linked Issue

Closes https://github.com/kaeawc/auto-mobile/issues/5202

## Bug / Regression Context

- **Prior attempts:** https://github.com/kaeawc/auto-mobile/pull/5210 preserved early launch diagnostics but intentionally retained duplicate-AVD handling; it did not remove the architecture probe.
- **Observed symptom:** On slower modern Play Store AVDs, the three-second `-verbose` probe was killed after creating an AVD lock. The real launch then exited with the duplicate-AVD FATAL and waited for readiness until the full boot timeout.
- **Repro steps / conditions:** Start a stopped modern Play Store AVD whose emulator does not print its target architecture within three seconds. The preflight process leaves a stale lock and the subsequent launch cannot acquire the AVD.

## Validation

- [x] `scripts/all_fast_validate_checks.sh` passes (33/33 checks)
- [x] `bun run turbo:validate`
- [x] `bun run typecheck` reports no new errors (185 known baseline errors)
- [x] Architecture and AVD-config acceptance tests pass (49 tests)
- [x] Android emulator-client tests pass (144 tests)
- [x] New code uses the existing `AvdConfigReader` interface, `FakeAvdConfigReader`, and `FakeTimer`; new unit tests complete in under 1ms each
- [x] Parsing uses built-in string/array operations; no dependency or generic helper was added
- [x] Rebased onto latest `origin/main`

## Follow-ups

None.
