### PR TITLE
fix(recovery): stop child after readiness failure

### DIFF
--- a/src/daemon/devicePool.ts
+++ b/src/daemon/devicePool.ts
@@ -1418,7 +1418,8 @@ export class DevicePool {
       childProcess.kill();
       return;
     }
-    if (exitCode !== null) {
+    const signalCode = (childProcess as { signalCode?: NodeJS.Signals | null }).signalCode;
+    if (exitCode !== null || (signalCode !== null && signalCode !== undefined)) {
       return;
     }
 

--- a/src/daemon/devicePool.ts
+++ b/src/daemon/devicePool.ts
@@ -1363,10 +1363,7 @@ export class DevicePool {
           await this.trackStartedDeviceProcess(ready, childProcess);
         } catch (error) {
           if (this.consumeIntentionalShutdown(recoveryDeviceIds)) {
-            intentionallyStopped = true;
-            if (readinessCompleted) {
-              await stopCancelledRecovery(ready);
-            }
+            await stopCancelledRecovery(readinessCompleted ? ready : undefined);
             return;
           }
           throw error;

--- a/test/daemon/devicePool.test.ts
+++ b/test/daemon/devicePool.test.ts
@@ -2157,6 +2157,54 @@ describe("DevicePool", () => {
       }
     });
 
+    test("does not re-terminate a recovery child that already exited by signal", async () => {
+      const originalRebootOnDeath = process.env.AUTOMOBILE_ANDROID_REBOOT_ON_DEATH;
+      process.env.AUTOMOBILE_ANDROID_REBOOT_ON_DEATH = "1";
+      fakeTimer.enableAutoAdvance();
+      const manager = new DeferredRecoveryDeviceManager();
+      manager.deviceImages = [
+        {
+          name: "Pixel 8",
+          platform: "android",
+          isRunning: false,
+          deviceId: "emulator-5554",
+          source: "local",
+        },
+      ];
+      devicePool = new DevicePool(
+        sessionManager,
+        "test-daemon-session-id",
+        fakeTimer,
+        fakeAppsRepo,
+        manager,
+        new DefaultRetryExecutor(fakeTimer),
+      );
+      try {
+        await devicePool.assignMultipleDevices(["session-1"], 1_000, "android");
+        await devicePool.releaseDevice("emulator-5554");
+
+        const recovery = devicePool.removeDisconnectedDevice("emulator-5554", false);
+        await manager.waitForRecoveryStart();
+        devicePool.markIntentionalShutdown("emulator-5554");
+        const recoveryChild = manager.childProcesses[1]!;
+        recoveryChild.exitCode = null;
+        recoveryChild.signalCode = "SIGTERM";
+        recoveryChild.emit("exit", null, "SIGTERM");
+        manager.releaseRecovery();
+
+        await expect(recovery).resolves.toBeUndefined();
+        expect(recoveryChild.killCount).toBe(0);
+        expect(devicePool.getDevice("emulator-5554")).toBeNull();
+      } finally {
+        manager.releaseRecovery();
+        if (originalRebootOnDeath === undefined) {
+          delete process.env.AUTOMOBILE_ANDROID_REBOOT_ON_DEATH;
+        } else {
+          process.env.AUTOMOBILE_ANDROID_REBOOT_ON_DEATH = originalRebootOnDeath;
+        }
+      }
+    });
+
     test("does not retry recovery when cancelling the owned child fails", async () => {
       const originalRebootOnDeath = process.env.AUTOMOBILE_ANDROID_REBOOT_ON_DEATH;
       process.env.AUTOMOBILE_ANDROID_REBOOT_ON_DEATH = "1";

--- a/test/daemon/devicePool.test.ts
+++ b/test/daemon/devicePool.test.ts
@@ -311,6 +311,16 @@ describe("DevicePool", () => {
     }
   }
 
+  class DeferredRecoveryDeviceManagerWithStubbornFailingReadiness extends DeferredRecoveryDeviceManagerWithStubbornChild {
+    override async waitForDeviceReady(device: DeviceInfo): Promise<BootedDevice> {
+      const ready = await super.waitForDeviceReady(device);
+      if (this.childProcesses.length === 2) {
+        throw new Error("recovery readiness rejected");
+      }
+      return ready;
+    }
+  }
+
   class DeferredLivenessRecoveryDeviceManager extends FakeDeviceManager {
     readonly childProcess = new FakeChildProcess();
     private readonly recoveryStartedPromise: Promise<void>;
@@ -2181,6 +2191,51 @@ describe("DevicePool", () => {
         await expect(recovery).rejects.toThrow("did not exit after SIGKILL");
         expect(manager.childProcesses).toHaveLength(2);
         expect(manager.recoveryChild.signals).toEqual(["SIGTERM", "SIGKILL"]);
+        expect(devicePool.getDevice("emulator-5554")).toBeNull();
+      } finally {
+        manager.releaseRecovery();
+        if (originalRebootOnDeath === undefined) {
+          delete process.env.AUTOMOBILE_ANDROID_REBOOT_ON_DEATH;
+        } else {
+          process.env.AUTOMOBILE_ANDROID_REBOOT_ON_DEATH = originalRebootOnDeath;
+        }
+      }
+    });
+
+    test("stops the owned child when cancellation coincides with readiness failure", async () => {
+      const originalRebootOnDeath = process.env.AUTOMOBILE_ANDROID_REBOOT_ON_DEATH;
+      process.env.AUTOMOBILE_ANDROID_REBOOT_ON_DEATH = "1";
+      fakeTimer.enableAutoAdvance();
+      const manager = new DeferredRecoveryDeviceManagerWithStubbornFailingReadiness();
+      manager.deviceImages = [
+        {
+          name: "Pixel 8",
+          platform: "android",
+          isRunning: false,
+          deviceId: "emulator-5554",
+          source: "local",
+        },
+      ];
+      devicePool = new DevicePool(
+        sessionManager,
+        "test-daemon-session-id",
+        fakeTimer,
+        fakeAppsRepo,
+        manager,
+        new DefaultRetryExecutor(fakeTimer),
+      );
+      try {
+        await devicePool.assignMultipleDevices(["session-1"], 1_000, "android");
+        await devicePool.releaseDevice("emulator-5554");
+
+        const recovery = devicePool.removeDisconnectedDevice("emulator-5554", false);
+        await manager.waitForRecoveryStart();
+        devicePool.markIntentionalShutdown("emulator-5554");
+        manager.releaseRecovery();
+
+        await expect(recovery).rejects.toThrow("did not exit after SIGKILL");
+        expect(manager.childProcesses).toHaveLength(2);
+        expect(manager.recoveryChild.signals).toEqual([undefined, "SIGTERM", "SIGKILL"]);
         expect(devicePool.getDevice("emulator-5554")).toBeNull();
       } finally {
         manager.releaseRecovery();


### PR DESCRIPTION
## Summary

Completes the Android recovery shutdown guarantee by running the robust owned-child stopper when an intentional shutdown coincides with readiness rejection. The follow-up fixes a late review finding on [PR #5325](https://github.com/kaeawc/auto-mobile/pull/5325), which merged [issue #5297](https://github.com/kaeawc/auto-mobile/issues/5297).

## Bug / Regression Context

- **Prior attempts:** [PR #5325](https://github.com/kaeawc/auto-mobile/pull/5325) handled cancellation after successful readiness and made termination failure terminal.
- **Observed symptom:** If readiness itself rejected after shutdown was marked, the readiness helper performed only one unchecked kill and recovery returned successfully, potentially leaving the owned emulator untracked.
- **Repro steps / conditions:** Start Android recovery, mark its serial intentionally shut down during deferred readiness, then make readiness reject while the owned child survives its initial kill.

## Validation

- [x] `bun test test/daemon/devicePool.test.ts` (94 passing)
- [x] `bun test test/utils/waitForDeviceReadyOrCancel.test.ts`
- [x] `bun run turbo:validate` (13,152 passed; 13 expected integration skips)
- [x] `bun run typecheck` reports no new errors (baseline gate)
- [x] New test uses the existing fake child-process and FakeTimer seams; no dependency added
- [x] Branched from current `origin/main` at [PR #5325](https://github.com/kaeawc/auto-mobile/pull/5325)'s merge commit
