### PR TITLE
ci: address review feedback on fast-validation dep installer

### DIFF
--- a/scripts/ci/install-fast-validation-deps.sh
+++ b/scripts/ci/install-fast-validation-deps.sh
@@ -16,9 +16,16 @@
 set -euo pipefail
 
 # Tunables (overridable for tuning and for the BATS tests).
-CMD_TIMEOUT_SECONDS="${FAST_VALIDATION_DEPS_CMD_TIMEOUT_SECONDS:-180}"
+#
+# Defaults are sized so the WORST CASE fits the workflow step's
+# `timeout-minutes: 10` backstop: 4 operations x (MAX_ATTEMPTS x
+# (CMD_TIMEOUT + KILL_GRACE) + retry delays) = 4 x (2 x (60 + 10) + 5) = 580s
+# < 600s. Healthy runs finish in seconds; a stalled mirror that cannot answer
+# in 60s will not answer in 180s either. Keep this arithmetic aligned when
+# changing any of these values or the step timeout.
+CMD_TIMEOUT_SECONDS="${FAST_VALIDATION_DEPS_CMD_TIMEOUT_SECONDS:-60}"
 KILL_GRACE_SECONDS="${FAST_VALIDATION_DEPS_KILL_GRACE_SECONDS:-10}"
-MAX_ATTEMPTS="${FAST_VALIDATION_DEPS_MAX_ATTEMPTS:-3}"
+MAX_ATTEMPTS="${FAST_VALIDATION_DEPS_MAX_ATTEMPTS:-2}"
 RETRY_BASE_DELAY_SECONDS="${FAST_VALIDATION_DEPS_RETRY_BASE_DELAY_SECONDS:-5}"
 BATS_CLONE_DIR="${FAST_VALIDATION_DEPS_BATS_CLONE_DIR:-/tmp/bats-core}"
 BATS_INSTALL_PREFIX="${FAST_VALIDATION_DEPS_BATS_INSTALL_PREFIX:-/usr/local}"
@@ -92,11 +99,15 @@ main() {
   if command -v bats > /dev/null 2>&1; then
     log "bats already on PATH; skipping source install"
   else
-    # Remove any partial clone from a previous killed attempt so `git clone`
-    # does not fail on a non-empty target directory.
-    rm -rf "$BATS_CLONE_DIR"
+    # The pre-clone cleanup must run inside the retried command: a clone that
+    # times out mid-transfer leaves a non-empty target directory, and without
+    # per-attempt cleanup every subsequent retry would fail instantly on it.
+    # `timeout` is an external binary and cannot run a shell function, so the
+    # cleanup+clone pair is composed with `bash -c`.
+    # shellcheck disable=SC2016 # $1 is deliberately expanded by the inner bash, not here.
     run_with_retry "clone bats-core" \
-      git clone --depth 1 https://github.com/bats-core/bats-core.git "$BATS_CLONE_DIR"
+      bash -c 'rm -rf "$1" && git clone --depth 1 https://github.com/bats-core/bats-core.git "$1"' \
+      _ "$BATS_CLONE_DIR"
     run_with_retry "install bats-core" \
       sudo "${BATS_CLONE_DIR}/install.sh" "$BATS_INSTALL_PREFIX"
   fi

--- a/test/bats/install-fast-validation-deps.bats
+++ b/test/bats/install-fast-validation-deps.bats
@@ -33,24 +33,44 @@ STUB
   # tool the script relies on in Ubuntu CI.
   cat > "${MOCK_BIN}/timeout" <<'STUB'
 #!/usr/bin/env bash
-if [ "$1" = "-k" ]; then shift 2; fi
+grace=""
+if [ "$1" = "-k" ]; then grace="$2"; shift 2; fi
 duration="$1"; shift
+# Sentinel recording that the killer actually fired. Checking the killer with
+# `kill -0` is racy: an exited-but-unreaped killer is a zombie, and `kill -0`
+# on a zombie still succeeds, which made this stub report the command's raw
+# exit (commonly 143) instead of 124.
+fired="$(mktemp -u)"
 "$@" &
 cmd_pid=$!
-( sleep "$duration"; kill -TERM "$cmd_pid" 2>/dev/null ) &
+(
+  sleep "$duration"
+  # Mark BEFORE signaling so the parent cannot observe the kill without the
+  # sentinel; un-mark if the command was already gone (natural exit won the
+  # race and must keep its own status).
+  : > "$fired"
+  if ! kill -TERM "$cmd_pid" 2>/dev/null; then
+    rm -f "$fired"
+  elif [ -n "$grace" ]; then
+    sleep "$grace"
+    kill -KILL "$cmd_pid" 2>/dev/null
+  fi
+) &
 killer_pid=$!
 if wait "$cmd_pid" 2>/dev/null; then status=0; else status=$?; fi
-if kill -0 "$killer_pid" 2>/dev/null; then
-  # Command finished first: cancel the killer and reap its `sleep` child so it
-  # is not orphaned (an orphaned long `sleep` would hold the output pipe open).
-  pkill -P "$killer_pid" 2>/dev/null
-  kill "$killer_pid" 2>/dev/null
-  wait "$killer_pid" 2>/dev/null
-  exit "$status"
+# Reap the killer and its `sleep` child either way so nothing orphaned holds
+# the output pipe open.
+pkill -P "$killer_pid" 2>/dev/null
+kill "$killer_pid" 2>/dev/null
+wait "$killer_pid" 2>/dev/null
+if [ -e "$fired" ] && [ "$status" -ne 0 ]; then
+  # Timed out: reap any grandchild of the killed command (e.g. a `sleep`).
+  pkill -P "$cmd_pid" 2>/dev/null
+  rm -f "$fired"
+  exit 124
 fi
-# Timed out: reap any grandchild of the killed command (e.g. a `sleep`).
-pkill -P "$cmd_pid" 2>/dev/null
-exit 124
+rm -f "$fired"
+exit "$status"
 STUB
   chmod +x "${MOCK_BIN}/timeout"
   export PATH="${MOCK_BIN}:${PATH}"
@@ -109,7 +129,68 @@ STUB
   make_apt_get 1
   run bash "$SCRIPT"
   [ "$status" -eq 0 ]
-  [[ "$output" == *"attempt 2/3"* ]]
+  [[ "$output" == *"attempt 2/2"* ]]
+  [[ "$output" == *"Fast Validation dependencies ready"* ]]
+}
+
+@test "default retry budget fits the 10-minute step timeout" {
+  # Worst case = 4 ops x (MAX_ATTEMPTS x (CMD_TIMEOUT + KILL_GRACE) + delays).
+  # Guard the arithmetic so a future default bump cannot silently exceed the
+  # workflow step's timeout-minutes backstop.
+  local cmd_timeout kill_grace attempts base_delay
+  cmd_timeout=$(grep -oE 'CMD_TIMEOUT_SECONDS:-[0-9]+' "$SCRIPT" | grep -oE '[0-9]+$')
+  kill_grace=$(grep -oE 'KILL_GRACE_SECONDS:-[0-9]+' "$SCRIPT" | grep -oE '[0-9]+$')
+  attempts=$(grep -oE 'MAX_ATTEMPTS:-[0-9]+' "$SCRIPT" | grep -oE '[0-9]+$')
+  base_delay=$(grep -oE 'RETRY_BASE_DELAY_SECONDS:-[0-9]+' "$SCRIPT" | grep -oE '[0-9]+$')
+  local delays=0 delay="$base_delay" i
+  for ((i = 1; i < attempts; i++)); do
+    delays=$((delays + delay))
+    delay=$((delay * 2))
+  done
+  local worst_case=$((4 * (attempts * (cmd_timeout + kill_grace) + delays)))
+  echo "worst_case=${worst_case}s"
+  [ "$worst_case" -le 600 ]
+}
+
+@test "a partial clone left by a killed attempt is cleaned before the retry" {
+  # Force the source-install branch: drop the `bats` stub and restrict PATH so
+  # the host's real bats (typically /usr/local or homebrew) is not found, while
+  # our git/sudo/timeout stubs still win.
+  rm "${MOCK_BIN}/bats"
+  make_apt_get 0
+  local clone_dir="${MOCK_BIN}/bats-clone"
+  export CLONE_STATE="${MOCK_BIN}/git-calls"
+  # First clone "dies mid-transfer": leaves a non-empty target and fails.
+  # Second clone must see a CLEAN target (proving per-attempt cleanup) — it
+  # fails loudly like real git if the directory still exists.
+  cat > "${MOCK_BIN}/git" <<STUB
+#!/usr/bin/env bash
+target="\${!#}"
+calls=0
+[ -f "${CLONE_STATE}" ] && calls="\$(cat "${CLONE_STATE}")"
+calls=\$((calls + 1))
+echo "\$calls" > "${CLONE_STATE}"
+if [ "\$calls" -eq 1 ]; then
+  mkdir -p "\$target"
+  echo partial > "\$target/partial-object"
+  exit 1
+fi
+if [ -e "\$target" ]; then
+  echo "fatal: destination path '\$target' already exists and is not an empty directory." >&2
+  exit 128
+fi
+mkdir -p "\$target"
+printf '#!/usr/bin/env bash\nexit 0\n' > "\$target/install.sh"
+chmod +x "\$target/install.sh"
+exit 0
+STUB
+  chmod +x "${MOCK_BIN}/git"
+  run env PATH="${MOCK_BIN}:/usr/bin:/bin" \
+    FAST_VALIDATION_DEPS_BATS_CLONE_DIR="$clone_dir" \
+    bash "$SCRIPT"
+  echo "$output"
+  [ "$status" -eq 0 ]
+  [[ "$output" == *"attempt 2/2"* ]]
   [[ "$output" == *"Fast Validation dependencies ready"* ]]
 }
 


### PR DESCRIPTION
## Summary

Follow-up addressing the three CodeRabbit review findings on the merged [#5388](https://github.com/kaeawc/auto-mobile/pull/5388) (Fast Validation dependency-install hang fix).

### 1. Retry budget aligned with the step timeout ([finding](https://github.com/kaeawc/auto-mobile/pull/5388#discussion_r3807552288))
The old defaults (3 attempts × 180s + grace + backoff, × 4 operations) had a **2,340s worst case** against the step's `timeout-minutes: 10` (600s) backstop — the tuning was incoherent. New defaults (2 attempts × 60s) bound the worst case at **580s < 600s**. Healthy operations finish in seconds, and a mirror that can't answer in 60s won't answer in 180s either. The arithmetic is documented in the script and **guarded by a new BATS test** that recomputes the worst case from the script's actual defaults, so a future bump can't silently break the alignment.

Note: the same finding's claim that `background:`/`wait:` are invalid workflow keys was verified as a **false positive** — those keys are pre-existing repo-wide (since #4142/#4144) and demonstrably execute on GitHub Actions (the `Wait` step appears with real conclusions in every run); actionlint's schema simply lags. No change made for that part.

### 2. Pre-clone cleanup moved inside the retried command ([finding](https://github.com/kaeawc/auto-mobile/pull/5388#discussion_r3807552296))
`rm -rf "$BATS_CLONE_DIR"` ran once, before the retry loop. A clone killed mid-transfer left a non-empty target, so attempts 2–3 would fail instantly on the existing directory — defeating the retry. The cleanup+clone pair is now composed with `bash -c` (coreutils `timeout` can't run shell functions) so every attempt starts from a clean target. Covered by a new partial-clone regression BATS test.

### 3. Deterministic 124 from the hermetic timeout stub ([finding](https://github.com/kaeawc/auto-mobile/pull/5388#discussion_r3807552302))
The stub detected "killer still pending" with `kill -0`, but an exited-unreaped killer is a zombie and `kill -0` succeeds on zombies — so the stub could report the command's raw exit (143) instead of 124, flaking the timeout test. A sentinel file written *before* signaling (removed if the kill loses the race, honored only alongside a non-zero exit) makes 124 deterministic; the `-k` grace period is now emulated as well.

## Validation

- `shellcheck scripts/ci/install-fast-validation-deps.sh` — clean
- `bats test/bats/install-fast-validation-deps.bats` — 10/10, run 3× consecutively (race check)
