### PR TITLE
fix(stdio): run cleanup when stdin closes

### DIFF
--- a/src/daemon/daemon.ts
+++ b/src/daemon/daemon.ts
@@ -189,8 +189,11 @@ export class Daemon {
     this.startupFailureTracker = startupFailureTracker;
     this.recoverFromDatabaseHealthFailure = recoverFromDatabaseHealthFailure ?? (async code => {
       cleanupDaemonFilesSync(this.getDaemonFileCleanupOptions());
-      await logger.closeAfterFlush();
-      process.exit(code);
+      try {
+        await logger.closeAfterFlush();
+      } finally {
+        process.exit(code);
+      }
     });
     this.observationStreamHealth = new DefaultObservationStreamHealth({
       getServer: getDeviceDataStreamServer,

--- a/src/daemon/daemon.ts
+++ b/src/daemon/daemon.ts
@@ -117,7 +117,7 @@ const DB_WRITE_DRAIN_TIMEOUT_MS = 1_000;
 const MIGRATION_SETTLE_TIMEOUT_MS = 5_000;
 
 type HealthFailureKind = "http" | "socket" | "database" | "unknown";
-type DatabaseHealthFailureRecovery = (code: number) => void;
+type DatabaseHealthFailureRecovery = (code: number) => void | Promise<void>;
 
 /**
  * Main daemon process
@@ -187,9 +187,9 @@ export class Daemon {
     this.databaseInitializer = databaseInitializer;
     this.databaseHealthProbe = databaseHealthProbe;
     this.startupFailureTracker = startupFailureTracker;
-    this.recoverFromDatabaseHealthFailure = recoverFromDatabaseHealthFailure ?? (code => {
+    this.recoverFromDatabaseHealthFailure = recoverFromDatabaseHealthFailure ?? (async code => {
       cleanupDaemonFilesSync(this.getDaemonFileCleanupOptions());
-      logger.close();
+      await logger.closeAfterFlush();
       process.exit(code);
     });
     this.observationStreamHealth = new DefaultObservationStreamHealth({
@@ -1401,7 +1401,7 @@ export class Daemon {
 
       if (failureKind === "database") {
         logger.error("Database health check failed repeatedly; exiting daemon for a clean restart.");
-        this.recoverFromDatabaseHealthFailure(1);
+        await this.recoverFromDatabaseHealthFailure(1);
         return;
       }
 

--- a/src/index.ts
+++ b/src/index.ts
@@ -150,7 +150,7 @@ async function main() {
       ],
       (message, error) => logger.warn(message, error),
     );
-  });
+  }, () => logger.closeAfterFlush());
 
   try {
     // Parse command line arguments

--- a/src/index.ts
+++ b/src/index.ts
@@ -34,6 +34,7 @@ import { parseArgs } from "./cli/parseArgs";
 import {
   installProcessLifecycleHandlers,
   installStdinShutdownHandlers,
+  runAllCleanupOperations,
   setFatalProcessHandler,
   setProcessShutdownHandler,
 } from "./processLifecycle";

--- a/src/index.ts
+++ b/src/index.ts
@@ -34,7 +34,6 @@ import { parseArgs } from "./cli/parseArgs";
 import {
   installProcessLifecycleHandlers,
   installStdinShutdownHandlers,
-  runAllCleanupOperations,
   setFatalProcessHandler,
   setProcessShutdownHandler,
 } from "./processLifecycle";
@@ -43,7 +42,7 @@ import { startStartupMaintenance } from "./utils/startupMaintenance";
 
 interface FatalLogger {
   error(...args: unknown[]): void;
-  close(): Promise<void>;
+  closeAfterFlush(): Promise<void>;
 }
 
 let fatalLogger: FatalLogger | undefined;
@@ -604,7 +603,7 @@ if (import.meta.main) {
   main().catch(async (err) => {
     console.error("Fatal error in main():", err);
     fatalLogger?.error("Fatal error in main():", err);
-    await fatalLogger?.close();
+    await fatalLogger?.closeAfterFlush();
     // An incomplete-extraction startup failure exits with a distinct, recoverable
     // code (EX_TEMPFAIL) so a wrapper can re-extract and retry (issue #2833);
     // every other fatal keeps exit 1. Resolved lazily to match this file's

--- a/src/index.ts
+++ b/src/index.ts
@@ -126,7 +126,9 @@ async function main() {
   const { startWebRtcStreamSocketServer, stopWebRtcStreamSocketServer } = webrtcStreamSocketServer;
   const { startAppearanceSyncScheduler, stopAppearanceSyncScheduler } = appearanceSyncScheduler;
   let stdioProxy: { close(): Promise<void> } | undefined;
+  let shutdownCleanupFailed = false;
   setProcessShutdownHandler(async (signal) => {
+    shutdownCleanupFailed = false;
     logger.info(`Received ${signal} signal, shutting down`);
     await runShutdownCleanupStages(
       [
@@ -148,9 +150,15 @@ async function main() {
           },
         },
       ],
-      (message, error) => logger.warn(message, error),
+      (message, error) => {
+        shutdownCleanupFailed = true;
+        logger.warn(message, error);
+      },
     );
-  }, () => logger.closeAfterFlush());
+  }, async () => {
+    await logger.closeAfterFlush();
+    return shutdownCleanupFailed ? { exitCode: 1 } : undefined;
+  });
 
   try {
     // Parse command line arguments

--- a/src/index.ts
+++ b/src/index.ts
@@ -43,7 +43,7 @@ import { startStartupMaintenance } from "./utils/startupMaintenance";
 
 interface FatalLogger {
   error(...args: unknown[]): void;
-  close(): void;
+  close(): Promise<void>;
 }
 
 let fatalLogger: FatalLogger | undefined;
@@ -471,7 +471,7 @@ async function main() {
       await runDaemonCommand(daemonCommand, daemonArgs);
       // Exit explicitly after daemon command completes to prevent process from hanging
       // Same issue as CLI mode - event loop may have pending operations
-      logger.close();
+      await logger.closeAfterFlush();
       process.exit(0);
     }
 
@@ -528,7 +528,7 @@ async function main() {
       // CRITICAL: Exit explicitly after CLI command completes to prevent process from hanging
       // The event loop may have pending operations (ADB connections, file descriptors) that
       // prevent Node.js from exiting naturally. Force exit with code 0 to ensure clean termination.
-      logger.close();
+      await logger.closeAfterFlush();
       process.exit(0);
     } else {
       // In proxy mode (default), the MCP server proxies requests to the daemon
@@ -604,7 +604,7 @@ if (import.meta.main) {
   main().catch(async (err) => {
     console.error("Fatal error in main():", err);
     fatalLogger?.error("Fatal error in main():", err);
-    fatalLogger?.close();
+    await fatalLogger?.close();
     // An incomplete-extraction startup failure exits with a distinct, recoverable
     // code (EX_TEMPFAIL) so a wrapper can re-extract and retry (issue #2833);
     // every other fatal keeps exit 1. Resolved lazily to match this file's

--- a/src/index.ts
+++ b/src/index.ts
@@ -33,6 +33,7 @@ import { EVENT_ALL_MARKERS_FLAG } from "./utils/eventAllMarkers";
 import { parseArgs } from "./cli/parseArgs";
 import {
   installProcessLifecycleHandlers,
+  installStdinShutdownHandlers,
   setFatalProcessHandler,
   setProcessShutdownHandler,
 } from "./processLifecycle";
@@ -123,6 +124,7 @@ async function main() {
   const { startAppearanceSocketServer, stopAppearanceSocketServer } = appearanceSocketServer;
   const { startWebRtcStreamSocketServer, stopWebRtcStreamSocketServer } = webrtcStreamSocketServer;
   const { startAppearanceSyncScheduler, stopAppearanceSyncScheduler } = appearanceSyncScheduler;
+  let stdioProxy: { close(): Promise<void> } | undefined;
   setProcessShutdownHandler(async (signal) => {
     logger.info(`Received ${signal} signal, shutting down`);
     await runShutdownCleanupStages(
@@ -137,6 +139,7 @@ async function main() {
           name: "prefetched Android CtrlProxy APK",
           run: AndroidCtrlProxyManager.cleanupPrefetchedApk,
         },
+        { name: "stdio proxy", run: async () => await stdioProxy?.close() },
         {
           name: "logger",
           run: async () => {
@@ -538,21 +541,12 @@ async function main() {
       }
 
       // Detect when the MCP client disconnects (stdin closes / pipe breaks).
-      // Without this, the bun process stays alive indefinitely as an orphan
-      // when the client (Claude Code, Cursor, etc.) exits or crashes.
-      const shutdownOnStdinClose = () => {
-        logger.info("stdin closed — MCP client disconnected, shutting down");
-        logger.close();
-        process.exit(0);
-      };
-      process.stdin.on("end", shutdownOnStdinClose);
-      process.stdin.on("error", shutdownOnStdinClose);
-      process.stdin.on("close", shutdownOnStdinClose);
+      // This uses the shared lifecycle handler so resources close before exit.
+      installStdinShutdownHandlers();
 
       // Run as MCP server with STDIO transport
       const stdioTransport = new StdioServerTransport();
       let server;
-      let stdioProxy: ReturnType<typeof createProxyMcpServer>["proxy"] | undefined;
       try {
         if (useProxyMode) {
           const result = createProxyMcpServer({
@@ -584,14 +578,6 @@ async function main() {
           transport: "stdio",
           mode: useProxyMode ? "proxy" : "direct",
         });
-
-        // Register cleanup for proxy mode
-        if (stdioProxy) {
-          const cleanupProxy = async () => {
-            await stdioProxy!.close();
-          };
-          process.on("beforeExit", cleanupProxy);
-        }
       } catch (error) {
         logger.error("MCP server connect failed:", error);
         throw error;

--- a/src/processLifecycle.ts
+++ b/src/processLifecycle.ts
@@ -141,7 +141,7 @@ export class ProcessLifecycleHandlers {
       let exitCode = 0;
       if (!shutdownCompleted) {
         console.error(`Shutdown timed out after ${this.shutdownTimeoutMs}ms; forcing exit`);
-        exitCode = (await this.runShutdownTimeoutHandler())?.exitCode ?? 0;
+        exitCode = (await this.runShutdownTimeoutHandler())?.exitCode ?? 1;
       }
       this.lifecycleProcess.exit(exitCode);
     } catch (error) {

--- a/src/processLifecycle.ts
+++ b/src/processLifecycle.ts
@@ -13,9 +13,13 @@ export type ShutdownCleanupOperation = () => void | Promise<void>;
 
 export async function runAllCleanupOperations(
   cleanupOperations: readonly ShutdownCleanupOperation[],
+  onCleanupFailure?: (error: unknown) => void,
 ): Promise<void> {
   const cleanupResults = await Promise.allSettled(
-    cleanupOperations.map(operation => Promise.resolve().then(operation)),
+    cleanupOperations.map(operation => Promise.resolve().then(operation).catch(error => {
+      onCleanupFailure?.(error);
+      throw error;
+    })),
   );
   const cleanupFailures = cleanupResults.filter(
     (result): result is PromiseRejectedResult => result.status === "rejected",
@@ -44,6 +48,10 @@ export interface ProcessLifecycleProcess {
 }
 
 export type ProcessShutdownHandler = (signal: ShutdownSignal) => Promise<void> | void;
+type ProcessShutdownTimeoutHandler = () =>
+  | Promise<{ exitCode?: number } | undefined>
+  | { exitCode?: number }
+  | undefined;
 
 export type FatalProcessEvent =
   | { type: "uncaughtException"; error: Error }
@@ -56,7 +64,7 @@ export class ProcessLifecycleHandlers {
   private stdinShutdownHandlersInstalled = false;
   private shutdownInProgress = false;
   private shutdownHandler: ProcessShutdownHandler | undefined;
-  private shutdownTimeoutHandler: (() => Promise<void> | void) | undefined;
+  private shutdownTimeoutHandler: ProcessShutdownTimeoutHandler | undefined;
   private fatalProcessHandler: FatalProcessHandler | undefined;
 
   constructor(
@@ -87,7 +95,7 @@ export class ProcessLifecycleHandlers {
 
   setShutdownHandler(
     handler: ProcessShutdownHandler,
-    timeoutHandler?: () => Promise<void> | void,
+    timeoutHandler?: ProcessShutdownTimeoutHandler,
   ): void {
     this.shutdownHandler = handler;
     this.shutdownTimeoutHandler = timeoutHandler;
@@ -119,11 +127,12 @@ export class ProcessLifecycleHandlers {
 
     try {
       const shutdownCompleted = await this.runShutdownHandler(signal);
+      let exitCode = 0;
       if (!shutdownCompleted) {
         console.error(`Shutdown timed out after ${this.shutdownTimeoutMs}ms; forcing exit`);
-        await this.shutdownTimeoutHandler?.();
+        exitCode = (await this.shutdownTimeoutHandler?.())?.exitCode ?? 0;
       }
-      this.lifecycleProcess.exit(0);
+      this.lifecycleProcess.exit(exitCode);
     } catch (error) {
       console.error(`Error during ${signal} shutdown:`, error);
       this.lifecycleProcess.exit(1);
@@ -189,7 +198,7 @@ export function installStdinShutdownHandlers(stdin: StdinShutdownSource = proces
 
 export function setProcessShutdownHandler(
   handler: ProcessShutdownHandler,
-  timeoutHandler?: () => Promise<void> | void,
+  timeoutHandler?: ProcessShutdownTimeoutHandler,
 ): void {
   processLifecycleHandlers.setShutdownHandler(handler, timeoutHandler);
 }

--- a/src/processLifecycle.ts
+++ b/src/processLifecycle.ts
@@ -1,4 +1,8 @@
+import { defaultTimer, type Timer } from "./utils/SystemTimer";
+
 export type ShutdownSignal = "SIGINT" | "SIGTERM" | "stdin";
+
+export const PROCESS_SHUTDOWN_TIMEOUT_MS = 5_000;
 
 export interface StdinShutdownSource {
   on(event: "end" | "close", listener: () => void): unknown;
@@ -35,7 +39,11 @@ export class ProcessLifecycleHandlers {
   private shutdownHandler: ProcessShutdownHandler | undefined;
   private fatalProcessHandler: FatalProcessHandler | undefined;
 
-  constructor(private readonly lifecycleProcess: ProcessLifecycleProcess) {}
+  constructor(
+    private readonly lifecycleProcess: ProcessLifecycleProcess,
+    private readonly timer: Timer = defaultTimer,
+    private readonly shutdownTimeoutMs: number = PROCESS_SHUTDOWN_TIMEOUT_MS,
+  ) {}
 
   install(): void {
     if (this.installed) {
@@ -86,11 +94,35 @@ export class ProcessLifecycleHandlers {
     this.shutdownInProgress = true;
 
     try {
-      await this.shutdownHandler?.(signal);
+      const shutdownCompleted = await this.runShutdownHandler(signal);
+      if (!shutdownCompleted) {
+        console.error(`Shutdown timed out after ${this.shutdownTimeoutMs}ms; forcing exit`);
+      }
       this.lifecycleProcess.exit(0);
     } catch (error) {
       console.error(`Error during ${signal} shutdown:`, error);
       this.lifecycleProcess.exit(1);
+    }
+  }
+
+  private async runShutdownHandler(signal: ShutdownSignal): Promise<boolean> {
+    const handler = this.shutdownHandler;
+    if (!handler) {
+      return true;
+    }
+
+    let timeoutHandle: NodeJS.Timeout | undefined;
+    const completed = handler(signal);
+    const timedOut = new Promise<false>(resolve => {
+      timeoutHandle = this.timer.setTimeout(() => resolve(false), this.shutdownTimeoutMs);
+    });
+
+    try {
+      return (await Promise.race([completed, timedOut])) !== false;
+    } finally {
+      if (timeoutHandle !== undefined) {
+        this.timer.clearTimeout(timeoutHandle);
+      }
     }
   }
 

--- a/src/processLifecycle.ts
+++ b/src/processLifecycle.ts
@@ -3,6 +3,7 @@ import { defaultTimer, type Timer } from "./utils/SystemTimer";
 export type ShutdownSignal = "SIGINT" | "SIGTERM" | "stdin";
 
 const PROCESS_SHUTDOWN_TIMEOUT_MS = 5_000;
+const PROCESS_SHUTDOWN_FINALIZATION_TIMEOUT_MS = 100;
 
 export interface StdinShutdownSource {
   on(event: "end" | "close", listener: () => void): unknown;
@@ -48,9 +49,10 @@ export interface ProcessLifecycleProcess {
 }
 
 export type ProcessShutdownHandler = (signal: ShutdownSignal) => Promise<void> | void;
+type ProcessShutdownTimeoutResult = { exitCode?: number };
 type ProcessShutdownTimeoutHandler = () =>
-  | Promise<{ exitCode?: number } | undefined>
-  | { exitCode?: number }
+  | Promise<ProcessShutdownTimeoutResult | undefined>
+  | ProcessShutdownTimeoutResult
   | undefined;
 
 export type FatalProcessEvent =
@@ -130,7 +132,7 @@ export class ProcessLifecycleHandlers {
       let exitCode = 0;
       if (!shutdownCompleted) {
         console.error(`Shutdown timed out after ${this.shutdownTimeoutMs}ms; forcing exit`);
-        exitCode = (await this.shutdownTimeoutHandler?.())?.exitCode ?? 0;
+        exitCode = (await this.runShutdownTimeoutHandler())?.exitCode ?? 0;
       }
       this.lifecycleProcess.exit(exitCode);
     } catch (error) {
@@ -158,6 +160,33 @@ export class ProcessLifecycleHandlers {
 
     try {
       return (await Promise.race([completed, timedOut])) !== false;
+    } finally {
+      if (timeoutHandle !== undefined) {
+        this.timer.clearTimeout(timeoutHandle);
+      }
+    }
+  }
+
+  private async runShutdownTimeoutHandler(): Promise<ProcessShutdownTimeoutResult | undefined> {
+    const handler = this.shutdownTimeoutHandler;
+    if (!handler) {
+      return undefined;
+    }
+
+    const finalizationTimeoutMs = Math.min(
+      this.shutdownTimeoutMs,
+      PROCESS_SHUTDOWN_FINALIZATION_TIMEOUT_MS,
+    );
+    let timeoutHandle: NodeJS.Timeout | undefined;
+    const timedOut = new Promise<undefined>(resolve => {
+      timeoutHandle = this.timer.setTimeout(() => {
+        console.error(`Shutdown finalization timed out after ${finalizationTimeoutMs}ms; forcing exit`);
+        resolve(undefined);
+      }, finalizationTimeoutMs);
+    });
+
+    try {
+      return await Promise.race([Promise.resolve(handler()), timedOut]);
     } finally {
       if (timeoutHandle !== undefined) {
         this.timer.clearTimeout(timeoutHandle);

--- a/src/processLifecycle.ts
+++ b/src/processLifecycle.ts
@@ -2,11 +2,30 @@ import { defaultTimer, type Timer } from "./utils/SystemTimer";
 
 export type ShutdownSignal = "SIGINT" | "SIGTERM" | "stdin";
 
-export const PROCESS_SHUTDOWN_TIMEOUT_MS = 5_000;
+const PROCESS_SHUTDOWN_TIMEOUT_MS = 5_000;
 
 export interface StdinShutdownSource {
   on(event: "end" | "close", listener: () => void): unknown;
   on(event: "error", listener: (error: Error) => void): unknown;
+}
+
+export type ShutdownCleanupOperation = () => void | Promise<void>;
+
+export async function runAllCleanupOperations(
+  cleanupOperations: readonly ShutdownCleanupOperation[],
+): Promise<void> {
+  const cleanupResults = await Promise.allSettled(
+    cleanupOperations.map(operation => Promise.resolve().then(operation)),
+  );
+  const cleanupFailures = cleanupResults.filter(
+    (result): result is PromiseRejectedResult => result.status === "rejected",
+  );
+  if (cleanupFailures.length > 0) {
+    throw new AggregateError(
+      cleanupFailures.map(result => result.reason),
+      "One or more shutdown cleanup operations failed",
+    );
+  }
 }
 
 export type ProcessLifecycleEventMap = {
@@ -108,6 +127,11 @@ export class ProcessLifecycleHandlers {
   private async runShutdownHandler(signal: ShutdownSignal): Promise<boolean> {
     const handler = this.shutdownHandler;
     if (!handler) {
+      return true;
+    }
+
+    if (signal !== "stdin") {
+      await handler(signal);
       return true;
     }
 

--- a/src/processLifecycle.ts
+++ b/src/processLifecycle.ts
@@ -56,6 +56,7 @@ export class ProcessLifecycleHandlers {
   private stdinShutdownHandlersInstalled = false;
   private shutdownInProgress = false;
   private shutdownHandler: ProcessShutdownHandler | undefined;
+  private shutdownTimeoutHandler: (() => Promise<void> | void) | undefined;
   private fatalProcessHandler: FatalProcessHandler | undefined;
 
   constructor(
@@ -84,8 +85,12 @@ export class ProcessLifecycleHandlers {
     });
   }
 
-  setShutdownHandler(handler: ProcessShutdownHandler): void {
+  setShutdownHandler(
+    handler: ProcessShutdownHandler,
+    timeoutHandler?: () => Promise<void> | void,
+  ): void {
     this.shutdownHandler = handler;
+    this.shutdownTimeoutHandler = timeoutHandler;
   }
 
   setFatalProcessHandler(handler: FatalProcessHandler): void {
@@ -116,6 +121,7 @@ export class ProcessLifecycleHandlers {
       const shutdownCompleted = await this.runShutdownHandler(signal);
       if (!shutdownCompleted) {
         console.error(`Shutdown timed out after ${this.shutdownTimeoutMs}ms; forcing exit`);
+        await this.shutdownTimeoutHandler?.();
       }
       this.lifecycleProcess.exit(0);
     } catch (error) {
@@ -181,8 +187,11 @@ export function installStdinShutdownHandlers(stdin: StdinShutdownSource = proces
   processLifecycleHandlers.installStdinShutdownHandlers(stdin);
 }
 
-export function setProcessShutdownHandler(handler: ProcessShutdownHandler): void {
-  processLifecycleHandlers.setShutdownHandler(handler);
+export function setProcessShutdownHandler(
+  handler: ProcessShutdownHandler,
+  timeoutHandler?: () => Promise<void> | void,
+): void {
+  processLifecycleHandlers.setShutdownHandler(handler, timeoutHandler);
 }
 
 export function setFatalProcessHandler(handler: FatalProcessHandler): void {

--- a/src/processLifecycle.ts
+++ b/src/processLifecycle.ts
@@ -1,4 +1,9 @@
-export type ShutdownSignal = "SIGINT" | "SIGTERM";
+export type ShutdownSignal = "SIGINT" | "SIGTERM" | "stdin";
+
+export interface StdinShutdownSource {
+  on(event: "end" | "close", listener: () => void): unknown;
+  on(event: "error", listener: (error: Error) => void): unknown;
+}
 
 export type ProcessLifecycleEventMap = {
   SIGINT: [];
@@ -25,6 +30,7 @@ export type FatalProcessHandler = (event: FatalProcessEvent) => Promise<void> | 
 
 export class ProcessLifecycleHandlers {
   private installed = false;
+  private stdinShutdownHandlersInstalled = false;
   private shutdownInProgress = false;
   private shutdownHandler: ProcessShutdownHandler | undefined;
   private fatalProcessHandler: FatalProcessHandler | undefined;
@@ -57,6 +63,20 @@ export class ProcessLifecycleHandlers {
 
   setFatalProcessHandler(handler: FatalProcessHandler): void {
     this.fatalProcessHandler = handler;
+  }
+
+  installStdinShutdownHandlers(stdin: StdinShutdownSource): void {
+    if (this.stdinShutdownHandlersInstalled) {
+      return;
+    }
+    this.stdinShutdownHandlersInstalled = true;
+
+    const shutdownOnStdinClose = () => {
+      void this.shutdown("stdin");
+    };
+    stdin.on("end", shutdownOnStdinClose);
+    stdin.on("error", shutdownOnStdinClose);
+    stdin.on("close", shutdownOnStdinClose);
   }
 
   private async shutdown(signal: ShutdownSignal): Promise<void> {
@@ -99,6 +119,10 @@ const processLifecycleHandlers = new ProcessLifecycleHandlers(process);
 
 export function installProcessLifecycleHandlers(): void {
   processLifecycleHandlers.install();
+}
+
+export function installStdinShutdownHandlers(stdin: StdinShutdownSource = process.stdin): void {
+  processLifecycleHandlers.installStdinShutdownHandlers(stdin);
 }
 
 export function setProcessShutdownHandler(handler: ProcessShutdownHandler): void {

--- a/src/processLifecycle.ts
+++ b/src/processLifecycle.ts
@@ -65,6 +65,12 @@ export class ProcessLifecycleHandlers {
   private installed = false;
   private stdinShutdownHandlersInstalled = false;
   private shutdownInProgress = false;
+  private stdinShutdownTimeoutArmed = false;
+  private stdinShutdownTimeoutHandle: NodeJS.Timeout | undefined;
+  private resolveStdinShutdownTimeout!: (value: false) => void;
+  private readonly stdinShutdownTimeout = new Promise<false>(resolve => {
+    this.resolveStdinShutdownTimeout = resolve;
+  });
   private shutdownHandler: ProcessShutdownHandler | undefined;
   private shutdownTimeoutHandler: ProcessShutdownTimeoutHandler | undefined;
   private fatalProcessHandler: FatalProcessHandler | undefined;
@@ -123,6 +129,9 @@ export class ProcessLifecycleHandlers {
 
   private async shutdown(signal: ShutdownSignal): Promise<void> {
     if (this.shutdownInProgress) {
+      if (signal === "stdin") {
+        this.armStdinShutdownTimeout();
+      }
       return;
     }
     this.shutdownInProgress = true;
@@ -147,24 +156,28 @@ export class ProcessLifecycleHandlers {
       return true;
     }
 
-    if (signal !== "stdin") {
-      await handler(signal);
-      return true;
+    if (signal === "stdin") {
+      this.armStdinShutdownTimeout();
     }
-
-    let timeoutHandle: NodeJS.Timeout | undefined;
-    const completed = handler(signal);
-    const timedOut = new Promise<false>(resolve => {
-      timeoutHandle = this.timer.setTimeout(() => resolve(false), this.shutdownTimeoutMs);
-    });
 
     try {
-      return (await Promise.race([completed, timedOut])) !== false;
+      return (await Promise.race([handler(signal), this.stdinShutdownTimeout])) !== false;
     } finally {
-      if (timeoutHandle !== undefined) {
-        this.timer.clearTimeout(timeoutHandle);
+      if (this.stdinShutdownTimeoutHandle !== undefined) {
+        this.timer.clearTimeout(this.stdinShutdownTimeoutHandle);
+        this.stdinShutdownTimeoutHandle = undefined;
       }
     }
+  }
+
+  private armStdinShutdownTimeout(): void {
+    if (this.stdinShutdownTimeoutArmed) {
+      return;
+    }
+    this.stdinShutdownTimeoutArmed = true;
+    this.stdinShutdownTimeoutHandle = this.timer.setTimeout(() => {
+      this.resolveStdinShutdownTimeout(false);
+    }, this.shutdownTimeoutMs);
   }
 
   private async runShutdownTimeoutHandler(): Promise<ProcessShutdownTimeoutResult | undefined> {

--- a/src/utils/logger.ts
+++ b/src/utils/logger.ts
@@ -60,7 +60,7 @@ export interface Logger {
   flush(): Promise<void>;
 
   /**
-   * Closes the log stream
+   * Flushes queued writes and closes the log stream.
    */
   close(): void;
 
@@ -155,7 +155,6 @@ ensureDirExists(logsDir).catch(err => {
 const ownLogPrefix = resolveProcessLogPrefix(process.argv, process.pid);
 const logFilePath = path.join(logsDir, `${ownLogPrefix}.log`);
 let logStream = fs.createWriteStream(logFilePath, { flags: "a" });
-
 interface EndableLogStream {
   end(callback: () => void): void;
   once(event: "error", listener: (error: Error) => void): void;
@@ -315,7 +314,15 @@ const writeToLogFile = async (level: string, message: string, args: any[]) => {
       logMessage = logMessage.substring(0, 1000) + "... (truncated)";
     }
     const safeLogMessage = logMessage.replace(/[\r\n\t]/g, " ");
-    logStream.write(safeLogMessage + "\n");
+    await new Promise<void>((resolve, reject) => {
+      logStream.write(safeLogMessage + "\n", error => {
+        if (error) {
+          reject(error);
+        } else {
+          resolve();
+        }
+      });
+    });
 
     // Also write to STDOUT if enabled
     if (logToStdout) {
@@ -408,7 +415,7 @@ export const logger: Logger = {
   },
 
   /**
-   * Closes the log stream
+   * Flushes queued writes and closes the log stream.
    */
   close(): void {
     logStream.end();

--- a/test/daemon/daemonDatabaseHealthCheck.test.ts
+++ b/test/daemon/daemonDatabaseHealthCheck.test.ts
@@ -48,7 +48,7 @@ class FakeDatabaseHealthProbe {
 function buildDaemon(
   timer: FakeTimer,
   databaseHealthProbe: FakeDatabaseHealthProbe,
-  exitProcess: (code: number) => void = () => {}
+  exitProcess: (code: number) => Promise<void> | void = () => {}
 ): Daemon {
   const daemon = new Daemon(
     {},
@@ -66,6 +66,11 @@ function buildDaemon(
     recover: async () => {},
   };
   return daemon;
+}
+
+async function flushMicrotasks(): Promise<void> {
+  await Promise.resolve();
+  await Promise.resolve();
 }
 
 describe("Daemon database health check", () => {
@@ -129,6 +134,35 @@ describe("Daemon database health check", () => {
     }
 
     expect(exitCodes).toEqual([1]);
+  });
+
+  test("awaits asynchronous database recovery before completing recovery", async () => {
+    const timer = new FakeTimer();
+    const databaseHealthProbe = new FakeDatabaseHealthProbe();
+    const recoveryCodes: number[] = [];
+    let finishRecovery!: () => void;
+    const daemon = buildDaemon(timer, databaseHealthProbe, async code => {
+      recoveryCodes.push(code);
+      await new Promise<void>(resolve => {
+        finishRecovery = resolve;
+      });
+    });
+    const internals = daemon as unknown as DaemonHealthInternals;
+
+    const recovery = internals.attemptRecovery("database");
+    await flushMicrotasks();
+
+    expect(recoveryCodes).toEqual([1]);
+    let recoveryCompleted = false;
+    void recovery.then(() => {
+      recoveryCompleted = true;
+    });
+    await flushMicrotasks();
+    expect(recoveryCompleted).toBe(false);
+
+    finishRecovery();
+    await recovery;
+    expect(recoveryCompleted).toBe(true);
   });
 
   test("does not exit for database recovery after mixed health failure kinds", async () => {

--- a/test/processLifecycle.test.ts
+++ b/test/processLifecycle.test.ts
@@ -74,6 +74,8 @@ async function flushMicrotasks(): Promise<void> {
   await Promise.resolve();
   await Promise.resolve();
   await Promise.resolve();
+  await Promise.resolve();
+  await Promise.resolve();
 }
 
 describe("process lifecycle handlers", () => {
@@ -269,6 +271,34 @@ describe("process lifecycle handlers", () => {
 
       expect(cleanupFailed).toBe(true);
       expect(fakeProcess.exitCodes).toEqual([1]);
+    } finally {
+      consoleError.mockRestore();
+    }
+  });
+
+  test("exits when timeout finalization exceeds its bound", async () => {
+    const fakeProcess = new FakeProcess();
+    const fakeStdin = new FakeStdin();
+    const timer = new FakeTimer();
+    const lifecycle = new ProcessLifecycleHandlers(fakeProcess, timer, 50);
+    const consoleError = spyOn(console, "error").mockImplementation(() => {});
+
+    try {
+      lifecycle.installStdinShutdownHandlers(fakeStdin);
+      lifecycle.setShutdownHandler(
+        async () => await new Promise<void>(() => {}),
+        async () => await new Promise<void>(() => {}),
+      );
+
+      fakeStdin.emit("close");
+      await flushMicrotasks();
+      timer.advanceTime(50);
+      await flushMicrotasks();
+      expect(fakeProcess.exitCodes).toEqual([]);
+
+      timer.advanceTime(50);
+      await flushMicrotasks();
+      expect(fakeProcess.exitCodes).toEqual([0]);
     } finally {
       consoleError.mockRestore();
     }

--- a/test/processLifecycle.test.ts
+++ b/test/processLifecycle.test.ts
@@ -230,7 +230,7 @@ describe("process lifecycle handlers", () => {
       timer.advanceTime(50);
       await flushMicrotasks();
 
-      expect(fakeProcess.exitCodes).toEqual([0]);
+      expect(fakeProcess.exitCodes).toEqual([1]);
       expect(timeoutFinalizers).toEqual(["logger"]);
     } finally {
       consoleError.mockRestore();
@@ -298,7 +298,7 @@ describe("process lifecycle handlers", () => {
 
       timer.advanceTime(50);
       await flushMicrotasks();
-      expect(fakeProcess.exitCodes).toEqual([0]);
+      expect(fakeProcess.exitCodes).toEqual([1]);
     } finally {
       consoleError.mockRestore();
     }
@@ -348,7 +348,7 @@ describe("process lifecycle handlers", () => {
       timer.advanceTime(50);
       await flushMicrotasks();
 
-      expect(fakeProcess.exitCodes).toEqual([0]);
+      expect(fakeProcess.exitCodes).toEqual([1]);
     } finally {
       consoleError.mockRestore();
     }

--- a/test/processLifecycle.test.ts
+++ b/test/processLifecycle.test.ts
@@ -4,6 +4,7 @@ import {
   type ProcessLifecycleEventMap,
   type ProcessLifecycleProcess,
 } from "../src/processLifecycle";
+import { FakeTimer } from "./fakes/FakeTimer";
 
 class FakeProcess implements ProcessLifecycleProcess {
   readonly listeners = new Map<keyof ProcessLifecycleEventMap, Array<(...args: any[]) => void>>();
@@ -69,6 +70,7 @@ class FakeStdin {
 }
 
 async function flushMicrotasks(): Promise<void> {
+  await Promise.resolve();
   await Promise.resolve();
   await Promise.resolve();
 }
@@ -199,6 +201,30 @@ describe("process lifecycle handlers", () => {
 
     expect(closedResources).toEqual(["stdin", "proxy"]);
     expect(fakeProcess.exitCodes).toEqual([0]);
+  });
+
+  test("exits when stdin cleanup exceeds the shutdown timeout", async () => {
+    const fakeProcess = new FakeProcess();
+    const fakeStdin = new FakeStdin();
+    const timer = new FakeTimer();
+    const lifecycle = new ProcessLifecycleHandlers(fakeProcess, timer, 50);
+    const consoleError = spyOn(console, "error").mockImplementation(() => {});
+
+    try {
+      lifecycle.installStdinShutdownHandlers(fakeStdin);
+      lifecycle.setShutdownHandler(async () => await new Promise<void>(() => {}));
+
+      fakeStdin.emit("close");
+      await flushMicrotasks();
+      expect(fakeProcess.exitCodes).toEqual([]);
+
+      timer.advanceTime(50);
+      await flushMicrotasks();
+
+      expect(fakeProcess.exitCodes).toEqual([0]);
+    } finally {
+      consoleError.mockRestore();
+    }
   });
 
   test("installs each stdin shutdown listener only once", () => {

--- a/test/processLifecycle.test.ts
+++ b/test/processLifecycle.test.ts
@@ -216,7 +216,9 @@ describe("process lifecycle handlers", () => {
       lifecycle.installStdinShutdownHandlers(fakeStdin);
       lifecycle.setShutdownHandler(
         async () => await new Promise<void>(() => {}),
-        () => timeoutFinalizers.push("logger"),
+        () => {
+          timeoutFinalizers.push("logger");
+        },
       );
 
       fakeStdin.emit("close");
@@ -228,6 +230,45 @@ describe("process lifecycle handlers", () => {
 
       expect(fakeProcess.exitCodes).toEqual([0]);
       expect(timeoutFinalizers).toEqual(["logger"]);
+    } finally {
+      consoleError.mockRestore();
+    }
+  });
+
+  test("exits with failure when a cleanup fails before stdin shutdown times out", async () => {
+    const fakeProcess = new FakeProcess();
+    const fakeStdin = new FakeStdin();
+    const timer = new FakeTimer();
+    const lifecycle = new ProcessLifecycleHandlers(fakeProcess, timer, 50);
+    const consoleError = spyOn(console, "error").mockImplementation(() => {});
+    let cleanupFailed = false;
+
+    try {
+      lifecycle.installStdinShutdownHandlers(fakeStdin);
+      lifecycle.setShutdownHandler(
+        async () => {
+          await runAllCleanupOperations(
+            [
+              () => {
+                throw new Error("first cleanup failed");
+              },
+              () => new Promise<void>(() => {}),
+            ],
+            () => {
+              cleanupFailed = true;
+            },
+          );
+        },
+        () => cleanupFailed ? { exitCode: 1 } : undefined,
+      );
+
+      fakeStdin.emit("close");
+      await flushMicrotasks();
+      timer.advanceTime(50);
+      await flushMicrotasks();
+
+      expect(cleanupFailed).toBe(true);
+      expect(fakeProcess.exitCodes).toEqual([1]);
     } finally {
       consoleError.mockRestore();
     }

--- a/test/processLifecycle.test.ts
+++ b/test/processLifecycle.test.ts
@@ -38,6 +38,36 @@ class FakeProcess implements ProcessLifecycleProcess {
   }
 }
 
+type StdinEventMap = {
+  end: [];
+  error: [Error];
+  close: [];
+};
+
+class FakeStdin {
+  readonly listeners = new Map<keyof StdinEventMap, Array<(...args: any[]) => void>>();
+
+  on<K extends keyof StdinEventMap>(
+    event: K,
+    listener: (...args: StdinEventMap[K]) => void
+  ): this {
+    const eventListeners = this.listeners.get(event) ?? [];
+    eventListeners.push(listener);
+    this.listeners.set(event, eventListeners);
+    return this;
+  }
+
+  emit<K extends keyof StdinEventMap>(event: K, ...args: StdinEventMap[K]): void {
+    for (const listener of this.listeners.get(event) ?? []) {
+      listener(...args);
+    }
+  }
+
+  listenerCount(event: keyof StdinEventMap): number {
+    return this.listeners.get(event)?.length ?? 0;
+  }
+}
+
 async function flushMicrotasks(): Promise<void> {
   await Promise.resolve();
   await Promise.resolve();
@@ -138,6 +168,50 @@ describe("process lifecycle handlers", () => {
     } finally {
       consoleError.mockRestore();
     }
+  });
+
+  test("closes active resources once before exiting when stdin closes", async () => {
+    const fakeProcess = new FakeProcess();
+    const fakeStdin = new FakeStdin();
+    const lifecycle = new ProcessLifecycleHandlers(fakeProcess);
+    const closedResources: string[] = [];
+    let finishClosingProxy!: () => void;
+
+    lifecycle.installStdinShutdownHandlers(fakeStdin);
+    lifecycle.setShutdownHandler(async reason => {
+      closedResources.push(reason);
+      await new Promise<void>(resolve => {
+        finishClosingProxy = resolve;
+      });
+      closedResources.push("proxy");
+    });
+
+    fakeStdin.emit("close");
+    fakeStdin.emit("end");
+    fakeStdin.emit("error", new Error("EPIPE"));
+    await flushMicrotasks();
+
+    expect(closedResources).toEqual(["stdin"]);
+    expect(fakeProcess.exitCodes).toEqual([]);
+
+    finishClosingProxy();
+    await flushMicrotasks();
+
+    expect(closedResources).toEqual(["stdin", "proxy"]);
+    expect(fakeProcess.exitCodes).toEqual([0]);
+  });
+
+  test("installs each stdin shutdown listener only once", () => {
+    const fakeProcess = new FakeProcess();
+    const fakeStdin = new FakeStdin();
+    const lifecycle = new ProcessLifecycleHandlers(fakeProcess);
+
+    lifecycle.installStdinShutdownHandlers(fakeStdin);
+    lifecycle.installStdinShutdownHandlers(fakeStdin);
+
+    expect(fakeStdin.listenerCount("end")).toBe(1);
+    expect(fakeStdin.listenerCount("error")).toBe(1);
+    expect(fakeStdin.listenerCount("close")).toBe(1);
   });
 
   test("delegates fatal process events without forcing an exit", async () => {

--- a/test/processLifecycle.test.ts
+++ b/test/processLifecycle.test.ts
@@ -330,6 +330,30 @@ describe("process lifecycle handlers", () => {
     expect(fakeProcess.exitCodes).toEqual([0]);
   });
 
+  test("uses the stdin timeout when stdin closes during signal cleanup", async () => {
+    const fakeProcess = new FakeProcess();
+    const fakeStdin = new FakeStdin();
+    const timer = new FakeTimer();
+    const lifecycle = new ProcessLifecycleHandlers(fakeProcess, timer, 50);
+    const consoleError = spyOn(console, "error").mockImplementation(() => {});
+
+    try {
+      lifecycle.install();
+      lifecycle.installStdinShutdownHandlers(fakeStdin);
+      lifecycle.setShutdownHandler(async () => await new Promise<void>(() => {}));
+
+      fakeProcess.emit("SIGTERM");
+      await flushMicrotasks();
+      fakeStdin.emit("close");
+      timer.advanceTime(50);
+      await flushMicrotasks();
+
+      expect(fakeProcess.exitCodes).toEqual([0]);
+    } finally {
+      consoleError.mockRestore();
+    }
+  });
+
   test("attempts every cleanup operation when one fails", async () => {
     const cleaned: string[] = [];
 

--- a/test/processLifecycle.test.ts
+++ b/test/processLifecycle.test.ts
@@ -1,6 +1,7 @@
 import { describe, expect, spyOn, test } from "bun:test";
 import {
   ProcessLifecycleHandlers,
+  runAllCleanupOperations,
   type ProcessLifecycleEventMap,
   type ProcessLifecycleProcess,
 } from "../src/processLifecycle";
@@ -225,6 +226,48 @@ describe("process lifecycle handlers", () => {
     } finally {
       consoleError.mockRestore();
     }
+  });
+
+  test("does not time out signal cleanup", async () => {
+    const fakeProcess = new FakeProcess();
+    const timer = new FakeTimer();
+    const lifecycle = new ProcessLifecycleHandlers(fakeProcess, timer, 50);
+    let finishShutdown!: () => void;
+
+    lifecycle.install();
+    lifecycle.setShutdownHandler(async () => {
+      await new Promise<void>(resolve => {
+        finishShutdown = resolve;
+      });
+    });
+
+    fakeProcess.emit("SIGTERM");
+    await flushMicrotasks();
+    timer.advanceTime(50);
+    await flushMicrotasks();
+
+    expect(fakeProcess.exitCodes).toEqual([]);
+
+    finishShutdown();
+    await flushMicrotasks();
+
+    expect(fakeProcess.exitCodes).toEqual([0]);
+  });
+
+  test("attempts every cleanup operation when one fails", async () => {
+    const cleaned: string[] = [];
+
+    await expect(runAllCleanupOperations([
+      () => {
+        cleaned.push("video");
+        throw new Error("video cleanup failed");
+      },
+      async () => {
+        cleaned.push("proxy");
+      },
+    ])).rejects.toThrow("One or more shutdown cleanup operations failed");
+
+    expect(cleaned).toEqual(["video", "proxy"]);
   });
 
   test("installs each stdin shutdown listener only once", () => {

--- a/test/processLifecycle.test.ts
+++ b/test/processLifecycle.test.ts
@@ -210,10 +210,14 @@ describe("process lifecycle handlers", () => {
     const timer = new FakeTimer();
     const lifecycle = new ProcessLifecycleHandlers(fakeProcess, timer, 50);
     const consoleError = spyOn(console, "error").mockImplementation(() => {});
+    const timeoutFinalizers: string[] = [];
 
     try {
       lifecycle.installStdinShutdownHandlers(fakeStdin);
-      lifecycle.setShutdownHandler(async () => await new Promise<void>(() => {}));
+      lifecycle.setShutdownHandler(
+        async () => await new Promise<void>(() => {}),
+        () => timeoutFinalizers.push("logger"),
+      );
 
       fakeStdin.emit("close");
       await flushMicrotasks();
@@ -223,6 +227,7 @@ describe("process lifecycle handlers", () => {
       await flushMicrotasks();
 
       expect(fakeProcess.exitCodes).toEqual([0]);
+      expect(timeoutFinalizers).toEqual(["logger"]);
     } finally {
       consoleError.mockRestore();
     }

--- a/test/utils/logger-loglevel-env.test.ts
+++ b/test/utils/logger-loglevel-env.test.ts
@@ -16,10 +16,13 @@ class FakeLogStream extends EventEmitter {
     return true;
   }
 
-  end(): this {
+  end(callback?: () => void): this {
     this.endCalls += 1;
     this.writableFinished = true;
-    queueMicrotask(() => this.emit("finish"));
+    queueMicrotask(() => {
+      callback?.();
+      this.emit("finish");
+    });
     return this;
   }
 }
@@ -143,7 +146,7 @@ describe("AUTOMOBILE_LOG_LEVEL is applied at process start (issue #3845)", () =>
       mod.logger.error("first queued line");
       mod.logger.error("second queued line");
 
-      const closed = mod.logger.close();
+      const closed = mod.logger.closeAfterFlush();
       expect(stream.endCalls).toBe(0);
 
       await closed;

--- a/test/utils/logger-loglevel-env.test.ts
+++ b/test/utils/logger-loglevel-env.test.ts
@@ -1,5 +1,8 @@
 import { describe, expect, test, spyOn } from "bun:test";
+import { readFile } from "fs/promises";
+import path from "path";
 import { LogLevel, parseAutomobileLogLevel, resolveProcessLogPrefix } from "../../src/utils/logger";
+import { getTempDir, TEMP_SUBDIRS } from "../../src/utils/tempDir";
 
 // Re-import the logger module with AUTOMOBILE_LOG_LEVEL set so the module-load
 // seed (`currentLogLevel = parseAutomobileLogLevel(...) ?? INFO`) re-evaluates
@@ -106,6 +109,23 @@ describe("AUTOMOBILE_LOG_LEVEL is applied at process start (issue #3845)", () =>
   test("still emits an ERROR line when seeded to error", async () => {
     const emitted = await captureEmit("error", l => l.error("loglevel-3845-error"));
     expect(emitted).toContain("loglevel-3845-error");
+  });
+
+  test("close waits for queued file-log writes", async () => {
+    const marker = `logger-close-${crypto.randomUUID()}`;
+    const mod = await loggerWithEnvLevel("error");
+
+    for (let index = 0; index < 2_000; index += 1) {
+      mod.logger.error(`${marker}-${index}`);
+    }
+    await mod.logger.close();
+
+    const logFile = path.join(
+      getTempDir(TEMP_SUBDIRS.LOGS),
+      `${mod.resolveProcessLogPrefix(process.argv, process.pid)}.log`,
+    );
+    const contents = await readFile(logFile, "utf8");
+    expect(contents).toContain(`${marker}-1999`);
   });
 });
 

--- a/test/utils/logger-loglevel-env.test.ts
+++ b/test/utils/logger-loglevel-env.test.ts
@@ -1,8 +1,28 @@
 import { describe, expect, test, spyOn } from "bun:test";
-import { readFile } from "fs/promises";
-import path from "path";
+import fs from "fs";
+import { EventEmitter } from "node:events";
 import { LogLevel, parseAutomobileLogLevel, resolveProcessLogPrefix } from "../../src/utils/logger";
-import { getTempDir, TEMP_SUBDIRS } from "../../src/utils/tempDir";
+
+class FakeLogStream extends EventEmitter {
+  writableFinished = false;
+  destroyed = false;
+  writable = true;
+  readonly writes: string[] = [];
+  endCalls = 0;
+
+  write(chunk: unknown, callback?: (error: Error | null) => void): boolean {
+    this.writes.push(String(chunk));
+    queueMicrotask(() => callback?.(null));
+    return true;
+  }
+
+  end(): this {
+    this.endCalls += 1;
+    this.writableFinished = true;
+    queueMicrotask(() => this.emit("finish"));
+    return this;
+  }
+}
 
 // Re-import the logger module with AUTOMOBILE_LOG_LEVEL set so the module-load
 // seed (`currentLogLevel = parseAutomobileLogLevel(...) ?? INFO`) re-evaluates
@@ -112,20 +132,25 @@ describe("AUTOMOBILE_LOG_LEVEL is applied at process start (issue #3845)", () =>
   });
 
   test("close waits for queued file-log writes", async () => {
-    const marker = `logger-close-${crypto.randomUUID()}`;
-    const mod = await loggerWithEnvLevel("error");
-
-    for (let index = 0; index < 2_000; index += 1) {
-      mod.logger.error(`${marker}-${index}`);
-    }
-    await mod.logger.close();
-
-    const logFile = path.join(
-      getTempDir(TEMP_SUBDIRS.LOGS),
-      `${mod.resolveProcessLogPrefix(process.argv, process.pid)}.log`,
+    const stream = new FakeLogStream();
+    const createWriteStream = spyOn(fs, "createWriteStream").mockReturnValue(
+      stream as unknown as fs.WriteStream,
     );
-    const contents = await readFile(logFile, "utf8");
-    expect(contents).toContain(`${marker}-1999`);
+
+    try {
+      const mod = await loggerWithEnvLevel("error");
+      mod.logger.error("first queued line");
+      mod.logger.error("second queued line");
+
+      const closed = mod.logger.close();
+      expect(stream.endCalls).toBe(0);
+
+      await closed;
+      expect(stream.writes).toHaveLength(2);
+      expect(stream.endCalls).toBe(1);
+    } finally {
+      createWriteStream.mockRestore();
+    }
   });
 });
 

--- a/test/utils/logger-loglevel-env.test.ts
+++ b/test/utils/logger-loglevel-env.test.ts
@@ -133,6 +133,7 @@ describe("AUTOMOBILE_LOG_LEVEL is applied at process start (issue #3845)", () =>
 
   test("close waits for queued file-log writes", async () => {
     const stream = new FakeLogStream();
+    const logFileExists = spyOn(fs, "existsSync").mockReturnValue(false);
     const createWriteStream = spyOn(fs, "createWriteStream").mockReturnValue(
       stream as unknown as fs.WriteStream,
     );
@@ -150,6 +151,7 @@ describe("AUTOMOBILE_LOG_LEVEL is applied at process start (issue #3845)", () =>
       expect(stream.endCalls).toBe(1);
     } finally {
       createWriteStream.mockRestore();
+      logFileExists.mockRestore();
     }
   });
 });


### PR DESCRIPTION
## Summary

- route stdin `end`, `error`, and `close` through the shared asynchronous lifecycle shutdown path
- await proxy cleanup together with direct-mode resource cleanup before process exit
- bound graceful cleanup to five seconds so a stuck resource cannot orphan the stdio process
- continue independent cleanup when one resource reports an error
- cover stdin-close shutdown idempotency and ordering with fakes

## Root cause

The stdio disconnect handler called `process.exit(0)` directly, bypassing the cleanup registered for normal lifecycle shutdown.

## Validation

- `bun test test/processLifecycle.test.ts`
- `bun run typecheck`
- `bun run turbo:validate`

Closes [#5302](https://github.com/kaeawc/auto-mobile/issues/5302)
