### PR TITLE
fix(navigation): scope getNavigationGraph by appId to fix flaky iOS SDK integration (#4579)

### DIFF
--- a/schemas/tool-definitions.json
+++ b/schemas/tool-definitions.json
@@ -1648,6 +1648,10 @@
             "ios"
           ]
         },
+        "appId": {
+          "description": "Scope the graph to this app id instead of the device's current foreground app",
+          "type": "string"
+        },
         "sessionUuid": {
           "description": "Session",
           "type": "string"

--- a/scripts/android/navigation-graph-sdk-event-integration.sh
+++ b/scripts/android/navigation-graph-sdk-event-integration.sh
@@ -87,8 +87,12 @@ for attempt in 1 2 3 4 5; do
     sleep 2
     continue
   fi
+  # Scope the read to the fixture package. Without --appId the daemon selects the
+  # device's latest observed foreground app, so a concurrent hierarchy push can
+  # redirect this assertion to another app's graph even though the event reached
+  # the fixture app (issue #4579).
   if ! graph="$(auto-mobile --debug --embedded-sdk --cli --session-uuid "$session_uuid" \
-    getNavigationGraph --platform android --deviceId "$device_id")"; then
+    getNavigationGraph --platform android --deviceId "$device_id" --appId "$package_id")"; then
     echo "getNavigationGraph attempt ${attempt} failed; retrying in 2s..." >&2
     sleep 2
     continue
@@ -103,6 +107,6 @@ for attempt in 1 2 3 4 5; do
   sleep 2
 done
 
-echo "error: Android SDK navigation event did not reach getNavigationGraph" >&2
+echo "error: Android SDK navigation event did not reach getNavigationGraph for app ${package_id}" >&2
 echo "last graph response: ${graph}" >&2
 exit 1

--- a/scripts/ios/navigation-graph-sdk-event-integration.sh
+++ b/scripts/ios/navigation-graph-sdk-event-integration.sh
@@ -128,7 +128,11 @@ for attempt in 1 2 3 4 5; do
     sleep 2
     continue
   fi
-  if ! graph="$(auto-mobile --debug --embedded-sdk --cli --session-uuid "${session_uuid}" getNavigationGraph --platform ios --deviceId "${device_id}")"; then
+  # Scope the read to the fixture bundle. Without --appId the daemon selects the
+  # device's latest observed foreground app, so a concurrent hierarchy push that
+  # marks com.apple.springboard current makes this assertion read the wrong
+  # (empty) graph even though the events reached the fixture app (issue #4579).
+  if ! graph="$(auto-mobile --debug --embedded-sdk --cli --session-uuid "${session_uuid}" getNavigationGraph --platform ios --deviceId "${device_id}" --appId "${bundle_id}")"; then
     echo "getNavigationGraph attempt ${attempt} failed; retrying in 2s..." >&2
     sleep 2
     continue
@@ -144,6 +148,6 @@ for attempt in 1 2 3 4 5; do
   sleep 2
 done
 
-echo "error: iOS SDK navigation events did not reach getNavigationGraph" >&2
+echo "error: iOS SDK navigation events did not reach getNavigationGraph for app ${bundle_id}" >&2
 echo "last graph response: ${graph}" >&2
 exit 1

--- a/src/server/navigationTools.ts
+++ b/src/server/navigationTools.ts
@@ -17,7 +17,8 @@ export const navigateToSchema = addDeviceTargetingToSchema(z.object({
 }));
 
 export const getNavigationGraphSchema = addDeviceTargetingToSchema(z.object({
-  platform: platformSchema.default("android")
+  platform: platformSchema.default("android"),
+  appId: z.string().optional().describe("Scope the graph to this app id instead of the device's current foreground app")
 }));
 
 export const exploreSchema = addDeviceTargetingToSchema(z.object({
@@ -42,6 +43,7 @@ export interface NavigateToArgs {
 
 export interface GetNavigationGraphArgs {
   platform: Platform;
+  appId?: string;
   sessionUuid?: string;
 }
 
@@ -107,12 +109,20 @@ export function registerNavigationTools() {
     try {
       const manager = getNavigationManager(args.sessionUuid);
       const observation = RealObserveScreen.getRecentCachedResultForDevice(device.deviceId);
-      const appId = observation?.viewHierarchy?.packageName ?? observation?.activeWindow?.appId;
-      const stats = await manager.getStatsForApp(appId ?? null);
-      const graph = await manager.exportGraphForApp(appId ?? null);
+      const observedAppId = observation?.viewHierarchy?.packageName ?? observation?.activeWindow?.appId ?? null;
+      // An explicit appId scopes the read to the requested app so a concurrent
+      // hierarchy update that marks a different app current (e.g. SpringBoard)
+      // cannot redirect the query away from the app the caller cares about
+      // (issue #4579). Fall back to the device's observed foreground app.
+      const requestedAppId = args.appId ?? null;
+      const appId = requestedAppId ?? observedAppId;
+      const stats = await manager.getStatsForApp(appId);
+      const graph = await manager.exportGraphForApp(appId);
 
       return createJSONToolResponse({
         message: `Navigation graph for app: ${appId || "none"}`,
+        requestedAppId,
+        observedAppId,
         currentScreen: stats.currentScreen,
         nodeCount: stats.nodeCount,
         edgeCount: stats.edgeCount,

--- a/test/bats/android-navigation-graph-sdk-event-integration.bats
+++ b/test/bats/android-navigation-graph-sdk-event-integration.bats
@@ -134,6 +134,9 @@ exit 1
   first_observe_line="$(grep -n -- "observe --platform android --deviceId emulator-5554" "$AUTO_MOBILE_LOG" | head -n 1 | cut -d: -f1)"
   [ "$root_line" -lt "$wait_for_device_line" ]
   [ "$launch_line" -lt "$first_observe_line" ]
+  # Regression for issue #4579: scope the graph read to the fixture package so a
+  # concurrent hierarchy push cannot redirect the query to another app's graph.
+  grep -q -- "getNavigationGraph --platform android --deviceId emulator-5554 --appId dev.jasonpearson.automobile.playground" "$AUTO_MOBILE_LOG"
 }
 
 @test "uses the workspace CLI entrypoint when the global auto-mobile install is unavailable" {

--- a/test/bats/navigation-graph-sdk-event-integration.bats
+++ b/test/bats/navigation-graph-sdk-event-integration.bats
@@ -111,6 +111,9 @@ fi
   [ "$(cat "$HEALTH_ATTEMPTS_FILE")" = "3" ]
   [ -f "$TARGET_APP_LAUNCHED_FILE" ]
   [[ "$output" == *"getNavigationGraph attempt 1 failed"* ]]
+  # Regression for issue #4579: the graph read must be scoped to the fixture
+  # bundle so a concurrent SpringBoard hierarchy push cannot redirect the query.
+  grep -q -- "getNavigationGraph --platform ios --deviceId simulator-udid --appId com.apple.reminders" "$INVOCATION_FILE"
   launch_line="$(grep -n -- "launchApp --platform ios --appId com.apple.reminders --deviceId simulator-udid" "$INVOCATION_FILE" | head -n 1 | cut -d: -f1)"
   observe_line="$(grep -n -- "observe --platform ios --deviceId simulator-udid" "$INVOCATION_FILE" | head -n 1 | cut -d: -f1)"
   [ "$launch_line" -lt "$observe_line" ]

--- a/test/server/navigationTools.test.ts
+++ b/test/server/navigationTools.test.ts
@@ -182,6 +182,81 @@ describe("navigation tool session graph selection", () => {
     }
   });
 
+  test("scopes the graph to an explicit appId even when the current app changed to SpringBoard", async () => {
+    // Regression for issue #4579: after SDK events reach the fixture app's
+    // graph, a concurrent hierarchy push can mark com.apple.springboard current.
+    // An explicit appId must read the fixture graph, not the current app's.
+    const graph = new FakeNavigationGraphManager();
+    Object.assign(graph, {
+      getStatsForApp: async (appId: string | null) => {
+        expect(appId).toBe("com.apple.reminders");
+        return {
+          nodeCount: 2,
+          edgeCount: 1,
+          currentScreen: null,
+          knownEdgeCount: 1,
+          unknownEdgeCount: 0,
+          toolCallHistorySize: 0,
+        };
+      },
+      exportGraphForApp: async (appId: string | null) => {
+        expect(appId).toBe("com.apple.reminders");
+        return {
+          appId,
+          currentScreen: null,
+          nodes: [
+            { screenName: "Issue4460Home", firstSeenAt: 1, lastSeenAt: 2, visitCount: 1 },
+            { screenName: "Issue4460Detail", firstSeenAt: 2, lastSeenAt: 3, visitCount: 1 },
+          ],
+          edges: [{
+            from: "Issue4460Home",
+            to: "Issue4460Detail",
+            timestamp: 3,
+            edgeType: "unknown" as const,
+          }],
+        };
+      },
+    });
+    const managerSpy = spyOn(NavigationGraphManager, "getInstance").mockReturnValue(
+      graph as unknown as NavigationGraphManager
+    );
+    // A concurrent hierarchy update marked SpringBoard current.
+    const observationSpy = spyOn(RealObserveScreen, "getRecentCachedResultForDevice").mockReturnValue({
+      viewHierarchy: { packageName: "com.apple.springboard" }
+    } as never);
+
+    try {
+      const handler = (ToolRegistry as unknown as {
+        tools: Map<string, { deviceAwareHandler?: (device: BootedDevice, args: any) => Promise<any> }>;
+      }).tools.get("getNavigationGraph")?.deviceAwareHandler;
+
+      const response = await handler!(device, {
+        platform: "ios",
+        appId: "com.apple.reminders",
+      });
+
+      const result = JSON.parse(response.content[0].text);
+      // Failures identify the queried app and the current app (diagnostics).
+      expect(result.message).toBe("Navigation graph for app: com.apple.reminders");
+      expect(result.requestedAppId).toBe("com.apple.reminders");
+      expect(result.observedAppId).toBe("com.apple.springboard");
+      expect(result).toMatchObject({
+        nodeCount: 2,
+        edgeCount: 1,
+        knownEdges: 1,
+        unknownEdges: 0,
+        screens: [
+          { name: "Issue4460Home", visitCount: 1 },
+          { name: "Issue4460Detail", visitCount: 1 },
+        ],
+        transitions: [{ from: "Issue4460Home", to: "Issue4460Detail", type: "unknown" }],
+      });
+    } finally {
+      observationSpy.mockRestore();
+      managerSpy.mockRestore();
+    }
+  });
+
   test("reports none when the target device has no cached observation", async () => {
     const staleGraph = new FakeNavigationGraphManager();
     staleGraph.setCurrentAppId("com.google.android.settings.intelligence");
@@ -222,6 +297,8 @@ describe("navigation tool session graph selection", () => {
 
       expect(JSON.parse(response.content[0].text)).toEqual({
         message: "Navigation graph for app: none",
+        requestedAppId: null,
+        observedAppId: null,
         currentScreen: null,
         nodeCount: 0,
         edgeCount: 0,


### PR DESCRIPTION
## Summary

The iOS `navigation-graph-sdk-event-integration.sh` CI check posts SDK events for a fixture bundle to `/sdk-events`, then reads `getNavigationGraph` using only the platform and device. The handler derives the target app from the device's most recent cached observation, so a concurrent hierarchy push that marks `com.apple.springboard` current makes the assertion read the empty SpringBoard graph instead of the fixture app's graph — reddening unrelated PRs.

This adds an optional `appId` to `getNavigationGraph`. When provided, the read is scoped to that app directly instead of the observed foreground app, so the assertion is independent of foreground-app races. The response also reports `requestedAppId` and `observedAppId` so failures distinguish event ingestion, app selection, and daemon responsiveness. Both the iOS and Android integration scripts now pass their fixture bundle explicitly. The change is additive on a `debugOnly + embeddedSdkOnly` tool; the public daemon workflow (`/sdk-events` + `getNavigationGraph`) is unchanged.

## Linked Issue

Closes #4579

## Bug / Regression Context

- **Prior attempts:** The script already launches/observes the fixture app to bias the foreground selection (issue's Option 3) — a weaker mitigation that hierarchy traffic can still defeat between the wait and the read.
- **Observed symptom:** SDK batch reaches the daemon and the fixture graph is populated, but the unscoped read returns a zero-node SpringBoard graph (or a 5s daemon CLI timeout). See runs linked in #4579.
- **Repro steps / conditions:** POST events for the fixture bundle, then a concurrent hierarchy push sets the current app to `com.apple.springboard` before the unscoped `getNavigationGraph` read.

## Changes

- `src/server/navigationTools.ts` — `getNavigationGraph` accepts an optional `appId`; scopes the read to it when present, else falls back to the observed foreground app. Response gains `requestedAppId` + `observedAppId` diagnostics.
- `scripts/ios/…` and `scripts/android/navigation-graph-sdk-event-integration.sh` — pass `--appId <fixture>` on the graph read; name the queried app in the final error line.
- `schemas/tool-definitions.json` — regenerated (additive `appId` field).

## Acceptance criteria

- [x] The integration check asserts the graph for the fixture bundle regardless of which app a concurrent hierarchy update marks current — explicit `--appId`, pinned by a handler unit test and the BATS wiring test.
- [x] A regression test covers successful event ingestion followed by a SpringBoard/current-app change — `test/server/navigationTools.test.ts` (observation returns SpringBoard, explicit appId returns the fixture graph).
- [x] Failures identify the app whose graph was queried and retain actionable daemon-response diagnostics — `requestedAppId`/`observedAppId` in the response; scripts name the queried app and echo the last graph response.
- [x] The solution continues to exercise the public daemon workflow rather than directly seeding a graph manager — still `/sdk-events` + public `getNavigationGraph`.

## Validation

- [x] `bun test` — full suite (13512 pass, 0 fail)
- [x] `bun run typecheck` reports no new errors (baseline gate)
- [x] `bun run lint` — no new ratchet violations
- [x] Android/iOS changes: `shellcheck` clean; BATS scripts green for both integration scripts
- [x] New tests use interfaces + fakes; unit tests run in <100ms

## Device Verification

- [ ] N/A — CI-script + tool-arg change; no on-device behavior change. The live iOS/Android integration scripts are the on-device exercise and run in PR CI.

## Follow-ups

- None. Android sibling script fixed in this PR alongside iOS since the tool change enables the same one-line scoping.
