### PR TITLE
fix(daemon): restore session state after persistence failure

### DIFF
--- a/src/daemon/daemon.ts
+++ b/src/daemon/daemon.ts
@@ -234,9 +234,10 @@ export class Daemon {
       AndroidCtrlProxyClient.getExistingInstance(deviceId)?.releaseSessionBinding(sessionId);
       IOSCtrlProxyClient.getExistingInstance(deviceId)?.releaseSessionBinding(sessionId);
     });
-    // Moving a live session must clear only the old device's observation and
-    // CtrlProxy binding. Session-wide cleanup belongs exclusively to release.
+    // A rebind keeps the session live, but its navigation state was collected on
+    // the old device and must not follow it to the new one.
     this.sessionManager.onSessionDeviceUnbound((sessionId, deviceId) => {
+      NavigationGraphManager.resetSession(sessionId);
       RealObserveScreen.clearCache(deviceId);
       AndroidCtrlProxyClient.getExistingInstance(deviceId)?.releaseSessionBinding(sessionId);
       IOSCtrlProxyClient.getExistingInstance(deviceId)?.releaseSessionBinding(sessionId);

--- a/src/daemon/daemon.ts
+++ b/src/daemon/daemon.ts
@@ -234,6 +234,13 @@ export class Daemon {
       AndroidCtrlProxyClient.getExistingInstance(deviceId)?.releaseSessionBinding(sessionId);
       IOSCtrlProxyClient.getExistingInstance(deviceId)?.releaseSessionBinding(sessionId);
     });
+    // Moving a live session must clear only the old device's observation and
+    // CtrlProxy binding. Session-wide cleanup belongs exclusively to release.
+    this.sessionManager.onSessionDeviceUnbound((sessionId, deviceId) => {
+      RealObserveScreen.clearCache(deviceId);
+      AndroidCtrlProxyClient.getExistingInstance(deviceId)?.releaseSessionBinding(sessionId);
+      IOSCtrlProxyClient.getExistingInstance(deviceId)?.releaseSessionBinding(sessionId);
+    });
     // Emit a real "session released" signal so a connected DaemonMcpProxy clears
     // its remembered session binding the moment the daemon releases the session
     // (heartbeat / idle / plan), rather than guessing with the replay TTL. Fires

--- a/src/daemon/devicePool.ts
+++ b/src/daemon/devicePool.ts
@@ -107,6 +107,11 @@ interface RollbackAssignment {
   session: Session;
 }
 
+type SessionAssignmentSnapshot = Pick<
+  PooledDevice,
+  "sessionId" | "status" | "lastUsedAt" | "assignmentCount" | "errorCount" | "autolockSessionId"
+>;
+
 interface IosLivenessSnapshot {
   discoverySucceeded: boolean;
   bootedDeviceIds: Set<string>;
@@ -2224,6 +2229,34 @@ export class DevicePool {
     });
   }
 
+  private snapshotSessionAssignment(device: PooledDevice): SessionAssignmentSnapshot {
+    return {
+      sessionId: device.sessionId,
+      status: device.status,
+      lastUsedAt: device.lastUsedAt,
+      assignmentCount: device.assignmentCount,
+      errorCount: device.errorCount,
+      autolockSessionId: device.autolockSessionId,
+    };
+  }
+
+  private restoreSessionAssignment(device: PooledDevice, snapshot: SessionAssignmentSnapshot): void {
+    Object.assign(device, snapshot);
+  }
+
+  private async createSessionOrRestore(
+    device: PooledDevice,
+    snapshot: SessionAssignmentSnapshot,
+    createSession: () => Promise<Session>,
+  ): Promise<Session> {
+    try {
+      return await createSession();
+    } catch (error) {
+      this.restoreSessionAssignment(device, snapshot);
+      throw error;
+    }
+  }
+
   /**
    * Release device from session
    *
@@ -2563,6 +2596,7 @@ export class DevicePool {
       );
     }
 
+    const assignmentSnapshot = this.snapshotSessionAssignment(device);
     device.sessionId = sessionId;
     device.status = "busy";
     device.lastUsedAt = this.nextLastUsedAt();
@@ -2740,12 +2774,14 @@ export class DevicePool {
     // (10s default) would reap the lock far sooner than the configured idle timeout.
     // Interactions still bump lastHeartbeat, so an active client stays locked while
     // a truly idle one is released after the idle timeout.
-    const session = await this.sessionManager.createSession(
-      sessionId,
-      deviceId,
-      platform,
-      timeoutMs,
-      timeoutMs,
+    const session = await this.createSessionOrRestore(device, assignmentSnapshot, () =>
+      this.sessionManager.createSession(
+        sessionId,
+        deviceId,
+        platform,
+        timeoutMs,
+        timeoutMs,
+      ),
     );
     if (mcpSessionId) {
       this.mcpSessionAutolockMap.set(mcpSessionId, sessionId);

--- a/src/daemon/devicePool.ts
+++ b/src/daemon/devicePool.ts
@@ -2596,7 +2596,6 @@ export class DevicePool {
       );
     }
 
-    const assignmentSnapshot = this.snapshotSessionAssignment(device);
     device.sessionId = sessionId;
     device.status = "busy";
     device.lastUsedAt = this.nextLastUsedAt();
@@ -2762,6 +2761,7 @@ export class DevicePool {
       );
     }
 
+    const assignmentSnapshot = this.snapshotSessionAssignment(device);
     device.sessionId = sessionId;
     device.status = "busy";
     device.lastUsedAt = this.nextLastUsedAt();

--- a/src/daemon/devicePool.ts
+++ b/src/daemon/devicePool.ts
@@ -2288,10 +2288,24 @@ export class DevicePool {
     );
   }
 
-  private async rollbackAssignedSessions(assignments: ReadonlyMap<string, string>): Promise<void> {
+  private async rollbackAssignedSessions(
+    assignments: ReadonlyMap<string, string>,
+    assignedSessions: ReadonlyMap<string, Session>,
+  ): Promise<void> {
     for (const [sessionId, deviceId] of assignments) {
-      await this.sessionManager.releaseSession(sessionId);
-      await this.releaseDevice(deviceId, sessionId);
+      const session = assignedSessions.get(sessionId);
+      if (!session) {
+        continue;
+      }
+      const releasedDeviceId = await this.sessionManager.releaseSessionIfOwned(
+        sessionId,
+        session,
+        deviceId,
+        "batch-allocation-rollback",
+      );
+      if (releasedDeviceId === deviceId && !this.sessionManager.getSession(sessionId)) {
+        await this.releaseDevice(deviceId, sessionId);
+      }
     }
   }
 

--- a/src/daemon/devicePool.ts
+++ b/src/daemon/devicePool.ts
@@ -2256,14 +2256,11 @@ export class DevicePool {
     const attemptedSessionId = device.sessionId;
     try {
       const session = await createSession();
+      await this.sessionManager.waitForSessionRelease(session.sessionId);
       // A tracked process can exit while the durable session write is pending.
       // Do not publish success for a device that eviction already removed or
       // released; undo the just-published session before restoring the pool.
-      if (
-        this.devices.get(device.id) !== device ||
-        device.sessionId !== session.sessionId ||
-        device.status !== "busy"
-      ) {
+      if (!this.isSessionAssignmentCurrent(device, session)) {
         await this.sessionManager.releaseSession(
           session.sessionId,
           `device-disconnected-during-session-create:${device.id}`,
@@ -2277,6 +2274,15 @@ export class DevicePool {
       }
       throw error;
     }
+  }
+
+  private isSessionAssignmentCurrent(device: PooledDevice, session: Session): boolean {
+    return (
+      this.devices.get(device.id) === device &&
+      device.sessionId === session.sessionId &&
+      device.status === "busy" &&
+      this.sessionManager.getSession(session.sessionId) === session
+    );
   }
 
   private async rollbackAssignedSessions(assignments: ReadonlyMap<string, string>): Promise<void> {
@@ -2604,40 +2610,40 @@ export class DevicePool {
         device.status = "idle";
       }
 
-      await this.claimKnownDeviceForSession(sessionId, device, platform);
+      const assignmentSnapshot = this.snapshotSessionAssignment(device);
+      const previousSession = this.sessionManager.getSession(sessionId);
+      device.sessionId = sessionId;
+      device.status = "busy";
+      device.lastUsedAt = this.nextLastUsedAt();
+      device.assignmentCount++;
+      device.errorCount = 0;
 
+      await this.createSessionOrRestore(
+        device,
+        assignmentSnapshot,
+        this.createSessionForBinding(previousSession, sessionId, deviceId, platform),
+      );
       logger.info(`Bound device ${deviceId} to session ${sessionId}`);
       return sessionId;
     });
   }
 
-  private async claimKnownDeviceForSession(
+  private createSessionForBinding(
+    previousSession: Session | null,
     sessionId: string,
-    device: PooledDevice,
+    deviceId: string,
     platform: Platform,
-  ): Promise<void> {
-    // Create the session before claiming the device so a session created by
-    // the automatic allocator cannot leave this device reserved as well.
-    const previousSession = this.sessionManager.getSession(sessionId);
+  ): () => Promise<Session> {
     const previousDeviceId = previousSession?.assignedDevice;
-    const session = previousSession && previousDeviceId !== device.id
-      ? await this.sessionManager.rebindSession(sessionId, device.id, platform)
-      : await this.sessionManager.createSession(sessionId, device.id, platform);
-    if (session.assignedDevice !== device.id) {
-      throw new ActionableError(
-        `Session '${sessionId}' is already assigned to device '${session.assignedDevice}'.`,
-      );
+    if (!previousDeviceId || previousDeviceId === deviceId) {
+      return async () => await this.sessionManager.createSession(sessionId, deviceId, platform);
     }
 
-    device.sessionId = sessionId;
-    device.status = "busy";
-    device.lastUsedAt = this.nextLastUsedAt();
-    device.assignmentCount++;
-    device.errorCount = 0;
-
-    if (previousDeviceId && previousDeviceId !== device.id) {
-      await this.releaseDevice(previousDeviceId, sessionId);
-    }
+    return async () => {
+      const session = await this.sessionManager.rebindSession(sessionId, deviceId, platform);
+      await this.releaseDevice(previousDeviceId);
+      return session;
+    };
   }
 
   private async reuseExistingDeviceSession(

--- a/src/daemon/devicePool.ts
+++ b/src/daemon/devicePool.ts
@@ -953,6 +953,9 @@ export class DevicePool {
       if (result.error instanceof DevicePoolError && !result.error.isRetryable) {
         throw new ActionableError(result.error.message);
       }
+      if (result.error && !(result.error instanceof DevicePoolError && result.error.isRetryable)) {
+        throw result.error;
+      }
 
       // Timeout case
       const elapsed = this.timer.now() - startTime;
@@ -2258,6 +2261,13 @@ export class DevicePool {
     }
   }
 
+  private async rollbackAssignedSessions(assignments: ReadonlyMap<string, string>): Promise<void> {
+    for (const [sessionId, deviceId] of assignments) {
+      await this.sessionManager.releaseSession(sessionId);
+      await this.releaseDevice(deviceId);
+    }
+  }
+
   /**
    * Release device from session
    *
@@ -2590,7 +2600,11 @@ export class DevicePool {
   ): Promise<void> {
     // Create the session before claiming the device so a session created by
     // the automatic allocator cannot leave this device reserved as well.
-    const session = await this.sessionManager.createSession(sessionId, device.id, platform);
+    const previousSession = this.sessionManager.getSession(sessionId);
+    const previousDeviceId = previousSession?.assignedDevice;
+    const session = previousSession && previousDeviceId !== device.id
+      ? await this.sessionManager.rebindSession(sessionId, device.id, platform)
+      : await this.sessionManager.createSession(sessionId, device.id, platform);
     if (session.assignedDevice !== device.id) {
       throw new ActionableError(
         `Session '${sessionId}' is already assigned to device '${session.assignedDevice}'.`,
@@ -2602,6 +2616,10 @@ export class DevicePool {
     device.lastUsedAt = this.nextLastUsedAt();
     device.assignmentCount++;
     device.errorCount = 0;
+
+    if (previousDeviceId && previousDeviceId !== device.id) {
+      await this.releaseDevice(previousDeviceId, sessionId);
+    }
   }
 
   private async reuseExistingDeviceSession(

--- a/src/daemon/devicePool.ts
+++ b/src/daemon/devicePool.ts
@@ -2253,10 +2253,28 @@ export class DevicePool {
     snapshot: SessionAssignmentSnapshot,
     createSession: () => Promise<Session>,
   ): Promise<Session> {
+    const attemptedSessionId = device.sessionId;
     try {
-      return await createSession();
+      const session = await createSession();
+      // A tracked process can exit while the durable session write is pending.
+      // Do not publish success for a device that eviction already removed or
+      // released; undo the just-published session before restoring the pool.
+      if (
+        this.devices.get(device.id) !== device ||
+        device.sessionId !== session.sessionId ||
+        device.status !== "busy"
+      ) {
+        await this.sessionManager.releaseSession(
+          session.sessionId,
+          `device-disconnected-during-session-create:${device.id}`,
+        );
+        throw new ActionableError(`Device '${device.id}' disconnected while its session was being created.`);
+      }
+      return session;
     } catch (error) {
-      this.restoreSessionAssignment(device, snapshot);
+      if (this.devices.get(device.id) === device && device.sessionId === attemptedSessionId) {
+        this.restoreSessionAssignment(device, snapshot);
+      }
       throw error;
     }
   }

--- a/src/daemon/devicePool.ts
+++ b/src/daemon/devicePool.ts
@@ -1816,6 +1816,9 @@ export class DevicePool {
       if (result.error instanceof DevicePoolError && !result.error.isRetryable) {
         throw new ActionableError(result.error.message);
       }
+      if (result.error && !(result.error instanceof DevicePoolError && result.error.isRetryable)) {
+        throw result.error;
+      }
       // Timeout case - all attempts exhausted
       const stats = this.getStatsForPlatform(platform);
       throw new ActionableError(
@@ -1911,10 +1914,8 @@ export class DevicePool {
       let selection = await this.selectAssignableIdleDevice(candidates);
       let device = selection.device;
       livenessUnknown ||= selection.livenessUnknown;
-      if (!device) {
-        candidates = selectCandidates();
-        totalDevices = candidates.length;
-      }
+      candidates = selectCandidates();
+      totalDevices = candidates.length;
 
       // If no devices available and pool is empty, try to refresh
       // This handles race conditions during daemon startup

--- a/src/daemon/devicePool.ts
+++ b/src/daemon/devicePool.ts
@@ -2297,13 +2297,14 @@ export class DevicePool {
       if (!session) {
         continue;
       }
-      const releasedDeviceId = await this.sessionManager.releaseSessionIfOwned(
+      await this.sessionManager.releaseSessionIfOwned(
         sessionId,
         session,
         deviceId,
         "batch-allocation-rollback",
       );
-      if (releasedDeviceId === deviceId && !this.sessionManager.getSession(sessionId)) {
+      const currentSession = this.sessionManager.getSession(sessionId);
+      if (!currentSession || currentSession.assignedDevice !== deviceId) {
         await this.releaseDevice(deviceId, sessionId);
       }
     }

--- a/src/daemon/devicePool.ts
+++ b/src/daemon/devicePool.ts
@@ -2259,6 +2259,12 @@ export class DevicePool {
         }
         return session;
       }
+      const currentSession = this.sessionManager.getSession(session.sessionId);
+      if (currentSession !== session && currentSession?.assignedDevice === device.id) {
+        // The attempted incarnation was replaced while its write completed.
+        // Return the attempted object so rollback can preserve the replacement.
+        return session;
+      }
       await this.sessionManager.waitForSessionRelease(session.sessionId);
       // A tracked process can exit while the durable session write is pending.
       // Do not publish success for a device that eviction already removed or
@@ -2286,28 +2292,6 @@ export class DevicePool {
       device.status === "busy" &&
       this.sessionManager.getSession(session.sessionId) === session
     );
-  }
-
-  private async rollbackAssignedSessions(
-    assignments: ReadonlyMap<string, string>,
-    assignedSessions: ReadonlyMap<string, Session>,
-  ): Promise<void> {
-    for (const [sessionId, deviceId] of assignments) {
-      const session = assignedSessions.get(sessionId);
-      if (!session) {
-        continue;
-      }
-      await this.sessionManager.releaseSessionIfOwned(
-        sessionId,
-        session,
-        deviceId,
-        "batch-allocation-rollback",
-      );
-      const currentSession = this.sessionManager.getSession(sessionId);
-      if (!currentSession || currentSession.assignedDevice !== deviceId) {
-        await this.releaseDevice(deviceId, sessionId);
-      }
-    }
   }
 
   /**

--- a/src/daemon/devicePool.ts
+++ b/src/daemon/devicePool.ts
@@ -2025,23 +2025,20 @@ export class DevicePool {
     sessionId: string,
     device: PooledDevice,
   ): Promise<{ deviceId: string; session?: Session }> {
-    // Create the session before claiming the device. A direct binding can
-    // create the same session while this allocator waits for the mutex; in
-    // that case, its device remains the sole owner.
     const existingSession = this.sessionManager.getSession(sessionId);
-    const session = await this.sessionManager.createSession(sessionId, device.id, device.platform);
-    if (session.assignedDevice !== device.id) {
-      logger.info(
-        `Reusing session ${sessionId} already assigned to device ${session.assignedDevice}`,
-      );
-      return { deviceId: session.assignedDevice };
-    }
-
+    const assignmentSnapshot = this.snapshotSessionAssignment(device);
     device.sessionId = sessionId;
     device.status = "busy";
     device.lastUsedAt = this.nextLastUsedAt();
     device.assignmentCount++;
     device.errorCount = 0;
+    const session = await this.createSessionOrRestore(device, assignmentSnapshot, () =>
+      this.sessionManager.createSession(sessionId, device.id, device.platform),
+    );
+    if (session.assignedDevice !== device.id) {
+      this.restoreSessionAssignment(device, assignmentSnapshot);
+      return { deviceId: session.assignedDevice };
+    }
     return existingSession === session ? { deviceId: device.id } : { deviceId: device.id, session };
   }
 
@@ -2256,6 +2253,12 @@ export class DevicePool {
     const attemptedSessionId = device.sessionId;
     try {
       const session = await createSession();
+      if (session.assignedDevice !== device.id) {
+        if (this.devices.get(device.id) === device && device.sessionId === attemptedSessionId) {
+          this.restoreSessionAssignment(device, snapshot);
+        }
+        return session;
+      }
       await this.sessionManager.waitForSessionRelease(session.sessionId);
       // A tracked process can exit while the durable session write is pending.
       // Do not publish success for a device that eviction already removed or
@@ -2288,7 +2291,7 @@ export class DevicePool {
   private async rollbackAssignedSessions(assignments: ReadonlyMap<string, string>): Promise<void> {
     for (const [sessionId, deviceId] of assignments) {
       await this.sessionManager.releaseSession(sessionId);
-      await this.releaseDevice(deviceId);
+      await this.releaseDevice(deviceId, sessionId);
     }
   }
 
@@ -2543,6 +2546,7 @@ export class DevicePool {
     sourceImage?: DeviceInfo,
     childProcess?: ChildProcess | null,
     expectedIdentity?: Pick<BootedDevice, "deviceId" | "name" | "platform">,
+    allowSessionRebind = false,
   ): Promise<string> {
     return await this.assignmentMutex.runExclusive(async () => {
       const alreadyPooled = this.devices.has(deviceId);
@@ -2621,7 +2625,13 @@ export class DevicePool {
       await this.createSessionOrRestore(
         device,
         assignmentSnapshot,
-        this.createSessionForBinding(previousSession, sessionId, deviceId, platform),
+        this.createSessionForBinding(
+          previousSession,
+          sessionId,
+          deviceId,
+          platform,
+          allowSessionRebind,
+        ),
       );
       logger.info(`Bound device ${deviceId} to session ${sessionId}`);
       return sessionId;
@@ -2633,15 +2643,24 @@ export class DevicePool {
     sessionId: string,
     deviceId: string,
     platform: Platform,
+    allowSessionRebind: boolean,
   ): () => Promise<Session> {
     const previousDeviceId = previousSession?.assignedDevice;
     if (!previousDeviceId || previousDeviceId === deviceId) {
       return async () => await this.sessionManager.createSession(sessionId, deviceId, platform);
     }
 
+    if (!allowSessionRebind) {
+      return async () => {
+        throw new ActionableError(
+          `Session '${sessionId}' is already assigned to device '${previousDeviceId}'.`,
+        );
+      };
+    }
+
     return async () => {
       const session = await this.sessionManager.rebindSession(sessionId, deviceId, platform);
-      await this.releaseDevice(previousDeviceId);
+      await this.releaseDevice(previousDeviceId, sessionId);
       return session;
     };
   }

--- a/src/daemon/sessionManager.ts
+++ b/src/daemon/sessionManager.ts
@@ -237,7 +237,12 @@ export class SessionManager {
     try {
       await this.persistSession(session);
     } catch (error) {
-      this.removeSession(sessionId);
+      // A release may have completed and the UUID may have been reused while
+      // the persistence write was pending. Only roll back the session instance
+      // that issued this write; removing by ID alone would delete its replacement.
+      if (this.sessions.get(sessionId) === session) {
+        this.removeSession(sessionId);
+      }
       throw error;
     }
 

--- a/src/daemon/sessionManager.ts
+++ b/src/daemon/sessionManager.ts
@@ -148,6 +148,8 @@ export class SessionManager {
   private readonly pendingDeviceCleanups: Map<string, Promise<void>> = new Map();
   /** Creation writes that must finish before a session becomes visible to callers. */
   private readonly pendingSessionCreations: Map<string, PendingSessionCreation> = new Map();
+  /** Releases received before a creation write has published its session. */
+  private readonly pendingCreationReleasePromises: Map<string, Promise<string | null>> = new Map();
   /** Rebinds that a release must await before it can remove the live binding. */
   private readonly pendingSessionRebinds: Map<string, PendingSessionRebind> = new Map();
   private deviceSessionRepository: DeviceSessionPersistence;
@@ -522,8 +524,7 @@ export class SessionManager {
       if (inFlightRelease) {
         return await inFlightRelease.promise;
       }
-      logger.warn(`Cannot release session ${sessionId}: not found`);
-      return null;
+      return await this.releasePendingSessionCreation(sessionId, releaseReason, allowExpired);
     }
 
     const inFlightRelease = this.releasePromises.get(sessionId);
@@ -549,6 +550,53 @@ export class SessionManager {
       if (this.releasePromises.get(sessionId) === release) {
         this.releasePromises.delete(sessionId);
       }
+    }
+  }
+
+  private async releasePendingSessionCreation(
+    sessionId: string,
+    releaseReason: string,
+    allowExpired: boolean,
+  ): Promise<string | null> {
+    const pendingCreation = this.pendingSessionCreations.get(sessionId);
+    if (!pendingCreation) {
+      logger.warn(`Cannot release session ${sessionId}: not found`);
+      return null;
+    }
+
+    const existingRelease = this.pendingCreationReleasePromises.get(sessionId);
+    if (existingRelease) {
+      return await existingRelease;
+    }
+
+    const release = this.releaseAfterSessionCreation(
+      sessionId,
+      releaseReason,
+      allowExpired,
+      pendingCreation,
+    );
+    this.pendingCreationReleasePromises.set(sessionId, release);
+    try {
+      return await release;
+    } finally {
+      if (this.pendingCreationReleasePromises.get(sessionId) === release) {
+        this.pendingCreationReleasePromises.delete(sessionId);
+      }
+    }
+  }
+
+  private async releaseAfterSessionCreation(
+    sessionId: string,
+    releaseReason: string,
+    allowExpired: boolean,
+    pendingCreation: PendingSessionCreation,
+  ): Promise<string | null> {
+    try {
+      await pendingCreation.promise;
+      return await this.releaseSession(sessionId, releaseReason, allowExpired);
+    } catch (error) {
+      logger.warn(`Session ${sessionId} creation failed before release: ${error}`);
+      return null;
     }
   }
 
@@ -602,6 +650,21 @@ export class SessionManager {
       }
     }
   }
+
+  /** Wait for a release already admitted for this session, if any. */
+  async waitForSessionRelease(sessionId: string): Promise<void> {
+    const pendingCreationRelease = this.pendingCreationReleasePromises.get(sessionId);
+    if (pendingCreationRelease) {
+      await pendingCreationRelease;
+      return;
+    }
+
+    const release = this.releasePromises.get(sessionId);
+    if (release) {
+      await release.promise;
+    }
+  }
+
   private async releaseSessionInternal(
     sessionId: string,
     session: Session,

--- a/src/daemon/sessionManager.ts
+++ b/src/daemon/sessionManager.ts
@@ -95,6 +95,17 @@ export interface ActiveSessionExecutionQuery {
 
 export type ActiveSessionExecutionChecker = (sessionId: string, query?: ActiveSessionExecutionQuery) => boolean;
 
+export type SessionDeviceUnboundCallback = (sessionId: string, deviceId: string) => void;
+
+interface PendingSessionCreation {
+  promise: Promise<Session>;
+}
+
+interface PendingSessionRebind {
+  session: Session;
+  promise: Promise<Session>;
+}
+
 export interface SessionDeviceAssigner {
   assignDeviceToSession(sessionId: string, platform?: Platform): Promise<string>;
 }
@@ -118,6 +129,7 @@ export class SessionManager {
   private cleanupTimer: NodeJS.Timeout | null = null;
   private timer: Timer;
   private releaseCallbacks: SessionReleaseCallback[] = [];
+  private deviceUnboundCallbacks: SessionDeviceUnboundCallback[] = [];
   private readonly releasePromises: Map<
     string,
     { session: Session; promise: Promise<string | null> }
@@ -135,7 +147,9 @@ export class SessionManager {
   */
   private readonly pendingDeviceCleanups: Map<string, Promise<void>> = new Map();
   /** Creation writes that must finish before a session becomes visible to callers. */
-  private readonly pendingSessionCreations: Map<string, Promise<Session>> = new Map();
+  private readonly pendingSessionCreations: Map<string, PendingSessionCreation> = new Map();
+  /** Rebinds that a release must await before it can remove the live binding. */
+  private readonly pendingSessionRebinds: Map<string, PendingSessionRebind> = new Map();
   private deviceSessionRepository: DeviceSessionPersistence;
   private readonly getBarrier: () => DbWriteBarrier;
   private readonly keepScreenAwakeRestorerFactory: (device: BootedDevice) => KeepScreenAwakeRestorer;
@@ -197,6 +211,15 @@ export class SessionManager {
   }
 
   /**
+    * Register cleanup for a device a session stopped using without ending that
+    * session. This intentionally excludes session-wide cleanup and transport
+    * unbinding, which must remain attached to a real session release.
+   */
+  onSessionDeviceUnbound(callback: SessionDeviceUnboundCallback): void {
+    this.deviceUnboundCallbacks.push(callback);
+  }
+
+  /**
    * Create a new session with an assigned device
    *
    * This is called by the daemon when a session UUID is first used.
@@ -216,7 +239,7 @@ export class SessionManager {
 
     const pendingCreation = this.pendingSessionCreations.get(sessionId);
     if (pendingCreation) {
-      return await pendingCreation;
+      return await pendingCreation.promise;
     }
 
     const now = this.timer.now();
@@ -237,10 +260,10 @@ export class SessionManager {
       hasReceivedHeartbeat: false,
     };
 
-    const creation = this.persistAndPublishSession(session);
+    const creation: PendingSessionCreation = { promise: this.persistAndPublishSession(session) };
     this.pendingSessionCreations.set(sessionId, creation);
     try {
-      return await creation;
+      return await creation.promise;
     } finally {
       if (this.pendingSessionCreations.get(sessionId) === creation) {
         this.pendingSessionCreations.delete(sessionId);
@@ -350,7 +373,7 @@ export class SessionManager {
 
     const pendingCreation = this.pendingSessionCreations.get(sessionId);
     if (pendingCreation) {
-      return await pendingCreation;
+      return await pendingCreation.promise;
     }
 
     const creation = this.createUnseenSession(sessionId, devicePool, platform).finally(() => {
@@ -404,16 +427,60 @@ export class SessionManager {
       return existing;
     }
 
-    const replacement: Session = { ...existing, assignedDevice, platform };
+    const pendingRebind = this.pendingSessionRebinds.get(sessionId);
+    if (pendingRebind) {
+      await pendingRebind.promise;
+      return await this.rebindSession(sessionId, assignedDevice, platform);
+    }
+
+    const inFlightRelease = this.releasePromises.get(sessionId);
+    if (inFlightRelease?.session === existing) {
+      await inFlightRelease.promise;
+      throw new Error(`Cannot rebind released session ${sessionId}.`);
+    }
+
+    const promise = this.persistAndPublishRebind(existing, assignedDevice, platform);
+    const rebind = { session: existing, promise };
+    this.pendingSessionRebinds.set(sessionId, rebind);
+    try {
+      return await promise;
+    } finally {
+      if (this.pendingSessionRebinds.get(sessionId) === rebind) {
+        this.pendingSessionRebinds.delete(sessionId);
+      }
+    }
+  }
+
+  private async persistAndPublishRebind(
+    existing: Session,
+    assignedDevice: string,
+    platform: Platform,
+  ): Promise<Session> {
+    const replacement: Session = {
+      ...existing,
+      assignedDevice,
+      platform,
+      cacheData: {},
+    };
     await this.persistSession(replacement);
 
-    this.sessions.set(sessionId, replacement);
-    this.sessionDeviceMap.set(sessionId, assignedDevice);
-    if (this.deviceSessionMap.get(existing.assignedDevice) === sessionId) {
-      this.deviceSessionMap.delete(existing.assignedDevice);
+    try {
+      await this.restoreKeepScreenAwake(existing);
+    } catch (error) {
+      logger.warn(`Failed to restore keep-awake state for rebound session ${existing.sessionId}: ${error}`);
     }
-    this.deviceSessionMap.set(assignedDevice, sessionId);
-    return replacement;
+
+    const previousDevice = existing.assignedDevice;
+    // Preserve object identity so an already-started release observes the
+    // rebinding and frees its live replacement rather than a stale snapshot.
+    Object.assign(existing, replacement);
+    this.sessionDeviceMap.set(existing.sessionId, assignedDevice);
+    if (this.deviceSessionMap.get(previousDevice) === existing.sessionId) {
+      this.deviceSessionMap.delete(previousDevice);
+    }
+    this.deviceSessionMap.set(assignedDevice, existing.sessionId);
+    this.notifySessionDeviceUnbound(existing.sessionId, previousDevice);
+    return existing;
   }
 
   /**
@@ -465,7 +532,13 @@ export class SessionManager {
     }
 
     this.releasingSessions.add(session);
-    const promise = this.releaseSessionInternal(sessionId, session, releaseReason);
+    const pendingRebind = this.pendingSessionRebinds.get(sessionId);
+    const promise = pendingRebind?.session === session
+      ? pendingRebind.promise.then(
+        () => this.releaseSessionInternal(sessionId, session, releaseReason),
+        () => this.releaseSessionInternal(sessionId, session, releaseReason),
+      )
+      : this.releaseSessionInternal(sessionId, session, releaseReason);
     const release = { session, promise };
     this.releasePromises.set(sessionId, release);
     this.activeReleasePromises.add(release);
@@ -641,6 +714,16 @@ export class SessionManager {
         this.pendingDeviceCleanups.delete(deviceId);
       }
     });
+  }
+
+  private notifySessionDeviceUnbound(sessionId: string, deviceId: string): void {
+    for (const callback of this.deviceUnboundCallbacks) {
+      try {
+        callback(sessionId, deviceId);
+      } catch (error) {
+        logger.warn(`Session device-unbound callback failed for ${sessionId}: ${error}`);
+      }
+    }
   }
 
   /**
@@ -884,7 +967,9 @@ export class SessionManager {
     if (!session || (expectedSession && session !== expectedSession)) {
       return false;
     }
-    this.deviceSessionMap.delete(session.assignedDevice);
+    if (this.deviceSessionMap.get(session.assignedDevice) === sessionId) {
+      this.deviceSessionMap.delete(session.assignedDevice);
+    }
     this.sessions.delete(sessionId);
     this.sessionDeviceMap.delete(sessionId);
     return true;

--- a/src/daemon/sessionManager.ts
+++ b/src/daemon/sessionManager.ts
@@ -115,7 +115,6 @@ export class SessionManager {
   private sessions: Map<string, Session> = new Map();
   private sessionDeviceMap: Map<string, string> = new Map(); // sessionId -> deviceId
   private deviceSessionMap: Map<string, string> = new Map(); // deviceId -> sessionId (reverse lookup)
-  private pendingSessionCreations: Map<string, Promise<Session>> = new Map();
   private cleanupTimer: NodeJS.Timeout | null = null;
   private timer: Timer;
   private releaseCallbacks: SessionReleaseCallback[] = [];
@@ -130,11 +129,13 @@ export class SessionManager {
   /** Sessions whose teardown has closed admission for further device-state setup. */
   private readonly releasingSessions: WeakSet<Session> = new WeakSet();
   /**
-   * Device work that outlived its bounded release phase. The pool keeps the
-   * device assigned until this settles, so no replacement session can race a
+    * Device work that outlived its bounded release phase. The pool keeps the
+    * device assigned until this settles, so no replacement session can race a
    * late setup or keep-awake restore.
-   */
+  */
   private readonly pendingDeviceCleanups: Map<string, Promise<void>> = new Map();
+  /** Creation writes that must finish before a session becomes visible to callers. */
+  private readonly pendingSessionCreations: Map<string, Promise<Session>> = new Map();
   private deviceSessionRepository: DeviceSessionPersistence;
   private readonly getBarrier: () => DbWriteBarrier;
   private readonly keepScreenAwakeRestorerFactory: (device: BootedDevice) => KeepScreenAwakeRestorer;
@@ -213,6 +214,11 @@ export class SessionManager {
       return this.sessions.get(sessionId)!;
     }
 
+    const pendingCreation = this.pendingSessionCreations.get(sessionId);
+    if (pendingCreation) {
+      return await pendingCreation;
+    }
+
     const now = this.timer.now();
     const sessionTimeoutMs = timeoutMs ?? this.SESSION_TIMEOUT_MS;
     const heartbeatTimeoutSource = heartbeatTimeoutMs === undefined ? "default" : "custom";
@@ -231,22 +237,23 @@ export class SessionManager {
       hasReceivedHeartbeat: false,
     };
 
-    this.sessions.set(sessionId, session);
-    this.sessionDeviceMap.set(sessionId, assignedDevice);
-    this.deviceSessionMap.set(assignedDevice, sessionId);
+    const creation = this.persistAndPublishSession(session);
+    this.pendingSessionCreations.set(sessionId, creation);
     try {
-      await this.persistSession(session);
-    } catch (error) {
-      // A release may have completed and the UUID may have been reused while
-      // the persistence write was pending. Only roll back the session instance
-      // that issued this write; removing by ID alone would delete its replacement.
-      if (this.sessions.get(sessionId) === session) {
-        this.removeSession(sessionId);
+      return await creation;
+    } finally {
+      if (this.pendingSessionCreations.get(sessionId) === creation) {
+        this.pendingSessionCreations.delete(sessionId);
       }
-      throw error;
     }
+  }
 
-    logger.info(`Created session ${sessionId} with device ${assignedDevice}`);
+  private async persistAndPublishSession(session: Session): Promise<Session> {
+    await this.persistSession(session);
+    this.sessions.set(session.sessionId, session);
+    this.sessionDeviceMap.set(session.sessionId, session.assignedDevice);
+    this.deviceSessionMap.set(session.assignedDevice, session.sessionId);
+    logger.info(`Created session ${session.sessionId} with device ${session.assignedDevice}`);
     return session;
   }
 

--- a/src/daemon/sessionManager.ts
+++ b/src/daemon/sessionManager.ts
@@ -391,6 +391,31 @@ export class SessionManager {
     return session;
   }
 
+  async rebindSession(
+    sessionId: string,
+    assignedDevice: string,
+    platform: Platform,
+  ): Promise<Session> {
+    const existing = this.sessions.get(sessionId);
+    if (!existing) {
+      return await this.createSession(sessionId, assignedDevice, platform);
+    }
+    if (existing.assignedDevice === assignedDevice) {
+      return existing;
+    }
+
+    const replacement: Session = { ...existing, assignedDevice, platform };
+    await this.persistSession(replacement);
+
+    this.sessions.set(sessionId, replacement);
+    this.sessionDeviceMap.set(sessionId, assignedDevice);
+    if (this.deviceSessionMap.get(existing.assignedDevice) === sessionId) {
+      this.deviceSessionMap.delete(existing.assignedDevice);
+    }
+    this.deviceSessionMap.set(assignedDevice, sessionId);
+    return replacement;
+  }
+
   /**
    * Get device assigned to a session
    */

--- a/src/daemon/sessionManager.ts
+++ b/src/daemon/sessionManager.ts
@@ -2,7 +2,7 @@ import { defaultTimer, Timer } from "../utils/SystemTimer";
 import { logger } from "../utils/logger";
 import { BootedDevice, Platform } from "../models";
 import { KeepScreenAwakeManager, KeepScreenAwakeState } from "../utils/KeepScreenAwakeManager";
-import { DeviceSessionRepository } from "../db/deviceSessionRepository";
+import { DeviceSessionRepository, type DeviceSessionPersistence } from "../db/deviceSessionRepository";
 import { type DbWriteBarrier, getDbWriteBarrier } from "../db/dbWriteBarrier";
 import type { ViewHierarchyResult } from "../models/ViewHierarchyResult";
 import type { ObserveResult } from "../models/ObserveResult";
@@ -135,7 +135,7 @@ export class SessionManager {
    * late setup or keep-awake restore.
    */
   private readonly pendingDeviceCleanups: Map<string, Promise<void>> = new Map();
-  private deviceSessionRepository: DeviceSessionRepository;
+  private deviceSessionRepository: DeviceSessionPersistence;
   private readonly getBarrier: () => DbWriteBarrier;
   private readonly keepScreenAwakeRestorerFactory: (device: BootedDevice) => KeepScreenAwakeRestorer;
   private activeSessionExecutionChecker: ActiveSessionExecutionChecker = () => false;
@@ -150,7 +150,7 @@ export class SessionManager {
 
   constructor(
     timer: Timer = defaultTimer,
-    deviceSessionRepository: DeviceSessionRepository = new DeviceSessionRepository(),
+    deviceSessionRepository: DeviceSessionPersistence = new DeviceSessionRepository(),
     // Resolve the shared barrier per write, not once at construction, so a
     // same-process DB reopen (resetDbWriteBarrier swaps in a fresh barrier) is
     // seen instead of a pinned drained instance (issue #2912). Because the barrier
@@ -234,7 +234,12 @@ export class SessionManager {
     this.sessions.set(sessionId, session);
     this.sessionDeviceMap.set(sessionId, assignedDevice);
     this.deviceSessionMap.set(assignedDevice, sessionId);
-    await this.persistSession(session);
+    try {
+      await this.persistSession(session);
+    } catch (error) {
+      this.removeSession(sessionId);
+      throw error;
+    }
 
     logger.info(`Created session ${sessionId} with device ${assignedDevice}`);
     return session;
@@ -510,7 +515,11 @@ export class SessionManager {
       }
       if (pendingCleanup.length > 0) {this.trackPendingDeviceCleanup(deviceId, pendingCleanup);}
 
-      await this.deviceSessionRepository.markReleased(sessionId, "released", this.timer.now(), releaseReason);
+      try {
+        await this.deviceSessionRepository.markReleased(sessionId, "released", this.timer.now(), releaseReason);
+      } catch (error) {
+        logger.warn(`[SessionManager] Failed to mark session released (${releaseReason}): ${error}`);
+      }
       for (const callback of this.releaseCallbacks) {
         try {
           callback(sessionId, deviceId);

--- a/src/daemon/sessionManager.ts
+++ b/src/daemon/sessionManager.ts
@@ -101,6 +101,10 @@ interface PendingSessionCreation {
   promise: Promise<Session>;
 }
 
+interface PendingSessionRelease {
+  promise: Promise<string | null>;
+}
+
 interface PendingSessionRebind {
   session: Session;
   promise: Promise<Session>;
@@ -151,7 +155,7 @@ export class SessionManager {
   /** Automatic device assignments that have not yet started their creation write. */
   private readonly pendingSessionAssignments: Map<string, Promise<Session>> = new Map();
   /** Releases received before a creation write has published its session. */
-  private readonly pendingCreationReleasePromises: Map<string, Promise<string | null>> = new Map();
+  private readonly pendingCreationReleases: Map<string, PendingSessionRelease> = new Map();
   /** Rebinds that a release must await before it can remove the live binding. */
   private readonly pendingSessionRebinds: Map<string, PendingSessionRebind> = new Map();
   private deviceSessionRepository: DeviceSessionPersistence;
@@ -585,23 +589,25 @@ export class SessionManager {
       return null;
     }
 
-    const existingRelease = this.pendingCreationReleasePromises.get(sessionId);
+    const existingRelease = this.pendingCreationReleases.get(sessionId);
     if (existingRelease) {
-      return await existingRelease;
+      return await existingRelease.promise;
     }
 
-    const release = this.releaseAfterSessionCreation(
-      sessionId,
-      releaseReason,
-      allowExpired,
-      pendingCreation,
-    );
-    this.pendingCreationReleasePromises.set(sessionId, release);
+    const release: PendingSessionRelease = {
+      promise: this.releaseAfterSessionCreation(
+        sessionId,
+        releaseReason,
+        allowExpired,
+        pendingCreation,
+      ),
+    };
+    this.pendingCreationReleases.set(sessionId, release);
     try {
-      return await release;
+      return await release.promise;
     } finally {
-      if (this.pendingCreationReleasePromises.get(sessionId) === release) {
-        this.pendingCreationReleasePromises.delete(sessionId);
+      if (this.pendingCreationReleases.get(sessionId) === release) {
+        this.pendingCreationReleases.delete(sessionId);
       }
     }
   }
@@ -674,9 +680,9 @@ export class SessionManager {
 
   /** Wait for a release already admitted for this session, if any. */
   async waitForSessionRelease(sessionId: string): Promise<void> {
-    const pendingCreationRelease = this.pendingCreationReleasePromises.get(sessionId);
+    const pendingCreationRelease = this.pendingCreationReleases.get(sessionId);
     if (pendingCreationRelease) {
-      await pendingCreationRelease;
+      await pendingCreationRelease.promise;
       return;
     }
 

--- a/src/daemon/sessionManager.ts
+++ b/src/daemon/sessionManager.ts
@@ -310,14 +310,15 @@ export class SessionManager {
     execution?: SessionExecutionMetadata,
   ): Session | null {
     const session = this.sessions.get(sessionId);
-    if (session && expireDespiteActiveExecution && this.isLateExecutionWhileEarlierWorkIsActive(session, execution)) {
+    if (!session) {
+      return null;
+    }
+    if (expireDespiteActiveExecution && this.isLateExecutionWhileEarlierWorkIsActive(session, execution)) {
       throw new Error(
         `Session ${sessionId} expired before this execution began while earlier work is still active.`,
       );
     }
-    if (session && (expireDespiteActiveExecution
-      ? this.isSessionExpiredForNewExecution(session, execution)
-      : this.isSessionExpired(session))) {
+    if (this.shouldExpireSession(session, expireDespiteActiveExecution, execution)) {
       // Release owns this exact session object until it has restored device state
       // and removed its assignment. Keep expiry cleanup from creating a second
       // incarnation with the same UUID before teardown completes.
@@ -347,7 +348,17 @@ export class SessionManager {
       }
       return null;
     }
-    return session || null;
+    return session;
+  }
+
+  private shouldExpireSession(
+    session: Session,
+    expireDespiteActiveExecution: boolean,
+    execution?: SessionExecutionMetadata,
+  ): boolean {
+    return expireDespiteActiveExecution
+      ? this.isSessionExpiredForNewExecution(session, execution)
+      : this.isSessionExpired(session);
   }
 
   /**

--- a/src/daemon/sessionManager.ts
+++ b/src/daemon/sessionManager.ts
@@ -154,8 +154,8 @@ export class SessionManager {
   private readonly pendingSessionCreations: Map<string, PendingSessionCreation> = new Map();
   /** Automatic device assignments that have not yet started their creation write. */
   private readonly pendingSessionAssignments: Map<string, Promise<Session>> = new Map();
-  /** Releases received before a creation write has published its session. */
-  private readonly pendingCreationReleases: Map<string, PendingSessionRelease> = new Map();
+  /** Releases received before an assignment has published its session. */
+  private readonly pendingSessionReleases: Map<string, PendingSessionRelease> = new Map();
   /** Rebinds that a release must await before it can remove the live binding. */
   private readonly pendingSessionRebinds: Map<string, PendingSessionRebind> = new Map();
   private deviceSessionRepository: DeviceSessionPersistence;
@@ -323,6 +323,13 @@ export class SessionManager {
       // incarnation with the same UUID before teardown completes.
       if (this.releasingSessions.has(session)) {
         return session;
+      }
+      if (this.pendingSessionRebinds.get(sessionId)?.session === session) {
+        const release = this.releaseSession(sessionId, "lazy-expiry", true);
+        void this.getBarrier()
+          .trackExisting(release)
+          .catch(error => logger.warn(`[SessionManager] Failed to release expired session ${sessionId}: ${error}`));
+        return null;
       }
       logger.info(`Session ${sessionId} has expired, removing`);
       const deviceId = session.assignedDevice;
@@ -531,11 +538,7 @@ export class SessionManager {
   ): Promise<string | null> {
     const session = allowExpired ? this.sessions.get(sessionId) ?? null : this.getSession(sessionId);
     if (!session) {
-      const inFlightRelease = this.releasePromises.get(sessionId);
-      if (inFlightRelease) {
-        return await inFlightRelease.promise;
-      }
-      return await this.releasePendingSessionCreation(sessionId, releaseReason, allowExpired);
+      return await this.releaseUnpublishedSession(sessionId, releaseReason, allowExpired);
     }
 
     const inFlightRelease = this.releasePromises.get(sessionId);
@@ -578,51 +581,65 @@ export class SessionManager {
     return await this.releaseSession(sessionId, releaseReason);
   }
 
-  private async releasePendingSessionCreation(
+  private async releaseUnpublishedSession(
     sessionId: string,
     releaseReason: string,
     allowExpired: boolean,
   ): Promise<string | null> {
+    const inFlightRelease = this.releasePromises.get(sessionId);
+    if (inFlightRelease) {
+      return await inFlightRelease.promise;
+    }
+    const pendingAssignment = this.pendingSessionAssignments.get(sessionId);
     const pendingCreation = this.pendingSessionCreations.get(sessionId);
-    if (!pendingCreation) {
+    const pendingSession = pendingAssignment ?? pendingCreation?.promise;
+    if (!pendingSession) {
       logger.warn(`Cannot release session ${sessionId}: not found`);
       return null;
     }
+    return await this.releasePendingSessionWork(sessionId, releaseReason, allowExpired, pendingSession);
+  }
 
-    const existingRelease = this.pendingCreationReleases.get(sessionId);
+  private async releasePendingSessionWork(
+    sessionId: string,
+    releaseReason: string,
+    allowExpired: boolean,
+    pendingSession: Promise<Session>,
+  ): Promise<string | null> {
+    const existingRelease = this.pendingSessionReleases.get(sessionId);
     if (existingRelease) {
       return await existingRelease.promise;
     }
 
     const release: PendingSessionRelease = {
-      promise: this.releaseAfterSessionCreation(
+      promise: this.releaseAfterPendingSessionWork(
         sessionId,
         releaseReason,
         allowExpired,
-        pendingCreation,
+        pendingSession,
       ),
     };
-    this.pendingCreationReleases.set(sessionId, release);
+    this.pendingSessionReleases.set(sessionId, release);
     try {
       return await release.promise;
     } finally {
-      if (this.pendingCreationReleases.get(sessionId) === release) {
-        this.pendingCreationReleases.delete(sessionId);
+      if (this.pendingSessionReleases.get(sessionId) === release) {
+        this.pendingSessionReleases.delete(sessionId);
       }
     }
   }
 
-  private async releaseAfterSessionCreation(
+  private async releaseAfterPendingSessionWork(
     sessionId: string,
     releaseReason: string,
     allowExpired: boolean,
-    pendingCreation: PendingSessionCreation,
+    pendingSession: Promise<Session>,
   ): Promise<string | null> {
     try {
-      await pendingCreation.promise;
+      await pendingSession;
       return await this.releaseSession(sessionId, releaseReason, allowExpired);
     } catch (error) {
-      logger.warn(`Session ${sessionId} creation failed before release: ${error}`);
+      logger.warn(`Session ${sessionId} assignment failed before release: ${error}`);
       return null;
     }
   }
@@ -680,9 +697,9 @@ export class SessionManager {
 
   /** Wait for a release already admitted for this session, if any. */
   async waitForSessionRelease(sessionId: string): Promise<void> {
-    const pendingCreationRelease = this.pendingCreationReleases.get(sessionId);
-    if (pendingCreationRelease) {
-      await pendingCreationRelease.promise;
+    const pendingSessionRelease = this.pendingSessionReleases.get(sessionId);
+    if (pendingSessionRelease) {
+      await pendingSessionRelease.promise;
       return;
     }
 

--- a/src/daemon/sessionManager.ts
+++ b/src/daemon/sessionManager.ts
@@ -560,6 +560,20 @@ export class SessionManager {
     }
   }
 
+  /** Release only the recorded session incarnation while it still owns the device. */
+  async releaseSessionIfOwned(
+    sessionId: string,
+    expectedSession: Session,
+    expectedDeviceId: string,
+    releaseReason: string = "explicit-release",
+  ): Promise<string | null> {
+    const session = this.sessions.get(sessionId);
+    if (session !== expectedSession || session.assignedDevice !== expectedDeviceId) {
+      return null;
+    }
+    return await this.releaseSession(sessionId, releaseReason);
+  }
+
   private async releasePendingSessionCreation(
     sessionId: string,
     releaseReason: string,
@@ -1091,19 +1105,28 @@ export class SessionManager {
 
     for (const sessionId of expiredSessions) {
       const session = this.sessions.get(sessionId);
-      const deviceId = session?.assignedDevice;
-      this.removeSession(sessionId);
-      // Notify release callbacks so session-scoped state is cleaned up
-      if (deviceId) {
+      if (!session) {
+        continue;
+      }
+      if (this.pendingSessionRebinds.get(sessionId)?.session === session) {
+        const release = this.releaseSession(sessionId, "cleanup-expired", true);
         void this.getBarrier()
-          .track(() => this.deviceSessionRepository.markReleased(sessionId, "expired", this.timer.now(), "cleanup-expired"))
-          .catch(error => logger.warn(`[SessionManager] Failed to mark session released (cleanup-expired): ${error}`));
-        for (const callback of this.releaseCallbacks) {
-          try {
-            callback(sessionId, deviceId);
-          } catch (error) {
-            logger.warn(`Session cleanup callback failed for ${sessionId}: ${error}`);
-          }
+          .trackExisting(release)
+          .catch(error => logger.warn(`[SessionManager] Failed to release expired session ${sessionId}: ${error}`));
+        continue;
+      }
+
+      const deviceId = session.assignedDevice;
+      this.removeSession(sessionId);
+      // Notify release callbacks so session-scoped state is cleaned up.
+      void this.getBarrier()
+        .track(() => this.deviceSessionRepository.markReleased(sessionId, "expired", this.timer.now(), "cleanup-expired"))
+        .catch(error => logger.warn(`[SessionManager] Failed to mark session released (cleanup-expired): ${error}`));
+      for (const callback of this.releaseCallbacks) {
+        try {
+          callback(sessionId, deviceId);
+        } catch (error) {
+          logger.warn(`Session cleanup callback failed for ${sessionId}: ${error}`);
         }
       }
     }

--- a/src/daemon/sessionManager.ts
+++ b/src/daemon/sessionManager.ts
@@ -148,6 +148,8 @@ export class SessionManager {
   private readonly pendingDeviceCleanups: Map<string, Promise<void>> = new Map();
   /** Creation writes that must finish before a session becomes visible to callers. */
   private readonly pendingSessionCreations: Map<string, PendingSessionCreation> = new Map();
+  /** Automatic device assignments that have not yet started their creation write. */
+  private readonly pendingSessionAssignments: Map<string, Promise<Session>> = new Map();
   /** Releases received before a creation write has published its session. */
   private readonly pendingCreationReleasePromises: Map<string, Promise<string | null>> = new Map();
   /** Rebinds that a release must await before it can remove the live binding. */
@@ -373,18 +375,23 @@ export class SessionManager {
       return existing;
     }
 
+    const pendingAssignment = this.pendingSessionAssignments.get(sessionId);
+    if (pendingAssignment) {
+      return await pendingAssignment;
+    }
+
     const pendingCreation = this.pendingSessionCreations.get(sessionId);
     if (pendingCreation) {
       return await pendingCreation.promise;
     }
 
-    const creation = this.createUnseenSession(sessionId, devicePool, platform).finally(() => {
-      if (this.pendingSessionCreations.get(sessionId) === creation) {
-        this.pendingSessionCreations.delete(sessionId);
+    const assignment = this.createUnseenSession(sessionId, devicePool, platform).finally(() => {
+      if (this.pendingSessionAssignments.get(sessionId) === assignment) {
+        this.pendingSessionAssignments.delete(sessionId);
       }
     });
-    this.pendingSessionCreations.set(sessionId, creation);
-    return await creation;
+    this.pendingSessionAssignments.set(sessionId, assignment);
+    return await assignment;
   }
 
   private async createUnseenSession(

--- a/src/db/deviceSessionRepository.ts
+++ b/src/db/deviceSessionRepository.ts
@@ -102,6 +102,7 @@ export class DeviceSessionRepository {
         .execute();
     } catch (error) {
       logger.warn(`[DeviceSessionRepository] Failed to upsert device session ${record.sessionUuid}: ${error}`);
+      throw error;
     }
   }
 

--- a/src/db/deviceSessionRepository.ts
+++ b/src/db/deviceSessionRepository.ts
@@ -27,6 +27,17 @@ export interface DeviceSessionActivityUpdate {
   hasReceivedHeartbeat: boolean;
 }
 
+export interface DeviceSessionPersistence {
+  upsertActiveSession(record: DeviceSessionRecord): Promise<void>;
+  recordActivity(sessionUuid: string, update: DeviceSessionActivityUpdate): Promise<void>;
+  markReleased(
+    sessionUuid: string,
+    status: DeviceSessionStatus,
+    releasedAtMs: number,
+    reason: string,
+  ): Promise<void>;
+}
+
 export class DeviceSessionRepository {
   private db: Kysely<Database> | null;
 

--- a/src/features/navigation/NavigationGraphManager.ts
+++ b/src/features/navigation/NavigationGraphManager.ts
@@ -393,10 +393,8 @@ export class NavigationGraphManager implements NavigationGraphService {
     NavigationGraphManager.releasedSessions.delete(sessionId);
   }
 
-  /**
-   * Release a session-scoped instance and its transient state.
-   */
-  public static releaseSession(sessionId: string): void {
+  /** Clear a live session's device-scoped navigation state without tombstoning it. */
+  public static resetSession(sessionId: string): void {
     const instance = NavigationGraphManager.sessionInstances.get(sessionId);
     if (instance) {
       instance.activeTestSession = null;
@@ -404,8 +402,15 @@ export class NavigationGraphManager implements NavigationGraphService {
       instance.activeNavigation = null;
       instance.graphUpdateListeners = [];
       NavigationGraphManager.sessionInstances.delete(sessionId);
-      logger.debug(`[NAV_GRAPH] Released session instance: ${sessionId}`);
+      logger.debug(`[NAV_GRAPH] Reset session instance: ${sessionId}`);
     }
+  }
+
+  /**
+   * Release a session-scoped instance and its transient state.
+   */
+  public static releaseSession(sessionId: string): void {
+    NavigationGraphManager.resetSession(sessionId);
     // Mark released even if no instance existed yet, so a later stray event for this
     // session resolves to the unattributed global rather than minting a manager for
     // the ended session (#4984). Bounded FIFO to cap long-daemon growth.

--- a/src/server/utilityTools.ts
+++ b/src/server/utilityTools.ts
@@ -148,7 +148,15 @@ export function registerUtilityTools() {
         // one, so a failed write leaves the caller's existing session intact.
         const existing = sessionManager.getSession(args.sessionUuid);
         if (!existing || existing.assignedDevice !== args.deviceId) {
-          const boundSession = await devicePool.bindOrReuseDeviceSession(args.sessionUuid, args.deviceId, args.platform);
+          const boundSession = await devicePool.bindOrReuseDeviceSession(
+            args.sessionUuid,
+            args.deviceId,
+            args.platform,
+            undefined,
+            undefined,
+            undefined,
+            true,
+          );
           if (boundSession !== args.sessionUuid) {
             throw new ActionableError(
               `Device '${args.deviceId}' is already assigned to session ${boundSession}`

--- a/src/server/utilityTools.ts
+++ b/src/server/utilityTools.ts
@@ -144,12 +144,9 @@ export function registerUtilityTools() {
             );
           }
         }
-        // Release any existing session for this sessionUuid before rebinding
+        // The pool persists a replacement binding before it releases the previous
+        // one, so a failed write leaves the caller's existing session intact.
         const existing = sessionManager.getSession(args.sessionUuid);
-        if (existing && existing.assignedDevice !== args.deviceId) {
-          await sessionManager.releaseSession(existing.sessionId);
-          await devicePool.releaseDevice(existing.assignedDevice, existing.sessionId);
-        }
         if (!existing || existing.assignedDevice !== args.deviceId) {
           const boundSession = await devicePool.bindOrReuseDeviceSession(args.sessionUuid, args.deviceId, args.platform);
           if (boundSession !== args.sessionUuid) {

--- a/test/daemon/SessionHeartbeatMonitor.test.ts
+++ b/test/daemon/SessionHeartbeatMonitor.test.ts
@@ -4,6 +4,7 @@ import { SessionManager } from "../../src/daemon/sessionManager";
 import { DevicePool } from "../../src/daemon/devicePool";
 import { ExecutionTracker } from "../../src/server/executionTracker";
 import { FakeTimer } from "../fakes/FakeTimer";
+import { FakeDeviceSessionPersistence } from "../fakes/FakeDeviceSessionPersistence";
 import { FakeDeviceUtils } from "../fakes/FakeDeviceUtils";
 
 const AUTOLOCK_ENV_KEYS = [
@@ -34,7 +35,7 @@ describe("SessionHeartbeatMonitor", () => {
   beforeEach(() => {
     clearAutolockEnv();
     timer = new FakeTimer();
-    sessionManager = new SessionManager(timer);
+    sessionManager = new SessionManager(timer, new FakeDeviceSessionPersistence());
   });
 
   afterEach(() => {

--- a/test/daemon/daemonRequestHandlers.test.ts
+++ b/test/daemon/daemonRequestHandlers.test.ts
@@ -6,6 +6,7 @@ import {
 import { SessionManager } from "../../src/daemon/sessionManager";
 import { DaemonRequest } from "../../src/daemon/types";
 import { FakeTimer } from "../fakes/FakeTimer";
+import { FakeDeviceSessionPersistence } from "../fakes/FakeDeviceSessionPersistence";
 import type { DeviceRecoveryEligibility, DeviceRecoveryPolicy, PooledDevice } from "../../src/daemon/devicePool";
 import { DeviceSessionRegistry } from "../../src/daemon/deviceSessionRegistry";
 import { FakeIdGenerator } from "../fakes/FakeIdGenerator";
@@ -104,7 +105,7 @@ describe("handleDaemonRequest", () => {
   beforeEach(() => {
     fakeTimer = new FakeTimer();
     fakeTimer.enableAutoAdvance();
-    sessionManager = new SessionManager(fakeTimer);
+    sessionManager = new SessionManager(fakeTimer, new FakeDeviceSessionPersistence());
   });
 
   afterEach(() => {

--- a/test/daemon/daemonSessionReleaseSignal.test.ts
+++ b/test/daemon/daemonSessionReleaseSignal.test.ts
@@ -1,6 +1,9 @@
 import { afterEach, describe, expect, test } from "bun:test";
 import { Daemon } from "../../src/daemon/daemon";
 import { DaemonState } from "../../src/daemon/daemonState";
+import { NavigationGraphManager } from "../../src/features/navigation/NavigationGraphManager";
+import { NavigationRepository } from "../../src/db/navigationRepository";
+import { TestCoverageRepository } from "../../src/db/testCoverageRepository";
 import { SessionReleaseBroadcaster } from "../../src/server/sessionReleaseBroadcast";
 import { DeviceSessionRepository } from "../../src/db/deviceSessionRepository";
 import { createTestDatabase } from "../db/testDbHelper";
@@ -18,6 +21,7 @@ describe("Daemon session-release signal wiring", () => {
     if (DaemonState.getInstance().isInitialized()) {
       DaemonState.getInstance().reset();
     }
+    NavigationGraphManager.resetInstance();
   });
 
   test("emits the released session key to the broadcaster on releaseSession", async () => {
@@ -41,6 +45,35 @@ describe("Daemon session-release signal wiring", () => {
       expect(emitted).toEqual(["session-release-signal"]);
     } finally {
       unsubscribe();
+      sessionManager.stopCleanupTimer();
+    }
+  });
+
+  test("resets navigation state when a live session rebinds to another device", async () => {
+    const db = await createTestDatabase();
+    NavigationGraphManager.setInstanceForSessionForTesting(
+      "session-rebind-navigation",
+      NavigationGraphManager.createForTesting(
+        new NavigationRepository(db),
+        new TestCoverageRepository(undefined, db),
+        undefined,
+        "session-rebind-navigation",
+      ),
+    );
+    const daemon = new Daemon({}, undefined, undefined, new DeviceSessionRepository(db));
+    const sessionManager = daemon.getSessionManager();
+
+    try {
+      await sessionManager.createSession("session-rebind-navigation", "emulator-old", "android");
+      const oldNavigation = NavigationGraphManager.getInstanceForSession("session-rebind-navigation");
+      await oldNavigation.setCurrentApp("com.example.old");
+
+      await sessionManager.rebindSession("session-rebind-navigation", "emulator-new", "android");
+
+      const reboundNavigation = NavigationGraphManager.getInstanceForSession("session-rebind-navigation");
+      expect(reboundNavigation).not.toBe(oldNavigation);
+      expect(reboundNavigation.getCurrentAppId()).toBeNull();
+    } finally {
       sessionManager.stopCleanupTimer();
     }
   });

--- a/test/daemon/devicePool.autolock.test.ts
+++ b/test/daemon/devicePool.autolock.test.ts
@@ -2,6 +2,7 @@ import { describe, it, expect, beforeEach, afterEach } from "bun:test";
 import { DevicePool } from "../../src/daemon/devicePool";
 import { SessionManager } from "../../src/daemon/sessionManager";
 import { FakeTimer } from "../fakes/FakeTimer";
+import { FakeDeviceSessionPersistence } from "../fakes/FakeDeviceSessionPersistence";
 import { FakeDeviceUtils } from "../fakes/FakeDeviceUtils";
 import { ActionableError } from "../../src/models";
 
@@ -35,7 +36,7 @@ describe("DevicePool autolock", () => {
   beforeEach(() => {
     clearAutolockEnv();
     timer = new FakeTimer();
-    sessionManager = new SessionManager(timer);
+    sessionManager = new SessionManager(timer, new FakeDeviceSessionPersistence());
     fakeDeviceUtils = new FakeDeviceUtils();
 
     pool = new DevicePool(

--- a/test/daemon/devicePool.evictionCatch.test.ts
+++ b/test/daemon/devicePool.evictionCatch.test.ts
@@ -3,6 +3,7 @@ import { EventEmitter } from "node:events";
 import { DevicePool } from "../../src/daemon/devicePool";
 import { SessionManager } from "../../src/daemon/sessionManager";
 import { FakeTimer } from "../fakes/FakeTimer";
+import { FakeDeviceSessionPersistence } from "../fakes/FakeDeviceSessionPersistence";
 import { FakeDeviceUtils } from "../fakes/FakeDeviceUtils";
 import { logger } from "../../src/utils/logger";
 
@@ -19,7 +20,7 @@ describe("DevicePool emulator-exit eviction rejection handling", () => {
 
   beforeEach(async () => {
     timer = new FakeTimer();
-    sessionManager = new SessionManager(timer);
+    sessionManager = new SessionManager(timer, new FakeDeviceSessionPersistence());
     fakeDeviceUtils = new FakeDeviceUtils();
     pool = new DevicePool(sessionManager, "daemon-session-1", timer, undefined, fakeDeviceUtils);
     fakeDeviceUtils.setBootedDevices("android", [androidDevice]);

--- a/test/daemon/devicePool.test.ts
+++ b/test/daemon/devicePool.test.ts
@@ -2084,7 +2084,15 @@ describe("DevicePool", () => {
       ]);
       await devicePool.bindOrReuseDeviceSession("session-1", "emulator-old", "android");
 
-      await devicePool.bindOrReuseDeviceSession("session-1", "emulator-new", "android");
+      await devicePool.bindOrReuseDeviceSession(
+        "session-1",
+        "emulator-new",
+        "android",
+        undefined,
+        undefined,
+        undefined,
+        true,
+      );
 
       expect(devicePool.getDevice("emulator-old")).toMatchObject({ sessionId: null, status: "idle" });
       expect(devicePool.getDevice("emulator-new")).toMatchObject({ sessionId: "session-1", status: "busy" });

--- a/test/daemon/devicePool.test.ts
+++ b/test/daemon/devicePool.test.ts
@@ -2077,6 +2077,20 @@ describe("DevicePool", () => {
       ).resolves.toBe("session-1");
     });
 
+    test("releases the old pooled device after rebinding an existing session", async () => {
+      await initializeLiveDevices([
+        createBootedDevice("emulator-old"),
+        createBootedDevice("emulator-new"),
+      ]);
+      await devicePool.bindOrReuseDeviceSession("session-1", "emulator-old", "android");
+
+      await devicePool.bindOrReuseDeviceSession("session-1", "emulator-new", "android");
+
+      expect(devicePool.getDevice("emulator-old")).toMatchObject({ sessionId: null, status: "idle" });
+      expect(devicePool.getDevice("emulator-new")).toMatchObject({ sessionId: "session-1", status: "busy" });
+      expect(sessionManager.getSession("session-1")?.assignedDevice).toBe("emulator-new");
+    });
+
     test("rejects a changed runtime identity inside the assignment mutex", async () => {
       await devicePool.initializeWithDevices([
         createBootedDevice("emulator-5554", "android", "Old Pixel"),

--- a/test/daemon/devicePool.test.ts
+++ b/test/daemon/devicePool.test.ts
@@ -7,6 +7,7 @@ import { SessionManager } from "../../src/daemon/sessionManager";
 import { FakeIdGenerator } from "../fakes/FakeIdGenerator";
 import { FakeTimer } from "../fakes/FakeTimer";
 import { FakeInstalledAppsRepository } from "../fakes/FakeInstalledAppsRepository";
+import { FakeDeviceSessionPersistence } from "../fakes/FakeDeviceSessionPersistence";
 import { FakeDeviceManager } from "../fakes/FakeDeviceManager";
 import { BootedDevice, DeviceInfo, Platform, SomePlatform } from "../../src/models";
 import { DefaultRetryExecutor } from "../../src/utils/retry/RetryExecutor";
@@ -1760,6 +1761,38 @@ describe("DevicePool", () => {
         sessionId: null,
         status: "idle",
       });
+    });
+
+    test("restores the pooled device when session persistence rejects", async () => {
+      sessionManager.stopCleanupTimer();
+      const sessionPersistence = new FakeDeviceSessionPersistence();
+      sessionPersistence.failure = "create";
+      sessionManager = new SessionManager(fakeTimer, sessionPersistence);
+      devicePool = new DevicePool(
+        sessionManager,
+        "test-daemon-session-id",
+        fakeTimer,
+        fakeAppsRepo,
+        fakeDeviceManager,
+        new DefaultRetryExecutor(fakeTimer),
+      );
+      await initializeLiveDevices([createBootedDevice("emulator-5554")]);
+      const before = devicePool.getDevice("emulator-5554");
+      const previousAssignment = {
+        sessionId: before?.sessionId,
+        status: before?.status,
+        assignmentCount: before?.assignmentCount,
+        errorCount: before?.errorCount,
+        lastUsedAt: before?.lastUsedAt,
+      };
+
+      await expect(devicePool.assignDeviceToSession("session-failure")).rejects.toThrow(
+        "Timed out waiting for device",
+      );
+
+      expect(devicePool.getDevice("emulator-5554")).toMatchObject(previousAssignment);
+      expect(sessionManager.getSession("session-failure")).toBeNull();
+      expect(sessionManager.getSessionForDevice("emulator-5554")).toBeNull();
     });
 
     test("should throw error when no devices available after timeout", async () => {

--- a/test/daemon/devicePool.test.ts
+++ b/test/daemon/devicePool.test.ts
@@ -499,7 +499,7 @@ describe("DevicePool", () => {
 
   beforeEach(() => {
     fakeTimer = new FakeTimer();
-    sessionManager = new SessionManager(fakeTimer);
+    sessionManager = new SessionManager(fakeTimer, new FakeDeviceSessionPersistence());
     fakeAppsRepo = new FakeInstalledAppsRepository();
     fakeDeviceManager = new FakeDeviceManager();
     // Create a RetryExecutor that uses the fakeTimer so time advancement works correctly

--- a/test/daemon/devicePool.test.ts
+++ b/test/daemon/devicePool.test.ts
@@ -2405,7 +2405,7 @@ describe("DevicePool", () => {
       expect(devicePool.getDevice("emulator-5554")?.status).toBe("idle");
     });
 
-    test("does not roll back a replacement session with the same UUID", async () => {
+    test("releases the old device without rolling back a replacement session with the same UUID", async () => {
       const secondWriteStarted = Promise.withResolvers<void>();
       const secondWriteFinished = Promise.withResolvers<void>();
       let writeCount = 0;
@@ -2434,25 +2434,19 @@ describe("DevicePool", () => {
       await initializeLiveDevices([
         createBootedDevice("emulator-5554"),
         createBootedDevice("emulator-5556"),
+        createBootedDevice("emulator-5558"),
       ]);
 
       const allocation = devicePool.assignMultipleDevices(["session-a", "session-b"], 1_000, "android");
-      const secondWriteStartedInTime = await Promise.race([
-        secondWriteStarted.promise.then(() => true),
-        new Promise<boolean>(resolve => setTimeout(() => resolve(false), 100)),
-      ]);
-      expect(secondWriteStartedInTime).toBe(true);
+      await secondWriteStarted.promise;
 
       await sessionManager.releaseSession("session-a");
-      await sessionManager.createSession("session-a", "emulator-5554", "android");
+      await sessionManager.createSession("session-a", "emulator-5558", "android");
       secondWriteFinished.resolve();
 
       await expect(allocation).rejects.toThrow("persist create failed");
-      expect(sessionManager.getSession("session-a")?.assignedDevice).toBe("emulator-5554");
-      expect(devicePool.getDevice("emulator-5554")).toMatchObject({
-        sessionId: "session-a",
-        status: "busy",
-      });
+      expect(sessionManager.getSession("session-a")?.assignedDevice).toBe("emulator-5558");
+      expect(devicePool.getDevice("emulator-5554")?.status).toBe("idle");
     });
   });
     test("evicts a started emulator when its process exits after readiness", async () => {

--- a/test/daemon/devicePool.test.ts
+++ b/test/daemon/devicePool.test.ts
@@ -1786,9 +1786,7 @@ describe("DevicePool", () => {
         lastUsedAt: before?.lastUsedAt,
       };
 
-      await expect(devicePool.assignDeviceToSession("session-failure")).rejects.toThrow(
-        "Timed out waiting for device",
-      );
+      await expect(devicePool.assignDeviceToSession("session-failure")).rejects.toThrow("persist create failed");
 
       expect(devicePool.getDevice("emulator-5554")).toMatchObject(previousAssignment);
       expect(sessionManager.getSession("session-failure")).toBeNull();

--- a/test/daemon/devicePool.test.ts
+++ b/test/daemon/devicePool.test.ts
@@ -2404,6 +2404,56 @@ describe("DevicePool", () => {
       expect(sessionManager.getSessionForDevice("emulator-5554")).toBeNull();
       expect(devicePool.getDevice("emulator-5554")?.status).toBe("idle");
     });
+
+    test("does not roll back a replacement session with the same UUID", async () => {
+      const secondWriteStarted = Promise.withResolvers<void>();
+      const secondWriteFinished = Promise.withResolvers<void>();
+      let writeCount = 0;
+      const sessionPersistence: DeviceSessionPersistence = {
+        async upsertActiveSession(): Promise<void> {
+          writeCount++;
+          if (writeCount === 2) {
+            secondWriteStarted.resolve();
+            await secondWriteFinished.promise;
+            throw new Error("persist create failed");
+          }
+        },
+        async recordActivity(): Promise<void> {},
+        async markReleased(): Promise<void> {},
+      };
+      sessionManager.stopCleanupTimer();
+      sessionManager = new SessionManager(fakeTimer, sessionPersistence);
+      devicePool = new DevicePool(
+        sessionManager,
+        "test-daemon-session-id",
+        fakeTimer,
+        fakeAppsRepo,
+        fakeDeviceManager,
+        new DefaultRetryExecutor(fakeTimer),
+      );
+      await initializeLiveDevices([
+        createBootedDevice("emulator-5554"),
+        createBootedDevice("emulator-5556"),
+      ]);
+
+      const allocation = devicePool.assignMultipleDevices(["session-a", "session-b"], 1_000, "android");
+      const secondWriteStartedInTime = await Promise.race([
+        secondWriteStarted.promise.then(() => true),
+        new Promise<boolean>(resolve => setTimeout(() => resolve(false), 100)),
+      ]);
+      expect(secondWriteStartedInTime).toBe(true);
+
+      await sessionManager.releaseSession("session-a");
+      await sessionManager.createSession("session-a", "emulator-5554", "android");
+      secondWriteFinished.resolve();
+
+      await expect(allocation).rejects.toThrow("persist create failed");
+      expect(sessionManager.getSession("session-a")?.assignedDevice).toBe("emulator-5554");
+      expect(devicePool.getDevice("emulator-5554")).toMatchObject({
+        sessionId: "session-a",
+        status: "busy",
+      });
+    });
   });
     test("evicts a started emulator when its process exits after readiness", async () => {
       const images: DeviceInfo[] = [

--- a/test/daemon/devicePool.test.ts
+++ b/test/daemon/devicePool.test.ts
@@ -8,6 +8,7 @@ import { FakeIdGenerator } from "../fakes/FakeIdGenerator";
 import { FakeTimer } from "../fakes/FakeTimer";
 import { FakeInstalledAppsRepository } from "../fakes/FakeInstalledAppsRepository";
 import { FakeDeviceSessionPersistence } from "../fakes/FakeDeviceSessionPersistence";
+import type { DeviceSessionPersistence } from "../../src/db/deviceSessionRepository";
 import { FakeDeviceManager } from "../fakes/FakeDeviceManager";
 import { BootedDevice, DeviceInfo, Platform, SomePlatform } from "../../src/models";
 import { DefaultRetryExecutor } from "../../src/utils/retry/RetryExecutor";
@@ -233,6 +234,33 @@ describe("DevicePool", () => {
       this.killCount++;
       return true;
     }
+  }
+
+  class DeferredDeviceSessionPersistence implements DeviceSessionPersistence {
+    private readonly writeStarted = Promise.withResolvers<void>();
+    private readonly writeFinished = Promise.withResolvers<void>();
+    private deferWrite = true;
+
+    async waitForUpsert(): Promise<void> {
+      await this.writeStarted.promise;
+    }
+
+    finishUpsert(): void {
+      this.writeFinished.resolve();
+    }
+
+    async upsertActiveSession(): Promise<void> {
+      if (!this.deferWrite) {
+        return;
+      }
+      this.deferWrite = false;
+      this.writeStarted.resolve();
+      await this.writeFinished.promise;
+    }
+
+    async recordActivity(): Promise<void> {}
+
+    async markReleased(): Promise<void> {}
   }
 
   class FakeDeviceManagerWithStartedProcess extends FakeDeviceManagerWithMinimalReadyDevice {
@@ -2442,6 +2470,39 @@ describe("DevicePool", () => {
       } finally {
         await reservation.release();
       }
+    });
+
+    test("does not publish a session when its started emulator exits during persistence", async () => {
+      const images: DeviceInfo[] = [{
+        name: "Pixel 8",
+        platform: "android",
+        isRunning: false,
+        deviceId: "emulator-5554",
+        source: "local",
+      }];
+      const manager = new FakeDeviceManagerWithStartedProcess(images);
+      const persistence = new DeferredDeviceSessionPersistence();
+      sessionManager.stopCleanupTimer();
+      sessionManager = new SessionManager(fakeTimer, persistence);
+      devicePool = new DevicePool(
+        sessionManager,
+        "test-daemon-session-id",
+        fakeTimer,
+        fakeAppsRepo,
+        manager,
+        new DefaultRetryExecutor(fakeTimer),
+      );
+
+      const assignment = devicePool.assignMultipleDevices(["session-1"], 1000, "android");
+      await persistence.waitForUpsert();
+      manager.childProcess.emit("exit", 0, null);
+      await new Promise(resolve => setImmediate(resolve));
+      persistence.finishUpsert();
+
+      await expect(assignment).rejects.toThrow("disconnected while its session was being created");
+      expect(devicePool.getDevice("emulator-5554")).toBeNull();
+      expect(sessionManager.getSession("session-1")).toBeNull();
+      expect(sessionManager.getSessionForDevice("emulator-5554")).toBeNull();
     });
 
     test("keeps criteria auto-start available after a process exit when recovery is disabled", async () => {

--- a/test/daemon/devicePool.test.ts
+++ b/test/daemon/devicePool.test.ts
@@ -2328,6 +2328,33 @@ describe("DevicePool", () => {
       expect(devicePool.getDevice("device-a")).toMatchObject({ sessionId: null, status: "idle" });
     });
 
+    test("releases earlier session ownership when a later persistence write rejects", async () => {
+      sessionManager.stopCleanupTimer();
+      const sessionPersistence = new FakeDeviceSessionPersistence();
+      sessionPersistence.createFailureOnAttempt = 2;
+      sessionManager = new SessionManager(fakeTimer, sessionPersistence);
+      devicePool = new DevicePool(
+        sessionManager,
+        "test-daemon-session-id",
+        fakeTimer,
+        fakeAppsRepo,
+        fakeDeviceManager,
+        new DefaultRetryExecutor(fakeTimer),
+      );
+      await initializeLiveDevices([
+        createBootedDevice("emulator-5554"),
+        createBootedDevice("emulator-5556"),
+      ]);
+
+      await expect(
+        devicePool.assignMultipleDevices(["session-a", "session-b"], 1_000, "android"),
+      ).rejects.toThrow("persist create failed");
+
+      expect(sessionManager.getSession("session-a")).toBeNull();
+      expect(sessionManager.getSessionForDevice("emulator-5554")).toBeNull();
+      expect(devicePool.getDevice("emulator-5554")?.status).toBe("idle");
+    });
+  });
     test("evicts a started emulator when its process exits after readiness", async () => {
       const images: DeviceInfo[] = [
         {

--- a/test/daemon/devicePool.test.ts
+++ b/test/daemon/devicePool.test.ts
@@ -2449,6 +2449,8 @@ describe("DevicePool", () => {
       expect(devicePool.getDevice("emulator-5554")?.status).toBe("idle");
     });
   });
+
+  describe("assignMultipleDevices", () => {
     test("evicts a started emulator when its process exits after readiness", async () => {
       const images: DeviceInfo[] = [
         {

--- a/test/daemon/devicePoolRecoveryPolicy.test.ts
+++ b/test/daemon/devicePoolRecoveryPolicy.test.ts
@@ -2,6 +2,7 @@ import { describe, expect, test } from "bun:test";
 import { DevicePool } from "../../src/daemon/devicePool";
 import { SessionManager } from "../../src/daemon/sessionManager";
 import { FakeTimer } from "../fakes/FakeTimer";
+import { FakeDeviceSessionPersistence } from "../fakes/FakeDeviceSessionPersistence";
 import { FakeInstalledAppsRepository } from "../fakes/FakeInstalledAppsRepository";
 import { FakeDeviceManager } from "../fakes/FakeDeviceManager";
 
@@ -9,7 +10,7 @@ describe("DevicePool recovery eligibility", () => {
   test("only reports AutoMobile-started Android virtual devices as recovery eligible", async () => {
     const timer = new FakeTimer();
     const pool = new DevicePool(
-      new SessionManager(timer),
+      new SessionManager(timer, new FakeDeviceSessionPersistence()),
       "daemon-session",
       timer,
       new FakeInstalledAppsRepository(),

--- a/test/daemon/integration/parallelExecution.test.ts
+++ b/test/daemon/integration/parallelExecution.test.ts
@@ -2,6 +2,7 @@ import { describe, expect, test, beforeEach, afterEach } from "bun:test";
 import { SessionManager } from "../../../src/daemon/sessionManager";
 import { DevicePool } from "../../../src/daemon/devicePool";
 import { FakeTimer } from "../../fakes/FakeTimer";
+import { FakeDeviceSessionPersistence } from "../../fakes/FakeDeviceSessionPersistence";
 import { FakeInstalledAppsRepository } from "../../fakes/FakeInstalledAppsRepository";
 import { BootedDevice } from "../../../src/models";
 import { DefaultRetryExecutor } from "../../../src/utils/retry/RetryExecutor";
@@ -20,7 +21,7 @@ describe("Parallel Execution Across Multiple Devices", function() {
 
   beforeEach(async function() {
     fakeTimer = new FakeTimer();
-    sessionManager = new SessionManager(fakeTimer);
+    sessionManager = new SessionManager(fakeTimer, new FakeDeviceSessionPersistence());
     fakeAppsRepo = new FakeInstalledAppsRepository();
     // Create a RetryExecutor that uses the fakeTimer so time advancement works correctly
     const retryExecutor = new DefaultRetryExecutor(fakeTimer);

--- a/test/daemon/sessionCacheTypedSlots.test.ts
+++ b/test/daemon/sessionCacheTypedSlots.test.ts
@@ -1,6 +1,7 @@
 import { describe, expect, test, beforeEach, afterEach } from "bun:test";
 import { SessionManager, type DeviceLabelMap, type KeepScreenAwakeRestorer } from "../../src/daemon/sessionManager";
 import { FakeTimer } from "../fakes/FakeTimer";
+import { FakeDeviceSessionPersistence } from "../fakes/FakeDeviceSessionPersistence";
 import { FakeDbWriteBarrier } from "../fakes/FakeDbWriteBarrier";
 import type { KeepScreenAwakeState } from "../../src/utils/KeepScreenAwakeManager";
 
@@ -44,7 +45,7 @@ describe("SessionCacheData typed slots (issue #2973)", () => {
 
   beforeEach(() => {
     fakeTimer = new FakeTimer();
-    sessionManager = new SessionManager(fakeTimer);
+    sessionManager = new SessionManager(fakeTimer, new FakeDeviceSessionPersistence());
   });
 
   afterEach(() => {

--- a/test/daemon/sessionManager.test.ts
+++ b/test/daemon/sessionManager.test.ts
@@ -14,6 +14,40 @@ import type { DeviceSessionPersistence } from "../../src/db/deviceSessionReposit
 import type { ViewHierarchyResult } from "../../src/models/ViewHierarchyResult";
 import type { KeepScreenAwakeState } from "../../src/utils/KeepScreenAwakeManager";
 
+class DeferredDeviceSessionPersistence implements DeviceSessionPersistence {
+  private deferredWrite: Promise<void> | null = null;
+  private resolveDeferredWrite: (() => void) | null = null;
+  private readonly writeStarted = Promise.withResolvers<void>();
+
+  deferNextUpsert(): void {
+    this.deferredWrite = new Promise<void>(resolve => {
+      this.resolveDeferredWrite = resolve;
+    });
+  }
+
+  async waitForUpsert(): Promise<void> {
+    await this.writeStarted.promise;
+  }
+
+  finishUpsert(): void {
+    this.resolveDeferredWrite?.();
+  }
+
+  async upsertActiveSession(): Promise<void> {
+    const deferredWrite = this.deferredWrite;
+    if (!deferredWrite) {
+      return;
+    }
+    this.deferredWrite = null;
+    this.writeStarted.resolve();
+    await deferredWrite;
+  }
+
+  async recordActivity(): Promise<void> {}
+
+  async markReleased(): Promise<void> {}
+}
+
 function makeHierarchy(label: string): ViewHierarchyResult {
   return {
     hierarchy: {
@@ -338,6 +372,59 @@ describe("SessionManager", () => {
 
         expect(manager.getSession("session-1")?.assignedDevice).toBe("emulator-old");
         expect(manager.getSessionForDevice("emulator-old")).toBe("session-1");
+        expect(manager.getSessionForDevice("emulator-new")).toBeNull();
+      } finally {
+        manager.stopCleanupTimer();
+      }
+    });
+
+    test("serializes a pending rebind with release and clears device-scoped state", async () => {
+      const repository = new DeferredDeviceSessionPersistence();
+      const restoredDevices: string[] = [];
+      const manager = new SessionManager(
+        fakeTimer,
+        repository,
+        undefined,
+        device => ({ restore: async () => { restoredDevices.push(device.deviceId); } }),
+      );
+      const unboundDevices: string[] = [];
+
+      try {
+        await manager.createSession("session-1", "emulator-old", "android");
+        manager.setLastHierarchy("session-1", makeHierarchy("old"));
+        manager.setKeepScreenAwake("session-1", { applied: true });
+        manager.onSessionDeviceUnbound((_sessionId, deviceId) => unboundDevices.push(deviceId));
+        repository.deferNextUpsert();
+
+        const rebinding = manager.rebindSession("session-1", "emulator-new", "android");
+        await repository.waitForUpsert();
+        const releasing = manager.releaseSession("session-1");
+        repository.finishUpsert();
+
+        await expect(rebinding).resolves.toMatchObject({ assignedDevice: "emulator-new", cacheData: {} });
+        await expect(releasing).resolves.toBe("emulator-new");
+        expect(restoredDevices).toEqual(["emulator-old"]);
+        expect(unboundDevices).toEqual(["emulator-old"]);
+        expect(manager.getSession("session-1")).toBeNull();
+        expect(manager.getSessionForDevice("emulator-old")).toBeNull();
+        expect(manager.getSessionForDevice("emulator-new")).toBeNull();
+      } finally {
+        manager.stopCleanupTimer();
+      }
+    });
+
+    test("does not recreate a session when a release wins the rebind race", async () => {
+      const repository = new DeferredDeviceSessionPersistence();
+      const manager = new SessionManager(fakeTimer, repository);
+
+      try {
+        await manager.createSession("session-1", "emulator-old", "android");
+        const releasing = manager.releaseSession("session-1");
+        await expect(manager.rebindSession("session-1", "emulator-new", "android")).rejects.toThrow(
+          "Cannot rebind released session session-1",
+        );
+        await expect(releasing).resolves.toBe("emulator-old");
+        expect(manager.getSession("session-1")).toBeNull();
         expect(manager.getSessionForDevice("emulator-new")).toBeNull();
       } finally {
         manager.stopCleanupTimer();

--- a/test/daemon/sessionManager.test.ts
+++ b/test/daemon/sessionManager.test.ts
@@ -434,6 +434,30 @@ describe("SessionManager", () => {
       }
     });
 
+    test("serializes expiry cleanup with a pending rebind", async () => {
+      const repository = new DeferredDeviceSessionPersistence();
+      const manager = new SessionManager(fakeTimer, repository, () => new FakeDbWriteBarrier());
+
+      try {
+        await manager.createSession("session-1", "emulator-old", "android", 1);
+        repository.deferNextUpsert();
+        const rebinding = manager.rebindSession("session-1", "emulator-new", "android");
+        await repository.waitForUpsert();
+
+        fakeTimer.advanceTime(2);
+        manager.cleanupExpiredSessions();
+        repository.finishUpsert();
+
+        await expect(rebinding).resolves.toMatchObject({ assignedDevice: "emulator-new" });
+        await expect(manager.drainReleasePromises(10)).resolves.toBe(true);
+        expect(manager.getSession("session-1")).toBeNull();
+        expect(manager.getSessionForDevice("emulator-old")).toBeNull();
+        expect(manager.getSessionForDevice("emulator-new")).toBeNull();
+      } finally {
+        manager.stopCleanupTimer();
+      }
+    });
+
     test("does not recreate a session when a release wins the rebind race", async () => {
       const repository = new DeferredDeviceSessionPersistence();
       const manager = new SessionManager(fakeTimer, repository);

--- a/test/daemon/sessionManager.test.ts
+++ b/test/daemon/sessionManager.test.ts
@@ -151,6 +151,27 @@ describe("SessionManager", () => {
       }
     });
 
+    test("releases a session after its pending creation finishes", async () => {
+      const repository = new DeferredDeviceSessionPersistence();
+      const manager = new SessionManager(fakeTimer, repository);
+
+      try {
+        repository.deferNextUpsert();
+        const creation = manager.createSession("session-pending-release", "emulator-5554", "android");
+        await repository.waitForUpsert();
+        const release = manager.releaseSession("session-pending-release");
+
+        repository.finishUpsert();
+
+        await expect(creation).resolves.toMatchObject({ sessionId: "session-pending-release" });
+        await expect(release).resolves.toBe("emulator-5554");
+        expect(manager.getSession("session-pending-release")).toBeNull();
+        expect(manager.getSessionForDevice("emulator-5554")).toBeNull();
+      } finally {
+        manager.stopCleanupTimer();
+      }
+    });
+
     test("keeps ownership unpublished while a creation write is pending", async () => {
       let rejectFirstWrite!: (error: Error) => void;
       const firstWrite = new Promise<void>((_resolve, reject) => {

--- a/test/daemon/sessionManager.test.ts
+++ b/test/daemon/sessionManager.test.ts
@@ -321,6 +321,33 @@ describe("SessionManager", () => {
       expect(attempts).toBe(2);
     });
 
+    test("releases a session after its pending automatic assignment finishes", async () => {
+      const manager = new SessionManager(fakeTimer, new FakeDeviceSessionPersistence());
+      const assignmentStarted = Promise.withResolvers<void>();
+      const finishAssignment = Promise.withResolvers<void>();
+      const devicePool: SessionDeviceAssigner = {
+        async assignDeviceToSession(sessionId: string): Promise<string> {
+          assignmentStarted.resolve();
+          await finishAssignment.promise;
+          return (await manager.createSession(sessionId, "emulator-5554", "android")).assignedDevice;
+        },
+      };
+
+      try {
+        const assignment = manager.getOrCreateSession("pending-assignment", devicePool);
+        await assignmentStarted.promise;
+        const release = manager.releaseSession("pending-assignment", "device-disconnected");
+        finishAssignment.resolve();
+
+        await expect(assignment).resolves.toMatchObject({ assignedDevice: "emulator-5554" });
+        await expect(release).resolves.toBe("emulator-5554");
+        expect(manager.getSession("pending-assignment")).toBeNull();
+        expect(manager.getSessionForDevice("emulator-5554")).toBeNull();
+      } finally {
+        manager.stopCleanupTimer();
+      }
+    });
+
     test("should return null session when expired session requested", async () => {
       const session = await sessionManager.createSession("session-1", "emulator-5554", "android");
       // Force expiration by setting expiresAt to past
@@ -446,6 +473,30 @@ describe("SessionManager", () => {
 
         fakeTimer.advanceTime(2);
         manager.cleanupExpiredSessions();
+        repository.finishUpsert();
+
+        await expect(rebinding).resolves.toMatchObject({ assignedDevice: "emulator-new" });
+        await expect(manager.drainReleasePromises(10)).resolves.toBe(true);
+        expect(manager.getSession("session-1")).toBeNull();
+        expect(manager.getSessionForDevice("emulator-old")).toBeNull();
+        expect(manager.getSessionForDevice("emulator-new")).toBeNull();
+      } finally {
+        manager.stopCleanupTimer();
+      }
+    });
+
+    test("does not remove rebind ownership when lazy expiry observes the pending rebind", async () => {
+      const repository = new DeferredDeviceSessionPersistence();
+      const manager = new SessionManager(fakeTimer, repository);
+
+      try {
+        await manager.createSession("session-1", "emulator-old", "android", 1);
+        repository.deferNextUpsert();
+        const rebinding = manager.rebindSession("session-1", "emulator-new", "android");
+        await repository.waitForUpsert();
+
+        fakeTimer.advanceTime(2);
+        expect(manager.getSession("session-1")).toBeNull();
         repository.finishUpsert();
 
         await expect(rebinding).resolves.toMatchObject({ assignedDevice: "emulator-new" });

--- a/test/daemon/sessionManager.test.ts
+++ b/test/daemon/sessionManager.test.ts
@@ -9,6 +9,8 @@ import { FakeTimer } from "../fakes/FakeTimer";
 import { FakeDbWriteBarrier } from "../fakes/FakeDbWriteBarrier";
 import { FakeInstalledAppsRepository } from "../fakes/FakeInstalledAppsRepository";
 import { FakeDeviceManager } from "../fakes/FakeDeviceManager";
+import { FakeDeviceSessionPersistence } from "../fakes/FakeDeviceSessionPersistence";
+import type { DeviceSessionPersistence } from "../../src/db/deviceSessionRepository";
 import type { ViewHierarchyResult } from "../../src/models/ViewHierarchyResult";
 import type { KeepScreenAwakeState } from "../../src/utils/KeepScreenAwakeManager";
 
@@ -41,7 +43,7 @@ describe("SessionManager", () => {
   beforeEach(() => {
     clearHeartbeatEnv();
     fakeTimer = new FakeTimer();
-    sessionManager = new SessionManager(fakeTimer);
+    sessionManager = new SessionManager(fakeTimer, new FakeDeviceSessionPersistence());
   });
 
   afterEach(() => {
@@ -95,6 +97,58 @@ describe("SessionManager", () => {
 
       expect(session.heartbeatTimeoutMs).toBe(15_000);
       expect(session.heartbeatTimeoutSource).toBe("custom");
+    });
+
+    test("removes every ownership mapping when persistence rejects", async () => {
+      const repository = new FakeDeviceSessionPersistence();
+      const manager = new SessionManager(fakeTimer, repository);
+      repository.failure = "create";
+
+      try {
+        await expect(manager.createSession("session-failure", "emulator-5554", "android")).rejects.toThrow(
+          "persist create failed",
+        );
+
+        expect(manager.getSession("session-failure")).toBeNull();
+        expect(manager.getSessionForDevice("emulator-5554")).toBeNull();
+        expect(manager.getActiveSessionCount()).toBe(0);
+      } finally {
+        manager.stopCleanupTimer();
+      }
+    });
+
+    test("does not remove a replacement session when an earlier write rejects", async () => {
+      let rejectFirstWrite!: (error: Error) => void;
+      const firstWrite = new Promise<void>((_resolve, reject) => {
+        rejectFirstWrite = reject;
+      });
+      let firstWritePending = true;
+      const repository: DeviceSessionPersistence = {
+        upsertActiveSession: async () => {
+          if (firstWritePending) {
+            firstWritePending = false;
+            await firstWrite;
+          }
+        },
+        recordActivity: async () => {},
+        markReleased: async () => {},
+      };
+      const manager = new SessionManager(fakeTimer, repository);
+
+      try {
+        const initialCreate = manager.createSession("reused", "emulator-old", "android");
+        await manager.releaseSession("reused");
+        await manager.createSession("reused", "emulator-new", "android");
+
+        rejectFirstWrite(new Error("first persistence failed"));
+        await expect(initialCreate).rejects.toThrow("first persistence failed");
+
+        expect(manager.getSession("reused")?.assignedDevice).toBe("emulator-new");
+        expect(manager.getSessionForDevice("emulator-new")).toBe("reused");
+        expect(manager.getActiveSessionCount()).toBe(1);
+      } finally {
+        manager.stopCleanupTimer();
+      }
     });
   });
 

--- a/test/daemon/sessionManager.test.ts
+++ b/test/daemon/sessionManager.test.ts
@@ -323,6 +323,28 @@ describe("SessionManager", () => {
     });
   });
 
+  describe("rebindSession", () => {
+    test("retains the existing binding when replacement persistence rejects", async () => {
+      const repository = new FakeDeviceSessionPersistence();
+      const manager = new SessionManager(fakeTimer, repository);
+
+      try {
+        await manager.createSession("session-1", "emulator-old", "android");
+        repository.failure = "create";
+
+        await expect(manager.rebindSession("session-1", "emulator-new", "android")).rejects.toThrow(
+          "persist create failed",
+        );
+
+        expect(manager.getSession("session-1")?.assignedDevice).toBe("emulator-old");
+        expect(manager.getSessionForDevice("emulator-old")).toBe("session-1");
+        expect(manager.getSessionForDevice("emulator-new")).toBeNull();
+      } finally {
+        manager.stopCleanupTimer();
+      }
+    });
+  });
+
   describe("cache management", () => {
     test("should update session cache data", async () => {
       await sessionManager.createSession("session-1", "emulator-5554", "android");

--- a/test/daemon/sessionManager.test.ts
+++ b/test/daemon/sessionManager.test.ts
@@ -742,10 +742,11 @@ describe("SessionManager", () => {
         await firstPersistenceStartedPromise;
         const replacement = manager.createSession("s1", "device-2", "android");
 
-        expect(manager.getSession("s1")).toMatchObject({ assignedDevice: "device-2" });
+        expect(manager.getSession("s1")).toBeNull();
         finishFirstPersistence();
         await expect(first).resolves.toBe("device-1");
         await expect(replacement).resolves.toMatchObject({ assignedDevice: "device-2" });
+        expect(manager.getSession("s1")).toMatchObject({ assignedDevice: "device-2" });
         await expect(manager.releaseSession("s1", "second")).resolves.toBe("device-2");
         expect(releases).toEqual(["first", "second"]);
       } finally {

--- a/test/daemon/sessionManager.test.ts
+++ b/test/daemon/sessionManager.test.ts
@@ -117,7 +117,7 @@ describe("SessionManager", () => {
       }
     });
 
-    test("does not remove a replacement session when an earlier write rejects", async () => {
+    test("keeps ownership unpublished while a creation write is pending", async () => {
       let rejectFirstWrite!: (error: Error) => void;
       const firstWrite = new Promise<void>((_resolve, reject) => {
         rejectFirstWrite = reject;
@@ -137,15 +137,17 @@ describe("SessionManager", () => {
 
       try {
         const initialCreate = manager.createSession("reused", "emulator-old", "android");
-        await manager.releaseSession("reused");
-        await manager.createSession("reused", "emulator-new", "android");
+        const duplicateCreate = manager.createSession("reused", "emulator-new", "android");
+
+        expect(manager.getSession("reused")).toBeNull();
+        expect(manager.getSessionForDevice("emulator-old")).toBeNull();
+        expect(manager.getSessionForDevice("emulator-new")).toBeNull();
 
         rejectFirstWrite(new Error("first persistence failed"));
-        await expect(initialCreate).rejects.toThrow("first persistence failed");
+        await expect(Promise.all([initialCreate, duplicateCreate])).rejects.toThrow("first persistence failed");
 
-        expect(manager.getSession("reused")?.assignedDevice).toBe("emulator-new");
-        expect(manager.getSessionForDevice("emulator-new")).toBe("reused");
-        expect(manager.getActiveSessionCount()).toBe(1);
+        expect(manager.getSession("reused")).toBeNull();
+        expect(manager.getActiveSessionCount()).toBe(0);
       } finally {
         manager.stopCleanupTimer();
       }

--- a/test/db/deviceSessionRepository.test.ts
+++ b/test/db/deviceSessionRepository.test.ts
@@ -291,10 +291,10 @@ describe("DeviceSessionRepository", () => {
     expect(row!.status).toBe("active");
   });
 
-  test("upsertActiveSession is best-effort: a write failure is logged and swallowed, not propagated", async () => {
-    // A session-persist throw must NOT take down the daemon hot path
-    // (deviceSessionRepository.ts:91-93). Destroy the connection so the write
-    // throws, then assert the call still resolves and logs a warning.
+  test("upsertActiveSession logs and propagates a write failure for session rollback", async () => {
+    // SessionManager owns the in-memory rollback after this awaited write fails.
+    // Destroy the table so the insert rejects, then preserve the diagnostic log
+    // while asserting the failure reaches that rollback path.
     const warnSpy = spyOn(logger, "warn");
     try {
       await db.schema.dropTable("device_sessions").execute(); // force the insert to throw
@@ -310,7 +310,7 @@ describe("DeviceSessionRepository", () => {
           heartbeatTimeoutMs: 60_000,
           hasReceivedHeartbeat: false,
         })
-      ).resolves.toBeUndefined();
+      ).rejects.toThrow(/no such table/);
       expect(warnSpy).toHaveBeenCalled();
       const logged = warnSpy.mock.calls.map(c => String(c[0])).join("\n");
       expect(logged).toContain("session-fail");

--- a/test/fakes/FakeDeviceSessionPersistence.ts
+++ b/test/fakes/FakeDeviceSessionPersistence.ts
@@ -2,9 +2,12 @@ import type { DeviceSessionPersistence } from "../../src/db/deviceSessionReposit
 
 export class FakeDeviceSessionPersistence implements DeviceSessionPersistence {
   failure: "create" | "release" | null = null;
+  createFailureOnAttempt: number | null = null;
+  private createAttempts = 0;
 
   async upsertActiveSession(): Promise<void> {
-    if (this.failure === "create") {
+    this.createAttempts++;
+    if (this.failure === "create" || this.createFailureOnAttempt === this.createAttempts) {
       throw new Error("persist create failed");
     }
   }

--- a/test/fakes/FakeDeviceSessionPersistence.ts
+++ b/test/fakes/FakeDeviceSessionPersistence.ts
@@ -1,0 +1,19 @@
+import type { DeviceSessionPersistence } from "../../src/db/deviceSessionRepository";
+
+export class FakeDeviceSessionPersistence implements DeviceSessionPersistence {
+  failure: "create" | "release" | null = null;
+
+  async upsertActiveSession(): Promise<void> {
+    if (this.failure === "create") {
+      throw new Error("persist create failed");
+    }
+  }
+
+  async recordActivity(): Promise<void> {}
+
+  async markReleased(): Promise<void> {
+    if (this.failure === "release") {
+      throw new Error("persist release failed");
+    }
+  }
+}

--- a/test/features/navigation/navigateToInternalNoDiffE2E.test.ts
+++ b/test/features/navigation/navigateToInternalNoDiffE2E.test.ts
@@ -5,6 +5,7 @@ import { NavigateTo } from "../../../src/features/navigation/NavigateTo";
 import { FakeDeviceSessionManager } from "../../fakes/FakeDeviceSessionManager";
 import { FakeDeviceUtils } from "../../fakes/FakeDeviceUtils";
 import { FakeTimer } from "../../fakes/FakeTimer";
+import { FakeDeviceSessionPersistence } from "../../fakes/FakeDeviceSessionPersistence";
 import { BootedDevice } from "../../../src/models";
 import { DaemonState } from "../../../src/daemon/daemonState";
 import { SessionManager } from "../../../src/daemon/sessionManager";
@@ -61,7 +62,7 @@ describe("NavigateTo → finalize internal no-diff (end-to-end, #3087)", () => {
   async function setupAutolockedSession(): Promise<string> {
     fakeDeviceSessionManager.setConnectedDevices([androidA]);
     const timer = new FakeTimer();
-    daemonSessionManager = new SessionManager(timer);
+    daemonSessionManager = new SessionManager(timer, new FakeDeviceSessionPersistence());
     const fakeDeviceUtils = new FakeDeviceUtils();
     fakeDeviceUtils.setBootedDevices("android", [androidA]);
     const pool = new DevicePool(daemonSessionManager, "daemon-session", timer, undefined, fakeDeviceUtils);

--- a/test/plan/planExecutorInternalNoDiffE2E.test.ts
+++ b/test/plan/planExecutorInternalNoDiffE2E.test.ts
@@ -7,6 +7,7 @@ import { registerInteractionTools } from "../../src/server/interactionTools";
 import { FakeDeviceSessionManager } from "../fakes/FakeDeviceSessionManager";
 import { FakeDeviceUtils } from "../fakes/FakeDeviceUtils";
 import { FakeTimer } from "../fakes/FakeTimer";
+import { FakeDeviceSessionPersistence } from "../fakes/FakeDeviceSessionPersistence";
 import { BootedDevice } from "../../src/models";
 import { DaemonState } from "../../src/daemon/daemonState";
 import { SessionManager } from "../../src/daemon/sessionManager";
@@ -55,7 +56,7 @@ describe("PlanExecutor → finalize internal no-diff (end-to-end, #3053)", () =>
   async function setupAutolockedSession(): Promise<string> {
     fakeDeviceSessionManager.setConnectedDevices([androidA]);
     const timer = new FakeTimer();
-    daemonSessionManager = new SessionManager(timer);
+    daemonSessionManager = new SessionManager(timer, new FakeDeviceSessionPersistence());
     const fakeDeviceUtils = new FakeDeviceUtils();
     fakeDeviceUtils.setBootedDevices("android", [androidA]);
     const pool = new DevicePool(daemonSessionManager, "daemon-session", timer, undefined, fakeDeviceUtils);

--- a/test/server/ToolExecutionContext.test.ts
+++ b/test/server/ToolExecutionContext.test.ts
@@ -7,6 +7,7 @@ import { AndroidCtrlProxyClient } from "../../src/features/observe/android";
 import { KeepScreenAwakeManager } from "../../src/utils/KeepScreenAwakeManager";
 import { FakeInstalledAppsRepository } from "../fakes/FakeInstalledAppsRepository";
 import { FakeTimer } from "../fakes/FakeTimer";
+import { FakeDeviceSessionPersistence } from "../fakes/FakeDeviceSessionPersistence";
 import { FakeDeviceManager } from "../fakes/FakeDeviceManager";
 import { BootedDevice } from "../../src/models";
 
@@ -27,7 +28,7 @@ describe("ToolExecutionContext", () => {
   beforeEach(async () => {
     fakeTimer = new FakeTimer();
     fakeTimer.enableAutoAdvance();
-    sessionManager = new SessionManager(fakeTimer);
+    sessionManager = new SessionManager(fakeTimer, new FakeDeviceSessionPersistence());
     fakeAppsRepo = new FakeInstalledAppsRepository();
     const fakeDeviceManager = new FakeDeviceManager();
     devicePool = new DevicePool(sessionManager, "test-daemon-session-id", fakeTimer, fakeAppsRepo, fakeDeviceManager);

--- a/test/server/deviceLabelMapping.test.ts
+++ b/test/server/deviceLabelMapping.test.ts
@@ -4,6 +4,7 @@ import { SessionManager } from "../../src/daemon/sessionManager";
 import { DevicePool } from "../../src/daemon/devicePool";
 import { FakeDeviceUtils } from "../fakes/FakeDeviceUtils";
 import { FakeTimer } from "../fakes/FakeTimer";
+import { FakeDeviceSessionPersistence } from "../fakes/FakeDeviceSessionPersistence";
 import { BootedDevice } from "../../src/models";
 import { buildDeviceLabelMap, getDeviceLabelMap } from "../../src/server/deviceLabelMapping";
 
@@ -19,7 +20,7 @@ describe("deviceLabelMapping ↔ SessionManager.deviceLabels slot (issue #2973)"
 
   beforeEach(async () => {
     const timer = new FakeTimer();
-    sessionManager = new SessionManager(timer);
+    sessionManager = new SessionManager(timer, new FakeDeviceSessionPersistence());
     const fakeDeviceUtils = new FakeDeviceUtils();
     fakeDeviceUtils.setBootedDevices("android", [androidA]);
     const pool = new DevicePool(sessionManager, "daemon-session", timer, undefined, fakeDeviceUtils);

--- a/test/server/deviceTools.startDevice.test.ts
+++ b/test/server/deviceTools.startDevice.test.ts
@@ -10,6 +10,7 @@ import { DaemonState } from "../../src/daemon/daemonState";
 import { SessionManager } from "../../src/daemon/sessionManager";
 import { DevicePool } from "../../src/daemon/devicePool";
 import { FakeTimer } from "../fakes/FakeTimer";
+import { FakeDeviceSessionPersistence } from "../fakes/FakeDeviceSessionPersistence";
 import { CountingIdGenerator } from "../../src/utils/IdGenerator";
 import {
   DEFAULT_DEVICE_READY_TIMEOUT_MS,
@@ -208,7 +209,7 @@ describe("startDevice handler", () => {
     }
 
     const timer = new FakeTimer();
-    daemonSessionManager = new SessionManager(timer);
+    daemonSessionManager = new SessionManager(timer, new FakeDeviceSessionPersistence());
     const pool = new DevicePool(
       daemonSessionManager,
       "daemon-session",
@@ -252,7 +253,7 @@ describe("startDevice handler", () => {
 
   it("reserves a public cold boot before resource notifications", async () => {
     const timer = new FakeTimer();
-    daemonSessionManager = new SessionManager(timer);
+    daemonSessionManager = new SessionManager(timer, new FakeDeviceSessionPersistence());
     const readyDeviceIds: string[] = [];
     const pool = new DevicePool(
       daemonSessionManager,
@@ -306,7 +307,7 @@ describe("startDevice handler", () => {
   it("reserves a pooled device while runner readiness is in flight", async () => {
     const timer = new FakeTimer();
     timer.enableAutoAdvance();
-    daemonSessionManager = new SessionManager(timer);
+    daemonSessionManager = new SessionManager(timer, new FakeDeviceSessionPersistence());
     const pool = new DevicePool(
       daemonSessionManager,
       "daemon-session",
@@ -354,7 +355,7 @@ describe("startDevice handler", () => {
 
   it("releases a pooled-device reservation when runner readiness fails", async () => {
     const timer = new FakeTimer();
-    daemonSessionManager = new SessionManager(timer);
+    daemonSessionManager = new SessionManager(timer, new FakeDeviceSessionPersistence());
     const pool = new DevicePool(
       daemonSessionManager,
       "daemon-session",
@@ -821,7 +822,7 @@ describe("startDevice handler", () => {
   it("registers the generated autolock session for the MCP session", async () => {
     process.env.AUTOMOBILE_DEVICE_POOL_AUTOLOCK = "1";
     const timer = new FakeTimer();
-    daemonSessionManager = new SessionManager(timer);
+    daemonSessionManager = new SessionManager(timer, new FakeDeviceSessionPersistence());
     const pool = new DevicePool(daemonSessionManager, "daemon-session", timer, undefined, fakeDeviceUtils);
     await pool.initializeWithDevices([androidDevice]);
     DaemonState.getInstance().initialize(daemonSessionManager, pool);
@@ -840,7 +841,7 @@ describe("startDevice handler", () => {
 
   it("rejects stale pooled platform metadata before session binding", async () => {
     const timer = new FakeTimer();
-    daemonSessionManager = new SessionManager(timer);
+    daemonSessionManager = new SessionManager(timer, new FakeDeviceSessionPersistence());
     const pool = new DevicePool(
       daemonSessionManager,
       "daemon-session",
@@ -865,7 +866,7 @@ describe("startDevice handler", () => {
 
   it("rejects a stale same-platform pool identity before session reuse", async () => {
     const timer = new FakeTimer();
-    daemonSessionManager = new SessionManager(timer);
+    daemonSessionManager = new SessionManager(timer, new FakeDeviceSessionPersistence());
     const pool = new DevicePool(
       daemonSessionManager,
       "daemon-session",
@@ -899,7 +900,7 @@ describe("startDevice handler", () => {
 
   it("reuses the returned sessionId for repeated startDevice calls when autolock is disabled", async () => {
     const timer = new FakeTimer();
-    daemonSessionManager = new SessionManager(timer);
+    daemonSessionManager = new SessionManager(timer, new FakeDeviceSessionPersistence());
     const pool = new DevicePool(daemonSessionManager, "daemon-session", timer, undefined, fakeDeviceUtils);
     await pool.initializeWithDevices([iosDevice]);
     DaemonState.getInstance().initialize(daemonSessionManager, pool);

--- a/test/server/resources/bootedDevices.test.ts
+++ b/test/server/resources/bootedDevices.test.ts
@@ -3,6 +3,7 @@ import { McpTestFixture } from "../../fixtures/mcpTestFixture";
 import { ResourceRegistry } from "../../../src/server/resourceRegistry";
 import { FakeDeviceUtils } from "../../fakes/FakeDeviceUtils";
 import { FakeTimer } from "../../fakes/FakeTimer";
+import { FakeDeviceSessionPersistence } from "../../fakes/FakeDeviceSessionPersistence";
 import { setDeviceManager, setDeviceLockProbe, notifyBootedDeviceResourcesUpdated, BootedDevicesResourceContent, DeviceLockStatesResourceContent } from "../../../src/server/bootedDeviceResources";
 import { BootedDevice, Platform } from "../../../src/models";
 import { DaemonState } from "../../../src/daemon/daemonState";
@@ -457,7 +458,7 @@ describe("MCP Booted Device Resources", () => {
 
       const fakeTimer = new FakeTimer();
       fakeTimer.enableAutoAdvance();
-      const sessionManager = new SessionManager(fakeTimer);
+      const sessionManager = new SessionManager(fakeTimer, new FakeDeviceSessionPersistence());
       const { FakeInstalledAppsRepository } = await import("../../fakes/FakeInstalledAppsRepository");
       const fakeAppsRepo = new FakeInstalledAppsRepository();
       const devicePool = new DevicePool(sessionManager, "test-daemon-session-id", fakeTimer, fakeAppsRepo, fakeDeviceUtils);
@@ -517,7 +518,7 @@ describe("MCP Booted Device Resources", () => {
 
       const fakeTimer = new FakeTimer();
       fakeTimer.enableAutoAdvance();
-      const sessionManager = new SessionManager(fakeTimer);
+      const sessionManager = new SessionManager(fakeTimer, new FakeDeviceSessionPersistence());
       const { FakeInstalledAppsRepository } = await import("../../fakes/FakeInstalledAppsRepository");
       const fakeAppsRepo = new FakeInstalledAppsRepository();
       const devicePool = new DevicePool(sessionManager, "test-daemon-session-id", fakeTimer, fakeAppsRepo);
@@ -564,7 +565,7 @@ describe("MCP Booted Device Resources", () => {
 
       const fakeTimer = new FakeTimer();
       fakeTimer.enableAutoAdvance();
-      const sessionManager = new SessionManager(fakeTimer);
+      const sessionManager = new SessionManager(fakeTimer, new FakeDeviceSessionPersistence());
       const { FakeInstalledAppsRepository } = await import("../../fakes/FakeInstalledAppsRepository");
       const fakeAppsRepo = new FakeInstalledAppsRepository();
       const devicePool = new DevicePool(

--- a/test/server/sessionToolCapabilities.test.ts
+++ b/test/server/sessionToolCapabilities.test.ts
@@ -8,6 +8,7 @@ import { DaemonState } from "../../src/daemon/daemonState";
 import { SessionManager } from "../../src/daemon/sessionManager";
 import { DevicePool } from "../../src/daemon/devicePool";
 import { FakeTimer } from "../fakes/FakeTimer";
+import { FakeDeviceSessionPersistence } from "../fakes/FakeDeviceSessionPersistence";
 import { FakeDeviceUtils } from "../fakes/FakeDeviceUtils";
 import { registerToolCapabilityTools } from "../../src/server/toolCapabilityTools";
 import { getToolCapabilityContext } from "../../src/features/toolCapabilities/toolCapabilityContext";
@@ -414,7 +415,7 @@ describe("capability union at the MCP boundary (#4611)", () => {
   beforeEach(async () => {
     ToolRegistry.clearTools();
     const timer = new FakeTimer();
-    sessionManager = new SessionManager(timer);
+    sessionManager = new SessionManager(timer, new FakeDeviceSessionPersistence());
     const fakeDeviceUtils = new FakeDeviceUtils();
     fakeDeviceUtils.setBootedDevices("android", [device]);
     const pool = new DevicePool(sessionManager, "daemon-session", timer, undefined, fakeDeviceUtils);

--- a/test/server/toolCapabilityRouting.test.ts
+++ b/test/server/toolCapabilityRouting.test.ts
@@ -8,6 +8,7 @@ import { DaemonState } from "../../src/daemon/daemonState";
 import { SessionManager } from "../../src/daemon/sessionManager";
 import { DevicePool } from "../../src/daemon/devicePool";
 import { FakeTimer } from "../fakes/FakeTimer";
+import { FakeDeviceSessionPersistence } from "../fakes/FakeDeviceSessionPersistence";
 import { FakeDeviceUtils } from "../fakes/FakeDeviceUtils";
 import { FakeDeviceSessionManager } from "../fakes/FakeDeviceSessionManager";
 
@@ -76,7 +77,7 @@ describe("ToolRegistry capability routing and enforcement (#4611)", () => {
 
   test("Gap A end-to-end: a real deviceId-only call enforces the device's owning session", async () => {
     const timer = new FakeTimer();
-    const sessionManager = new SessionManager(timer);
+    const sessionManager = new SessionManager(timer, new FakeDeviceSessionPersistence());
     const fakeDeviceUtils = new FakeDeviceUtils();
     fakeDeviceUtils.setBootedDevices("android", [device]);
     const pool = new DevicePool(sessionManager, "daemon-session", timer, undefined, fakeDeviceUtils);
@@ -204,7 +205,7 @@ describe("ToolRegistry capability routing and enforcement (#4611)", () => {
   // union gate entirely.
   const initializeDaemonWithLabeledBase = async () => {
     const timer = new FakeTimer();
-    const sessionManager = new SessionManager(timer);
+    const sessionManager = new SessionManager(timer, new FakeDeviceSessionPersistence());
     const fakeDeviceUtils = new FakeDeviceUtils();
     fakeDeviceUtils.setBootedDevices("android", [device]);
     const pool = new DevicePool(sessionManager, "daemon-session", timer, undefined, fakeDeviceUtils);

--- a/test/server/toolRegistry.autolockSession.test.ts
+++ b/test/server/toolRegistry.autolockSession.test.ts
@@ -7,6 +7,7 @@ import { DaemonState } from "../../src/daemon/daemonState";
 import { SessionManager } from "../../src/daemon/sessionManager";
 import { DevicePool } from "../../src/daemon/devicePool";
 import { FakeTimer } from "../fakes/FakeTimer";
+import { FakeDeviceSessionPersistence } from "../fakes/FakeDeviceSessionPersistence";
 import { FakeDeviceUtils } from "../fakes/FakeDeviceUtils";
 
 const AUTOLOCK_ENV_KEYS = [
@@ -144,7 +145,7 @@ describe("ToolRegistry autolock session enforcement", () => {
     fakeDeviceSessionManager.setConnectedDevices([androidA, androidB]);
 
     const timer = new FakeTimer();
-    daemonSessionManager = new SessionManager(timer);
+    daemonSessionManager = new SessionManager(timer, new FakeDeviceSessionPersistence());
     const fakeDeviceUtils = new FakeDeviceUtils();
     fakeDeviceUtils.setBootedDevices("android", [androidA, androidB]);
     const pool = new DevicePool(daemonSessionManager, "daemon-session", timer, undefined, fakeDeviceUtils);
@@ -178,7 +179,7 @@ describe("ToolRegistry autolock session enforcement", () => {
     fakeDeviceSessionManager.setConnectedDevices([androidA, androidB]);
 
     const timer = new FakeTimer();
-    daemonSessionManager = new SessionManager(timer);
+    daemonSessionManager = new SessionManager(timer, new FakeDeviceSessionPersistence());
     const fakeDeviceUtils = new FakeDeviceUtils();
     fakeDeviceUtils.setBootedDevices("android", [androidA, androidB]);
     const pool = new DevicePool(daemonSessionManager, "daemon-session", timer, undefined, fakeDeviceUtils);
@@ -212,7 +213,7 @@ describe("ToolRegistry autolock session enforcement", () => {
     fakeDeviceSessionManager.setConnectedDevices([androidA, androidB]);
 
     const timer = new FakeTimer();
-    daemonSessionManager = new SessionManager(timer);
+    daemonSessionManager = new SessionManager(timer, new FakeDeviceSessionPersistence());
     const fakeDeviceUtils = new FakeDeviceUtils();
     fakeDeviceUtils.setBootedDevices("android", [androidA, androidB]);
     const pool = new DevicePool(daemonSessionManager, "daemon-session", timer, undefined, fakeDeviceUtils);

--- a/test/server/toolRegistry.internalNoDiff.test.ts
+++ b/test/server/toolRegistry.internalNoDiff.test.ts
@@ -4,6 +4,7 @@ import { ToolRegistry } from "../../src/server/toolRegistry";
 import { FakeDeviceSessionManager } from "../fakes/FakeDeviceSessionManager";
 import { FakeDeviceUtils } from "../fakes/FakeDeviceUtils";
 import { FakeTimer } from "../fakes/FakeTimer";
+import { FakeDeviceSessionPersistence } from "../fakes/FakeDeviceSessionPersistence";
 import { BootedDevice } from "../../src/models";
 import { DaemonState } from "../../src/daemon/daemonState";
 import { SessionManager } from "../../src/daemon/sessionManager";
@@ -61,7 +62,7 @@ describe("ToolRegistry internal no-diff guard (#3053)", () => {
   async function setupAutolockedSession(): Promise<string> {
     fakeDeviceSessionManager.setConnectedDevices([androidA]);
     const timer = new FakeTimer();
-    daemonSessionManager = new SessionManager(timer);
+    daemonSessionManager = new SessionManager(timer, new FakeDeviceSessionPersistence());
     const fakeDeviceUtils = new FakeDeviceUtils();
     fakeDeviceUtils.setBootedDevices("android", [androidA]);
     const pool = new DevicePool(daemonSessionManager, "daemon-session", timer, undefined, fakeDeviceUtils);

--- a/test/server/toolRegistry.lastHierarchyCache.test.ts
+++ b/test/server/toolRegistry.lastHierarchyCache.test.ts
@@ -4,6 +4,7 @@ import { ToolRegistry } from "../../src/server/toolRegistry";
 import { FakeDeviceSessionManager } from "../fakes/FakeDeviceSessionManager";
 import { FakeDeviceUtils } from "../fakes/FakeDeviceUtils";
 import { FakeTimer } from "../fakes/FakeTimer";
+import { FakeDeviceSessionPersistence } from "../fakes/FakeDeviceSessionPersistence";
 import { BootedDevice } from "../../src/models";
 import { DaemonState } from "../../src/daemon/daemonState";
 import { SessionManager } from "../../src/daemon/sessionManager";
@@ -53,7 +54,7 @@ describe("ToolRegistry observe lastHierarchy cache repair (#2758)", () => {
     fakeDeviceSessionManager.setConnectedDevices([androidA]);
 
     const timer = new FakeTimer();
-    daemonSessionManager = new SessionManager(timer);
+    daemonSessionManager = new SessionManager(timer, new FakeDeviceSessionPersistence());
     const fakeDeviceUtils = new FakeDeviceUtils();
     fakeDeviceUtils.setBootedDevices("android", [androidA]);
     const pool = new DevicePool(daemonSessionManager, "daemon-session", timer, undefined, fakeDeviceUtils);

--- a/test/server/toolRegistry.scrollPositionUpdate.test.ts
+++ b/test/server/toolRegistry.scrollPositionUpdate.test.ts
@@ -4,6 +4,7 @@ import { ToolRegistry } from "../../src/server/toolRegistry";
 import { FakeDeviceSessionManager } from "../fakes/FakeDeviceSessionManager";
 import { FakeDeviceUtils } from "../fakes/FakeDeviceUtils";
 import { FakeTimer } from "../fakes/FakeTimer";
+import { FakeDeviceSessionPersistence } from "../fakes/FakeDeviceSessionPersistence";
 import { BootedDevice } from "../../src/models";
 import { DaemonState } from "../../src/daemon/daemonState";
 import { SessionManager } from "../../src/daemon/sessionManager";
@@ -38,7 +39,7 @@ describe("ToolRegistry swipeOn scroll-position update repair (#2897)", () => {
     fakeDeviceSessionManager.setConnectedDevices([androidA]);
 
     const timer = new FakeTimer();
-    daemonSessionManager = new SessionManager(timer);
+    daemonSessionManager = new SessionManager(timer, new FakeDeviceSessionPersistence());
     const fakeDeviceUtils = new FakeDeviceUtils();
     fakeDeviceUtils.setBootedDevices("android", [androidA]);
     const pool = new DevicePool(daemonSessionManager, "daemon-session", timer, undefined, fakeDeviceUtils);

--- a/test/server/utilityTools.deviceState.test.ts
+++ b/test/server/utilityTools.deviceState.test.ts
@@ -9,6 +9,7 @@ import { DefaultRetryExecutor } from "../../src/utils/retry/RetryExecutor";
 import { FakeDeviceManager } from "../fakes/FakeDeviceManager";
 import { FakeInstalledAppsRepository } from "../fakes/FakeInstalledAppsRepository";
 import { FakeTimer } from "../fakes/FakeTimer";
+import { FakeDeviceSessionPersistence } from "../fakes/FakeDeviceSessionPersistence";
 
 const createBootedDevice = (
   deviceId: string,
@@ -52,7 +53,7 @@ describe("device state tools", () => {
 
   test("setActiveDevice binds a refreshed session device in the pool", async () => {
     const fakeTimer = new FakeTimer();
-    const sessionManager = new SessionManager(fakeTimer);
+    const sessionManager = new SessionManager(fakeTimer, new FakeDeviceSessionPersistence());
     const fakeDeviceManager = new FakeDeviceManager(
       [],
       [createBootedDevice("sim-new", "ios", "iPhone 16")]
@@ -83,7 +84,7 @@ describe("device state tools", () => {
 
   test("setActiveDevice rejects devices owned by another live session", async () => {
     const fakeTimer = new FakeTimer();
-    const sessionManager = new SessionManager(fakeTimer);
+    const sessionManager = new SessionManager(fakeTimer, new FakeDeviceSessionPersistence());
     const fakeDeviceManager = new FakeDeviceManager(
       [],
       [


### PR DESCRIPTION
## Summary

- Roll back SessionManager ownership maps and DevicePool assignment state when session creation persistence fails.
- Continue release callbacks and device cleanup when release persistence fails, while logging the failed write.
- Add an injected persistence interface and fake-backed regression coverage for both failure paths.

## Root cause

Session and pool ownership were mutated before awaited repository writes. A rejected write could leave stale in-memory ownership or bypass release cleanup.

## Validation

- `bun run turbo:validate` — 7 tasks successful; 13,233 passed, 13 skipped, 0 failed.
- `bun run typecheck` — no new errors beyond the accepted baseline.
- Mutation-tested each new regression by temporarily removing its rollback or cleanup behavior.

Closes [#5292](https://github.com/kaeawc/auto-mobile/issues/5292)
