### PR TITLE
ci: bound Fast Validation dependency install to stop 50-min hangs

### DIFF
--- a/.github/workflows/pull_request.yml
+++ b/.github/workflows/pull_request.yml
@@ -723,17 +723,18 @@ jobs:
       # xmlstarlet, and the BATS step needs bats. No dpkg-lock contention — this
       # is the only apt user in the job (setup-java unpacks a tarball and
       # setup-ripgrep installs a pre-built binary). Mechanism per #3779.
+      #
+      # Each network call inside the helper is bounded by a per-command timeout
+      # and retried with backoff so a stalled apt mirror or GitHub clone fails
+      # fast instead of hanging silently — a `background` failure surfaces at the
+      # `- wait:` below, and without this an indefinite hang ate the whole
+      # 50-minute job budget. `timeout-minutes` is the hard backstop.
       - name: "Install fast validation dependencies"
         shell: bash
         background: true
         id: install-fast-validation-deps
-        run: |
-          sudo apt-get update
-          sudo apt-get install -y xmlstarlet
-          if ! command -v bats &>/dev/null; then
-            git clone --depth 1 https://github.com/bats-core/bats-core.git /tmp/bats-core
-            sudo /tmp/bats-core/install.sh /usr/local
-          fi
+        timeout-minutes: 10
+        run: scripts/ci/install-fast-validation-deps.sh
 
       # Pin the JDK so the ktfmt check formats deterministically (project targets
       # Java 21) instead of relying on the runner image's default JDK.

--- a/scripts/ci/install-fast-validation-deps.sh
+++ b/scripts/ci/install-fast-validation-deps.sh
@@ -1,0 +1,107 @@
+#!/usr/bin/env bash
+#
+# Installs the Fast Validation job's extra CLI dependencies (xmlstarlet + bats)
+# with bounded, retrying network calls.
+#
+# The Fast Validation "Install fast validation dependencies" step runs three
+# network operations -- `apt-get update`, `apt-get install`, and a `git clone`
+# of bats-core -- as a `background: true` step. Native parallel-step failure
+# surfaces at the `- wait:` barrier, so when a stalled apt mirror or GitHub TCP
+# read never returns, the command blocks with no output, the wait never
+# completes, and the whole 50-minute job budget is consumed before the run is
+# cancelled by timeout. Wrapping each call in a per-command wall-clock timeout
+# plus exponential-backoff retry turns an indefinite hang into a fast, retried,
+# and ultimately loud failure. The workflow step also carries `timeout-minutes`
+# as a hard backstop.
+set -euo pipefail
+
+# Tunables (overridable for tuning and for the BATS tests).
+CMD_TIMEOUT_SECONDS="${FAST_VALIDATION_DEPS_CMD_TIMEOUT_SECONDS:-180}"
+KILL_GRACE_SECONDS="${FAST_VALIDATION_DEPS_KILL_GRACE_SECONDS:-10}"
+MAX_ATTEMPTS="${FAST_VALIDATION_DEPS_MAX_ATTEMPTS:-3}"
+RETRY_BASE_DELAY_SECONDS="${FAST_VALIDATION_DEPS_RETRY_BASE_DELAY_SECONDS:-5}"
+BATS_CLONE_DIR="${FAST_VALIDATION_DEPS_BATS_CLONE_DIR:-/tmp/bats-core}"
+BATS_INSTALL_PREFIX="${FAST_VALIDATION_DEPS_BATS_INSTALL_PREFIX:-/usr/local}"
+
+log() {
+  echo "[install-fast-validation-deps] $*"
+}
+
+die() {
+  echo "[install-fast-validation-deps] ERROR: $*" >&2
+  exit 1
+}
+
+is_positive_integer() {
+  [[ "$1" =~ ^[1-9][0-9]*$ ]]
+}
+
+# Run "$@" under a wall-clock timeout, retrying with exponential backoff.
+#
+# Each attempt is bounded by CMD_TIMEOUT_SECONDS so a network stall cannot hang
+# forever; `timeout` sends SIGTERM on expiry and, after KILL_GRACE_SECONDS,
+# SIGKILL (-k) so a child that ignores SIGTERM cannot linger. A timeout exits
+# 124 and is treated as a retryable failure, as is any other non-zero exit.
+run_with_retry() {
+  local description="$1"
+  shift
+
+  local attempt=1
+  local delay="$RETRY_BASE_DELAY_SECONDS"
+  local status=0
+
+  while true; do
+    log "${description} (attempt ${attempt}/${MAX_ATTEMPTS}, timeout ${CMD_TIMEOUT_SECONDS}s)"
+    # Capture the real exit code in the condition: a bare `if cmd; then ...; fi`
+    # with no `else` reports status 0 for the compound statement, so reading
+    # `$?` after `fi` would always see 0 rather than the command's exit.
+    status=0
+    timeout -k "$KILL_GRACE_SECONDS" "$CMD_TIMEOUT_SECONDS" "$@" || status=$?
+    if [[ "$status" -eq 0 ]]; then
+      return 0
+    fi
+
+    if [[ "$status" -eq 124 ]]; then
+      log "${description} timed out after ${CMD_TIMEOUT_SECONDS}s"
+    else
+      log "${description} failed with exit ${status}"
+    fi
+
+    if [[ "$attempt" -ge "$MAX_ATTEMPTS" ]]; then
+      die "${description} failed after ${MAX_ATTEMPTS} attempts (last exit ${status})"
+    fi
+
+    log "Retrying ${description} in ${delay}s..."
+    sleep "$delay"
+    attempt=$((attempt + 1))
+    delay=$((delay * 2))
+  done
+}
+
+main() {
+  local var
+  for var in CMD_TIMEOUT_SECONDS KILL_GRACE_SECONDS MAX_ATTEMPTS RETRY_BASE_DELAY_SECONDS; do
+    if ! is_positive_integer "${!var}"; then
+      die "${var} must be a positive integer (got '${!var}')"
+    fi
+  done
+
+  run_with_retry "apt-get update" sudo apt-get update
+  run_with_retry "apt-get install xmlstarlet" sudo apt-get install -y xmlstarlet
+
+  if command -v bats > /dev/null 2>&1; then
+    log "bats already on PATH; skipping source install"
+  else
+    # Remove any partial clone from a previous killed attempt so `git clone`
+    # does not fail on a non-empty target directory.
+    rm -rf "$BATS_CLONE_DIR"
+    run_with_retry "clone bats-core" \
+      git clone --depth 1 https://github.com/bats-core/bats-core.git "$BATS_CLONE_DIR"
+    run_with_retry "install bats-core" \
+      sudo "${BATS_CLONE_DIR}/install.sh" "$BATS_INSTALL_PREFIX"
+  fi
+
+  log "Fast Validation dependencies ready"
+}
+
+main "$@"

--- a/test/bats/install-fast-validation-deps.bats
+++ b/test/bats/install-fast-validation-deps.bats
@@ -1,0 +1,145 @@
+#!/usr/bin/env bats
+#
+# Tests for scripts/ci/install-fast-validation-deps.sh
+#
+# The real script installs xmlstarlet + bats over the network. These tests stub
+# `sudo`, `apt-get`, and `git` on PATH so nothing touches the network, and drive
+# the timeout/retry logic that bounds the Fast Validation dependency-install
+# hang class.
+
+SCRIPT="scripts/ci/install-fast-validation-deps.sh"
+
+setup() {
+  MOCK_BIN="$(mktemp -d)"
+  ORIG_PATH="$PATH"
+  # A shared counter file lets a stub fail the first N invocations.
+  export STATE_FILE="${MOCK_BIN}/apt-calls"
+  # Keep the bats source-install branch out of the way: a stub `bats` on PATH
+  # makes the script skip cloning bats-core.
+  cat > "${MOCK_BIN}/bats" <<'STUB'
+#!/usr/bin/env bash
+exit 0
+STUB
+  chmod +x "${MOCK_BIN}/bats"
+  # `sudo` just drops the sudo and execs the rest.
+  cat > "${MOCK_BIN}/sudo" <<'STUB'
+#!/usr/bin/env bash
+exec "$@"
+STUB
+  chmod +x "${MOCK_BIN}/sudo"
+  # A hermetic GNU-`timeout` emulation so these tests do not depend on the host
+  # shipping coreutils `timeout` (macOS does not). Supports `[-k GRACE] DURATION
+  # CMD...` and returns 124 when it has to kill the command, matching the real
+  # tool the script relies on in Ubuntu CI.
+  cat > "${MOCK_BIN}/timeout" <<'STUB'
+#!/usr/bin/env bash
+if [ "$1" = "-k" ]; then shift 2; fi
+duration="$1"; shift
+"$@" &
+cmd_pid=$!
+( sleep "$duration"; kill -TERM "$cmd_pid" 2>/dev/null ) &
+killer_pid=$!
+if wait "$cmd_pid" 2>/dev/null; then status=0; else status=$?; fi
+if kill -0 "$killer_pid" 2>/dev/null; then
+  # Command finished first: cancel the killer and reap its `sleep` child so it
+  # is not orphaned (an orphaned long `sleep` would hold the output pipe open).
+  pkill -P "$killer_pid" 2>/dev/null
+  kill "$killer_pid" 2>/dev/null
+  wait "$killer_pid" 2>/dev/null
+  exit "$status"
+fi
+# Timed out: reap any grandchild of the killed command (e.g. a `sleep`).
+pkill -P "$cmd_pid" 2>/dev/null
+exit 124
+STUB
+  chmod +x "${MOCK_BIN}/timeout"
+  export PATH="${MOCK_BIN}:${PATH}"
+  # Fast, deterministic retries.
+  export FAST_VALIDATION_DEPS_RETRY_BASE_DELAY_SECONDS=1
+}
+
+teardown() {
+  rm -rf "$MOCK_BIN"
+  export PATH="$ORIG_PATH"
+}
+
+# Writes an `apt-get` stub that fails its first $1 invocations, then succeeds.
+make_apt_get() {
+  local fail_first="$1"
+  cat > "${MOCK_BIN}/apt-get" <<STUB
+#!/usr/bin/env bash
+calls=0
+[ -f "${STATE_FILE}" ] && calls="\$(cat "${STATE_FILE}")"
+calls=\$((calls + 1))
+echo "\$calls" > "${STATE_FILE}"
+if [ "\$calls" -le "${fail_first}" ]; then
+  echo "apt-get transient failure \$calls" >&2
+  exit 100
+fi
+exit 0
+STUB
+  chmod +x "${MOCK_BIN}/apt-get"
+}
+
+@test "script is executable" {
+  [ -x "$SCRIPT" ]
+}
+
+@test "script has bash shebang" {
+  head -1 "$SCRIPT" | grep -q "bash"
+}
+
+@test "shellcheck passes" {
+  if ! command -v shellcheck > /dev/null 2>&1; then
+    skip "shellcheck not installed"
+  fi
+  run shellcheck "$SCRIPT"
+  [ "$status" -eq 0 ]
+}
+
+@test "succeeds when all network commands succeed" {
+  make_apt_get 0
+  run bash "$SCRIPT"
+  [ "$status" -eq 0 ]
+  [[ "$output" == *"Fast Validation dependencies ready"* ]]
+}
+
+@test "retries a transiently-failing apt-get and then succeeds" {
+  # First `apt-get update` call fails once, then succeeds; install then succeeds.
+  make_apt_get 1
+  run bash "$SCRIPT"
+  [ "$status" -eq 0 ]
+  [[ "$output" == *"attempt 2/3"* ]]
+  [[ "$output" == *"Fast Validation dependencies ready"* ]]
+}
+
+@test "fails loudly after exhausting retries" {
+  # apt-get fails more times than MAX_ATTEMPTS allows.
+  make_apt_get 99
+  run env FAST_VALIDATION_DEPS_MAX_ATTEMPTS=2 bash "$SCRIPT"
+  [ "$status" -ne 0 ]
+  [[ "$output" == *"failed after 2 attempts"* ]]
+}
+
+@test "bounds a hanging command with the per-command timeout" {
+  # apt-get sleeps far longer than the 1s per-command timeout; with a single
+  # attempt the run must fail fast (via exit 124) rather than block.
+  cat > "${MOCK_BIN}/apt-get" <<'STUB'
+#!/usr/bin/env bash
+sleep 30
+STUB
+  chmod +x "${MOCK_BIN}/apt-get"
+  run env FAST_VALIDATION_DEPS_CMD_TIMEOUT_SECONDS=1 \
+    FAST_VALIDATION_DEPS_KILL_GRACE_SECONDS=1 \
+    FAST_VALIDATION_DEPS_MAX_ATTEMPTS=1 \
+    bash "$SCRIPT"
+  [ "$status" -ne 0 ]
+  [[ "$output" == *"timed out after 1s"* ]]
+}
+
+@test "rejects a non-positive-integer tunable" {
+  make_apt_get 0
+  run env FAST_VALIDATION_DEPS_MAX_ATTEMPTS=0 bash "$SCRIPT"
+  [ "$status" -ne 0 ]
+  [[ "$output" == *"must be a positive integer"* ]]
+}


### PR DESCRIPTION
## Problem

The required **Fast Validation** job intermittently hangs for ~50 minutes and is then cancelled by timeout. Observed on runs [32157833446](https://github.com/kaeawc/auto-mobile/actions/runs/32157833446) and [32157762911](https://github.com/kaeawc/auto-mobile/actions/runs/32157762911): the job started at 16:16, made no progress, and was cancelled at 17:07. The reported hung steps were **"Install fast validation dependencies"** and **"Wait"**.

## Root cause

`.github/workflows/pull_request.yml` ran the install as a `background: true` step with **no `timeout-minutes`, no per-command timeout, and no retry**:

```yaml
- name: "Install fast validation dependencies"
  background: true
  id: install-fast-validation-deps
  run: |
    sudo apt-get update
    sudo apt-get install -y xmlstarlet
    if ! command -v bats &>/dev/null; then
      git clone --depth 1 https://github.com/bats-core/bats-core.git /tmp/bats-core
      sudo /tmp/bats-core/install.sh /usr/local
    fi
```

When an apt mirror or the GitHub `git clone` stalled on a TCP connect/read that never returned, the command blocked with **no output**. Native parallel-step failure surfaces at the `- wait:` barrier (see #3779), so the background step never completed, `- wait: install-fast-validation-deps` sat waiting, and the whole 50-minute job budget was consumed before cancellation — exactly the "Install… + Wait hung, no progress" symptom.

## Fix

- Move the install into **`scripts/ci/install-fast-validation-deps.sh`**, which wraps each network call (`apt-get update`, `apt-get install`, `git clone`, `bats` install) in a per-command `timeout -k` **plus exponential-backoff retry** (default 3 attempts × 180s). A transient stall now recovers on retry; a persistent one **fails loudly** after the attempts instead of hanging.
- Add **`timeout-minutes: 10`** to the step as a hard backstop, so a hung install fails fast rather than eating the whole job.

This removes the hang class two ways: the retry makes transient network stalls recoverable, and the per-command + step timeouts convert an indefinite hang into a fast, bounded failure. It does **not** bump the overall job timeout.

## Why this prevents the 50-min hang

- A stalled `apt-get`/`git clone` is killed after 180s (per command) and retried, instead of blocking forever with no output.
- If every retry stalls, the step's `timeout-minutes: 10` fails the job in ~10 min, and the failure surfaces at `- wait:` — the required check reports a clear failure instead of being cancelled at 50 min.

## Tests

`test/bats/install-fast-validation-deps.bats` (stubs `sudo`/`apt-get`/`git`/`timeout`, no network): success path, retry-then-succeed, retry exhaustion (loud failure), a hanging command bounded by the per-command timeout, and tunable validation. Script is shellcheck-clean.
