### PR TITLE
fix(daemon): preserve bound MCP session ownership

### DIFF
--- a/src/daemon/SessionHeartbeatMonitor.ts
+++ b/src/daemon/SessionHeartbeatMonitor.ts
@@ -12,6 +12,10 @@ export interface HeartbeatSessionSource {
   cleanupExpiredSessions(): void;
 }
 
+type SessionHeartbeatReleaseReason =
+  | "missing-first-heartbeat"
+  | "heartbeat-timeout";
+
 export interface SessionHeartbeatMonitorConfig {
   /** How often to scan for stale sessions. Default: 10s. */
   checkIntervalMs?: number;
@@ -59,7 +63,10 @@ export class SessionHeartbeatMonitor {
   constructor(
     private readonly sessions: HeartbeatSessionSource,
     private readonly hasActiveExecutions: (sessionId: string) => boolean,
-    private readonly reap: (sessionId: string) => Promise<void>,
+    private readonly reap: (
+      sessionId: string,
+      reason: SessionHeartbeatReleaseReason,
+    ) => Promise<void>,
     private readonly timer: Timer = defaultTimer,
     config: SessionHeartbeatMonitorConfig = {},
   ) {
@@ -116,8 +123,11 @@ export class SessionHeartbeatMonitor {
         const lastHeartbeat = session.lastHeartbeat ?? session.lastUsedAt;
         if (session.heartbeatTimeoutSource === "default") {
           if (now - lastHeartbeat > this.preFirstHeartbeatGraceMs) {
-            logger.warn(`Session ${session.sessionId} never received first heartbeat, cancelling`);
-            await this.reap(session.sessionId);
+            const reason = "missing-first-heartbeat";
+            logger.warn(
+              `Session ${session.sessionId} never received first heartbeat, cancelling (reason=${reason})`,
+            );
+            await this.reap(session.sessionId, reason);
           }
           continue;
         }
@@ -128,8 +138,11 @@ export class SessionHeartbeatMonitor {
       }
       const lastHeartbeat = session.lastHeartbeat ?? session.lastUsedAt;
       if (now - lastHeartbeat > timeoutMs) {
-        logger.warn(`Session ${session.sessionId} heartbeat timeout, cancelling`);
-        await this.reap(session.sessionId);
+        const reason = "heartbeat-timeout";
+        logger.warn(
+          `Session ${session.sessionId} heartbeat timeout, cancelling (reason=${reason})`,
+        );
+        await this.reap(session.sessionId, reason);
       }
     }
   }

--- a/src/daemon/client.ts
+++ b/src/daemon/client.ts
@@ -527,8 +527,10 @@ export class DaemonClient {
     this.connected = false;
 
     // Reject all pending requests
-    for (const [, { timeout }] of this.pendingRequests) {
+    const closeError = new DaemonUnavailableError("Socket connection closed");
+    for (const [, { timeout, reject }] of this.pendingRequests) {
       this.timer.clearTimeout(timeout);
+      reject(closeError);
     }
     this.pendingRequests.clear();
     this.notificationHandlers.clear();

--- a/src/daemon/daemon.ts
+++ b/src/daemon/daemon.ts
@@ -252,8 +252,8 @@ export class Daemon {
     // (heartbeat / idle / plan), rather than guessing with the replay TTL. Fires
     // for every released key — base and derived `${base}:${label}` alike; the
     // proxy matches its bound (base) UUID by exact equality (issue #4610).
-    this.sessionManager.onSessionRelease(sessionId => {
-      SessionReleaseBroadcaster.emit(sessionId);
+    this.sessionManager.onSessionRelease((sessionId, _deviceId, releaseReason) => {
+      SessionReleaseBroadcaster.emit(sessionId, releaseReason);
     });
     this.installedAppsRepository = installedAppsRepository ?? new InstalledAppsRepository();
     const recoveryConfiguration = parseDeviceRecoveryPolicy(recoveryPolicyEnvironment);
@@ -1249,7 +1249,7 @@ export class Daemon {
     this.heartbeatMonitor = new SessionHeartbeatMonitor(
       this.sessionManager,
       sessionId => this.hasActiveSessionExecution(sessionId),
-      sessionId => this.cancelAndReleaseSession(sessionId),
+      (sessionId, reason) => this.cancelAndReleaseSession(sessionId, reason),
       this.timer,
     );
     this.heartbeatMonitor.start();

--- a/src/daemon/daemonMcpProxy.ts
+++ b/src/daemon/daemonMcpProxy.ts
@@ -51,11 +51,17 @@ const DAEMON_MCP_HEARTBEAT_INTERVAL_MS = 2_000;
 function heartbeatIntervalMs(config: DaemonMcpProxyConfig): number {
   const configuredTimeout = config.heartbeatTimeoutMs;
   const configuredInterval = config.heartbeatIntervalMs;
+  if (
+    configuredTimeout !== undefined &&
+    (!Number.isFinite(configuredTimeout) || configuredTimeout <= 0)
+  ) {
+    throw new Error("heartbeat timeout must be a positive finite number");
+  }
   const interval =
     configuredInterval ??
     (configuredTimeout === undefined
       ? DAEMON_MCP_HEARTBEAT_INTERVAL_MS
-      : Math.floor(configuredTimeout / 2));
+      : Math.max(1, Math.floor(configuredTimeout / 2)));
   if (!Number.isFinite(interval) || interval <= 0) {
     throw new Error("heartbeat interval must be a positive finite number");
   }

--- a/src/daemon/daemonMcpProxy.ts
+++ b/src/daemon/daemonMcpProxy.ts
@@ -28,6 +28,7 @@ import { compareStrictNumericVersions } from "../server/deviceMatcher";
 import { releaseVersion } from "../utils/mcpVersion";
 import { defaultTimer, type Timer } from "../utils/SystemTimer";
 import { isExplicitPin, resolveAssetVersion, resolvePinnedVersion } from "../constants/release";
+import { SingleFlightInterval } from "./SingleFlightInterval";
 import {
   type BuildIdentity,
   buildIdentitiesMatch,
@@ -44,6 +45,8 @@ export type VersionMismatchReason =
   | "restartMismatch";
 
 export type BuildMismatchReason = "autoStartDisabled" | "cooldown" | "restartMismatch";
+
+const DAEMON_MCP_HEARTBEAT_INTERVAL_MS = 2_000;
 
 /**
  * Raised before connecting when the running daemon and MCP client package
@@ -140,6 +143,26 @@ export class DaemonAssetVersionMismatchError extends DaemonUnavailableError {
 }
 
 /**
+ * Raised after a daemon release proves that this transport's device-session
+ * identity is terminal. A fresh transport may create a new session; this bound
+ * transport must never silently resurrect its UUID against another device.
+ */
+export class DaemonBoundSessionExpiredError extends Error {
+  readonly sessionUuid: string;
+  readonly reason: string;
+
+  constructor(sessionUuid: string, reason: string) {
+    super(
+      `Device session ${sessionUuid} expired or was released (${reason}). ` +
+        "This MCP transport cannot create a replacement session; start a new transport.",
+    );
+    this.name = "DaemonBoundSessionExpiredError";
+    this.sessionUuid = sessionUuid;
+    this.reason = reason;
+  }
+}
+
+/**
  * Raised when a tool the frontend advertises is rejected by the daemon as
  * "Unknown tool" even after the proxy reconciled build identity and retried.
  * Replaces the opaque `-32603` with an actionable message naming both builds.
@@ -181,8 +204,8 @@ export interface DaemonMcpProxyConfig {
   daemonManager?: DaemonManagerLike;
   /** Options to pass when auto-starting the daemon */
   daemonOptions?: DaemonOptions;
-  /** Timer for version restart cooldown checks */
-  timer?: Pick<Timer, "now">;
+  /** Timer for restart cooldown checks and bound-session heartbeats. */
+  timer?: Timer;
   /** This client's build identity (for testing; defaults to the current process build) */
   buildIdentity?: BuildIdentity;
   /** This client's version for the daemon version gate (defaults to DAEMON_VERSION; injectable for testing) */
@@ -367,7 +390,8 @@ export class DaemonMcpProxy {
   private config: DaemonMcpProxyConfig;
   private daemonManager: DaemonManagerLike;
   private clientFactory: DaemonClientFactory;
-  private readonly timer: Pick<Timer, "now">;
+  private readonly timer: Timer;
+  private readonly heartbeatKeeper: SingleFlightInterval;
   private readonly buildIdentity: BuildIdentity;
   private readonly clientVersion: string;
   private readonly clientAssetVersion: string | null;
@@ -382,6 +406,12 @@ export class DaemonMcpProxy {
   // refreshing it, the remembered UUID is treated as retired so a sessionless
   // call is not rewritten to a released session (issue #4610).
   private boundSessionUuidAt: number | undefined;
+  // Once the daemon confirms this transport's bound session is gone, preserve
+  // that terminal identity instead of clearing it and allowing the same UUID to
+  // acquire another device.
+  private terminalBoundSession:
+    | { sessionUuid: string; reason: string }
+    | undefined;
   // Startup bindings remain authoritative until the daemon signals release.
   // Replay expiration only protects bindings inferred from ordinary calls.
   private initialSessionBindingConfigured = false;
@@ -401,6 +431,7 @@ export class DaemonMcpProxy {
   // actually forwarded, while a release of the forwarded UUID still preserves.
   private releaseEpoch: number = 0;
   private readonly releasedSessionEpochs = new Map<string, number>();
+  private readonly releasedSessionReasons = new Map<string, string>();
   // Monotonic counter bumped whenever a daemon push invalidates a discovery cache
   // or the session binding mid-flight (list_changed nulls a cache; a bound-session
   // release changes the session scope). A `tools/list` / `resources/list` captures
@@ -434,6 +465,16 @@ export class DaemonMcpProxy {
       config.clientFactory ??
       (() => new DaemonClient(this.config.socketPath, this.config.connectionTimeoutMs));
     this.timer = config.timer ?? defaultTimer;
+    this.heartbeatKeeper = new SingleFlightInterval(
+      this.timer,
+      DAEMON_MCP_HEARTBEAT_INTERVAL_MS,
+      () => this.sendBoundSessionHeartbeat(),
+      {
+        onError: error => {
+          logger.warn(`[DaemonMcpProxy] Bound-session heartbeat failed: ${error}`);
+        },
+      },
+    );
     if (
       typeof config.initialSessionUuid === "string" &&
       config.initialSessionUuid.trim().length > 0
@@ -520,6 +561,7 @@ export class DaemonMcpProxy {
         logger.warn(`[DaemonMcpProxy] Failed to subscribe to daemon notifications: ${error}`);
       }
     }
+    this.startBoundSessionHeartbeat();
   }
 
   /**
@@ -537,24 +579,7 @@ export class DaemonMcpProxy {
 
   private handleDaemonNotification(notification: DaemonNotification): void {
     if (notification.method === SESSION_RELEASED_NOTIFICATION_METHOD) {
-      // The daemon actually released a session. Record the release against the
-      // SPECIFIC UUID (issue #4655) so an in-flight call that forwarded exactly
-      // this session declines to re-remember it on completion — regardless of
-      // whether it is the currently-bound session. If it IS the one this proxy
-      // remembers, also drop the binding NOW so a later sessionless call is not
-      // rewritten to the retired UUID (issue #4610). A non-matching key —
-      // including a derived `${base}:${label}` release when we hold the base —
-      // leaves the binding intact. The replay TTL stays as a dropped-frame
-      // backstop for when this signal never arrives.
-      if (typeof notification.sessionId === "string" && notification.sessionId.length > 0) {
-        this.recordSessionReleased(notification.sessionId);
-      }
-      if (this.boundSessionUuid !== undefined && notification.sessionId === this.boundSessionUuid) {
-        // A bound-session release changes the scope of any in-flight discovery
-        // forwarded with that UUID, so invalidate pending discovery too (#4655).
-        this.discoveryEpoch += 1;
-        this.clearBoundSessionUuid();
-      }
+      this.handleSessionReleasedNotification(notification);
       return;
     }
 
@@ -585,6 +610,30 @@ export class DaemonMcpProxy {
         // break cache invalidation or sibling listeners.
         logger.warn(`[DaemonMcpProxy] list_changed listener failed for ${kind}: ${error}`);
       }
+    }
+  }
+
+  private handleSessionReleasedNotification(notification: DaemonNotification): void {
+    // Record the release against the specific UUID so an in-flight call that
+    // forwarded it cannot re-remember it. Exact matching leaves unrelated and
+    // derived sessions untouched; the replay TTL remains a dropped-frame
+    // backstop (issues #4610, #4655).
+    const releasedSessionUuid =
+      typeof notification.sessionId === "string" && notification.sessionId.length > 0
+        ? notification.sessionId
+        : undefined;
+    if (!releasedSessionUuid) {
+      return;
+    }
+    this.recordSessionReleased(releasedSessionUuid, notification.reason);
+    if (
+      releasedSessionUuid === this.boundSessionUuid ||
+      releasedSessionUuid === this.terminalBoundSession?.sessionUuid
+    ) {
+      this.fenceBoundSessionUuid(
+        releasedSessionUuid,
+        notification.reason ?? "released",
+      );
     }
   }
 
@@ -877,12 +926,18 @@ export class DaemonMcpProxy {
     }
   }
 
-  private async withRecoverableReconnect<T>(operation: () => Promise<T>): Promise<T> {
+  private async withRecoverableReconnect<T>(
+    operation: () => Promise<T>,
+    attemptedSessionUuid?: string,
+  ): Promise<T> {
+    this.throwIfBoundSessionFenced();
     await this.ensureConnected();
+    this.throwIfBoundSessionFenced();
 
     try {
       return await operation();
     } catch (error) {
+      this.throwIfBoundSessionFenced();
       if (!this.isRecoverableDaemonSessionError(error)) {
         throw error;
       }
@@ -891,17 +946,23 @@ export class DaemonMcpProxy {
         `[DaemonMcpProxy] Daemon session is stale, reconnecting and retrying once: ${error instanceof Error ? error.message : String(error)}`,
       );
       await this.resetConnection();
+      this.throwIfBoundSessionFenced();
       await this.ensureConnected();
+      this.throwIfBoundSessionFenced();
       try {
         return await operation();
       } catch (retryError) {
-        // A configured binding normally survives beyond the replay TTL, because
-        // only an actual daemon release may retire it. If the release push was
-        // missed, two authoritative "Session not found" responses prove the
-        // configured session is gone, so unblock an explicit replacement.
-        if (this.initialSessionBindingConfigured && this.isDaemonSessionNotFoundError(retryError)) {
-          this.discoveryEpoch += 1;
-          this.clearBoundSessionUuid();
+        this.throwIfBoundSessionFenced();
+        if (
+          attemptedSessionUuid &&
+          this.boundSessionUuid === attemptedSessionUuid &&
+          this.isDaemonSessionNotFoundError(retryError)
+        ) {
+          this.fenceBoundSessionUuid(
+            attemptedSessionUuid,
+            "session-not-found",
+          );
+          throw this.boundSessionExpiredError();
         }
         throw retryError;
       }
@@ -953,6 +1014,7 @@ export class DaemonMcpProxy {
    * Get list of available tools from daemon
    */
   async listTools(): Promise<ProxiedToolDefinition[]> {
+    this.throwIfBoundSessionUnavailable();
     // Return cached tools if available
     if (this.cachedTools) {
       return this.cachedTools;
@@ -962,15 +1024,13 @@ export class DaemonMcpProxy {
       // Bind discovery to the session like callTool does. Without this, a
       // recoverable reconnect INSIDE withRecoverableReconnect retries tools/list
       // with empty params against the fresh UNSEEDED transport, which returns the
-      // full unfiltered tool list instead of the session-scoped one. Computing the
-      // forwarded params inside the operation closure re-seeds the retry after a
-      // reconnect (issue #4610).
+      // full unfiltered tool list instead of the session-scoped one. Reusing the
+      // session-scoped params re-seeds the retry after a reconnect (issue #4610).
       const discoveryEpoch = this.discoveryEpoch;
-      const result = await this.withRecoverableReconnect(() =>
-        this.client!.callDaemonMethod(
-          "tools/list",
-          this.withCapabilityProfile(this.withBoundSessionUuid({})),
-        ),
+      const forwardedParams = this.withCapabilityProfile(this.withBoundSessionUuid({}));
+      const result = await this.withRecoverableReconnect(
+        () => this.client!.callDaemonMethod("tools/list", forwardedParams),
+        this.sessionUuidFromArgs(forwardedParams),
       );
       const tools = result?.tools ?? [];
       // If a list_changed or bound-session release invalidated this cache WHILE the
@@ -998,6 +1058,7 @@ export class DaemonMcpProxy {
     const routingArgs =
       name === SET_TOOL_CAPABILITY_TOOL_NAME ? args : this.withBoundSessionUuid(args);
     const forwardedArgs = this.withCapabilityProfile(routingArgs);
+    const forwardedSessionUuid = this.sessionUuidFromArgs(forwardedArgs);
     // Snapshot the release epoch at forward time. If a session-released signal for
     // the SPECIFIC forwarded UUID lands WHILE this call is in flight, that UUID's
     // recorded epoch advances past this snapshot and the completion path below
@@ -1006,8 +1067,12 @@ export class DaemonMcpProxy {
     // so it does not block remembering the session this call forwarded.
     const callReleaseEpoch = this.releaseEpoch;
     try {
-      const result = await this.withRecoverableReconnect(() =>
-        this.client!.callTool(name, forwardedArgs),
+      const result = await this.withRecoverableReconnect(
+        () => {
+          this.throwIfForwardedSessionReleasedSince(forwardedArgs, callReleaseEpoch);
+          return this.client!.callTool(name, forwardedArgs);
+        },
+        forwardedSessionUuid,
       );
       this.rememberCapabilityProfile(name, args, result);
       // Remember what was actually forwarded, not the caller's raw args. An
@@ -1046,15 +1111,13 @@ export class DaemonMcpProxy {
   }
 
   private withBoundSessionUuid(args: Record<string, unknown>): Record<string, unknown> {
+    this.throwIfBoundSessionUnavailable();
     // A daemon session released by ordinary heartbeat/idle expiry leaves this
     // remembered binding dangling; replaying its UUID on a later sessionless call
     // would silently recreate the session and reacquire a device without the
     // caller asking for it (issue #4610). Once the replay window has elapsed with
     // no forwarded call (explicit or implicit) refreshing the binding, treat it
     // as retired.
-    if (this.isBoundSessionReplayExpired()) {
-      this.clearBoundSessionUuid();
-    }
     const explicitSessionUuid =
       typeof args.sessionUuid === "string" && args.sessionUuid.trim().length > 0
         ? args.sessionUuid
@@ -1076,6 +1139,21 @@ export class DaemonMcpProxy {
       sessionUuid: this.boundSessionUuid,
       [DAEMON_BOUND_SESSION_PARAM]: this.boundSessionUuid,
     };
+  }
+
+  private throwIfBoundSessionUnavailable(): void {
+    this.throwIfBoundSessionFenced();
+    if (!this.isBoundSessionReplayExpired()) {
+      return;
+    }
+    this.fenceBoundSessionUuid(this.boundSessionUuid!, "replay-lease-expired");
+    throw this.boundSessionExpiredError();
+  }
+
+  private sessionUuidFromArgs(args: Record<string, unknown>): string | undefined {
+    return typeof args.sessionUuid === "string" && args.sessionUuid.trim().length > 0
+      ? args.sessionUuid.trim()
+      : undefined;
   }
 
   private withCapabilityProfile(args: Record<string, unknown>): Record<string, unknown> {
@@ -1121,32 +1199,128 @@ export class DaemonMcpProxy {
     this.initialSessionBindingConfigured = false;
   }
 
+  private fenceBoundSessionUuid(sessionUuid: string, reason: string): void {
+    if (this.terminalBoundSession) {
+      if (
+        this.terminalBoundSession.sessionUuid === sessionUuid &&
+        reason !== "released"
+      ) {
+        this.terminalBoundSession.reason = reason;
+      }
+      return;
+    }
+    this.terminalBoundSession = { sessionUuid, reason };
+    // A terminal release changes the scope of in-flight discovery and prevents
+    // its stale response from repopulating a cleared cache.
+    this.discoveryEpoch += 1;
+    this.invalidateCache();
+    this.clearBoundSessionUuid();
+    void this.stopBoundSessionHeartbeat();
+  }
+
+  private throwIfBoundSessionFenced(): void {
+    if (this.terminalBoundSession) {
+      throw this.boundSessionExpiredError();
+    }
+  }
+
+  private boundSessionExpiredError(): DaemonBoundSessionExpiredError {
+    const terminal = this.terminalBoundSession;
+    if (!terminal) {
+      throw new Error("Bound session is not terminal");
+    }
+    return new DaemonBoundSessionExpiredError(terminal.sessionUuid, terminal.reason);
+  }
+
+  private startBoundSessionHeartbeat(): void {
+    if (this.boundSessionUuid && !this.terminalBoundSession && this.connected) {
+      this.heartbeatKeeper.start();
+    }
+  }
+
+  private async stopBoundSessionHeartbeat(): Promise<void> {
+    const settled = await this.heartbeatKeeper.stop();
+    if (!settled) {
+      logger.warn("[DaemonMcpProxy] Bound-session heartbeat did not settle before shutdown");
+    }
+  }
+
+  private async sendBoundSessionHeartbeat(): Promise<void> {
+    const sessionUuid = this.boundSessionUuid;
+    if (!sessionUuid || this.terminalBoundSession) {
+      return;
+    }
+    try {
+      await this.withRecoverableReconnect(() =>
+        this.client!.callDaemonMethod("daemon/heartbeat", { sessionId: sessionUuid }),
+        sessionUuid,
+      );
+    } catch (error) {
+      if (error instanceof DaemonBoundSessionExpiredError) {
+        // Terminal fencing already stopped the keeper; this tick has no further work.
+        logger.debug(`[DaemonMcpProxy] Bound-session heartbeat stopped: ${error.message}`);
+        return;
+      }
+      throw error;
+    }
+    if (this.boundSessionUuid === sessionUuid && !this.terminalBoundSession) {
+      this.boundSessionUuidAt = this.timer.now();
+    }
+  }
+
   // Record that the daemon released a specific session UUID, advancing the global
   // release epoch. An in-flight call that forwarded this exact UUID compares its
   // captured epoch against this entry and declines to resurrect the released
   // session on completion (issue #4655). Scoping the record to the UUID — not a
   // global counter — is what lets an unrelated session's release NOT block
   // remembering the session another in-flight call forwarded.
-  private recordSessionReleased(sessionUuid: string): void {
+  private recordSessionReleased(sessionUuid: string, reason?: string): void {
     this.releaseEpoch += 1;
     this.releasedSessionEpochs.set(sessionUuid, this.releaseEpoch);
+    this.releasedSessionReasons.set(sessionUuid, reason ?? "released");
   }
 
-  // True when the session THIS call forwarded was released at a later epoch than
-  // the one captured at forward time — i.e. a release for the forwarded UUID
-  // landed WHILE the call was in flight. A release of any OTHER session advances
-  // the global epoch but leaves the forwarded UUID's entry untouched, so this
-  // stays false for it (issue #4655).
-  private wasForwardedSessionReleasedSince(
+  private forwardedSessionReleaseReasonSince(
     forwardedArgs: Record<string, unknown>,
     forwardEpoch: number,
-  ): boolean {
-    const forwardedUuid =
-      typeof forwardedArgs.sessionUuid === "string" ? forwardedArgs.sessionUuid : undefined;
-    if (forwardedUuid === undefined || forwardedUuid.trim().length === 0) {
-      return false;
+  ): string | undefined {
+    const forwardedUuid = this.sessionUuidFromArgs(forwardedArgs);
+    if (
+      !forwardedUuid ||
+      (this.releasedSessionEpochs.get(forwardedUuid) ?? 0) <= forwardEpoch
+    ) {
+      return undefined;
     }
-    return (this.releasedSessionEpochs.get(forwardedUuid) ?? 0) > forwardEpoch;
+    return this.releasedSessionReasons.get(forwardedUuid) ?? "released";
+  }
+
+  private fenceReleasedForwardedSession(
+    forwardedArgs: Record<string, unknown>,
+    reason: string,
+  ): void {
+    const forwardedUuid = this.sessionUuidFromArgs(forwardedArgs) ?? "";
+    if (
+      forwardedUuid.length > 0
+      && (!this.boundSessionUuid || this.boundSessionUuid === forwardedUuid)
+    ) {
+      this.fenceBoundSessionUuid(forwardedUuid, reason);
+    }
+  }
+
+  private throwIfForwardedSessionReleasedSince(
+    forwardedArgs: Record<string, unknown>,
+    forwardEpoch: number,
+  ): void {
+    const reason = this.forwardedSessionReleaseReasonSince(forwardedArgs, forwardEpoch);
+    if (!reason) {
+      return;
+    }
+    const forwardedUuid = this.sessionUuidFromArgs(forwardedArgs)!;
+    this.fenceReleasedForwardedSession(forwardedArgs, reason);
+    if (this.terminalBoundSession?.sessionUuid === forwardedUuid) {
+      throw this.boundSessionExpiredError();
+    }
+    throw new DaemonBoundSessionExpiredError(forwardedUuid, reason);
   }
 
   // Called with the FORWARDED args (post-withBoundSessionUuid), so an implicit
@@ -1159,7 +1333,9 @@ export class DaemonMcpProxy {
     callReleaseEpoch: number,
   ): void {
     if (name === "executePlan") {
-      this.clearBoundSessionUuid();
+      // The daemon owns plan-session release. Preserve the binding until its
+      // release notification (or heartbeat not-found fallback) terminally fences
+      // this transport.
       return;
     }
     if (name === SET_TOOL_CAPABILITY_TOOL_NAME) {
@@ -1171,7 +1347,10 @@ export class DaemonMcpProxy {
     // sessionless call recreate it (issue #4611). Scoped to the forwarded UUID so
     // an unrelated session's mid-call release does NOT block this remember (issue
     // #4655); a later explicit call re-binds normally.
-    if (this.wasForwardedSessionReleasedSince(forwardedArgs, callReleaseEpoch)) {
+    const releaseReason =
+      this.forwardedSessionReleaseReasonSince(forwardedArgs, callReleaseEpoch);
+    if (releaseReason) {
+      this.fenceReleasedForwardedSession(forwardedArgs, releaseReason);
       return;
     }
     if (
@@ -1180,6 +1359,7 @@ export class DaemonMcpProxy {
     ) {
       this.boundSessionUuid = forwardedArgs.sessionUuid;
       this.boundSessionUuidAt = this.timer.now();
+      this.startBoundSessionHeartbeat();
     }
   }
 
@@ -1211,7 +1391,10 @@ export class DaemonMcpProxy {
     // mid-flight already recorded it, so an admitted-then-rejected call must not
     // re-refresh the released UUID's lease (issue #4611/#4655). The session is
     // gone; resurrecting the lease would replay it on the next sessionless call.
-    if (this.wasForwardedSessionReleasedSince(forwardedArgs, callReleaseEpoch)) {
+    const releaseReason =
+      this.forwardedSessionReleaseReasonSince(forwardedArgs, callReleaseEpoch);
+    if (releaseReason) {
+      this.fenceReleasedForwardedSession(forwardedArgs, releaseReason);
       return;
     }
     if (
@@ -1220,6 +1403,7 @@ export class DaemonMcpProxy {
     ) {
       this.boundSessionUuid = forwardedArgs.sessionUuid;
       this.boundSessionUuidAt = this.timer.now();
+      this.startBoundSessionHeartbeat();
     }
   }
 
@@ -1244,6 +1428,7 @@ export class DaemonMcpProxy {
    * Get list of available resources from daemon
    */
   async listResources(): Promise<ProxiedResourceDefinition[]> {
+    this.throwIfBoundSessionUnavailable();
     // Return cached resources if available
     if (this.cachedResources) {
       return this.cachedResources;
@@ -1251,8 +1436,10 @@ export class DaemonMcpProxy {
 
     try {
       const discoveryEpoch = this.discoveryEpoch;
+      const forwardedParams = this.withBoundSessionUuid({});
       const result = await this.withRecoverableReconnect(() =>
-        this.client!.callDaemonMethod("resources/list", this.withBoundSessionUuid({})),
+        this.client!.callDaemonMethod("resources/list", forwardedParams),
+        this.sessionUuidFromArgs(forwardedParams),
       );
       const resources = result?.resources ?? [];
       // Discard a response invalidated mid-flight rather than caching the stale
@@ -1271,6 +1458,7 @@ export class DaemonMcpProxy {
    * Get list of resource templates from daemon
    */
   async listResourceTemplates(): Promise<ProxiedResourceTemplate[]> {
+    this.throwIfBoundSessionUnavailable();
     // Return cached templates if available
     if (this.cachedResourceTemplates) {
       return this.cachedResourceTemplates;
@@ -1278,8 +1466,10 @@ export class DaemonMcpProxy {
 
     try {
       const discoveryEpoch = this.discoveryEpoch;
+      const forwardedParams = this.withBoundSessionUuid({});
       const result = await this.withRecoverableReconnect(() =>
-        this.client!.callDaemonMethod("resources/list-templates", this.withBoundSessionUuid({})),
+        this.client!.callDaemonMethod("resources/list-templates", forwardedParams),
+        this.sessionUuidFromArgs(forwardedParams),
       );
       const templates = result?.resourceTemplates ?? [];
       // Discard a response invalidated mid-flight rather than caching the stale
@@ -1298,8 +1488,10 @@ export class DaemonMcpProxy {
    * Read a resource from the daemon
    */
   async readResource(uri: string): Promise<any> {
+    const forwardedParams = this.withBoundSessionUuid({});
     return await this.withRecoverableReconnect(() =>
-      this.client!.readResource(uri, this.withBoundSessionUuid({})),
+      this.client!.readResource(uri, forwardedParams),
+      this.sessionUuidFromArgs(forwardedParams),
     );
   }
 
@@ -1323,6 +1515,7 @@ export class DaemonMcpProxy {
    * Close the connection to daemon
    */
   async close(): Promise<void> {
+    await this.stopBoundSessionHeartbeat();
     if (this.client) {
       await this.client.close();
       this.client = null;
@@ -1331,6 +1524,7 @@ export class DaemonMcpProxy {
     this.notificationUnsubscribe = null;
     this.connected = false;
     this.clearBoundSessionUuid();
+    this.terminalBoundSession = undefined;
     this.invalidateCache();
     logger.debug("[DaemonMcpProxy] Disconnected from daemon");
   }

--- a/src/daemon/daemonMcpProxy.ts
+++ b/src/daemon/daemonMcpProxy.ts
@@ -619,8 +619,8 @@ export class DaemonMcpProxy {
     // derived sessions untouched; the replay TTL remains a dropped-frame
     // backstop (issues #4610, #4655).
     const releasedSessionUuid =
-      typeof notification.sessionId === "string" && notification.sessionId.length > 0
-        ? notification.sessionId
+      typeof notification.sessionId === "string" && notification.sessionId.trim().length > 0
+        ? notification.sessionId.trim()
         : undefined;
     if (!releasedSessionUuid) {
       return;
@@ -1118,12 +1118,13 @@ export class DaemonMcpProxy {
     // caller asking for it (issue #4610). Once the replay window has elapsed with
     // no forwarded call (explicit or implicit) refreshing the binding, treat it
     // as retired.
-    const explicitSessionUuid =
-      typeof args.sessionUuid === "string" && args.sessionUuid.trim().length > 0
-        ? args.sessionUuid
-        : undefined;
+    const explicitSessionUuid = this.sessionUuidFromArgs(args);
+    const normalizedArgs =
+      explicitSessionUuid && explicitSessionUuid !== args.sessionUuid
+        ? { ...args, sessionUuid: explicitSessionUuid }
+        : args;
     if (!this.boundSessionUuid || explicitSessionUuid === this.boundSessionUuid) {
-      return args;
+      return normalizedArgs;
     }
     if (explicitSessionUuid && this.initialSessionBindingConfigured) {
       throw new Error(
@@ -1132,7 +1133,7 @@ export class DaemonMcpProxy {
       );
     }
     if (explicitSessionUuid) {
-      return args;
+      return normalizedArgs;
     }
     return {
       ...args,
@@ -1275,9 +1276,13 @@ export class DaemonMcpProxy {
   // global counter — is what lets an unrelated session's release NOT block
   // remembering the session another in-flight call forwarded.
   private recordSessionReleased(sessionUuid: string, reason?: string): void {
+    const normalizedSessionUuid = sessionUuid.trim();
+    if (normalizedSessionUuid.length === 0) {
+      return;
+    }
     this.releaseEpoch += 1;
-    this.releasedSessionEpochs.set(sessionUuid, this.releaseEpoch);
-    this.releasedSessionReasons.set(sessionUuid, reason ?? "released");
+    this.releasedSessionEpochs.set(normalizedSessionUuid, this.releaseEpoch);
+    this.releasedSessionReasons.set(normalizedSessionUuid, reason ?? "released");
   }
 
   private forwardedSessionReleaseReasonSince(
@@ -1353,11 +1358,9 @@ export class DaemonMcpProxy {
       this.fenceReleasedForwardedSession(forwardedArgs, releaseReason);
       return;
     }
-    if (
-      typeof forwardedArgs.sessionUuid === "string" &&
-      forwardedArgs.sessionUuid.trim().length > 0
-    ) {
-      this.boundSessionUuid = forwardedArgs.sessionUuid;
+    const rememberedSessionUuid = this.sessionUuidFromArgs(forwardedArgs);
+    if (rememberedSessionUuid) {
+      this.boundSessionUuid = rememberedSessionUuid;
       this.boundSessionUuidAt = this.timer.now();
       this.startBoundSessionHeartbeat();
     }
@@ -1397,11 +1400,9 @@ export class DaemonMcpProxy {
       this.fenceReleasedForwardedSession(forwardedArgs, releaseReason);
       return;
     }
-    if (
-      typeof forwardedArgs.sessionUuid === "string" &&
-      forwardedArgs.sessionUuid.trim().length > 0
-    ) {
-      this.boundSessionUuid = forwardedArgs.sessionUuid;
+    const admittedSessionUuid = this.sessionUuidFromArgs(forwardedArgs);
+    if (admittedSessionUuid) {
+      this.boundSessionUuid = admittedSessionUuid;
       this.boundSessionUuidAt = this.timer.now();
       this.startBoundSessionHeartbeat();
     }

--- a/src/daemon/daemonMcpProxy.ts
+++ b/src/daemon/daemonMcpProxy.ts
@@ -48,6 +48,20 @@ export type BuildMismatchReason = "autoStartDisabled" | "cooldown" | "restartMis
 
 const DAEMON_MCP_HEARTBEAT_INTERVAL_MS = 2_000;
 
+function heartbeatIntervalMs(config: DaemonMcpProxyConfig): number {
+  const configuredTimeout = config.heartbeatTimeoutMs;
+  const configuredInterval = config.heartbeatIntervalMs;
+  const interval =
+    configuredInterval ??
+    (configuredTimeout === undefined
+      ? DAEMON_MCP_HEARTBEAT_INTERVAL_MS
+      : Math.floor(configuredTimeout / 2));
+  if (!Number.isFinite(interval) || interval <= 0) {
+    throw new Error("heartbeat interval must be a positive finite number");
+  }
+  return Math.max(1, interval);
+}
+
 /**
  * Raised before connecting when the running daemon and MCP client package
  * versions differ but the proxy cannot safely reconcile them immediately.
@@ -206,6 +220,10 @@ export interface DaemonMcpProxyConfig {
   daemonOptions?: DaemonOptions;
   /** Timer for restart cooldown checks and bound-session heartbeats. */
   timer?: Timer;
+  /** Daemon session heartbeat timeout used to derive a safe cadence when unset. */
+  heartbeatTimeoutMs?: number;
+  /** Explicit bound-session heartbeat cadence; defaults to half the timeout or 2s. */
+  heartbeatIntervalMs?: number;
   /** This client's build identity (for testing; defaults to the current process build) */
   buildIdentity?: BuildIdentity;
   /** This client's version for the daemon version gate (defaults to DAEMON_VERSION; injectable for testing) */
@@ -397,6 +415,7 @@ export class DaemonMcpProxy {
   private readonly clientAssetVersion: string | null;
   private connecting: Promise<void> | null = null;
   private connected: boolean = false;
+  private closing: boolean = false;
   // The daemon clears socket-local state when its RPC connection drops. Keep this
   // proxy's successful explicit binding so subsequent sessionless calls can seed
   // a replacement socket without sharing the binding with other proxies.
@@ -467,7 +486,7 @@ export class DaemonMcpProxy {
     this.timer = config.timer ?? defaultTimer;
     this.heartbeatKeeper = new SingleFlightInterval(
       this.timer,
-      DAEMON_MCP_HEARTBEAT_INTERVAL_MS,
+      heartbeatIntervalMs(config),
       () => this.sendBoundSessionHeartbeat(),
       {
         onError: error => {
@@ -493,6 +512,9 @@ export class DaemonMcpProxy {
    * Will auto-start daemon if configured and daemon is not running
    */
   async ensureConnected(): Promise<void> {
+    if (this.closing) {
+      throw new DaemonUnavailableError("MCP proxy is closing");
+    }
     if (this.connected && this.client) {
       return;
     }
@@ -511,6 +533,9 @@ export class DaemonMcpProxy {
   }
 
   private async doConnect(): Promise<void> {
+    if (this.closing) {
+      throw new DaemonUnavailableError("MCP proxy is closing");
+    }
     // Check if daemon is available
     const socketPath = this.config.socketPath ?? SOCKET_PATH;
     const isAvailable = await DaemonClient.isAvailable(socketPath);
@@ -533,6 +558,9 @@ export class DaemonMcpProxy {
     }
 
     // Create and connect client
+    if (this.closing) {
+      throw new DaemonUnavailableError("MCP proxy is closing");
+    }
     this.client = this.clientFactory();
     const client = this.client;
     // Wire daemon-pushed list-changed forwarding (issue #3223) when the client
@@ -548,6 +576,10 @@ export class DaemonMcpProxy {
       );
     }
     await client.connect();
+    if (this.closing) {
+      await client.close();
+      throw new DaemonUnavailableError("MCP proxy is closing");
+    }
     this.connected = true;
     logger.info("[DaemonMcpProxy] Connected to daemon");
 
@@ -930,6 +962,9 @@ export class DaemonMcpProxy {
     operation: () => Promise<T>,
     attemptedSessionUuid?: string,
   ): Promise<T> {
+    if (this.closing) {
+      throw new DaemonUnavailableError("MCP proxy is closing");
+    }
     this.throwIfBoundSessionFenced();
     await this.ensureConnected();
     this.throwIfBoundSessionFenced();
@@ -937,6 +972,9 @@ export class DaemonMcpProxy {
     try {
       return await operation();
     } catch (error) {
+      if (this.closing) {
+        throw error;
+      }
       this.throwIfBoundSessionFenced();
       if (!this.isRecoverableDaemonSessionError(error)) {
         throw error;
@@ -1124,6 +1162,12 @@ export class DaemonMcpProxy {
         ? { ...args, sessionUuid: explicitSessionUuid }
         : args;
     if (!this.boundSessionUuid || explicitSessionUuid === this.boundSessionUuid) {
+      if (explicitSessionUuid === this.boundSessionUuid && this.boundSessionUuid) {
+        return {
+          ...normalizedArgs,
+          [DAEMON_BOUND_SESSION_PARAM]: this.boundSessionUuid,
+        };
+      }
       return normalizedArgs;
     }
     if (explicitSessionUuid && this.initialSessionBindingConfigured) {
@@ -1234,7 +1278,8 @@ export class DaemonMcpProxy {
   }
 
   private startBoundSessionHeartbeat(): void {
-    if (this.boundSessionUuid && !this.terminalBoundSession && this.connected) {
+    if (this.boundSessionUuid && !this.terminalBoundSession && this.connected && !this.closing) {
+      void this.heartbeatKeeper.run();
       this.heartbeatKeeper.start();
     }
   }
@@ -1248,7 +1293,7 @@ export class DaemonMcpProxy {
 
   private async sendBoundSessionHeartbeat(): Promise<void> {
     const sessionUuid = this.boundSessionUuid;
-    if (!sessionUuid || this.terminalBoundSession) {
+    if (!sessionUuid || this.terminalBoundSession || this.closing) {
       return;
     }
     try {
@@ -1516,6 +1561,7 @@ export class DaemonMcpProxy {
    * Close the connection to daemon
    */
   async close(): Promise<void> {
+    this.closing = true;
     await this.stopBoundSessionHeartbeat();
     if (this.client) {
       await this.client.close();

--- a/src/daemon/daemonMcpProxy.ts
+++ b/src/daemon/daemonMcpProxy.ts
@@ -420,6 +420,7 @@ export class DaemonMcpProxy {
   private readonly clientVersion: string;
   private readonly clientAssetVersion: string | null;
   private connecting: Promise<void> | null = null;
+  private connectionCloseReject: ((reason?: unknown) => void) | null = null;
   private connected: boolean = false;
   private closing: boolean = false;
   // The daemon clears socket-local state when its RPC connection drops. Keep this
@@ -457,6 +458,7 @@ export class DaemonMcpProxy {
   private releaseEpoch: number = 0;
   private readonly releasedSessionEpochs = new Map<string, number>();
   private readonly releasedSessionReasons = new Map<string, string>();
+  private readonly activeReleaseEpochReferences = new Map<string, number>();
   // Monotonic counter bumped whenever a daemon push invalidates a discovery cache
   // or the session binding mid-flight (list_changed nulls a cache; a bound-session
   // release changes the session scope). A `tools/list` / `resources/list` captures
@@ -530,11 +532,19 @@ export class DaemonMcpProxy {
       return this.connecting;
     }
 
-    this.connecting = this.doConnect();
+    const attempt = this.doConnect();
+    const connecting = new Promise<void>((resolve, reject) => {
+      this.connectionCloseReject = reject;
+      void attempt.then(resolve, reject);
+    });
+    this.connecting = connecting;
     try {
-      await this.connecting;
+      await connecting;
     } finally {
-      this.connecting = null;
+      if (this.connecting === connecting) {
+        this.connecting = null;
+        this.connectionCloseReject = null;
+      }
     }
   }
 
@@ -1103,6 +1113,7 @@ export class DaemonMcpProxy {
       name === SET_TOOL_CAPABILITY_TOOL_NAME ? args : this.withBoundSessionUuid(args);
     const forwardedArgs = this.withCapabilityProfile(routingArgs);
     const forwardedSessionUuid = this.sessionUuidFromArgs(forwardedArgs);
+    this.retainReleaseEpochReference(forwardedSessionUuid);
     // Snapshot the release epoch at forward time. If a session-released signal for
     // the SPECIFIC forwarded UUID lands WHILE this call is in flight, that UUID's
     // recorded epoch advances past this snapshot and the completion path below
@@ -1151,6 +1162,8 @@ export class DaemonMcpProxy {
         throw await this.toolUnavailableError(name);
       }
       throw error;
+    } finally {
+      this.releaseReleaseEpochReference(forwardedSessionUuid);
     }
   }
 
@@ -1332,8 +1345,35 @@ export class DaemonMcpProxy {
       return;
     }
     this.releaseEpoch += 1;
+    if (!this.activeReleaseEpochReferences.has(normalizedSessionUuid)) {
+      return;
+    }
     this.releasedSessionEpochs.set(normalizedSessionUuid, this.releaseEpoch);
     this.releasedSessionReasons.set(normalizedSessionUuid, reason ?? "released");
+  }
+
+  private retainReleaseEpochReference(sessionUuid: string | undefined): void {
+    if (!sessionUuid) {
+      return;
+    }
+    this.activeReleaseEpochReferences.set(
+      sessionUuid,
+      (this.activeReleaseEpochReferences.get(sessionUuid) ?? 0) + 1,
+    );
+  }
+
+  private releaseReleaseEpochReference(sessionUuid: string | undefined): void {
+    if (!sessionUuid) {
+      return;
+    }
+    const references = (this.activeReleaseEpochReferences.get(sessionUuid) ?? 0) - 1;
+    if (references > 0) {
+      this.activeReleaseEpochReferences.set(sessionUuid, references);
+      return;
+    }
+    this.activeReleaseEpochReferences.delete(sessionUuid);
+    this.releasedSessionEpochs.delete(sessionUuid);
+    this.releasedSessionReasons.delete(sessionUuid);
   }
 
   private forwardedSessionReleaseReasonSince(
@@ -1568,6 +1608,7 @@ export class DaemonMcpProxy {
    */
   async close(): Promise<void> {
     this.closing = true;
+    this.connectionCloseReject?.(new DaemonUnavailableError("MCP proxy is closing"));
     await this.stopBoundSessionHeartbeat();
     if (this.client) {
       await this.client.close();

--- a/src/daemon/sessionManager.ts
+++ b/src/daemon/sessionManager.ts
@@ -116,6 +116,12 @@ export interface SessionDeviceAssigner {
 
 const KEEP_SCREEN_AWAKE_RESTORE_TIMEOUT_MS = 1_000;
 const SESSION_SETUP_DRAIN_TIMEOUT_MS = 1_000;
+const EXPIRY_RELEASE_REASONS = new Set([
+  "lazy-expiry",
+  "cleanup-expired",
+  "missing-first-heartbeat",
+  "heartbeat-timeout",
+]);
 
 export function getDefaultSessionHeartbeatTimeoutMs(): number {
   const rawValue = process.env.AUTOMOBILE_SESSION_HEARTBEAT_TIMEOUT_MS
@@ -735,20 +741,23 @@ export class SessionManager {
       }
       if (pendingCleanup.length > 0) {this.trackPendingDeviceCleanup(deviceId, pendingCleanup);}
 
-      try {
-        const terminalStatus = releaseReason === "lazy-expiry" || releaseReason === "cleanup-expired"
-          ? "expired"
-          : "released";
-        await this.deviceSessionRepository.markReleased(sessionId, terminalStatus, this.timer.now(), releaseReason);
-      } catch (error) {
-        logger.warn(`[SessionManager] Failed to mark session released (${releaseReason}): ${error}`);
-      }
+      // In-memory ownership is already terminal, so notify bound transports
+      // before awaiting best-effort persistence. This closes the window where a
+      // released UUID could be forwarded again while the DB write is pending.
       for (const callback of this.releaseCallbacks) {
         try {
           callback(sessionId, deviceId, releaseReason);
         } catch (error) {
           logger.warn(`Session release callback failed for ${sessionId}: ${error}`);
         }
+      }
+      try {
+        const terminalStatus = EXPIRY_RELEASE_REASONS.has(releaseReason)
+          ? "expired"
+          : "released";
+        await this.deviceSessionRepository.markReleased(sessionId, terminalStatus, this.timer.now(), releaseReason);
+      } catch (error) {
+        logger.warn(`[SessionManager] Failed to mark session released (${releaseReason}): ${error}`);
       }
       logger.info(
         pendingCleanup.length > 0

--- a/src/daemon/socketServer.ts
+++ b/src/daemon/socketServer.ts
@@ -229,6 +229,8 @@ class InputTypeTextAppendError extends Error {
 
 export class UnixSocketServer {
   private server: NetServer | null = null;
+  private closing = false;
+  private lifecycleGeneration = 0;
   private socketFileIdentity: SocketFileIdentity | null = null;
   private sessions: Map<string, SessionContext> = new Map();
   /** Live client sockets by session ID, for server-pushed notification frames (issue #3223). */
@@ -344,6 +346,8 @@ export class UnixSocketServer {
    * Start the Unix socket server
    */
   async start(): Promise<void> {
+    this.closing = false;
+    this.lifecycleGeneration += 1;
     // Owner-only (0o700) socket directory so the control socket is not
     // world-traversable. On macOS socket-file permission bits are not reliably
     // enforced on connect(), so the containing directory's mode is the primary
@@ -373,6 +377,7 @@ export class UnixSocketServer {
     // recovery-rewire reason as list-changed; close() unsubscribes symmetrically.
     this.sessionReleaseUnsubscribe?.();
     this.sessionReleaseUnsubscribe = SessionReleaseBroadcaster.subscribe((sessionId, reason) => {
+      this.clearBoundMcpClientsForReleasedSession(sessionId);
       this.broadcastSessionReleased(sessionId, reason);
     });
 
@@ -1136,6 +1141,14 @@ export class UnixSocketServer {
     }
     this.boundMcpClientKeysBySocketSession.delete(socketSessionId);
     this.scheduleMcpClientIdleClose(boundClient.clientKey);
+  }
+
+  private clearBoundMcpClientsForReleasedSession(sessionUuid: string): void {
+    for (const [socketSessionId, boundClient] of this.boundMcpClientKeysBySocketSession) {
+      if (boundClient.sessionUuid === sessionUuid) {
+        this.clearBoundMcpClientKey(socketSessionId);
+      }
+    }
   }
 
   private isMcpClientKeyBound(key: string): boolean {
@@ -2811,14 +2824,23 @@ export class UnixSocketServer {
       return existingPromise;
     }
 
+    const generation = this.lifecycleGeneration;
     const clientPromise = this.mcpClientFactory(boundSessionUuid, capabilityProfileUuid)
-      .then(client => {
+      .then(async client => {
+        if (this.closing || generation !== this.lifecycleGeneration) {
+          await client.close();
+          throw new Error("Unix socket server is closing");
+        }
         this.mcpClients.set(key, client);
-        this.mcpClientPromises.delete(key);
+        if (this.mcpClientPromises.get(key) === clientPromise) {
+          this.mcpClientPromises.delete(key);
+        }
         return client;
       })
       .catch(error => {
-        this.mcpClientPromises.delete(key);
+        if (this.mcpClientPromises.get(key) === clientPromise) {
+          this.mcpClientPromises.delete(key);
+        }
         throw error;
       });
 
@@ -2974,6 +2996,8 @@ export class UnixSocketServer {
    */
   async close(): Promise<void> {
     logger.info("Closing Unix socket server...");
+    this.closing = true;
+    this.lifecycleGeneration += 1;
 
     // Stop receiving list-changed events (mirrors the subscribe in start()).
     this.listChangedUnsubscribe?.();

--- a/src/daemon/socketServer.ts
+++ b/src/daemon/socketServer.ts
@@ -837,6 +837,30 @@ export class UnixSocketServer {
     }
 
     const boundRoute = this.getBoundMcpClientRoute(socketSessionId);
+    if (
+      request.method === "tools/list" ||
+      request.method === "resources/list" ||
+      request.method === "resources/list-templates"
+    ) {
+      return this.getDiscoveryForwardRoute(request, socketSessionId, boundRoute);
+    }
+
+    if (request.method === "ide/getNavigationGraph") {
+      return this.getNavigationGraphForwardRoute(request, socketSessionId, boundRoute);
+    }
+
+    if (request.method === "resources/read") {
+      return this.getResourceReadForwardRoute(request, socketSessionId);
+    }
+
+    return this.sharedMcpForwardRoute(`method:${request.method}`);
+  }
+
+  private getDiscoveryForwardRoute(
+    request: DaemonRequest,
+    socketSessionId: string,
+    boundRoute: McpForwardRoute | undefined,
+  ): McpForwardRoute {
     if (request.method === "tools/list") {
       // A reconnected restricted discovery re-sends `{sessionUuid}` (see
       // daemonMcpProxy.listTools). A fresh socket has no boundRoute, so without
@@ -856,15 +880,16 @@ export class UnixSocketServer {
       return boundRoute ?? this.sharedMcpForwardRoute(`method:${request.method}`);
     }
 
-    if (request.method === "ide/getNavigationGraph") {
-      return this.getNavigationGraphForwardRoute(request, socketSessionId, boundRoute);
+    const sessionUuid = this.getSessionUuid(request.params);
+    const capabilityProfileUuid = this.getCapabilityProfileUuid(request.params);
+    this.throwIfReleasedBoundSession(request.params);
+    if (sessionUuid) {
+      return this.sessionScopedForwardRoute(socketSessionId, sessionUuid, undefined, capabilityProfileUuid);
     }
-
-    if (request.method === "resources/read") {
-      return this.getResourceReadForwardRoute(request, socketSessionId);
+    if (capabilityProfileUuid) {
+      return this.capabilityProfileScopedForwardRoute(socketSessionId, capabilityProfileUuid, undefined);
     }
-
-    return this.sharedMcpForwardRoute(`method:${request.method}`);
+    return boundRoute ?? this.sharedMcpForwardRoute(`method:${request.method}`);
   }
 
   private getNavigationGraphForwardRoute(

--- a/src/daemon/socketServer.ts
+++ b/src/daemon/socketServer.ts
@@ -372,8 +372,8 @@ export class UnixSocketServer {
     // replay-TTL guess. Subscribed here (not in the daemon) for the same
     // recovery-rewire reason as list-changed; close() unsubscribes symmetrically.
     this.sessionReleaseUnsubscribe?.();
-    this.sessionReleaseUnsubscribe = SessionReleaseBroadcaster.subscribe(sessionId => {
-      this.broadcastSessionReleased(sessionId);
+    this.sessionReleaseUnsubscribe = SessionReleaseBroadcaster.subscribe((sessionId, reason) => {
+      this.broadcastSessionReleased(sessionId, reason);
     });
 
     return new Promise((resolve, reject) => {
@@ -513,11 +513,12 @@ export class UnixSocketServer {
    * {@link broadcastListChanged}. Note `sessionId` here is the socket-client id,
    * distinct from the released daemon session carried in the frame.
    */
-  private broadcastSessionReleased(releasedSessionId: string): void {
+  private broadcastSessionReleased(releasedSessionId: string, reason?: string): void {
     const notification: DaemonNotification = {
       type: "daemon_notification",
       method: SESSION_RELEASED_NOTIFICATION_METHOD,
       sessionId: releasedSessionId,
+      ...(reason !== undefined ? { reason } : {}),
     };
     for (const sessionId of this.notificationSubscribers) {
       const socket = this.clientSockets.get(sessionId);
@@ -891,8 +892,9 @@ export class UnixSocketServer {
     request: DaemonRequest,
     socketSessionId: string,
   ): McpForwardRoute {
+    this.throwIfReleasedBoundSession(request.params);
     const sessionUuid = this.getSessionUuid(request.params);
-    if (sessionUuid && !this.isReleasedBoundSession(request.params)) {
+    if (sessionUuid) {
       return this.sessionScopedForwardRoute(socketSessionId, sessionUuid, undefined);
     }
     const uri = request.params?.uri;
@@ -900,11 +902,12 @@ export class UnixSocketServer {
   }
 
   private getToolsCallForwardRoute(args: unknown, socketSessionId: string): McpForwardRoute {
+    this.throwIfReleasedBoundSession(args);
     const scopedKey = this.getRequestArgumentScopeKey(args);
     const boundRoute = this.getBoundMcpClientRoute(socketSessionId);
     const sessionUuid = this.getSessionUuid(args);
     const capabilityProfileUuid = this.getCapabilityProfileUuid(args) ?? boundRoute?.capabilityProfileUuid;
-    if (sessionUuid && !this.isReleasedBoundSession(args)) {
+    if (sessionUuid) {
       return this.sessionScopedForwardRoute(socketSessionId, sessionUuid, scopedKey, capabilityProfileUuid);
     }
     if (capabilityProfileUuid) {
@@ -1156,6 +1159,13 @@ export class UnixSocketServer {
       record[DAEMON_BOUND_SESSION_PARAM] === sessionUuid &&
       !this.hasActiveDaemonSession(sessionUuid)
     );
+  }
+
+  private throwIfReleasedBoundSession(args: unknown): void {
+    if (!this.isReleasedBoundSession(args)) {
+      return;
+    }
+    throw new Error(`Session not found: ${this.getSessionUuid(args)}`);
   }
 
   private getRequestArgumentScopeKey(args: unknown): string | undefined {
@@ -2697,6 +2707,7 @@ export class UnixSocketServer {
 
     const forwardedArgs = { ...args } as Record<string, unknown>;
     delete forwardedArgs[DAEMON_CAPABILITY_PROFILE_PARAM];
+    this.throwIfReleasedBoundSession(forwardedArgs);
     const boundSessionUuid = this.getSessionUuid(forwardedArgs);
     const usesBoundSession = forwardedArgs[DAEMON_BOUND_SESSION_PARAM] === boundSessionUuid;
     delete forwardedArgs[DAEMON_BOUND_SESSION_PARAM];

--- a/src/daemon/socketServer.ts
+++ b/src/daemon/socketServer.ts
@@ -846,7 +846,8 @@ export class UnixSocketServer {
       // the proxy-side reconnect seeding (issue #4610).
       const listSessionUuid = this.getSessionUuid(request.params);
       const capabilityProfileUuid = this.getCapabilityProfileUuid(request.params);
-      if (listSessionUuid && !this.isReleasedBoundSession(request.params)) {
+      this.throwIfReleasedBoundSession(request.params);
+      if (listSessionUuid) {
         return this.sessionScopedForwardRoute(socketSessionId, listSessionUuid, undefined, capabilityProfileUuid);
       }
       if (capabilityProfileUuid) {

--- a/src/daemon/types.ts
+++ b/src/daemon/types.ts
@@ -62,10 +62,12 @@ export interface DaemonNotification {
   method: string;
   /**
    * Released session key for `notifications/session/released` frames (issue
-   * #4610). Absent for list-changed frames. The proxy clears its remembered
+   * #4610). Absent for list-changed frames. The proxy fences its remembered
    * binding only when this exactly equals its bound (base) session UUID.
    */
   sessionId?: string;
+  /** Diagnostic release reason for `notifications/session/released`. */
+  reason?: string;
 }
 
 /** Discriminates a daemon socket frame as a server-pushed notification. */

--- a/src/index.ts
+++ b/src/index.ts
@@ -568,11 +568,13 @@ async function main() {
       let server;
       try {
         if (useProxyMode) {
+          const { getDefaultSessionHeartbeatTimeoutMs } = await import("./daemon/sessionManager");
           const result = createProxyMcpServer({
             proxyConfig: {
               autoStartDaemon: !noDaemon,
               daemonOptions: daemonStartupOptions,
               initialSessionUuid,
+              heartbeatTimeoutMs: getDefaultSessionHeartbeatTimeoutMs(),
             },
           });
           server = result.server;

--- a/src/server/proxyServer.ts
+++ b/src/server/proxyServer.ts
@@ -27,12 +27,19 @@ export interface ProxyMcpServerOptions {
   sessionContext?: { sessionId?: string };
 }
 
+function sessionOwnershipLostPayload(error: DaemonBoundSessionExpiredError) {
+  return {
+    error: {
+      code: "session_ownership_lost",
+      message: `Session ownership lost for ${error.sessionUuid}: ${error.reason}`,
+      sessionUuid: error.sessionUuid,
+      reason: error.reason,
+    },
+  };
+}
+
 function sessionOwnershipLostMessage(error: DaemonBoundSessionExpiredError): string {
-  return JSON.stringify({
-    code: "session_ownership_lost",
-    sessionUuid: error.sessionUuid,
-    reason: error.reason,
-  });
+  return JSON.stringify(sessionOwnershipLostPayload(error));
 }
 
 function sessionOwnershipLostResult(
@@ -50,11 +57,8 @@ function sessionOwnershipLostResult(
 }
 
 function sessionOwnershipLostError(error: DaemonBoundSessionExpiredError): McpError {
-  return new McpError(-32603, sessionOwnershipLostMessage(error), {
-    code: "session_ownership_lost",
-    sessionUuid: error.sessionUuid,
-    reason: error.reason,
-  });
+  const payload = sessionOwnershipLostPayload(error);
+  return new McpError(-32603, sessionOwnershipLostMessage(error), payload);
 }
 
 /**

--- a/src/server/proxyServer.ts
+++ b/src/server/proxyServer.ts
@@ -6,6 +6,7 @@ import {
   ReadResourceRequestSchema,
   ListResourceTemplatesRequestSchema,
   type CallToolResult,
+  McpError,
 } from "@modelcontextprotocol/sdk/types.js";
 import { logger } from "../utils/logger";
 import {
@@ -48,8 +49,12 @@ function sessionOwnershipLostResult(
   };
 }
 
-function sessionOwnershipLostError(error: DaemonBoundSessionExpiredError): ActionableError {
-  return new ActionableError(sessionOwnershipLostMessage(error));
+function sessionOwnershipLostError(error: DaemonBoundSessionExpiredError): McpError {
+  return new McpError(-32603, sessionOwnershipLostMessage(error), {
+    code: "session_ownership_lost",
+    sessionUuid: error.sessionUuid,
+    reason: error.reason,
+  });
 }
 
 /**

--- a/src/server/proxyServer.ts
+++ b/src/server/proxyServer.ts
@@ -5,6 +5,7 @@ import {
   ListResourcesRequestSchema,
   ReadResourceRequestSchema,
   ListResourceTemplatesRequestSchema,
+  type CallToolResult,
 } from "@modelcontextprotocol/sdk/types.js";
 import { logger } from "../utils/logger";
 import {
@@ -25,27 +26,30 @@ export interface ProxyMcpServerOptions {
   sessionContext?: { sessionId?: string };
 }
 
-interface SessionOwnershipLostCallToolResult {
-  content: Array<{ type: "text"; text: string }>;
-  isError: true;
+function sessionOwnershipLostMessage(error: DaemonBoundSessionExpiredError): string {
+  return JSON.stringify({
+    code: "session_ownership_lost",
+    sessionUuid: error.sessionUuid,
+    reason: error.reason,
+  });
 }
 
 function sessionOwnershipLostResult(
   error: DaemonBoundSessionExpiredError,
-): SessionOwnershipLostCallToolResult {
+): CallToolResult {
   return {
     content: [
       {
         type: "text",
-        text: JSON.stringify({
-          code: "session_ownership_lost",
-          sessionUuid: error.sessionUuid,
-          reason: error.reason,
-        }),
+        text: sessionOwnershipLostMessage(error),
       },
     ],
     isError: true,
   };
+}
+
+function sessionOwnershipLostError(error: DaemonBoundSessionExpiredError): ActionableError {
+  return new ActionableError(sessionOwnershipLostMessage(error));
 }
 
 /**
@@ -119,6 +123,9 @@ export function createProxyMcpServer(options: ProxyMcpServerOptions = {}): {
       const tools = await proxy.listTools();
       return { tools };
     } catch (error) {
+      if (error instanceof DaemonBoundSessionExpiredError) {
+        throw sessionOwnershipLostError(error);
+      }
       logger.error(`[ProxyServer] Failed to list tools: ${error}`);
       throw new ActionableError(
         `Failed to list tools from daemon: ${error instanceof Error ? error.message : String(error)}`
@@ -167,6 +174,9 @@ export function createProxyMcpServer(options: ProxyMcpServerOptions = {}): {
       const resources = await proxy.listResources();
       return { resources };
     } catch (error) {
+      if (error instanceof DaemonBoundSessionExpiredError) {
+        throw sessionOwnershipLostError(error);
+      }
       logger.error(`[ProxyServer] Failed to list resources: ${error}`);
       throw new ActionableError(
         `Failed to list resources from daemon: ${error instanceof Error ? error.message : String(error)}`
@@ -180,6 +190,9 @@ export function createProxyMcpServer(options: ProxyMcpServerOptions = {}): {
       const resourceTemplates = await proxy.listResourceTemplates();
       return { resourceTemplates };
     } catch (error) {
+      if (error instanceof DaemonBoundSessionExpiredError) {
+        throw sessionOwnershipLostError(error);
+      }
       logger.error(`[ProxyServer] Failed to list resource templates: ${error}`);
       throw new ActionableError(
         `Failed to list resource templates from daemon: ${error instanceof Error ? error.message : String(error)}`
@@ -201,6 +214,9 @@ export function createProxyMcpServer(options: ProxyMcpServerOptions = {}): {
       const result = await proxy.readResource(uri);
       return result;
     } catch (error) {
+      if (error instanceof DaemonBoundSessionExpiredError) {
+        throw sessionOwnershipLostError(error);
+      }
       logger.error(`[ProxyServer] Resource read failed: ${uri} - ${error}`);
       throw new ActionableError(
         `Failed to read resource from daemon: ${error instanceof Error ? error.message : String(error)}`

--- a/src/server/proxyServer.ts
+++ b/src/server/proxyServer.ts
@@ -7,7 +7,11 @@ import {
   ListResourceTemplatesRequestSchema,
 } from "@modelcontextprotocol/sdk/types.js";
 import { logger } from "../utils/logger";
-import { DaemonMcpProxy, type DaemonMcpProxyConfig } from "../daemon/daemonMcpProxy";
+import {
+  DaemonBoundSessionExpiredError,
+  DaemonMcpProxy,
+  type DaemonMcpProxyConfig,
+} from "../daemon/daemonMcpProxy";
 import { ActionableError } from "../models";
 import { getMcpServerVersion } from "../utils/mcpVersion";
 
@@ -19,6 +23,29 @@ export interface ProxyMcpServerOptions {
   proxyConfig?: DaemonMcpProxyConfig;
   /** Session context for tracking */
   sessionContext?: { sessionId?: string };
+}
+
+interface SessionOwnershipLostCallToolResult {
+  content: Array<{ type: "text"; text: string }>;
+  isError: true;
+}
+
+function sessionOwnershipLostResult(
+  error: DaemonBoundSessionExpiredError,
+): SessionOwnershipLostCallToolResult {
+  return {
+    content: [
+      {
+        type: "text",
+        text: JSON.stringify({
+          code: "session_ownership_lost",
+          sessionUuid: error.sessionUuid,
+          reason: error.reason,
+        }),
+      },
+    ],
+    isError: true,
+  };
 }
 
 /**
@@ -114,6 +141,12 @@ export function createProxyMcpServer(options: ProxyMcpServerOptions = {}): {
       const result = await proxy.callTool(name, args);
       return result;
     } catch (error) {
+      if (error instanceof DaemonBoundSessionExpiredError) {
+        logger.warn(
+          `[ProxyServer] Session ownership lost for ${error.sessionUuid}: ${error.reason}`,
+        );
+        return sessionOwnershipLostResult(error);
+      }
       logger.error(`[ProxyServer] Tool call failed: ${name} - ${error}`);
       // Return error as tool result (not throwing) to match expected MCP behavior
       return {

--- a/src/server/sessionReleaseBroadcast.ts
+++ b/src/server/sessionReleaseBroadcast.ts
@@ -10,7 +10,7 @@ import { logger } from "../utils/logger";
 export const SESSION_RELEASED_NOTIFICATION_METHOD = "notifications/session/released";
 
 export interface SessionReleaseListener {
-  (sessionId: string): void;
+  (sessionId: string, reason?: string): void;
 }
 
 /**
@@ -37,10 +37,10 @@ class SessionReleaseBroadcasterClass {
     };
   }
 
-  emit(sessionId: string): void {
+  emit(sessionId: string, reason?: string): void {
     for (const listener of this.listeners) {
       try {
-        listener(sessionId);
+        listener(sessionId, reason);
       } catch (error) {
         // Best-effort fan-out: one broken sink must not block the others or the
         // session release that triggered the emit.

--- a/src/types/mcp-sdk.d.ts
+++ b/src/types/mcp-sdk.d.ts
@@ -54,6 +54,10 @@ declare module "@modelcontextprotocol/sdk/types.js" {
     isError?: boolean;
   }
 
+  export class McpError extends Error {
+    constructor(code: number, message: string, data?: any);
+  }
+
   export const CallToolRequestSchema: any;
   export const ListToolsRequestSchema: any;
   export const GetResourceRequestSchema: any;

--- a/src/types/mcp-sdk.d.ts
+++ b/src/types/mcp-sdk.d.ts
@@ -46,6 +46,14 @@ declare module "@modelcontextprotocol/sdk/types.js" {
     mimeType?: string;
   }
 
+  export interface CallToolResult {
+    content: Array<{
+      type: string;
+      text: string;
+    }>;
+    isError?: boolean;
+  }
+
   export const CallToolRequestSchema: any;
   export const ListToolsRequestSchema: any;
   export const GetResourceRequestSchema: any;
@@ -66,5 +74,6 @@ declare module "@modelcontextprotocol/sdk/types" {
       type: string;
       text: string;
     }>;
+    isError?: boolean;
   }
 }

--- a/test/daemon/SessionHeartbeatMonitor.test.ts
+++ b/test/daemon/SessionHeartbeatMonitor.test.ts
@@ -93,13 +93,39 @@ describe("SessionHeartbeatMonitor", () => {
 
     it("reaps a default-heartbeat session shortly after it misses the first heartbeat", async () => {
       await sessionManager.createSession("s1", "emulator-5554", "android", 60_000);
-      const reaped: string[] = [];
-      const monitor = new SessionHeartbeatMonitor(sessionManager, () => false, async sid => { reaped.push(sid); }, timer);
+      const reaped: Array<{ sessionId: string; reason: string }> = [];
+      const monitor = new SessionHeartbeatMonitor(
+        sessionManager,
+        () => false,
+        async (sessionId, reason) => {
+          reaped.push({ sessionId, reason });
+        },
+        timer,
+      );
 
       timer.advanceTime(5_001);
       await monitor.tick();
 
-      expect(reaped).toEqual(["s1"]);
+      expect(reaped).toEqual([{ sessionId: "s1", reason: "missing-first-heartbeat" }]);
+    });
+
+    it("reports heartbeat-timeout after a session received its first heartbeat", async () => {
+      await sessionManager.createSession("s1", "emulator-5554", "android", 60_000, 1_000);
+      sessionManager.recordHeartbeat("s1");
+      const reaped: Array<{ sessionId: string; reason: string }> = [];
+      const monitor = new SessionHeartbeatMonitor(
+        sessionManager,
+        () => false,
+        async (sessionId, reason) => {
+          reaped.push({ sessionId, reason });
+        },
+        timer,
+      );
+
+      timer.advanceTime(1_001);
+      await monitor.tick();
+
+      expect(reaped).toEqual([{ sessionId: "s1", reason: "heartbeat-timeout" }]);
     });
 
     it("does not reap a default-heartbeat session with recent activity before its first heartbeat", async () => {

--- a/test/daemon/daemonMcpProxy.test.ts
+++ b/test/daemon/daemonMcpProxy.test.ts
@@ -205,6 +205,185 @@ describe("DaemonMcpProxy", () => {
       }
     });
 
+    test("keeps two configured session bindings alive independently while idle", async () => {
+      const timer = new FakeTimer();
+      const firstClient = new FakeDaemonClient({
+        daemonMethodResults: new Map([["tools/list", { tools: [] }]]),
+      });
+      const secondClient = new FakeDaemonClient({
+        daemonMethodResults: new Map([["tools/list", { tools: [] }]]),
+      });
+      const isAvailableSpy = spyOn(DaemonClient, "isAvailable").mockResolvedValue(true);
+      const firstProxy = new DaemonMcpProxy({
+        initialSessionUuid: "device-session-a",
+        clientFactory: () => firstClient,
+        daemonManager: matchingDaemonManager(),
+        autoStartDaemon: false,
+        timer,
+      });
+      const secondProxy = new DaemonMcpProxy({
+        initialSessionUuid: "device-session-b",
+        clientFactory: () => secondClient,
+        daemonManager: matchingDaemonManager(),
+        autoStartDaemon: false,
+        timer,
+      });
+
+      try {
+        await Promise.all([firstProxy.listTools(), secondProxy.listTools()]);
+        await timer.advanceTimeAsync(6_000);
+
+        expect(
+          firstClient.callDaemonMethodCalls.filter(call => call.method === "daemon/heartbeat"),
+        ).toEqual([
+          { method: "daemon/heartbeat", params: { sessionId: "device-session-a" } },
+          { method: "daemon/heartbeat", params: { sessionId: "device-session-a" } },
+          { method: "daemon/heartbeat", params: { sessionId: "device-session-a" } },
+        ]);
+        expect(
+          secondClient.callDaemonMethodCalls.filter(call => call.method === "daemon/heartbeat"),
+        ).toEqual([
+          { method: "daemon/heartbeat", params: { sessionId: "device-session-b" } },
+          { method: "daemon/heartbeat", params: { sessionId: "device-session-b" } },
+          { method: "daemon/heartbeat", params: { sessionId: "device-session-b" } },
+        ]);
+      } finally {
+        isAvailableSpy.mockRestore();
+        await firstProxy.close();
+        await secondProxy.close();
+      }
+      expect(timer.getPendingIntervalCount()).toBe(0);
+    });
+
+    test("replays a learned session heartbeat through a recoverable daemon reconnect", async () => {
+      const timer = new FakeTimer();
+      const staleClient = new ScriptedDaemonClient({
+        daemonMethodError: new DaemonUnavailableError("Daemon socket connection lost"),
+      });
+      const freshClient = new FakeDaemonClient();
+      const clients: DaemonClientLike[] = [staleClient, freshClient];
+      const isAvailableSpy = spyOn(DaemonClient, "isAvailable").mockResolvedValue(true);
+      const proxy = new DaemonMcpProxy({
+        clientFactory: () => clients.shift()!,
+        daemonManager: matchingDaemonManager(),
+        autoStartDaemon: false,
+        timer,
+      });
+
+      try {
+        await proxy.callTool("observe", {
+          sessionUuid: "device-session-a",
+          deviceId: "device-a",
+        });
+        await timer.advanceTimeAsync(2_000);
+
+        expect(staleClient.callDaemonMethodCalls).toEqual([
+          { method: "daemon/heartbeat", params: { sessionId: "device-session-a" } },
+        ]);
+        expect(staleClient.closeCallCount).toBe(1);
+        expect(freshClient.callDaemonMethodCalls).toEqual([
+          { method: "daemon/heartbeat", params: { sessionId: "device-session-a" } },
+        ]);
+      } finally {
+        isAvailableSpy.mockRestore();
+        await proxy.close();
+      }
+    });
+
+    test("a stale heartbeat retry cannot fence a newer explicit binding", async () => {
+      const timer = new FakeTimer();
+      const heartbeatStarted = Promise.withResolvers<void>();
+      const releaseFirstHeartbeat = Promise.withResolvers<void>();
+      const retryHeartbeatCalled = Promise.withResolvers<void>();
+      const staleClient = new FakeDaemonClient({
+        onCallDaemonMethod: async method => {
+          if (method === "daemon/heartbeat") {
+            heartbeatStarted.resolve();
+            await releaseFirstHeartbeat.promise;
+            throw new Error("Session not found: session-a");
+          }
+        },
+      });
+      const freshClient = new FakeDaemonClient({
+        onCallDaemonMethod: method => {
+          if (method === "daemon/heartbeat") {
+            retryHeartbeatCalled.resolve();
+            throw new Error("Session not found: session-a");
+          }
+        },
+      });
+      const clients: DaemonClientLike[] = [staleClient, freshClient];
+      const isAvailableSpy = spyOn(DaemonClient, "isAvailable").mockResolvedValue(true);
+      const proxy = new DaemonMcpProxy({
+        clientFactory: () => clients.shift()!,
+        daemonManager: matchingDaemonManager(),
+        autoStartDaemon: false,
+        timer,
+      });
+
+      try {
+        await proxy.callTool("observe", {
+          sessionUuid: "session-a",
+          deviceId: "device-a",
+        });
+        timer.advanceTime(2_000);
+        await heartbeatStarted.promise;
+
+        await proxy.callTool("observe", {
+          sessionUuid: "session-b",
+          deviceId: "device-b",
+        });
+        releaseFirstHeartbeat.resolve();
+        await retryHeartbeatCalled.promise;
+        await Promise.resolve();
+        await Promise.resolve();
+
+        await expect(
+          proxy.callTool("observe", { deviceId: "device-b" }),
+        ).resolves.toBeDefined();
+        expect(freshClient.callToolCalls.at(-1)).toEqual({
+          toolName: "observe",
+          params: { deviceId: "device-b", sessionUuid: "session-b" },
+        });
+      } finally {
+        isAvailableSpy.mockRestore();
+        await proxy.close();
+      }
+    });
+
+    test("a release received during connection setup prevents the first explicit call", async () => {
+      const fakeClient = new FakeDaemonClient();
+      fakeClient.subscribeToNotifications = async () => {
+        fakeClient.emitNotification(
+          SESSION_RELEASED_NOTIFICATION_METHOD,
+          "session-a",
+          "heartbeat-timeout",
+        );
+      };
+      const isAvailableSpy = spyOn(DaemonClient, "isAvailable").mockResolvedValue(true);
+      const proxy = new DaemonMcpProxy({
+        clientFactory: () => fakeClient,
+        daemonManager: matchingDaemonManager(),
+        autoStartDaemon: false,
+      });
+
+      try {
+        await expect(
+          proxy.callTool("observe", {
+            sessionUuid: "session-a",
+            deviceId: "device-a",
+          }),
+        ).rejects.toMatchObject({
+          sessionUuid: "session-a",
+          reason: "heartbeat-timeout",
+        });
+        expect(fakeClient.callToolCalls).toEqual([]);
+      } finally {
+        isAvailableSpy.mockRestore();
+        await proxy.close();
+      }
+    });
+
     test("auto-starts daemon when not running", async () => {
       const fakeClient = new FakeDaemonClient({
         daemonMethodResults: new Map([["tools/list", { tools: [] }]]),
@@ -1543,12 +1722,11 @@ describe("DaemonMcpProxy", () => {
       }
     });
 
-    test("stops replaying a bound session after the daemon session idle window elapses", async () => {
+    test("terminally fences a bound session after the replay backstop elapses", async () => {
       // The daemon's heartbeat/idle cleanup can release an ordinary session while
       // this proxy stays connected. Once the replay window elapses with no
-      // explicit-sessionUuid call refreshing the binding, a later device-aware
-      // call that omits sessionUuid must NOT be rewritten to the retired UUID —
-      // otherwise createToolExecutionContext silently recreates the session
+      // activity refreshing the binding, a later device-aware call must fail
+      // instead of silently recreating the session
       // (issue [#4610](https://github.com/kaeawc/auto-mobile/issues/4610)).
       const timer = new FakeTimer();
       const client = new ScriptedDaemonClient({
@@ -1564,12 +1742,15 @@ describe("DaemonMcpProxy", () => {
 
       try {
         await proxy.callTool("observe", { sessionUuid: "session-a", deviceId: "device-a" });
-        timer.advanceTime(DAEMON_BOUND_SESSION_REPLAY_TTL_MS);
-        await proxy.callTool("observe", { deviceId: "device-a" });
+        // Move the clock without running the keeper to model a dropped heartbeat
+        // path where the replay lease is the final safety backstop.
+        timer.setCurrentTime(DAEMON_BOUND_SESSION_REPLAY_TTL_MS);
+        await expect(proxy.callTool("observe", { deviceId: "device-a" })).rejects.toThrow(
+          /session-a.*expired/i,
+        );
 
         expect(client.callToolCalls).toEqual([
           { toolName: "observe", params: { sessionUuid: "session-a", deviceId: "device-a" } },
-          { toolName: "observe", params: { deviceId: "device-a" } },
         ]);
       } finally {
         isAvailableSpy.mockRestore();
@@ -1713,11 +1894,10 @@ describe("DaemonMcpProxy", () => {
       }
     });
 
-    test("does NOT refresh the replay lease when the failing call never reached the daemon", async () => {
-      // A transport/connect failure (DaemonUnavailableError) never reached the
-      // handler, so the live session was not refreshed. The lease must be allowed
-      // to expire — refreshing it would replay a UUID whose session may be gone
-      // (issue [#4610](https://github.com/kaeawc/auto-mobile/issues/4610)).
+    test("successful heartbeats keep the replay lease alive across a failed tool transport", async () => {
+      // The failed tool request did not refresh the daemon session, but the
+      // independent heartbeat keeper did. The binding therefore remains live
+      // across the old replay-TTL boundary (issue #5411).
       const timer = new FakeTimer();
       const client = new ScriptedDaemonClient({
         toolResult: { content: [{ type: "text", text: "ok" }] },
@@ -1742,10 +1922,13 @@ describe("DaemonMcpProxy", () => {
         timer.advanceTime(DAEMON_BOUND_SESSION_REPLAY_TTL_MS - 1);
         await proxy.callTool("observe", { deviceId: "device-a" });
 
-        // The final implicit observe must NOT carry an injected sessionUuid: the
-        // lease expired because the transport failure did not refresh it.
+        // The final implicit observe remains bound because heartbeat activity,
+        // not the failed tool attempt, refreshed the live session.
         const lastCall = client.callToolCalls[client.callToolCalls.length - 1];
-        expect(lastCall).toEqual({ toolName: "observe", params: { deviceId: "device-a" } });
+        expect(lastCall).toEqual({
+          toolName: "observe",
+          params: { deviceId: "device-a", sessionUuid: "session-a" },
+        });
       } finally {
         isAvailableSpy.mockRestore();
         await proxy.close();
@@ -1881,9 +2064,10 @@ describe("DaemonMcpProxy", () => {
     // instead of waiting out the replay-TTL guess. The TTL stays as a
     // dropped-frame backstop.
 
-    test("a released signal clears an initial binding before a later sessionless call", async () => {
+    test("a released signal terminally fences an initial binding", async () => {
       const fakeClient = new FakeDaemonClient({
         toolResult: { content: [{ type: "text", text: "ok" }] },
+        daemonMethodResults: new Map([["tools/list", { tools: [] }]]),
       });
       const isAvailableSpy = spyOn(DaemonClient, "isAvailable").mockResolvedValue(true);
       const proxy = new DaemonMcpProxy({
@@ -1895,14 +2079,19 @@ describe("DaemonMcpProxy", () => {
 
       try {
         // The initial routing binding scopes calls before any mutable device selection.
+        await proxy.listTools();
         await proxy.callTool("observe", { deviceId: "device-a" });
         fakeClient.emitNotification(SESSION_RELEASED_NOTIFICATION_METHOD, "session-a");
-        // The next sessionless call must NOT be rewritten to the retired UUID.
-        await proxy.callTool("observe", { deviceId: "device-a" });
+        await expect(proxy.listTools()).rejects.toThrow(/session-a.*(?:expired|released)/i);
+        await expect(proxy.callTool("observe", { deviceId: "device-a" })).rejects.toThrow(
+          /session-a.*(?:expired|released)/i,
+        );
+        await expect(
+          proxy.callTool("observe", { sessionUuid: "session-a", deviceId: "device-a" }),
+        ).rejects.toThrow(/session-a.*(?:expired|released)/i);
 
         expect(fakeClient.callToolCalls).toEqual([
           { toolName: "observe", params: { sessionUuid: "session-a", deviceId: "device-a" } },
-          { toolName: "observe", params: { deviceId: "device-a" } },
         ]);
       } finally {
         isAvailableSpy.mockRestore();
@@ -1967,14 +2156,43 @@ describe("DaemonMcpProxy", () => {
         await proxy.callTool("observe", { sessionUuid: "session-a", deviceId: "device-a" });
         // Call 2 injects session-a, then the release lands mid-flight.
         await proxy.callTool("observe", { deviceId: "device-a" });
-        // Call 3 must NOT be rewritten to the released UUID.
-        await proxy.callTool("observe", { deviceId: "device-a" });
+        // Call 3 must fail terminally without reaching the daemon.
+        await expect(proxy.callTool("observe", { deviceId: "device-a" })).rejects.toThrow(
+          /session-a.*(?:expired|released)/i,
+        );
 
         expect(fakeClient.callToolCalls).toEqual([
           { toolName: "observe", params: { sessionUuid: "session-a", deviceId: "device-a" } },
           { toolName: "observe", params: { deviceId: "device-a", sessionUuid: "session-a" } },
-          { toolName: "observe", params: { deviceId: "device-a" } },
         ]);
+      } finally {
+        isAvailableSpy.mockRestore();
+        await proxy.close();
+      }
+    });
+
+    test("a release during the first explicit call fences the transport before reuse", async () => {
+      const fakeClient: FakeDaemonClient = new FakeDaemonClient({
+        onCallTool: () => {
+          fakeClient.emitNotification(SESSION_RELEASED_NOTIFICATION_METHOD, "session-a");
+        },
+      });
+      const isAvailableSpy = spyOn(DaemonClient, "isAvailable").mockResolvedValue(true);
+      const proxy = new DaemonMcpProxy({
+        clientFactory: () => fakeClient,
+        daemonManager: matchingDaemonManager(),
+        autoStartDaemon: false,
+      });
+
+      try {
+        await proxy.callTool("observe", {
+          sessionUuid: "session-a",
+          deviceId: "device-a",
+        });
+        await expect(
+          proxy.callTool("observe", { sessionUuid: "session-a", deviceId: "device-a" }),
+        ).rejects.toThrow(/session-a.*(?:expired|released)/i);
+        expect(fakeClient.callToolCalls).toHaveLength(1);
       } finally {
         isAvailableSpy.mockRestore();
         await proxy.close();
@@ -2038,15 +2256,16 @@ describe("DaemonMcpProxy", () => {
       try {
         await proxy.callTool("observe", { sessionUuid: "session-a", deviceId: "device-a" });
         await expect(proxy.callTool("tapOn", { deviceId: "device-a" })).rejects.toThrow(
-          "handler rejected the admitted call",
+          /session-a.*(?:expired|released)/i,
         );
         // The admitted-failure refresh must not resurrect the released UUID's lease.
-        await proxy.callTool("observe", { deviceId: "device-a" });
+        await expect(proxy.callTool("observe", { deviceId: "device-a" })).rejects.toThrow(
+          /session-a.*(?:expired|released)/i,
+        );
 
         expect(fakeClient.callToolCalls).toEqual([
           { toolName: "observe", params: { sessionUuid: "session-a", deviceId: "device-a" } },
           { toolName: "tapOn", params: { deviceId: "device-a", sessionUuid: "session-a" } },
-          { toolName: "observe", params: { deviceId: "device-a" } },
         ]);
       } finally {
         isAvailableSpy.mockRestore();
@@ -2087,9 +2306,9 @@ describe("DaemonMcpProxy", () => {
       }
     });
 
-    test("the TTL backstop still expires the binding when no signal arrives", async () => {
+    test("the TTL backstop terminally fences the binding when no signal arrives", async () => {
       // Dropped-frame path: no released signal is delivered, so the replay TTL
-      // must still retire the binding on its own.
+      // must still fence the binding on its own.
       const timer = new FakeTimer();
       const fakeClient = new FakeDaemonClient({
         toolResult: { content: [{ type: "text", text: "ok" }] },
@@ -2104,16 +2323,72 @@ describe("DaemonMcpProxy", () => {
 
       try {
         await proxy.callTool("observe", { sessionUuid: "session-a", deviceId: "device-a" });
-        timer.advanceTime(DAEMON_BOUND_SESSION_REPLAY_TTL_MS);
-        await proxy.callTool("observe", { deviceId: "device-a" });
+        timer.setCurrentTime(DAEMON_BOUND_SESSION_REPLAY_TTL_MS);
+        await expect(proxy.callTool("observe", { deviceId: "device-a" })).rejects.toThrow(
+          /session-a.*expired/i,
+        );
 
         expect(fakeClient.callToolCalls).toEqual([
           { toolName: "observe", params: { sessionUuid: "session-a", deviceId: "device-a" } },
-          { toolName: "observe", params: { deviceId: "device-a" } },
         ]);
       } finally {
         isAvailableSpy.mockRestore();
         await proxy.close();
+      }
+    });
+
+    test("cached discovery surfaces still enforce the bound-session replay backstop", async () => {
+      const discoveryCases = [
+        {
+          name: "tools/list",
+          read: (proxy: DaemonMcpProxy) => proxy.listTools(),
+        },
+        {
+          name: "resources/list",
+          read: (proxy: DaemonMcpProxy) => proxy.listResources(),
+        },
+        {
+          name: "resources/list-templates",
+          read: (proxy: DaemonMcpProxy) => proxy.listResourceTemplates(),
+        },
+      ];
+      const isAvailableSpy = spyOn(DaemonClient, "isAvailable").mockResolvedValue(true);
+
+      try {
+        for (const discoveryCase of discoveryCases) {
+          const timer = new FakeTimer();
+          const fakeClient = new FakeDaemonClient({
+            daemonMethodResults: new Map([
+              ["tools/list", { tools: [{ name: "observe", inputSchema: {} }] }],
+              ["resources/list", { resources: [{ uri: "automobile:test", name: "test" }] }],
+              ["resources/list-templates", { resourceTemplates: [{ uriTemplate: "test://{id}", name: "test" }] }],
+            ]),
+          });
+          const proxy = new DaemonMcpProxy({
+            clientFactory: () => fakeClient,
+            daemonManager: matchingDaemonManager(),
+            autoStartDaemon: false,
+            timer,
+          });
+
+          try {
+            await proxy.callTool("observe", {
+              sessionUuid: "session-a",
+              deviceId: "device-a",
+            });
+            await discoveryCase.read(proxy);
+            timer.setCurrentTime(DAEMON_BOUND_SESSION_REPLAY_TTL_MS);
+
+            await expect(discoveryCase.read(proxy)).rejects.toMatchObject({
+              sessionUuid: "session-a",
+              reason: "replay-lease-expired",
+            });
+          } finally {
+            await proxy.close();
+          }
+        }
+      } finally {
+        isAvailableSpy.mockRestore();
       }
     });
 
@@ -2142,7 +2417,7 @@ describe("DaemonMcpProxy", () => {
       }
     });
 
-    test("clears a configured binding after a confirmed missing-session fallback", async () => {
+    test("terminally fences a configured binding after a confirmed missing-session fallback", async () => {
       const firstClient = new ScriptedDaemonClient({
         toolError: new Error("Session not found"),
       });
@@ -2161,7 +2436,7 @@ describe("DaemonMcpProxy", () => {
 
       try {
         await expect(proxy.callTool("observe", { deviceId: "device-a" })).rejects.toThrow(
-          "Session not found",
+          /session-a.*(?:expired|released)/i,
         );
         await proxy.close();
         await proxy.callTool("observe", { sessionUuid: "session-b", deviceId: "device-b" });

--- a/test/daemon/daemonMcpProxy.test.ts
+++ b/test/daemon/daemonMcpProxy.test.ts
@@ -61,6 +61,7 @@ class ScriptedDaemonClient implements DaemonClientLike {
       resourceError?: Error;
       daemonMethodResults?: Map<string, any>;
       daemonMethodError?: Error;
+      daemonMethodErrors?: Map<string, Error>;
     },
   ) {}
 
@@ -101,6 +102,10 @@ class ScriptedDaemonClient implements DaemonClientLike {
     const recordedParams = { ...params };
     delete recordedParams.__autoMobileBoundSessionUuid;
     this.callDaemonMethodCalls.push({ method, params: recordedParams });
+    const methodError = this.behavior.daemonMethodErrors?.get(method);
+    if (methodError) {
+      throw methodError;
+    }
     if (this.behavior.daemonMethodError) {
       throw this.behavior.daemonMethodError;
     }
@@ -181,10 +186,14 @@ describe("DaemonMcpProxy", () => {
         ]);
 
         expect(firstClient.callDaemonMethodCalls).toEqual([
+          { method: "daemon/heartbeat", params: { sessionId: "device-session-a" } },
           { method: "tools/list", params: { sessionUuid: "device-session-a" } },
+          { method: "daemon/heartbeat", params: { sessionId: "device-session-a" } },
         ]);
         expect(secondClient.callDaemonMethodCalls).toEqual([
+          { method: "daemon/heartbeat", params: { sessionId: "device-session-b" } },
           { method: "tools/list", params: { sessionUuid: "device-session-b" } },
+          { method: "daemon/heartbeat", params: { sessionId: "device-session-b" } },
         ]);
         expect(firstClient.callToolCalls).toEqual([
           {
@@ -239,10 +248,12 @@ describe("DaemonMcpProxy", () => {
           { method: "daemon/heartbeat", params: { sessionId: "device-session-a" } },
           { method: "daemon/heartbeat", params: { sessionId: "device-session-a" } },
           { method: "daemon/heartbeat", params: { sessionId: "device-session-a" } },
+          { method: "daemon/heartbeat", params: { sessionId: "device-session-a" } },
         ]);
         expect(
           secondClient.callDaemonMethodCalls.filter(call => call.method === "daemon/heartbeat"),
         ).toEqual([
+          { method: "daemon/heartbeat", params: { sessionId: "device-session-b" } },
           { method: "daemon/heartbeat", params: { sessionId: "device-session-b" } },
           { method: "daemon/heartbeat", params: { sessionId: "device-session-b" } },
           { method: "daemon/heartbeat", params: { sessionId: "device-session-b" } },
@@ -1667,7 +1678,7 @@ describe("DaemonMcpProxy", () => {
       // tools/list so it returns the session-scoped list (issue #4610).
       const staleClient = new ScriptedDaemonClient({
         toolResult: { content: [{ type: "text", text: "bound" }] },
-        daemonMethodError: new Error("Session not found"),
+        daemonMethodErrors: new Map([["tools/list", new Error("Session not found")]]),
       });
       const freshClient = new ScriptedDaemonClient({
         daemonMethodResults: new Map([
@@ -1689,9 +1700,11 @@ describe("DaemonMcpProxy", () => {
         expect(tools).toEqual([{ name: "scopedTool", inputSchema: {} }]);
         // The stale attempt and the reconnect retry both carry the bound session.
         expect(staleClient.callDaemonMethodCalls).toEqual([
+          { method: "daemon/heartbeat", params: { sessionId: "session-a" } },
           { method: "tools/list", params: { sessionUuid: "session-a" } },
         ]);
         expect(freshClient.callDaemonMethodCalls).toEqual([
+          { method: "daemon/heartbeat", params: { sessionId: "session-a" } },
           { method: "tools/list", params: { sessionUuid: "session-a" } },
         ]);
       } finally {
@@ -2481,12 +2494,10 @@ describe("DaemonMcpProxy", () => {
         await expect(proxy.callTool("observe", { deviceId: "device-a" })).rejects.toThrow(
           /session-a.*(?:expired|released)/i,
         );
-        await proxy.close();
-        await proxy.callTool("observe", { sessionUuid: "session-b", deviceId: "device-b" });
-
-        expect(replacementClient.callToolCalls).toEqual([
-          { toolName: "observe", params: { sessionUuid: "session-b", deviceId: "device-b" } },
-        ]);
+        await expect(
+          proxy.callTool("observe", { sessionUuid: "session-b", deviceId: "device-b" }),
+        ).rejects.toThrow(/session-a.*(?:expired|released)/i);
+        expect(replacementClient.callToolCalls).toEqual([]);
       } finally {
         isAvailableSpy.mockRestore();
         await proxy.close();

--- a/test/daemon/daemonMcpProxy.test.ts
+++ b/test/daemon/daemonMcpProxy.test.ts
@@ -351,6 +351,49 @@ describe("DaemonMcpProxy", () => {
       }
     });
 
+    test("normalizes an explicit session UUID before remembering and fencing it", async () => {
+      let callCount = 0;
+      const firstClient = new FakeDaemonClient({
+        onCallTool: () => {
+          callCount += 1;
+          if (callCount === 2) {
+            throw new Error("Session not found: session-a");
+          }
+        },
+      });
+      const retryClient = new ScriptedDaemonClient({
+        toolError: new Error("Session not found: session-a"),
+      });
+      const clients: DaemonClientLike[] = [firstClient, retryClient];
+      const isAvailableSpy = spyOn(DaemonClient, "isAvailable").mockResolvedValue(true);
+      const proxy = new DaemonMcpProxy({
+        clientFactory: () => clients.shift()!,
+        daemonManager: matchingDaemonManager(),
+        autoStartDaemon: false,
+      });
+
+      try {
+        await proxy.callTool("observe", {
+          sessionUuid: "  session-a  ",
+          deviceId: "device-a",
+        });
+        expect(firstClient.callToolCalls[0]).toEqual({
+          toolName: "observe",
+          params: { sessionUuid: "session-a", deviceId: "device-a" },
+        });
+
+        await expect(
+          proxy.callTool("observe", { deviceId: "device-a" }),
+        ).rejects.toMatchObject({
+          sessionUuid: "session-a",
+          reason: "session-not-found",
+        });
+      } finally {
+        isAvailableSpy.mockRestore();
+        await proxy.close();
+      }
+    });
+
     test("a release received during connection setup prevents the first explicit call", async () => {
       const fakeClient = new FakeDaemonClient();
       fakeClient.subscribeToNotifications = async () => {

--- a/test/daemon/daemonSessionReleaseSignal.test.ts
+++ b/test/daemon/daemonSessionReleaseSignal.test.ts
@@ -7,11 +7,17 @@ import { TestCoverageRepository } from "../../src/db/testCoverageRepository";
 import { SessionReleaseBroadcaster } from "../../src/server/sessionReleaseBroadcast";
 import { DeviceSessionRepository } from "../../src/db/deviceSessionRepository";
 import { createTestDatabase } from "../db/testDbHelper";
+import { FakeTimer } from "../fakes/FakeTimer";
 
 // Issue #4610: the daemon registers a release callback (next to the nav-graph /
 // observe-cache cleanup) that fans the released session key out to the
 // SessionReleaseBroadcaster, so a connected proxy learns of a real release
 // instead of guessing with the replay TTL.
+
+interface DaemonHeartbeatMonitorInternals {
+  heartbeatMonitor: { stop(): void } | null;
+  startHeartbeatMonitor(): void;
+}
 
 describe("Daemon session-release signal wiring", () => {
   afterEach(() => {
@@ -33,18 +39,60 @@ describe("Daemon session-release signal wiring", () => {
     const daemon = new Daemon({}, undefined, undefined, new DeviceSessionRepository(db));
     const sessionManager = daemon.getSessionManager();
 
-    const emitted: string[] = [];
-    const unsubscribe = SessionReleaseBroadcaster.subscribe(sessionId => {
-      emitted.push(sessionId);
+    const emitted: Array<{ sessionId: string; reason?: string }> = [];
+    const unsubscribe = SessionReleaseBroadcaster.subscribe((sessionId, reason) => {
+      emitted.push({ sessionId, reason });
     });
 
     try {
       await sessionManager.createSession("session-release-signal", "emulator-5554", "android");
       await sessionManager.releaseSession("session-release-signal");
 
-      expect(emitted).toEqual(["session-release-signal"]);
+      expect(emitted).toEqual([
+        { sessionId: "session-release-signal", reason: "explicit-release" },
+      ]);
     } finally {
       unsubscribe();
+      sessionManager.stopCleanupTimer();
+    }
+  });
+
+  test("heartbeat monitor persists and broadcasts the diagnostic expiry reason", async () => {
+    const db = await createTestDatabase();
+    const timer = new FakeTimer();
+    const repository = new DeviceSessionRepository(db);
+    const daemon = new Daemon({}, undefined, timer, repository);
+    const sessionManager = daemon.getSessionManager();
+    const internals = daemon as unknown as DaemonHeartbeatMonitorInternals;
+    const emitted: Array<{ sessionId: string; reason?: string }> = [];
+    const unsubscribe = SessionReleaseBroadcaster.subscribe((sessionId, reason) => {
+      emitted.push({ sessionId, reason });
+    });
+
+    try {
+      await sessionManager.createSession(
+        "heartbeat-expired",
+        "emulator-5554",
+        "android",
+        60_000,
+        1_000,
+      );
+      sessionManager.recordHeartbeat("heartbeat-expired");
+      internals.startHeartbeatMonitor();
+
+      await timer.advanceTimeAsync(10_000);
+
+      const persisted = await repository.getSession("heartbeat-expired");
+      expect(persisted).toMatchObject({
+        status: "expired",
+        release_reason: "heartbeat-timeout",
+      });
+      expect(emitted).toEqual([
+        { sessionId: "heartbeat-expired", reason: "heartbeat-timeout" },
+      ]);
+    } finally {
+      unsubscribe();
+      internals.heartbeatMonitor?.stop();
       sessionManager.stopCleanupTimer();
     }
   });

--- a/test/daemon/socketServerMcpForwardSerialization.test.ts
+++ b/test/daemon/socketServerMcpForwardSerialization.test.ts
@@ -819,6 +819,35 @@ describe("UnixSocketServer MCP forward serialization", () => {
     expect(forwardedArguments).toEqual([]);
   });
 
+  test("rejects tools/list for a released implicit proxy binding", async () => {
+    const clientBindings: Array<string | undefined> = [];
+    server.mcpClientFactory = async boundSessionUuid => {
+      clientBindings.push(boundSessionUuid);
+      return {
+        listTools: async () => ({ tools: [] }),
+        callTool: async () => ({ content: [] }),
+        listResources: async () => ({ resources: [] }),
+        readResource: async () => ({ contents: [] }),
+        listResourceTemplates: async () => ({ resourceTemplates: [] }),
+        close: async () => {},
+      };
+    };
+
+    const response = await sendRequest(socketPath, {
+      id: randomUUID(),
+      type: "mcp_request",
+      method: "tools/list",
+      params: {
+        sessionUuid: "released-session",
+        [DAEMON_BOUND_SESSION_PARAM]: "released-session",
+      },
+    });
+
+    expect(response.success).toBe(false);
+    expect(response.error).toContain("Session not found: released-session");
+    expect(clientBindings).toEqual([]);
+  });
+
   test("routes a bound resources/read call through its session-scoped MCP client", async () => {
     sessionDevices.set("session-a", "device-a");
     const clientBindings: Array<string | undefined> = [];

--- a/test/daemon/socketServerMcpForwardSerialization.test.ts
+++ b/test/daemon/socketServerMcpForwardSerialization.test.ts
@@ -848,6 +848,37 @@ describe("UnixSocketServer MCP forward serialization", () => {
     expect(clientBindings).toEqual([]);
   });
 
+  test("rejects released bound resource discovery before shared routing", async () => {
+    const clientBindings: Array<string | undefined> = [];
+    server.mcpClientFactory = async boundSessionUuid => {
+      clientBindings.push(boundSessionUuid);
+      return {
+        listTools: async () => ({ tools: [] }),
+        callTool: async () => ({ content: [] }),
+        listResources: async () => ({ resources: [] }),
+        readResource: async () => ({ contents: [] }),
+        listResourceTemplates: async () => ({ resourceTemplates: [] }),
+        close: async () => {},
+      };
+    };
+
+    for (const method of ["resources/list", "resources/list-templates"]) {
+      const response = await sendRequest(socketPath, {
+        id: randomUUID(),
+        type: "mcp_request",
+        method,
+        params: {
+          sessionUuid: "released-session",
+          [DAEMON_BOUND_SESSION_PARAM]: "released-session",
+        },
+      });
+
+      expect(response.success).toBe(false);
+      expect(response.error).toContain("Session not found: released-session");
+    }
+    expect(clientBindings).toEqual([]);
+  });
+
   test("routes a bound resources/read call through its session-scoped MCP client", async () => {
     sessionDevices.set("session-a", "device-a");
     const clientBindings: Array<string | undefined> = [];

--- a/test/daemon/socketServerMcpForwardSerialization.test.ts
+++ b/test/daemon/socketServerMcpForwardSerialization.test.ts
@@ -789,7 +789,7 @@ describe("UnixSocketServer MCP forward serialization", () => {
     }
   });
 
-  test("does not recreate a released session from an implicit proxy binding", async () => {
+  test("rejects a released implicit proxy binding instead of forwarding unbound", async () => {
     const clientBindings: Array<string | undefined> = [];
     const forwardedArguments: Array<Record<string, unknown>> = [];
     server.mcpClientFactory = async boundSessionUuid => {
@@ -813,12 +813,10 @@ describe("UnixSocketServer MCP forward serialization", () => {
       [DAEMON_BOUND_SESSION_PARAM]: "released-session",
     });
 
-    expect(response.success).toBe(true);
-    expect(clientBindings).toEqual([undefined]);
-    expect(forwardedArguments).toEqual([expect.not.objectContaining({
-      sessionUuid: expect.anything(),
-      [DAEMON_BOUND_SESSION_PARAM]: expect.anything(),
-    })]);
+    expect(response.success).toBe(false);
+    expect(response.error).toContain("Session not found: released-session");
+    expect(clientBindings).toEqual([]);
+    expect(forwardedArguments).toEqual([]);
   });
 
   test("routes a bound resources/read call through its session-scoped MCP client", async () => {

--- a/test/daemon/socketServerNotifications.test.ts
+++ b/test/daemon/socketServerNotifications.test.ts
@@ -164,20 +164,21 @@ describe("UnixSocketServer notification broadcast", () => {
     });
   });
 
-  test("pushes a session-released frame carrying the released session id to subscribers (issue #4610)", async () => {
+  test("pushes a session-released frame carrying the id and diagnostic reason", async () => {
     const subscriber = await connectedClient();
     subscriber.send(DAEMON_SUBSCRIBE_NOTIFICATIONS_METHOD);
     await subscriber.waitForFrames(1);
 
     // Emitted by the daemon's onSessionRelease callback in production; the socket
     // server subscribes to the broadcaster in start().
-    SessionReleaseBroadcaster.emit("session-a");
+    SessionReleaseBroadcaster.emit("session-a", "missing-first-heartbeat");
     await subscriber.waitForFrames(2);
 
     expect(subscriber.frames[1]).toEqual({
       type: "daemon_notification",
       method: SESSION_RELEASED_NOTIFICATION_METHOD,
       sessionId: "session-a",
+      reason: "missing-first-heartbeat",
     });
   });
 

--- a/test/db/deviceSessionRepository.test.ts
+++ b/test/db/deviceSessionRepository.test.ts
@@ -203,6 +203,40 @@ describe("DeviceSessionRepository", () => {
     }
   });
 
+  test("SessionManager persists heartbeat expiry reasons as expired sessions", async () => {
+    const timer = new FakeTimer();
+    const sessionManager = new SessionManager(timer, repo);
+
+    try {
+      await sessionManager.createSession(
+        "missing-heartbeat",
+        "emulator-5554",
+        "android",
+        60_000,
+        60_000,
+      );
+      await sessionManager.createSession(
+        "stale-heartbeat",
+        "emulator-5556",
+        "android",
+        60_000,
+        60_000,
+      );
+
+      await sessionManager.releaseSession("missing-heartbeat", "missing-first-heartbeat");
+      await sessionManager.releaseSession("stale-heartbeat", "heartbeat-timeout");
+
+      const missingHeartbeat = await repo.getSession("missing-heartbeat");
+      const staleHeartbeat = await repo.getSession("stale-heartbeat");
+      expect(missingHeartbeat!.status).toBe("expired");
+      expect(missingHeartbeat!.release_reason).toBe("missing-first-heartbeat");
+      expect(staleHeartbeat!.status).toBe("expired");
+      expect(staleHeartbeat!.release_reason).toBe("heartbeat-timeout");
+    } finally {
+      sessionManager.stopCleanupTimer();
+    }
+  });
+
   test("DevicePool stale emulator eviction persists device-disconnected release reason", async () => {
     const timer = new FakeTimer();
     const fakeDeviceUtils = new FakeDeviceUtils();

--- a/test/fakes/FakeDaemonClient.ts
+++ b/test/fakes/FakeDaemonClient.ts
@@ -100,12 +100,13 @@ export class FakeDaemonClient implements DaemonClientLike {
   }
 
   /** Test hook: simulate a daemon-pushed notification frame. */
-  emitNotification(method: string, sessionId?: string): void {
+  emitNotification(method: string, sessionId?: string, reason?: string): void {
     for (const handler of this.notificationHandlers) {
       handler({
         type: "daemon_notification",
         method,
         ...(sessionId !== undefined ? { sessionId } : {}),
+        ...(reason !== undefined ? { reason } : {}),
       });
     }
   }

--- a/test/server/proxyServerSessionOwnership.test.ts
+++ b/test/server/proxyServerSessionOwnership.test.ts
@@ -57,9 +57,12 @@ describe("proxy server session ownership errors", () => {
           {
             type: "text",
             text: JSON.stringify({
-              code: "session_ownership_lost",
-              sessionUuid: "session-123",
-              reason: "heartbeat-timeout",
+              error: {
+                code: "session_ownership_lost",
+                message: "Session ownership lost for session-123: heartbeat-timeout",
+                sessionUuid: "session-123",
+                reason: "heartbeat-timeout",
+              },
             }),
           },
         ],

--- a/test/server/proxyServerSessionOwnership.test.ts
+++ b/test/server/proxyServerSessionOwnership.test.ts
@@ -1,0 +1,74 @@
+import { afterEach, describe, expect, spyOn, test } from "bun:test";
+import { Client } from "@modelcontextprotocol/sdk/client/index.js";
+import { InMemoryTransport } from "@modelcontextprotocol/sdk/inMemory.js";
+import { createProxyMcpServer } from "../../src/server/proxyServer";
+import { DaemonClient } from "../../src/daemon/client";
+import { DAEMON_VERSION } from "../../src/daemon/constants";
+import { SESSION_RELEASED_NOTIFICATION_METHOD } from "../../src/server/sessionReleaseBroadcast";
+import { FakeDaemonClient } from "../fakes/FakeDaemonClient";
+import { FakeDaemonManager } from "../fakes/FakeDaemonManager";
+
+let isAvailableSpy: ReturnType<typeof spyOn> | null = null;
+
+afterEach(() => {
+  isAvailableSpy?.mockRestore();
+  isAvailableSpy = null;
+});
+
+describe("proxy server session ownership errors", () => {
+  test("returns machine-readable ownership loss as an error CallToolResult", async () => {
+    isAvailableSpy = spyOn(DaemonClient, "isAvailable").mockResolvedValue(true);
+    const fakeClient = new FakeDaemonClient({
+      daemonMethodResults: new Map([["tools/list", { tools: [] }]]),
+    });
+    const daemonManager = new FakeDaemonManager();
+    daemonManager.statusResult = {
+      ...daemonManager.statusResult,
+      version: DAEMON_VERSION,
+    };
+    const { server, proxy } = createProxyMcpServer({
+      proxyConfig: {
+        initialSessionUuid: "session-123",
+        clientFactory: () => fakeClient,
+        daemonManager,
+        autoStartDaemon: false,
+      },
+    });
+    const [serverTransport, clientTransport] = InMemoryTransport.createLinkedPair();
+    const client = new Client({ name: "ownership-test-client", version: "0.0.1" });
+
+    try {
+      await server.connect(serverTransport);
+      await client.connect(clientTransport);
+      await proxy.listTools();
+      fakeClient.emitNotification(
+        SESSION_RELEASED_NOTIFICATION_METHOD,
+        "session-123",
+        "heartbeat-timeout",
+      );
+
+      const result = await client.callTool({
+        name: "observe",
+        arguments: { deviceId: "emulator-5554" },
+      });
+
+      expect(result).toEqual({
+        content: [
+          {
+            type: "text",
+            text: JSON.stringify({
+              code: "session_ownership_lost",
+              sessionUuid: "session-123",
+              reason: "heartbeat-timeout",
+            }),
+          },
+        ],
+        isError: true,
+      });
+      expect(fakeClient.callToolCalls).toEqual([]);
+    } finally {
+      await client.close();
+      await proxy.close();
+    }
+  });
+});

--- a/test/server/proxyServerSessionOwnership.test.ts
+++ b/test/server/proxyServerSessionOwnership.test.ts
@@ -68,6 +68,52 @@ describe("proxy server session ownership errors", () => {
       expect(fakeClient.callToolCalls).toEqual([]);
     } finally {
       await client.close();
+      await server.close();
+      await proxy.close();
+    }
+  });
+
+  test("preserves machine-readable ownership loss across discovery errors", async () => {
+    isAvailableSpy = spyOn(DaemonClient, "isAvailable").mockResolvedValue(true);
+    const fakeClient = new FakeDaemonClient({
+      daemonMethodResults: new Map([["tools/list", { tools: [] }]]),
+    });
+    const daemonManager = new FakeDaemonManager();
+    daemonManager.statusResult = {
+      ...daemonManager.statusResult,
+      version: DAEMON_VERSION,
+    };
+    const { server, proxy } = createProxyMcpServer({
+      proxyConfig: {
+        initialSessionUuid: "session-123",
+        clientFactory: () => fakeClient,
+        daemonManager,
+        autoStartDaemon: false,
+      },
+    });
+    const [serverTransport, clientTransport] = InMemoryTransport.createLinkedPair();
+    const client = new Client({ name: "ownership-test-client", version: "0.0.1" });
+    const ownershipLoss = /session_ownership_lost.*session-123.*heartbeat-timeout/;
+
+    try {
+      await server.connect(serverTransport);
+      await client.connect(clientTransport);
+      await proxy.listTools();
+      fakeClient.emitNotification(
+        SESSION_RELEASED_NOTIFICATION_METHOD,
+        "session-123",
+        "heartbeat-timeout",
+      );
+
+      await expect(client.listTools()).rejects.toThrow(ownershipLoss);
+      await expect(client.listResources()).rejects.toThrow(ownershipLoss);
+      await expect(client.listResourceTemplates()).rejects.toThrow(ownershipLoss);
+      await expect(
+        client.readResource({ uri: "automobile:devices/booted" }),
+      ).rejects.toThrow(ownershipLoss);
+    } finally {
+      await client.close();
+      await server.close();
       await proxy.close();
     }
   });

--- a/test/server/sessionReleaseBroadcast.test.ts
+++ b/test/server/sessionReleaseBroadcast.test.ts
@@ -11,23 +11,26 @@ describe("SESSION_RELEASED_NOTIFICATION_METHOD", () => {
 });
 
 describe("SessionReleaseBroadcaster", () => {
-  test("emit reaches all subscribers with the released session id; unsubscribe stops delivery", () => {
-    const first: string[] = [];
-    const second: string[] = [];
-    const unsubscribeFirst = SessionReleaseBroadcaster.subscribe(sessionId => {
-      first.push(sessionId);
+  test("emit reaches subscribers with the session id and reason; unsubscribe stops delivery", () => {
+    const first: Array<{ sessionId: string; reason?: string }> = [];
+    const second: Array<{ sessionId: string; reason?: string }> = [];
+    const unsubscribeFirst = SessionReleaseBroadcaster.subscribe((sessionId, reason) => {
+      first.push({ sessionId, reason });
     });
-    const unsubscribeSecond = SessionReleaseBroadcaster.subscribe(sessionId => {
-      second.push(sessionId);
+    const unsubscribeSecond = SessionReleaseBroadcaster.subscribe((sessionId, reason) => {
+      second.push({ sessionId, reason });
     });
 
     try {
-      SessionReleaseBroadcaster.emit("session-a");
+      SessionReleaseBroadcaster.emit("session-a", "heartbeat-timeout");
       unsubscribeFirst();
-      SessionReleaseBroadcaster.emit("session-a:device-a");
+      SessionReleaseBroadcaster.emit("session-a:device-a", "explicit-release");
 
-      expect(first).toEqual(["session-a"]);
-      expect(second).toEqual(["session-a", "session-a:device-a"]);
+      expect(first).toEqual([{ sessionId: "session-a", reason: "heartbeat-timeout" }]);
+      expect(second).toEqual([
+        { sessionId: "session-a", reason: "heartbeat-timeout" },
+        { sessionId: "session-a:device-a", reason: "explicit-release" },
+      ]);
     } finally {
       unsubscribeFirst();
       unsubscribeSecond();


### PR DESCRIPTION
## Summary

Keep long-lived MCP proxy bindings alive with per-session heartbeats and terminally fence identities that the daemon releases, so one session UUID can never silently resume against another device. Propagate the daemon's exact release reason through notifications and return ownership loss as an error `CallToolResult` whose text is machine-readable JSON (`session_ownership_lost`, `sessionUuid`, and `reason`).

The socket forwarding path now rejects stale bound markers instead of falling back to an unbound call, and reconnect/release/cache races are covered with deterministic `FakeTimer` and in-memory MCP tests.

## Linked Issue

Closes #5411

## Bug / Regression Context

- **Prior attempts:** Session replay and release signaling from [#4610](https://github.com/kaeawc/auto-mobile/issues/4610) and [#4611](https://github.com/kaeawc/auto-mobile/issues/4611) prevented several resurrection paths but did not keep bound transports alive or terminally fence every race.
- **Observed symptom:** A long-lived bound client could lose its daemon session during normal think time, then silently recreate the same UUID against another available device.
- **Repro steps / conditions:** Bind a standard MCP proxy session, leave it idle beyond the first-heartbeat grace, then issue another device-aware call while multiple devices are available.

## Validation

- [x] `scripts/all_fast_validate_checks.sh` passes (33/33)
- [x] `bun run turbo:validate` passes (lint, build, full test suite, boundary checks)
- [x] `bun run typecheck` reports no new errors (183 baseline errors unchanged)
- [x] 162 focused heartbeat, release, socket-forwarding, persistence, and MCP boundary tests pass
- [x] New code uses existing interfaces, fakes, `SingleFlightInterval`, and `FakeTimer`; focused unit tests remain under 100ms each
- [x] No new dependency, generated artifact, platform runner, schema migration, or device verification is required
- [x] Based on current `main` with no conflicts

Made with [Cursor](https://cursor.com)