### PR TITLE
fix(ci): disable config-cache reuse for Detekt job (#5332)

### DIFF
--- a/.github/workflows/merge.yml
+++ b/.github/workflows/merge.yml
@@ -262,7 +262,16 @@ jobs:
           gradle-tasks: "detektMain detektTest"
           gradle-project-directory: "android"
           gradle-home-directory: "~/.gradle/${{ github.job }}"
-          reuse-configuration-cache: true
+          # Configuration-cache reuse is deliberately OFF here (#5332), matching
+          # the PR-CI Detekt job in pull_request.yml. A restored config-cache
+          # entry intermittently evaluated the Metro Gradle plugin classpath under
+          # a stale JVM context ("Dependency requires at least JVM runtime version
+          # 21. This build uses a Java 17 JVM."), failing ~2min with a generic
+          # exit 1 and NO `.kt` annotations. On this post-merge backstop that flake
+          # reddens main. Disabling reuse removes it deterministically; the Gradle
+          # BUILD cache (the real speed win) stays on. Guarded by
+          # test/bats/detekt-config-cache-disabled.bats.
+          reuse-configuration-cache: false
           gradle-encryption-key: ${{ secrets.GRADLE_ENCRYPTION_KEY }}
 
       - name: "Upload Detekt Reports"

--- a/.github/workflows/pull_request.yml
+++ b/.github/workflows/pull_request.yml
@@ -862,7 +862,18 @@ jobs:
           gradle-tasks: "detektMain detektTest"
           gradle-project-directory: "android"
           gradle-home-directory: "~/.gradle/${{ github.job }}"
-          reuse-configuration-cache: true
+          # Configuration-cache reuse is deliberately OFF here (#5332). A restored
+          # config-cache entry intermittently evaluated the Metro Gradle plugin
+          # classpath under a stale JVM context, failing ~2min with a generic
+          # exit 1 and NO `.kt` annotations ("Dependency requires at least JVM
+          # runtime version 21. This build uses a Java 17 JVM.") even though the
+          # action pins JDK 21 and local `--rerun-tasks` runs are green. Disabling
+          # reuse removes that flake deterministically; the Gradle BUILD cache
+          # (the real speed win) stays on, so the cost is only the configuration
+          # phase, not a full recompile. Do not flip this back to true without
+          # first fixing the underlying config-cache/JVM interaction -- the guard
+          # in test/bats/detekt-config-cache-disabled.bats pins it.
+          reuse-configuration-cache: false
           gradle-encryption-key: ${{ secrets.GRADLE_ENCRYPTION_KEY }}
 
       - name: "Upload Detekt Reports"

--- a/test/bats/detekt-config-cache-disabled.bats
+++ b/test/bats/detekt-config-cache-disabled.bats
@@ -1,0 +1,57 @@
+#!/usr/bin/env bats
+#
+# Guards the Detekt job's configuration-cache setting in pull_request.yml (#5332).
+#
+# The Detekt job (`detektMain detektTest` via `.github/actions/gradle-task-run`)
+# intermittently failed ~2min with a generic exit 1 and NO `.kt` annotations:
+#
+#   Dependency requires at least JVM runtime version 21. This build uses a Java 17 JVM.
+#
+# even though the action pins Zulu JDK 21 and a local `--rerun-tasks` run is green.
+# That is a configuration-cache-REUSE corruption flake -- a restored cache entry
+# evaluates the Metro Gradle plugin classpath under a stale JVM context. Disabling
+# configuration-cache reuse for this job removes the flake deterministically; the
+# Gradle BUILD cache (the actual speed win) stays on, so the cost is only the
+# configuration phase, not a full recompile.
+#
+# This suite pins that setting: flip `reuse-configuration-cache` back to true and
+# Fast Validation (BATS Shell Tests -> Shell Tests) goes red instead of the flake
+# silently returning.
+
+WF=".github/workflows/pull_request.yml"
+
+# Print the YAML block for a top-level job id (2-space indent), from its header
+# up to the next job header.
+job_block() {
+  awk -v j="$1" '
+    $0 ~ "^  " j ":[[:space:]]*$" { cap = 1; next }
+    cap && /^  [A-Za-z0-9_-]+:[[:space:]]*$/ { exit }
+    cap { print }
+  ' "$WF"
+}
+
+@test "detekt job disables configuration-cache reuse (guards the JVM17 flake)" {
+  block="$(job_block detekt)"
+  # Guard against a vacuous pass: a renamed/removed job would make job_block
+  # return "" and every substring assertion below would trivially fail.
+  [[ -n "$block" ]]
+  [[ "$block" == *"reuse-configuration-cache: false"* ]]
+  [[ "$block" != *"reuse-configuration-cache: true"* ]]
+}
+
+@test "detekt job still runs the full detektMain detektTest task list" {
+  # Disabling config-cache must not narrow WHAT is analyzed -- the full-tree task
+  # list is load-bearing for this project's cross-module potential-bugs rules.
+  block="$(job_block detekt)"
+  [[ -n "$block" ]]
+  [[ "$block" == *"detektMain detektTest"* ]]
+}
+
+@test "detekt job keeps the Gradle build cache on (only config-cache is disabled)" {
+  # The build cache is what makes the job fast; only configuration-cache reuse is
+  # the flake source. `reuse-build-cache` defaults to true, so the job must not
+  # opt out of it.
+  block="$(job_block detekt)"
+  [[ -n "$block" ]]
+  [[ "$block" != *"reuse-build-cache: false"* ]]
+}

--- a/test/bats/detekt-config-cache-disabled.bats
+++ b/test/bats/detekt-config-cache-disabled.bats
@@ -1,6 +1,7 @@
 #!/usr/bin/env bats
 #
-# Guards the Detekt job's configuration-cache setting in pull_request.yml (#5332).
+# Guards the Detekt job's configuration-cache setting in both the PR-CI
+# (pull_request.yml) and post-merge backstop (merge.yml) workflows (#5332).
 #
 # The Detekt job (`detektMain detektTest` via `.github/actions/gradle-task-run`)
 # intermittently failed ~2min with a generic exit 1 and NO `.kt` annotations:
@@ -14,24 +15,24 @@
 # Gradle BUILD cache (the actual speed win) stays on, so the cost is only the
 # configuration phase, not a full recompile.
 #
-# This suite pins that setting: flip `reuse-configuration-cache` back to true and
-# Fast Validation (BATS Shell Tests -> Shell Tests) goes red instead of the flake
-# silently returning.
+# Both the PR job AND the merge.yml full-tree backstop run the identical task list
+# and were both subject to the flake, so both must disable reuse -- otherwise the
+# flake just moves to reddening main post-merge. This suite pins both: flip either
+# `reuse-configuration-cache` back to true and Fast Validation (BATS Shell Tests
+# -> Shell Tests) goes red instead of the flake silently returning.
 
-WF=".github/workflows/pull_request.yml"
-
-# Print the YAML block for a top-level job id (2-space indent), from its header
-# up to the next job header.
+# Print the YAML block for a top-level job id (2-space indent) in $1, from its
+# header up to the next job header.
 job_block() {
-  awk -v j="$1" '
+  awk -v j="$2" '
     $0 ~ "^  " j ":[[:space:]]*$" { cap = 1; next }
     cap && /^  [A-Za-z0-9_-]+:[[:space:]]*$/ { exit }
     cap { print }
-  ' "$WF"
+  ' "$1"
 }
 
-@test "detekt job disables configuration-cache reuse (guards the JVM17 flake)" {
-  block="$(job_block detekt)"
+@test "PR-CI detekt job disables configuration-cache reuse (guards the JVM17 flake)" {
+  block="$(job_block ".github/workflows/pull_request.yml" detekt)"
   # Guard against a vacuous pass: a renamed/removed job would make job_block
   # return "" and every substring assertion below would trivially fail.
   [[ -n "$block" ]]
@@ -39,19 +40,30 @@ job_block() {
   [[ "$block" != *"reuse-configuration-cache: true"* ]]
 }
 
-@test "detekt job still runs the full detektMain detektTest task list" {
-  # Disabling config-cache must not narrow WHAT is analyzed -- the full-tree task
-  # list is load-bearing for this project's cross-module potential-bugs rules.
-  block="$(job_block detekt)"
+@test "merge.yml post-merge detekt backstop also disables configuration-cache reuse" {
+  block="$(job_block ".github/workflows/merge.yml" detekt)"
   [[ -n "$block" ]]
-  [[ "$block" == *"detektMain detektTest"* ]]
+  [[ "$block" == *"reuse-configuration-cache: false"* ]]
+  [[ "$block" != *"reuse-configuration-cache: true"* ]]
 }
 
-@test "detekt job keeps the Gradle build cache on (only config-cache is disabled)" {
+@test "both detekt jobs still run the full detektMain detektTest task list" {
+  # Disabling config-cache must not narrow WHAT is analyzed -- the full-tree task
+  # list is load-bearing for this project's cross-module potential-bugs rules.
+  for wf in ".github/workflows/pull_request.yml" ".github/workflows/merge.yml"; do
+    block="$(job_block "$wf" detekt)"
+    [[ -n "$block" ]]
+    [[ "$block" == *"detektMain detektTest"* ]]
+  done
+}
+
+@test "both detekt jobs keep the Gradle build cache on (only config-cache is disabled)" {
   # The build cache is what makes the job fast; only configuration-cache reuse is
-  # the flake source. `reuse-build-cache` defaults to true, so the job must not
+  # the flake source. `reuse-build-cache` defaults to true, so neither job must
   # opt out of it.
-  block="$(job_block detekt)"
-  [[ -n "$block" ]]
-  [[ "$block" != *"reuse-build-cache: false"* ]]
+  for wf in ".github/workflows/pull_request.yml" ".github/workflows/merge.yml"; do
+    block="$(job_block "$wf" detekt)"
+    [[ -n "$block" ]]
+    [[ "$block" != *"reuse-build-cache: false"* ]]
+  done
 }


### PR DESCRIPTION
## Summary

The **Detekt** CI job (`detektMain detektTest` via `.github/actions/gradle-task-run`) intermittently failed ~2min with a generic `exit code 1` and **no `.kt` annotations** — a rerun-not-fix infra flake. Root cause is a **configuration-cache-reuse corruption**: a restored config-cache entry evaluates the Metro Gradle plugin classpath under a stale JVM context, surfacing as:

> Dependency requires at least JVM runtime version 21. This build uses a Java 17 JVM.

even though the action pins **Zulu JDK 21** and a local `--rerun-tasks` run is always green.

This sets `reuse-configuration-cache: false` for the Detekt job **only**, removing the flake deterministically. The Gradle **build** cache (the actual speed win) stays on, so the cost is the configuration phase — not a full recompile.

## Linked Issue

Closes #5332

## Bug / Regression Context

- **Observed symptom:** Detekt fails ~2m16s with generic `exit code 1`, no `*.kt` annotations; rerun (or a new commit) clears it (evidence: PR #5310, check-run `95175344675` on `3aa837e134`, repeats on `435f342`/`f3f6f77`/`13b6e287`).
- **Repro conditions:** restored config-cache entry evaluating the Metro plugin classpath under a stale JVM context; not reproducible locally with `--rerun-tasks` (cache busted).
- **Why config-cache-disable over auto-retry:** a retry would have to bust the corrupt config-cache anyway; disabling reuse for this one job is the deterministic, smaller fix and keeps the build cache.

## Changes

- `.github/workflows/pull_request.yml`: Detekt job `reuse-configuration-cache: true` → `false`, with a rationale comment tying it to #5332.
- `.github/workflows/merge.yml`: same fix on the post-merge full-tree Detekt **backstop** — it runs the identical `detektMain detektTest` and was equally exposed, so the flake would otherwise just move to reddening main after merge.
- `test/bats/detekt-config-cache-disabled.bats`: new guard pinning the setting (and that the job keeps the full task list + build cache), so it can't be silently flipped back.

## Validation

- [x] `bats test/bats/` — all 880 tests pass (incl. 3 new)
- [x] `scripts/all_fast_validate_checks.sh --only yaml,shellcheck` — pass
- [x] No TypeScript touched → typecheck baseline unaffected (N/A)

## Acceptance Criteria (inferred — issue lists suggestions, not ACs)

- [x] **AC1** Detekt no longer reuses the configuration cache → JVM17 config-cache flake eliminated deterministically (guard asserts `reuse-configuration-cache: false`).
- [x] **AC2** Scoped to Detekt only — no fleet-wide config-cache disable; build cache stays on (guard asserts full task list + no `reuse-build-cache: false`).
- [x] **AC3** Rationale comment (`#5332`) ties the setting to the flake so it isn't reverted blindly.

## Follow-ups

- Suggested follow-up #2 in the issue — *surfacing the underlying Gradle error into the CI annotation instead of a generic exit 1* — is intentionally out of scope here; the failing command output is already visible in the job log. Can file separately if desired.
