### PR TITLE
fix(desktop): complete navigation test graph

### DIFF
--- a/android/desktop-core/src/test/kotlin/dev/jasonpearson/automobile/desktop/core/navigation/NavigationProvenanceUiTest.kt
+++ b/android/desktop-core/src/test/kotlin/dev/jasonpearson/automobile/desktop/core/navigation/NavigationProvenanceUiTest.kt
@@ -13,8 +13,11 @@ import androidx.compose.ui.test.runComposeUiTest
 import dev.jasonpearson.automobile.desktop.core.datasource.DefaultDataSourceFactory
 import dev.jasonpearson.automobile.desktop.core.di.AutoMobileGraphProvider
 import dev.jasonpearson.automobile.desktop.core.di.LocalAutoMobileGraph
+import dev.jasonpearson.automobile.desktop.core.platform.AppVersion
+import dev.jasonpearson.automobile.desktop.core.platform.AppVersionProvider
 import dev.jasonpearson.automobile.desktop.core.settings.FakeSettingsProvider
 import dev.jasonpearson.automobile.desktop.core.testing.FakeAutoMobileClient
+import dev.jasonpearson.automobile.desktop.core.update.FakeUpdateController
 import dev.jasonpearson.automobile.desktop.domain.NavigationGraph
 import org.junit.Test
 
@@ -36,6 +39,8 @@ class NavigationProvenanceUiTest {
       override val autoMobileClient = client
       override val settingsProvider = FakeSettingsProvider()
       override val dataSourceFactory = DefaultDataSourceFactory(client)
+      override val updateController = FakeUpdateController()
+      override val appVersionProvider = AppVersionProvider { AppVersion.Dev }
     }
   }
 


### PR DESCRIPTION
## What changed

Completes the `AutoMobileGraphProvider` fake in `NavigationProvenanceUiTest` with the existing fake update controller and development version provider.

## Why

The provider interface gained those dependencies, but this UI test fake was not updated. That caused the post-merge Detekt workflow to fail while compiling desktop-core tests.

## Validation

- `./gradlew :desktop-core:compileTestKotlin`
- `./gradlew detekt`
