### PR TITLE
fix(ios): exclude unavailable simulator images from auto-start

### DIFF
--- a/src/utils/DeviceSessionManager.ts
+++ b/src/utils/DeviceSessionManager.ts
@@ -910,16 +910,19 @@ export class DeviceSessionManager implements DeviceSessionManager {
     const perf = createGlobalPerformanceTracker();
 
     perf.startOperation("listSimulators");
-    const allDevices = await this.simctl.listSimulatorImages();
+    const simulatorImages = await this.simctl.listSimulatorImages();
     perf.endOperation("listSimulators");
-    allDevices.sort((a, b) => (a.deviceId || "").localeCompare(b.deviceId || ""));
+    const unavailableDevices = simulatorImages.filter(device => device.isAvailable === false);
+    const availableDevices = simulatorImages
+      .filter(device => device.isAvailable !== false)
+      .sort((a, b) => (a.deviceId || "").localeCompare(b.deviceId || ""));
 
-    if (allDevices.length === 0) {
+    if (availableDevices.length === 0) {
       // No CLI flag reaches this path, so the opt-in is env-var only here.
       const gate = getDeviceCreationGate();
       if (gate.isCreationAllowed()) {
         logger.info(
-          `[DeviceSessionManager] No iOS simulators found; creating one (gate: ${gate.describeSource()})`
+          `[DeviceSessionManager] No available iOS simulators found; creating one (gate: ${gate.describeSource()})`
         );
         const provisioner = createDefaultDeviceProvisioner(() => this.simctl);
         const provisioned = await provisioner.provision({ platform: "ios" });
@@ -930,6 +933,13 @@ export class DeviceSessionManager implements DeviceSessionManager {
         await this.verifyIosDevice(provisioned.deviceId!, options);
         perf.endOperation("verifyDevice");
         return createdDevice;
+      }
+
+      if (unavailableDevices.length > 0) {
+        const diagnostics = unavailableDevices
+          .map(device => `${device.name} (${device.deviceId ?? "unknown ID"}): ${device.availabilityError ?? "unavailable"}`)
+          .join("; ");
+        throw new ActionableError(`No available iOS simulators. Unavailable simulators: ${diagnostics}.`);
       }
 
       throw new ActionableError(
@@ -954,7 +964,7 @@ export class DeviceSessionManager implements DeviceSessionManager {
     }
 
     // No booted devices - boot the first available simulator
-    const device = allDevices[0];
+    const device = availableDevices[0];
     const deviceId = device.deviceId!;
     logger.info(`[DeviceSessionManager] Booting iOS simulator ${device.name} (${deviceId})...`);
 

--- a/test/utils/DeviceSessionManager.createIfMissing.test.ts
+++ b/test/utils/DeviceSessionManager.createIfMissing.test.ts
@@ -6,7 +6,7 @@ import { FakeDeviceClientProvider } from "../fakes/FakeDeviceClientProvider";
 import { FakeDeviceCreationGate } from "../fakes/FakeDeviceCreationGate";
 import { resetDeviceCreationGate, setDeviceCreationGate } from "../../src/utils/deviceCreationGate";
 import type { SimCtlClient } from "../../src/utils/ios-cmdline-tools/SimCtlClient";
-import type { BootedDevice } from "../../src/models";
+import type { BootedDevice, DeviceInfo } from "../../src/models";
 
 interface SimctlRecorder {
   createCalls: { name: string; deviceType: string; runtime: string }[];
@@ -14,12 +14,12 @@ interface SimctlRecorder {
 }
 
 /**
- * Minimal simctl stub reporting an EMPTY simulator list — the condition that
- * makes findOrStartIosDevice either throw or (when gated on) provision.
+ * Minimal injected simctl fake. It never reaches a real simulator, and records
+ * the creation and boot decisions made by findOrStartIosDevice.
  */
-function makeEmptySimctl(recorder: SimctlRecorder): SimCtlClient {
+function makeSimctl(recorder: SimctlRecorder, simulatorImages: DeviceInfo[] = []): SimCtlClient {
   return {
-    listSimulatorImages: async () => [],
+    listSimulatorImages: async () => simulatorImages,
     getBootedSimulators: async () => [],
     getDeviceTypes: async () => [
       {
@@ -45,6 +45,22 @@ function makeEmptySimctl(recorder: SimctlRecorder): SimCtlClient {
   } as unknown as SimCtlClient;
 }
 
+function simulatorImage(
+  deviceId: string,
+  isAvailable: boolean,
+  availabilityError?: string,
+): DeviceInfo {
+  return {
+    name: `iPhone ${deviceId}`,
+    platform: "ios",
+    isRunning: false,
+    deviceId,
+    state: "Shutdown",
+    isAvailable,
+    availabilityError,
+  };
+}
+
 describe("findOrStartIosDevice creation gate", () => {
   let recorder: SimctlRecorder;
   let manager: DeviceSessionManager;
@@ -54,7 +70,7 @@ describe("findOrStartIosDevice creation gate", () => {
     const provider = new FakeDeviceClientProvider(
       new FakeAdbExecutor(),
       new FakeDeviceUtils(),
-      makeEmptySimctl(recorder),
+      makeSimctl(recorder),
     );
     manager = new DeviceSessionManager(provider);
   });
@@ -92,5 +108,52 @@ describe("findOrStartIosDevice creation gate", () => {
 
     await expect(manager.findOrStartIosDevice()).rejects.toThrow(/No iOS simulators are available/);
     expect(gate.calls).toEqual([undefined]);
+  });
+
+  test("boots an available simulator when an unavailable one sorts first", async () => {
+    const provider = new FakeDeviceClientProvider(
+      new FakeAdbExecutor(),
+      new FakeDeviceUtils(),
+      makeSimctl(recorder, [
+        simulatorImage("000-unavailable", false, "runtime unavailable"),
+        simulatorImage("999-available", true),
+      ]),
+    );
+    manager = new DeviceSessionManager(provider);
+
+    await manager.findOrStartIosDevice();
+
+    expect(recorder.bootCalls).toEqual(["999-available"]);
+  });
+
+  test("provisions a replacement when every simulator image is unavailable and creation is enabled", async () => {
+    const provider = new FakeDeviceClientProvider(
+      new FakeAdbExecutor(),
+      new FakeDeviceUtils(),
+      makeSimctl(recorder, [simulatorImage("unavailable", false, "runtime unavailable")]),
+    );
+    manager = new DeviceSessionManager(provider);
+    setDeviceCreationGate(new FakeDeviceCreationGate(true));
+
+    await manager.findOrStartIosDevice();
+
+    expect(recorder.createCalls).toHaveLength(1);
+    expect(recorder.bootCalls).toEqual(["CREATED-UDID"]);
+  });
+
+  test("reports unavailable simulator diagnostics when creation is disabled", async () => {
+    const provider = new FakeDeviceClientProvider(
+      new FakeAdbExecutor(),
+      new FakeDeviceUtils(),
+      makeSimctl(recorder, [simulatorImage("unavailable", false, "runtime unavailable")]),
+    );
+    manager = new DeviceSessionManager(provider);
+    setDeviceCreationGate(new FakeDeviceCreationGate(false));
+
+    await expect(manager.findOrStartIosDevice()).rejects.toThrow(
+      "No available iOS simulators. Unavailable simulators: iPhone unavailable (unavailable): runtime unavailable."
+    );
+    expect(recorder.createCalls).toEqual([]);
+    expect(recorder.bootCalls).toEqual([]);
   });
 });


### PR DESCRIPTION
## Summary

- Exclude unavailable iOS simulator images before auto-start selects or counts candidates.
- Reuse the existing create-if-missing flow when every listed simulator is unavailable.
- Include unavailable simulator names, IDs, and CoreSimulator availability errors when creation is disabled.

## Root cause

Auto-start sorted and selected every image returned by `simctl`, including images marked unavailable. An unavailable image with an earlier UDID could therefore be booted, and an unavailable-only list prevented the existing provisioning path from running.

## Validation

- `bun test test/utils/DeviceSessionManager.createIfMissing.test.ts`
- `bun run typecheck`
- `bun run turbo:validate`

Closes [#5279](https://github.com/kaeawc/auto-mobile/issues/5279)
