### PR TITLE
fix(device): label bare external abort with boot-phase ActionableError

### DIFF
--- a/src/utils/deviceBootService.ts
+++ b/src/utils/deviceBootService.ts
@@ -20,6 +20,26 @@ import { runWithAbortSignal } from "./AbortContext";
 
 const ABORT_SETTLEMENT_GRACE_MS = 1_000;
 
+/**
+ * True for an `AbortSignal.reason` that carries no caller-supplied context: a
+ * literal `undefined` (used by synthetic/fake signals in tests), or the
+ * platform's own default `DOMException` that `AbortController.abort()`
+ * synthesizes when called with no argument (`name: "AbortError"`).
+ *
+ * A bare `abort()` never leaves `reason` as `undefined` on a real
+ * `AbortSignal` — the runtime fills in that default `DOMException` — so this
+ * is the actual signal a generic/unlabeled external cancellation needs to be
+ * detected by. An explicit `abort(null)` deliberately stays "not default":
+ * `null !== undefined` and `null` is not a `DOMException`, so a caller who
+ * explicitly cancels with a `null` reason still gets that reason back as-is.
+ * Any other explicit reason (`Error`, `DeviceLostError`, string, etc.) is
+ * likewise left untouched — only this platform sentinel is relabeled with
+ * boot-phase context (issue #5394).
+ */
+function isDefaultAbortReason(reason: unknown): boolean {
+  return reason === undefined || (reason instanceof DOMException && reason.name === "AbortError");
+}
+
 /** Inputs which affect device discovery, creation, and readiness, but not MCP sessions or automation setup. */
 export interface DeviceBootRequest {
   platform: "android" | "ios";
@@ -418,7 +438,7 @@ export class DeviceBootService {
       ? new Promise<never>((_resolve, reject) => {
           const rejectForAbort = () => {
             reject(
-              externalSignal.reason === undefined
+              isDefaultAbortReason(externalSignal.reason)
                 ? new ActionableError(`startDevice request cancelled while ${phase}`)
                 : externalSignal.reason,
             );
@@ -474,7 +494,7 @@ export class DeviceBootService {
 
   private throwExternalAbortReason(signal: AbortSignal | undefined, phase: string): void {
     if (signal?.aborted) {
-      if (signal.reason === undefined) {
+      if (isDefaultAbortReason(signal.reason)) {
         throw new ActionableError(`startDevice cancelled while ${phase}`);
       }
       throw signal.reason;

--- a/test/server/deviceTools.startDevice.test.ts
+++ b/test/server/deviceTools.startDevice.test.ts
@@ -10,7 +10,7 @@ import {
 import { FakeDeviceUtils } from "../fakes/FakeDeviceUtils";
 import { FakeDeviceMatcher } from "../fakes/FakeDeviceMatcher";
 import { ToolRegistry } from "../../src/server/toolRegistry";
-import type { BootedDevice, DeviceInfo } from "../../src/models";
+import { ActionableError, type BootedDevice, type DeviceInfo } from "../../src/models";
 import { DaemonState } from "../../src/daemon/daemonState";
 import { SessionManager } from "../../src/daemon/sessionManager";
 import { DevicePool } from "../../src/daemon/devicePool";
@@ -182,9 +182,11 @@ describe("startDevice handler", () => {
     await new Promise<void>((resolve) => setImmediate(resolve));
     bootTimer.advanceTime(1_000);
 
-    // A bare abort() propagates the platform's default AbortError (#5368
-    // preserves the caller-provided abort reason as-is).
-    await expect(start).rejects.toThrow("The operation was aborted");
+    // A bare abort() carries the platform's default AbortError DOMException as
+    // its reason, not `undefined`. #5394 relabels that generic/unlabeled case
+    // with the boot phase in flight instead of letting it surface raw.
+    await expect(start).rejects.toBeInstanceOf(ActionableError);
+    await expect(start).rejects.toThrow("startDevice cancelled while listing device images");
     resolveImages([androidImage]);
     await Promise.resolve();
 
@@ -237,9 +239,13 @@ describe("startDevice handler", () => {
     controller.abort();
 
     // Progress phases skip abort settlement, so the rejection propagates
-    // immediately; a bare abort() surfaces the platform's default AbortError
-    // (#5368 preserves the caller-provided abort reason as-is).
-    await expect(start).rejects.toThrow("The operation was aborted");
+    // immediately. A bare abort() carries the platform's default AbortError
+    // DOMException as its reason; #5394 relabels it with the boot phase in
+    // flight instead of letting it surface raw.
+    await expect(start).rejects.toBeInstanceOf(ActionableError);
+    await expect(start).rejects.toThrow(
+      "startDevice cancelled while reporting 100% device boot progress",
+    );
     resolveFinalProgress();
     await Promise.resolve();
 
@@ -339,7 +345,10 @@ describe("startDevice handler", () => {
     const childProcess = new FakeExitChildProcess();
     fakeDeviceUtils.setBootedDevices("android", [discoveredDevice]);
     fakeDeviceUtils.setDeviceImages("android", [coldBootImage]);
-    fakeDeviceUtils.setMockChildProcess(coldBootImage.name, childProcess as unknown as ChildProcess);
+    fakeDeviceUtils.setMockChildProcess(
+      coldBootImage.name,
+      childProcess as unknown as ChildProcess,
+    );
     fakeMatcher.setBootedResult(null);
     fakeMatcher.setImageResult(coldBootImage);
 

--- a/test/utils/deviceBootService.test.ts
+++ b/test/utils/deviceBootService.test.ts
@@ -3,11 +3,12 @@ import { describe, expect, it } from "bun:test";
 import { DeviceBootService, type DeviceBootProgress } from "../../src/utils/deviceBootService";
 import { FakeDeviceMatcher } from "../fakes/FakeDeviceMatcher";
 import { FakeDeviceUtils } from "../fakes/FakeDeviceUtils";
-import type { BootedDevice, DeviceInfo } from "../../src/models";
+import { ActionableError, type BootedDevice, type DeviceInfo } from "../../src/models";
 import type { DeviceMatchCriteria } from "../../src/models/DeviceMatchCriteria";
 import type { DeviceBootRecovery } from "../../src/utils/deviceBootRecovery";
 import type { Timer } from "../../src/utils/SystemTimer";
 import { FakeTimer } from "../fakes/FakeTimer";
+import { DeviceLostError } from "../../src/server/deviceLossOutcome";
 
 const image: DeviceInfo = {
   name: "Pixel_9_API_35",
@@ -331,7 +332,11 @@ describe("DeviceBootService", () => {
     await discoveryStarted;
     controller.abort();
 
-    await expect(boot).rejects.toBe(controller.signal.reason);
+    // A bare abort() carries the platform's default AbortError DOMException as
+    // `reason`, not `undefined` — it must still be relabeled with the boot
+    // phase in flight (#5394), not surfaced raw.
+    await expect(boot).rejects.toBeInstanceOf(ActionableError);
+    await expect(boot).rejects.toThrow("startDevice cancelled while discovering running devices");
     resolveDiscovery([running]);
     await Promise.resolve();
 
@@ -371,7 +376,9 @@ describe("DeviceBootService", () => {
     controller.abort();
 
     resolveStart(handle);
-    await expect(boot).rejects.toBe(controller.signal.reason);
+    // Bare abort(): default AbortError DOMException relabeled with phase context.
+    await expect(boot).rejects.toBeInstanceOf(ActionableError);
+    await expect(boot).rejects.toThrow("startDevice cancelled while starting the device");
     await Promise.resolve();
     await Promise.resolve();
 
@@ -455,7 +462,11 @@ describe("DeviceBootService", () => {
     controller.abort();
     resolveProgress();
 
-    await expect(boot).rejects.toBe(controller.signal.reason);
+    // Bare abort(): default AbortError DOMException relabeled with phase context.
+    await expect(boot).rejects.toBeInstanceOf(ActionableError);
+    await expect(boot).rejects.toThrow(
+      "startDevice cancelled while reporting 60% device boot progress",
+    );
     expect(killCount).toBe(1);
     expect(devices.wasMethodCalled("waitForDeviceReady")).toBe(false);
   });
@@ -498,7 +509,11 @@ describe("DeviceBootService", () => {
     await finalProgressStarted;
     controller.abort();
 
-    await expect(boot).rejects.toBe(controller.signal.reason);
+    // Bare abort(): default AbortError DOMException relabeled with phase context.
+    await expect(boot).rejects.toBeInstanceOf(ActionableError);
+    await expect(boot).rejects.toThrow(
+      "startDevice cancelled while reporting 100% device boot progress",
+    );
     resolveFinalProgress();
     await Promise.resolve();
 
@@ -700,5 +715,139 @@ describe("DeviceBootService", () => {
     });
 
     expect(provisionCriteria).toMatchObject({ minOsVersion: "26.3", maxOsVersion: "26.3" });
+  });
+
+  describe("bare external abort phase labeling (#5394)", () => {
+    // "listing device images" and "waiting for device boot readiness" both
+    // default `awaitAbortSettlement` to true, so the fake operation below
+    // (which never cooperatively observes the abort signal) is only unstuck
+    // by advancing the FakeTimer past ABORT_SETTLEMENT_GRACE_MS -- mirroring
+    // the deterministic pattern the #5393 deadlock fix established. Skipping
+    // this advance hangs `bun test` outright rather than merely failing.
+    const ABORT_SETTLEMENT_GRACE_MS = 1_000;
+
+    it("labels a bare abort during image listing with its boot phase", async () => {
+      const devices = new FakeDeviceUtils();
+      const matcher = new FakeDeviceMatcher();
+      const timer = new FakeTimer();
+      const controller = new AbortController();
+      let markListingStarted!: () => void;
+      const listingStarted = new Promise<void>((resolve) => {
+        markListingStarted = resolve;
+      });
+      const pendingImages = new Promise<DeviceInfo[]>(() => {});
+      devices.listDeviceImages = async () => {
+        markListingStarted();
+        return pendingImages;
+      };
+
+      const boot = service(devices, matcher, undefined, timer).boot({
+        platform: "android",
+        signal: controller.signal,
+      });
+      void boot.catch(() => {});
+      await listingStarted;
+      controller.abort();
+      await new Promise<void>((resolve) => setImmediate(resolve));
+      timer.advanceTime(ABORT_SETTLEMENT_GRACE_MS);
+
+      await expect(boot).rejects.toBeInstanceOf(ActionableError);
+      await expect(boot).rejects.toThrow("startDevice cancelled while listing device images");
+    });
+
+    it("labels a bare abort during device boot readiness with its boot phase", async () => {
+      const devices = new FakeDeviceUtils();
+      const matcher = new FakeDeviceMatcher();
+      const timer = new FakeTimer();
+      const controller = new AbortController();
+      let markReadinessStarted!: () => void;
+      const readinessStarted = new Promise<void>((resolve) => {
+        markReadinessStarted = resolve;
+      });
+      const pendingReadiness = new Promise<BootedDevice>(() => {});
+      devices.setDeviceImages("android", [image]);
+      matcher.setImageResult(image);
+      devices.setMockChildProcess(image.name, { kill: () => true, pid: 12 } as any);
+      devices.waitForDeviceReady = async () => {
+        markReadinessStarted();
+        return pendingReadiness;
+      };
+
+      const boot = service(devices, matcher, undefined, timer).boot({
+        platform: "android",
+        signal: controller.signal,
+      });
+      void boot.catch(() => {});
+      await readinessStarted;
+      controller.abort();
+      await new Promise<void>((resolve) => setImmediate(resolve));
+      timer.advanceTime(ABORT_SETTLEMENT_GRACE_MS);
+
+      await expect(boot).rejects.toBeInstanceOf(ActionableError);
+      await expect(boot).rejects.toThrow(
+        "startDevice cancelled while waiting for device boot readiness",
+      );
+    });
+
+    it("preserves a tracked device-loss reason over the generic abort label", async () => {
+      const devices = new FakeDeviceUtils();
+      const matcher = new FakeDeviceMatcher();
+      const timer = new FakeTimer();
+      const controller = new AbortController();
+      const deviceLoss = new DeviceLostError("emulator-5554", "device-disconnected:emulator-5554");
+      let markListingStarted!: () => void;
+      const listingStarted = new Promise<void>((resolve) => {
+        markListingStarted = resolve;
+      });
+      const pendingImages = new Promise<DeviceInfo[]>(() => {});
+      devices.listDeviceImages = async () => {
+        markListingStarted();
+        return pendingImages;
+      };
+
+      const boot = service(devices, matcher, undefined, timer).boot({
+        platform: "android",
+        signal: controller.signal,
+      });
+      void boot.catch(() => {});
+      await listingStarted;
+      controller.abort(deviceLoss);
+      await new Promise<void>((resolve) => setImmediate(resolve));
+      timer.advanceTime(ABORT_SETTLEMENT_GRACE_MS);
+
+      // A tracked device-loss reason takes precedence over the generic
+      // phase-labeled ActionableError: the caller-supplied `DeviceLostError`
+      // surfaces unchanged, not wrapped or relabeled (#5394).
+      await expect(boot).rejects.toBe(deviceLoss);
+    });
+
+    it("preserves an explicit AbortError-shaped reason distinct from the platform default", async () => {
+      const devices = new FakeDeviceUtils();
+      const matcher = new FakeDeviceMatcher();
+      const timer = new FakeTimer();
+      const controller = new AbortController();
+      let markListingStarted!: () => void;
+      const listingStarted = new Promise<void>((resolve) => {
+        markListingStarted = resolve;
+      });
+      const pendingImages = new Promise<DeviceInfo[]>(() => {});
+      devices.listDeviceImages = async () => {
+        markListingStarted();
+        return pendingImages;
+      };
+
+      const boot = service(devices, matcher, undefined, timer).boot({
+        platform: "android",
+        signal: controller.signal,
+      });
+      void boot.catch(() => {});
+      await listingStarted;
+      const explicitReason = new Error("caller-cancelled");
+      controller.abort(explicitReason);
+      await new Promise<void>((resolve) => setImmediate(resolve));
+      timer.advanceTime(ABORT_SETTLEMENT_GRACE_MS);
+
+      await expect(boot).rejects.toBe(explicitReason);
+    });
   });
 });


### PR DESCRIPTION
## Summary

`DeviceBootService.runPhase` re-derives a caught abort's rejection from
`signal.reason` directly (in `throwExternalAbortReason` and the
`externalAbortPromise` rejector added by [#5368](https://github.com/kaeawc/auto-mobile/pull/5368)), passing it through
unwrapped whenever `reason !== undefined`. A bare `controller.abort()`
never actually leaves `reason` as `undefined` though — the platform fills
in its own default `DOMException` (`name: "AbortError"`) — so every
generic/unlabeled external cancellation surfaced that raw platform error to
MCP callers with **zero boot-phase context**, instead of the phase-labeled
`ActionableError` CLAUDE.md's error-handling convention calls for at this
boundary. [#5393](https://github.com/kaeawc/auto-mobile/pull/5393) fixed the resulting test deadlock but deliberately left
this product question open.

## Fix

Added `isDefaultAbortReason()` in `src/utils/deviceBootService.ts`, which
treats a platform-default `AbortError` `DOMException` the same as a literal
`undefined` reason. Both call sites (`throwExternalAbortReason` and the
`externalAbortPromise` rejector inside `runPhase`) now use it, so a bare
abort is relabeled with the in-flight boot phase:

```
startDevice cancelled while <phase>
```

An **explicit** reason is left untouched and still propagates unchanged:

- an explicit `abort(null)` (distinct from `undefined` — `null` is not a
  `DOMException` and is not the default sentinel)
- a tracked `DeviceLostError` (the `throwIfAborted` /
  `rememberDeviceLossAbort` device-loss path from [#5390](https://github.com/kaeawc/auto-mobile/pull/5390) is unaffected —
  it never goes through `deviceBootService`'s reason detection at all, and
  when a device-loss reason is set directly as the abort reason it is a
  real `Error` instance, so it isn't touched by this change either)
- any other caller-supplied `Error`

### Phase taxonomy (from `src/utils/deviceBootService.ts`)

The phases a bare abort can now be labeled with, taken verbatim from the
`runPhase(context, "<phase>", ...)` call sites:

- `discovering running devices`
- `listing device images`
- `resolving the running device image`
- `provisioning a device`
- `waiting for a running device`
- `starting the device`
- `waiting for device boot readiness`
- `reporting <N>% device boot progress` (progress-callback phases)

(`CiIosBootRecovery`'s own `recovering the CI iOS simulator` phase already
threw a labeled `ActionableError` before this change and is untouched.)

## Tests

- `test/utils/deviceBootService.test.ts`: updated the four assertions that
  pinned the old raw-passthrough behavior for bare `abort()` (discovery,
  start-handle, and both progress-reporting phases) to assert the new
  phase-labeled `ActionableError` instead. Left the two assertions that
  exercise an **explicit** abort reason unchanged. Added a new
  `describe("bare external abort phase labeling (#5394)")` block covering:
  bare abort during image listing, bare abort during device-boot-readiness,
  a tracked `DeviceLostError` taking precedence over the generic label, and
  an explicit non-default `Error` reason still propagating as-is.
- `test/server/deviceTools.startDevice.test.ts`: updated the two
  MCP-boundary regression tests from [#5393](https://github.com/kaeawc/auto-mobile/pull/5393) that previously asserted
  `"The operation was aborted"` (the raw platform message) to assert the
  phase-labeled `ActionableError` instead, keeping the same deterministic
  `bootTimer.advanceTime(...)` pattern that fixed the [#5393](https://github.com/kaeawc/auto-mobile/pull/5393) deadlock.

All new/changed tests use the existing `FakeTimer` / `FakeDeviceUtils` /
`FakeDeviceMatcher` seams — no real timers or sleeps.

## Validation

- `bun test test/utils/deviceBootService.test.ts test/server/deviceTools.startDevice.test.ts` — 66 pass, 0 fail, ~240ms
- Related suites (`ciIosBootRecovery`, `deviceBootRecovery`, `throwIfAborted`,
  `executionTracker`, `deviceLossOutcome*`) — 33 pass, 0 fail
- Looped the two touched test files 20x — all green, no flakes
- `bun run typecheck` — clean (183 known baseline errors, no new ones)
- `bun run lint` — clean (oxlint ratchet: no new violations; boundary-checks: 13/13 passed)

Closes #5394
