### PR TITLE
fix(desktop): register hotRun by declaring Compose plugin on root classloader

### DIFF
--- a/android/build.gradle.kts
+++ b/android/build.gradle.kts
@@ -16,6 +16,13 @@ plugins {
   alias(libs.plugins.android.application) apply false
   alias(libs.plugins.kotlin.serialization) apply false
   alias(libs.plugins.compose.compiler) apply false
+  // Declared here (not applied) so the Compose Multiplatform plugin shares the root
+  // classloader with the hot-reload plugin below. Compose Hot Reload's
+  // hasComposePluginAccess() does Class.forName("org.jetbrains.compose.ComposePlugin")
+  // from its own classloader; without this the class is only visible in leaf-module
+  // classloaders, the check fails ("Cannot access 'org.jetbrains.compose' plugin"),
+  // and the plugin never auto-registers the :desktop-app:hotRun task.
+  alias(libs.plugins.compose.multiplatform) apply false
   alias(libs.plugins.compose.hot.reload) apply false
   alias(libs.plugins.mavenPublish) apply false
   alias(libs.plugins.metro) apply false

--- a/android/desktop-app/build.gradle.kts
+++ b/android/desktop-app/build.gradle.kts
@@ -228,9 +228,15 @@ compose.desktop {
   }
 }
 
-// Compose Hot Reload: `./gradlew :desktop-app:hotRun --autoReload` launches the desktop
-// dashboard with live UI reloading. Composables live in :desktop-core (an implementation
-// dependency), so edits there reload into the running window without a restart.
+// Compose Hot Reload: `./gradlew :desktop-app:hotRun --autoReload --no-configuration-cache`
+// launches the desktop dashboard with live UI reloading. Composables live in :desktop-core
+// (an implementation dependency), so edits there recompile and reload into the running window
+// without a restart. `--no-configuration-cache` is required because the hot-reload run tasks
+// (e.g. ComposeHotSnapshotTask) are not configuration-cache serializable and the repo enables
+// the configuration cache by default. The `hotRun` task itself is auto-registered by the
+// hot-reload plugin -- which only happens because the Compose Multiplatform plugin is declared
+// on the root classloader in android/build.gradle.kts (see the comment there); this block just
+// points the auto-registered task at the app's main class.
 tasks.withType<ComposeHotRun>().configureEach {
   mainClass.set("dev.jasonpearson.automobile.desktop.MainKt")
 }

--- a/docs/design-docs/plat/android/desktop-app.md
+++ b/docs/design-docs/plat/android/desktop-app.md
@@ -53,10 +53,11 @@ The `:desktop-app` module applies [JetBrains Compose Hot Reload](https://github.
 Launch the dashboard in hot-reload mode:
 
 ```bash
-./gradlew -p android :desktop-app:hotRun --autoReload
+./gradlew -p android :desktop-app:hotRun --autoReload --no-configuration-cache
 ```
 
-- The plugin auto-registers `hotRun` (blocking) and `hotDev` (async) tasks for this Kotlin/JVM module.
+- The plugin auto-registers `hotRun` (blocking) and `hotDev` (async) tasks for this Kotlin/JVM module -- but **only** because the Compose Multiplatform plugin (`org.jetbrains.compose`) is declared on the root build's classloader in `android/build.gradle.kts` (`alias(libs.plugins.compose.multiplatform) apply false`). The hot-reload plugin gates auto-registration on `Class.forName("org.jetbrains.compose.ComposePlugin")` resolving from its own (root) classloader; applying the Compose plugin only in leaf modules leaves that class invisible to it, it logs `Cannot access 'org.jetbrains.compose' plugin. Was this plugin loaded?`, and no `hotRun` task is created.
+- `--no-configuration-cache` is required: the hot-reload run tasks (e.g. `ComposeHotSnapshotTask`) are not configuration-cache serializable, and the repo enables the configuration cache by default. (The inner continuous-build daemon it spawns uses its own configuration cache and is unaffected.)
 - `ComposeHotRun.mainClass` is pinned to `dev.jasonpearson.automobile.desktop.MainKt` in `desktop-app/build.gradle.kts`.
 - Most composables live in `:desktop-core` (an `implementation` dependency of `:desktop-app`), so editing a dashboard panel there reloads into the running window.
 - Requires the JetBrains Runtime (JBR) for enhanced class redefinition; the foojay toolchain resolver in `settings.gradle.kts` provisions a compatible JDK. Java target stays at 21.


### PR DESCRIPTION
## What

Enables Compose Hot Reload for the desktop app. `./gradlew :desktop-app:hotRun --autoReload` was documented but **silently non-functional** — the `hotRun` task was never registered, so `tasks.withType<ComposeHotRun>().configureEach {}` configured nothing.

Closes [#5273](https://github.com/kaeawc/auto-mobile/issues/5273).

## Root cause

Compose Hot Reload auto-registers its run tasks only if `hasComposePluginAccess()` succeeds, which does `Class.forName("org.jetbrains.compose.ComposePlugin", …, ComposeHotReloadPlugin.classLoader)` — the Compose Multiplatform plugin has to be visible on the **root** build classloader. It was applied only in leaf modules (`:desktop-app`, `:desktop-core`), so the class lived on a child classloader the hot-reload plugin couldn't see. The plugin logged `Cannot access 'org.jetbrains.compose' plugin. Was this plugin loaded?` and skipped registration — no `hotRun` task, ever.

## Fix

One declaration in the root `android/build.gradle.kts` plugins block:

```kotlin
alias(libs.plugins.compose.multiplatform) apply false
```

This puts the Compose plugin on the shared root classloader (right next to the already-present `compose.hot.reload apply false`). The hot-reload plugin then auto-registers the full graph — `hotRun`, `hotDev`, `hotReloadMain`, `hotSnapshot*` — and the existing `configureEach` block points `hotRun` at `MainKt`.

## Validation (end to end, on this toolchain)

Kotlin 2.4.10 / Compose 1.11.1 / hot-reload 1.2.0 / Gradle 9.7 / JBR 21.

- `:desktop-app:hotRun --autoReload --no-configuration-cache` launches the dashboard on the auto-provisioned JetBrains Runtime in auto-reload mode.
- Edited a `:desktop-core` composable live — CHR log showed `Change detected → BUILD SUCCESSFUL in 3s → Compose Runtime Analyzer` — hot-swapped into the running window with **no restart and no `NoClassDefFoundError`**.
- `./gradlew projects` configures cleanly and the root change is itself config-cache safe (only the hot-reload *run* tasks are CC-incompatible → hence `--no-configuration-cache`, now documented).
- ktfmt: clean (881 files). No `.kt` source changed, so detekt/typecheck are unaffected.

## Notes for reviewers

- `--no-configuration-cache` is required because the repo enables the configuration cache by default and `ComposeHotSnapshotTask` isn't CC-serializable. Documented in both the build comment and `docs/design-docs/plat/android/desktop-app.md`.
- **Regression guard is the inline comments**, not a new CI check: the failure mode is silent (drop the root line → `hotRun` disappears again), so both build files and the design doc now explain *why* the root declaration must stay. A dedicated CI guard for a one-line build declaration seemed disproportionate — happy to add a `:desktop-app:tasks | grep hotRun` BATS check if preferred.
- Making `hotRun` the **default** local dev-run path (over `:desktop-app:run` in `scripts/local-dev/lib/ide-plugin.sh`) is intentionally **not** in this PR — this one just makes it work. Can follow up if desired.

## Files

- `android/build.gradle.kts` — the fix (+ rationale comment)
- `android/desktop-app/build.gradle.kts` — comment: working command, `--no-configuration-cache`, classloader note
- `docs/design-docs/plat/android/desktop-app.md` — corrected command + the two hard-won requirements
