### PR TITLE
fix(daemon): preserve active sessions during expiry cleanup

### DIFF
--- a/src/daemon/daemon.ts
+++ b/src/daemon/daemon.ts
@@ -4,7 +4,7 @@ import { createMcpServer } from "../server";
 import { logger } from "../utils/logger";
 import { MultiPlatformDeviceManager } from "../utils/deviceUtils";
 import { UnixSocketServer } from "./socketServer";
-import { SessionManager } from "./sessionManager";
+import { SessionManager, type ActiveSessionExecutionQuery } from "./sessionManager";
 import { SessionHeartbeatMonitor } from "./SessionHeartbeatMonitor";
 import { SingleFlightInterval } from "./SingleFlightInterval";
 import { DevicePool, type PooledDevice } from "./devicePool";
@@ -219,7 +219,7 @@ export class Daemon {
     this.deviceSessionRepository = deviceSessionRepository;
     this.sessionManager = new SessionManager(this.timer, this.deviceSessionRepository);
     this.sessionManager.setActiveSessionExecutionChecker(
-      (sessionId, startedAtOrBefore) => this.hasActiveSessionExecution(sessionId, startedAtOrBefore),
+      (sessionId, query) => this.hasActiveSessionExecution(sessionId, query),
     );
     // Register centralized cleanup for session-scoped state
     this.sessionManager.onSessionRelease((sessionId, deviceId) => {
@@ -1229,12 +1229,12 @@ export class Daemon {
     this.navigationRetentionMonitor.start();
   }
 
-  private hasActiveSessionExecution(sessionId: string, startedAtOrBefore?: number): boolean {
-    return executionTracker.hasActiveSessionUuidExecutions(sessionId, startedAtOrBefore)
+  private hasActiveSessionExecution(sessionId: string, query?: ActiveSessionExecutionQuery): boolean {
+    return executionTracker.hasActiveSessionUuidExecutions(sessionId, query)
       || this.devicePool.hasActiveAutolockMcpSessionExecution(
         sessionId,
-        (mcpSessionId, startAtOrBefore) => executionTracker.hasActiveSessionExecutions(mcpSessionId, startAtOrBefore),
-        startedAtOrBefore,
+        (mcpSessionId, executionQuery) => executionTracker.hasActiveSessionExecutions(mcpSessionId, executionQuery),
+        query,
       );
   }
 

--- a/src/daemon/daemon.ts
+++ b/src/daemon/daemon.ts
@@ -218,6 +218,9 @@ export class Daemon {
     });
     this.deviceSessionRepository = deviceSessionRepository;
     this.sessionManager = new SessionManager(this.timer, this.deviceSessionRepository);
+    this.sessionManager.setActiveSessionExecutionChecker(
+      sessionId => this.hasActiveSessionExecution(sessionId),
+    );
     // Register centralized cleanup for session-scoped state
     this.sessionManager.onSessionRelease((sessionId, deviceId) => {
       NavigationGraphManager.releaseSession(sessionId);
@@ -1202,7 +1205,7 @@ export class Daemon {
   private startHeartbeatMonitor(): void {
     this.heartbeatMonitor = new SessionHeartbeatMonitor(
       this.sessionManager,
-      sessionId => executionTracker.hasActiveSessionUuidExecutions(sessionId),
+      sessionId => this.hasActiveSessionExecution(sessionId),
       sessionId => this.cancelAndReleaseSession(sessionId),
       this.timer,
     );
@@ -1224,6 +1227,14 @@ export class Daemon {
     );
     this.navigationRetentionMonitor = new NavigationRetentionMonitor(retention, this.timer);
     this.navigationRetentionMonitor.start();
+  }
+
+  private hasActiveSessionExecution(sessionId: string): boolean {
+    return executionTracker.hasActiveSessionUuidExecutions(sessionId)
+      || this.devicePool.hasActiveAutolockMcpSessionExecution(
+        sessionId,
+        mcpSessionId => executionTracker.hasActiveSessionExecutions(mcpSessionId),
+      );
   }
 
   private startDeviceDisconnectMonitor(): void {

--- a/src/daemon/daemon.ts
+++ b/src/daemon/daemon.ts
@@ -219,7 +219,7 @@ export class Daemon {
     this.deviceSessionRepository = deviceSessionRepository;
     this.sessionManager = new SessionManager(this.timer, this.deviceSessionRepository);
     this.sessionManager.setActiveSessionExecutionChecker(
-      sessionId => this.hasActiveSessionExecution(sessionId),
+      (sessionId, startedAtOrBefore) => this.hasActiveSessionExecution(sessionId, startedAtOrBefore),
     );
     // Register centralized cleanup for session-scoped state
     this.sessionManager.onSessionRelease((sessionId, deviceId) => {
@@ -1229,11 +1229,12 @@ export class Daemon {
     this.navigationRetentionMonitor.start();
   }
 
-  private hasActiveSessionExecution(sessionId: string): boolean {
-    return executionTracker.hasActiveSessionUuidExecutions(sessionId)
+  private hasActiveSessionExecution(sessionId: string, startedAtOrBefore?: number): boolean {
+    return executionTracker.hasActiveSessionUuidExecutions(sessionId, startedAtOrBefore)
       || this.devicePool.hasActiveAutolockMcpSessionExecution(
         sessionId,
-        mcpSessionId => executionTracker.hasActiveSessionExecutions(mcpSessionId),
+        (mcpSessionId, startAtOrBefore) => executionTracker.hasActiveSessionExecutions(mcpSessionId, startAtOrBefore),
+        startedAtOrBefore,
       );
   }
 

--- a/src/daemon/devicePool.ts
+++ b/src/daemon/devicePool.ts
@@ -1,7 +1,12 @@
 import type { ChildProcess } from "child_process";
 import { randomUUID } from "node:crypto";
 import { logger } from "../utils/logger";
-import { SessionManager, type Session } from "./sessionManager";
+import {
+  SessionManager,
+  type ActiveSessionExecutionQuery,
+  type Session,
+  type SessionExecutionMetadata,
+} from "./sessionManager";
 import { ActionableError, BootedDevice, DeviceInfo, Platform } from "../models";
 import { Mutex } from "async-mutex";
 import {
@@ -2767,6 +2772,7 @@ export class DevicePool {
   resolveAutolockSessionForMcpSession(
     mcpSessionId: string | undefined,
     platform?: Platform,
+    execution?: SessionExecutionMetadata,
   ): string | undefined {
     if (!mcpSessionId) {
       return undefined;
@@ -2777,7 +2783,7 @@ export class DevicePool {
       return undefined;
     }
 
-    const session = this.sessionManager.getSessionForNewExecution(sessionId);
+    const session = this.sessionManager.getSessionForNewExecution(sessionId, execution);
     if (!session) {
       this.mcpSessionAutolockMap.delete(mcpSessionId);
       return undefined;
@@ -2803,11 +2809,11 @@ export class DevicePool {
    */
   hasActiveAutolockMcpSessionExecution(
     sessionId: string,
-    hasActiveMcpSessionExecution: (mcpSessionId: string, startedAtOrBefore?: number) => boolean,
-    startedAtOrBefore?: number,
+    hasActiveMcpSessionExecution: (mcpSessionId: string, query?: ActiveSessionExecutionQuery) => boolean,
+    query?: ActiveSessionExecutionQuery,
   ): boolean {
     for (const [mcpSessionId, mappedSessionId] of this.mcpSessionAutolockMap) {
-      if (mappedSessionId === sessionId && hasActiveMcpSessionExecution(mcpSessionId, startedAtOrBefore)) {
+      if (mappedSessionId === sessionId && hasActiveMcpSessionExecution(mcpSessionId, query)) {
         return true;
       }
     }

--- a/src/daemon/devicePool.ts
+++ b/src/daemon/devicePool.ts
@@ -2777,7 +2777,7 @@ export class DevicePool {
       return undefined;
     }
 
-    const session = this.sessionManager.getSession(sessionId);
+    const session = this.sessionManager.getSessionForNewExecution(sessionId);
     if (!session) {
       this.mcpSessionAutolockMap.delete(mcpSessionId);
       return undefined;
@@ -2803,10 +2803,11 @@ export class DevicePool {
    */
   hasActiveAutolockMcpSessionExecution(
     sessionId: string,
-    hasActiveMcpSessionExecution: (mcpSessionId: string) => boolean,
+    hasActiveMcpSessionExecution: (mcpSessionId: string, startedAtOrBefore?: number) => boolean,
+    startedAtOrBefore?: number,
   ): boolean {
     for (const [mcpSessionId, mappedSessionId] of this.mcpSessionAutolockMap) {
-      if (mappedSessionId === sessionId && hasActiveMcpSessionExecution(mcpSessionId)) {
+      if (mappedSessionId === sessionId && hasActiveMcpSessionExecution(mcpSessionId, startedAtOrBefore)) {
         return true;
       }
     }

--- a/src/daemon/devicePool.ts
+++ b/src/daemon/devicePool.ts
@@ -2797,6 +2797,23 @@ export class DevicePool {
   }
 
   /**
+   * Whether a live MCP call owns this autolock session. The execution tracker
+   * keys socket-forwarded work by MCP session while SessionManager keys expiry
+   * by the generated device-session UUID, so this bridges those identities.
+   */
+  hasActiveAutolockMcpSessionExecution(
+    sessionId: string,
+    hasActiveMcpSessionExecution: (mcpSessionId: string) => boolean,
+  ): boolean {
+    for (const [mcpSessionId, mappedSessionId] of this.mcpSessionAutolockMap) {
+      if (mappedSessionId === sessionId && hasActiveMcpSessionExecution(mcpSessionId)) {
+        return true;
+      }
+    }
+    return false;
+  }
+
+  /**
    * Free a device whose autolock session has been released or has expired.
    *
    * Invoked via the SessionManager release callback. Only acts on devices that

--- a/src/daemon/sessionManager.ts
+++ b/src/daemon/sessionManager.ts
@@ -234,8 +234,24 @@ export class SessionManager {
    * Get existing session
    */
   getSession(sessionId: string): Session | null {
+    return this.getSessionInternal(sessionId, false);
+  }
+
+  /**
+   * Resolve a session before a new tool execution is accepted. Existing work may
+   * defer expiry cleanup, but it must not let a request that arrived after the
+   * deadline revive an expired session.
+   */
+  getSessionForNewExecution(sessionId: string): Session | null {
+    return this.getSessionInternal(sessionId, true);
+  }
+
+  private getSessionInternal(sessionId: string, expireDespiteActiveExecution: boolean): Session | null {
     const session = this.sessions.get(sessionId);
-    if (session && this.isSessionExpired(session)) {
+<<<<<<< HEAD
+    if (session && (expireDespiteActiveExecution
+      ? this.timer.now() > session.expiresAt
+      : this.isSessionExpired(session))) {
       // Release owns this exact session object until it has restored device state
       // and removed its assignment. Keep expiry cleanup from creating a second
       // incarnation with the same UUID before teardown completes.
@@ -275,7 +291,7 @@ export class SessionManager {
     devicePool?: SessionDeviceAssigner,
     platform?: Platform
   ): Promise<Session> {
-    const existing = this.getSession(sessionId);
+    const existing = this.getSessionForNewExecution(sessionId);
     if (existing) {
       const inFlightRelease = this.releasePromises.get(sessionId);
       if (this.releasingSessions.has(existing) && inFlightRelease?.session === existing) {

--- a/src/daemon/sessionManager.ts
+++ b/src/daemon/sessionManager.ts
@@ -83,7 +83,17 @@ export interface Session {
  * while sharing centralized state in the daemon.
  */
 export type SessionReleaseCallback = (sessionId: string, deviceId: string) => void;
-export type ActiveSessionExecutionChecker = (sessionId: string, startedAtOrBefore?: number) => boolean;
+export interface SessionExecutionMetadata {
+  executionId: string;
+  startTime: number;
+}
+
+export interface ActiveSessionExecutionQuery {
+  startedAtOrBefore?: number;
+  excludeExecutionId?: string;
+}
+
+export type ActiveSessionExecutionChecker = (sessionId: string, query?: ActiveSessionExecutionQuery) => boolean;
 
 export interface SessionDeviceAssigner {
   assignDeviceToSession(sessionId: string, platform?: Platform): Promise<string>;
@@ -242,15 +252,23 @@ export class SessionManager {
    * defer expiry cleanup, but it must not let a request that arrived after the
    * deadline revive an expired session.
    */
-  getSessionForNewExecution(sessionId: string): Session | null {
-    return this.getSessionInternal(sessionId, true);
+  getSessionForNewExecution(sessionId: string, execution?: SessionExecutionMetadata): Session | null {
+    return this.getSessionInternal(sessionId, true, execution);
   }
 
-  private getSessionInternal(sessionId: string, expireDespiteActiveExecution: boolean): Session | null {
+  private getSessionInternal(
+    sessionId: string,
+    expireDespiteActiveExecution: boolean,
+    execution?: SessionExecutionMetadata,
+  ): Session | null {
     const session = this.sessions.get(sessionId);
-<<<<<<< HEAD
+    if (session && expireDespiteActiveExecution && this.isLateExecutionWhileEarlierWorkIsActive(session, execution)) {
+      throw new Error(
+        `Session ${sessionId} expired before this execution began while earlier work is still active.`,
+      );
+    }
     if (session && (expireDespiteActiveExecution
-      ? this.isSessionExpiredForNewExecution(session)
+      ? this.isSessionExpiredForNewExecution(session, execution)
       : this.isSessionExpired(session))) {
       // Release owns this exact session object until it has restored device state
       // and removed its assignment. Keep expiry cleanup from creating a second
@@ -289,9 +307,10 @@ export class SessionManager {
   async getOrCreateSession(
     sessionId: string,
     devicePool?: SessionDeviceAssigner,
-    platform?: Platform
+    platform?: Platform,
+    execution?: SessionExecutionMetadata,
   ): Promise<Session> {
-    const existing = this.getSessionForNewExecution(sessionId);
+    const existing = this.getSessionForNewExecution(sessionId, execution);
     if (existing) {
       const inFlightRelease = this.releasePromises.get(sessionId);
       if (this.releasingSessions.has(existing) && inFlightRelease?.session === existing) {
@@ -792,9 +811,23 @@ export class SessionManager {
       && this.timer.now() > session.expiresAt;
   }
 
-  private isSessionExpiredForNewExecution(session: Session): boolean {
-    return !this.activeSessionExecutionChecker(session.sessionId, session.expiresAt)
-      && this.timer.now() > session.expiresAt;
+  private isSessionExpiredForNewExecution(session: Session, execution?: SessionExecutionMetadata): boolean {
+    if (this.timer.now() <= session.expiresAt) {
+      return false;
+    }
+    return execution?.startTime === undefined || execution.startTime > session.expiresAt;
+  }
+
+  private isLateExecutionWhileEarlierWorkIsActive(
+    session: Session,
+    execution: SessionExecutionMetadata | undefined,
+  ): boolean {
+    return execution !== undefined
+      && this.timer.now() > session.expiresAt
+      && execution.startTime > session.expiresAt
+      && this.activeSessionExecutionChecker(session.sessionId, {
+        excludeExecutionId: execution.executionId,
+      });
   }
 
   /**

--- a/src/daemon/sessionManager.ts
+++ b/src/daemon/sessionManager.ts
@@ -83,6 +83,7 @@ export interface Session {
  * while sharing centralized state in the daemon.
  */
 export type SessionReleaseCallback = (sessionId: string, deviceId: string) => void;
+export type ActiveSessionExecutionChecker = (sessionId: string) => boolean;
 
 export interface SessionDeviceAssigner {
   assignDeviceToSession(sessionId: string, platform?: Platform): Promise<string>;
@@ -127,6 +128,7 @@ export class SessionManager {
   private deviceSessionRepository: DeviceSessionRepository;
   private readonly getBarrier: () => DbWriteBarrier;
   private readonly keepScreenAwakeRestorerFactory: (device: BootedDevice) => KeepScreenAwakeRestorer;
+  private activeSessionExecutionChecker: ActiveSessionExecutionChecker = () => false;
 
   // Session timeout: 30 minutes
   private readonly SESSION_TIMEOUT_MS = 30 * 60 * 1000;
@@ -172,6 +174,15 @@ export class SessionManager {
   /** Return outstanding post-release device work, if the device must stay quarantined. */
   getPendingDeviceCleanup(deviceId: string): Promise<void> | null {
     return this.pendingDeviceCleanups.get(deviceId) ?? null;
+  }
+
+  /**
+   * Keep sessions assigned while their work is still running, even if their
+   * idle timeout elapses. The daemon supplies the execution tracker; tests can
+   * inject a deterministic checker.
+   */
+  setActiveSessionExecutionChecker(checker: ActiveSessionExecutionChecker): void {
+    this.activeSessionExecutionChecker = checker;
   }
 
   /**
@@ -761,7 +772,8 @@ export class SessionManager {
    * Check if session is expired
    */
   private isSessionExpired(session: Session): boolean {
-    return this.timer.now() > session.expiresAt;
+    return !this.activeSessionExecutionChecker(session.sessionId)
+      && this.timer.now() > session.expiresAt;
   }
 
   /**

--- a/src/daemon/sessionManager.ts
+++ b/src/daemon/sessionManager.ts
@@ -83,7 +83,7 @@ export interface Session {
  * while sharing centralized state in the daemon.
  */
 export type SessionReleaseCallback = (sessionId: string, deviceId: string) => void;
-export type ActiveSessionExecutionChecker = (sessionId: string) => boolean;
+export type ActiveSessionExecutionChecker = (sessionId: string, startedAtOrBefore?: number) => boolean;
 
 export interface SessionDeviceAssigner {
   assignDeviceToSession(sessionId: string, platform?: Platform): Promise<string>;
@@ -250,7 +250,7 @@ export class SessionManager {
     const session = this.sessions.get(sessionId);
 <<<<<<< HEAD
     if (session && (expireDespiteActiveExecution
-      ? this.timer.now() > session.expiresAt
+      ? this.isSessionExpiredForNewExecution(session)
       : this.isSessionExpired(session))) {
       // Release owns this exact session object until it has restored device state
       // and removed its assignment. Keep expiry cleanup from creating a second
@@ -789,6 +789,11 @@ export class SessionManager {
    */
   private isSessionExpired(session: Session): boolean {
     return !this.activeSessionExecutionChecker(session.sessionId)
+      && this.timer.now() > session.expiresAt;
+  }
+
+  private isSessionExpiredForNewExecution(session: Session): boolean {
+    return !this.activeSessionExecutionChecker(session.sessionId, session.expiresAt)
       && this.timer.now() > session.expiresAt;
   }
 

--- a/src/features/record/McpCallRecorder.ts
+++ b/src/features/record/McpCallRecorder.ts
@@ -40,6 +40,8 @@ export const INTERNAL_PARAMS = new Set([
   "devices",
   "keepScreenAwake",
   "__mcpSessionId",
+  "__executionId",
+  "__executionStartTime",
   "__lockNamespace",
   INTERNAL_NO_DIFF_PARAM,
 ]);

--- a/src/features/toolCapabilities/toolCapabilityContext.ts
+++ b/src/features/toolCapabilities/toolCapabilityContext.ts
@@ -16,6 +16,11 @@ import type { SessionToolProfileService } from "./SessionToolProfileService";
  */
 type ToolCapabilityContext = {
   routingSessionUuid?: string;
+  /** Identity of the outer execution, used to keep an autolock session alive across nested calls. */
+  execution?: {
+    executionId: string;
+    startTime: number;
+  };
   /** Connection-scoped profile used for policy, distinct from device routing. */
   capabilitySessionUuid?: string;
   /** An admitted executePlan may invoke its nested plan steps without per-step opt-ins. */
@@ -33,6 +38,7 @@ export const runWithToolCapabilityContext = async <T>(
   const parent = toolCapabilityContext.getStore();
   return toolCapabilityContext.run({
     routingSessionUuid: context.routingSessionUuid ?? parent?.routingSessionUuid,
+    execution: context.execution ?? parent?.execution,
     capabilitySessionUuid: context.capabilitySessionUuid ?? parent?.capabilitySessionUuid,
     planCapabilitiesAuthorized: context.planCapabilitiesAuthorized
       ?? parent?.planCapabilitiesAuthorized,

--- a/src/server/ToolExecutionContext.ts
+++ b/src/server/ToolExecutionContext.ts
@@ -1,5 +1,5 @@
 import { SessionManager } from "../daemon/sessionManager";
-import type { Session } from "../daemon/sessionManager";
+import type { Session, SessionExecutionMetadata } from "../daemon/sessionManager";
 import { DevicePool } from "../daemon/devicePool";
 import { AndroidCtrlProxyManager } from "../utils/CtrlProxyManager";
 import { NavigationGraphManager } from "../features/navigation/NavigationGraphManager";
@@ -74,19 +74,21 @@ export async function createToolExecutionContext(
   sessionUuid: string | undefined,
   sessionManager: SessionManager,
   devicePool: DevicePool,
-  sessionOptions: SessionOptions = {}
+  sessionOptions: SessionOptions = {},
+  execution?: SessionExecutionMetadata,
 ): Promise<ToolExecutionContext> {
   if (!sessionUuid) {
     return {};
   }
 
-  const existingSession = sessionManager.getSessionForNewExecution(sessionUuid);
+  const existingSession = sessionManager.getSessionForNewExecution(sessionUuid, execution);
 
   // Get or create session
   const session = await sessionManager.getOrCreateSession(
     sessionUuid,
     devicePool,
-    sessionOptions.platform
+    sessionOptions.platform,
+    execution,
   );
 
   if (!sessionManager.isCurrentSession(session)) {

--- a/src/server/ToolExecutionContext.ts
+++ b/src/server/ToolExecutionContext.ts
@@ -80,7 +80,7 @@ export async function createToolExecutionContext(
     return {};
   }
 
-  const existingSession = sessionManager.getSession(sessionUuid);
+  const existingSession = sessionManager.getSessionForNewExecution(sessionUuid);
 
   // Get or create session
   const session = await sessionManager.getOrCreateSession(

--- a/src/server/executionTracker.ts
+++ b/src/server/executionTracker.ts
@@ -134,14 +134,12 @@ export class ExecutionTracker {
     );
   }
 
-  hasActiveSessionUuidExecutions(sessionUuid: string): boolean {
-    const executions = this.sessionUuidExecutions.get(sessionUuid);
-    return executions !== undefined && executions.size > 0;
+  hasActiveSessionUuidExecutions(sessionUuid: string, startedAtOrBefore?: number): boolean {
+    return this.hasActiveExecutionsForKey(this.sessionUuidExecutions, sessionUuid, startedAtOrBefore);
   }
 
-  hasActiveSessionExecutions(sessionId: string): boolean {
-    const executions = this.sessionExecutions.get(sessionId);
-    return executions !== undefined && executions.size > 0;
+  hasActiveSessionExecutions(sessionId: string, startedAtOrBefore?: number): boolean {
+    return this.hasActiveExecutionsForKey(this.sessionExecutions, sessionId, startedAtOrBefore);
   }
 
   hasActiveToolExecution(toolName: string, options: ExecutionScopeOptions): boolean {
@@ -181,6 +179,24 @@ export class ExecutionTracker {
     if (sessionSet?.size === 0) {
       this.sessionExecutions.delete(sessionId);
     }
+  }
+
+  private hasActiveExecutionsForKey(
+    executionMap: Map<string, Set<string>>,
+    key: string,
+    startedAtOrBefore?: number,
+  ): boolean {
+    const executions = executionMap.get(key);
+    if (!executions || executions.size === 0) {
+      return false;
+    }
+    if (startedAtOrBefore === undefined) {
+      return true;
+    }
+    return Array.from(executions).some(executionId => {
+      const execution = this.executions.get(executionId);
+      return execution !== undefined && execution.startTime <= startedAtOrBefore;
+    });
   }
 
   private hasActiveToolExecutionForKey(

--- a/src/server/executionTracker.ts
+++ b/src/server/executionTracker.ts
@@ -40,6 +40,11 @@ export interface ExecutionCancellationOptions {
   excludeSignal?: AbortSignal;
 }
 
+export interface ActiveExecutionQuery {
+  startedAtOrBefore?: number;
+  excludeExecutionId?: string;
+}
+
 export class ExecutionTracker {
   private executions = new Map<string, ActiveExecution>();
   private sessionExecutions = new Map<string, Set<string>>();
@@ -134,12 +139,12 @@ export class ExecutionTracker {
     );
   }
 
-  hasActiveSessionUuidExecutions(sessionUuid: string, startedAtOrBefore?: number): boolean {
-    return this.hasActiveExecutionsForKey(this.sessionUuidExecutions, sessionUuid, startedAtOrBefore);
+  hasActiveSessionUuidExecutions(sessionUuid: string, query?: ActiveExecutionQuery): boolean {
+    return this.hasActiveExecutionsForKey(this.sessionUuidExecutions, sessionUuid, query);
   }
 
-  hasActiveSessionExecutions(sessionId: string, startedAtOrBefore?: number): boolean {
-    return this.hasActiveExecutionsForKey(this.sessionExecutions, sessionId, startedAtOrBefore);
+  hasActiveSessionExecutions(sessionId: string, query?: ActiveExecutionQuery): boolean {
+    return this.hasActiveExecutionsForKey(this.sessionExecutions, sessionId, query);
   }
 
   hasActiveToolExecution(toolName: string, options: ExecutionScopeOptions): boolean {
@@ -184,18 +189,20 @@ export class ExecutionTracker {
   private hasActiveExecutionsForKey(
     executionMap: Map<string, Set<string>>,
     key: string,
-    startedAtOrBefore?: number,
+    query?: ActiveExecutionQuery,
   ): boolean {
     const executions = executionMap.get(key);
     if (!executions || executions.size === 0) {
       return false;
     }
-    if (startedAtOrBefore === undefined) {
+    if (query?.startedAtOrBefore === undefined && query?.excludeExecutionId === undefined) {
       return true;
     }
     return Array.from(executions).some(executionId => {
       const execution = this.executions.get(executionId);
-      return execution !== undefined && execution.startTime <= startedAtOrBefore;
+      return execution !== undefined
+        && executionId !== query?.excludeExecutionId
+        && (query?.startedAtOrBefore === undefined || execution.startTime <= query.startedAtOrBefore);
     });
   }
 

--- a/src/server/executionTracker.ts
+++ b/src/server/executionTracker.ts
@@ -11,6 +11,7 @@ interface ActiveExecution {
   id: string;
   toolName: string;
   sessionId?: string;
+  transportSessionId?: string;
   sessionUuid?: string;
   startTime: number;
   abortController: AbortController;
@@ -54,13 +55,15 @@ export class ExecutionTracker {
   startExecution(
     toolName: string,
     sessionId?: string,
-    sessionUuid?: string
+    sessionUuid?: string,
+    transportSessionId?: string,
   ): ActiveExecution {
     const id = this.idGenerator.next();
     const execution: ActiveExecution = {
       id,
       toolName,
       sessionId,
+      transportSessionId,
       sessionUuid,
       startTime: this.timer.now(),
       abortController: new AbortController()
@@ -69,9 +72,11 @@ export class ExecutionTracker {
     this.executions.set(id, execution);
 
     if (sessionId) {
-      const sessionSet = this.sessionExecutions.get(sessionId) ?? new Set();
-      sessionSet.add(id);
-      this.sessionExecutions.set(sessionId, sessionSet);
+      this.registerSessionExecution(sessionId, id);
+    }
+
+    if (transportSessionId && transportSessionId !== sessionId) {
+      this.registerSessionExecution(transportSessionId, id);
     }
 
     if (sessionUuid) {
@@ -92,11 +97,11 @@ export class ExecutionTracker {
     this.executions.delete(executionId);
 
     if (execution.sessionId) {
-      const sessionSet = this.sessionExecutions.get(execution.sessionId);
-      sessionSet?.delete(executionId);
-      if (sessionSet?.size === 0) {
-        this.sessionExecutions.delete(execution.sessionId);
-      }
+      this.unregisterSessionExecution(execution.sessionId, executionId);
+    }
+
+    if (execution.transportSessionId && execution.transportSessionId !== execution.sessionId) {
+      this.unregisterSessionExecution(execution.transportSessionId, executionId);
     }
 
     if (execution.sessionUuid) {
@@ -162,6 +167,20 @@ export class ExecutionTracker {
       }
     }
     return false;
+  }
+
+  private registerSessionExecution(sessionId: string, executionId: string): void {
+    const sessionSet = this.sessionExecutions.get(sessionId) ?? new Set<string>();
+    sessionSet.add(executionId);
+    this.sessionExecutions.set(sessionId, sessionSet);
+  }
+
+  private unregisterSessionExecution(sessionId: string, executionId: string): void {
+    const sessionSet = this.sessionExecutions.get(sessionId);
+    sessionSet?.delete(executionId);
+    if (sessionSet?.size === 0) {
+      this.sessionExecutions.delete(sessionId);
+    }
   }
 
   private hasActiveToolExecutionForKey(

--- a/src/server/executionTracker.ts
+++ b/src/server/executionTracker.ts
@@ -134,6 +134,11 @@ export class ExecutionTracker {
     return executions !== undefined && executions.size > 0;
   }
 
+  hasActiveSessionExecutions(sessionId: string): boolean {
+    const executions = this.sessionExecutions.get(sessionId);
+    return executions !== undefined && executions.size > 0;
+  }
+
   hasActiveToolExecution(toolName: string, options: ExecutionScopeOptions): boolean {
     if (options.scope === "global") {
       return this.hasActiveToolExecutionGlobal(toolName);

--- a/src/server/index.ts
+++ b/src/server/index.ts
@@ -528,6 +528,10 @@ export const createMcpServer = (options: McpServerOptions = {}): McpServer => {
         () => runWithToolCapabilityContext(
           {
             routingSessionUuid,
+            execution: {
+              executionId: execution.id,
+              startTime: execution.startTime,
+            },
             // A routing session already carries its own base/label union in
             // ToolRegistry. Carry only a distinct connection profile so it
             // cannot suppress that derived-label resolution.

--- a/src/server/index.ts
+++ b/src/server/index.ts
@@ -481,7 +481,12 @@ export const createMcpServer = (options: McpServerOptions = {}): McpServer => {
 
     const executionSessionUuid = derivedLabelSessionUuid ?? providedSessionUuid ?? routingSessionUuid;
     const executionSessionId = requestMcpSessionId ?? sessionId;
-    const execution = executionTracker.startExecution(name, executionSessionId, executionSessionUuid);
+    const execution = executionTracker.startExecution(
+      name,
+      executionSessionId,
+      executionSessionUuid,
+      sessionId,
+    );
     const handlerParams = implicitAutolockMcpSessionId && parsedParams && typeof parsedParams === "object"
       ? { ...parsedParams, [INTERNAL_MCP_SESSION_PARAM]: implicitAutolockMcpSessionId }
       : parsedParams;

--- a/src/server/index.ts
+++ b/src/server/index.ts
@@ -480,7 +480,8 @@ export const createMcpServer = (options: McpServerOptions = {}): McpServer => {
     }
 
     const executionSessionUuid = derivedLabelSessionUuid ?? providedSessionUuid ?? routingSessionUuid;
-    const execution = executionTracker.startExecution(name, sessionId, executionSessionUuid);
+    const executionSessionId = requestMcpSessionId ?? sessionId;
+    const execution = executionTracker.startExecution(name, executionSessionId, executionSessionUuid);
     const handlerParams = implicitAutolockMcpSessionId && parsedParams && typeof parsedParams === "object"
       ? { ...parsedParams, [INTERNAL_MCP_SESSION_PARAM]: implicitAutolockMcpSessionId }
       : parsedParams;

--- a/src/server/index.ts
+++ b/src/server/index.ts
@@ -96,6 +96,8 @@ export interface McpServerOptions {
 }
 
 const INTERNAL_MCP_SESSION_PARAM = "__mcpSessionId";
+const INTERNAL_EXECUTION_ID_PARAM = "__executionId";
+const INTERNAL_EXECUTION_START_TIME_PARAM = "__executionStartTime";
 function extractInternalMcpSessionId(params: unknown): string | undefined {
   if (!params || typeof params !== "object" || Array.isArray(params)) {
     return undefined;
@@ -110,12 +112,16 @@ function stripInternalToolParams(params: unknown): unknown {
     return params;
   }
 
-  if (!(INTERNAL_MCP_SESSION_PARAM in params)) {
+  if (!(INTERNAL_MCP_SESSION_PARAM in params)
+    && !(INTERNAL_EXECUTION_ID_PARAM in params)
+    && !(INTERNAL_EXECUTION_START_TIME_PARAM in params)) {
     return params;
   }
 
   const rest = { ...(params as Record<string, unknown>) };
   delete rest[INTERNAL_MCP_SESSION_PARAM];
+  delete rest[INTERNAL_EXECUTION_ID_PARAM];
+  delete rest[INTERNAL_EXECUTION_START_TIME_PARAM];
   return rest;
 }
 
@@ -487,8 +493,13 @@ export const createMcpServer = (options: McpServerOptions = {}): McpServer => {
       executionSessionUuid,
       sessionId,
     );
-    const handlerParams = implicitAutolockMcpSessionId && parsedParams && typeof parsedParams === "object"
-      ? { ...parsedParams, [INTERNAL_MCP_SESSION_PARAM]: implicitAutolockMcpSessionId }
+    const handlerParams = parsedParams && typeof parsedParams === "object"
+      ? {
+        ...parsedParams,
+        ...(implicitAutolockMcpSessionId ? { [INTERNAL_MCP_SESSION_PARAM]: implicitAutolockMcpSessionId } : {}),
+        [INTERNAL_EXECUTION_ID_PARAM]: execution.id,
+        [INTERNAL_EXECUTION_START_TIME_PARAM]: execution.startTime,
+      }
       : parsedParams;
 
     // Create progress callback if tool supports progress

--- a/src/server/toolRegistry.ts
+++ b/src/server/toolRegistry.ts
@@ -307,6 +307,9 @@ class DefaultExecutionTargetResolver implements ExecutionTargetResolver {
     const deviceLabel = typeof args.device === "string" ? args.device : undefined;
     const declaredDeviceLabels = Array.isArray(args.devices) ? args.devices : undefined;
     const mcpSessionId = typeof args.__mcpSessionId === "string" ? args.__mcpSessionId : undefined;
+    const execution = typeof args.__executionId === "string" && typeof args.__executionStartTime === "number"
+      ? { executionId: args.__executionId, startTime: args.__executionStartTime }
+      : undefined;
     // Internal tool-to-tool marker (#3053 / #3087): internal callers (PlanExecutor
     // steps, navigation/setup replays) set this via `markInternalToolCall` so a
     // plan/navigation step's finalized envelope is never diffed/stripped and never
@@ -351,7 +354,7 @@ class DefaultExecutionTargetResolver implements ExecutionTargetResolver {
     let platform: SomePlatform = args.platform || "either";
 
     if (shouldResolveDevice) {
-      const implicitSessionUuid = this.resolveImplicitAutolockSession(platform, sessionUuid, providedDeviceId, mcpSessionId);
+      const implicitSessionUuid = this.resolveImplicitAutolockSession(platform, sessionUuid, providedDeviceId, mcpSessionId, execution);
       if (implicitSessionUuid) {
         sessionUuid = implicitSessionUuid;
         logger.info(`[ToolRegistry] Resolved implicit autolock session for MCP session ${mcpSessionId}: ${implicitSessionUuid}`);
@@ -376,7 +379,7 @@ class DefaultExecutionTargetResolver implements ExecutionTargetResolver {
       const context = await createToolExecutionContext(sessionUuid, sessionManager, devicePool, {
         keepScreenAwake,
         platform: platform === "android" || platform === "ios" ? platform : undefined
-      });
+      }, execution);
       if (context.deviceId && !providedDeviceId) {
         providedDeviceId = context.deviceId;
         logger.info(`[ToolRegistry] Resolved device from session: ${providedDeviceId}`);
@@ -502,7 +505,8 @@ class DefaultExecutionTargetResolver implements ExecutionTargetResolver {
     platform: SomePlatform,
     sessionUuid: string | undefined,
     providedDeviceId: string | undefined,
-    mcpSessionId: string | undefined
+    mcpSessionId: string | undefined,
+    execution?: import("../daemon/sessionManager").SessionExecutionMetadata,
   ): string | undefined {
     if (sessionUuid) {
       return undefined;
@@ -514,7 +518,7 @@ class DefaultExecutionTargetResolver implements ExecutionTargetResolver {
     const platformFilter = platform === "android" || platform === "ios" ? platform : undefined;
     const sessionId = DaemonState.getInstance()
       .getDevicePool()
-      .resolveAutolockSessionForMcpSession(mcpSessionId, platformFilter);
+      .resolveAutolockSessionForMcpSession(mcpSessionId, platformFilter, execution);
     if (!sessionId) {
       return undefined;
     }

--- a/src/server/toolRegistry.ts
+++ b/src/server/toolRegistry.ts
@@ -216,6 +216,43 @@ interface NavigationToolCallRecorder {
   record(name: string, args: any, device: BootedDevice | undefined, sessionUuid: string | undefined): void;
 }
 
+/** Removes routing and execution implementation details before persisting a navigation edge. */
+export function stripNavigationInternalParams(args: Record<string, unknown>): Record<string, unknown> {
+  const clean = { ...args };
+  delete clean.__mcpSessionId;
+  delete clean.__executionId;
+  delete clean.__executionStartTime;
+  delete clean[INTERNAL_NO_DIFF_PARAM];
+  return clean;
+}
+
+function withAmbientDeviceContext(
+  args: Record<string, unknown>,
+  routingSessionUuid: string | undefined,
+  execution: { executionId: string; startTime: number } | undefined,
+): Record<string, unknown> {
+  const needsRoutingSession = routingSessionUuid && args.sessionUuid !== routingSessionUuid;
+  const needsExecution = execution && (
+    args.__executionId !== execution.executionId
+    || args.__executionStartTime !== execution.startTime
+  );
+  if (!needsRoutingSession && !needsExecution) {
+    return args;
+  }
+  return {
+    ...args,
+    ...(needsRoutingSession
+      ? { sessionUuid: routingSessionUuid }
+      : {}),
+    ...(needsExecution
+      ? {
+        __executionId: execution!.executionId,
+        __executionStartTime: execution!.startTime,
+      }
+      : {}),
+  };
+}
+
 interface AfterToolCallInput {
   name: string;
   args: any;
@@ -647,7 +684,7 @@ class DefaultNavigationToolCallRecorder implements NavigationToolCallRecorder {
     const navManager = sessionUuid
       ? NavigationGraphManager.getInstanceForSession(sessionUuid)
       : NavigationGraphManager.getInstance();
-    navManager.recordToolCall(name, args, uiState);
+    navManager.recordToolCall(name, stripNavigationInternalParams(args), uiState);
   }
 }
 
@@ -960,9 +997,11 @@ export class ToolRegistryClass {
       // Re-inject the ambient ROUTING session (issue #4611 Gap C) so a nested
       // device-aware call keeps the outer call's derived/label routing identity
       // rather than reverting to the base session.
-      const handlerArgs = capabilityContext?.routingSessionUuid && args.sessionUuid !== capabilityContext.routingSessionUuid
-        ? { ...args, sessionUuid: capabilityContext.routingSessionUuid }
-        : args;
+      const handlerArgs: any = withAmbientDeviceContext(
+        args,
+        capabilityContext?.routingSessionUuid,
+        capabilityContext?.execution,
+      );
       const toolStartMs = this.timer.now();
       const toolCallTimestamp = new Date().toISOString();
       let toolDurationMs: number | undefined;

--- a/test/daemon/SessionHeartbeatMonitor.test.ts
+++ b/test/daemon/SessionHeartbeatMonitor.test.ts
@@ -2,6 +2,7 @@ import { describe, it, expect, beforeEach, afterEach } from "bun:test";
 import { SessionHeartbeatMonitor } from "../../src/daemon/SessionHeartbeatMonitor";
 import { SessionManager } from "../../src/daemon/sessionManager";
 import { DevicePool } from "../../src/daemon/devicePool";
+import { ExecutionTracker } from "../../src/server/executionTracker";
 import { FakeTimer } from "../fakes/FakeTimer";
 import { FakeDeviceUtils } from "../fakes/FakeDeviceUtils";
 
@@ -285,6 +286,42 @@ describe("SessionHeartbeatMonitor", () => {
         await monitor.tick();
         expect(pool.getDevice("emulator-5554")!.status).toBe("busy");
       }
+    });
+
+    it("keeps an expired autolocked session assigned until active work completes", async () => {
+      const sessionId = await pool.autolockDevice("emulator-5554", "android", "mcp-session-1");
+      const executionTracker = new ExecutionTracker(timer);
+      const hasActiveExecutions = (sessionUuid: string): boolean =>
+        executionTracker.hasActiveSessionUuidExecutions(sessionUuid)
+        || pool.hasActiveAutolockMcpSessionExecution(
+          sessionUuid,
+          mcpSessionId => executionTracker.hasActiveSessionExecutions(mcpSessionId),
+        );
+      sessionManager.setActiveSessionExecutionChecker(hasActiveExecutions);
+      const monitor = new SessionHeartbeatMonitor(
+        sessionManager,
+        hasActiveExecutions,
+        reapVia(sessionManager, pool),
+        timer,
+      );
+      const execution = executionTracker.startExecution("tapOn", "mcp-session-1");
+
+      timer.advanceTime(60_001); // Past the autolock idle timeout.
+      await monitor.tick();
+
+      const activeDevice = pool.getDevice("emulator-5554")!;
+      expect(activeDevice.status).toBe("busy");
+      expect(activeDevice.autolockSessionId).toBe(sessionId);
+      expect(sessionManager.getActiveSessionCount()).toBe(1);
+      expect(sessionManager.getSession(sessionId!)).not.toBeNull();
+
+      executionTracker.endExecution(execution.id);
+      await monitor.tick();
+
+      const releasedDevice = pool.getDevice("emulator-5554")!;
+      expect(releasedDevice.status).toBe("idle");
+      expect(releasedDevice.autolockSessionId).toBeUndefined();
+      expect(sessionManager.getActiveSessionCount()).toBe(0);
     });
   });
 });

--- a/test/daemon/devicePool.autolock.test.ts
+++ b/test/daemon/devicePool.autolock.test.ts
@@ -242,6 +242,17 @@ describe("DevicePool autolock", () => {
       expect(pool.resolveAutolockSessionForMcpSession("mcp-session-1", "android")).toBeUndefined();
     });
 
+    it("does not route a new MCP request through an expired autolock held by older work", async () => {
+      await initializeLiveAndroidDevice();
+      sessionManager.setActiveSessionExecutionChecker((_sessionId, startedAtOrBefore) => startedAtOrBefore === undefined);
+
+      await pool.autolockDevice("emulator-5554", "android", "mcp-session-1");
+      timer.advanceTime(61 * 1000);
+
+      expect(pool.resolveAutolockSessionForMcpSession("mcp-session-1", "android")).toBeUndefined();
+      expect(pool.getDevice("emulator-5554")!.status).toBe("idle");
+    });
+
     it("aligns the session heartbeat timeout with the idle timeout", async () => {
       // The daemon heartbeat watchdog reaps sessions whose heartbeat is stale.
       // Autolock clients do not send heartbeats, so the heartbeat timeout must

--- a/test/daemon/devicePool.autolock.test.ts
+++ b/test/daemon/devicePool.autolock.test.ts
@@ -253,6 +253,21 @@ describe("DevicePool autolock", () => {
       expect(pool.getDevice("emulator-5554")!.status).toBe("idle");
     });
 
+    it("rejects a late MCP request while earlier work still owns the expired autolock", async () => {
+      await initializeLiveAndroidDevice();
+      sessionManager.setActiveSessionExecutionChecker((_sessionId, query) => query?.excludeExecutionId === "late");
+
+      await pool.autolockDevice("emulator-5554", "android", "mcp-session-1");
+      timer.advanceTime(61 * 1000);
+
+      expect(() => pool.resolveAutolockSessionForMcpSession(
+        "mcp-session-1",
+        "android",
+        { executionId: "late", startTime: timer.now() },
+      )).toThrow("earlier work is still active");
+      expect(pool.getDevice("emulator-5554")!.status).toBe("busy");
+    });
+
     it("aligns the session heartbeat timeout with the idle timeout", async () => {
       // The daemon heartbeat watchdog reaps sessions whose heartbeat is stale.
       // Autolock clients do not send heartbeats, so the heartbeat timeout must

--- a/test/daemon/sessionManager.test.ts
+++ b/test/daemon/sessionManager.test.ts
@@ -237,13 +237,32 @@ describe("SessionManager", () => {
     });
 
     test("keeps a session when work began before its expiry deadline", async () => {
-      sessionManager.setActiveSessionExecutionChecker((_sessionId, startedAtOrBefore) => startedAtOrBefore === 1000);
       const session = await sessionManager.createSession("session-1", "emulator-5554", "android", 1000);
       fakeTimer.advanceTime(1001);
 
-      const resolved = await sessionManager.getOrCreateSession("session-1");
+      const resolved = await sessionManager.getOrCreateSession(
+        "session-1",
+        undefined,
+        undefined,
+        { executionId: "pre-deadline", startTime: 1000 },
+      );
 
       expect(resolved).toBe(session);
+      expect(sessionManager.getActiveSessionCount()).toBe(1);
+    });
+
+    test("rejects a late execution while earlier work keeps the expired session assigned", async () => {
+      sessionManager.setActiveSessionExecutionChecker((_sessionId, query) => query?.excludeExecutionId === "late");
+      await sessionManager.createSession("session-1", "emulator-5554", "android", 1000);
+      fakeTimer.advanceTime(1001);
+
+      await expect(sessionManager.getOrCreateSession(
+        "session-1",
+        undefined,
+        undefined,
+        { executionId: "late", startTime: 1001 },
+      )).rejects.toThrow("earlier work is still active");
+
       expect(sessionManager.getActiveSessionCount()).toBe(1);
     });
   });

--- a/test/daemon/sessionManager.test.ts
+++ b/test/daemon/sessionManager.test.ts
@@ -219,6 +219,22 @@ describe("SessionManager", () => {
       const retrieved = sessionManager.getSession("session-1");
       expect(retrieved).toBeNull();
     });
+
+    test("expires a session before accepting a request that arrives after its deadline", async () => {
+      const released: string[] = [];
+      sessionManager.setActiveSessionExecutionChecker(() => true);
+      sessionManager.onSessionRelease(sessionId => released.push(sessionId));
+      await sessionManager.createSession("session-1", "emulator-5554", "android", 1000);
+      fakeTimer.advanceTime(1001);
+
+      // Existing work keeps an expired session assigned, but a new request must
+      // not use that protection to revive the session after its deadline.
+      expect(sessionManager.getSession("session-1")).not.toBeNull();
+      await expect(sessionManager.getOrCreateSession("session-1")).rejects.toThrow("not found");
+
+      expect(released).toEqual(["session-1"]);
+      expect(sessionManager.getActiveSessionCount()).toBe(0);
+    });
   });
 
   describe("cache management", () => {

--- a/test/daemon/sessionManager.test.ts
+++ b/test/daemon/sessionManager.test.ts
@@ -222,7 +222,7 @@ describe("SessionManager", () => {
 
     test("expires a session before accepting a request that arrives after its deadline", async () => {
       const released: string[] = [];
-      sessionManager.setActiveSessionExecutionChecker(() => true);
+      sessionManager.setActiveSessionExecutionChecker((_sessionId, startedAtOrBefore) => startedAtOrBefore === undefined);
       sessionManager.onSessionRelease(sessionId => released.push(sessionId));
       await sessionManager.createSession("session-1", "emulator-5554", "android", 1000);
       fakeTimer.advanceTime(1001);
@@ -234,6 +234,17 @@ describe("SessionManager", () => {
 
       expect(released).toEqual(["session-1"]);
       expect(sessionManager.getActiveSessionCount()).toBe(0);
+    });
+
+    test("keeps a session when work began before its expiry deadline", async () => {
+      sessionManager.setActiveSessionExecutionChecker((_sessionId, startedAtOrBefore) => startedAtOrBefore === 1000);
+      const session = await sessionManager.createSession("session-1", "emulator-5554", "android", 1000);
+      fakeTimer.advanceTime(1001);
+
+      const resolved = await sessionManager.getOrCreateSession("session-1");
+
+      expect(resolved).toBe(session);
+      expect(sessionManager.getActiveSessionCount()).toBe(1);
     });
   });
 

--- a/test/server/executionTracker.test.ts
+++ b/test/server/executionTracker.test.ts
@@ -109,6 +109,20 @@ describe("ExecutionTracker", function() {
     expect(execution.abortController.signal.aborted).toBe(true);
   });
 
+  test("distinguishes executions that began before a session deadline", function() {
+    const timer = new FakeTimer();
+    const tracker = new ExecutionTracker(timer, new FakeIdGenerator(["before", "after"]));
+    tracker.startExecution("tapOn", "session-id");
+    timer.advanceTime(10);
+
+    expect(tracker.hasActiveSessionExecutions("session-id", 5)).toBe(true);
+
+    tracker.endExecution("before");
+    tracker.startExecution("tapOn", "session-id");
+
+    expect(tracker.hasActiveSessionExecutions("session-id", 5)).toBe(false);
+  });
+
   // #4183 item 6 (A3): the scope fallback in hasActiveToolExecution (executionTracker.ts)
   // had no table coverage. The scope order is: explicit "global" → sessionUuid map →
   // sessionId map → global fallback when neither key is provided.

--- a/test/server/executionTracker.test.ts
+++ b/test/server/executionTracker.test.ts
@@ -115,12 +115,12 @@ describe("ExecutionTracker", function() {
     tracker.startExecution("tapOn", "session-id");
     timer.advanceTime(10);
 
-    expect(tracker.hasActiveSessionExecutions("session-id", 5)).toBe(true);
+    expect(tracker.hasActiveSessionExecutions("session-id", { startedAtOrBefore: 5 })).toBe(true);
 
     tracker.endExecution("before");
     tracker.startExecution("tapOn", "session-id");
 
-    expect(tracker.hasActiveSessionExecutions("session-id", 5)).toBe(false);
+    expect(tracker.hasActiveSessionExecutions("session-id", { startedAtOrBefore: 5 })).toBe(false);
   });
 
   // #4183 item 6 (A3): the scope fallback in hasActiveToolExecution (executionTracker.ts)

--- a/test/server/executionTracker.test.ts
+++ b/test/server/executionTracker.test.ts
@@ -92,6 +92,23 @@ describe("ExecutionTracker", function() {
     expect(tap.abortController.signal.aborted).toBe(true);
   });
 
+  test("cancels a forwarded execution when its transport session closes", async function() {
+    const tracker = new ExecutionTracker(new FakeTimer(), new FakeIdGenerator(["execution-1"]));
+    const execution = tracker.startExecution(
+      "tapOn",
+      "forwarded-mcp-session",
+      undefined,
+      "streamable-http-session",
+    );
+
+    expect(tracker.hasActiveSessionExecutions("forwarded-mcp-session")).toBe(true);
+    expect(tracker.hasActiveSessionExecutions("streamable-http-session")).toBe(true);
+
+    await tracker.cancelSessionExecutions("streamable-http-session", "streamable_http_onclose");
+
+    expect(execution.abortController.signal.aborted).toBe(true);
+  });
+
   // #4183 item 6 (A3): the scope fallback in hasActiveToolExecution (executionTracker.ts)
   // had no table coverage. The scope order is: explicit "global" → sessionUuid map →
   // sessionId map → global fallback when neither key is provided.

--- a/test/server/mcpSessionAutolockRouting.test.ts
+++ b/test/server/mcpSessionAutolockRouting.test.ts
@@ -67,7 +67,9 @@ describe("MCP session autolock routing", () => {
       { value: "ok", __mcpSessionId: "unix-socket-session" },
       () => {
         expect(executionTracker.hasActiveSessionExecutions("unix-socket-session")).toBe(true);
-        expect(executionTracker.hasActiveSessionExecutions("shared-loopback-session")).toBe(false);
+        // The forwarded key drives autolock expiry, while the transport key is
+        // retained solely so its close/error handlers can cancel this execution.
+        expect(executionTracker.hasActiveSessionExecutions("shared-loopback-session")).toBe(true);
       },
     );
   });

--- a/test/server/mcpSessionAutolockRouting.test.ts
+++ b/test/server/mcpSessionAutolockRouting.test.ts
@@ -2,6 +2,7 @@ import { afterEach, describe, expect, test } from "bun:test";
 import { z } from "zod";
 import { McpTestFixture } from "../fixtures/mcpTestFixture";
 import { ToolRegistry } from "../../src/server/toolRegistry";
+import { executionTracker } from "../../src/server/executionTracker";
 
 const captureSchema = z.object({
   value: z.string().optional(),
@@ -9,12 +10,14 @@ const captureSchema = z.object({
 
 async function callCaptureTool(
   fixture: McpTestFixture,
-  args: Record<string, unknown>
+  args: Record<string, unknown>,
+  whileHandling?: (handlerArgs: Record<string, unknown>) => void,
 ): Promise<Record<string, unknown>> {
   let capturedArgs: Record<string, unknown> | undefined;
   ToolRegistry.clearTools();
   ToolRegistry.register("captureMcpSession", "captureMcpSession", captureSchema, async handlerArgs => {
     capturedArgs = handlerArgs;
+    whileHandling?.(handlerArgs);
     return { content: [{ type: "text", text: "ok" }] };
   });
 
@@ -53,6 +56,20 @@ describe("MCP session autolock routing", () => {
 
     expect(capturedArgs.value).toBe("ok");
     expect(capturedArgs.__mcpSessionId).toBe("unix-socket-session");
+  });
+
+  test("tracks proxy-injected MCP sessions under their autolock key", async () => {
+    fixture = new McpTestFixture({ daemonMode: true, sessionContext: { sessionId: "shared-loopback-session" } });
+    await fixture.setup();
+
+    await callCaptureTool(
+      fixture,
+      { value: "ok", __mcpSessionId: "unix-socket-session" },
+      () => {
+        expect(executionTracker.hasActiveSessionExecutions("unix-socket-session")).toBe(true);
+        expect(executionTracker.hasActiveSessionExecutions("shared-loopback-session")).toBe(false);
+      },
+    );
   });
 
   test("does not use the shared daemon loopback MCP session as an implicit autolock key", async () => {

--- a/test/server/toolRegistry.callInternal.test.ts
+++ b/test/server/toolRegistry.callInternal.test.ts
@@ -160,6 +160,58 @@ describe("ToolRegistry.callInternal (#3108)", () => {
     expect(captured).toHaveLength(1);
   });
 
+  test("propagates outer execution metadata to a nested device-aware plan step", async () => {
+    const device = { name: "Pixel", deviceId: "emulator-5554", platform: "android" as const };
+    const originalRecorder = (ToolRegistry as any).navigationToolCallRecorder;
+    const originalRepository = (ToolRegistry as any).toolCallRepository;
+    const restore = ToolRegistry.setPipelineOverridesForTesting({
+      executionTargetResolver: {
+        async resolveExecutionTarget(input: any) {
+          return {
+            args: input.args,
+            baseSessionUuid: undefined,
+            device,
+            internalCall: true,
+            sessionUuid: undefined,
+            shouldResolveDevice: true,
+          };
+        },
+      },
+      auditRunner: {
+        async run(input: any) {
+          return input.handler(input.device, input.args, input.progress, input.signal);
+        },
+      },
+      afterToolCall: {
+        async handle(input: any) {
+          return { durationMs: 0, finalizedResponse: input.response };
+        },
+      },
+      planLifecycleManager: { async afterExecution() {} },
+    });
+    (ToolRegistry as any).navigationToolCallRecorder = { record() {} };
+    (ToolRegistry as any).toolCallRepository = { async recordToolCall() {} };
+    try {
+      ToolRegistry.registerDeviceAware("nestedStep", "Nested step", z.object({}), async (_device, args) => {
+        captured.push({ args });
+        return SENTINEL;
+      }, { planExecutable: true });
+
+      await runWithToolCapabilityContext(
+        { execution: { executionId: "outer-execution", startTime: 123 } },
+        () => ToolRegistry.callInternal("nestedStep", {}, undefined, undefined, { forPlan: true }),
+      );
+
+      expect(captured).toHaveLength(1);
+      expect(captured[0].args.__executionId).toBe("outer-execution");
+      expect(captured[0].args.__executionStartTime).toBe(123);
+    } finally {
+      restore();
+      (ToolRegistry as any).navigationToolCallRecorder = originalRecorder;
+      (ToolRegistry as any).toolCallRepository = originalRepository;
+    }
+  });
+
   test("AC3: throws ActionableError when the tool name is unresolved", async () => {
     await expect(ToolRegistry.callInternal("nonexistent", {})).rejects.toBeInstanceOf(ActionableError);
     await expect(ToolRegistry.callInternal("nonexistent", {})).rejects.toThrow(/Tool not found: nonexistent/);

--- a/test/server/toolRegistry.navigationRecorder.test.ts
+++ b/test/server/toolRegistry.navigationRecorder.test.ts
@@ -1,0 +1,15 @@
+import { describe, expect, test } from "bun:test";
+import { stripNavigationInternalParams } from "../../src/server/toolRegistry";
+import { INTERNAL_NO_DIFF_PARAM } from "../../src/server/internalToolCall";
+
+describe("navigation tool call recording", () => {
+  test("does not persist internal execution metadata in navigation arguments", () => {
+    expect(stripNavigationInternalParams({
+      text: "Continue",
+      __mcpSessionId: "mcp-session",
+      __executionId: "execution-1",
+      __executionStartTime: 123,
+      [INTERNAL_NO_DIFF_PARAM]: true,
+    })).toEqual({ text: "Continue" });
+  });
+});


### PR DESCRIPTION
## Summary

- Preserve active device sessions through heartbeat and idle-expiry cleanup.
- Track socket-forwarded executions by their actual MCP-session identity, and bridge that identity to autolocked device sessions.
- Add regressions for the socket-routing and post-expiry release lifecycle.

## Root cause

Expiry cleanup could release an autolocked device while its tool execution was still running. Socket-forwarded autolock requests were also tracked under the daemon loopback identity rather than the request's MCP-session identity, leaving the active execution invisible to session expiry protection.

## Validation

- `bun test test/daemon/SessionHeartbeatMonitor.test.ts test/daemon/sessionManager.test.ts test/server/mcpSessionAutolockRouting.test.ts test/server/executionTracker.test.ts`
- `bun run typecheck`
- `bun run turbo:validate` (13,231 passed, 0 failed before the final upstream fast-forward)

Closes #5288
