### PR TITLE
fix(daemon): close shutdown session teardown races

### DIFF
--- a/src/daemon/daemon.ts
+++ b/src/daemon/daemon.ts
@@ -116,7 +116,7 @@ const SSE_KEEPALIVE_INTERVAL_MS = 30_000;
 // writes to quiesce before closing the connection (issue #2792). Best-effort
 // writes are best-effort: if the bound elapses, shutdown proceeds anyway.
 const DB_WRITE_DRAIN_TIMEOUT_MS = 1_000;
-const SESSION_RELEASE_DRAIN_TIMEOUT_MS = 1_000;
+const SESSION_RELEASE_DRAIN_TIMEOUT_MS = 5_000;
 
 // Ceiling on awaiting an in-flight cold-start migration before closing the DB on
 // shutdown (issue #3044). A SIGTERM arriving mid-startup-migration would otherwise
@@ -174,6 +174,7 @@ export class Daemon {
   private options: DaemonOptions;
   private shutdownHandlersRegistered: boolean = false;
   private shutdownInProgress: boolean = false;
+  private shutdownSessionReleasesDrained = true;
 
   constructor(
     options: DaemonOptions = {},
@@ -1835,7 +1836,16 @@ export class Daemon {
             }
           },
         },
-        { name: "database", run: closeDatabase },
+        {
+          name: "database",
+          run: async () => {
+            if (!this.shutdownSessionReleasesDrained) {
+              logger.warn("Skipping database close because a session terminal write is still in flight");
+              return;
+            }
+            await closeDatabase();
+          },
+        },
         {
           name: "logger",
           run: async () => {
@@ -1849,34 +1859,29 @@ export class Daemon {
   }
 
   private async releaseActiveSessionsForShutdown(): Promise<void> {
-    await Promise.all(this.sessionManager.getAllSessionIds().map(sessionId => this.releaseSessionForShutdown(sessionId)));
-    if (!await this.sessionManager.drainReleasePromises(SESSION_RELEASE_DRAIN_TIMEOUT_MS)) {
-      logger.warn(`Timed out after ${SESSION_RELEASE_DRAIN_TIMEOUT_MS}ms draining in-flight session releases during shutdown`);
-    }
-  }
-
-  private async releaseSessionForShutdown(sessionId: string): Promise<void> {
-    const release = this.cancelAndReleaseSession(sessionId, "daemon-shutdown", true);
-    let timeoutHandle: NodeJS.Timeout | undefined;
-    const timeout = new Promise<boolean>(resolve => {
-      timeoutHandle = this.timer.setTimeout(() => resolve(false), SESSION_RELEASE_DRAIN_TIMEOUT_MS);
-    });
-    try {
-      const released = await Promise.race([
-        release.then(() => true, error => {
-          logger.warn(`[Daemon] Failed to release session ${sessionId} during shutdown: ${error}`);
-          return true;
-        }),
-        timeout,
-      ]);
-      if (!released) {
-        logger.warn(`Timed out after ${SESSION_RELEASE_DRAIN_TIMEOUT_MS}ms releasing session ${sessionId} during shutdown`);
+    const sessionIds = this.sessionManager.getAllSessionIds();
+    const releases = sessionIds.map(sessionId =>
+      this.cancelAndReleaseSession(sessionId, "daemon-shutdown", true),
+    );
+    const reportFailures = (results: PromiseSettledResult<void>[]): void => {
+      for (const [index, release] of results.entries()) {
+        if (release.status === "rejected") {
+          logger.warn(
+            `[Daemon] Failed to release session ${sessionIds[index] ?? "unknown"} during shutdown: ${release.reason}`,
+          );
+        }
       }
-    } finally {
-      if (timeoutHandle !== undefined) {
-        this.timer.clearTimeout(timeoutHandle);
-      }
+    };
+    const settled = Promise.allSettled(releases);
+    await Promise.resolve();
+    const drained = await this.sessionManager.drainReleasePromises(SESSION_RELEASE_DRAIN_TIMEOUT_MS);
+    if (!drained) {
+      this.shutdownSessionReleasesDrained = false;
+      logger.warn(`Timed out after ${SESSION_RELEASE_DRAIN_TIMEOUT_MS}ms draining session releases; database will remain open`);
+      void settled.then(reportFailures);
+      return;
     }
+    reportFailures(await settled);
   }
 
   private getDaemonFileCleanupOptions(): { expectedPid?: number } {

--- a/src/daemon/devicePool.ts
+++ b/src/daemon/devicePool.ts
@@ -173,6 +173,11 @@ export class DevicePool {
    * marker that belonged to a device that is already gone.
    */
   private readonly intentionalShutdowns: Map<string, number> = new Map();
+  /** Releases waiting for late session teardown, bound to one pooled incarnation. */
+  private readonly deferredDeviceReleases: Map<
+    string,
+    { device: PooledDevice; sessionId: string; cleanup: Promise<void> }
+  > = new Map();
   private deviceIncarnationCounter = 0;
 
   // Max consecutive errors before marking device as failed
@@ -469,6 +474,7 @@ export class DevicePool {
     }
 
     this.devices.delete(deviceId);
+    this.deferredDeviceReleases.delete(deviceId);
     this.notifyDeviceRemoved(deviceId);
     this.deviceSessionStarts.delete(deviceId);
     this.refreshMissingDeviceMisses.delete(deviceId);
@@ -2035,6 +2041,28 @@ export class DevicePool {
       return;
     }
 
+    const existingDeferredRelease = this.deferredDeviceReleases.get(deviceId);
+    if (existingDeferredRelease) {
+      return;
+    }
+    const cleanup = this.sessionManager.getPendingDeviceCleanup(deviceId);
+    if (cleanup) {
+      const deferredRelease = { device, sessionId: expectedSessionId, cleanup };
+      this.deferredDeviceReleases.set(deviceId, deferredRelease);
+      void cleanup.then(() => {
+        if (
+          this.deferredDeviceReleases.get(deviceId) !== deferredRelease ||
+          this.devices.get(deviceId) !== device
+        ) {
+          return;
+        }
+        this.deferredDeviceReleases.delete(deviceId);
+        return this.releaseDevice(deviceId, expectedSessionId);
+      });
+      logger.info(`Keeping device ${deviceId} assigned until late session teardown completes`);
+      return;
+    }
+
     const sessionId = device.sessionId;
     device.sessionId = null;
     device.status = "idle";
@@ -2415,14 +2443,11 @@ export class DevicePool {
       return;
     }
 
-    device.sessionId = null;
-    device.status = "idle";
-    device.errorCount = 0;
     device.autolockSessionId = undefined;
-    this.lastReleasedDeviceId = deviceId;
     this.clearMcpAutolockMappings(sessionId);
-
-    logger.info(`Autolock idle timeout: released device ${deviceId} from session ${sessionId}`);
+    void this.releaseDevice(deviceId, sessionId).then(() => {
+      logger.info(`Autolock idle timeout: released device ${deviceId} from session ${sessionId}`);
+    });
   }
 
   private clearMcpAutolockMappings(sessionId: string): void {

--- a/src/daemon/devicePool.ts
+++ b/src/daemon/devicePool.ts
@@ -164,6 +164,8 @@ export class DevicePool {
   private readonly recoveringAndroidDeviceIds: Set<string> = new Set();
   private readonly startedDeviceProcesses: Map<string, ChildProcess> = new Map();
   private readonly readinessReservationCounts: Map<string, number> = new Map();
+  /** Devices awaiting late session teardown work before they may be reused. */
+  private readonly deferredDeviceReleases: Map<string, Promise<void>> = new Map();
   /**
    * Serials the user intentionally stopped, mapped to the pooled-device
    * incarnation that was present at mark time (or {@link INCARNATION_ANY} when
@@ -2026,6 +2028,26 @@ export class DevicePool {
     const device = this.devices.get(deviceId);
     if (!device) {
       logger.warn(`Cannot release device ${deviceId}: not in pool`);
+      return;
+    }
+
+    if (this.deferredDeviceReleases.has(deviceId)) {
+      return;
+    }
+
+    const pendingCleanup = this.sessionManager.getPendingDeviceCleanup(deviceId);
+    if (pendingCleanup) {
+      this.deferredDeviceReleases.set(deviceId, pendingCleanup);
+      logger.warn(`Keeping device ${deviceId} assigned until late session teardown completes`);
+      void pendingCleanup.then(() => {
+        if (this.deferredDeviceReleases.get(deviceId) !== pendingCleanup) {
+          return;
+        }
+        this.deferredDeviceReleases.delete(deviceId);
+        return this.releaseDevice(deviceId);
+      }).catch(error => {
+        logger.warn(`Failed to release device ${deviceId} after late session teardown: ${error}`);
+      });
       return;
     }
 

--- a/src/daemon/devicePool.ts
+++ b/src/daemon/devicePool.ts
@@ -164,8 +164,6 @@ export class DevicePool {
   private readonly recoveringAndroidDeviceIds: Set<string> = new Set();
   private readonly startedDeviceProcesses: Map<string, ChildProcess> = new Map();
   private readonly readinessReservationCounts: Map<string, number> = new Map();
-  /** Devices awaiting late session teardown work before they may be reused. */
-  private readonly deferredDeviceReleases: Map<string, Promise<void>> = new Map();
   /**
    * Serials the user intentionally stopped, mapped to the pooled-device
    * incarnation that was present at mark time (or {@link INCARNATION_ANY} when
@@ -2031,26 +2029,6 @@ export class DevicePool {
       return;
     }
 
-    if (this.deferredDeviceReleases.has(deviceId)) {
-      return;
-    }
-
-    const pendingCleanup = this.sessionManager.getPendingDeviceCleanup(deviceId);
-    if (pendingCleanup) {
-      this.deferredDeviceReleases.set(deviceId, pendingCleanup);
-      logger.warn(`Keeping device ${deviceId} assigned until late session teardown completes`);
-      void pendingCleanup.then(() => {
-        if (this.deferredDeviceReleases.get(deviceId) !== pendingCleanup) {
-          return;
-        }
-        this.deferredDeviceReleases.delete(deviceId);
-        return this.releaseDevice(deviceId);
-      }).catch(error => {
-        logger.warn(`Failed to release device ${deviceId} after late session teardown: ${error}`);
-      });
-      return;
-    }
-
     if (!device.sessionId) {
       logger.debug(`Device ${deviceId} is already idle`);
       return;
@@ -2080,7 +2058,7 @@ export class DevicePool {
         }
         this.deferredDeviceReleases.delete(deviceId);
         return this.releaseDevice(deviceId, expectedSessionId);
-      });
+      }).catch(error => logger.warn(`Failed to release device ${deviceId} after late session teardown: ${error}`));
       logger.info(`Keeping device ${deviceId} assigned until late session teardown completes`);
       return;
     }

--- a/src/daemon/sessionManager.ts
+++ b/src/daemon/sessionManager.ts
@@ -266,6 +266,11 @@ export class SessionManager {
   ): Promise<Session> {
     const existing = this.getSession(sessionId);
     if (existing) {
+      const inFlightRelease = this.releasePromises.get(sessionId);
+      if (this.releasingSessions.has(existing) && inFlightRelease?.session === existing) {
+        await inFlightRelease.promise;
+        return await this.getOrCreateSession(sessionId, devicePool, platform);
+      }
       logger.info(`[SessionManager] Found existing session ${sessionId} with device ${existing.assignedDevice}`);
       // Resolving a session for a tool call is activity: extend both the idle
       // timeout (expiresAt) and the heartbeat clock (lastHeartbeat). Without the
@@ -436,10 +441,6 @@ export class SessionManager {
       }
     }
   }
-  getPendingDeviceCleanup(deviceId: string): Promise<void> | null {
-    return this.pendingDeviceCleanups.get(deviceId) ?? null;
-  }
-
   private async releaseSessionInternal(
     sessionId: string,
     session: Session,
@@ -457,11 +458,11 @@ export class SessionManager {
       const deviceId = session.assignedDevice;
 
       if (!this.removeSession(sessionId, session)) {
-        if (pendingCleanup.length > 0) this.trackPendingDeviceCleanup(deviceId, pendingCleanup);
+        if (pendingCleanup.length > 0) {this.trackPendingDeviceCleanup(deviceId, pendingCleanup);}
         logger.warn(`Skipping release finalization for ${sessionId}: session ownership changed`);
         return null;
       }
-      if (pendingCleanup.length > 0) this.trackPendingDeviceCleanup(deviceId, pendingCleanup);
+      if (pendingCleanup.length > 0) {this.trackPendingDeviceCleanup(deviceId, pendingCleanup);}
 
       await this.deviceSessionRepository.markReleased(sessionId, "released", this.timer.now(), releaseReason);
       for (const callback of this.releaseCallbacks) {
@@ -502,11 +503,11 @@ export class SessionManager {
         return { pending: settled.then(() => undefined) };
       }
       for (const setup of result) {
-        if (setup.status === "rejected") logger.warn(`Failed session setup for ${sessionId} before release: ${setup.reason}`);
+        if (setup.status === "rejected") {logger.warn(`Failed session setup for ${sessionId} before release: ${setup.reason}`);}
       }
       return { pending: null };
     } finally {
-      if (timeoutHandle !== undefined) this.timer.clearTimeout(timeoutHandle);
+      if (timeoutHandle !== undefined) {this.timer.clearTimeout(timeoutHandle);}
     }
   }
 
@@ -534,7 +535,7 @@ export class SessionManager {
       }
       return { pending: null };
     } finally {
-      if (timeoutHandle !== undefined) this.timer.clearTimeout(timeoutHandle);
+      if (timeoutHandle !== undefined) {this.timer.clearTimeout(timeoutHandle);}
     }
   }
 

--- a/src/daemon/sessionManager.ts
+++ b/src/daemon/sessionManager.ts
@@ -88,6 +88,9 @@ export interface SessionDeviceAssigner {
   assignDeviceToSession(sessionId: string, platform?: Platform): Promise<string>;
 }
 
+const KEEP_SCREEN_AWAKE_RESTORE_TIMEOUT_MS = 1_000;
+const SESSION_SETUP_DRAIN_TIMEOUT_MS = 1_000;
+
 export function getDefaultSessionHeartbeatTimeoutMs(): number {
   const rawValue = process.env.AUTOMOBILE_SESSION_HEARTBEAT_TIMEOUT_MS
     ?? process.env.AUTO_MOBILE_SESSION_HEARTBEAT_TIMEOUT_MS;
@@ -111,10 +114,12 @@ export class SessionManager {
   > = new Map();
   /** Every release still running, including an older session that reused a UUID. */
   private readonly activeReleasePromises: Set<{ session: Session; promise: Promise<string | null> }> = new Set();
-  /** Setup work that must settle before a session restores its cached device state. */
+  /** Setup work that can modify device state after a session has been assigned. */
   private readonly sessionSetupPromises: Set<{ session: Session; promise: Promise<void> }> = new Set();
   /** Sessions whose teardown has closed admission for further device-state setup. */
   private readonly releasingSessions: WeakSet<Session> = new WeakSet();
+  /** Device work that outlived the bounded release phase. */
+  private readonly pendingDeviceCleanups: Map<string, Promise<void>> = new Map();
   private deviceSessionRepository: DeviceSessionRepository;
   private readonly getBarrier: () => DbWriteBarrier;
   private readonly keepScreenAwakeRestorerFactory: (device: BootedDevice) => KeepScreenAwakeRestorer;
@@ -327,6 +332,10 @@ export class SessionManager {
     return this.deviceSessionMap.get(deviceId) ?? null;
   }
 
+  isCurrentSession(session: Session): boolean {
+    return this.sessions.get(session.sessionId) === session;
+  }
+
   /**
    * Release a session and free its device
    *
@@ -338,11 +347,12 @@ export class SessionManager {
     releaseReason: string = "explicit-release",
     allowExpired: boolean = false,
   ): Promise<string | null> {
-    // Match the promise to this particular session object, rather than only its
-    // UUID. A caller can create a new session with a reused UUID after the old
-    // release has removed it but before that release's persistence finishes.
     const session = allowExpired ? this.sessions.get(sessionId) ?? null : this.getSession(sessionId);
     if (!session) {
+      const inFlightRelease = this.releasePromises.get(sessionId);
+      if (inFlightRelease) {
+        return await inFlightRelease.promise;
+      }
       logger.warn(`Cannot release session ${sessionId}: not found`);
       return null;
     }
@@ -371,17 +381,28 @@ export class SessionManager {
    * Track setup that can modify device state after a session has been assigned.
    * Release waits for this work so restoration sees the final cached state.
    */
-  trackSessionSetup(session: Session, setupFactory: () => Promise<void>): Promise<void> {
+  trackSessionSetup(session: Session, createSetup: () => Promise<void>): Promise<void> {
     if (this.releasingSessions.has(session) || this.sessions.get(session.sessionId) !== session) {
       return Promise.resolve();
     }
 
-    const setup = setupFactory();
+    let resolveSetup!: () => void;
+    let rejectSetup!: (error: unknown) => void;
+    const setup = new Promise<void>((resolve, reject) => {
+      resolveSetup = resolve;
+      rejectSetup = reject;
+    });
     const tracked = { session, promise: setup };
     this.sessionSetupPromises.add(tracked);
+    try {
+      void createSetup().then(resolveSetup, rejectSetup);
+    } catch (error) {
+      logger.warn(`Session setup factory failed for ${session.sessionId}: ${error}`);
+      rejectSetup(error);
+    }
     void setup.then(
       () => this.clearSessionSetup(tracked),
-      () => this.clearSessionSetup(tracked)
+      () => this.clearSessionSetup(tracked),
     );
     return setup;
   }
@@ -406,64 +427,111 @@ export class SessionManager {
       }
     }
   }
+  getPendingDeviceCleanup(deviceId: string): Promise<void> | null {
+    return this.pendingDeviceCleanups.get(deviceId) ?? null;
+  }
 
   private async releaseSessionInternal(
     sessionId: string,
     session: Session,
     releaseReason: string,
   ): Promise<string | null> {
-    const setups = Array.from(this.sessionSetupPromises, setup => setup.session === session ? setup.promise : null)
-      .filter((setup): setup is Promise<void> => setup !== null);
-    if (setups.length > 0) {
-      const setupResults = await Promise.allSettled(setups);
-      for (const result of setupResults) {
-        if (result.status === "rejected") {
-          logger.warn(`Failed session setup for ${sessionId} before release: ${result.reason}`);
+    try {
+      const setups = Array.from(this.sessionSetupPromises, setup => setup.session === session ? setup.promise : null)
+        .filter((setup): setup is Promise<void> => setup !== null);
+      const pendingSetups = setups.length > 0
+        ? (await this.waitForSessionSetup(sessionId, setups)).pending
+        : null;
+      const pendingRestoration = (await this.restoreKeepScreenAwakeBestEffort(session)).pending;
+      const pendingCleanup = [pendingSetups, pendingRestoration]
+        .filter((cleanup): cleanup is Promise<void> => cleanup !== null);
+      const deviceId = session.assignedDevice;
+
+      if (!this.removeSession(sessionId, session)) {
+        if (pendingCleanup.length > 0) this.trackPendingDeviceCleanup(deviceId, pendingCleanup);
+        logger.warn(`Skipping release finalization for ${sessionId}: session ownership changed`);
+        return null;
+      }
+      if (pendingCleanup.length > 0) this.trackPendingDeviceCleanup(deviceId, pendingCleanup);
+
+      await this.deviceSessionRepository.markReleased(sessionId, "released", this.timer.now(), releaseReason);
+      for (const callback of this.releaseCallbacks) {
+        try {
+          callback(sessionId, deviceId);
+        } catch (error) {
+          logger.warn(`Session release callback failed for ${sessionId}: ${error}`);
         }
       }
+      logger.info(
+        pendingCleanup.length > 0
+          ? `Released session ${sessionId}; device ${deviceId} remains quarantined until teardown completes`
+          : `Released session ${sessionId}, freeing device ${deviceId}`,
+      );
+      return deviceId;
+    } finally {
+      this.releasingSessions.delete(session);
     }
-
-    try {
-      await this.restoreKeepScreenAwake(session);
-    } catch (error) {
-      // Releasing a session must still remove its device assignment and persist
-      // its terminal state when restoration fails. The restore is best-effort;
-      // retaining the session would leak the device and leave the durable row
-      // active during shutdown.
-      logger.warn(`Failed to restore keep-awake state for session ${sessionId}: ${error}`);
-    }
-
-    const deviceId = session.assignedDevice;
-    if (!this.removeSession(sessionId, session)) {
-      logger.warn(`Skipping release finalization for ${sessionId}: session ownership changed`);
-      return null;
-    }
-    // Intentionally NOT barrier-tracked: releaseSession is awaited by its caller
-    // (explicit release), so this write is caller-tied, not fire-and-forget. Only
-    // the lazy-expiry / cleanup-expired markReleased calls above are fire-and-forget
-    // and therefore barrier-tracked. The cleanup/disconnect timers are cleared before
-    // the shutdown drain (#2792/#2912), so awaited writes have small exposure. Do not
-    // wrap this in the DbWriteBarrier (#2885) — that would be a non-bug fix.
-    await this.deviceSessionRepository.markReleased(sessionId, "released", this.timer.now(), releaseReason);
-
-    // Notify release callbacks for centralized cleanup
-    for (const callback of this.releaseCallbacks) {
-      try {
-        callback(sessionId, deviceId);
-      } catch (error) {
-        logger.warn(`Session release callback failed for ${sessionId}: ${error}`);
-      }
-    }
-
-    logger.info(`Released session ${sessionId}, freeing device ${deviceId}`);
-
-    return deviceId;
   }
 
-  private clearSessionSetup(
-    tracked: { session: Session; promise: Promise<void> },
-  ): void {
+  private clearSessionSetup(tracked: { session: Session; promise: Promise<void> }): void {
     this.sessionSetupPromises.delete(tracked);
+  }
+
+  private async waitForSessionSetup(
+    sessionId: string,
+    setups: readonly Promise<void>[],
+  ): Promise<{ pending: Promise<void> | null }> {
+    let timeoutHandle: NodeJS.Timeout | undefined;
+    const settled = Promise.allSettled(setups);
+    const timeout = new Promise<"timed-out">(resolve => {
+      timeoutHandle = this.timer.setTimeout(() => resolve("timed-out"), SESSION_SETUP_DRAIN_TIMEOUT_MS);
+    });
+    try {
+      const result = await Promise.race([settled, timeout]);
+      if (result === "timed-out") {
+        logger.warn(`Timed out after ${SESSION_SETUP_DRAIN_TIMEOUT_MS}ms waiting for session ${sessionId} setup during release`);
+        return { pending: settled.then(() => undefined) };
+      }
+      for (const setup of result) {
+        if (setup.status === "rejected") logger.warn(`Failed session setup for ${sessionId} before release: ${setup.reason}`);
+      }
+      return { pending: null };
+    } finally {
+      if (timeoutHandle !== undefined) this.timer.clearTimeout(timeoutHandle);
+    }
+  }
+
+  private async restoreKeepScreenAwakeBestEffort(session: Session): Promise<{ pending: Promise<void> | null }> {
+    if (!session.cacheData.keepScreenAwake?.applied) return { pending: null };
+    let timeoutHandle: NodeJS.Timeout | undefined;
+    const restoration = this.restoreKeepScreenAwake(session).then(
+      () => ({ outcome: "restored" as const }),
+      error => ({ outcome: "failed" as const, error }),
+    );
+    const timeout = new Promise<{ outcome: "timed-out" }>(resolve => {
+      timeoutHandle = this.timer.setTimeout(() => resolve({ outcome: "timed-out" }), KEEP_SCREEN_AWAKE_RESTORE_TIMEOUT_MS);
+    });
+    try {
+      const result = await Promise.race([restoration, timeout]);
+      if (result.outcome === "failed") {
+        logger.warn(`Failed to restore keep-awake state for session ${session.sessionId}: ${result.error}`);
+      } else if (result.outcome === "timed-out") {
+        logger.warn(`Timed out after ${KEEP_SCREEN_AWAKE_RESTORE_TIMEOUT_MS}ms restoring keep-awake state for session ${session.sessionId}`);
+        return { pending: restoration.then(() => undefined) };
+      }
+      return { pending: null };
+    } finally {
+      if (timeoutHandle !== undefined) this.timer.clearTimeout(timeoutHandle);
+    }
+  }
+
+  private trackPendingDeviceCleanup(deviceId: string, cleanups: readonly Promise<void>[]): void {
+    const previous = this.pendingDeviceCleanups.get(deviceId);
+    const cleanup = Promise.allSettled(previous ? [previous, ...cleanups] : cleanups).then(() => undefined);
+    this.pendingDeviceCleanups.set(deviceId, cleanup);
+    void cleanup.then(() => {
+      if (this.pendingDeviceCleanups.get(deviceId) === cleanup) this.pendingDeviceCleanups.delete(deviceId);
+    });
   }
 
   /**

--- a/src/daemon/sessionManager.ts
+++ b/src/daemon/sessionManager.ts
@@ -118,7 +118,11 @@ export class SessionManager {
   private readonly sessionSetupPromises: Set<{ session: Session; promise: Promise<void> }> = new Set();
   /** Sessions whose teardown has closed admission for further device-state setup. */
   private readonly releasingSessions: WeakSet<Session> = new WeakSet();
-  /** Device work that outlived the bounded release phase. */
+  /**
+   * Device work that outlived its bounded release phase. The pool keeps the
+   * device assigned until this settles, so no replacement session can race a
+   * late setup or keep-awake restore.
+   */
   private readonly pendingDeviceCleanups: Map<string, Promise<void>> = new Map();
   private deviceSessionRepository: DeviceSessionRepository;
   private readonly getBarrier: () => DbWriteBarrier;
@@ -163,6 +167,11 @@ export class SessionManager {
    */
   onSessionRelease(callback: SessionReleaseCallback): void {
     this.releaseCallbacks.push(callback);
+  }
+
+  /** Return outstanding post-release device work, if the device must stay quarantined. */
+  getPendingDeviceCleanup(deviceId: string): Promise<void> | null {
+    return this.pendingDeviceCleanups.get(deviceId) ?? null;
   }
 
   /**
@@ -502,7 +511,9 @@ export class SessionManager {
   }
 
   private async restoreKeepScreenAwakeBestEffort(session: Session): Promise<{ pending: Promise<void> | null }> {
-    if (!session.cacheData.keepScreenAwake?.applied) return { pending: null };
+    if (!session.cacheData.keepScreenAwake?.applied) {
+      return { pending: null };
+    }
     let timeoutHandle: NodeJS.Timeout | undefined;
     const restoration = this.restoreKeepScreenAwake(session).then(
       () => ({ outcome: "restored" as const }),
@@ -516,7 +527,9 @@ export class SessionManager {
       if (result.outcome === "failed") {
         logger.warn(`Failed to restore keep-awake state for session ${session.sessionId}: ${result.error}`);
       } else if (result.outcome === "timed-out") {
-        logger.warn(`Timed out after ${KEEP_SCREEN_AWAKE_RESTORE_TIMEOUT_MS}ms restoring keep-awake state for session ${session.sessionId}`);
+        logger.warn(
+          `Timed out after ${KEEP_SCREEN_AWAKE_RESTORE_TIMEOUT_MS}ms restoring keep-awake state for session ${session.sessionId}`,
+        );
         return { pending: restoration.then(() => undefined) };
       }
       return { pending: null };
@@ -527,10 +540,13 @@ export class SessionManager {
 
   private trackPendingDeviceCleanup(deviceId: string, cleanups: readonly Promise<void>[]): void {
     const previous = this.pendingDeviceCleanups.get(deviceId);
-    const cleanup = Promise.allSettled(previous ? [previous, ...cleanups] : cleanups).then(() => undefined);
+    const cleanup = Promise.allSettled(previous ? [previous, ...cleanups] : cleanups)
+      .then(() => undefined);
     this.pendingDeviceCleanups.set(deviceId, cleanup);
     void cleanup.then(() => {
-      if (this.pendingDeviceCleanups.get(deviceId) === cleanup) this.pendingDeviceCleanups.delete(deviceId);
+      if (this.pendingDeviceCleanups.get(deviceId) === cleanup) {
+        this.pendingDeviceCleanups.delete(deviceId);
+      }
     });
   }
 

--- a/src/server/ToolExecutionContext.ts
+++ b/src/server/ToolExecutionContext.ts
@@ -89,24 +89,14 @@ export async function createToolExecutionContext(
     sessionOptions.platform
   );
 
+  if (!sessionManager.isCurrentSession(session)) {
+    throw new ActionableError(`Session ${sessionUuid} was released during setup`);
+  }
+
   await sessionManager.trackSessionSetup(
     session,
-    () => ensureKeepScreenAwake(session, sessionManager, sessionOptions),
+    () => setupSession(session, existingSession !== null, sessionManager, sessionOptions),
   );
-
-  if (!existingSession) {
-    if (session.platform === "android") {
-      await ensureAccessibilityServiceReady(session.assignedDevice, sessionUuid, session.platform);
-    }
-
-    // Start test coverage session for navigation graph tracking
-    // This enables automatic tracking of screens and transitions during test execution
-    const navManager = NavigationGraphManager.getInstanceForSession(sessionUuid);
-    if (navManager.getCurrentAppId()) {
-      await navManager.startTestSession(sessionUuid);
-      logger.info(`[ToolExecutionContext] Started test coverage tracking for session ${sessionUuid}`);
-    }
-  }
 
   return {
     sessionId: sessionUuid,
@@ -115,6 +105,40 @@ export async function createToolExecutionContext(
     sessionManager,
     devicePool,
   };
+}
+
+async function setupSession(
+  session: Session,
+  existingSession: boolean,
+  sessionManager: SessionManager,
+  sessionOptions: SessionOptions,
+): Promise<void> {
+  await ensureKeepScreenAwake(session, sessionManager, sessionOptions);
+  if (existingSession) {
+    return;
+  }
+
+  ensureSessionIsCurrent(session, sessionManager);
+  if (session.platform === "android") {
+    await ensureAccessibilityServiceReady(session.assignedDevice, session.sessionId, session.platform);
+  }
+  ensureSessionIsCurrent(session, sessionManager);
+
+  // Start test coverage session for navigation graph tracking
+  // This enables automatic tracking of screens and transitions during test execution
+  const navManager = NavigationGraphManager.getInstanceForSession(session.sessionId);
+  if (navManager.getCurrentAppId()) {
+    ensureSessionIsCurrent(session, sessionManager);
+    await navManager.startTestSession(session.sessionId);
+    ensureSessionIsCurrent(session, sessionManager);
+    logger.info(`[ToolExecutionContext] Started test coverage tracking for session ${session.sessionId}`);
+  }
+}
+
+function ensureSessionIsCurrent(session: Session, sessionManager: SessionManager): void {
+  if (!sessionManager.isCurrentSession(session)) {
+    throw new ActionableError(`Session ${session.sessionId} was released during setup`);
+  }
 }
 
 const A11Y_TRANSIENT_ERROR_PATTERNS = [
@@ -218,6 +242,17 @@ async function ensureKeepScreenAwake(
   } catch (error) {
     logger.warn(`[ToolExecutionContext] Failed to apply keep-awake for ${device.deviceId}: ${error}`);
     state = { applied: false, skipReason: "failed" };
+  }
+
+  if (!sessionManager.isCurrentSession(session)) {
+    if (state.applied) {
+      try {
+        await manager.restore(state);
+      } catch (error) {
+        logger.warn(`[ToolExecutionContext] Failed to restore keep-awake after session release for ${device.deviceId}: ${error}`);
+      }
+    }
+    throw new ActionableError(`Session ${session.sessionId} was released during setup`);
   }
 
   sessionManager.setKeepScreenAwake(session.sessionId, state);

--- a/src/server/ToolExecutionContext.ts
+++ b/src/server/ToolExecutionContext.ts
@@ -95,7 +95,7 @@ export async function createToolExecutionContext(
 
   await sessionManager.trackSessionSetup(
     session,
-    () => setupSession(session, existingSession !== null, sessionManager, sessionOptions),
+    () => setupSession(session, existingSession === session, sessionManager, sessionOptions),
   );
 
   return {

--- a/test/daemon/daemonShutdownSessionRelease.test.ts
+++ b/test/daemon/daemonShutdownSessionRelease.test.ts
@@ -157,7 +157,7 @@ describe("Daemon shutdown session release (issue #5303)", () => {
     }
   });
 
-  test("releases the session when keep-awake restoration fails", async () => {
+  test("continues releasing remaining sessions when restoration fails", async () => {
     const timer = new FakeTimer();
     const repository = new FakeDeviceSessionRepository();
     const daemon = new Daemon(
@@ -168,26 +168,33 @@ describe("Daemon shutdown session release (issue #5303)", () => {
     );
     const sessionManager = daemon.getSessionManager();
     const devicePool = daemon.getDevicePool();
-    const sessionId = "restore-failure-shutdown-session";
-    const deviceId = "restore-failure-device";
+    const brokenSessionId = "broken-shutdown-session";
+    const healthySessionId = "healthy-shutdown-session";
     const restoreSpy = spyOn(KeepScreenAwakeManager.prototype, "restore")
-      .mockRejectedValue(new Error("simulated restore failure"));
+      .mockRejectedValueOnce(new Error("simulated restore failure"))
+      .mockResolvedValue(undefined);
     const loggerCloseSpy = spyOn(logger, "closeAfterFlush").mockResolvedValue(undefined);
 
     try {
-      await devicePool.initializeWithDevices([{
-        name: "Restore Failure Android",
-        deviceId,
-        platform: "android",
-      }]);
-      await devicePool.assignDeviceToSession(sessionId, "android");
-      sessionManager.setKeepScreenAwake(sessionId, { applied: true, method: "svc", svcWasEnabled: false });
+      await devicePool.initializeWithDevices([
+        { name: "Broken Android", deviceId: "broken-device", platform: "android" },
+        { name: "Healthy Android", deviceId: "healthy-device", platform: "android" },
+      ]);
+      await devicePool.assignDeviceToSession(brokenSessionId, "android");
+      await devicePool.assignDeviceToSession(healthySessionId, "android");
+      sessionManager.setKeepScreenAwake(brokenSessionId, { applied: true, method: "svc", svcWasEnabled: false });
+      sessionManager.setKeepScreenAwake(healthySessionId, { applied: true, method: "svc", svcWasEnabled: false });
 
       await expect(daemon.stop()).resolves.toBeUndefined();
 
-      expect(sessionManager.getSession(sessionId)).toBeNull();
-      expect(devicePool.getDevice(deviceId)).toMatchObject({ sessionId: null, status: "idle" });
-      expect(repository.sessions.get(sessionId)).toMatchObject({
+      expect(restoreSpy).toHaveBeenCalledTimes(2);
+      expect(sessionManager.getSession(brokenSessionId)).toBeNull();
+      expect(sessionManager.getSession(healthySessionId)).toBeNull();
+      expect(repository.sessions.get(brokenSessionId)).toMatchObject({
+        status: "released",
+        reason: "daemon-shutdown",
+      });
+      expect(repository.sessions.get(healthySessionId)).toMatchObject({
         status: "released",
         reason: "daemon-shutdown",
       });
@@ -197,7 +204,53 @@ describe("Daemon shutdown session release (issue #5303)", () => {
     }
   });
 
-  test("releases sessions that expired after cleanup stopped", async () => {
+  test("drains a monitor release that removed its session before shutdown snapshots it", async () => {
+    const timer = new FakeTimer();
+    const repository = new FakeDeviceSessionRepository();
+    const daemon = new Daemon(
+      {},
+      new FakeInstalledAppsRepository(),
+      timer,
+      repository as unknown as DeviceSessionRepository,
+    );
+    const sessionManager = daemon.getSessionManager();
+    let allowPersistence!: () => void;
+    const persistence = new Promise<void>(resolve => { allowPersistence = resolve; });
+    let persistenceStarted!: () => void;
+    const persistenceStartedPromise = new Promise<void>(resolve => { persistenceStarted = resolve; });
+    const originalMarkReleased = repository.markReleased.bind(repository);
+    const markReleasedSpy = spyOn(repository, "markReleased")
+      .mockImplementation(async (...args) => {
+        persistenceStarted();
+        await persistence;
+        await originalMarkReleased(...args);
+      });
+    const closeDatabaseSpy = spyOn(databaseModule, "closeDatabase").mockImplementation(async () => {
+      repository.events.push("closeDatabase");
+    });
+    const loggerCloseSpy = spyOn(logger, "closeAfterFlush").mockResolvedValue(undefined);
+
+    try {
+      await sessionManager.createSession("in-flight-session", "in-flight-device", "android");
+      const release = sessionManager.releaseSession("in-flight-session", "heartbeat");
+      await persistenceStartedPromise;
+
+      const stop = daemon.stop();
+      await Promise.resolve();
+      expect(closeDatabaseSpy).not.toHaveBeenCalled();
+
+      allowPersistence();
+      await release;
+      await stop;
+      expect(repository.events).toEqual(["markReleased", "closeDatabase"]);
+    } finally {
+      markReleasedSpy.mockRestore();
+      closeDatabaseSpy.mockRestore();
+      loggerCloseSpy.mockRestore();
+    }
+  });
+
+  test("releases expired sessions that remain in memory during shutdown", async () => {
     const timer = new FakeTimer();
     const repository = new FakeDeviceSessionRepository();
     const daemon = new Daemon(

--- a/test/daemon/sessionManager.test.ts
+++ b/test/daemon/sessionManager.test.ts
@@ -445,29 +445,32 @@ describe("SessionManager", () => {
       try {
         await manager.createSession("s1", "device-1", "android");
         manager.setKeepScreenAwake("s1", { applied: true, method: "svc", svcWasEnabled: false });
-        const release = manager.releaseSession("s1", "heartbeat");
-        const drained = manager.drainReleasePromises(1_000);
-
+        const release = manager.releaseSession("s1", "daemon-shutdown");
+        await Promise.resolve();
+        const drain = manager.drainReleasePromises(1_000);
         fakeTimer.advanceTime(1_000);
-        await expect(drained).resolves.toBe(false);
+        await expect(drain).resolves.toBe(false);
 
         finishRestore();
-        await release;
+        await expect(release).resolves.toBe("device-1");
       } finally {
         manager.stopCleanupTimer();
       }
     });
 
-    test("does not coalesce a replacement session with the same UUID", async () => {
-      const releases: string[] = [];
+    test("waits for an old session's terminal write before recreating its UUID", async () => {
       let finishFirstPersistence!: () => void;
       const firstPersistence = new Promise<void>(resolve => { finishFirstPersistence = resolve; });
+      let firstPersistenceStarted!: () => void;
+      const firstPersistenceStartedPromise = new Promise<void>(resolve => { firstPersistenceStarted = resolve; });
+      const releases: string[] = [];
       const repository = {
         async upsertActiveSession(): Promise<void> {},
         async recordActivity(): Promise<void> {},
         async markReleased(_sessionId: string, _status: string, _releasedAt: number, reason: string): Promise<void> {
           releases.push(reason);
           if (reason === "first") {
+            firstPersistenceStarted();
             await firstPersistence;
           }
         },
@@ -477,15 +480,74 @@ describe("SessionManager", () => {
       try {
         await manager.createSession("s1", "device-1", "android");
         const first = manager.releaseSession("s1", "first");
-        await Promise.resolve();
+        await firstPersistenceStartedPromise;
+        const replacement = manager.createSession("s1", "device-2", "android");
 
-        await manager.createSession("s1", "device-2", "android");
-        await expect(manager.releaseSession("s1", "second")).resolves.toBe("device-2");
+        expect(manager.getSession("s1")).toBeNull();
         finishFirstPersistence();
         await expect(first).resolves.toBe("device-1");
-
+        await expect(replacement).resolves.toMatchObject({ assignedDevice: "device-2" });
+        await expect(manager.releaseSession("s1", "second")).resolves.toBe("device-2");
         expect(releases).toEqual(["first", "second"]);
+      } finally {
+        manager.stopCleanupTimer();
+      }
+    });
+
+    test("persists terminal state when keep-awake restoration times out", async () => {
+      const released: string[] = [];
+      const manager = new SessionManager(
+        fakeTimer,
+        {
+          async upsertActiveSession(): Promise<void> {},
+          async recordActivity(): Promise<void> {},
+          async markReleased(sessionId: string): Promise<void> { released.push(sessionId); },
+          async markStaleActiveSessionsExpired(): Promise<void> {},
+        },
+        () => new FakeDbWriteBarrier(),
+        () => ({ restore: async () => await new Promise<void>(() => {}) }),
+      );
+      try {
+        await manager.createSession("s1", "device-1", "android");
+        manager.setKeepScreenAwake("s1", { applied: true, method: "svc", svcWasEnabled: false });
+        const release = manager.releaseSession("s1", "daemon-shutdown");
+        await Promise.resolve();
+        fakeTimer.advanceTime(1_000);
+        await expect(release).resolves.toBe("device-1");
+
         expect(manager.getSession("s1")).toBeNull();
+        expect(released).toEqual(["s1"]);
+      } finally {
+        manager.stopCleanupTimer();
+      }
+    });
+
+    test("coalesces a failed in-flight release into terminal cleanup", async () => {
+      let rejectRestore!: (error: Error) => void;
+      const restore = new Promise<void>((_resolve, reject) => { rejectRestore = reject; });
+      const released: string[] = [];
+      const manager = new SessionManager(
+        fakeTimer,
+        {
+          async upsertActiveSession(): Promise<void> {},
+          async recordActivity(): Promise<void> {},
+          async markReleased(sessionId: string): Promise<void> { released.push(sessionId); },
+          async markStaleActiveSessionsExpired(): Promise<void> {},
+        },
+        () => new FakeDbWriteBarrier(),
+        () => ({ restore: async () => await restore }),
+      );
+      try {
+        await manager.createSession("s1", "device-1", "android");
+        manager.setKeepScreenAwake("s1", { applied: true, method: "svc", svcWasEnabled: false });
+
+        const first = manager.releaseSession("s1", "heartbeat");
+        const joined = manager.releaseSession("s1", "daemon-shutdown", true);
+        rejectRestore(new Error("restore failed"));
+
+        await expect(Promise.all([first, joined])).resolves.toEqual(["device-1", "device-1"]);
+        expect(manager.getSession("s1")).toBeNull();
+        expect(released).toEqual(["s1"]);
       } finally {
         manager.stopCleanupTimer();
       }

--- a/test/daemon/sessionManager.test.ts
+++ b/test/daemon/sessionManager.test.ts
@@ -486,7 +486,7 @@ describe("SessionManager", () => {
         await firstPersistenceStartedPromise;
         const replacement = manager.createSession("s1", "device-2", "android");
 
-        expect(manager.getSession("s1")).toBeNull();
+        expect(manager.getSession("s1")).toMatchObject({ assignedDevice: "device-2" });
         finishFirstPersistence();
         await expect(first).resolves.toBe("device-1");
         await expect(replacement).resolves.toMatchObject({ assignedDevice: "device-2" });
@@ -563,15 +563,23 @@ describe("SessionManager", () => {
         await Promise.resolve();
         await Promise.resolve();
         const deviceId = await release;
-        await pool.releaseDevice(deviceId!);
+        await pool.releaseDevice(deviceId!, "s1");
 
         expect(pool.getDevice("device-1")).toMatchObject({ sessionId: "s1", status: "busy" });
+
+        // A same-serial replacement must not be released by the old deferred callback.
+        const oldDevice = pool.getDevice("device-1")!;
+        oldDevice.sessionId = null;
+        oldDevice.status = "idle";
+        await pool.removeDevice("device-1");
+        await pool.initializeWithDevices([{ name: "device-1", deviceId: "device-1", platform: "android" }]);
+        await pool.assignDeviceToSession("s2", "android");
 
         finishRestore();
         for (let attempt = 0; attempt < 10 && pool.getDevice("device-1")?.status !== "idle"; attempt++) {
           await new Promise<void>(resolve => setImmediate(resolve));
         }
-        expect(pool.getDevice("device-1")).toMatchObject({ sessionId: null, status: "idle" });
+        expect(pool.getDevice("device-1")).toMatchObject({ sessionId: "s2", status: "busy" });
       } finally {
         manager.stopCleanupTimer();
       }

--- a/test/daemon/sessionManager.test.ts
+++ b/test/daemon/sessionManager.test.ts
@@ -4,8 +4,11 @@ import {
   type KeepScreenAwakeRestorer,
   type SessionDeviceAssigner,
 } from "../../src/daemon/sessionManager";
+import { DevicePool } from "../../src/daemon/devicePool";
 import { FakeTimer } from "../fakes/FakeTimer";
 import { FakeDbWriteBarrier } from "../fakes/FakeDbWriteBarrier";
+import { FakeInstalledAppsRepository } from "../fakes/FakeInstalledAppsRepository";
+import { FakeDeviceManager } from "../fakes/FakeDeviceManager";
 import type { ViewHierarchyResult } from "../../src/models/ViewHierarchyResult";
 import type { KeepScreenAwakeState } from "../../src/utils/KeepScreenAwakeManager";
 
@@ -517,6 +520,58 @@ describe("SessionManager", () => {
 
         expect(manager.getSession("s1")).toBeNull();
         expect(released).toEqual(["s1"]);
+      } finally {
+        manager.stopCleanupTimer();
+      }
+    });
+
+    test("keeps a device quarantined until timed-out keep-awake restoration completes", async () => {
+      let finishRestore!: () => void;
+      const restoration = new Promise<void>(resolve => { finishRestore = resolve; });
+      let restoreStarted!: () => void;
+      const restorationStarted = new Promise<void>(resolve => { restoreStarted = resolve; });
+      const manager = new SessionManager(
+        fakeTimer,
+        {
+          async upsertActiveSession(): Promise<void> {},
+          async recordActivity(): Promise<void> {},
+          async markReleased(): Promise<void> {},
+          async markStaleActiveSessionsExpired(): Promise<void> {},
+        },
+        () => new FakeDbWriteBarrier(),
+        () => ({ restore: async () => {
+          restoreStarted();
+          await restoration;
+        } }),
+      );
+      const pool = new DevicePool(
+        manager,
+        "test-daemon",
+        fakeTimer,
+        new FakeInstalledAppsRepository(),
+        new FakeDeviceManager(),
+      );
+      try {
+        await pool.initializeWithDevices([{ name: "device-1", deviceId: "device-1", platform: "android" }]);
+        await pool.assignDeviceToSession("s1", "android");
+        manager.setKeepScreenAwake("s1", { applied: true, method: "svc", svcWasEnabled: false });
+
+        const release = manager.releaseSession("s1", "daemon-shutdown");
+        await restorationStarted;
+        await Promise.resolve();
+        fakeTimer.advanceTime(1_000);
+        await Promise.resolve();
+        await Promise.resolve();
+        const deviceId = await release;
+        await pool.releaseDevice(deviceId!);
+
+        expect(pool.getDevice("device-1")).toMatchObject({ sessionId: "s1", status: "busy" });
+
+        finishRestore();
+        for (let attempt = 0; attempt < 10 && pool.getDevice("device-1")?.status !== "idle"; attempt++) {
+          await new Promise<void>(resolve => setImmediate(resolve));
+        }
+        expect(pool.getDevice("device-1")).toMatchObject({ sessionId: null, status: "idle" });
       } finally {
         manager.stopCleanupTimer();
       }

--- a/test/server/ToolExecutionContext.test.ts
+++ b/test/server/ToolExecutionContext.test.ts
@@ -138,6 +138,43 @@ describe("ToolExecutionContext", () => {
     expect(setupCalls).toBe(0);
   });
 
+  test("runs first-session setup when a released UUID is recreated during context creation", async () => {
+    let setupCalls = 0;
+    AndroidCtrlProxyManager.getInstance = () =>
+      ({
+        resetSetupState: () => {},
+        setup: async () => {
+          setupCalls += 1;
+          return { success: true, message: "ok" };
+        },
+      } as any);
+    AndroidCtrlProxyClient.getInstance = (() => ({
+      waitForConnection: async () => true,
+      close: async () => {},
+    })) as any;
+
+    const original = await sessionManager.createSession("session-recreated", "device-1", "android");
+    let finishSetup!: () => void;
+    const setup = sessionManager.trackSessionSetup(
+      original,
+      () => new Promise<void>(resolve => { finishSetup = resolve; }),
+    );
+    const release = sessionManager.releaseSession("session-recreated");
+    await Promise.resolve();
+    const context = createToolExecutionContext(
+      "session-recreated",
+      sessionManager,
+      devicePool,
+      sessionOptions,
+    );
+    finishSetup();
+    await setup;
+    await release;
+
+    await expect(context).resolves.toMatchObject({ deviceId: "device-1" });
+    expect(setupCalls).toBe(1);
+  });
+
   test("does not apply keep-awake after a session is released during setup", async () => {
     let allowActivityWrite!: () => void;
     const activityWrite = new Promise<void>(resolve => { allowActivityWrite = resolve; });
@@ -177,6 +214,21 @@ describe("ToolExecutionContext", () => {
   });
 
   test("bounds accessibility setup and rejects it after the session releases", async () => {
+    const boundedTimer = new FakeTimer();
+    const boundedSessionManager = new SessionManager(boundedTimer, {
+      async upsertActiveSession(): Promise<void> {},
+      async recordActivity(): Promise<void> {},
+      async markReleased(): Promise<void> {},
+      async markStaleActiveSessionsExpired(): Promise<void> {},
+    });
+    const boundedPool = new DevicePool(
+      boundedSessionManager,
+      "test-daemon-session-id",
+      boundedTimer,
+      fakeAppsRepo,
+      new FakeDeviceManager(),
+    );
+    await boundedPool.initializeWithDevices([createBootedDevice("device-1")]);
     let finishSetup!: () => void;
     const setupFinished = new Promise<void>(resolve => { finishSetup = resolve; });
     let setupStarted!: () => void;
@@ -195,16 +247,38 @@ describe("ToolExecutionContext", () => {
       close: async () => {},
     })) as any;
 
-    const context = createToolExecutionContext("session-setup-race", sessionManager, devicePool, sessionOptions);
-    await setupStartedPromise;
-    void sessionManager.releaseSession("session-setup-race");
-    await Promise.resolve();
-    fakeTimer.advanceTime(1_000);
-    await fakeTimer.sleep(0);
+    try {
+      const context = createToolExecutionContext("session-setup-race", boundedSessionManager, boundedPool, sessionOptions);
+      await setupStartedPromise;
+      const release = boundedSessionManager.releaseSession("session-setup-race");
+      for (let attempt = 0; attempt < 10 && !boundedTimer.getPendingTimeouts().includes(1_000); attempt++) {
+        await Promise.resolve();
+      }
+      expect(boundedTimer.getPendingTimeouts()).toContain(1_000);
+      boundedTimer.advanceTime(1_000);
+      let releasedDevice: string | null | undefined;
+      void release.then(deviceId => { releasedDevice = deviceId; });
+      for (let attempt = 0; attempt < 10 && releasedDevice === undefined; attempt++) {
+        await new Promise<void>(resolve => setImmediate(resolve));
+      }
+      expect(releasedDevice).toBe("device-1");
+      await boundedPool.releaseDevice("device-1");
 
-    expect(sessionManager.getSession("session-setup-race")).toBeNull();
+      expect(boundedSessionManager.getSession("session-setup-race")).toBeNull();
+      expect(boundedPool.getDevice("device-1")).toMatchObject({
+        sessionId: "session-setup-race",
+        status: "busy",
+      });
 
-    finishSetup();
-    await expect(context).rejects.toThrow("released during setup");
+      finishSetup();
+      await expect(context).rejects.toThrow("released during setup");
+      await Promise.resolve();
+      expect(boundedPool.getDevice("device-1")).toMatchObject({
+        sessionId: null,
+        status: "idle",
+      });
+    } finally {
+      boundedSessionManager.stopCleanupTimer();
+    }
   });
 });

--- a/test/server/ToolExecutionContext.test.ts
+++ b/test/server/ToolExecutionContext.test.ts
@@ -262,7 +262,7 @@ describe("ToolExecutionContext", () => {
         await new Promise<void>(resolve => setImmediate(resolve));
       }
       expect(releasedDevice).toBe("device-1");
-      await boundedPool.releaseDevice("device-1");
+      await boundedPool.releaseDevice("device-1", "session-setup-race");
 
       expect(boundedSessionManager.getSession("session-setup-race")).toBeNull();
       expect(boundedPool.getDevice("device-1")).toMatchObject({

--- a/test/server/ToolExecutionContext.test.ts
+++ b/test/server/ToolExecutionContext.test.ts
@@ -1,9 +1,10 @@
-import { afterEach, beforeEach, describe, expect, test } from "bun:test";
+import { afterEach, beforeEach, describe, expect, spyOn, test } from "bun:test";
 import { SessionManager } from "../../src/daemon/sessionManager";
 import { DevicePool } from "../../src/daemon/devicePool";
 import { createToolExecutionContext } from "../../src/server/ToolExecutionContext";
 import { AndroidCtrlProxyManager } from "../../src/utils/CtrlProxyManager";
 import { AndroidCtrlProxyClient } from "../../src/features/observe/android";
+import { KeepScreenAwakeManager } from "../../src/utils/KeepScreenAwakeManager";
 import { FakeInstalledAppsRepository } from "../fakes/FakeInstalledAppsRepository";
 import { FakeTimer } from "../fakes/FakeTimer";
 import { FakeDeviceManager } from "../fakes/FakeDeviceManager";
@@ -135,5 +136,75 @@ describe("ToolExecutionContext", () => {
 
     expect(context.deviceId).toBe("device-1");
     expect(setupCalls).toBe(0);
+  });
+
+  test("does not apply keep-awake after a session is released during setup", async () => {
+    let allowActivityWrite!: () => void;
+    const activityWrite = new Promise<void>(resolve => { allowActivityWrite = resolve; });
+    let activityStarted!: () => void;
+    const activityStartedPromise = new Promise<void>(resolve => { activityStarted = resolve; });
+    const repository = {
+      async upsertActiveSession(): Promise<void> {},
+      async recordActivity(): Promise<void> {
+        activityStarted();
+        await activityWrite;
+      },
+      async markReleased(): Promise<void> {},
+      async markStaleActiveSessionsExpired(): Promise<void> {},
+    };
+    const manager = new SessionManager(fakeTimer, repository);
+    const pool = new DevicePool(manager, "test-daemon-session-id", fakeTimer, fakeAppsRepo, new FakeDeviceManager());
+    const applySpy = spyOn(KeepScreenAwakeManager.prototype, "apply").mockResolvedValue({
+      applied: false,
+      skipReason: "disabled",
+    });
+
+    try {
+      await pool.initializeWithDevices([createBootedDevice("device-race")]);
+      await manager.createSession("session-race", "device-race", "android");
+
+      const context = createToolExecutionContext("session-race", manager, pool, sessionOptions);
+      await activityStartedPromise;
+      await manager.releaseSession("session-race");
+      allowActivityWrite();
+
+      await expect(context).rejects.toThrow("released during setup");
+      expect(applySpy).not.toHaveBeenCalled();
+    } finally {
+      applySpy.mockRestore();
+      manager.stopCleanupTimer();
+    }
+  });
+
+  test("bounds accessibility setup and rejects it after the session releases", async () => {
+    let finishSetup!: () => void;
+    const setupFinished = new Promise<void>(resolve => { finishSetup = resolve; });
+    let setupStarted!: () => void;
+    const setupStartedPromise = new Promise<void>(resolve => { setupStarted = resolve; });
+    AndroidCtrlProxyManager.getInstance = () =>
+      ({
+        resetSetupState: () => {},
+        setup: async () => {
+          setupStarted();
+          await setupFinished;
+          return { success: true, message: "ok" };
+        },
+      } as any);
+    AndroidCtrlProxyClient.getInstance = (() => ({
+      waitForConnection: async () => true,
+      close: async () => {},
+    })) as any;
+
+    const context = createToolExecutionContext("session-setup-race", sessionManager, devicePool, sessionOptions);
+    await setupStartedPromise;
+    void sessionManager.releaseSession("session-setup-race");
+    await Promise.resolve();
+    fakeTimer.advanceTime(1_000);
+    await fakeTimer.sleep(0);
+
+    expect(sessionManager.getSession("session-setup-race")).toBeNull();
+
+    finishSetup();
+    await expect(context).rejects.toThrow("released during setup");
   });
 });


### PR DESCRIPTION
## Summary

Closes [#5346](https://github.com/kaeawc/auto-mobile/issues/5346), a follow-up to [#5303](https://github.com/kaeawc/auto-mobile/issues/5303) after [#5327](https://github.com/kaeawc/auto-mobile/pull/5327) merged.

- Bound keep-awake restoration and setup waiting inside the canonical release path, then persist the terminal session state before shutdown can close the database.
- Drain releases that began before shutdown’s session snapshot, and prevent same-UUID recreation until the prior release’s terminal write completes.
- Close setup admission at teardown start; setup now registers before it can mutate a device and rechecks session identity after asynchronous work.

## Root cause

The prior shutdown timeout raced the caller rather than the restore/setup operation. A release could therefore continue after shutdown closed the database, while a late setup could still mutate device state after the session was removed.

## Validation

- `bun run turbo:validate` — 13,244 passed; 13 skipped; 0 failed
- Focused session and shutdown regressions — 55 passed
- `bun run lint`
- `bun run typecheck`
