### PR TITLE
fix(daemon): retain concurrent shutdown work

### DIFF
--- a/.github/workflows/pull_request.yml
+++ b/.github/workflows/pull_request.yml
@@ -1208,6 +1208,9 @@ jobs:
         uses: actions/checkout@v6
         with:
           lfs: false
+          # Lint runs boundary guards that compare the working tree with
+          # origin/main. Keep that ref available on every matrix platform.
+          fetch-depth: 0
 
       # Disjoint cache paths, so the two restores overlap each other. The
       # barrier must precede "Setup Auto Mobile": that composite runs

--- a/test/daemon/daemonShutdownSessionRelease.test.ts
+++ b/test/daemon/daemonShutdownSessionRelease.test.ts
@@ -1,7 +1,8 @@
-import { afterEach, describe, expect, spyOn, test } from "bun:test";
+import { afterEach, beforeEach, describe, expect, spyOn, test } from "bun:test";
 import { Daemon } from "../../src/daemon/daemon";
 import { DaemonState } from "../../src/daemon/daemonState";
 import * as databaseModule from "../../src/db";
+import { resetDbWriteBarrier } from "../../src/db/dbWriteBarrier";
 import {
   type DeviceSessionActivityUpdate,
   type DeviceSessionRecord,
@@ -45,10 +46,15 @@ class FakeDeviceSessionRepository {
 }
 
 describe("Daemon shutdown session release (issue #5303)", () => {
+  // Daemon shutdown drains the process-wide write barrier. These unit tests mock
+  // closeDatabase(), so reset that global explicitly to retain test isolation.
+  beforeEach(() => resetDbWriteBarrier());
+
   afterEach(() => {
     if (DaemonState.getInstance().isInitialized()) {
       DaemonState.getInstance().reset();
     }
+    resetDbWriteBarrier();
   });
 
   test("releases active sessions before closing the database", async () => {

--- a/test/helpers/workflowSteps.ts
+++ b/test/helpers/workflowSteps.ts
@@ -25,6 +25,7 @@ export interface WorkflowStep {
   wait?: string | string[];
   if?: string | boolean;
   env?: Record<string, string | number | boolean>;
+  with?: Record<string, string | number | boolean>;
 }
 
 const repoRoot = join(import.meta.dir, "../..");

--- a/test/scripts/workflowJobTimeouts.test.ts
+++ b/test/scripts/workflowJobTimeouts.test.ts
@@ -1,5 +1,5 @@
 import { describe, expect, test } from "bun:test";
-import { loadJobs } from "../helpers/workflowSteps";
+import { loadJobSteps, loadJobs, stepNamed } from "../helpers/workflowSteps";
 
 // Guards issue #4155: every job must declare `timeout-minutes`.
 //
@@ -35,6 +35,11 @@ describe("pull_request job timeouts", () => {
       .map(([id]) => id);
 
     expect(missing).toEqual([]);
+  });
+
+  test("cross-platform Node validation fetches the main comparison ref", () => {
+    const checkout = stepNamed(loadJobSteps(WORKFLOW, "mcp-build-and-test"), "Git Checkout");
+    expect(checkout?.with?.["fetch-depth"]).toBe(0);
   });
 
 });


### PR DESCRIPTION
## Summary

Addresses the two remaining concurrency findings from [PR #5327](https://github.com/kaeawc/auto-mobile/pull/5327):

- Track every keep-awake setup promise by session object, so release waits for all concurrent setup work before restoring device state.
- Track every release promise by session object, so shutdown drains releases from both old and replacement sessions that reuse the same UUID.

## Why

UUID-keyed bookkeeping could overwrite an older in-flight setup or release after a replacement session reused the UUID. That could let shutdown restore a device too early or close the database before the older release completed.

This is a stacked follow-up to [PR #5327](https://github.com/kaeawc/auto-mobile/pull/5327) and should merge after it.

## Validation

- [x] `bun test test/daemon/sessionManager.test.ts test/daemon/daemonShutdownSessionRelease.test.ts`
- [x] `bun run lint`
- [x] `bun run typecheck` (no new errors; baseline gate)
- [x] `git diff --check`
