### PR TITLE
Add independent log directory override

### DIFF
--- a/docs/design-docs/mcp/daemon/multi-agent-filesystem-contract.md
+++ b/docs/design-docs/mcp/daemon/multi-agent-filesystem-contract.md
@@ -4,7 +4,7 @@
 
 > **Current state:** The filesystem isolation described here is implemented and covered by tests — per-pid logs with multi-process-safe pruning, age-gated screenshot eviction, and data-dir cache paths. The operational guidance (per-agent `AUTOMOBILE_DATA_DIR` + shared-daemon discovery) is a deployment recommendation. See the [Status Glossary](../../status-glossary.md) for chip definitions and [Daemon Overview](index.md) for architecture context.
 
-> **Stable base dir (issue #2724):** All auto-mobile on-disk state resolves under a
+> **Stable base dir (issue #2724):** All auto-mobile **non-log** on-disk state resolves under a
 > **stable, non-ephemeral base directory**, not `os.tmpdir()`. The base is
 > resolved by `resolveAutoMobileBaseDir()` (`src/utils/tempDir.ts`):
 > `AUTOMOBILE_DATA_DIR` / `AUTO_MOBILE_DATA_DIR` if set → else `~/.auto-mobile` →
@@ -12,7 +12,10 @@
 > deliberately **not** derived from `TMPDIR`/`TMP`/`TEMP`, because `bunx` can point
 > those at an extraction tree it later reaps while the daemon still holds open
 > fds — the cause of the 0-byte logs and `ENOENT` cache writes in #2724.
-> Paths written `${TMPDIR}/auto-mobile/...` below are historical; read them as
+> `AUTOMOBILE_LOG_DIR` / `AUTO_MOBILE_LOG_DIR`, when set, overrides only the
+> core log directory; otherwise logs use
+> `${AUTOMOBILE_DATA_DIR:-~/.auto-mobile}/logs`. Paths written
+> `${TMPDIR}/auto-mobile/...` below are historical; read non-log paths as
 > `${AUTOMOBILE_DATA_DIR:-~/.auto-mobile}/...`.
 
 ## Overview
@@ -58,6 +61,8 @@ dir**. With a per-agent `AUTOMOBILE_DATA_DIR` (§4) every per-client row collaps
 to a single writer in its own tree. Paths are written `${TMPDIR}/auto-mobile/...`
 for historical continuity; resolve them as
 `${AUTOMOBILE_DATA_DIR:-~/.auto-mobile}/...` (see the stable-base-dir note above).
+Core log paths below use `$LOG_DIR`, which resolves to
+`${AUTOMOBILE_LOG_DIR:-${AUTOMOBILE_DATA_DIR:-~/.auto-mobile}/logs}`.
 
 | Path / resource | Writers (shared base dir) | Collision risk & mitigation |
 |---|---|---|
@@ -68,10 +73,10 @@ for historical continuity; resolve them as
 | `${TMPDIR}/auto-mobile/cache/screen-size` | N | `md5(deviceId).json` — per-device, content is stable; concurrent writes are idempotent. (No longer CWD-relative.) |
 | daemon control socket / PID / lock | 1 (daemon) | discovered by clients via env — see §2. |
 | auxiliary sockets (video, snapshot, …) | 1 (daemon) | resolved from the configured/default daemon paths; clients and daemon must agree on explicit overrides. |
-| `${TMPDIR}/auto-mobile/logs/daemon.log` | 1 daemon | stable daemon log; rotated files are `daemon-<timestamp>.log`. |
-| `${TMPDIR}/auto-mobile/logs/stdio-<pid>.log` | 1 each | per-stdio-client file; pruning only trims this pid's files + sweeps stale others by mtime. |
-| `${TMPDIR}/auto-mobile/tool_logs` (`LOG_DIR`) | N | routed through `tempDir` (honors `AUTOMOBILE_DATA_DIR`, not `TMPDIR`). |
-| `…/auto-mobile/logs/daemon-launch-<pid>.log` | 1 per manager | daemon stdout/stderr launch capture, in the **stable** logs dir (was an ephemeral `mkdtemp(tmpdir())` — issue #2724); truncated per launch. |
+| `$LOG_DIR/daemon.log` | 1 daemon | stable daemon log; rotated files are `daemon-<timestamp>.log`. |
+| `$LOG_DIR/stdio-<pid>.log` | 1 each | per-stdio-client file; pruning only trims this pid's files + sweeps stale others by mtime. |
+| `${TMPDIR}/auto-mobile/tool_logs` | N | routed through `tempDir` (honors `AUTOMOBILE_DATA_DIR`, not `TMPDIR`). |
+| `$LOG_DIR/daemon-launch-<pid>.log` | 1 per manager | daemon stdout/stderr launch capture, in the **stable** logs dir (was an ephemeral `mkdtemp(tmpdir())` — issue #2724); truncated per launch. |
 | `mkdtemp(...)` APK / prefetch dirs | per-call unique | **already safe** (random suffix). |
 
 The daemon enforces exactly one daemon per host per user (single-daemon policy in
@@ -90,9 +95,12 @@ single biggest source of "client can't find the daemon" failures.
 
 ```bash
 # AUTOMOBILE_DATA_DIR should be PER-AGENT (see §4), NOT shared — it scopes each
-# agent's logs and device caches to a stable, non-ephemeral tree. Daemon
+# agent's device caches and default log location to a stable, non-ephemeral tree. Daemon
 # discovery does NOT depend on it, so isolating it is free.
 #   export AUTOMOBILE_DATA_DIR=/run/auto-mobile/agent-$AGENT_ID
+
+# Optional: redirect only core logs, without relocating device caches or other state.
+#   export AUTOMOBILE_LOG_DIR=/var/log/auto-mobile
 
 # Daemon discovery — MUST match between clients and the daemon, or clients
 # resolve a different socket/PID/lock than the daemon created.
@@ -100,7 +108,7 @@ export AUTOMOBILE_DAEMON_SOCKET_PATH=/var/run/auto-mobile/daemon.sock
 export AUTOMOBILE_DAEMON_PID_FILE_PATH=/var/run/auto-mobile/daemon.pid
 export AUTOMOBILE_DAEMON_LOCK_FILE_PATH=/var/run/auto-mobile/daemon.lock
 
-# Log routing (after the code fix in §4): keep this per-host, not per-client.
+# Log level: keep shared logging volume manageable in production.
 export AUTOMOBILE_LOG_LEVEL=warn           # quieter shared log in prod
 ```
 
@@ -114,6 +122,10 @@ export AUTOMOBILE_LOG_LEVEL=warn           # quieter shared log in prod
   you keep a shared base instead, the code's defense-in-depth (age-gated
   screenshot eviction, per-pid logs, per-device cache cleanup) keeps agents from
   deleting each other's files.
+- **`AUTOMOBILE_LOG_DIR`** — when set, routes only core daemon/client logs,
+  rotated logs, and daemon-launch captures to that directory. It takes
+  precedence over the `logs` child of `AUTOMOBILE_DATA_DIR`; all non-log state
+  remains data-dir scoped.
 - **`AUTOMOBILE_DAEMON_*` paths** — `daemon/constants.ts` resolves these at
   module load. Default is `/tmp/auto-mobile-daemon-<uid>.{sock,pid,lock}`. If
   you override them, override them for **both** sides. The daemon already
@@ -161,8 +173,9 @@ give **each agent its own `AUTOMOBILE_DATA_DIR`** and point them all at the
 **same daemon**:
 
 ```bash
-# Per agent: isolated, STABLE base dir (device caches, logs never share a
-# directory, and survive bunx temp-dir cleanup — issue #2724).
+# Per agent: isolated, STABLE base dir (device caches, and logs when
+# AUTOMOBILE_LOG_DIR is unset, never share a directory and survive bunx
+# temp-dir cleanup — issue #2724).
 export AUTOMOBILE_DATA_DIR=/run/auto-mobile/agent-$AGENT_ID
 
 # Same on every agent: the shared daemon is discovered via explicit paths that

--- a/docs/design-docs/mcp/daemon/multi-agent-filesystem-contract.md
+++ b/docs/design-docs/mcp/daemon/multi-agent-filesystem-contract.md
@@ -14,7 +14,8 @@
 > fds — the cause of the 0-byte logs and `ENOENT` cache writes in #2724.
 > `AUTOMOBILE_LOG_DIR` / `AUTO_MOBILE_LOG_DIR`, when set, overrides only the
 > core log directory; otherwise logs use
-> `${AUTOMOBILE_DATA_DIR:-~/.auto-mobile}/logs`. Paths written
+> `${AUTOMOBILE_DATA_DIR:-~/.auto-mobile}/logs` (or
+> `os.tmpdir()/auto-mobile/logs` when no home directory is resolvable). Paths written
 > `${TMPDIR}/auto-mobile/...` below are historical; read non-log paths as
 > `${AUTOMOBILE_DATA_DIR:-~/.auto-mobile}/...`.
 

--- a/docs/using/environment-variables.md
+++ b/docs/using/environment-variables.md
@@ -18,6 +18,10 @@ unset.
 | `AUTOMOBILE_DATA_DIR` | `AUTO_MOBILE_DATA_DIR` | Stable base directory for AutoMobile's non-log state, including caches, screenshots, `tool_logs`, and the default log location. | `~/.auto-mobile` |
 | `AUTOMOBILE_LOG_DIR` | `AUTO_MOBILE_LOG_DIR` | Directory for structured daemon/client logs, rotated logs, and daemon-launch captures. Takes precedence over the `logs` child of `AUTOMOBILE_DATA_DIR` without relocating any non-log state. Relative paths resolve from the daemon's launch working directory. | `${AUTOMOBILE_DATA_DIR:-~/.auto-mobile}/logs` |
 
+When no home directory is available and `AUTOMOBILE_DATA_DIR` is unset, the data
+directory falls back to `os.tmpdir()/auto-mobile`; the default log directory is
+then `os.tmpdir()/auto-mobile/logs`.
+
 For example, keep durable state under one path while routing only logs to a
 location collected by your deployment:
 

--- a/docs/using/environment-variables.md
+++ b/docs/using/environment-variables.md
@@ -11,6 +11,21 @@ Every `AUTOMOBILE_*` variable also accepts a legacy `AUTO_MOBILE_*` alias
 retained for backward compatibility and is used only when the preferred name is
 unset.
 
+## State & log locations
+
+| Variable | Legacy alias | Purpose | Default |
+|----------|--------------|---------|---------|
+| `AUTOMOBILE_DATA_DIR` | `AUTO_MOBILE_DATA_DIR` | Stable base directory for AutoMobile's non-log state, including caches, screenshots, `tool_logs`, and the default log location. | `~/.auto-mobile` |
+| `AUTOMOBILE_LOG_DIR` | `AUTO_MOBILE_LOG_DIR` | Directory for structured daemon/client logs, rotated logs, and daemon-launch captures. Takes precedence over the `logs` child of `AUTOMOBILE_DATA_DIR` without relocating any non-log state. Relative paths resolve from the daemon's launch working directory. | `${AUTOMOBILE_DATA_DIR:-~/.auto-mobile}/logs` |
+
+For example, keep durable state under one path while routing only logs to a
+location collected by your deployment:
+
+```bash
+export AUTOMOBILE_DATA_DIR=/var/lib/automobile
+export AUTOMOBILE_LOG_DIR=/var/log/automobile
+```
+
 ## Database location & behavior (`AUTOMOBILE_DB_*`)
 
 These control where the SQLite database (`auto-mobile.db`) is stored and how the

--- a/src/daemon/daemon.ts
+++ b/src/daemon/daemon.ts
@@ -359,9 +359,9 @@ export class Daemon {
    */
   async start(): Promise<void> {
     // Mirror structured daemon logs to stdout/stderr capture as well. The
-    // primary stable log is `<auto-mobile data dir>/logs/daemon.log` (defaults to
-    // `~/.auto-mobile/logs/daemon.log`); the daemon manager also redirects
-    // stdout/stderr to a per-start capture file in that same stable logs dir.
+    // primary stable log is `<configured log dir>/daemon.log` (defaulting to
+    // `<auto-mobile data dir>/logs/daemon.log`); the daemon manager also
+    // redirects stdout/stderr to a per-start capture file in that same dir.
     logger.enableStdoutLogging();
     const stableWorkingDirectory = resolveStableDaemonWorkingDirectory();
     process.env[DAEMON_LAUNCH_CWD_ENV] ??= safeProcessCwd(stableWorkingDirectory);

--- a/src/daemon/manager.ts
+++ b/src/daemon/manager.ts
@@ -9,7 +9,7 @@ import {
   INCOMPLETE_EXTRACTION_CODE,
   INCOMPLETE_EXTRACTION_EXIT_CODE,
 } from "../db/migrationDependencyIntegrity";
-import { ensureSecureTempDirSync, TEMP_SUBDIRS } from "../utils/tempDir";
+import { ensureSecureLogsDirSync } from "../utils/tempDir";
 import { outputReductionFlagsToArgs } from "../utils/outputReductionFlags";
 import {
   EVENT_ALL_MARKERS_FLAG,
@@ -546,14 +546,14 @@ export class DaemonManager implements DaemonManagerLike {
     // Falls back to bunx to avoid requiring a global install.
     let { command: autoMobileCmd, args } = this.withDaemonOptions(this.resolveLaunchCommand(), options);
 
-    // Redirect the detached daemon's stdout/stderr into the STABLE logs dir
+    // Redirect the detached daemon's stdout/stderr into the configured logs dir
     // (`~/.auto-mobile/logs` by default) rather than an ephemeral
     // `mkdtemp(tmpdir())` directory. Under bunx the temp tree is reaped while the
     // daemon keeps this fd open, which previously left the on-disk log unlinked
     // and post-hoc debugging impossible (issue #2724). The logs dir is created
-    // owner-only (0o700) by ensureSecureTempDirSync, so a fixed, predictable
+    // owner-only (0o700) by ensureSecureLogsDirSync, so a fixed, predictable
     // filename inside it is not exposed to other users.
-    const logsDir = ensureSecureTempDirSync(TEMP_SUBDIRS.LOGS);
+    const logsDir = ensureSecureLogsDirSync();
     const logPath = join(logsDir, `daemon-launch-${process.pid}.log`);
     // Open with restricted permissions (0o600 = owner read/write only).
     // Truncate per launch so a single manager's bootstrap captures don't grow

--- a/src/utils/logger.ts
+++ b/src/utils/logger.ts
@@ -3,8 +3,8 @@
  */
 import fs from "fs";
 import path from "path";
-import { ensureDirExists, statAsync, renameAsync } from "./io";
-import { getTempDir, TEMP_SUBDIRS } from "./tempDir";
+import { statAsync, renameAsync } from "./io";
+import { ensureSecureLogsDirSync } from "./tempDir";
 import { pruneLogFiles } from "./logPruner";
 
 /**
@@ -138,16 +138,9 @@ const trackWrite = (write: Promise<void>): void => {
   lastWrite = lastWrite.then(() => write);
 };
 
-// Create logs directory if it doesn't exist. Use getTempDir so the location
-// honors TMPDIR and matches the rest of the auto-mobile temp tree (rather than a
-// hardcoded /tmp path that can diverge from where other processes look).
-const logsDir = getTempDir(TEMP_SUBDIRS.LOGS);
-if (!fs.existsSync(logsDir)) {
-  fs.mkdirSync(logsDir, { recursive: true });
-}
-ensureDirExists(logsDir).catch(err => {
-  console.error("Failed to create logs directory:", err);
-});
+// Create the configured log directory with owner-only permissions. This may be
+// independent of AUTOMOBILE_DATA_DIR, which continues to scope non-log state.
+const logsDir = ensureSecureLogsDirSync();
 
 // The daemon is single-owner, so keep its stable log name easy to document and
 // tail. Stdio/client processes remain PID-scoped because several can run in

--- a/src/utils/tempDir.ts
+++ b/src/utils/tempDir.ts
@@ -69,7 +69,7 @@ export function resolveAutoMobileBaseDir(
 export function resolveAutoMobileLogsDir(
   env: NodeJS.ProcessEnv = process.env,
   homeDir: string = os.homedir(),
-  daemonLaunchWorkingDirectory: string = resolveDaemonLaunchWorkingDirectory()
+  daemonLaunchWorkingDirectory: string = resolveDaemonLaunchWorkingDirectory(undefined, env)
 ): string {
   const override = (env.AUTOMOBILE_LOG_DIR ?? env.AUTO_MOBILE_LOG_DIR)?.trim();
   if (override && override.length > 0) {
@@ -95,6 +95,12 @@ export function getTempDir(subdirectory: string): string {
 
 function ensureSecureDirectorySync(dir: string): string {
   fs.mkdirSync(dir, { recursive: true, mode: SECURE_DIR_MODE });
+  if (fs.lstatSync(dir).isSymbolicLink()) {
+    throw new Error(`Refusing to use symbolic-link directory: ${dir}`);
+  }
+  if (process.platform !== "win32") {
+    fs.chmodSync(dir, SECURE_DIR_MODE);
+  }
   return dir;
 }
 

--- a/src/utils/tempDir.ts
+++ b/src/utils/tempDir.ts
@@ -14,6 +14,7 @@
 import fs from "node:fs";
 import os from "os";
 import path from "path";
+import { resolveDaemonLaunchWorkingDirectory } from "./workingDirectory";
 
 /**
  * Restrictive directory permissions (owner read/write/execute only).
@@ -22,7 +23,7 @@ import path from "path";
 const SECURE_DIR_MODE = 0o700;
 
 /**
- * Resolve the stable base directory for all auto-mobile on-disk state.
+ * Resolve the stable base directory for AutoMobile's non-log on-disk state.
  *
  * Resolution order:
  * 1. `AUTOMOBILE_DATA_DIR` / `AUTO_MOBILE_DATA_DIR` — explicit, configurable
@@ -58,6 +59,27 @@ export function resolveAutoMobileBaseDir(
 }
 
 /**
+ * Resolve the directory for structured and daemon-launch logs.
+ *
+ * A log-dir override intentionally takes precedence over the data-dir-derived
+ * logs child without changing the base directory for any other AutoMobile
+ * state. Relative overrides are anchored to the daemon launch directory so a
+ * manager and its spawned daemon agree even after the daemon changes cwd.
+ */
+export function resolveAutoMobileLogsDir(
+  env: NodeJS.ProcessEnv = process.env,
+  homeDir: string = os.homedir(),
+  daemonLaunchWorkingDirectory: string = resolveDaemonLaunchWorkingDirectory()
+): string {
+  const override = (env.AUTOMOBILE_LOG_DIR ?? env.AUTO_MOBILE_LOG_DIR)?.trim();
+  if (override && override.length > 0) {
+    return path.resolve(daemonLaunchWorkingDirectory, override);
+  }
+
+  return path.join(resolveAutoMobileBaseDir(env, homeDir), TEMP_SUBDIRS.LOGS);
+}
+
+/**
  * Get a secure auto-mobile directory path for a given subdirectory.
  * Does NOT create the directory - use ensureSecureTempDirSync for that.
  *
@@ -71,6 +93,11 @@ export function getTempDir(subdirectory: string): string {
   return path.join(resolveAutoMobileBaseDir(), subdirectory);
 }
 
+function ensureSecureDirectorySync(dir: string): string {
+  fs.mkdirSync(dir, { recursive: true, mode: SECURE_DIR_MODE });
+  return dir;
+}
+
 /**
  * Synchronously ensure a secure temp directory exists with restrictive permissions.
  *
@@ -78,9 +105,14 @@ export function getTempDir(subdirectory: string): string {
  * @returns Full path to the created/existing temp directory
  */
 export function ensureSecureTempDirSync(subdirectory: string): string {
-  const dir = getTempDir(subdirectory);
-  fs.mkdirSync(dir, { recursive: true, mode: SECURE_DIR_MODE });
-  return dir;
+  return ensureSecureDirectorySync(getTempDir(subdirectory));
+}
+
+/**
+ * Synchronously ensure the shared log directory exists with restrictive permissions.
+ */
+export function ensureSecureLogsDirSync(): string {
+  return ensureSecureDirectorySync(resolveAutoMobileLogsDir());
 }
 
 // Common subdirectory constants for consistency

--- a/src/utils/workingDirectory.ts
+++ b/src/utils/workingDirectory.ts
@@ -23,9 +23,10 @@ export function resolveStableDaemonWorkingDirectory(
 }
 
 export function resolveDaemonLaunchWorkingDirectory(
-  currentWorkingDirectory: string = safeProcessCwd()
+  currentWorkingDirectory: string = safeProcessCwd(),
+  env: NodeJS.ProcessEnv = process.env
 ): string {
-  const launchCwd = process.env[DAEMON_LAUNCH_CWD_ENV]?.trim();
+  const launchCwd = env[DAEMON_LAUNCH_CWD_ENV]?.trim();
   return launchCwd && path.isAbsolute(launchCwd)
     ? launchCwd
     : currentWorkingDirectory;

--- a/test/daemon/daemonManagerLaunch.test.ts
+++ b/test/daemon/daemonManagerLaunch.test.ts
@@ -23,6 +23,7 @@ describe("DaemonManager launch", () => {
     process.chdir(originalCwd);
     delete process.env[DAEMON_LAUNCH_CWD_ENV];
     delete process.env.AUTOMOBILE_DATA_DIR;
+    delete process.env.AUTOMOBILE_LOG_DIR;
     delete process.env[EVENT_ALL_MARKERS_ENV];
     for (const dir of tempDirs) {
       rmSync(dir, { recursive: true, force: true });
@@ -76,6 +77,58 @@ describe("DaemonManager launch", () => {
     expect(existsSync(logsDir)).toBe(true);
     const launchLogs = readdirSync(logsDir).filter(name => name.startsWith("daemon-launch"));
     expect(launchLogs.length).toBeGreaterThan(0);
+  });
+
+  test("writes the daemon launch log to AUTOMOBILE_LOG_DIR without moving data paths", async () => {
+    const stateDir = createTempDir("daemon-launch-state-");
+    const dataDir = createTempDir("daemon-data-dir-");
+    const logDir = join(createTempDir("daemon-log-dir-"), "logs");
+    process.env.AUTOMOBILE_DATA_DIR = dataDir;
+    process.env.AUTOMOBILE_LOG_DIR = logDir;
+
+    let capturedOptions: SpawnOptions | undefined;
+    const processSpawner: DaemonProcessSpawner = {
+      spawn: (_command: string, _args: string[], options: SpawnOptions) => {
+        capturedOptions = options;
+        return {
+          unref() {},
+          once() { return this; },
+          off() { return this; },
+        } as ChildProcess;
+      }
+    };
+
+    let statusCallCount = 0;
+    class TestDaemonManager extends DaemonManager {
+      override findAllDaemonProcesses(): number[] { return []; }
+      override async status(): Promise<any> {
+        statusCallCount++;
+        return statusCallCount === 1
+          ? { running: false }
+          : { running: true, pid: 1234, port: 31847, socketPath: join(stateDir, "daemon.sock") };
+      }
+      override async waitForReady(_timeout: number): Promise<boolean> {
+        return true;
+      }
+    }
+
+    const manager = new TestDaemonManager(
+      undefined,
+      undefined,
+      new FakeTimer(),
+      join(stateDir, "daemon.lock"),
+      join(stateDir, "daemon.pid"),
+      join(stateDir, "daemon.sock"),
+      undefined,
+      processSpawner
+    );
+
+    await manager.start();
+
+    expect(existsSync(logDir)).toBe(true);
+    expect(readdirSync(logDir).some(name => name.startsWith("daemon-launch"))).toBe(true);
+    expect(existsSync(join(dataDir, "logs"))).toBe(false);
+    expect(capturedOptions?.env?.AUTOMOBILE_LOG_DIR).toBe(logDir);
   });
 
   test("spawns detached daemon from a stable cwd instead of inheriting the spawner cwd", async () => {

--- a/test/utils/dataDir.test.ts
+++ b/test/utils/dataDir.test.ts
@@ -78,32 +78,44 @@ describe("resolveAutoMobileLogsDir", () => {
         home,
         "/launch",
       )
-    ).toBe("/srv/logs");
+    ).toBe(path.resolve("/srv/logs"));
   });
 
   test("honors the legacy log-dir alias", () => {
     expect(
       resolveAutoMobileLogsDir({ AUTO_MOBILE_LOG_DIR: "/srv/legacy-logs" }, home, "/launch")
-    ).toBe("/srv/legacy-logs");
+    ).toBe(path.resolve("/srv/legacy-logs"));
   });
 
   test("resolves relative log overrides from the daemon launch directory", () => {
     expect(
       resolveAutoMobileLogsDir({ AUTOMOBILE_LOG_DIR: "logs" }, home, "/launch")
-    ).toBe("/launch/logs");
+    ).toBe(path.resolve("/launch", "logs"));
+  });
+
+  test("uses the injected launch directory for a relative log override", () => {
+    expect(
+      resolveAutoMobileLogsDir(
+        {
+          AUTOMOBILE_LOG_DIR: "logs",
+          AUTOMOBILE_DAEMON_LAUNCH_CWD: "/injected-launch",
+        },
+        home,
+      )
+    ).toBe(path.resolve("/injected-launch", "logs"));
   });
 
   test("falls back to the data-dir logs child for an unset or blank override", () => {
     expect(
       resolveAutoMobileLogsDir({ AUTOMOBILE_DATA_DIR: "/srv/data" }, home, "/launch")
-    ).toBe("/srv/data/logs");
+    ).toBe(path.join(path.resolve("/srv/data"), "logs"));
     expect(
       resolveAutoMobileLogsDir(
         { AUTOMOBILE_LOG_DIR: "   ", AUTOMOBILE_DATA_DIR: "/srv/data" },
         home,
         "/launch",
       )
-    ).toBe("/srv/data/logs");
+    ).toBe(path.join(path.resolve("/srv/data"), "logs"));
   });
 });
 
@@ -120,8 +132,12 @@ describe("getTempDir", () => {
     process.env.AUTOMOBILE_DATA_DIR = "/srv/data";
     process.env.AUTOMOBILE_LOG_DIR = "/srv/logs";
     try {
-      expect(getTempDir(TEMP_SUBDIRS.SCREENSHOTS)).toBe("/srv/data/screenshots");
-      expect(getTempDir(TEMP_SUBDIRS.TOOL_LOGS)).toBe("/srv/data/tool_logs");
+      expect(getTempDir(TEMP_SUBDIRS.SCREENSHOTS)).toBe(
+        path.join(path.resolve("/srv/data"), "screenshots")
+      );
+      expect(getTempDir(TEMP_SUBDIRS.TOOL_LOGS)).toBe(
+        path.join(path.resolve("/srv/data"), "tool_logs")
+      );
     } finally {
       if (previousDataDir === undefined) {
         delete process.env.AUTOMOBILE_DATA_DIR;
@@ -172,6 +188,46 @@ describe("ensureSecureTempDirSync", () => {
       const mode = fs.statSync(dir).mode & 0o777;
       expect(dir).toBe(logDir);
       expect(mode).toBe(0o700);
+    } finally {
+      if (previousLogDir === undefined) {
+        delete process.env.AUTOMOBILE_LOG_DIR;
+      } else {
+        process.env.AUTOMOBILE_LOG_DIR = previousLogDir;
+      }
+      fs.rmSync(tmpBase, { recursive: true, force: true });
+    }
+  });
+
+  test.skipIf(process.platform === "win32")("repairs an existing overridden logs directory to 0o700", () => {
+    const tmpBase = fs.mkdtempSync(path.join(os.tmpdir(), "am-log-mode-repair-"));
+    const logDir = path.join(tmpBase, "logs");
+    const previousLogDir = process.env.AUTOMOBILE_LOG_DIR;
+    fs.mkdirSync(logDir, { mode: 0o755 });
+    fs.chmodSync(logDir, 0o755);
+    process.env.AUTOMOBILE_LOG_DIR = logDir;
+    try {
+      ensureSecureLogsDirSync();
+      expect(fs.statSync(logDir).mode & 0o777).toBe(0o700);
+    } finally {
+      if (previousLogDir === undefined) {
+        delete process.env.AUTOMOBILE_LOG_DIR;
+      } else {
+        process.env.AUTOMOBILE_LOG_DIR = previousLogDir;
+      }
+      fs.rmSync(tmpBase, { recursive: true, force: true });
+    }
+  });
+
+  test.skipIf(process.platform === "win32")("rejects a symbolic-link log directory", () => {
+    const tmpBase = fs.mkdtempSync(path.join(os.tmpdir(), "am-log-link-"));
+    const targetDir = path.join(tmpBase, "target");
+    const linkDir = path.join(tmpBase, "logs");
+    const previousLogDir = process.env.AUTOMOBILE_LOG_DIR;
+    fs.mkdirSync(targetDir);
+    fs.symlinkSync(targetDir, linkDir, "dir");
+    process.env.AUTOMOBILE_LOG_DIR = linkDir;
+    try {
+      expect(() => ensureSecureLogsDirSync()).toThrow("symbolic-link directory");
     } finally {
       if (previousLogDir === undefined) {
         delete process.env.AUTOMOBILE_LOG_DIR;

--- a/test/utils/dataDir.test.ts
+++ b/test/utils/dataDir.test.ts
@@ -4,7 +4,9 @@ import os from "node:os";
 import path from "node:path";
 import {
   resolveAutoMobileBaseDir,
+  resolveAutoMobileLogsDir,
   getTempDir,
+  ensureSecureLogsDirSync,
   ensureSecureTempDirSync,
   TEMP_SUBDIRS,
 } from "../../src/utils/tempDir";
@@ -62,11 +64,76 @@ describe("resolveAutoMobileBaseDir", () => {
   });
 });
 
+describe("resolveAutoMobileLogsDir", () => {
+  const home = "/home/tester";
+
+  test("prefers the log override over data-dir and legacy log overrides", () => {
+    expect(
+      resolveAutoMobileLogsDir(
+        {
+          AUTOMOBILE_LOG_DIR: "/srv/logs",
+          AUTO_MOBILE_LOG_DIR: "/srv/legacy-logs",
+          AUTOMOBILE_DATA_DIR: "/srv/data",
+        },
+        home,
+        "/launch",
+      )
+    ).toBe("/srv/logs");
+  });
+
+  test("honors the legacy log-dir alias", () => {
+    expect(
+      resolveAutoMobileLogsDir({ AUTO_MOBILE_LOG_DIR: "/srv/legacy-logs" }, home, "/launch")
+    ).toBe("/srv/legacy-logs");
+  });
+
+  test("resolves relative log overrides from the daemon launch directory", () => {
+    expect(
+      resolveAutoMobileLogsDir({ AUTOMOBILE_LOG_DIR: "logs" }, home, "/launch")
+    ).toBe("/launch/logs");
+  });
+
+  test("falls back to the data-dir logs child for an unset or blank override", () => {
+    expect(
+      resolveAutoMobileLogsDir({ AUTOMOBILE_DATA_DIR: "/srv/data" }, home, "/launch")
+    ).toBe("/srv/data/logs");
+    expect(
+      resolveAutoMobileLogsDir(
+        { AUTOMOBILE_LOG_DIR: "   ", AUTOMOBILE_DATA_DIR: "/srv/data" },
+        home,
+        "/launch",
+      )
+    ).toBe("/srv/data/logs");
+  });
+});
+
 describe("getTempDir", () => {
   test("derives every subdirectory from the resolved stable base", () => {
     const logs = getTempDir(TEMP_SUBDIRS.LOGS);
     const base = resolveAutoMobileBaseDir();
     expect(logs).toBe(path.join(base, TEMP_SUBDIRS.LOGS));
+  });
+
+  test("keeps non-log paths under AUTOMOBILE_DATA_DIR when logs are overridden", () => {
+    const previousDataDir = process.env.AUTOMOBILE_DATA_DIR;
+    const previousLogDir = process.env.AUTOMOBILE_LOG_DIR;
+    process.env.AUTOMOBILE_DATA_DIR = "/srv/data";
+    process.env.AUTOMOBILE_LOG_DIR = "/srv/logs";
+    try {
+      expect(getTempDir(TEMP_SUBDIRS.SCREENSHOTS)).toBe("/srv/data/screenshots");
+      expect(getTempDir(TEMP_SUBDIRS.TOOL_LOGS)).toBe("/srv/data/tool_logs");
+    } finally {
+      if (previousDataDir === undefined) {
+        delete process.env.AUTOMOBILE_DATA_DIR;
+      } else {
+        process.env.AUTOMOBILE_DATA_DIR = previousDataDir;
+      }
+      if (previousLogDir === undefined) {
+        delete process.env.AUTOMOBILE_LOG_DIR;
+      } else {
+        process.env.AUTOMOBILE_LOG_DIR = previousLogDir;
+      }
+    }
   });
 });
 
@@ -90,6 +157,26 @@ describe("ensureSecureTempDirSync", () => {
         delete process.env.AUTOMOBILE_DATA_DIR;
       } else {
         process.env.AUTOMOBILE_DATA_DIR = prev;
+      }
+      fs.rmSync(tmpBase, { recursive: true, force: true });
+    }
+  });
+
+  test.skipIf(process.platform === "win32")("creates an overridden logs directory with restrictive 0o700 permissions", () => {
+    const tmpBase = fs.mkdtempSync(path.join(os.tmpdir(), "am-log-mode-test-"));
+    const logDir = path.join(tmpBase, "logs");
+    const previousLogDir = process.env.AUTOMOBILE_LOG_DIR;
+    process.env.AUTOMOBILE_LOG_DIR = logDir;
+    try {
+      const dir = ensureSecureLogsDirSync();
+      const mode = fs.statSync(dir).mode & 0o777;
+      expect(dir).toBe(logDir);
+      expect(mode).toBe(0o700);
+    } finally {
+      if (previousLogDir === undefined) {
+        delete process.env.AUTOMOBILE_LOG_DIR;
+      } else {
+        process.env.AUTOMOBILE_LOG_DIR = previousLogDir;
       }
       fs.rmSync(tmpBase, { recursive: true, force: true });
     }

--- a/test/utils/logger-loglevel-env.test.ts
+++ b/test/utils/logger-loglevel-env.test.ts
@@ -1,6 +1,8 @@
 import { describe, expect, test, spyOn } from "bun:test";
 import fs from "fs";
 import { EventEmitter } from "node:events";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
 import { LogLevel, parseAutomobileLogLevel, resolveProcessLogPrefix } from "../../src/utils/logger";
 
 class FakeLogStream extends EventEmitter {
@@ -48,6 +50,30 @@ async function loggerWithEnvLevel(
       delete process.env.AUTOMOBILE_LOG_LEVEL;
     } else {
       process.env.AUTOMOBILE_LOG_LEVEL = previous;
+    }
+  }
+}
+
+async function loggerWithLogDirectory(
+  logDir: string,
+  dataDir: string
+): Promise<typeof import("../../src/utils/logger")> {
+  const previousLogDir = process.env.AUTOMOBILE_LOG_DIR;
+  const previousDataDir = process.env.AUTOMOBILE_DATA_DIR;
+  process.env.AUTOMOBILE_LOG_DIR = logDir;
+  process.env.AUTOMOBILE_DATA_DIR = dataDir;
+  try {
+    return await import(`../../src/utils/logger.ts?log-directory-${freshImportCounter++}`);
+  } finally {
+    if (previousLogDir === undefined) {
+      delete process.env.AUTOMOBILE_LOG_DIR;
+    } else {
+      process.env.AUTOMOBILE_LOG_DIR = previousLogDir;
+    }
+    if (previousDataDir === undefined) {
+      delete process.env.AUTOMOBILE_DATA_DIR;
+    } else {
+      process.env.AUTOMOBILE_DATA_DIR = previousDataDir;
     }
   }
 }
@@ -155,6 +181,29 @@ describe("AUTOMOBILE_LOG_LEVEL is applied at process start (issue #3845)", () =>
     } finally {
       createWriteStream.mockRestore();
       logFileExists.mockRestore();
+    }
+  });
+});
+
+describe("AUTOMOBILE_LOG_DIR", () => {
+  test("routes structured logs outside the data directory", async () => {
+    const root = fs.mkdtempSync(join(tmpdir(), "am-logger-dir-"));
+    const logDir = join(root, "logs");
+    const dataDir = join(root, "data");
+    const stream = new FakeLogStream();
+    const createWriteStream = spyOn(fs, "createWriteStream").mockReturnValue(
+      stream as unknown as fs.WriteStream,
+    );
+
+    try {
+      const mod = await loggerWithLogDirectory(logDir, dataDir);
+      const prefix = mod.resolveProcessLogPrefix(process.argv, process.pid);
+      expect(createWriteStream).toHaveBeenCalledWith(join(logDir, `${prefix}.log`), { flags: "a" });
+      expect(fs.existsSync(join(dataDir, "logs"))).toBeFalse();
+      await mod.logger.closeAfterFlush();
+    } finally {
+      createWriteStream.mockRestore();
+      fs.rmSync(root, { recursive: true, force: true });
     }
   });
 });


### PR DESCRIPTION
## Summary

- Add `AUTOMOBILE_LOG_DIR` / `AUTO_MOBILE_LOG_DIR` to route core logs without relocating data, caches, or sockets.
- Route structured, rotated, and daemon-launch logs through the shared secure resolver, including relative paths anchored to the daemon launch directory.
- Document the precedence and add coverage for resolver behavior, logger output, daemon launch capture, and directory permissions.

Closes #5413

## Validation

- `bun test test/utils/dataDir.test.ts test/utils/logger-loglevel-env.test.ts test/daemon/daemonManagerLaunch.test.ts`
- `bun run lint`
- `bun run typecheck`
- `bun run build`
- `bun run turbo:validate`
- `bash scripts/all_fast_validate_checks.sh`
