### PR TITLE
ci: skip ffmpeg install in installer validation jobs

### DIFF
--- a/.github/workflows/merge.yml
+++ b/.github/workflows/merge.yml
@@ -466,6 +466,10 @@ jobs:
   installer-minimal:
     name: "Installer Minimal (${{ matrix.os }})"
     runs-on: ${{ matrix.os }}
+    env:
+      # ffmpeg is a large, slow install (it has timed out this job) and video
+      # recording is not exercised here — skip it.
+      AUTOMOBILE_INSTALL_SKIP_FFMPEG: "true"
     strategy:
       fail-fast: false
       matrix:
@@ -546,6 +550,7 @@ jobs:
         continue-on-error: true
         env:
           # Keep this disabled-job definition aligned with the PR installer lane.
+          AUTOMOBILE_INSTALL_SKIP_FFMPEG: "true"
           AUTOMOBILE_DAEMON_STARTUP_TIMEOUT_MS: "30000"
           AUTOMOBILE_STARTUP_BENCHMARK: "1"
           AUTOMOBILE_STARTUP_BENCHMARK_OUTPUT: "${{ github.workspace }}/ci-logs/installer-daemon-startup.json"

--- a/.github/workflows/pull_request.yml
+++ b/.github/workflows/pull_request.yml
@@ -951,6 +951,9 @@ jobs:
     needs: detect-changes
     env:
       RUN_INSTALLER: ${{ needs.detect-changes.outputs.docs_only != 'true' }}
+      # ffmpeg is a large, slow install (it has timed out this job) and video
+      # recording is not exercised here — skip it.
+      AUTOMOBILE_INSTALL_SKIP_FFMPEG: "true"
     strategy:
       fail-fast: false
       matrix:
@@ -1017,6 +1020,9 @@ jobs:
     needs: detect-changes
     env:
       RUN_INSTALLER: ${{ needs.detect-changes.outputs.docs_only != 'true' }}
+      # ffmpeg is a large, slow install (it has timed out this job) and video
+      # recording is not exercised here — skip it.
+      AUTOMOBILE_INSTALL_SKIP_FFMPEG: "true"
     strategy:
       fail-fast: false
       matrix:

--- a/scripts/install.sh
+++ b/scripts/install.sh
@@ -3289,8 +3289,13 @@ _install_system_package() {
 }
 
 install_runtime_deps() {
-    # ffmpeg — required for video recording features
-    if ! command_exists ffmpeg; then
+    # ffmpeg — required for video recording features.
+    # CI can opt out via AUTOMOBILE_INSTALL_SKIP_FFMPEG=true: ffmpeg is a large,
+    # slow dependency (its install has timed out the installer check) and video
+    # recording is not exercised by the installer validation jobs.
+    if [[ "${AUTOMOBILE_INSTALL_SKIP_FFMPEG:-false}" == "true" ]]; then
+        log_info "Skipping ffmpeg install (AUTOMOBILE_INSTALL_SKIP_FFMPEG=true) — video recording will be unavailable"
+    elif ! command_exists ffmpeg; then
         _install_system_package "ffmpeg" "required for video recording"
     fi
 }

--- a/test/bats/install-runtime-deps.bats
+++ b/test/bats/install-runtime-deps.bats
@@ -26,6 +26,21 @@ setup() {
   [ "$status" -eq 1 ]
 }
 
+@test "skips ffmpeg install and succeeds when AUTOMOBILE_INSTALL_SKIP_FFMPEG=true" {
+  command_exists() {
+    [[ "$1" != "ffmpeg" ]]
+  }
+  _install_system_package() {
+    # Must never be called when the skip flag is set.
+    return 1
+  }
+  export AUTOMOBILE_INSTALL_SKIP_FFMPEG=true
+
+  run install_runtime_deps
+
+  [ "$status" -eq 0 ]
+}
+
 @test "succeeds when ffmpeg is already installed" {
   command_exists() {
     [[ "$1" == "ffmpeg" ]]


### PR DESCRIPTION
## Problem

The installer CI checks (`Installer Minimal` / `Installer Development`) were spending their entire budget on `brew install ffmpeg`, hitting the installer's 600s bounded-install ceiling and aborting:

```
INFO Installing ffmpeg (required for video recording)...
WARN Installing ffmpeg exceeded 600s and was aborted
WARN ffmpeg install failed — required for video recording will be unavailable
```

ffmpeg is a large, slow dependency and is only used by video recording, which the installer validation jobs do not exercise — so installing it there is pure cost.

## Change

- `install_runtime_deps()` now honors `AUTOMOBILE_INSTALL_SKIP_FFMPEG=true`, logging a skip instead of installing. Default behavior (real installs for end users) is unchanged.
- Set the flag at the job level for `installer-minimal` and `installer-development` in `pull_request.yml`, and on the corresponding merge-lane jobs in `merge.yml`.
- Added BATS coverage for the skip path.

## Validation

- Fast validation `shellcheck` + `yaml`: pass
- `bats test/bats/install-runtime-deps.bats`: 4/4 pass
