### PR TITLE
feat(daemon): multiplex subscriptions by subscriptionId

### DIFF
--- a/android/desktop-core/src/main/kotlin/dev/jasonpearson/automobile/desktop/core/daemon/ObservationStreamClient.kt
+++ b/android/desktop-core/src/main/kotlin/dev/jasonpearson/automobile/desktop/core/daemon/ObservationStreamClient.kt
@@ -104,6 +104,7 @@ class ObservationStreamClient : ObservationStream {
   // Requested observation cadence, remembered so it is re-applied on every (re)subscribe (so the
   // cadence survives reconnects). Managed via setCadence(); null means "use the daemon's default".
   private var subscribedDeviceId: String? = null
+  private var subscriptionId: String? = null
   private var requestedScreenshotIntervalMs: Long? = null
   private var requestedHierarchyIntervalMs: Long? = null
 
@@ -148,6 +149,7 @@ class ObservationStreamClient : ObservationStream {
 
       // Send subscribe request (carries any cadence configured via setCadence)
       subscribedDeviceId = deviceId
+      subscriptionId = null
       subscribe(deviceId)
 
       // Start reading messages
@@ -168,10 +170,12 @@ class ObservationStreamClient : ObservationStream {
     try {
       // Send unsubscribe request
       if (previousState is ConnectionState.Connected && previousState.subscribed) {
+        val currentSubscriptionId = subscriptionId
         val request =
           StreamRequest(
             id = UUID.randomUUID().toString(),
             command = "unsubscribe",
+            subscriptionId = currentSubscriptionId,
           )
         sendRequest(request)
       }
@@ -184,6 +188,7 @@ class ObservationStreamClient : ObservationStream {
     channel = null
     reader = null
     writer = null
+    subscriptionId = null
     _connectionState.update { ConnectionState.Disconnected() }
   }
 
@@ -238,11 +243,13 @@ class ObservationStreamClient : ObservationStream {
     requestedHierarchyIntervalMs = hierarchyIntervalMs
 
     if (!_connectionState.value.isConnected) return
+    val currentSubscriptionId = subscriptionId ?: return
 
     val request =
       StreamRequest(
         id = UUID.randomUUID().toString(),
         command = "update_cadence",
+        subscriptionId = currentSubscriptionId,
         deviceId = subscribedDeviceId,
         screenshotIntervalMs = screenshotIntervalMs,
         hierarchyIntervalMs = hierarchyIntervalMs,
@@ -305,6 +312,8 @@ class ObservationStreamClient : ObservationStream {
         log.info("Subscription response: success=${response.success}")
         if (response.success != true) {
           log.warn("Subscription failed: ${response.error}")
+        } else if (response.subscriptionId != null) {
+          subscriptionId = response.subscriptionId
         }
       }
       "hierarchy_update" -> {
@@ -550,6 +559,7 @@ class ObservationStreamClient : ObservationStream {
 data class StreamRequest(
   val id: String,
   val command: String,
+  val subscriptionId: String? = null,
   val deviceId: String? = null,
   val appId: String? = null,
   val screenshotIntervalMs: Long? = null,
@@ -562,6 +572,7 @@ data class StreamResponse(
   val type: String,
   val success: Boolean? = null,
   val error: String? = null,
+  val subscriptionId: String? = null,
   val deviceId: String? = null,
   val timestamp: Long? = null,
   val data: JsonElement? = null,

--- a/android/desktop-core/src/main/kotlin/dev/jasonpearson/automobile/desktop/core/daemon/ObservationStreamClient.kt
+++ b/android/desktop-core/src/main/kotlin/dev/jasonpearson/automobile/desktop/core/daemon/ObservationStreamClient.kt
@@ -105,6 +105,7 @@ class ObservationStreamClient : ObservationStream {
   // cadence survives reconnects). Managed via setCadence(); null means "use the daemon's default".
   private var subscribedDeviceId: String? = null
   private var subscriptionId: String? = null
+  private var pendingCadenceUpdate = false
   private var requestedScreenshotIntervalMs: Long? = null
   private var requestedHierarchyIntervalMs: Long? = null
 
@@ -150,6 +151,7 @@ class ObservationStreamClient : ObservationStream {
       // Send subscribe request (carries any cadence configured via setCadence)
       subscribedDeviceId = deviceId
       subscriptionId = null
+      pendingCadenceUpdate = false
       subscribe(deviceId)
 
       // Start reading messages
@@ -189,6 +191,7 @@ class ObservationStreamClient : ObservationStream {
     reader = null
     writer = null
     subscriptionId = null
+    pendingCadenceUpdate = false
     _connectionState.update { ConnectionState.Disconnected() }
   }
 
@@ -243,22 +246,32 @@ class ObservationStreamClient : ObservationStream {
     requestedHierarchyIntervalMs = hierarchyIntervalMs
 
     if (!_connectionState.value.isConnected) return
-    val currentSubscriptionId = subscriptionId ?: return
+    val currentSubscriptionId = subscriptionId
+    if (currentSubscriptionId == null) {
+      pendingCadenceUpdate = true
+      return
+    }
 
+    sendCadenceUpdate(currentSubscriptionId)
+  }
+
+  private fun sendCadenceUpdate(currentSubscriptionId: String): Boolean {
     val request =
       StreamRequest(
         id = UUID.randomUUID().toString(),
         command = "update_cadence",
         subscriptionId = currentSubscriptionId,
         deviceId = subscribedDeviceId,
-        screenshotIntervalMs = screenshotIntervalMs,
-        hierarchyIntervalMs = hierarchyIntervalMs,
+        screenshotIntervalMs = requestedScreenshotIntervalMs,
+        hierarchyIntervalMs = requestedHierarchyIntervalMs,
       )
     if (sendRequest(request)) {
       log.info(
-        "Requested observation cadence update (screenshot=$screenshotIntervalMs, hierarchy=$hierarchyIntervalMs)"
+        "Requested observation cadence update (screenshot=$requestedScreenshotIntervalMs, hierarchy=$requestedHierarchyIntervalMs)"
       )
+      return true
     }
+    return false
   }
 
   private fun sendRequest(request: StreamRequest): Boolean {
@@ -314,6 +327,9 @@ class ObservationStreamClient : ObservationStream {
           log.warn("Subscription failed: ${response.error}")
         } else if (response.subscriptionId != null) {
           subscriptionId = response.subscriptionId
+          if (pendingCadenceUpdate) {
+            pendingCadenceUpdate = !sendCadenceUpdate(response.subscriptionId)
+          }
         }
       }
       "hierarchy_update" -> {

--- a/android/desktop-core/src/test/kotlin/dev/jasonpearson/automobile/desktop/core/daemon/ObservationStreamClientTest.kt
+++ b/android/desktop-core/src/test/kotlin/dev/jasonpearson/automobile/desktop/core/daemon/ObservationStreamClientTest.kt
@@ -55,6 +55,7 @@ class ObservationStreamClientTest {
       StreamRequest(
         id = "req-3",
         command = "update_cadence",
+        subscriptionId = "devicedatastream-1",
         deviceId = "emulator-5554",
         screenshotIntervalMs = 500L,
       )
@@ -62,8 +63,20 @@ class ObservationStreamClientTest {
     val encoded = wireJson.encodeToString(StreamRequest.serializer(), request)
 
     assertTrue(encoded.contains("\"command\":\"update_cadence\""), encoded)
+    assertTrue(encoded.contains("\"subscriptionId\":\"devicedatastream-1\""), encoded)
     assertTrue(encoded.contains("\"screenshotIntervalMs\":500"), encoded)
     assertFalse(encoded.contains("hierarchyIntervalMs"), encoded)
+  }
+
+  @Test
+  fun `subscription response decodes the server minted subscription ID`() {
+    val response =
+      wireJson.decodeFromString(
+        StreamResponse.serializer(),
+        """{"type":"subscription_response","success":true,"subscriptionId":"devicedatastream-1"}""",
+      )
+
+    assertEquals("devicedatastream-1", response.subscriptionId)
   }
 
   @Test

--- a/docs/design-docs/mcp/daemon/client-screen-control.md
+++ b/docs/design-docs/mcp/daemon/client-screen-control.md
@@ -18,11 +18,11 @@ conforming `frameContext` reference implementation.
 
 ## What talks to the daemon (and what does not)
 
-| Consumer | Uses screen control? |
-| --- | --- |
-| Desktop app (`android/desktop-app`) | **Yes** — legacy frame-context integration; see [#4596](https://github.com/kaeawc/auto-mobile/issues/4596). |
-| Third-party daemon clients | **Yes** — the audience for this document. |
-| IntelliJ / Android Studio plugin (`android/ide-plugin`) | **No — inspector only.** |
+| Consumer                                                | Uses screen control?                                                                                        |
+| ------------------------------------------------------- | ----------------------------------------------------------------------------------------------------------- |
+| Desktop app (`android/desktop-app`)                     | **Yes** — legacy frame-context integration; see [#4596](https://github.com/kaeawc/auto-mobile/issues/4596). |
+| Third-party daemon clients                              | **Yes** — the audience for this document.                                                                   |
+| IntelliJ / Android Studio plugin (`android/ide-plugin`) | **No — inspector only.**                                                                                    |
 
 The IDE plugin shares the `desktop-core` rendering code but **never enables control mode**. It
 is an inspector: it selects elements and highlights them, and forwards no device input of any
@@ -35,13 +35,13 @@ as a deliberate scope decision, not a dropped feature.
 Screen control is five separate contracts. This page ties them together; each linked document is
 the normative spec for its piece.
 
-| # | Contract | Where it lives |
-| --- | --- | --- |
-| 1 | The `input/*` socket endpoints (tap, swipe, pressButton, typeText, key) | [Unix Socket API → Input API](unix-socket-api.md#input-api) |
-| 2 | Viewport→device **coordinate mapping** ([#3346](https://github.com/kaeawc/auto-mobile/issues/3346)) | [Screen Control Mapping](screen-control-mapping.md#viewport--device-mapping) |
-| 3 | **Drag-to-swipe** threshold and cancellation ([#3350](https://github.com/kaeawc/auto-mobile/issues/3350)) | [Screen Control Mapping → Drag-to-swipe policy](screen-control-mapping.md#drag-to-swipe-policy) |
-| 4 | **Key-forwarding** and host-shortcut policy ([#3351](https://github.com/kaeawc/auto-mobile/issues/3351)) | [Screen Control Mapping → Keyboard forwarding policy](screen-control-mapping.md#keyboard-forwarding-policy) |
-| 5 | **Frame snapshot** pairing + **post-input refresh** ([#3348](https://github.com/kaeawc/auto-mobile/issues/3348)) | [Client Frame Snapshot](client-frame-snapshot.md) |
+| #   | Contract                                                                                                         | Where it lives                                                                                              |
+| --- | ---------------------------------------------------------------------------------------------------------------- | ----------------------------------------------------------------------------------------------------------- |
+| 1   | The `input/*` socket endpoints (tap, swipe, pressButton, typeText, key)                                          | [Unix Socket API → Input API](unix-socket-api.md#input-api)                                                 |
+| 2   | Viewport→device **coordinate mapping** ([#3346](https://github.com/kaeawc/auto-mobile/issues/3346))              | [Screen Control Mapping](screen-control-mapping.md#viewport--device-mapping)                                |
+| 3   | **Drag-to-swipe** threshold and cancellation ([#3350](https://github.com/kaeawc/auto-mobile/issues/3350))        | [Screen Control Mapping → Drag-to-swipe policy](screen-control-mapping.md#drag-to-swipe-policy)             |
+| 4   | **Key-forwarding** and host-shortcut policy ([#3351](https://github.com/kaeawc/auto-mobile/issues/3351))         | [Screen Control Mapping → Keyboard forwarding policy](screen-control-mapping.md#keyboard-forwarding-policy) |
+| 5   | **Frame snapshot** pairing + **post-input refresh** ([#3348](https://github.com/kaeawc/auto-mobile/issues/3348)) | [Client Frame Snapshot](client-frame-snapshot.md)                                                           |
 
 ## Observation stream protocol
 
@@ -57,14 +57,15 @@ it is authoritative to `src/daemon/deviceDataStreamSocketServer.ts`.
 
 ### Subscribe handshake
 
-Send a `subscribe` command; the daemon replies once, then pushes update messages until you
-`unsubscribe` or disconnect.
+Send a `subscribe` command for each device/facet. The daemon returns a server-minted
+`subscriptionId`; include that ID in every later `unsubscribe` or `update_cadence` command for the
+subscription. One connection can hold any number of independent subscriptions.
 
 ```json
 // client -> daemon
 { "id": "1", "command": "subscribe", "deviceId": "emulator-5554" }
 // daemon -> client
-{ "id": "1", "type": "subscription_response", "success": true }
+{ "id": "1", "type": "subscription_response", "success": true, "subscriptionId": "devicedatastream-1" }
 ```
 
 - `deviceId` is **optional**: omit it (or send `null`) to receive frames for **all** devices; pass a
@@ -72,15 +73,17 @@ Send a `subscribe` command; the daemon replies once, then pushes update messages
   device the user selected.
 - Optional `screenshotIntervalMs` / `hierarchyIntervalMs` on the `subscribe` request set the capture
   cadence (daemon defaults: screenshot 3000 ms, hierarchy 1000 ms; minimum 250 ms). To change
-  cadence in place later, send `{ "command": "update_cadence", "screenshotIntervalMs": …,
-  "hierarchyIntervalMs": … }`; to stop, send `{ "command": "unsubscribe" }`. An older daemon that
-  does not know a command replies with a benign error and keeps its default cadence.
+  cadence in place later, send `{ "command": "update_cadence", "subscriptionId":
+"devicedatastream-1", "screenshotIntervalMs": …, "hierarchyIntervalMs": … }`; to stop, send
+  `{ "command": "unsubscribe", "subscriptionId": "devicedatastream-1" }`.
+- Every pushed frame includes the `subscriptionId` that produced it, allowing a multiplexing client
+  to demultiplex independently of the frame's `deviceId`.
 
 ### Keepalive (ping/pong) — required to stay connected
 
-The daemon actively reaps subscribers it considers dead. Every **10 s** a keepalive sweep sends
-each subscriber a ping push and destroys any subscriber whose activity has not been refreshed for
-**more than 30 s**, removing its subscription. Because reaping happens only on those 10 s sweep
+The daemon actively reaps connections it considers dead. Every **10 s** a keepalive sweep sends one
+ping per connection and destroys any connection whose activity has not been refreshed for **more than 30 s**,
+removing all of its subscriptions. Because reaping happens only on those 10 s sweep
 boundaries, the effective disconnect lands **between just over 30 s and just under 40 s** of
 inactivity, depending on how the subscription aligns with the sweep. A client that subscribes but
 never answers pings is disconnected in that window — even while it is happily receiving frames.
@@ -173,7 +176,7 @@ platforms. That is the whole contract:
 - **Writing.** Send `input/tap` and `input/swipe` coordinates in those same pixels. The daemon does
   any runner-specific conversion itself (it divides by the runner-reported `nativeScale` for the iOS
   XCUITest runner, exactly and without rounding; Android runners already take pixels).
-- **Do not outlive the declaration.** That conversion uses the runner's *current* metadata, so a
+- **Do not outlive the declaration.** That conversion uses the runner's _current_ metadata, so a
   coordinate mapped against a frame whose space has since changed would be converted as the wrong
   unit. Bind the declared space to the snapshot and stop acting through a **retained** frame the
   moment an incoming message declares a different one — see
@@ -201,13 +204,13 @@ unavailable for control; that fails closed, which is always safe.
 **An unrecognized value is not the legacy fallback.** If a message declares a `coordinateSpace` this
 client does not implement — some future value — you **must** treat that frame as **unsupported** and
 fail closed, not fold it into the absent/point-space path. The two states carry different amounts of
-knowledge: *absent* means "a daemon whose geometry and `input/*` units I know exactly", while
-*declared something else* means "a daemon newer than me, whose bounds I cannot interpret and whose
+knowledge: _absent_ means "a daemon whose geometry and `input/*` units I know exactly", while
+_declared something else_ means "a daemon newer than me, whose bounds I cannot interpret and whose
 input endpoints may expect a unit I do not know". Degrading the second into the first would forward
 coordinates whose meaning is unknown, to real hardware. Surface it as a version mismatch — the
 reference client blocks with a distinct `UnsupportedCoordinateSpace` reason and tells the user to
 update — rather than as a transient condition that will resolve itself. Keeping the two distinct is
-also what lets the retained-frame rule below notice a transition *into* an unknown space.
+also what lets the retained-frame rule below notice a transition _into_ an unknown space.
 
 ### Pairing and the active device
 
@@ -280,8 +283,8 @@ rules:
 
 - A single width-based ratio scales both axes (the frame is aspect-fitted).
 - The mapping **never clamps**; it returns the raw coordinate plus an `inBounds` flag.
-- A control client **must not tap an out-of-bounds point** — drop it. (An out-of-bounds *drag
-  end* is the one exception; see below.)
+- A control client **must not tap an out-of-bounds point** — drop it. (An out-of-bounds _drag
+  end_ is the one exception; see below.)
 
 Map the point through **exactly the snapshot the user clicked**, and keep that snapshot bound to
 the input all the way to the request. A snapshot swap between click and send must not change the
@@ -298,9 +301,9 @@ executes whatever it is handed, so convergence on one policy is what keeps clien
   **≥ `24 * nativeScale` device coordinates** on a `coordinateSpace: "px"` frame, **≥ 24** on a
   legacy one (the threshold preserves the same physical distance in each frame's unit; see
   [Drag-to-swipe policy](screen-control-mapping.md#threshold)), measured after the end is
-  clamped. Below that, send **nothing** — not a swipe and *not* a tap. Map both
-  endpoints through the **one** snapshot pinned when the drag began. A drag that *started*
-  off-screen is dropped; a drag that *ended* off-screen is clamped to the last addressable pixel.
+  clamped. Below that, send **nothing** — not a swipe and _not_ a tap. Map both
+  endpoints through the **one** snapshot pinned when the drag began. A drag that _started_
+  off-screen is dropped; a drag that _ended_ off-screen is clamped to the last addressable pixel.
   Use a fixed **300 ms** duration, not the pointer velocity. Full rules:
   [Drag-to-swipe policy](screen-control-mapping.md#drag-to-swipe-policy).
 - **Keyboard** — forward only while the mirror view **holds keyboard focus** and is in control
@@ -366,15 +369,15 @@ consistent.
 
 ## Android vs iOS support matrix
 
-| Input | Android | iOS |
-| --- | --- | --- |
-| Tap (`input/tap`) | ✅ Supported | ✅ Supported |
-| Swipe / drag (`input/swipe`) | ✅ Supported | ✅ Supported |
-| Device buttons (`input/pressButton`) | ✅ Supported | ⚠️ Supported with platform gaps (unsupported buttons fail rather than being ignored) |
-| Discrete keys (`input/key`: Enter, Tab, arrows, …) | ✅ Supported | ❌ Unsupported — CtrlProxy exposes no discrete key events; the daemon returns an actionable error |
-| Printable text (`input/typeText`) | ✅ Supported via non-destructive `mode: "append"` | ✅ Supported via non-destructive `mode: "append"` |
+| Input                                              | Android                                           | iOS                                                                                               |
+| -------------------------------------------------- | ------------------------------------------------- | ------------------------------------------------------------------------------------------------- |
+| Tap (`input/tap`)                                  | ✅ Supported                                      | ✅ Supported                                                                                      |
+| Swipe / drag (`input/swipe`)                       | ✅ Supported                                      | ✅ Supported                                                                                      |
+| Device buttons (`input/pressButton`)               | ✅ Supported                                      | ⚠️ Supported with platform gaps (unsupported buttons fail rather than being ignored)              |
+| Discrete keys (`input/key`: Enter, Tab, arrows, …) | ✅ Supported                                      | ❌ Unsupported — CtrlProxy exposes no discrete key events; the daemon returns an actionable error |
+| Printable text (`input/typeText`)                  | ✅ Supported via non-destructive `mode: "append"` | ✅ Supported via non-destructive `mode: "append"`                                                 |
 
-**Why iOS text is forwarded.** `input/typeText`'s default path *replaces* the focused field's
+**Why iOS text is forwarded.** `input/typeText`'s default path _replaces_ the focused field's
 contents, so a client that forwards each character must use `mode: "append"`. Android realizes
 append through real key events. iOS routes append through CtrlProxy's focused-field insertion
 primitive, which calls XCUITest `typeText` at the current caret without clearing or resolving a
@@ -399,7 +402,7 @@ desktop app (or your client) connected to the daemon and a device/simulator stre
 2. **Tap** a button; confirm the device actuates it and the touch pulse appears where you clicked.
 3. **Swipe** to scroll a list; confirm the list scrolls and a sub-24px nudge does nothing.
 4. **Button** — press `Esc`; confirm the device navigates back.
-5. **Text/keys** — focus a text field, type ASCII text (confirm it *appends*, not replaces),
+5. **Text/keys** — focus a text field, type ASCII text (confirm it _appends_, not replaces),
    press Enter/Tab/arrows/Backspace; confirm each maps to the device.
 6. Trigger a failure (e.g. overload the queue) and confirm the error banner shows and clears.
 
@@ -408,7 +411,7 @@ desktop app (or your client) connected to the daemon and a device/simulator stre
 1. Enter control mode as above.
 2. **Tap** and **swipe** — confirm both actuate.
 3. **Button** — `Esc` → back; confirm.
-4. **Text/keys** — focus a text field and type ASCII text; confirm each character *appends* at the
+4. **Text/keys** — focus a text field and type ASCII text; confirm each character _appends_ at the
    current caret without clearing the field. Confirm `input/key` presses surface an actionable
    error rather than being silently dropped.
 
@@ -421,10 +424,10 @@ desktop app (or your client) connected to the daemon and a device/simulator stre
 The Client Screen Control milestone is complete. The following are intentionally deferred and
 tracked back to [#1099](https://github.com/kaeawc/auto-mobile/issues/1099):
 
-| Issue | Deferred item |
-| --- | --- |
-| [#4502](https://github.com/kaeawc/auto-mobile/issues/4502) | Close the same-device rotation window in the client control-tap gate. |
-| [#4533](https://github.com/kaeawc/auto-mobile/issues/4533) | Bound `ensureAdbPath` discovery so a cold cache cannot wedge the per-device input queue. |
-| [#4534](https://github.com/kaeawc/auto-mobile/issues/4534) | Evict the append cache on rapid same-serial device reuse (needs a device-connect signal). |
+| Issue                                                      | Deferred item                                                                                 |
+| ---------------------------------------------------------- | --------------------------------------------------------------------------------------------- |
+| [#4502](https://github.com/kaeawc/auto-mobile/issues/4502) | Close the same-device rotation window in the client control-tap gate.                         |
+| [#4533](https://github.com/kaeawc/auto-mobile/issues/4533) | Bound `ensureAdbPath` discovery so a cold cache cannot wedge the per-device input queue.      |
+| [#4534](https://github.com/kaeawc/auto-mobile/issues/4534) | Evict the append cache on rapid same-serial device reuse (needs a device-connect signal).     |
 | [#4535](https://github.com/kaeawc/auto-mobile/issues/4535) | Optional daemon capability signal for newer input params (e.g. `input/typeText mode:append`). |
-| [#4536](https://github.com/kaeawc/auto-mobile/issues/4536) | Prefer a reliable native AltGraph signal over the `ctrl && alt` heuristic. |
+| [#4536](https://github.com/kaeawc/auto-mobile/issues/4536) | Prefer a reliable native AltGraph signal over the `ctrl && alt` heuristic.                    |

--- a/scripts/typecheck-baseline.txt
+++ b/scripts/typecheck-baseline.txt
@@ -117,7 +117,6 @@ src/features/observe/ios/CtrlProxyGestures.ts: error TS2345: Argument of type '{
 src/features/observe/ios/CtrlProxyGestures.ts: error TS2459: Module '"./types"' declares 'GestureTimingResult' locally, but it is not exported.
 src/features/observe/ios/CtrlProxyHighlights.ts: error TS2322: Type '{ type: "box"; style?: HighlightStyle | null | undefined; bounds: { x: number; y: number; width: number; height: number; sourceWidth: null | number | undefined; sourceHeight: number | ... 1 more ... | undefined; } | null | undefined; } | { ...; }' is not assignable to type 'HighlightShape'.
 src/features/performance/PerformanceAudit.ts: error TS2551: Property 'refreshRateHz' does not exist on type 'DeviceCapabilities'. Did you mean 'refreshRate'?
-src/features/performance/PerformanceMonitor.ts: error TS2740: Type 'PerformanceDataPusher' is missing the following properties from type 'PerformancePushSocketServer': close, readSocketFileIdentity, isOwnedSocketFile, isListening, and 35 more.
 src/features/preferences/AppPreferences.ts: error TS2345: Argument of type 'PreferenceResultValue | null' is not assignable to parameter of type 'PreferenceValue | null'.
 src/features/preferences/AppPreferences.ts: error TS2345: Argument of type 'PreferenceResultValue | null' is not assignable to parameter of type 'PreferenceValue | null'.
 src/features/record/android/DualTrackRecorder.ts: error TS2322: Type 'A11ySource | AndroidCtrlProxyClient' is not assignable to type 'A11ySource'.
@@ -273,7 +272,6 @@ src/utils/ios-cmdline-tools/XcodeSigning.ts: error TS2322: Type 'Promise<string 
 # swap-fp: 5,7,7 :: src/server/networkGraph.ts: error TS18048: 'group' is possibly 'undefined'.
 # swap-fp: 51 :: src/server/navigationTools.ts: error TS2339: Property 'interactionsPerformed' does not exist on type 'ExploreExecutionResult'.
 # swap-fp: 52 :: src/features/observe/collectors/DeviceStateCollector.ts: error TS2554: Expected 0 arguments, but got 1.
-# swap-fp: 52 :: src/features/performance/PerformanceMonitor.ts: error TS2740: Type 'PerformanceDataPusher' is missing the following properties from type 'PerformancePushSocketServer': close, readSocketFileIdentity, isOwnedSocketFile, isListening, and 35 more.
 # swap-fp: 54 :: src/features/action/OpenURL.ts: error TS2740: Type 'AdbExecutor' is missing the following properties from type 'AdbClient': device, execAsync, spawnFn, adbPath, and 30 more.
 # swap-fp: 55 :: src/features/navigation/UIStateExtractor.ts: error TS2741: Property '$' is missing in type 'Record<string, any>' but required in type 'ViewHierarchyNode'.
 # swap-fp: 56 :: src/features/action/refreshAndroidViewHierarchy.ts: error TS2339: Property 'getUiAutomatorHierarchy' does not exist on type 'ViewHierarchy'.

--- a/src/daemon/deviceDataStreamSocketServer.ts
+++ b/src/daemon/deviceDataStreamSocketServer.ts
@@ -76,6 +76,7 @@ export interface PerformanceStreamData {
  */
 interface DeviceDataStreamMessage extends ScreenshotMetadata {
   id?: string;
+  subscriptionId?: string;
   type:
     | "subscription_response"
     | "hierarchy_update"
@@ -158,7 +159,7 @@ interface DeviceDataStreamMessage extends ScreenshotMetadata {
 function pixelsMatchClaimedGeometry(
   measured: { width: number; height: number } | null,
   claimedWidth: number,
-  claimedHeight: number
+  claimedHeight: number,
 ): boolean {
   if (measured === null) {
     return false;
@@ -257,7 +258,9 @@ export type OnObservationRequestedCallback = (request: {
  * Callback invoked when a client requests the current navigation graph.
  * Returns the current graph data, or null if no graph is available.
  */
-export type OnNavigationGraphRequestedCallback = (appId?: string | null) => Promise<NavigationGraphStreamData | null>;
+export type OnNavigationGraphRequestedCallback = (
+  appId?: string | null,
+) => Promise<NavigationGraphStreamData | null>;
 
 // iOS observe (ViewHierarchy.getiOSViewHierarchy -> getLatestHierarchy) can
 // legitimately wait up to 15s for a fresh hierarchy. Keep this wrapper timeout
@@ -279,11 +282,11 @@ const MAX_HIERARCHY_INTERVAL_MS = 2_147_483_647;
  *
  * Protocol:
  * - Client sends: {"id": "1", "command": "subscribe", "deviceId": "emulator-5554"}
- * - Server responds: {"id": "1", "type": "subscription_response", "success": true}
- * - Server pushes: {"type": "hierarchy_update", "deviceId": "emulator-5554", "timestamp": 123, "data": {...}}
- * - Server pushes: {"type": "screenshot_update", "deviceId": "emulator-5554", "timestamp": 123, "screenshotBase64": "..."}
- * - Server pushes: {"type": "storage_update", "deviceId": "emulator-5554", "timestamp": 123, "storageEvent": {...}}
- * - Server pushes: {"type": "error", "deviceId": "emulator-5554", "timestamp": 123, "error": "device connection lost"}
+ * - Server responds: {"id": "1", "type": "subscription_response", "success": true, "subscriptionId": "devicedatastream-1"}
+ * - Server pushes: {"type": "hierarchy_update", "subscriptionId": "devicedatastream-1", "deviceId": "emulator-5554", "timestamp": 123, "data": {...}}
+ * - Server pushes: {"type": "screenshot_update", "subscriptionId": "devicedatastream-1", "deviceId": "emulator-5554", "timestamp": 123, "screenshotBase64": "..."}
+ * - Server pushes: {"type": "storage_update", "subscriptionId": "devicedatastream-1", "deviceId": "emulator-5554", "timestamp": 123, "storageEvent": {...}}
+ * - Server pushes: {"type": "error", "subscriptionId": "devicedatastream-1", "deviceId": "emulator-5554", "timestamp": 123, "error": "device connection lost"}
  */
 export class DeviceDataStreamSocketServer extends PushSubscriptionSocketServer<
   DeviceDataFilter,
@@ -316,7 +319,10 @@ export class DeviceDataStreamSocketServer extends PushSubscriptionSocketServer<
   // request and hand it back on push, which is the only way to survive same-resolution navigation.
   private nextCaptureSequence = 1;
 
-  constructor(socketPath: string = getSocketPath(DEVICE_DATA_STREAM_SOCKET_CONFIG), timer: Timer = defaultTimer) {
+  constructor(
+    socketPath: string = getSocketPath(DEVICE_DATA_STREAM_SOCKET_CONFIG),
+    timer: Timer = defaultTimer,
+  ) {
     super(socketPath, timer, "DeviceDataStream");
   }
 
@@ -347,7 +353,7 @@ export class DeviceDataStreamSocketServer extends PushSubscriptionSocketServer<
    */
   setOnObservationRequested(
     callback: OnObservationRequestedCallback,
-    timeoutMs: number = DEFAULT_OBSERVATION_REQUEST_TIMEOUT_MS
+    timeoutMs: number = DEFAULT_OBSERVATION_REQUEST_TIMEOUT_MS,
   ): void {
     this.onObservationRequested = callback;
     this.observationRequestTimeoutMs = timeoutMs;
@@ -363,10 +369,14 @@ export class DeviceDataStreamSocketServer extends PushSubscriptionSocketServer<
   /**
    * Push a hierarchy update to all subscribers interested in this device.
    */
-  pushHierarchyUpdate(deviceId: string, hierarchy: ViewHierarchyResult, frameContext?: string): number | null {
+  pushHierarchyUpdate(
+    deviceId: string,
+    hierarchy: ViewHierarchyResult,
+    frameContext?: string,
+  ): number | null {
     this.frameContextGenerations.set(
       deviceId,
-      (this.frameContextGenerations.get(deviceId) ?? 0) + 1
+      (this.frameContextGenerations.get(deviceId) ?? 0) + 1,
     );
     if (frameContext !== undefined) {
       this.currentFrameContexts.set(deviceId, frameContext);
@@ -426,7 +436,9 @@ export class DeviceDataStreamSocketServer extends PushSubscriptionSocketServer<
 
     const sentCount = this.pushToSubscribers({ message, targetDeviceId: deviceId });
     if (sentCount > 0) {
-      logger.debug(`[DeviceDataStream] Pushed hierarchy_update to ${sentCount} subscribers (device: ${deviceId})`);
+      logger.debug(
+        `[DeviceDataStream] Pushed hierarchy_update to ${sentCount} subscribers (device: ${deviceId})`,
+      );
     }
     return captureSequence;
   }
@@ -440,7 +452,7 @@ export class DeviceDataStreamSocketServer extends PushSubscriptionSocketServer<
     screenWidth: number,
     screenHeight: number,
     metadata: ScreenshotMetadata = {},
-    options: PushScreenshotOptions = {}
+    options: PushScreenshotOptions = {},
   ): void {
     const {
       screenshotMimeType,
@@ -496,7 +508,9 @@ export class DeviceDataStreamSocketServer extends PushSubscriptionSocketServer<
     };
     const sentCount = this.pushToSubscribers({ message, targetDeviceId: deviceId });
     if (sentCount > 0) {
-      logger.debug(`[DeviceDataStream] Pushed screenshot_update to ${sentCount} subscribers (device: ${deviceId})`);
+      logger.debug(
+        `[DeviceDataStream] Pushed screenshot_update to ${sentCount} subscribers (device: ${deviceId})`,
+      );
     }
   }
 
@@ -530,7 +544,9 @@ export class DeviceDataStreamSocketServer extends PushSubscriptionSocketServer<
 
     const sentCount = this.pushToSubscribers({ message, targetDeviceId: deviceId });
     if (sentCount > 0) {
-      logger.debug(`[DeviceDataStream] Pushed performance_update to ${sentCount} subscribers (device: ${deviceId})`);
+      logger.debug(
+        `[DeviceDataStream] Pushed performance_update to ${sentCount} subscribers (device: ${deviceId})`,
+      );
     }
   }
 
@@ -547,7 +563,9 @@ export class DeviceDataStreamSocketServer extends PushSubscriptionSocketServer<
 
     const sentCount = this.pushToSubscribers({ message, targetDeviceId: deviceId });
     if (sentCount > 0) {
-      logger.debug(`[DeviceDataStream] Pushed storage_update to ${sentCount} subscribers (device: ${deviceId})`);
+      logger.debug(
+        `[DeviceDataStream] Pushed storage_update to ${sentCount} subscribers (device: ${deviceId})`,
+      );
     }
   }
 
@@ -585,8 +603,8 @@ export class DeviceDataStreamSocketServer extends PushSubscriptionSocketServer<
       deviceId,
       "screenshot_update",
       DEFAULT_SCREENSHOT_INTERVAL_MS,
-      filter => filter.screenshotIntervalMs,
-      true
+      (filter) => filter.screenshotIntervalMs,
+      true,
     );
   }
 
@@ -594,13 +612,16 @@ export class DeviceDataStreamSocketServer extends PushSubscriptionSocketServer<
    * Return the fastest active hierarchy cadence requested for this device,
    * or the default iOS hierarchy polling cadence when none is requested.
    */
-  getHierarchyIntervalMsForDevice(deviceId: string, defaultIntervalMs: number = DEFAULT_HIERARCHY_INTERVAL_MS): number {
+  getHierarchyIntervalMsForDevice(
+    deviceId: string,
+    defaultIntervalMs: number = DEFAULT_HIERARCHY_INTERVAL_MS,
+  ): number {
     return this.getFastestIntervalMsForDevice(
       deviceId,
       "hierarchy_update",
       defaultIntervalMs,
-      filter => filter.hierarchyIntervalMs,
-      false
+      (filter) => filter.hierarchyIntervalMs,
+      false,
     );
   }
 
@@ -609,7 +630,7 @@ export class DeviceDataStreamSocketServer extends PushSubscriptionSocketServer<
     messageType: "screenshot_update" | "hierarchy_update",
     defaultIntervalMs: number,
     getRequestedIntervalMs: (filter: DeviceDataFilter) => number | null,
-    useDefaultWhenRequestMissing: boolean
+    useDefaultWhenRequestMissing: boolean,
   ): number {
     const probe: DeviceDataPush = {
       message: {
@@ -635,9 +656,8 @@ export class DeviceDataStreamSocketServer extends PushSubscriptionSocketServer<
       }
       const intervalMs = requestedIntervalMs ?? defaultIntervalMs;
 
-      fastestIntervalMs = fastestIntervalMs === null
-        ? intervalMs
-        : Math.min(fastestIntervalMs, intervalMs);
+      fastestIntervalMs =
+        fastestIntervalMs === null ? intervalMs : Math.min(fastestIntervalMs, intervalMs);
     }
 
     return fastestIntervalMs ?? defaultIntervalMs;
@@ -664,7 +684,9 @@ export class DeviceDataStreamSocketServer extends PushSubscriptionSocketServer<
 
     const sentCount = this.pushToSubscribers({ message, targetDeviceId: deviceId });
     if (sentCount > 0) {
-      logger.debug(`[DeviceDataStream] Pushed device connection lost error to ${sentCount} subscribers (device: ${deviceId})`);
+      logger.debug(
+        `[DeviceDataStream] Pushed device connection lost error to ${sentCount} subscribers (device: ${deviceId})`,
+      );
     }
   }
 
@@ -679,6 +701,7 @@ export class DeviceDataStreamSocketServer extends PushSubscriptionSocketServer<
       appId?: string;
       screenshotIntervalMs?: unknown;
       hierarchyIntervalMs?: unknown;
+      subscriptionId?: string;
     }>(line);
 
     if (!request) {
@@ -760,7 +783,9 @@ export class DeviceDataStreamSocketServer extends PushSubscriptionSocketServer<
     }
 
     if (request.command === "unsubscribe") {
-      const filter = this.findFilterForSocket(socket);
+      const filter = request.subscriptionId
+        ? this.findSubscriber(socket, request.subscriptionId)?.filter
+        : undefined;
       await super.processLine(socket, line);
       if (filter) {
         this.notifyScreenshotCadenceChanged(filter.deviceId);
@@ -774,7 +799,9 @@ export class DeviceDataStreamSocketServer extends PushSubscriptionSocketServer<
     // subscriber raise the cadence while it is actively viewing the device and relax it when
     // backgrounded. Unknown to older daemons, which reply with a benign "unknown command" error.
     if (request.command === "update_cadence") {
-      const filter = this.findFilterForSocket(socket);
+      const filter = request.subscriptionId
+        ? this.findSubscriber(socket, request.subscriptionId)?.filter
+        : undefined;
       if (filter) {
         filter.screenshotIntervalMs = this.parseScreenshotIntervalMs(request.screenshotIntervalMs);
         filter.hierarchyIntervalMs = this.parseHierarchyIntervalMs(request.hierarchyIntervalMs);
@@ -797,20 +824,20 @@ export class DeviceDataStreamSocketServer extends PushSubscriptionSocketServer<
   }
 
   protected onConnectionClose(socket: Socket): void {
-    const filter = this.findFilterForSocket(socket);
+    const filters = this.getSubscribersForSocket(socket).map((subscriber) => subscriber.filter);
     super.onConnectionClose(socket);
-    if (filter) {
-      this.notifyScreenshotCadenceChanged(filter.deviceId);
-      this.notifyHierarchyCadenceChanged(filter.deviceId);
+    for (const deviceId of new Set(filters.map((filter) => filter.deviceId))) {
+      this.notifyScreenshotCadenceChanged(deviceId);
+      this.notifyHierarchyCadenceChanged(deviceId);
     }
   }
 
   protected onConnectionError(socket: Socket, error: Error): void {
-    const filter = this.findFilterForSocket(socket);
+    const filters = this.getSubscribersForSocket(socket).map((subscriber) => subscriber.filter);
     super.onConnectionError(socket, error);
-    if (filter) {
-      this.notifyScreenshotCadenceChanged(filter.deviceId);
-      this.notifyHierarchyCadenceChanged(filter.deviceId);
+    for (const deviceId of new Set(filters.map((filter) => filter.deviceId))) {
+      this.notifyScreenshotCadenceChanged(deviceId);
+      this.notifyHierarchyCadenceChanged(deviceId);
     }
   }
 
@@ -840,19 +867,30 @@ export class DeviceDataStreamSocketServer extends PushSubscriptionSocketServer<
     return filter.deviceId === null || filter.deviceId === data.targetDeviceId;
   }
 
-  protected createPushMessage(data: DeviceDataPush): DeviceDataStreamMessage {
-    return data.message;
+  protected createPushMessage(
+    data: DeviceDataPush,
+    subscriptionId: string,
+  ): DeviceDataStreamMessage {
+    return { ...data.message, subscriptionId };
   }
 
   private parseScreenshotIntervalMs(value: unknown): number | null {
-    return this.parseClampedIntervalMs(value, MIN_SCREENSHOT_INTERVAL_MS, MAX_SCREENSHOT_INTERVAL_MS);
+    return this.parseClampedIntervalMs(
+      value,
+      MIN_SCREENSHOT_INTERVAL_MS,
+      MAX_SCREENSHOT_INTERVAL_MS,
+    );
   }
 
   private parseHierarchyIntervalMs(value: unknown): number | null {
     return this.parseClampedIntervalMs(value, MIN_HIERARCHY_INTERVAL_MS, MAX_HIERARCHY_INTERVAL_MS);
   }
 
-  private parseClampedIntervalMs(value: unknown, minIntervalMs: number, maxIntervalMs: number): number | null {
+  private parseClampedIntervalMs(
+    value: unknown,
+    minIntervalMs: number,
+    maxIntervalMs: number,
+  ): number | null {
     if (value === null || value === undefined) {
       return null;
     }
@@ -861,33 +899,29 @@ export class DeviceDataStreamSocketServer extends PushSubscriptionSocketServer<
       return null;
     }
 
-    return Math.min(
-      Math.max(Math.round(value), minIntervalMs),
-      maxIntervalMs
-    );
-  }
-
-  private findFilterForSocket(socket: Socket): DeviceDataFilter | null {
-    for (const subscriber of this.subscribers.values()) {
-      if (subscriber.socket === socket) {
-        return subscriber.filter;
-      }
-    }
-    return null;
+    return Math.min(Math.max(Math.round(value), minIntervalMs), maxIntervalMs);
   }
 
   private notifyScreenshotCadenceChanged(deviceId: string | null): void {
-    this.notifyCadenceChanged(this.onScreenshotCadenceChanged, "onScreenshotCadenceChanged", deviceId);
+    this.notifyCadenceChanged(
+      this.onScreenshotCadenceChanged,
+      "onScreenshotCadenceChanged",
+      deviceId,
+    );
   }
 
   private notifyHierarchyCadenceChanged(deviceId: string | null): void {
-    this.notifyCadenceChanged(this.onHierarchyCadenceChanged, "onHierarchyCadenceChanged", deviceId);
+    this.notifyCadenceChanged(
+      this.onHierarchyCadenceChanged,
+      "onHierarchyCadenceChanged",
+      deviceId,
+    );
   }
 
   private notifyCadenceChanged(
     callback: ((deviceId: string | null) => void) | null,
     callbackName: string,
-    deviceId: string | null
+    deviceId: string | null,
   ): void {
     if (!callback) {
       return;
@@ -902,7 +936,7 @@ export class DeviceDataStreamSocketServer extends PushSubscriptionSocketServer<
 
   private async handleObservationRequest(
     socket: Socket,
-    request: { id?: string; deviceId?: string }
+    request: { id?: string; deviceId?: string },
   ): Promise<void> {
     if (!this.onObservationRequested) {
       const response: SubscriptionResponse = {
@@ -937,11 +971,11 @@ export class DeviceDataStreamSocketServer extends PushSubscriptionSocketServer<
           continue;
         }
         if (
-          (this.frameContextGenerations.get(deviceId) ?? 0)
-          !== (frameContextGenerationsAtStart.get(deviceId) ?? 0)
+          (this.frameContextGenerations.get(deviceId) ?? 0) !==
+          (frameContextGenerationsAtStart.get(deviceId) ?? 0)
         ) {
           logger.debug(
-            `[DeviceDataStream] Skipped stale explicit observation for ${deviceId}; a newer hierarchy arrived`
+            `[DeviceDataStream] Skipped stale explicit observation for ${deviceId}; a newer hierarchy arrived`,
           );
           continue;
         }
@@ -980,9 +1014,10 @@ export class DeviceDataStreamSocketServer extends PushSubscriptionSocketServer<
   }
 
   private describeMissingHierarchy(deviceId: string, observation: ObserveResult): string {
-    const observationError = observation.error
-      ?? observation.errors?.map(error => error.message).join("; ")
-      ?? "Observation did not include view hierarchy";
+    const observationError =
+      observation.error ??
+      observation.errors?.map((error) => error.message).join("; ") ??
+      "Observation did not include view hierarchy";
     return `Observation request failed for ${deviceId}: ${observationError}`;
   }
 
@@ -996,7 +1031,9 @@ export class DeviceDataStreamSocketServer extends PushSubscriptionSocketServer<
     const timeoutPromise = new Promise<never>((_, reject) => {
       timeoutHandle = this.timer.setTimeout(() => {
         controller.abort();
-        reject(new Error(`Observation request timed out after ${this.observationRequestTimeoutMs}ms`));
+        reject(
+          new Error(`Observation request timed out after ${this.observationRequestTimeoutMs}ms`),
+        );
       }, this.observationRequestTimeoutMs);
     });
 
@@ -1029,10 +1066,13 @@ export function getDeviceDataStreamSocketPath(): string {
 }
 
 export async function startDeviceDataStreamSocketServer(
-  timer: Timer = defaultTimer
+  timer: Timer = defaultTimer,
 ): Promise<DeviceDataStreamSocketServer> {
   if (!socketServer) {
-    socketServer = new DeviceDataStreamSocketServer(getSocketPath(DEVICE_DATA_STREAM_SOCKET_CONFIG), timer);
+    socketServer = new DeviceDataStreamSocketServer(
+      getSocketPath(DEVICE_DATA_STREAM_SOCKET_CONFIG),
+      timer,
+    );
   }
   if (!socketServer.isListening()) {
     await socketServer.start();

--- a/src/daemon/failuresPushSocketServer.ts
+++ b/src/daemon/failuresPushSocketServer.ts
@@ -32,6 +32,7 @@ interface FailurePushMessage {
   type: "failure_push";
   timestamp: number;
   data: FailureNotificationPush;
+  subscriptionId: string;
 }
 
 /**
@@ -39,8 +40,8 @@ interface FailurePushMessage {
  *
  * Protocol:
  * - Client sends: {"id": "1", "command": "subscribe", "type": "crash", "severity": "high"}
- * - Server responds: {"id": "1", "type": "subscription_response", "success": true}
- * - Server pushes: {"type": "failure_push", "timestamp": 123, "data": {...}}
+ * - Server responds: {"id": "1", "type": "subscription_response", "success": true, "subscriptionId": "failurespush-1"}
+ * - Server pushes: {"type": "failure_push", "subscriptionId": "failurespush-1", "timestamp": 123, "data": {...}}
  * - Server sends ping every 10s: {"type": "ping", "timestamp": 123}
  * - Client responds: {"id": "x", "command": "pong"}
  */
@@ -48,7 +49,10 @@ export class FailuresPushSocketServer extends PushSubscriptionSocketServer<
   FailureFilter,
   FailureNotificationPush
 > {
-  constructor(socketPath: string = getSocketPath(FAILURES_PUSH_SOCKET_CONFIG), timer: Timer = defaultTimer) {
+  constructor(
+    socketPath: string = getSocketPath(FAILURES_PUSH_SOCKET_CONFIG),
+    timer: Timer = defaultTimer,
+  ) {
     super(socketPath, timer, "FailuresPush");
   }
 
@@ -56,7 +60,9 @@ export class FailuresPushSocketServer extends PushSubscriptionSocketServer<
    * Push a failure notification to all interested subscribers.
    */
   pushFailure(data: FailureNotificationPush): void {
-    logger.info(`[FailuresPush] Pushing failure: ${data.type} - ${data.title} (subscribers: ${this.getSubscriberCount()})`);
+    logger.info(
+      `[FailuresPush] Pushing failure: ${data.type} - ${data.title} (subscribers: ${this.getSubscriberCount()})`,
+    );
     const sentCount = this.pushToSubscribers(data);
     logger.info(`[FailuresPush] Pushed failure to ${sentCount} subscribers: ${data.title}`);
   }
@@ -74,11 +80,15 @@ export class FailuresPushSocketServer extends PushSubscriptionSocketServer<
     return matchesType && matchesSeverity;
   }
 
-  protected createPushMessage(data: FailureNotificationPush): FailurePushMessage {
+  protected createPushMessage(
+    data: FailureNotificationPush,
+    subscriptionId: string,
+  ): FailurePushMessage {
     return {
       type: "failure_push",
       timestamp: this.timer.now(),
       data,
+      subscriptionId,
     };
   }
 }

--- a/src/daemon/performancePushSocketServer.ts
+++ b/src/daemon/performancePushSocketServer.ts
@@ -82,6 +82,7 @@ interface PerformancePushMessage {
   type: "performance_push";
   timestamp: number;
   data: LivePerformanceData;
+  subscriptionId: string;
 }
 
 /**
@@ -89,8 +90,8 @@ interface PerformancePushMessage {
  *
  * Protocol:
  * - Client sends: {"id": "1", "command": "subscribe", "deviceId": "emulator-5554", "packageName": "com.example.app"}
- * - Server responds: {"id": "1", "type": "subscription_response", "success": true}
- * - Server pushes: {"type": "performance_push", "data": {...}}
+ * - Server responds: {"id": "1", "type": "subscription_response", "success": true, "subscriptionId": "performancepush-1"}
+ * - Server pushes: {"type": "performance_push", "subscriptionId": "performancepush-1", "data": {...}}
  * - Server sends ping every 10s: {"type": "ping", "timestamp": 123}
  * - Client responds: {"id": "x", "command": "pong"}
  */
@@ -98,7 +99,10 @@ export class PerformancePushSocketServer extends PushSubscriptionSocketServer<
   PerformanceFilter,
   LivePerformanceData
 > {
-  constructor(socketPath: string = getSocketPath(PERFORMANCE_PUSH_SOCKET_CONFIG), timer: Timer = defaultTimer) {
+  constructor(
+    socketPath: string = getSocketPath(PERFORMANCE_PUSH_SOCKET_CONFIG),
+    timer: Timer = defaultTimer,
+  ) {
     super(socketPath, timer, "PerformancePush");
   }
 
@@ -117,42 +121,66 @@ export class PerformancePushSocketServer extends PushSubscriptionSocketServer<
    */
   static calculateHealth(
     metrics: LivePerformanceData["metrics"],
-    thresholds: PerformanceThresholds
+    thresholds: PerformanceThresholds,
   ): HealthStatus {
     // Check FPS (lower is worse)
     if (metrics.fps !== null) {
-      if (metrics.fps < thresholds.fpsCritical) {return "critical";}
-      if (metrics.fps < thresholds.fpsWarning) {return "warning";}
+      if (metrics.fps < thresholds.fpsCritical) {
+        return "critical";
+      }
+      if (metrics.fps < thresholds.fpsWarning) {
+        return "warning";
+      }
     }
 
     // Check frame time (higher is worse)
     if (metrics.frameTimeMs !== null) {
-      if (metrics.frameTimeMs > thresholds.frameTimeCritical) {return "critical";}
-      if (metrics.frameTimeMs > thresholds.frameTimeWarning) {return "warning";}
+      if (metrics.frameTimeMs > thresholds.frameTimeCritical) {
+        return "critical";
+      }
+      if (metrics.frameTimeMs > thresholds.frameTimeWarning) {
+        return "warning";
+      }
     }
 
     // Check jank frames (higher is worse)
     if (metrics.jankFrames !== null) {
-      if (metrics.jankFrames > thresholds.jankCritical) {return "critical";}
-      if (metrics.jankFrames > thresholds.jankWarning) {return "warning";}
+      if (metrics.jankFrames > thresholds.jankCritical) {
+        return "critical";
+      }
+      if (metrics.jankFrames > thresholds.jankWarning) {
+        return "warning";
+      }
     }
 
     // Check touch latency (higher is worse)
     if (metrics.touchLatencyMs !== null) {
-      if (metrics.touchLatencyMs > thresholds.touchLatencyCritical) {return "critical";}
-      if (metrics.touchLatencyMs > thresholds.touchLatencyWarning) {return "warning";}
+      if (metrics.touchLatencyMs > thresholds.touchLatencyCritical) {
+        return "critical";
+      }
+      if (metrics.touchLatencyMs > thresholds.touchLatencyWarning) {
+        return "warning";
+      }
     }
 
     // Check TTFF (higher is worse)
     if (metrics.ttffMs !== null) {
-      if (metrics.ttffMs > thresholds.ttffCritical) {return "critical";}
-      if (metrics.ttffMs > thresholds.ttffWarning) {return "warning";}
+      if (metrics.ttffMs > thresholds.ttffCritical) {
+        return "critical";
+      }
+      if (metrics.ttffMs > thresholds.ttffWarning) {
+        return "warning";
+      }
     }
 
     // Check TTI (higher is worse)
     if (metrics.ttiMs !== null) {
-      if (metrics.ttiMs > thresholds.ttiCritical) {return "critical";}
-      if (metrics.ttiMs > thresholds.ttiWarning) {return "warning";}
+      if (metrics.ttiMs > thresholds.ttiCritical) {
+        return "critical";
+      }
+      if (metrics.ttiMs > thresholds.ttiWarning) {
+        return "warning";
+      }
     }
 
     return "healthy";
@@ -171,11 +199,15 @@ export class PerformancePushSocketServer extends PushSubscriptionSocketServer<
     return matchesDevice && matchesPackage;
   }
 
-  protected createPushMessage(data: LivePerformanceData): PerformancePushMessage {
+  protected createPushMessage(
+    data: LivePerformanceData,
+    subscriptionId: string,
+  ): PerformancePushMessage {
     return {
       type: "performance_push",
       timestamp: this.timer.now(),
       data,
+      subscriptionId,
     };
   }
 }

--- a/src/daemon/socketServer/PushSubscriptionSocketServer.ts
+++ b/src/daemon/socketServer/PushSubscriptionSocketServer.ts
@@ -18,6 +18,12 @@ export interface SubscriptionResponse {
   success?: boolean;
   error?: string;
   timestamp?: number;
+  subscriptionId?: string;
+}
+
+interface ConnectionState {
+  lastActivity: number;
+  drainPending: boolean;
 }
 
 /**
@@ -30,6 +36,7 @@ export interface SubscriptionResponse {
  */
 export abstract class PushSubscriptionSocketServer<TFilter, TPushData> extends BaseSocketServer {
   protected subscribers: Map<string, Subscriber<TFilter>> = new Map();
+  private connections: Map<Socket, ConnectionState> = new Map();
   private subscriptionCounter = 0;
   private keepaliveInterval: ReturnType<typeof setInterval> | null = null;
   protected readonly keepaliveConfig: KeepaliveConfig;
@@ -38,7 +45,7 @@ export abstract class PushSubscriptionSocketServer<TFilter, TPushData> extends B
     socketPath: string,
     timer: Timer = defaultTimer,
     serverName: string = "Push",
-    keepaliveConfig: KeepaliveConfig = DEFAULT_KEEPALIVE_CONFIG
+    keepaliveConfig: KeepaliveConfig = DEFAULT_KEEPALIVE_CONFIG,
   ) {
     super(socketPath, timer, serverName);
     this.keepaliveConfig = keepaliveConfig;
@@ -57,14 +64,15 @@ export abstract class PushSubscriptionSocketServer<TFilter, TPushData> extends B
   protected onServerClosing(): void {
     this.stopKeepalive();
 
-    for (const subscriber of this.subscribers.values()) {
+    for (const socket of this.connections.keys()) {
       try {
-        subscriber.socket.end();
+        socket.end();
       } catch {
         // Ignore errors when closing
       }
     }
     this.subscribers.clear();
+    this.connections.clear();
   }
 
   /**
@@ -91,25 +99,26 @@ export abstract class PushSubscriptionSocketServer<TFilter, TPushData> extends B
   }
 
   /**
-   * Check keepalive for all subscribers, removing dead ones.
+   * Check keepalive for all connections, removing every subscription for dead connections.
    */
   protected checkKeepalive(): void {
     const now = this.timer.now();
-    const deadSubscribers: string[] = [];
+    const deadSockets = new Set<Socket>();
 
-    for (const [subscriptionId, subscriber] of this.subscribers) {
-      if (subscriber.socket.destroyed) {
-        logger.info(`[${this.serverName}] Subscriber ${subscriptionId} socket destroyed, removing`);
-        deadSubscribers.push(subscriptionId);
+    this.ensureConnectionStates();
+    for (const [socket, connection] of this.connections) {
+      if (socket.destroyed) {
+        logger.info(`[${this.serverName}] Connection socket destroyed, removing subscriptions`);
+        deadSockets.add(socket);
         continue;
       }
 
-      const timeSinceActivity = now - subscriber.lastActivity;
+      const timeSinceActivity = now - connection.lastActivity;
       if (timeSinceActivity > this.keepaliveConfig.timeoutMs) {
-        logger.warn(`[${this.serverName}] Subscriber ${subscriptionId} timed out, removing`);
-        deadSubscribers.push(subscriptionId);
+        logger.warn(`[${this.serverName}] Connection timed out, removing subscriptions`);
+        deadSockets.add(socket);
         try {
-          subscriber.socket.destroy();
+          socket.destroy();
         } catch {
           // Ignore errors when destroying
         }
@@ -122,23 +131,23 @@ export abstract class PushSubscriptionSocketServer<TFilter, TPushData> extends B
         timestamp: now,
       };
       try {
-        const ok = this.sendJson(subscriber.socket, pingMessage);
+        const ok = this.sendJson(socket, pingMessage);
         if (!ok) {
-          this.armDrainListener(subscriber);
+          this.armDrainListener(socket);
         }
       } catch (error) {
-        logger.warn(`[${this.serverName}] Failed to ping ${subscriptionId}: ${error}`);
-        deadSubscribers.push(subscriptionId);
+        logger.warn(`[${this.serverName}] Failed to ping connection: ${error}`);
+        deadSockets.add(socket);
         try {
-          subscriber.socket.destroy();
+          socket.destroy();
         } catch {
           // Ignore
         }
       }
     }
 
-    for (const subscriptionId of deadSubscribers) {
-      this.subscribers.delete(subscriptionId);
+    for (const socket of deadSockets) {
+      this.removeSubscribersForSocket(socket);
     }
   }
 
@@ -189,7 +198,7 @@ export abstract class PushSubscriptionSocketServer<TFilter, TPushData> extends B
    */
   private async handleSubscribe(
     socket: Socket,
-    request: SubscriptionCommand & Record<string, unknown>
+    request: SubscriptionCommand & Record<string, unknown>,
   ): Promise<void> {
     const subscriptionId = `${this.serverName.toLowerCase()}-${++this.subscriptionCounter}`;
     const filter = this.parseSubscriptionFilter(request);
@@ -202,11 +211,19 @@ export abstract class PushSubscriptionSocketServer<TFilter, TPushData> extends B
       backfilling: false,
       drainPending: false,
     });
+    this.connections.set(
+      socket,
+      this.connections.get(socket) ?? {
+        lastActivity: this.timer.now(),
+        drainPending: false,
+      },
+    );
 
     const response: SubscriptionResponse = {
       id: request.id,
       type: "subscription_response",
       success: true,
+      subscriptionId,
     };
     this.sendJson(socket, response);
 
@@ -225,16 +242,13 @@ export abstract class PushSubscriptionSocketServer<TFilter, TPushData> extends B
   /**
    * Handle an unsubscribe command.
    */
-  private async handleUnsubscribe(
-    socket: Socket,
-    request: SubscriptionCommand
-  ): Promise<void> {
-    for (const [subId, subscriber] of this.subscribers) {
-      if (subscriber.socket === socket) {
-        this.subscribers.delete(subId);
-        logger.info(`[${this.serverName}] Unsubscribed ${subId}`);
-        break;
-      }
+  private async handleUnsubscribe(socket: Socket, request: SubscriptionCommand): Promise<void> {
+    const subscriber = request.subscriptionId
+      ? this.findSubscriber(socket, request.subscriptionId)
+      : undefined;
+    if (subscriber) {
+      this.removeSubscription(subscriber.subscriptionId);
+      logger.info(`[${this.serverName}] Unsubscribed ${subscriber.subscriptionId}`);
     }
 
     const response: SubscriptionResponse = {
@@ -249,50 +263,46 @@ export abstract class PushSubscriptionSocketServer<TFilter, TPushData> extends B
    * Handle a pong command (keepalive response).
    */
   private handlePong(socket: Socket): void {
+    const now = this.timer.now();
+    const connection = this.connections.get(socket);
+    if (connection) {
+      connection.lastActivity = now;
+    }
     for (const subscriber of this.subscribers.values()) {
       if (subscriber.socket === socket) {
-        subscriber.lastActivity = this.timer.now();
+        subscriber.lastActivity = now;
         logger.debug(`[${this.serverName}] Received pong from ${subscriber.subscriptionId}`);
-        break;
       }
     }
   }
 
   /**
-   * Called when a connection closes. Removes subscriber.
+   * Called when a connection closes. Removes every subscription on that connection.
    */
   protected onConnectionClose(socket: Socket): void {
-    for (const [subId, subscriber] of this.subscribers) {
-      if (subscriber.socket === socket) {
-        this.subscribers.delete(subId);
-        logger.info(`[${this.serverName}] Subscriber ${subId} disconnected`);
-        break;
-      }
+    for (const subscriber of this.removeSubscribersForSocket(socket)) {
+      logger.info(`[${this.serverName}] Subscriber ${subscriber.subscriptionId} disconnected`);
     }
   }
 
   /**
-   * Called when a connection error occurs. Removes subscriber.
+   * Called when a connection error occurs. Removes every subscription on that connection.
    */
   protected onConnectionError(socket: Socket, _error: Error): void {
-    for (const [subId, subscriber] of this.subscribers) {
-      if (subscriber.socket === socket) {
-        this.subscribers.delete(subId);
-        break;
-      }
-    }
+    this.removeSubscribersForSocket(socket);
   }
 
   /**
    * Push data to all matching subscribers.
    */
   protected pushToSubscribers(data: TPushData): number {
-    const message = this.createPushMessage(data);
-    const json = JSON.stringify(message) + "\n";
     let sentCount = 0;
-    const deadSubscribers: string[] = [];
+    const deadSockets = new Set<Socket>();
 
     for (const [subscriptionId, subscriber] of this.subscribers) {
+      if (deadSockets.has(subscriber.socket)) {
+        continue;
+      }
       if (subscriber.backfilling) {
         continue;
       }
@@ -302,15 +312,16 @@ export abstract class PushSubscriptionSocketServer<TFilter, TPushData> extends B
       }
 
       if (subscriber.socket.destroyed) {
-        deadSubscribers.push(subscriptionId);
+        deadSockets.add(subscriber.socket);
         continue;
       }
 
       try {
+        const json = JSON.stringify(this.createPushMessage(data, subscriptionId)) + "\n";
         const result = subscriber.socket.write(json);
         if (!result) {
           // write()=false is not a death signal — wait for drain; truly dead peers get reaped by timeoutMs.
-          this.armDrainListener(subscriber);
+          this.armDrainListener(subscriber.socket);
         }
         // A successful write only proves our local send buffer accepted the bytes — not that the
         // peer is alive. Liveness is tracked via inbound pongs (and drain events, which prove the
@@ -321,7 +332,7 @@ export abstract class PushSubscriptionSocketServer<TFilter, TPushData> extends B
         sentCount++;
       } catch (error) {
         logger.warn(`[${this.serverName}] Failed to send to ${subscriptionId}: ${error}`);
-        deadSubscribers.push(subscriptionId);
+        deadSockets.add(subscriber.socket);
         try {
           subscriber.socket.destroy();
         } catch {
@@ -330,26 +341,93 @@ export abstract class PushSubscriptionSocketServer<TFilter, TPushData> extends B
       }
     }
 
-    for (const subscriptionId of deadSubscribers) {
-      this.subscribers.delete(subscriptionId);
+    for (const socket of deadSockets) {
+      this.removeSubscribersForSocket(socket);
     }
 
     return sentCount;
   }
 
-  private armDrainListener(subscriber: Subscriber<TFilter>): void {
-    if (subscriber.drainPending) {
+  private armDrainListener(socket: Socket): void {
+    this.ensureConnectionStates();
+    const connection = this.connections.get(socket);
+    if (!connection || connection.drainPending) {
       return;
     }
-    const socket = subscriber.socket;
     if (typeof socket.once !== "function") {
       return;
     }
-    subscriber.drainPending = true;
+    connection.drainPending = true;
+    this.setDrainPending(socket, true);
     socket.once("drain", () => {
-      subscriber.drainPending = false;
-      subscriber.lastActivity = this.timer.now();
+      const currentConnection = this.connections.get(socket);
+      if (!currentConnection) {
+        return;
+      }
+      const now = this.timer.now();
+      currentConnection.drainPending = false;
+      currentConnection.lastActivity = now;
+      this.setDrainPending(socket, false);
+      for (const subscriber of this.getSubscribersForSocket(socket)) {
+        subscriber.lastActivity = now;
+      }
     });
+  }
+
+  /** Finds a subscription owned by a connection without exposing other connections' subscriptions. */
+  protected findSubscriber(
+    socket: Socket,
+    subscriptionId: string,
+  ): Subscriber<TFilter> | undefined {
+    const subscriber = this.subscribers.get(subscriptionId);
+    return subscriber?.socket === socket ? subscriber : undefined;
+  }
+
+  /** Returns every active subscription held by a connection. */
+  protected getSubscribersForSocket(socket: Socket): Subscriber<TFilter>[] {
+    return [...this.subscribers.values()].filter((subscriber) => subscriber.socket === socket);
+  }
+
+  /** Removes every subscription held by a connection and returns the removed entries. */
+  protected removeSubscribersForSocket(socket: Socket): Subscriber<TFilter>[] {
+    const removed = this.getSubscribersForSocket(socket);
+    for (const subscriber of removed) {
+      this.subscribers.delete(subscriber.subscriptionId);
+    }
+    this.connections.delete(socket);
+    return removed;
+  }
+
+  private removeSubscription(subscriptionId: string): Subscriber<TFilter> | undefined {
+    const subscriber = this.subscribers.get(subscriptionId);
+    if (!subscriber) {
+      return undefined;
+    }
+    this.subscribers.delete(subscriptionId);
+    if (this.getSubscribersForSocket(subscriber.socket).length === 0) {
+      this.connections.delete(subscriber.socket);
+    }
+    return subscriber;
+  }
+
+  private ensureConnectionStates(): void {
+    for (const subscriber of this.subscribers.values()) {
+      const connection = this.connections.get(subscriber.socket);
+      if (!connection) {
+        this.connections.set(subscriber.socket, {
+          lastActivity: subscriber.lastActivity,
+          drainPending: subscriber.drainPending,
+        });
+      } else if (subscriber.lastActivity > connection.lastActivity) {
+        connection.lastActivity = subscriber.lastActivity;
+      }
+    }
+  }
+
+  private setDrainPending(socket: Socket, drainPending: boolean): void {
+    for (const subscriber of this.getSubscribersForSocket(socket)) {
+      subscriber.drainPending = drainPending;
+    }
   }
 
   /**
@@ -375,5 +453,5 @@ export abstract class PushSubscriptionSocketServer<TFilter, TPushData> extends B
    * Create a push message from data.
    * Subclasses must implement this.
    */
-  protected abstract createPushMessage(data: TPushData): unknown;
+  protected abstract createPushMessage(data: TPushData, subscriptionId: string): unknown;
 }

--- a/src/daemon/socketServer/SocketServerTypes.ts
+++ b/src/daemon/socketServer/SocketServerTypes.ts
@@ -45,7 +45,9 @@ export interface Subscriber<TFilter = unknown> {
  */
 export interface SubscriptionCommand {
   id: string;
-  command: "subscribe" | "unsubscribe" | "pong";
+  command: "subscribe" | "unsubscribe" | "update_cadence" | "pong";
+  /** Server-minted subscription identity for subscription-scoped operations. */
+  subscriptionId?: string;
 }
 
 /**

--- a/src/daemon/telemetryPushSocketServer.ts
+++ b/src/daemon/telemetryPushSocketServer.ts
@@ -166,6 +166,7 @@ export class TelemetryPushSocketServer extends PushSubscriptionSocketServer<
   ): Promise<void> {
     const limit = 100;
     const deviceId = filter.deviceId ?? undefined;
+    const sessionId = filter.sessionId ?? undefined;
     const events: TelemetryEvent[] = [];
 
     const shouldInclude = (category: string) =>
@@ -173,9 +174,9 @@ export class TelemetryPushSocketServer extends PushSubscriptionSocketServer<
 
     // Run independent backfill queries in parallel
     const [networkRows, logRows, osRows] = await Promise.all([
-      shouldInclude("network") ? getNetworkEvents({ deviceId, limit }) : [],
-      shouldInclude("log") ? getLogEvents({ deviceId, limit }) : [],
-      shouldInclude("os") ? getOsEvents({ deviceId, limit }) : [],
+      shouldInclude("network") ? getNetworkEvents({ deviceId, sessionId, limit }) : [],
+      shouldInclude("log") ? getLogEvents({ deviceId, sessionId, limit }) : [],
+      shouldInclude("os") ? getOsEvents({ deviceId, sessionId, limit }) : [],
     ]);
     for (const r of networkRows) {
       events.push({
@@ -206,7 +207,7 @@ export class TelemetryPushSocketServer extends PushSubscriptionSocketServer<
     }
 
     if (shouldInclude("navigation")) {
-      const rows = await getNavigationEvents({ deviceId, limit });
+      const rows = await getNavigationEvents({ deviceId, sessionId, limit });
       // Look up screenshot node IDs for navigation events
       const screenshotUris: Map<string, string> = new Map();
       if (rows.length > 0) {
@@ -277,6 +278,9 @@ export class TelemetryPushSocketServer extends PushSubscriptionSocketServer<
             .where("failure_occurrences.device_id", "is not", null)
             .where("failure_occurrences.device_id", "!=", "");
         }
+        if (sessionId) {
+          q = q.where("failure_occurrences.session_id", "=", sessionId);
+        }
 
         const rows = await q
           .orderBy("failure_occurrences.timestamp", "desc")
@@ -330,8 +334,8 @@ export class TelemetryPushSocketServer extends PushSubscriptionSocketServer<
     await Promise.all(failureTypes.map(failureBackfillFn));
 
     const [storageRows, layoutRows] = await Promise.all([
-      shouldInclude("storage") ? getStorageEvents({ deviceId, limit }) : [],
-      shouldInclude("layout") ? getLayoutEvents({ deviceId, limit }) : [],
+      shouldInclude("storage") ? getStorageEvents({ deviceId, sessionId, limit }) : [],
+      shouldInclude("layout") ? getLayoutEvents({ deviceId, sessionId, limit }) : [],
     ]);
     for (const r of storageRows) {
       events.push({

--- a/src/daemon/telemetryPushSocketServer.ts
+++ b/src/daemon/telemetryPushSocketServer.ts
@@ -94,13 +94,17 @@ interface TelemetryPushMessage {
   type: "telemetry_push";
   timestamp: number;
   data: TelemetryEvent;
+  subscriptionId: string;
 }
 
 export class TelemetryPushSocketServer extends PushSubscriptionSocketServer<
   TelemetryFilter,
   TelemetryEvent
 > {
-  constructor(socketPath: string = getSocketPath(TELEMETRY_PUSH_SOCKET_CONFIG), timer: Timer = defaultTimer) {
+  constructor(
+    socketPath: string = getSocketPath(TELEMETRY_PUSH_SOCKET_CONFIG),
+    timer: Timer = defaultTimer,
+  ) {
     super(socketPath, timer, "TelemetryPush");
   }
 
@@ -109,7 +113,9 @@ export class TelemetryPushSocketServer extends PushSubscriptionSocketServer<
     if (sentCount > 0) {
       logger.info(`[TelemetryPush] Pushed ${event.category} event to ${sentCount} subscribers`);
     } else if (event.category === "navigation") {
-      logger.warn(`[TelemetryPush] No subscribers matched navigation event (${this.getSubscriberCount()} total subs, event deviceId: ${event.deviceId})`);
+      logger.warn(
+        `[TelemetryPush] No subscribers matched navigation event (${this.getSubscriberCount()} total subs, event deviceId: ${event.deviceId})`,
+      );
     }
   }
 
@@ -134,22 +140,30 @@ export class TelemetryPushSocketServer extends PushSubscriptionSocketServer<
     return true;
   }
 
-  protected override onSubscribed(subscriptionId: string, filter: TelemetryFilter, socket: Socket): void {
+  protected override onSubscribed(
+    subscriptionId: string,
+    filter: TelemetryFilter,
+    socket: Socket,
+  ): void {
     const subscriber = this.subscribers.get(subscriptionId);
     if (subscriber) {
       subscriber.backfilling = true;
     }
-    this.backfillRecentEvents(filter, socket).catch(err =>
-      logger.warn(`[TelemetryPush] Backfill failed: ${err}`)
-    ).finally(() => {
-      const sub = this.subscribers.get(subscriptionId);
-      if (sub) {
-        sub.backfilling = false;
-      }
-    });
+    this.backfillRecentEvents(subscriptionId, filter, socket)
+      .catch((err) => logger.warn(`[TelemetryPush] Backfill failed: ${err}`))
+      .finally(() => {
+        const sub = this.subscribers.get(subscriptionId);
+        if (sub) {
+          sub.backfilling = false;
+        }
+      });
   }
 
-  private async backfillRecentEvents(filter: TelemetryFilter, socket: Socket): Promise<void> {
+  private async backfillRecentEvents(
+    subscriptionId: string,
+    filter: TelemetryFilter,
+    socket: Socket,
+  ): Promise<void> {
     const limit = 100;
     const deviceId = filter.deviceId ?? undefined;
     const events: TelemetryEvent[] = [];
@@ -164,13 +178,31 @@ export class TelemetryPushSocketServer extends PushSubscriptionSocketServer<
       shouldInclude("os") ? getOsEvents({ deviceId, limit }) : [],
     ]);
     for (const r of networkRows) {
-      events.push({ category: "network", timestamp: r.timestamp, deviceId: r.deviceId, sessionId: r.sessionId ?? null, data: r });
+      events.push({
+        category: "network",
+        timestamp: r.timestamp,
+        deviceId: r.deviceId,
+        sessionId: r.sessionId ?? null,
+        data: r,
+      });
     }
     for (const r of logRows) {
-      events.push({ category: "log", timestamp: r.timestamp, deviceId: r.deviceId, sessionId: r.sessionId ?? null, data: r });
+      events.push({
+        category: "log",
+        timestamp: r.timestamp,
+        deviceId: r.deviceId,
+        sessionId: r.sessionId ?? null,
+        data: r,
+      });
     }
     for (const r of osRows) {
-      events.push({ category: "os", timestamp: r.timestamp, deviceId: r.deviceId, sessionId: r.sessionId ?? null, data: r });
+      events.push({
+        category: "os",
+        timestamp: r.timestamp,
+        deviceId: r.deviceId,
+        sessionId: r.sessionId ?? null,
+        data: r,
+      });
     }
 
     if (shouldInclude("navigation")) {
@@ -180,7 +212,7 @@ export class TelemetryPushSocketServer extends PushSubscriptionSocketServer<
       if (rows.length > 0) {
         try {
           const db = getDatabase() as unknown as Kysely<Database>;
-          const destinations = [...new Set(rows.map(r => r.destination))];
+          const destinations = [...new Set(rows.map((r) => r.destination))];
           const nodes = await db
             .selectFrom("navigation_nodes")
             .select(["id", "screen_name", "app_id"])
@@ -190,7 +222,9 @@ export class TelemetryPushSocketServer extends PushSubscriptionSocketServer<
             const key = `${node.app_id}:${node.screen_name}`;
             screenshotUris.set(key, `automobile:navigation/nodes/${node.id}/screenshot`);
           }
-        } catch { /* best-effort screenshot URI lookup */ }
+        } catch {
+          /* best-effort screenshot URI lookup */
+        }
       }
       for (const r of rows) {
         const screenshotUri = screenshotUris.get(`${r.applicationId}:${r.destination}`) ?? null;
@@ -206,8 +240,10 @@ export class TelemetryPushSocketServer extends PushSubscriptionSocketServer<
 
     // Backfill failures (crash/anr/nonfatal) in parallel
     const failureTypes = ["crash", "anr", "nonfatal"] as const;
-    const failureBackfillFn = async (failureType: typeof failureTypes[number]) => {
-      if (!shouldInclude(failureType)) {return;}
+    const failureBackfillFn = async (failureType: (typeof failureTypes)[number]) => {
+      if (!shouldInclude(failureType)) {
+        return;
+      }
       try {
         const db = getDatabase() as unknown as Kysely<Database>;
         let q = db
@@ -237,11 +273,15 @@ export class TelemetryPushSocketServer extends PushSubscriptionSocketServer<
           q = q.where("failure_occurrences.device_id", "=", deviceId);
         } else {
           // Even without a device filter, exclude failures with no device_id
-          q = q.where("failure_occurrences.device_id", "is not", null)
+          q = q
+            .where("failure_occurrences.device_id", "is not", null)
             .where("failure_occurrences.device_id", "!=", "");
         }
 
-        const rows = await q.orderBy("failure_occurrences.timestamp", "desc").limit(limit).execute();
+        const rows = await q
+          .orderBy("failure_occurrences.timestamp", "desc")
+          .limit(limit)
+          .execute();
 
         for (const r of rows) {
           let exceptionType: string | undefined;
@@ -255,7 +295,9 @@ export class TelemetryPushSocketServer extends PushSubscriptionSocketServer<
                   exceptionType = frames[0].className ?? frames[0].declaringClass;
                 }
               }
-            } catch { /* ignore parse errors */ }
+            } catch {
+              /* ignore parse errors */
+            }
           }
 
           // Bound the parsed stack trace by serialized size so a multi-hundred-KB
@@ -269,9 +311,15 @@ export class TelemetryPushSocketServer extends PushSubscriptionSocketServer<
             deviceId: r.deviceId,
             sessionId: r.sessionId ?? null,
             data: {
-              type: r.type, occurrenceId: r.occurrenceId, groupId: r.groupId,
-              severity: r.severity, title: r.title, exceptionType,
-              screen: r.screen, timestamp: r.timestamp, stackTrace: boundedStackTrace,
+              type: r.type,
+              occurrenceId: r.occurrenceId,
+              groupId: r.groupId,
+              severity: r.severity,
+              title: r.title,
+              exceptionType,
+              screen: r.screen,
+              timestamp: r.timestamp,
+              stackTrace: boundedStackTrace,
             },
           });
         }
@@ -286,30 +334,50 @@ export class TelemetryPushSocketServer extends PushSubscriptionSocketServer<
       shouldInclude("layout") ? getLayoutEvents({ deviceId, limit }) : [],
     ]);
     for (const r of storageRows) {
-      events.push({ category: "storage", timestamp: r.timestamp, deviceId: r.deviceId, sessionId: r.sessionId ?? null, data: r });
+      events.push({
+        category: "storage",
+        timestamp: r.timestamp,
+        deviceId: r.deviceId,
+        sessionId: r.sessionId ?? null,
+        data: r,
+      });
     }
     for (const r of layoutRows) {
-      events.push({ category: "layout", timestamp: r.timestamp, deviceId: r.deviceId, sessionId: r.sessionId ?? null, data: r });
+      events.push({
+        category: "layout",
+        timestamp: r.timestamp,
+        deviceId: r.deviceId,
+        sessionId: r.sessionId ?? null,
+        data: r,
+      });
     }
 
     // Sort oldest-first so dashboard shows them in correct order
     events.sort((a, b) => a.timestamp - b.timestamp);
 
     for (const event of events) {
+      const subscriber = this.subscribers.get(subscriptionId);
+      if (!subscriber || subscriber.socket !== socket) {
+        return;
+      }
+      if (filter.sessionId !== null && event.sessionId !== filter.sessionId) {
+        continue;
+      }
       // Single boundary cap for large plain-text fields (#2801): network bodies
       // are already capped in the repository mapRow; this bounds log/storage.
-      const msg = this.createPushMessage(boundBackfillEventText(event));
+      const msg = this.createPushMessage(boundBackfillEventText(event), subscriptionId);
       this.sendJson(socket, msg);
     }
 
     logger.info(`[TelemetryPush] Backfilled ${events.length} events to new subscriber`);
   }
 
-  protected createPushMessage(data: TelemetryEvent): TelemetryPushMessage {
+  protected createPushMessage(data: TelemetryEvent, subscriptionId: string): TelemetryPushMessage {
     return {
       type: "telemetry_push",
       timestamp: this.timer.now(),
       data,
+      subscriptionId,
     };
   }
 }

--- a/src/db/layoutEventRepository.ts
+++ b/src/db/layoutEventRepository.ts
@@ -62,13 +62,16 @@ export async function recordLayoutEvents(
 }
 
 export async function getLayoutEvents(
-  query: { deviceId?: string; sinceTimestamp?: number; limit?: number },
+  query: { deviceId?: string; sessionId?: string; sinceTimestamp?: number; limit?: number },
   db?: Kysely<Database>
 ): Promise<RecordLayoutEventInput[]> {
   let q = getDb(db).selectFrom("layout_events").selectAll();
 
   if (query.deviceId) {
     q = q.where("device_id", "=", query.deviceId);
+  }
+  if (query.sessionId) {
+    q = q.where("session_id", "=", query.sessionId);
   }
   if (query.sinceTimestamp) {
     q = q.where("timestamp", ">=", query.sinceTimestamp);

--- a/src/db/logEventRepository.ts
+++ b/src/db/logEventRepository.ts
@@ -55,13 +55,16 @@ export async function recordLogEvents(
 }
 
 export async function getLogEvents(
-  query: { deviceId?: string; sinceTimestamp?: number; tag?: string; limit?: number },
+  query: { deviceId?: string; sessionId?: string; sinceTimestamp?: number; tag?: string; limit?: number },
   db?: Kysely<Database>
 ): Promise<RecordLogEventInput[]> {
   let q = getDb(db).selectFrom("log_events").selectAll();
 
   if (query.deviceId) {
     q = q.where("device_id", "=", query.deviceId);
+  }
+  if (query.sessionId) {
+    q = q.where("session_id", "=", query.sessionId);
   }
   if (query.sinceTimestamp) {
     q = q.where("timestamp", ">=", query.sinceTimestamp);

--- a/src/db/navigationEventRepository.ts
+++ b/src/db/navigationEventRepository.ts
@@ -54,13 +54,16 @@ export async function recordNavigationEvents(
 }
 
 export async function getNavigationEvents(
-  query: { deviceId?: string; sinceTimestamp?: number; limit?: number },
+  query: { deviceId?: string; sessionId?: string; sinceTimestamp?: number; limit?: number },
   db?: Kysely<Database>
 ): Promise<RecordNavigationEventInput[]> {
   let q = getDb(db).selectFrom("navigation_events").selectAll();
 
   if (query.deviceId) {
     q = q.where("device_id", "=", query.deviceId);
+  }
+  if (query.sessionId) {
+    q = q.where("session_id", "=", query.sessionId);
   }
   if (query.sinceTimestamp) {
     q = q.where("timestamp", ">=", query.sinceTimestamp);

--- a/src/db/networkEventRepository.ts
+++ b/src/db/networkEventRepository.ts
@@ -68,6 +68,7 @@ export interface NetworkEventWithId extends RecordNetworkEventInput {
 
 export interface NetworkEventQuery {
   deviceId?: string;
+  sessionId?: string;
   sinceTimestamp?: number;
   limit?: number;
   host?: string;
@@ -133,6 +134,9 @@ export async function getNetworkEvents(
 
   if (query.deviceId) {
     q = q.where("device_id", "=", query.deviceId);
+  }
+  if (query.sessionId) {
+    q = q.where("session_id", "=", query.sessionId);
   }
   if (query.sinceTimestamp) {
     q = q.where("timestamp", ">=", query.sinceTimestamp);

--- a/src/db/osEventRepository.ts
+++ b/src/db/osEventRepository.ts
@@ -52,13 +52,16 @@ export async function recordOsEvents(
 }
 
 export async function getOsEvents(
-  query: { deviceId?: string; sinceTimestamp?: number; category?: string; limit?: number },
+  query: { deviceId?: string; sessionId?: string; sinceTimestamp?: number; category?: string; limit?: number },
   db?: Kysely<Database>
 ): Promise<RecordOsEventInput[]> {
   let q = getDb(db).selectFrom("os_events").selectAll();
 
   if (query.deviceId) {
     q = q.where("device_id", "=", query.deviceId);
+  }
+  if (query.sessionId) {
+    q = q.where("session_id", "=", query.sessionId);
   }
   if (query.sinceTimestamp) {
     q = q.where("timestamp", ">=", query.sinceTimestamp);

--- a/src/db/storageEventRepository.ts
+++ b/src/db/storageEventRepository.ts
@@ -145,13 +145,16 @@ async function insertStorageEventWithPreviousValue(
 }
 
 export async function getStorageEvents(
-  query: { deviceId?: string; sinceTimestamp?: number; limit?: number },
+  query: { deviceId?: string; sessionId?: string; sinceTimestamp?: number; limit?: number },
   db?: Kysely<Database>
 ): Promise<RecordStorageEventInput[]> {
   let q = getDb(db).selectFrom("storage_events").selectAll();
 
   if (query.deviceId) {
     q = q.where("device_id", "=", query.deviceId);
+  }
+  if (query.sessionId) {
+    q = q.where("session_id", "=", query.sessionId);
   }
   if (query.sinceTimestamp) {
     q = q.where("timestamp", ">=", query.sinceTimestamp);

--- a/src/features/performance/PerformanceMonitor.ts
+++ b/src/features/performance/PerformanceMonitor.ts
@@ -6,12 +6,18 @@ import {
   DEFAULT_THRESHOLDS,
   PerformancePushSocketServer,
 } from "../../daemon/performancePushSocketServer";
-import { getDeviceDataStreamServer, PerformanceStreamData } from "../../daemon/deviceDataStreamSocketServer";
+import {
+  getDeviceDataStreamServer,
+  PerformanceStreamData,
+} from "../../daemon/deviceDataStreamSocketServer";
 import { RecompositionTracker } from "./RecompositionTracker";
 import { getPerfWindowBuffer, PerfWindowBuffer } from "./PerfWindowBuffer";
 import { getSdkFrameMetricsStore, SdkFrameMetricsStore } from "./SdkFrameMetricsStore";
 import { TelemetryRecorder } from "../telemetry/TelemetryRecorder";
-import { defaultAdbClientFactory, AdbClientFactory } from "../../utils/android-cmdline-tools/AdbClientFactory";
+import {
+  defaultAdbClientFactory,
+  AdbClientFactory,
+} from "../../utils/android-cmdline-tools/AdbClientFactory";
 import { SimCtlClient, SimCtl } from "../../utils/ios-cmdline-tools/SimCtlClient";
 import { execFile } from "child_process";
 import { promisify } from "util";
@@ -28,7 +34,10 @@ export interface PerformanceTelemetryEmitter {
  * Type for the exec function used to run host commands.
  * Injected for testing.
  */
-export type ExecFileAsyncFn = (file: string, args: string[]) => Promise<{ stdout: string; stderr: string }>;
+export type ExecFileAsyncFn = (
+  file: string,
+  args: string[],
+) => Promise<{ stdout: string; stderr: string }>;
 
 /**
  * Factory interface for creating SimCtlClient instances.
@@ -225,7 +234,11 @@ export class PerformanceMonitor {
    * @param packageName - The package/bundle identifier to monitor
    * @param platform - The platform ("android" or "ios"), defaults to "android"
    */
-  startMonitoring(deviceId: string, packageName: string, platform: "android" | "ios" = "android"): void {
+  startMonitoring(
+    deviceId: string,
+    packageName: string,
+    platform: "android" | "ios" = "android",
+  ): void {
     if (this.monitoredDevices.has(deviceId)) {
       // Update package name if already monitoring this device
       const existing = this.monitoredDevices.get(deviceId)!;
@@ -252,7 +265,9 @@ export class PerformanceMonitor {
         // deviceId, so a package switch must reset it).
         this.perfWindowBuffer.clear(deviceId);
         this.frameMetricsStore.clear(deviceId);
-        logger.info(`[PerformanceMonitor] Updated monitoring to ${packageName} on ${deviceId} (${platform})`);
+        logger.info(
+          `[PerformanceMonitor] Updated monitoring to ${packageName} on ${deviceId} (${platform})`,
+        );
       }
       return;
     }
@@ -276,7 +291,9 @@ export class PerformanceMonitor {
       gfxPrimed: false,
       previousMetricHealth: {},
     });
-    logger.info(`[PerformanceMonitor] Started monitoring ${packageName} on ${deviceId} (${platform})`);
+    logger.info(
+      `[PerformanceMonitor] Started monitoring ${packageName} on ${deviceId} (${platform})`,
+    );
   }
 
   /**
@@ -306,10 +323,16 @@ export class PerformanceMonitor {
    * package switch or `stopMonitoring()`, and such a stale sample must not touch
    * the current device's caches, stream, or buffer.
    */
-  private isSampleCurrent(device: MonitoredDevice, samplingPackage: string, samplingGeneration: number): boolean {
-    return this.monitoredDevices.get(device.deviceId) === device &&
+  private isSampleCurrent(
+    device: MonitoredDevice,
+    samplingPackage: string,
+    samplingGeneration: number,
+  ): boolean {
+    return (
+      this.monitoredDevices.get(device.deviceId) === device &&
       device.packageName === samplingPackage &&
-      device.monitoringGeneration === samplingGeneration;
+      device.monitoringGeneration === samplingGeneration
+    );
   }
 
   /**
@@ -363,7 +386,7 @@ export class PerformanceMonitor {
   private async sampleDevice(
     device: MonitoredDevice,
     now: number,
-    server: PerformancePushSocketServer
+    server: PerformanceDataPusher,
   ): Promise<void> {
     try {
       if (device.platform === "ios") {
@@ -382,7 +405,7 @@ export class PerformanceMonitor {
   private async sampleAndroidDevice(
     device: MonitoredDevice,
     now: number,
-    server: PerformancePushSocketServer
+    server: PerformanceDataPusher,
   ): Promise<void> {
     // Identity captured before any await: if the monitored package switches (or
     // monitoring stops) while these adb calls are in flight, this whole sample
@@ -399,7 +422,7 @@ export class PerformanceMonitor {
       device.deviceId,
       samplingPackage,
       now,
-      PerformanceMonitor.SDK_FRAME_TTL_MS
+      PerformanceMonitor.SDK_FRAME_TTL_MS,
     );
 
     const gfxPromise = sdkFrame ? Promise.resolve(null) : this.collectGfxMetrics(device);
@@ -416,8 +439,7 @@ export class PerformanceMonitor {
 
     // Collect slow metrics (memory) if interval elapsed or first collection
     const shouldCollectMemory =
-      device.lastSlowTick === 0 ||
-      now - device.lastSlowTick >= PerformanceMonitor.SLOW_INTERVAL_MS;
+      device.lastSlowTick === 0 || now - device.lastSlowTick >= PerformanceMonitor.SLOW_INTERVAL_MS;
     const memoryPromise = shouldCollectMemory
       ? this.collectMemoryMetrics(device)
       : Promise.resolve(device.cachedMemory);
@@ -493,7 +515,7 @@ export class PerformanceMonitor {
       jankFrames = null;
       if (gfxData.rawJankCounters) {
         const curr = gfxData.rawJankCounters;
-        jankFrames = curr.jankyFrames ?? (curr.missedVsync + curr.slowUi + curr.deadlineMissed);
+        jankFrames = curr.jankyFrames ?? curr.missedVsync + curr.slowUi + curr.deadlineMissed;
       }
 
       const touch = this.estimateTouchLatency(gfxData, frameTimeMs, device);
@@ -552,7 +574,7 @@ export class PerformanceMonitor {
   private estimateTouchLatency(
     gfx: { totalFrames: number | null; highInputLatencyFrames: number | null },
     frameTimeMs: number | null,
-    device: MonitoredDevice
+    device: MonitoredDevice,
   ): { streamMs: number; rawMs: number | null } {
     if (gfx.totalFrames === null || gfx.totalFrames <= 0 || frameTimeMs === null) {
       // No frames this interval - assume optimal latency (idle app is responsive).
@@ -574,7 +596,7 @@ export class PerformanceMonitor {
   private async sampleIOSDevice(
     device: MonitoredDevice,
     now: number,
-    server: PerformancePushSocketServer
+    server: PerformanceDataPusher,
   ): Promise<void> {
     // Identity captured before any await (see sampleAndroidDevice).
     const samplingPackage = device.packageName;
@@ -591,8 +613,7 @@ export class PerformanceMonitor {
 
     // Collect slow metrics (memory) if interval elapsed or first collection
     const shouldCollectMemory =
-      device.lastSlowTick === 0 ||
-      now - device.lastSlowTick >= PerformanceMonitor.SLOW_INTERVAL_MS;
+      device.lastSlowTick === 0 || now - device.lastSlowTick >= PerformanceMonitor.SLOW_INTERVAL_MS;
     const memoryPromise = shouldCollectMemory
       ? this.collectIOSMemoryMetrics(device)
       : Promise.resolve(device.cachedMemory);
@@ -662,7 +683,7 @@ export class PerformanceMonitor {
       memoryUsageMb: number | null;
     },
     jankFrames: number | null,
-    server: PerformancePushSocketServer,
+    server: PerformanceDataPusher,
     // Raw per-interval readings for the windowed buffer only (null on an idle
     // no-frame tick), kept separate from the cached/fabricated stream values.
     // Callers guarantee (via isSampleCurrent) that the sample still belongs to
@@ -674,7 +695,7 @@ export class PerformanceMonitor {
       touchLatencyMs: number | null;
       cpuUsagePercent: number | null;
       memoryUsageMb: number | null;
-    }
+    },
   ): void {
     const data: LivePerformanceData = {
       deviceId: device.deviceId,
@@ -714,7 +735,10 @@ export class PerformanceMonitor {
 
     const observationServer = getDeviceDataStreamServer();
     if (observationServer) {
-      const recompositionSummary = RecompositionTracker.getInstance().getLatestSummary(device.deviceId, device.packageName);
+      const recompositionSummary = RecompositionTracker.getInstance().getLatestSummary(
+        device.deviceId,
+        device.packageName,
+      );
       const streamData: PerformanceStreamData = {
         fps: metrics.fps ?? 0,
         frameTimeMs: metrics.frameTimeMs ?? 0,
@@ -733,7 +757,11 @@ export class PerformanceMonitor {
     }
   }
 
-  private consumeGfxPriming(device: MonitoredDevice, sdkFrame: unknown, resetSucceeded: boolean): boolean {
+  private consumeGfxPriming(
+    device: MonitoredDevice,
+    sdkFrame: unknown,
+    resetSucceeded: boolean,
+  ): boolean {
     const hasSdkFrame = sdkFrame !== null;
     if (hasSdkFrame) {
       // SDK samples are interval-scoped. A later fallback must still be treated
@@ -766,7 +794,7 @@ export class PerformanceMonitor {
       memoryUsageMb: number | null;
       cpuUsagePercent: number | null;
     },
-    overallHealth: string
+    overallHealth: string,
   ): void {
     const th = DEFAULT_THRESHOLDS;
     const currentHealth: Record<string, string> = {};
@@ -774,16 +802,36 @@ export class PerformanceMonitor {
 
     // Classify each metric
     if (metrics.fps !== null) {
-      currentHealth.fps = metrics.fps < th.fpsCritical ? "critical" : metrics.fps < th.fpsWarning ? "warning" : "healthy";
+      currentHealth.fps =
+        metrics.fps < th.fpsCritical
+          ? "critical"
+          : metrics.fps < th.fpsWarning
+            ? "warning"
+            : "healthy";
     }
     if (metrics.frameTimeMs !== null) {
-      currentHealth.frameTime = metrics.frameTimeMs > th.frameTimeCritical ? "critical" : metrics.frameTimeMs > th.frameTimeWarning ? "warning" : "healthy";
+      currentHealth.frameTime =
+        metrics.frameTimeMs > th.frameTimeCritical
+          ? "critical"
+          : metrics.frameTimeMs > th.frameTimeWarning
+            ? "warning"
+            : "healthy";
     }
     if (metrics.jankFrames !== null) {
-      currentHealth.jank = metrics.jankFrames > th.jankCritical ? "critical" : metrics.jankFrames > th.jankWarning ? "warning" : "healthy";
+      currentHealth.jank =
+        metrics.jankFrames > th.jankCritical
+          ? "critical"
+          : metrics.jankFrames > th.jankWarning
+            ? "warning"
+            : "healthy";
     }
     if (metrics.touchLatencyMs !== null) {
-      currentHealth.touchLatency = metrics.touchLatencyMs > th.touchLatencyCritical ? "critical" : metrics.touchLatencyMs > th.touchLatencyWarning ? "warning" : "healthy";
+      currentHealth.touchLatency =
+        metrics.touchLatencyMs > th.touchLatencyCritical
+          ? "critical"
+          : metrics.touchLatencyMs > th.touchLatencyWarning
+            ? "warning"
+            : "healthy";
     }
     if (metrics.memoryUsageMb !== null) {
       // Classify memory into bands — emit telemetry when band changes.
@@ -834,7 +882,7 @@ export class PerformanceMonitor {
    * Jank delta calculation happens in sampleDevice.
    */
   private async collectGfxMetrics(
-    device: MonitoredDevice
+    device: MonitoredDevice,
   ): Promise<GfxMetrics & { rawJankCounters: RawJankCounters | null; resetSucceeded: boolean }> {
     try {
       const adb = this.adbClientFactory.create({
@@ -845,7 +893,9 @@ export class PerformanceMonitor {
 
       // Read and reset gfxinfo in one command to get fresh interval data
       // The 'reset' flag clears stats after reading, so next read reflects only new frames
-      const { stdout } = await adb.executeCommand(`shell dumpsys gfxinfo ${device.packageName} reset`);
+      const { stdout } = await adb.executeCommand(
+        `shell dumpsys gfxinfo ${device.packageName} reset`,
+      );
 
       // Check if any frames were actually rendered in this interval
       const totalFramesMatch = stdout.match(/Total frames rendered:\s+(\d+)/);
@@ -861,14 +911,19 @@ export class PerformanceMonitor {
       // Parse jank counters (now reflects only jank since last reset)
       const missedVsync = parseInt(stdout.match(/Missed Vsync:\s+(\d+)/)?.[1] || "0", 10);
       const slowUi = parseInt(stdout.match(/Slow UI thread:\s+(\d+)/)?.[1] || "0", 10);
-      const deadlineMissed = parseInt(stdout.match(/Frame deadline missed:\s+(\d+)/)?.[1] || "0", 10);
+      const deadlineMissed = parseInt(
+        stdout.match(/Frame deadline missed:\s+(\d+)/)?.[1] || "0",
+        10,
+      );
       // Aggregate janky-frame count (deduplicated across causes) when present.
       const jankyMatch = stdout.match(/Janky frames:\s+(\d+)/);
       const jankyFrames = jankyMatch ? parseInt(jankyMatch[1], 10) : null;
 
       // Parse high input latency frame count
       const highInputLatencyMatch = stdout.match(/Number High input latency:\s+(\d+)/);
-      const highInputLatencyFrames = highInputLatencyMatch ? parseInt(highInputLatencyMatch[1], 10) : null;
+      const highInputLatencyFrames = highInputLatencyMatch
+        ? parseInt(highInputLatencyMatch[1], 10)
+        : null;
 
       // Calculate FPS from frame time
       const fps = frameTimeMs && frameTimeMs > 0 ? Math.min(1000 / frameTimeMs, 60) : null;
@@ -965,7 +1020,7 @@ export class PerformanceMonitor {
       });
 
       const { stdout } = await adb.executeCommand(
-        `shell dumpsys meminfo ${device.packageName} | grep "TOTAL PSS"`
+        `shell dumpsys meminfo ${device.packageName} | grep "TOTAL PSS"`,
       );
 
       // Format: "TOTAL PSS:    12345"
@@ -1050,7 +1105,9 @@ export class PerformanceMonitor {
 
       return null;
     } catch (error) {
-      logger.debug(`[PerformanceMonitor] iOS memory metrics failed for ${device.deviceId}: ${error}`);
+      logger.debug(
+        `[PerformanceMonitor] iOS memory metrics failed for ${device.deviceId}: ${error}`,
+      );
       return null;
     }
   }

--- a/test/daemon/deviceDataStreamSocketServer.test.ts
+++ b/test/daemon/deviceDataStreamSocketServer.test.ts
@@ -71,11 +71,15 @@ describe("DeviceDataStreamSocketServer", () => {
   });
 
   it("records a device-authored frame context even without an IDE subscriber", () => {
-    server.pushHierarchyUpdate("device-1", {
-      updatedAt: 123,
-      packageName: "com.example.app",
-      hierarchy: { text: "Home" },
-    } as any, "frame-A");
+    server.pushHierarchyUpdate(
+      "device-1",
+      {
+        updatedAt: 123,
+        packageName: "com.example.app",
+        hierarchy: { text: "Home" },
+      } as any,
+      "frame-A",
+    );
 
     expect(server.getCurrentFrameContext("device-1")).toBe("frame-A");
   });
@@ -93,7 +97,10 @@ describe("DeviceDataStreamSocketServer", () => {
   });
 
   describe("request_observation", () => {
-    const requestedObservation = (deviceId: string, frameContext?: string): RequestedObservation => ({
+    const requestedObservation = (
+      deviceId: string,
+      frameContext?: string,
+    ): RequestedObservation => ({
       deviceId,
       observation: {
         updatedAt: "2026-06-24T00:00:00.000Z",
@@ -111,18 +118,21 @@ describe("DeviceDataStreamSocketServer", () => {
     it("triggers callback, pushes hierarchy update, and acknowledges success", async () => {
       let requestedDeviceId: string | null | undefined;
       let requestSignal: AbortSignal | undefined;
-      server.setOnObservationRequested(async request => {
+      server.setOnObservationRequested(async (request) => {
         requestedDeviceId = request.deviceId;
         requestSignal = request.signal;
         return [requestedObservation("emulator-5554")];
       });
       const { socket } = server.simulateSubscription({ deviceId: "emulator-5554" });
 
-      await server.processLineForTest(socket, JSON.stringify({
-        id: "obs-1",
-        command: "request_observation",
-        deviceId: "emulator-5554",
-      }));
+      await server.processLineForTest(
+        socket,
+        JSON.stringify({
+          id: "obs-1",
+          command: "request_observation",
+          deviceId: "emulator-5554",
+        }),
+      );
 
       expect(requestedDeviceId).toBe("emulator-5554");
       expect(requestSignal?.aborted).toBe(false);
@@ -143,16 +153,19 @@ describe("DeviceDataStreamSocketServer", () => {
     });
 
     it("forwards proven frame context and clears it when an explicit observation lacks provenance", async () => {
-      server.setOnObservationRequested(async request => [
+      server.setOnObservationRequested(async (request) => [
         requestedObservation(request.deviceId ?? "emulator-5554", "frame-A"),
       ]);
       const { socket } = server.simulateSubscription({ deviceId: "emulator-5554" });
 
-      await server.processLineForTest(socket, JSON.stringify({
-        id: "obs-context",
-        command: "request_observation",
-        deviceId: "emulator-5554",
-      }));
+      await server.processLineForTest(
+        socket,
+        JSON.stringify({
+          id: "obs-context",
+          command: "request_observation",
+          deviceId: "emulator-5554",
+        }),
+      );
 
       const firstMessages = socket.getWrittenMessages<{
         type: string;
@@ -161,54 +174,68 @@ describe("DeviceDataStreamSocketServer", () => {
       expect(firstMessages[0].frameContext).toBe("frame-A");
       expect(server.getCurrentFrameContext("emulator-5554")).toBe("frame-A");
 
-      server.setOnObservationRequested(async request => [
+      server.setOnObservationRequested(async (request) => [
         requestedObservation(request.deviceId ?? "emulator-5554"),
       ]);
-      await server.processLineForTest(socket, JSON.stringify({
-        id: "obs-contextless",
-        command: "request_observation",
-        deviceId: "emulator-5554",
-      }));
+      await server.processLineForTest(
+        socket,
+        JSON.stringify({
+          id: "obs-contextless",
+          command: "request_observation",
+          deviceId: "emulator-5554",
+        }),
+      );
 
       expect(server.getCurrentFrameContext("emulator-5554")).toBeUndefined();
     });
 
     it("does not let a completed explicit observation replace a newer live frame context", async () => {
       let resolveObservation: ((observations: RequestedObservation[]) => void) | undefined;
-      server.setOnObservationRequested(() => new Promise(resolve => {
-        resolveObservation = resolve;
-      }));
+      server.setOnObservationRequested(
+        () =>
+          new Promise((resolve) => {
+            resolveObservation = resolve;
+          }),
+      );
       const { socket } = server.simulateSubscription({ deviceId: "emulator-5554" });
 
-      const request = server.processLineForTest(socket, JSON.stringify({
-        id: "obs-race",
-        command: "request_observation",
-        deviceId: "emulator-5554",
-      }));
+      const request = server.processLineForTest(
+        socket,
+        JSON.stringify({
+          id: "obs-race",
+          command: "request_observation",
+          deviceId: "emulator-5554",
+        }),
+      );
       await Promise.resolve();
       expect(resolveObservation).toBeDefined();
 
       server.pushHierarchyUpdate(
         "emulator-5554",
         requestedObservation("emulator-5554", "frame-B").observation.viewHierarchy!,
-        "frame-B"
+        "frame-B",
       );
       resolveObservation!([requestedObservation("emulator-5554", "frame-A")]);
       await request;
 
       expect(server.getCurrentFrameContext("emulator-5554")).toBe("frame-B");
-      expect(socket.getWrittenMessages<{ type: string }>().filter(message =>
-        message.type === "hierarchy_update"
-      )).toHaveLength(1);
+      expect(
+        socket
+          .getWrittenMessages<{ type: string }>()
+          .filter((message) => message.type === "hierarchy_update"),
+      ).toHaveLength(1);
     });
 
     it("returns error when no observation callback is configured", async () => {
       const socket = new FakeSocket();
 
-      await server.processLineForTest(socket, JSON.stringify({
-        id: "obs-2",
-        command: "request_observation",
-      }));
+      await server.processLineForTest(
+        socket,
+        JSON.stringify({
+          id: "obs-2",
+          command: "request_observation",
+        }),
+      );
 
       const msgs = socket.getWrittenMessages<{
         id?: string;
@@ -224,23 +251,28 @@ describe("DeviceDataStreamSocketServer", () => {
     });
 
     it("returns error when observation has no hierarchy", async () => {
-      server.setOnObservationRequested(async () => [{
-        deviceId: "emulator-5554",
-        observation: {
-          updatedAt: "2026-06-24T00:00:00.000Z",
-          screenSize: { width: 0, height: 0 },
-          systemInsets: { top: 0, right: 0, bottom: 0, left: 0 },
-          errors: [{ phase: "viewHierarchy", message: "Accessibility service unavailable" }],
-          error: "Accessibility service unavailable",
+      server.setOnObservationRequested(async () => [
+        {
+          deviceId: "emulator-5554",
+          observation: {
+            updatedAt: "2026-06-24T00:00:00.000Z",
+            screenSize: { width: 0, height: 0 },
+            systemInsets: { top: 0, right: 0, bottom: 0, left: 0 },
+            errors: [{ phase: "viewHierarchy", message: "Accessibility service unavailable" }],
+            error: "Accessibility service unavailable",
+          },
         },
-      }]);
+      ]);
       const { socket } = server.simulateSubscription({ deviceId: "emulator-5554" });
 
-      await server.processLineForTest(socket, JSON.stringify({
-        id: "obs-no-hierarchy",
-        command: "request_observation",
-        deviceId: "emulator-5554",
-      }));
+      await server.processLineForTest(
+        socket,
+        JSON.stringify({
+          id: "obs-no-hierarchy",
+          command: "request_observation",
+          deviceId: "emulator-5554",
+        }),
+      );
 
       const msgs = socket.getWrittenMessages<{
         id?: string;
@@ -253,7 +285,7 @@ describe("DeviceDataStreamSocketServer", () => {
       expect(msgs[0].id).toBe("obs-no-hierarchy");
       expect(msgs[0].success).toBe(false);
       expect(msgs[0].error).toBe(
-        "Observation request failed for emulator-5554: Accessibility service unavailable"
+        "Observation request failed for emulator-5554: Accessibility service unavailable",
       );
     });
 
@@ -273,10 +305,13 @@ describe("DeviceDataStreamSocketServer", () => {
       ]);
       const { socket } = server.simulateSubscription({});
 
-      await server.processLineForTest(socket, JSON.stringify({
-        id: "obs-partial",
-        command: "request_observation",
-      }));
+      await server.processLineForTest(
+        socket,
+        JSON.stringify({
+          id: "obs-partial",
+          command: "request_observation",
+        }),
+      );
 
       const msgs = socket.getWrittenMessages<{
         id?: string;
@@ -294,7 +329,7 @@ describe("DeviceDataStreamSocketServer", () => {
       expect(msgs[1].id).toBe("obs-partial");
       expect(msgs[1].success).toBe(false);
       expect(msgs[1].error).toBe(
-        "Observation request failed for emulator-5556: CtrlProxy unavailable"
+        "Observation request failed for emulator-5556: CtrlProxy unavailable",
       );
     });
 
@@ -302,10 +337,13 @@ describe("DeviceDataStreamSocketServer", () => {
       server.setOnObservationRequested(async () => []);
       const socket = new FakeSocket();
 
-      await server.processLineForTest(socket, JSON.stringify({
-        id: "obs-empty",
-        command: "request_observation",
-      }));
+      await server.processLineForTest(
+        socket,
+        JSON.stringify({
+          id: "obs-empty",
+          command: "request_observation",
+        }),
+      );
 
       const msgs = socket.getWrittenMessages<{
         id?: string;
@@ -326,10 +364,13 @@ describe("DeviceDataStreamSocketServer", () => {
       });
       const socket = new FakeSocket();
 
-      await server.processLineForTest(socket, JSON.stringify({
-        id: "obs-3",
-        command: "request_observation",
-      }));
+      await server.processLineForTest(
+        socket,
+        JSON.stringify({
+          id: "obs-3",
+          command: "request_observation",
+        }),
+      );
 
       const msgs = socket.getWrittenMessages<{
         id?: string;
@@ -346,16 +387,19 @@ describe("DeviceDataStreamSocketServer", () => {
 
     it("returns error and aborts request when observation times out", async () => {
       let requestSignal: AbortSignal | undefined;
-      server.setOnObservationRequested(request => {
+      server.setOnObservationRequested((request) => {
         requestSignal = request.signal;
         return new Promise<RequestedObservation[]>(() => {});
       }, 100);
       const socket = new FakeSocket();
 
-      const requestPromise = server.processLineForTest(socket, JSON.stringify({
-        id: "obs-4",
-        command: "request_observation",
-      }));
+      const requestPromise = server.processLineForTest(
+        socket,
+        JSON.stringify({
+          id: "obs-4",
+          command: "request_observation",
+        }),
+      );
       await Promise.resolve();
       timer.advanceTime(100);
       await requestPromise;
@@ -382,9 +426,7 @@ describe("DeviceDataStreamSocketServer", () => {
         { id: 1, screenName: "Home", visitCount: 3 },
         { id: 2, screenName: "Settings", visitCount: 1 },
       ],
-      edges: [
-        { id: 1, from: "Home", to: "Settings", toolName: "tapOn", traversalCount: 2 },
-      ],
+      edges: [{ id: 1, from: "Home", to: "Settings", toolName: "tapOn", traversalCount: 2 }],
       currentScreen: "Home",
     };
 
@@ -522,6 +564,7 @@ describe("DeviceDataStreamSocketServer", () => {
       const requestLine = JSON.stringify({
         id: "unsub-1",
         command: "unsubscribe",
+        subscriptionId: "devicedatastream-1",
       });
 
       await server.processLineForTest(socket, requestLine);
@@ -536,30 +579,110 @@ describe("DeviceDataStreamSocketServer", () => {
       expect(msgs[0].success).toBe(true);
       expect(server.getSubscriberCount()).toBe(0);
     });
+
+    it("multiplexes device filters and cadence updates by subscriptionId", async () => {
+      const socket = new FakeSocket();
+      await server.processLineForTest(
+        socket,
+        JSON.stringify({
+          id: "sub-device-1",
+          command: "subscribe",
+          deviceId: "device-1",
+          screenshotIntervalMs: 500,
+        }),
+      );
+      await server.processLineForTest(
+        socket,
+        JSON.stringify({
+          id: "sub-device-2",
+          command: "subscribe",
+          deviceId: "device-2",
+          screenshotIntervalMs: 1000,
+        }),
+      );
+
+      const [firstResponse, secondResponse] = socket.getWrittenMessages<{
+        id: string;
+        subscriptionId: string;
+      }>();
+      expect(server.getSubscriberCount()).toBe(2);
+      expect(firstResponse.subscriptionId).toBe("devicedatastream-1");
+      expect(secondResponse.subscriptionId).toBe("devicedatastream-2");
+
+      server.pushScreenshotUpdate("device-1", "device-1-frame", 100, 200);
+      server.pushScreenshotUpdate("device-2", "device-2-frame", 100, 200);
+      expect(
+        socket
+          .getWrittenMessages<{
+            type: string;
+            subscriptionId: string;
+            screenshotBase64?: string;
+          }>()
+          .filter((message) => message.type === "screenshot_update"),
+      ).toMatchObject([
+        { subscriptionId: firstResponse.subscriptionId, screenshotBase64: "device-1-frame" },
+        { subscriptionId: secondResponse.subscriptionId, screenshotBase64: "device-2-frame" },
+      ]);
+
+      await server.processLineForTest(
+        socket,
+        JSON.stringify({
+          id: "relax-device-2",
+          command: "update_cadence",
+          subscriptionId: secondResponse.subscriptionId,
+          screenshotIntervalMs: 1500,
+        }),
+      );
+
+      expect(server.getScreenshotIntervalMsForDevice("device-1")).toBe(500);
+      expect(server.getScreenshotIntervalMsForDevice("device-2")).toBe(1500);
+    });
+
+    it("removes every multiplexed device subscription on connection close", async () => {
+      const screenshotChanges: Array<string | null> = [];
+      server.setOnScreenshotCadenceChanged((deviceId) => screenshotChanges.push(deviceId));
+      const socket = new FakeSocket();
+      await server.processLineForTest(
+        socket,
+        JSON.stringify({
+          id: "sub-device-1",
+          command: "subscribe",
+          deviceId: "device-1",
+        }),
+      );
+      await server.processLineForTest(
+        socket,
+        JSON.stringify({
+          id: "sub-device-2",
+          command: "subscribe",
+          deviceId: "device-2",
+        }),
+      );
+      screenshotChanges.length = 0;
+
+      server.closeConnectionForTest(socket);
+
+      expect(server.getSubscriberCount()).toBe(0);
+      expect(screenshotChanges).toEqual(["device-1", "device-2"]);
+    });
   });
 
   describe("screenshot updates", () => {
     it("includes optional screenshot metadata when pushing updates", () => {
       const { socket } = server.simulateSubscription({ deviceId: "device-1" });
 
-      server.pushScreenshotUpdate(
-        "device-1",
-        "png-frame",
-        1080,
-        2340,
-        {
-          screenshotMimeType: "image/png",
-          screenshotFormat: "png",
-          screenshotCaptureSource: "android_adb_screencap",
-          screenshotFallback: true,
-          screenshotFallbackReason: "websocket_unavailable",
-          screenshotCaptureDurationMs: 42,
-          screenshotEncodeDurationMs: 7,
-          screenshotByteLength: 1200,
-          screenshotBase64Length: 1600,
-          checksum: "internal-checksum",
-        } as any
-      );
+      server.pushScreenshotUpdate("device-1", "png-frame", 1080, 2340, {
+        screenshotMimeType: "image/png",
+        screenshotFormat: "png",
+        screenshotCaptureSource: "android_adb_screencap",
+        screenshotFallback: true,
+        screenshotFallbackReason: "websocket_unavailable",
+        screenshotCaptureDurationMs: 42,
+        screenshotEncodeDurationMs: 7,
+        screenshotByteLength: 1200,
+        screenshotBase64Length: 1600,
+        checksum: "internal-checksum",
+      } as any);
 
       const msgs = socket.getWrittenMessages<{
         type: string;
@@ -600,18 +723,12 @@ describe("DeviceDataStreamSocketServer", () => {
     it("omits screenshot performance metadata when it is not provided", () => {
       const { socket } = server.simulateSubscription({ deviceId: "device-1" });
 
-      server.pushScreenshotUpdate(
-        "device-1",
-        "legacy-frame",
-        1080,
-        2340,
-        {
-          screenshotMimeType: "image/jpeg",
-          screenshotFormat: "jpeg",
-          screenshotCaptureSource: "android_ctrlproxy_a11y",
-          screenshotFallback: false,
-        }
-      );
+      server.pushScreenshotUpdate("device-1", "legacy-frame", 1080, 2340, {
+        screenshotMimeType: "image/jpeg",
+        screenshotFormat: "jpeg",
+        screenshotCaptureSource: "android_ctrlproxy_a11y",
+        screenshotFallback: false,
+      });
 
       const [message] = socket.getWrittenMessages<Record<string, unknown>>();
       expect(message).toMatchObject({
@@ -639,7 +756,10 @@ describe("DeviceDataStreamSocketServer", () => {
 
   describe("hierarchy diff annotation", () => {
     const frame = (text: string, rotation: number = 0) =>
-      ({ hierarchy: { node: { $: { class: "Root" }, node: [{ $: { class: "Child", text } }] } }, rotation }) as any;
+      ({
+        hierarchy: { node: { $: { class: "Root" }, node: [{ $: { class: "Child", text } }] } },
+        rotation,
+      }) as any;
 
     it("reports no baseline and annotates nothing on the first frame", () => {
       const { socket } = server.simulateSubscription({ deviceId: "device-1" });
@@ -648,7 +768,12 @@ describe("DeviceDataStreamSocketServer", () => {
 
       const [message] = socket.getWrittenMessages<any>();
       expect(message.type).toBe("hierarchy_update");
-      expect(message.hierarchyDiff).toEqual({ hasBaseline: false, added: 0, changed: 0, removed: 0 });
+      expect(message.hierarchyDiff).toEqual({
+        hasBaseline: false,
+        added: 0,
+        changed: 0,
+        removed: 0,
+      });
       expect(message.data.hierarchy.node.node[0].$.diffState).toBeUndefined();
     });
 
@@ -660,7 +785,12 @@ describe("DeviceDataStreamSocketServer", () => {
 
       const messages = socket.getWrittenMessages<any>();
       expect(messages).toHaveLength(2);
-      expect(messages[1].hierarchyDiff).toEqual({ hasBaseline: true, added: 0, changed: 1, removed: 0 });
+      expect(messages[1].hierarchyDiff).toEqual({
+        hasBaseline: true,
+        added: 0,
+        changed: 1,
+        removed: 0,
+      });
       expect(messages[1].data.hierarchy.node.node[0].$.diffState).toBe("changed");
     });
 
@@ -674,7 +804,7 @@ describe("DeviceDataStreamSocketServer", () => {
       // The post-reconnect frame is diffed against a fresh baseline, not the
       // pre-drop tree, so it reports no baseline rather than a spurious change.
       const messages = socket.getWrittenMessages<any>();
-      const hierarchyMessages = messages.filter(m => m.type === "hierarchy_update");
+      const hierarchyMessages = messages.filter((m) => m.type === "hierarchy_update");
       expect(hierarchyMessages[hierarchyMessages.length - 1].hierarchyDiff.hasBaseline).toBe(false);
     });
 
@@ -692,19 +822,33 @@ describe("DeviceDataStreamSocketServer", () => {
       const { socket } = server.simulateSubscription({ deviceId: "device-1" });
 
       const first = server.pushHierarchyUpdate("device-1", frame("a", 0));
-      server.pushScreenshotUpdate("device-1", pngFrame(1080, 2340), 1080, 2340, {}, {
-        captureSequence: first ?? undefined,
-        rotation: 0,
-      });
+      server.pushScreenshotUpdate(
+        "device-1",
+        pngFrame(1080, 2340),
+        1080,
+        2340,
+        {},
+        {
+          captureSequence: first ?? undefined,
+          rotation: 0,
+        },
+      );
       const second = server.pushHierarchyUpdate("device-1", frame("b", 1));
-      server.pushScreenshotUpdate("device-1", pngFrame(720, 1560), 720, 1560, {}, {
-        captureSequence: second ?? undefined,
-        rotation: 1,
-      });
+      server.pushScreenshotUpdate(
+        "device-1",
+        pngFrame(720, 1560),
+        720,
+        1560,
+        {},
+        {
+          captureSequence: second ?? undefined,
+          rotation: 1,
+        },
+      );
 
       const [h1, s1, h2, s2] = socket
         .getWrittenMessages<any>()
-        .filter(m => m.type === "hierarchy_update" || m.type === "screenshot_update");
+        .filter((m) => m.type === "hierarchy_update" || m.type === "screenshot_update");
 
       expect(h1.captureSequence).toBe(1);
       expect(s1.captureSequence).toBe(1);
@@ -726,11 +870,20 @@ describe("DeviceDataStreamSocketServer", () => {
       const { socket } = server.simulateSubscription({ deviceId: "device-1" });
 
       const captureSequence = server.pushHierarchyUpdate("device-1", frame("a"));
-      server.pushScreenshotUpdate("device-1", pngFrame(720, 1560), 1080, 2340, {}, {
-        captureSequence: captureSequence ?? undefined,
-      });
+      server.pushScreenshotUpdate(
+        "device-1",
+        pngFrame(720, 1560),
+        1080,
+        2340,
+        {},
+        {
+          captureSequence: captureSequence ?? undefined,
+        },
+      );
 
-      const screenshot = socket.getWrittenMessages<any>().find(m => m.type === "screenshot_update");
+      const screenshot = socket
+        .getWrittenMessages<any>()
+        .find((m) => m.type === "screenshot_update");
       expect(screenshot.captureSequence).toBeUndefined();
       // The published geometry is the frame's real size, not the stale claim, so a client that
       // falls back to it maps through the pixels it is actually rendering.
@@ -746,7 +899,9 @@ describe("DeviceDataStreamSocketServer", () => {
       server.pushHierarchyUpdate("device-1", frame("a"));
       server.pushScreenshotUpdate("device-1", pngFrame(1080, 2340), 1080, 2340);
 
-      const screenshot = socket.getWrittenMessages<any>().find(m => m.type === "screenshot_update");
+      const screenshot = socket
+        .getWrittenMessages<any>()
+        .find((m) => m.type === "screenshot_update");
       expect(screenshot.captureSequence).toBeUndefined();
     });
 
@@ -758,11 +913,20 @@ describe("DeviceDataStreamSocketServer", () => {
       const { socket } = server.simulateSubscription({ deviceId: "device-1" });
 
       const captureSequence = server.pushHierarchyUpdate("device-1", frame("a"));
-      server.pushScreenshotUpdate("device-1", pngFrame(1170, 2532), 2532, 1170, {}, {
-        captureSequence: captureSequence ?? undefined,
-      });
+      server.pushScreenshotUpdate(
+        "device-1",
+        pngFrame(1170, 2532),
+        2532,
+        1170,
+        {},
+        {
+          captureSequence: captureSequence ?? undefined,
+        },
+      );
 
-      const screenshot = socket.getWrittenMessages<any>().find(m => m.type === "screenshot_update");
+      const screenshot = socket
+        .getWrittenMessages<any>()
+        .find((m) => m.type === "screenshot_update");
       expect(screenshot.captureSequence).toBe(captureSequence);
       // The MEASURED dimensions are still what gets published, so a client maps through the pixels
       // it actually renders rather than the claim.
@@ -775,11 +939,20 @@ describe("DeviceDataStreamSocketServer", () => {
       const { socket } = server.simulateSubscription({ deviceId: "device-1" });
 
       const captureSequence = server.pushHierarchyUpdate("device-1", frame("a"));
-      server.pushScreenshotUpdate("device-1", pngFrame(720, 1560), 1080, 2340, {}, {
-        captureSequence: captureSequence ?? undefined,
-      });
+      server.pushScreenshotUpdate(
+        "device-1",
+        pngFrame(720, 1560),
+        1080,
+        2340,
+        {},
+        {
+          captureSequence: captureSequence ?? undefined,
+        },
+      );
 
-      const screenshot = socket.getWrittenMessages<any>().find(m => m.type === "screenshot_update");
+      const screenshot = socket
+        .getWrittenMessages<any>()
+        .find((m) => m.type === "screenshot_update");
       expect(screenshot.captureSequence).toBeUndefined();
     });
 
@@ -787,11 +960,20 @@ describe("DeviceDataStreamSocketServer", () => {
       const { socket } = server.simulateSubscription({ deviceId: "device-1" });
 
       const captureSequence = server.pushHierarchyUpdate("device-1", frame("a"));
-      server.pushScreenshotUpdate("device-1", pngFrame(800, 600), 1080, 2340, {}, {
-        captureSequence: captureSequence ?? undefined,
-      });
+      server.pushScreenshotUpdate(
+        "device-1",
+        pngFrame(800, 600),
+        1080,
+        2340,
+        {},
+        {
+          captureSequence: captureSequence ?? undefined,
+        },
+      );
 
-      const screenshot = socket.getWrittenMessages<any>().find(m => m.type === "screenshot_update");
+      const screenshot = socket
+        .getWrittenMessages<any>()
+        .find((m) => m.type === "screenshot_update");
       expect(screenshot.captureSequence).toBeUndefined();
     });
 
@@ -804,11 +986,20 @@ describe("DeviceDataStreamSocketServer", () => {
       malformed.write("IDAT", 12, "ascii");
 
       const captureSequence = server.pushHierarchyUpdate("device-1", frame("a"));
-      server.pushScreenshotUpdate("device-1", malformed.toString("base64"), 1080, 2340, {}, {
-        captureSequence: captureSequence ?? undefined,
-      });
+      server.pushScreenshotUpdate(
+        "device-1",
+        malformed.toString("base64"),
+        1080,
+        2340,
+        {},
+        {
+          captureSequence: captureSequence ?? undefined,
+        },
+      );
 
-      const screenshot = socket.getWrittenMessages<any>().find(m => m.type === "screenshot_update");
+      const screenshot = socket
+        .getWrittenMessages<any>()
+        .find((m) => m.type === "screenshot_update");
       expect(screenshot.captureSequence).toBeUndefined();
     });
 
@@ -816,11 +1007,20 @@ describe("DeviceDataStreamSocketServer", () => {
       const { socket } = server.simulateSubscription({ deviceId: "device-1" });
 
       const captureSequence = server.pushHierarchyUpdate("device-1", frame("a"));
-      server.pushScreenshotUpdate("device-1", Buffer.from("not-an-image").toString("base64"), 1080, 2340, {}, {
-        captureSequence: captureSequence ?? undefined,
-      });
+      server.pushScreenshotUpdate(
+        "device-1",
+        Buffer.from("not-an-image").toString("base64"),
+        1080,
+        2340,
+        {},
+        {
+          captureSequence: captureSequence ?? undefined,
+        },
+      );
 
-      const screenshot = socket.getWrittenMessages<any>().find(m => m.type === "screenshot_update");
+      const screenshot = socket
+        .getWrittenMessages<any>()
+        .find((m) => m.type === "screenshot_update");
       expect(screenshot.captureSequence).toBeUndefined();
       // Unmeasurable: fall back to the caller's claim for display, but never pair on it.
       expect(screenshot.screenWidth).toBe(1080);
@@ -831,7 +1031,9 @@ describe("DeviceDataStreamSocketServer", () => {
 
       server.pushScreenshotUpdate("device-1", pngFrame(1080, 2340), 1080, 2340);
 
-      const screenshot = socket.getWrittenMessages<any>().find(m => m.type === "screenshot_update");
+      const screenshot = socket
+        .getWrittenMessages<any>()
+        .find((m) => m.type === "screenshot_update");
       expect(screenshot.captureSequence).toBeUndefined();
     });
 
@@ -847,11 +1049,20 @@ describe("DeviceDataStreamSocketServer", () => {
       const screenB = server.pushHierarchyUpdate("device-1", frame("screen-b"));
       expect(screenB).toBeGreaterThan(screenA!);
       // ... and only now does the in-flight frame arrive and get pushed.
-      server.pushScreenshotUpdate("device-1", pngFrame(1080, 2340), 1080, 2340, {}, {
-        captureSequence: screenA ?? undefined,
-      });
+      server.pushScreenshotUpdate(
+        "device-1",
+        pngFrame(1080, 2340),
+        1080,
+        2340,
+        {},
+        {
+          captureSequence: screenA ?? undefined,
+        },
+      );
 
-      const screenshot = socket.getWrittenMessages<any>().find(m => m.type === "screenshot_update");
+      const screenshot = socket
+        .getWrittenMessages<any>()
+        .find((m) => m.type === "screenshot_update");
       expect(screenshot.captureSequence).toBe(screenA);
       expect(screenshot.captureSequence).not.toBe(screenB);
     });
@@ -868,8 +1079,8 @@ describe("DeviceDataStreamSocketServer", () => {
 
       const ids = socket
         .getWrittenMessages<any>()
-        .filter(m => m.type === "hierarchy_update")
-        .map(m => m.captureSequence);
+        .filter((m) => m.type === "hierarchy_update")
+        .map((m) => m.captureSequence);
 
       expect(new Set(ids).size).toBe(ids.length);
       expect(ids[2]).toBeGreaterThan(ids[1]);
@@ -883,7 +1094,9 @@ describe("DeviceDataStreamSocketServer", () => {
       // The client drops its binding when the connection goes away, so nothing is supplied.
       server.pushScreenshotUpdate("device-1", pngFrame(1080, 2340), 1080, 2340);
 
-      const screenshot = socket.getWrittenMessages<any>().find(m => m.type === "screenshot_update");
+      const screenshot = socket
+        .getWrittenMessages<any>()
+        .find((m) => m.type === "screenshot_update");
       expect(screenshot.captureSequence).toBeUndefined();
     });
 
@@ -939,12 +1152,15 @@ describe("DeviceDataStreamSocketServer", () => {
     it("parses requested screenshot cadence from subscribe commands", async () => {
       const socket = new FakeSocket();
 
-      await server.processLineForTest(socket, JSON.stringify({
-        id: "sub-fast",
-        command: "subscribe",
-        deviceId: "device-1",
-        screenshotIntervalMs: 500,
-      }));
+      await server.processLineForTest(
+        socket,
+        JSON.stringify({
+          id: "sub-fast",
+          command: "subscribe",
+          deviceId: "device-1",
+          screenshotIntervalMs: 500,
+        }),
+      );
 
       expect(server.getScreenshotIntervalMsForDevice("device-1")).toBe(500);
     });
@@ -952,12 +1168,15 @@ describe("DeviceDataStreamSocketServer", () => {
     it("clamps requested screenshot cadence to the safe minimum", async () => {
       const socket = new FakeSocket();
 
-      await server.processLineForTest(socket, JSON.stringify({
-        id: "sub-clamped",
-        command: "subscribe",
-        deviceId: "device-1",
-        screenshotIntervalMs: 50,
-      }));
+      await server.processLineForTest(
+        socket,
+        JSON.stringify({
+          id: "sub-clamped",
+          command: "subscribe",
+          deviceId: "device-1",
+          screenshotIntervalMs: 50,
+        }),
+      );
 
       expect(server.getScreenshotIntervalMsForDevice("device-1")).toBe(250);
     });
@@ -965,12 +1184,15 @@ describe("DeviceDataStreamSocketServer", () => {
     it("clamps requested screenshot cadence to the maximum timer delay", async () => {
       const socket = new FakeSocket();
 
-      await server.processLineForTest(socket, JSON.stringify({
-        id: "sub-max-clamped",
-        command: "subscribe",
-        deviceId: "device-1",
-        screenshotIntervalMs: 3_000_000_000,
-      }));
+      await server.processLineForTest(
+        socket,
+        JSON.stringify({
+          id: "sub-max-clamped",
+          command: "subscribe",
+          deviceId: "device-1",
+          screenshotIntervalMs: 3_000_000_000,
+        }),
+      );
 
       expect(server.getScreenshotIntervalMsForDevice("device-1")).toBe(2_147_483_647);
     });
@@ -998,18 +1220,28 @@ describe("DeviceDataStreamSocketServer", () => {
     });
 
     it("removes requested cadence after unsubscribe", async () => {
-      const { socket } = server.simulateSubscription({ deviceId: "device-1", screenshotIntervalMs: 500 });
+      const { socket } = server.simulateSubscription({
+        deviceId: "device-1",
+        screenshotIntervalMs: 500,
+      });
 
-      await server.processLineForTest(socket, JSON.stringify({
-        id: "unsub-fast",
-        command: "unsubscribe",
-      }));
+      await server.processLineForTest(
+        socket,
+        JSON.stringify({
+          id: "unsub-fast",
+          command: "unsubscribe",
+          subscriptionId: "devicedatastream-1",
+        }),
+      );
 
       expect(server.getScreenshotIntervalMsForDevice("device-1")).toBe(3000);
     });
 
     it("ignores destroyed subscriber sockets when aggregating cadence", () => {
-      const { socket } = server.simulateSubscription({ deviceId: "device-1", screenshotIntervalMs: 500 });
+      const { socket } = server.simulateSubscription({
+        deviceId: "device-1",
+        screenshotIntervalMs: 500,
+      });
       socket.destroy();
 
       expect(server.getScreenshotIntervalMsForDevice("device-1")).toBe(3000);
@@ -1017,57 +1249,74 @@ describe("DeviceDataStreamSocketServer", () => {
 
     it("notifies when subscribe changes screenshot cadence", async () => {
       const changedDevices: Array<string | null> = [];
-      server.setOnScreenshotCadenceChanged(deviceId => {
+      server.setOnScreenshotCadenceChanged((deviceId) => {
         changedDevices.push(deviceId);
       });
       const socket = new FakeSocket();
 
-      await server.processLineForTest(socket, JSON.stringify({
-        id: "sub-fast",
-        command: "subscribe",
-        deviceId: "device-1",
-        screenshotIntervalMs: 500,
-      }));
+      await server.processLineForTest(
+        socket,
+        JSON.stringify({
+          id: "sub-fast",
+          command: "subscribe",
+          deviceId: "device-1",
+          screenshotIntervalMs: 500,
+        }),
+      );
 
       expect(changedDevices).toEqual(["device-1"]);
     });
 
     it("notifies when unsubscribe removes screenshot cadence", async () => {
       const changedDevices: Array<string | null> = [];
-      server.setOnScreenshotCadenceChanged(deviceId => {
+      server.setOnScreenshotCadenceChanged((deviceId) => {
         changedDevices.push(deviceId);
       });
-      const { socket } = server.simulateSubscription({ deviceId: "device-1", screenshotIntervalMs: 500 });
+      const { socket } = server.simulateSubscription({
+        deviceId: "device-1",
+        screenshotIntervalMs: 500,
+      });
 
-      await server.processLineForTest(socket, JSON.stringify({
-        id: "unsub-fast",
-        command: "unsubscribe",
-      }));
+      await server.processLineForTest(
+        socket,
+        JSON.stringify({
+          id: "unsub-fast",
+          command: "unsubscribe",
+          subscriptionId: "devicedatastream-1",
+        }),
+      );
 
       expect(changedDevices).toEqual(["device-1"]);
     });
 
     it("does not notify when unsubscribe has no active subscription", async () => {
       const changedDevices: Array<string | null> = [];
-      server.setOnScreenshotCadenceChanged(deviceId => {
+      server.setOnScreenshotCadenceChanged((deviceId) => {
         changedDevices.push(deviceId);
       });
       const socket = new FakeSocket();
 
-      await server.processLineForTest(socket, JSON.stringify({
-        id: "unsub-missing",
-        command: "unsubscribe",
-      }));
+      await server.processLineForTest(
+        socket,
+        JSON.stringify({
+          id: "unsub-missing",
+          command: "unsubscribe",
+          subscriptionId: "devicedatastream-missing",
+        }),
+      );
 
       expect(changedDevices).toEqual([]);
     });
 
     it("notifies when connection close removes screenshot cadence", () => {
       const changedDevices: Array<string | null> = [];
-      server.setOnScreenshotCadenceChanged(deviceId => {
+      server.setOnScreenshotCadenceChanged((deviceId) => {
         changedDevices.push(deviceId);
       });
-      const { socket } = server.simulateSubscription({ deviceId: "device-1", screenshotIntervalMs: 500 });
+      const { socket } = server.simulateSubscription({
+        deviceId: "device-1",
+        screenshotIntervalMs: 500,
+      });
 
       server.closeConnectionForTest(socket);
 
@@ -1091,12 +1340,15 @@ describe("DeviceDataStreamSocketServer", () => {
     it("parses requested hierarchy cadence from subscribe commands", async () => {
       const socket = new FakeSocket();
 
-      await server.processLineForTest(socket, JSON.stringify({
-        id: "sub-fast-hierarchy",
-        command: "subscribe",
-        deviceId: "device-1",
-        hierarchyIntervalMs: 500,
-      }));
+      await server.processLineForTest(
+        socket,
+        JSON.stringify({
+          id: "sub-fast-hierarchy",
+          command: "subscribe",
+          deviceId: "device-1",
+          hierarchyIntervalMs: 500,
+        }),
+      );
 
       expect(server.getHierarchyIntervalMsForDevice("device-1")).toBe(500);
     });
@@ -1104,12 +1356,15 @@ describe("DeviceDataStreamSocketServer", () => {
     it("clamps requested hierarchy cadence to the safe minimum", async () => {
       const socket = new FakeSocket();
 
-      await server.processLineForTest(socket, JSON.stringify({
-        id: "sub-clamped-hierarchy",
-        command: "subscribe",
-        deviceId: "device-1",
-        hierarchyIntervalMs: 50,
-      }));
+      await server.processLineForTest(
+        socket,
+        JSON.stringify({
+          id: "sub-clamped-hierarchy",
+          command: "subscribe",
+          deviceId: "device-1",
+          hierarchyIntervalMs: 50,
+        }),
+      );
 
       expect(server.getHierarchyIntervalMsForDevice("device-1")).toBe(250);
     });
@@ -1117,12 +1372,15 @@ describe("DeviceDataStreamSocketServer", () => {
     it("clamps requested hierarchy cadence to the maximum timer delay", async () => {
       const socket = new FakeSocket();
 
-      await server.processLineForTest(socket, JSON.stringify({
-        id: "sub-hierarchy-max-clamped",
-        command: "subscribe",
-        deviceId: "device-1",
-        hierarchyIntervalMs: 3_000_000_000,
-      }));
+      await server.processLineForTest(
+        socket,
+        JSON.stringify({
+          id: "sub-hierarchy-max-clamped",
+          command: "subscribe",
+          deviceId: "device-1",
+          hierarchyIntervalMs: 3_000_000_000,
+        }),
+      );
 
       expect(server.getHierarchyIntervalMsForDevice("device-1")).toBe(2_147_483_647);
     });
@@ -1157,18 +1415,28 @@ describe("DeviceDataStreamSocketServer", () => {
     });
 
     it("removes requested hierarchy cadence after unsubscribe", async () => {
-      const { socket } = server.simulateSubscription({ deviceId: "device-1", hierarchyIntervalMs: 500 });
+      const { socket } = server.simulateSubscription({
+        deviceId: "device-1",
+        hierarchyIntervalMs: 500,
+      });
 
-      await server.processLineForTest(socket, JSON.stringify({
-        id: "unsub-fast-hierarchy",
-        command: "unsubscribe",
-      }));
+      await server.processLineForTest(
+        socket,
+        JSON.stringify({
+          id: "unsub-fast-hierarchy",
+          command: "unsubscribe",
+          subscriptionId: "devicedatastream-1",
+        }),
+      );
 
       expect(server.getHierarchyIntervalMsForDevice("device-1")).toBe(1000);
     });
 
     it("ignores destroyed subscriber sockets when aggregating hierarchy cadence", () => {
-      const { socket } = server.simulateSubscription({ deviceId: "device-1", hierarchyIntervalMs: 500 });
+      const { socket } = server.simulateSubscription({
+        deviceId: "device-1",
+        hierarchyIntervalMs: 500,
+      });
       socket.destroy();
 
       expect(server.getHierarchyIntervalMsForDevice("device-1")).toBe(1000);
@@ -1181,12 +1449,15 @@ describe("DeviceDataStreamSocketServer", () => {
       });
       const socket = new FakeSocket();
 
-      await server.processLineForTest(socket, JSON.stringify({
-        id: "sub-fast-hierarchy",
-        command: "subscribe",
-        deviceId: "device-1",
-        hierarchyIntervalMs: 500,
-      }));
+      await server.processLineForTest(
+        socket,
+        JSON.stringify({
+          id: "sub-fast-hierarchy",
+          command: "subscribe",
+          deviceId: "device-1",
+          hierarchyIntervalMs: 500,
+        }),
+      );
 
       expect(changedDevices).toEqual(["device-1"]);
     });
@@ -1196,12 +1467,19 @@ describe("DeviceDataStreamSocketServer", () => {
       server.setOnHierarchyCadenceChanged((deviceId: string | null) => {
         changedDevices.push(deviceId);
       });
-      const { socket } = server.simulateSubscription({ deviceId: "device-1", hierarchyIntervalMs: 500 });
+      const { socket } = server.simulateSubscription({
+        deviceId: "device-1",
+        hierarchyIntervalMs: 500,
+      });
 
-      await server.processLineForTest(socket, JSON.stringify({
-        id: "unsub-hierarchy-fast",
-        command: "unsubscribe",
-      }));
+      await server.processLineForTest(
+        socket,
+        JSON.stringify({
+          id: "unsub-hierarchy-fast",
+          command: "unsubscribe",
+          subscriptionId: "devicedatastream-1",
+        }),
+      );
 
       expect(changedDevices).toEqual(["device-1"]);
     });
@@ -1211,7 +1489,10 @@ describe("DeviceDataStreamSocketServer", () => {
       server.setOnHierarchyCadenceChanged((deviceId: string | null) => {
         changedDevices.push(deviceId);
       });
-      const { socket } = server.simulateSubscription({ deviceId: "device-1", hierarchyIntervalMs: 500 });
+      const { socket } = server.simulateSubscription({
+        deviceId: "device-1",
+        hierarchyIntervalMs: 500,
+      });
 
       server.closeConnectionForTest(socket);
 
@@ -1222,56 +1503,77 @@ describe("DeviceDataStreamSocketServer", () => {
   describe("update_cadence", () => {
     it("raises the screenshot cadence for an existing subscription in place", async () => {
       const socket = new FakeSocket();
-      await server.processLineForTest(socket, JSON.stringify({
-        id: "sub",
-        command: "subscribe",
-        deviceId: "device-1",
-      }));
+      await server.processLineForTest(
+        socket,
+        JSON.stringify({
+          id: "sub",
+          command: "subscribe",
+          deviceId: "device-1",
+        }),
+      );
       expect(server.getScreenshotIntervalMsForDevice("device-1")).toBe(3000);
 
-      await server.processLineForTest(socket, JSON.stringify({
-        id: "upd",
-        command: "update_cadence",
-        deviceId: "device-1",
-        screenshotIntervalMs: 500,
-      }));
+      await server.processLineForTest(
+        socket,
+        JSON.stringify({
+          id: "upd",
+          command: "update_cadence",
+          subscriptionId: "devicedatastream-1",
+          deviceId: "device-1",
+          screenshotIntervalMs: 500,
+        }),
+      );
 
       expect(server.getScreenshotIntervalMsForDevice("device-1")).toBe(500);
     });
 
     it("does not add a second subscriber when updating cadence", async () => {
       const socket = new FakeSocket();
-      await server.processLineForTest(socket, JSON.stringify({
-        id: "sub",
-        command: "subscribe",
-        deviceId: "device-1",
-      }));
+      await server.processLineForTest(
+        socket,
+        JSON.stringify({
+          id: "sub",
+          command: "subscribe",
+          deviceId: "device-1",
+        }),
+      );
 
-      await server.processLineForTest(socket, JSON.stringify({
-        id: "upd",
-        command: "update_cadence",
-        deviceId: "device-1",
-        screenshotIntervalMs: 500,
-      }));
+      await server.processLineForTest(
+        socket,
+        JSON.stringify({
+          id: "upd",
+          command: "update_cadence",
+          subscriptionId: "devicedatastream-1",
+          deviceId: "device-1",
+          screenshotIntervalMs: 500,
+        }),
+      );
 
       expect((server as any).subscribers.size).toBe(1);
     });
 
     it("relaxes cadence back to the default when the field is omitted", async () => {
       const socket = new FakeSocket();
-      await server.processLineForTest(socket, JSON.stringify({
-        id: "sub",
-        command: "subscribe",
-        deviceId: "device-1",
-        screenshotIntervalMs: 500,
-      }));
+      await server.processLineForTest(
+        socket,
+        JSON.stringify({
+          id: "sub",
+          command: "subscribe",
+          deviceId: "device-1",
+          screenshotIntervalMs: 500,
+        }),
+      );
       expect(server.getScreenshotIntervalMsForDevice("device-1")).toBe(500);
 
-      await server.processLineForTest(socket, JSON.stringify({
-        id: "upd",
-        command: "update_cadence",
-        deviceId: "device-1",
-      }));
+      await server.processLineForTest(
+        socket,
+        JSON.stringify({
+          id: "upd",
+          command: "update_cadence",
+          subscriptionId: "devicedatastream-1",
+          deviceId: "device-1",
+        }),
+      );
 
       expect(server.getScreenshotIntervalMsForDevice("device-1")).toBe(3000);
     });
@@ -1279,23 +1581,30 @@ describe("DeviceDataStreamSocketServer", () => {
     it("clamps the updated hierarchy cadence and notifies both cadence listeners", async () => {
       const changedScreenshot: Array<string | null> = [];
       const changedHierarchy: Array<string | null> = [];
-      server.setOnScreenshotCadenceChanged(deviceId => changedScreenshot.push(deviceId));
-      server.setOnHierarchyCadenceChanged(deviceId => changedHierarchy.push(deviceId));
+      server.setOnScreenshotCadenceChanged((deviceId) => changedScreenshot.push(deviceId));
+      server.setOnHierarchyCadenceChanged((deviceId) => changedHierarchy.push(deviceId));
       const socket = new FakeSocket();
-      await server.processLineForTest(socket, JSON.stringify({
-        id: "sub",
-        command: "subscribe",
-        deviceId: "device-1",
-      }));
+      await server.processLineForTest(
+        socket,
+        JSON.stringify({
+          id: "sub",
+          command: "subscribe",
+          deviceId: "device-1",
+        }),
+      );
       changedScreenshot.length = 0;
       changedHierarchy.length = 0;
 
-      await server.processLineForTest(socket, JSON.stringify({
-        id: "upd",
-        command: "update_cadence",
-        deviceId: "device-1",
-        hierarchyIntervalMs: 50,
-      }));
+      await server.processLineForTest(
+        socket,
+        JSON.stringify({
+          id: "upd",
+          command: "update_cadence",
+          subscriptionId: "devicedatastream-1",
+          deviceId: "device-1",
+          hierarchyIntervalMs: 50,
+        }),
+      );
 
       expect(server.getHierarchyIntervalMsForDevice("device-1")).toBe(250);
       expect(changedScreenshot).toEqual(["device-1"]);
@@ -1304,22 +1613,29 @@ describe("DeviceDataStreamSocketServer", () => {
 
     it("acknowledges update_cadence with a subscription_response", async () => {
       const socket = new FakeSocket();
-      await server.processLineForTest(socket, JSON.stringify({
-        id: "sub",
-        command: "subscribe",
-        deviceId: "device-1",
-      }));
+      await server.processLineForTest(
+        socket,
+        JSON.stringify({
+          id: "sub",
+          command: "subscribe",
+          deviceId: "device-1",
+        }),
+      );
 
-      await server.processLineForTest(socket, JSON.stringify({
-        id: "upd-ack",
-        command: "update_cadence",
-        deviceId: "device-1",
-        screenshotIntervalMs: 500,
-      }));
+      await server.processLineForTest(
+        socket,
+        JSON.stringify({
+          id: "upd-ack",
+          command: "update_cadence",
+          subscriptionId: "devicedatastream-1",
+          deviceId: "device-1",
+          screenshotIntervalMs: 500,
+        }),
+      );
 
       const ack = socket
         .getWrittenMessages<{ id?: string; type: string; success?: boolean }>()
-        .find(message => message.id === "upd-ack");
+        .find((message) => message.id === "upd-ack");
       expect(ack?.type).toBe("subscription_response");
       expect(ack?.success).toBe(true);
     });
@@ -1327,16 +1643,20 @@ describe("DeviceDataStreamSocketServer", () => {
     it("acknowledges update_cadence even when the socket has no active subscription", async () => {
       const socket = new FakeSocket();
 
-      await server.processLineForTest(socket, JSON.stringify({
-        id: "upd-no-sub",
-        command: "update_cadence",
-        deviceId: "device-1",
-        screenshotIntervalMs: 500,
-      }));
+      await server.processLineForTest(
+        socket,
+        JSON.stringify({
+          id: "upd-no-sub",
+          command: "update_cadence",
+          subscriptionId: "devicedatastream-missing",
+          deviceId: "device-1",
+          screenshotIntervalMs: 500,
+        }),
+      );
 
       const ack = socket
         .getWrittenMessages<{ id?: string; type: string; success?: boolean }>()
-        .find(message => message.id === "upd-no-sub");
+        .find((message) => message.id === "upd-no-sub");
       expect(ack?.type).toBe("subscription_response");
       expect(ack?.success).toBe(true);
       expect((server as any).subscribers.size).toBe(0);
@@ -1361,6 +1681,7 @@ describe("DeviceDataStreamSocketServer", () => {
         {
           type: "error",
           success: false,
+          subscriptionId: "devicedatastream-1",
           deviceId: "emulator-5554",
           timestamp: 1234,
           error: "device connection lost",
@@ -1400,7 +1721,15 @@ describe("DeviceDataStreamSocketServer", () => {
           bounds: { left: 0, top: 0, right: 390, bottom: 844 },
           node: {
             $: { class: "UIWindow", bounds: { left: 0, top: 0, right: 390, bottom: 844 } },
-            node: [{ $: { class: "UIButton", text: "Go", bounds: { left: 10, top: 20, right: 100, bottom: 60 } } }],
+            node: [
+              {
+                $: {
+                  class: "UIButton",
+                  text: "Go",
+                  bounds: { left: 10, top: 20, right: 100, bottom: 60 },
+                },
+              },
+            ],
           },
         },
         screenWidth: 390,
@@ -1421,8 +1750,18 @@ describe("DeviceDataStreamSocketServer", () => {
       expect(message.nativeScale).toBe(3);
       expect(message.data.screenWidth).toBe(1170);
       expect(message.data.screenHeight).toBe(2532);
-      expect(message.data.hierarchy.node.$.bounds).toEqual({ left: 0, top: 0, right: 1170, bottom: 2532 });
-      expect(message.data.hierarchy.node.node[0].$.bounds).toEqual({ left: 30, top: 60, right: 300, bottom: 180 });
+      expect(message.data.hierarchy.node.$.bounds).toEqual({
+        left: 0,
+        top: 0,
+        right: 1170,
+        bottom: 2532,
+      });
+      expect(message.data.hierarchy.node.node[0].$.bounds).toEqual({
+        left: 30,
+        top: 60,
+        right: 300,
+        bottom: 180,
+      });
       expect(message.data.hierarchy.bounds).toEqual({ left: 0, top: 0, right: 1170, bottom: 2532 });
     });
 
@@ -1431,7 +1770,12 @@ describe("DeviceDataStreamSocketServer", () => {
       const input = iosFrame();
       server.pushHierarchyUpdate("ios-1", input);
       // The push converts a clone; the object the caller (and MCP observe) holds is untouched.
-      expect(input.data ?? input.hierarchy.node.$.bounds).toEqual({ left: 0, top: 0, right: 390, bottom: 844 });
+      expect(input.data ?? input.hierarchy.node.$.bounds).toEqual({
+        left: 0,
+        top: 0,
+        right: 390,
+        bottom: 844,
+      });
       expect(input.screenWidth).toBe(390);
     });
 
@@ -1448,13 +1792,22 @@ describe("DeviceDataStreamSocketServer", () => {
       expect(message.nativeScale).toBeUndefined();
       // Point-space bounds and dims pass through unchanged.
       expect(message.data.screenWidth).toBe(390);
-      expect(message.data.hierarchy.node.node[0].$.bounds).toEqual({ left: 10, top: 20, right: 100, bottom: 60 });
+      expect(message.data.hierarchy.node.node[0].$.bounds).toEqual({
+        left: 10,
+        top: 20,
+        right: 100,
+        bottom: 60,
+      });
     });
 
     it("Android (nativeScale 1) leaves bounds numerically identical but still declares px", () => {
       const { socket } = server.simulateSubscription({ deviceId: "android-1" });
       const androidFrame = {
-        hierarchy: { node: { $: { class: "FrameLayout", bounds: { left: 0, top: 0, right: 1080, bottom: 2340 } } } },
+        hierarchy: {
+          node: {
+            $: { class: "FrameLayout", bounds: { left: 0, top: 0, right: 1080, bottom: 2340 } },
+          },
+        },
         screenWidth: 1080,
         screenHeight: 2340,
         nativeScale: 1,
@@ -1465,18 +1818,30 @@ describe("DeviceDataStreamSocketServer", () => {
 
       const [message] = socket.getWrittenMessages<any>();
       expect(message.coordinateSpace).toBe("px");
-      expect(message.data.hierarchy.node.$.bounds).toEqual({ left: 0, top: 0, right: 1080, bottom: 2340 });
+      expect(message.data.hierarchy.node.$.bounds).toEqual({
+        left: 0,
+        top: 0,
+        right: 1080,
+        bottom: 2340,
+      });
     });
 
     it("stamps coordinateSpace:px on a screenshot when the caller declares px", () => {
       const { socket } = server.simulateSubscription({ deviceId: "ios-1" });
       const seq = server.pushHierarchyUpdate("ios-1", iosFrame());
-      server.pushScreenshotUpdate("ios-1", pngFrame(1170, 2532), 1170, 2532, {}, {
-        captureSequence: seq ?? undefined,
-        coordinateSpace: "px",
-        nativeScale: 3,
-      });
-      const shot = socket.getWrittenMessages<any>().find(m => m.type === "screenshot_update");
+      server.pushScreenshotUpdate(
+        "ios-1",
+        pngFrame(1170, 2532),
+        1170,
+        2532,
+        {},
+        {
+          captureSequence: seq ?? undefined,
+          coordinateSpace: "px",
+          nativeScale: 3,
+        },
+      );
+      const shot = socket.getWrittenMessages<any>().find((m) => m.type === "screenshot_update");
       expect(shot.coordinateSpace).toBe("px");
       expect(shot.nativeScale).toBe(3);
       expect(shot.captureSequence).toBe(seq);
@@ -1485,7 +1850,7 @@ describe("DeviceDataStreamSocketServer", () => {
     it("omits coordinateSpace on a screenshot from a legacy (non-px) caller", () => {
       const { socket } = server.simulateSubscription({ deviceId: "ios-legacy" });
       server.pushScreenshotUpdate("ios-legacy", pngFrame(1170, 2532), 1170, 2532, {}, {});
-      const shot = socket.getWrittenMessages<any>().find(m => m.type === "screenshot_update");
+      const shot = socket.getWrittenMessages<any>().find((m) => m.type === "screenshot_update");
       expect(shot.coordinateSpace).toBeUndefined();
       expect(shot.nativeScale).toBeUndefined();
     });
@@ -1498,7 +1863,9 @@ describe("DeviceDataStreamSocketServer", () => {
     // frame's measured pixels are consistent with the claimed geometry (exact match or swapped
     // orientation — never a scale change, never an unmeasurable frame).
     const goldenFrame = (text: string) =>
-      ({ hierarchy: { node: { $: { class: "Root" }, node: [{ $: { class: "Child", text } }] } } }) as any;
+      ({
+        hierarchy: { node: { $: { class: "Root" }, node: [{ $: { class: "Child", text } }] } },
+      }) as any;
 
     const vectors = loadCoordinateMappingVectors().geometryPairing;
 
@@ -1518,10 +1885,12 @@ describe("DeviceDataStreamSocketServer", () => {
           vector.claimedWidth,
           vector.claimedHeight,
           {},
-          { captureSequence: captureSequence ?? undefined }
+          { captureSequence: captureSequence ?? undefined },
         );
 
-        const screenshot = socket.getWrittenMessages<any>().find(m => m.type === "screenshot_update");
+        const screenshot = socket
+          .getWrittenMessages<any>()
+          .find((m) => m.type === "screenshot_update");
         if (vector.expectedMatch === 1) {
           expect(screenshot.captureSequence).toBe(captureSequence);
         } else {

--- a/test/daemon/socketServer/PushSubscriptionSocketServer.test.ts
+++ b/test/daemon/socketServer/PushSubscriptionSocketServer.test.ts
@@ -22,9 +22,13 @@ interface TestPushMessage {
   type: "test_push";
   data: TestPushData;
   timestamp: number;
+  subscriptionId: string;
 }
 
-class TestablePushSubscriptionServer extends PushSubscriptionSocketServer<TestFilter, TestPushData> {
+class TestablePushSubscriptionServer extends PushSubscriptionSocketServer<
+  TestFilter,
+  TestPushData
+> {
   constructor(timer: FakeTimer) {
     super("/fake/path/test.sock", timer, "TestPush");
   }
@@ -48,10 +52,10 @@ class TestablePushSubscriptionServer extends PushSubscriptionSocketServer<TestFi
   /**
    * Simulate a client connection and subscription
    */
-  simulateSubscription(options: {
-    deviceId?: string;
-    packageName?: string;
-  }): { socket: FakeSocket; subscriptionId: string } {
+  simulateSubscription(options: { deviceId?: string; packageName?: string }): {
+    socket: FakeSocket;
+    subscriptionId: string;
+  } {
     const socket = new FakeSocket();
     const subscriptionId = `testpush-${++(this as any).subscriptionCounter}`;
     const timer = (this as any).timer as FakeTimer;
@@ -81,6 +85,10 @@ class TestablePushSubscriptionServer extends PushSubscriptionSocketServer<TestFi
     await (this as any).processLine(socket as unknown as Socket, line);
   }
 
+  closeConnectionForTest(socket: FakeSocket): void {
+    (this as any).onConnectionClose(socket as unknown as Socket);
+  }
+
   /**
    * Trigger keepalive check
    */
@@ -108,11 +116,12 @@ class TestablePushSubscriptionServer extends PushSubscriptionSocketServer<TestFi
     return matchesDevice && matchesPackage;
   }
 
-  protected createPushMessage(data: TestPushData): TestPushMessage {
+  protected createPushMessage(data: TestPushData, subscriptionId: string): TestPushMessage {
     return {
       type: "test_push",
       data,
       timestamp: (this as any).timer.now(),
+      subscriptionId,
     };
   }
 }
@@ -231,7 +240,7 @@ describe("PushSubscriptionSocketServer", () => {
       server.triggerKeepalive();
 
       const messages = socket.getWrittenMessages<{ type: string }>();
-      expect(messages.some(m => m.type === "ping")).toBe(true);
+      expect(messages.some((m) => m.type === "ping")).toBe(true);
     });
 
     it("removes subscribers with destroyed sockets", () => {
@@ -258,6 +267,7 @@ describe("PushSubscriptionSocketServer", () => {
       expect(messages[0].type).toBe("test_push");
       expect(messages[0].data).toEqual(data);
       expect(messages[0].timestamp).toBe(12345);
+      expect(messages[0].subscriptionId).toBe("testpush-1");
     });
   });
 
@@ -390,7 +400,7 @@ describe("PushSubscriptionSocketServer", () => {
 
       await server.simulateLine(
         socket,
-        JSON.stringify({ command: "subscribe", id: "req-1", deviceId: "device-1" })
+        JSON.stringify({ command: "subscribe", id: "req-1", deviceId: "device-1" }),
       );
 
       expect(server.getSubscriberCount()).toBe(1);
@@ -401,7 +411,115 @@ describe("PushSubscriptionSocketServer", () => {
         id: "req-1",
         type: "subscription_response",
         success: true,
+        subscriptionId: "testpush-1",
       });
+    });
+
+    it("multiplexes independently filtered subscriptions on one connection", async () => {
+      const socket = new FakeSocket();
+      await server.simulateLine(
+        socket,
+        JSON.stringify({
+          command: "subscribe",
+          id: "device-1",
+          deviceId: "device-1",
+        }),
+      );
+      await server.simulateLine(
+        socket,
+        JSON.stringify({
+          command: "subscribe",
+          id: "device-2",
+          deviceId: "device-2",
+        }),
+      );
+
+      expect(server.getSubscriberCount()).toBe(2);
+      expect(socket.getWrittenMessages<SubscriptionResponse>()).toMatchObject([
+        { id: "device-1", type: "subscription_response", subscriptionId: "testpush-1" },
+        { id: "device-2", type: "subscription_response", subscriptionId: "testpush-2" },
+      ]);
+
+      server.pushData({ deviceId: "device-1", packageName: "com.app", value: 1 });
+      server.pushData({ deviceId: "device-2", packageName: "com.app", value: 2 });
+
+      expect(socket.getWrittenMessages<TestPushMessage>().slice(2)).toMatchObject([
+        { type: "test_push", subscriptionId: "testpush-1", data: { value: 1 } },
+        { type: "test_push", subscriptionId: "testpush-2", data: { value: 2 } },
+      ]);
+    });
+
+    it("unsubscribes only the addressed subscription on a multiplexed connection", async () => {
+      const socket = new FakeSocket();
+      await server.simulateLine(
+        socket,
+        JSON.stringify({
+          command: "subscribe",
+          id: "device-1",
+          deviceId: "device-1",
+        }),
+      );
+      await server.simulateLine(
+        socket,
+        JSON.stringify({
+          command: "subscribe",
+          id: "device-2",
+          deviceId: "device-2",
+        }),
+      );
+
+      await server.simulateLine(
+        socket,
+        JSON.stringify({
+          command: "unsubscribe",
+          id: "remove-device-1",
+          subscriptionId: "testpush-1",
+        }),
+      );
+
+      expect(server.getSubscriberCount()).toBe(1);
+      server.pushData({ deviceId: "device-1", packageName: "com.app", value: 1 });
+      server.pushData({ deviceId: "device-2", packageName: "com.app", value: 2 });
+      expect(socket.getWrittenMessages<TestPushMessage>().slice(-1)).toMatchObject([
+        { type: "test_push", subscriptionId: "testpush-2", data: { value: 2 } },
+      ]);
+    });
+
+    it("removes every subscription when a multiplexed connection closes", async () => {
+      const socket = new FakeSocket();
+      await server.simulateLine(socket, JSON.stringify({ command: "subscribe", id: "first" }));
+      await server.simulateLine(socket, JSON.stringify({ command: "subscribe", id: "second" }));
+      expect(server.getSubscriberCount()).toBe(2);
+
+      server.closeConnectionForTest(socket);
+
+      expect(server.getSubscriberCount()).toBe(0);
+    });
+
+    it("sends one keepalive ping per multiplexed connection", async () => {
+      const socket = new FakeSocket();
+      await server.simulateLine(socket, JSON.stringify({ command: "subscribe", id: "first" }));
+      await server.simulateLine(socket, JSON.stringify({ command: "subscribe", id: "second" }));
+
+      server.triggerKeepalive();
+
+      expect(
+        socket
+          .getWrittenMessages<SubscriptionResponse>()
+          .filter((message) => message.type === "ping"),
+      ).toHaveLength(1);
+    });
+
+    it("reaps every subscription when a multiplexed connection stops responding", async () => {
+      const socket = new FakeSocket();
+      await server.simulateLine(socket, JSON.stringify({ command: "subscribe", id: "first" }));
+      await server.simulateLine(socket, JSON.stringify({ command: "subscribe", id: "second" }));
+
+      timer.advanceTimersByTime(31_000);
+      server.triggerKeepalive();
+
+      expect(server.getSubscriberCount()).toBe(0);
+      expect(socket.destroyed).toBe(true);
     });
 
     it("returns a typed error for an unknown command over the wire", async () => {

--- a/test/daemon/telemetryPushSocketServer.test.ts
+++ b/test/daemon/telemetryPushSocketServer.test.ts
@@ -501,7 +501,7 @@ describe("TelemetryPushSocketServer", () => {
  * again without a red test.
  */
 describe("TelemetryPushSocketServer failure backfill (#4209)", () => {
-  it("carries the originating session id on backfilled crash events", async () => {
+  it("applies the session filter before limiting backfilled crash events", async () => {
     await withInMemorySingletonDatabase(async () => {
       const db = getDatabase() as unknown as Kysely<Database>;
       await runMigrations(db as unknown as Kysely<unknown>);
@@ -542,6 +542,27 @@ describe("TelemetryPushSocketServer failure backfill (#4209)", () => {
           duration_ms: null,
           tool_args_json: null,
         })
+        .execute();
+      await db
+        .insertInto("failure_occurrences")
+        .values(
+          Array.from({ length: 100 }, (_, index) => ({
+            id: `occ-other-${index}`,
+            group_id: "group-1",
+            timestamp: 2000 + index,
+            device_id: "emulator-5554",
+            device_model: "Pixel",
+            os: "34",
+            app_version: "1.0.0",
+            session_id: "session-other",
+            screen_at_failure: "MainActivity",
+            test_name: null,
+            test_execution_id: null,
+            error_code: null,
+            duration_ms: null,
+            tool_args_json: null,
+          })),
+        )
         .execute();
 
       const server = new TestableTelemetryPushSocketServer(new FakeTimer());

--- a/test/daemon/telemetryPushSocketServer.test.ts
+++ b/test/daemon/telemetryPushSocketServer.test.ts
@@ -33,10 +33,10 @@ class TestableTelemetryPushSocketServer extends TelemetryPushSocketServer {
     (this as any).server = null;
   }
 
-  simulateSubscription(options: {
-    category?: string | null;
-    deviceId?: string | null;
-  }): { socket: FakeSocket; subscriptionId: string } {
+  simulateSubscription(options: { category?: string | null; deviceId?: string | null }): {
+    socket: FakeSocket;
+    subscriptionId: string;
+  } {
     const socket = new FakeSocket();
     const subscriptionId = `telemetrypush-${++(this as any).subscriptionCounter}`;
     const timer = (this as any).timer as FakeTimer;
@@ -140,7 +140,8 @@ describe("boundBackfillEventText", () => {
     };
     const bounded = boundBackfillEventText(event);
     const details = (bounded.data as { details: unknown }).details as {
-      _truncated: boolean; bytes: number;
+      _truncated: boolean;
+      bytes: number;
     };
     expect(details._truncated).toBe(true);
     expect(details.bytes).toBe(JSON.stringify(bigDetails).length);
@@ -170,7 +171,8 @@ describe("boundBackfillEventText", () => {
     };
     const bounded = boundBackfillEventText(event);
     const dj = (bounded.data as { detailsJson: unknown }).detailsJson as {
-      _truncated: boolean; bytes: number;
+      _truncated: boolean;
+      bytes: number;
     };
     expect(dj._truncated).toBe(true);
     expect(dj.bytes).toBe(raw.length);
@@ -196,7 +198,10 @@ describe("boundStructuredField", () => {
   });
 
   it("keeps a within-budget stack trace array unchanged", () => {
-    const frames = [{ className: "A", line: 1 }, { className: "B", line: 2 }];
+    const frames = [
+      { className: "A", line: 1 },
+      { className: "B", line: 2 },
+    ];
     expect(boundStructuredField(frames, false)).toBe(frames);
   });
 
@@ -207,7 +212,8 @@ describe("boundStructuredField", () => {
       line: i,
     }));
     const bounded = boundStructuredField(frames, false) as {
-      _truncated: boolean; bytes: number;
+      _truncated: boolean;
+      bytes: number;
     };
     expect(bounded._truncated).toBe(true);
     expect(bounded.bytes).toBe(JSON.stringify(frames).length);
@@ -397,7 +403,11 @@ describe("TelemetryPushSocketServer", () => {
 
     server.pushTelemetryEvent(event);
 
-    const msgs = socket.getWrittenMessages<{ type: string; timestamp: number; data?: TelemetryEvent }>();
+    const msgs = socket.getWrittenMessages<{
+      type: string;
+      timestamp: number;
+      data?: TelemetryEvent;
+    }>();
     expect(msgs[0].timestamp).toBe(99999);
     expect(msgs[0].data?.timestamp).toBe(50000);
   });
@@ -536,16 +546,46 @@ describe("TelemetryPushSocketServer failure backfill (#4209)", () => {
 
       const server = new TestableTelemetryPushSocketServer(new FakeTimer());
       const socket = new FakeSocket();
+      (server as any).subscribers.set("backfill-test", {
+        socket: socket as unknown as Socket,
+        subscriptionId: "backfill-test",
+        lastActivity: 0,
+        filter: { category: "crash", deviceId: "emulator-5554", sessionId: "session-abc" },
+        backfilling: true,
+        drainPending: false,
+      });
 
       await (server as any).backfillRecentEvents(
-        { category: "crash", deviceId: "emulator-5554", sessionId: null },
-        socket as unknown as Socket
+        "backfill-test",
+        { category: "crash", deviceId: "emulator-5554", sessionId: "session-abc" },
+        socket as unknown as Socket,
       );
 
-      const messages = socket.getWrittenMessages<{ data: TelemetryEvent }>();
-      const crash = messages.find(m => m.data.category === "crash");
+      const messages = socket.getWrittenMessages<{ data: TelemetryEvent; subscriptionId: string }>();
+      const crash = messages.find((m) => m.data.category === "crash");
       expect(crash).toBeDefined();
       expect(crash!.data.sessionId).toBe("session-abc");
+      expect(crash!.subscriptionId).toBe("backfill-test");
+
+      socket.reset();
+      (server as any).subscribers.set("backfill-test", {
+        socket: socket as unknown as Socket,
+        subscriptionId: "backfill-test",
+        lastActivity: 0,
+        filter: { category: "crash", deviceId: "emulator-5554", sessionId: "session-abc" },
+        backfilling: true,
+        drainPending: false,
+      });
+      const backfill = (server as any).backfillRecentEvents(
+        "backfill-test",
+        { category: "crash", deviceId: "emulator-5554", sessionId: "session-abc" },
+        socket as unknown as Socket,
+      );
+      (server as any).subscribers.delete("backfill-test");
+
+      await backfill;
+
+      expect(socket.getWrittenMessages()).toHaveLength(0);
     });
   });
 });


### PR DESCRIPTION
## Summary

Rekeys daemon push subscriptions by server-minted `subscriptionId`, allowing one Unix-socket
connection to carry independently filtered subscriptions. Each emitted frame carries its producing
subscription ID; keepalive is now connection-scoped, and disconnect/reap tears down every subscription
on that connection.

The observation, telemetry, performance, and failure streams now share this multiplexed contract.
Telemetry backfill keeps its subscription ID, honors session filters, and stops if its subscription is
removed while queries are in flight.

## Linked Issue

Closes [#5258](https://github.com/kaeawc/auto-mobile/issues/5258)

## Validation

- [x] Focused push-stream, observation-stream, telemetry-backfill, and performance-monitor tests
- [x] `bun test` — 13,393 pass, 0 fail, 13 real-device/integration skips
- [x] `bun run lint`
- [x] `bun run build`
- [x] `bun run typecheck` — no new errors; baseline ratcheted from 185 to 184
- [x] `bash scripts/all_fast_validate_checks.sh` — 33/33 pass

## Device Verification

N/A — daemon socket protocol change covered by deterministic fake-socket and `FakeTimer` tests.

## Follow-ups

The remaining device-session routing work stays in the parent [epic #5256](https://github.com/kaeawc/auto-mobile/issues/5256).
