### PR TITLE
fix(ios)/ci: make simulator boot resilient in XCTestRunner CI

### DIFF
--- a/.github/actions/ios-simulator-bring-up/action.yml
+++ b/.github/actions/ios-simulator-bring-up/action.yml
@@ -34,7 +34,10 @@ runs:
       shell: bash
       run: |
         ios_version="$(xcrun --sdk iphonesimulator --show-sdk-version)"
-        bun run src/index.ts --boot-device --platform ios --create-if-missing --timeout-ms 300000 \
+        # 600000ms matches the Android product-boot budget: the shared boot
+        # deadline must cover a cold `bootstatus -b` plus the in-process
+        # erase-and-reboot recovery on a loaded runner (see #4286 lineage).
+        bun run src/index.ts --boot-device --platform ios --create-if-missing --timeout-ms 600000 \
           --min-os-version "${ios_version}" --max-os-version "${ios_version}"
 
     - name: "Ensure AutoMobile daemon ready"

--- a/.github/workflows/pull_request.yml
+++ b/.github/workflows/pull_request.yml
@@ -1784,7 +1784,16 @@ jobs:
         id: ctrlproxy-simulator
         run: |
           ios_version="$(xcrun --sdk iphonesimulator --show-sdk-version)"
-          result="$(bun run src/index.ts --boot-device --platform ios --create-if-missing --timeout-ms 300000 --min-os-version "${ios_version}" --max-os-version "${ios_version}")"
+          # 600000ms matches the Android emulator product-boot budget
+          # (scripts/android/boot-emulator.sh). The whole boot draws from ONE
+          # shared deadline, including the in-process CiIosBootRecovery
+          # shutdown+erase+reboot. At 300000ms a slow first cold `bootstatus -b`
+          # on a loaded runner left the recovery's second boot with
+          # remainingBudgetMs=0 (`startDevice timeout exhausted while starting
+          # the device`), so the CLI returned no deviceId and this step, its
+          # `wait` barrier, and the nav-graph step (which reuses this UDID) all
+          # failed as a cascade. Healthy boots finish far inside either budget.
+          result="$(bun run src/index.ts --boot-device --platform ios --create-if-missing --timeout-ms 600000 --min-os-version "${ios_version}" --max-os-version "${ios_version}")"
           simulator_udid="$(printf '%s' "${result}" | jq -r '.deviceId')"
           if [[ -z "${simulator_udid}" || "${simulator_udid}" == "null" ]]; then
             echo "::error::AutoMobile product boot returned no deviceId." >&2

--- a/.github/workflows/webrtc-device-integration.yml
+++ b/.github/workflows/webrtc-device-integration.yml
@@ -139,7 +139,10 @@ jobs:
           (cd ios/screen-capture && swift build)
       - name: "Boot and activate iOS Simulator"
         run: |
-          result="$(bun run src/index.ts --boot-device --platform ios --create-if-missing --timeout-ms 300000)"
+          # 600000ms matches the Android product-boot budget and the sibling
+          # CtrlProxy boot: the shared deadline must cover a cold `bootstatus -b`
+          # plus the in-process erase-and-reboot recovery on a loaded runner.
+          result="$(bun run src/index.ts --boot-device --platform ios --create-if-missing --timeout-ms 600000)"
           simulator_udid="$(printf '%s' "${result}" | jq -r '.deviceId')"
           if [[ -z "${simulator_udid}" || "${simulator_udid}" == "null" ]]; then
             echo "::error::AutoMobile product boot returned no deviceId." >&2

--- a/docs/design-docs/plat/ios/xctestrunner/ci-integration.md
+++ b/docs/design-docs/plat/ios/xctestrunner/ci-integration.md
@@ -67,7 +67,7 @@ automobile-tests:
     - name: Boot iOS Simulator
       run: |
         ios_version="$(xcrun --sdk iphonesimulator --show-sdk-version)"
-        auto-mobile --boot-device --platform ios --create-if-missing --timeout-ms 300000 \\
+        auto-mobile --boot-device --platform ios --create-if-missing --timeout-ms 600000 \\
           --min-os-version "${ios_version}" --max-os-version "${ios_version}"
 
     - name: Start simulator log stream
@@ -146,7 +146,7 @@ The artifact contains both test bundles (`YourAppTests.xctest` and
 
 ```bash
 ios_version="$(xcrun --sdk iphonesimulator --show-sdk-version)"
-auto-mobile --boot-device --platform ios --create-if-missing --timeout-ms 300000 \
+auto-mobile --boot-device --platform ios --create-if-missing --timeout-ms 600000 \
   --min-os-version "${ios_version}" --max-os-version "${ios_version}"
 ```
 

--- a/docs/design-docs/plat/ios/xctestrunner/project-setup.md
+++ b/docs/design-docs/plat/ios/xctestrunner/project-setup.md
@@ -217,7 +217,7 @@ an appropriate simulator and boots it:
 
 ```bash
 ios_version="$(xcrun --sdk iphonesimulator --show-sdk-version)"
-auto-mobile --boot-device --platform ios --create-if-missing --timeout-ms 300000 \
+auto-mobile --boot-device --platform ios --create-if-missing --timeout-ms 600000 \
   --min-os-version "${ios_version}" --max-os-version "${ios_version}"
 ```
 
@@ -377,7 +377,7 @@ xcrun xcresulttool get test-results tests \
 | `no such module 'XCTestRunner'` | `YourAppTests` compiles AutoMobile files without the package linked | Add `excludes: [AutoMobile/**]` to `YourAppTests` sources in `project.yml`; regenerate |
 | `AutoMobile daemon is not running and could not be started` | `auto-mobile` not on PATH or daemon failed to start | Install `@kaeawc/auto-mobile` globally; check PATH includes `~/.bun/bin` or `/usr/local/bin` |
 | `Plan not found at path: test-plans/launch-app.yaml` | YAML file not bundled | Verify the YAML is under `Tests/AutoMobile/` and appears in Build Phases → Copy Bundle Resources |
-| `No booted iPhone simulator found` | No simulator running | Run `ios_version="$(xcrun --sdk iphonesimulator --show-sdk-version)"; auto-mobile --boot-device --platform ios --create-if-missing --timeout-ms 300000 --min-os-version "${ios_version}" --max-os-version "${ios_version}"` or `xcrun simctl boot "iPhone 16"` |
+| `No booted iPhone simulator found` | No simulator running | Run `ios_version="$(xcrun --sdk iphonesimulator --show-sdk-version)"; auto-mobile --boot-device --platform ios --create-if-missing --timeout-ms 600000 --min-os-version "${ios_version}" --max-os-version "${ios_version}"` or `xcrun simctl boot "iPhone 16"` |
 | `Missing AutoMobile test plan path.` | `planPath` returns empty string | Override `var planPath: String` in your test class |
 | `Could not resolve package 'XCTestRunner'` | Local path wrong or source files missing | Verify `libs/spm/XCTestRunner/` exists and `Package.swift` references the correct `path` |
 

--- a/scripts/ios/video-recording-start-stop-integration.sh
+++ b/scripts/ios/video-recording-start-stop-integration.sh
@@ -44,7 +44,10 @@ fi
 
 if [[ -z "${DEVICE_ID}" ]]; then
   ios_version="$(xcrun --sdk iphonesimulator --show-sdk-version)"
-  boot_result="$(cd "${PROJECT_ROOT}" && bun run src/index.ts --boot-device --platform ios --create-if-missing --timeout-ms 300000 --min-os-version "${ios_version}" --max-os-version "${ios_version}")"
+  # 600000ms matches the Android product-boot budget: the shared boot deadline
+  # must cover a cold `bootstatus -b` plus the in-process erase-and-reboot
+  # recovery on a loaded runner.
+  boot_result="$(cd "${PROJECT_ROOT}" && bun run src/index.ts --boot-device --platform ios --create-if-missing --timeout-ms 600000 --min-os-version "${ios_version}" --max-os-version "${ios_version}")"
   DEVICE_ID="$(printf '%s' "${boot_result}" | jq -r '.deviceId')"
   if [[ -z "${DEVICE_ID}" || "${DEVICE_ID}" == "null" ]]; then
     echo "error: AutoMobile product boot returned no deviceId" >&2

--- a/test/bats/video-recording-start-stop-integration.bats
+++ b/test/bats/video-recording-start-stop-integration.bats
@@ -102,7 +102,7 @@ SCRIPT
   run bash "$SCRIPT"
 
   [ "$status" -eq 0 ]
-  grep -q -- "run src/index.ts --boot-device --platform ios --create-if-missing --timeout-ms 300000 --min-os-version 26.5 --max-os-version 26.5" "$INVOCATIONS_FILE"
+  grep -q -- "run src/index.ts --boot-device --platform ios --create-if-missing --timeout-ms 600000 --min-os-version 26.5 --max-os-version 26.5" "$INVOCATIONS_FILE"
   grep -q -- "simctl io PRODUCT-UDID screenshot" "$INVOCATIONS_FILE"
 }
 

--- a/test/scripts/iosSimulatorProductBootLifecycle.test.ts
+++ b/test/scripts/iosSimulatorProductBootLifecycle.test.ts
@@ -3,7 +3,7 @@ import { readFileSync } from "node:fs";
 import { load } from "js-yaml";
 import { loadJobSteps, stepNamed, type WorkflowStep } from "../helpers/workflowSteps";
 
-const PRODUCT_BOOT = "bun run src/index.ts --boot-device --platform ios --create-if-missing --timeout-ms 300000";
+const PRODUCT_BOOT = "bun run src/index.ts --boot-device --platform ios --create-if-missing --timeout-ms 600000";
 
 function actionSteps(): WorkflowStep[] {
   const action = load(readFileSync(".github/actions/ios-simulator-bring-up/action.yml", "utf8")) as {

--- a/test/scripts/webrtcDeviceIntegrationWorkflow.test.ts
+++ b/test/scripts/webrtcDeviceIntegrationWorkflow.test.ts
@@ -167,7 +167,7 @@ describe("#4308 device WebRTC integration workflow", () => {
 
     expect(boot).toBeDefined();
     expect(capture).toBeDefined();
-    expect(boot?.run).toContain("bun run src/index.ts --boot-device --platform ios --create-if-missing --timeout-ms 300000");
+    expect(boot?.run).toContain("bun run src/index.ts --boot-device --platform ios --create-if-missing --timeout-ms 600000");
     expect(boot?.run).toContain("jq -r '.deviceId'");
     expect(boot?.run).toContain("killall Simulator");
     expect(boot?.run).toContain("open -a Simulator --args -CurrentDeviceUDID");


### PR DESCRIPTION
## Root cause

The "XCTestRunner Simulator Tests" bring-up flake (observed run 32156007593) is an **under-budgeting cascade**, not four independent failures.

The daemon-free iOS product boot draws **every phase from one shared deadline** (`--timeout-ms`), including the in-process `CiIosBootRecovery` shutdown -> erase -> reboot second attempt (`src/utils/deviceBootRecovery.ts:38-62`, wrapping `src/utils/deviceBootService.ts`). The CI steps passed `--timeout-ms 300000` — **half** the budget the Android emulator product boot already uses (`scripts/android/boot-emulator.sh:9` = `600000`).

On a loaded `macos-26` runner a slow first cold `simctl bootstatus -b` consumes most of the 300s. The recovery's second boot then reaches `remaining()` with `<= 0` budget and throws:

```
startDevice timeout exhausted while starting the device; remainingBudgetMs=0
```
(`src/utils/deviceBootService.ts:391-399`) — so the CLI returns **no deviceId**.

### The cascade (all four log errors, one cause)
- Boot step's `jq -r '.deviceId'` comes back empty -> `::error::AutoMobile product boot returned no deviceId.`
- The `wait` barrier surfaces the failed background boot.
- "Run iOS navigation graph Simulator workflow" reuses the now-empty `steps.ctrlproxy-simulator.outputs.simulator_udid` (`pull_request.yml:1903`) and fails.
- `Source-built CtrlProxy xctest executable not found` / `Unable to compute a valid CtrlProxy xctest SHA256` are the **same cascade** — artifacts that never materialized because the boot never completed.

## Fix

Raise every iOS product-boot CI call site from `--timeout-ms 300000` to `600000` (Android parity), so a cold `bootstatus -b` **plus** the in-process erase-and-reboot recovery both fit inside the one shared deadline.

This is the seam commit #4286 ("ci(ios): use product boot without reboot cycle") deliberately left in place: it **deleted** the old `scripts/ios/boot-simulator.sh` wrapper and moved retry/recovery into the product boot. A test even guards against reintroducing that wrapper. So the correct fix is the **budget**, not a new shell retry layer — deterministic `bootstatus -b` waiting and bounded in-process verification/recovery retry (`SimCtlClient.bootAndVerify`, `maxAttempts=2`) already exist; only the CI budget was too small to let the recovery they already perform actually complete.

### Did I fix the budget, add retry, or both?
**Budget only.** Retry (in-process erase-and-reboot + bootstatus verification retry) and deterministic `bootstatus -b` waiting were already implemented in TypeScript by #4286; the flake was purely that CI granted them an under-sized shared deadline. No `src/` change was needed or made.

### Not masking real failures
Healthy boots (~30-90s) finish far inside either budget and are unaffected. A simulator that genuinely cannot boot still fails with the same actionable error, just after the larger, honest budget — the same trade-off Android already accepts at 600000.

### Sites changed (kept uniform)
- `.github/workflows/pull_request.yml` — CtrlProxy UI boot (the reported flake)
- `.github/workflows/webrtc-device-integration.yml` — boot + activate
- `.github/actions/ios-simulator-bring-up/action.yml` — shared bring-up action
- `scripts/ios/video-recording-start-stop-integration.sh`
- `docs/design-docs/plat/ios/xctestrunner/{ci-integration,project-setup}.md`
- Coupled workflow-shape tests updated to the new budget.

## Validation
- `bun test` on the 4 coupled workflow-shape/CLI tests: **19 pass**.
- `bats test/bats/video-recording-start-stop-integration.bats`: **5 pass**.
- `shellcheck` clean on the touched script.
- No real simulator was booted; reasoned from code + logs, per task constraints.
