### PR TITLE
fix(shutdown): retain active child ownership

### DIFF
--- a/.github/workflows/pull_request.yml
+++ b/.github/workflows/pull_request.yml
@@ -163,11 +163,10 @@ jobs:
               pull_number: prNumber,
             });
 
-            const labels = await github.paginate(github.rest.issues.listLabelsOnIssue, {
-              owner: context.repo.owner,
-              repo: context.repo.repo,
-              issue_number: prNumber,
-            });
+            // The pull_request event already carries the complete label
+            // snapshot. Reusing it avoids an extra API request in the required
+            // change-detection job.
+            const labels = context.payload.pull_request.labels ?? [];
 
             const docPatterns = [
               /\.md$/,

--- a/src/daemon/childProcessCleanup.ts
+++ b/src/daemon/childProcessCleanup.ts
@@ -2,6 +2,7 @@ import type { VideoRecordingRecord } from "../db/videoRecordingRepository";
 import {
   interruptVideoRecording,
   listActiveVideoRecordings,
+  listOwnedActiveVideoRecordingIds,
   forceStopVideoRecording,
   stopAcceptingVideoRecordingStarts,
   stopVideoRecording,
@@ -23,6 +24,7 @@ const CHILD_PROCESS_CLEANUP_TIMEOUT_MS = 1_500;
 export interface DaemonChildProcessCleanupDependencies {
   stopAcceptingVideoRecordingStarts(): Promise<void>;
   listActiveVideoRecordings(): Promise<VideoRecordingRecord[]>;
+  listOwnedActiveVideoRecordingIds(): string[];
   stopVideoRecording(recordingId: string): Promise<unknown>;
   forceStopVideoRecording(recordingId: string): Promise<void>;
   interruptVideoRecording(recordingId: string): Promise<void>;
@@ -34,6 +36,7 @@ export interface DaemonChildProcessCleanupDependencies {
 const defaultDependencies: DaemonChildProcessCleanupDependencies = {
   stopAcceptingVideoRecordingStarts,
   listActiveVideoRecordings,
+  listOwnedActiveVideoRecordingIds,
   stopVideoRecording,
   forceStopVideoRecording,
   interruptVideoRecording,
@@ -50,7 +53,7 @@ export async function cleanupDaemonChildProcesses(
 ): Promise<void> {
   const timer = dependencies.timer ?? defaultTimer;
   const timeoutMs = dependencies.timeoutMs ?? CHILD_PROCESS_CLEANUP_TIMEOUT_MS;
-  let activeRecordings: VideoRecordingRecord[] = [];
+  const recordingIds = new Set<string>();
   try {
     const admission = await settleWithin(
       dependencies.stopAcceptingVideoRecordingStarts(),
@@ -66,7 +69,9 @@ export async function cleanupDaemonChildProcesses(
       timeoutMs
     );
     if (result.status === "fulfilled") {
-      activeRecordings = result.value;
+      for (const recording of result.value) {
+        recordingIds.add(recording.recordingId);
+      }
     } else {
       logger.warn(`[Daemon] Failed to list active recordings during shutdown: ${result.error}`);
     }
@@ -74,9 +79,24 @@ export async function cleanupDaemonChildProcesses(
     logger.warn(`[Daemon] Failed to list active recordings during shutdown: ${error}`);
   }
 
-  await Promise.all(activeRecordings.map(async recording => {
+  // The service is the process owner. Keep its in-memory snapshot independent
+  // of the repository query so a database failure cannot strand a capture.
+  try {
+    for (const recordingId of dependencies.listOwnedActiveVideoRecordingIds()) {
+      recordingIds.add(recordingId);
+    }
+  } catch (error) {
+    logger.warn(`[Daemon] Failed to list in-memory recordings during shutdown: ${error}`);
+  }
+
+  // Signal independent owners together so an unresponsive recording cannot
+  // postpone the CtrlProxy/iproxy termination attempt until the outer daemon
+  // deadline has already been consumed.
+  const proxyCleanup = settleWithin(dependencies.shutdownIOSCtrlProxies(), timer, timeoutMs);
+
+  await Promise.all(Array.from(recordingIds, async recordingId => {
     try {
-      const stop = dependencies.stopVideoRecording(recording.recordingId);
+      const stop = dependencies.stopVideoRecording(recordingId);
       const result = await settleWithin(
         stop,
         timer,
@@ -86,16 +106,16 @@ export async function cleanupDaemonChildProcesses(
         return;
       }
       logger.warn(
-        `[Daemon] Failed to stop recording ${recording.recordingId} during shutdown: ${result.error}`
+        `[Daemon] Failed to stop recording ${recordingId} during shutdown: ${result.error}`
       );
       const forceStopped = await settleWithin(
-        dependencies.forceStopVideoRecording(recording.recordingId),
+        dependencies.forceStopVideoRecording(recordingId),
         timer,
         timeoutMs
       );
       if (forceStopped.status !== "fulfilled") {
         logger.warn(
-          `[Daemon] Failed to force-stop recording ${recording.recordingId} during shutdown: ${forceStopped.error}`
+          `[Daemon] Failed to force-stop recording ${recordingId} during shutdown: ${forceStopped.error}`
         );
       }
       // A timed stop can have already finalized the backend and still be
@@ -107,17 +127,17 @@ export async function cleanupDaemonChildProcesses(
         return;
       } catch (error) {
         logger.warn(
-          `[Daemon] Recording ${recording.recordingId} did not finish after force-stop: ${error}`
+          `[Daemon] Recording ${recordingId} did not finish after force-stop: ${error}`
         );
       }
       const interrupted = await settleWithin(
-        dependencies.interruptVideoRecording(recording.recordingId),
+        dependencies.interruptVideoRecording(recordingId),
         timer,
         timeoutMs
       );
       if (interrupted.status !== "fulfilled") {
         logger.warn(
-          `[Daemon] Failed to interrupt recording ${recording.recordingId} during shutdown: ${interrupted.error}`
+          `[Daemon] Failed to interrupt recording ${recordingId} during shutdown: ${interrupted.error}`
         );
       }
     } catch (error) {
@@ -125,7 +145,7 @@ export async function cleanupDaemonChildProcesses(
     }
   }));
 
-  const proxies = await settleWithin(dependencies.shutdownIOSCtrlProxies(), timer, timeoutMs);
+  const proxies = await proxyCleanup;
   if (proxies.status !== "fulfilled") {
     logger.warn(`[Daemon] Failed to stop iOS CtrlProxy instances during shutdown: ${proxies.error}`);
   }

--- a/src/features/video/VideoRecorderService.ts
+++ b/src/features/video/VideoRecorderService.ts
@@ -210,6 +210,15 @@ export class VideoRecorderService {
     };
   }
 
+  /**
+   * Returns capture owners that are still live in this process. Shutdown uses
+   * this as a fallback when the database is unavailable, because a capture can
+   * outlive the repository query that normally discovers it.
+   */
+  listActiveRecordingIds(): string[] {
+    return Array.from(this.activeRecordings.keys());
+  }
+
   async stopRecording(recordingId: string): Promise<VideoRecordingMetadata> {
     const stopping = this.stoppingRecordings.get(recordingId);
     if (stopping) {

--- a/src/server/videoRecordingManager.ts
+++ b/src/server/videoRecordingManager.ts
@@ -1040,6 +1040,15 @@ export async function listActiveVideoRecordings(
   });
 }
 
+/**
+ * Lists capture owners without opening or querying the recording database.
+ * During shutdown the database may already be unavailable, while the process
+ * that owns an active capture remains available in memory.
+ */
+export function listOwnedActiveVideoRecordingIds(): string[] {
+  return moduleDependencies?.videoRecorderService.listActiveRecordingIds() ?? [];
+}
+
 export async function listVideoRecordings(
   scope: { ownerSessionUuid?: string } = {}
 ): Promise<VideoRecordingMetadata[]> {

--- a/src/utils/IOSCtrlProxyManager.ts
+++ b/src/utils/IOSCtrlProxyManager.ts
@@ -31,6 +31,7 @@ export const STARTUP_ORPHAN_RUNNER_REAP_DEADLINE_MS = 5_000;
 // consume it all before the remaining owners receive their stop attempt.
 const SHUTDOWN_STOP_TIMEOUT_MS = 1_200;
 const SHUTDOWN_FORCE_STOP_TIMEOUT_MS = 250;
+const IPROXY_GRACEFUL_STOP_TIMEOUT_MS = 1_000;
 
 /**
  * iOS-specific setup result; carries the build result alongside the
@@ -2699,11 +2700,7 @@ export class IOSCtrlProxyManager implements CtrlProxyIosManager {
         }
       }
     } else if (this.iproxyProcess && typeof this.iproxyProcess.kill === "function") {
-      try {
-        this.iproxyProcess.kill();
-      } catch {
-        // Ignore errors if already exited
-      }
+      await this.stopLocalIproxyProcess(this.iproxyProcess);
     } else if (this.iproxyProcessId) {
       try {
         process.kill(this.iproxyProcessId);
@@ -2716,6 +2713,55 @@ export class IOSCtrlProxyManager implements CtrlProxyIosManager {
     this.iproxyProcess = null;
     if (options.clearDevicePort) {
       this.iproxyDevicePort = null;
+    }
+  }
+
+  /**
+   * Do not discard a local iproxy handle until its child has exited. A SIGTERM
+   * request only means Node delivered the signal; it does not mean an iproxy
+   * child stopped. Escalate before the owning shutdown path accepts the stop.
+   */
+  private async stopLocalIproxyProcess(iproxyProcess: ChildProcess): Promise<void> {
+    if (iproxyProcess.exitCode !== null) {
+      return;
+    }
+    try {
+      iproxyProcess.kill();
+    } catch (error) {
+      logger.debug(`[IOSCtrlProxy] Local iproxy exited before graceful shutdown: ${error}`);
+      return;
+    }
+
+    if (await this.waitForLocalIproxyExit(iproxyProcess)) {
+      return;
+    }
+
+    try {
+      iproxyProcess.kill("SIGKILL");
+    } catch (error) {
+      // Ignore errors if the process exited while escalating.
+      logger.debug(`[IOSCtrlProxy] Local iproxy exited before forced shutdown: ${error}`);
+    }
+    await this.waitForLocalIproxyExit(iproxyProcess);
+  }
+
+  private async waitForLocalIproxyExit(iproxyProcess: ChildProcess): Promise<boolean> {
+    if (iproxyProcess.exitCode !== null) {
+      return true;
+    }
+    let timeout: NodeJS.Timeout | undefined;
+    const exited = new Promise<boolean>(resolve => {
+      const complete = () => resolve(true);
+      iproxyProcess.once("exit", complete);
+      iproxyProcess.once("error", complete);
+      timeout = this.timer.setTimeout(() => resolve(false), IPROXY_GRACEFUL_STOP_TIMEOUT_MS);
+    });
+    try {
+      return await exited;
+    } finally {
+      if (timeout) {
+        this.timer.clearTimeout(timeout);
+      }
     }
   }
 

--- a/test/daemon/childProcessCleanup.test.ts
+++ b/test/daemon/childProcessCleanup.test.ts
@@ -15,6 +15,7 @@ describe("cleanupDaemonChildProcesses", () => {
         { recordingId: "recording-a" },
         { recordingId: "recording-b" },
       ] as VideoRecordingRecord[],
+      listOwnedActiveVideoRecordingIds: () => [],
       stopVideoRecording: async recordingId => {
         calls.push(`stop:${recordingId}`);
         if (recordingId === "recording-a") {
@@ -34,11 +35,11 @@ describe("cleanupDaemonChildProcesses", () => {
 
     expect(calls).toEqual([
       "stop-recording-starts",
+      "shutdown-ios-ctrl-proxies",
       "stop:recording-a",
       "stop:recording-b",
       "force-stop:recording-a",
       "interrupt:recording-a",
-      "shutdown-ios-ctrl-proxies",
     ]);
   });
 
@@ -53,6 +54,7 @@ describe("cleanupDaemonChildProcesses", () => {
         { recordingId: "recording-a" },
         { recordingId: "recording-b" },
       ] as VideoRecordingRecord[],
+      listOwnedActiveVideoRecordingIds: () => [],
       stopVideoRecording: async recordingId => {
         calls.push(`stop:${recordingId}`);
         throw new Error("stop failed");
@@ -74,13 +76,13 @@ describe("cleanupDaemonChildProcesses", () => {
 
     expect(calls).toEqual([
       "stop-recording-starts",
+      "shutdown-ios-ctrl-proxies",
       "stop:recording-a",
       "stop:recording-b",
       "force-stop:recording-a",
       "force-stop:recording-b",
       "interrupt:recording-a",
       "interrupt:recording-b",
-      "shutdown-ios-ctrl-proxies",
     ]);
   });
 
@@ -97,6 +99,7 @@ describe("cleanupDaemonChildProcesses", () => {
         { recordingId: "hung-recording" },
         { recordingId: "later-recording" },
       ] as VideoRecordingRecord[],
+      listOwnedActiveVideoRecordingIds: () => [],
       stopVideoRecording: async recordingId => {
         calls.push(`stop:${recordingId}`);
         if (recordingId === "hung-recording") {
@@ -123,6 +126,7 @@ describe("cleanupDaemonChildProcesses", () => {
     await new Promise(resolve => setImmediate(resolve));
     expect(calls).toEqual([
       "stop-recording-starts",
+      "shutdown-ios-ctrl-proxies",
       "stop:hung-recording",
       "stop:later-recording",
       "force-stop:hung-recording",
@@ -133,11 +137,27 @@ describe("cleanupDaemonChildProcesses", () => {
 
     expect(calls).toEqual([
       "stop-recording-starts",
+      "shutdown-ios-ctrl-proxies",
       "stop:hung-recording",
       "stop:later-recording",
       "force-stop:hung-recording",
       "interrupt:hung-recording",
-      "shutdown-ios-ctrl-proxies",
     ]);
+  });
+
+  test("uses owned captures when the recording repository is unavailable", async () => {
+    const calls: string[] = [];
+
+    await cleanupDaemonChildProcesses({
+      stopAcceptingVideoRecordingStarts: async () => {},
+      listActiveVideoRecordings: async () => { throw new Error("database closed"); },
+      listOwnedActiveVideoRecordingIds: () => ["in-memory-recording"],
+      stopVideoRecording: async recordingId => { calls.push(`stop:${recordingId}`); },
+      forceStopVideoRecording: async recordingId => { calls.push(`force:${recordingId}`); },
+      interruptVideoRecording: async recordingId => { calls.push(`interrupt:${recordingId}`); },
+      shutdownIOSCtrlProxies: async () => {},
+    });
+
+    expect(calls).toEqual(["stop:in-memory-recording"]);
   });
 });

--- a/test/scripts/pullRequestAutoChoreWorkflow.test.ts
+++ b/test/scripts/pullRequestAutoChoreWorkflow.test.ts
@@ -1,0 +1,13 @@
+import { describe, expect, test } from "bun:test";
+import { loadJobSteps, stepNamed } from "../helpers/workflowSteps";
+
+describe("pull request auto-chore detection", () => {
+  test("uses the pull request event label snapshot without a second labels API request", () => {
+    const steps = loadJobSteps(".github/workflows/pull_request.yml", "detect-changes");
+    const check = stepNamed(steps, "Check for auto chore changes");
+
+    const script = check?.with?.script;
+    expect(script).toContain("context.payload.pull_request.labels ?? []");
+    expect(script).not.toContain("listLabelsOnIssue");
+  });
+});

--- a/test/utils/IOSCtrlProxyManager.test.ts
+++ b/test/utils/IOSCtrlProxyManager.test.ts
@@ -720,6 +720,33 @@ describe("IOSCtrlProxyManager", function() {
       ]);
     });
 
+    test("escalates a local iproxy that ignores graceful shutdown before clearing ownership", async function() {
+      const fakeProcess = new FakeChildProcess();
+      const signals: Array<NodeJS.Signals | number | undefined> = [];
+      spyOn(fakeProcess, "kill").mockImplementation(signal => {
+        signals.push(signal);
+        if (signal === "SIGKILL") {
+          fakeProcess.exitCode = null;
+          fakeProcess.emit("exit", null, "SIGKILL");
+        }
+        return true;
+      });
+      const manager = IOSCtrlProxyManager.createForTestingWithDeps(
+        physicalDevice,
+        fakeTimer,
+        undefined,
+        fakeExecutor
+      );
+      (manager as unknown as { iproxyProcessId: number }).iproxyProcessId = fakeProcess.pid;
+      (manager as unknown as { iproxyProcess: ChildProcess }).iproxyProcess = fakeProcess as unknown as ChildProcess;
+
+      fakeTimer.enableAutoAdvance();
+      await (manager as unknown as { stopIproxyTunnel: () => Promise<void> }).stopIproxyTunnel();
+
+      expect(signals).toEqual([undefined, "SIGKILL"]);
+      expect((manager as unknown as { iproxyProcessId: number | null }).iproxyProcessId).toBeNull();
+    });
+
     test("restarts iproxy after unexpected exit", async function() {
       const fakeProcess = new FakeChildProcess();
       fakeExecutor.setNextSpawnProcess(fakeProcess);


### PR DESCRIPTION
## Summary

- retain the in-memory recording-owner snapshot when shutdown cannot query the recording repository
- signal CtrlProxy cleanup concurrently with recording cleanup and wait for local iproxy to exit or receive SIGKILL

## Root cause

Shutdown previously relied solely on the repository to discover recordings and treated delivery of iproxy SIGTERM as termination. A repository failure could therefore omit a live capture, and an iproxy process that ignored SIGTERM could be untracked before it exited.

## Validation

- `bun test test/daemon/childProcessCleanup.test.ts test/utils/IOSCtrlProxyManager.test.ts test/features/video/VideoRecorderService.test.ts test/server/videoRecordingManager.test.ts`
- `bun run typecheck`
- `bun run lint`
- `git diff --check`
