### PR TITLE
fix(daemon): bind executions to resolved autolocks

### DIFF
--- a/src/daemon/daemon.ts
+++ b/src/daemon/daemon.ts
@@ -1242,13 +1242,10 @@ export class Daemon {
   private hasActiveSessionExecution(sessionId: string, query?: ActiveSessionExecutionQuery): boolean {
     const executionSessionId = resolveCapabilityBaseSessionUuid(sessionId, this.sessionManager) ?? sessionId;
     return executionTracker.hasActiveSessionUuidExecutions(sessionId, query)
+      || executionTracker.hasActiveAutolockSessionExecutions(sessionId, query)
       || (executionSessionId !== sessionId
-        && executionTracker.hasActiveSessionUuidExecutions(executionSessionId, query))
-      || this.devicePool.hasActiveAutolockMcpSessionExecution(
-        sessionId,
-        (mcpSessionId, executionQuery) => executionTracker.hasActiveSessionExecutions(mcpSessionId, executionQuery),
-        query,
-      );
+        && (executionTracker.hasActiveSessionUuidExecutions(executionSessionId, query)
+          || executionTracker.hasActiveAutolockSessionExecutions(executionSessionId, query)));
   }
 
   private startDeviceDisconnectMonitor(): void {

--- a/src/daemon/devicePool.ts
+++ b/src/daemon/devicePool.ts
@@ -3,7 +3,6 @@ import { randomUUID } from "node:crypto";
 import { logger } from "../utils/logger";
 import {
   SessionManager,
-  type ActiveSessionExecutionQuery,
   type Session,
   type SessionExecutionMetadata,
 } from "./sessionManager";
@@ -3000,25 +2999,7 @@ export class DevicePool {
   }
 
   /**
-   * Whether a live MCP call owns this autolock session. The execution tracker
-   * keys socket-forwarded work by MCP session while SessionManager keys expiry
-   * by the generated device-session UUID, so this bridges those identities.
-   */
-  hasActiveAutolockMcpSessionExecution(
-    sessionId: string,
-    hasActiveMcpSessionExecution: (mcpSessionId: string, query?: ActiveSessionExecutionQuery) => boolean,
-    query?: ActiveSessionExecutionQuery,
-  ): boolean {
-    for (const [mcpSessionId, mappedSessionId] of this.mcpSessionAutolockMap) {
-      if (mappedSessionId === sessionId && hasActiveMcpSessionExecution(mcpSessionId, query)) {
-        return true;
-      }
-    }
-    return false;
-  }
-
-  /**
-   * Free a device whose current session has expired.
+   * Free a device whose autolock session has been released or has expired.
    *
    * Invoked via the SessionManager expiry callback. Only acts when the device
    * is still owned by the released session, so a stale callback cannot free a

--- a/src/server/executionTracker.ts
+++ b/src/server/executionTracker.ts
@@ -13,6 +13,7 @@ interface ActiveExecution {
   sessionId?: string;
   transportSessionId?: string;
   sessionUuid?: string;
+  resolvedAutolockSessionUuid?: string;
   startTime: number;
   abortController: AbortController;
   /**
@@ -49,6 +50,7 @@ export class ExecutionTracker {
   private executions = new Map<string, ActiveExecution>();
   private sessionExecutions = new Map<string, Set<string>>();
   private sessionUuidExecutions = new Map<string, Set<string>>();
+  private autolockSessionExecutions = new Map<string, Set<string>>();
   private timer: Timer;
   private idGenerator: IdGenerator;
 
@@ -116,6 +118,10 @@ export class ExecutionTracker {
         this.sessionUuidExecutions.delete(execution.sessionUuid);
       }
     }
+
+    if (execution.resolvedAutolockSessionUuid) {
+      this.unregisterAutolockSessionExecution(execution.resolvedAutolockSessionUuid, executionId);
+    }
   }
 
   /**
@@ -145,6 +151,28 @@ export class ExecutionTracker {
 
   hasActiveSessionExecutions(sessionId: string, query?: ActiveExecutionQuery): boolean {
     return this.hasActiveExecutionsForKey(this.sessionExecutions, sessionId, query);
+  }
+
+  /**
+   * Records the concrete autolock UUID selected after an implicit MCP call begins.
+   * This association must not follow later changes to the MCP-session routing map.
+   */
+  setResolvedAutolockSessionUuid(executionId: string, sessionUuid: string): void {
+    const execution = this.executions.get(executionId);
+    if (!execution || execution.resolvedAutolockSessionUuid === sessionUuid) {
+      return;
+    }
+    if (execution.resolvedAutolockSessionUuid) {
+      this.unregisterAutolockSessionExecution(execution.resolvedAutolockSessionUuid, executionId);
+    }
+    execution.resolvedAutolockSessionUuid = sessionUuid;
+    const executions = this.autolockSessionExecutions.get(sessionUuid) ?? new Set<string>();
+    executions.add(executionId);
+    this.autolockSessionExecutions.set(sessionUuid, executions);
+  }
+
+  hasActiveAutolockSessionExecutions(sessionUuid: string, query?: ActiveExecutionQuery): boolean {
+    return this.hasActiveExecutionsForKey(this.autolockSessionExecutions, sessionUuid, query);
   }
 
   hasActiveToolExecution(toolName: string, options: ExecutionScopeOptions): boolean {
@@ -183,6 +211,14 @@ export class ExecutionTracker {
     sessionSet?.delete(executionId);
     if (sessionSet?.size === 0) {
       this.sessionExecutions.delete(sessionId);
+    }
+  }
+
+  private unregisterAutolockSessionExecution(sessionUuid: string, executionId: string): void {
+    const executions = this.autolockSessionExecutions.get(sessionUuid);
+    executions?.delete(executionId);
+    if (executions?.size === 0) {
+      this.autolockSessionExecutions.delete(sessionUuid);
     }
   }
 

--- a/src/server/toolRegistry.ts
+++ b/src/server/toolRegistry.ts
@@ -48,6 +48,7 @@ import {
   runWithToolCapabilityContext,
 } from "../features/toolCapabilities/toolCapabilityContext";
 import { isDeviceLostError } from "./deviceLossOutcome";
+import { executionTracker } from "./executionTracker";
 
 // Re-exported for backward compatibility; the implementation now lives in
 // ./TopLevelUnionFlattener so the schema-flattening concern is independently testable.
@@ -394,6 +395,9 @@ class DefaultExecutionTargetResolver implements ExecutionTargetResolver {
       const implicitSessionUuid = this.resolveImplicitAutolockSession(platform, sessionUuid, providedDeviceId, mcpSessionId, execution);
       if (implicitSessionUuid) {
         sessionUuid = implicitSessionUuid;
+        if (execution) {
+          executionTracker.setResolvedAutolockSessionUuid(execution.executionId, implicitSessionUuid);
+        }
         logger.info(`[ToolRegistry] Resolved implicit autolock session for MCP session ${mcpSessionId}: ${implicitSessionUuid}`);
       }
       if (sessionUuid) {

--- a/test/daemon/SessionHeartbeatMonitor.test.ts
+++ b/test/daemon/SessionHeartbeatMonitor.test.ts
@@ -240,10 +240,13 @@ describe("SessionHeartbeatMonitor", () => {
       process.env.AUTOMOBILE_DEVICE_POOL_AUTOLOCK = "1";
       process.env.AUTOMOBILE_DEVICE_POOL_TIMEOUT = "60"; // 60s idle timeout
       const fakeDeviceUtils = new FakeDeviceUtils();
-      const androidDevice = { name: "Pixel 7", platform: "android" as const, deviceId: "emulator-5554" };
-      fakeDeviceUtils.setBootedDevices("android", [androidDevice]);
+      const androidDevices = [
+        { name: "Pixel 7", platform: "android" as const, deviceId: "emulator-5554" },
+        { name: "Pixel 8", platform: "android" as const, deviceId: "emulator-5556" },
+      ];
+      fakeDeviceUtils.setBootedDevices("android", androidDevices);
       pool = new DevicePool(sessionManager, "daemon-test", timer, undefined, fakeDeviceUtils);
-      await pool.initializeWithDevices([androidDevice]);
+      await pool.initializeWithDevices(androidDevices);
     });
 
     // Mirrors daemon.ts cancelAndReleaseSession (minus execution cancellation).
@@ -289,15 +292,12 @@ describe("SessionHeartbeatMonitor", () => {
       }
     });
 
-    it("keeps an expired autolocked session assigned until active work completes", async () => {
-      const sessionId = await pool.autolockDevice("emulator-5554", "android", "mcp-session-1");
+    it("keeps the autolock resolved by an implicit execution after its MCP session remaps", async () => {
+      const firstSessionId = await pool.autolockDevice("emulator-5554", "android", "mcp-session-1");
       const executionTracker = new ExecutionTracker(timer);
       const hasActiveExecutions = (sessionUuid: string): boolean =>
         executionTracker.hasActiveSessionUuidExecutions(sessionUuid)
-        || pool.hasActiveAutolockMcpSessionExecution(
-          sessionUuid,
-          mcpSessionId => executionTracker.hasActiveSessionExecutions(mcpSessionId),
-        );
+        || executionTracker.hasActiveAutolockSessionExecutions(sessionUuid);
       sessionManager.setActiveSessionExecutionChecker(hasActiveExecutions);
       const monitor = new SessionHeartbeatMonitor(
         sessionManager,
@@ -306,23 +306,64 @@ describe("SessionHeartbeatMonitor", () => {
         timer,
       );
       const execution = executionTracker.startExecution("tapOn", "mcp-session-1");
+      executionTracker.setResolvedAutolockSessionUuid(execution.id, firstSessionId!);
+
+      // A later startDevice call from the same MCP session changes only the
+      // routing map. It must not transfer this running call's ownership.
+      const replacementSessionId = await pool.autolockDevice(
+        "emulator-5556",
+        "android",
+        "mcp-session-1",
+      );
 
       timer.advanceTime(60_001); // Past the autolock idle timeout.
       await monitor.tick();
 
-      const activeDevice = pool.getDevice("emulator-5554")!;
-      expect(activeDevice.status).toBe("busy");
-      expect(activeDevice.autolockSessionId).toBe(sessionId);
-      expect(sessionManager.getActiveSessionCount()).toBe(1);
-      expect(sessionManager.getSession(sessionId!)).not.toBeNull();
+      expect(pool.getDevice("emulator-5554")!.autolockSessionId).toBe(firstSessionId);
+      expect(pool.getDevice("emulator-5554")!.status).toBe("busy");
+      expect(sessionManager.getSession(firstSessionId!)).not.toBeNull();
+      expect(pool.getDevice("emulator-5556")!.status).toBe("idle");
+      expect(sessionManager.getSession(replacementSessionId!)).toBeNull();
 
       executionTracker.endExecution(execution.id);
       await monitor.tick();
 
-      const releasedDevice = pool.getDevice("emulator-5554")!;
-      expect(releasedDevice.status).toBe("idle");
-      expect(releasedDevice.autolockSessionId).toBeUndefined();
-      expect(sessionManager.getActiveSessionCount()).toBe(0);
+      expect(pool.getDevice("emulator-5554")!.status).toBe("idle");
+      expect(pool.getDevice("emulator-5554")!.autolockSessionId).toBeUndefined();
+    });
+
+    it("does not pin the mapped autolock for an explicit call to another session", async () => {
+      const mappedSessionId = await pool.autolockDevice("emulator-5554", "android", "mcp-session-1");
+      const explicitSessionId = await pool.autolockDevice("emulator-5556", "android", "other-mcp-session");
+      const executionTracker = new ExecutionTracker(timer);
+      const hasActiveExecutions = (sessionUuid: string): boolean =>
+        executionTracker.hasActiveSessionUuidExecutions(sessionUuid)
+        || executionTracker.hasActiveAutolockSessionExecutions(sessionUuid);
+      sessionManager.setActiveSessionExecutionChecker(hasActiveExecutions);
+      const monitor = new SessionHeartbeatMonitor(
+        sessionManager,
+        hasActiveExecutions,
+        reapVia(sessionManager, pool),
+        timer,
+      );
+      const execution = executionTracker.startExecution(
+        "tapOn",
+        "mcp-session-1",
+        explicitSessionId,
+      );
+
+      timer.advanceTime(60_001);
+      await monitor.tick();
+
+      expect(pool.getDevice("emulator-5554")!.status).toBe("idle");
+      expect(sessionManager.getSession(mappedSessionId!)).toBeNull();
+      expect(pool.getDevice("emulator-5556")!.autolockSessionId).toBe(explicitSessionId);
+      expect(sessionManager.getSession(explicitSessionId!)).not.toBeNull();
+
+      executionTracker.endExecution(execution.id);
+      await monitor.tick();
+
+      expect(pool.getDevice("emulator-5556")!.status).toBe("idle");
     });
   });
 });

--- a/test/server/executionTracker.test.ts
+++ b/test/server/executionTracker.test.ts
@@ -123,6 +123,23 @@ describe("ExecutionTracker", function() {
     expect(tracker.hasActiveSessionExecutions("session-id", { startedAtOrBefore: 5 })).toBe(false);
   });
 
+  test("tracks an implicit execution under its resolved autolock session", function() {
+    const tracker = new ExecutionTracker(
+      new FakeTimer(),
+      new FakeIdGenerator(["execution-1"]),
+    );
+    const execution = tracker.startExecution("tapOn", "mcp-session");
+
+    tracker.setResolvedAutolockSessionUuid(execution.id, "autolock-session");
+
+    expect(tracker.hasActiveAutolockSessionExecutions("autolock-session")).toBe(true);
+    expect(tracker.hasActiveAutolockSessionExecutions("replacement-session")).toBe(false);
+
+    tracker.endExecution(execution.id);
+
+    expect(tracker.hasActiveAutolockSessionExecutions("autolock-session")).toBe(false);
+  });
+
   // #4183 item 6 (A3): the scope fallback in hasActiveToolExecution (executionTracker.ts)
   // had no table coverage. The scope order is: explicit "global" → sessionUuid map →
   // sessionId map → global fallback when neither key is provided.

--- a/test/server/mcpSessionAutolockRouting.test.ts
+++ b/test/server/mcpSessionAutolockRouting.test.ts
@@ -3,6 +3,12 @@ import { z } from "zod";
 import { McpTestFixture } from "../fixtures/mcpTestFixture";
 import { ToolRegistry } from "../../src/server/toolRegistry";
 import { executionTracker } from "../../src/server/executionTracker";
+import { DevicePool } from "../../src/daemon/devicePool";
+import { DaemonState } from "../../src/daemon/daemonState";
+import { SessionManager } from "../../src/daemon/sessionManager";
+import { FakeDeviceUtils } from "../fakes/FakeDeviceUtils";
+import { FakeDeviceSessionPersistence } from "../fakes/FakeDeviceSessionPersistence";
+import { FakeTimer } from "../fakes/FakeTimer";
 
 const captureSchema = z.object({
   value: z.string().optional(),
@@ -72,6 +78,60 @@ describe("MCP session autolock routing", () => {
         expect(executionTracker.hasActiveSessionExecutions("shared-loopback-session")).toBe(true);
       },
     );
+  });
+
+  test("binds an implicit execution to its resolved autolock before an MCP remap", async () => {
+    process.env.AUTOMOBILE_DEVICE_POOL_AUTOLOCK = "1";
+    process.env.AUTOMOBILE_DEVICE_POOL_TIMEOUT = "60";
+    const timer = new FakeTimer();
+    const sessionManager = new SessionManager(timer, new FakeDeviceSessionPersistence());
+    const fakeDeviceUtils = new FakeDeviceUtils();
+    const devices = [
+      { name: "Pixel 7", platform: "android" as const, deviceId: "emulator-5554" },
+      { name: "Pixel 8", platform: "android" as const, deviceId: "emulator-5556" },
+    ];
+    fakeDeviceUtils.setBootedDevices("android", devices);
+    const pool = new DevicePool(sessionManager, "daemon-test", timer, undefined, fakeDeviceUtils);
+    await pool.initializeWithDevices(devices);
+    DaemonState.getInstance().initialize(sessionManager, pool);
+    const originalSessionId = await pool.autolockDevice("emulator-5554", "android", "mcp-session");
+    const handlerStarted = Promise.withResolvers<void>();
+    const releaseHandler = Promise.withResolvers<void>();
+
+    ToolRegistry.clearTools();
+    ToolRegistry.registerDeviceAware("captureAutolockOwnership", "captureAutolockOwnership", captureSchema, async () => {
+      handlerStarted.resolve();
+      await releaseHandler.promise;
+      return { content: [{ type: "text", text: "ok" }] };
+    });
+    fixture = new McpTestFixture({ sessionContext: { sessionId: "mcp-session" } });
+    await fixture.setup();
+
+    const { client } = fixture.getContext();
+    const request = client.request({
+      method: "tools/call",
+      params: { name: "captureAutolockOwnership", arguments: {} },
+    }, z.any());
+    await handlerStarted.promise;
+
+    const replacementSessionId = await pool.autolockDevice("emulator-5556", "android", "mcp-session");
+    expect(executionTracker.hasActiveAutolockSessionExecutions(originalSessionId!)).toBe(true);
+    expect(executionTracker.hasActiveAutolockSessionExecutions(replacementSessionId!)).toBe(false);
+
+    sessionManager.setActiveSessionExecutionChecker(sessionUuid =>
+      executionTracker.hasActiveSessionUuidExecutions(sessionUuid)
+      || executionTracker.hasActiveAutolockSessionExecutions(sessionUuid),
+    );
+    timer.advanceTime(60_001);
+    expect(sessionManager.getSession(originalSessionId!)).not.toBeNull();
+    expect(sessionManager.getSession(replacementSessionId!)).toBeNull();
+
+    releaseHandler.resolve();
+    await request;
+    sessionManager.stopCleanupTimer();
+    DaemonState.getInstance().reset();
+    delete process.env.AUTOMOBILE_DEVICE_POOL_AUTOLOCK;
+    delete process.env.AUTOMOBILE_DEVICE_POOL_TIMEOUT;
   });
 
   test("does not use the shared daemon loopback MCP session as an implicit autolock key", async () => {


### PR DESCRIPTION
## Summary

Bind implicit tool executions to the exact autolock UUID resolved at invocation time. Expiry now consults that immutable ownership instead of the mutable MCP-session routing map, so a later `startDevice` remap cannot release the original lock or pin its replacement.

## Linked Issue

Closes [#5351](https://github.com/kaeawc/auto-mobile/issues/5351)

## Bug / Regression Context

- **Prior attempts:** [PR #5343](https://github.com/kaeawc/auto-mobile/pull/5343) protected active autolocks through the current MCP-session mapping.
- **Observed symptom:** Remapping an MCP session while a call was active transferred expiry protection to the replacement autolock.
- **Repro steps / conditions:** Start an implicit call on autolock A, then use the same MCP session to create autolock B before A's call completes.

## Validation

- [x] Focused FakeTimer regressions cover implicit remapping and explicit-session calls.
- [x] The end-to-end MCP routing regression covers production binding before remapping.
- [x] `bun run lint`, `bun run build`, and `bun run typecheck` pass in CI.
- [x] The changed files pass `oxfmt --check`.
- [ ] Full `bun test --isolate`: CI has one unrelated `throwIfAborted` assertion failure; it passes when run locally. The workflow is still running, so its failed job cannot yet be retried.
