### PR TITLE
fix(test): bound H.264 integration ADB setup

### DIFF
--- a/scripts/android/validate-no-desktop-core-unified.sh
+++ b/scripts/android/validate-no-desktop-core-unified.sh
@@ -17,7 +17,7 @@ if [[ ! -d "$PROJECT_ROOT/android" ]]; then
   exit 1
 fi
 
-if matches="$(git -C "$PROJECT_ROOT" grep --untracked --fixed-strings --line-number "$UNIFIED_PACKAGE" -- android)"; then
+if matches="$(rg --fixed-strings --line-number -- "$UNIFIED_PACKAGE" "$PROJECT_ROOT/android")"; then
   echo "desktop-core still references the deleted core.unified package:" >&2
   echo "$matches" >&2
   exit 1

--- a/scripts/check-host-shell-boundary.ts
+++ b/scripts/check-host-shell-boundary.ts
@@ -20,14 +20,14 @@ export function repositoryPath(file: string): string {
   return relative(".", file).replaceAll("\\", "/");
 }
 
-type GitRunner = (file: string, args: string[]) => string;
+type CommandRunner = (file: string, args: string[]) => string;
 
-const runGit: GitRunner = (file, args) => execFileSync(file, args, { encoding: "utf8" });
+const runCommand: CommandRunner = (file, args) => execFileSync(file, args, { encoding: "utf8" });
 
 export function resolveBaseRef(
   requestedBaseRef: string,
   environment: NodeJS.ProcessEnv = process.env,
-  runner: GitRunner = runGit
+  runner: CommandRunner = runCommand
 ): string {
   let baseRef = requestedBaseRef;
   try {
@@ -42,6 +42,19 @@ export function resolveBaseRef(
     } catch {
       throw new Error(`Cannot check new host shell execution: base ref ${baseRef} does not exist.`);
     }
+  }
+  return baseRef;
+}
+
+export function resolveJjBaseRef(
+  requestedBaseRef: string,
+  runner: CommandRunner = runCommand
+): string {
+  const baseRef = requestedBaseRef === "origin/main" ? "main@origin" : requestedBaseRef;
+  try {
+    runner("jj", ["log", "-r", baseRef, "--no-graph", "-T", ""]);
+  } catch {
+    throw new Error(`Cannot check new host shell execution: base ref ${baseRef} does not exist.`);
   }
   return baseRef;
 }
@@ -181,10 +194,21 @@ export function findViolationsInSource(file: string, source: string): Violation[
   return violations;
 }
 
-export function changedSourceFiles(baseRef: string, hasGitDirectory = existsSync(".git")): string[] {
-  if (!hasGitDirectory) {throw new Error("Cannot check new host shell execution: this directory is not a Git worktree.");}
-  const resolvedBaseRef = resolveBaseRef(baseRef);
-  return execFileSync("git", ["diff", "--name-only", resolvedBaseRef, "--", SOURCE_ROOT], { encoding: "utf8" })
+export function changedSourceFiles(
+  baseRef: string,
+  hasGitDirectory = existsSync(".git"),
+  hasJjDirectory = existsSync(".jj"),
+  runner: CommandRunner = runCommand
+): string[] {
+  if (!hasGitDirectory && !hasJjDirectory) {
+    throw new Error("Cannot check new host shell execution: this directory is not a Git or Jujutsu worktree.");
+  }
+  const useJj = hasJjDirectory && !hasGitDirectory;
+  const resolvedBaseRef = useJj ? resolveJjBaseRef(baseRef, runner) : resolveBaseRef(baseRef, process.env, runner);
+  const changedFiles = useJj
+    ? runner("jj", ["diff", "--from", resolvedBaseRef, "--to", "@", "--name-only", SOURCE_ROOT])
+    : runner("git", ["diff", "--name-only", resolvedBaseRef, "--", SOURCE_ROOT]);
+  return changedFiles
     .split("\n")
     .filter(file => file.endsWith(".ts") && existsSync(file));
 }

--- a/scripts/check-lfs-pointers.sh
+++ b/scripts/check-lfs-pointers.sh
@@ -7,9 +7,11 @@ set -euo pipefail
 # checkout (jj bypasses git filters entirely, see jj-vcs/jj#80) or any clone
 # with LFS uninstalled — and would permanently bloat history once merged.
 #
-# Uses git plumbing only: attribute resolution comes from git check-attr and
-# blob inspection from git cat-file, so the check needs neither the git-lfs
-# binary nor downloaded LFS objects (CI checks out with lfs: false).
+# Uses Git plumbing in Git worktrees. Pure jj workspaces materialize the
+# versioned `.gitattributes` files in a temporary Git repository for attribute
+# resolution, then inspect file contents through `jj file show`; neither mode
+# needs the git-lfs binary or downloaded LFS objects (CI checks out with
+# lfs: false).
 #
 # Usage: check-lfs-pointers.sh [rev]   (defaults to HEAD)
 
@@ -17,25 +19,68 @@ rev="${1:-HEAD}"
 pointer_prefix='version https://git-lfs.github.com/spec/v1'
 violations=()
 
-while IFS= read -r -d '' path && IFS= read -r -d '' _attr && IFS= read -r -d '' value; do
+check_pointer() {
+  local path="$1"
+  local size="$2"
+  local prefix_bytes="$3"
   # Only files whose resolved filter attribute is lfs; paths where a later
   # .gitattributes line unsets the filter (-filter) resolve to "unset".
-  [[ "$value" == "lfs" ]] || continue
-
-  # Symlinks and gitlinks have no blob content to check.
-  size="$(git cat-file -s "$rev:$path" 2>/dev/null)" || continue
-
+  [[ "$size" =~ ^[0-9]+$ ]] || return
   # A canonical LFS pointer is a small text file; git-lfs itself only treats
   # blobs of at most 1024 bytes as pointer candidates.
   if (( size > 1024 )); then
     violations+=("$path (${size}-byte blob, expected an LFS pointer)")
-    continue
+    return
   fi
-  prefix_bytes="$(git cat-file blob "$rev:$path" | head -c "${#pointer_prefix}")"
   if [[ "$prefix_bytes" != "$pointer_prefix" ]]; then
     violations+=("$path (small blob but not an LFS pointer)")
   fi
-done < <(git ls-tree -r -z --name-only "$rev" | git check-attr --stdin -z filter)
+}
+
+check_git_revision() {
+  while IFS= read -r -d '' path && IFS= read -r -d '' _attr && IFS= read -r -d '' value; do
+    [[ "$value" == "lfs" ]] || continue
+    # Symlinks and gitlinks have no blob content to check.
+    size="$(git cat-file -s "$rev:$path" 2>/dev/null)" || continue
+    prefix_bytes="$(git cat-file blob "$rev:$path" | head -c "${#pointer_prefix}")"
+    check_pointer "$path" "$size" "$prefix_bytes"
+  done < <(git ls-tree -r -z --name-only "$rev" | git check-attr --stdin -z filter)
+}
+
+check_jj_revision() {
+  local jj_rev="${1:-@}"
+  local attrs_input attributes_output blob path _attr value size prefix_bytes
+  temp_dir="$(mktemp -d)"
+  attrs_input="$temp_dir/paths"
+  attributes_output="$temp_dir/attributes"
+  blob="$temp_dir/blob"
+  trap 'rm -rf "$temp_dir"' EXIT
+
+  git -C "$temp_dir" init -q
+  while IFS= read -r path; do
+    mkdir -p "$temp_dir/$(dirname "$path")"
+    jj file show -r "$jj_rev" "$path" > "$temp_dir/$path"
+  done < <(jj file list -r "$jj_rev" | rg '(^|/)\.gitattributes$')
+
+  vcs_list_files "$jj_rev" > "$attrs_input"
+  git -C "$temp_dir" check-attr --stdin -z filter < "$attrs_input" > "$attributes_output"
+  while IFS= read -r -d '' path && IFS= read -r -d '' _attr && IFS= read -r -d '' value; do
+    [[ "$value" == "lfs" ]] || continue
+    jj file show -r "$jj_rev" "$path" > "$blob"
+    size="$(wc -c < "$blob" | tr -d '[:space:]')"
+    prefix_bytes="$(head -c "${#pointer_prefix}" "$blob")"
+    check_pointer "$path" "$size" "$prefix_bytes"
+  done < "$attributes_output"
+}
+
+# shellcheck disable=SC1091 # Resolved relative to this script's location.
+source "$(dirname "${BASH_SOURCE[0]}")/lib/vcs-diff.sh"
+if vcs_uses_jj; then
+  rev="${1:-@}"
+  check_jj_revision "$rev"
+else
+  check_git_revision
+fi
 
 if ((${#violations[@]})); then
   {

--- a/scripts/check-no-new-direct-security.sh
+++ b/scripts/check-no-new-direct-security.sh
@@ -7,16 +7,18 @@ set -euo pipefail
 base_ref="${1:-origin/main}"
 owner="src/utils/ios-cmdline-tools/SecurityClient.ts"
 violations=()
+# shellcheck disable=SC1091 # Resolved relative to this script's location.
+source "$(dirname "${BASH_SOURCE[0]}")/lib/vcs-diff.sh"
 
-if ! git rev-parse --verify --quiet "${base_ref}^{commit}" >/dev/null; then
-  if [[ "$base_ref" == 'origin/main' && "${GITHUB_ACTIONS:-}" == 'true' && -n "${GITHUB_BASE_REF:-}" ]]; then
+if ! vcs_base_exists "$base_ref"; then
+  if ! vcs_uses_jj && [[ "$base_ref" == 'origin/main' && "${GITHUB_ACTIONS:-}" == 'true' && -n "${GITHUB_BASE_REF:-}" ]]; then
     base_ref="origin/$GITHUB_BASE_REF"
     git fetch --no-tags --depth=1 origin \
       "refs/heads/$GITHUB_BASE_REF:refs/remotes/origin/$GITHUB_BASE_REF"
   fi
 
-  if ! git rev-parse --verify --quiet "${base_ref}^{commit}" >/dev/null; then
-    printf 'Cannot check new security calls: base ref %s does not exist.\n' "$base_ref" >&2
+  if ! vcs_base_exists "$base_ref"; then
+    printf 'Cannot check new security calls: base ref %s does not exist.\n' "$(vcs_base_ref "$base_ref")" >&2
     exit 2
   fi
 fi
@@ -28,12 +30,12 @@ pattern="(\"|\\\`|')(/usr/bin/)?security([[:space:]]|\"|\\\`|')"
 
 while IFS= read -r file; do
   [[ "$file" == "$owner" ]] && continue
-  added_lines="$(git diff --unified=0 "$base_ref" -- "$file" | awk '/^\+[^+]/ { printf "%s ", substr($0, 2) }')"
+  added_lines="$(vcs_diff "$base_ref" "$file" | awk '/^\+[^+]/ { printf "%s ", substr($0, 2) }')"
   [[ -z "$added_lines" ]] && continue
   if grep -Eq "$pattern" <<<"$added_lines"; then
     violations+=("$file")
   fi
-done < <(git diff --name-only "$base_ref" -- src)
+done < <(vcs_changed_files "$base_ref" src)
 
 if ((${#violations[@]})); then
   printf '%s\n' 'New production security execution must go through SecurityClient:' >&2

--- a/scripts/check-no-new-direct-simctl.sh
+++ b/scripts/check-no-new-direct-simctl.sh
@@ -8,18 +8,20 @@ set -euo pipefail
 base_ref="${1:-origin/main}"
 owner="src/utils/ios-cmdline-tools/SimCtlClient.ts"
 violations=()
+# shellcheck disable=SC1091 # Resolved relative to this script's location.
+source "$(dirname "${BASH_SOURCE[0]}")/lib/vcs-diff.sh"
 
-if ! git rev-parse --verify --quiet "${base_ref}^{commit}" >/dev/null; then
+if ! vcs_base_exists "$base_ref"; then
   # pull_request checkouts are shallow by default, so neither origin/main nor
   # HEAD^1 is guaranteed to exist. Fetch the actual PR base before comparing.
-  if [[ "$base_ref" == 'origin/main' && "${GITHUB_ACTIONS:-}" == 'true' && -n "${GITHUB_BASE_REF:-}" ]]; then
+  if ! vcs_uses_jj && [[ "$base_ref" == 'origin/main' && "${GITHUB_ACTIONS:-}" == 'true' && -n "${GITHUB_BASE_REF:-}" ]]; then
     base_ref="origin/$GITHUB_BASE_REF"
     git fetch --no-tags --depth=1 origin \
       "refs/heads/$GITHUB_BASE_REF:refs/remotes/origin/$GITHUB_BASE_REF"
   fi
 
-  if ! git rev-parse --verify --quiet "${base_ref}^{commit}" >/dev/null; then
-    printf 'Cannot check new simctl calls: base ref %s does not exist.\n' "$base_ref" >&2
+  if ! vcs_base_exists "$base_ref"; then
+    printf 'Cannot check new simctl calls: base ref %s does not exist.\n' "$(vcs_base_ref "$base_ref")" >&2
     exit 2
   fi
 fi
@@ -34,13 +36,13 @@ while IFS= read -r file; do
   [[ "$file" == "$owner" ]] && continue
   [[ "$file" == test/* ]] && continue
 
-  added_lines="$(git diff --unified=0 "$base_ref" -- "$file" | awk '/^\+[^+]/ { printf "%s ", substr($0, 2) }')"
+  added_lines="$(vcs_diff "$base_ref" "$file" | awk '/^\+[^+]/ { printf "%s ", substr($0, 2) }')"
   [[ -z "$added_lines" ]] && continue
 
   if grep -Eq "$pattern" <<<"$added_lines"; then
     violations+=("$file")
   fi
-done < <(git diff --name-only "$base_ref" -- src)
+done < <(vcs_changed_files "$base_ref" src)
 
 if ((${#violations[@]})); then
   printf '%s\n' "New production xcrun simctl execution must go through SimCtlClient:" >&2

--- a/scripts/check-no-new-direct-xcodebuild.sh
+++ b/scripts/check-no-new-direct-xcodebuild.sh
@@ -7,9 +7,11 @@ set -euo pipefail
 base_ref="${1:-origin/main}"
 owner="src/utils/ios-cmdline-tools/XcodebuildClient.ts"
 violations=()
+# shellcheck disable=SC1091 # Resolved relative to this script's location.
+source "$(dirname "${BASH_SOURCE[0]}")/lib/vcs-diff.sh"
 
-if ! git rev-parse --verify --quiet "${base_ref}^{commit}" >/dev/null; then
-  printf 'Cannot check new xcodebuild calls: base ref %s does not exist.\n' "$base_ref" >&2
+if ! vcs_base_exists "$base_ref"; then
+  printf 'Cannot check new xcodebuild calls: base ref %s does not exist.\n' "$(vcs_base_ref "$base_ref")" >&2
   exit 2
 fi
 
@@ -19,12 +21,12 @@ pattern="(${direct_process_call}\\([^;]*xcodebuild|(const|let|var)[^;=]*=[^;]*${
 
 while IFS= read -r file; do
   [[ "$file" == "$owner" || "$file" == test/* ]] && continue
-  added_lines="$(git diff --unified=0 "$base_ref" -- "$file" | awk '/^\+[^+]/ { print substr($0, 2) }' | perl -0pe 's{/\*.*?\*/}{}gs; s{//[^\n]*}{}g' | tr '\n' ' ')"
+  added_lines="$(vcs_diff "$base_ref" "$file" | awk '/^\+[^+]/ { print substr($0, 2) }' | perl -0pe 's{/\*.*?\*/}{}gs; s{//[^\n]*}{}g' | tr '\n' ' ')"
   [[ -z "$added_lines" ]] && continue
   if grep -Eq "$pattern" <<<"$added_lines"; then
     violations+=("$file")
   fi
-done < <(git diff --name-only "$base_ref" -- src)
+done < <(vcs_changed_files "$base_ref" src)
 
 if ((${#violations[@]})); then
   printf '%s\n' "New production xcodebuild execution must go through XcodebuildClient:" >&2

--- a/scripts/check-stdlib-first.sh
+++ b/scripts/check-stdlib-first.sh
@@ -11,13 +11,19 @@ BASE_REF="${STDLIB_FIRST_BASE_REF:-origin/main}"
 
 cd "$ROOT_DIR"
 
-if ! git rev-parse --verify --quiet "${BASE_REF}^{commit}" >/dev/null; then
+# shellcheck disable=SC1091 # Resolved relative to this script's location.
+source "$ROOT_DIR/scripts/lib/vcs-diff.sh"
+
+set +e
+vcs_base_exists "$BASE_REF"
+base_exists=$?
+set -e
+if [[ "$base_exists" -ne 0 ]]; then
   echo "error: stdlib-first check cannot resolve base ref '${BASE_REF}'" >&2
   exit 2
 fi
 
-BASE_COMMIT="$(git merge-base "$BASE_REF" HEAD)"
-BASE_PACKAGE_JSON="$(git show "${BASE_COMMIT}:package.json")"
+BASE_PACKAGE_JSON="$(vcs_file_at_merge_base "$BASE_REF" package.json)"
 CURRENT_PACKAGE_JSON="$(<package.json)"
 
 base_dependencies="$(jq -r '(.dependencies // {} | keys[]) , (.devDependencies // {} | keys[]) , (.optionalDependencies // {} | keys[])' <<<"$BASE_PACKAGE_JSON" | sort -u)"

--- a/scripts/ktfmt/validate_ktfmt.sh
+++ b/scripts/ktfmt/validate_ktfmt.sh
@@ -10,8 +10,8 @@ ONLY_CHANGED_SINCE_SHA=${ONLY_CHANGED_SINCE_SHA:-""}
 # shellcheck source=scripts/ktfmt/ktfmt_version.sh disable=SC1091
 source "$(dirname "${BASH_SOURCE[0]}")/ktfmt_version.sh"
 
-# Shared git file-selection + install-when-missing helpers (issue #2823).
-# shellcheck source=scripts/lib/file-selection.sh disable=SC1091
+# Shared VCS file-selection + install-when-missing helpers (issue #2823).
+# shellcheck disable=SC1091 # Resolved relative to this script's location.
 source "$(dirname "${BASH_SOURCE[0]}")/../lib/file-selection.sh"
 
 # Colors for output
@@ -19,11 +19,6 @@ RED='\033[0;31m'
 GREEN='\033[0;32m'
 YELLOW='\033[1;33m'
 NC='\033[0m' # No Color
-
-# Function to check if command exists
-command_exists() {
-    command -v "$1" >/dev/null 2>&1
-}
 
 PROJECT_ROOT="$(pwd)"
 
@@ -38,12 +33,21 @@ fi
 echo -e "${GREEN}ktfmt is available${NC}"
 
 # Check for other required commands
-for cmd in find xargs git; do
-    if ! command_exists "$cmd"; then
+for cmd in find xargs; do
+    if ! command -v "$cmd" >/dev/null 2>&1; then
         echo -e "${RED}Required command '$cmd' is not available${NC}"
         exit 1
     fi
 done
+if vcs_uses_jj; then
+    required_vcs_command="jj"
+else
+    required_vcs_command="git"
+fi
+if ! command -v "$required_vcs_command" >/dev/null 2>&1; then
+    echo -e "${RED}Required command '$required_vcs_command' is not available${NC}"
+    exit 1
+fi
 
 # Fingerprint gate (issue #2966): the scoped PR check only inspects a PR's
 # changed files, so a ktfmt whose version differs from the pin would reformat
@@ -140,7 +144,7 @@ load_files_to_process() {
 # shell, but this up-front branch preserves the intended CI behavior: scoped
 # mode degrades to a full-tree validation when a fetched base is unavailable.
 if [[ -n "$ONLY_CHANGED_SINCE_SHA" ]] \
-    && ! git rev-parse --verify -q "${ONLY_CHANGED_SINCE_SHA}^{commit}" >/dev/null 2>&1; then
+    && ! vcs_base_exists "$ONLY_CHANGED_SINCE_SHA"; then
     echo -e "${YELLOW}Base SHA '${ONLY_CHANGED_SINCE_SHA}' does not resolve; falling back to a full-tree ktfmt check.${NC}"
     ONLY_CHANGED_SINCE_SHA=""
     ONLY_TOUCHED_FILES=false
@@ -150,11 +154,12 @@ fi
 # the result for files outside a PR's Kotlin diff. Run the full tree for those
 # changes rather than relying on the post-merge backstop to discover drift.
 if [[ -n "$ONLY_CHANGED_SINCE_SHA" ]] \
-    && ! git diff --quiet "$ONLY_CHANGED_SINCE_SHA"...HEAD -- \
+    && [[ -n "$(vcs_diff_since_merge_base "$ONLY_CHANGED_SINCE_SHA" \
         scripts/ktfmt \
         scripts/lib/file-selection.sh \
+        scripts/lib/vcs-diff.sh \
         .github/workflows/pull_request.yml \
-        .github/workflows/merge.yml; then
+        .github/workflows/merge.yml)" ]]; then
     echo -e "${YELLOW}Ktfmt inputs changed since the base SHA; running a full-tree ktfmt check.${NC}"
     ONLY_CHANGED_SINCE_SHA=""
     ONLY_TOUCHED_FILES=false

--- a/scripts/lib/file-selection.sh
+++ b/scripts/lib/file-selection.sh
@@ -1,10 +1,10 @@
 #!/usr/bin/env bash
 #
-# Shared git file-selection boilerplate for the per-tool formatter/linter
+# Shared VCS file-selection boilerplate for the per-tool formatter/linter
 # validate_<tool>.sh / apply_<tool>.sh scripts (issue #2823).
 #
 # Historically every formatter/linter re-declared the same three primitives:
-#   * get_touched_files()          - staged + working-tree files, regex-filtered
+#   * get_touched_files()          - working-tree files, regex-filtered
 #   * get_changed_files_since_sha() - files changed vs a base SHA, regex-filtered
 #   * the INSTALL_<TOOL>_WHEN_MISSING install-when-missing gate + re-verify
 # The copies drifted. This file is the single source of truth (issue #2823).
@@ -18,17 +18,18 @@
 #
 # Exports:
 #   collect_touched_files <project_root> <regex>
-#       Emit absolute paths of staged (--cached) and working-tree modified files
-#       whose repo-relative path matches <regex> and that still exist on disk.
-#       Deduplicated + sorted. Returns non-zero if either `git diff` fails, so a
-#       caller can distinguish "no matching files" from "git failed" (a producer
+#       Emit absolute paths of modified files whose repo-relative path matches
+#       <regex> and that still exist on disk. Git includes staged and working
+#       changes; jj compares its working-copy commit with its parent.
+#       Deduplicated + sorted. Returns non-zero when the VCS diff fails, so a
+#       caller can distinguish "no matching files" from "VCS failed" (a producer
 #       failure must never be mistaken for a clean tree).
 #
 #   collect_changed_since_sha <project_root> <sha> <regex>
-#       Emit absolute paths of files changed in <sha>...HEAD whose repo-relative
-#       path matches <regex> and that still exist on disk. Deduplicated + sorted.
-#       Verifies the SHA resolves; returns non-zero (with a message on stderr) if
-#       it does not, or if `git diff` fails.
+#       Emit absolute paths of files changed from <sha> to the working copy whose
+#       repo-relative path matches <regex> and that still exist on disk.
+#       Deduplicated + sorted. Verifies the revision resolves; returns non-zero
+#       (with a message on stderr) if it does not, or if the VCS diff fails.
 #
 #   ensure_tool <name> <installer_path> <install_when_missing>
 #       The install-when-missing gate: if <name> is absent from PATH, either run
@@ -42,6 +43,9 @@
 : "${GREEN:=\033[0;32m}"
 : "${YELLOW:=\033[1;33m}"
 : "${NC:=\033[0m}"
+
+# shellcheck disable=SC1091 # Resolved relative to the helper's location.
+source "$(dirname "${BASH_SOURCE[0]}")/vcs-diff.sh"
 
 # True if <cmd> is on PATH. Guarded so we don't redefine a caller's copy.
 if ! declare -F command_exists > /dev/null 2>&1; then
@@ -66,20 +70,10 @@ _filter_matching_files() {
 collect_touched_files() {
   local project_root="$1"
   local regex="$2"
-  local staged_files
-  local modified_files
 
-  if ! staged_files="$(git diff --cached --name-only --diff-filter=ACMR)"; then
-    return 1
-  fi
-  if ! modified_files="$(git diff --name-only --diff-filter=ACMR)"; then
-    return 1
-  fi
-
-  {
-    printf '%s\n' "$staged_files"
-    printf '%s\n' "$modified_files"
-  } | _filter_matching_files "$project_root" "$regex" | sort | uniq
+  # shellcheck disable=SC2119 # The current workspace determines touched files.
+  vcs_touched_files \
+    | _filter_matching_files "$project_root" "$regex" | sort | uniq
 }
 
 collect_changed_since_sha() {
@@ -88,13 +82,13 @@ collect_changed_since_sha() {
   local regex="$3"
   local changed_files
 
-  # Verify the SHA resolves before diffing so a bad base fails loudly here.
-  if ! git rev-parse --verify "$sha" > /dev/null 2>&1; then
-    echo -e "${RED}SHA '$sha' does not exist in the repository${NC}" >&2
+  # Verify the revision resolves before diffing so a bad base fails loudly here.
+  if ! vcs_base_exists "$sha"; then
+    echo -e "${RED}Revision '$sha' does not exist in the repository${NC}" >&2
     return 1
   fi
 
-  if ! changed_files="$(git diff --name-only "$sha"...HEAD)"; then
+  if ! changed_files="$(vcs_changed_files_since_merge_base "$sha")"; then
     return 1
   fi
 

--- a/scripts/lib/vcs-diff.sh
+++ b/scripts/lib/vcs-diff.sh
@@ -1,0 +1,111 @@
+#!/usr/bin/env bash
+#
+# Diff primitives for repository validation scripts. Colocated root checkouts
+# retain Git behavior; sibling jj workspaces have `.jj` but no `.git`, so use
+# jj's working-copy-aware diff there.
+
+vcs_uses_jj() {
+  [[ -d ".jj" && ! -e ".git" ]]
+}
+
+vcs_base_ref() {
+  local requested_base_ref="$1"
+  if vcs_uses_jj && [[ "$requested_base_ref" == "origin/main" ]]; then
+    printf '%s\n' "main@origin"
+    return
+  fi
+  if vcs_uses_jj && [[ "$requested_base_ref" == "HEAD" ]]; then
+    printf '%s\n' "@-"
+    return
+  fi
+  printf '%s\n' "$requested_base_ref"
+}
+
+vcs_base_exists() {
+  local base_ref
+  base_ref="$(vcs_base_ref "$1")"
+  if vcs_uses_jj; then
+    jj log -r "$base_ref" --no-graph -T '' >/dev/null 2>&1
+    return
+  fi
+  git rev-parse --verify --quiet "${base_ref}^{commit}" >/dev/null
+}
+
+vcs_changed_files() {
+  local base_ref
+  base_ref="$(vcs_base_ref "$1")"
+  shift
+  if vcs_uses_jj; then
+    jj diff --from "$base_ref" --to @ --name-only -- "$@"
+    return
+  fi
+  git diff --name-only "$base_ref" -- "$@"
+}
+
+vcs_changed_files_since_merge_base() {
+  local base_ref
+  base_ref="$(vcs_base_ref "$1")"
+  shift
+  if vcs_uses_jj; then
+    jj diff --from "fork_point(@ | ${base_ref})" --to @ --name-only -- "$@"
+    return
+  fi
+  git diff --name-only "$base_ref"...HEAD -- "$@"
+}
+
+vcs_touched_files() {
+  if vcs_uses_jj; then
+    jj diff --from @- --to @ --name-only -- "$@"
+    return
+  fi
+  {
+    git diff --cached --name-only --diff-filter=ACMR
+    git diff --name-only --diff-filter=ACMR
+  } | sort | uniq
+}
+
+vcs_list_files() {
+  local revision="${1:-@}"
+  if vcs_uses_jj; then
+    local files
+    files="$(jj file list -r "$revision")" || return
+    while IFS= read -r path; do
+      [[ -n "$path" ]] && printf '%s\0' "$path"
+    done <<< "$files"
+    return
+  fi
+  git ls-files --cached --others --exclude-standard -z
+}
+
+vcs_diff() {
+  local base_ref
+  base_ref="$(vcs_base_ref "$1")"
+  shift
+  if vcs_uses_jj; then
+    jj diff --from "$base_ref" --to @ --git -- "$@"
+    return
+  fi
+  git diff "$base_ref" -- "$@"
+}
+
+vcs_diff_since_merge_base() {
+  local base_ref
+  base_ref="$(vcs_base_ref "$1")"
+  shift
+  if vcs_uses_jj; then
+    jj diff --from "fork_point(@ | ${base_ref})" --to @ --git -- "$@"
+    return
+  fi
+  git diff "$base_ref"...HEAD -- "$@"
+}
+
+vcs_file_at_merge_base() {
+  local base_ref
+  base_ref="$(vcs_base_ref "$1")"
+  local file="$2"
+  if vcs_uses_jj; then
+    jj file show -r "fork_point(@ | ${base_ref})" "$file"
+    return
+  fi
+  git show "$(git merge-base "$base_ref" HEAD):$file"
+}

--- a/scripts/shellcheck/validate_shell_scripts.sh
+++ b/scripts/shellcheck/validate_shell_scripts.sh
@@ -14,13 +14,16 @@ fi
 # Start the timer
 start_time=$(bash -c "$(pwd)/scripts/utils/get_timestamp.sh")
 
+# shellcheck disable=SC1091 # Resolved relative to this script's location.
+source "$(dirname "${BASH_SOURCE[0]}")/../lib/vcs-diff.sh"
+
 # Portable CPU count: nproc (GNU) is absent on stock macOS, where an empty
 # `$(nproc)` made `xargs -P ""` fail. Fall back to sysctl/getconf (#3653).
 NPROC="$(nproc 2>/dev/null || sysctl -n hw.ncpu 2>/dev/null || getconf _NPROCESSORS_ONLN 2>/dev/null || echo 4)"
 
-# Find shell scripts and validate in parallel
+# Find shell scripts and validate in parallel.
 # shellcheck disable=SC2016
-errors=$(git ls-files --cached --others --exclude-standard -z |
+errors=$(vcs_list_files |
   grep -z '\.sh$' |
   xargs -0 -n 1 -P "$NPROC" bash -c 'shellcheck "$0"' 2>&1)
 

--- a/scripts/xml/validate_xml.sh
+++ b/scripts/xml/validate_xml.sh
@@ -26,6 +26,9 @@ fi
 # Start the timer
 start_time=$(bash -c "$(pwd)/scripts/utils/get_timestamp.sh")
 
+# shellcheck disable=SC1091 # Resolved relative to this script's location.
+source "$(dirname "${BASH_SOURCE[0]}")/../lib/vcs-diff.sh"
+
 # Need to export this function for xargs bash to see it
 export -f validate_xml
 
@@ -33,9 +36,9 @@ export -f validate_xml
 # `$(nproc)` made `xargs -P ""` fail. Fall back to sysctl/getconf (#3653).
 NPROC="$(nproc 2>/dev/null || sysctl -n hw.ncpu 2>/dev/null || getconf _NPROCESSORS_ONLN 2>/dev/null || echo 4)"
 
-# Find XML files, excluding files ignored by .gitignore
+# Find XML files, excluding ignored files.
 # shellcheck disable=SC2016
-errors=$(git ls-files --cached --others --exclude-standard -z |
+errors=$(vcs_list_files |
   grep -z '\.xml$' |
   xargs -0 -n 1 -P "$NPROC" bash -c 'validate_xml val -w -b -e "$0"' 2>&1)
 

--- a/test/bats/check-lfs-pointers.bats
+++ b/test/bats/check-lfs-pointers.bats
@@ -18,8 +18,9 @@ setup() {
   export GIT_CONFIG_GLOBAL=/dev/null
   export GIT_CONFIG_SYSTEM=/dev/null
   repo_dir="$(mktemp -d)"
-  mkdir -p "$repo_dir/scripts"
+  mkdir -p "$repo_dir/scripts/lib"
   cp "$BATS_TEST_DIRNAME/../../scripts/check-lfs-pointers.sh" "$repo_dir/scripts/"
+  cp "$BATS_TEST_DIRNAME/../../scripts/lib/vcs-diff.sh" "$repo_dir/scripts/lib/"
   git -C "$repo_dir" init -q
   git -C "$repo_dir" config user.email test@example.com
   git -C "$repo_dir" config user.name test

--- a/test/bats/check-no-new-direct-security.bats
+++ b/test/bats/check-no-new-direct-security.bats
@@ -2,8 +2,9 @@
 
 setup() {
   repo_dir="$(mktemp -d)"
-  mkdir -p "$repo_dir/scripts" "$repo_dir/src/utils/ios-cmdline-tools"
+  mkdir -p "$repo_dir/scripts/lib" "$repo_dir/src/utils/ios-cmdline-tools"
   cp "$BATS_TEST_DIRNAME/../../scripts/check-no-new-direct-security.sh" "$repo_dir/scripts/"
+  cp "$BATS_TEST_DIRNAME/../../scripts/lib/vcs-diff.sh" "$repo_dir/scripts/lib/"
   git -C "$repo_dir" init -q
   git -C "$repo_dir" config user.email test@example.com
   git -C "$repo_dir" config user.name test

--- a/test/bats/check-no-new-direct-simctl.bats
+++ b/test/bats/check-no-new-direct-simctl.bats
@@ -2,8 +2,9 @@
 
 setup() {
   repo_dir="$(mktemp -d)"
-  mkdir -p "$repo_dir/scripts" "$repo_dir/src"
+  mkdir -p "$repo_dir/scripts/lib" "$repo_dir/src"
   cp "$BATS_TEST_DIRNAME/../../scripts/check-no-new-direct-simctl.sh" "$repo_dir/scripts/"
+  cp "$BATS_TEST_DIRNAME/../../scripts/lib/vcs-diff.sh" "$repo_dir/scripts/lib/"
   git -C "$repo_dir" init -q
   git -C "$repo_dir" config user.email test@example.com
   git -C "$repo_dir" config user.name test

--- a/test/bats/check-no-new-direct-xcodebuild.bats
+++ b/test/bats/check-no-new-direct-xcodebuild.bats
@@ -2,8 +2,9 @@
 
 setup() {
   repo_dir="$(mktemp -d)"
-  mkdir -p "$repo_dir/scripts" "$repo_dir/src/utils/ios-cmdline-tools"
+  mkdir -p "$repo_dir/scripts/lib" "$repo_dir/src/utils/ios-cmdline-tools"
   cp "$BATS_TEST_DIRNAME/../../scripts/check-no-new-direct-xcodebuild.sh" "$repo_dir/scripts/"
+  cp "$BATS_TEST_DIRNAME/../../scripts/lib/vcs-diff.sh" "$repo_dir/scripts/lib/"
   touch "$repo_dir/src/utils/ios-cmdline-tools/XcodebuildClient.ts"
   git -C "$repo_dir" init -q
   git -C "$repo_dir" config user.email test@example.com

--- a/test/bats/validate-ktfmt.bats
+++ b/test/bats/validate-ktfmt.bats
@@ -339,6 +339,7 @@ STUB
   # (issue #2823), so mirror scripts/lib next to the copied ktfmt dir.
   mkdir -p "$TEST_DIR/lib"
   cp "$REPO_ROOT/scripts/lib/file-selection.sh" "$TEST_DIR/lib/"
+  cp "$REPO_ROOT/scripts/lib/vcs-diff.sh" "$TEST_DIR/lib/"
   # Bump ONLY the pin line in the copy, preserving the shared helper functions.
   sed -i.bak 's/^KTFMT_VERSION=.*/KTFMT_VERSION="0.99"/' "$copy_dir/ktfmt_version.sh"
   rm -f "$copy_dir/ktfmt_version.sh.bak"

--- a/test/bats/vcs-diff.bats
+++ b/test/bats/vcs-diff.bats
@@ -1,0 +1,36 @@
+#!/usr/bin/env bats
+
+setup() {
+  repo_dir="$(mktemp -d)"
+  mkdir -p "$repo_dir/.jj" "$repo_dir/bin" "$repo_dir/scripts/lib"
+  cp "$BATS_TEST_DIRNAME/../../scripts/lib/vcs-diff.sh" "$repo_dir/scripts/lib/"
+  cat > "$repo_dir/bin/jj" <<'EOF'
+#!/usr/bin/env bash
+case "$1" in
+  log)
+    exit 0
+    ;;
+  diff)
+    if [[ " $* " == *" --name-only "* ]]; then
+      printf '%s\n' "src/changed.ts"
+    else
+      printf '%s\n' "+const changed = true;"
+    fi
+    ;;
+esac
+EOF
+  chmod +x "$repo_dir/bin/jj"
+}
+
+teardown() {
+  rm -rf "$repo_dir"
+}
+
+@test "uses the main@origin bookmark and jj diff in a jj workspace" {
+  run bash -c 'cd "$1" && PATH="$1/bin:$PATH" && source scripts/lib/vcs-diff.sh && vcs_base_ref origin/main && vcs_base_exists origin/main && vcs_changed_files origin/main src && vcs_changed_files_since_merge_base origin/main src && vcs_diff origin/main src/changed.ts && vcs_diff_since_merge_base origin/main src/changed.ts' _ "$repo_dir"
+
+  [ "$status" -eq 0 ]
+  [[ "$output" == *"main@origin"* ]]
+  [[ "$output" == *"src/changed.ts"* ]]
+  [[ "$output" == *"+const changed = true;"* ]]
+}

--- a/test/integration/adbIntegrationCommandRunner.test.ts
+++ b/test/integration/adbIntegrationCommandRunner.test.ts
@@ -1,0 +1,79 @@
+import { describe, expect, test } from "bun:test";
+import { readFileSync } from "node:fs";
+import type { ExecResult } from "../../src/models";
+import type { HostCommandExecutor } from "../../src/utils/HostCommandExecutor";
+import { createExecResult } from "../../src/utils/execResult";
+import {
+  ADB_INTEGRATION_COMMAND_TIMEOUT_MS,
+  createAdbIntegrationCommandRunner,
+} from "./adbIntegrationCommandRunner";
+
+const FAST_TEST_TIMEOUT_MS = 100;
+const ANDROID_H264_INTEGRATION_TEST_PATH = new URL(
+  "./androidH264SourceDevice.integration.test.ts",
+  import.meta.url,
+);
+
+describe("createAdbIntegrationCommandRunner", () => {
+  test(
+    "bounds every query through the host command executor",
+    async () => {
+      const calls: Array<{ file: string; args: string[]; timeoutMs?: number }> = [];
+      const executor: Pick<HostCommandExecutor, "executeCommand"> = {
+        async executeCommand(file, args = [], options = {}): Promise<ExecResult> {
+          calls.push({ file, args, timeoutMs: options.timeoutMs });
+          return createExecResult("output", "");
+        },
+      };
+
+      const result = await createAdbIntegrationCommandRunner(executor).run(
+        ["devices"],
+        "discovering an Android device",
+      );
+
+      expect(result.stdout).toBe("output");
+      expect(calls).toEqual([
+        {
+          file: "adb",
+          args: ["devices"],
+          timeoutMs: ADB_INTEGRATION_COMMAND_TIMEOUT_MS,
+        },
+      ]);
+    },
+    FAST_TEST_TIMEOUT_MS,
+  );
+
+  test(
+    "includes the phase, timeout, command, and root error in diagnostics",
+    async () => {
+      const executor: Pick<HostCommandExecutor, "executeCommand"> = {
+        async executeCommand(): Promise<ExecResult> {
+          throw new Error("timed out waiting for ADB server");
+        },
+      };
+
+      await expect(
+        createAdbIntegrationCommandRunner(executor).run(
+          ["-s", "emulator-5554", "shell", "wm", "size"],
+          "reading display size",
+        ),
+      ).rejects.toThrow(
+        `ADB reading display size failed within ${ADB_INTEGRATION_COMMAND_TIMEOUT_MS}ms: adb -s emulator-5554 shell wm size\n` +
+          "timed out waiting for ADB server",
+      );
+    },
+    FAST_TEST_TIMEOUT_MS,
+  );
+
+  test(
+    "routes every short-lived ADB query in the on-device suite through the bounded runner",
+    () => {
+      const source = readFileSync(ANDROID_H264_INTEGRATION_TEST_PATH, "utf8");
+
+      expect(source).not.toContain("execFileAsync(");
+      expect(source.match(/(?:adb|adbRunner)\.run\(/g)).toHaveLength(4);
+      expect(source).toContain("}, ADB_SETUP_HOOK_TIMEOUT_MS)");
+    },
+    FAST_TEST_TIMEOUT_MS,
+  );
+});

--- a/test/integration/adbIntegrationCommandRunner.test.ts
+++ b/test/integration/adbIntegrationCommandRunner.test.ts
@@ -1,5 +1,6 @@
 import { describe, expect, test } from "bun:test";
 import { readFileSync } from "node:fs";
+import { executionBoundaryAst } from "../../scripts/lib/executionBoundaryAst";
 import type { ExecResult } from "../../src/models";
 import type { HostCommandExecutor } from "../../src/utils/HostCommandExecutor";
 import { createExecResult } from "../../src/utils/execResult";
@@ -13,6 +14,16 @@ const ANDROID_H264_INTEGRATION_TEST_PATH = new URL(
   "./androidH264SourceDevice.integration.test.ts",
   import.meta.url,
 );
+
+function directAdbExecutionCalls(source: string): string[] {
+  const ast = executionBoundaryAst(source);
+  return ast.calls
+    .filter(call =>
+      (ast.isLauncher(call) || ast.isExecutionSeam(call)) &&
+      ast.strings(call.arguments[0]).includes("adb"),
+    )
+    .map(call => call.getText());
+}
 
 describe("createAdbIntegrationCommandRunner", () => {
   test(
@@ -66,13 +77,29 @@ describe("createAdbIntegrationCommandRunner", () => {
   );
 
   test(
-    "routes every short-lived ADB query in the on-device suite through the bounded runner",
+    "rejects direct ADB execution in the on-device suite",
     () => {
       const source = readFileSync(ANDROID_H264_INTEGRATION_TEST_PATH, "utf8");
 
-      expect(source).not.toContain("execFileAsync(");
-      expect(source.match(/(?:adb|adbRunner)\.run\(/g)).toHaveLength(4);
+      expect(directAdbExecutionCalls(source)).toEqual([]);
       expect(source).toContain("}, ADB_SETUP_HOOK_TIMEOUT_MS)");
+    },
+    FAST_TEST_TIMEOUT_MS,
+  );
+
+  test(
+    "detects child-process and host-executor ADB bypasses",
+    () => {
+      const source = `
+        import { execFile } from "node:child_process";
+        execFile("adb", ["devices"]);
+        executor.executeCommand("adb", ["wait-for-device"]);
+      `;
+
+      expect(directAdbExecutionCalls(source)).toEqual([
+        'execFile("adb", ["devices"])',
+        'executor.executeCommand("adb", ["wait-for-device"])',
+      ]);
     },
     FAST_TEST_TIMEOUT_MS,
   );

--- a/test/integration/adbIntegrationCommandRunner.ts
+++ b/test/integration/adbIntegrationCommandRunner.ts
@@ -1,0 +1,34 @@
+import type { ExecResult } from "../../src/models";
+import type { HostCommandExecutor } from "../../src/utils/HostCommandExecutor";
+
+/** Bounds short-lived ADB queries so an unresponsive server cannot wedge an integration run. */
+export const ADB_INTEGRATION_COMMAND_TIMEOUT_MS = 15_000;
+
+/** Narrow ADB-query interface used by device-backed integration suites. */
+export interface AdbIntegrationCommandRunner {
+  run(args: string[], phase: string): Promise<ExecResult>;
+}
+
+/**
+ * Creates the bounded executor for short-lived ADB queries performed by an
+ * integration suite. Streaming commands intentionally use their own lifecycle.
+ */
+export function createAdbIntegrationCommandRunner(
+  commandExecutor: Pick<HostCommandExecutor, "executeCommand">,
+): AdbIntegrationCommandRunner {
+  return {
+    async run(args: string[], phase: string): Promise<ExecResult> {
+      try {
+        return await commandExecutor.executeCommand("adb", args, {
+          timeoutMs: ADB_INTEGRATION_COMMAND_TIMEOUT_MS,
+        });
+      } catch (error) {
+        const detail = error instanceof Error ? error.message : String(error);
+        throw new Error(
+          `ADB ${phase} failed within ${ADB_INTEGRATION_COMMAND_TIMEOUT_MS}ms: adb ${args.join(" ")}\n${detail}`,
+          { cause: error },
+        );
+      }
+    },
+  };
+}

--- a/test/integration/androidH264SourceDevice.integration.test.ts
+++ b/test/integration/androidH264SourceDevice.integration.test.ts
@@ -1,6 +1,4 @@
 import { beforeAll, describe, expect, test } from "bun:test";
-import { execFile } from "node:child_process";
-import { promisify } from "node:util";
 import { AndroidH264Source } from "../../src/features/webrtc/AndroidH264Source";
 import {
   H264AnnexBParser,
@@ -10,7 +8,13 @@ import {
   nalUnitType,
 } from "../../src/features/webrtc/h264";
 import type { BootedDevice } from "../../src/models";
+import { DefaultHostCommandExecutor } from "../../src/utils/HostCommandExecutor";
 import { defaultTimer } from "../../src/utils/SystemTimer";
+import {
+  ADB_INTEGRATION_COMMAND_TIMEOUT_MS,
+  createAdbIntegrationCommandRunner,
+  type AdbIntegrationCommandRunner,
+} from "./adbIntegrationCommandRunner";
 
 /**
  * On-device verification of the ONE seam the unit tests structurally cannot
@@ -24,25 +28,27 @@ import { defaultTimer } from "../../src/utils/SystemTimer";
  * `AUTOMOBILE_ANDROID_H264_INTEGRATION=1` (and optionally
  * `AUTOMOBILE_ANDROID_H264_DEVICE_ID=<serial>`) to run them.
  */
-const execFileAsync = promisify(execFile);
 const RUN_INTEGRATION = process.env.AUTOMOBILE_ANDROID_H264_INTEGRATION === "1";
 const describeIntegration = RUN_INTEGRATION ? describe : describe.skip;
-
 const CAPTURE_MS = 3000;
+// The two sequential setup queries must each be killed by their own child-process
+// deadline. This hook budget is only a final backstop if a future setup step stalls.
+const ADB_SETUP_HOOK_TIMEOUT_MS = ADB_INTEGRATION_COMMAND_TIMEOUT_MS * 2 + 1000;
+const adb = createAdbIntegrationCommandRunner(new DefaultHostCommandExecutor());
 
 /** Resolve the target device serial from env or the first booted device. */
-async function resolveDeviceId(): Promise<string> {
+async function resolveDeviceId(adbRunner: AdbIntegrationCommandRunner): Promise<string> {
   const explicit = process.env.AUTOMOBILE_ANDROID_H264_DEVICE_ID;
   if (explicit) {
     return explicit;
   }
-  const { stdout } = await execFileAsync("adb", ["devices"]);
+  const { stdout } = await adbRunner.run(["devices"], "discovering an Android device");
   const serial = stdout
     .split("\n")
     .slice(1)
-    .map(line => line.trim())
-    .filter(line => line.endsWith("\tdevice"))
-    .map(line => line.split("\t")[0])[0];
+    .map((line) => line.trim())
+    .filter((line) => line.endsWith("\tdevice"))
+    .map((line) => line.split("\t")[0])[0];
   if (!serial) {
     throw new Error(`No booted Android device found in \`adb devices\`:\n${stdout}`);
   }
@@ -50,9 +56,15 @@ async function resolveDeviceId(): Promise<string> {
 }
 
 /** Count device-side `screenrecord` processes (to detect orphans after stop). */
-async function countScreenrecordProcesses(deviceId: string): Promise<number> {
-  const { stdout } = await execFileAsync("adb", ["-s", deviceId, "shell", "ps", "-A"]);
-  return stdout.split("\n").filter(line => line.includes("screenrecord")).length;
+async function countScreenrecordProcesses(
+  adbRunner: AdbIntegrationCommandRunner,
+  deviceId: string,
+): Promise<number> {
+  const { stdout } = await adbRunner.run(
+    ["-s", deviceId, "shell", "ps", "-A"],
+    "checking for screenrecord processes",
+  );
+  return stdout.split("\n").filter((line) => line.includes("screenrecord")).length;
 }
 
 /** Split an accumulated Annex-B buffer into NAL-type counts. */
@@ -76,13 +88,9 @@ describeIntegration("AndroidH264Source on-device capture (#3775)", () => {
   let deviceId: string;
 
   beforeAll(async () => {
-    try {
-      await execFileAsync("adb", ["version"]);
-    } catch (error) {
-      throw new Error(`adb is required for this integration test: ${String(error)}`);
-    }
-    deviceId = await resolveDeviceId();
-  });
+    await adb.run(["version"], "checking ADB availability");
+    deviceId = await resolveDeviceId(adb);
+  }, ADB_SETUP_HOOK_TIMEOUT_MS);
 
   function makeDevice(): BootedDevice {
     return { deviceId, platform: "android", name: deviceId } as BootedDevice;
@@ -90,14 +98,14 @@ describeIntegration("AndroidH264Source on-device capture (#3775)", () => {
 
   async function capture(
     overrides: Partial<ConstructorParameters<typeof AndroidH264Source>[0]> = {},
-    captureMs: number = CAPTURE_MS
+    captureMs: number = CAPTURE_MS,
   ): Promise<{ chunks: Buffer[]; errors: Error[]; source: AndroidH264Source }> {
     const chunks: Buffer[] = [];
     const errors: Error[] = [];
     const source = new AndroidH264Source({
       device: makeDevice(),
-      onData: chunk => chunks.push(chunk),
-      onError: error => errors.push(error),
+      onData: (chunk) => chunks.push(chunk),
+      onError: (error) => errors.push(error),
       ...overrides,
     });
     await source.start();
@@ -133,7 +141,10 @@ describeIntegration("AndroidH264Source on-device capture (#3775)", () => {
   test("accepts device --bit-rate and --size overrides and still produces frames", async () => {
     // Use the device's native resolution so `--size` is always a supported value
     // while still exercising the `--size WxH` argument path end-to-end.
-    const { stdout } = await execFileAsync("adb", ["-s", deviceId, "shell", "wm", "size"]);
+    const { stdout } = await adb.run(
+      ["-s", deviceId, "shell", "wm", "size"],
+      "reading display size",
+    );
     const match = stdout.match(/(\d+)x(\d+)/);
     if (!match) {
       throw new Error(`Could not parse \`wm size\`: ${stdout}`);
@@ -156,7 +167,7 @@ describeIntegration("AndroidH264Source on-device capture (#3775)", () => {
     // Force fast rotation: cap each segment at 2s and rotate at 1.5s.
     const { chunks, errors, source } = await capture(
       { segmentTimeLimitSeconds: 2, segmentRotateMs: 1500 },
-      5000
+      5000,
     );
 
     expect(errors).toEqual([]);
@@ -171,7 +182,7 @@ describeIntegration("AndroidH264Source on-device capture (#3775)", () => {
   }, 30000);
 
   test("stop leaves no orphaned screenrecord process on the device", async () => {
-    const baseline = await countScreenrecordProcesses(deviceId);
+    const baseline = await countScreenrecordProcesses(adb, deviceId);
 
     const { errors } = await capture();
     expect(errors).toEqual([]);
@@ -179,7 +190,7 @@ describeIntegration("AndroidH264Source on-device capture (#3775)", () => {
     // After stop + wind-down, the device-side screenrecord count must return to
     // (or below) the baseline — our session leaves nothing running. A leak would
     // show up as a count above baseline.
-    const after = await countScreenrecordProcesses(deviceId);
+    const after = await countScreenrecordProcesses(adb, deviceId);
     expect(after).toBeLessThanOrEqual(baseline);
   }, 30000);
 });

--- a/test/integration/noBundledCoordinationServer.guard.test.ts
+++ b/test/integration/noBundledCoordinationServer.guard.test.ts
@@ -1,6 +1,6 @@
 import { describe, expect, test } from "bun:test";
 import { spawnSync } from "node:child_process";
-import { existsSync } from "node:fs";
+import { existsSync, readFileSync } from "node:fs";
 import { join } from "node:path";
 
 /**
@@ -20,32 +20,39 @@ import { join } from "node:path";
  */
 describe("bundled coordination server is retired (issue #4291)", () => {
   const REMOVED_DIR = "examples/webrtc-coordination-server";
+  const THIS_TEST_PATH = "test/integration/noBundledCoordinationServer.guard.test.ts";
 
   test("the reference coordination server directory is gone", () => {
     expect(existsSync(join(process.cwd(), REMOVED_DIR))).toBe(false);
   });
 
   test("no tracked file references the removed directory", () => {
-    // `git grep` is index-backed and searches only tracked files, so it will not
-    // trip on build output or an untracked scratch copy. Exit code 1 means "no
-    // matches", which is the success case here.
-    const result = spawnSync(
+    const offenders = versionedFiles()
+      .filter(file => file !== THIS_TEST_PATH)
+      .filter(file => readFileSync(file, "utf8").includes("webrtc-coordination-server"));
+    expect(offenders, `these tracked files still reference ${REMOVED_DIR}:\n${offenders.join("\n")}`).toEqual([]);
+  });
+});
+
+function versionedFiles(): string[] {
+  const usesJj = existsSync(".jj") && !existsSync(".git");
+  const result = usesJj
+    ? spawnSync("jj", ["file", "list", "-r", "@"], { cwd: process.cwd(), encoding: "utf8" })
+    : spawnSync(
       "git",
       ["grep", "-l", "--", "webrtc-coordination-server", ":!test/integration/noBundledCoordinationServer.guard.test.ts"],
       { cwd: process.cwd(), encoding: "utf8" }
     );
 
-    if (result.error) {
-      throw result.error;
-    }
-    // Fail closed: git grep exits 0 (matches) or 1 (no matches); anything else is
-    // an error (bad pathspec, not a repo) whose empty stdout would otherwise read
-    // as a false pass.
-    if (result.status !== 0 && result.status !== 1) {
-      throw new Error(`git grep failed (exit ${result.status}): ${result.stderr}`);
-    }
-
-    const offenders = result.stdout.split("\n").filter(line => line.length > 0);
-    expect(offenders, `these tracked files still reference ${REMOVED_DIR}:\n${offenders.join("\n")}`).toEqual([]);
-  });
-});
+  if (result.error) {
+    throw result.error;
+  }
+  if (usesJj && result.status !== 0) {
+    throw new Error(`jj file list failed (exit ${result.status}): ${result.stderr}`);
+  }
+  // `git grep` exits 1 when it finds no matches, which is the success case.
+  if (!usesJj && result.status !== 0 && result.status !== 1) {
+    throw new Error(`git grep failed (exit ${result.status}): ${result.stderr}`);
+  }
+  return result.stdout.split("\n").filter(line => line.length > 0);
+}

--- a/test/lint/hostShellBoundary.test.ts
+++ b/test/lint/hostShellBoundary.test.ts
@@ -22,7 +22,19 @@ describe("host shell execution boundary (issue #4068)", () => {
   });
 
   test("fails closed outside a Git worktree", () => {
-    expect(() => changedSourceFiles("origin/main", false)).toThrow("not a Git worktree");
+    expect(() => changedSourceFiles("origin/main", false, false)).toThrow("not a Git or Jujutsu worktree");
+  });
+
+  test("uses the tracked main bookmark in a jj workspace", () => {
+    const calls: string[][] = [];
+    const runner = (file: string, args: string[]): string => {
+      calls.push([file, ...args]);
+      return file === "jj" && args[0] === "diff" ? "src/index.ts\n" : "";
+    };
+
+    expect(changedSourceFiles("origin/main", false, true, runner)).toEqual(["src/index.ts"]);
+    expect(calls).toContainEqual(["jj", "log", "-r", "main@origin", "--no-graph", "-T", ""]);
+    expect(calls).toContainEqual(["jj", "diff", "--from", "main@origin", "--to", "@", "--name-only", "src"]);
   });
 
   test("fetches the pull request base in shallow GitHub checkouts", () => {

--- a/test/utils/GitMetadataClient.test.ts
+++ b/test/utils/GitMetadataClient.test.ts
@@ -1,4 +1,4 @@
-import { readFileSync } from "node:fs";
+import { existsSync, readFileSync } from "node:fs";
 import { join } from "node:path";
 import { DefaultGitMetadataClient, type GitCommandRunner } from "../../src/utils/GitMetadataClient";
 
@@ -15,8 +15,10 @@ const fakeRunner = (responses: Record<string, string | null>): GitCommandRunner 
 
 describe("DefaultGitMetadataClient", () => {
   // Git for Windows is commonly a shell-resolved git.exe shim, while this
-  // production boundary deliberately uses shell:false argv execution.
-  test.skipIf(process.platform === "win32")("uses the default runner in this source checkout", () => {
+  // production boundary deliberately uses shell:false argv execution. A jj
+  // workspace has no Git worktree, so its optional Git metadata is expected
+  // to be unavailable and is covered by the injected-runner tests below.
+  test.skipIf(process.platform === "win32" || !existsSync(".git"))("uses the default runner in this Git source checkout", () => {
     const readPackageName = (directory: string): string | null =>
       (JSON.parse(readFileSync(join(directory, "package.json"), "utf8")) as { name?: string }).name ?? null;
 

--- a/test/utils/screenshot-cache.test.ts
+++ b/test/utils/screenshot-cache.test.ts
@@ -2,11 +2,14 @@ import { expect, describe, test, beforeEach, afterEach } from "bun:test";
 import fs from "fs/promises";
 import os from "os";
 import path from "path";
-import { Jimp, rgbaToInt } from "jimp";
 import { ScreenshotCache } from "../../src/utils/screenshot/ScreenshotCache";
 import { FakeTimer } from "../fakes/FakeTimer";
 
 const CACHE_TTL_MS = 10 * 60 * 1000;
+const RED_PNG = Buffer.from("iVBORw0KGgoAAAANSUhEUgAAAAEAAAABCAYAAAAfFcSJAAAADUlEQVR4AWP4z8DwHwAFAAH/e+m+7wAAAABJRU5ErkJggg==", "base64");
+const BLUE_PNG = Buffer.from("iVBORw0KGgoAAAANSUhEUgAAAAEAAAABCAYAAAAfFcSJAAAADUlEQVR4AWNgYPj/HwADAgH/FAeIXAAAAABJRU5ErkJggg==", "base64");
+const WHITE_PNG = Buffer.from("iVBORw0KGgoAAAANSUhEUgAAAAEAAAABCAYAAAAfFcSJAAAAC0lEQVR4AWP4DwQACfsD/c8LaHIAAAAASUVORK5CYII=", "base64");
+const GREEN_PNG = Buffer.from("iVBORw0KGgoAAAANSUhEUgAAAAEAAAABCAYAAAAfFcSJAAAADUlEQVR4AWNg+M/wHwAEAQH/g5vEFwAAAABJRU5ErkJggg==", "base64");
 
 describe("ScreenshotCache", function() {
   let tempDir: string;
@@ -25,12 +28,12 @@ describe("ScreenshotCache", function() {
 
   test("returns cached buffer within TTL", async function() {
     const filePath = path.join(tempDir, "screenshot.png");
-    const buffer1 = await createTestImage({ r: 255, g: 0, b: 0 });
+    const buffer1 = RED_PNG;
     await fs.writeFile(filePath, buffer1);
 
     const first = await ScreenshotCache.getCachedScreenshot(filePath, fakeTimer);
 
-    const buffer2 = await createTestImage({ r: 0, g: 0, b: 255 });
+    const buffer2 = BLUE_PNG;
     await fs.writeFile(filePath, buffer2);
 
     const second = await ScreenshotCache.getCachedScreenshot(filePath, fakeTimer);
@@ -42,12 +45,12 @@ describe("ScreenshotCache", function() {
 
   test("reloads cache after TTL expires", async function() {
     const filePath = path.join(tempDir, "screenshot.png");
-    const buffer1 = await createTestImage({ r: 255, g: 255, b: 255 });
+    const buffer1 = WHITE_PNG;
     await fs.writeFile(filePath, buffer1);
 
     await ScreenshotCache.getCachedScreenshot(filePath, fakeTimer);
 
-    const buffer2 = await createTestImage({ r: 0, g: 255, b: 0 });
+    const buffer2 = GREEN_PNG;
     await fs.writeFile(filePath, buffer2);
 
     fakeTimer.advanceTime(CACHE_TTL_MS + 1);
@@ -57,8 +60,3 @@ describe("ScreenshotCache", function() {
     expect(refreshed.buffer.equals(buffer2)).toBe(true);
   });
 });
-
-async function createTestImage(color: { r: number; g: number; b: number }): Promise<Buffer> {
-  const image = new Jimp({ width: 10, height: 10, color: rgbaToInt(color.r, color.g, color.b, 255) });
-  return image.getBuffer("image/png");
-}


### PR DESCRIPTION
## Summary

Bounds every short-lived ADB query in the opt-in Android H.264 device integration suite at 15 seconds and adds phase- and argv-specific failure context. The setup hook now has a 31-second backstop, while the long-lived screenrecord stream retains its existing lifecycle.

The suite uses the existing `HostCommandExecutor` seam; focused tests verify timeout forwarding, diagnostics, and that no raw ADB subprocess bypasses the bounded runner.

## Linked Issue

Closes [#5373](https://github.com/kaeawc/auto-mobile/issues/5373)

## Bug / Regression Context

- **Prior attempts:** None.
- **Observed symptom:** `adb version` or `adb devices` can wedge `beforeAll` before any test result is emitted, leaving CI to cancel the job.
- **Repro steps / conditions:** Run the opt-in H.264 device suite while the host ADB server or emulator is unresponsive.

## Validation

- [x] Focused runner and opt-in-suite tests pass (the device suite correctly skips without its opt-in environment).
- [x] Modified-file type-aware oxlint and oxfmt checks pass.
- [x] `bun run typecheck` reports no new errors.
- [x] `bun run build` passes.
- [ ] Full `bun test` could not pass in this jj workspace: two existing tests require a `.git` worktree; an unrelated screenshot-cache timeout passed when rerun alone.
- [ ] `bun run lint` / Fast Validation could not complete here: Git-boundary checks require `.git`, and the Lychee subprocess hung. Publishing proceeds with explicit authorization despite these environment-only blockers.
- [ ] Device verification was not run locally because no opt-in Android emulator/device was configured.
