### PR TITLE
test(ios): real-socket regression that GET /health stays responsive during a blocked command

### DIFF
--- a/ios/control-proxy/Tests/CtrlProxyTests/WebSocketServerTests.swift
+++ b/ios/control-proxy/Tests/CtrlProxyTests/WebSocketServerTests.swift
@@ -382,4 +382,155 @@ final class WebSocketServerTests: XCTestCase {
         let request = Data("GET /health HTTP/1.1\r\nHost: localhost\r\n\r\n".utf8)
         XCTAssertEqual(WebSocketConnection.completeHTTPRequestLength(in: request), request.count)
     }
+
+    // MARK: - /health stays responsive over a real socket while a command blocks (#5374)
+
+    /// A gesture performer whose `pressBack` parks the calling thread on a
+    /// semaphore until the test releases it.
+    ///
+    /// A gesture command runs its operation through `FrameContext.performIfCurrent`
+    /// → `runOnMainThread` (`DispatchQueue.main.sync`), so `pressBack` executes on
+    /// the **main thread** while the server's dispatch queue is blocked
+    /// synchronously waiting for it — reproducing the exact production wedge where
+    /// a hung XCUITest gesture pins the runner's main thread.
+    private final class BlockingGesturePerformer: FakeGesturePerformer, @unchecked Sendable {
+        let didStart = DispatchSemaphore(value: 0)
+        let release = DispatchSemaphore(value: 0)
+
+        override func pressBack() throws {
+            didStart.signal()
+            release.wait()
+            try super.pressBack()
+        }
+    }
+
+    /// Starts a real `WebSocketServer` on the first free port at/above `base`,
+    /// returning the running server and its bound port. Bind collisions
+    /// (`ServerError.failedToStart`) are retried on the next port so the test
+    /// does not depend on a specific port being free.
+    private func startServerOnFreePort(
+        commandHandler: CommandHandler,
+        perfProvider: PerfProvider,
+        base: UInt16 = 8850,
+        attempts: Int = 40,
+        file: StaticString = #file,
+        line: UInt = #line
+    )
+        -> (server: WebSocketServer, port: UInt16)
+    {
+        for offset in 0 ..< attempts {
+            let port = base + UInt16(offset)
+            let server = WebSocketServer(
+                port: port,
+                commandHandler: commandHandler,
+                perfProvider: perfProvider
+            )
+            do {
+                try server.start()
+                return (server, port)
+            } catch {
+                continue
+            }
+        }
+        XCTFail("could not bind a WebSocketServer on any port in [\(base), \(base + UInt16(attempts))]", file: file, line: line)
+        fatalError("unreachable")
+    }
+
+    /// End-to-end regression for the daemon health probe over a real socket:
+    /// while one WebSocket connection is stuck inside a blocked command, an
+    /// independent `GET /health` request over a *separate* connection must still
+    /// return promptly. This is the property the daemon relies on to tell "the
+    /// runner is wedged on this gesture" apart from "the runner is dead" — the
+    /// XCTestRunner flake in #5374 was exactly this: five 5s `/health` probes
+    /// timed out mid-command and a live runner was torn down.
+    ///
+    /// The command-offload fix (#5374) keeps the server queue free by running
+    /// commands on a dedicated `commandQueue`; `testDispatchCommandDoesNotBlock…`
+    /// pins that offload at the `dispatchCommand` seam. This test complements it
+    /// one layer out — it drives the real `WebSocketServer` (real `NWListener`,
+    /// real sockets on 127.0.0.1) and asserts an actual HTTP `GET /health`
+    /// returns 200 while a command blocks, covering the accept + HTTP-serving
+    /// path the seam-level test does not. The blocked gesture pins the main
+    /// thread via `runOnMainThread` (just as a hung XCUITest call does on
+    /// device), so the whole probe is orchestrated from a background thread and
+    /// the main thread is left free to run the gesture's `main.sync`. It fails —
+    /// `/health` never returns 200 — if command execution is ever moved back onto
+    /// the queue that accepts connections and serves `/health`.
+    func testHealthCheckStaysResponsiveWhileCommandBlocks() throws {
+        let fakeTimeProvider = FakeTimeProvider(initialTime: 1000)
+        perfProvider = PerfProvider.createForTesting(timeProvider: fakeTimeProvider)
+        let blockingPerformer = BlockingGesturePerformer()
+        let handler = CommandHandler.createForTesting(
+            elementLocator: FakeElementLocator(),
+            gesturePerformer: blockingPerformer,
+            perfProvider: perfProvider
+        )
+        let (server, port) = startServerOnFreePort(commandHandler: handler, perfProvider: perfProvider)
+        defer {
+            blockingPerformer.release.signal() // unblock the parked command so teardown can proceed
+            server.stop()
+        }
+
+        // 127.0.0.1 (not "localhost") avoids DNS / IPv6 happy-eyeballs latency.
+        let wsURL = try XCTUnwrap(URL(string: "ws://127.0.0.1:\(port)/"))
+        let healthURL = try XCTUnwrap(URL(string: "http://127.0.0.1:\(port)/health"))
+
+        let statusBox = Box<Int?>(nil)
+        let bodyBox = Box<String?>(nil)
+        let probeFinished = expectation(description: "health probe orchestration finished")
+
+        // Everything runs off the main thread: the blocked gesture will occupy
+        // the main thread (via runOnMainThread), so the main thread must stay in
+        // `wait(for:)` — pumping its run loop — for that `main.sync` to execute.
+        DispatchQueue.global().async {
+            let session = URLSession(configuration: .ephemeral)
+            let wsTask = session.webSocketTask(with: wsURL)
+            wsTask.resume()
+            wsTask.send(.data(Data(#"{"type":"request_press_back","requestId":"blocker"}"#.utf8))) { _ in }
+
+            // Proceed only once the command is actually executing and thus
+            // occupying the main thread + the server's dispatch queue.
+            let started = blockingPerformer.didStart.wait(timeout: .now() + 15)
+
+            // With the command parked, GET /health over a separate connection
+            // must still respond. Bound by its own timeout so a regression
+            // surfaces as a failed assertion, not a hung test.
+            let healthConfig = URLSessionConfiguration.ephemeral
+            healthConfig.timeoutIntervalForRequest = 4
+            let healthSession = URLSession(configuration: healthConfig)
+            let healthDone = DispatchSemaphore(value: 0)
+            let healthTask = healthSession
+                .dataTask(with: healthURL) { data, response, _ in
+                    statusBox.value = (response as? HTTPURLResponse)?.statusCode
+                    bodyBox.value = data.flatMap { String(data: $0, encoding: .utf8) }
+                    healthDone.signal()
+                }
+            if started == .success {
+                healthTask.resume()
+                _ = healthDone.wait(timeout: .now() + 6)
+            }
+
+            // Unblock the parked gesture so the main thread (and server queue)
+            // are released, then hand control back to the main test thread.
+            blockingPerformer.release.signal()
+            session.invalidateAndCancel()
+            healthSession.invalidateAndCancel()
+            probeFinished.fulfill()
+        }
+
+        wait(for: [probeFinished], timeout: 30)
+        XCTAssertEqual(statusBox.value, 200, "health check should return 200 while a command is blocked")
+        XCTAssertEqual(
+            bodyBox.value.flatMap { (try? JSONSerialization.jsonObject(with: Data($0.utf8))) as? [String: Any] }?["status"] as? String,
+            "ok",
+            "health body should report status:ok"
+        )
+    }
+}
+
+/// Reference wrapper so escaping completion handlers can publish a result back
+/// to the test without tripping Swift's captured-var concurrency diagnostics.
+private final class Box<T>: @unchecked Sendable {
+    var value: T
+    init(_ value: T) { self.value = value }
 }

--- a/ios/control-proxy/Tests/CtrlProxyTests/WebSocketServerTests.swift
+++ b/ios/control-proxy/Tests/CtrlProxyTests/WebSocketServerTests.swift
@@ -528,9 +528,28 @@ final class WebSocketServerTests: XCTestCase {
     }
 }
 
-/// Reference wrapper so escaping completion handlers can publish a result back
-/// to the test without tripping Swift's captured-var concurrency diagnostics.
+/// Lock-protected reference cell so an escaping completion handler can publish a
+/// result back to the test thread. Access is synchronized because the timeout
+/// path has no happens-before: if `healthDone.wait` times out, the driver tears
+/// down the session, whose cancelled `dataTask` completion still fires and writes
+/// `value` concurrently with the main thread's post-`wait` read. The lock keeps
+/// that access defined (matching `LockingResponder`'s pattern above).
 private final class Box<T>: @unchecked Sendable {
-    var value: T
-    init(_ value: T) { self.value = value }
+    private let lock = NSLock()
+    private var _value: T
+
+    init(_ value: T) { _value = value }
+
+    var value: T {
+        get {
+            lock.lock()
+            defer { lock.unlock() }
+            return _value
+        }
+        set {
+            lock.lock()
+            defer { lock.unlock() }
+            _value = newValue
+        }
+    }
 }

--- a/ios/control-proxy/Tests/CtrlProxyTests/WebSocketServerTests.swift
+++ b/ios/control-proxy/Tests/CtrlProxyTests/WebSocketServerTests.swift
@@ -477,6 +477,12 @@ final class WebSocketServerTests: XCTestCase {
 
         let statusBox = Box<Int?>(nil)
         let bodyBox = Box<String?>(nil)
+        // The health outcome is captured strictly BEFORE the command is released.
+        // In a regression the probe stays blocked until release and only returns
+        // afterward; gating on this `.success` (which happens-before the status
+        // read) excludes that late response, so a post-release 200 cannot forge a
+        // pass. `.timedOut` unless health answers while the command is blocked.
+        let healthWaitResult = Box<DispatchTimeoutResult>(.timedOut)
         let probeFinished = expectation(description: "health probe orchestration finished")
 
         // Everything runs off the main thread: the blocked gesture will occupy
@@ -507,11 +513,14 @@ final class WebSocketServerTests: XCTestCase {
                 }
             if started == .success {
                 healthTask.resume()
-                _ = healthDone.wait(timeout: .now() + 6)
+                // The completion writes status/body before signaling, so a
+                // `.success` here happens-before those reads: the probe answered
+                // while the command was still blocked (release not yet signaled).
+                healthWaitResult.value = healthDone.wait(timeout: .now() + 6)
             }
 
-            // Unblock the parked gesture so the main thread (and server queue)
-            // are released, then hand control back to the main test thread.
+            // Only now unblock the parked gesture so the main thread (and server
+            // queue) are released, then hand control back to the main test thread.
             blockingPerformer.release.signal()
             session.invalidateAndCancel()
             healthSession.invalidateAndCancel()
@@ -519,6 +528,11 @@ final class WebSocketServerTests: XCTestCase {
         }
 
         wait(for: [probeFinished], timeout: 30)
+        XCTAssertEqual(
+            healthWaitResult.value,
+            .success,
+            "GET /health must respond while the command is still blocked (before it is released)"
+        )
         XCTAssertEqual(statusBox.value, 200, "health check should return 200 while a command is blocked")
         XCTAssertEqual(
             bodyBox.value.flatMap { (try? JSONSerialization.jsonObject(with: Data($0.utf8))) as? [String: Any] }?["status"] as? String,


### PR DESCRIPTION
## What this is now

**Test-only.** Rebased onto latest `main`. The production fix for this flakiness already landed in [#5374 / #5375](https://github.com/kaeawc/auto-mobile/pull/5375) (CtrlProxy queue offload), so this PR keeps only the piece that survives that overlap: an **end-to-end regression over a real socket**.

## Why it's still worth landing

[#5374](https://github.com/kaeawc/auto-mobile/pull/5375) fixed the XCTestRunner flake — a live-but-unresponsive runner whose five 5s `GET /health` probes timed out while a command ran on the shared `com.ctrlproxy.server` queue — by offloading command execution onto a dedicated `commandQueue`. Its own regression, `testDispatchCommandDoesNotBlockCallerWhileHandlerRuns`, pins that offload **at the `dispatchCommand` seam** with a fake responder.

This adds the layer that seam-level test doesn't reach: it drives the **real** `WebSocketServer` (real `NWListener`, real sockets on `127.0.0.1`) and asserts an actual HTTP `GET /health` returns `200` while a command blocks the main thread. That's the accept + HTTP-serving path, and it matches the shape of the real flake (real `/health` probes over the socket). It fails if command execution is ever moved back onto the queue that accepts connections and serves `/health` — a regression the seam-level test would miss.

The blocked gesture pins the main thread via `runOnMainThread` (as a hung XCUITest call does on device), so the probe is orchestrated from a background thread with the main thread left free to run the gesture's `main.sync`.

## Verification

- Full CtrlProxy suite (incl. #5374's offload test and this one): **455 tests, 0 failures**.
- New test: green in ~13ms, stable across repeated runs; a regression fails as a clean `nil ≠ 200` assertion within ~21s, never a hang.
- Confirmed the test passes on `main`'s command-offload mechanism *without* any source change — it validates the property, not a particular implementation.
- SwiftLint clean; no production change, no new file (no `xcodegen` needed).

## History note

Earlier revisions of this PR carried a *different* fix for the same root cause (per-connection dispatch queues). Dropped as redundant with #5374's already-merged command-offload — one mechanism per concern.
