### PR TITLE
fix(daemon): count successful empty discovery misses

### DIFF
--- a/.github/workflows/pull_request.yml
+++ b/.github/workflows/pull_request.yml
@@ -1186,10 +1186,10 @@ jobs:
     name: "Node TypeScript Build and Test (${{ matrix.os }})"
     runs-on: ${{ matrix.os }}
     needs: detect-changes
-    # The full isolated Bun suite can approach ten minutes on a contended hosted
-    # macOS runner. Keep the cross-platform lane intact while allowing enough
-    # headroom to finish after setup, lint, and build (issue #5328).
-    timeout-minutes: 15
+    # The full isolated Bun suite can approach fifteen minutes on a contended
+    # hosted macOS runner. Keep the cross-platform lane intact while allowing
+    # enough headroom to finish after setup, lint, and build (issue #5328).
+    timeout-minutes: 25
     env:
       RUN_MCP_BUILD_TEST: ${{ needs.detect-changes.outputs.docs_only != 'true' && needs.detect-changes.outputs.sha256_only != 'true' }}
     strategy:

--- a/src/daemon/daemon.ts
+++ b/src/daemon/daemon.ts
@@ -148,6 +148,7 @@ export class Daemon {
   private deviceDisconnectMonitor: SingleFlightInterval | null = null;
   private pidFileWritten = false;
   private deviceDisconnectMisses: Map<string, number> = new Map();
+  private deviceDisconnectMissIncarnations: Map<string, number> = new Map();
   private confirmedDisconnectedDeviceIds: Set<string> = new Set();
   private forceDisconnectedDeviceIds: Set<string> = new Set();
   private stoppingRecordings: Set<string> = new Set();
@@ -1242,6 +1243,7 @@ export class Daemon {
         const missingByDevice = new Map<string, string[]>();
         const candidateDeviceIds = new Set<string>();
         const candidatePlatforms = new Map<string, "android" | "ios">();
+        const candidateIncarnations = new Map<string, number>();
         for (const recording of activeRecordings) {
           candidateDeviceIds.add(recording.deviceId);
           candidatePlatforms.set(recording.deviceId, recording.platform);
@@ -1249,6 +1251,7 @@ export class Daemon {
         for (const device of this.devicePool.getAllDevices()) {
           candidateDeviceIds.add(device.id);
           candidatePlatforms.set(device.id, device.platform);
+          candidateIncarnations.set(device.id, device.incarnation);
         }
         for (const deviceId of this.sessionManager.getAssignedDevices()) {
           candidateDeviceIds.add(deviceId);
@@ -1261,6 +1264,8 @@ export class Daemon {
           candidateDeviceIds,
           succeededPlatforms,
           candidatePlatforms,
+          candidateIncarnations,
+          deviceDisconnectMissIncarnations: this.deviceDisconnectMissIncarnations,
           forceDisconnectedDeviceIds: this.forceDisconnectedDeviceIds,
           missThreshold: DEVICE_DISCONNECT_MISS_THRESHOLD,
         });
@@ -1361,6 +1366,7 @@ export class Daemon {
           if (deviceCleanupSucceeded) {
             this.confirmedDisconnectedDeviceIds.add(deviceId);
             this.deviceDisconnectMisses.delete(deviceId);
+            this.deviceDisconnectMissIncarnations.delete(deviceId);
             this.forceDisconnectedDeviceIds.delete(deviceId);
           }
         }

--- a/src/daemon/daemon.ts
+++ b/src/daemon/daemon.ts
@@ -1385,6 +1385,10 @@ export class Daemon {
       if (!this.devicePool.getDevice(deviceId)) {
         return false;
       }
+      this.deviceDisconnectMisses.delete(deviceId);
+      this.deviceDisconnectMissIncarnations.delete(deviceId);
+      this.confirmedDisconnectedDeviceIds.delete(deviceId);
+      this.forceDisconnectedDeviceIds.delete(deviceId);
       logger.info(
         `[DisconnectMonitor] Skipping stale disconnect cleanup for recovered device ${deviceId}`
       );
@@ -1393,6 +1397,10 @@ export class Daemon {
     if (await this.devicePool.isCurrentDisconnectedDevice(pooledDeviceAtDisconnect)) {
       return false;
     }
+    this.deviceDisconnectMisses.delete(deviceId);
+    this.deviceDisconnectMissIncarnations.delete(deviceId);
+    this.confirmedDisconnectedDeviceIds.delete(deviceId);
+    this.forceDisconnectedDeviceIds.delete(deviceId);
     logger.info(
       `[DisconnectMonitor] Skipping stale disconnect cleanup for recovered device ${deviceId}`
     );

--- a/src/daemon/daemon.ts
+++ b/src/daemon/daemon.ts
@@ -151,6 +151,7 @@ export class Daemon {
   private deviceDisconnectMissIncarnations: Map<string, number> = new Map();
   private confirmedDisconnectedDeviceIds: Set<string> = new Set();
   private forceDisconnectedDeviceIds: Set<string> = new Set();
+  private forceDisconnectedDeviceGenerations: Map<string, number> = new Map();
   private stoppingRecordings: Set<string> = new Set();
   private sessionManager: SessionManager;
   private devicePool: DevicePool;
@@ -1368,6 +1369,7 @@ export class Daemon {
             this.deviceDisconnectMisses.delete(deviceId);
             this.deviceDisconnectMissIncarnations.delete(deviceId);
             this.forceDisconnectedDeviceIds.delete(deviceId);
+            this.forceDisconnectedDeviceGenerations.delete(deviceId);
           }
         }
       } catch (error) {
@@ -1389,11 +1391,13 @@ export class Daemon {
       this.deviceDisconnectMissIncarnations.delete(deviceId);
       this.confirmedDisconnectedDeviceIds.delete(deviceId);
       this.forceDisconnectedDeviceIds.delete(deviceId);
+      this.forceDisconnectedDeviceGenerations.delete(deviceId);
       logger.info(
         `[DisconnectMonitor] Skipping stale disconnect cleanup for recovered device ${deviceId}`
       );
       return true;
     }
+    const forceGenerationAtVerificationStart = this.forceDisconnectedDeviceGenerations.get(deviceId);
     const disconnectStatus = await this.devicePool.isCurrentDisconnectedDevice(pooledDeviceAtDisconnect);
     if (disconnectStatus === "current") {
       return false;
@@ -1407,7 +1411,10 @@ export class Daemon {
     this.deviceDisconnectMisses.delete(deviceId);
     this.deviceDisconnectMissIncarnations.delete(deviceId);
     this.confirmedDisconnectedDeviceIds.delete(deviceId);
-    this.forceDisconnectedDeviceIds.delete(deviceId);
+    if (this.forceDisconnectedDeviceGenerations.get(deviceId) === forceGenerationAtVerificationStart) {
+      this.forceDisconnectedDeviceIds.delete(deviceId);
+      this.forceDisconnectedDeviceGenerations.delete(deviceId);
+    }
     logger.info(
       `[DisconnectMonitor] Skipping stale disconnect cleanup for recovered device ${deviceId}`
     );
@@ -1425,6 +1432,10 @@ export class Daemon {
       }
       logger.warn(`[Daemon] ADB reported tracked device ${event.deviceId} missing: ${event.message}`);
       this.forceDisconnectedDeviceIds.add(event.deviceId);
+      this.forceDisconnectedDeviceGenerations.set(
+        event.deviceId,
+        (this.forceDisconnectedDeviceGenerations.get(event.deviceId) ?? 0) + 1,
+      );
       this.deviceDisconnectMisses.set(event.deviceId, DEVICE_DISCONNECT_MISS_THRESHOLD);
     });
   }

--- a/src/daemon/daemon.ts
+++ b/src/daemon/daemon.ts
@@ -1394,8 +1394,15 @@ export class Daemon {
       );
       return true;
     }
-    if (await this.devicePool.isCurrentDisconnectedDevice(pooledDeviceAtDisconnect)) {
+    const disconnectStatus = await this.devicePool.isCurrentDisconnectedDevice(pooledDeviceAtDisconnect);
+    if (disconnectStatus === "current") {
       return false;
+    }
+    if (disconnectStatus === "unknown") {
+      logger.warn(
+        `[DisconnectMonitor] Retaining disconnect state for ${deviceId}: recovery verification was inconclusive`
+      );
+      return true;
     }
     this.deviceDisconnectMisses.delete(deviceId);
     this.deviceDisconnectMissIncarnations.delete(deviceId);

--- a/src/daemon/daemon.ts
+++ b/src/daemon/daemon.ts
@@ -1242,7 +1242,6 @@ export class Daemon {
         const missingByDevice = new Map<string, string[]>();
         const candidateDeviceIds = new Set<string>();
         const candidatePlatforms = new Map<string, "android" | "ios">();
-        const idleCandidateIds = new Set<string>();
         for (const recording of activeRecordings) {
           candidateDeviceIds.add(recording.deviceId);
           candidatePlatforms.set(recording.deviceId, recording.platform);
@@ -1250,9 +1249,6 @@ export class Daemon {
         for (const device of this.devicePool.getAllDevices()) {
           candidateDeviceIds.add(device.id);
           candidatePlatforms.set(device.id, device.platform);
-          if (device.status === "idle") {
-            idleCandidateIds.add(device.id);
-          }
         }
         for (const deviceId of this.sessionManager.getAssignedDevices()) {
           candidateDeviceIds.add(deviceId);
@@ -1265,14 +1261,13 @@ export class Daemon {
           candidateDeviceIds,
           succeededPlatforms,
           candidatePlatforms,
-          idleCandidateIds,
           forceDisconnectedDeviceIds: this.forceDisconnectedDeviceIds,
           missThreshold: DEVICE_DISCONNECT_MISS_THRESHOLD,
         });
 
-        if (disconnectResult.skippedAdbUnreachable) {
+        if (disconnectResult.skippedAllDiscoveryFailed) {
           logger.warn(
-            `[DisconnectMonitor] ADB returned 0 devices but ${candidateDeviceIds.size} tracked — skipping miss count (ADB likely unreachable)`
+            `[DisconnectMonitor] No platform discovery succeeded but ${candidateDeviceIds.size} tracked — skipping miss count`
           );
           return;
         }

--- a/src/daemon/daemon.ts
+++ b/src/daemon/daemon.ts
@@ -80,7 +80,11 @@ import { startPerformanceMonitor, stopPerformanceMonitor, getPerformanceMonitor 
 import { interruptVideoRecording, listActiveVideoRecordings, stopVideoRecording } from "../server/videoRecordingManager";
 import { Timer, defaultTimer } from "../utils/SystemTimer";
 import { IdGenerator, defaultIdGenerator } from "../utils/IdGenerator";
-import { evaluateDeviceDisconnects } from "./disconnectMonitor";
+import {
+  evaluateDeviceDisconnects,
+  recordingCandidateIncarnations,
+  type DisconnectCandidateIncarnation,
+} from "./disconnectMonitor";
 import { describeUnknownError } from "../utils/describeUnknownError";
 import { FeatureFlagService } from "../features/featureFlags/FeatureFlagService";
 import { serverConfig } from "../utils/ServerConfig";
@@ -148,7 +152,7 @@ export class Daemon {
   private deviceDisconnectMonitor: SingleFlightInterval | null = null;
   private pidFileWritten = false;
   private deviceDisconnectMisses: Map<string, number> = new Map();
-  private deviceDisconnectMissIncarnations: Map<string, number> = new Map();
+  private deviceDisconnectMissIncarnations: Map<string, DisconnectCandidateIncarnation> = new Map();
   private confirmedDisconnectedDeviceIds: Set<string> = new Set();
   private forceDisconnectedDeviceIds: Set<string> = new Set();
   private forceDisconnectedDeviceGenerations: Map<string, number> = new Map();
@@ -1244,7 +1248,7 @@ export class Daemon {
         const missingByDevice = new Map<string, string[]>();
         const candidateDeviceIds = new Set<string>();
         const candidatePlatforms = new Map<string, "android" | "ios">();
-        const candidateIncarnations = new Map<string, number>();
+        const candidateIncarnations = recordingCandidateIncarnations(activeRecordings);
         for (const recording of activeRecordings) {
           candidateDeviceIds.add(recording.deviceId);
           candidatePlatforms.set(recording.deviceId, recording.platform);

--- a/src/daemon/daemon.ts
+++ b/src/daemon/daemon.ts
@@ -1381,10 +1381,16 @@ export class Daemon {
     pooledDeviceAtDisconnect: PooledDevice | null,
     deviceId: string
   ): Promise<boolean> {
-    if (
-      !pooledDeviceAtDisconnect ||
-      await this.devicePool.isCurrentDisconnectedDevice(pooledDeviceAtDisconnect)
-    ) {
+    if (!pooledDeviceAtDisconnect) {
+      if (!this.devicePool.getDevice(deviceId)) {
+        return false;
+      }
+      logger.info(
+        `[DisconnectMonitor] Skipping stale disconnect cleanup for recovered device ${deviceId}`
+      );
+      return true;
+    }
+    if (await this.devicePool.isCurrentDisconnectedDevice(pooledDeviceAtDisconnect)) {
       return false;
     }
     logger.info(

--- a/src/daemon/devicePool.ts
+++ b/src/daemon/devicePool.ts
@@ -52,6 +52,8 @@ export class DevicePoolError extends Error {
  * Pooled Device Status
  */
 export type DeviceStatus = "idle" | "busy" | "error";
+type AndroidRediscoveryVerification = "rediscovered" | "not-rediscovered" | "unknown";
+export type CurrentDisconnectStatus = "current" | "recovered" | "unknown";
 export type DeviceRecoveryIneligibilityReason =
   | "disabled"
   | "not-automobile-owned"
@@ -504,7 +506,11 @@ export class DevicePool {
       this.intentionalShutdowns.delete(deviceId);
       return false;
     }
-    if (mayBeStaleSignal && device && (await this.wasRebootedAndroidDeviceRediscovered(device))) {
+    if (
+      mayBeStaleSignal &&
+      device &&
+      (await this.wasRebootedAndroidDeviceRediscovered(device)) !== "not-rediscovered"
+    ) {
       // The intentionally-stopped serial is still (or again) booted, so this
       // disconnect is stale — keep the live device and the marker until a real
       // disconnect for this incarnation arrives.
@@ -536,9 +542,10 @@ export class DevicePool {
       await this.removeDevice(deviceId);
       return;
     }
-    const rediscovered =
-      mayBeStaleSignal && (await this.wasRebootedAndroidDeviceRediscovered(device));
-    if (this.devices.get(deviceId) !== device || rediscovered) {
+    const rediscovery = mayBeStaleSignal
+      ? await this.wasRebootedAndroidDeviceRediscovered(device)
+      : "not-rediscovered";
+    if (this.devices.get(deviceId) !== device || rediscovery !== "not-rediscovered") {
       return;
     }
     if (await this.rebootDisconnectedAndroidDevice(device)) {
@@ -552,9 +559,11 @@ export class DevicePool {
     await this.removeDevice(deviceId);
   }
 
-  private async wasRebootedAndroidDeviceRediscovered(device: PooledDevice): Promise<boolean> {
+  private async wasRebootedAndroidDeviceRediscovered(
+    device: PooledDevice,
+  ): Promise<AndroidRediscoveryVerification> {
     if (!this.getRecoveryPolicy().onLoss || !this.isAutoMobileOwnedAndroidVirtualDevice(device)) {
-      return false;
+      return "not-rediscovered";
     }
     const avdName = device.avdName;
     try {
@@ -564,34 +573,40 @@ export class DevicePool {
         logger.warn(
           `[DevicePool] Retained ${device.id}: Android discovery failed during stale-disconnect check`,
         );
-        return true;
+        return "unknown";
       }
       if (
         !discovery.devices.some((candidate) =>
           this.criteriaMatcher.androidRediscoveryMatches(candidate, device.id, avdName),
         )
       ) {
-        return false;
+        return "not-rediscovered";
       }
       logger.info(
         `[DevicePool] Retained ${device.id}: a rebooted Android emulator is present despite a stale disconnect signal`,
       );
-      return true;
+      return "rediscovered";
     } catch (error) {
       logger.warn(
         `[DevicePool] Could not verify rebooted Android emulator ${device.id}: ${error}`,
         error,
       );
-      return true;
+      return "unknown";
     }
   }
 
-  async isCurrentDisconnectedDevice(device: PooledDevice): Promise<boolean> {
+  async isCurrentDisconnectedDevice(device: PooledDevice): Promise<CurrentDisconnectStatus> {
     if (this.devices.get(device.id) !== device) {
-      return false;
+      return "recovered";
     }
-    const rediscovered = await this.wasRebootedAndroidDeviceRediscovered(device);
-    return this.devices.get(device.id) === device && !rediscovered;
+    const rediscovery = await this.wasRebootedAndroidDeviceRediscovered(device);
+    if (this.devices.get(device.id) !== device) {
+      return "recovered";
+    }
+    if (rediscovery === "unknown") {
+      return "unknown";
+    }
+    return rediscovery === "rediscovered" ? "recovered" : "current";
   }
 
   /** Assign the next monotonic incarnation id for a newly pooled connection. */

--- a/src/daemon/disconnectMonitor.ts
+++ b/src/daemon/disconnectMonitor.ts
@@ -1,5 +1,35 @@
 import type { Platform } from "../models";
 
+export type DisconnectCandidateIncarnation = number | string;
+
+interface RecordingDisconnectCandidate {
+  deviceId: string;
+  recordingId: string;
+}
+
+/**
+ * Derive a stable lifecycle marker for recording-only candidates. A device ID
+ * can be reused immediately after a recording stops, so its active recording
+ * IDs are the only identity evidence available when it is not pooled.
+ */
+export function recordingCandidateIncarnations(
+  recordings: Iterable<RecordingDisconnectCandidate>,
+): Map<string, DisconnectCandidateIncarnation> {
+  const recordingIdsByDevice = new Map<string, string[]>();
+  for (const recording of recordings) {
+    const recordingIds = recordingIdsByDevice.get(recording.deviceId) ?? [];
+    recordingIds.push(recording.recordingId);
+    recordingIdsByDevice.set(recording.deviceId, recordingIds);
+  }
+
+  return new Map(
+    [...recordingIdsByDevice].map(([deviceId, recordingIds]) => [
+      deviceId,
+      `recordings:${recordingIds.sort().join("\u0000")}`,
+    ]),
+  );
+}
+
 export interface DisconnectMonitorEvaluation {
   disconnected: string[];
   missed: Array<{ deviceId: string; misses: number }>;
@@ -13,8 +43,8 @@ export interface DisconnectMonitorEvaluationInput {
   candidateDeviceIds: Set<string>;
   succeededPlatforms: Set<Platform>;
   candidatePlatforms: Map<string, Platform>;
-  candidateIncarnations?: Map<string, number>;
-  deviceDisconnectMissIncarnations?: Map<string, number>;
+  candidateIncarnations?: Map<string, DisconnectCandidateIncarnation>;
+  deviceDisconnectMissIncarnations?: Map<string, DisconnectCandidateIncarnation>;
   forceDisconnectedDeviceIds?: Set<string>;
   missThreshold: number;
 }

--- a/src/daemon/disconnectMonitor.ts
+++ b/src/daemon/disconnectMonitor.ts
@@ -3,7 +3,7 @@ import type { Platform } from "../models";
 export interface DisconnectMonitorEvaluation {
   disconnected: string[];
   missed: Array<{ deviceId: string; misses: number }>;
-  skippedAdbUnreachable: boolean;
+  skippedAllDiscoveryFailed: boolean;
 }
 
 export interface DisconnectMonitorEvaluationInput {
@@ -13,7 +13,6 @@ export interface DisconnectMonitorEvaluationInput {
   candidateDeviceIds: Set<string>;
   succeededPlatforms: Set<Platform>;
   candidatePlatforms: Map<string, Platform>;
-  idleCandidateIds: Set<string>;
   forceDisconnectedDeviceIds?: Set<string>;
   missThreshold: number;
 }
@@ -41,11 +40,15 @@ export function evaluateDeviceDisconnects(
   }
 
   if (disconnected.length > 0) {
-    return { disconnected, missed, skippedAdbUnreachable: false };
+    return { disconnected, missed, skippedAllDiscoveryFailed: false };
   }
 
-  if (input.bootedDeviceIds.size === 0 && input.candidateDeviceIds.size > 0) {
-    return { disconnected, missed, skippedAdbUnreachable: true };
+  if (
+    input.bootedDeviceIds.size === 0 &&
+    input.candidateDeviceIds.size > 0 &&
+    input.succeededPlatforms.size === 0
+  ) {
+    return { disconnected, missed, skippedAllDiscoveryFailed: true };
   }
 
   for (const deviceId of input.candidateDeviceIds) {
@@ -61,11 +64,7 @@ export function evaluateDeviceDisconnects(
     }
 
     const platform = input.candidatePlatforms.get(deviceId);
-    if (
-      platform &&
-      input.idleCandidateIds.has(deviceId) &&
-      !input.succeededPlatforms.has(platform)
-    ) {
+    if (platform && !input.succeededPlatforms.has(platform)) {
       input.deviceDisconnectMisses.delete(deviceId);
       continue;
     }
@@ -81,5 +80,5 @@ export function evaluateDeviceDisconnects(
     }
   }
 
-  return { disconnected, missed, skippedAdbUnreachable: false };
+  return { disconnected, missed, skippedAllDiscoveryFailed: false };
 }

--- a/src/daemon/disconnectMonitor.ts
+++ b/src/daemon/disconnectMonitor.ts
@@ -36,6 +36,7 @@ export function evaluateDeviceDisconnects(
   for (const deviceId of input.deviceDisconnectMisses.keys()) {
     if (!input.candidateDeviceIds.has(deviceId)) {
       clearMiss(deviceId);
+      input.confirmedDisconnectedDeviceIds.delete(deviceId);
     }
   }
 

--- a/src/daemon/disconnectMonitor.ts
+++ b/src/daemon/disconnectMonitor.ts
@@ -33,6 +33,12 @@ export function evaluateDeviceDisconnects(
     deviceDisconnectMissIncarnations.delete(deviceId);
   };
 
+  for (const deviceId of input.confirmedDisconnectedDeviceIds) {
+    if (!input.candidateDeviceIds.has(deviceId)) {
+      input.confirmedDisconnectedDeviceIds.delete(deviceId);
+    }
+  }
+
   for (const deviceId of input.deviceDisconnectMisses.keys()) {
     if (!input.candidateDeviceIds.has(deviceId)) {
       clearMiss(deviceId);

--- a/src/daemon/disconnectMonitor.ts
+++ b/src/daemon/disconnectMonitor.ts
@@ -33,6 +33,12 @@ export function evaluateDeviceDisconnects(
     deviceDisconnectMissIncarnations.delete(deviceId);
   };
 
+  for (const deviceId of input.deviceDisconnectMisses.keys()) {
+    if (!input.candidateDeviceIds.has(deviceId)) {
+      clearMiss(deviceId);
+    }
+  }
+
   for (const deviceId of input.candidateDeviceIds) {
     if (input.bootedDeviceIds.has(deviceId)) {
       clearMiss(deviceId);
@@ -65,6 +71,10 @@ export function evaluateDeviceDisconnects(
       clearMiss(deviceId);
       input.confirmedDisconnectedDeviceIds.delete(deviceId);
       continue;
+    }
+
+    if (candidateIncarnations.has(deviceId)) {
+      input.confirmedDisconnectedDeviceIds.delete(deviceId);
     }
 
     if (input.confirmedDisconnectedDeviceIds.has(deviceId)) {

--- a/src/daemon/disconnectMonitor.ts
+++ b/src/daemon/disconnectMonitor.ts
@@ -13,6 +13,8 @@ export interface DisconnectMonitorEvaluationInput {
   candidateDeviceIds: Set<string>;
   succeededPlatforms: Set<Platform>;
   candidatePlatforms: Map<string, Platform>;
+  candidateIncarnations?: Map<string, number>;
+  deviceDisconnectMissIncarnations?: Map<string, number>;
   forceDisconnectedDeviceIds?: Set<string>;
   missThreshold: number;
 }
@@ -23,17 +25,24 @@ export function evaluateDeviceDisconnects(
   const disconnected: string[] = [];
   const missed: Array<{ deviceId: string; misses: number }> = [];
   const forceDisconnectedDeviceIds = input.forceDisconnectedDeviceIds ?? new Set<string>();
+  const candidateIncarnations = input.candidateIncarnations ?? new Map<string, number>();
+  const deviceDisconnectMissIncarnations =
+    input.deviceDisconnectMissIncarnations ?? new Map<string, number>();
+  const clearMiss = (deviceId: string): void => {
+    input.deviceDisconnectMisses.delete(deviceId);
+    deviceDisconnectMissIncarnations.delete(deviceId);
+  };
 
   for (const deviceId of input.candidateDeviceIds) {
     if (input.bootedDeviceIds.has(deviceId)) {
-      input.deviceDisconnectMisses.delete(deviceId);
+      clearMiss(deviceId);
       input.confirmedDisconnectedDeviceIds.delete(deviceId);
       forceDisconnectedDeviceIds.delete(deviceId);
       continue;
     }
 
     if (forceDisconnectedDeviceIds.has(deviceId)) {
-      input.deviceDisconnectMisses.delete(deviceId);
+      clearMiss(deviceId);
       disconnected.push(deviceId);
       continue;
     }
@@ -53,27 +62,37 @@ export function evaluateDeviceDisconnects(
 
   for (const deviceId of input.candidateDeviceIds) {
     if (input.bootedDeviceIds.has(deviceId)) {
-      input.deviceDisconnectMisses.delete(deviceId);
+      clearMiss(deviceId);
       input.confirmedDisconnectedDeviceIds.delete(deviceId);
       continue;
     }
 
     if (input.confirmedDisconnectedDeviceIds.has(deviceId)) {
-      input.deviceDisconnectMisses.delete(deviceId);
+      clearMiss(deviceId);
       continue;
     }
 
     const platform = input.candidatePlatforms.get(deviceId);
     if (platform && !input.succeededPlatforms.has(platform)) {
-      input.deviceDisconnectMisses.delete(deviceId);
+      clearMiss(deviceId);
       continue;
     }
 
+    const candidateIncarnation = candidateIncarnations.get(deviceId);
+    const priorMisses =
+      candidateIncarnation === deviceDisconnectMissIncarnations.get(deviceId)
+        ? (input.deviceDisconnectMisses.get(deviceId) ?? 0)
+        : 0;
     const misses = Math.min(
-      (input.deviceDisconnectMisses.get(deviceId) ?? 0) + 1,
+      priorMisses + 1,
       input.missThreshold
     );
     input.deviceDisconnectMisses.set(deviceId, misses);
+    if (candidateIncarnation === undefined) {
+      deviceDisconnectMissIncarnations.delete(deviceId);
+    } else {
+      deviceDisconnectMissIncarnations.set(deviceId, candidateIncarnation);
+    }
     missed.push({ deviceId, misses });
     if (misses >= input.missThreshold) {
       disconnected.push(deviceId);

--- a/src/server/deviceLossOutcome.ts
+++ b/src/server/deviceLossOutcome.ts
@@ -1,9 +1,5 @@
 export const DEVICE_LOSS_OUTCOME_CODE = "device_lost";
-const DEVICE_LOSS_ABORT_ERROR = Symbol.for("automobile.device-loss-error");
-
-type DeviceLossAwareAbortSignal = AbortSignal & {
-  [DEVICE_LOSS_ABORT_ERROR]?: DeviceLostError;
-};
+const deviceLossAbortErrors = new WeakMap<AbortSignal, DeviceLostError>();
 
 export interface DeviceLossOutcome {
   code: typeof DEVICE_LOSS_OUTCOME_CODE;
@@ -42,17 +38,17 @@ export function deviceLostErrorFromCancellationReason(reason: string): DeviceLos
 
 /**
  * Bun can report an aborted signal while temporarily hiding `signal.reason`.
- * Track the typed reason by signal so downstream cancellation checks retain the
- * infrastructure outcome in that runtime path.
+ * Keep the typed reason out of the runtime-owned signal object so downstream
+ * cancellation checks retain the infrastructure outcome across runtimes.
  */
 export function rememberDeviceLossAbort(signal: AbortSignal, error: DeviceLostError): void {
-  (signal as DeviceLossAwareAbortSignal)[DEVICE_LOSS_ABORT_ERROR] = error;
+  deviceLossAbortErrors.set(signal, error);
 }
 
 export function deviceLostErrorFromAbortSignal(signal: AbortSignal): DeviceLostError | undefined {
   return isDeviceLostError(signal.reason)
     ? signal.reason
-    : (signal as DeviceLossAwareAbortSignal)[DEVICE_LOSS_ABORT_ERROR];
+    : deviceLossAbortErrors.get(signal);
 }
 
 export function deviceLossOutcomeFromError(

--- a/test/daemon/devicePool.test.ts
+++ b/test/daemon/devicePool.test.ts
@@ -583,7 +583,7 @@ describe("DevicePool", () => {
       }
       devicePool.markIntentionalShutdown(device.id);
 
-      expect(await devicePool.isCurrentDisconnectedDevice(device)).toBe(true);
+      expect(await devicePool.isCurrentDisconnectedDevice(device)).toBe("current");
     });
 
     test("does not accept a different AVD that reuses the disconnected emulator serial", async () => {
@@ -605,7 +605,7 @@ describe("DevicePool", () => {
           createBootedDevice("emulator-5554", "android", "Pixel 9"),
         ];
 
-        expect(await devicePool.isCurrentDisconnectedDevice(disconnected)).toBe(true);
+        expect(await devicePool.isCurrentDisconnectedDevice(disconnected)).toBe("current");
       } finally {
         if (originalRebootOnDeath === undefined) {
           delete process.env.AUTOMOBILE_ANDROID_REBOOT_ON_DEATH;
@@ -648,7 +648,48 @@ describe("DevicePool", () => {
           createBootedDevice("emulator-5554", "android", "Unknown (emulator-5554)"),
         ];
 
-        expect(await devicePool.isCurrentDisconnectedDevice(disconnected)).toBe(false);
+        expect(await devicePool.isCurrentDisconnectedDevice(disconnected)).toBe("recovered");
+      } finally {
+        if (originalRebootOnDeath === undefined) {
+          delete process.env.AUTOMOBILE_ANDROID_REBOOT_ON_DEATH;
+        } else {
+          process.env.AUTOMOBILE_ANDROID_REBOOT_ON_DEATH = originalRebootOnDeath;
+        }
+      }
+    });
+
+    test("reports an unknown disconnect state when Android rediscovery discovery fails", async () => {
+      const originalRebootOnDeath = process.env.AUTOMOBILE_ANDROID_REBOOT_ON_DEATH;
+      process.env.AUTOMOBILE_ANDROID_REBOOT_ON_DEATH = "1";
+      const ready = createBootedDevice("emulator-5554", "android", "Pixel 8");
+      try {
+        devicePool = new DevicePool(
+          sessionManager,
+          "test-daemon-session-id",
+          fakeTimer,
+          fakeAppsRepo,
+          fakeDeviceManager,
+          new DefaultRetryExecutor(fakeTimer),
+          undefined,
+          undefined,
+          undefined,
+          undefined,
+          undefined,
+          { onLoss: true, maxAttempts: 2 },
+        );
+        await devicePool.addDevice(ready, {
+          name: "Pixel 8",
+          platform: "android",
+          isRunning: false,
+          source: "local",
+        });
+        const disconnected = devicePool.getDevice(ready.deviceId);
+        if (!disconnected) {
+          throw new Error("expected disconnected pooled device");
+        }
+        fakeDeviceManager.failedPlatforms = new Set(["android"]);
+
+        expect(await devicePool.isCurrentDisconnectedDevice(disconnected)).toBe("unknown");
       } finally {
         if (originalRebootOnDeath === undefined) {
           delete process.env.AUTOMOBILE_ANDROID_REBOOT_ON_DEATH;
@@ -691,7 +732,7 @@ describe("DevicePool", () => {
 
         manager.releaseDiscovery();
 
-        expect(await validation).toBe(false);
+        expect(await validation).toBe("recovered");
         expect(devicePool.getDevice(ready.deviceId)).toBe(replacement);
       } finally {
         manager.releaseDiscovery();

--- a/test/daemon/sseKeepaliveAndDisconnect.test.ts
+++ b/test/daemon/sseKeepaliveAndDisconnect.test.ts
@@ -361,10 +361,20 @@ describe("disconnect monitor miss counting", () => {
 
   test("clears miss state after a candidate stops being tracked", () => {
     const misses = new Map<string, number>([["sim-1", 2]]);
+    const confirmedDisconnectedDeviceIds = new Set(["sim-1"]);
 
-    runDisconnectPoll(misses, new Set(["emulator-5554"]), new Set(), new Set(["android"]));
+    evaluateDeviceDisconnects({
+      deviceDisconnectMisses: misses,
+      confirmedDisconnectedDeviceIds,
+      bootedDeviceIds: new Set(["emulator-5554"]),
+      candidateDeviceIds: new Set(),
+      succeededPlatforms: new Set(["android" as const]),
+      candidatePlatforms: new Map(),
+      missThreshold: DEVICE_DISCONNECT_MISS_THRESHOLD,
+    });
 
     expect(misses.has("sim-1")).toBe(false);
+    expect(confirmedDisconnectedDeviceIds.has("sim-1")).toBe(false);
   });
 
   test("clears a confirmed marker for a newly pooled candidate", () => {

--- a/test/daemon/sseKeepaliveAndDisconnect.test.ts
+++ b/test/daemon/sseKeepaliveAndDisconnect.test.ts
@@ -359,6 +359,33 @@ describe("disconnect monitor miss counting", () => {
     expect(deviceDisconnectMissIncarnations.get("sim-1")).toBe(2);
   });
 
+  test("clears miss state after a candidate stops being tracked", () => {
+    const misses = new Map<string, number>([["sim-1", 2]]);
+
+    runDisconnectPoll(misses, new Set(["emulator-5554"]), new Set(), new Set(["android"]));
+
+    expect(misses.has("sim-1")).toBe(false);
+  });
+
+  test("clears a confirmed marker for a newly pooled candidate", () => {
+    const confirmedDisconnectedDeviceIds = new Set(["sim-1"]);
+    const misses = new Map<string, number>();
+
+    evaluateDeviceDisconnects({
+      deviceDisconnectMisses: misses,
+      confirmedDisconnectedDeviceIds,
+      bootedDeviceIds: new Set(["emulator-5554"]),
+      candidateDeviceIds: new Set(["sim-1"]),
+      succeededPlatforms: new Set(["android" as const, "ios" as const]),
+      candidatePlatforms: new Map([["sim-1", "ios" as const]]),
+      candidateIncarnations: new Map([["sim-1", 2]]),
+      missThreshold: DEVICE_DISCONNECT_MISS_THRESHOLD,
+    });
+
+    expect(confirmedDisconnectedDeviceIds.has("sim-1")).toBe(false);
+    expect(misses.get("sim-1")).toBe(1);
+  });
+
   test("keeps returning a threshold-missed stale candidate until caller settles cleanup", () => {
     const misses = new Map<string, number>();
     const confirmedDisconnectedDeviceIds = new Set<string>();

--- a/test/daemon/sseKeepaliveAndDisconnect.test.ts
+++ b/test/daemon/sseKeepaliveAndDisconnect.test.ts
@@ -441,11 +441,19 @@ describe("disconnect monitor miss counting", () => {
     expect(confirmedDisconnectedDeviceIds.has("device-1")).toBe(false);
   });
 
-  test("skips cleanup when an absent candidate is pooled before cleanup", async () => {
+  test("clears disconnect state when an absent candidate is pooled before cleanup", async () => {
+    const misses = new Map([["sim-1", DEVICE_DISCONNECT_MISS_THRESHOLD]]);
+    const missIncarnations = new Map([["sim-1", 1]]);
+    const confirmed = new Set(["sim-1"]);
+    const forced = new Set(["sim-1"]);
     const daemon = {
       devicePool: {
         getDevice: () => ({}),
       },
+      deviceDisconnectMisses: misses,
+      deviceDisconnectMissIncarnations: missIncarnations,
+      confirmedDisconnectedDeviceIds: confirmed,
+      forceDisconnectedDeviceIds: forced,
     };
     const shouldSkipStaleDisconnectCleanup = (
       Daemon.prototype as unknown as {
@@ -459,6 +467,40 @@ describe("disconnect monitor miss counting", () => {
     await expect(
       shouldSkipStaleDisconnectCleanup.call(daemon, null, "sim-1"),
     ).resolves.toBe(true);
+    expect(misses.has("sim-1")).toBe(false);
+    expect(missIncarnations.has("sim-1")).toBe(false);
+    expect(confirmed.has("sim-1")).toBe(false);
+    expect(forced.has("sim-1")).toBe(false);
+  });
+
+  test("clears disconnect state when cleanup rediscovers the pooled incarnation", async () => {
+    const misses = new Map([["emulator-5554", DEVICE_DISCONNECT_MISS_THRESHOLD]]);
+    const missIncarnations = new Map([["emulator-5554", 4]]);
+    const daemon = {
+      devicePool: {
+        isCurrentDisconnectedDevice: async () => false,
+      },
+      deviceDisconnectMisses: misses,
+      deviceDisconnectMissIncarnations: missIncarnations,
+      confirmedDisconnectedDeviceIds: new Set(["emulator-5554"]),
+      forceDisconnectedDeviceIds: new Set(["emulator-5554"]),
+    };
+    const shouldSkipStaleDisconnectCleanup = (
+      Daemon.prototype as unknown as {
+        shouldSkipStaleDisconnectCleanup: (
+          pooledDeviceAtDisconnect: object,
+          deviceId: string,
+        ) => Promise<boolean>;
+      }
+    ).shouldSkipStaleDisconnectCleanup;
+
+    await expect(
+      shouldSkipStaleDisconnectCleanup.call(daemon, {}, "emulator-5554"),
+    ).resolves.toBe(true);
+    expect(misses.has("emulator-5554")).toBe(false);
+    expect(missIncarnations.has("emulator-5554")).toBe(false);
+    expect(daemon.confirmedDisconnectedDeviceIds.has("emulator-5554")).toBe(false);
+    expect(daemon.forceDisconnectedDeviceIds.has("emulator-5554")).toBe(false);
   });
 
   test("fires at poll interval using FakeTimer", () => {

--- a/test/daemon/sseKeepaliveAndDisconnect.test.ts
+++ b/test/daemon/sseKeepaliveAndDisconnect.test.ts
@@ -135,8 +135,7 @@ describe("disconnect monitor miss counting", () => {
     candidateDeviceIds: Set<string>,
     succeededPlatforms: Set<string> = new Set(),
     candidatePlatforms: Map<string, string> = new Map(),
-    idleCandidateIds: Set<string> = new Set(),
-  ): { disconnected: string[]; skippedAdbUnreachable: boolean } => {
+  ): { disconnected: string[]; skippedAllDiscoveryFailed: boolean } => {
     return evaluateDeviceDisconnects({
       deviceDisconnectMisses,
       confirmedDisconnectedDeviceIds: new Set(),
@@ -144,7 +143,6 @@ describe("disconnect monitor miss counting", () => {
       candidateDeviceIds,
       succeededPlatforms: succeededPlatforms as Set<"android" | "ios">,
       candidatePlatforms: candidatePlatforms as Map<string, "android" | "ios">,
-      idleCandidateIds,
       missThreshold: DEVICE_DISCONNECT_MISS_THRESHOLD,
     });
   };
@@ -161,7 +159,7 @@ describe("disconnect monitor miss counting", () => {
     const misses = new Map<string, number>();
 
     runDisconnectPoll(misses, new Set(), new Set(["device-1"]));
-    // ADB unreachable guard: 0 booted but 1 tracked → skip
+    // No platform discovery succeeded, so retain the tracked device.
     expect(misses.has("device-1")).toBe(false);
 
     // Simulate ADB returning some devices but not ours
@@ -184,21 +182,75 @@ describe("disconnect monitor miss counting", () => {
     expect(result.disconnected).toEqual(["device-1"]);
   });
 
-  test("skips miss counting when ADB returns 0 devices (unreachable guard)", () => {
+  test("miss-counts an Android candidate when Android discovery succeeds empty", () => {
     const misses = new Map<string, number>();
 
     const result = runDisconnectPoll(
       misses,
       new Set(),
-      new Set(["device-1", "device-2"]),
+      new Set(["device-1"]),
+      new Set(["android"]),
+      new Map([["device-1", "android"]]),
     );
 
-    expect(result.skippedAdbUnreachable).toBe(true);
+    expect(result.skippedAllDiscoveryFailed).toBe(false);
     expect(result.disconnected).toEqual([]);
-    expect(misses.size).toBe(0);
+    expect(misses.get("device-1")).toBe(1);
   });
 
-  test("forced missing devices bypass the zero-device ADB guard", () => {
+  test("miss-counts an iOS candidate when iOS discovery succeeds empty", () => {
+    const misses = new Map<string, number>();
+
+    const result = runDisconnectPoll(
+      misses,
+      new Set(),
+      new Set(["sim-1"]),
+      new Set(["ios"]),
+      new Map([["sim-1", "ios"]]),
+    );
+
+    expect(result.skippedAllDiscoveryFailed).toBe(false);
+    expect(result.disconnected).toEqual([]);
+    expect(misses.get("sim-1")).toBe(1);
+  });
+
+  test("retains candidates without misses when all platform discovery fails", () => {
+    const misses = new Map<string, number>([["device-1", 2]]);
+
+    const result = runDisconnectPoll(
+      misses,
+      new Set(),
+      new Set(["device-1"]),
+      new Set(),
+      new Map([["device-1", "android"]]),
+    );
+
+    expect(result.skippedAllDiscoveryFailed).toBe(true);
+    expect(result.disconnected).toEqual([]);
+    expect(misses.get("device-1")).toBe(2);
+  });
+
+  test("miss-counts only candidates whose platform discovery succeeds", () => {
+    const misses = new Map<string, number>();
+
+    const result = runDisconnectPoll(
+      misses,
+      new Set(),
+      new Set(["device-1", "sim-1"]),
+      new Set(["android"]),
+      new Map([
+        ["device-1", "android"],
+        ["sim-1", "ios"],
+      ]),
+    );
+
+    expect(result.skippedAllDiscoveryFailed).toBe(false);
+    expect(result.disconnected).toEqual([]);
+    expect(misses.get("device-1")).toBe(1);
+    expect(misses.has("sim-1")).toBe(false);
+  });
+
+  test("forced missing devices bypass the all-discovery-failed guard", () => {
     const result = evaluateDeviceDisconnects({
       deviceDisconnectMisses: new Map(),
       confirmedDisconnectedDeviceIds: new Set(),
@@ -207,11 +259,10 @@ describe("disconnect monitor miss counting", () => {
       candidateDeviceIds: new Set(["emulator-5554"]),
       succeededPlatforms: new Set(["android" as const]),
       candidatePlatforms: new Map([["emulator-5554", "android" as const]]),
-      idleCandidateIds: new Set<string>(),
       missThreshold: DEVICE_DISCONNECT_MISS_THRESHOLD,
     });
 
-    expect(result.skippedAdbUnreachable).toBe(false);
+    expect(result.skippedAllDiscoveryFailed).toBe(false);
     expect(result.disconnected).toEqual(["emulator-5554"]);
   });
 
@@ -225,20 +276,19 @@ describe("disconnect monitor miss counting", () => {
       candidateDeviceIds: new Set(["emulator-5554"]),
       succeededPlatforms: new Set(["android" as const]),
       candidatePlatforms: new Map([["emulator-5554", "android" as const]]),
-      idleCandidateIds: new Set<string>(),
       missThreshold: DEVICE_DISCONNECT_MISS_THRESHOLD,
     });
 
-    expect(result.skippedAdbUnreachable).toBe(false);
+    expect(result.skippedAllDiscoveryFailed).toBe(false);
     expect(result.disconnected).toEqual([]);
     expect(forceDisconnectedDeviceIds.has("emulator-5554")).toBe(false);
   });
 
-  test("skips idle candidates from platforms whose discovery did not succeed", () => {
+  test("skips candidates from platforms whose discovery did not succeed", () => {
     const misses = new Map<string, number>();
     misses.set("sim-1", 2);
 
-    // Android discovery succeeded; iOS discovery did not, so the idle iOS
+    // Android discovery succeeded; iOS discovery did not, so the iOS
     // simulator must not be miss-counted toward disconnect.
     const result = runDisconnectPoll(
       misses,
@@ -246,18 +296,17 @@ describe("disconnect monitor miss counting", () => {
       new Set(["sim-1"]),
       new Set(["android"]),
       new Map([["sim-1", "ios"]]),
-      new Set(["sim-1"]),
     );
 
-    expect(result.skippedAdbUnreachable).toBe(false);
+    expect(result.skippedAllDiscoveryFailed).toBe(false);
     expect(result.disconnected).toEqual([]);
     expect(misses.has("sim-1")).toBe(false);
   });
 
-  test("miss-counts an idle device once its platform discovery succeeds", () => {
+  test("miss-counts a device once its platform discovery succeeds", () => {
     const misses = new Map<string, number>();
 
-    // iOS discovery succeeded but reported zero simulators, so an idle iOS
+    // iOS discovery succeeded but reported zero simulators, so an iOS
     // device that is genuinely gone should now be miss-counted.
     const result = runDisconnectPoll(
       misses,
@@ -265,10 +314,9 @@ describe("disconnect monitor miss counting", () => {
       new Set(["sim-1"]),
       new Set(["android", "ios"]),
       new Map([["sim-1", "ios"]]),
-      new Set(["sim-1"]),
     );
 
-    expect(result.skippedAdbUnreachable).toBe(false);
+    expect(result.skippedAllDiscoveryFailed).toBe(false);
     expect(misses.get("sim-1")).toBe(1);
   });
 
@@ -296,7 +344,6 @@ describe("disconnect monitor miss counting", () => {
       candidateDeviceIds: new Set(["device-1"]),
       succeededPlatforms: new Set(["android" as const, "ios" as const]),
       candidatePlatforms: new Map([["device-1", "android" as const]]),
-      idleCandidateIds: new Set<string>(),
       missThreshold: DEVICE_DISCONNECT_MISS_THRESHOLD,
     };
 
@@ -326,7 +373,6 @@ describe("disconnect monitor miss counting", () => {
       candidateDeviceIds: new Set(["device-1"]),
       succeededPlatforms: new Set(["android" as const]),
       candidatePlatforms: new Map([["device-1", "android" as const]]),
-      idleCandidateIds: new Set<string>(),
       missThreshold: DEVICE_DISCONNECT_MISS_THRESHOLD,
     });
 

--- a/test/daemon/sseKeepaliveAndDisconnect.test.ts
+++ b/test/daemon/sseKeepaliveAndDisconnect.test.ts
@@ -1,6 +1,9 @@
 import { describe, expect, test } from "bun:test";
 import { Daemon } from "../../src/daemon/daemon";
-import { evaluateDeviceDisconnects } from "../../src/daemon/disconnectMonitor";
+import {
+  evaluateDeviceDisconnects,
+  recordingCandidateIncarnations,
+} from "../../src/daemon/disconnectMonitor";
 import { FakeTimer } from "../fakes/FakeTimer";
 
 
@@ -357,6 +360,33 @@ describe("disconnect monitor miss counting", () => {
     expect(result.disconnected).toEqual([]);
     expect(misses.get("sim-1")).toBe(1);
     expect(deviceDisconnectMissIncarnations.get("sim-1")).toBe(2);
+  });
+
+  test("does not carry misses to a replacement recording-only lifecycle", () => {
+    const misses = new Map<string, number>([["sim-1", 2]]);
+    const priorIncarnations = recordingCandidateIncarnations([
+      { deviceId: "sim-1", recordingId: "recording-old" },
+    ]);
+    const replacementIncarnations = recordingCandidateIncarnations([
+      { deviceId: "sim-1", recordingId: "recording-new" },
+    ]);
+    const deviceDisconnectMissIncarnations = new Map([
+      ["sim-1", priorIncarnations.get("sim-1")!],
+    ]);
+
+    const result = runDisconnectPoll(
+      misses,
+      new Set(["emulator-5554"]),
+      new Set(["sim-1"]),
+      new Set(["android", "ios"]),
+      new Map([["sim-1", "ios"]]),
+      replacementIncarnations,
+      deviceDisconnectMissIncarnations,
+    );
+
+    expect(result.disconnected).toEqual([]);
+    expect(misses.get("sim-1")).toBe(1);
+    expect(deviceDisconnectMissIncarnations.get("sim-1")).toBe(replacementIncarnations.get("sim-1"));
   });
 
   test("clears miss state after a candidate stops being tracked", () => {

--- a/test/daemon/sseKeepaliveAndDisconnect.test.ts
+++ b/test/daemon/sseKeepaliveAndDisconnect.test.ts
@@ -377,6 +377,22 @@ describe("disconnect monitor miss counting", () => {
     expect(confirmedDisconnectedDeviceIds.has("sim-1")).toBe(false);
   });
 
+  test("clears confirmed state after a recording-only candidate stops being tracked", () => {
+    const confirmedDisconnectedDeviceIds = new Set(["sim-1"]);
+
+    evaluateDeviceDisconnects({
+      deviceDisconnectMisses: new Map(),
+      confirmedDisconnectedDeviceIds,
+      bootedDeviceIds: new Set(["emulator-5554"]),
+      candidateDeviceIds: new Set(),
+      succeededPlatforms: new Set(["android" as const]),
+      candidatePlatforms: new Map(),
+      missThreshold: DEVICE_DISCONNECT_MISS_THRESHOLD,
+    });
+
+    expect(confirmedDisconnectedDeviceIds.has("sim-1")).toBe(false);
+  });
+
   test("clears a confirmed marker for a newly pooled candidate", () => {
     const confirmedDisconnectedDeviceIds = new Set(["sim-1"]);
     const misses = new Map<string, number>();
@@ -454,6 +470,7 @@ describe("disconnect monitor miss counting", () => {
       deviceDisconnectMissIncarnations: missIncarnations,
       confirmedDisconnectedDeviceIds: confirmed,
       forceDisconnectedDeviceIds: forced,
+      forceDisconnectedDeviceGenerations: new Map(),
     };
     const shouldSkipStaleDisconnectCleanup = (
       Daemon.prototype as unknown as {
@@ -484,6 +501,7 @@ describe("disconnect monitor miss counting", () => {
       deviceDisconnectMissIncarnations: missIncarnations,
       confirmedDisconnectedDeviceIds: new Set(["emulator-5554"]),
       forceDisconnectedDeviceIds: new Set(["emulator-5554"]),
+      forceDisconnectedDeviceGenerations: new Map([["emulator-5554", 1]]),
     };
     const shouldSkipStaleDisconnectCleanup = (
       Daemon.prototype as unknown as {
@@ -503,6 +521,45 @@ describe("disconnect monitor miss counting", () => {
     expect(daemon.forceDisconnectedDeviceIds.has("emulator-5554")).toBe(false);
   });
 
+  test("preserves a force signal raised during recovery verification", async () => {
+    let resolveVerification: (() => void) | undefined;
+    const verification = new Promise<void>(resolve => {
+      resolveVerification = resolve;
+    });
+    const forced = new Set<string>();
+    const forceGenerations = new Map<string, number>();
+    const daemon = {
+      devicePool: {
+        isCurrentDisconnectedDevice: async () => {
+          await verification;
+          return "recovered" as const;
+        },
+      },
+      deviceDisconnectMisses: new Map([["emulator-5554", DEVICE_DISCONNECT_MISS_THRESHOLD]]),
+      deviceDisconnectMissIncarnations: new Map([["emulator-5554", 4]]),
+      confirmedDisconnectedDeviceIds: new Set(["emulator-5554"]),
+      forceDisconnectedDeviceIds: forced,
+      forceDisconnectedDeviceGenerations: forceGenerations,
+    };
+    const shouldSkipStaleDisconnectCleanup = (
+      Daemon.prototype as unknown as {
+        shouldSkipStaleDisconnectCleanup: (
+          pooledDeviceAtDisconnect: object,
+          deviceId: string,
+        ) => Promise<boolean>;
+      }
+    ).shouldSkipStaleDisconnectCleanup;
+
+    const pending = shouldSkipStaleDisconnectCleanup.call(daemon, {}, "emulator-5554");
+    forced.add("emulator-5554");
+    forceGenerations.set("emulator-5554", 1);
+    resolveVerification?.();
+
+    await expect(pending).resolves.toBe(true);
+    expect(forced.has("emulator-5554")).toBe(true);
+    expect(forceGenerations.get("emulator-5554")).toBe(1);
+  });
+
   test("retains disconnect state when cleanup verification is inconclusive", async () => {
     const misses = new Map([["emulator-5554", DEVICE_DISCONNECT_MISS_THRESHOLD]]);
     const missIncarnations = new Map([["emulator-5554", 4]]);
@@ -514,6 +571,7 @@ describe("disconnect monitor miss counting", () => {
       deviceDisconnectMissIncarnations: missIncarnations,
       confirmedDisconnectedDeviceIds: new Set(["emulator-5554"]),
       forceDisconnectedDeviceIds: new Set(["emulator-5554"]),
+      forceDisconnectedDeviceGenerations: new Map([["emulator-5554", 1]]),
     };
     const shouldSkipStaleDisconnectCleanup = (
       Daemon.prototype as unknown as {

--- a/test/daemon/sseKeepaliveAndDisconnect.test.ts
+++ b/test/daemon/sseKeepaliveAndDisconnect.test.ts
@@ -478,7 +478,7 @@ describe("disconnect monitor miss counting", () => {
     const missIncarnations = new Map([["emulator-5554", 4]]);
     const daemon = {
       devicePool: {
-        isCurrentDisconnectedDevice: async () => false,
+        isCurrentDisconnectedDevice: async () => "recovered" as const,
       },
       deviceDisconnectMisses: misses,
       deviceDisconnectMissIncarnations: missIncarnations,
@@ -501,6 +501,36 @@ describe("disconnect monitor miss counting", () => {
     expect(missIncarnations.has("emulator-5554")).toBe(false);
     expect(daemon.confirmedDisconnectedDeviceIds.has("emulator-5554")).toBe(false);
     expect(daemon.forceDisconnectedDeviceIds.has("emulator-5554")).toBe(false);
+  });
+
+  test("retains disconnect state when cleanup verification is inconclusive", async () => {
+    const misses = new Map([["emulator-5554", DEVICE_DISCONNECT_MISS_THRESHOLD]]);
+    const missIncarnations = new Map([["emulator-5554", 4]]);
+    const daemon = {
+      devicePool: {
+        isCurrentDisconnectedDevice: async () => "unknown" as const,
+      },
+      deviceDisconnectMisses: misses,
+      deviceDisconnectMissIncarnations: missIncarnations,
+      confirmedDisconnectedDeviceIds: new Set(["emulator-5554"]),
+      forceDisconnectedDeviceIds: new Set(["emulator-5554"]),
+    };
+    const shouldSkipStaleDisconnectCleanup = (
+      Daemon.prototype as unknown as {
+        shouldSkipStaleDisconnectCleanup: (
+          pooledDeviceAtDisconnect: object,
+          deviceId: string,
+        ) => Promise<boolean>;
+      }
+    ).shouldSkipStaleDisconnectCleanup;
+
+    await expect(
+      shouldSkipStaleDisconnectCleanup.call(daemon, {}, "emulator-5554"),
+    ).resolves.toBe(true);
+    expect(misses.get("emulator-5554")).toBe(DEVICE_DISCONNECT_MISS_THRESHOLD);
+    expect(missIncarnations.get("emulator-5554")).toBe(4);
+    expect(daemon.confirmedDisconnectedDeviceIds.has("emulator-5554")).toBe(true);
+    expect(daemon.forceDisconnectedDeviceIds.has("emulator-5554")).toBe(true);
   });
 
   test("fires at poll interval using FakeTimer", () => {

--- a/test/daemon/sseKeepaliveAndDisconnect.test.ts
+++ b/test/daemon/sseKeepaliveAndDisconnect.test.ts
@@ -1,4 +1,5 @@
 import { describe, expect, test } from "bun:test";
+import { Daemon } from "../../src/daemon/daemon";
 import { evaluateDeviceDisconnects } from "../../src/daemon/disconnectMonitor";
 import { FakeTimer } from "../fakes/FakeTimer";
 
@@ -401,6 +402,26 @@ describe("disconnect monitor miss counting", () => {
     });
 
     expect(confirmedDisconnectedDeviceIds.has("device-1")).toBe(false);
+  });
+
+  test("skips cleanup when an absent candidate is pooled before cleanup", async () => {
+    const daemon = {
+      devicePool: {
+        getDevice: () => ({}),
+      },
+    };
+    const shouldSkipStaleDisconnectCleanup = (
+      Daemon.prototype as unknown as {
+        shouldSkipStaleDisconnectCleanup: (
+          pooledDeviceAtDisconnect: null,
+          deviceId: string,
+        ) => Promise<boolean>;
+      }
+    ).shouldSkipStaleDisconnectCleanup;
+
+    await expect(
+      shouldSkipStaleDisconnectCleanup.call(daemon, null, "sim-1"),
+    ).resolves.toBe(true);
   });
 
   test("fires at poll interval using FakeTimer", () => {

--- a/test/daemon/sseKeepaliveAndDisconnect.test.ts
+++ b/test/daemon/sseKeepaliveAndDisconnect.test.ts
@@ -135,6 +135,8 @@ describe("disconnect monitor miss counting", () => {
     candidateDeviceIds: Set<string>,
     succeededPlatforms: Set<string> = new Set(),
     candidatePlatforms: Map<string, string> = new Map(),
+    candidateIncarnations: Map<string, number> = new Map(),
+    deviceDisconnectMissIncarnations: Map<string, number> = new Map(),
   ): { disconnected: string[]; skippedAllDiscoveryFailed: boolean } => {
     return evaluateDeviceDisconnects({
       deviceDisconnectMisses,
@@ -143,6 +145,8 @@ describe("disconnect monitor miss counting", () => {
       candidateDeviceIds,
       succeededPlatforms: succeededPlatforms as Set<"android" | "ios">,
       candidatePlatforms: candidatePlatforms as Map<string, "android" | "ios">,
+      candidateIncarnations,
+      deviceDisconnectMissIncarnations,
       missThreshold: DEVICE_DISCONNECT_MISS_THRESHOLD,
     });
   };
@@ -332,6 +336,26 @@ describe("disconnect monitor miss counting", () => {
 
     runDisconnectPoll(misses, new Set(["other"]), new Set(["device-1"]));
     expect(misses.get("device-1")).toBe(1);
+  });
+
+  test("does not carry misses from a replaced device incarnation", () => {
+    const misses = new Map<string, number>([["sim-1", 2]]);
+    const candidateIncarnations = new Map<string, number>([["sim-1", 2]]);
+    const deviceDisconnectMissIncarnations = new Map<string, number>([["sim-1", 1]]);
+
+    const result = runDisconnectPoll(
+      misses,
+      new Set(["emulator-5554"]),
+      new Set(["sim-1"]),
+      new Set(["android", "ios"]),
+      new Map([["sim-1", "ios"]]),
+      candidateIncarnations,
+      deviceDisconnectMissIncarnations,
+    );
+
+    expect(result.disconnected).toEqual([]);
+    expect(misses.get("sim-1")).toBe(1);
+    expect(deviceDisconnectMissIncarnations.get("sim-1")).toBe(2);
   });
 
   test("keeps returning a threshold-missed stale candidate until caller settles cleanup", () => {


### PR DESCRIPTION
Closes [#5293](https://github.com/kaeawc/auto-mobile/issues/5293)

## Summary

- Count disconnect misses when Android or iOS discovery succeeds with an empty result.
- Keep candidates from failed platform discovery out of miss counting.
- Apply discovery success per platform instead of only to idle pool candidates.

## Root cause

The monitor treated every globally empty discovery result as an ADB outage before considering which platform scans succeeded. A successful empty platform scan therefore could not establish a device miss.

## Impact

Stale device sessions, executions, and pooled devices are now cleaned up after the existing miss threshold when their platform returns a successful empty scan. Failed platform discovery remains non-destructive.

## Validation

- `bun test test/daemon/sseKeepaliveAndDisconnect.test.ts`
- `bun run build`
- `bun run typecheck`
- `bun run turbo:validate` completed lint, build, and all boundary checks; its repository-wide test task was stopped after a shared concurrent test-runner hang outside this change.
