### PR TITLE
fix(daemon): release active sessions on shutdown

### DIFF
--- a/.github/workflows/pull_request.yml
+++ b/.github/workflows/pull_request.yml
@@ -1186,7 +1186,10 @@ jobs:
     name: "Node TypeScript Build and Test (${{ matrix.os }})"
     runs-on: ${{ matrix.os }}
     needs: detect-changes
-    timeout-minutes: 10
+    # The full isolated Bun suite can approach ten minutes on a contended hosted
+    # macOS runner. Keep the cross-platform lane intact while allowing enough
+    # headroom to finish after setup, lint, and build (issue #5328).
+    timeout-minutes: 15
     env:
       RUN_MCP_BUILD_TEST: ${{ needs.detect-changes.outputs.docs_only != 'true' && needs.detect-changes.outputs.sha256_only != 'true' }}
     strategy:

--- a/src/daemon/daemon.ts
+++ b/src/daemon/daemon.ts
@@ -108,6 +108,7 @@ const SSE_KEEPALIVE_INTERVAL_MS = 30_000;
 // writes to quiesce before closing the connection (issue #2792). Best-effort
 // writes are best-effort: if the bound elapses, shutdown proceeds anyway.
 const DB_WRITE_DRAIN_TIMEOUT_MS = 1_000;
+const SESSION_RELEASE_DRAIN_TIMEOUT_MS = 1_000;
 
 // Ceiling on awaiting an in-flight cold-start migration before closing the DB on
 // shutdown (issue #3044). A SIGTERM arriving mid-startup-migration would otherwise
@@ -1383,9 +1384,13 @@ export class Daemon {
     });
   }
 
-  private async cancelAndReleaseSession(sessionId: string, releaseReason: string = "explicit-release"): Promise<void> {
+  private async cancelAndReleaseSession(
+    sessionId: string,
+    releaseReason: string = "explicit-release",
+    allowExpired: boolean = false,
+  ): Promise<void> {
     const cancelled = await executionTracker.cancelSessionUuidExecutions(sessionId, releaseReason);
-    const deviceId = await this.sessionManager.releaseSession(sessionId, releaseReason);
+    const deviceId = await this.sessionManager.releaseSession(sessionId, releaseReason, allowExpired);
     if (deviceId) {
       await this.devicePool.releaseDevice(deviceId);
     }
@@ -1731,6 +1736,7 @@ export class Daemon {
           name: "HTTP server",
           run: () => this.closeHttpListener(),
         },
+        { name: "active device sessions", run: () => this.releaseActiveSessionsForShutdown() },
         { name: "daemon files", run: () => cleanupDaemonFiles(this.getDaemonFileCleanupOptions()) },
         {
           name: "database write drain",
@@ -1775,6 +1781,37 @@ export class Daemon {
       ],
       (message, error) => logger.warn(message, error),
     );
+  }
+
+  private async releaseActiveSessionsForShutdown(): Promise<void> {
+    await Promise.all(this.sessionManager.getAllSessionIds().map(sessionId => this.releaseSessionForShutdown(sessionId)));
+    if (!await this.sessionManager.drainReleasePromises(SESSION_RELEASE_DRAIN_TIMEOUT_MS)) {
+      logger.warn(`Timed out after ${SESSION_RELEASE_DRAIN_TIMEOUT_MS}ms draining in-flight session releases during shutdown`);
+    }
+  }
+
+  private async releaseSessionForShutdown(sessionId: string): Promise<void> {
+    const release = this.cancelAndReleaseSession(sessionId, "daemon-shutdown", true);
+    let timeoutHandle: NodeJS.Timeout | undefined;
+    const timeout = new Promise<boolean>(resolve => {
+      timeoutHandle = this.timer.setTimeout(() => resolve(false), SESSION_RELEASE_DRAIN_TIMEOUT_MS);
+    });
+    try {
+      const released = await Promise.race([
+        release.then(() => true, error => {
+          logger.warn(`[Daemon] Failed to release session ${sessionId} during shutdown: ${error}`);
+          return true;
+        }),
+        timeout,
+      ]);
+      if (!released) {
+        logger.warn(`Timed out after ${SESSION_RELEASE_DRAIN_TIMEOUT_MS}ms releasing session ${sessionId} during shutdown`);
+      }
+    } finally {
+      if (timeoutHandle !== undefined) {
+        this.timer.clearTimeout(timeoutHandle);
+      }
+    }
   }
 
   private getDaemonFileCleanupOptions(): { expectedPid?: number } {

--- a/src/daemon/sessionManager.ts
+++ b/src/daemon/sessionManager.ts
@@ -100,6 +100,10 @@ export class SessionManager {
   private cleanupTimer: NodeJS.Timeout | null = null;
   private timer: Timer;
   private releaseCallbacks: SessionReleaseCallback[] = [];
+  private readonly releasePromises: Map<
+    string,
+    { session: Session; promise: Promise<string | null> }
+  > = new Map();
   private deviceSessionRepository: DeviceSessionRepository;
   private readonly getBarrier: () => DbWriteBarrier;
   private readonly keepScreenAwakeRestorerFactory: (device: BootedDevice) => KeepScreenAwakeRestorer;
@@ -293,14 +297,51 @@ export class SessionManager {
    * Called when a test completes or times out.
    * Returns the device ID so DevicePool can mark it as available.
    */
-  async releaseSession(sessionId: string, releaseReason: string = "explicit-release"): Promise<string | null> {
-    const session = this.getSession(sessionId);
+  async releaseSession(
+    sessionId: string,
+    releaseReason: string = "explicit-release",
+    allowExpired: boolean = false,
+  ): Promise<string | null> {
+    // Match the promise to this particular session object, rather than only its
+    // UUID. A caller can create a new session with a reused UUID after the old
+    // release has removed it but before that release's persistence finishes.
+    const session = allowExpired ? this.sessions.get(sessionId) ?? null : this.getSession(sessionId);
     if (!session) {
       logger.warn(`Cannot release session ${sessionId}: not found`);
       return null;
     }
 
-    await this.restoreKeepScreenAwake(session);
+    const inFlightRelease = this.releasePromises.get(sessionId);
+    if (inFlightRelease?.session === session) {
+      return await inFlightRelease.promise;
+    }
+
+    const promise = this.releaseSessionInternal(sessionId, session, releaseReason);
+    const release = { session, promise };
+    this.releasePromises.set(sessionId, release);
+    try {
+      return await promise;
+    } finally {
+      if (this.releasePromises.get(sessionId) === release) {
+        this.releasePromises.delete(sessionId);
+      }
+    }
+  }
+
+  private async releaseSessionInternal(
+    sessionId: string,
+    session: Session,
+    releaseReason: string,
+  ): Promise<string | null> {
+    try {
+      await this.restoreKeepScreenAwake(session);
+    } catch (error) {
+      // Releasing a session must still remove its device assignment and persist
+      // its terminal state when restoration fails. The restore is best-effort;
+      // retaining the session would leak the device and leave the durable row
+      // active during shutdown.
+      logger.warn(`Failed to restore keep-awake state for session ${sessionId}: ${error}`);
+    }
 
     const deviceId = session.assignedDevice;
     this.removeSession(sessionId);
@@ -514,6 +555,11 @@ export class SessionManager {
     return Array.from(this.sessions.values()).filter(
       s => !this.isSessionExpired(s)
     );
+  }
+
+  /** Snapshot every in-memory session, including expired entries awaiting cleanup. */
+  getAllSessionIds(): string[] {
+    return Array.from(this.sessions.keys());
   }
 
   /**

--- a/src/daemon/sessionManager.ts
+++ b/src/daemon/sessionManager.ts
@@ -104,8 +104,10 @@ export class SessionManager {
     string,
     { session: Session; promise: Promise<string | null> }
   > = new Map();
+  /** Every release still running, including an older session that reused a UUID. */
+  private readonly activeReleasePromises: Set<{ session: Session; promise: Promise<string | null> }> = new Set();
   /** Setup work that must settle before a session restores its cached device state. */
-  private readonly sessionSetupPromises: Map<string, { session: Session; promise: Promise<void> }> = new Map();
+  private readonly sessionSetupPromises: Set<{ session: Session; promise: Promise<void> }> = new Set();
   private deviceSessionRepository: DeviceSessionRepository;
   private readonly getBarrier: () => DbWriteBarrier;
   private readonly keepScreenAwakeRestorerFactory: (device: BootedDevice) => KeepScreenAwakeRestorer;
@@ -321,9 +323,11 @@ export class SessionManager {
     const promise = this.releaseSessionInternal(sessionId, session, releaseReason);
     const release = { session, promise };
     this.releasePromises.set(sessionId, release);
+    this.activeReleasePromises.add(release);
     try {
       return await promise;
     } finally {
+      this.activeReleasePromises.delete(release);
       if (this.releasePromises.get(sessionId) === release) {
         this.releasePromises.delete(sessionId);
       }
@@ -336,17 +340,17 @@ export class SessionManager {
    */
   trackSessionSetup(session: Session, setup: Promise<void>): Promise<void> {
     const tracked = { session, promise: setup };
-    this.sessionSetupPromises.set(session.sessionId, tracked);
+    this.sessionSetupPromises.add(tracked);
     void setup.then(
-      () => this.clearSessionSetup(session.sessionId, tracked),
-      () => this.clearSessionSetup(session.sessionId, tracked)
+      () => this.clearSessionSetup(tracked),
+      () => this.clearSessionSetup(tracked)
     );
     return setup;
   }
 
   /** Wait a bounded amount of time for releases already started by monitors. */
   async drainReleasePromises(timeoutMs: number): Promise<boolean> {
-    const releases = Array.from(this.releasePromises.values(), release => release.promise);
+    const releases = Array.from(this.activeReleasePromises, release => release.promise);
     if (releases.length === 0) {
       return true;
     }
@@ -370,12 +374,14 @@ export class SessionManager {
     session: Session,
     releaseReason: string,
   ): Promise<string | null> {
-    const setup = this.sessionSetupPromises.get(sessionId);
-    if (setup?.session === session) {
-      try {
-        await setup.promise;
-      } catch (error) {
-        logger.warn(`Failed session setup for ${sessionId} before release: ${error}`);
+    const setups = Array.from(this.sessionSetupPromises, setup => setup.session === session ? setup.promise : null)
+      .filter((setup): setup is Promise<void> => setup !== null);
+    if (setups.length > 0) {
+      const setupResults = await Promise.allSettled(setups);
+      for (const result of setupResults) {
+        if (result.status === "rejected") {
+          logger.warn(`Failed session setup for ${sessionId} before release: ${result.reason}`);
+        }
       }
     }
 
@@ -414,12 +420,9 @@ export class SessionManager {
   }
 
   private clearSessionSetup(
-    sessionId: string,
     tracked: { session: Session; promise: Promise<void> },
   ): void {
-    if (this.sessionSetupPromises.get(sessionId) === tracked) {
-      this.sessionSetupPromises.delete(sessionId);
-    }
+    this.sessionSetupPromises.delete(tracked);
   }
 
   /**

--- a/src/daemon/sessionManager.ts
+++ b/src/daemon/sessionManager.ts
@@ -104,6 +104,8 @@ export class SessionManager {
     string,
     { session: Session; promise: Promise<string | null> }
   > = new Map();
+  /** Setup work that must settle before a session restores its cached device state. */
+  private readonly sessionSetupPromises: Map<string, { session: Session; promise: Promise<void> }> = new Map();
   private deviceSessionRepository: DeviceSessionRepository;
   private readonly getBarrier: () => DbWriteBarrier;
   private readonly keepScreenAwakeRestorerFactory: (device: BootedDevice) => KeepScreenAwakeRestorer;
@@ -328,11 +330,55 @@ export class SessionManager {
     }
   }
 
+  /**
+   * Track setup that can modify device state after a session has been assigned.
+   * Release waits for this work so restoration sees the final cached state.
+   */
+  trackSessionSetup(session: Session, setup: Promise<void>): Promise<void> {
+    const tracked = { session, promise: setup };
+    this.sessionSetupPromises.set(session.sessionId, tracked);
+    void setup.then(
+      () => this.clearSessionSetup(session.sessionId, tracked),
+      () => this.clearSessionSetup(session.sessionId, tracked)
+    );
+    return setup;
+  }
+
+  /** Wait a bounded amount of time for releases already started by monitors. */
+  async drainReleasePromises(timeoutMs: number): Promise<boolean> {
+    const releases = Array.from(this.releasePromises.values(), release => release.promise);
+    if (releases.length === 0) {
+      return true;
+    }
+
+    let timeoutHandle: NodeJS.Timeout | undefined;
+    const timeout = new Promise<boolean>(resolve => {
+      timeoutHandle = this.timer.setTimeout(() => resolve(false), timeoutMs);
+    });
+
+    try {
+      return await Promise.race([Promise.allSettled(releases).then(() => true), timeout]);
+    } finally {
+      if (timeoutHandle !== undefined) {
+        this.timer.clearTimeout(timeoutHandle);
+      }
+    }
+  }
+
   private async releaseSessionInternal(
     sessionId: string,
     session: Session,
     releaseReason: string,
   ): Promise<string | null> {
+    const setup = this.sessionSetupPromises.get(sessionId);
+    if (setup?.session === session) {
+      try {
+        await setup.promise;
+      } catch (error) {
+        logger.warn(`Failed session setup for ${sessionId} before release: ${error}`);
+      }
+    }
+
     try {
       await this.restoreKeepScreenAwake(session);
     } catch (error) {
@@ -365,6 +411,15 @@ export class SessionManager {
     logger.info(`Released session ${sessionId}, freeing device ${deviceId}`);
 
     return deviceId;
+  }
+
+  private clearSessionSetup(
+    sessionId: string,
+    tracked: { session: Session; promise: Promise<void> },
+  ): void {
+    if (this.sessionSetupPromises.get(sessionId) === tracked) {
+      this.sessionSetupPromises.delete(sessionId);
+    }
   }
 
   /**

--- a/src/server/ToolExecutionContext.ts
+++ b/src/server/ToolExecutionContext.ts
@@ -89,7 +89,10 @@ export async function createToolExecutionContext(
     sessionOptions.platform
   );
 
-  await ensureKeepScreenAwake(session, sessionManager, sessionOptions);
+  await sessionManager.trackSessionSetup(
+    session,
+    ensureKeepScreenAwake(session, sessionManager, sessionOptions),
+  );
 
   if (!existingSession) {
     if (session.platform === "android") {

--- a/test/daemon/daemonShutdownSessionRelease.test.ts
+++ b/test/daemon/daemonShutdownSessionRelease.test.ts
@@ -1,0 +1,249 @@
+import { afterEach, describe, expect, spyOn, test } from "bun:test";
+import { Daemon } from "../../src/daemon/daemon";
+import { DaemonState } from "../../src/daemon/daemonState";
+import * as databaseModule from "../../src/db";
+import {
+  type DeviceSessionActivityUpdate,
+  type DeviceSessionRecord,
+  DeviceSessionRepository,
+} from "../../src/db/deviceSessionRepository";
+import type { DeviceSessionStatus } from "../../src/db/types";
+import { KeepScreenAwakeManager, type KeepScreenAwakeState } from "../../src/utils/KeepScreenAwakeManager";
+import { logger } from "../../src/utils/logger";
+import { FakeTimer } from "../fakes/FakeTimer";
+import { FakeInstalledAppsRepository } from "../fakes/FakeInstalledAppsRepository";
+
+class FakeDeviceSessionRepository {
+  readonly events: string[] = [];
+  readonly sessions = new Map<string, {
+    status: DeviceSessionStatus;
+    releasedAtMs: number | null;
+    reason: string | null;
+  }>();
+
+  async upsertActiveSession(record: DeviceSessionRecord): Promise<void> {
+    this.sessions.set(record.sessionUuid, {
+      status: "active",
+      releasedAtMs: null,
+      reason: null,
+    });
+  }
+
+  async recordActivity(_sessionUuid: string, _update: DeviceSessionActivityUpdate): Promise<void> {}
+
+  async markReleased(
+    sessionUuid: string,
+    status: DeviceSessionStatus,
+    releasedAtMs: number,
+    reason: string,
+  ): Promise<void> {
+    this.events.push("markReleased");
+    this.sessions.set(sessionUuid, { status, releasedAtMs, reason });
+  }
+
+  async markStaleActiveSessionsExpired(): Promise<void> {}
+}
+
+describe("Daemon shutdown session release (issue #5303)", () => {
+  afterEach(() => {
+    if (DaemonState.getInstance().isInitialized()) {
+      DaemonState.getInstance().reset();
+    }
+  });
+
+  test("releases active sessions before closing the database", async () => {
+    const timer = new FakeTimer();
+    const repository = new FakeDeviceSessionRepository();
+    const daemon = new Daemon(
+      {},
+      new FakeInstalledAppsRepository(),
+      timer,
+      repository as unknown as DeviceSessionRepository,
+    );
+    const sessionManager = daemon.getSessionManager();
+    const devicePool = daemon.getDevicePool();
+    const sessionId = "shutdown-session";
+    const deviceId = "physical-device";
+    const keepAwakeState: KeepScreenAwakeState = {
+      applied: true,
+      method: "settings",
+      originalStayOnWhilePluggedIn: "0",
+      originalScreenOffTimeout: "60000",
+      appliedSettings: { stayOnWhilePluggedIn: true, screenOffTimeout: true },
+    };
+    const releasedCallbacks: Array<{ sessionId: string; deviceId: string }> = [];
+    const restoreSpy = spyOn(KeepScreenAwakeManager.prototype, "restore")
+      .mockResolvedValue(undefined);
+    const releaseDeviceSpy = spyOn(devicePool, "releaseDevice");
+    const loggerCloseSpy = spyOn(logger, "close").mockImplementation(() => {});
+    const closeDatabaseSpy = spyOn(databaseModule, "closeDatabase").mockImplementation(async () => {
+      repository.events.push("closeDatabase");
+    });
+
+    try {
+      await devicePool.initializeWithDevices([{
+        name: "Physical Android",
+        deviceId,
+        platform: "android",
+      }]);
+      await devicePool.assignDeviceToSession(sessionId, "android");
+      sessionManager.setKeepScreenAwake(sessionId, keepAwakeState);
+      sessionManager.onSessionRelease((releasedSessionId, releasedDeviceId) => {
+        releasedCallbacks.push({ sessionId: releasedSessionId, deviceId: releasedDeviceId });
+      });
+
+      await daemon.stop();
+
+      expect(restoreSpy).toHaveBeenCalledWith(keepAwakeState);
+      expect(releasedCallbacks).toContainEqual({ sessionId, deviceId });
+      expect(releaseDeviceSpy).toHaveBeenCalledWith(deviceId);
+      expect(sessionManager.getSession(sessionId)).toBeNull();
+      expect(devicePool.getDevice(deviceId)).toMatchObject({
+        sessionId: null,
+        status: "idle",
+      });
+      expect(repository.sessions.get(sessionId)).toMatchObject({
+        status: "released",
+        releasedAtMs: timer.now(),
+        reason: "daemon-shutdown",
+      });
+      expect(repository.events).toEqual(["markReleased", "closeDatabase"]);
+    } finally {
+      restoreSpy.mockRestore();
+      releaseDeviceSpy.mockRestore();
+      loggerCloseSpy.mockRestore();
+      closeDatabaseSpy.mockRestore();
+    }
+  });
+
+  test("continues releasing other sessions when one teardown fails", async () => {
+    const timer = new FakeTimer();
+    const repository = new FakeDeviceSessionRepository();
+    const daemon = new Daemon(
+      {},
+      new FakeInstalledAppsRepository(),
+      timer,
+      repository as unknown as DeviceSessionRepository,
+    );
+    const sessionManager = daemon.getSessionManager();
+    const brokenSessionId = "broken-shutdown-session";
+    const healthySessionId = "healthy-shutdown-session";
+    const originalRelease = sessionManager.releaseSession.bind(sessionManager);
+    const releaseSpy = spyOn(sessionManager, "releaseSession")
+      .mockImplementation(async (sessionId, reason) => {
+        if (sessionId === brokenSessionId) {
+          throw new Error("simulated release failure");
+        }
+        return await originalRelease(sessionId, reason);
+      });
+    const loggerCloseSpy = spyOn(logger, "close").mockImplementation(() => {});
+
+    try {
+      await sessionManager.createSession(brokenSessionId, "broken-device", "android");
+      await sessionManager.createSession(healthySessionId, "healthy-device", "android");
+
+      await expect(daemon.stop()).resolves.toBeUndefined();
+
+      expect(releaseSpy).toHaveBeenCalledWith(brokenSessionId, "daemon-shutdown", true);
+      expect(releaseSpy).toHaveBeenCalledWith(healthySessionId, "daemon-shutdown", true);
+      expect(sessionManager.getSession(healthySessionId)).toBeNull();
+      expect(repository.sessions.get(healthySessionId)).toMatchObject({
+        status: "released",
+        reason: "daemon-shutdown",
+      });
+    } finally {
+      releaseSpy.mockRestore();
+      loggerCloseSpy.mockRestore();
+    }
+  });
+
+  test("releases the session when keep-awake restoration fails", async () => {
+    const timer = new FakeTimer();
+    const repository = new FakeDeviceSessionRepository();
+    const daemon = new Daemon(
+      {},
+      new FakeInstalledAppsRepository(),
+      timer,
+      repository as unknown as DeviceSessionRepository,
+    );
+    const sessionManager = daemon.getSessionManager();
+    const devicePool = daemon.getDevicePool();
+    const sessionId = "restore-failure-shutdown-session";
+    const deviceId = "restore-failure-device";
+    const restoreSpy = spyOn(KeepScreenAwakeManager.prototype, "restore")
+      .mockRejectedValue(new Error("simulated restore failure"));
+    const loggerCloseSpy = spyOn(logger, "close").mockImplementation(() => {});
+
+    try {
+      await devicePool.initializeWithDevices([{
+        name: "Restore Failure Android",
+        deviceId,
+        platform: "android",
+      }]);
+      await devicePool.assignDeviceToSession(sessionId, "android");
+      sessionManager.setKeepScreenAwake(sessionId, { applied: true, method: "svc", svcWasEnabled: false });
+
+      await expect(daemon.stop()).resolves.toBeUndefined();
+
+      expect(sessionManager.getSession(sessionId)).toBeNull();
+      expect(devicePool.getDevice(deviceId)).toMatchObject({ sessionId: null, status: "idle" });
+      expect(repository.sessions.get(sessionId)).toMatchObject({
+        status: "released",
+        reason: "daemon-shutdown",
+      });
+    } finally {
+      restoreSpy.mockRestore();
+      loggerCloseSpy.mockRestore();
+    }
+  });
+
+  test("releases sessions that expired after cleanup stopped", async () => {
+    const timer = new FakeTimer();
+    const repository = new FakeDeviceSessionRepository();
+    const daemon = new Daemon(
+      {},
+      new FakeInstalledAppsRepository(),
+      timer,
+      repository as unknown as DeviceSessionRepository,
+    );
+    const sessionManager = daemon.getSessionManager();
+    const devicePool = daemon.getDevicePool();
+    const sessionId = "expired-shutdown-session";
+    const deviceId = "expired-device";
+    const keepAwakeState: KeepScreenAwakeState = {
+      applied: true,
+      method: "svc",
+      originalStayOnWhilePluggedIn: "0",
+    };
+    const releasedCallbacks: string[] = [];
+    const restoreSpy = spyOn(KeepScreenAwakeManager.prototype, "restore")
+      .mockResolvedValue(undefined);
+    const loggerCloseSpy = spyOn(logger, "close").mockImplementation(() => {});
+
+    try {
+      await devicePool.initializeWithDevices([{
+        name: "Expired Android",
+        deviceId,
+        platform: "android",
+      }]);
+      await devicePool.assignDeviceToSession(sessionId, "android");
+      sessionManager.setKeepScreenAwake(sessionId, keepAwakeState);
+      sessionManager.onSessionRelease(releasedSessionId => releasedCallbacks.push(releasedSessionId));
+      sessionManager.stopCleanupTimer();
+      timer.advanceTime(31 * 60 * 1000);
+
+      await daemon.stop();
+
+      expect(restoreSpy).toHaveBeenCalledWith(keepAwakeState);
+      expect(releasedCallbacks).toContain(sessionId);
+      expect(devicePool.getDevice(deviceId)).toMatchObject({ sessionId: null, status: "idle" });
+      expect(repository.sessions.get(sessionId)).toMatchObject({
+        status: "released",
+        reason: "daemon-shutdown",
+      });
+    } finally {
+      restoreSpy.mockRestore();
+      loggerCloseSpy.mockRestore();
+    }
+  });
+});

--- a/test/daemon/daemonShutdownSessionRelease.test.ts
+++ b/test/daemon/daemonShutdownSessionRelease.test.ts
@@ -75,7 +75,7 @@ describe("Daemon shutdown session release (issue #5303)", () => {
     const restoreSpy = spyOn(KeepScreenAwakeManager.prototype, "restore")
       .mockResolvedValue(undefined);
     const releaseDeviceSpy = spyOn(devicePool, "releaseDevice");
-    const loggerCloseSpy = spyOn(logger, "close").mockImplementation(() => {});
+    const loggerCloseSpy = spyOn(logger, "closeAfterFlush").mockResolvedValue(undefined);
     const closeDatabaseSpy = spyOn(databaseModule, "closeDatabase").mockImplementation(async () => {
       repository.events.push("closeDatabase");
     });
@@ -136,7 +136,7 @@ describe("Daemon shutdown session release (issue #5303)", () => {
         }
         return await originalRelease(sessionId, reason);
       });
-    const loggerCloseSpy = spyOn(logger, "close").mockImplementation(() => {});
+    const loggerCloseSpy = spyOn(logger, "closeAfterFlush").mockResolvedValue(undefined);
 
     try {
       await sessionManager.createSession(brokenSessionId, "broken-device", "android");
@@ -172,7 +172,7 @@ describe("Daemon shutdown session release (issue #5303)", () => {
     const deviceId = "restore-failure-device";
     const restoreSpy = spyOn(KeepScreenAwakeManager.prototype, "restore")
       .mockRejectedValue(new Error("simulated restore failure"));
-    const loggerCloseSpy = spyOn(logger, "close").mockImplementation(() => {});
+    const loggerCloseSpy = spyOn(logger, "closeAfterFlush").mockResolvedValue(undefined);
 
     try {
       await devicePool.initializeWithDevices([{
@@ -218,7 +218,7 @@ describe("Daemon shutdown session release (issue #5303)", () => {
     const releasedCallbacks: string[] = [];
     const restoreSpy = spyOn(KeepScreenAwakeManager.prototype, "restore")
       .mockResolvedValue(undefined);
-    const loggerCloseSpy = spyOn(logger, "close").mockImplementation(() => {});
+    const loggerCloseSpy = spyOn(logger, "closeAfterFlush").mockResolvedValue(undefined);
 
     try {
       await devicePool.initializeWithDevices([{

--- a/test/daemon/sessionManager.test.ts
+++ b/test/daemon/sessionManager.test.ts
@@ -1,8 +1,9 @@
 import { describe, expect, test, beforeEach, afterEach } from "bun:test";
-import { SessionManager } from "../../src/daemon/sessionManager";
+import { SessionManager, type KeepScreenAwakeRestorer } from "../../src/daemon/sessionManager";
 import { FakeTimer } from "../fakes/FakeTimer";
 import { FakeDbWriteBarrier } from "../fakes/FakeDbWriteBarrier";
 import type { ViewHierarchyResult } from "../../src/models/ViewHierarchyResult";
+import type { KeepScreenAwakeState } from "../../src/utils/KeepScreenAwakeManager";
 
 function makeHierarchy(label: string): ViewHierarchyResult {
   return {
@@ -238,6 +239,82 @@ describe("SessionManager", () => {
     test("should return null for non-existent session", async () => {
       const deviceId = await sessionManager.releaseSession("non-existent");
       expect(deviceId).toBeNull();
+    });
+
+    test("coalesces concurrent releases before callbacks and persistence", async () => {
+      const released: string[] = [];
+      const callbacks: string[] = [];
+      let beginRestore!: () => void;
+      const restoreStarted = new Promise<void>(resolve => { beginRestore = resolve; });
+      let finishRestore!: () => void;
+      const restoreFinished = new Promise<void>(resolve => { finishRestore = resolve; });
+      const restorer: KeepScreenAwakeRestorer = {
+        async restore(_state: KeepScreenAwakeState): Promise<void> {
+          beginRestore();
+          await restoreFinished;
+        },
+      };
+      const repository = {
+        async upsertActiveSession(): Promise<void> {},
+        async recordActivity(): Promise<void> {},
+        async markReleased(sessionId: string): Promise<void> { released.push(sessionId); },
+        async markStaleActiveSessionsExpired(): Promise<void> {},
+      };
+      const manager = new SessionManager(
+        fakeTimer,
+        repository,
+        () => new FakeDbWriteBarrier(),
+        () => restorer,
+      );
+      try {
+        await manager.createSession("s1", "device-1", "android");
+        manager.setKeepScreenAwake("s1", { applied: true, method: "svc", svcWasEnabled: false });
+        manager.onSessionRelease(sessionId => callbacks.push(sessionId));
+
+        const first = manager.releaseSession("s1", "heartbeat");
+        await restoreStarted;
+        const second = manager.releaseSession("s1", "daemon-shutdown");
+        finishRestore();
+
+        await expect(Promise.all([first, second])).resolves.toEqual(["device-1", "device-1"]);
+        expect(callbacks).toEqual(["s1"]);
+        expect(released).toEqual(["s1"]);
+      } finally {
+        manager.stopCleanupTimer();
+      }
+    });
+
+    test("does not coalesce a replacement session with the same UUID", async () => {
+      const releases: string[] = [];
+      let finishFirstPersistence!: () => void;
+      const firstPersistence = new Promise<void>(resolve => { finishFirstPersistence = resolve; });
+      const repository = {
+        async upsertActiveSession(): Promise<void> {},
+        async recordActivity(): Promise<void> {},
+        async markReleased(_sessionId: string, _status: string, _releasedAt: number, reason: string): Promise<void> {
+          releases.push(reason);
+          if (reason === "first") {
+            await firstPersistence;
+          }
+        },
+        async markStaleActiveSessionsExpired(): Promise<void> {},
+      };
+      const manager = new SessionManager(fakeTimer, repository, () => new FakeDbWriteBarrier());
+      try {
+        await manager.createSession("s1", "device-1", "android");
+        const first = manager.releaseSession("s1", "first");
+        await Promise.resolve();
+
+        await manager.createSession("s1", "device-2", "android");
+        await expect(manager.releaseSession("s1", "second")).resolves.toBe("device-2");
+        finishFirstPersistence();
+        await expect(first).resolves.toBe("device-1");
+
+        expect(releases).toEqual(["first", "second"]);
+        expect(manager.getSession("s1")).toBeNull();
+      } finally {
+        manager.stopCleanupTimer();
+      }
     });
   });
 

--- a/test/daemon/sessionManager.test.ts
+++ b/test/daemon/sessionManager.test.ts
@@ -284,6 +284,62 @@ describe("SessionManager", () => {
       }
     });
 
+    test("waits for tracked setup before restoring and removing a session", async () => {
+      let finishSetup!: () => void;
+      const setupFinished = new Promise<void>(resolve => { finishSetup = resolve; });
+      const manager = new SessionManager(fakeTimer, {
+        async upsertActiveSession(): Promise<void> {},
+        async recordActivity(): Promise<void> {},
+        async markReleased(): Promise<void> {},
+        async markStaleActiveSessionsExpired(): Promise<void> {},
+      }, () => new FakeDbWriteBarrier());
+      try {
+        const session = await manager.createSession("s1", "device-1", "android");
+        const setup = manager.trackSessionSetup(session, setupFinished);
+        const release = manager.releaseSession("s1", "daemon-shutdown");
+
+        await Promise.resolve();
+        expect(manager.getSession("s1")).not.toBeNull();
+
+        finishSetup();
+        await setup;
+        await expect(release).resolves.toBe("device-1");
+        expect(manager.getSession("s1")).toBeNull();
+      } finally {
+        manager.stopCleanupTimer();
+      }
+    });
+
+    test("bounds a drain of an already-started release", async () => {
+      let finishRestore!: () => void;
+      const restoreFinished = new Promise<void>(resolve => { finishRestore = resolve; });
+      const manager = new SessionManager(
+        fakeTimer,
+        {
+          async upsertActiveSession(): Promise<void> {},
+          async recordActivity(): Promise<void> {},
+          async markReleased(): Promise<void> {},
+          async markStaleActiveSessionsExpired(): Promise<void> {},
+        },
+        () => new FakeDbWriteBarrier(),
+        () => ({ restore: async () => await restoreFinished }),
+      );
+      try {
+        await manager.createSession("s1", "device-1", "android");
+        manager.setKeepScreenAwake("s1", { applied: true, method: "svc", svcWasEnabled: false });
+        const release = manager.releaseSession("s1", "heartbeat");
+        const drained = manager.drainReleasePromises(1_000);
+
+        fakeTimer.advanceTime(1_000);
+        await expect(drained).resolves.toBe(false);
+
+        finishRestore();
+        await release;
+      } finally {
+        manager.stopCleanupTimer();
+      }
+    });
+
     test("does not coalesce a replacement session with the same UUID", async () => {
       const releases: string[] = [];
       let finishFirstPersistence!: () => void;


### PR DESCRIPTION
## Summary

Graceful daemon shutdown now releases every active session through the existing cancellation and release path after all request intake is closed. This restores keep-awake state, runs session-scoped cleanup callbacks, frees pooled devices, and persists terminal session rows before the database closes. A failed teardown is logged without preventing the remaining sessions from releasing.

## Linked Issue

Closes [#5303](https://github.com/kaeawc/auto-mobile/issues/5303)

## Bug / Regression Context

- **Prior attempts:** None.
- **Observed symptom:** Daemon shutdown stopped transports and timers but left active session state unreleased.
- **Repro steps / conditions:** Stop a daemon with an Android session that has applied keep-screen-awake state.

## Validation

- [x] `bun run turbo:validate` passes (13,140 tests passed; 13 expected skips).
- [x] `bun run typecheck` reports no new errors (baseline gate).
- [x] New coverage uses fakes and `FakeTimer`; the added unit tests run in under 15 ms.
- [x] No new dependency or generic helper was added.
- [x] Rebased onto current `origin/main` (`af94a03a`).

## Follow-ups

None.
