### PR TITLE
build(desktop): Conveyor control-API update path (coexists with GitHub checker) [C2]

### DIFF
--- a/android/desktop-app/src/main/kotlin/dev/jasonpearson/automobile/desktop/AutoMobileDesktopApp.kt
+++ b/android/desktop-app/src/main/kotlin/dev/jasonpearson/automobile/desktop/AutoMobileDesktopApp.kt
@@ -540,6 +540,16 @@ fun AutoMobileDesktopApp(
                     onOpenReleaseNotes = {
                       availableUpdate.releaseNotesUrl?.let { openReleaseNotesInBrowser(it) }
                     },
+                    // Only a Conveyor package can apply in place; the GitHub path reports false and
+                    // the install action stays disabled. Conveyor tears the app down as it
+                    // restarts,
+                    // so this is the last thing the process does.
+                    onInstall =
+                      if (updateController.canApplyUpdate()) {
+                        { scope.launch { updateController.applyUpdate() } }
+                      } else {
+                        null
+                      },
                   )
                 }
               }

--- a/android/desktop-core/build.gradle.kts
+++ b/android/desktop-core/build.gradle.kts
@@ -112,6 +112,12 @@ dependencies {
   // Metro DI
   implementation(libs.metro.runtime)
 
+  // Conveyor in-app update control API (SoftwareUpdateController). Functional only inside a
+  // Conveyor
+  // package; getInstance() returns null otherwise (dev, jpackage, tests), so the desktop app
+  // degrades to the GitHub-Releases checker. See #5227 (PR-C2).
+  implementation(libs.conveyor.control)
+
   // Test dependencies
   testImplementation(libs.kotlin.test)
   testImplementation(libs.kotlinx.coroutines.test)

--- a/android/desktop-core/src/main/kotlin/dev/jasonpearson/automobile/desktop/core/di/ApplicationModule.kt
+++ b/android/desktop-core/src/main/kotlin/dev/jasonpearson/automobile/desktop/core/di/ApplicationModule.kt
@@ -7,6 +7,8 @@ import dev.jasonpearson.automobile.desktop.core.platform.PackagedVersionSource
 import dev.jasonpearson.automobile.desktop.core.platform.RuntimeAppVersionProvider
 import dev.jasonpearson.automobile.desktop.core.settings.FileSettingsProvider
 import dev.jasonpearson.automobile.desktop.core.settings.SettingsProvider
+import dev.jasonpearson.automobile.desktop.core.update.ConveyorSoftwareUpdateGateway
+import dev.jasonpearson.automobile.desktop.core.update.ConveyorUpdateController
 import dev.jasonpearson.automobile.desktop.core.update.GitHubReleaseSource
 import dev.jasonpearson.automobile.desktop.core.update.RealUpdateController
 import dev.jasonpearson.automobile.desktop.core.update.UpdateController
@@ -44,9 +46,18 @@ interface ApplicationModule {
     @Provides
     @SingleIn(AppScope::class)
     fun provideUpdateController(appVersionProvider: AppVersionProvider): UpdateController {
-      // Checks GitHub Releases against the running version (#5224). Purely reactive — nothing
-      // fetches until a caller invokes checkForUpdate().
-      return RealUpdateController(GitHubReleaseSource(), appVersionProvider)
+      // Inside a Conveyor package, drive updates through Conveyor's control API — it can both check
+      // and apply (download + install + restart). Everywhere else (dev, jpackage builds) the
+      // gateway
+      // is null, so fall back to the GitHub-Releases checker (#5224, #5227). Both are purely
+      // reactive
+      // — nothing fetches until a caller invokes checkForUpdate().
+      val conveyorGateway = ConveyorSoftwareUpdateGateway.createOrNull()
+      return if (conveyorGateway != null) {
+        ConveyorUpdateController(conveyorGateway)
+      } else {
+        RealUpdateController(GitHubReleaseSource(), appVersionProvider)
+      }
     }
   }
 }

--- a/android/desktop-core/src/main/kotlin/dev/jasonpearson/automobile/desktop/core/di/LocalAutoMobileGraph.kt
+++ b/android/desktop-core/src/main/kotlin/dev/jasonpearson/automobile/desktop/core/di/LocalAutoMobileGraph.kt
@@ -6,6 +6,8 @@ import dev.jasonpearson.automobile.desktop.core.datasource.DefaultDataSourceFact
 import dev.jasonpearson.automobile.desktop.core.platform.PackagedVersionSource
 import dev.jasonpearson.automobile.desktop.core.platform.RuntimeAppVersionProvider
 import dev.jasonpearson.automobile.desktop.core.settings.FakeSettingsProvider
+import dev.jasonpearson.automobile.desktop.core.update.ConveyorSoftwareUpdateGateway
+import dev.jasonpearson.automobile.desktop.core.update.ConveyorUpdateController
 import dev.jasonpearson.automobile.desktop.core.update.GitHubReleaseSource
 import dev.jasonpearson.automobile.desktop.core.update.RealUpdateController
 
@@ -24,6 +26,8 @@ val LocalAutoMobileGraph =
       override val settingsProvider = FakeSettingsProvider()
       override val dataSourceFactory = DefaultDataSourceFactory(client)
       override val appVersionProvider = versionProvider
-      override val updateController = RealUpdateController(GitHubReleaseSource(), versionProvider)
+      override val updateController =
+        ConveyorSoftwareUpdateGateway.createOrNull()?.let { ConveyorUpdateController(it) }
+          ?: RealUpdateController(GitHubReleaseSource(), versionProvider)
     }
   }

--- a/android/desktop-core/src/main/kotlin/dev/jasonpearson/automobile/desktop/core/shell/UpdateReadyButton.kt
+++ b/android/desktop-core/src/main/kotlin/dev/jasonpearson/automobile/desktop/core/shell/UpdateReadyButton.kt
@@ -81,8 +81,10 @@ fun UpdateReadyButton(
 
 /**
  * The compact details surface shown when the update pill is clicked: the available version, the
- * running version, a link to the release notes, and a (disabled here) install action delivered by a
- * later item. Pure content — the shell wraps it in a Popup.
+ * running version, a link to the release notes, and an "Install & restart" action. The action is
+ * enabled only when [onInstall] is non-null — the shell passes a callback only for packaging that
+ * can apply in place (a Conveyor package), and `null` for the GitHub-Releases path, which can only
+ * surface the release. Pure content — the shell wraps it in a Popup.
  */
 @Composable
 fun UpdateDetailsContent(
@@ -90,6 +92,7 @@ fun UpdateDetailsContent(
   currentVersion: String,
   onOpenReleaseNotes: () -> Unit,
   modifier: Modifier = Modifier,
+  onInstall: (() -> Unit)? = null,
 ) {
   Column(
     modifier = modifier.padding(12.dp),
@@ -107,9 +110,9 @@ fun UpdateDetailsContent(
     }
 
     Row(verticalAlignment = Alignment.CenterVertically) {
-      // Applying the update (download + install + restart) is delivered by a later item, so the
-      // action is present but not yet enabled.
-      TextButton(onClick = {}, enabled = false) {
+      // Enabled only when the shell supplies an install callback (a Conveyor package can apply in
+      // place); the GitHub-Releases path passes null and the action stays disabled.
+      TextButton(onClick = onInstall ?: {}, enabled = onInstall != null) {
         Icon(
           imageVector = Icons.Filled.Download,
           contentDescription = null,

--- a/android/desktop-core/src/main/kotlin/dev/jasonpearson/automobile/desktop/core/update/ConveyorSoftwareUpdateGateway.kt
+++ b/android/desktop-core/src/main/kotlin/dev/jasonpearson/automobile/desktop/core/update/ConveyorSoftwareUpdateGateway.kt
@@ -1,0 +1,54 @@
+package dev.jasonpearson.automobile.desktop.core.update
+
+import dev.hydraulic.conveyor.control.SoftwareUpdateController
+import dev.jasonpearson.automobile.desktop.core.logging.LoggerFactory
+
+private val LOG = LoggerFactory.getLogger("ConveyorSoftwareUpdateGateway")
+
+/**
+ * The production [SoftwareUpdateGateway], backed by Conveyor's [SoftwareUpdateController]. Only
+ * constructible when the app runs inside a Conveyor package — [createOrNull] returns `null`
+ * otherwise (development, jpackage builds, tests), so DI can fall back to the GitHub checker.
+ */
+class ConveyorSoftwareUpdateGateway
+private constructor(private val controller: SoftwareUpdateController) : SoftwareUpdateGateway {
+
+  override fun probe(): UpdateProbe {
+    val repository =
+      try {
+        controller.currentVersionFromRepository
+      } catch (error: SoftwareUpdateController.UpdateCheckException) {
+        throw UpdateProbeException(error.message ?: "Update repository check failed", error)
+      }
+    // No repository version means nothing newer is published (or the repo has no releases yet).
+    if (repository == null) return UpdateProbe.UpToDate
+
+    // A null current version (unknown packaged version) is treated as "older than anything the
+    // repository advertises", so the update surfaces rather than being silently swallowed.
+    val current = controller.currentVersion
+    val isNewer = current == null || current < repository
+    return if (isNewer) UpdateProbe.Available(repository.version) else UpdateProbe.UpToDate
+  }
+
+  override fun canApply(): Boolean =
+    controller.canTriggerUpdateCheckUI() == SoftwareUpdateController.Availability.AVAILABLE
+
+  override fun apply() {
+    controller.triggerUpdateCheckUI()
+  }
+
+  companion object {
+    /**
+     * A gateway when the app is running inside a Conveyor package, else `null`. The underlying
+     * [SoftwareUpdateController.getInstance] is `null` in development, jpackage builds and tests.
+     */
+    fun createOrNull(): SoftwareUpdateGateway? {
+      val controller = SoftwareUpdateController.getInstance()
+      if (controller == null) {
+        LOG.debug("Not running inside a Conveyor package; SoftwareUpdateController unavailable.")
+        return null
+      }
+      return ConveyorSoftwareUpdateGateway(controller)
+    }
+  }
+}

--- a/android/desktop-core/src/main/kotlin/dev/jasonpearson/automobile/desktop/core/update/ConveyorUpdateController.kt
+++ b/android/desktop-core/src/main/kotlin/dev/jasonpearson/automobile/desktop/core/update/ConveyorUpdateController.kt
@@ -1,0 +1,68 @@
+package dev.jasonpearson.automobile.desktop.core.update
+
+import dev.jasonpearson.automobile.desktop.core.logging.LoggerFactory
+import kotlinx.coroutines.CancellationException
+import kotlinx.coroutines.Dispatchers
+import kotlinx.coroutines.flow.MutableStateFlow
+import kotlinx.coroutines.flow.StateFlow
+import kotlinx.coroutines.flow.asStateFlow
+import kotlinx.coroutines.sync.Mutex
+import kotlinx.coroutines.sync.withLock
+import kotlinx.coroutines.withContext
+
+private val LOG = LoggerFactory.getLogger("ConveyorUpdateController")
+
+/**
+ * Drives the update affordance from Conveyor's control API via a [SoftwareUpdateGateway]. DI
+ * selects this over [RealUpdateController] only when the app runs inside a Conveyor package. Purely
+ * reactive: no network work until [checkForUpdate] is called, and never on construction.
+ *
+ * The probe runs on [Dispatchers.IO] (it performs network I/O); [applyUpdate] hands off to
+ * Conveyor, which downloads, installs and restarts — so the app process is expected to exit.
+ */
+class ConveyorUpdateController(private val gateway: SoftwareUpdateGateway) : UpdateController {
+
+  private val mutableStatus = MutableStateFlow<UpdateStatus>(UpdateStatus.Idle)
+  override val status: StateFlow<UpdateStatus> = mutableStatus.asStateFlow()
+
+  // Serializes checks so overlapping callers (a startup check racing a manual one) never interleave
+  // their status writes — the previous-state capture below is only correct with one check in
+  // flight.
+  private val checkMutex = Mutex()
+
+  override suspend fun checkForUpdate(): Unit = checkMutex.withLock {
+    // Captured so a cancelled check restores the last stable state rather than pinning the shared
+    // singleton StateFlow at Checking for every collector.
+    val previousStatus = mutableStatus.value
+    mutableStatus.value = UpdateStatus.Checking
+    val probe =
+      try {
+        withContext(Dispatchers.IO) { gateway.probe() }
+      } catch (cancellation: CancellationException) {
+        mutableStatus.value = previousStatus
+        throw cancellation
+      } catch (error: Exception) {
+        // Typed failure surfaced to the UI; the check is best-effort and must never crash the app.
+        LOG.warn("Conveyor update check failed: ${error.message}", error)
+        mutableStatus.value = UpdateStatus.Failed(error.message ?: "Update check failed")
+        return
+      }
+
+    mutableStatus.value =
+      when (probe) {
+        is UpdateProbe.UpToDate -> UpdateStatus.UpToDate
+        // Conveyor owns the download, so there is no per-asset URL or release-notes link to carry.
+        is UpdateProbe.Available -> UpdateStatus.UpdateAvailable(version = probe.version)
+      }
+  }
+
+  override fun canApplyUpdate(): Boolean = gateway.canApply()
+
+  override suspend fun applyUpdate() {
+    // Conveyor blocks while it hands off to the platform updater and tears the app down; keep it
+    // off
+    // the UI thread. Guarded by canApplyUpdate() at the call site, but harmless if the gateway is
+    // asked when unsupported.
+    withContext(Dispatchers.IO) { gateway.apply() }
+  }
+}

--- a/android/desktop-core/src/main/kotlin/dev/jasonpearson/automobile/desktop/core/update/RealUpdateController.kt
+++ b/android/desktop-core/src/main/kotlin/dev/jasonpearson/automobile/desktop/core/update/RealUpdateController.kt
@@ -35,6 +35,15 @@ class RealUpdateController(
     runCheck()
   }
 
+  // The GitHub-Releases checker never gained a download/install path — the status-bar pill links to
+  // the release, and applying in place is delivered by Conveyor (ConveyorUpdateController, #5227).
+  override fun canApplyUpdate(): Boolean = false
+
+  override suspend fun applyUpdate() {
+    // Nothing to apply: this controller only surfaces that a newer release exists. See
+    // canApplyUpdate() — the UI keeps its "Install & restart" action disabled for this path.
+  }
+
   private suspend fun runCheck() {
     val appVersion = appVersionProvider.current()
     // A development build (no packaged version) and an OS we don't ship an installer for both mean

--- a/android/desktop-core/src/main/kotlin/dev/jasonpearson/automobile/desktop/core/update/SoftwareUpdateGateway.kt
+++ b/android/desktop-core/src/main/kotlin/dev/jasonpearson/automobile/desktop/core/update/SoftwareUpdateGateway.kt
@@ -1,0 +1,44 @@
+package dev.jasonpearson.automobile.desktop.core.update
+
+/** The result of probing the update repository for a newer build. */
+sealed interface UpdateProbe {
+  /** The running build is the latest the repository offers. */
+  data object UpToDate : UpdateProbe
+
+  /** A newer build is available; [version] is its human-readable version string. */
+  data class Available(val version: String) : UpdateProbe
+}
+
+/**
+ * Raised when an [SoftwareUpdateGateway.probe] cannot complete (network error, repository fault).
+ */
+class UpdateProbeException(message: String, cause: Throwable? = null) : Exception(message, cause)
+
+/**
+ * A narrow, fakeable seam over Conveyor's `SoftwareUpdateController`. Isolating the three
+ * operations the controller needs keeps [ConveyorUpdateController] unit-testable without a real
+ * Conveyor package (the underlying `getInstance()` returns `null` outside one).
+ *
+ * The production implementation is [ConveyorSoftwareUpdateGateway]; its `createOrNull()` returns
+ * `null` when the app isn't running inside a Conveyor package, which is how DI decides to fall back
+ * to the GitHub-Releases checker.
+ */
+interface SoftwareUpdateGateway {
+  /**
+   * Compares the packaged version against the repository's latest. Performs network I/O — call it
+   * off the UI thread. Throws [UpdateProbeException] if the repository can't be reached or read.
+   */
+  fun probe(): UpdateProbe
+
+  /**
+   * Whether [apply] can install an update in place on this OS and package type. `false` where
+   * Conveyor can't trigger an update from the app (notably Linux, where updates flow through apt).
+   */
+  fun canApply(): Boolean
+
+  /**
+   * Hands off to Conveyor to download, install and restart into the new version. The app process is
+   * expected to exit; save state before calling. A no-op guarded by [canApply] at the call site.
+   */
+  fun apply()
+}

--- a/android/desktop-core/src/main/kotlin/dev/jasonpearson/automobile/desktop/core/update/UpdateController.kt
+++ b/android/desktop-core/src/main/kotlin/dev/jasonpearson/automobile/desktop/core/update/UpdateController.kt
@@ -3,9 +3,13 @@ package dev.jasonpearson.automobile.desktop.core.update
 import kotlinx.coroutines.flow.StateFlow
 
 /**
- * Observes whether a newer desktop release is available. The UI collects [status]; nothing checks
- * automatically — a caller (the app shell, a manual "check now" action) invokes [checkForUpdate].
- * This item performs the *check* only; downloading and installing an update is a later item.
+ * Observes whether a newer desktop release is available and, where the packaging supports it,
+ * applies it. The UI collects [status]; nothing checks automatically — a caller (the app shell, a
+ * manual "check now" action) invokes [checkForUpdate].
+ *
+ * Two implementations sit behind this seam: [RealUpdateController] checks GitHub Releases and
+ * cannot self-apply, while [ConveyorUpdateController] uses Conveyor's control API to both check and
+ * apply. DI picks the Conveyor one only when the app runs inside a Conveyor package (#5227, PR-C2).
  */
 interface UpdateController {
   /** Current update state. Starts at [UpdateStatus.Idle] until the first [checkForUpdate]. */
@@ -17,4 +21,18 @@ interface UpdateController {
    * leaving [status] at its prior stable value.
    */
   suspend fun checkForUpdate()
+
+  /**
+   * Whether [applyUpdate] can install an update in place. `false` for the GitHub-Releases checker
+   * (it only surfaces the release) and on platforms Conveyor can't trigger from the app (Linux
+   * updates flow through apt). The UI enables its "Install & restart" action on this.
+   */
+  fun canApplyUpdate(): Boolean
+
+  /**
+   * Applies the available update — download, install, restart — handing off to the platform
+   * updater. The app process is expected to exit as part of this, so callers must save state first.
+   * A no-op when [canApplyUpdate] is `false`. Performs I/O; call off the UI thread.
+   */
+  suspend fun applyUpdate()
 }

--- a/android/desktop-core/src/main/kotlin/dev/jasonpearson/automobile/desktop/core/update/UpdateStatus.kt
+++ b/android/desktop-core/src/main/kotlin/dev/jasonpearson/automobile/desktop/core/update/UpdateStatus.kt
@@ -23,11 +23,17 @@ sealed interface UpdateStatus {
    */
   data object UpToDate : UpdateStatus
 
-  /** A newer release exists with an installer for this OS. */
+  /**
+   * A newer release is available. [asset] is the OS-specific installer for the GitHub-Releases
+   * checker ([RealUpdateController]); it is `null` for a Conveyor-managed update
+   * ([ConveyorUpdateController]), which owns the download and exposes no per-asset URL.
+   * [releaseNotesUrl] is likewise GitHub-only. Whether the app can apply the update in place is
+   * answered by [UpdateController.canApplyUpdate], not carried here.
+   */
   data class UpdateAvailable(
     val version: String,
-    val asset: ReleaseAsset,
-    val releaseNotesUrl: String?,
+    val asset: ReleaseAsset? = null,
+    val releaseNotesUrl: String? = null,
   ) : UpdateStatus
 
   /** The check could not complete (network, rate limit, malformed response). */

--- a/android/desktop-core/src/test/kotlin/dev/jasonpearson/automobile/desktop/core/shell/UpdateReadyButtonUiTest.kt
+++ b/android/desktop-core/src/test/kotlin/dev/jasonpearson/automobile/desktop/core/shell/UpdateReadyButtonUiTest.kt
@@ -3,6 +3,7 @@ package dev.jasonpearson.automobile.desktop.core.shell
 import androidx.compose.material3.MaterialTheme
 import androidx.compose.ui.test.ExperimentalTestApi
 import androidx.compose.ui.test.assertIsDisplayed
+import androidx.compose.ui.test.assertIsEnabled
 import androidx.compose.ui.test.assertIsNotEnabled
 import androidx.compose.ui.test.onNodeWithText
 import androidx.compose.ui.test.performClick
@@ -74,17 +75,36 @@ class UpdateReadyButtonUiTest {
   }
 
   @Test
-  fun `install action is present but disabled in this item`() = runComposeUiTest {
+  fun `install action is disabled when no install callback is supplied`() = runComposeUiTest {
     setContent {
       MaterialTheme {
         UpdateDetailsContent(
           update = available,
           currentVersion = "0.0.52",
           onOpenReleaseNotes = {},
+          // onInstall defaults to null (the GitHub-Releases path, which can't apply in place).
         )
       }
     }
-    // The install affordance exists but is not yet actionable (delivered by a later item).
     onNodeWithText("Install", substring = true).assertIsNotEnabled()
   }
+
+  @Test
+  fun `install action is enabled and invokes the callback when one is supplied`() =
+    runComposeUiTest {
+      var installs = 0
+      setContent {
+        MaterialTheme {
+          UpdateDetailsContent(
+            update = available,
+            currentVersion = "0.0.52",
+            onOpenReleaseNotes = {},
+            onInstall = { installs++ },
+          )
+        }
+      }
+      onNodeWithText("Install", substring = true).assertIsEnabled()
+      onNodeWithText("Install", substring = true).performClick()
+      assertEquals(1, installs)
+    }
 }

--- a/android/desktop-core/src/test/kotlin/dev/jasonpearson/automobile/desktop/core/update/ConveyorUpdateControllerTest.kt
+++ b/android/desktop-core/src/test/kotlin/dev/jasonpearson/automobile/desktop/core/update/ConveyorUpdateControllerTest.kt
@@ -1,0 +1,92 @@
+package dev.jasonpearson.automobile.desktop.core.update
+
+import kotlin.test.Test
+import kotlin.test.assertEquals
+import kotlin.test.assertFalse
+import kotlin.test.assertIs
+import kotlin.test.assertNull
+import kotlin.test.assertTrue
+import kotlinx.coroutines.CancellationException
+import kotlinx.coroutines.test.runTest
+
+/** Maps a [SoftwareUpdateGateway] probe to [UpdateStatus] and delegates apply to the gateway. */
+class ConveyorUpdateControllerTest {
+
+  @Test
+  fun `up-to-date probe yields UpToDate`() = runTest {
+    val gateway = FakeSoftwareUpdateGateway(probeResult = UpdateProbe.UpToDate)
+    val controller = ConveyorUpdateController(gateway)
+
+    controller.checkForUpdate()
+
+    assertTrue(gateway.probed)
+    assertIs<UpdateStatus.UpToDate>(controller.status.value)
+  }
+
+  @Test
+  fun `available probe yields UpdateAvailable with no asset or notes`() = runTest {
+    val gateway = FakeSoftwareUpdateGateway(probeResult = UpdateProbe.Available("1.2.3"))
+    val controller = ConveyorUpdateController(gateway)
+
+    controller.checkForUpdate()
+
+    val status = controller.status.value
+    assertIs<UpdateStatus.UpdateAvailable>(status)
+    assertEquals("1.2.3", status.version)
+    // Conveyor owns the download; there is no per-asset URL or release-notes link to carry.
+    assertNull(status.asset)
+    assertNull(status.releaseNotesUrl)
+  }
+
+  @Test
+  fun `probe failure yields Failed rather than throwing`() = runTest {
+    val gateway =
+      FakeSoftwareUpdateGateway(probeError = UpdateProbeException("repository unreachable"))
+    val controller = ConveyorUpdateController(gateway)
+
+    controller.checkForUpdate()
+
+    val status = controller.status.value
+    assertIs<UpdateStatus.Failed>(status)
+    assertEquals("repository unreachable", status.reason)
+  }
+
+  @Test
+  fun `cancellation during the probe restores the prior status and rethrows`() = runTest {
+    // A CancellationException surfacing from the probe stands in for the coroutine being cancelled
+    // mid-network-call: the controller must restore the last stable status (Idle) and rethrow,
+    // never leave the shared StateFlow pinned at Checking.
+    val gateway = FakeSoftwareUpdateGateway(probeError = CancellationException("cancelled"))
+    val controller = ConveyorUpdateController(gateway)
+
+    var rethrown = false
+    try {
+      controller.checkForUpdate()
+    } catch (cancellation: CancellationException) {
+      rethrown = true
+    }
+
+    assertTrue(rethrown)
+    assertIs<UpdateStatus.Idle>(controller.status.value)
+  }
+
+  @Test
+  fun `canApplyUpdate delegates to the gateway`() = runTest {
+    assertTrue(
+      ConveyorUpdateController(FakeSoftwareUpdateGateway(canApply = true)).canApplyUpdate()
+    )
+    assertFalse(
+      ConveyorUpdateController(FakeSoftwareUpdateGateway(canApply = false)).canApplyUpdate()
+    )
+  }
+
+  @Test
+  fun `applyUpdate hands off to the gateway`() = runTest {
+    val gateway = FakeSoftwareUpdateGateway(canApply = true)
+    val controller = ConveyorUpdateController(gateway)
+
+    controller.applyUpdate()
+
+    assertTrue(gateway.applied)
+  }
+}

--- a/android/desktop-core/src/test/kotlin/dev/jasonpearson/automobile/desktop/core/update/FakeSoftwareUpdateGateway.kt
+++ b/android/desktop-core/src/test/kotlin/dev/jasonpearson/automobile/desktop/core/update/FakeSoftwareUpdateGateway.kt
@@ -1,0 +1,33 @@
+package dev.jasonpearson.automobile.desktop.core.update
+
+/**
+ * A configurable [SoftwareUpdateGateway] for tests: returns a canned [probe] result (or throws),
+ * reports a fixed [canApply], and records whether [apply] ran — so [ConveyorUpdateController] can
+ * be exercised without a real Conveyor package.
+ */
+class FakeSoftwareUpdateGateway(
+  private val probeResult: UpdateProbe = UpdateProbe.UpToDate,
+  private val probeError: Exception? = null,
+  private val canApply: Boolean = false,
+  private val onApply: () -> Unit = {},
+) : SoftwareUpdateGateway {
+
+  var probed = false
+    private set
+
+  var applied = false
+    private set
+
+  override fun probe(): UpdateProbe {
+    probed = true
+    probeError?.let { throw it }
+    return probeResult
+  }
+
+  override fun canApply(): Boolean = canApply
+
+  override fun apply() {
+    applied = true
+    onApply()
+  }
+}

--- a/android/desktop-core/src/test/kotlin/dev/jasonpearson/automobile/desktop/core/update/FakeUpdateController.kt
+++ b/android/desktop-core/src/test/kotlin/dev/jasonpearson/automobile/desktop/core/update/FakeUpdateController.kt
@@ -15,4 +15,10 @@ class FakeUpdateController(initial: UpdateStatus = UpdateStatus.Idle) : UpdateCo
   override suspend fun checkForUpdate() {
     // No-op: the fixed status stands in for a real check.
   }
+
+  override fun canApplyUpdate(): Boolean = false
+
+  override suspend fun applyUpdate() {
+    // No-op: the fake never applies an update.
+  }
 }

--- a/android/desktop-core/src/test/kotlin/dev/jasonpearson/automobile/desktop/core/update/RealUpdateControllerTest.kt
+++ b/android/desktop-core/src/test/kotlin/dev/jasonpearson/automobile/desktop/core/update/RealUpdateControllerTest.kt
@@ -54,7 +54,7 @@ class RealUpdateControllerTest {
     val status = controller.status.value
     assertIs<UpdateStatus.UpdateAvailable>(status)
     assertEquals("0.0.53", status.version)
-    assertEquals("AutoMobile-x-macos.dmg", status.asset.name)
+    assertEquals("AutoMobile-x-macos.dmg", status.asset?.name)
     assertEquals("https://notes", status.releaseNotesUrl)
   }
 

--- a/android/gradle/libs.versions.toml
+++ b/android/gradle/libs.versions.toml
@@ -79,6 +79,9 @@ compose-multiplatform = "1.11.1"
 compose-hot-reload = "1.2.0"
 metro = "1.4.1"
 conveyor = "2.0"
+# Conveyor's in-app update control API (SoftwareUpdateController). Versioned independently of the
+# `conveyor` Gradle plugin above — this is the runtime library the desktop app links against.
+conveyor-control = "1.1"
 
 [plugins]
 compose-compiler = { id = "org.jetbrains.kotlin.plugin.compose", version.ref = "build-kotlin" }
@@ -111,6 +114,7 @@ kgp = { module = "org.jetbrains.kotlin:kotlin-gradle-plugin", version.ref = "bui
 kotlin-stdlib-consumer = { module = "org.jetbrains.kotlin:kotlin-stdlib", version.ref = "build-kotlin-consumer" }
 agp = { module = "com.android.tools.build:gradle", version.ref = "build-android-agp" }
 
+conveyor-control = { module = "dev.hydraulic.conveyor:conveyor-control", version.ref = "conveyor-control" }
 koog-agents = { module = "ai.koog:koog-agents", version.ref = "koog-agents" }
 kotlin-test = { module = "org.jetbrains.kotlin:kotlin-test" }
 kotlinx-coroutines-test = { module = "org.jetbrains.kotlinx:kotlinx-coroutines-test", version.ref = "kotlinx-coroutines-test" }


### PR DESCRIPTION
## Summary

**PR-C2 of the Conveyor pivot** ([#5227](https://github.com/kaeawc/auto-mobile/issues/5227)),
building on the C1 scaffold ([#5305](https://github.com/kaeawc/auto-mobile/pull/5305)). Rewires the
desktop update **internals** to Conveyor's in-app control API
([`SoftwareUpdateController`](https://conveyor.hydraulic.dev/latest/control-api-jvm/)) while keeping
the existing `UpdateController` / `UpdateStatus` UI seam and **coexisting** with the GitHub-Releases
checker — no regression for jpackage builds, and it also enables the previously-stubbed
"Install & restart" action.

## Why this shape

The current updater is *check-only*: it surfaces an "update ready" pill from GitHub Releases, and
the "Install & restart" button was a disabled stub (no download/install code ever existed). So C2
adds a Conveyor-backed controller behind the same seam rather than replacing the UI.

`SoftwareUpdateController.getInstance()` returns `null` unless the app runs inside a Conveyor
package — i.e. `null` in development, jpackage builds, and tests. That drives the coexistence
design: DI picks the Conveyor controller **only** inside a Conveyor package, otherwise it falls back
to today's GitHub checker. jpackage keeps working until C4 retires it.

## Changes

- **`gradle/libs.versions.toml` + `desktop-core/build.gradle.kts`**: add
  `dev.hydraulic.conveyor:conveyor-control:1.1`.
- **`SoftwareUpdateGateway`** (new): a narrow, fakeable seam over `SoftwareUpdateController` —
  `probe(): UpdateProbe`, `canApply()`, `apply()`. **`ConveyorSoftwareUpdateGateway`** (new) is the
  real impl; `createOrNull()` returns `null` when not in a Conveyor package, so `getInstance()==null`
  degrades gracefully.
- **`ConveyorUpdateController`** (new): maps a probe → `UpdateStatus` on `Dispatchers.IO`, mirroring
  `RealUpdateController`'s mutex/cancellation semantics, and implements the apply path.
- **`UpdateController`**: gains `canApplyUpdate(): Boolean` + `suspend applyUpdate()`.
  `RealUpdateController` (GitHub) returns `false` / no-op — its DIY apply was never built.
- **DI** (`ApplicationModule`, `LocalAutoMobileGraph`): select `ConveyorUpdateController` when
  `ConveyorSoftwareUpdateGateway.createOrNull() != null`, else `RealUpdateController`.
- **UI** (`UpdateReadyButton`): `UpdateDetailsContent` gains an optional `onInstall`; the
  "Install & restart" button is enabled only when it's non-null. The app wires it to `applyUpdate()`
  gated on `canApplyUpdate()`.
- **`UpdateStatus.UpdateAvailable`**: `asset` / `releaseNotesUrl` are now nullable — Conveyor owns
  the download and exposes no per-asset URL. The GitHub path still populates them.

## Tests (fast, fakes only — no real Conveyor package)

- `ConveyorUpdateControllerTest`: probe → `UpToDate` / `UpdateAvailable` (no asset/notes) / `Failed`;
  cancellation restores the prior stable status and rethrows; `canApplyUpdate` / `applyUpdate`
  delegate to the gateway. (6 tests)
- `UpdateReadyButtonUiTest`: install action disabled without `onInstall`, enabled + invoked with it.

## Validation

- [x] `:desktop-core:test` + `:desktop-app:test` green
- [x] Detekt green on desktop-core + desktop-app (main + test)
- [x] `scripts/ktfmt/validate_ktfmt.sh` clean on touched files
- [x] The GitHub-Releases path is unchanged for jpackage/dev builds (gateway is `null` there)

## Not done here (PR-C3)

The Conveyor CLI, `conveyor make`, signing, the CI cutover, and the
`StripFfmpegProgramsTransform` fix. The real gateway path only activates inside a Conveyor package;
everything in this PR is exercised via the GitHub fallback + fakes.

## Linked

Part of the Conveyor migration on #5227. Predecessor: #5305 (C1). Follow-ups: PR-C3 (CI cutover +
signing), PR-C4 (retire jpackage + cleanup).
