### PR TITLE
fix(observe): measure Android observation age in the host clock domain (#5377)

### DIFF
--- a/src/features/observe/ObserveScreen.ts
+++ b/src/features/observe/ObserveScreen.ts
@@ -346,6 +346,7 @@ export class RealObserveScreen implements ObserveScreen {
       result.freshness = computeFreshness({
         requestedAfter: minTimestamp > 0 ? minTimestamp : undefined,
         actualTimestamp: this.resolveObservationTimestampMs(result),
+        hostAgeBasisMs: this.resolveHostReceivedAtMs(result),
         now: this.timer.now(),
         verified: typeof result.viewHierarchy === "object" && result.viewHierarchy !== null
           ? result.viewHierarchy.fresh
@@ -647,6 +648,20 @@ export class RealObserveScreen implements ObserveScreen {
       if (!Number.isNaN(parsed)) {
         return parsed;
       }
+    }
+    return undefined;
+  }
+
+  /**
+   * Host-clock-domain receipt time for the observed tree, when the delegate
+   * reports one (Android). Used as the age basis so clock skew between a device
+   * and the host is not misreported as observation age (issue #5377). Absent on
+   * iOS (shares the host clock), where age falls back to the device timestamp.
+   */
+  private resolveHostReceivedAtMs(result: ObserveResult): number | undefined {
+    const candidate = result.viewHierarchy?.receivedAt;
+    if (typeof candidate === "number" && !Number.isNaN(candidate)) {
+      return candidate;
     }
     return undefined;
   }

--- a/src/features/observe/android/CtrlProxyHierarchy.ts
+++ b/src/features/observe/android/CtrlProxyHierarchy.ts
@@ -183,6 +183,7 @@ export class CtrlProxyHierarchy {
               hierarchy: cachedHierarchy.hierarchy,
               fresh: isFresh,
               updatedAt: updatedAt,
+              receivedAt: cachedHierarchy.receivedAt,
               perfTiming: cachedHierarchy.perfTiming,
               frameContext: cachedHierarchy.frameContext,
             };
@@ -197,6 +198,7 @@ export class CtrlProxyHierarchy {
             hierarchy: cachedHierarchy.hierarchy,
             fresh: isFresh,
             updatedAt: updatedAt,
+            receivedAt: cachedHierarchy.receivedAt,
             perfTiming: cachedHierarchy.perfTiming,
             frameContext: cachedHierarchy.frameContext,
           };
@@ -227,6 +229,7 @@ export class CtrlProxyHierarchy {
             hierarchy: freshData.hierarchy,
             fresh: true,
             updatedAt: freshData.hierarchy.updatedAt,
+            receivedAt: freshData.receivedAt,
             perfTiming: freshData.perfTiming,
             frameContext: freshData.frameContext,
           };
@@ -251,6 +254,7 @@ export class CtrlProxyHierarchy {
               hierarchy: currentCache.hierarchy,
               fresh: false,
               updatedAt: currentCache.hierarchy.updatedAt,
+              receivedAt: currentCache.receivedAt,
               perfTiming: currentCache.perfTiming,
               frameContext: currentCache.frameContext,
             };
@@ -328,6 +332,11 @@ export class CtrlProxyHierarchy {
       let isFresh = response.fresh;
       let androidPerfTiming = response.perfTiming;
       let frameContext = response.frameContext;
+      // Host-clock-domain receipt time, so observation age is not computed by
+      // subtracting the device-authored `updatedAt` from host `now` across a
+      // skewed emulator clock (issue #5377). Cache hits carry their original
+      // receipt time; a fresh sync below re-stamps it to the current host clock.
+      let receivedAt = response.receivedAt;
 
       // If no hierarchy from WebSocket or data is stale, sync to get fresh data
       const needsSync = !hierarchyData || !isFresh;
@@ -351,6 +360,7 @@ export class CtrlProxyHierarchy {
           }
           frameContext = syncResult.frameContext;
           isFresh = true;
+          receivedAt = this.context.timer.now();
           if (hierarchyData.packageName) {
             this.lastKnownPackageName = hierarchyData.packageName;
           }
@@ -375,6 +385,11 @@ export class CtrlProxyHierarchy {
       // Add the device timestamp to the result
       if (hierarchyData!.updatedAt) {
         convertedHierarchy.updatedAt = hierarchyData!.updatedAt;
+      }
+      // Carry the host-domain receipt time so ObserveScreen can measure age
+      // without crossing clock domains (issue #5377).
+      if (receivedAt !== undefined) {
+        convertedHierarchy.receivedAt = receivedAt;
       }
       if (frameContext !== undefined) {
         convertedHierarchy.frameContext = frameContext;

--- a/src/features/observe/android/types.ts
+++ b/src/features/observe/android/types.ts
@@ -189,6 +189,7 @@ export interface AccessibilityHierarchyResponse {
   hierarchy: AccessibilityHierarchy | null;
   fresh: boolean;
   updatedAt?: number; // Timestamp from device (only present when hierarchy data exists)
+  receivedAt?: number; // Host-clock-domain receipt time; basis for host-domain age (issue #5377)
   perfTiming?: AndroidPerfTiming[]; // Android-side performance timing data
   frameContext?: string;
 }

--- a/src/features/observe/observationFreshness.ts
+++ b/src/features/observe/observationFreshness.ts
@@ -47,6 +47,16 @@ export interface FreshnessInputs {
   requestedAfter?: number;
   /** The capture timestamp carried by the observation itself. */
   actualTimestamp?: number;
+  /**
+   * A host-clock-domain timestamp to measure {@link FreshnessVerdict.ageMs}
+   * against, when the source can supply one (e.g. the Android delegate's
+   * host-side receipt time). `actualTimestamp` is device-authored, so on an
+   * emulator whose clock is skewed from the host, `now - actualTimestamp` reports
+   * the skew as age (issue #5377). When present, age is computed from this
+   * host-domain basis instead; when absent (iOS, which shares the host clock),
+   * age falls back to `actualTimestamp` and behavior is unchanged.
+   */
+  hostAgeBasisMs?: number;
   /** Wall clock at report time. */
   now: number;
   /**
@@ -116,6 +126,25 @@ function computeRequestedFreshness(
 }
 
 /**
+ * Wall-clock age of the observation, measured in a single clock domain.
+ *
+ * Age subtracts a capture time from host `now`, so both operands must share a
+ * clock. Prefer a host-authored basis when the source supplies one; only fall
+ * back to the device-authored capture timestamp (iOS, which shares the host
+ * clock). Subtracting a skewed device timestamp from host `now` reports the
+ * clock skew as age (issue #5377). Clamped at 0 so a device clock running ahead
+ * of the host cannot produce a negative age.
+ */
+function resolveAgeMs(
+  hostAgeBasisMs: number | undefined,
+  actualTimestamp: number | undefined,
+  now: number
+): number | undefined {
+  const ageBasis = hostAgeBasisMs ?? actualTimestamp;
+  return ageBasis !== undefined ? Math.max(0, now - ageBasis) : undefined;
+}
+
+/**
  * Compute the freshness verdict.
  *
  * The `requestedAfter` branch is unchanged from the original implementation, so
@@ -123,10 +152,10 @@ function computeRequestedFreshness(
  * used to return the constant `true` is new.
  */
 export function computeFreshness(inputs: FreshnessInputs): FreshnessVerdict {
-  const { requestedAfter, actualTimestamp, now, verified, unavailable } = inputs;
+  const { requestedAfter, actualTimestamp, hostAgeBasisMs, now, verified, unavailable } = inputs;
   const maxAgeMs = inputs.maxAgeMs ?? maxObservationAgeMs();
 
-  const ageMs = actualTimestamp !== undefined ? Math.max(0, now - actualTimestamp) : undefined;
+  const ageMs = resolveAgeMs(hostAgeBasisMs, actualTimestamp, now);
 
   if (unavailable) {
     return {

--- a/src/models/ViewHierarchyResult.ts
+++ b/src/models/ViewHierarchyResult.ts
@@ -15,6 +15,15 @@ export interface ViewHierarchyResult {
   hierarchy: Hierarchy;
   /** Timestamp from the device when the hierarchy was captured (milliseconds since epoch) */
   updatedAt?: number;
+  /**
+   * Host-clock-domain timestamp (ms since epoch) for when the host took delivery
+   * of this tree — a fresh sync's receipt time, or a cache entry's original
+   * receipt time. Used to measure observation age without crossing clock domains:
+   * `updatedAt` is device-authored, so on a skewed emulator `hostNow - updatedAt`
+   * misreports clock skew as age (issue #5377). Absent on iOS, which shares the
+   * host clock, and on any source that does not track receipt time.
+   */
+  receivedAt?: number;
   /** Opaque device-authored identity for the UI state captured in this hierarchy. */
   frameContext?: string;
   /**

--- a/test/features/observe/android/ctrlProxyHierarchyReceivedAt.test.ts
+++ b/test/features/observe/android/ctrlProxyHierarchyReceivedAt.test.ts
@@ -1,0 +1,121 @@
+/**
+ * Host-domain receipt time on the Android hierarchy delegate (issue #5377).
+ *
+ * Observation age must be measured in a single clock domain. The Android device
+ * clock (an emulator, commonly) can be seconds off the host, so subtracting the
+ * device-authored `updatedAt` from host `now` misreports that skew as age. The
+ * delegate already tracks a host-clock `receivedAt` for its cache; these tests
+ * pin that it is carried onto the converted `ViewHierarchyResult` so
+ * `ObserveScreen` can base age on it:
+ *
+ *   - a fresh sync stamps `receivedAt` to the current HOST clock, and
+ *   - a cache hit carries the cache entry's ORIGINAL host receipt time.
+ */
+
+import { afterEach, describe, expect, spyOn, test } from "bun:test";
+import { CtrlProxyHierarchy } from "../../../../src/features/observe/android/CtrlProxyHierarchy";
+import type {
+  AccessibilityHierarchy,
+  CachedHierarchy,
+  HierarchyDelegateContext,
+} from "../../../../src/features/observe/android/types";
+import type { ViewHierarchyResult } from "../../../../src/models/ViewHierarchyResult";
+import { AndroidCtrlProxyManager } from "../../../../src/utils/CtrlProxyManager";
+import { RequestManager } from "../../../../src/utils/RequestManager";
+import { FakeTimer } from "../../../fakes/FakeTimer";
+
+interface Harness {
+  hierarchy: CtrlProxyHierarchy;
+  timer: FakeTimer;
+  setCached: (h: CachedHierarchy | null) => void;
+  restore: () => void;
+}
+
+function createHarness(): Harness {
+  const timer = new FakeTimer();
+  let cached: CachedHierarchy | null = null;
+
+  const context: HierarchyDelegateContext = {
+    getWebSocket: () => null,
+    requestManager: new RequestManager(timer),
+    timer,
+    ensureConnected: async () => true,
+    cancelScreenshotBackoff: () => {},
+    device: { deviceId: "emulator-5554", platform: "android" } as never,
+    adb: {} as never,
+    getCachedHierarchy: () => cached,
+    setCachedHierarchy: h => { cached = h; },
+    getLastWebSocketTimeout: () => 0,
+    setLastWebSocketTimeout: () => {},
+  };
+
+  const managerSpy = spyOn(AndroidCtrlProxyManager, "getInstance").mockReturnValue({
+    isAvailable: async () => true,
+  } as never);
+
+  const hierarchy = new CtrlProxyHierarchy(context);
+  // The tree content and its conversion are not under test — return a minimal
+  // converted result so we can assert only the receipt-time metadata on it.
+  const convertSpy = spyOn(hierarchy, "convertToViewHierarchyResult").mockImplementation(
+    (h: AccessibilityHierarchy) => ({ hierarchy: { node: { $: {} } }, updatedAt: h.updatedAt } as ViewHierarchyResult)
+  );
+
+  return {
+    hierarchy,
+    timer,
+    setCached: h => { cached = h; },
+    restore: () => {
+      managerSpy.mockRestore();
+      convertSpy.mockRestore();
+    },
+  };
+}
+
+const DEVICE_SKEW_MS = 25_000;
+
+describe("Android CtrlProxyHierarchy host-domain receivedAt (#5377)", () => {
+  let h: Harness | null = null;
+
+  afterEach(() => {
+    h?.restore();
+    h = null;
+  });
+
+  test("a fresh sync stamps receivedAt to the current host clock, not the device timestamp", async () => {
+    h = createHarness();
+    h.timer.advanceTime(100_000); // host clock now well past 0
+
+    // No cache, so the delegate falls through to a synchronous fetch. The device
+    // authored `updatedAt` is skewed 25s behind the host clock.
+    const deviceUpdatedAt = h.timer.now() - DEVICE_SKEW_MS;
+    const syncSpy = spyOn(h.hierarchy, "requestHierarchySync").mockResolvedValue({
+      hierarchy: { updatedAt: deviceUpdatedAt, packageName: "com.test.app" } as AccessibilityHierarchy,
+    });
+
+    const result = await h.hierarchy.getAccessibilityHierarchy(undefined, undefined, true, 0);
+
+    expect(result).not.toBeNull();
+    expect(result!.updatedAt).toBe(deviceUpdatedAt); // device timestamp preserved
+    expect(result!.receivedAt).toBe(h.timer.now()); // host domain, ~now
+    syncSpy.mockRestore();
+  });
+
+  test("a cache hit carries the cache entry's original host receipt time", async () => {
+    h = createHarness();
+    h.timer.advanceTime(100_000);
+
+    const receivedAt = h.timer.now() - 300; // host domain: cached 300ms ago
+    const deviceUpdatedAt = h.timer.now() - DEVICE_SKEW_MS; // device domain, skewed
+    h.setCached({
+      hierarchy: { updatedAt: deviceUpdatedAt, packageName: "com.test.app" } as AccessibilityHierarchy,
+      receivedAt,
+      fresh: true,
+    });
+
+    // Glance path (skipWaitForFresh) so the fresh cache entry is served directly.
+    const result = await h.hierarchy.getAccessibilityHierarchy(undefined, undefined, true, 0);
+
+    expect(result).not.toBeNull();
+    expect(result!.receivedAt).toBe(receivedAt);
+  });
+});

--- a/test/features/observe/freshnessRegressionRepro.test.ts
+++ b/test/features/observe/freshnessRegressionRepro.test.ts
@@ -82,7 +82,7 @@ class FakeDeviceStateCollector implements Pick<DeviceStateCollector, "collectBac
 
 /** Hands `execute()` a caller-controlled `result.viewHierarchy` directly. */
 class ScriptedHierarchyCollector implements Pick<HierarchyCollector, "collect" | "collectRaw" | "extractScreenSize" | "reconcileScreenDimensions"> {
-  constructor(private viewHierarchy: { hierarchy: unknown; updatedAt?: number; fresh?: boolean }) {}
+  constructor(private viewHierarchy: { hierarchy: unknown; updatedAt?: number; receivedAt?: number; fresh?: boolean }) {}
   async collect(result: ObserveResult): Promise<void> {
     result.viewHierarchy = {
       screenWidth: 1080,
@@ -104,7 +104,7 @@ const device: BootedDevice = { deviceId: "test-device", name: "Test Device", pla
 
 function createObserveScreen(
   fakeTimer: FakeTimer,
-  viewHierarchy: { hierarchy: unknown; updatedAt?: number; fresh?: boolean },
+  viewHierarchy: { hierarchy: unknown; updatedAt?: number; receivedAt?: number; fresh?: boolean },
   platformValidator?: HierarchyPlatformValidator,
 ) {
   const observeScreen = new RealObserveScreen(device, new FakeAdbClientFactory(new FakeAdbExecutor()), {
@@ -161,6 +161,30 @@ describe("freshness regression repro (glance path, ObserveScreen.execute)", () =
     const result = await observeScreen.execute();
 
     expect(result.freshness?.isFresh).toBe(false);
+  });
+
+  test("CLOCK SKEW (#5377): a device-skewed but host-fresh tree reports host-domain age with no false warning", async () => {
+    // Reproduces the reported emulator symptom: the device clock is ~25s behind
+    // the host, so the device-authored `updatedAt` is 25s in the past relative to
+    // host `now`, but the tree was verified and received on the host ~200ms ago.
+    // ageMs must reflect the ~200ms host-domain receipt age, not the 25s skew,
+    // and the "…the rest of the observation was slow" warning must NOT fire.
+    const SKEW_MS = 25_000;
+    const fakeTimer = new FakeTimer();
+    const { observeScreen } = createObserveScreen(fakeTimer, {
+      hierarchy: { text: "Wifi" },
+      updatedAt: fakeTimer.now() - SKEW_MS, // device domain, skewed behind host
+      receivedAt: fakeTimer.now() - 200, // host domain, freshly received
+      fresh: true, // delegate verified against the device on this call
+    });
+
+    const result = await observeScreen.execute();
+
+    expect(result.freshness?.isFresh).toBe(true);
+    expect(result.freshness?.ageMs).toBe(200);
+    expect(result.freshness?.warning).toBeUndefined();
+    // The raw device timestamp is still reported for correlation.
+    expect(result.freshness?.actualTimestamp).toBe(fakeTimer.now() - SKEW_MS);
   });
 
   test("A RETRIEVAL FAILURE: an error hierarchy is never reported fresh", async () => {

--- a/test/features/observe/observationFreshness.test.ts
+++ b/test/features/observe/observationFreshness.test.ts
@@ -91,6 +91,61 @@ describe("computeFreshness", () => {
       expect(v.ageMs).toBe(0);
       expect(v.isFresh).toBe(true);
     });
+
+    // --- issue #5377: age must be measured in a single (host) clock domain ---
+
+    test("CLOCK SKEW: a host-domain age basis is used for ageMs instead of the device timestamp", () => {
+      // The device clock is ~25s behind the host, so `actualTimestamp` (device
+      // domain) is 25s "in the past" relative to host `now` even though the tree
+      // was captured ~now on the device and received ~200ms ago on the host.
+      // ageMs must reflect the host-domain receipt age, not the skew.
+      const v = computeFreshness({
+        actualTimestamp: NOW - 25_000, // device-authored, skewed
+        hostAgeBasisMs: NOW - 200, // host-authored receipt time
+        now: NOW,
+        verified: true,
+      });
+      expect(v.ageMs).toBe(200);
+      expect(v.actualTimestamp).toBe(NOW - 25_000); // still reports the device timestamp
+      expect(v.isFresh).toBe(true);
+      expect(v.warning).toBeUndefined(); // no spurious "the rest of the observation was slow"
+    });
+
+    test("CLOCK SKEW: no spurious over-budget warning when only the device clock is skewed", () => {
+      // Recent host receipt but a wildly skewed device timestamp: without the
+      // host-domain basis this fired the false "already Nms old … slow" warning.
+      const v = computeFreshness({
+        actualTimestamp: NOW - 25_000,
+        hostAgeBasisMs: NOW - 100,
+        now: NOW,
+        verified: true,
+      });
+      expect(v.isFresh).toBe(true);
+      expect(v.warning).toBeUndefined();
+    });
+
+    test("a genuinely slow observation still warns, measured in the host domain", () => {
+      // Host-domain basis IS past the budget: this is real slowness (dense-screen
+      // extraction), so the verified-tree warning is legitimate here.
+      const v = computeFreshness({
+        actualTimestamp: NOW - 11_000,
+        hostAgeBasisMs: NOW - 11_000,
+        now: NOW,
+        verified: true,
+      });
+      expect(v.ageMs).toBe(11_000);
+      expect(v.isFresh).toBe(true);
+      expect(v.warning).toContain("verified against the device");
+    });
+
+    test("FALLBACK: with no host-domain basis, age falls back to the device timestamp (iOS)", () => {
+      // iOS shares the host clock, so it never supplies a host basis; the old
+      // device-timestamp age must remain byte-identical.
+      const v = computeFreshness({ actualTimestamp: NOW - 200, now: NOW, verified: true });
+      expect(v.ageMs).toBe(200);
+      expect(v.isFresh).toBe(true);
+      expect(v.warning).toBeUndefined();
+    });
   });
 
   describe("with a requested minimum (the `waitFor` polling path)", () => {


### PR DESCRIPTION
## Summary

On Android, `observe`'s `freshness.ageMs` and `freshness.warning` were computed
by subtracting a **device-authored** capture timestamp (`viewHierarchy.updatedAt`)
from a **host-authored** `now`, so any clock skew between the emulator and the
host was misreported as observation age. A freshly-verified tree showed a large
`ageMs` and a spurious "…already Nms old… the rest of the observation was slow"
warning on essentially every Android `observe` when the clock was skewed (~24s is
common on emulators). `freshness.isFresh` was already protected by the delegate's
`fresh` verdict and stays correct.

This fixes it via the issue's **preferred option 1**: measure age in a single
(host) clock domain, using the host-authored receipt time the Android delegate
already tracks (`CachedHierarchy.receivedAt`) instead of the device `updatedAt`.
`actualTimestamp` keeps reporting the device timestamp (useful for correlation);
only the age math changes. iOS shares the host clock, supplies no host basis, and
falls back to the device timestamp — behavior unchanged.

## Linked Issue

Closes #5377

## Bug / Regression Context

- **Prior attempts:** #5272 protected `isFresh` against skew (via `viewHierarchy.fresh`); the age math was left as a latent hazard, surfaced during a post-`0.0.58` manual-test pass.
- **Observed symptom:** `ageMs: 25597` and a false "the rest of the observation was slow" warning on a fresh Android capture whose device clock was ~24s behind the host, while `actualTimestamp` was only +421ms past the emulator's own clock.
- **Repro conditions:** emulator with a device↔host clock skew; a single `observe` immediately after navigating.

## Changes

- `observationFreshness.ts` — new optional `hostAgeBasisMs` input; age is computed from it when present, else falls back to `actualTimestamp` (extracted `resolveAgeMs` helper to stay under the complexity budget).
- `ViewHierarchyResult` / `AccessibilityHierarchyResponse` — carry a host-domain `receivedAt`.
- Android `CtrlProxyHierarchy` — stamp `receivedAt` onto the converted result: a fresh sync uses the current host clock; a cache hit carries the entry's original host receipt time.
- `ObserveScreen` — pass `viewHierarchy.receivedAt` as the host age basis.

## Acceptance criteria → tests

| Criterion | Test |
|---|---|
| AC1 Android `ageMs` reflects host-domain age, not skew | `observationFreshness.test.ts` "CLOCK SKEW: a host-domain age basis is used…"; `freshnessRegressionRepro.test.ts` "CLOCK SKEW (#5377)…" (through `ObserveScreen.execute`) |
| AC2 No spurious over-budget warning from skew; warns only on genuine host-domain slowness | freshness "…no spurious over-budget warning…" + "…a genuinely slow observation still warns…" |
| AC3 `isFresh` stays correct | existing freshness/regression tests still green |
| AC4 iOS unchanged (falls back to device timestamp) | freshness "FALLBACK: with no host-domain basis…" |
| AC5 `actualTimestamp` still the device timestamp | asserted in the skew tests |
| Android `receivedAt` plumbing (sync vs cache) | `android/ctrlProxyHierarchyReceivedAt.test.ts` |

## Validation

- [x] `bun run lint` + `bun test` pass (13476 pass, 0 fail); ratchet gate: no new violations
- [x] `bun run typecheck` reports no new errors (baseline gate)
- [x] `bun run build` succeeds
- [x] New code uses interfaces + fakes + FakeTimer; unit tests run in <100ms

## Device Verification

- [ ] Not re-run on-device in this PR; the reported repro is captured as `ObserveScreen.execute`-level and unit tests. Original device evidence is in the issue.

## Follow-ups

- [ ] None required — scope limited to the age-math fix in the issue.
