### PR TITLE
test(ios): pin the bounded startCapture() timeout for the #4350 no-frames flake

### DIFF
--- a/ios/screen-capture/Sources/ScreenCaptureHelper/SimulatorCaptureSession.swift
+++ b/ios/screen-capture/Sources/ScreenCaptureHelper/SimulatorCaptureSession.swift
@@ -73,6 +73,12 @@ final class SimulatorCaptureSession: NSObject, SCStreamOutput, SCStreamDelegate 
     /// frame starvation. See issues #4350 / #4764.
     static let startCaptureDeadlineSeconds: TimeInterval = 14.0
 
+    /// Effective deadline the `startCapture()` race uses, defaulting to the
+    /// production `startCaptureDeadlineSeconds`. `internal` (not a constant) only
+    /// so `@testable` tests can shrink it to exercise the hung-start path without
+    /// a real 14s wait; production never mutates it. See issue #4350.
+    var startCaptureDeadlineSeconds: TimeInterval = SimulatorCaptureSession.startCaptureDeadlineSeconds
+
     init(
         writer: FrameWriter,
         makeStream: @escaping StreamFactory = { filter, config, delegate in
@@ -133,7 +139,7 @@ final class SimulatorCaptureSession: NSObject, SCStreamOutput, SCStreamDelegate 
         if audio {
             try stream.addStreamOutput(self, type: .audio, sampleHandlerQueue: queue)
         }
-        try await SimulatorCaptureSession.startCapture(stream)
+        try await startCapture(stream)
         self.stream = stream
     }
 
@@ -145,8 +151,11 @@ final class SimulatorCaptureSession: NSObject, SCStreamOutput, SCStreamDelegate 
     /// unstructured tasks and the first to finish wins; on timeout the stalled
     /// capture task is left to be reaped by process exit, which the parent
     /// triggers immediately after seeing the `error:` diagnostic.
-    private static func startCapture(_ stream: CaptureStream) async throws {
+    private func startCapture(_ stream: CaptureStream) async throws {
         let race = StartRaceState()
+        // Snapshot the deadline into a Sendable local so the unstructured tasks
+        // below capture a value rather than the non-Sendable session.
+        let deadlineSeconds = startCaptureDeadlineSeconds
         try await withCheckedThrowingContinuation { (continuation: CheckedContinuation<Void, Error>) in
             let capture = Task {
                 do {
@@ -157,12 +166,12 @@ final class SimulatorCaptureSession: NSObject, SCStreamOutput, SCStreamDelegate 
                 }
             }
             Task {
-                let deadlineNanos = UInt64(startCaptureDeadlineSeconds * 1_000_000_000)
+                let deadlineNanos = UInt64(deadlineSeconds * 1_000_000_000)
                 try? await Task.sleep(nanoseconds: deadlineNanos)
                 if race.finish() {
                     capture.cancel()
                     continuation.resume(
-                        throwing: StartCaptureTimeoutError(deadlineSeconds: startCaptureDeadlineSeconds)
+                        throwing: StartCaptureTimeoutError(deadlineSeconds: deadlineSeconds)
                     )
                 }
             }

--- a/ios/screen-capture/Tests/ScreenCaptureHelperTests/SimulatorCaptureSessionTests.swift
+++ b/ios/screen-capture/Tests/ScreenCaptureHelperTests/SimulatorCaptureSessionTests.swift
@@ -40,6 +40,14 @@ final class SimulatorCaptureSessionTests: XCTestCase {
         private(set) var updatedConfigurations: [SCStreamConfiguration] = []
 
         var startCaptureError: Error?
+        /// When `true`, `startCapture()` parks far longer than any test-injected
+        /// deadline, standing in for a `SCStream.startCapture()` hung inside
+        /// ScreenCaptureKit start (issue #4350). The session's deadline race is
+        /// expected to cancel this task, so the sleep unwinds via `CancellationError`
+        /// rather than leaking. If the deadline ever regresses, the sleep instead
+        /// completes (a bounded 5s) so the test fails fast with a clear assertion
+        /// instead of hanging.
+        var startCaptureHangs = false
         /// When set, every `updateConfiguration` call throws it.
         var updateConfigurationError: Error?
         /// Throws on the first N `updateConfiguration` calls, then succeeds —
@@ -61,6 +69,13 @@ final class SimulatorCaptureSessionTests: XCTestCase {
 
         func startCapture() async throws {
             startCaptureCallCount += 1
+            if startCaptureHangs {
+                // Far exceeds any sane test deadline; the session's timeout arm
+                // cancels this task, so the sleep throws `CancellationError` and
+                // unwinds cleanly. The 5s bound only elapses if the deadline
+                // regresses, turning a hang into a fast assertion failure.
+                try await Task.sleep(nanoseconds: 5_000_000_000)
+            }
             if let error = startCaptureError { throw error }
         }
 
@@ -275,8 +290,33 @@ final class SimulatorCaptureSessionTests: XCTestCase {
         XCTAssertTrue(diagnostics.lines.isEmpty)
     }
 
-    // NOTE: A bounded `startCapture()` timeout is not present on this branch
-    // (tracked separately as the #4350 hardening work). When it lands, add a
-    // case here that injects a `startCapture()` which never returns and asserts
-    // the session times out — the `CaptureStream` seam already supports it.
+    // MARK: - Bounded startCapture() deadline (issue #4350 / #4764)
+
+    /// A `startCapture()` that hangs inside ScreenCaptureKit start must be
+    /// surfaced as a specific `StartCaptureTimeoutError` — the greppable
+    /// `error:` diagnostic the parent supervisor fails fast on — rather than
+    /// stalling until the parent's 15s SIGTERM with silent frame starvation.
+    /// This pins the deadline race added for the #4350 no-frames flake.
+    func testBeginCaptureTimesOutWhenStartCaptureHangs() async {
+        let diagnostics = DiagnosticRecorder()
+        let session = makeSession(diagnostics: diagnostics)
+        // Shrink the 14s production deadline so the hang resolves in tens of ms.
+        session.startCaptureDeadlineSeconds = 0.05
+        let fake = FakeCaptureStream()
+        fake.startCaptureHangs = true
+
+        do {
+            try await session.beginCapture(with: fake, audio: false)
+            XCTFail("beginCapture should time out when startCapture never returns")
+        } catch let error as StartCaptureTimeoutError {
+            XCTAssertEqual(error.deadlineSeconds, 0.05)
+        } catch {
+            XCTFail("unexpected error type: \(error)")
+        }
+
+        // The start was attempted, but a stream that never started must not be
+        // retained as the live stream.
+        XCTAssertEqual(fake.startCaptureCallCount, 1)
+        XCTAssertNil(session.stream)
+    }
 }


### PR DESCRIPTION
## Summary

[#4350](https://github.com/kaeawc/auto-mobile/issues/4350) tracked an intermittent iOS device-capture flake where the Simulator capture helper delivered no H.264 frames. It was localized to `SCStream.startCapture()` hanging inside ScreenCaptureKit startup, and the issue's plan was to *"choose the narrow recovery change and add a regression test around that observed failure mode."*

The narrow recovery change — bounding `startCapture()` with a deadline so a hung start surfaces a specific `StartCaptureTimeoutError` instead of silent frame starvation — landed in [#4820](https://github.com/kaeawc/auto-mobile/pull/4820). **The regression test never did.** `SimulatorCaptureSessionTests.swift` still carried a stale NOTE claiming the timeout *"is not present on this branch,"* even though the code has been on `main` for weeks.

This PR fills exactly that gap:

- Adds `testBeginCaptureTimesOutWhenStartCaptureHangs` — a `FakeCaptureStream` whose `startCapture()` parks past an injected deadline; the test asserts `beginCapture(...)` throws `StartCaptureTimeoutError` and leaves `session.stream` unset (a start that never completed must not be retained as the live stream).
- Exposes `startCaptureDeadlineSeconds` as a **test-injectable instance seam** defaulting to the unchanged `14.0`s constant, so the hang resolves in ~50ms instead of a real 14s wait. Production runtime behavior is byte-identical.
- Removes the now-false NOTE.

I verified the test genuinely pins the timeout (not just any path): temporarily bypassing the deadline race makes the test fail (`beginCapture should time out when startCapture never returns`); restoring it makes it pass.

## Linked Issue

Refs #4350

<!-- Deliberately NOT "Closes": the root-cause fix already merged; this adds the missing regression test. Empirical confirmation that the flake is gone still wants a green iOS device-capture CI batch, so closing #4350 is left to that verification. -->

## Bug / Regression Context

- **Prior attempts:** [#4820](https://github.com/kaeawc/auto-mobile/pull/4820) landed the bounded-`startCapture()` deadline fix; [#4816](https://github.com/kaeawc/auto-mobile/pull/4816)/[#4829](https://github.com/kaeawc/auto-mobile/pull/4829)/[#4895](https://github.com/kaeawc/auto-mobile/pull/4895) added surrounding hardening. None added the regression test the issue asked for.
- **Observed symptom:** iOS leg of `webrtc-device-integration.yml` intermittently failed with `capture source did not deliver H.264 frames to the WHIP publisher`; `sourceStarted` never reached — the helper was blocked inside `SCStream.startCapture()`.
- **Repro steps / conditions:** cold-start on hosted `macos26` runners where `startCapture()` occasionally exceeded the parent's 15s first-frame budget with no diagnostic. The new test reproduces the hang deterministically via the injected `CaptureStream` seam — no Simulator, window, or Screen Recording permission required.

## Validation

- [x] Android/iOS changes: ran the matching `scripts/` validation — `./scripts/ios/swift-build.sh` (build complete, no warnings); `./scripts/ios/swift-test.sh` (screen-capture package: 133 tests, 0 failures); `swiftlint` clean on both changed files.
- [x] New code uses interfaces + fakes; unit test runs in ~55ms (`<100ms`)
- [x] New generic code reuses existing project helpers — reuses the existing `CaptureStream` seam and `FakeCaptureStream`; no new dependency.
- [x] Rebased onto latest `main`, conflicts resolved
- [ ] `scripts/all_fast_validate_checks.sh` / `bun run typecheck` — N/A: diff is Swift-only (`git diff --name-only main...HEAD` = two files under `ios/screen-capture/`); no TypeScript, so the TS lint/build/test/typecheck surfaces are untouched by construction.

## Device Verification

N/A — the change is a helper-internal test seam with byte-identical runtime behavior (default deadline unchanged at 14.0s). No on-device behavior changes, and **no helper re-cut is required**.

## Follow-ups

- [ ] Close #4350 after a green iOS `webrtc-device-integration.yml` batch confirms the no-frames flake is empirically gone.
