### PR TITLE
fix(daemon): close Unix clients before shutdown

### DIFF
--- a/src/daemon/socketServer.ts
+++ b/src/daemon/socketServer.ts
@@ -2706,33 +2706,54 @@ export class UnixSocketServer {
     this.mcpForwardIdleCloseKeys.clear();
     this.appendTextInputs.clear();
 
+    // Capture clients before clearing their session bookkeeping. server.close() stops
+    // accepting new connections, but waits for existing ones; destroy them before
+    // awaiting its callback so daemon shutdown cannot hang on an idle client.
+    const clientSockets = Array.from(this.clientSockets.values());
+
     // Clear sessions
     this.sessions.clear();
     this.clientSockets.clear();
     this.notificationSubscribers.clear();
 
     const ownsSocketPath = this.isOwnedSocketFile();
+    const serverClosed = this.closeListeningServer(ownsSocketPath);
 
-    if (this.server && (ownsSocketPath || !existsSync(this.socketPath))) {
-      await new Promise<void>(resolve => {
-        this.server!.close(() => {
-          logger.info("Unix socket server closed");
-          resolve();
-        });
-      });
-      this.server = null;
-    } else if (this.server) {
-      logger.warn(
-        `Unix socket path ${this.socketPath} no longer belongs to this server; leaving listener for process teardown`
-      );
-      this.server.unref();
-      this.server = null;
-    }
+    this.destroyClientSockets(clientSockets);
+    await serverClosed;
+    this.server = null;
 
     if (ownsSocketPath && existsSync(this.socketPath)) {
       await unlink(this.socketPath);
     }
     this.socketFileIdentity = null;
+  }
+
+  private closeListeningServer(ownsSocketPath: boolean): Promise<void> {
+    if (!this.server) {
+      return Promise.resolve();
+    }
+    if (!ownsSocketPath && existsSync(this.socketPath)) {
+      logger.warn(
+        `Unix socket path ${this.socketPath} no longer belongs to this server; leaving listener for process teardown`
+      );
+      this.server.unref();
+      return Promise.resolve();
+    }
+    return new Promise(resolve => {
+      this.server!.close(() => {
+        logger.info("Unix socket server closed");
+        resolve();
+      });
+    });
+  }
+
+  private destroyClientSockets(clientSockets: Socket[]): void {
+    for (const socket of clientSockets) {
+      if (!socket.destroyed) {
+        socket.destroy();
+      }
+    }
   }
 
   private readSocketFileIdentity(): SocketFileIdentity | null {

--- a/src/daemon/socketServer.ts
+++ b/src/daemon/socketServer.ts
@@ -2723,7 +2723,7 @@ export class UnixSocketServer {
     await serverClosed;
     this.server = null;
 
-    if (ownsSocketPath && existsSync(this.socketPath)) {
+    if (this.isOwnedSocketFile()) {
       await unlink(this.socketPath);
     }
     this.socketFileIdentity = null;

--- a/src/daemon/socketServer.ts
+++ b/src/daemon/socketServer.ts
@@ -2740,9 +2740,9 @@ export class UnixSocketServer {
     await requestHandlersDrained;
     this.server = null;
 
-    if (this.isOwnedSocketFile()) {
-      await unlink(this.socketPath);
-    }
+    // The listener removes the socket it created as part of close(). Do not
+    // unlink the pathname afterward: a successor can bind in the interval and
+    // filesystems are allowed to reuse the original socket inode immediately.
     this.socketFileIdentity = null;
   }
 

--- a/src/daemon/socketServer.ts
+++ b/src/daemon/socketServer.ts
@@ -90,6 +90,8 @@ import type { KeyValueType } from "../features/storage/storageTypes";
 import type { BootedDevice, ImeAction, ScreenScaleMetadata } from "../models";
 import type { DeviceService } from "../features/observe/DeviceService";
 const MCP_CLIENT_IDLE_CLOSE_MS = 5 * 60 * 1000;
+/** Keep shutdown bounded if a request handler ignores its disconnected peer. */
+const DAEMON_REQUEST_HANDLER_DRAIN_TIMEOUT_MS = 1_000;
 
 /**
  * Unix Socket Server that proxies requests to the HTTP MCP server
@@ -210,6 +212,8 @@ export class UnixSocketServer {
   private sessions: Map<string, SessionContext> = new Map();
   /** Live client sockets by session ID, for server-pushed notification frames (issue #3223). */
   private clientSockets: Map<string, Socket> = new Map();
+  /** Request handlers that can continue after their client socket is destroyed. */
+  private activeRequestHandlers: Set<Promise<void>> = new Set();
   /** Socket sessions that opted in to server-pushed notifications. */
   private notificationSubscribers: Set<string> = new Set();
   private listChangedUnsubscribe: (() => void) | null = null;
@@ -385,34 +389,37 @@ export class UnixSocketServer {
       socket.destroy();
     });
 
-    socket.on("data", async data => {
-      buffer += data.toString();
+    socket.on("data", data => {
+      const handler = (async () => {
+        buffer += data.toString();
 
-      const lines = buffer.split("\n");
-      buffer = lines.pop() || "";
+        const lines = buffer.split("\n");
+        buffer = lines.pop() || "";
 
-      for (const line of lines) {
-        if (!line.trim()) {
-          continue;
+        for (const line of lines) {
+          if (!line.trim()) {
+            continue;
+          }
+
+          let requestId = "unknown";
+          try {
+            const request: DaemonRequest = JSON.parse(line);
+            requestId = request.id;
+            const response = await this.handleRequest(sessionId, request);
+            this.writeFrame(socket, sessionId, response);
+          } catch (error) {
+            logger.error(`Error processing request ${requestId} from ${sessionId}:`, error);
+            const errorResponse: DaemonResponse = {
+              id: requestId,
+              type: "mcp_response",
+              success: false,
+              error: error instanceof Error ? error.message : String(error),
+            };
+            this.writeFrame(socket, sessionId, errorResponse);
+          }
         }
-
-        let requestId = "unknown";
-        try {
-          const request: DaemonRequest = JSON.parse(line);
-          requestId = request.id;
-          const response = await this.handleRequest(sessionId, request);
-          this.writeFrame(socket, sessionId, response);
-        } catch (error) {
-          logger.error(`Error processing request ${requestId} from ${sessionId}:`, error);
-          const errorResponse: DaemonResponse = {
-            id: requestId,
-            type: "mcp_response",
-            success: false,
-            error: error instanceof Error ? error.message : String(error),
-          };
-          this.writeFrame(socket, sessionId, errorResponse);
-        }
-      }
+      })();
+      this.trackRequestHandler(handler);
     });
 
     socket.on("close", () => {
@@ -433,6 +440,14 @@ export class UnixSocketServer {
         socket.destroy();
       }
     });
+  }
+
+  private trackRequestHandler(handler: Promise<void>): void {
+    this.activeRequestHandlers.add(handler);
+    void handler.then(
+      () => this.activeRequestHandlers.delete(handler),
+      () => this.activeRequestHandlers.delete(handler)
+    );
   }
 
   /**
@@ -2718,9 +2733,11 @@ export class UnixSocketServer {
 
     const ownsSocketPath = this.isOwnedSocketFile();
     const serverClosed = this.closeListeningServer(ownsSocketPath);
+    const requestHandlersDrained = this.drainActiveRequestHandlers();
 
     this.destroyClientSockets(clientSockets);
     await serverClosed;
+    await requestHandlersDrained;
     this.server = null;
 
     if (this.isOwnedSocketFile()) {
@@ -2752,6 +2769,31 @@ export class UnixSocketServer {
     for (const socket of clientSockets) {
       if (!socket.destroyed) {
         socket.destroy();
+      }
+    }
+  }
+
+  private async drainActiveRequestHandlers(): Promise<void> {
+    const handlers = Array.from(this.activeRequestHandlers);
+    if (handlers.length === 0) {
+      return;
+    }
+
+    let timeoutHandle: NodeJS.Timeout | undefined;
+    const timeout = new Promise<boolean>(resolve => {
+      timeoutHandle = this.timer.setTimeout(() => resolve(false), DAEMON_REQUEST_HANDLER_DRAIN_TIMEOUT_MS);
+    });
+
+    try {
+      const drained = await Promise.race([Promise.allSettled(handlers).then(() => true), timeout]);
+      if (!drained) {
+        logger.warn(
+          `Timed out waiting for ${handlers.length} in-flight Unix socket request handler(s) to finish during shutdown`
+        );
+      }
+    } finally {
+      if (timeoutHandle !== undefined) {
+        this.timer.clearTimeout(timeoutHandle);
       }
     }
   }

--- a/test/daemon/socketServerClose.test.ts
+++ b/test/daemon/socketServerClose.test.ts
@@ -7,7 +7,6 @@ import { unlink } from "node:fs/promises";
 import { platform, tmpdir } from "node:os";
 import { join } from "node:path";
 import { UnixSocketServer } from "../../src/daemon/socketServer";
-import { defaultTimer } from "../../src/utils/SystemTimer";
 import { FakeTimer } from "../fakes/FakeTimer";
 
 const isWindows = platform() === "win32";
@@ -96,7 +95,7 @@ describe("UnixSocketServer close", () => {
     const closePromise = server.close();
 
     try {
-      await resolvesWithin(Promise.all([closePromise, clientClosed]), 100);
+      await Promise.all([closePromise, clientClosed]);
       expect(client.destroyed).toBe(true);
     } finally {
       if (!client.destroyed) {
@@ -104,31 +103,13 @@ describe("UnixSocketServer close", () => {
       }
       await closePromise;
     }
-  });
+  }, 1_000);
 });
 
 async function connectClient(socketPath: string): Promise<Socket> {
   const client = createConnection(socketPath);
   await once(client, "connect");
   return client;
-}
-
-function resolvesWithin<T>(promise: Promise<T>, timeoutMs: number): Promise<T> {
-  return new Promise((resolve, reject) => {
-    const timeout = defaultTimer.setTimeout(() => {
-      reject(new Error(`Timed out after ${timeoutMs}ms`));
-    }, timeoutMs);
-    promise.then(
-      value => {
-        defaultTimer.clearTimeout(timeout);
-        resolve(value);
-      },
-      error => {
-        defaultTimer.clearTimeout(timeout);
-        reject(error);
-      }
-    );
-  });
 }
 
 function listenOnSocket(socketPath: string): Promise<NetServer> {

--- a/test/daemon/socketServerClose.test.ts
+++ b/test/daemon/socketServerClose.test.ts
@@ -1,11 +1,13 @@
 import { afterEach, beforeEach, describe, expect, test } from "bun:test";
 import { randomUUID } from "node:crypto";
-import { createServer, type Server as NetServer } from "node:net";
+import { once } from "node:events";
+import { createConnection, createServer, type Server as NetServer, type Socket } from "node:net";
 import { existsSync } from "node:fs";
 import { unlink } from "node:fs/promises";
 import { platform, tmpdir } from "node:os";
 import { join } from "node:path";
 import { UnixSocketServer } from "../../src/daemon/socketServer";
+import { defaultTimer } from "../../src/utils/SystemTimer";
 import { FakeTimer } from "../fakes/FakeTimer";
 
 const isWindows = platform() === "win32";
@@ -50,6 +52,12 @@ describe("UnixSocketServer close", () => {
     expect(existsSync(socketPath)).toBe(false);
   });
 
+  (isWindows ? test.skip : test)("is idempotent after shutdown", async () => {
+    await server.close();
+
+    await expect(server.close()).resolves.toBeUndefined();
+  });
+
   (isWindows ? test.skip : test)("does not remove a replacement socket at the socket path", async () => {
     await unlink(socketPath);
     const replacementServer = await listenOnSocket(socketPath);
@@ -62,7 +70,47 @@ describe("UnixSocketServer close", () => {
       await closeServer(replacementServer);
     }
   });
+
+  (isWindows ? test.skip : test)("destroys active clients before waiting for server shutdown", async () => {
+    const client = await connectClient(socketPath);
+    const clientClosed = once(client, "close");
+    const closePromise = server.close();
+
+    try {
+      await resolvesWithin(Promise.all([closePromise, clientClosed]), 100);
+      expect(client.destroyed).toBe(true);
+    } finally {
+      if (!client.destroyed) {
+        client.destroy();
+      }
+      await closePromise;
+    }
+  });
 });
+
+async function connectClient(socketPath: string): Promise<Socket> {
+  const client = createConnection(socketPath);
+  await once(client, "connect");
+  return client;
+}
+
+function resolvesWithin<T>(promise: Promise<T>, timeoutMs: number): Promise<T> {
+  return new Promise((resolve, reject) => {
+    const timeout = defaultTimer.setTimeout(() => {
+      reject(new Error(`Timed out after ${timeoutMs}ms`));
+    }, timeoutMs);
+    promise.then(
+      value => {
+        defaultTimer.clearTimeout(timeout);
+        resolve(value);
+      },
+      error => {
+        defaultTimer.clearTimeout(timeout);
+        reject(error);
+      }
+    );
+  });
+}
 
 function listenOnSocket(socketPath: string): Promise<NetServer> {
   const replacementServer = createServer();

--- a/test/daemon/socketServerClose.test.ts
+++ b/test/daemon/socketServerClose.test.ts
@@ -11,12 +11,12 @@ import { FakeTimer } from "../fakes/FakeTimer";
 
 const isWindows = platform() === "win32";
 
-function createFakeDaemonState() {
+function createFakeDaemonState(refreshDevices: () => Promise<number> = async () => 0) {
   return {
     isInitialized: () => true,
     getSessionManager: () => ({ getSession: () => null, releaseSession: async () => null }),
     getDevicePool: () => ({
-      refreshDevices: async () => 0,
+      refreshDevices,
       getStats: () => ({ total: 0, idle: 0, assigned: 0, error: 0 }),
       releaseDevice: async () => {},
     }),
@@ -26,14 +26,16 @@ function createFakeDaemonState() {
 describe("UnixSocketServer close", () => {
   let socketPath: string;
   let server: UnixSocketServer;
+  let timer: FakeTimer;
 
   beforeEach(async () => {
     socketPath = join(tmpdir(), `socket-close-${randomUUID()}.sock`);
+    timer = new FakeTimer();
     server = new UnixSocketServer(
       socketPath,
       "http://localhost:0/mcp",
       createFakeDaemonState(),
-      new FakeTimer(),
+      timer,
     );
     await server.start();
   });
@@ -98,6 +100,102 @@ describe("UnixSocketServer close", () => {
       await Promise.all([closePromise, clientClosed]);
       expect(client.destroyed).toBe(true);
     } finally {
+      if (!client.destroyed) {
+        client.destroy();
+      }
+      await closePromise;
+    }
+  }, 1_000);
+
+  (isWindows ? test.skip : test)("drains an in-flight request before shutdown completes", async () => {
+    let releaseRefresh: () => void;
+    const refreshComplete = new Promise<number>(resolve => {
+      releaseRefresh = () => {resolve(0);};
+    });
+    let signalRefreshStarted: () => void;
+    const requestStarted = new Promise<void>(resolve => {
+      signalRefreshStarted = resolve;
+    });
+
+    await server.close();
+    timer = new FakeTimer();
+    server = new UnixSocketServer(
+      socketPath,
+      "http://localhost:0/mcp",
+      createFakeDaemonState(async () => {
+        signalRefreshStarted();
+        return refreshComplete;
+      }),
+      timer,
+    );
+    await server.start();
+
+    const client = await connectClient(socketPath);
+    const clientClosed = once(client, "close");
+    client.write(`${JSON.stringify({ id: "refresh", type: "mcp_request", method: "daemon/refreshDevices" })}\n`);
+    await requestStarted;
+
+    let closeCompleted = false;
+    const closePromise = server.close().then(() => {
+      closeCompleted = true;
+    });
+
+    try {
+      await clientClosed;
+      await Promise.resolve();
+      expect(closeCompleted).toBe(false);
+
+      releaseRefresh();
+      await closePromise;
+    } finally {
+      releaseRefresh();
+      if (!client.destroyed) {
+        client.destroy();
+      }
+      await closePromise;
+    }
+  }, 1_000);
+
+  (isWindows ? test.skip : test)("bounds shutdown while an in-flight request does not settle", async () => {
+    let releaseRefresh: () => void;
+    const refreshComplete = new Promise<number>(resolve => {
+      releaseRefresh = () => {
+        resolve(0);
+      };
+    });
+    let signalRefreshStarted: () => void;
+    const requestStarted = new Promise<void>(resolve => {
+      signalRefreshStarted = resolve;
+    });
+
+    await server.close();
+    timer = new FakeTimer();
+    server = new UnixSocketServer(
+      socketPath,
+      "http://localhost:0/mcp",
+      createFakeDaemonState(async () => {
+        signalRefreshStarted();
+        return refreshComplete;
+      }),
+      timer,
+    );
+    await server.start();
+
+    const client = await connectClient(socketPath);
+    const clientClosed = once(client, "close");
+    client.write(`${JSON.stringify({ id: "refresh", type: "mcp_request", method: "daemon/refreshDevices" })}\n`);
+    await requestStarted;
+
+    const closePromise = server.close();
+    try {
+      await clientClosed;
+      await Promise.resolve();
+      expect(timer.getPendingTimeoutCount()).toBe(1);
+
+      timer.advanceTime(1_000);
+      await closePromise;
+    } finally {
+      releaseRefresh();
       if (!client.destroyed) {
         client.destroy();
       }

--- a/test/daemon/socketServerClose.test.ts
+++ b/test/daemon/socketServerClose.test.ts
@@ -71,6 +71,25 @@ describe("UnixSocketServer close", () => {
     }
   });
 
+  (isWindows ? test.skip : test)("does not remove a successor socket bound during close", async () => {
+    const listener = (server as unknown as { server: NetServer | null }).server;
+    expect(listener).not.toBeNull();
+
+    const replacementServer = createServer();
+    const originalClose = listener!.close.bind(listener);
+    listener!.close = callback => originalClose(error => {
+      replacementServer.listen(socketPath, () => callback?.(error));
+    });
+
+    try {
+      await server.close();
+
+      expect(existsSync(socketPath)).toBe(true);
+    } finally {
+      await closeServer(replacementServer);
+    }
+  });
+
   (isWindows ? test.skip : test)("destroys active clients before waiting for server shutdown", async () => {
     const client = await connectClient(socketPath);
     const clientClosed = once(client, "close");


### PR DESCRIPTION
## Summary

Unix socket shutdown now starts closing the listener, destroys every active client socket, and only then waits for the close callback. It also drains already-started request handlers before returning, with a one-second injected-clock bound so shutdown remains finite. This prevents an idle connected client or a detached handler from blocking daemon recovery or SIGTERM cleanup. The listener alone removes the socket it created; post-close cleanup never unlinks a pathname that may now belong to a successor.

## Linked Issue

Closes #5300

## Bug / Regression Context

- **Prior attempts:** None.
- **Observed symptom:** `server.close()` waited indefinitely for a connected Unix client to disconnect.
- **Repro steps / conditions:** Start the daemon socket server, connect a Unix client, and invoke `close()` while the client remains idle.

## Validation

- [x] `bun run lint` and `bun run typecheck` report no new violations or errors.
- [x] Focused `bun test test/daemon/socketServerClose.test.ts` passes, including real-client prompt shutdown, handler draining/bounding, repeated-close, and successor-socket ownership-race coverage.
- [x] `bun test test/server/compactBoundsAdvertisement.property.test.ts` passes in isolation; the local all-tests phase of `turbo:validate` was stopped after it ceased progressing in that unrelated file under concurrent local test load. CI is running the complete suite on this exact head.
- [x] No Android, iOS, Kotlin, dependencies, or schema changes.

## Follow-ups

- [x] No out-of-scope follow-ups identified.
