### PR TITLE
fix(startDevice): allow unknown cold-boot transport IDs

### DIFF
--- a/src/daemon/devicePool.ts
+++ b/src/daemon/devicePool.ts
@@ -2758,7 +2758,7 @@ export class DevicePool {
       pooled.id === expected.deviceId &&
       pooled.name === expected.name &&
       pooled.platform === expected.platform &&
-      pooled.transportId === expected.transportId
+      (expected.transportId === undefined || pooled.transportId === expected.transportId)
     );
   }
 

--- a/test/server/deviceTools.startDevice.test.ts
+++ b/test/server/deviceTools.startDevice.test.ts
@@ -198,6 +198,35 @@ describe("startDevice handler", () => {
     expect(fakeDeviceUtils.wasMethodCalled("startDevice")).toBe(true);
   });
 
+  it("cold-boots when discovery supplies a transport ID after boot readiness", async () => {
+    const timer = new FakeTimer();
+    daemonSessionManager = new SessionManager(timer, new FakeDeviceSessionPersistence());
+    const pool = new DevicePool(
+      daemonSessionManager,
+      "daemon-session",
+      timer,
+      undefined,
+      fakeDeviceUtils,
+    );
+    DaemonState.getInstance().initialize(daemonSessionManager, pool);
+
+    const discoveredDevice = { ...androidDevice, transportId: "23" };
+    const coldBootImage = { ...androidImage, deviceId: androidDevice.deviceId };
+    fakeDeviceUtils.setBootedDevices("android", [discoveredDevice]);
+    fakeDeviceUtils.setDeviceImages("android", [coldBootImage]);
+    fakeMatcher.setBootedResult(null);
+    fakeMatcher.setImageResult(coldBootImage);
+
+    const result = await callStartDevice({ platform: "android" });
+
+    expect(result.source).toBe("cold-boot");
+    expect(result.sessionId).toBeDefined();
+    expect(pool.getDevice(androidDevice.deviceId)).toMatchObject({
+      transportId: "23",
+      sessionId: result.sessionId,
+    });
+  });
+
   it("tracks the process handle for a public Android cold boot", async () => {
     const recoveryKeys = [
       "AUTOMOBILE_ANDROID_REBOOT_ON_DEATH",

--- a/test/server/deviceTools.startDevice.test.ts
+++ b/test/server/deviceTools.startDevice.test.ts
@@ -212,8 +212,10 @@ describe("startDevice handler", () => {
 
     const discoveredDevice = { ...androidDevice, transportId: "23" };
     const coldBootImage = { ...androidImage, deviceId: androidDevice.deviceId };
+    const childProcess = new FakeExitChildProcess();
     fakeDeviceUtils.setBootedDevices("android", [discoveredDevice]);
     fakeDeviceUtils.setDeviceImages("android", [coldBootImage]);
+    fakeDeviceUtils.setMockChildProcess(coldBootImage.name, childProcess as unknown as ChildProcess);
     fakeMatcher.setBootedResult(null);
     fakeMatcher.setImageResult(coldBootImage);
 
@@ -225,6 +227,7 @@ describe("startDevice handler", () => {
       transportId: "23",
       sessionId: result.sessionId,
     });
+    expect(childProcess.killed).toBe(false);
   });
 
   it("tracks the process handle for a public Android cold boot", async () => {


### PR DESCRIPTION
## Summary

Treat a missing expected Android `transportId` during cold-boot binding as unknown, while retaining strict comparison when the expected transport ID is known. This prevents a fresh emulator from being torn down when ADB discovery supplies its transport ID after readiness returns.

## Linked Issue

Closes [#5369](https://github.com/kaeawc/auto-mobile/issues/5369)

## Bug / Regression Context

- **Prior regression:** [#5340](https://github.com/kaeawc/auto-mobile/pull/5340) added `transportId` to runtime identity comparison.
- **Observed symptom:** Android `startDevice` cold boots fail with `Device pool identity mismatch` when the ready device has no transport ID but the pooled discovery result does.
- **Repro conditions:** Start an Android emulator from stopped state with a daemon pool; readiness returns the device identity before ADB discovery supplies its transport ID.

## Validation

- [x] Added a handler-level cold-boot regression test using the existing device, matcher, session, and timer fakes.
- [x] `bun test test/server/deviceTools.startDevice.test.ts test/daemon/devicePool.test.ts`
- [x] `bun run typecheck` reports no new errors (baseline gate)
- [x] `bun run turbo:validate` passes (lint, build, full test suite, and boundary checks)
- [x] `git diff --check`
