### PR TITLE
fix(daemon): verify process exit after SIGKILL escalation

### DIFF
--- a/src/daemon/manager.ts
+++ b/src/daemon/manager.ts
@@ -1088,7 +1088,7 @@ export class DaemonManager implements DaemonManagerLike {
       await this.timer.sleep(pollInterval);
     }
 
-    return false;
+    return !this.isProcessRunning(pid);
   }
 
   /**

--- a/src/daemon/manager.ts
+++ b/src/daemon/manager.ts
@@ -844,8 +844,9 @@ export class DaemonManager implements DaemonManagerLike {
         stderrLog(`Daemon did not stop gracefully, sending SIGKILL...`);
         process.kill(pid, "SIGKILL");
 
-        // Wait a bit more
-        await this.timer.sleep(1000);
+        if (!(await this.waitForStop(pid, 1000))) {
+          throw new Error(`Daemon process ${pid} did not exit after SIGKILL`);
+        }
       }
 
       await cleanupDaemonFiles({

--- a/test/daemon/manager.test.ts
+++ b/test/daemon/manager.test.ts
@@ -104,6 +104,114 @@ describe("DaemonManager restart", () => {
   });
 });
 
+describe("DaemonManager stop", () => {
+  function createManagerForStop(
+    livePids: Set<number>,
+    timer: FakeTimer,
+    pidFilePath: string,
+    socketPath: string,
+    onLivenessCheck?: () => void,
+  ): DaemonManager {
+    const processFinder: DaemonProcessFinder & DaemonProcessLivenessChecker = {
+      findDaemonProcesses: () => [],
+      isProcessRunning: pid => {
+        onLivenessCheck?.();
+        return livePids.has(pid);
+      },
+    };
+    return new DaemonManager(
+      undefined,
+      undefined,
+      timer,
+      join(tmpdir(), "unused-daemon-lock"),
+      pidFilePath,
+      socketPath,
+      processFinder,
+    );
+  }
+
+  function writeStopPidFile(pidFilePath: string, pid: number, socketPath: string): void {
+    writeFileSync(pidFilePath, JSON.stringify({
+      pid,
+      socketPath,
+      port: 3000,
+      startedAt: 1,
+      version: "test",
+    }));
+  }
+
+  test("fails without cleanup when the daemon remains live after SIGKILL", async () => {
+    const directory = mkdtempSync(join(tmpdir(), "daemon-manager-stop-stubborn-"));
+    const pidFilePath = join(directory, "daemon.pid");
+    const socketPath = join(directory, "daemon.sock");
+    const pid = 4242;
+    const livePids = new Set([pid]);
+    const timer = new FakeTimer();
+    timer.enableAutoAdvance();
+    writeStopPidFile(pidFilePath, pid, socketPath);
+    writeFileSync(socketPath, "socket");
+    const manager = createManagerForStop(livePids, timer, pidFilePath, socketPath);
+    const killSpy = spyOn(process, "kill").mockImplementation(() => true);
+
+    try {
+      await expect(manager.stop(1_000)).rejects.toThrow(
+        "Daemon process 4242 did not exit after SIGKILL",
+      );
+
+      expect(killSpy.mock.calls.filter(([targetPid]) => targetPid === pid)).toEqual([
+        [pid, "SIGTERM"],
+        [pid, "SIGKILL"],
+      ]);
+      expect(existsSync(pidFilePath)).toBe(true);
+      expect(existsSync(socketPath)).toBe(true);
+    } finally {
+      killSpy.mockRestore();
+      rmSync(directory, { recursive: true, force: true });
+    }
+  });
+
+  test("cleans metadata after post-SIGKILL polling confirms exit", async () => {
+    const directory = mkdtempSync(join(tmpdir(), "daemon-manager-stop-exit-"));
+    const pidFilePath = join(directory, "daemon.pid");
+    const socketPath = join(directory, "daemon.sock");
+    const pid = 4243;
+    const livePids = new Set([pid]);
+    const timer = new FakeTimer();
+    let livenessChecks = 0;
+    timer.enableAutoAdvance();
+    writeStopPidFile(pidFilePath, pid, socketPath);
+    writeFileSync(socketPath, "socket");
+    const manager = createManagerForStop(
+      livePids,
+      timer,
+      pidFilePath,
+      socketPath,
+      () => { livenessChecks++; },
+    );
+    const killSpy = spyOn(process, "kill").mockImplementation((_targetPid, signal) => {
+      if (signal === "SIGKILL") {
+        livePids.delete(pid);
+      }
+      return true;
+    });
+
+    try {
+      await expect(manager.stop(1_000)).resolves.toBeUndefined();
+
+      expect(killSpy.mock.calls.filter(([targetPid]) => targetPid === pid)).toEqual([
+        [pid, "SIGTERM"],
+        [pid, "SIGKILL"],
+      ]);
+      expect(livenessChecks).toBe(12);
+      expect(existsSync(pidFilePath)).toBe(false);
+      expect(existsSync(socketPath)).toBe(false);
+    } finally {
+      killSpy.mockRestore();
+      rmSync(directory, { recursive: true, force: true });
+    }
+  });
+});
+
 class FakeDaemonClient implements DaemonClientLike {
   readonly readResourceCalls: string[] = [];
   readonly callToolCalls: Array<{ toolName: string; params: Record<string, any> }> = [];

--- a/test/daemon/manager.test.ts
+++ b/test/daemon/manager.test.ts
@@ -202,7 +202,40 @@ describe("DaemonManager stop", () => {
         [pid, "SIGTERM"],
         [pid, "SIGKILL"],
       ]);
-      expect(livenessChecks).toBe(12);
+      expect(livenessChecks).toBeGreaterThan(12);
+      expect(existsSync(pidFilePath)).toBe(false);
+      expect(existsSync(socketPath)).toBe(false);
+    } finally {
+      killSpy.mockRestore();
+      rmSync(directory, { recursive: true, force: true });
+    }
+  });
+
+  test("cleans metadata when the daemon exits at the post-SIGKILL deadline", async () => {
+    const directory = mkdtempSync(join(tmpdir(), "daemon-manager-stop-deadline-"));
+    const pidFilePath = join(directory, "daemon.pid");
+    const socketPath = join(directory, "daemon.sock");
+    const pid = 4244;
+    const livePids = new Set([pid]);
+    const timer = new FakeTimer();
+    timer.enableAutoAdvance();
+    writeStopPidFile(pidFilePath, pid, socketPath);
+    writeFileSync(socketPath, "socket");
+    const manager = createManagerForStop(livePids, timer, pidFilePath, socketPath);
+    const killSpy = spyOn(process, "kill").mockImplementation((_targetPid, signal) => {
+      if (signal === "SIGKILL") {
+        timer.setTimeout(() => { livePids.delete(pid); }, 1_000);
+      }
+      return true;
+    });
+
+    try {
+      await expect(manager.stop(1_000)).resolves.toBeUndefined();
+
+      expect(killSpy.mock.calls.filter(([targetPid]) => targetPid === pid)).toEqual([
+        [pid, "SIGTERM"],
+        [pid, "SIGKILL"],
+      ]);
       expect(existsSync(pidFilePath)).toBe(false);
       expect(existsSync(socketPath)).toBe(false);
     } finally {


### PR DESCRIPTION
## Summary

- Verify daemon liveness with bounded polling after SIGKILL escalation.
- Retain daemon PID and socket metadata when the process remains live and report an explicit error.
- Cover both failed termination and confirmed post-SIGKILL cleanup with FakeTimer tests.

## Root cause

Daemon shutdown previously waited one second after SIGKILL and then removed ownership metadata without checking whether the target process had exited. A surviving process could therefore race a replacement daemon after its metadata was deleted.

## Validation

- `bun test test/daemon/manager.test.ts`
- `bun run typecheck`
- `bun run turbo:validate`
- `git diff --check origin/main...HEAD`

Closes #5299
