### PR TITLE
fix(ios): require runner readiness for session auto-start

### DIFF
--- a/src/daemon/daemon.ts
+++ b/src/daemon/daemon.ts
@@ -1490,22 +1490,22 @@ export class Daemon {
       try {
         logger.info(`[Daemon] Setting up CtrlProxy iOS for iOS device ${device.id}`);
 
-        const timeoutPromise = new Promise<never>((_, reject) => {
-          const timer = defaultTimer.setTimeout(() => {
-            reject(new Error(`Timeout after ${PER_DEVICE_TIMEOUT_MS}ms`));
-          }, PER_DEVICE_TIMEOUT_MS);
-          // Allow process to exit even if this timer is pending
-          if (typeof (timer as { unref?: () => void }).unref === "function") {
-            (timer as { unref: () => void }).unref();
-          }
-        });
-
-        await Promise.race([
-          deviceSessionManager.verifyIosDevice(device.id, {
-            skipCtrlProxyDownload: true  // Skip app download during startup, use cached version
-          }),
-          timeoutPromise
-        ]);
+        const controller = new AbortController();
+        const timer = defaultTimer.setTimeout(() => {
+          controller.abort(new Error(`Timeout after ${PER_DEVICE_TIMEOUT_MS}ms`));
+        }, PER_DEVICE_TIMEOUT_MS);
+        // Allow process to exit even if this timer is pending.
+        if (typeof (timer as { unref?: () => void }).unref === "function") {
+          (timer as { unref: () => void }).unref();
+        }
+        try {
+          await deviceSessionManager.verifyIosDevice(device.id, {
+            skipCtrlProxyDownload: true, // Skip app download during startup, use cached version
+            signal: controller.signal,
+          });
+        } finally {
+          defaultTimer.clearTimeout(timer);
+        }
         logger.info(`[Daemon] CtrlProxy iOS ready for iOS device ${device.id}`);
       } catch (error) {
         // Log but don't fail - service will be set up on first tool call if needed

--- a/src/utils/DeviceSessionManager.ts
+++ b/src/utils/DeviceSessionManager.ts
@@ -24,8 +24,8 @@ import { applyAppearanceOnConnect } from "./appearance/applyAppearanceOnConnect"
 import { disableStylusHandwriting } from "./disableStylusHandwriting";
 import { checkIosCtrlProxyOverride } from "./iosCtrlProxyOverride";
 import { RunnerReadinessService } from "./RunnerReadinessService";
-import { DEFAULT_RUNNER_READINESS_TIMEOUT_MS } from "./runnerReadinessConfig";
 import { defaultTimer, type Timer } from "./SystemTimer";
+import { serverConfig } from "./ServerConfig";
 
 /**
  * Render a device list for a "not found" error.
@@ -248,7 +248,7 @@ export class DeviceSessionManager implements DeviceSessionManager {
     this.adbFactory = adbFactory;
     this.runnerReadinessTimer = options.runnerReadinessTimer ?? defaultTimer;
     this.runnerReadinessTimeoutMs =
-      options.runnerReadinessTimeoutMs ?? DEFAULT_RUNNER_READINESS_TIMEOUT_MS;
+      options.runnerReadinessTimeoutMs ?? serverConfig.getRunnerReadinessTimeoutMs();
     this.runnerReadinessService = new RunnerReadinessService({
       timer: this.runnerReadinessTimer,
       getAndroidManager: (device) => this.provider.getAndroidCtrlProxyManager(device),
@@ -752,6 +752,7 @@ export class DeviceSessionManager implements DeviceSessionManager {
       await this.runnerReadinessService.ensureReady({
         device,
         requestedIdentity: `platform=ios deviceId=${deviceId}`,
+        operationName: "legacy iOS session auto-start",
         totalDeadlineMs,
         readinessTimeoutMs: this.runnerReadinessTimeoutMs,
         skipCtrlProxyDownload:

--- a/src/utils/DeviceSessionManager.ts
+++ b/src/utils/DeviceSessionManager.ts
@@ -23,7 +23,7 @@ import { storeSetupTiming } from "../server/ToolExecutionContext";
 import { applyAppearanceOnConnect } from "./appearance/applyAppearanceOnConnect";
 import { disableStylusHandwriting } from "./disableStylusHandwriting";
 import { checkIosCtrlProxyOverride } from "./iosCtrlProxyOverride";
-import { RunnerReadinessService } from "./RunnerReadinessService";
+import { RunnerReadinessError, RunnerReadinessService } from "./RunnerReadinessService";
 import { defaultTimer, type Timer } from "./SystemTimer";
 import { serverConfig } from "./ServerConfig";
 
@@ -208,6 +208,7 @@ export interface DeviceSessionManager {
 
 export interface DeviceReadyOptions {
   skipCtrlProxyDownload?: boolean;
+  signal?: AbortSignal;
   /**
    * @deprecated Use skipCtrlProxyDownload instead.
    */
@@ -232,7 +233,7 @@ export class DeviceSessionManager implements DeviceSessionManager {
   private readonly adbFactory: AdbClientFactory;
   private readonly runnerReadinessService: RunnerReadinessService;
   private readonly runnerReadinessTimer: Timer;
-  private readonly runnerReadinessTimeoutMs: number;
+  private readonly runnerReadinessTimeoutMs: number | undefined;
   private _adb: AdbExecutor | undefined;
   private simulatorAppOpened = false;
 
@@ -247,8 +248,7 @@ export class DeviceSessionManager implements DeviceSessionManager {
     this.provider = provider;
     this.adbFactory = adbFactory;
     this.runnerReadinessTimer = options.runnerReadinessTimer ?? defaultTimer;
-    this.runnerReadinessTimeoutMs =
-      options.runnerReadinessTimeoutMs ?? serverConfig.getRunnerReadinessTimeoutMs();
+    this.runnerReadinessTimeoutMs = options.runnerReadinessTimeoutMs;
     this.runnerReadinessService = new RunnerReadinessService({
       timer: this.runnerReadinessTimer,
       getAndroidManager: (device) => this.provider.getAndroidCtrlProxyManager(device),
@@ -453,6 +453,9 @@ export class DeviceSessionManager implements DeviceSessionManager {
         deviceVerified = true;
         deviceSource = "current";
       } catch (error) {
+        if (error instanceof RunnerReadinessError) {
+          throw error;
+        }
         logger.warn(`Current device ${this.currentDevice} is no longer ready: ${error}`);
         this.currentDevice = undefined;
         this.currentPlatform = undefined;
@@ -745,21 +748,24 @@ export class DeviceSessionManager implements DeviceSessionManager {
     const perf = createPerformanceTracker(true);
     perf.serial("ensureCtrlProxy iOS");
     let didSetup = false;
+    const runnerReadinessTimeoutMs =
+      this.runnerReadinessTimeoutMs ?? serverConfig.getRunnerReadinessTimeoutMs();
 
     try {
       const totalDeadlineMs =
-        this.runnerReadinessTimer.now() + this.runnerReadinessTimeoutMs;
+        this.runnerReadinessTimer.now() + runnerReadinessTimeoutMs;
       await this.runnerReadinessService.ensureReady({
         device,
         requestedIdentity: `platform=ios deviceId=${deviceId}`,
         operationName: "legacy iOS session auto-start",
         totalDeadlineMs,
-        readinessTimeoutMs: this.runnerReadinessTimeoutMs,
+        readinessTimeoutMs: runnerReadinessTimeoutMs,
         skipCtrlProxyDownload:
           options?.skipCtrlProxyDownload ??
           options?.skipAccessibilityDownload ??
           options?.skipAccessibilitySetup,
         perf,
+        signal: options?.signal,
         onRunnerSetup: () => {
           didSetup = true;
         },

--- a/src/utils/DeviceSessionManager.ts
+++ b/src/utils/DeviceSessionManager.ts
@@ -23,6 +23,9 @@ import { storeSetupTiming } from "../server/ToolExecutionContext";
 import { applyAppearanceOnConnect } from "./appearance/applyAppearanceOnConnect";
 import { disableStylusHandwriting } from "./disableStylusHandwriting";
 import { checkIosCtrlProxyOverride } from "./iosCtrlProxyOverride";
+import { RunnerReadinessService } from "./RunnerReadinessService";
+import { DEFAULT_RUNNER_READINESS_TIMEOUT_MS } from "./runnerReadinessConfig";
+import { defaultTimer, type Timer } from "./SystemTimer";
 
 /**
  * Render a device list for a "not found" error.
@@ -215,6 +218,11 @@ export interface DeviceReadyOptions {
   skipAccessibilitySetup?: boolean;
 }
 
+export interface DeviceSessionManagerOptions {
+  runnerReadinessTimer?: Timer;
+  runnerReadinessTimeoutMs?: number;
+}
+
 export class DeviceSessionManager implements DeviceSessionManager {
   private currentDevice: BootedDevice | undefined;
   private currentPlatform: Platform | undefined;
@@ -222,15 +230,34 @@ export class DeviceSessionManager implements DeviceSessionManager {
   private static defaultProvider: DeviceClientProvider | undefined;
   private readonly provider: DeviceClientProvider;
   private readonly adbFactory: AdbClientFactory;
+  private readonly runnerReadinessService: RunnerReadinessService;
+  private readonly runnerReadinessTimer: Timer;
+  private readonly runnerReadinessTimeoutMs: number;
   private _adb: AdbExecutor | undefined;
   private simulatorAppOpened = false;
 
   // Track devices that have push update listeners registered
   private static pushUpdateListenersRegistered: Set<string> = new Set();
 
-  private constructor(provider: DeviceClientProvider, adbFactory: AdbClientFactory = defaultAdbClientFactory) {
+  private constructor(
+    provider: DeviceClientProvider,
+    adbFactory: AdbClientFactory = defaultAdbClientFactory,
+    options: DeviceSessionManagerOptions = {},
+  ) {
     this.provider = provider;
     this.adbFactory = adbFactory;
+    this.runnerReadinessTimer = options.runnerReadinessTimer ?? defaultTimer;
+    this.runnerReadinessTimeoutMs =
+      options.runnerReadinessTimeoutMs ?? DEFAULT_RUNNER_READINESS_TIMEOUT_MS;
+    this.runnerReadinessService = new RunnerReadinessService({
+      timer: this.runnerReadinessTimer,
+      getAndroidManager: (device) => this.provider.getAndroidCtrlProxyManager(device),
+      getAndroidClient: (device) => this.provider.getAndroidCtrlProxyClient(device),
+      getIosManager: (device) => this.provider.getIOSCtrlProxyManager(device),
+      getIosClient: (device, port) => this.provider.getIOSCtrlProxyClient(device, port),
+      checkIosOverride: checkIosCtrlProxyOverride,
+      awaitIosStartupMaintenance: () => IOSCtrlProxyManager.awaitStartupOrphanRunnerReap(),
+    });
   }
 
   private get adb(): AdbExecutor {
@@ -262,8 +289,12 @@ export class DeviceSessionManager implements DeviceSessionManager {
     return DeviceSessionManager.instance;
   }
 
-  public static createInstance(provider: DeviceClientProvider, adbFactory?: AdbClientFactory): DeviceSessionManager {
-    return new DeviceSessionManager(provider, adbFactory);
+  public static createInstance(
+    provider: DeviceClientProvider,
+    adbFactory?: AdbClientFactory,
+    options?: DeviceSessionManagerOptions,
+  ): DeviceSessionManager {
+    return new DeviceSessionManager(provider, adbFactory, options);
   }
 
   /**
@@ -709,121 +740,32 @@ export class DeviceSessionManager implements DeviceSessionManager {
       platform: "ios"
     };
 
-    // Always track setup timing (one-time per session, valuable for debugging)
+    // Pass the tracker through to CtrlProxy setup while keeping the legacy
+    // session path subject to the same strict readiness contract as startDevice.
     const perf = createPerformanceTracker(true);
     perf.serial("ensureCtrlProxy iOS");
     let didSetup = false;
 
     try {
-      const skipCtrlProxyIOSSetup = options?.skipCtrlProxyDownload ?? options?.skipAccessibilityDownload ?? options?.skipAccessibilitySetup;
-
-      await IOSCtrlProxyManager.awaitStartupOrphanRunnerReap();
-      const manager = this.provider.getIOSCtrlProxyManager(device);
-      const xcTestClient = this.provider.getIOSCtrlProxyClient(device, manager.getServicePort());
-
-      // Check if WebSocket is already connected
-      if (xcTestClient.isConnected()) {
-        // WebSocket appears connected, verify service is actually responsive
-        logger.info(`[DeviceSessionManager] CtrlProxy iOS WebSocket connected for ${deviceId}, verifying service is responsive`);
-        const isReady = await perf.track("verifyConnectedService", () =>
-          xcTestClient.verifyServiceReady(2, 200, 2000)
-        );
-        if (isReady) {
-          logger.info(`[DeviceSessionManager] CtrlProxy iOS verified responsive for ${deviceId}`);
-          this.registerPushUpdateListener(device);
-          perf.end();
-          return;
-        }
-        // Service not responsive despite connected socket - fall through to normal flow
-        logger.warn(`[DeviceSessionManager] WebSocket connected but CtrlProxy iOS not responsive for ${deviceId}, checking status`);
-      }
-
-      // Check current status
-      const isRunning = await perf.track("checkRunning", () => manager.isRunning());
-
-      if (isRunning) {
-        logger.info(`[DeviceSessionManager] CtrlProxy iOS already running for ${deviceId}, verifying WebSocket connection`);
-        // Service is running, try to connect WebSocket
-        const connected = await perf.track("verifyConnection", () => xcTestClient.waitForConnection(3, 200));
-        if (connected) {
-          // Verify service is responsive and cache hierarchy for fast first observe
-          logger.info(`[DeviceSessionManager] Verifying CtrlProxy iOS is responsive for ${deviceId}`);
-          const ready = await perf.track("verifyServiceReady", () => xcTestClient.verifyServiceReady(3, 500, 3000));
-          if (ready) {
-            logger.info(`[DeviceSessionManager] CtrlProxy iOS running, connected, and verified for ${deviceId}`);
-            this.registerPushUpdateListener(device);
-            perf.end();
-            return;
-          }
-          logger.warn(`[DeviceSessionManager] CtrlProxy iOS running and connected but not responsive for ${deviceId}`);
-        }
-        // WebSocket won't connect despite service running - may need restart
-        logger.warn(`[DeviceSessionManager] CtrlProxy iOS running but WebSocket failed for ${deviceId}, will attempt restart`);
-        manager.resetSetupState();
-      }
-
-      if (skipCtrlProxyIOSSetup) {
-        // When download is disabled, only start from cached artifacts — never trigger
-        // needsRebuild() or download. Use start() directly to avoid the build path.
-        const isRunningNow = await manager.isRunning();
-        if (!isRunningNow) {
-          const isInstalled = await manager.isInstalled();
-          if (isInstalled) {
-            logger.info(`[DeviceSessionManager] CtrlProxy iOS installed (cached), starting without download for ${deviceId}`);
-            try {
-              await manager.start();
-            } catch (error) {
-              logger.warn(`[DeviceSessionManager] Failed to start cached CtrlProxy iOS for ${deviceId}: ${error}`);
-            }
-          } else {
-            logger.info(`[DeviceSessionManager] Skipping CtrlProxy iOS setup for ${deviceId} (not installed, download disabled)`);
-          }
-        }
-        perf.end();
-        return;
-      }
-
-      // Setup the service (will start if not running, may download if needed)
-      logger.info(`[DeviceSessionManager] Setting up CtrlProxy iOS for ${deviceId}`);
-      const setupResult = await manager.setup(false, perf);
-      didSetup = true;
-
-      if (!setupResult.success) {
-        // Log build-specific errors if available
-        if (setupResult.buildResult && !setupResult.buildResult.success) {
-          logger.warn(`[DeviceSessionManager] CtrlProxy iOS build failed for ${deviceId}: ${setupResult.buildResult.error}`);
-        } else {
-          logger.warn(`[DeviceSessionManager] CtrlProxy iOS setup failed for ${deviceId}: ${setupResult.error}`);
-        }
-        // Don't throw - allow observe to fall back to other methods
-        perf.end();
-        return;
-      }
-
-      // Wait for WebSocket connection after setup
-      // After fresh setup, WebSocket may need extra time to initialize
-      logger.info(`[DeviceSessionManager] Waiting for CtrlProxy iOS WebSocket connection after setup for ${deviceId}`);
-      const connected = await perf.track("waitForConnection", () => xcTestClient.waitForConnection(5, 1000));
-      if (connected) {
-        // Verify service is actually ready to respond (not just WebSocket connected)
-        logger.info(`[DeviceSessionManager] Verifying CtrlProxy iOS is responsive for ${deviceId}`);
-        const ready = await perf.track("verifyServiceReady", () => xcTestClient.verifyServiceReady(5, 1000, 5000));
-        if (!ready) {
-          logger.warn(`[DeviceSessionManager] CtrlProxy iOS not responsive after setup for ${deviceId}`);
-        } else {
-          logger.info(`[DeviceSessionManager] CtrlProxy iOS setup complete and verified for ${deviceId}`);
-          this.registerPushUpdateListener(device);
-        }
-      } else {
-        logger.warn(`[DeviceSessionManager] WebSocket connection failed after CtrlProxy iOS setup for ${deviceId}`);
-      }
-    } catch (error) {
-      const errorMessage = error instanceof Error ? error.message : String(error);
-      logger.error(`[DeviceSessionManager] Failed to setup CtrlProxy iOS: ${errorMessage}`);
-      // Don't throw - allow observe to fall back to other methods
+      const totalDeadlineMs =
+        this.runnerReadinessTimer.now() + this.runnerReadinessTimeoutMs;
+      await this.runnerReadinessService.ensureReady({
+        device,
+        requestedIdentity: `platform=ios deviceId=${deviceId}`,
+        totalDeadlineMs,
+        readinessTimeoutMs: this.runnerReadinessTimeoutMs,
+        skipCtrlProxyDownload:
+          options?.skipCtrlProxyDownload ??
+          options?.skipAccessibilityDownload ??
+          options?.skipAccessibilitySetup,
+        perf,
+        onRunnerSetup: () => {
+          didSetup = true;
+        },
+      });
+      this.registerPushUpdateListener(device);
     } finally {
       perf.end();
-      // Store timing if we actually did setup work
       if (didSetup) {
         const timings = perf.getTimings();
         if (timings) {

--- a/src/utils/RunnerReadinessService.ts
+++ b/src/utils/RunnerReadinessService.ts
@@ -91,6 +91,8 @@ export interface RunnerReadinessDependencies {
 export interface RunnerReadinessRequest {
   device: BootedDevice;
   requestedIdentity: string;
+  /** User-visible operation that requires the runner to become responsive. */
+  operationName?: string;
   /** Absolute deadline shared with device boot. */
   totalDeadlineMs: number;
   /** Maximum time allocated to runner readiness within the total deadline. */
@@ -545,7 +547,7 @@ export class RunnerReadinessService {
       `platform=${device.platform} requested=[${context.requestedIdentity}] ` +
       `resolved=[${device.name} (${device.deviceId})]`;
     throw new ActionableError(
-      `startDevice automation runner readiness failed: ${mapping} phase=${phase} ` +
+      `${context.operationName ?? "startDevice"} automation runner readiness failed: ${mapping} phase=${phase} ` +
         `attempts=${attempts} remainingBudgetMs=${this.remaining(context)}: ${normalizeDiagnostic(detail)}`,
     );
   }

--- a/src/utils/RunnerReadinessService.ts
+++ b/src/utils/RunnerReadinessService.ts
@@ -98,6 +98,7 @@ export interface RunnerReadinessRequest {
   skipCtrlProxyDownload?: boolean;
   perf?: PerformanceTracker;
   signal?: AbortSignal;
+  onRunnerSetup?: () => void;
 }
 
 interface ReadinessAttemptContext extends RunnerReadinessRequest {
@@ -398,6 +399,7 @@ export class RunnerReadinessService {
     const setup = await this.runPhase(context, "runner-setup", 1, (signal) =>
       manager.setup(false, context.perf, signal, this.remaining(context)),
     );
+    context.onRunnerSetup?.();
     if (!setup.success) {
       this.fail(context, "runner-setup", 1, setup.error ?? setup.message);
     }

--- a/src/utils/RunnerReadinessService.ts
+++ b/src/utils/RunnerReadinessService.ts
@@ -22,6 +22,8 @@ type RunnerReadinessPhase =
   | "runner-connect"
   | "runner-health";
 
+export class RunnerReadinessError extends ActionableError {}
+
 export interface AndroidCompatibilityResult {
   status:
     | "skipped"
@@ -59,6 +61,7 @@ export interface ReadinessAndroidManager {
 
 export interface ReadinessIosManager {
   isInstalled(): Promise<boolean>;
+  resetSetupState(): void;
   start(options?: {
     signal?: AbortSignal;
     minimumHealthPollDurationMs?: number;
@@ -391,6 +394,7 @@ export class RunnerReadinessService {
       if (ready) {
         return;
       }
+      manager.resetSetupState();
     }
 
     if (context.skipCtrlProxyDownload) {
@@ -546,7 +550,7 @@ export class RunnerReadinessService {
     const mapping =
       `platform=${device.platform} requested=[${context.requestedIdentity}] ` +
       `resolved=[${device.name} (${device.deviceId})]`;
-    throw new ActionableError(
+    throw new RunnerReadinessError(
       `${context.operationName ?? "startDevice"} automation runner readiness failed: ${mapping} phase=${phase} ` +
         `attempts=${attempts} remainingBudgetMs=${this.remaining(context)}: ${normalizeDiagnostic(detail)}`,
     );

--- a/test/fakes/FakeIOSCtrlProxyManager.ts
+++ b/test/fakes/FakeIOSCtrlProxyManager.ts
@@ -17,6 +17,7 @@ export class FakeIOSCtrlProxyManager implements CtrlProxyIosManager {
   private shouldSetupFail: boolean = false;
   private shouldForceRestartFail: boolean = false;
   private shouldIsRunningFail: boolean = false;
+  private lastSetupMinimumHealthPollDurationMs: number | undefined;
 
   // MARK: - Configuration Methods
 
@@ -117,6 +118,10 @@ export class FakeIOSCtrlProxyManager implements CtrlProxyIosManager {
     return this.executedOperations.filter(op => op.includes(operationName)).length;
   }
 
+  getLastSetupMinimumHealthPollDurationMs(): number | undefined {
+    return this.lastSetupMinimumHealthPollDurationMs;
+  }
+
   /**
    * Clear operation history
    */
@@ -174,8 +179,14 @@ export class FakeIOSCtrlProxyManager implements CtrlProxyIosManager {
     this.runningState = false;
   }
 
-  async setup(force: boolean = false, perf?: PerformanceTracker): Promise<CtrlProxyIosSetupResult> {
+  async setup(
+    force: boolean = false,
+    perf?: PerformanceTracker,
+    _signal?: AbortSignal,
+    minimumHealthPollDurationMs?: number,
+  ): Promise<CtrlProxyIosSetupResult> {
     this.executedOperations.push(`setup:force=${force}`);
+    this.lastSetupMinimumHealthPollDurationMs = minimumHealthPollDurationMs;
 
     if (this.shouldSetupFail) {
       return {

--- a/test/utils/DeviceSessionManager.test.ts
+++ b/test/utils/DeviceSessionManager.test.ts
@@ -454,6 +454,7 @@ describe("DeviceSessionManager legacy iOS auto-start readiness", () => {
   function createManager(
     iosManager: FakeIOSCtrlProxyManager,
     iosClient: FakeIOSCtrlProxy,
+    useConfiguredReadinessTimeout: boolean = false,
   ): DeviceSessionManager {
     const fakeAdb = new FakeAdbExecutor();
     const fakeDeviceUtils = new FakeDeviceUtils();
@@ -481,10 +482,11 @@ describe("DeviceSessionManager legacy iOS auto-start readiness", () => {
     const timer = new FakeTimer();
     timer.enableAutoAdvance();
 
-    return DeviceSessionManager.createInstance(provider, undefined, {
+    const options = {
       runnerReadinessTimer: timer,
-      runnerReadinessTimeoutMs: 1_000,
-    });
+      ...(useConfiguredReadinessTimeout ? {} : { runnerReadinessTimeoutMs: 1_000 }),
+    };
+    return DeviceSessionManager.createInstance(provider, undefined, options);
   }
 
   test("fails auto-start with the original CtrlProxy setup diagnostic", async () => {
@@ -494,9 +496,13 @@ describe("DeviceSessionManager legacy iOS auto-start readiness", () => {
     iosClient.setConnected(false);
     const manager = createManager(iosManager, iosClient);
 
-    await expect(manager.ensureDeviceReady("ios")).rejects.toThrow(
-      /phase=runner-setup.*Mock setup failure/,
+    const error = await manager.ensureDeviceReady("ios").then(
+      () => undefined,
+      (reason: unknown) => reason,
     );
+    const message = error instanceof Error ? error.message : String(error);
+    expect(message).toMatch(/legacy iOS session auto-start.*phase=runner-setup.*Mock setup failure/);
+    expect(message).not.toContain("startDevice");
   });
 
   test("fails auto-start when CtrlProxy setup throws", async () => {
@@ -520,6 +526,22 @@ describe("DeviceSessionManager legacy iOS auto-start readiness", () => {
     const manager = createManager(iosManager, iosClient);
 
     await expect(manager.ensureDeviceReady("ios")).rejects.toThrow(/phase=runner-connect/);
+  });
+
+  test("uses the configured readiness budget when no test override is supplied", async () => {
+    const originalTimeoutMs = serverConfig.getRunnerReadinessTimeoutMs();
+    serverConfig.setRunnerReadinessTimeoutMs(120_000);
+    try {
+      const iosManager = new FakeIOSCtrlProxyManager();
+      const iosClient = new FakeIOSCtrlProxy();
+      iosClient.setConnected(false);
+      const manager = createManager(iosManager, iosClient, true);
+
+      await expect(manager.ensureDeviceReady("ios")).rejects.toThrow(/phase=runner-connect/);
+      expect(iosManager.getLastSetupMinimumHealthPollDurationMs()).toBe(120_000);
+    } finally {
+      serverConfig.setRunnerReadinessTimeoutMs(originalTimeoutMs);
+    }
   });
 
   test("fails auto-start when a connected CtrlProxy never becomes healthy", async () => {

--- a/test/utils/DeviceSessionManager.test.ts
+++ b/test/utils/DeviceSessionManager.test.ts
@@ -530,18 +530,44 @@ describe("DeviceSessionManager legacy iOS auto-start readiness", () => {
 
   test("uses the configured readiness budget when no test override is supplied", async () => {
     const originalTimeoutMs = serverConfig.getRunnerReadinessTimeoutMs();
-    serverConfig.setRunnerReadinessTimeoutMs(120_000);
     try {
       const iosManager = new FakeIOSCtrlProxyManager();
       const iosClient = new FakeIOSCtrlProxy();
       iosClient.setConnected(false);
       const manager = createManager(iosManager, iosClient, true);
+      serverConfig.setRunnerReadinessTimeoutMs(120_000);
 
       await expect(manager.ensureDeviceReady("ios")).rejects.toThrow(/phase=runner-connect/);
       expect(iosManager.getLastSetupMinimumHealthPollDurationMs()).toBe(120_000);
     } finally {
       serverConfig.setRunnerReadinessTimeoutMs(originalTimeoutMs);
     }
+  });
+
+  test("resets stale setup state after the connected health probe fails", async () => {
+    const iosManager = new FakeIOSCtrlProxyManager();
+    const iosClient = new FakeIOSCtrlProxy();
+    iosClient.setConnected(true);
+    spyOn(iosClient, "verifyServiceReady")
+      .mockResolvedValueOnce(false)
+      .mockResolvedValueOnce(true);
+    const manager = createManager(iosManager, iosClient);
+
+    await expect(manager.ensureDeviceReady("ios")).resolves.toEqual(iosDevice);
+    expect(iosManager.wasMethodCalled("resetSetupState")).toBe(true);
+    expect(iosManager.wasMethodCalled("setup")).toBe(true);
+  });
+
+  test("does not retry the current simulator after runner readiness fails", async () => {
+    const iosManager = new FakeIOSCtrlProxyManager();
+    iosManager.setSetupShouldFail(true);
+    const iosClient = new FakeIOSCtrlProxy();
+    iosClient.setConnected(false);
+    const manager = createManager(iosManager, iosClient);
+    manager.setCurrentDevice(iosDevice, "ios");
+
+    await expect(manager.ensureDeviceReady("ios")).rejects.toThrow(/phase=runner-setup/);
+    expect(iosManager.getCallCount("setup")).toBe(1);
   });
 
   test("fails auto-start when a connected CtrlProxy never becomes healthy", async () => {

--- a/test/utils/DeviceSessionManager.test.ts
+++ b/test/utils/DeviceSessionManager.test.ts
@@ -11,6 +11,7 @@ import { FakeIOSCtrlProxy } from "../fakes/FakeIOSCtrlProxy";
 import { FakeObserveScreenCache } from "../fakes/FakeObserveScreenCache";
 import { FakeSimCtlClient } from "../fakes/FakeSimCtlClient";
 import { FakeSimctl } from "../fakes/FakeSimctl";
+import { FakeTimer } from "../fakes/FakeTimer";
 import { FakeWindow } from "../fakes/FakeWindow";
 import { BootedDevice, AppearanceConfigInput } from "../../src/models";
 import { serverConfig } from "../../src/utils/ServerConfig";
@@ -443,6 +444,105 @@ describe("DeviceSessionManager iOS push-update cache invalidation", () => {
   });
 });
 
+describe("DeviceSessionManager legacy iOS auto-start readiness", () => {
+  const iosDevice: BootedDevice = {
+    deviceId: "ios-ready-1",
+    name: "iPhone 15",
+    platform: "ios",
+  };
+
+  function createManager(
+    iosManager: FakeIOSCtrlProxyManager,
+    iosClient: FakeIOSCtrlProxy,
+  ): DeviceSessionManager {
+    const fakeAdb = new FakeAdbExecutor();
+    const fakeDeviceUtils = new FakeDeviceUtils();
+    const fakeSimctl = new FakeSimctl();
+    fakeSimctl.setAvailableSimulators([iosDevice]);
+    fakeSimctl.setBootedSimulators([iosDevice]);
+    fakeSimctl.setDeviceInfo(iosDevice.deviceId, {
+      udid: iosDevice.deviceId,
+      name: iosDevice.name,
+      state: "Booted",
+      isAvailable: true,
+    });
+    const simctl = Object.assign(fakeSimctl, {
+      openSimulatorApp: async () => {},
+    });
+    const provider = new FakeDeviceClientProvider(
+      fakeAdb,
+      fakeDeviceUtils,
+      simctl as never,
+      {
+        iosCtrlProxyManager: iosManager,
+        iosCtrlProxyClient: iosClient,
+      },
+    );
+    const timer = new FakeTimer();
+    timer.enableAutoAdvance();
+
+    return DeviceSessionManager.createInstance(provider, undefined, {
+      runnerReadinessTimer: timer,
+      runnerReadinessTimeoutMs: 1_000,
+    });
+  }
+
+  test("fails auto-start with the original CtrlProxy setup diagnostic", async () => {
+    const iosManager = new FakeIOSCtrlProxyManager();
+    iosManager.setSetupShouldFail(true);
+    const iosClient = new FakeIOSCtrlProxy();
+    iosClient.setConnected(false);
+    const manager = createManager(iosManager, iosClient);
+
+    await expect(manager.ensureDeviceReady("ios")).rejects.toThrow(
+      /phase=runner-setup.*Mock setup failure/,
+    );
+  });
+
+  test("fails auto-start when CtrlProxy setup throws", async () => {
+    const iosManager = new FakeIOSCtrlProxyManager();
+    iosManager.setup = async () => {
+      throw new Error("xcodebuild exited 65");
+    };
+    const iosClient = new FakeIOSCtrlProxy();
+    iosClient.setConnected(false);
+    const manager = createManager(iosManager, iosClient);
+
+    await expect(manager.ensureDeviceReady("ios")).rejects.toThrow(
+      /phase=runner-setup.*xcodebuild exited 65/,
+    );
+  });
+
+  test("fails auto-start when CtrlProxy never connects", async () => {
+    const iosManager = new FakeIOSCtrlProxyManager();
+    const iosClient = new FakeIOSCtrlProxy();
+    iosClient.setConnected(false);
+    const manager = createManager(iosManager, iosClient);
+
+    await expect(manager.ensureDeviceReady("ios")).rejects.toThrow(/phase=runner-connect/);
+  });
+
+  test("fails auto-start when a connected CtrlProxy never becomes healthy", async () => {
+    const iosManager = new FakeIOSCtrlProxyManager();
+    const iosClient = new FakeIOSCtrlProxy();
+    iosClient.setConnected(true);
+    spyOn(iosClient, "verifyServiceReady").mockResolvedValue(false);
+    const manager = createManager(iosManager, iosClient);
+
+    await expect(manager.ensureDeviceReady("ios")).rejects.toThrow(/phase=runner-health/);
+  });
+
+  test("keeps an already-responsive CtrlProxy on the fast path", async () => {
+    const iosManager = new FakeIOSCtrlProxyManager();
+    const iosClient = new FakeIOSCtrlProxy();
+    iosClient.setConnected(true);
+    const manager = createManager(iosManager, iosClient);
+
+    await expect(manager.ensureDeviceReady("ios")).resolves.toEqual(iosDevice);
+    expect(iosManager.wasMethodCalled("setup")).toBe(false);
+  });
+});
+
 describe("DeviceSessionManager iOS openSimulatorApp", () => {
   let fakeAdb: FakeAdbExecutor;
   let fakeDeviceUtils: FakeDeviceUtils;
@@ -471,9 +571,8 @@ describe("DeviceSessionManager iOS openSimulatorApp", () => {
     fakeSimctl: FakeSimCtlClient
   ): FakeDeviceClientProvider {
     const iosManager = new FakeIOSCtrlProxyManager();
-    iosManager.setSetupShouldFail(true); // skip the setup path in these tests
     const iosClient = new FakeIOSCtrlProxy();
-    iosClient.setConnected(false);
+    iosClient.setConnected(true);
     return new FakeDeviceClientProvider(
       fakeAdb,
       fakeDeviceUtils,
@@ -626,9 +725,8 @@ describe("DeviceSessionManager dual-platform resolution", () => {
     fakeCtrlProxy.setVersionCompatible(true);
 
     const fakeIosManager = new FakeIOSCtrlProxyManager();
-    fakeIosManager.setSetupShouldFail(true);
     const fakeIosClient = new FakeIOSCtrlProxy();
-    fakeIosClient.setConnected(false);
+    fakeIosClient.setConnected(true);
 
     return new FakeDeviceClientProvider(
       fakeAdb,


### PR DESCRIPTION
## Summary

Legacy iOS session auto-start now uses the same bounded CtrlProxy readiness service as `startDevice`. It fails with the setup, connection, or health diagnostic instead of returning an automation-unready simulator, while preserving the already-responsive fast path and setup timing capture.

## Linked Issue

Closes [#5278](https://github.com/kaeawc/auto-mobile/issues/5278)

## Bug / Regression Context

- **Observed symptom:** Session auto-start succeeded even when CtrlProxy setup or health checks had failed, causing the first automation operation to fail later.
- **Root cause:** `DeviceSessionManager.verifyIosDevice()` treated runner setup and verification failures as best-effort.

## Validation

- [x] `bun test`
- [x] `bun run lint`
- [x] `bun run typecheck`
- [x] `bun run build`
- [x] `scripts/all_fast_validate_checks.sh`
- [x] Focused session and runner readiness tests use `FakeTimer`

## Risk

Session acquisition now fails closed when an iOS CtrlProxy runner cannot become responsive within the configured readiness budget. This aligns it with explicit `startDevice` behavior.
