### PR TITLE
fix(daemon): harden lifecycle recovery

### DIFF
--- a/src/daemon/daemon.ts
+++ b/src/daemon/daemon.ts
@@ -242,6 +242,9 @@ export class Daemon {
     });
     // Register centralized cleanup for session-scoped state
     this.sessionManager.onSessionRelease((sessionId, deviceId) => {
+      this.navigationGraphListenerManagers.delete(
+        NavigationGraphManager.getInstanceForSession(sessionId),
+      );
       NavigationGraphManager.releaseSession(sessionId);
       RealObserveScreen.clearCache(deviceId);
       // Clear the per-device CtrlProxy client's binding to the released session
@@ -256,7 +259,12 @@ export class Daemon {
     // A rebind keeps the session live, but its navigation state was collected on
     // the old device and must not follow it to the new one.
     this.sessionManager.onSessionDeviceUnbound((sessionId, deviceId) => {
+      const previousNavigationManager = NavigationGraphManager.getInstanceForSession(sessionId);
       NavigationGraphManager.resetSession(sessionId);
+      this.navigationGraphListenerManagers.delete(previousNavigationManager);
+      this.setupNavigationGraphUpdateListener(
+        NavigationGraphManager.getInstanceForSession(sessionId),
+      );
       RealObserveScreen.clearCache(deviceId);
       AndroidCtrlProxyClient.getExistingInstance(deviceId)?.releaseSessionBinding(sessionId);
       IOSCtrlProxyClient.getExistingInstance(deviceId)?.releaseSessionBinding(sessionId);
@@ -1194,6 +1202,10 @@ export class Daemon {
       logger.info("[Daemon] Navigation graph listener triggered, exporting summary...");
       try {
         const summary = await navGraphManager.exportGraphSummary();
+        if (!this.navigationGraphListenerManagers.has(navGraphManager)) {
+          logger.debug("[Daemon] Ignoring navigation update from a released or rebound session");
+          return;
+        }
         logger.info(`[Daemon] Got summary: appId=${summary.appId}, nodes=${summary.nodes.length}, edges=${summary.edges.length}`);
 
         const streamData = convertSummaryToStreamData(summary);
@@ -2071,7 +2083,7 @@ export class Daemon {
   }
 
   private async releaseActiveSessionsForShutdown(): Promise<void> {
-    const sessionIds = this.sessionManager.getAllSessionIds();
+    const sessionIds = this.sessionManager.getAllKnownSessionIds();
     const releases = sessionIds.map(sessionId =>
       this.cancelAndReleaseSession(sessionId, "daemon-shutdown", true),
     );

--- a/src/daemon/daemon.ts
+++ b/src/daemon/daemon.ts
@@ -4,7 +4,7 @@ import { createMcpServer } from "../server";
 import { logger } from "../utils/logger";
 import { MultiPlatformDeviceManager } from "../utils/deviceUtils";
 import { UnixSocketServer } from "./socketServer";
-import { SessionManager, type ActiveSessionExecutionQuery } from "./sessionManager";
+import { SessionManager, type ActiveSessionExecutionQuery, type Session } from "./sessionManager";
 import { SessionHeartbeatMonitor } from "./SessionHeartbeatMonitor";
 import { SingleFlightInterval } from "./SingleFlightInterval";
 import { DevicePool, type PooledDevice } from "./devicePool";
@@ -132,6 +132,12 @@ const MIGRATION_SETTLE_TIMEOUT_MS = 5_000;
 
 type HealthFailureKind = "http" | "socket" | "database" | "unknown";
 type DatabaseHealthFailureRecovery = (code: number) => void | Promise<void>;
+type DeviceSessionRoutingTargets = {
+  deviceDataStream: ReturnType<typeof getDeviceDataStreamServer>;
+  performancePush: ReturnType<typeof getPerformancePushServer>;
+  failuresPush: ReturnType<typeof getFailuresPushServer>;
+  telemetryPush: ReturnType<typeof getTelemetryPushServer>;
+};
 
 /**
  * Main daemon process
@@ -175,6 +181,8 @@ export class Daemon {
   private startupFailureTracker: StartupFailureTracker;
   private recoverFromDatabaseHealthFailure: DatabaseHealthFailureRecovery;
   private observationStreamHealth: ObservationStreamHealth;
+  private deviceDataStreamServer: ReturnType<typeof getDeviceDataStreamServer> = null;
+  private readonly navigationGraphListenerManagers = new WeakSet<NavigationGraphManager>();
   private unsubscribeAdbMissingDevice: (() => void) | null = null;
   private options: DaemonOptions;
   private shutdownHandlersRegistered: boolean = false;
@@ -219,13 +227,18 @@ export class Daemon {
       startServer: async () => {
         await startDeviceDataStreamSocketServer(this.timer);
       },
-      configureCallbacks: () => this.setupDeviceDataStreamCallback(),
+      configureCallbacks: () => this.configureDeviceDataStreamServer(),
     });
     this.deviceSessionRepository = deviceSessionRepository;
     this.sessionManager = new SessionManager(this.timer, this.deviceSessionRepository);
     this.sessionManager.setActiveSessionExecutionChecker(
       (sessionId, query) => this.hasActiveSessionExecution(sessionId, query),
     );
+    this.sessionManager.onSessionCreated((session) => {
+      this.setupNavigationGraphUpdateListener(
+        NavigationGraphManager.getInstanceForSession(session.sessionId),
+      );
+    });
     // Register centralized cleanup for session-scoped state
     this.sessionManager.onSessionRelease((sessionId, deviceId) => {
       NavigationGraphManager.releaseSession(sessionId);
@@ -426,21 +439,18 @@ export class Daemon {
     await startDeviceSnapshotSocketServer();
     await startAppearanceSocketServer();
     await startPerformanceStreamSocketServer();
+    await startDeviceDataStreamSocketServer(this.timer);
+    this.configureDeviceDataStreamServer();
     await startPerformancePushSocketServer();
-    await startDeviceDataStreamSocketServer();
+    this.setupDeviceSessionRouting();
     await startFailuresStreamSocketServer();
     await startFailuresPushSocketServer();
+    this.setupDeviceSessionRouting();
     await startTelemetryPushSocketServer();
+    this.setupDeviceSessionRouting();
     await startWebRtcStreamSocketServer();
     await startVideoStreamSocketServer();
     startupBenchmark.endPhase("auxiliarySocketServerStart");
-
-    // Wire up callback to establish WebSocket connections when IDE plugins subscribe
-    this.setupDeviceDataStreamCallback();
-
-    // Wire the device-session routing key (epic #5256, item 3): give every push
-    // server the serial↔deviceSessionUuid resolver, and stream session lifecycle.
-    this.setupDeviceSessionRouting();
 
     startAppearanceSyncScheduler();
     startPerformanceMonitor();
@@ -969,13 +979,35 @@ export class Daemon {
    * the registry's connect/disconnect transitions to `device_session_started` /
    * `device_session_ended` frames on the observation stream (epic #5256, item 3).
    */
+  private getDeviceSessionRoutingTargets(): DeviceSessionRoutingTargets {
+    return {
+      deviceDataStream: getDeviceDataStreamServer(),
+      performancePush: getPerformancePushServer(),
+      failuresPush: getFailuresPushServer(),
+      telemetryPush: getTelemetryPushServer(),
+    };
+  }
+
+  private configureDeviceDataStreamServer(): void {
+    // The stream singleton can be replaced by health recovery. Route it before
+    // registering request callbacks so every handler observes the current epoch.
+    this.setupDeviceSessionRouting();
+    this.setupDeviceDataStreamCallback();
+  }
+
   private setupDeviceSessionRouting(): void {
     const resolver = createRegistryDeviceSessionResolver(this.deviceSessionRegistry);
-    const deviceDataStream = getDeviceDataStreamServer();
+    const {
+      deviceDataStream,
+      performancePush,
+      failuresPush,
+      telemetryPush,
+    } = this.getDeviceSessionRoutingTargets();
+    this.deviceDataStreamServer = deviceDataStream;
     deviceDataStream?.setDeviceSessionResolver(resolver);
-    getPerformancePushServer()?.setDeviceSessionResolver(resolver);
-    getFailuresPushServer()?.setDeviceSessionResolver(resolver);
-    getTelemetryPushServer()?.setDeviceSessionResolver(resolver);
+    performancePush?.setDeviceSessionResolver(resolver);
+    failuresPush?.setDeviceSessionResolver(resolver);
+    telemetryPush?.setDeviceSessionResolver(resolver);
 
     if (deviceDataStream) {
       this.deviceSessionRegistry.setLifecycleListener({
@@ -986,7 +1018,7 @@ export class Daemon {
   }
 
   private setupDeviceDataStreamCallback(): void {
-    const server = getDeviceDataStreamServer();
+    const server = this.deviceDataStreamServer ?? getDeviceDataStreamServer();
     if (!server) {
       logger.warn("[Daemon] Observation stream server not available for callback setup");
       return;
@@ -1135,8 +1167,28 @@ export class Daemon {
       return;
     }
 
-    const navGraphManager = NavigationGraphManager.getInstance();
+    this.setupNavigationGraphUpdateListener(NavigationGraphManager.getInstance());
+    for (const session of this.sessionManager.getAllSessions()) {
+      this.setupNavigationGraphUpdateListener(
+        NavigationGraphManager.getInstanceForSession(session.sessionId)
+      );
+    }
 
+    // Requests retain the legacy unattributed graph behavior. Live graph changes
+    // above are also wired to each active session manager, which is where tool
+    // execution records navigation state.
+    server.setOnNavigationGraphRequested(
+      createNavigationGraphRequestHandler(NavigationGraphManager.getInstance())
+    );
+
+    logger.info("[Daemon] Navigation graph stream listener configured");
+  }
+
+  private setupNavigationGraphUpdateListener(navGraphManager: NavigationGraphManager): void {
+    if (this.navigationGraphListenerManagers.has(navGraphManager)) {
+      return;
+    }
+    this.navigationGraphListenerManagers.add(navGraphManager);
     navGraphManager.setGraphUpdateListener(async () => {
       logger.info("[Daemon] Navigation graph listener triggered, exporting summary...");
       try {
@@ -1147,21 +1199,13 @@ export class Daemon {
         // Attribute the update to the device that owns this app's graph so panes
         // watching other devices are not cross-contaminated (epic #5256; #4837).
         const deviceId = navGraphManager.getDeviceIdForApp(summary.appId);
-        server.pushNavigationGraphUpdate(streamData, deviceId);
+        this.deviceDataStreamServer?.pushNavigationGraphUpdate(streamData, deviceId);
 
         logger.info(`[Daemon] Pushed navigation graph update: ${summary.nodes.length} nodes, ${summary.edges.length} edges`);
       } catch (error) {
         logger.warn(`[Daemon] Failed to push navigation graph update: ${error}`);
       }
     });
-
-    // Wire up on-demand navigation graph requests from IDE plugins. A failed export must NOT be
-    // swallowed to null (issue #4918): the handler rethrows so the stream server's existing error
-    // path surfaces a typed `error` frame, letting a stream-driven client distinguish "export
-    // failed" from "no app / empty graph".
-    server.setOnNavigationGraphRequested(createNavigationGraphRequestHandler(navGraphManager));
-
-    logger.info("[Daemon] Navigation graph stream listener configured");
   }
 
   /**
@@ -1356,7 +1400,18 @@ export class Daemon {
 
         for (const [deviceId, recordingIds] of missingByDevice.entries()) {
           const pooledDeviceAtDisconnect = this.devicePool.getDevice(deviceId);
-          if (await this.shouldSkipStaleDisconnectCleanup(pooledDeviceAtDisconnect, deviceId)) {
+          const assignmentCountAtDisconnect = pooledDeviceAtDisconnect?.assignmentCount;
+          const sessionIdAtDisconnect =
+            pooledDeviceAtDisconnect?.sessionId ?? this.sessionManager.getSessionForDevice(deviceId);
+          const sessionAtDisconnect = sessionIdAtDisconnect
+            ? this.sessionManager.getSession(sessionIdAtDisconnect)
+            : null;
+          const forceGenerationAtDisconnect = this.forceDisconnectedDeviceGenerations.get(deviceId);
+          if (await this.shouldSkipStaleDisconnectCleanup(
+            pooledDeviceAtDisconnect,
+            deviceId,
+            forceGenerationAtDisconnect,
+          )) {
             continue;
           }
           let deviceCleanupSucceeded = true;
@@ -1365,37 +1420,16 @@ export class Daemon {
           getPerformanceMonitor().stopMonitoring(deviceId);
 
           for (const recordingId of recordingIds) {
-            if (this.stoppingRecordings.has(recordingId)) {
+            if (!(await this.stopRecordingAfterDeviceDisconnect(recordingId, deviceId))) {
               deviceCleanupSucceeded = false;
-              continue;
-            }
-            this.stoppingRecordings.add(recordingId);
-            try {
-              await stopVideoRecording(recordingId);
-              logger.warn(
-                `[Daemon] Stopped recording ${recordingId} after device ${deviceId} disconnected`
-              );
-            } catch (error) {
-              logger.warn(
-                `[Daemon] Failed to stop recording ${recordingId} after device ${deviceId} disconnected: ${error}`
-              );
-              try {
-                await interruptVideoRecording(recordingId);
-                logger.warn(
-                  `[Daemon] Marked recording ${recordingId} interrupted after device ${deviceId} disconnected`
-                );
-              } catch (interruptError) {
-                deviceCleanupSucceeded = false;
-                logger.warn(
-                  `[Daemon] Failed to mark recording ${recordingId} interrupted after device ${deviceId} disconnected: ${interruptError}`
-                );
-              }
-            } finally {
-              this.stoppingRecordings.delete(recordingId);
             }
           }
 
-          if (await this.shouldSkipStaleDisconnectCleanup(pooledDeviceAtDisconnect, deviceId)) {
+          if (await this.shouldSkipStaleDisconnectCleanup(
+            pooledDeviceAtDisconnect,
+            deviceId,
+            forceGenerationAtDisconnect,
+          )) {
             continue;
           }
 
@@ -1409,41 +1443,67 @@ export class Daemon {
             undefined,
             "absent",
           );
-          if (await this.shouldSkipStaleDisconnectCleanup(pooledDeviceAtDisconnect, deviceId)) {
+          if (await this.shouldSkipStaleDisconnectCleanup(
+            pooledDeviceAtDisconnect,
+            deviceId,
+            forceGenerationAtDisconnect,
+          ) || !this.isCapturedDisconnectTargetCurrent(
+            deviceId,
+            pooledDeviceAtDisconnect,
+            assignmentCountAtDisconnect,
+            sessionIdAtDisconnect,
+            sessionAtDisconnect,
+          )) {
             continue;
           }
-          const sessionId = this.sessionManager.getSessionForDevice(deviceId);
-          if (sessionId) {
+          if (sessionIdAtDisconnect && sessionAtDisconnect) {
             logger.warn(
-              `[DisconnectMonitor] Device ${deviceId} confirmed disconnected after ${DEVICE_DISCONNECT_MISS_THRESHOLD} consecutive misses — cancelling session ${sessionId}`
+              `[DisconnectMonitor] Device ${deviceId} confirmed disconnected after ${DEVICE_DISCONNECT_MISS_THRESHOLD} consecutive misses — cancelling session ${sessionIdAtDisconnect}`
             );
             await this.cancelAndReleaseSession(
-              sessionId,
+              sessionIdAtDisconnect,
               deviceLossCancellationReason(deviceId, incidentId),
+              false,
+              sessionAtDisconnect,
             );
           }
 
-          await this.devicePool.removeDisconnectedDevice(deviceId, true, incidentId);
+          if (!this.isCapturedDisconnectTargetCurrent(
+            deviceId,
+            pooledDeviceAtDisconnect,
+            assignmentCountAtDisconnect,
+          )) {
+            continue;
+          }
+          await this.devicePool.removeDisconnectedDevice(
+            deviceId,
+            true,
+            incidentId,
+            pooledDeviceAtDisconnect ?? undefined,
+          );
           // Drop any per-device input caches so a device replaced under the same
           // serial does not inherit the previous one's cached API-level capability
           // (issue #3351): an API 31+/pre-31 mismatch mis-handles SHIFT/uppercase.
           // This fires only on a CONFIRMED disappearance; a fast same-serial restart
           // that never confirms is handled by the device-ready callback; the 5-min
           // idle close remains a fallback.
-          this.socketServer?.evictDeviceInputCache(deviceId);
           if (this.devicePool.getDevice(deviceId)) {
             // removeDisconnectedDevice can synchronously recover a same-serial
             // Android emulator (reboot → re-add), which mints a fresh epoch. The
             // device is live again, so retiring here would delete that just-minted
             // epoch; skip the retire and let cleanup fail so the monitor retries.
             deviceCleanupSucceeded = false;
+          } else {
+            this.socketServer?.evictDeviceInputCache(deviceId);
           }
           if (deviceCleanupSucceeded) {
             this.confirmedDisconnectedDeviceIds.add(deviceId);
             this.deviceDisconnectMisses.delete(deviceId);
             this.deviceDisconnectMissIncarnations.delete(deviceId);
-            this.forceDisconnectedDeviceIds.delete(deviceId);
-            this.forceDisconnectedDeviceGenerations.delete(deviceId);
+            if (this.forceDisconnectedDeviceGenerations.get(deviceId) === forceGenerationAtDisconnect) {
+              this.forceDisconnectedDeviceIds.delete(deviceId);
+              this.forceDisconnectedDeviceGenerations.delete(deviceId);
+            }
           }
         }
       } catch (error) {
@@ -1453,9 +1513,45 @@ export class Daemon {
     this.deviceDisconnectMonitor.start();
   }
 
+  private async stopRecordingAfterDeviceDisconnect(recordingId: string, deviceId: string): Promise<boolean> {
+    if (this.stoppingRecordings.has(recordingId)) {
+      return false;
+    }
+    this.stoppingRecordings.add(recordingId);
+    try {
+      await stopVideoRecording(recordingId);
+      logger.warn(`[Daemon] Stopped recording ${recordingId} after device ${deviceId} disconnected`);
+      return true;
+    } catch (error) {
+      logger.warn(
+        `[Daemon] Failed to stop recording ${recordingId} after device ${deviceId} disconnected: ${error}`,
+      );
+      return await this.interruptRecordingAfterDeviceDisconnect(recordingId, deviceId);
+    } finally {
+      this.stoppingRecordings.delete(recordingId);
+    }
+  }
+
+  private async interruptRecordingAfterDeviceDisconnect(
+    recordingId: string,
+    deviceId: string,
+  ): Promise<boolean> {
+    try {
+      await interruptVideoRecording(recordingId);
+      logger.warn(`[Daemon] Marked recording ${recordingId} interrupted after device ${deviceId} disconnected`);
+      return true;
+    } catch (error) {
+      logger.warn(
+        `[Daemon] Failed to mark recording ${recordingId} interrupted after device ${deviceId} disconnected: ${error}`,
+      );
+      return false;
+    }
+  }
+
   private async shouldSkipStaleDisconnectCleanup(
     pooledDeviceAtDisconnect: PooledDevice | null,
-    deviceId: string
+    deviceId: string,
+    forceGenerationAtDisconnect: number | undefined = this.forceDisconnectedDeviceGenerations.get(deviceId),
   ): Promise<boolean> {
     if (!pooledDeviceAtDisconnect) {
       if (!this.devicePool.getDevice(deviceId)) {
@@ -1464,14 +1560,15 @@ export class Daemon {
       this.deviceDisconnectMisses.delete(deviceId);
       this.deviceDisconnectMissIncarnations.delete(deviceId);
       this.confirmedDisconnectedDeviceIds.delete(deviceId);
-      this.forceDisconnectedDeviceIds.delete(deviceId);
-      this.forceDisconnectedDeviceGenerations.delete(deviceId);
+      if (this.forceDisconnectedDeviceGenerations.get(deviceId) === forceGenerationAtDisconnect) {
+        this.forceDisconnectedDeviceIds.delete(deviceId);
+        this.forceDisconnectedDeviceGenerations.delete(deviceId);
+      }
       logger.info(
         `[DisconnectMonitor] Skipping stale disconnect cleanup for recovered device ${deviceId}`
       );
       return true;
     }
-    const forceGenerationAtVerificationStart = this.forceDisconnectedDeviceGenerations.get(deviceId);
     const disconnectStatus = await this.devicePool.isCurrentDisconnectedDevice(pooledDeviceAtDisconnect);
     if (disconnectStatus === "current") {
       return false;
@@ -1485,7 +1582,7 @@ export class Daemon {
     this.deviceDisconnectMisses.delete(deviceId);
     this.deviceDisconnectMissIncarnations.delete(deviceId);
     this.confirmedDisconnectedDeviceIds.delete(deviceId);
-    if (this.forceDisconnectedDeviceGenerations.get(deviceId) === forceGenerationAtVerificationStart) {
+    if (this.forceDisconnectedDeviceGenerations.get(deviceId) === forceGenerationAtDisconnect) {
       this.forceDisconnectedDeviceIds.delete(deviceId);
       this.forceDisconnectedDeviceGenerations.delete(deviceId);
     }
@@ -1493,6 +1590,33 @@ export class Daemon {
       `[DisconnectMonitor] Skipping stale disconnect cleanup for recovered device ${deviceId}`
     );
     return true;
+  }
+
+  private isCapturedDisconnectTargetCurrent(
+    deviceId: string,
+    pooledDeviceAtDisconnect: PooledDevice | null,
+    assignmentCountAtDisconnect: number | undefined,
+    sessionIdAtDisconnect?: string | null,
+    sessionAtDisconnect?: Session | null,
+  ): boolean {
+    if (pooledDeviceAtDisconnect) {
+      if (
+        this.devicePool.getDevice(deviceId) !== pooledDeviceAtDisconnect ||
+        pooledDeviceAtDisconnect.assignmentCount !== assignmentCountAtDisconnect
+      ) {
+        return false;
+      }
+    } else if (this.devicePool.getDevice(deviceId)) {
+      return false;
+    }
+
+    if (!sessionIdAtDisconnect) {
+      return this.sessionManager.getSessionForDevice(deviceId) === null;
+    }
+    return (
+      this.sessionManager.getSessionForDevice(deviceId) === sessionIdAtDisconnect &&
+      this.sessionManager.getSession(sessionIdAtDisconnect) === sessionAtDisconnect
+    );
   }
 
   private startAdbMissingDeviceListener(): void {
@@ -1518,9 +1642,17 @@ export class Daemon {
     sessionId: string,
     releaseReason: string = "explicit-release",
     allowExpired: boolean = false,
+    expectedSession?: Session,
   ): Promise<void> {
     const cancelled = await executionTracker.cancelSessionUuidExecutions(sessionId, releaseReason);
-    const deviceId = await this.sessionManager.releaseSession(sessionId, releaseReason, allowExpired);
+    const deviceId = expectedSession
+      ? await this.sessionManager.releaseSessionIfOwned(
+        sessionId,
+        expectedSession,
+        expectedSession.assignedDevice,
+        releaseReason,
+      )
+      : await this.sessionManager.releaseSession(sessionId, releaseReason, allowExpired);
     if (deviceId) {
       await this.devicePool.releaseDevice(deviceId, sessionId);
     }
@@ -1573,6 +1705,9 @@ export class Daemon {
         logger.info("Restarting observation stream socket server...");
         try {
           await this.observationStreamHealth.recover();
+          // DefaultObservationStreamHealth recreates the device-data singleton.
+          // Reinstall the resolver and lifecycle bridge on that replacement.
+          this.setupDeviceSessionRouting();
           logger.info("Observation stream socket server restarted successfully");
         } catch (error) {
           logger.error(`Failed to restart observation stream socket server: ${error}`);

--- a/src/daemon/daemon.ts
+++ b/src/daemon/daemon.ts
@@ -235,6 +235,7 @@ export class Daemon {
       (sessionId, query) => this.hasActiveSessionExecution(sessionId, query),
     );
     this.sessionManager.onSessionCreated((session) => {
+      NavigationGraphManager.clearReleasedSession(session.sessionId);
       this.setupNavigationGraphUpdateListener(
         NavigationGraphManager.getInstanceForSession(session.sessionId),
       );
@@ -1706,8 +1707,9 @@ export class Daemon {
         try {
           await this.observationStreamHealth.recover();
           // DefaultObservationStreamHealth recreates the device-data singleton.
-          // Reinstall the resolver and lifecycle bridge on that replacement.
-          this.setupDeviceSessionRouting();
+          // Reinstall routing, lifecycle delivery, cadence, observation, and
+          // navigation callbacks on that replacement.
+          this.configureDeviceDataStreamServer();
           logger.info("Observation stream socket server restarted successfully");
         } catch (error) {
           logger.error(`Failed to restart observation stream socket server: ${error}`);

--- a/src/daemon/daemonMcpProxy.ts
+++ b/src/daemon/daemonMcpProxy.ts
@@ -554,7 +554,10 @@ export class DaemonMcpProxy {
     }
     // Check if daemon is available
     const socketPath = this.config.socketPath ?? SOCKET_PATH;
-    const isAvailable = await DaemonClient.isAvailable(socketPath);
+    // This is an observation-only probe. A daemon from another checkout may own
+    // this namespace's socket without its PID record; cleaning the path before
+    // DaemonManager can verify that candidate would sever a live daemon.
+    const isAvailable = await DaemonClient.isAvailable(socketPath, { skipStaleCleanup: true });
 
     if (!isAvailable) {
       if (!this.config.autoStartDaemon) {

--- a/src/daemon/deviceDataStreamSocketServer.ts
+++ b/src/daemon/deviceDataStreamSocketServer.ts
@@ -691,7 +691,9 @@ export class DeviceDataStreamSocketServer extends PushSubscriptionSocketServer<
    * a non-null UUID with a null `deviceId` schedules none.
    */
   private subscriberWantsDevice(filter: DeviceDataFilter, deviceId: string): boolean {
-    return filter.deviceSessionUuid === null || filter.deviceId === deviceId;
+    return filter.deviceSessionUuid === null ||
+      (filter.deviceId === deviceId &&
+        this.deviceSessionResolver.resolveUuid(deviceId) === filter.deviceSessionUuid);
   }
 
   /**
@@ -880,6 +882,21 @@ export class DeviceDataStreamSocketServer extends PushSubscriptionSocketServer<
         return;
       }
 
+      const subscribedDeviceId =
+        deviceSessionUuid === null
+          ? null
+          : this.deviceSessionResolver.resolveDeviceId(deviceSessionUuid);
+      if (deviceSessionUuid !== null && subscribedDeviceId === null) {
+        const errorResponse: SubscriptionResponse = {
+          id: request.id,
+          type: "error",
+          success: false,
+          error: `deviceSessionUuid '${deviceSessionUuid}' does not identify a live device session`,
+        };
+        this.sendJson(socket, errorResponse);
+        return;
+      }
+
       // Let base class handle the subscription
       await super.processLine(socket, line);
 
@@ -887,11 +904,6 @@ export class DeviceDataStreamSocketServer extends PushSubscriptionSocketServer<
       // serial-scoped, so resolve to the current serial. A missing UUID is an
       // intentional all-device subscription; an unresolvable UUID schedules no
       // device and must not be treated as that all-device case.
-      const subscribedDeviceId =
-        deviceSessionUuid === null
-          ? null
-          : this.deviceSessionResolver.resolveDeviceId(deviceSessionUuid);
-
       if (deviceSessionUuid === null || subscribedDeviceId !== null) {
         this.notifyScreenshotCadenceChanged(subscribedDeviceId);
         this.notifyHierarchyCadenceChanged(subscribedDeviceId);
@@ -1031,6 +1043,9 @@ export class DeviceDataStreamSocketServer extends PushSubscriptionSocketServer<
     }
     if (typeof value !== "string") {
       throw new Error("deviceSessionUuid must be a string or null");
+    }
+    if (value.trim().length === 0) {
+      throw new Error("deviceSessionUuid must not be blank");
     }
     return value;
   }

--- a/src/daemon/deviceDataStreamSocketServer.ts
+++ b/src/daemon/deviceDataStreamSocketServer.ts
@@ -229,7 +229,12 @@ interface PushScreenshotOptions {
  */
 interface DeviceDataFilter {
   deviceSessionUuid: string | null; // null means subscribe to all devices
-  deviceId: string | null; // serial resolved from deviceSessionUuid, for cadence only
+  /**
+   * Serial resolved from deviceSessionUuid, for cadence only. A non-null UUID
+   * that cannot be resolved remains null: it is a no-device subscription, not
+   * an all-devices subscription.
+   */
+  deviceId: string | null;
   screenshotIntervalMs: number | null;
   hierarchyIntervalMs: number | null;
 }
@@ -682,10 +687,11 @@ export class DeviceDataStreamSocketServer extends PushSubscriptionSocketServer<
    * the POLLING question (which serial to poll, how fast), kept separate from frame
    * routing (`matchesFilter`, on `deviceSessionUuid`): the cadence machinery is
    * inherently serial-addressed, and `filter.deviceId` is the serial resolved for
-   * exactly this purpose. `null` = an all-devices subscription.
+   * exactly this purpose. Only a `null` `deviceSessionUuid` means all devices;
+   * a non-null UUID with a null `deviceId` schedules none.
    */
   private subscriberWantsDevice(filter: DeviceDataFilter, deviceId: string): boolean {
-    return filter.deviceId === null || filter.deviceId === deviceId;
+    return filter.deviceSessionUuid === null || filter.deviceId === deviceId;
   }
 
   /**
@@ -828,7 +834,7 @@ export class DeviceDataStreamSocketServer extends PushSubscriptionSocketServer<
             type: "navigation_update",
             deviceSessionUuid,
             deviceId: deviceSessionUuid
-              ? this.deviceSessionResolver.resolveDeviceId(deviceSessionUuid) ?? undefined
+              ? (this.deviceSessionResolver.resolveDeviceId(deviceSessionUuid) ?? undefined)
               : undefined,
             timestamp: this.timer.now(),
             navigationGraph: graphData,
@@ -857,20 +863,45 @@ export class DeviceDataStreamSocketServer extends PushSubscriptionSocketServer<
 
     // Handle subscribe with onSubscriberConnected callback
     if (request.command === "subscribe") {
+      let deviceSessionUuid: string | null;
+      try {
+        // JSON parsing does not validate fields at runtime. Do it before the
+        // base server creates a subscription so malformed keys cannot quietly
+        // become all-device subscriptions.
+        deviceSessionUuid = this.parseDeviceSessionUuid(request.deviceSessionUuid);
+      } catch (error) {
+        const errorResponse: SubscriptionResponse = {
+          id: request.id,
+          type: "error",
+          success: false,
+          error: error instanceof Error ? error.message : String(error),
+        };
+        this.sendJson(socket, errorResponse);
+        return;
+      }
+
       // Let base class handle the subscription
       await super.processLine(socket, line);
 
       // The wire now targets a deviceSessionUuid; the cadence/connect machinery is
-      // serial-scoped, so resolve to the current serial (null = all devices).
-      const subscribedDeviceId = request.deviceSessionUuid
-        ? this.deviceSessionResolver.resolveDeviceId(request.deviceSessionUuid)
-        : null;
+      // serial-scoped, so resolve to the current serial. A missing UUID is an
+      // intentional all-device subscription; an unresolvable UUID schedules no
+      // device and must not be treated as that all-device case.
+      const subscribedDeviceId =
+        deviceSessionUuid === null
+          ? null
+          : this.deviceSessionResolver.resolveDeviceId(deviceSessionUuid);
 
-      this.notifyScreenshotCadenceChanged(subscribedDeviceId);
-      this.notifyHierarchyCadenceChanged(subscribedDeviceId);
+      if (deviceSessionUuid === null || subscribedDeviceId !== null) {
+        this.notifyScreenshotCadenceChanged(subscribedDeviceId);
+        this.notifyHierarchyCadenceChanged(subscribedDeviceId);
+      }
 
       // Trigger the callback if set
-      if (this.onSubscriberConnected) {
+      if (
+        this.onSubscriberConnected &&
+        (deviceSessionUuid === null || subscribedDeviceId !== null)
+      ) {
         try {
           this.onSubscriberConnected(subscribedDeviceId);
         } catch (error) {
@@ -886,8 +917,7 @@ export class DeviceDataStreamSocketServer extends PushSubscriptionSocketServer<
         : undefined;
       await super.processLine(socket, line);
       if (filter) {
-        this.notifyScreenshotCadenceChanged(filter.deviceId);
-        this.notifyHierarchyCadenceChanged(filter.deviceId);
+        this.notifyCadenceChangedForFilter(filter);
       }
       return;
     }
@@ -911,8 +941,7 @@ export class DeviceDataStreamSocketServer extends PushSubscriptionSocketServer<
       };
       this.sendJson(socket, response);
       if (filter) {
-        this.notifyScreenshotCadenceChanged(filter.deviceId);
-        this.notifyHierarchyCadenceChanged(filter.deviceId);
+        this.notifyCadenceChangedForFilter(filter);
       }
       return;
     }
@@ -924,32 +953,36 @@ export class DeviceDataStreamSocketServer extends PushSubscriptionSocketServer<
   protected onConnectionClose(socket: Socket): void {
     const filters = this.getSubscribersForSocket(socket).map((subscriber) => subscriber.filter);
     super.onConnectionClose(socket);
-    for (const deviceId of new Set(filters.map((filter) => filter.deviceId))) {
-      this.notifyScreenshotCadenceChanged(deviceId);
-      this.notifyHierarchyCadenceChanged(deviceId);
+    for (const filter of filters) {
+      this.notifyCadenceChangedForFilter(filter);
     }
   }
 
   protected onConnectionError(socket: Socket, error: Error): void {
     const filters = this.getSubscribersForSocket(socket).map((subscriber) => subscriber.filter);
     super.onConnectionError(socket, error);
-    for (const deviceId of new Set(filters.map((filter) => filter.deviceId))) {
-      this.notifyScreenshotCadenceChanged(deviceId);
-      this.notifyHierarchyCadenceChanged(deviceId);
+    for (const filter of filters) {
+      this.notifyCadenceChangedForFilter(filter);
     }
   }
 
   protected checkKeepalive(): void {
-    const subscriberCountBefore = this.subscribers.size;
+    const filtersBySubscriptionId = new Map(
+      [...this.subscribers].map(([subscriptionId, subscriber]) => [
+        subscriptionId,
+        subscriber.filter,
+      ]),
+    );
     super.checkKeepalive();
-    if (this.subscribers.size !== subscriberCountBefore) {
-      this.notifyScreenshotCadenceChanged(null);
-      this.notifyHierarchyCadenceChanged(null);
+    for (const [subscriptionId, filter] of filtersBySubscriptionId) {
+      if (!this.subscribers.has(subscriptionId)) {
+        this.notifyCadenceChangedForFilter(filter);
+      }
     }
   }
 
   protected parseSubscriptionFilter(request: Record<string, unknown>): DeviceDataFilter {
-    const deviceSessionUuid = (request.deviceSessionUuid as string) ?? null;
+    const deviceSessionUuid = this.parseDeviceSessionUuid(request.deviceSessionUuid);
     return {
       deviceSessionUuid,
       // Resolve the serial once, at subscribe time, for the serial-scoped cadence
@@ -969,7 +1002,7 @@ export class DeviceDataStreamSocketServer extends PushSubscriptionSocketServer<
     // into another device's subscription (epic #5256, AC2/AC4; closes #4837).
     return (
       filter.deviceSessionUuid === null ||
-      filter.deviceSessionUuid === data.targetDeviceSessionUuid
+      (filter.deviceId !== null && filter.deviceSessionUuid === data.targetDeviceSessionUuid)
     );
   }
 
@@ -990,6 +1023,16 @@ export class DeviceDataStreamSocketServer extends PushSubscriptionSocketServer<
 
   private parseHierarchyIntervalMs(value: unknown): number | null {
     return this.parseClampedIntervalMs(value, MIN_HIERARCHY_INTERVAL_MS, MAX_HIERARCHY_INTERVAL_MS);
+  }
+
+  private parseDeviceSessionUuid(value: unknown): string | null {
+    if (value === undefined || value === null) {
+      return null;
+    }
+    if (typeof value !== "string") {
+      throw new Error("deviceSessionUuid must be a string or null");
+    }
+    return value;
   }
 
   private parseClampedIntervalMs(
@@ -1022,6 +1065,14 @@ export class DeviceDataStreamSocketServer extends PushSubscriptionSocketServer<
       "onHierarchyCadenceChanged",
       deviceId,
     );
+  }
+
+  private notifyCadenceChangedForFilter(filter: DeviceDataFilter): void {
+    if (filter.deviceSessionUuid !== null && filter.deviceId === null) {
+      return;
+    }
+    this.notifyScreenshotCadenceChanged(filter.deviceId);
+    this.notifyHierarchyCadenceChanged(filter.deviceId);
   }
 
   private notifyCadenceChanged(

--- a/src/daemon/devicePool.ts
+++ b/src/daemon/devicePool.ts
@@ -279,7 +279,7 @@ export class DevicePool {
   /** Releases waiting for late session teardown, bound to one pooled incarnation. */
   private readonly deferredDeviceReleases: Map<
     string,
-    { device: PooledDevice; sessionId: string; cleanup: Promise<void> }
+    { device: PooledDevice; sessionId: string; assignmentCount: number; cleanup: Promise<void> }
   > = new Map();
   private deviceIncarnationCounter = 0;
 
@@ -638,9 +638,17 @@ export class DevicePool {
   /**
    * Remove device from pool
    */
-  async removeDevice(deviceId: string, awaitCacheCleanup: boolean = true): Promise<void> {
+  async removeDevice(
+    deviceId: string,
+    awaitCacheCleanup: boolean = true,
+    expectedDevice?: PooledDevice,
+  ): Promise<void> {
     const device = this.devices.get(deviceId);
     if (!device) {
+      return;
+    }
+    if (expectedDevice && device !== expectedDevice) {
+      logger.debug(`Ignoring stale removal for replacement device ${deviceId}`);
       return;
     }
 
@@ -716,7 +724,7 @@ export class DevicePool {
       return true;
     }
     this.intentionalShutdowns.delete(deviceId);
-    await this.removeDevice(deviceId);
+    await this.removeDevice(deviceId, true, device);
     return true;
   }
 
@@ -738,19 +746,30 @@ export class DevicePool {
     deviceId: string,
     mayBeStaleSignal: boolean = true,
     incidentId?: string,
+    expectedDevice?: PooledDevice,
   ): Promise<void> {
     const device = this.devices.get(deviceId);
+    if (!this.matchesExpectedDisconnectedDevice(device, expectedDevice)) {
+      return;
+    }
     if (await this.shouldDeferDisconnectCleanup(deviceId, device, mayBeStaleSignal)) {
       return;
     }
-    if (!device || device.sessionId) {
-      await this.removeDevice(deviceId);
+    if (!this.matchesExpectedDisconnectedDevice(this.devices.get(deviceId), expectedDevice)) {
+      return;
+    }
+    if (!device) {
+      await this.removeDevice(deviceId, true, device);
+      return;
+    }
+    if (device.sessionId) {
+      await this.removeDevice(deviceId, true, device);
       return;
     }
     const rediscovery = mayBeStaleSignal
       ? await this.wasRebootedAndroidDeviceRediscovered(device)
       : "not-rediscovered";
-    if (this.devices.get(deviceId) !== device || rediscovery !== "not-rediscovered") {
+    if (!this.canContinueDisconnectCleanup(device, rediscovery)) {
       return;
     }
     const recordedIncidentId = incidentId ?? await this.recordEmulatorLossIncident(
@@ -763,13 +782,31 @@ export class DevicePool {
     if (await this.rebootDisconnectedAndroidDevice(device, recordedIncidentId)) {
       return;
     }
-    const current = this.devices.get(deviceId);
-    if (current && current !== device) {
+    if (this.hasReplacementDisconnectedDevice(device)) {
       return;
     }
     this.suppressAutoStartForDevice(device);
     await this.completeRecoveryIfNotAttempted(recordedIncidentId, recoveryWasAttempted);
-    await this.removeDevice(deviceId);
+    await this.removeDevice(deviceId, true, device);
+  }
+
+  private matchesExpectedDisconnectedDevice(
+    device: PooledDevice | undefined,
+    expectedDevice: PooledDevice | undefined,
+  ): boolean {
+    return expectedDevice === undefined || device === expectedDevice;
+  }
+
+  private canContinueDisconnectCleanup(
+    device: PooledDevice,
+    rediscovery: "rediscovered" | "not-rediscovered" | "unknown",
+  ): boolean {
+    return this.devices.get(device.id) === device && rediscovery === "not-rediscovered";
+  }
+
+  private hasReplacementDisconnectedDevice(device: PooledDevice): boolean {
+    const current = this.devices.get(device.id);
+    return current !== undefined && current !== device;
   }
 
   /**
@@ -1740,7 +1777,7 @@ export class DevicePool {
       return;
     }
     await this.completeEmulatorLossRecovery(correlatedIncidentId, "not-attempted");
-    await this.removeDevice(device.id);
+    await this.removeDevice(device.id, true, device);
   }
 
   private shouldRebootDisconnectedAndroidDevice(
@@ -2649,44 +2686,49 @@ export class DevicePool {
       logger.warn(`Cannot release device ${deviceId}: not in pool`);
       return;
     }
+    await this.releaseCapturedDevice(device, expectedSessionId, device.assignmentCount);
+  }
 
-    if (expectedSessionId !== undefined && device.sessionId !== expectedSessionId) {
-      logger.warn(
-        `Cannot release device ${deviceId}: expected session ${expectedSessionId}, ` +
-          `but it is owned by ${device.sessionId ?? "no session"}`,
-      );
-      return;
-    }
-
-    if (!device.sessionId) {
-      logger.debug(`Device ${deviceId} is already idle`);
-      return;
-    }
-
-    if (device.sessionId !== expectedSessionId) {
-      logger.debug(
-        `Ignoring stale release for device ${deviceId}: expected ${expectedSessionId}, owned by ${device.sessionId}`,
-      );
+  private async releaseCapturedDevice(
+    device: PooledDevice,
+    expectedSessionId: string,
+    expectedAssignmentCount: number,
+  ): Promise<void> {
+    const deviceId = device.id;
+    if (!this.isCapturedReleaseCurrent(device, expectedSessionId, expectedAssignmentCount)) {
       return;
     }
 
     const existingDeferredRelease = this.deferredDeviceReleases.get(deviceId);
     if (existingDeferredRelease) {
-      return;
+      if (
+        existingDeferredRelease.device === device &&
+        existingDeferredRelease.sessionId === expectedSessionId &&
+        existingDeferredRelease.assignmentCount === expectedAssignmentCount
+      ) {
+        return;
+      }
+      this.deferredDeviceReleases.delete(deviceId);
     }
     const cleanup = this.sessionManager.getPendingDeviceCleanup(deviceId);
     if (cleanup) {
-      const deferredRelease = { device, sessionId: expectedSessionId, cleanup };
+      const deferredRelease = {
+        device,
+        sessionId: expectedSessionId,
+        assignmentCount: expectedAssignmentCount,
+        cleanup,
+      };
       this.deferredDeviceReleases.set(deviceId, deferredRelease);
       void cleanup.then(() => {
         if (
           this.deferredDeviceReleases.get(deviceId) !== deferredRelease ||
-          this.devices.get(deviceId) !== device
+          this.devices.get(deviceId) !== device ||
+          device.assignmentCount !== expectedAssignmentCount
         ) {
           return;
         }
         this.deferredDeviceReleases.delete(deviceId);
-        return this.releaseDevice(deviceId, expectedSessionId);
+        return this.releaseCapturedDevice(device, expectedSessionId, expectedAssignmentCount);
       }).catch(error => logger.warn(`Failed to release device ${deviceId} after late session teardown: ${error}`));
       logger.info(`Keeping device ${deviceId} assigned until late session teardown completes`);
       return;
@@ -2699,6 +2741,42 @@ export class DevicePool {
     this.lastReleasedDeviceId = deviceId;
 
     logger.info(`Released device ${deviceId} from session ${sessionId}`);
+  }
+
+  private isCapturedReleaseCurrent(
+    device: PooledDevice,
+    expectedSessionId: string,
+    expectedAssignmentCount: number,
+  ): boolean {
+    const deviceId = device.id;
+    if (this.devices.get(deviceId) !== device) {
+      logger.debug(`Ignoring stale release for replacement device ${deviceId}`);
+      return false;
+    }
+    if (device.assignmentCount !== expectedAssignmentCount) {
+      logger.debug(`Ignoring stale release for reassigned device ${deviceId}`);
+      return false;
+    }
+    if (expectedSessionId !== undefined && device.sessionId !== expectedSessionId) {
+      logger.warn(
+        `Cannot release device ${deviceId}: expected session ${expectedSessionId}, ` +
+          `but it is owned by ${device.sessionId ?? "no session"}`,
+      );
+      return false;
+    }
+
+    if (!device.sessionId) {
+      logger.debug(`Device ${deviceId} is already idle`);
+      return false;
+    }
+
+    if (device.sessionId !== expectedSessionId) {
+      logger.debug(
+        `Ignoring stale release for device ${deviceId}: expected ${expectedSessionId}, owned by ${device.sessionId}`,
+      );
+      return false;
+    }
+    return true;
   }
 
   /**
@@ -3311,26 +3389,37 @@ export class DevicePool {
       return;
     }
 
+    const assignmentCount = device.assignmentCount;
     const cleanup = this.sessionManager.getPendingDeviceCleanup(deviceId);
-    const release = this.releaseDevice(deviceId, sessionId);
+    const release = this.releaseCapturedDevice(device, sessionId, assignmentCount);
     void release.then(() => {
       if (!cleanup) {
-        this.clearExpiredAutolockStateWhenIdle(sessionId, deviceId);
+        this.clearExpiredAutolockStateWhenIdle(sessionId, device, assignmentCount);
       }
       logger.info(`Released device ${deviceId} from session ${sessionId}`);
     });
     if (cleanup) {
-      void cleanup.then(() => this.clearExpiredAutolockStateWhenIdle(sessionId, deviceId));
+      void cleanup.then(() =>
+        this.clearExpiredAutolockStateWhenIdle(sessionId, device, assignmentCount),
+      );
     }
   }
 
-  private clearExpiredAutolockStateWhenIdle(sessionId: string, deviceId: string): void {
-    const device = this.devices.get(deviceId);
-    if (!device || device.sessionId !== null || device.autolockSessionId !== sessionId) {
+  private clearExpiredAutolockStateWhenIdle(
+    sessionId: string,
+    expectedDevice: PooledDevice,
+    expectedAssignmentCount: number,
+  ): void {
+    if (
+      this.devices.get(expectedDevice.id) !== expectedDevice ||
+      expectedDevice.assignmentCount !== expectedAssignmentCount ||
+      expectedDevice.sessionId !== null ||
+      expectedDevice.autolockSessionId !== sessionId
+    ) {
       return;
     }
 
-    device.autolockSessionId = undefined;
+    expectedDevice.autolockSessionId = undefined;
     this.clearMcpAutolockMappings(sessionId);
   }
 

--- a/src/daemon/devicePool.ts
+++ b/src/daemon/devicePool.ts
@@ -281,6 +281,15 @@ export class DevicePool {
     string,
     { device: PooledDevice; sessionId: string; assignmentCount: number; cleanup: Promise<void> }
   > = new Map();
+  /**
+   * Explicit session-release callbacks run before terminal persistence awaits.
+   * Capture ownership there so the later caller-ordered pool release cannot
+   * snapshot and free a same-UUID replacement assignment.
+   */
+  private readonly releasedDeviceCaptures: Map<
+    string,
+    { device: PooledDevice; deviceId: string; assignmentCount: number }
+  > = new Map();
   private deviceIncarnationCounter = 0;
 
   // Max consecutive errors before marking device as failed
@@ -336,6 +345,7 @@ export class DevicePool {
       if (releaseReason === "lazy-expiry" || releaseReason === "cleanup-expired") {
         this.releaseExpiredSessionDevice(sessionId, deviceId);
       } else {
+        this.captureReleasedDevice(sessionId, deviceId);
         this.clearReleasedAutolockState(sessionId, deviceId);
       }
     });
@@ -759,7 +769,6 @@ export class DevicePool {
       return;
     }
     if (!device) {
-      await this.removeDevice(deviceId, true, device);
       return;
     }
     if (device.sessionId) {
@@ -2681,12 +2690,35 @@ export class DevicePool {
    * Frees the device so it can be assigned to other sessions.
    */
   async releaseDevice(deviceId: string, expectedSessionId: string): Promise<void> {
+    const releasedCapture = this.releasedDeviceCaptures.get(expectedSessionId);
+    if (releasedCapture?.deviceId === deviceId) {
+      this.releasedDeviceCaptures.delete(expectedSessionId);
+      await this.releaseCapturedDevice(
+        releasedCapture.device,
+        expectedSessionId,
+        releasedCapture.assignmentCount,
+      );
+      return;
+    }
+
     const device = this.devices.get(deviceId);
     if (!device) {
       logger.warn(`Cannot release device ${deviceId}: not in pool`);
       return;
     }
     await this.releaseCapturedDevice(device, expectedSessionId, device.assignmentCount);
+  }
+
+  private captureReleasedDevice(sessionId: string, deviceId: string): void {
+    const device = this.devices.get(deviceId);
+    if (!device || device.sessionId !== sessionId) {
+      return;
+    }
+    this.releasedDeviceCaptures.set(sessionId, {
+      device,
+      deviceId,
+      assignmentCount: device.assignmentCount,
+    });
   }
 
   private async releaseCapturedDevice(
@@ -3392,16 +3424,24 @@ export class DevicePool {
     const assignmentCount = device.assignmentCount;
     const cleanup = this.sessionManager.getPendingDeviceCleanup(deviceId);
     const release = this.releaseCapturedDevice(device, sessionId, assignmentCount);
-    void release.then(() => {
-      if (!cleanup) {
-        this.clearExpiredAutolockStateWhenIdle(sessionId, device, assignmentCount);
-      }
-      logger.info(`Released device ${deviceId} from session ${sessionId}`);
-    });
+    void release
+      .then(() => {
+        if (!cleanup) {
+          this.clearExpiredAutolockStateWhenIdle(sessionId, device, assignmentCount);
+        }
+        logger.info(`Released device ${deviceId} from session ${sessionId}`);
+      })
+      .catch(error => {
+        logger.warn(`Failed to release expired-session device ${deviceId}: ${error}`, error);
+      });
     if (cleanup) {
-      void cleanup.then(() =>
-        this.clearExpiredAutolockStateWhenIdle(sessionId, device, assignmentCount),
-      );
+      void cleanup
+        .then(() =>
+          this.clearExpiredAutolockStateWhenIdle(sessionId, device, assignmentCount),
+        )
+        .catch(error => {
+          logger.warn(`Failed to finish expired-session cleanup for ${deviceId}: ${error}`, error);
+        });
     }
   }
 

--- a/src/daemon/manager.ts
+++ b/src/daemon/manager.ts
@@ -104,19 +104,28 @@ function normalizeProcessCommand(command: string): string {
   return command.replace(/\\/g, "/").replace(/\/+/g, "/");
 }
 
+function invokedCommand(command: string): string {
+  const shellInvocation = command.trim().match(
+    /(?:^|\s)(?:-c|\/c|-(?:command|encodedcommand|c|ec))\s+["']?(.+)$/i,
+  );
+  return shellInvocation?.[1].trim() ?? command.trim();
+}
+
 function isAutoMobileDaemonCommand(command: string): boolean {
   const normalizedCommand = normalizeProcessCommand(command);
-  if (!/(?:^|\s)--daemon-mode(?:\s|["']|$)/.test(normalizedCommand)) {
+  const invocation = invokedCommand(normalizedCommand);
+  if (!/(?:^|\s)--daemon-mode(?:\s|["']|$)/.test(invocation)) {
     return false;
   }
 
   const runsBundledEntrypoint =
-    /(?:^|["'\s\\/])(?:bun|node)(?:\.exe)?(?:\s|["'])/.test(normalizedCommand) &&
-    /(?:^|["'\s])[^"'\s]*dist\/src\/index\.js(?:\s|["']|$)/.test(normalizedCommand);
+    /(?:^|["'\s\\/])(?:bun|node)(?:\.exe)?(?:\s|["'])/.test(invocation) &&
+    /(?:^|["'\s])[^"'\s]*\/(?:@kaeawc\/)?auto-mobile\/dist\/src\/index\.js(?:\s|["']|$)/.test(invocation);
   const runsPublishedPackage =
-    /(?:^|["'\s])(bunx?|npx)(?:\.exe)?(?:\s+(?!--daemon-mode)[^"'\s]+)*\s+@kaeawc\/auto-mobile(?:@[^\s"']+)?(?:\s|["']|$)/.test(normalizedCommand);
+    /^(?:"?[^"'\s]*\/)?(?:bunx|npx)(?:\.exe)?\s+(?:(?:-y|--yes|--bun|--no-cache)\s+)*@kaeawc\/auto-mobile(?:@[^\s"']+)?(?:\s|["']|$)/.test(invocation) ||
+    /^(?:"?[^"'\s]*\/)?bun(?:\.exe)?\s+x\s+(?:(?:-y|--yes|--bun|--no-cache)\s+)*@kaeawc\/auto-mobile(?:@[^\s"']+)?(?:\s|["']|$)/.test(invocation);
   const runsStandaloneBinary =
-    /^(?:"?[^"'\s]*\/)?auto-mobile(?:\.exe)?(?:\s|$)/i.test(normalizedCommand);
+    /^(?:"?[^"'\s]*\/)?auto-mobile(?:\.exe)?(?:\s|$)/i.test(invocation);
 
   return runsBundledEntrypoint || runsPublishedPackage || runsStandaloneBinary;
 }

--- a/src/daemon/manager.ts
+++ b/src/daemon/manager.ts
@@ -207,6 +207,16 @@ export interface DaemonProcessLivenessChecker {
   isProcessRunning(pid: number): boolean;
 }
 
+export interface DaemonProcessSignaler {
+  signal(pid: number, signal: NodeJS.Signals): void;
+}
+
+const defaultDaemonProcessSignaler: DaemonProcessSignaler = {
+  signal(pid, signal): void {
+    process.kill(pid, signal);
+  },
+};
+
 export class PsDaemonProcessFinder implements DaemonProcessFinder, DaemonProcessLivenessChecker {
   constructor(private readonly runCommand: ProcessTableCommandRunner = execSync) {}
 
@@ -324,6 +334,7 @@ export class DaemonManager implements DaemonManagerLike {
   private readonly socketPath: string;
   private readonly processFinder: DaemonProcessFinder;
   private readonly processLivenessChecker: DaemonProcessLivenessChecker;
+  private readonly processSignaler: DaemonProcessSignaler;
   private readonly extractionCleaner: ExtractionCleaner;
   private readonly launcher: DaemonLauncher;
   private readonly fallbackLauncher: DaemonLauncher;
@@ -340,6 +351,7 @@ export class DaemonManager implements DaemonManagerLike {
     processSpawner: DaemonProcessSpawner | undefined = undefined,
     extractionCleaner: ExtractionCleaner = fileSystemExtractionCleaner,
     launcher: DaemonLauncher | (() => DaemonLaunchCommand) | undefined = undefined,
+    processSignaler: DaemonProcessSignaler = defaultDaemonProcessSignaler,
   ) {
     this.stateProvider = stateProvider;
     this.timer = timer;
@@ -357,6 +369,7 @@ export class DaemonManager implements DaemonManagerLike {
       this.processLivenessChecker = processFinder;
       processSpawner = processFinderOrSpawner;
     }
+    this.processSignaler = processSignaler;
     this.extractionCleaner = extractionCleaner;
     this.launchCommandResolver = typeof launcher === "function" ? launcher : undefined;
     this.launcher = (typeof launcher === "object" ? launcher : undefined) ?? new DaemonLauncher({
@@ -941,7 +954,7 @@ export class DaemonManager implements DaemonManagerLike {
     if (status.running) {
       await this.stop();
     } else {
-      await this.stopVerifiedUnrecordedDaemon();
+      await this.stopUnrecordedDaemonsForExplicitRestart();
     }
     // Wait a bit before starting
     await this.timer.sleep(1000);
@@ -949,54 +962,35 @@ export class DaemonManager implements DaemonManagerLike {
   }
 
   /**
-   * An explicit restart may be the only way to replace a daemon started from
-   * another checkout, whose PID file is outside this manager's namespace.
-   * Never infer that a process owns this socket from process-table output
-   * alone: first prove this namespace's socket is reachable, then re-check the
-   * candidate PID before signalling it. Ordinary `start` intentionally remains
-   * non-destructive.
+   * An explicit restart force-cleans live daemon-mode processes discovered from
+   * other PID-file namespaces. This intentionally does not require this
+   * manager's socket to be reachable: an orphaned daemon is precisely the
+   * failure mode that `--daemon restart` must recover from. Ordinary `start`
+   * remains non-destructive.
    */
-  private async stopVerifiedUnrecordedDaemon(): Promise<void> {
+  private async stopUnrecordedDaemonsForExplicitRestart(): Promise<void> {
     const candidates = this.findLiveDaemonProcesses();
     if (candidates.length === 0) {
       return;
     }
 
     stderrLog(
-      `Found ${candidates.length} live AutoMobile daemon candidate(s) without this namespace's PID record; verifying socket ownership before restart...`
+      `Explicit restart force-stopping ${candidates.length} live AutoMobile daemon candidate(s) without this namespace's PID record...`
     );
-    if (!(await this.waitForExistingDaemon(DAEMON_STARTUP_TIMEOUT_MS))) {
-      const stillLiveCandidates = candidates.filter(pid => this.isProcessRunning(pid));
-      if (stillLiveCandidates.length > 0) {
-        throw new ActionableError(
-          `Found live AutoMobile daemon candidate(s) (${stillLiveCandidates.join(", ")}) but this namespace's socket did not become reachable within ` +
-          `${DAEMON_STARTUP_TIMEOUT_MS}ms. Refusing to terminate an unverified daemon during restart.`
-        );
-      }
-      return;
+    for (const pid of candidates) {
+      await this.stopUnrecordedDaemonProcess(pid);
     }
-
-    // A candidate can exit while the connection probe is waiting or retrying.
-    // Do not signal a PID that has already gone away (and may have been reused).
-    const verifiedCandidates = candidates.filter(pid => this.isProcessRunning(pid));
-    if (verifiedCandidates.length === 0) {
-      stderrLog("Daemon candidate exited while its socket was being verified; starting a replacement.");
-      return;
-    }
-    if (verifiedCandidates.length > 1) {
-      throw new ActionableError(
-        `Found multiple live AutoMobile daemon candidates (${verifiedCandidates.join(", ")}); ` +
-        "cannot safely identify which one owns this namespace's socket. Stop the intended daemon explicitly before restarting."
-      );
-    }
-
-    await this.stopUnrecordedDaemonProcess(verifiedCandidates[0]);
   }
 
   private async stopUnrecordedDaemonProcess(pid: number): Promise<void> {
-    stderrLog(`Stopping verified daemon without this namespace's PID record (PID ${pid})...`);
+    if (!this.findLiveDaemonProcesses().includes(pid)) {
+      stderrLog(`Daemon candidate ${pid} exited before explicit restart could stop it.`);
+      return;
+    }
+
+    stderrLog(`Stopping daemon without this namespace's PID record (PID ${pid})...`);
     try {
-      process.kill(pid, "SIGTERM");
+      this.processSignaler.signal(pid, "SIGTERM");
     } catch (error) {
       if (this.isMissingProcessError(error)) {
         return;
@@ -1011,8 +1005,12 @@ export class DaemonManager implements DaemonManagerLike {
     }
 
     stderrLog(`Verified daemon ${pid} did not stop gracefully, sending SIGKILL...`);
+    if (!this.findLiveDaemonProcesses().includes(pid)) {
+      stderrLog(`Daemon candidate ${pid} exited before explicit restart could force-stop it.`);
+      return;
+    }
     try {
-      process.kill(pid, "SIGKILL");
+      this.processSignaler.signal(pid, "SIGKILL");
     } catch (error) {
       if (this.isMissingProcessError(error)) {
         return;

--- a/src/daemon/manager.ts
+++ b/src/daemon/manager.ts
@@ -932,15 +932,103 @@ export class DaemonManager implements DaemonManagerLike {
     // replace a stale checkout. Preserve the daemon's PID-recorded options so
     // that replacement cannot silently discard configuration such as debug,
     // output, or accessibility flags.
-    const runningOptions = (await this.status()).options ?? {};
+    const status = await this.status();
+    const runningOptions = status.options ?? {};
     const requestedOptions = Object.fromEntries(
       Object.entries(options).filter(([, value]) => value !== undefined)
     ) as DaemonOptions;
     const restartOptions: DaemonOptions = { ...runningOptions, ...requestedOptions };
-    await this.stop();
+    if (status.running) {
+      await this.stop();
+    } else {
+      await this.stopVerifiedUnrecordedDaemon();
+    }
     // Wait a bit before starting
     await this.timer.sleep(1000);
     await this.start(restartOptions);
+  }
+
+  /**
+   * An explicit restart may be the only way to replace a daemon started from
+   * another checkout, whose PID file is outside this manager's namespace.
+   * Never infer that a process owns this socket from process-table output
+   * alone: first prove this namespace's socket is reachable, then re-check the
+   * candidate PID before signalling it. Ordinary `start` intentionally remains
+   * non-destructive.
+   */
+  private async stopVerifiedUnrecordedDaemon(): Promise<void> {
+    const candidates = this.findLiveDaemonProcesses();
+    if (candidates.length === 0) {
+      return;
+    }
+
+    stderrLog(
+      `Found ${candidates.length} live AutoMobile daemon candidate(s) without this namespace's PID record; verifying socket ownership before restart...`
+    );
+    if (!(await this.waitForExistingDaemon(DAEMON_STARTUP_TIMEOUT_MS))) {
+      const stillLiveCandidates = candidates.filter(pid => this.isProcessRunning(pid));
+      if (stillLiveCandidates.length > 0) {
+        throw new ActionableError(
+          `Found live AutoMobile daemon candidate(s) (${stillLiveCandidates.join(", ")}) but this namespace's socket did not become reachable within ` +
+          `${DAEMON_STARTUP_TIMEOUT_MS}ms. Refusing to terminate an unverified daemon during restart.`
+        );
+      }
+      return;
+    }
+
+    // A candidate can exit while the connection probe is waiting or retrying.
+    // Do not signal a PID that has already gone away (and may have been reused).
+    const verifiedCandidates = candidates.filter(pid => this.isProcessRunning(pid));
+    if (verifiedCandidates.length === 0) {
+      stderrLog("Daemon candidate exited while its socket was being verified; starting a replacement.");
+      return;
+    }
+    if (verifiedCandidates.length > 1) {
+      throw new ActionableError(
+        `Found multiple live AutoMobile daemon candidates (${verifiedCandidates.join(", ")}); ` +
+        "cannot safely identify which one owns this namespace's socket. Stop the intended daemon explicitly before restarting."
+      );
+    }
+
+    await this.stopUnrecordedDaemonProcess(verifiedCandidates[0]);
+  }
+
+  private async stopUnrecordedDaemonProcess(pid: number): Promise<void> {
+    stderrLog(`Stopping verified daemon without this namespace's PID record (PID ${pid})...`);
+    try {
+      process.kill(pid, "SIGTERM");
+    } catch (error) {
+      if (this.isMissingProcessError(error)) {
+        return;
+      }
+      throw new ActionableError(
+        `Failed to stop verified daemon process ${pid}: ${this.describeError(error)}`
+      );
+    }
+
+    if (await this.waitForStop(pid, DAEMON_SHUTDOWN_TIMEOUT_MS)) {
+      return;
+    }
+
+    stderrLog(`Verified daemon ${pid} did not stop gracefully, sending SIGKILL...`);
+    try {
+      process.kill(pid, "SIGKILL");
+    } catch (error) {
+      if (this.isMissingProcessError(error)) {
+        return;
+      }
+      throw new ActionableError(
+        `Failed to force-stop verified daemon process ${pid}: ${this.describeError(error)}`
+      );
+    }
+
+    if (!(await this.waitForStop(pid, 1000))) {
+      throw new ActionableError(`Verified daemon process ${pid} did not exit after SIGKILL`);
+    }
+  }
+
+  private isMissingProcessError(error: unknown): boolean {
+    return error instanceof Error && error.message.includes("ESRCH");
   }
 
   /**
@@ -959,18 +1047,21 @@ export class DaemonManager implements DaemonManagerLike {
       pollCount++;
       if (existsSync(this.socketPath)) {
         socketObserved = true;
+        // A daemon started from another checkout can own this namespace's socket
+        // without writing this namespace's PID record. The socket connection is
+        // authoritative readiness in that case; status() cannot prove ownership.
+        if (await this.verifyDaemonConnection()) {
+          stderrLog(
+            `Daemon readiness probe succeeded after ${this.timer.now() - startTime}ms ` +
+            `(${pollCount} polls; socket observed)`
+          );
+          return true;
+        }
+        if (signal?.aborted) {
+          return false;
+        }
         const status = await this.status();
         if (status.running) {
-          if (await this.verifyDaemonConnection()) {
-            stderrLog(
-              `Daemon readiness probe succeeded after ${this.timer.now() - startTime}ms ` +
-              `(${pollCount} polls; socket observed)`
-            );
-            return true;
-          }
-          if (signal?.aborted) {
-            return false;
-          }
           await this.removeInvalidSocketPath();
         }
       }

--- a/src/daemon/manager.ts
+++ b/src/daemon/manager.ts
@@ -953,9 +953,8 @@ export class DaemonManager implements DaemonManagerLike {
     const restartOptions: DaemonOptions = { ...runningOptions, ...requestedOptions };
     if (status.running) {
       await this.stop();
-    } else {
-      await this.stopUnrecordedDaemonsForExplicitRestart();
     }
+    await this.stopUnrecordedDaemonsForExplicitRestart(status.pid);
     // Wait a bit before starting
     await this.timer.sleep(1000);
     await this.start(restartOptions);
@@ -968,8 +967,8 @@ export class DaemonManager implements DaemonManagerLike {
    * failure mode that `--daemon restart` must recover from. Ordinary `start`
    * remains non-destructive.
    */
-  private async stopUnrecordedDaemonsForExplicitRestart(): Promise<void> {
-    const candidates = this.findLiveDaemonProcesses();
+  private async stopUnrecordedDaemonsForExplicitRestart(recordedPid?: number): Promise<void> {
+    const candidates = this.findLiveDaemonProcesses().filter(pid => pid !== recordedPid);
     if (candidates.length === 0) {
       return;
     }

--- a/src/daemon/manager.ts
+++ b/src/daemon/manager.ts
@@ -106,8 +106,19 @@ function normalizeProcessCommand(command: string): string {
 
 function isAutoMobileDaemonCommand(command: string): boolean {
   const normalizedCommand = normalizeProcessCommand(command);
-  return normalizedCommand.includes("--daemon-mode") &&
-    (normalizedCommand.includes("auto-mobile") || normalizedCommand.includes("dist/src/index.js"));
+  if (!/(?:^|\s)--daemon-mode(?:\s|["']|$)/.test(normalizedCommand)) {
+    return false;
+  }
+
+  const runsBundledEntrypoint =
+    /(?:^|["'\s\\/])(?:bun|node)(?:\.exe)?(?:\s|["'])/.test(normalizedCommand) &&
+    /(?:^|["'\s])[^"'\s]*dist\/src\/index\.js(?:\s|["']|$)/.test(normalizedCommand);
+  const runsPublishedPackage =
+    /(?:^|["'\s])(bunx?|npx)(?:\.exe)?(?:\s+(?!--daemon-mode)[^"'\s]+)*\s+@kaeawc\/auto-mobile(?:@[^\s"']+)?(?:\s|["']|$)/.test(normalizedCommand);
+  const runsStandaloneBinary =
+    /^(?:"?[^"'\s]*\/)?auto-mobile(?:\.exe)?(?:\s|$)/i.test(normalizedCommand);
+
+  return runsBundledEntrypoint || runsPublishedPackage || runsStandaloneBinary;
 }
 
 function isShellCommandWrapper(command: string): boolean {

--- a/src/daemon/sessionManager.ts
+++ b/src/daemon/sessionManager.ts
@@ -377,6 +377,12 @@ export class SessionManager {
     platform?: Platform,
     execution?: SessionExecutionMetadata,
   ): Promise<Session> {
+    const pendingRebind = this.pendingSessionRebinds.get(sessionId);
+    if (pendingRebind) {
+      await pendingRebind.promise;
+      return await this.getOrCreateSession(sessionId, devicePool, platform, execution);
+    }
+
     const existing = this.getSessionForNewExecution(sessionId, execution);
     if (existing) {
       const inFlightRelease = this.releasePromises.get(sessionId);

--- a/src/daemon/sessionManager.ts
+++ b/src/daemon/sessionManager.ts
@@ -83,6 +83,7 @@ export interface Session {
  * while sharing centralized state in the daemon.
  */
 export type SessionReleaseCallback = (sessionId: string, deviceId: string, releaseReason: string) => void;
+export type SessionCreatedCallback = (session: Session) => void;
 export interface SessionExecutionMetadata {
   executionId: string;
   startTime: number;
@@ -139,6 +140,7 @@ export class SessionManager {
   private cleanupTimer: NodeJS.Timeout | null = null;
   private timer: Timer;
   private releaseCallbacks: SessionReleaseCallback[] = [];
+  private createdCallbacks: SessionCreatedCallback[] = [];
   private deviceUnboundCallbacks: SessionDeviceUnboundCallback[] = [];
   private readonly releasePromises: Map<
     string,
@@ -208,6 +210,13 @@ export class SessionManager {
    */
   onSessionRelease(callback: SessionReleaseCallback): void {
     this.releaseCallbacks.push(callback);
+  }
+
+  /**
+   * Register a callback invoked after a newly-created session is published.
+   */
+  onSessionCreated(callback: SessionCreatedCallback): void {
+    this.createdCallbacks.push(callback);
   }
 
   /** Return outstanding post-release device work, if the device must stay quarantined. */
@@ -290,6 +299,7 @@ export class SessionManager {
     this.sessions.set(session.sessionId, session);
     this.sessionDeviceMap.set(session.sessionId, session.assignedDevice);
     this.deviceSessionMap.set(session.assignedDevice, session.sessionId);
+    this.notifySessionCreated(session);
     logger.info(`Created session ${session.sessionId} with device ${session.assignedDevice}`);
     return session;
   }
@@ -485,12 +495,7 @@ export class SessionManager {
     assignedDevice: string,
     platform: Platform,
   ): Promise<Session> {
-    const replacement: Session = {
-      ...existing,
-      assignedDevice,
-      platform,
-      cacheData: {},
-    };
+    const replacement = this.createReboundSession(existing, assignedDevice, platform);
     await this.persistSession(replacement);
 
     try {
@@ -502,7 +507,10 @@ export class SessionManager {
     const previousDevice = existing.assignedDevice;
     // Preserve object identity so an already-started release observes the
     // rebinding and frees its live replacement rather than a stale snapshot.
-    Object.assign(existing, replacement);
+    // Recreate the replacement after awaited work: activity and label-routing
+    // updates remain live while persistence is in flight, and publishing the
+    // pre-persistence snapshot would overwrite them.
+    Object.assign(existing, this.createReboundSession(existing, assignedDevice, platform));
     this.sessionDeviceMap.set(existing.sessionId, assignedDevice);
     if (this.deviceSessionMap.get(previousDevice) === existing.sessionId) {
       this.deviceSessionMap.delete(previousDevice);
@@ -510,6 +518,25 @@ export class SessionManager {
     this.deviceSessionMap.set(assignedDevice, existing.sessionId);
     this.notifySessionDeviceUnbound(existing.sessionId, previousDevice);
     return existing;
+  }
+
+  /**
+   * Rebinding keeps only session-level routing cache. Hierarchy, rendered
+   * observation, and keep-awake state belong to the old physical device.
+   */
+  private createReboundSession(
+    session: Session,
+    assignedDevice: string,
+    platform: Platform,
+  ): Session {
+    return {
+      ...session,
+      assignedDevice,
+      platform,
+      cacheData: session.cacheData.deviceLabels === undefined
+        ? {}
+        : { deviceLabels: session.cacheData.deviceLabels },
+    };
   }
 
   /**
@@ -844,6 +871,16 @@ export class SessionManager {
         callback(sessionId, deviceId);
       } catch (error) {
         logger.warn(`Session device-unbound callback failed for ${sessionId}: ${error}`);
+      }
+    }
+  }
+
+  private notifySessionCreated(session: Session): void {
+    for (const callback of this.createdCallbacks) {
+      try {
+        callback(session);
+      } catch (error) {
+        logger.warn(`Session creation callback failed for ${session.sessionId}: ${error}`);
       }
     }
   }

--- a/src/daemon/sessionManager.ts
+++ b/src/daemon/sessionManager.ts
@@ -1087,6 +1087,21 @@ export class SessionManager {
   }
 
   /**
+   * Snapshot every session identity that is published or still completing
+   * creation, assignment, rebind, or early-release work.
+   */
+  getAllKnownSessionIds(): string[] {
+    return Array.from(new Set([
+      ...this.sessions.keys(),
+      ...this.pendingSessionCreations.keys(),
+      ...this.pendingSessionAssignments.keys(),
+      ...this.pendingSessionRebinds.keys(),
+      ...this.pendingSessionReleases.keys(),
+      ...this.releasePromises.keys(),
+    ]));
+  }
+
+  /**
    * Get all devices currently assigned to sessions
    */
   getAssignedDevices(): Set<string> {

--- a/src/server/deviceTools.ts
+++ b/src/server/deviceTools.ts
@@ -32,6 +32,7 @@ import { getDbWriteBarrier } from "../db/dbWriteBarrier";
 import { isAdbMissingDeviceError } from "../utils/android-cmdline-tools/AdbDeviceHealth";
 import { defaultTimer, type Timer } from "../utils/SystemTimer";
 import { getAbortSignal, runWithAbortSignal } from "../utils/AbortContext";
+import { getToolCapabilityContext } from "../features/toolCapabilities/toolCapabilityContext";
 import { executionTracker } from "./executionTracker";
 import {
   createDefaultRunnerReadinessService,
@@ -125,6 +126,10 @@ export const DEVICE_ALREADY_STOPPED_ERROR_CODE = "device_already_stopped";
 const DEVICE_SHUTDOWN_TIMEOUT_MS = 30_000;
 const DEVICE_SHUTDOWN_POLL_INTERVAL_MS = 1_000;
 const DEVICE_SHUTDOWN_POST_RELEASE_RECHECK_TIMEOUT_MS = 1_000;
+
+function getShutdownInitiatingExecutionId(): string | undefined {
+  return getToolCapabilityContext()?.execution?.executionId;
+}
 
 function isAlreadyStoppedDeviceError(
   platform: SomePlatform,
@@ -807,7 +812,7 @@ async function retireShutdownOwnership(
     await executionTracker.cancelSessionUuidExecutions(
       sessionId,
       `device-disconnected:${device.deviceId}`,
-      { excludeSignal: abortSignal },
+      { excludeExecutionId: getShutdownInitiatingExecutionId() },
     );
     const release = sessionManager.releaseSession(sessionId, `device-stopped:${device.deviceId}`);
     try {

--- a/src/server/executionTracker.ts
+++ b/src/server/executionTracker.ts
@@ -38,7 +38,7 @@ export interface ExecutionCancellationOptions {
    * Keeps the control-plane operation that triggered a device shutdown alive
    * while cancelling the device-bound work that must fail fast.
    */
-  excludeSignal?: AbortSignal;
+  excludeExecutionId?: string;
 }
 
 export interface ActiveExecutionQuery {
@@ -280,7 +280,7 @@ export class ExecutionTracker {
       if (!execution) {
         continue;
       }
-      if (execution.abortController.signal === options.excludeSignal) {
+      if (execution.id === options.excludeExecutionId) {
         continue;
       }
       if (cancelReason.startsWith("device-disconnected:")) {

--- a/test/daemon/daemonManagerReadiness.test.ts
+++ b/test/daemon/daemonManagerReadiness.test.ts
@@ -152,6 +152,35 @@ describe("DaemonManager readiness", () => {
     expect(existsSync(socketPath)).toBe(true);
   });
 
+  test("reports direct socket readiness when this namespace has no PID record", async () => {
+    const { lockPath, pidPath, socketPath } = createPaths();
+    const fakeTimer = new FakeTimer();
+    fakeTimer.enableAutoAdvance();
+    const clients: ProbeClient[] = [];
+    // A daemon from another checkout can own this namespace's socket without
+    // writing its PID metadata here. The successful direct connection is enough
+    // to reuse it; no PID file is written for this namespace.
+    writeFileSync(socketPath, "socket placeholder");
+
+    const manager = new DaemonManager(
+      () => {
+        const client = new ProbeClient(true);
+        clients.push(client);
+        return client;
+      },
+      undefined,
+      fakeTimer,
+      lockPath,
+      pidPath,
+      socketPath
+    );
+
+    await expect(manager.waitForReady(100)).resolves.toBe(true);
+    expect(clients).toHaveLength(1);
+    expect(existsSync(pidPath)).toBe(false);
+    expect(existsSync(socketPath)).toBe(true);
+  });
+
   test("removes an invalid non-socket path and keeps waiting when the PID is alive", async () => {
     const { lockPath, pidPath, socketPath } = createPaths();
     const fakeTimer = new FakeTimer();

--- a/test/daemon/daemonMcpProxy.test.ts
+++ b/test/daemon/daemonMcpProxy.test.ts
@@ -438,7 +438,7 @@ describe("DaemonMcpProxy", () => {
       }
     });
 
-    test("auto-starts daemon when not running", async () => {
+    test("observes the socket without cleanup before auto-starting", async () => {
       const fakeClient = new FakeDaemonClient({
         daemonMethodResults: new Map([["tools/list", { tools: [] }]]),
       });
@@ -462,6 +462,10 @@ describe("DaemonMcpProxy", () => {
         await proxy.listTools();
 
         expect(fakeManager.startCalled).toBe(true);
+        expect(isAvailableSpy).toHaveBeenCalledWith(
+          expect.any(String),
+          { skipStaleCleanup: true },
+        );
       } finally {
         isAvailableSpy.mockRestore();
         await proxy.close();

--- a/test/daemon/daemonStreamWiring.test.ts
+++ b/test/daemon/daemonStreamWiring.test.ts
@@ -1,0 +1,228 @@
+import { afterEach, describe, expect, test } from "bun:test";
+import { Daemon } from "../../src/daemon/daemon";
+import { DaemonState } from "../../src/daemon/daemonState";
+import type {
+  DeviceSessionRecord,
+  DeviceSessionRegistry,
+} from "../../src/daemon/deviceSessionRegistry";
+import type { DeviceSessionResolver } from "../../src/daemon/deviceSessionResolver";
+import { DeviceSessionRepository } from "../../src/db/deviceSessionRepository";
+import { NavigationRepository } from "../../src/db/navigationRepository";
+import { TestCoverageRepository } from "../../src/db/testCoverageRepository";
+import { NavigationGraphManager } from "../../src/features/navigation/NavigationGraphManager";
+import { CountingIdGenerator } from "../../src/utils/IdGenerator";
+import { createTestDatabase } from "../db/testDbHelper";
+import { FakeTimer } from "../fakes/FakeTimer";
+
+interface RoutingTarget {
+  setDeviceSessionResolver(resolver: DeviceSessionResolver): void;
+}
+
+interface RoutingTargets {
+  deviceDataStream: RoutingTarget | null;
+  performancePush: RoutingTarget | null;
+  failuresPush: RoutingTarget | null;
+  telemetryPush: RoutingTarget | null;
+}
+
+interface DaemonStreamInternals {
+  observationStreamHealth: {
+    isHealthy(): boolean;
+    recover(): Promise<void>;
+  };
+  deviceSessionRegistry: DeviceSessionRegistry;
+  getDeviceSessionRoutingTargets(): RoutingTargets;
+  setupDeviceSessionRouting(): void;
+  setupNavigationGraphStreamListener(server: unknown): void;
+  attemptRecovery(failureKind?: string): Promise<void>;
+}
+
+class FakePushServer implements RoutingTarget {
+  resolver: DeviceSessionResolver | null = null;
+
+  setDeviceSessionResolver(resolver: DeviceSessionResolver): void {
+    this.resolver = resolver;
+  }
+}
+
+class FakeDeviceDataStreamServer extends FakePushServer {
+  started: DeviceSessionRecord[] = [];
+  navigationUpdates: Array<{ appId: string | null; deviceId: string | null | undefined }> = [];
+
+  pushDeviceSessionStarted(record: DeviceSessionRecord): void {
+    this.started.push(record);
+  }
+
+  pushDeviceSessionEnded(_record: DeviceSessionRecord): void {}
+
+  pushNavigationGraphUpdate(
+    streamData: { appId: string | null },
+    deviceId: string | null | undefined,
+  ): void {
+    this.navigationUpdates.push({ appId: streamData.appId, deviceId });
+  }
+
+  setOnNavigationGraphRequested(_handler: unknown): void {}
+}
+
+function targets(deviceDataStream: FakeDeviceDataStreamServer): RoutingTargets {
+  return {
+    deviceDataStream,
+    performancePush: new FakePushServer(),
+    failuresPush: new FakePushServer(),
+    telemetryPush: new FakePushServer(),
+  };
+}
+
+async function flushNavigationUpdate(): Promise<void> {
+  await Promise.resolve();
+  await Promise.resolve();
+  await Promise.resolve();
+  await new Promise<void>((resolve) => setImmediate(resolve));
+}
+
+describe("Daemon stream wiring", () => {
+  afterEach(() => {
+    if (DaemonState.getInstance().isInitialized()) {
+      DaemonState.getInstance().reset();
+    }
+    NavigationGraphManager.resetInstance();
+  });
+
+  test("reinstalls routing and lifecycle delivery on an observation-stream replacement", async () => {
+    const timer = new FakeTimer();
+    const db = await createTestDatabase();
+    const daemon = new Daemon(
+      {},
+      undefined,
+      timer,
+      new DeviceSessionRepository(db),
+      new CountingIdGenerator("device-session"),
+    );
+    const internals = daemon as unknown as DaemonStreamInternals;
+    const originalStream = new FakeDeviceDataStreamServer();
+    const replacementStream = new FakeDeviceDataStreamServer();
+    let activeTargets = targets(originalStream);
+    internals.getDeviceSessionRoutingTargets = () => activeTargets;
+
+    try {
+      internals.setupDeviceSessionRouting();
+      const originalRecord = internals.deviceSessionRegistry.onDeviceConnected({
+        deviceId: "emulator-original",
+        platform: "android",
+        incarnation: 1,
+      });
+
+      internals.observationStreamHealth = {
+        isHealthy: () => false,
+        recover: async () => {
+          activeTargets = targets(replacementStream);
+        },
+      };
+      await internals.attemptRecovery("socket");
+
+      const recoveredRecord = internals.deviceSessionRegistry.onDeviceConnected({
+        deviceId: "emulator-recovered",
+        platform: "android",
+        incarnation: 1,
+      });
+
+      expect(originalStream.resolver?.resolveUuid(originalRecord.deviceId)).toBe(
+        originalRecord.deviceSessionUuid,
+      );
+      expect(originalStream.started).toEqual([originalRecord]);
+      expect(replacementStream.resolver?.resolveUuid(recoveredRecord.deviceId)).toBe(
+        recoveredRecord.deviceSessionUuid,
+      );
+      expect(replacementStream.started).toEqual([recoveredRecord]);
+    } finally {
+      daemon.getSessionManager().stopCleanupTimer();
+    }
+  });
+
+  test("forwards live session-scoped navigation changes to the active stream", async () => {
+    const timer = new FakeTimer();
+    const db = await createTestDatabase();
+    const sessionId = "navigation-session";
+    const sessionNavigation = NavigationGraphManager.createForTesting(
+      new NavigationRepository(db),
+      new TestCoverageRepository(undefined, db),
+      undefined,
+      sessionId,
+    );
+    NavigationGraphManager.setInstanceForTesting(
+      NavigationGraphManager.createForTesting(
+        new NavigationRepository(db),
+        new TestCoverageRepository(undefined, db),
+      ),
+    );
+    NavigationGraphManager.setInstanceForSessionForTesting(sessionId, sessionNavigation);
+    const daemon = new Daemon(
+      {},
+      undefined,
+      timer,
+      new DeviceSessionRepository(db),
+      new CountingIdGenerator("daemon"),
+    );
+    const internals = daemon as unknown as DaemonStreamInternals;
+    const stream = new FakeDeviceDataStreamServer();
+    internals.getDeviceSessionRoutingTargets = () => targets(stream);
+
+    try {
+      await daemon.getSessionManager().createSession(sessionId, "emulator-5554", "android");
+      internals.setupDeviceSessionRouting();
+      internals.setupNavigationGraphStreamListener(stream);
+
+      await sessionNavigation.setCurrentApp("com.example.session");
+      await flushNavigationUpdate();
+
+      expect(stream.navigationUpdates).toEqual([{ appId: "com.example.session", deviceId: null }]);
+    } finally {
+      daemon.getSessionManager().stopCleanupTimer();
+    }
+  });
+
+  test("attaches a newly-created session without a later stream configuration pass", async () => {
+    const timer = new FakeTimer();
+    const db = await createTestDatabase();
+    const sessionId = "created-after-stream-setup";
+    const sessionNavigation = NavigationGraphManager.createForTesting(
+      new NavigationRepository(db),
+      new TestCoverageRepository(undefined, db),
+      undefined,
+      sessionId,
+    );
+    NavigationGraphManager.setInstanceForTesting(
+      NavigationGraphManager.createForTesting(
+        new NavigationRepository(db),
+        new TestCoverageRepository(undefined, db),
+      ),
+    );
+    NavigationGraphManager.setInstanceForSessionForTesting(sessionId, sessionNavigation);
+    const daemon = new Daemon(
+      {},
+      undefined,
+      timer,
+      new DeviceSessionRepository(db),
+      new CountingIdGenerator("daemon"),
+    );
+    const internals = daemon as unknown as DaemonStreamInternals;
+    const stream = new FakeDeviceDataStreamServer();
+    internals.getDeviceSessionRoutingTargets = () => targets(stream);
+
+    try {
+      internals.setupDeviceSessionRouting();
+      internals.setupNavigationGraphStreamListener(stream);
+      await daemon.getSessionManager().createSession(sessionId, "emulator-5554", "android");
+
+      await sessionNavigation.setCurrentApp("com.example.created-after-setup");
+      await flushNavigationUpdate();
+
+      expect(stream.navigationUpdates).toEqual([
+        { appId: "com.example.created-after-setup", deviceId: null },
+      ]);
+    } finally {
+      daemon.getSessionManager().stopCleanupTimer();
+    }
+  });
+});

--- a/test/daemon/daemonStreamWiring.test.ts
+++ b/test/daemon/daemonStreamWiring.test.ts
@@ -34,6 +34,7 @@ interface DaemonStreamInternals {
   getDeviceSessionRoutingTargets(): RoutingTargets;
   setupDeviceSessionRouting(): void;
   setupNavigationGraphStreamListener(server: unknown): void;
+  setupNavigationGraphUpdateListener(manager: NavigationGraphManager): void;
   attemptRecovery(failureKind?: string): Promise<void>;
 }
 
@@ -48,6 +49,11 @@ class FakePushServer implements RoutingTarget {
 class FakeDeviceDataStreamServer extends FakePushServer {
   started: DeviceSessionRecord[] = [];
   navigationUpdates: Array<{ appId: string | null; deviceId: string | null | undefined }> = [];
+  subscriberCallbackInstalled = false;
+  screenshotCadenceCallbackInstalled = false;
+  hierarchyCadenceCallbackInstalled = false;
+  observationCallbackInstalled = false;
+  navigationRequestCallbackInstalled = false;
 
   pushDeviceSessionStarted(record: DeviceSessionRecord): void {
     this.started.push(record);
@@ -62,7 +68,25 @@ class FakeDeviceDataStreamServer extends FakePushServer {
     this.navigationUpdates.push({ appId: streamData.appId, deviceId });
   }
 
-  setOnNavigationGraphRequested(_handler: unknown): void {}
+  setOnSubscriberConnected(_handler: unknown): void {
+    this.subscriberCallbackInstalled = true;
+  }
+
+  setOnScreenshotCadenceChanged(_handler: unknown): void {
+    this.screenshotCadenceCallbackInstalled = true;
+  }
+
+  setOnHierarchyCadenceChanged(_handler: unknown): void {
+    this.hierarchyCadenceCallbackInstalled = true;
+  }
+
+  setOnObservationRequested(_handler: unknown): void {
+    this.observationCallbackInstalled = true;
+  }
+
+  setOnNavigationGraphRequested(_handler: unknown): void {
+    this.navigationRequestCallbackInstalled = true;
+  }
 }
 
 function targets(deviceDataStream: FakeDeviceDataStreamServer): RoutingTargets {
@@ -135,6 +159,11 @@ describe("Daemon stream wiring", () => {
         recoveredRecord.deviceSessionUuid,
       );
       expect(replacementStream.started).toEqual([recoveredRecord]);
+      expect(replacementStream.subscriberCallbackInstalled).toBe(true);
+      expect(replacementStream.screenshotCadenceCallbackInstalled).toBe(true);
+      expect(replacementStream.hierarchyCadenceCallbackInstalled).toBe(true);
+      expect(replacementStream.observationCallbackInstalled).toBe(true);
+      expect(replacementStream.navigationRequestCallbackInstalled).toBe(true);
     } finally {
       daemon.getSessionManager().stopCleanupTimer();
     }
@@ -221,6 +250,40 @@ describe("Daemon stream wiring", () => {
       expect(stream.navigationUpdates).toEqual([
         { appId: "com.example.created-after-setup", deviceId: null },
       ]);
+    } finally {
+      daemon.getSessionManager().stopCleanupTimer();
+    }
+  });
+
+  test("clears a released UUID tombstone before attaching its recreated session", async () => {
+    const timer = new FakeTimer();
+    const db = await createTestDatabase();
+    const sessionId = "recreated-session";
+    const globalNavigation = NavigationGraphManager.createForTesting(
+      new NavigationRepository(db),
+      new TestCoverageRepository(undefined, db),
+    );
+    NavigationGraphManager.setInstanceForTesting(globalNavigation);
+    NavigationGraphManager.releaseSession(sessionId);
+    const daemon = new Daemon(
+      {},
+      undefined,
+      timer,
+      new DeviceSessionRepository(db),
+      new CountingIdGenerator("daemon"),
+    );
+    const internals = daemon as unknown as DaemonStreamInternals;
+    const attachedManagers: NavigationGraphManager[] = [];
+    internals.setupNavigationGraphUpdateListener = manager => {
+      attachedManagers.push(manager);
+    };
+
+    try {
+      await daemon.getSessionManager().createSession(sessionId, "emulator-5554", "android");
+
+      const recreatedNavigation = NavigationGraphManager.getInstanceForSession(sessionId);
+      expect(recreatedNavigation).not.toBe(globalNavigation);
+      expect(attachedManagers).toEqual([recreatedNavigation]);
     } finally {
       daemon.getSessionManager().stopCleanupTimer();
     }

--- a/test/daemon/daemonStreamWiring.test.ts
+++ b/test/daemon/daemonStreamWiring.test.ts
@@ -255,6 +255,106 @@ describe("Daemon stream wiring", () => {
     }
   });
 
+  test("replaces the navigation listener when a session rebinds", async () => {
+    const timer = new FakeTimer();
+    const db = await createTestDatabase();
+    const sessionId = "rebound-navigation-session";
+    const initialNavigation = NavigationGraphManager.createForTesting(
+      new NavigationRepository(db),
+      new TestCoverageRepository(undefined, db),
+      undefined,
+      sessionId,
+    );
+    NavigationGraphManager.setInstanceForTesting(
+      NavigationGraphManager.createForTesting(
+        new NavigationRepository(db),
+        new TestCoverageRepository(undefined, db),
+      ),
+    );
+    NavigationGraphManager.setInstanceForSessionForTesting(sessionId, initialNavigation);
+    const daemon = new Daemon(
+      {},
+      undefined,
+      timer,
+      new DeviceSessionRepository(db),
+      new CountingIdGenerator("daemon"),
+    );
+    const internals = daemon as unknown as DaemonStreamInternals;
+    const stream = new FakeDeviceDataStreamServer();
+    internals.getDeviceSessionRoutingTargets = () => targets(stream);
+    const attachedManagers: NavigationGraphManager[] = [];
+    internals.setupNavigationGraphUpdateListener = manager => {
+      attachedManagers.push(manager);
+    };
+
+    try {
+      internals.setupDeviceSessionRouting();
+      internals.setupNavigationGraphStreamListener(stream);
+      await daemon.getSessionManager().createSession(sessionId, "emulator-old", "android");
+
+      await daemon.getSessionManager().rebindSession(sessionId, "emulator-new", "android");
+
+      expect(attachedManagers).toHaveLength(3);
+      expect(attachedManagers[1]).toBe(initialNavigation);
+      expect(attachedManagers[2]).not.toBe(initialNavigation);
+    } finally {
+      daemon.getSessionManager().stopCleanupTimer();
+    }
+  });
+
+  test("does not deliver an in-flight navigation update after session release", async () => {
+    const timer = new FakeTimer();
+    const db = await createTestDatabase();
+    const sessionId = "released-navigation-session";
+    NavigationGraphManager.setInstanceForTesting(
+      NavigationGraphManager.createForTesting(
+        new NavigationRepository(db),
+        new TestCoverageRepository(undefined, db),
+      ),
+    );
+    const sessionNavigation = NavigationGraphManager.createForTesting(
+      new NavigationRepository(db),
+      new TestCoverageRepository(undefined, db),
+      undefined,
+      sessionId,
+    );
+    NavigationGraphManager.setInstanceForSessionForTesting(sessionId, sessionNavigation);
+    const daemon = new Daemon(
+      {},
+      undefined,
+      timer,
+      new DeviceSessionRepository(db),
+      new CountingIdGenerator("daemon"),
+    );
+    const internals = daemon as unknown as DaemonStreamInternals;
+    const stream = new FakeDeviceDataStreamServer();
+    internals.getDeviceSessionRoutingTargets = () => targets(stream);
+
+    try {
+      internals.setupDeviceSessionRouting();
+      internals.setupNavigationGraphStreamListener(stream);
+      await daemon.getSessionManager().createSession(sessionId, "emulator-5554", "android");
+      const originalExport = sessionNavigation.exportGraphSummary.bind(sessionNavigation);
+      const exportStarted = Promise.withResolvers<void>();
+      const resumeExport = Promise.withResolvers<void>();
+      sessionNavigation.exportGraphSummary = async () => {
+        exportStarted.resolve();
+        await resumeExport.promise;
+        return await originalExport();
+      };
+
+      await sessionNavigation.setCurrentApp("com.example.released");
+      await exportStarted.promise;
+      await daemon.getSessionManager().releaseSession(sessionId);
+      resumeExport.resolve();
+      await flushNavigationUpdate();
+
+      expect(stream.navigationUpdates).toEqual([]);
+    } finally {
+      daemon.getSessionManager().stopCleanupTimer();
+    }
+  });
+
   test("clears a released UUID tombstone before attaching its recreated session", async () => {
     const timer = new FakeTimer();
     const db = await createTestDatabase();

--- a/test/daemon/deviceDataStreamSocketServer.test.ts
+++ b/test/daemon/deviceDataStreamSocketServer.test.ts
@@ -584,6 +584,96 @@ describe("DeviceDataStreamSocketServer", () => {
       expect(server.getSubscriberCount()).toBe(1);
     });
 
+    it("rejects a malformed deviceSessionUuid at the socket boundary", async () => {
+      const screenshotChanges: Array<string | null> = [];
+      server.setOnScreenshotCadenceChanged((deviceId) => screenshotChanges.push(deviceId));
+      const socket = new FakeSocket();
+
+      await server.processLineForTest(
+        socket,
+        JSON.stringify({
+          id: "sub-invalid-session",
+          command: "subscribe",
+          deviceSessionUuid: 42,
+          screenshotIntervalMs: 500,
+        }),
+      );
+
+      expect(socket.getWrittenMessages()).toEqual([
+        {
+          id: "sub-invalid-session",
+          type: "error",
+          success: false,
+          error: "deviceSessionUuid must be a string or null",
+        },
+      ]);
+      expect(server.getSubscriberCount()).toBe(0);
+      expect(screenshotChanges).toEqual([]);
+    });
+
+    it("treats an omitted deviceSessionUuid as an intentional all-devices subscription", async () => {
+      const screenshotChanges: Array<string | null> = [];
+      const hierarchyChanges: Array<string | null> = [];
+      server.setOnScreenshotCadenceChanged((deviceId) => screenshotChanges.push(deviceId));
+      server.setOnHierarchyCadenceChanged((deviceId) => hierarchyChanges.push(deviceId));
+      const socket = new FakeSocket();
+
+      await server.processLineForTest(
+        socket,
+        JSON.stringify({
+          id: "sub-all-devices",
+          command: "subscribe",
+          screenshotIntervalMs: 750,
+          hierarchyIntervalMs: 500,
+        }),
+      );
+
+      expect(screenshotChanges).toEqual([null]);
+      expect(hierarchyChanges).toEqual([null]);
+      expect(server.getScreenshotIntervalMsForDevice("device-1")).toBe(750);
+      expect(server.getScreenshotIntervalMsForDevice("device-2")).toBe(750);
+      expect(server.getHierarchyIntervalMsForDevice("device-1")).toBe(500);
+      expect(server.getHierarchyIntervalMsForDevice("device-2")).toBe(500);
+    });
+
+    it("keeps an unresolved deviceSessionUuid from matching or scheduling devices", async () => {
+      const screenshotChanges: Array<string | null> = [];
+      const hierarchyChanges: Array<string | null> = [];
+      server.setOnScreenshotCadenceChanged((deviceId) => screenshotChanges.push(deviceId));
+      server.setOnHierarchyCadenceChanged((deviceId) => hierarchyChanges.push(deviceId));
+      const socket = new FakeSocket();
+
+      await server.processLineForTest(
+        socket,
+        JSON.stringify({
+          id: "sub-unknown-session",
+          command: "subscribe",
+          deviceSessionUuid: "session-unknown",
+          screenshotIntervalMs: 250,
+          hierarchyIntervalMs: 250,
+        }),
+      );
+
+      expect(socket.getWrittenMessages<{ type: string; success?: boolean }>()).toMatchObject([
+        { type: "subscription_response", success: true },
+      ]);
+      expect(screenshotChanges).toEqual([]);
+      expect(hierarchyChanges).toEqual([]);
+      expect(server.hasSubscriberForDevice("device-1")).toBe(false);
+      expect(server.getScreenshotIntervalMsForDevice("device-1")).toBe(3000);
+      expect(server.getHierarchyIntervalMsForDevice("device-1")).toBe(1000);
+
+      // The subscription resolved to no device at creation time, so a later
+      // rebind cannot attach it to the new epoch.
+      server.sessionResolver.bind("device-1", "session-unknown");
+      server.pushScreenshotUpdate("device-1", "frame", 100, 200);
+
+      expect(socket.getWrittenMessages()).toHaveLength(1);
+      expect(server.hasSubscriberForDevice("device-1")).toBe(false);
+      expect(server.getScreenshotIntervalMsForDevice("device-1")).toBe(3000);
+      expect(server.getHierarchyIntervalMsForDevice("device-1")).toBe(1000);
+    });
+
     it("handles unsubscribe command", async () => {
       const { socket } = server.simulateSubscription({});
       expect(server.getSubscriberCount()).toBe(1);
@@ -1992,6 +2082,15 @@ describe("DeviceDataStreamSocketServer", () => {
       expect(frames(socket).filter(f => f.type === "hierarchy_update")).toHaveLength(0);
     });
 
+    it("retires the previous uuid when a fake resolver rebinds a device", () => {
+      server.sessionResolver.bind("device-a", "session-device-a");
+      server.sessionResolver.bind("device-a", "session-device-a-2");
+
+      expect(server.sessionResolver.resolveUuid("device-a")).toBe("session-device-a-2");
+      expect(server.sessionResolver.resolveDeviceId("session-device-a")).toBeNull();
+      expect(server.sessionResolver.resolveDeviceId("session-device-a-2")).toBe("device-a");
+    });
+
     describe("navigation targeting (AC3, closes #4837)", () => {
       it("targets the device that owns the graph; other panes see nothing", () => {
         const a = server.simulateSubscription({ deviceId: "device-a" });
@@ -2045,7 +2144,11 @@ describe("DeviceDataStreamSocketServer", () => {
       });
 
       it("pushes device_session_started to a matching-uuid and an all-device subscriber", () => {
-        const scoped = server.simulateSubscription({ deviceSessionUuid: "session-device-a" });
+        server.sessionResolver.bind("device-a", "session-device-a");
+        const scoped = server.simulateSubscription({
+          deviceId: "device-a",
+          deviceSessionUuid: "session-device-a",
+        });
         const all = server.simulateSubscription({});
         const other = server.simulateSubscription({ deviceSessionUuid: "session-other" });
 
@@ -2060,7 +2163,12 @@ describe("DeviceDataStreamSocketServer", () => {
       });
 
       it("pushes device_session_ended with the retired identity", () => {
-        const { socket } = server.simulateSubscription({ deviceSessionUuid: "session-device-a" });
+        server.sessionResolver.bind("device-a", "session-device-a");
+        const { socket } = server.simulateSubscription({
+          deviceId: "device-a",
+          deviceSessionUuid: "session-device-a",
+        });
+        server.sessionResolver.retire("device-a");
         server.pushDeviceSessionEnded(record());
 
         const f = frames(socket).filter(x => x.type === "device_session_ended");

--- a/test/daemon/deviceDataStreamSocketServer.test.ts
+++ b/test/daemon/deviceDataStreamSocketServer.test.ts
@@ -636,7 +636,7 @@ describe("DeviceDataStreamSocketServer", () => {
       expect(server.getHierarchyIntervalMsForDevice("device-2")).toBe(500);
     });
 
-    it("keeps an unresolved deviceSessionUuid from matching or scheduling devices", async () => {
+    it("rejects an unresolved deviceSessionUuid before creating a subscription", async () => {
       const screenshotChanges: Array<string | null> = [];
       const hierarchyChanges: Array<string | null> = [];
       server.setOnScreenshotCadenceChanged((deviceId) => screenshotChanges.push(deviceId));
@@ -654,24 +654,43 @@ describe("DeviceDataStreamSocketServer", () => {
         }),
       );
 
-      expect(socket.getWrittenMessages<{ type: string; success?: boolean }>()).toMatchObject([
-        { type: "subscription_response", success: true },
+      expect(socket.getWrittenMessages<{ type: string; success?: boolean; error?: string }>()).toEqual([
+        {
+          id: "sub-unknown-session",
+          type: "error",
+          success: false,
+          error: "deviceSessionUuid 'session-unknown' does not identify a live device session",
+        },
       ]);
       expect(screenshotChanges).toEqual([]);
       expect(hierarchyChanges).toEqual([]);
+      expect(server.getSubscriberCount()).toBe(0);
       expect(server.hasSubscriberForDevice("device-1")).toBe(false);
       expect(server.getScreenshotIntervalMsForDevice("device-1")).toBe(3000);
       expect(server.getHierarchyIntervalMsForDevice("device-1")).toBe(1000);
+    });
 
-      // The subscription resolved to no device at creation time, so a later
-      // rebind cannot attach it to the new epoch.
-      server.sessionResolver.bind("device-1", "session-unknown");
-      server.pushScreenshotUpdate("device-1", "frame", 100, 200);
+    it("rejects a blank deviceSessionUuid", async () => {
+      const socket = new FakeSocket();
 
-      expect(socket.getWrittenMessages()).toHaveLength(1);
-      expect(server.hasSubscriberForDevice("device-1")).toBe(false);
-      expect(server.getScreenshotIntervalMsForDevice("device-1")).toBe(3000);
-      expect(server.getHierarchyIntervalMsForDevice("device-1")).toBe(1000);
+      await server.processLineForTest(
+        socket,
+        JSON.stringify({
+          id: "sub-blank-session",
+          command: "subscribe",
+          deviceSessionUuid: "  ",
+        }),
+      );
+
+      expect(socket.getWrittenMessages()).toEqual([
+        {
+          id: "sub-blank-session",
+          type: "error",
+          success: false,
+          error: "deviceSessionUuid must not be blank",
+        },
+      ]);
+      expect(server.getSubscriberCount()).toBe(0);
     });
 
     it("handles unsubscribe command", async () => {
@@ -2072,14 +2091,25 @@ describe("DeviceDataStreamSocketServer", () => {
         .toEqual(["session-device-b"]);
     });
 
-    it("yields zero events to a stale/retired deviceSessionUuid subscriber (AC4)", () => {
-      const { socket } = server.simulateSubscription({ deviceId: "device-a" });
+    it("yields zero events and stops capture for a stale/retired deviceSessionUuid subscriber (AC4)", () => {
+      const { socket } = server.simulateSubscription({
+        deviceId: "device-a",
+        screenshotIntervalMs: 250,
+        hierarchyIntervalMs: 250,
+      });
+      expect(server.hasSubscriberForDevice("device-a")).toBe(true);
+      expect(server.getScreenshotIntervalMsForDevice("device-a")).toBe(250);
+      expect(server.getHierarchyIntervalMsForDevice("device-a")).toBe(250);
+
       // device-a reconnects under a new epoch: the serial now resolves to a new uuid.
       server.sessionResolver.retire("device-a").bind("device-a", "session-device-a-2");
 
       server.pushHierarchyUpdate("device-a", hierarchy);
 
       expect(frames(socket).filter(f => f.type === "hierarchy_update")).toHaveLength(0);
+      expect(server.hasSubscriberForDevice("device-a")).toBe(false);
+      expect(server.getScreenshotIntervalMsForDevice("device-a")).toBe(3000);
+      expect(server.getHierarchyIntervalMsForDevice("device-a")).toBe(1000);
     });
 
     it("retires the previous uuid when a fake resolver rebinds a device", () => {

--- a/test/daemon/devicePool.autolock.test.ts
+++ b/test/daemon/devicePool.autolock.test.ts
@@ -396,6 +396,63 @@ describe("DevicePool autolock", () => {
       }
     });
 
+    it("does not release a same-UUID replacement after deferred teardown", async () => {
+      let finishRestore!: () => void;
+      const restoration = new Promise<void>(resolve => { finishRestore = resolve; });
+      let restoreStarted!: () => void;
+      const restorationStarted = new Promise<void>(resolve => { restoreStarted = resolve; });
+      const restoringManager = new SessionManager(
+        timer,
+        new FakeDeviceSessionPersistence(),
+        () => new FakeDbWriteBarrier(),
+        () => ({ restore: async (): Promise<void> => {
+          restoreStarted();
+          await restoration;
+        } }),
+      );
+      const restoringPool = new DevicePool(
+        restoringManager,
+        "daemon-session-1",
+        timer,
+        undefined,
+        fakeDeviceUtils,
+      );
+      try {
+        fakeDeviceUtils.setBootedDevices("android", [androidDevice]);
+        await restoringPool.initializeWithDevices([androidDevice]);
+        await restoringPool.assignDeviceToSession("reused-session", "android");
+        restoringManager.setKeepScreenAwake(
+          "reused-session",
+          { applied: true, method: "svc", svcWasEnabled: false },
+        );
+
+        const release = restoringManager.releaseSession("reused-session");
+        await restorationStarted;
+        timer.advanceTime(1_000);
+        await restoringManager.waitForSessionRelease("reused-session");
+        await release;
+        await restoringPool.releaseDevice("emulator-5554", "reused-session");
+        await restoringPool.bindOrReuseDeviceSession(
+          "reused-session",
+          "emulator-5554",
+          "android",
+        );
+
+        finishRestore();
+        for (let attempt = 0; attempt < 10; attempt++) {
+          await new Promise<void>(resolve => setImmediate(resolve));
+        }
+
+        expect(restoringPool.getDevice("emulator-5554")).toMatchObject({
+          sessionId: "reused-session",
+          status: "busy",
+        });
+        expect(restoringManager.getSession("reused-session")?.assignedDevice).toBe("emulator-5554");
+      } finally {
+        restoringManager.stopCleanupTimer();
+      }
+    });
+
     it("rejects a late MCP request while earlier work still owns the expired autolock", async () => {
       await initializeLiveAndroidDevice();
       sessionManager.setActiveSessionExecutionChecker((_sessionId, query) => query?.excludeExecutionId === "late");

--- a/test/daemon/devicePool.test.ts
+++ b/test/daemon/devicePool.test.ts
@@ -722,6 +722,38 @@ describe("DevicePool", () => {
       }
     });
 
+    test("does not remove a same-serial device added after an absent disconnect capture", async () => {
+      const device = createBootedDevice("emulator-5554");
+
+      const disconnect = devicePool.removeDisconnectedDevice(device.deviceId);
+      await devicePool.initializeWithDevices([device]);
+      const replacement = devicePool.getDevice(device.deviceId);
+      await disconnect;
+
+      expect(devicePool.getDevice(device.deviceId)).toBe(replacement);
+    });
+
+    test("does not release a same-UUID replacement assignment after session persistence", async () => {
+      const device = createBootedDevice("emulator-5554");
+      fakeDeviceManager.bootedDevices = [device];
+      await devicePool.initializeWithDevices([device]);
+      await devicePool.bindOrReuseDeviceSession("session-1", device.deviceId, device.platform);
+      const originalAssignmentCount = devicePool.getDevice(device.deviceId)?.assignmentCount;
+
+      await sessionManager.releaseSession("session-1");
+      await devicePool.bindOrReuseDeviceSession("session-1", device.deviceId, device.platform);
+      const replacement = devicePool.getDevice(device.deviceId);
+      expect(replacement?.assignmentCount).toBe((originalAssignmentCount ?? 0) + 1);
+
+      await devicePool.releaseDevice(device.deviceId, "session-1");
+
+      expect(devicePool.getDevice(device.deviceId)).toBe(replacement);
+      expect(replacement).toMatchObject({
+        sessionId: "session-1",
+        status: "busy",
+      });
+    });
+
     // Boundary row (PARAM-7): the pool is keyed by device id, so two devices
     // with the same id collapse to a single tracked entry rather than being
     // double-counted. Pins the de-dup invariant a duplicate-id feed depends on.

--- a/test/daemon/manager.test.ts
+++ b/test/daemon/manager.test.ts
@@ -839,6 +839,146 @@ describe("Daemon manager process detection", () => {
     }
   });
 
+  test("restart takes over a verified daemon without the default namespace PID record", async () => {
+    const fakeTimer = new FakeTimer();
+    fakeTimer.enableAutoAdvance();
+    const candidatePid = 451;
+    const livePids = new Set([candidatePid]);
+    const processFinder: DaemonProcessFinder & DaemonProcessLivenessChecker = {
+      findDaemonProcesses: () => [{
+        pid: candidatePid,
+        ppid: 1,
+        command: "bun /other-checkout/dist/src/index.js --daemon-mode",
+      }],
+      isProcessRunning: pid => livePids.has(pid),
+    };
+    const manager = new DaemonManager(
+      () => new FakeDaemonClient({}),
+      undefined,
+      fakeTimer,
+      undefined,
+      undefined,
+      undefined,
+      processFinder,
+    );
+    const statusSpy = spyOn(manager, "status").mockResolvedValue({ running: false });
+    const startSpy = spyOn(manager, "start").mockResolvedValue(undefined);
+    const killSpy = spyOn(process, "kill").mockImplementation(((pid: number, signal?: NodeJS.Signals | number) => {
+      if (pid === candidatePid && signal === "SIGTERM") {
+        livePids.delete(pid);
+      }
+      return true;
+    }) as typeof process.kill);
+
+    try {
+      await manager.restart();
+
+      expect(killSpy).toHaveBeenCalledWith(candidatePid, "SIGTERM");
+      expect(startSpy).toHaveBeenCalledWith({});
+    } finally {
+      killSpy.mockRestore();
+      startSpy.mockRestore();
+      statusSpy.mockRestore();
+    }
+  });
+
+  test("restart takes over a verified daemon without a custom namespace PID record", async () => {
+    const dir = mkdtempSync(join(tmpdir(), "daemon-manager-custom-restart-test-"));
+    const fakeTimer = new FakeTimer();
+    fakeTimer.enableAutoAdvance();
+    const candidatePid = 452;
+    const livePids = new Set([candidatePid]);
+    const processFinder: DaemonProcessFinder & DaemonProcessLivenessChecker = {
+      findDaemonProcesses: () => [{
+        pid: candidatePid,
+        ppid: 1,
+        command: "bun /other-checkout/dist/src/index.js --daemon-mode",
+      }],
+      isProcessRunning: pid => livePids.has(pid),
+    };
+    const manager = new DaemonManager(
+      () => new FakeDaemonClient({}),
+      undefined,
+      fakeTimer,
+      join(dir, "daemon.lock"),
+      join(dir, "daemon.pid"),
+      join(dir, "daemon.sock"),
+      processFinder,
+    );
+    const statusSpy = spyOn(manager, "status").mockResolvedValue({ running: false });
+    const startSpy = spyOn(manager, "start").mockResolvedValue(undefined);
+    const killSpy = spyOn(process, "kill").mockImplementation(((pid: number, signal?: NodeJS.Signals | number) => {
+      if (pid === candidatePid && signal === "SIGTERM") {
+        livePids.delete(pid);
+      }
+      return true;
+    }) as typeof process.kill);
+
+    try {
+      await manager.restart();
+
+      expect(killSpy).toHaveBeenCalledWith(candidatePid, "SIGTERM");
+      expect(startSpy).toHaveBeenCalledWith({});
+    } finally {
+      killSpy.mockRestore();
+      startSpy.mockRestore();
+      statusSpy.mockRestore();
+      rmSync(dir, { recursive: true, force: true });
+    }
+  });
+
+  test("restart does not signal a candidate that exits while its socket is probed", async () => {
+    const fakeTimer = new FakeTimer();
+    fakeTimer.enableAutoAdvance();
+    const candidatePid = 453;
+    const livePids = new Set([candidatePid]);
+    const processFinder: DaemonProcessFinder & DaemonProcessLivenessChecker = {
+      findDaemonProcesses: () => [{
+        pid: candidatePid,
+        ppid: 1,
+        command: "bun /other-checkout/dist/src/index.js --daemon-mode",
+      }],
+      isProcessRunning: pid => livePids.has(pid),
+    };
+    const manager = new DaemonManager(
+      () => ({
+        async connect() {
+          livePids.delete(candidatePid);
+        },
+        async close() {},
+        async callTool() {
+          return {};
+        },
+        async readResource() {
+          return {};
+        },
+        async callDaemonMethod() {
+          return {};
+        },
+      }),
+      undefined,
+      fakeTimer,
+      undefined,
+      undefined,
+      undefined,
+      processFinder,
+    );
+    const statusSpy = spyOn(manager, "status").mockResolvedValue({ running: false });
+    const startSpy = spyOn(manager, "start").mockResolvedValue(undefined);
+    const killSpy = spyOn(process, "kill").mockImplementation(() => true);
+
+    try {
+      await manager.restart();
+
+      expect(killSpy).not.toHaveBeenCalled();
+      expect(startSpy).toHaveBeenCalledWith({});
+    } finally {
+      killSpy.mockRestore();
+      startSpy.mockRestore();
+      statusSpy.mockRestore();
+    }
+  });
+
   test("start takeover does not signal transient daemon-mode candidates that are gone by liveness re-check", async () => {
     const dir = mkdtempSync(join(tmpdir(), "daemon-manager-transient-takeover-test-"));
     process.env.AUTOMOBILE_DATA_DIR = dir;

--- a/test/daemon/manager.test.ts
+++ b/test/daemon/manager.test.ts
@@ -84,7 +84,18 @@ describe("DaemonManager restart", () => {
   test("preserves PID-recorded options when no replacement options are requested", async () => {
     const timer = new FakeTimer();
     timer.enableAutoAdvance();
-    const manager = new DaemonManager(undefined, undefined, timer);
+    const manager = new DaemonManager(
+      undefined,
+      undefined,
+      timer,
+      undefined,
+      undefined,
+      undefined,
+      {
+        findDaemonProcesses: () => [],
+        isProcessRunning: () => false,
+      },
+    );
     const recordedOptions: DaemonOptions = {
       debug: true,
       toolOutputsDir: "/tmp/automobile-artifacts",
@@ -92,6 +103,7 @@ describe("DaemonManager restart", () => {
     };
     const statusSpy = spyOn(manager, "status").mockResolvedValue({
       running: true,
+      pid: 999,
       options: recordedOptions,
     });
     const stopSpy = spyOn(manager, "stop").mockResolvedValue(undefined);
@@ -947,6 +959,60 @@ describe("Daemon manager process detection", () => {
       startSpy.mockRestore();
       statusSpy.mockRestore();
       rmSync(dir, { recursive: true, force: true });
+    }
+  });
+
+  test("explicit restart stops the recorded daemon and every cross-namespace daemon", async () => {
+    const fakeTimer = new FakeTimer();
+    fakeTimer.enableAutoAdvance();
+    const recordedPid = 451;
+    const crossNamespacePid = 452;
+    const livePids = new Set([recordedPid, crossNamespacePid]);
+    const processFinder: DaemonProcessFinder & DaemonProcessLivenessChecker = {
+      findDaemonProcesses: () => [recordedPid, crossNamespacePid].map(pid => ({
+        pid,
+        ppid: 1,
+        command: "bun /other-checkout/dist/src/index.js --daemon-mode",
+      })),
+      isProcessRunning: pid => livePids.has(pid),
+    };
+    const signaler = new FakeDaemonProcessSignaler((pid, signal) => {
+      if (signal === "SIGTERM") {
+        livePids.delete(pid);
+      }
+    });
+    const manager = new DaemonManager(
+      undefined,
+      undefined,
+      fakeTimer,
+      undefined,
+      undefined,
+      undefined,
+      processFinder,
+      undefined,
+      undefined,
+      undefined,
+      signaler,
+    );
+    const statusSpy = spyOn(manager, "status").mockResolvedValue({
+      running: true,
+      pid: recordedPid,
+    });
+    const stopSpy = spyOn(manager, "stop").mockImplementation(async () => {
+      livePids.delete(recordedPid);
+    });
+    const startSpy = spyOn(manager, "start").mockResolvedValue(undefined);
+
+    try {
+      await manager.restart();
+
+      expect(stopSpy).toHaveBeenCalledTimes(1);
+      expect(signaler.signals).toEqual([{ pid: crossNamespacePid, signal: "SIGTERM" }]);
+      expect(startSpy).toHaveBeenCalledWith({});
+    } finally {
+      startSpy.mockRestore();
+      stopSpy.mockRestore();
+      statusSpy.mockRestore();
     }
   });
 

--- a/test/daemon/manager.test.ts
+++ b/test/daemon/manager.test.ts
@@ -405,6 +405,7 @@ describe("Daemon manager process detection", () => {
   test("parses daemon processes from ps pid ppid command output", () => {
     const records = parseDaemonProcessTable(`
       10     1 /usr/bin/unrelated --daemon-mode
+      11     1 python worker.py --note auto-mobile --daemon-mode
       20     1 /bin/sh -c "bun /worktree/dist/src/index.js --daemon-mode"
       21    20 bun /worktree/dist/src/index.js --daemon-mode
       22     1 bun /worktree/dist/src/index.js

--- a/test/daemon/manager.test.ts
+++ b/test/daemon/manager.test.ts
@@ -406,27 +406,35 @@ describe("Daemon manager process detection", () => {
     const records = parseDaemonProcessTable(`
       10     1 /usr/bin/unrelated --daemon-mode
       11     1 python worker.py --note auto-mobile --daemon-mode
-      20     1 /bin/sh -c "bun /worktree/dist/src/index.js --daemon-mode"
-      21    20 bun /worktree/dist/src/index.js --daemon-mode
-      22     1 bun /worktree/dist/src/index.js
+      12     1 bunx -y other-package @kaeawc/auto-mobile --daemon-mode
+      13     1 bun /worktree/unrelated/dist/src/index.js --daemon-mode
+      20     1 /bin/sh -c "bun /worktree/auto-mobile/dist/src/index.js --daemon-mode"
+      21    20 bun /worktree/auto-mobile/dist/src/index.js --daemon-mode
+      22     1 bun /worktree/auto-mobile/dist/src/index.js
       30     1 bunx -y @kaeawc/auto-mobile@0.0.38 --daemon-mode
+      31     1 bun x -y @kaeawc/auto-mobile@0.0.38 --daemon-mode
     `);
 
     expect(records).toEqual([
       {
         pid: 20,
         ppid: 1,
-        command: `/bin/sh -c "bun /worktree/dist/src/index.js --daemon-mode"`,
+        command: `/bin/sh -c "bun /worktree/auto-mobile/dist/src/index.js --daemon-mode"`,
       },
       {
         pid: 21,
         ppid: 20,
-        command: "bun /worktree/dist/src/index.js --daemon-mode",
+        command: "bun /worktree/auto-mobile/dist/src/index.js --daemon-mode",
       },
       {
         pid: 30,
         ppid: 1,
         command: "bunx -y @kaeawc/auto-mobile@0.0.38 --daemon-mode",
+      },
+      {
+        pid: 31,
+        ppid: 1,
+        command: "bun x -y @kaeawc/auto-mobile@0.0.38 --daemon-mode",
       },
     ]);
   });
@@ -475,7 +483,7 @@ describe("Daemon manager process detection", () => {
       {
         ProcessId: 21,
         ParentProcessId: 20,
-        CommandLine: "C:\\\\Program Files\\\\nodejs\\\\node.exe C:\\\\repo\\\\dist\\\\src\\\\index.js --daemon-mode",
+        CommandLine: "C:\\\\Program Files\\\\nodejs\\\\node.exe C:\\\\repo\\\\auto-mobile\\\\dist\\\\src\\\\index.js --daemon-mode",
       },
       {
         ProcessId: 22,
@@ -493,7 +501,7 @@ describe("Daemon manager process detection", () => {
       {
         pid: 21,
         ppid: 20,
-        command: "C:\\\\Program Files\\\\nodejs\\\\node.exe C:\\\\repo\\\\dist\\\\src\\\\index.js --daemon-mode",
+        command: "C:\\\\Program Files\\\\nodejs\\\\node.exe C:\\\\repo\\\\auto-mobile\\\\dist\\\\src\\\\index.js --daemon-mode",
       },
     ]);
   });

--- a/test/daemon/manager.test.ts
+++ b/test/daemon/manager.test.ts
@@ -20,6 +20,7 @@ import type { DaemonOptions, DaemonStatus } from "../../src/daemon/types";
 import type {
   DaemonProcessFinder,
   DaemonProcessLivenessChecker,
+  DaemonProcessSignaler,
   DaemonProcessSpawner,
   DaemonProcessRecord,
   ExtractionCleaner,
@@ -287,6 +288,17 @@ class FakeDaemonProcessFinder implements DaemonProcessFinder, DaemonProcessLiven
 
   isProcessRunning(pid: number): boolean {
     return this.livePids.has(pid);
+  }
+}
+
+class FakeDaemonProcessSignaler implements DaemonProcessSignaler {
+  readonly signals: Array<{ pid: number; signal: NodeJS.Signals }> = [];
+
+  constructor(private readonly onSignal?: (pid: number, signal: NodeJS.Signals) => void) {}
+
+  signal(pid: number, signal: NodeJS.Signals): void {
+    this.signals.push({ pid, signal });
+    this.onSignal?.(pid, signal);
   }
 }
 
@@ -839,7 +851,7 @@ describe("Daemon manager process detection", () => {
     }
   });
 
-  test("restart takes over a verified daemon without the default namespace PID record", async () => {
+  test("explicit restart force-stops an unreachable daemon without the default namespace PID record", async () => {
     const fakeTimer = new FakeTimer();
     fakeTimer.enableAutoAdvance();
     const candidatePid = 451;
@@ -852,128 +864,134 @@ describe("Daemon manager process detection", () => {
       }],
       isProcessRunning: pid => livePids.has(pid),
     };
+    const signaler = new FakeDaemonProcessSignaler((pid, signal) => {
+      if (pid === candidatePid && signal === "SIGTERM") {
+        livePids.delete(pid);
+      }
+    });
     const manager = new DaemonManager(
-      () => new FakeDaemonClient({}),
+      () => {
+        throw new Error("unreachable daemon socket must not block explicit restart");
+      },
       undefined,
       fakeTimer,
       undefined,
       undefined,
       undefined,
       processFinder,
+      undefined,
+      undefined,
+      undefined,
+      signaler,
     );
     const statusSpy = spyOn(manager, "status").mockResolvedValue({ running: false });
     const startSpy = spyOn(manager, "start").mockResolvedValue(undefined);
-    const killSpy = spyOn(process, "kill").mockImplementation(((pid: number, signal?: NodeJS.Signals | number) => {
-      if (pid === candidatePid && signal === "SIGTERM") {
-        livePids.delete(pid);
-      }
-      return true;
-    }) as typeof process.kill);
 
     try {
       await manager.restart();
 
-      expect(killSpy).toHaveBeenCalledWith(candidatePid, "SIGTERM");
+      expect(signaler.signals).toEqual([{ pid: candidatePid, signal: "SIGTERM" }]);
       expect(startSpy).toHaveBeenCalledWith({});
     } finally {
-      killSpy.mockRestore();
       startSpy.mockRestore();
       statusSpy.mockRestore();
     }
   });
 
-  test("restart takes over a verified daemon without a custom namespace PID record", async () => {
+  test("explicit restart force-stops every daemon from other PID-file namespaces", async () => {
     const dir = mkdtempSync(join(tmpdir(), "daemon-manager-custom-restart-test-"));
     const fakeTimer = new FakeTimer();
     fakeTimer.enableAutoAdvance();
-    const candidatePid = 452;
-    const livePids = new Set([candidatePid]);
+    const candidatePids = [452, 453];
+    const livePids = new Set(candidatePids);
     const processFinder: DaemonProcessFinder & DaemonProcessLivenessChecker = {
-      findDaemonProcesses: () => [{
-        pid: candidatePid,
+      findDaemonProcesses: () => candidatePids.map(pid => ({
+        pid,
         ppid: 1,
         command: "bun /other-checkout/dist/src/index.js --daemon-mode",
-      }],
+      })),
       isProcessRunning: pid => livePids.has(pid),
     };
+    const signaler = new FakeDaemonProcessSignaler((pid, signal) => {
+      if (signal === "SIGTERM") {
+        livePids.delete(pid);
+      }
+    });
     const manager = new DaemonManager(
-      () => new FakeDaemonClient({}),
+      () => {
+        throw new Error("unreachable daemon socket must not block explicit restart");
+      },
       undefined,
       fakeTimer,
       join(dir, "daemon.lock"),
       join(dir, "daemon.pid"),
       join(dir, "daemon.sock"),
       processFinder,
+      undefined,
+      undefined,
+      undefined,
+      signaler,
     );
     const statusSpy = spyOn(manager, "status").mockResolvedValue({ running: false });
     const startSpy = spyOn(manager, "start").mockResolvedValue(undefined);
-    const killSpy = spyOn(process, "kill").mockImplementation(((pid: number, signal?: NodeJS.Signals | number) => {
-      if (pid === candidatePid && signal === "SIGTERM") {
-        livePids.delete(pid);
-      }
-      return true;
-    }) as typeof process.kill);
 
     try {
       await manager.restart();
 
-      expect(killSpy).toHaveBeenCalledWith(candidatePid, "SIGTERM");
+      expect(signaler.signals).toEqual([
+        { pid: 452, signal: "SIGTERM" },
+        { pid: 453, signal: "SIGTERM" },
+      ]);
       expect(startSpy).toHaveBeenCalledWith({});
     } finally {
-      killSpy.mockRestore();
       startSpy.mockRestore();
       statusSpy.mockRestore();
       rmSync(dir, { recursive: true, force: true });
     }
   });
 
-  test("restart does not signal a candidate that exits while its socket is probed", async () => {
+  test("explicit restart does not signal a candidate that exits before the forced stop", async () => {
     const fakeTimer = new FakeTimer();
     fakeTimer.enableAutoAdvance();
     const candidatePid = 453;
-    const livePids = new Set([candidatePid]);
+    let livenessChecks = 0;
     const processFinder: DaemonProcessFinder & DaemonProcessLivenessChecker = {
       findDaemonProcesses: () => [{
         pid: candidatePid,
         ppid: 1,
         command: "bun /other-checkout/dist/src/index.js --daemon-mode",
       }],
-      isProcessRunning: pid => livePids.has(pid),
+      isProcessRunning: pid => {
+        if (pid !== candidatePid) {
+          return false;
+        }
+        livenessChecks++;
+        return livenessChecks === 1;
+      },
     };
+    const signaler = new FakeDaemonProcessSignaler();
     const manager = new DaemonManager(
-      () => ({
-        async connect() {
-          livePids.delete(candidatePid);
-        },
-        async close() {},
-        async callTool() {
-          return {};
-        },
-        async readResource() {
-          return {};
-        },
-        async callDaemonMethod() {
-          return {};
-        },
-      }),
+      undefined,
       undefined,
       fakeTimer,
       undefined,
       undefined,
       undefined,
       processFinder,
+      undefined,
+      undefined,
+      undefined,
+      signaler,
     );
     const statusSpy = spyOn(manager, "status").mockResolvedValue({ running: false });
     const startSpy = spyOn(manager, "start").mockResolvedValue(undefined);
-    const killSpy = spyOn(process, "kill").mockImplementation(() => true);
 
     try {
       await manager.restart();
 
-      expect(killSpy).not.toHaveBeenCalled();
+      expect(signaler.signals).toEqual([]);
       expect(startSpy).toHaveBeenCalledWith({});
     } finally {
-      killSpy.mockRestore();
       startSpy.mockRestore();
       statusSpy.mockRestore();
     }

--- a/test/daemon/sessionManager.test.ts
+++ b/test/daemon/sessionManager.test.ts
@@ -599,6 +599,44 @@ describe("SessionManager", () => {
       }
     });
 
+    test("publishes live heartbeat and label routing updates after deferred persistence", async () => {
+      const repository = new DeferredDeviceSessionPersistence();
+      const manager = new SessionManager(fakeTimer, repository);
+      const labels = {
+        primary: "session-1",
+        secondary: "session-2",
+      };
+
+      try {
+        await manager.createSession("session-1", "emulator-old", "android", 1_000);
+        manager.setLastHierarchy("session-1", makeHierarchy("old"));
+        manager.setKeepScreenAwake("session-1", { applied: true });
+        repository.deferNextUpsert();
+
+        const rebinding = manager.rebindSession("session-1", "emulator-new", "android");
+        await repository.waitForUpsert();
+
+        fakeTimer.advanceTime(100);
+        manager.setDeviceLabels("session-1", labels);
+        fakeTimer.advanceTime(50);
+        manager.recordHeartbeat("session-1");
+        repository.finishUpsert();
+
+        await expect(rebinding).resolves.toMatchObject({
+          assignedDevice: "emulator-new",
+          lastUsedAt: 150,
+          lastHeartbeat: 150,
+          expiresAt: 1_150,
+          hasReceivedHeartbeat: true,
+          cacheData: { deviceLabels: labels },
+        });
+        expect(manager.getDeviceLabels("session-1")).toEqual(labels);
+        expect(manager.getSession("session-1")?.cacheData).toEqual({ deviceLabels: labels });
+      } finally {
+        manager.stopCleanupTimer();
+      }
+    });
+
     test("serializes expiry cleanup with a pending rebind", async () => {
       const repository = new DeferredDeviceSessionPersistence();
       const manager = new SessionManager(fakeTimer, repository, () => new FakeDbWriteBarrier());

--- a/test/daemon/sessionManager.test.ts
+++ b/test/daemon/sessionManager.test.ts
@@ -173,6 +173,25 @@ describe("SessionManager", () => {
       }
     });
 
+    test("includes a pending creation in the shutdown session snapshot", async () => {
+      const repository = new DeferredDeviceSessionPersistence();
+      const manager = new SessionManager(fakeTimer, repository);
+
+      try {
+        repository.deferNextUpsert();
+        const creating = manager.createSession("pending-shutdown", "emulator-5554", "android");
+        await repository.waitForUpsert();
+
+        expect(manager.getAllSessionIds()).toEqual([]);
+        expect(manager.getAllKnownSessionIds()).toEqual(["pending-shutdown"]);
+
+        repository.finishUpsert();
+        await creating;
+      } finally {
+        manager.stopCleanupTimer();
+      }
+    });
+
     test("keeps ownership unpublished while a creation write is pending", async () => {
       let rejectFirstWrite!: (error: Error) => void;
       const firstWrite = new Promise<void>((_resolve, reject) => {

--- a/test/daemon/sessionManager.test.ts
+++ b/test/daemon/sessionManager.test.ts
@@ -601,7 +601,12 @@ describe("SessionManager", () => {
 
     test("publishes live heartbeat and label routing updates after deferred persistence", async () => {
       const repository = new DeferredDeviceSessionPersistence();
-      const manager = new SessionManager(fakeTimer, repository);
+      const manager = new SessionManager(
+        fakeTimer,
+        repository,
+        undefined,
+        () => ({ restore: async () => {} }),
+      );
       const labels = {
         primary: "session-1",
         secondary: "session-2",
@@ -632,6 +637,33 @@ describe("SessionManager", () => {
         });
         expect(manager.getDeviceLabels("session-1")).toEqual(labels);
         expect(manager.getSession("session-1")?.cacheData).toEqual({ deviceLabels: labels });
+      } finally {
+        manager.stopCleanupTimer();
+      }
+    });
+
+    test("waits for a pending rebind before admitting a new execution", async () => {
+      const repository = new DeferredDeviceSessionPersistence();
+      const manager = new SessionManager(fakeTimer, repository);
+
+      try {
+        await manager.createSession("session-1", "emulator-old", "android");
+        repository.deferNextUpsert();
+
+        const rebinding = manager.rebindSession("session-1", "emulator-new", "android");
+        await repository.waitForUpsert();
+        let resolvedDevice: string | null = null;
+        const resolving = manager.getOrCreateSession("session-1").then((session) => {
+          resolvedDevice = session.assignedDevice;
+          return session;
+        });
+        await Promise.resolve();
+
+        expect(resolvedDevice).toBeNull();
+        repository.finishUpsert();
+
+        await expect(rebinding).resolves.toMatchObject({ assignedDevice: "emulator-new" });
+        await expect(resolving).resolves.toMatchObject({ assignedDevice: "emulator-new" });
       } finally {
         manager.stopCleanupTimer();
       }

--- a/test/daemon/sseKeepaliveAndDisconnect.test.ts
+++ b/test/daemon/sseKeepaliveAndDisconnect.test.ts
@@ -520,6 +520,36 @@ describe("disconnect monitor miss counting", () => {
     expect(forced.has("sim-1")).toBe(false);
   });
 
+  test("retains a replacement force marker when null-captured cleanup finds a pooled device", async () => {
+    const forced = new Set(["sim-1"]);
+    const forceGenerations = new Map([["sim-1", 2]]);
+    const daemon = {
+      devicePool: {
+        getDevice: () => ({}),
+      },
+      deviceDisconnectMisses: new Map([["sim-1", DEVICE_DISCONNECT_MISS_THRESHOLD]]),
+      deviceDisconnectMissIncarnations: new Map([["sim-1", 1]]),
+      confirmedDisconnectedDeviceIds: new Set(["sim-1"]),
+      forceDisconnectedDeviceIds: forced,
+      forceDisconnectedDeviceGenerations: forceGenerations,
+    };
+    const shouldSkipStaleDisconnectCleanup = (
+      Daemon.prototype as unknown as {
+        shouldSkipStaleDisconnectCleanup: (
+          pooledDeviceAtDisconnect: null,
+          deviceId: string,
+          forceGenerationAtDisconnect: number | undefined,
+        ) => Promise<boolean>;
+      }
+    ).shouldSkipStaleDisconnectCleanup;
+
+    await expect(
+      shouldSkipStaleDisconnectCleanup.call(daemon, null, "sim-1", 1),
+    ).resolves.toBe(true);
+    expect(forced.has("sim-1")).toBe(true);
+    expect(forceGenerations.get("sim-1")).toBe(2);
+  });
+
   test("clears disconnect state when cleanup rediscovers the pooled incarnation", async () => {
     const misses = new Map([["emulator-5554", DEVICE_DISCONNECT_MISS_THRESHOLD]]);
     const missIncarnations = new Map([["emulator-5554", 4]]);
@@ -588,6 +618,32 @@ describe("disconnect monitor miss counting", () => {
     await expect(pending).resolves.toBe(true);
     expect(forced.has("emulator-5554")).toBe(true);
     expect(forceGenerations.get("emulator-5554")).toBe(1);
+  });
+
+  test("rejects an old disconnect target after cancellation races a same-ID replacement", () => {
+    const capturedDevice = { assignmentCount: 4 };
+    const replacementDevice = { assignmentCount: 1 };
+    const daemon = {
+      devicePool: {
+        getDevice: () => replacementDevice,
+      },
+      sessionManager: {
+        getSessionForDevice: () => null,
+      },
+    };
+    const isCapturedDisconnectTargetCurrent = (
+      Daemon.prototype as unknown as {
+        isCapturedDisconnectTargetCurrent: (
+          deviceId: string,
+          pooledDeviceAtDisconnect: object,
+          assignmentCountAtDisconnect: number,
+        ) => boolean;
+      }
+    ).isCapturedDisconnectTargetCurrent;
+
+    expect(
+      isCapturedDisconnectTargetCurrent.call(daemon, "emulator-5554", capturedDevice, 4),
+    ).toBe(false);
   });
 
   test("retains disconnect state when cleanup verification is inconclusive", async () => {

--- a/test/fakes/FakeDeviceSessionResolver.ts
+++ b/test/fakes/FakeDeviceSessionResolver.ts
@@ -10,6 +10,10 @@ export class FakeDeviceSessionResolver implements DeviceSessionResolver {
   private readonly uuidToDeviceId = new Map<string, string>();
 
   bind(deviceId: string, deviceSessionUuid: string): this {
+    const previousUuid = this.deviceIdToUuid.get(deviceId);
+    if (previousUuid !== undefined && previousUuid !== deviceSessionUuid) {
+      this.uuidToDeviceId.delete(previousUuid);
+    }
     this.deviceIdToUuid.set(deviceId, deviceSessionUuid);
     this.uuidToDeviceId.set(deviceSessionUuid, deviceId);
     return this;

--- a/test/features/observe/android/CtrlProxyPackages.test.ts
+++ b/test/features/observe/android/CtrlProxyPackages.test.ts
@@ -204,6 +204,9 @@ describe("CtrlProxyPackages (Android)", function() {
         backfilling: false,
         filter: {
           deviceId: testDevice.deviceId,
+          // Device-scoped subscriptions created at the socket boundary always
+          // carry an explicit session filter; null is the all-session sentinel.
+          deviceSessionUuid: null,
           screenshotIntervalMs: null,
           hierarchyIntervalMs: 500,
         },

--- a/test/server/deviceTools.killDevice.test.ts
+++ b/test/server/deviceTools.killDevice.test.ts
@@ -17,9 +17,11 @@ import {
 } from "../../src/server/videoRecordingManager";
 import type { BootedDevice, DeviceInfo } from "../../src/models";
 import { DefaultRetryExecutor } from "../../src/utils/retry/RetryExecutor";
-import { getAbortSignal } from "../../src/utils/AbortContext";
+import { getAbortSignal, runWithAbortSignal } from "../../src/utils/AbortContext";
+import { runWithToolCapabilityContext } from "../../src/features/toolCapabilities/toolCapabilityContext";
 import { IOSCtrlProxyManager } from "../../src/utils/IOSCtrlProxyManager";
 import { DeviceSessionRepository } from "../../src/db/DeviceSessionRepository";
+import { executionTracker } from "../../src/server/executionTracker";
 import { FakeTimer } from "../fakes/FakeTimer";
 import { FakeDeviceUtils } from "../fakes/FakeDeviceUtils";
 import { FakeInstalledAppsRepository } from "../fakes/FakeInstalledAppsRepository";
@@ -462,6 +464,77 @@ describe("killDevice handler", () => {
 
     expect(successfulManager.getCallCount("startDevice")).toBe(1);
     expect(pool.getDevice("emulator-5554")).toBeNull();
+  });
+
+  test("keeps the initiating parallel plan alive while cancelling other execution tracks", async () => {
+    const timer = new FakeTimer();
+    const successfulManager = new SuccessfulKillDeviceManager();
+    manager = successfulManager;
+    const deviceSessionRepository = new FakeDeviceSessionRepository();
+    const image: DeviceInfo = {
+      name: "Pixel 8",
+      platform: "android",
+      deviceId: "emulator-5554",
+      isRunning: false,
+      source: "local",
+    };
+    setDeviceToolsDependencies({
+      deviceManagerFactory: () => successfulManager,
+      notifyResourcesChanged: async () => {},
+      ensureCtrlProxyReady: async () => {},
+      clearInstalledAppsForDevice: async () => {},
+      timer,
+    });
+    sessionManager = new SessionManager(timer, deviceSessionRepository);
+    successfulManager.setDeviceImages("android", [image]);
+    const pool = new DevicePool(
+      sessionManager,
+      "daemon-session",
+      timer,
+      new FakeInstalledAppsRepository(),
+      successfulManager,
+      new DefaultRetryExecutor(timer),
+      deviceSessionRepository,
+    );
+    DaemonState.getInstance().initialize(sessionManager, pool);
+    await pool.assignMultipleDevices(["session-1"], 1_000, "android");
+    const initiatingPlan = executionTracker.startExecution("executePlan", undefined, "session-1");
+    const competingExecution = executionTracker.startExecution("tapOn", undefined, "session-1");
+    const trackAbortController = new AbortController();
+    const parallelTrackSignal = AbortSignal.any([
+      initiatingPlan.abortController.signal,
+      trackAbortController.signal,
+    ]);
+    const tool = ToolRegistry.getTool("killDevice");
+    if (!tool) {
+      throw new Error("killDevice not registered");
+    }
+
+    try {
+      expect(parallelTrackSignal).not.toBe(initiatingPlan.abortController.signal);
+      await runWithToolCapabilityContext(
+        {
+          execution: {
+            executionId: initiatingPlan.id,
+            startTime: initiatingPlan.startTime,
+          },
+        },
+        async () => await runWithAbortSignal(
+          parallelTrackSignal,
+          async () => await tool.handler(
+            { device: { name: image.name, platform: "android", deviceId: image.deviceId! } },
+            undefined,
+            parallelTrackSignal,
+          ),
+        ),
+      );
+
+      expect(initiatingPlan.abortController.signal.aborted).toBe(false);
+      expect(competingExecution.abortController.signal.aborted).toBe(true);
+    } finally {
+      executionTracker.endExecution(initiatingPlan.id);
+      executionTracker.endExecution(competingExecution.id);
+    }
   });
 
   test("bypasses the Android device-list cache while confirming shutdown", async () => {

--- a/test/server/executionTracker.test.ts
+++ b/test/server/executionTracker.test.ts
@@ -84,7 +84,7 @@ describe("ExecutionTracker", function() {
     const cancelled = await tracker.cancelSessionUuidExecutions(
       "session-uuid",
       "device-disconnected:emulator-5554",
-      { excludeSignal: kill.abortController.signal },
+      { excludeExecutionId: kill.id },
     );
 
     expect(cancelled).toBe(1);


### PR DESCRIPTION
## Summary
- Restore safe explicit restart recovery for reachable daemons that lack the caller namespace's PID record, while keeping ordinary start non-destructive.
- Make an explicit daemon restart force-stop live AutoMobile daemon-mode processes from other PID-file namespaces even when the configured socket is unreachable.
- Reinstall device-session stream routing after recovery; reject malformed or unresolved UUID subscriptions without polling unrelated devices; deliver session-scoped navigation updates.
- Preserve plan ownership, session rebind activity/label state, and device/session incarnation identity through shutdown and deferred cleanup.

## Why
Daemon and session lifecycle work can cross namespace, recovery, asynchronous persistence, and same-ID replacement boundaries. An orphaned daemon can no longer serve its socket but still prevent a replacement from starting; an explicit restart now removes those discovered daemon processes before bootstrapping the replacement.

## Validation
- `bun test test/daemon/manager.test.ts`
- `bun run typecheck`
- `bun run build`
- Manual local `--daemon restart` against an unreachable cross-namespace daemon, followed by `--cli observe --platform android`
- `git diff --check`

## Note
The repository-wide `bun run format:check` remains red because the existing formatting baseline reports 1,868 files. This change intentionally avoids unrelated formatting churn.
