### PR TITLE
ci(playground): run design-system tests in CI (Android + iOS)

### DIFF
--- a/.github/workflows/pull_request.yml
+++ b/.github/workflows/pull_request.yml
@@ -1722,6 +1722,40 @@ jobs:
       - name: "Build Xcode Projects"
         run: ./scripts/ios/xcode-build.sh
 
+  # Runs the Playground PlaygroundTests target (design-system colour/contrast/
+  # typography/shape tests, #5102) via xcode-test.sh, scoped to "Playground" so
+  # the heavier CtrlProxy tests (covered by ios-xctest-runner-simulator-tests)
+  # are not double-run. Simulator-based, so it feeds the non-required "iOS" gate
+  # (not the deterministic "iOS Build" gate) — matching the repo policy that
+  # simulator tests must not gate merges.
+  ios-playground-tests:
+    name: "iOS Playground Tests (${{ matrix.config.name }})"
+    runs-on: ${{ matrix.config.runner }}
+    needs: detect-changes
+    if: needs.detect-changes.outputs.ios_should_run == 'true'
+    timeout-minutes: 45
+    strategy:
+      fail-fast: false
+      matrix:
+        config:
+          - { name: "Xcode 26.5", runner: "macos-26", xcode: "26.5" }
+    steps:
+      - name: "Git Checkout"
+        uses: actions/checkout@v6
+        with:
+          lfs: false
+
+      - name: "Select Xcode ${{ matrix.config.xcode }}"
+        uses: maxim-lobanov/setup-xcode@v1
+        with:
+          xcode-version: ${{ matrix.config.xcode }}
+
+      - name: "Ensure iOS Simulator runtime"
+        uses: ./.github/actions/ensure-ios-simulator-runtime
+
+      - name: "Run Playground Tests"
+        run: ./scripts/ios/xcode-test.sh Playground
+
   ios-xctest-runner-simulator-tests:
     name: "XCTestRunner Simulator Tests"
     runs-on: macos-26
@@ -2322,7 +2356,11 @@ jobs:
 
       - uses: ./.github/actions/gradle-task-run
         with:
-          gradle-tasks: ":playground:app:assembleDebug"
+          # Also runs the design-system library's host unit tests (#5102): the
+          # colour/contrast/typography/shape/asset tests live in
+          # :playground:design:system, which :playground:app:assembleDebug does
+          # not exercise, so without this they never gate.
+          gradle-tasks: ":playground:app:assembleDebug :playground:design:system:testDebugUnitTest"
           gradle-project-directory: "android"
           gradle-home-directory: "~/.gradle/${{ github.job }}"
           reuse-configuration-cache: true
@@ -2875,6 +2913,7 @@ jobs:
       - detect-changes
       - ios-build-gate
       - ios-xctest-runner-simulator-tests
+      - ios-playground-tests
       - ios-spm-root-package-build
     runs-on: ubuntu-latest
     steps:
@@ -2884,6 +2923,7 @@ jobs:
             "${{ needs.detect-changes.result }}" \
             "${{ needs.ios-build-gate.result }}" \
             "${{ needs.ios-xctest-runner-simulator-tests.result }}" \
+            "${{ needs.ios-playground-tests.result }}" \
             "${{ needs.ios-spm-root-package-build.result }}" \
           )
           for r in "${results[@]}"; do

--- a/scripts/ios/xcode-test.sh
+++ b/scripts/ios/xcode-test.sh
@@ -19,7 +19,51 @@ SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
 # shellcheck source=scripts/ios/local-sim-build-args.sh disable=SC1091
 source "${SCRIPT_DIR}/local-sim-build-args.sh"
 PROJECT_ROOT="$(cd "${SCRIPT_DIR}/../.." && pwd)"
-IOS_DIR="${PROJECT_ROOT}/ios"
+# IOS_DIR is overridable (tests point it at a fixture dir); defaults to ios/.
+IOS_DIR="${IOS_DIR:-${PROJECT_ROOT}/ios}"
+
+# Optional positional args restrict which Xcode projects get tested, by name
+# (without the .xcodeproj suffix). With no args, every project under ios/ is
+# tested (legacy behavior). CI's Playground job passes "Playground" so the
+# heavier CtrlProxy tests (covered by the XCTestRunner simulator job) are not
+# double-run here.
+REQUESTED_PROJECTS=("$@")
+
+# Discover and filter projects up front so a dry run needs no Xcode. The dry run
+# (XCODE_TEST_DRY_RUN=1) prints the selected project names and exits, which is
+# how test/bats/xcode-test-project-filter.bats pins the filter on any host. The
+# match is inlined (rather than a helper invoked in an `if`) so `set -e` stays
+# active for the rest of the loop body (shellcheck SC2310).
+SELECTED_XCODEPROJ_DIRS=()
+while IFS= read -r _xcodeproj; do
+    [ -z "${_xcodeproj}" ] && continue
+    _name="$(basename "${_xcodeproj}" .xcodeproj)"
+    _match=0
+    if [ ${#REQUESTED_PROJECTS[@]} -eq 0 ]; then
+        # No filter given: every project is selected (legacy behavior).
+        _match=1
+    else
+        for _want in "${REQUESTED_PROJECTS[@]}"; do
+            [ "${_want}" = "${_name}" ] && _match=1
+        done
+    fi
+    [ "${_match}" -eq 1 ] && SELECTED_XCODEPROJ_DIRS+=("${_xcodeproj}")
+done < <(find "${IOS_DIR}" -name "*.xcodeproj" -type d 2>/dev/null || true)
+
+# Fail closed: an explicit filter that matches nothing is a misconfiguration
+# (e.g. a renamed project), not a reason to pass a gating job with zero tests.
+# With no filter, an empty result is handled later as a benign no-op.
+if [ ${#REQUESTED_PROJECTS[@]} -ne 0 ] && [ ${#SELECTED_XCODEPROJ_DIRS[@]} -eq 0 ]; then
+    echo "Error: no Xcode project under ${IOS_DIR} matched: ${REQUESTED_PROJECTS[*]}" >&2
+    exit 1
+fi
+
+if [ "${XCODE_TEST_DRY_RUN:-0}" = "1" ]; then
+    for _xcodeproj in "${SELECTED_XCODEPROJ_DIRS[@]}"; do
+        basename "${_xcodeproj}" .xcodeproj
+    done
+    exit 0
+fi
 
 # On a local arm64 host, build only the arch the simulator runs and skip the
 # index store; empty in CI / on Intel so those keep building universal (#5024).
@@ -108,17 +152,16 @@ echo ""
 # Build destination string
 DESTINATION="platform=iOS Simulator,id=${SIMULATOR_ID}"
 
-# Find all xcodeproj directories
-echo -e "${BLUE}Searching for Xcode projects...${NC}"
-XCODEPROJ_DIRS=$(find "${IOS_DIR}" -name "*.xcodeproj" -type d 2>/dev/null || true)
+# Projects were discovered and filtered up front (see SELECTED_XCODEPROJ_DIRS).
+echo -e "${BLUE}Testing Xcode projects: ${SELECTED_XCODEPROJ_DIRS[*]:-none}${NC}"
 
-if [ -z "${XCODEPROJ_DIRS}" ]; then
-    echo -e "${YELLOW}No Xcode projects found in ${IOS_DIR}${NC}"
+if [ ${#SELECTED_XCODEPROJ_DIRS[@]} -eq 0 ]; then
+    echo -e "${YELLOW}No matching Xcode projects found in ${IOS_DIR}${NC}"
     exit 0
 fi
 
 # Test each project
-for xcodeproj in ${XCODEPROJ_DIRS}; do
+for xcodeproj in "${SELECTED_XCODEPROJ_DIRS[@]}"; do
     PROJECT_NAME=$(basename "${xcodeproj}" .xcodeproj)
 
     echo -e "  Testing ${PROJECT_NAME}..."
@@ -132,10 +175,16 @@ for xcodeproj in ${XCODEPROJ_DIRS}; do
         continue
     fi
 
-    # Run tests for the first scheme (usually the main app scheme)
+    # Prefer the scheme whose name matches the project (e.g. Playground.xcodeproj
+    # → the "Playground" scheme, which wires the PlaygroundTests test action).
+    # xcodebuild -list also surfaces auto-generated schemes for dependency
+    # targets (e.g. "AutoMobileSDK") that have no test action and can sort first,
+    # so a blind `head -1` would try to test the wrong scheme. Fall back to the
+    # first scheme when no name matches (preserves legacy single-scheme behavior).
     TEST_SUCCESS=true
     TESTS_RAN=false
-    FIRST_SCHEME=$(echo "${SCHEMES}" | head -1)
+    FIRST_SCHEME=$(echo "${SCHEMES}" | grep -Fx "${PROJECT_NAME}" | head -1 || true)
+    [ -z "${FIRST_SCHEME}" ] && FIRST_SCHEME=$(echo "${SCHEMES}" | head -1)
 
     if [ -n "${FIRST_SCHEME}" ]; then
         echo -e "    Testing scheme: ${FIRST_SCHEME}..."

--- a/test/bats/xcode-test-project-filter.bats
+++ b/test/bats/xcode-test-project-filter.bats
@@ -1,0 +1,39 @@
+#!/usr/bin/env bats
+#
+# Pins the optional project-name filter of scripts/ios/xcode-test.sh (#5102).
+# The CI Playground test job passes "Playground" so the heavier CtrlProxy tests
+# (covered by the XCTestRunner simulator job) are not double-run. The dry-run
+# path (XCODE_TEST_DRY_RUN=1) prints the selected projects without invoking
+# xcodebuild, so this runs on any host — no Xcode required.
+
+setup() {
+  ios_dir="$(mktemp -d)"
+  mkdir -p "$ios_dir/Playground/Playground.xcodeproj"
+  mkdir -p "$ios_dir/control-proxy/CtrlProxy.xcodeproj"
+  script="$BATS_TEST_DIRNAME/../../scripts/ios/xcode-test.sh"
+}
+
+teardown() {
+  rm -rf "$ios_dir"
+}
+
+@test "no args selects every xcodeproj" {
+  run env IOS_DIR="$ios_dir" XCODE_TEST_DRY_RUN=1 bash "$script"
+  [ "$status" -eq 0 ]
+  [[ "$output" == *"Playground"* ]]
+  [[ "$output" == *"CtrlProxy"* ]]
+}
+
+@test "a project-name arg restricts the selection to that project" {
+  run env IOS_DIR="$ios_dir" XCODE_TEST_DRY_RUN=1 bash "$script" Playground
+  [ "$status" -eq 0 ]
+  [[ "$output" == *"Playground"* ]]
+  [[ "$output" != *"CtrlProxy"* ]]
+}
+
+@test "an unknown project-name arg fails closed (non-zero, no silent no-op)" {
+  run env IOS_DIR="$ios_dir" XCODE_TEST_DRY_RUN=1 bash "$script" Nonexistent
+  [ "$status" -ne 0 ]
+  [[ "$output" == *"no Xcode project"* ]]
+  [[ "$output" == *"Nonexistent"* ]]
+}


### PR DESCRIPTION
## Summary

The Playground **design-system tests never gated in CI** on either platform (#5102):

- **iOS** — the required `ios-xcode-build` job ends with the `build` action, and `scripts/ios/xcode-test.sh` had no workflow caller, so `PlaygroundThemeTests` (contrast / font registration / shapes) ran only locally.
- **Android** — the Playground jobs run `:playground:app:*` only; the design-system library's tests live in `:playground:design:system` (colour / contrast / typography / shape / crayon), which `:playground:app:assembleDebug` does not exercise, so they never ran.

This wires both into CI:

- **Android (real gating):** appends `:playground:design:system:testDebugUnitTest` to the **`build-playground-app`** job — already a **required** status check ("Build Playground App"). These are JVM host tests, so no emulator is involved.
- **iOS:** a new `ios-playground-tests` job runs `scripts/ios/xcode-test.sh Playground` on a simulator. Because it is simulator-based, it feeds the **non-required "iOS" gate** (not the deterministic required "iOS Build" gate), matching this repo's deliberate policy that simulator tests must not block merges — the same treatment as `ios-xctest-runner-simulator-tests`.
- **`scripts/ios/xcode-test.sh`:** now accepts optional project-name args to scope which `.xcodeproj` get tested (default: all — backward compatible). CI passes `Playground` so the heavier CtrlProxy tests (already covered by the XCTestRunner simulator job) are not double-run. A dry-run mode (`XCODE_TEST_DRY_RUN=1`) prints the selected projects without invoking `xcodebuild`, which lets the filter be unit-tested on any host.

## Linked Issue

Closes #5102

## Validation

- [x] `scripts/all_fast_validate_checks.sh` passes (shellcheck / yaml / etc.)
- [x] New bats test `test/bats/xcode-test-project-filter.bats` pins the `xcode-test.sh` project filter (3 cases: no-arg = all, `Playground` = Playground only, unknown = none)
- [x] Gate-wiring bats (`pr-gate-wiring.bats`, `xctest-shared-prereq-gate.bats`) green — including the assertion that the required "iOS Build" gate still **excludes** the simulator job
- [x] Workflow-parsing TS tests green (`workflowJobTimeouts`, `miscParallelSteps`, `pullRequestAutoChoreWorkflow`, `iosIntegrationWorkflowChangeGuard`, and 8 more)
- [x] `:playground:design:system:testDebugUnitTest` runs green locally; **a deliberate contrast break (`ratio >= 4.5` → `>= 99.0`) reddens the task** (AC verified), then reverted
- [x] `shellcheck scripts/ios/xcode-test.sh` clean

No `src/` TypeScript changed → typecheck/oxlint baselines unaffected.

## Notes

- The iOS deliberate-break proof runs in CI (the Android equivalent was verified locally above); the iOS job is non-required by policy, so a Playground-test regression reddens the "iOS" check without hard-blocking merges. Promoting it to a required check is a separate branch-protection decision, intentionally out of scope here.

## Follow-ups

- None.
