### PR TITLE
fix(desktop): close ObservationStreamClient transport on EOF to stop fd leak

### DIFF
--- a/android/desktop-core/src/main/kotlin/dev/jasonpearson/automobile/desktop/core/daemon/ObservationStreamClient.kt
+++ b/android/desktop-core/src/main/kotlin/dev/jasonpearson/automobile/desktop/core/daemon/ObservationStreamClient.kt
@@ -36,12 +36,60 @@ import kotlinx.serialization.json.contentOrNull
 import kotlinx.serialization.serializer
 
 /**
+ * A line-oriented bidirectional transport over the observation-stream socket. Abstracted from the
+ * concrete [SocketChannel] so [ObservationStreamClient] can be unit-tested for fd release across an
+ * EOF -> reconnect / EOF -> dispose cycle without a real daemon socket (issue #5261).
+ *
+ * [close] must be idempotent: the read loop and [ObservationStreamClient.disconnect] can both reach
+ * it for the same transport.
+ */
+interface ObservationStreamTransport {
+  val reader: BufferedReader
+  val writer: BufferedWriter
+
+  fun close()
+}
+
+/**
+ * Opens an [ObservationStreamTransport] for a socket path. Constructor-injected into
+ * [ObservationStreamClient]; production uses [SocketChannelTransportFactory] (a real AF_UNIX
+ * socket), tests supply a fake that records opens and closes.
+ */
+fun interface ObservationStreamTransportFactory {
+  fun open(socketPath: String): ObservationStreamTransport
+}
+
+/** Default factory backed by a real AF_UNIX [SocketChannel]. */
+internal object SocketChannelTransportFactory : ObservationStreamTransportFactory {
+  override fun open(socketPath: String): ObservationStreamTransport =
+    SocketChannelTransport(SocketChannel.open(UnixDomainSocketAddress.of(socketPath)))
+}
+
+private class SocketChannelTransport(private val channel: SocketChannel) :
+  ObservationStreamTransport {
+  override val reader: BufferedReader =
+    BufferedReader(InputStreamReader(Channels.newInputStream(channel), StandardCharsets.UTF_8))
+  override val writer: BufferedWriter =
+    BufferedWriter(OutputStreamWriter(Channels.newOutputStream(channel), StandardCharsets.UTF_8))
+
+  // Closing the channel tears down the streams built from it; SocketChannel.close() on an
+  // already-closed channel is a no-op, so this stays idempotent for the death-point/disconnect
+  // race.
+  override fun close() {
+    channel.close()
+  }
+}
+
+/**
  * Client for the observation stream Unix socket server. Subscribes to receive real-time hierarchy
  * and screenshot updates from the MCP server.
  *
  * Socket path: ~/.auto-mobile/observation-stream.sock
  */
-class ObservationStreamClient : ObservationStream {
+class ObservationStreamClient(
+  private val transportFactory: ObservationStreamTransportFactory = SocketChannelTransportFactory,
+  private val socketPathProvider: () -> String = { getSocketPath() },
+) : ObservationStream {
   companion object {
     internal fun getSocketPath(): String =
       AutoMobileSocketPaths.socketPath("observation-stream.sock")
@@ -53,9 +101,10 @@ class ObservationStreamClient : ObservationStream {
   private val json = DaemonJson
   private val scope = CoroutineScope(SupervisorJob() + Dispatchers.IO)
 
-  private var channel: SocketChannel? = null
-  private var reader: BufferedReader? = null
-  private var writer: BufferedWriter? = null
+  // Single owning reference to the live transport. It is closed both at its death point in the read
+  // loop (EOF or read error) and in disconnect(), so no reconnect abandons a still-open socket
+  // (issue #5261).
+  private var transport: ObservationStreamTransport? = null
 
   // Flow for hierarchy updates
   private val _hierarchyUpdates = MutableSharedFlow<HierarchyStreamUpdate>(replay = 1)
@@ -121,7 +170,7 @@ class ObservationStreamClient : ObservationStream {
       return
     }
 
-    val socketPath = getSocketPath()
+    val socketPath = socketPathProvider()
     log.info("Connecting to observation stream at $socketPath")
 
     _connectionState.update { ConnectionState.Connecting }
@@ -134,16 +183,10 @@ class ObservationStreamClient : ObservationStream {
         return
       }
 
-      val address = UnixDomainSocketAddress.of(socketPath)
-      channel = SocketChannel.open(address)
-      reader =
-        BufferedReader(
-          InputStreamReader(Channels.newInputStream(channel!!), StandardCharsets.UTF_8)
-        )
-      writer =
-        BufferedWriter(
-          OutputStreamWriter(Channels.newOutputStream(channel!!), StandardCharsets.UTF_8)
-        )
+      // Close any transport left over from a previous connection before opening a fresh one, so a
+      // dead socket from a prior EOF is never abandoned (issue #5261).
+      closeTransport(transport)
+      transport = transportFactory.open(socketPath)
 
       _connectionState.update { ConnectionState.Connected() }
       log.info("Connected to observation stream")
@@ -181,18 +224,31 @@ class ObservationStreamClient : ObservationStream {
           )
         sendRequest(request)
       }
-
-      channel?.close()
     } catch (e: Exception) {
       log.warn("Error disconnecting from observation stream: ${e.message}")
     }
 
-    channel = null
-    reader = null
-    writer = null
+    closeTransport(transport)
     subscriptionId = null
     pendingCadenceUpdate = false
     _connectionState.update { ConnectionState.Disconnected() }
+  }
+
+  /**
+   * Close [target] and, when it is still the active transport, drop the reference. Closing a
+   * [SocketChannel]-backed transport is idempotent, so a redundant call (the read loop racing
+   * [disconnect]) is safe. This is the single point that releases the socket fd (issue #5261).
+   */
+  private fun closeTransport(target: ObservationStreamTransport?) {
+    if (target == null) return
+    try {
+      target.close()
+    } catch (e: Exception) {
+      log.warn("Error closing observation stream transport: ${e.message}")
+    }
+    if (transport === target) {
+      transport = null
+    }
   }
 
   override fun isConnected(): Boolean = _connectionState.value.isConnected
@@ -275,7 +331,7 @@ class ObservationStreamClient : ObservationStream {
   }
 
   private fun sendRequest(request: StreamRequest): Boolean {
-    val currentWriter = writer ?: return false
+    val currentWriter = transport?.writer ?: return false
 
     return try {
       val message = json.encodeToString(serializer<StreamRequest>(), request)
@@ -290,7 +346,8 @@ class ObservationStreamClient : ObservationStream {
   }
 
   private suspend fun readMessages() {
-    val currentReader = reader ?: return
+    val activeTransport = transport ?: return
+    val currentReader = activeTransport.reader
 
     try {
       log.info("Starting message read loop")
@@ -312,6 +369,11 @@ class ObservationStreamClient : ObservationStream {
       log.warn("Error reading from observation stream: ${e.message}", e)
     }
 
+    // Close the transport at its death point (EOF or read error) BEFORE publishing Disconnected.
+    // disconnect() early-returns once the state is no longer Connected, so without this every
+    // reconnect that reuses this instance would abandon the dead socket and leak its fd (issue
+    // #5261).
+    closeTransport(activeTransport)
     _connectionState.update { ConnectionState.Disconnected("Stream ended") }
     log.info("Observation stream disconnected")
   }

--- a/android/desktop-core/src/main/kotlin/dev/jasonpearson/automobile/desktop/core/daemon/ObservationStreamClient.kt
+++ b/android/desktop-core/src/main/kotlin/dev/jasonpearson/automobile/desktop/core/daemon/ObservationStreamClient.kt
@@ -89,6 +89,9 @@ private class SocketChannelTransport(private val channel: SocketChannel) :
 class ObservationStreamClient(
   private val transportFactory: ObservationStreamTransportFactory = SocketChannelTransportFactory,
   private val socketPathProvider: () -> String = { getSocketPath() },
+  // Test seam: invoked when a readMessages() invocation returns (superseded or not), so a test can
+  // await a specific read loop's completion deterministically. No-op in production.
+  private val onReadLoopExit: () -> Unit = {},
 ) : ObservationStream {
   companion object {
     internal fun getSocketPath(): String =
@@ -101,10 +104,21 @@ class ObservationStreamClient(
   private val json = DaemonJson
   private val scope = CoroutineScope(SupervisorJob() + Dispatchers.IO)
 
-  // Single owning reference to the live transport. It is closed both at its death point in the read
-  // loop (EOF or read error) and in disconnect(), so no reconnect abandons a still-open socket
-  // (issue #5261).
+  // Serializes transport ownership: the (transport, connectionGeneration) pair is only ever read or
+  // mutated while holding this lock, so a read loop's generation check and connect()/disconnect()'s
+  // reassignment can never interleave.
+  private val ownershipLock = Any()
+
+  // Single owning reference to the live transport. Closed at its death point in the read loop (EOF
+  // or read error) and in disconnect(), so no reconnect abandons a still-open socket (issue #5261).
   private var transport: ObservationStreamTransport? = null
+
+  // Monotonic token identifying the current connection attempt. Advanced whenever the active
+  // transport is installed (connect) or released (disconnect/EOF). A read loop captures the
+  // generation it was started for and only clears the transport / publishes Disconnected while it
+  // still owns that generation, so a stale loop that outlives a reconnect is inert (issue #5261,
+  // CodeRabbit).
+  private var connectionGeneration: Long = 0L
 
   // Flow for hierarchy updates
   private val _hierarchyUpdates = MutableSharedFlow<HierarchyStreamUpdate>(replay = 1)
@@ -183,10 +197,18 @@ class ObservationStreamClient(
         return
       }
 
-      // Close any transport left over from a previous connection before opening a fresh one, so a
-      // dead socket from a prior EOF is never abandoned (issue #5261).
-      closeTransport(transport)
-      transport = transportFactory.open(socketPath)
+      // Open the fresh transport, then install it and advance the generation atomically. Any
+      // transport left over from a prior connection is closed rather than abandoned (issue #5261),
+      // and the generation bump supersedes any read loop still running from a previous attempt.
+      val newTransport = transportFactory.open(socketPath)
+      val previousTransport: ObservationStreamTransport?
+      val generation: Long
+      synchronized(ownershipLock) {
+        previousTransport = transport
+        transport = newTransport
+        generation = ++connectionGeneration
+      }
+      closeQuietly(previousTransport)
 
       _connectionState.update { ConnectionState.Connected() }
       log.info("Connected to observation stream")
@@ -197,9 +219,9 @@ class ObservationStreamClient(
       pendingCadenceUpdate = false
       subscribe(deviceId)
 
-      // Start reading messages
+      // Start reading messages for this generation
       scope.launch {
-        readMessages()
+        readMessages(generation)
       }
     } catch (e: Exception) {
       log.warn("Failed to connect to observation stream: ${e.message}")
@@ -228,26 +250,38 @@ class ObservationStreamClient(
       log.warn("Error disconnecting from observation stream: ${e.message}")
     }
 
-    closeTransport(transport)
+    releaseActiveTransport()
     subscriptionId = null
     pendingCadenceUpdate = false
     _connectionState.update { ConnectionState.Disconnected() }
   }
 
   /**
-   * Close [target] and, when it is still the active transport, drop the reference. Closing a
-   * [SocketChannel]-backed transport is idempotent, so a redundant call (the read loop racing
-   * [disconnect]) is safe. This is the single point that releases the socket fd (issue #5261).
+   * Clear the active transport and advance the generation under [ownershipLock], then close it. The
+   * generation bump supersedes any running read loop so it becomes inert on exit, and closing the
+   * transport releases its fd (issue #5261). Safe when there is no transport (no-op close).
    */
-  private fun closeTransport(target: ObservationStreamTransport?) {
+  private fun releaseActiveTransport() {
+    val target =
+      synchronized(ownershipLock) {
+        val current = transport
+        transport = null
+        connectionGeneration++
+        current
+      }
+    closeQuietly(target)
+  }
+
+  /**
+   * Close [target] best-effort. Closing a [SocketChannel]-backed transport is idempotent, so a
+   * redundant call (the read loop racing [disconnect]) is safe.
+   */
+  private fun closeQuietly(target: ObservationStreamTransport?) {
     if (target == null) return
     try {
       target.close()
     } catch (e: Exception) {
       log.warn("Error closing observation stream transport: ${e.message}")
-    }
-    if (transport === target) {
-      transport = null
     }
   }
 
@@ -345,14 +379,23 @@ class ObservationStreamClient(
     }
   }
 
-  private suspend fun readMessages() {
-    val activeTransport = transport ?: return
+  private suspend fun readMessages(generation: Long) {
+    // Bind to the transport for this generation. If a disconnect()/reconnect already superseded us
+    // before we started reading, there is nothing to own -- exit without touching state.
+    val activeTransport =
+      synchronized(ownershipLock) { if (connectionGeneration == generation) transport else null }
+    if (activeTransport == null) {
+      onReadLoopExit()
+      return
+    }
     val currentReader = activeTransport.reader
 
     try {
       log.info("Starting message read loop")
 
-      while (_connectionState.value.isConnected) {
+      // Stop as soon as a later connect()/disconnect() supersedes this generation, so a stale loop
+      // never emits frames onto the shared flows after ownership has moved on.
+      while (ownsGeneration(generation) && _connectionState.value.isConnected) {
         val line = currentReader.readLine() ?: break
         if (line.isBlank()) continue
 
@@ -369,14 +412,32 @@ class ObservationStreamClient(
       log.warn("Error reading from observation stream: ${e.message}", e)
     }
 
-    // Close the transport at its death point (EOF or read error) BEFORE publishing Disconnected.
-    // disconnect() early-returns once the state is no longer Connected, so without this every
-    // reconnect that reuses this instance would abandon the dead socket and leak its fd (issue
-    // #5261).
-    closeTransport(activeTransport)
-    _connectionState.update { ConnectionState.Disconnected("Stream ended") }
-    log.info("Observation stream disconnected")
+    // Death point (EOF or read error). Clear the transport and publish Disconnected ONLY while we
+    // still own the active generation: a loop superseded by disconnect()/reconnect must do nothing,
+    // or it would both close the NEW transport's slot and stomp the live Connected state -- after
+    // which disconnect()/dispose() would early-return and leak the new socket (issue #5261,
+    // CodeRabbit). disconnect() early-returns once not Connected, so for the still-owning EOF case
+    // this is the only place that releases the dead socket's fd.
+    val stillOwner =
+      synchronized(ownershipLock) {
+        if (connectionGeneration == generation) {
+          transport = null
+          connectionGeneration++
+          true
+        } else {
+          false
+        }
+      }
+    if (stillOwner) {
+      closeQuietly(activeTransport)
+      _connectionState.update { ConnectionState.Disconnected("Stream ended") }
+      log.info("Observation stream disconnected")
+    }
+    onReadLoopExit()
   }
+
+  private fun ownsGeneration(generation: Long): Boolean =
+    synchronized(ownershipLock) { connectionGeneration == generation }
 
   internal suspend fun handleMessage(message: String) {
     val response = json.decodeFromString(serializer<StreamResponse>(), message)

--- a/android/desktop-core/src/test/kotlin/dev/jasonpearson/automobile/desktop/core/daemon/ObservationStreamClientTest.kt
+++ b/android/desktop-core/src/test/kotlin/dev/jasonpearson/automobile/desktop/core/daemon/ObservationStreamClientTest.kt
@@ -1,13 +1,22 @@
 package dev.jasonpearson.automobile.desktop.core.daemon
 
 import app.cash.turbine.test
+import dev.jasonpearson.automobile.desktop.core.connection.ConnectionState
 import dev.jasonpearson.automobile.desktop.domain.CoordinateSpace
+import java.io.BufferedReader
+import java.io.BufferedWriter
+import java.io.StringReader
+import java.io.StringWriter
+import java.nio.file.Files
 import kotlin.test.Test
 import kotlin.test.assertEquals
 import kotlin.test.assertFalse
 import kotlin.test.assertNull
 import kotlin.test.assertTrue
+import kotlinx.coroutines.flow.first
+import kotlinx.coroutines.runBlocking
 import kotlinx.coroutines.test.runTest
+import kotlinx.coroutines.withTimeout
 
 class ObservationStreamClientTest {
   // Uses the same configuration as ObservationStreamClient so these assertions match the socket.
@@ -394,6 +403,97 @@ class ObservationStreamClientTest {
     // After reset, a new subscriber gets nothing until a genuinely fresh frame arrives.
     client.hierarchyUpdates.test { expectNoEvents() }
     client.screenshotUpdates.test { expectNoEvents() }
+  }
+
+  @Test
+  fun `closes the dead transport on EOF and opens a fresh one on reconnect without leaking`() {
+    // Regression for issue #5261 (supersedes #5045): before the fix, the read loop set
+    // Disconnected("Stream ended") on EOF without closing the SocketChannel, and disconnect()
+    // early-returns once not Connected -- so every reconnect abandoned a still-open fd. This drives
+    // the injectable transport seam through EOF -> reconnect and EOF -> dispose with no real
+    // socket.
+    runBlocking {
+      // connect() gates on Files.exists(socketPath); a real temp file passes it hermetically while
+      // the fake factory ignores the path entirely.
+      val tempSocket = Files.createTempFile("obs-stream-fdleak", ".sock")
+      try {
+        val factory = RecordingTransportFactory()
+        val client =
+          ObservationStreamClient(
+            transportFactory = factory,
+            socketPathProvider = { tempSocket.toString() },
+          )
+
+        // First connection: the empty reader yields immediate EOF, ending the read loop.
+        client.connect("emulator-5554")
+        client.awaitStreamEnded()
+
+        assertEquals(1, factory.opened.size, "connect should open exactly one transport")
+        val first = factory.opened[0]
+        assertTrue(first.isClosed, "the dead transport must be closed at EOF, not leaked")
+        assertFalse(client.isConnected())
+
+        // Reconnect on the SAME instance: opens a fresh transport; the previous one stays closed
+        // and
+        // is never re-owned (AC2).
+        client.connect("emulator-5554")
+        client.awaitStreamEnded()
+
+        assertEquals(2, factory.opened.size, "reconnect should open a second, fresh transport")
+        assertTrue(factory.opened[1].isClosed, "the second dead transport must also be closed")
+        assertEquals(1, first.closeCount, "the first transport must be closed exactly once")
+
+        // EOF -> dispose: disposing after a death finds nothing to leak and must not throw.
+        client.dispose()
+        assertTrue(
+          factory.opened.all { it.isClosed },
+          "no transport may be left open after dispose",
+        )
+      } finally {
+        Files.deleteIfExists(tempSocket)
+      }
+    }
+  }
+
+  /**
+   * Await the EOF-driven terminal state. The read loop runs on the client's own Dispatchers.IO
+   * scope, so the StateFlow flips from a real background coroutine; `first { ... }` replays the
+   * current value and returns as soon as the death point has published it (AC1: once observers can
+   * see Disconnected, the transport is already closed).
+   */
+  private suspend fun ObservationStreamClient.awaitStreamEnded() {
+    withTimeout(5_000) {
+      connectionState.first { it is ConnectionState.Disconnected && it.reason == "Stream ended" }
+    }
+  }
+
+  /**
+   * Records every transport it hands out so a test can assert each one was closed (issue #5261).
+   */
+  private class RecordingTransportFactory : ObservationStreamTransportFactory {
+    val opened = mutableListOf<FakeStreamTransport>()
+
+    override fun open(socketPath: String): ObservationStreamTransport =
+      FakeStreamTransport().also { opened += it }
+  }
+
+  /**
+   * In-memory [ObservationStreamTransport]: an empty reader (immediate EOF) over a discarding
+   * writer, counting [close] calls in place of releasing a real fd.
+   */
+  private class FakeStreamTransport : ObservationStreamTransport {
+    override val reader: BufferedReader = BufferedReader(StringReader(""))
+    override val writer: BufferedWriter = BufferedWriter(StringWriter())
+
+    var closeCount = 0
+      private set
+
+    val isClosed: Boolean
+      get() = closeCount > 0
+
+    override fun close() {
+      closeCount++
+    }
   }
 
   private fun deviceConnectionLostMessage(): String =

--- a/android/desktop-core/src/test/kotlin/dev/jasonpearson/automobile/desktop/core/daemon/ObservationStreamClientTest.kt
+++ b/android/desktop-core/src/test/kotlin/dev/jasonpearson/automobile/desktop/core/daemon/ObservationStreamClientTest.kt
@@ -5,12 +5,16 @@ import dev.jasonpearson.automobile.desktop.core.connection.ConnectionState
 import dev.jasonpearson.automobile.desktop.domain.CoordinateSpace
 import java.io.BufferedReader
 import java.io.BufferedWriter
-import java.io.StringReader
+import java.io.Reader
 import java.io.StringWriter
 import java.nio.file.Files
+import java.util.concurrent.CountDownLatch
+import java.util.concurrent.LinkedBlockingQueue
+import java.util.concurrent.TimeUnit
 import kotlin.test.Test
 import kotlin.test.assertEquals
 import kotlin.test.assertFalse
+import kotlin.test.assertNotNull
 import kotlin.test.assertNull
 import kotlin.test.assertTrue
 import kotlinx.coroutines.flow.first
@@ -455,6 +459,75 @@ class ObservationStreamClientTest {
     }
   }
 
+  @Test
+  fun `a read loop superseded by a reconnect stays inert and the new transport is still closable`() {
+    // Regression for the CodeRabbit "Major" race on PR #5387: disconnect() then connect() can
+    // install a fresh transport BEFORE the previous readMessages() coroutine reaches its end.
+    // Without a generation guard the stale loop publishes Disconnected("Stream ended") AFTER the
+    // new
+    // transport is live -- so a later disconnect()/dispose() early-returns (state not Connected)
+    // and
+    // leaks the new socket. The generation guard makes the superseded loop inert on exit.
+    runBlocking {
+      val tempSocket = Files.createTempFile("obs-stream-stale", ".sock")
+      try {
+        val readLoopExits = LinkedBlockingQueue<Unit>()
+        // blocking = true lets the test hold each read loop at its blocking read and choose exactly
+        // when it terminates, so the stale loop ends AFTER the reconnect.
+        val factory = RecordingTransportFactory(blocking = true)
+        val client =
+          ObservationStreamClient(
+            transportFactory = factory,
+            socketPathProvider = { tempSocket.toString() },
+            onReadLoopExit = { readLoopExits.add(Unit) },
+          )
+
+        // Connect: the first read loop starts and parks inside its blocking read.
+        client.connect("emulator-5554")
+        val first = factory.opened[0]
+        first.awaitReadEntered()
+
+        // Disconnect closes the first transport, then reconnect installs a fresh one whose read
+        // loop
+        // also parks -- all while the first loop is still parked (not yet terminated).
+        client.disconnect()
+        assertTrue(first.isClosed, "disconnect must close the first transport")
+        client.connect("emulator-5554")
+        assertEquals(2, factory.opened.size, "reconnect must open a second transport")
+        val second = factory.opened[1]
+        second.awaitReadEntered()
+        assertTrue(client.isConnected())
+        assertEquals(0, second.closeCount)
+
+        // Now let the STALE loop terminate, after the reconnect. It must be inert.
+        first.releaseEof()
+        assertNotNull(readLoopExits.poll(5, TimeUnit.SECONDS), "the stale read loop never exited")
+
+        assertTrue(
+          client.isConnected(),
+          "a superseded read loop must not disconnect the live session",
+        )
+        assertEquals(
+          0,
+          second.closeCount,
+          "a superseded read loop must not close the new transport",
+        )
+
+        // dispose() must still close the live transport -- proving the new socket is not leaked,
+        // which is exactly the hole the generation guard closes.
+        client.dispose()
+        assertEquals(1, second.closeCount, "dispose must close the live transport")
+        assertFalse(client.isConnected())
+
+        // Release the live loop so its background thread exits cleanly.
+        second.releaseEof()
+        assertNotNull(readLoopExits.poll(5, TimeUnit.SECONDS))
+      } finally {
+        Files.deleteIfExists(tempSocket)
+      }
+    }
+  }
+
   /**
    * Await the EOF-driven terminal state. The read loop runs on the client's own Dispatchers.IO
    * scope, so the StateFlow flips from a real background coroutine; `first { ... }` replays the
@@ -468,21 +541,25 @@ class ObservationStreamClientTest {
   }
 
   /**
-   * Records every transport it hands out so a test can assert each one was closed (issue #5261).
+   * Records every transport it hands out so a test can assert each one was closed (issue #5261). In
+   * [blocking] mode the transports park their read loop until [FakeStreamTransport.releaseEof].
    */
-  private class RecordingTransportFactory : ObservationStreamTransportFactory {
+  private class RecordingTransportFactory(private val blocking: Boolean = false) :
+    ObservationStreamTransportFactory {
     val opened = mutableListOf<FakeStreamTransport>()
 
     override fun open(socketPath: String): ObservationStreamTransport =
-      FakeStreamTransport().also { opened += it }
+      FakeStreamTransport(blocking).also { opened += it }
   }
 
   /**
-   * In-memory [ObservationStreamTransport]: an empty reader (immediate EOF) over a discarding
-   * writer, counting [close] calls in place of releasing a real fd.
+   * In-memory [ObservationStreamTransport] over a discarding writer, counting [close] calls in
+   * place of releasing a real fd. Its reader yields EOF immediately, or (in blocking mode) blocks
+   * until [releaseEof] so a test can interleave a reconnect before the read loop terminates.
    */
-  private class FakeStreamTransport : ObservationStreamTransport {
-    override val reader: BufferedReader = BufferedReader(StringReader(""))
+  private class FakeStreamTransport(blocking: Boolean = false) : ObservationStreamTransport {
+    private val controllableReader = ControllableReader(blocking)
+    override val reader: BufferedReader = BufferedReader(controllableReader)
     override val writer: BufferedWriter = BufferedWriter(StringWriter())
 
     var closeCount = 0
@@ -491,9 +568,40 @@ class ObservationStreamClientTest {
     val isClosed: Boolean
       get() = closeCount > 0
 
+    /** Block until this transport's read loop has entered its (blocking) read. */
+    fun awaitReadEntered() = controllableReader.awaitReadEntered()
+
+    /** Release the parked read so it returns EOF, ending the read loop. */
+    fun releaseEof() = controllableReader.releaseEof()
+
     override fun close() {
       closeCount++
     }
+  }
+
+  /**
+   * A [Reader] whose single read returns EOF. In [blocking] mode it first parks until [releaseEof],
+   * letting a test drive exactly when the read loop terminates relative to a reconnect; otherwise
+   * it EOFs immediately.
+   */
+  private class ControllableReader(private val blocking: Boolean) : Reader() {
+    private val readEntered = CountDownLatch(1)
+    private val eofGate = CountDownLatch(1)
+
+    fun awaitReadEntered() =
+      check(readEntered.await(5, TimeUnit.SECONDS)) { "read loop never entered its read" }
+
+    fun releaseEof() = eofGate.countDown()
+
+    override fun read(cbuf: CharArray, off: Int, len: Int): Int {
+      readEntered.countDown()
+      if (blocking) {
+        check(eofGate.await(5, TimeUnit.SECONDS)) { "EOF was never released" }
+      }
+      return -1
+    }
+
+    override fun close() = Unit
   }
 
   private fun deviceConnectionLostMessage(): String =


### PR DESCRIPTION
## Problem

`ObservationStreamClient` never closed its `SocketChannel` when the connection ended via
**EOF / read-loop termination** (as opposed to an explicit `disconnect()`), so every reconnect that
reused the same instance leaked one file descriptor:

- `readMessages()` ended the read loop on EOF and set `Disconnected("Stream ended")` without closing
  `channel`. The only `channel?.close()` lived in `disconnect()`.
- `disconnect()` early-returns when the state is not `Connected`, so after an EOF it could no longer
  reach the close — and `dispose()` (which calls `disconnect()`) leaked too.
- `connect()` then proceeded and did `channel = SocketChannel.open(...)`, overwriting the reference to
  the still-open dead socket.

PR #5038's shared reconnect lifecycle (`rememberReconnectingObservationStream`) multiplied this by the
number of open facets. Surfaced by Codex review of #5038.

## Change

**Close where it dies.** The read loop now closes and drops the transport at its death point (EOF or
read error) **before** publishing `Disconnected`, so a subsequent `connect()` opens a fresh transport
and `disconnect()`/`dispose()` find nothing to leak. This fixes every reconnect caller at once
(`AutoMobileContent` health-check loop, `rememberReconnectingObservationStream`, the two-device compare
sides). `connect()` also defensively closes any leftover transport before opening a new one, so a dead
socket is never abandoned.

Concretely, the `channel`/`reader`/`writer` trio is replaced by a single owning `transport` reference,
released through one idempotent `closeTransport(...)` helper reachable from both the death point and
`disconnect()` (closing a `SocketChannel` twice is a no-op, so the read-loop/`disconnect` race is safe).

## Test seam

The client previously had no channel/transport seam (`ObservationStreamClientTest` drives
`handleMessage(...)` directly; `FakeObservationStream` fakes the `ObservationStream` interface, not the
real client's socket). This introduces a small injectable seam following the repo's interface+fake
convention:

- `ObservationStreamTransport` — a line-oriented `reader`/`writer`/`close()` abstraction over the
  socket.
- `ObservationStreamTransportFactory` — constructor-injected, **defaulting to the real
  `SocketChannel.open`** (`SocketChannelTransportFactory`); production behavior is unchanged.
- A defaulted `socketPathProvider` so the `connect()` `Files.exists` gate can be satisfied by a temp
  file in tests, hermetically.

## Regression test

`closes the dead transport on EOF and opens a fresh one on reconnect without leaking` drives a fake
transport (empty reader → immediate EOF) through:

1. **EOF** → the dead transport is closed (fd released) and the client is `Disconnected` — no real
   daemon/socket.
2. **Reconnect** on the same instance → a fresh transport is opened while the previous one stays closed
   and is never re-owned.
3. **EOF → dispose** → dispose finds nothing to leak and leaves no transport open.

Fast (<0.4s for the whole class), deterministic.

## Validation

- `./gradlew :desktop-core:test --tests '*ObservationStreamClient*'` — **PASS**, 13 tests, 0 failures.
- `./gradlew :desktop-core:detektMain :desktop-core:detektTest` — **PASS**, no violations.
- ktfmt (CI jar, `scripts/ktfmt/validate_ktfmt.sh`) — **PASS**.
- `:desktop-core` compiles and jars.

## Closes

Closes #5261
Closes #5045
