### PR TITLE
Add device-session-lifecycle skill

### DIFF
--- a/.claude/commands/device-lifecycle.md
+++ b/.claude/commands/device-lifecycle.md
@@ -1,0 +1,40 @@
+---
+description: Hunt or fix a device session lifecycle bug (startDevice, session UUIDs, boot readiness, shutdown, daemon, pool/session races) using the accumulated bug history and invariants.
+allowed-tools: Bash, Read, Write, Edit, Grep, Glob, Task, WebFetch, Skill
+argument-hint: [issue # | symptom description | "audit <area>"] (optional)
+---
+
+Load and follow the `device-session-lifecycle` skill
+(`skills/device-session-lifecycle/SKILL.md`) — it is the source of truth for
+the identifiers, invariants, recurring bug classes, weak-spot map, and test
+discipline. Its `references/history.md` catalogs every past lifecycle
+issue/PR by era and bug class.
+
+## Input
+
+`$ARGUMENTS` is one of:
+- **An issue number** — read it with `gh issue view`, classify the symptom
+  against the skill's bug classes, check the history catalog for a prior
+  instance, then hunt per the skill's procedure (§4).
+- **A symptom description** — same, starting from the identifier
+  classification step (§1): which of the four identifiers is involved?
+- **`audit <area>`** (e.g. `audit shutdown`, `audit registry retire paths`)
+  — sweep the named area's weak spots (§6) for violations of the invariants
+  (§2), following the audit style of Era 4 (coded findings, one issue per
+  confirmed defect).
+- Empty — ask what to hunt, offering the open threads listed at the end of
+  the skill as candidates.
+
+## Rules
+
+- Before diagnosing, rule out the documented environment artifacts (skill
+  §4.2): daemon-restart transport wedge, multi-worktree daemon churn,
+  DisconnectMonitor auto-restart, stale dist behind a fresh version string.
+- Ground every claim in adb/simctl/process-table/daemon-log evidence, never
+  a tool's `success` flag.
+- A fix is not done until a unit test forces the exact interleaving via the
+  injected seams (FakeTimer/FakeIdGenerator/fakes), and — for anything
+  touching pool runtime identity or streaming — a live-emulator or
+  stream-subscriber check has run (skill §7 blind spots).
+- File issues / open PRs per repo conventions (`skills/ship-issue`,
+  `skills/push-pr`) when the user asks for fixes to land.

--- a/skills/device-session-lifecycle/SKILL.md
+++ b/skills/device-session-lifecycle/SKILL.md
@@ -1,0 +1,278 @@
+---
+name: device-session-lifecycle
+description: "Hunt, fix, and prevent device session lifecycle bugs in AutoMobile: startDevice/killDevice, device session UUIDs, boot readiness, daemon start/stop/restart, session expiry/release, pool state races, and flaky lifecycle tests. Use when a bug involves sessions binding to the wrong device, devices stuck busy/idle/ghost, boot or shutdown hangs, daemon churn or 'Session not found', stream frames routed to the wrong device, or when designing/reviewing changes to devicePool, sessionManager, deviceSessionRegistry, deviceTools, or the daemon proxy."
+---
+
+# Device Session Lifecycle — Hunting & Fixing
+
+The device session layer is where AutoMobile has shipped the most regressions.
+The bug classes repeat; the fixes that stuck follow a small set of patterns.
+This skill encodes both, plus the invariants any change must preserve.
+
+Line refs are against main @ 2026-08-20 (post PR #5419). They drift — verify
+with grep before citing. Full bug history: `references/history.md`.
+
+## 1. Four identifiers, three lifecycles — never conflate them
+
+| Identifier | Minted by | Meaning | Persisted |
+|---|---|---|---|
+| `sessionUuid` | `IdGenerator` in startDevice (`src/server/deviceTools.ts`), autolock (`src/daemon/devicePool.ts`), or client-supplied | **Who is driving**: client/test session owning one device; caches, capability profile | yes (`device_sessions` table) |
+| `deviceSessionUuid` | `src/daemon/deviceSessionRegistry.ts` | **One device connection epoch**: minted per pool incarnation, retired on disconnect, re-minted on reconnect even for the same serial. Stream routing key | no — meaningless across daemon restarts |
+| `__mcpSessionId` | socket-server connection / MCP transport | Per-connection transport identity; implicit autolock resolution | no |
+| `deviceId` (serial/UDID) | adb / simctl | Human label + adb target only. **Mutable across reboots — never an identity key** | n/a |
+
+Three lifecycles overlap: (A) pooled device (`PooledDevice.status` +
+`incarnation` in `devicePool.ts`), (B) device-session epoch (registry),
+(C) MCP/pool session (`sessionManager.ts`). Plus the daemon process itself
+(`manager.ts` / `DaemonLauncher.ts`). Historic conflations: #2599 ("Session
+not found" = transport session, not pool session), #5411 (pool session
+rebind), the #5256 epic (epoch identity was missing entirely).
+
+`incarnation` (bumped only at pooled-entry **creation**) is the sole thing
+distinguishing "same serial, new boot" from "same device". Anything
+identity-sensitive must be keyed on it, with unknown `transportId` treated as
+wildcard (#5372 regression: strict compare broke every Android cold boot).
+
+## 2. Invariants (the contract every fix must preserve)
+
+1. **Epoch identity**: `deviceSessionUuid` = one device connection epoch.
+   Mint idempotent per incarnation; fresh mint on reconnect even with an
+   identical serial; mint correctness must never depend on retire having
+   fired (#5257).
+2. **Retire symmetric with mint**: every removal path (refresh eviction, idle
+   pruning, liveness check, kill, recovery, shutdown) must retire — hang
+   listeners off the single choke point `DevicePool.removeDevice` (#5266).
+   Gate retire on the device actually being gone (`!getDevice`), or
+   same-serial recovery churns UUIDs.
+3. **One bound client ↔ one session ↔ one device.** A session UUID must never
+   silently resume against a different device. Released identities are
+   terminally **fenced**: machine-readable `session_ownership_lost` error,
+   never a rebind (#5411/#5412). Bound MCP proxies heartbeat at 2s.
+4. **Every release names its expected owner**; stale releases are ignored,
+   repeats idempotent (#5348). Sessions with active executions are not reaped
+   (#5343). Expiry retires session + pool ownership together (#5339).
+5. **startDevice readiness is the automation boundary, not OS boot**: a
+   returned session is observe-ready (CtrlProxy installed + healthy) or fails
+   with a phase-labeled ActionableError inside one absolute deadline
+   (#5237/#5238). startDevice is idempotent for an already-bound device
+   (#2421). Fast "already running" paths still verify readiness (#3334).
+6. **killDevice succeeds only after confirmed disappearance + ownership
+   retire** (bounded 30s), incarnation-checked so a fast same-ID replacement
+   isn't destroyed (#5315).
+7. **Session release is a pushed signal, not a TTL guess**: all releases fan
+   out through the SessionManager choke point → `SessionReleaseBroadcaster` →
+   `notifications/session/released`; TTLs are only a backstop (#4655).
+8. **Stream routing**: null filter = all devices; frames for unresolvable
+   devices carry uuid `null` and reach only all-device subscribers; a
+   retired uuid matches nothing (no fall-through to backfill). Consumers
+   enumerate `daemon/listDeviceSessions` first, then rely on
+   `device_session_started/ended` frames — boot-time devices emit no started
+   frame (#5259/#5407).
+9. **Under autolock with >1 candidate, untargeted device-aware calls are
+   rejected** — sessionUuid or explicit deviceId required (#2328).
+10. **Recovery** only touches AutoMobile-owned virtual devices; default 2
+    attempts; env-configured at daemon startup
+    (`AUTOMOBILE_DEVICE_RECOVERY_ON_LOSS`, `..._MAX_ATTEMPTS`) (#4915/#4979).
+11. **Monitors are single-flight** (`SingleFlightInterval` on an injected
+    Timer) — no overlapping ticks (#5317). Daemon shutdown releases sessions
+    through canonical teardown and restores keep-awake best-effort (#5327);
+    stdin close runs the same bounded async shutdown, never `process.exit`
+    (#5326).
+12. **Daemon replacement**: ordinary start is non-destructive; only explicit
+    restart force-stops live daemon-mode processes from other PID-file
+    namespaces, and fails closed on unrelated processes (#5419). Readiness is
+    a positive signal (connect + health), never PID/socket-file existence
+    (#2444).
+13. `setActiveDevice` global routing is legacy compat only; session-bound
+    routing is the model (#4979). No backward compatibility on the
+    daemon↔desktop wire protocol — they ship together (#5256); a skewed old
+    client silently becomes an all-devices subscriber (privacy leak).
+14. UUIDs come only from the injected `IdGenerator` — never `randomUUID()`
+    at call sites (#2663).
+
+## 3. Recurring bug classes → where to look first
+
+1. **Release/teardown asymmetry** — acquire is centralized, release is bolted
+   onto one call site; alternate paths leak state (ghost-busy devices, stale
+   registry entries). Smell: state cleaned in one handler but N removal
+   paths exist. Grep all callers of the acquire; diff against callers of the
+   release. (#2445, #5266, #5287, #5303, #5326)
+2. **ABA / stale actor clobbers replacement** — delayed release, discovery
+   timeout, or callback lands after reassignment. Smell: any `await` between
+   read and mutate of pool/session maps without an expected-owner or
+   incarnation guard. (#5290, #5296, #5289, #5283; regression risk: #5369)
+3. **Success before the observable effect** — "booted" before boot_completed,
+   killDevice success on `adb emu kill` ack, install success on the wrong
+   simulator. Smell: success derived from a command's ack, not from
+   ground-truth polling. (#3334, #3393, #5294, #2387, #5237)
+4. **Identity by mutable key** — serial/UDID/transportId used where an
+   incarnation or epoch UUID belongs. Smell: `deviceId` in a map key for
+   anything longer-lived than one call. (#3393, #5267, #5369, epic #5256)
+5. **Heartbeat bookkeeping vs real liveness** — grace windows,
+   `hasReceivedHeartbeat`, agent think-time gaps. Smell: expiry math with two
+   clocks or two flags. (#2443, #5288, #5411)
+6. **Un-owned children / probes with side effects** — emulator, simctl,
+   xcodebuild processes outliving timeouts; a "probe" that actually boots
+   (#5202's `-verbose` probe left a stale `hardware-qemu.ini.lock`). Smell:
+   spawn without kill-on-timeout/abort; timeout that kills the promise, not
+   the child. (#3938, #3952, #5297)
+7. **Readiness budget vs cold-start reality** — every new bounded budget is
+   eventually exceeded by a cold CI runner. Fix by warm-up **ordering**, not
+   budget inflation. (#3110, #5376)
+8. **Daemon process identity** — clients holding state about a replaced
+   daemon: stale tool caches, "Unknown tool", wedged transports, orphaned
+   cross-namespace daemons blocking replacement. (#2599, #2732, #2444, #5419)
+
+## 4. Hunting procedure
+
+1. **Classify the identifier** involved (table §1) before anything else.
+   Most misdiagnoses start by chasing the wrong session concept.
+2. **Rule out environment artifacts** (all documented, all reproduce as
+   "bugs"):
+   - `Session not found` right after a daemon restart → #2599 transport
+     wedge, not a session bug. Confirm with a second unrelated tool call.
+   - Competing worktree daemons on the shared socket
+     (`/tmp/auto-mobile-daemon-<uid>.sock`) cause build-skew rejects and
+     flag loss — kill strays, re-check (see `skills/manual-test/SKILL.md`
+     Phase 2).
+   - The DisconnectMonitor may auto-restart an emulator you killed by hand.
+   - Stale dist masked by the version string — verify by build hash / dist
+     mtime, never `0.0.x+g<sha>`.
+3. **Ground truth, never the `success` flag**: `adb -s <id> emu avd name`,
+   `getprop sys.boot_completed`, `adb get-state`, `xcrun simctl list`,
+   process table for emulator children, `adb forward --list` for orphaned
+   forwards. Daemon log: grep `ensureDeviceReady`, `session_ownership_lost`,
+   release reasons (`heartbeat-timeout`, `missing-first-heartbeat`,
+   `device-stopped:`, `device-disconnected:`), `need download`.
+4. **Drive via the build-matched CLI** when proxy skew is possible:
+   `bun dist/src/index.js --cli <tool> --<param> <value>`.
+5. **Reproduce the race deterministically in a unit test** with the injected
+   seams (`FakeTimer`, `FakeIdGenerator`, fake pool/clients) before fixing —
+   the repo's races are all await-interleavings, and every landed fix in
+   this area ships with a test that forces the interleaving.
+6. **Check the weak-spot map (§6)** — if your symptom touches one of those
+   sites, read the surrounding invariant comments first; several say
+   explicitly "do not 'fix' this by adding a barrier".
+
+## 5. Fix patterns that stuck / anti-patterns
+
+**Stuck:**
+- Single choke point + listeners: route all removals through
+  `DevicePool.removeDevice`, all releases through `SessionManager`, and hang
+  cross-cutting concerns (registry retire, broadcast) off them.
+- Expected-owner compare-and-act on every mutation; incarnation guards with
+  unknown-field-as-wildcard.
+- Bounded absolute deadline sliced per phase (`DeviceBootService.runPhase`),
+  abort raced against every phase, 1s settlement grace, child killed on
+  timeout.
+- Positive readiness signals at the consumer's boundary.
+- `SingleFlightInterval` for periodic work; re-validate state after every
+  await in unlocked paths.
+- Structured, machine-readable errors (`session_ownership_lost`,
+  `device_already_stopped`, phase-labeled ActionableErrors).
+
+**Anti-patterns (each caused a real regression):**
+- Widening a mutex / adding a barrier to "fix" ordering — breaks the
+  shutdown drain contract (see warnings in `sessionManager.ts`).
+- Tightening identity matching without a wildcard for fields older callers
+  don't populate (#5369).
+- Inflating a readiness budget instead of reordering warm-up (#5376).
+- A probe that boots (#5202); success from an ack (#5294).
+- Retire/cleanup that assumes the device is gone without checking whether
+  recovery already re-created it.
+- Growing a base class surface casually — the typecheck baseline's
+  "…and N more" counts are sensitive to it.
+
+## 6. Weak-spot map (highest bug density first)
+
+- `src/server/deviceTools.ts` ~:594-772 — killDevice late-retirement trio
+  compensates for uncancellable release; 1s post-release recheck window can
+  miss a slow same-ID replacement.
+- `src/daemon/devicePool.ts` — 3.6k-line god object. Known soft spots:
+  intentional-shutdown gating is incarnation-scoped on disconnect but
+  serial-scoped on recovery; `removeDisconnectedDevice` runs outside
+  `assignmentMutex` (re-validate after each await); shutdown-reservation
+  release bypasses the mutex by design; two independent miss-debounce
+  policies (refresh threshold 2 vs monitor 3×5s); hard-coded 60×1s
+  assignment retry loop.
+- `src/daemon/daemonMcpProxy.ts` ~:426-468 — five interacting bound-session
+  caches, each from a distinct in-flight-release bug. Highest-complexity
+  invariant surface in the repo.
+- `src/daemon/daemon.ts` — disconnect cleanup re-checks staleness three
+  times per iteration (each await can invalidate); DB left open if session
+  releases don't drain in 5s; pool init capped at 5s but not cancelled.
+- `src/daemon/sessionManager.ts` — 1s caps on setup drain / keep-awake
+  restore overflow into `pendingDeviceCleanup` quarantine the pool must
+  honor; two "do not add a barrier" comments.
+- `src/utils/android-cmdline-tools/AndroidEmulatorClient.ts` ~:2004-2360 —
+  readiness main loop shares mutable state with a detached background
+  poller; fatal child exit can be observed then re-armed; "multiple
+  emulators with same AVD" is swallowed (can attach readiness to another
+  process's emulator).
+- `src/daemon/manager.ts` + `constants.ts` — readiness probe retry (3×150ms)
+  exists because one failed probe used to unlink a healthy daemon's socket
+  ("dominant cause of devices-not-found after restart"); lockfile takeover
+  has a documented double-race; 10s startup budget vs 5s discovery + 5s/iOS
+  CtrlProxy warmup.
+- `src/daemon/daemonFiles.ts` + `socketPaths.ts` — two parallel socket
+  registries that must move together (#4195).
+- `src/server/utilityTools.ts` setActiveDevice — treats "has sessionId but
+  getSession null" as free-to-take; that's exactly the release-in-flight
+  window.
+
+No TODO/FIXME markers exist in lifecycle code — hazards live in prose
+comments. **A refactor that drops a comment silently drops an invariant.**
+
+## 7. Test discipline
+
+- Unit tests: interface + fake + `FakeTimer`, <100ms, injected
+  `IdGenerator`/`Random`; never resolve the real file-backed DB (guard in
+  `src/db/database.ts`). No per-test retries — fix the seam, don't retry.
+- Force the interleaving: races are tested by pausing at the injected seam
+  (timer tick, deferred promise) and mutating state mid-flight. See
+  `test/server/deviceTools.killDevice.test.ts` (same-ID replacement, late
+  retirement, hung discovery) and `test/daemon/devicePool.test.ts` as the
+  canonical patterns.
+- Harness traps: match socket acks **by request id**, not first-ack;
+  `FakeTimer` auto-fires scheduled intervals when advanced a full period
+  (don't also fire manually); `initializeWithDevices` is deliberately a
+  silent pre-populate (no ready listeners).
+- **Known blind spot**: unit fakes can't represent live adb transport
+  population timing — #5369 shipped green through unit tests. Anything
+  touching pool runtime identity (`transportId`, incarnation matching on
+  real reconnects) needs a live-emulator check: `/manual-test` sweep, or
+  `--cli startDevice`/`killDevice` against a real emulator; with ≥2
+  emulators, sanity-check returned `deviceId` against `adb emu avd name`.
+- Streaming changes (`deviceSessionUuid` stamping, subscription routing)
+  are not exercised by standard device tools — they need a stream
+  subscriber. A streaming-consumer smoke test is a known release-checklist
+  gap; don't mark such changes verified off tool calls alone.
+- Flake classification before re-run: macOS Node-TS contention (#5248)
+  shows as either exit 124 (12-min suite ceiling) or one sub-100ms test
+  blowing its budget; classify via cross-OS comparison + job log.
+  `Publish Android Libraries Snapshot` reddens every merge and is
+  non-blocking.
+
+## 8. Key files
+
+Tool surface: `src/server/deviceTools.ts` (startDevice/killDevice
+choreography), `toolRegistry.ts` (resolution + autolock),
+`ToolExecutionContext.ts`, `SessionToolBinding.ts`, `executionTracker.ts`,
+`sessionReleaseBroadcast.ts`.
+Daemon: `daemon.ts`, `manager.ts`, `DaemonLauncher.ts`, `daemonMcpProxy.ts`,
+`socketServer.ts`, `daemonRequestHandlers.ts`, `constants.ts`,
+`daemonState.ts`.
+State: `devicePool.ts`, `sessionManager.ts`, `deviceSessionRegistry.ts`,
+`deviceSessionResolver.ts`, `SessionHeartbeatMonitor.ts`,
+`SingleFlightInterval.ts`, `poolConfig.ts`,
+`src/db/deviceSessionRepository.ts`.
+Boot/readiness: `src/utils/deviceBootService.ts`, `deviceUtils.ts`,
+`AndroidEmulatorClient.ts`, `SimCtlClient.ts`, `deviceTimeouts.ts`,
+`RunnerReadinessService.ts`, `deviceBootRecovery.ts`.
+Shutdown: `src/processLifecycle.ts`, `shutdownCleanup.ts`,
+`src/daemon/childProcessCleanup.ts`.
+
+History catalog with every issue/PR by era and bug class:
+`references/history.md`. Open threads: epic #5256 items (#5260 push-socket
+auth, #5262 DaemonStreamHub, #5263 workspace keying), #4680/#4881 picker
+boot flow, #4858 daemon status probe, #5415 concurrent screenshot collision.

--- a/skills/device-session-lifecycle/references/history.md
+++ b/skills/device-session-lifecycle/references/history.md
@@ -1,0 +1,160 @@
+# Device Session Lifecycle — Bug History Catalog
+
+Compiled 2026-08-20 from GitHub issues/PRs (through PR #5419, merged
+2026-08-20) and past working sessions. Organized by era, then cross-indexed
+by bug class. Use this to check whether a "new" bug is a recurrence and to
+find the canonical fix pattern.
+
+## Era 1 — Session model origins (autolock, ~#2300–2700)
+
+| Item | Bug | Root cause | Fix |
+|---|---|---|---|
+| PR #2328 | Device-aware calls routed to arbitrary device under autolock | Guard only covered multiple-iOS case | `enforceSessionUuidForAutolock`: require sessionUuid/deviceId when autolock on and >1 candidate |
+| #2387 → #2419 | installApp success but app absent for launchApp | install resolved device via session, launch via platform → two different simulators | One shared resolution path |
+| PR #2421 | Repeated startDevice for a bound device failed | Non-autolock startDevice minted a competing UUID that failed binding (regression from #2419) | Reuse the live session — startDevice idempotent |
+| #2443 | Device held ~30s when client dies pre-first-heartbeat | grace (20s) + heartbeat timeout (10s) before reclaim | Shorter pre-first-heartbeat grace |
+| #2444 | Client hangs on "ready" daemon | Readiness inferred from PID/socket-file existence | Positive-signal readiness: connect + health request |
+| #2445 → #2455 | Phantom devices wedge discovery until daemon restart | `refreshDevices()` only added, never removed; idle entries never liveness-checked | Bidirectional reconcile, prune idle |
+| #2599 | Daemon restart wedges every MCP client ("Session not found") | Socket sessions are per-daemon-process; proxy retries didn't re-register | Treat as recoverable: teardown, reconnect, re-register, retry once (typed transport failures, PR #2739) |
+| #2732 | Wrong-build daemon serves frontend ("Unknown tool") | One socket per uid shared by all checkouts; version gate compared identical strings; tool cache not invalidated | Build-identity handshake (PR #2749), self-heal on unknown tool |
+| #2638 | DisconnectMonitor churns on removed devices + resurrects user-killed emulators | Stale recording refs; miss counters re-counted; warm-up re-boots killed emulators | Clear refs, stop re-warning, don't auto-resurrect |
+| #2663 | — | — | Repo rule: UUIDs only via injected `IdGenerator`, never raw `randomUUID()` |
+
+## Era 2 — Boot correctness (#3300–4000)
+
+| Item | Bug | Root cause | Fix |
+|---|---|---|---|
+| #3334 | "Booted" before OS finished booting; installApp fails "still booting" | Three "already running" fast paths had zero readiness check; Android missed `sys.boot_completed` gating; iOS `simctl list` shows Booted before SpringBoard | Readiness checks on fast paths |
+| #3393 → #3397/#3401 | Cold-boot returns wrong deviceId + false isReady with ≥2 emulators | Name-match fallback picked the *first* running emulator when the new one hadn't attached to adb | Correlate cold boot to the actual launched emulator |
+| #3552 → #3554 | Dead emulator kept being assigned | Pool never evicted on process/adb disappearance | Evict on exit/disappearance |
+| #3553 → #3555 | Stale idle iOS UDIDs assigned | No liveness validation pre-assignment | Validate simulator liveness |
+| #3938 → #3941/#3945 | Command timeouts orphan simctl/emulator/xcodebuild children | Timeout killed the promise, not the child | Kill child on timeout |
+| #3952 → #3954 | Hung boot leaks a half-started device | Readiness failure didn't cancel the start handle | Auto-cancel via `handle.kill()` |
+| #3110 | XCTestRunner "Daemon failed to start within 10000ms" | 10s readiness budget too small on cold macOS runners | Budget/warm-up ordering |
+| #3877/#3943 → #3944 | videoRecording "bare stop" flaked on macOS CI | Module-level singleton let the real file-backed DB be resolved | Inject narrow device detector + real-DB guard |
+| #3640 | CI daemon-lifecycle script false-green | pipeline exit code lost | `PIPESTATUS` fix in `scripts/ci/daemon-lifecycle.sh` |
+
+## Era 3 — Managed sessions, recovery, capability lifecycle (#4600–5250)
+
+| Item | Bug | Root cause | Fix |
+|---|---|---|---|
+| #4610/#4611 → #4626/#4634/#4655 | Capability profiles leaked/bypassed; released plan sessions kept enforcing stale profiles | TTL-guess for release; explicit-deviceId bypass; routing vs capability session conflated | `SessionReleaseBroadcaster` + `notifications/session/released` push; enforcement on every path |
+| #4914 → #4915 | Emulator dies mid-session → pool empty forever | Detect-and-remove only; `PooledDevice` didn't retain avdName | Opt-in same-AVD recovery for pool-owned emulators |
+| #4974 → #4978 | All boot failures collapse into generic 120s timeout | No failure-class detection | Detectors: mprotect/HVF, stuck-offline, tiny-RAM AVD, outdated cmdline-tools |
+| #4979 → #4980 | Session routing vs mutable active-device unsafe for concurrent clients | `setActiveDevice` is global mutable state | Bind MCP connection to a pool session at startup; recovery env vars; setActiveDevice = legacy compat |
+| #4753 → #4888 | Orphaned `adb forward` entries accumulate | Server-side expiry didn't clean host forwards | Sweep orphaned forwards |
+| #5202 | startDevice hangs full 180s on modern AVDs | Arch probe ran a real boot (`-verbose`, 3s timeout, SIGKILL) → stale `hardware-qemu.ini.lock` → "multiple emulators with same AVD" misread as "already starting" | Read ABI from `config.ini`; verify "already starting" registers in adb |
+| #5237 → #5238 | Session returned before automation runner ready; first observes fail | Readiness at OS-boot boundary, not automation boundary | Runner readiness inside startDevice budget; phase-labeled ActionableErrors |
+| #4992/#4999 | Transient adb `offline` failed readiness | Offline treated as terminal | Tolerate transient offline |
+| #4989 → #5245 | WHEP capture lanes red at daemon bring-up on hosted runners | Readiness budget vs runner cold start | Bring-up hardening |
+
+## Era 4 — Lifecycle audit + DeviceSessionRegistry (#5256–5419)
+
+Systematic audit at main@312a1680 produced coded findings (START/SESS/DISC/
+RECV/SHUT), each an issue+PR pair:
+
+| Finding | Issue → PR | Bug | Fix pattern |
+|---|---|---|---|
+| SESS-01 | #5287 → #5339 | Expiry removed session but left device busy (release callback only handled autolock) | Expiry retires session + pool ownership together |
+| SESS-02 | #5288 → #5343 | Heartbeat cleanup reaped sessions with active executions | Active executions block reaping |
+| SESS-03 | #5289 → #5338 | Partial multi-device rollback released devices but left sessions | Owner-checked rollback removes every created session |
+| SESS-04 | #5290 → #5348 | Delayed duplicate release cleared a reassigned device | Every release names expected owner; stale releases ignored |
+| SESS-05 | #5291 → #5342 | Concurrent same-UUID `getOrCreateSession` reserved two devices | Recheck existence after acquiring assignment mutex |
+| SESS-06 | #5292 → #5341 | In-memory ownership mutated before awaited persistence; repo failure left ghost-busy | Restore invariants on persistence failure |
+| DISC-02 | #5294 → #5315 | killDevice success on `adb emu kill` ack, before exit or retire | Bounded 30s wait for disappearance; retire before success; incarnation-checked |
+| RECV-01 | #5296 → #5323 | Startup discovery raced its 5s timeout; late resolution overwrote live assignments | Timed-out discovery can't overwrite; owner-preserving refresh |
+| SHUT-03 | #5302 → #5326 | stdin close called `process.exit(0)`, skipping async shutdown | One idempotent bounded shutdown on stdin end/error/close |
+| SHUT-04 | #5303 → #5327 | Graceful shutdown never released active sessions; keep-awake settings lost | Shutdown releases via canonical teardown, persists terminal state |
+| START-03 | #5281 → #5359 | External abort not raced against non-cooperative boot phases | Abort rejects every phase; late settlement can't bind |
+| START-05 | #5283 → #5358 | Concurrent same-AVD starts: null-handle adopter binds first, owner's cleanup kills shared emulator | Single lifecycle owner; transfer forbids post-transfer kill |
+| — | #5295 → #5317 | Async `setInterval` monitors overlapped ticks | `SingleFlightInterval` on injected Timer |
+| — | #5276→#5360, #5297→#5325, #5280, #5282, #5284–#5286, #5298 | Readiness/recovery long tail: lost diagnostics, un-terminated children on cancel, unbounded readiness ADB calls | Bounded deadlines, child termination, diagnostics persistence |
+
+**DeviceSessionRegistry epic #5256** (no wire-protocol backward compat —
+daemon and desktop ship together):
+
+- #5257 → PR #5265 (keystone): `DeviceSessionRegistry` mints
+  `deviceSessionUuid` per device connection epoch, keyed on
+  `PooledDevice.incarnation`; idempotent per incarnation; in-memory only.
+  In-PR fixes: retire gated on `!devicePool.getDevice(deviceId)` (else
+  same-serial auto-recovery churns the just-minted epoch); startup mint done
+  in the daemon's `initializeDevicePool` path because `initializeWithDevices`
+  is deliberately a silent pre-populate. Latent footgun: `DaemonState
+  .initialize` defaults its registry param — a 2-arg caller silently gets a
+  throwaway registry.
+- #5266 → #5313: retire was asymmetric (only disconnect monitor fired it);
+  refresh eviction / liveness / idle-pruning bypassed it → stale entries.
+  Fix: `onDeviceRemoved` listener on `DevicePool.removeDevice`, the single
+  `devices.delete` choke point; also mint for devices present at startup.
+- #5267 → #5340: fast same-serial reconnect before miss threshold kept the
+  old incarnation → two adb epochs aliased to one UUID. Fix: `transportId`
+  in pool runtime identity.
+- **#5369 → #5372: regression from #5340** — cold boot built
+  `expectedIdentity` without transportId; `undefined !== 23` → identity
+  mismatch on every Android cold boot, emulator torn down. Fix: unknown
+  transportId is a wildcard. **Not caught by unit tests** (needed live adb
+  transport timing).
+- #5258 → #5365: multiplexed subscriptions — `subscriptionId` echoed on
+  subscribe and stamped on every frame (backfill included);
+  unsubscribe/update_cadence per-subscription; pong/close/error
+  per-connection; keepalive one ping per socket. (Pre-existing: five
+  socket-keyed break-after-first-match loops made a second subscription on
+  one socket unreachable.)
+- #5259 → #5407: stamp `deviceSessionUuid` on every stream envelope +
+  `device_session_started/ended` lifecycle frames. Filter rule: null = all
+  devices; retired uuid matches nothing (explicit backfill guard); unknown
+  provenance ⇒ uuid null ⇒ all-device subscribers only (kills #4837
+  navigation cross-contamination). Skew hazard: old deviceId-only subscribe
+  against new daemon silently becomes all-devices. Discovery contract:
+  enumerate `daemon/listDeviceSessions` first; boot-time devices emit no
+  started frame. Wire doc: `docs/design-docs/mcp/daemon/client-screen-control.md`
+  (doc-coupling tests exist).
+- Open: #5260 (push-socket auth + registration-only sessions + ownership
+  re-auth revoking foreign subscribers), #5262 (desktop DaemonStreamHub),
+  #5263 (workspace state keyed on deviceSessionUuid).
+
+**Bound-session fencing:**
+
+- #5411 → #5412: a bound MCP transport's session expired during normal agent
+  think-time (tool activity updated `lastHeartbeat` but not
+  `hasReceivedHeartbeat`; the stdio proxy never sent `daemon/heartbeat`),
+  and lookup could *recreate* the expired UUID against a different device.
+  Fix: proxy heartbeats at 2s while bound; released identities terminally
+  fenced (`session_ownership_lost`, machine-readable, never silent rebind);
+  diagnostic release reasons (`missing-first-heartbeat`,
+  `heartbeat-timeout`).
+
+**PR #5419 (merged 2026-08-20) — "harden lifecycle recovery":**
+
+- Explicit daemon restart force-stops live AutoMobile daemon-mode processes
+  from other PID-file namespaces even when the configured socket is
+  unreachable (orphaned cross-namespace daemons could block replacement);
+  ordinary start stays non-destructive; fails closed on unrelated processes.
+- Reinstalls device-session stream routing after recovery.
+- Rejects malformed/unresolved UUID subscriptions without polling unrelated
+  devices; session-scoped navigation updates.
+- Preserves plan ownership, session rebind activity/label state, and
+  device/session incarnation identity through shutdown and deferred cleanup.
+- Files: daemon.ts, daemonMcpProxy.ts, deviceDataStreamSocketServer.ts,
+  devicePool.ts, manager.ts, sessionManager.ts, deviceTools.ts,
+  executionTracker.ts + 13 test files.
+
+**Related same-week:** #5414 (independent log dir override), #5415
+(screenshot EEXIST collision under concurrent same-device capture), #5416
+(desktop restarts newer daemon at compatible version), #5376 → #5389 (30s
+runner-readiness budget vs ~85s cold CtrlProxy launch — fixed by CI
+*ordering*, not budget inflation), #5248/#5393 (macOS runner contention
+flake classification).
+
+## Cross-index: bug class → instances
+
+1. **Release/teardown asymmetry**: #2445, #5266, #5287, #5302, #5303
+2. **ABA / stale actor**: #5289, #5290, #5296, #5283, (#5369 as the
+   identity-tightening regression)
+3. **Success before observable effect**: #2387, #3334, #3393, #5237, #5294
+4. **Identity by mutable key**: #3393, #5267, #5369, epic #5256
+5. **Heartbeat vs liveness**: #2443, #5288, #5411
+6. **Un-owned children / side-effect probes**: #3938, #3952, #5202, #5297,
+   #5298
+7. **Readiness budget vs cold start**: #3110, #5376, #4989
+8. **Daemon process identity/replacement**: #2444, #2599, #2732, #5419


### PR DESCRIPTION
## Summary
Adds a `device-session-lifecycle` skill documenting the recurring device
session lifecycle bug classes, invariants, and hunting/fix procedure for
startDevice/killDevice, device session UUIDs, boot readiness, daemon
start/stop/restart, and pool/session state races.

## Contents
- `skills/device-session-lifecycle/SKILL.md` — the four identifiers
  (`sessionUuid`/`deviceSessionUuid`/`__mcpSessionId`/serial) and three
  overlapping lifecycles, 14 numbered invariants every fix must preserve,
  8 recurring bug classes with smell → look-here guidance, a hunting
  procedure, fix patterns vs. anti-patterns (each tied to a real
  regression), a weak-spot file map, and test discipline including the
  known unit-test blind spot for live adb transport timing (how #5369
  shipped green).
- `skills/device-session-lifecycle/references/history.md` — full catalog
  of ~30 issues/PRs across four eras (autolock origins → boot correctness
  → managed sessions/recovery → the DeviceSessionRegistry epic #5256 and
  PR #5419), cross-indexed by bug class.
- `.claude/commands/device-lifecycle.md` — thin command entry point.

## Source
Compiled from a fan-out research pass: GitHub issue/PR history, a full
architecture map of the daemon/pool/session code, and end-to-end reads of
four past working sessions (socket-API UUID design, device session
stamping, a manual-test run, and issue triage).

Docs-only change; no source files touched.