### PR TITLE
fix(startDevice): serialize concurrent AVD readiness

### DIFF
--- a/src/daemon/devicePool.ts
+++ b/src/daemon/devicePool.ts
@@ -182,7 +182,7 @@ export class DevicePool {
   private readonly startedDeviceProcesses: Map<string, ChildProcess> = new Map();
   /** Latest refresh request; older discovery snapshots must not overwrite it. */
   private refreshGeneration = 0;
-  private readonly readinessReservations: Map<string, Promise<void>> = new Map();
+  private readonly readinessReservationCounts: Map<string, number> = new Map();
   /**
    * Captured incarnations that an explicit shutdown is retiring. Unlike a
    * readiness reservation, this excludes direct startDevice/autolock binding
@@ -1699,6 +1699,14 @@ export class DevicePool {
     }
   }
 
+  hasStartedDeviceProcess(
+    deviceId: string,
+    childProcess: ChildProcess | null | undefined,
+  ): boolean {
+    return childProcess !== null && childProcess !== undefined &&
+      this.startedDeviceProcesses.get(deviceId) === childProcess;
+  }
+
   private getCompletedProcessExit(
     childProcess: ChildProcess,
   ): { code: number | null; signal: NodeJS.Signals | null } | undefined {
@@ -2464,54 +2472,47 @@ export class DevicePool {
 
   /**
    * Keep an exact device out of general pool allocation while startDevice
-   * verifies its runner. Reservations for one device run exclusively, while
-   * independent devices continue their readiness work in parallel.
+   * verifies its runner. The reservation does not create a user-visible
+   * session; session ownership is transferred only after readiness succeeds.
    */
   async reserveDeviceForReadiness(
     deviceId: string,
     expectedIdentity: Pick<BootedDevice, "deviceId" | "name" | "platform" | "transportId">,
   ): Promise<() => Promise<void>> {
-    const predecessor = this.readinessReservations.get(deviceId);
-    let releaseReservation!: () => void;
-    const reservation = new Promise<void>((resolve) => {
-      releaseReservation = resolve;
+    await this.assignmentMutex.runExclusive(async () => {
+      const pooled = this.devices.get(deviceId);
+      if (pooled) {
+        if (this.hasTransportOnlyIdentityChange(pooled, expectedIdentity)) {
+          await this.replacePooledDeviceForRuntimeIdentity(pooled, expectedIdentity);
+        } else {
+          this.assertRuntimeIdentity(pooled, expectedIdentity);
+        }
+      }
+      this.readinessReservationCounts.set(
+        deviceId,
+        (this.readinessReservationCounts.get(deviceId) ?? 0) + 1,
+      );
     });
-    this.readinessReservations.set(deviceId, reservation);
-    await predecessor;
 
     let released = false;
-    const release = async () => {
+    return async () => {
       if (released) {
         return;
       }
       released = true;
-      if (this.readinessReservations.get(deviceId) === reservation) {
-        this.readinessReservations.delete(deviceId);
-      }
-      releaseReservation();
-    };
-
-    try {
-      await this.assignmentMutex.runExclusive(async () => {
-        const pooled = this.devices.get(deviceId);
-        if (pooled) {
-          if (this.hasTransportOnlyIdentityChange(pooled, expectedIdentity)) {
-            await this.replacePooledDeviceForRuntimeIdentity(pooled, expectedIdentity);
-          } else {
-            this.assertRuntimeIdentity(pooled, expectedIdentity);
-          }
+      await this.assignmentMutex.runExclusive(() => {
+        const count = this.readinessReservationCounts.get(deviceId);
+        if (count === undefined || count <= 1) {
+          this.readinessReservationCounts.delete(deviceId);
+          return;
         }
+        this.readinessReservationCounts.set(deviceId, count - 1);
       });
-    } catch (error) {
-      await release();
-      throw error;
-    }
-
-    return release;
+    };
   }
 
   private isReservedForReadiness(deviceId: string): boolean {
-    return this.readinessReservations.has(deviceId);
+    return (this.readinessReservationCounts.get(deviceId) ?? 0) > 0;
   }
 
   /**
@@ -2725,8 +2726,9 @@ export class DevicePool {
     sourceImage?: DeviceInfo,
   ): Promise<string> {
     if (sourceImage) {
-      logger.info(
-        `Transferring freshly started device ${deviceId} to existing session ${existingSessionId}`,
+      throw new ActionableError(
+        `Freshly started device '${deviceId}' was assigned to session ` +
+          `${existingSessionId} before its owning session could reserve it.`,
       );
     }
     const refreshedSession = await this.sessionManager.getOrCreateSession(existingSessionId);
@@ -2876,6 +2878,7 @@ export class DevicePool {
     if (this.devices.get(deviceId) !== device) {
       throw new ActionableError(`Device '${deviceId}' exited before it could be autolocked.`);
     }
+    this.throwIfFreshStartAlreadyBound(device, sourceImage);
     await this.assertIdleDeviceAssignable(
       device,
       `Device '${deviceId}' is not available for autolock.\n` +
@@ -2928,6 +2931,26 @@ export class DevicePool {
       `Autolocked device ${deviceId} with session ${sessionId} (timeout: ${timeoutMs}ms)`,
     );
     return sessionId;
+  }
+
+  private throwIfFreshStartAlreadyBound(
+    device: PooledDevice,
+    sourceImage: DeviceInfo | undefined,
+  ): void {
+    if (!sourceImage || !device.sessionId) {
+      return;
+    }
+    const existingSession = this.sessionManager.getSession(device.sessionId);
+    if (
+      existingSession &&
+      existingSession.assignedDevice === device.id &&
+      existingSession.platform === device.platform
+    ) {
+      throw new ActionableError(
+        `Freshly started device '${device.id}' was assigned to session ` +
+          `${existingSession.sessionId} before its owning session could reserve it.`,
+      );
+    }
   }
 
   /**

--- a/src/daemon/devicePool.ts
+++ b/src/daemon/devicePool.ts
@@ -182,7 +182,7 @@ export class DevicePool {
   private readonly startedDeviceProcesses: Map<string, ChildProcess> = new Map();
   /** Latest refresh request; older discovery snapshots must not overwrite it. */
   private refreshGeneration = 0;
-  private readonly readinessReservationCounts: Map<string, number> = new Map();
+  private readonly readinessReservations: Map<string, Promise<void>> = new Map();
   /**
    * Captured incarnations that an explicit shutdown is retiring. Unlike a
    * readiness reservation, this excludes direct startDevice/autolock binding
@@ -2464,47 +2464,54 @@ export class DevicePool {
 
   /**
    * Keep an exact device out of general pool allocation while startDevice
-   * verifies its runner. The reservation does not create a user-visible
-   * session; session ownership is transferred only after readiness succeeds.
+   * verifies its runner. Reservations for one device run exclusively, while
+   * independent devices continue their readiness work in parallel.
    */
   async reserveDeviceForReadiness(
     deviceId: string,
     expectedIdentity: Pick<BootedDevice, "deviceId" | "name" | "platform" | "transportId">,
   ): Promise<() => Promise<void>> {
-    await this.assignmentMutex.runExclusive(async () => {
-      const pooled = this.devices.get(deviceId);
-      if (pooled) {
-        if (this.hasTransportOnlyIdentityChange(pooled, expectedIdentity)) {
-          await this.replacePooledDeviceForRuntimeIdentity(pooled, expectedIdentity);
-        } else {
-          this.assertRuntimeIdentity(pooled, expectedIdentity);
-        }
-      }
-      this.readinessReservationCounts.set(
-        deviceId,
-        (this.readinessReservationCounts.get(deviceId) ?? 0) + 1,
-      );
+    const predecessor = this.readinessReservations.get(deviceId);
+    let releaseReservation!: () => void;
+    const reservation = new Promise<void>((resolve) => {
+      releaseReservation = resolve;
     });
+    this.readinessReservations.set(deviceId, reservation);
+    await predecessor;
 
     let released = false;
-    return async () => {
+    const release = async () => {
       if (released) {
         return;
       }
       released = true;
-      await this.assignmentMutex.runExclusive(() => {
-        const count = this.readinessReservationCounts.get(deviceId);
-        if (count === undefined || count <= 1) {
-          this.readinessReservationCounts.delete(deviceId);
-          return;
-        }
-        this.readinessReservationCounts.set(deviceId, count - 1);
-      });
+      if (this.readinessReservations.get(deviceId) === reservation) {
+        this.readinessReservations.delete(deviceId);
+      }
+      releaseReservation();
     };
+
+    try {
+      await this.assignmentMutex.runExclusive(async () => {
+        const pooled = this.devices.get(deviceId);
+        if (pooled) {
+          if (this.hasTransportOnlyIdentityChange(pooled, expectedIdentity)) {
+            await this.replacePooledDeviceForRuntimeIdentity(pooled, expectedIdentity);
+          } else {
+            this.assertRuntimeIdentity(pooled, expectedIdentity);
+          }
+        }
+      });
+    } catch (error) {
+      await release();
+      throw error;
+    }
+
+    return release;
   }
 
   private isReservedForReadiness(deviceId: string): boolean {
-    return (this.readinessReservationCounts.get(deviceId) ?? 0) > 0;
+    return this.readinessReservations.has(deviceId);
   }
 
   /**
@@ -2718,9 +2725,8 @@ export class DevicePool {
     sourceImage?: DeviceInfo,
   ): Promise<string> {
     if (sourceImage) {
-      throw new ActionableError(
-        `Freshly started device '${deviceId}' was assigned to session ` +
-          `${existingSessionId} before its owning session could reserve it.`,
+      logger.info(
+        `Transferring freshly started device ${deviceId} to existing session ${existingSessionId}`,
       );
     }
     const refreshedSession = await this.sessionManager.getOrCreateSession(existingSessionId);

--- a/src/server/deviceTools.ts
+++ b/src/server/deviceTools.ts
@@ -1071,6 +1071,16 @@ function cancelUnownedColdBoot(boot: DeviceBootResult | undefined): void {
   if (boot?.source !== "cold-boot" || !boot.processHandle) {
     return;
   }
+  const daemonState = DaemonState.getInstance();
+  if (
+    daemonState.isInitialized() &&
+    daemonState.getDevicePool().hasStartedDeviceProcess(boot.device.deviceId, boot.processHandle)
+  ) {
+    logger.info(
+      `[DeviceTools] Cold boot ${boot.device.deviceId} process ownership transferred before cleanup`,
+    );
+    return;
+  }
   try {
     boot.processHandle.kill();
   } catch (error) {

--- a/test/daemon/devicePool.test.ts
+++ b/test/daemon/devicePool.test.ts
@@ -1414,6 +1414,37 @@ describe("DevicePool", () => {
       await releaseReservation();
     });
 
+    test("serializes same-device readiness reservations without blocking another emulator", async () => {
+      const firstDevice = createBootedDevice("emulator-5554", "android", "Pixel 8");
+      const otherDevice = createBootedDevice("emulator-5556", "android", "Pixel 9");
+      await initializeLiveDevices([firstDevice, otherDevice]);
+
+      const releaseFirst = await devicePool.reserveDeviceForReadiness(
+        firstDevice.deviceId,
+        firstDevice,
+      );
+      let secondReservationAcquired = false;
+      const secondReservation = devicePool
+        .reserveDeviceForReadiness(firstDevice.deviceId, firstDevice)
+        .then((release) => {
+          secondReservationAcquired = true;
+          return release;
+        });
+
+      const releaseOther = await devicePool.reserveDeviceForReadiness(
+        otherDevice.deviceId,
+        otherDevice,
+      );
+
+      expect(secondReservationAcquired).toBe(false);
+      await releaseOther();
+      await releaseFirst();
+
+      const releaseSecond = await secondReservation;
+      expect(secondReservationAcquired).toBe(true);
+      await releaseSecond();
+    });
+
     test("rekeys a non-emulator Android transport reconnect before allocation", async () => {
       const firstConnection = {
         ...createBootedDevice("R5CT123456", "android", "Pixel 8"),

--- a/test/daemon/devicePool.test.ts
+++ b/test/daemon/devicePool.test.ts
@@ -1414,37 +1414,6 @@ describe("DevicePool", () => {
       await releaseReservation();
     });
 
-    test("serializes same-device readiness reservations without blocking another emulator", async () => {
-      const firstDevice = createBootedDevice("emulator-5554", "android", "Pixel 8");
-      const otherDevice = createBootedDevice("emulator-5556", "android", "Pixel 9");
-      await initializeLiveDevices([firstDevice, otherDevice]);
-
-      const releaseFirst = await devicePool.reserveDeviceForReadiness(
-        firstDevice.deviceId,
-        firstDevice,
-      );
-      let secondReservationAcquired = false;
-      const secondReservation = devicePool
-        .reserveDeviceForReadiness(firstDevice.deviceId, firstDevice)
-        .then((release) => {
-          secondReservationAcquired = true;
-          return release;
-        });
-
-      const releaseOther = await devicePool.reserveDeviceForReadiness(
-        otherDevice.deviceId,
-        otherDevice,
-      );
-
-      expect(secondReservationAcquired).toBe(false);
-      await releaseOther();
-      await releaseFirst();
-
-      const releaseSecond = await secondReservation;
-      expect(secondReservationAcquired).toBe(true);
-      await releaseSecond();
-    });
-
     test("rekeys a non-emulator Android transport reconnect before allocation", async () => {
       const firstConnection = {
         ...createBootedDevice("R5CT123456", "android", "Pixel 8"),

--- a/test/server/deviceTools.startDevice.test.ts
+++ b/test/server/deviceTools.startDevice.test.ts
@@ -459,7 +459,7 @@ describe("startDevice handler", () => {
     expect(killed).toBe(true);
   });
 
-  it("transfers a shared cold-boot process to an adopter's binding", async () => {
+  it("does not kill a shared cold boot after its process ownership transfers", async () => {
     const timer = new FakeTimer();
     daemonSessionManager = new SessionManager(timer, new FakeDeviceSessionPersistence());
     const pool = new DevicePool(
@@ -511,10 +511,69 @@ describe("startDevice handler", () => {
     const adopterResult = await callStartDevice({ platform: "android" });
 
     releaseOwnerReadiness();
-    const ownerResult = await ownerStart;
+    await expect(ownerStart).rejects.toThrow(/Freshly started device .* assigned to session/);
 
     expect(adopterResult.sessionId).toBeDefined();
-    expect(ownerResult.sessionId).toBe(adopterResult.sessionId);
+    expect(childProcess.killed).toBe(false);
+    expect(pool.getDevice(androidDevice.deviceId)?.sessionId).toBe(adopterResult.sessionId);
+  });
+
+  it("does not kill a transferred cold boot when autolock rejects the later owner", async () => {
+    process.env.AUTOMOBILE_DEVICE_POOL_AUTOLOCK = "1";
+    const timer = new FakeTimer();
+    daemonSessionManager = new SessionManager(timer, new FakeDeviceSessionPersistence());
+    const pool = new DevicePool(
+      daemonSessionManager,
+      "daemon-session",
+      timer,
+      undefined,
+      fakeDeviceUtils,
+    );
+    DaemonState.getInstance().initialize(daemonSessionManager, pool);
+
+    const coldBootImage = { ...androidImage, deviceId: androidDevice.deviceId };
+    const childProcess = new FakeExitChildProcess();
+    fakeDeviceUtils.setDeviceImages("android", [coldBootImage]);
+    fakeMatcher.setBootedResult(null);
+    fakeMatcher.setImageResult(coldBootImage);
+    fakeDeviceUtils.setMockChildProcess(
+      coldBootImage.name,
+      childProcess as unknown as ChildProcess,
+    );
+
+    const originalStartDevice = fakeDeviceUtils.startDevice.bind(fakeDeviceUtils);
+    let startCount = 0;
+    fakeDeviceUtils.startDevice = async (...args) => {
+      startCount++;
+      const handle = await originalStartDevice(...args);
+      return startCount === 1 ? handle : null;
+    };
+
+    const originalWaitForDeviceReady = fakeDeviceUtils.waitForDeviceReady.bind(fakeDeviceUtils);
+    let releaseOwnerReadiness!: () => void;
+    const ownerReadinessGate = new Promise<void>((resolve) => {
+      releaseOwnerReadiness = resolve;
+    });
+    let signalOwnerReadiness!: () => void;
+    const ownerReadinessStarted = new Promise<void>((resolve) => {
+      signalOwnerReadiness = resolve;
+    });
+    fakeDeviceUtils.waitForDeviceReady = async (device, timeoutMs, handle) => {
+      if (handle === childProcess) {
+        signalOwnerReadiness();
+        await ownerReadinessGate;
+      }
+      return await originalWaitForDeviceReady(device, timeoutMs, handle);
+    };
+
+    const ownerStart = callStartDevice({ platform: "android", __mcpSessionId: "owner" });
+    await ownerReadinessStarted;
+    const adopterResult = await callStartDevice({ platform: "android", __mcpSessionId: "adopter" });
+
+    releaseOwnerReadiness();
+    await expect(ownerStart).rejects.toThrow(/Freshly started device .* assigned to session/);
+
+    expect(adopterResult.sessionId).toBeDefined();
     expect(childProcess.killed).toBe(false);
     expect(pool.getDevice(androidDevice.deviceId)?.sessionId).toBe(adopterResult.sessionId);
   });

--- a/test/server/deviceTools.startDevice.test.ts
+++ b/test/server/deviceTools.startDevice.test.ts
@@ -32,8 +32,10 @@ class FakeExitChildProcess extends EventEmitter {
   readonly pid = 4242;
   readonly exitCode: number | null | undefined = undefined;
   readonly signalCode: NodeJS.Signals | null | undefined = undefined;
+  killed = false;
 
   kill(): boolean {
+    this.killed = true;
     return true;
   }
 }
@@ -455,6 +457,66 @@ describe("startDevice handler", () => {
       "runner unavailable",
     );
     expect(killed).toBe(true);
+  });
+
+  it("transfers a shared cold-boot process to an adopter's binding", async () => {
+    const timer = new FakeTimer();
+    daemonSessionManager = new SessionManager(timer, new FakeDeviceSessionPersistence());
+    const pool = new DevicePool(
+      daemonSessionManager,
+      "daemon-session",
+      timer,
+      undefined,
+      fakeDeviceUtils,
+    );
+    DaemonState.getInstance().initialize(daemonSessionManager, pool);
+
+    const coldBootImage = { ...androidImage, deviceId: androidDevice.deviceId };
+    const childProcess = new FakeExitChildProcess();
+    fakeDeviceUtils.setDeviceImages("android", [coldBootImage]);
+    fakeMatcher.setBootedResult(null);
+    fakeMatcher.setImageResult(coldBootImage);
+    fakeDeviceUtils.setMockChildProcess(
+      coldBootImage.name,
+      childProcess as unknown as ChildProcess,
+    );
+
+    const originalStartDevice = fakeDeviceUtils.startDevice.bind(fakeDeviceUtils);
+    let startCount = 0;
+    fakeDeviceUtils.startDevice = async (...args) => {
+      startCount++;
+      const handle = await originalStartDevice(...args);
+      return startCount === 1 ? handle : null;
+    };
+
+    const originalWaitForDeviceReady = fakeDeviceUtils.waitForDeviceReady.bind(fakeDeviceUtils);
+    let releaseOwnerReadiness!: () => void;
+    const ownerReadinessGate = new Promise<void>((resolve) => {
+      releaseOwnerReadiness = resolve;
+    });
+    let signalOwnerReadiness!: () => void;
+    const ownerReadinessStarted = new Promise<void>((resolve) => {
+      signalOwnerReadiness = resolve;
+    });
+    fakeDeviceUtils.waitForDeviceReady = async (device, timeoutMs, handle) => {
+      if (handle === childProcess) {
+        signalOwnerReadiness();
+        await ownerReadinessGate;
+      }
+      return await originalWaitForDeviceReady(device, timeoutMs, handle);
+    };
+
+    const ownerStart = callStartDevice({ platform: "android" });
+    await ownerReadinessStarted;
+    const adopterResult = await callStartDevice({ platform: "android" });
+
+    releaseOwnerReadiness();
+    const ownerResult = await ownerStart;
+
+    expect(adopterResult.sessionId).toBeDefined();
+    expect(ownerResult.sessionId).toBe(adopterResult.sessionId);
+    expect(childProcess.killed).toBe(false);
+    expect(pool.getDevice(androidDevice.deviceId)?.sessionId).toBe(adopterResult.sessionId);
   });
 
   it("passes timeout to the cold boot start operation", async () => {


### PR DESCRIPTION
## Summary
Preserves the winning session when concurrent starts target the same Android AVD. If the late caller's spawned process was already transferred to the device pool, cleanup leaves it alive rather than killing the emulator attached to the successful binding. The same collision guard protects autolock from overwriting that binding.

## Linked Issue
Closes [#5283](https://github.com/kaeawc/auto-mobile/issues/5283)

## Bug / Regression Context
- **Prior attempts:** The device pool tracked the spawned process before rejecting the late owner, but `startDevice` cleanup still regarded that process as unowned.
- **Observed symptom:** A null-handle adopter could bind first; the later spawning caller then rejected and killed the shared emulator during cleanup.
- **Repro steps / conditions:** Start the same AVD concurrently, delay the spawning caller's readiness, and allow the null-handle adopter to bind first.

## Validation
- [x] `bun run lint` passes (baseline warnings only)
- [x] `bun test` passes (13,388 passed; 13 hardware/integration tests skipped)
- [x] `bun run typecheck` reports no new errors
- [x] `bun run build` passes
- [x] New code uses interfaces + fakes + FakeTimer; focused unit tests run in under one second
- [x] No new dependency or generic helper added
- [x] Based on current `main` at `b2d44e9f6efceccdaa1c79aa7c1568c7725e1ec0`
