### PR TITLE
fix(daemon): prevent overlapping lifecycle monitor ticks

### DIFF
--- a/src/daemon/SessionHeartbeatMonitor.ts
+++ b/src/daemon/SessionHeartbeatMonitor.ts
@@ -1,6 +1,7 @@
 import { Timer, defaultTimer } from "../utils/SystemTimer";
 import { logger } from "../utils/logger";
 import { getDefaultSessionHeartbeatTimeoutMs, type Session } from "./sessionManager";
+import { SingleFlightInterval } from "./SingleFlightInterval";
 
 /**
  * Minimal view of the session store the heartbeat monitor needs.
@@ -49,7 +50,7 @@ function readPositiveMsEnv(primaryName: string, legacyName: string): number | un
  * the daemon passes its default timer.
  */
 export class SessionHeartbeatMonitor {
-  private timerHandle: NodeJS.Timeout | null = null;
+  private readonly interval: SingleFlightInterval;
   private readonly checkIntervalMs: number;
   private readonly graceMs: number;
   private readonly preFirstHeartbeatGraceMs: number;
@@ -74,27 +75,17 @@ export class SessionHeartbeatMonitor {
     this.defaultHeartbeatTimeoutMs = config.heartbeatTimeoutMs
       ?? readPositiveMsEnv("AUTOMOBILE_SESSION_HEARTBEAT_TIMEOUT_MS", "AUTO_MOBILE_SESSION_HEARTBEAT_TIMEOUT_MS")
       ?? getDefaultSessionHeartbeatTimeoutMs();
+    this.interval = new SingleFlightInterval(this.timer, this.checkIntervalMs, () => this.tickOnce());
   }
 
   start(): void {
-    if (this.timerHandle) {
-      return;
-    }
-    this.timerHandle = this.timer.setInterval(() => {
-      void this.tick();
-    }, this.checkIntervalMs);
-
-    // Allow the process to exit even if the monitor is running.
-    const handle = this.timerHandle as { unref?: () => void };
-    if (handle && typeof handle.unref === "function") {
-      handle.unref();
-    }
+    this.interval.start();
   }
 
-  stop(): void {
-    if (this.timerHandle) {
-      this.timer.clearInterval(this.timerHandle);
-      this.timerHandle = null;
+  async stop(): Promise<void> {
+    const settled = await this.interval.stop();
+    if (!settled) {
+      logger.warn("Session heartbeat monitor did not settle before shutdown timeout");
     }
   }
 
@@ -103,6 +94,10 @@ export class SessionHeartbeatMonitor {
    * Exposed for deterministic testing; also invoked on each interval tick.
    */
   async tick(): Promise<void> {
+    return this.interval.run();
+  }
+
+  private async tickOnce(): Promise<void> {
     const now = this.timer.now();
 
     // Release idle/expired sessions promptly (e.g. autolocked devices whose idle

--- a/src/daemon/SingleFlightInterval.ts
+++ b/src/daemon/SingleFlightInterval.ts
@@ -1,0 +1,109 @@
+import { defaultTimer, type Timer } from "../utils/SystemTimer";
+import { logger } from "../utils/logger";
+
+const DEFAULT_STOP_TIMEOUT_MS = 5_000;
+
+export interface SingleFlightIntervalOptions {
+  /** Maximum time shutdown waits for work already started by an interval tick. */
+  stopTimeoutMs?: number;
+  /** Receives a rejected background tick after its in-flight state is cleared. */
+  onError?: (error: unknown) => void;
+}
+
+/**
+ * Schedules asynchronous work without allowing interval callbacks to overlap.
+ *
+ * The callback is deliberately dropped while a prior invocation is active:
+ * monitors use a completed callback as one polling epoch, so queueing a stale
+ * callback would compress misses immediately after a slow dependency recovers.
+ */
+export class SingleFlightInterval {
+  private intervalHandle: NodeJS.Timeout | null = null;
+  private inFlight: Promise<void> | null = null;
+  private readonly stopTimeoutMs: number;
+  private readonly onError: (error: unknown) => void;
+
+  constructor(
+    private readonly timer: Timer = defaultTimer,
+    private readonly intervalMs: number,
+    private readonly task: () => Promise<void>,
+    options: SingleFlightIntervalOptions = {},
+  ) {
+    this.stopTimeoutMs = options.stopTimeoutMs ?? DEFAULT_STOP_TIMEOUT_MS;
+    this.onError = options.onError ?? (error => {
+      logger.error("[SingleFlightInterval] Background tick failed", error);
+    });
+  }
+
+  start(): void {
+    if (this.intervalHandle) {
+      return;
+    }
+    this.intervalHandle = this.timer.setInterval(() => {
+      void this.run();
+    }, this.intervalMs);
+
+    const handle = this.intervalHandle as { unref?: () => void };
+    if (typeof handle.unref === "function") {
+      handle.unref();
+    }
+  }
+
+  /** Run one polling epoch, sharing an already-active invocation if present. */
+  run(): Promise<void> {
+    if (this.inFlight) {
+      return this.inFlight;
+    }
+
+    let inFlight: Promise<void>;
+    try {
+      inFlight = this.task();
+    } catch (error) {
+      inFlight = Promise.reject(error);
+    }
+    this.inFlight = inFlight;
+    void inFlight.then(
+      () => this.clearInFlight(inFlight),
+      error => {
+        this.clearInFlight(inFlight);
+        this.onError(error);
+      },
+    );
+    return inFlight;
+  }
+
+  /** Stop future ticks and wait a bounded amount of time for the current one. */
+  async stop(): Promise<boolean> {
+    if (this.intervalHandle) {
+      this.timer.clearInterval(this.intervalHandle);
+      this.intervalHandle = null;
+    }
+    return this.awaitInFlightTick();
+  }
+
+  private async awaitInFlightTick(): Promise<boolean> {
+    const activeTick = this.inFlight;
+    if (!activeTick) {
+      return true;
+    }
+
+    let timeoutHandle: NodeJS.Timeout | undefined;
+    const timeout = new Promise<boolean>(resolve => {
+      timeoutHandle = this.timer.setTimeout(() => resolve(false), this.stopTimeoutMs);
+    });
+
+    try {
+      return await Promise.race([activeTick.then(() => true, () => true), timeout]);
+    } finally {
+      if (timeoutHandle) {
+        this.timer.clearTimeout(timeoutHandle);
+      }
+    }
+  }
+
+  private clearInFlight(inFlight: Promise<void>): void {
+    if (this.inFlight === inFlight) {
+      this.inFlight = null;
+    }
+  }
+}

--- a/src/daemon/daemon.ts
+++ b/src/daemon/daemon.ts
@@ -6,6 +6,7 @@ import { MultiPlatformDeviceManager } from "../utils/deviceUtils";
 import { UnixSocketServer } from "./socketServer";
 import { SessionManager } from "./sessionManager";
 import { SessionHeartbeatMonitor } from "./SessionHeartbeatMonitor";
+import { SingleFlightInterval } from "./SingleFlightInterval";
 import { DevicePool, type PooledDevice } from "./devicePool";
 import { parseDeviceRecoveryPolicy } from "./poolConfig";
 import { DaemonState } from "./daemonState";
@@ -135,7 +136,7 @@ export class Daemon {
   private debug: boolean;
   private healthCheckTimer: NodeJS.Timeout | null = null;
   private heartbeatMonitor: SessionHeartbeatMonitor | null = null;
-  private deviceDisconnectTimer: NodeJS.Timeout | null = null;
+  private deviceDisconnectMonitor: SingleFlightInterval | null = null;
   private pidFileWritten = false;
   private deviceDisconnectMisses: Map<string, number> = new Map();
   private confirmedDisconnectedDeviceIds: Set<string> = new Set();
@@ -1138,13 +1139,13 @@ export class Daemon {
   }
 
   private startDeviceDisconnectMonitor(): void {
-    if (this.deviceDisconnectTimer) {
+    if (this.deviceDisconnectMonitor) {
       return;
     }
 
     const deviceManager = new MultiPlatformDeviceManager();
 
-    this.deviceDisconnectTimer = defaultTimer.setInterval(async () => {
+    this.deviceDisconnectMonitor = new SingleFlightInterval(this.timer, DEVICE_DISCONNECT_POLL_INTERVAL_MS, async () => {
       try {
         if (serverConfig.isPlanExecutionActive()) {
           logger.debug("[DisconnectMonitor] Skipping — plan execution active");
@@ -1295,9 +1296,8 @@ export class Daemon {
       } catch (error) {
         logger.warn(`[Daemon] Device disconnect monitor failed: ${error}`);
       }
-    }, DEVICE_DISCONNECT_POLL_INTERVAL_MS);
-
-    this.deviceDisconnectTimer.unref();
+    });
+    this.deviceDisconnectMonitor.start();
   }
 
   private async shouldSkipStaleDisconnectCleanup(
@@ -1584,13 +1584,19 @@ export class Daemon {
 
     // Clear health check timer
     this.stopHealthCheckTimer();
-    if (this.heartbeatMonitor) {
-      this.heartbeatMonitor.stop();
-      this.heartbeatMonitor = null;
+    const heartbeatMonitor = this.heartbeatMonitor;
+    this.heartbeatMonitor = null;
+    const deviceDisconnectMonitor = this.deviceDisconnectMonitor;
+    this.deviceDisconnectMonitor = null;
+    const [heartbeatSettled, disconnectSettled] = await Promise.all([
+      heartbeatMonitor ? heartbeatMonitor.stop().then(() => true) : true,
+      deviceDisconnectMonitor ? deviceDisconnectMonitor.stop() : true,
+    ]);
+    if (!heartbeatSettled) {
+      logger.warn("Session heartbeat monitor did not settle before daemon shutdown");
     }
-    if (this.deviceDisconnectTimer) {
-      clearInterval(this.deviceDisconnectTimer);
-      this.deviceDisconnectTimer = null;
+    if (!disconnectSettled) {
+      logger.warn("Device disconnect monitor did not settle before daemon shutdown");
     }
     if (this.unsubscribeAdbMissingDevice) {
       this.unsubscribeAdbMissingDevice();

--- a/test/daemon/SessionHeartbeatMonitor.test.ts
+++ b/test/daemon/SessionHeartbeatMonitor.test.ts
@@ -188,10 +188,46 @@ describe("SessionHeartbeatMonitor", () => {
       await Promise.resolve();
       expect(reaped).toEqual([]);
 
-      timer.advanceTime(2);
+      // FakeTimer catches up interval callbacks synchronously. Drive each
+      // scheduled epoch separately so a completed async tick gets its normal
+      // event-loop turn before the next interval callback.
+      timer.advanceTime(1);
+      await Promise.resolve();
+      timer.advanceTime(1);
       await Promise.resolve();
       expect(reaped).toEqual(["s1"]);
       monitor.stop();
+    });
+
+    it("does not overlap a heartbeat reap with the next interval tick", async () => {
+      await sessionManager.createSession("s1", "emulator-5554", "android", 60_000);
+      let resolveReap!: () => void;
+      const blockedReap = new Promise<void>(resolve => { resolveReap = resolve; });
+      let reapCount = 0;
+      const monitor = new SessionHeartbeatMonitor(
+        sessionManager,
+        () => false,
+        async () => {
+          reapCount++;
+          return blockedReap;
+        },
+        timer,
+        { checkIntervalMs: 1, preFirstHeartbeatGraceMs: 0 },
+      );
+
+      monitor.start();
+      timer.advanceTime(1);
+      expect(reapCount).toBe(1);
+
+      timer.advanceTime(1);
+      expect(reapCount).toBe(1);
+
+      resolveReap();
+      await new Promise<void>(resolve => setImmediate(resolve));
+      timer.advanceTime(1);
+      expect(reapCount).toBe(2);
+
+      await monitor.stop();
     });
   });
 

--- a/test/daemon/SingleFlightInterval.test.ts
+++ b/test/daemon/SingleFlightInterval.test.ts
@@ -1,0 +1,111 @@
+import { describe, expect, test } from "bun:test";
+import { SingleFlightInterval } from "../../src/daemon/SingleFlightInterval";
+import { FakeTimer } from "../fakes/FakeTimer";
+
+function deferred(): { promise: Promise<void>; resolve: () => void } {
+  let resolve!: () => void;
+  const promise = new Promise<void>(done => {
+    resolve = done;
+  });
+  return { promise, resolve };
+}
+
+describe("SingleFlightInterval", () => {
+  test("drops an interval tick while the previous tick is still active", async () => {
+    const timer = new FakeTimer();
+    const firstTick = deferred();
+    let starts = 0;
+    const interval = new SingleFlightInterval(timer, 5_000, () => {
+      starts++;
+      return starts === 1 ? firstTick.promise : Promise.resolve();
+    });
+
+    interval.start();
+    timer.advanceTime(5_000);
+    expect(starts).toBe(1);
+
+    // A slow poll must not create a second, concurrent polling epoch.
+    timer.advanceTime(5_000);
+    expect(starts).toBe(1);
+
+    firstTick.resolve();
+    await Promise.resolve();
+    await Promise.resolve();
+
+    timer.advanceTime(5_000);
+    expect(starts).toBe(2);
+    await interval.stop();
+  });
+
+  test("stops scheduling and waits for an active tick to settle", async () => {
+    const timer = new FakeTimer();
+    const activeTick = deferred();
+    let starts = 0;
+    const interval = new SingleFlightInterval(
+      timer,
+      5_000,
+      () => {
+        starts++;
+        return activeTick.promise;
+      },
+      { stopTimeoutMs: 10_000 },
+    );
+
+    interval.start();
+    timer.advanceTime(5_000);
+    const stopped = interval.stop();
+
+    expect(timer.getPendingIntervalCount()).toBe(0);
+    timer.advanceTime(5_000);
+    expect(starts).toBe(1);
+
+    activeTick.resolve();
+    await expect(stopped).resolves.toBe(true);
+  });
+
+  test("bounds shutdown when an active tick does not settle", async () => {
+    const timer = new FakeTimer();
+    const activeTick = deferred();
+    const interval = new SingleFlightInterval(
+      timer,
+      5_000,
+      () => activeTick.promise,
+      { stopTimeoutMs: 50 },
+    );
+
+    interval.start();
+    timer.advanceTime(5_000);
+    const stopped = interval.stop();
+
+    timer.advanceTime(49);
+    let settled = false;
+    void stopped.then(() => { settled = true; });
+    await Promise.resolve();
+    expect(settled).toBe(false);
+
+    timer.advanceTime(1);
+    await expect(stopped).resolves.toBe(false);
+  });
+
+  test("reports a rejected active tick and treats it as settled during shutdown", async () => {
+    const timer = new FakeTimer();
+    let rejectTick!: (error: Error) => void;
+    const activeTick = new Promise<void>((_resolve, reject) => { rejectTick = reject; });
+    const errors: Error[] = [];
+    const interval = new SingleFlightInterval(
+      timer,
+      5_000,
+      () => activeTick,
+      { onError: error => { errors.push(error as Error); } },
+    );
+
+    interval.start();
+    timer.advanceTime(5_000);
+    const stopped = interval.stop();
+    const failure = new Error("reap failed");
+    rejectTick(failure);
+
+    await expect(stopped).resolves.toBe(true);
+    expect(errors).toEqual([failure]);
+  });
+});


### PR DESCRIPTION
## Summary

Prevents the daemon's device-disconnect and session-heartbeat interval callbacks from overlapping. Both monitors now share an injected single-flight interval lifecycle that drops stale scheduled ticks, reports rejected background work, and bounds shutdown waiting after future scheduling is stopped.

The root cause was independent async `setInterval` callbacks: a slow discovery, cleanup, or reap operation could still be active when the next interval began, compressing miss epochs and duplicating cleanup. The new helper uses the existing `Timer` seam and has two production consumers; no dependency was added.

## Linked Issue

Closes #5295

## Bug / Regression Context

- **Prior attempts:** None.
- **Observed symptom:** Slow disconnect discovery or heartbeat reaping could run concurrently with a later scheduled tick and continue during daemon shutdown.
- **Repro steps / conditions:** Block one monitor tick past its next interval.

## Validation

- [x] `bun run turbo:validate` — 13,126 passed; 13 expected device-dependent skips.
- [x] `bun run typecheck` reports no new errors (185 known baseline errors).
- [x] Focused `SingleFlightInterval` and `SessionHeartbeatMonitor` tests use `FakeTimer` and deferred promises to prove no overlap and bounded shutdown.
- [x] No new dependency; reused the existing injectable `Timer` seam for two real monitor consumers.
- [x] Rebased onto latest `main`, conflicts resolved.
