### PR TITLE
fix(android): reject clean emulator startup exits

### DIFF
--- a/src/utils/android-cmdline-tools/AndroidEmulatorClient.ts
+++ b/src/utils/android-cmdline-tools/AndroidEmulatorClient.ts
@@ -1396,6 +1396,7 @@ export class AndroidEmulatorClient implements AndroidEmulator {
       let duplicateAvdDetected = false;
       let earlyExitCategory: LaunchFailureCategory | undefined;
       let startupValidationComplete = false;
+      let childTerminationObserved = false;
       let exitCode: number | null | undefined;
       let exitSignal: NodeJS.Signals | null | undefined;
       perf.startOperation("panicDetection");
@@ -1561,7 +1562,7 @@ export class AndroidEmulatorClient implements AndroidEmulator {
           output.includes("Detected GPU type")
         ) {
           // Emulator has started successfully, resolve with the child process
-          if (!startupValidationComplete) {
+          if (!childTerminationObserved && !startupValidationComplete) {
             startupValidationComplete = true;
             perf.endOperation("panicDetection");
             resolve(child);
@@ -1732,6 +1733,7 @@ export class AndroidEmulatorClient implements AndroidEmulator {
 
       child.on("exit", (code, signal) => {
         this.timer.clearTimeout(startupTimeout);
+        childTerminationObserved = true;
         exitCode = code;
         exitSignal = signal;
         if (code !== 0) {
@@ -1752,6 +1754,7 @@ export class AndroidEmulatorClient implements AndroidEmulator {
       child.on("close", (code, signal) => {
         this.timer.clearTimeout(startupTimeout);
         clearExitDrainTimeout();
+        childTerminationObserved = true;
         exitCode ??= code;
         exitSignal ??= signal;
         if (startupValidationComplete) {

--- a/src/utils/android-cmdline-tools/AndroidEmulatorClient.ts
+++ b/src/utils/android-cmdline-tools/AndroidEmulatorClient.ts
@@ -1680,7 +1680,11 @@ export class AndroidEmulatorClient implements AndroidEmulator {
 
           let category = earlyExitCategory ?? this.launchFailureCategory(finalizedOutput);
           let accelCheckOutput = "";
-          if (this.platform === "linux" && (!category || category === "kvm_permission_denied")) {
+          if (
+            completedExitCode !== 0 &&
+            this.platform === "linux" &&
+            (!category || category === "kvm_permission_denied")
+          ) {
             accelCheckOutput = await this.runAccelerationCheck();
             category = category ?? this.accelerationCheckCategory(accelCheckOutput);
           }
@@ -1732,16 +1736,16 @@ export class AndroidEmulatorClient implements AndroidEmulator {
         exitSignal = signal;
         if (code !== 0) {
           logger.error(`Emulator process exited with code: ${code}`);
-          if (!startupValidationComplete) {
-            exitDrainTimeout = this.timer.setTimeout(() => {
-              logger.debug(
-                `Emulator stdio did not close within ${EARLY_EXIT_DRAIN_TIMEOUT_MS}ms after an early exit`,
-              );
-              finalizeEarlyExit();
-            }, EARLY_EXIT_DRAIN_TIMEOUT_MS);
-          }
         } else {
           logger.info(`Emulator process exited with code: ${code}`);
+        }
+        if (!startupValidationComplete) {
+          exitDrainTimeout = this.timer.setTimeout(() => {
+            logger.debug(
+              `Emulator stdio did not close within ${EARLY_EXIT_DRAIN_TIMEOUT_MS}ms after an early exit`,
+            );
+            finalizeEarlyExit();
+          }, EARLY_EXIT_DRAIN_TIMEOUT_MS);
         }
       });
 
@@ -1750,7 +1754,7 @@ export class AndroidEmulatorClient implements AndroidEmulator {
         clearExitDrainTimeout();
         exitCode ??= code;
         exitSignal ??= signal;
-        if (exitCode === 0 || startupValidationComplete) {
+        if (startupValidationComplete) {
           return;
         }
         finalizeEarlyExit();

--- a/test/utils/android-cmdline-tools/AndroidEmulatorClient-launchDiagnostics.test.ts
+++ b/test/utils/android-cmdline-tools/AndroidEmulatorClient-launchDiagnostics.test.ts
@@ -280,13 +280,17 @@ describe("AndroidEmulatorClient launch diagnostics", () => {
     expect(error.message).toContain("Disk image is corrupt");
   });
 
-  test("does not run an acceleration check for a successful launch", async () => {
+  test("keeps a validated launch resolved after a later clean exit", async () => {
     const child = createChild();
     const { client, accelChecks } = createClient(child, () => {
       child.stdout!.emit("data", Buffer.from("Detected GPU type: host\n"));
     });
 
-    await expect(client.startEmulator(avdName)).resolves.toBe(child);
+    const launchedChild = await client.startEmulator(avdName);
+    child.emit("exit", 0, null);
+    child.emit("close", 0, null);
+
+    expect(launchedChild).toBe(child);
     expect(accelChecks()).toBe(0);
   });
 
@@ -331,6 +335,27 @@ describe("AndroidEmulatorClient launch diagnostics", () => {
     const error = await expectRejection(start);
 
     expect(error.message).toContain("exited with code: 1");
+  });
+
+  test("rejects promptly when the child exits cleanly before startup validation", async () => {
+    const child = createChild();
+    const { client, accelChecks, timer } = createClient(child, () => {
+      child.emit("exit", 0, null);
+      child.emit("close", 0, null);
+    });
+    let rejection: Error | undefined;
+    void client.startEmulator(avdName).catch((error) => {
+      rejection = error instanceof Error ? error : new Error(String(error));
+    });
+
+    for (let turn = 0; turn < 10 && !rejection; turn += 1) {
+      await new Promise<void>((resolve) => setImmediate(resolve));
+    }
+
+    expect(rejection?.message).toContain("exited with code: 0");
+    expect(rejection?.message).toContain(`AVD '${avdName}'`);
+    expect(accelChecks()).toBe(0);
+    expect(timer.getPendingTimeoutCount()).toBe(0);
   });
 
   test("bounds and redacts a generic early-exit diagnostic tail", async () => {

--- a/test/utils/android-cmdline-tools/AndroidEmulatorClient-launchDiagnostics.test.ts
+++ b/test/utils/android-cmdline-tools/AndroidEmulatorClient-launchDiagnostics.test.ts
@@ -358,6 +358,21 @@ describe("AndroidEmulatorClient launch diagnostics", () => {
     expect(timer.getPendingTimeoutCount()).toBe(0);
   });
 
+  test("rejects when a startup marker drains after child exit", async () => {
+    const child = createChild();
+    const { client, accelChecks } = createClient(child, () => {
+      child.emit("exit", 0, null);
+      child.stdout!.emit("data", Buffer.from("Detected GPU type: host\n"));
+      child.emit("close", 0, null);
+    });
+
+    const error = await expectRejection(client.startEmulator(avdName));
+
+    expect(error.message).toContain("exited with code: 0");
+    expect(error.message).toContain(`AVD '${avdName}'`);
+    expect(accelChecks()).toBe(0);
+  });
+
   test("bounds and redacts a generic early-exit diagnostic tail", async () => {
     const child = createChild();
     const home = homedir();


### PR DESCRIPTION
## Summary

Reject Android emulator processes that exit cleanly before startup validation. Clean early exits now use the existing actionable diagnostic path without an irrelevant acceleration probe, while validated launches remain unaffected by later clean exits.

## Linked Issue

Closes #5284

## Bug / Regression Context

- **Prior attempts:** [PR #5210](https://github.com/kaeawc/auto-mobile/pull/5210) added bounded early-exit diagnostics but retained a code-zero branch that cleared startup validation without settling it.
- **Observed symptom:** `exit(0)` followed by `close(0)` left `startEmulator` pending with its validation timeout already cleared.
- **Repro steps / conditions:** Spawn an emulator child, emit clean exit and close events before any startup-success marker, and observe that the launch promise never settles.

## Validation

- [x] `bun run turbo:validate` passes
- [x] `bun run typecheck` reports no new errors (baseline gate)
- [x] All Android emulator client tests pass
- [x] Regression tests use the injected child process and `FakeTimer`; each runs in under 1ms
- [x] No new helper or dependency
- [x] Rebased onto latest `main`, conflicts resolved

## Follow-ups

None.
