### PR TITLE
fix(daemon): persist emulator loss diagnostics

### DIFF
--- a/src/daemon/daemon.ts
+++ b/src/daemon/daemon.ts
@@ -9,6 +9,7 @@ import { SessionHeartbeatMonitor } from "./SessionHeartbeatMonitor";
 import { SingleFlightInterval } from "./SingleFlightInterval";
 import { DevicePool, type PooledDevice } from "./devicePool";
 import { parseDeviceRecoveryPolicy } from "./poolConfig";
+import { deviceLossCancellationReason } from "./emulatorLossIncident";
 import { DaemonState } from "./daemonState";
 import { DeviceSessionRegistry } from "./deviceSessionRegistry";
 import {
@@ -75,6 +76,7 @@ import { RealObserveScreen } from "../features/observe/ObserveScreen";
 import type { InstalledAppsStore } from "../db/installedAppsRepository";
 import { InstalledAppsRepository } from "../db/installedAppsRepository";
 import { DeviceSessionRepository } from "../db/deviceSessionRepository";
+import { EmulatorLossIncidentRepository } from "../db/emulatorLossIncidentRepository";
 import { DeviceSessionManager } from "../utils/DeviceSessionManager";
 import { startAppearanceSyncScheduler, stopAppearanceSyncScheduler } from "../utils/appearance/AppearanceSyncScheduler";
 import { startPerformanceMonitor, stopPerformanceMonitor, getPerformanceMonitor } from "../features/performance/PerformanceMonitor";
@@ -276,6 +278,7 @@ export class Daemon {
       undefined,
       recoveryConfiguration.policy,
       deviceId => this.deviceSessionRegistry.onDeviceDisconnected(deviceId),
+      new EmulatorLossIncidentRepository(this.timer, this.idGenerator),
     );
     // Initialize singleton for daemon state access
     DaemonState.getInstance().initialize(
@@ -1368,15 +1371,26 @@ export class Daemon {
 
           // Cancel active executions and release the session so the test fails
           // fast instead of waiting for the full MCP request timeout.
+          const incidentId = await this.devicePool.recordEmulatorLossIncident(
+            deviceId,
+            this.forceDisconnectedDeviceIds.has(deviceId)
+              ? "adb-transport-failure"
+              : "device-discovery-miss",
+            undefined,
+            "absent",
+          );
           const sessionId = this.sessionManager.getSessionForDevice(deviceId);
           if (sessionId) {
             logger.warn(
               `[DisconnectMonitor] Device ${deviceId} confirmed disconnected after ${DEVICE_DISCONNECT_MISS_THRESHOLD} consecutive misses — cancelling session ${sessionId}`
             );
-            await this.cancelAndReleaseSession(sessionId, `device-disconnected:${deviceId}`);
+            await this.cancelAndReleaseSession(
+              sessionId,
+              deviceLossCancellationReason(deviceId, incidentId),
+            );
           }
 
-          await this.devicePool.removeDisconnectedDevice(deviceId);
+          await this.devicePool.removeDisconnectedDevice(deviceId, true, incidentId);
           // Drop any per-device input caches so a device replaced under the same
           // serial does not inherit the previous one's cached API-level capability
           // (issue #3351): an API 31+/pre-31 mismatch mis-handles SHIFT/uppercase.

--- a/src/daemon/daemon.ts
+++ b/src/daemon/daemon.ts
@@ -1379,6 +1379,9 @@ export class Daemon {
             undefined,
             "absent",
           );
+          if (await this.shouldSkipStaleDisconnectCleanup(pooledDeviceAtDisconnect, deviceId)) {
+            continue;
+          }
           const sessionId = this.sessionManager.getSessionForDevice(deviceId);
           if (sessionId) {
             logger.warn(

--- a/src/daemon/devicePool.ts
+++ b/src/daemon/devicePool.ts
@@ -151,24 +151,39 @@ interface DeviceRemovedListener {
  */
 class EmulatorProcessOutputTail {
   private output = "";
-  private readonly redactor = new AndroidCommandOutputStreamRedactor();
+  private readonly stdoutRedactor = new AndroidCommandOutputStreamRedactor();
+  private readonly stderrRedactor = new AndroidCommandOutputStreamRedactor();
+  private readonly streamsClosed: Promise<void>;
 
-  constructor(childProcess: ChildProcess) {
-    childProcess.stdout?.on("data", value => this.append(value));
-    childProcess.stderr?.on("data", value => this.append(value));
+  constructor(
+    childProcess: ChildProcess,
+    private readonly timer: Timer,
+  ) {
+    const hasStreams = childProcess.stdout !== null && childProcess.stdout !== undefined
+      || childProcess.stderr !== null && childProcess.stderr !== undefined;
+    this.streamsClosed = hasStreams
+      ? new Promise(resolve => childProcess.once("close", resolve))
+      : Promise.resolve();
+    childProcess.stdout?.on("data", value => this.append(value, this.stdoutRedactor));
+    childProcess.stderr?.on("data", value => this.append(value, this.stderrRedactor));
   }
 
   snapshot(): string | undefined {
-    const output = boundedEmulatorOutputTail(this.output + this.redactor.snapshot());
+    const output = boundedEmulatorOutputTail(
+      this.output + this.stdoutRedactor.snapshot() + this.stderrRedactor.snapshot(),
+    );
     return output.length > 0 ? output : undefined;
   }
 
-  finalize(): string | undefined {
-    this.output = boundedEmulatorOutputTail(this.output + this.redactor.flush());
+  async finalize(): Promise<string | undefined> {
+    await this.waitForStreamClose();
+    this.output = boundedEmulatorOutputTail(
+      this.output + this.stdoutRedactor.flush() + this.stderrRedactor.flush(),
+    );
     return this.output.length > 0 ? this.output : undefined;
   }
 
-  private append(value: unknown): void {
+  private append(value: unknown, redactor: AndroidCommandOutputStreamRedactor): void {
     const text = typeof value === "string"
       ? value
       : Buffer.isBuffer(value)
@@ -177,7 +192,23 @@ class EmulatorProcessOutputTail {
     if (!text) {
       return;
     }
-    this.output = boundedEmulatorOutputTail(this.output + this.redactor.append(text));
+    this.output = boundedEmulatorOutputTail(this.output + redactor.append(text));
+  }
+
+  private async waitForStreamClose(): Promise<void> {
+    let timeout: NodeJS.Timeout | undefined;
+    try {
+      await Promise.race([
+        this.streamsClosed,
+        new Promise<void>(resolve => {
+          timeout = this.timer.setTimeout(resolve, 1_000);
+        }),
+      ]);
+    } finally {
+      if (timeout) {
+        this.timer.clearTimeout(timeout);
+      }
+    }
   }
 }
 
@@ -584,6 +615,9 @@ export class DevicePool {
     const startedProcess = preserveAutoMobileOwnership
       ? this.startedDeviceProcesses.get(pooledDevice.id)
       : undefined;
+    const startedProcessOutput = preserveAutoMobileOwnership
+      ? this.startedDeviceProcessOutput.get(pooledDevice.id)
+      : undefined;
     await this.evictMissingPooledDevice(
       pooledDevice,
       `runtime identity changed to ${bootedDevice.platform}:${bootedDevice.name}`,
@@ -594,6 +628,9 @@ export class DevicePool {
     await this.addDevice(bootedDevice, sourceImage);
     if (startedProcess) {
       this.startedDeviceProcesses.set(bootedDevice.deviceId, startedProcess);
+    }
+    if (startedProcessOutput) {
+      this.startedDeviceProcessOutput.set(bootedDevice.deviceId, startedProcessOutput);
     }
     return true;
   }
@@ -722,6 +759,7 @@ export class DevicePool {
       undefined,
       "absent",
     );
+    const recoveryWasAttempted = this.shouldRebootDisconnectedAndroidDevice(device);
     if (await this.rebootDisconnectedAndroidDevice(device, recordedIncidentId)) {
       return;
     }
@@ -730,7 +768,7 @@ export class DevicePool {
       return;
     }
     this.suppressAutoStartForDevice(device);
-    await this.completeEmulatorLossRecovery(recordedIncidentId, "not-attempted");
+    await this.completeRecoveryIfNotAttempted(recordedIncidentId, recoveryWasAttempted);
     await this.removeDevice(deviceId);
   }
 
@@ -753,7 +791,7 @@ export class DevicePool {
       return undefined;
     }
     const outputTail = detectionPath === "watched-process-exit"
-      ? this.startedDeviceProcessOutput.get(deviceId)?.finalize()
+      ? await this.startedDeviceProcessOutput.get(deviceId)?.finalize()
       : this.startedDeviceProcessOutput.get(deviceId)?.snapshot();
     try {
       const incident = await this.emulatorLossIncidentStore.open({
@@ -772,6 +810,15 @@ export class DevicePool {
         error,
       );
       return undefined;
+    }
+  }
+
+  private async completeRecoveryIfNotAttempted(
+    incidentId: string | undefined,
+    recoveryWasAttempted: boolean,
+  ): Promise<void> {
+    if (!recoveryWasAttempted) {
+      await this.completeEmulatorLossRecovery(incidentId, "not-attempted");
     }
   }
 
@@ -1743,6 +1790,7 @@ export class DevicePool {
       }
       const current = this.devices.get(device.id);
       if (current && current !== device) {
+        await this.completeEmulatorLossRecovery(incidentId, "recovered");
         return true;
       }
       await this.removeDevice(device.id);
@@ -1754,7 +1802,7 @@ export class DevicePool {
           return;
         }
         const attempt = ++recoveryAttempt;
-        const childProcess = await this.deviceManager.startDevice(target);
+        let childProcess: ChildProcess | null = null;
         let ready: BootedDevice | undefined;
         let readinessCompleted = false;
         const stopCancelledRecovery = async (deviceToRemove?: BootedDevice): Promise<void> => {
@@ -1773,6 +1821,7 @@ export class DevicePool {
           }
         };
         try {
+          childProcess = await this.deviceManager.startDevice(target);
           ready = this.criteriaMatcher.withDeviceImageMetadata(
             await waitForDeviceReadyOrCancel(this.deviceManager, target, childProcess),
             recoveryImage,
@@ -1909,7 +1958,10 @@ export class DevicePool {
     }
 
     this.startedDeviceProcesses.set(device.deviceId, childProcess);
-    this.startedDeviceProcessOutput.set(device.deviceId, new EmulatorProcessOutputTail(childProcess));
+    this.startedDeviceProcessOutput.set(
+      device.deviceId,
+      new EmulatorProcessOutputTail(childProcess, this.timer),
+    );
     let exitHandled = false;
     const handleExit = (code: number | null, signal: NodeJS.Signals | null): void => {
       if (exitHandled) {

--- a/src/daemon/devicePool.ts
+++ b/src/daemon/devicePool.ts
@@ -2044,7 +2044,6 @@ export class DevicePool {
       deviceId,
       "watched-process-exit",
       { code, signal },
-      "device",
     );
     await this.evictMissingPooledDevice(
       device,

--- a/src/daemon/devicePool.ts
+++ b/src/daemon/devicePool.ts
@@ -790,10 +790,12 @@ export class DevicePool {
     ) {
       return undefined;
     }
-    const outputTail = detectionPath === "watched-process-exit"
-      ? await this.startedDeviceProcessOutput.get(deviceId)?.finalize()
-      : this.startedDeviceProcessOutput.get(deviceId)?.snapshot();
     try {
+      // Capture the tail inside the try so a finalize()/snapshot() rejection
+      // degrades to no tail rather than blocking device-loss cleanup.
+      const outputTail = detectionPath === "watched-process-exit"
+        ? await this.startedDeviceProcessOutput.get(deviceId)?.finalize()
+        : this.startedDeviceProcessOutput.get(deviceId)?.snapshot();
       const incident = await this.emulatorLossIncidentStore.open({
         deviceId,
         ...(device.avdName ? { avdName: device.avdName } : {}),

--- a/src/daemon/devicePool.ts
+++ b/src/daemon/devicePool.ts
@@ -36,6 +36,14 @@ import { consolePortFromSerial } from "../utils/android-cmdline-tools/EmulatorCo
 import { getInstalledAppsCacheWriteCoordinator } from "../db/installedAppsCacheWriteCoordinator";
 import { getDbWriteBarrier } from "../db/dbWriteBarrier";
 import { runWithAbortSignal } from "../utils/AbortContext";
+import { AndroidCommandOutputStreamRedactor } from "../utils/android-cmdline-tools/redactAndroidCommandOutput";
+import { boundedEmulatorOutputTail } from "../utils/android-cmdline-tools/AndroidEmulatorClient";
+import {
+  deviceLossCancellationReason,
+  InMemoryEmulatorLossIncidentStore,
+  type EmulatorLossDetectionPath,
+  type EmulatorLossIncidentStore,
+} from "./emulatorLossIncident";
 
 export type { DeviceAllocationCriteria, DeviceAllocationRequest } from "./DeviceCriteriaMatcher";
 export type { DeviceRecoveryPolicy } from "./poolConfig";
@@ -137,6 +145,43 @@ interface DeviceRemovedListener {
 }
 
 /**
+ * A process can emit output after readiness. Capture its redacted bounded tail
+ * so a later unexpected exit has the same useful evidence as an early launch
+ * failure without retaining unbounded process output.
+ */
+class EmulatorProcessOutputTail {
+  private output = "";
+  private readonly redactor = new AndroidCommandOutputStreamRedactor();
+
+  constructor(childProcess: ChildProcess) {
+    childProcess.stdout?.on("data", value => this.append(value));
+    childProcess.stderr?.on("data", value => this.append(value));
+  }
+
+  snapshot(): string | undefined {
+    const output = boundedEmulatorOutputTail(this.output + this.redactor.snapshot());
+    return output.length > 0 ? output : undefined;
+  }
+
+  finalize(): string | undefined {
+    this.output = boundedEmulatorOutputTail(this.output + this.redactor.flush());
+    return this.output.length > 0 ? this.output : undefined;
+  }
+
+  private append(value: unknown): void {
+    const text = typeof value === "string"
+      ? value
+      : Buffer.isBuffer(value)
+        ? value.toString()
+        : "";
+    if (!text) {
+      return;
+    }
+    this.output = boundedEmulatorOutputTail(this.output + this.redactor.append(text));
+  }
+}
+
+/**
  * Marker incarnation used when an intentional shutdown is recorded while no
  * pooled device is present (only an in-flight recovery). Such a marker applies
  * to whatever incarnation the recovery produces, matching the pre-existing
@@ -180,6 +225,8 @@ export class DevicePool {
   private readonly recoveringAndroidImages: Map<string, DeviceInfo> = new Map();
   private readonly recoveringAndroidDeviceIds: Set<string> = new Set();
   private readonly startedDeviceProcesses: Map<string, ChildProcess> = new Map();
+  private readonly startedDeviceProcessOutput: Map<string, EmulatorProcessOutputTail> = new Map();
+  private readonly emulatorLossIncidentStore: EmulatorLossIncidentStore;
   /** Latest refresh request; older discovery snapshots must not overwrite it. */
   private refreshGeneration = 0;
   private readonly readinessReservationCounts: Map<string, number> = new Map();
@@ -227,6 +274,7 @@ export class DevicePool {
     androidDeviceReboot?: AndroidDeviceReboot,
     recoveryPolicy?: DeviceRecoveryPolicy,
     onDeviceRemoved?: DeviceRemovedListener,
+    emulatorLossIncidentStore: EmulatorLossIncidentStore = new InMemoryEmulatorLossIncidentStore(timer),
   ) {
     this.sessionManager = sessionManager;
     this.daemonSessionId = daemonSessionId;
@@ -238,6 +286,7 @@ export class DevicePool {
     this.criteriaMatcher = criteriaMatcher;
     this.onDeviceReady = onDeviceReady;
     this.onDeviceRemoved = onDeviceRemoved;
+    this.emulatorLossIncidentStore = emulatorLossIncidentStore;
     // Resolve recovery policy once so retries and status agree even if the
     // process environment changes after construction.
     this.recoveryPolicy = { ...(recoveryPolicy ?? getDeviceRecoveryPolicy()) };
@@ -569,6 +618,7 @@ export class DevicePool {
     this.deviceSessionStarts.delete(deviceId);
     this.refreshMissingDeviceMisses.delete(deviceId);
     this.startedDeviceProcesses.delete(deviceId);
+    this.startedDeviceProcessOutput.delete(deviceId);
     if (this.lastReleasedDeviceId === deviceId) {
       this.lastReleasedDeviceId = null;
     }
@@ -650,6 +700,7 @@ export class DevicePool {
   async removeDisconnectedDevice(
     deviceId: string,
     mayBeStaleSignal: boolean = true,
+    incidentId?: string,
   ): Promise<void> {
     const device = this.devices.get(deviceId);
     if (await this.shouldDeferDisconnectCleanup(deviceId, device, mayBeStaleSignal)) {
@@ -665,7 +716,13 @@ export class DevicePool {
     if (this.devices.get(deviceId) !== device || rediscovery !== "not-rediscovered") {
       return;
     }
-    if (await this.rebootDisconnectedAndroidDevice(device)) {
+    const recordedIncidentId = incidentId ?? await this.recordEmulatorLossIncident(
+      deviceId,
+      "device-discovery-miss",
+      undefined,
+      "absent",
+    );
+    if (await this.rebootDisconnectedAndroidDevice(device, recordedIncidentId)) {
       return;
     }
     const current = this.devices.get(deviceId);
@@ -673,7 +730,83 @@ export class DevicePool {
       return;
     }
     this.suppressAutoStartForDevice(device);
+    await this.completeEmulatorLossRecovery(recordedIncidentId, "not-attempted");
     await this.removeDevice(deviceId);
+  }
+
+  /**
+   * Opens a durable postmortem record without allowing diagnostics persistence
+   * failure to block the critical device-loss cleanup path.
+   */
+  async recordEmulatorLossIncident(
+    deviceId: string,
+    detectionPath: EmulatorLossDetectionPath,
+    processExit?: { code: number | null; signal: NodeJS.Signals | null },
+    lastAdbState?: string,
+  ): Promise<string | undefined> {
+    const device = this.devices.get(deviceId);
+    if (
+      !device ||
+      device.platform !== "android" ||
+      consolePortFromSerial(device.id) === null
+    ) {
+      return undefined;
+    }
+    const outputTail = detectionPath === "watched-process-exit"
+      ? this.startedDeviceProcessOutput.get(deviceId)?.finalize()
+      : this.startedDeviceProcessOutput.get(deviceId)?.snapshot();
+    try {
+      const incident = await this.emulatorLossIncidentStore.open({
+        deviceId,
+        ...(device.avdName ? { avdName: device.avdName } : {}),
+        detectionPath,
+        ...(processExit ? { processExit } : {}),
+        ...(outputTail ? { outputTail } : {}),
+        ...(lastAdbState ? { lastAdbState } : {}),
+        recoveryPolicy: this.getRecoveryPolicy(),
+      });
+      return incident.id;
+    } catch (error) {
+      logger.warn(
+        `[DevicePool] Failed to record emulator-loss incident for ${deviceId}: ${error}`,
+        error,
+      );
+      return undefined;
+    }
+  }
+
+  private async recordEmulatorLossRecoveryAttempt(
+    incidentId: string | undefined,
+    attempt: { attempt: number; outcome: "failed" | "succeeded" },
+  ): Promise<void> {
+    if (!incidentId) {
+      return;
+    }
+    try {
+      await this.emulatorLossIncidentStore.recordRecoveryAttempt(incidentId, attempt);
+    } catch (error) {
+      logger.warn(
+        `[DevicePool] Failed to record emulator-loss recovery attempt for ${incidentId}: ${error}`,
+        error,
+      );
+    }
+  }
+
+  private async completeEmulatorLossRecovery(
+    incidentId: string | undefined,
+    outcome: "recovered" | "exhausted" | "not-attempted",
+  ): Promise<void> {
+    if (!incidentId) {
+      return;
+    }
+    try {
+      await this.emulatorLossIncidentStore.completeRecovery(incidentId, outcome);
+    } catch (error) {
+      logger.warn(
+        `[DevicePool] Failed to finalize emulator-loss incident ${incidentId}: ${error}`,
+        error,
+      );
+    }
   }
 
   private async wasRebootedAndroidDeviceRediscovered(
@@ -1518,6 +1651,7 @@ export class DevicePool {
     device: PooledDevice,
     reason: string,
     recoverAndroidEmulator: boolean = false,
+    incidentId?: string,
   ): Promise<void> {
     if (this.isReservedForShutdown(device)) {
       // killDevice alone owns a shutdown-reserved incarnation until it either
@@ -1527,11 +1661,21 @@ export class DevicePool {
       return;
     }
     logger.warn(`Evicting device ${device.id} from pool: ${reason}`);
+    const correlatedIncidentId = incidentId ?? (
+      recoverAndroidEmulator
+        ? await this.recordEmulatorLossIncident(
+          device.id,
+          "device-discovery-miss",
+          undefined,
+          "absent",
+        )
+        : undefined
+    );
     if (device.sessionId) {
       await this.releaseSessionForDisconnectedDevice(
         device.sessionId,
         device.id,
-        `device-disconnected:${device.id}`,
+        deviceLossCancellationReason(device.id, correlatedIncidentId),
       );
       if (this.devices.get(device.id) !== device) {
         return;
@@ -1543,9 +1687,10 @@ export class DevicePool {
     }
     device.status = "idle";
     if (recoverAndroidEmulator && this.shouldRebootDisconnectedAndroidDevice(device)) {
-      await this.removeDisconnectedDevice(device.id, false);
+      await this.removeDisconnectedDevice(device.id, false, correlatedIncidentId);
       return;
     }
+    await this.completeEmulatorLossRecovery(correlatedIncidentId, "not-attempted");
     await this.removeDevice(device.id);
   }
 
@@ -1559,7 +1704,10 @@ export class DevicePool {
     );
   }
 
-  private async rebootDisconnectedAndroidDevice(device: PooledDevice): Promise<boolean> {
+  private async rebootDisconnectedAndroidDevice(
+    device: PooledDevice,
+    incidentId?: string,
+  ): Promise<boolean> {
     if (!this.shouldRebootDisconnectedAndroidDevice(device)) {
       return false;
     }
@@ -1581,6 +1729,7 @@ export class DevicePool {
     };
     this.recoveringAndroidImages.set(avdName, recoveryImage);
     this.recoveringAndroidDeviceIds.add(device.id);
+    let recoveryAttempt = 0;
     try {
       try {
         await this.stopTrackedEmulatorProcess(device.id);
@@ -1589,6 +1738,7 @@ export class DevicePool {
           `[DevicePool] Could not terminate disconnected emulator ${device.id}: ${error}`,
           error,
         );
+        await this.completeEmulatorLossRecovery(incidentId, "exhausted");
         return false;
       }
       const current = this.devices.get(device.id);
@@ -1603,6 +1753,7 @@ export class DevicePool {
           intentionallyStopped = true;
           return;
         }
+        const attempt = ++recoveryAttempt;
         const childProcess = await this.deviceManager.startDevice(target);
         let ready: BootedDevice | undefined;
         let readinessCompleted = false;
@@ -1639,11 +1790,19 @@ export class DevicePool {
             return;
           }
           await this.trackStartedDeviceProcess(ready, childProcess);
+          await this.recordEmulatorLossRecoveryAttempt(incidentId, {
+            attempt,
+            outcome: "succeeded",
+          });
         } catch (error) {
           if (this.consumeIntentionalShutdown(recoveryDeviceIds)) {
             await stopCancelledRecovery(readinessCompleted ? ready : undefined);
             return;
           }
+          await this.recordEmulatorLossRecoveryAttempt(incidentId, {
+            attempt,
+            outcome: "failed",
+          });
           throw error;
         }
       });
@@ -1654,11 +1813,13 @@ export class DevicePool {
         logger.info(
           `[DevicePool] Cancelled Android emulator ${avdName} recovery after intentional shutdown`,
         );
+        await this.completeEmulatorLossRecovery(incidentId, "not-attempted");
         return true;
       }
       if (recovered) {
         logger.info(`[DevicePool] Restarted Android emulator ${avdName} after disconnect`);
       }
+      await this.completeEmulatorLossRecovery(incidentId, recovered ? "recovered" : "exhausted");
       return recovered;
     } finally {
       this.recoveringAndroidImages.delete(avdName);
@@ -1683,6 +1844,7 @@ export class DevicePool {
   private async stopTrackedEmulatorProcess(deviceId: string): Promise<void> {
     const childProcess = this.startedDeviceProcesses.get(deviceId);
     this.startedDeviceProcesses.delete(deviceId);
+    this.startedDeviceProcessOutput.delete(deviceId);
     await this.stopEmulatorProcess(childProcess);
   }
 
@@ -1747,6 +1909,7 @@ export class DevicePool {
     }
 
     this.startedDeviceProcesses.set(device.deviceId, childProcess);
+    this.startedDeviceProcessOutput.set(device.deviceId, new EmulatorProcessOutputTail(childProcess));
     let exitHandled = false;
     const handleExit = (code: number | null, signal: NodeJS.Signals | null): void => {
       if (exitHandled) {
@@ -1825,10 +1988,17 @@ export class DevicePool {
       return;
     }
 
+    const incidentId = await this.recordEmulatorLossIncident(
+      deviceId,
+      "watched-process-exit",
+      { code, signal },
+      "device",
+    );
     await this.evictMissingPooledDevice(
       device,
       `emulator process exited after startup (code=${code ?? "null"}, signal=${signal ?? "null"})`,
       true,
+      incidentId,
     );
   }
 

--- a/src/daemon/emulatorLossIncident.ts
+++ b/src/daemon/emulatorLossIncident.ts
@@ -133,7 +133,11 @@ export class InMemoryEmulatorLossIncidentStore implements EmulatorLossIncidentSt
   }
 
   async list(limit: number = this.maxRetained): Promise<EmulatorLossIncident[]> {
-    return Array.from(this.incidents.values()).slice(-limit).reverse().map(copyIncident);
+    // Match EmulatorLossIncidentRepository.list, whose `.limit(0)` returns no
+    // rows. `slice(-0)` equals `slice(0)` and would otherwise return everything.
+    const incidents = Array.from(this.incidents.values());
+    const newest = limit <= 0 ? [] : incidents.slice(-limit);
+    return newest.reverse().map(copyIncident);
   }
 
   private prune(): void {

--- a/src/daemon/emulatorLossIncident.ts
+++ b/src/daemon/emulatorLossIncident.ts
@@ -1,0 +1,148 @@
+import type { DeviceRecoveryPolicy } from "./poolConfig";
+import type { IdGenerator } from "../utils/IdGenerator";
+import { defaultIdGenerator } from "../utils/IdGenerator";
+import type { Timer } from "../utils/SystemTimer";
+import { defaultTimer } from "../utils/SystemTimer";
+
+export const DEFAULT_MAX_RETAINED_EMULATOR_LOSS_INCIDENTS = 50;
+
+export type EmulatorLossDetectionPath =
+  | "watched-process-exit"
+  | "device-discovery-miss"
+  | "adb-transport-failure";
+
+export type EmulatorRecoveryOutcome = "recovered" | "exhausted" | "not-attempted";
+
+export interface EmulatorLossRecoveryAttempt {
+  attempt: number;
+  outcome: "failed" | "succeeded";
+}
+
+export interface EmulatorLossIncident {
+  id: string;
+  observedAtMs: number;
+  updatedAtMs: number;
+  deviceId: string;
+  avdName?: string;
+  detectionPath: EmulatorLossDetectionPath;
+  processExit?: {
+    code: number | null;
+    signal: NodeJS.Signals | null;
+  };
+  outputTail?: string;
+  lastAdbState?: string;
+  recovery: {
+    policy: DeviceRecoveryPolicy;
+    attempts: EmulatorLossRecoveryAttempt[];
+    outcome?: EmulatorRecoveryOutcome;
+  };
+}
+
+export interface OpenEmulatorLossIncidentInput {
+  deviceId: string;
+  avdName?: string;
+  detectionPath: EmulatorLossDetectionPath;
+  processExit?: EmulatorLossIncident["processExit"];
+  outputTail?: string;
+  lastAdbState?: string;
+  recoveryPolicy: DeviceRecoveryPolicy;
+}
+
+export interface EmulatorLossIncidentStore {
+  open(input: OpenEmulatorLossIncidentInput): Promise<EmulatorLossIncident>;
+  recordRecoveryAttempt(incidentId: string, attempt: EmulatorLossRecoveryAttempt): Promise<void>;
+  completeRecovery(incidentId: string, outcome: EmulatorRecoveryOutcome): Promise<void>;
+  get(incidentId: string): Promise<EmulatorLossIncident | undefined>;
+  list(limit?: number): Promise<EmulatorLossIncident[]>;
+}
+
+export function deviceLossCancellationReason(deviceId: string, incidentId?: string): string {
+  return incidentId
+    ? `device-disconnected:${deviceId};incident=${incidentId}`
+    : `device-disconnected:${deviceId}`;
+}
+
+function copyIncident(incident: EmulatorLossIncident): EmulatorLossIncident {
+  return {
+    ...incident,
+    ...(incident.processExit ? { processExit: { ...incident.processExit } } : {}),
+    recovery: {
+      ...incident.recovery,
+      policy: { ...incident.recovery.policy },
+      attempts: incident.recovery.attempts.map((attempt) => ({ ...attempt })),
+    },
+  };
+}
+
+/** Bounded in-memory store used by tests and direct-mode callers. */
+export class InMemoryEmulatorLossIncidentStore implements EmulatorLossIncidentStore {
+  private readonly incidents = new Map<string, EmulatorLossIncident>();
+
+  constructor(
+    private readonly timer: Timer = defaultTimer,
+    private readonly idGenerator: IdGenerator = defaultIdGenerator,
+    private readonly maxRetained: number = DEFAULT_MAX_RETAINED_EMULATOR_LOSS_INCIDENTS,
+  ) {}
+
+  async open(input: OpenEmulatorLossIncidentInput): Promise<EmulatorLossIncident> {
+    const now = this.timer.now();
+    const incident: EmulatorLossIncident = {
+      id: `emulator-loss-${this.idGenerator.next()}`,
+      observedAtMs: now,
+      updatedAtMs: now,
+      deviceId: input.deviceId,
+      ...(input.avdName ? { avdName: input.avdName } : {}),
+      detectionPath: input.detectionPath,
+      ...(input.processExit ? { processExit: { ...input.processExit } } : {}),
+      ...(input.outputTail ? { outputTail: input.outputTail } : {}),
+      ...(input.lastAdbState ? { lastAdbState: input.lastAdbState } : {}),
+      recovery: {
+        policy: { ...input.recoveryPolicy },
+        attempts: [],
+      },
+    };
+    this.incidents.set(incident.id, incident);
+    this.prune();
+    return copyIncident(incident);
+  }
+
+  async recordRecoveryAttempt(
+    incidentId: string,
+    attempt: EmulatorLossRecoveryAttempt,
+  ): Promise<void> {
+    const incident = this.incidents.get(incidentId);
+    if (!incident) {
+      return;
+    }
+    incident.recovery.attempts.push({ ...attempt });
+    incident.updatedAtMs = this.timer.now();
+  }
+
+  async completeRecovery(incidentId: string, outcome: EmulatorRecoveryOutcome): Promise<void> {
+    const incident = this.incidents.get(incidentId);
+    if (!incident) {
+      return;
+    }
+    incident.recovery.outcome = outcome;
+    incident.updatedAtMs = this.timer.now();
+  }
+
+  async get(incidentId: string): Promise<EmulatorLossIncident | undefined> {
+    const incident = this.incidents.get(incidentId);
+    return incident ? copyIncident(incident) : undefined;
+  }
+
+  async list(limit: number = this.maxRetained): Promise<EmulatorLossIncident[]> {
+    return Array.from(this.incidents.values()).slice(-limit).reverse().map(copyIncident);
+  }
+
+  private prune(): void {
+    while (this.incidents.size > this.maxRetained) {
+      const oldest = this.incidents.keys().next().value;
+      if (oldest === undefined) {
+        return;
+      }
+      this.incidents.delete(oldest);
+    }
+  }
+}

--- a/src/db/emulatorLossIncidentRepository.ts
+++ b/src/db/emulatorLossIncidentRepository.ts
@@ -73,17 +73,31 @@ export class EmulatorLossIncidentRepository implements EmulatorLossIncidentStore
         attempts: [],
       },
     };
-    await this.getDb()
-      .insertInto("emulator_loss_incidents")
-      .values({
-        incident_id: incident.id,
-        device_id: incident.deviceId,
-        observed_at_ms: incident.observedAtMs,
-        updated_at_ms: incident.updatedAtMs,
-        incident_json: JSON.stringify(incident),
-      })
-      .execute();
-    await this.prune();
+    await this.getDb().transaction().execute(async (trx) => {
+      await trx
+        .insertInto("emulator_loss_incidents")
+        .values({
+          incident_id: incident.id,
+          device_id: incident.deviceId,
+          observed_at_ms: incident.observedAtMs,
+          updated_at_ms: incident.updatedAtMs,
+          incident_json: JSON.stringify(incident),
+        })
+        .execute();
+      const rows = await trx
+        .selectFrom("emulator_loss_incidents")
+        .select("incident_id")
+        .orderBy("observed_at_ms", "desc")
+        .orderBy("id", "desc")
+        .execute();
+      const excessIds = rows.slice(this.maxRetained).map((row) => row.incident_id);
+      if (excessIds.length > 0) {
+        await trx
+          .deleteFrom("emulator_loss_incidents")
+          .where("incident_id", "in", excessIds)
+          .execute();
+      }
+    });
     return incident;
   }
 
@@ -116,7 +130,7 @@ export class EmulatorLossIncidentRepository implements EmulatorLossIncidentStore
       .selectFrom("emulator_loss_incidents")
       .select("incident_json")
       .orderBy("observed_at_ms", "desc")
-      .orderBy("incident_id", "desc")
+      .orderBy("id", "desc")
       .limit(limit)
       .execute();
     return rows.flatMap((row) => {
@@ -146,23 +160,6 @@ export class EmulatorLossIncidentRepository implements EmulatorLossIncidentStore
         incident_json: JSON.stringify(incident),
       })
       .where("incident_id", "=", incidentId)
-      .execute();
-  }
-
-  private async prune(): Promise<void> {
-    const rows = await this.getDb()
-      .selectFrom("emulator_loss_incidents")
-      .select("incident_id")
-      .orderBy("observed_at_ms", "desc")
-      .orderBy("incident_id", "desc")
-      .execute();
-    const excessIds = rows.slice(this.maxRetained).map((row) => row.incident_id);
-    if (excessIds.length === 0) {
-      return;
-    }
-    await this.getDb()
-      .deleteFrom("emulator_loss_incidents")
-      .where("incident_id", "in", excessIds)
       .execute();
   }
 }

--- a/src/db/emulatorLossIncidentRepository.ts
+++ b/src/db/emulatorLossIncidentRepository.ts
@@ -15,6 +15,8 @@ import type { Timer } from "../utils/SystemTimer";
 import { defaultTimer } from "../utils/SystemTimer";
 import { logger } from "../utils/logger";
 
+const MAX_UPDATE_ATTEMPTS = 3;
+
 function isRecord(value: unknown): value is Record<string, unknown> {
   return typeof value === "object" && value !== null && !Array.isArray(value);
 }
@@ -81,6 +83,7 @@ export class EmulatorLossIncidentRepository implements EmulatorLossIncidentStore
           device_id: incident.deviceId,
           observed_at_ms: incident.observedAtMs,
           updated_at_ms: incident.updatedAtMs,
+          revision: 0,
           incident_json: JSON.stringify(incident),
         })
         .execute();
@@ -147,19 +150,35 @@ export class EmulatorLossIncidentRepository implements EmulatorLossIncidentStore
     incidentId: string,
     mutate: (incident: EmulatorLossIncident) => void,
   ): Promise<void> {
-    const incident = await this.get(incidentId);
-    if (!incident) {
-      return;
+    for (let attempt = 0; attempt < MAX_UPDATE_ATTEMPTS; attempt++) {
+      const row = await this.getDb()
+        .selectFrom("emulator_loss_incidents")
+        .select(["incident_json", "revision"])
+        .where("incident_id", "=", incidentId)
+        .executeTakeFirst();
+      if (!row) {
+        return;
+      }
+      const incident = decodeIncident(row.incident_json);
+      if (!incident) {
+        return;
+      }
+      mutate(incident);
+      incident.updatedAtMs = this.timer.now();
+      const result = await this.getDb()
+        .updateTable("emulator_loss_incidents")
+        .set({
+          updated_at_ms: incident.updatedAtMs,
+          revision: row.revision + 1,
+          incident_json: JSON.stringify(incident),
+        })
+        .where("incident_id", "=", incidentId)
+        .where("revision", "=", row.revision)
+        .executeTakeFirst();
+      if (Number(result.numUpdatedRows) > 0) {
+        return;
+      }
     }
-    mutate(incident);
-    incident.updatedAtMs = this.timer.now();
-    await this.getDb()
-      .updateTable("emulator_loss_incidents")
-      .set({
-        updated_at_ms: incident.updatedAtMs,
-        incident_json: JSON.stringify(incident),
-      })
-      .where("incident_id", "=", incidentId)
-      .execute();
+    throw new Error(`Could not update emulator-loss incident ${incidentId} after concurrent updates`);
   }
 }

--- a/src/db/emulatorLossIncidentRepository.ts
+++ b/src/db/emulatorLossIncidentRepository.ts
@@ -1,0 +1,168 @@
+import type { Kysely } from "kysely";
+import { getDatabase } from "./database";
+import type { Database } from "./types";
+import {
+  DEFAULT_MAX_RETAINED_EMULATOR_LOSS_INCIDENTS,
+  type EmulatorLossIncident,
+  type EmulatorLossIncidentStore,
+  type EmulatorLossRecoveryAttempt,
+  type EmulatorRecoveryOutcome,
+  type OpenEmulatorLossIncidentInput,
+} from "../daemon/emulatorLossIncident";
+import type { IdGenerator } from "../utils/IdGenerator";
+import { defaultIdGenerator } from "../utils/IdGenerator";
+import type { Timer } from "../utils/SystemTimer";
+import { defaultTimer } from "../utils/SystemTimer";
+import { logger } from "../utils/logger";
+
+function isRecord(value: unknown): value is Record<string, unknown> {
+  return typeof value === "object" && value !== null && !Array.isArray(value);
+}
+
+function isIncident(value: unknown): value is EmulatorLossIncident {
+  if (!isRecord(value) || typeof value.id !== "string" || typeof value.deviceId !== "string") {
+    return false;
+  }
+  return (
+    typeof value.observedAtMs === "number" &&
+    typeof value.updatedAtMs === "number" &&
+    typeof value.detectionPath === "string" &&
+    isRecord(value.recovery) &&
+    Array.isArray(value.recovery.attempts) &&
+    isRecord(value.recovery.policy)
+  );
+}
+
+function decodeIncident(value: string): EmulatorLossIncident | undefined {
+  try {
+    const parsed: unknown = JSON.parse(value);
+    return isIncident(parsed) ? parsed : undefined;
+  } catch (error) {
+    logger.warn(`[EmulatorLossIncidentRepository] Invalid stored incident: ${error}`, error);
+    return undefined;
+  }
+}
+
+/**
+ * Persists a bounded set of emulator-loss incidents. The DB resolves lazily so
+ * unit tests must inject their in-memory Kysely database instead of opening the
+ * user's default file-backed store.
+ */
+export class EmulatorLossIncidentRepository implements EmulatorLossIncidentStore {
+  constructor(
+    private readonly timer: Timer = defaultTimer,
+    private readonly idGenerator: IdGenerator = defaultIdGenerator,
+    private readonly maxRetained: number = DEFAULT_MAX_RETAINED_EMULATOR_LOSS_INCIDENTS,
+    private readonly database?: Kysely<Database>,
+  ) {}
+
+  async open(input: OpenEmulatorLossIncidentInput): Promise<EmulatorLossIncident> {
+    const now = this.timer.now();
+    const incident: EmulatorLossIncident = {
+      id: `emulator-loss-${this.idGenerator.next()}`,
+      observedAtMs: now,
+      updatedAtMs: now,
+      deviceId: input.deviceId,
+      ...(input.avdName ? { avdName: input.avdName } : {}),
+      detectionPath: input.detectionPath,
+      ...(input.processExit ? { processExit: { ...input.processExit } } : {}),
+      ...(input.outputTail ? { outputTail: input.outputTail } : {}),
+      ...(input.lastAdbState ? { lastAdbState: input.lastAdbState } : {}),
+      recovery: {
+        policy: { ...input.recoveryPolicy },
+        attempts: [],
+      },
+    };
+    await this.getDb()
+      .insertInto("emulator_loss_incidents")
+      .values({
+        incident_id: incident.id,
+        device_id: incident.deviceId,
+        observed_at_ms: incident.observedAtMs,
+        updated_at_ms: incident.updatedAtMs,
+        incident_json: JSON.stringify(incident),
+      })
+      .execute();
+    await this.prune();
+    return incident;
+  }
+
+  async recordRecoveryAttempt(
+    incidentId: string,
+    attempt: EmulatorLossRecoveryAttempt,
+  ): Promise<void> {
+    await this.update(incidentId, (incident) => {
+      incident.recovery.attempts.push({ ...attempt });
+    });
+  }
+
+  async completeRecovery(incidentId: string, outcome: EmulatorRecoveryOutcome): Promise<void> {
+    await this.update(incidentId, (incident) => {
+      incident.recovery.outcome = outcome;
+    });
+  }
+
+  async get(incidentId: string): Promise<EmulatorLossIncident | undefined> {
+    const row = await this.getDb()
+      .selectFrom("emulator_loss_incidents")
+      .select("incident_json")
+      .where("incident_id", "=", incidentId)
+      .executeTakeFirst();
+    return row ? decodeIncident(row.incident_json) : undefined;
+  }
+
+  async list(limit: number = this.maxRetained): Promise<EmulatorLossIncident[]> {
+    const rows = await this.getDb()
+      .selectFrom("emulator_loss_incidents")
+      .select("incident_json")
+      .orderBy("observed_at_ms", "desc")
+      .orderBy("incident_id", "desc")
+      .limit(limit)
+      .execute();
+    return rows.flatMap((row) => {
+      const incident = decodeIncident(row.incident_json);
+      return incident ? [incident] : [];
+    });
+  }
+
+  private getDb(): Kysely<Database> {
+    return this.database ?? getDatabase();
+  }
+
+  private async update(
+    incidentId: string,
+    mutate: (incident: EmulatorLossIncident) => void,
+  ): Promise<void> {
+    const incident = await this.get(incidentId);
+    if (!incident) {
+      return;
+    }
+    mutate(incident);
+    incident.updatedAtMs = this.timer.now();
+    await this.getDb()
+      .updateTable("emulator_loss_incidents")
+      .set({
+        updated_at_ms: incident.updatedAtMs,
+        incident_json: JSON.stringify(incident),
+      })
+      .where("incident_id", "=", incidentId)
+      .execute();
+  }
+
+  private async prune(): Promise<void> {
+    const rows = await this.getDb()
+      .selectFrom("emulator_loss_incidents")
+      .select("incident_id")
+      .orderBy("observed_at_ms", "desc")
+      .orderBy("incident_id", "desc")
+      .execute();
+    const excessIds = rows.slice(this.maxRetained).map((row) => row.incident_id);
+    if (excessIds.length === 0) {
+      return;
+    }
+    await this.getDb()
+      .deleteFrom("emulator_loss_incidents")
+      .where("incident_id", "in", excessIds)
+      .execute();
+  }
+}

--- a/src/db/migrations/2026_08_17_000_emulator_loss_incidents.ts
+++ b/src/db/migrations/2026_08_17_000_emulator_loss_incidents.ts
@@ -9,7 +9,8 @@ export async function up(db: Kysely<unknown>): Promise<void> {
   await db.schema
     .createTable("emulator_loss_incidents")
     .ifNotExists()
-    .addColumn("incident_id", "text", (col) => col.primaryKey())
+    .addColumn("id", "integer", (col) => col.primaryKey().autoIncrement())
+    .addColumn("incident_id", "text", (col) => col.notNull().unique())
     .addColumn("device_id", "text", (col) => col.notNull())
     .addColumn("observed_at_ms", "integer", (col) => col.notNull())
     .addColumn("updated_at_ms", "integer", (col) => col.notNull())
@@ -21,7 +22,7 @@ export async function up(db: Kysely<unknown>): Promise<void> {
     .createIndex("idx_emulator_loss_incidents_observed")
     .ifNotExists()
     .on("emulator_loss_incidents")
-    .columns(["observed_at_ms", "incident_id"])
+    .columns(["observed_at_ms", "id"])
     .execute();
 
   await db.schema

--- a/src/db/migrations/2026_08_17_000_emulator_loss_incidents.ts
+++ b/src/db/migrations/2026_08_17_000_emulator_loss_incidents.ts
@@ -1,0 +1,37 @@
+import { type Kysely, sql } from "kysely";
+
+/**
+ * Durable, bounded postmortem records for Android emulator loss. The JSON
+ * payload retains the evolving recovery attempts while the indexed columns make
+ * incident lookup and retention pruning cheap.
+ */
+export async function up(db: Kysely<unknown>): Promise<void> {
+  await db.schema
+    .createTable("emulator_loss_incidents")
+    .ifNotExists()
+    .addColumn("incident_id", "text", (col) => col.primaryKey())
+    .addColumn("device_id", "text", (col) => col.notNull())
+    .addColumn("observed_at_ms", "integer", (col) => col.notNull())
+    .addColumn("updated_at_ms", "integer", (col) => col.notNull())
+    .addColumn("incident_json", "text", (col) => col.notNull())
+    .addColumn("created_at", "text", (col) => col.notNull().defaultTo(sql`(datetime('now'))`))
+    .execute();
+
+  await db.schema
+    .createIndex("idx_emulator_loss_incidents_observed")
+    .ifNotExists()
+    .on("emulator_loss_incidents")
+    .columns(["observed_at_ms", "incident_id"])
+    .execute();
+
+  await db.schema
+    .createIndex("idx_emulator_loss_incidents_device")
+    .ifNotExists()
+    .on("emulator_loss_incidents")
+    .column("device_id")
+    .execute();
+}
+
+export async function down(db: Kysely<unknown>): Promise<void> {
+  await db.schema.dropTable("emulator_loss_incidents").execute();
+}

--- a/src/db/migrations/2026_08_17_000_emulator_loss_incidents.ts
+++ b/src/db/migrations/2026_08_17_000_emulator_loss_incidents.ts
@@ -14,6 +14,7 @@ export async function up(db: Kysely<unknown>): Promise<void> {
     .addColumn("device_id", "text", (col) => col.notNull())
     .addColumn("observed_at_ms", "integer", (col) => col.notNull())
     .addColumn("updated_at_ms", "integer", (col) => col.notNull())
+    .addColumn("revision", "integer", (col) => col.notNull().defaultTo(0))
     .addColumn("incident_json", "text", (col) => col.notNull())
     .addColumn("created_at", "text", (col) => col.notNull().defaultTo(sql`(datetime('now'))`))
     .execute();

--- a/src/db/types.ts
+++ b/src/db/types.ts
@@ -521,6 +521,16 @@ export interface DeviceLocksTable {
   updated_at: Generated<string>;
 }
 
+/** Bounded, durable diagnostics for unexpectedly lost Android emulators. */
+export interface EmulatorLossIncidentsTable {
+  incident_id: string;
+  device_id: string;
+  observed_at_ms: number;
+  updated_at_ms: number;
+  incident_json: string;
+  created_at: Generated<string>;
+}
+
 // Feature flags table
 export interface FeatureFlagsTable {
   key: string;
@@ -750,6 +760,7 @@ export interface Database {
   layout_events: LayoutEventsTable;
   device_sessions: DeviceSessionsTable;
   device_locks: DeviceLocksTable;
+  emulator_loss_incidents: EmulatorLossIncidentsTable;
 }
 
 // Convenience types for each table
@@ -762,6 +773,10 @@ export type DeviceSessionUpdate = Updateable<DeviceSessionsTable>;
 
 export type DeviceLock = Selectable<DeviceLocksTable>;
 export type NewDeviceLock = Insertable<DeviceLocksTable>;
+
+export type EmulatorLossIncidentRow = Selectable<EmulatorLossIncidentsTable>;
+export type NewEmulatorLossIncidentRow = Insertable<EmulatorLossIncidentsTable>;
+export type EmulatorLossIncidentRowUpdate = Updateable<EmulatorLossIncidentsTable>;
 
 export type PerformanceThresholds = Selectable<PerformanceThresholdsTable>;
 export type NewPerformanceThresholds = Insertable<PerformanceThresholdsTable>;

--- a/src/db/types.ts
+++ b/src/db/types.ts
@@ -528,6 +528,7 @@ export interface EmulatorLossIncidentsTable {
   device_id: string;
   observed_at_ms: number;
   updated_at_ms: number;
+  revision: number;
   incident_json: string;
   created_at: Generated<string>;
 }

--- a/src/db/types.ts
+++ b/src/db/types.ts
@@ -523,6 +523,7 @@ export interface DeviceLocksTable {
 
 /** Bounded, durable diagnostics for unexpectedly lost Android emulators. */
 export interface EmulatorLossIncidentsTable {
+  id: Generated<number>;
   incident_id: string;
   device_id: string;
   observed_at_ms: number;

--- a/src/server/deviceLossOutcome.ts
+++ b/src/server/deviceLossOutcome.ts
@@ -5,6 +5,7 @@ export interface DeviceLossOutcome {
   code: typeof DEVICE_LOSS_OUTCOME_CODE;
   deviceId: string;
   sessionUuid?: string;
+  incidentId?: string;
   reason: "confirmed-unavailable";
 }
 
@@ -19,6 +20,7 @@ export class DeviceLostError extends Error {
   constructor(
     readonly deviceId: string,
     reason: string,
+    readonly incidentId?: string,
   ) {
     super(reason);
     this.name = "DeviceLostError";
@@ -30,10 +32,17 @@ export function isDeviceLostError(error: unknown): error is DeviceLostError {
 }
 
 export function deviceLostErrorFromCancellationReason(reason: string): DeviceLostError | undefined {
-  const deviceId = reason.startsWith("device-disconnected:")
-    ? reason.slice("device-disconnected:".length)
-    : "";
-  return deviceId ? new DeviceLostError(deviceId, reason) : undefined;
+  if (!reason.startsWith("device-disconnected:")) {
+    return undefined;
+  }
+  const details = reason.slice("device-disconnected:".length);
+  const incidentDelimiter = ";incident=";
+  const incidentIndex = details.indexOf(incidentDelimiter);
+  const deviceId = incidentIndex === -1 ? details : details.slice(0, incidentIndex);
+  const incidentId = incidentIndex === -1
+    ? undefined
+    : details.slice(incidentIndex + incidentDelimiter.length) || undefined;
+  return deviceId ? new DeviceLostError(deviceId, reason, incidentId) : undefined;
 }
 
 /**
@@ -62,6 +71,7 @@ export function deviceLossOutcomeFromError(
     code: DEVICE_LOSS_OUTCOME_CODE,
     deviceId: error.deviceId,
     ...(sessionUuid ? { sessionUuid } : {}),
+    ...(error.incidentId ? { incidentId: error.incidentId } : {}),
     reason: "confirmed-unavailable",
   };
 }

--- a/src/server/emulatorLossIncidentResourceUris.ts
+++ b/src/server/emulatorLossIncidentResourceUris.ts
@@ -1,0 +1,3 @@
+export const EMULATOR_LOSS_INCIDENT_RESOURCE_URIS = {
+  ARCHIVE: "automobile:emulators/loss-incidents",
+} as const;

--- a/src/server/emulatorLossIncidentResources.ts
+++ b/src/server/emulatorLossIncidentResources.ts
@@ -1,0 +1,66 @@
+import { EmulatorLossIncidentRepository } from "../db/emulatorLossIncidentRepository";
+import type { EmulatorLossIncident } from "../daemon/emulatorLossIncident";
+import { logger } from "../utils/logger";
+import { ResourceRegistry, type ResourceContent } from "./resourceRegistry";
+import { EMULATOR_LOSS_INCIDENT_RESOURCE_URIS } from "./emulatorLossIncidentResourceUris";
+
+interface EmulatorLossIncidentReader {
+  list(limit?: number): Promise<EmulatorLossIncident[]>;
+}
+
+let reader: EmulatorLossIncidentReader | undefined;
+
+function getReader(): EmulatorLossIncidentReader {
+  return reader ?? new EmulatorLossIncidentRepository();
+}
+
+export function setEmulatorLossIncidentReaderForTesting(
+  incidentReader: EmulatorLossIncidentReader,
+): void {
+  reader = incidentReader;
+}
+
+export function resetEmulatorLossIncidentReaderForTesting(): void {
+  reader = undefined;
+}
+
+async function getIncidentArchive(): Promise<ResourceContent> {
+  try {
+    const incidents = await getReader().list();
+    return {
+      uri: EMULATOR_LOSS_INCIDENT_RESOURCE_URIS.ARCHIVE,
+      mimeType: "application/json",
+      text: JSON.stringify(
+        {
+          incidents,
+          count: incidents.length,
+        },
+        null,
+        2,
+      ),
+    };
+  } catch (error) {
+    logger.warn(`[EmulatorLossIncidentResources] Failed to list incidents: ${error}`, error);
+    return {
+      uri: EMULATOR_LOSS_INCIDENT_RESOURCE_URIS.ARCHIVE,
+      mimeType: "application/json",
+      text: JSON.stringify(
+        {
+          error: "Failed to list emulator-loss incidents.",
+        },
+        null,
+        2,
+      ),
+    };
+  }
+}
+
+export function registerEmulatorLossIncidentResources(): void {
+  ResourceRegistry.register(
+    EMULATOR_LOSS_INCIDENT_RESOURCE_URIS.ARCHIVE,
+    "Android Emulator Loss Incidents",
+    "Bounded diagnostics and recovery outcomes for unexpectedly lost Android emulators.",
+    "application/json",
+    getIncidentArchive,
+  );
+}

--- a/src/server/index.ts
+++ b/src/server/index.ts
@@ -69,6 +69,7 @@ import { registerStorageResources } from "./storageResources";
 import { registerAppFileResources } from "./appFileResources";
 import { registerFeatureFlagResources } from "./featureFlagResources";
 import { registerNetworkResources } from "./networkResources";
+import { registerEmulatorLossIncidentResources } from "./emulatorLossIncidentResources";
 import { FeatureFlagService } from "../features/featureFlags/FeatureFlagService";
 import { startupBenchmark } from "../utils/startupBenchmark";
 import {
@@ -252,6 +253,7 @@ export const createMcpServer = (options: McpServerOptions = {}): McpServer => {
   registerAppFileResources();
   registerFeatureFlagResources();
   registerNetworkResources();
+  registerEmulatorLossIncidentResources();
   startupBenchmark.endPhase("resourceRegistration");
 
   // Create a new MCP server

--- a/src/utils/android-cmdline-tools/AndroidEmulatorClient.ts
+++ b/src/utils/android-cmdline-tools/AndroidEmulatorClient.ts
@@ -35,7 +35,7 @@ type LaunchFailureCategory =
   | "kvm_permission_denied"
   | "missing_shared_library";
 
-function boundedOutputTail(output: string): string {
+export function boundedEmulatorOutputTail(output: string): string {
   const lines = output.split(/\r?\n/);
   const recentLines = lines.slice(-MAX_LAUNCH_OUTPUT_LINES);
   const recentOutput = recentLines.join("\n");
@@ -915,7 +915,7 @@ export class AndroidEmulatorClient implements AndroidEmulator {
       return "";
     }
     const output = error as { stdout?: unknown; stderr?: unknown };
-    return boundedOutputTail(
+    return boundedEmulatorOutputTail(
       redactAndroidCommandOutput(
         [outputFromUnknown(output.stdout), outputFromUnknown(output.stderr)]
           .filter(Boolean)
@@ -931,7 +931,7 @@ export class AndroidEmulatorClient implements AndroidEmulator {
       .then(() => this.execAsync(this.emulatorPath, ["-accel-check"], controller.signal))
       .then(
         (result) =>
-          boundedOutputTail(
+          boundedEmulatorOutputTail(
             redactAndroidCommandOutput([result.stdout, result.stderr].filter(Boolean).join("\n")),
           ),
         (error) => this.diagnosticOutputFromError(error),
@@ -1417,11 +1417,11 @@ export class AndroidEmulatorClient implements AndroidEmulator {
 
       const appendRedactedLaunchOutput = (output: string) => {
         if (output.length > 0) {
-          launchOutput = boundedOutputTail(launchOutput + output);
+          launchOutput = boundedEmulatorOutputTail(launchOutput + output);
         }
       };
       const currentLaunchOutput = () =>
-        boundedOutputTail(launchOutput + stdoutRedactor.snapshot() + stderrRedactor.snapshot());
+        boundedEmulatorOutputTail(launchOutput + stdoutRedactor.snapshot() + stderrRedactor.snapshot());
       const flushLaunchOutput = () => {
         for (const redactor of [stdoutRedactor, stderrRedactor]) {
           const flushedOutput = redactor.flush();

--- a/test/daemon/devicePool.evictionCatch.test.ts
+++ b/test/daemon/devicePool.evictionCatch.test.ts
@@ -6,6 +6,8 @@ import { FakeTimer } from "../fakes/FakeTimer";
 import { FakeDeviceSessionPersistence } from "../fakes/FakeDeviceSessionPersistence";
 import { FakeDeviceUtils } from "../fakes/FakeDeviceUtils";
 import { logger } from "../../src/utils/logger";
+import { InMemoryEmulatorLossIncidentStore } from "../../src/daemon/emulatorLossIncident";
+import { CountingIdGenerator } from "../../src/utils/IdGenerator";
 
 // Regression for #3593: the emulator-exit eviction was a fire-and-forget
 // `void this.evictStartedDeviceAfterProcessExit(...)` with no rejection handler.
@@ -61,5 +63,69 @@ describe("DevicePool emulator-exit eviction rejection handling", () => {
 
     warnSpy.mockRestore();
     evictSpy.mockRestore();
+  });
+
+  it("persists redacted post-ready process diagnostics and recovery outcome", async () => {
+    const incidentStore = new InMemoryEmulatorLossIncidentStore(
+      timer,
+      new CountingIdGenerator("test"),
+    );
+    const diagnosticPool = new DevicePool(
+      sessionManager,
+      "daemon-session-1",
+      timer,
+      undefined,
+      fakeDeviceUtils,
+      undefined,
+      undefined,
+      undefined,
+      undefined,
+      undefined,
+      undefined,
+      { onLoss: false, maxAttempts: 2 },
+      undefined,
+      incidentStore,
+    );
+    await diagnosticPool.initializeWithDevices([androidDevice]);
+    const pooled = diagnosticPool.getDevice(androidDevice.deviceId)!;
+    pooled.avdName = "Pixel_7";
+    pooled.androidImage = {
+      name: "Pixel_7",
+      platform: "android",
+      isRunning: false,
+      source: "local",
+    };
+
+    const child = new EventEmitter() as unknown as {
+      once(event: "exit", listener: (code: number | null, signal: NodeJS.Signals | null) => void): void;
+      stdout: EventEmitter;
+      stderr: EventEmitter;
+    };
+    child.stdout = new EventEmitter();
+    child.stderr = new EventEmitter();
+    (diagnosticPool as unknown as {
+      trackStartedDeviceProcess: (device: unknown, child: unknown) => Promise<void>;
+    }).trackStartedDeviceProcess(androidDevice, child);
+    child.stderr.emit("data", Buffer.from("token=should-not-leak emulator died\n"));
+    (child as unknown as EventEmitter).emit("exit", 1, null);
+
+    for (let i = 0; i < 10; i++) {
+      await Promise.resolve();
+    }
+
+    const [incident] = await incidentStore.list();
+    expect(incident).toMatchObject({
+      deviceId: "emulator-5554",
+      avdName: "Pixel_7",
+      detectionPath: "watched-process-exit",
+      processExit: { code: 1, signal: null },
+      outputTail: "token=[REDACTED] emulator died\n",
+      recovery: {
+        policy: { onLoss: false, maxAttempts: 2 },
+        attempts: [],
+        outcome: "not-attempted",
+      },
+    });
+    expect(incident.outputTail).not.toContain("should-not-leak");
   });
 });

--- a/test/daemon/devicePool.evictionCatch.test.ts
+++ b/test/daemon/devicePool.evictionCatch.test.ts
@@ -106,8 +106,11 @@ describe("DevicePool emulator-exit eviction rejection handling", () => {
     (diagnosticPool as unknown as {
       trackStartedDeviceProcess: (device: unknown, child: unknown) => Promise<void>;
     }).trackStartedDeviceProcess(androidDevice, child);
-    child.stderr.emit("data", Buffer.from("token=should-not-leak emulator died\n"));
+    child.stdout.emit("data", Buffer.from("token="));
     (child as unknown as EventEmitter).emit("exit", 1, null);
+    child.stderr.emit("data", Buffer.from("emulator died\n"));
+    child.stdout.emit("data", Buffer.from("should-not-leak\n"));
+    (child as unknown as EventEmitter).emit("close", 1, null);
 
     for (let i = 0; i < 10; i++) {
       await Promise.resolve();
@@ -119,7 +122,7 @@ describe("DevicePool emulator-exit eviction rejection handling", () => {
       avdName: "Pixel_7",
       detectionPath: "watched-process-exit",
       processExit: { code: 1, signal: null },
-      outputTail: "token=[REDACTED] emulator died\n",
+      outputTail: "token=[REDACTED]\nemulator died\n",
       recovery: {
         policy: { onLoss: false, maxAttempts: 2 },
         attempts: [],

--- a/test/daemon/devicePool.evictionCatch.test.ts
+++ b/test/daemon/devicePool.evictionCatch.test.ts
@@ -103,7 +103,7 @@ describe("DevicePool emulator-exit eviction rejection handling", () => {
     };
     child.stdout = new EventEmitter();
     child.stderr = new EventEmitter();
-    (diagnosticPool as unknown as {
+    await (diagnosticPool as unknown as {
       trackStartedDeviceProcess: (device: unknown, child: unknown) => Promise<void>;
     }).trackStartedDeviceProcess(androidDevice, child);
     child.stdout.emit("data", Buffer.from("token="));

--- a/test/daemon/devicePool.test.ts
+++ b/test/daemon/devicePool.test.ts
@@ -19,6 +19,8 @@ import type { AdbClient } from "../../src/utils/android-cmdline-tools/AdbClient"
 import type { AndroidEmulatorClient } from "../../src/utils/android-cmdline-tools/AndroidEmulatorClient";
 import type { SimCtlClient } from "../../src/utils/ios-cmdline-tools/SimCtlClient";
 import { getAbortSignal } from "../../src/utils/AbortContext";
+import { InMemoryEmulatorLossIncidentStore } from "../../src/daemon/emulatorLossIncident";
+import { CountingIdGenerator } from "../../src/utils/IdGenerator";
 
 async function withProcessPlatform<T>(platform: NodeJS.Platform, fn: () => Promise<T>): Promise<T> {
   const original = process.platform;
@@ -382,6 +384,18 @@ describe("DevicePool", () => {
         childProcess.signalCode = null;
       }
       return childProcess;
+    }
+  }
+
+  class FakeDeviceManagerWithFailingRecoveryStart extends FakeDeviceManagerWithDistinctStartedProcesses {
+    override async startDevice(
+      device: DeviceInfo,
+      timeoutMs: number = DEFAULT_DEVICE_READY_TIMEOUT_MS,
+    ): Promise<FakeChildProcess> {
+      if (this.childProcesses.length > 0) {
+        throw new Error("recovery spawn failed");
+      }
+      return await super.startDevice(device, timeoutMs);
     }
   }
 
@@ -2971,6 +2985,64 @@ describe("DevicePool", () => {
           process.env.AUTOMOBILE_ANDROID_REBOOT_ON_DEATH = originalRebootOnDeath;
         }
       }
+    });
+
+    test("records failed recovery spawn attempts", async () => {
+      const images: DeviceInfo[] = [{
+        name: "Pixel 8",
+        platform: "android",
+        isRunning: false,
+        deviceId: "emulator-5554",
+        source: "local",
+      }];
+      const manager = new FakeDeviceManagerWithFailingRecoveryStart(images);
+      const incidents = new InMemoryEmulatorLossIncidentStore(
+        fakeTimer,
+        new CountingIdGenerator("incident"),
+      );
+      const twoFailedAttempts = {
+        async run(_target: DeviceInfo, reboot: () => Promise<void>): Promise<boolean> {
+          for (let attempt = 0; attempt < 2; attempt++) {
+            try {
+              await reboot();
+            } catch {
+              // The retry policy intentionally continues after each failed start.
+            }
+          }
+          return false;
+        },
+      };
+      devicePool = new DevicePool(
+        sessionManager,
+        "test-daemon-session-id",
+        fakeTimer,
+        fakeAppsRepo,
+        manager,
+        new DefaultRetryExecutor(fakeTimer),
+        undefined,
+        undefined,
+        undefined,
+        undefined,
+        twoFailedAttempts,
+        { onLoss: true, maxAttempts: 2 },
+        undefined,
+        incidents,
+      );
+
+      await devicePool.assignMultipleDevices(["session-1"], 1_000, "android");
+      manager.bootedDevices = [];
+      manager.childProcesses[0]!.emit("exit", 1, null);
+      await new Promise((resolve) => setImmediate(resolve));
+
+      const [incident] = await incidents.list();
+      expect(incident?.recovery).toEqual({
+        policy: { onLoss: true, maxAttempts: 2 },
+        attempts: [
+          { attempt: 1, outcome: "failed" },
+          { attempt: 2, outcome: "failed" },
+        ],
+        outcome: "exhausted",
+      });
     });
 
     test("does not recover an emulator intentionally shut down by the client", async () => {

--- a/test/daemon/devicePool.test.ts
+++ b/test/daemon/devicePool.test.ts
@@ -2793,13 +2793,14 @@ describe("DevicePool", () => {
       manager.childProcess.emit("exit", 0, null);
       await new Promise((resolve) => setImmediate(resolve));
 
-      expect(releaseCalls).toEqual([
-        {
-          sessionId: "session-1",
-          deviceId: "emulator-5554",
-          reason: "device-disconnected:emulator-5554",
-        },
-      ]);
+      expect(releaseCalls).toHaveLength(1);
+      expect(releaseCalls[0]).toEqual({
+        sessionId: "session-1",
+        deviceId: "emulator-5554",
+        reason: expect.stringMatching(
+          /^device-disconnected:emulator-5554;incident=emulator-loss-/,
+        ),
+      });
       expect(devicePool.getDevice("emulator-5554")).toBeNull();
       expect(sessionManager.getSession("session-1")).toBeNull();
     });

--- a/test/daemon/emulatorLossIncident.test.ts
+++ b/test/daemon/emulatorLossIncident.test.ts
@@ -1,0 +1,72 @@
+import { describe, expect, test } from "bun:test";
+import {
+  InMemoryEmulatorLossIncidentStore,
+  type EmulatorLossIncident,
+} from "../../src/daemon/emulatorLossIncident";
+import { CountingIdGenerator } from "../../src/utils/IdGenerator";
+import { FakeTimer } from "../fakes/FakeTimer";
+
+function createStore(): InMemoryEmulatorLossIncidentStore {
+  return new InMemoryEmulatorLossIncidentStore(
+    new FakeTimer(),
+    new CountingIdGenerator("incident"),
+  );
+}
+
+describe("emulator loss incident store", () => {
+  test("retains a bounded, correlated recovery record", async () => {
+    const store = createStore();
+
+    const incident = await store.open({
+      deviceId: "emulator-5554",
+      avdName: "Pixel_9_Pro",
+      detectionPath: "watched-process-exit",
+      processExit: { code: 1, signal: null },
+      outputTail: "token=[REDACTED]\nqemu exited",
+      lastAdbState: "device",
+      recoveryPolicy: { onLoss: true, maxAttempts: 2 },
+    });
+    await store.recordRecoveryAttempt(incident.id, { attempt: 1, outcome: "failed" });
+    await store.recordRecoveryAttempt(incident.id, { attempt: 2, outcome: "succeeded" });
+    await store.completeRecovery(incident.id, "recovered");
+
+    expect(await store.get(incident.id)).toEqual<EmulatorLossIncident>({
+      ...incident,
+      recovery: {
+        policy: { onLoss: true, maxAttempts: 2 },
+        attempts: [
+          { attempt: 1, outcome: "failed" },
+          { attempt: 2, outcome: "succeeded" },
+        ],
+        outcome: "recovered",
+      },
+    });
+  });
+
+  test("keeps only the configured newest incident records", async () => {
+    const store = new InMemoryEmulatorLossIncidentStore(
+      new FakeTimer(),
+      new CountingIdGenerator("incident"),
+      2,
+    );
+
+    const first = await store.open({
+      deviceId: "emulator-5554",
+      detectionPath: "device-discovery-miss",
+      recoveryPolicy: { onLoss: false, maxAttempts: 2 },
+    });
+    const second = await store.open({
+      deviceId: "emulator-5556",
+      detectionPath: "device-discovery-miss",
+      recoveryPolicy: { onLoss: false, maxAttempts: 2 },
+    });
+    const third = await store.open({
+      deviceId: "emulator-5558",
+      detectionPath: "adb-transport-failure",
+      recoveryPolicy: { onLoss: false, maxAttempts: 2 },
+    });
+
+    expect(await store.get(first.id)).toBeUndefined();
+    expect((await store.list()).map((incident) => incident.id)).toEqual([third.id, second.id]);
+  });
+});

--- a/test/daemon/emulatorLossIncident.test.ts
+++ b/test/daemon/emulatorLossIncident.test.ts
@@ -69,4 +69,15 @@ describe("emulator loss incident store", () => {
     expect(await store.get(first.id)).toBeUndefined();
     expect((await store.list()).map((incident) => incident.id)).toEqual([third.id, second.id]);
   });
+
+  test("list(0) returns no incidents, matching the repository", async () => {
+    const store = createStore();
+    await store.open({
+      deviceId: "emulator-5554",
+      detectionPath: "device-discovery-miss",
+      recoveryPolicy: { onLoss: false, maxAttempts: 2 },
+    });
+
+    expect(await store.list(0)).toEqual([]);
+  });
 });

--- a/test/db/deviceSessionRepository.test.ts
+++ b/test/db/deviceSessionRepository.test.ts
@@ -222,7 +222,9 @@ describe("DeviceSessionRepository", () => {
         .rejects.toThrow(/not available|shut down|disconnected/);
 
       const row = await repo.getSession("session-1");
-      expect(row!.release_reason).toBe("device-disconnected:emulator-5554");
+      expect(row!.release_reason).toMatch(
+        /^device-disconnected:emulator-5554;incident=emulator-loss-/,
+      );
     } finally {
       sessionManager.stopCleanupTimer();
     }

--- a/test/db/emulatorLossIncidentRepository.test.ts
+++ b/test/db/emulatorLossIncidentRepository.test.ts
@@ -56,4 +56,27 @@ describe("EmulatorLossIncidentRepository", () => {
       outcome: "exhausted",
     });
   });
+
+  test("retains the most recently inserted incident when timestamps tie", async () => {
+    const ids = ["z-first", "a-second"];
+    const repository = new EmulatorLossIncidentRepository(
+      new FakeTimer(),
+      { next: () => ids.shift()! },
+      1,
+      db,
+    );
+    const first = await repository.open({
+      deviceId: "emulator-5554",
+      detectionPath: "device-discovery-miss",
+      recoveryPolicy: { onLoss: true, maxAttempts: 2 },
+    });
+    const second = await repository.open({
+      deviceId: "emulator-5556",
+      detectionPath: "device-discovery-miss",
+      recoveryPolicy: { onLoss: true, maxAttempts: 2 },
+    });
+
+    expect(await repository.get(first.id)).toBeUndefined();
+    expect((await repository.list()).map((incident) => incident.id)).toEqual([second.id]);
+  });
 });

--- a/test/db/emulatorLossIncidentRepository.test.ts
+++ b/test/db/emulatorLossIncidentRepository.test.ts
@@ -1,21 +1,16 @@
 import { afterEach, beforeEach, describe, expect, test } from "bun:test";
-import { Database as BunDatabase } from "bun:sqlite";
 import { Kysely } from "kysely";
-import { BunSqliteDialect } from "../../src/db/bunSqliteDialect";
 import { EmulatorLossIncidentRepository } from "../../src/db/emulatorLossIncidentRepository";
-import { up as emulatorLossIncidentsUp } from "../../src/db/migrations/2026_08_17_000_emulator_loss_incidents";
 import type { Database } from "../../src/db/types";
 import { FakeTimer } from "../fakes/FakeTimer";
 import { CountingIdGenerator } from "../../src/utils/IdGenerator";
+import { createTestDatabase } from "./testDbHelper";
 
 describe("EmulatorLossIncidentRepository", () => {
   let db: Kysely<Database>;
 
   beforeEach(async () => {
-    db = new Kysely<Database>({
-      dialect: new BunSqliteDialect({ database: new BunDatabase(":memory:") }),
-    });
-    await emulatorLossIncidentsUp(db as unknown as Kysely<unknown>);
+    db = await createTestDatabase();
   });
 
   afterEach(async () => {
@@ -78,5 +73,37 @@ describe("EmulatorLossIncidentRepository", () => {
 
     expect(await repository.get(first.id)).toBeUndefined();
     expect((await repository.list()).map((incident) => incident.id)).toEqual([second.id]);
+  });
+
+  test("preserves concurrent recovery updates", async () => {
+    const timer = new FakeTimer();
+    const repository = new EmulatorLossIncidentRepository(
+      timer,
+      new CountingIdGenerator("incident"),
+      2,
+      db,
+    );
+    const concurrentRepository = new EmulatorLossIncidentRepository(
+      timer,
+      new CountingIdGenerator("concurrent"),
+      2,
+      db,
+    );
+    const incident = await repository.open({
+      deviceId: "emulator-5554",
+      detectionPath: "watched-process-exit",
+      recoveryPolicy: { onLoss: true, maxAttempts: 2 },
+    });
+
+    await Promise.all([
+      repository.recordRecoveryAttempt(incident.id, { attempt: 1, outcome: "failed" }),
+      concurrentRepository.completeRecovery(incident.id, "exhausted"),
+    ]);
+
+    expect((await repository.get(incident.id))?.recovery).toEqual({
+      policy: { onLoss: true, maxAttempts: 2 },
+      attempts: [{ attempt: 1, outcome: "failed" }],
+      outcome: "exhausted",
+    });
   });
 });

--- a/test/db/emulatorLossIncidentRepository.test.ts
+++ b/test/db/emulatorLossIncidentRepository.test.ts
@@ -1,0 +1,59 @@
+import { afterEach, beforeEach, describe, expect, test } from "bun:test";
+import { Database as BunDatabase } from "bun:sqlite";
+import { Kysely } from "kysely";
+import { BunSqliteDialect } from "../../src/db/bunSqliteDialect";
+import { EmulatorLossIncidentRepository } from "../../src/db/emulatorLossIncidentRepository";
+import { up as emulatorLossIncidentsUp } from "../../src/db/migrations/2026_08_17_000_emulator_loss_incidents";
+import type { Database } from "../../src/db/types";
+import { FakeTimer } from "../fakes/FakeTimer";
+import { CountingIdGenerator } from "../../src/utils/IdGenerator";
+
+describe("EmulatorLossIncidentRepository", () => {
+  let db: Kysely<Database>;
+
+  beforeEach(async () => {
+    db = new Kysely<Database>({
+      dialect: new BunSqliteDialect({ database: new BunDatabase(":memory:") }),
+    });
+    await emulatorLossIncidentsUp(db as unknown as Kysely<unknown>);
+  });
+
+  afterEach(async () => {
+    await db.destroy();
+  });
+
+  test("persists recovery attempts and prunes oldest records", async () => {
+    const repository = new EmulatorLossIncidentRepository(
+      new FakeTimer(),
+      new CountingIdGenerator("incident"),
+      2,
+      db,
+    );
+    const first = await repository.open({
+      deviceId: "emulator-5554",
+      detectionPath: "device-discovery-miss",
+      recoveryPolicy: { onLoss: true, maxAttempts: 2 },
+    });
+    const second = await repository.open({
+      deviceId: "emulator-5556",
+      detectionPath: "device-discovery-miss",
+      recoveryPolicy: { onLoss: true, maxAttempts: 2 },
+    });
+    const third = await repository.open({
+      deviceId: "emulator-5558",
+      detectionPath: "adb-transport-failure",
+      recoveryPolicy: { onLoss: true, maxAttempts: 2 },
+    });
+
+    await repository.recordRecoveryAttempt(third.id, { attempt: 1, outcome: "failed" });
+    await repository.completeRecovery(third.id, "exhausted");
+
+    expect(await repository.get(first.id)).toBeUndefined();
+    expect((await repository.list()).map((incident) => incident.id)).toEqual([third.id, second.id]);
+    expect((await repository.get(third.id))?.recovery).toEqual({
+      policy: { onLoss: true, maxAttempts: 2 },
+      attempts: [{ attempt: 1, outcome: "failed" }],
+      outcome: "exhausted",
+    });
+  });
+});

--- a/test/server/deviceLossOutcome.test.ts
+++ b/test/server/deviceLossOutcome.test.ts
@@ -2,6 +2,7 @@ import { describe, expect, test } from "bun:test";
 import {
   DEVICE_LOSS_OUTCOME_CODE,
   DeviceLostError,
+  deviceLostErrorFromCancellationReason,
   deviceLossOutcomeFromError,
 } from "../../src/server/deviceLossOutcome";
 
@@ -16,5 +17,19 @@ describe("device-loss outcome", () => {
       reason: "confirmed-unavailable",
     });
     expect(deviceLossOutcomeFromError(new Error("tap failed"), "session-a")).toBeUndefined();
+  });
+
+  test("preserves the emulator-loss incident correlation identifier", () => {
+    const error = deviceLostErrorFromCancellationReason(
+      "device-disconnected:emulator-5554;incident=emulator-loss-test-1",
+    );
+
+    expect(deviceLossOutcomeFromError(error, "session-a")).toEqual({
+      code: DEVICE_LOSS_OUTCOME_CODE,
+      deviceId: "emulator-5554",
+      sessionUuid: "session-a",
+      incidentId: "emulator-loss-test-1",
+      reason: "confirmed-unavailable",
+    });
   });
 });

--- a/test/server/emulatorLossIncidentResources.test.ts
+++ b/test/server/emulatorLossIncidentResources.test.ts
@@ -1,0 +1,47 @@
+import { afterEach, beforeEach, describe, expect, test } from "bun:test";
+import {
+  registerEmulatorLossIncidentResources,
+  resetEmulatorLossIncidentReaderForTesting,
+  setEmulatorLossIncidentReaderForTesting,
+} from "../../src/server/emulatorLossIncidentResources";
+import { EMULATOR_LOSS_INCIDENT_RESOURCE_URIS } from "../../src/server/emulatorLossIncidentResourceUris";
+import { ResourceRegistry } from "../../src/server/resourceRegistry";
+import type { EmulatorLossIncident } from "../../src/daemon/emulatorLossIncident";
+
+const incident: EmulatorLossIncident = {
+  id: "emulator-loss-1",
+  observedAtMs: 1,
+  updatedAtMs: 2,
+  deviceId: "emulator-5554",
+  detectionPath: "watched-process-exit",
+  recovery: {
+    policy: { onLoss: true, maxAttempts: 2 },
+    attempts: [{ attempt: 1, outcome: "succeeded" }],
+    outcome: "recovered",
+  },
+};
+
+describe("emulatorLossIncidentResources", () => {
+  beforeEach(() => {
+    registerEmulatorLossIncidentResources();
+  });
+
+  afterEach(() => {
+    ResourceRegistry.clearResources();
+    resetEmulatorLossIncidentReaderForTesting();
+  });
+
+  test("lists persisted incidents through a stable resource URI", async () => {
+    setEmulatorLossIncidentReaderForTesting({
+      list: async () => [incident],
+    });
+    const resource = ResourceRegistry.getResource(EMULATOR_LOSS_INCIDENT_RESOURCE_URIS.ARCHIVE);
+
+    expect(resource).toBeDefined();
+    const content = await resource!.handler();
+    expect(JSON.parse(content.text ?? "{}")).toEqual({
+      incidents: [incident],
+      count: 1,
+    });
+  });
+});


### PR DESCRIPTION
## Summary
- Persist bounded, redacted Android emulator-loss incidents, including process output, exit metadata, ADB detection path, and recovery attempts.
- Surface an incident ID in `device_lost` MCP outcomes and expose the retained incident archive as a resource.
- Preserve existing recovery behavior while recording its final outcome.

Closes [#5276](https://github.com/kaeawc/auto-mobile/issues/5276).

## Validation
- `bun run lint`
- `bun run typecheck`
- `bun run build`
- `bun test test/daemon/devicePool.test.ts test/daemon/devicePoolRecoveryPolicy.test.ts test/daemon/devicePool.evictionCatch.test.ts test/daemon/daemonDevicePoolStartup.test.ts test/server/deviceLossOutcome.test.ts test/server/deviceLossOutcomeWire.test.ts test/db/emulatorLossIncidentRepository.test.ts test/server/emulatorLossIncidentResources.test.ts test/db/migrations.test.ts test/db/migrationFilenameOrdering.test.ts`
