### PR TITLE
fix: harden device reconnect replacement

### DIFF
--- a/src/daemon/devicePool.ts
+++ b/src/daemon/devicePool.ts
@@ -1391,11 +1391,12 @@ export class DevicePool {
     }
 
     if (bootedDevice) {
-      return !(await this.replaceIdlePooledDeviceForLivenessCheck(
+      const replaced = await this.replaceIdlePooledDeviceForLivenessCheck(
         device,
         bootedDevice,
         assignmentLockHeld,
-      ));
+      );
+      return !replaced && this.devices.get(device.id) === device;
     }
 
     if (deferRecovery && this.shouldRebootDisconnectedAndroidDevice(device)) {

--- a/src/daemon/devicePool.ts
+++ b/src/daemon/devicePool.ts
@@ -521,8 +521,14 @@ export class DevicePool {
     pooledDevice: PooledDevice,
     bootedDevice: BootedDevice,
   ): Promise<boolean> {
-    const sourceImage = pooledDevice.androidImage;
-    const startedProcess = this.startedDeviceProcesses.get(pooledDevice.id);
+    const preserveAutoMobileOwnership = this.hasTransportOnlyIdentityChange(
+      pooledDevice,
+      bootedDevice,
+    );
+    const sourceImage = preserveAutoMobileOwnership ? pooledDevice.androidImage : undefined;
+    const startedProcess = preserveAutoMobileOwnership
+      ? this.startedDeviceProcesses.get(pooledDevice.id)
+      : undefined;
     await this.evictMissingPooledDevice(
       pooledDevice,
       `runtime identity changed to ${bootedDevice.platform}:${bootedDevice.name}`,
@@ -1363,6 +1369,7 @@ export class DevicePool {
   private async ensurePooledDevicePresentForUse(
     device: PooledDevice,
     deferRecovery: boolean = false,
+    assignmentLockHeld: boolean = false,
   ): Promise<boolean> {
     if (!this.shouldValidatePooledDevicePresence(device)) {
       return true;
@@ -1384,8 +1391,11 @@ export class DevicePool {
     }
 
     if (bootedDevice) {
-      await this.replacePooledDeviceForRuntimeIdentity(device, bootedDevice);
-      return false;
+      return !(await this.replaceIdlePooledDeviceForLivenessCheck(
+        device,
+        bootedDevice,
+        assignmentLockHeld,
+      ));
     }
 
     if (deferRecovery && this.shouldRebootDisconnectedAndroidDevice(device)) {
@@ -1400,6 +1410,26 @@ export class DevicePool {
     }
     await this.evictMissingPooledDevice(device, "not present in adb devices", true);
     return false;
+  }
+
+  private async replaceIdlePooledDeviceForLivenessCheck(
+    device: PooledDevice,
+    bootedDevice: BootedDevice,
+    assignmentLockHeld: boolean,
+  ): Promise<boolean> {
+    const replaceIfStillIdle = async () => {
+      if (
+        this.devices.get(device.id) !== device ||
+        device.status !== "idle" ||
+        device.sessionId !== null
+      ) {
+        return false;
+      }
+      return await this.replacePooledDeviceForRuntimeIdentity(device, bootedDevice);
+    };
+    return assignmentLockHeld
+      ? await replaceIfStillIdle()
+      : await this.assignmentMutex.runExclusive(replaceIfStillIdle);
   }
 
   private async evictMissingPooledDevice(
@@ -1990,7 +2020,7 @@ export class DevicePool {
     while (device) {
       const skippedDeviceId = device.id;
       if (this.shouldValidatePooledDevicePresence(device)) {
-        if (await this.ensurePooledDevicePresentForUse(device, true)) {
+        if (await this.ensurePooledDevicePresentForUse(device, true, true)) {
           return { device, livenessUnknown };
         }
         candidates = candidates.filter((candidate) => candidate.id !== skippedDeviceId);
@@ -2557,7 +2587,7 @@ export class DevicePool {
         }
       }
 
-      const device = this.devices.get(deviceId);
+      let device = this.devices.get(deviceId);
       if (!device) {
         throw new ActionableError(`Device '${deviceId}' is not available in the device pool.`);
       }
@@ -2586,12 +2616,12 @@ export class DevicePool {
         `Device '${deviceId}' is not available in the device pool.`,
       );
 
-      if (!(await this.ensurePooledDevicePresentForUse(device))) {
-        throw new ActionableError(
-          `Device '${deviceId}' is not available in the device pool. ` +
-            "It may have been shut down or disconnected.",
-        );
-      }
+      device = await this.validateOrReloadIdlePooledDevice(
+        device,
+        expectedIdentity,
+        `Device '${deviceId}' is not available in the device pool. ` +
+          "It may have been shut down or disconnected.",
+      );
 
       if (device.sessionId) {
         const existingSession = this.sessionManager.getSession(device.sessionId);
@@ -2635,6 +2665,23 @@ export class DevicePool {
       logger.info(`Bound device ${deviceId} to session ${sessionId}`);
       return sessionId;
     });
+  }
+
+  private async validateOrReloadIdlePooledDevice(
+    device: PooledDevice,
+    expectedIdentity: Pick<BootedDevice, "deviceId" | "name" | "platform"> | undefined,
+    unavailableMessage: string,
+  ): Promise<PooledDevice> {
+    if (await this.ensurePooledDevicePresentForUse(device, false, true)) {
+      return device;
+    }
+    const replacement = this.devices.get(device.id);
+    if (!replacement) {
+      throw new ActionableError(unavailableMessage);
+    }
+    this.assertRuntimeIdentity(replacement, expectedIdentity);
+    await this.assertIdleDeviceAssignable(replacement, unavailableMessage);
+    return replacement;
   }
 
   private createSessionForBinding(

--- a/src/daemon/devicePool.ts
+++ b/src/daemon/devicePool.ts
@@ -2761,21 +2761,25 @@ export class DevicePool {
     return (
       pooled.id === expected.deviceId &&
       pooled.platform === expected.platform &&
-      this.hasSameOrUnknownEmulatorName(pooled.name, expected.name, pooled.id) &&
+      this.hasSameOrUnknownEmulatorName(pooled, expected) &&
       !this.matchesRuntimeIdentity(pooled, expected)
     );
   }
 
   private hasSameOrUnknownEmulatorName(
-    pooledName: string,
-    expectedName: string,
-    deviceId: string,
+    pooled: PooledDevice,
+    expected: Pick<BootedDevice, "deviceId" | "name">,
   ): boolean {
-    const unknownName = `Unknown (${deviceId})`;
+    if (pooled.name === expected.name) {
+      return true;
+    }
+    if (!pooled.id.startsWith("emulator-")) {
+      return false;
+    }
+    const unknownName = `Unknown (${pooled.id})`;
     return (
-      pooledName === expectedName ||
-      (deviceId.startsWith("emulator-") &&
-        (pooledName === unknownName || expectedName === unknownName))
+      expected.name === unknownName ||
+      (pooled.name === unknownName && pooled.avdName === expected.name)
     );
   }
 

--- a/src/daemon/devicePool.ts
+++ b/src/daemon/devicePool.ts
@@ -2759,9 +2759,22 @@ export class DevicePool {
   ): boolean {
     return (
       pooled.id === expected.deviceId &&
-      pooled.name === expected.name &&
       pooled.platform === expected.platform &&
+      this.hasSameOrUnknownEmulatorName(pooled.name, expected.name, pooled.id) &&
       !this.matchesRuntimeIdentity(pooled, expected)
+    );
+  }
+
+  private hasSameOrUnknownEmulatorName(
+    pooledName: string,
+    expectedName: string,
+    deviceId: string,
+  ): boolean {
+    const unknownName = `Unknown (${deviceId})`;
+    return (
+      pooledName === expectedName ||
+      (deviceId.startsWith("emulator-") &&
+        (pooledName === unknownName || expectedName === unknownName))
     );
   }
 
@@ -2821,7 +2834,7 @@ export class DevicePool {
     }
 
     // Assign the device to the generated session
-    const device = this.devices.get(deviceId);
+    let device = this.devices.get(deviceId);
     if (!device) {
       throw new ActionableError(
         `Device '${deviceId}' is not available for autolock.\n` +
@@ -2858,16 +2871,16 @@ export class DevicePool {
         `The device may have been shut down or disconnected.`,
     );
 
-    if (!(await this.ensurePooledDevicePresentForUse(device))) {
-      throw new ActionableError(
-        `Device '${deviceId}' is not available for autolock.\n` +
-          `The device may have been shut down or disconnected.\n\n` +
-          `Options:\n` +
-          `  - Use 'startDevice' with the same criteria to boot a new device\n` +
-          `  - Use 'startDevice' with deviceId to restart this specific device\n` +
-          `  - Use 'listDevices' to see currently available devices`,
-      );
-    }
+    device = await this.validateOrReloadIdlePooledDevice(
+      device,
+      expectedIdentity,
+      `Device '${deviceId}' is not available for autolock.\n` +
+        `The device may have been shut down or disconnected.\n\n` +
+        `Options:\n` +
+        `  - Use 'startDevice' with the same criteria to boot a new device\n` +
+        `  - Use 'startDevice' with deviceId to restart this specific device\n` +
+        `  - Use 'listDevices' to see currently available devices`,
+    );
 
     const assignmentSnapshot = this.snapshotSessionAssignment(device);
     device.sessionId = sessionId;

--- a/test/daemon/devicePool.test.ts
+++ b/test/daemon/devicePool.test.ts
@@ -1361,6 +1361,42 @@ describe("DevicePool", () => {
       });
     });
 
+    test("does not transfer ownership from an unknown-name emulator to a different known AVD", async () => {
+      const sourceImage: DeviceInfo = {
+        name: "Pixel 8",
+        platform: "android",
+        isRunning: false,
+        source: "local",
+      };
+      const firstConnection = {
+        ...createBootedDevice("emulator-5554", "android", "Pixel 8"),
+        transportId: "1",
+      };
+      const rediscoveredWithUnknownName = {
+        ...firstConnection,
+        name: "Unknown (emulator-5554)",
+        transportId: "2",
+      };
+      const differentAvd = {
+        ...firstConnection,
+        name: "Pixel 9",
+        transportId: "3",
+      };
+      await devicePool.addDevice(firstConnection, sourceImage);
+      fakeDeviceManager.bootedDevices = [rediscoveredWithUnknownName];
+      await devicePool.refreshDevices();
+      fakeDeviceManager.bootedDevices = [differentAvd];
+
+      await devicePool.refreshDevices();
+
+      expect(devicePool.getDevice(differentAvd.deviceId)).toMatchObject({
+        name: "Pixel 9",
+        transportId: "3",
+      });
+      expect(devicePool.getDevice(differentAvd.deviceId)?.androidImage).toBeUndefined();
+      expect(devicePool.getDevice(differentAvd.deviceId)?.avdName).toBeUndefined();
+    });
+
     test("rekeys a transport-only mismatch before reserving startDevice readiness", async () => {
       const firstConnection = {
         ...createBootedDevice("emulator-5554", "android", "Pixel 8"),

--- a/test/daemon/devicePool.test.ts
+++ b/test/daemon/devicePool.test.ts
@@ -2254,6 +2254,41 @@ describe("DevicePool", () => {
       }
     });
 
+    test("assigns the current replacement after liveness discovery supersedes a captured device", async () => {
+      const firstConnection = {
+        ...createBootedDevice("emulator-5554", "android", "Pixel 8"),
+        transportId: "1",
+      };
+      const reconnected = { ...firstConnection, transportId: "2" };
+      const manager = new DeferredReconnectionDiscoveryFakeDeviceManager(
+        [reconnected],
+        [reconnected],
+      );
+      devicePool = new DevicePool(
+        sessionManager,
+        "test-daemon-session-id",
+        fakeTimer,
+        fakeAppsRepo,
+        manager,
+        new DefaultRetryExecutor(fakeTimer),
+      );
+      await devicePool.addDevice(firstConnection);
+
+      const assignment = devicePool.assignDeviceToSession("session-1", "android");
+      await manager.waitForDiscoveryStart();
+      await devicePool.removeDevice(firstConnection.deviceId);
+      await devicePool.addDevice(reconnected);
+
+      manager.releaseDiscovery();
+
+      await expect(assignment).resolves.toBe(reconnected.deviceId);
+      expect(devicePool.getDevice(reconnected.deviceId)).toMatchObject({
+        transportId: "2",
+        sessionId: "session-1",
+        status: "busy",
+      });
+    });
+
     test("rejects a changed runtime identity inside the assignment mutex", async () => {
       await devicePool.initializeWithDevices([
         createBootedDevice("emulator-5554", "android", "Old Pixel"),

--- a/test/daemon/devicePool.test.ts
+++ b/test/daemon/devicePool.test.ts
@@ -219,6 +219,53 @@ describe("DevicePool", () => {
     }
   }
 
+  class DeferredReconnectionDiscoveryFakeDeviceManager extends FakeDeviceManager {
+    private readonly discoveryStartedPromise: Promise<void>;
+    private readonly discoveryReleasePromise: Promise<void>;
+    private resolveDiscoveryStarted!: () => void;
+    private resolveDiscoveryRelease!: () => void;
+    private discoveryCount = 0;
+
+    constructor(
+      private readonly delayedSnapshot: BootedDevice[],
+      private readonly concurrentSnapshot: BootedDevice[],
+    ) {
+      super();
+      this.discoveryStartedPromise = new Promise((resolve) => {
+        this.resolveDiscoveryStarted = resolve;
+      });
+      this.discoveryReleasePromise = new Promise((resolve) => {
+        this.resolveDiscoveryRelease = resolve;
+      });
+    }
+
+    override async getBootedDevicesDetailed(platform: SomePlatform) {
+      this.discoveryCount++;
+      if (this.discoveryCount === 1) {
+        this.resolveDiscoveryStarted();
+        await this.discoveryReleasePromise;
+        return this.discoveryFor(this.delayedSnapshot, platform);
+      }
+      return this.discoveryFor(this.concurrentSnapshot, platform);
+    }
+
+    async waitForDiscoveryStart(): Promise<void> {
+      await this.discoveryStartedPromise;
+    }
+
+    releaseDiscovery(): void {
+      this.resolveDiscoveryRelease();
+    }
+
+    private discoveryFor(devices: BootedDevice[], platform: SomePlatform) {
+      const platforms: Platform[] = platform === "either" ? ["android", "ios"] : [platform];
+      return {
+        devices: devices.filter((device) => platforms.includes(device.platform)),
+        succeededPlatforms: new Set(platforms),
+      };
+    }
+  }
+
   class ThrowingDiscoveryFakeDeviceManager extends FakeDeviceManager {
     override async getBootedDevicesDetailed(): Promise<never> {
       throw new Error("adb discovery crashed");
@@ -1256,6 +1303,35 @@ describe("DevicePool", () => {
       });
     });
 
+    test("does not transfer AutoMobile-owned metadata to a different AVD with the same serial", async () => {
+      const sourceImage: DeviceInfo = {
+        name: "Pixel 8",
+        platform: "android",
+        isRunning: false,
+        source: "local",
+      };
+      const firstConnection = {
+        ...createBootedDevice("emulator-5554", "android", "Pixel 8"),
+        transportId: "1",
+      };
+      const replacement = {
+        ...firstConnection,
+        name: "Pixel 9",
+        transportId: "2",
+      };
+      await devicePool.addDevice(firstConnection, sourceImage);
+      fakeDeviceManager.bootedDevices = [replacement];
+
+      await devicePool.refreshDevices();
+
+      expect(devicePool.getDevice(replacement.deviceId)).toMatchObject({
+        name: "Pixel 9",
+        transportId: "2",
+      });
+      expect(devicePool.getDevice(replacement.deviceId)?.androidImage).toBeUndefined();
+      expect(devicePool.getDevice(replacement.deviceId)?.avdName).toBeUndefined();
+    });
+
     test("rekeys a transport-only mismatch before reserving startDevice readiness", async () => {
       const firstConnection = {
         ...createBootedDevice("emulator-5554", "android", "Pixel 8"),
@@ -2099,6 +2175,27 @@ describe("DevicePool", () => {
       expect(sessionManager.getSession("session-1")?.assignedDevice).toBe("emulator-new");
     });
 
+    test("binds a same-serial transport reconnect without requiring a retry", async () => {
+      const firstConnection = {
+        ...createBootedDevice("emulator-5554", "android", "Pixel 8"),
+        transportId: "1",
+      };
+      const reconnected = { ...firstConnection, transportId: "2" };
+      await initializeLiveDevices([firstConnection]);
+      fakeDeviceManager.bootedDevices = [reconnected];
+
+      await expect(
+        devicePool.bindOrReuseDeviceSession("session-1", reconnected.deviceId, "android"),
+      ).resolves.toBe("session-1");
+
+      expect(devicePool.getDevice(reconnected.deviceId)).toMatchObject({
+        transportId: "2",
+        sessionId: "session-1",
+        status: "busy",
+      });
+      expect(sessionManager.getSession("session-1")?.assignedDevice).toBe(reconnected.deviceId);
+    });
+
     test("rejects a changed runtime identity inside the assignment mutex", async () => {
       await devicePool.initializeWithDevices([
         createBootedDevice("emulator-5554", "android", "Old Pixel"),
@@ -2201,6 +2298,49 @@ describe("DevicePool", () => {
   });
 
   describe("assignMultipleDevices", () => {
+    test("does not evict a session claimed while preflight reconnect discovery is pending", async () => {
+      const firstConnection = {
+        ...createBootedDevice("emulator-5554", "android", "Pixel 8"),
+        transportId: "1",
+      };
+      const reconnected = { ...firstConnection, transportId: "2" };
+      const deferredDeviceManager = new DeferredReconnectionDiscoveryFakeDeviceManager(
+        [reconnected],
+        [firstConnection],
+      );
+      fakeDeviceManager = deferredDeviceManager;
+      devicePool = new DevicePool(
+        sessionManager,
+        "test-daemon-session-id",
+        fakeTimer,
+        fakeAppsRepo,
+        fakeDeviceManager,
+        new DefaultRetryExecutor(fakeTimer),
+      );
+      await initializeLiveDevices([firstConnection]);
+
+      const preflightAllocation = devicePool.assignMultipleDevices(
+        ["preflight-session"],
+        1000,
+        "android",
+      );
+      await deferredDeviceManager.waitForDiscoveryStart();
+
+      await devicePool.assignDeviceToSession("concurrent-session", "android");
+      await devicePool.addDevice(createBootedDevice("R5CT654321", "android", "Pixel 9"));
+      deferredDeviceManager.releaseDiscovery();
+      await preflightAllocation;
+
+      expect(sessionManager.getSession("concurrent-session")?.assignedDevice).toBe(
+        firstConnection.deviceId,
+      );
+      expect(devicePool.getDevice(firstConnection.deviceId)).toMatchObject({
+        sessionId: "concurrent-session",
+        status: "busy",
+        transportId: "1",
+      });
+    });
+
     test("rolls back sessions and devices when platform allocation loses iOS liveness after a partial assignment", async () => {
       await initializeLiveDevices([
         createBootedDevice("sim-1", "ios", "iPhone 15"),

--- a/test/daemon/devicePool.test.ts
+++ b/test/daemon/devicePool.test.ts
@@ -1332,6 +1332,35 @@ describe("DevicePool", () => {
       expect(devicePool.getDevice(replacement.deviceId)?.avdName).toBeUndefined();
     });
 
+    test("keeps AutoMobile-owned metadata when emulator name discovery is unknown", async () => {
+      const sourceImage: DeviceInfo = {
+        name: "Pixel 8",
+        platform: "android",
+        isRunning: false,
+        source: "local",
+      };
+      const firstConnection = {
+        ...createBootedDevice("emulator-5554", "android", "Pixel 8"),
+        transportId: "1",
+      };
+      const rediscoveredWithUnknownName = {
+        ...firstConnection,
+        name: "Unknown (emulator-5554)",
+        transportId: "2",
+      };
+      await devicePool.addDevice(firstConnection, sourceImage);
+      fakeDeviceManager.bootedDevices = [rediscoveredWithUnknownName];
+
+      await devicePool.refreshDevices();
+
+      expect(devicePool.getDevice(firstConnection.deviceId)).toMatchObject({
+        name: "Unknown (emulator-5554)",
+        transportId: "2",
+        androidImage: sourceImage,
+        avdName: "Pixel 8",
+      });
+    });
+
     test("rekeys a transport-only mismatch before reserving startDevice readiness", async () => {
       const firstConnection = {
         ...createBootedDevice("emulator-5554", "android", "Pixel 8"),
@@ -2194,6 +2223,35 @@ describe("DevicePool", () => {
         status: "busy",
       });
       expect(sessionManager.getSession("session-1")?.assignedDevice).toBe(reconnected.deviceId);
+    });
+
+    test("autolocks a same-serial transport reconnect without reacquiring the assignment mutex", async () => {
+      const originalAutolock = process.env.AUTOMOBILE_DEVICE_POOL_AUTOLOCK;
+      const firstConnection = {
+        ...createBootedDevice("emulator-5554", "android", "Pixel 8"),
+        transportId: "1",
+      };
+      const reconnected = { ...firstConnection, transportId: "2" };
+      try {
+        process.env.AUTOMOBILE_DEVICE_POOL_AUTOLOCK = "1";
+        await initializeLiveDevices([firstConnection]);
+        fakeDeviceManager.bootedDevices = [reconnected];
+
+        await expect(
+          devicePool.autolockDevice(reconnected.deviceId, "android", "mcp-session-1"),
+        ).resolves.toBeDefined();
+
+        expect(devicePool.getDevice(reconnected.deviceId)).toMatchObject({
+          transportId: "2",
+          status: "busy",
+        });
+      } finally {
+        if (originalAutolock === undefined) {
+          delete process.env.AUTOMOBILE_DEVICE_POOL_AUTOLOCK;
+        } else {
+          process.env.AUTOMOBILE_DEVICE_POOL_AUTOLOCK = originalAutolock;
+        }
+      }
     });
 
     test("rejects a changed runtime identity inside the assignment mutex", async () => {


### PR DESCRIPTION
## Summary

Follow-up to [#5340](https://github.com/kaeawc/auto-mobile/pull/5340)'s reconnect review feedback.

- Reload a transport-rekeyed pooled device within the original `startDevice` binding request, so it does not require a retry.
- Serialize liveness-driven replacement with pool assignment and recheck that the captured device is still idle before replacing it.
- Preserve AutoMobile-owned AVD and process metadata only when the runtime change is transport-only, never when a different AVD reuses a serial.

## Root cause

The first reconnect implementation correctly detected changed ADB transports, but direct binding treated a just-replaced entry as absent. Its unlocked preflight discovery could also apply an older snapshot to a device that had become session-owned. Finally, replacement transferred ownership metadata across an AVD identity change.

## Validation

- `bun test test/daemon/devicePool.test.ts --bail` (117 pass)
- `bun run lint`
- `bun run typecheck`
- `bun run turbo:validate` (13,296 pass, 13 skipped, 0 failures)
