### PR TITLE
fix(test): eliminate the never-settling-wait hang class behind the macos watchdog

### DIFF
--- a/scripts/webrtc/run-mediamtx-publisher-integration.sh
+++ b/scripts/webrtc/run-mediamtx-publisher-integration.sh
@@ -9,6 +9,10 @@ set -euo pipefail
 
 readonly MEDIAMTX_VERSION="1.19.2"
 readonly TEST_FILE="${AUTOMOBILE_MEDIAMTX_TEST_FILE:-test/integration/mediamtxWebRtcPublisher.integration.test.ts}"
+# The werift loopback suite shares the opt-in gate: its DTLS/ICE handshake runs
+# over real UDP sockets, so it lives in this integration lane rather than the
+# default `bun test` run (macos real-I/O hang class, #5391).
+readonly LOOPBACK_TEST_FILE="test/features/webrtc/WebRtcPublisher.loopback.test.ts"
 
 repo_root="$(cd "$(dirname "${BASH_SOURCE[0]}")/../.." && pwd)"
 cache_dir="${AUTOMOBILE_MEDIAMTX_CACHE_DIR:-${repo_root}/scratch/mediamtx}"
@@ -92,4 +96,4 @@ mediamtx_binary="$(cd "$(dirname "${mediamtx_binary}")" && pwd -P)/$(basename "$
 cd "${repo_root}"
 AUTOMOBILE_MEDIAMTX_WEBRTC_INTEGRATION=1 \
 AUTOMOBILE_MEDIAMTX_BINARY="${mediamtx_binary}" \
-  exec bun test "${TEST_FILE}"
+  exec bun test "${TEST_FILE}" "${LOOPBACK_TEST_FILE}"

--- a/test/bats/mediamtx-webrtc-integration.bats
+++ b/test/bats/mediamtx-webrtc-integration.bats
@@ -5,6 +5,7 @@
 
 SCRIPT="scripts/webrtc/run-mediamtx-publisher-integration.sh"
 TEST_FILE="test/integration/mediamtxWebRtcPublisher.integration.test.ts"
+LOOPBACK_TEST_FILE="test/features/webrtc/WebRtcPublisher.loopback.test.ts"
 
 setup() {
   TEST_DIR="$(mktemp -d)"
@@ -54,7 +55,7 @@ SCRIPT
     bash "${ABS}"
 
   [ "${status}" -eq 0 ]
-  [ "$(cat "${INVOCATIONS_FILE}")" = "gate=1 binary=${resolved_binary} args=test ${TEST_FILE}" ]
+  [ "$(cat "${INVOCATIONS_FILE}")" = "gate=1 binary=${resolved_binary} args=test ${TEST_FILE} ${LOOPBACK_TEST_FILE}" ]
 }
 
 @test "runner resolves an injected relative MediaMTX binary before forwarding it" {
@@ -75,7 +76,7 @@ SCRIPT
     bash "${ABS}"
 
   [ "${status}" -eq 0 ]
-  [ "$(cat "${INVOCATIONS_FILE}")" = "gate=1 binary=${resolved_binary} args=test ${TEST_FILE}" ]
+  [ "$(cat "${INVOCATIONS_FILE}")" = "gate=1 binary=${resolved_binary} args=test ${TEST_FILE} ${LOOPBACK_TEST_FILE}" ]
 }
 
 @test "download path rejects a MediaMTX archive whose pinned checksum does not match" {

--- a/test/daemon/helpers/inputSocketHarness.ts
+++ b/test/daemon/helpers/inputSocketHarness.ts
@@ -1,6 +1,13 @@
 import { Socket } from "node:net";
 import { randomUUID } from "node:crypto";
 import { mock } from "bun:test";
+import {
+  SOCKET_REQUEST_DEADLINE_MS,
+  connectBounded,
+  sendRawSocketRequest,
+  sendSocketRequest,
+} from "./socketRequest";
+import { defaultTimer } from "../../../src/utils/SystemTimer";
 import { PlatformDeviceManagerFactory } from "../../../src/utils/factories/PlatformDeviceManagerFactory";
 import type { DaemonRequest, DaemonResponse } from "../../../src/daemon/types";
 import type { DeviceLabelMap, Session } from "../../../src/daemon/sessionManager";
@@ -86,87 +93,16 @@ export function sendRequest(
   params: Record<string, unknown> = {},
   timeoutMs?: number
 ): Promise<DaemonResponse> {
-  return new Promise((resolve, reject) => {
-    const client = new Socket();
-    let buffer = "";
-    const request: DaemonRequest = {
-      id: randomUUID(),
-      type: "mcp_request",
-      method,
-      params,
-      ...(timeoutMs === undefined ? {} : { timeoutMs }),
-    };
-
-    client.connect(socketPath, () => {
-      client.write(JSON.stringify(request) + "\n");
-    });
-
-    client.on("data", data => {
-      buffer += data.toString();
-      const lines = buffer.split("\n");
-      for (const line of lines) {
-        if (!line.trim()) {
-          continue;
-        }
-        try {
-          const response = JSON.parse(line) as DaemonResponse;
-          client.destroy();
-          resolve(response);
-          return;
-        } catch {
-          // Incomplete JSON, keep buffering.
-        }
-      }
-    });
-
-    client.on("error", reject);
-    client.on("close", () => {
-      if (!buffer.trim()) {
-        reject(new Error("Connection closed without response"));
-      }
-    });
-  });
+  return sendSocketRequest(socketPath, method, params, timeoutMs);
 }
 
-export function sendRequestAfterConnect(
+export async function sendRequestAfterConnect(
   socketPath: string,
   request: DaemonRequest,
   onConnect: () => void
 ): Promise<DaemonResponse> {
-  return new Promise((resolve, reject) => {
-    const client = new Socket();
-    let buffer = "";
-
-    client.connect(socketPath, () => {
-      onConnect();
-      client.write(JSON.stringify(request) + "\n");
-    });
-
-    client.on("data", data => {
-      buffer += data.toString();
-      const lines = buffer.split("\n");
-      for (const line of lines) {
-        if (!line.trim()) {
-          continue;
-        }
-        try {
-          const response = JSON.parse(line) as DaemonResponse;
-          client.destroy();
-          resolve(response);
-          return;
-        } catch {
-          // Incomplete JSON, keep buffering.
-        }
-      }
-    });
-
-    client.on("error", reject);
-    client.on("close", () => {
-      if (!buffer.trim()) {
-        reject(new Error("Connection closed without response"));
-      }
-    });
-  });
+  const { response } = await sendRawSocketRequest(socketPath, request, { onConnect });
+  return response;
 }
 
 /** One persistent socket connection that can send several requests before closing. */
@@ -184,49 +120,64 @@ export interface PersistentConnection {
  * one session and then {@link PersistentConnection.close} it to model a mid-drag disconnect.
  * Responses are correlated by request id, so concurrent sends are supported.
  */
-export function openPersistentConnection(socketPath: string): Promise<PersistentConnection> {
-  return new Promise((resolveConn, rejectConn) => {
-    const client = new Socket();
-    let buffer = "";
-    const pending = new Map<string, (response: DaemonResponse) => void>();
+export async function openPersistentConnection(socketPath: string): Promise<PersistentConnection> {
+  const client = new Socket();
+  let buffer = "";
+  const pending = new Map<string, { resolve: (response: DaemonResponse) => void; deadline: NodeJS.Timeout }>();
 
-    client.on("data", data => {
-      buffer += data.toString();
-      const lines = buffer.split("\n");
-      buffer = lines.pop() || "";
-      for (const line of lines) {
-        if (!line.trim()) {
-          continue;
-        }
-        const response = JSON.parse(line) as DaemonResponse;
-        const resolve = pending.get(response.id);
-        if (resolve) {
-          pending.delete(response.id);
-          resolve(response);
-        }
+  client.on("data", data => {
+    buffer += data.toString();
+    const lines = buffer.split("\n");
+    buffer = lines.pop() || "";
+    for (const line of lines) {
+      if (!line.trim()) {
+        continue;
       }
-    });
-    client.on("error", rejectConn);
-    client.connect(socketPath, () => {
-      resolveConn({
-        send(method, params = {}, timeoutMs) {
-          const id = randomUUID();
-          return new Promise<DaemonResponse>(resolve => {
-            pending.set(id, resolve);
-            const request: DaemonRequest = {
-              id,
-              type: "mcp_request",
-              method,
-              params,
-              ...(timeoutMs === undefined ? {} : { timeoutMs }),
-            };
-            client.write(JSON.stringify(request) + "\n");
-          });
-        },
-        close() {
-          client.destroy();
-        },
-      });
-    });
+      const response = JSON.parse(line) as DaemonResponse;
+      const entry = pending.get(response.id);
+      if (entry) {
+        pending.delete(response.id);
+        defaultTimer.clearTimeout(entry.deadline);
+        entry.resolve(response);
+      }
+    }
   });
+  await connectBounded(client, socketPath);
+  // Post-connect transport errors (e.g. ECONNRESET when a test closes the
+  // server mid-stream) must not become uncaught 'error' events; pending sends
+  // are already bounded by their own deadlines.
+  client.on("error", () => {});
+  return {
+    send(method, params = {}, timeoutMs) {
+      const id = randomUUID();
+      return new Promise<DaemonResponse>((resolve, reject) => {
+        // Bounded like sendSocketRequest: an unanswered request must fail fast
+        // with a diagnostic, not pend until the suite's wall-clock watchdog.
+        const deadline = defaultTimer.setTimeout(() => {
+          pending.delete(id);
+          client.destroy();
+          reject(new Error(
+            `No response to ${method} on ${socketPath} within ${SOCKET_REQUEST_DEADLINE_MS}ms — `
+            + "bounded socket-test deadline hit (the server hung or dropped the request)"
+          ));
+        }, SOCKET_REQUEST_DEADLINE_MS);
+        pending.set(id, { resolve, deadline });
+        const request: DaemonRequest = {
+          id,
+          type: "mcp_request",
+          method,
+          params,
+          ...(timeoutMs === undefined ? {} : { timeoutMs }),
+        };
+        client.write(JSON.stringify(request) + "\n");
+      });
+    },
+    close() {
+      for (const entry of pending.values()) {
+        defaultTimer.clearTimeout(entry.deadline);
+      }
+      pending.clear();
+      client.destroy();
+    },
+  };
 }

--- a/test/daemon/helpers/socketRequest.ts
+++ b/test/daemon/helpers/socketRequest.ts
@@ -1,0 +1,181 @@
+import { Socket } from "node:net";
+import { randomUUID } from "node:crypto";
+import { defaultTimer } from "../../../src/utils/SystemTimer";
+import type { DaemonRequest, DaemonResponse } from "../../../src/daemon/types";
+
+/**
+ * Canonical BOUNDED unix-socket request helpers for the daemon socket-server
+ * suites.
+ *
+ * Every suite that talks to a real `UnixSocketServer` over a real unix domain
+ * socket must go through these instead of hand-rolling a `Socket` + `Promise`
+ * pair: a raw read on a socket the server never answers never settles, and the
+ * leaked handle keeps the worker process alive after the test times out —
+ * exactly the hang class that wedged the macos CI `bun test` run behind the
+ * #5391 watchdog. Each helper enforces a hard client-side deadline and
+ * destroys its socket on EVERY settle path (response, error, close, deadline),
+ * so a server bug degrades into a fast red failure with a diagnostic instead
+ * of a silent 12-minute wall-clock abort.
+ */
+
+/**
+ * Hard client-side ceiling for one connect + write + response round trip over
+ * a loopback unix socket. Healthy round trips take single-digit milliseconds;
+ * 10s absorbs macos-runner contention while still failing an actually-hung
+ * server well inside bun's 20s CI test timeout.
+ */
+export const SOCKET_REQUEST_DEADLINE_MS = 10_000;
+
+export interface SocketRequestOptions {
+  /** Hard client-side deadline for the whole round trip. */
+  deadlineMs?: number;
+  /** Runs inside the connect callback, before the request line is written. */
+  onConnect?: () => void;
+  /**
+   * "first" (default) resolves on the first complete JSON frame and destroys
+   * the socket immediately. "drain" half-closes after each frame and resolves
+   * on close with the LAST frame plus the total frame count, so a test can
+   * assert exactly how many frames the server wrote.
+   */
+  resolveOn?: "first" | "drain";
+}
+
+export interface SocketRequestResult {
+  response: DaemonResponse;
+  /** Complete JSON frames received before the promise settled. */
+  frameCount: number;
+}
+
+/**
+ * Send one newline-framed JSON request over a fresh unix-socket connection and
+ * resolve with the response. An `id` is generated unless `request` carries one.
+ */
+export function sendRawSocketRequest(
+  socketPath: string,
+  request: DaemonRequest | Record<string, unknown>,
+  options: SocketRequestOptions = {},
+): Promise<SocketRequestResult> {
+  const { deadlineMs = SOCKET_REQUEST_DEADLINE_MS, onConnect, resolveOn = "first" } = options;
+  const label = String((request as Record<string, unknown>).method ?? (request as Record<string, unknown>).type ?? "request");
+  return new Promise((resolve, reject) => {
+    const client = new Socket();
+    let buffer = "";
+    let frameCount = 0;
+    let lastResponse: DaemonResponse | undefined;
+    let settled = false;
+
+    const settle = (action: () => void) => {
+      if (settled) {
+        return;
+      }
+      settled = true;
+      defaultTimer.clearTimeout(deadline);
+      client.destroy();
+      action();
+    };
+    const deadline = defaultTimer.setTimeout(() => {
+      settle(() => reject(new Error(
+        `No response to ${label} on ${socketPath} within ${deadlineMs}ms — `
+        + "bounded socket-test deadline hit (the server hung or dropped the request)"
+      )));
+    }, deadlineMs);
+
+    client.connect(socketPath, () => {
+      onConnect?.();
+      client.write(JSON.stringify({ id: randomUUID(), ...request }) + "\n");
+    });
+
+    client.on("data", data => {
+      buffer += data.toString();
+      const lines = buffer.split("\n");
+      buffer = lines.pop() ?? "";
+      for (const line of lines) {
+        if (!line.trim()) {
+          continue;
+        }
+        let parsed: DaemonResponse;
+        try {
+          parsed = JSON.parse(line) as DaemonResponse;
+        } catch {
+          // Not yet a complete/valid frame; keep reading until the deadline.
+          continue;
+        }
+        frameCount++;
+        lastResponse = parsed;
+        if (resolveOn === "first") {
+          settle(() => resolve({ response: parsed, frameCount }));
+          return;
+        }
+        client.end();
+      }
+    });
+
+    client.on("error", error => settle(() => reject(error)));
+    client.on("close", () => {
+      const response = lastResponse;
+      if (response) {
+        settle(() => resolve({ response, frameCount }));
+      } else {
+        settle(() => reject(new Error("Connection closed without response")));
+      }
+    });
+  });
+}
+
+/**
+ * The common `mcp_request` round trip. `requestTimeoutMs` is the SERVER-side
+ * per-request timeout embedded in the request payload — the client-side
+ * deadline is `options.deadlineMs`.
+ */
+export async function sendSocketRequest(
+  socketPath: string,
+  method: string,
+  params: Record<string, unknown> = {},
+  requestTimeoutMs?: number,
+  options: SocketRequestOptions = {},
+): Promise<DaemonResponse> {
+  const request: DaemonRequest = {
+    id: randomUUID(),
+    type: "mcp_request",
+    method,
+    params,
+    ...(requestTimeoutMs === undefined ? {} : { timeoutMs: requestTimeoutMs }),
+  };
+  const { response } = await sendRawSocketRequest(socketPath, request, options);
+  return response;
+}
+
+/**
+ * Await an already-configured client socket's `connect` (or reject on `error`
+ * or after `deadlineMs`), for stream suites that attach `data` handlers before
+ * connecting. Destroys the socket on the failure paths so nothing leaks.
+ */
+export function connectBounded(
+  socket: Socket,
+  socketPath: string,
+  deadlineMs: number = SOCKET_REQUEST_DEADLINE_MS,
+): Promise<void> {
+  return new Promise((resolve, reject) => {
+    let settled = false;
+    const settle = (action: () => void, destroy: boolean) => {
+      if (settled) {
+        return;
+      }
+      settled = true;
+      defaultTimer.clearTimeout(deadline);
+      socket.off("error", onError);
+      if (destroy) {
+        socket.destroy();
+      }
+      action();
+    };
+    const deadline = defaultTimer.setTimeout(() => {
+      settle(() => reject(new Error(
+        `Socket did not connect to ${socketPath} within ${deadlineMs}ms — bounded socket-test deadline hit`
+      )), true);
+    }, deadlineMs);
+    const onError = (error: Error) => settle(() => reject(error), true);
+    socket.once("error", onError);
+    socket.connect(socketPath, () => settle(() => resolve(), false));
+  });
+}

--- a/test/daemon/socketServerFeatureFlags.test.ts
+++ b/test/daemon/socketServerFeatureFlags.test.ts
@@ -1,11 +1,11 @@
 import { afterEach, beforeEach, describe, expect, test } from "bun:test";
-import { Socket } from "node:net";
 import { randomUUID } from "node:crypto";
 import { existsSync } from "node:fs";
 import { unlink } from "node:fs/promises";
 import { tmpdir } from "node:os";
 import { join } from "node:path";
 import { UnixSocketServer } from "../../src/daemon/socketServer";
+import { sendSocketRequest } from "./helpers/socketRequest";
 import { FeatureFlagService } from "../../src/features/featureFlags/FeatureFlagService";
 import { FakeFeatureFlagRepository } from "../fakes/FakeFeatureFlagRepository";
 import { FakeFeatureFlagApplier } from "../fakes/FakeFeatureFlagApplier";
@@ -37,44 +37,7 @@ function createFakeDaemonState() {
 }
 
 function sendRequest(socketPath: string, method: string, params: Record<string, unknown> = {}): Promise<DaemonResponse> {
-  return new Promise((resolve, reject) => {
-    const client = new Socket();
-    let buffer = "";
-
-    client.connect(socketPath, () => {
-      const request = JSON.stringify({
-        id: randomUUID(),
-        type: "mcp_request",
-        method,
-        params,
-      });
-      client.write(request + "\n");
-    });
-
-    client.on("data", data => {
-      buffer += data.toString();
-      const lines = buffer.split("\n");
-      for (const line of lines) {
-        if (line.trim()) {
-          try {
-            const response = JSON.parse(line) as DaemonResponse;
-            client.destroy();
-            resolve(response);
-            return;
-          } catch {
-            // Incomplete JSON, keep buffering
-          }
-        }
-      }
-    });
-
-    client.on("error", reject);
-    client.on("close", () => {
-      if (!buffer.trim()) {
-        reject(new Error("Connection closed without response"));
-      }
-    });
-  });
+  return sendSocketRequest(socketPath, method, params);
 }
 
 describe("UnixSocketServer feature flag handlers", () => {

--- a/test/daemon/socketServerHandshake.test.ts
+++ b/test/daemon/socketServerHandshake.test.ts
@@ -1,11 +1,11 @@
 import { afterEach, describe, expect, test } from "bun:test";
-import { Socket } from "node:net";
 import { randomUUID } from "node:crypto";
 import { existsSync } from "node:fs";
 import { unlink } from "node:fs/promises";
 import { tmpdir } from "node:os";
 import { join } from "node:path";
 import { UnixSocketServer } from "../../src/daemon/socketServer";
+import { sendRawSocketRequest } from "./helpers/socketRequest";
 import { FakeTimer } from "../fakes/FakeTimer";
 import type { DaemonResponse } from "../../src/daemon/types";
 import type { DaemonSelfIdentity } from "../../src/daemon/daemonHandshake";
@@ -22,42 +22,12 @@ function createFakeDaemonState() {
   };
 }
 
-function sendRequest(
+async function sendRequest(
   socketPath: string,
   payload: Record<string, unknown>
 ): Promise<DaemonResponse> {
-  return new Promise((resolve, reject) => {
-    const client = new Socket();
-    let buffer = "";
-
-    client.connect(socketPath, () => {
-      client.write(JSON.stringify({ id: randomUUID(), ...payload }) + "\n");
-    });
-
-    client.on("data", data => {
-      buffer += data.toString();
-      const lines = buffer.split("\n");
-      for (const line of lines) {
-        if (line.trim()) {
-          try {
-            const response = JSON.parse(line) as DaemonResponse;
-            client.destroy();
-            resolve(response);
-            return;
-          } catch {
-            // keep buffering
-          }
-        }
-      }
-    });
-
-    client.on("error", reject);
-    client.on("close", () => {
-      if (!buffer.trim()) {
-        reject(new Error("Connection closed without response"));
-      }
-    });
-  });
+  const { response } = await sendRawSocketRequest(socketPath, payload);
+  return response;
 }
 
 // `ide/ping` is handled locally without the MCP client, so these tests exercise the

--- a/test/daemon/socketServerIdeStatus.test.ts
+++ b/test/daemon/socketServerIdeStatus.test.ts
@@ -1,11 +1,11 @@
 import { afterEach, beforeEach, describe, expect, spyOn, test } from "bun:test";
-import { Socket } from "node:net";
 import { randomUUID } from "node:crypto";
 import { existsSync } from "node:fs";
 import { unlink } from "node:fs/promises";
 import { tmpdir } from "node:os";
 import { join } from "node:path";
 import { UnixSocketServer } from "../../src/daemon/socketServer";
+import { sendSocketRequest } from "./helpers/socketRequest";
 import { FakeTimer } from "../fakes/FakeTimer";
 import type { DaemonResponse } from "../../src/daemon/types";
 import { AndroidCtrlProxyManager } from "../../src/utils/CtrlProxyManager";
@@ -28,44 +28,7 @@ function createFakeDaemonState() {
 }
 
 function sendRequest(socketPath: string, method: string, params: Record<string, unknown> = {}): Promise<DaemonResponse> {
-  return new Promise((resolve, reject) => {
-    const client = new Socket();
-    let buffer = "";
-
-    client.connect(socketPath, () => {
-      const request = JSON.stringify({
-        id: randomUUID(),
-        type: "mcp_request",
-        method,
-        params,
-      });
-      client.write(request + "\n");
-    });
-
-    client.on("data", data => {
-      buffer += data.toString();
-      const lines = buffer.split("\n");
-      for (const line of lines) {
-        if (line.trim()) {
-          try {
-            const response = JSON.parse(line) as DaemonResponse;
-            client.destroy();
-            resolve(response);
-            return;
-          } catch {
-            // Incomplete JSON, keep buffering
-          }
-        }
-      }
-    });
-
-    client.on("error", reject);
-    client.on("close", () => {
-      if (!buffer.trim()) {
-        reject(new Error("Connection closed without response"));
-      }
-    });
-  });
+  return sendSocketRequest(socketPath, method, params);
 }
 
 describe("UnixSocketServer ide/status and ide/updateService handlers", () => {

--- a/test/daemon/socketServerInputKey.test.ts
+++ b/test/daemon/socketServerInputKey.test.ts
@@ -1,11 +1,11 @@
 import { afterEach, beforeEach, describe, expect, mock, test } from "bun:test";
-import { Socket } from "node:net";
 import { randomUUID } from "node:crypto";
 import { existsSync } from "node:fs";
 import { unlink } from "node:fs/promises";
 import { tmpdir } from "node:os";
 import { join } from "node:path";
 import { UnixSocketServer } from "../../src/daemon/socketServer";
+import { sendRawSocketRequest } from "./helpers/socketRequest";
 import { InputKey, type InputKeyName } from "../../src/features/action/InputKey";
 import { PlatformDeviceManagerFactory } from "../../src/utils/factories/PlatformDeviceManagerFactory";
 import { FakeTimer } from "../fakes/FakeTimer";
@@ -61,46 +61,16 @@ function sendRequest(
   params: Record<string, unknown> = {},
   timeoutMs?: number
 ): Promise<{ response: DaemonResponse; frameCount: number }> {
-  return new Promise((resolve, reject) => {
-    const client = new Socket();
-    let buffer = "";
-    let frameCount = 0;
-    let response: DaemonResponse | undefined;
-    const request: DaemonRequest = {
-      id: randomUUID(),
-      type: "mcp_request",
-      method,
-      params,
-      ...(timeoutMs === undefined ? {} : { timeoutMs }),
-    };
-
-    client.connect(socketPath, () => {
-      client.write(JSON.stringify(request) + "\n");
-    });
-
-    client.on("data", data => {
-      buffer += data.toString();
-      const lines = buffer.split("\n");
-      buffer = lines.pop() ?? "";
-      for (const line of lines) {
-        if (!line.trim()) {
-          continue;
-        }
-        frameCount++;
-        response = JSON.parse(line) as DaemonResponse;
-        client.end();
-      }
-    });
-
-    client.on("error", reject);
-    client.on("close", () => {
-      if (!response) {
-        reject(new Error("Connection closed without response"));
-        return;
-      }
-      resolve({ response, frameCount });
-    });
-  });
+  const request: DaemonRequest = {
+    id: randomUUID(),
+    type: "mcp_request",
+    method,
+    params,
+    ...(timeoutMs === undefined ? {} : { timeoutMs }),
+  };
+  // "drain" resolves on close with the LAST frame and the total frame count,
+  // so the tests below can assert the server wrote exactly one response frame.
+  return sendRawSocketRequest(socketPath, request, { resolveOn: "drain" });
 }
 
 describe("UnixSocketServer input/key", () => {

--- a/test/daemon/socketServerInputPressButton.test.ts
+++ b/test/daemon/socketServerInputPressButton.test.ts
@@ -1,11 +1,11 @@
 import { afterEach, beforeEach, describe, expect, mock, test } from "bun:test";
-import { Socket } from "node:net";
 import { randomUUID } from "node:crypto";
 import { existsSync } from "node:fs";
 import { unlink } from "node:fs/promises";
 import { tmpdir } from "node:os";
 import { join } from "node:path";
 import { UnixSocketServer } from "../../src/daemon/socketServer";
+import { sendRawSocketRequest, sendSocketRequest } from "./helpers/socketRequest";
 import { PressButton } from "../../src/features/action/PressButton";
 import { PlatformDeviceManagerFactory } from "../../src/utils/factories/PlatformDeviceManagerFactory";
 import { FakeTimer } from "../fakes/FakeTimer";
@@ -87,87 +87,16 @@ function sendRequest(
   params: Record<string, unknown> = {},
   timeoutMs?: number
 ): Promise<DaemonResponse> {
-  return new Promise((resolve, reject) => {
-    const client = new Socket();
-    let buffer = "";
-    const request: DaemonRequest = {
-      id: randomUUID(),
-      type: "mcp_request",
-      method,
-      params,
-      ...(timeoutMs === undefined ? {} : { timeoutMs }),
-    };
-
-    client.connect(socketPath, () => {
-      client.write(JSON.stringify(request) + "\n");
-    });
-
-    client.on("data", data => {
-      buffer += data.toString();
-      const lines = buffer.split("\n");
-      for (const line of lines) {
-        if (!line.trim()) {
-          continue;
-        }
-        try {
-          const response = JSON.parse(line) as DaemonResponse;
-          client.destroy();
-          resolve(response);
-          return;
-        } catch {
-          // Incomplete JSON, keep buffering.
-        }
-      }
-    });
-
-    client.on("error", reject);
-    client.on("close", () => {
-      if (!buffer.trim()) {
-        reject(new Error("Connection closed without response"));
-      }
-    });
-  });
+  return sendSocketRequest(socketPath, method, params, timeoutMs);
 }
 
-function sendRequestAfterConnect(
+async function sendRequestAfterConnect(
   socketPath: string,
   request: DaemonRequest,
   onConnect: () => void
 ): Promise<DaemonResponse> {
-  return new Promise((resolve, reject) => {
-    const client = new Socket();
-    let buffer = "";
-
-    client.connect(socketPath, () => {
-      onConnect();
-      client.write(JSON.stringify(request) + "\n");
-    });
-
-    client.on("data", data => {
-      buffer += data.toString();
-      const lines = buffer.split("\n");
-      for (const line of lines) {
-        if (!line.trim()) {
-          continue;
-        }
-        try {
-          const response = JSON.parse(line) as DaemonResponse;
-          client.destroy();
-          resolve(response);
-          return;
-        } catch {
-          // Incomplete JSON, keep buffering.
-        }
-      }
-    });
-
-    client.on("error", reject);
-    client.on("close", () => {
-      if (!buffer.trim()) {
-        reject(new Error("Connection closed without response"));
-      }
-    });
-  });
+  const { response } = await sendRawSocketRequest(socketPath, request, { onConnect });
+  return response;
 }
 
 describe("UnixSocketServer input/pressButton", () => {

--- a/test/daemon/socketServerKeyValue.test.ts
+++ b/test/daemon/socketServerKeyValue.test.ts
@@ -1,11 +1,11 @@
 import { afterEach, beforeEach, describe, expect, mock, test } from "bun:test";
-import { Socket } from "node:net";
 import { existsSync } from "node:fs";
 import { unlink } from "node:fs/promises";
 import { tmpdir } from "node:os";
 import { join } from "node:path";
 import { randomUUID } from "node:crypto";
 import { UnixSocketServer } from "../../src/daemon/socketServer";
+import { sendSocketRequest } from "./helpers/socketRequest";
 import { AndroidCtrlProxyClient } from "../../src/features/observe/android";
 import { IOSCtrlProxyClient } from "../../src/features/observe/ios";
 import { PlatformDeviceManagerFactory } from "../../src/utils/factories/PlatformDeviceManagerFactory";
@@ -52,27 +52,7 @@ function createDaemonState() {
 }
 
 function sendRequest(socketPath: string, method: string, params: Record<string, unknown>): Promise<DaemonResponse> {
-  return new Promise((resolve, reject) => {
-    const socket = new Socket();
-    let buffer = "";
-    socket.connect(socketPath, () => {
-      socket.write(JSON.stringify({
-        id: randomUUID(),
-        type: "mcp_request",
-        method,
-        params,
-      }) + "\n");
-    });
-    socket.on("data", data => {
-      buffer += data.toString();
-      const line = buffer.split("\n").find(value => value.trim());
-      if (line) {
-        socket.destroy();
-        resolve(JSON.parse(line) as DaemonResponse);
-      }
-    });
-    socket.on("error", reject);
-  });
+  return sendSocketRequest(socketPath, method, params);
 }
 
 describe("UnixSocketServer key-value mutation platform routing (#4708)", () => {

--- a/test/daemon/socketServerMcpForwardSerialization.test.ts
+++ b/test/daemon/socketServerMcpForwardSerialization.test.ts
@@ -6,6 +6,8 @@ import { unlink } from "node:fs/promises";
 import { tmpdir } from "node:os";
 import { join } from "node:path";
 import { UnixSocketServer } from "../../src/daemon/socketServer";
+import { SOCKET_REQUEST_DEADLINE_MS, sendRawSocketRequest } from "./helpers/socketRequest";
+import { defaultTimer } from "../../src/utils/SystemTimer";
 import {
   DAEMON_BOUND_SESSION_PARAM,
   DAEMON_CAPABILITY_PROFILE_PARAM,
@@ -70,39 +72,9 @@ function createFakeDaemonState(
   };
 }
 
-function sendRequest(socketPath: string, request: DaemonRequest): Promise<DaemonResponse> {
-  return new Promise((resolve, reject) => {
-    const client = new Socket();
-    let buffer = "";
-
-    client.connect(socketPath, () => {
-      client.write(JSON.stringify(request) + "\n");
-    });
-
-    client.on("data", data => {
-      buffer += data.toString();
-      const lines = buffer.split("\n");
-      for (const line of lines) {
-        if (line.trim()) {
-          try {
-            const response = JSON.parse(line) as DaemonResponse;
-            client.destroy();
-            resolve(response);
-            return;
-          } catch {
-            // keep buffering
-          }
-        }
-      }
-    });
-
-    client.on("error", reject);
-    client.on("close", () => {
-      if (!buffer.trim()) {
-        reject(new Error("Connection closed without response"));
-      }
-    });
-  });
+async function sendRequest(socketPath: string, request: DaemonRequest): Promise<DaemonResponse> {
+  const { response } = await sendRawSocketRequest(socketPath, request);
+  return response;
 }
 
 function sendToolsCallWithArgs(
@@ -144,6 +116,16 @@ function sendTwoToolsCallsOnOneSocket(socketPath: string, toolName: string): Pro
       }
     });
 
+    // Bounded: two unanswered pipelined requests must fail fast with a
+    // diagnostic, not pend until the suite's wall-clock watchdog (#5391).
+    const deadline = defaultTimer.setTimeout(() => {
+      client.destroy();
+      reject(new Error(
+        `Received ${responses.length}/2 responses to pipelined tools/call within ${SOCKET_REQUEST_DEADLINE_MS}ms — `
+        + "bounded socket-test deadline hit"
+      ));
+    }, SOCKET_REQUEST_DEADLINE_MS);
+
     client.on("data", data => {
       buffer += data.toString();
       const lines = buffer.split("\n");
@@ -154,6 +136,7 @@ function sendTwoToolsCallsOnOneSocket(socketPath: string, toolName: string): Pro
         }
         responses.push(JSON.parse(line) as DaemonResponse);
         if (responses.length === 2) {
+          defaultTimer.clearTimeout(deadline);
           client.destroy();
           resolve(responses);
           return;
@@ -161,8 +144,12 @@ function sendTwoToolsCallsOnOneSocket(socketPath: string, toolName: string): Pro
       }
     });
 
-    client.on("error", reject);
+    client.on("error", error => {
+      defaultTimer.clearTimeout(deadline);
+      reject(error);
+    });
     client.on("close", () => {
+      defaultTimer.clearTimeout(deadline);
       if (responses.length < 2) {
         reject(new Error(`Connection closed after ${responses.length} responses`));
       }
@@ -209,8 +196,18 @@ class PersistentSocketClient {
       this.responses.delete(id);
       return Promise.resolve(buffered);
     }
-    return new Promise(resolve => {
-      this.waiters.set(id, resolve);
+    return new Promise((resolve, reject) => {
+      // Bounded: an unanswered request must fail fast with a diagnostic, not
+      // pend until the suite's wall-clock watchdog (macos hang class, #5391).
+      const deadline = defaultTimer.setTimeout(() => {
+        this.waiters.delete(id);
+        this.socket.destroy();
+        reject(new Error(`No response to ${method} within ${SOCKET_REQUEST_DEADLINE_MS}ms — bounded socket-test deadline hit`));
+      }, SOCKET_REQUEST_DEADLINE_MS);
+      this.waiters.set(id, response => {
+        defaultTimer.clearTimeout(deadline);
+        resolve(response);
+      });
     });
   }
 

--- a/test/daemon/socketServerMcpReconnect.test.ts
+++ b/test/daemon/socketServerMcpReconnect.test.ts
@@ -6,6 +6,8 @@ import { unlink } from "node:fs/promises";
 import { tmpdir } from "node:os";
 import { join } from "node:path";
 import { UnixSocketServer } from "../../src/daemon/socketServer";
+import { SOCKET_REQUEST_DEADLINE_MS, sendSocketRequest } from "./helpers/socketRequest";
+import { defaultTimer } from "../../src/utils/SystemTimer";
 import { FakeTimer } from "../fakes/FakeTimer";
 import type { DaemonResponse } from "../../src/daemon/types";
 
@@ -47,44 +49,7 @@ function createFakeDaemonState() {
 }
 
 function sendRequest(socketPath: string, method: string, params: Record<string, unknown> = {}): Promise<DaemonResponse> {
-  return new Promise((resolve, reject) => {
-    const client = new Socket();
-    let buffer = "";
-
-    client.connect(socketPath, () => {
-      const request = JSON.stringify({
-        id: randomUUID(),
-        type: "mcp_request",
-        method,
-        params,
-      });
-      client.write(request + "\n");
-    });
-
-    client.on("data", data => {
-      buffer += data.toString();
-      const lines = buffer.split("\n");
-      for (const line of lines) {
-        if (line.trim()) {
-          try {
-            const response = JSON.parse(line) as DaemonResponse;
-            client.destroy();
-            resolve(response);
-            return;
-          } catch {
-            // Incomplete JSON, keep buffering
-          }
-        }
-      }
-    });
-
-    client.on("error", reject);
-    client.on("close", () => {
-      if (!buffer.trim()) {
-        reject(new Error("Connection closed without response"));
-      }
-    });
-  });
+  return sendSocketRequest(socketPath, method, params);
 }
 
 class PersistentSocketClient {
@@ -126,8 +91,18 @@ class PersistentSocketClient {
       this.responses.delete(id);
       return Promise.resolve(buffered);
     }
-    return new Promise(resolve => {
-      this.waiters.set(id, resolve);
+    return new Promise((resolve, reject) => {
+      // Bounded: an unanswered request must fail fast with a diagnostic, not
+      // pend until the suite's wall-clock watchdog (macos hang class, #5391).
+      const deadline = defaultTimer.setTimeout(() => {
+        this.waiters.delete(id);
+        this.socket.destroy();
+        reject(new Error(`No response to ${method} within ${SOCKET_REQUEST_DEADLINE_MS}ms — bounded socket-test deadline hit`));
+      }, SOCKET_REQUEST_DEADLINE_MS);
+      this.waiters.set(id, response => {
+        defaultTimer.clearTimeout(deadline);
+        resolve(response);
+      });
     });
   }
 

--- a/test/daemon/socketServerNotifications.test.ts
+++ b/test/daemon/socketServerNotifications.test.ts
@@ -63,11 +63,21 @@ class FrameCollectingClient {
     this.socket.write(JSON.stringify({ id: randomUUID(), type: "daemon_request", method, params }) + "\n");
   }
 
-  /** Resolves once at least `count` frames have arrived (bounded by the bun test timeout). */
-  async waitForFrames(count: number): Promise<void> {
+  /**
+   * Resolves once at least `count` frames have arrived, or rejects with a
+   * diagnostic after `deadlineMs`. An unbounded wait here would pend until the
+   * CI wall-clock watchdog on a dropped broadcast (macos hang class, #5391).
+   */
+  async waitForFrames(count: number, deadlineMs: number = 10_000): Promise<void> {
+    const deadline = Date.now() + deadlineMs;
     while (this.frames.length < count) {
+      const remaining = deadline - Date.now();
+      if (remaining <= 0) {
+        throw new Error(`Received ${this.frames.length}/${count} notification frames within ${deadlineMs}ms — bounded socket-test deadline hit`);
+      }
       await new Promise<void>(resolve => {
         this.frameWaiters.push(resolve);
+        defaultTimer.setTimeout(resolve, remaining).unref();
       });
     }
   }

--- a/test/daemon/socketServerToolCapabilities.test.ts
+++ b/test/daemon/socketServerToolCapabilities.test.ts
@@ -1,11 +1,11 @@
 import { afterEach, beforeEach, describe, expect, mock, test } from "bun:test";
-import { Socket } from "node:net";
 import { existsSync } from "node:fs";
 import { unlink } from "node:fs/promises";
 import { tmpdir } from "node:os";
 import { join } from "node:path";
 import { randomUUID } from "node:crypto";
 import { UnixSocketServer } from "../../src/daemon/socketServer";
+import { sendSocketRequest } from "./helpers/socketRequest";
 import { AndroidCtrlProxyClient } from "../../src/features/observe/android";
 import { PlatformDeviceManagerFactory } from "../../src/utils/factories/PlatformDeviceManagerFactory";
 import { FakeTimer } from "../fakes/FakeTimer";
@@ -40,27 +40,7 @@ function createDaemonState(options?: { useLabeledSession?: boolean }) {
 }
 
 function sendRequest(socketPath: string, method: string, params: Record<string, unknown>): Promise<DaemonResponse> {
-  return new Promise((resolve, reject) => {
-    const socket = new Socket();
-    let buffer = "";
-    socket.connect(socketPath, () => {
-      socket.write(JSON.stringify({
-        id: randomUUID(),
-        type: "mcp_request",
-        method,
-        params,
-      }) + "\n");
-    });
-    socket.on("data", data => {
-      buffer += data.toString();
-      const line = buffer.split("\n").find(value => value.trim());
-      if (line) {
-        socket.destroy();
-        resolve(JSON.parse(line) as DaemonResponse);
-      }
-    });
-    socket.on("error", reject);
-  });
+  return sendSocketRequest(socketPath, method, params);
 }
 
 describe("UnixSocketServer app-data capability enforcement", () => {

--- a/test/daemon/videoStreamSocketServer.test.ts
+++ b/test/daemon/videoStreamSocketServer.test.ts
@@ -1,5 +1,6 @@
 import { afterEach, describe, expect, test } from "bun:test";
 import net from "node:net";
+import { connectBounded } from "./helpers/socketRequest";
 import { mkdtempSync, rmSync } from "node:fs";
 import { tmpdir } from "node:os";
 import path from "node:path";
@@ -147,11 +148,8 @@ async function subscribe(
   socketPath: string,
   request: Record<string, unknown> = { action: "subscribe", deviceId: DEVICE.deviceId }
 ): Promise<{ socket: net.Socket; ack: Record<string, unknown>; binary: () => Buffer }> {
-  const socket = net.createConnection(socketPath);
-  await new Promise<void>((resolve, reject) => {
-    socket.once("connect", () => resolve());
-    socket.once("error", reject);
-  });
+  const socket = new net.Socket();
+  await connectBounded(socket, socketPath);
 
   const chunks: Buffer[] = [];
   socket.on("data", data => chunks.push(data));
@@ -457,8 +455,8 @@ describe("VideoStreamSocketServer", () => {
 
     await waitFor(() => harnesses.some(h => h.socketPath === socketPath));
     const harness = harnesses.find(h => h.socketPath === socketPath)!;
-    const socket = net.createConnection(socketPath);
-    await new Promise<void>(resolve => socket.once("connect", resolve));
+    const socket = new net.Socket();
+    await connectBounded(socket, socketPath);
     socket.write(`${JSON.stringify({ action: "subscribe", deviceId: DEVICE.deviceId })}\n`);
     await sourceCreated;
     socket.destroy();
@@ -505,8 +503,8 @@ describe("VideoStreamSocketServer", () => {
       },
     });
 
-    const abandonedSocket = net.createConnection(socketPath);
-    await new Promise<void>(resolve => abandonedSocket.once("connect", resolve));
+    const abandonedSocket = new net.Socket();
+    await connectBounded(abandonedSocket, socketPath);
     abandonedSocket.write(`${JSON.stringify({ action: "subscribe", deviceId: DEVICE.deviceId })}\n`);
     await waitFor(() => resolveAbandonedSource !== undefined);
     abandonedSocket.destroy();
@@ -816,8 +814,8 @@ describe("VideoStreamSocketServer", () => {
 
   test("malformed JSON is rejected rather than crashing the server", async () => {
     const h = await startHarness();
-    const socket = net.createConnection(h.socketPath);
-    await new Promise<void>(resolve => socket.once("connect", () => resolve()));
+    const socket = new net.Socket();
+    await connectBounded(socket, h.socketPath);
 
     const chunks: Buffer[] = [];
     socket.on("data", data => chunks.push(data));

--- a/test/features/webrtc/WebRtcPublisher.loopback.test.ts
+++ b/test/features/webrtc/WebRtcPublisher.loopback.test.ts
@@ -8,6 +8,7 @@ import {
 } from "werift";
 import { WebRtcPublisher } from "../../../src/features/webrtc/WebRtcPublisher";
 import { WhipClient, type FetchLike } from "../../../src/features/webrtc/WhipClient";
+import { defaultTimer } from "../../../src/utils/SystemTimer";
 
 /**
  * End-to-end loopback: a real werift publisher POSTs a WHIP offer to an
@@ -15,7 +16,36 @@ import { WhipClient, type FetchLike } from "../../../src/features/webrtc/WhipCli
  * endpoint). This exercises RTP packetization + DTLS/ICE + media transport
  * without a device or a real HTTP server — the true proof that the publish path
  * works.
+ *
+ * Deliberately opt-in, like the MediaMTX integration suite: the DTLS/ICE
+ * handshake runs over REAL loopback UDP sockets, which under CI runner
+ * contention can stall — exactly the real-I/O hang class the macos "Run Tests"
+ * watchdog (#5391) guards against, and one a fakes-based unit test cannot
+ * cover. It runs in the dedicated `webrtc-integration-test` CI job (and
+ * locally) via `bun run test:integration:webrtc-mediamtx`; the fakes-based
+ * WebRtcPublisher.test.ts / WebRtcPublisher.trickle.test.ts suites keep the
+ * publisher logic covered in the default `bun test` run.
  */
+const RUN_INTEGRATION = process.env.AUTOMOBILE_MEDIAMTX_WEBRTC_INTEGRATION === "1";
+const describeLoopback = RUN_INTEGRATION ? describe : describe.skip;
+
+/** Bound a real-I/O step so a stalled DTLS/ICE exchange fails with a diagnostic. */
+async function withDeadline<T>(step: string, timeoutMs: number, run: () => Promise<T>): Promise<T> {
+  let timer: NodeJS.Timeout | undefined;
+  const deadline = new Promise<never>((_, reject) => {
+    timer = defaultTimer.setTimeout(
+      () => reject(new Error(`${step} did not complete within ${timeoutMs}ms — bounded real-I/O deadline hit`)),
+      timeoutMs
+    );
+  });
+  try {
+    return await Promise.race([run(), deadline]);
+  } finally {
+    if (timer !== undefined) {
+      defaultTimer.clearTimeout(timer);
+    }
+  }
+}
 
 const START = Buffer.from([0x00, 0x00, 0x00, 0x01]);
 
@@ -51,7 +81,7 @@ async function waitForIceComplete(pc: RTCPeerConnection): Promise<void> {
   await pc.iceGatheringStateChange.watch(state => state === "complete", 5000);
 }
 
-describe("WebRtcPublisher loopback", () => {
+describeLoopback("WebRtcPublisher loopback", () => {
   test(
     "publishes an H.264 stream over WHIP and the receiver gets RTP frames",
     async () => {
@@ -96,7 +126,7 @@ describe("WebRtcPublisher loopback", () => {
       );
 
       try {
-        await publisher.start();
+        await withDeadline("publisher.start (WHIP offer/answer + ICE)", 10_000, () => publisher.start());
         expect(publisher.getState()).toBe("connected");
 
         // Wait for the DTLS/ICE transport to connect before pumping media.
@@ -118,8 +148,10 @@ describe("WebRtcPublisher loopback", () => {
         expect(descriptor.resourceUrl).toBe("https://ingest.local/whip/loopback");
         expect(descriptor.framesSent).toBeGreaterThan(0);
       } finally {
-        await publisher.stop();
-        await receiver.close();
+        // Teardown must be bounded too: a hung stop/close would leak the real
+        // UDP sockets and keep the worker process alive after the test fails.
+        await withDeadline("publisher.stop", 5_000, () => publisher.stop());
+        await withDeadline("receiver.close", 5_000, async () => { await receiver.close(); });
       }
     },
     20000

--- a/test/integration/mediamtxWebRtcPublisher.integration.test.ts
+++ b/test/integration/mediamtxWebRtcPublisher.integration.test.ts
@@ -9,6 +9,7 @@ import { join, resolve } from "node:path";
 import WebSocket from "ws";
 import { WebRtcPublisher } from "../../src/features/webrtc/WebRtcPublisher";
 import { WhipClient } from "../../src/features/webrtc/WhipClient";
+import { defaultTimer } from "../../src/utils/SystemTimer";
 
 /**
  * Real SFU + decoder coverage for #4290. This is deliberately opt-in: it
@@ -301,32 +302,74 @@ async function readDecodedVideo(cdp: CdpClient): Promise<DecodedVideo> {
   return value;
 }
 
+/**
+ * Bound a wait on a real child-process event: these three helper tests run in
+ * the DEFAULT `bun test` suite on macOS/Linux (only win32 is skipped), so an
+ * unbounded `once()` on a child that never emits would ride the whole CI
+ * wall-clock watchdog (#5391) instead of failing with a diagnostic.
+ */
+async function boundedOnce(
+  emitter: Parameters<typeof once>[0],
+  event: string,
+  description: string,
+  timeoutMs: number = 10_000,
+): Promise<void> {
+  let timer: NodeJS.Timeout | undefined;
+  const deadline = new Promise<never>((_, reject) => {
+    timer = defaultTimer.setTimeout(
+      () => reject(new Error(`${description} did not emit '${event}' within ${timeoutMs}ms — bounded real-I/O deadline hit`)),
+      timeoutMs
+    );
+  });
+  try {
+    await Promise.race([once(emitter, event), deadline]);
+  } finally {
+    if (timer !== undefined) {
+      defaultTimer.clearTimeout(timer);
+    }
+  }
+}
+
 test.skipIf(process.platform === "win32")("force-kills a child that ignores SIGTERM", async () => {
   const child = spawn("/bin/sh", ["-c", 'trap "" TERM; printf ready; while :; do sleep 1; done'], {
     stdio: ["ignore", "pipe", "pipe"],
   });
-  await once(child.stdout, "data");
+  try {
+    await boundedOnce(child.stdout, "data", "SIGTERM-ignoring child stdout");
 
-  await stopProcess(child, 10);
+    await stopProcess(child, 10);
 
-  expect(child.exitCode).toBeNull();
-  expect(child.signalCode).toBe("SIGKILL");
+    expect(child.exitCode).toBeNull();
+    expect(child.signalCode).toBe("SIGKILL");
+  } finally {
+    // Guaranteed teardown even when an assertion or the deadline throws: a
+    // surviving `while :; do sleep 1; done` child would leak past the suite.
+    if (child.exitCode === null && child.signalCode === null) {
+      child.kill("SIGKILL");
+    }
+  }
 });
 
 test.skipIf(process.platform === "win32")("rejects a stale listener when the server child has already exited", async () => {
   const child = spawn("/bin/sh", ["-c", "exit 7"], {
     stdio: ["ignore", "pipe", "pipe"],
   });
-  await once(child, "exit");
+  try {
+    await boundedOnce(child, "exit", "immediately-exiting child");
 
-  await expect(waitForHttpServer(child, () => "address already in use", "http://127.0.0.1:8889/", "MediaMTX"))
-    .rejects.toThrow("MediaMTX exited before readiness (exit code 7):\naddress already in use");
+    await expect(waitForHttpServer(child, () => "address already in use", "http://127.0.0.1:8889/", "MediaMTX"))
+      .rejects.toThrow("MediaMTX exited before readiness (exit code 7):\naddress already in use");
+  } finally {
+    if (child.exitCode === null && child.signalCode === null) {
+      child.kill("SIGKILL");
+    }
+  }
 });
 
 test.skipIf(process.platform === "win32")("captures a child spawn error for the test body", async () => {
   const started = startProcess(join(tmpdir(), "missing-mediamtx-test-binary"), [], tmpdir());
 
-  await once(started.process, "error");
+  await boundedOnce(started.process, "error", "missing-binary spawn");
 
   expect(started.error()).toBeInstanceOf(Error);
   await stopProcess(started.process, 1);

--- a/test/server/deviceTools.startDevice.test.ts
+++ b/test/server/deviceTools.startDevice.test.ts
@@ -55,18 +55,20 @@ describe("startDevice handler", () => {
   let fakeDeviceUtils: FakeDeviceUtils;
   let fakeMatcher: FakeDeviceMatcher;
   let daemonSessionManager: SessionManager | undefined;
+  let bootTimer: FakeTimer;
 
   beforeEach(() => {
     fakeDeviceUtils = new FakeDeviceUtils();
     fakeMatcher = new FakeDeviceMatcher();
     daemonSessionManager = undefined;
+    bootTimer = new FakeTimer();
 
     setDeviceToolsDependencies({
       deviceManagerFactory: () => fakeDeviceUtils,
       deviceMatcherFactory: () => fakeMatcher,
       notifyResourcesChanged: async () => {},
       ensureCtrlProxyReady: async () => {},
-      timer: new FakeTimer(),
+      timer: bootTimer,
     });
 
     registerDeviceTools();
@@ -171,8 +173,18 @@ describe("startDevice handler", () => {
     const start = callStartDevice({ platform: "android" }, controller.signal);
     await imageListingStarted;
     controller.abort();
+    // #5368 holds an externally-aborted phase's rejection until the operation
+    // gets ABORT_SETTLEMENT_GRACE_MS (1s) to settle. That grace timer runs on
+    // the injected FakeTimer, and this fake image listing deliberately never
+    // settles, so advance the fake clock deterministically — without this the
+    // rejection never propagates and the whole `bun test` run wedges (the
+    // macos hang class behind the #5391 watchdog).
+    await new Promise<void>((resolve) => setImmediate(resolve));
+    bootTimer.advanceTime(1_000);
 
-    await expect(start).rejects.toThrow("startDevice cancelled while listing device images");
+    // A bare abort() propagates the platform's default AbortError (#5368
+    // preserves the caller-provided abort reason as-is).
+    await expect(start).rejects.toThrow("The operation was aborted");
     resolveImages([androidImage]);
     await Promise.resolve();
 
@@ -224,9 +236,10 @@ describe("startDevice handler", () => {
     await finalProgressStarted;
     controller.abort();
 
-    await expect(start).rejects.toThrow(
-      "startDevice cancelled while reporting device readiness progress",
-    );
+    // Progress phases skip abort settlement, so the rejection propagates
+    // immediately; a bare abort() surfaces the platform's default AbortError
+    // (#5368 preserves the caller-provided abort reason as-is).
+    await expect(start).rejects.toThrow("The operation was aborted");
     resolveFinalProgress();
     await Promise.resolve();
 


### PR DESCRIPTION
Follow-up cure to the defensive wall-clock watchdog in [#5391](https://github.com/kaeawc/auto-mobile/pull/5391): that PR made a wedged macos "Run Tests" step fail fast and red; this PR removes the hang class itself — tests whose waits can never settle. `bun test --timeout` only bounds test/hook bodies, so a never-settling wait or a leaked socket/child handle can still wedge a run the way [run 32156898919](https://github.com/kaeawc/auto-mobile/actions/runs/32156898919) wedged mid-suite for ~24 minutes.

## The wedge that is live on main right now

While proving this PR with a full local `bun test --isolate`, the suite wedged deterministically — and bisecting found the culprit is **not** one of the original real-I/O suspects:

**`test/server/deviceTools.startDevice.test.ts` deadlocks the entire run** since [#5368](https://github.com/kaeawc/auto-mobile/pull/5368) (merged today). `runPhase` now holds an externally-aborted phase's rejection until the operation gets `ABORT_SETTLEMENT_GRACE_MS` (1s) to settle. In the *"does not reach runner readiness or session binding after an externally cancelled boot"* test, the fake image listing deliberately never settles **and** the grace timer runs on the suite's injected `FakeTimer`, which nobody advances — a three-way circular wait (test awaits rejection ← rejection awaits settlement ← settlement awaits a clock nobody advances) that not even bun's per-test timeout interrupts. Reproduces 100% on a single-file run, plain or `--isolate`; the latest merge run's "Node TypeScript Build and Test (ubuntu-latest)" job is being **cancelled** the same way. The fix advances the injected fake clock past the grace deterministically and aligns the two cancellation tests with #5368's deliberate reason-propagation semantics (their real assertions — no runner readiness, no session binding, owned process killed — are unchanged). Suite: 42 pass in ~200ms, 20/20 loop green.

## Audit verdicts on the original leads

| Suspect | Verdict | Blocking construct |
| --- | --- | --- |
| `test/daemon/socketServer*` suites | **Confirmed** | Hand-rolled `sendRequest` promises resolved only on a full JSON line over a real unix socket — no deadline, and the client socket destroyed only on the response path, so an unanswered request pended forever and leaked its handle (old `socketServerHandshake.test.ts:25-61`, `inputSocketHarness.ts:83-129`, plus 8 more copies; `openPersistentConnection` sends, `PersistentSocketClient.request` in the mcpReconnect / mcpForwardSerialization suites, unbounded `waitForFrames` in the notifications suite, and 3 error-handler-less `once("connect")` awaits in the videoStream suite) |
| `test/features/webrtc/WebRtcPublisher.loopback.test.ts` | **Confirmed** | The only real-werift suite: DTLS/ICE handshake over real loopback UDP inside `publisher.start()`, plus unbounded `publisher.stop()` / `receiver.close()` in teardown — under contention the handshake can stall and the werift UDP sockets leak past the test timeout |
| `test/integration/mediamtxWebRtcPublisher.integration.test.ts:304/316/326` | **Confirmed** | Three helper tests gated only by `skipIf(win32)` run on every macos CI pass; `await once(child.stdout, "data")` and the other `once()` waits had no deadline, and the SIGTERM-ignoring `while :; do sleep 1; done` child was not killed on failure paths |
| Broader sweep (real `spawn`/UDP/`Bun.listen`, >100ms sleeps, other integration files) | **Cleared** | Other daemon suites use `FakeSocket`/resolve-gates; publisher/trickle webrtc suites use fake peer connections; all other `test/integration` files are env-gated; the "npm 503" WARNs seen mid-run come from a fakes-based metrics test, not the network |

## What changed

- **New canonical bounded helper** `test/daemon/helpers/socketRequest.ts`: `sendRawSocketRequest` / `sendSocketRequest` / `connectBounded` enforce a hard 10s client-side deadline (via `defaultTimer`, per the no-raw-timer rule) and destroy the socket on **every** settle path — response, error, close, deadline — so a server bug becomes a fast red failure with a diagnostic instead of a leaked handle.
- `inputSocketHarness` delegates to it; `openPersistentConnection` gains a bounded connect and per-send deadlines (all gesture-suite sends are awaited before `close()`, so no orphan rejections).
- The nine hand-rolled unbounded `sendRequest` copies now use the canonical helper: handshake, toolCapabilities, keyValue, mcpReconnect, featureFlags, ideStatus, inputPressButton, inputKey (drain mode preserves its frame-count assertion), mcpForwardSerialization (including its persistent client and the pipelined two-request helper).
- `socketServerNotifications.waitForFrames` and the videoStream connect awaits are bounded with diagnostics.
- **Loopback suite gated + bounded**: `WebRtcPublisher.loopback.test.ts` moves behind `AUTOMOBILE_MEDIAMTX_WEBRTC_INTEGRATION=1`, with `start`/`stop`/`close` deadline-wrapped. It still runs in CI: `scripts/webrtc/run-mediamtx-publisher-integration.sh` now includes it, so the dedicated **"WebRTC Publisher Integration (MediaMTX)"** job runs it on every webrtc-touching PR and on merge (and locally via `bun run test:integration:webrtc-mediamtx` — verified 20/20 green with the gate armed). Default-suite coverage of the publisher logic stays with the fakes-based `WebRtcPublisher.test.ts` / `.trickle.test.ts`. The BATS contract test for the runner is updated to match.
- The three always-on child-process helper tests bound their `once()` waits (`boundedOnce`, 10s) and kill the child in `finally`.
- `test/server/deviceTools.startDevice.test.ts`: deterministic fake-clock advance past the abort-settlement grace + expectation alignment (see above).

## Proof

- 20/20 loop of all 17 daemon/webrtc/integration touched files: 0 failures, ~1.5s per iteration.
- 20/20 loop of the gated loopback suite with the integration gate armed: 0 failures (~1s each).
- 20/20 loop of `test/server/deviceTools.startDevice.test.ts` under `--isolate`: 0 failures (~200ms each; previously wedged forever).
- `bun test test/daemon/ test/features/webrtc/ test/integration/`: 1892 pass / 14 skip / 0 fail in 3.0s.
- Full `bun test --isolate`: **before** this PR's second commit it wedged indefinitely (two runs killed at 12-13 min, plus two 2-day-old `bun test --isolate` processes found spinning on this machine from before the fix — live evidence of the class); **after**, green (wall-clock in the first comment below).
- `bun run lint` (ratchet unchanged, boundaries pass), `bun run typecheck` (no new baseline errors), `bun run build`, `bats test/bats/mediamtx-webrtc-integration.bats`, `shellcheck`: all green.

## Deliberately left alone

- The [#5391](https://github.com/kaeawc/auto-mobile/pull/5391) watchdog itself stays as defense in depth.
- `src/utils/deviceBootService.ts` is untouched: #5368's settlement-then-rethrow semantics are days old and deliberate; the deadlock leg that belongs to the test (an un-advanced fake clock) is what this PR fixes. If the phase-labeled cancellation message is preferred over the platform AbortError for bare `abort()`, that is a product decision for a follow-up.
- `stopProcess`'s post-SIGKILL `once(process, "exit")` wait in the mediamtx file: SIGKILL delivery is reliable, and the helper tests around it are now bounded and kill children in `finally`.
- `socketServerClose.test.ts` / `BaseSocketServerOwnership.test.ts` listen/close callback waits: local unix-socket `listen`/`close` callbacks always fire, and `connectClient` uses `events.once`, which rejects on `error`.
- `deviceDataStreamSocketServer`'s never-resolving promise is an in-process fake return (deterministic), not real I/O.
