### PR TITLE
fix(daemon): bound fallback timeout cleanup

### DIFF
--- a/src/daemon/DaemonLauncher.ts
+++ b/src/daemon/DaemonLauncher.ts
@@ -5,7 +5,6 @@ import { ActionableError } from "../models";
 import {
   trackProcess,
   waitForExit,
-  type StoppableProcess,
   type TrackedChildProcess,
 } from "../utils/ChildProcessTracker";
 import { releaseVersion } from "../utils/mcpVersion";
@@ -22,8 +21,8 @@ export interface DaemonProcessSpawner {
   spawn(command: string, args: string[], options: SpawnOptions): ChildProcess;
 }
 
-/** Signals the dedicated process group created by a detached POSIX spawn. */
-export type DaemonProcessGroupKiller = (pid: number, signal: NodeJS.Signals) => void;
+/** Signals or probes the dedicated process group created by a detached POSIX spawn. */
+export type DaemonProcessGroupKiller = (pid: number, signal: NodeJS.Signals | 0) => void;
 
 export interface DaemonLauncherDependencies {
   entryScript?: string | null;
@@ -217,15 +216,16 @@ export class DaemonLauncher {
         }
         cleanupProcessListeners();
 
-        // Keep startup ownership until the child has actually exited. The shared
-        // tracker sends SIGTERM, escalates to SIGKILL after the bounded daemon
-        // shutdown grace, and waits for the corresponding exit observation.
+        // Keep startup ownership until the child has actually exited. Detached
+        // POSIX launchers also keep process-group escalation armed after their
+        // package-runner wrapper exits, so the daemon descendant is reaped.
         const tracker = trackProcess(daemonProcess as TrackedChildProcess);
-        await waitForExit(this.shutdownTarget(tracker.process, daemonProcess.pid, request.spawnOptions.detached === true), tracker.exitPromise, {
-          signal: "SIGTERM",
-          timeoutMs: DAEMON_SHUTDOWN_TIMEOUT_MS,
-          timer: this.timer,
-        });
+        await this.stopTimedOutProcess(
+          tracker.process,
+          tracker.exitPromise,
+          daemonProcess.pid,
+          request.spawnOptions.detached === true,
+        );
         throw await request.formatFailure(`Daemon failed to start within ${request.timeoutMs}ms`);
       }
     } finally {
@@ -256,43 +256,77 @@ export class DaemonLauncher {
     }
   }
 
-  /**
-   * Detached POSIX spawns lead a new process group. Signalling that group keeps
-   * a `bunx`/`bun x` wrapper from leaving its daemon child behind. Windows has
-   * no negative-PID process-group signal API, so retain the direct-child path.
-   */
-  private shutdownTarget(
+  private async stopTimedOutProcess(
     process: TrackedChildProcess,
+    exitPromise: Promise<void>,
     pid: number | undefined,
     detached: boolean,
-  ): StoppableProcess {
+  ): Promise<void> {
     if (!detached || this.platform === "win32" || pid === undefined) {
-      return process;
+      await waitForExit(process, exitPromise, {
+        signal: "SIGTERM",
+        timeoutMs: DAEMON_SHUTDOWN_TIMEOUT_MS,
+        timer: this.timer,
+      });
+      return;
     }
 
-    const processGroupPid = pid;
-    return {
-      get exitCode() {
-        return process.exitCode;
-      },
-      get killed() {
-        return process.killed;
-      },
-      kill: signal => {
-        try {
-          this.processGroupKiller(processGroupPid, signal as NodeJS.Signals);
-          return true;
-        } catch (error) {
-          // A vanished group has no descendants left to reap. Fall back to the
-          // direct handle for unusual spawn implementations that do not create
-          // a process group despite receiving `detached: true`.
-          logger.debug(
-            `Daemon process-group signal failed for pid=${processGroupPid}; falling back to the direct child: ${error}`
-          );
-          return process.kill(signal);
-        }
-      },
-    };
+    this.signalProcessGroup(process, pid, "SIGTERM");
+    let timeout: NodeJS.Timeout | undefined;
+    const deadline = new Promise<void>(resolve => {
+      timeout = this.timer.setTimeout(resolve, DAEMON_SHUTDOWN_TIMEOUT_MS);
+    });
+
+    try {
+      const wrapperExited = await Promise.race([
+        exitPromise.then(() => true),
+        deadline.then(() => false),
+      ]);
+
+      // A `bunx`/`bun x` wrapper can exit while its daemon remains in the same
+      // detached group. Keep the grace timer alive when that group still exists.
+      if (wrapperExited && !this.isProcessGroupAlive(pid)) {
+        return;
+      }
+
+      await deadline;
+      if (this.isProcessGroupAlive(pid)) {
+        this.signalProcessGroup(process, pid, "SIGKILL");
+      }
+      await exitPromise;
+    } finally {
+      if (timeout) {
+        this.timer.clearTimeout(timeout);
+      }
+    }
+  }
+
+  private isProcessGroupAlive(pid: number): boolean {
+    try {
+      this.processGroupKiller(pid, 0);
+      return true;
+    } catch (error) {
+      logger.debug(`Daemon process group is no longer alive for pid=${pid}: ${error}`);
+      return false;
+    }
+  }
+
+  private signalProcessGroup(
+    process: TrackedChildProcess,
+    pid: number,
+    signal: NodeJS.Signals,
+  ): void {
+    try {
+      this.processGroupKiller(pid, signal);
+    } catch (error) {
+      // A vanished group has no descendants left to reap. Fall back to the
+      // direct handle for unusual spawn implementations that do not create a
+      // group despite receiving `detached: true`.
+      logger.debug(
+        `Daemon process-group signal failed for pid=${pid}; falling back to the direct child: ${error}`
+      );
+      process.kill(signal);
+    }
   }
 }
 

--- a/src/daemon/DaemonLauncher.ts
+++ b/src/daemon/DaemonLauncher.ts
@@ -2,8 +2,14 @@ import { spawn as nodeSpawn, type ChildProcess, type SpawnOptions } from "node:c
 import { existsSync } from "node:fs";
 import { posix, win32 } from "node:path";
 import { ActionableError } from "../models";
-import { trackProcess, waitForExit, type TrackedChildProcess } from "../utils/ChildProcessTracker";
+import {
+  trackProcess,
+  waitForExit,
+  type StoppableProcess,
+  type TrackedChildProcess,
+} from "../utils/ChildProcessTracker";
 import { releaseVersion } from "../utils/mcpVersion";
+import { logger } from "../utils/logger";
 import { defaultTimer, type Timer } from "../utils/SystemTimer";
 import { DAEMON_SHUTDOWN_TIMEOUT_MS, DAEMON_VERSION } from "./constants";
 
@@ -16,6 +22,9 @@ export interface DaemonProcessSpawner {
   spawn(command: string, args: string[], options: SpawnOptions): ChildProcess;
 }
 
+/** Signals the dedicated process group created by a detached POSIX spawn. */
+export type DaemonProcessGroupKiller = (pid: number, signal: NodeJS.Signals) => void;
+
 export interface DaemonLauncherDependencies {
   entryScript?: string | null;
   version?: string;
@@ -25,6 +34,7 @@ export interface DaemonLauncherDependencies {
   executableExists?: (path: string) => boolean;
   spawn?: DaemonProcessSpawner["spawn"];
   timer?: Timer;
+  processGroupKiller?: DaemonProcessGroupKiller;
 }
 
 export interface DaemonLaunchRequest {
@@ -98,6 +108,7 @@ export class DaemonLauncher {
   private readonly executableExists: (path: string) => boolean;
   private readonly spawn: DaemonProcessSpawner["spawn"];
   private readonly timer: Timer;
+  private readonly processGroupKiller: DaemonProcessGroupKiller;
 
   constructor(dependencies: DaemonLauncherDependencies = {}) {
     this.entryScript = dependencies.entryScript === undefined
@@ -110,6 +121,7 @@ export class DaemonLauncher {
     this.executableExists = dependencies.executableExists ?? existsSync;
     this.spawn = dependencies.spawn ?? nodeSpawn;
     this.timer = dependencies.timer ?? defaultTimer;
+    this.processGroupKiller = dependencies.processGroupKiller ?? defaultProcessGroupKiller;
   }
 
   resolveCommand(): DaemonLaunchCommand {
@@ -193,10 +205,10 @@ export class DaemonLauncher {
         readinessAbort.abort();
         // Keep the startup listeners installed while the final check awaits so
         // a late child error or exit cannot become unobserved in that window.
-        const isReadyAtDeadline = await Promise.race([
+        const isReadyAtDeadline = await this.waitForFinalReadinessCheck(
           request.isReadyForLaunchedProcess?.(daemonProcess.pid) ?? Promise.resolve(false),
           processFailure,
-        ]);
+        );
         if (processFailureObserved) {
           await processFailure;
         }
@@ -209,7 +221,7 @@ export class DaemonLauncher {
         // tracker sends SIGTERM, escalates to SIGKILL after the bounded daemon
         // shutdown grace, and waits for the corresponding exit observation.
         const tracker = trackProcess(daemonProcess as TrackedChildProcess);
-        await waitForExit(tracker.process, tracker.exitPromise, {
+        await waitForExit(this.shutdownTarget(tracker.process, daemonProcess.pid, request.spawnOptions.detached === true), tracker.exitPromise, {
           signal: "SIGTERM",
           timeoutMs: DAEMON_SHUTDOWN_TIMEOUT_MS,
           timer: this.timer,
@@ -221,4 +233,69 @@ export class DaemonLauncher {
       cleanupProcessListeners();
     }
   }
+
+  /**
+   * The final check is a grace-period race, not a second unbounded startup
+   * phase. The normal connection probe may wait for a long client timeout, so
+   * it must not delay cleanup of a child that already missed startup readiness.
+   */
+  private async waitForFinalReadinessCheck(
+    readinessCheck: Promise<boolean>,
+    processFailure: Promise<never>,
+  ): Promise<boolean> {
+    let timeout: NodeJS.Timeout | undefined;
+    const deadline = new Promise<boolean>(resolve => {
+      timeout = this.timer.setTimeout(() => resolve(false), DAEMON_SHUTDOWN_TIMEOUT_MS);
+    });
+    try {
+      return await Promise.race([readinessCheck, processFailure, deadline]);
+    } finally {
+      if (timeout) {
+        this.timer.clearTimeout(timeout);
+      }
+    }
+  }
+
+  /**
+   * Detached POSIX spawns lead a new process group. Signalling that group keeps
+   * a `bunx`/`bun x` wrapper from leaving its daemon child behind. Windows has
+   * no negative-PID process-group signal API, so retain the direct-child path.
+   */
+  private shutdownTarget(
+    process: TrackedChildProcess,
+    pid: number | undefined,
+    detached: boolean,
+  ): StoppableProcess {
+    if (!detached || this.platform === "win32" || pid === undefined) {
+      return process;
+    }
+
+    const processGroupPid = pid;
+    return {
+      get exitCode() {
+        return process.exitCode;
+      },
+      get killed() {
+        return process.killed;
+      },
+      kill: signal => {
+        try {
+          this.processGroupKiller(processGroupPid, signal as NodeJS.Signals);
+          return true;
+        } catch (error) {
+          // A vanished group has no descendants left to reap. Fall back to the
+          // direct handle for unusual spawn implementations that do not create
+          // a process group despite receiving `detached: true`.
+          logger.debug(
+            `Daemon process-group signal failed for pid=${processGroupPid}; falling back to the direct child: ${error}`
+          );
+          return process.kill(signal);
+        }
+      },
+    };
+  }
 }
+
+const defaultProcessGroupKiller: DaemonProcessGroupKiller = (pid, signal) => {
+  process.kill(-pid, signal);
+};

--- a/test/daemon/DaemonLauncher.test.ts
+++ b/test/daemon/DaemonLauncher.test.ts
@@ -5,6 +5,7 @@ import {
   DaemonLauncher,
   type DaemonProcessSpawner,
 } from "../../src/daemon/DaemonLauncher";
+import { DAEMON_SHUTDOWN_TIMEOUT_MS } from "../../src/daemon/constants";
 import { FakeTimer } from "../fakes/FakeTimer";
 
 class FakeDaemonProcess extends EventEmitter {
@@ -237,6 +238,69 @@ describe("DaemonLauncher", () => {
 
     expect(spawner.process.signals).toEqual(["SIGTERM", "SIGKILL"]);
     expect(spawner.process.exitCode).toBe(0);
+  });
+
+  test("bounds a stalled final readiness check before terminating the child", async () => {
+    const spawner = new FakeDaemonSpawner();
+    spawner.process.exitOnSignal = "SIGTERM";
+    const timer = new FakeTimer();
+    const launcher = new DaemonLauncher({
+      spawn: spawner.spawn.bind(spawner),
+      timer,
+    });
+
+    const launch = launcher.launchAndWait({
+      command: "auto-mobile",
+      args: ["--daemon-mode"],
+      spawnOptions: {},
+      timeoutMs: 100,
+      waitForReady: async () => false,
+      isReadyForLaunchedProcess: async () => new Promise<boolean>(() => {}),
+      formatFailure: async summary => new Error(summary),
+    });
+
+    await new Promise<void>(resolve => setImmediate(resolve));
+    expect(spawner.process.signals).toEqual([]);
+    expect(timer.getPendingTimeoutCount()).toBe(1);
+
+    timer.advanceTime(DAEMON_SHUTDOWN_TIMEOUT_MS);
+    await expect(launch).rejects.toThrow("Daemon failed to start within 100ms");
+
+    expect(spawner.process.signals).toEqual(["SIGTERM"]);
+    expect(timer.getPendingTimeoutCount()).toBe(0);
+  });
+
+  test("escalates the detached POSIX process group to reap a package-runner child", async () => {
+    const spawner = new FakeDaemonSpawner();
+    const timer = new FakeTimer();
+    timer.enableAutoAdvance();
+    const processGroupSignals: Array<{ pid: number; signal: NodeJS.Signals }> = [];
+    const launcher = new DaemonLauncher({
+      spawn: spawner.spawn.bind(spawner),
+      timer,
+      platform: "linux",
+      processGroupKiller: (pid, signal) => {
+        processGroupSignals.push({ pid, signal });
+        if (signal === "SIGKILL") {
+          spawner.process.emitExit(signal);
+        }
+      },
+    });
+
+    await expect(launcher.launchAndWait({
+      command: "bunx",
+      args: ["-y", "@kaeawc/auto-mobile@1.2.3", "--daemon-mode"],
+      spawnOptions: { detached: true },
+      timeoutMs: 100,
+      waitForReady: async () => false,
+      formatFailure: async summary => new Error(summary),
+    })).rejects.toThrow("Daemon failed to start within 100ms");
+
+    expect(processGroupSignals).toEqual([
+      { pid: 12345, signal: "SIGTERM" },
+      { pid: 12345, signal: "SIGKILL" },
+    ]);
+    expect(spawner.process.signals).toEqual([]);
   });
 
   test("keeps a launched child that becomes ready at the readiness deadline", async () => {

--- a/test/daemon/DaemonLauncher.test.ts
+++ b/test/daemon/DaemonLauncher.test.ts
@@ -274,7 +274,7 @@ describe("DaemonLauncher", () => {
     const spawner = new FakeDaemonSpawner();
     const timer = new FakeTimer();
     timer.enableAutoAdvance();
-    const processGroupSignals: Array<{ pid: number; signal: NodeJS.Signals }> = [];
+    const processGroupSignals: Array<{ pid: number; signal: NodeJS.Signals | 0 }> = [];
     const launcher = new DaemonLauncher({
       spawn: spawner.spawn.bind(spawner),
       timer,
@@ -298,8 +298,55 @@ describe("DaemonLauncher", () => {
 
     expect(processGroupSignals).toEqual([
       { pid: 12345, signal: "SIGTERM" },
+      { pid: 12345, signal: 0 },
       { pid: 12345, signal: "SIGKILL" },
     ]);
+    expect(spawner.process.signals).toEqual([]);
+  });
+
+  test("keeps detached process-group escalation armed after its wrapper exits", async () => {
+    const spawner = new FakeDaemonSpawner();
+    const timer = new FakeTimer();
+    const processGroupSignals: Array<NodeJS.Signals | 0> = [];
+    let daemonStillAlive = true;
+    const launcher = new DaemonLauncher({
+      spawn: spawner.spawn.bind(spawner),
+      timer,
+      platform: "linux",
+      processGroupKiller: (_pid, signal) => {
+        processGroupSignals.push(signal);
+        if (signal === 0 && !daemonStillAlive) {
+          throw new Error("ESRCH");
+        }
+        if (signal === "SIGTERM") {
+          // The package runner exits, but its daemon descendant ignores TERM.
+          spawner.process.emitExit(signal);
+        }
+        if (signal === "SIGKILL") {
+          daemonStillAlive = false;
+        }
+      },
+    });
+    let settled = false;
+    const launch = launcher.launchAndWait({
+      command: "bunx",
+      args: ["-y", "@kaeawc/auto-mobile@1.2.3", "--daemon-mode"],
+      spawnOptions: { detached: true },
+      timeoutMs: 100,
+      waitForReady: async () => false,
+      formatFailure: async summary => new Error(summary),
+    }).finally(() => {
+      settled = true;
+    });
+
+    await new Promise<void>(resolve => setImmediate(resolve));
+    expect(processGroupSignals).toEqual(["SIGTERM", 0]);
+    expect(settled).toBe(false);
+
+    timer.advanceTime(DAEMON_SHUTDOWN_TIMEOUT_MS);
+    await expect(launch).rejects.toThrow("Daemon failed to start within 100ms");
+
+    expect(processGroupSignals).toEqual(["SIGTERM", 0, 0, "SIGKILL"]);
     expect(spawner.process.signals).toEqual([]);
   });
 


### PR DESCRIPTION
## Summary

- bound the post-timeout daemon identity/readiness recheck with the injected timer
- signal the detached POSIX daemon process group during timeout cleanup, so a `bunx`/`bun x` wrapper cannot leave the daemon child running
- add FakeTimer regression coverage for both paths

## Root cause

The original timeout cleanup guarded the immediate child only and awaited its final identity probe without a deadline. A package-runner wrapper could exit while its daemon child remained alive, and a stalled probe could indefinitely delay cleanup.

## Validation

- `bun test test/daemon/DaemonLauncher.test.ts test/daemon/daemonManagerReadiness.test.ts`
- `bun run lint`
- `bun run typecheck`
- `bun run check:daemon-launcher-boundary`
- `bun run turbo:validate`
