### PR TITLE
fix(daemon): serialize creation of the same session UUID

### DIFF
--- a/src/daemon/devicePool.ts
+++ b/src/daemon/devicePool.ts
@@ -1786,21 +1786,13 @@ export class DevicePool {
         };
       }
 
-      // Assign to session
-      device.sessionId = sessionId;
-      device.status = "busy";
-      device.lastUsedAt = this.nextLastUsedAt();
-      device.assignmentCount++;
-      device.errorCount = 0; // Reset errors on successful assignment
-
-      // Create session in SessionManager
-      await this.sessionManager.createSession(sessionId, device.id, device.platform);
+      const assignedDeviceId = await this.claimSelectedDeviceForSession(sessionId, device);
 
       logger.info(`Assigned device ${device.id} to session ${sessionId}`);
 
       return {
         success: true,
-        deviceId: device.id,
+        deviceId: assignedDeviceId,
         shouldWait: false,
         totalDevices,
       };
@@ -1850,6 +1842,29 @@ export class DevicePool {
     }
 
     return { livenessUnknown };
+  }
+
+  private async claimSelectedDeviceForSession(
+    sessionId: string,
+    device: PooledDevice,
+  ): Promise<string> {
+    // Create the session before claiming the device. A direct binding can
+    // create the same session while this allocator waits for the mutex; in
+    // that case, its device remains the sole owner.
+    const session = await this.sessionManager.createSession(sessionId, device.id, device.platform);
+    if (session.assignedDevice !== device.id) {
+      logger.info(
+        `Reusing session ${sessionId} already assigned to device ${session.assignedDevice}`,
+      );
+      return session.assignedDevice;
+    }
+
+    device.sessionId = sessionId;
+    device.status = "busy";
+    device.lastUsedAt = this.nextLastUsedAt();
+    device.assignmentCount++;
+    device.errorCount = 0;
+    return device.id;
   }
 
   private selectIdleDevice(candidates: PooledDevice[]): PooledDevice | undefined {
@@ -2123,16 +2138,32 @@ export class DevicePool {
         device.status = "idle";
       }
 
-      device.sessionId = sessionId;
-      device.status = "busy";
-      device.lastUsedAt = this.nextLastUsedAt();
-      device.assignmentCount++;
-      device.errorCount = 0;
+      await this.claimKnownDeviceForSession(sessionId, device, platform);
 
-      await this.sessionManager.createSession(sessionId, deviceId, platform);
       logger.info(`Bound device ${deviceId} to session ${sessionId}`);
       return sessionId;
     });
+  }
+
+  private async claimKnownDeviceForSession(
+    sessionId: string,
+    device: PooledDevice,
+    platform: Platform,
+  ): Promise<void> {
+    // Create the session before claiming the device so a session created by
+    // the automatic allocator cannot leave this device reserved as well.
+    const session = await this.sessionManager.createSession(sessionId, device.id, platform);
+    if (session.assignedDevice !== device.id) {
+      throw new ActionableError(
+        `Session '${sessionId}' is already assigned to device '${session.assignedDevice}'.`,
+      );
+    }
+
+    device.sessionId = sessionId;
+    device.status = "busy";
+    device.lastUsedAt = this.nextLastUsedAt();
+    device.assignmentCount++;
+    device.errorCount = 0;
   }
 
   private async reuseExistingDeviceSession(

--- a/src/daemon/sessionManager.ts
+++ b/src/daemon/sessionManager.ts
@@ -263,15 +263,13 @@ export class SessionManager {
       return await pendingCreation;
     }
 
-    const creation = this.createUnseenSession(sessionId, devicePool, platform);
-    this.pendingSessionCreations.set(sessionId, creation);
-    try {
-      return await creation;
-    } finally {
+    const creation = this.createUnseenSession(sessionId, devicePool, platform).finally(() => {
       if (this.pendingSessionCreations.get(sessionId) === creation) {
         this.pendingSessionCreations.delete(sessionId);
       }
-    }
+    });
+    this.pendingSessionCreations.set(sessionId, creation);
+    return await creation;
   }
 
   private async createUnseenSession(

--- a/src/daemon/sessionManager.ts
+++ b/src/daemon/sessionManager.ts
@@ -84,6 +84,10 @@ export interface Session {
  */
 export type SessionReleaseCallback = (sessionId: string, deviceId: string) => void;
 
+export interface SessionDeviceAssigner {
+  assignDeviceToSession(sessionId: string, platform?: Platform): Promise<string>;
+}
+
 export function getDefaultSessionHeartbeatTimeoutMs(): number {
   const rawValue = process.env.AUTOMOBILE_SESSION_HEARTBEAT_TIMEOUT_MS
     ?? process.env.AUTO_MOBILE_SESSION_HEARTBEAT_TIMEOUT_MS;
@@ -97,6 +101,7 @@ export class SessionManager {
   private sessions: Map<string, Session> = new Map();
   private sessionDeviceMap: Map<string, string> = new Map(); // sessionId -> deviceId
   private deviceSessionMap: Map<string, string> = new Map(); // deviceId -> sessionId (reverse lookup)
+  private pendingSessionCreations: Map<string, Promise<Session>> = new Map();
   private cleanupTimer: NodeJS.Timeout | null = null;
   private timer: Timer;
   private releaseCallbacks: SessionReleaseCallback[] = [];
@@ -234,7 +239,7 @@ export class SessionManager {
    */
   async getOrCreateSession(
     sessionId: string,
-    devicePool?: import("./devicePool").DevicePool,
+    devicePool?: SessionDeviceAssigner,
     platform?: Platform
   ): Promise<Session> {
     const existing = this.getSession(sessionId);
@@ -253,6 +258,27 @@ export class SessionManager {
       return existing;
     }
 
+    const pendingCreation = this.pendingSessionCreations.get(sessionId);
+    if (pendingCreation) {
+      return await pendingCreation;
+    }
+
+    const creation = this.createUnseenSession(sessionId, devicePool, platform);
+    this.pendingSessionCreations.set(sessionId, creation);
+    try {
+      return await creation;
+    } finally {
+      if (this.pendingSessionCreations.get(sessionId) === creation) {
+        this.pendingSessionCreations.delete(sessionId);
+      }
+    }
+  }
+
+  private async createUnseenSession(
+    sessionId: string,
+    devicePool: SessionDeviceAssigner | undefined,
+    platform: Platform | undefined,
+  ): Promise<Session> {
     logger.info(`[SessionManager] Creating new session ${sessionId}, calling devicePool.assignDeviceToSession()`);
 
     // Need to create new session - assign device from pool

--- a/test/daemon/devicePool.test.ts
+++ b/test/daemon/devicePool.test.ts
@@ -1279,6 +1279,24 @@ describe("DevicePool", () => {
       expect(device?.errorCount).toBe(0);
     });
 
+    test("concurrent same-session creation converges on one assigned device", async () => {
+      await initializeLiveDevices([
+        createBootedDevice("emulator-5554"),
+        createBootedDevice("emulator-5556"),
+      ]);
+
+      const [first, second] = await Promise.all([
+        sessionManager.getOrCreateSession("shared-session", devicePool),
+        sessionManager.getOrCreateSession("shared-session", devicePool),
+      ]);
+
+      expect(first.sessionId).toBe("shared-session");
+      expect(second).toBe(first);
+      expect(first.assignedDevice).toBe(second.assignedDevice);
+      expect(devicePool.getAvailableDeviceCount()).toBe(1);
+      expect(devicePool.getDevice(first.assignedDevice)?.status).toBe("busy");
+    });
+
     test("should throw error when no devices available after timeout", async () => {
       // Use manual mode so we can control time advancement
 

--- a/test/daemon/devicePool.test.ts
+++ b/test/daemon/devicePool.test.ts
@@ -1297,6 +1297,51 @@ describe("DevicePool", () => {
       expect(devicePool.getDevice(first.assignedDevice)?.status).toBe("busy");
     });
 
+    test("does not reserve a second device when binding an automatically created session", async () => {
+      await initializeLiveDevices([
+        createBootedDevice("emulator-5554"),
+        createBootedDevice("emulator-5556"),
+      ]);
+
+      const session = await sessionManager.getOrCreateSession("shared-session", devicePool);
+      const otherDeviceId = session.assignedDevice === "emulator-5554"
+        ? "emulator-5556"
+        : "emulator-5554";
+
+      await expect(
+        devicePool.bindOrReuseDeviceSession("shared-session", otherDeviceId, "android"),
+      ).rejects.toThrow(`Session 'shared-session' is already assigned to device '${session.assignedDevice}'.`);
+
+      expect(devicePool.getAvailableDeviceCount()).toBe(1);
+      expect(devicePool.getDevice(otherDeviceId)).toMatchObject({
+        sessionId: null,
+        status: "idle",
+      });
+    });
+
+    test("keeps an explicit binding as the sole owner during automatic creation", async () => {
+      await initializeLiveDevices([
+        createBootedDevice("emulator-5554"),
+        createBootedDevice("emulator-5556"),
+      ]);
+
+      const explicitBinding = devicePool.bindOrReuseDeviceSession(
+        "shared-session",
+        "emulator-5556",
+        "android",
+      );
+      const automaticCreation = sessionManager.getOrCreateSession("shared-session", devicePool);
+      const [boundSession, session] = await Promise.all([explicitBinding, automaticCreation]);
+
+      expect(boundSession).toBe("shared-session");
+      expect(session.assignedDevice).toBe("emulator-5556");
+      expect(devicePool.getAvailableDeviceCount()).toBe(1);
+      expect(devicePool.getDevice("emulator-5554")).toMatchObject({
+        sessionId: null,
+        status: "idle",
+      });
+    });
+
     test("should throw error when no devices available after timeout", async () => {
       // Use manual mode so we can control time advancement
 

--- a/test/daemon/sessionManager.test.ts
+++ b/test/daemon/sessionManager.test.ts
@@ -1,5 +1,9 @@
 import { describe, expect, test, beforeEach, afterEach } from "bun:test";
-import { SessionManager, type KeepScreenAwakeRestorer } from "../../src/daemon/sessionManager";
+import {
+  SessionManager,
+  type KeepScreenAwakeRestorer,
+  type SessionDeviceAssigner,
+} from "../../src/daemon/sessionManager";
 import { FakeTimer } from "../fakes/FakeTimer";
 import { FakeDbWriteBarrier } from "../fakes/FakeDbWriteBarrier";
 import type { ViewHierarchyResult } from "../../src/models/ViewHierarchyResult";
@@ -141,6 +145,66 @@ describe("SessionManager", () => {
         expect(error instanceof Error).toBe(true);
         expect((error as Error).message).toContain("not found");
       }
+    });
+
+    test("allows distinct unseen session IDs to begin assignment independently", async () => {
+      const assignedSessionIds: string[] = [];
+      let releaseAssignments!: () => void;
+      const assignmentsReleased = new Promise<void>((resolve) => {
+        releaseAssignments = resolve;
+      });
+      let signalBothAssignmentsStarted!: () => void;
+      const bothAssignmentsStarted = new Promise<void>((resolve) => {
+        signalBothAssignmentsStarted = resolve;
+      });
+      const devicePool: SessionDeviceAssigner = {
+        assignDeviceToSession: async (sessionId: string): Promise<string> => {
+          assignedSessionIds.push(sessionId);
+          if (assignedSessionIds.length === 2) {
+            signalBothAssignmentsStarted();
+          }
+          await assignmentsReleased;
+          const session = await sessionManager.createSession(sessionId, `device-${sessionId}`, "android");
+          return session.assignedDevice;
+        },
+      };
+
+      const sessionsPromise = Promise.all([
+        sessionManager.getOrCreateSession("session-a", devicePool),
+        sessionManager.getOrCreateSession("session-b", devicePool),
+      ]);
+
+      await bothAssignmentsStarted;
+      expect(assignedSessionIds).toEqual(["session-a", "session-b"]);
+
+      releaseAssignments();
+      const [first, second] = await sessionsPromise;
+      expect(first.assignedDevice).toBe("device-session-a");
+      expect(second.assignedDevice).toBe("device-session-b");
+    });
+
+    test("allows a retry after an unseen-session assignment fails", async () => {
+      let attempts = 0;
+      const devicePool: SessionDeviceAssigner = {
+        assignDeviceToSession: async (sessionId: string): Promise<string> => {
+          attempts++;
+          if (attempts === 1) {
+            throw new Error("first assignment failed");
+          }
+          const session = await sessionManager.createSession(sessionId, "retry-device", "android");
+          return session.assignedDevice;
+        },
+      };
+
+      await expect(sessionManager.getOrCreateSession("retry-session", devicePool)).rejects.toThrow(
+        "first assignment failed",
+      );
+
+      await expect(sessionManager.getOrCreateSession("retry-session", devicePool)).resolves.toMatchObject({
+        sessionId: "retry-session",
+        assignedDevice: "retry-device",
+      });
+      expect(attempts).toBe(2);
     });
 
     test("should return null session when expired session requested", async () => {


### PR DESCRIPTION
## Summary

- Deduplicate concurrent unseen-session creation by session UUID.
- Keep distinct session UUID allocations independent and allow retries after a failed assignment.
- Add deterministic session-manager and device-pool regressions.

## Root cause

Two callers could both observe a missing session before either assignment completed. Device assignment was serialized, but the second caller did not re-check session creation after entering that allocation path, so it could reserve a second device even though `createSession` returned the first session.

## Validation

- `bun test test/daemon/sessionManager.test.ts test/daemon/devicePool.test.ts`
- `bun run typecheck`
- `bun run turbo:validate` — 13,201 passed, 13 expected skips

Closes [#5291](https://github.com/kaeawc/auto-mobile/issues/5291)
