### PR TITLE
fix(killDevice): wait for device shutdown

### DIFF
--- a/schemas/tool-definitions.json
+++ b/schemas/tool-definitions.json
@@ -2788,6 +2788,9 @@
                 "android",
                 "ios"
               ]
+            },
+            "transportId": {
+              "type": "string"
             }
           },
           "required": [

--- a/src/daemon/devicePool.ts
+++ b/src/daemon/devicePool.ts
@@ -1293,6 +1293,13 @@ export class DevicePool {
     reason: string,
     recoverAndroidEmulator: boolean = false,
   ): Promise<void> {
+    if (this.isReservedForShutdown(device)) {
+      // killDevice alone owns a shutdown-reserved incarnation until it either
+      // retires it or atomically hands off a same-ID replacement. Discovery
+      // pruning must not remove it in the middle of that handoff.
+      logger.debug(`Deferring eviction of shutdown-reserved device ${device.id}: ${reason}`);
+      return;
+    }
     logger.warn(`Evicting device ${device.id} from pool: ${reason}`);
     if (device.sessionId) {
       await this.releaseSessionForDisconnectedDevice(

--- a/src/daemon/devicePool.ts
+++ b/src/daemon/devicePool.ts
@@ -410,7 +410,11 @@ export class DevicePool {
   /**
    * Add a new device to the pool
    */
-  async addDevice(device: BootedDevice, sourceImage?: DeviceInfo): Promise<void> {
+  async addDevice(
+    device: BootedDevice,
+    sourceImage?: DeviceInfo,
+    awaitSessionTracking: boolean = true,
+  ): Promise<void> {
     this.clearAutoStartSuppressionForBootedDevice(device, sourceImage);
     if (sourceImage) {
       this.intentionalShutdowns.delete(device.deviceId);
@@ -449,7 +453,14 @@ export class DevicePool {
       this.recordSourceAndroidAvd(device.deviceId, sourceImage);
       this.deviceSessionStarts.set(device.deviceId, now);
       this.refreshMissingDeviceMisses.delete(device.deviceId);
-      await this.setDeviceSessionTracking(device.deviceId, now);
+      const sessionTracking = this.setDeviceSessionTracking(device.deviceId, now);
+      if (awaitSessionTracking) {
+        await sessionTracking;
+      } else {
+        // Shutdown replacement already owns assignmentMutex. Persisting cache
+        // metadata is best-effort and must not make allocators wait forever.
+        void sessionTracking;
+      }
 
       logger.info(`Added device ${device.deviceId} to pool`);
     }
@@ -2201,7 +2212,11 @@ export class DevicePool {
       if (this.devices.has(expectedDevice.id)) {
         return undefined;
       }
-      await this.addDevice(replacement, this.sourceImageForSameAndroidReplacement(expectedDevice, replacement));
+      await this.addDevice(
+        replacement,
+        this.sourceImageForSameAndroidReplacement(expectedDevice, replacement),
+        false,
+      );
       return this.devices.get(replacement.deviceId);
     });
   }
@@ -2293,7 +2308,7 @@ export class DevicePool {
       if (!expectedDevice) {
         return;
       }
-      if (this.shutdownReservations.has(deviceId)) {
+      if (this.shutdownReservations.get(deviceId) === expectedDevice) {
         throw new ActionableError(`Device '${deviceId}' is already shutting down.`);
       }
       this.shutdownReservations.set(deviceId, expectedDevice);

--- a/src/daemon/devicePool.ts
+++ b/src/daemon/devicePool.ts
@@ -2208,6 +2208,7 @@ export class DevicePool {
       replacement.platform !== "android" ||
       !expectedDevice.avdName ||
       !expectedDevice.androidImage ||
+      replacement.name !== expectedDevice.avdName ||
       !this.criteriaMatcher.androidRediscoveryMatches(
         replacement,
         expectedDevice.id,

--- a/src/daemon/devicePool.ts
+++ b/src/daemon/devicePool.ts
@@ -468,7 +468,7 @@ export class DevicePool {
   /**
    * Remove device from pool
    */
-  async removeDevice(deviceId: string): Promise<void> {
+  async removeDevice(deviceId: string, awaitCacheCleanup: boolean = true): Promise<void> {
     const device = this.devices.get(deviceId);
     if (!device) {
       return;
@@ -487,7 +487,14 @@ export class DevicePool {
     if (this.lastReleasedDeviceId === deviceId) {
       this.lastReleasedDeviceId = null;
     }
-    await this.clearDeviceSessionCache(deviceId);
+    const cacheCleanup = this.clearDeviceSessionCache(deviceId);
+    if (awaitCacheCleanup) {
+      await cacheCleanup;
+    } else {
+      void cacheCleanup.catch((error) => {
+        logger.warn(`[DevicePool] Deferred cache cleanup failed for ${deviceId}: ${error}`, error);
+      });
+    }
     logger.info(`Removed device ${deviceId} from pool and cleared cached data`);
   }
 
@@ -2171,7 +2178,7 @@ export class DevicePool {
         return false;
       }
       this.releaseCapturedDeviceForShutdown(expectedDevice);
-      await this.removeDevice(expectedDevice.id);
+      await this.removeDevice(expectedDevice.id, false);
       return !this.devices.has(expectedDevice.id);
     });
   }
@@ -2190,7 +2197,7 @@ export class DevicePool {
         return undefined;
       }
       this.releaseCapturedDeviceForShutdown(expectedDevice);
-      await this.removeDevice(expectedDevice.id);
+      await this.removeDevice(expectedDevice.id, false);
       if (this.devices.has(expectedDevice.id)) {
         return undefined;
       }

--- a/src/daemon/devicePool.ts
+++ b/src/daemon/devicePool.ts
@@ -2272,12 +2272,15 @@ export class DevicePool {
    * gone and retires its ownership. A replacement with the same ID remains
    * independently assignable once it has been atomically installed.
    */
-  async reserveDeviceForShutdown(deviceId: string): Promise<{
+  async reserveDeviceForShutdown(deviceId: string, abortSignal?: AbortSignal): Promise<{
     device: PooledDevice;
     release: () => Promise<void>;
   } | undefined> {
     let expectedDevice: PooledDevice | undefined;
     await this.assignmentMutex.runExclusive(() => {
+      if (abortSignal?.aborted) {
+        throw abortSignal.reason ?? new Error("Shutdown reservation cancelled");
+      }
       expectedDevice = this.devices.get(deviceId);
       if (!expectedDevice) {
         return;

--- a/src/daemon/devicePool.ts
+++ b/src/daemon/devicePool.ts
@@ -541,12 +541,26 @@ export class DevicePool {
     return true;
   }
 
+  private async shouldDeferDisconnectCleanup(
+    deviceId: string,
+    device: PooledDevice | undefined,
+    mayBeStaleSignal: boolean,
+  ): Promise<boolean> {
+    if (device && this.isReservedForShutdown(device)) {
+      // killDevice owns this captured incarnation until its bounded disappearance
+      // check retires it (or hands a replacement to the pool). A concurrent
+      // monitor signal must not release its session or consume its marker.
+      return true;
+    }
+    return await this.applyIntentionalShutdownOnDisconnect(deviceId, device, mayBeStaleSignal);
+  }
+
   async removeDisconnectedDevice(
     deviceId: string,
     mayBeStaleSignal: boolean = true,
   ): Promise<void> {
     const device = this.devices.get(deviceId);
-    if (await this.applyIntentionalShutdownOnDisconnect(deviceId, device, mayBeStaleSignal)) {
+    if (await this.shouldDeferDisconnectCleanup(deviceId, device, mayBeStaleSignal)) {
       return;
     }
     if (!device || device.sessionId) {

--- a/src/daemon/devicePool.ts
+++ b/src/daemon/devicePool.ts
@@ -2301,11 +2301,11 @@ export class DevicePool {
         return;
       }
       released = true;
-      await this.assignmentMutex.runExclusive(() => {
-        if (this.shutdownReservations.get(capturedDevice.id) === capturedDevice) {
-          this.shutdownReservations.delete(capturedDevice.id);
-        }
-      });
+      // Reservation ownership is identity-scoped. Releasing it does not mutate
+      // the pool, so it must not queue behind a refresh holding assignmentMutex.
+      if (this.shutdownReservations.get(capturedDevice.id) === capturedDevice) {
+        this.shutdownReservations.delete(capturedDevice.id);
+      }
     };
     return { device: capturedDevice, release };
   }

--- a/src/daemon/devicePool.ts
+++ b/src/daemon/devicePool.ts
@@ -2161,9 +2161,29 @@ export class DevicePool {
       if (this.devices.has(expectedDevice.id)) {
         return undefined;
       }
-      await this.addDevice(replacement);
+      await this.addDevice(replacement, this.sourceImageForSameAndroidReplacement(expectedDevice, replacement));
       return this.devices.get(replacement.deviceId);
     });
+  }
+
+  private sourceImageForSameAndroidReplacement(
+    expectedDevice: PooledDevice,
+    replacement: BootedDevice,
+  ): DeviceInfo | undefined {
+    if (
+      expectedDevice.platform !== "android" ||
+      replacement.platform !== "android" ||
+      !expectedDevice.avdName ||
+      !expectedDevice.androidImage ||
+      !this.criteriaMatcher.androidRediscoveryMatches(
+        replacement,
+        expectedDevice.id,
+        expectedDevice.avdName,
+      )
+    ) {
+      return undefined;
+    }
+    return expectedDevice.androidImage;
   }
 
   private releaseCapturedDeviceForShutdown(device: PooledDevice): void {

--- a/src/daemon/devicePool.ts
+++ b/src/daemon/devicePool.ts
@@ -170,6 +170,12 @@ export class DevicePool {
   private readonly startedDeviceProcesses: Map<string, ChildProcess> = new Map();
   private readonly readinessReservationCounts: Map<string, number> = new Map();
   /**
+   * Captured incarnations that an explicit shutdown is retiring. Unlike a
+   * readiness reservation, this excludes direct startDevice/autolock binding
+   * as well as ordinary pool allocation.
+   */
+  private readonly shutdownReservations: Map<string, PooledDevice> = new Map();
+  /**
    * Serials the user intentionally stopped, mapped to the pooled-device
    * incarnation that was present at mark time (or {@link INCARNATION_ANY} when
    * only a recovery was in flight). Consuming this on a disconnect is gated on
@@ -1775,7 +1781,7 @@ export class DevicePool {
       // If no devices available and pool is empty, try to refresh
       // This handles race conditions during daemon startup
       const busyDevicesBeforeRefresh = candidates.filter(
-        (device) => device.status === "busy" || this.isReservedForReadiness(device.id),
+        (device) => device.status === "busy" || this.isReservedForAssignment(device),
       ).length;
       if (
         !device &&
@@ -1803,7 +1809,7 @@ export class DevicePool {
       if (!device) {
         // No idle device - check if devices exist but are busy
         const busyDevices = candidates.filter(
-          (candidate) => candidate.status === "busy" || this.isReservedForReadiness(candidate.id),
+          (candidate) => candidate.status === "busy" || this.isReservedForAssignment(candidate),
         ).length;
 
         return {
@@ -1900,7 +1906,7 @@ export class DevicePool {
   private selectIdleDevice(candidates: PooledDevice[]): PooledDevice | undefined {
     // Find idle devices and prefer most recently released for reuse
     const idleDevices = candidates.filter(
-      (device) => device.status === "idle" && !this.isReservedForReadiness(device.id),
+      (device) => device.status === "idle" && !this.isReservedForAssignment(device),
     );
     if (idleDevices.length === 0) {
       return undefined;
@@ -2235,6 +2241,52 @@ export class DevicePool {
   }
 
   /**
+   * Exclusively reserve a captured incarnation while killDevice confirms it is
+   * gone and retires its ownership. A replacement with the same ID remains
+   * independently assignable once it has been atomically installed.
+   */
+  async reserveDeviceForShutdown(expectedDevice: PooledDevice): Promise<() => Promise<void>> {
+    await this.assignmentMutex.runExclusive(() => {
+      if (this.devices.get(expectedDevice.id) !== expectedDevice) {
+        throw new ActionableError(
+          `Device '${expectedDevice.id}' is no longer available for shutdown.`,
+        );
+      }
+      if (this.shutdownReservations.has(expectedDevice.id)) {
+        throw new ActionableError(`Device '${expectedDevice.id}' is already shutting down.`);
+      }
+      this.shutdownReservations.set(expectedDevice.id, expectedDevice);
+    });
+
+    let released = false;
+    return async () => {
+      if (released) {
+        return;
+      }
+      released = true;
+      await this.assignmentMutex.runExclusive(() => {
+        if (this.shutdownReservations.get(expectedDevice.id) === expectedDevice) {
+          this.shutdownReservations.delete(expectedDevice.id);
+        }
+      });
+    };
+  }
+
+  private isReservedForShutdown(device: PooledDevice): boolean {
+    return this.shutdownReservations.get(device.id) === device;
+  }
+
+  private isReservedForAssignment(device: PooledDevice): boolean {
+    return this.isReservedForReadiness(device.id) || this.isReservedForShutdown(device);
+  }
+
+  private assertNotReservedForShutdown(device: PooledDevice, unavailableMessage: string): void {
+    if (this.isReservedForShutdown(device)) {
+      throw new ActionableError(unavailableMessage);
+    }
+  }
+
+  /**
    * Bind a known device to a session without running the pool's idle-device
    * selection. If the device is already bound to a live session, reuse that
    * session so repeated startDevice calls stay idempotent.
@@ -2249,10 +2301,6 @@ export class DevicePool {
   ): Promise<string> {
     return await this.assignmentMutex.runExclusive(async () => {
       const alreadyPooled = this.devices.has(deviceId);
-      if (alreadyPooled) {
-        this.recordSourceAndroidAvd(deviceId, sourceImage);
-        this.notifyDeviceReady(deviceId);
-      }
       if (!alreadyPooled) {
         const bootedDevices = await this.deviceManager.getBootedDevices(platform);
         const booted = bootedDevices.find((d) => d.deviceId === deviceId);
@@ -2266,6 +2314,14 @@ export class DevicePool {
         throw new ActionableError(`Device '${deviceId}' is not available in the device pool.`);
       }
       this.assertRuntimeIdentity(device, expectedIdentity);
+      this.assertNotReservedForShutdown(
+        device,
+        `Device '${deviceId}' is shutting down and cannot be assigned.`,
+      );
+      if (alreadyPooled) {
+        this.recordSourceAndroidAvd(deviceId, sourceImage);
+        this.notifyDeviceReady(deviceId);
+      }
       await this.trackStartedDeviceProcess(
         {
           deviceId: device.id,
@@ -2425,10 +2481,6 @@ export class DevicePool {
 
     // Ensure device is in the pool (it may have been freshly booted)
     const alreadyPooled = this.devices.has(deviceId);
-    if (alreadyPooled) {
-      this.recordSourceAndroidAvd(deviceId, sourceImage);
-      this.notifyDeviceReady(deviceId);
-    }
     if (!alreadyPooled) {
       const bootedDevices = await this.deviceManager.getBootedDevices(platform);
       const booted = bootedDevices.find((d) => d.deviceId === deviceId);
@@ -2450,6 +2502,14 @@ export class DevicePool {
       );
     }
     this.assertRuntimeIdentity(device, expectedIdentity);
+    this.assertNotReservedForShutdown(
+      device,
+      `Device '${deviceId}' is shutting down and cannot be autolocked.`,
+    );
+    if (alreadyPooled) {
+      this.recordSourceAndroidAvd(deviceId, sourceImage);
+      this.notifyDeviceReady(deviceId);
+    }
     await this.trackStartedDeviceProcess(
       {
         deviceId: device.id,
@@ -2664,7 +2724,7 @@ export class DevicePool {
    */
   getIdleDevices(): PooledDevice[] {
     return Array.from(this.devices.values()).filter(
-      (device) => device.status === "idle" && !this.isReservedForReadiness(device.id),
+      (device) => device.status === "idle" && !this.isReservedForAssignment(device),
     );
   }
 
@@ -2757,10 +2817,10 @@ export class DevicePool {
   } {
     const devices = this.getDevicesByPlatform(platform);
     const idle = devices.filter(
-      (device) => device.status === "idle" && !this.isReservedForReadiness(device.id),
+      (device) => device.status === "idle" && !this.isReservedForAssignment(device),
     ).length;
     const assigned = devices.filter(
-      (device) => device.status === "busy" || this.isReservedForReadiness(device.id),
+      (device) => device.status === "busy" || this.isReservedForAssignment(device),
     ).length;
     const error = devices.filter((device) => device.status === "error").length;
 
@@ -2785,7 +2845,7 @@ export class DevicePool {
     const all = this.getAllDevices();
     const idle = this.getIdleDevices().length;
     const assigned = all.filter(
-      (device) => device.status === "busy" || this.isReservedForReadiness(device.id),
+      (device) => device.status === "busy" || this.isReservedForAssignment(device),
     ).length;
     const error = this.getErrorDevices().length;
     const avgAssignments =

--- a/src/daemon/devicePool.ts
+++ b/src/daemon/devicePool.ts
@@ -1577,6 +1577,12 @@ export class DevicePool {
     if (!device) {
       return;
     }
+    if (this.isReservedForShutdown(device)) {
+      // An explicit kill owns this incarnation until it confirms physical exit
+      // and retires ownership. Its tracked process exit is expected and must
+      // not cancel the initiating request or plan through normal loss cleanup.
+      return;
+    }
 
     await this.evictMissingPooledDevice(
       device,

--- a/src/daemon/devicePool.ts
+++ b/src/daemon/devicePool.ts
@@ -2128,6 +2128,52 @@ export class DevicePool {
   }
 
   /**
+   * Retire a captured device incarnation without publishing it as idle first.
+   * A device that has been explicitly stopped must not become assignable in the
+   * interval between its session release and pool removal.
+   */
+  async retireDeviceForShutdown(expectedDevice: PooledDevice): Promise<boolean> {
+    return await this.assignmentMutex.runExclusive(async () => {
+      if (this.devices.get(expectedDevice.id) !== expectedDevice) {
+        return false;
+      }
+      this.releaseCapturedDeviceForShutdown(expectedDevice);
+      await this.removeDevice(expectedDevice.id);
+      return this.devices.get(expectedDevice.id) !== expectedDevice;
+    });
+  }
+
+  /**
+   * Atomically replace a captured stopped-device incarnation with the device
+   * discovered under the same ID. This keeps allocators from claiming the old
+   * device during the handoff.
+   */
+  async replaceDeviceForShutdown(
+    expectedDevice: PooledDevice,
+    replacement: BootedDevice,
+  ): Promise<PooledDevice | undefined> {
+    return await this.assignmentMutex.runExclusive(async () => {
+      if (this.devices.get(expectedDevice.id) !== expectedDevice) {
+        return undefined;
+      }
+      this.releaseCapturedDeviceForShutdown(expectedDevice);
+      await this.removeDevice(expectedDevice.id);
+      if (this.devices.has(expectedDevice.id)) {
+        return undefined;
+      }
+      await this.addDevice(replacement);
+      return this.devices.get(replacement.deviceId);
+    });
+  }
+
+  private releaseCapturedDeviceForShutdown(device: PooledDevice): void {
+    device.sessionId = null;
+    device.status = "idle";
+    device.errorCount = 0;
+    this.lastReleasedDeviceId = device.id;
+  }
+
+  /**
    * Keep an exact device out of general pool allocation while startDevice
    * verifies its runner. The reservation does not create a user-visible
    * session; session ownership is transferred only after readiness succeeds.

--- a/src/daemon/devicePool.ts
+++ b/src/daemon/devicePool.ts
@@ -2245,31 +2245,39 @@ export class DevicePool {
    * gone and retires its ownership. A replacement with the same ID remains
    * independently assignable once it has been atomically installed.
    */
-  async reserveDeviceForShutdown(expectedDevice: PooledDevice): Promise<() => Promise<void>> {
+  async reserveDeviceForShutdown(deviceId: string): Promise<{
+    device: PooledDevice;
+    release: () => Promise<void>;
+  } | undefined> {
+    let expectedDevice: PooledDevice | undefined;
     await this.assignmentMutex.runExclusive(() => {
-      if (this.devices.get(expectedDevice.id) !== expectedDevice) {
-        throw new ActionableError(
-          `Device '${expectedDevice.id}' is no longer available for shutdown.`,
-        );
+      expectedDevice = this.devices.get(deviceId);
+      if (!expectedDevice) {
+        return;
       }
-      if (this.shutdownReservations.has(expectedDevice.id)) {
-        throw new ActionableError(`Device '${expectedDevice.id}' is already shutting down.`);
+      if (this.shutdownReservations.has(deviceId)) {
+        throw new ActionableError(`Device '${deviceId}' is already shutting down.`);
       }
-      this.shutdownReservations.set(expectedDevice.id, expectedDevice);
+      this.shutdownReservations.set(deviceId, expectedDevice);
     });
+    if (!expectedDevice) {
+      return undefined;
+    }
+    const capturedDevice = expectedDevice;
 
     let released = false;
-    return async () => {
+    const release = async () => {
       if (released) {
         return;
       }
       released = true;
       await this.assignmentMutex.runExclusive(() => {
-        if (this.shutdownReservations.get(expectedDevice.id) === expectedDevice) {
-          this.shutdownReservations.delete(expectedDevice.id);
+        if (this.shutdownReservations.get(capturedDevice.id) === capturedDevice) {
+          this.shutdownReservations.delete(capturedDevice.id);
         }
       });
     };
+    return { device: capturedDevice, release };
   }
 
   private isReservedForShutdown(device: PooledDevice): boolean {

--- a/src/daemon/devicePool.ts
+++ b/src/daemon/devicePool.ts
@@ -2202,6 +2202,7 @@ export class DevicePool {
   async replaceDeviceForShutdown(
     expectedDevice: PooledDevice,
     replacement: BootedDevice,
+    beforeReplacementPublishes?: () => void,
   ): Promise<PooledDevice | undefined> {
     return await this.assignmentMutex.runExclusive(async () => {
       if (this.devices.get(expectedDevice.id) !== expectedDevice) {
@@ -2212,6 +2213,7 @@ export class DevicePool {
       if (this.devices.has(expectedDevice.id)) {
         return undefined;
       }
+      beforeReplacementPublishes?.();
       await this.addDevice(
         replacement,
         this.sourceImageForSameAndroidReplacement(expectedDevice, replacement),

--- a/src/daemon/devicePool.ts
+++ b/src/daemon/devicePool.ts
@@ -2139,7 +2139,7 @@ export class DevicePool {
       }
       this.releaseCapturedDeviceForShutdown(expectedDevice);
       await this.removeDevice(expectedDevice.id);
-      return this.devices.get(expectedDevice.id) !== expectedDevice;
+      return !this.devices.has(expectedDevice.id);
     });
   }
 

--- a/src/server/deviceTools.ts
+++ b/src/server/deviceTools.ts
@@ -19,6 +19,7 @@ import { DEVICE_POOL_MATCHING, isDevicePoolAutolockEnabled } from "../daemon/poo
 import { DEVICE_CREATE_ENV_VAR, getDeviceCreationGate, type DeviceCreationGate } from "../utils/deviceCreationGate";
 import { createDefaultDeviceProvisioner, type DeviceProvisioner } from "../utils/deviceProvisioning";
 import { DaemonState } from "../daemon/daemonState";
+import type { PooledDevice } from "../daemon/devicePool";
 import { DeviceBootService, type DeviceBootResult } from "../utils/deviceBootService";
 import { getInstalledAppsCacheWriteCoordinator } from "../db/installedAppsCacheWriteCoordinator";
 import { getDbWriteBarrier } from "../db/dbWriteBarrier";
@@ -108,6 +109,12 @@ export const killDeviceSchema = z.object({
 });
 
 export const DEVICE_ALREADY_STOPPED_ERROR_CODE = "device_already_stopped";
+
+// A successful platform shutdown command only confirms that the request was
+// accepted. Keep the public killDevice result coupled to the observable device
+// lifecycle, while bounding the wait so a wedged platform command is actionable.
+const DEVICE_SHUTDOWN_TIMEOUT_MS = 30_000;
+const DEVICE_SHUTDOWN_POLL_INTERVAL_MS = 1_000;
 
 function isAlreadyStoppedDeviceError(
   platform: SomePlatform,
@@ -240,6 +247,113 @@ async function notifyResourcesAfterShutdown(dependencies: DeviceToolsDependencie
     // The device is already stopped; resource subscriptions refresh on their next update.
     logger.warn(`[DeviceTools] Failed to notify resource changes after shutdown: ${error}`, error);
   }
+}
+
+async function waitForDeviceShutdown(
+  deviceManager: PlatformDeviceManager,
+  device: BootedDevice,
+  timer: Timer,
+): Promise<void> {
+  const startedAt = timer.now();
+  for (;;) {
+    const discovery = await deviceManager.getBootedDevicesDetailed(device.platform);
+    const platformWasDiscovered = discovery.succeededPlatforms.has(device.platform);
+    const isStillBooted = discovery.devices.some(candidate =>
+      candidate.platform === device.platform && candidate.deviceId === device.deviceId,
+    );
+    if (platformWasDiscovered && !isStillBooted) {
+      return;
+    }
+
+    const elapsedMs = timer.now() - startedAt;
+    if (elapsedMs >= DEVICE_SHUTDOWN_TIMEOUT_MS) {
+      const discoveryDetail = platformWasDiscovered
+        ? "the device is still reported as booted"
+        : "platform discovery did not succeed";
+      throw new ActionableError(
+        `Timed out waiting for ${device.platform} device '${device.name}' (${device.deviceId}) ` +
+        `to disappear after ${DEVICE_SHUTDOWN_TIMEOUT_MS}ms: ${discoveryDetail}. ` +
+        "Verify the platform shutdown state and retry.",
+      );
+    }
+    await timer.sleep(Math.min(DEVICE_SHUTDOWN_POLL_INTERVAL_MS, DEVICE_SHUTDOWN_TIMEOUT_MS - elapsedMs));
+  }
+}
+
+async function retireShutdownOwnership(
+  device: BootedDevice,
+  expectedPooledDevice: PooledDevice | null,
+): Promise<void> {
+  if (!expectedPooledDevice) {
+    return;
+  }
+  const daemonState = DaemonState.getInstance();
+  if (!daemonState.isInitialized()) {
+    return;
+  }
+  const devicePool = daemonState.getDevicePool();
+  // A fast reboot can reuse a serial. Do not release or remove a later pool
+  // incarnation that happens to use the same device ID.
+  if (devicePool.getDevice(device.deviceId) !== expectedPooledDevice) {
+    return;
+  }
+
+  const sessionManager = daemonState.getSessionManager();
+  const sessionId = expectedPooledDevice?.sessionId;
+  if (sessionId && sessionManager.getSessionForDevice(device.deviceId) === sessionId) {
+    await sessionManager.releaseSession(sessionId, `device-stopped:${device.deviceId}`);
+  }
+  if (devicePool.getDevice(device.deviceId) !== expectedPooledDevice) {
+    return;
+  }
+
+  await devicePool.releaseDevice(device.deviceId);
+  await devicePool.removeDisconnectedDevice(device.deviceId, false);
+  if (!devicePool.getDevice(device.deviceId)) {
+    daemonState.getDeviceSessionRegistry().onDeviceDisconnected(device.deviceId);
+  }
+}
+
+async function killProcessAndRetireOwnership(
+  dependencies: DeviceToolsDependencies,
+  device: BootedDevice,
+  perf: ReturnType<typeof createPerformanceTracker>,
+): Promise<string | undefined> {
+  const deviceManager = dependencies.deviceManagerFactory();
+  const devicePool = DaemonState.getInstance().isInitialized()
+    ? DaemonState.getInstance().getDevicePool()
+    : undefined;
+  const expectedPooledDevice = devicePool?.getDevice?.(device.deviceId) ?? null;
+  if (device.platform === "android") {
+    devicePool?.markIntentionalShutdown(device.deviceId);
+  }
+
+  let alreadyStoppedMessage: string | undefined;
+  perf.startOperation("killProcess");
+  try {
+    await deviceManager.killDevice(device);
+  } catch (error) {
+    if (isAlreadyStoppedDeviceError(device.platform, device.deviceId, error)) {
+      alreadyStoppedMessage = `Failed to kill ${device.platform} device: ${error}`;
+    } else {
+      devicePool?.clearIntentionalShutdown(device.deviceId);
+      throw error;
+    }
+  }
+  perf.endOperation("killProcess");
+
+  if (alreadyStoppedMessage !== undefined) {
+    return alreadyStoppedMessage;
+  }
+
+  perf.startOperation("waitForShutdown");
+  await waitForDeviceShutdown(deviceManager, device, dependencies.timer);
+  perf.endOperation("waitForShutdown");
+
+  perf.startOperation("retireOwnership");
+  await retireShutdownOwnership(device, expectedPooledDevice);
+  perf.endOperation("retireOwnership");
+  return undefined;
 }
 
 let moduleDependencies: DeviceToolsDependencies | null = null;
@@ -651,26 +765,7 @@ export function registerDeviceTools() {
       }
 
       const deps = getDeviceToolsDependencies();
-      const deviceUtils = deps.deviceManagerFactory();
-      perf.startOperation("killProcess");
-      const devicePool = DaemonState.getInstance().isInitialized()
-        ? DaemonState.getInstance().getDevicePool()
-        : undefined;
-      if (args.device.platform === "android") {
-        devicePool?.markIntentionalShutdown(args.device.deviceId);
-      }
-      let alreadyStoppedMessage: string | undefined;
-      try {
-        await deviceUtils.killDevice(args.device);
-      } catch (error) {
-        if (isAlreadyStoppedDeviceError(args.device.platform, args.device.deviceId, error)) {
-          alreadyStoppedMessage = `Failed to kill ${args.device.platform} device: ${error}`;
-        } else {
-          devicePool?.clearIntentionalShutdown(args.device.deviceId);
-          throw error;
-        }
-      }
-      perf.endOperation("killProcess");
+      const alreadyStoppedMessage = await killProcessAndRetireOwnership(deps, args.device, perf);
 
       perf.startOperation("cleanup");
       await clearInstalledAppsAfterShutdown(deps, args.device.deviceId);

--- a/src/server/deviceTools.ts
+++ b/src/server/deviceTools.ts
@@ -17,6 +17,7 @@ import { listActiveVideoRecordings, stopVideoRecording } from "./videoRecordingM
 import { IOSCtrlProxyManager } from "../utils/IOSCtrlProxyManager";
 import { logger } from "../utils/logger";
 import { createPerformanceTracker } from "../utils/PerformanceTracker";
+import { getPerformanceMonitor } from "../features/performance/PerformanceMonitor";
 import { platformSchema } from "./toolSchemaHelpers";
 import { DefaultDeviceMatcher, type DeviceMatcher } from "../utils/deviceMatcher";
 import { DEVICE_POOL_MATCHING, isDevicePoolAutolockEnabled } from "../daemon/poolConfig";
@@ -121,6 +122,7 @@ export const DEVICE_ALREADY_STOPPED_ERROR_CODE = "device_already_stopped";
 // lifecycle, while bounding the wait so a wedged platform command is actionable.
 const DEVICE_SHUTDOWN_TIMEOUT_MS = 30_000;
 const DEVICE_SHUTDOWN_POLL_INTERVAL_MS = 1_000;
+const DEVICE_SHUTDOWN_POST_RELEASE_RECHECK_TIMEOUT_MS = 1_000;
 
 function isAlreadyStoppedDeviceError(
   platform: SomePlatform,
@@ -213,6 +215,7 @@ export interface DeviceToolsDependencies {
   deviceCreationGateFactory: () => DeviceCreationGate;
   deviceProvisionerFactory: () => DeviceProvisioner;
   clearInstalledAppsForDevice: (deviceId: string) => Promise<void>;
+  stopPerformanceMonitoring: (deviceId: string) => void;
   idGenerator: IdGenerator;
   timer: Timer;
 }
@@ -374,17 +377,21 @@ async function findReplacementAfterSessionRelease(
   device: BootedDevice,
   timer: Timer,
   deadlineMs: number,
-  replacementObservedDuringShutdown: BootedDevice | undefined,
 ): Promise<BootedDevice | undefined> {
-  if (timer.now() >= deadlineMs) {
-    return replacementObservedDuringShutdown;
-  }
-  const discovery = await getShutdownDiscovery(deviceManager, device, timer, deadlineMs);
+  // The absence observation only proves the old incarnation was gone before
+  // session release. A same-ID replacement can appear while that release
+  // awaits persistence, so reserve a short, bounded recheck even after the
+  // disappearance deadline was consumed.
+  const recheckDeadlineMs = Math.max(
+    deadlineMs,
+    timer.now() + DEVICE_SHUTDOWN_POST_RELEASE_RECHECK_TIMEOUT_MS,
+  );
+  const discovery = await getShutdownDiscovery(deviceManager, device, timer, recheckDeadlineMs);
   const replacement = findDiscoveredDevice(discovery, device);
   if (replacement || discovery.succeededPlatforms.has(device.platform)) {
     return replacement;
   }
-  return await waitForDeviceShutdown(deviceManager, device, timer, deadlineMs);
+  return await waitForDeviceShutdown(deviceManager, device, timer, recheckDeadlineMs);
 }
 
 async function retireShutdownOwnership(
@@ -394,7 +401,7 @@ async function retireShutdownOwnership(
   timer: Timer,
   deadlineMs: number,
   abortSignal: AbortSignal | undefined,
-  replacementObservedDuringShutdown: BootedDevice | undefined,
+  stopPerformanceMonitoring: (deviceId: string) => void,
 ): Promise<void> {
   if (!expectedPooledDevice) {
     return;
@@ -427,15 +434,13 @@ async function retireShutdownOwnership(
   // A same-ID replacement can boot while releasing the old session. If so,
   // retire only the captured incarnation, then immediately rediscover the
   // replacement so it owns a fresh pool and registry epoch. Once shutdown was
-  // observed, an exhausted disappearance deadline must not prevent ownership
-  // cleanup; reuse that successful observation instead of starting another
-  // deadline-bound discovery.
+  // observed, a bounded post-release recheck protects against a replacement
+  // that boots at the disappearance deadline.
   const replacement = await findReplacementAfterSessionRelease(
     deviceManager,
     device,
     timer,
     deadlineMs,
-    replacementObservedDuringShutdown,
   );
   if (replacement) {
     await rebuildSameIdReplacement(device, expectedPooledDevice, replacement, daemonState);
@@ -445,6 +450,7 @@ async function retireShutdownOwnership(
     return;
   }
   if (await devicePool.retireDeviceForShutdown(expectedPooledDevice)) {
+    stopPerformanceMonitoring(device.deviceId);
     daemonState.getDeviceSessionRegistry().onDeviceDisconnected(device.deviceId);
   }
 }
@@ -486,7 +492,7 @@ async function killProcessAndRetireOwnership(
 
   const shutdownDeadlineMs = dependencies.timer.now() + DEVICE_SHUTDOWN_TIMEOUT_MS;
   perf.startOperation("waitForShutdown");
-  const replacementObservedDuringShutdown = await waitForDeviceShutdown(
+  await waitForDeviceShutdown(
     deviceManager,
     shutdownDevice,
     dependencies.timer,
@@ -502,7 +508,7 @@ async function killProcessAndRetireOwnership(
     dependencies.timer,
     shutdownDeadlineMs,
     abortSignal,
-    replacementObservedDuringShutdown,
+    dependencies.stopPerformanceMonitoring,
   );
   perf.endOperation("retireOwnership");
   return undefined;
@@ -519,6 +525,7 @@ function getDeviceToolsDependencies(): DeviceToolsDependencies {
       deviceCreationGateFactory: () => getDeviceCreationGate(),
       deviceProvisionerFactory: () => createDefaultDeviceProvisioner(),
       clearInstalledAppsForDevice: defaultClearInstalledAppsForDevice,
+      stopPerformanceMonitoring: deviceId => getPerformanceMonitor().stopMonitoring(deviceId),
       idGenerator: defaultIdGenerator,
       timer: defaultTimer,
     };
@@ -537,6 +544,8 @@ export function setDeviceToolsDependencies(deps: Partial<DeviceToolsDependencies
     deviceProvisionerFactory: deps.deviceProvisionerFactory ?? currentDeps.deviceProvisionerFactory,
     clearInstalledAppsForDevice:
       deps.clearInstalledAppsForDevice ?? currentDeps.clearInstalledAppsForDevice,
+    stopPerformanceMonitoring:
+      deps.stopPerformanceMonitoring ?? currentDeps.stopPerformanceMonitoring,
     idGenerator: deps.idGenerator ?? currentDeps.idGenerator,
     timer: deps.timer ?? currentDeps.timer,
   };

--- a/src/server/deviceTools.ts
+++ b/src/server/deviceTools.ts
@@ -267,6 +267,10 @@ function shutdownTimeoutError(device: BootedDevice, detail: string): ActionableE
   );
 }
 
+function isShutdownTimeoutError(error: unknown): error is ActionableError {
+  return error instanceof ActionableError && String(error.message).startsWith("Timed out waiting for");
+}
+
 function abortPromise(signal: AbortSignal | undefined): {
   promise: Promise<never> | undefined;
   cleanup: () => void;
@@ -558,13 +562,12 @@ async function killProcessAndRetireOwnership(
   dependencies: DeviceToolsDependencies,
   device: BootedDevice,
   perf: ReturnType<typeof createPerformanceTracker>,
-  abortSignal: AbortSignal | undefined,
+  requestAbortSignal: AbortSignal | undefined,
   devicePool: DevicePool | undefined,
   expectedPooledDevice: PooledDevice | null,
+  shutdownDeadlineMs: number,
 ): Promise<string | undefined> {
   const deviceManager = dependencies.deviceManagerFactory();
-  const shutdownDeadlineMs = dependencies.timer.now() + DEVICE_SHUTDOWN_TIMEOUT_MS;
-  const requestAbortSignal = abortSignal ?? getAbortSignal();
   if (device.platform === "android") {
     devicePool?.markIntentionalShutdown(device.deviceId);
   }
@@ -1013,20 +1016,47 @@ export function registerDeviceTools() {
     perf.serial("killDevice");
     const daemonState = DaemonState.getInstance();
     const devicePool = daemonState.isInitialized() ? daemonState.getDevicePool() : undefined;
+    const deps = getDeviceToolsDependencies();
+    const shutdownDeadlineMs = deps.timer.now() + DEVICE_SHUTDOWN_TIMEOUT_MS;
+    const requestAbortSignal = abortSignal ?? getAbortSignal();
     let shutdownReservation: Awaited<ReturnType<DevicePool["reserveDeviceForShutdown"]>>;
     try {
-      shutdownReservation = await devicePool?.reserveDeviceForShutdown(args.device.deviceId);
+      shutdownReservation = await runWithinShutdownDeadline(
+        args.device,
+        deps.timer,
+        shutdownDeadlineMs,
+        "shutdown preparation did not complete",
+        requestAbortSignal,
+        async () => await devicePool?.reserveDeviceForShutdown(args.device.deviceId),
+      );
       const expectedPooledDevice = shutdownReservation?.device ?? null;
 
       perf.startOperation("stopRecordings");
-      const activeRecordings = await listActiveVideoRecordings({
-        deviceId: args.device.deviceId,
-        platform: args.device.platform,
-      });
+      const activeRecordings = await runWithinShutdownDeadline(
+        args.device,
+        deps.timer,
+        shutdownDeadlineMs,
+        "recording discovery did not complete",
+        requestAbortSignal,
+        async () => await listActiveVideoRecordings({
+          deviceId: args.device.deviceId,
+          platform: args.device.platform,
+        }),
+      );
       for (const recording of activeRecordings) {
         try {
-          await stopVideoRecording(recording.recordingId);
+          await runWithinShutdownDeadline(
+            args.device,
+            deps.timer,
+            shutdownDeadlineMs,
+            "video recording teardown did not complete",
+            requestAbortSignal,
+            async () => await stopVideoRecording(recording.recordingId),
+          );
         } catch (error) {
+          if (isShutdownTimeoutError(error)) {
+            throw error;
+          }
           logger.warn(
             `[DeviceTools] Failed to stop recording ${recording.recordingId} before shutdown: ${error}`
           );
@@ -1044,21 +1074,31 @@ export function registerDeviceTools() {
             deviceId: args.device.deviceId,
             source: "local",
           });
-          await xcTestManager.stop();
+          await runWithinShutdownDeadline(
+            args.device,
+            deps.timer,
+            shutdownDeadlineMs,
+            "iOS CtrlProxy shutdown did not complete",
+            requestAbortSignal,
+            async () => await xcTestManager.stop(),
+          );
         } catch (error) {
+          if (isShutdownTimeoutError(error)) {
+            throw error;
+          }
           logger.warn(`[DeviceTools] Failed to stop CtrlProxy iOS before kill: ${error}`);
         }
         perf.endOperation("stopCtrlProxy");
       }
 
-      const deps = getDeviceToolsDependencies();
       const alreadyStoppedMessage = await killProcessAndRetireOwnership(
         deps,
         args.device,
         perf,
-        abortSignal,
+        requestAbortSignal,
         devicePool,
         expectedPooledDevice,
+        shutdownDeadlineMs,
       );
 
       perf.startOperation("cleanup");

--- a/src/server/deviceTools.ts
+++ b/src/server/deviceTools.ts
@@ -605,6 +605,70 @@ async function findReplacementAfterSessionRelease(
   );
 }
 
+function finishLateShutdownRetirement(
+  release: Promise<string | null>,
+  device: BootedDevice,
+  expectedPooledDevice: PooledDevice,
+  observedReplacement: BootedDevice | undefined,
+  deviceManager: PlatformDeviceManager,
+  timer: Timer,
+  deadlineMs: number,
+  stopPerformanceMonitoring: (deviceId: string) => void,
+  retainReservationUntil: (retirement: Promise<void>) => void,
+): void {
+  const lateRetirement = release.then(async () => {
+    await retireShutdownOwnership(
+      device,
+      expectedPooledDevice,
+      observedReplacement,
+      deviceManager,
+      timer,
+      deadlineMs,
+      undefined,
+      stopPerformanceMonitoring,
+      () => undefined,
+    );
+  });
+  lateRetirement.catch(lateError => {
+    logger.warn(
+      `[DeviceTools] Failed to finish late shutdown retirement for ${device.deviceId}: ${lateError}`,
+    );
+  });
+  retainReservationUntil(lateRetirement);
+}
+
+function preserveLateShutdownRetirement(
+  error: unknown,
+  release: Promise<string | null>,
+  device: BootedDevice,
+  expectedPooledDevice: PooledDevice,
+  observedReplacement: BootedDevice | undefined,
+  deviceManager: PlatformDeviceManager,
+  timer: Timer,
+  deadlineMs: number,
+  stopPerformanceMonitoring: (deviceId: string) => void,
+  retainReservationUntil: (retirement: Promise<void>) => void,
+): void {
+  if (!isShutdownTimeoutError(error)) {
+    return;
+  }
+  // Session release removes its in-memory mapping before its durable write.
+  // It cannot be cancelled safely, so keep the captured shutdown reservation
+  // until the late release finishes its identity-guarded retirement. Otherwise
+  // a stopped device could become an idle ghost.
+  finishLateShutdownRetirement(
+    release,
+    device,
+    expectedPooledDevice,
+    observedReplacement,
+    deviceManager,
+    timer,
+    deadlineMs,
+    stopPerformanceMonitoring,
+    retainReservationUntil,
+  );
+}
+
 async function retireShutdownOwnership(
   device: BootedDevice,
   expectedPooledDevice: PooledDevice | null,
@@ -614,6 +678,7 @@ async function retireShutdownOwnership(
   deadlineMs: number,
   abortSignal: AbortSignal | undefined,
   stopPerformanceMonitoring: (deviceId: string) => void,
+  retainReservationUntil: (retirement: Promise<void>) => void,
 ): Promise<void> {
   if (!expectedPooledDevice) {
     return;
@@ -641,14 +706,31 @@ async function retireShutdownOwnership(
       `device-disconnected:${device.deviceId}`,
       { excludeSignal: abortSignal },
     );
-    await runWithinShutdownDeadline(
-      device,
-      timer,
-      retirementDeadlineMs,
-      "session ownership retirement did not complete",
-      abortSignal,
-      async () => await sessionManager.releaseSession(sessionId, `device-stopped:${device.deviceId}`),
-    );
+    const release = sessionManager.releaseSession(sessionId, `device-stopped:${device.deviceId}`);
+    try {
+      await runWithinShutdownDeadline(
+        device,
+        timer,
+        retirementDeadlineMs,
+        "session ownership retirement did not complete",
+        abortSignal,
+        async () => await release,
+      );
+    } catch (error) {
+      preserveLateShutdownRetirement(
+        error,
+        release,
+        device,
+        expectedPooledDevice,
+        observedReplacement,
+        deviceManager,
+        timer,
+        deadlineMs,
+        stopPerformanceMonitoring,
+        retainReservationUntil,
+      );
+      throw error;
+    }
   }
   if (devicePool.getDevice(device.deviceId) !== expectedPooledDevice) {
     return;
@@ -693,6 +775,7 @@ async function killProcessAndRetireOwnership(
   devicePool: DevicePool | undefined,
   expectedPooledDevice: PooledDevice | null,
   shutdownDeadlineMs: number,
+  retainReservationUntil: (retirement: Promise<void>) => void,
 ): Promise<string | undefined> {
   const deviceManager = dependencies.deviceManagerFactory();
   if (device.platform === "android") {
@@ -744,6 +827,7 @@ async function killProcessAndRetireOwnership(
       shutdownDeadlineMs,
       requestAbortSignal,
       dependencies.stopPerformanceMonitoring,
+      retainReservationUntil,
     );
     perf.endOperation("retireOwnership");
     return undefined;
@@ -1149,6 +1233,7 @@ export function registerDeviceTools() {
     const shutdownDeadlineMs = deps.timer.now() + DEVICE_SHUTDOWN_TIMEOUT_MS;
     const requestAbortSignal = abortSignal ?? getAbortSignal();
     let shutdownReservation: Awaited<ReturnType<DevicePool["reserveDeviceForShutdown"]>>;
+    let retainShutdownReservation = false;
     try {
       shutdownReservation = await runWithinShutdownDeadline(
         args.device,
@@ -1176,7 +1261,17 @@ export function registerDeviceTools() {
         devicePool,
         expectedPooledDevice,
         shutdownDeadlineMs,
+        retirement => {
+          retainShutdownReservation = true;
+          void retirement.then(
+            () => shutdownReservation?.release(),
+            () => shutdownReservation?.release(),
+          );
+        },
       );
+
+      await shutdownReservation?.release();
+      shutdownReservation = undefined;
 
       perf.startOperation("cleanup");
       await clearInstalledAppsAfterShutdown(deps, args.device.deviceId);
@@ -1193,7 +1288,9 @@ export function registerDeviceTools() {
     } catch (error) {
       throw new ActionableError(`Failed to kill ${args.device.platform} device: ${error}`);
     } finally {
-      await shutdownReservation?.release();
+      if (!retainShutdownReservation) {
+        await shutdownReservation?.release();
+      }
     }
   };
 

--- a/src/server/deviceTools.ts
+++ b/src/server/deviceTools.ts
@@ -359,6 +359,13 @@ function isShutdownTimeoutError(error: unknown): error is ActionableError {
   return error instanceof ActionableError && String(error.message).startsWith("Timed out waiting for");
 }
 
+function shouldClearIntentionalShutdownAfterFailure(
+  platform: SomePlatform,
+  requestAbortSignal: AbortSignal | undefined,
+): boolean {
+  return platform === "android" && !requestAbortSignal?.aborted;
+}
+
 function abortPromise(signal: AbortSignal | undefined): {
   promise: Promise<never> | undefined;
   cleanup: () => void;
@@ -714,7 +721,9 @@ async function killProcessAndRetireOwnership(
   } catch (error) {
     // A failed disappearance confirmation leaves the original incarnation in
     // the pool. It must remain eligible for normal unexpected-loss recovery.
-    if (device.platform === "android") {
+    // Caller cancellation is different: the platform command may already have
+    // succeeded, so retain the marker for its later process-exit cleanup.
+    if (shouldClearIntentionalShutdownAfterFailure(device.platform, requestAbortSignal)) {
       devicePool?.clearIntentionalShutdown(device.deviceId);
     }
     throw error;

--- a/src/server/deviceTools.ts
+++ b/src/server/deviceTools.ts
@@ -366,6 +366,28 @@ function shouldClearIntentionalShutdownAfterFailure(
   return platform === "android" && !requestAbortSignal?.aborted;
 }
 
+function shouldKeepIntentionalShutdownAfterCommandError(
+  error: unknown,
+  requestAbortSignal: AbortSignal | undefined,
+): boolean {
+  return requestAbortSignal?.aborted === true || isShutdownTimeoutError(error);
+}
+
+function handleShutdownCommandError(
+  device: BootedDevice,
+  error: unknown,
+  devicePool: DevicePool | undefined,
+  requestAbortSignal: AbortSignal | undefined,
+): string | undefined {
+  if (isAlreadyStoppedDeviceError(device.platform, device.deviceId, error)) {
+    return `Failed to kill ${device.platform} device: ${error}`;
+  }
+  if (!shouldKeepIntentionalShutdownAfterCommandError(error, requestAbortSignal)) {
+    devicePool?.clearIntentionalShutdown(device.deviceId);
+  }
+  throw error;
+}
+
 function abortPromise(signal: AbortSignal | undefined): {
   promise: Promise<never> | undefined;
   cleanup: () => void;
@@ -688,12 +710,7 @@ async function killProcessAndRetireOwnership(
     );
     shutdownDevice = killedDevice ?? device;
   } catch (error) {
-    if (isAlreadyStoppedDeviceError(device.platform, device.deviceId, error)) {
-      alreadyStoppedMessage = `Failed to kill ${device.platform} device: ${error}`;
-    } else {
-      devicePool?.clearIntentionalShutdown(device.deviceId);
-      throw error;
-    }
+    alreadyStoppedMessage = handleShutdownCommandError(device, error, devicePool, requestAbortSignal);
   }
   perf.endOperation("killProcess");
 

--- a/src/server/deviceTools.ts
+++ b/src/server/deviceTools.ts
@@ -30,7 +30,7 @@ import { getInstalledAppsCacheWriteCoordinator } from "../db/installedAppsCacheW
 import { getDbWriteBarrier } from "../db/dbWriteBarrier";
 import { isAdbMissingDeviceError } from "../utils/android-cmdline-tools/AdbDeviceHealth";
 import { defaultTimer, type Timer } from "../utils/SystemTimer";
-import { runWithAbortSignal } from "../utils/AbortContext";
+import { getAbortSignal, runWithAbortSignal } from "../utils/AbortContext";
 import { executionTracker } from "./executionTracker";
 import {
   createDefaultRunnerReadinessService,
@@ -267,38 +267,99 @@ function shutdownTimeoutError(device: BootedDevice, detail: string): ActionableE
   );
 }
 
-async function getShutdownDiscovery(
-  deviceManager: PlatformDeviceManager,
+function abortPromise(signal: AbortSignal | undefined): {
+  promise: Promise<never> | undefined;
+  cleanup: () => void;
+} {
+  if (!signal) {
+    return { promise: undefined, cleanup: () => undefined };
+  }
+  let onAbort: (() => void) | undefined;
+  const promise = new Promise<never>((_, reject) => {
+    onAbort = () => reject(signal.reason ?? new Error("Operation cancelled"));
+    if (signal.aborted) {
+      onAbort();
+      return;
+    }
+    signal.addEventListener("abort", onAbort, { once: true });
+  });
+  return {
+    promise,
+    cleanup: () => {
+      if (onAbort) {
+        signal.removeEventListener("abort", onAbort);
+      }
+    },
+  };
+}
+
+async function runWithinShutdownDeadline<T>(
   device: BootedDevice,
   timer: Timer,
   deadlineMs: number,
-) {
+  detail: string,
+  requestAbortSignal: AbortSignal | undefined,
+  operation: (signal: AbortSignal, timeoutMs: number) => Promise<T>,
+): Promise<T> {
   const remainingMs = deadlineMs - timer.now();
   if (remainingMs <= 0) {
-    throw shutdownTimeoutError(device, "platform discovery did not complete");
+    throw shutdownTimeoutError(device, detail);
   }
+  const deadlineController = new AbortController();
+  const signal = requestAbortSignal
+    ? AbortSignal.any([requestAbortSignal, deadlineController.signal])
+    : deadlineController.signal;
   let timeout: NodeJS.Timeout | undefined;
-  const controller = new AbortController();
+  let timedOut = false;
   const timeoutPromise = new Promise<never>((_, reject) => {
     timeout = timer.setTimeout(() => {
-      controller.abort();
-      reject(shutdownTimeoutError(device, "platform discovery did not complete"));
+      timedOut = true;
+      deadlineController.abort();
+      reject(shutdownTimeoutError(device, detail));
     }, remainingMs);
   });
+  const requestAbort = abortPromise(requestAbortSignal);
+  const operationPromise = runWithAbortSignal(signal, () => operation(signal, remainingMs)).catch(error => {
+    if (timedOut) {
+      throw shutdownTimeoutError(device, detail);
+    }
+    throw error;
+  });
+  // If the deadline wins while a platform command ignores abort, the race is
+  // settled but the underlying promise remains observed rather than leaking an
+  // unhandled rejection when it eventually completes.
+  operationPromise.catch(() => undefined);
   try {
     return await Promise.race([
-      runWithAbortSignal(controller.signal, () =>
-        deviceManager.getBootedDevicesDetailed(device.platform, {
-          bypassAndroidDeviceListCache: true,
-        }),
-      ),
+      operationPromise,
       timeoutPromise,
+      ...(requestAbort.promise ? [requestAbort.promise] : []),
     ]);
   } finally {
     if (timeout) {
       timer.clearTimeout(timeout);
     }
+    requestAbort.cleanup();
   }
+}
+
+async function getShutdownDiscovery(
+  deviceManager: PlatformDeviceManager,
+  device: BootedDevice,
+  timer: Timer,
+  deadlineMs: number,
+  requestAbortSignal: AbortSignal | undefined,
+) {
+  return await runWithinShutdownDeadline(
+    device,
+    timer,
+    deadlineMs,
+    "platform discovery did not complete",
+    requestAbortSignal ?? getAbortSignal(),
+    async () => await deviceManager.getBootedDevicesDetailed(device.platform, {
+          bypassAndroidDeviceListCache: true,
+        }),
+  );
 }
 
 async function waitForDeviceShutdown(
@@ -306,13 +367,20 @@ async function waitForDeviceShutdown(
   device: BootedDevice,
   timer: Timer,
   deadlineMs: number,
+  requestAbortSignal: AbortSignal | undefined,
 ): Promise<BootedDevice | undefined> {
   let lastDiscoveryDetail = "platform discovery did not complete";
   for (;;) {
     if (timer.now() >= deadlineMs) {
       throw shutdownTimeoutError(device, lastDiscoveryDetail);
     }
-    const discovery = await getShutdownDiscovery(deviceManager, device, timer, deadlineMs);
+    const discovery = await getShutdownDiscovery(
+      deviceManager,
+      device,
+      timer,
+      deadlineMs,
+      requestAbortSignal,
+    );
     const platformWasDiscovered = discovery.succeededPlatforms.has(device.platform);
     const matchingDevice = findDiscoveredDevice(discovery, device);
     if (platformWasDiscovered && !matchingDevice) {
@@ -384,6 +452,7 @@ async function findReplacementAfterSessionRelease(
   device: BootedDevice,
   timer: Timer,
   deadlineMs: number,
+  requestAbortSignal: AbortSignal | undefined,
 ): Promise<BootedDevice | undefined> {
   // The absence observation only proves the old incarnation was gone before
   // session release. A same-ID replacement can appear while that release
@@ -393,7 +462,13 @@ async function findReplacementAfterSessionRelease(
     deadlineMs,
     timer.now() + DEVICE_SHUTDOWN_POST_RELEASE_RECHECK_TIMEOUT_MS,
   );
-  const discovery = await getShutdownDiscovery(deviceManager, device, timer, recheckDeadlineMs);
+  const discovery = await getShutdownDiscovery(
+    deviceManager,
+    device,
+    timer,
+    recheckDeadlineMs,
+    requestAbortSignal,
+  );
   const replacement = findDiscoveredDevice(discovery, device);
   if (replacement && !isSameBootedDeviceIdentity(device, replacement)) {
     return replacement;
@@ -401,7 +476,13 @@ async function findReplacementAfterSessionRelease(
   if (!replacement && discovery.succeededPlatforms.has(device.platform)) {
     return undefined;
   }
-  return await waitForDeviceShutdown(deviceManager, device, timer, recheckDeadlineMs);
+  return await waitForDeviceShutdown(
+    deviceManager,
+    device,
+    timer,
+    recheckDeadlineMs,
+    requestAbortSignal,
+  );
 }
 
 async function retireShutdownOwnership(
@@ -452,6 +533,7 @@ async function retireShutdownOwnership(
     device,
     timer,
     deadlineMs,
+    abortSignal,
   );
   if (replacement) {
     await rebuildSameIdReplacement(
@@ -481,6 +563,8 @@ async function killProcessAndRetireOwnership(
   expectedPooledDevice: PooledDevice | null,
 ): Promise<string | undefined> {
   const deviceManager = dependencies.deviceManagerFactory();
+  const shutdownDeadlineMs = dependencies.timer.now() + DEVICE_SHUTDOWN_TIMEOUT_MS;
+  const requestAbortSignal = abortSignal ?? getAbortSignal();
   if (device.platform === "android") {
     devicePool?.markIntentionalShutdown(device.deviceId);
   }
@@ -489,7 +573,14 @@ async function killProcessAndRetireOwnership(
   let alreadyStoppedMessage: string | undefined;
   perf.startOperation("killProcess");
   try {
-    const killedDevice = await deviceManager.killDevice(device);
+    const killedDevice = await runWithinShutdownDeadline(
+      device,
+      dependencies.timer,
+      shutdownDeadlineMs,
+      "platform shutdown command did not complete",
+      requestAbortSignal,
+      async (signal, timeoutMs) => await deviceManager.killDevice(device, { signal, timeoutMs }),
+    );
     shutdownDevice = killedDevice ?? device;
   } catch (error) {
     if (isAlreadyStoppedDeviceError(device.platform, device.deviceId, error)) {
@@ -505,7 +596,6 @@ async function killProcessAndRetireOwnership(
     return alreadyStoppedMessage;
   }
 
-  const shutdownDeadlineMs = dependencies.timer.now() + DEVICE_SHUTDOWN_TIMEOUT_MS;
   try {
     perf.startOperation("waitForShutdown");
     const observedReplacement = await waitForDeviceShutdown(
@@ -513,6 +603,7 @@ async function killProcessAndRetireOwnership(
       shutdownDevice,
       dependencies.timer,
       shutdownDeadlineMs,
+      requestAbortSignal,
     );
     perf.endOperation("waitForShutdown");
 
@@ -524,7 +615,7 @@ async function killProcessAndRetireOwnership(
       deviceManager,
       dependencies.timer,
       shutdownDeadlineMs,
-      abortSignal,
+      requestAbortSignal,
       dependencies.stopPerformanceMonitoring,
     );
     perf.endOperation("retireOwnership");

--- a/src/server/deviceTools.ts
+++ b/src/server/deviceTools.ts
@@ -359,12 +359,14 @@ async function rebuildSameIdReplacement(
   expectedPooledDevice: PooledDevice,
   replacement: BootedDevice,
   daemonState: DaemonState,
+  stopPerformanceMonitoring: (deviceId: string) => void,
 ): Promise<void> {
   const devicePool = daemonState.getDevicePool();
   const rebuilt = await devicePool.replaceDeviceForShutdown(expectedPooledDevice, replacement);
   if (!rebuilt) {
     return;
   }
+  stopPerformanceMonitoring(device.deviceId);
   daemonState.getDeviceSessionRegistry().onDeviceConnected({
     deviceId: rebuilt.id,
     platform: rebuilt.platform,
@@ -443,7 +445,13 @@ async function retireShutdownOwnership(
     deadlineMs,
   );
   if (replacement) {
-    await rebuildSameIdReplacement(device, expectedPooledDevice, replacement, daemonState);
+    await rebuildSameIdReplacement(
+      device,
+      expectedPooledDevice,
+      replacement,
+      daemonState,
+      stopPerformanceMonitoring,
+    );
     return;
   }
   if (devicePool.getDevice(device.deviceId) !== expectedPooledDevice) {

--- a/src/server/deviceTools.ts
+++ b/src/server/deviceTools.ts
@@ -295,7 +295,7 @@ async function waitForDeviceShutdown(
   device: BootedDevice,
   timer: Timer,
   deadlineMs: number,
-): Promise<void> {
+): Promise<BootedDevice | undefined> {
   let lastDiscoveryDetail = "platform discovery did not complete";
   for (;;) {
     if (timer.now() >= deadlineMs) {
@@ -303,11 +303,12 @@ async function waitForDeviceShutdown(
     }
     const discovery = await getShutdownDiscovery(deviceManager, device, timer, deadlineMs);
     const platformWasDiscovered = discovery.succeededPlatforms.has(device.platform);
-    const isStillBooted = discovery.devices.some(candidate =>
-      candidate.platform === device.platform && candidate.deviceId === device.deviceId,
-    );
-    if (platformWasDiscovered && !isStillBooted) {
-      return;
+    const matchingDevice = findDiscoveredDevice(discovery, device);
+    if (platformWasDiscovered && !matchingDevice) {
+      return undefined;
+    }
+    if (matchingDevice && !isSameBootedDeviceIdentity(device, matchingDevice)) {
+      return matchingDevice;
     }
 
     lastDiscoveryDetail = platformWasDiscovered
@@ -319,6 +320,20 @@ async function waitForDeviceShutdown(
     }
     await timer.sleep(Math.min(DEVICE_SHUTDOWN_POLL_INTERVAL_MS, remainingMs));
   }
+}
+
+function isSameBootedDeviceIdentity(device: BootedDevice, candidate: BootedDevice): boolean {
+  if (device.platform !== candidate.platform || device.deviceId !== candidate.deviceId) {
+    return false;
+  }
+  if (
+    device.transportId !== undefined &&
+    candidate.transportId !== undefined &&
+    device.transportId !== candidate.transportId
+  ) {
+    return false;
+  }
+  return device.name === candidate.name;
 }
 
 function findDiscoveredDevice(
@@ -340,23 +355,16 @@ async function rebuildSameIdReplacement(
   daemonState: DaemonState,
 ): Promise<void> {
   const devicePool = daemonState.getDevicePool();
-  await devicePool.releaseDevice(device.deviceId);
-  if (devicePool.getDevice(device.deviceId) !== expectedPooledDevice) {
+  const rebuilt = await devicePool.replaceDeviceForShutdown(expectedPooledDevice, replacement);
+  if (!rebuilt) {
     return;
   }
-  await devicePool.removeDisconnectedDevice(device.deviceId, false);
-  if (!devicePool.getDevice(device.deviceId)) {
-    daemonState.getDeviceSessionRegistry().onDeviceDisconnected(device.deviceId);
-  }
-  await devicePool.addDevice(replacement);
-  const rebuilt = devicePool.getDevice(device.deviceId);
-  if (rebuilt) {
-    daemonState.getDeviceSessionRegistry().onDeviceConnected({
-      deviceId: rebuilt.id,
-      platform: rebuilt.platform,
-      incarnation: rebuilt.incarnation,
-    });
-  }
+  daemonState.getDeviceSessionRegistry().onDeviceDisconnected(device.deviceId);
+  daemonState.getDeviceSessionRegistry().onDeviceConnected({
+    deviceId: rebuilt.id,
+    platform: rebuilt.platform,
+    incarnation: rebuilt.incarnation,
+  });
 }
 
 async function retireShutdownOwnership(
@@ -410,12 +418,7 @@ async function retireShutdownOwnership(
   if (devicePool.getDevice(device.deviceId) !== expectedPooledDevice) {
     return;
   }
-  await devicePool.releaseDevice(device.deviceId);
-  if (devicePool.getDevice(device.deviceId) !== expectedPooledDevice) {
-    return;
-  }
-  await devicePool.removeDisconnectedDevice(device.deviceId, false);
-  if (!devicePool.getDevice(device.deviceId)) {
+  if (await devicePool.retireDeviceForShutdown(expectedPooledDevice)) {
     daemonState.getDeviceSessionRegistry().onDeviceDisconnected(device.deviceId);
   }
 }

--- a/src/server/deviceTools.ts
+++ b/src/server/deviceTools.ts
@@ -266,6 +266,13 @@ interface ShutdownDeadlineContext {
   requestAbortSignal: AbortSignal | undefined;
 }
 
+function shouldPropagateShutdownPreparationError(
+  error: unknown,
+  requestAbortSignal: AbortSignal | undefined,
+): boolean {
+  return isShutdownTimeoutError(error) || requestAbortSignal?.aborted === true;
+}
+
 async function stopVideoRecordingBeforeShutdown(
   recordingId: string,
   context: ShutdownDeadlineContext,
@@ -280,7 +287,7 @@ async function stopVideoRecordingBeforeShutdown(
       async () => await stopVideoRecording(recordingId),
     );
   } catch (error) {
-    if (isShutdownTimeoutError(error)) {
+    if (shouldPropagateShutdownPreparationError(error, context.requestAbortSignal)) {
       throw error;
     }
     logger.warn(
@@ -627,6 +634,7 @@ function finishLateShutdownRetirement(
       undefined,
       stopPerformanceMonitoring,
       () => undefined,
+      false,
     );
   });
   lateRetirement.catch(lateError => {
@@ -637,8 +645,82 @@ function finishLateShutdownRetirement(
   retainReservationUntil(lateRetirement);
 }
 
+function retainFailedShutdownRetirement(
+  error: unknown,
+  device: BootedDevice,
+  expectedPooledDevice: PooledDevice,
+  observedReplacement: BootedDevice | undefined,
+  deviceManager: PlatformDeviceManager,
+  timer: Timer,
+  deadlineMs: number,
+  stopPerformanceMonitoring: (deviceId: string) => void,
+  retainReservationUntil: (retirement: Promise<void>) => void,
+  retryAfterFailure: boolean,
+): void {
+  const retirement = retryAfterFailure
+    ? timer.sleep(DEVICE_SHUTDOWN_POST_RELEASE_RECHECK_TIMEOUT_MS).then(async () => {
+      await retireShutdownOwnership(
+        device,
+        expectedPooledDevice,
+        observedReplacement,
+        deviceManager,
+        timer,
+        deadlineMs,
+        undefined,
+        stopPerformanceMonitoring,
+        () => undefined,
+        false,
+      );
+    })
+    : Promise.reject(error);
+  retirement.catch(lateError => {
+    logger.warn(
+      `[DeviceTools] Retaining shutdown reservation after retirement failed for ${device.deviceId}: ${lateError}`,
+    );
+  });
+  retainReservationUntil(retirement);
+}
+
+async function findReplacementOrRetainShutdownReservation(
+  device: BootedDevice,
+  expectedPooledDevice: PooledDevice,
+  observedReplacement: BootedDevice | undefined,
+  deviceManager: PlatformDeviceManager,
+  timer: Timer,
+  deadlineMs: number,
+  abortSignal: AbortSignal | undefined,
+  stopPerformanceMonitoring: (deviceId: string) => void,
+  retainReservationUntil: (retirement: Promise<void>) => void,
+  retryAfterFailure: boolean,
+): Promise<BootedDevice | undefined> {
+  try {
+    return observedReplacement ?? await findReplacementAfterSessionRelease(
+      deviceManager,
+      device,
+      timer,
+      deadlineMs,
+      abortSignal,
+    );
+  } catch (error) {
+    retainFailedShutdownRetirement(
+      error,
+      device,
+      expectedPooledDevice,
+      observedReplacement,
+      deviceManager,
+      timer,
+      deadlineMs,
+      stopPerformanceMonitoring,
+      retainReservationUntil,
+      retryAfterFailure,
+    );
+    throw error;
+  }
+}
+
 function preserveLateShutdownRetirement(
   error: unknown,
+  requestAbortSignal: AbortSignal | undefined,
   release: Promise<string | null>,
   device: BootedDevice,
   expectedPooledDevice: PooledDevice,
@@ -649,7 +731,7 @@ function preserveLateShutdownRetirement(
   stopPerformanceMonitoring: (deviceId: string) => void,
   retainReservationUntil: (retirement: Promise<void>) => void,
 ): void {
-  if (!isShutdownTimeoutError(error)) {
+  if (!isShutdownTimeoutError(error) && !requestAbortSignal?.aborted) {
     return;
   }
   // Session release removes its in-memory mapping before its durable write.
@@ -679,6 +761,7 @@ async function retireShutdownOwnership(
   abortSignal: AbortSignal | undefined,
   stopPerformanceMonitoring: (deviceId: string) => void,
   retainReservationUntil: (retirement: Promise<void>) => void,
+  retryAfterDiscoveryFailure: boolean = true,
 ): Promise<void> {
   if (!expectedPooledDevice) {
     return;
@@ -719,6 +802,7 @@ async function retireShutdownOwnership(
     } catch (error) {
       preserveLateShutdownRetirement(
         error,
+        abortSignal,
         release,
         device,
         expectedPooledDevice,
@@ -741,12 +825,17 @@ async function retireShutdownOwnership(
   // replacement so it owns a fresh pool and registry epoch. Once shutdown was
   // observed, a bounded post-release recheck protects against a replacement
   // that boots at the disappearance deadline.
-  const replacement = observedReplacement ?? await findReplacementAfterSessionRelease(
-    deviceManager,
+  const replacement = await findReplacementOrRetainShutdownReservation(
     device,
+    expectedPooledDevice,
+    observedReplacement,
+    deviceManager,
     timer,
     deadlineMs,
     abortSignal,
+    stopPerformanceMonitoring,
+    retainReservationUntil,
+    retryAfterDiscoveryFailure,
   );
   if (replacement) {
     await rebuildSameIdReplacement(
@@ -1265,7 +1354,9 @@ export function registerDeviceTools() {
           retainShutdownReservation = true;
           void retirement.then(
             () => shutdownReservation?.release(),
-            () => shutdownReservation?.release(),
+            error => logger.warn(
+              `[DeviceTools] Retaining shutdown reservation after late retirement failed: ${error}`,
+            ),
           );
         },
       );

--- a/src/server/deviceTools.ts
+++ b/src/server/deviceTools.ts
@@ -259,6 +259,94 @@ async function notifyResourcesAfterShutdown(dependencies: DeviceToolsDependencie
   }
 }
 
+interface ShutdownDeadlineContext {
+  device: BootedDevice;
+  timer: Timer;
+  deadlineMs: number;
+  requestAbortSignal: AbortSignal | undefined;
+}
+
+async function stopVideoRecordingBeforeShutdown(
+  recordingId: string,
+  context: ShutdownDeadlineContext,
+): Promise<void> {
+  try {
+    await runWithinShutdownDeadline(
+      context.device,
+      context.timer,
+      context.deadlineMs,
+      "video recording teardown did not complete",
+      context.requestAbortSignal,
+      async () => await stopVideoRecording(recordingId),
+    );
+  } catch (error) {
+    if (isShutdownTimeoutError(error)) {
+      throw error;
+    }
+    logger.warn(
+      `[DeviceTools] Failed to stop recording ${recordingId} before shutdown: ${error}`
+    );
+  }
+}
+
+async function stopVideoRecordingsBeforeShutdown(
+  context: ShutdownDeadlineContext,
+  perf: ReturnType<typeof createPerformanceTracker>,
+): Promise<void> {
+  perf.startOperation("stopRecordings");
+  try {
+    const activeRecordings = await runWithinShutdownDeadline(
+      context.device,
+      context.timer,
+      context.deadlineMs,
+      "recording discovery did not complete",
+      context.requestAbortSignal,
+      async () => await listActiveVideoRecordings({
+        deviceId: context.device.deviceId,
+        platform: context.device.platform,
+      }),
+    );
+    for (const recording of activeRecordings) {
+      await stopVideoRecordingBeforeShutdown(recording.recordingId, context);
+    }
+  } finally {
+    perf.endOperation("stopRecordings");
+  }
+}
+
+async function stopIosCtrlProxyBeforeShutdown(
+  context: ShutdownDeadlineContext,
+  perf: ReturnType<typeof createPerformanceTracker>,
+): Promise<void> {
+  if (context.device.platform !== "ios") {
+    return;
+  }
+  perf.startOperation("stopCtrlProxy");
+  try {
+    const xcTestManager = IOSCtrlProxyManager.getInstance({
+      name: context.device.name,
+      platform: "ios",
+      deviceId: context.device.deviceId,
+      source: "local",
+    });
+    await runWithinShutdownDeadline(
+      context.device,
+      context.timer,
+      context.deadlineMs,
+      "iOS CtrlProxy shutdown did not complete",
+      context.requestAbortSignal,
+      async () => await xcTestManager.stop(),
+    );
+  } catch (error) {
+    if (isShutdownTimeoutError(error)) {
+      throw error;
+    }
+    logger.warn(`[DeviceTools] Failed to stop CtrlProxy iOS before kill: ${error}`);
+  } finally {
+    perf.endOperation("stopCtrlProxy");
+  }
+}
+
 function shutdownTimeoutError(device: BootedDevice, detail: string): ActionableError {
   return new ActionableError(
     `Timed out waiting for ${device.platform} device '${device.name}' (${device.deviceId}) ` +
@@ -1030,66 +1118,14 @@ export function registerDeviceTools() {
         async () => await devicePool?.reserveDeviceForShutdown(args.device.deviceId),
       );
       const expectedPooledDevice = shutdownReservation?.device ?? null;
-
-      perf.startOperation("stopRecordings");
-      const activeRecordings = await runWithinShutdownDeadline(
-        args.device,
-        deps.timer,
-        shutdownDeadlineMs,
-        "recording discovery did not complete",
+      const shutdownContext = {
+        device: args.device,
+        timer: deps.timer,
+        deadlineMs: shutdownDeadlineMs,
         requestAbortSignal,
-        async () => await listActiveVideoRecordings({
-          deviceId: args.device.deviceId,
-          platform: args.device.platform,
-        }),
-      );
-      for (const recording of activeRecordings) {
-        try {
-          await runWithinShutdownDeadline(
-            args.device,
-            deps.timer,
-            shutdownDeadlineMs,
-            "video recording teardown did not complete",
-            requestAbortSignal,
-            async () => await stopVideoRecording(recording.recordingId),
-          );
-        } catch (error) {
-          if (isShutdownTimeoutError(error)) {
-            throw error;
-          }
-          logger.warn(
-            `[DeviceTools] Failed to stop recording ${recording.recordingId} before shutdown: ${error}`
-          );
-        }
-      }
-      perf.endOperation("stopRecordings");
-
-      // Stop CtrlProxy iOS before shutting down iOS simulators
-      if (args.device.platform === "ios") {
-        perf.startOperation("stopCtrlProxy");
-        try {
-          const xcTestManager = IOSCtrlProxyManager.getInstance({
-            name: args.device.name,
-            platform: "ios",
-            deviceId: args.device.deviceId,
-            source: "local",
-          });
-          await runWithinShutdownDeadline(
-            args.device,
-            deps.timer,
-            shutdownDeadlineMs,
-            "iOS CtrlProxy shutdown did not complete",
-            requestAbortSignal,
-            async () => await xcTestManager.stop(),
-          );
-        } catch (error) {
-          if (isShutdownTimeoutError(error)) {
-            throw error;
-          }
-          logger.warn(`[DeviceTools] Failed to stop CtrlProxy iOS before kill: ${error}`);
-        }
-        perf.endOperation("stopCtrlProxy");
-      }
+      };
+      await stopVideoRecordingsBeforeShutdown(shutdownContext, perf);
+      await stopIosCtrlProxyBeforeShutdown(shutdownContext, perf);
 
       const alreadyStoppedMessage = await killProcessAndRetireOwnership(
         deps,

--- a/src/server/deviceTools.ts
+++ b/src/server/deviceTools.ts
@@ -249,14 +249,54 @@ async function notifyResourcesAfterShutdown(dependencies: DeviceToolsDependencie
   }
 }
 
+function shutdownTimeoutError(device: BootedDevice, detail: string): ActionableError {
+  return new ActionableError(
+    `Timed out waiting for ${device.platform} device '${device.name}' (${device.deviceId}) ` +
+    `to disappear after ${DEVICE_SHUTDOWN_TIMEOUT_MS}ms: ${detail}. ` +
+    "Verify the platform shutdown state and retry.",
+  );
+}
+
+async function getShutdownDiscovery(
+  deviceManager: PlatformDeviceManager,
+  device: BootedDevice,
+  timer: Timer,
+  deadlineMs: number,
+) {
+  const remainingMs = deadlineMs - timer.now();
+  if (remainingMs <= 0) {
+    throw shutdownTimeoutError(device, "platform discovery did not complete");
+  }
+  let timeout: NodeJS.Timeout | undefined;
+  const timeoutPromise = new Promise<never>((_, reject) => {
+    timeout = timer.setTimeout(() => {
+      reject(shutdownTimeoutError(device, "platform discovery did not complete"));
+    }, remainingMs);
+  });
+  try {
+    return await Promise.race([
+      deviceManager.getBootedDevicesDetailed(device.platform),
+      timeoutPromise,
+    ]);
+  } finally {
+    if (timeout) {
+      timer.clearTimeout(timeout);
+    }
+  }
+}
+
 async function waitForDeviceShutdown(
   deviceManager: PlatformDeviceManager,
   device: BootedDevice,
   timer: Timer,
+  deadlineMs: number,
 ): Promise<void> {
-  const startedAt = timer.now();
+  let lastDiscoveryDetail = "platform discovery did not complete";
   for (;;) {
-    const discovery = await deviceManager.getBootedDevicesDetailed(device.platform);
+    if (timer.now() >= deadlineMs) {
+      throw shutdownTimeoutError(device, lastDiscoveryDetail);
+    }
+    const discovery = await getShutdownDiscovery(deviceManager, device, timer, deadlineMs);
     const platformWasDiscovered = discovery.succeededPlatforms.has(device.platform);
     const isStillBooted = discovery.devices.some(candidate =>
       candidate.platform === device.platform && candidate.deviceId === device.deviceId,
@@ -265,24 +305,23 @@ async function waitForDeviceShutdown(
       return;
     }
 
-    const elapsedMs = timer.now() - startedAt;
-    if (elapsedMs >= DEVICE_SHUTDOWN_TIMEOUT_MS) {
-      const discoveryDetail = platformWasDiscovered
-        ? "the device is still reported as booted"
-        : "platform discovery did not succeed";
-      throw new ActionableError(
-        `Timed out waiting for ${device.platform} device '${device.name}' (${device.deviceId}) ` +
-        `to disappear after ${DEVICE_SHUTDOWN_TIMEOUT_MS}ms: ${discoveryDetail}. ` +
-        "Verify the platform shutdown state and retry.",
-      );
+    lastDiscoveryDetail = platformWasDiscovered
+      ? "the device is still reported as booted"
+      : "platform discovery did not succeed";
+    const remainingMs = deadlineMs - timer.now();
+    if (remainingMs <= 0) {
+      throw shutdownTimeoutError(device, lastDiscoveryDetail);
     }
-    await timer.sleep(Math.min(DEVICE_SHUTDOWN_POLL_INTERVAL_MS, DEVICE_SHUTDOWN_TIMEOUT_MS - elapsedMs));
+    await timer.sleep(Math.min(DEVICE_SHUTDOWN_POLL_INTERVAL_MS, remainingMs));
   }
 }
 
 async function retireShutdownOwnership(
   device: BootedDevice,
   expectedPooledDevice: PooledDevice | null,
+  deviceManager: PlatformDeviceManager,
+  timer: Timer,
+  deadlineMs: number,
 ): Promise<void> {
   if (!expectedPooledDevice) {
     return;
@@ -299,7 +338,7 @@ async function retireShutdownOwnership(
   }
 
   const sessionManager = daemonState.getSessionManager();
-  const sessionId = expectedPooledDevice?.sessionId;
+  const sessionId = expectedPooledDevice.sessionId;
   if (sessionId && sessionManager.getSessionForDevice(device.deviceId) === sessionId) {
     await sessionManager.releaseSession(sessionId, `device-stopped:${device.deviceId}`);
   }
@@ -307,11 +346,24 @@ async function retireShutdownOwnership(
     return;
   }
 
-  await devicePool.releaseDevice(device.deviceId);
-  await devicePool.removeDisconnectedDevice(device.deviceId, false);
+  // A same-ID replacement can boot while releasing the old session. Re-check
+  // physical disappearance after that await, then synchronously detach the
+  // captured pool entry before another lifecycle event can interleave.
+  await waitForDeviceShutdown(deviceManager, device, timer, deadlineMs);
+  if (devicePool.getDevice(device.deviceId) !== expectedPooledDevice) {
+    return;
+  }
+  const poolRelease = devicePool.releaseDevice(device.deviceId);
+  if (devicePool.getDevice(device.deviceId) !== expectedPooledDevice) {
+    await poolRelease;
+    return;
+  }
+  const poolRemoval = devicePool.removeDisconnectedDevice(device.deviceId, false);
   if (!devicePool.getDevice(device.deviceId)) {
     daemonState.getDeviceSessionRegistry().onDeviceDisconnected(device.deviceId);
   }
+  await poolRelease;
+  await poolRemoval;
 }
 
 async function killProcessAndRetireOwnership(
@@ -346,12 +398,19 @@ async function killProcessAndRetireOwnership(
     return alreadyStoppedMessage;
   }
 
+  const shutdownDeadlineMs = dependencies.timer.now() + DEVICE_SHUTDOWN_TIMEOUT_MS;
   perf.startOperation("waitForShutdown");
-  await waitForDeviceShutdown(deviceManager, device, dependencies.timer);
+  await waitForDeviceShutdown(deviceManager, device, dependencies.timer, shutdownDeadlineMs);
   perf.endOperation("waitForShutdown");
 
   perf.startOperation("retireOwnership");
-  await retireShutdownOwnership(device, expectedPooledDevice);
+  await retireShutdownOwnership(
+    device,
+    expectedPooledDevice,
+    deviceManager,
+    dependencies.timer,
+    shutdownDeadlineMs,
+  );
   perf.endOperation("retireOwnership");
   return undefined;
 }

--- a/src/server/deviceTools.ts
+++ b/src/server/deviceTools.ts
@@ -390,8 +390,11 @@ async function findReplacementAfterSessionRelease(
   );
   const discovery = await getShutdownDiscovery(deviceManager, device, timer, recheckDeadlineMs);
   const replacement = findDiscoveredDevice(discovery, device);
-  if (replacement || discovery.succeededPlatforms.has(device.platform)) {
+  if (replacement && !isSameBootedDeviceIdentity(device, replacement)) {
     return replacement;
+  }
+  if (!replacement && discovery.succeededPlatforms.has(device.platform)) {
+    return undefined;
   }
   return await waitForDeviceShutdown(deviceManager, device, timer, recheckDeadlineMs);
 }
@@ -500,27 +503,36 @@ async function killProcessAndRetireOwnership(
     }
 
     const shutdownDeadlineMs = dependencies.timer.now() + DEVICE_SHUTDOWN_TIMEOUT_MS;
-    perf.startOperation("waitForShutdown");
-    await waitForDeviceShutdown(
-      deviceManager,
-      shutdownDevice,
-      dependencies.timer,
-      shutdownDeadlineMs,
-    );
-    perf.endOperation("waitForShutdown");
+    try {
+      perf.startOperation("waitForShutdown");
+      await waitForDeviceShutdown(
+        deviceManager,
+        shutdownDevice,
+        dependencies.timer,
+        shutdownDeadlineMs,
+      );
+      perf.endOperation("waitForShutdown");
 
-    perf.startOperation("retireOwnership");
-    await retireShutdownOwnership(
-      shutdownDevice,
-      expectedPooledDevice,
-      deviceManager,
-      dependencies.timer,
-      shutdownDeadlineMs,
-      abortSignal,
-      dependencies.stopPerformanceMonitoring,
-    );
-    perf.endOperation("retireOwnership");
-    return undefined;
+      perf.startOperation("retireOwnership");
+      await retireShutdownOwnership(
+        shutdownDevice,
+        expectedPooledDevice,
+        deviceManager,
+        dependencies.timer,
+        shutdownDeadlineMs,
+        abortSignal,
+        dependencies.stopPerformanceMonitoring,
+      );
+      perf.endOperation("retireOwnership");
+      return undefined;
+    } catch (error) {
+      // A failed disappearance confirmation leaves the original incarnation in
+      // the pool. It must remain eligible for normal unexpected-loss recovery.
+      if (device.platform === "android") {
+        devicePool?.clearIntentionalShutdown(device.deviceId);
+      }
+      throw error;
+    }
   });
 }
 
@@ -532,11 +544,7 @@ async function withShutdownPoolReservation<T>(
   if (!devicePool || !expectedPooledDevice) {
     return await operation();
   }
-  const releaseReservation = await devicePool.reserveDeviceForReadiness(expectedPooledDevice.id, {
-    deviceId: expectedPooledDevice.id,
-    name: expectedPooledDevice.name,
-    platform: expectedPooledDevice.platform,
-  });
+  const releaseReservation = await devicePool.reserveDeviceForShutdown(expectedPooledDevice);
   try {
     return await operation();
   } finally {

--- a/src/server/deviceTools.ts
+++ b/src/server/deviceTools.ts
@@ -504,12 +504,8 @@ function isSameBootedDeviceIdentity(device: BootedDevice, candidate: BootedDevic
   if (device.platform !== candidate.platform || device.deviceId !== candidate.deviceId) {
     return false;
   }
-  if (
-    device.transportId !== undefined &&
-    candidate.transportId !== undefined &&
-    device.transportId !== candidate.transportId
-  ) {
-    return false;
+  if (device.platform === "android" && device.transportId !== undefined && candidate.transportId !== undefined) {
+    return device.transportId === candidate.transportId;
   }
   return device.name === candidate.name;
 }
@@ -611,12 +607,23 @@ async function retireShutdownOwnership(
   const sessionManager = daemonState.getSessionManager();
   const sessionId = expectedPooledDevice.sessionId;
   if (sessionId && sessionManager.getSessionForDevice(device.deviceId) === sessionId) {
+    const retirementDeadlineMs = Math.max(
+      deadlineMs,
+      timer.now() + DEVICE_SHUTDOWN_POST_RELEASE_RECHECK_TIMEOUT_MS,
+    );
     await executionTracker.cancelSessionUuidExecutions(
       sessionId,
       `device-disconnected:${device.deviceId}`,
       { excludeSignal: abortSignal },
     );
-    await sessionManager.releaseSession(sessionId, `device-stopped:${device.deviceId}`);
+    await runWithinShutdownDeadline(
+      device,
+      timer,
+      retirementDeadlineMs,
+      "session ownership retirement did not complete",
+      abortSignal,
+      async () => await sessionManager.releaseSession(sessionId, `device-stopped:${device.deviceId}`),
+    );
   }
   if (devicePool.getDevice(device.deviceId) !== expectedPooledDevice) {
     return;
@@ -1124,7 +1131,7 @@ export function registerDeviceTools() {
         shutdownDeadlineMs,
         "shutdown preparation did not complete",
         requestAbortSignal,
-        async () => await devicePool?.reserveDeviceForShutdown(args.device.deviceId),
+        async signal => await devicePool?.reserveDeviceForShutdown(args.device.deviceId, signal),
       );
       const expectedPooledDevice = shutdownReservation?.device ?? null;
       const shutdownContext = {

--- a/src/server/deviceTools.ts
+++ b/src/server/deviceTools.ts
@@ -701,6 +701,7 @@ async function killProcessAndRetireOwnership(
     return alreadyStoppedMessage;
   }
 
+  let shutdownWasConfirmed = false;
   try {
     perf.startOperation("waitForShutdown");
     const observedReplacement = await waitForDeviceShutdown(
@@ -711,6 +712,7 @@ async function killProcessAndRetireOwnership(
       requestAbortSignal,
     );
     perf.endOperation("waitForShutdown");
+    shutdownWasConfirmed = true;
 
     perf.startOperation("retireOwnership");
     await retireShutdownOwnership(
@@ -730,7 +732,10 @@ async function killProcessAndRetireOwnership(
     // the pool. It must remain eligible for normal unexpected-loss recovery.
     // Caller cancellation is different: the platform command may already have
     // succeeded, so retain the marker for its later process-exit cleanup.
-    if (shouldClearIntentionalShutdownAfterFailure(device.platform, requestAbortSignal)) {
+    if (
+      !shutdownWasConfirmed &&
+      shouldClearIntentionalShutdownAfterFailure(device.platform, requestAbortSignal)
+    ) {
       devicePool?.clearIntentionalShutdown(device.deviceId);
     }
     throw error;

--- a/src/server/deviceTools.ts
+++ b/src/server/deviceTools.ts
@@ -109,7 +109,8 @@ export const killDeviceSchema = z.object({
   device: z.object({
     name: z.string().describe("Device image name"),
     deviceId: z.string(),
-    platform: platformSchema
+    platform: platformSchema,
+    transportId: z.string().optional(),
   })
 });
 
@@ -413,7 +414,21 @@ async function retireShutdownOwnership(
     return;
   }
   if (!discovery.succeededPlatforms.has(device.platform)) {
-    await waitForDeviceShutdown(deviceManager, device, timer, deadlineMs);
+    const replacementAfterRetry = await waitForDeviceShutdown(
+      deviceManager,
+      device,
+      timer,
+      deadlineMs,
+    );
+    if (replacementAfterRetry) {
+      await rebuildSameIdReplacement(
+        device,
+        expectedPooledDevice,
+        replacementAfterRetry,
+        daemonState,
+      );
+      return;
+    }
   }
   if (devicePool.getDevice(device.deviceId) !== expectedPooledDevice) {
     return;

--- a/src/server/deviceTools.ts
+++ b/src/server/deviceTools.ts
@@ -368,6 +368,24 @@ async function rebuildSameIdReplacement(
   });
 }
 
+async function findReplacementAfterSessionRelease(
+  deviceManager: PlatformDeviceManager,
+  device: BootedDevice,
+  timer: Timer,
+  deadlineMs: number,
+  replacementObservedDuringShutdown: BootedDevice | undefined,
+): Promise<BootedDevice | undefined> {
+  if (timer.now() >= deadlineMs) {
+    return replacementObservedDuringShutdown;
+  }
+  const discovery = await getShutdownDiscovery(deviceManager, device, timer, deadlineMs);
+  const replacement = findDiscoveredDevice(discovery, device);
+  if (replacement || discovery.succeededPlatforms.has(device.platform)) {
+    return replacement;
+  }
+  return await waitForDeviceShutdown(deviceManager, device, timer, deadlineMs);
+}
+
 async function retireShutdownOwnership(
   device: BootedDevice,
   expectedPooledDevice: PooledDevice | null,
@@ -375,6 +393,7 @@ async function retireShutdownOwnership(
   timer: Timer,
   deadlineMs: number,
   abortSignal: AbortSignal | undefined,
+  replacementObservedDuringShutdown: BootedDevice | undefined,
 ): Promise<void> {
   if (!expectedPooledDevice) {
     return;
@@ -406,29 +425,20 @@ async function retireShutdownOwnership(
 
   // A same-ID replacement can boot while releasing the old session. If so,
   // retire only the captured incarnation, then immediately rediscover the
-  // replacement so it owns a fresh pool and registry epoch.
-  const discovery = await getShutdownDiscovery(deviceManager, device, timer, deadlineMs);
-  const replacement = findDiscoveredDevice(discovery, device);
+  // replacement so it owns a fresh pool and registry epoch. Once shutdown was
+  // observed, an exhausted disappearance deadline must not prevent ownership
+  // cleanup; reuse that successful observation instead of starting another
+  // deadline-bound discovery.
+  const replacement = await findReplacementAfterSessionRelease(
+    deviceManager,
+    device,
+    timer,
+    deadlineMs,
+    replacementObservedDuringShutdown,
+  );
   if (replacement) {
     await rebuildSameIdReplacement(device, expectedPooledDevice, replacement, daemonState);
     return;
-  }
-  if (!discovery.succeededPlatforms.has(device.platform)) {
-    const replacementAfterRetry = await waitForDeviceShutdown(
-      deviceManager,
-      device,
-      timer,
-      deadlineMs,
-    );
-    if (replacementAfterRetry) {
-      await rebuildSameIdReplacement(
-        device,
-        expectedPooledDevice,
-        replacementAfterRetry,
-        daemonState,
-      );
-      return;
-    }
   }
   if (devicePool.getDevice(device.deviceId) !== expectedPooledDevice) {
     return;
@@ -473,7 +483,12 @@ async function killProcessAndRetireOwnership(
 
   const shutdownDeadlineMs = dependencies.timer.now() + DEVICE_SHUTDOWN_TIMEOUT_MS;
   perf.startOperation("waitForShutdown");
-  await waitForDeviceShutdown(deviceManager, device, dependencies.timer, shutdownDeadlineMs);
+  const replacementObservedDuringShutdown = await waitForDeviceShutdown(
+    deviceManager,
+    device,
+    dependencies.timer,
+    shutdownDeadlineMs,
+  );
   perf.endOperation("waitForShutdown");
 
   perf.startOperation("retireOwnership");
@@ -484,6 +499,7 @@ async function killProcessAndRetireOwnership(
     dependencies.timer,
     shutdownDeadlineMs,
     abortSignal,
+    replacementObservedDuringShutdown,
   );
   perf.endOperation("retireOwnership");
   return undefined;

--- a/src/server/deviceTools.ts
+++ b/src/server/deviceTools.ts
@@ -30,6 +30,7 @@ import { getInstalledAppsCacheWriteCoordinator } from "../db/installedAppsCacheW
 import { getDbWriteBarrier } from "../db/dbWriteBarrier";
 import { isAdbMissingDeviceError } from "../utils/android-cmdline-tools/AdbDeviceHealth";
 import { defaultTimer, type Timer } from "../utils/SystemTimer";
+import { runWithAbortSignal } from "../utils/AbortContext";
 import { executionTracker } from "./executionTracker";
 import {
   createDefaultRunnerReadinessService,
@@ -277,16 +278,20 @@ async function getShutdownDiscovery(
     throw shutdownTimeoutError(device, "platform discovery did not complete");
   }
   let timeout: NodeJS.Timeout | undefined;
+  const controller = new AbortController();
   const timeoutPromise = new Promise<never>((_, reject) => {
     timeout = timer.setTimeout(() => {
+      controller.abort();
       reject(shutdownTimeoutError(device, "platform discovery did not complete"));
     }, remainingMs);
   });
   try {
     return await Promise.race([
-      deviceManager.getBootedDevicesDetailed(device.platform, {
-        bypassAndroidDeviceListCache: true,
-      }),
+      runWithAbortSignal(controller.signal, () =>
+        deviceManager.getBootedDevicesDetailed(device.platform, {
+          bypassAndroidDeviceListCache: true,
+        }),
+      ),
       timeoutPromise,
     ]);
   } finally {
@@ -402,6 +407,7 @@ async function findReplacementAfterSessionRelease(
 async function retireShutdownOwnership(
   device: BootedDevice,
   expectedPooledDevice: PooledDevice | null,
+  observedReplacement: BootedDevice | undefined,
   deviceManager: PlatformDeviceManager,
   timer: Timer,
   deadlineMs: number,
@@ -441,7 +447,7 @@ async function retireShutdownOwnership(
   // replacement so it owns a fresh pool and registry epoch. Once shutdown was
   // observed, a bounded post-release recheck protects against a replacement
   // that boots at the disappearance deadline.
-  const replacement = await findReplacementAfterSessionRelease(
+  const replacement = observedReplacement ?? await findReplacementAfterSessionRelease(
     deviceManager,
     device,
     timer,
@@ -471,84 +477,65 @@ async function killProcessAndRetireOwnership(
   device: BootedDevice,
   perf: ReturnType<typeof createPerformanceTracker>,
   abortSignal: AbortSignal | undefined,
-): Promise<string | undefined> {
-  const deviceManager = dependencies.deviceManagerFactory();
-  const devicePool = DaemonState.getInstance().isInitialized()
-    ? DaemonState.getInstance().getDevicePool()
-    : undefined;
-  const expectedPooledDevice = devicePool?.getDevice?.(device.deviceId) ?? null;
-  return await withShutdownPoolReservation(devicePool, expectedPooledDevice, async () => {
-    if (device.platform === "android") {
-      devicePool?.markIntentionalShutdown(device.deviceId);
-    }
-
-    let shutdownDevice = device;
-    let alreadyStoppedMessage: string | undefined;
-    perf.startOperation("killProcess");
-    try {
-      const killedDevice = await deviceManager.killDevice(device);
-      shutdownDevice = killedDevice ?? device;
-    } catch (error) {
-      if (isAlreadyStoppedDeviceError(device.platform, device.deviceId, error)) {
-        alreadyStoppedMessage = `Failed to kill ${device.platform} device: ${error}`;
-      } else {
-        devicePool?.clearIntentionalShutdown(device.deviceId);
-        throw error;
-      }
-    }
-    perf.endOperation("killProcess");
-
-    if (alreadyStoppedMessage !== undefined) {
-      return alreadyStoppedMessage;
-    }
-
-    const shutdownDeadlineMs = dependencies.timer.now() + DEVICE_SHUTDOWN_TIMEOUT_MS;
-    try {
-      perf.startOperation("waitForShutdown");
-      await waitForDeviceShutdown(
-        deviceManager,
-        shutdownDevice,
-        dependencies.timer,
-        shutdownDeadlineMs,
-      );
-      perf.endOperation("waitForShutdown");
-
-      perf.startOperation("retireOwnership");
-      await retireShutdownOwnership(
-        shutdownDevice,
-        expectedPooledDevice,
-        deviceManager,
-        dependencies.timer,
-        shutdownDeadlineMs,
-        abortSignal,
-        dependencies.stopPerformanceMonitoring,
-      );
-      perf.endOperation("retireOwnership");
-      return undefined;
-    } catch (error) {
-      // A failed disappearance confirmation leaves the original incarnation in
-      // the pool. It must remain eligible for normal unexpected-loss recovery.
-      if (device.platform === "android") {
-        devicePool?.clearIntentionalShutdown(device.deviceId);
-      }
-      throw error;
-    }
-  });
-}
-
-async function withShutdownPoolReservation<T>(
   devicePool: DevicePool | undefined,
   expectedPooledDevice: PooledDevice | null,
-  operation: () => Promise<T>,
-): Promise<T> {
-  if (!devicePool || !expectedPooledDevice) {
-    return await operation();
+): Promise<string | undefined> {
+  const deviceManager = dependencies.deviceManagerFactory();
+  if (device.platform === "android") {
+    devicePool?.markIntentionalShutdown(device.deviceId);
   }
-  const releaseReservation = await devicePool.reserveDeviceForShutdown(expectedPooledDevice);
+
+  let shutdownDevice = device;
+  let alreadyStoppedMessage: string | undefined;
+  perf.startOperation("killProcess");
   try {
-    return await operation();
-  } finally {
-    await releaseReservation();
+    const killedDevice = await deviceManager.killDevice(device);
+    shutdownDevice = killedDevice ?? device;
+  } catch (error) {
+    if (isAlreadyStoppedDeviceError(device.platform, device.deviceId, error)) {
+      alreadyStoppedMessage = `Failed to kill ${device.platform} device: ${error}`;
+    } else {
+      devicePool?.clearIntentionalShutdown(device.deviceId);
+      throw error;
+    }
+  }
+  perf.endOperation("killProcess");
+
+  if (alreadyStoppedMessage !== undefined) {
+    return alreadyStoppedMessage;
+  }
+
+  const shutdownDeadlineMs = dependencies.timer.now() + DEVICE_SHUTDOWN_TIMEOUT_MS;
+  try {
+    perf.startOperation("waitForShutdown");
+    const observedReplacement = await waitForDeviceShutdown(
+      deviceManager,
+      shutdownDevice,
+      dependencies.timer,
+      shutdownDeadlineMs,
+    );
+    perf.endOperation("waitForShutdown");
+
+    perf.startOperation("retireOwnership");
+    await retireShutdownOwnership(
+      shutdownDevice,
+      expectedPooledDevice,
+      observedReplacement,
+      deviceManager,
+      dependencies.timer,
+      shutdownDeadlineMs,
+      abortSignal,
+      dependencies.stopPerformanceMonitoring,
+    );
+    perf.endOperation("retireOwnership");
+    return undefined;
+  } catch (error) {
+    // A failed disappearance confirmation leaves the original incarnation in
+    // the pool. It must remain eligible for normal unexpected-loss recovery.
+    if (device.platform === "android") {
+      devicePool?.clearIntentionalShutdown(device.deviceId);
+    }
+    throw error;
   }
 }
 
@@ -933,7 +920,13 @@ export function registerDeviceTools() {
   ) => {
     const perf = createPerformanceTracker(true);
     perf.serial("killDevice");
+    const daemonState = DaemonState.getInstance();
+    const devicePool = daemonState.isInitialized() ? daemonState.getDevicePool() : undefined;
+    let shutdownReservation: Awaited<ReturnType<DevicePool["reserveDeviceForShutdown"]>>;
     try {
+      shutdownReservation = await devicePool?.reserveDeviceForShutdown(args.device.deviceId);
+      const expectedPooledDevice = shutdownReservation?.device ?? null;
+
       perf.startOperation("stopRecordings");
       const activeRecordings = await listActiveVideoRecordings({
         deviceId: args.device.deviceId,
@@ -973,6 +966,8 @@ export function registerDeviceTools() {
         args.device,
         perf,
         abortSignal,
+        devicePool,
+        expectedPooledDevice,
       );
 
       perf.startOperation("cleanup");
@@ -989,6 +984,8 @@ export function registerDeviceTools() {
       return createKillDeviceResponse(args, timing, alreadyStoppedMessage);
     } catch (error) {
       throw new ActionableError(`Failed to kill ${args.device.platform} device: ${error}`);
+    } finally {
+      await shutdownReservation?.release();
     }
   };
 

--- a/src/server/deviceTools.ts
+++ b/src/server/deviceTools.ts
@@ -265,7 +265,7 @@ interface ShutdownDeadlineContext {
   timer: Timer;
   deadlineMs: number;
   requestAbortSignal: AbortSignal | undefined;
-  retainReservationUntil?: (operation: Promise<unknown>) => void;
+  retainReservationUntil?: (operation: Promise<unknown>, releaseAfterFailure?: boolean) => void;
 }
 
 function shouldPropagateShutdownPreparationError(
@@ -349,9 +349,12 @@ async function stopIosCtrlProxyBeforeShutdown(
       async () => await stop,
     );
   } catch (error) {
-    if (isShutdownTimeoutError(error)) {
+    if (shouldPropagateShutdownPreparationError(error, context.requestAbortSignal)) {
       if (stop) {
-        context.retainReservationUntil?.(stop);
+        // CtrlProxy shutdown mutates process state after its caller stops waiting.
+        // Keep this device unavailable until it settles, but release it after a
+        // failed pre-kill teardown because the platform was never shut down.
+        context.retainReservationUntil?.(stop, true);
       }
       throw error;
     }
@@ -1352,13 +1355,22 @@ export function registerDeviceTools() {
         async signal => await devicePool?.reserveDeviceForShutdown(args.device.deviceId, signal),
       );
       const expectedPooledDevice = shutdownReservation?.device ?? null;
-      const retainReservationUntil = (operation: Promise<unknown>): void => {
+      const retainReservationUntil = (
+        operation: Promise<unknown>,
+        releaseAfterFailure = false,
+      ): void => {
         retainShutdownReservation = true;
         void operation.then(
           () => shutdownReservation?.release(),
-          error => logger.warn(
-            `[DeviceTools] Retaining shutdown reservation after late teardown failed: ${error}`,
-          ),
+          error => {
+            if (releaseAfterFailure) {
+              void shutdownReservation?.release();
+              return;
+            }
+            logger.warn(
+              `[DeviceTools] Retaining shutdown reservation after late teardown failed: ${error}`,
+            );
+          },
         );
       };
       const shutdownContext: ShutdownDeadlineContext = {

--- a/src/server/deviceTools.ts
+++ b/src/server/deviceTools.ts
@@ -2,7 +2,11 @@ import type { ChildProcess } from "child_process";
 import { z } from "zod";
 import { defaultIdGenerator, type IdGenerator } from "../utils/IdGenerator";
 import { ToolRegistry, ProgressCallback } from "./toolRegistry";
-import { MultiPlatformDeviceManager, PlatformDeviceManager } from "../utils/deviceUtils";
+import {
+  type BootedDeviceDiscovery,
+  MultiPlatformDeviceManager,
+  PlatformDeviceManager,
+} from "../utils/deviceUtils";
 import { createJSONToolResponse } from "../utils/toolUtils";
 import { ActionableError, BootedDevice, DeviceInfo, SomePlatform } from "../models";
 import type { FormFactor, StartDeviceResult } from "../models/DeviceMatchCriteria";
@@ -25,6 +29,7 @@ import { getInstalledAppsCacheWriteCoordinator } from "../db/installedAppsCacheW
 import { getDbWriteBarrier } from "../db/dbWriteBarrier";
 import { isAdbMissingDeviceError } from "../utils/android-cmdline-tools/AdbDeviceHealth";
 import { defaultTimer, type Timer } from "../utils/SystemTimer";
+import { executionTracker } from "./executionTracker";
 import {
   createDefaultRunnerReadinessService,
   type RunnerReadinessRequest,
@@ -316,6 +321,37 @@ async function waitForDeviceShutdown(
   }
 }
 
+function discoveryShowsDevice(discovery: BootedDeviceDiscovery, device: BootedDevice): boolean {
+  return discovery.succeededPlatforms.has(device.platform) && discovery.devices.some(candidate =>
+    candidate.platform === device.platform && candidate.deviceId === device.deviceId,
+  );
+}
+
+async function rebuildSameIdReplacement(
+  device: BootedDevice,
+  expectedPooledDevice: PooledDevice,
+  daemonState: DaemonState,
+): Promise<void> {
+  const devicePool = daemonState.getDevicePool();
+  await devicePool.releaseDevice(device.deviceId);
+  if (devicePool.getDevice(device.deviceId) !== expectedPooledDevice) {
+    return;
+  }
+  await devicePool.removeDisconnectedDevice(device.deviceId, false);
+  if (!devicePool.getDevice(device.deviceId)) {
+    daemonState.getDeviceSessionRegistry().onDeviceDisconnected(device.deviceId);
+  }
+  await devicePool.refreshDevices();
+  const replacement = devicePool.getDevice(device.deviceId);
+  if (replacement) {
+    daemonState.getDeviceSessionRegistry().onDeviceConnected({
+      deviceId: replacement.id,
+      platform: replacement.platform,
+      incarnation: replacement.incarnation,
+    });
+  }
+}
+
 async function retireShutdownOwnership(
   device: BootedDevice,
   expectedPooledDevice: PooledDevice | null,
@@ -340,30 +376,39 @@ async function retireShutdownOwnership(
   const sessionManager = daemonState.getSessionManager();
   const sessionId = expectedPooledDevice.sessionId;
   if (sessionId && sessionManager.getSessionForDevice(device.deviceId) === sessionId) {
+    await executionTracker.cancelSessionUuidExecutions(
+      sessionId,
+      `device-disconnected:${device.deviceId}`,
+      { excludeToolName: "killDevice" },
+    );
     await sessionManager.releaseSession(sessionId, `device-stopped:${device.deviceId}`);
   }
   if (devicePool.getDevice(device.deviceId) !== expectedPooledDevice) {
     return;
   }
 
-  // A same-ID replacement can boot while releasing the old session. Re-check
-  // physical disappearance after that await, then synchronously detach the
-  // captured pool entry before another lifecycle event can interleave.
-  await waitForDeviceShutdown(deviceManager, device, timer, deadlineMs);
+  // A same-ID replacement can boot while releasing the old session. If so,
+  // retire only the captured incarnation, then immediately rediscover the
+  // replacement so it owns a fresh pool and registry epoch.
+  const discovery = await getShutdownDiscovery(deviceManager, device, timer, deadlineMs);
+  if (discoveryShowsDevice(discovery, device)) {
+    await rebuildSameIdReplacement(device, expectedPooledDevice, daemonState);
+    return;
+  }
+  if (!discovery.succeededPlatforms.has(device.platform)) {
+    await waitForDeviceShutdown(deviceManager, device, timer, deadlineMs);
+  }
   if (devicePool.getDevice(device.deviceId) !== expectedPooledDevice) {
     return;
   }
-  const poolRelease = devicePool.releaseDevice(device.deviceId);
+  await devicePool.releaseDevice(device.deviceId);
   if (devicePool.getDevice(device.deviceId) !== expectedPooledDevice) {
-    await poolRelease;
     return;
   }
-  const poolRemoval = devicePool.removeDisconnectedDevice(device.deviceId, false);
+  await devicePool.removeDisconnectedDevice(device.deviceId, false);
   if (!devicePool.getDevice(device.deviceId)) {
     daemonState.getDeviceSessionRegistry().onDeviceDisconnected(device.deviceId);
   }
-  await poolRelease;
-  await poolRemoval;
 }
 
 async function killProcessAndRetireOwnership(

--- a/src/server/deviceTools.ts
+++ b/src/server/deviceTools.ts
@@ -25,6 +25,7 @@ import { DEVICE_CREATE_ENV_VAR, getDeviceCreationGate, type DeviceCreationGate }
 import { createDefaultDeviceProvisioner, type DeviceProvisioner } from "../utils/deviceProvisioning";
 import { DaemonState } from "../daemon/daemonState";
 import type { DevicePool, PooledDevice } from "../daemon/devicePool";
+import type { SessionManager } from "../daemon/sessionManager";
 import { DeviceBootService, type DeviceBootResult } from "../utils/deviceBootService";
 import { getInstalledAppsCacheWriteCoordinator } from "../db/installedAppsCacheWriteCoordinator";
 import { getDbWriteBarrier } from "../db/dbWriteBarrier";
@@ -264,6 +265,7 @@ interface ShutdownDeadlineContext {
   timer: Timer;
   deadlineMs: number;
   requestAbortSignal: AbortSignal | undefined;
+  retainReservationUntil?: (operation: Promise<unknown>) => void;
 }
 
 function shouldPropagateShutdownPreparationError(
@@ -328,6 +330,7 @@ async function stopIosCtrlProxyBeforeShutdown(
   if (context.device.platform !== "ios") {
     return;
   }
+  let stop: Promise<void> | undefined;
   perf.startOperation("stopCtrlProxy");
   try {
     const xcTestManager = IOSCtrlProxyManager.getInstance({
@@ -336,16 +339,20 @@ async function stopIosCtrlProxyBeforeShutdown(
       deviceId: context.device.deviceId,
       source: "local",
     });
+    stop = xcTestManager.stop();
     await runWithinShutdownDeadline(
       context.device,
       context.timer,
       context.deadlineMs,
       "iOS CtrlProxy shutdown did not complete",
       context.requestAbortSignal,
-      async () => await xcTestManager.stop(),
+      async () => await stop,
     );
   } catch (error) {
     if (isShutdownTimeoutError(error)) {
+      if (stop) {
+        context.retainReservationUntil?.(stop);
+      }
       throw error;
     }
     logger.warn(`[DeviceTools] Failed to stop CtrlProxy iOS before kill: ${error}`);
@@ -559,11 +566,14 @@ async function rebuildSameIdReplacement(
   stopPerformanceMonitoring: (deviceId: string) => void,
 ): Promise<void> {
   const devicePool = daemonState.getDevicePool();
-  const rebuilt = await devicePool.replaceDeviceForShutdown(expectedPooledDevice, replacement);
+  const rebuilt = await devicePool.replaceDeviceForShutdown(
+    expectedPooledDevice,
+    replacement,
+    () => stopPerformanceMonitoring(device.deviceId),
+  );
   if (!rebuilt) {
     return;
   }
-  stopPerformanceMonitoring(device.deviceId);
   daemonState.getDeviceSessionRegistry().onDeviceConnected({
     deviceId: rebuilt.id,
     platform: rebuilt.platform,
@@ -623,7 +633,7 @@ function finishLateShutdownRetirement(
   stopPerformanceMonitoring: (deviceId: string) => void,
   retainReservationUntil: (retirement: Promise<void>) => void,
 ): void {
-  const lateRetirement = release.then(async () => {
+  const continueRetirement = async () => {
     await retireShutdownOwnership(
       device,
       expectedPooledDevice,
@@ -636,7 +646,8 @@ function finishLateShutdownRetirement(
       () => undefined,
       false,
     );
-  });
+  };
+  const lateRetirement = release.then(continueRetirement, continueRetirement);
   lateRetirement.catch(lateError => {
     logger.warn(
       `[DeviceTools] Failed to finish late shutdown retirement for ${device.deviceId}: ${lateError}`,
@@ -721,6 +732,8 @@ async function findReplacementOrRetainShutdownReservation(
 function preserveLateShutdownRetirement(
   error: unknown,
   requestAbortSignal: AbortSignal | undefined,
+  sessionManager: SessionManager,
+  sessionId: string,
   release: Promise<string | null>,
   device: BootedDevice,
   expectedPooledDevice: PooledDevice,
@@ -731,7 +744,11 @@ function preserveLateShutdownRetirement(
   stopPerformanceMonitoring: (deviceId: string) => void,
   retainReservationUntil: (retirement: Promise<void>) => void,
 ): void {
-  if (!isShutdownTimeoutError(error) && !requestAbortSignal?.aborted) {
+  if (
+    !isShutdownTimeoutError(error) &&
+    !requestAbortSignal?.aborted &&
+    sessionManager.getSessionForDevice(device.deviceId) === sessionId
+  ) {
     return;
   }
   // Session release removes its in-memory mapping before its durable write.
@@ -803,6 +820,8 @@ async function retireShutdownOwnership(
       preserveLateShutdownRetirement(
         error,
         abortSignal,
+        sessionManager,
+        sessionId,
         release,
         device,
         expectedPooledDevice,
@@ -1333,11 +1352,21 @@ export function registerDeviceTools() {
         async signal => await devicePool?.reserveDeviceForShutdown(args.device.deviceId, signal),
       );
       const expectedPooledDevice = shutdownReservation?.device ?? null;
-      const shutdownContext = {
+      const retainReservationUntil = (operation: Promise<unknown>): void => {
+        retainShutdownReservation = true;
+        void operation.then(
+          () => shutdownReservation?.release(),
+          error => logger.warn(
+            `[DeviceTools] Retaining shutdown reservation after late teardown failed: ${error}`,
+          ),
+        );
+      };
+      const shutdownContext: ShutdownDeadlineContext = {
         device: args.device,
         timer: deps.timer,
         deadlineMs: shutdownDeadlineMs,
         requestAbortSignal,
+        retainReservationUntil,
       };
       await stopVideoRecordingsBeforeShutdown(shutdownContext, perf);
       await stopIosCtrlProxyBeforeShutdown(shutdownContext, perf);
@@ -1351,13 +1380,7 @@ export function registerDeviceTools() {
         expectedPooledDevice,
         shutdownDeadlineMs,
         retirement => {
-          retainShutdownReservation = true;
-          void retirement.then(
-            () => shutdownReservation?.release(),
-            error => logger.warn(
-              `[DeviceTools] Retaining shutdown reservation after late retirement failed: ${error}`,
-            ),
-          );
+          retainReservationUntil(retirement);
         },
       );
 

--- a/src/server/deviceTools.ts
+++ b/src/server/deviceTools.ts
@@ -24,7 +24,7 @@ import { DEVICE_POOL_MATCHING, isDevicePoolAutolockEnabled } from "../daemon/poo
 import { DEVICE_CREATE_ENV_VAR, getDeviceCreationGate, type DeviceCreationGate } from "../utils/deviceCreationGate";
 import { createDefaultDeviceProvisioner, type DeviceProvisioner } from "../utils/deviceProvisioning";
 import { DaemonState } from "../daemon/daemonState";
-import type { PooledDevice } from "../daemon/devicePool";
+import type { DevicePool, PooledDevice } from "../daemon/devicePool";
 import { DeviceBootService, type DeviceBootResult } from "../utils/deviceBootService";
 import { getInstalledAppsCacheWriteCoordinator } from "../db/installedAppsCacheWriteCoordinator";
 import { getDbWriteBarrier } from "../db/dbWriteBarrier";
@@ -474,52 +474,74 @@ async function killProcessAndRetireOwnership(
     ? DaemonState.getInstance().getDevicePool()
     : undefined;
   const expectedPooledDevice = devicePool?.getDevice?.(device.deviceId) ?? null;
-  if (device.platform === "android") {
-    devicePool?.markIntentionalShutdown(device.deviceId);
-  }
-
-  let shutdownDevice = device;
-  let alreadyStoppedMessage: string | undefined;
-  perf.startOperation("killProcess");
-  try {
-    const killedDevice = await deviceManager.killDevice(device);
-    shutdownDevice = killedDevice ?? device;
-  } catch (error) {
-    if (isAlreadyStoppedDeviceError(device.platform, device.deviceId, error)) {
-      alreadyStoppedMessage = `Failed to kill ${device.platform} device: ${error}`;
-    } else {
-      devicePool?.clearIntentionalShutdown(device.deviceId);
-      throw error;
+  return await withShutdownPoolReservation(devicePool, expectedPooledDevice, async () => {
+    if (device.platform === "android") {
+      devicePool?.markIntentionalShutdown(device.deviceId);
     }
+
+    let shutdownDevice = device;
+    let alreadyStoppedMessage: string | undefined;
+    perf.startOperation("killProcess");
+    try {
+      const killedDevice = await deviceManager.killDevice(device);
+      shutdownDevice = killedDevice ?? device;
+    } catch (error) {
+      if (isAlreadyStoppedDeviceError(device.platform, device.deviceId, error)) {
+        alreadyStoppedMessage = `Failed to kill ${device.platform} device: ${error}`;
+      } else {
+        devicePool?.clearIntentionalShutdown(device.deviceId);
+        throw error;
+      }
+    }
+    perf.endOperation("killProcess");
+
+    if (alreadyStoppedMessage !== undefined) {
+      return alreadyStoppedMessage;
+    }
+
+    const shutdownDeadlineMs = dependencies.timer.now() + DEVICE_SHUTDOWN_TIMEOUT_MS;
+    perf.startOperation("waitForShutdown");
+    await waitForDeviceShutdown(
+      deviceManager,
+      shutdownDevice,
+      dependencies.timer,
+      shutdownDeadlineMs,
+    );
+    perf.endOperation("waitForShutdown");
+
+    perf.startOperation("retireOwnership");
+    await retireShutdownOwnership(
+      shutdownDevice,
+      expectedPooledDevice,
+      deviceManager,
+      dependencies.timer,
+      shutdownDeadlineMs,
+      abortSignal,
+      dependencies.stopPerformanceMonitoring,
+    );
+    perf.endOperation("retireOwnership");
+    return undefined;
+  });
+}
+
+async function withShutdownPoolReservation<T>(
+  devicePool: DevicePool | undefined,
+  expectedPooledDevice: PooledDevice | null,
+  operation: () => Promise<T>,
+): Promise<T> {
+  if (!devicePool || !expectedPooledDevice) {
+    return await operation();
   }
-  perf.endOperation("killProcess");
-
-  if (alreadyStoppedMessage !== undefined) {
-    return alreadyStoppedMessage;
+  const releaseReservation = await devicePool.reserveDeviceForReadiness(expectedPooledDevice.id, {
+    deviceId: expectedPooledDevice.id,
+    name: expectedPooledDevice.name,
+    platform: expectedPooledDevice.platform,
+  });
+  try {
+    return await operation();
+  } finally {
+    await releaseReservation();
   }
-
-  const shutdownDeadlineMs = dependencies.timer.now() + DEVICE_SHUTDOWN_TIMEOUT_MS;
-  perf.startOperation("waitForShutdown");
-  await waitForDeviceShutdown(
-    deviceManager,
-    shutdownDevice,
-    dependencies.timer,
-    shutdownDeadlineMs,
-  );
-  perf.endOperation("waitForShutdown");
-
-  perf.startOperation("retireOwnership");
-  await retireShutdownOwnership(
-    shutdownDevice,
-    expectedPooledDevice,
-    deviceManager,
-    dependencies.timer,
-    shutdownDeadlineMs,
-    abortSignal,
-    dependencies.stopPerformanceMonitoring,
-  );
-  perf.endOperation("retireOwnership");
-  return undefined;
 }
 
 let moduleDependencies: DeviceToolsDependencies | null = null;

--- a/src/server/deviceTools.ts
+++ b/src/server/deviceTools.ts
@@ -321,8 +321,14 @@ async function waitForDeviceShutdown(
   }
 }
 
-function discoveryShowsDevice(discovery: BootedDeviceDiscovery, device: BootedDevice): boolean {
-  return discovery.succeededPlatforms.has(device.platform) && discovery.devices.some(candidate =>
+function findDiscoveredDevice(
+  discovery: BootedDeviceDiscovery,
+  device: BootedDevice,
+): BootedDevice | undefined {
+  if (!discovery.succeededPlatforms.has(device.platform)) {
+    return undefined;
+  }
+  return discovery.devices.find(candidate =>
     candidate.platform === device.platform && candidate.deviceId === device.deviceId,
   );
 }
@@ -330,6 +336,7 @@ function discoveryShowsDevice(discovery: BootedDeviceDiscovery, device: BootedDe
 async function rebuildSameIdReplacement(
   device: BootedDevice,
   expectedPooledDevice: PooledDevice,
+  replacement: BootedDevice,
   daemonState: DaemonState,
 ): Promise<void> {
   const devicePool = daemonState.getDevicePool();
@@ -341,13 +348,13 @@ async function rebuildSameIdReplacement(
   if (!devicePool.getDevice(device.deviceId)) {
     daemonState.getDeviceSessionRegistry().onDeviceDisconnected(device.deviceId);
   }
-  await devicePool.refreshDevices();
-  const replacement = devicePool.getDevice(device.deviceId);
-  if (replacement) {
+  await devicePool.addDevice(replacement);
+  const rebuilt = devicePool.getDevice(device.deviceId);
+  if (rebuilt) {
     daemonState.getDeviceSessionRegistry().onDeviceConnected({
-      deviceId: replacement.id,
-      platform: replacement.platform,
-      incarnation: replacement.incarnation,
+      deviceId: rebuilt.id,
+      platform: rebuilt.platform,
+      incarnation: rebuilt.incarnation,
     });
   }
 }
@@ -358,6 +365,7 @@ async function retireShutdownOwnership(
   deviceManager: PlatformDeviceManager,
   timer: Timer,
   deadlineMs: number,
+  abortSignal: AbortSignal | undefined,
 ): Promise<void> {
   if (!expectedPooledDevice) {
     return;
@@ -379,7 +387,7 @@ async function retireShutdownOwnership(
     await executionTracker.cancelSessionUuidExecutions(
       sessionId,
       `device-disconnected:${device.deviceId}`,
-      { excludeToolName: "killDevice" },
+      { excludeSignal: abortSignal },
     );
     await sessionManager.releaseSession(sessionId, `device-stopped:${device.deviceId}`);
   }
@@ -391,8 +399,9 @@ async function retireShutdownOwnership(
   // retire only the captured incarnation, then immediately rediscover the
   // replacement so it owns a fresh pool and registry epoch.
   const discovery = await getShutdownDiscovery(deviceManager, device, timer, deadlineMs);
-  if (discoveryShowsDevice(discovery, device)) {
-    await rebuildSameIdReplacement(device, expectedPooledDevice, daemonState);
+  const replacement = findDiscoveredDevice(discovery, device);
+  if (replacement) {
+    await rebuildSameIdReplacement(device, expectedPooledDevice, replacement, daemonState);
     return;
   }
   if (!discovery.succeededPlatforms.has(device.platform)) {
@@ -415,6 +424,7 @@ async function killProcessAndRetireOwnership(
   dependencies: DeviceToolsDependencies,
   device: BootedDevice,
   perf: ReturnType<typeof createPerformanceTracker>,
+  abortSignal: AbortSignal | undefined,
 ): Promise<string | undefined> {
   const deviceManager = dependencies.deviceManagerFactory();
   const devicePool = DaemonState.getInstance().isInitialized()
@@ -455,6 +465,7 @@ async function killProcessAndRetireOwnership(
     deviceManager,
     dependencies.timer,
     shutdownDeadlineMs,
+    abortSignal,
   );
   perf.endOperation("retireOwnership");
   return undefined;
@@ -831,7 +842,11 @@ export function registerDeviceTools() {
   }
 
 
-  const killDeviceHandler = async (args: KillDeviceArgs) => {
+  const killDeviceHandler = async (
+    args: KillDeviceArgs,
+    _progress?: ProgressCallback,
+    abortSignal?: AbortSignal,
+  ) => {
     const perf = createPerformanceTracker(true);
     perf.serial("killDevice");
     try {
@@ -869,7 +884,12 @@ export function registerDeviceTools() {
       }
 
       const deps = getDeviceToolsDependencies();
-      const alreadyStoppedMessage = await killProcessAndRetireOwnership(deps, args.device, perf);
+      const alreadyStoppedMessage = await killProcessAndRetireOwnership(
+        deps,
+        args.device,
+        perf,
+        abortSignal,
+      );
 
       perf.startOperation("cleanup");
       await clearInstalledAppsAfterShutdown(deps, args.device.deviceId);

--- a/src/server/deviceTools.ts
+++ b/src/server/deviceTools.ts
@@ -281,7 +281,9 @@ async function getShutdownDiscovery(
   });
   try {
     return await Promise.race([
-      deviceManager.getBootedDevicesDetailed(device.platform),
+      deviceManager.getBootedDevicesDetailed(device.platform, {
+        bypassAndroidDeviceListCache: true,
+      }),
       timeoutPromise,
     ]);
   } finally {
@@ -360,7 +362,6 @@ async function rebuildSameIdReplacement(
   if (!rebuilt) {
     return;
   }
-  daemonState.getDeviceSessionRegistry().onDeviceDisconnected(device.deviceId);
   daemonState.getDeviceSessionRegistry().onDeviceConnected({
     deviceId: rebuilt.id,
     platform: rebuilt.platform,
@@ -463,10 +464,12 @@ async function killProcessAndRetireOwnership(
     devicePool?.markIntentionalShutdown(device.deviceId);
   }
 
+  let shutdownDevice = device;
   let alreadyStoppedMessage: string | undefined;
   perf.startOperation("killProcess");
   try {
-    await deviceManager.killDevice(device);
+    const killedDevice = await deviceManager.killDevice(device);
+    shutdownDevice = killedDevice ?? device;
   } catch (error) {
     if (isAlreadyStoppedDeviceError(device.platform, device.deviceId, error)) {
       alreadyStoppedMessage = `Failed to kill ${device.platform} device: ${error}`;
@@ -485,7 +488,7 @@ async function killProcessAndRetireOwnership(
   perf.startOperation("waitForShutdown");
   const replacementObservedDuringShutdown = await waitForDeviceShutdown(
     deviceManager,
-    device,
+    shutdownDevice,
     dependencies.timer,
     shutdownDeadlineMs,
   );
@@ -493,7 +496,7 @@ async function killProcessAndRetireOwnership(
 
   perf.startOperation("retireOwnership");
   await retireShutdownOwnership(
-    device,
+    shutdownDevice,
     expectedPooledDevice,
     deviceManager,
     dependencies.timer,

--- a/src/server/deviceTools.ts
+++ b/src/server/deviceTools.ts
@@ -587,7 +587,10 @@ async function findReplacementAfterSessionRelease(
     requestAbortSignal,
   );
   const replacement = findDiscoveredDevice(discovery, device);
-  if (replacement && !isSameBootedDeviceIdentity(device, replacement)) {
+  if (
+    replacement &&
+    (device.platform === "ios" || !isSameBootedDeviceIdentity(device, replacement))
+  ) {
     return replacement;
   }
   if (!replacement && discovery.succeededPlatforms.has(device.platform)) {

--- a/src/server/executionTracker.ts
+++ b/src/server/executionTracker.ts
@@ -36,7 +36,7 @@ export interface ExecutionCancellationOptions {
    * Keeps the control-plane operation that triggered a device shutdown alive
    * while cancelling the device-bound work that must fail fast.
    */
-  excludeToolName?: string;
+  excludeSignal?: AbortSignal;
 }
 
 export class ExecutionTracker {
@@ -197,7 +197,7 @@ export class ExecutionTracker {
       if (!execution) {
         continue;
       }
-      if (execution.toolName === options.excludeToolName) {
+      if (execution.abortController.signal === options.excludeSignal) {
         continue;
       }
       if (cancelReason.startsWith("device-disconnected:")) {

--- a/src/server/executionTracker.ts
+++ b/src/server/executionTracker.ts
@@ -31,6 +31,14 @@ export interface ExecutionScopeOptions {
   sessionUuid?: string;
 }
 
+export interface ExecutionCancellationOptions {
+  /**
+   * Keeps the control-plane operation that triggered a device shutdown alive
+   * while cancelling the device-bound work that must fail fast.
+   */
+  excludeToolName?: string;
+}
+
 export class ExecutionTracker {
   private executions = new Map<string, ActiveExecution>();
   private sessionExecutions = new Map<string, Set<string>>();
@@ -107,8 +115,18 @@ export class ExecutionTracker {
     return this.cancelExecutionsForKey(sessionId, this.sessionExecutions, "sessionId", reason);
   }
 
-  async cancelSessionUuidExecutions(sessionUuid: string, reason: string = "unspecified"): Promise<number> {
-    return this.cancelExecutionsForKey(sessionUuid, this.sessionUuidExecutions, "sessionUuid", reason);
+  async cancelSessionUuidExecutions(
+    sessionUuid: string,
+    reason: string = "unspecified",
+    options: ExecutionCancellationOptions = {},
+  ): Promise<number> {
+    return this.cancelExecutionsForKey(
+      sessionUuid,
+      this.sessionUuidExecutions,
+      "sessionUuid",
+      reason,
+      options,
+    );
   }
 
   hasActiveSessionUuidExecutions(sessionUuid: string): boolean {
@@ -165,7 +183,8 @@ export class ExecutionTracker {
     key: string,
     executionMap: Map<string, Set<string>>,
     label: "sessionId" | "sessionUuid",
-    cancelReason: string = "unspecified"
+    cancelReason: string = "unspecified",
+    options: ExecutionCancellationOptions = {},
   ): Promise<number> {
     const executions = executionMap.get(key);
     if (!executions || executions.size === 0) {
@@ -176,6 +195,9 @@ export class ExecutionTracker {
     for (const executionId of executions) {
       const execution = this.executions.get(executionId);
       if (!execution) {
+        continue;
+      }
+      if (execution.toolName === options.excludeToolName) {
         continue;
       }
       if (cancelReason.startsWith("device-disconnected:")) {

--- a/src/utils/android-cmdline-tools/AdbClient.ts
+++ b/src/utils/android-cmdline-tools/AdbClient.ts
@@ -953,7 +953,7 @@ export class AdbClient implements AdbExecutor {
    * @returns Promise with an array of device IDs
    */
   async getBootedAndroidDevices(
-    options: { bypassCache?: boolean; throwOnMissingAdb?: boolean } = {}
+    options: { bypassCache?: boolean; throwOnMissingAdb?: boolean; signal?: AbortSignal } = {}
   ): Promise<BootedDevice[]> {
     if (this.shouldSkipMissingAdbProbe()) {
       if (options.throwOnMissingAdb) {
@@ -977,7 +977,8 @@ export class AdbClient implements AdbExecutor {
         "devices -l",
         AdbClient.DEVICE_LIST_TIMEOUT_MS,
         undefined,
-        true
+        true,
+        options.signal,
       );
     } catch (error) {
       if (this.isMissingExecutableError(error)) {

--- a/src/utils/android-cmdline-tools/AndroidEmulatorClient.ts
+++ b/src/utils/android-cmdline-tools/AndroidEmulatorClient.ts
@@ -148,7 +148,7 @@ export interface AndroidEmulator {
    * @param device - The device to kill
    * @returns Promise that resolves when emulator is stopped
    */
-  killDevice(device: BootedDevice): Promise<BootedDevice>;
+  killDevice(device: BootedDevice, options?: { timeoutMs?: number; signal?: AbortSignal }): Promise<BootedDevice>;
 
   /**
    * Wait for the emulator to be ready for use
@@ -1128,6 +1128,7 @@ export class AndroidEmulatorClient implements AndroidEmulator {
   async getBootedDevicesChecked(
     onlyEmulators: boolean = false,
     options: { bypassDeviceListCache?: boolean } = {},
+    signal?: AbortSignal,
   ): Promise<BootedDevice[]> {
     const perf = createGlobalPerformanceTracker();
     {
@@ -1136,6 +1137,7 @@ export class AndroidEmulatorClient implements AndroidEmulator {
       const devices = await adb.getBootedAndroidDevices({
         bypassCache: options.bypassDeviceListCache,
         throwOnMissingAdb: true,
+        signal,
       });
       perf.endOperation("adbDeviceScan");
       const runningDevices: BootedDevice[] = [];
@@ -1156,6 +1158,7 @@ export class AndroidEmulatorClient implements AndroidEmulator {
             infoTimeoutMs,
             undefined,
             true,
+            signal,
           );
           const avdName = result.stdout.trim().replace(/\r?\n.*$/, ""); // Remove any trailing newlines and additional text
 
@@ -1198,6 +1201,7 @@ export class AndroidEmulatorClient implements AndroidEmulator {
               infoTimeoutMs,
               undefined,
               true,
+              signal,
             );
             const modelName = result.stdout.trim();
 
@@ -1780,10 +1784,13 @@ export class AndroidEmulatorClient implements AndroidEmulator {
    * @param device - The device to kill
    * @returns Promise that resolves when emulator is stopped
    */
-  async killDevice(device: BootedDevice): Promise<BootedDevice> {
+  async killDevice(
+    device: BootedDevice,
+    options: { timeoutMs?: number; signal?: AbortSignal } = {},
+  ): Promise<BootedDevice> {
     const runningEmulators = await this.getBootedDevicesChecked(false, {
       bypassDeviceListCache: true,
-    });
+    }, options.signal);
     const emulator = runningEmulators.find((emu) => emu.deviceId === device.deviceId);
 
     if (!emulator || !emulator.deviceId) {
@@ -1792,7 +1799,7 @@ export class AndroidEmulatorClient implements AndroidEmulator {
 
     // Use ADB to stop the emulator
     const adb = this.adbFactory.create(emulator);
-    await adb.executeCommand("emu kill");
+    await adb.executeCommand("emu kill", options.timeoutMs, undefined, true, options.signal);
 
     logger.info(`Killed emulator '${device.name}'`);
     return emulator;

--- a/src/utils/android-cmdline-tools/AndroidEmulatorClient.ts
+++ b/src/utils/android-cmdline-tools/AndroidEmulatorClient.ts
@@ -148,7 +148,7 @@ export interface AndroidEmulator {
    * @param device - The device to kill
    * @returns Promise that resolves when emulator is stopped
    */
-  killDevice(device: BootedDevice): Promise<void>;
+  killDevice(device: BootedDevice): Promise<BootedDevice>;
 
   /**
    * Wait for the emulator to be ready for use
@@ -1780,7 +1780,7 @@ export class AndroidEmulatorClient implements AndroidEmulator {
    * @param device - The device to kill
    * @returns Promise that resolves when emulator is stopped
    */
-  async killDevice(device: BootedDevice): Promise<void> {
+  async killDevice(device: BootedDevice): Promise<BootedDevice> {
     const runningEmulators = await this.getBootedDevicesChecked(false, {
       bypassDeviceListCache: true,
     });
@@ -1795,6 +1795,7 @@ export class AndroidEmulatorClient implements AndroidEmulator {
     await adb.executeCommand("emu kill");
 
     logger.info(`Killed emulator '${device.name}'`);
+    return emulator;
   }
 
   private getLaunchTargetDeviceId(childProcess?: ChildProcess | null): string | undefined {

--- a/src/utils/android-cmdline-tools/interfaces/AdbExecutor.ts
+++ b/src/utils/android-cmdline-tools/interfaces/AdbExecutor.ts
@@ -97,6 +97,7 @@ export interface AdbExecutor {
   getBootedAndroidDevices(options?: {
     bypassCache?: boolean;
     throwOnMissingAdb?: boolean;
+    signal?: AbortSignal;
   }): Promise<BootedDevice[]>;
 
   /** Return raw ADB device states, including `offline` and `unauthorized` rows. */

--- a/src/utils/deviceBootRecovery.ts
+++ b/src/utils/deviceBootRecovery.ts
@@ -114,11 +114,13 @@ export async function createCiIosBootConfiguration(
     }),
     recovery: new CiIosBootRecovery({
       ownedSimulatorName,
-      shutdown: target => deviceManager.killDevice({
-        name: target.name,
-        platform: "ios",
-        deviceId: target.deviceId!,
-      }),
+      shutdown: async target => {
+        await deviceManager.killDevice({
+          name: target.name,
+          platform: "ios",
+          deviceId: target.deviceId!,
+        });
+      },
       erase: udid => simctl.eraseSimulator(udid),
     }),
   };

--- a/src/utils/deviceUtils.ts
+++ b/src/utils/deviceUtils.ts
@@ -79,7 +79,7 @@ export interface PlatformDeviceManager {
    * @param device - The booted device to kill
    * @returns Promise that resolves when the device has been stopped
    */
-  killDevice(device: BootedDevice): Promise<void>;
+  killDevice(device: BootedDevice): Promise<BootedDevice | void>;
 
   /**
    * Wait for a device to be ready for use after starting
@@ -336,7 +336,7 @@ export class MultiPlatformDeviceManager implements PlatformDeviceManager {
    */
   async killDevice(
     device: BootedDevice
-  ): Promise<void> {
+  ): Promise<BootedDevice | void> {
     switch (device.platform) {
       case "android":
         return this.emulator.killDevice(device);

--- a/src/utils/deviceUtils.ts
+++ b/src/utils/deviceUtils.ts
@@ -267,7 +267,7 @@ export class MultiPlatformDeviceManager implements PlatformDeviceManager {
       try {
         const emulators = await this.emulator.getBootedDevicesChecked(false, {
           bypassDeviceListCache: options.bypassAndroidDeviceListCache,
-        });
+        }, getAbortSignal());
         devices.push(...emulators);
         succeededPlatforms.add("android");
       } catch (error) {

--- a/src/utils/deviceUtils.ts
+++ b/src/utils/deviceUtils.ts
@@ -28,6 +28,12 @@ export interface BootedDeviceDiscoveryOptions {
   bypassAndroidDeviceListCache?: boolean;
 }
 
+/** Bounds and cancels a platform shutdown command. */
+export interface DeviceShutdownOptions {
+  timeoutMs?: number;
+  signal?: AbortSignal;
+}
+
 /**
  * Interface for device utility operations
  * Provides platform-agnostic device management for Android emulators and iOS simulators
@@ -79,7 +85,7 @@ export interface PlatformDeviceManager {
    * @param device - The booted device to kill
    * @returns Promise that resolves when the device has been stopped
    */
-  killDevice(device: BootedDevice): Promise<BootedDevice | void>;
+  killDevice(device: BootedDevice, options?: DeviceShutdownOptions): Promise<BootedDevice | void>;
 
   /**
    * Wait for a device to be ready for use after starting
@@ -335,13 +341,14 @@ export class MultiPlatformDeviceManager implements PlatformDeviceManager {
    * @returns Promise that resolves when device is stopped
    */
   async killDevice(
-    device: BootedDevice
+    device: BootedDevice,
+    options?: DeviceShutdownOptions,
   ): Promise<BootedDevice | void> {
     switch (device.platform) {
       case "android":
-        return this.emulator.killDevice(device);
+        return this.emulator.killDevice(device, options);
       case "ios":
-        return this.simctl.killSimulator(device);
+        return this.simctl.killSimulator(device, options);
     }
   }
 

--- a/src/utils/ios-cmdline-tools/SimCtlClient.ts
+++ b/src/utils/ios-cmdline-tools/SimCtlClient.ts
@@ -121,7 +121,7 @@ export interface SimCtl {
    * @param device - Device to kill
    * @returns Promise that resolves when kill is complete
    */
-  killSimulator(device: BootedDevice): Promise<void>;
+  killSimulator(device: BootedDevice, options?: { timeoutMs?: number; signal?: AbortSignal }): Promise<void>;
 
   /** Erase all data from a simulator. Reserved for CI-owned recovery flows. */
   eraseSimulator(udid: string): Promise<void>;
@@ -1093,9 +1093,16 @@ export class SimCtlClient implements SimCtl {
     }
   }
 
-  async killSimulator(device: BootedDevice): Promise<void> {
+  async killSimulator(
+    device: BootedDevice,
+    options: { timeoutMs?: number; signal?: AbortSignal } = {},
+  ): Promise<void> {
     logger.debug(`Killing iOS simulator ${device.deviceId}`);
-    await this.shutdownSimulatorCoordinated(device.deviceId, 10_000, getAbortSignal());
+    await this.shutdownSimulatorCoordinated(
+      device.deviceId,
+      options.timeoutMs ?? 10_000,
+      options.signal ?? getAbortSignal(),
+    );
   }
 
   async eraseSimulator(udid: string): Promise<void> {

--- a/test/daemon/devicePool.test.ts
+++ b/test/daemon/devicePool.test.ts
@@ -1642,6 +1642,9 @@ describe("DevicePool", () => {
 
       try {
         expect(devicePool.getAvailableDeviceCount()).toBe(0);
+        devicePool.markIntentionalShutdown(captured.id);
+        await devicePool.removeDisconnectedDevice(captured.id, false);
+        expect(devicePool.getDevice(captured.id)).toBe(captured);
         await expect(
           devicePool.bindOrReuseDeviceSession("session-1", device.deviceId, device.platform),
         ).rejects.toThrow(/shutting down/);

--- a/test/daemon/devicePool.test.ts
+++ b/test/daemon/devicePool.test.ts
@@ -1260,6 +1260,32 @@ describe("DevicePool", () => {
       expect(devicePool.getTotalDeviceCount()).toBe(0);
     });
 
+    test("defers refresh eviction while a shutdown reservation owns the incarnation", async () => {
+      const device = createBootedDevice("emulator-5554", "android", "Pixel 8");
+      await devicePool.initializeWithDevices([device]);
+      const captured = devicePool.getDevice(device.deviceId);
+      if (!captured) {
+        throw new Error("expected shutdown device to be pooled");
+      }
+      const reservation = await devicePool.reserveDeviceForShutdown(captured.id);
+      if (!reservation) {
+        throw new Error("expected shutdown reservation");
+      }
+      fakeDeviceManager.bootedDevices = [];
+
+      try {
+        await devicePool.refreshDevices();
+        await devicePool.refreshDevices();
+
+        expect(devicePool.getDevice(captured.id)).toBe(captured);
+      } finally {
+        await reservation.release();
+      }
+
+      await devicePool.refreshDevices();
+      expect(devicePool.getDevice(captured.id)).toBeNull();
+    });
+
     test("retains devices on first partial platform discovery miss", async () => {
       await devicePool.initializeWithDevices([createBootedDevice("sim-old", "ios", "iPhone 15")]);
       fakeDeviceManager.bootedDevices = [createBootedDevice("emulator-5554", "android", "Pixel 8")];

--- a/test/daemon/devicePool.test.ts
+++ b/test/daemon/devicePool.test.ts
@@ -1991,6 +1991,51 @@ describe("DevicePool", () => {
       expect(sessionManager.getSession("session-1")).toBeNull();
     });
 
+    test("defers a started emulator's process-exit cleanup while shutdown is reserved", async () => {
+      const images: DeviceInfo[] = [
+        {
+          name: "Pixel 8",
+          platform: "android",
+          isRunning: false,
+          deviceId: "emulator-5554",
+          source: "local",
+        },
+      ];
+      const manager = new FakeDeviceManagerWithStartedProcess(images);
+      const releaseCalls: Array<{ sessionId: string; deviceId: string; reason: string }> = [];
+      devicePool = new DevicePool(
+        sessionManager,
+        "test-daemon-session-id",
+        fakeTimer,
+        fakeAppsRepo,
+        manager,
+        new DefaultRetryExecutor(fakeTimer),
+        undefined,
+        undefined,
+        async (sessionId, deviceId, reason) => {
+          releaseCalls.push({ sessionId, deviceId, reason });
+          await sessionManager.releaseSession(sessionId, reason);
+        },
+      );
+
+      await devicePool.assignMultipleDevices(["session-1"], 1_000, "android");
+      const reservation = await devicePool.reserveDeviceForShutdown("emulator-5554");
+      if (!reservation) {
+        throw new Error("expected shutdown reservation");
+      }
+
+      try {
+        manager.childProcess.emit("exit", 0, null);
+        await new Promise((resolve) => setImmediate(resolve));
+
+        expect(releaseCalls).toEqual([]);
+        expect(devicePool.getDevice("emulator-5554")).toBe(reservation.device);
+        expect(sessionManager.getSessionForDevice("emulator-5554")).toBe("session-1");
+      } finally {
+        await reservation.release();
+      }
+    });
+
     test("keeps criteria auto-start available after a process exit when recovery is disabled", async () => {
       const originalRebootOnDeath = process.env.AUTOMOBILE_ANDROID_REBOOT_ON_DEATH;
       const originalRebootOnDeathAlias = process.env.AUTO_MOBILE_ANDROID_REBOOT_ON_DEATH;

--- a/test/daemon/devicePool.test.ts
+++ b/test/daemon/devicePool.test.ts
@@ -1635,7 +1635,10 @@ describe("DevicePool", () => {
       if (!captured) {
         throw new Error("expected shutdown device to be pooled");
       }
-      const releaseReservation = await devicePool.reserveDeviceForShutdown(captured);
+      const reservation = await devicePool.reserveDeviceForShutdown(captured.id);
+      if (!reservation) {
+        throw new Error("expected shutdown reservation");
+      }
 
       try {
         expect(devicePool.getAvailableDeviceCount()).toBe(0);
@@ -1648,7 +1651,7 @@ describe("DevicePool", () => {
           devicePool.autolockDevice(device.deviceId, device.platform, "mcp-session-1"),
         ).rejects.toThrow(/shutting down/);
       } finally {
-        await releaseReservation();
+        await reservation.release();
         if (originalAutolock === undefined) {
           delete process.env.AUTOMOBILE_DEVICE_POOL_AUTOLOCK;
         } else {

--- a/test/daemon/devicePool.test.ts
+++ b/test/daemon/devicePool.test.ts
@@ -1627,6 +1627,41 @@ describe("DevicePool", () => {
       expect(sessionManager.getSession("session-1")?.assignedDevice).toBe("sim-1");
     });
 
+    test("keeps a shutdown reservation exclusive to direct binding and autolock", async () => {
+      const originalAutolock = process.env.AUTOMOBILE_DEVICE_POOL_AUTOLOCK;
+      const device = createBootedDevice("emulator-5554", "android", "Pixel 8");
+      await initializeLiveDevices([device]);
+      const captured = devicePool.getDevice(device.deviceId);
+      if (!captured) {
+        throw new Error("expected shutdown device to be pooled");
+      }
+      const releaseReservation = await devicePool.reserveDeviceForShutdown(captured);
+
+      try {
+        expect(devicePool.getAvailableDeviceCount()).toBe(0);
+        await expect(
+          devicePool.bindOrReuseDeviceSession("session-1", device.deviceId, device.platform),
+        ).rejects.toThrow(/shutting down/);
+
+        process.env.AUTOMOBILE_DEVICE_POOL_AUTOLOCK = "1";
+        await expect(
+          devicePool.autolockDevice(device.deviceId, device.platform, "mcp-session-1"),
+        ).rejects.toThrow(/shutting down/);
+      } finally {
+        await releaseReservation();
+        if (originalAutolock === undefined) {
+          delete process.env.AUTOMOBILE_DEVICE_POOL_AUTOLOCK;
+        } else {
+          process.env.AUTOMOBILE_DEVICE_POOL_AUTOLOCK = originalAutolock;
+        }
+      }
+
+      expect(devicePool.getAvailableDeviceCount()).toBe(1);
+      await expect(
+        devicePool.bindOrReuseDeviceSession("session-1", device.deviceId, device.platform),
+      ).resolves.toBe("session-1");
+    });
+
     test("rejects a changed runtime identity inside the assignment mutex", async () => {
       await devicePool.initializeWithDevices([
         createBootedDevice("emulator-5554", "android", "Old Pixel"),

--- a/test/daemon/devicePool.test.ts
+++ b/test/daemon/devicePool.test.ts
@@ -137,6 +137,33 @@ describe("DevicePool", () => {
     }
   }
 
+  class DeferredSessionTrackingAppsRepository extends FakeInstalledAppsRepository {
+    private deferTracking = false;
+    private resolveDeferredTracking: (() => void) | undefined;
+
+    deferNextTrackingWrite(): void {
+      this.deferTracking = true;
+    }
+
+    finishDeferredTrackingWrite(): void {
+      this.resolveDeferredTracking?.();
+    }
+
+    override async setSessionTracking(
+      daemonSessionId: string,
+      deviceId: string,
+      deviceSessionStart: number,
+    ): Promise<void> {
+      if (this.deferTracking) {
+        this.deferTracking = false;
+        await new Promise<void>(resolve => {
+          this.resolveDeferredTracking = resolve;
+        });
+      }
+      await super.setSessionTracking(daemonSessionId, deviceId, deviceSessionStart);
+    }
+  }
+
   class ThrowingDiscoveryFakeDeviceManager extends FakeDeviceManager {
     override async getBootedDevicesDetailed(): Promise<never> {
       throw new Error("adb discovery crashed");
@@ -1284,6 +1311,56 @@ describe("DevicePool", () => {
 
       await devicePool.refreshDevices();
       expect(devicePool.getDevice(captured.id)).toBeNull();
+    });
+
+    test("does not hold the assignment mutex for replacement session tracking", async () => {
+      const device = createBootedDevice("emulator-5554", "android", "Pixel 8");
+      const appsRepository = new DeferredSessionTrackingAppsRepository();
+      const pool = new DevicePool(
+        sessionManager,
+        "daemon-session",
+        fakeTimer,
+        appsRepository,
+        fakeDeviceManager,
+        new DefaultRetryExecutor(fakeTimer),
+      );
+      await pool.initializeWithDevices([device]);
+      const captured = pool.getDevice(device.deviceId);
+      if (!captured) {
+        throw new Error("expected shutdown device to be pooled");
+      }
+      appsRepository.deferNextTrackingWrite();
+
+      const replacement = await pool.replaceDeviceForShutdown(captured, {
+        ...device,
+        name: "Pixel 8 replacement",
+      });
+
+      expect(replacement?.name).toBe("Pixel 8 replacement");
+      appsRepository.finishDeferredTrackingWrite();
+    });
+
+    test("allows a replacement incarnation to acquire its own shutdown reservation", async () => {
+      const device = createBootedDevice("emulator-5554", "android", "Pixel 8");
+      await devicePool.initializeWithDevices([device]);
+      const captured = devicePool.getDevice(device.deviceId);
+      if (!captured) {
+        throw new Error("expected shutdown device to be pooled");
+      }
+      const originalReservation = await devicePool.reserveDeviceForShutdown(captured.id);
+      if (!originalReservation) {
+        throw new Error("expected original shutdown reservation");
+      }
+
+      const replacement = await devicePool.replaceDeviceForShutdown(captured, {
+        ...device,
+        name: "Pixel 8 replacement",
+      });
+      const replacementReservation = await devicePool.reserveDeviceForShutdown(captured.id);
+
+      expect(replacementReservation?.device).toBe(replacement);
+      await replacementReservation?.release();
+      await originalReservation.release();
     });
 
     test("retains devices on first partial platform discovery miss", async () => {

--- a/test/server/deviceTools.killDevice.test.ts
+++ b/test/server/deviceTools.killDevice.test.ts
@@ -100,6 +100,41 @@ class FailedDiscoveryThenReplacementDeviceManager extends DelayedSuccessfulKillD
   }
 }
 
+class DeadlineExhaustingShutdownDeviceManager extends DelayedSuccessfulKillDeviceManager {
+  private exhaustDeadlineOnNextDiscovery = false;
+
+  constructor(private readonly timer: FakeTimer) {
+    super();
+  }
+
+  exhaustDeadlineOnNextShutdownDiscovery(): void {
+    this.exhaustDeadlineOnNextDiscovery = true;
+  }
+
+  override async getBootedDevicesDetailed(platform: SomePlatform): Promise<BootedDeviceDiscovery> {
+    if (this.exhaustDeadlineOnNextDiscovery) {
+      this.exhaustDeadlineOnNextDiscovery = false;
+      this.timer.setCurrentTime(30_000);
+      return {
+        devices: [],
+        succeededPlatforms: new Set(platform === "either" ? ["android", "ios"] : [platform]),
+      };
+    }
+    return await super.getBootedDevicesDetailed(platform);
+  }
+}
+
+class ReplacementDuringCacheClearRepository extends FakeInstalledAppsRepository {
+  constructor(private readonly onClearDeviceSession: () => Promise<void>) {
+    super();
+  }
+
+  override async clearDeviceSession(deviceId: string): Promise<void> {
+    await this.onClearDeviceSession();
+    await super.clearDeviceSession(deviceId);
+  }
+}
+
 class HungDiscoveryKillDeviceManager extends DelayedSuccessfulKillDeviceManager {
   override getBootedDevicesDetailed(): Promise<BootedDeviceDiscovery> {
     return new Promise<BootedDeviceDiscovery>(() => {});
@@ -827,6 +862,139 @@ describe("killDevice handler", () => {
     expect(current).not.toBe(original);
     expect(current?.name).toBe(replacement.name);
     expect(sessionManager.getSessionForDevice(image.deviceId!)).toBeNull();
+    expect(registry.getByUuid(originalSession.deviceSessionUuid)).toBeUndefined();
+    expect(registry.getByDeviceId(image.deviceId!)?.deviceSessionUuid).toBeDefined();
+  });
+
+  test("retires ownership after shutdown is observed at the disappearance deadline", async () => {
+    const timer = new FakeTimer();
+    const deadlineManager = new DeadlineExhaustingShutdownDeviceManager(timer);
+    manager = deadlineManager;
+    const deviceSessionRepository = new FakeDeviceSessionRepository();
+    const image: DeviceInfo = {
+      name: "Pixel 8",
+      platform: "android",
+      deviceId: "emulator-5554",
+      isRunning: false,
+      source: "local",
+    };
+    setDeviceToolsDependencies({
+      deviceManagerFactory: () => deadlineManager,
+      notifyResourcesChanged: async () => {},
+      ensureCtrlProxyReady: async () => {},
+      clearInstalledAppsForDevice: async () => {},
+      timer,
+    });
+    sessionManager = new SessionManager(timer, deviceSessionRepository);
+    deadlineManager.setDeviceImages("android", [image]);
+    const pool = new DevicePool(
+      sessionManager,
+      "daemon-session",
+      timer,
+      new FakeInstalledAppsRepository(),
+      deadlineManager,
+      new DefaultRetryExecutor(timer),
+      deviceSessionRepository,
+    );
+    const registry = new DeviceSessionRegistry(timer);
+    DaemonState.getInstance().initialize(sessionManager, pool, registry);
+    await pool.assignMultipleDevices(["session-1"], 1_000, "android");
+    const pooled = pool.getDevice(image.deviceId!);
+    if (!pooled) {
+      throw new Error("expected assigned device to be pooled");
+    }
+    const deviceSession = registry.onDeviceConnected({
+      deviceId: pooled.id,
+      platform: pooled.platform,
+      incarnation: pooled.incarnation,
+    });
+    const tool = ToolRegistry.getTool("killDevice");
+    if (!tool) {
+      throw new Error("killDevice not registered");
+    }
+
+    deadlineManager.exhaustDeadlineOnNextShutdownDiscovery();
+    await expect(tool.handler({
+      device: { name: image.name, platform: "android", deviceId: image.deviceId! },
+    })).resolves.toBeDefined();
+
+    expect(pool.getDevice(image.deviceId!)).toBeNull();
+    expect(sessionManager.getSessionForDevice(image.deviceId!)).toBeNull();
+    expect(registry.getByUuid(deviceSession.deviceSessionUuid)).toBeUndefined();
+  });
+
+  test("keeps a replacement epoch created during shutdown cache cleanup", async () => {
+    const timer = new FakeTimer();
+    const successfulManager = new SuccessfulKillDeviceManager();
+    manager = successfulManager;
+    const image: DeviceInfo = {
+      name: "Pixel 8",
+      platform: "android",
+      deviceId: "emulator-5554",
+      isRunning: false,
+      source: "local",
+    };
+    const replacement: BootedDevice = {
+      name: "Pixel 8 replacement",
+      platform: "android",
+      deviceId: image.deviceId!,
+    };
+    const deviceSessionRepository = new FakeDeviceSessionRepository();
+    setDeviceToolsDependencies({
+      deviceManagerFactory: () => successfulManager,
+      notifyResourcesChanged: async () => {},
+      ensureCtrlProxyReady: async () => {},
+      clearInstalledAppsForDevice: async () => {},
+      timer,
+    });
+    sessionManager = new SessionManager(timer, deviceSessionRepository);
+    successfulManager.setDeviceImages("android", [image]);
+    const registry = new DeviceSessionRegistry(timer);
+    const installedAppsRepository = new ReplacementDuringCacheClearRepository(async () => {
+      await pool.addDevice(replacement);
+      const current = pool.getDevice(image.deviceId!);
+      if (!current) {
+        throw new Error("expected replacement device to be pooled");
+      }
+      registry.onDeviceConnected({
+        deviceId: current.id,
+        platform: current.platform,
+        incarnation: current.incarnation,
+      });
+    });
+    const pool = new DevicePool(
+      sessionManager,
+      "daemon-session",
+      timer,
+      installedAppsRepository,
+      successfulManager,
+      new DefaultRetryExecutor(timer),
+      deviceSessionRepository,
+    );
+    DaemonState.getInstance().initialize(sessionManager, pool, registry);
+    await pool.assignMultipleDevices(["session-1"], 1_000, "android");
+    const original = pool.getDevice(image.deviceId!);
+    if (!original) {
+      throw new Error("expected original device to be pooled");
+    }
+    const originalSession = registry.onDeviceConnected({
+      deviceId: original.id,
+      platform: original.platform,
+      incarnation: original.incarnation,
+    });
+    const tool = ToolRegistry.getTool("killDevice");
+    if (!tool) {
+      throw new Error("killDevice not registered");
+    }
+
+    await tool.handler({
+      device: { name: image.name, platform: "android", deviceId: image.deviceId! },
+    });
+
+    const current = pool.getDevice(image.deviceId!);
+    expect(current).not.toBeNull();
+    expect(current).not.toBe(original);
+    expect(current?.name).toBe(replacement.name);
     expect(registry.getByUuid(originalSession.deviceSessionUuid)).toBeUndefined();
     expect(registry.getByDeviceId(image.deviceId!)?.deviceSessionUuid).toBeDefined();
   });

--- a/test/server/deviceTools.killDevice.test.ts
+++ b/test/server/deviceTools.killDevice.test.ts
@@ -73,6 +73,33 @@ class DelayedSuccessfulKillDeviceManager extends FailingKillDeviceManager {
   override async killDevice(): Promise<void> {}
 }
 
+class FailedDiscoveryThenReplacementDeviceManager extends DelayedSuccessfulKillDeviceManager {
+  private replacementSequenceStarted = false;
+  private failedDiscoveryReported = false;
+
+  constructor(private readonly replacement: BootedDevice) {
+    super();
+  }
+
+  beginReplacementSequence(): void {
+    this.replacementSequenceStarted = true;
+  }
+
+  override async getBootedDevicesDetailed(platform: SomePlatform): Promise<BootedDeviceDiscovery> {
+    if (!this.replacementSequenceStarted) {
+      return await super.getBootedDevicesDetailed(platform);
+    }
+    if (!this.failedDiscoveryReported) {
+      this.failedDiscoveryReported = true;
+      return { devices: [], succeededPlatforms: new Set() };
+    }
+    return {
+      devices: [this.replacement],
+      succeededPlatforms: new Set([this.replacement.platform]),
+    };
+  }
+}
+
 class HungDiscoveryKillDeviceManager extends DelayedSuccessfulKillDeviceManager {
   override getBootedDevicesDetailed(): Promise<BootedDeviceDiscovery> {
     return new Promise<BootedDeviceDiscovery>(() => {});
@@ -711,18 +738,94 @@ describe("killDevice handler", () => {
       throw new Error("killDevice not registered");
     }
 
-    await expect(tool.handler({
+    await expect(tool.handler(tool.schema.parse({
       device: {
         name: image.name,
         platform: "android",
         deviceId: image.deviceId!,
         transportId: "1",
       },
-    })).resolves.toBeDefined();
+    }))).resolves.toBeDefined();
 
     const current = pool.getDevice(image.deviceId!);
     expect(current).not.toBeNull();
     expect(current).not.toBe(original);
+    expect(sessionManager.getSessionForDevice(image.deviceId!)).toBeNull();
+    expect(registry.getByUuid(originalSession.deviceSessionUuid)).toBeUndefined();
+    expect(registry.getByDeviceId(image.deviceId!)?.deviceSessionUuid).toBeDefined();
+    expect(pool.getRecoveryEligibility(image.deviceId!)).toEqual({ eligible: true, action: "restart" });
+  });
+
+  test("rebuilds a replacement found after a failed post-release discovery", async () => {
+    const timer = new FakeTimer();
+    const image: DeviceInfo = {
+      name: "Pixel 8",
+      platform: "android",
+      deviceId: "emulator-5554",
+      isRunning: false,
+      source: "local",
+    };
+    const replacement: BootedDevice = {
+      name: "Pixel 8 replacement",
+      platform: "android",
+      deviceId: image.deviceId!,
+      transportId: "2",
+    };
+    const replacementManager = new FailedDiscoveryThenReplacementDeviceManager(replacement);
+    manager = replacementManager;
+    const deviceSessionRepository = new FakeDeviceSessionRepository();
+    setDeviceToolsDependencies({
+      deviceManagerFactory: () => replacementManager,
+      notifyResourcesChanged: async () => {},
+      ensureCtrlProxyReady: async () => {},
+      clearInstalledAppsForDevice: async () => {},
+      timer,
+    });
+    sessionManager = new SessionManager(timer, deviceSessionRepository);
+    replacementManager.setDeviceImages("android", [image]);
+    const pool = new DevicePool(
+      sessionManager,
+      "daemon-session",
+      timer,
+      new FakeInstalledAppsRepository(),
+      replacementManager,
+      new DefaultRetryExecutor(timer),
+      deviceSessionRepository,
+    );
+    const registry = new DeviceSessionRegistry(timer);
+    DaemonState.getInstance().initialize(sessionManager, pool, registry);
+    await pool.assignMultipleDevices(["session-1"], 1_000, "android");
+    const original = pool.getDevice(image.deviceId!);
+    if (!original) {
+      throw new Error("expected original device to be pooled");
+    }
+    const originalSession = registry.onDeviceConnected({
+      deviceId: original.id,
+      platform: original.platform,
+      incarnation: original.incarnation,
+    });
+    const tool = ToolRegistry.getTool("killDevice");
+    if (!tool) {
+      throw new Error("killDevice not registered");
+    }
+
+    replacementManager.beginReplacementSequence();
+    const result = tool.handler(tool.schema.parse({
+      device: {
+        name: image.name,
+        platform: "android",
+        deviceId: image.deviceId!,
+        transportId: "1",
+      },
+    }));
+    await new Promise(resolve => setImmediate(resolve));
+    timer.advanceTime(1_000);
+    await expect(result).resolves.toBeDefined();
+
+    const current = pool.getDevice(image.deviceId!);
+    expect(current).not.toBeNull();
+    expect(current).not.toBe(original);
+    expect(current?.name).toBe(replacement.name);
     expect(sessionManager.getSessionForDevice(image.deviceId!)).toBeNull();
     expect(registry.getByUuid(originalSession.deviceSessionUuid)).toBeUndefined();
     expect(registry.getByDeviceId(image.deviceId!)?.deviceSessionUuid).toBeDefined();

--- a/test/server/deviceTools.killDevice.test.ts
+++ b/test/server/deviceTools.killDevice.test.ts
@@ -1183,6 +1183,8 @@ describe("killDevice handler", () => {
   test("preserves caller cancellation while shutdown discovery is pending", async () => {
     const timer = new FakeTimer();
     const abortAwareManager = new AbortAwareHungDiscoveryKillDeviceManager();
+    let markedIntentionalShutdown = 0;
+    let clearedIntentionalShutdown = 0;
     manager = abortAwareManager;
     setDeviceToolsDependencies({
       deviceManagerFactory: () => abortAwareManager,
@@ -1191,6 +1193,15 @@ describe("killDevice handler", () => {
       clearInstalledAppsForDevice: async () => {},
       timer,
     });
+    DaemonState.getInstance().initialize({} as SessionManager, {
+      markIntentionalShutdown: () => {
+        markedIntentionalShutdown++;
+      },
+      clearIntentionalShutdown: () => {
+        clearedIntentionalShutdown++;
+      },
+      reserveDeviceForShutdown: async () => undefined,
+    } as never);
     const controller = new AbortController();
     const tool = ToolRegistry.getTool("killDevice");
     if (!tool) {
@@ -1198,13 +1209,15 @@ describe("killDevice handler", () => {
     }
 
     const result = tool.handler({
-      device: { name: "iPhone 16", platform: "ios", deviceId: "IOS-UDID" },
+      device: { name: "Pixel 8", platform: "android", deviceId: "emulator-5554" },
     }, undefined, controller.signal);
     await new Promise(resolve => setImmediate(resolve));
     controller.abort(new Error("caller cancelled shutdown"));
 
     await expect(result).rejects.toThrow("caller cancelled shutdown");
     expect(abortAwareManager.discoveryWasAborted).toBe(true);
+    expect(markedIntentionalShutdown).toBe(1);
+    expect(clearedIntentionalShutdown).toBe(0);
   });
 
   test("does not retire ownership when shutdown discovery fails", async () => {

--- a/test/server/deviceTools.killDevice.test.ts
+++ b/test/server/deviceTools.killDevice.test.ts
@@ -52,6 +52,23 @@ class SuccessfulKillDeviceManager extends FailingKillDeviceManager {
   }
 }
 
+class ReplacementBeforeShutdownWaitDeviceManager extends FailingKillDeviceManager {
+  constructor(private readonly replacement: BootedDevice) {
+    super();
+  }
+
+  override async killDevice(device: BootedDevice): Promise<void> {
+    this.setBootedDevices(device.platform, [this.replacement]);
+  }
+}
+
+class AllocationRaceDevicePool extends DevicePool {
+  override async releaseDevice(deviceId: string): Promise<void> {
+    await super.releaseDevice(deviceId);
+    await this.assignMultipleDevices(["racing-session"], 1_000, "android");
+  }
+}
+
 class DelayedSuccessfulKillDeviceManager extends FailingKillDeviceManager {
   override async killDevice(): Promise<void> {}
 }
@@ -632,6 +649,147 @@ describe("killDevice handler", () => {
     });
 
     await expect(result).resolves.toBeDefined();
+    const current = pool.getDevice(image.deviceId!);
+    expect(current).not.toBeNull();
+    expect(current).not.toBe(original);
+    expect(current?.name).toBe(replacement.name);
+    expect(sessionManager.getSessionForDevice(image.deviceId!)).toBeNull();
+    expect(registry.getByUuid(originalSession.deviceSessionUuid)).toBeUndefined();
+    expect(registry.getByDeviceId(image.deviceId!)?.deviceSessionUuid).toBeDefined();
+  });
+
+  test("recognizes a same-ID Android replacement before the first shutdown poll", async () => {
+    const timer = new FakeTimer();
+    const image: DeviceInfo = {
+      name: "Pixel 8",
+      platform: "android",
+      deviceId: "emulator-5554",
+      isRunning: false,
+      source: "local",
+    };
+    const replacement: BootedDevice = {
+      name: image.name,
+      platform: "android",
+      deviceId: image.deviceId!,
+      transportId: "2",
+    };
+    const replacementManager = new ReplacementBeforeShutdownWaitDeviceManager(replacement);
+    manager = replacementManager;
+    const deviceSessionRepository = new FakeDeviceSessionRepository();
+    setDeviceToolsDependencies({
+      deviceManagerFactory: () => replacementManager,
+      notifyResourcesChanged: async () => {},
+      ensureCtrlProxyReady: async () => {},
+      clearInstalledAppsForDevice: async () => {},
+      timer,
+    });
+    sessionManager = new SessionManager(timer, deviceSessionRepository);
+    replacementManager.setDeviceImages("android", [image]);
+    const pool = new DevicePool(
+      sessionManager,
+      "daemon-session",
+      timer,
+      new FakeInstalledAppsRepository(),
+      replacementManager,
+      new DefaultRetryExecutor(timer),
+      deviceSessionRepository,
+    );
+    const registry = new DeviceSessionRegistry(timer);
+    DaemonState.getInstance().initialize(sessionManager, pool, registry);
+    await pool.assignMultipleDevices(["session-1"], 1_000, "android");
+    const original = pool.getDevice(image.deviceId!);
+    if (!original) {
+      throw new Error("expected original device to be pooled");
+    }
+    const originalSession = registry.onDeviceConnected({
+      deviceId: original.id,
+      platform: original.platform,
+      incarnation: original.incarnation,
+    });
+    const tool = ToolRegistry.getTool("killDevice");
+    if (!tool) {
+      throw new Error("killDevice not registered");
+    }
+
+    await expect(tool.handler({
+      device: {
+        name: image.name,
+        platform: "android",
+        deviceId: image.deviceId!,
+        transportId: "1",
+      },
+    })).resolves.toBeDefined();
+
+    const current = pool.getDevice(image.deviceId!);
+    expect(current).not.toBeNull();
+    expect(current).not.toBe(original);
+    expect(sessionManager.getSessionForDevice(image.deviceId!)).toBeNull();
+    expect(registry.getByUuid(originalSession.deviceSessionUuid)).toBeUndefined();
+    expect(registry.getByDeviceId(image.deviceId!)?.deviceSessionUuid).toBeDefined();
+  });
+
+  test("does not publish a same-ID replacement's dead incarnation as idle", async () => {
+    const timer = new FakeTimer();
+    const successfulManager = new SuccessfulKillDeviceManager();
+    manager = successfulManager;
+    const image: DeviceInfo = {
+      name: "Pixel 8",
+      platform: "android",
+      deviceId: "emulator-5554",
+      isRunning: false,
+      source: "local",
+    };
+    const replacement: BootedDevice = {
+      name: "Pixel 8 replacement",
+      platform: "android",
+      deviceId: image.deviceId!,
+    };
+    const deviceSessionRepository = new ReplacingDeviceSessionRepository(async () => {
+      successfulManager.setBootedDevices("android", [replacement]);
+    });
+    setDeviceToolsDependencies({
+      deviceManagerFactory: () => successfulManager,
+      notifyResourcesChanged: async () => {},
+      ensureCtrlProxyReady: async () => {},
+      clearInstalledAppsForDevice: async () => {},
+      timer,
+    });
+    sessionManager = new SessionManager(timer, deviceSessionRepository);
+    successfulManager.setDeviceImages("android", [image]);
+    const pool = new AllocationRaceDevicePool(
+      sessionManager,
+      "daemon-session",
+      timer,
+      new FakeInstalledAppsRepository(),
+      successfulManager,
+      new DefaultRetryExecutor(timer),
+      deviceSessionRepository,
+    );
+    const registry = new DeviceSessionRegistry(timer);
+    DaemonState.getInstance().initialize(sessionManager, pool, registry);
+    await pool.assignMultipleDevices(["session-1"], 1_000, "android");
+    const original = pool.getDevice(image.deviceId!);
+    if (!original) {
+      throw new Error("expected original device to be pooled");
+    }
+    const originalSession = registry.onDeviceConnected({
+      deviceId: original.id,
+      platform: original.platform,
+      incarnation: original.incarnation,
+    });
+    const tool = ToolRegistry.getTool("killDevice");
+    if (!tool) {
+      throw new Error("killDevice not registered");
+    }
+
+    await tool.handler({
+      device: {
+        name: image.name,
+        platform: "android",
+        deviceId: image.deviceId!,
+      },
+    });
+
     const current = pool.getDevice(image.deviceId!);
     expect(current).not.toBeNull();
     expect(current).not.toBe(original);

--- a/test/server/deviceTools.killDevice.test.ts
+++ b/test/server/deviceTools.killDevice.test.ts
@@ -18,6 +18,7 @@ import {
 import type { BootedDevice, DeviceInfo } from "../../src/models";
 import { DefaultRetryExecutor } from "../../src/utils/retry/RetryExecutor";
 import { getAbortSignal } from "../../src/utils/AbortContext";
+import { IOSCtrlProxyManager } from "../../src/utils/IOSCtrlProxyManager";
 import { DeviceSessionRepository } from "../../src/db/DeviceSessionRepository";
 import { FakeTimer } from "../fakes/FakeTimer";
 import { FakeDeviceUtils } from "../fakes/FakeDeviceUtils";
@@ -1114,6 +1115,70 @@ describe("killDevice handler", () => {
 
     expect(pool.getDevice(image.deviceId!)).toBeNull();
     expect(registry.getByUuid(deviceSession.deviceSessionUuid)).toBeUndefined();
+  });
+
+  test("releases an iOS shutdown reservation after a late CtrlProxy teardown failure", async () => {
+    const timer = new FakeTimer();
+    const successfulManager = new SuccessfulKillDeviceManager();
+    manager = successfulManager;
+    const image: DeviceInfo = {
+      name: "iPhone 16",
+      platform: "ios",
+      deviceId: "ios-udid-1",
+      isRunning: false,
+      source: "local",
+    };
+    let rejectStop: (error: Error) => void;
+    const deferredStop = new Promise<void>((_, reject) => {
+      rejectStop = reject;
+    });
+    const originalGetInstance = IOSCtrlProxyManager.getInstance;
+    (IOSCtrlProxyManager as unknown as {
+      getInstance: typeof IOSCtrlProxyManager.getInstance;
+    }).getInstance = () => ({ stop: () => deferredStop }) as never;
+    try {
+      setDeviceToolsDependencies({
+        deviceManagerFactory: () => successfulManager,
+        notifyResourcesChanged: async () => {},
+        ensureCtrlProxyReady: async () => {},
+        clearInstalledAppsForDevice: async () => {},
+        timer,
+      });
+      sessionManager = new SessionManager(timer, new FakeDeviceSessionRepository());
+      successfulManager.setDeviceImages("ios", [image]);
+      const pool = new DevicePool(
+        sessionManager,
+        "daemon-session",
+        timer,
+        new FakeInstalledAppsRepository(),
+        successfulManager,
+        new DefaultRetryExecutor(timer),
+        new FakeDeviceSessionRepository(),
+      );
+      DaemonState.getInstance().initialize(sessionManager, pool);
+      await pool.assignMultipleDevices(["session-1"], 1_000, "ios");
+      await pool.releaseDevice(image.deviceId!, "session-1");
+      const tool = ToolRegistry.getTool("killDevice");
+      if (!tool) {
+        throw new Error("killDevice not registered");
+      }
+
+      const result = tool.handler({
+        device: { name: image.name, platform: "ios", deviceId: image.deviceId! },
+      });
+      await new Promise(resolve => setImmediate(resolve));
+      timer.advanceTime(30_000);
+      await expect(result).rejects.toThrow("iOS CtrlProxy shutdown did not complete");
+      expect(pool.getStats()).toMatchObject({ idle: 0, assigned: 1 });
+
+      rejectStop!(new Error("CtrlProxy stop failed"));
+      await deferredStop.catch(() => undefined);
+      expect(pool.getStats()).toMatchObject({ idle: 1, assigned: 0 });
+    } finally {
+      (IOSCtrlProxyManager as unknown as {
+        getInstance: typeof IOSCtrlProxyManager.getInstance;
+      }).getInstance = originalGetInstance;
+    }
   });
 
   test("bounds a hung shutdown discovery with the same actionable timeout", async () => {

--- a/test/server/deviceTools.killDevice.test.ts
+++ b/test/server/deviceTools.killDevice.test.ts
@@ -165,6 +165,7 @@ class DeadlineExhaustingShutdownDeviceManager extends DelayedSuccessfulKillDevic
     if (this.exhaustDeadlineOnNextDiscovery) {
       this.exhaustDeadlineOnNextDiscovery = false;
       this.timer.setCurrentTime(30_000);
+      this.setBootedDevices("android", []);
       return {
         devices: [],
         succeededPlatforms: new Set(platform === "either" ? ["android", "ios"] : [platform]),
@@ -1079,6 +1080,120 @@ describe("killDevice handler", () => {
     expect(pool.getDevice(image.deviceId!)).toBeNull();
     expect(sessionManager.getSessionForDevice(image.deviceId!)).toBeNull();
     expect(registry.getByUuid(deviceSession.deviceSessionUuid)).toBeUndefined();
+  });
+
+  test("rechecks for a replacement that boots while releasing ownership after the deadline", async () => {
+    const timer = new FakeTimer();
+    const deadlineManager = new DeadlineExhaustingShutdownDeviceManager(timer);
+    manager = deadlineManager;
+    const image: DeviceInfo = {
+      name: "Pixel 8",
+      platform: "android",
+      deviceId: "emulator-5554",
+      isRunning: false,
+      source: "local",
+    };
+    const replacement: BootedDevice = {
+      name: "Pixel 8 replacement",
+      platform: "android",
+      deviceId: image.deviceId!,
+      transportId: "2",
+    };
+    const deviceSessionRepository = new ReplacingDeviceSessionRepository(async () => {
+      deadlineManager.setBootedDevices("android", [replacement]);
+    });
+    setDeviceToolsDependencies({
+      deviceManagerFactory: () => deadlineManager,
+      notifyResourcesChanged: async () => {},
+      ensureCtrlProxyReady: async () => {},
+      clearInstalledAppsForDevice: async () => {},
+      timer,
+    });
+    sessionManager = new SessionManager(timer, deviceSessionRepository);
+    deadlineManager.setDeviceImages("android", [image]);
+    const pool = new DevicePool(
+      sessionManager,
+      "daemon-session",
+      timer,
+      new FakeInstalledAppsRepository(),
+      deadlineManager,
+      new DefaultRetryExecutor(timer),
+      deviceSessionRepository,
+    );
+    const registry = new DeviceSessionRegistry(timer);
+    DaemonState.getInstance().initialize(sessionManager, pool, registry);
+    await pool.assignMultipleDevices(["session-1"], 1_000, "android");
+    const original = pool.getDevice(image.deviceId!);
+    if (!original) {
+      throw new Error("expected assigned device to be pooled");
+    }
+    const originalSession = registry.onDeviceConnected({
+      deviceId: original.id,
+      platform: original.platform,
+      incarnation: original.incarnation,
+    });
+    const tool = ToolRegistry.getTool("killDevice");
+    if (!tool) {
+      throw new Error("killDevice not registered");
+    }
+
+    deadlineManager.exhaustDeadlineOnNextShutdownDiscovery();
+    await expect(tool.handler({
+      device: { name: image.name, platform: "android", deviceId: image.deviceId! },
+    })).resolves.toBeDefined();
+
+    const current = pool.getDevice(image.deviceId!);
+    expect(current).not.toBeNull();
+    expect(current).not.toBe(original);
+    expect(current?.name).toBe(replacement.name);
+    expect(registry.getByUuid(originalSession.deviceSessionUuid)).toBeUndefined();
+    expect(registry.getByDeviceId(image.deviceId!)?.deviceSessionUuid).toBeDefined();
+  });
+
+  test("stops performance monitoring after direct shutdown retirement", async () => {
+    const timer = new FakeTimer();
+    const successfulManager = new SuccessfulKillDeviceManager();
+    manager = successfulManager;
+    const stoppedDeviceIds: string[] = [];
+    const deviceSessionRepository = new FakeDeviceSessionRepository();
+    const image: DeviceInfo = {
+      name: "Pixel 8",
+      platform: "android",
+      deviceId: "emulator-5554",
+      isRunning: false,
+      source: "local",
+    };
+    setDeviceToolsDependencies({
+      deviceManagerFactory: () => successfulManager,
+      notifyResourcesChanged: async () => {},
+      ensureCtrlProxyReady: async () => {},
+      clearInstalledAppsForDevice: async () => {},
+      stopPerformanceMonitoring: deviceId => stoppedDeviceIds.push(deviceId),
+      timer,
+    });
+    sessionManager = new SessionManager(timer, deviceSessionRepository);
+    successfulManager.setDeviceImages("android", [image]);
+    const pool = new DevicePool(
+      sessionManager,
+      "daemon-session",
+      timer,
+      new FakeInstalledAppsRepository(),
+      successfulManager,
+      new DefaultRetryExecutor(timer),
+      deviceSessionRepository,
+    );
+    DaemonState.getInstance().initialize(sessionManager, pool);
+    await pool.assignMultipleDevices(["session-1"], 1_000, "android");
+    const tool = ToolRegistry.getTool("killDevice");
+    if (!tool) {
+      throw new Error("killDevice not registered");
+    }
+
+    await expect(tool.handler({
+      device: { name: image.name, platform: "android", deviceId: image.deviceId! },
+    })).resolves.toBeDefined();
+
+    expect(stoppedDeviceIds).toEqual([image.deviceId]);
   });
 
   test("keeps a replacement epoch created during shutdown cache cleanup", async () => {

--- a/test/server/deviceTools.killDevice.test.ts
+++ b/test/server/deviceTools.killDevice.test.ts
@@ -1086,6 +1086,7 @@ describe("killDevice handler", () => {
     const timer = new FakeTimer();
     const deadlineManager = new DeadlineExhaustingShutdownDeviceManager(timer);
     manager = deadlineManager;
+    const stoppedDeviceIds: string[] = [];
     const image: DeviceInfo = {
       name: "Pixel 8",
       platform: "android",
@@ -1107,6 +1108,7 @@ describe("killDevice handler", () => {
       notifyResourcesChanged: async () => {},
       ensureCtrlProxyReady: async () => {},
       clearInstalledAppsForDevice: async () => {},
+      stopPerformanceMonitoring: deviceId => stoppedDeviceIds.push(deviceId),
       timer,
     });
     sessionManager = new SessionManager(timer, deviceSessionRepository);
@@ -1148,6 +1150,7 @@ describe("killDevice handler", () => {
     expect(current?.name).toBe(replacement.name);
     expect(registry.getByUuid(originalSession.deviceSessionUuid)).toBeUndefined();
     expect(registry.getByDeviceId(image.deviceId!)?.deviceSessionUuid).toBeDefined();
+    expect(stoppedDeviceIds).toEqual([image.deviceId]);
   });
 
   test("stops performance monitoring after direct shutdown retirement", async () => {

--- a/test/server/deviceTools.killDevice.test.ts
+++ b/test/server/deviceTools.killDevice.test.ts
@@ -341,6 +341,61 @@ describe("killDevice handler", () => {
     await expect(result).rejects.toThrow("Timed out waiting for android device 'Pixel 8' (emulator-5554) to disappear");
   });
 
+  test("awaits iOS pool removal before retiring its device-session epoch", async () => {
+    const timer = new FakeTimer();
+    const successfulManager = new SuccessfulKillDeviceManager();
+    manager = successfulManager;
+    const deviceSessionRepository = new FakeDeviceSessionRepository();
+    setDeviceToolsDependencies({
+      deviceManagerFactory: () => successfulManager,
+      notifyResourcesChanged: async () => {},
+      ensureCtrlProxyReady: async () => {},
+      clearInstalledAppsForDevice: async () => {},
+      timer,
+    });
+    sessionManager = new SessionManager(timer, deviceSessionRepository);
+    const image: DeviceInfo = {
+      name: "iPhone 16",
+      platform: "ios",
+      deviceId: "ios-udid-1",
+      isRunning: false,
+      source: "local",
+    };
+    successfulManager.setDeviceImages("ios", [image]);
+    const pool = new DevicePool(
+      sessionManager,
+      "daemon-session",
+      timer,
+      new FakeInstalledAppsRepository(),
+      successfulManager,
+      new DefaultRetryExecutor(timer),
+      deviceSessionRepository,
+    );
+    const registry = new DeviceSessionRegistry(timer);
+    DaemonState.getInstance().initialize(sessionManager, pool, registry);
+    await pool.assignMultipleDevices(["session-1"], 1_000, "ios");
+    const pooled = pool.getDevice(image.deviceId!);
+    if (!pooled) {
+      throw new Error("expected assigned iOS device to be pooled");
+    }
+    const deviceSession = registry.onDeviceConnected({
+      deviceId: pooled.id,
+      platform: pooled.platform,
+      incarnation: pooled.incarnation,
+    });
+    const tool = ToolRegistry.getTool("killDevice");
+    if (!tool) {
+      throw new Error("killDevice not registered");
+    }
+
+    await tool.handler({
+      device: { name: image.name, platform: "ios", deviceId: image.deviceId! },
+    });
+
+    expect(pool.getDevice(image.deviceId!)).toBeNull();
+    expect(registry.getByUuid(deviceSession.deviceSessionUuid)).toBeUndefined();
+  });
+
   test("bounds a hung shutdown discovery with the same actionable timeout", async () => {
     const timer = new FakeTimer();
     const hungManager = new HungDiscoveryKillDeviceManager();
@@ -514,7 +569,7 @@ describe("killDevice handler", () => {
     expect(registry.getByDeviceId(image.deviceId!)?.deviceSessionUuid).toBeDefined();
   });
 
-  test("does not retire a same-ID device that reappears while releasing the old session", async () => {
+  test("rebuilds a same-ID device that reappears while releasing the old session", async () => {
     const timer = new FakeTimer();
     const successfulManager = new SuccessfulKillDeviceManager();
     manager = successfulManager;
@@ -575,12 +630,15 @@ describe("killDevice handler", () => {
         deviceId: image.deviceId!,
       },
     });
-    await new Promise(resolve => setImmediate(resolve));
-    timer.advanceTime(30_000);
 
-    await expect(result).rejects.toThrow("the device is still reported as booted");
-    expect(pool.getDevice(image.deviceId!)).toBe(original);
-    expect(registry.getByUuid(originalSession.deviceSessionUuid)).toBeDefined();
+    await expect(result).resolves.toBeDefined();
+    const current = pool.getDevice(image.deviceId!);
+    expect(current).not.toBeNull();
+    expect(current).not.toBe(original);
+    expect(current?.name).toBe(replacement.name);
+    expect(sessionManager.getSessionForDevice(image.deviceId!)).toBeNull();
+    expect(registry.getByUuid(originalSession.deviceSessionUuid)).toBeUndefined();
+    expect(registry.getByDeviceId(image.deviceId!)?.deviceSessionUuid).toBeDefined();
   });
 
   test.each([

--- a/test/server/deviceTools.killDevice.test.ts
+++ b/test/server/deviceTools.killDevice.test.ts
@@ -834,6 +834,71 @@ describe("killDevice handler", () => {
     expect(pool.getDevice(image.deviceId!)).toBeNull();
   });
 
+  test("releases a shutdown reservation when recording teardown exhausts the deadline", async () => {
+    const timer = new FakeTimer();
+    const successfulManager = new SuccessfulKillDeviceManager();
+    manager = successfulManager;
+    const image: DeviceInfo = {
+      name: "Pixel 8",
+      platform: "android",
+      deviceId: "emulator-5554",
+      isRunning: false,
+      source: "local",
+    };
+    const deviceSessionRepository = new FakeDeviceSessionRepository();
+    let recordingListCalls = 0;
+    sessionManager = new SessionManager(timer, deviceSessionRepository);
+    successfulManager.setDeviceImages("android", [image]);
+    const pool = new DevicePool(
+      sessionManager,
+      "daemon-session",
+      timer,
+      new FakeInstalledAppsRepository(),
+      successfulManager,
+      new DefaultRetryExecutor(timer),
+      deviceSessionRepository,
+    );
+    DaemonState.getInstance().initialize(sessionManager, pool);
+    await pool.assignMultipleDevices(["session-1"], 1_000, "android");
+    await setVideoRecordingManagerDependencies({
+      videoRecorderService: {
+        stopRecording: async () => await new Promise<void>(() => {}),
+      } as never,
+      recordingRepository: {
+        listRecordings: async () => {
+          recordingListCalls++;
+          return recordingListCalls === 1 ? [] : [{ recordingId: "recording-1" }];
+        },
+      } as never,
+      configRepository: {} as never,
+      highlightClient: {} as never,
+      timer,
+      now: () => new Date(0),
+    });
+    setDeviceToolsDependencies({
+      deviceManagerFactory: () => successfulManager,
+      notifyResourcesChanged: async () => {},
+      ensureCtrlProxyReady: async () => {},
+      clearInstalledAppsForDevice: async () => {},
+      timer,
+    });
+    const tool = ToolRegistry.getTool("killDevice");
+    if (!tool) {
+      throw new Error("killDevice not registered");
+    }
+
+    const result = tool.handler({
+      device: { name: image.name, platform: image.platform, deviceId: image.deviceId! },
+    });
+    await new Promise(resolve => setImmediate(resolve));
+    timer.advanceTime(30_000);
+
+    await expect(result).rejects.toThrow("video recording teardown did not complete");
+    expect(pool.getDevice(image.deviceId!)?.sessionId).toBe("session-1");
+    await pool.releaseDevice(image.deviceId!);
+    expect(pool.getAvailableDeviceCount()).toBe(1);
+  });
+
   test("returns an actionable timeout instead of reporting success while the device remains visible", async () => {
     const timer = new FakeTimer();
     const delayedManager = new DelayedSuccessfulKillDeviceManager();

--- a/test/server/deviceTools.killDevice.test.ts
+++ b/test/server/deviceTools.killDevice.test.ts
@@ -3,6 +3,7 @@ import { EventEmitter } from "node:events";
 import type { ChildProcess } from "node:child_process";
 import { DaemonState } from "../../src/daemon/daemonState";
 import { DevicePool } from "../../src/daemon/devicePool";
+import { DeviceSessionRegistry } from "../../src/daemon/deviceSessionRegistry";
 import { SessionManager } from "../../src/daemon/sessionManager";
 import {
   registerDeviceTools,
@@ -45,6 +46,12 @@ class FailingKillDeviceManager extends FakeDeviceUtils {
 }
 
 class SuccessfulKillDeviceManager extends FailingKillDeviceManager {
+  override async killDevice(device: BootedDevice): Promise<void> {
+    this.setBootedDevices(device.platform, []);
+  }
+}
+
+class DelayedSuccessfulKillDeviceManager extends FailingKillDeviceManager {
   override async killDevice(): Promise<void> {}
 }
 
@@ -62,6 +69,16 @@ class FakeDeviceSessionRepository extends DeviceSessionRepository {
   override async upsertActiveSession(): Promise<void> {}
   override async markReleased(): Promise<void> {}
   override async recordActivity(): Promise<void> {}
+}
+
+class ReplacingDeviceSessionRepository extends FakeDeviceSessionRepository {
+  constructor(private readonly onMarkReleased: () => Promise<void>) {
+    super();
+  }
+
+  override async markReleased(): Promise<void> {
+    await this.onMarkReleased();
+  }
 }
 
 describe("killDevice handler", () => {
@@ -205,6 +222,197 @@ describe("killDevice handler", () => {
 
     expect(successfulManager.getCallCount("startDevice")).toBe(1);
     expect(pool.getDevice("emulator-5554")).toBeNull();
+  });
+
+  test("waits for physical exit before retiring the matching session, pool entry, and device session", async () => {
+    const timer = new FakeTimer();
+    const deviceSessionRepository = new FakeDeviceSessionRepository();
+    const delayedManager = new DelayedSuccessfulKillDeviceManager();
+    manager = delayedManager;
+    setDeviceToolsDependencies({
+      deviceManagerFactory: () => delayedManager,
+      notifyResourcesChanged: async () => {},
+      ensureCtrlProxyReady: async () => {},
+      clearInstalledAppsForDevice: async () => {},
+      timer,
+    });
+    sessionManager = new SessionManager(timer, deviceSessionRepository);
+    const image: DeviceInfo = {
+      name: "Pixel 8",
+      platform: "android",
+      deviceId: "emulator-5554",
+      isRunning: false,
+      source: "local",
+    };
+    delayedManager.setDeviceImages("android", [image]);
+    const pool = new DevicePool(
+      sessionManager,
+      "daemon-session",
+      timer,
+      new FakeInstalledAppsRepository(),
+      delayedManager,
+      new DefaultRetryExecutor(timer),
+      deviceSessionRepository,
+    );
+    const registry = new DeviceSessionRegistry(timer);
+    DaemonState.getInstance().initialize(sessionManager, pool, registry);
+    await pool.assignMultipleDevices(["session-1"], 1_000, "android");
+    const pooled = pool.getDevice("emulator-5554");
+    if (!pooled) {
+      throw new Error("expected assigned device to be pooled");
+    }
+    const deviceSession = registry.onDeviceConnected({
+      deviceId: pooled.id,
+      platform: pooled.platform,
+      incarnation: pooled.incarnation,
+    });
+
+    // `adb emu kill` resolving only means the command was accepted. Keep the
+    // fake visible until after the handler starts waiting for its disappearance.
+    delayedManager.setBootedDevices("android", [{
+      name: image.name,
+      platform: "android",
+      deviceId: image.deviceId!,
+    }]);
+    const tool = ToolRegistry.getTool("killDevice");
+    if (!tool) {
+      throw new Error("killDevice not registered");
+    }
+    const result = tool.handler({
+      device: {
+        name: image.name,
+        platform: "android",
+        deviceId: image.deviceId!,
+      },
+    });
+
+    let settled = false;
+    void result.then(() => {
+      settled = true;
+    });
+    await new Promise(resolve => setImmediate(resolve));
+    expect(settled).toBe(false);
+    expect(pool.getDevice(image.deviceId!)).toBe(pooled);
+    expect(sessionManager.getSessionForDevice(image.deviceId!)).toBe("session-1");
+    expect(registry.getByUuid(deviceSession.deviceSessionUuid)).toBeDefined();
+
+    delayedManager.setBootedDevices("android", []);
+    timer.advanceTime(1_000);
+    const response = await result;
+    expect(response.isError).toBeUndefined();
+    expect(pool.getDevice(image.deviceId!)).toBeNull();
+    expect(sessionManager.getSessionForDevice(image.deviceId!)).toBeNull();
+    expect(registry.getByUuid(deviceSession.deviceSessionUuid)).toBeUndefined();
+  });
+
+  test("returns an actionable timeout instead of reporting success while the device remains visible", async () => {
+    const timer = new FakeTimer();
+    const delayedManager = new DelayedSuccessfulKillDeviceManager();
+    manager = delayedManager;
+    setDeviceToolsDependencies({
+      deviceManagerFactory: () => delayedManager,
+      notifyResourcesChanged: async () => {},
+      ensureCtrlProxyReady: async () => {},
+      clearInstalledAppsForDevice: async () => {},
+      timer,
+    });
+    const device: BootedDevice = {
+      name: "Pixel 8",
+      platform: "android",
+      deviceId: "emulator-5554",
+    };
+    delayedManager.setBootedDevices("android", [device]);
+    const tool = ToolRegistry.getTool("killDevice");
+    if (!tool) {
+      throw new Error("killDevice not registered");
+    }
+
+    const result = tool.handler({ device });
+    await new Promise(resolve => setImmediate(resolve));
+    timer.advanceTime(30_000);
+
+    await expect(result).rejects.toThrow("Timed out waiting for android device 'Pixel 8' (emulator-5554) to disappear");
+  });
+
+  test("does not remove a replacement pool incarnation during shutdown ownership retirement", async () => {
+    const timer = new FakeTimer();
+    const successfulManager = new SuccessfulKillDeviceManager();
+    manager = successfulManager;
+    const image: DeviceInfo = {
+      name: "Pixel 8",
+      platform: "android",
+      deviceId: "emulator-5554",
+      isRunning: false,
+      source: "local",
+    };
+    const replacement: BootedDevice = {
+      name: "Pixel 8 replacement",
+      platform: "android",
+      deviceId: image.deviceId!,
+    };
+    const deviceSessionRepository = new ReplacingDeviceSessionRepository(async () => {
+      await pool.releaseDevice(image.deviceId!);
+      await pool.removeDevice(image.deviceId!);
+      await pool.initializeWithDevices([replacement]);
+      const replacementPooled = pool.getDevice(image.deviceId!);
+      if (!replacementPooled) {
+        throw new Error("expected replacement device to enter the pool");
+      }
+      registry.onDeviceConnected({
+        deviceId: replacementPooled.id,
+        platform: replacementPooled.platform,
+        incarnation: replacementPooled.incarnation,
+      });
+    });
+    setDeviceToolsDependencies({
+      deviceManagerFactory: () => successfulManager,
+      notifyResourcesChanged: async () => {},
+      ensureCtrlProxyReady: async () => {},
+      clearInstalledAppsForDevice: async () => {},
+      timer,
+    });
+    sessionManager = new SessionManager(timer, deviceSessionRepository);
+    successfulManager.setDeviceImages("android", [image]);
+    const pool = new DevicePool(
+      sessionManager,
+      "daemon-session",
+      timer,
+      new FakeInstalledAppsRepository(),
+      successfulManager,
+      new DefaultRetryExecutor(timer),
+      deviceSessionRepository,
+    );
+    const registry = new DeviceSessionRegistry(timer);
+    DaemonState.getInstance().initialize(sessionManager, pool, registry);
+    await pool.assignMultipleDevices(["session-1"], 1_000, "android");
+    const original = pool.getDevice(image.deviceId!);
+    if (!original) {
+      throw new Error("expected original device to be pooled");
+    }
+    const originalSession = registry.onDeviceConnected({
+      deviceId: original.id,
+      platform: original.platform,
+      incarnation: original.incarnation,
+    });
+    const tool = ToolRegistry.getTool("killDevice");
+    if (!tool) {
+      throw new Error("killDevice not registered");
+    }
+
+    await tool.handler({
+      device: {
+        name: image.name,
+        platform: "android",
+        deviceId: image.deviceId!,
+      },
+    });
+
+    const current = pool.getDevice(image.deviceId!);
+    expect(current).not.toBeNull();
+    expect(current).not.toBe(original);
+    expect(current?.name).toBe(replacement.name);
+    expect(registry.getByUuid(originalSession.deviceSessionUuid)).toBeUndefined();
+    expect(registry.getByDeviceId(image.deviceId!)?.deviceSessionUuid).toBeDefined();
   });
 
   test.each([

--- a/test/server/deviceTools.killDevice.test.ts
+++ b/test/server/deviceTools.killDevice.test.ts
@@ -21,6 +21,7 @@ import { DeviceSessionRepository } from "../../src/db/DeviceSessionRepository";
 import { FakeTimer } from "../fakes/FakeTimer";
 import { FakeDeviceUtils } from "../fakes/FakeDeviceUtils";
 import { FakeInstalledAppsRepository } from "../fakes/FakeInstalledAppsRepository";
+import type { BootedDeviceDiscovery } from "../../src/utils/deviceUtils";
 
 class FailingKillDeviceManager extends FakeDeviceUtils {
   readonly childProcess = new EventEmitter() as ChildProcess;
@@ -53,6 +54,12 @@ class SuccessfulKillDeviceManager extends FailingKillDeviceManager {
 
 class DelayedSuccessfulKillDeviceManager extends FailingKillDeviceManager {
   override async killDevice(): Promise<void> {}
+}
+
+class HungDiscoveryKillDeviceManager extends DelayedSuccessfulKillDeviceManager {
+  override getBootedDevicesDetailed(): Promise<BootedDeviceDiscovery> {
+    return new Promise<BootedDeviceDiscovery>(() => {});
+  }
 }
 
 class AlreadyStoppedKillDeviceManager extends FailingKillDeviceManager {
@@ -334,6 +341,98 @@ describe("killDevice handler", () => {
     await expect(result).rejects.toThrow("Timed out waiting for android device 'Pixel 8' (emulator-5554) to disappear");
   });
 
+  test("bounds a hung shutdown discovery with the same actionable timeout", async () => {
+    const timer = new FakeTimer();
+    const hungManager = new HungDiscoveryKillDeviceManager();
+    manager = hungManager;
+    setDeviceToolsDependencies({
+      deviceManagerFactory: () => hungManager,
+      notifyResourcesChanged: async () => {},
+      ensureCtrlProxyReady: async () => {},
+      clearInstalledAppsForDevice: async () => {},
+      timer,
+    });
+    const device: BootedDevice = {
+      name: "Pixel 8",
+      platform: "android",
+      deviceId: "emulator-5554",
+    };
+    const tool = ToolRegistry.getTool("killDevice");
+    if (!tool) {
+      throw new Error("killDevice not registered");
+    }
+
+    const result = tool.handler({ device });
+    await new Promise(resolve => setImmediate(resolve));
+    timer.advanceTime(30_000);
+
+    await expect(result).rejects.toThrow("platform discovery did not complete");
+  });
+
+  test("does not retire ownership when shutdown discovery fails", async () => {
+    const timer = new FakeTimer();
+    const deviceSessionRepository = new FakeDeviceSessionRepository();
+    const delayedManager = new DelayedSuccessfulKillDeviceManager();
+    manager = delayedManager;
+    setDeviceToolsDependencies({
+      deviceManagerFactory: () => delayedManager,
+      notifyResourcesChanged: async () => {},
+      ensureCtrlProxyReady: async () => {},
+      clearInstalledAppsForDevice: async () => {},
+      timer,
+    });
+    sessionManager = new SessionManager(timer, deviceSessionRepository);
+    const image: DeviceInfo = {
+      name: "Pixel 8",
+      platform: "android",
+      deviceId: "emulator-5554",
+      isRunning: false,
+      source: "local",
+    };
+    delayedManager.setDeviceImages("android", [image]);
+    const pool = new DevicePool(
+      sessionManager,
+      "daemon-session",
+      timer,
+      new FakeInstalledAppsRepository(),
+      delayedManager,
+      new DefaultRetryExecutor(timer),
+      deviceSessionRepository,
+    );
+    const registry = new DeviceSessionRegistry(timer);
+    DaemonState.getInstance().initialize(sessionManager, pool, registry);
+    await pool.assignMultipleDevices(["session-1"], 1_000, "android");
+    const pooled = pool.getDevice(image.deviceId!);
+    if (!pooled) {
+      throw new Error("expected assigned device to be pooled");
+    }
+    const deviceSession = registry.onDeviceConnected({
+      deviceId: pooled.id,
+      platform: pooled.platform,
+      incarnation: pooled.incarnation,
+    });
+    delayedManager.failedPlatforms.add("android");
+    const tool = ToolRegistry.getTool("killDevice");
+    if (!tool) {
+      throw new Error("killDevice not registered");
+    }
+
+    const result = tool.handler({
+      device: {
+        name: image.name,
+        platform: "android",
+        deviceId: image.deviceId!,
+      },
+    });
+    await new Promise(resolve => setImmediate(resolve));
+    timer.advanceTime(30_000);
+
+    await expect(result).rejects.toThrow("platform discovery did not succeed");
+    expect(pool.getDevice(image.deviceId!)).toBe(pooled);
+    expect(sessionManager.getSessionForDevice(image.deviceId!)).toBe("session-1");
+    expect(registry.getByUuid(deviceSession.deviceSessionUuid)).toBeDefined();
+  });
+
   test("does not remove a replacement pool incarnation during shutdown ownership retirement", async () => {
     const timer = new FakeTimer();
     const successfulManager = new SuccessfulKillDeviceManager();
@@ -413,6 +512,75 @@ describe("killDevice handler", () => {
     expect(current?.name).toBe(replacement.name);
     expect(registry.getByUuid(originalSession.deviceSessionUuid)).toBeUndefined();
     expect(registry.getByDeviceId(image.deviceId!)?.deviceSessionUuid).toBeDefined();
+  });
+
+  test("does not retire a same-ID device that reappears while releasing the old session", async () => {
+    const timer = new FakeTimer();
+    const successfulManager = new SuccessfulKillDeviceManager();
+    manager = successfulManager;
+    const image: DeviceInfo = {
+      name: "Pixel 8",
+      platform: "android",
+      deviceId: "emulator-5554",
+      isRunning: false,
+      source: "local",
+    };
+    const replacement: BootedDevice = {
+      name: "Pixel 8 replacement",
+      platform: "android",
+      deviceId: image.deviceId!,
+    };
+    const deviceSessionRepository = new ReplacingDeviceSessionRepository(async () => {
+      successfulManager.setBootedDevices("android", [replacement]);
+    });
+    setDeviceToolsDependencies({
+      deviceManagerFactory: () => successfulManager,
+      notifyResourcesChanged: async () => {},
+      ensureCtrlProxyReady: async () => {},
+      clearInstalledAppsForDevice: async () => {},
+      timer,
+    });
+    sessionManager = new SessionManager(timer, deviceSessionRepository);
+    successfulManager.setDeviceImages("android", [image]);
+    const pool = new DevicePool(
+      sessionManager,
+      "daemon-session",
+      timer,
+      new FakeInstalledAppsRepository(),
+      successfulManager,
+      new DefaultRetryExecutor(timer),
+      deviceSessionRepository,
+    );
+    const registry = new DeviceSessionRegistry(timer);
+    DaemonState.getInstance().initialize(sessionManager, pool, registry);
+    await pool.assignMultipleDevices(["session-1"], 1_000, "android");
+    const original = pool.getDevice(image.deviceId!);
+    if (!original) {
+      throw new Error("expected original device to be pooled");
+    }
+    const originalSession = registry.onDeviceConnected({
+      deviceId: original.id,
+      platform: original.platform,
+      incarnation: original.incarnation,
+    });
+    const tool = ToolRegistry.getTool("killDevice");
+    if (!tool) {
+      throw new Error("killDevice not registered");
+    }
+
+    const result = tool.handler({
+      device: {
+        name: image.name,
+        platform: "android",
+        deviceId: image.deviceId!,
+      },
+    });
+    await new Promise(resolve => setImmediate(resolve));
+    timer.advanceTime(30_000);
+
+    await expect(result).rejects.toThrow("the device is still reported as booted");
+    expect(pool.getDevice(image.deviceId!)).toBe(original);
+    expect(registry.getByUuid(originalSession.deviceSessionUuid)).toBeDefined();
   });
 
   test.each([

--- a/test/server/deviceTools.killDevice.test.ts
+++ b/test/server/deviceTools.killDevice.test.ts
@@ -17,6 +17,7 @@ import {
 } from "../../src/server/videoRecordingManager";
 import type { BootedDevice, DeviceInfo } from "../../src/models";
 import { DefaultRetryExecutor } from "../../src/utils/retry/RetryExecutor";
+import { getAbortSignal } from "../../src/utils/AbortContext";
 import { DeviceSessionRepository } from "../../src/db/DeviceSessionRepository";
 import { FakeTimer } from "../fakes/FakeTimer";
 import { FakeDeviceUtils } from "../fakes/FakeDeviceUtils";
@@ -214,6 +215,42 @@ class ReplacementDuringCacheClearRepository extends FakeInstalledAppsRepository 
 class HungDiscoveryKillDeviceManager extends DelayedSuccessfulKillDeviceManager {
   override getBootedDevicesDetailed(): Promise<BootedDeviceDiscovery> {
     return new Promise<BootedDeviceDiscovery>(() => {});
+  }
+}
+
+class AbortAwareHungDiscoveryKillDeviceManager extends DelayedSuccessfulKillDeviceManager {
+  discoveryWasAborted = false;
+
+  override getBootedDevicesDetailed(): Promise<BootedDeviceDiscovery> {
+    const signal = getAbortSignal();
+    signal?.addEventListener("abort", () => {
+      this.discoveryWasAborted = true;
+    }, { once: true });
+    return new Promise<BootedDeviceDiscovery>(() => {});
+  }
+}
+
+class FirstReplacementThenEmptyDeviceManager extends DelayedSuccessfulKillDeviceManager {
+  private shutdownDiscoveryCalls = 0;
+  private shutdownStarted = false;
+
+  constructor(private readonly replacement: BootedDevice) {
+    super();
+  }
+
+  override async killDevice(): Promise<void> {
+    this.shutdownStarted = true;
+  }
+
+  override async getBootedDevicesDetailed(platform: SomePlatform): Promise<BootedDeviceDiscovery> {
+    if (!this.shutdownStarted) {
+      return await super.getBootedDevicesDetailed(platform);
+    }
+    this.shutdownDiscoveryCalls++;
+    return {
+      devices: this.shutdownDiscoveryCalls === 1 ? [this.replacement] : [],
+      succeededPlatforms: new Set([this.replacement.platform]),
+    };
   }
 }
 
@@ -711,6 +748,75 @@ describe("killDevice handler", () => {
     expect(pool.getDevice(image.deviceId!)).toBeNull();
   });
 
+  test("reserves a shutdown target before recording teardown yields", async () => {
+    const timer = new FakeTimer();
+    const successfulManager = new SuccessfulKillDeviceManager();
+    manager = successfulManager;
+    const image: DeviceInfo = {
+      name: "Pixel 8",
+      platform: "android",
+      deviceId: "emulator-5554",
+      isRunning: false,
+      source: "local",
+    };
+    let allocationOutcome: "assigned" | "blocked" | undefined;
+    let recordingListCalls = 0;
+    const deviceSessionRepository = new FakeDeviceSessionRepository();
+    sessionManager = new SessionManager(timer, deviceSessionRepository);
+    successfulManager.setDeviceImages("android", [image]);
+    const pool = new DevicePool(
+      sessionManager,
+      "daemon-session",
+      timer,
+      new FakeInstalledAppsRepository(),
+      successfulManager,
+      new DefaultRetryExecutor(timer),
+      deviceSessionRepository,
+    );
+    DaemonState.getInstance().initialize(sessionManager, pool);
+    await pool.assignMultipleDevices(["session-1"], 1_000, "android");
+    await pool.releaseDevice(image.deviceId!);
+    await setVideoRecordingManagerDependencies({
+      videoRecorderService: {
+        stopRecording: async () => {
+          allocationOutcome = await pool
+            .assignMultipleDevices(["racing-session"], 1, "android")
+            .then(() => "assigned" as const, () => "blocked" as const);
+          throw new Error("recording already stopped");
+        },
+      } as never,
+      recordingRepository: {
+        listRecordings: async () => {
+          recordingListCalls++;
+          return recordingListCalls === 1 ? [] : [{ recordingId: "recording-1" }];
+        },
+      } as never,
+      configRepository: {} as never,
+      highlightClient: {} as never,
+      timer,
+      now: () => new Date(0),
+    });
+    setDeviceToolsDependencies({
+      deviceManagerFactory: () => successfulManager,
+      notifyResourcesChanged: async () => {},
+      ensureCtrlProxyReady: async () => {},
+      clearInstalledAppsForDevice: async () => {},
+      timer,
+    });
+    const tool = ToolRegistry.getTool("killDevice");
+    if (!tool) {
+      throw new Error("killDevice not registered");
+    }
+
+    await tool.handler({
+      device: { name: image.name, platform: "android", deviceId: image.deviceId! },
+    });
+
+    expect(allocationOutcome).toBe("blocked");
+    expect(sessionManager.getSession("racing-session")).toBeNull();
+    expect(pool.getDevice(image.deviceId!)).toBeNull();
+  });
+
   test("returns an actionable timeout instead of reporting success while the device remains visible", async () => {
     const timer = new FakeTimer();
     const delayedManager = new DelayedSuccessfulKillDeviceManager();
@@ -931,6 +1037,35 @@ describe("killDevice handler", () => {
     timer.advanceTime(30_000);
 
     await expect(result).rejects.toThrow("platform discovery did not complete");
+  });
+
+  test("aborts a hung shutdown discovery when the deadline expires", async () => {
+    const timer = new FakeTimer();
+    const abortAwareManager = new AbortAwareHungDiscoveryKillDeviceManager();
+    manager = abortAwareManager;
+    setDeviceToolsDependencies({
+      deviceManagerFactory: () => abortAwareManager,
+      notifyResourcesChanged: async () => {},
+      ensureCtrlProxyReady: async () => {},
+      clearInstalledAppsForDevice: async () => {},
+      timer,
+    });
+    const device: BootedDevice = {
+      name: "iPhone 16",
+      platform: "ios",
+      deviceId: "IOS-UDID",
+    };
+    const tool = ToolRegistry.getTool("killDevice");
+    if (!tool) {
+      throw new Error("killDevice not registered");
+    }
+
+    const result = tool.handler({ device });
+    await new Promise(resolve => setImmediate(resolve));
+    timer.advanceTime(30_000);
+    await expect(result).rejects.toThrow("platform discovery did not complete");
+
+    expect(abortAwareManager.discoveryWasAborted).toBe(true);
   });
 
   test("does not retire ownership when shutdown discovery fails", async () => {
@@ -1219,6 +1354,57 @@ describe("killDevice handler", () => {
     expect(registry.getByUuid(originalSession.deviceSessionUuid)).toBeUndefined();
     expect(registry.getByDeviceId(image.deviceId!)?.deviceSessionUuid).toBeDefined();
     expect(pool.getRecoveryEligibility(image.deviceId!)).toEqual({ eligible: true, action: "restart" });
+  });
+
+  test("rebuilds a replacement observed by the initial shutdown wait", async () => {
+    const timer = new FakeTimer();
+    const image: DeviceInfo = {
+      name: "Pixel 8",
+      platform: "android",
+      deviceId: "emulator-5554",
+      isRunning: false,
+      source: "local",
+    };
+    const replacement: BootedDevice = {
+      name: "Pixel 8 replacement",
+      platform: "android",
+      deviceId: image.deviceId!,
+      transportId: "2",
+    };
+    const replacementManager = new FirstReplacementThenEmptyDeviceManager(replacement);
+    manager = replacementManager;
+    const deviceSessionRepository = new FakeDeviceSessionRepository();
+    setDeviceToolsDependencies({
+      deviceManagerFactory: () => replacementManager,
+      notifyResourcesChanged: async () => {},
+      ensureCtrlProxyReady: async () => {},
+      clearInstalledAppsForDevice: async () => {},
+      timer,
+    });
+    sessionManager = new SessionManager(timer, deviceSessionRepository);
+    replacementManager.setDeviceImages("android", [image]);
+    const pool = new DevicePool(
+      sessionManager,
+      "daemon-session",
+      timer,
+      new FakeInstalledAppsRepository(),
+      replacementManager,
+      new DefaultRetryExecutor(timer),
+      deviceSessionRepository,
+    );
+    DaemonState.getInstance().initialize(sessionManager, pool);
+    await pool.assignMultipleDevices(["session-1"], 1_000, "android");
+    const tool = ToolRegistry.getTool("killDevice");
+    if (!tool) {
+      throw new Error("killDevice not registered");
+    }
+
+    await expect(tool.handler(tool.schema.parse({
+      device: { ...image, transportId: "1" },
+    }))).resolves.toBeDefined();
+
+    expect(pool.getDevice(image.deviceId!)?.name).toBe(replacement.name);
+    expect(sessionManager.getSessionForDevice(image.deviceId!)).toBeNull();
   });
 
   test("rebuilds a replacement found after a failed post-release discovery", async () => {
@@ -1636,6 +1822,7 @@ describe("killDevice handler", () => {
         clearIntentionalShutdown: () => {
           clearedIntentionalShutdown++;
         },
+        reserveDeviceForShutdown: async () => undefined,
       } as never);
     }
     setDeviceToolsDependencies({

--- a/test/server/deviceTools.killDevice.test.ts
+++ b/test/server/deviceTools.killDevice.test.ts
@@ -21,7 +21,7 @@ import { DeviceSessionRepository } from "../../src/db/DeviceSessionRepository";
 import { FakeTimer } from "../fakes/FakeTimer";
 import { FakeDeviceUtils } from "../fakes/FakeDeviceUtils";
 import { FakeInstalledAppsRepository } from "../fakes/FakeInstalledAppsRepository";
-import type { BootedDeviceDiscovery } from "../../src/utils/deviceUtils";
+import type { BootedDeviceDiscovery, BootedDeviceDiscoveryOptions } from "../../src/utils/deviceUtils";
 
 class FailingKillDeviceManager extends FakeDeviceUtils {
   readonly childProcess = new EventEmitter() as ChildProcess;
@@ -49,6 +49,56 @@ class FailingKillDeviceManager extends FakeDeviceUtils {
 class SuccessfulKillDeviceManager extends FailingKillDeviceManager {
   override async killDevice(device: BootedDevice): Promise<void> {
     this.setBootedDevices(device.platform, []);
+  }
+}
+
+class ShutdownDiscoveryOptionsDeviceManager extends SuccessfulKillDeviceManager {
+  readonly shutdownDiscoveryOptions: Array<BootedDeviceDiscoveryOptions | undefined> = [];
+  private trackShutdownDiscovery = false;
+
+  beginTrackingShutdownDiscovery(): void {
+    this.trackShutdownDiscovery = true;
+  }
+
+  override async getBootedDevicesDetailed(
+    platform: SomePlatform,
+    options?: BootedDeviceDiscoveryOptions,
+  ): Promise<BootedDeviceDiscovery> {
+    if (this.trackShutdownDiscovery) {
+      this.shutdownDiscoveryOptions.push(options);
+    }
+    return await super.getBootedDevicesDetailed(platform);
+  }
+}
+
+class CurrentTransportKillDeviceManager extends FailingKillDeviceManager {
+  private shutdownPollsStarted = false;
+  private shutdownPollCount = 0;
+
+  constructor(private readonly currentDevice: BootedDevice) {
+    super();
+  }
+
+  beginShutdownPolls(): void {
+    this.shutdownPollsStarted = true;
+  }
+
+  override async killDevice(): Promise<BootedDevice> {
+    return this.currentDevice;
+  }
+
+  override async getBootedDevicesDetailed(
+    platform: SomePlatform,
+    options?: BootedDeviceDiscoveryOptions,
+  ): Promise<BootedDeviceDiscovery> {
+    if (!this.shutdownPollsStarted) {
+      return await super.getBootedDevicesDetailed(platform);
+    }
+    this.shutdownPollCount++;
+    return {
+      devices: this.shutdownPollCount === 1 ? [this.currentDevice] : [],
+      succeededPlatforms: new Set(["android"]),
+    };
   }
 }
 
@@ -308,6 +358,114 @@ describe("killDevice handler", () => {
 
     expect(successfulManager.getCallCount("startDevice")).toBe(1);
     expect(pool.getDevice("emulator-5554")).toBeNull();
+  });
+
+  test("bypasses the Android device-list cache while confirming shutdown", async () => {
+    const timer = new FakeTimer();
+    const cacheAwareManager = new ShutdownDiscoveryOptionsDeviceManager();
+    manager = cacheAwareManager;
+    const deviceSessionRepository = new FakeDeviceSessionRepository();
+    const image: DeviceInfo = {
+      name: "Pixel 8",
+      platform: "android",
+      deviceId: "emulator-5554",
+      isRunning: false,
+      source: "local",
+    };
+    setDeviceToolsDependencies({
+      deviceManagerFactory: () => cacheAwareManager,
+      notifyResourcesChanged: async () => {},
+      ensureCtrlProxyReady: async () => {},
+      clearInstalledAppsForDevice: async () => {},
+      timer,
+    });
+    sessionManager = new SessionManager(timer, deviceSessionRepository);
+    cacheAwareManager.setDeviceImages("android", [image]);
+    const pool = new DevicePool(
+      sessionManager,
+      "daemon-session",
+      timer,
+      new FakeInstalledAppsRepository(),
+      cacheAwareManager,
+      new DefaultRetryExecutor(timer),
+      deviceSessionRepository,
+    );
+    DaemonState.getInstance().initialize(sessionManager, pool);
+    await pool.assignMultipleDevices(["session-1"], 1_000, "android");
+    const tool = ToolRegistry.getTool("killDevice");
+    if (!tool) {
+      throw new Error("killDevice not registered");
+    }
+
+    cacheAwareManager.beginTrackingShutdownDiscovery();
+    await tool.handler({
+      device: { name: image.name, platform: "android", deviceId: image.deviceId! },
+    });
+
+    expect(cacheAwareManager.shutdownDiscoveryOptions).not.toBeEmpty();
+    expect(cacheAwareManager.shutdownDiscoveryOptions).toEqual(
+      expect.arrayContaining([{ bypassAndroidDeviceListCache: true }]),
+    );
+  });
+
+  test("waits for the transport that the Android kill preflight actually selected", async () => {
+    const timer = new FakeTimer();
+    const image: DeviceInfo = {
+      name: "Pixel 8",
+      platform: "android",
+      deviceId: "emulator-5554",
+      isRunning: false,
+      source: "local",
+    };
+    const currentDevice: BootedDevice = {
+      name: image.name,
+      platform: "android",
+      deviceId: image.deviceId!,
+      transportId: "2",
+    };
+    const currentTransportManager = new CurrentTransportKillDeviceManager(currentDevice);
+    manager = currentTransportManager;
+    const deviceSessionRepository = new FakeDeviceSessionRepository();
+    setDeviceToolsDependencies({
+      deviceManagerFactory: () => currentTransportManager,
+      notifyResourcesChanged: async () => {},
+      ensureCtrlProxyReady: async () => {},
+      clearInstalledAppsForDevice: async () => {},
+      timer,
+    });
+    sessionManager = new SessionManager(timer, deviceSessionRepository);
+    currentTransportManager.setDeviceImages("android", [image]);
+    const pool = new DevicePool(
+      sessionManager,
+      "daemon-session",
+      timer,
+      new FakeInstalledAppsRepository(),
+      currentTransportManager,
+      new DefaultRetryExecutor(timer),
+      deviceSessionRepository,
+    );
+    DaemonState.getInstance().initialize(sessionManager, pool);
+    await pool.assignMultipleDevices(["session-1"], 1_000, "android");
+    const tool = ToolRegistry.getTool("killDevice");
+    if (!tool) {
+      throw new Error("killDevice not registered");
+    }
+
+    currentTransportManager.beginShutdownPolls();
+    const result = tool.handler(tool.schema.parse({
+      device: {
+        name: image.name,
+        platform: "android",
+        deviceId: image.deviceId!,
+        transportId: "1",
+      },
+    }));
+    await new Promise(resolve => setImmediate(resolve));
+    expect(pool.getDevice(image.deviceId!)).not.toBeNull();
+    timer.advanceTime(1_000);
+    await expect(result).resolves.toBeDefined();
+
+    expect(pool.getDevice(image.deviceId!)).toBeNull();
   });
 
   test("waits for physical exit before retiring the matching session, pool entry, and device session", async () => {

--- a/test/server/deviceTools.killDevice.test.ts
+++ b/test/server/deviceTools.killDevice.test.ts
@@ -175,6 +175,31 @@ class DeadlineExhaustingShutdownDeviceManager extends DelayedSuccessfulKillDevic
   }
 }
 
+class TransientAbsenceThenSameIncarnationDeviceManager extends DelayedSuccessfulKillDeviceManager {
+  shutdownDiscoveryCalls = 0;
+  private shutdownStarted = false;
+
+  constructor(private readonly device: BootedDevice) {
+    super();
+  }
+
+  override async killDevice(): Promise<void> {
+    this.shutdownStarted = true;
+  }
+
+  override async getBootedDevicesDetailed(platform: SomePlatform): Promise<BootedDeviceDiscovery> {
+    if (!this.shutdownStarted) {
+      return await super.getBootedDevicesDetailed(platform);
+    }
+    this.shutdownDiscoveryCalls++;
+    const isTransientAbsence = this.shutdownDiscoveryCalls === 2 || this.shutdownDiscoveryCalls === 5;
+    return {
+      devices: isTransientAbsence ? [] : [this.device],
+      succeededPlatforms: new Set([this.device.platform]),
+    };
+  }
+}
+
 class ReplacementDuringCacheClearRepository extends FakeInstalledAppsRepository {
   constructor(private readonly onClearDeviceSession: () => Promise<void>) {
     super();
@@ -617,6 +642,75 @@ describe("killDevice handler", () => {
     expect(pool.getDevice(image.deviceId!)).toBeNull();
   });
 
+  test("keeps a shutdown target reserved against direct session binding", async () => {
+    const timer = new FakeTimer();
+    const delayedManager = new DelayedSuccessfulKillDeviceManager();
+    manager = delayedManager;
+    const image: DeviceInfo = {
+      name: "Pixel 8",
+      platform: "android",
+      deviceId: "emulator-5554",
+      isRunning: false,
+      source: "local",
+    };
+    let bindingError: unknown;
+    const deviceSessionRepository = new ReplacingDeviceSessionRepository(async () => {
+      const activePool = DaemonState.getInstance().getDevicePool();
+      await activePool.releaseDevice(image.deviceId!);
+      try {
+        await activePool.bindOrReuseDeviceSession(
+          "racing-session",
+          image.deviceId!,
+          "android",
+        );
+      } catch (error) {
+        bindingError = error;
+      }
+    });
+    setDeviceToolsDependencies({
+      deviceManagerFactory: () => delayedManager,
+      notifyResourcesChanged: async () => {},
+      ensureCtrlProxyReady: async () => {},
+      clearInstalledAppsForDevice: async () => {},
+      timer,
+    });
+    sessionManager = new SessionManager(timer, deviceSessionRepository);
+    delayedManager.setDeviceImages("android", [image]);
+    const pool = new DevicePool(
+      sessionManager,
+      "daemon-session",
+      timer,
+      new FakeInstalledAppsRepository(),
+      delayedManager,
+      new DefaultRetryExecutor(timer),
+      deviceSessionRepository,
+    );
+    DaemonState.getInstance().initialize(sessionManager, pool);
+    await pool.assignMultipleDevices(["session-1"], 1_000, "android");
+    delayedManager.setBootedDevices("android", [{
+      name: image.name,
+      platform: "android",
+      deviceId: image.deviceId!,
+    }]);
+    const tool = ToolRegistry.getTool("killDevice");
+    if (!tool) {
+      throw new Error("killDevice not registered");
+    }
+
+    const result = tool.handler({
+      device: { name: image.name, platform: "android", deviceId: image.deviceId! },
+    });
+    await new Promise(resolve => setImmediate(resolve));
+    delayedManager.setBootedDevices("android", []);
+    timer.advanceTime(1_000);
+    await expect(result).resolves.toBeDefined();
+
+    expect(bindingError).toBeInstanceOf(Error);
+    expect(String(bindingError)).toContain("shutting down");
+    expect(sessionManager.getSession("racing-session")).toBeNull();
+    expect(pool.getDevice(image.deviceId!)).toBeNull();
+  });
+
   test("returns an actionable timeout instead of reporting success while the device remains visible", async () => {
     const timer = new FakeTimer();
     const delayedManager = new DelayedSuccessfulKillDeviceManager();
@@ -644,6 +738,116 @@ describe("killDevice handler", () => {
     timer.advanceTime(30_000);
 
     await expect(result).rejects.toThrow("Timed out waiting for android device 'Pixel 8' (emulator-5554) to disappear");
+  });
+
+  test("clears the intentional-shutdown marker after confirmation times out", async () => {
+    const timer = new FakeTimer();
+    const delayedManager = new DelayedSuccessfulKillDeviceManager();
+    manager = delayedManager;
+    const deviceSessionRepository = new FakeDeviceSessionRepository();
+    const image: DeviceInfo = {
+      name: "Pixel 8",
+      platform: "android",
+      deviceId: "emulator-5554",
+      isRunning: false,
+      source: "local",
+    };
+    setDeviceToolsDependencies({
+      deviceManagerFactory: () => delayedManager,
+      notifyResourcesChanged: async () => {},
+      ensureCtrlProxyReady: async () => {},
+      clearInstalledAppsForDevice: async () => {},
+      timer,
+    });
+    sessionManager = new SessionManager(timer, deviceSessionRepository);
+    delayedManager.setDeviceImages("android", [image]);
+    const pool = new DevicePool(
+      sessionManager,
+      "daemon-session",
+      timer,
+      new FakeInstalledAppsRepository(),
+      delayedManager,
+      new DefaultRetryExecutor(timer),
+      deviceSessionRepository,
+    );
+    DaemonState.getInstance().initialize(sessionManager, pool);
+    await pool.assignMultipleDevices(["session-1"], 1_000, "android");
+    delayedManager.setBootedDevices("android", [{
+      name: image.name,
+      platform: "android",
+      deviceId: image.deviceId!,
+    }]);
+    const tool = ToolRegistry.getTool("killDevice");
+    if (!tool) {
+      throw new Error("killDevice not registered");
+    }
+
+    const result = tool.handler({
+      device: { name: image.name, platform: "android", deviceId: image.deviceId! },
+    });
+    await new Promise(resolve => setImmediate(resolve));
+    timer.advanceTime(30_000);
+    await expect(result).rejects.toThrow("Timed out waiting for android device");
+
+    Object.assign(delayedManager.childProcess, { exitCode: 1 });
+    delayedManager.childProcess.emit("exit", 1, null);
+    await new Promise(resolve => setImmediate(resolve));
+
+    expect(delayedManager.getCallCount("startDevice")).toBe(2);
+  });
+
+  test("resumes shutdown polling when the same incarnation reappears after a transient absence", async () => {
+    const timer = new FakeTimer();
+    const device: BootedDevice = {
+      name: "Pixel 8",
+      platform: "android",
+      deviceId: "emulator-5554",
+      transportId: "1",
+    };
+    const transientManager = new TransientAbsenceThenSameIncarnationDeviceManager(device);
+    manager = transientManager;
+    const deviceSessionRepository = new FakeDeviceSessionRepository();
+    setDeviceToolsDependencies({
+      deviceManagerFactory: () => transientManager,
+      notifyResourcesChanged: async () => {},
+      ensureCtrlProxyReady: async () => {},
+      clearInstalledAppsForDevice: async () => {},
+      timer,
+    });
+    sessionManager = new SessionManager(timer, deviceSessionRepository);
+    transientManager.setDeviceImages("android", [{
+      name: device.name,
+      platform: device.platform,
+      deviceId: device.deviceId,
+      isRunning: false,
+      source: "local",
+    }]);
+    const pool = new DevicePool(
+      sessionManager,
+      "daemon-session",
+      timer,
+      new FakeInstalledAppsRepository(),
+      transientManager,
+      new DefaultRetryExecutor(timer),
+      deviceSessionRepository,
+    );
+    DaemonState.getInstance().initialize(sessionManager, pool);
+    await pool.assignMultipleDevices(["session-1"], 1_000, "android");
+    const tool = ToolRegistry.getTool("killDevice");
+    if (!tool) {
+      throw new Error("killDevice not registered");
+    }
+
+    const result = tool.handler(tool.schema.parse({ device }));
+    await new Promise(resolve => setImmediate(resolve));
+    timer.advanceTime(1_000);
+    await new Promise(resolve => setImmediate(resolve));
+    expect(transientManager.shutdownDiscoveryCalls).toBe(4);
+    timer.advanceTime(1_000);
+    await expect(result).resolves.toBeDefined();
+
+    expect(transientManager.shutdownDiscoveryCalls).toBe(5);
+    expect(pool.getDevice(device.deviceId)).toBeNull();
   });
 
   test("awaits iOS pool removal before retiring its device-session epoch", async () => {

--- a/test/server/deviceTools.killDevice.test.ts
+++ b/test/server/deviceTools.killDevice.test.ts
@@ -550,6 +550,73 @@ describe("killDevice handler", () => {
     expect(registry.getByUuid(deviceSession.deviceSessionUuid)).toBeUndefined();
   });
 
+  test("keeps a shutdown target reserved against allocation during ownership release", async () => {
+    const timer = new FakeTimer();
+    const delayedManager = new DelayedSuccessfulKillDeviceManager();
+    manager = delayedManager;
+    const image: DeviceInfo = {
+      name: "Pixel 8",
+      platform: "android",
+      deviceId: "emulator-5554",
+      isRunning: false,
+      source: "local",
+    };
+    let allocationOutcome: "assigned" | "blocked" | undefined;
+    const deviceSessionRepository = new ReplacingDeviceSessionRepository(async () => {
+      const activePool = DaemonState.getInstance().getDevicePool();
+      await activePool.releaseDevice(image.deviceId!);
+      allocationOutcome = await activePool
+        .assignMultipleDevices(["racing-session"], 1, "android")
+        .then(() => "assigned" as const, () => "blocked" as const);
+    });
+    setDeviceToolsDependencies({
+      deviceManagerFactory: () => delayedManager,
+      notifyResourcesChanged: async () => {},
+      ensureCtrlProxyReady: async () => {},
+      clearInstalledAppsForDevice: async () => {},
+      timer,
+    });
+    sessionManager = new SessionManager(timer, deviceSessionRepository);
+    delayedManager.setDeviceImages("android", [image]);
+    const pool = new DevicePool(
+      sessionManager,
+      "daemon-session",
+      timer,
+      new FakeInstalledAppsRepository(),
+      delayedManager,
+      new DefaultRetryExecutor(timer),
+      deviceSessionRepository,
+    );
+    DaemonState.getInstance().initialize(sessionManager, pool);
+    await pool.assignMultipleDevices(["session-1"], 1_000, "android");
+    const original = pool.getDevice(image.deviceId!);
+    if (!original) {
+      throw new Error("expected assigned device to be pooled");
+    }
+    delayedManager.setBootedDevices("android", [{
+      name: image.name,
+      platform: "android",
+      deviceId: image.deviceId!,
+    }]);
+    const tool = ToolRegistry.getTool("killDevice");
+    if (!tool) {
+      throw new Error("killDevice not registered");
+    }
+
+    const result = tool.handler({
+      device: { name: image.name, platform: "android", deviceId: image.deviceId! },
+    });
+    await new Promise(resolve => setImmediate(resolve));
+    delayedManager.setBootedDevices("android", []);
+    timer.advanceTime(1_000);
+    await expect(result).resolves.toBeDefined();
+
+    expect(allocationOutcome).toBe("blocked");
+    expect(sessionManager.getSessionForDevice("emulator-5554")).toBeNull();
+    expect(sessionManager.getSession("racing-session")).toBeNull();
+    expect(pool.getDevice(image.deviceId!)).toBeNull();
+  });
+
   test("returns an actionable timeout instead of reporting success while the device remains visible", async () => {
     const timer = new FakeTimer();
     const delayedManager = new DelayedSuccessfulKillDeviceManager();

--- a/test/server/deviceTools.killDevice.test.ts
+++ b/test/server/deviceTools.killDevice.test.ts
@@ -22,7 +22,11 @@ import { DeviceSessionRepository } from "../../src/db/DeviceSessionRepository";
 import { FakeTimer } from "../fakes/FakeTimer";
 import { FakeDeviceUtils } from "../fakes/FakeDeviceUtils";
 import { FakeInstalledAppsRepository } from "../fakes/FakeInstalledAppsRepository";
-import type { BootedDeviceDiscovery, BootedDeviceDiscoveryOptions } from "../../src/utils/deviceUtils";
+import type {
+  BootedDeviceDiscovery,
+  BootedDeviceDiscoveryOptions,
+  DeviceShutdownOptions,
+} from "../../src/utils/deviceUtils";
 
 class FailingKillDeviceManager extends FakeDeviceUtils {
   readonly childProcess = new EventEmitter() as ChildProcess;
@@ -227,6 +231,19 @@ class AbortAwareHungDiscoveryKillDeviceManager extends DelayedSuccessfulKillDevi
       this.discoveryWasAborted = true;
     }, { once: true });
     return new Promise<BootedDeviceDiscovery>(() => {});
+  }
+}
+
+class AbortAwareHungShutdownCommandDeviceManager extends FailingKillDeviceManager {
+  commandWasAborted = false;
+  commandOptions: DeviceShutdownOptions | undefined;
+
+  override killDevice(_: BootedDevice, options?: DeviceShutdownOptions): Promise<void> {
+    this.commandOptions = options;
+    options?.signal?.addEventListener("abort", () => {
+      this.commandWasAborted = true;
+    }, { once: true });
+    return new Promise<void>(() => {});
   }
 }
 
@@ -1065,6 +1082,63 @@ describe("killDevice handler", () => {
     timer.advanceTime(30_000);
     await expect(result).rejects.toThrow("platform discovery did not complete");
 
+    expect(abortAwareManager.discoveryWasAborted).toBe(true);
+  });
+
+  test("bounds and aborts a hung platform shutdown command", async () => {
+    const timer = new FakeTimer();
+    const hungManager = new AbortAwareHungShutdownCommandDeviceManager();
+    manager = hungManager;
+    setDeviceToolsDependencies({
+      deviceManagerFactory: () => hungManager,
+      notifyResourcesChanged: async () => {},
+      ensureCtrlProxyReady: async () => {},
+      clearInstalledAppsForDevice: async () => {},
+      timer,
+    });
+    const device: BootedDevice = {
+      name: "Pixel 8",
+      platform: "android",
+      deviceId: "emulator-5554",
+    };
+    const tool = ToolRegistry.getTool("killDevice");
+    if (!tool) {
+      throw new Error("killDevice not registered");
+    }
+
+    const result = tool.handler({ device });
+    await new Promise(resolve => setImmediate(resolve));
+    timer.advanceTime(30_000);
+
+    await expect(result).rejects.toThrow("platform shutdown command did not complete");
+    expect(hungManager.commandWasAborted).toBe(true);
+    expect(hungManager.commandOptions?.timeoutMs).toBe(30_000);
+  });
+
+  test("preserves caller cancellation while shutdown discovery is pending", async () => {
+    const timer = new FakeTimer();
+    const abortAwareManager = new AbortAwareHungDiscoveryKillDeviceManager();
+    manager = abortAwareManager;
+    setDeviceToolsDependencies({
+      deviceManagerFactory: () => abortAwareManager,
+      notifyResourcesChanged: async () => {},
+      ensureCtrlProxyReady: async () => {},
+      clearInstalledAppsForDevice: async () => {},
+      timer,
+    });
+    const controller = new AbortController();
+    const tool = ToolRegistry.getTool("killDevice");
+    if (!tool) {
+      throw new Error("killDevice not registered");
+    }
+
+    const result = tool.handler({
+      device: { name: "iPhone 16", platform: "ios", deviceId: "IOS-UDID" },
+    }, undefined, controller.signal);
+    await new Promise(resolve => setImmediate(resolve));
+    controller.abort(new Error("caller cancelled shutdown"));
+
+    await expect(result).rejects.toThrow("caller cancelled shutdown");
     expect(abortAwareManager.discoveryWasAborted).toBe(true);
   });
 

--- a/test/server/deviceTools.killDevice.test.ts
+++ b/test/server/deviceTools.killDevice.test.ts
@@ -297,6 +297,29 @@ class ReplacingDeviceSessionRepository extends FakeDeviceSessionRepository {
   }
 }
 
+class DeferredReleaseDeviceSessionRepository extends FakeDeviceSessionRepository {
+  private releaseMarkReleased: (() => void) | undefined;
+  private resolveMarkReleasedStarted: (() => void) | undefined;
+  private readonly markReleasedStarted = new Promise<void>(resolve => {
+    this.resolveMarkReleasedStarted = resolve;
+  });
+
+  override async markReleased(): Promise<void> {
+    this.resolveMarkReleasedStarted?.();
+    await new Promise<void>(resolve => {
+      this.releaseMarkReleased = resolve;
+    });
+  }
+
+  async waitForMarkReleased(): Promise<void> {
+    await this.markReleasedStarted;
+  }
+
+  finishMarkReleased(): void {
+    this.releaseMarkReleased?.();
+  }
+}
+
 describe("killDevice handler", () => {
   const originalPreferred = process.env.AUTOMOBILE_ANDROID_REBOOT_ON_DEATH;
   const originalAlias = process.env.AUTO_MOBILE_ANDROID_REBOOT_ON_DEATH;
@@ -792,7 +815,7 @@ describe("killDevice handler", () => {
     );
     DaemonState.getInstance().initialize(sessionManager, pool);
     await pool.assignMultipleDevices(["session-1"], 1_000, "android");
-    await pool.releaseDevice(image.deviceId!);
+    await pool.releaseDevice(image.deviceId!, "session-1");
     await setVideoRecordingManagerDependencies({
       videoRecorderService: {
         stopRecording: async () => {
@@ -895,7 +918,7 @@ describe("killDevice handler", () => {
 
     await expect(result).rejects.toThrow("video recording teardown did not complete");
     expect(pool.getDevice(image.deviceId!)?.sessionId).toBe("session-1");
-    await pool.releaseDevice(image.deviceId!);
+    await pool.releaseDevice(image.deviceId!, "session-1");
     expect(pool.getAvailableDeviceCount()).toBe(1);
   });
 
@@ -1435,6 +1458,135 @@ describe("killDevice handler", () => {
     expect(sessionManager.getSessionForDevice(image.deviceId!)).toBeNull();
     expect(registry.getByUuid(originalSession.deviceSessionUuid)).toBeUndefined();
     expect(registry.getByDeviceId(image.deviceId!)?.deviceSessionUuid).toBeDefined();
+  });
+
+  test("releases the shutdown reservation before post-shutdown cleanup", async () => {
+    const timer = new FakeTimer();
+    const image: DeviceInfo = {
+      name: "Pixel 8",
+      platform: "android",
+      deviceId: "emulator-5554",
+      isRunning: false,
+      source: "local",
+    };
+    const replacement: BootedDevice = {
+      name: "Pixel 8 replacement",
+      platform: "android",
+      deviceId: image.deviceId!,
+      transportId: "2",
+    };
+    const replacementManager = new FirstReplacementThenEmptyDeviceManager(replacement);
+    manager = replacementManager;
+    const deviceSessionRepository = new FakeDeviceSessionRepository();
+    let finishCleanup: (() => void) | undefined;
+    let resolveCleanupStarted: (() => void) | undefined;
+    const cleanupStarted = new Promise<void>(resolve => {
+      resolveCleanupStarted = resolve;
+    });
+    setDeviceToolsDependencies({
+      deviceManagerFactory: () => replacementManager,
+      notifyResourcesChanged: async () => {},
+      ensureCtrlProxyReady: async () => {},
+      clearInstalledAppsForDevice: async () => {
+        resolveCleanupStarted?.();
+        await new Promise<void>(resolve => {
+          finishCleanup = resolve;
+        });
+      },
+      timer,
+    });
+    sessionManager = new SessionManager(timer, deviceSessionRepository);
+    replacementManager.setDeviceImages("android", [image]);
+    const pool = new DevicePool(
+      sessionManager,
+      "daemon-session",
+      timer,
+      new FakeInstalledAppsRepository(),
+      replacementManager,
+      new DefaultRetryExecutor(timer),
+      deviceSessionRepository,
+    );
+    DaemonState.getInstance().initialize(sessionManager, pool);
+    await pool.assignMultipleDevices(["session-1"], 1_000, "android");
+    const tool = ToolRegistry.getTool("killDevice");
+    if (!tool) {
+      throw new Error("killDevice not registered");
+    }
+
+    const result = tool.handler(tool.schema.parse({
+      device: { ...image, transportId: "1" },
+    }));
+    await cleanupStarted;
+
+    const replacementReservation = await pool.reserveDeviceForShutdown(image.deviceId!);
+    expect(replacementReservation?.device.name).toBe(replacement.name);
+    await replacementReservation?.release();
+
+    finishCleanup?.();
+    await expect(result).resolves.toBeDefined();
+  });
+
+  test("finishes retiring a stopped device after a timed-out session release completes", async () => {
+    const timer = new FakeTimer();
+    const successfulManager = new SuccessfulKillDeviceManager();
+    manager = successfulManager;
+    const image: DeviceInfo = {
+      name: "Pixel 8",
+      platform: "android",
+      deviceId: "emulator-5554",
+      isRunning: false,
+      source: "local",
+    };
+    const deviceSessionRepository = new DeferredReleaseDeviceSessionRepository();
+    setDeviceToolsDependencies({
+      deviceManagerFactory: () => successfulManager,
+      notifyResourcesChanged: async () => {},
+      ensureCtrlProxyReady: async () => {},
+      clearInstalledAppsForDevice: async () => {},
+      timer,
+    });
+    sessionManager = new SessionManager(timer, deviceSessionRepository);
+    successfulManager.setDeviceImages("android", [image]);
+    const pool = new DevicePool(
+      sessionManager,
+      "daemon-session",
+      timer,
+      new FakeInstalledAppsRepository(),
+      successfulManager,
+      new DefaultRetryExecutor(timer),
+      deviceSessionRepository,
+    );
+    const registry = new DeviceSessionRegistry(timer);
+    DaemonState.getInstance().initialize(sessionManager, pool, registry);
+    await pool.assignMultipleDevices(["session-1"], 1_000, "android");
+    const pooled = pool.getDevice(image.deviceId!);
+    if (!pooled) {
+      throw new Error("expected assigned device to be pooled");
+    }
+    const deviceSession = registry.onDeviceConnected({
+      deviceId: pooled.id,
+      platform: pooled.platform,
+      incarnation: pooled.incarnation,
+    });
+    const tool = ToolRegistry.getTool("killDevice");
+    if (!tool) {
+      throw new Error("killDevice not registered");
+    }
+
+    const result = tool.handler({
+      device: { name: image.name, platform: image.platform, deviceId: image.deviceId! },
+    });
+    await deviceSessionRepository.waitForMarkReleased();
+    timer.advanceTime(30_000);
+
+    await expect(result).rejects.toThrow("session ownership retirement did not complete");
+    expect(pool.getDevice(image.deviceId!)).toBe(pooled);
+
+    deviceSessionRepository.finishMarkReleased();
+    await new Promise(resolve => setImmediate(resolve));
+
+    expect(pool.getDevice(image.deviceId!)).toBeNull();
+    expect(registry.getByUuid(deviceSession.deviceSessionUuid)).toBeUndefined();
   });
 
   test("recognizes a same-ID Android replacement before the first shutdown poll", async () => {

--- a/test/server/executionTracker.test.ts
+++ b/test/server/executionTracker.test.ts
@@ -78,13 +78,13 @@ describe("ExecutionTracker", function() {
       new FakeTimer(),
       new FakeIdGenerator(["kill", "tap"]),
     );
-    const kill = tracker.startExecution("killDevice", undefined, "session-uuid");
+    const kill = tracker.startExecution("executePlan", undefined, "session-uuid");
     const tap = tracker.startExecution("tapOn", undefined, "session-uuid");
 
     const cancelled = await tracker.cancelSessionUuidExecutions(
       "session-uuid",
       "device-disconnected:emulator-5554",
-      { excludeToolName: "killDevice" },
+      { excludeSignal: kill.abortController.signal },
     );
 
     expect(cancelled).toBe(1);

--- a/test/server/executionTracker.test.ts
+++ b/test/server/executionTracker.test.ts
@@ -73,6 +73,25 @@ describe("ExecutionTracker", function() {
     expect(tracker.hasActiveSessionUuidExecutions("session-uuid")).toBe(false);
   });
 
+  test("keeps the shutdown control operation alive while cancelling device work", async function() {
+    const tracker = new ExecutionTracker(
+      new FakeTimer(),
+      new FakeIdGenerator(["kill", "tap"]),
+    );
+    const kill = tracker.startExecution("killDevice", undefined, "session-uuid");
+    const tap = tracker.startExecution("tapOn", undefined, "session-uuid");
+
+    const cancelled = await tracker.cancelSessionUuidExecutions(
+      "session-uuid",
+      "device-disconnected:emulator-5554",
+      { excludeToolName: "killDevice" },
+    );
+
+    expect(cancelled).toBe(1);
+    expect(kill.abortController.signal.aborted).toBe(false);
+    expect(tap.abortController.signal.aborted).toBe(true);
+  });
+
   // #4183 item 6 (A3): the scope fallback in hasActiveToolExecution (executionTracker.ts)
   // had no table coverage. The scope order is: explicit "global" → sessionUuid map →
   // sessionId map → global fallback when neither key is provided.

--- a/test/utils/deviceUtils.test.ts
+++ b/test/utils/deviceUtils.test.ts
@@ -5,6 +5,7 @@ import { SimCtlClient } from "../../src/utils/ios-cmdline-tools/SimCtlClient";
 import { FakeAdbClient } from "../fakes/FakeAdbClient";
 import { AdbClient } from "../../src/utils/android-cmdline-tools/AdbClient";
 import type { AndroidEmulatorClient } from "../../src/utils/android-cmdline-tools/AndroidEmulatorClient";
+import { runWithAbortSignal } from "../../src/utils/AbortContext";
 
 async function withProcessPlatform<T>(platform: NodeJS.Platform, fn: () => Promise<T>): Promise<T> {
   const original = process.platform;
@@ -23,6 +24,30 @@ async function withProcessPlatform<T>(platform: NodeJS.Platform, fn: () => Promi
 }
 
 describe("MultiPlatformDeviceManager", () => {
+  test("forwards ambient cancellation to Android detailed discovery", async () => {
+    const controller = new AbortController();
+    let receivedSignal: AbortSignal | undefined;
+    const emulator = {
+      getBootedDevicesChecked: async (
+        _onlyEmulators: boolean,
+        _options: { bypassDeviceListCache?: boolean },
+        signal?: AbortSignal,
+      ): Promise<BootedDevice[]> => {
+        receivedSignal = signal;
+        return [];
+      },
+    } as unknown as AndroidEmulatorClient;
+    const manager = new MultiPlatformDeviceManager(
+      new FakeAdbClient() as unknown as AdbClient,
+      {} as SimCtlClient,
+      emulator,
+    );
+
+    await runWithAbortSignal(controller.signal, () => manager.getBootedDevicesDetailed("android"));
+
+    expect(receivedSignal).toBe(controller.signal);
+  });
+
   test("isDeviceImageRunning uses UDID when present for iOS", async () => {
     const fakeSimctl = {
       isAvailable: async () => true,

--- a/test/utils/iosSimulatorContinuity.test.ts
+++ b/test/utils/iosSimulatorContinuity.test.ts
@@ -386,8 +386,15 @@ describe("redactContinuityEvidence — retains a shareable, redacted result (AC7
     expect(serialized).not.toContain("mac-worker-07.internal");
     expect(serialized).not.toContain("AAAAAAAA-BBBB-CCCC-DDDD-EEEEEEEEEEEE");
     expect(serialized).not.toContain("/Users/ci");
-    expect(serialized).not.toContain("4201");
-    expect(serialized).not.toContain("4310");
+    for (const [role, rawPid] of Object.entries(evidence.before.processIds)) {
+      // Opaque SHA-256 tokens can legitimately contain a PID's decimal digits.
+      // Verify the typed field is a token rather than rejecting that harmless
+      // substring anywhere in a serialized artifact.
+      const token = redacted.before.processIds[role];
+      expect(token).toMatch(/^pid:[a-f0-9]{12}$/);
+      expect(token).not.toBe(String(rawPid));
+      expect(token).not.toBe(`pid:${rawPid}`);
+    }
   });
 
   it("keeps the non-sensitive fields needed to read the evidence", () => {


### PR DESCRIPTION
## Summary

`killDevice` now waits up to 30 seconds for successful platform discovery to
confirm that the requested device disappeared, including when discovery hangs
or fails. Only then does it retire the matching session, pool entry, and
device-session record. A final physical recheck and identity checks preserve a
rapid same-ID replacement.

## Linked Issue

Closes [#5294](https://github.com/kaeawc/auto-mobile/issues/5294)

## Bug / Regression Context

- **Observed symptom:** a successful `adb emu kill` acknowledgement could make
  `killDevice` report success while the emulator remained alive and ownership
  stayed stale.
- **Repro conditions:** platform shutdown is accepted but exit is delayed, or
  disconnect discovery does not promptly observe an assigned simulator.

## Validation

- [x] `bun test test/server/deviceTools.killDevice.test.ts` (12 passing)
- [x] `bun run lint` (ratchet and boundary checks pass)
- [x] `bun run build`
- [x] `bun run typecheck` (no new errors)
- [x] New code uses interfaces, fakes, and `FakeTimer`; focused unit tests run
  in under 100 ms.
- [x] Fresh worktree created from the latest `origin/main`.
- [ ] Aggregate `bun run turbo:validate`: the all-tests process stalled after
  4.5 minutes at an existing iOS boundary-suite transition. That exact suite
  passes independently; the aggregate run did not complete locally.
