### PR TITLE
fix(android): preserve emulator exits across readiness handoff

### DIFF
--- a/src/utils/android-cmdline-tools/AndroidEmulatorClient.ts
+++ b/src/utils/android-cmdline-tools/AndroidEmulatorClient.ts
@@ -331,7 +331,7 @@ export class AndroidEmulatorClient implements AndroidEmulator {
   private readonly launchErrors = new WeakMap<ChildProcess, ActionableError>();
   private readonly launchErrorFinalizations = new WeakMap<
     ChildProcess,
-    Promise<ActionableError>
+    Promise<ActionableError | undefined>
   >();
 
   /**
@@ -1404,7 +1404,9 @@ export class AndroidEmulatorClient implements AndroidEmulator {
       let exitCode: number | null | undefined;
       let exitSignal: NodeJS.Signals | null | undefined;
       let provisionalPostValidationExitError: ActionableError | undefined;
-      let resolvePostValidationExit: ((error: ActionableError) => void) | undefined;
+      let resolvePostValidationExit:
+        | ((error: ActionableError | undefined) => void)
+        | undefined;
       perf.startOperation("panicDetection");
 
       const appendRedactedLaunchOutput = (output: string) => {
@@ -1444,13 +1446,14 @@ export class AndroidEmulatorClient implements AndroidEmulator {
           !startupValidationComplete ||
           exitCode === undefined ||
           exitCode === 0 ||
+          duplicateAvdDetected ||
           resolvePostValidationExit
         ) {
           return;
         }
         this.launchErrorFinalizations.set(
           child,
-          new Promise<ActionableError>((resolveFinalization) => {
+          new Promise<ActionableError | undefined>((resolveFinalization) => {
             resolvePostValidationExit = resolveFinalization;
           }),
         );
@@ -1470,6 +1473,17 @@ export class AndroidEmulatorClient implements AndroidEmulator {
           return;
         }
         clearExitDrainTimeout();
+        if (
+          duplicateAvdDetected ||
+          output.includes("Running multiple emulators with the same AVD")
+        ) {
+          this.launchErrors.delete(child);
+          const resolveFinalization = resolvePostValidationExit;
+          resolvePostValidationExit = undefined;
+          this.launchErrorFinalizations.delete(child);
+          resolveFinalization(undefined);
+          return;
+        }
         if (
           !this.launchErrors.has(child) ||
           this.launchErrors.get(child) === provisionalPostValidationExitError
@@ -1870,7 +1884,7 @@ export class AndroidEmulatorClient implements AndroidEmulator {
 
   private getLaunchErrorFinalization(
     childProcess?: ChildProcess | null,
-  ): Promise<ActionableError> | undefined {
+  ): Promise<ActionableError | undefined> | undefined {
     return childProcess ? this.launchErrorFinalizations.get(childProcess) : undefined;
   }
 

--- a/src/utils/android-cmdline-tools/AndroidEmulatorClient.ts
+++ b/src/utils/android-cmdline-tools/AndroidEmulatorClient.ts
@@ -1480,7 +1480,6 @@ export class AndroidEmulatorClient implements AndroidEmulator {
           this.launchErrors.delete(child);
           const resolveFinalization = resolvePostValidationExit;
           resolvePostValidationExit = undefined;
-          this.launchErrorFinalizations.delete(child);
           resolveFinalization(undefined);
           return;
         }
@@ -1494,7 +1493,6 @@ export class AndroidEmulatorClient implements AndroidEmulator {
         const finalError = this.launchErrors.get(child) ?? postValidationExitError(output);
         const resolveFinalization = resolvePostValidationExit;
         resolvePostValidationExit = undefined;
-        this.launchErrorFinalizations.delete(child);
         resolveFinalization(finalError);
       };
 
@@ -1843,7 +1841,7 @@ export class AndroidEmulatorClient implements AndroidEmulator {
       child.on("error", (error) => {
         this.timer.clearTimeout(startupTimeout);
         if (startupValidationComplete) {
-          finalizePostValidationExit(flushLaunchOutput());
+          // The exit drain timer or close event owns finalization so later stdio is retained.
           return;
         }
         clearExitDrainTimeout();
@@ -1896,15 +1894,18 @@ export class AndroidEmulatorClient implements AndroidEmulator {
     }
   }
 
-  private async finalizedReadinessExitError(
+  private async settleReadinessExit(
     childProcess: ChildProcess | null | undefined,
     fallback: ActionableError,
-  ): Promise<ActionableError> {
+    onFatal: (error: ActionableError) => Promise<never>,
+  ): Promise<void> {
     const finalization = this.getLaunchErrorFinalization(childProcess);
     const finalizedError = finalization
       ? await finalization
-      : this.getLaunchError(childProcess);
-    return finalizedError ?? fallback;
+      : (this.getLaunchError(childProcess) ?? fallback);
+    if (finalizedError) {
+      await onFatal(finalizedError);
+    }
   }
 
   private recordLaunchError(
@@ -2035,6 +2036,12 @@ export class AndroidEmulatorClient implements AndroidEmulator {
         // failed Qt xcb plugin on a headless host) — treat that as a failure too.
         if (code !== 0) {
           const combinedOutput = processOutput.join("");
+          if (combinedOutput.includes("Running multiple emulators with the same AVD")) {
+            logger.info(
+              `AVD '${avdName}' is owned by another emulator process; continuing readiness polling`,
+            );
+            return;
+          }
 
           // Check for known error patterns
           const sandboxError = this.sandboxFailure(combinedOutput);
@@ -2069,7 +2076,6 @@ export class AndroidEmulatorClient implements AndroidEmulator {
           logger.error(
             `Emulator process exited during readiness wait: ${processExitError.message}`,
           );
-          pollingActive = false;
         }
       };
       childProcess.stdout?.on("data", captureOutput);
@@ -2092,7 +2098,6 @@ export class AndroidEmulatorClient implements AndroidEmulator {
         try {
           this.recordLaunchError(childProcess, (error) => {
             processExitError = error;
-            pollingActive = false;
           });
           logger.debug(`Background polling iteration - checking for emulator '${avdName}'...`);
 
@@ -2286,15 +2291,19 @@ export class AndroidEmulatorClient implements AndroidEmulator {
     while (this.timer.now() - startTime < timeoutMs) {
       const readinessFailure = processExitError;
       if (readinessFailure) {
-        pollingActive = false;
-        await pollingPromise;
-        const finalizedReadinessFailure = await this.finalizedReadinessExitError(
+        await this.settleReadinessExit(
           childProcess,
           readinessFailure,
+          async (finalizedReadinessFailure) => {
+            pollingActive = false;
+            await pollingPromise;
+            perf.endOperation("devicePolling");
+            cleanupProcessListeners();
+            throw finalizedReadinessFailure;
+          },
         );
-        perf.endOperation("devicePolling");
-        cleanupProcessListeners();
-        throw finalizedReadinessFailure;
+        processExitError = null;
+        continue;
       }
 
       if (foundDeviceId) {

--- a/src/utils/android-cmdline-tools/AndroidEmulatorClient.ts
+++ b/src/utils/android-cmdline-tools/AndroidEmulatorClient.ts
@@ -1399,6 +1399,7 @@ export class AndroidEmulatorClient implements AndroidEmulator {
       let childTerminationObserved = false;
       let exitCode: number | null | undefined;
       let exitSignal: NodeJS.Signals | null | undefined;
+      let genericPostValidationExitRecorded = false;
       perf.startOperation("panicDetection");
 
       const appendRedactedLaunchOutput = (output: string) => {
@@ -1423,6 +1424,28 @@ export class AndroidEmulatorClient implements AndroidEmulator {
         if (category && (!earlyExitCategory || category === "missing_shared_library")) {
           earlyExitCategory = category;
         }
+      };
+      const recordPostValidationExit = (output: string) => {
+        if (
+          !startupValidationComplete ||
+          exitCode === undefined ||
+          exitCode === 0 ||
+          (this.launchErrors.has(child) && !genericPostValidationExitRecorded)
+        ) {
+          return;
+        }
+        this.launchErrors.set(
+          child,
+          this.formatEarlyExitError(
+            avdName,
+            exitCode,
+            exitSignal ?? null,
+            earlyExitCategory,
+            output,
+            "",
+          ),
+        );
+        genericPostValidationExitRecorded = true;
       };
 
       // Monitor emulator output for PANIC errors
@@ -1741,6 +1764,7 @@ export class AndroidEmulatorClient implements AndroidEmulator {
         } else {
           logger.info(`Emulator process exited with code: ${code}`);
         }
+        recordPostValidationExit(currentLaunchOutput());
         if (!startupValidationComplete) {
           exitDrainTimeout = this.timer.setTimeout(() => {
             logger.debug(
@@ -1758,6 +1782,7 @@ export class AndroidEmulatorClient implements AndroidEmulator {
         exitCode ??= code;
         exitSignal ??= signal;
         if (startupValidationComplete) {
+          recordPostValidationExit(flushLaunchOutput());
           return;
         }
         finalizeEarlyExit();
@@ -1906,9 +1931,15 @@ export class AndroidEmulatorClient implements AndroidEmulator {
       `Waiting for emulator '${avdName}' to be ready... (polling interval: ${pollingIntervalMs}ms)`,
     );
 
+    const recordedLaunchError = this.getLaunchError(childProcess);
+    if (recordedLaunchError) {
+      throw recordedLaunchError;
+    }
+
     // Monitor child process for early exit if provided
     let pollingActive = true;
     let processExitError: ActionableError | null = null;
+    let cleanupProcessListeners = () => {};
     if (childProcess && childProcess.pid) {
       const processOutput: string[] = [];
       const captureOutput = (data: any) => {
@@ -1920,9 +1951,7 @@ export class AndroidEmulatorClient implements AndroidEmulator {
           processOutput.splice(0, processOutput.length - 50);
         }
       };
-      childProcess.stdout?.on("data", captureOutput);
-      childProcess.stderr?.on("data", captureOutput);
-      childProcess.on("exit", (code) => {
+      const handleProcessExit = (code: number | null) => {
         // A null code means the process was killed by signal (e.g. SIGABRT from a
         // failed Qt xcb plugin on a headless host) — treat that as a failure too.
         if (code !== 0) {
@@ -1963,7 +1992,15 @@ export class AndroidEmulatorClient implements AndroidEmulator {
           );
           pollingActive = false;
         }
-      });
+      };
+      childProcess.stdout?.on("data", captureOutput);
+      childProcess.stderr?.on("data", captureOutput);
+      childProcess.on("exit", handleProcessExit);
+      cleanupProcessListeners = () => {
+        childProcess.stdout?.off("data", captureOutput);
+        childProcess.stderr?.off("data", captureOutput);
+        childProcess.off("exit", handleProcessExit);
+      };
     }
 
     // Start background polling immediately with configurable intervals
@@ -2173,12 +2210,14 @@ export class AndroidEmulatorClient implements AndroidEmulator {
         pollingActive = false;
         await pollingPromise;
         perf.endOperation("devicePolling");
+        cleanupProcessListeners();
         throw readinessFailure;
       }
 
       if (foundDeviceId) {
         pollingActive = false;
         perf.endOperation("devicePolling");
+        cleanupProcessListeners();
         logger.info(`Emulator '${avdName}' is ready! Device ID: ${foundDeviceId}`);
         const bootedDevice = {
           name: avdName,
@@ -2199,6 +2238,7 @@ export class AndroidEmulatorClient implements AndroidEmulator {
     pollingActive = false;
     await pollingPromise;
     perf.endOperation("devicePolling");
+    cleanupProcessListeners();
 
     if (foundDeviceId) {
       logger.info(`Emulator '${avdName}' is ready! Device ID: ${foundDeviceId}`);

--- a/src/utils/android-cmdline-tools/AndroidEmulatorClient.ts
+++ b/src/utils/android-cmdline-tools/AndroidEmulatorClient.ts
@@ -1842,12 +1842,14 @@ export class AndroidEmulatorClient implements AndroidEmulator {
 
       child.on("error", (error) => {
         this.timer.clearTimeout(startupTimeout);
-        clearExitDrainTimeout();
-        if (!startupValidationComplete) {
-          startupValidationComplete = true;
-          perf.endOperation("panicDetection");
-          reject(new ActionableError(`Emulator failed to start: ${error.message}`));
+        if (startupValidationComplete) {
+          finalizePostValidationExit(flushLaunchOutput());
+          return;
         }
+        clearExitDrainTimeout();
+        startupValidationComplete = true;
+        perf.endOperation("panicDetection");
+        reject(new ActionableError(`Emulator failed to start: ${error.message}`));
       });
     });
   }
@@ -1892,6 +1894,17 @@ export class AndroidEmulatorClient implements AndroidEmulator {
     if (error) {
       throw error;
     }
+  }
+
+  private async finalizedReadinessExitError(
+    childProcess: ChildProcess | null | undefined,
+    fallback: ActionableError,
+  ): Promise<ActionableError> {
+    const finalization = this.getLaunchErrorFinalization(childProcess);
+    const finalizedError = finalization
+      ? await finalization
+      : this.getLaunchError(childProcess);
+    return finalizedError ?? fallback;
   }
 
   private recordLaunchError(
@@ -2275,9 +2288,13 @@ export class AndroidEmulatorClient implements AndroidEmulator {
       if (readinessFailure) {
         pollingActive = false;
         await pollingPromise;
+        const finalizedReadinessFailure = await this.finalizedReadinessExitError(
+          childProcess,
+          readinessFailure,
+        );
         perf.endOperation("devicePolling");
         cleanupProcessListeners();
-        throw readinessFailure;
+        throw finalizedReadinessFailure;
       }
 
       if (foundDeviceId) {

--- a/src/utils/android-cmdline-tools/AndroidEmulatorClient.ts
+++ b/src/utils/android-cmdline-tools/AndroidEmulatorClient.ts
@@ -1446,7 +1446,6 @@ export class AndroidEmulatorClient implements AndroidEmulator {
           !startupValidationComplete ||
           exitCode === undefined ||
           exitCode === 0 ||
-          duplicateAvdDetected ||
           resolvePostValidationExit
         ) {
           return;

--- a/src/utils/android-cmdline-tools/AndroidEmulatorClient.ts
+++ b/src/utils/android-cmdline-tools/AndroidEmulatorClient.ts
@@ -1888,6 +1888,12 @@ export class AndroidEmulatorClient implements AndroidEmulator {
     return childProcess ? this.launchErrorFinalizations.get(childProcess) : undefined;
   }
 
+  private throwLaunchError(error?: ActionableError): void {
+    if (error) {
+      throw error;
+    }
+  }
+
   private recordLaunchError(
     childProcess: ChildProcess | null | undefined,
     onError: (error: ActionableError) => void,
@@ -1989,11 +1995,12 @@ export class AndroidEmulatorClient implements AndroidEmulator {
       `Waiting for emulator '${avdName}' to be ready... (polling interval: ${pollingIntervalMs}ms)`,
     );
 
-    const finalizedLaunchError = await this.getLaunchErrorFinalization(childProcess);
+    const launchErrorFinalization = this.getLaunchErrorFinalization(childProcess);
+    const finalizedLaunchError = launchErrorFinalization
+      ? await launchErrorFinalization
+      : undefined;
     const recordedLaunchError = finalizedLaunchError ?? this.getLaunchError(childProcess);
-    if (recordedLaunchError) {
-      throw recordedLaunchError;
-    }
+    this.throwLaunchError(recordedLaunchError);
 
     // Monitor child process for early exit if provided
     let pollingActive = true;

--- a/src/utils/android-cmdline-tools/AndroidEmulatorClient.ts
+++ b/src/utils/android-cmdline-tools/AndroidEmulatorClient.ts
@@ -329,6 +329,10 @@ export class AndroidEmulatorClient implements AndroidEmulator {
   private hostArchitecture: string;
   private readonly launchTargetDeviceIds = new WeakMap<ChildProcess, string>();
   private readonly launchErrors = new WeakMap<ChildProcess, ActionableError>();
+  private readonly launchErrorFinalizations = new WeakMap<
+    ChildProcess,
+    Promise<ActionableError>
+  >();
 
   /**
    * Create an AndroidEmulatorClient instance
@@ -1399,7 +1403,8 @@ export class AndroidEmulatorClient implements AndroidEmulator {
       let childTerminationObserved = false;
       let exitCode: number | null | undefined;
       let exitSignal: NodeJS.Signals | null | undefined;
-      let genericPostValidationExitRecorded = false;
+      let provisionalPostValidationExitError: ActionableError | undefined;
+      let resolvePostValidationExit: ((error: ActionableError) => void) | undefined;
       perf.startOperation("panicDetection");
 
       const appendRedactedLaunchOutput = (output: string) => {
@@ -1425,27 +1430,58 @@ export class AndroidEmulatorClient implements AndroidEmulator {
           earlyExitCategory = category;
         }
       };
-      const recordPostValidationExit = (output: string) => {
+      const postValidationExitError = (output: string) =>
+        this.formatEarlyExitError(
+          avdName,
+          exitCode ?? null,
+          exitSignal ?? null,
+          earlyExitCategory,
+          output,
+          "",
+        );
+      const beginPostValidationExit = (output: string) => {
         if (
           !startupValidationComplete ||
           exitCode === undefined ||
           exitCode === 0 ||
-          (this.launchErrors.has(child) && !genericPostValidationExitRecorded)
+          resolvePostValidationExit
         ) {
           return;
         }
-        this.launchErrors.set(
+        this.launchErrorFinalizations.set(
           child,
-          this.formatEarlyExitError(
-            avdName,
-            exitCode,
-            exitSignal ?? null,
-            earlyExitCategory,
-            output,
-            "",
-          ),
+          new Promise<ActionableError>((resolveFinalization) => {
+            resolvePostValidationExit = resolveFinalization;
+          }),
         );
-        genericPostValidationExitRecorded = true;
+        if (!this.launchErrors.has(child)) {
+          provisionalPostValidationExitError = postValidationExitError(output);
+          this.launchErrors.set(child, provisionalPostValidationExitError);
+        }
+        exitDrainTimeout = this.timer.setTimeout(() => {
+          logger.debug(
+            `Emulator stdio did not close within ${EARLY_EXIT_DRAIN_TIMEOUT_MS}ms after a validated exit`,
+          );
+          finalizePostValidationExit(flushLaunchOutput());
+        }, EARLY_EXIT_DRAIN_TIMEOUT_MS);
+      };
+      const finalizePostValidationExit = (output: string) => {
+        if (!resolvePostValidationExit) {
+          return;
+        }
+        clearExitDrainTimeout();
+        if (
+          !this.launchErrors.has(child) ||
+          this.launchErrors.get(child) === provisionalPostValidationExitError
+        ) {
+          provisionalPostValidationExitError = postValidationExitError(output);
+          this.launchErrors.set(child, provisionalPostValidationExitError);
+        }
+        const finalError = this.launchErrors.get(child) ?? postValidationExitError(output);
+        const resolveFinalization = resolvePostValidationExit;
+        resolvePostValidationExit = undefined;
+        this.launchErrorFinalizations.delete(child);
+        resolveFinalization(finalError);
       };
 
       // Monitor emulator output for PANIC errors
@@ -1764,8 +1800,9 @@ export class AndroidEmulatorClient implements AndroidEmulator {
         } else {
           logger.info(`Emulator process exited with code: ${code}`);
         }
-        recordPostValidationExit(currentLaunchOutput());
-        if (!startupValidationComplete) {
+        if (startupValidationComplete) {
+          beginPostValidationExit(currentLaunchOutput());
+        } else {
           exitDrainTimeout = this.timer.setTimeout(() => {
             logger.debug(
               `Emulator stdio did not close within ${EARLY_EXIT_DRAIN_TIMEOUT_MS}ms after an early exit`,
@@ -1782,7 +1819,8 @@ export class AndroidEmulatorClient implements AndroidEmulator {
         exitCode ??= code;
         exitSignal ??= signal;
         if (startupValidationComplete) {
-          recordPostValidationExit(flushLaunchOutput());
+          beginPostValidationExit(currentLaunchOutput());
+          finalizePostValidationExit(flushLaunchOutput());
           return;
         }
         finalizeEarlyExit();
@@ -1828,6 +1866,12 @@ export class AndroidEmulatorClient implements AndroidEmulator {
 
   private getLaunchError(childProcess?: ChildProcess | null): ActionableError | undefined {
     return childProcess ? this.launchErrors.get(childProcess) : undefined;
+  }
+
+  private getLaunchErrorFinalization(
+    childProcess?: ChildProcess | null,
+  ): Promise<ActionableError> | undefined {
+    return childProcess ? this.launchErrorFinalizations.get(childProcess) : undefined;
   }
 
   private recordLaunchError(
@@ -1931,7 +1975,8 @@ export class AndroidEmulatorClient implements AndroidEmulator {
       `Waiting for emulator '${avdName}' to be ready... (polling interval: ${pollingIntervalMs}ms)`,
     );
 
-    const recordedLaunchError = this.getLaunchError(childProcess);
+    const finalizedLaunchError = await this.getLaunchErrorFinalization(childProcess);
+    const recordedLaunchError = finalizedLaunchError ?? this.getLaunchError(childProcess);
     if (recordedLaunchError) {
       throw recordedLaunchError;
     }

--- a/test/utils/android-cmdline-tools/AndroidEmulatorClient-corruptImage.test.ts
+++ b/test/utils/android-cmdline-tools/AndroidEmulatorClient-corruptImage.test.ts
@@ -532,8 +532,25 @@ describe("AndroidEmulatorClient waitForEmulatorReady with child process monitori
     expect(error.message).toContain("failed to become ready within 100ms");
   });
 
+  test("removes child process listeners after readiness times out", async () => {
+    const fakeChild = createFakeChildProcess();
+    fakeTimer.enableAutoAdvance();
+    const client = new AndroidEmulatorClient(mockExecAsync, null, fakeTimer, fakeFactory);
+    skipEmulatorPathDetection(client);
+
+    const error = await expectRejection(
+      client.waitForEmulatorReady("Pixel_9_Pro", 100, fakeChild),
+    );
+
+    expect(error.message).toContain("failed to become ready within 100ms");
+    expect(fakeChild.listenerCount("exit")).toBe(0);
+    expect(fakeChild.stdout!.listenerCount("data")).toBe(0);
+    expect(fakeChild.stderr!.listenerCount("data")).toBe(0);
+  });
+
   test("waits for Android boot-complete signals before reporting readiness", async () => {
     fakeTimer.enableAutoAdvance();
+    const fakeChild = createFakeChildProcess();
     fakeAdb.setDevices([{
       name: "Pixel_9_Pro",
       platform: "android",
@@ -552,7 +569,7 @@ describe("AndroidEmulatorClient waitForEmulatorReady with child process monitori
     const client = new AndroidEmulatorClient(mockExecAsync, null, fakeTimer, fakeFactory);
     skipEmulatorPathDetection(client);
 
-    const result = await client.waitForEmulatorReady("Pixel_9_Pro", 5_000);
+    const result = await client.waitForEmulatorReady("Pixel_9_Pro", 5_000, fakeChild);
 
     expect(result.deviceId).toBe("emulator-5554");
     expect(fakeAdb.wasCommandExecuted("shell getprop sys.boot_completed")).toBe(true);
@@ -561,6 +578,9 @@ describe("AndroidEmulatorClient waitForEmulatorReady with child process monitori
       fakeAdb.getExecutedCommands()
         .filter(command => command.includes("shell getprop sys.boot_completed")),
     ).toHaveLength(2);
+    expect(fakeChild.listenerCount("exit")).toBe(0);
+    expect(fakeChild.stdout!.listenerCount("data")).toBe(0);
+    expect(fakeChild.stderr!.listenerCount("data")).toBe(0);
   });
 
   test("targets the selected emulator deviceId during already-running readiness waits", async () => {

--- a/test/utils/android-cmdline-tools/AndroidEmulatorClient-launchDiagnostics.test.ts
+++ b/test/utils/android-cmdline-tools/AndroidEmulatorClient-launchDiagnostics.test.ts
@@ -307,31 +307,67 @@ describe("AndroidEmulatorClient launch diagnostics", () => {
     );
     child.emit("exit", 1, null);
 
-    const readiness = client.waitForEmulatorReady(avdName, 60_000, launchedChild);
-    let rejection: Error | undefined;
-    void readiness.catch((error) => {
-      rejection = error instanceof Error ? error : new Error(String(error));
+    const readiness = expectRejection(
+      client.waitForEmulatorReady(avdName, 60_000, launchedChild),
+    );
+
+    child.stderr!.emit("data", Buffer.from("late handoff diagnostic\n"));
+    child.emit("close", 1, null);
+    const error = await readiness;
+
+    expect(error.message).toContain("exited with code: 1");
+    expect(error.message).toContain("handoff diagnostic");
+    expect(error.message).toContain("late handoff diagnostic");
+    expect(error.message).toContain("token=[REDACTED]");
+    expect(error.message).not.toContain("handoff-secret");
+    expect(timer.getSleepCallCount()).toBe(0);
+    expect(child.listenerCount("exit")).toBe(baselineExitListeners);
+  });
+
+  test("preserves richer diagnostics emitted after a post-validation exit", async () => {
+    const child = createChild();
+    const { client } = createClient(child, () => {
+      child.stdout!.emit("data", Buffer.from("Detected GPU type: host\n"));
     });
+    const launchedChild = await client.startEmulator(avdName);
+    child.emit("exit", 1, null);
+    const readiness = expectRejection(
+      client.waitForEmulatorReady(avdName, 60_000, launchedChild),
+    );
+    child.stderr!.emit(
+      "data",
+      Buffer.from("qemu_mprotect__osdep: mprotect failed: Permission denied\n"),
+    );
+    child.emit("close", 1, null);
 
-    try {
-      for (let turn = 0; turn < 10 && !rejection; turn += 1) {
-        await new Promise<void>((resolve) => setImmediate(resolve));
-      }
+    const error = await readiness;
+    expect(error.message).toContain("hypervisor");
+    expect(error.message).toContain("sandbox");
+  });
 
-      expect(rejection?.message).toContain("exited with code: 1");
-      expect(rejection?.message).toContain("handoff diagnostic");
-      expect(rejection?.message).toContain("token=[REDACTED]");
-      expect(rejection?.message).not.toContain("handoff-secret");
-      expect(timer.getSleepCallCount()).toBe(0);
-      expect(child.listenerCount("exit")).toBe(baselineExitListeners);
-    } finally {
-      child.emit("close", 1, null);
-      timer.setCurrentTime(60_000);
-      timer.resolveAll();
-      await new Promise<void>((resolve) => setImmediate(resolve));
-      timer.resolveAll();
-      await readiness.catch(() => undefined);
-    }
+  test("bounds post-validation exit diagnostic draining", async () => {
+    const child = createChild();
+    const { client, timer } = createClient(child, () => {
+      child.stdout!.emit("data", Buffer.from("Detected GPU type: host\n"));
+    });
+    const launchedChild = await client.startEmulator(avdName);
+    child.emit("exit", 1, null);
+    const readiness = expectRejection(
+      client.waitForEmulatorReady(avdName, 60_000, launchedChild),
+    );
+    let settled = false;
+    void readiness.then(() => {
+      settled = true;
+    });
+    await new Promise<void>((resolve) => setImmediate(resolve));
+
+    expect(settled).toBe(false);
+    await timer.advanceTimeAsync(999);
+    await new Promise<void>((resolve) => setImmediate(resolve));
+    expect(settled).toBe(false);
+    await timer.advanceTimeAsync(1);
+    const error = await readiness;
+    expect(error.message).toContain("exited with code: 1");
   });
 
   test("removes readiness listeners after observing a process exit", async () => {

--- a/test/utils/android-cmdline-tools/AndroidEmulatorClient-launchDiagnostics.test.ts
+++ b/test/utils/android-cmdline-tools/AndroidEmulatorClient-launchDiagnostics.test.ts
@@ -421,6 +421,56 @@ describe("AndroidEmulatorClient launch diagnostics", () => {
     }
   });
 
+  test("keeps post-validation exit finalization bounded after a child error", async () => {
+    const child = createChild();
+    const { client, timer } = createClient(child, () => {
+      child.stdout!.emit("data", Buffer.from("Detected GPU type: host\n"));
+    });
+    const launchedChild = await client.startEmulator(avdName);
+    child.emit("exit", 1, null);
+    const readiness = client.waitForEmulatorReady(avdName, 60_000, launchedChild);
+    let rejection: Error | undefined;
+    void readiness.catch((error) => {
+      rejection = error instanceof Error ? error : new Error(String(error));
+    });
+    child.emit("error", new Error("stdio failed after exit"));
+
+    try {
+      await timer.advanceTimeAsync(1_000);
+      await new Promise<void>((resolve) => setImmediate(resolve));
+      expect(rejection?.message).toContain("exited with code: 1");
+    } finally {
+      child.emit("close", 1, null);
+      await readiness.catch(() => undefined);
+    }
+  });
+
+  test("prefers finalized diagnostics for exits observed during readiness", async () => {
+    const child = createChild();
+    const { client, timer } = createClient(child, () => {
+      child.stdout!.emit("data", Buffer.from("Detected GPU type: host\n"));
+    });
+    const launchedChild = await client.startEmulator(avdName);
+    const readiness = expectRejection(
+      client.waitForEmulatorReady(avdName, 60_000, launchedChild),
+    );
+
+    for (let turn = 0; turn < 10 && timer.getSleepCallCount() < 2; turn += 1) {
+      await new Promise<void>((resolve) => setImmediate(resolve));
+    }
+    child.emit("exit", 1, null);
+    child.stderr!.emit(
+      "data",
+      Buffer.from("qemu_mprotect__osdep: mprotect failed: Permission denied\n"),
+    );
+    child.emit("close", 1, null);
+    await timer.advanceTimeAsync(500);
+
+    const error = await readiness;
+    expect(error.message).toContain("hypervisor");
+    expect(error.message).toContain("sandbox");
+  });
+
   test("removes readiness listeners after observing a process exit", async () => {
     const child = createChild();
     const { client, timer } = createClient(child, () => {
@@ -441,7 +491,7 @@ describe("AndroidEmulatorClient launch diagnostics", () => {
     await timer.advanceTimeAsync(500);
 
     const error = await readinessError;
-    expect(error.message).toContain("exited with code 1");
+    expect(error.message).toContain("exited with code: 1");
     expect(child.listenerCount("exit")).toBe(baselineExitListeners);
     expect(child.stdout!.listenerCount("data")).toBe(baselineStdoutListeners);
     expect(child.stderr!.listenerCount("data")).toBe(baselineStderrListeners);

--- a/test/utils/android-cmdline-tools/AndroidEmulatorClient-launchDiagnostics.test.ts
+++ b/test/utils/android-cmdline-tools/AndroidEmulatorClient-launchDiagnostics.test.ts
@@ -515,6 +515,9 @@ describe("AndroidEmulatorClient launch diagnostics", () => {
           "Running multiple emulators with the same AVD is an experimental feature.\n",
         ),
       );
+      for (let index = 0; index < 51; index += 1) {
+        child.stderr!.emit("data", Buffer.from(`later readiness diagnostic ${index}\n`));
+      }
       child.emit("exit", 1, null);
       child.emit("close", 1, null);
       await timer.advanceTimeAsync(500);

--- a/test/utils/android-cmdline-tools/AndroidEmulatorClient-launchDiagnostics.test.ts
+++ b/test/utils/android-cmdline-tools/AndroidEmulatorClient-launchDiagnostics.test.ts
@@ -401,6 +401,26 @@ describe("AndroidEmulatorClient launch diagnostics", () => {
     expect(error.message).toContain("exited with code: 1");
   });
 
+  test("installs readiness exit monitoring without a check-to-listener yield", async () => {
+    const child = createChild();
+    const { client, timer } = createClient(child, () => {
+      child.stdout!.emit("data", Buffer.from("Detected GPU type: host\n"));
+    });
+    const launchedChild = await client.startEmulator(avdName);
+    const baselineExitListeners = child.listenerCount("exit");
+    const readiness = client.waitForEmulatorReady(avdName, 60_000, launchedChild);
+    const readinessSettled = readiness.catch(() => undefined);
+
+    try {
+      expect(child.listenerCount("exit")).toBe(baselineExitListeners + 1);
+    } finally {
+      child.emit("exit", 1, null);
+      child.emit("close", 1, null);
+      await timer.advanceTimeAsync(500);
+      await readinessSettled;
+    }
+  });
+
   test("removes readiness listeners after observing a process exit", async () => {
     const child = createChild();
     const { client, timer } = createClient(child, () => {

--- a/test/utils/android-cmdline-tools/AndroidEmulatorClient-launchDiagnostics.test.ts
+++ b/test/utils/android-cmdline-tools/AndroidEmulatorClient-launchDiagnostics.test.ts
@@ -345,6 +345,37 @@ describe("AndroidEmulatorClient launch diagnostics", () => {
     expect(error.message).toContain("sandbox");
   });
 
+  test("keeps a post-validation duplicate-AVD exit nonfatal", async () => {
+    const child = createChild();
+    const { client, timer, accelChecks } = createClient(child, () => {
+      child.stdout!.emit("data", Buffer.from("Detected GPU type: host\n"));
+    });
+    const launchedChild = await client.startEmulator(avdName);
+    child.stderr!.emit(
+      "data",
+      Buffer.from("Running multiple emulators with the same AVD is an experimental feature.\n"),
+    );
+    child.emit("exit", 1, null);
+    child.emit("close", 1, null);
+    const readiness = client.waitForEmulatorReady(avdName, 60_000, launchedChild);
+    let rejection: Error | undefined;
+    void readiness.catch((error) => {
+      rejection = error instanceof Error ? error : new Error(String(error));
+    });
+
+    try {
+      await new Promise<void>((resolve) => setImmediate(resolve));
+      expect(rejection).toBeUndefined();
+      expect(accelChecks()).toBe(0);
+    } finally {
+      timer.setCurrentTime(60_000);
+      timer.resolveAll();
+      await new Promise<void>((resolve) => setImmediate(resolve));
+      timer.resolveAll();
+      await readiness.catch(() => undefined);
+    }
+  });
+
   test("bounds post-validation exit diagnostic draining", async () => {
     const child = createChild();
     const { client, timer } = createClient(child, () => {

--- a/test/utils/android-cmdline-tools/AndroidEmulatorClient-launchDiagnostics.test.ts
+++ b/test/utils/android-cmdline-tools/AndroidEmulatorClient-launchDiagnostics.test.ts
@@ -445,6 +445,28 @@ describe("AndroidEmulatorClient launch diagnostics", () => {
     }
   });
 
+  test("preserves diagnostics emitted after a post-exit child error", async () => {
+    const child = createChild();
+    const { client } = createClient(child, () => {
+      child.stdout!.emit("data", Buffer.from("Detected GPU type: host\n"));
+    });
+    const launchedChild = await client.startEmulator(avdName);
+    child.emit("exit", 1, null);
+    const readiness = expectRejection(
+      client.waitForEmulatorReady(avdName, 60_000, launchedChild),
+    );
+    child.emit("error", new Error("stdio failed after exit"));
+    child.stderr!.emit(
+      "data",
+      Buffer.from("qemu_mprotect__osdep: mprotect failed: Permission denied\n"),
+    );
+    child.emit("close", 1, null);
+
+    const error = await readiness;
+    expect(error.message).toContain("hypervisor");
+    expect(error.message).toContain("sandbox");
+  });
+
   test("prefers finalized diagnostics for exits observed during readiness", async () => {
     const child = createChild();
     const { client, timer } = createClient(child, () => {
@@ -469,6 +491,43 @@ describe("AndroidEmulatorClient launch diagnostics", () => {
     const error = await readiness;
     expect(error.message).toContain("hypervisor");
     expect(error.message).toContain("sandbox");
+  });
+
+  test("keeps duplicate-AVD adoption nonfatal during active readiness", async () => {
+    const child = createChild();
+    const { client, timer } = createClient(child, () => {
+      child.stdout!.emit("data", Buffer.from("Detected GPU type: host\n"));
+    });
+    const launchedChild = await client.startEmulator(avdName);
+    const readiness = client.waitForEmulatorReady(avdName, 60_000, launchedChild);
+    let rejection: Error | undefined;
+    void readiness.catch((error) => {
+      rejection = error instanceof Error ? error : new Error(String(error));
+    });
+
+    try {
+      for (let turn = 0; turn < 10 && timer.getSleepCallCount() < 2; turn += 1) {
+        await new Promise<void>((resolve) => setImmediate(resolve));
+      }
+      child.stderr!.emit(
+        "data",
+        Buffer.from(
+          "Running multiple emulators with the same AVD is an experimental feature.\n",
+        ),
+      );
+      child.emit("exit", 1, null);
+      child.emit("close", 1, null);
+      await timer.advanceTimeAsync(500);
+      await new Promise<void>((resolve) => setImmediate(resolve));
+
+      expect(rejection).toBeUndefined();
+    } finally {
+      timer.setCurrentTime(60_000);
+      timer.resolveAll();
+      await new Promise<void>((resolve) => setImmediate(resolve));
+      timer.resolveAll();
+      await readiness.catch(() => undefined);
+    }
   });
 
   test("removes readiness listeners after observing a process exit", async () => {

--- a/test/utils/android-cmdline-tools/AndroidEmulatorClient-launchDiagnostics.test.ts
+++ b/test/utils/android-cmdline-tools/AndroidEmulatorClient-launchDiagnostics.test.ts
@@ -294,6 +294,72 @@ describe("AndroidEmulatorClient launch diagnostics", () => {
     expect(accelChecks()).toBe(0);
   });
 
+  test("replays a post-validation exit to readiness with launch diagnostics", async () => {
+    const child = createChild();
+    const { client, timer } = createClient(child, () => {
+      child.stdout!.emit("data", Buffer.from("Detected GPU type: host\n"));
+    });
+    const launchedChild = await client.startEmulator(avdName);
+    const baselineExitListeners = child.listenerCount("exit");
+    child.stderr!.emit(
+      "data",
+      Buffer.from("token=handoff-secret\nhandoff diagnostic\n"),
+    );
+    child.emit("exit", 1, null);
+    child.emit("close", 1, null);
+
+    const readiness = client.waitForEmulatorReady(avdName, 60_000, launchedChild);
+    let rejection: Error | undefined;
+    void readiness.catch((error) => {
+      rejection = error instanceof Error ? error : new Error(String(error));
+    });
+
+    try {
+      for (let turn = 0; turn < 10 && !rejection; turn += 1) {
+        await new Promise<void>((resolve) => setImmediate(resolve));
+      }
+
+      expect(rejection?.message).toContain("exited with code: 1");
+      expect(rejection?.message).toContain("handoff diagnostic");
+      expect(rejection?.message).toContain("token=[REDACTED]");
+      expect(rejection?.message).not.toContain("handoff-secret");
+      expect(timer.getSleepCallCount()).toBe(0);
+      expect(child.listenerCount("exit")).toBe(baselineExitListeners);
+    } finally {
+      timer.setCurrentTime(60_000);
+      timer.resolveAll();
+      await new Promise<void>((resolve) => setImmediate(resolve));
+      timer.resolveAll();
+      await readiness.catch(() => undefined);
+    }
+  });
+
+  test("removes readiness listeners after observing a process exit", async () => {
+    const child = createChild();
+    const { client, timer } = createClient(child, () => {
+      child.stdout!.emit("data", Buffer.from("Detected GPU type: host\n"));
+    });
+    const launchedChild = await client.startEmulator(avdName);
+    const baselineExitListeners = child.listenerCount("exit");
+    const baselineStdoutListeners = child.stdout!.listenerCount("data");
+    const baselineStderrListeners = child.stderr!.listenerCount("data");
+    const readiness = client.waitForEmulatorReady(avdName, 60_000, launchedChild);
+    const readinessError = expectRejection(readiness);
+
+    for (let turn = 0; turn < 10 && timer.getSleepCallCount() < 2; turn += 1) {
+      await new Promise<void>((resolve) => setImmediate(resolve));
+    }
+    child.emit("exit", 1, null);
+    child.emit("close", 1, null);
+    await timer.advanceTimeAsync(500);
+
+    const error = await readinessError;
+    expect(error.message).toContain("exited with code 1");
+    expect(child.listenerCount("exit")).toBe(baselineExitListeners);
+    expect(child.stdout!.listenerCount("data")).toBe(baselineStdoutListeners);
+    expect(child.stderr!.listenerCount("data")).toBe(baselineStderrListeners);
+  });
+
   test("times out an acceleration check without masking the original exit code", async () => {
     const child = createChild();
     let probeSignal: AbortSignal | undefined;

--- a/test/utils/android-cmdline-tools/AndroidEmulatorClient-launchDiagnostics.test.ts
+++ b/test/utils/android-cmdline-tools/AndroidEmulatorClient-launchDiagnostics.test.ts
@@ -306,7 +306,6 @@ describe("AndroidEmulatorClient launch diagnostics", () => {
       Buffer.from("token=handoff-secret\nhandoff diagnostic\n"),
     );
     child.emit("exit", 1, null);
-    child.emit("close", 1, null);
 
     const readiness = client.waitForEmulatorReady(avdName, 60_000, launchedChild);
     let rejection: Error | undefined;
@@ -326,6 +325,7 @@ describe("AndroidEmulatorClient launch diagnostics", () => {
       expect(timer.getSleepCallCount()).toBe(0);
       expect(child.listenerCount("exit")).toBe(baselineExitListeners);
     } finally {
+      child.emit("close", 1, null);
       timer.setCurrentTime(60_000);
       timer.resolveAll();
       await new Promise<void>((resolve) => setImmediate(resolve));


### PR DESCRIPTION
## Summary

Preserve Android emulator exits across the launch-to-readiness handoff. Post-validation exits are recorded with bounded, redacted launch diagnostics and replayed before readiness starts polling; readiness listeners are removed on every settlement path.

## Linked Issue

Closes #5286

## Bug / Regression Context

- **Prior attempts:** [PR #5210](https://github.com/kaeawc/auto-mobile/pull/5210) preserved launch diagnostics through process close, but generic exits after launch validation were not retained for readiness.
- **Observed symptom:** A child could emit a startup marker, exit before readiness installed its listener, and leave readiness waiting for the generic timeout.
- **Repro steps / conditions:** Resolve launch from a startup marker, emit diagnostic output and a nonzero process exit, then begin readiness with that child process.

## Validation

- [x] `bun run turbo:validate` passes
- [x] `bun run typecheck` reports no new errors (baseline gate)
- [x] All Android emulator client tests pass
- [x] Regression tests use an injected child process and `FakeTimer`; each runs in under 4ms
- [x] Existing bounded/redacted diagnostics and per-child error storage are reused
- [x] No new helper or dependency
- [x] Rebased onto latest `main`, conflicts resolved

## Follow-ups

None.
