### PR TITLE
fix(android): recover uninstall request timeouts

### DIFF
--- a/src/daemon/mcpRequestTimeout.ts
+++ b/src/daemon/mcpRequestTimeout.ts
@@ -31,6 +31,14 @@ export const MIN_START_DEVICE_MCP_TIMEOUT_MS = 180_000;
 export const MIN_LAUNCH_APP_MCP_TIMEOUT_MS = 90_000;
 
 /**
+ * Floor for `uninstallApp` — the Android command has a 20s local deadline,
+ * followed by bounded package-state reconciliation (and, if still installed,
+ * one retry). The default 30s MCP deadline can otherwise abort recovery after
+ * Android has already removed the package, causing a false failure.
+ */
+export const MIN_UNINSTALL_APP_MCP_TIMEOUT_MS = 60_000;
+
+/**
  * Floor for `openLink` — deep links can trigger sign-in, onboarding, data sync,
  * or other post-open navigation before the final observation settles. A sign-in
  * deeplink that launches the app and performs a backend token exchange was
@@ -79,6 +87,8 @@ function resolveToolTimeoutFloorMs(toolName: string | undefined): number | undef
       return MIN_START_DEVICE_MCP_TIMEOUT_MS;
     case "launchApp":
       return MIN_LAUNCH_APP_MCP_TIMEOUT_MS;
+    case "uninstallApp":
+      return MIN_UNINSTALL_APP_MCP_TIMEOUT_MS;
     case "openLink":
       return resolveEnvTimeoutFloorMs(
         OPEN_LINK_MCP_TIMEOUT_ENV_VAR,

--- a/src/features/action/UninstallApp.ts
+++ b/src/features/action/UninstallApp.ts
@@ -307,6 +307,7 @@ export class UninstallApp {
     logger.warn(
       `[UninstallApp] Android uninstall timed out for ${packageName} (user ${userId}); package remains installed, retrying once.`,
     );
+    let retryTimedOut = false;
     try {
       await this.adb.executeCommand(
         command,
@@ -317,12 +318,15 @@ export class UninstallApp {
       );
     } catch (error) {
       throwIfAborted(signal);
-      return this.androidUninstallTimeoutFailure(
-        packageName,
-        keepData,
-        userId,
-        `One bounded retry failed: ${error instanceof Error ? error.message : String(error)}`,
-      );
+      if (!(error instanceof AdbCommandTimeoutError)) {
+        return this.androidUninstallTimeoutFailure(
+          packageName,
+          keepData,
+          userId,
+          `One bounded retry failed: ${error instanceof Error ? error.message : String(error)}`,
+        );
+      }
+      retryTimedOut = true;
     }
 
     await this.markInstalledAppsCacheStale();
@@ -351,7 +355,9 @@ export class UninstallApp {
       packageName,
       keepData,
       userId,
-      "Package remains installed after one bounded retry.",
+      retryTimedOut
+        ? "Package remains installed after one bounded retry timed out."
+        : "Package remains installed after one bounded retry.",
     );
   }
 

--- a/src/features/action/UninstallApp.ts
+++ b/src/features/action/UninstallApp.ts
@@ -17,7 +17,7 @@ import { InstalledAppsRepository, type InstalledAppsStore } from "../../db/insta
 import { getDbWriteBarrier } from "../../db/dbWriteBarrier";
 import { getInstalledAppsCacheWriteCoordinator } from "../../db/installedAppsCacheWriteCoordinator";
 import { AdbCommandTimeoutError } from "../../utils/android-cmdline-tools/AdbClient";
-import { OPERATION_CANCELLED_MESSAGE } from "../../utils/constants";
+import { throwIfAborted } from "../../utils/toolUtils";
 
 const ANDROID_UNINSTALL_TIMEOUT_MS = 20_000;
 const ANDROID_UNINSTALL_RECOVERY_TIMEOUT_MS = 5_000;
@@ -65,7 +65,7 @@ export class UninstallApp {
     userId?: number,
     signal?: AbortSignal,
   ): Promise<UninstallAppResult> {
-    this.throwIfCancelled(signal);
+    throwIfAborted(signal);
     const perf = createGlobalPerformanceTracker();
     perf.serial("uninstallApp");
 
@@ -220,7 +220,7 @@ export class UninstallApp {
       try {
         await this.adb.executeCommand(cmd, ANDROID_UNINSTALL_TIMEOUT_MS, undefined, true, signal);
       } catch (error) {
-        this.throwIfCancelled(signal);
+        throwIfAborted(signal);
         if (error instanceof AdbCommandTimeoutError) {
           return this.recoverTimedOutAndroidUninstall(
             packageName,
@@ -262,7 +262,7 @@ export class UninstallApp {
         userId: targetUserId,
       };
     } catch (error) {
-      this.throwIfCancelled(signal);
+      throwIfAborted(signal);
       return {
         success: false,
         packageName,
@@ -291,7 +291,7 @@ export class UninstallApp {
         signal,
       );
     } catch (error) {
-      this.throwIfCancelled(signal);
+      throwIfAborted(signal);
       return this.androidUninstallTimeoutFailure(
         packageName,
         keepData,
@@ -316,7 +316,7 @@ export class UninstallApp {
         signal,
       );
     } catch (error) {
-      this.throwIfCancelled(signal);
+      throwIfAborted(signal);
       return this.androidUninstallTimeoutFailure(
         packageName,
         keepData,
@@ -334,7 +334,7 @@ export class UninstallApp {
         signal,
       );
     } catch (error) {
-      this.throwIfCancelled(signal);
+      throwIfAborted(signal);
       return this.androidUninstallTimeoutFailure(
         packageName,
         keepData,
@@ -399,13 +399,6 @@ export class UninstallApp {
       signal,
     );
     return result.stdout.split("\n").some((line) => line.trim() === `package:${packageName}`);
-  }
-
-  private throwIfCancelled(signal?: AbortSignal): void {
-    if (!signal?.aborted) {
-      return;
-    }
-    throw signal.reason instanceof Error ? signal.reason : new Error(OPERATION_CANCELLED_MESSAGE);
   }
 
   private async markInstalledAppsCacheStale(): Promise<void> {

--- a/src/features/action/UninstallApp.ts
+++ b/src/features/action/UninstallApp.ts
@@ -1,4 +1,7 @@
-import { AdbClientFactory, defaultAdbClientFactory } from "../../utils/android-cmdline-tools/AdbClientFactory";
+import {
+  AdbClientFactory,
+  defaultAdbClientFactory,
+} from "../../utils/android-cmdline-tools/AdbClientFactory";
 import type { AdbExecutor } from "../../utils/android-cmdline-tools/interfaces/AdbExecutor";
 import { AndroidUserTargetResolver } from "../../utils/android-cmdline-tools/AndroidUserTargetResolver";
 import { UninstallAppResult } from "../../models/UninstallAppResult";
@@ -13,6 +16,11 @@ import { IOSCtrlProxyClient } from "../observe/ios";
 import { InstalledAppsRepository, type InstalledAppsStore } from "../../db/installedAppsRepository";
 import { getDbWriteBarrier } from "../../db/dbWriteBarrier";
 import { getInstalledAppsCacheWriteCoordinator } from "../../db/installedAppsCacheWriteCoordinator";
+import { AdbCommandTimeoutError } from "../../utils/android-cmdline-tools/AdbClient";
+import { OPERATION_CANCELLED_MESSAGE } from "../../utils/constants";
+
+const ANDROID_UNINSTALL_TIMEOUT_MS = 20_000;
+const ANDROID_UNINSTALL_RECOVERY_TIMEOUT_MS = 5_000;
 
 export interface DeviceAppUninstaller {
   uninstallApp(deviceUdid: string, bundleId: string, isSimulator?: boolean): Promise<void>;
@@ -31,7 +39,7 @@ export class UninstallApp {
     adbFactory: AdbClientFactory = defaultAdbClientFactory,
     simctl: SimCtlClient | null = null,
     deviceAppUninstaller: DeviceAppUninstaller | null = null,
-    installedAppsRepository: InstalledAppsStore = new InstalledAppsRepository()
+    installedAppsRepository: InstalledAppsStore = new InstalledAppsRepository(),
   ) {
     this.device = device;
     this.adbFactory = adbFactory;
@@ -54,8 +62,10 @@ export class UninstallApp {
   async execute(
     packageName: string,
     keepData: boolean = false,
-    userId?: number
+    userId?: number,
+    signal?: AbortSignal,
   ): Promise<UninstallAppResult> {
+    this.throwIfCancelled(signal);
     const perf = createGlobalPerformanceTracker();
     perf.serial("uninstallApp");
 
@@ -67,7 +77,7 @@ export class UninstallApp {
         packageName: packageName || "",
         wasInstalled: false,
         keepData,
-        error: "Invalid package name provided"
+        error: "Invalid package name provided",
       };
     }
 
@@ -75,7 +85,9 @@ export class UninstallApp {
       case "ios":
         return perf.track("iOSUninstall", () => this.executeiOS(packageName));
       case "android":
-        return perf.track("androidUninstall", () => this.executeAndroid(packageName, keepData, userId));
+        return perf.track("androidUninstall", () =>
+          this.executeAndroid(packageName, keepData, userId, signal),
+        );
       default:
         perf.end();
         throw new Error(`Unsupported platform: ${this.device.platform}`);
@@ -93,16 +105,20 @@ export class UninstallApp {
       // Check if app is installed. Keep the cache disabled so the pre-uninstall
       // check always reflects live device state (the previous executor-arg path
       // left caching off; passing the default factory would silently enable it).
-      const listApps = new ListInstalledApps(this.device, this.adbFactory, this.simctl, { cacheEnabled: false });
-      const installed = (await listApps.execute()).find(app => app === bundleId) !== undefined;
+      const listApps = new ListInstalledApps(this.device, this.adbFactory, this.simctl, {
+        cacheEnabled: false,
+      });
+      const installed = (await listApps.execute()).find((app) => app === bundleId) !== undefined;
 
       if (!installed) {
-        IOSCtrlProxyClient.getExistingInstance(this.device.deviceId)?.clearSdkScreenIdentity(bundleId);
+        IOSCtrlProxyClient.getExistingInstance(this.device.deviceId)?.clearSdkScreenIdentity(
+          bundleId,
+        );
         return {
           success: true,
           packageName: bundleId,
           wasInstalled: false,
-          keepData: false
+          keepData: false,
         };
       }
 
@@ -120,7 +136,8 @@ export class UninstallApp {
       await this.markInstalledAppsCacheStale();
 
       // Verify the app was uninstalled
-      const isStillInstalled = (await listApps.execute()).find(app => app === bundleId) !== undefined;
+      const isStillInstalled =
+        (await listApps.execute()).find((app) => app === bundleId) !== undefined;
 
       if (isStillInstalled) {
         return {
@@ -128,17 +145,19 @@ export class UninstallApp {
           packageName: bundleId,
           wasInstalled: true,
           keepData: false,
-          error: "Failed to uninstall application"
+          error: "Failed to uninstall application",
         };
       }
 
-      IOSCtrlProxyClient.getExistingInstance(this.device.deviceId)?.clearSdkScreenIdentity(bundleId);
+      IOSCtrlProxyClient.getExistingInstance(this.device.deviceId)?.clearSdkScreenIdentity(
+        bundleId,
+      );
 
       return {
         success: true,
         packageName: bundleId,
         wasInstalled: true,
-        keepData: false // iOS doesn't support keeping data during uninstall
+        keepData: false, // iOS doesn't support keeping data during uninstall
       };
     } catch (error) {
       return {
@@ -146,7 +165,7 @@ export class UninstallApp {
         packageName: bundleId,
         wasInstalled: true,
         keepData: false,
-        error: error instanceof Error ? error.message : String(error)
+        error: error instanceof Error ? error.message : String(error),
       };
     }
   }
@@ -157,12 +176,23 @@ export class UninstallApp {
    * @param keepData - Whether to keep app data
    * @param userId - Optional Android user ID (auto-detected if not provided)
    */
-  private async executeAndroid(packageName: string, keepData: boolean, userId?: number): Promise<UninstallAppResult> {
+  private async executeAndroid(
+    packageName: string,
+    keepData: boolean,
+    userId?: number,
+    signal?: AbortSignal,
+  ): Promise<UninstallAppResult> {
     try {
       // Auto-detect target user if not specified
-      const targetUserId = (await new AndroidUserTargetResolver(this.adb).resolve({ packageName, explicitUserId: userId })).userId;
+      const targetUserId = (
+        await new AndroidUserTargetResolver(this.adb).resolve({
+          packageName,
+          explicitUserId: userId,
+          signal,
+        })
+      ).userId;
 
-      const installed = await this.isInstalledForUser(packageName, targetUserId);
+      const installed = await this.isInstalledForUser(packageName, targetUserId, undefined, signal);
 
       if (!installed) {
         return {
@@ -170,23 +200,48 @@ export class UninstallApp {
           packageName,
           wasInstalled: false,
           keepData,
-          userId: targetUserId
+          userId: targetUserId,
         };
       }
 
       // TODO: query if app was running and needed to be stopped
-      await this.adb.executeCommand(`shell am force-stop --user ${targetUserId} ${packageName}`);
+      await this.adb.executeCommand(
+        `shell am force-stop --user ${targetUserId} ${packageName}`,
+        undefined,
+        undefined,
+        false,
+        signal,
+      );
 
-      const cmd = keepData ?
-        `shell pm uninstall --user ${targetUserId} -k ${packageName}` :
-        `shell pm uninstall --user ${targetUserId} ${packageName}`;
+      const cmd = keepData
+        ? `shell pm uninstall --user ${targetUserId} -k ${packageName}`
+        : `shell pm uninstall --user ${targetUserId} ${packageName}`;
 
-      await this.adb.executeCommand(cmd);
+      try {
+        await this.adb.executeCommand(cmd, ANDROID_UNINSTALL_TIMEOUT_MS, undefined, true, signal);
+      } catch (error) {
+        this.throwIfCancelled(signal);
+        if (error instanceof AdbCommandTimeoutError) {
+          return this.recoverTimedOutAndroidUninstall(
+            packageName,
+            keepData,
+            targetUserId,
+            cmd,
+            signal,
+          );
+        }
+        throw error;
+      }
 
       await this.markInstalledAppsCacheStale();
 
       // Verify the app was uninstalled
-      const isStillInstalled = await this.isInstalledForUser(packageName, targetUserId);
+      const isStillInstalled = await this.isInstalledForUser(
+        packageName,
+        targetUserId,
+        undefined,
+        signal,
+      );
 
       if (isStillInstalled) {
         return {
@@ -195,7 +250,7 @@ export class UninstallApp {
           wasInstalled: true,
           keepData,
           userId: targetUserId,
-          error: "Failed to uninstall application"
+          error: "Failed to uninstall application",
         };
       }
 
@@ -204,35 +259,161 @@ export class UninstallApp {
         packageName,
         wasInstalled: true,
         keepData,
-        userId: targetUserId
+        userId: targetUserId,
       };
     } catch (error) {
+      this.throwIfCancelled(signal);
       return {
         success: false,
         packageName,
         wasInstalled: true,
         keepData,
-        error: "Error occurred during application uninstallation"
+        error: error instanceof Error ? error.message : String(error),
       };
     }
   }
 
-  private async isInstalledForUser(packageName: string, userId: number): Promise<boolean> {
+  private async recoverTimedOutAndroidUninstall(
+    packageName: string,
+    keepData: boolean,
+    userId: number,
+    command: string,
+    signal?: AbortSignal,
+  ): Promise<UninstallAppResult> {
+    await this.markInstalledAppsCacheStale();
+
+    let isStillInstalled: boolean;
+    try {
+      isStillInstalled = await this.isInstalledForUser(
+        packageName,
+        userId,
+        ANDROID_UNINSTALL_RECOVERY_TIMEOUT_MS,
+        signal,
+      );
+    } catch (error) {
+      this.throwIfCancelled(signal);
+      return this.androidUninstallTimeoutFailure(
+        packageName,
+        keepData,
+        userId,
+        `Package-state check failed: ${error instanceof Error ? error.message : String(error)}`,
+      );
+    }
+
+    if (!isStillInstalled) {
+      return this.successfulAndroidUninstall(packageName, keepData, userId);
+    }
+
+    logger.warn(
+      `[UninstallApp] Android uninstall timed out for ${packageName} (user ${userId}); package remains installed, retrying once.`,
+    );
+    try {
+      await this.adb.executeCommand(
+        command,
+        ANDROID_UNINSTALL_RECOVERY_TIMEOUT_MS,
+        undefined,
+        true,
+        signal,
+      );
+    } catch (error) {
+      this.throwIfCancelled(signal);
+      return this.androidUninstallTimeoutFailure(
+        packageName,
+        keepData,
+        userId,
+        `One bounded retry failed: ${error instanceof Error ? error.message : String(error)}`,
+      );
+    }
+
+    await this.markInstalledAppsCacheStale();
+    try {
+      isStillInstalled = await this.isInstalledForUser(
+        packageName,
+        userId,
+        ANDROID_UNINSTALL_RECOVERY_TIMEOUT_MS,
+        signal,
+      );
+    } catch (error) {
+      this.throwIfCancelled(signal);
+      return this.androidUninstallTimeoutFailure(
+        packageName,
+        keepData,
+        userId,
+        `Post-retry package-state check failed: ${error instanceof Error ? error.message : String(error)}`,
+      );
+    }
+
+    if (!isStillInstalled) {
+      return this.successfulAndroidUninstall(packageName, keepData, userId);
+    }
+
+    return this.androidUninstallTimeoutFailure(
+      packageName,
+      keepData,
+      userId,
+      "Package remains installed after one bounded retry.",
+    );
+  }
+
+  private successfulAndroidUninstall(
+    packageName: string,
+    keepData: boolean,
+    userId: number,
+  ): UninstallAppResult {
+    return {
+      success: true,
+      packageName,
+      wasInstalled: true,
+      keepData,
+      userId,
+    };
+  }
+
+  private androidUninstallTimeoutFailure(
+    packageName: string,
+    keepData: boolean,
+    userId: number,
+    detail: string,
+  ): UninstallAppResult {
+    return {
+      success: false,
+      packageName,
+      wasInstalled: true,
+      keepData,
+      userId,
+      error: `Android uninstall timed out after ${ANDROID_UNINSTALL_TIMEOUT_MS}ms for package ${packageName} (user ${userId}). ${detail}`,
+    };
+  }
+
+  private async isInstalledForUser(
+    packageName: string,
+    userId: number,
+    timeoutMs?: number,
+    signal?: AbortSignal,
+  ): Promise<boolean> {
     const result = await this.adb.executeCommand(
       `shell pm list packages --user ${userId}`,
+      timeoutMs,
       undefined,
-      undefined,
-      true
+      true,
+      signal,
     );
-    return result.stdout.split("\n").some(line => line.trim() === `package:${packageName}`);
+    return result.stdout.split("\n").some((line) => line.trim() === `package:${packageName}`);
+  }
+
+  private throwIfCancelled(signal?: AbortSignal): void {
+    if (!signal?.aborted) {
+      return;
+    }
+    throw signal.reason instanceof Error ? signal.reason : new Error(OPERATION_CANCELLED_MESSAGE);
   }
 
   private async markInstalledAppsCacheStale(): Promise<void> {
     try {
       await getInstalledAppsCacheWriteCoordinator().invalidate(this.device.deviceId, () =>
-        getDbWriteBarrier().track(() =>
-          this.installedAppsRepository.markDeviceStale(this.device.deviceId)
-        ).then(() => undefined)
+        getDbWriteBarrier()
+          .track(() => this.installedAppsRepository.markDeviceStale(this.device.deviceId))
+          .then(() => undefined),
       );
     } catch (error) {
       logger.warn(`[UninstallApp] Failed to invalidate installed apps cache: ${error}`);

--- a/src/server/appTools.ts
+++ b/src/server/appTools.ts
@@ -6,14 +6,22 @@ import { TerminateApp } from "../features/action/TerminateApp";
 import { InstallApp } from "../features/action/InstallApp";
 import { UninstallApp } from "../features/action/UninstallApp";
 import { AppPermissions } from "../features/action/AppPermissions";
-import { createJSONToolResponse, DefaultToolResponseFormatter, ToolResponseFormatter } from "../utils/toolUtils";
-import { addDeviceTargetingToSchema, withAppIdAliases, withJsonSchemaOverride } from "./toolSchemaHelpers";
+import {
+  createJSONToolResponse,
+  DefaultToolResponseFormatter,
+  ToolResponseFormatter,
+} from "../utils/toolUtils";
+import {
+  addDeviceTargetingToSchema,
+  withAppIdAliases,
+  withJsonSchemaOverride,
+} from "./toolSchemaHelpers";
 import {
   APPS_RESOURCE_URIS,
   APP_RESOURCE_TEMPLATES,
   invalidateInstalledAppsCache,
   invalidateInstalledAppResourceCache,
-  notifyInstalledAppResourceUpdated
+  notifyInstalledAppResourceUpdated,
 } from "./appResources";
 import { logger } from "../utils/logger";
 
@@ -26,7 +34,7 @@ let listAppsToolDependencies: ListAppsToolDependencies | null = null;
 function getListAppsToolDependencies(): ListAppsToolDependencies {
   if (!listAppsToolDependencies) {
     listAppsToolDependencies = {
-      toolResponseFormatter: new DefaultToolResponseFormatter()
+      toolResponseFormatter: new DefaultToolResponseFormatter(),
     };
   }
   return listAppsToolDependencies;
@@ -35,7 +43,7 @@ function getListAppsToolDependencies(): ListAppsToolDependencies {
 export function setListAppsToolDependencies(deps: Partial<ListAppsToolDependencies>): void {
   const currentDeps = getListAppsToolDependencies();
   listAppsToolDependencies = {
-    toolResponseFormatter: deps.toolResponseFormatter ?? currentDeps.toolResponseFormatter
+    toolResponseFormatter: deps.toolResponseFormatter ?? currentDeps.toolResponseFormatter,
   };
 }
 
@@ -44,127 +52,154 @@ export function resetListAppsToolDependencies(): void {
 }
 
 // Schema definitions
-export const packageNameSchema = withAppIdAliases(addDeviceTargetingToSchema(z.object({
-  appId: z.string(),
-})));
+export const packageNameSchema = withAppIdAliases(
+  addDeviceTargetingToSchema(
+    z.object({
+      appId: z.string(),
+    }),
+  ),
+);
 
-export const launchAppSchema = withAppIdAliases(addDeviceTargetingToSchema(z.object({
-  appId: z.string(),
-  clearAppData: z.boolean().optional().describe("Clear app data before launch (default false)"),
-  coldBoot: z.boolean().optional().describe("Cold boot app (default false)"),
-})));
+export const launchAppSchema = withAppIdAliases(
+  addDeviceTargetingToSchema(
+    z.object({
+      appId: z.string(),
+      clearAppData: z.boolean().optional().describe("Clear app data before launch (default false)"),
+      coldBoot: z.boolean().optional().describe("Cold boot app (default false)"),
+    }),
+  ),
+);
 
-export const installAppSchema = addDeviceTargetingToSchema(z.object({
-  artifactPath: z.string().describe("App artifact path (.apk, .app, or .ipa)"),
-}));
+export const installAppSchema = addDeviceTargetingToSchema(
+  z.object({
+    artifactPath: z.string().describe("App artifact path (.apk, .app, or .ipa)"),
+  }),
+);
 
-export const uninstallAppSchema = withAppIdAliases(addDeviceTargetingToSchema(z.object({
-  appId: z.string(),
-  keepData: z.boolean().optional().describe("Keep app data after uninstall (Android only, default false)"),
-})));
+export const uninstallAppSchema = withAppIdAliases(
+  addDeviceTargetingToSchema(
+    z.object({
+      appId: z.string(),
+      keepData: z
+        .boolean()
+        .optional()
+        .describe("Keep app data after uninstall (Android only, default false)"),
+    }),
+  ),
+);
 
 const appPermissionActionSchema = z.enum(["grant", "revoke", "reset"]);
 
-export const setAppPermissionsSchema = withJsonSchemaOverride(withAppIdAliases(addDeviceTargetingToSchema(
-  z.object({
-    appId: z.string().trim().min(1),
-    action: appPermissionActionSchema
-      .optional()
-      .describe(
-        "Action (default grant). Android reset requires permissions=['all'] device-wide; " +
-        "iOS physical devices support reset only."
-      ),
-    permissions: z
-      .array(z.string().min(1))
-      .optional()
-      .describe("Permissions; Android reset accepts only 'all'; physical iOS accepts it too"),
-    userId: z
-      .number()
-      .int()
-      .nonnegative()
-      .optional()
-      .describe("Android user ID for grant/revoke, not reset"),
-    notificationsEnabled: z
-      .boolean()
-      .optional()
-      .describe("Android notification state, independent of POST_NOTIFICATIONS"),
-    notificationPolicyAccess: z
-      .boolean()
-      .optional()
-      .describe("Android: set DND policy access"),
-    scheduleExactAlarm: z
-      .enum(["allow", "deny"])
-      .optional()
-      .describe("Android: set SCHEDULE_EXACT_ALARM appop"),
-  })
-)).refine(
-  args =>
-    (args.permissions !== undefined && args.permissions.length > 0) ||
-    args.notificationsEnabled !== undefined ||
-    args.notificationPolicyAccess !== undefined ||
-    args.scheduleExactAlarm !== undefined,
-  "Provide at least one permission or platform-specific permission option"
-).refine(
-  args => args.action !== "reset" || args.userId === undefined,
-  "Android reset is device-wide and does not support userId"
-).refine(
-  args => args.action !== "reset" || args.permissions?.some(permission => permission.trim().length > 0) === true,
-  "Reset requires permissions"
-).refine(
-  args =>
-    args.action !== "reset" ||
-    args.platform !== "android" ||
-    (args.permissions?.length === 1 && args.permissions[0] === "all"),
-  "Android reset requires permissions=['all']"
-), jsonSchema => {
-  const properties = jsonSchema.properties as Record<string, Record<string, unknown>>;
-  delete properties.appId?.minLength;
-  delete properties.action?.type;
-  delete properties.scheduleExactAlarm?.type;
-  for (const name of [
-    "action",
-    "permissions",
-    "userId",
-    "notificationsEnabled",
-    "notificationPolicyAccess",
-    "scheduleExactAlarm",
-    "sessionUuid",
-    "device",
-  ]) {
-    delete properties[name]?.description;
-  }
-  jsonSchema.if = {
-    properties: { action: { const: "reset" } },
-    required: ["action"],
-  };
-  jsonSchema.then = {
-    required: ["permissions"],
-    not: { required: ["userId"] },
-    if: {
-      properties: { platform: { const: "android" } },
-      required: ["platform"],
-    },
-    then: {
-      properties: {
-        permissions: {
-          minItems: 1,
-          maxItems: 1,
-          items: { const: "all" },
+export const setAppPermissionsSchema = withJsonSchemaOverride(
+  withAppIdAliases(
+    addDeviceTargetingToSchema(
+      z.object({
+        appId: z.string().trim().min(1),
+        action: appPermissionActionSchema
+          .optional()
+          .describe(
+            "Action (default grant). Android reset requires permissions=['all'] device-wide; " +
+              "iOS physical devices support reset only.",
+          ),
+        permissions: z
+          .array(z.string().min(1))
+          .optional()
+          .describe("Permissions; Android reset accepts only 'all'; physical iOS accepts it too"),
+        userId: z
+          .number()
+          .int()
+          .nonnegative()
+          .optional()
+          .describe("Android user ID for grant/revoke, not reset"),
+        notificationsEnabled: z
+          .boolean()
+          .optional()
+          .describe("Android notification state, independent of POST_NOTIFICATIONS"),
+        notificationPolicyAccess: z.boolean().optional().describe("Android: set DND policy access"),
+        scheduleExactAlarm: z
+          .enum(["allow", "deny"])
+          .optional()
+          .describe("Android: set SCHEDULE_EXACT_ALARM appop"),
+      }),
+    ),
+  )
+    .refine(
+      (args) =>
+        (args.permissions !== undefined && args.permissions.length > 0) ||
+        args.notificationsEnabled !== undefined ||
+        args.notificationPolicyAccess !== undefined ||
+        args.scheduleExactAlarm !== undefined,
+      "Provide at least one permission or platform-specific permission option",
+    )
+    .refine(
+      (args) => args.action !== "reset" || args.userId === undefined,
+      "Android reset is device-wide and does not support userId",
+    )
+    .refine(
+      (args) =>
+        args.action !== "reset" ||
+        args.permissions?.some((permission) => permission.trim().length > 0) === true,
+      "Reset requires permissions",
+    )
+    .refine(
+      (args) =>
+        args.action !== "reset" ||
+        args.platform !== "android" ||
+        (args.permissions?.length === 1 && args.permissions[0] === "all"),
+      "Android reset requires permissions=['all']",
+    ),
+  (jsonSchema) => {
+    const properties = jsonSchema.properties as Record<string, Record<string, unknown>>;
+    delete properties.appId?.minLength;
+    delete properties.action?.type;
+    delete properties.scheduleExactAlarm?.type;
+    for (const name of [
+      "action",
+      "permissions",
+      "userId",
+      "notificationsEnabled",
+      "notificationPolicyAccess",
+      "scheduleExactAlarm",
+      "sessionUuid",
+      "device",
+    ]) {
+      delete properties[name]?.description;
+    }
+    jsonSchema.if = {
+      properties: { action: { const: "reset" } },
+      required: ["action"],
+    };
+    jsonSchema.then = {
+      required: ["permissions"],
+      not: { required: ["userId"] },
+      if: {
+        properties: { platform: { const: "android" } },
+        required: ["platform"],
+      },
+      then: {
+        properties: {
+          permissions: {
+            minItems: 1,
+            maxItems: 1,
+            items: { const: "all" },
+          },
         },
       },
-    },
-  };
-});
+    };
+  },
+);
 
-export const getAppPermissionsSchema = withAppIdAliases(addDeviceTargetingToSchema(
-  z.object({
-    appId: z.string(),
-    permissions: z
-      .array(z.string().min(1))
-      .optional()
-      .describe("Optional permissions or simulator privacy services to query"),
-  })
-));
+export const getAppPermissionsSchema = withAppIdAliases(
+  addDeviceTargetingToSchema(
+    z.object({
+      appId: z.string(),
+      permissions: z
+        .array(z.string().min(1))
+        .optional()
+        .describe("Optional permissions or simulator privacy services to query"),
+    }),
+  ),
+);
 
 export const listAppsSchema = z.object({}).passthrough();
 
@@ -193,12 +228,12 @@ export type SetAppPermissionsArgs = z.infer<typeof setAppPermissionsSchema>;
 export type GetAppPermissionsArgs = z.infer<typeof getAppPermissionsSchema>;
 
 // Register tools
-export function registerAppTools(
-) {
+export function registerAppTools() {
   const listAppsHandler = async () => {
     const { toolResponseFormatter } = getListAppsToolDependencies();
     return toolResponseFormatter.createJSONToolResponse({
-      message: "To list installed apps, follow this workflow:\n\n" +
+      message:
+        "To list installed apps, follow this workflow:\n\n" +
         "1. Get available devices:\n" +
         "   Read resource: automobile:devices/booted\n\n" +
         "2. List apps for a specific device (using deviceId from step 1):\n" +
@@ -212,9 +247,9 @@ export function registerAppTools(
       resources: [
         "automobile:devices/booted",
         APP_RESOURCE_TEMPLATES.DEVICE_APPS,
-        APPS_RESOURCE_URIS.BASE + "?deviceId={deviceId}"
+        APPS_RESOURCE_URIS.BASE + "?deviceId={deviceId}",
       ],
-      note: "All resource URIs use the 'automobile:' prefix. URIs like 'android://apps' are not supported."
+      note: "All resource URIs use the 'automobile:' prefix. URIs like 'android://apps' are not supported.",
     });
   };
 
@@ -225,13 +260,13 @@ export function registerAppTools(
       const result = await launchApp.execute(
         args.appId,
         args.clearAppData ?? false,
-        args.coldBoot ?? false
+        args.coldBoot ?? false,
       );
 
       return createJSONToolResponse({
         message: `Launched app ${args.appId}`,
         observation: result.observation,
-        ...result
+        ...result,
       });
     } catch (error) {
       throw new ActionableError(`Failed to launch app: ${error}`);
@@ -250,13 +285,13 @@ export function registerAppTools(
     try {
       const terminateApp = new TerminateApp(device);
       const result = await terminateApp.execute(args.appId, {
-        skipUiStability: true // skip the 12+ second stability polling
+        skipUiStability: true, // skip the 12+ second stability polling
       });
 
       return createJSONToolResponse({
         message: `Terminated app ${args.appId}`,
         observation: result.observation,
-        ...result
+        ...result,
       });
     } catch (error) {
       throw new ActionableError(`Failed to terminate app: ${error}`);
@@ -271,7 +306,12 @@ export function registerAppTools(
   };
 
   // Install app handler
-  const installAppHandler = async (device: BootedDevice, args: InstallAppArgs, _progress?: unknown, signal?: AbortSignal) => {
+  const installAppHandler = async (
+    device: BootedDevice,
+    args: InstallAppArgs,
+    _progress?: unknown,
+    signal?: AbortSignal,
+  ) => {
     try {
       const installApp = new InstallApp(device);
       const result = await installApp.execute(args.artifactPath, undefined, signal);
@@ -281,7 +321,7 @@ export function registerAppTools(
 
       return createJSONToolResponse({
         message,
-        ...result
+        ...result,
       });
     } catch (error) {
       throw new ActionableError(`Failed to install app: ${error}`);
@@ -296,10 +336,20 @@ export function registerAppTools(
   };
 
   // Uninstall app handler
-  const uninstallAppHandler = async (device: BootedDevice, args: UninstallAppArgs) => {
+  const uninstallAppHandler = async (
+    device: BootedDevice,
+    args: UninstallAppArgs,
+    _progress?: unknown,
+    signal?: AbortSignal,
+  ) => {
     try {
       const uninstallApp = new UninstallApp(device);
-      const result = await uninstallApp.execute(args.appId, args.keepData ?? false);
+      const result = await uninstallApp.execute(
+        args.appId,
+        args.keepData ?? false,
+        undefined,
+        signal,
+      );
 
       if (!result.success) {
         throw new ActionableError(result.error || `Failed to uninstall app ${args.appId}`);
@@ -311,10 +361,12 @@ export function registerAppTools(
 
       return createJSONToolResponse({
         message,
-        ...result
+        ...result,
       });
     } catch (error) {
-      if (error instanceof ActionableError) {throw error;}
+      if (error instanceof ActionableError) {
+        throw error;
+      }
       throw new ActionableError(`Failed to uninstall app: ${error}`);
     } finally {
       try {
@@ -340,7 +392,7 @@ export function registerAppTools(
     return createJSONToolResponse({
       message: result.success
         ? `Applied ${result.changedCount} app permission change(s) for ${args.appId}`
-        : result.error ?? `Failed to apply app permission changes for ${args.appId}`,
+        : (result.error ?? `Failed to apply app permission changes for ${args.appId}`),
       ...result,
     });
   };
@@ -354,7 +406,7 @@ export function registerAppTools(
     return createJSONToolResponse({
       message: result.success
         ? `Read ${result.permissions.length} app permission state row(s) for ${args.appId}`
-        : result.error ?? `Failed to read app permission state for ${args.appId}`,
+        : (result.error ?? `Failed to read app permission state for ${args.appId}`),
       ...result,
     });
   };
@@ -364,48 +416,48 @@ export function registerAppTools(
     "launchApp",
     "Launch app by package name",
     launchAppSchema,
-    launchAppHandler
+    launchAppHandler,
   );
 
   ToolRegistry.registerDeviceAware(
     "terminateApp",
     "Terminate app by package name",
     packageNameSchema,
-    terminateAppHandler
+    terminateAppHandler,
   );
 
   ToolRegistry.registerDeviceAware(
     "installApp",
     "Install app on device (.apk, .app, or .ipa)",
     installAppSchema,
-    installAppHandler
+    installAppHandler,
   );
 
   ToolRegistry.registerDeviceAware(
     "uninstallApp",
     "Uninstall app by package name or bundle identifier",
     uninstallAppSchema,
-    uninstallAppHandler
+    uninstallAppHandler,
   );
 
   ToolRegistry.registerDeviceAware(
     "setAppPermissions",
     "userId grant/revoke; device-wide reset ['all']; no POST_NOTIFICATIONS.",
     setAppPermissionsSchema,
-    setAppPermissionsHandler
+    setAppPermissionsHandler,
   );
 
   ToolRegistry.registerDeviceAware(
     "getAppPermissions",
     "Read app permission state",
     getAppPermissionsSchema,
-    getAppPermissionsHandler
+    getAppPermissionsHandler,
   );
 
   ToolRegistry.register(
     "listApps",
     "Guide for listing apps via MCP resources",
     listAppsSchema,
-    listAppsHandler
+    listAppsHandler,
   );
 }

--- a/test/daemon/clientRequestTimeout.test.ts
+++ b/test/daemon/clientRequestTimeout.test.ts
@@ -2,7 +2,11 @@ import { describe, expect, test, beforeEach } from "bun:test";
 import { Duplex } from "node:stream";
 import { DaemonClient } from "../../src/daemon/client";
 import { McpTimeoutError } from "../../src/daemon/McpTimeoutError";
-import { MIN_START_DEVICE_MCP_TIMEOUT_MS, DEFAULT_MCP_REQUEST_TIMEOUT_MS } from "../../src/daemon/mcpRequestTimeout";
+import {
+  DEFAULT_MCP_REQUEST_TIMEOUT_MS,
+  MIN_START_DEVICE_MCP_TIMEOUT_MS,
+  MIN_UNINSTALL_APP_MCP_TIMEOUT_MS,
+} from "../../src/daemon/mcpRequestTimeout";
 import { FakeTimer } from "../fakes/FakeTimer";
 
 function createBlackHoleSocket(): Duplex {
@@ -40,6 +44,26 @@ describe("DaemonClient per-request timeout", () => {
       const timeoutErr = err as McpTimeoutError;
       expect(timeoutErr.toolName).toBe("startDevice");
       expect(timeoutErr.timeoutMs).toBe(MIN_START_DEVICE_MCP_TIMEOUT_MS);
+      expect(timeoutErr.origin).toBe("DaemonClient.sendRequest");
+    } finally {
+      await client.close();
+    }
+  });
+
+  test("uninstallApp uses MIN_UNINSTALL_APP_MCP_TIMEOUT_MS", async () => {
+    const client = createConnectedClient(fakeTimer);
+
+    const promise = client.callTool("uninstallApp", { appId: "com.example.app" });
+    fakeTimer.advanceTime(MIN_UNINSTALL_APP_MCP_TIMEOUT_MS);
+
+    try {
+      await promise;
+      expect.unreachable("should have timed out");
+    } catch (err) {
+      expect(err).toBeInstanceOf(McpTimeoutError);
+      const timeoutErr = err as McpTimeoutError;
+      expect(timeoutErr.toolName).toBe("uninstallApp");
+      expect(timeoutErr.timeoutMs).toBe(MIN_UNINSTALL_APP_MCP_TIMEOUT_MS);
       expect(timeoutErr.origin).toBe("DaemonClient.sendRequest");
     } finally {
       await client.close();

--- a/test/daemon/mcpRequestTimeout.test.ts
+++ b/test/daemon/mcpRequestTimeout.test.ts
@@ -8,6 +8,7 @@ import {
   MIN_EXECUTE_PLAN_MCP_TIMEOUT_MS,
   MIN_LAUNCH_APP_MCP_TIMEOUT_MS,
   MIN_START_DEVICE_MCP_TIMEOUT_MS,
+  MIN_UNINSTALL_APP_MCP_TIMEOUT_MS,
   OBSERVE_MCP_TIMEOUT_ENV_VAR,
   OPEN_LINK_MCP_TIMEOUT_ENV_VAR,
   START_DEVICE_MCP_TIMEOUT_OVERHEAD_MS,
@@ -67,6 +68,7 @@ describe("resolveMcpRequestTimeoutMs", () => {
     { name: "executePlan floor when timeoutMs omitted", tool: "executePlan", expected: MIN_EXECUTE_PLAN_MCP_TIMEOUT_MS },
     { name: "startDevice floor when timeoutMs omitted", tool: "startDevice", expected: MIN_START_DEVICE_MCP_TIMEOUT_MS },
     { name: "launchApp floor when timeoutMs omitted", tool: "launchApp", expected: MIN_LAUNCH_APP_MCP_TIMEOUT_MS },
+    { name: "uninstallApp floor when timeoutMs omitted", tool: "uninstallApp", expected: MIN_UNINSTALL_APP_MCP_TIMEOUT_MS },
     { name: "observe default floor when timeoutMs omitted", tool: "observe", expected: DEFAULT_OBSERVE_MCP_TIMEOUT_MS },
     { name: "openLink default floor when timeoutMs omitted", tool: "openLink", expected: DEFAULT_OPEN_LINK_MCP_TIMEOUT_MS },
 
@@ -74,6 +76,7 @@ describe("resolveMcpRequestTimeoutMs", () => {
     { name: "raises short executePlan to floor", tool: "executePlan", timeoutMs: 180_000, expected: MIN_EXECUTE_PLAN_MCP_TIMEOUT_MS },
     { name: "raises short startDevice to floor", tool: "startDevice", timeoutMs: 60_000, expected: MIN_START_DEVICE_MCP_TIMEOUT_MS },
     { name: "raises short launchApp to floor", tool: "launchApp", timeoutMs: 10_000, expected: MIN_LAUNCH_APP_MCP_TIMEOUT_MS },
+    { name: "raises short uninstallApp to floor", tool: "uninstallApp", timeoutMs: 30_000, expected: MIN_UNINSTALL_APP_MCP_TIMEOUT_MS },
     { name: "raises short observe to floor", tool: "observe", timeoutMs: 30_000, expected: DEFAULT_OBSERVE_MCP_TIMEOUT_MS },
     { name: "raises short openLink to floor", tool: "openLink", timeoutMs: 10_000, expected: DEFAULT_OPEN_LINK_MCP_TIMEOUT_MS },
 
@@ -81,6 +84,7 @@ describe("resolveMcpRequestTimeoutMs", () => {
     { name: "preserves executePlan above floor", tool: "executePlan", timeoutMs: 900_000, expected: 900_000 },
     { name: "preserves startDevice above floor", tool: "startDevice", timeoutMs: 300_000, expected: 300_000 },
     { name: "preserves launchApp above floor", tool: "launchApp", timeoutMs: 150_000, expected: 150_000 },
+    { name: "preserves uninstallApp above floor", tool: "uninstallApp", timeoutMs: 90_000, expected: 90_000 },
     { name: "preserves observe above floor", tool: "observe", timeoutMs: 150_000, expected: 150_000 },
 
     // --- Boundary: base exactly equal to the floor stays put (Math.max is idempotent) ---

--- a/test/features/action/UninstallApp.test.ts
+++ b/test/features/action/UninstallApp.test.ts
@@ -1,16 +1,26 @@
 import { expect, describe, test, beforeEach } from "bun:test";
-import { UninstallApp as ProductionUninstallApp, DeviceAppUninstaller } from "../../../src/features/action/UninstallApp";
+import {
+  UninstallApp as ProductionUninstallApp,
+  DeviceAppUninstaller,
+} from "../../../src/features/action/UninstallApp";
 import type { BootedDevice } from "../../../src/models";
 import { FakeSimctl } from "../../fakes/FakeSimctl";
 import { FakeAdbClient } from "../../fakes/FakeAdbClient";
 import { FakeInstalledAppsRepository } from "../../fakes/FakeInstalledAppsRepository";
+import { AdbCommandTimeoutError } from "../../../src/utils/android-cmdline-tools/AdbClient";
 
 // Keep action tests isolated from the production SQLite repository even when a
 // scenario does not need to inspect stale-marker rows explicitly.
 class UninstallApp extends ProductionUninstallApp {
   constructor(...args: ConstructorParameters<typeof ProductionUninstallApp>) {
     const [device, adbFactory, simctl, deviceAppUninstaller, repository] = args;
-    super(device, adbFactory, simctl, deviceAppUninstaller, repository ?? new FakeInstalledAppsRepository());
+    super(
+      device,
+      adbFactory,
+      simctl,
+      deviceAppUninstaller,
+      repository ?? new FakeInstalledAppsRepository(),
+    );
   }
 }
 
@@ -27,13 +37,13 @@ class FakeDeviceAppUninstaller implements DeviceAppUninstaller {
 }
 
 const fakeAdbFactory = (fakeAdb: FakeAdbClient) => ({ create: () => fakeAdb as any });
-const nullAdbFactory = { create: () => ({} as any) };
+const nullAdbFactory = { create: () => ({}) as any };
 
 describe("UninstallApp (iOS simulator)", () => {
   const iosSimDevice: BootedDevice = {
     deviceId: "A1B2C3D4-E5F6-7890-ABCD-EF1234567890",
     name: "iPhone 15",
-    platform: "ios"
+    platform: "ios",
   };
 
   let fakeSimctl: FakeSimctl;
@@ -55,7 +65,13 @@ describe("UninstallApp (iOS simulator)", () => {
 
     const repo = new FakeInstalledAppsRepository();
     await repo.upsertInstalledApp(iosSimDevice.deviceId, 0, "com.example.app", false, 1_000);
-    const uninstall = new UninstallApp(iosSimDevice, nullAdbFactory, fakeSimctl, fakeUninstaller, repo);
+    const uninstall = new UninstallApp(
+      iosSimDevice,
+      nullAdbFactory,
+      fakeSimctl,
+      fakeUninstaller,
+      repo,
+    );
     const result = await uninstall.execute("com.example.app");
 
     expect(result.success).toBe(true);
@@ -130,14 +146,14 @@ describe("UninstallApp (unsupported platform)", () => {
     const webDevice = {
       deviceId: "web-device-1",
       name: "web",
-      platform: "web"
+      platform: "web",
     } as unknown as BootedDevice;
 
     const uninstall = new UninstallApp(
       webDevice,
       nullAdbFactory,
       new FakeSimctl(),
-      new FakeDeviceAppUninstaller()
+      new FakeDeviceAppUninstaller(),
     );
 
     await expect(uninstall.execute("com.example.app")).rejects.toThrow("Unsupported platform: web");
@@ -148,7 +164,7 @@ describe("UninstallApp (iOS physical device)", () => {
   const iosPhysicalDevice: BootedDevice = {
     deviceId: "00008110001234560A",
     name: "Jason's iPhone",
-    platform: "ios"
+    platform: "ios",
   };
 
   let fakeSimctl: FakeSimctl;
@@ -167,7 +183,12 @@ describe("UninstallApp (iOS physical device)", () => {
       fakeSimctl.setInstalledApps([]);
     };
 
-    const uninstall = new UninstallApp(iosPhysicalDevice, nullAdbFactory, fakeSimctl, fakeUninstaller);
+    const uninstall = new UninstallApp(
+      iosPhysicalDevice,
+      nullAdbFactory,
+      fakeSimctl,
+      fakeUninstaller,
+    );
     const result = await uninstall.execute("com.example.app");
 
     expect(result.success).toBe(true);
@@ -183,19 +204,16 @@ describe("UninstallApp (Android)", () => {
   const androidDevice: BootedDevice = {
     deviceId: "emulator-5554",
     name: "Pixel 7",
-    platform: "android"
+    platform: "android",
   };
 
   let fakeAdb: FakeAdbClient;
 
   function setupNoApp(adb: FakeAdbClient, userId: number): void {
-    adb.setCommandResult(
-      `shell pm list packages --user ${userId}`,
-      "package:com.android.settings"
-    );
+    adb.setCommandResult(`shell pm list packages --user ${userId}`, "package:com.android.settings");
     adb.setCommandResult(
       `shell pm list packages -s --user ${userId}`,
-      "package:com.android.settings"
+      "package:com.android.settings",
     );
   }
 
@@ -209,7 +227,7 @@ describe("UninstallApp (Android)", () => {
     // Pre-uninstall the app is present; the post-uninstall re-check sees it gone.
     fakeAdb.setCommandResultSequence("shell pm list packages --user 0", [
       { stdout: "package:com.example.app\npackage:com.android.settings" },
-      { stdout: "package:com.android.settings" }
+      { stdout: "package:com.android.settings" },
     ]);
 
     const uninstall = new UninstallApp(androidDevice, fakeAdbFactory(fakeAdb));
@@ -221,7 +239,7 @@ describe("UninstallApp (Android)", () => {
     expect(result.userId).toBe(0);
 
     // Assert the exact emitted commands — no -k because keepData is false.
-    const commands = fakeAdb.getCommandCalls().map(call => call.command);
+    const commands = fakeAdb.getCommandCalls().map((call) => call.command);
     expect(commands).toContain("shell am force-stop --user 0 com.example.app");
     expect(commands).toContain("shell pm uninstall --user 0 com.example.app");
     expect(commands).not.toContain("shell pm uninstall --user 0 -k com.example.app");
@@ -232,7 +250,7 @@ describe("UninstallApp (Android)", () => {
     await repo.upsertInstalledApp(androidDevice.deviceId, 0, "com.example.previous", false, 1_000);
     fakeAdb.setCommandResultSequence("shell pm list packages --user 0", [
       { stdout: "package:com.example.app\npackage:com.android.settings" },
-      { stdout: "package:com.android.settings" }
+      { stdout: "package:com.android.settings" },
     ]);
 
     const uninstall = new UninstallApp(androidDevice, fakeAdbFactory(fakeAdb), null, null, repo);
@@ -251,7 +269,7 @@ describe("UninstallApp (Android)", () => {
         timeoutMs?: number,
         maxBuffer?: number,
         noRetry?: boolean,
-        signal?: AbortSignal
+        signal?: AbortSignal,
       ) {
         if (command === "shell pm list packages --user 0") {
           this.listPackagesCalls++;
@@ -280,7 +298,7 @@ describe("UninstallApp (Android)", () => {
     fakeAdb.setUsers([{ userId: 0, name: "Owner", running: true }]);
     fakeAdb.setCommandResultSequence("shell pm list packages --user 0", [
       { stdout: "package:com.example.app\npackage:com.android.settings" },
-      { stdout: "package:com.android.settings" }
+      { stdout: "package:com.android.settings" },
     ]);
 
     const uninstall = new UninstallApp(androidDevice, fakeAdbFactory(fakeAdb));
@@ -290,9 +308,142 @@ describe("UninstallApp (Android)", () => {
     expect(result.keepData).toBe(true);
 
     // The -k flag preserves app data; assert the exact command carried it.
-    const commands = fakeAdb.getCommandCalls().map(call => call.command);
+    const commands = fakeAdb.getCommandCalls().map((call) => call.command);
     expect(commands).toContain("shell pm uninstall --user 0 -k com.example.app");
     expect(commands).not.toContain("shell pm uninstall --user 0 com.example.app");
+  });
+
+  test("reports success when a timed-out uninstall removed the package", async () => {
+    class TimeoutUninstallAdb extends FakeAdbClient {
+      override async executeCommand(
+        command: string,
+        timeoutMs?: number,
+        maxBuffer?: number,
+        noRetry?: boolean,
+        signal?: AbortSignal,
+      ) {
+        if (command === "shell pm uninstall --user 0 com.example.app") {
+          await super.executeCommand(command, timeoutMs, maxBuffer, noRetry, signal);
+          throw new AdbCommandTimeoutError("Command timed out");
+        }
+        return super.executeCommand(command, timeoutMs, maxBuffer, noRetry, signal);
+      }
+    }
+
+    const adb = new TimeoutUninstallAdb();
+    adb.setCommandResultSequence("shell pm list packages --user 0", [
+      "package:com.example.app",
+      "package:com.android.settings",
+    ]);
+
+    const result = await new UninstallApp(androidDevice, fakeAdbFactory(adb)).execute(
+      "com.example.app",
+    );
+
+    expect(result).toMatchObject({ success: true, wasInstalled: true, userId: 0 });
+    expect(
+      adb
+        .getCommandCalls()
+        .filter((call) => call.command === "shell pm uninstall --user 0 com.example.app"),
+    ).toHaveLength(1);
+  });
+
+  test("retries a timed-out uninstall once only after confirming the package remains installed", async () => {
+    class TimeoutThenSuccessAdb extends FakeAdbClient {
+      private uninstallAttempts = 0;
+
+      override async executeCommand(
+        command: string,
+        timeoutMs?: number,
+        maxBuffer?: number,
+        noRetry?: boolean,
+        signal?: AbortSignal,
+      ) {
+        if (command === "shell pm uninstall --user 0 com.example.app") {
+          this.uninstallAttempts++;
+          if (this.uninstallAttempts === 1) {
+            await super.executeCommand(command, timeoutMs, maxBuffer, noRetry, signal);
+            throw new AdbCommandTimeoutError("Command timed out");
+          }
+        }
+        return super.executeCommand(command, timeoutMs, maxBuffer, noRetry, signal);
+      }
+    }
+
+    const adb = new TimeoutThenSuccessAdb();
+    adb.setCommandResultSequence("shell pm list packages --user 0", [
+      "package:com.example.app",
+      "package:com.example.app",
+      "package:com.android.settings",
+    ]);
+
+    const result = await new UninstallApp(androidDevice, fakeAdbFactory(adb)).execute(
+      "com.example.app",
+    );
+
+    expect(result).toMatchObject({ success: true, wasInstalled: true, userId: 0 });
+    expect(
+      adb
+        .getCommandCalls()
+        .filter((call) => call.command === "shell pm uninstall --user 0 com.example.app"),
+    ).toHaveLength(2);
+  });
+
+  test("returns actionable diagnostics when the bounded retry also times out", async () => {
+    class AlwaysTimeoutUninstallAdb extends FakeAdbClient {
+      override async executeCommand(
+        command: string,
+        timeoutMs?: number,
+        maxBuffer?: number,
+        noRetry?: boolean,
+        signal?: AbortSignal,
+      ) {
+        if (command === "shell pm uninstall --user 0 com.example.app") {
+          await super.executeCommand(command, timeoutMs, maxBuffer, noRetry, signal);
+          throw new AdbCommandTimeoutError("Command timed out");
+        }
+        return super.executeCommand(command, timeoutMs, maxBuffer, noRetry, signal);
+      }
+    }
+
+    const adb = new AlwaysTimeoutUninstallAdb();
+    adb.setCommandResultSequence("shell pm list packages --user 0", [
+      "package:com.example.app",
+      "package:com.example.app",
+    ]);
+
+    const result = await new UninstallApp(androidDevice, fakeAdbFactory(adb)).execute(
+      "com.example.app",
+    );
+
+    expect(result).toMatchObject({
+      success: false,
+      userId: 0,
+      error:
+        "Android uninstall timed out after 20000ms for package com.example.app (user 0). One bounded retry failed: Command timed out",
+    });
+    const uninstallCalls = adb
+      .getCommandCalls()
+      .filter((call) => call.command === "shell pm uninstall --user 0 com.example.app");
+    expect(uninstallCalls).toEqual([
+      expect.objectContaining({ timeoutMs: 20_000, noRetry: true }),
+      expect.objectContaining({ timeoutMs: 5_000, noRetry: true }),
+    ]);
+  });
+
+  test("preserves an already-aborted caller signal without issuing commands", async () => {
+    const controller = new AbortController();
+    controller.abort(new Error("caller cancelled"));
+
+    await expect(
+      new UninstallApp(androidDevice, fakeAdbFactory(fakeAdb)).execute(
+        "com.example.app",
+        false,
+        undefined,
+        controller.signal,
+      ),
+    ).rejects.toThrow("caller cancelled");
+    expect(fakeAdb.getCommandCalls()).toHaveLength(0);
   });
 
   test("returns not installed when package is missing", async () => {
@@ -315,13 +466,13 @@ describe("UninstallApp (Android)", () => {
     fakeAdb.setForegroundApp(null);
     fakeAdb.setUsers([
       { userId: 0, name: "Owner", running: true },
-      { userId: 10, name: "Work", flags: 0x30, running: true }
+      { userId: 10, name: "Work", flags: 0x30, running: true },
     ]);
     // App installed under work profile (userId 10)
     setupNoApp(fakeAdb, 0);
     fakeAdb.setCommandResultSequence("shell pm list packages --user 10", [
       { stdout: "package:com.example.app\npackage:com.android.settings" },
-      { stdout: "package:com.android.settings" }
+      { stdout: "package:com.android.settings" },
     ]);
 
     const uninstall = new UninstallApp(androidDevice, fakeAdbFactory(fakeAdb));
@@ -329,7 +480,7 @@ describe("UninstallApp (Android)", () => {
 
     expect(result.userId).toBe(10);
     // The uninstall must target the work-profile user, not user 0.
-    const commands = fakeAdb.getCommandCalls().map(call => call.command);
+    const commands = fakeAdb.getCommandCalls().map((call) => call.command);
     expect(commands).toContain("shell pm uninstall --user 10 com.example.app");
     expect(commands).not.toContain("shell pm uninstall --user 0 com.example.app");
   });

--- a/test/features/action/UninstallApp.test.ts
+++ b/test/features/action/UninstallApp.test.ts
@@ -421,7 +421,7 @@ describe("UninstallApp (Android)", () => {
       success: false,
       userId: 0,
       error:
-        "Android uninstall timed out after 20000ms for package com.example.app (user 0). One bounded retry failed: Command timed out",
+        "Android uninstall timed out after 20000ms for package com.example.app (user 0). Package remains installed after one bounded retry timed out.",
     });
     const uninstallCalls = adb
       .getCommandCalls()
@@ -430,6 +430,37 @@ describe("UninstallApp (Android)", () => {
       expect.objectContaining({ timeoutMs: 20_000, noRetry: true }),
       expect.objectContaining({ timeoutMs: 5_000, noRetry: true }),
     ]);
+  });
+
+  test("reports success when the bounded retry times out after removing the package", async () => {
+    class AlwaysTimeoutUninstallAdb extends FakeAdbClient {
+      override async executeCommand(
+        command: string,
+        timeoutMs?: number,
+        maxBuffer?: number,
+        noRetry?: boolean,
+        signal?: AbortSignal,
+      ) {
+        if (command === "shell pm uninstall --user 0 com.example.app") {
+          await super.executeCommand(command, timeoutMs, maxBuffer, noRetry, signal);
+          throw new AdbCommandTimeoutError("Command timed out");
+        }
+        return super.executeCommand(command, timeoutMs, maxBuffer, noRetry, signal);
+      }
+    }
+
+    const adb = new AlwaysTimeoutUninstallAdb();
+    adb.setCommandResultSequence("shell pm list packages --user 0", [
+      "package:com.example.app",
+      "package:com.example.app",
+      "package:com.android.settings",
+    ]);
+
+    const result = await new UninstallApp(androidDevice, fakeAdbFactory(adb)).execute(
+      "com.example.app",
+    );
+
+    expect(result).toMatchObject({ success: true, wasInstalled: true, userId: 0 });
   });
 
   test("preserves an already-aborted caller signal without issuing commands", async () => {

--- a/test/features/action/UninstallApp.test.ts
+++ b/test/features/action/UninstallApp.test.ts
@@ -8,6 +8,7 @@ import { FakeSimctl } from "../../fakes/FakeSimctl";
 import { FakeAdbClient } from "../../fakes/FakeAdbClient";
 import { FakeInstalledAppsRepository } from "../../fakes/FakeInstalledAppsRepository";
 import { AdbCommandTimeoutError } from "../../../src/utils/android-cmdline-tools/AdbClient";
+import { OPERATION_CANCELLED_MESSAGE } from "../../../src/utils/constants";
 
 // Keep action tests isolated from the production SQLite repository even when a
 // scenario does not need to inspect stale-marker rows explicitly.
@@ -442,8 +443,47 @@ describe("UninstallApp (Android)", () => {
         undefined,
         controller.signal,
       ),
-    ).rejects.toThrow("caller cancelled");
+    ).rejects.toThrow(OPERATION_CANCELLED_MESSAGE);
     expect(fakeAdb.getCommandCalls()).toHaveLength(0);
+  });
+
+  test("stops timeout recovery when the caller cancels after the uninstall dispatches", async () => {
+    const controller = new AbortController();
+
+    class TimeoutThenAbortAdb extends FakeAdbClient {
+      override async executeCommand(
+        command: string,
+        timeoutMs?: number,
+        maxBuffer?: number,
+        noRetry?: boolean,
+        signal?: AbortSignal,
+      ) {
+        if (command === "shell pm uninstall --user 0 com.example.app") {
+          await super.executeCommand(command, timeoutMs, maxBuffer, noRetry, signal);
+          controller.abort();
+          throw new AdbCommandTimeoutError("Command timed out");
+        }
+        return super.executeCommand(command, timeoutMs, maxBuffer, noRetry, signal);
+      }
+    }
+
+    const adb = new TimeoutThenAbortAdb();
+    adb.setCommandResult("shell pm list packages --user 0", "package:com.example.app");
+
+    await expect(
+      new UninstallApp(androidDevice, fakeAdbFactory(adb)).execute(
+        "com.example.app",
+        false,
+        undefined,
+        controller.signal,
+      ),
+    ).rejects.toThrow(OPERATION_CANCELLED_MESSAGE);
+    expect(adb.getCommandCalls().filter((call) => call.command === "shell pm list packages --user 0")).toHaveLength(1);
+    expect(
+      adb
+        .getCommandCalls()
+        .filter((call) => call.command === "shell pm uninstall --user 0 com.example.app"),
+    ).toHaveLength(1);
   });
 
   test("returns not installed when package is missing", async () => {


### PR DESCRIPTION
## Summary

Bound Android `uninstallApp` requests to 20 seconds, then verify package state before treating a timeout as failure or attempting one five-second retry. Reserve a 60-second MCP request window so the reconciliation completes before transport cancellation, and thread caller cancellation through the action.

## Linked Issue

Closes [#5357](https://github.com/kaeawc/auto-mobile/issues/5357)

## Bug / Regression Context

- **Observed symptom:** `uninstallApp` could surface `MCP error -32001: Request timed out` without establishing whether Android had completed the uninstall.
- **Repro steps / conditions:** An ADB package-manager uninstall exceeds the request budget.

## Validation

- [x] `scripts/all_fast_validate_checks.sh` passes
- [x] `bun run lint` passes
- [x] `bun test --isolate` passes
- [x] Final-head focused timeout, recovery, cancellation, and daemon request-budget suites pass
- [x] `bun run build` passes
- [x] `bun run typecheck` reports no new errors
- [x] Focused regression coverage uses the injected ADB fake and FakeTimer; no new dependency or generic helper
- [x] Branch was created from the latest `main`

## Device Verification

Not run: deterministic unit coverage simulates the ADB timeout and post-timeout package state without requiring a device.
