### PR TITLE
ci: authenticate lychee github.com checks to stop rate-limit timeouts

### DIFF
--- a/.github/workflows/merge.yml
+++ b/.github/workflows/merge.yml
@@ -460,6 +460,11 @@ jobs:
 
       - name: "Validate Links"
         shell: "bash"
+        # Lychee routes github.com links through the GitHub API (not throttled
+        # HTTP scraping) when GITHUB_TOKEN is set, which prevents the mass
+        # request timeouts we hit against the repo's own issue/actions links.
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         run: |
           scripts/lychee/validate_lychee.sh
 

--- a/scripts/lychee/validate_lychee.sh
+++ b/scripts/lychee/validate_lychee.sh
@@ -77,6 +77,24 @@ fi
 LYCHEE_VERSION=$(lychee --version | head -1)
 print_status "Using $LYCHEE_VERSION"
 
+# Lychee routes github.com links through the GitHub API (not throttled HTTP
+# scraping) when GITHUB_TOKEN is set. Without it, the many self-referencing
+# issue/actions links in our docs mass-timeout under GitHub's unauthenticated
+# rate limit. CI injects the token via env; for local runs, fall back to the
+# developer's gh CLI credentials so behavior matches CI.
+if [[ -z "${GITHUB_TOKEN:-}" ]] && command -v gh >/dev/null 2>&1; then
+    if GH_TOKEN=$(gh auth token 2>/dev/null) && [[ -n "$GH_TOKEN" ]]; then
+        export GITHUB_TOKEN="$GH_TOKEN"
+        print_status "Using GitHub token from gh CLI for github.com link checks"
+    fi
+fi
+
+if [[ -n "${GITHUB_TOKEN:-}" ]]; then
+    print_status "GITHUB_TOKEN present: github.com links checked via GitHub API"
+else
+    print_warning "No GITHUB_TOKEN: github.com links may time out under rate limits"
+fi
+
 # Check if config file exists
 if [[ ! -f "$LYCHEE_CONFIG" ]]; then
     print_warning "Lychee config not found at: $LYCHEE_CONFIG"

--- a/scripts/lychee/validate_lychee.sh
+++ b/scripts/lychee/validate_lychee.sh
@@ -83,7 +83,9 @@ print_status "Using $LYCHEE_VERSION"
 # rate limit. CI injects the token via env; for local runs, fall back to the
 # developer's gh CLI credentials so behavior matches CI.
 if [[ -z "${GITHUB_TOKEN:-}" ]] && command -v gh >/dev/null 2>&1; then
-    if GH_TOKEN=$(gh auth token 2>/dev/null) && [[ -n "$GH_TOKEN" ]]; then
+    # Pin to github.com so a set GH_HOST (e.g. GitHub Enterprise) can't leak an
+    # Enterprise token into GITHUB_TOKEN for github.com link checks.
+    if GH_TOKEN=$(gh auth token --hostname github.com 2>/dev/null) && [[ -n "$GH_TOKEN" ]]; then
         export GITHUB_TOKEN="$GH_TOKEN"
         print_status "Using GitHub token from gh CLI for github.com link checks"
     fi


### PR DESCRIPTION
## Problem

[On Merge run 32199674792](https://github.com/kaeawc/auto-mobile/actions/runs/32199674792) failed on **Validate Documentation Links** with `0 Errors 🚫` but **42 Timeouts ⏳**. Every timed-out URL is a `github.com` self-link — the repo's own issues, `actions/workflows/*`, and badge URLs. Lychee checks ~2300 links; the burst of unauthenticated requests to `github.com` hits GitHub's rate limit and times out (timeouts fail the job). No documentation link is actually broken.

## Fix

Lychee routes `github.com` links through the GitHub API — which is authenticated and not throttled — instead of raw HTTP scraping whenever `GITHUB_TOKEN` is present. This PR supplies it in both the CI and local paths:

- **`.github/workflows/merge.yml`** — inject `GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}` into the *Validate Links* step.
- **`scripts/lychee/validate_lychee.sh`** — fall back to `gh auth token` when `GITHUB_TOKEN` is unset, so a local `validate_lychee.sh` run gets the same reliability as CI (it previously relied on the token happening to be in the caller's environment, which locally it usually isn't).

## Validation

- `shellcheck scripts/lychee/validate_lychee.sh` — clean
- `scripts/all_fast_validate_checks.sh` — exit 0