### PR TITLE
feat(daemon): stamp deviceSessionUuid on every stream envelope + filter key + lifecycle events

### DIFF
--- a/docs/design-docs/mcp/daemon/client-screen-control.md
+++ b/docs/design-docs/mcp/daemon/client-screen-control.md
@@ -63,21 +63,29 @@ subscription. One connection can hold any number of independent subscriptions.
 
 ```json
 // client -> daemon
-{ "id": "1", "command": "subscribe", "deviceId": "emulator-5554" }
+{ "id": "1", "command": "subscribe", "deviceSessionUuid": "d1f0c2a4-…" }
 // daemon -> client
 { "id": "1", "type": "subscription_response", "success": true, "subscriptionId": "devicedatastream-1" }
 ```
 
-- `deviceId` is **optional**: omit it (or send `null`) to receive frames for **all** devices; pass a
-  specific id to receive only that device's frames. A control client should subscribe to the one
-  device the user selected.
+- `deviceSessionUuid` is the **routing key** (epic [#5256](https://github.com/kaeawc/auto-mobile/issues/5256)) and is **optional**:
+  omit it (or send `null`) to receive frames for **all** devices; pass a specific value to receive
+  only that device's frames. A control client should subscribe to the `deviceSessionUuid` of the one
+  device the user selected. The uuid is daemon-minted per **device connection epoch** — it is
+  retired on disconnect and a fresh one is minted on reconnect even when the serial/UDID is
+  identical, so it is stable where the raw `deviceId` (serial/UDID) is not. Discover the current
+  uuid for each connected device via the `listDeviceSessions` daemon command, then keep it current
+  from the `device_session_started` / `device_session_ended` lifecycle frames (below). Subscribing
+  with a **retired** uuid matches nothing (it never re-attaches to a reused serial) rather than
+  silently attaching to the reincarnated device. The raw `deviceId` is **no longer** a subscribe
+  filter — it remains only as a human-facing label on each frame.
 - Optional `screenshotIntervalMs` / `hierarchyIntervalMs` on the `subscribe` request set the capture
   cadence (daemon defaults: screenshot 3000 ms, hierarchy 1000 ms; minimum 250 ms). To change
   cadence in place later, send `{ "command": "update_cadence", "subscriptionId":
 "devicedatastream-1", "screenshotIntervalMs": …, "hierarchyIntervalMs": … }`; to stop, send
   `{ "command": "unsubscribe", "subscriptionId": "devicedatastream-1" }`.
 - Every pushed frame includes the `subscriptionId` that produced it, allowing a multiplexing client
-  to demultiplex independently of the frame's `deviceId`.
+  to demultiplex independently of the frame's `deviceSessionUuid`.
 
 ### Keepalive (ping/pong) — required to stay connected
 
@@ -116,8 +124,10 @@ never answers pings is disconnected in that window — even while it is happily 
 
 ### Pushed messages
 
-Every push carries a `type`, the `deviceId` it belongs to, and a display-only `timestamp`. Pair
-frames **only** across messages with the same `deviceId`.
+Every push carries a `type`, the `deviceSessionUuid` it belongs to (the epoch-stable routing key,
+`null` only on an unattributable frame), the raw `deviceId` label, and a display-only `timestamp`.
+Pair frames **only** across messages with the same `deviceSessionUuid` — it survives a same-serial
+reconnect that `deviceId` does not.
 
 **`hierarchy_update`** — the element tree. Carries a `captureSequence` and, on current
 CtrlProxy runners, a device-authored `frameContext`.
@@ -125,6 +135,7 @@ CtrlProxy runners, a device-authored `frameContext`.
 ```json
 {
   "type": "hierarchy_update",
+  "deviceSessionUuid": "d1f0c2a4-…",
   "deviceId": "emulator-5554",
   "timestamp": 1737942000123,
   "data": { "hierarchy": { "…": "ViewHierarchyResult with element bounds" } },
@@ -143,6 +154,7 @@ field is **absent** and a control client must fail closed for that frame.
 ```json
 {
   "type": "screenshot_update",
+  "deviceSessionUuid": "d1f0c2a4-…",
   "deviceId": "emulator-5554",
   "timestamp": 1737942000456,
   "screenshotBase64": "<PNG bytes, base64>",
@@ -156,9 +168,23 @@ field is **absent** and a control client must fail closed for that frame.
 ```
 
 **`error`** — a device-side problem (e.g. connection lost):
-`{ "type": "error", "deviceId": "…", "timestamp": …, "error": "device connection lost" }`.
+`{ "type": "error", "deviceSessionUuid": "…", "deviceId": "…", "timestamp": …, "error": "device connection lost" }`.
 
-(The stream also pushes `navigation_update`, `performance_update`, and `storage_update`; a control
+**`device_session_started` / `device_session_ended`** — device-session lifecycle (epic
+[#5256](https://github.com/kaeawc/auto-mobile/issues/5256)). Emitted when the daemon mints or retires a
+`deviceSessionUuid`, so a consumer flushes per-device state on a real epoch boundary instead of
+guessing from serial reuse. A same-serial reconnect surfaces as an `ended` for the old uuid
+immediately followed by a `started` for the new one.
+`{ "type": "device_session_started", "deviceSessionUuid": "…", "deviceId": "emulator-5554", "platform": "android", "timestamp": … }`.
+Because a `device_session_started` frame announces a **brand-new** uuid, only an **all-devices**
+(`null`-filter) subscription observes it — a uuid-scoped subscription cannot yet be filtered on a
+uuid it has not learned. A client that must track the full device set therefore runs at least one
+all-devices subscription, and **enumerates existing devices via `listDeviceSessions` on connect**:
+devices already booted when the daemon started mint their epoch before the observation-stream
+server exists, so they emit no `started` frame and are discoverable only by enumeration.
+
+(The stream also pushes `navigation_update` — now targeted at the owning device's
+`deviceSessionUuid` rather than broadcast — `performance_update`, and `storage_update`; a control
 client ignores them.)
 
 ### Coordinates: one unit, no platform knowledge required
@@ -230,10 +256,12 @@ also what lets the retained-frame rule below notice a transition _into_ an unkno
 - **Release availability:** the default `0.0.58` CtrlProxy artifacts predate `frameContext`
   support. Use runners built from a revision that publishes the field before enabling this control
   flow; otherwise treat the runner as legacy and keep the mirror in inspector mode.
-- **Active device:** every message's `deviceId` identifies its device. Subscribe with the selected
-  device's id (rather than the all-devices `null`) so you only receive its frames, and still confirm
-  each message's `deviceId` matches the selection before pairing — a lingering frame from a
-  previously-selected device must not pair with the new one.
+- **Active device:** every message's `deviceSessionUuid` identifies its device epoch. Subscribe with
+  the selected device's `deviceSessionUuid` (rather than the all-devices `null`) so you only receive
+  its frames, and still confirm each message's `deviceSessionUuid` matches the selection before
+  pairing — a lingering frame from a previously-selected device (or a pre-reconnect epoch) must not
+  pair with the new one. On `device_session_ended` for the selected uuid, stop pairing and re-select
+  from the device's new epoch.
 
 ## Implementing a client, end to end
 

--- a/scripts/typecheck-baseline.txt
+++ b/scripts/typecheck-baseline.txt
@@ -83,14 +83,14 @@ src/features/navigation/Explore.ts: error TS2740: Type 'AdbExecutor' is missing 
 src/features/navigation/Explore.ts: error TS2740: Type 'AdbExecutor' is missing the following properties from type 'AdbClient': device, execAsync, spawnFn, adbPath, and 30 more.
 src/features/navigation/Explore.ts: error TS2740: Type 'AdbExecutor' is missing the following properties from type 'AdbClient': device, execAsync, spawnFn, adbPath, and 30 more.
 src/features/navigation/Explore.ts: error TS2740: Type 'AdbExecutor' is missing the following properties from type 'AdbClient': device, execAsync, spawnFn, adbPath, and 30 more.
-src/features/navigation/Explore.ts: error TS2740: Type 'NavigationGraphService' is missing the following properties from type 'NavigationGraphManager': repository, testCoverageRepository, timer, currentAppId, and 31 more.
-src/features/navigation/Explore.ts: error TS2740: Type 'NavigationGraphService' is missing the following properties from type 'NavigationGraphManager': repository, testCoverageRepository, timer, currentAppId, and 31 more.
+src/features/navigation/Explore.ts: error TS2740: Type 'NavigationGraphService' is missing the following properties from type 'NavigationGraphManager': repository, testCoverageRepository, timer, currentAppId, and 32 more.
+src/features/navigation/Explore.ts: error TS2740: Type 'NavigationGraphService' is missing the following properties from type 'NavigationGraphManager': repository, testCoverageRepository, timer, currentAppId, and 32 more.
 src/features/navigation/ExploreElementExtraction.ts: error TS2322: Type '{}' is not assignable to type 'string'.
 src/features/navigation/ExploreElementExtraction.ts: error TS2322: Type '{}' is not assignable to type 'string'.
 src/features/navigation/ExploreElementExtraction.ts: error TS2322: Type '{}' is not assignable to type 'string'.
 src/features/navigation/NavigateTo.ts: error TS2459: Module '"./NavigationGraphManager"' declares 'ToolCallInteraction' locally, but it is not exported.
 src/features/navigation/NavigateTo.ts: error TS2740: Type 'AdbExecutor' is missing the following properties from type 'AdbClient': device, execAsync, spawnFn, adbPath, and 30 more.
-src/features/navigation/NavigateTo.ts: error TS2740: Type 'NavigationGraphService' is missing the following properties from type 'NavigationGraphManager': repository, testCoverageRepository, timer, currentAppId, and 31 more.
+src/features/navigation/NavigateTo.ts: error TS2740: Type 'NavigationGraphService' is missing the following properties from type 'NavigationGraphManager': repository, testCoverageRepository, timer, currentAppId, and 32 more.
 src/features/navigation/NavigationGraphManager.ts: error TS2345: Argument of type 'number | undefined' is not assignable to parameter of type 'number'.
 src/features/navigation/UIStateExtractor.ts: error TS2741: Property '$' is missing in type 'Record<string, any>' but required in type 'ViewHierarchyNode'.
 src/features/observe/DeviceServiceUtils.ts: error TS2694: Namespace '"src/features/observe/DeviceService"' has no exported member 'ImeActionResult'.
@@ -206,7 +206,7 @@ src/utils/ios-cmdline-tools/XcodeSigning.ts: error TS2322: Type 'Promise<string 
 # swap-fp: 14 :: src/features/accessibility/WcagAudit.ts: error TS2352: Conversion of type 'ViewHierarchyNode[]' to type 'ViewHierarchyNode' may be a mistake because neither type sufficiently overlaps with the other. If this was intentional, convert the expression to 'unknown' first.
 # swap-fp: 149 :: src/server/navigationTools.ts: error TS2339: Property 'coverage' does not exist on type 'ExploreExecutionResult'.
 # swap-fp: 15 :: src/server/networkTools.ts: error TS2459: Module '"../utils/deviceUtils"' declares 'BootedDevice' locally, but it is not exported.
-# swap-fp: 15,67 :: src/features/navigation/Explore.ts: error TS2740: Type 'NavigationGraphService' is missing the following properties from type 'NavigationGraphManager': repository, testCoverageRepository, timer, currentAppId, and 31 more.
+# swap-fp: 15,67 :: src/features/navigation/Explore.ts: error TS2740: Type 'NavigationGraphService' is missing the following properties from type 'NavigationGraphManager': repository, testCoverageRepository, timer, currentAppId, and 32 more.
 # swap-fp: 159,161 :: src/features/action/BaseVisualChange.ts: error TS2339: Property 'signal' does not exist on type '{ changeExpected: boolean; tolerancePercent?: number | undefined; queryOptions?: ViewHierarchyQueryOptions | undefined; gfxMetrics?: GfxMetrics | null | undefined; perf?: PerformanceTracker | undefined; actionStartTime?: number | undefined; predictionContext?: PredictionActionContext | undefined; }'.
 # swap-fp: 16 :: src/server/compactBoundsAdvertisement.ts: error TS2698: Spread types may only be created from object types.
 # swap-fp: 18 :: src/server/appFileService.ts: error TS2430: Interface 'PutAppFileRequest' incorrectly extends interface 'PutAppFileArgs'.
@@ -284,7 +284,7 @@ src/utils/ios-cmdline-tools/XcodeSigning.ts: error TS2322: Type 'Promise<string 
 # swap-fp: 67,73 :: src/features/utility/ElementFinder.ts: error TS4104: The type 'readonly string[]' is 'readonly' and cannot be assigned to the mutable type 'string[]'.
 # swap-fp: 7 :: src/features/action/swipeon/SwipeOn.ts: error TS2322: Type '(block: (observeResult: ObserveResult) => Promise<any>, options: ObservedChangeOptions) => Promise<any>' is not assignable to type '<T>(action: (observeResult: ObserveResult) => Promise<T>, options: { changeExpected: boolean; timeoutMs: number; progress?: unknown; perf?: PerformanceTracker | undefined; skipPreviousObserve?: boolean | undefined; queryOptions?: { ...; } | undefined; predictionContext?: { ...; } | undefined; }) => Promise<...>'.
 # swap-fp: 7 :: src/features/action/swipeon/SwipeOn.ts: error TS2322: Type 'AndroidCtrlProxyClient' is not assignable to type 'ScrollAccessibilityService'.
-# swap-fp: 7 :: src/features/navigation/NavigateTo.ts: error TS2740: Type 'NavigationGraphService' is missing the following properties from type 'NavigationGraphManager': repository, testCoverageRepository, timer, currentAppId, and 31 more.
+# swap-fp: 7 :: src/features/navigation/NavigateTo.ts: error TS2740: Type 'NavigationGraphService' is missing the following properties from type 'NavigationGraphManager': repository, testCoverageRepository, timer, currentAppId, and 32 more.
 # swap-fp: 7 :: src/features/observe/Idle.ts: error TS2741: Property 'updatedPrevTotalFrames' is missing in type '{ isStable: false; shouldUpdateLastNonIdleTime: true; updatedPrevMissedVsync: null; updatedPrevSlowUiThread: null; updatedPrevFrameDeadlineMissed: null; updatedFirstGfxInfoLog: false; }' but required in type 'UiStabilityResult'.
 # swap-fp: 7 :: src/index.ts: error TS2322: Type '["debug", boolean, string]' is not assignable to type '[FeatureFlagKey, boolean, string, Record<string, unknown> | null | undefined]'.
 # swap-fp: 7 :: src/index.ts: error TS2322: Type '["debug-perf", boolean, string]' is not assignable to type '[FeatureFlagKey, boolean, string, Record<string, unknown> | null | undefined]'.

--- a/src/daemon/daemon.ts
+++ b/src/daemon/daemon.ts
@@ -52,11 +52,12 @@ import { startTestRecordingSocketServer, stopTestRecordingSocketServer } from ".
 import { startDeviceSnapshotSocketServer, stopDeviceSnapshotSocketServer } from "./deviceSnapshotSocketServer";
 import { startAppearanceSocketServer, stopAppearanceSocketServer } from "./appearanceSocketServer";
 import { startPerformanceStreamSocketServer, stopPerformanceStreamSocketServer } from "./performanceStreamSocketServer";
-import { startPerformancePushSocketServer, stopPerformancePushSocketServer } from "./performancePushSocketServer";
+import { startPerformancePushSocketServer, stopPerformancePushSocketServer, getPerformancePushServer } from "./performancePushSocketServer";
 import { startDeviceDataStreamSocketServer, stopDeviceDataStreamSocketServer, getDeviceDataStreamServer } from "./deviceDataStreamSocketServer";
 import { startFailuresStreamSocketServer, stopFailuresStreamSocketServer } from "./failuresStreamSocketServer";
-import { startFailuresPushSocketServer, stopFailuresPushSocketServer } from "./failuresPushSocketServer";
-import { startTelemetryPushSocketServer, stopTelemetryPushSocketServer } from "./telemetryPushSocketServer";
+import { startFailuresPushSocketServer, stopFailuresPushSocketServer, getFailuresPushServer } from "./failuresPushSocketServer";
+import { startTelemetryPushSocketServer, stopTelemetryPushSocketServer, getTelemetryPushServer } from "./telemetryPushSocketServer";
+import { createRegistryDeviceSessionResolver } from "./deviceSessionResolver";
 import { startWebRtcStreamSocketServer, stopWebRtcStreamSocketServer } from "./webrtcStreamSocketServer";
 import { startVideoStreamSocketServer, stopVideoStreamSocketServer } from "./videoStreamSocketServer";
 import { getDaemonSocketPathsByName } from "./socketPaths";
@@ -436,6 +437,10 @@ export class Daemon {
 
     // Wire up callback to establish WebSocket connections when IDE plugins subscribe
     this.setupDeviceDataStreamCallback();
+
+    // Wire the device-session routing key (epic #5256, item 3): give every push
+    // server the serial↔deviceSessionUuid resolver, and stream session lifecycle.
+    this.setupDeviceSessionRouting();
 
     startAppearanceSyncScheduler();
     startPerformanceMonitor();
@@ -958,6 +963,28 @@ export class Daemon {
    * the WebSocket connections to Android devices are established so that
    * hierarchy updates can flow continuously.
    */
+  /**
+   * Give every push socket server the serial↔`deviceSessionUuid` resolver so it can
+   * stamp the epoch key on outgoing frames and route subscriptions on it, and wire
+   * the registry's connect/disconnect transitions to `device_session_started` /
+   * `device_session_ended` frames on the observation stream (epic #5256, item 3).
+   */
+  private setupDeviceSessionRouting(): void {
+    const resolver = createRegistryDeviceSessionResolver(this.deviceSessionRegistry);
+    const deviceDataStream = getDeviceDataStreamServer();
+    deviceDataStream?.setDeviceSessionResolver(resolver);
+    getPerformancePushServer()?.setDeviceSessionResolver(resolver);
+    getFailuresPushServer()?.setDeviceSessionResolver(resolver);
+    getTelemetryPushServer()?.setDeviceSessionResolver(resolver);
+
+    if (deviceDataStream) {
+      this.deviceSessionRegistry.setLifecycleListener({
+        onSessionStarted: record => deviceDataStream.pushDeviceSessionStarted(record),
+        onSessionEnded: record => deviceDataStream.pushDeviceSessionEnded(record),
+      });
+    }
+  }
+
   private setupDeviceDataStreamCallback(): void {
     const server = getDeviceDataStreamServer();
     if (!server) {
@@ -1117,7 +1144,10 @@ export class Daemon {
         logger.info(`[Daemon] Got summary: appId=${summary.appId}, nodes=${summary.nodes.length}, edges=${summary.edges.length}`);
 
         const streamData = convertSummaryToStreamData(summary);
-        server.pushNavigationGraphUpdate(streamData);
+        // Attribute the update to the device that owns this app's graph so panes
+        // watching other devices are not cross-contaminated (epic #5256; #4837).
+        const deviceId = navGraphManager.getDeviceIdForApp(summary.appId);
+        server.pushNavigationGraphUpdate(streamData, deviceId);
 
         logger.info(`[Daemon] Pushed navigation graph update: ${summary.nodes.length} nodes, ${summary.edges.length} edges`);
       } catch (error) {

--- a/src/daemon/deviceDataStreamSocketServer.ts
+++ b/src/daemon/deviceDataStreamSocketServer.ts
@@ -6,8 +6,10 @@ import {
   getSocketPath,
   SubscriptionResponse,
 } from "./socketServer/index";
-import type { ObserveResult, ViewHierarchyResult } from "../models";
+import type { ObserveResult, Platform, ViewHierarchyResult } from "../models";
 import type { StorageChangedEvent } from "../features/storage/storageTypes";
+import { type DeviceSessionResolver, nullDeviceSessionResolver } from "./deviceSessionResolver";
+import type { DeviceSessionRecord } from "./deviceSessionRegistry";
 import { DEVICE_DATA_STREAM_SOCKET_CONFIG } from "./daemonFiles";
 import type { ScreenshotMetadata } from "../features/observe/ScreenshotMetadata";
 import { annotateHierarchyDiff, type HierarchyDiffSummary } from "./hierarchyStreamDiff";
@@ -84,12 +86,23 @@ interface DeviceDataStreamMessage extends ScreenshotMetadata {
     | "navigation_update"
     | "performance_update"
     | "storage_update"
+    | "device_session_started"
+    | "device_session_ended"
     | "ping"
     | "pong"
     | "error";
   success?: boolean;
   error?: string;
   deviceId?: string;
+  /**
+   * Stable device-session routing key for this frame's device epoch (epic #5256,
+   * item 3). Present on every device-attributed frame — resolved from `deviceId`
+   * by the server at push time — and on the lifecycle frames. `null` when no live
+   * epoch maps to the serial (e.g. a navigation broadcast with unknown provenance).
+   */
+  deviceSessionUuid?: string | null;
+  /** Device platform. Carried on `device_session_started`/`device_session_ended` frames. */
+  platform?: Platform;
   timestamp?: number;
   data?: ViewHierarchyResult;
   screenshotBase64?: string;
@@ -206,19 +219,29 @@ interface PushScreenshotOptions {
 
 /**
  * Filter for device data stream subscriptions.
+ *
+ * `deviceSessionUuid` is the primary routing key (epic #5256, item 3): frame
+ * delivery matches on it (`null` = every device). `deviceId` is the serial
+ * resolved from that uuid at subscribe time and is used ONLY by the serial-scoped
+ * cadence/polling machinery (which device to poll, at what interval) — it is never
+ * the delivery key. The two are separated on purpose: routing is epoch-stable,
+ * polling is inherently serial-addressed.
  */
 interface DeviceDataFilter {
-  deviceId: string | null; // null means subscribe to all devices
+  deviceSessionUuid: string | null; // null means subscribe to all devices
+  deviceId: string | null; // serial resolved from deviceSessionUuid, for cadence only
   screenshotIntervalMs: number | null;
   hierarchyIntervalMs: number | null;
 }
 
 /**
- * Push data wrapper - used internally for type safety with base class.
+ * Push data wrapper - used internally for type safety with base class. Routing is
+ * on `targetDeviceSessionUuid`; `null` reaches only all-device (`null`-filter)
+ * subscribers (there is no cross-device broadcast — see `matchesFilter`).
  */
 interface DeviceDataPush {
   message: DeviceDataStreamMessage;
-  targetDeviceId: string | null; // null for broadcast to all
+  targetDeviceSessionUuid: string | null;
 }
 
 /**
@@ -301,6 +324,7 @@ export class DeviceDataStreamSocketServer extends PushSubscriptionSocketServer<
   getCurrentFrameContext(deviceId: string): string | undefined {
     return this.currentFrameContexts.get(deviceId);
   }
+  private deviceSessionResolver: DeviceSessionResolver = nullDeviceSessionResolver;
   private onSubscriberConnected: OnSubscriberConnectedCallback | null = null;
   private onScreenshotCadenceChanged: OnScreenshotCadenceChangedCallback | null = null;
   private onHierarchyCadenceChanged: OnHierarchyCadenceChangedCallback | null = null;
@@ -324,6 +348,24 @@ export class DeviceDataStreamSocketServer extends PushSubscriptionSocketServer<
     timer: Timer = defaultTimer,
   ) {
     super(socketPath, timer, "DeviceDataStream");
+  }
+
+  /** Wire the serial↔`deviceSessionUuid` resolver used to stamp frames and route on the epoch key. */
+  setDeviceSessionResolver(resolver: DeviceSessionResolver): void {
+    this.deviceSessionResolver = resolver;
+  }
+
+  /**
+   * Stamp a device-attributed frame with the live `deviceSessionUuid` for its
+   * serial and push it, routing on that uuid. A serial with no live epoch resolves
+   * to `null`, reaching only all-device subscribers.
+   */
+  private pushForDevice(deviceId: string, message: DeviceDataStreamMessage): number {
+    const deviceSessionUuid = this.deviceSessionResolver.resolveUuid(deviceId);
+    return this.pushToSubscribers({
+      message: { ...message, deviceSessionUuid },
+      targetDeviceSessionUuid: deviceSessionUuid,
+    });
   }
 
   /**
@@ -434,7 +476,7 @@ export class DeviceDataStreamSocketServer extends PushSubscriptionSocketServer<
       rotation: hierarchy.rotation,
     };
 
-    const sentCount = this.pushToSubscribers({ message, targetDeviceId: deviceId });
+    const sentCount = this.pushForDevice(deviceId, message);
     if (sentCount > 0) {
       logger.debug(
         `[DeviceDataStream] Pushed hierarchy_update to ${sentCount} subscribers (device: ${deviceId})`,
@@ -506,7 +548,7 @@ export class DeviceDataStreamSocketServer extends PushSubscriptionSocketServer<
       screenshotByteLength,
       screenshotBase64Length,
     };
-    const sentCount = this.pushToSubscribers({ message, targetDeviceId: deviceId });
+    const sentCount = this.pushForDevice(deviceId, message);
     if (sentCount > 0) {
       logger.debug(
         `[DeviceDataStream] Pushed screenshot_update to ${sentCount} subscribers (device: ${deviceId})`,
@@ -515,19 +557,68 @@ export class DeviceDataStreamSocketServer extends PushSubscriptionSocketServer<
   }
 
   /**
-   * Push a navigation graph update to all subscribers.
-   * Navigation graph updates are broadcast to all subscribers (not device-specific).
+   * Push a navigation graph update, targeting the device whose graph changed
+   * (epic #5256, item 3 — closes #4837, which cross-contaminated panes because
+   * this broadcast to every subscriber). The daemon resolves the graph's owning
+   * serial from the app's build context; `deviceId` is `null` only when that
+   * provenance is unknown, in which case the frame reaches all-device subscribers
+   * (`null` filter) but never a specific device's pane.
    */
-  pushNavigationGraphUpdate(navigationGraph: NavigationGraphStreamData): void {
+  pushNavigationGraphUpdate(
+    navigationGraph: NavigationGraphStreamData,
+    deviceId: string | null,
+  ): void {
+    const deviceSessionUuid = deviceId ? this.deviceSessionResolver.resolveUuid(deviceId) : null;
     const message: DeviceDataStreamMessage = {
       type: "navigation_update",
+      deviceId: deviceId ?? undefined,
+      deviceSessionUuid,
       timestamp: this.timer.now(),
       navigationGraph,
     };
 
-    const sentCount = this.pushToSubscribers({ message, targetDeviceId: null });
+    const sentCount = this.pushToSubscribers({
+      message,
+      targetDeviceSessionUuid: deviceSessionUuid,
+    });
     if (sentCount > 0) {
       logger.debug(`[DeviceDataStream] Pushed navigation_update to ${sentCount} subscribers`);
+    }
+  }
+
+  /**
+   * Push a device-session lifecycle frame so consumers flush per-device state on a
+   * real epoch boundary (epic #5256, item 3). Emitted from the registry's
+   * connect/disconnect transitions; targets the session's own uuid so both a
+   * device-scoped pane and an all-device hub observe the transition.
+   */
+  pushDeviceSessionStarted(record: DeviceSessionRecord): void {
+    this.pushDeviceSessionLifecycle("device_session_started", record);
+  }
+
+  pushDeviceSessionEnded(record: DeviceSessionRecord): void {
+    this.pushDeviceSessionLifecycle("device_session_ended", record);
+  }
+
+  private pushDeviceSessionLifecycle(
+    type: "device_session_started" | "device_session_ended",
+    record: DeviceSessionRecord,
+  ): void {
+    const message: DeviceDataStreamMessage = {
+      type,
+      deviceId: record.deviceId,
+      deviceSessionUuid: record.deviceSessionUuid,
+      platform: record.platform,
+      timestamp: this.timer.now(),
+    };
+    const sentCount = this.pushToSubscribers({
+      message,
+      targetDeviceSessionUuid: record.deviceSessionUuid,
+    });
+    if (sentCount > 0) {
+      logger.debug(
+        `[DeviceDataStream] Pushed ${type} to ${sentCount} subscribers (device: ${record.deviceId}, session: ${record.deviceSessionUuid})`,
+      );
     }
   }
 
@@ -542,7 +633,7 @@ export class DeviceDataStreamSocketServer extends PushSubscriptionSocketServer<
       performanceData,
     };
 
-    const sentCount = this.pushToSubscribers({ message, targetDeviceId: deviceId });
+    const sentCount = this.pushForDevice(deviceId, message);
     if (sentCount > 0) {
       logger.debug(
         `[DeviceDataStream] Pushed performance_update to ${sentCount} subscribers (device: ${deviceId})`,
@@ -561,7 +652,7 @@ export class DeviceDataStreamSocketServer extends PushSubscriptionSocketServer<
       storageEvent: event,
     };
 
-    const sentCount = this.pushToSubscribers({ message, targetDeviceId: deviceId });
+    const sentCount = this.pushForDevice(deviceId, message);
     if (sentCount > 0) {
       logger.debug(
         `[DeviceDataStream] Pushed storage_update to ${sentCount} subscribers (device: ${deviceId})`,
@@ -573,25 +664,28 @@ export class DeviceDataStreamSocketServer extends PushSubscriptionSocketServer<
    * Return true when at least one active subscriber would receive updates for this device.
    */
   hasSubscriberForDevice(deviceId: string): boolean {
-    const probe: DeviceDataPush = {
-      message: {
-        type: "screenshot_update",
-        deviceId,
-      },
-      targetDeviceId: deviceId,
-    };
-
     for (const subscriber of this.subscribers.values()) {
       if (subscriber.backfilling || subscriber.socket.destroyed) {
         continue;
       }
 
-      if (this.matchesFilter(subscriber.filter, probe)) {
+      if (this.subscriberWantsDevice(subscriber.filter, deviceId)) {
         return true;
       }
     }
 
     return false;
+  }
+
+  /**
+   * Whether a subscription's serial-scoped cadence applies to this device. This is
+   * the POLLING question (which serial to poll, how fast), kept separate from frame
+   * routing (`matchesFilter`, on `deviceSessionUuid`): the cadence machinery is
+   * inherently serial-addressed, and `filter.deviceId` is the serial resolved for
+   * exactly this purpose. `null` = an all-devices subscription.
+   */
+  private subscriberWantsDevice(filter: DeviceDataFilter, deviceId: string): boolean {
+    return filter.deviceId === null || filter.deviceId === deviceId;
   }
 
   /**
@@ -601,7 +695,6 @@ export class DeviceDataStreamSocketServer extends PushSubscriptionSocketServer<
   getScreenshotIntervalMsForDevice(deviceId: string): number {
     return this.getFastestIntervalMsForDevice(
       deviceId,
-      "screenshot_update",
       DEFAULT_SCREENSHOT_INTERVAL_MS,
       (filter) => filter.screenshotIntervalMs,
       true,
@@ -618,7 +711,6 @@ export class DeviceDataStreamSocketServer extends PushSubscriptionSocketServer<
   ): number {
     return this.getFastestIntervalMsForDevice(
       deviceId,
-      "hierarchy_update",
       defaultIntervalMs,
       (filter) => filter.hierarchyIntervalMs,
       false,
@@ -627,18 +719,10 @@ export class DeviceDataStreamSocketServer extends PushSubscriptionSocketServer<
 
   private getFastestIntervalMsForDevice(
     deviceId: string,
-    messageType: "screenshot_update" | "hierarchy_update",
     defaultIntervalMs: number,
     getRequestedIntervalMs: (filter: DeviceDataFilter) => number | null,
     useDefaultWhenRequestMissing: boolean,
   ): number {
-    const probe: DeviceDataPush = {
-      message: {
-        type: messageType,
-        deviceId,
-      },
-      targetDeviceId: deviceId,
-    };
     let fastestIntervalMs: number | null = null;
 
     for (const subscriber of this.subscribers.values()) {
@@ -646,7 +730,7 @@ export class DeviceDataStreamSocketServer extends PushSubscriptionSocketServer<
         continue;
       }
 
-      if (!this.matchesFilter(subscriber.filter, probe)) {
+      if (!this.subscriberWantsDevice(subscriber.filter, deviceId)) {
         continue;
       }
 
@@ -682,7 +766,7 @@ export class DeviceDataStreamSocketServer extends PushSubscriptionSocketServer<
       error: "device connection lost",
     };
 
-    const sentCount = this.pushToSubscribers({ message, targetDeviceId: deviceId });
+    const sentCount = this.pushForDevice(deviceId, message);
     if (sentCount > 0) {
       logger.debug(
         `[DeviceDataStream] Pushed device connection lost error to ${sentCount} subscribers (device: ${deviceId})`,
@@ -698,6 +782,7 @@ export class DeviceDataStreamSocketServer extends PushSubscriptionSocketServer<
       id?: string;
       command: string;
       deviceId?: string;
+      deviceSessionUuid?: string;
       appId?: string;
       screenshotIntervalMs?: unknown;
       hierarchyIntervalMs?: unknown;
@@ -735,9 +820,16 @@ export class DeviceDataStreamSocketServer extends PushSubscriptionSocketServer<
       try {
         const graphData = await this.onNavigationGraphRequested(request.appId ?? null);
         if (graphData) {
+          // Echo the requester's device-session key so the pane can attribute this
+          // on-demand response to its own device (epic #5256, item 3; #4837 AC2).
+          const deviceSessionUuid = request.deviceSessionUuid ?? null;
           const message: DeviceDataStreamMessage = {
             id: request.id,
             type: "navigation_update",
+            deviceSessionUuid,
+            deviceId: deviceSessionUuid
+              ? this.deviceSessionResolver.resolveDeviceId(deviceSessionUuid) ?? undefined
+              : undefined,
             timestamp: this.timer.now(),
             navigationGraph: graphData,
           };
@@ -768,13 +860,19 @@ export class DeviceDataStreamSocketServer extends PushSubscriptionSocketServer<
       // Let base class handle the subscription
       await super.processLine(socket, line);
 
-      this.notifyScreenshotCadenceChanged(request.deviceId ?? null);
-      this.notifyHierarchyCadenceChanged(request.deviceId ?? null);
+      // The wire now targets a deviceSessionUuid; the cadence/connect machinery is
+      // serial-scoped, so resolve to the current serial (null = all devices).
+      const subscribedDeviceId = request.deviceSessionUuid
+        ? this.deviceSessionResolver.resolveDeviceId(request.deviceSessionUuid)
+        : null;
+
+      this.notifyScreenshotCadenceChanged(subscribedDeviceId);
+      this.notifyHierarchyCadenceChanged(subscribedDeviceId);
 
       // Trigger the callback if set
       if (this.onSubscriberConnected) {
         try {
-          this.onSubscriberConnected(request.deviceId ?? null);
+          this.onSubscriberConnected(subscribedDeviceId);
         } catch (error) {
           logger.warn(`[DeviceDataStream] Error in onSubscriberConnected callback: ${error}`);
         }
@@ -851,20 +949,28 @@ export class DeviceDataStreamSocketServer extends PushSubscriptionSocketServer<
   }
 
   protected parseSubscriptionFilter(request: Record<string, unknown>): DeviceDataFilter {
+    const deviceSessionUuid = (request.deviceSessionUuid as string) ?? null;
     return {
-      deviceId: (request.deviceId as string) ?? null,
+      deviceSessionUuid,
+      // Resolve the serial once, at subscribe time, for the serial-scoped cadence
+      // machinery. Within an epoch the serial is stable, so a snapshot is safe.
+      deviceId: deviceSessionUuid
+        ? this.deviceSessionResolver.resolveDeviceId(deviceSessionUuid)
+        : null,
       screenshotIntervalMs: this.parseScreenshotIntervalMs(request.screenshotIntervalMs),
       hierarchyIntervalMs: this.parseHierarchyIntervalMs(request.hierarchyIntervalMs),
     };
   }
 
   protected matchesFilter(filter: DeviceDataFilter, data: DeviceDataPush): boolean {
-    // If targetDeviceId is null, broadcast to all subscribers
-    if (data.targetDeviceId === null) {
-      return true;
-    }
-    // Send to subscribers that want all devices or specifically this device
-    return filter.deviceId === null || filter.deviceId === data.targetDeviceId;
+    // Route on the stable epoch key. A `null` target reaches only all-device
+    // (`null`-filter) subscribers — there is no cross-device broadcast, so a frame
+    // for one device (or a retired epoch, which resolves to `null`) can never leak
+    // into another device's subscription (epic #5256, AC2/AC4; closes #4837).
+    return (
+      filter.deviceSessionUuid === null ||
+      filter.deviceSessionUuid === data.targetDeviceSessionUuid
+    );
   }
 
   protected createPushMessage(

--- a/src/daemon/deviceSessionRegistry.ts
+++ b/src/daemon/deviceSessionRegistry.ts
@@ -1,5 +1,6 @@
 import { defaultTimer, type Timer } from "../utils/SystemTimer";
 import { defaultIdGenerator, type IdGenerator } from "../utils/IdGenerator";
+import { logger } from "../utils/logger";
 import type { Platform } from "../models";
 
 /**
@@ -43,6 +44,20 @@ interface LiveEntry {
 }
 
 /**
+ * Observer of device-session epoch transitions.
+ *
+ * The daemon wires this to push `device_session_started` / `device_session_ended`
+ * lifecycle frames onto the observation stream (epic #5256, item 3) so a consumer
+ * flushes per-device state on a real epoch boundary instead of guessing from serial
+ * reuse. A same-serial reincarnation surfaces as `onSessionEnded(old)` immediately
+ * followed by `onSessionStarted(new)`.
+ */
+export interface DeviceSessionLifecycleListener {
+  onSessionStarted(record: DeviceSessionRecord): void;
+  onSessionEnded(record: DeviceSessionRecord): void;
+}
+
+/**
  * Process-lifetime map of `deviceId (serial/UDID) ↔ deviceSessionUuid`, the
  * single source of truth for device-session identity across the daemon's
  * stream API. Purely in-memory: an epoch is meaningless across daemon restarts,
@@ -53,10 +68,38 @@ export class DeviceSessionRegistry {
   private readonly idGenerator: IdGenerator;
   private readonly byDeviceId = new Map<string, LiveEntry>();
   private readonly uuidToDeviceId = new Map<string, string>();
+  private lifecycleListener: DeviceSessionLifecycleListener | null = null;
 
   constructor(timer: Timer = defaultTimer, idGenerator: IdGenerator = defaultIdGenerator) {
     this.timer = timer;
     this.idGenerator = idGenerator;
+  }
+
+  /**
+   * Register (or clear, with `null`) the observer notified on epoch transitions.
+   * Wired by the daemon after the observation-stream server is up.
+   */
+  setLifecycleListener(listener: DeviceSessionLifecycleListener | null): void {
+    this.lifecycleListener = listener;
+  }
+
+  private emitStarted(record: DeviceSessionRecord): void {
+    try {
+      this.lifecycleListener?.onSessionStarted(record);
+    } catch (error) {
+      // A lifecycle observer must never break identity bookkeeping — swallow and
+      // keep the registry authoritative; trace at debug for diagnosis.
+      logger.debug(`[DeviceSessionRegistry] onSessionStarted listener threw: ${error}`);
+    }
+  }
+
+  private emitEnded(record: DeviceSessionRecord): void {
+    try {
+      this.lifecycleListener?.onSessionEnded(record);
+    } catch (error) {
+      // See emitStarted: swallow observer faults, keep the registry authoritative.
+      logger.debug(`[DeviceSessionRegistry] onSessionEnded listener threw: ${error}`);
+    }
   }
 
   /**
@@ -74,8 +117,10 @@ export class DeviceSessionRegistry {
     }
     if (existing) {
       // Superseded epoch (new incarnation for the same serial) — drop its uuid
-      // so a stale reference cannot resolve to the reincarnated device.
+      // so a stale reference cannot resolve to the reincarnated device, and
+      // surface the boundary as an end of the old epoch before the new one starts.
       this.uuidToDeviceId.delete(existing.record.deviceSessionUuid);
+      this.emitEnded(existing.record);
     }
 
     const record: DeviceSessionRecord = {
@@ -86,6 +131,7 @@ export class DeviceSessionRegistry {
     };
     this.byDeviceId.set(input.deviceId, { record, incarnation: input.incarnation });
     this.uuidToDeviceId.set(record.deviceSessionUuid, input.deviceId);
+    this.emitStarted(record);
     return record;
   }
 
@@ -97,6 +143,7 @@ export class DeviceSessionRegistry {
     }
     this.byDeviceId.delete(deviceId);
     this.uuidToDeviceId.delete(existing.record.deviceSessionUuid);
+    this.emitEnded(existing.record);
   }
 
   getByDeviceId(deviceId: string): DeviceSessionRecord | undefined {

--- a/src/daemon/deviceSessionResolver.ts
+++ b/src/daemon/deviceSessionResolver.ts
@@ -1,0 +1,41 @@
+import type { DeviceSessionRegistry } from "./deviceSessionRegistry";
+
+/**
+ * Bidirectional resolver between a device's mutable serial/UDID (`deviceId`) and
+ * its daemon-minted `deviceSessionUuid` (the epic #5256 routing key).
+ *
+ * The push socket servers depend on this narrow contract rather than the whole
+ * {@link DeviceSessionRegistry}: at push time they hold a `deviceId` and need the
+ * live uuid to stamp the envelope; at subscribe time they hold a `deviceSessionUuid`
+ * filter and need the current serial for the serial-scoped machinery (cadence
+ * polling, telemetry backfill queries). A retired epoch resolves to `null` in both
+ * directions, so a stale uuid can never re-attach to a reincarnated serial.
+ */
+export interface DeviceSessionResolver {
+  /** Live `deviceSessionUuid` for a serial/UDID, or `null` when no epoch is live. */
+  resolveUuid(deviceId: string): string | null;
+  /** Live serial/UDID for a `deviceSessionUuid`, or `null` when the epoch is retired/unknown. */
+  resolveDeviceId(deviceSessionUuid: string): string | null;
+}
+
+/**
+ * Null resolver — every lookup misses. The default in each push server before the
+ * daemon wires the real registry, and a safe stand-in for unit tests that do not
+ * exercise device-session routing: frames stamp `deviceSessionUuid: null` and only
+ * all-device (`null`-filter) subscribers match.
+ */
+export const nullDeviceSessionResolver: DeviceSessionResolver = {
+  resolveUuid: () => null,
+  resolveDeviceId: () => null,
+};
+
+/** Adapt a {@link DeviceSessionRegistry} to the narrow {@link DeviceSessionResolver} contract. */
+export function createRegistryDeviceSessionResolver(
+  registry: DeviceSessionRegistry,
+): DeviceSessionResolver {
+  return {
+    resolveUuid: (deviceId: string) => registry.getByDeviceId(deviceId)?.deviceSessionUuid ?? null,
+    resolveDeviceId: (deviceSessionUuid: string) =>
+      registry.getByUuid(deviceSessionUuid)?.deviceId ?? null,
+  };
+}

--- a/src/daemon/failuresPushSocketServer.ts
+++ b/src/daemon/failuresPushSocketServer.ts
@@ -3,9 +3,16 @@ import { Timer, defaultTimer } from "../utils/SystemTimer";
 import { PushSubscriptionSocketServer, getSocketPath } from "./socketServer/index";
 import type { FailureType, FailureSeverity } from "../server/failuresResources";
 import { FAILURES_PUSH_SOCKET_CONFIG } from "./daemonFiles";
+import { type DeviceSessionResolver, nullDeviceSessionResolver } from "./deviceSessionResolver";
 
 /**
- * Failure notification data pushed to clients
+ * Failure notification data pushed to clients.
+ *
+ * `deviceId` and `deviceSessionUuid` are the device attribution added in epic
+ * #5256, item 3 — failures previously carried no device dimension at all. The
+ * caller supplies `deviceId` (the originating serial/UDID, or `null` for a
+ * genuinely device-less failure); the server resolves `deviceSessionUuid` from it
+ * at push time so subscribers can filter on the stable epoch key.
  */
 export interface FailureNotificationPush {
   occurrenceId: string;
@@ -15,14 +22,18 @@ export interface FailureNotificationPush {
   title: string;
   message: string;
   timestamp: number;
+  deviceId: string | null;
+  deviceSessionUuid: string | null;
 }
 
 /**
- * Filter for failure push subscriptions.
+ * Filter for failure push subscriptions. `deviceSessionUuid` is the primary
+ * device routing key (epic #5256); `null` matches every device.
  */
 interface FailureFilter {
   type: FailureType | null;
   severity: FailureSeverity | null;
+  deviceSessionUuid: string | null;
 }
 
 /**
@@ -49,6 +60,8 @@ export class FailuresPushSocketServer extends PushSubscriptionSocketServer<
   FailureFilter,
   FailureNotificationPush
 > {
+  private deviceSessionResolver: DeviceSessionResolver = nullDeviceSessionResolver;
+
   constructor(
     socketPath: string = getSocketPath(FAILURES_PUSH_SOCKET_CONFIG),
     timer: Timer = defaultTimer,
@@ -56,28 +69,42 @@ export class FailuresPushSocketServer extends PushSubscriptionSocketServer<
     super(socketPath, timer, "FailuresPush");
   }
 
+  /** Wire the serial↔`deviceSessionUuid` resolver used to stamp pushed frames. */
+  setDeviceSessionResolver(resolver: DeviceSessionResolver): void {
+    this.deviceSessionResolver = resolver;
+  }
+
   /**
-   * Push a failure notification to all interested subscribers.
+   * Push a failure notification to all interested subscribers. The caller sets
+   * `deviceId`; `deviceSessionUuid` is (re)resolved here from the live registry so
+   * the routing key reflects the device's current epoch.
    */
   pushFailure(data: FailureNotificationPush): void {
+    const deviceSessionUuid = data.deviceId
+      ? this.deviceSessionResolver.resolveUuid(data.deviceId)
+      : null;
+    const enriched: FailureNotificationPush = { ...data, deviceSessionUuid };
     logger.info(
-      `[FailuresPush] Pushing failure: ${data.type} - ${data.title} (subscribers: ${this.getSubscriberCount()})`,
+      `[FailuresPush] Pushing failure: ${enriched.type} - ${enriched.title} (subscribers: ${this.getSubscriberCount()})`,
     );
-    const sentCount = this.pushToSubscribers(data);
-    logger.info(`[FailuresPush] Pushed failure to ${sentCount} subscribers: ${data.title}`);
+    const sentCount = this.pushToSubscribers(enriched);
+    logger.info(`[FailuresPush] Pushed failure to ${sentCount} subscribers: ${enriched.title}`);
   }
 
   protected parseSubscriptionFilter(request: Record<string, unknown>): FailureFilter {
     return {
       type: (request.type as FailureType) ?? null,
       severity: (request.severity as FailureSeverity) ?? null,
+      deviceSessionUuid: (request.deviceSessionUuid as string) ?? null,
     };
   }
 
   protected matchesFilter(filter: FailureFilter, data: FailureNotificationPush): boolean {
     const matchesType = filter.type === null || filter.type === data.type;
     const matchesSeverity = filter.severity === null || filter.severity === data.severity;
-    return matchesType && matchesSeverity;
+    const matchesDevice =
+      filter.deviceSessionUuid === null || filter.deviceSessionUuid === data.deviceSessionUuid;
+    return matchesType && matchesSeverity && matchesDevice;
   }
 
   protected createPushMessage(

--- a/src/daemon/performancePushSocketServer.ts
+++ b/src/daemon/performancePushSocketServer.ts
@@ -2,6 +2,7 @@ import { logger } from "../utils/logger";
 import { Timer, defaultTimer } from "../utils/SystemTimer";
 import { PushSubscriptionSocketServer, getSocketPath } from "./socketServer/index";
 import { PERFORMANCE_PUSH_SOCKET_CONFIG } from "./daemonFiles";
+import { type DeviceSessionResolver, nullDeviceSessionResolver } from "./deviceSessionResolver";
 
 /**
  * Performance thresholds for health status calculation
@@ -49,6 +50,12 @@ export type HealthStatus = "healthy" | "warning" | "critical";
  */
 export interface LivePerformanceData {
   deviceId: string;
+  /**
+   * Stable device-session routing key for this device's current epoch (epic #5256,
+   * item 3). Resolved by the push server from `deviceId`; `null` when no live epoch
+   * maps to the serial. Callers may leave it `null` — the server (re)resolves it.
+   */
+  deviceSessionUuid: string | null;
   packageName: string;
   timestamp: number;
   nodeId: number | null;
@@ -71,7 +78,7 @@ export interface LivePerformanceData {
  * Filter for performance push subscriptions.
  */
 interface PerformanceFilter {
-  deviceId: string | null;
+  deviceSessionUuid: string | null;
   packageName: string | null;
 }
 
@@ -99,6 +106,8 @@ export class PerformancePushSocketServer extends PushSubscriptionSocketServer<
   PerformanceFilter,
   LivePerformanceData
 > {
+  private deviceSessionResolver: DeviceSessionResolver = nullDeviceSessionResolver;
+
   constructor(
     socketPath: string = getSocketPath(PERFORMANCE_PUSH_SOCKET_CONFIG),
     timer: Timer = defaultTimer,
@@ -106,11 +115,21 @@ export class PerformancePushSocketServer extends PushSubscriptionSocketServer<
     super(socketPath, timer, "PerformancePush");
   }
 
+  /** Wire the serial↔`deviceSessionUuid` resolver used to stamp pushed frames. */
+  setDeviceSessionResolver(resolver: DeviceSessionResolver): void {
+    this.deviceSessionResolver = resolver;
+  }
+
   /**
-   * Push live performance data to all interested subscribers.
+   * Push live performance data to all interested subscribers. `deviceSessionUuid`
+   * is (re)resolved here from `deviceId` so the routing key reflects the device's
+   * current epoch regardless of what the caller supplied.
    */
   pushPerformanceData(data: LivePerformanceData): void {
-    const sentCount = this.pushToSubscribers(data);
+    const deviceSessionUuid = data.deviceId
+      ? this.deviceSessionResolver.resolveUuid(data.deviceId)
+      : null;
+    const sentCount = this.pushToSubscribers({ ...data, deviceSessionUuid });
     if (sentCount > 0) {
       logger.debug(`[PerformancePush] Pushed data to ${sentCount} subscribers`);
     }
@@ -188,13 +207,14 @@ export class PerformancePushSocketServer extends PushSubscriptionSocketServer<
 
   protected parseSubscriptionFilter(request: Record<string, unknown>): PerformanceFilter {
     return {
-      deviceId: (request.deviceId as string) ?? null,
+      deviceSessionUuid: (request.deviceSessionUuid as string) ?? null,
       packageName: (request.packageName as string) ?? null,
     };
   }
 
   protected matchesFilter(filter: PerformanceFilter, data: LivePerformanceData): boolean {
-    const matchesDevice = filter.deviceId === null || filter.deviceId === data.deviceId;
+    const matchesDevice =
+      filter.deviceSessionUuid === null || filter.deviceSessionUuid === data.deviceSessionUuid;
     const matchesPackage = filter.packageName === null || filter.packageName === data.packageName;
     return matchesDevice && matchesPackage;
   }

--- a/src/daemon/telemetryPushSocketServer.ts
+++ b/src/daemon/telemetryPushSocketServer.ts
@@ -14,6 +14,7 @@ import type { Database } from "../db/types";
 import type { Kysely } from "kysely";
 import { TELEMETRY_PUSH_SOCKET_CONFIG } from "./daemonFiles";
 import { truncateBodyText, boundStructuredField } from "../utils/truncateBodyText";
+import { type DeviceSessionResolver, nullDeviceSessionResolver } from "./deviceSessionResolver";
 
 /**
  * Opaque plain-text fields that the backfill fans out (limit=100) and that can
@@ -86,6 +87,17 @@ export function boundBackfillEventText(event: TelemetryEvent): TelemetryEvent {
 
 interface TelemetryFilter {
   category: string | null; // "network", "log", "os", "navigation", "crash", "anr", "nonfatal", "storage", "layout", or null for all
+  /**
+   * Primary device routing key (epic #5256). `null` matches every device.
+   * Live-event delivery filters on this.
+   */
+  deviceSessionUuid: string | null;
+  /**
+   * Serial/UDID resolved from `deviceSessionUuid` at subscribe time. Retained
+   * only for the serial-scoped backfill DB queries (which key on the persisted
+   * `device_id`); it is NOT the live routing key. `null` for an all-devices
+   * subscription or a `deviceSessionUuid` with no live epoch.
+   */
   deviceId: string | null;
   sessionId: string | null;
 }
@@ -101,6 +113,8 @@ export class TelemetryPushSocketServer extends PushSubscriptionSocketServer<
   TelemetryFilter,
   TelemetryEvent
 > {
+  private deviceSessionResolver: DeviceSessionResolver = nullDeviceSessionResolver;
+
   constructor(
     socketPath: string = getSocketPath(TELEMETRY_PUSH_SOCKET_CONFIG),
     timer: Timer = defaultTimer,
@@ -108,21 +122,41 @@ export class TelemetryPushSocketServer extends PushSubscriptionSocketServer<
     super(socketPath, timer, "TelemetryPush");
   }
 
+  /** Wire the serial↔`deviceSessionUuid` resolver used to stamp and route events. */
+  setDeviceSessionResolver(resolver: DeviceSessionResolver): void {
+    this.deviceSessionResolver = resolver;
+  }
+
+  /** Stamp the live `deviceSessionUuid` for an event's serial (epic #5256). */
+  private stampDeviceSession(event: TelemetryEvent): TelemetryEvent {
+    const deviceSessionUuid = event.deviceId
+      ? this.deviceSessionResolver.resolveUuid(event.deviceId)
+      : null;
+    return { ...event, deviceSessionUuid };
+  }
+
   pushTelemetryEvent(event: TelemetryEvent): void {
-    const sentCount = this.pushToSubscribers(event);
+    const stamped = this.stampDeviceSession(event);
+    const sentCount = this.pushToSubscribers(stamped);
     if (sentCount > 0) {
-      logger.info(`[TelemetryPush] Pushed ${event.category} event to ${sentCount} subscribers`);
-    } else if (event.category === "navigation") {
+      logger.info(`[TelemetryPush] Pushed ${stamped.category} event to ${sentCount} subscribers`);
+    } else if (stamped.category === "navigation") {
       logger.warn(
-        `[TelemetryPush] No subscribers matched navigation event (${this.getSubscriberCount()} total subs, event deviceId: ${event.deviceId})`,
+        `[TelemetryPush] No subscribers matched navigation event (${this.getSubscriberCount()} total subs, event deviceId: ${stamped.deviceId})`,
       );
     }
   }
 
   protected parseSubscriptionFilter(request: Record<string, unknown>): TelemetryFilter {
+    const deviceSessionUuid = (request.deviceSessionUuid as string) ?? null;
     return {
       category: (request.category as string) ?? null,
-      deviceId: (request.deviceId as string) ?? null,
+      deviceSessionUuid,
+      // Resolve the serial once, at subscribe time, for the serial-scoped backfill
+      // queries. Within an epoch the serial is stable, so a snapshot is safe.
+      deviceId: deviceSessionUuid
+        ? this.deviceSessionResolver.resolveDeviceId(deviceSessionUuid)
+        : null,
       sessionId: (request.sessionId as string) ?? null,
     };
   }
@@ -134,7 +168,10 @@ export class TelemetryPushSocketServer extends PushSubscriptionSocketServer<
     if (filter.sessionId !== null && filter.sessionId !== data.sessionId) {
       return false;
     }
-    if (filter.deviceId !== null && filter.deviceId !== data.deviceId) {
+    if (
+      filter.deviceSessionUuid !== null &&
+      filter.deviceSessionUuid !== (data.deviceSessionUuid ?? null)
+    ) {
       return false;
     }
     return true;
@@ -165,6 +202,14 @@ export class TelemetryPushSocketServer extends PushSubscriptionSocketServer<
     socket: Socket,
   ): Promise<void> {
     const limit = 100;
+    // A subscription that named a specific deviceSessionUuid which no longer
+    // resolves to a live serial (retired epoch) must backfill NOTHING — never fall
+    // through to an all-devices query, which would leak other devices' history to a
+    // stale-uuid subscriber (epic #5256, AC4). An all-devices subscription
+    // (deviceSessionUuid === null) still backfills every device.
+    if (filter.deviceSessionUuid !== null && filter.deviceId === null) {
+      return;
+    }
     const deviceId = filter.deviceId ?? undefined;
     const sessionId = filter.sessionId ?? undefined;
     const events: TelemetryEvent[] = [];
@@ -369,7 +414,12 @@ export class TelemetryPushSocketServer extends PushSubscriptionSocketServer<
       }
       // Single boundary cap for large plain-text fields (#2801): network bodies
       // are already capped in the repository mapRow; this bounds log/storage.
-      const msg = this.createPushMessage(boundBackfillEventText(event), subscriptionId);
+      // Stamp the device-session key so every backfilled frame carries the same
+      // attribution as live frames (epic #5256, AC1).
+      const msg = this.createPushMessage(
+        this.stampDeviceSession(boundBackfillEventText(event)),
+        subscriptionId,
+      );
       this.sendJson(socket, msg);
     }
 

--- a/src/features/failures/FailureRecorder.ts
+++ b/src/features/failures/FailureRecorder.ts
@@ -228,7 +228,8 @@ export class FailureRecorder implements FailureRecorderService {
         "tool_failure",
         severity,
         failureInput.title,
-        input.errorMessage
+        input.errorMessage,
+        input.deviceId ?? null
       );
 
       return occurrenceId;
@@ -278,7 +279,8 @@ export class FailureRecorder implements FailureRecorderService {
         "crash",
         severity,
         title,
-        `${input.exceptionType}: ${input.exceptionMessage}`
+        `${input.exceptionType}: ${input.exceptionMessage}`,
+        input.deviceId ?? null
       );
 
       // Push to telemetry timeline
@@ -342,7 +344,8 @@ export class FailureRecorder implements FailureRecorderService {
         "anr",
         "high", // ANRs are always high severity
         title,
-        input.reason
+        input.reason,
+        input.deviceId ?? null
       );
 
       // Push to telemetry timeline
@@ -406,7 +409,8 @@ export class FailureRecorder implements FailureRecorderService {
         "nonfatal",
         severity,
         title,
-        failureInput.message
+        failureInput.message,
+        input.deviceId ?? null
       );
 
       // Push to telemetry timeline
@@ -441,7 +445,8 @@ export class FailureRecorder implements FailureRecorderService {
     type: FailureType,
     severity: FailureSeverity,
     title: string,
-    message: string
+    message: string,
+    deviceId: string | null
   ): void {
     const server = getFailuresPushServer();
     if (server) {
@@ -453,6 +458,10 @@ export class FailureRecorder implements FailureRecorderService {
         title,
         message,
         timestamp: this.timer.now(),
+        // Attribution added in epic #5256, item 3. The push server resolves the
+        // stable deviceSessionUuid from this serial at push time.
+        deviceId,
+        deviceSessionUuid: null,
       };
       logger.debug(`[FailureRecorder] Pushing failure notification: ${type} - ${title}`);
       server.pushFailure(notification);

--- a/src/features/navigation/NavigationGraphManager.ts
+++ b/src/features/navigation/NavigationGraphManager.ts
@@ -351,6 +351,25 @@ export class NavigationGraphManager implements NavigationGraphService {
   }
 
   /**
+   * Resolve the serial/UDID that owns an app's navigation graph, from the app's
+   * build context (epic #5256, item 3). The daemon uses this to attribute a
+   * graph-update push to a device so panes watching other devices are not
+   * cross-contaminated (closes #4837). Returns `null` when the app has no build
+   * context or only the legacy sentinel — in which case the daemon broadcasts to
+   * all-device subscribers rather than mis-attributing.
+   */
+  public getDeviceIdForApp(appId: string | null): string | null {
+    if (!appId) {
+      return null;
+    }
+    const deviceId = this.buildContexts.get(appId)?.deviceId;
+    if (!deviceId || deviceId === LEGACY_PROVENANCE_SENTINEL) {
+      return null;
+    }
+    return deviceId;
+  }
+
+  /**
    * Get the singleton instance of NavigationGraphManager.
    * Used for non-daemon single-agent mode.
    */

--- a/src/features/performance/PerformanceMonitor.ts
+++ b/src/features/performance/PerformanceMonitor.ts
@@ -728,6 +728,8 @@ export class PerformanceMonitor {
   ): void {
     const data: LivePerformanceData = {
       deviceId: device.deviceId,
+      // Resolved by the push server from deviceId at push time (epic #5256, item 3).
+      deviceSessionUuid: null,
       packageName: device.packageName,
       timestamp: now,
       nodeId: null,

--- a/src/features/telemetry/TelemetryRecorder.ts
+++ b/src/features/telemetry/TelemetryRecorder.ts
@@ -19,6 +19,13 @@ export interface TelemetryEvent {
   category: TelemetryCategory;
   timestamp: number;
   deviceId: string | null;
+  /**
+   * Stable device-session routing key for the epoch this event belongs to (epic
+   * #5256, item 3). Stamped by the telemetry push server from `deviceId` at push
+   * and backfill time; recorders leave it absent. `null` when no live epoch maps
+   * to the serial (e.g. a backfilled event for a now-disconnected device).
+   */
+  deviceSessionUuid?: string | null;
   sessionId: string | null;
   data: unknown;
 }

--- a/test/daemon/deviceDataStreamSocketServer.test.ts
+++ b/test/daemon/deviceDataStreamSocketServer.test.ts
@@ -7,15 +7,30 @@ import {
 } from "../../src/daemon/deviceDataStreamSocketServer";
 import { FakeTimer } from "../fakes/FakeTimer";
 import { FakeSocket } from "../fakes/FakeNetServer";
+import { FakeDeviceSessionResolver } from "../fakes/FakeDeviceSessionResolver";
 import { loadCoordinateMappingVectors } from "../parity/coordinateMappingGoldenVectors";
+
+/** Deterministic deviceSessionUuid the harness mints for a given serial. */
+function sessionUuidFor(deviceId: string): string {
+  return `session-${deviceId}`;
+}
 
 /**
  * Test helper that wraps DeviceDataStreamSocketServer to allow injecting fake sockets
  * without requiring real network connections.
+ *
+ * The device-session routing key (epic #5256, item 3) is transparent to existing
+ * device-scoped tests: `simulateSubscription({ deviceId })` mints a deterministic
+ * `deviceSessionUuid` for that serial, binds it in the shared resolver, and keys the
+ * subscription on it — so a `pushHierarchyUpdate(deviceId, ...)` resolves to the same
+ * uuid and routes correctly without every test naming a uuid.
  */
 class TestableDeviceDataStreamSocketServer extends DeviceDataStreamSocketServer {
+  readonly sessionResolver = new FakeDeviceSessionResolver();
+
   constructor(timer: FakeTimer) {
     super("/fake/path/test.sock", timer);
+    this.setDeviceSessionResolver(this.sessionResolver);
   }
 
   async startFake(): Promise<void> {
@@ -30,17 +45,29 @@ class TestableDeviceDataStreamSocketServer extends DeviceDataStreamSocketServer 
 
   simulateSubscription(options: {
     deviceId?: string;
+    deviceSessionUuid?: string | null;
     screenshotIntervalMs?: number | null;
     hierarchyIntervalMs?: number | null;
   }): { socket: FakeSocket; subscriptionId: string } {
     const socket = new FakeSocket();
     const subscriptionId = `devicedatastream-${++(this as any).subscriptionCounter}`;
     const timer = (this as any).timer as FakeTimer;
+    // Bind serial↔uuid so pushes for this device resolve to the same key we filter on.
+    let deviceSessionUuid: string | null;
+    if (options.deviceSessionUuid !== undefined) {
+      deviceSessionUuid = options.deviceSessionUuid;
+    } else if (options.deviceId) {
+      deviceSessionUuid = sessionUuidFor(options.deviceId);
+      this.sessionResolver.bind(options.deviceId, deviceSessionUuid);
+    } else {
+      deviceSessionUuid = null;
+    }
     this.subscribers.set(subscriptionId, {
       socket: socket as unknown as Socket,
       subscriptionId,
       lastActivity: timer.now(),
       filter: {
+        deviceSessionUuid,
         deviceId: options.deviceId ?? null,
         screenshotIntervalMs: options.screenshotIntervalMs ?? null,
         hierarchyIntervalMs: options.hierarchyIntervalMs ?? null,
@@ -581,13 +608,16 @@ describe("DeviceDataStreamSocketServer", () => {
     });
 
     it("multiplexes device filters and cadence updates by subscriptionId", async () => {
+      server.sessionResolver
+        .bind("device-1", "session-device-1")
+        .bind("device-2", "session-device-2");
       const socket = new FakeSocket();
       await server.processLineForTest(
         socket,
         JSON.stringify({
           id: "sub-device-1",
           command: "subscribe",
-          deviceId: "device-1",
+          deviceSessionUuid: "session-device-1",
           screenshotIntervalMs: 500,
         }),
       );
@@ -596,7 +626,7 @@ describe("DeviceDataStreamSocketServer", () => {
         JSON.stringify({
           id: "sub-device-2",
           command: "subscribe",
-          deviceId: "device-2",
+          deviceSessionUuid: "session-device-2",
           screenshotIntervalMs: 1000,
         }),
       );
@@ -641,13 +671,16 @@ describe("DeviceDataStreamSocketServer", () => {
     it("removes every multiplexed device subscription on connection close", async () => {
       const screenshotChanges: Array<string | null> = [];
       server.setOnScreenshotCadenceChanged((deviceId) => screenshotChanges.push(deviceId));
+      server.sessionResolver
+        .bind("device-1", "session-device-1")
+        .bind("device-2", "session-device-2");
       const socket = new FakeSocket();
       await server.processLineForTest(
         socket,
         JSON.stringify({
           id: "sub-device-1",
           command: "subscribe",
-          deviceId: "device-1",
+          deviceSessionUuid: "session-device-1",
         }),
       );
       await server.processLineForTest(
@@ -655,7 +688,7 @@ describe("DeviceDataStreamSocketServer", () => {
         JSON.stringify({
           id: "sub-device-2",
           command: "subscribe",
-          deviceId: "device-2",
+          deviceSessionUuid: "session-device-2",
         }),
       );
       screenshotChanges.length = 0;
@@ -663,6 +696,7 @@ describe("DeviceDataStreamSocketServer", () => {
       server.closeConnectionForTest(socket);
 
       expect(server.getSubscriberCount()).toBe(0);
+      // Cadence notifications carry the resolved serial (the polling key), not the uuid.
       expect(screenshotChanges).toEqual(["device-1", "device-2"]);
     });
   });
@@ -1252,6 +1286,7 @@ describe("DeviceDataStreamSocketServer", () => {
       server.setOnScreenshotCadenceChanged((deviceId) => {
         changedDevices.push(deviceId);
       });
+      server.sessionResolver.bind("device-1", "session-device-1");
       const socket = new FakeSocket();
 
       await server.processLineForTest(
@@ -1259,11 +1294,12 @@ describe("DeviceDataStreamSocketServer", () => {
         JSON.stringify({
           id: "sub-fast",
           command: "subscribe",
-          deviceId: "device-1",
+          deviceSessionUuid: "session-device-1",
           screenshotIntervalMs: 500,
         }),
       );
 
+      // Cadence notifications carry the resolved serial, not the uuid.
       expect(changedDevices).toEqual(["device-1"]);
     });
 
@@ -1447,6 +1483,7 @@ describe("DeviceDataStreamSocketServer", () => {
       server.setOnHierarchyCadenceChanged((deviceId: string | null) => {
         changedDevices.push(deviceId);
       });
+      server.sessionResolver.bind("device-1", "session-device-1");
       const socket = new FakeSocket();
 
       await server.processLineForTest(
@@ -1454,11 +1491,12 @@ describe("DeviceDataStreamSocketServer", () => {
         JSON.stringify({
           id: "sub-fast-hierarchy",
           command: "subscribe",
-          deviceId: "device-1",
+          deviceSessionUuid: "session-device-1",
           hierarchyIntervalMs: 500,
         }),
       );
 
+      // Cadence notifications carry the resolved serial, not the uuid.
       expect(changedDevices).toEqual(["device-1"]);
     });
 
@@ -1583,13 +1621,14 @@ describe("DeviceDataStreamSocketServer", () => {
       const changedHierarchy: Array<string | null> = [];
       server.setOnScreenshotCadenceChanged((deviceId) => changedScreenshot.push(deviceId));
       server.setOnHierarchyCadenceChanged((deviceId) => changedHierarchy.push(deviceId));
+      server.sessionResolver.bind("device-1", "session-device-1");
       const socket = new FakeSocket();
       await server.processLineForTest(
         socket,
         JSON.stringify({
           id: "sub",
           command: "subscribe",
-          deviceId: "device-1",
+          deviceSessionUuid: "session-device-1",
         }),
       );
       changedScreenshot.length = 0;
@@ -1601,12 +1640,12 @@ describe("DeviceDataStreamSocketServer", () => {
           id: "upd",
           command: "update_cadence",
           subscriptionId: "devicedatastream-1",
-          deviceId: "device-1",
           hierarchyIntervalMs: 50,
         }),
       );
 
       expect(server.getHierarchyIntervalMsForDevice("device-1")).toBe(250);
+      // Cadence notifications carry the resolved serial, not the uuid.
       expect(changedScreenshot).toEqual(["device-1"]);
       expect(changedHierarchy).toEqual(["device-1"]);
     });
@@ -1674,6 +1713,7 @@ describe("DeviceDataStreamSocketServer", () => {
         type: string;
         success?: boolean;
         deviceId?: string;
+        deviceSessionUuid?: string | null;
         timestamp?: number;
         error?: string;
       }>();
@@ -1683,6 +1723,8 @@ describe("DeviceDataStreamSocketServer", () => {
           success: false,
           subscriptionId: "devicedatastream-1",
           deviceId: "emulator-5554",
+          // Resolved from the serial by the harness's auto-bound resolver (epic #5256).
+          deviceSessionUuid: "session-emulator-5554",
           timestamp: 1234,
           error: "device connection lost",
         },
@@ -1898,5 +1940,133 @@ describe("DeviceDataStreamSocketServer", () => {
         }
       });
     }
+  });
+
+  describe("deviceSessionUuid routing (#5259)", () => {
+    interface Frame {
+      type: string;
+      deviceId?: string;
+      deviceSessionUuid?: string | null;
+      platform?: string;
+      navigationGraph?: NavigationGraphStreamData;
+    }
+    const frames = (socket: FakeSocket) => socket.getWrittenMessages<Frame>();
+    const hierarchy = { hierarchy: { node: { $: {}, node: [] } } } as any;
+
+    it("stamps deviceId and the resolved deviceSessionUuid on every device frame (AC1)", () => {
+      const { socket } = server.simulateSubscription({ deviceId: "emulator-5554" });
+
+      server.pushHierarchyUpdate("emulator-5554", hierarchy);
+      server.pushScreenshotUpdate("emulator-5554", "png", 100, 200);
+      server.pushPerformanceUpdate("emulator-5554", { fps: 60 } as any);
+      server.pushStorageUpdate("emulator-5554", { key: "k" } as any);
+
+      const got = frames(socket).filter(f => f.type.endsWith("_update"));
+      expect(got.length).toBe(4);
+      for (const f of got) {
+        expect(f.deviceId).toBe("emulator-5554");
+        expect(f.deviceSessionUuid).toBe("session-emulator-5554");
+      }
+    });
+
+    it("isolates two devices by deviceSessionUuid across the observation stream (AC2)", () => {
+      const a = server.simulateSubscription({ deviceId: "device-a" });
+      const b = server.simulateSubscription({ deviceId: "device-b" });
+
+      server.pushHierarchyUpdate("device-a", hierarchy);
+      server.pushHierarchyUpdate("device-b", hierarchy);
+
+      expect(frames(a.socket).filter(f => f.type === "hierarchy_update").map(f => f.deviceSessionUuid))
+        .toEqual(["session-device-a"]);
+      expect(frames(b.socket).filter(f => f.type === "hierarchy_update").map(f => f.deviceSessionUuid))
+        .toEqual(["session-device-b"]);
+    });
+
+    it("yields zero events to a stale/retired deviceSessionUuid subscriber (AC4)", () => {
+      const { socket } = server.simulateSubscription({ deviceId: "device-a" });
+      // device-a reconnects under a new epoch: the serial now resolves to a new uuid.
+      server.sessionResolver.retire("device-a").bind("device-a", "session-device-a-2");
+
+      server.pushHierarchyUpdate("device-a", hierarchy);
+
+      expect(frames(socket).filter(f => f.type === "hierarchy_update")).toHaveLength(0);
+    });
+
+    describe("navigation targeting (AC3, closes #4837)", () => {
+      it("targets the device that owns the graph; other panes see nothing", () => {
+        const a = server.simulateSubscription({ deviceId: "device-a" });
+        const b = server.simulateSubscription({ deviceId: "device-b" });
+
+        server.pushNavigationGraphUpdate({ appId: "com.x", nodes: [], edges: [], currentScreen: null }, "device-a");
+
+        expect(frames(a.socket).filter(f => f.type === "navigation_update").map(f => f.deviceSessionUuid))
+          .toEqual(["session-device-a"]);
+        expect(frames(b.socket).filter(f => f.type === "navigation_update")).toHaveLength(0);
+      });
+
+      it("reaches only all-device subscribers when provenance is unknown (deviceId null)", () => {
+        const scoped = server.simulateSubscription({ deviceId: "device-a" });
+        const all = server.simulateSubscription({});
+
+        server.pushNavigationGraphUpdate({ appId: null, nodes: [], edges: [], currentScreen: null }, null);
+
+        expect(frames(scoped.socket).filter(f => f.type === "navigation_update")).toHaveLength(0);
+        const allNav = frames(all.socket).filter(f => f.type === "navigation_update");
+        expect(allNav).toHaveLength(1);
+        expect(allNav[0].deviceSessionUuid).toBeNull();
+      });
+
+      it("echoes the requester's deviceSessionUuid on an on-demand request response", async () => {
+        server.sessionResolver.bind("device-a", "session-device-a");
+        server.setOnNavigationGraphRequested(async () => ({
+          appId: "com.x", nodes: [], edges: [], currentScreen: null,
+        }));
+        const socket = new FakeSocket();
+
+        await server.processLineForTest(
+          socket,
+          JSON.stringify({ id: "r1", command: "request_navigation_graph", deviceSessionUuid: "session-device-a", appId: "com.x" }),
+        );
+
+        const nav = frames(socket).filter(f => f.type === "navigation_update");
+        expect(nav).toHaveLength(1);
+        expect(nav[0].deviceSessionUuid).toBe("session-device-a");
+        expect(nav[0].deviceId).toBe("device-a");
+      });
+    });
+
+    describe("session lifecycle frames (AC5)", () => {
+      const record = (over: Partial<{ deviceSessionUuid: string; deviceId: string; platform: string }> = {}) => ({
+        deviceSessionUuid: "session-device-a",
+        deviceId: "device-a",
+        platform: "android" as const,
+        epochStartedAt: 0,
+        ...over,
+      });
+
+      it("pushes device_session_started to a matching-uuid and an all-device subscriber", () => {
+        const scoped = server.simulateSubscription({ deviceSessionUuid: "session-device-a" });
+        const all = server.simulateSubscription({});
+        const other = server.simulateSubscription({ deviceSessionUuid: "session-other" });
+
+        server.pushDeviceSessionStarted(record());
+
+        for (const s of [scoped, all]) {
+          const f = frames(s.socket).filter(x => x.type === "device_session_started");
+          expect(f).toHaveLength(1);
+          expect(f[0]).toMatchObject({ deviceSessionUuid: "session-device-a", deviceId: "device-a", platform: "android" });
+        }
+        expect(frames(other.socket).filter(x => x.type === "device_session_started")).toHaveLength(0);
+      });
+
+      it("pushes device_session_ended with the retired identity", () => {
+        const { socket } = server.simulateSubscription({ deviceSessionUuid: "session-device-a" });
+        server.pushDeviceSessionEnded(record());
+
+        const f = frames(socket).filter(x => x.type === "device_session_ended");
+        expect(f).toHaveLength(1);
+        expect(f[0]).toMatchObject({ deviceSessionUuid: "session-device-a", deviceId: "device-a", platform: "android" });
+      });
+    });
   });
 });

--- a/test/daemon/deviceSessionRegistry.test.ts
+++ b/test/daemon/deviceSessionRegistry.test.ts
@@ -104,4 +104,71 @@ describe("DeviceSessionRegistry", () => {
     expect(list.map(r => r.deviceId).sort()).toEqual(["00008030-001", "emulator-5554"]);
     expect(list.find(r => r.deviceId === "00008030-001")?.platform).toBe("ios");
   });
+
+  describe("lifecycle listener", () => {
+    type Event = { kind: "started" | "ended"; uuid: string; deviceId: string; platform: string };
+
+    function withListener(scripted?: string[]) {
+      const { registry, timer, idGenerator } = makeRegistry(scripted);
+      const events: Event[] = [];
+      registry.setLifecycleListener({
+        onSessionStarted: record =>
+          events.push({ kind: "started", uuid: record.deviceSessionUuid, deviceId: record.deviceId, platform: record.platform }),
+        onSessionEnded: record =>
+          events.push({ kind: "ended", uuid: record.deviceSessionUuid, deviceId: record.deviceId, platform: record.platform }),
+      });
+      return { registry, timer, idGenerator, events };
+    }
+
+    it("emits session_started with correct identity on a fresh connect", () => {
+      const { events } = (() => {
+        const ctx = withListener(["uuid-a"]);
+        ctx.registry.onDeviceConnected({ deviceId: "emulator-5554", platform: "android", incarnation: 1 });
+        return ctx;
+      })();
+
+      expect(events).toEqual([
+        { kind: "started", uuid: "uuid-a", deviceId: "emulator-5554", platform: "android" },
+      ]);
+    });
+
+    it("does NOT emit for an idempotent repeat connect (same incarnation)", () => {
+      const { registry, events } = withListener(["uuid-a", "uuid-b"]);
+      registry.onDeviceConnected({ deviceId: "emulator-5554", platform: "android", incarnation: 1 });
+      registry.onDeviceConnected({ deviceId: "emulator-5554", platform: "android", incarnation: 1 });
+
+      expect(events).toEqual([
+        { kind: "started", uuid: "uuid-a", deviceId: "emulator-5554", platform: "android" },
+      ]);
+    });
+
+    it("emits session_ended on disconnect with the retired identity", () => {
+      const { registry, events } = withListener(["uuid-a"]);
+      registry.onDeviceConnected({ deviceId: "emulator-5554", platform: "android", incarnation: 1 });
+      registry.onDeviceDisconnected("emulator-5554");
+
+      expect(events).toEqual([
+        { kind: "started", uuid: "uuid-a", deviceId: "emulator-5554", platform: "android" },
+        { kind: "ended", uuid: "uuid-a", deviceId: "emulator-5554", platform: "android" },
+      ]);
+    });
+
+    it("does NOT emit session_ended when disconnecting an unknown serial", () => {
+      const { registry, events } = withListener(["uuid-a"]);
+      registry.onDeviceDisconnected("never-seen");
+      expect(events).toEqual([]);
+    });
+
+    it("emits ended(old) then started(new) on a same-serial reincarnation", () => {
+      const { registry, events } = withListener(["uuid-a", "uuid-b"]);
+      registry.onDeviceConnected({ deviceId: "emulator-5554", platform: "android", incarnation: 1 });
+      registry.onDeviceConnected({ deviceId: "emulator-5554", platform: "android", incarnation: 2 });
+
+      expect(events).toEqual([
+        { kind: "started", uuid: "uuid-a", deviceId: "emulator-5554", platform: "android" },
+        { kind: "ended", uuid: "uuid-a", deviceId: "emulator-5554", platform: "android" },
+        { kind: "started", uuid: "uuid-b", deviceId: "emulator-5554", platform: "android" },
+      ]);
+    });
+  });
 });

--- a/test/daemon/failuresPushSocketServer.test.ts
+++ b/test/daemon/failuresPushSocketServer.test.ts
@@ -1,0 +1,145 @@
+import { describe, it, expect, beforeEach } from "bun:test";
+import { Socket } from "node:net";
+import {
+  FailuresPushSocketServer,
+  type FailureNotificationPush,
+} from "../../src/daemon/failuresPushSocketServer";
+import { FakeTimer } from "../fakes/FakeTimer";
+import { FakeSocket } from "../fakes/FakeNetServer";
+import { FakeDeviceSessionResolver } from "../fakes/FakeDeviceSessionResolver";
+
+/**
+ * Wraps FailuresPushSocketServer so tests can inject fake sockets and drive the
+ * device-session attribution added in epic #5256, item 3 (#5259) without real IO.
+ */
+class TestableFailuresPushSocketServer extends FailuresPushSocketServer {
+  constructor(timer: FakeTimer) {
+    super("/fake/path/test.sock", timer);
+  }
+
+  async startFake(): Promise<void> {
+    (this as any).server = { listening: true };
+    (this as any).onServerStarted();
+  }
+
+  async closeFake(): Promise<void> {
+    (this as any).onServerClosing();
+    (this as any).server = null;
+  }
+
+  simulateSubscription(options: {
+    type?: string;
+    severity?: string;
+    deviceSessionUuid?: string | null;
+  }): { socket: FakeSocket; subscriptionId: string } {
+    const socket = new FakeSocket();
+    const subscriptionId = `failurespush-${++(this as any).subscriptionCounter}`;
+    const timer = (this as any).timer as FakeTimer;
+    this.subscribers.set(subscriptionId, {
+      socket: socket as unknown as Socket,
+      subscriptionId,
+      lastActivity: timer.now(),
+      filter: {
+        type: options.type ?? null,
+        severity: options.severity ?? null,
+        deviceSessionUuid: options.deviceSessionUuid ?? null,
+      },
+      backfilling: false,
+      drainPending: false,
+    });
+    return { socket, subscriptionId };
+  }
+}
+
+function pushed(socket: FakeSocket): Array<{ type: string; data: FailureNotificationPush }> {
+  return socket.getWrittenMessages<{ type: string; data: FailureNotificationPush }>();
+}
+
+function notification(overrides: Partial<FailureNotificationPush> = {}): FailureNotificationPush {
+  return {
+    occurrenceId: "occ-1",
+    groupId: "grp-1",
+    type: "crash",
+    severity: "high",
+    title: "Boom",
+    message: "boom happened",
+    timestamp: 0,
+    deviceId: "emulator-5554",
+    deviceSessionUuid: null,
+    ...overrides,
+  };
+}
+
+describe("FailuresPushSocketServer device-session attribution (#5259)", () => {
+  let server: TestableFailuresPushSocketServer;
+  let timer: FakeTimer;
+  let resolver: FakeDeviceSessionResolver;
+
+  beforeEach(async () => {
+    timer = new FakeTimer();
+    server = new TestableFailuresPushSocketServer(timer);
+    resolver = new FakeDeviceSessionResolver()
+      .bind("emulator-5554", "uuid-a")
+      .bind("emulator-5556", "uuid-b");
+    server.setDeviceSessionResolver(resolver);
+    await server.startFake();
+  });
+
+  it("stamps deviceId and the resolved deviceSessionUuid on every pushed frame (AC1)", () => {
+    const { socket } = server.simulateSubscription({});
+    server.pushFailure(notification({ deviceId: "emulator-5554" }));
+
+    const msgs = pushed(socket);
+    expect(msgs).toHaveLength(1);
+    expect(msgs[0].data.deviceId).toBe("emulator-5554");
+    expect(msgs[0].data.deviceSessionUuid).toBe("uuid-a");
+  });
+
+  it("isolates two devices by deviceSessionUuid filter (AC2)", () => {
+    const a = server.simulateSubscription({ deviceSessionUuid: "uuid-a" });
+    const b = server.simulateSubscription({ deviceSessionUuid: "uuid-b" });
+
+    server.pushFailure(notification({ occurrenceId: "occ-a", deviceId: "emulator-5554" }));
+    server.pushFailure(notification({ occurrenceId: "occ-b", deviceId: "emulator-5556" }));
+
+    expect(pushed(a.socket).map(m => m.data.occurrenceId)).toEqual(["occ-a"]);
+    expect(pushed(b.socket).map(m => m.data.occurrenceId)).toEqual(["occ-b"]);
+  });
+
+  it("delivers every device's failures to a null (all-devices) subscriber", () => {
+    const { socket } = server.simulateSubscription({ deviceSessionUuid: null });
+    server.pushFailure(notification({ occurrenceId: "occ-a", deviceId: "emulator-5554" }));
+    server.pushFailure(notification({ occurrenceId: "occ-b", deviceId: "emulator-5556" }));
+
+    expect(pushed(socket).map(m => m.data.occurrenceId)).toEqual(["occ-a", "occ-b"]);
+  });
+
+  it("yields zero events to a stale/retired deviceSessionUuid filter (AC4)", () => {
+    const { socket } = server.simulateSubscription({ deviceSessionUuid: "uuid-a" });
+    // Device reconnects under a new epoch: the old uuid no longer resolves and the
+    // serial now maps to uuid-c.
+    resolver.retire("emulator-5554").bind("emulator-5554", "uuid-c");
+
+    server.pushFailure(notification({ deviceId: "emulator-5554" }));
+
+    expect(pushed(socket)).toHaveLength(0);
+  });
+
+  it("still honors type/severity filters alongside the device key", () => {
+    const { socket } = server.simulateSubscription({ type: "anr", deviceSessionUuid: "uuid-a" });
+    server.pushFailure(notification({ type: "crash", deviceId: "emulator-5554" }));
+    server.pushFailure(notification({ type: "anr", deviceId: "emulator-5554" }));
+
+    expect(pushed(socket).map(m => m.data.type)).toEqual(["anr"]);
+  });
+
+  it("carries a null deviceSessionUuid for a device-less failure", () => {
+    const { socket } = server.simulateSubscription({ deviceSessionUuid: null });
+    server.pushFailure(notification({ deviceId: null }));
+
+    const msgs = pushed(socket);
+    expect(msgs).toHaveLength(1);
+    expect(msgs[0].data.deviceId).toBeNull();
+    expect(msgs[0].data.deviceSessionUuid).toBeNull();
+  });
+});

--- a/test/daemon/performancePushSocketServer.test.ts
+++ b/test/daemon/performancePushSocketServer.test.ts
@@ -7,6 +7,7 @@ import {
 } from "../../src/daemon/performancePushSocketServer";
 import { FakeTimer } from "../fakes/FakeTimer";
 import { FakeSocket } from "../fakes/FakeNetServer";
+import { FakeDeviceSessionResolver } from "../fakes/FakeDeviceSessionResolver";
 
 /**
  * Test helper that wraps PerformancePushSocketServer to allow injecting fake sockets
@@ -40,7 +41,7 @@ class TestablePerformancePushSocketServer extends PerformancePushSocketServer {
    * Simulate a client connection and subscription
    */
   simulateSubscription(options: {
-    deviceId?: string;
+    deviceSessionUuid?: string | null;
     packageName?: string;
   }): { socket: FakeSocket; subscriptionId: string } {
     const socket = new FakeSocket();
@@ -53,7 +54,7 @@ class TestablePerformancePushSocketServer extends PerformancePushSocketServer {
       subscriptionId,
       lastActivity: timer.now(),
       filter: {
-        deviceId: options.deviceId ?? null,
+        deviceSessionUuid: options.deviceSessionUuid ?? null,
         packageName: options.packageName ?? null,
       },
       backfilling: false,
@@ -78,14 +79,14 @@ class TestablePerformancePushSocketServer extends PerformancePushSocketServer {
    * Get subscriber info for testing
    */
   getSubscriber(subscriptionId: string): {
-    deviceId: string | null;
+    deviceSessionUuid: string | null;
     packageName: string | null;
     lastActivity: number;
   } | null {
     const subscriber = this.subscribers.get(subscriptionId);
     if (!subscriber) {return null;}
     return {
-      deviceId: subscriber.filter.deviceId,
+      deviceSessionUuid: subscriber.filter.deviceSessionUuid,
       packageName: subscriber.filter.packageName,
       lastActivity: subscriber.lastActivity,
     };
@@ -102,10 +103,16 @@ class TestablePerformancePushSocketServer extends PerformancePushSocketServer {
 describe("PerformancePushSocketServer", () => {
   let server: TestablePerformancePushSocketServer;
   let timer: FakeTimer;
+  let resolver: FakeDeviceSessionResolver;
 
   beforeEach(async () => {
     timer = new FakeTimer();
     server = new TestablePerformancePushSocketServer(timer);
+    resolver = new FakeDeviceSessionResolver()
+      .bind("emulator-5554", "uuid-a")
+      .bind("device-1", "uuid-1")
+      .bind("device-2", "uuid-2");
+    server.setDeviceSessionResolver(resolver);
     await server.startFake();
   });
 
@@ -115,19 +122,19 @@ describe("PerformancePushSocketServer", () => {
     server.simulateSubscription({});
     expect(server.getSubscriberCount()).toBe(1);
 
-    server.simulateSubscription({ deviceId: "device-1" });
+    server.simulateSubscription({ deviceSessionUuid: "uuid-1" });
     expect(server.getSubscriberCount()).toBe(2);
   });
 
   it("stores subscription filters correctly", () => {
     const { subscriptionId } = server.simulateSubscription({
-      deviceId: "emulator-5554",
+      deviceSessionUuid: "uuid-a",
       packageName: "com.example.app",
     });
 
     const subscriber = server.getSubscriber(subscriptionId);
     expect(subscriber).not.toBeNull();
-    expect(subscriber?.deviceId).toBe("emulator-5554");
+    expect(subscriber?.deviceSessionUuid).toBe("uuid-a");
     expect(subscriber?.packageName).toBe("com.example.app");
   });
 
@@ -137,6 +144,7 @@ describe("PerformancePushSocketServer", () => {
 
     const testData: LivePerformanceData = {
       deviceId: "emulator-5554",
+      deviceSessionUuid: null,
       packageName: "com.example.app",
       timestamp: Date.now(),
       nodeId: 42,
@@ -163,17 +171,20 @@ describe("PerformancePushSocketServer", () => {
     expect(msgs1).toHaveLength(1);
     expect(msgs1[0].type).toBe("performance_push");
     expect(msgs1[0].data?.deviceId).toBe("emulator-5554");
+    // Server resolves the stable epoch key from the serial (AC1).
+    expect(msgs1[0].data?.deviceSessionUuid).toBe("uuid-a");
 
     expect(msgs2).toHaveLength(1);
     expect(msgs2[0].type).toBe("performance_push");
   });
 
-  it("filters pushes by deviceId", async () => {
-    const { socket: socket1 } = server.simulateSubscription({ deviceId: "device-1" });
-    const { socket: socket2 } = server.simulateSubscription({ deviceId: "device-2" });
+  it("filters pushes by deviceSessionUuid (AC2)", async () => {
+    const { socket: socket1 } = server.simulateSubscription({ deviceSessionUuid: "uuid-1" });
+    const { socket: socket2 } = server.simulateSubscription({ deviceSessionUuid: "uuid-2" });
 
     const testData: LivePerformanceData = {
       deviceId: "device-1",
+      deviceSessionUuid: null,
       packageName: "com.example.app",
       timestamp: Date.now(),
       nodeId: null,
@@ -195,12 +206,36 @@ describe("PerformancePushSocketServer", () => {
     expect(msgs2).toHaveLength(0);
   });
 
+  it("yields zero events to a stale/retired deviceSessionUuid filter (AC4)", async () => {
+    const { socket } = server.simulateSubscription({ deviceSessionUuid: "uuid-1" });
+    // device-1 reconnects under a new epoch: uuid-1 is retired, serial now maps to uuid-1b.
+    resolver.retire("device-1").bind("device-1", "uuid-1b");
+
+    server.pushPerformanceData({
+      deviceId: "device-1",
+      deviceSessionUuid: null,
+      packageName: "com.app",
+      timestamp: Date.now(),
+      nodeId: null,
+      screenName: null,
+      metrics: {
+        fps: 60, frameTimeMs: 16, jankFrames: 0, touchLatencyMs: null,
+        ttffMs: null, ttiMs: null, cpuUsagePercent: null, memoryUsageMb: null,
+      },
+      thresholds: DEFAULT_THRESHOLDS,
+      health: "healthy",
+    });
+
+    expect(socket.getWrittenMessages()).toHaveLength(0);
+  });
+
   it("filters pushes by packageName", async () => {
     const { socket: socket1 } = server.simulateSubscription({ packageName: "com.app.one" });
     const { socket: socket2 } = server.simulateSubscription({ packageName: "com.app.two" });
 
     const testData: LivePerformanceData = {
       deviceId: "device-1",
+      deviceSessionUuid: null,
       packageName: "com.app.one",
       timestamp: Date.now(),
       nodeId: null,
@@ -231,6 +266,7 @@ describe("PerformancePushSocketServer", () => {
     // Push data - should clean up destroyed socket
     const testData: LivePerformanceData = {
       deviceId: "device-1",
+      deviceSessionUuid: null,
       packageName: "com.app",
       timestamp: Date.now(),
       nodeId: null,

--- a/test/daemon/telemetryPushSocketServer.test.ts
+++ b/test/daemon/telemetryPushSocketServer.test.ts
@@ -642,4 +642,56 @@ describe("TelemetryPushSocketServer failure backfill (#4209)", () => {
       expect(socket.getWrittenMessages()).toHaveLength(0);
     });
   });
-});
+
+  // AC4 for the BACKFILL path (epic #5256): a subscription that named a specific
+    // deviceSessionUuid which no longer resolves to a live serial (deviceId === null)
+    // must backfill NOTHING — never fall through to an all-devices DB query that would
+    // dump every device's history to a stale-uuid subscriber. Discriminating: delete
+    // the guard in backfillRecentEvents and the stale case below leaks the crash.
+    it("backfills zero events for a specific deviceSessionUuid that no longer resolves (AC4)", async () => {
+      await withInMemorySingletonDatabase(async () => {
+        const db = getDatabase() as unknown as Kysely<Database>;
+        await runMigrations(db as unknown as Kysely<unknown>);
+
+        await db
+          .insertInto("failure_groups")
+          .values({
+            id: "group-x", type: "crash", signature: "sig-x", title: "Boom", message: "boom",
+            severity: "critical", first_occurrence: 1000, last_occurrence: 1000,
+            total_count: 1, unique_sessions: 1, stack_trace_json: null, tool_call_info_json: null,
+          })
+          .execute();
+        await db
+          .insertInto("failure_occurrences")
+          .values({
+            id: "occ-x", group_id: "group-x", timestamp: 1000, device_id: "emulator-5554",
+            device_model: "Pixel", os: "34", app_version: "1.0.0", session_id: "session-x",
+            screen_at_failure: "MainActivity", test_name: null, test_execution_id: null,
+            error_code: null, duration_ms: null, tool_args_json: null,
+          })
+          .execute();
+
+        const server = new TestableTelemetryPushSocketServer(new FakeTimer());
+
+        // Stale/retired uuid: resolves to deviceId === null → the guard suppresses the query.
+        const staleSocket = new FakeSocket();
+        const staleFilter = { category: null, deviceSessionUuid: "uuid-retired", deviceId: null, sessionId: null };
+        (server as any).subscribers.set("stale", {
+          socket: staleSocket as unknown as Socket, subscriptionId: "stale",
+          lastActivity: 0, filter: staleFilter, backfilling: true, drainPending: false,
+        });
+        await (server as any).backfillRecentEvents("stale", staleFilter, staleSocket as unknown as Socket);
+        expect(staleSocket.getWrittenMessages()).toHaveLength(0);
+
+        // Contrast: an all-devices subscription (deviceSessionUuid === null) still backfills.
+        const allSocket = new FakeSocket();
+        const allFilter = { category: null, deviceSessionUuid: null, deviceId: null, sessionId: null };
+        (server as any).subscribers.set("all", {
+          socket: allSocket as unknown as Socket, subscriptionId: "all",
+          lastActivity: 0, filter: allFilter, backfilling: true, drainPending: false,
+        });
+        await (server as any).backfillRecentEvents("all", allFilter, allSocket as unknown as Socket);
+        expect(allSocket.getWrittenMessages().length).toBeGreaterThan(0);
+      });
+    });
+  });

--- a/test/daemon/telemetryPushSocketServer.test.ts
+++ b/test/daemon/telemetryPushSocketServer.test.ts
@@ -8,6 +8,7 @@ import { boundStructuredField } from "../../src/utils/truncateBodyText";
 import type { TelemetryEvent } from "../../src/features/telemetry/TelemetryRecorder";
 import { FakeTimer } from "../fakes/FakeTimer";
 import { FakeSocket } from "../fakes/FakeNetServer";
+import { FakeDeviceSessionResolver } from "../fakes/FakeDeviceSessionResolver";
 import { withInMemorySingletonDatabase } from "../db/inMemorySingletonDatabase";
 import { getDatabase } from "../../src/db/database";
 import { runMigrations } from "../../src/db/migrator";
@@ -33,7 +34,12 @@ class TestableTelemetryPushSocketServer extends TelemetryPushSocketServer {
     (this as any).server = null;
   }
 
-  simulateSubscription(options: { category?: string | null; deviceId?: string | null }): {
+  simulateSubscription(options: {
+    category?: string | null;
+    deviceSessionUuid?: string | null;
+    deviceId?: string | null;
+    sessionId?: string | null;
+  }): {
     socket: FakeSocket;
     subscriptionId: string;
   } {
@@ -46,8 +52,11 @@ class TestableTelemetryPushSocketServer extends TelemetryPushSocketServer {
       lastActivity: timer.now(),
       filter: {
         category: options.category ?? null,
+        deviceSessionUuid: options.deviceSessionUuid ?? null,
+        // The server resolves this from deviceSessionUuid at real subscribe time; a
+        // test may seed it directly for backfill-query coverage.
         deviceId: options.deviceId ?? null,
-        sessionId: null,
+        sessionId: options.sessionId ?? null,
       },
       backfilling: false,
       drainPending: false,
@@ -230,10 +239,15 @@ describe("boundStructuredField", () => {
 describe("TelemetryPushSocketServer", () => {
   let server: TestableTelemetryPushSocketServer;
   let timer: FakeTimer;
+  let resolver: FakeDeviceSessionResolver;
 
   beforeEach(async () => {
     timer = new FakeTimer();
     server = new TestableTelemetryPushSocketServer(timer);
+    resolver = new FakeDeviceSessionResolver()
+      .bind("device-1", "uuid-1")
+      .bind("device-2", "uuid-2");
+    server.setDeviceSessionResolver(resolver);
     await server.startFake();
   });
 
@@ -412,27 +426,46 @@ describe("TelemetryPushSocketServer", () => {
     expect(msgs[0].data?.timestamp).toBe(50000);
   });
 
-  it("filters pushes by deviceId", () => {
-    const { socket: d1Socket } = server.simulateSubscription({ deviceId: "device-1" });
-    const { socket: d2Socket } = server.simulateSubscription({ deviceId: "device-2" });
+  it("filters pushes by deviceSessionUuid (AC2)", () => {
+    const { socket: d1Socket } = server.simulateSubscription({ deviceSessionUuid: "uuid-1" });
+    const { socket: d2Socket } = server.simulateSubscription({ deviceSessionUuid: "uuid-2" });
     const { socket: allSocket } = server.simulateSubscription({});
 
     const event: TelemetryEvent = {
       category: "network",
       timestamp: 1000,
       deviceId: "device-1",
+      sessionId: null,
       data: { method: "GET", url: "/test", statusCode: 200, durationMs: 10 },
     };
 
     server.pushTelemetryEvent(event);
 
-    expect(d1Socket.getWrittenMessages()).toHaveLength(1);
+    const d1 = d1Socket.getWrittenMessages<{ data?: TelemetryEvent }>();
+    expect(d1).toHaveLength(1);
+    // Live events carry the resolved epoch key (AC1).
+    expect(d1[0].data?.deviceSessionUuid).toBe("uuid-1");
     expect(d2Socket.getWrittenMessages()).toHaveLength(0);
     expect(allSocket.getWrittenMessages()).toHaveLength(1);
   });
 
-  it("filters by both category and deviceId", () => {
-    const { socket } = server.simulateSubscription({ category: "log", deviceId: "device-1" });
+  it("yields zero events to a stale/retired deviceSessionUuid filter (AC4)", () => {
+    const { socket } = server.simulateSubscription({ deviceSessionUuid: "uuid-1" });
+    resolver.retire("device-1").bind("device-1", "uuid-1b");
+
+    server.pushTelemetryEvent({
+      category: "network",
+      timestamp: 1000,
+      deviceId: "device-1",
+      sessionId: null,
+      data: { method: "GET", url: "/test", statusCode: 200, durationMs: 10 },
+    });
+
+    expect(socket.getWrittenMessages()).toHaveLength(0);
+  });
+
+  it("filters by both category and deviceSessionUuid", () => {
+    const { socket } = server.simulateSubscription({ category: "log", deviceSessionUuid: "uuid-1" });
 
     const matchEvent: TelemetryEvent = {
       category: "log",

--- a/test/fakes/FakeDeviceSessionResolver.ts
+++ b/test/fakes/FakeDeviceSessionResolver.ts
@@ -1,0 +1,34 @@
+import type { DeviceSessionResolver } from "../../src/daemon/deviceSessionResolver";
+
+/**
+ * In-memory {@link DeviceSessionResolver} for unit tests. Seed live serial↔uuid
+ * pairs with {@link bind}; {@link retire} drops a pair so both directions miss
+ * (mirroring a disconnected epoch). Unknown ids resolve to `null`.
+ */
+export class FakeDeviceSessionResolver implements DeviceSessionResolver {
+  private readonly deviceIdToUuid = new Map<string, string>();
+  private readonly uuidToDeviceId = new Map<string, string>();
+
+  bind(deviceId: string, deviceSessionUuid: string): this {
+    this.deviceIdToUuid.set(deviceId, deviceSessionUuid);
+    this.uuidToDeviceId.set(deviceSessionUuid, deviceId);
+    return this;
+  }
+
+  retire(deviceId: string): this {
+    const uuid = this.deviceIdToUuid.get(deviceId);
+    if (uuid !== undefined) {
+      this.uuidToDeviceId.delete(uuid);
+    }
+    this.deviceIdToUuid.delete(deviceId);
+    return this;
+  }
+
+  resolveUuid(deviceId: string): string | null {
+    return this.deviceIdToUuid.get(deviceId) ?? null;
+  }
+
+  resolveDeviceId(deviceSessionUuid: string): string | null {
+    return this.uuidToDeviceId.get(deviceSessionUuid) ?? null;
+  }
+}


### PR DESCRIPTION
## Summary

Item 3 of the device-session-UUID routing epic (#5256). Introduces the daemon-minted `deviceSessionUuid` as the primary routing key across **every** push-stream socket, stamps it on every envelope alongside `deviceId`, adds device attribution to the two streams that had none, and emits device-session lifecycle events so consumers flush per-device state on a real epoch boundary instead of guessing from serial reuse.

**This is a deliberate wire-protocol break with no backward compat**, exactly as the epic specifies (the daemon and desktop ship together). It is **daemon-only (TypeScript)**; the Kotlin desktop client is rebuilt on this contract in items 6/7 (#5262/#5263).

## Changes

- **Shared resolver** (`deviceSessionResolver.ts`): a narrow bidirectional `deviceSessionUuid ↔ deviceId` contract backed by `DeviceSessionRegistry`, injected into each push server. Servers stamp the uuid at push time from the `deviceId` they already receive, so the many external callers stay untouched.
- **Uniform filter match** on all four servers (observation / telemetry / performance / failures): route on `deviceSessionUuid` (`null` = all devices). The old `null`-target *broadcast* is removed — a `null` target now reaches only all-device subscribers, which is precisely the fix for the navigation cross-contamination in #4837. A retired epoch resolves to `null`, so a stale uuid filter matches nothing (no re-attach to a reincarnated serial).
- **Observation stream**: `deviceSessionUuid` on every frame; the subscribe filter's `deviceId` is kept only as the resolved serial for the serial-scoped cadence/polling machinery (routing and polling are separated on purpose).
- **Failures**: added both `deviceId` (threaded through `FailureRecorder`) and `deviceSessionUuid` — this stream had no device dimension at all.
- **Navigation**: `pushNavigationGraphUpdate` targets the device that owns the app's graph (resolved via `NavigationGraphManager.getDeviceIdForApp` from the app's build context); on-demand `request_navigation_graph` echoes the requester's `deviceSessionUuid`.
- **Telemetry backfill**: resolves the uuid to a serial for the DB queries; a specific-but-unresolvable uuid backfills nothing rather than leaking every device's history.
- **Lifecycle**: `DeviceSessionRegistry` gains a listener wired by the daemon to push `device_session_started` / `device_session_ended` frames (emits `ended(old)`→`started(new)` on a same-serial reincarnation).

## Linked Issue

Closes #5259
Closes #4837

## Acceptance criteria

1. **Every frame carries `deviceSessionUuid` + `deviceId`** — per-server tests assert both fields on obs/telemetry/perf/failures/nav frames.
2. **`deviceSessionUuid=X` isolates a device across all streams** — two-device isolation tests per server, including failures and navigation which previously had no device dimension.
3. **`navigation_update` targets the subscribed device** — two-subscriber test asserts each pane sees only its own graph (the #4837 repro); unknown provenance reaches only all-device subscribers; on-demand response echoes the requester's uuid.
4. **Stale/retired uuid yields zero events** — per-server tests (live path) + telemetry backfill guard.
5. **`device_session_started`/`ended` fire with correct identity** — registry lifecycle tests + observation-stream frame tests.
6. **<100ms, in-memory, fake `IdGenerator`/resolver** — all new tests use fakes; no real DB or sockets.

## Validation

- [x] `bun test` — 13540 pass, 0 fail (full suite)
- [x] `bun run typecheck` — no new errors (4 pre-existing baseline lines had their "N more" count text shift by one from a new public method; baseline count unchanged at 183)
- [x] `bun run lint` — no new ratchet violations
- [x] `bun run build` — clean
- [x] New code uses interfaces + fakes; unit tests run in <100ms

## Follow-ups

- [ ] Desktop items 6/7 (#5262/#5263) rebuild the Kotlin client on this new wire contract.
