### PR TITLE
fix(daemon): guard stale session device releases

### DIFF
--- a/src/daemon/daemon.ts
+++ b/src/daemon/daemon.ts
@@ -1415,7 +1415,7 @@ export class Daemon {
     const cancelled = await executionTracker.cancelSessionUuidExecutions(sessionId, releaseReason);
     const deviceId = await this.sessionManager.releaseSession(sessionId, releaseReason, allowExpired);
     if (deviceId) {
-      await this.devicePool.releaseDevice(deviceId);
+      await this.devicePool.releaseDevice(deviceId, sessionId);
     }
     logger.info(
       `Cancelled session ${sessionId} (${cancelled} executions) and released device ${deviceId ?? "unknown"} ` +

--- a/src/daemon/daemonRequestHandlers.ts
+++ b/src/daemon/daemonRequestHandlers.ts
@@ -26,7 +26,7 @@ export interface DaemonStateAccess {
   getDevicePool(): {
     refreshDevices(): Promise<number>;
     getStats(): DevicePoolStats;
-    releaseDevice(deviceId: string): Promise<void>;
+    releaseDevice(deviceId: string, expectedSessionId: string): Promise<void>;
     getAllDevices?(): PooledDevice[];
     getRecoveryPolicy?(): DeviceRecoveryPolicy;
     getRecoveryEligibility?(deviceId: string): DeviceRecoveryEligibility;
@@ -191,7 +191,7 @@ export async function handleDaemonRequest(
       }
       const deviceId = session.assignedDevice;
       await manager.releaseSession(sessionId);
-      await pool.releaseDevice(deviceId);
+      await pool.releaseDevice(deviceId, sessionId);
       return {
         success: true,
         result: {

--- a/src/daemon/devicePool.ts
+++ b/src/daemon/devicePool.ts
@@ -799,8 +799,8 @@ export class DevicePool {
 
     if (!result.success) {
       // Release any devices we've assigned so far
-      for (const deviceId of assignments.values()) {
-        await this.releaseDevice(deviceId);
+      for (const [sessionId, deviceId] of assignments) {
+        await this.releaseDevice(deviceId, sessionId);
       }
 
       // Check if it was a non-retryable error
@@ -909,8 +909,8 @@ export class DevicePool {
       const elapsed = this.timer.now() - startTime;
 
       if (elapsed > timeoutMs) {
-        for (const deviceId of assignments.values()) {
-          await this.releaseDevice(deviceId);
+        for (const [sessionId, deviceId] of assignments) {
+          await this.releaseDevice(deviceId, sessionId);
         }
         throw new ActionableError(
           `Timed out allocating devices after ${Math.round(elapsed / 1000)}s (${attemptCount} attempts).\n` +
@@ -939,15 +939,15 @@ export class DevicePool {
               `(${assignments.size}/${requiredCount})`,
           );
         } else if (result.livenessUnknown) {
-          for (const deviceId of assignments.values()) {
-            await this.releaseDevice(deviceId);
+          for (const [sessionId, deviceId] of assignments) {
+            await this.releaseDevice(deviceId, sessionId);
           }
           throw new ActionableError(
             `Unable to verify iOS simulator liveness for session ${request.sessionId}; iOS discovery failed.`,
           );
         } else if (!result.shouldWait) {
-          for (const deviceId of assignments.values()) {
-            await this.releaseDevice(deviceId);
+          for (const [sessionId, deviceId] of assignments) {
+            await this.releaseDevice(deviceId, sessionId);
           }
           const summary = this.criteriaMatcher.formatCriteriaSummary(request.criteria);
           throw new ActionableError(
@@ -1986,7 +1986,7 @@ export class DevicePool {
    * Called when a session completes or times out.
    * Frees the device so it can be assigned to other sessions.
    */
-  async releaseDevice(deviceId: string): Promise<void> {
+  async releaseDevice(deviceId: string, expectedSessionId: string): Promise<void> {
     const device = this.devices.get(deviceId);
     if (!device) {
       logger.warn(`Cannot release device ${deviceId}: not in pool`);
@@ -1995,6 +1995,13 @@ export class DevicePool {
 
     if (!device.sessionId) {
       logger.debug(`Device ${deviceId} is already idle`);
+      return;
+    }
+
+    if (device.sessionId !== expectedSessionId) {
+      logger.debug(
+        `Ignoring stale release for device ${deviceId}: expected ${expectedSessionId}, owned by ${device.sessionId}`,
+      );
       return;
     }
 

--- a/src/daemon/manager.ts
+++ b/src/daemon/manager.ts
@@ -1506,7 +1506,7 @@ export async function runDaemonCommand(
           }
           const deviceId = session.assignedDevice;
           sessionManager.releaseSession(sessionId);
-          pool.releaseDevice(deviceId);
+          pool.releaseDevice(deviceId, sessionId);
           console.log(`Session ${sessionId} released`);
           console.log(`Device ${deviceId} is now available`);
         } else {

--- a/src/server/deviceLabelMapping.ts
+++ b/src/server/deviceLabelMapping.ts
@@ -118,7 +118,7 @@ export const releaseDeviceLabelSessions = async (baseSessionUuid: string): Promi
     // possibly reassigned — otherwise hierarchy/nav broadcasts during the release get
     // recorded under the ended session's uuid. Mirrors the base-session path (#4984).
     await sessionManager.releaseSession(sessionUuid);
-    await devicePool.releaseDevice(deviceId);
+    await devicePool.releaseDevice(deviceId, sessionUuid);
     released.push(sessionUuid);
   }
 

--- a/src/server/toolRegistry.ts
+++ b/src/server/toolRegistry.ts
@@ -825,7 +825,7 @@ export class DefaultPlanLifecycleManager implements PlanLifecycleManager {
           // detector cleanup) complete — and any rejection is caught by this try —
           // before the device is freed (#4984).
           await sessionManager.releaseSession(session.sessionId);
-          await devicePool.releaseDevice(deviceId);
+          await devicePool.releaseDevice(deviceId, session.sessionId);
           NavigationGraphManager.releaseSession(releaseSessionUuid);
           // CtrlProxy client binding + detector cleanup for the released session is
           // handled centrally in the daemon's onSessionRelease hook (#4984), which

--- a/src/server/utilityTools.ts
+++ b/src/server/utilityTools.ts
@@ -148,7 +148,7 @@ export function registerUtilityTools() {
         const existing = sessionManager.getSession(args.sessionUuid);
         if (existing && existing.assignedDevice !== args.deviceId) {
           await sessionManager.releaseSession(existing.sessionId);
-          await devicePool.releaseDevice(existing.assignedDevice);
+          await devicePool.releaseDevice(existing.assignedDevice, existing.sessionId);
         }
         if (!existing || existing.assignedDevice !== args.deviceId) {
           const boundSession = await devicePool.bindOrReuseDeviceSession(args.sessionUuid, args.deviceId, args.platform);

--- a/test/daemon/SessionHeartbeatMonitor.test.ts
+++ b/test/daemon/SessionHeartbeatMonitor.test.ts
@@ -248,7 +248,7 @@ describe("SessionHeartbeatMonitor", () => {
     const reapVia = (mgr: SessionManager, devicePool: DevicePool) => async (sid: string): Promise<void> => {
       const deviceId = await mgr.releaseSession(sid);
       if (deviceId) {
-        await devicePool.releaseDevice(deviceId);
+        await devicePool.releaseDevice(deviceId, sid);
       }
     };
 

--- a/test/daemon/daemonRequestHandlers.test.ts
+++ b/test/daemon/daemonRequestHandlers.test.ts
@@ -13,7 +13,7 @@ import { FakeIdGenerator } from "../fakes/FakeIdGenerator";
 class FakeDevicePool {
   stats: DevicePoolStats;
   refreshedCount = 0;
-  releasedDevices: string[] = [];
+  releasedDevices: Array<{ deviceId: string; expectedSessionId: string }> = [];
   addedDevices: number;
   recoveryPolicy: DeviceRecoveryPolicy = { onLoss: false, maxAttempts: 2 };
   devices: PooledDevice[] = [];
@@ -32,8 +32,8 @@ class FakeDevicePool {
     return this.stats;
   }
 
-  async releaseDevice(deviceId: string): Promise<void> {
-    this.releasedDevices.push(deviceId);
+  async releaseDevice(deviceId: string, expectedSessionId: string): Promise<void> {
+    this.releasedDevices.push({ deviceId, expectedSessionId });
   }
 
   getRecoveryPolicy(): DeviceRecoveryPolicy {
@@ -233,7 +233,7 @@ describe("handleDaemonRequest", () => {
       device: deviceId,
       alreadyReleased: false,
     });
-    expect(devicePool.releasedDevices).toEqual([deviceId]);
+    expect(devicePool.releasedDevices).toEqual([{ deviceId, expectedSessionId: sessionId }]);
     expect(sessionManager.getSession(sessionId)).toBeNull();
   });
 

--- a/test/daemon/daemonShutdownSessionRelease.test.ts
+++ b/test/daemon/daemonShutdownSessionRelease.test.ts
@@ -96,7 +96,7 @@ describe("Daemon shutdown session release (issue #5303)", () => {
 
       expect(restoreSpy).toHaveBeenCalledWith(keepAwakeState);
       expect(releasedCallbacks).toContainEqual({ sessionId, deviceId });
-      expect(releaseDeviceSpy).toHaveBeenCalledWith(deviceId);
+      expect(releaseDeviceSpy).toHaveBeenCalledWith(deviceId, sessionId);
       expect(sessionManager.getSession(sessionId)).toBeNull();
       expect(devicePool.getDevice(deviceId)).toMatchObject({
         sessionId: null,

--- a/test/daemon/devicePool.autolock.test.ts
+++ b/test/daemon/devicePool.autolock.test.ts
@@ -130,7 +130,7 @@ describe("DevicePool autolock", () => {
     fakeDeviceUtils.markDeviceAsStopped("Medium_Phone_API_35");
     fakeDeviceUtils.markDeviceAsStopped("emulator-5554");
     await pool.removeDisconnectedDevice("emulator-5554");
-    await pool.releaseDevice("emulator-5554");
+    await pool.releaseDevice("emulator-5554", "active-session");
     await pool.removeDevice("emulator-5554");
 
     const assignments = await pool.assignMultipleDevices(["next-session"], 1000, "android");

--- a/test/daemon/devicePool.test.ts
+++ b/test/daemon/devicePool.test.ts
@@ -1323,7 +1323,7 @@ describe("DevicePool", () => {
       }
 
       // Release the device
-      await devicePool.releaseDevice(device1);
+      await devicePool.releaseDevice(device1, "session-1");
 
       // Advance time to allow the retry
       fakeTimer.advanceTime(1000);
@@ -1346,7 +1346,7 @@ describe("DevicePool", () => {
     test("should reuse device after session release", async () => {
       await initializeLiveDevices([createBootedDevice("emulator-5554")]);
       const device1 = await devicePool.assignDeviceToSession("session-1");
-      await devicePool.releaseDevice(device1);
+      await devicePool.releaseDevice(device1, "session-1");
       const device2 = await devicePool.assignDeviceToSession("session-2");
       expect(device1).toBe(device2);
     });
@@ -1363,7 +1363,7 @@ describe("DevicePool", () => {
 
       const firstDevice = await devicePool.assignDeviceToSession("session-1", "ios");
       expect(firstDevice).toBe("sim-old");
-      await devicePool.releaseDevice(firstDevice);
+      await devicePool.releaseDevice(firstDevice, "session-1");
       fakeDeviceManager.bootedDevices = [createBootedDevice("sim-new", "ios", "iPhone 16")];
 
       const secondDevice = await devicePool.assignDeviceToSession("session-2", "ios");
@@ -1832,7 +1832,7 @@ describe("DevicePool", () => {
         );
 
         await devicePool.assignMultipleDevices(["session-1"], 1000, "android");
-        await devicePool.releaseDevice("emulator-5554");
+        await devicePool.releaseDevice("emulator-5554", "session-1");
         manager.bootedDevices = [];
         await devicePool.removeDisconnectedDevice("emulator-5554");
         await devicePool.assignMultipleDevices(["session-2"], 1000, "android");
@@ -2181,7 +2181,7 @@ describe("DevicePool", () => {
       );
       try {
         await devicePool.assignMultipleDevices(["session-1"], 1_000, "android");
-        await devicePool.releaseDevice("emulator-5554");
+        await devicePool.releaseDevice("emulator-5554", "session-1");
 
         const recovery = devicePool.removeDisconnectedDevice("emulator-5554", false);
         await manager.waitForRecoveryStart();
@@ -2229,7 +2229,7 @@ describe("DevicePool", () => {
       );
       try {
         await devicePool.assignMultipleDevices(["session-1"], 1_000, "android");
-        await devicePool.releaseDevice("emulator-5554");
+        await devicePool.releaseDevice("emulator-5554", "session-1");
 
         const recovery = devicePool.removeDisconnectedDevice("emulator-5554", false);
         await manager.waitForRecoveryStart();
@@ -2274,7 +2274,7 @@ describe("DevicePool", () => {
       );
       try {
         await devicePool.assignMultipleDevices(["session-1"], 1_000, "android");
-        await devicePool.releaseDevice("emulator-5554");
+        await devicePool.releaseDevice("emulator-5554", "session-1");
 
         const recovery = devicePool.removeDisconnectedDevice("emulator-5554", false);
         await manager.waitForRecoveryStart();
@@ -2318,7 +2318,7 @@ describe("DevicePool", () => {
       );
       try {
         await devicePool.assignMultipleDevices(["session-1"], 1_000, "android");
-        await devicePool.releaseDevice("emulator-5554");
+        await devicePool.releaseDevice("emulator-5554", "session-1");
         manager.bootedDevices = [];
 
         await devicePool.removeDisconnectedDevice("emulator-5554", false);
@@ -2361,7 +2361,7 @@ describe("DevicePool", () => {
       );
       try {
         await devicePool.assignMultipleDevices(["session-1"], 1_000, "android");
-        await devicePool.releaseDevice("emulator-5554");
+        await devicePool.releaseDevice("emulator-5554", "session-1");
         manager.bootedDevices = [];
         await devicePool.removeDisconnectedDevice("emulator-5554", false);
 
@@ -2420,7 +2420,7 @@ describe("DevicePool", () => {
       );
       try {
         await devicePool.assignMultipleDevices(["session-1"], 1_000, "android");
-        await devicePool.releaseDevice("emulator-5554");
+        await devicePool.releaseDevice("emulator-5554", "session-1");
         manager.bootedDevices = [];
         await devicePool.removeDisconnectedDevice("emulator-5554", false);
 
@@ -3044,9 +3044,9 @@ describe("DevicePool", () => {
       await devicePool.bindOrReuseDeviceSession("seed-b", "dev-b", "android");
       await devicePool.bindOrReuseDeviceSession("seed-a", "dev-a", "android");
 
-      await devicePool.releaseDevice("dev-a");
-      await devicePool.releaseDevice("dev-b");
-      await devicePool.releaseDevice("dev-c");
+      await devicePool.releaseDevice("dev-a", "seed-a");
+      await devicePool.releaseDevice("dev-b", "seed-b");
+      await devicePool.releaseDevice("dev-c", "seed-c");
 
       // Re-bind dev-c so it is busy (and remains the lastReleasedDeviceId,
       // which should be ignored because it is no longer idle). Idle pool is
@@ -3072,24 +3072,39 @@ describe("DevicePool", () => {
     test("should release device assigned to session", async () => {
       await initializeLiveDevices([createBootedDevice("emulator-5554")]);
       const deviceId = await devicePool.assignDeviceToSession("session-1");
-      await devicePool.releaseDevice(deviceId);
+      await devicePool.releaseDevice(deviceId, "session-1");
       const device = devicePool.getDevice(deviceId);
       expect(device?.sessionId).toBeNull();
       expect(device?.status).toBe("idle");
       expect(devicePool.getAvailableDeviceCount()).toBe(1);
     });
 
-    test("should handle release of already idle device", async () => {
-      await devicePool.initializeWithDevices([createBootedDevice("emulator-5554")]);
+    test("keeps repeated release idempotent", async () => {
+      await initializeLiveDevices([createBootedDevice("emulator-5554")]);
+      await devicePool.assignDeviceToSession("session-1");
+      await devicePool.releaseDevice("emulator-5554", "session-1");
+      await devicePool.releaseDevice("emulator-5554", "session-1");
       const device = devicePool.getDevice("emulator-5554");
-      expect(device?.status).toBe("idle");
-      await devicePool.releaseDevice("emulator-5554");
       expect(device?.status).toBe("idle");
     });
 
     test("should handle release of non-existent device", async () => {
-      await devicePool.releaseDevice("non-existent");
+      await devicePool.releaseDevice("non-existent", "session-1");
       expect(devicePool.getTotalDeviceCount()).toBe(0);
+    });
+
+    test("does not release a replacement session after a duplicate stale release", async () => {
+      await initializeLiveDevices([createBootedDevice("emulator-5554")]);
+      const deviceId = await devicePool.assignDeviceToSession("session-s");
+
+      await devicePool.releaseDevice(deviceId, "session-s");
+      await devicePool.assignDeviceToSession("session-t");
+      await devicePool.releaseDevice(deviceId, "session-s");
+
+      const device = devicePool.getDevice(deviceId);
+      expect(device?.sessionId).toBe("session-t");
+      expect(device?.status).toBe("busy");
+      expect(devicePool.getAvailableDeviceCount()).toBe(0);
     });
   });
 
@@ -3118,7 +3133,7 @@ describe("DevicePool", () => {
       await initializeLiveDevices([createBootedDevice("emulator-5554")]);
       devicePool.recordDeviceError("emulator-5554");
       expect(devicePool.getDevice("emulator-5554")?.errorCount).toBe(1);
-      await devicePool.releaseDevice("emulator-5554");
+      await devicePool.releaseDevice("emulator-5554", "session-1");
       await devicePool.assignDeviceToSession("session-1");
       expect(devicePool.getDevice("emulator-5554")?.errorCount).toBe(0);
     });

--- a/test/daemon/integration/parallelExecution.test.ts
+++ b/test/daemon/integration/parallelExecution.test.ts
@@ -116,7 +116,7 @@ describe("Parallel Execution Across Multiple Devices", function() {
       const device1 = await devicePool.assignDeviceToSession(session1Id);
 
       // Release first session
-      await devicePool.releaseDevice(device1);
+      await devicePool.releaseDevice(device1, session1Id);
 
       const deviceIds = ["device-1", "device-2", "device-3"];
       const releasedDevice = devicePool.getDevice(device1);
@@ -157,9 +157,9 @@ describe("Parallel Execution Across Multiple Devices", function() {
         expect(devicePool.getAvailableDeviceCount()).toBe(0);
 
         // Release all devices
-        await devicePool.releaseDevice(device1);
-        await devicePool.releaseDevice(device2);
-        await devicePool.releaseDevice(device3);
+        await devicePool.releaseDevice(device1, session1Id);
+        await devicePool.releaseDevice(device2, session2Id);
+        await devicePool.releaseDevice(device3, session3Id);
 
         // Verify all devices are back to idle
         expect(devicePool.getAvailableDeviceCount()).toBe(3);
@@ -232,7 +232,7 @@ describe("Parallel Execution Across Multiple Devices", function() {
       expect(device3).toBe(assignedDevice);
 
       // Release and verify device is removed
-      await devicePool.releaseDevice(assignedDevice);
+      await devicePool.releaseDevice(assignedDevice, sessionId);
       const device4 = devicePool.getDeviceForSession(sessionId);
       expect(device4).toBeNull();
     });
@@ -268,8 +268,8 @@ describe("Parallel Execution Across Multiple Devices", function() {
       }
 
       // Release all in parallel
-      const releasePromises = assignedDevices.map(deviceId =>
-        devicePool.releaseDevice(deviceId)
+      const releasePromises = assignedDevices.map((deviceId, index) =>
+        devicePool.releaseDevice(deviceId, sessionIds[index]!)
       );
 
       await Promise.all(releasePromises);


### PR DESCRIPTION
## Summary

Require every device-pool release to identify its expected session owner. A release whose device has since been reassigned is ignored, preserving both the replacement owner and repeated-release idempotency. The expected owner now flows through daemon, server, CLI, heartbeat, and allocation-rollback release paths.

## Linked Issue

Closes [#5290](https://github.com/kaeawc/auto-mobile/issues/5290)

## Bug / Regression Context

- **Prior attempts:** None.
- **Observed symptom:** A duplicate release cleared a device after it had been assigned to a replacement session.
- **Repro steps / conditions:** Release session S, assign the device to T, then deliver a delayed duplicate release for S.

## Validation

- [x] 181 focused tests covering device release, shutdown release, plan routing, and lint rules
- [x] `bun run typecheck` reports no new errors (baseline gate)
- [ ] `bun run turbo:validate` could not complete in this shared environment: two attempts stalled in unrelated tests that pass alone (`planExecutorSessionRouting` and `additionalRules`); CI remains required
- [x] Android/iOS changes: not applicable
- [x] New code uses existing interfaces, fakes, and FakeTimer-backed tests
- [x] No new generic helper or direct dependency
- [x] Rebased onto latest `main`, conflicts resolved
