### PR TITLE
Fix packaged desktop HTTP runtime module

### DIFF
--- a/.github/workflows/build-desktop-app-installers.yml
+++ b/.github/workflows/build-desktop-app-installers.yml
@@ -145,6 +145,21 @@ jobs:
           gradle-encryption-key: ${{ secrets.GRADLE_ENCRYPTION_KEY }}
           malloc-replacement: ${{ runner.os == 'Linux' && 'jemalloc' || 'none' }}
 
+      # `GitHubReleaseSource` is created during desktop-app startup and requires this module.
+      # Compose's jlink image is minimized, so assert the actual app image includes it before
+      # notarization instead of discovering a missing class after release.
+      - name: "Verify Java HTTP module in app image"
+        if: matrix.platform == 'macos'
+        working-directory: android
+        run: |
+          set -euo pipefail
+          APP=$(find desktop-app/build/compose/binaries/main/app -maxdepth 1 -type d -name '*.app' | head -n 1)
+          if [ -z "$APP" ]; then
+            echo "No .app was produced under desktop-app/build/compose/binaries/main/app" >&2
+            exit 1
+          fi
+          "${GITHUB_WORKSPACE}/scripts/ci/verify-desktop-app-http-module.sh" "$APP"
+
       - name: "Write App Store Connect API key"
         if: matrix.platform == 'macos'
         env:

--- a/android/desktop-app/build.gradle.kts
+++ b/android/desktop-app/build.gradle.kts
@@ -196,6 +196,10 @@ compose.desktop {
     mainClass = "dev.jasonpearson.automobile.desktop.MainKt"
     nativeDistributions {
       targetFormats(TargetFormat.Dmg, TargetFormat.Msi, TargetFormat.Deb)
+      // GitHubReleaseSource (constructed during application startup) uses the JDK HttpClient.
+      // Compose's minimized jlink runtime does not infer this module from the classpath, so it
+      // must be declared explicitly or packaged apps fail with NoClassDefFoundError.
+      modules("java.net.http")
       packageName = "AutoMobile"
       packageVersion = desktopPackageVersion
       description = "AutoMobile Desktop - Device automation and testing dashboard"

--- a/scripts/ci/verify-desktop-app-http-module.sh
+++ b/scripts/ci/verify-desktop-app-http-module.sh
@@ -1,0 +1,39 @@
+#!/usr/bin/env bash
+#
+# Verify that a packaged AutoMobile desktop app includes the JDK HTTP client
+# module required by the startup update checker.
+#
+# Usage: verify-desktop-app-http-module.sh <AutoMobile.app>
+# Env:   JIMAGE (optional) — override the jimage binary for tests.
+set -euo pipefail
+
+app_path="${1:-}"
+if [ -z "${app_path}" ]; then
+  echo "usage: verify-desktop-app-http-module.sh <AutoMobile.app>" >&2
+  exit 2
+fi
+if [ ! -d "${app_path}" ]; then
+  echo "verify-desktop-app-http-module: app not found: ${app_path}" >&2
+  exit 2
+fi
+
+module_image="${app_path}/Contents/runtime/Contents/Home/lib/modules"
+if [ ! -f "${module_image}" ]; then
+  echo "verify-desktop-app-http-module: Java module image not found: ${module_image}" >&2
+  exit 2
+fi
+
+jimage_bin="${JIMAGE:-${JAVA_HOME:+${JAVA_HOME}/bin/jimage}}"
+if [ -z "${jimage_bin}" ]; then
+  echo "verify-desktop-app-http-module: set JAVA_HOME or JIMAGE" >&2
+  exit 2
+fi
+
+# Do not use grep -q here: with pipefail it can close the pipe early, causing
+# jimage to receive SIGPIPE and turning a valid runtime image into a false failure.
+if ! "${jimage_bin}" list "${module_image}" | grep 'java/net/http/HttpClient.class$' >/dev/null; then
+  echo "Packaged Java runtime is missing java.net.http (HttpClient)" >&2
+  exit 1
+fi
+
+echo "Verified java.net.http in ${app_path}"

--- a/test/bats/desktop-installer-app-staple.bats
+++ b/test/bats/desktop-installer-app-staple.bats
@@ -34,6 +34,22 @@ wiring_requires_yq() {
   [[ "$output" == ":desktop-app:createDistributable" ]]
 }
 
+@test "the macOS app image verifies java.net.http before notarization" {
+  wiring_requires_yq
+
+  local module_check_idx notarize_idx run_block
+  run_block="$(yq -r '.jobs.build.steps[] | select(.name == "Verify Java HTTP module in app image") | .run' "$WORKFLOW")"
+  [ -n "$run_block" ]
+  [[ "$run_block" == *'verify-desktop-app-http-module.sh'* ]]
+  [[ "$run_block" == *'"$APP"'* ]]
+
+  module_check_idx="$(yq -r '.jobs.build.steps | to_entries[] | select(.value.name == "Verify Java HTTP module in app image") | .key' "$WORKFLOW")"
+  notarize_idx="$(yq -r '.jobs.build.steps | to_entries[] | select(.value.name == "Notarize and staple app image") | .key' "$WORKFLOW")"
+  [ -n "$module_check_idx" ]
+  [ -n "$notarize_idx" ]
+  [ "$module_check_idx" -lt "$notarize_idx" ]
+}
+
 @test "the app image is notarized and stapled before the DMG is assembled" {
   wiring_requires_yq
 

--- a/test/bats/verify-desktop-app-http-module.bats
+++ b/test/bats/verify-desktop-app-http-module.bats
@@ -1,0 +1,79 @@
+#!/usr/bin/env bats
+#
+# Unit tests for scripts/ci/verify-desktop-app-http-module.sh. The jimage
+# executable is injected so these tests do not require macOS or a real JDK image.
+
+SCRIPT="scripts/ci/verify-desktop-app-http-module.sh"
+
+setup() {
+  TEST_ROOT="$(mktemp -d)"
+  APP="${TEST_ROOT}/AutoMobile.app"
+  MODULE_IMAGE="${APP}/Contents/runtime/Contents/Home/lib/modules"
+  mkdir -p "$(dirname "${MODULE_IMAGE}")"
+  : >"${MODULE_IMAGE}"
+
+  JIMAGE="${TEST_ROOT}/jimage"
+  cat >"${JIMAGE}" <<'FAKE'
+#!/usr/bin/env bash
+set -euo pipefail
+
+if [ "${1:-}" != "list" ]; then
+  echo "expected jimage list" >&2
+  exit 2
+fi
+
+case "${JIMAGE_MODE:-present}" in
+  present)
+    printf '    java/net/http/HttpClient.class\n'
+    # The class appears near the start of the real module image. Keep writing to
+    # detect a grep -q regression that closes the pipe before jimage finishes.
+    for _ in $(seq 1 1000); do
+      printf '    java/lang/Object.class\n'
+    done
+    ;;
+  missing) printf '    java/lang/Object.class\n' ;;
+esac
+FAKE
+  chmod +x "${JIMAGE}"
+}
+
+teardown() {
+  rm -rf "${TEST_ROOT}"
+}
+
+@test "accepts an app runtime that contains HttpClient" {
+  run env JIMAGE="${JIMAGE}" JIMAGE_MODE="present" "${SCRIPT}" "${APP}"
+  [ "$status" -eq 0 ]
+  [[ "$output" == *"Verified java.net.http"* ]]
+}
+
+@test "fails when the module image lacks HttpClient" {
+  run env JIMAGE="${JIMAGE}" JIMAGE_MODE="missing" "${SCRIPT}" "${APP}"
+  [ "$status" -eq 1 ]
+  [[ "$output" == *"missing java.net.http"* ]]
+}
+
+@test "errors when no app path is given" {
+  run env JIMAGE="${JIMAGE}" "${SCRIPT}"
+  [ "$status" -eq 2 ]
+  [[ "$output" == *"usage:"* ]]
+}
+
+@test "errors when the app path does not exist" {
+  run env JIMAGE="${JIMAGE}" "${SCRIPT}" "${TEST_ROOT}/missing.app"
+  [ "$status" -eq 2 ]
+  [[ "$output" == *"app not found"* ]]
+}
+
+@test "errors when the app has no Java module image" {
+  rm -f "${MODULE_IMAGE}"
+  run env JIMAGE="${JIMAGE}" "${SCRIPT}" "${APP}"
+  [ "$status" -eq 2 ]
+  [[ "$output" == *"Java module image not found"* ]]
+}
+
+@test "errors when neither JIMAGE nor JAVA_HOME is available" {
+  run env -u JIMAGE -u JAVA_HOME "${SCRIPT}" "${APP}"
+  [ "$status" -eq 2 ]
+  [[ "$output" == *"set JAVA_HOME or JIMAGE"* ]]
+}


### PR DESCRIPTION
## Summary
- Include `java.net.http` in the Compose Desktop runtime image so startup can construct the update client.
- Fail macOS packaging before notarization when the app image lacks `HttpClient`.
- Cover the new workflow verification with the existing BATS suite.

## Test plan
- [x] `bats test/bats/desktop-installer-app-staple.bats`
- [x] `JAVA_HOME=... ./gradlew -Dorg.gradle.jvmargs='-Xmx2g -Dfile.encoding=UTF-8' :desktop-app:createDistributable -PdesktopPackageVersion=0.0.60`
- [x] Verified the built runtime contains `java/net/http/HttpClient.class`
- [x] `scripts/all_fast_validate_checks.sh`

Made with [Cursor](https://cursor.com)