### PR TITLE
fix(daemon): escalate fallback child shutdown

### DIFF
--- a/src/daemon/DaemonLauncher.ts
+++ b/src/daemon/DaemonLauncher.ts
@@ -271,7 +271,7 @@ export class DaemonLauncher {
       return;
     }
 
-    this.signalProcessGroup(process, pid, "SIGTERM");
+    const signalledProcessGroup = this.signalProcessGroup(process, pid, "SIGTERM");
     let timeout: NodeJS.Timeout | undefined;
     const deadline = new Promise<void>(resolve => {
       timeout = this.timer.setTimeout(resolve, DAEMON_SHUTDOWN_TIMEOUT_MS);
@@ -292,6 +292,8 @@ export class DaemonLauncher {
       await deadline;
       if (this.isProcessGroupAlive(pid)) {
         this.signalProcessGroup(process, pid, "SIGKILL");
+      } else if (!signalledProcessGroup && process.exitCode === null) {
+        process.kill("SIGKILL");
       }
       await exitPromise;
     } finally {
@@ -315,9 +317,10 @@ export class DaemonLauncher {
     process: TrackedChildProcess,
     pid: number,
     signal: NodeJS.Signals,
-  ): void {
+  ): boolean {
     try {
       this.processGroupKiller(pid, signal);
+      return true;
     } catch (error) {
       // A vanished group has no descendants left to reap. Fall back to the
       // direct handle for unusual spawn implementations that do not create a
@@ -326,6 +329,7 @@ export class DaemonLauncher {
         `Daemon process-group signal failed for pid=${pid}; falling back to the direct child: ${error}`
       );
       process.kill(signal);
+      return false;
     }
   }
 }

--- a/test/daemon/DaemonLauncher.test.ts
+++ b/test/daemon/DaemonLauncher.test.ts
@@ -350,6 +350,40 @@ describe("DaemonLauncher", () => {
     expect(spawner.process.signals).toEqual([]);
   });
 
+  test("escalates the direct child when detached process-group signaling falls back", async () => {
+    const spawner = new FakeDaemonSpawner();
+    spawner.process.exitOnSignal = "SIGKILL";
+    const timer = new FakeTimer();
+    const processGroupSignals: Array<NodeJS.Signals | 0> = [];
+    const launcher = new DaemonLauncher({
+      spawn: spawner.spawn.bind(spawner),
+      timer,
+      platform: "linux",
+      processGroupKiller: (_pid, signal) => {
+        processGroupSignals.push(signal);
+        throw new Error("ESRCH");
+      },
+    });
+
+    const launch = launcher.launchAndWait({
+      command: "bunx",
+      args: ["-y", "@kaeawc/auto-mobile@1.2.3", "--daemon-mode"],
+      spawnOptions: { detached: true },
+      timeoutMs: 100,
+      waitForReady: async () => false,
+      formatFailure: async summary => new Error(summary),
+    });
+
+    await new Promise<void>(resolve => setImmediate(resolve));
+    expect(spawner.process.signals).toEqual(["SIGTERM"]);
+
+    timer.advanceTime(DAEMON_SHUTDOWN_TIMEOUT_MS);
+    await expect(launch).rejects.toThrow("Daemon failed to start within 100ms");
+
+    expect(processGroupSignals).toEqual(["SIGTERM", 0]);
+    expect(spawner.process.signals).toEqual(["SIGTERM", "SIGKILL"]);
+  });
+
   test("keeps a launched child that becomes ready at the readiness deadline", async () => {
     const spawner = new FakeDaemonSpawner();
     const launcher = new DaemonLauncher({ spawn: spawner.spawn.bind(spawner) });


### PR DESCRIPTION
## Summary

- preserve whether detached POSIX process-group signalling fell back to the direct child
- send SIGKILL to that direct child after the shutdown grace when the group never existed
- add deterministic FakeTimer coverage for the fallback escalation path

## Root cause

The prior process-group cleanup correctly fell back to SIGTERM on the direct child, but a missing process group caused the later liveness probe to suppress SIGKILL. A child that ignored SIGTERM could then hold startup cleanup indefinitely.

## Validation

- `bun test test/daemon/DaemonLauncher.test.ts test/daemon/daemonManagerReadiness.test.ts`
- `bun run lint`
- `bun run typecheck`
- `bun run check:daemon-launcher-boundary`
