### PR TITLE
feat(daemon): retire sessions from all pool removals

### DIFF
--- a/src/daemon/daemon.ts
+++ b/src/daemon/daemon.ts
@@ -242,6 +242,7 @@ export class Daemon {
       deviceId => this.onDeviceReadyForSessionRegistry(deviceId),
       undefined,
       recoveryConfiguration.policy,
+      deviceId => this.deviceSessionRegistry.onDeviceDisconnected(deviceId),
     );
     // Initialize singleton for daemon state access
     DaemonState.getInstance().initialize(
@@ -1280,11 +1281,6 @@ export class Daemon {
             // device is live again, so retiring here would delete that just-minted
             // epoch; skip the retire and let cleanup fail so the monitor retries.
             deviceCleanupSucceeded = false;
-          } else {
-            // Confirmed gone: retire the device-session epoch so a stale
-            // deviceSessionUuid stops resolving and listDeviceSessions drops the
-            // device (epic #5256).
-            this.deviceSessionRegistry.onDeviceDisconnected(deviceId);
           }
           if (deviceCleanupSucceeded) {
             this.confirmedDisconnectedDeviceIds.add(deviceId);

--- a/src/daemon/devicePool.ts
+++ b/src/daemon/devicePool.ts
@@ -113,6 +113,10 @@ interface DeviceReadyListener {
   (deviceId: string): void;
 }
 
+interface DeviceRemovedListener {
+  (deviceId: string): void;
+}
+
 /**
  * Marker incarnation used when an intentional shutdown is recorded while no
  * pooled device is present (only an in-flight recovery). Such a marker applies
@@ -151,6 +155,7 @@ export class DevicePool {
   private readonly criteriaMatcher: DeviceCriteriaMatcher;
   private readonly releaseSessionForDisconnectedDevice: DeviceDisconnectSessionReleaser;
   private readonly onDeviceReady: DeviceReadyListener | undefined;
+  private readonly onDeviceRemoved: DeviceRemovedListener | undefined;
   private readonly androidDeviceReboot: AndroidDeviceReboot;
   private readonly recoveryPolicy: DeviceRecoveryPolicy;
   private readonly recoveringAndroidImages: Map<string, DeviceInfo> = new Map();
@@ -189,6 +194,7 @@ export class DevicePool {
     onDeviceReady?: DeviceReadyListener,
     androidDeviceReboot?: AndroidDeviceReboot,
     recoveryPolicy?: DeviceRecoveryPolicy,
+    onDeviceRemoved?: DeviceRemovedListener,
   ) {
     this.sessionManager = sessionManager;
     this.daemonSessionId = daemonSessionId;
@@ -199,6 +205,7 @@ export class DevicePool {
     this.deviceSessionRepository = deviceSessionRepository;
     this.criteriaMatcher = criteriaMatcher;
     this.onDeviceReady = onDeviceReady;
+    this.onDeviceRemoved = onDeviceRemoved;
     // Resolve recovery policy once so retries and status agree even if the
     // process environment changes after construction.
     this.recoveryPolicy = { ...(recoveryPolicy ?? getDeviceRecoveryPolicy()) };
@@ -376,6 +383,15 @@ export class DevicePool {
     }
   }
 
+  /** Notify consumers that a device has been removed from the pool. */
+  private notifyDeviceRemoved(deviceId: string): void {
+    try {
+      this.onDeviceRemoved?.(deviceId);
+    } catch (error) {
+      logger.warn(`[DevicePool] Device-removed listener failed for ${deviceId}: ${error}`);
+    }
+  }
+
   /**
    * Add a new device to the pool
    */
@@ -449,6 +465,7 @@ export class DevicePool {
     }
 
     this.devices.delete(deviceId);
+    this.notifyDeviceRemoved(deviceId);
     this.deviceSessionStarts.delete(deviceId);
     this.refreshMissingDeviceMisses.delete(deviceId);
     this.startedDeviceProcesses.delete(deviceId);

--- a/src/daemon/devicePool.ts
+++ b/src/daemon/devicePool.ts
@@ -388,6 +388,8 @@ export class DevicePool {
     try {
       this.onDeviceRemoved?.(deviceId);
     } catch (error) {
+      // Mirror the ready-listener contract: observers cannot roll back a removal
+      // after the pool has deleted the device, so keep mandatory cleanup running.
       logger.warn(`[DevicePool] Device-removed listener failed for ${deviceId}: ${error}`);
     }
   }

--- a/test/daemon/daemonIdGenerator.test.ts
+++ b/test/daemon/daemonIdGenerator.test.ts
@@ -4,7 +4,6 @@ import { DaemonState } from "../../src/daemon/daemonState";
 import { FakeTimer } from "../fakes/FakeTimer";
 import { FakeInstalledAppsRepository } from "../fakes/FakeInstalledAppsRepository";
 import { DeviceSessionRepository } from "../../src/db/deviceSessionRepository";
-import { createTestDatabase } from "../db/testDbHelper";
 import { CountingIdGenerator } from "../../src/utils/IdGenerator";
 
 describe("Daemon UUID source", function() {
@@ -39,7 +38,7 @@ describe("Daemon UUID source", function() {
       {},
       new FakeInstalledAppsRepository(),
       timer,
-      new DeviceSessionRepository(await createTestDatabase()),
+      undefined,
       idGenerator,
     );
     const pool = daemon.getDevicePool();

--- a/test/daemon/daemonIdGenerator.test.ts
+++ b/test/daemon/daemonIdGenerator.test.ts
@@ -2,7 +2,9 @@ import { afterEach, describe, expect, test } from "bun:test";
 import { Daemon } from "../../src/daemon/daemon";
 import { DaemonState } from "../../src/daemon/daemonState";
 import { FakeTimer } from "../fakes/FakeTimer";
+import { FakeInstalledAppsRepository } from "../fakes/FakeInstalledAppsRepository";
 import { DeviceSessionRepository } from "../../src/db/deviceSessionRepository";
+import { createTestDatabase } from "../db/testDbHelper";
 import { CountingIdGenerator } from "../../src/utils/IdGenerator";
 
 describe("Daemon UUID source", function() {
@@ -28,5 +30,44 @@ describe("Daemon UUID source", function() {
     // First id minted during construction (daemonSessionId).
     expect((daemon as unknown as { daemonSessionId: string }).daemonSessionId)
       .toBe("daemon-session-1");
+  });
+
+  test("retires a removed device epoch and mints a replacement through daemon wiring", async () => {
+    const timer = new FakeTimer();
+    const idGenerator = new CountingIdGenerator("device-session");
+    const daemon = new Daemon(
+      {},
+      new FakeInstalledAppsRepository(),
+      timer,
+      new DeviceSessionRepository(await createTestDatabase()),
+      idGenerator,
+    );
+    const pool = daemon.getDevicePool();
+    const registry = (daemon as unknown as { deviceSessionRegistry: {
+      getByDeviceId(deviceId: string): { deviceSessionUuid: string } | undefined;
+      getByUuid(deviceSessionUuid: string): unknown;
+    } }).deviceSessionRegistry;
+    const bootedDevice = {
+      name: "emulator-5554",
+      deviceId: "emulator-5554",
+      platform: "android" as const,
+    };
+
+    await pool.initializeWithDevices([bootedDevice]);
+    pool.notifyDeviceReady(bootedDevice.deviceId);
+    const first = registry.getByDeviceId(bootedDevice.deviceId);
+    if (!first) {
+      throw new Error("expected device session epoch");
+    }
+
+    await pool.removeDevice(bootedDevice.deviceId);
+
+    expect(registry.getByDeviceId(bootedDevice.deviceId)).toBeUndefined();
+    expect(registry.getByUuid(first.deviceSessionUuid)).toBeUndefined();
+
+    await pool.addDevice(bootedDevice);
+
+    expect(registry.getByDeviceId(bootedDevice.deviceId)?.deviceSessionUuid)
+      .not.toBe(first.deviceSessionUuid);
   });
 });

--- a/test/daemon/devicePool.test.ts
+++ b/test/daemon/devicePool.test.ts
@@ -389,6 +389,7 @@ describe("DevicePool", () => {
     test("notifies the removal listener so a device session epoch is retired", async () => {
       const registry = new DeviceSessionRegistry(fakeTimer, new FakeIdGenerator(["uuid-a"]));
       const removedDeviceIds: string[] = [];
+      let listenerObservedDeletedDevice = false;
       devicePool = new DevicePool(
         sessionManager,
         "test-daemon-session-id",
@@ -403,6 +404,7 @@ describe("DevicePool", () => {
         undefined,
         undefined,
         (deviceId) => {
+          listenerObservedDeletedDevice = devicePool.getDevice(deviceId) === null;
           removedDeviceIds.push(deviceId);
           registry.onDeviceDisconnected(deviceId);
         },
@@ -418,9 +420,11 @@ describe("DevicePool", () => {
         incarnation: pooled.incarnation,
       });
 
-      await devicePool.removeDevice(pooled.id);
+      const removal = devicePool.removeDevice(pooled.id);
 
       expect(removedDeviceIds).toEqual([pooled.id]);
+      expect(listenerObservedDeletedDevice).toBe(true);
+      await removal;
       expect(registry.list()).toEqual([]);
       expect(registry.getByUuid(record.deviceSessionUuid)).toBeUndefined();
     });

--- a/test/daemon/devicePool.test.ts
+++ b/test/daemon/devicePool.test.ts
@@ -2,7 +2,9 @@ import { afterEach, describe, expect, test, beforeEach } from "bun:test";
 import { EventEmitter } from "node:events";
 import type { ChildProcess } from "node:child_process";
 import { DevicePool } from "../../src/daemon/devicePool";
+import { DeviceSessionRegistry } from "../../src/daemon/deviceSessionRegistry";
 import { SessionManager } from "../../src/daemon/sessionManager";
+import { FakeIdGenerator } from "../fakes/FakeIdGenerator";
 import { FakeTimer } from "../fakes/FakeTimer";
 import { FakeInstalledAppsRepository } from "../fakes/FakeInstalledAppsRepository";
 import { FakeDeviceManager } from "../fakes/FakeDeviceManager";
@@ -382,6 +384,45 @@ describe("DevicePool", () => {
       expect(device?.sessionId).toBeNull();
       expect(device?.assignmentCount).toBe(0);
       expect(device?.errorCount).toBe(0);
+    });
+
+    test("notifies the removal listener so a device session epoch is retired", async () => {
+      const registry = new DeviceSessionRegistry(fakeTimer, new FakeIdGenerator(["uuid-a"]));
+      const removedDeviceIds: string[] = [];
+      devicePool = new DevicePool(
+        sessionManager,
+        "test-daemon-session-id",
+        fakeTimer,
+        fakeAppsRepo,
+        fakeDeviceManager,
+        new DefaultRetryExecutor(fakeTimer),
+        undefined,
+        undefined,
+        undefined,
+        undefined,
+        undefined,
+        undefined,
+        (deviceId) => {
+          removedDeviceIds.push(deviceId);
+          registry.onDeviceDisconnected(deviceId);
+        },
+      );
+      await devicePool.initializeWithDevices([createBootedDevice("emulator-5554")]);
+      const pooled = devicePool.getDevice("emulator-5554");
+      if (!pooled) {
+        throw new Error("expected pooled device");
+      }
+      const record = registry.onDeviceConnected({
+        deviceId: pooled.id,
+        platform: pooled.platform,
+        incarnation: pooled.incarnation,
+      });
+
+      await devicePool.removeDevice(pooled.id);
+
+      expect(removedDeviceIds).toEqual([pooled.id]);
+      expect(registry.list()).toEqual([]);
+      expect(registry.getByUuid(record.deviceSessionUuid)).toBeUndefined();
     });
 
     test("should initialize with multiple devices", async () => {


### PR DESCRIPTION
## Summary

Moves device-session retirement to `DevicePool`'s single removal seam. Every successful pool removal now synchronously notifies the daemon, which retires the corresponding in-memory session epoch before cache cleanup. This covers refresh eviction, assignment liveness eviction, idle iOS pruning, process recovery, and the disconnect monitor without risking a stale device-session record.

The prior monitor-only retirement is removed. Same-serial recovery remains safe: removal retires the old epoch, then the existing ready listener mints the replacement's new incarnation.

## Linked Issue

Closes [#5266](https://github.com/kaeawc/auto-mobile/issues/5266)

## Bug / Regression Context

- **Prior attempts:** [PR #5265](https://github.com/kaeawc/auto-mobile/pull/5265) minted connection epochs and retired them from the disconnect monitor only.
- **Observed symptom:** a device removed through another pool path remained listed for the daemon lifetime and its prior UUID still resolved.
- **Repro steps / conditions:** remove an idle pooled device through refresh, liveness, or pruning before the disconnect monitor independently confirms it.

## Validation

- [x] `bun test test/daemon/devicePool.test.ts test/daemon/deviceSessionRegistry.test.ts test/daemon/daemonRequestHandlers.test.ts`
- [x] `bun run turbo:validate`
- [x] `bun run typecheck` reports no new errors (baseline gate)
- [x] New code uses the injected listener plus existing `FakeTimer` and `FakeIdGenerator`; focused unit coverage remains below 100ms
- [x] No dependency or generic helper added
- [x] Rebased onto latest `main`, conflicts resolved

## Device Verification

N/A — in-memory daemon lifecycle behavior with unit and fake-daemon coverage.
