### PR TITLE
fix(startDevice): bound progress callbacks

### DIFF
--- a/src/utils/deviceBootService.ts
+++ b/src/utils/deviceBootService.ts
@@ -418,8 +418,9 @@ export class DeviceBootService {
       ? new Promise<never>((_resolve, reject) => {
           const rejectForAbort = () => {
             reject(
-              externalSignal.reason ??
-                new ActionableError(`startDevice request cancelled while ${phase}`),
+              externalSignal.reason === undefined
+                ? new ActionableError(`startDevice request cancelled while ${phase}`)
+                : externalSignal.reason,
             );
           };
           if (externalSignal.aborted) {
@@ -473,7 +474,10 @@ export class DeviceBootService {
 
   private throwExternalAbortReason(signal: AbortSignal | undefined, phase: string): void {
     if (signal?.aborted) {
-      throw signal.reason ?? new ActionableError(`startDevice cancelled while ${phase}`);
+      if (signal.reason === undefined) {
+        throw new ActionableError(`startDevice cancelled while ${phase}`);
+      }
+      throw signal.reason;
     }
   }
 

--- a/src/utils/deviceBootService.ts
+++ b/src/utils/deviceBootService.ts
@@ -454,6 +454,7 @@ export class DeviceBootService {
         operationPromise,
         awaitAbortSettlement && (controller.signal.aborted || externalSignal?.aborted === true),
       );
+      this.throwExternalAbortReason(externalSignal, phase);
       cancellation.throwIfCancelled();
       if (controller.signal.aborted) {
         throw new ActionableError(
@@ -467,6 +468,12 @@ export class DeviceBootService {
       }
       cancellation.dispose();
       removeExternalAbortListener?.();
+    }
+  }
+
+  private throwExternalAbortReason(signal: AbortSignal | undefined, phase: string): void {
+    if (signal?.aborted) {
+      throw signal.reason ?? new ActionableError(`startDevice cancelled while ${phase}`);
     }
   }
 

--- a/src/utils/deviceBootService.ts
+++ b/src/utils/deviceBootService.ts
@@ -13,7 +13,6 @@ import type { DeviceProvisioner } from "./deviceProvisioning";
 import { NoopDeviceBootRecovery, type DeviceBootRecovery } from "./deviceBootRecovery";
 import { defaultTimer, type Timer } from "./SystemTimer";
 import { runWithAbortSignal } from "./AbortContext";
-import { logger } from "./logger";
 
 const ABORT_SETTLEMENT_GRACE_MS = 1_000;
 
@@ -402,15 +401,35 @@ export class DeviceBootService {
     const cancellation = createPhaseCancellation(context.signal, phase);
     cancellation.throwIfCancelled();
     const controller = new AbortController();
-    const signal = context.signal
-      ? AbortSignal.any([context.signal, controller.signal])
+    const externalSignal = context.signal;
+    const signal = externalSignal
+      ? AbortSignal.any([externalSignal, controller.signal])
       : controller.signal;
     let timeoutHandle: NodeJS.Timeout | undefined;
+    let removeExternalAbortListener: (() => void) | undefined;
+    const externalAbortPromise = externalSignal
+      ? new Promise<never>((_resolve, reject) => {
+          const rejectForAbort = () => {
+            reject(
+              externalSignal.reason ??
+                new ActionableError(`startDevice request cancelled while ${phase}`),
+            );
+          };
+          if (externalSignal.aborted) {
+            rejectForAbort();
+            return;
+          }
+          externalSignal.addEventListener("abort", rejectForAbort, { once: true });
+          removeExternalAbortListener = () =>
+            externalSignal.removeEventListener("abort", rejectForAbort);
+        })
+      : undefined;
     const operationPromise = runWithAbortSignal(signal, () => operation(signal));
     void operationPromise.catch(() => {});
     try {
       return await Promise.race([
         operationPromise,
+        ...(externalAbortPromise ? [externalAbortPromise] : []),
         new Promise<never>((_resolve, reject) => {
           timeoutHandle = this.timer.setTimeout(() => {
             controller.abort(new Error(`startDevice timeout exhausted while ${phase}`));
@@ -439,6 +458,7 @@ export class DeviceBootService {
         this.timer.clearTimeout(timeoutHandle);
       }
       cancellation.dispose();
+      removeExternalAbortListener?.();
     }
   }
 

--- a/src/utils/deviceBootService.ts
+++ b/src/utils/deviceBootService.ts
@@ -7,7 +7,11 @@ import type {
   MatchingStrategy,
 } from "../models/DeviceMatchCriteria";
 import type { DeviceCreationGate } from "./deviceCreationGate";
-import { DEFAULT_DEVICE_READY_TIMEOUT_MS, type PlatformDeviceManager } from "./deviceUtils";
+import {
+  DEFAULT_DEVICE_READY_TIMEOUT_MS,
+  type PlatformDeviceManager,
+  waitForDeviceReadyOrCancel,
+} from "./deviceUtils";
 import type { DeviceMatcher } from "./deviceMatcher";
 import type { DeviceProvisioner } from "./deviceProvisioning";
 import { NoopDeviceBootRecovery, type DeviceBootRecovery } from "./deviceBootRecovery";
@@ -195,8 +199,11 @@ export class DeviceBootService {
     if (request.preferRunning === false) {
       return undefined;
     }
-    const booted = await this.runPhase(context, "discovering running devices", () =>
-      this.dependencies.deviceManager.getBootedDevices(request.platform),
+    const booted = await this.runPhase(
+      context,
+      "discovering running devices",
+      () => this.dependencies.deviceManager.getBootedDevices(request.platform),
+      false,
     );
     const match = this.dependencies.deviceMatcher.matchBootedDevice(
       criteria,
@@ -443,11 +450,12 @@ export class DeviceBootService {
         cancellation.promise,
       ]);
     } catch (error) {
+      await this.awaitAbortSettlementIfNeeded(
+        operationPromise,
+        awaitAbortSettlement && (controller.signal.aborted || externalSignal?.aborted === true),
+      );
       cancellation.throwIfCancelled();
       if (controller.signal.aborted) {
-        if (awaitAbortSettlement) {
-          await this.awaitAbortSettlement(operationPromise);
-        }
         throw new ActionableError(
           `startDevice timeout exhausted while ${phase}; remainingBudgetMs=0`,
         );
@@ -459,6 +467,15 @@ export class DeviceBootService {
       }
       cancellation.dispose();
       removeExternalAbortListener?.();
+    }
+  }
+
+  private async awaitAbortSettlementIfNeeded(
+    operation: Promise<unknown>,
+    shouldAwait: boolean,
+  ): Promise<void> {
+    if (shouldAwait) {
+      await this.awaitAbortSettlement(operation);
     }
   }
 

--- a/src/utils/deviceBootService.ts
+++ b/src/utils/deviceBootService.ts
@@ -7,16 +7,13 @@ import type {
   MatchingStrategy,
 } from "../models/DeviceMatchCriteria";
 import type { DeviceCreationGate } from "./deviceCreationGate";
-import {
-  DEFAULT_DEVICE_READY_TIMEOUT_MS,
-  type PlatformDeviceManager,
-  waitForDeviceReadyOrCancel,
-} from "./deviceUtils";
+import { DEFAULT_DEVICE_READY_TIMEOUT_MS, type PlatformDeviceManager } from "./deviceUtils";
 import type { DeviceMatcher } from "./deviceMatcher";
 import type { DeviceProvisioner } from "./deviceProvisioning";
 import { NoopDeviceBootRecovery, type DeviceBootRecovery } from "./deviceBootRecovery";
 import { defaultTimer, type Timer } from "./SystemTimer";
 import { runWithAbortSignal } from "./AbortContext";
+import { logger } from "./logger";
 
 const ABORT_SETTLEMENT_GRACE_MS = 1_000;
 
@@ -210,11 +207,7 @@ export class DeviceBootService {
     if (!match) {
       return undefined;
     }
-    if (progress) {
-      await this.runPhase(context, "reporting matching device progress", async () =>
-        progress.report(100, 100, "Found matching running device"),
-      );
-    }
+    await this.reportProgress(context, progress, 100, "Found matching running device");
     return this.waitForRunningDevice(match, context, progress);
   }
 
@@ -343,11 +336,7 @@ export class DeviceBootService {
     };
     context.signal?.addEventListener("abort", cancelHandle, { once: true });
     try {
-      if (progress) {
-        await this.runPhase(context, "reporting device start progress", async () =>
-          progress.report(60, 100, "Device started, waiting for readiness..."),
-        );
-      }
+      await this.reportProgress(context, progress, 60, "Device started, waiting for readiness...");
       const ready = await this.runPhase(context, "waiting for device boot readiness", (signal) =>
         waitForDeviceReadyOrCancel(
           this.dependencies.deviceManager,
@@ -359,11 +348,7 @@ export class DeviceBootService {
           cancelHandle,
         ),
       );
-      if (progress) {
-        await this.runPhase(context, "reporting device readiness progress", async () =>
-          progress.report(100, 100, "Device is ready for use"),
-        );
-      }
+      await this.reportProgress(context, progress, 100, "Device is ready for use");
       return {
         device: enrichBootedDevice(ready, image),
         source: "cold-boot",
@@ -380,6 +365,23 @@ export class DeviceBootService {
     }
   }
 
+  private async reportProgress(
+    context: BootDeadlineContext,
+    progress: DeviceBootProgress | undefined,
+    current: number,
+    message: string,
+  ): Promise<void> {
+    if (!progress) {
+      return;
+    }
+    await this.runPhase(
+      context,
+      `reporting ${current}% device boot progress`,
+      () => progress.report(current, 100, message),
+      false,
+    );
+  }
+
   private remaining(deadlineMs: number, phase: string): number {
     const remainingMs = Math.floor(deadlineMs - this.timer.now());
     if (remainingMs <= 0) {
@@ -394,6 +396,7 @@ export class DeviceBootService {
     context: BootDeadlineContext,
     phase: string,
     operation: (signal: AbortSignal) => Promise<T>,
+    awaitAbortSettlement = true,
   ): Promise<T> {
     const remainingMs = this.remaining(context.deadlineMs, phase);
     const cancellation = createPhaseCancellation(context.signal, phase);
@@ -423,7 +426,9 @@ export class DeviceBootService {
     } catch (error) {
       cancellation.throwIfCancelled();
       if (controller.signal.aborted) {
-        await this.awaitAbortSettlement(operationPromise);
+        if (awaitAbortSettlement) {
+          await this.awaitAbortSettlement(operationPromise);
+        }
         throw new ActionableError(
           `startDevice timeout exhausted while ${phase}; remainingBudgetMs=0`,
         );

--- a/test/utils/deviceBootService.test.ts
+++ b/test/utils/deviceBootService.test.ts
@@ -334,8 +334,8 @@ describe("DeviceBootService", () => {
     await startStarted;
     controller.abort();
 
-    await expect(boot).rejects.toThrow("startDevice cancelled while starting the device");
     resolveStart(handle);
+    await expect(boot).rejects.toThrow("startDevice cancelled while starting the device");
     await Promise.resolve();
     await Promise.resolve();
 
@@ -419,7 +419,7 @@ describe("DeviceBootService", () => {
     resolveProgress();
 
     await expect(boot).rejects.toThrow(
-      "startDevice cancelled while reporting device start progress",
+      "startDevice cancelled while reporting 60% device boot progress",
     );
     expect(killCount).toBe(1);
     expect(devices.wasMethodCalled("waitForDeviceReady")).toBe(false);
@@ -464,12 +464,62 @@ describe("DeviceBootService", () => {
     controller.abort();
 
     await expect(boot).rejects.toThrow(
-      "startDevice cancelled while reporting device readiness progress",
+      "startDevice cancelled while reporting 100% device boot progress",
     );
     resolveFinalProgress();
     await Promise.resolve();
 
     expect(killCount).toBe(1);
+  });
+
+  it("awaits cancellation-aware provisioning before returning an external abort", async () => {
+    const devices = new FakeDeviceUtils();
+    const timer = new FakeTimer();
+    const controller = new AbortController();
+    let provisionSettled = false;
+    let outcome: "pending" | "rejected" = "pending";
+    const bootService = new DeviceBootService({
+      deviceManager: devices,
+      deviceMatcher: new FakeDeviceMatcher(),
+      deviceCreationGate: { isCreationAllowed: () => true, describeSource: () => "test" },
+      deviceProvisioner: {
+        provision: async (_criteria, signal) => {
+          await new Promise<void>((_resolve, reject) => {
+            signal?.addEventListener(
+              "abort",
+              () => {
+                timer.setTimeout(() => {
+                  provisionSettled = true;
+                  reject(signal.reason);
+                }, 250);
+              },
+              { once: true },
+            );
+          });
+          throw new Error("unexpected provision completion");
+        },
+      },
+      matchingStrategy: "LATEST",
+      timer,
+    });
+
+    const boot = bootService.boot({
+      platform: "android",
+      createIfMissing: true,
+      signal: controller.signal,
+    });
+    void boot.catch(() => {
+      outcome = "rejected";
+    });
+
+    await new Promise<void>((resolve) => setImmediate(resolve));
+    controller.abort(new Error("request cancelled"));
+    await new Promise<void>((resolve) => setImmediate(resolve));
+
+    expect(outcome).toBe("pending");
+    timer.advanceTime(250);
+    await expect(boot).rejects.toThrow("startDevice cancelled while provisioning a device");
+    expect(provisionSettled).toBe(true);
   });
 
   it("adopts and awaits a matching running device", async () => {

--- a/test/utils/deviceBootService.test.ts
+++ b/test/utils/deviceBootService.test.ts
@@ -122,6 +122,47 @@ describe("DeviceBootService", () => {
     expect(killCount).toBe(1);
   });
 
+  it("cancels the owned process when a pending progress callback is externally aborted", async () => {
+    const devices = new FakeDeviceUtils();
+    const matcher = new FakeDeviceMatcher();
+    const controller = new AbortController();
+    let killCount = 0;
+    let progressStarted = false;
+    let outcome: "pending" | "rejected" = "pending";
+    devices.setDeviceImages("android", [image]);
+    matcher.setImageResult(image);
+    devices.setMockChildProcess(image.name, {
+      kill: () => {
+        killCount++;
+        return true;
+      },
+      pid: 12,
+    } as any);
+
+    const boot = service(devices, matcher).boot(
+      { platform: "android", signal: controller.signal },
+      {
+        report: async (current) => {
+          if (current === 60) {
+            progressStarted = true;
+            await new Promise<void>(() => {});
+          }
+        },
+      },
+    );
+    void boot.catch(() => {
+      outcome = "rejected";
+    });
+
+    await new Promise<void>((resolve) => setImmediate(resolve));
+    expect(progressStarted).toBe(true);
+    controller.abort(new Error("request cancelled"));
+    await new Promise<void>((resolve) => setImmediate(resolve));
+
+    expect(outcome).toBe("rejected");
+    expect(killCount).toBe(1);
+  });
+
   it("cancels the owned process when final progress reporting fails", async () => {
     const devices = new FakeDeviceUtils();
     const matcher = new FakeDeviceMatcher();

--- a/test/utils/deviceBootService.test.ts
+++ b/test/utils/deviceBootService.test.ts
@@ -295,7 +295,7 @@ describe("DeviceBootService", () => {
     await discoveryStarted;
     controller.abort();
 
-    await expect(boot).rejects.toThrow("startDevice cancelled while discovering running devices");
+    await expect(boot).rejects.toBe(controller.signal.reason);
     resolveDiscovery([running]);
     await Promise.resolve();
 
@@ -335,7 +335,7 @@ describe("DeviceBootService", () => {
     controller.abort();
 
     resolveStart(handle);
-    await expect(boot).rejects.toThrow("startDevice cancelled while starting the device");
+    await expect(boot).rejects.toBe(controller.signal.reason);
     await Promise.resolve();
     await Promise.resolve();
 
@@ -347,6 +347,7 @@ describe("DeviceBootService", () => {
     const devices = new FakeDeviceUtils();
     const matcher = new FakeDeviceMatcher();
     const controller = new AbortController();
+    const abortReason = new Error("request cancelled");
     let resolveStart!: (handle: ChildProcess | null) => void;
     let markStartStarted!: () => void;
     const startStarted = new Promise<void>((resolve) => {
@@ -373,9 +374,9 @@ describe("DeviceBootService", () => {
     const boot = service(devices, matcher).boot({ platform: "android", signal: controller.signal });
     await startStarted;
     resolveStart(handle);
-    queueMicrotask(() => controller.abort());
+    queueMicrotask(() => controller.abort(abortReason));
 
-    await expect(boot).rejects.toThrow("startDevice cancelled while starting the device");
+    await expect(boot).rejects.toBe(abortReason);
 
     expect(killCount).toBe(1);
     expect(devices.wasMethodCalled("waitForDeviceReady")).toBe(false);
@@ -418,9 +419,7 @@ describe("DeviceBootService", () => {
     controller.abort();
     resolveProgress();
 
-    await expect(boot).rejects.toThrow(
-      "startDevice cancelled while reporting 60% device boot progress",
-    );
+    await expect(boot).rejects.toBe(controller.signal.reason);
     expect(killCount).toBe(1);
     expect(devices.wasMethodCalled("waitForDeviceReady")).toBe(false);
   });
@@ -463,9 +462,7 @@ describe("DeviceBootService", () => {
     await finalProgressStarted;
     controller.abort();
 
-    await expect(boot).rejects.toThrow(
-      "startDevice cancelled while reporting 100% device boot progress",
-    );
+    await expect(boot).rejects.toBe(controller.signal.reason);
     resolveFinalProgress();
     await Promise.resolve();
 
@@ -476,6 +473,7 @@ describe("DeviceBootService", () => {
     const devices = new FakeDeviceUtils();
     const timer = new FakeTimer();
     const controller = new AbortController();
+    const abortReason = new Error("request cancelled");
     let provisionSettled = false;
     let outcome: "pending" | "rejected" = "pending";
     const bootService = new DeviceBootService({
@@ -513,12 +511,12 @@ describe("DeviceBootService", () => {
     });
 
     await new Promise<void>((resolve) => setImmediate(resolve));
-    controller.abort(new Error("request cancelled"));
+    controller.abort(abortReason);
     await new Promise<void>((resolve) => setImmediate(resolve));
 
     expect(outcome).toBe("pending");
     timer.advanceTime(250);
-    await expect(boot).rejects.toThrow("startDevice cancelled while provisioning a device");
+    await expect(boot).rejects.toBe(abortReason);
     expect(provisionSettled).toBe(true);
   });
 

--- a/test/utils/deviceBootService.test.ts
+++ b/test/utils/deviceBootService.test.ts
@@ -163,6 +163,42 @@ describe("DeviceBootService", () => {
     expect(killCount).toBe(1);
   });
 
+  it("preserves an explicit null abort reason instead of substituting an error", async () => {
+    const devices = new FakeDeviceUtils();
+    const matcher = new FakeDeviceMatcher();
+    const controller = new AbortController();
+    let progressStarted = false;
+    let rejection: unknown = "unset";
+    devices.setDeviceImages("android", [image]);
+    matcher.setImageResult(image);
+    devices.setMockChildProcess(image.name, {
+      kill: () => true,
+      pid: 12,
+    } as any);
+
+    const boot = service(devices, matcher).boot(
+      { platform: "android", signal: controller.signal },
+      {
+        report: async (current) => {
+          if (current === 60) {
+            progressStarted = true;
+            await new Promise<void>(() => {});
+          }
+        },
+      },
+    );
+    void boot.catch((error: unknown) => {
+      rejection = error;
+    });
+
+    await new Promise<void>((resolve) => setImmediate(resolve));
+    expect(progressStarted).toBe(true);
+    controller.abort(null);
+    await new Promise<void>((resolve) => setImmediate(resolve));
+
+    expect(rejection).toBeNull();
+  });
+
   it("cancels the owned process when final progress reporting fails", async () => {
     const devices = new FakeDeviceUtils();
     const matcher = new FakeDeviceMatcher();

--- a/test/utils/deviceBootService.test.ts
+++ b/test/utils/deviceBootService.test.ts
@@ -81,6 +81,99 @@ describe("DeviceBootService", () => {
     expect(devices.getWaitForDeviceReadySignal()?.aborted).toBe(false);
   });
 
+  it("bounds a pending start progress callback by the shared deadline and cancels its owned process", async () => {
+    const devices = new FakeDeviceUtils();
+    const matcher = new FakeDeviceMatcher();
+    const timer = new FakeTimer();
+    let killCount = 0;
+    let progressStarted = false;
+    let outcome: "pending" | "rejected" = "pending";
+    devices.setDeviceImages("android", [image]);
+    matcher.setImageResult(image);
+    devices.setMockChildProcess(image.name, {
+      kill: () => {
+        killCount++;
+        return true;
+      },
+      pid: 12,
+    } as any);
+
+    const boot = service(devices, matcher, undefined, timer).boot(
+      { platform: "android", timeoutMs: 10_000 },
+      {
+        report: async (current) => {
+          if (current === 60) {
+            progressStarted = true;
+            await new Promise<void>(() => {});
+          }
+        },
+      },
+    );
+    void boot.catch(() => {
+      outcome = "rejected";
+    });
+
+    await new Promise<void>((resolve) => setImmediate(resolve));
+    expect(progressStarted).toBe(true);
+    timer.advanceTime(10_000);
+    await new Promise<void>((resolve) => setImmediate(resolve));
+
+    expect(outcome).toBe("rejected");
+    expect(killCount).toBe(1);
+  });
+
+  it("cancels the owned process when final progress reporting fails", async () => {
+    const devices = new FakeDeviceUtils();
+    const matcher = new FakeDeviceMatcher();
+    let killCount = 0;
+    devices.setDeviceImages("android", [image]);
+    matcher.setImageResult(image);
+    devices.setMockChildProcess(image.name, {
+      kill: () => {
+        killCount++;
+        return true;
+      },
+      pid: 12,
+    } as any);
+
+    await expect(
+      service(devices, matcher).boot(
+        { platform: "android" },
+        {
+          report: async (current) => {
+            if (current === 100) {
+              throw new Error("progress failed");
+            }
+          },
+        },
+      ),
+    ).rejects.toThrow("progress failed");
+
+    expect(killCount).toBe(1);
+  });
+
+  it("preserves successful cold-boot progress reporting", async () => {
+    const devices = new FakeDeviceUtils();
+    const matcher = new FakeDeviceMatcher();
+    const reports: Array<{ current: number; total: number; message: string }> = [];
+    devices.setDeviceImages("android", [image]);
+    matcher.setImageResult(image);
+
+    await service(devices, matcher).boot(
+      { platform: "android" },
+      {
+        report: async (current, total, message) => {
+          reports.push({ current, total, message });
+        },
+      },
+    );
+
+    expect(reports).toEqual([
+      { current: 60, total: 100, message: "Device started, waiting for readiness..." },
+      { current: 100, total: 100, message: "Device is ready for use" },
+    ]);
+  });
+
   it("aborts provisioning at the shared absolute deadline", async () => {
     const devices = new FakeDeviceUtils();
     const timer = new FakeTimer();


### PR DESCRIPTION
## Summary
- Bound `DeviceBootService` progress callbacks by the shared absolute `startDevice` deadline.
- Cancel the launch handle when post-launch progress or readiness fails, without affecting unowned devices.
- Added deterministic FakeTimer coverage for a stalled 60% callback, a failing 100% callback, and successful reporting.

## Linked Issue
Closes [#5280](https://github.com/kaeawc/auto-mobile/issues/5280)

## Bug / Regression Context
- **Observed symptom:** a stalled or rejected progress callback could outlive the request deadline; after process creation, a rejected callback could leave that request's emulator running.
- **Repro steps / conditions:** make the 60% callback remain pending or reject a post-launch callback.

## Validation
- [x] `bun test test/utils/deviceBootService.test.ts`
- [x] `bun run turbo:validate`
- [x] `bun run typecheck`
- [x] Touched files pass `oxfmt --check`
- [x] New coverage uses the existing `FakeDeviceUtils` and `FakeTimer` seams

## Risk
Low: this scopes existing deadline and cleanup behavior to asynchronous progress reporting; normal successful progress output is covered by regression tests.
