### PR TITLE
ci: stop main from redding on missing-rg 127 and the ffmpeg-skip contradiction

### DIFF
--- a/scripts/android/validate-no-desktop-core-unified.sh
+++ b/scripts/android/validate-no-desktop-core-unified.sh
@@ -21,7 +21,23 @@ if [[ ! -d "$PROJECT_ROOT/android" ]]; then
   exit 1
 fi
 
-if matches="$(rg --fixed-strings --line-number -- "$UNIFIED_PACKAGE" "$PROJECT_ROOT/android")"; then
+# Layered scanner: rg when available (fastest, works in jj workspaces with no
+# Git worktree — the reason #5386 reached for it), then `git grep` inside a Git
+# worktree (the deliberate no-ripgrep CI path from 6f2434a40 — merge.yml's BATS
+# runners do not ship rg, so an unconditional rg dependency 127s there), then
+# plain `grep -rF` as the last resort (jj workspace on a host without rg).
+# All three exit 0=match, 1=no-match, >1=error, so the caller logic is shared.
+scan_for_unified_references() {
+  if command -v rg > /dev/null 2>&1; then
+    rg --fixed-strings --line-number -- "$UNIFIED_PACKAGE" "$PROJECT_ROOT/android"
+  elif git -C "$PROJECT_ROOT" rev-parse --is-inside-work-tree > /dev/null 2>&1; then
+    git -C "$PROJECT_ROOT" grep --untracked --fixed-strings --line-number "$UNIFIED_PACKAGE" -- android
+  else
+    grep -rFn -- "$UNIFIED_PACKAGE" "$PROJECT_ROOT/android"
+  fi
+}
+
+if matches="$(scan_for_unified_references)"; then
   echo "desktop-core still references the deleted core.unified package:" >&2
   echo "$matches" >&2
   exit 1

--- a/scripts/ci/verify-runtime-deps.sh
+++ b/scripts/ci/verify-runtime-deps.sh
@@ -41,8 +41,15 @@ command -v bun     >/dev/null 2>&1 || missing+=("bun")
 command -v bunx    >/dev/null 2>&1 || missing+=("bunx")
 
 # Runtime deps (ffmpeg installed by installer on macOS via brew,
-# pre-installed on ubuntu-latest)
-command -v ffmpeg  >/dev/null 2>&1 || missing+=("ffmpeg")
+# pre-installed on ubuntu-latest). When the workflow told the installer to
+# skip ffmpeg (AUTOMOBILE_INSTALL_SKIP_FFMPEG, #5385 — the ubuntu apt install
+# stalled for ~10 minutes per run), requiring it here would contradict that
+# skip and deterministically fail the job.
+if [[ "${AUTOMOBILE_INSTALL_SKIP_FFMPEG:-}" == "true" ]]; then
+  echo "Skipping ffmpeg check: AUTOMOBILE_INSTALL_SKIP_FFMPEG=true"
+else
+  command -v ffmpeg  >/dev/null 2>&1 || missing+=("ffmpeg")
+fi
 
 # Dev tools (installed by development preset via brew on macOS,
 # some pre-installed on ubuntu-latest)

--- a/test/bats/validate-no-desktop-core-unified.bats
+++ b/test/bats/validate-no-desktop-core-unified.bats
@@ -33,6 +33,30 @@ SCRIPT="scripts/android/validate-no-desktop-core-unified.sh"
   [[ "$output" == *"desktop-core still references the deleted core.unified package"* ]]
 }
 
+@test "passes without ripgrep on PATH (git-grep fallback)" {
+  # Regression for #5386 reintroducing a hard rg dependency (6f2434a40 removed
+  # it): merge.yml's BATS runners have no ripgrep, so the guard 127'd on every
+  # merge. A PATH without rg must fall back to `git grep` inside the worktree.
+  run env PATH="/usr/bin:/bin" bash "$SCRIPT"
+  [ "$status" -eq 0 ]
+  [[ "$output" == *"No desktop-core unified socket-client package or references found."* ]]
+}
+
+@test "detects references without ripgrep in a non-git root (grep fallback)" {
+  # jj workspaces have no Git worktree AND a host may lack rg: the plain-grep
+  # last resort must still find the offending reference.
+  local tmp_root
+  tmp_root="$(mktemp -d)"
+  local fixture_dir="$tmp_root/android/desktop-core/src/test/kotlin/dev/jasonpearson/automobile/desktop"
+  mkdir -p "$fixture_dir"
+  printf 'import dev.jasonpearson.automobile.desktop.core.unified.UnifiedSocketClient\n' \
+    > "$fixture_dir/__UnifiedReferenceGuardFixture.kt"
+  run env PATH="/usr/bin:/bin" bash "$SCRIPT" "$tmp_root"
+  rm -rf "$tmp_root"
+  [ "$status" -ne 0 ]
+  [[ "$output" == *"desktop-core still references the deleted core.unified package"* ]]
+}
+
 @test "fails when the unified package directory itself is present" {
   local tmp_root
   tmp_root="$(mktemp -d)"


### PR DESCRIPTION
## Summary

Fixes the two real regressions behind main staying red through [run 32195906639](https://github.com/kaeawc/auto-mobile/actions/runs/32195906639) (`c19a2300b`), after [#5395](https://github.com/kaeawc/auto-mobile/pull/5395) fixed the fixture race but not the underlying cause.

### 1. Hard `rg` dependency 127s on merge.yml's BATS runners
[#5386](https://github.com/kaeawc/auto-mobile/pull/5386) switched `validate-no-desktop-core-unified.sh` from `git grep` to `rg` to support jj workspaces (no Git worktree there). `merge.yml`'s BATS runners don't ship ripgrep, so every BATS run 127'd on tests 746-748 (`command not found`) — visible as `not ok 756-758` even after #5395 removed the race, because the failure was never about the race being present, it was a missing binary. Layered scanner: `rg` when present, `git grep` inside a Git worktree otherwise (restores pre-#5386 behavior on CI), plain `grep -rF` as a last resort for a jj workspace lacking `rg`. Two new regression tests pin the no-rg paths.

### 2. `verify-runtime-deps.sh` contradicts `AUTOMOBILE_INSTALL_SKIP_FFMPEG`
The workflow sets `AUTOMOBILE_INSTALL_SKIP_FFMPEG: "true"` (added by [#5385](https://github.com/kaeawc/auto-mobile/pull/5385) to dodge the ~10-minute apt ffmpeg install stall) on the same jobs that run this verifier, which unconditionally required ffmpeg — a deterministic self-contradiction. The verifier now honors the same skip flag.

## Validation
- `shellcheck` clean on both scripts
- `bats test/bats/validate-no-desktop-core-unified.bats` — 6/6 (adds 2 no-rg regression tests)
- Manually confirmed `AUTOMOBILE_INSTALL_SKIP_FFMPEG=true` now prints `Skipping ffmpeg check` and exits 0