### PR TITLE
fix(logging): default logs to temporary directory

### DIFF
--- a/.github/workflows/merge.yml
+++ b/.github/workflows/merge.yml
@@ -578,7 +578,8 @@ jobs:
           install_status=${PIPESTATUS[0]}
           set -e
           mkdir -p ci-logs/daemon-logs
-          daemon_log_dir="${AUTOMOBILE_LOG_DIR:-${TMPDIR:-/tmp}/auto-mobile}"
+          source scripts/lib/auto-mobile-log-dir.sh
+          daemon_log_dir="$(resolve_automobile_log_dir)"
           if [[ -d "${daemon_log_dir}" ]]; then
             cp -R "${daemon_log_dir}/." ci-logs/daemon-logs/ || true
           else

--- a/.github/workflows/merge.yml
+++ b/.github/workflows/merge.yml
@@ -578,8 +578,9 @@ jobs:
           install_status=${PIPESTATUS[0]}
           set -e
           mkdir -p ci-logs/daemon-logs
-          if [[ -d "${HOME}/.auto-mobile/logs" ]]; then
-            cp -R "${HOME}/.auto-mobile/logs/." ci-logs/daemon-logs/ || true
+          daemon_log_dir="${AUTOMOBILE_LOG_DIR:-${TMPDIR:-/tmp}/auto-mobile}"
+          if [[ -d "${daemon_log_dir}" ]]; then
+            cp -R "${daemon_log_dir}/." ci-logs/daemon-logs/ || true
           else
             echo "No daemon logs directory was created" > ci-logs/daemon-logs/README.txt
           fi

--- a/.github/workflows/pull_request.yml
+++ b/.github/workflows/pull_request.yml
@@ -1081,7 +1081,8 @@ jobs:
           install_status=${PIPESTATUS[0]}
           set -e
           mkdir -p ci-logs/daemon-logs
-          daemon_log_dir="${AUTOMOBILE_LOG_DIR:-${TMPDIR:-/tmp}/auto-mobile}"
+          source scripts/lib/auto-mobile-log-dir.sh
+          daemon_log_dir="$(resolve_automobile_log_dir)"
           if [[ -d "${daemon_log_dir}" ]]; then
             cp -R "${daemon_log_dir}/." ci-logs/daemon-logs/ || true
           else
@@ -1993,7 +1994,8 @@ jobs:
         continue-on-error: true
         run: |
           mkdir -p ci-logs/daemon-logs
-          daemon_log_dir="${AUTOMOBILE_LOG_DIR:-${TMPDIR:-/tmp}/auto-mobile}"
+          source scripts/lib/auto-mobile-log-dir.sh
+          daemon_log_dir="$(resolve_automobile_log_dir)"
           if [[ -d "${daemon_log_dir}" ]]; then
             cp -R "${daemon_log_dir}/." ci-logs/daemon-logs/
           fi

--- a/.github/workflows/pull_request.yml
+++ b/.github/workflows/pull_request.yml
@@ -1081,8 +1081,9 @@ jobs:
           install_status=${PIPESTATUS[0]}
           set -e
           mkdir -p ci-logs/daemon-logs
-          if [[ -d "${HOME}/.auto-mobile/logs" ]]; then
-            cp -R "${HOME}/.auto-mobile/logs/." ci-logs/daemon-logs/ || true
+          daemon_log_dir="${AUTOMOBILE_LOG_DIR:-${TMPDIR:-/tmp}/auto-mobile}"
+          if [[ -d "${daemon_log_dir}" ]]; then
+            cp -R "${daemon_log_dir}/." ci-logs/daemon-logs/ || true
           else
             echo "No daemon logs directory was created" > ci-logs/daemon-logs/README.txt
           fi
@@ -1986,16 +1987,24 @@ jobs:
       # Daemon-internal logs (CtrlProxy startup/health/observe timing) are the only
       # way to diagnose iOS observe failures — the swift-test stdout doesn't include
       # them. Upload on failure only (they aren't needed on green runs, and this
-      # avoids publishing env/path details from passing runs). `include-hidden-files`
-      # is required because the logs live under the dot-dir ~/.auto-mobile.
+      # avoids publishing env/path details from passing runs).
+      - name: "Collect AutoMobile daemon logs"
+        if: failure()
+        continue-on-error: true
+        run: |
+          mkdir -p ci-logs/daemon-logs
+          daemon_log_dir="${AUTOMOBILE_LOG_DIR:-${TMPDIR:-/tmp}/auto-mobile}"
+          if [[ -d "${daemon_log_dir}" ]]; then
+            cp -R "${daemon_log_dir}/." ci-logs/daemon-logs/
+          fi
+
       - name: "Upload AutoMobile daemon logs"
         if: failure()
         continue-on-error: true
         uses: actions/upload-artifact@v4
         with:
           name: automobile-daemon-logs-xctestrunner
-          path: ~/.auto-mobile/logs/
-          include-hidden-files: true
+          path: ci-logs/daemon-logs/
           if-no-files-found: ignore
           retention-days: 7
 

--- a/docs/design-docs/mcp/daemon/multi-agent-filesystem-contract.md
+++ b/docs/design-docs/mcp/daemon/multi-agent-filesystem-contract.md
@@ -11,11 +11,9 @@
 > else `os.tmpdir()/auto-mobile` only when no home dir is resolvable. The base is
 > deliberately **not** derived from `TMPDIR`/`TMP`/`TEMP`, because `bunx` can point
 > those at an extraction tree it later reaps while the daemon still holds open
-> fds — the cause of the 0-byte logs and `ENOENT` cache writes in #2724.
+> fds — the cause of the `ENOENT` cache writes in #2724.
 > `AUTOMOBILE_LOG_DIR` / `AUTO_MOBILE_LOG_DIR`, when set, overrides only the
-> core log directory; otherwise logs use
-> `${AUTOMOBILE_DATA_DIR:-~/.auto-mobile}/logs` (or
-> `os.tmpdir()/auto-mobile/logs` when no home directory is resolvable). Paths written
+> core log directory; otherwise logs use `os.tmpdir()/auto-mobile`. Paths written
 > `${TMPDIR}/auto-mobile/...` below are historical; read non-log paths as
 > `${AUTOMOBILE_DATA_DIR:-~/.auto-mobile}/...`.
 
@@ -63,7 +61,7 @@ to a single writer in its own tree. Paths are written `${TMPDIR}/auto-mobile/...
 for historical continuity; resolve them as
 `${AUTOMOBILE_DATA_DIR:-~/.auto-mobile}/...` (see the stable-base-dir note above).
 Core log paths below use `$LOG_DIR`, which resolves to
-`${AUTOMOBILE_LOG_DIR:-${AUTOMOBILE_DATA_DIR:-~/.auto-mobile}/logs}`.
+`${AUTOMOBILE_LOG_DIR:-os.tmpdir()/auto-mobile}`.
 
 | Path / resource | Writers (shared base dir) | Collision risk & mitigation |
 |---|---|---|
@@ -77,7 +75,7 @@ Core log paths below use `$LOG_DIR`, which resolves to
 | `$LOG_DIR/daemon.log` | 1 daemon | stable daemon log; rotated files are `daemon-<timestamp>.log`. |
 | `$LOG_DIR/stdio-<pid>.log` | 1 each | per-stdio-client file; pruning only trims this pid's files + sweeps stale others by mtime. |
 | `${TMPDIR}/auto-mobile/tool_logs` | N | routed through `tempDir` (honors `AUTOMOBILE_DATA_DIR`, not `TMPDIR`). |
-| `$LOG_DIR/daemon-launch-<pid>.log` | 1 per manager | daemon stdout/stderr launch capture, in the **stable** logs dir (was an ephemeral `mkdtemp(tmpdir())` — issue #2724); truncated per launch. |
+| `$LOG_DIR/daemon-launch-<pid>.log` | 1 per manager | daemon stdout/stderr launch capture in the configured log dir; truncated per launch. |
 | `mkdtemp(...)` APK / prefetch dirs | per-call unique | **already safe** (random suffix). |
 
 The daemon enforces exactly one daemon per host per user (single-daemon policy in
@@ -96,12 +94,12 @@ single biggest source of "client can't find the daemon" failures.
 
 ```bash
 # AUTOMOBILE_DATA_DIR should be PER-AGENT (see §4), NOT shared — it scopes each
-# agent's device caches and default log location to a stable, non-ephemeral tree. Daemon
-# discovery does NOT depend on it, so isolating it is free.
+# agent's device caches to a stable, non-ephemeral tree. Daemon discovery does
+# NOT depend on it, so isolating it is free.
 #   export AUTOMOBILE_DATA_DIR=/run/auto-mobile/agent-$AGENT_ID
 
 # Optional: redirect only core logs, without relocating device caches or other state.
-#   export AUTOMOBILE_LOG_DIR=/var/log/auto-mobile
+#   export AUTOMOBILE_LOG_DIR=/var/logs/auto-mobile
 
 # Daemon discovery — MUST match between clients and the daemon, or clients
 # resolve a different socket/PID/lock than the daemon created.
@@ -125,7 +123,7 @@ export AUTOMOBILE_LOG_LEVEL=warn           # quieter shared log in prod
   deleting each other's files.
 - **`AUTOMOBILE_LOG_DIR`** — when set, routes only core daemon/client logs,
   rotated logs, and daemon-launch captures to that directory. It takes
-  precedence over the `logs` child of `AUTOMOBILE_DATA_DIR`; all non-log state
+  precedence over the `os.tmpdir()/auto-mobile` default; all non-log state
   remains data-dir scoped.
 - **`AUTOMOBILE_DAEMON_*` paths** — `daemon/constants.ts` resolves these at
   module load. Default is `/tmp/auto-mobile-daemon-<uid>.{sock,pid,lock}`. If
@@ -174,9 +172,7 @@ give **each agent its own `AUTOMOBILE_DATA_DIR`** and point them all at the
 **same daemon**:
 
 ```bash
-# Per agent: isolated, STABLE base dir (device caches, and logs when
-# AUTOMOBILE_LOG_DIR is unset, never share a directory and survive bunx
-# temp-dir cleanup — issue #2724).
+# Per agent: isolated, STABLE base dir for device caches.
 export AUTOMOBILE_DATA_DIR=/run/auto-mobile/agent-$AGENT_ID
 
 # Same on every agent: the shared daemon is discovered via explicit paths that

--- a/docs/design-docs/mcp/daemon/multi-agent-filesystem-contract.md
+++ b/docs/design-docs/mcp/daemon/multi-agent-filesystem-contract.md
@@ -13,7 +13,7 @@
 > those at an extraction tree it later reaps while the daemon still holds open
 > fds — the cause of the `ENOENT` cache writes in #2724.
 > `AUTOMOBILE_LOG_DIR` / `AUTO_MOBILE_LOG_DIR`, when set, overrides only the
-> core log directory; otherwise logs use `os.tmpdir()/auto-mobile`. Paths written
+> core log directory; otherwise logs use `~/.auto-mobile/logs`. Paths written
 > `${TMPDIR}/auto-mobile/...` below are historical; read non-log paths as
 > `${AUTOMOBILE_DATA_DIR:-~/.auto-mobile}/...`.
 
@@ -61,7 +61,7 @@ to a single writer in its own tree. Paths are written `${TMPDIR}/auto-mobile/...
 for historical continuity; resolve them as
 `${AUTOMOBILE_DATA_DIR:-~/.auto-mobile}/...` (see the stable-base-dir note above).
 Core log paths below use `$LOG_DIR`, which resolves to
-`${AUTOMOBILE_LOG_DIR:-os.tmpdir()/auto-mobile}`.
+`${AUTOMOBILE_LOG_DIR:-~/.auto-mobile/logs}`.
 
 | Path / resource | Writers (shared base dir) | Collision risk & mitigation |
 |---|---|---|
@@ -99,7 +99,7 @@ single biggest source of "client can't find the daemon" failures.
 #   export AUTOMOBILE_DATA_DIR=/run/auto-mobile/agent-$AGENT_ID
 
 # Optional: redirect only core logs, without relocating device caches or other state.
-#   export AUTOMOBILE_LOG_DIR=/var/logs/auto-mobile
+#   export AUTOMOBILE_LOG_DIR=/var/log/auto-mobile
 
 # Daemon discovery — MUST match between clients and the daemon, or clients
 # resolve a different socket/PID/lock than the daemon created.
@@ -123,8 +123,8 @@ export AUTOMOBILE_LOG_LEVEL=warn           # quieter shared log in prod
   deleting each other's files.
 - **`AUTOMOBILE_LOG_DIR`** — when set, routes only core daemon/client logs,
   rotated logs, and daemon-launch captures to that directory. It takes
-  precedence over the `os.tmpdir()/auto-mobile` default; all non-log state
-  remains data-dir scoped.
+  precedence over the `~/.auto-mobile/logs` default; all non-log state remains
+  data-dir scoped.
 - **`AUTOMOBILE_DAEMON_*` paths** — `daemon/constants.ts` resolves these at
   module load. Default is `/tmp/auto-mobile-daemon-<uid>.{sock,pid,lock}`. If
   you override them, override them for **both** sides. The daemon already
@@ -168,12 +168,14 @@ run **one daemon per user** (each gets its own `<uid>` paths automatically).
 ## 4. Per-agent isolation (the primary production recommendation)
 
 Because every agent executes tools in its own process, the robust setup is to
-give **each agent its own `AUTOMOBILE_DATA_DIR`** and point them all at the
-**same daemon**:
+give **each agent its own `AUTOMOBILE_DATA_DIR` and `AUTOMOBILE_LOG_DIR`** and
+point them all at the **same daemon**:
 
 ```bash
 # Per agent: isolated, STABLE base dir for device caches.
 export AUTOMOBILE_DATA_DIR=/run/auto-mobile/agent-$AGENT_ID
+# Per agent: isolate structured and daemon-launch logs too.
+export AUTOMOBILE_LOG_DIR=/run/auto-mobile/agent-$AGENT_ID/logs
 
 # Same on every agent: the shared daemon is discovered via explicit paths that
 # are INDEPENDENT of the data dir, so isolating it does not fragment the daemon.
@@ -205,8 +207,9 @@ cross-agent data loss as defense-in-depth:
 ## 5. Quick checklist
 
 - [ ] All clients + daemon run as the **same OS user**.
-- [ ] **Per-agent `AUTOMOBILE_DATA_DIR`** (preferred), with explicit
-      `AUTOMOBILE_DAEMON_*` paths pointing every agent at the one shared daemon.
+- [ ] **Per-agent `AUTOMOBILE_DATA_DIR` and `AUTOMOBILE_LOG_DIR`** (preferred),
+      with explicit `AUTOMOBILE_DAEMON_*` paths pointing every agent at the one
+      shared daemon.
 - [ ] If overriding `AUTOMOBILE_DAEMON_{SOCKET,PID,LOCK}_FILE_PATH`, set them
       everywhere.
 - [ ] One pinned package version across the fleet.

--- a/docs/design-docs/plat/android/junit-runner/ci-daemon-logs.md
+++ b/docs/design-docs/plat/android/junit-runner/ci-daemon-logs.md
@@ -6,16 +6,24 @@ Use this when debugging **JUnit / YAML plan** runs that talk to the AutoMobile *
 
 ## Where the log file is
 
-When the daemon is started through the normal **`--daemon start` / `restart`** flow, AutoMobile creates a **unique directory under `/tmp`** on the **CI runner** (the machine running Gradle), for example:
+When the daemon is started through the normal **`--daemon start` / `restart`**
+flow, AutoMobile writes logs to **`os.tmpdir()/auto-mobile`** on the CI runner
+(normally `/tmp/auto-mobile` on Linux). Set `AUTOMOBILE_LOG_DIR` to use another
+directory.
 
-`/tmp/auto-mobile-daemon-<random>/daemon.log`
+The structured daemon log is:
 
-Daemon **stdout and stderr** are written to that file.
+`/tmp/auto-mobile/daemon.log`
 
-This is **not** the same path as the Unix socket:
+The daemon manager also captures the daemon process's stdout and stderr per
+launch:
 
-- **Socket (stable):** `/tmp/auto-mobile-daemon-<uid>.sock` (UID = user running the tests, e.g. `id -u` on Linux)
-- **Log file (random subfolder):** use **`find`** or the **`Logs:`** line below
+`/tmp/auto-mobile/daemon-launch-<manager-pid>.log`
+
+This is separate from the Unix socket:
+
+- **Socket:** `/tmp/auto-mobile-daemon-<uid>.sock` (UID = user running the tests, e.g. `id -u` on Linux)
+- **Log directory:** `${AUTOMOBILE_LOG_DIR:-${TMPDIR:-/tmp}/auto-mobile}`
 
 ---
 
@@ -24,12 +32,13 @@ This is **not** the same path as the Unix socket:
 On a successful daemon start, the parent process often prints to **stderr** a line like:
 
 ```text
-Logs: /tmp/auto-mobile-daemon-xxxxx/daemon.log
+Logs: /tmp/auto-mobile/daemon-launch-12345.log
 ```
 
 Search your **CI job log** for **`Logs:`** if Gradle or the wrapper surfaces stderr.
 
-If that line is missing, locate the file with **`find`** (see below).
+If that line is missing, inspect `daemon.log` and `daemon-launch-*.log` in the
+log directory (see below).
 
 ---
 
@@ -40,8 +49,9 @@ Add an **`after_script`** (runs even when tests fail) so the log is visible in t
 ```yaml
 after_script:
   - |
-    echo "=== AutoMobile daemon.log (if any) ==="
-    find /tmp -maxdepth 4 -name daemon.log -path '*auto-mobile-daemon*' 2>/dev/null | while read -r f; do
+    log_dir="${AUTOMOBILE_LOG_DIR:-${TMPDIR:-/tmp}/auto-mobile}"
+    echo "=== AutoMobile daemon logs in $log_dir (if any) ==="
+    find "$log_dir" -maxdepth 1 -type f -name 'daemon*.log' 2>/dev/null | while read -r f; do
       echo "--- $f ---"
       tail -n 500 "$f" || true
     done
@@ -65,8 +75,9 @@ artifacts:
 after_script:
   - mkdir -p daemon-logs
   - |
-    find /tmp -maxdepth 4 -name daemon.log -path '*auto-mobile-daemon*' -print 2>/dev/null | while read -r f; do
-      cp "$f" "daemon-logs/$(basename "$(dirname "$f")").log" || true
+    log_dir="${AUTOMOBILE_LOG_DIR:-${TMPDIR:-/tmp}/auto-mobile}"
+    find "$log_dir" -maxdepth 1 -type f -name 'daemon*.log' -print 2>/dev/null | while read -r f; do
+      cp "$f" daemon-logs/ || true
     done
 ```
 
@@ -80,7 +91,8 @@ Download the job artifact and open the `daemon-logs/*.log` files.
 - name: AutoMobile daemon log
   if: always()
   run: |
-    find /tmp -maxdepth 4 -name daemon.log -path '*auto-mobile-daemon*' 2>/dev/null | while read -r f; do
+    log_dir="${AUTOMOBILE_LOG_DIR:-${TMPDIR:-/tmp}/auto-mobile}"
+    find "$log_dir" -maxdepth 1 -type f -name 'daemon*.log' 2>/dev/null | while read -r f; do
       echo "--- $f ---"
       tail -n 500 "$f" || true
     done
@@ -93,16 +105,17 @@ Download the job artifact and open the `daemon-logs/*.log` files.
 If you have SSH or a debug shell on the same host that ran the daemon:
 
 ```bash
-find /tmp -maxdepth 4 -name daemon.log -path '*auto-mobile-daemon*' 2>/dev/null
-tail -n 200 /tmp/auto-mobile-daemon-XXXXXX/daemon.log
+log_dir="${AUTOMOBILE_LOG_DIR:-${TMPDIR:-/tmp}/auto-mobile}"
+find "$log_dir" -maxdepth 1 -type f -name 'daemon*.log' 2>/dev/null
+tail -n 200 "$log_dir/daemon.log"
 ```
 
 ---
 
 ## Gotchas
 
-- **Same job only:** The log exists on the runner that started the daemon. A **later** CI job does not see that `/tmp` unless you pass an **artifact** or a shared cache (unusual for logs).
-- **Ephemeral runners:** `/tmp` may be wiped between jobs—use **`when: always`** and **`after_script`** on the job that runs tests.
+- **Same job only:** The logs exist on the runner that started the daemon. A **later** CI job does not see `os.tmpdir()` unless you pass an **artifact** or a shared cache (unusual for logs).
+- **Ephemeral runners:** The default temporary directory may be wiped between jobs—use **`when: always`** and **`after_script`** on the job that runs tests.
 - **Enable more noise:** JVM **`automobile.debug=true`** can help surface daemon-related paths and diagnostics in test output; see the JUnit runner README for system properties.
 
 ---

--- a/docs/design-docs/plat/android/junit-runner/ci-troubleshooting-app-launch.md
+++ b/docs/design-docs/plat/android/junit-runner/ci-troubleshooting-app-launch.md
@@ -18,7 +18,8 @@ Grab **everything you can** from the same failing CI run; each source answers a 
 
 **Reading order:** CI log + JUnit output → **`daemon.log`** → **`logcat`** (or reproduce launch locally with adb if CI did not save logcat). If you only keep two artifacts, prefer **`daemon.log`** and **`logcat`** (or CI log if logcat is unavailable).
 
-See [CI daemon logs](ci-daemon-logs.md) for printing or uploading **`daemon.log`** from the runner’s `/tmp`.
+See [CI daemon logs](ci-daemon-logs.md) for printing or uploading **`daemon.log`**
+from the runner's default `os.tmpdir()/auto-mobile` directory.
 
 ---
 

--- a/docs/design-docs/plat/android/junit-runner/ci-troubleshooting-app-launch.md
+++ b/docs/design-docs/plat/android/junit-runner/ci-troubleshooting-app-launch.md
@@ -19,7 +19,7 @@ Grab **everything you can** from the same failing CI run; each source answers a 
 **Reading order:** CI log + JUnit output → **`daemon.log`** → **`logcat`** (or reproduce launch locally with adb if CI did not save logcat). If you only keep two artifacts, prefer **`daemon.log`** and **`logcat`** (or CI log if logcat is unavailable).
 
 See [CI daemon logs](ci-daemon-logs.md) for printing or uploading **`daemon.log`**
-from the runner's default `os.tmpdir()/auto-mobile` directory.
+from the runner's default `~/.auto-mobile/logs` directory.
 
 ---
 

--- a/docs/design-docs/plat/android/junit-runner/diagnosing-daemon-mcp-connectivity.md
+++ b/docs/design-docs/plat/android/junit-runner/diagnosing-daemon-mcp-connectivity.md
@@ -24,14 +24,16 @@ When the daemon log includes **`Full error: {"code":"ConnectionRefused",…}`**,
 
 When **`automobile.debug=true`** (or your CI already prints it), stderr often includes:
 
-- **`Logs: /tmp/auto-mobile-daemon-…/daemon.log`**
+- **`Logs: /tmp/auto-mobile/daemon-launch-<pid>.log`**
 
 Open that file on the failed job artifact or add a step to **`cat`** it after tests. Look for:
 
 - **`Error forwarding request to MCP server`** — confirms the failure is the **HTTP MCP client**, not ADB or YAML.
 - The **stack trace** immediately after that line.
 
-If you do not have the path in logs, search under **`/tmp`** for **`auto-mobile-daemon`** or **`daemon.log`** in the job’s post-failure script.
+If you do not have the path in logs, search
+**`${AUTOMOBILE_LOG_DIR:-${TMPDIR:-/tmp}/auto-mobile}`** for `daemon*.log` in
+the job’s post-failure script.
 
 ### 2. Check proxy environment variables
 

--- a/docs/design-docs/plat/android/junit-runner/diagnosing-daemon-mcp-connectivity.md
+++ b/docs/design-docs/plat/android/junit-runner/diagnosing-daemon-mcp-connectivity.md
@@ -24,7 +24,7 @@ When the daemon log includes **`Full error: {"code":"ConnectionRefused",…}`**,
 
 When **`automobile.debug=true`** (or your CI already prints it), stderr often includes:
 
-- **`Logs: /tmp/auto-mobile/daemon-launch-<pid>.log`**
+- **`Logs: ~/.auto-mobile/logs/daemon-launch-<pid>.log`**
 
 Open that file on the failed job artifact or add a step to **`cat`** it after tests. Look for:
 
@@ -32,8 +32,9 @@ Open that file on the failed job artifact or add a step to **`cat`** it after te
 - The **stack trace** immediately after that line.
 
 If you do not have the path in logs, search
-**`${AUTOMOBILE_LOG_DIR:-${TMPDIR:-/tmp}/auto-mobile}`** for `daemon*.log` in
-the job’s post-failure script.
+the resolved directory from
+[CI daemon logs](ci-daemon-logs.md#resolve-the-log-directory-in-shell) for
+`daemon*.log` in the job’s post-failure script.
 
 ### 2. Check proxy environment variables
 

--- a/docs/faq.md
+++ b/docs/faq.md
@@ -40,8 +40,9 @@ No. Almost all functionality works without adding the Android AutoMobile SDK to 
 
 | Location | Contents |
 |----------|----------|
-| `/tmp/auto-mobile/` | Logs, caches (host machine) |
-| `~/.auto-mobile/sqlite.db` | Navigation graph, tool history, test records, performance records |
+| `os.tmpdir()/auto-mobile/` | Structured daemon/client logs and daemon-launch captures (overridable with `AUTOMOBILE_LOG_DIR`) |
+| `~/.auto-mobile/` | Caches, screenshots, tool outputs, and other non-log state (overridable with `AUTOMOBILE_DATA_DIR`) |
+| `~/.auto-mobile/auto-mobile.db` | Navigation graph, tool history, test records, performance records |
 
 Logs rotate at 10MB. Observe caches expire after a short TTL.
 

--- a/docs/faq.md
+++ b/docs/faq.md
@@ -40,7 +40,7 @@ No. Almost all functionality works without adding the Android AutoMobile SDK to 
 
 | Location | Contents |
 |----------|----------|
-| `os.tmpdir()/auto-mobile/` | Structured daemon/client logs and daemon-launch captures (overridable with `AUTOMOBILE_LOG_DIR`) |
+| `~/.auto-mobile/logs/` | Structured daemon/client logs and daemon-launch captures (overridable with `AUTOMOBILE_LOG_DIR`) |
 | `~/.auto-mobile/` | Caches, screenshots, tool outputs, and other non-log state (overridable with `AUTOMOBILE_DATA_DIR`) |
 | `~/.auto-mobile/auto-mobile.db` | Navigation graph, tool history, test records, performance records |
 

--- a/docs/using/environment-variables.md
+++ b/docs/using/environment-variables.md
@@ -16,18 +16,22 @@ unset.
 | Variable | Legacy alias | Purpose | Default |
 |----------|--------------|---------|---------|
 | `AUTOMOBILE_DATA_DIR` | `AUTO_MOBILE_DATA_DIR` | Stable base directory for AutoMobile's non-log state, including caches, screenshots, and `tool_logs`. | `~/.auto-mobile` |
-| `AUTOMOBILE_LOG_DIR` | `AUTO_MOBILE_LOG_DIR` | Directory for structured daemon/client logs, rotated logs, and daemon-launch captures. Takes precedence over the default without relocating any non-log state. Relative paths resolve from the daemon's launch working directory. | `os.tmpdir()/auto-mobile` |
+| `AUTOMOBILE_LOG_DIR` | `AUTO_MOBILE_LOG_DIR` | Directory for structured daemon/client logs, rotated logs, and daemon-launch captures. Takes precedence over the default without relocating any non-log state. Relative paths resolve from the daemon's launch working directory. | `~/.auto-mobile/logs` |
 
 When no home directory is available and `AUTOMOBILE_DATA_DIR` is unset, the data
-directory falls back to `os.tmpdir()/auto-mobile`. Logs always default to
-`os.tmpdir()/auto-mobile` unless `AUTOMOBILE_LOG_DIR` is set.
+directory falls back to `os.tmpdir()/auto-mobile`. Logs default to
+`~/.auto-mobile/logs`, inside the owner-controlled AutoMobile directory rather
+than a shared temporary root. If no home directory is available, the log
+directory falls back to `/tmp/auto-mobile-<uid>` on Unix or the system temporary
+directory on Windows. If the default log directory cannot be initialized and
+`AUTOMOBILE_DATA_DIR` is set, logs fall back to `<AUTOMOBILE_DATA_DIR>/logs`.
 
 For example, keep durable state under one path while routing only logs to a
 location collected by your deployment:
 
 ```bash
 export AUTOMOBILE_DATA_DIR=/var/lib/automobile
-export AUTOMOBILE_LOG_DIR=/var/logs/auto-mobile
+export AUTOMOBILE_LOG_DIR=/var/log/auto-mobile
 ```
 
 ## Database location & behavior (`AUTOMOBILE_DB_*`)

--- a/docs/using/environment-variables.md
+++ b/docs/using/environment-variables.md
@@ -15,19 +15,19 @@ unset.
 
 | Variable | Legacy alias | Purpose | Default |
 |----------|--------------|---------|---------|
-| `AUTOMOBILE_DATA_DIR` | `AUTO_MOBILE_DATA_DIR` | Stable base directory for AutoMobile's non-log state, including caches, screenshots, `tool_logs`, and the default log location. | `~/.auto-mobile` |
-| `AUTOMOBILE_LOG_DIR` | `AUTO_MOBILE_LOG_DIR` | Directory for structured daemon/client logs, rotated logs, and daemon-launch captures. Takes precedence over the `logs` child of `AUTOMOBILE_DATA_DIR` without relocating any non-log state. Relative paths resolve from the daemon's launch working directory. | `${AUTOMOBILE_DATA_DIR:-~/.auto-mobile}/logs` |
+| `AUTOMOBILE_DATA_DIR` | `AUTO_MOBILE_DATA_DIR` | Stable base directory for AutoMobile's non-log state, including caches, screenshots, and `tool_logs`. | `~/.auto-mobile` |
+| `AUTOMOBILE_LOG_DIR` | `AUTO_MOBILE_LOG_DIR` | Directory for structured daemon/client logs, rotated logs, and daemon-launch captures. Takes precedence over the default without relocating any non-log state. Relative paths resolve from the daemon's launch working directory. | `os.tmpdir()/auto-mobile` |
 
 When no home directory is available and `AUTOMOBILE_DATA_DIR` is unset, the data
-directory falls back to `os.tmpdir()/auto-mobile`; the default log directory is
-then `os.tmpdir()/auto-mobile/logs`.
+directory falls back to `os.tmpdir()/auto-mobile`. Logs always default to
+`os.tmpdir()/auto-mobile` unless `AUTOMOBILE_LOG_DIR` is set.
 
 For example, keep durable state under one path while routing only logs to a
 location collected by your deployment:
 
 ```bash
 export AUTOMOBILE_DATA_DIR=/var/lib/automobile
-export AUTOMOBILE_LOG_DIR=/var/log/automobile
+export AUTOMOBILE_LOG_DIR=/var/logs/auto-mobile
 ```
 
 ## Database location & behavior (`AUTOMOBILE_DB_*`)

--- a/scripts/benchmark-startup.sh
+++ b/scripts/benchmark-startup.sh
@@ -20,6 +20,10 @@
 #   0 - All benchmarks passed or no comparisons were requested
 #   1 - One or more regressions detected or error occurred
 
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+# shellcheck source=scripts/lib/auto-mobile-log-dir.sh disable=SC1091
+source "$SCRIPT_DIR/lib/auto-mobile-log-dir.sh"
+
 DEFAULT_TIMEOUT_MS=15000
 GLOBAL_TIMEOUT_MS=30000
 MCP_PROTOCOL_VERSION="2024-11-05"
@@ -117,7 +121,8 @@ global_timeout_handler() {
   echo "" >&2
 
   # Show daemon logs in the same location used by the runtime.
-  local automobile_log_dir="${AUTOMOBILE_LOG_DIR:-${TMPDIR:-/tmp}/auto-mobile}"
+  local automobile_log_dir
+  automobile_log_dir="$(resolve_automobile_log_dir)"
   for log_file in "$automobile_log_dir"/daemon*.log; do
     if [[ -f "$log_file" && -s "$log_file" ]]; then
       echo "Daemon log ($log_file):" >&2

--- a/scripts/benchmark-startup.sh
+++ b/scripts/benchmark-startup.sh
@@ -116,10 +116,11 @@ global_timeout_handler() {
   fi
   echo "" >&2
 
-  # Show any stderr logs collected
-  for log_file in /tmp/auto-mobile-*/stderr.log; do
+  # Show daemon logs in the same location used by the runtime.
+  local automobile_log_dir="${AUTOMOBILE_LOG_DIR:-${TMPDIR:-/tmp}/auto-mobile}"
+  for log_file in "$automobile_log_dir"/daemon*.log; do
     if [[ -f "$log_file" && -s "$log_file" ]]; then
-      echo "Stderr log ($log_file):" >&2
+      echo "Daemon log ($log_file):" >&2
       tail -n 30 "$log_file" 2>/dev/null | sed 's/^/  /' >&2 || true
       echo "" >&2
     fi

--- a/scripts/lib/auto-mobile-log-dir.sh
+++ b/scripts/lib/auto-mobile-log-dir.sh
@@ -1,56 +1,10 @@
-# Reading the AutoMobile daemon log in CI
+#!/usr/bin/env bash
+# Resolve the same AutoMobile log directory that the TypeScript runtime uses.
 
-Use this when debugging **JUnit / YAML plan** runs that talk to the AutoMobile **daemon** (local checkout via `AUTOMOBILE_DAEMON_LOCAL_PROJECT_PATH` or `bunx @kaeawc/auto-mobile`). The daemon log is the highest-signal place to see **`[LaunchApp]`**, **`CTRL_PROXY`**, **`ConnectionRefused`**, and other server-side errors.
-
----
-
-## Where the log file is
-
-When the daemon is started through the normal **`--daemon start` / `restart`**
-flow, AutoMobile writes logs to **`~/.auto-mobile/logs`** on the CI runner. Set
-`AUTOMOBILE_LOG_DIR` to use another directory.
-
-The structured daemon log is:
-
-`~/.auto-mobile/logs/daemon.log`
-
-The daemon manager also captures the daemon process's stdout and stderr per
-launch:
-
-`~/.auto-mobile/logs/daemon-launch-<manager-pid>.log`
-
-This is separate from the Unix socket:
-
-- **Socket:** `/tmp/auto-mobile-daemon-<uid>.sock` (UID = user running the tests, e.g. `id -u` on Linux)
-- **Log directory:** `AUTOMOBILE_LOG_DIR` (or legacy `AUTO_MOBILE_LOG_DIR`) when
-  set; otherwise `~/.auto-mobile/logs`.
-
----
-
-## How to see the exact path
-
-On a successful daemon start, the parent process often prints to **stderr** a line like:
-
-```text
-Logs: /home/ci/.auto-mobile/logs/daemon-launch-12345.log
-```
-
-Search your **CI job log** for **`Logs:`** if Gradle or the wrapper surfaces stderr.
-
-If that line is missing, inspect `daemon.log` and `daemon-launch-*.log` in the
-log directory (see below).
-
----
-
-## Resolve the log directory in shell
-
-Use this Bash helper before the snippets below. It follows the runtime’s
-override precedence, whitespace handling, relative-path anchoring, and
-owner-controlled default.
-
-```bash
 normalize_automobile_log_dir_path() {
-  local root="/" path component last_index protected_component_count=0
+  local root="/"
+  local path
+  local protected_component_count=0
   if [[ "${2:-}" == "preserve-unc" && "$1" == //* ]]; then
     root="//"
     path="${1#//}"
@@ -58,22 +12,38 @@ normalize_automobile_log_dir_path() {
   else
     path="${1#/}"
   fi
+  local component
+  local last_index
   local -a components=()
+
   while [[ -n "$path" ]]; do
     component="${path%%/*}"
-    if [[ "$path" == */* ]]; then path="${path#*/}"; else path=""; fi
+    if [[ "$path" == */* ]]; then
+      path="${path#*/}"
+    else
+      path=""
+    fi
+
     case "$component" in
-      ""|.) ;;
+      ""|.)
+        ;;
       ..)
         if (( ${#components[@]} > protected_component_count )); then
           last_index=$((${#components[@]} - 1))
           unset "components[$last_index]"
         fi
         ;;
-      *) components+=("$component") ;;
+      *)
+        components+=("$component")
+        ;;
     esac
   done
-  if (( ${#components[@]} == 0 )); then printf '%s\n' "$root"; return; fi
+
+  if (( ${#components[@]} == 0 )); then
+    printf '%s\n' "$root"
+    return
+  fi
+
   local IFS="/"
   printf '%s%s\n' "$root" "${components[*]}"
 }
@@ -95,10 +65,12 @@ automobile_unix_home_dir() {
   local user_id
   user_id="$(id -u 2>/dev/null || true)"
   [[ -n "$user_id" ]] || return
+
   if command -v getent >/dev/null 2>&1; then
     getent passwd "$user_id" | awk -F: 'NR == 1 { print $6 }'
     return
   fi
+
   if command -v dscl >/dev/null 2>&1; then
     local user_name
     user_name="$(id -un 2>/dev/null || true)"
@@ -137,6 +109,7 @@ automobile_windows_temp_dir() {
     automobile_windows_path_to_bash_path "$temp_dir"
     return
   fi
+
   temp_dir="${temp_dir//\\//}"
   if [[ "$temp_dir" != /* ]]; then
     temp_dir="$(automobile_daemon_launch_dir)/$temp_dir"
@@ -159,6 +132,7 @@ automobile_windows_rooted_path_from_launch_dir() {
     normalize_automobile_log_dir_path "${launch_dir:0:2}/${rooted_path#/}"
     return
   fi
+
   if [[ "$launch_dir" == //* ]]; then
     local unc_path="${launch_dir#//}"
     local unc_server="${unc_path%%/*}"
@@ -169,6 +143,7 @@ automobile_windows_rooted_path_from_launch_dir() {
       return
     fi
   fi
+
   normalize_automobile_log_dir_path "$rooted_path"
 }
 
@@ -188,6 +163,7 @@ automobile_directory_is_creatable() {
     fi
     return
   fi
+
   while [[ ! -e "$directory" && ! -L "$directory" && "$directory" != "/" ]]; do
     if [[ "$directory" == */* ]]; then
       directory="${directory%/*}"
@@ -208,6 +184,7 @@ resolve_automobile_log_dir() {
   fi
   log_dir="${log_dir#"${log_dir%%[![:space:]]*}"}"
   log_dir="${log_dir%"${log_dir##*[![:space:]]}"}"
+
   if [[ -n "$log_dir" ]]; then
     if [[ "${OS:-}" == "Windows_NT" ]]; then
       if automobile_is_windows_path "$log_dir"; then
@@ -220,10 +197,12 @@ resolve_automobile_log_dir() {
         return
       fi
     fi
+
     if [[ "$log_dir" = /* ]]; then
       normalize_automobile_log_dir_path "$log_dir"
       return
     fi
+
     local launch_dir
     launch_dir="$(automobile_daemon_launch_dir)"
     if [[ "${OS:-}" == "Windows_NT" && "$launch_dir" == //* ]]; then
@@ -246,6 +225,7 @@ resolve_automobile_log_dir() {
   elif [[ -z "$home_dir" ]]; then
     home_dir="$(automobile_unix_home_dir)"
   fi
+
   if [[ -n "$home_dir" ]]; then
     local launch_dir
     launch_dir="$(automobile_daemon_launch_dir)"
@@ -310,93 +290,3 @@ resolve_automobile_log_dir() {
   user_id="$(id -u 2>/dev/null || printf 'default')"
   printf '/tmp/auto-mobile-%s\n' "$user_id"
 }
-```
-
----
-
-## GitLab CI: print the log in the job output
-
-Add an **`after_script`** (runs even when tests fail) so the log is visible in the job log:
-
-```yaml
-after_script:
-  - |
-    # Define resolve_automobile_log_dir as shown above.
-    log_dir="$(resolve_automobile_log_dir)"
-    echo "=== AutoMobile daemon logs in $log_dir (if any) ==="
-    find "$log_dir" -maxdepth 1 -type f -name 'daemon*.log' 2>/dev/null | while read -r f; do
-      echo "--- $f ---"
-      tail -n 500 "$f" || true
-    done
-```
-
-Adjust **`tail -n`** if you need more lines.
-
----
-
-## GitLab CI: save logs as a downloadable artifact
-
-Useful when logs are large or you want to attach them to a ticket:
-
-```yaml
-artifacts:
-  when: always
-  paths:
-    - daemon-logs/
-  expire_in: 3 days
-
-after_script:
-  - mkdir -p daemon-logs
-  - |
-    # Define resolve_automobile_log_dir as shown above.
-    log_dir="$(resolve_automobile_log_dir)"
-    find "$log_dir" -maxdepth 1 -type f -name 'daemon*.log' -print 2>/dev/null | while read -r f; do
-      cp "$f" daemon-logs/ || true
-    done
-```
-
-Download the job artifact and open the `daemon-logs/*.log` files.
-
----
-
-## GitHub Actions (same idea)
-
-```yaml
-- name: AutoMobile daemon log
-  if: always()
-  run: |
-    # Define resolve_automobile_log_dir as shown above.
-    log_dir="$(resolve_automobile_log_dir)"
-    find "$log_dir" -maxdepth 1 -type f -name 'daemon*.log' 2>/dev/null | while read -r f; do
-      echo "--- $f ---"
-      tail -n 500 "$f" || true
-    done
-```
-
----
-
-## One-off on a shell session
-
-If you have SSH or a debug shell on the same host that ran the daemon:
-
-```bash
-# Define resolve_automobile_log_dir as shown above.
-log_dir="$(resolve_automobile_log_dir)"
-find "$log_dir" -maxdepth 1 -type f -name 'daemon*.log' 2>/dev/null
-tail -n 200 "$log_dir/daemon.log"
-```
-
----
-
-## Gotchas
-
-- **Same job only:** The logs exist on the runner that started the daemon. A **later** CI job does not see `os.tmpdir()` unless you pass an **artifact** or a shared cache (unusual for logs).
-- **Ephemeral runners:** The default temporary directory may be wiped between jobs—use **`when: always`** and **`after_script`** on the job that runs tests.
-- **Enable more noise:** JVM **`automobile.debug=true`** can help surface daemon-related paths and diagnostics in test output; see the JUnit runner README for system properties.
-
----
-
-## Related
-
-- [CI Integration](ci-integration.md) — clone/build AutoMobile, env vars, Gradle wiring
-- [Diagnosing daemon MCP connectivity](diagnosing-daemon-mcp-connectivity.md) — socket path, health check, transport errors

--- a/src/daemon/daemon.ts
+++ b/src/daemon/daemon.ts
@@ -403,7 +403,7 @@ export class Daemon {
   async start(): Promise<void> {
     // Mirror structured daemon logs to stdout/stderr capture as well. The
     // primary log is `<configured log dir>/daemon.log` (defaulting to
-    // `os.tmpdir()/auto-mobile/daemon.log`); the daemon manager also redirects
+    // `~/.auto-mobile/logs/daemon.log`); the daemon manager also redirects
     // stdout/stderr to a per-start capture file in that same dir.
     logger.enableStdoutLogging();
     const stableWorkingDirectory = resolveStableDaemonWorkingDirectory();

--- a/src/daemon/daemon.ts
+++ b/src/daemon/daemon.ts
@@ -402,9 +402,9 @@ export class Daemon {
    */
   async start(): Promise<void> {
     // Mirror structured daemon logs to stdout/stderr capture as well. The
-    // primary stable log is `<configured log dir>/daemon.log` (defaulting to
-    // `<auto-mobile data dir>/logs/daemon.log`); the daemon manager also
-    // redirects stdout/stderr to a per-start capture file in that same dir.
+    // primary log is `<configured log dir>/daemon.log` (defaulting to
+    // `os.tmpdir()/auto-mobile/daemon.log`); the daemon manager also redirects
+    // stdout/stderr to a per-start capture file in that same dir.
     logger.enableStdoutLogging();
     const stableWorkingDirectory = resolveStableDaemonWorkingDirectory();
     process.env[DAEMON_LAUNCH_CWD_ENV] ??= safeProcessCwd(stableWorkingDirectory);

--- a/src/daemon/manager.ts
+++ b/src/daemon/manager.ts
@@ -9,7 +9,7 @@ import {
   INCOMPLETE_EXTRACTION_CODE,
   INCOMPLETE_EXTRACTION_EXIT_CODE,
 } from "../db/migrationDependencyIntegrity";
-import { ensureSecureLogsDirSync, resolveAutoMobileLogsDir } from "../utils/tempDir";
+import { ensureSecureLogsDirSync } from "../utils/tempDir";
 import { outputReductionFlagsToArgs } from "../utils/outputReductionFlags";
 import {
   EVENT_ALL_MARKERS_FLAG,
@@ -359,6 +359,7 @@ export class DaemonManager implements DaemonManagerLike {
   private readonly launcher: DaemonLauncher;
   private readonly fallbackLauncher: DaemonLauncher;
   private readonly launchCommandResolver: (() => DaemonLaunchCommand) | undefined;
+  private readonly ensureLogsDir: () => string;
   private heldLockLogPath: string | undefined;
 
   constructor(
@@ -373,6 +374,7 @@ export class DaemonManager implements DaemonManagerLike {
     extractionCleaner: ExtractionCleaner = fileSystemExtractionCleaner,
     launcher: DaemonLauncher | (() => DaemonLaunchCommand) | undefined = undefined,
     processSignaler: DaemonProcessSignaler = defaultDaemonProcessSignaler,
+    ensureLogsDir: () => string = ensureSecureLogsDirSync,
   ) {
     this.stateProvider = stateProvider;
     this.timer = timer;
@@ -392,6 +394,7 @@ export class DaemonManager implements DaemonManagerLike {
     }
     this.processSignaler = processSignaler;
     this.extractionCleaner = extractionCleaner;
+    this.ensureLogsDir = ensureLogsDir;
     this.launchCommandResolver = typeof launcher === "function" ? launcher : undefined;
     this.launcher = (typeof launcher === "object" ? launcher : undefined) ?? new DaemonLauncher({
       spawn: processSpawner?.spawn.bind(processSpawner),
@@ -592,7 +595,6 @@ export class DaemonManager implements DaemonManagerLike {
     // owner-only (0o700) by ensureSecureLogsDirSync, so a fixed, predictable
     // filename inside it is not exposed to other users.
     const logPath = this.heldLockLogPath ?? this.daemonLaunchLogPath();
-    ensureSecureLogsDirSync();
     // Open with restricted permissions (0o600 = owner read/write only).
     // Truncate per launch so a single manager's bootstrap captures don't grow
     // unbounded across restarts.
@@ -829,7 +831,7 @@ export class DaemonManager implements DaemonManagerLike {
   }
 
   private daemonLaunchLogPath(): string {
-    return join(resolveAutoMobileLogsDir(), `daemon-launch-${process.pid}.log`);
+    return join(this.ensureLogsDir(), `daemon-launch-${process.pid}.log`);
   }
 
   private async createDaemonExitFailure(

--- a/src/models/ActionableError.ts
+++ b/src/models/ActionableError.ts
@@ -2,8 +2,8 @@
  If thrown, the MCP server will catch it and send the message to the client.
  */
 export class ActionableError extends Error {
-  constructor(message: string) {
-    super(message);
+  constructor(message: string, options?: ErrorOptions) {
+    super(message, options);
   }
 }
 

--- a/src/utils/tempDir.ts
+++ b/src/utils/tempDir.ts
@@ -3,12 +3,11 @@
  *
  * Provides consistent, secure working directory creation with restrictive
  * permissions. The base resolves to a STABLE, non-ephemeral location so that
- * long-lived state (daemon logs, persistent caches) survives package-runner
- * temp-dir cleanup. When AutoMobile is launched via `bunx`, `os.tmpdir()` can
- * point into an extraction tree that bunx later reaps while the daemon still
- * holds open file descriptors — leaving on-disk logs at 0 bytes and cache
- * writes failing with ENOENT (issue #2724). Anchoring on the user's home dir
- * (`~/.auto-mobile`) avoids that lifecycle entirely.
+ * long-lived non-log state (persistent caches) survives package-runner temp-dir
+ * cleanup. When AutoMobile is launched via `bunx`, `os.tmpdir()` can point into
+ * an extraction tree that bunx later reaps while the daemon still holds open
+ * file descriptors, so persistent state is anchored on the user's home dir
+ * (`~/.auto-mobile`).
  */
 
 import fs from "node:fs";
@@ -61,10 +60,11 @@ export function resolveAutoMobileBaseDir(
 /**
  * Resolve the directory for structured and daemon-launch logs.
  *
- * A log-dir override intentionally takes precedence over the data-dir-derived
- * logs child without changing the base directory for any other AutoMobile
- * state. Relative overrides are anchored to the daemon launch directory so a
- * manager and its spawned daemon agree even after the daemon changes cwd.
+ * A log-dir override intentionally takes precedence over the default without
+ * changing the base directory for any other AutoMobile state. Without an
+ * override, logs use `os.tmpdir()/auto-mobile`. Relative overrides are anchored
+ * to the daemon launch directory so a manager and its spawned daemon agree even
+ * after the daemon changes cwd.
  */
 export function resolveAutoMobileLogsDir(
   env: NodeJS.ProcessEnv = process.env,
@@ -76,7 +76,7 @@ export function resolveAutoMobileLogsDir(
     return path.resolve(daemonLaunchWorkingDirectory, override);
   }
 
-  return path.join(resolveAutoMobileBaseDir(env, homeDir), TEMP_SUBDIRS.LOGS);
+  return path.join(os.tmpdir(), "auto-mobile");
 }
 
 /**

--- a/src/utils/tempDir.ts
+++ b/src/utils/tempDir.ts
@@ -13,6 +13,7 @@
 import fs from "node:fs";
 import os from "os";
 import path from "path";
+import { ActionableError } from "../models/ActionableError";
 import { resolveDaemonLaunchWorkingDirectory } from "./workingDirectory";
 
 /**
@@ -20,6 +21,23 @@ import { resolveDaemonLaunchWorkingDirectory } from "./workingDirectory";
  * Prevents other users from accessing auto-mobile files.
  */
 const SECURE_DIR_MODE = 0o700;
+
+function defaultAutoMobileLogsDir(homeDir: string, daemonLaunchWorkingDirectory: string): string {
+  if (homeDir && homeDir.length > 0) {
+    return path.resolve(daemonLaunchWorkingDirectory, homeDir, ".auto-mobile", "logs");
+  }
+
+  const userId = process.platform === "win32"
+    ? os.userInfo().username || "default"
+    : process.getuid?.()?.toString() || "default";
+  const temporaryRoot = process.platform === "win32" ? os.tmpdir() : "/tmp";
+  return path.join(temporaryRoot, `auto-mobile-${userId}`);
+}
+
+function resolveAutoMobileLogsDirOverride(env: NodeJS.ProcessEnv): string | undefined {
+  const override = (env.AUTOMOBILE_LOG_DIR ?? env.AUTO_MOBILE_LOG_DIR)?.trim();
+  return override && override.length > 0 ? override : undefined;
+}
 
 /**
  * Resolve the stable base directory for AutoMobile's non-log on-disk state.
@@ -43,15 +61,16 @@ const SECURE_DIR_MODE = 0o700;
  */
 export function resolveAutoMobileBaseDir(
   env: NodeJS.ProcessEnv = process.env,
-  homeDir: string = os.homedir()
+  homeDir: string = os.homedir(),
+  daemonLaunchWorkingDirectory: string = resolveDaemonLaunchWorkingDirectory(undefined, env)
 ): string {
   const override = (env.AUTOMOBILE_DATA_DIR ?? env.AUTO_MOBILE_DATA_DIR)?.trim();
   if (override && override.length > 0) {
-    return path.resolve(override);
+    return path.resolve(daemonLaunchWorkingDirectory, override);
   }
 
   if (homeDir && homeDir.length > 0) {
-    return path.join(homeDir, ".auto-mobile");
+    return path.resolve(daemonLaunchWorkingDirectory, homeDir, ".auto-mobile");
   }
 
   return path.join(os.tmpdir(), "auto-mobile");
@@ -62,21 +81,25 @@ export function resolveAutoMobileBaseDir(
  *
  * A log-dir override intentionally takes precedence over the default without
  * changing the base directory for any other AutoMobile state. Without an
- * override, logs use `os.tmpdir()/auto-mobile`. Relative overrides are anchored
- * to the daemon launch directory so a manager and its spawned daemon agree even
- * after the daemon changes cwd.
+ * override, logs use the owner-controlled `~/.auto-mobile/logs` directory.
+ * If that directory cannot be initialized and `AUTOMOBILE_DATA_DIR` is set,
+ * initialization falls back to `<data-dir>/logs`. This avoids both
+ * package-runner temporary-directory cleanup and a predictable directory entry
+ * in a shared system temporary root. Relative overrides are anchored to the
+ * daemon launch directory so a manager and its spawned daemon agree even after
+ * the daemon changes cwd.
  */
 export function resolveAutoMobileLogsDir(
   env: NodeJS.ProcessEnv = process.env,
   homeDir: string = os.homedir(),
   daemonLaunchWorkingDirectory: string = resolveDaemonLaunchWorkingDirectory(undefined, env)
 ): string {
-  const override = (env.AUTOMOBILE_LOG_DIR ?? env.AUTO_MOBILE_LOG_DIR)?.trim();
-  if (override && override.length > 0) {
+  const override = resolveAutoMobileLogsDirOverride(env);
+  if (override) {
     return path.resolve(daemonLaunchWorkingDirectory, override);
   }
 
-  return path.join(os.tmpdir(), "auto-mobile");
+  return defaultAutoMobileLogsDir(homeDir, daemonLaunchWorkingDirectory);
 }
 
 /**
@@ -117,8 +140,41 @@ export function ensureSecureTempDirSync(subdirectory: string): string {
 /**
  * Synchronously ensure the shared log directory exists with restrictive permissions.
  */
-export function ensureSecureLogsDirSync(): string {
-  return ensureSecureDirectorySync(resolveAutoMobileLogsDir());
+export function ensureSecureLogsDirSync(
+  env: NodeJS.ProcessEnv = process.env,
+  homeDir: string = os.homedir()
+): string {
+  try {
+    const daemonLaunchWorkingDirectory = resolveDaemonLaunchWorkingDirectory(undefined, env);
+    const logsDir = resolveAutoMobileLogsDir(env, homeDir, daemonLaunchWorkingDirectory);
+    try {
+      return ensureSecureDirectorySync(logsDir);
+    } catch (error) {
+      if (resolveAutoMobileLogsDirOverride(env)) {
+        throw error;
+      }
+
+      const dataDirLogs = path.join(
+        resolveAutoMobileBaseDir(env, homeDir, daemonLaunchWorkingDirectory),
+        "logs"
+      );
+      if (dataDirLogs === logsDir) {
+        throw error;
+      }
+      return ensureSecureDirectorySync(dataDirLogs);
+    }
+  } catch (error) {
+    if (error instanceof Error && error.message.includes("symbolic-link directory")) {
+      throw new ActionableError(
+        "Refusing to use symbolic-link directory for AutoMobile logs",
+        { cause: error }
+      );
+    }
+    throw new ActionableError(
+      "Unable to initialize the AutoMobile log directory. Set AUTOMOBILE_LOG_DIR to a writable directory.",
+      { cause: error }
+    );
+  }
 }
 
 // Common subdirectory constants for consistency

--- a/test/bats/auto-mobile-log-dir.bats
+++ b/test/bats/auto-mobile-log-dir.bats
@@ -1,0 +1,501 @@
+#!/usr/bin/env bats
+
+LIB="scripts/lib/auto-mobile-log-dir.sh"
+
+@test "prefers a trimmed AUTOMOBILE_LOG_DIR over the legacy alias" {
+  run bash -c '
+    source "$1"
+    AUTOMOBILE_LOG_DIR="  /var/log/auto-mobile  "
+    AUTO_MOBILE_LOG_DIR="/legacy/logs"
+    resolve_automobile_log_dir
+  ' _ "$LIB"
+
+  [ "$status" -eq 0 ]
+  [ "$output" = "/var/log/auto-mobile" ]
+}
+
+@test "resolves a relative legacy override from the daemon launch directory" {
+  run bash -c '
+    source "$1"
+    AUTO_MOBILE_LOG_DIR=" logs/daemon "
+    AUTOMOBILE_DAEMON_LAUNCH_CWD="/workspace/auto-mobile"
+    resolve_automobile_log_dir
+  ' _ "$LIB"
+
+  [ "$status" -eq 0 ]
+  [ "$output" = "/workspace/auto-mobile/logs/daemon" ]
+}
+
+@test "normalizes dot segments in a relative override" {
+  run bash -c '
+    source "$1"
+    AUTOMOBILE_LOG_DIR="missing/../logs"
+    AUTOMOBILE_DAEMON_LAUNCH_CWD="/workspace/auto-mobile"
+    resolve_automobile_log_dir
+  ' _ "$LIB"
+
+  [ "$status" -eq 0 ]
+  [ "$output" = "/workspace/auto-mobile/logs" ]
+}
+
+@test "trims the daemon launch directory before resolving a relative override" {
+  run bash -c '
+    source "$1"
+    AUTOMOBILE_LOG_DIR="logs"
+    AUTOMOBILE_DAEMON_LAUNCH_CWD="  /workspace/auto-mobile  "
+    resolve_automobile_log_dir
+  ' _ "$LIB"
+
+  [ "$status" -eq 0 ]
+  [ "$output" = "/workspace/auto-mobile/logs" ]
+}
+
+@test "uses the owner-controlled home directory when no override is set" {
+  run bash -c '
+    source "$1"
+    HOME="/home/tester"
+    resolve_automobile_log_dir
+  ' _ "$LIB"
+
+  [ "$status" -eq 0 ]
+  [ "$output" = "/home/tester/.auto-mobile/logs" ]
+}
+
+@test "uses an owned home log directory that runtime can repair" {
+  run bash -c '
+    source "$1"
+    tmp="$(mktemp -d)"
+    trap "chmod 700 \"$tmp/home/.auto-mobile/logs\" 2>/dev/null || true; rm -rf \"$tmp\"" EXIT
+    HOME="$tmp/home"
+    AUTOMOBILE_DATA_DIR="$tmp/data"
+    mkdir -p "$HOME/.auto-mobile/logs"
+    chmod 000 "$HOME/.auto-mobile/logs"
+    resolve_automobile_log_dir
+  ' _ "$LIB"
+
+  [ "$status" -eq 0 ]
+  [[ "$output" == */home/.auto-mobile/logs ]]
+}
+
+@test "normalizes dot segments in an absolute home directory" {
+  run bash -c '
+    source "$1"
+    tmp="$(mktemp -d)"
+    trap "rm -rf \"$tmp\"" EXIT
+    HOME="$tmp/missing/../actual"
+    resolve_automobile_log_dir
+  ' _ "$LIB"
+
+  [ "$status" -eq 0 ]
+  [[ "$output" == */actual/.auto-mobile/logs ]]
+}
+
+@test "treats an empty primary override as authoritative over the legacy alias" {
+  run bash -c '
+    source "$1"
+    HOME="/home/tester"
+    AUTOMOBILE_LOG_DIR=""
+    AUTO_MOBILE_LOG_DIR="/legacy/logs"
+    resolve_automobile_log_dir
+  ' _ "$LIB"
+
+  [ "$status" -eq 0 ]
+  [ "$output" = "/home/tester/.auto-mobile/logs" ]
+}
+
+@test "converts an absolute Windows override to a Git Bash path" {
+  run bash -c '
+    source "$1"
+    OS="Windows_NT"
+    AUTOMOBILE_LOG_DIR="C:\\logs\\auto-mobile"
+    cygpath() {
+      [ "$1" = "-u" ]
+      [ "$2" = "C:\\logs\\auto-mobile" ]
+      printf "/c/logs/auto-mobile\n"
+    }
+    resolve_automobile_log_dir
+  ' _ "$LIB"
+
+  [ "$status" -eq 0 ]
+  [ "$output" = "/c/logs/auto-mobile" ]
+}
+
+@test "converts a drive-relative Windows override with Windows path semantics" {
+  run bash -c '
+    source "$1"
+    OS="Windows_NT"
+    AUTOMOBILE_LOG_DIR="C:logs"
+    cygpath() {
+      [ "$1" = "-u" ]
+      [ "$2" = "C:logs" ]
+      printf "/c/daemon-cwd/logs\n"
+    }
+    resolve_automobile_log_dir
+  ' _ "$LIB"
+
+  [ "$status" -eq 0 ]
+  [ "$output" = "/c/daemon-cwd/logs" ]
+}
+
+@test "converts a forward-slash UNC Windows override to a Git Bash path" {
+  run bash -c '
+    source "$1"
+    OS="Windows_NT"
+    AUTOMOBILE_LOG_DIR="//server/share/logs"
+    cygpath() {
+      [ "$1" = "-u" ]
+      [ "$2" = "//server/share/logs" ]
+      printf "//server/share/logs\n"
+    }
+    resolve_automobile_log_dir
+  ' _ "$LIB"
+
+  [ "$status" -eq 0 ]
+  [ "$output" = "//server/share/logs" ]
+}
+
+@test "resolves a slash-rooted Windows override from the launch drive" {
+  run bash -c '
+    source "$1"
+    OS="Windows_NT"
+    AUTOMOBILE_LOG_DIR="/c/logs"
+    AUTOMOBILE_DAEMON_LAUNCH_CWD="D:\\launch"
+    cygpath() {
+      [ "$1" = "-u" ]
+      [ "$2" = "D:\\launch" ]
+      printf "/d/launch\n"
+    }
+    resolve_automobile_log_dir
+  ' _ "$LIB"
+
+  [ "$status" -eq 0 ]
+  [ "$output" = "/d/c/logs" ]
+}
+
+@test "uses the Windows profile directory for the default in Git Bash" {
+  run bash -c '
+    source "$1"
+    OS="Windows_NT"
+    USERPROFILE="C:\\Users\\tester"
+    cygpath() {
+      [ "$1" = "-u" ]
+      [ "$2" = "C:\\Users\\tester" ]
+      printf "/c/Users/tester\n"
+    }
+    resolve_automobile_log_dir
+  ' _ "$LIB"
+
+  [ "$status" -eq 0 ]
+  [ "$output" = "/c/Users/tester/.auto-mobile/logs" ]
+}
+
+@test "uses HOMEDRIVE and HOMEPATH when the Windows profile variable is unset" {
+  run bash -c '
+    source "$1"
+    OS="Windows_NT"
+    unset HOME USERPROFILE
+    HOMEDRIVE="D:"
+    HOMEPATH="\\Users\\tester"
+    cygpath() {
+      [ "$1" = "-u" ]
+      [ "$2" = "D:\\Users\\tester" ]
+      printf "/d/Users/tester\n"
+    }
+    resolve_automobile_log_dir
+  ' _ "$LIB"
+
+  [ "$status" -eq 0 ]
+  [ "$output" = "/d/Users/tester/.auto-mobile/logs" ]
+}
+
+@test "uses the Windows temp directory and username when no account home is available" {
+  run bash -c '
+    source "$1"
+    OS="Windows_NT"
+    unset HOME USERPROFILE HOMEDRIVE HOMEPATH
+    USERNAME="tester"
+    TEMP="C:\\Windows\\Temp"
+    cygpath() {
+      [ "$1" = "-u" ]
+      [ "$2" = "C:\\Windows\\Temp" ]
+      printf "/c/Windows/Temp\n"
+    }
+    resolve_automobile_log_dir
+  ' _ "$LIB"
+
+  [ "$status" -eq 0 ]
+  [ "$output" = "/c/Windows/Temp/auto-mobile-tester" ]
+}
+
+@test "resolves the Unix account home when HOME is unset" {
+  run bash -c '
+    source "$1"
+    unset HOME
+    id() {
+      if [ "$1" = "-u" ]; then
+        printf "4242\n"
+      else
+        printf "tester\n"
+      fi
+    }
+    getent() {
+      [ "$1" = "passwd" ]
+      [ "$2" = "4242" ]
+      printf "tester:x:4242:4242:Tester:/home/tester:/bin/bash\n"
+    }
+    resolve_automobile_log_dir
+  ' _ "$LIB"
+
+  [ "$status" -eq 0 ]
+  [ "$output" = "/home/tester/.auto-mobile/logs" ]
+}
+
+@test "preserves spaces in the macOS account home when HOME is unset" {
+  run bash -c '
+    source "$1"
+    unset HOME
+    id() {
+      if [ "$1" = "-u" ]; then
+        printf "4242\n"
+      else
+        printf "tester\n"
+      fi
+    }
+    command() {
+      if [ "$1" = "-v" ] && [ "$2" = "getent" ]; then
+        return 1
+      fi
+      if [ "$1" = "-v" ] && [ "$2" = "dscl" ]; then
+        return 0
+      fi
+      builtin command "$@"
+    }
+    dscl() {
+      [ "$1" = "." ]
+      [ "$2" = "-read" ]
+      [ "$3" = "/Users/tester" ]
+      [ "$4" = "NFSHomeDirectory" ]
+      printf "NFSHomeDirectory: /Volumes/My Disk/tester\n"
+    }
+    resolve_automobile_log_dir
+  ' _ "$LIB"
+
+  [ "$status" -eq 0 ]
+  [ "$output" = "/Volumes/My Disk/tester/.auto-mobile/logs" ]
+}
+
+@test "falls back to the configured data directory when the home is unusable" {
+  run bash -c '
+    source "$1"
+    HOME="/dev/null"
+    AUTOMOBILE_DATA_DIR="/tmp/auto-mobile-data"
+    resolve_automobile_log_dir
+  ' _ "$LIB"
+
+  [ "$status" -eq 0 ]
+  [ "$output" = "/tmp/auto-mobile-data/logs" ]
+}
+
+@test "falls back from a missing top-level home component without looping" {
+  run bash -c '
+    source "$1"
+    HOME="/nonexistent"
+    AUTOMOBILE_DATA_DIR="/tmp/auto-mobile-data"
+    resolve_automobile_log_dir
+  ' _ "$LIB"
+
+  [ "$status" -eq 0 ]
+  [ "$output" = "/tmp/auto-mobile-data/logs" ]
+}
+
+@test "resolves a relative home path without hanging" {
+  run bash -c '
+    source "$1"
+    expected="/tmp/auto-mobile-data/logs"
+    HOME="relative"
+    AUTOMOBILE_DATA_DIR="/tmp/auto-mobile-data"
+    AUTOMOBILE_DAEMON_LAUNCH_CWD="/launch"
+    ( sleep 1; kill -TERM "$$" 2>/dev/null ) &
+    watchdog="$!"
+    trap "kill \"$watchdog\" 2>/dev/null || true" EXIT
+    result="$(resolve_automobile_log_dir)"
+    result_status="$?"
+    kill "$watchdog" 2>/dev/null || true
+    wait "$watchdog" 2>/dev/null || true
+    trap - EXIT
+    [ "$result_status" -eq 0 ]
+    [ "$result" = "$expected" ]
+  ' _ "$LIB"
+
+  [ "$status" -eq 0 ]
+}
+
+@test "anchors a relative data fallback to the daemon launch directory" {
+  run bash -c '
+    source "$1"
+    HOME="/dev/null"
+    AUTOMOBILE_DATA_DIR="relative-data"
+    AUTOMOBILE_DAEMON_LAUNCH_CWD="/launch"
+    resolve_automobile_log_dir
+  ' _ "$LIB"
+
+  [ "$status" -eq 0 ]
+  [ "$output" = "/launch/relative-data/logs" ]
+}
+
+@test "falls back from a symlinked home log directory" {
+  run bash -c '
+    source "$1"
+    tmp="$(mktemp -d)"
+    trap "rm -rf \"$tmp\"" EXIT
+    HOME="$tmp/home"
+    AUTOMOBILE_DATA_DIR="$tmp/data"
+    mkdir -p "$HOME/.auto-mobile" "$tmp/target"
+    ln -s "$tmp/target" "$HOME/.auto-mobile/logs"
+    resolve_automobile_log_dir
+  ' _ "$LIB"
+
+  [ "$status" -eq 0 ]
+  [[ "$output" == */data/logs ]]
+}
+
+@test "falls back from a dangling home-directory symlink" {
+  run bash -c '
+    source "$1"
+    tmp="$(mktemp -d)"
+    trap "rm -rf \"$tmp\"" EXIT
+    HOME="$tmp/home"
+    AUTOMOBILE_DATA_DIR="$tmp/data"
+    mkdir -p "$HOME"
+    ln -s "$tmp/missing" "$HOME/.auto-mobile"
+    resolve_automobile_log_dir
+  ' _ "$LIB"
+
+  [ "$status" -eq 0 ]
+  [[ "$output" == */data/logs ]]
+}
+
+@test "falls back when an existing home log directory cannot be secured" {
+  run bash -c '
+    source "$1"
+    tmp="$(mktemp -d)"
+    trap "rm -rf \"$tmp\"" EXIT
+    HOME="$tmp/home"
+    AUTOMOBILE_DATA_DIR="$tmp/data"
+    mkdir -p "$HOME/.auto-mobile/logs"
+    automobile_directory_is_owned_by_current_user() { return 1; }
+    resolve_automobile_log_dir
+  ' _ "$LIB"
+
+  [ "$status" -eq 0 ]
+  [[ "$output" == */data/logs ]]
+}
+
+@test "converts a drive-absolute Windows data fallback to a Git Bash path" {
+  run bash -c '
+    source "$1"
+    OS="Windows_NT"
+    HOME="/dev/null"
+    AUTOMOBILE_DATA_DIR="D:\\auto-data"
+    cygpath() {
+      [ "$1" = "-u" ]
+      [ "$2" = "D:\\auto-data" ]
+      printf "/d/auto-data\n"
+    }
+    resolve_automobile_log_dir
+  ' _ "$LIB"
+
+  [ "$status" -eq 0 ]
+  [ "$output" = "/d/auto-data/logs" ]
+}
+
+@test "resolves a slash-rooted Windows data fallback from the launch drive" {
+  run bash -c '
+    source "$1"
+    OS="Windows_NT"
+    HOME="/dev/null"
+    AUTOMOBILE_DATA_DIR="/d/data"
+    AUTOMOBILE_DAEMON_LAUNCH_CWD="C:\\launch"
+    cygpath() {
+      [ "$1" = "-u" ]
+      [ "$2" = "C:\\launch" ]
+      printf "/c/launch\n"
+    }
+    resolve_automobile_log_dir
+  ' _ "$LIB"
+
+  [ "$status" -eq 0 ]
+  [ "$output" = "/c/d/data/logs" ]
+}
+
+@test "preserves a UNC root for a Windows data fallback" {
+  run bash -c '
+    source "$1"
+    OS="Windows_NT"
+    HOME="/dev/null"
+    AUTOMOBILE_DATA_DIR="\\\\server\\share\\auto-data"
+    cygpath() {
+      [ "$1" = "-u" ]
+      [ "$2" = "\\\\server\\share\\auto-data" ]
+      printf "//server/share/auto-data\n"
+    }
+    resolve_automobile_log_dir
+  ' _ "$LIB"
+
+  [ "$status" -eq 0 ]
+  [ "$output" = "//server/share/auto-data/logs" ]
+}
+
+@test "preserves a UNC launch root for a relative Windows override" {
+  run bash -c '
+    source "$1"
+    OS="Windows_NT"
+    AUTOMOBILE_LOG_DIR="logs"
+    AUTOMOBILE_DAEMON_LAUNCH_CWD="\\\\server\\share\\launch"
+    cygpath() {
+      [ "$1" = "-u" ]
+      [ "$2" = "\\\\server\\share\\launch" ]
+      printf "//server/share/launch\n"
+    }
+    resolve_automobile_log_dir
+  ' _ "$LIB"
+
+  [ "$status" -eq 0 ]
+  [ "$output" = "//server/share/launch/logs" ]
+}
+
+@test "does not resolve a relative Windows override above a UNC share root" {
+  run bash -c '
+    source "$1"
+    OS="Windows_NT"
+    AUTOMOBILE_LOG_DIR="../../logs"
+    AUTOMOBILE_DAEMON_LAUNCH_CWD="\\\\server\\share\\launch"
+    cygpath() {
+      [ "$1" = "-u" ]
+      [ "$2" = "\\\\server\\share\\launch" ]
+      printf "//server/share/launch\n"
+    }
+    resolve_automobile_log_dir
+  ' _ "$LIB"
+
+  [ "$status" -eq 0 ]
+  [ "$output" = "//server/share/logs" ]
+}
+
+@test "resolves a slash-rooted Windows override from a UNC share root" {
+  run bash -c '
+    source "$1"
+    OS="Windows_NT"
+    AUTOMOBILE_LOG_DIR="/logs"
+    AUTOMOBILE_DAEMON_LAUNCH_CWD="\\\\server\\share\\launch"
+    cygpath() {
+      [ "$1" = "-u" ]
+      [ "$2" = "\\\\server\\share\\launch" ]
+      printf "//server/share/launch\n"
+    }
+    resolve_automobile_log_dir
+  ' _ "$LIB"
+
+  [ "$status" -eq 0 ]
+  [ "$output" = "//server/share/logs" ]
+}

--- a/test/daemon/daemonManagerLaunch.test.ts
+++ b/test/daemon/daemonManagerLaunch.test.ts
@@ -31,10 +31,12 @@ describe("DaemonManager launch", () => {
     tempDirs.length = 0;
   });
 
-  test("writes the daemon launch log under the stable data dir, not an ephemeral mkdtemp", async () => {
+  test("writes the daemon launch log to AUTOMOBILE_LOG_DIR independently of the data directory", async () => {
     const stateDir = createTempDir("daemon-launch-state-");
     const dataDir = createTempDir("daemon-data-dir-");
+    const logDir = join(createTempDir("daemon-log-dir-"), "logs");
     process.env.AUTOMOBILE_DATA_DIR = dataDir;
+    process.env.AUTOMOBILE_LOG_DIR = logDir;
 
     const processSpawner: DaemonProcessSpawner = {
       spawn: (_command: string, _args: string[], _options: SpawnOptions) => {
@@ -73,9 +75,9 @@ describe("DaemonManager launch", () => {
 
     await manager.start();
 
-    const logsDir = join(dataDir, "logs");
-    expect(existsSync(logsDir)).toBe(true);
-    const launchLogs = readdirSync(logsDir).filter(name => name.startsWith("daemon-launch"));
+    expect(existsSync(logDir)).toBe(true);
+    expect(existsSync(join(dataDir, "logs"))).toBe(false);
+    const launchLogs = readdirSync(logDir).filter(name => name.startsWith("daemon-launch"));
     expect(launchLogs.length).toBeGreaterThan(0);
   });
 
@@ -135,9 +137,10 @@ describe("DaemonManager launch", () => {
     const spawnerCwd = createTempDir("daemon-spawner-cwd-");
     const stateDir = createTempDir("daemon-launch-state-");
     process.chdir(spawnerCwd);
-    // Keep the daemon launch log inside this test's temp tree, not the real
-    // `~/.auto-mobile/logs` default (see tempDir.resolveAutoMobileBaseDir).
+    // Keep the daemon launch log inside this test's temp tree, not the shared
+    // `os.tmpdir()/auto-mobile` default.
     process.env.AUTOMOBILE_DATA_DIR = spawnerCwd;
+    process.env.AUTOMOBILE_LOG_DIR = join(spawnerCwd, "logs");
 
     let capturedOptions: SpawnOptions | undefined;
     const processSpawner: DaemonProcessSpawner = {
@@ -187,9 +190,10 @@ describe("DaemonManager launch", () => {
     const spawnerCwd = createTempDir("daemon-spawner-cwd-");
     const stateDir = createTempDir("daemon-launch-state-");
     process.chdir(spawnerCwd);
-    // Keep the daemon launch log inside this test's temp tree, not the real
-    // `~/.auto-mobile/logs` default (see tempDir.resolveAutoMobileBaseDir).
+    // Keep the daemon launch log inside this test's temp tree, not the shared
+    // `os.tmpdir()/auto-mobile` default.
     process.env.AUTOMOBILE_DATA_DIR = spawnerCwd;
+    process.env.AUTOMOBILE_LOG_DIR = join(spawnerCwd, "logs");
 
     let capturedEnv: NodeJS.ProcessEnv | undefined;
     const processSpawner: DaemonProcessSpawner = {
@@ -236,6 +240,7 @@ describe("DaemonManager launch", () => {
   test("passes tool outputs directory option to the daemon child env to preserve spaces", async () => {
     const stateDir = createTempDir("daemon-launch-state-");
     process.env.AUTOMOBILE_DATA_DIR = stateDir;
+    process.env.AUTOMOBILE_LOG_DIR = join(stateDir, "logs");
 
     let capturedArgs: string[] | undefined;
     let capturedEnv: NodeJS.ProcessEnv | undefined;
@@ -286,6 +291,7 @@ describe("DaemonManager launch", () => {
   test("serializes explicit empty event-all marker override so daemon env fallback stays disabled", async () => {
     const stateDir = createTempDir("daemon-launch-state-");
     process.env.AUTOMOBILE_DATA_DIR = stateDir;
+    process.env.AUTOMOBILE_LOG_DIR = join(stateDir, "logs");
     process.env[EVENT_ALL_MARKERS_ENV] = "@";
 
     let capturedArgs: string[] | undefined;
@@ -334,6 +340,7 @@ describe("DaemonManager launch", () => {
   test("does not serialize absent event-all marker config as an empty override", async () => {
     const stateDir = createTempDir("daemon-launch-state-");
     process.env.AUTOMOBILE_DATA_DIR = stateDir;
+    process.env.AUTOMOBILE_LOG_DIR = join(stateDir, "logs");
 
     let capturedArgs: string[] | undefined;
     const processSpawner: DaemonProcessSpawner = {
@@ -381,9 +388,10 @@ describe("DaemonManager launch", () => {
   test("resolves relative daemon state paths before changing daemon cwd", async () => {
     const spawnerCwd = createTempDir("daemon-spawner-cwd-");
     process.chdir(spawnerCwd);
-    // Keep the daemon launch log inside this test's temp tree, not the real
-    // `~/.auto-mobile/logs` default (see tempDir.resolveAutoMobileBaseDir).
+    // Keep the daemon launch log inside this test's temp tree, not the shared
+    // `os.tmpdir()/auto-mobile` default.
     process.env.AUTOMOBILE_DATA_DIR = spawnerCwd;
+    process.env.AUTOMOBILE_LOG_DIR = join(spawnerCwd, "logs");
     const canonicalSpawnerCwd = realpathSync(spawnerCwd);
     const expectedLockPath = resolve(canonicalSpawnerCwd, ".auto-mobile", "daemon.lock");
     const expectedPidPath = resolve(canonicalSpawnerCwd, ".auto-mobile", "daemon.pid");

--- a/test/daemon/daemonManagerLaunch.test.ts
+++ b/test/daemon/daemonManagerLaunch.test.ts
@@ -1,5 +1,5 @@
 import { afterEach, describe, expect, test } from "bun:test";
-import { existsSync, mkdtempSync, readdirSync, realpathSync, rmSync } from "node:fs";
+import { existsSync, mkdirSync, mkdtempSync, readdirSync, realpathSync, rmSync } from "node:fs";
 import { tmpdir } from "node:os";
 import { join, resolve } from "node:path";
 import type { ChildProcess, SpawnOptions } from "node:child_process";
@@ -131,6 +131,62 @@ describe("DaemonManager launch", () => {
     expect(readdirSync(logDir).some(name => name.startsWith("daemon-launch"))).toBe(true);
     expect(existsSync(join(dataDir, "logs"))).toBe(false);
     expect(capturedOptions?.env?.AUTOMOBILE_LOG_DIR).toBe(logDir);
+  });
+
+  test("uses the ensured data-dir fallback for daemon launch capture", async () => {
+    const stateDir = createTempDir("daemon-launch-state-");
+    const dataDir = createTempDir("daemon-data-dir-");
+    const logDir = join(dataDir, "logs");
+    let ensureCalls = 0;
+
+    const processSpawner: DaemonProcessSpawner = {
+      spawn: (_command: string, _args: string[], _options: SpawnOptions) => {
+        return {
+          unref() {},
+          once() { return this; },
+          off() { return this; },
+        } as ChildProcess;
+      }
+    };
+
+    let statusCallCount = 0;
+    class TestDaemonManager extends DaemonManager {
+      override findAllDaemonProcesses(): number[] { return []; }
+      override async status(): Promise<any> {
+        statusCallCount++;
+        return statusCallCount === 1
+          ? { running: false }
+          : { running: true, pid: 1234, port: 31847, socketPath: join(stateDir, "daemon.sock") };
+      }
+      override async waitForReady(_timeout: number): Promise<boolean> {
+        return true;
+      }
+    }
+
+    const manager = new TestDaemonManager(
+      undefined,
+      undefined,
+      new FakeTimer(),
+      join(stateDir, "daemon.lock"),
+      join(stateDir, "daemon.pid"),
+      join(stateDir, "daemon.sock"),
+      undefined,
+      processSpawner,
+      undefined,
+      undefined,
+      undefined,
+      () => {
+        ensureCalls++;
+        mkdirSync(logDir, { recursive: true });
+        return logDir;
+      }
+    );
+
+    await manager.start();
+
+    expect(ensureCalls).toBeGreaterThan(0);
+    expect(existsSync(logDir)).toBe(true);
+    expect(readdirSync(logDir).some(name => name.startsWith("daemon-launch"))).toBe(true);
   });
 
   test("spawns detached daemon from a stable cwd instead of inheriting the spawner cwd", async () => {

--- a/test/daemon/daemonManagerLock.test.ts
+++ b/test/daemon/daemonManagerLock.test.ts
@@ -11,9 +11,10 @@ describe("DaemonManager file lock", () => {
   function createTempLockPath(): string {
     const dir = mkdtempSync(join(tmpdir(), "daemon-lock-test-"));
     tempDirs.push(dir);
-    // Keep any daemon launch log inside this test's temp tree, not the real
-    // `~/.auto-mobile/logs` default (see tempDir.resolveAutoMobileBaseDir).
+    // Keep any daemon launch log inside this test's temp tree, not the shared
+    // `os.tmpdir()/auto-mobile` default.
     process.env.AUTOMOBILE_DATA_DIR = dir;
+    process.env.AUTOMOBILE_LOG_DIR = join(dir, "logs");
     return join(dir, "daemon.lock");
   }
 

--- a/test/daemon/daemonManagerReadiness.test.ts
+++ b/test/daemon/daemonManagerReadiness.test.ts
@@ -89,9 +89,10 @@ describe("DaemonManager readiness", () => {
   function createPaths(): { dir: string; lockPath: string; pidPath: string; socketPath: string } {
     const dir = mkdtempSync(join(tmpdir(), "daemon-readiness-test-"));
     tempDirs.push(dir);
-    // Keep the daemon launch log inside this test's temp dir instead of the real
-    // `~/.auto-mobile/logs` default (see tempDir.resolveAutoMobileBaseDir).
+    // Keep the daemon launch log inside this test's temp dir instead of the
+    // shared `os.tmpdir()/auto-mobile` default.
     process.env.AUTOMOBILE_DATA_DIR = dir;
+    process.env.AUTOMOBILE_LOG_DIR = join(dir, "logs");
     return {
       dir,
       lockPath: join(dir, "daemon.lock"),
@@ -122,6 +123,7 @@ describe("DaemonManager readiness", () => {
     }
     tempDirs.length = 0;
     delete process.env.AUTOMOBILE_DATA_DIR;
+    delete process.env.AUTOMOBILE_LOG_DIR;
   });
 
   test("reports ready only after the daemon socket accepts a connection", async () => {

--- a/test/daemon/manager.test.ts
+++ b/test/daemon/manager.test.ts
@@ -396,10 +396,10 @@ describe("DaemonLauncher command resolution", () => {
 
 describe("Daemon manager process detection", () => {
   // Tests that reach manager.start() open a daemon launch log; keep it inside the
-  // per-test temp dir (set via AUTOMOBILE_DATA_DIR) rather than the real
-  // `~/.auto-mobile/logs` default (see tempDir.resolveAutoMobileBaseDir).
+  // per-test temp dir rather than the shared `os.tmpdir()/auto-mobile` default.
   afterEach(() => {
     delete process.env.AUTOMOBILE_DATA_DIR;
+    delete process.env.AUTOMOBILE_LOG_DIR;
   });
 
   test("parses daemon processes from ps pid ppid command output", () => {
@@ -733,6 +733,7 @@ describe("Daemon manager process detection", () => {
   test("start reuses a responsive live daemon when its PID record is unavailable", async () => {
     const dir = mkdtempSync(join(tmpdir(), "daemon-manager-takeover-test-"));
     process.env.AUTOMOBILE_DATA_DIR = dir;
+    process.env.AUTOMOBILE_LOG_DIR = join(dir, "logs");
     const pidFilePath = join(dir, "daemon.pid");
     const fakeTimer = new FakeTimer();
     fakeTimer.enableAutoAdvance();
@@ -797,6 +798,7 @@ describe("Daemon manager process detection", () => {
   test("start refuses to signal a live daemon that never becomes reachable", async () => {
     const dir = mkdtempSync(join(tmpdir(), "daemon-manager-takeover-revalidate-test-"));
     process.env.AUTOMOBILE_DATA_DIR = dir;
+    process.env.AUTOMOBILE_LOG_DIR = join(dir, "logs");
     const pidFilePath = join(dir, "daemon.pid");
     const fakeTimer = new FakeTimer();
     fakeTimer.enableAutoAdvance();
@@ -1075,6 +1077,7 @@ describe("Daemon manager process detection", () => {
   test("start takeover does not signal transient daemon-mode candidates that are gone by liveness re-check", async () => {
     const dir = mkdtempSync(join(tmpdir(), "daemon-manager-transient-takeover-test-"));
     process.env.AUTOMOBILE_DATA_DIR = dir;
+    process.env.AUTOMOBILE_LOG_DIR = join(dir, "logs");
     const pidFilePath = join(dir, "daemon.pid");
     writeDaemonPidFile(pidFilePath, 201);
     const fakeTimer = new FakeTimer();
@@ -1135,6 +1138,7 @@ describe("Daemon manager process detection", () => {
   test("surfaces incomplete-extraction remediation when daemon exits with exit code 75", async () => {
     const dir = mkdtempSync(join(tmpdir(), "daemon-manager-incomplete-extraction-message-test-"));
     process.env.AUTOMOBILE_DATA_DIR = dir;
+    process.env.AUTOMOBILE_LOG_DIR = join(dir, "logs");
     const fakeTimer = new FakeTimer();
     fakeTimer.enableAutoAdvance();
     const entryScript = join(
@@ -1190,6 +1194,7 @@ describe("Daemon manager process detection", () => {
   test("removes an incomplete extraction and retries once after exit code 75", async () => {
     const dir = mkdtempSync(join(tmpdir(), "daemon-manager-incomplete-extraction-retry-test-"));
     process.env.AUTOMOBILE_DATA_DIR = dir;
+    process.env.AUTOMOBILE_LOG_DIR = join(dir, "logs");
     const fakeTimer = new FakeTimer();
     fakeTimer.enableAutoAdvance();
     const entryScript = join(
@@ -1261,6 +1266,7 @@ describe("Daemon manager process detection", () => {
     const dir = mkdtempSync(join(tmpdir(), "daemon-manager-default-extraction-cleaner-test-"));
     const dataDir = join(dir, "data");
     process.env.AUTOMOBILE_DATA_DIR = dataDir;
+    process.env.AUTOMOBILE_LOG_DIR = join(dir, "logs");
     const fakeTimer = new FakeTimer();
     fakeTimer.enableAutoAdvance();
     const extractionRoot = join(dir, "bunx-extract");
@@ -1331,6 +1337,7 @@ describe("Daemon manager process detection", () => {
   test("gives up with remediation when the retry exits with exit code 75 again", async () => {
     const dir = mkdtempSync(join(tmpdir(), "daemon-manager-incomplete-extraction-give-up-test-"));
     process.env.AUTOMOBILE_DATA_DIR = dir;
+    process.env.AUTOMOBILE_LOG_DIR = join(dir, "logs");
     const fakeTimer = new FakeTimer();
     fakeTimer.enableAutoAdvance();
     const entryScript = join(
@@ -1392,6 +1399,7 @@ describe("Daemon manager process detection", () => {
   test("does not remove or retry for non-incomplete-extraction daemon exits", async () => {
     const dir = mkdtempSync(join(tmpdir(), "daemon-manager-generic-exit-test-"));
     process.env.AUTOMOBILE_DATA_DIR = dir;
+    process.env.AUTOMOBILE_LOG_DIR = join(dir, "logs");
     const fakeTimer = new FakeTimer();
     fakeTimer.enableAutoAdvance();
     const child = new FakeDaemonChildProcess();

--- a/test/daemon/manager.test.ts
+++ b/test/daemon/manager.test.ts
@@ -400,6 +400,7 @@ describe("Daemon manager process detection", () => {
   afterEach(() => {
     delete process.env.AUTOMOBILE_DATA_DIR;
     delete process.env.AUTOMOBILE_LOG_DIR;
+    delete process.env.AUTO_MOBILE_LOG_DIR;
   });
 
   test("parses daemon processes from ps pid ppid command output", () => {

--- a/test/utils/dataDir.test.ts
+++ b/test/utils/dataDir.test.ts
@@ -105,17 +105,17 @@ describe("resolveAutoMobileLogsDir", () => {
     ).toBe(path.resolve("/injected-launch", "logs"));
   });
 
-  test("falls back to the data-dir logs child for an unset or blank override", () => {
+  test("defaults to os.tmpdir()/auto-mobile independently of AUTOMOBILE_DATA_DIR", () => {
     expect(
       resolveAutoMobileLogsDir({ AUTOMOBILE_DATA_DIR: "/srv/data" }, home, "/launch")
-    ).toBe(path.join(path.resolve("/srv/data"), "logs"));
+    ).toBe(path.join(os.tmpdir(), "auto-mobile"));
     expect(
       resolveAutoMobileLogsDir(
         { AUTOMOBILE_LOG_DIR: "   ", AUTOMOBILE_DATA_DIR: "/srv/data" },
         home,
         "/launch",
       )
-    ).toBe(path.join(path.resolve("/srv/data"), "logs"));
+    ).toBe(path.join(os.tmpdir(), "auto-mobile"));
   });
 });
 

--- a/test/utils/dataDir.test.ts
+++ b/test/utils/dataDir.test.ts
@@ -2,6 +2,7 @@ import { describe, expect, test } from "bun:test";
 import fs from "node:fs";
 import os from "node:os";
 import path from "node:path";
+import { ActionableError } from "../../src/models/ActionableError";
 import {
   resolveAutoMobileBaseDir,
   resolveAutoMobileLogsDir,
@@ -39,14 +40,25 @@ describe("resolveAutoMobileBaseDir", () => {
     expect(resolved.endsWith(path.join("rel", "data"))).toBe(true);
   });
 
+  test("anchors a relative override to the daemon launch directory", () => {
+    expect(
+      resolveAutoMobileBaseDir({ AUTOMOBILE_DATA_DIR: "rel/data" }, home, "/launch")
+    ).toBe(path.resolve("/launch", "rel/data"));
+  });
+
+  test("anchors a relative home directory to the daemon launch directory", () => {
+    expect(resolveAutoMobileBaseDir({}, "relative-home", "/launch"))
+      .toBe(path.resolve("/launch", "relative-home", ".auto-mobile"));
+  });
+
   test("ignores a blank override and uses the stable home default", () => {
     expect(resolveAutoMobileBaseDir({ AUTOMOBILE_DATA_DIR: "   " }, home))
-      .toBe(path.join(home, ".auto-mobile"));
+      .toBe(path.resolve(home, ".auto-mobile"));
   });
 
   test("defaults to ~/.auto-mobile, never under os.tmpdir()", () => {
     const base = resolveAutoMobileBaseDir({}, home);
-    expect(base).toBe(path.join(home, ".auto-mobile"));
+    expect(base).toBe(path.resolve(home, ".auto-mobile"));
     expect(base.startsWith(os.tmpdir())).toBe(false);
   });
 
@@ -60,7 +72,7 @@ describe("resolveAutoMobileBaseDir", () => {
       { TMPDIR: "/ephemeral/bunx-123", TMP: "/ephemeral/bunx-123", TEMP: "/ephemeral/bunx-123" },
       home
     );
-    expect(base).toBe(path.join(home, ".auto-mobile"));
+    expect(base).toBe(path.resolve(home, ".auto-mobile"));
   });
 });
 
@@ -105,17 +117,33 @@ describe("resolveAutoMobileLogsDir", () => {
     ).toBe(path.resolve("/injected-launch", "logs"));
   });
 
-  test("defaults to os.tmpdir()/auto-mobile independently of AUTOMOBILE_DATA_DIR", () => {
+  test("defaults to an owner-controlled logs directory independently of AUTOMOBILE_DATA_DIR", () => {
+    const defaultLogDir = path.resolve(home, ".auto-mobile", "logs");
     expect(
       resolveAutoMobileLogsDir({ AUTOMOBILE_DATA_DIR: "/srv/data" }, home, "/launch")
-    ).toBe(path.join(os.tmpdir(), "auto-mobile"));
+    ).toBe(defaultLogDir);
     expect(
       resolveAutoMobileLogsDir(
         { AUTOMOBILE_LOG_DIR: "   ", AUTOMOBILE_DATA_DIR: "/srv/data" },
         home,
         "/launch",
       )
-    ).toBe(path.join(os.tmpdir(), "auto-mobile"));
+    ).toBe(defaultLogDir);
+  });
+
+  test("anchors a relative home directory to the daemon launch directory", () => {
+    expect(resolveAutoMobileLogsDir({}, "relative-home", "/launch"))
+      .toBe(path.resolve("/launch", "relative-home", ".auto-mobile", "logs"));
+  });
+
+  test("does not inherit a bunx TMPDIR", () => {
+    expect(
+      resolveAutoMobileLogsDir(
+        { TMPDIR: "/ephemeral/bunx-123", TMP: "/ephemeral/bunx-123", TEMP: "/ephemeral/bunx-123" },
+        home,
+        "/launch",
+      )
+    ).toBe(path.resolve(home, ".auto-mobile", "logs"));
   });
 });
 
@@ -218,6 +246,34 @@ describe("ensureSecureTempDirSync", () => {
     }
   });
 
+  test.skipIf(process.platform === "win32")("falls back to the configured data directory when the default home is unusable", () => {
+    const tmpBase = fs.mkdtempSync(path.join(os.tmpdir(), "am-log-data-fallback-"));
+    try {
+      expect(
+        ensureSecureLogsDirSync({ AUTOMOBILE_DATA_DIR: tmpBase }, "/dev/null")
+      ).toBe(path.join(tmpBase, "logs"));
+    } finally {
+      fs.rmSync(tmpBase, { recursive: true, force: true });
+    }
+  });
+
+  test.skipIf(process.platform === "win32")("anchors a relative data fallback to the daemon launch directory", () => {
+    const tmpBase = fs.mkdtempSync(path.join(os.tmpdir(), "am-relative-log-data-fallback-"));
+    try {
+      expect(
+        ensureSecureLogsDirSync(
+          {
+            AUTOMOBILE_DATA_DIR: "relative-data",
+            AUTOMOBILE_DAEMON_LAUNCH_CWD: tmpBase,
+          },
+          "/dev/null"
+        )
+      ).toBe(path.join(tmpBase, "relative-data", "logs"));
+    } finally {
+      fs.rmSync(tmpBase, { recursive: true, force: true });
+    }
+  });
+
   test.skipIf(process.platform === "win32")("rejects a symbolic-link log directory", () => {
     const tmpBase = fs.mkdtempSync(path.join(os.tmpdir(), "am-log-link-"));
     const targetDir = path.join(tmpBase, "target");
@@ -227,7 +283,15 @@ describe("ensureSecureTempDirSync", () => {
     fs.symlinkSync(targetDir, linkDir, "dir");
     process.env.AUTOMOBILE_LOG_DIR = linkDir;
     try {
-      expect(() => ensureSecureLogsDirSync()).toThrow("symbolic-link directory");
+      let thrown: unknown;
+      try {
+        ensureSecureLogsDirSync();
+      } catch (error) {
+        thrown = error;
+      }
+      expect(thrown).toBeInstanceOf(ActionableError);
+      expect((thrown as Error).message).toBe("Refusing to use symbolic-link directory for AutoMobile logs");
+      expect((thrown as Error & { cause?: unknown }).cause).toBeInstanceOf(Error);
     } finally {
       if (previousLogDir === undefined) {
         delete process.env.AUTOMOBILE_LOG_DIR;


### PR DESCRIPTION
## Summary

- Default structured and daemon-launch logs to `os.tmpdir()/auto-mobile`, independently of `AUTOMOBILE_DATA_DIR`.
- Preserve `AUTOMOBILE_LOG_DIR` overrides and document `/var/logs/auto-mobile` for managed deployments.
- Update CI artifact collection, troubleshooting guides, and benchmark diagnostics to use the configured log directory.

## Validation

- `bun test --isolate test/utils/dataDir.test.ts test/utils/logger-loglevel-env.test.ts test/daemon/daemonManagerLaunch.test.ts test/daemon/daemonManagerLock.test.ts test/daemon/daemonManagerReadiness.test.ts test/daemon/manager.test.ts test/scripts/docsWorkflow.test.ts test/scripts/iosIntegrationWorkflowChangeGuard.test.ts`
- `bun run build`
- `bun run validate:yaml`
- `shellcheck scripts/benchmark-startup.sh`
