### PR TITLE
fix(ios): unflake XCTestRunner — CtrlProxy queue offload + cold-provision readiness budget

### DIFF
--- a/.github/workflows/pull_request.yml
+++ b/.github/workflows/pull_request.yml
@@ -1842,9 +1842,18 @@ jobs:
             -only-testing:CtrlProxyTests/RotationChangeGenerationTests/testGestureOrientationKeepsLandscapeSceneWhenDeviceIsFaceUp \
             -only-testing:CtrlProxyUITests/CtrlProxyUITests/testHierarchyIncludesTypedTextInputsMissingFromSnapshotTree
 
+      # Re-sync the backgrounded ffmpeg install before its only consumer. With the
+      # install hoisted out, this step's 10-minute cap now covers the test alone.
+      - wait: install-ffmpeg
+
+      - name: "Run videoRecording MP4 integration test"
+        timeout-minutes: 10
+        env:
+          AUTOMOBILE_TOOLSET_SCREEN_ARTIFACTS: "1"
+        run: ./scripts/ios/video-recording-start-stop-integration.sh
+
       # This is a freshly-booted sim, so bring the daemon to ready and warm
-      # CtrlProxy before ANY of the downstream bounded integration tests — the
-      # videoRecording test below included. Pre-starting the daemon and waiting
+      # CtrlProxy before the downstream simulator workflows. Pre-starting the daemon and waiting
       # for readiness makes a startup failure surface loudly here instead of
       # silently skipping the test (#2730); `auto-mobile` (installed to ~/.bun/bin
       # by `bun add -g .`) is thereby on PATH for the swift-test step.
@@ -1859,30 +1868,14 @@ jobs:
         run: ./scripts/ci/ensure-daemon-ready.sh
 
       # Launch CtrlProxy on the booted sim now (a slow, one-time xcodebuild launch)
-      # so the first `observe` in a bounded integration test doesn't pay that cost
-      # inside its short waitFor / readiness window and time out (#2730 follow-up).
-      # This MUST precede the videoRecording test: that test's in-process session
-      # auto-start is bounded by the #5362 runner-readiness budget (30s), far less
-      # than a ~90s cold CtrlProxy launch, so a cold launch there fails with
-      # `remainingBudgetMs=0` (#5376). With CtrlProxy already alive,
-      # IOSCtrlProxyManager.startInternal short-circuits on `pgrep -f CtrlProxy`
-      # ("process is alive, skipping start") and the readiness fast path returns in
-      # seconds. Worst case ≈ 3 × (observe floor 150s + delay); bound the step so a
-      # pathological hang points here instead of at the 45-min job cap.
+      # so the test's first `observe` doesn't pay that cost inside its short
+      # waitFor window and time out (#2730 follow-up). Worst case ≈ 3 × (observe
+      # floor 150s + delay); bound the step so a pathological hang points here
+      # instead of at the 45-min job cap.
       - name: "Warm up iOS CtrlProxy (Xcode 26.5)"
         if: ${{ !cancelled() && steps.build-ctrlproxy.outcome == 'success' }}
         timeout-minutes: 12
         run: ./scripts/ci/ensure-ctrl-proxy-ready.sh
-
-      # Re-sync the backgrounded ffmpeg install before its only consumer. With the
-      # install hoisted out, this step's 10-minute cap now covers the test alone.
-      - wait: install-ffmpeg
-
-      - name: "Run videoRecording MP4 integration test"
-        timeout-minutes: 10
-        env:
-          AUTOMOBILE_TOOLSET_SCREEN_ARTIFACTS: "1"
-        run: ./scripts/ios/video-recording-start-stop-integration.sh
 
       - name: "Run iOS navigation graph Simulator workflow"
         if: ${{ !cancelled() && steps.build-ctrlproxy.outcome == 'success' }}

--- a/.github/workflows/pull_request.yml
+++ b/.github/workflows/pull_request.yml
@@ -1842,18 +1842,9 @@ jobs:
             -only-testing:CtrlProxyTests/RotationChangeGenerationTests/testGestureOrientationKeepsLandscapeSceneWhenDeviceIsFaceUp \
             -only-testing:CtrlProxyUITests/CtrlProxyUITests/testHierarchyIncludesTypedTextInputsMissingFromSnapshotTree
 
-      # Re-sync the backgrounded ffmpeg install before its only consumer. With the
-      # install hoisted out, this step's 10-minute cap now covers the test alone.
-      - wait: install-ffmpeg
-
-      - name: "Run videoRecording MP4 integration test"
-        timeout-minutes: 10
-        env:
-          AUTOMOBILE_TOOLSET_SCREEN_ARTIFACTS: "1"
-        run: ./scripts/ios/video-recording-start-stop-integration.sh
-
       # This is a freshly-booted sim, so bring the daemon to ready and warm
-      # CtrlProxy before the downstream simulator workflows. Pre-starting the daemon and waiting
+      # CtrlProxy before ANY of the downstream bounded integration tests — the
+      # videoRecording test below included. Pre-starting the daemon and waiting
       # for readiness makes a startup failure surface loudly here instead of
       # silently skipping the test (#2730); `auto-mobile` (installed to ~/.bun/bin
       # by `bun add -g .`) is thereby on PATH for the swift-test step.
@@ -1868,14 +1859,30 @@ jobs:
         run: ./scripts/ci/ensure-daemon-ready.sh
 
       # Launch CtrlProxy on the booted sim now (a slow, one-time xcodebuild launch)
-      # so the test's first `observe` doesn't pay that cost inside its short
-      # waitFor window and time out (#2730 follow-up). Worst case ≈ 3 × (observe
-      # floor 150s + delay); bound the step so a pathological hang points here
-      # instead of at the 45-min job cap.
+      # so the first `observe` in a bounded integration test doesn't pay that cost
+      # inside its short waitFor / readiness window and time out (#2730 follow-up).
+      # This MUST precede the videoRecording test: that test's in-process session
+      # auto-start is bounded by the #5362 runner-readiness budget (30s), far less
+      # than a ~90s cold CtrlProxy launch, so a cold launch there fails with
+      # `remainingBudgetMs=0` (#5376). With CtrlProxy already alive,
+      # IOSCtrlProxyManager.startInternal short-circuits on `pgrep -f CtrlProxy`
+      # ("process is alive, skipping start") and the readiness fast path returns in
+      # seconds. Worst case ≈ 3 × (observe floor 150s + delay); bound the step so a
+      # pathological hang points here instead of at the 45-min job cap.
       - name: "Warm up iOS CtrlProxy (Xcode 26.5)"
         if: ${{ !cancelled() && steps.build-ctrlproxy.outcome == 'success' }}
         timeout-minutes: 12
         run: ./scripts/ci/ensure-ctrl-proxy-ready.sh
+
+      # Re-sync the backgrounded ffmpeg install before its only consumer. With the
+      # install hoisted out, this step's 10-minute cap now covers the test alone.
+      - wait: install-ffmpeg
+
+      - name: "Run videoRecording MP4 integration test"
+        timeout-minutes: 10
+        env:
+          AUTOMOBILE_TOOLSET_SCREEN_ARTIFACTS: "1"
+        run: ./scripts/ios/video-recording-start-stop-integration.sh
 
       - name: "Run iOS navigation graph Simulator workflow"
         if: ${{ !cancelled() && steps.build-ctrlproxy.outcome == 'success' }}

--- a/ios/control-proxy/Sources/CtrlProxy/WebSocketServer.swift
+++ b/ios/control-proxy/Sources/CtrlProxy/WebSocketServer.swift
@@ -114,6 +114,11 @@ public class WebSocketServer: WebSocketServing {
     private let frameContext: FrameContext
     private let broadcastSink: ((Data) -> Void)?
     private let queue = DispatchQueue(label: "com.ctrlproxy.server")
+    /// Command execution runs here, off the accept/`queue`, so a long XCUITest
+    /// walk or screenshot cannot starve `GET /health`, `POST /sdk-events`, or new
+    /// connection accepts — all of which are serviced on `queue`. A single
+    /// serial queue preserves per-connection command ordering (issue #5374).
+    private let commandQueue = DispatchQueue(label: "com.ctrlproxy.command")
     var onSdkHierarchyUpdated: (() -> Void)?
 
     public var isRunning: Bool {
@@ -221,7 +226,25 @@ public class WebSocketServer: WebSocketServing {
 
     private func handleMessage(_ data: Data, connectionId: Int) {
         guard let connection = connections.value(forId: connectionId) else { return }
-        handleMessage(data, responder: connection)
+        dispatchCommand(data, responder: connection)
+    }
+
+    /// Runs one command off the server `queue` on the serial `commandQueue`.
+    ///
+    /// The accept loop, `GET /health`, and `POST /sdk-events` are all serviced on
+    /// `queue`; before this hop, a slow command (an XCUITest element-tree walk, a
+    /// screenshot, or a semaphore-blocked SDK HTTP call) ran inline on `queue` and
+    /// starved them — a live-but-unresponsive runner whose `/health` probes time
+    /// out mid-run (issue #5374). Offloading keeps `queue` free while commands run
+    /// serially here, preserving per-connection ordering. `responder` is captured
+    /// strongly so it outlives the hop; `NWConnection.send` is thread-safe.
+    ///
+    /// Internal, not private, so `WebSocketServerTests` can drive the offload with a
+    /// fake responder and assert the caller is not blocked while a command runs.
+    func dispatchCommand(_ data: Data, responder: WebSocketResponding) {
+        commandQueue.async { [weak self] in
+            self?.handleMessage(data, responder: responder)
+        }
     }
 
     /// Decode → dispatch → encode → send, with the decode-failure `catch` #2854

--- a/ios/control-proxy/Tests/CtrlProxyTests/WebSocketServerTests.swift
+++ b/ios/control-proxy/Tests/CtrlProxyTests/WebSocketServerTests.swift
@@ -21,6 +21,28 @@ final class WebSocketServerTests: XCTestCase {
         }
     }
 
+    /// Thread-safe responder for the command-offload test: `dispatchCommand`
+    /// delivers `send` from the `commandQueue`, so the test thread reads `count`
+    /// concurrently and must not race a bare array append.
+    private final class LockingResponder: WebSocketResponding {
+        private let lock = NSLock()
+        private var _sent: [Data] = []
+        /// Invoked on every `send`, on whatever queue produced the response.
+        var onSend: ((Data) -> Void)?
+        var count: Int {
+            lock.lock()
+            defer { lock.unlock() }
+            return _sent.count
+        }
+
+        func send(_ data: Data) {
+            lock.lock()
+            _sent.append(data)
+            lock.unlock()
+            onSend?(data)
+        }
+    }
+
     private final class TransitionInjectingExecutor: FrameContextMainExecuting {
         var afterNextPerform: (() -> Void)?
 
@@ -45,14 +67,15 @@ final class WebSocketServerTests: XCTestCase {
     /// singleton is untouched.
     private func makeServer(
         frameContext: FrameContext = FrameContext(),
-        broadcastSink: ((Data) -> Void)? = nil
+        broadcastSink: ((Data) -> Void)? = nil,
+        elementLocator: ElementLocating = FakeElementLocator()
     )
         -> WebSocketServer
     {
         let fakeTimeProvider = FakeTimeProvider(initialTime: 1000)
         perfProvider = PerfProvider.createForTesting(timeProvider: fakeTimeProvider)
         let handler = CommandHandler.createForTesting(
-            elementLocator: FakeElementLocator(),
+            elementLocator: elementLocator,
             gesturePerformer: FakeGesturePerformer(),
             perfProvider: perfProvider
         )
@@ -257,6 +280,66 @@ final class WebSocketServerTests: XCTestCase {
         // Every id added was also removed, so the registry must be empty and intact.
         XCTAssertEqual(registry.count, 0)
         XCTAssertTrue(registry.values().isEmpty)
+    }
+
+    // MARK: - Command offload keeps the server queue responsive (#5374)
+
+    /// A slow command (element-tree walk / screenshot / semaphore-blocked SDK
+    /// call) used to run inline on the server `DispatchQueue`, which also accepts
+    /// connections and answers `GET /health` and `POST /sdk-events`. While it ran,
+    /// those were starved — a live-but-unresponsive runner whose `/health` probes
+    /// time out mid-run (issue #5374: XCTestRunner Simulator Tests, five 5s health
+    /// probes returning 0 bytes).
+    ///
+    /// `dispatchCommand` now offloads execution onto a dedicated serial
+    /// `commandQueue`, so the caller (the server queue) returns immediately and
+    /// stays free to serve `/health`. This drives the real offload path with a
+    /// blocking `getViewHierarchy` and asserts the caller is not blocked while the
+    /// command runs. Pre-fix (inline execution) the caller blocks for the full
+    /// release delay and the elapsed-time assertion fails; the response still
+    /// arrives once the handler is released, proving the offload preserves it.
+    func testDispatchCommandDoesNotBlockCallerWhileHandlerRuns() {
+        let releaseAfter: TimeInterval = 0.5
+        let handlerReleased = DispatchSemaphore(value: 0)
+        let handlerEntered = DispatchSemaphore(value: 0)
+
+        let locator = FakeElementLocator()
+        locator.onHierarchyRead = {
+            // Signal that the command is executing, then block until released.
+            handlerEntered.signal()
+            _ = handlerReleased.wait(timeout: .now() + 10)
+        }
+
+        let server = makeServer(elementLocator: locator)
+        let responder = LockingResponder()
+        let responded = expectation(description: "command response delivered after handler release")
+        responder.onSend = { _ in responded.fulfill() }
+
+        // Independent releaser: unblock the handler shortly after it starts, from a
+        // thread that is never the caller — so pre-fix the only way the caller can
+        // return is by blocking here for `releaseAfter`.
+        DispatchQueue.global().async {
+            guard handlerEntered.wait(timeout: .now() + 5) == .success else { return }
+            Thread.sleep(forTimeInterval: releaseAfter)
+            handlerReleased.signal()
+        }
+
+        let command = Data(#"{"type":"request_hierarchy","requestId":"offload-1"}"#.utf8)
+        let start = Date()
+        server.dispatchCommand(command, responder: responder)
+        let elapsed = Date().timeIntervalSince(start)
+
+        // Offloaded, the caller returns in microseconds; inline, it blocks for
+        // ~releaseAfter until the handler completes. Generous margin for CI jitter.
+        XCTAssertLessThan(
+            elapsed,
+            releaseAfter - 0.1,
+            "command execution must be offloaded so the server queue is not blocked (issue #5374)"
+        )
+
+        // The response is still produced once the handler is released.
+        wait(for: [responded], timeout: 5)
+        XCTAssertEqual(responder.count, 1, "exactly one framed response should be delivered")
     }
 
     // MARK: - WebSocket frame length bounds (#3626)

--- a/src/utils/DeviceSessionManager.ts
+++ b/src/utils/DeviceSessionManager.ts
@@ -26,6 +26,7 @@ import { checkIosCtrlProxyOverride } from "./iosCtrlProxyOverride";
 import { RunnerReadinessError, RunnerReadinessService } from "./RunnerReadinessService";
 import { defaultTimer, type Timer } from "./SystemTimer";
 import { serverConfig } from "./ServerConfig";
+import { DEFAULT_RUNNER_PROVISION_TIMEOUT_MS } from "./runnerReadinessConfig";
 
 /**
  * Render a device list for a "not found" error.
@@ -222,6 +223,12 @@ export interface DeviceReadyOptions {
 export interface DeviceSessionManagerOptions {
   runnerReadinessTimer?: Timer;
   runnerReadinessTimeoutMs?: number;
+  /**
+   * Boot-class budget for one-time runner provisioning (cold CtrlProxy launch)
+   * on the session auto-start path, which owns no separate device-boot deadline.
+   * Defaults to {@link DEFAULT_RUNNER_PROVISION_TIMEOUT_MS} (#5376).
+   */
+  runnerProvisionTimeoutMs?: number;
 }
 
 export class DeviceSessionManager implements DeviceSessionManager {
@@ -234,6 +241,7 @@ export class DeviceSessionManager implements DeviceSessionManager {
   private readonly runnerReadinessService: RunnerReadinessService;
   private readonly runnerReadinessTimer: Timer;
   private readonly runnerReadinessTimeoutMs: number | undefined;
+  private readonly runnerProvisionTimeoutMs: number | undefined;
   private _adb: AdbExecutor | undefined;
   private simulatorAppOpened = false;
 
@@ -249,6 +257,7 @@ export class DeviceSessionManager implements DeviceSessionManager {
     this.adbFactory = adbFactory;
     this.runnerReadinessTimer = options.runnerReadinessTimer ?? defaultTimer;
     this.runnerReadinessTimeoutMs = options.runnerReadinessTimeoutMs;
+    this.runnerProvisionTimeoutMs = options.runnerProvisionTimeoutMs;
     this.runnerReadinessService = new RunnerReadinessService({
       timer: this.runnerReadinessTimer,
       getAndroidManager: (device) => this.provider.getAndroidCtrlProxyManager(device),
@@ -750,10 +759,19 @@ export class DeviceSessionManager implements DeviceSessionManager {
     let didSetup = false;
     const runnerReadinessTimeoutMs =
       this.runnerReadinessTimeoutMs ?? serverConfig.getRunnerReadinessTimeoutMs();
+    // Session auto-start owns no separate device-boot deadline, so a genuine cold
+    // first call must fit the one-time CtrlProxy provisioning (~90-115s launch)
+    // in the total deadline. Size it to the provision budget while keeping
+    // `readinessTimeoutMs` as the fast-fail steady-state health window; the
+    // service bounds setup by the total and opens the health window only after
+    // provisioning completes (#5376).
+    const runnerProvisionTimeoutMs =
+      this.runnerProvisionTimeoutMs ?? DEFAULT_RUNNER_PROVISION_TIMEOUT_MS;
 
     try {
       const totalDeadlineMs =
-        this.runnerReadinessTimer.now() + runnerReadinessTimeoutMs;
+        this.runnerReadinessTimer.now() +
+        Math.max(runnerProvisionTimeoutMs, runnerReadinessTimeoutMs);
       await this.runnerReadinessService.ensureReady({
         device,
         requestedIdentity: `platform=ios deviceId=${deviceId}`,

--- a/src/utils/RunnerReadinessService.ts
+++ b/src/utils/RunnerReadinessService.ts
@@ -107,7 +107,13 @@ export interface RunnerReadinessRequest {
 }
 
 interface ReadinessAttemptContext extends RunnerReadinessRequest {
-  readinessDeadlineMs: number;
+  /**
+   * Absolute deadline for the steady-state connect/health phases, opened when
+   * `waitForResponsiveClient` begins (null until then) so a long cold
+   * provisioning does not consume the short health budget. Setup/provision
+   * phases are bounded by `totalDeadlineMs` directly (#5376).
+   */
+  healthDeadlineMs: number | null;
 }
 
 type ReadinessRelease = () => void;
@@ -133,11 +139,10 @@ export class RunnerReadinessService {
   constructor(private readonly dependencies: RunnerReadinessDependencies) {}
 
   async ensureReady(request: RunnerReadinessRequest): Promise<void> {
-    const readinessDeadlineMs = Math.min(
-      request.totalDeadlineMs,
-      this.dependencies.timer.now() + request.readinessTimeoutMs,
-    );
-    const context: ReadinessAttemptContext = { ...request, readinessDeadlineMs };
+    // Setup/provision phases run against `totalDeadlineMs`; the connect/health
+    // window is opened later (see `startHealthWindow`) so a cold launch cannot
+    // starve it (#5376).
+    const context: ReadinessAttemptContext = { ...request, healthDeadlineMs: null };
     const key = `${request.device.platform}:${request.device.deviceId}`;
     const release = await this.acquireReadinessTurn(context, key);
     try {
@@ -159,7 +164,7 @@ export class RunnerReadinessService {
     context: ReadinessAttemptContext,
     key: string,
   ): Promise<ReadinessRelease> {
-    if (this.remaining(context) <= 0) {
+    if (this.remainingForPhase(context, "runner-setup") <= 0) {
       this.fail(context, "runner-setup", 1, "readiness budget exhausted before setup lock");
     }
     const lock = readinessLocksByDevice.get(key) ?? { locked: false, waiters: [] };
@@ -188,7 +193,7 @@ export class RunnerReadinessService {
         };
         waiter.timeoutHandle = this.dependencies.timer.setTimeout(
           () => abandon(new Error("readiness setup lock exceeded this request's deadline")),
-          this.remaining(context),
+          this.remainingForPhase(context, "runner-setup"),
         );
         waiter.abortListener = () => abandon(context.signal?.reason);
         context.signal?.addEventListener("abort", waiter.abortListener, { once: true });
@@ -403,7 +408,7 @@ export class RunnerReadinessService {
     }
 
     const setup = await this.runPhase(context, "runner-setup", 1, (signal) =>
-      manager.setup(false, context.perf, signal, this.remaining(context)),
+      manager.setup(false, context.perf, signal, this.remainingForPhase(context, "runner-setup")),
     );
     context.onRunnerSetup?.();
     if (!setup.success) {
@@ -429,7 +434,7 @@ export class RunnerReadinessService {
     await this.runPhase(context, "runner-setup", 1, (signal) =>
       manager.start({
         signal,
-        minimumHealthPollDurationMs: this.remaining(context),
+        minimumHealthPollDurationMs: this.remainingForPhase(context, "runner-setup"),
       }),
     );
     await this.waitForResponsiveClient(context, client);
@@ -439,10 +444,13 @@ export class RunnerReadinessService {
     context: ReadinessAttemptContext,
     client: ReadinessClient,
   ): Promise<void> {
+    // Provisioning is done; open the steady-state health window now so a long
+    // cold launch above did not consume it (#5376).
+    this.startHealthWindow(context);
     let attempts = 0;
     let connected = client.isConnected();
     let phase: RunnerReadinessPhase = connected ? "runner-health" : "runner-connect";
-    while (this.remaining(context) > 0) {
+    while (this.remainingForPhase(context, "runner-health") > 0) {
       attempts++;
       connected = client.isConnected();
       if (!connected) {
@@ -461,7 +469,7 @@ export class RunnerReadinessService {
         }
       }
 
-      const remaining = this.remaining(context);
+      const remaining = this.remainingForPhase(context, "runner-health");
       if (remaining > 0) {
         await this.dependencies.timer.sleep(Math.min(READINESS_RETRY_DELAY_MS, remaining));
       }
@@ -480,10 +488,10 @@ export class RunnerReadinessService {
     attempts: number,
     operation: (signal: AbortSignal) => Promise<T>,
   ): Promise<T> {
-    if (this.remaining(context) <= 0) {
+    if (this.remainingForPhase(context, phase) <= 0) {
       this.fail(context, phase, attempts, "readiness budget exhausted before phase started");
     }
-    const remainingMs = this.remaining(context);
+    const remainingMs = this.remainingForPhase(context, phase);
     const controller = new AbortController();
     const signal = context.signal
       ? AbortSignal.any([context.signal, controller.signal])
@@ -533,11 +541,48 @@ export class RunnerReadinessService {
   }
 
   private probeTimeout(context: ReadinessAttemptContext): number {
-    return Math.max(1, Math.min(READINESS_PROBE_TIMEOUT_MS, this.remaining(context)));
+    return Math.max(
+      1,
+      Math.min(READINESS_PROBE_TIMEOUT_MS, this.remainingForPhase(context, "runner-health")),
+    );
   }
 
-  private remaining(context: ReadinessAttemptContext): number {
-    return Math.max(0, context.readinessDeadlineMs - this.dependencies.timer.now());
+  /**
+   * Setup/provision phases (a cold CtrlProxy download + `xcodebuild`/install
+   * launch) are the ones that legitimately take boot-class time, so they run
+   * against `totalDeadlineMs`. Connect/health probes are steady-state and stay
+   * fast-fail against the health window (#5376).
+   */
+  private static isSetupPhase(phase: RunnerReadinessPhase): boolean {
+    return phase === "runner-setup" || phase === "package-compatibility";
+  }
+
+  private phaseDeadlineMs(context: ReadinessAttemptContext, phase: RunnerReadinessPhase): number {
+    if (RunnerReadinessService.isSetupPhase(phase)) {
+      return context.totalDeadlineMs;
+    }
+    // Before the health window opens (fast-path probes run before setup), fall
+    // back to the total deadline; those probes self-bound via `probeTimeout`.
+    return context.healthDeadlineMs ?? context.totalDeadlineMs;
+  }
+
+  private remainingForPhase(
+    context: ReadinessAttemptContext,
+    phase: RunnerReadinessPhase,
+  ): number {
+    return Math.max(0, this.phaseDeadlineMs(context, phase) - this.dependencies.timer.now());
+  }
+
+  /**
+   * Open the steady-state connect/health window once provisioning is done, so a
+   * long cold launch does not eat the health budget. Still bounded by the
+   * caller's total deadline (#5376).
+   */
+  private startHealthWindow(context: ReadinessAttemptContext): void {
+    context.healthDeadlineMs = Math.min(
+      context.totalDeadlineMs,
+      this.dependencies.timer.now() + context.readinessTimeoutMs,
+    );
   }
 
   private fail(
@@ -552,7 +597,7 @@ export class RunnerReadinessService {
       `resolved=[${device.name} (${device.deviceId})]`;
     throw new RunnerReadinessError(
       `${context.operationName ?? "startDevice"} automation runner readiness failed: ${mapping} phase=${phase} ` +
-        `attempts=${attempts} remainingBudgetMs=${this.remaining(context)}: ${normalizeDiagnostic(detail)}`,
+        `attempts=${attempts} remainingBudgetMs=${this.remainingForPhase(context, phase)}: ${normalizeDiagnostic(detail)}`,
     );
   }
 }

--- a/src/utils/runnerReadinessConfig.ts
+++ b/src/utils/runnerReadinessConfig.ts
@@ -4,6 +4,17 @@ export const DEFAULT_RUNNER_READINESS_TIMEOUT_MS = 30_000;
 export const MIN_RUNNER_READINESS_TIMEOUT_MS = 1_000;
 export const MAX_RUNNER_READINESS_TIMEOUT_MS = 120_000;
 
+/**
+ * Boot-class budget for the one-time runner PROVISIONING (CtrlProxy download +
+ * cold `xcodebuild`/install launch) on a fresh device — the setup phases, which
+ * `RunnerReadinessService` bounds by the request's `totalDeadlineMs` rather than
+ * the short steady-state `readinessTimeoutMs`. A cold iOS CtrlProxy launch has
+ * been observed to take ~90–115s, so the session-auto-start path (which owns no
+ * separate boot budget) uses this as its total deadline while keeping
+ * `readinessTimeoutMs` for the fast-fail health window (#5376).
+ */
+export const DEFAULT_RUNNER_PROVISION_TIMEOUT_MS = 180_000;
+
 export function parseRunnerReadinessTimeout(
   value: string | number | undefined,
 ): number | undefined {

--- a/test/utils/DeviceSessionManager.test.ts
+++ b/test/utils/DeviceSessionManager.test.ts
@@ -15,6 +15,7 @@ import { FakeTimer } from "../fakes/FakeTimer";
 import { FakeWindow } from "../fakes/FakeWindow";
 import { BootedDevice, AppearanceConfigInput } from "../../src/models";
 import { serverConfig } from "../../src/utils/ServerConfig";
+import { DEFAULT_RUNNER_PROVISION_TIMEOUT_MS } from "../../src/utils/runnerReadinessConfig";
 import type { AdbClientFactory } from "../../src/utils/android-cmdline-tools/AdbClientFactory";
 import type { AndroidCtrlProxy } from "../../src/features/observe/android/AndroidCtrlProxyClient";
 import type { IOSCtrlProxy } from "../../src/features/observe/ios/IOSCtrlProxyClient";
@@ -528,17 +529,24 @@ describe("DeviceSessionManager legacy iOS auto-start readiness", () => {
     await expect(manager.ensureDeviceReady("ios")).rejects.toThrow(/phase=runner-connect/);
   });
 
-  test("uses the configured readiness budget when no test override is supplied", async () => {
+  test("sizes runner provisioning by the provision budget, decoupled from the health budget", async () => {
+    // Session auto-start's total deadline covers a cold CtrlProxy launch
+    // (the provision budget), so the setup health-poll duration reflects that
+    // budget — not the short steady-state readiness/health config (#5376).
     const originalTimeoutMs = serverConfig.getRunnerReadinessTimeoutMs();
     try {
       const iosManager = new FakeIOSCtrlProxyManager();
       const iosClient = new FakeIOSCtrlProxy();
       iosClient.setConnected(false);
       const manager = createManager(iosManager, iosClient, true);
-      serverConfig.setRunnerReadinessTimeoutMs(120_000);
+      serverConfig.setRunnerReadinessTimeoutMs(30_000);
 
       await expect(manager.ensureDeviceReady("ios")).rejects.toThrow(/phase=runner-connect/);
-      expect(iosManager.getLastSetupMinimumHealthPollDurationMs()).toBe(120_000);
+      // Provision (setup) budget dominates the health budget, so a cold launch
+      // gets the full provision window rather than the 30s health window.
+      expect(iosManager.getLastSetupMinimumHealthPollDurationMs()).toBe(
+        DEFAULT_RUNNER_PROVISION_TIMEOUT_MS,
+      );
     } finally {
       serverConfig.setRunnerReadinessTimeoutMs(originalTimeoutMs);
     }

--- a/test/utils/RunnerReadinessService.test.ts
+++ b/test/utils/RunnerReadinessService.test.ts
@@ -98,9 +98,16 @@ class FakeIosManager implements ReadinessIosManager {
     return this.installed;
   }
 
+  /** Optional hook to simulate elapsed provisioning time (e.g. a cold launch). */
+  onStart?: () => Promise<void>;
+  onSetup?: () => Promise<void>;
+
   async start(options?: { signal?: AbortSignal; minimumHealthPollDurationMs?: number }): Promise<void> {
     this.startCalls++;
     this.startOptions = options;
+    if (this.onStart) {
+      await this.onStart();
+    }
   }
 
   async setup(
@@ -112,6 +119,9 @@ class FakeIosManager implements ReadinessIosManager {
     this.setupCalls++;
     this.setupSignal = signal;
     this.setupMinimumHealthPollDurationMs = minimumHealthPollDurationMs;
+    if (this.onSetup) {
+      await this.onSetup();
+    }
     return this.setupResult;
   }
 
@@ -337,6 +347,81 @@ describe("RunnerReadinessService", () => {
     expect(iosManager.startOptions?.signal).toBeDefined();
     expect(iosManager.setupCalls).toBe(0);
     expect(iosClient.healthCalls).toBe(1);
+  });
+
+  test("sizes the cold-launch health poll by the provision budget, not the health budget", async () => {
+    // With a provision-class total deadline larger than the health budget, the
+    // one-time cold launch runs against the total, not the 30s health window
+    // (#5376). Pre-fix this was min(total, readiness) = 30_000, killing a cold
+    // launch mid-flight.
+    const iosManager = new FakeIosManager();
+    const iosClient = new FakeReadinessClient();
+    iosClient.connected = false;
+    const { service } = createService({ iosManager, iosClient });
+
+    await service.ensureReady({
+      device: iosDevice,
+      requestedIdentity: "platform=ios deviceId=IOS-UDID",
+      totalDeadlineMs: 180_000,
+      readinessTimeoutMs: 30_000,
+      skipCtrlProxyDownload: true,
+    });
+
+    expect(iosManager.startOptions?.minimumHealthPollDurationMs).toBe(180_000);
+  });
+
+  test("provisions a cold iOS runner whose launch outlasts the health budget", async () => {
+    const iosManager = new FakeIosManager();
+    const iosClient = new FakeReadinessClient();
+    iosClient.connected = false;
+    const { service, timer } = createService({ iosManager, iosClient });
+    // Cold launch takes 90s — longer than the 30s health budget but well within
+    // the 180s provision budget. Pre-#5376 the setup phase was capped at the
+    // health budget and aborted at 30s; now it runs against the total deadline.
+    iosManager.onStart = async () => {
+      await timer.sleep(90_000);
+    };
+
+    await service.ensureReady({
+      device: iosDevice,
+      requestedIdentity: "platform=ios deviceId=IOS-UDID",
+      totalDeadlineMs: 180_000,
+      readinessTimeoutMs: 30_000,
+      skipCtrlProxyDownload: true,
+    });
+
+    expect(iosManager.startCalls).toBe(1);
+    expect(iosClient.healthCalls).toBe(1);
+    // The health window opened only after the launch, so we spent the launch
+    // time but did not exhaust the total budget.
+    expect(timer.now()).toBeGreaterThanOrEqual(90_000);
+    expect(timer.now()).toBeLessThan(180_000);
+  });
+
+  test("keeps the health probe fast-fail after a long cold provision", async () => {
+    const iosManager = new FakeIosManager();
+    const iosClient = new FakeReadinessClient();
+    iosClient.connected = false;
+    iosClient.connectionResults = []; // runner launches but never answers
+    const { service, timer } = createService({ iosManager, iosClient });
+    iosManager.onStart = async () => {
+      await timer.sleep(90_000);
+    };
+
+    await expect(
+      service.ensureReady({
+        device: iosDevice,
+        requestedIdentity: "platform=ios deviceId=IOS-UDID",
+        totalDeadlineMs: 180_000,
+        readinessTimeoutMs: 1_000,
+        skipCtrlProxyDownload: true,
+      }),
+    ).rejects.toThrow(/phase=runner-connect/);
+
+    // The 90s launch was allowed to finish (provision budget), but the health
+    // window then failed within ~1s — it did not stretch to the 180s total.
+    expect(timer.now()).toBeGreaterThanOrEqual(90_000);
+    expect(timer.now()).toBeLessThan(95_000);
   });
 
   test("fails without iOS setup when downloads are disabled and no runner is installed", async () => {


### PR DESCRIPTION
## Summary

Unflakes the **XCTestRunner Simulator Tests** job by fixing two distinct root causes, and hardens the iOS session-auto-start readiness lifecycle for genuine cold starts. Each is evidence-backed from the failing runs; each has regression coverage that fails before the fix.

## 1. CtrlProxy runner starves `/health` (Swift) — closes [#5374](https://github.com/kaeawc/auto-mobile/issues/5374)

**Root cause.** `WebSocketServer` ran every WebSocket command synchronously on the single serial queue (`com.ctrlproxy.server`) that also accepts connections and serves `GET /health` and `POST /sdk-events`. While a long command ran (an XCUITest element-tree walk, a screenshot, or a semaphore-blocked SDK HTTP call), the queue never read newly accepted sockets, so `/health` connected but received **0 bytes** until the command finished — a live-but-unresponsive runner.

Evidence (run [32038967709](https://github.com/kaeawc/auto-mobile/actions/runs/32038967709)): the script's five 5s `/health` curls each `curl: (28) ... 0 bytes received`; the runner later logs a burst of `Send failed with error "Broken pipe"` flushing responses to curls that hung up ~20s earlier; runner stdout shows a ~90s+ XCUITest walk spanning the window.

**Fix.** Offload command execution onto a dedicated serial `commandQueue`; the server queue stays free to accept connections and answer `/health` / `/sdk-events`. Cross-queue state is already lock-protected (`ConnectionRegistry` #3611, `PerfProvider`, `SdkEventBuffer`, `SdkHierarchyCache`) or thread-safe (`NWConnection.send`), and broadcasts already run off the server queue — no new concurrency class. Verified on CI: the navigation-graph step then reached `getNavigationGraph on attempt 1` with zero health timeouts.

**Test.** `WebSocketServerTests.testDispatchCommandDoesNotBlockCallerWhileHandlerRuns` — verified failing on the pre-fix inline execution (caller blocks ~0.5s ≥ 0.4s threshold), passing with the offload.

## 2. Cold first-call provisioning budget (product lifecycle) — closes [#5376](https://github.com/kaeawc/auto-mobile/issues/5376)

**Root cause.** Since [#5362](https://github.com/kaeawc/auto-mobile/pull/5362) added a runner-readiness budget to session auto-start, `RunnerReadinessService` applied one budget (`readinessTimeoutMs`, 30s) uniformly to setup + connect + health via a single deadline. A cold provision (CtrlProxy download + `xcodebuild`/install launch, ~90–115s) cannot fit in 30s, so a genuine cold first call fails `remainingBudgetMs=0` — on the iOS session path (`verifyIosDevice`, where `totalDeadline == readiness == 30s`) and on `startDevice` whenever no explicit `timeoutMs` is passed. In CI this reddened the **videoRecording MP4 integration test** (the first iOS op), which cold-launches its own CtrlProxy and failed `phase=runner-health remainingBudgetMs=0` — the dominant XCTestRunner flake post-#5362 (4 of 5 recent failures across unrelated PRs).

**Fix — phase-tiered budget.** Setup/provision phases are bounded by the caller's boot-class `totalDeadlineMs`; the connect/health window is opened only when `waitForResponsiveClient` begins and keeps the tight `readinessTimeoutMs` — so a long cold launch no longer consumes the health budget, and an installed-but-unresponsive runner still fails fast in ~30s (preserving #5278/#5362 intent). `verifyIosDevice` now passes a provision-class `totalDeadlineMs` (`DEFAULT_RUNNER_PROVISION_TIMEOUT_MS = 180s`) while keeping 30s for health. Covers both platforms via `startDevice` (`ensureReady` branches internally); Android session-verify uses a separate flow tracked by #5282.

**Tests** (`RunnerReadinessService.test.ts`, FakeTimer — all fail before the fix with `phase=runner-setup remainingBudgetMs=0`):
- provisions a cold runner whose 90s launch outlasts the 30s health budget (succeeds);
- sizes the cold-launch health poll by the provision budget, not the health budget (deterministic);
- keeps the health probe fast-fail (~1s) after a long provision, not stretching to the 180s total.

### Note on the CI-ordering approach (tried and reverted)

An earlier revision reordered the workflow to warm CtrlProxy *before* the videoRecording step. CI ([32145723921](https://github.com/kaeawc/auto-mobile/actions/runs/32145723921)) showed this is **harmful**: it made the in-process videoRecording test and the resident daemon drive one shared CtrlProxy concurrently, saturating the XCUITest runner's main thread (`ElementLocator.swift:737: Unable to perform work on main run loop, process main thread busy for 30.0s`) and crashing it — which then broke the navigation-graph step too. The original workflow deliberately isolates each step's CtrlProxy (videoRecording solo, then a daemon restart, then a fresh warm-up for navigation-graph); the budget fix lets videoRecording's **solo** cold launch complete within budget, so no reorder is needed. That commit is reverted (workflow now byte-identical to `main`).

## Validation

- Swift: `swift test` (CtrlProxy) 454 pass; SwiftLint clean (pre-existing warnings only).
- TS: `RunnerReadinessService` + `DeviceSessionManager` suites 62 pass; `bun run typecheck` gate clean; `turbo run lint build test` green apart from one known unrelated flake (`throwIfAborted reason-unavailable`, confirmed passing in isolation).
- `scripts/check-boundaries.sh`, `scripts/all_fast_validate_checks.sh` (32 checks), and the workflow BATS green.

## Proof

The required proof is a green **XCTestRunner Simulator Tests** job on this PR head.

## Risk

The budget change deliberately softens fail-fast for the *setup* phase only (a cold first call should provision); health fail-fast is unchanged. Injected interfaces / FakeTimer seams preserved throughout.
