### PR TITLE
fix(daemon): preserve live assignments after startup timeout

### DIFF
--- a/src/daemon/daemon.ts
+++ b/src/daemon/daemon.ts
@@ -1399,7 +1399,7 @@ export class Daemon {
   private async initializeDevicePoolWithTimeout(timeoutMs: number): Promise<void> {
     let timeoutHandle: NodeJS.Timeout | undefined;
     const timeoutPromise = new Promise<void>(resolve => {
-      timeoutHandle = defaultTimer.setTimeout(() => {
+      timeoutHandle = this.timer.setTimeout(() => {
         logger.warn(`Device pool initialization timed out after ${timeoutMs}ms`);
         resolve();
       }, timeoutMs);
@@ -1414,7 +1414,7 @@ export class Daemon {
       await Promise.race([initPromise, timeoutPromise]);
     } finally {
       if (timeoutHandle !== undefined) {
-        defaultTimer.clearTimeout(timeoutHandle);
+        this.timer.clearTimeout(timeoutHandle);
       }
     }
 
@@ -1434,17 +1434,19 @@ export class Daemon {
    */
   private async initializeDevicePool(): Promise<void> {
     try {
-      const deviceManager = new MultiPlatformDeviceManager();
-      const bootedDevices = await deviceManager.getBootedDevices("either");
+      // Use the pool's refresh path instead of replacing entries directly. The
+      // startup timeout does not cancel discovery, so this may run after a
+      // session has claimed a device; refresh preserves that owner and its
+      // incarnation when rediscovering the same device.
+      await this.devicePool.refreshDevices();
+      const bootedDevices = this.devicePool.getAllDevices();
 
       if (bootedDevices.length > 0) {
-        await this.devicePool.initializeWithDevices(bootedDevices);
         // Mint a device-session epoch for every startup-booted device so
         // daemon/listDeviceSessions enumerates idle devices immediately, without
-        // waiting for a first assignment/refresh. initializeWithDevices does not
-        // fire the device-ready callback (that path stays silent by contract), so
-        // mint directly here. Idempotent with the later onDeviceReady mint — the
-        // incarnation is unchanged, so it returns the same uuid (epic #5256).
+        // waiting for a first assignment/refresh. The refresh callback may have
+        // minted these already; this is idempotent because the incarnation is
+        // unchanged (epic #5256).
         for (const pooled of this.devicePool.getAllDevices()) {
           this.deviceSessionRegistry.onDeviceConnected({
             deviceId: pooled.id,
@@ -1452,7 +1454,7 @@ export class Daemon {
             incarnation: pooled.incarnation,
           });
         }
-        logger.info(`Device pool initialized with ${bootedDevices.length} devices: ${bootedDevices.map(device => device.deviceId).join(", ")}`);
+        logger.info(`Device pool initialized with ${bootedDevices.length} devices: ${bootedDevices.map(device => device.id).join(", ")}`);
       } else {
         logger.warn("No devices detected during daemon startup. Device pool is empty.");
         logger.warn("Start an emulator or connect a physical device before creating sessions.");

--- a/test/daemon/daemonDevicePoolStartup.test.ts
+++ b/test/daemon/daemonDevicePoolStartup.test.ts
@@ -1,0 +1,114 @@
+import { afterEach, describe, expect, test } from "bun:test";
+import { Daemon } from "../../src/daemon/daemon";
+import { DevicePool } from "../../src/daemon/devicePool";
+import { DaemonState } from "../../src/daemon/daemonState";
+import { DeviceSessionRepository } from "../../src/db/deviceSessionRepository";
+import type { BootedDevice, SomePlatform } from "../../src/models";
+import { CountingIdGenerator } from "../../src/utils/IdGenerator";
+import { FakeDatabaseInitializer } from "../fakes/FakeDatabaseInitializer";
+import { FakeDeviceManager } from "../fakes/FakeDeviceManager";
+import { FakeInstalledAppsRepository } from "../fakes/FakeInstalledAppsRepository";
+import { FakeStartupFailureTracker } from "../fakes/FakeStartupFailureTracker";
+import { FakeTimer } from "../fakes/FakeTimer";
+
+interface DaemonStartupInternals {
+  devicePool: DevicePool;
+  initializeDevicePoolWithTimeout(timeoutMs: number): Promise<void>;
+}
+
+class DeferredDiscoveryDeviceManager extends FakeDeviceManager {
+  private discoveryStarted = false;
+  private readonly started = Promise.withResolvers<void>();
+  private readonly release = Promise.withResolvers<void>();
+  private readonly completed = Promise.withResolvers<void>();
+
+  override async getBootedDevicesDetailed(platform: SomePlatform) {
+    this.discoveryStarted = true;
+    this.started.resolve();
+    await this.release.promise;
+    const discovery = await super.getBootedDevicesDetailed(platform);
+    this.completed.resolve();
+    return discovery;
+  }
+
+  waitForDiscoveryStart(): Promise<void> {
+    return this.started.promise;
+  }
+
+  hasStartedDiscovery(): boolean {
+    return this.discoveryStarted;
+  }
+
+  releaseDiscovery(): void {
+    this.release.resolve();
+  }
+
+  waitForDiscoveryCompletion(): Promise<void> {
+    return this.completed.promise;
+  }
+}
+
+class FakeDeviceSessionRepository extends DeviceSessionRepository {
+  override async upsertActiveSession(): Promise<void> {}
+}
+
+function buildDaemon(timer: FakeTimer): Daemon {
+  return new Daemon(
+    {},
+    new FakeInstalledAppsRepository(),
+    timer,
+    new FakeDeviceSessionRepository(),
+    new CountingIdGenerator("daemon-session"),
+    new FakeDatabaseInitializer(),
+    new FakeStartupFailureTracker(),
+  );
+}
+
+describe("Daemon startup device discovery", () => {
+  afterEach(() => {
+    if (DaemonState.getInstance().isInitialized()) {
+      DaemonState.getInstance().reset();
+    }
+  });
+
+  test("does not overwrite a live assignment when timed-out discovery finishes later", async () => {
+    const timer = new FakeTimer();
+    const daemon = buildDaemon(timer);
+    const internals = daemon as unknown as DaemonStartupInternals;
+    const manager = new DeferredDiscoveryDeviceManager();
+    const device: BootedDevice = { deviceId: "android-device-1", name: "Pixel 8", platform: "android" };
+    manager.bootedDevices = [device];
+    (internals.devicePool as unknown as { deviceManager: DeferredDiscoveryDeviceManager }).deviceManager = manager;
+
+    const startup = internals.initializeDevicePoolWithTimeout(5_000);
+    await Promise.resolve();
+    expect(manager.hasStartedDiscovery()).toBe(true);
+    await manager.waitForDiscoveryStart();
+
+    timer.advanceTime(5_000);
+    await startup;
+
+    await internals.devicePool.initializeWithDevices([device]);
+    const assignedBeforeLateDiscovery = internals.devicePool.getDevice(device.deviceId);
+    if (!assignedBeforeLateDiscovery) {
+      throw new Error("expected startup device in pool");
+    }
+    await internals.devicePool.assignDeviceToSession("live-session", "android");
+    expect(assignedBeforeLateDiscovery).toMatchObject({
+      sessionId: "live-session",
+      status: "busy",
+    });
+    const incarnation = assignedBeforeLateDiscovery?.incarnation;
+
+    manager.releaseDiscovery();
+    await manager.waitForDiscoveryCompletion();
+    await Promise.resolve();
+    await Promise.resolve();
+
+    expect(internals.devicePool.getDevice(device.deviceId)).toMatchObject({
+      sessionId: "live-session",
+      status: "busy",
+      incarnation,
+    });
+  });
+});

--- a/test/daemon/daemonDevicePoolStartup.test.ts
+++ b/test/daemon/daemonDevicePoolStartup.test.ts
@@ -20,15 +20,12 @@ class DeferredDiscoveryDeviceManager extends FakeDeviceManager {
   private discoveryStarted = false;
   private readonly started = Promise.withResolvers<void>();
   private readonly release = Promise.withResolvers<void>();
-  private readonly completed = Promise.withResolvers<void>();
 
   override async getBootedDevicesDetailed(platform: SomePlatform) {
     this.discoveryStarted = true;
     this.started.resolve();
     await this.release.promise;
-    const discovery = await super.getBootedDevicesDetailed(platform);
-    this.completed.resolve();
-    return discovery;
+    return await super.getBootedDevicesDetailed(platform);
   }
 
   waitForDiscoveryStart(): Promise<void> {
@@ -43,9 +40,6 @@ class DeferredDiscoveryDeviceManager extends FakeDeviceManager {
     this.release.resolve();
   }
 
-  waitForDiscoveryCompletion(): Promise<void> {
-    return this.completed.promise;
-  }
 }
 
 class FakeDeviceSessionRepository extends DeviceSessionRepository {
@@ -77,8 +71,16 @@ describe("Daemon startup device discovery", () => {
     const internals = daemon as unknown as DaemonStartupInternals;
     const manager = new DeferredDiscoveryDeviceManager();
     const device: BootedDevice = { deviceId: "android-device-1", name: "Pixel 8", platform: "android" };
-    manager.bootedDevices = [device];
+    const lateDevice: BootedDevice = { deviceId: "android-device-2", name: "Pixel 9", platform: "android" };
+    manager.bootedDevices = [device, lateDevice];
     (internals.devicePool as unknown as { deviceManager: DeferredDiscoveryDeviceManager }).deviceManager = manager;
+    const refreshCompleted = Promise.withResolvers<void>();
+    const originalRefresh = internals.devicePool.refreshDevices.bind(internals.devicePool);
+    internals.devicePool.refreshDevices = async () => {
+      const added = await originalRefresh();
+      refreshCompleted.resolve();
+      return added;
+    };
 
     const startup = internals.initializeDevicePoolWithTimeout(5_000);
     await Promise.resolve();
@@ -101,14 +103,16 @@ describe("Daemon startup device discovery", () => {
     const incarnation = assignedBeforeLateDiscovery?.incarnation;
 
     manager.releaseDiscovery();
-    await manager.waitForDiscoveryCompletion();
-    await Promise.resolve();
-    await Promise.resolve();
+    await refreshCompleted.promise;
 
     expect(internals.devicePool.getDevice(device.deviceId)).toMatchObject({
       sessionId: "live-session",
       status: "busy",
       incarnation,
+    });
+    expect(internals.devicePool.getDevice(lateDevice.deviceId)).toMatchObject({
+      sessionId: null,
+      status: "idle",
     });
   });
 });


### PR DESCRIPTION
## Summary

Routes daemon startup discovery through `DevicePool.refreshDevices()` instead of directly replacing pool entries. A timed-out discovery can therefore finish after the daemon begins serving without changing a live session's ownership or device incarnation.

## Linked Issue

Closes [issue #5296](https://github.com/kaeawc/auto-mobile/issues/5296).

## Bug / Regression Context

- **Observed symptom:** a delayed startup discovery could replace an assigned device with a new idle pool entry.
- **Repro steps / conditions:** initial discovery exceeds five seconds, a session claims the device, then the original discovery returns that same device.

## Validation

- [x] `bun run turbo:validate` passes (lint, build, tests, and boundary checks).
- [x] `bun run typecheck` reports no new errors (baseline gate).
- [x] `bun test test/daemon/daemonDevicePoolStartup.test.ts test/daemon/devicePool.test.ts` passes.
- [x] New test uses a fake device manager and `FakeTimer`; the regression test completes in under 100 ms.
- [x] No new dependency or generic helper was added.
- [x] Branch starts at the freshly fetched `main` head.
