### PR TITLE
fix(recovery): terminate cancelled emulator boot

### DIFF
--- a/src/daemon/devicePool.ts
+++ b/src/daemon/devicePool.ts
@@ -1319,6 +1319,7 @@ export class DevicePool {
       }
       await this.removeDevice(device.id);
       let intentionallyStopped = false;
+      let intentionalShutdownCleanupError: unknown;
       const recovered = await this.androidDeviceReboot.run(target, async () => {
         if (this.consumeIntentionalShutdown(recoveryDeviceIds)) {
           intentionallyStopped = true;
@@ -1327,6 +1328,21 @@ export class DevicePool {
         const childProcess = await this.deviceManager.startDevice(target);
         let ready: BootedDevice | undefined;
         let readinessCompleted = false;
+        const stopCancelledRecovery = async (deviceToRemove?: BootedDevice): Promise<void> => {
+          intentionallyStopped = true;
+          if (deviceToRemove) {
+            try {
+              await this.removeDevice(deviceToRemove.deviceId);
+            } catch (error) {
+              intentionalShutdownCleanupError = error;
+            }
+          }
+          try {
+            await this.stopEmulatorProcess(childProcess);
+          } catch (error) {
+            intentionalShutdownCleanupError ??= error;
+          }
+        };
         try {
           ready = this.criteriaMatcher.withDeviceImageMetadata(
             await waitForDeviceReadyOrCancel(this.deviceManager, target, childProcess),
@@ -1336,26 +1352,20 @@ export class DevicePool {
           recoveryDeviceIds.add(ready.deviceId);
           this.recoveringAndroidDeviceIds.add(ready.deviceId);
           if (this.consumeIntentionalShutdown(recoveryDeviceIds)) {
-            intentionallyStopped = true;
-            await this.stopEmulatorProcess(childProcess);
+            await stopCancelledRecovery();
             return;
           }
           await this.addDevice(ready, recoveryImage);
           if (this.consumeIntentionalShutdown(recoveryDeviceIds)) {
-            intentionallyStopped = true;
-            await this.removeDevice(ready.deviceId);
-            await this.stopEmulatorProcess(childProcess);
+            await stopCancelledRecovery(ready);
             return;
           }
           await this.trackStartedDeviceProcess(ready, childProcess);
         } catch (error) {
           if (this.consumeIntentionalShutdown(recoveryDeviceIds)) {
             intentionallyStopped = true;
-            if (ready) {
-              await this.removeDevice(ready.deviceId);
-            }
             if (readinessCompleted) {
-              await this.stopEmulatorProcess(childProcess);
+              await stopCancelledRecovery(ready);
             }
             return;
           }
@@ -1363,6 +1373,9 @@ export class DevicePool {
         }
       });
       if (intentionallyStopped) {
+        if (intentionalShutdownCleanupError !== undefined) {
+          throw intentionalShutdownCleanupError;
+        }
         logger.info(
           `[DevicePool] Cancelled Android emulator ${avdName} recovery after intentional shutdown`,
         );

--- a/src/daemon/devicePool.ts
+++ b/src/daemon/devicePool.ts
@@ -1326,21 +1326,25 @@ export class DevicePool {
         }
         const childProcess = await this.deviceManager.startDevice(target);
         let ready: BootedDevice | undefined;
+        let readinessCompleted = false;
         try {
           ready = this.criteriaMatcher.withDeviceImageMetadata(
             await waitForDeviceReadyOrCancel(this.deviceManager, target, childProcess),
             recoveryImage,
           );
+          readinessCompleted = true;
           recoveryDeviceIds.add(ready.deviceId);
           this.recoveringAndroidDeviceIds.add(ready.deviceId);
           if (this.consumeIntentionalShutdown(recoveryDeviceIds)) {
             intentionallyStopped = true;
+            await this.stopEmulatorProcess(childProcess);
             return;
           }
           await this.addDevice(ready, recoveryImage);
           if (this.consumeIntentionalShutdown(recoveryDeviceIds)) {
             intentionallyStopped = true;
             await this.removeDevice(ready.deviceId);
+            await this.stopEmulatorProcess(childProcess);
             return;
           }
           await this.trackStartedDeviceProcess(ready, childProcess);
@@ -1349,6 +1353,9 @@ export class DevicePool {
             intentionallyStopped = true;
             if (ready) {
               await this.removeDevice(ready.deviceId);
+            }
+            if (readinessCompleted) {
+              await this.stopEmulatorProcess(childProcess);
             }
             return;
           }
@@ -1388,6 +1395,10 @@ export class DevicePool {
   private async stopTrackedEmulatorProcess(deviceId: string): Promise<void> {
     const childProcess = this.startedDeviceProcesses.get(deviceId);
     this.startedDeviceProcesses.delete(deviceId);
+    await this.stopEmulatorProcess(childProcess);
+  }
+
+  private async stopEmulatorProcess(childProcess: ChildProcess | null | undefined): Promise<void> {
     if (!childProcess || typeof childProcess.kill !== "function") {
       return;
     }

--- a/test/daemon/devicePool.test.ts
+++ b/test/daemon/devicePool.test.ts
@@ -250,9 +250,14 @@ describe("DevicePool", () => {
         this.bootedDevices = [];
         this.resolveRecoveryStarted();
       }
-      const childProcess = new FakeChildProcess();
+      const childProcess =
+        this.childProcesses.length === 1 ? this.createRecoveryChild() : new FakeChildProcess();
       this.childProcesses.push(childProcess);
       return childProcess;
+    }
+
+    protected createRecoveryChild(): FakeChildProcess {
+      return new FakeChildProcess();
     }
 
     override async waitForDeviceReady(device: DeviceInfo): Promise<BootedDevice> {
@@ -279,6 +284,30 @@ describe("DevicePool", () => {
 
     releaseRecovery(): void {
       this.resolveRecoveryRelease();
+    }
+  }
+
+  class StubbornRecoveryChildProcess extends FakeChildProcess {
+    readonly signals: Array<NodeJS.Signals | number | undefined> = [];
+
+    constructor() {
+      super();
+      this.exitCode = null;
+      this.signalCode = null;
+    }
+
+    override kill(signal?: NodeJS.Signals | number): boolean {
+      this.killCount++;
+      this.signals.push(signal);
+      return true;
+    }
+  }
+
+  class DeferredRecoveryDeviceManagerWithStubbornChild extends DeferredRecoveryDeviceManager {
+    readonly recoveryChild = new StubbornRecoveryChildProcess();
+
+    protected override createRecoveryChild(): FakeChildProcess {
+      return this.recoveryChild;
     }
   }
 
@@ -2107,6 +2136,51 @@ describe("DevicePool", () => {
 
         expect(manager.childProcesses).toHaveLength(2);
         expect(manager.childProcesses[1]!.killCount).toBe(1);
+        expect(devicePool.getDevice("emulator-5554")).toBeNull();
+      } finally {
+        manager.releaseRecovery();
+        if (originalRebootOnDeath === undefined) {
+          delete process.env.AUTOMOBILE_ANDROID_REBOOT_ON_DEATH;
+        } else {
+          process.env.AUTOMOBILE_ANDROID_REBOOT_ON_DEATH = originalRebootOnDeath;
+        }
+      }
+    });
+
+    test("does not retry recovery when cancelling the owned child fails", async () => {
+      const originalRebootOnDeath = process.env.AUTOMOBILE_ANDROID_REBOOT_ON_DEATH;
+      process.env.AUTOMOBILE_ANDROID_REBOOT_ON_DEATH = "1";
+      fakeTimer.enableAutoAdvance();
+      const manager = new DeferredRecoveryDeviceManagerWithStubbornChild();
+      manager.deviceImages = [
+        {
+          name: "Pixel 8",
+          platform: "android",
+          isRunning: false,
+          deviceId: "emulator-5554",
+          source: "local",
+        },
+      ];
+      devicePool = new DevicePool(
+        sessionManager,
+        "test-daemon-session-id",
+        fakeTimer,
+        fakeAppsRepo,
+        manager,
+        new DefaultRetryExecutor(fakeTimer),
+      );
+      try {
+        await devicePool.assignMultipleDevices(["session-1"], 1_000, "android");
+        await devicePool.releaseDevice("emulator-5554");
+
+        const recovery = devicePool.removeDisconnectedDevice("emulator-5554", false);
+        await manager.waitForRecoveryStart();
+        devicePool.markIntentionalShutdown("emulator-5554");
+        manager.releaseRecovery();
+
+        await expect(recovery).rejects.toThrow("did not exit after SIGKILL");
+        expect(manager.childProcesses).toHaveLength(2);
+        expect(manager.recoveryChild.signals).toEqual(["SIGTERM", "SIGKILL"]);
         expect(devicePool.getDevice("emulator-5554")).toBeNull();
       } finally {
         manager.releaseRecovery();

--- a/test/daemon/devicePool.test.ts
+++ b/test/daemon/devicePool.test.ts
@@ -118,8 +118,10 @@ describe("DevicePool", () => {
     pid = 12345;
     exitCode: number | null | undefined = undefined;
     signalCode: NodeJS.Signals | null | undefined = undefined;
+    killCount = 0;
     kill(): boolean {
-      return false;
+      this.killCount++;
+      return true;
     }
   }
 
@@ -2104,6 +2106,7 @@ describe("DevicePool", () => {
         await new Promise((resolve) => setImmediate(resolve));
 
         expect(manager.childProcesses).toHaveLength(2);
+        expect(manager.childProcesses[1]!.killCount).toBe(1);
         expect(devicePool.getDevice("emulator-5554")).toBeNull();
       } finally {
         manager.releaseRecovery();


### PR DESCRIPTION
## Summary

Stops and waits for the process owned by an Android emulator recovery when an intentional shutdown is consumed before process tracking begins. This prevents a recovered emulator from completing its boot untracked, and surfaces an unkillable child after the recovery retry loop so it cannot launch a replacement emulator.

## Linked Issue

Closes [issue #5297](https://github.com/kaeawc/auto-mobile/issues/5297).

## Bug / Regression Context

- **Prior attempts:** Intentional shutdown cancelled recovery bookkeeping but did not terminate the newly started recovery process before it was tracked.
- **Observed symptom:** An emulator could finish booting after cancellation without a pool entry or tracked process handle.
- **Repro steps / conditions:** Start Android recovery, mark its serial intentionally shut down while readiness is deferred, then allow readiness to complete.

## Validation

- [x] `bun test test/daemon/devicePool.test.ts`
- [x] `bun test test/utils/waitForDeviceReadyOrCancel.test.ts`
- [x] `bun run turbo:validate` (13,139 passed; 13 expected integration skips)
- [x] `bun run typecheck` reports no new errors (baseline gate)
- [x] New code reuses the existing emulator-process termination and fake-timer seams; no dependency added
- [x] Branched from freshly fetched `origin/main`
