### PR TITLE
fix(desktop-core): restart a newer daemon at the compatible version

### DIFF
--- a/android/desktop-core/src/main/kotlin/dev/jasonpearson/automobile/desktop/core/daemon/DesktopDaemonLifecycle.kt
+++ b/android/desktop-core/src/main/kotlin/dev/jasonpearson/automobile/desktop/core/daemon/DesktopDaemonLifecycle.kt
@@ -400,13 +400,6 @@ internal class DesktopDaemonLifecycle(
         return DaemonLifecycleResult.Ready(restarted = false)
       }
 
-      if (daemonAvailable && daemonIsNewer(currentVersion, expectedVersion)) {
-        return DaemonLifecycleResult.Failure(
-          "AutoMobile daemon $currentVersion is newer than desktop $expectedVersion. " +
-            "Update the desktop application before connecting."
-        )
-      }
-
       if (declaresFullVersion(expectedVersion)) {
         return DaemonLifecycleResult.Failure(
           "AutoMobile desktop source build $expectedVersion cannot start a matching published daemon. " +
@@ -496,23 +489,6 @@ internal class DesktopDaemonLifecycle(
     repeat(SOCKET_PROBE_ATTEMPTS) { attempt ->
       if (socketChecker.isReady()) return true
       if (attempt + 1 < SOCKET_PROBE_ATTEMPTS) timer.sleep(SOCKET_PROBE_RETRY_DELAY_MS)
-    }
-    return false
-  }
-
-  private fun daemonIsNewer(
-    currentVersion: String?,
-    expectedVersion: String,
-  ): Boolean {
-    val currentRelease = currentVersion?.let(DaemonSocketPaths::releaseVersion).orEmpty()
-    val expectedRelease = DaemonSocketPaths.releaseVersion(expectedVersion)
-    val currentParts = currentRelease.split('.').map { it.toIntOrNull() ?: return false }
-    val expectedParts = expectedRelease.split('.').map { it.toIntOrNull() ?: return false }
-    val length = maxOf(currentParts.size, expectedParts.size)
-    for (index in 0 until length) {
-      val difference =
-        (currentParts.getOrElse(index) { 0 }).compareTo(expectedParts.getOrElse(index) { 0 })
-      if (difference != 0) return difference > 0
     }
     return false
   }

--- a/android/desktop-core/src/test/kotlin/dev/jasonpearson/automobile/desktop/core/daemon/DesktopDaemonLifecycleTest.kt
+++ b/android/desktop-core/src/test/kotlin/dev/jasonpearson/automobile/desktop/core/daemon/DesktopDaemonLifecycleTest.kt
@@ -82,22 +82,26 @@ class DesktopDaemonLifecycleTest {
   }
 
   @Test
-  fun `rejects a newer daemon without restarting it`() {
+  fun `restarts a newer daemon at the compatible desktop version`() {
     val commands = FakeDaemonCommandExecutor()
     val lifecycle =
       DesktopDaemonLifecycle(
         expectedVersionProvider = { "0.0.40" },
-        socketChecker = FakeDaemonSocketChecker(listOf(true)),
-        pidFileReader = FakeDaemonPidFileReader(listOf("0.0.41")),
+        socketChecker = FakeDaemonSocketChecker(listOf(true, true)),
+        pidFileReader = FakeDaemonPidFileReader(listOf("0.0.41", "0.0.40")),
         commandExecutor = commands,
         timer = FakeDaemonRetryTimer(),
+        packageRunnerResolver = FakeDaemonPackageRunnerResolver("bunx"),
       )
 
     val result = lifecycle.ensureVersionMatchedDaemon()
 
-    assertIs<DaemonLifecycleResult.Failure>(result)
-    assertTrue(result.message.contains("newer"))
-    assertTrue(commands.commands.isEmpty())
+    assertIs<DaemonLifecycleResult.Ready>(result)
+    assertTrue(result.restarted)
+    assertEquals(
+      listOf(listOf("bunx", "@kaeawc/auto-mobile@0.0.40", "--daemon", "restart")),
+      commands.commands,
+    )
   }
 
   @Test


### PR DESCRIPTION
## Summary

The desktop's daemon version gate was failing hard instead of self-healing when the running daemon reported a *newer* release than the desktop jar (e.g. desktop `0.0.52` connecting to a `0.0.60` daemon from a fresh checkout). Users saw `AutoMobile daemon <x> is newer than desktop <y>. Update the desktop application before connecting.` with no automatic recovery.

The desktop already knows how to reconcile a version-skewed shared daemon by restarting it through the pinned `bunx @kaeawc/auto-mobile@<version> --daemon restart` package. The newer-daemon case was the only branch that opted out of that flow. This removes that special-case early-return (and the now-unused `daemonIsNewer` helper) so a newer daemon falls through to the existing restart path and gets relaunched at the version the desktop is compatible with. The source-build guard directly below still rejects the one case `bunx` cannot satisfy (a source-build desktop cannot spawn a published daemon).

## Linked Issue

No linked issue — reported directly from a desktop run showing the version-mismatch error.

## Bug / Regression Context

- **Prior attempts:** version-match daemon lifecycle was introduced in #4457, which deliberately rejected newer daemons rather than restarting them.
- **Observed symptom:** desktop refuses to connect with "daemon is newer than desktop — update the desktop application", requiring a manual desktop rebuild.
- **Repro steps / conditions:** run a newer daemon (e.g. a source build from a checkout ahead of the installed desktop), then open the older desktop app and let it read booted devices.

## Validation

- [x] `:desktop-core:test --tests "*DesktopDaemonLifecycleTest*"` passes (retargeted test asserts the bunx restart command)
- [x] Kotlin sources formatted with `scripts/ktfmt/apply_ktfmt.sh`

## Kotlin Reuse Check

- [x] No new helpers or dependencies; the change deletes code and reuses the existing restart flow.

## Device Verification

N/A — pure daemon-lifecycle control-flow change, covered by unit tests.