### PR TITLE
fix(ios): shut down simulator after failed boot verification

### DIFF
--- a/src/utils/ios-cmdline-tools/SimCtlClient.ts
+++ b/src/utils/ios-cmdline-tools/SimCtlClient.ts
@@ -12,6 +12,7 @@ import { DEFAULT_DEVICE_READY_TIMEOUT_MS } from "../deviceTimeouts";
 import { PlistClient, type PlistReader } from "./PlistClient";
 import { isIosSimulatorUdid } from "./iosDeviceType";
 import { getAbortSignal } from "../AbortContext";
+import { Mutex } from "async-mutex";
 
 export interface AppleDevice {
   udid: string;
@@ -113,7 +114,7 @@ export interface SimCtl {
    * @param udid - Device UDID to start
    * @returns Promise that resolves when simulator is started
    */
-  startSimulator(udid: string, timeoutMs?: number): Promise<any>;
+  startSimulator(udid: string, timeoutMs?: number): Promise<ChildProcess>;
 
   /**
    * Kill a simulator
@@ -142,9 +143,10 @@ export interface SimCtl {
 
   /**
    * Get the list of available (booted and shutdown) simulator UDIDs
+   * @param timeoutMs - Optional timeout for simulator discovery
    * @returns Promise with an array of device info
    */
-  listSimulatorImages(): Promise<DeviceInfo[]>;
+  listSimulatorImages(timeoutMs?: number): Promise<DeviceInfo[]>;
 
   /**
    * Get the list of booted simulator UDIDs
@@ -264,7 +266,7 @@ export interface SimCtl {
    * With multiple simulators booted, this ensures the right device is visible.
    * @param udid - Optional device UDID to focus
    */
-  openSimulatorApp(udid?: string): Promise<void>;
+  openSimulatorApp(udid?: string, signal?: AbortSignal): Promise<void>;
 
   /**
    * Deliver a simulated remote push notification to a booted simulator.
@@ -483,6 +485,17 @@ export const DEFAULT_SIMCTL_BOOT_OPTIONS: SimCtlBootOptions = {
   retryBackoffMs: 2000,
 };
 
+interface SimulatorBootState {
+  mutex: Mutex;
+  lastBootSucceeded: boolean;
+  ownerToken: object | undefined;
+}
+
+interface SimulatorBootLease {
+  state: SimulatorBootState;
+  release(): void;
+}
+
 export class SimCtlClient implements SimCtl {
   device: BootedDevice | null;
   execAsync: (
@@ -508,6 +521,7 @@ export class SimCtlClient implements SimCtl {
   private static deviceListCache: { devices: DeviceInfo[]; timestamp: number } | null = null;
   private static readonly DEVICE_LIST_CACHE_TTL = 5000; // 5 seconds
   private static localSimctlAvailability: Promise<void> | null = null;
+  private static readonly simulatorBoots = new Map<string, SimulatorBootState>();
 
   /**
    * Create an IosUtils instance
@@ -765,9 +779,43 @@ export class SimCtlClient implements SimCtl {
     udid: string,
     timeoutMs: number = DEFAULT_DEVICE_READY_TIMEOUT_MS,
   ): Promise<ChildProcess> {
+    const deadlineMs = this.bootDeadline(timeoutMs);
+    const startSignal = getAbortSignal();
+    const lease = await this.acquireSimulatorBoot(udid, deadlineMs, startSignal);
+    try {
+      if (this.timer.now() >= deadlineMs) {
+        throw new Error(`Timed out waiting to start iOS simulator ${udid}`);
+      }
+      if (startSignal?.aborted) {
+        throw startSignal.reason ?? new ActionableError(`iOS simulator start aborted for ${udid}`);
+      }
+      if (lease.state.lastBootSucceeded) {
+        const simulatorStillBooted = (
+          await this.getBootedSimulatorsChecked(this.remainingBootTimeoutMs(deadlineMs))
+        ).some((simulator) => simulator.deviceId === udid);
+        if (simulatorStillBooted) {
+          throw new ActionableError(`iOS simulator ${udid} is already running`);
+        }
+        lease.state.lastBootSucceeded = false;
+        lease.state.ownerToken = undefined;
+      }
+      await this.startSimulatorExclusive(udid, deadlineMs, startSignal);
+      const ownerToken = {};
+      lease.state.lastBootSucceeded = true;
+      lease.state.ownerToken = ownerToken;
+      return this.createSimulatorHandle(udid, ownerToken);
+    } finally {
+      lease.release();
+    }
+  }
+
+  private async startSimulatorExclusive(
+    udid: string,
+    deadlineMs: number,
+    startSignal: AbortSignal | undefined,
+  ): Promise<void> {
     logger.debug(`Starting iOS simulator ${udid}`);
     const perf = createGlobalPerformanceTracker();
-    const startSignal = getAbortSignal();
 
     // `bootstatus -b` is idempotent: it boots shutdown simulators, accepts
     // already-booted simulators, and waits until CoreSimulator reports ready.
@@ -776,12 +824,7 @@ export class SimCtlClient implements SimCtl {
     // {@link bootAndVerify}.
     perf.startOperation("bootstatus");
     try {
-      await this.bootAndVerify(udid, this.bootDeadline(timeoutMs));
-    } catch (error) {
-      if (startSignal?.aborted) {
-        await this.shutdownAfterAbortedStart(udid);
-      }
-      throw error;
+      await this.runOwnedBoot(udid, () => this.bootAndVerify(udid, deadlineMs));
     } finally {
       perf.endOperation("bootstatus");
     }
@@ -789,17 +832,67 @@ export class SimCtlClient implements SimCtl {
     // Open Simulator.app focused on this specific device (no-op on headless hosts)
     try {
       perf.startOperation("openSimulatorApp");
-      await this.openSimulatorApp(udid);
+      await this.openSimulatorAppBeforeDeadline(udid, deadlineMs, startSignal);
       perf.endOperation("openSimulatorApp");
     } catch {
       perf.endOperation("openSimulatorApp");
       logger.debug("Could not open Simulator.app (non-fatal)");
     }
     if (startSignal?.aborted) {
-      await this.shutdownAfterAbortedStart(udid);
+      await this.shutdownAfterFailedStart(udid);
       throw startSignal.reason ?? new ActionableError(`iOS simulator start aborted for ${udid}`);
     }
+  }
 
+  private async openSimulatorAppBeforeDeadline(
+    udid: string,
+    deadlineMs: number,
+    signal: AbortSignal | undefined,
+  ): Promise<void> {
+    const remainingMs = this.remainingBootTimeoutMs(deadlineMs);
+    if (signal?.aborted) {
+      throw signal.reason ?? new ActionableError(`iOS simulator start aborted for ${udid}`);
+    }
+
+    let timeoutHandle: NodeJS.Timeout | undefined;
+    let abortListener: (() => void) | undefined;
+    const timeoutController = new AbortController();
+    const operationSignal = signal
+      ? AbortSignal.any([signal, timeoutController.signal])
+      : timeoutController.signal;
+    const timeout = new Promise<never>((_resolve, reject) => {
+      timeoutHandle = this.timer.setTimeout(() => {
+        timeoutController.abort();
+        reject(new Error(`Timed out opening Simulator.app for ${udid}`));
+      }, remainingMs);
+    });
+    const contenders: Array<Promise<void>> = [
+      this.openSimulatorApp(udid, operationSignal),
+      timeout,
+    ];
+    if (signal) {
+      contenders.push(
+        new Promise<never>((_resolve, reject) => {
+          abortListener = () =>
+            reject(signal.reason ?? new ActionableError(`iOS simulator start aborted for ${udid}`));
+          signal.addEventListener("abort", abortListener, { once: true });
+        }),
+      );
+    }
+
+    try {
+      await Promise.race(contenders);
+    } finally {
+      if (timeoutHandle) {
+        this.timer.clearTimeout(timeoutHandle);
+      }
+      if (signal && abortListener) {
+        signal.removeEventListener("abort", abortListener);
+      }
+    }
+  }
+
+  private createSimulatorHandle(udid: string, ownerToken: object): ChildProcess {
     // `simctl bootstatus -b` is synchronous, so there is no long-lived OS child
     // process to hand back. Rather than fabricate a mock handle whose `kill()` is
     // a no-op (issue #3938), return an honest handle: `pid` is undefined (no OS
@@ -812,9 +905,11 @@ export class SimCtlClient implements SimCtl {
       kill: (): boolean => {
         // Cancellation cleanup must not inherit an already-aborted request signal.
         const cleanupSignal = new AbortController().signal;
-        void this.executeCommandArgs(["shutdown", udid], 10_000, cleanupSignal).catch((error) => {
-          logger.debug(`[iOS] handle.kill() shutdown failed for ${udid}: ${error}`);
-        });
+        void this.shutdownSimulatorCoordinated(udid, 10_000, cleanupSignal, ownerToken).catch(
+          (error) => {
+            logger.debug(`[iOS] handle.kill() shutdown failed for ${udid}: ${error}`);
+          },
+        );
         return true;
       },
       killed: false,
@@ -827,19 +922,180 @@ export class SimCtlClient implements SimCtl {
     > as ChildProcess;
   }
 
-  private async shutdownAfterAbortedStart(udid: string): Promise<void> {
+  private async runOwnedBoot<T>(udid: string, operation: () => Promise<T>): Promise<T> {
+    try {
+      return await operation();
+    } catch (error) {
+      await this.shutdownAfterFailedStart(udid);
+      throw error;
+    }
+  }
+
+  private async runCoordinatedBoot<T>(
+    udid: string,
+    deadlineMs: number,
+    signal: AbortSignal | undefined,
+    ownsBoot: boolean,
+    operation: () => Promise<T>,
+    adoptPriorSuccess?: () => Promise<T>,
+  ): Promise<T> {
+    const lease = await this.acquireSimulatorBoot(udid, deadlineMs, signal);
+    const priorBootSucceeded = lease.state.lastBootSucceeded;
+    if (!priorBootSucceeded) {
+      lease.state.lastBootSucceeded = false;
+    }
+    try {
+      if (this.timer.now() >= deadlineMs) {
+        throw new Error(`Timed out waiting to start iOS simulator ${udid}`);
+      }
+      if (signal?.aborted) {
+        throw signal.reason ?? new ActionableError(`iOS simulator start aborted for ${udid}`);
+      }
+      if (priorBootSucceeded && adoptPriorSuccess) {
+        const simulatorStillBooted = (
+          await this.getBootedSimulatorsChecked(this.remainingBootTimeoutMs(deadlineMs))
+        ).some((simulator) => simulator.deviceId === udid);
+        if (simulatorStillBooted) {
+          return await adoptPriorSuccess();
+        }
+        lease.state.lastBootSucceeded = false;
+        lease.state.ownerToken = undefined;
+      }
+      if (lease.state.lastBootSucceeded && ownsBoot) {
+        throw new ActionableError(`iOS simulator ${udid} is already running`);
+      }
+      const result = ownsBoot ? await this.runOwnedBoot(udid, operation) : await operation();
+      lease.state.lastBootSucceeded = true;
+      return result;
+    } finally {
+      lease.release();
+    }
+  }
+
+  private async acquireSimulatorBoot(
+    udid: string,
+    deadlineMs: number | undefined,
+    signal: AbortSignal | undefined,
+  ): Promise<SimulatorBootLease> {
+    if (signal?.aborted) {
+      throw signal.reason ?? new ActionableError(`iOS simulator start aborted for ${udid}`);
+    }
+
+    let state = SimCtlClient.simulatorBoots.get(udid);
+    if (!state) {
+      state = { mutex: new Mutex(), lastBootSucceeded: false, ownerToken: undefined };
+      SimCtlClient.simulatorBoots.set(udid, state);
+    }
+
+    let abandoned = false;
+    let acquiredRelease: (() => void) | undefined;
+    const acquirePromise = state.mutex.acquire().then((release) => {
+      acquiredRelease = release;
+      if (abandoned) {
+        acquiredRelease = undefined;
+        this.releaseSimulatorBoot(udid, state, release);
+      }
+      return release;
+    });
+
+    let timeoutHandle: NodeJS.Timeout | undefined;
+    let abortListener: (() => void) | undefined;
+    const contenders: Array<Promise<() => void>> = [acquirePromise];
+    if (deadlineMs !== undefined) {
+      const remainingMs = Math.max(0, deadlineMs - this.timer.now());
+      contenders.push(
+        new Promise<never>((_resolve, reject) => {
+          timeoutHandle = this.timer.setTimeout(
+            () => reject(new Error(`Timed out waiting to start iOS simulator ${udid}`)),
+            remainingMs,
+          );
+        }),
+      );
+    }
+    if (signal) {
+      contenders.push(
+        new Promise<never>((_resolve, reject) => {
+          abortListener = () =>
+            reject(signal.reason ?? new ActionableError(`iOS simulator start aborted for ${udid}`));
+          signal.addEventListener("abort", abortListener, { once: true });
+        }),
+      );
+    }
+
+    let acquired = false;
+    try {
+      const release = await Promise.race(contenders);
+      acquired = true;
+      acquiredRelease = undefined;
+      return {
+        state,
+        release: () => this.releaseSimulatorBoot(udid, state, release),
+      };
+    } finally {
+      abandoned = !acquired;
+      if (abandoned && acquiredRelease) {
+        const release = acquiredRelease;
+        acquiredRelease = undefined;
+        this.releaseSimulatorBoot(udid, state, release);
+      }
+      if (timeoutHandle) {
+        this.timer.clearTimeout(timeoutHandle);
+      }
+      if (signal && abortListener) {
+        signal.removeEventListener("abort", abortListener);
+      }
+    }
+  }
+
+  private releaseSimulatorBoot(udid: string, state: SimulatorBootState, release: () => void): void {
+    release();
+    if (
+      !state.lastBootSucceeded &&
+      !state.mutex.isLocked() &&
+      SimCtlClient.simulatorBoots.get(udid) === state
+    ) {
+      SimCtlClient.simulatorBoots.delete(udid);
+    }
+  }
+
+  private async shutdownAfterFailedStart(udid: string): Promise<void> {
     try {
       // Cleanup must not inherit the already-aborted request signal.
       const cleanupSignal = new AbortController().signal;
       await this.executeCommandArgs(["shutdown", udid], 10_000, cleanupSignal);
     } catch (error) {
-      logger.warn(`[iOS] Failed to shut down simulator ${udid} after aborted start: ${error}`);
+      logger.warn(`[iOS] Failed to shut down simulator ${udid} after unsuccessful start: ${error}`);
+    }
+  }
+
+  private async shutdownSimulatorCoordinated(
+    udid: string,
+    timeoutMs: number,
+    signal: AbortSignal | undefined,
+    expectedOwnerToken?: object,
+  ): Promise<void> {
+    // Waiting for an active boot must not consume the shutdown command's own
+    // timeout. The caller's abort signal bounds the queue wait; once acquired,
+    // simctl shutdown receives the complete timeout budget.
+    const lease = await this.acquireSimulatorBoot(udid, undefined, signal);
+    try {
+      if (
+        expectedOwnerToken !== undefined &&
+        (!lease.state.lastBootSucceeded || lease.state.ownerToken !== expectedOwnerToken)
+      ) {
+        return;
+      }
+      await this.executeCommandArgs(["shutdown", udid], timeoutMs, signal);
+      lease.state.lastBootSucceeded = false;
+      lease.state.ownerToken = undefined;
+    } finally {
+      lease.release();
     }
   }
 
   async killSimulator(device: BootedDevice): Promise<void> {
     logger.debug(`Killing iOS simulator ${device.deviceId}`);
-    await this.executeCommandArgs(["shutdown", device.deviceId]);
+    await this.shutdownSimulatorCoordinated(device.deviceId, 10_000, getAbortSignal());
   }
 
   async eraseSimulator(udid: string): Promise<void> {
@@ -860,18 +1116,22 @@ export class SimCtlClient implements SimCtl {
     // boot wait with its own independent timeout budget (issue #3938 follow-up),
     // so skip straight to metadata resolution.
     if (options?.assumeBooted) {
-      return this.resolveReadySimulator(udid);
+      const deadlineMs = this.bootDeadline(timeoutMs ?? DEFAULT_DEVICE_READY_TIMEOUT_MS);
+      return this.runCoordinatedBoot(udid, deadlineMs, getAbortSignal(), false, () =>
+        this.resolveReadySimulator(udid, this.remainingBootTimeoutMs(deadlineMs)),
+      );
     }
 
     // Use `simctl bootstatus -b` which blocks until the simulator is fully
     // booted (data migration complete, system app ready, springboard launched).
     // This is far more reliable than polling `simctl list devices` for state.
+    const deadlineMs = this.bootDeadline(timeoutMs ?? DEFAULT_DEVICE_READY_TIMEOUT_MS);
     perf.startOperation("bootstatus");
     try {
-      await this.bootAndVerify(
-        udid,
-        this.bootDeadline(timeoutMs ?? DEFAULT_DEVICE_READY_TIMEOUT_MS),
-      );
+      return await this.runCoordinatedBoot(udid, deadlineMs, getAbortSignal(), false, async () => {
+        await this.bootAndVerify(udid, deadlineMs);
+        return this.resolveReadySimulator(udid, this.remainingBootTimeoutMs(deadlineMs));
+      });
     } catch (error) {
       const message = error instanceof Error ? error.message : String(error);
       // "Invalid device" means the UDID doesn't exist at all
@@ -882,8 +1142,6 @@ export class SimCtlClient implements SimCtl {
     } finally {
       perf.endOperation("bootstatus");
     }
-
-    return this.resolveReadySimulator(udid);
   }
 
   /**
@@ -1086,10 +1344,12 @@ export class SimCtlClient implements SimCtl {
    * as a BootedDevice. Shared by the cold-boot (assumeBooted) and already-running
    * branches of {@link waitForSimulatorReady}.
    */
-  private async resolveReadySimulator(udid: string): Promise<BootedDevice> {
+  private async resolveReadySimulator(udid: string, timeoutMs?: number): Promise<BootedDevice> {
     const perf = createGlobalPerformanceTracker();
     perf.startOperation("deviceLookup");
-    const simulator = (await this.listSimulatorImages()).find((device) => device.deviceId === udid);
+    const simulator = (await this.listSimulatorImages(timeoutMs)).find(
+      (device) => device.deviceId === udid,
+    );
     perf.endOperation("deviceLookup");
 
     if (!simulator) {
@@ -1107,7 +1367,7 @@ export class SimCtlClient implements SimCtl {
    * Get the list of available (booted and shutdown) simulator UDIDs
    * @returns Promise with an array of device UDIDs
    */
-  async listSimulatorImages(): Promise<DeviceInfo[]> {
+  async listSimulatorImages(timeoutMs?: number): Promise<DeviceInfo[]> {
     // Check cache first
     if (SimCtlClient.deviceListCache) {
       const cacheAge = this.timer.now() - SimCtlClient.deviceListCache.timestamp;
@@ -1120,7 +1380,7 @@ export class SimCtlClient implements SimCtl {
     logger.debug("Getting list of iOS simulators");
 
     try {
-      const simulatorList = await this.listSimulators();
+      const simulatorList = await this.listSimulators(timeoutMs);
       const devices: DeviceInfo[] = [];
 
       // Extract all devices from all runtime versions
@@ -1254,11 +1514,30 @@ export class SimCtlClient implements SimCtl {
     // shown up in the booted list -- neither a wait nor a proof of readiness.
     const deadlineMs = this.bootDeadline(DEFAULT_DEVICE_READY_TIMEOUT_MS);
     perf.startOperation("simctlBoot");
-    await this.bootAndVerify(udid, deadlineMs);
-    perf.endOperation("simctlBoot");
+    return this.runCoordinatedBoot(
+      udid,
+      deadlineMs,
+      getAbortSignal(),
+      true,
+      async () => {
+        await this.bootAndVerify(udid, deadlineMs);
+        perf.endOperation("simctlBoot");
+        return this.resolveRegisteredBootSimulator(udid, deadlineMs, perf);
+      },
+      () => {
+        perf.endOperation("simctlBoot");
+        return this.resolveRegisteredBootSimulator(udid, deadlineMs, perf);
+      },
+    );
+  }
 
+  private async resolveRegisteredBootSimulator(
+    udid: string,
+    deadlineMs: number,
+    perf: ReturnType<typeof createGlobalPerformanceTracker>,
+  ): Promise<BootedDevice> {
     perf.startOperation("bootRegistration");
-    const bootedSimulators = await this.getBootedSimulators(
+    const bootedSimulators = await this.getBootedSimulatorsChecked(
       this.remainingBootTimeoutMs(deadlineMs),
     );
     const bootedSimulator = bootedSimulators.find((device) => device.deviceId === udid);
@@ -1575,25 +1854,33 @@ export class SimCtlClient implements SimCtl {
     }
   }
 
-  async openSimulatorApp(udid?: string): Promise<void> {
+  async openSimulatorApp(udid?: string, signal?: AbortSignal): Promise<void> {
     // On a headless macOS host (no Aqua GUI session, e.g. a launchd daemon or
     // SSH context) `open -a Simulator` fails with OSLaunchdErrorDomain Code=125
     // after a slow retry, wasting wall-clock against the daemon-start budget.
     // The booted simulator + CtrlProxy work without the GUI, so skip the launch.
-    if (await this.isHeadlessSession()) {
+    if (await this.isHeadlessSession(signal)) {
       logger.debug("Skipping open -a Simulator: headless session (no Aqua GUI)");
       return;
     }
 
     // Ensure Simulator.app is open (creates windows for all booted devices)
-    await this.execAsync("open", ["-a", "Simulator"]);
+    await this.execAsync("open", ["-a", "Simulator"], undefined, signal);
     // If a specific device is requested, focus it by switching to it
     // --args -CurrentDeviceUDID only works on fresh launch; for already-running
     // Simulator, we activate the app which brings all device windows forward
     if (udid) {
       try {
-        await this.execAsync("osascript", ["-e", 'tell application "Simulator" to activate']);
+        await this.execAsync(
+          "osascript",
+          ["-e", 'tell application "Simulator" to activate'],
+          undefined,
+          signal,
+        );
       } catch (error) {
+        if (signal?.aborted) {
+          throw error;
+        }
         logger.debug(`[iOS] Could not activate Simulator.app for ${udid}: ${error}`);
       }
     }
@@ -1616,7 +1903,7 @@ export class SimCtlClient implements SimCtl {
    * If detection itself fails we assume a GUI session to preserve the prior
    * behavior. The result is cached so launchctl is probed at most once.
    */
-  private async isHeadlessSession(): Promise<boolean> {
+  private async isHeadlessSession(signal?: AbortSignal): Promise<boolean> {
     if (this.platform !== "darwin") {
       return true;
     }
@@ -1627,18 +1914,21 @@ export class SimCtlClient implements SimCtl {
     }
 
     if (this.headlessSessionCache === null) {
-      this.headlessSessionCache = await this.detectHeadlessSession();
+      this.headlessSessionCache = await this.detectHeadlessSession(signal);
     }
     return this.headlessSessionCache;
   }
 
-  private async detectHeadlessSession(): Promise<boolean> {
+  private async detectHeadlessSession(signal?: AbortSignal): Promise<boolean> {
     try {
-      const result = await this.execAsync("launchctl", ["managername"]);
+      const result = await this.execAsync("launchctl", ["managername"], undefined, signal);
       const managerName = (result.stdout || "").trim();
       // "Aqua" is the GUI login session manager; "System"/"Background" are not.
       return managerName !== "Aqua";
     } catch (error) {
+      if (signal?.aborted) {
+        throw error;
+      }
       // Can't determine the session type; assume a GUI session so we preserve
       // the historical behavior rather than silently suppressing the launch.
       logger.debug(`launchctl managername probe failed, assuming GUI session: ${error}`);

--- a/test/utils/ios-cmdline-tools/simctl-client.bootVerification.test.ts
+++ b/test/utils/ios-cmdline-tools/simctl-client.bootVerification.test.ts
@@ -1,4 +1,4 @@
-import { describe, expect, test } from "bun:test";
+import { beforeEach, describe, expect, test } from "bun:test";
 import {
   SimCtlClient,
   type SimCtlBootOptions,
@@ -7,8 +7,18 @@ import { createExecResult } from "../../../src/utils/execResult";
 import { FakeTimer } from "../../fakes/FakeTimer";
 import { ActionableError } from "../../../src/models";
 import { runWithAbortSignal } from "../../../src/utils/AbortContext";
+import { DEFAULT_DEVICE_READY_TIMEOUT_MS } from "../../../src/utils/deviceTimeouts";
 
 const UDID = "11111111-2222-3333-4444-555555555555";
+const OTHER_UDID = "AAAAAAAA-BBBB-CCCC-DDDD-EEEEEEEEEEEE";
+
+function resetSimctlState(): void {
+  const simctlClass = SimCtlClient as unknown as {
+    simulatorBoots: Map<string, unknown>;
+  };
+  simctlClass.simulatorBoots.clear();
+  SimCtlClient.invalidateDeviceListCache();
+}
 
 interface Harness {
   simctl: SimCtlClient;
@@ -134,7 +144,140 @@ function coreSimulator405Error(stderr: string = ALREADY_BOOTED_405): Error {
 const commandTimeouts = (harness: Harness, command: string): boolean[] =>
   harness.commandTimeouts.get(command) ?? [];
 
+interface ConcurrentStartHarness {
+  timer: FakeTimer;
+  lifecycleCalls: string[];
+  createClient(): SimCtlClient;
+  bootstatusInvocations(): number;
+  shutdownInvocations(): number;
+}
+
+function rejectWhenAborted(
+  signal: AbortSignal | undefined,
+  preserveReason = false,
+): Promise<never> {
+  return new Promise<never>((_resolve, reject) => {
+    signal?.addEventListener(
+      "abort",
+      () =>
+        reject(
+          preserveReason
+            ? (signal.reason ?? new Error("aborted"))
+            : Object.assign(new Error("aborted"), { name: "AbortError" }),
+        ),
+      { once: true },
+    );
+  });
+}
+
+function bootedSimulatorListResult() {
+  return createExecResult(
+    JSON.stringify({
+      devices: {
+        "com.apple.CoreSimulator.SimRuntime.iOS-26-0": [
+          { udid: UDID, name: "iPhone 17", state: "Booted", isAvailable: true },
+        ],
+      },
+    }),
+    "",
+  );
+}
+
+function createConcurrentStartHarness(
+  bootstatus: (
+    invocation: number,
+    signal: AbortSignal | undefined,
+  ) => Promise<ReturnType<typeof createExecResult>>,
+  listDevices: (
+    invocation: number,
+    signal: AbortSignal | undefined,
+  ) =>
+    | ReturnType<typeof createExecResult>
+    | Promise<ReturnType<typeof createExecResult>> = bootedSimulatorListResult,
+  options: {
+    openSimulatorApp?: (
+      signal: AbortSignal | undefined,
+    ) => Promise<ReturnType<typeof createExecResult>>;
+    shutdown?: (
+      invocation: number,
+      signal: AbortSignal | undefined,
+    ) => Promise<ReturnType<typeof createExecResult>>;
+  } = {},
+): ConcurrentStartHarness {
+  const timer = new FakeTimer();
+  const lifecycleCalls: string[] = [];
+  let bootstatusCount = 0;
+  let shutdownCount = 0;
+  let listDevicesCount = 0;
+  const execAsync = async (
+    file: string,
+    args: string[],
+    _maxBuffer?: number,
+    signal?: AbortSignal,
+  ) => {
+    const command = `${file} ${args.join(" ")}`;
+    if (command === "xcrun simctl --version") {
+      return createExecResult("", "");
+    }
+    if (command === `xcrun simctl bootstatus ${UDID} -b`) {
+      bootstatusCount++;
+      lifecycleCalls.push(`bootstatus-${bootstatusCount}`);
+      return bootstatus(bootstatusCount, signal);
+    }
+    if (command === `xcrun simctl shutdown ${UDID}`) {
+      shutdownCount++;
+      lifecycleCalls.push("shutdown");
+      return options.shutdown?.(shutdownCount, signal) ?? createExecResult("", "");
+    }
+    if (command === "xcrun simctl list devices --json") {
+      listDevicesCount++;
+      return listDevices(listDevicesCount, signal);
+    }
+    if (options.openSimulatorApp && command === "launchctl managername") {
+      return createExecResult("Aqua", "");
+    }
+    if (options.openSimulatorApp && command === "open -a Simulator") {
+      return options.openSimulatorApp(signal);
+    }
+    return createExecResult("", "");
+  };
+
+  return {
+    timer,
+    lifecycleCalls,
+    createClient: () =>
+      new SimCtlClient(null, execAsync, timer, "darwin", undefined, undefined, {
+        maxAttempts: 1,
+        retryBackoffMs: 0,
+      }),
+    bootstatusInvocations: () => bootstatusCount,
+    shutdownInvocations: () => shutdownCount,
+  };
+}
+
+async function drainMicrotasks(turns = 10): Promise<void> {
+  for (let turn = 0; turn < turns; turn++) {
+    await Promise.resolve();
+  }
+}
+
+async function waitForCondition(
+  condition: () => boolean,
+  description: string,
+  turns = 100,
+): Promise<void> {
+  for (let turn = 0; turn < turns; turn++) {
+    if (condition()) {
+      return;
+    }
+    await Promise.resolve();
+  }
+  throw new Error(`Timed out waiting for ${description}`);
+}
+
 describe("SimCtlClient boot self-verification", () => {
+  beforeEach(resetSimctlState);
+
   test("shuts down a simulator when its start request is aborted", async () => {
     const calls: string[] = [];
     const simctl = new SimCtlClient(
@@ -157,12 +300,481 @@ describe("SimCtlClient boot self-verification", () => {
     );
     const controller = new AbortController();
     const start = runWithAbortSignal(controller.signal, () => simctl.startSimulator(UDID, 5_000));
-    await new Promise<void>((resolve) => setImmediate(resolve));
+    await waitForCondition(
+      () => calls.includes(`xcrun simctl bootstatus ${UDID} -b`),
+      "the abortable bootstatus command",
+    );
 
     controller.abort(new Error("request cancelled"));
 
     await expect(start).rejects.toThrow("request cancelled");
     expect(shutdownCalls(calls)).toEqual([`xcrun simctl shutdown ${UDID}`]);
+  });
+
+  test("shuts down after an internal bootstatus timeout without replacing the timeout error", async () => {
+    const calls: string[] = [];
+    const timer = new FakeTimer();
+    const requestController = new AbortController();
+    let bootstatusSignal: AbortSignal | undefined;
+    let shutdownSignal: AbortSignal | undefined;
+    let shutdownStartedAborted: boolean | undefined;
+    const simctl = new SimCtlClient(
+      null,
+      async (file, args, _maxBuffer, signal) => {
+        const command = `${file} ${args.join(" ")}`;
+        calls.push(command);
+        if (command === "xcrun simctl --version") {
+          return createExecResult("", "");
+        }
+        if (command === `xcrun simctl bootstatus ${UDID} -b`) {
+          bootstatusSignal = signal;
+          return new Promise((_resolve, reject) => {
+            signal?.addEventListener(
+              "abort",
+              () => reject(Object.assign(new Error("aborted"), { name: "AbortError" })),
+              { once: true },
+            );
+          });
+        }
+        if (command === `xcrun simctl shutdown ${UDID}`) {
+          shutdownSignal = signal;
+          shutdownStartedAborted = signal?.aborted;
+          return rejectWhenAborted(signal);
+        }
+        return createExecResult("", "");
+      },
+      timer,
+      "darwin",
+    );
+    const start = runWithAbortSignal(requestController.signal, () =>
+      simctl.startSimulator(UDID, 1_234),
+    );
+    await waitForCondition(() => bootstatusSignal !== undefined, "the timed bootstatus command");
+
+    timer.advanceTime(1_234);
+    await waitForCondition(() => shutdownSignal !== undefined, "the bounded cleanup command");
+    timer.advanceTime(10_000);
+
+    await expect(start).rejects.toThrow(
+      `Command timed out after 1234ms: xcrun simctl bootstatus ${UDID} -b`,
+    );
+    expect(requestController.signal.aborted).toBe(false);
+    expect(bootstatusSignal.aborted).toBe(true);
+    expect(shutdownCalls(calls)).toEqual([`xcrun simctl shutdown ${UDID}`]);
+    expect(shutdownSignal).toBeDefined();
+    expect(shutdownStartedAborted).toBe(false);
+    expect(shutdownSignal?.aborted).toBe(true);
+  });
+
+  test("serializes same-UDID starts before failed-start cleanup", async () => {
+    let completeCleanup: (() => void) | undefined;
+    const harness = createConcurrentStartHarness(
+      (invocation, signal) =>
+        invocation === 1 ? rejectWhenAborted(signal) : Promise.resolve(createExecResult("", "")),
+      bootedSimulatorListResult,
+      {
+        shutdown: () =>
+          new Promise((resolve) => {
+            completeCleanup = () => resolve(createExecResult("", ""));
+          }),
+      },
+    );
+    const firstStart = harness.createClient().startSimulator(UDID, 1_000);
+    await waitForCondition(() => harness.bootstatusInvocations() === 1, "the first same-UDID boot");
+    const secondStart = harness.createClient().startSimulator(UDID, 5_000);
+    await drainMicrotasks();
+    const bootstatusInvocationsBeforeFirstTimeout = harness.bootstatusInvocations();
+
+    harness.timer.advanceTime(1_000);
+    await waitForCondition(() => completeCleanup !== undefined, "failed-start cleanup");
+    await drainMicrotasks();
+    expect(harness.bootstatusInvocations()).toBe(1);
+    completeCleanup();
+
+    await expect(firstStart).rejects.toThrow(
+      `Command timed out after 1000ms: xcrun simctl bootstatus ${UDID} -b`,
+    );
+    await expect(secondStart).resolves.toBeDefined();
+    expect(bootstatusInvocationsBeforeFirstTimeout).toBe(1);
+    expect(harness.lifecycleCalls).toEqual(["bootstatus-1", "shutdown", "bootstatus-2"]);
+  });
+
+  test("does not serialize boot attempts for different UDIDs", async () => {
+    const calls: string[] = [];
+    const firstController = new AbortController();
+    const execAsync = async (
+      file: string,
+      args: string[],
+      _maxBuffer?: number,
+      signal?: AbortSignal,
+    ) => {
+      const command = `${file} ${args.join(" ")}`;
+      calls.push(command);
+      if (command === `xcrun simctl bootstatus ${UDID} -b`) {
+        return rejectWhenAborted(signal, true);
+      }
+      if (command === `xcrun simctl bootstatus ${OTHER_UDID} -b`) {
+        return createExecResult("", "");
+      }
+      if (command === "xcrun simctl list devices --json") {
+        return createExecResult(
+          JSON.stringify({
+            devices: {
+              "com.apple.CoreSimulator.SimRuntime.iOS-26-0": [
+                { udid: UDID, name: "iPhone 17", state: "Booted", isAvailable: true },
+                { udid: OTHER_UDID, name: "iPhone 17 Pro", state: "Booted", isAvailable: true },
+              ],
+            },
+          }),
+          "",
+        );
+      }
+      return createExecResult("", "");
+    };
+    const timer = new FakeTimer();
+    const createClient = () => new SimCtlClient(null, execAsync, timer, "darwin");
+    const firstStart = runWithAbortSignal(firstController.signal, () =>
+      createClient().startSimulator(UDID, 5_000),
+    );
+    await waitForCondition(
+      () => calls.includes(`xcrun simctl bootstatus ${UDID} -b`),
+      "the first UDID boot",
+    );
+
+    await expect(createClient().startSimulator(OTHER_UDID, 5_000)).resolves.toBeDefined();
+    expect(calls).toContain(`xcrun simctl bootstatus ${OTHER_UDID} -b`);
+
+    firstController.abort(new Error("first UDID cancelled"));
+    await expect(firstStart).rejects.toThrow("first UDID cancelled");
+  });
+
+  test("serializes session auto-start behind failed-start cleanup", async () => {
+    const harness = createConcurrentStartHarness((invocation, signal) =>
+      invocation === 1 ? rejectWhenAborted(signal) : Promise.resolve(createExecResult("", "")),
+    );
+    const publicStart = harness.createClient().startSimulator(UDID, 1_000);
+    await waitForCondition(
+      () => harness.bootstatusInvocations() === 1,
+      "the public start bootstatus",
+    );
+    const sessionStart = harness.createClient().bootSimulator(UDID);
+    await drainMicrotasks();
+    const bootstatusInvocationsBeforePublicTimeout = harness.bootstatusInvocations();
+
+    harness.timer.advanceTime(1_000);
+
+    await expect(publicStart).rejects.toThrow(
+      `Command timed out after 1000ms: xcrun simctl bootstatus ${UDID} -b`,
+    );
+    await expect(sessionStart).resolves.toMatchObject({ deviceId: UDID });
+    expect(bootstatusInvocationsBeforePublicTimeout).toBe(1);
+    expect(harness.lifecycleCalls).toEqual(["bootstatus-1", "shutdown", "bootstatus-2"]);
+  });
+
+  test("serializes readiness verification behind failed-start cleanup", async () => {
+    const harness = createConcurrentStartHarness((invocation, signal) =>
+      invocation === 1 ? rejectWhenAborted(signal) : Promise.resolve(createExecResult("", "")),
+    );
+    const publicStart = harness.createClient().startSimulator(UDID, 1_000);
+    await waitForCondition(
+      () => harness.bootstatusInvocations() === 1,
+      "the public start bootstatus",
+    );
+    const readiness = harness.createClient().waitForSimulatorReady(UDID, 5_000);
+    await drainMicrotasks();
+    const bootstatusInvocationsBeforePublicTimeout = harness.bootstatusInvocations();
+
+    harness.timer.advanceTime(1_000);
+
+    await expect(publicStart).rejects.toThrow(
+      `Command timed out after 1000ms: xcrun simctl bootstatus ${UDID} -b`,
+    );
+    await expect(readiness).resolves.toMatchObject({ deviceId: UDID });
+    expect(bootstatusInvocationsBeforePublicTimeout).toBe(1);
+    expect(harness.lifecycleCalls).toEqual(["bootstatus-1", "shutdown", "bootstatus-2"]);
+  });
+
+  test("session auto-start cleans up an internal bootstatus timeout", async () => {
+    const harness = createConcurrentStartHarness((_invocation, signal) =>
+      rejectWhenAborted(signal),
+    );
+    const sessionStart = harness.createClient().bootSimulator(UDID);
+    await waitForCondition(
+      () => harness.bootstatusInvocations() === 1,
+      "the session auto-start bootstatus",
+    );
+
+    harness.timer.advanceTime(DEFAULT_DEVICE_READY_TIMEOUT_MS);
+
+    await expect(sessionStart).rejects.toThrow(
+      `Command timed out after ${DEFAULT_DEVICE_READY_TIMEOUT_MS}ms: ` +
+        `xcrun simctl bootstatus ${UDID} -b`,
+    );
+    expect(harness.lifecycleCalls).toEqual(["bootstatus-1", "shutdown"]);
+  });
+
+  test("session auto-start cleans up a post-boot registration failure", async () => {
+    const harness = createConcurrentStartHarness(
+      () => Promise.resolve(createExecResult("", "")),
+      (invocation) =>
+        invocation === 1
+          ? bootedSimulatorListResult()
+          : createExecResult(JSON.stringify({ devices: {} }), ""),
+    );
+
+    await expect(harness.createClient().bootSimulator(UDID)).rejects.toThrow(
+      `Failed to boot iOS simulator ${UDID}`,
+    );
+    expect(harness.lifecycleCalls).toEqual(["bootstatus-1", "shutdown"]);
+  });
+
+  test("session auto-start preserves a post-boot registration discovery error", async () => {
+    const registrationError = new Error("registration discovery failed");
+    const harness = createConcurrentStartHarness(
+      () => Promise.resolve(createExecResult("", "")),
+      (invocation) => {
+        if (invocation === 1) {
+          return bootedSimulatorListResult();
+        }
+        throw registrationError;
+      },
+    );
+
+    await expect(harness.createClient().bootSimulator(UDID)).rejects.toBe(registrationError);
+    expect(harness.lifecycleCalls).toEqual(["bootstatus-1", "shutdown"]);
+  });
+
+  test("rejects a queued public owner but lets session and readiness adopt success", async () => {
+    let completeFirstBootstatus: (() => void) | undefined;
+    const harness = createConcurrentStartHarness((invocation) => {
+      if (invocation > 1) {
+        return Promise.resolve(createExecResult("", ""));
+      }
+      return new Promise((resolve) => {
+        completeFirstBootstatus = () => resolve(createExecResult("", ""));
+      });
+    });
+
+    const firstStart = harness.createClient().startSimulator(UDID, 5_000);
+    await waitForCondition(
+      () => completeFirstBootstatus !== undefined,
+      "the owner bootstatus command",
+    );
+    const waitingStart = harness
+      .createClient()
+      .startSimulator(UDID, 100)
+      .catch((error: unknown) => error);
+    const sessionStart = harness.createClient().bootSimulator(UDID);
+    const readiness = harness.createClient().waitForSimulatorReady(UDID, 5_000);
+    completeFirstBootstatus();
+    await expect(firstStart).resolves.toBeDefined();
+
+    const waitingError = await waitingStart;
+    await expect(sessionStart).resolves.toMatchObject({ deviceId: UDID });
+    await expect(readiness).resolves.toMatchObject({ deviceId: UDID });
+    expect(waitingError).toBeInstanceOf(ActionableError);
+    expect((waitingError as Error).message).toBe(`iOS simulator ${UDID} is already running`);
+    expect(harness.bootstatusInvocations()).toBe(2);
+    expect(harness.shutdownInvocations()).toBe(0);
+  });
+
+  test("retains successful ownership for a caller that enters after lease release", async () => {
+    const harness = createConcurrentStartHarness(() => Promise.resolve(createExecResult("", "")));
+    const ownerHandle = await harness.createClient().startSimulator(UDID, 5_000);
+
+    const lateStartError = await harness
+      .createClient()
+      .startSimulator(UDID, 5_000)
+      .catch((error: unknown) => error);
+
+    expect(lateStartError).toBeInstanceOf(ActionableError);
+    expect((lateStartError as Error).message).toBe(`iOS simulator ${UDID} is already running`);
+    expect(harness.bootstatusInvocations()).toBe(1);
+    expect(ownerHandle.kill()).toBe(true);
+    await waitForCondition(() => harness.shutdownInvocations() === 1, "owner shutdown");
+  });
+
+  test("reboots after out-of-band shutdown and invalidates the stale owner handle", async () => {
+    const harness = createConcurrentStartHarness(
+      () => Promise.resolve(createExecResult("", "")),
+      (invocation) =>
+        invocation === 2
+          ? createExecResult(JSON.stringify({ devices: {} }), "")
+          : bootedSimulatorListResult(),
+    );
+    const staleHandle = await harness.createClient().startSimulator(UDID, 5_000);
+
+    const replacementHandle = await harness.createClient().startSimulator(UDID, 5_000);
+
+    expect(harness.bootstatusInvocations()).toBe(2);
+    expect(staleHandle.kill()).toBe(true);
+    await drainMicrotasks();
+    expect(harness.shutdownInvocations()).toBe(0);
+    expect(replacementHandle.kill()).toBe(true);
+    await waitForCondition(() => harness.shutdownInvocations() === 1, "replacement shutdown");
+  });
+
+  test("does not reuse an owner identity after coordinated state eviction", async () => {
+    const harness = createConcurrentStartHarness(() => Promise.resolve(createExecResult("", "")));
+    const staleHandle = await harness.createClient().startSimulator(UDID, 5_000);
+    await harness.createClient().killSimulator({
+      name: "iPhone 17",
+      platform: "ios",
+      deviceId: UDID,
+    });
+    expect(harness.shutdownInvocations()).toBe(1);
+    const replacementHandle = await harness.createClient().startSimulator(UDID, 5_000);
+
+    expect(staleHandle.kill()).toBe(true);
+    await drainMicrotasks();
+    expect(harness.shutdownInvocations()).toBe(1);
+    expect(replacementHandle.kill()).toBe(true);
+    await waitForCondition(() => harness.shutdownInvocations() === 2, "replacement shutdown");
+  });
+
+  test("session auto-start reboots after an out-of-band shutdown", async () => {
+    const harness = createConcurrentStartHarness(
+      () => Promise.resolve(createExecResult("", "")),
+      (invocation) =>
+        invocation === 3
+          ? createExecResult(JSON.stringify({ devices: {} }), "")
+          : bootedSimulatorListResult(),
+    );
+    await expect(harness.createClient().bootSimulator(UDID)).resolves.toMatchObject({
+      deviceId: UDID,
+    });
+
+    await expect(harness.createClient().bootSimulator(UDID)).resolves.toMatchObject({
+      deviceId: UDID,
+    });
+
+    expect(harness.bootstatusInvocations()).toBe(2);
+    expect(harness.shutdownInvocations()).toBe(0);
+  });
+
+  test("does not clean up when a queued session adopter cannot resolve registration", async () => {
+    let completeOwnerBootstatus: (() => void) | undefined;
+    const registrationError = new Error("adopter registration failed");
+    const harness = createConcurrentStartHarness(
+      () =>
+        new Promise((resolve) => {
+          completeOwnerBootstatus = () => resolve(createExecResult("", ""));
+        }),
+      (invocation) => {
+        if (invocation === 1) {
+          return bootedSimulatorListResult();
+        }
+        throw registrationError;
+      },
+    );
+    const owner = harness.createClient().startSimulator(UDID, 5_000);
+    await waitForCondition(() => completeOwnerBootstatus !== undefined, "owner bootstatus");
+    const adopter = harness
+      .createClient()
+      .bootSimulator(UDID)
+      .catch((error: unknown) => error);
+    completeOwnerBootstatus();
+
+    await expect(owner).resolves.toBeDefined();
+    await expect(adopter).resolves.toBe(registrationError);
+    expect(harness.shutdownInvocations()).toBe(0);
+  });
+
+  test("bounds Simulator.app focus while retaining the successful boot lease", async () => {
+    let openingSimulatorApp = false;
+    let openSimulatorSignal: AbortSignal | undefined;
+    const harness = createConcurrentStartHarness(
+      () => Promise.resolve(createExecResult("", "")),
+      bootedSimulatorListResult,
+      {
+        openSimulatorApp: (signal) => {
+          openingSimulatorApp = true;
+          openSimulatorSignal = signal;
+          return rejectWhenAborted(signal);
+        },
+      },
+    );
+
+    const firstStart = harness.createClient().startSimulator(UDID, 100);
+    await waitForCondition(() => openingSimulatorApp, "Simulator.app focus");
+    const waitingStart = harness
+      .createClient()
+      .startSimulator(UDID, 5_000)
+      .catch((error: unknown) => error);
+    await drainMicrotasks();
+    expect(harness.bootstatusInvocations()).toBe(1);
+
+    harness.timer.advanceTime(100);
+
+    await expect(firstStart).resolves.toBeDefined();
+    expect(openSimulatorSignal?.aborted).toBe(true);
+    const waitingError = await waitingStart;
+    expect(waitingError).toBeInstanceOf(ActionableError);
+    expect((waitingError as Error).message).toBe(`iOS simulator ${UDID} is already running`);
+    expect(harness.bootstatusInvocations()).toBe(1);
+    expect(harness.shutdownInvocations()).toBe(0);
+  });
+
+  test("does not reuse stale success after an idle start is shut down", async () => {
+    const harness = createConcurrentStartHarness(() => Promise.resolve(createExecResult("", "")));
+    const firstHandle = await harness.createClient().startSimulator(UDID, 5_000);
+    if (!firstHandle) {
+      throw new Error("The owning start must return a cancellation handle");
+    }
+    expect(firstHandle.kill()).toBe(true);
+    await drainMicrotasks();
+
+    const abortedOwnerController = new AbortController();
+    const abortedOwner = runWithAbortSignal(abortedOwnerController.signal, () =>
+      harness.createClient().startSimulator(UDID, 5_000),
+    ).catch((error: unknown) => error);
+    const waitingStart = harness.createClient().startSimulator(UDID, 5_000);
+    abortedOwnerController.abort(new Error("new owner cancelled"));
+
+    await expect(abortedOwner).resolves.toBeInstanceOf(Error);
+    await expect(waitingStart).resolves.not.toBeNull();
+    expect(harness.bootstatusInvocations()).toBe(2);
+    expect(harness.shutdownInvocations()).toBe(1);
+  });
+
+  test("bounds and cancels same-UDID start lock waiters without booting or cleanup", async () => {
+    const harness = createConcurrentStartHarness((_invocation, signal) =>
+      rejectWhenAborted(signal, true),
+    );
+    const ownerController = new AbortController();
+    const cancelledWaiterController = new AbortController();
+    const ownerStart = runWithAbortSignal(ownerController.signal, () =>
+      harness.createClient().startSimulator(UDID, 5_000),
+    );
+    await waitForCondition(
+      () => harness.bootstatusInvocations() === 1,
+      "the lock-owning bootstatus command",
+    );
+    const cancelledWaiter = runWithAbortSignal(cancelledWaiterController.signal, () =>
+      harness.createClient().startSimulator(UDID, 5_000),
+    ).catch((error: unknown) => error);
+    const timedOutWaiter = harness
+      .createClient()
+      .startSimulator(UDID, 100)
+      .catch((error: unknown) => error);
+    await drainMicrotasks();
+
+    cancelledWaiterController.abort(new Error("waiting request cancelled"));
+    harness.timer.advanceTime(100);
+
+    const cancelledError = await cancelledWaiter;
+    const timedOutError = await timedOutWaiter;
+    ownerController.abort(new Error("owner request cancelled"));
+    await expect(ownerStart).rejects.toThrow("owner request cancelled");
+
+    expect(cancelledError).toBeInstanceOf(Error);
+    expect((cancelledError as Error).message).toBe("waiting request cancelled");
+    expect(timedOutError).toBeInstanceOf(Error);
+    expect((timedOutError as Error).message).toBe(
+      `Timed out waiting to start iOS simulator ${UDID}`,
+    );
+    expect(harness.bootstatusInvocations()).toBe(1);
+    expect(harness.shutdownInvocations()).toBe(1);
   });
 
   test("handle.kill shutdown does not inherit an aborted request signal", async () => {
@@ -174,12 +786,135 @@ describe("SimCtlClient boot self-verification", () => {
 
     await runWithAbortSignal(controller.signal, async () => {
       expect(handle.kill()).toBe(true);
-      await new Promise<void>((resolve) => setImmediate(resolve));
+      await drainMicrotasks();
     });
 
     const shutdownSignal = harness.commandSignals.get(`xcrun simctl shutdown ${UDID}`)?.[0];
     expect(shutdownSignal).toBeDefined();
     expect(shutdownSignal?.aborted).toBe(false);
+  });
+
+  test("serializes handle shutdown with cold-readiness metadata and clears success", async () => {
+    let completeMetadata: (() => void) | undefined;
+    const harness = createConcurrentStartHarness(
+      () => Promise.resolve(createExecResult("", "")),
+      (invocation) => {
+        if (invocation !== 2) {
+          return bootedSimulatorListResult();
+        }
+        return new Promise((resolve) => {
+          completeMetadata = () => resolve(bootedSimulatorListResult());
+        });
+      },
+    );
+    const handle = await harness.createClient().startSimulator(UDID, 5_000);
+    const readiness = harness
+      .createClient()
+      .waitForSimulatorReady(UDID, 5_000, { assumeBooted: true });
+    await waitForCondition(() => completeMetadata !== undefined, "cold-readiness metadata");
+
+    expect(handle.kill()).toBe(true);
+    await drainMicrotasks();
+    expect(harness.shutdownInvocations()).toBe(0);
+    completeMetadata();
+
+    await expect(readiness).resolves.toMatchObject({ deviceId: UDID });
+    await waitForCondition(
+      () => harness.shutdownInvocations() === 1,
+      "coordinated handle shutdown",
+    );
+    await expect(harness.createClient().startSimulator(UDID, 5_000)).resolves.toBeDefined();
+    expect(harness.lifecycleCalls).toEqual(["bootstatus-1", "shutdown", "bootstatus-2"]);
+  });
+
+  test("bounds cold-readiness metadata while retaining the boot lease", async () => {
+    let metadataSignal: AbortSignal | undefined;
+    const harness = createConcurrentStartHarness(
+      () => Promise.resolve(createExecResult("", "")),
+      (invocation, signal) => {
+        if (invocation > 1) {
+          return bootedSimulatorListResult();
+        }
+        metadataSignal = signal;
+        return rejectWhenAborted(signal);
+      },
+    );
+    const readiness = harness
+      .createClient()
+      .waitForSimulatorReady(UDID, 100, { assumeBooted: true });
+    await waitForCondition(() => metadataSignal !== undefined, "bounded cold-readiness metadata");
+
+    harness.timer.advanceTime(100);
+
+    await expect(readiness).rejects.toThrow(
+      "Command timed out after 100ms: xcrun simctl list devices --json",
+    );
+    expect(metadataSignal?.aborted).toBe(true);
+    await expect(harness.createClient().startSimulator(UDID, 5_000)).resolves.toBeDefined();
+    expect(harness.shutdownInvocations()).toBe(0);
+  });
+
+  test("serializes killSimulator behind in-flight readiness verification", async () => {
+    let completeReadiness: (() => void) | undefined;
+    const harness = createConcurrentStartHarness(
+      () =>
+        new Promise((resolve) => {
+          completeReadiness = () => resolve(createExecResult("", ""));
+        }),
+    );
+    const readiness = harness.createClient().waitForSimulatorReady(UDID, 120_000);
+    await waitForCondition(() => completeReadiness !== undefined, "readiness verification");
+    const kill = harness.createClient().killSimulator({
+      name: "iPhone 17",
+      platform: "ios",
+      deviceId: UDID,
+    });
+    harness.timer.advanceTime(10_001);
+    await drainMicrotasks();
+    expect(harness.shutdownInvocations()).toBe(0);
+
+    completeReadiness();
+
+    await expect(readiness).resolves.toMatchObject({ deviceId: UDID });
+    await expect(kill).resolves.toBeUndefined();
+    expect(harness.lifecycleCalls).toEqual(["bootstatus-1", "shutdown"]);
+  });
+
+  test("preserves successful boot state when coordinated shutdown fails", async () => {
+    let completeOwnerBootstatus: (() => void) | undefined;
+    const shutdownError = new Error("shutdown failed");
+    const harness = createConcurrentStartHarness(
+      (invocation) => {
+        if (invocation > 1) {
+          return Promise.resolve(createExecResult("", ""));
+        }
+        return new Promise((resolve) => {
+          completeOwnerBootstatus = () => resolve(createExecResult("", ""));
+        });
+      },
+      bootedSimulatorListResult,
+      {
+        shutdown: () => Promise.reject(shutdownError),
+      },
+    );
+    const owner = harness.createClient().startSimulator(UDID, 5_000);
+    await waitForCondition(() => completeOwnerBootstatus !== undefined, "owner bootstatus");
+    const kill = harness
+      .createClient()
+      .killSimulator({ name: "iPhone 17", platform: "ios", deviceId: UDID })
+      .catch((error: unknown) => error);
+    const waitingStart = harness
+      .createClient()
+      .startSimulator(UDID, 5_000)
+      .catch((error: unknown) => error);
+    completeOwnerBootstatus();
+
+    await expect(owner).resolves.toBeDefined();
+    await expect(kill).resolves.toBe(shutdownError);
+    const waitingError = await waitingStart;
+    expect(waitingError).toBeInstanceOf(ActionableError);
+    expect((waitingError as Error).message).toBe(`iOS simulator ${UDID} is already running`);
+    expect(harness.bootstatusInvocations()).toBe(1);
   });
 
   test("a wedged boot (bootstatus exit 0, device Shutdown) fails with an actionable error", async () => {
@@ -309,14 +1044,17 @@ describe("SimCtlClient boot self-verification", () => {
     );
 
     // Set up the first retry before advancing fake time so its deadline starts at zero.
-    await new Promise<void>((resolve) => setImmediate(resolve));
+    await waitForCondition(
+      () => harness.timer.getPendingSleepCount() === 1,
+      "the retry backoff sleep",
+    );
     const error = await harness.timer.resolvePromise(boot);
 
     expect(error).toBeInstanceOf(Error);
     expect(harness.timer.now()).toBe(5000);
     expect(harness.timer.getSleepHistory()).toEqual([5000]);
     expect(bootstatusCalls(harness.calls).length).toBe(1);
-    expect(shutdownCalls(harness.calls).length).toBe(1);
+    expect(shutdownCalls(harness.calls).length).toBe(2);
   });
 
   test("stops after the bounded attempt count and reports the observed state", async () => {
@@ -331,7 +1069,7 @@ describe("SimCtlClient boot self-verification", () => {
 
     expect((error as Error).message).toContain("after 3 boot attempt(s)");
     expect(bootstatusCalls(harness.calls).length).toBe(3);
-    expect(shutdownCalls(harness.calls).length).toBe(2);
+    expect(shutdownCalls(harness.calls).length).toBe(3);
     expect(harness.timer.getSleepHistory()).toEqual([25, 25]);
   });
 
@@ -348,7 +1086,7 @@ describe("SimCtlClient boot self-verification", () => {
 
     expect((error as Error).message).toContain("Invalid device");
     expect(bootstatusCalls(harness.calls).length).toBe(1);
-    expect(shutdownCalls(harness.calls).length).toBe(0);
+    expect(shutdownCalls(harness.calls).length).toBe(1);
     expect(harness.timer.getSleepCallCount()).toBe(0);
   });
 
@@ -365,6 +1103,7 @@ describe("SimCtlClient boot self-verification", () => {
     // It must go through bootstatus, not a bare `simctl boot`.
     expect(bootstatusCalls(harness.calls).length).toBe(1);
     expect(harness.calls).not.toContain(`xcrun simctl boot ${UDID}`);
+    expect(shutdownCalls(harness.calls).length).toBe(1);
   });
 
   test("bootSimulator retries a wedged boot and returns the device once Booted", async () => {
@@ -398,5 +1137,6 @@ describe("SimCtlClient boot self-verification", () => {
     expect(error).toBeInstanceOf(ActionableError);
     expect((error as Error).message).toContain("failed to become ready");
     expect((error as Error).message).toContain("Shutdown");
+    expect(shutdownCalls(harness.calls).length).toBe(0);
   });
 });

--- a/test/utils/ios-cmdline-tools/simctl.test.ts
+++ b/test/utils/ios-cmdline-tools/simctl.test.ts
@@ -10,9 +10,11 @@ function resetSimctlCaches(): void {
   const simctlClass = Simctl as unknown as {
     deviceListCache: { devices: unknown[]; timestamp: number } | null;
     localSimctlAvailability: Promise<void> | null;
+    simulatorBoots: Map<string, unknown>;
   };
   simctlClass.deviceListCache = null;
   simctlClass.localSimctlAvailability = null;
+  simctlClass.simulatorBoots.clear();
 }
 
 function forceStaticAvailabilityPath(instance: Simctl): void {
@@ -258,6 +260,9 @@ describe("Simctl", function() {
         if (file === "xcrun" && args.join(" ") === "simctl --version") {
           return createExecResult("simctl version 1.0.0", "");
         }
+        if (file === "xcrun" && args.join(" ") === "simctl shutdown test-ios-device-id") {
+          return createExecResult("", "");
+        }
         return new Promise<ExecResult>(resolve => {
           resolveCommand = resolve;
         });
@@ -284,6 +289,9 @@ describe("Simctl", function() {
         if (file === "xcrun" && args.join(" ") === "simctl --version") {
           return createExecResult("simctl version 1.0.0", "");
         }
+        if (file === "xcrun" && args.join(" ") === "simctl shutdown test-ios-device-id") {
+          return createExecResult("", "");
+        }
         return new Promise<ExecResult>(resolve => {
           resolveCommand = resolve;
         });
@@ -309,6 +317,9 @@ describe("Simctl", function() {
       mockExecAsync = async (file: string, args: string[], _maxBuffer?: number, signal?: AbortSignal): Promise<ExecResult> => {
         if (file === "xcrun" && args.join(" ") === "simctl --version") {
           return createExecResult("simctl version 1.0.0", "");
+        }
+        if (file === "xcrun" && args.join(" ") === "simctl shutdown test-ios-device-id") {
+          return createExecResult("", "");
         }
         capturedSignal = signal;
         // Simulate a long-running child that only settles when aborted, mirroring


### PR DESCRIPTION
## Summary

Shut down an iOS simulator whenever an owned public or session auto-start fails boot verification, including when `bootstatus -b` exhausts its own command timeout before the caller signal is aborted. Cleanup is bounded, uses a fresh signal, and cannot replace the original boot failure.

Coordinate every same-UDID boot, readiness, and shutdown path across `SimCtlClient` instances. Queued owning starts cannot inherit destructive ownership after another owner succeeds, non-owning readiness remains safe, post-boot registration preserves discovery errors, and unrelated UDIDs remain independent.

## Linked Issue

Closes #5277

## Bug / Regression Context

- **Prior attempts:** [#3938](https://github.com/kaeawc/auto-mobile/issues/3938) stopped timed-out command processes, and [#3952](https://github.com/kaeawc/auto-mobile/issues/3952) canceled failures after a start handle existed. Neither covered an internal `bootstatus` timeout before `startSimulator` returned a handle.
- **Observed symptom:** `startDevice` returned a timeout while CoreSimulator could continue booting the requested UDID, causing retries to collide with a `Booting` simulator.
- **Repro conditions:** Let `simctl bootstatus <udid> -b` exceed its remaining command timeout while the enclosing request signal is still active.

## Validation

- [x] Affected iOS boot-path suites: 119 passed
- [x] `bun run turbo:validate` on the preceding reviewed head: 13,183 passed, 13 skipped, 0 failed
- [x] Final stale-owner delta: targeted suites, typecheck, lint/build, and 33/33 fast gates passed; two full-suite reruns stalled in unrelated tests that pass in isolation
- [x] `bun run typecheck`: no new errors
- [x] `bash scripts/all_fast_validate_checks.sh`: 33/33 passed
- [x] `bun run check:simctl-boundary`
- [x] Concurrency, timeout, cancellation, cleanup, ownership, and independent-UDID tests use the injected executor and `FakeTimer`; no real waits or simulator
- [x] Rebased onto `main@origin` at `5aad26d6743e`

## Device Verification

Not run on a real simulator. The acceptance criteria require deterministic coverage without a simulator; the injected executor distinguishes the internal command timeout from caller cancellation, verifies the fresh cleanup signal, and controls concurrent public, session, readiness, and shutdown paths.

## Follow-ups

None.
