### PR TITLE
fix(device-pool): roll back partial multi-device allocations

### DIFF
--- a/src/daemon/devicePool.ts
+++ b/src/daemon/devicePool.ts
@@ -813,10 +813,7 @@ export class DevicePool {
     );
 
     if (!result.success) {
-      // Release any devices we've assigned so far
-      for (const [sessionId, deviceId] of assignments) {
-        await this.releaseDevice(deviceId, sessionId);
-      }
+      await this.rollbackAssignments(assignments);
 
       // Check if it was a non-retryable error
       if (result.error instanceof DevicePoolError && !result.error.isRetryable) {
@@ -924,9 +921,7 @@ export class DevicePool {
       const elapsed = this.timer.now() - startTime;
 
       if (elapsed > timeoutMs) {
-        for (const [sessionId, deviceId] of assignments) {
-          await this.releaseDevice(deviceId, sessionId);
-        }
+        await this.rollbackAssignments(assignments);
         throw new ActionableError(
           `Timed out allocating devices after ${Math.round(elapsed / 1000)}s (${attemptCount} attempts).\n` +
             `Required: ${requiredCount} devices, allocated: ${assignments.size}\n` +
@@ -954,16 +949,12 @@ export class DevicePool {
               `(${assignments.size}/${requiredCount})`,
           );
         } else if (result.livenessUnknown) {
-          for (const [sessionId, deviceId] of assignments) {
-            await this.releaseDevice(deviceId, sessionId);
-          }
+          await this.rollbackAssignments(assignments);
           throw new ActionableError(
             `Unable to verify iOS simulator liveness for session ${request.sessionId}; iOS discovery failed.`,
           );
         } else if (!result.shouldWait) {
-          for (const [sessionId, deviceId] of assignments) {
-            await this.releaseDevice(deviceId, sessionId);
-          }
+          await this.rollbackAssignments(assignments);
           const summary = this.criteriaMatcher.formatCriteriaSummary(request.criteria);
           throw new ActionableError(
             `Failed to allocate device for session ${request.sessionId}${summary}.\n` +
@@ -2011,6 +2002,43 @@ export class DevicePool {
   }
 
   /**
+   * Undo the completed portion of a failed multi-device allocation.
+   *
+   * The mutex keeps a new allocation from taking ownership between releasing
+   * the session and returning its device to the idle pool. The optional owner
+   * check in releaseDevice also protects this cleanup from any concurrent
+   * external release that has already reassigned the device.
+   */
+  private async rollbackAssignments(assignments: ReadonlyMap<string, string>): Promise<void> {
+    await this.assignmentMutex.runExclusive(async () => {
+      for (const [sessionId, deviceId] of assignments) {
+        const device = this.devices.get(deviceId);
+        if (!device || device.sessionId !== sessionId) {
+          logger.warn(
+            `[DevicePool] Skipping allocation rollback for ${sessionId}: ` +
+              `device ${deviceId} is no longer owned by that session`,
+          );
+          continue;
+        }
+
+        const session = this.sessionManager.getSession(sessionId);
+        if (session && session.assignedDevice !== deviceId) {
+          logger.warn(
+            `[DevicePool] Skipping allocation rollback for ${sessionId}: ` +
+              `session is now assigned to ${session.assignedDevice}, not ${deviceId}`,
+          );
+          continue;
+        }
+
+        if (session) {
+          await this.sessionManager.releaseSession(sessionId, "allocation-rollback");
+        }
+        await this.releaseDevice(deviceId, sessionId);
+      }
+    });
+  }
+
+  /**
    * Release device from session
    *
    * Called when a session completes or times out.
@@ -2020,6 +2048,14 @@ export class DevicePool {
     const device = this.devices.get(deviceId);
     if (!device) {
       logger.warn(`Cannot release device ${deviceId}: not in pool`);
+      return;
+    }
+
+    if (expectedSessionId !== undefined && device.sessionId !== expectedSessionId) {
+      logger.warn(
+        `Cannot release device ${deviceId}: expected session ${expectedSessionId}, ` +
+          `but it is owned by ${device.sessionId ?? "no session"}`,
+      );
       return;
     }
 

--- a/src/daemon/devicePool.ts
+++ b/src/daemon/devicePool.ts
@@ -2024,9 +2024,10 @@ export class DevicePool {
         const session = this.sessionManager.getSession(sessionId);
         if (session && session.assignedDevice !== deviceId) {
           logger.warn(
-            `[DevicePool] Skipping allocation rollback for ${sessionId}: ` +
-              `session is now assigned to ${session.assignedDevice}, not ${deviceId}`,
+            `[DevicePool] Preserving session ${sessionId} on ${session.assignedDevice} ` +
+              `while releasing stale allocation of ${deviceId}`,
           );
+          await this.releaseDevice(deviceId, sessionId);
           continue;
         }
 

--- a/src/daemon/devicePool.ts
+++ b/src/daemon/devicePool.ts
@@ -1,7 +1,7 @@
 import type { ChildProcess } from "child_process";
 import { randomUUID } from "node:crypto";
 import { logger } from "../utils/logger";
-import { SessionManager } from "./sessionManager";
+import { SessionManager, type Session } from "./sessionManager";
 import { ActionableError, BootedDevice, DeviceInfo, Platform } from "../models";
 import { Mutex } from "async-mutex";
 import {
@@ -93,6 +93,11 @@ export interface PooledDevice {
    * shutdown-marker same-serial-reuse race, follow-up to PR #5015).
    */
   incarnation: number;
+}
+
+interface RollbackAssignment {
+  deviceId: string;
+  session: Session;
 }
 
 interface IosLivenessSnapshot {
@@ -700,6 +705,7 @@ export class DevicePool {
   ): Promise<Map<string, string>> {
     const startTime = this.timer.now();
     const assignments = new Map<string, string>();
+    const assignmentsToRollback = new Map<string, RollbackAssignment>();
     const requiredCount = sessionIds.length;
 
     logger.info(
@@ -763,6 +769,12 @@ export class DevicePool {
           if (assignResult.success) {
             assigned.add(sessionId);
             assignments.set(sessionId, assignResult.deviceId!);
+            if (assignResult.session) {
+              assignmentsToRollback.set(sessionId, {
+                deviceId: assignResult.deviceId!,
+                session: assignResult.session,
+              });
+            }
             logger.info(
               `[DevicePool] Allocated device ${assignResult.deviceId} to session ${sessionId} ` +
                 `(${assigned.size}/${requiredCount})`,
@@ -813,7 +825,7 @@ export class DevicePool {
     );
 
     if (!result.success) {
-      await this.rollbackAssignments(assignments);
+      await this.rollbackAssignments(assignmentsToRollback);
 
       // Check if it was a non-retryable error
       if (result.error instanceof DevicePoolError && !result.error.isRetryable) {
@@ -861,6 +873,7 @@ export class DevicePool {
   ): Promise<Map<string, string>> {
     const startTime = this.timer.now();
     const assignments = new Map<string, string>();
+    const assignmentsToRollback = new Map<string, RollbackAssignment>();
     const requiredCount = requests.length;
 
     if (requiredCount === 0) {
@@ -921,7 +934,7 @@ export class DevicePool {
       const elapsed = this.timer.now() - startTime;
 
       if (elapsed > timeoutMs) {
-        await this.rollbackAssignments(assignments);
+        await this.rollbackAssignments(assignmentsToRollback);
         throw new ActionableError(
           `Timed out allocating devices after ${Math.round(elapsed / 1000)}s (${attemptCount} attempts).\n` +
             `Required: ${requiredCount} devices, allocated: ${assignments.size}\n` +
@@ -943,18 +956,24 @@ export class DevicePool {
 
         if (result.success) {
           assignments.set(request.sessionId, result.deviceId!);
+          if (result.session) {
+            assignmentsToRollback.set(request.sessionId, {
+              deviceId: result.deviceId!,
+              session: result.session,
+            });
+          }
           assignedThisRound++;
           logger.info(
             `[DevicePool] Allocated device ${result.deviceId} to session ${request.sessionId} ` +
               `(${assignments.size}/${requiredCount})`,
           );
         } else if (result.livenessUnknown) {
-          await this.rollbackAssignments(assignments);
+          await this.rollbackAssignments(assignmentsToRollback);
           throw new ActionableError(
             `Unable to verify iOS simulator liveness for session ${request.sessionId}; iOS discovery failed.`,
           );
         } else if (!result.shouldWait) {
-          await this.rollbackAssignments(assignments);
+          await this.rollbackAssignments(assignmentsToRollback);
           const summary = this.criteriaMatcher.formatCriteriaSummary(request.criteria);
           throw new ActionableError(
             `Failed to allocate device for session ${request.sessionId}${summary}.\n` +
@@ -1684,6 +1703,7 @@ export class DevicePool {
   ): Promise<{
     success: boolean;
     deviceId?: string;
+    session?: Session;
     shouldWait: boolean;
     totalDevices: number;
     livenessUnknown?: boolean;
@@ -1702,6 +1722,7 @@ export class DevicePool {
   ): Promise<{
     success: boolean;
     deviceId?: string;
+    session?: Session;
     shouldWait: boolean;
     totalDevices: number;
     livenessUnknown?: boolean;
@@ -1733,6 +1754,7 @@ export class DevicePool {
   ): Promise<{
     success: boolean;
     deviceId?: string;
+    session?: Session;
     shouldWait: boolean;
     totalDevices: number;
     livenessUnknown?: boolean;
@@ -1792,13 +1814,14 @@ export class DevicePool {
         };
       }
 
-      const assignedDeviceId = await this.claimSelectedDeviceForSession(sessionId, device);
+      const assignment = await this.claimSelectedDeviceForSession(sessionId, device);
 
       logger.info(`Assigned device ${device.id} to session ${sessionId}`);
 
       return {
         success: true,
-        deviceId: assignedDeviceId,
+        deviceId: assignment.deviceId,
+        session: assignment.session,
         shouldWait: false,
         totalDevices,
       };
@@ -1853,16 +1876,17 @@ export class DevicePool {
   private async claimSelectedDeviceForSession(
     sessionId: string,
     device: PooledDevice,
-  ): Promise<string> {
+  ): Promise<{ deviceId: string; session?: Session }> {
     // Create the session before claiming the device. A direct binding can
     // create the same session while this allocator waits for the mutex; in
     // that case, its device remains the sole owner.
+    const existingSession = this.sessionManager.getSession(sessionId);
     const session = await this.sessionManager.createSession(sessionId, device.id, device.platform);
     if (session.assignedDevice !== device.id) {
       logger.info(
         `Reusing session ${sessionId} already assigned to device ${session.assignedDevice}`,
       );
-      return session.assignedDevice;
+      return { deviceId: session.assignedDevice };
     }
 
     device.sessionId = sessionId;
@@ -1870,7 +1894,7 @@ export class DevicePool {
     device.lastUsedAt = this.nextLastUsedAt();
     device.assignmentCount++;
     device.errorCount = 0;
-    return device.id;
+    return existingSession === session ? { deviceId: device.id } : { deviceId: device.id, session };
   }
 
   private selectIdleDevice(candidates: PooledDevice[]): PooledDevice | undefined {
@@ -2005,13 +2029,14 @@ export class DevicePool {
    * Undo the completed portion of a failed multi-device allocation.
    *
    * The mutex keeps a new allocation from taking ownership between releasing
-   * the session and returning its device to the idle pool. The optional owner
-   * check in releaseDevice also protects this cleanup from any concurrent
-   * external release that has already reassigned the device.
+   * the session and returning its device to the idle pool. The recorded Session
+   * object prevents a reused UUID from making this rollback release a replacement
+   * allocation.
    */
-  private async rollbackAssignments(assignments: ReadonlyMap<string, string>): Promise<void> {
+  private async rollbackAssignments(assignments: ReadonlyMap<string, RollbackAssignment>): Promise<void> {
     await this.assignmentMutex.runExclusive(async () => {
-      for (const [sessionId, deviceId] of assignments) {
+      for (const [sessionId, allocation] of assignments) {
+        const { deviceId, session: allocatedSession } = allocation;
         const device = this.devices.get(deviceId);
         if (!device || device.sessionId !== sessionId) {
           logger.warn(
@@ -2021,18 +2046,39 @@ export class DevicePool {
           continue;
         }
 
-        const session = this.sessionManager.getSession(sessionId);
-        if (session && session.assignedDevice !== deviceId) {
+        const currentSession = this.sessionManager.getSession(sessionId);
+        if (currentSession !== allocatedSession) {
+          if (currentSession?.assignedDevice === deviceId) {
+            logger.warn(
+              `[DevicePool] Preserving replacement session ${sessionId} on ${deviceId} ` +
+                `during allocation rollback`,
+            );
+            continue;
+          }
           logger.warn(
-            `[DevicePool] Preserving session ${sessionId} on ${session.assignedDevice} ` +
+            `[DevicePool] Releasing stale allocation of ${deviceId} for replaced session ${sessionId}`,
+          );
+          await this.releaseDevice(deviceId, sessionId);
+          continue;
+        }
+
+        if (allocatedSession.assignedDevice !== deviceId) {
+          logger.warn(
+            `[DevicePool] Preserving session ${sessionId} on ${allocatedSession.assignedDevice} ` +
               `while releasing stale allocation of ${deviceId}`,
           );
           await this.releaseDevice(deviceId, sessionId);
           continue;
         }
 
-        if (session) {
-          await this.sessionManager.releaseSession(sessionId, "allocation-rollback");
+        await this.sessionManager.releaseSession(sessionId, "allocation-rollback");
+        const replacementSession = this.sessionManager.getSession(sessionId);
+        if (replacementSession?.assignedDevice === deviceId) {
+          logger.warn(
+            `[DevicePool] Preserving replacement session ${sessionId} on ${deviceId} ` +
+              `during allocation rollback`,
+          );
+          continue;
         }
         await this.releaseDevice(deviceId, sessionId);
       }

--- a/test/daemon/devicePool.test.ts
+++ b/test/daemon/devicePool.test.ts
@@ -56,6 +56,31 @@ describe("DevicePool", () => {
     await devicePool.initializeWithDevices(devices);
   };
 
+  const failIosLivenessAfterFirstSession = (): void => {
+    const createSession = sessionManager.createSession.bind(sessionManager);
+    let sessionCreates = 0;
+    sessionManager.createSession = async (
+      sessionId,
+      deviceId,
+      platform,
+      timeoutMs,
+      heartbeatTimeoutMs,
+    ) => {
+      const session = await createSession(
+        sessionId,
+        deviceId,
+        platform,
+        timeoutMs,
+        heartbeatTimeoutMs,
+      );
+      sessionCreates++;
+      if (sessionCreates === 1) {
+        fakeDeviceManager.failedPlatforms.add("ios");
+      }
+      return session;
+    };
+  };
+
   class FakeDeviceManagerWithMinimalReadyDevice extends FakeDeviceManager {
     async waitForDeviceReady(device: DeviceInfo): Promise<BootedDevice> {
       const id = device.deviceId ?? device.name;
@@ -1700,6 +1725,48 @@ describe("DevicePool", () => {
   });
 
   describe("assignMultipleDevices", () => {
+    test("rolls back sessions and devices when platform allocation loses iOS liveness after a partial assignment", async () => {
+      await initializeLiveDevices([
+        createBootedDevice("sim-1", "ios", "iPhone 15"),
+        createBootedDevice("sim-2", "ios", "iPhone 16"),
+      ]);
+
+      failIosLivenessAfterFirstSession();
+
+      await expect(
+        devicePool.assignMultipleDevices(["session-a", "session-b"], 1000, "ios"),
+      ).rejects.toThrow(/Unable to verify iOS simulator liveness/);
+
+      expect(sessionManager.getSession("session-a")).toBeNull();
+      expect(sessionManager.getSession("session-b")).toBeNull();
+      expect(devicePool.getDevice("sim-1")).toMatchObject({ sessionId: null, status: "idle" });
+      expect(devicePool.getDevice("sim-2")).toMatchObject({ sessionId: null, status: "idle" });
+    });
+
+    test("rolls back sessions and devices when criteria allocation loses iOS liveness after a partial assignment", async () => {
+      await initializeLiveDevices([
+        createBootedDevice("sim-1", "ios", "iPhone 15"),
+        createBootedDevice("sim-2", "ios", "iPhone 16"),
+      ]);
+
+      failIosLivenessAfterFirstSession();
+
+      await expect(
+        devicePool.assignMultipleDevicesByCriteria(
+          [
+            { sessionId: "session-a", criteria: { platform: "ios" } },
+            { sessionId: "session-b", criteria: { platform: "ios" } },
+          ],
+          1000,
+        ),
+      ).rejects.toThrow(/Unable to verify iOS simulator liveness/);
+
+      expect(sessionManager.getSession("session-a")).toBeNull();
+      expect(sessionManager.getSession("session-b")).toBeNull();
+      expect(devicePool.getDevice("sim-1")).toMatchObject({ sessionId: null, status: "idle" });
+      expect(devicePool.getDevice("sim-2")).toMatchObject({ sessionId: null, status: "idle" });
+    });
+
     test("evicts a started emulator when its process exits after readiness", async () => {
       const images: DeviceInfo[] = [
         {
@@ -3173,6 +3240,23 @@ describe("DevicePool", () => {
   });
 
   describe("releaseDevice", () => {
+    test("does not release a replacement allocation when an expected session no longer owns the device", async () => {
+      await initializeLiveDevices([createBootedDevice("emulator-5554")]);
+      const deviceId = await devicePool.assignDeviceToSession("session-a");
+
+      await sessionManager.releaseSession("session-a");
+      await devicePool.releaseDevice(deviceId);
+      await devicePool.assignDeviceToSession("session-b");
+
+      await devicePool.releaseDevice(deviceId, "session-a");
+
+      expect(sessionManager.getSession("session-b")?.assignedDevice).toBe(deviceId);
+      expect(devicePool.getDevice(deviceId)).toMatchObject({
+        sessionId: "session-b",
+        status: "busy",
+      });
+    });
+
     test("should release device assigned to session", async () => {
       await initializeLiveDevices([createBootedDevice("emulator-5554")]);
       const deviceId = await devicePool.assignDeviceToSession("session-1");

--- a/test/daemon/devicePool.test.ts
+++ b/test/daemon/devicePool.test.ts
@@ -3344,7 +3344,7 @@ describe("DevicePool", () => {
       const deviceId = await devicePool.assignDeviceToSession("session-a");
 
       await sessionManager.releaseSession("session-a");
-      await devicePool.releaseDevice(deviceId);
+      await devicePool.releaseDevice(deviceId, "session-a");
       await devicePool.assignDeviceToSession("session-b");
 
       await devicePool.releaseDevice(deviceId, "session-a");

--- a/test/daemon/devicePool.test.ts
+++ b/test/daemon/devicePool.test.ts
@@ -1747,6 +1747,25 @@ describe("DevicePool", () => {
       expect(devicePool.getDevice("sim-2")).toMatchObject({ sessionId: null, status: "idle" });
     });
 
+    test("releases a partial device claim when the session was already bound elsewhere", async () => {
+      await initializeLiveDevices([
+        createBootedDevice("sim-1", "ios", "iPhone 15"),
+        createBootedDevice("sim-2", "ios", "iPhone 16"),
+      ]);
+      await sessionManager.createSession("session-a", "existing-device", "ios");
+      failIosLivenessAfterFirstSession();
+
+      await expect(
+        devicePool.assignMultipleDevices(["session-a", "session-b"], 1000, "ios"),
+      ).rejects.toThrow(/Unable to verify iOS simulator liveness/);
+
+      expect(sessionManager.getSession("session-a")).toMatchObject({
+        assignedDevice: "existing-device",
+      });
+      expect(devicePool.getDevice("sim-1")).toMatchObject({ sessionId: null, status: "idle" });
+      expect(devicePool.getDevice("sim-2")).toMatchObject({ sessionId: null, status: "idle" });
+    });
+
     test("rolls back sessions and devices when criteria allocation loses iOS liveness after a partial assignment", async () => {
       await initializeLiveDevices([
         createBootedDevice("sim-1", "ios", "iPhone 15"),

--- a/test/daemon/devicePool.test.ts
+++ b/test/daemon/devicePool.test.ts
@@ -56,7 +56,7 @@ describe("DevicePool", () => {
     await devicePool.initializeWithDevices(devices);
   };
 
-  const failIosLivenessAfterFirstSession = (): void => {
+  const configureAfterFirstSession = (configure: () => void): void => {
     const createSession = sessionManager.createSession.bind(sessionManager);
     let sessionCreates = 0;
     sessionManager.createSession = async (
@@ -75,10 +75,14 @@ describe("DevicePool", () => {
       );
       sessionCreates++;
       if (sessionCreates === 1) {
-        fakeDeviceManager.failedPlatforms.add("ios");
+        configure();
       }
       return session;
     };
+  };
+
+  const failIosLivenessAfterFirstSession = (): void => {
+    configureAfterFirstSession(() => fakeDeviceManager.failedPlatforms.add("ios"));
   };
 
   class FakeDeviceManagerWithMinimalReadyDevice extends FakeDeviceManager {
@@ -1765,6 +1769,82 @@ describe("DevicePool", () => {
       expect(sessionManager.getSession("session-b")).toBeNull();
       expect(devicePool.getDevice("sim-1")).toMatchObject({ sessionId: null, status: "idle" });
       expect(devicePool.getDevice("sim-2")).toMatchObject({ sessionId: null, status: "idle" });
+    });
+
+    test("rolls back the completed assignment when platform allocation exhausts retries", async () => {
+      await initializeLiveDevices([
+        createBootedDevice("device-a"),
+        createBootedDevice("device-b"),
+      ]);
+      configureAfterFirstSession(() => {
+        const unavailable = devicePool.getDevice("device-b");
+        if (!unavailable) {
+          throw new Error("expected second pooled device");
+        }
+        unavailable.status = "busy";
+      });
+
+      await expect(
+        devicePool.assignMultipleDevices(["session-a", "session-b"], 1000, "android"),
+      ).rejects.toThrow(/Timed out allocating devices/);
+
+      expect(sessionManager.getSession("session-a")).toBeNull();
+      expect(devicePool.getDevice("device-a")).toMatchObject({ sessionId: null, status: "idle" });
+    });
+
+    test("rolls back the completed assignment when criteria allocation times out", async () => {
+      await initializeLiveDevices([
+        createBootedDevice("device-a"),
+        createBootedDevice("device-b"),
+      ]);
+      configureAfterFirstSession(() => {
+        const unavailable = devicePool.getDevice("device-b");
+        if (!unavailable) {
+          throw new Error("expected second pooled device");
+        }
+        unavailable.status = "busy";
+        fakeTimer.advanceTime(1001);
+      });
+
+      await expect(
+        devicePool.assignMultipleDevicesByCriteria(
+          [
+            { sessionId: "session-a", criteria: { platform: "android" } },
+            { sessionId: "session-b", criteria: { platform: "android" } },
+          ],
+          1000,
+        ),
+      ).rejects.toThrow(/Timed out allocating devices/);
+
+      expect(sessionManager.getSession("session-a")).toBeNull();
+      expect(devicePool.getDevice("device-a")).toMatchObject({ sessionId: null, status: "idle" });
+    });
+
+    test("rolls back the completed assignment when criteria allocation becomes non-retryable", async () => {
+      await initializeLiveDevices([
+        createBootedDevice("device-a"),
+        createBootedDevice("device-b", "ios", "iPhone 16"),
+      ]);
+      configureAfterFirstSession(() => {
+        const unavailable = devicePool.getDevice("device-b");
+        if (!unavailable) {
+          throw new Error("expected second pooled device");
+        }
+        unavailable.status = "error";
+      });
+
+      await expect(
+        devicePool.assignMultipleDevicesByCriteria(
+          [
+            { sessionId: "session-a", criteria: { platform: "android" } },
+            { sessionId: "session-b", criteria: { platform: "ios" } },
+          ],
+          1000,
+        ),
+      ).rejects.toThrow(/Failed to allocate device for session session-b/);
+
+      expect(sessionManager.getSession("session-a")).toBeNull();
+      expect(devicePool.getDevice("device-a")).toMatchObject({ sessionId: null, status: "idle" });
     });
 
     test("evicts a started emulator when its process exits after readiness", async () => {

--- a/test/daemon/devicePool.test.ts
+++ b/test/daemon/devicePool.test.ts
@@ -1766,6 +1766,46 @@ describe("DevicePool", () => {
       expect(devicePool.getDevice("sim-2")).toMatchObject({ sessionId: null, status: "idle" });
     });
 
+    test("preserves a replacement session that reuses a UUID during rollback", async () => {
+      await initializeLiveDevices([
+        createBootedDevice("sim-1", "ios", "iPhone 15"),
+        createBootedDevice("sim-2", "ios", "iPhone 16"),
+      ]);
+      const createSession = sessionManager.createSession.bind(sessionManager);
+      const releaseSession = sessionManager.releaseSession.bind(sessionManager);
+      let sessionCreates = 0;
+      sessionManager.createSession = async (
+        sessionId,
+        deviceId,
+        platform,
+        timeoutMs,
+        heartbeatTimeoutMs,
+      ) => {
+        const session = await createSession(
+          sessionId,
+          deviceId,
+          platform,
+          timeoutMs,
+          heartbeatTimeoutMs,
+        );
+        sessionCreates++;
+        if (sessionCreates === 1) {
+          await releaseSession(sessionId);
+          await createSession(sessionId, deviceId, platform, timeoutMs, heartbeatTimeoutMs);
+          fakeDeviceManager.failedPlatforms.add("ios");
+        }
+        return session;
+      };
+
+      await expect(
+        devicePool.assignMultipleDevices(["session-a", "session-b"], 1000, "ios"),
+      ).rejects.toThrow(/Unable to verify iOS simulator liveness/);
+
+      expect(sessionManager.getSession("session-a")).toMatchObject({ assignedDevice: "sim-1" });
+      expect(devicePool.getDevice("sim-1")).toMatchObject({ sessionId: "session-a", status: "busy" });
+      expect(devicePool.getDevice("sim-2")).toMatchObject({ sessionId: null, status: "idle" });
+    });
+
     test("rolls back sessions and devices when criteria allocation loses iOS liveness after a partial assignment", async () => {
       await initializeLiveDevices([
         createBootedDevice("sim-1", "ios", "iPhone 15"),


### PR DESCRIPTION
## Summary

- Roll back both session records and device assignments after a partial multi-device allocation fails.
- Apply the same owner-checked rollback to platform and criteria-based allocation paths.
- Add regression coverage for liveness failure after an early assignment and stale cleanup after device reassignment.

## Root cause

Partial allocation failure returned devices to the pool without removing the sessions already created for successful assignments.

## Validation

- `bun test test/daemon/devicePool.test.ts`
- `bun run lint`
- `bun run typecheck`
- `bun run turbo:validate`

Closes #5289
