### PR TITLE
ci/test: bound macos test run to stop 25-min hangs

### DIFF
--- a/.github/workflows/pull_request.yml
+++ b/.github/workflows/pull_request.yml
@@ -1327,7 +1327,30 @@ jobs:
             # hook budgets (verified). Bypass turbo like the Windows branch so the
             # flag applies directly (macos then always runs, which also keeps the
             # native-source-scan guard tests from ever replaying a cached result).
-            bun test --isolate --timeout 20000 2>&1 | tee "ci-logs/bun-test-${{ matrix.os }}.log"
+            #
+            # bun's --timeout ONLY bounds individual test()/hook bodies. It cannot
+            # bound a hang OUTSIDE that scope: module-level/describe-body evaluation,
+            # a leaked real socket/child that keeps the process alive at teardown, or
+            # a real-timer/real-socket poll that never settles. Several files in this
+            # suite do real I/O (unix-socket daemon servers, a werift WebRTC loopback,
+            # real child spawns) rather than injected fakes, so one of them can wedge
+            # the whole run. Before this bound such a wedge rode the 25-minute JOB
+            # timeout to a silent CANCELLED (run 32156898919: bun hung mid-suite for
+            # ~24m, GitHub dropped the streamed log, no actionable signal). Wrap the
+            # invocation in a portable wall-clock watchdog (macos has no GNU
+            # `timeout`; this helper kills the whole process group and returns 124 on
+            # expiry) sized well above a healthy run (~6m observed) but far below the
+            # job timeout, so a hang fails FAST and RED with the tee'd log preserved
+            # for the "Upload Build/Test Logs" step to capture (issue: macos test hang).
+            # shellcheck source=scripts/ios/run_with_timeout.sh
+            source scripts/ios/run_with_timeout.sh
+            test_status=0
+            run_with_timeout 720 bun test --isolate --timeout 20000 2>&1 \
+              | tee "ci-logs/bun-test-${{ matrix.os }}.log" || test_status=$?
+            if [[ "$test_status" -eq 124 ]]; then
+              echo "::error::macOS bun test suite exceeded the 12-minute wall-clock ceiling and was aborted (a test is hanging on real I/O — a real socket/child/timer, not an injected fake). Inspect the last ::group:: in the uploaded ci-logs/bun-test-macos-latest.log to find the file that ran last."
+            fi
+            exit "$test_status"
           fi
 
       - name: "Run Bun image runtime smoke"


### PR DESCRIPTION
## Problem

The **Node TypeScript Build and Test (macos-latest)** leg intermittently gets **CANCELLED at ~25 min** on the "Run Tests" step (e.g. [run 32156898919](https://github.com/kaeawc/auto-mobile/actions/runs/32156898919): started 16:06:28, cancelled 16:31:54 — it rode the 25-minute job timeout). The ubuntu and windows legs of the same suite finish in ~3-6 min. This is a **runner-contention / hanging-test class**, not an assertion failure.

## Root cause

`pull_request.yml` runs the macOS leg as `bun test --isolate --timeout 20000` (was raised to 20s in #5248). **`--timeout` only bounds individual `test()`/hook bodies.** It cannot bound a hang *outside* that scope:

- module-level / `describe`-body evaluation (runs before any `test()` timer is armed),
- a leaked real socket/child that keeps the process alive at teardown,
- a real-timer / real-socket poll that never settles.

Evidence from the cancelled run's uploaded `ci-logs/bun-test-macos-latest.log`: bun printed output for only **54 of the several-hundred test files** across ~24 minutes, i.e. it **wedged mid-suite** — a specific file hung, and the per-test ceiling never caught it. Several files in this suite do **real I/O instead of injected fakes** (violating the repo's fakes-only / <100ms convention): `test/daemon/socketServer*` (real unix-socket server + client sockets with no JS-side response timeout), `test/features/webrtc/WebRtcPublisher.loopback.test.ts` (real werift DTLS/ICE over UDP), three ungated `test.skipIf(win32)` helper tests in `mediamtxWebRtcPublisher.integration.test.ts` that `spawn` real children on every macOS run, and real-TCP/ffmpeg-spawn tests. Any of these can wedge under contention.

**Honesty note:** I could **not** conclusively pin the single offending file. The streamed CI log is dropped on a cancelled job, and bun's block-buffered output through `tee` truncates the tee'd log at the last flushed boundary, so the exact hang point isn't recoverable from one artifact; the hang is intermittent and macOS-contention-dependent, so it does not reproduce locally. Rather than speculatively rewrite a test that isn't proven to be the cause, this PR applies the **defensive wall-clock bound** — which is robust to *every* hang class above and makes the next occurrence diagnosable.

## Fix

Wrap the macOS invocation in the repo's existing portable watchdog `scripts/ios/run_with_timeout.sh` (macOS has no GNU `timeout`; the helper kills the **whole process group** — important since these tests spawn children / hold sockets — and returns `124` on expiry):

```bash
source scripts/ios/run_with_timeout.sh
test_status=0
run_with_timeout 720 bun test --isolate --timeout 20000 2>&1 \
  | tee "ci-logs/bun-test-macos-latest.log" || test_status=$?
if [[ "$test_status" -eq 124 ]]; then
  echo "::error::macOS bun test suite exceeded the 12-minute wall-clock ceiling ..."
fi
exit "$test_status"
```

**Sizing:** healthy macOS "Run Tests" is ~6 min (observed 5m44s / 6m07s on recent green runs). The 720s (12 min) ceiling is ~2x that headroom yet far below the 25-min job timeout. A slow-but-healthy run still passes; a true hang now fails **fast and RED at ~12 min** with an actionable `::error::` and the tee'd log preserved (the existing "Upload Build/Test Logs" step fires on `failure()`), instead of a non-actionable **CANCELLED** that also burns 25 min of runner time.

## Validation

- Reproduced the exact snippet locally on macOS (same platform): success→`0`, timeout→`124` (log preserved, killed the stuck child), real failure→`3` (propagates through `pipefail`, not masked).
- `bash scripts/check-boundaries.sh --only yaml,shellcheck,shell-portability,shell-sete` — all pass.
- YAML-only change (zero `.ts` touched), so the typecheck baseline gate is definitionally unaffected. (The gate could not run in this environment — `tsgo` 404 on offline fetch — but no TypeScript changed.)

## Follow-up (out of scope)

The underlying real-I/O tests that violate the fakes-only convention (`socketServer*`, werift loopback, ungated mediamtx spawn tests) should be migrated to injected fakes or gated out of the default `bun test`. This PR bounds the blast radius so they can no longer silently burn a 25-min job; the `::error::` output will help pin the exact file next time it fires.
