### PR TITLE
fix(startDevice): preempt non-cooperative boot cancellation

### DIFF
--- a/src/utils/deviceBootRecovery.ts
+++ b/src/utils/deviceBootRecovery.ts
@@ -11,12 +11,12 @@ const CI_SIMULATOR_NAME = "AutoMobile CI iPhone";
 
 /** Recovery policy for a cold device boot. Product callers default to no recovery. */
 export interface DeviceBootRecovery {
-  run<T>(target: DeviceInfo, boot: () => Promise<T>): Promise<T>;
+  run<T>(target: DeviceInfo, boot: () => Promise<T>, signal?: AbortSignal): Promise<T>;
 }
 
 /** The default product policy: surface the first boot failure unchanged. */
 export class NoopDeviceBootRecovery implements DeviceBootRecovery {
-  run<T>(_target: DeviceInfo, boot: () => Promise<T>): Promise<T> {
+  run<T>(_target: DeviceInfo, boot: () => Promise<T>, _signal?: AbortSignal): Promise<T> {
     return boot();
   }
 }
@@ -35,7 +35,7 @@ export interface CiIosBootRecoveryDependencies {
 export class CiIosBootRecovery implements DeviceBootRecovery {
   constructor(private readonly dependencies: CiIosBootRecoveryDependencies) {}
 
-  async run<T>(target: DeviceInfo, boot: () => Promise<T>): Promise<T> {
+  async run<T>(target: DeviceInfo, boot: () => Promise<T>, signal?: AbortSignal): Promise<T> {
     if (!this.isOwnedTarget(target)) {
       return boot();
     }
@@ -43,6 +43,9 @@ export class CiIosBootRecovery implements DeviceBootRecovery {
     try {
       return await boot();
     } catch (error) {
+      if (signal?.aborted) {
+        throw error;
+      }
       firstFailure = error;
     }
     await this.recover(() => this.dependencies.shutdown(target));

--- a/src/utils/deviceBootRecovery.ts
+++ b/src/utils/deviceBootRecovery.ts
@@ -1,4 +1,4 @@
-import type { DeviceInfo } from "../models";
+import { ActionableError, type DeviceInfo } from "../models";
 import type { DeviceBootRequest } from "./deviceBootService";
 import { DefaultDeviceProvisioner, createDefaultAndroidAvdCreator } from "./deviceProvisioning";
 import type { DeviceProvisioner } from "./deviceProvisioning";
@@ -48,30 +48,62 @@ export class CiIosBootRecovery implements DeviceBootRecovery {
       }
       firstFailure = error;
     }
-    await this.recover(() => this.dependencies.shutdown(target));
-    if (signal?.aborted) {
-      throw firstFailure;
-    }
-    await this.recover(() => this.dependencies.erase(target.deviceId!));
-    if (signal?.aborted) {
-      throw firstFailure;
-    }
+    this.throwIfCancelled(signal);
+    await this.recover(signal, () => this.dependencies.shutdown(target));
+    this.throwIfCancelled(signal);
+    await this.recover(signal, () => this.dependencies.erase(target.deviceId!));
+    this.throwIfCancelled(signal);
     try {
       return await boot();
     } catch {
+      this.throwIfCancelled(signal);
       throw firstFailure;
     }
   }
 
   private isOwnedTarget(target: DeviceInfo): boolean {
-    return target.platform === "ios" && target.name === this.dependencies.ownedSimulatorName && Boolean(target.deviceId);
+    return (
+      target.platform === "ios" &&
+      target.name === this.dependencies.ownedSimulatorName &&
+      Boolean(target.deviceId)
+    );
   }
 
-  private async recover(action: () => Promise<void>): Promise<void> {
+  private throwIfCancelled(signal: AbortSignal | undefined): void {
+    if (signal?.aborted) {
+      throw new ActionableError("startDevice cancelled while recovering the CI iOS simulator");
+    }
+  }
+
+  private async recover(
+    signal: AbortSignal | undefined,
+    action: () => Promise<void>,
+  ): Promise<void> {
+    const actionPromise = Promise.resolve()
+      .then(action)
+      .catch((error) => {
+        // Recovery is best-effort; an unavailable simulator can still be retried.
+        logger.debug(`[CI iOS boot] recovery command failed: ${error}`);
+      });
+    if (!signal) {
+      await actionPromise;
+      return;
+    }
+    this.throwIfCancelled(signal);
+    let rejectCancellation!: (error: ActionableError) => void;
+    const cancellation = new Promise<never>((_resolve, reject) => {
+      rejectCancellation = reject;
+    });
+    const cancel = () => {
+      rejectCancellation(
+        new ActionableError("startDevice cancelled while recovering the CI iOS simulator"),
+      );
+    };
+    signal.addEventListener("abort", cancel, { once: true });
     try {
-      await action();
-    } catch (error) {
-      logger.debug(`[CI iOS boot] recovery command failed: ${error}`);
+      await Promise.race([actionPromise, cancellation]);
+    } finally {
+      signal.removeEventListener("abort", cancel);
     }
   }
 }
@@ -89,12 +121,23 @@ export function isGitHubActionsCi(environment: NodeJS.ProcessEnv): boolean {
 }
 
 /** CI recovery owns only the un-targeted product boot used by the workflow. */
-export function shouldUseCiIosBootRecovery(request: DeviceBootRequest, environment: NodeJS.ProcessEnv): boolean {
-  return request.platform === "ios" && !request.name && !request.deviceId && isGitHubActionsCi(environment);
+export function shouldUseCiIosBootRecovery(
+  request: DeviceBootRequest,
+  environment: NodeJS.ProcessEnv,
+): boolean {
+  return (
+    request.platform === "ios" &&
+    !request.name &&
+    !request.deviceId &&
+    isGitHubActionsCi(environment)
+  );
 }
 
 /** Match the runtime-qualified CI-owned name across fallback without changing provisioning bounds. */
-export function normalizeCiIosBootRequest(request: DeviceBootRequest, ownedSimulatorName: string): DeviceBootRequest {
+export function normalizeCiIosBootRequest(
+  request: DeviceBootRequest,
+  ownedSimulatorName: string,
+): DeviceBootRequest {
   return { ...request, name: ownedSimulatorName, matchNamedDeviceIgnoringOsVersion: true };
 }
 
@@ -123,14 +166,14 @@ export async function createCiIosBootConfiguration(
     }),
     recovery: new CiIosBootRecovery({
       ownedSimulatorName,
-      shutdown: async target => {
+      shutdown: async (target) => {
         await deviceManager.killDevice({
           name: target.name,
           platform: "ios",
           deviceId: target.deviceId!,
         });
       },
-      erase: udid => simctl.eraseSimulator(udid),
+      erase: (udid) => simctl.eraseSimulator(udid),
     }),
   };
 }

--- a/src/utils/deviceBootRecovery.ts
+++ b/src/utils/deviceBootRecovery.ts
@@ -49,7 +49,13 @@ export class CiIosBootRecovery implements DeviceBootRecovery {
       firstFailure = error;
     }
     await this.recover(() => this.dependencies.shutdown(target));
+    if (signal?.aborted) {
+      throw firstFailure;
+    }
     await this.recover(() => this.dependencies.erase(target.deviceId!));
+    if (signal?.aborted) {
+      throw firstFailure;
+    }
     try {
       return await boot();
     } catch {

--- a/src/utils/deviceBootService.ts
+++ b/src/utils/deviceBootService.ts
@@ -74,7 +74,10 @@ interface PhaseCancellation {
   dispose(): void;
 }
 
-function createPhaseCancellation(signal: AbortSignal | undefined, phase: string): PhaseCancellation {
+function createPhaseCancellation(
+  signal: AbortSignal | undefined,
+  phase: string,
+): PhaseCancellation {
   const never = new Promise<never>(() => undefined);
   const throwIfCancelled = () => {
     if (signal?.aborted) {
@@ -207,7 +210,11 @@ export class DeviceBootService {
     if (!match) {
       return undefined;
     }
-    await progress?.report(100, 100, "Found matching running device");
+    if (progress) {
+      await this.runPhase(context, "reporting matching device progress", async () =>
+        progress.report(100, 100, "Found matching running device"),
+      );
+    }
     return this.waitForRunningDevice(match, context, progress);
   }
 
@@ -268,19 +275,23 @@ export class DeviceBootService {
   ): Promise<DeviceBootResult> {
     const recoveryTarget: DeviceInfo = { ...device, isRunning: true };
     let attempts = 0;
-    return this.bootRecovery.run(recoveryTarget, async () => {
-      attempts++;
-      if (attempts > 1) {
-        return this.bootImageOnce(recoveryTarget, context, progress, false);
-      }
-      const ready = await this.runPhase(context, "waiting for a running device", () =>
-        this.dependencies.deviceManager.waitForDeviceReady(
-          { ...device, isRunning: true },
-          this.remaining(context.deadlineMs, "waiting for a running device"),
-        ),
-      );
-      return { device: { ...device, ...ready }, source: "booted", provisioned: false };
-    }, context.signal);
+    return this.bootRecovery.run(
+      recoveryTarget,
+      async () => {
+        attempts++;
+        if (attempts > 1) {
+          return this.bootImageOnce(recoveryTarget, context, progress, false);
+        }
+        const ready = await this.runPhase(context, "waiting for a running device", () =>
+          this.dependencies.deviceManager.waitForDeviceReady(
+            { ...device, isRunning: true },
+            this.remaining(context.deadlineMs, "waiting for a running device"),
+          ),
+        );
+        return { device: { ...device, ...ready }, source: "booted", provisioned: false };
+      },
+      context.signal,
+    );
   }
 
   private async bootImage(
@@ -305,16 +316,24 @@ export class DeviceBootService {
     progress: DeviceBootProgress | undefined,
     provisioned: boolean,
   ): Promise<DeviceBootResult> {
-    const handle = await this.runPhase(context, "starting the device", async signal => {
+    let disposeStartHandleCancellation = () => {};
+    const handle = await this.runPhase(context, "starting the device", async (signal) => {
       const started = await this.dependencies.deviceManager.startDevice(
         image,
         this.remaining(context.deadlineMs, "starting the device"),
       );
-      if (signal.aborted && started) {
-        started.kill();
+      const cancelStarted = () => {
+        started?.kill();
+      };
+      if (signal.aborted) {
+        cancelStarted();
+      } else {
+        signal.addEventListener("abort", cancelStarted, { once: true });
+        disposeStartHandleCancellation = () => signal.removeEventListener("abort", cancelStarted);
       }
       return started;
     });
+    disposeStartHandleCancellation();
     let handleCancelled = false;
     const cancelHandle = () => {
       if (handle && !handleCancelled) {
@@ -324,8 +343,12 @@ export class DeviceBootService {
     };
     context.signal?.addEventListener("abort", cancelHandle, { once: true });
     try {
-      await progress?.report(60, 100, "Device started, waiting for readiness...");
-      const ready = await this.runPhase(context, "waiting for device boot readiness", signal =>
+      if (progress) {
+        await this.runPhase(context, "reporting device start progress", async () =>
+          progress.report(60, 100, "Device started, waiting for readiness..."),
+        );
+      }
+      const ready = await this.runPhase(context, "waiting for device boot readiness", (signal) =>
         waitForDeviceReadyOrCancel(
           this.dependencies.deviceManager,
           image,
@@ -335,7 +358,11 @@ export class DeviceBootService {
           cancelHandle,
         ),
       );
-      await progress?.report(100, 100, "Device is ready for use");
+      if (progress) {
+        await this.runPhase(context, "reporting device readiness progress", async () =>
+          progress.report(100, 100, "Device is ready for use"),
+        );
+      }
       return {
         device: enrichBootedDevice(ready, image),
         source: "cold-boot",

--- a/src/utils/deviceBootService.ts
+++ b/src/utils/deviceBootService.ts
@@ -315,25 +315,41 @@ export class DeviceBootService {
       }
       return started;
     });
-    await progress?.report(60, 100, "Device started, waiting for readiness...");
-    const ready = await this.runPhase(context, "waiting for device boot readiness", signal =>
-      waitForDeviceReadyOrCancel(
-        this.dependencies.deviceManager,
-        image,
-        handle,
-        this.remaining(context.deadlineMs, "waiting for device boot readiness"),
-        signal,
-      ),
-    );
-    await progress?.report(100, 100, "Device is ready for use");
-    return {
-      device: enrichBootedDevice(ready, image),
-      source: "cold-boot",
-      sourceImage: image,
-      processHandle: handle,
-      processId: handle?.pid,
-      provisioned,
+    let handleCancelled = false;
+    const cancelHandle = () => {
+      if (handle && !handleCancelled) {
+        handleCancelled = true;
+        handle.kill();
+      }
     };
+    context.signal?.addEventListener("abort", cancelHandle, { once: true });
+    try {
+      await progress?.report(60, 100, "Device started, waiting for readiness...");
+      const ready = await this.runPhase(context, "waiting for device boot readiness", signal =>
+        waitForDeviceReadyOrCancel(
+          this.dependencies.deviceManager,
+          image,
+          handle,
+          this.remaining(context.deadlineMs, "waiting for device boot readiness"),
+          signal,
+          cancelHandle,
+        ),
+      );
+      await progress?.report(100, 100, "Device is ready for use");
+      return {
+        device: enrichBootedDevice(ready, image),
+        source: "cold-boot",
+        sourceImage: image,
+        processHandle: handle,
+        processId: handle?.pid,
+        provisioned,
+      };
+    } catch (error) {
+      cancelHandle();
+      throw error;
+    } finally {
+      context.signal?.removeEventListener("abort", cancelHandle);
+    }
   }
 
   private remaining(deadlineMs: number, phase: string): number {
@@ -351,9 +367,9 @@ export class DeviceBootService {
     phase: string,
     operation: (signal: AbortSignal) => Promise<T>,
   ): Promise<T> {
+    const remainingMs = this.remaining(context.deadlineMs, phase);
     const cancellation = createPhaseCancellation(context.signal, phase);
     cancellation.throwIfCancelled();
-    const remainingMs = this.remaining(context.deadlineMs, phase);
     const controller = new AbortController();
     const signal = context.signal
       ? AbortSignal.any([context.signal, controller.signal])

--- a/src/utils/deviceBootService.ts
+++ b/src/utils/deviceBootService.ts
@@ -68,6 +68,38 @@ interface BootDeadlineContext {
   signal?: AbortSignal;
 }
 
+interface PhaseCancellation {
+  promise: Promise<never>;
+  throwIfCancelled(): void;
+  dispose(): void;
+}
+
+function createPhaseCancellation(signal: AbortSignal | undefined, phase: string): PhaseCancellation {
+  const never = new Promise<never>(() => undefined);
+  const throwIfCancelled = () => {
+    if (signal?.aborted) {
+      throw new ActionableError(`startDevice cancelled while ${phase}`);
+    }
+  };
+  if (!signal || signal.aborted) {
+    return { promise: never, throwIfCancelled, dispose: () => {} };
+  }
+
+  let rejectCancellation!: (error: ActionableError) => void;
+  const promise = new Promise<never>((_resolve, reject) => {
+    rejectCancellation = reject;
+  });
+  const abort = () => {
+    rejectCancellation(new ActionableError(`startDevice cancelled while ${phase}`));
+  };
+  signal.addEventListener("abort", abort, { once: true });
+  return {
+    promise,
+    throwIfCancelled,
+    dispose: () => signal.removeEventListener("abort", abort),
+  };
+}
+
 /**
  * Product boot boundary shared by MCP and daemon-free callers.
  *
@@ -248,7 +280,7 @@ export class DeviceBootService {
         ),
       );
       return { device: { ...device, ...ready }, source: "booted", provisioned: false };
-    });
+    }, context.signal);
   }
 
   private async bootImage(
@@ -260,8 +292,10 @@ export class DeviceBootService {
     if (image.platform === "ios" && !image.deviceId) {
       throw new ActionableError("iOS simulator deviceId (UDID) is required to start a simulator.");
     }
-    return this.bootRecovery.run(image, async () =>
-      this.bootImageOnce(image, context, progress, provisioned),
+    return this.bootRecovery.run(
+      image,
+      async () => this.bootImageOnce(image, context, progress, provisioned),
+      context.signal,
     );
   }
 
@@ -271,19 +305,24 @@ export class DeviceBootService {
     progress: DeviceBootProgress | undefined,
     provisioned: boolean,
   ): Promise<DeviceBootResult> {
-    const handle = await this.runPhase(context, "starting the device", () =>
-      this.dependencies.deviceManager.startDevice(
+    const handle = await this.runPhase(context, "starting the device", async signal => {
+      const started = await this.dependencies.deviceManager.startDevice(
         image,
         this.remaining(context.deadlineMs, "starting the device"),
-      ),
-    );
+      );
+      if (signal.aborted && started) {
+        started.kill();
+      }
+      return started;
+    });
     await progress?.report(60, 100, "Device started, waiting for readiness...");
-    const ready = await this.runPhase(context, "waiting for device boot readiness", () =>
+    const ready = await this.runPhase(context, "waiting for device boot readiness", signal =>
       waitForDeviceReadyOrCancel(
         this.dependencies.deviceManager,
         image,
         handle,
         this.remaining(context.deadlineMs, "waiting for device boot readiness"),
+        signal,
       ),
     );
     await progress?.report(100, 100, "Device is ready for use");
@@ -312,6 +351,8 @@ export class DeviceBootService {
     phase: string,
     operation: (signal: AbortSignal) => Promise<T>,
   ): Promise<T> {
+    const cancellation = createPhaseCancellation(context.signal, phase);
+    cancellation.throwIfCancelled();
     const remainingMs = this.remaining(context.deadlineMs, phase);
     const controller = new AbortController();
     const signal = context.signal
@@ -333,8 +374,10 @@ export class DeviceBootService {
             );
           }, remainingMs);
         }),
+        cancellation.promise,
       ]);
     } catch (error) {
+      cancellation.throwIfCancelled();
       if (controller.signal.aborted) {
         await this.awaitAbortSettlement(operationPromise);
         throw new ActionableError(
@@ -346,6 +389,7 @@ export class DeviceBootService {
       if (timeoutHandle) {
         this.timer.clearTimeout(timeoutHandle);
       }
+      cancellation.dispose();
     }
   }
 

--- a/src/utils/deviceUtils.ts
+++ b/src/utils/deviceUtils.ts
@@ -97,6 +97,38 @@ export interface PlatformDeviceManager {
   waitForDeviceReady(device: DeviceInfo, timeoutMs?: number, childProcess?: ChildProcess | null): Promise<BootedDevice>;
 }
 
+interface ReadinessCancellation {
+  promise: Promise<never>;
+  throwIfCancelled(): void;
+  dispose(): void;
+}
+
+function createReadinessCancellation(signal: AbortSignal | undefined): ReadinessCancellation {
+  const never = new Promise<never>(() => undefined);
+  const throwIfCancelled = () => {
+    if (signal?.aborted) {
+      throw new ActionableError("Device readiness was cancelled.");
+    }
+  };
+  if (!signal || signal.aborted) {
+    return { promise: never, throwIfCancelled, dispose: () => {} };
+  }
+
+  let rejectCancellation!: (error: ActionableError) => void;
+  const promise = new Promise<never>((_resolve, reject) => {
+    rejectCancellation = reject;
+  });
+  const abort = () => {
+    rejectCancellation(new ActionableError("Device readiness was cancelled."));
+  };
+  signal.addEventListener("abort", abort, { once: true });
+  return {
+    promise,
+    throwIfCancelled,
+    dispose: () => signal.removeEventListener("abort", abort),
+  };
+}
+
 /**
  * Wait for a freshly-started device to become ready, actively cancelling the
  * boot if readiness fails (issue #3952).
@@ -116,6 +148,7 @@ export interface PlatformDeviceManager {
  * @param device - The device that was started
  * @param handle - The start handle from `startDevice` (null for adopted devices)
  * @param timeoutMs - Optional readiness timeout
+ * @param signal - Optional cancellation signal for a non-cooperative readiness wait
  * @returns The booted device once ready
  * @throws Re-throws the original readiness error after cancelling the boot
  */
@@ -124,9 +157,13 @@ export async function waitForDeviceReadyOrCancel(
   device: DeviceInfo,
   handle: ChildProcess | null,
   timeoutMs?: number,
+  signal?: AbortSignal,
 ): Promise<BootedDevice> {
+  const cancellation = createReadinessCancellation(signal);
   try {
-    return await deviceManager.waitForDeviceReady(device, timeoutMs, handle);
+    cancellation.throwIfCancelled();
+    const readiness = deviceManager.waitForDeviceReady(device, timeoutMs, handle);
+    return await Promise.race([readiness, cancellation.promise]);
   } catch (error) {
     if (handle) {
       logger.warn(
@@ -137,6 +174,8 @@ export async function waitForDeviceReadyOrCancel(
       handle.kill();
     }
     throw error;
+  } finally {
+    cancellation.dispose();
   }
 }
 

--- a/src/utils/deviceUtils.ts
+++ b/src/utils/deviceUtils.ts
@@ -149,6 +149,7 @@ function createReadinessCancellation(signal: AbortSignal | undefined): Readiness
  * @param handle - The start handle from `startDevice` (null for adopted devices)
  * @param timeoutMs - Optional readiness timeout
  * @param signal - Optional cancellation signal for a non-cooperative readiness wait
+ * @param cancelOwnedBoot - Optional idempotent cleanup for the owned launch handle
  * @returns The booted device once ready
  * @throws Re-throws the original readiness error after cancelling the boot
  */
@@ -158,6 +159,7 @@ export async function waitForDeviceReadyOrCancel(
   handle: ChildProcess | null,
   timeoutMs?: number,
   signal?: AbortSignal,
+  cancelOwnedBoot?: () => void,
 ): Promise<BootedDevice> {
   const cancellation = createReadinessCancellation(signal);
   try {
@@ -171,7 +173,7 @@ export async function waitForDeviceReadyOrCancel(
         `cancelling boot via handle.kill()`,
         error,
       );
-      handle.kill();
+      (cancelOwnedBoot ?? (() => handle.kill()))();
     }
     throw error;
   } finally {

--- a/test/server/deviceTools.startDevice.test.ts
+++ b/test/server/deviceTools.startDevice.test.ts
@@ -72,10 +72,13 @@ describe("startDevice handler", () => {
     daemonSessionManager?.stopCleanupTimer();
   });
 
-  async function callStartDevice(args: Record<string, unknown>): Promise<Record<string, unknown>> {
+  async function callStartDevice(
+    args: Record<string, unknown>,
+    signal?: AbortSignal,
+  ): Promise<Record<string, unknown>> {
     const tool = ToolRegistry.getTool("startDevice");
     if (!tool) {throw new Error("startDevice not registered");}
-    const result = await tool.handler(args);
+    const result = await tool.handler(args, undefined, signal);
     return JSON.parse(typeof result === "string" ? result : (result as any).content?.[0]?.text ?? "{}");
   }
 
@@ -122,6 +125,47 @@ describe("startDevice handler", () => {
     expect(result.osVersion).toBe("14");
     expect(result.sessionId).toBeDefined();
     expect(typeof result.sessionId).toBe("string");
+  });
+
+  it("does not reach runner readiness or session binding after an externally cancelled boot", async () => {
+    const controller = new AbortController();
+    let resolveImages!: (images: DeviceInfo[]) => void;
+    let markImageListingStarted!: () => void;
+    const imageListingStarted = new Promise<void>(resolve => {
+      markImageListingStarted = resolve;
+    });
+    const pendingImages = new Promise<DeviceInfo[]>(resolve => {
+      resolveImages = resolve;
+    });
+    let runnerReadinessCalls = 0;
+    let sessionIdCalls = 0;
+    fakeDeviceUtils.listDeviceImages = async () => {
+      markImageListingStarted();
+      return pendingImages;
+    };
+    setDeviceToolsDependencies({
+      ensureCtrlProxyReady: async () => {
+        runnerReadinessCalls++;
+      },
+      idGenerator: {
+        next: () => {
+          sessionIdCalls++;
+          return `session-${sessionIdCalls}`;
+        },
+      },
+    });
+    registerDeviceTools();
+
+    const start = callStartDevice({ platform: "android" }, controller.signal);
+    await imageListingStarted;
+    controller.abort();
+
+    await expect(start).rejects.toThrow("startDevice cancelled while listing device images");
+    resolveImages([androidImage]);
+    await Promise.resolve();
+
+    expect(runnerReadinessCalls).toBe(0);
+    expect(sessionIdCalls).toBe(0);
   });
 
   it("sources the fallback sessionId from the injected IdGenerator", async () => {

--- a/test/server/deviceTools.startDevice.test.ts
+++ b/test/server/deviceTools.startDevice.test.ts
@@ -1,7 +1,12 @@
 import { describe, it, expect, beforeEach, afterEach } from "bun:test";
 import type { ChildProcess } from "child_process";
 import { EventEmitter } from "node:events";
-import { setDeviceToolsDependencies, resetDeviceToolsDependencies, registerDeviceTools, startDeviceSchema } from "../../src/server/deviceTools";
+import {
+  setDeviceToolsDependencies,
+  resetDeviceToolsDependencies,
+  registerDeviceTools,
+  startDeviceSchema,
+} from "../../src/server/deviceTools";
 import { FakeDeviceUtils } from "../fakes/FakeDeviceUtils";
 import { FakeDeviceMatcher } from "../fakes/FakeDeviceMatcher";
 import { ToolRegistry } from "../../src/server/toolRegistry";
@@ -77,11 +82,16 @@ describe("startDevice handler", () => {
   async function callStartDevice(
     args: Record<string, unknown>,
     signal?: AbortSignal,
+    progress?: (current: number, total: number, message: string) => Promise<void>,
   ): Promise<Record<string, unknown>> {
     const tool = ToolRegistry.getTool("startDevice");
-    if (!tool) {throw new Error("startDevice not registered");}
-    const result = await tool.handler(args, undefined, signal);
-    return JSON.parse(typeof result === "string" ? result : (result as any).content?.[0]?.text ?? "{}");
+    if (!tool) {
+      throw new Error("startDevice not registered");
+    }
+    const result = await tool.handler(args, progress, signal);
+    return JSON.parse(
+      typeof result === "string" ? result : ((result as any).content?.[0]?.text ?? "{}"),
+    );
   }
 
   const androidDevice: BootedDevice = {
@@ -133,10 +143,10 @@ describe("startDevice handler", () => {
     const controller = new AbortController();
     let resolveImages!: (images: DeviceInfo[]) => void;
     let markImageListingStarted!: () => void;
-    const imageListingStarted = new Promise<void>(resolve => {
+    const imageListingStarted = new Promise<void>((resolve) => {
       markImageListingStarted = resolve;
     });
-    const pendingImages = new Promise<DeviceInfo[]>(resolve => {
+    const pendingImages = new Promise<DeviceInfo[]>((resolve) => {
       resolveImages = resolve;
     });
     let runnerReadinessCalls = 0;
@@ -168,6 +178,61 @@ describe("startDevice handler", () => {
 
     expect(runnerReadinessCalls).toBe(0);
     expect(sessionIdCalls).toBe(0);
+  });
+
+  it("does not bind a session after cancellation during final boot progress", async () => {
+    const controller = new AbortController();
+    let markFinalProgressStarted!: () => void;
+    let resolveFinalProgress!: () => void;
+    const finalProgressStarted = new Promise<void>((resolve) => {
+      markFinalProgressStarted = resolve;
+    });
+    const pendingFinalProgress = new Promise<void>((resolve) => {
+      resolveFinalProgress = resolve;
+    });
+    let runnerReadinessCalls = 0;
+    let sessionIdCalls = 0;
+    let killed = false;
+    fakeDeviceUtils.setDeviceImages("android", [androidImage]);
+    fakeMatcher.setImageResult(androidImage);
+    fakeDeviceUtils.setMockChildProcess(androidImage.name, {
+      pid: 4242,
+      kill: () => {
+        killed = true;
+        return true;
+      },
+    } as ChildProcess);
+    setDeviceToolsDependencies({
+      ensureCtrlProxyReady: async () => {
+        runnerReadinessCalls++;
+      },
+      idGenerator: {
+        next: () => {
+          sessionIdCalls++;
+          return `session-${sessionIdCalls}`;
+        },
+      },
+    });
+    registerDeviceTools();
+
+    const start = callStartDevice({ platform: "android" }, controller.signal, async (current) => {
+      if (current === 100) {
+        markFinalProgressStarted();
+        await pendingFinalProgress;
+      }
+    });
+    await finalProgressStarted;
+    controller.abort();
+
+    await expect(start).rejects.toThrow(
+      "startDevice cancelled while reporting device readiness progress",
+    );
+    resolveFinalProgress();
+    await Promise.resolve();
+
+    expect(runnerReadinessCalls).toBe(0);
+    expect(sessionIdCalls).toBe(0);
+    expect(killed).toBe(true);
   });
 
   it("sources the fallback sessionId from the injected IdGenerator", async () => {
@@ -206,7 +271,9 @@ describe("startDevice handler", () => {
     const original = process.env.AUTOMOBILE_CTRL_PROXY_IOS_BUNDLE_PATH;
     process.env.AUTOMOBILE_CTRL_PROXY_IOS_BUNDLE_PATH = os.tmpdir(); // a directory
     try {
-      await expect(callStartDevice({ platform: "ios" })).rejects.toThrow(/BUNDLE_PATH.*unusable|directory|runnable .ipa/);
+      await expect(callStartDevice({ platform: "ios" })).rejects.toThrow(
+        /BUNDLE_PATH.*unusable|directory|runnable .ipa/,
+      );
     } finally {
       if (original === undefined) {
         delete process.env.AUTOMOBILE_CTRL_PROXY_IOS_BUNDLE_PATH;
@@ -247,9 +314,7 @@ describe("startDevice handler", () => {
       "AUTOMOBILE_ANDROID_REBOOT_ON_DEATH",
       "AUTO_MOBILE_ANDROID_REBOOT_ON_DEATH",
     ] as const;
-    const originalRecoveryEnv = new Map(
-      recoveryKeys.map(key => [key, process.env[key]])
-    );
+    const originalRecoveryEnv = new Map(recoveryKeys.map((key) => [key, process.env[key]]));
     for (const key of recoveryKeys) {
       delete process.env[key];
     }
@@ -261,7 +326,7 @@ describe("startDevice handler", () => {
       "daemon-session",
       timer,
       undefined,
-      fakeDeviceUtils
+      fakeDeviceUtils,
     );
     DaemonState.getInstance().initialize(daemonSessionManager, pool);
 
@@ -270,7 +335,7 @@ describe("startDevice handler", () => {
     fakeDeviceUtils.setDeviceImages("android", [coldBootImage]);
     fakeDeviceUtils.setMockChildProcess(
       coldBootImage.name,
-      childProcess as unknown as ChildProcess
+      childProcess as unknown as ChildProcess,
     );
     fakeMatcher.setBootedResult(null);
     fakeMatcher.setImageResult(coldBootImage);
@@ -280,8 +345,8 @@ describe("startDevice handler", () => {
       expect(daemonSessionManager.getSession(result.sessionId as string)).not.toBeNull();
 
       childProcess.emit("exit", 1, null);
-      await new Promise(resolve => setImmediate(resolve));
-      await new Promise(resolve => setImmediate(resolve));
+      await new Promise((resolve) => setImmediate(resolve));
+      await new Promise((resolve) => setImmediate(resolve));
 
       expect(daemonSessionManager.getSession(result.sessionId as string)).toBeNull();
       expect(pool.getDevice(androidDevice.deviceId)).toBeNull();
@@ -311,7 +376,7 @@ describe("startDevice handler", () => {
       undefined,
       undefined,
       undefined,
-      deviceId => readyDeviceIds.push(deviceId)
+      (deviceId) => readyDeviceIds.push(deviceId),
     );
     DaemonState.getInstance().initialize(daemonSessionManager, pool);
 
@@ -321,11 +386,11 @@ describe("startDevice handler", () => {
     fakeMatcher.setImageResult(coldBootImage);
 
     let releaseResources!: () => void;
-    const resourcesStarted = new Promise<void>(resolve => {
+    const resourcesStarted = new Promise<void>((resolve) => {
       releaseResources = resolve;
     });
     let signalResourcesStarted!: () => void;
-    const waitForResources = new Promise<void>(resolve => {
+    const waitForResources = new Promise<void>((resolve) => {
       signalResourcesStarted = resolve;
     });
     setDeviceToolsDependencies({
@@ -454,7 +519,10 @@ describe("startDevice handler", () => {
     // mid-boot (issue #3952).
     let killed = false;
     fakeDeviceUtils.setMockChildProcess(androidImage.name, {
-      kill: (): boolean => { killed = true; return true; },
+      kill: (): boolean => {
+        killed = true;
+        return true;
+      },
       pid: 4242,
     } as any);
     fakeDeviceUtils.setWaitForDeviceReadyError(new Error("readiness timeout"));
@@ -497,9 +565,7 @@ describe("startDevice handler", () => {
     });
     registerDeviceTools();
 
-    await expect(callStartDevice({ platform: "android" })).rejects.toThrow(
-      "runner unavailable",
-    );
+    await expect(callStartDevice({ platform: "android" })).rejects.toThrow("runner unavailable");
     expect(killed).toBe(true);
   });
 
@@ -624,13 +690,15 @@ describe("startDevice handler", () => {
 
   it("passes timeout to the cold boot start operation", async () => {
     fakeDeviceUtils.setBootedDevices("ios", []);
-    fakeDeviceUtils.setDeviceImages("ios", [{
-      name: "iPhone 15",
-      platform: "ios",
-      deviceId: "ABCD-1234",
-      isRunning: false,
-      osVersion: "17.2",
-    }]);
+    fakeDeviceUtils.setDeviceImages("ios", [
+      {
+        name: "iPhone 15",
+        platform: "ios",
+        deviceId: "ABCD-1234",
+        isRunning: false,
+        osVersion: "17.2",
+      },
+    ]);
     fakeMatcher.setBootedResult(null);
     fakeMatcher.setImageResult({
       name: "iPhone 15",
@@ -643,12 +711,8 @@ describe("startDevice handler", () => {
     const result = await callStartDevice({ platform: "ios", timeoutMs: 30_000 });
 
     expect(result.source).toBe("cold-boot");
-    expect(fakeDeviceUtils.getExecutedOperations()).toContain(
-      "startDevice:iPhone 15:30000",
-    );
-    expect(fakeDeviceUtils.getExecutedOperations()).toContain(
-      "waitForDeviceReady:iPhone 15:30000",
-    );
+    expect(fakeDeviceUtils.getExecutedOperations()).toContain("startDevice:iPhone 15:30000");
+    expect(fakeDeviceUtils.getExecutedOperations()).toContain("waitForDeviceReady:iPhone 15:30000");
   });
 
   it("passes the default timeout to cold boot when timeout is omitted", async () => {
@@ -698,9 +762,7 @@ describe("startDevice handler", () => {
 
     expect(result.deviceId).toBe("ABCD-1234");
     expect(result.source).toBe("booted");
-    expect(fakeDeviceUtils.getExecutedOperations()).toContain(
-      "waitForDeviceReady:iPhone 15:30000",
-    );
+    expect(fakeDeviceUtils.getExecutedOperations()).toContain("waitForDeviceReady:iPhone 15:30000");
   });
 
   it("rejects a running-device identity mismatch before runner readiness", async () => {
@@ -710,10 +772,12 @@ describe("startDevice handler", () => {
       deviceId: "emulator-5556",
     });
 
-    await expect(callStartDevice({
-      platform: "android",
-      deviceId: "emulator-5554",
-    })).rejects.toThrow(/requested=.*emulator-5554.*resolved=.*emulator-5556/);
+    await expect(
+      callStartDevice({
+        platform: "android",
+        deviceId: "emulator-5554",
+      }),
+    ).rejects.toThrow(/requested=.*emulator-5554.*resolved=.*emulator-5556/);
   });
 
   it("rejects an iOS cold-boot UDID mismatch before binding a session", async () => {
@@ -731,10 +795,12 @@ describe("startDevice handler", () => {
       deviceId: "OTHER-UDID",
     });
 
-    await expect(callStartDevice({
-      platform: "ios",
-      deviceId: "REQUESTED-UDID",
-    })).rejects.toThrow(/phase=pool-match.*UDID differs/);
+    await expect(
+      callStartDevice({
+        platform: "ios",
+        deviceId: "REQUESTED-UDID",
+      }),
+    ).rejects.toThrow(/phase=pool-match.*UDID differs/);
   });
 
   it("passes the request runner budget and shared total deadline to readiness", async () => {
@@ -747,7 +813,7 @@ describe("startDevice handler", () => {
     timer.advanceTime(1_000);
     setDeviceToolsDependencies({
       timer,
-      ensureCtrlProxyReady: async request => {
+      ensureCtrlProxyReady: async (request) => {
         readinessRequests.push(request);
       },
     });
@@ -762,11 +828,13 @@ describe("startDevice handler", () => {
       runnerReadinessTimeoutMs: 15_000,
     });
 
-    expect(readinessRequests).toEqual([expect.objectContaining({
-      totalDeadlineMs: 61_000,
-      readinessTimeoutMs: 15_000,
-      requestedIdentity: "platform=android deviceId=emulator-5554",
-    })]);
+    expect(readinessRequests).toEqual([
+      expect.objectContaining({
+        totalDeadlineMs: 61_000,
+        readinessTimeoutMs: 15_000,
+        requestedIdentity: "platform=android deviceId=emulator-5554",
+      }),
+    ]);
   });
 
   it("uses an explicit total timeout for readiness when no phase override is supplied", async () => {
@@ -778,7 +846,7 @@ describe("startDevice handler", () => {
     timer.advanceTime(1_000);
     setDeviceToolsDependencies({
       timer,
-      ensureCtrlProxyReady: async request => {
+      ensureCtrlProxyReady: async (request) => {
         readinessRequests.push(request);
       },
     });
@@ -792,10 +860,12 @@ describe("startDevice handler", () => {
       timeoutMs: 300_000,
     });
 
-    expect(readinessRequests).toEqual([expect.objectContaining({
-      totalDeadlineMs: 301_000,
-      readinessTimeoutMs: 300_000,
-    })]);
+    expect(readinessRequests).toEqual([
+      expect.objectContaining({
+        totalDeadlineMs: 301_000,
+        readinessTimeoutMs: 300_000,
+      }),
+    ]);
   });
 
   it("boots image when deviceId matches an image name", async () => {
@@ -815,9 +885,9 @@ describe("startDevice handler", () => {
     fakeDeviceUtils.setBootedDevices("android", []);
     fakeDeviceUtils.setDeviceImages("android", []);
 
-    await expect(
-      callStartDevice({ platform: "android", deviceId: "nonexistent" })
-    ).rejects.toThrow(/not found/);
+    await expect(callStartDevice({ platform: "android", deviceId: "nonexistent" })).rejects.toThrow(
+      /not found/,
+    );
   });
 
   it("throws when no device matches criteria", async () => {
@@ -826,9 +896,9 @@ describe("startDevice handler", () => {
     fakeMatcher.setBootedResult(null);
     fakeMatcher.setImageResult(null);
 
-    await expect(
-      callStartDevice({ platform: "android", minOsVersion: "99" })
-    ).rejects.toThrow(/No android device matching criteria/);
+    await expect(callStartDevice({ platform: "android", minOsVersion: "99" })).rejects.toThrow(
+      /No android device matching criteria/,
+    );
   });
 
   it("skips booted devices when preferRunning is false", async () => {
@@ -901,9 +971,7 @@ describe("startDevice handler", () => {
     fakeMatcher.setBootedResult(null);
     fakeMatcher.setImageResult(iosImageNoId);
 
-    await expect(
-      callStartDevice({ platform: "ios" })
-    ).rejects.toThrow(/UDID/);
+    await expect(callStartDevice({ platform: "ios" })).rejects.toThrow(/UDID/);
   });
 
   it("accepts legacy nested device payloads", async () => {
@@ -935,18 +1003,24 @@ describe("startDevice handler", () => {
   });
 
   it("bounds runner readiness timeout overrides", () => {
-    expect(() => startDeviceSchema.parse({
-      platform: "android",
-      runnerReadinessTimeoutMs: MIN_RUNNER_READINESS_TIMEOUT_MS - 1,
-    })).toThrow();
-    expect(() => startDeviceSchema.parse({
-      platform: "android",
-      runnerReadinessTimeoutMs: MAX_RUNNER_READINESS_TIMEOUT_MS + 1,
-    })).toThrow();
-    expect(() => startDeviceSchema.parse({
-      platform: "android",
-      timeoutMs: MAX_DEVICE_READY_TIMEOUT_MS + 1,
-    })).toThrow();
+    expect(() =>
+      startDeviceSchema.parse({
+        platform: "android",
+        runnerReadinessTimeoutMs: MIN_RUNNER_READINESS_TIMEOUT_MS - 1,
+      }),
+    ).toThrow();
+    expect(() =>
+      startDeviceSchema.parse({
+        platform: "android",
+        runnerReadinessTimeoutMs: MAX_RUNNER_READINESS_TIMEOUT_MS + 1,
+      }),
+    ).toThrow();
+    expect(() =>
+      startDeviceSchema.parse({
+        platform: "android",
+        timeoutMs: MAX_DEVICE_READY_TIMEOUT_MS + 1,
+      }),
+    ).toThrow();
   });
 
   it("prefers deviceId over name when enriching booted device metadata", async () => {
@@ -988,7 +1062,13 @@ describe("startDevice handler", () => {
     process.env.AUTOMOBILE_DEVICE_POOL_AUTOLOCK = "1";
     const timer = new FakeTimer();
     daemonSessionManager = new SessionManager(timer, new FakeDeviceSessionPersistence());
-    const pool = new DevicePool(daemonSessionManager, "daemon-session", timer, undefined, fakeDeviceUtils);
+    const pool = new DevicePool(
+      daemonSessionManager,
+      "daemon-session",
+      timer,
+      undefined,
+      fakeDeviceUtils,
+    );
     await pool.initializeWithDevices([androidDevice]);
     DaemonState.getInstance().initialize(daemonSessionManager, pool);
 
@@ -1001,7 +1081,9 @@ describe("startDevice handler", () => {
     });
 
     expect(typeof result.sessionId).toBe("string");
-    expect(pool.resolveAutolockSessionForMcpSession("mcp-session-1", "android")).toBe(result.sessionId);
+    expect(pool.resolveAutolockSessionForMcpSession("mcp-session-1", "android")).toBe(
+      result.sessionId,
+    );
   });
 
   it("rejects stale pooled platform metadata before session binding", async () => {
@@ -1014,18 +1096,22 @@ describe("startDevice handler", () => {
       undefined,
       fakeDeviceUtils,
     );
-    await pool.initializeWithDevices([{
-      ...iosDevice,
-      deviceId: androidDevice.deviceId,
-    }]);
+    await pool.initializeWithDevices([
+      {
+        ...iosDevice,
+        deviceId: androidDevice.deviceId,
+      },
+    ]);
     DaemonState.getInstance().initialize(daemonSessionManager, pool);
     fakeDeviceUtils.setBootedDevices("android", [androidDevice]);
     fakeMatcher.setBootedResult(androidDevice);
 
-    await expect(callStartDevice({
-      platform: "android",
-      deviceId: androidDevice.deviceId,
-    })).rejects.toThrow(/phase=pool-match.*stale pool identity conflicts/);
+    await expect(
+      callStartDevice({
+        platform: "android",
+        deviceId: androidDevice.deviceId,
+      }),
+    ).rejects.toThrow(/phase=pool-match.*stale pool identity conflicts/);
     expect(pool.getDevice(androidDevice.deviceId)?.sessionId).toBeNull();
   });
 
@@ -1039,34 +1125,42 @@ describe("startDevice handler", () => {
       undefined,
       fakeDeviceUtils,
     );
-    fakeDeviceUtils.setBootedDevices("android", [{
-      ...androidDevice,
-      name: "Old_Pixel_AVD",
-    }]);
-    await pool.initializeWithDevices([{
-      ...androidDevice,
-      name: "Old_Pixel_AVD",
-    }]);
-    await pool.bindOrReuseDeviceSession(
-      "stale-session",
-      androidDevice.deviceId,
-      "android",
-    );
+    fakeDeviceUtils.setBootedDevices("android", [
+      {
+        ...androidDevice,
+        name: "Old_Pixel_AVD",
+      },
+    ]);
+    await pool.initializeWithDevices([
+      {
+        ...androidDevice,
+        name: "Old_Pixel_AVD",
+      },
+    ]);
+    await pool.bindOrReuseDeviceSession("stale-session", androidDevice.deviceId, "android");
     DaemonState.getInstance().initialize(daemonSessionManager, pool);
     fakeDeviceUtils.setBootedDevices("android", [androidDevice]);
     fakeMatcher.setBootedResult(androidDevice);
 
-    await expect(callStartDevice({
-      platform: "android",
-      deviceId: androidDevice.deviceId,
-    })).rejects.toThrow(/phase=pool-match.*stale pool identity conflicts/);
+    await expect(
+      callStartDevice({
+        platform: "android",
+        deviceId: androidDevice.deviceId,
+      }),
+    ).rejects.toThrow(/phase=pool-match.*stale pool identity conflicts/);
     expect(pool.getDevice(androidDevice.deviceId)?.sessionId).toBe("stale-session");
   });
 
   it("reuses the returned sessionId for repeated startDevice calls when autolock is disabled", async () => {
     const timer = new FakeTimer();
     daemonSessionManager = new SessionManager(timer, new FakeDeviceSessionPersistence());
-    const pool = new DevicePool(daemonSessionManager, "daemon-session", timer, undefined, fakeDeviceUtils);
+    const pool = new DevicePool(
+      daemonSessionManager,
+      "daemon-session",
+      timer,
+      undefined,
+      fakeDeviceUtils,
+    );
     await pool.initializeWithDevices([iosDevice]);
     DaemonState.getInstance().initialize(daemonSessionManager, pool);
 

--- a/test/utils/deviceBootRecovery.test.ts
+++ b/test/utils/deviceBootRecovery.test.ts
@@ -41,10 +41,10 @@ describe("CiIosBootRecovery", () => {
     const controller = new AbortController();
     let markShutdownStarted!: () => void;
     let releaseShutdown!: () => void;
-    const shutdownStarted = new Promise<void>(resolve => {
+    const shutdownStarted = new Promise<void>((resolve) => {
       markShutdownStarted = resolve;
     });
-    const pendingShutdown = new Promise<void>(resolve => {
+    const pendingShutdown = new Promise<void>((resolve) => {
       releaseShutdown = () => {
         resolve();
       };
@@ -72,10 +72,60 @@ describe("CiIosBootRecovery", () => {
     );
     await shutdownStarted;
     controller.abort();
-    releaseShutdown();
 
-    await expect(boot).rejects.toThrow("boot failed");
+    await expect(boot).rejects.toThrow(
+      "startDevice cancelled while recovering the CI iOS simulator",
+    );
     expect(recovered).toEqual([]);
     expect(bootAttempts).toBe(1);
+
+    releaseShutdown();
+    await Promise.resolve();
+    expect(recovered).toEqual([]);
+  });
+
+  it("reports cancellation rather than the first failure during the recovery retry", async () => {
+    const controller = new AbortController();
+    let markRetryStarted!: () => void;
+    let rejectRetry!: (error: unknown) => void;
+    const retryStarted = new Promise<void>((resolve) => {
+      markRetryStarted = resolve;
+    });
+    const pendingRetry = new Promise<string>((_resolve, reject) => {
+      rejectRetry = reject;
+    });
+    const recovered: string[] = [];
+    let bootAttempts = 0;
+    const recovery = new CiIosBootRecovery({
+      ownedSimulatorName: target.name,
+      shutdown: async () => {
+        recovered.push("shutdown");
+      },
+      erase: async () => {
+        recovered.push("erase");
+      },
+    });
+
+    const boot = recovery.run(
+      target,
+      async () => {
+        bootAttempts++;
+        if (bootAttempts === 1) {
+          throw new Error("first boot failed");
+        }
+        markRetryStarted();
+        return pendingRetry;
+      },
+      controller.signal,
+    );
+    await retryStarted;
+    controller.abort();
+    rejectRetry(controller.signal.reason);
+
+    await expect(boot).rejects.toThrow(
+      "startDevice cancelled while recovering the CI iOS simulator",
+    );
+    expect(recovered).toEqual(["shutdown", "erase"]);
+    expect(bootAttempts).toBe(2);
   });
 });

--- a/test/utils/deviceBootRecovery.test.ts
+++ b/test/utils/deviceBootRecovery.test.ts
@@ -1,0 +1,39 @@
+import { describe, expect, it } from "bun:test";
+import { CiIosBootRecovery } from "../../src/utils/deviceBootRecovery";
+import type { DeviceInfo } from "../../src/models";
+
+describe("CiIosBootRecovery", () => {
+  const target: DeviceInfo = {
+    name: "AutoMobile CI iPhone",
+    platform: "ios",
+    deviceId: "CI-UDID",
+    isRunning: false,
+  };
+
+  it("does not recover an owned simulator after cancellation", async () => {
+    const controller = new AbortController();
+    const recovered: string[] = [];
+    const recovery = new CiIosBootRecovery({
+      ownedSimulatorName: target.name,
+      shutdown: async () => {
+        recovered.push("shutdown");
+      },
+      erase: async () => {
+        recovered.push("erase");
+      },
+    });
+    controller.abort();
+
+    await expect(
+      recovery.run(
+        target,
+        async () => {
+          throw new Error("cancelled boot");
+        },
+        controller.signal,
+      ),
+    ).rejects.toThrow("cancelled boot");
+
+    expect(recovered).toEqual([]);
+  });
+});

--- a/test/utils/deviceBootRecovery.test.ts
+++ b/test/utils/deviceBootRecovery.test.ts
@@ -36,4 +36,46 @@ describe("CiIosBootRecovery", () => {
 
     expect(recovered).toEqual([]);
   });
+
+  it("stops recovery when cancellation arrives during shutdown", async () => {
+    const controller = new AbortController();
+    let markShutdownStarted!: () => void;
+    let releaseShutdown!: () => void;
+    const shutdownStarted = new Promise<void>(resolve => {
+      markShutdownStarted = resolve;
+    });
+    const pendingShutdown = new Promise<void>(resolve => {
+      releaseShutdown = () => {
+        resolve();
+      };
+    });
+    let bootAttempts = 0;
+    const recovered: string[] = [];
+    const recovery = new CiIosBootRecovery({
+      ownedSimulatorName: target.name,
+      shutdown: async () => {
+        markShutdownStarted();
+        await pendingShutdown;
+      },
+      erase: async () => {
+        recovered.push("erase");
+      },
+    });
+
+    const boot = recovery.run(
+      target,
+      async () => {
+        bootAttempts++;
+        throw new Error("boot failed");
+      },
+      controller.signal,
+    );
+    await shutdownStarted;
+    controller.abort();
+    releaseShutdown();
+
+    await expect(boot).rejects.toThrow("boot failed");
+    expect(recovered).toEqual([]);
+    expect(bootAttempts).toBe(1);
+  });
 });

--- a/test/utils/deviceBootService.test.ts
+++ b/test/utils/deviceBootService.test.ts
@@ -1,6 +1,6 @@
 import type { ChildProcess } from "node:child_process";
 import { describe, expect, it } from "bun:test";
-import { DeviceBootService } from "../../src/utils/deviceBootService";
+import { DeviceBootService, type DeviceBootProgress } from "../../src/utils/deviceBootService";
 import { FakeDeviceMatcher } from "../fakes/FakeDeviceMatcher";
 import { FakeDeviceUtils } from "../fakes/FakeDeviceUtils";
 import type { BootedDevice, DeviceInfo } from "../../src/models";
@@ -203,6 +203,45 @@ describe("DeviceBootService", () => {
     await Promise.resolve();
     await Promise.resolve();
 
+    expect(killCount).toBe(1);
+    expect(devices.wasMethodCalled("waitForDeviceReady")).toBe(false);
+  });
+
+  it("cancels a started handle when external cancellation lands during progress reporting", async () => {
+    const devices = new FakeDeviceUtils();
+    const matcher = new FakeDeviceMatcher();
+    const controller = new AbortController();
+    let resolveProgress!: () => void;
+    let markProgressStarted!: () => void;
+    const progressStarted = new Promise<void>(resolve => {
+      markProgressStarted = resolve;
+    });
+    const pendingProgress = new Promise<void>(resolve => {
+      resolveProgress = resolve;
+    });
+    let killCount = 0;
+    const progress: DeviceBootProgress = {
+      report: async () => {
+        markProgressStarted();
+        await pendingProgress;
+      },
+    };
+    devices.setDeviceImages("android", [image]);
+    matcher.setImageResult(image);
+    devices.setMockChildProcess(image.name, {
+      pid: 12,
+      kill: () => {
+        killCount++;
+        return true;
+      },
+    } as ChildProcess);
+
+    const boot = service(devices, matcher).boot({ platform: "android", signal: controller.signal }, progress);
+    await progressStarted;
+    controller.abort();
+    resolveProgress();
+
+    await expect(boot).rejects.toThrow("startDevice cancelled while waiting for device boot readiness");
     expect(killCount).toBe(1);
     expect(devices.wasMethodCalled("waitForDeviceReady")).toBe(false);
   });

--- a/test/utils/deviceBootService.test.ts
+++ b/test/utils/deviceBootService.test.ts
@@ -1,8 +1,9 @@
+import type { ChildProcess } from "node:child_process";
 import { describe, expect, it } from "bun:test";
 import { DeviceBootService } from "../../src/utils/deviceBootService";
 import { FakeDeviceMatcher } from "../fakes/FakeDeviceMatcher";
 import { FakeDeviceUtils } from "../fakes/FakeDeviceUtils";
-import type { DeviceInfo } from "../../src/models";
+import type { BootedDevice, DeviceInfo } from "../../src/models";
 import type { DeviceMatchCriteria } from "../../src/models/DeviceMatchCriteria";
 import type { DeviceBootRecovery } from "../../src/utils/deviceBootRecovery";
 import type { Timer } from "../../src/utils/SystemTimer";
@@ -128,6 +129,82 @@ describe("DeviceBootService", () => {
     expect(provisionSignal?.aborted).toBe(true);
     expect(provisionSettled).toBe(true);
     expect(created).toBe(false);
+  });
+
+  it("preempts a non-cooperative discovery phase after external cancellation", async () => {
+    const devices = new FakeDeviceUtils();
+    const matcher = new FakeDeviceMatcher();
+    const controller = new AbortController();
+    const running: BootedDevice = {
+      name: image.name,
+      platform: "android",
+      deviceId: "emulator-5554",
+    };
+    let resolveDiscovery!: (devices: BootedDevice[]) => void;
+    let markDiscoveryStarted!: () => void;
+    const discoveryStarted = new Promise<void>(resolve => {
+      markDiscoveryStarted = resolve;
+    });
+    const pendingDiscovery = new Promise<BootedDevice[]>(resolve => {
+      resolveDiscovery = resolve;
+    });
+    devices.setDeviceImages("android", [image]);
+    matcher.setBootedResult(running);
+    devices.getBootedDevices = async () => {
+      markDiscoveryStarted();
+      return pendingDiscovery;
+    };
+
+    const boot = service(devices, matcher).boot({ platform: "android", signal: controller.signal });
+    await discoveryStarted;
+    controller.abort();
+
+    await expect(boot).rejects.toThrow("startDevice cancelled while discovering running devices");
+    resolveDiscovery([running]);
+    await Promise.resolve();
+
+    expect(devices.wasMethodCalled("waitForDeviceReady")).toBe(false);
+    expect(devices.wasMethodCalled("startDevice")).toBe(false);
+  });
+
+  it("cancels a late start handle after external cancellation", async () => {
+    const devices = new FakeDeviceUtils();
+    const matcher = new FakeDeviceMatcher();
+    const controller = new AbortController();
+    let resolveStart!: (handle: ChildProcess | null) => void;
+    let markStartStarted!: () => void;
+    const startStarted = new Promise<void>(resolve => {
+      markStartStarted = resolve;
+    });
+    const pendingStart = new Promise<ChildProcess | null>(resolve => {
+      resolveStart = resolve;
+    });
+    let killCount = 0;
+    const handle = {
+      pid: 12,
+      kill: () => {
+        killCount++;
+        return true;
+      },
+    } as ChildProcess;
+    devices.setDeviceImages("android", [image]);
+    matcher.setImageResult(image);
+    devices.startDevice = async () => {
+      markStartStarted();
+      return pendingStart;
+    };
+
+    const boot = service(devices, matcher).boot({ platform: "android", signal: controller.signal });
+    await startStarted;
+    controller.abort();
+
+    await expect(boot).rejects.toThrow("startDevice cancelled while starting the device");
+    resolveStart(handle);
+    await Promise.resolve();
+    await Promise.resolve();
+
+    expect(killCount).toBe(1);
+    expect(devices.wasMethodCalled("waitForDeviceReady")).toBe(false);
   });
 
   it("adopts and awaits a matching running device", async () => {

--- a/test/utils/deviceBootService.test.ts
+++ b/test/utils/deviceBootService.test.ts
@@ -142,10 +142,10 @@ describe("DeviceBootService", () => {
     };
     let resolveDiscovery!: (devices: BootedDevice[]) => void;
     let markDiscoveryStarted!: () => void;
-    const discoveryStarted = new Promise<void>(resolve => {
+    const discoveryStarted = new Promise<void>((resolve) => {
       markDiscoveryStarted = resolve;
     });
-    const pendingDiscovery = new Promise<BootedDevice[]>(resolve => {
+    const pendingDiscovery = new Promise<BootedDevice[]>((resolve) => {
       resolveDiscovery = resolve;
     });
     devices.setDeviceImages("android", [image]);
@@ -173,10 +173,10 @@ describe("DeviceBootService", () => {
     const controller = new AbortController();
     let resolveStart!: (handle: ChildProcess | null) => void;
     let markStartStarted!: () => void;
-    const startStarted = new Promise<void>(resolve => {
+    const startStarted = new Promise<void>((resolve) => {
       markStartStarted = resolve;
     });
-    const pendingStart = new Promise<ChildProcess | null>(resolve => {
+    const pendingStart = new Promise<ChildProcess | null>((resolve) => {
       resolveStart = resolve;
     });
     let killCount = 0;
@@ -207,16 +207,54 @@ describe("DeviceBootService", () => {
     expect(devices.wasMethodCalled("waitForDeviceReady")).toBe(false);
   });
 
+  it("cancels a resolved start handle when cancellation wins the phase boundary", async () => {
+    const devices = new FakeDeviceUtils();
+    const matcher = new FakeDeviceMatcher();
+    const controller = new AbortController();
+    let resolveStart!: (handle: ChildProcess | null) => void;
+    let markStartStarted!: () => void;
+    const startStarted = new Promise<void>((resolve) => {
+      markStartStarted = resolve;
+    });
+    const pendingStart = new Promise<ChildProcess | null>((resolve) => {
+      resolveStart = resolve;
+    });
+    let killCount = 0;
+    const handle = {
+      pid: 12,
+      kill: () => {
+        killCount++;
+        return true;
+      },
+    } as ChildProcess;
+    devices.setDeviceImages("android", [image]);
+    matcher.setImageResult(image);
+    devices.startDevice = async () => {
+      markStartStarted();
+      return pendingStart;
+    };
+
+    const boot = service(devices, matcher).boot({ platform: "android", signal: controller.signal });
+    await startStarted;
+    resolveStart(handle);
+    queueMicrotask(() => controller.abort());
+
+    await expect(boot).rejects.toThrow("startDevice cancelled while starting the device");
+
+    expect(killCount).toBe(1);
+    expect(devices.wasMethodCalled("waitForDeviceReady")).toBe(false);
+  });
+
   it("cancels a started handle when external cancellation lands during progress reporting", async () => {
     const devices = new FakeDeviceUtils();
     const matcher = new FakeDeviceMatcher();
     const controller = new AbortController();
     let resolveProgress!: () => void;
     let markProgressStarted!: () => void;
-    const progressStarted = new Promise<void>(resolve => {
+    const progressStarted = new Promise<void>((resolve) => {
       markProgressStarted = resolve;
     });
-    const pendingProgress = new Promise<void>(resolve => {
+    const pendingProgress = new Promise<void>((resolve) => {
       resolveProgress = resolve;
     });
     let killCount = 0;
@@ -236,14 +274,66 @@ describe("DeviceBootService", () => {
       },
     } as ChildProcess);
 
-    const boot = service(devices, matcher).boot({ platform: "android", signal: controller.signal }, progress);
+    const boot = service(devices, matcher).boot(
+      { platform: "android", signal: controller.signal },
+      progress,
+    );
     await progressStarted;
     controller.abort();
     resolveProgress();
 
-    await expect(boot).rejects.toThrow("startDevice cancelled while waiting for device boot readiness");
+    await expect(boot).rejects.toThrow(
+      "startDevice cancelled while reporting device start progress",
+    );
     expect(killCount).toBe(1);
     expect(devices.wasMethodCalled("waitForDeviceReady")).toBe(false);
+  });
+
+  it("prevents a final progress callback from returning a cancelled cold boot", async () => {
+    const devices = new FakeDeviceUtils();
+    const matcher = new FakeDeviceMatcher();
+    const controller = new AbortController();
+    let markFinalProgressStarted!: () => void;
+    let resolveFinalProgress!: () => void;
+    const finalProgressStarted = new Promise<void>((resolve) => {
+      markFinalProgressStarted = resolve;
+    });
+    const pendingFinalProgress = new Promise<void>((resolve) => {
+      resolveFinalProgress = resolve;
+    });
+    let killCount = 0;
+    const progress: DeviceBootProgress = {
+      report: async (current) => {
+        if (current === 100) {
+          markFinalProgressStarted();
+          await pendingFinalProgress;
+        }
+      },
+    };
+    devices.setDeviceImages("android", [image]);
+    matcher.setImageResult(image);
+    devices.setMockChildProcess(image.name, {
+      pid: 12,
+      kill: () => {
+        killCount++;
+        return true;
+      },
+    } as ChildProcess);
+
+    const boot = service(devices, matcher).boot(
+      { platform: "android", signal: controller.signal },
+      progress,
+    );
+    await finalProgressStarted;
+    controller.abort();
+
+    await expect(boot).rejects.toThrow(
+      "startDevice cancelled while reporting device readiness progress",
+    );
+    resolveFinalProgress();
+    await Promise.resolve();
+
+    expect(killCount).toBe(1);
   });
 
   it("adopts and awaits a matching running device", async () => {

--- a/test/utils/waitForDeviceReadyOrCancel.test.ts
+++ b/test/utils/waitForDeviceReadyOrCancel.test.ts
@@ -69,4 +69,64 @@ describe("waitForDeviceReadyOrCancel", () => {
       waitForDeviceReadyOrCancel(deviceManager, iosImage, null, 30_000),
     ).rejects.toThrow("readiness timeout");
   });
+
+  it("kills an owned handle when external cancellation preempts non-cooperative readiness", async () => {
+    const deviceManager = new FakeDeviceUtils();
+    const controller = new AbortController();
+    const { handle, killed } = spyHandle();
+    let resolveReadiness!: () => void;
+    const pendingReadiness = new Promise<void>(resolve => {
+      resolveReadiness = resolve;
+    });
+    deviceManager.waitForDeviceReady = async () => {
+      await pendingReadiness;
+      return {
+        name: iosImage.name,
+        platform: "ios",
+        deviceId: iosImage.deviceId!,
+      };
+    };
+
+    const readiness = waitForDeviceReadyOrCancel(
+      deviceManager,
+      iosImage,
+      handle,
+      30_000,
+      controller.signal,
+    );
+    controller.abort();
+
+    await expect(readiness).rejects.toThrow();
+    expect(killed()).toBe(true);
+    resolveReadiness();
+  });
+
+  it("does not touch an adopted device when external cancellation preempts readiness", async () => {
+    const deviceManager = new FakeDeviceUtils();
+    const controller = new AbortController();
+    let resolveReadiness!: () => void;
+    const pendingReadiness = new Promise<void>(resolve => {
+      resolveReadiness = resolve;
+    });
+    deviceManager.waitForDeviceReady = async () => {
+      await pendingReadiness;
+      return {
+        name: iosImage.name,
+        platform: "ios",
+        deviceId: iosImage.deviceId!,
+      };
+    };
+
+    const readiness = waitForDeviceReadyOrCancel(
+      deviceManager,
+      iosImage,
+      null,
+      30_000,
+      controller.signal,
+    );
+    controller.abort();
+
+    await expect(readiness).rejects.toThrow();
+    resolveReadiness();
+  });
 });


### PR DESCRIPTION
## Summary
- Race external cancellation against every device boot phase, including non-cooperative dependencies.
- Cancel late-owned launch handles and preserve adopted devices during readiness cancellation.
- Prevent CI iOS recovery from erase/retry after cancellation, with service, helper, and handler regressions.

## Validation
- `bun test`
- `bun test test/utils/deviceBootService.test.ts test/utils/waitForDeviceReadyOrCancel.test.ts test/utils/deviceBootRecovery.test.ts test/server/deviceTools.startDevice.test.ts`
- `bun run lint`
- `bun run build`
- `bun run typecheck`

## Risk
Cancellation now rejects immediately rather than waiting for a dependency to cooperate; late completion remains observed for cleanup without allowing boot continuation.

Closes https://github.com/kaeawc/auto-mobile/issues/5281

Made with [Cursor](https://cursor.com)