### PR TITLE
fix(daemon): rekey device epoch on adb transport change

### DIFF
--- a/src/daemon/devicePool.ts
+++ b/src/daemon/devicePool.ts
@@ -300,11 +300,6 @@ export class DevicePool {
         `Device discovery completed in ${discoveryTime}ms, found ${bootedDevices.length} devices`,
       );
 
-      if (refreshGeneration !== this.refreshGeneration) {
-        logger.info("Discarding an out-of-date device discovery snapshot");
-        return 0;
-      }
-
       const now = this.seedLastUsedAt(this.timer.now());
       let addedCount = 0;
       let removedCount = 0;
@@ -312,11 +307,18 @@ export class DevicePool {
       const bootedPlatforms = new Set(bootedDevices.map((device) => device.platform));
 
       perf.startOperation("poolUpdate");
-      removedCount = await this.removeDevicesMissingFrom(
+      const removed = await this.removeMissingDevicesForRefresh(
+        assignmentLockHeld,
+        refreshGeneration,
         bootedDeviceIds,
         bootedPlatforms,
         discovery.succeededPlatforms,
       );
+      if (removed === undefined) {
+        logger.info("Discarding an out-of-date device discovery snapshot");
+        return 0;
+      }
+      removedCount = removed;
 
       for (const device of bootedDevices) {
         this.clearAutoStartSuppressionForBootedDevice(device);
@@ -709,6 +711,28 @@ export class DevicePool {
     }
 
     return removedCount;
+  }
+
+  private async removeMissingDevicesForRefresh(
+    assignmentLockHeld: boolean,
+    refreshGeneration: number,
+    bootedDeviceIds: Set<string>,
+    bootedPlatforms: Set<Platform>,
+    succeededPlatforms: Set<Platform>,
+  ): Promise<number | undefined> {
+    const removeMissingDevices = async () => {
+      if (refreshGeneration !== this.refreshGeneration) {
+        return undefined;
+      }
+      return await this.removeDevicesMissingFrom(
+        bootedDeviceIds,
+        bootedPlatforms,
+        succeededPlatforms,
+      );
+    };
+    return assignmentLockHeld
+      ? await removeMissingDevices()
+      : await this.assignmentMutex.runExclusive(removeMissingDevices);
   }
 
   /**
@@ -1248,7 +1272,10 @@ export class DevicePool {
   }
 
   private shouldValidatePooledDevicePresence(device: PooledDevice): boolean {
-    return device.platform === "android" && consolePortFromSerial(device.id) !== null;
+    return (
+      device.platform === "android" &&
+      (consolePortFromSerial(device.id) !== null || device.transportId !== undefined)
+    );
   }
 
   private async ensurePooledDevicePresentForUse(
@@ -2064,12 +2091,16 @@ export class DevicePool {
    */
   async reserveDeviceForReadiness(
     deviceId: string,
-    expectedIdentity: Pick<BootedDevice, "deviceId" | "name" | "platform">,
+    expectedIdentity: Pick<BootedDevice, "deviceId" | "name" | "platform" | "transportId">,
   ): Promise<() => Promise<void>> {
-    await this.assignmentMutex.runExclusive(() => {
+    await this.assignmentMutex.runExclusive(async () => {
       const pooled = this.devices.get(deviceId);
       if (pooled) {
-        this.assertRuntimeIdentity(pooled, expectedIdentity);
+        if (this.hasTransportOnlyIdentityChange(pooled, expectedIdentity)) {
+          await this.replacePooledDeviceForRuntimeIdentity(pooled, expectedIdentity);
+        } else {
+          this.assertRuntimeIdentity(pooled, expectedIdentity);
+        }
       }
       this.readinessReservationCounts.set(
         deviceId,
@@ -2224,6 +2255,18 @@ export class DevicePool {
       pooled.name === expected.name &&
       pooled.platform === expected.platform &&
       pooled.transportId === expected.transportId
+    );
+  }
+
+  private hasTransportOnlyIdentityChange(
+    pooled: PooledDevice,
+    expected: Pick<BootedDevice, "deviceId" | "name" | "platform" | "transportId">,
+  ): boolean {
+    return (
+      pooled.id === expected.deviceId &&
+      pooled.name === expected.name &&
+      pooled.platform === expected.platform &&
+      !this.matchesRuntimeIdentity(pooled, expected)
     );
   }
 

--- a/src/daemon/devicePool.ts
+++ b/src/daemon/devicePool.ts
@@ -163,6 +163,8 @@ export class DevicePool {
   private readonly recoveringAndroidImages: Map<string, DeviceInfo> = new Map();
   private readonly recoveringAndroidDeviceIds: Set<string> = new Set();
   private readonly startedDeviceProcesses: Map<string, ChildProcess> = new Map();
+  /** Latest refresh request; older discovery snapshots must not overwrite it. */
+  private refreshGeneration = 0;
   private readonly readinessReservationCounts: Map<string, number> = new Map();
   /**
    * Serials the user intentionally stopped, mapped to the pooled-device
@@ -278,6 +280,7 @@ export class DevicePool {
   private async refreshDevicesInternal(assignmentLockHeld: boolean): Promise<number> {
     const startTime = this.timer.now();
     const perf = createGlobalPerformanceTracker();
+    const refreshGeneration = ++this.refreshGeneration;
     try {
       logger.info("Refreshing device pool - discovering connected devices...");
 
@@ -297,6 +300,11 @@ export class DevicePool {
         `Device discovery completed in ${discoveryTime}ms, found ${bootedDevices.length} devices`,
       );
 
+      if (refreshGeneration !== this.refreshGeneration) {
+        logger.info("Discarding an out-of-date device discovery snapshot");
+        return 0;
+      }
+
       const now = this.seedLastUsedAt(this.timer.now());
       let addedCount = 0;
       let removedCount = 0;
@@ -313,17 +321,21 @@ export class DevicePool {
       for (const device of bootedDevices) {
         this.clearAutoStartSuppressionForBootedDevice(device);
         const updatePooledDevice = async () => {
+          if (refreshGeneration !== this.refreshGeneration) {
+            return false;
+          }
           let pooledDevice = this.devices.get(device.deviceId);
+          let runtimeReplaced = false;
           if (pooledDevice && !this.matchesRuntimeIdentity(pooledDevice, device)) {
-            await this.evictMissingPooledDevice(
+            runtimeReplaced = await this.replacePooledDeviceForRuntimeIdentity(
               pooledDevice,
-              `runtime identity changed to ${device.platform}:${device.name}`,
+              device,
             );
             pooledDevice = this.devices.get(device.deviceId);
           }
           if (pooledDevice) {
             pooledDevice.iosVersion = device.iosVersion;
-            return false;
+            return runtimeReplaced;
           }
           this.devices.set(device.deviceId, {
             id: device.deviceId,
@@ -457,6 +469,31 @@ export class DevicePool {
       device.avdName = sourceImage.name;
       device.androidImage = sourceImage;
     }
+  }
+
+  /**
+   * Replace a pooled connection whose stable serial now identifies a different
+   * runtime. Preserve AutoMobile-owned emulator state because the process and
+   * AVD did not change; only the ADB connection incarnation did.
+   */
+  private async replacePooledDeviceForRuntimeIdentity(
+    pooledDevice: PooledDevice,
+    bootedDevice: BootedDevice,
+  ): Promise<boolean> {
+    const sourceImage = pooledDevice.androidImage;
+    const startedProcess = this.startedDeviceProcesses.get(pooledDevice.id);
+    await this.evictMissingPooledDevice(
+      pooledDevice,
+      `runtime identity changed to ${bootedDevice.platform}:${bootedDevice.name}`,
+    );
+    if (this.devices.has(bootedDevice.deviceId)) {
+      return false;
+    }
+    await this.addDevice(bootedDevice, sourceImage);
+    if (startedProcess) {
+      this.startedDeviceProcesses.set(bootedDevice.deviceId, startedProcess);
+    }
+    return true;
   }
 
   /**
@@ -1231,9 +1268,15 @@ export class DevicePool {
       return true;
     }
 
-    if (discovery.devices.some((booted) => booted.deviceId === device.id)) {
+    const bootedDevice = discovery.devices.find((booted) => booted.deviceId === device.id);
+    if (bootedDevice && this.matchesRuntimeIdentity(device, bootedDevice)) {
       this.refreshMissingDeviceMisses.delete(device.id);
       return true;
+    }
+
+    if (bootedDevice) {
+      await this.replacePooledDeviceForRuntimeIdentity(device, bootedDevice);
+      return false;
     }
 
     if (deferRecovery && this.shouldRebootDisconnectedAndroidDevice(device)) {

--- a/src/daemon/devicePool.ts
+++ b/src/daemon/devicePool.ts
@@ -71,6 +71,8 @@ export interface PooledDevice {
   id: string; // Device ID (e.g., "emulator-5554")
   name: string; // Device name (e.g., "Pixel 7")
   platform: Platform; // Device platform
+  /** ADB transport identity for Android devices; changes when a serial reconnects. */
+  transportId?: string;
   sessionId: string | null; // Session currently using it, null if idle
   status: DeviceStatus; // Current status
   lastUsedAt: number; // Last usage timestamp
@@ -87,8 +89,8 @@ export interface PooledDevice {
    * Monotonic id for this pooled connection incarnation, assigned when the
    * device is first added to the pool. A serial (`id`) can be reused across
    * boots, so this distinguishes "the device we intentionally stopped" from a
-   * later same-serial replacement — see `intentionalShutdowns` (issue: DevicePool
-   * shutdown-marker same-serial-reuse race, follow-up to PR #5015).
+   * later same-serial or transport replacement — see `intentionalShutdowns`
+   * (issue: DevicePool shutdown-marker same-serial-reuse race, follow-up to PR #5015).
    */
   incarnation: number;
 }
@@ -240,6 +242,7 @@ export class DevicePool {
         id: device.deviceId,
         name: device.name,
         platform: device.platform,
+        transportId: device.transportId,
         sessionId: null,
         status: "idle",
         lastUsedAt: now,
@@ -284,7 +287,9 @@ export class DevicePool {
       logger.info(`Environment: ANDROID_HOME=${androidHome}, ANDROID_SDK_ROOT=${androidSdkRoot}`);
 
       perf.startOperation("deviceDiscovery");
-      const discovery = await this.deviceManager.getBootedDevicesDetailed("either");
+      const discovery = await this.deviceManager.getBootedDevicesDetailed("either", {
+        bypassAndroidDeviceListCache: true,
+      });
       perf.endOperation("deviceDiscovery");
       const bootedDevices = discovery.devices;
       const discoveryTime = this.timer.now() - startTime;
@@ -324,6 +329,7 @@ export class DevicePool {
             id: device.deviceId,
             name: device.name,
             platform: device.platform,
+            transportId: device.transportId,
             sessionId: null,
             status: "idle",
             lastUsedAt: now,
@@ -424,6 +430,7 @@ export class DevicePool {
         id: device.deviceId,
         name: device.name,
         platform: device.platform,
+        transportId: device.transportId,
         sessionId: null,
         status: "idle",
         lastUsedAt: now,
@@ -2153,26 +2160,27 @@ export class DevicePool {
 
   private assertRuntimeIdentity(
     pooled: PooledDevice,
-    expected: Pick<BootedDevice, "deviceId" | "name" | "platform"> | undefined,
+    expected: Pick<BootedDevice, "deviceId" | "name" | "platform" | "transportId"> | undefined,
   ): void {
     if (!expected || this.matchesRuntimeIdentity(pooled, expected)) {
       return;
     }
     throw new ActionableError(
       `Device pool identity mismatch for '${expected.deviceId}': ` +
-        `resolved=[${expected.name} platform=${expected.platform}] ` +
-        `pooled=[${pooled.name} platform=${pooled.platform}].`,
+        `resolved=[${expected.name} platform=${expected.platform} transportId=${expected.transportId}] ` +
+        `pooled=[${pooled.name} platform=${pooled.platform} transportId=${pooled.transportId}].`,
     );
   }
 
   private matchesRuntimeIdentity(
     pooled: PooledDevice,
-    expected: Pick<BootedDevice, "deviceId" | "name" | "platform">,
+    expected: Pick<BootedDevice, "deviceId" | "name" | "platform" | "transportId">,
   ): boolean {
     return (
       pooled.id === expected.deviceId &&
       pooled.name === expected.name &&
-      pooled.platform === expected.platform
+      pooled.platform === expected.platform &&
+      pooled.transportId === expected.transportId
     );
   }
 

--- a/test/daemon/devicePool.test.ts
+++ b/test/daemon/devicePool.test.ts
@@ -77,6 +77,18 @@ describe("DevicePool", () => {
     }
   }
 
+  class TransportAwareFakeDeviceManager extends FakeDeviceManager {
+    discoveryOptions: Array<{ bypassAndroidDeviceListCache?: boolean } | undefined> = [];
+
+    override async getBootedDevicesDetailed(
+      platform: SomePlatform,
+      options?: { bypassAndroidDeviceListCache?: boolean },
+    ) {
+      this.discoveryOptions.push(options);
+      return await super.getBootedDevicesDetailed(platform);
+    }
+  }
+
   class DeferredDiscoveryFakeDeviceManager extends FakeDeviceManager {
     private readonly discoveryStartedPromise: Promise<void>;
     private readonly discoveryReleasePromise: Promise<void>;
@@ -896,27 +908,82 @@ describe("DevicePool", () => {
       });
     });
 
-    test("assigns a fresh incarnation per pooled connection and keeps it across a reusing refresh", async () => {
-      await initializeLiveDevices([createBootedDevice("emulator-5554", "android", "Pixel 8")]);
+    test("assigns a fresh incarnation per pooled connection and keeps it across a same-transport refresh", async () => {
+      const device = { ...createBootedDevice("emulator-5554", "android", "Pixel 8"), transportId: "1" };
+      await initializeLiveDevices([device]);
       const first = devicePool.getDevice("emulator-5554");
       if (!first) {
         throw new Error("expected pooled device");
       }
       const firstIncarnation = first.incarnation;
 
-      // A refresh that rediscovers the same serial reuses the entry — same
-      // incarnation, so an existing mark for it still applies.
+      // A refresh that rediscovers the same serial and transport reuses the
+      // entry — same incarnation, so an existing mark for it still applies.
       await devicePool.refreshDevices();
       expect(devicePool.getDevice("emulator-5554")?.incarnation).toBe(firstIncarnation);
 
       // Once the serial leaves and re-appears, it is a new connection and gets a
       // fresh incarnation, so a mark from the prior incarnation cannot match it.
       await devicePool.removeDevice("emulator-5554");
-      fakeDeviceManager.bootedDevices = [createBootedDevice("emulator-5554", "android", "Pixel 8")];
+      fakeDeviceManager.bootedDevices = [device];
       await devicePool.refreshDevices();
       const second = devicePool.getDevice("emulator-5554");
       expect(second).not.toBeNull();
       expect(second!.incarnation).toBeGreaterThan(firstIncarnation);
+    });
+
+    test("replaces a fast same-serial transport reconnect with a new device session epoch", async () => {
+      const registry = new DeviceSessionRegistry(fakeTimer, new FakeIdGenerator(["uuid-a", "uuid-b"]));
+      const transportAwareDeviceManager = new TransportAwareFakeDeviceManager();
+      fakeDeviceManager = transportAwareDeviceManager;
+      devicePool = new DevicePool(
+        sessionManager,
+        "test-daemon-session-id",
+        fakeTimer,
+        fakeAppsRepo,
+        fakeDeviceManager,
+        new DefaultRetryExecutor(fakeTimer),
+        undefined,
+        undefined,
+        undefined,
+        (deviceId) => {
+          const pooled = devicePool.getDevice(deviceId);
+          if (pooled) {
+            registry.onDeviceConnected({
+              deviceId: pooled.id,
+              platform: pooled.platform,
+              incarnation: pooled.incarnation,
+            });
+          }
+        },
+        undefined,
+        undefined,
+        deviceId => registry.onDeviceDisconnected(deviceId),
+      );
+      const firstConnection = {
+        ...createBootedDevice("emulator-5554", "android", "Pixel 8"),
+        transportId: "1",
+      };
+      const reconnected = { ...firstConnection, transportId: "2" };
+      await initializeLiveDevices([firstConnection]);
+      devicePool.notifyDeviceReady(firstConnection.deviceId);
+      const firstEpoch = registry.getByDeviceId(firstConnection.deviceId);
+      const firstIncarnation = devicePool.getDevice(firstConnection.deviceId)?.incarnation;
+      if (!firstEpoch || firstIncarnation === undefined) {
+        throw new Error("expected the first pooled connection epoch");
+      }
+
+      fakeDeviceManager.bootedDevices = [reconnected];
+
+      const added = await devicePool.refreshDevices();
+
+      const secondEpoch = registry.getByDeviceId(reconnected.deviceId);
+      expect(added).toBe(1);
+      expect(devicePool.getDevice(reconnected.deviceId)?.incarnation).toBeGreaterThan(firstIncarnation);
+      expect(secondEpoch?.deviceSessionUuid).toBe("uuid-b");
+      expect(secondEpoch?.deviceSessionUuid).not.toBe(firstEpoch.deviceSessionUuid);
+      expect(registry.getByUuid(firstEpoch.deviceSessionUuid)).toBeUndefined();
+      expect(transportAwareDeviceManager.discoveryOptions).toEqual([{ bypassAndroidDeviceListCache: true }]);
     });
   });
 

--- a/test/daemon/devicePool.test.ts
+++ b/test/daemon/devicePool.test.ts
@@ -1129,6 +1129,42 @@ describe("DevicePool", () => {
         androidImage: sourceImage,
       });
     });
+
+    test("rekeys a transport-only mismatch before reserving startDevice readiness", async () => {
+      const firstConnection = {
+        ...createBootedDevice("emulator-5554", "android", "Pixel 8"),
+        transportId: "1",
+      };
+      const reconnected = { ...firstConnection, transportId: "2" };
+      await initializeLiveDevices([firstConnection]);
+
+      const releaseReservation = await devicePool.reserveDeviceForReadiness(
+        reconnected.deviceId,
+        reconnected,
+      );
+
+      expect(devicePool.getDevice(reconnected.deviceId)?.transportId).toBe("2");
+      await releaseReservation();
+    });
+
+    test("rekeys a non-emulator Android transport reconnect before allocation", async () => {
+      const firstConnection = {
+        ...createBootedDevice("R5CT123456", "android", "Pixel 8"),
+        transportId: "1",
+      };
+      const reconnected = { ...firstConnection, transportId: "2" };
+      await initializeLiveDevices([firstConnection]);
+      fakeDeviceManager.bootedDevices = [reconnected];
+
+      await expect(devicePool.assignDeviceToSession("session-usb", "android")).resolves.toBe(
+        reconnected.deviceId,
+      );
+
+      expect(devicePool.getDevice(reconnected.deviceId)).toMatchObject({
+        transportId: "2",
+        sessionId: "session-usb",
+      });
+    });
   });
 
   describe("device-ready notifications", () => {

--- a/test/daemon/devicePool.test.ts
+++ b/test/daemon/devicePool.test.ts
@@ -89,6 +89,47 @@ describe("DevicePool", () => {
     }
   }
 
+  class OutOfOrderRefreshFakeDeviceManager extends FakeDeviceManager {
+    private readonly firstDiscoveryStartedPromise: Promise<void>;
+    private readonly firstDiscoveryReleasePromise: Promise<void>;
+    private resolveFirstDiscoveryStarted!: () => void;
+    private resolveFirstDiscoveryRelease!: () => void;
+    private discoveryCount = 0;
+
+    constructor(
+      private readonly firstSnapshot: BootedDevice[],
+      private readonly secondSnapshot: BootedDevice[],
+    ) {
+      super();
+      this.firstDiscoveryStartedPromise = new Promise((resolve) => {
+        this.resolveFirstDiscoveryStarted = resolve;
+      });
+      this.firstDiscoveryReleasePromise = new Promise((resolve) => {
+        this.resolveFirstDiscoveryRelease = resolve;
+      });
+    }
+
+    override async getBootedDevicesDetailed(platform: SomePlatform) {
+      this.discoveryCount++;
+      if (this.discoveryCount === 1) {
+        this.resolveFirstDiscoveryStarted();
+        await this.firstDiscoveryReleasePromise;
+        this.bootedDevices = this.firstSnapshot;
+      } else {
+        this.bootedDevices = this.secondSnapshot;
+      }
+      return await super.getBootedDevicesDetailed(platform);
+    }
+
+    async waitForFirstDiscoveryStart(): Promise<void> {
+      await this.firstDiscoveryStartedPromise;
+    }
+
+    releaseFirstDiscovery(): void {
+      this.resolveFirstDiscoveryRelease();
+    }
+  }
+
   class DeferredDiscoveryFakeDeviceManager extends FakeDeviceManager {
     private readonly discoveryStartedPromise: Promise<void>;
     private readonly discoveryReleasePromise: Promise<void>;
@@ -984,6 +1025,109 @@ describe("DevicePool", () => {
       expect(secondEpoch?.deviceSessionUuid).not.toBe(firstEpoch.deviceSessionUuid);
       expect(registry.getByUuid(firstEpoch.deviceSessionUuid)).toBeUndefined();
       expect(transportAwareDeviceManager.discoveryOptions).toEqual([{ bypassAndroidDeviceListCache: true }]);
+    });
+
+    test("rekeys a same-serial transport reconnect before assigning an idle device", async () => {
+      const registry = new DeviceSessionRegistry(fakeTimer, new FakeIdGenerator(["uuid-a", "uuid-b"]));
+      fakeDeviceManager = new TransportAwareFakeDeviceManager();
+      devicePool = new DevicePool(
+        sessionManager,
+        "test-daemon-session-id",
+        fakeTimer,
+        fakeAppsRepo,
+        fakeDeviceManager,
+        new DefaultRetryExecutor(fakeTimer),
+        undefined,
+        undefined,
+        undefined,
+        (deviceId) => {
+          const pooled = devicePool.getDevice(deviceId);
+          if (pooled) {
+            registry.onDeviceConnected({
+              deviceId: pooled.id,
+              platform: pooled.platform,
+              incarnation: pooled.incarnation,
+            });
+          }
+        },
+        undefined,
+        undefined,
+        (deviceId) => registry.onDeviceDisconnected(deviceId),
+      );
+      const firstConnection = {
+        ...createBootedDevice("emulator-5554", "android", "Pixel 8"),
+        transportId: "1",
+      };
+      const reconnected = { ...firstConnection, transportId: "2" };
+      await initializeLiveDevices([firstConnection]);
+      devicePool.notifyDeviceReady(firstConnection.deviceId);
+      const firstEpoch = registry.getByDeviceId(firstConnection.deviceId);
+      fakeDeviceManager.bootedDevices = [reconnected];
+
+      await expect(devicePool.assignDeviceToSession("session-1", "android")).resolves.toBe(
+        reconnected.deviceId,
+      );
+
+      expect(devicePool.getDevice(reconnected.deviceId)).toMatchObject({
+        transportId: "2",
+        sessionId: "session-1",
+      });
+      expect(registry.getByDeviceId(reconnected.deviceId)?.deviceSessionUuid).toBe("uuid-b");
+      expect(registry.getByUuid(firstEpoch!.deviceSessionUuid)).toBeUndefined();
+    });
+
+    test("discards an older refresh snapshot after a newer transport replacement", async () => {
+      const firstConnection = {
+        ...createBootedDevice("emulator-5554", "android", "Pixel 8"),
+        transportId: "1",
+      };
+      const reconnected = { ...firstConnection, transportId: "2" };
+      const outOfOrderManager = new OutOfOrderRefreshFakeDeviceManager(
+        [firstConnection],
+        [reconnected],
+      );
+      fakeDeviceManager = outOfOrderManager;
+      devicePool = new DevicePool(
+        sessionManager,
+        "test-daemon-session-id",
+        fakeTimer,
+        fakeAppsRepo,
+        fakeDeviceManager,
+        new DefaultRetryExecutor(fakeTimer),
+      );
+      await initializeLiveDevices([firstConnection]);
+
+      const olderRefresh = devicePool.refreshDevices();
+      await outOfOrderManager.waitForFirstDiscoveryStart();
+      await devicePool.refreshDevices();
+      outOfOrderManager.releaseFirstDiscovery();
+      await olderRefresh;
+
+      expect(devicePool.getDevice(reconnected.deviceId)?.transportId).toBe("2");
+    });
+
+    test("preserves AutoMobile-owned emulator metadata across a transport rekey", async () => {
+      const sourceImage: DeviceInfo = {
+        name: "Pixel 8",
+        platform: "android",
+        isRunning: false,
+        source: "local",
+      };
+      const firstConnection = {
+        ...createBootedDevice("emulator-5554", "android", "Pixel 8"),
+        transportId: "1",
+      };
+      const reconnected = { ...firstConnection, transportId: "2" };
+      await devicePool.addDevice(firstConnection, sourceImage);
+      fakeDeviceManager.bootedDevices = [reconnected];
+
+      await devicePool.refreshDevices();
+
+      expect(devicePool.getDevice(reconnected.deviceId)).toMatchObject({
+        transportId: "2",
+        avdName: "Pixel 8",
+        androidImage: sourceImage,
+      });
     });
   });
 


### PR DESCRIPTION
## Summary

Fixes device-session identity for an Android device that reconnects under the
same serial before the disconnect monitor confirms it disappeared.

The device pool now bypasses the short ADB device-list cache during refresh,
persists the resulting `transportId`, and includes it in runtime identity
comparison. A changed transport evicts the prior pooled connection,
which retires its `deviceSessionUuid` through the existing removal callback and
creates a fresh pooled incarnation and UUID through the ready callback.

## Root cause

The pool previously compared only serial, device name, and platform. A fast
same-serial ADB reconnect therefore reused the existing pooled entry and its
incarnation, causing `DeviceSessionRegistry` to retain the old epoch UUID.

## Validation

- `bun test test/daemon/devicePool.test.ts test/daemon/deviceSessionRegistry.test.ts test/daemon/daemonIdGenerator.test.ts`
- `bun run lint`
- `bun run typecheck`
- `bun run turbo:validate` — 13,199 passed; 13 expected device-dependent skips; 0 failures

Closes [#5267](https://github.com/kaeawc/auto-mobile/issues/5267)
