### PR TITLE
fix(daemon): terminate timed-out daemon child

### DIFF
--- a/src/daemon/DaemonLauncher.ts
+++ b/src/daemon/DaemonLauncher.ts
@@ -136,8 +136,10 @@ export class DaemonLauncher {
 
     const readinessAbort = new AbortController();
     let cleanupProcessListeners = () => {};
+    let processFailureObserved = false;
     const processFailure = new Promise<never>((_, reject) => {
       const rejectWithContext = (summary: string) => {
+        processFailureObserved = true;
         void request.formatFailure(summary).then(
           error => {
             reject(error);
@@ -153,6 +155,7 @@ export class DaemonLauncher {
         rejectWithContext(`Daemon subprocess failed to spawn: ${formatRawSpawnError(error)}`);
       };
       const onExit = (code: number | null, signal: NodeJS.Signals | null) => {
+        processFailureObserved = true;
         if (request.formatExitFailure) {
           void request.formatExitFailure(code, signal).then(
             error => {
@@ -188,10 +191,19 @@ export class DaemonLauncher {
         // PID-recorded daemon and its connection before signalling the exact
         // spawned handle, so a daemon that became healthy at the deadline lives.
         readinessAbort.abort();
-        cleanupProcessListeners();
-        if (await request.isReadyForLaunchedProcess?.(daemonProcess.pid) ?? false) {
+        // Keep the startup listeners installed while the final check awaits so
+        // a late child error or exit cannot become unobserved in that window.
+        const isReadyAtDeadline = await Promise.race([
+          request.isReadyForLaunchedProcess?.(daemonProcess.pid) ?? Promise.resolve(false),
+          processFailure,
+        ]);
+        if (processFailureObserved) {
+          await processFailure;
+        }
+        if (isReadyAtDeadline) {
           return;
         }
+        cleanupProcessListeners();
 
         // Keep startup ownership until the child has actually exited. The shared
         // tracker sends SIGTERM, escalates to SIGKILL after the bounded daemon

--- a/src/daemon/DaemonLauncher.ts
+++ b/src/daemon/DaemonLauncher.ts
@@ -2,8 +2,10 @@ import { spawn as nodeSpawn, type ChildProcess, type SpawnOptions } from "node:c
 import { existsSync } from "node:fs";
 import { posix, win32 } from "node:path";
 import { ActionableError } from "../models";
+import { trackProcess, waitForExit, type TrackedChildProcess } from "../utils/ChildProcessTracker";
 import { releaseVersion } from "../utils/mcpVersion";
-import { DAEMON_VERSION } from "./constants";
+import { defaultTimer, type Timer } from "../utils/SystemTimer";
+import { DAEMON_SHUTDOWN_TIMEOUT_MS, DAEMON_VERSION } from "./constants";
 
 export interface DaemonLaunchCommand {
   command: string;
@@ -22,6 +24,7 @@ export interface DaemonLauncherDependencies {
   processExecPath?: string;
   executableExists?: (path: string) => boolean;
   spawn?: DaemonProcessSpawner["spawn"];
+  timer?: Timer;
 }
 
 export interface DaemonLaunchRequest {
@@ -30,6 +33,11 @@ export interface DaemonLaunchRequest {
   spawnOptions: SpawnOptions;
   timeoutMs: number;
   waitForReady: (timeoutMs: number, signal: AbortSignal) => Promise<boolean>;
+  /**
+   * Rechecks that the exact spawned PID is now the reachable daemon before the
+   * launcher terminates it for a readiness timeout.
+   */
+  isReadyForLaunchedProcess?: (pid: number | undefined) => Promise<boolean>;
   formatFailure: (summary: string) => Promise<Error>;
   formatExitFailure?: (code: number | null, signal: NodeJS.Signals | null) => Promise<Error>;
 }
@@ -89,6 +97,7 @@ export class DaemonLauncher {
   private readonly processExecPath: string;
   private readonly executableExists: (path: string) => boolean;
   private readonly spawn: DaemonProcessSpawner["spawn"];
+  private readonly timer: Timer;
 
   constructor(dependencies: DaemonLauncherDependencies = {}) {
     this.entryScript = dependencies.entryScript === undefined
@@ -100,6 +109,7 @@ export class DaemonLauncher {
     this.processExecPath = dependencies.processExecPath ?? process.execPath;
     this.executableExists = dependencies.executableExists ?? existsSync;
     this.spawn = dependencies.spawn ?? nodeSpawn;
+    this.timer = dependencies.timer ?? defaultTimer;
   }
 
   resolveCommand(): DaemonLaunchCommand {
@@ -174,6 +184,24 @@ export class DaemonLauncher {
         processFailure,
       ]);
       if (!ready) {
+        // A readiness timeout can race the child binding its socket. Recheck the
+        // PID-recorded daemon and its connection before signalling the exact
+        // spawned handle, so a daemon that became healthy at the deadline lives.
+        readinessAbort.abort();
+        cleanupProcessListeners();
+        if (await request.isReadyForLaunchedProcess?.(daemonProcess.pid) ?? false) {
+          return;
+        }
+
+        // Keep startup ownership until the child has actually exited. The shared
+        // tracker sends SIGTERM, escalates to SIGKILL after the bounded daemon
+        // shutdown grace, and waits for the corresponding exit observation.
+        const tracker = trackProcess(daemonProcess as TrackedChildProcess);
+        await waitForExit(tracker.process, tracker.exitPromise, {
+          signal: "SIGTERM",
+          timeoutMs: DAEMON_SHUTDOWN_TIMEOUT_MS,
+          timer: this.timer,
+        });
         throw await request.formatFailure(`Daemon failed to start within ${request.timeoutMs}ms`);
       }
     } finally {

--- a/src/daemon/manager.ts
+++ b/src/daemon/manager.ts
@@ -361,10 +361,12 @@ export class DaemonManager implements DaemonManagerLike {
     this.launchCommandResolver = typeof launcher === "function" ? launcher : undefined;
     this.launcher = (typeof launcher === "object" ? launcher : undefined) ?? new DaemonLauncher({
       spawn: processSpawner?.spawn.bind(processSpawner),
+      timer,
     });
     this.fallbackLauncher = new DaemonLauncher({
       entryScript: null,
       spawn: processSpawner?.spawn.bind(processSpawner),
+      timer,
     });
     this.clientFactory = clientFactory ?? (() => new DaemonClient(this.socketPath));
   }
@@ -590,6 +592,7 @@ export class DaemonManager implements DaemonManagerLike {
             },
             timeoutMs: DAEMON_STARTUP_TIMEOUT_MS,
             waitForReady: (timeoutMs, signal) => this.waitForReady(timeoutMs, signal),
+            isReadyForLaunchedProcess: pid => this.isLaunchedProcessReady(pid),
             formatFailure: summary => this.createDaemonStartupFailure(summary, logPath),
             formatExitFailure: (code, signal) => this.createDaemonExitFailure(code, signal, logPath),
           });
@@ -1048,6 +1051,15 @@ export class DaemonManager implements DaemonManagerLike {
     }
 
     return false;
+  }
+
+  private async isLaunchedProcessReady(pid: number | undefined): Promise<boolean> {
+    if (pid === undefined) {
+      return false;
+    }
+
+    const status = await this.status();
+    return status.running === true && status.pid === pid && await this.verifyDaemonConnection();
   }
 
   /**

--- a/test/daemon/DaemonLauncher.test.ts
+++ b/test/daemon/DaemonLauncher.test.ts
@@ -14,18 +14,23 @@ class FakeDaemonProcess extends EventEmitter {
   killed = false;
   readonly signals: NodeJS.Signals[] = [];
   exitOnSignal: NodeJS.Signals | undefined;
+  emitExitImmediately = true;
 
   unref(): void {}
 
   kill(signal: NodeJS.Signals): boolean {
     this.killed = true;
     this.signals.push(signal);
-    if (this.exitOnSignal === signal) {
-      this.exitCode = 0;
-      this.signalCode = signal;
-      this.emit("exit", 0, signal);
+    if (this.exitOnSignal === signal && this.emitExitImmediately) {
+      this.emitExit(signal);
     }
     return true;
+  }
+
+  emitExit(signal: NodeJS.Signals): void {
+    this.exitCode = 0;
+    this.signalCode = signal;
+    this.emit("exit", 0, signal);
   }
 }
 
@@ -180,6 +185,37 @@ describe("DaemonLauncher", () => {
     expect(spawner.process.exitCode).toBe(0);
   });
 
+  test("does not release startup ownership until the timed-out child exits", async () => {
+    const spawner = new FakeDaemonSpawner();
+    spawner.process.exitOnSignal = "SIGTERM";
+    spawner.process.emitExitImmediately = false;
+    const timer = new FakeTimer();
+    timer.enableAutoAdvance();
+    const launcher = new DaemonLauncher({
+      spawn: spawner.spawn.bind(spawner),
+      timer,
+    });
+    let settled = false;
+    const launch = launcher.launchAndWait({
+      command: "auto-mobile",
+      args: ["--daemon-mode"],
+      spawnOptions: {},
+      timeoutMs: 100,
+      waitForReady: async () => false,
+      formatFailure: async summary => new Error(summary),
+    }).finally(() => {
+      settled = true;
+    });
+
+    await new Promise<void>(resolve => setImmediate(resolve));
+    expect(spawner.process.signals).toEqual(["SIGTERM"]);
+    expect(settled).toBe(false);
+
+    spawner.process.emitExit("SIGTERM");
+    await expect(launch).rejects.toThrow("Daemon failed to start within 100ms");
+    expect(settled).toBe(true);
+  });
+
   test("escalates to SIGKILL when the timed-out child ignores SIGTERM", async () => {
     const spawner = new FakeDaemonSpawner();
     spawner.process.exitOnSignal = "SIGKILL";
@@ -223,5 +259,28 @@ describe("DaemonLauncher", () => {
 
     expect(finalChecks).toEqual([12345]);
     expect(spawner.process.signals).toEqual([]);
+  });
+
+  test("keeps child error observation while the final readiness check is pending", async () => {
+    const spawner = new FakeDaemonSpawner();
+    const launcher = new DaemonLauncher({ spawn: spawner.spawn.bind(spawner) });
+
+    await expect(launcher.launchAndWait({
+      command: "auto-mobile",
+      args: ["--daemon-mode"],
+      spawnOptions: {},
+      timeoutMs: 100,
+      waitForReady: async () => false,
+      isReadyForLaunchedProcess: async () => {
+        await Promise.resolve();
+        spawner.process.emit("error", new Error("late child error"));
+        return false;
+      },
+      formatFailure: async summary => new Error(`formatted: ${summary}`),
+    })).rejects.toThrow("formatted: Daemon subprocess failed to spawn: late child error");
+
+    expect(spawner.process.signals).toEqual([]);
+    expect(spawner.process.listenerCount("error")).toBe(0);
+    expect(spawner.process.listenerCount("exit")).toBe(0);
   });
 });

--- a/test/daemon/DaemonLauncher.test.ts
+++ b/test/daemon/DaemonLauncher.test.ts
@@ -5,9 +5,28 @@ import {
   DaemonLauncher,
   type DaemonProcessSpawner,
 } from "../../src/daemon/DaemonLauncher";
+import { FakeTimer } from "../fakes/FakeTimer";
 
 class FakeDaemonProcess extends EventEmitter {
+  pid = 12345;
+  exitCode: number | null = null;
+  signalCode: NodeJS.Signals | null = null;
+  killed = false;
+  readonly signals: NodeJS.Signals[] = [];
+  exitOnSignal: NodeJS.Signals | undefined;
+
   unref(): void {}
+
+  kill(signal: NodeJS.Signals): boolean {
+    this.killed = true;
+    this.signals.push(signal);
+    if (this.exitOnSignal === signal) {
+      this.exitCode = 0;
+      this.signalCode = signal;
+      this.emit("exit", 0, signal);
+    }
+    return true;
+  }
 }
 
 class FakeDaemonSpawner implements DaemonProcessSpawner {
@@ -130,5 +149,79 @@ describe("DaemonLauncher", () => {
     expect(readinessSignal?.aborted).toBe(true);
     expect(spawner.process.listenerCount("error")).toBe(0);
     expect(spawner.process.listenerCount("exit")).toBe(0);
+  });
+
+  test("terminates and observes a child that remains alive after readiness times out", async () => {
+    const spawner = new FakeDaemonSpawner();
+    spawner.process.exitOnSignal = "SIGTERM";
+    const timer = new FakeTimer();
+    timer.enableAutoAdvance();
+    const launcher = new DaemonLauncher({
+      spawn: spawner.spawn.bind(spawner),
+      timer,
+    });
+    const finalChecks: Array<number | undefined> = [];
+
+    await expect(launcher.launchAndWait({
+      command: "auto-mobile",
+      args: ["--daemon-mode"],
+      spawnOptions: {},
+      timeoutMs: 100,
+      waitForReady: async () => false,
+      isReadyForLaunchedProcess: async pid => {
+        finalChecks.push(pid);
+        return false;
+      },
+      formatFailure: async summary => new Error(`formatted: ${summary}`),
+    })).rejects.toThrow("formatted: Daemon failed to start within 100ms");
+
+    expect(finalChecks).toEqual([12345]);
+    expect(spawner.process.signals).toEqual(["SIGTERM"]);
+    expect(spawner.process.exitCode).toBe(0);
+  });
+
+  test("escalates to SIGKILL when the timed-out child ignores SIGTERM", async () => {
+    const spawner = new FakeDaemonSpawner();
+    spawner.process.exitOnSignal = "SIGKILL";
+    const timer = new FakeTimer();
+    timer.enableAutoAdvance();
+    const launcher = new DaemonLauncher({
+      spawn: spawner.spawn.bind(spawner),
+      timer,
+    });
+
+    await expect(launcher.launchAndWait({
+      command: "auto-mobile",
+      args: ["--daemon-mode"],
+      spawnOptions: {},
+      timeoutMs: 100,
+      waitForReady: async () => false,
+      formatFailure: async summary => new Error(summary),
+    })).rejects.toThrow("Daemon failed to start within 100ms");
+
+    expect(spawner.process.signals).toEqual(["SIGTERM", "SIGKILL"]);
+    expect(spawner.process.exitCode).toBe(0);
+  });
+
+  test("keeps a launched child that becomes ready at the readiness deadline", async () => {
+    const spawner = new FakeDaemonSpawner();
+    const launcher = new DaemonLauncher({ spawn: spawner.spawn.bind(spawner) });
+    const finalChecks: Array<number | undefined> = [];
+
+    await launcher.launchAndWait({
+      command: "auto-mobile",
+      args: ["--daemon-mode"],
+      spawnOptions: {},
+      timeoutMs: 100,
+      waitForReady: async () => false,
+      isReadyForLaunchedProcess: async pid => {
+        finalChecks.push(pid);
+        return true;
+      },
+      formatFailure: async summary => new Error(summary),
+    });
+
+    expect(finalChecks).toEqual([12345]);
+    expect(spawner.process.signals).toEqual([]);
   });
 });

--- a/test/daemon/daemonManagerReadiness.test.ts
+++ b/test/daemon/daemonManagerReadiness.test.ts
@@ -44,7 +44,21 @@ class ProbeClient implements DaemonClientLike {
 
 class FakeDaemonProcess extends EventEmitter {
   pid = 12345;
+  exitCode: number | null = null;
+  signalCode: NodeJS.Signals | null = null;
+  killed = false;
+  readonly signals: NodeJS.Signals[] = [];
+
   unref(): void {}
+
+  kill(signal: NodeJS.Signals): boolean {
+    this.killed = true;
+    this.signals.push(signal);
+    this.exitCode = 0;
+    this.signalCode = signal;
+    this.emit("exit", 0, signal);
+    return true;
+  }
 }
 
 class FakeDaemonSpawner implements DaemonProcessSpawner {
@@ -330,9 +344,56 @@ describe("DaemonManager readiness", () => {
         /Daemon failed to start within \d+ms[\s\S]*Logs: .*daemon-launch-\d+\.log[\s\S]*SQLiteError: database is locked/
       );
       expect(message).not.toContain("OLD_LOG_START");
+      expect(spawner.process.signals).toEqual(["SIGTERM"]);
     } finally {
       readySpy.mockRestore();
       findSpy.mockRestore();
+    }
+  });
+
+  test("preserves the spawned daemon when its exact PID becomes reachable at the deadline", async () => {
+    const { lockPath, pidPath, socketPath } = createPaths();
+    const fakeTimer = new FakeTimer();
+    const spawner = new FakeDaemonSpawner();
+    const clients: ProbeClient[] = [];
+    const manager = new DaemonManager(
+      () => {
+        const client = new ProbeClient(true);
+        clients.push(client);
+        return client;
+      },
+      undefined,
+      fakeTimer,
+      lockPath,
+      pidPath,
+      socketPath,
+      spawner
+    );
+    let statusCalls = 0;
+    const statusSpy = spyOn(manager, "status").mockImplementation(async () => {
+      statusCalls++;
+      if (statusCalls === 1) {
+        return { running: false };
+      }
+      return {
+        running: true,
+        pid: spawner.process.pid,
+        port: 31879,
+        socketPath,
+      };
+    });
+    const findSpy = spyOn(manager, "findAllDaemonProcesses").mockReturnValue([]);
+    const readySpy = spyOn(manager, "waitForReady").mockResolvedValue(false);
+
+    try {
+      await expect(manager.start()).resolves.toBeUndefined();
+      expect(statusCalls).toBe(3);
+      expect(clients[0].connectCallCount).toBe(1);
+      expect(spawner.process.signals).toEqual([]);
+    } finally {
+      statusSpy.mockRestore();
+      findSpy.mockRestore();
+      readySpy.mockRestore();
     }
   });
 


### PR DESCRIPTION
## Summary

- terminate the exact detached daemon child when its startup readiness wait fails, using `SIGTERM` followed by bounded `SIGKILL` escalation and an observed exit
- recheck that the launched PID is the reachable daemon at the deadline, preserving it when it became healthy during the race
- cover graceful termination, forced termination, and deadline-race preservation with `FakeTimer` unit tests

## Root cause

`DaemonLauncher` aborted the readiness waiter on failure but released startup ownership without signalling or observing the still-running detached child.

## Validation

- `bun test test/daemon/DaemonLauncher.test.ts test/daemon/daemonManagerReadiness.test.ts`
- `bun run lint`
- `bun run typecheck`
- `bun run turbo:validate`
- `bun run check:daemon-launcher-boundary`

Closes #5298
