### PR TITLE
fix(android): resolve launcher activity for launchApp

### DIFF
--- a/src/features/action/LaunchApp.ts
+++ b/src/features/action/LaunchApp.ts
@@ -974,16 +974,16 @@ export class LaunchApp extends BaseVisualChange {
       const intentResult = await perf.track("intentLaunch", async () => {
         logger.info(`[LaunchApp] Trying am start with intent for user ${userId}`);
         try {
-          // Use am start with MAIN/LAUNCHER intent - more reliable than monkey
-          const intentCmd = `shell am start --user ${userId} -a android.intent.action.MAIN -c android.intent.category.LAUNCHER -n ${packageName}/.MainActivity 2>/dev/null || am start --user ${userId} -a android.intent.action.MAIN -c android.intent.category.LAUNCHER ${packageName}`;
+          // Let PackageManager resolve the app's launcher activity instead of guessing MainActivity.
+          const intentCmd = `shell am start --user ${userId} -a android.intent.action.MAIN -c android.intent.category.LAUNCHER ${packageName}`;
           logger.info(`[LaunchApp] Intent command: ${intentCmd}`);
           const result = await this.adb.executeCommand(intentCmd);
-          // Check if launch was successful (no "Error" in output)
-          if (result.stdout && !result.stdout.includes("Error")) {
+          // am start may report launch errors on stderr while still returning exit code 0.
+          if (result.stdout && !result.stdout.includes("Error") && !result.stderr.includes("Error")) {
             logger.info(`[LaunchApp] Intent launch completed successfully`);
             return { success: true };
           }
-          logger.info(`[LaunchApp] Intent launch returned error: ${result.stdout}`);
+          logger.info(`[LaunchApp] Intent launch returned error: ${result.stdout}${result.stderr}`);
           return { success: false };
         } catch (error) {
           logger.info(`[LaunchApp] Intent launch failed: ${error}, falling back to monkey`);

--- a/test/features/action/LaunchApp.test.ts
+++ b/test/features/action/LaunchApp.test.ts
@@ -81,6 +81,32 @@ describe("LaunchApp", () => {
     expect(fakeAwaitIdle.wasMethodCalled("initializeUiStabilityTracking")).toBe(true);
   });
 
+  test("launches an Android app whose launcher activity is not MainActivity with the package resolver", async () => {
+    fakeTimer.enableAutoAdvance();
+    const settingsPackageName = "com.android.settings";
+    const resolverCommand = `shell am start --user 0 -a android.intent.action.MAIN -c android.intent.category.LAUNCHER ${settingsPackageName}`;
+
+    fakeAdb.setCommandResponse("shell pm list packages --user 0", {
+      stdout: `package:${settingsPackageName}\n`,
+      stderr: ""
+    });
+    fakeAdb.setCommandResponse(resolverCommand, {
+      stdout: "Starting: Intent { act=android.intent.action.MAIN }",
+      stderr: ""
+    });
+    fakeAdb.setCommandResponse(`shell ps | grep ${settingsPackageName}`, { stdout: "0\n", stderr: "" });
+    fakeAdb.setForegroundApp({ packageName: settingsPackageName, userId: 0 });
+    fakeObserveScreen.setObserveResult(createObserveResult(settingsPackageName));
+
+    const result = await launchApp.execute(settingsPackageName, false, false);
+
+    expect(result.success).toBe(true);
+    expect(result.observation?.activeWindow?.appId).toBe(settingsPackageName);
+    expect(fakeAdb.getExecutedCommands().filter(command => command.includes("shell am start") && command.includes("android.intent.category.LAUNCHER")))
+      .toEqual([resolverCommand]);
+    expect(fakeAdb.wasCommandExecuted(`shell monkey -p ${settingsPackageName}`)).toBe(false);
+  });
+
   test("clears Android app data through the injected action before relaunch", async () => {
     fakeTimer.enableAutoAdvance();
     fakeAdb.setForegroundApp({ packageName, userId: 0 });


### PR DESCRIPTION
## Summary

- launch Android apps through the package manager's `MAIN`/`LAUNCHER` resolver instead of guessing `.MainActivity`
- preserve the fallback chain when `am start` reports an error, including errors emitted on stderr
- cover a Settings-like launcher activity with a focused regression test

## Root cause

`am start -n <package>/.MainActivity` can write a missing-activity error to stderr while exiting successfully. The previous command suppressed stderr and therefore skipped its component-less launcher fallback.

## Validation

- `bun test test/features/action/LaunchApp.test.ts`
- `bun run turbo:validate` (13,389 passing, 13 expected skips)
- `bun run typecheck` (no new errors; 185 known baseline errors)

Closes #5254
