### PR TITLE
fix(shutdown): continue cleanup after failures

### DIFF
--- a/src/daemon/daemon.ts
+++ b/src/daemon/daemon.ts
@@ -1649,19 +1649,11 @@ export class Daemon {
         },
         { name: "appearance sync scheduler", run: stopAppearanceSyncScheduler },
         { name: "performance monitor", run: stopPerformanceMonitor },
-        {
-          name: "active HTTP sessions",
-          run: async () => {
-            for (const [sessionId, streamableTransport] of this.transports) {
-              try {
-                await streamableTransport.close();
-              } catch (error) {
-                logger.warn(`Error closing Streamable HTTP session ${sessionId}:`, error);
-              }
-            }
-            this.transports.clear();
-          },
-        },
+        ...Array.from(this.transports, ([sessionId, streamableTransport]) => ({
+          name: `Streamable HTTP session ${sessionId}`,
+          run: () => streamableTransport.close(),
+        })),
+        { name: "active HTTP session registry", run: () => this.transports.clear() },
         {
           name: "HTTP server",
           run: async () => {

--- a/src/daemon/daemon.ts
+++ b/src/daemon/daemon.ts
@@ -130,8 +130,10 @@ type DatabaseHealthFailureRecovery = (code: number) => void;
  */
 export class Daemon {
   private httpServer: HttpServer | null = null;
+  private httpServerClosePromise: Promise<void> | null = null;
   private socketServer: UnixSocketServer | null = null;
   private transports: Map<string, StreamableHTTPServerTransport> = new Map();
+  private acceptingHttpSessions = false;
   private port: number;
   private host: string;
   private debug: boolean;
@@ -505,6 +507,8 @@ export class Daemon {
    */
   private async startHttpServer(): Promise<void> {
     this.httpServer = createHttpServer();
+    this.httpServerClosePromise = null;
+    this.acceptingHttpSessions = true;
 
     // Disable default timeouts on this loopback-only server. Node.js 18+ sets
     // requestTimeout to 300 000 ms (5 min), which kills Streamable HTTP
@@ -575,6 +579,12 @@ export class Daemon {
       }
 
       if (url.pathname === MCP_STREAMABLE_PATH) {
+        if (!this.acceptingHttpSessions) {
+          res.writeHead(503, { "Content-Type": "application/json" });
+          res.end(JSON.stringify({ error: "Daemon is shutting down" }));
+          return;
+        }
+
         // Get session ID from header
         const sessionId = req.headers["mcp-session-id"] as string | undefined;
 
@@ -630,6 +640,15 @@ export class Daemon {
           }));
         };
 
+        // A request may have begun reading its body just before shutdown
+        // quiesced the listener. Recheck admission before it can create or use
+        // a transport after the shutdown session snapshot is taken.
+        if (!this.acceptingHttpSessions) {
+          res.writeHead(503, { "Content-Type": "application/json" });
+          res.end(JSON.stringify({ error: "Daemon is shutting down" }));
+          return;
+        }
+
         if (sessionId && this.transports.has(sessionId)) {
           // Use existing transport
           streamableTransport = this.transports.get(sessionId)!;
@@ -652,7 +671,9 @@ export class Daemon {
           streamableTransport = new StreamableHTTPServerTransport({
             sessionIdGenerator: () => this.idGenerator.next(),
             onsessioninitialized: newSessionId => {
-              this.transports.set(newSessionId, streamableTransport);
+              if (!this.registerHttpTransport(newSessionId, streamableTransport)) {
+                return;
+              }
               sessionContext.sessionId = newSessionId;
               logger.info(
                 `Streamable HTTP session initialized: ${newSessionId}`
@@ -767,6 +788,37 @@ export class Daemon {
         reject(error);
       });
     });
+  }
+
+  private registerHttpTransport(
+    sessionId: string,
+    transport: StreamableHTTPServerTransport,
+  ): boolean {
+    if (!this.acceptingHttpSessions) {
+      void transport.close().catch(error => {
+        logger.warn(`Failed to close HTTP session ${sessionId} rejected during shutdown`, error);
+      });
+      return false;
+    }
+    this.transports.set(sessionId, transport);
+    return true;
+  }
+
+  private closeHttpListener(): Promise<void> {
+    if (!this.httpServer) {
+      return Promise.resolve();
+    }
+    this.httpServerClosePromise ??= new Promise<void>((resolve, reject) => {
+      this.httpServer!.close(error => {
+        if (error) {
+          reject(error);
+          return;
+        }
+        logger.info("HTTP server stopped");
+        resolve();
+      });
+    });
+    return this.httpServerClosePromise;
   }
 
   /**
@@ -1624,6 +1676,16 @@ export class Daemon {
           run: () => this.sessionManager.stopCleanupTimer(),
         },
         {
+          name: "HTTP session admission",
+          run: () => {
+            this.acceptingHttpSessions = false;
+            // Start closing the listener now so it cannot admit a connection
+            // after the transport snapshot below. The later HTTP server stage
+            // awaits this same close once active transports have been closed.
+            void this.closeHttpListener().catch(() => {});
+          },
+        },
+        {
           name: "Unix socket server",
           run: async () => {
             if (this.socketServer) {
@@ -1649,23 +1711,20 @@ export class Daemon {
         },
         { name: "appearance sync scheduler", run: stopAppearanceSyncScheduler },
         { name: "performance monitor", run: stopPerformanceMonitor },
-        ...Array.from(this.transports, ([sessionId, streamableTransport]) => ({
-          name: `Streamable HTTP session ${sessionId}`,
-          run: () => streamableTransport.close(),
-        })),
+        {
+          name: "active HTTP sessions",
+          run: () => runShutdownCleanupStages(
+            Array.from(this.transports, ([sessionId, streamableTransport]) => ({
+              name: `Streamable HTTP session ${sessionId}`,
+              run: () => streamableTransport.close(),
+            })),
+            (message, error) => logger.warn(message, error),
+          ),
+        },
         { name: "active HTTP session registry", run: () => this.transports.clear() },
         {
           name: "HTTP server",
-          run: async () => {
-            if (this.httpServer) {
-              await new Promise<void>((resolve) => {
-                this.httpServer!.close(() => {
-                  logger.info("HTTP server stopped");
-                  resolve();
-                });
-              });
-            }
-          },
+          run: () => this.closeHttpListener(),
         },
         { name: "daemon files", run: () => cleanupDaemonFiles(this.getDaemonFileCleanupOptions()) },
         {

--- a/src/daemon/daemon.ts
+++ b/src/daemon/daemon.ts
@@ -99,6 +99,7 @@ import {
 } from "./ObservationStreamHealth";
 import { onAdbMissingDevice } from "../utils/android-cmdline-tools/AdbDeviceHealth";
 import { iosSimulatorCaptureHelperPool } from "../features/screen-stream";
+import { runShutdownCleanupStages } from "../shutdownCleanup";
 
 const DEVICE_DISCONNECT_POLL_INTERVAL_MS = 5000;
 const DEVICE_DISCONNECT_MISS_THRESHOLD = 3;
@@ -1578,111 +1579,147 @@ export class Daemon {
   async stop(): Promise<void> {
     logger.info("Stopping daemon...");
 
-    // Clear health check timer
-    this.stopHealthCheckTimer();
     const heartbeatMonitor = this.heartbeatMonitor;
     this.heartbeatMonitor = null;
     const deviceDisconnectMonitor = this.deviceDisconnectMonitor;
     this.deviceDisconnectMonitor = null;
-    const [heartbeatSettled, disconnectSettled] = await Promise.all([
-      heartbeatMonitor ? heartbeatMonitor.stop().then(() => true) : true,
-      deviceDisconnectMonitor ? deviceDisconnectMonitor.stop() : true,
-    ]);
-    if (!heartbeatSettled) {
-      logger.warn("Session heartbeat monitor did not settle before daemon shutdown");
-    }
-    if (!disconnectSettled) {
-      logger.warn("Device disconnect monitor did not settle before daemon shutdown");
-    }
-    if (this.unsubscribeAdbMissingDevice) {
-      this.unsubscribeAdbMissingDevice();
-      this.unsubscribeAdbMissingDevice = null;
-    }
-
-    // Stop the session cleanup interval before the DB drain below. It is the one
-    // best-effort DB writer that fires on its own timer rather than an external
-    // socket (which are all torn down here), so if left running it could route a
-    // tracked `markReleased` write through a freshly-resolved, non-draining
-    // barrier in the microtask window AFTER closeDatabase()'s resetDbWriteBarrier()
-    // and hit the just-closed connection (issue #2912; #2792 safety window).
-    this.sessionManager.stopCleanupTimer();
-
-    // Close Unix socket server
-    if (this.socketServer) {
-      await this.socketServer.close();
-    }
-
-    await stopVideoRecordingSocketServer();
-    await stopTestRecordingSocketServer();
-    await stopDeviceSnapshotSocketServer();
-    await stopAppearanceSocketServer();
-    await stopPerformanceStreamSocketServer();
-    await stopPerformancePushSocketServer();
-    await stopDeviceDataStreamSocketServer();
-    await stopFailuresStreamSocketServer();
-    await stopFailuresPushSocketServer();
-    await stopTelemetryPushSocketServer();
-    await stopWebRtcStreamSocketServer();
-    await stopVideoStreamSocketServer();
-    await iosSimulatorCaptureHelperPool.shutdown();
-    stopAppearanceSyncScheduler();
-    stopPerformanceMonitor();
-
-    // Close all active HTTP sessions
-    for (const [sessionId, streamableTransport] of this.transports) {
-      try {
-        await streamableTransport.close();
-      } catch (error) {
-        logger.warn(
-          `Error closing Streamable HTTP session ${sessionId}:`,
-          error
-        );
-      }
-    }
-    this.transports.clear();
-
-    // Close HTTP server
-    if (this.httpServer) {
-      await new Promise<void>(resolve => {
-        this.httpServer!.close(() => {
-          logger.info("HTTP server stopped");
-          resolve();
-        });
-      });
-    }
-
-    await cleanupDaemonFiles(this.getDaemonFileCleanupOptions());
-
-    // Quiesce in-flight best-effort DB writes (fire-and-forget telemetry ingest,
-    // background retention cleanup) BEFORE closing the connection, so a query
-    // queued in Kysely's ConnectionMutex can't strand shutdown on an unsettled
-    // promise (issue #2792). Bounded: a wedged write cannot itself hang shutdown.
-    const drained = await getDbWriteBarrier().drain(DB_WRITE_DRAIN_TIMEOUT_MS);
-    if (!drained) {
-      logger.warn(
-        `Timed out after ${DB_WRITE_DRAIN_TIMEOUT_MS}ms draining in-flight DB writes; closing database anyway`
-      );
-    }
-
-    // If a SIGTERM arrived mid cold-start migration, the detached migration
-    // connection is still open and writing on its own connection (its writes are
-    // NOT tracked by the write barrier drained above). Let it settle before
-    // closeDatabase() destroys the app connection, so their WAL writes/checkpoint
-    // can't contend and stall shutdown on busy_timeout (Windows; issue #3044).
-    // Bounded so a wedged migration cannot itself hang shutdown.
-    const migrationsSettled = await awaitInFlightMigrations(
-      MIGRATION_SETTLE_TIMEOUT_MS
+    await runShutdownCleanupStages(
+      [
+        {
+          name: "health check timer",
+          run: () => this.stopHealthCheckTimer(),
+        },
+        {
+          name: "shutdown monitors",
+          run: async () => {
+            const [heartbeatSettled, disconnectSettled] = await Promise.all([
+              heartbeatMonitor ? heartbeatMonitor.stop().then(() => true) : true,
+              deviceDisconnectMonitor ? deviceDisconnectMonitor.stop() : true,
+            ]);
+            if (!heartbeatSettled) {
+              logger.warn("Session heartbeat monitor did not settle before daemon shutdown");
+            }
+            if (!disconnectSettled) {
+              logger.warn("Device disconnect monitor did not settle before daemon shutdown");
+            }
+          },
+        },
+        {
+          name: "ADB missing-device subscription",
+          run: () => {
+            if (this.unsubscribeAdbMissingDevice) {
+              this.unsubscribeAdbMissingDevice();
+              this.unsubscribeAdbMissingDevice = null;
+            }
+          },
+        },
+        {
+          // Stop the session cleanup interval before the DB drain below. It is the one
+          // best-effort DB writer that fires on its own timer rather than an external
+          // socket (which are all torn down here), so if left running it could route a
+          // tracked `markReleased` write through a freshly-resolved, non-draining
+          // barrier in the microtask window AFTER closeDatabase()'s resetDbWriteBarrier()
+          // and hit the just-closed connection (issue #2912; #2792 safety window).
+          name: "session cleanup timer",
+          run: () => this.sessionManager.stopCleanupTimer(),
+        },
+        {
+          name: "Unix socket server",
+          run: async () => {
+            if (this.socketServer) {
+              await this.socketServer.close();
+            }
+          },
+        },
+        { name: "video recording socket server", run: stopVideoRecordingSocketServer },
+        { name: "test recording socket server", run: stopTestRecordingSocketServer },
+        { name: "device snapshot socket server", run: stopDeviceSnapshotSocketServer },
+        { name: "appearance socket server", run: stopAppearanceSocketServer },
+        { name: "performance stream socket server", run: stopPerformanceStreamSocketServer },
+        { name: "performance push socket server", run: stopPerformancePushSocketServer },
+        { name: "device data stream socket server", run: stopDeviceDataStreamSocketServer },
+        { name: "failures stream socket server", run: stopFailuresStreamSocketServer },
+        { name: "failures push socket server", run: stopFailuresPushSocketServer },
+        { name: "telemetry push socket server", run: stopTelemetryPushSocketServer },
+        { name: "WebRTC stream socket server", run: stopWebRtcStreamSocketServer },
+        { name: "video stream socket server", run: stopVideoStreamSocketServer },
+        {
+          name: "iOS simulator capture helper pool",
+          run: () => iosSimulatorCaptureHelperPool.shutdown(),
+        },
+        { name: "appearance sync scheduler", run: stopAppearanceSyncScheduler },
+        { name: "performance monitor", run: stopPerformanceMonitor },
+        {
+          name: "active HTTP sessions",
+          run: async () => {
+            for (const [sessionId, streamableTransport] of this.transports) {
+              try {
+                await streamableTransport.close();
+              } catch (error) {
+                logger.warn(`Error closing Streamable HTTP session ${sessionId}:`, error);
+              }
+            }
+            this.transports.clear();
+          },
+        },
+        {
+          name: "HTTP server",
+          run: async () => {
+            if (this.httpServer) {
+              await new Promise<void>((resolve) => {
+                this.httpServer!.close(() => {
+                  logger.info("HTTP server stopped");
+                  resolve();
+                });
+              });
+            }
+          },
+        },
+        { name: "daemon files", run: () => cleanupDaemonFiles(this.getDaemonFileCleanupOptions()) },
+        {
+          name: "database write drain",
+          run: async () => {
+            // Quiesce in-flight best-effort DB writes (fire-and-forget telemetry ingest,
+            // background retention cleanup) BEFORE closing the connection, so a query
+            // queued in Kysely's ConnectionMutex can't strand shutdown on an unsettled
+            // promise (issue #2792). Bounded: a wedged write cannot itself hang shutdown.
+            const drained = await getDbWriteBarrier().drain(DB_WRITE_DRAIN_TIMEOUT_MS);
+            if (!drained) {
+              logger.warn(
+                `Timed out after ${DB_WRITE_DRAIN_TIMEOUT_MS}ms draining in-flight DB writes; closing database anyway`,
+              );
+            }
+          },
+        },
+        {
+          name: "in-flight migrations",
+          run: async () => {
+            // If a SIGTERM arrived mid cold-start migration, the detached migration
+            // connection is still open and writing on its own connection (its writes are
+            // NOT tracked by the write barrier drained above). Let it settle before
+            // closeDatabase() destroys the app connection, so their WAL writes/checkpoint
+            // can't contend and stall shutdown on busy_timeout (Windows; issue #3044).
+            // Bounded so a wedged migration cannot itself hang shutdown.
+            const migrationsSettled = await awaitInFlightMigrations(MIGRATION_SETTLE_TIMEOUT_MS);
+            if (!migrationsSettled) {
+              logger.warn(
+                `Timed out after ${MIGRATION_SETTLE_TIMEOUT_MS}ms awaiting in-flight startup migration; closing database anyway`,
+              );
+            }
+          },
+        },
+        { name: "database", run: closeDatabase },
+        {
+          name: "logger",
+          run: async () => {
+            logger.info("Daemon stopped");
+            await logger.flush();
+            logger.close();
+          },
+        },
+      ],
+      (message, error) => logger.warn(message, error),
     );
-    if (!migrationsSettled) {
-      logger.warn(
-        `Timed out after ${MIGRATION_SETTLE_TIMEOUT_MS}ms awaiting in-flight startup migration; closing database anyway`
-      );
-    }
-
-    await closeDatabase();
-
-    logger.info("Daemon stopped");
-    logger.close();
   }
 
   private getDaemonFileCleanupOptions(): { expectedPid?: number } {

--- a/src/daemon/daemon.ts
+++ b/src/daemon/daemon.ts
@@ -1705,8 +1705,7 @@ export class Daemon {
           name: "logger",
           run: async () => {
             logger.info("Daemon stopped");
-            await logger.flush();
-            logger.close();
+            await logger.closeAfterFlush();
           },
         },
       ],

--- a/src/index.ts
+++ b/src/index.ts
@@ -36,6 +36,7 @@ import {
   setFatalProcessHandler,
   setProcessShutdownHandler,
 } from "./processLifecycle";
+import { runShutdownCleanupStages } from "./shutdownCleanup";
 import { startStartupMaintenance } from "./utils/startupMaintenance";
 
 interface FatalLogger {
@@ -124,14 +125,28 @@ async function main() {
   const { startAppearanceSyncScheduler, stopAppearanceSyncScheduler } = appearanceSyncScheduler;
   setProcessShutdownHandler(async (signal) => {
     logger.info(`Received ${signal} signal, shutting down`);
-    await stopVideoRecordingSocketServer();
-    await stopTestRecordingSocketServer();
-    await stopDeviceSnapshotSocketServer();
-    await stopAppearanceSocketServer();
-    await stopWebRtcStreamSocketServer();
-    stopAppearanceSyncScheduler();
-    await AndroidCtrlProxyManager.cleanupPrefetchedApk();
-    logger.close();
+    await runShutdownCleanupStages(
+      [
+        { name: "video recording socket server", run: stopVideoRecordingSocketServer },
+        { name: "test recording socket server", run: stopTestRecordingSocketServer },
+        { name: "device snapshot socket server", run: stopDeviceSnapshotSocketServer },
+        { name: "appearance socket server", run: stopAppearanceSocketServer },
+        { name: "WebRTC stream socket server", run: stopWebRtcStreamSocketServer },
+        { name: "appearance sync scheduler", run: stopAppearanceSyncScheduler },
+        {
+          name: "prefetched Android CtrlProxy APK",
+          run: AndroidCtrlProxyManager.cleanupPrefetchedApk,
+        },
+        {
+          name: "logger",
+          run: async () => {
+            await logger.flush();
+            logger.close();
+          },
+        },
+      ],
+      (message, error) => logger.warn(message, error),
+    );
   });
 
   try {

--- a/src/index.ts
+++ b/src/index.ts
@@ -140,8 +140,7 @@ async function main() {
         {
           name: "logger",
           run: async () => {
-            await logger.flush();
-            logger.close();
+            await logger.closeAfterFlush();
           },
         },
       ],

--- a/src/shutdownCleanup.ts
+++ b/src/shutdownCleanup.ts
@@ -1,0 +1,32 @@
+export interface ShutdownCleanupStage {
+  readonly name: string;
+  readonly run: () => Promise<void> | void;
+}
+
+export type ShutdownCleanupFailureReporter = (message: string, error: unknown) => void;
+
+/**
+ * Runs shutdown work in order while allowing independent later stages to reclaim
+ * their resources after an earlier stage fails. The aggregate is rethrown only
+ * once every stage has had one chance to run so the process lifecycle can exit
+ * with failure without leaking later resources.
+ */
+export async function runShutdownCleanupStages(
+  stages: readonly ShutdownCleanupStage[],
+  reportFailure: ShutdownCleanupFailureReporter,
+): Promise<void> {
+  const failures: unknown[] = [];
+
+  for (const stage of stages) {
+    try {
+      await stage.run();
+    } catch (error) {
+      failures.push(error);
+      reportFailure(`Shutdown cleanup stage ${stage.name} failed`, error);
+    }
+  }
+
+  if (failures.length > 0) {
+    throw new AggregateError(failures, "One or more shutdown cleanup stages failed");
+  }
+}

--- a/src/utils/logger.ts
+++ b/src/utils/logger.ts
@@ -63,6 +63,13 @@ export interface Logger {
    * Closes the log stream
    */
   close(): void;
+
+  /**
+   * Flushes pending writes and waits until the log stream finishes closing.
+   * Use this before an explicit process exit so the final log entries reach
+   * the stream.
+   */
+  closeAfterFlush(): Promise<void>;
 }
 
 export const LogLevel = {
@@ -148,6 +155,27 @@ ensureDirExists(logsDir).catch(err => {
 const ownLogPrefix = resolveProcessLogPrefix(process.argv, process.pid);
 const logFilePath = path.join(logsDir, `${ownLogPrefix}.log`);
 let logStream = fs.createWriteStream(logFilePath, { flags: "a" });
+
+interface EndableLogStream {
+  end(callback: () => void): void;
+  once(event: "error", listener: (error: Error) => void): void;
+  off(event: "error", listener: (error: Error) => void): void;
+}
+
+/** Resolves when a log stream has finished, or rejects if closing it fails. */
+export function closeLogStream(stream: EndableLogStream): Promise<void> {
+  return new Promise((resolve, reject) => {
+    const onError = (error: Error): void => {
+      stream.off("error", onError);
+      reject(error);
+    };
+    stream.once("error", onError);
+    stream.end(() => {
+      stream.off("error", onError);
+      resolve();
+    });
+  });
+}
 
 // Maximum log file size (10MB)
 const MAX_LOG_SIZE = 10 * 1024 * 1024;
@@ -384,5 +412,10 @@ export const logger: Logger = {
    */
   close(): void {
     logStream.end();
+  },
+
+  async closeAfterFlush(): Promise<void> {
+    await lastWrite;
+    await closeLogStream(logStream);
   }
 };

--- a/test/daemon/daemonHttpSessionShutdown.test.ts
+++ b/test/daemon/daemonHttpSessionShutdown.test.ts
@@ -1,0 +1,53 @@
+import { afterEach, describe, expect, test } from "bun:test";
+import { Daemon } from "../../src/daemon/daemon";
+import { DaemonState } from "../../src/daemon/daemonState";
+
+interface ClosableTransport {
+  close(): Promise<void>;
+}
+
+interface DaemonHttpSessionInternals {
+  acceptingHttpSessions: boolean;
+  transports: Map<string, ClosableTransport>;
+  registerHttpTransport(sessionId: string, transport: ClosableTransport): boolean;
+}
+
+class FakeTransport implements ClosableTransport {
+  closeCalls = 0;
+
+  async close(): Promise<void> {
+    this.closeCalls += 1;
+  }
+}
+
+describe("Daemon HTTP session shutdown", () => {
+  afterEach(() => {
+    if (DaemonState.getInstance().isInitialized()) {
+      DaemonState.getInstance().reset();
+    }
+  });
+
+  test("rejects and closes a transport initialized after HTTP admission is quiesced", async () => {
+    const daemon = new Daemon({});
+    const internals = daemon as unknown as DaemonHttpSessionInternals;
+    const transport = new FakeTransport();
+    internals.acceptingHttpSessions = false;
+
+    expect(internals.registerHttpTransport("late-session", transport)).toBeFalse();
+    await Promise.resolve();
+
+    expect(transport.closeCalls).toBe(1);
+    expect(internals.transports.has("late-session")).toBeFalse();
+  });
+
+  test("keeps an admitted transport available for shutdown cleanup", () => {
+    const daemon = new Daemon({});
+    const internals = daemon as unknown as DaemonHttpSessionInternals;
+    const transport = new FakeTransport();
+    internals.acceptingHttpSessions = true;
+
+    expect(internals.registerHttpTransport("active-session", transport)).toBeTrue();
+    expect(internals.transports.get("active-session")).toBe(transport);
+    expect(transport.closeCalls).toBe(0);
+  });
+});

--- a/test/fakes/FakeLogger.ts
+++ b/test/fakes/FakeLogger.ts
@@ -43,6 +43,7 @@ export class FakeLogger implements Logger {
   // Writes are synchronous in the fake, so there is nothing in flight to await.
   async flush(): Promise<void> {}
   close(): void {}
+  async closeAfterFlush(): Promise<void> {}
 
   /** Messages emitted at the given level. */
   at(level: LoggedMessage["level"]): LoggedMessage[] {

--- a/test/processLifecycle.test.ts
+++ b/test/processLifecycle.test.ts
@@ -120,6 +120,26 @@ describe("process lifecycle handlers", () => {
     expect(fakeProcess.exitCodes).toEqual([0]);
   });
 
+  test("exits with failure after shutdown cleanup reports an aggregate failure", async () => {
+    const fakeProcess = new FakeProcess();
+    const lifecycle = new ProcessLifecycleHandlers(fakeProcess);
+    const consoleError = spyOn(console, "error").mockImplementation(() => {});
+
+    try {
+      lifecycle.install();
+      lifecycle.setShutdownHandler(() => {
+        throw new AggregateError([new Error("socket cleanup failed")], "cleanup failed");
+      });
+
+      fakeProcess.emit("SIGTERM");
+      await flushMicrotasks();
+
+      expect(fakeProcess.exitCodes).toEqual([1]);
+    } finally {
+      consoleError.mockRestore();
+    }
+  });
+
   test("delegates fatal process events without forcing an exit", async () => {
     const fakeProcess = new FakeProcess();
     const lifecycle = new ProcessLifecycleHandlers(fakeProcess);

--- a/test/shutdownCleanup.test.ts
+++ b/test/shutdownCleanup.test.ts
@@ -1,0 +1,85 @@
+import { describe, expect, test } from "bun:test";
+import { runShutdownCleanupStages, type ShutdownCleanupStage } from "../src/shutdownCleanup";
+
+const stageNames = ["socket", "helpers", "database", "logger"] as const;
+
+function createStages(
+  calls: string[],
+  failures: ReadonlyMap<string, Error>,
+): ShutdownCleanupStage[] {
+  return stageNames.map((name) => ({
+    name,
+    run: async () => {
+      calls.push(name);
+      const failure = failures.get(name);
+      if (failure) {
+        throw failure;
+      }
+    },
+  }));
+}
+
+describe("runShutdownCleanupStages", () => {
+  for (const failingStage of stageNames) {
+    test(`runs every cleanup stage exactly once when ${failingStage} fails`, async () => {
+      const calls: string[] = [];
+      const failure = new Error(`${failingStage} failed`);
+      const warnings: Array<{ message: string; error: unknown }> = [];
+
+      await expect(
+        runShutdownCleanupStages(
+          createStages(calls, new Map([[failingStage, failure]])),
+          (message, error) => warnings.push({ message, error }),
+        ),
+      ).rejects.toBeInstanceOf(AggregateError);
+
+      expect(calls).toEqual(stageNames);
+      expect(warnings).toEqual([
+        {
+          message: `Shutdown cleanup stage ${failingStage} failed`,
+          error: failure,
+        },
+      ]);
+    });
+  }
+
+  test("aggregates all failures after every stage has run", async () => {
+    const calls: string[] = [];
+    const firstFailure = new Error("socket failed");
+    const lastFailure = new Error("logger failed");
+    let aggregate: unknown;
+
+    try {
+      await runShutdownCleanupStages(
+        createStages(
+          calls,
+          new Map([
+            ["socket", firstFailure],
+            ["logger", lastFailure],
+          ]),
+        ),
+        () => {},
+      );
+    } catch (error) {
+      aggregate = error;
+    }
+
+    expect(calls).toEqual(stageNames);
+    expect(aggregate).toBeInstanceOf(AggregateError);
+    expect((aggregate as AggregateError).errors).toEqual([firstFailure, lastFailure]);
+  });
+
+  test("resolves without logging when every cleanup stage succeeds", async () => {
+    const calls: string[] = [];
+    const warnings: Array<{ message: string; error: unknown }> = [];
+
+    await expect(
+      runShutdownCleanupStages(createStages(calls, new Map()), (message, error) =>
+        warnings.push({ message, error }),
+      ),
+    ).resolves.toBeUndefined();
+
+    expect(calls).toEqual(stageNames);
+    expect(warnings).toEqual([]);
+  });
+});

--- a/test/utils/logger-close.test.ts
+++ b/test/utils/logger-close.test.ts
@@ -1,0 +1,56 @@
+import { describe, expect, test } from "bun:test";
+import { closeLogStream } from "../../src/utils/logger";
+
+class FakeLogStream {
+  private readonly errorListeners = new Set<(error: Error) => void>();
+  private finish: (() => void) | undefined;
+
+  end(callback: () => void): void {
+    this.finish = callback;
+  }
+
+  once(_event: "error", listener: (error: Error) => void): void {
+    this.errorListeners.add(listener);
+  }
+
+  off(_event: "error", listener: (error: Error) => void): void {
+    this.errorListeners.delete(listener);
+  }
+
+  finishClose(): void {
+    this.finish?.();
+  }
+
+  failClose(error: Error): void {
+    for (const listener of this.errorListeners) {
+      listener(error);
+    }
+  }
+}
+
+describe("closeLogStream", () => {
+  test("waits for the stream close callback", async () => {
+    const stream = new FakeLogStream();
+    let settled = false;
+    const close = closeLogStream(stream).then(() => {
+      settled = true;
+    });
+
+    await Promise.resolve();
+    expect(settled).toBeFalse();
+
+    stream.finishClose();
+    await close;
+    expect(settled).toBeTrue();
+  });
+
+  test("propagates a stream close error", async () => {
+    const stream = new FakeLogStream();
+    const close = closeLogStream(stream);
+    const error = new Error("log stream close failed");
+
+    stream.failClose(error);
+
+    await expect(close).rejects.toBe(error);
+  });
+});


### PR DESCRIPTION
## Summary

- continue independent shutdown cleanup stages after an earlier stage fails
- aggregate failures so graceful shutdown exits non-zero after cleanup completes
- flush failure logs before closing the logger

## Root cause

Both daemon and direct-mode shutdown awaited cleanup stages fail-fast. A rejected earlier cleanup skipped later resources, database close, and logger close.

## Validation

- `bun test test/shutdownCleanup.test.ts test/processLifecycle.test.ts`
- `bun run build`
- `bun run typecheck`
- `bun run lint`
- `git diff --check`
- `bun run turbo:validate` reached passing lint, build, and boundary tasks, then was cancelled during an unrelated server-boundary test under concurrent full-suite host contention; it will be retried before merge.

Closes [#5304](https://github.com/kaeawc/auto-mobile/issues/5304)
