### PR TITLE
fix(daemon): release pooled devices on session expiry

### DIFF
--- a/src/daemon/devicePool.ts
+++ b/src/daemon/devicePool.ts
@@ -3022,7 +3022,8 @@ export class DevicePool {
    *
    * Invoked via the SessionManager expiry callback. Only acts when the device
    * is still owned by the released session, so a stale callback cannot free a
-   * replacement owner. Autolock-specific state is cleared when applicable.
+   * replacement owner. Autolock-specific state is cleared when the device is
+   * actually returned to idle.
    */
   private releaseExpiredSessionDevice(sessionId: string, deviceId: string): void {
     const device = this.devices.get(deviceId);
@@ -3030,13 +3031,27 @@ export class DevicePool {
       return;
     }
 
-    if (device.autolockSessionId === sessionId) {
-      device.autolockSessionId = undefined;
-      this.clearMcpAutolockMappings(sessionId);
-    }
-    void this.releaseDevice(deviceId, sessionId).then(() => {
+    const cleanup = this.sessionManager.getPendingDeviceCleanup(deviceId);
+    const release = this.releaseDevice(deviceId, sessionId);
+    void release.then(() => {
+      if (!cleanup) {
+        this.clearExpiredAutolockStateWhenIdle(sessionId, deviceId);
+      }
       logger.info(`Released device ${deviceId} from session ${sessionId}`);
     });
+    if (cleanup) {
+      void cleanup.then(() => this.clearExpiredAutolockStateWhenIdle(sessionId, deviceId));
+    }
+  }
+
+  private clearExpiredAutolockStateWhenIdle(sessionId: string, deviceId: string): void {
+    const device = this.devices.get(deviceId);
+    if (!device || device.sessionId !== null || device.autolockSessionId !== sessionId) {
+      return;
+    }
+
+    device.autolockSessionId = undefined;
+    this.clearMcpAutolockMappings(sessionId);
   }
 
   /** Clear autolock-only state for an explicit release without freeing early. */

--- a/src/daemon/devicePool.ts
+++ b/src/daemon/devicePool.ts
@@ -249,9 +249,15 @@ export class DevicePool {
         await this.sessionManager.releaseSession(sessionId, releaseReason);
       });
 
-    // Free autolocked devices when their session expires (idle timeout auto-release).
-    this.sessionManager.onSessionRelease((sessionId, deviceId) => {
-      this.releaseAutolockedDevice(sessionId, deviceId);
+    // Expiry has no caller available to return the device to the pool. Explicit
+    // release callers retain their ordered cleanup and release flow, while
+    // autolock metadata is still removed when their session ends.
+    this.sessionManager.onSessionRelease((sessionId, deviceId, releaseReason) => {
+      if (releaseReason === "lazy-expiry" || releaseReason === "cleanup-expired") {
+        this.releaseExpiredSessionDevice(sessionId, deviceId);
+      } else {
+        this.clearReleasedAutolockState(sessionId, deviceId);
+      }
     });
   }
 
@@ -3012,13 +3018,29 @@ export class DevicePool {
   }
 
   /**
-   * Free a device whose autolock session has been released or has expired.
+   * Free a device whose current session has expired.
    *
-   * Invoked via the SessionManager release callback. Only acts on devices that
-   * were locked by the released session, so non-autolock sessions and devices
-   * that have since been re-locked by a different session are left untouched.
+   * Invoked via the SessionManager expiry callback. Only acts when the device
+   * is still owned by the released session, so a stale callback cannot free a
+   * replacement owner. Autolock-specific state is cleared when applicable.
    */
-  private releaseAutolockedDevice(sessionId: string, deviceId: string): void {
+  private releaseExpiredSessionDevice(sessionId: string, deviceId: string): void {
+    const device = this.devices.get(deviceId);
+    if (!device || device.sessionId !== sessionId) {
+      return;
+    }
+
+    if (device.autolockSessionId === sessionId) {
+      device.autolockSessionId = undefined;
+      this.clearMcpAutolockMappings(sessionId);
+    }
+    void this.releaseDevice(deviceId, sessionId).then(() => {
+      logger.info(`Released device ${deviceId} from session ${sessionId}`);
+    });
+  }
+
+  /** Clear autolock-only state for an explicit release without freeing early. */
+  private clearReleasedAutolockState(sessionId: string, deviceId: string): void {
     const device = this.devices.get(deviceId);
     if (!device || device.autolockSessionId !== sessionId) {
       return;
@@ -3026,9 +3048,6 @@ export class DevicePool {
 
     device.autolockSessionId = undefined;
     this.clearMcpAutolockMappings(sessionId);
-    void this.releaseDevice(deviceId, sessionId).then(() => {
-      logger.info(`Autolock idle timeout: released device ${deviceId} from session ${sessionId}`);
-    });
   }
 
   private clearMcpAutolockMappings(sessionId: string): void {

--- a/src/daemon/sessionManager.ts
+++ b/src/daemon/sessionManager.ts
@@ -728,7 +728,10 @@ export class SessionManager {
       if (pendingCleanup.length > 0) {this.trackPendingDeviceCleanup(deviceId, pendingCleanup);}
 
       try {
-        await this.deviceSessionRepository.markReleased(sessionId, "released", this.timer.now(), releaseReason);
+        const terminalStatus = releaseReason === "lazy-expiry" || releaseReason === "cleanup-expired"
+          ? "expired"
+          : "released";
+        await this.deviceSessionRepository.markReleased(sessionId, terminalStatus, this.timer.now(), releaseReason);
       } catch (error) {
         logger.warn(`[SessionManager] Failed to mark session released (${releaseReason}): ${error}`);
       }

--- a/src/daemon/sessionManager.ts
+++ b/src/daemon/sessionManager.ts
@@ -383,7 +383,8 @@ export class SessionManager {
     }
 
     const inFlightRelease = this.releasePromises.get(sessionId);
-    if (inFlightRelease && inFlightRelease.session === this.sessions.get(sessionId)) {
+    const currentSession = this.sessions.get(sessionId);
+    if (inFlightRelease && (currentSession === undefined || inFlightRelease.session === currentSession)) {
       await inFlightRelease.promise;
       return await this.getOrCreateSession(sessionId, devicePool, platform);
     }

--- a/src/daemon/sessionManager.ts
+++ b/src/daemon/sessionManager.ts
@@ -82,7 +82,7 @@ export interface Session {
  * This enables parallel tests to each have their own device
  * while sharing centralized state in the daemon.
  */
-export type SessionReleaseCallback = (sessionId: string, deviceId: string) => void;
+export type SessionReleaseCallback = (sessionId: string, deviceId: string, releaseReason: string) => void;
 export interface SessionExecutionMetadata {
   executionId: string;
   startTime: number;
@@ -341,7 +341,7 @@ export class SessionManager {
       // Notify release callbacks so session-scoped state is cleaned up
       for (const callback of this.releaseCallbacks) {
         try {
-          callback(sessionId, deviceId);
+          callback(sessionId, deviceId, "lazy-expiry");
         } catch (error) {
           logger.warn(`Session expiry callback failed for ${sessionId}: ${error}`);
         }
@@ -750,7 +750,7 @@ export class SessionManager {
       }
       for (const callback of this.releaseCallbacks) {
         try {
-          callback(sessionId, deviceId);
+          callback(sessionId, deviceId, releaseReason);
         } catch (error) {
           logger.warn(`Session release callback failed for ${sessionId}: ${error}`);
         }
@@ -1158,7 +1158,7 @@ export class SessionManager {
         .catch(error => logger.warn(`[SessionManager] Failed to mark session released (cleanup-expired): ${error}`));
       for (const callback of this.releaseCallbacks) {
         try {
-          callback(sessionId, deviceId);
+          callback(sessionId, deviceId, "cleanup-expired");
         } catch (error) {
           logger.warn(`Session cleanup callback failed for ${sessionId}: ${error}`);
         }

--- a/src/daemon/sessionManager.ts
+++ b/src/daemon/sessionManager.ts
@@ -321,9 +321,10 @@ export class SessionManager {
     if (this.shouldExpireSession(session, expireDespiteActiveExecution, execution)) {
       // Release owns this exact session object until it has restored device state
       // and removed its assignment. Keep expiry cleanup from creating a second
-      // incarnation with the same UUID before teardown completes.
+      // incarnation with the same UUID before teardown completes, without
+      // exposing the expired session to callers during that teardown.
       if (this.releasingSessions.has(session)) {
-        return session;
+        return null;
       }
       logger.info(`Session ${sessionId} has expired, releasing`);
       const release = this.releaseSession(sessionId, "lazy-expiry", true);
@@ -379,6 +380,12 @@ export class SessionManager {
       existing.expiresAt = now + existing.sessionTimeoutMs;
       await this.recordSessionActivity(existing);
       return existing;
+    }
+
+    const inFlightRelease = this.releasePromises.get(sessionId);
+    if (inFlightRelease && inFlightRelease.session === this.sessions.get(sessionId)) {
+      await inFlightRelease.promise;
+      return await this.getOrCreateSession(sessionId, devicePool, platform);
     }
 
     const pendingAssignment = this.pendingSessionAssignments.get(sessionId);

--- a/src/daemon/sessionManager.ts
+++ b/src/daemon/sessionManager.ts
@@ -325,27 +325,11 @@ export class SessionManager {
       if (this.releasingSessions.has(session)) {
         return session;
       }
-      if (this.pendingSessionRebinds.get(sessionId)?.session === session) {
-        const release = this.releaseSession(sessionId, "lazy-expiry", true);
-        void this.getBarrier()
-          .trackExisting(release)
-          .catch(error => logger.warn(`[SessionManager] Failed to release expired session ${sessionId}: ${error}`));
-        return null;
-      }
-      logger.info(`Session ${sessionId} has expired, removing`);
-      const deviceId = session.assignedDevice;
-      this.removeSession(sessionId);
+      logger.info(`Session ${sessionId} has expired, releasing`);
+      const release = this.releaseSession(sessionId, "lazy-expiry", true);
       void this.getBarrier()
-        .track(() => this.deviceSessionRepository.markReleased(sessionId, "expired", this.timer.now(), "lazy-expiry"))
-        .catch(error => logger.warn(`[SessionManager] Failed to mark session released (lazy-expiry): ${error}`));
-      // Notify release callbacks so session-scoped state is cleaned up
-      for (const callback of this.releaseCallbacks) {
-        try {
-          callback(sessionId, deviceId, "lazy-expiry");
-        } catch (error) {
-          logger.warn(`Session expiry callback failed for ${sessionId}: ${error}`);
-        }
-      }
+        .trackExisting(release)
+        .catch(error => logger.warn(`[SessionManager] Failed to release expired session ${sessionId}: ${error}`));
       return null;
     }
     return session;
@@ -1142,27 +1126,10 @@ export class SessionManager {
       if (!session) {
         continue;
       }
-      if (this.pendingSessionRebinds.get(sessionId)?.session === session) {
-        const release = this.releaseSession(sessionId, "cleanup-expired", true);
-        void this.getBarrier()
-          .trackExisting(release)
-          .catch(error => logger.warn(`[SessionManager] Failed to release expired session ${sessionId}: ${error}`));
-        continue;
-      }
-
-      const deviceId = session.assignedDevice;
-      this.removeSession(sessionId);
-      // Notify release callbacks so session-scoped state is cleaned up.
+      const release = this.releaseSession(sessionId, "cleanup-expired", true);
       void this.getBarrier()
-        .track(() => this.deviceSessionRepository.markReleased(sessionId, "expired", this.timer.now(), "cleanup-expired"))
-        .catch(error => logger.warn(`[SessionManager] Failed to mark session released (cleanup-expired): ${error}`));
-      for (const callback of this.releaseCallbacks) {
-        try {
-          callback(sessionId, deviceId, "cleanup-expired");
-        } catch (error) {
-          logger.warn(`Session cleanup callback failed for ${sessionId}: ${error}`);
-        }
-      }
+        .trackExisting(release)
+        .catch(error => logger.warn(`[SessionManager] Failed to release expired session ${sessionId}: ${error}`));
     }
   }
 

--- a/test/daemon/devicePool.autolock.test.ts
+++ b/test/daemon/devicePool.autolock.test.ts
@@ -1,8 +1,9 @@
 import { describe, it, expect, beforeEach, afterEach } from "bun:test";
 import { DevicePool } from "../../src/daemon/devicePool";
-import { SessionManager } from "../../src/daemon/sessionManager";
+import { SessionManager, type KeepScreenAwakeRestorer } from "../../src/daemon/sessionManager";
 import { FakeTimer } from "../fakes/FakeTimer";
 import { FakeDeviceSessionPersistence } from "../fakes/FakeDeviceSessionPersistence";
+import { FakeDbWriteBarrier } from "../fakes/FakeDbWriteBarrier";
 import { FakeDeviceUtils } from "../fakes/FakeDeviceUtils";
 import { ActionableError } from "../../src/models";
 
@@ -83,6 +84,7 @@ describe("DevicePool autolock", () => {
     // has no autolockSessionId, but must still return its matching device to the pool.
     timer.advanceTime(31 * 60 * 1000);
     expect(sessionManager.getSession("test-session")).toBeNull();
+    await sessionManager.waitForSessionRelease("test-session");
     expect(pool.getDevice("emulator-5554")).toMatchObject({
       sessionId: null,
       status: "idle",
@@ -100,6 +102,7 @@ describe("DevicePool autolock", () => {
     // Advance past the 30-minute timeout and the five-minute cleanup interval
     // without reading the session, so the periodic callback owns the expiry.
     timer.advanceTime(36 * 60 * 1000);
+    await sessionManager.waitForSessionRelease("test-session");
 
     expect(pool.getDevice("emulator-5554")).toMatchObject({
       sessionId: null,
@@ -107,6 +110,52 @@ describe("DevicePool autolock", () => {
     });
     await expect(pool.assignDeviceToSession("replacement-session", "android"))
       .resolves.toBe("emulator-5554");
+  });
+
+  it("restores expired session state before returning its device to the pool", async () => {
+    let finishRestore!: () => void;
+    const restoreFinished = new Promise<void>(resolve => { finishRestore = resolve; });
+    let restoreCalls = 0;
+    const restorer: KeepScreenAwakeRestorer = {
+      async restore(): Promise<void> {
+        restoreCalls++;
+        await restoreFinished;
+      },
+    };
+    const restoringManager = new SessionManager(
+      timer,
+      new FakeDeviceSessionPersistence(),
+      () => new FakeDbWriteBarrier(),
+      () => restorer,
+    );
+    const restoringPool = new DevicePool(
+      restoringManager,
+      "daemon-session-1",
+      timer,
+      undefined,
+      fakeDeviceUtils,
+    );
+    fakeDeviceUtils.setBootedDevices("android", [androidDevice]);
+    await restoringPool.initializeWithDevices([androidDevice]);
+    await restoringPool.assignDeviceToSession("test-session", "android");
+    restoringManager.setKeepScreenAwake("test-session", { applied: true, method: "svc", svcWasEnabled: false });
+
+    timer.advanceTime(31 * 60 * 1000);
+    expect(restoringManager.getSession("test-session")).toBeNull();
+    await Promise.resolve();
+    expect(restoreCalls).toBe(1);
+    expect(restoringPool.getDevice("emulator-5554")).toMatchObject({
+      sessionId: "test-session",
+      status: "busy",
+    });
+
+    finishRestore();
+    await restoringManager.waitForSessionRelease("test-session");
+    expect(restoringPool.getDevice("emulator-5554")).toMatchObject({
+      sessionId: null,
+      status: "idle",
+    });
+    restoringManager.stopCleanupTimer();
   });
 
   it("leaves explicit session release to its caller's ordered pool cleanup", async () => {
@@ -275,6 +324,7 @@ describe("DevicePool autolock", () => {
 
       timer.advanceTime(61 * 1000);
       expect(sessionManager.getSession(sessionId!)).toBeNull();
+      await sessionManager.waitForSessionRelease(sessionId!);
 
       expect(pool.resolveAutolockSessionForMcpSession("mcp-session-1", "android")).toBeUndefined();
     });
@@ -283,10 +333,11 @@ describe("DevicePool autolock", () => {
       await initializeLiveAndroidDevice();
       sessionManager.setActiveSessionExecutionChecker((_sessionId, startedAtOrBefore) => startedAtOrBefore === undefined);
 
-      await pool.autolockDevice("emulator-5554", "android", "mcp-session-1");
+      const sessionId = await pool.autolockDevice("emulator-5554", "android", "mcp-session-1");
       timer.advanceTime(61 * 1000);
 
       expect(pool.resolveAutolockSessionForMcpSession("mcp-session-1", "android")).toBeUndefined();
+      await sessionManager.waitForSessionRelease(sessionId!);
       expect(pool.getDevice("emulator-5554")!.status).toBe("idle");
     });
 
@@ -410,6 +461,7 @@ describe("DevicePool autolock", () => {
       // Advance past both the idle timeout (60s) and the cleanup interval (5 min),
       // so the periodic cleanup fires and releases the expired session's device.
       timer.advanceTime(6 * 60 * 1000);
+      await sessionManager.waitForSessionRelease(sessionId!);
 
       const device = pool.getDevice("emulator-5554")!;
       expect(device.status).toBe("idle");
@@ -428,6 +480,7 @@ describe("DevicePool autolock", () => {
 
       // Touching the expired session lazily expires it and fires the release callback.
       expect(sessionManager.getSession(sessionId!)).toBeNull();
+      await sessionManager.waitForSessionRelease(sessionId!);
 
       const device = pool.getDevice("emulator-5554")!;
       expect(device.status).toBe("idle");

--- a/test/daemon/devicePool.autolock.test.ts
+++ b/test/daemon/devicePool.autolock.test.ts
@@ -341,6 +341,61 @@ describe("DevicePool autolock", () => {
       expect(pool.getDevice("emulator-5554")!.status).toBe("idle");
     });
 
+    it("keeps autolock enforcement until deferred expiry release publishes the device idle", async () => {
+      process.env.AUTOMOBILE_DEVICE_POOL_TIMEOUT = "1";
+      let finishRestore!: () => void;
+      const restoration = new Promise<void>(resolve => { finishRestore = resolve; });
+      let restoreStarted!: () => void;
+      const restorationStarted = new Promise<void>(resolve => { restoreStarted = resolve; });
+      const restoringManager = new SessionManager(
+        timer,
+        new FakeDeviceSessionPersistence(),
+        () => new FakeDbWriteBarrier(),
+        () => ({ restore: async (): Promise<void> => {
+          restoreStarted();
+          await restoration;
+        } }),
+      );
+      const restoringPool = new DevicePool(
+        restoringManager,
+        "daemon-session-1",
+        timer,
+        undefined,
+        fakeDeviceUtils,
+      );
+      try {
+        fakeDeviceUtils.setBootedDevices("android", [androidDevice]);
+        await restoringPool.initializeWithDevices([androidDevice]);
+        const sessionId = await restoringPool.autolockDevice("emulator-5554", "android");
+        restoringManager.setKeepScreenAwake(sessionId!, { applied: true, method: "svc", svcWasEnabled: false });
+        timer.advanceTime(1_001);
+        expect(restoringManager.getSession(sessionId!)).toBeNull();
+        await restorationStarted;
+
+        timer.advanceTime(1_000);
+        await restoringManager.waitForSessionRelease(sessionId!);
+        expect(restoringPool.getDevice("emulator-5554")).toMatchObject({
+          sessionId,
+          status: "busy",
+          autolockSessionId: sessionId,
+        });
+        expect(() => restoringPool.assertAutolockAccess("emulator-5554", "other-session"))
+          .toThrow(ActionableError);
+
+        finishRestore();
+        for (let attempt = 0; attempt < 10 && restoringPool.getDevice("emulator-5554")?.status !== "idle"; attempt++) {
+          await new Promise<void>(resolve => setImmediate(resolve));
+        }
+        expect(restoringPool.getDevice("emulator-5554")).toMatchObject({
+          sessionId: null,
+          status: "idle",
+          autolockSessionId: undefined,
+        });
+      } finally {
+        restoringManager.stopCleanupTimer();
+      }
+    });
+
     it("rejects a late MCP request while earlier work still owns the expired autolock", async () => {
       await initializeLiveAndroidDevice();
       sessionManager.setActiveSessionExecutionChecker((_sessionId, query) => query?.excludeExecutionId === "late");

--- a/test/daemon/devicePool.autolock.test.ts
+++ b/test/daemon/devicePool.autolock.test.ts
@@ -74,21 +74,57 @@ describe("DevicePool autolock", () => {
     expect(session!.assignedDevice).toBe("emulator-5554");
   });
 
-  it("session expires and frees device after timeout", async () => {
+  it("releases a matching pooled device when an ordinary session expires", async () => {
     await initializeLiveAndroidDevice();
-
-    // Create session with short timeout
     await pool.assignDeviceToSession("test-session", "android");
-
-    // Session exists
     expect(sessionManager.getSession("test-session")).not.toBeNull();
 
-    // Advance past the session timeout (30 min default)
+    // Trigger ordinary lazy expiry. Unlike an autolock session, this assignment
+    // has no autolockSessionId, but must still return its matching device to the pool.
     timer.advanceTime(31 * 60 * 1000);
+    expect(sessionManager.getSession("test-session")).toBeNull();
+    expect(pool.getDevice("emulator-5554")).toMatchObject({
+      sessionId: null,
+      status: "idle",
+    });
 
-    // Session should now be expired
-    const session = sessionManager.getSession("test-session");
-    expect(session).toBeNull();
+    await expect(pool.assignDeviceToSession("replacement-session", "android"))
+      .resolves.toBe("emulator-5554");
+    expect(pool.getDevice("emulator-5554")?.sessionId).toBe("replacement-session");
+  });
+
+  it("releases a matching pooled device during ordinary session cleanup", async () => {
+    await initializeLiveAndroidDevice();
+    await pool.assignDeviceToSession("test-session", "android");
+
+    // Advance past the 30-minute timeout and the five-minute cleanup interval
+    // without reading the session, so the periodic callback owns the expiry.
+    timer.advanceTime(36 * 60 * 1000);
+
+    expect(pool.getDevice("emulator-5554")).toMatchObject({
+      sessionId: null,
+      status: "idle",
+    });
+    await expect(pool.assignDeviceToSession("replacement-session", "android"))
+      .resolves.toBe("emulator-5554");
+  });
+
+  it("leaves explicit session release to its caller's ordered pool cleanup", async () => {
+    await initializeLiveAndroidDevice();
+    await pool.assignDeviceToSession("test-session", "android");
+
+    await sessionManager.releaseSession("test-session");
+
+    // Explicit callers perform other release cleanup before calling releaseDevice.
+    expect(pool.getDevice("emulator-5554")).toMatchObject({
+      sessionId: "test-session",
+      status: "busy",
+    });
+    await pool.releaseDevice("emulator-5554", "test-session");
+    expect(pool.getDevice("emulator-5554")).toMatchObject({
+      sessionId: null,
+      status: "idle",
+    });
   });
 
   it("does not auto-start a device image after that pool device disconnects", async () => {
@@ -460,6 +496,7 @@ describe("DevicePool autolock", () => {
       // The stale release for the first session must not free the re-locked device.
       const after = pool.getDevice("emulator-5554")!;
       expect(after.status).toBe("busy");
+      expect(after.sessionId).toBe("new-session");
       expect(after.autolockSessionId).toBe("new-session");
     });
 

--- a/test/daemon/sessionManager.test.ts
+++ b/test/daemon/sessionManager.test.ts
@@ -472,6 +472,46 @@ describe("SessionManager", () => {
       }
     });
 
+    test("waits for expired session terminal work before recreating its UUID", async () => {
+      const persistenceStarted = Promise.withResolvers<void>();
+      const finishPersistence = Promise.withResolvers<void>();
+      const manager = new SessionManager(fakeTimer, {
+        async upsertActiveSession(): Promise<void> {},
+        async recordActivity(): Promise<void> {},
+        async markReleased(): Promise<void> {
+          persistenceStarted.resolve();
+          await finishPersistence.promise;
+        },
+        async markStaleActiveSessionsExpired(): Promise<void> {},
+      }, () => new FakeDbWriteBarrier());
+      const assignedSessionIds: string[] = [];
+      const devicePool: SessionDeviceAssigner = {
+        async assignDeviceToSession(sessionId: string): Promise<string> {
+          assignedSessionIds.push(sessionId);
+          const replacement = await manager.createSession(sessionId, "device-2", "android");
+          return replacement.assignedDevice;
+        },
+      };
+      try {
+        await manager.createSession("s1", "device-1", "android", 1);
+        fakeTimer.advanceTime(2);
+        expect(manager.getSession("s1")).toBeNull();
+        await persistenceStarted.promise;
+
+        const replacement = manager.getOrCreateSession("s1", devicePool);
+        await Promise.resolve();
+        expect(assignedSessionIds).toEqual([]);
+
+        finishPersistence.resolve();
+        await expect(replacement).resolves.toMatchObject({
+          sessionId: "s1",
+          assignedDevice: "device-2",
+        });
+      } finally {
+        manager.stopCleanupTimer();
+      }
+    });
+
     test("keeps a session when work began before its expiry deadline", async () => {
       const session = await sessionManager.createSession("session-1", "emulator-5554", "android", 1000);
       fakeTimer.advanceTime(1001);

--- a/test/daemon/sessionManager.test.ts
+++ b/test/daemon/sessionManager.test.ts
@@ -375,6 +375,103 @@ describe("SessionManager", () => {
       expect(sessionManager.getActiveSessionCount()).toBe(0);
     });
 
+    test("keeps an expired session unavailable while its teardown restores device state", async () => {
+      let finishRestore!: () => void;
+      const restoration = new Promise<void>(resolve => { finishRestore = resolve; });
+      let restoreStarted!: () => void;
+      const restorationStarted = new Promise<void>(resolve => { restoreStarted = resolve; });
+      const activity: string[] = [];
+      const manager = new SessionManager(
+        fakeTimer,
+        {
+          async upsertActiveSession(): Promise<void> {},
+          async recordActivity(sessionId: string): Promise<void> { activity.push(sessionId); },
+          async markReleased(): Promise<void> {},
+          async markStaleActiveSessionsExpired(): Promise<void> {},
+        },
+        () => new FakeDbWriteBarrier(),
+        () => ({ restore: async (): Promise<void> => {
+          restoreStarted();
+          await restoration;
+        } }),
+      );
+      const assignedSessionIds: string[] = [];
+      const devicePool: SessionDeviceAssigner = {
+        async assignDeviceToSession(sessionId: string): Promise<string> {
+          assignedSessionIds.push(sessionId);
+          const replacement = await manager.createSession(sessionId, "device-2", "android");
+          return replacement.assignedDevice;
+        },
+      };
+      try {
+        const session = await manager.createSession("s1", "device-1", "android", 1);
+        manager.setKeepScreenAwake("s1", { applied: true, method: "svc", svcWasEnabled: false });
+        await Promise.resolve();
+        activity.length = 0;
+        fakeTimer.advanceTime(2);
+
+        expect(manager.getSession("s1")).toBeNull();
+        await restorationStarted;
+        expect(manager.getSession("s1")).toBeNull();
+        expect(manager.getSessionForNewExecution("s1")).toBeNull();
+
+        const expiresAt = session.expiresAt;
+        manager.recordHeartbeat("s1");
+        await Promise.resolve();
+        expect(session.expiresAt).toBe(expiresAt);
+        expect(activity).toEqual([]);
+
+        const replacement = manager.getOrCreateSession("s1", devicePool);
+        await Promise.resolve();
+        expect(assignedSessionIds).toEqual([]);
+
+        finishRestore();
+        await expect(replacement).resolves.toMatchObject({
+          sessionId: "s1",
+          assignedDevice: "device-2",
+        });
+      } finally {
+        manager.stopCleanupTimer();
+      }
+    });
+
+    test("keeps a periodically expired session unavailable during teardown", async () => {
+      let finishRestore!: () => void;
+      const restoration = new Promise<void>(resolve => { finishRestore = resolve; });
+      let restoreStarted!: () => void;
+      const restorationStarted = new Promise<void>(resolve => { restoreStarted = resolve; });
+      const manager = new SessionManager(
+        fakeTimer,
+        {
+          async upsertActiveSession(): Promise<void> {},
+          async recordActivity(): Promise<void> {},
+          async markReleased(): Promise<void> {},
+          async markStaleActiveSessionsExpired(): Promise<void> {},
+        },
+        () => new FakeDbWriteBarrier(),
+        () => ({ restore: async (): Promise<void> => {
+          restoreStarted();
+          await restoration;
+        } }),
+      );
+      try {
+        const session = await manager.createSession("s1", "device-1", "android", 1);
+        manager.setKeepScreenAwake("s1", { applied: true, method: "svc", svcWasEnabled: false });
+        fakeTimer.advanceTime(5 * 60 * 1000);
+
+        await restorationStarted;
+        expect(manager.getSession("s1")).toBeNull();
+        expect(manager.getSessionForNewExecution("s1")).toBeNull();
+        manager.recordHeartbeat("s1");
+        expect(session.expiresAt).toBe(1);
+
+        finishRestore();
+        await manager.waitForSessionRelease("s1");
+      } finally {
+        manager.stopCleanupTimer();
+      }
+    });
+
     test("keeps a session when work began before its expiry deadline", async () => {
       const session = await sessionManager.createSession("session-1", "emulator-5554", "android", 1000);
       fakeTimer.advanceTime(1001);

--- a/test/daemon/sessionManager.test.ts
+++ b/test/daemon/sessionManager.test.ts
@@ -1015,6 +1015,7 @@ describe("SessionManager", () => {
       // Accessing the expired session should trigger cleanup + callback
       const result = sessionManager.getSession("session-expiry");
       expect(result).toBeNull();
+      await sessionManager.waitForSessionRelease("session-expiry");
       expect(released).toHaveLength(1);
       expect(released[0].sessionId).toBe("session-expiry");
       expect(released[0].deviceId).toBe("emulator-5554");
@@ -1030,6 +1031,7 @@ describe("SessionManager", () => {
 
       // Advance past session timeout + cleanup interval (30min + 5min)
       fakeTimer.advanceTime(36 * 60 * 1000);
+      await sessionManager.waitForSessionRelease("session-timer");
 
       expect(released).toHaveLength(1);
       expect(released[0].sessionId).toBe("session-timer");
@@ -1101,12 +1103,11 @@ describe("SessionManager", () => {
         await mgr.createSession("s1", "emulator-5554", "android");
         // Past session timeout (30m) + cleanup interval (5m): the timer fires.
         fakeTimer.advanceTime(36 * 60 * 1000);
-        await Promise.resolve();
+        await mgr.waitForSessionRelease("s1");
         expect(released).toContain("s1");
-        // Exactly one barrier-tracked write: the cleanup sweep releases the single
-        // expired session once, routing one fire-and-forget markReleased through the
-        // barrier. A duplicate-write regression would push this to 2.
-        expect(barrier.ran.length).toBe(1);
+        // Exactly one release promise is registered before daemon shutdown can
+        // begin draining. A duplicate release regression would push this to 2.
+        expect(barrier.trackedExisting.length).toBe(1);
       } finally {
         mgr.stopCleanupTimer();
       }

--- a/test/daemon/sessionManager.test.ts
+++ b/test/daemon/sessionManager.test.ts
@@ -11,6 +11,7 @@ import { FakeInstalledAppsRepository } from "../fakes/FakeInstalledAppsRepositor
 import { FakeDeviceManager } from "../fakes/FakeDeviceManager";
 import { FakeDeviceSessionPersistence } from "../fakes/FakeDeviceSessionPersistence";
 import type { DeviceSessionPersistence } from "../../src/db/deviceSessionRepository";
+import type { DeviceSessionStatus } from "../../src/db/types";
 import type { ViewHierarchyResult } from "../../src/models/ViewHierarchyResult";
 import type { KeepScreenAwakeState } from "../../src/utils/KeepScreenAwakeManager";
 
@@ -1036,6 +1037,36 @@ describe("SessionManager", () => {
       expect(released).toHaveLength(1);
       expect(released[0].sessionId).toBe("session-timer");
       expect(released[0].deviceId).toBe("emulator-5556");
+    });
+
+    test("persists expired status for lazy and periodic session expiry", async () => {
+      const releases: Array<{ sessionId: string; status: DeviceSessionStatus; reason: string }> = [];
+      const repository: DeviceSessionPersistence = {
+        async upsertActiveSession(): Promise<void> {},
+        async recordActivity(): Promise<void> {},
+        async markReleased(sessionId, status, _releasedAtMs, reason): Promise<void> {
+          releases.push({ sessionId, status, reason });
+        },
+        async markStaleActiveSessionsExpired(): Promise<void> {},
+      };
+      const manager = new SessionManager(fakeTimer, repository);
+      try {
+        await manager.createSession("lazy-expiry", "emulator-5554", "android");
+        fakeTimer.advanceTime(31 * 60 * 1000);
+        expect(manager.getSession("lazy-expiry")).toBeNull();
+        await manager.waitForSessionRelease("lazy-expiry");
+
+        await manager.createSession("periodic-expiry", "emulator-5556", "android");
+        fakeTimer.advanceTime(36 * 60 * 1000);
+        await manager.waitForSessionRelease("periodic-expiry");
+
+        expect(releases).toEqual([
+          { sessionId: "lazy-expiry", status: "expired", reason: "lazy-expiry" },
+          { sessionId: "periodic-expiry", status: "expired", reason: "cleanup-expired" },
+        ]);
+      } finally {
+        manager.stopCleanupTimer();
+      }
     });
   });
 


### PR DESCRIPTION
## Summary

Return a pooled device to `DevicePool` when its ordinary session expires through lazy expiry or periodic cleanup. The release callback now carries its reason so explicit-release callers retain their existing cleanup ordering, while explicit autolock release still clears its lock metadata and MCP mapping.

## Linked Issue

Closes #5287

## Bug / Regression Context

- **Prior attempts:** None.
- **Observed symptom:** An expired ordinary session disappeared from `SessionManager`, but its pooled device remained busy and retained the expired session ID.
- **Repro steps / conditions:** Let a regular pooled session expire through lazy access or the periodic cleanup sweep, then try to allocate the same device.

## Validation

- [x] `bun run turbo:validate` passes.
- [x] `bun run typecheck` reports no new errors (baseline gate).
- [x] New behavior uses existing `FakeTimer` and fakes; focused unit tests complete in under 100ms.
- [x] No new helper or dependency added.
- [x] Based on current `origin/main` when the isolated worktree was created.

## Follow-ups

None.
