### PR TITLE
fix(daemon): retain plan sessions through label setup

### DIFF
--- a/src/daemon/daemon.ts
+++ b/src/daemon/daemon.ts
@@ -1240,7 +1240,9 @@ export class Daemon {
 
   private hasActiveSessionExecution(sessionId: string, query?: ActiveSessionExecutionQuery): boolean {
     const executionSessionId = resolveCapabilityBaseSessionUuid(sessionId, this.sessionManager) ?? sessionId;
-    return executionTracker.hasActiveSessionUuidExecutions(executionSessionId, query)
+    return executionTracker.hasActiveSessionUuidExecutions(sessionId, query)
+      || (executionSessionId !== sessionId
+        && executionTracker.hasActiveSessionUuidExecutions(executionSessionId, query))
       || this.devicePool.hasActiveAutolockMcpSessionExecution(
         sessionId,
         (mcpSessionId, executionQuery) => executionTracker.hasActiveSessionExecutions(mcpSessionId, executionQuery),

--- a/src/daemon/daemon.ts
+++ b/src/daemon/daemon.ts
@@ -28,6 +28,7 @@ import { getCurrentBuildIdentity } from "./buildIdentity";
 import { cleanupDaemonFiles, cleanupDaemonFilesSync, readPidFileDataSync } from "./daemonFiles";
 import { executionTracker } from "../server/executionTracker";
 import { SessionReleaseBroadcaster } from "../server/sessionReleaseBroadcast";
+import { resolveCapabilityBaseSessionUuid } from "../features/toolCapabilities/capabilitySessionResolver";
 import {
   awaitInFlightMigrations,
   closeDatabase,
@@ -1238,7 +1239,8 @@ export class Daemon {
   }
 
   private hasActiveSessionExecution(sessionId: string, query?: ActiveSessionExecutionQuery): boolean {
-    return executionTracker.hasActiveSessionUuidExecutions(sessionId, query)
+    const executionSessionId = resolveCapabilityBaseSessionUuid(sessionId, this.sessionManager) ?? sessionId;
+    return executionTracker.hasActiveSessionUuidExecutions(executionSessionId, query)
       || this.devicePool.hasActiveAutolockMcpSessionExecution(
         sessionId,
         (mcpSessionId, executionQuery) => executionTracker.hasActiveSessionExecutions(mcpSessionId, executionQuery),

--- a/src/server/deviceLabelMapping.ts
+++ b/src/server/deviceLabelMapping.ts
@@ -75,10 +75,11 @@ export const registerDeviceLabelMap = async (
     return deviceLabelMap;
   }
 
-  // Ensure the base session is set up (accessibility/keep-awake side effects),
-  // then store the label map in its typed `deviceLabels` slot (issue #2973).
-  await createToolExecutionContext(baseSessionUuid, sessionManager, devicePool, sessionOptions, execution);
+  // Publish the base-to-derived relationship before the first setup await. The
+  // expiry checker uses it to keep every labeled session alive for the active
+  // base-plan execution while allocation/setup crosses an idle deadline.
   sessionManager.setDeviceLabels(baseSessionUuid, deviceLabelMap);
+  await createToolExecutionContext(baseSessionUuid, sessionManager, devicePool, sessionOptions, execution);
 
   const assignedSessions = new Set(Object.values(deviceLabelMap));
   assignedSessions.delete(baseSessionUuid);

--- a/src/server/deviceLabelMapping.ts
+++ b/src/server/deviceLabelMapping.ts
@@ -2,7 +2,7 @@ import { DaemonState } from "../daemon/daemonState";
 import { ActionableError } from "../models";
 import { createToolExecutionContext } from "./ToolExecutionContext";
 import type { SessionOptions } from "./ToolExecutionContext";
-import type { DeviceLabelMap } from "../daemon/sessionManager";
+import type { DeviceLabelMap, SessionExecutionMetadata } from "../daemon/sessionManager";
 import { logger } from "../utils/logger";
 
 const buildDeviceLabelList = (labels: string[]): string[] => {
@@ -60,7 +60,8 @@ export const registerDeviceLabelMap = async (
   baseSessionUuid: string,
   labels: string[],
   primaryLabel?: string,
-  sessionOptions: SessionOptions = {}
+  sessionOptions: SessionOptions = {},
+  execution?: SessionExecutionMetadata,
 ): Promise<DeviceLabelMap> => {
   if (!DaemonState.getInstance().isInitialized()) {
     throw new ActionableError("Device labels require an active daemon session.");
@@ -76,14 +77,14 @@ export const registerDeviceLabelMap = async (
 
   // Ensure the base session is set up (accessibility/keep-awake side effects),
   // then store the label map in its typed `deviceLabels` slot (issue #2973).
-  await createToolExecutionContext(baseSessionUuid, sessionManager, devicePool, sessionOptions);
+  await createToolExecutionContext(baseSessionUuid, sessionManager, devicePool, sessionOptions, execution);
   sessionManager.setDeviceLabels(baseSessionUuid, deviceLabelMap);
 
   const assignedSessions = new Set(Object.values(deviceLabelMap));
   assignedSessions.delete(baseSessionUuid);
 
   for (const sessionUuid of assignedSessions) {
-    await createToolExecutionContext(sessionUuid, sessionManager, devicePool, sessionOptions);
+    await createToolExecutionContext(sessionUuid, sessionManager, devicePool, sessionOptions, execution);
   }
 
   logger.info(`[DeviceLabelMap] Registered labels for session ${baseSessionUuid}: ${Object.keys(deviceLabelMap).join(", ")}`);

--- a/src/server/planExecutionOrchestrator.ts
+++ b/src/server/planExecutionOrchestrator.ts
@@ -485,6 +485,11 @@ export class PlanExecutionOrchestrator {
       );
     }
 
+    // The plan execution is tracked on its base session. Publish its derived
+    // label-session ownership before any expiry-aware session read so cleanup
+    // keeps every allocation alive while this plan is still running.
+    sessionManager.setDeviceLabels(this.request.sessionUuid, labelToSessionMap);
+
     for (const sessionUuid of sessionToDeviceMap.keys()) {
       if (!sessionManager.getSession(sessionUuid)) {
         throw new ActionableError(

--- a/src/server/planExecutionOrchestrator.ts
+++ b/src/server/planExecutionOrchestrator.ts
@@ -24,6 +24,7 @@ import { serverConfig } from "../utils/ServerConfig";
 import { defaultTimer, Timer } from "../utils/SystemTimer";
 import { logger } from "../utils/logger";
 import { ProgressCallback } from "./toolRegistry";
+import { getToolCapabilityContext } from "../features/toolCapabilities/toolCapabilityContext";
 import type { Plan } from "../models/Plan";
 import { isDeviceLostError } from "./deviceLossOutcome";
 
@@ -513,7 +514,8 @@ export class PlanExecutionOrchestrator {
       this.request.sessionUuid,
       effectiveLabels,
       this.request.device,
-      { keepScreenAwake: this.request.keepScreenAwake, platform: this.request.platform }
+      { keepScreenAwake: this.request.keepScreenAwake, platform: this.request.platform },
+      getToolCapabilityContext()?.execution,
     );
 
     return deviceMapping;

--- a/src/server/planExecutionOrchestrator.ts
+++ b/src/server/planExecutionOrchestrator.ts
@@ -14,6 +14,8 @@ type NormalizedPlanDevices = ReturnType<typeof normalizePlanDevices>;
 import { buildDeviceLabelMap, registerDeviceLabelMap } from "./deviceLabelMapping";
 import { importPlanFromYaml, executePlan } from "../utils/planUtils";
 import { DaemonState } from "../daemon/daemonState";
+import type { DevicePool } from "../daemon/devicePool";
+import type { SessionManager } from "../daemon/sessionManager";
 import { AndroidSegmentedPlanVideoSession } from "./androidSegmentedPlanVideoSession";
 import { type StoppedSegment, writeSegmentManifest } from "./segmentManifest";
 import {
@@ -413,20 +415,21 @@ export class PlanExecutionOrchestrator {
    * plan with no labels.
    */
   private async allocateDevices(_plan: Plan): Promise<Record<string, string> | undefined> {
-    const normalized = this.normalizedDevices ?? { labels: [], hasDefinitions: false, definitions: [] };
+    const normalized = this.normalizedDevices ?? normalizePlanDevices();
     const planDeviceLabels = normalized.labels;
     const effectiveLabels = this.request.devices && this.request.devices.length > 0
       ? this.request.devices
       : planDeviceLabels;
 
-    if (!effectiveLabels || effectiveLabels.length === 0) {
+    if (effectiveLabels.length === 0) {
       if (this.request.device) {
         throw new ActionableError("Device label requires a devices list to be provided.");
       }
       return undefined;
     }
 
-    if (!this.request.sessionUuid) {
+    const sessionUuid = this.request.sessionUuid;
+    if (!sessionUuid) {
       throw new ActionableError("Device labels require a sessionUuid to be provided.");
     }
     if (this.request.device && !effectiveLabels.includes(this.request.device)) {
@@ -443,53 +446,106 @@ export class PlanExecutionOrchestrator {
 
     const devicePool = DaemonState.getInstance().getDevicePool();
     const sessionManager = DaemonState.getInstance().getSessionManager();
-    const labelToSessionMap = buildDeviceLabelMap(effectiveLabels, this.request.sessionUuid, this.request.device);
+    const labelToSessionMap = buildDeviceLabelMap(effectiveLabels, sessionUuid, this.request.device);
     const sessionIds = Object.values(labelToSessionMap);
+
+    // The plan execution is tracked on its base session. Publish its derived
+    // label-session ownership before the allocator's first await so heartbeat
+    // and idle cleanup keep partial allocations alive while this plan runs.
+    const previousDeviceLabels = sessionManager.getDeviceLabels(sessionUuid);
+    sessionManager.setDeviceLabels(sessionUuid, labelToSessionMap);
 
     logger.info(
       `Requesting allocation of ${sessionIds.length} devices for labels: ${Object.keys(labelToSessionMap).join(", ")} ` +
       `(timeout: ${this.request.deviceAllocationTimeoutMs / 1000}s)`
     );
 
-    let sessionToDeviceMap: Map<string, string>;
-    if (normalized.hasDefinitions) {
-      const definitionMap = new Map(
-        normalized.definitions.map(definition => [definition.label, definition])
-      );
-      const requests = effectiveLabels.map(label => {
-        const definition = definitionMap.get(label);
-        if (!definition) {
-          throw new ActionableError(
-            `Device definition for label '${label}' not found in plan devices.`
-          );
-        }
-        return {
-          sessionId: labelToSessionMap[label],
-          criteria: {
-            platform: definition.platform,
-            simulatorType: definition.simulatorType,
-            iosVersion: definition.iosVersion,
-          },
-        };
-      });
+    const restorePreviousDeviceLabels = (error: unknown): never => {
+      if (previousDeviceLabels) {
+        sessionManager.setDeviceLabels(sessionUuid, previousDeviceLabels);
+      } else {
+        sessionManager.clearSessionCache(sessionUuid, "deviceLabels");
+      }
+      throw error;
+    };
 
-      sessionToDeviceMap = await devicePool.assignMultipleDevicesByCriteria(
-        requests,
-        this.request.deviceAllocationTimeoutMs
-      );
-    } else {
-      sessionToDeviceMap = await devicePool.assignMultipleDevices(
+    const allocation = Promise.resolve().then(() => this.requestDeviceAllocation(
+      devicePool,
+      normalized,
+      effectiveLabels,
+      labelToSessionMap,
+      sessionIds
+    ));
+
+    const sessionToDeviceMap = await allocation.catch(error => {
+      return restorePreviousDeviceLabels(error);
+    });
+
+    const deviceMapping = this.buildDeviceMapping(sessionManager, sessionToDeviceMap, labelToSessionMap);
+
+    this.perfLog("Device allocation complete");
+    for (const [label, deviceId] of Object.entries(deviceMapping)) {
+      const sessionUuid = labelToSessionMap[label];
+      this.perfLog(`  ${label} → ${deviceId} (session: ${sessionUuid})`);
+    }
+
+    await registerDeviceLabelMap(
+      sessionUuid,
+      effectiveLabels,
+      this.request.device,
+      { keepScreenAwake: this.request.keepScreenAwake, platform: this.request.platform },
+      getToolCapabilityContext()?.execution,
+    );
+
+    return deviceMapping;
+  }
+
+  private requestDeviceAllocation(
+    devicePool: DevicePool,
+    normalized: NormalizedPlanDevices,
+    effectiveLabels: string[],
+    labelToSessionMap: Record<string, string>,
+    sessionIds: string[]
+  ): Promise<Map<string, string>> {
+    if (!normalized.hasDefinitions) {
+      return devicePool.assignMultipleDevices(
         sessionIds,
         this.request.deviceAllocationTimeoutMs,
         this.request.platform
       );
     }
 
-    // The plan execution is tracked on its base session. Publish its derived
-    // label-session ownership before any expiry-aware session read so cleanup
-    // keeps every allocation alive while this plan is still running.
-    sessionManager.setDeviceLabels(this.request.sessionUuid, labelToSessionMap);
+    const definitionMap = new Map(
+      normalized.definitions.map(definition => [definition.label, definition])
+    );
+    const requests = effectiveLabels.map(label => {
+      const definition = definitionMap.get(label);
+      if (!definition) {
+        throw new ActionableError(
+          `Device definition for label '${label}' not found in plan devices.`
+        );
+      }
+      return {
+        sessionId: labelToSessionMap[label],
+        criteria: {
+          platform: definition.platform,
+          simulatorType: definition.simulatorType,
+          iosVersion: definition.iosVersion,
+        },
+      };
+    });
 
+    return devicePool.assignMultipleDevicesByCriteria(
+      requests,
+      this.request.deviceAllocationTimeoutMs
+    );
+  }
+
+  private buildDeviceMapping(
+    sessionManager: SessionManager,
+    sessionToDeviceMap: Map<string, string>,
+    labelToSessionMap: Record<string, string>
+  ): Record<string, string> {
     for (const sessionUuid of sessionToDeviceMap.keys()) {
       if (!sessionManager.getSession(sessionUuid)) {
         throw new ActionableError(
@@ -508,21 +564,6 @@ export class PlanExecutionOrchestrator {
       }
       deviceMapping[label] = deviceId;
     }
-
-    this.perfLog("Device allocation complete");
-    for (const [label, deviceId] of Object.entries(deviceMapping)) {
-      const sessionUuid = labelToSessionMap[label];
-      this.perfLog(`  ${label} → ${deviceId} (session: ${sessionUuid})`);
-    }
-
-    await registerDeviceLabelMap(
-      this.request.sessionUuid,
-      effectiveLabels,
-      this.request.device,
-      { keepScreenAwake: this.request.keepScreenAwake, platform: this.request.platform },
-      getToolCapabilityContext()?.execution,
-    );
-
     return deviceMapping;
   }
 

--- a/test/server/planExecutionOrchestrator.test.ts
+++ b/test/server/planExecutionOrchestrator.test.ts
@@ -243,7 +243,7 @@ steps:
     expect(result.error).toContain("Device label requires a devices list");
   });
 
-  test("keeps every labeled session assigned when allocation crosses idle expiry", async () => {
+  test("keeps every labeled session assigned when expired setup follows allocation", async () => {
     const timer = new FakeTimer();
     const sessionManager = new SessionManager(timer, new FakeDeviceSessionPersistence());
     const secondAndroidDevice: BootedDevice = {
@@ -257,7 +257,7 @@ steps:
       timer,
     );
     DaemonState.getInstance().initialize(sessionManager, devicePool);
-    await sessionManager.createSession("base", androidDevice.deviceId, "android");
+    await sessionManager.createSession("base", androidDevice.deviceId, "android", 1_000);
     const executionTracker = new ExecutionTracker(timer);
     const execution = executionTracker.startExecution("executePlan", undefined, "base");
     const hasActiveExecution = (sessionId: string, query?: { excludeExecutionId?: string }) =>
@@ -278,7 +278,7 @@ steps:
       for (const [index, sessionId] of sessionIds.entries()) {
         const device = index === 0 ? androidDevice : secondAndroidDevice;
         if (!sessionManager.getSession(sessionId)) {
-          await sessionManager.createSession(sessionId, device.deviceId, "android");
+          await sessionManager.createSession(sessionId, device.deviceId, "android", 1_000);
         }
         assignments.set(sessionId, device.deviceId);
       }

--- a/test/server/planExecutionOrchestrator.test.ts
+++ b/test/server/planExecutionOrchestrator.test.ts
@@ -3,9 +3,14 @@ import os from "node:os";
 import path from "node:path";
 import { promises as fsPromises } from "node:fs";
 import { FakeTimer } from "../fakes/FakeTimer";
+import { FakeDeviceSessionPersistence } from "../fakes/FakeDeviceSessionPersistence";
 import type { BootedDevice } from "../../src/models";
 import type { TestExecutionRecord, TestExecutionRepository } from "../../src/db/testExecutionRepository";
 import { ANDROID_PLAN_VIDEO_SEGMENT_ROTATE_MS } from "../../src/features/video/androidScreenrecord";
+import { DaemonState } from "../../src/daemon/daemonState";
+import { DevicePool } from "../../src/daemon/devicePool";
+import { SessionManager } from "../../src/daemon/sessionManager";
+import { runWithToolCapabilityContext } from "../../src/features/toolCapabilities/toolCapabilityContext";
 
 // Mock planUtils so the orchestrator's runPlan() phase is observable without
 // spinning up a real PlanExecutor. The companion test
@@ -233,6 +238,76 @@ steps:
     const result = await orchestrator.execute();
     expect(result.success).toBe(false);
     expect(result.error).toContain("Device label requires a devices list");
+  });
+
+  test("keeps every labeled session assigned when allocation crosses idle expiry", async () => {
+    const timer = new FakeTimer();
+    const sessionManager = new SessionManager(timer, new FakeDeviceSessionPersistence());
+    const secondAndroidDevice: BootedDevice = {
+      ...androidDevice,
+      deviceId: "emulator-5556",
+      name: "Android Emulator 2",
+    };
+    const devicePool = new DevicePool(
+      sessionManager,
+      "daemon-session",
+      timer,
+    );
+    DaemonState.getInstance().initialize(sessionManager, devicePool);
+    sessionManager.setActiveSessionExecutionChecker(() => true);
+
+    devicePool.assignMultipleDevices = async sessionIds => {
+      const assignments = new Map<string, string>();
+      for (const [index, sessionId] of sessionIds.entries()) {
+        const device = index === 0 ? androidDevice : secondAndroidDevice;
+        const session = await sessionManager.createSession(sessionId, device.deviceId, "android");
+        session.expiresAt = timer.now();
+        assignments.set(sessionId, device.deviceId);
+      }
+      timer.advanceTime(1);
+      return assignments;
+    };
+    devicePool.assignDeviceToSession = async () => {
+      throw new Error("expired labeled sessions must not be recreated");
+    };
+
+    const multiDevicePlan = `
+name: multi-device-test
+devices:
+  - A
+  - B
+steps:
+  - tool: observe
+    device: A
+    params: {}
+`;
+
+    try {
+      const result = await runWithToolCapabilityContext(
+        { execution: { executionId: "plan-execution", startTime: 0 } },
+        () => new PlanExecutionOrchestrator(
+          {
+            device: androidDevice,
+            request: {
+              ...baseRequest,
+              planContent: multiDevicePlan,
+              platform: "android",
+              sessionUuid: "base",
+              device: "A",
+              devices: ["A", "B"],
+            },
+          },
+          { ...baseDeps(), timer },
+        ).execute(),
+      );
+
+      expect(result.success).toBe(true);
+      expect(sessionManager.getSession("base")).not.toBeNull();
+      expect(sessionManager.getSession("base:B")).not.toBeNull();
+    } finally {
+      DaemonState.getInstance().reset();
+      sessionManager.stopCleanupTimer();
+    }
   });
 
   test("execute() records test execution to the repository when metadata is provided", async () => {

--- a/test/server/planExecutionOrchestrator.test.ts
+++ b/test/server/planExecutionOrchestrator.test.ts
@@ -259,7 +259,7 @@ steps:
     DaemonState.getInstance().initialize(sessionManager, devicePool);
     await sessionManager.createSession("base", androidDevice.deviceId, "android");
     const executionTracker = new ExecutionTracker(timer);
-    executionTracker.startExecution("executePlan", undefined, "base");
+    const execution = executionTracker.startExecution("executePlan", undefined, "base");
     const hasActiveExecution = (sessionId: string, query?: { excludeExecutionId?: string }) =>
       executionTracker.hasActiveSessionUuidExecutions(
         resolveCapabilityBaseSessionUuid(sessionId, sessionManager),
@@ -330,6 +330,12 @@ steps:
       expect(result).toMatchObject({ success: true });
       expect(sessionManager.getSession("base")).not.toBeNull();
       expect(sessionManager.getSession("base:B")).not.toBeNull();
+
+      executionTracker.endExecution(execution.id);
+      timer.advanceTime(30 * 60 * 1000 + 1);
+      sessionManager.cleanupExpiredSessions();
+      expect(sessionManager.getSession("base")).toBeNull();
+      expect(sessionManager.getSession("base:B")).toBeNull();
     } finally {
       DaemonState.getInstance().reset();
       sessionManager.stopCleanupTimer();

--- a/test/server/planExecutionOrchestrator.test.ts
+++ b/test/server/planExecutionOrchestrator.test.ts
@@ -9,6 +9,7 @@ import type { TestExecutionRecord, TestExecutionRepository } from "../../src/db/
 import { ANDROID_PLAN_VIDEO_SEGMENT_ROTATE_MS } from "../../src/features/video/androidScreenrecord";
 import { DaemonState } from "../../src/daemon/daemonState";
 import { DevicePool } from "../../src/daemon/devicePool";
+import { SessionHeartbeatMonitor } from "../../src/daemon/SessionHeartbeatMonitor";
 import { SessionManager } from "../../src/daemon/sessionManager";
 import { runWithToolCapabilityContext } from "../../src/features/toolCapabilities/toolCapabilityContext";
 import { resolveCapabilityBaseSessionUuid } from "../../src/features/toolCapabilities/capabilitySessionResolver";
@@ -256,24 +257,33 @@ steps:
       timer,
     );
     DaemonState.getInstance().initialize(sessionManager, devicePool);
+    await sessionManager.createSession("base", androidDevice.deviceId, "android");
     const executionTracker = new ExecutionTracker(timer);
     executionTracker.startExecution("executePlan", undefined, "base");
-    sessionManager.setActiveSessionExecutionChecker((sessionId, query) =>
+    const hasActiveExecution = (sessionId: string, query?: { excludeExecutionId?: string }) =>
       executionTracker.hasActiveSessionUuidExecutions(
         resolveCapabilityBaseSessionUuid(sessionId, sessionManager),
         query,
-      ),
+      );
+    sessionManager.setActiveSessionExecutionChecker(hasActiveExecution);
+    const heartbeatMonitor = new SessionHeartbeatMonitor(
+      sessionManager,
+      hasActiveExecution,
+      sessionId => sessionManager.releaseSession(sessionId),
+      timer,
     );
 
     devicePool.assignMultipleDevices = async sessionIds => {
       const assignments = new Map<string, string>();
       for (const [index, sessionId] of sessionIds.entries()) {
         const device = index === 0 ? androidDevice : secondAndroidDevice;
-        const session = await sessionManager.createSession(sessionId, device.deviceId, "android");
-        session.expiresAt = timer.now();
+        if (!sessionManager.getSession(sessionId)) {
+          await sessionManager.createSession(sessionId, device.deviceId, "android");
+        }
         assignments.set(sessionId, device.deviceId);
       }
-      timer.advanceTime(1);
+      timer.advanceTime(6_000);
+      await heartbeatMonitor.tick();
       return assignments;
     };
     devicePool.assignDeviceToSession = async () => {
@@ -320,6 +330,51 @@ steps:
       expect(result).toMatchObject({ success: true });
       expect(sessionManager.getSession("base")).not.toBeNull();
       expect(sessionManager.getSession("base:B")).not.toBeNull();
+    } finally {
+      DaemonState.getInstance().reset();
+      sessionManager.stopCleanupTimer();
+    }
+  });
+
+  test("restores the previous device-label map when allocation fails", async () => {
+    const timer = new FakeTimer();
+    const sessionManager = new SessionManager(timer, new FakeDeviceSessionPersistence());
+    const devicePool = new DevicePool(sessionManager, "daemon-session", timer);
+    DaemonState.getInstance().initialize(sessionManager, devicePool);
+    await sessionManager.createSession("base", androidDevice.deviceId, "android");
+    const previousDeviceLabels = { existing: "base" };
+    sessionManager.setDeviceLabels("base", previousDeviceLabels);
+    devicePool.assignMultipleDevices = async () => {
+      throw new Error("allocation failed");
+    };
+
+    try {
+      const result = await new PlanExecutionOrchestrator(
+        {
+          device: androidDevice,
+          request: {
+            ...baseRequest,
+            planContent: `
+name: multi-device-test
+devices:
+  - A
+  - B
+steps:
+  - tool: observe
+    device: A
+    params: {}
+`,
+            platform: "android",
+            sessionUuid: "base",
+            device: "A",
+            devices: ["A", "B"],
+          },
+        },
+        { ...baseDeps(), timer },
+      ).execute();
+
+      expect(result.success).toBe(false);
+      expect(sessionManager.getDeviceLabels("base")).toEqual(previousDeviceLabels);
     } finally {
       DaemonState.getInstance().reset();
       sessionManager.stopCleanupTimer();

--- a/test/server/planExecutionOrchestrator.test.ts
+++ b/test/server/planExecutionOrchestrator.test.ts
@@ -11,6 +11,8 @@ import { DaemonState } from "../../src/daemon/daemonState";
 import { DevicePool } from "../../src/daemon/devicePool";
 import { SessionManager } from "../../src/daemon/sessionManager";
 import { runWithToolCapabilityContext } from "../../src/features/toolCapabilities/toolCapabilityContext";
+import { resolveCapabilityBaseSessionUuid } from "../../src/features/toolCapabilities/capabilitySessionResolver";
+import { ExecutionTracker } from "../../src/server/executionTracker";
 
 // Mock planUtils so the orchestrator's runPlan() phase is observable without
 // spinning up a real PlanExecutor. The companion test
@@ -254,7 +256,14 @@ steps:
       timer,
     );
     DaemonState.getInstance().initialize(sessionManager, devicePool);
-    sessionManager.setActiveSessionExecutionChecker(() => true);
+    const executionTracker = new ExecutionTracker(timer);
+    executionTracker.startExecution("executePlan", undefined, "base");
+    sessionManager.setActiveSessionExecutionChecker((sessionId, query) =>
+      executionTracker.hasActiveSessionUuidExecutions(
+        resolveCapabilityBaseSessionUuid(sessionId, sessionManager),
+        query,
+      ),
+    );
 
     devicePool.assignMultipleDevices = async sessionIds => {
       const assignments = new Map<string, string>();
@@ -269,6 +278,13 @@ steps:
     };
     devicePool.assignDeviceToSession = async () => {
       throw new Error("expired labeled sessions must not be recreated");
+    };
+    const trackSessionSetup = sessionManager.trackSessionSetup.bind(sessionManager);
+    sessionManager.trackSessionSetup = async (session, setup) => {
+      await trackSessionSetup(session, setup);
+      if (session.sessionId === "base") {
+        sessionManager.cleanupExpiredSessions();
+      }
     };
 
     const multiDevicePlan = `
@@ -301,7 +317,7 @@ steps:
         ).execute(),
       );
 
-      expect(result.success).toBe(true);
+      expect(result).toMatchObject({ success: true });
       expect(sessionManager.getSession("base")).not.toBeNull();
       expect(sessionManager.getSession("base:B")).not.toBeNull();
     } finally {


### PR DESCRIPTION
## Summary

- Preserve ambient execution metadata while `executePlan` finishes labeled-device setup.
- Publish base-to-derived label ownership before allocation can await, so heartbeat and idle-expiry checks retain partially allocated sessions.
- Restore the prior device-label map if allocation fails, and resolve labeled sessions through the active base-plan execution.

## Root cause

The session-expiry fix from [#5288](https://github.com/kaeawc/auto-mobile/issues/5288) reached direct tool-context creation, but labeled-plan setup did not publish base-to-derived ownership until after the allocator returned. A derived session could therefore be released or recreated while its base plan still ran.

## Validation

- `bun test test/server/planExecutionOrchestrator.test.ts test/server/deviceLabelMapping.test.ts test/features/toolCapabilities/capabilitySessionResolver.test.ts test/daemon/SessionHeartbeatMonitor.test.ts test/daemon/sessionManager.test.ts`
- `bun run lint`
- `bun run build`
- `bun run typecheck`
- `bun run turbo:validate` — 13,359 passed, 13 skipped, 0 failed
- `git diff --check`

Closes #5350
