### PR TITLE
feat(playground/android): hand-drawn crayon treatment for filled/nav DS components + demo wiring

### DIFF
--- a/android/playground/app/src/main/kotlin/dev/jasonpearson/automobile/playground/navigation/AppDestinations.kt
+++ b/android/playground/app/src/main/kotlin/dev/jasonpearson/automobile/playground/navigation/AppDestinations.kt
@@ -45,3 +45,5 @@ data class HomeDestination(
 @Serializable data object DemoHandledExceptionDestination : AppDestination
 
 @Serializable data object DemoNetworkTestDestination : AppDestination
+
+@Serializable data object DesignSystemDemoDestination : AppDestination

--- a/android/playground/app/src/main/kotlin/dev/jasonpearson/automobile/playground/navigation/AppNavigation.kt
+++ b/android/playground/app/src/main/kotlin/dev/jasonpearson/automobile/playground/navigation/AppNavigation.kt
@@ -30,6 +30,7 @@ import dev.jasonpearson.automobile.demos.TapTargetsDemoScreen
 import dev.jasonpearson.automobile.demos.UxFlowDetailsScreen
 import dev.jasonpearson.automobile.demos.UxFlowStartScreen
 import dev.jasonpearson.automobile.demos.UxFlowSummaryScreen
+import dev.jasonpearson.automobile.design.system.demo.DesignSystemDemoScreen
 import dev.jasonpearson.automobile.home.HomeScreen
 import dev.jasonpearson.automobile.login.ui.LoginScreen
 import dev.jasonpearson.automobile.mediaplayer.VideoPlayerScreen
@@ -150,7 +151,8 @@ fun determineStartDestinationWithDeepLink(
           is DemoTapTargetsDestination,
           is DemoBugReproDestination,
           is DemoHandledExceptionDestination,
-          is DemoNetworkTestDestination -> {
+          is DemoNetworkTestDestination,
+          is DesignSystemDemoDestination -> {
             // For protected destinations, ensure user is authenticated
             when {
               !hasCompletedOnboarding -> {
@@ -285,7 +287,8 @@ fun AppNavigation(deepLinkUri: Uri? = null, onDeepLinkCallbackSet: ((Uri) -> Uni
             is DemoTapTargetsDestination,
             is DemoBugReproDestination,
             is DemoHandledExceptionDestination,
-            is DemoNetworkTestDestination -> {
+            is DemoNetworkTestDestination,
+            is DesignSystemDemoDestination -> {
               // For protected destinations, ensure user is authenticated
               when {
                 !userPreferences.hasCompletedOnboarding -> {
@@ -581,8 +584,20 @@ fun AppNavigation(deepLinkUri: Uri? = null, onDeepLinkCallbackSet: ((Uri) -> Uni
                 backStack.add(DemoHandledExceptionDestination)
               },
               onNavigateToNetworkTest = { backStack.add(DemoNetworkTestDestination) },
+              onNavigateToDesignSystem = { backStack.add(DesignSystemDemoDestination) },
               onNavigateBack = { backStack.removeLastOrNull() },
             )
+          }
+        }
+
+        entry<DesignSystemDemoDestination> { destination ->
+          Navigation3Adapter.TrackNavigation(destination)
+          LaunchedEffect(Unit) {
+            Log.d(TAG, "Navigated to DesignSystemDemoScreen")
+            analyticsTracker.trackScreenView("DesignSystemDemoScreen")
+          }
+          Box(modifier = Modifier.destinationSemanticModifier<DesignSystemDemoDestination>()) {
+            DesignSystemDemoScreen(onBackClick = { backStack.removeLastOrNull() })
           }
         }
 

--- a/android/playground/demos/src/main/kotlin/dev/jasonpearson/automobile/demos/DemoIndexScreen.kt
+++ b/android/playground/demos/src/main/kotlin/dev/jasonpearson/automobile/demos/DemoIndexScreen.kt
@@ -48,6 +48,7 @@ fun DemoIndexScreen(
   onNavigateToBugRepro: () -> Unit,
   onNavigateToHandledException: () -> Unit = {},
   onNavigateToNetworkTest: () -> Unit = {},
+  onNavigateToDesignSystem: () -> Unit = {},
   onNavigateBack: () -> Unit = {},
 ) {
   TrackRecomposition(id = "screen.demo.index", composableName = "DemoIndexScreen") {
@@ -108,6 +109,13 @@ fun DemoIndexScreen(
           description = "HTTP requests, failures, and random user images.",
           buttonLabel = "Open Network Test",
           onClick = onNavigateToNetworkTest,
+        ),
+        DemoEntry(
+          id = "demo_design_system",
+          title = "Design System",
+          description = "Hand-drawn crayon components: buttons, cards, nav, dialogs.",
+          buttonLabel = "Open Design System",
+          onClick = onNavigateToDesignSystem,
         ),
       )
 

--- a/android/playground/design/system/src/main/kotlin/dev/jasonpearson/automobile/design/system/components/BottomNavigation.kt
+++ b/android/playground/design/system/src/main/kotlin/dev/jasonpearson/automobile/design/system/components/BottomNavigation.kt
@@ -36,7 +36,16 @@ fun AutoMobileBottomNavigation(
   modifier: Modifier = Modifier,
 ) {
   NavigationBar(
-    modifier = modifier.height(AutoMobileDimensions.bottomNavHeight),
+    // A crayon divider line along the top edge (#5115) — the nav counterpart of the
+    // bordered components' crayonBorder.
+    modifier =
+      modifier
+        .height(AutoMobileDimensions.bottomNavHeight)
+        .crayonHorizontalEdge(
+          color = MaterialTheme.colorScheme.primary,
+          atBottom = false,
+          seed = 33L,
+        ),
     containerColor = MaterialTheme.colorScheme.surface,
     contentColor = MaterialTheme.colorScheme.onSurface,
     tonalElevation = AutoMobileDimensions.elevationSmall,

--- a/android/playground/design/system/src/main/kotlin/dev/jasonpearson/automobile/design/system/components/Button.kt
+++ b/android/playground/design/system/src/main/kotlin/dev/jasonpearson/automobile/design/system/components/Button.kt
@@ -27,7 +27,21 @@ fun AutoMobileButton(
 ) {
   Button(
     onClick = onClick,
-    modifier = modifier.height(AutoMobileDimensions.buttonHeight),
+    // A wobbly border reads as a box on a bordered surface; on a filled surface the
+    // same primitive reads as a hand-inked outline, drawn in the contrasting content
+    // colour and clamped to the button's stadium shape (#5115).
+    modifier =
+      modifier
+        .height(AutoMobileDimensions.buttonHeight)
+        .crayonBorder(
+          // Fade the outline with the button so a disabled (greyed) button does not
+          // keep a vivid ink line.
+          color =
+            if (enabled) MaterialTheme.colorScheme.onPrimary
+            else MaterialTheme.colorScheme.onPrimary.copy(alpha = 0.38f),
+          cornerRadius = AutoMobileDimensions.buttonHeight / 2f,
+          seed = 11L,
+        ),
     enabled = enabled,
     colors =
       ButtonDefaults.buttonColors(

--- a/android/playground/design/system/src/main/kotlin/dev/jasonpearson/automobile/design/system/components/CrayonSketch.kt
+++ b/android/playground/design/system/src/main/kotlin/dev/jasonpearson/automobile/design/system/components/CrayonSketch.kt
@@ -102,6 +102,30 @@ fun crayonOutlineOffsets(
   return jittered.dropLast(1) + jittered.first()
 }
 
+/**
+ * A hand-drawn 1-D crayon line: a deterministic, seeded perpendicular jitter of a straight baseline
+ * from `(0, 0)` to `(length, 0)`. Same [seed] -> identical points. The endpoints stay anchored on
+ * the baseline (`y == 0`) so a divider meets both edges cleanly, while interior points wobble in
+ * `y` within `[-roughness, roughness]`. `x` is monotonic across `segments + 1` samples. Pure
+ * `Offset` maths (host-testable). Used for the top-app-bar / bottom-nav divider strokes — a full
+ * [crayonBorder] would read as a box, so nav surfaces get a single sketchy line instead.
+ */
+fun crayonLinePoints(
+  length: Float,
+  seed: Long,
+  roughness: Float,
+  segments: Int = 12,
+): List<Offset> {
+  // Zero/negative segments would drop every sample or crash the range; clamp to a single span.
+  val segs = segments.coerceAtLeast(1)
+  return (0..segs).map { i ->
+    val x = length * i / segs
+    // Anchor the endpoints on the baseline so the divider meets both component edges.
+    val jitterY = if (i == 0 || i == segs) 0f else sketchNoise(seed, i) * roughness
+    Offset(x, jitterY)
+  }
+}
+
 private fun List<Offset>.toPath(): Path =
   Path().apply {
     forEachIndexed { i, o -> if (i == 0) moveTo(o.x, o.y) else lineTo(o.x, o.y) }
@@ -140,3 +164,36 @@ fun Modifier.crayonBorder(
     drawPath(main, color = color, style = solid)
   }
 }
+
+/**
+ * Draws a single hand-drawn crayon line along the top or bottom edge of the content — the nav
+ * surfaces' answer to [crayonBorder]. A full wobbly box would fight a top app bar / bottom nav, so
+ * they get one sketchy divider stroke instead (built from [crayonLinePoints]). Deterministic per
+ * [seed]; minSdk-24 safe.
+ */
+fun Modifier.crayonHorizontalEdge(
+  color: Color,
+  atBottom: Boolean,
+  thickness: Dp = 2.5.dp,
+  seed: Long = 0L,
+  roughness: Dp = 2.dp,
+): Modifier = drawWithCache {
+  val rough = roughness.toPx()
+  val strokePx = thickness.toPx()
+  // Sample ~1 point per 24dp so the wobble density is consistent across bar widths.
+  val spacing = 24.dp.toPx()
+  val seg = (size.width / spacing).toInt().coerceIn(8, 64)
+  // Inset by the stroke so the whole rounded line stays inside the component bounds.
+  val baseY = if (atBottom) size.height - strokePx else strokePx
+  val line =
+    crayonLinePoints(size.width, seed, rough, seg).map { Offset(it.x, baseY + it.y) }.toPolyline()
+  val stroke = Stroke(width = strokePx, cap = StrokeCap.Round, join = StrokeJoin.Round)
+  onDrawWithContent {
+    drawContent()
+    drawPath(line, color = color, style = stroke)
+  }
+}
+
+/** An open polyline (unlike [toPath], which closes the loop for a border). */
+private fun List<Offset>.toPolyline(): Path =
+  Path().apply { forEachIndexed { i, o -> if (i == 0) moveTo(o.x, o.y) else lineTo(o.x, o.y) } }

--- a/android/playground/design/system/src/main/kotlin/dev/jasonpearson/automobile/design/system/components/Dialog.kt
+++ b/android/playground/design/system/src/main/kotlin/dev/jasonpearson/automobile/design/system/components/Dialog.kt
@@ -17,6 +17,7 @@ import androidx.compose.material3.MaterialTheme
 import androidx.compose.runtime.Composable
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.tooling.preview.Preview
+import androidx.compose.ui.unit.dp
 import androidx.compose.ui.window.DialogProperties
 import dev.jasonpearson.automobile.design.system.theme.AutoMobileDimensions
 import dev.jasonpearson.automobile.design.system.theme.AutoMobileTheme
@@ -42,7 +43,10 @@ fun AutoMobileAlertDialog(
       if (dismissButtonText != null && onDismissClick != null) {
         { AutoMobileTextButton(text = dismissButtonText, onClick = onDismissClick) }
       } else null,
-    modifier = modifier,
+    // Crayon border on the dialog surface — the same treatment as the bordered
+    // Card, matched to the dialog's rounded shape (#5115).
+    modifier =
+      modifier.crayonBorder(color = MaterialTheme.colorScheme.outline, cornerRadius = 28.dp),
     containerColor = MaterialTheme.colorScheme.surface,
     titleContentColor = MaterialTheme.colorScheme.onSurface,
     textContentColor = MaterialTheme.colorScheme.onSurfaceVariant,
@@ -64,6 +68,8 @@ fun AutoMobileCustomDialog(
     properties = properties,
   ) {
     Card(
+      // Crayon border on the custom dialog surface (#5115).
+      modifier = Modifier.crayonBorder(color = MaterialTheme.colorScheme.outline),
       colors =
         CardDefaults.cardColors(
           containerColor = MaterialTheme.colorScheme.surface,

--- a/android/playground/design/system/src/main/kotlin/dev/jasonpearson/automobile/design/system/components/FloatingActionButton.kt
+++ b/android/playground/design/system/src/main/kotlin/dev/jasonpearson/automobile/design/system/components/FloatingActionButton.kt
@@ -27,7 +27,13 @@ fun AutoMobileFloatingActionButton(
 ) {
   FloatingActionButton(
     onClick = onClick,
-    modifier = modifier,
+    // Hand-inked outline on the filled surface (#5115), in the contrasting content colour.
+    modifier =
+      modifier.crayonBorder(
+        color = MaterialTheme.colorScheme.onSecondary,
+        cornerRadius = AutoMobileDimensions.cornerRadiusLarge,
+        seed = 22L,
+      ),
     containerColor = MaterialTheme.colorScheme.secondary,
     contentColor = MaterialTheme.colorScheme.onSecondary,
     elevation = FloatingActionButtonDefaults.elevation(),
@@ -45,7 +51,12 @@ fun AutoMobileSmallFloatingActionButton(
 ) {
   SmallFloatingActionButton(
     onClick = onClick,
-    modifier = modifier,
+    modifier =
+      modifier.crayonBorder(
+        color = MaterialTheme.colorScheme.onSecondary,
+        cornerRadius = AutoMobileDimensions.cornerRadiusMedium,
+        seed = 23L,
+      ),
     containerColor = MaterialTheme.colorScheme.secondary,
     contentColor = MaterialTheme.colorScheme.onSecondary,
     elevation = FloatingActionButtonDefaults.elevation(),
@@ -64,7 +75,12 @@ fun AutoMobileExtendedFloatingActionButton(
 ) {
   ExtendedFloatingActionButton(
     onClick = onClick,
-    modifier = modifier,
+    modifier =
+      modifier.crayonBorder(
+        color = MaterialTheme.colorScheme.onSecondary,
+        cornerRadius = AutoMobileDimensions.cornerRadiusLarge,
+        seed = 24L,
+      ),
     containerColor = MaterialTheme.colorScheme.secondary,
     contentColor = MaterialTheme.colorScheme.onSecondary,
     elevation = FloatingActionButtonDefaults.elevation(),

--- a/android/playground/design/system/src/main/kotlin/dev/jasonpearson/automobile/design/system/components/TopAppBar.kt
+++ b/android/playground/design/system/src/main/kotlin/dev/jasonpearson/automobile/design/system/components/TopAppBar.kt
@@ -33,7 +33,14 @@ fun AutoMobileTopAppBar(
 ) {
   TopAppBar(
     title = title,
-    modifier = modifier,
+    // A crayon divider line along the bottom edge — a single sketchy stroke reads
+    // better on a bar than a full wobbly box would (#5115).
+    modifier =
+      modifier.crayonHorizontalEdge(
+        color = MaterialTheme.colorScheme.primary,
+        atBottom = true,
+        seed = 31L,
+      ),
     navigationIcon = navigationIcon,
     actions = actions,
     colors = colors,
@@ -57,7 +64,12 @@ fun AutoMobileCenterAlignedTopAppBar(
 ) {
   CenterAlignedTopAppBar(
     title = title,
-    modifier = modifier,
+    modifier =
+      modifier.crayonHorizontalEdge(
+        color = MaterialTheme.colorScheme.primary,
+        atBottom = true,
+        seed = 32L,
+      ),
     navigationIcon = navigationIcon,
     actions = actions,
     colors = colors,

--- a/android/playground/design/system/src/test/kotlin/dev/jasonpearson/automobile/design/system/components/CrayonLineTest.kt
+++ b/android/playground/design/system/src/test/kotlin/dev/jasonpearson/automobile/design/system/components/CrayonLineTest.kt
@@ -1,0 +1,81 @@
+package dev.jasonpearson.automobile.design.system.components
+
+import kotlin.math.abs
+import org.junit.Assert.assertEquals
+import org.junit.Assert.assertNotEquals
+import org.junit.Assert.assertTrue
+import org.junit.Test
+
+/**
+ * Pins the 1-D hand-drawn "crayon line" geometry (#5115): a deterministic, seeded perpendicular
+ * jitter of a straight baseline, used for the divider strokes on the top app bar / bottom nav.
+ * Deterministic so the look is screenshot-testable and never flakes; bounded so the wobble stays a
+ * sketchy line rather than a spilling scribble; endpoints anchored so the divider spans the full
+ * width. Pure `Offset` maths, so this runs as a fast host test.
+ */
+class CrayonLineTest {
+
+  private val length = 320f
+  private val roughness = 2.5f
+
+  @Test
+  fun sameSeed_producesIdenticalLine() {
+    val a = crayonLinePoints(length, seed = 42L, roughness = roughness)
+    val b = crayonLinePoints(length, seed = 42L, roughness = roughness)
+    assertEquals("line must be deterministic for a given seed", a, b)
+  }
+
+  @Test
+  fun differentSeed_producesDifferentLine() {
+    val a = crayonLinePoints(length, seed = 1L, roughness = roughness)
+    val b = crayonLinePoints(length, seed = 2L, roughness = roughness)
+    assertNotEquals("different seeds must jitter differently", a, b)
+  }
+
+  @Test
+  fun line_spansFullLengthExactly() {
+    val pts = crayonLinePoints(length, seed = 7L, roughness = roughness)
+    assertTrue("line should have a reasonable number of points", pts.size >= 4)
+    assertEquals("first point anchored at x=0", 0f, pts.first().x, 0.0001f)
+    assertEquals("last point anchored at x=length", length, pts.last().x, 0.0001f)
+  }
+
+  @Test
+  fun pointCount_matchesSegmentsPlusOne() {
+    val pts = crayonLinePoints(length, seed = 5L, roughness = roughness, segments = 10)
+    assertEquals("segments+1 samples", 11, pts.size)
+  }
+
+  @Test
+  fun everyPoint_staysWithinBounds() {
+    val pts = crayonLinePoints(length, seed = 99L, roughness = roughness)
+    pts.forEach { p ->
+      assertTrue("x ${p.x} within [0, length]", p.x >= -0.0001f && p.x <= length + 0.0001f)
+      assertTrue("y ${p.y} within [-r, r]", abs(p.y) <= roughness + 0.0001f)
+    }
+  }
+
+  @Test
+  fun xIsMonotonicNonDecreasing() {
+    val pts = crayonLinePoints(length, seed = 11L, roughness = roughness)
+    for (i in 1 until pts.size) {
+      assertTrue("x must not go backwards at $i", pts[i].x >= pts[i - 1].x - 0.0001f)
+    }
+  }
+
+  @Test
+  fun nonPositiveSegments_clampToOne() {
+    // Zero or negative segments must not throw and must behave like 1 (a 2-point line).
+    val one = crayonLinePoints(length, seed = 8L, roughness = 0f, segments = 1)
+    for (bad in listOf(0, -1, -7)) {
+      val got = crayonLinePoints(length, seed = 8L, roughness = 0f, segments = bad)
+      assertEquals("segments $bad should clamp to 1", one, got)
+    }
+  }
+
+  @Test
+  fun zeroRoughness_isAFlatBaseline() {
+    val pts = crayonLinePoints(length, seed = 3L, roughness = 0f, segments = 8)
+    pts.forEach { p -> assertEquals("no jitter => y == 0", 0f, p.y, 0.0001f) }
+  }
+}


### PR DESCRIPTION
## Summary

Phase B follow-on to #5114 (item 3 of the crayon design-system epic #5047). #5114 added `Modifier.crayonBorder` and applied it to the **bordered** components; a wobbly box reads best on a bordered surface, so the **filled / nav / dialog** components needed a different hand-drawn treatment. This adds it, reusing the tested #5114 primitive.

## Changes

- **`CrayonSketch.kt`** — new `crayonLinePoints(length, seed, roughness, segments)`: a pure, deterministic, seeded **1-D** jitter of a straight baseline (endpoints anchored on the baseline, interior wobbles in `y`), plus `Modifier.crayonHorizontalEdge(color, atBottom, …)` that draws it as a single divider stroke. minSdk-24 safe, no `RuntimeShader`.
- **Filled `AutoMobileButton` + `AutoMobileFloatingActionButton`** (all three FAB variants) — a crayon **ink outline** (the existing `crayonBorder`) in the contrasting content colour, clamped to each component's shape. A full wobbly box reads as a border on a bordered surface; on a filled surface the same primitive reads as a hand-inked outline.
- **`AutoMobileTopAppBar` / `AutoMobileBottomNavigation`** — a crayon **divider line** (`crayonHorizontalEdge`) along the bottom / top edge, rather than a full border.
- **`AutoMobileAlertDialog` / `AutoMobileCustomDialog`** — `crayonBorder` on the dialog surface (matching the bordered-Card convention, `colorScheme.outline`).
- **Demo wiring** — `DesignSystemDemoScreen` (previously unreferenced) is now reachable in-app: a "Design System" entry in `DemoIndexScreen` → new `DesignSystemDemoDestination` + nav entry in `AppNavigation`, so all hand-drawn components are viewable in one place.

Public component APIs are unchanged.

## Linked Issue

Closes #5115

## Validation

- [x] **New host tests** `CrayonLineTest` (8, all green, <100ms): determinism (same seed → identical), variation (different seed), full-length span, point count, in-bounds, x-monotonic, `segments` clamp-to-one, zero-roughness flat baseline. `CrayonSketchTest` still green.
- [x] `:playground:app:assembleDebug` + `:playground:design:system:testDebugUnitTest` green (all `when`-exhaustiveness over the sealed `AppDestination` satisfied).
- [x] detekt green on `:playground:design:system`, `:playground:demos`, `:playground:app`.
- [x] ktfmt (the pinned `0.64` jar, `--google-style`) clean on all touched files.
- [x] **On-device (emulator):** installed this build; the app renders the crayon design system correctly (Shantell Sans, doubled-up marker outlines on the login button/fields), no crashes/rendering errors. The new filled/nav/dialog treatments are host-pinned for geometry and now viewable via **Demos → Design System**.

## Notes

The geometry of the hand-drawn primitives is host-tested; the Modifier *application* to Compose components is visual (Compose UI isn't unit-testable here without screenshot infra the Playground lacks), verified by compile + the design-system test job (gated by #5408) + the emulator check above.

## Follow-ups

- None.
