### PR TITLE
fix(daemon): close session teardown races

### DIFF
--- a/src/daemon/sessionManager.ts
+++ b/src/daemon/sessionManager.ts
@@ -108,6 +108,8 @@ export class SessionManager {
   private readonly activeReleasePromises: Set<{ session: Session; promise: Promise<string | null> }> = new Set();
   /** Setup work that must settle before a session restores its cached device state. */
   private readonly sessionSetupPromises: Set<{ session: Session; promise: Promise<void> }> = new Set();
+  /** Sessions whose teardown has closed admission for further device-state setup. */
+  private readonly releasingSessions: WeakSet<Session> = new WeakSet();
   private deviceSessionRepository: DeviceSessionRepository;
   private readonly getBarrier: () => DbWriteBarrier;
   private readonly keepScreenAwakeRestorerFactory: (device: BootedDevice) => KeepScreenAwakeRestorer;
@@ -204,6 +206,12 @@ export class SessionManager {
   getSession(sessionId: string): Session | null {
     const session = this.sessions.get(sessionId);
     if (session && this.isSessionExpired(session)) {
+      // Release owns this exact session object until it has restored device state
+      // and removed its assignment. Keep expiry cleanup from creating a second
+      // incarnation with the same UUID before teardown completes.
+      if (this.releasingSessions.has(session)) {
+        return session;
+      }
       logger.info(`Session ${sessionId} has expired, removing`);
       const deviceId = session.assignedDevice;
       this.removeSession(sessionId);
@@ -320,6 +328,7 @@ export class SessionManager {
       return await inFlightRelease.promise;
     }
 
+    this.releasingSessions.add(session);
     const promise = this.releaseSessionInternal(sessionId, session, releaseReason);
     const release = { session, promise };
     this.releasePromises.set(sessionId, release);
@@ -338,7 +347,12 @@ export class SessionManager {
    * Track setup that can modify device state after a session has been assigned.
    * Release waits for this work so restoration sees the final cached state.
    */
-  trackSessionSetup(session: Session, setup: Promise<void>): Promise<void> {
+  trackSessionSetup(session: Session, setupFactory: () => Promise<void>): Promise<void> {
+    if (this.releasingSessions.has(session) || this.sessions.get(session.sessionId) !== session) {
+      return Promise.resolve();
+    }
+
+    const setup = setupFactory();
     const tracked = { session, promise: setup };
     this.sessionSetupPromises.add(tracked);
     void setup.then(
@@ -396,7 +410,10 @@ export class SessionManager {
     }
 
     const deviceId = session.assignedDevice;
-    this.removeSession(sessionId);
+    if (!this.removeSession(sessionId, session)) {
+      logger.warn(`Skipping release finalization for ${sessionId}: session ownership changed`);
+      return null;
+    }
     // Intentionally NOT barrier-tracked: releaseSession is awaited by its caller
     // (explicit release), so this write is caller-tied, not fire-and-forget. Only
     // the lazy-expiry / cleanup-expired markReleased calls above are fire-and-forget
@@ -641,13 +658,15 @@ export class SessionManager {
   /**
    * Remove session from all maps
    */
-  private removeSession(sessionId: string): void {
+  private removeSession(sessionId: string, expectedSession?: Session): boolean {
     const session = this.sessions.get(sessionId);
-    if (session) {
-      this.deviceSessionMap.delete(session.assignedDevice);
+    if (!session || (expectedSession && session !== expectedSession)) {
+      return false;
     }
+    this.deviceSessionMap.delete(session.assignedDevice);
     this.sessions.delete(sessionId);
     this.sessionDeviceMap.delete(sessionId);
+    return true;
   }
 
   private async restoreKeepScreenAwake(session: Session): Promise<void> {
@@ -680,7 +699,7 @@ export class SessionManager {
     const expiredSessions: string[] = [];
 
     for (const [sessionId, session] of this.sessions) {
-      if (this.isSessionExpired(session)) {
+      if (this.isSessionExpired(session) && !this.releasingSessions.has(session)) {
         expiredSessions.push(sessionId);
       }
     }

--- a/src/server/ToolExecutionContext.ts
+++ b/src/server/ToolExecutionContext.ts
@@ -91,7 +91,7 @@ export async function createToolExecutionContext(
 
   await sessionManager.trackSessionSetup(
     session,
-    ensureKeepScreenAwake(session, sessionManager, sessionOptions),
+    () => ensureKeepScreenAwake(session, sessionManager, sessionOptions),
   );
 
   if (!existingSession) {

--- a/test/daemon/sessionManager.test.ts
+++ b/test/daemon/sessionManager.test.ts
@@ -295,12 +295,66 @@ describe("SessionManager", () => {
       }, () => new FakeDbWriteBarrier());
       try {
         const session = await manager.createSession("s1", "device-1", "android");
-        const setup = manager.trackSessionSetup(session, setupFinished);
+        const setup = manager.trackSessionSetup(session, () => setupFinished);
         const release = manager.releaseSession("s1", "daemon-shutdown");
 
         await Promise.resolve();
         expect(manager.getSession("s1")).not.toBeNull();
 
+        finishSetup();
+        await setup;
+        await expect(release).resolves.toBe("device-1");
+        expect(manager.getSession("s1")).toBeNull();
+      } finally {
+        manager.stopCleanupTimer();
+      }
+    });
+
+    test("does not admit setup that arrives after release begins", async () => {
+      let finishInitialSetup!: () => void;
+      const initialSetup = new Promise<void>(resolve => { finishInitialSetup = resolve; });
+      const manager = new SessionManager(fakeTimer, {
+        async upsertActiveSession(): Promise<void> {},
+        async recordActivity(): Promise<void> {},
+        async markReleased(): Promise<void> {},
+        async markStaleActiveSessionsExpired(): Promise<void> {},
+      }, () => new FakeDbWriteBarrier());
+      try {
+        const session = await manager.createSession("s1", "device-1", "android");
+        const setup = manager.trackSessionSetup(session, () => initialSetup);
+        const release = manager.releaseSession("s1", "daemon-shutdown");
+        let lateSetupStarted = false;
+
+        await Promise.resolve();
+        await manager.trackSessionSetup(session, async () => { lateSetupStarted = true; });
+        expect(lateSetupStarted).toBe(false);
+
+        finishInitialSetup();
+        await setup;
+        await expect(release).resolves.toBe("device-1");
+      } finally {
+        manager.stopCleanupTimer();
+      }
+    });
+
+    test("keeps an expiring session assigned until its release finishes", async () => {
+      let finishSetup!: () => void;
+      const setupFinished = new Promise<void>(resolve => { finishSetup = resolve; });
+      const manager = new SessionManager(fakeTimer, {
+        async upsertActiveSession(): Promise<void> {},
+        async recordActivity(): Promise<void> {},
+        async markReleased(): Promise<void> {},
+        async markStaleActiveSessionsExpired(): Promise<void> {},
+      }, () => new FakeDbWriteBarrier());
+      try {
+        const session = await manager.createSession("s1", "device-1", "android", 1);
+        const setup = manager.trackSessionSetup(session, () => setupFinished);
+        const release = manager.releaseSession("s1", "daemon-shutdown", true);
+
+        fakeTimer.advanceTime(1);
+        manager.cleanupExpiredSessions();
+
+        await expect(manager.createSession("s1", "device-2", "android")).resolves.toBe(session);
         finishSetup();
         await setup;
         await expect(release).resolves.toBe("device-1");


### PR DESCRIPTION
## Summary

- close setup admission as soon as session teardown begins, so late tool-context setup cannot modify Android keep-awake state after restoration
- keep an expiring session assigned throughout its in-flight teardown and remove it only when the captured session object still owns the UUID
- add focused FakeTimer regressions for both races

## Why

This follow-up addresses two post-merge review findings from [PR #5327](https://github.com/kaeawc/auto-mobile/pull/5327). A late admitted setup could otherwise finish after teardown, and expiry cleanup could otherwise recreate a UUID before teardown removed the original session.

## Validation

- `bun test test/daemon/sessionManager.test.ts test/server/ToolExecutionContext.test.ts test/daemon/daemonShutdownSessionRelease.test.ts`
- `bun run typecheck`
- `bun run lint`
