### PR TITLE
fix(test): stop unified-guard BATS fixture racing siblings under --jobs

### DIFF
--- a/scripts/android/validate-no-desktop-core-unified.sh
+++ b/scripts/android/validate-no-desktop-core-unified.sh
@@ -2,7 +2,11 @@
 set -euo pipefail
 
 SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
-PROJECT_ROOT="$(cd "$SCRIPT_DIR/../.." && pwd)"
+# Optional first argument overrides the scanned root. Tests use this to point
+# the guard at a temp fixture tree instead of mutating the real repository,
+# which raced sibling tests under `bats --jobs` (fixture visible to the
+# "passes when absent" tests running concurrently).
+PROJECT_ROOT="${1:-$(cd "$SCRIPT_DIR/../.." && pwd)}"
 
 readonly UNIFIED_DIR="$PROJECT_ROOT/android/desktop-core/src/main/kotlin/dev/jasonpearson/automobile/desktop/core/unified"
 readonly UNIFIED_PACKAGE="dev.jasonpearson.automobile.desktop.core.unified"

--- a/test/bats/validate-no-desktop-core-unified.bats
+++ b/test/bats/validate-no-desktop-core-unified.bats
@@ -17,12 +17,28 @@ SCRIPT="scripts/android/validate-no-desktop-core-unified.sh"
 }
 
 @test "fails when a core.unified package reference is present" {
-  local fixture_dir="android/desktop-core/src/test/kotlin/dev/jasonpearson/automobile/desktop"
-  local fixture="$fixture_dir/__UnifiedReferenceGuardFixture.kt"
+  # Build the offending reference in a TEMP root and point the script at it via
+  # its root-override argument. Writing the fixture into the real tree raced
+  # the sibling "passes when absent" tests under `bats --jobs`: they scanned
+  # the repository while the fixture existed and failed spuriously.
+  local tmp_root
+  tmp_root="$(mktemp -d)"
+  local fixture_dir="$tmp_root/android/desktop-core/src/test/kotlin/dev/jasonpearson/automobile/desktop"
   mkdir -p "$fixture_dir"
-  printf 'package dev.jasonpearson.automobile.desktop\nimport dev.jasonpearson.automobile.desktop.core.unified.UnifiedSocketClient\n' > "$fixture"
-  run bash "$SCRIPT"
-  rm -f "$fixture"
+  printf 'package dev.jasonpearson.automobile.desktop\nimport dev.jasonpearson.automobile.desktop.core.unified.UnifiedSocketClient\n' \
+    > "$fixture_dir/__UnifiedReferenceGuardFixture.kt"
+  run bash "$SCRIPT" "$tmp_root"
+  rm -rf "$tmp_root"
   [ "$status" -ne 0 ]
   [[ "$output" == *"desktop-core still references the deleted core.unified package"* ]]
+}
+
+@test "fails when the unified package directory itself is present" {
+  local tmp_root
+  tmp_root="$(mktemp -d)"
+  mkdir -p "$tmp_root/android/desktop-core/src/main/kotlin/dev/jasonpearson/automobile/desktop/core/unified"
+  run bash "$SCRIPT" "$tmp_root"
+  rm -rf "$tmp_root"
+  [ "$status" -ne 0 ]
+  [[ "$output" == *"unified socket-client package still exists"* ]]
 }


### PR DESCRIPTION
## Summary

Fixes the pre-existing `validate-no-desktop-core-unified.bats` fixture race that reddened [main's On Merge run](https://github.com/kaeawc/auto-mobile/actions/runs/32192325321) for `fd0702b60` (BATS tests 756–758 on both platforms).

The 'reference present' test wrote its fixture **into the real repository tree**; under `bats --jobs` the sibling 'passes when absent' tests scanned the repo while the fixture existed and failed spuriously. The script now takes an optional root-override argument and the mutating tests build their offending tree in `mktemp` roots — no test touches the repository, so no shared state remains to race. Also adds a previously-missing test for the unified-directory-present branch.

## Validation
- `shellcheck` clean
- `bats test/bats/validate-no-desktop-core-unified.bats` — 4/4, 5 consecutive runs
- `git status` confirms zero repository mutation during the suite