### PR TITLE
ci: make runtime-graph clean-room verification a required gate (#5421)

### DIFF
--- a/.github/workflows/pull_request.yml
+++ b/.github/workflows/pull_request.yml
@@ -376,6 +376,11 @@ jobs:
               - '.oxlintrc.json'
               - '.oxfmtrc.json'
               - 'oxlint-plugins/**'
+              # These files define and prepare the runtime-graph verification.
+              # Keep the clean-room check from being skipped when its own
+              # workflow wiring changes.
+              - '.github/workflows/pull_request.yml'
+              - '.github/actions/setup-auto-mobile-npm-package/**'
 
       - name: "Decide if Android jobs should run"
         id: android_should_run

--- a/.github/workflows/pull_request.yml
+++ b/.github/workflows/pull_request.yml
@@ -2395,18 +2395,6 @@ jobs:
 
       - uses: ./.github/actions/setup-auto-mobile-npm-package
 
-      - name: "Verify pinned runtime dependency graph (#5421)"
-        shell: bash
-        run: bash scripts/ci/verify-pinned-runtime-graph.sh
-
-      - name: "Upload Pinned Runtime Graph Report"
-        uses: actions/upload-artifact@v6
-        if: always()
-        with:
-          name: pinned-runtime-graph-report
-          path: ci-logs/pinned-runtime-graph.log
-          retention-days: 90
-
       - name: "Run MCP Benchmarks"
         shell: bash
         run: |
@@ -2845,6 +2833,41 @@ jobs:
             exit 1
           fi
 
+  # Clean-room pack+install proof that a consumer's
+  # `bun install -g @kaeawc/auto-mobile` reproduces the pinned runtime
+  # dependency graph (issue #5421, acceptance criterion 3). Extracted from the
+  # "MCP Benchmarks" job into its own job so it can be rolled up by
+  # runtime-graph-gate below and promoted to a required status check — the
+  # heavy pack+install still runs exactly once per PR. Same gating as
+  # benchmarks (ts_changed, minus the automated sha256-only PRs) so the
+  # verification exercises every source/dependency change without wedging the
+  # SHA256 bump chores.
+  runtime-graph-verification:
+    timeout-minutes: 20
+    name: "Pinned Runtime Graph"
+    runs-on: ubuntu-latest
+    needs: detect-changes
+    if: needs.detect-changes.outputs.ts_changed == 'true' && needs.detect-changes.outputs.sha256_only != 'true'
+    steps:
+      - name: "Git Checkout"
+        uses: actions/checkout@v6
+        with:
+          lfs: false
+
+      - uses: ./.github/actions/setup-auto-mobile-npm-package
+
+      - name: "Verify pinned runtime dependency graph (#5421)"
+        shell: bash
+        run: bash scripts/ci/verify-pinned-runtime-graph.sh
+
+      - name: "Upload Pinned Runtime Graph Report"
+        uses: actions/upload-artifact@v6
+        if: always()
+        with:
+          name: pinned-runtime-graph-report
+          path: ci-logs/pinned-runtime-graph.log
+          retention-days: 90
+
 
   # =============================================================================
   # Gate Jobs for Branch Protection
@@ -3140,6 +3163,45 @@ jobs:
             r="${results[$name]}"
             if [[ "$r" == "failure" || "$r" == "cancelled" ]]; then
               echo "::error::WebRTC gate dependency ${name} = ${r}"
+              fail=1
+            fi
+          done
+          if [[ -n "${fail}" ]]; then
+            echo "One or more jobs failed or were cancelled"
+            exit 1
+          fi
+
+  # Stable roll-up of the clean-room pinned-runtime-graph verification so it can
+  # be promoted to a required check (issue #5421, acceptance criterion 3). The
+  # verification is conditional (runtime-graph-verification runs only on
+  # ts_changed, non-sha256-only PRs); when it is gated out its result is
+  # "skipped" (not failure), so this gate passes and does not wedge PRs that do
+  # not touch the runtime graph. A real verification failure is "failure", which
+  # this gate turns into a merge block. NOTE: advisory until "Pinned Runtime
+  # Graph Gate" is added to the green-main ruleset's required checks — a manual
+  # repo-settings step.
+  runtime-graph-gate:
+    timeout-minutes: 10
+    name: "Pinned Runtime Graph Gate"
+    if: always() && needs.detect-changes.outputs.auto_chore != 'true'
+    needs:
+      - detect-changes
+      - runtime-graph-verification
+    # Roll-up only reads needs.*.result — it needs no token scopes.
+    permissions: {}
+    runs-on: ubuntu-latest
+    steps:
+      - name: "Check results"
+        run: |
+          declare -A results=(
+            [detect-changes]="${{ needs.detect-changes.result }}"
+            [runtime-graph-verification]="${{ needs.runtime-graph-verification.result }}"
+          )
+          fail=
+          for name in "${!results[@]}"; do
+            r="${results[$name]}"
+            if [[ "$r" == "failure" || "$r" == "cancelled" ]]; then
+              echo "::error::Pinned Runtime Graph gate dependency ${name} = ${r}"
               fail=1
             fi
           done

--- a/test/bats/pr-gate-wiring.bats
+++ b/test/bats/pr-gate-wiring.bats
@@ -151,7 +151,7 @@ wiring_requires_yq() {
   # automated sha256-only chores.
   run yq -r '.jobs."runtime-graph-verification".if' "$WF"
   [ "$status" -eq 0 ]
-  [[ "$output" == *"needs.detect-changes.outputs.ts_changed == 'true'"* ]]
+  [ "$output" = "needs.detect-changes.outputs.ts_changed == 'true' && needs.detect-changes.outputs.sha256_only != 'true'" ]
 
   # Preserves the ci-logs artifact upload.
   run yq -r '

--- a/test/bats/pr-gate-wiring.bats
+++ b/test/bats/pr-gate-wiring.bats
@@ -32,12 +32,13 @@ job_block() {
   grep -q '^    name: "iOS Build"$' "$WF"
   grep -q '^    name: "CodeQL"$' "$WF"
   grep -q '^    name: "Shell Tests"$' "$WF"
+  grep -q '^    name: "Pinned Runtime Graph Gate"$' "$WF"
 }
 
 @test "required gates run with always() so they always post a conclusion" {
   # A required check that never posts hangs as "Expected"; always() guarantees a
   # success/failure/skipped conclusion in every path.
-  for job in ios-build-gate codeql-gate shell-tests-gate; do
+  for job in ios-build-gate codeql-gate shell-tests-gate runtime-graph-gate; do
     block="$(job_block "$job")"
     [[ "$block" == *"if: always() &&"* ]]
   done
@@ -64,7 +65,7 @@ job_block() {
   # The whole point of the gate is to go red when a dependency fails; a gate that
   # never `exit 1`s is a permanent false-green. Pin the failure semantics so
   # weakening the loop (e.g. exit 1 -> exit 0) fails this guard.
-  for job in ios-build-gate codeql-gate shell-tests-gate; do
+  for job in ios-build-gate codeql-gate shell-tests-gate runtime-graph-gate; do
     block="$(job_block "$job")"
     [[ -n "$block" ]]
     [[ "$block" == *'"$r" == "failure" || "$r" == "cancelled"'* ]]
@@ -82,6 +83,28 @@ job_block() {
   block="$(job_block shell-tests-gate)"
   [[ "$block" == *"- bats-tests"* ]]
   [[ "$block" == *"needs.bats-tests.result"* ]]
+}
+
+@test "runtime-graph-gate rolls up runtime-graph-verification (#5421)" {
+  block="$(job_block runtime-graph-gate)"
+  [[ "$block" == *"- runtime-graph-verification"* ]]
+  [[ "$block" == *"needs.runtime-graph-verification.result"* ]]
+}
+
+@test "runtime-graph-verification runs the clean-room pinned-graph check exactly once (#5421)" {
+  # The heavy pack+install verification must live in its own required-able job
+  # and NOT be duplicated back into the benchmarks job (it was extracted from
+  # there). Assert exactly one invocation across the whole workflow.
+  count="$(grep -c 'scripts/ci/verify-pinned-runtime-graph.sh' "$WF")"
+  [[ "$count" -eq 1 ]]
+  block="$(job_block runtime-graph-verification)"
+  [[ -n "$block" ]]
+  [[ "$block" == *"scripts/ci/verify-pinned-runtime-graph.sh"* ]]
+  # Gated to the same source/dependency surface as benchmarks, minus the
+  # automated sha256-only chores.
+  [[ "$block" == *"needs.detect-changes.outputs.ts_changed == 'true'"* ]]
+  # Preserves the ci-logs artifact upload.
+  [[ "$block" == *"pinned-runtime-graph-report"* ]]
 }
 
 @test "ios-gate reuses ios-build-gate so build-leg membership is declared once" {

--- a/test/bats/pr-gate-wiring.bats
+++ b/test/bats/pr-gate-wiring.bats
@@ -103,17 +103,38 @@ wiring_requires_yq() {
 @test "runtime-graph-verification runs the clean-room pinned-graph check exactly once (#5421)" {
   # The heavy pack+install verification must live in its own required-able job
   # and NOT be duplicated back into the benchmarks job (it was extracted from
-  # there). Assert exactly one invocation across the whole workflow.
-  count="$(grep -c 'scripts/ci/verify-pinned-runtime-graph.sh' "$WF")"
-  [[ "$count" -eq 1 ]]
-  block="$(job_block runtime-graph-verification)"
-  [[ -n "$block" ]]
-  [[ "$block" == *"scripts/ci/verify-pinned-runtime-graph.sh"* ]]
+  # there). Read parsed `run` fields so a commented-out command cannot satisfy
+  # the guard.
+  wiring_requires_yq
+  run yq -r '
+    [.jobs[] | .steps[]? | .run? | select(. == "bash scripts/ci/verify-pinned-runtime-graph.sh")]
+    | length
+  ' "$WF"
+  [ "$status" -eq 0 ]
+  [ "$output" -eq 1 ]
+
+  run yq -r '
+    .jobs."runtime-graph-verification".steps[]
+    | select(.name == "Verify pinned runtime dependency graph (#5421)")
+    | .run
+  ' "$WF"
+  [ "$status" -eq 0 ]
+  [ "$output" = "bash scripts/ci/verify-pinned-runtime-graph.sh" ]
+
   # Gated to the same source/dependency surface as benchmarks, minus the
   # automated sha256-only chores.
-  [[ "$block" == *"needs.detect-changes.outputs.ts_changed == 'true'"* ]]
+  run yq -r '.jobs."runtime-graph-verification".if' "$WF"
+  [ "$status" -eq 0 ]
+  [[ "$output" == *"needs.detect-changes.outputs.ts_changed == 'true'"* ]]
+
   # Preserves the ci-logs artifact upload.
-  [[ "$block" == *"pinned-runtime-graph-report"* ]]
+  run yq -r '
+    .jobs."runtime-graph-verification".steps[]
+    | select(.name == "Upload Pinned Runtime Graph Report")
+    | .with.name
+  ' "$WF"
+  [ "$status" -eq 0 ]
+  [ "$output" = "pinned-runtime-graph-report" ]
 }
 
 @test "runtime-graph verification runs when its workflow wiring changes (#5421)" {

--- a/test/bats/pr-gate-wiring.bats
+++ b/test/bats/pr-gate-wiring.bats
@@ -28,6 +28,14 @@ job_block() {
   ' "$WF"
 }
 
+ts_filter_block() {
+  awk '
+    /^        id: filter-ts$/ { cap = 1; next }
+    cap && /^      - name: / { exit }
+    cap { print }
+  ' "$WF"
+}
+
 @test "required gate jobs exist with stable context names" {
   grep -q '^    name: "iOS Build"$' "$WF"
   grep -q '^    name: "CodeQL"$' "$WF"
@@ -105,6 +113,13 @@ job_block() {
   [[ "$block" == *"needs.detect-changes.outputs.ts_changed == 'true'"* ]]
   # Preserves the ci-logs artifact upload.
   [[ "$block" == *"pinned-runtime-graph-report"* ]]
+}
+
+@test "runtime-graph verification runs when its workflow wiring changes (#5421)" {
+  block="$(ts_filter_block)"
+  [[ -n "$block" ]]
+  [[ "$block" == *"- '.github/workflows/pull_request.yml'"* ]]
+  [[ "$block" == *"- '.github/actions/setup-auto-mobile-npm-package/**'"* ]]
 }
 
 @test "ios-gate reuses ios-build-gate so build-leg membership is declared once" {

--- a/test/bats/pr-gate-wiring.bats
+++ b/test/bats/pr-gate-wiring.bats
@@ -28,12 +28,13 @@ job_block() {
   ' "$WF"
 }
 
-ts_filter_block() {
-  awk '
-    /^        id: filter-ts$/ { cap = 1; next }
-    cap && /^      - name: / { exit }
-    cap { print }
-  ' "$WF"
+wiring_requires_yq() {
+  command -v yq >/dev/null 2>&1 && return 0
+  if [[ -n "${CI:-}" ]]; then
+    echo "yq is required in CI to verify pull-request workflow wiring" >&2
+    return 1
+  fi
+  skip "yq not installed"
 }
 
 @test "required gate jobs exist with stable context names" {
@@ -116,10 +117,15 @@ ts_filter_block() {
 }
 
 @test "runtime-graph verification runs when its workflow wiring changes (#5421)" {
-  block="$(ts_filter_block)"
-  [[ -n "$block" ]]
-  [[ "$block" == *"- '.github/workflows/pull_request.yml'"* ]]
-  [[ "$block" == *"- '.github/actions/setup-auto-mobile-npm-package/**'"* ]]
+  wiring_requires_yq
+  run yq -r '
+    .jobs."detect-changes".steps[]
+    | select(.id == "filter-ts")
+    | (.with.filters | from_yaml | .ts[])
+  ' "$WF"
+  [ "$status" -eq 0 ]
+  [[ $'\n'"$output"$'\n' == *$'\n.github/workflows/pull_request.yml\n'* ]]
+  [[ $'\n'"$output"$'\n' == *$'\n.github/actions/setup-auto-mobile-npm-package/**\n'* ]]
 }
 
 @test "ios-gate reuses ios-build-gate so build-leg membership is declared once" {

--- a/test/bats/pr-gate-wiring.bats
+++ b/test/bats/pr-gate-wiring.bats
@@ -38,18 +38,29 @@ wiring_requires_yq() {
 }
 
 @test "required gate jobs exist with stable context names" {
-  grep -q '^    name: "iOS Build"$' "$WF"
-  grep -q '^    name: "CodeQL"$' "$WF"
-  grep -q '^    name: "Shell Tests"$' "$WF"
-  grep -q '^    name: "Pinned Runtime Graph Gate"$' "$WF"
+  wiring_requires_yq
+  local job expected
+  for job in ios-build-gate codeql-gate shell-tests-gate runtime-graph-gate; do
+    case "$job" in
+      ios-build-gate) expected="iOS Build" ;;
+      codeql-gate) expected="CodeQL" ;;
+      shell-tests-gate) expected="Shell Tests" ;;
+      runtime-graph-gate) expected="Pinned Runtime Graph Gate" ;;
+    esac
+    run yq -r ".jobs.\"${job}\".name" "$WF"
+    [ "$status" -eq 0 ]
+    [ "$output" = "$expected" ]
+  done
 }
 
 @test "required gates run with always() so they always post a conclusion" {
   # A required check that never posts hangs as "Expected"; always() guarantees a
   # success/failure/skipped conclusion in every path.
+  wiring_requires_yq
   for job in ios-build-gate codeql-gate shell-tests-gate runtime-graph-gate; do
-    block="$(job_block "$job")"
-    [[ "$block" == *"if: always() &&"* ]]
+    run yq -r ".jobs.\"${job}\".if" "$WF"
+    [ "$status" -eq 0 ]
+    [[ "$output" == "always() &&"* ]]
   done
 }
 
@@ -74,11 +85,16 @@ wiring_requires_yq() {
   # The whole point of the gate is to go red when a dependency fails; a gate that
   # never `exit 1`s is a permanent false-green. Pin the failure semantics so
   # weakening the loop (e.g. exit 1 -> exit 0) fails this guard.
+  wiring_requires_yq
   for job in ios-build-gate codeql-gate shell-tests-gate runtime-graph-gate; do
-    block="$(job_block "$job")"
-    [[ -n "$block" ]]
-    [[ "$block" == *'"$r" == "failure" || "$r" == "cancelled"'* ]]
-    [[ "$block" == *"exit 1"* ]]
+    run yq -r "
+      .jobs.\"${job}\".steps[]
+      | select(.name == \"Check results\")
+      | .run
+    " "$WF"
+    [ "$status" -eq 0 ]
+    printf '%s\n' "$output" | grep -Fqx '  if [[ "$r" == "failure" || "$r" == "cancelled" ]]; then'
+    printf '%s\n' "$output" | grep -Fqx '  exit 1'
   done
 }
 
@@ -95,9 +111,19 @@ wiring_requires_yq() {
 }
 
 @test "runtime-graph-gate rolls up runtime-graph-verification (#5421)" {
-  block="$(job_block runtime-graph-gate)"
-  [[ "$block" == *"- runtime-graph-verification"* ]]
-  [[ "$block" == *"needs.runtime-graph-verification.result"* ]]
+  wiring_requires_yq
+  run yq -r '.jobs."runtime-graph-gate".needs[]' "$WF"
+  [ "$status" -eq 0 ]
+  [[ $'\n'"$output"$'\n' == *$'\nruntime-graph-verification\n'* ]]
+
+  run yq -r '
+    .jobs."runtime-graph-gate".steps[]
+    | select(.name == "Check results")
+    | .run
+  ' "$WF"
+  [ "$status" -eq 0 ]
+  printf '%s\n' "$output" \
+    | grep -Fqx '  [runtime-graph-verification]="${{ needs.runtime-graph-verification.result }}"'
 }
 
 @test "runtime-graph-verification runs the clean-room pinned-graph check exactly once (#5421)" {


### PR DESCRIPTION
## Why

[PR #5423](https://github.com/kaeawc/auto-mobile/pull/5423) (issue [#5421](https://github.com/kaeawc/auto-mobile/issues/5421)) added `scripts/ci/verify-pinned-runtime-graph.sh` — a clean-room pack+install check proving a consumer's `bun install -g @kaeawc/auto-mobile` reproduces the pinned runtime dependency graph (acceptance criterion 3).

The gap: that verification runs only as a **step inside the `benchmarks` job ("MCP Benchmarks")**, which is not a required status check. So AC3 is verified in CI but is **not a hard merge blocker** — a regression in the published runtime graph could still merge.

## What

Follows this repo's existing required-gate convention (the `*-gate` roll-up jobs):

- **Extract** the verification out of `benchmarks` into its own dedicated job, `runtime-graph-verification` (`name: "Pinned Runtime Graph"`), `needs: detect-changes`, gated the same way `benchmarks` was (`ts_changed == 'true' && sha256_only != 'true'`), same setup (`./.github/actions/setup-auto-mobile-npm-package`, ubuntu-latest). The `ci-logs/pinned-runtime-graph.log` artifact upload is preserved.
- **Add** a `runtime-graph-gate` roll-up job (`name: "Pinned Runtime Graph Gate"`) mirroring `webrtc-gate` exactly: `if: always() && auto_chore != 'true'`, `needs: [detect-changes, runtime-graph-verification]`, and the shared result loop that fails on `failure`/`cancelled` and treats a legitimately-`skipped` verification as pass.
- The heavy pack+install now **runs exactly once** per PR (removed from `benchmarks`).

A maintainer can then mark the single stable context **"Pinned Runtime Graph Gate"** as required.

### Correctness (hand-simulated)

| PR kind | `runtime-graph-verification` | `runtime-graph-gate` | merge |
|---|---|---|---|
| TS/deps change (`src/**`, `scripts/**`, `package.json`, `bun.lock`) | runs → success/**failure** | reads result; **failure ⇒ exit 1** | **blocked on failure** |
| non-TS change (docs/native only) | `skipped` | skipped ⇒ pass | not wedged |
| automated SHA256-only chore | `skipped` (`sha256_only`) | skipped ⇒ pass | not wedged |
| `detect-changes` fails/cancelled | `skipped` | reads detect-changes = failure ⇒ exit 1 | blocked |
| `auto_chore` PR | — | gate itself skipped (`auto_chore != 'true'`) | not wedged |

The gate does **not** pass merely because the job was skipped-when-it-should-run: the verification is skipped only when it legitimately should not run (no TS/deps change), and the gate reads the real success/failure whenever it does run — identical semantics to the existing `webrtc-gate`.

## Validation

- `bun install --frozen-lockfile`
- `scripts/all_fast_validate_checks.sh --only yaml` → OK
- `test/bats/pr-gate-wiring.bats` (added 3 guards for the new gate) → 10/10 pass; `release-workflow-wiring.bats` + `workflow-artifact-name-uniqueness.bats` → pass
- YAML parse: all `needs:` targets resolve; no dangling references; script referenced exactly once

## Merge order

**Must merge AFTER [#5423](https://github.com/kaeawc/auto-mobile/pull/5423).** This PR is stacked on `work/ship-issue-5421-6e6056` (the branch that introduces the script + benchmarks step). GitHub will auto-retarget this PR's base to `main` once #5423 merges.

## Action required after merge

A maintainer must add the new gate job name **"Pinned Runtime Graph Gate"** to branch protection's required status checks (the green-main ruleset) for the gate to actually block merges — same manual repo-settings step noted for `webrtc-gate`. Until then the gate is advisory.
