### PR TITLE
fix(android): correlate unlabelled emulator launches

### DIFF
--- a/src/utils/android-cmdline-tools/AndroidEmulatorClient.ts
+++ b/src/utils/android-cmdline-tools/AndroidEmulatorClient.ts
@@ -329,6 +329,9 @@ export class AndroidEmulatorClient implements AndroidEmulator {
   private platform: NodeJS.Platform;
   private hostArchitecture: string;
   private readonly launchTargetDeviceIds = new WeakMap<ChildProcess, string>();
+  // startDevice creates a fresh client per request, so this safety boundary must
+  // cover every client in the daemon rather than one client instance.
+  private static readonly pendingUnlabelledLaunches = new Set<ChildProcess>();
   private readonly launchPreexistingEmulatorDeviceIds = new WeakMap<
     ChildProcess,
     ReadonlySet<string>
@@ -369,6 +372,10 @@ export class AndroidEmulatorClient implements AndroidEmulator {
     this.hostArchitecture = hostArchitecture;
     // Only set a fallback emulator path here; proper detection happens lazily
     this.emulatorPath = this.getFallbackEmulatorPath();
+  }
+
+  static resetUnlabelledLaunchTrackingForTesting(): void {
+    AndroidEmulatorClient.pendingUnlabelledLaunches.clear();
   }
 
   /**
@@ -1820,6 +1827,7 @@ export class AndroidEmulatorClient implements AndroidEmulator {
 
       child.on("exit", (code, signal) => {
         this.timer.clearTimeout(startupTimeout);
+        this.releaseUnlabelledLaunch(child);
         childTerminationObserved = true;
         exitCode = code;
         exitSignal = signal;
@@ -1842,6 +1850,7 @@ export class AndroidEmulatorClient implements AndroidEmulator {
 
       child.on("close", (code, signal) => {
         this.timer.clearTimeout(startupTimeout);
+        this.releaseUnlabelledLaunch(child);
         clearExitDrainTimeout();
         childTerminationObserved = true;
         exitCode ??= code;
@@ -1926,6 +1935,13 @@ export class AndroidEmulatorClient implements AndroidEmulator {
   ): void {
     if (preexistingDeviceIds) {
       this.launchPreexistingEmulatorDeviceIds.set(childProcess, preexistingDeviceIds);
+      AndroidEmulatorClient.pendingUnlabelledLaunches.add(childProcess);
+    }
+  }
+
+  private releaseUnlabelledLaunch(childProcess?: ChildProcess | null): void {
+    if (childProcess) {
+      AndroidEmulatorClient.pendingUnlabelledLaunches.delete(childProcess);
     }
   }
 
@@ -1945,6 +1961,15 @@ export class AndroidEmulatorClient implements AndroidEmulator {
       return {};
     }
 
+    const pendingUnlabelledLaunches = AndroidEmulatorClient.pendingUnlabelledLaunches.size;
+    if (pendingUnlabelledLaunches > 1) {
+      return {
+        failure:
+          `Emulator '${avdName}' cannot safely correlate the launched emulator while ` +
+          `${pendingUnlabelledLaunches} unlabelled emulator launches are pending`,
+      };
+    }
+
     const newUnknownEmulators = runningEmulators.filter(
       (candidate) =>
         candidate.deviceId.startsWith("emulator-") &&
@@ -1953,6 +1978,7 @@ export class AndroidEmulatorClient implements AndroidEmulator {
     );
     if (newUnknownEmulators.length === 1) {
       const emulator = newUnknownEmulators[0];
+      this.recordLaunchTargetDeviceId(childProcess, emulator.deviceId, "pre-launch device set");
       logger.debug(`Correlated launched emulator from pre-launch device set: ${emulator.deviceId}`);
       return { emulator };
     }
@@ -1977,6 +2003,7 @@ export class AndroidEmulatorClient implements AndroidEmulator {
       `Exact name match for '${avdName}': ${namedEmulator ? `Found ${namedEmulator.deviceId}` : "Not found"}`,
     );
     if (namedEmulator) {
+      this.recordLaunchTargetDeviceId(childProcess, namedEmulator.deviceId, "AVD name");
       return { emulator: namedEmulator };
     }
 
@@ -2096,11 +2123,21 @@ export class AndroidEmulatorClient implements AndroidEmulator {
 
     const targetDeviceId = this.detectDeviceIdFromEmulatorOutput(output);
     if (targetDeviceId) {
-      this.launchTargetDeviceIds.set(childProcess, targetDeviceId);
-      logger.debug(
-        `Captured emulator launch target deviceId from process output: ${targetDeviceId}`,
-      );
+      this.recordLaunchTargetDeviceId(childProcess, targetDeviceId, "process output");
     }
+  }
+
+  private recordLaunchTargetDeviceId(
+    childProcess: ChildProcess | null | undefined,
+    targetDeviceId: string,
+    source: string,
+  ): void {
+    if (!childProcess || this.launchTargetDeviceIds.has(childProcess)) {
+      return;
+    }
+    this.launchTargetDeviceIds.set(childProcess, targetDeviceId);
+    this.releaseUnlabelledLaunch(childProcess);
+    logger.debug(`Captured emulator launch target deviceId from ${source}: ${targetDeviceId}`);
   }
 
   /**

--- a/src/utils/android-cmdline-tools/AndroidEmulatorClient.ts
+++ b/src/utils/android-cmdline-tools/AndroidEmulatorClient.ts
@@ -331,7 +331,7 @@ export class AndroidEmulatorClient implements AndroidEmulator {
   private readonly launchTargetDeviceIds = new WeakMap<ChildProcess, string>();
   // startDevice creates a fresh client per request, so this safety boundary must
   // cover every client in the daemon rather than one client instance.
-  private static readonly pendingUnlabelledLaunches = new Set<ChildProcess>();
+  private static readonly unlabelledLaunchDeviceIds = new Map<ChildProcess, string | undefined>();
   private readonly launchPreexistingEmulatorDeviceIds = new WeakMap<
     ChildProcess,
     ReadonlySet<string>
@@ -375,7 +375,7 @@ export class AndroidEmulatorClient implements AndroidEmulator {
   }
 
   static resetUnlabelledLaunchTrackingForTesting(): void {
-    AndroidEmulatorClient.pendingUnlabelledLaunches.clear();
+    AndroidEmulatorClient.unlabelledLaunchDeviceIds.clear();
   }
 
   /**
@@ -1414,7 +1414,11 @@ export class AndroidEmulatorClient implements AndroidEmulator {
       perf.startOperation("spawnEmulator");
       const child = this.spawnFn(this.emulatorPath, args);
       perf.endOperation("spawnEmulator");
-      this.recordPreLaunchEmulatorDeviceIds(child, preLaunchEmulatorDeviceIds);
+      this.recordPreLaunchEmulatorDeviceIds(
+        child,
+        preLaunchEmulatorDeviceIds,
+        capturePreLaunchDeviceIds,
+      );
       onSpawn?.(child);
 
       // Keep only a redacted tail for launch diagnostics and failure classification.
@@ -1924,6 +1928,8 @@ export class AndroidEmulatorClient implements AndroidEmulator {
           .filter((deviceId): deviceId is string => deviceId.startsWith("emulator-")),
       );
     } catch (error) {
+      // Without a baseline, unknown-device fallback stays disabled. Readiness can
+      // still use a captured serial or an exact AVD-name match.
       logger.debug(`Could not capture pre-launch emulator device IDs: ${error}`);
       return undefined;
     }
@@ -1932,16 +1938,20 @@ export class AndroidEmulatorClient implements AndroidEmulator {
   private recordPreLaunchEmulatorDeviceIds(
     childProcess: ChildProcess,
     preexistingDeviceIds: ReadonlySet<string> | undefined,
+    trackUnlabelledLaunch: boolean,
   ): void {
+    if (!trackUnlabelledLaunch) {
+      return;
+    }
     if (preexistingDeviceIds) {
       this.launchPreexistingEmulatorDeviceIds.set(childProcess, preexistingDeviceIds);
-      AndroidEmulatorClient.pendingUnlabelledLaunches.add(childProcess);
     }
+    AndroidEmulatorClient.unlabelledLaunchDeviceIds.set(childProcess, undefined);
   }
 
   private releaseUnlabelledLaunch(childProcess?: ChildProcess | null): void {
     if (childProcess) {
-      AndroidEmulatorClient.pendingUnlabelledLaunches.delete(childProcess);
+      AndroidEmulatorClient.unlabelledLaunchDeviceIds.delete(childProcess);
     }
   }
 
@@ -1961,7 +1971,9 @@ export class AndroidEmulatorClient implements AndroidEmulator {
       return {};
     }
 
-    const pendingUnlabelledLaunches = AndroidEmulatorClient.pendingUnlabelledLaunches.size;
+    const pendingUnlabelledLaunches = Array.from(
+      AndroidEmulatorClient.unlabelledLaunchDeviceIds.values(),
+    ).filter((deviceId) => deviceId === undefined).length;
     if (pendingUnlabelledLaunches > 1) {
       return {
         failure:
@@ -1974,6 +1986,7 @@ export class AndroidEmulatorClient implements AndroidEmulator {
       (candidate) =>
         candidate.deviceId.startsWith("emulator-") &&
         !preexistingDeviceIds.has(candidate.deviceId) &&
+        !this.isTrackedUnlabelledLaunchDeviceId(childProcess, candidate.deviceId) &&
         this.isUnknownEmulatorName(candidate.name, candidate.deviceId),
     );
     if (newUnknownEmulators.length === 1) {
@@ -2136,8 +2149,20 @@ export class AndroidEmulatorClient implements AndroidEmulator {
       return;
     }
     this.launchTargetDeviceIds.set(childProcess, targetDeviceId);
-    this.releaseUnlabelledLaunch(childProcess);
+    if (AndroidEmulatorClient.unlabelledLaunchDeviceIds.has(childProcess)) {
+      AndroidEmulatorClient.unlabelledLaunchDeviceIds.set(childProcess, targetDeviceId);
+    }
     logger.debug(`Captured emulator launch target deviceId from ${source}: ${targetDeviceId}`);
+  }
+
+  private isTrackedUnlabelledLaunchDeviceId(
+    childProcess: ChildProcess | null | undefined,
+    deviceId: string,
+  ): boolean {
+    return Array.from(AndroidEmulatorClient.unlabelledLaunchDeviceIds.entries()).some(
+      ([trackedProcess, trackedDeviceId]) =>
+        trackedProcess !== childProcess && trackedDeviceId === deviceId,
+    );
   }
 
   /**

--- a/src/utils/android-cmdline-tools/AndroidEmulatorClient.ts
+++ b/src/utils/android-cmdline-tools/AndroidEmulatorClient.ts
@@ -503,6 +503,7 @@ export class AndroidEmulatorClient implements AndroidEmulator {
   private static readonly pendingLaunchDeviceIds = new Map<string, EmulatorDeviceIdReservation>();
   private static readonly terminalReservedDeviceIds = new Map<string, TerminalEmulatorReservation>();
   private static terminalReservationGeneration = 0;
+  private static hostPortAvailabilityCheckerForTesting: HostPortAvailabilityChecker | undefined;
   private readonly launchErrors = new WeakMap<ChildProcess, ActionableError>();
   private readonly launchErrorFinalizations = new WeakMap<
     ChildProcess,
@@ -530,7 +531,9 @@ export class AndroidEmulatorClient implements AndroidEmulator {
     avdConfigReader?: AvdConfigReader,
     platform: NodeJS.Platform = process.platform,
     hostArchitecture: string = arch(),
-    hostPortAvailabilityChecker: HostPortAvailabilityChecker = new TcpHostPortAvailabilityChecker(),
+    hostPortAvailabilityChecker: HostPortAvailabilityChecker =
+      AndroidEmulatorClient.hostPortAvailabilityCheckerForTesting ??
+      new TcpHostPortAvailabilityChecker(),
   ) {
     this.execAsync = execAsyncFn || execAsync;
     this.spawnFn = spawnFn || spawn;
@@ -549,6 +552,12 @@ export class AndroidEmulatorClient implements AndroidEmulator {
     AndroidEmulatorClient.pendingLaunchDeviceIds.clear();
     AndroidEmulatorClient.terminalReservedDeviceIds.clear();
     AndroidEmulatorClient.terminalReservationGeneration = 0;
+  }
+
+  static setHostPortAvailabilityCheckerForTesting(
+    checker: HostPortAvailabilityChecker | undefined,
+  ): void {
+    AndroidEmulatorClient.hostPortAvailabilityCheckerForTesting = checker;
   }
 
   /**

--- a/src/utils/android-cmdline-tools/AndroidEmulatorClient.ts
+++ b/src/utils/android-cmdline-tools/AndroidEmulatorClient.ts
@@ -8,6 +8,10 @@ import { arch } from "os";
 import { detectAndroidCommandLineTools, getBestAndroidToolsLocation } from "./detection";
 import { defaultTimer, Timer } from "../SystemTimer";
 import { createGlobalPerformanceTracker } from "../PerformanceTracker";
+import {
+  TcpHostPortAvailabilityChecker,
+  type HostPortAvailabilityChecker,
+} from "../ios/IOSHostPortAvailabilityChecker";
 import type { AvdConfig, AvdConfigReader } from "./AvdConfigReader";
 import { FileAvdConfigReader, MIN_AVD_RAM_MB } from "./AvdConfigReader";
 import { WakeAndUnlock } from "../../features/action/WakeAndUnlock";
@@ -389,6 +393,17 @@ function emulatorPortsForDeviceId(deviceId: string | undefined): EmulatorPortPai
   return { consolePort, adbPort: consolePort + 1 };
 }
 
+function observedEmulatorPorts(deviceId: string): EmulatorPortPair | undefined {
+  if (!deviceId.startsWith("emulator-")) {
+    return undefined;
+  }
+  const consolePort = Number(deviceId.slice("emulator-".length));
+  if (!Number.isInteger(consolePort) || consolePort < 1 || consolePort >= 65_535) {
+    return undefined;
+  }
+  return { consolePort, adbPort: consolePort + 1 };
+}
+
 function emulatorDeviceIdForConsolePort(consolePort: number): string {
   return `emulator-${consolePort}`;
 }
@@ -480,10 +495,12 @@ export class AndroidEmulatorClient implements AndroidEmulator {
   private avdConfigReader: AvdConfigReader;
   private platform: NodeJS.Platform;
   private hostArchitecture: string;
+  private readonly hostPortAvailabilityChecker: HostPortAvailabilityChecker;
   private readonly launchTargetDeviceIds = new WeakMap<ChildProcess, string>();
   // startDevice creates a fresh client per request, so reservations must cover
   // every client in the daemon rather than one client instance.
   private static readonly reservedLaunchDeviceIds = new Map<ChildProcess, EmulatorDeviceIdReservation>();
+  private static readonly pendingLaunchDeviceIds = new Map<string, EmulatorDeviceIdReservation>();
   private static readonly terminalReservedDeviceIds = new Map<string, TerminalEmulatorReservation>();
   private static terminalReservationGeneration = 0;
   private readonly launchErrors = new WeakMap<ChildProcess, ActionableError>();
@@ -501,6 +518,7 @@ export class AndroidEmulatorClient implements AndroidEmulator {
    * @param avdConfigReader - Reader for AVD config.ini files (for testing)
    * @param platform - Host platform (for testing)
    * @param hostArchitecture - Host CPU architecture (for testing)
+   * @param hostPortAvailabilityChecker - Checks whether emulator ports are free (for testing)
    */
   constructor(
     execAsyncFn:
@@ -512,6 +530,7 @@ export class AndroidEmulatorClient implements AndroidEmulator {
     avdConfigReader?: AvdConfigReader,
     platform: NodeJS.Platform = process.platform,
     hostArchitecture: string = arch(),
+    hostPortAvailabilityChecker: HostPortAvailabilityChecker = new TcpHostPortAvailabilityChecker(),
   ) {
     this.execAsync = execAsyncFn || execAsync;
     this.spawnFn = spawnFn || spawn;
@@ -520,12 +539,14 @@ export class AndroidEmulatorClient implements AndroidEmulator {
     this.avdConfigReader = avdConfigReader ?? new FileAvdConfigReader();
     this.platform = platform;
     this.hostArchitecture = hostArchitecture;
+    this.hostPortAvailabilityChecker = hostPortAvailabilityChecker;
     // Only set a fallback emulator path here; proper detection happens lazily
     this.emulatorPath = this.getFallbackEmulatorPath();
   }
 
   static resetLaunchReservationsForTesting(): void {
     AndroidEmulatorClient.reservedLaunchDeviceIds.clear();
+    AndroidEmulatorClient.pendingLaunchDeviceIds.clear();
     AndroidEmulatorClient.terminalReservedDeviceIds.clear();
     AndroidEmulatorClient.terminalReservationGeneration = 0;
   }
@@ -1564,7 +1585,7 @@ export class AndroidEmulatorClient implements AndroidEmulator {
       signal,
     );
     this.throwIfLaunchCancelled(avdName, isCancelled);
-    const reservedEmulator = this.addReservedEmulatorPort(
+    const reservedEmulator = await this.addReservedEmulatorPort(
       args,
       preLaunchEmulatorDeviceSnapshot,
       expectedDeviceId,
@@ -1574,7 +1595,15 @@ export class AndroidEmulatorClient implements AndroidEmulator {
 
     return new Promise((resolve, reject) => {
       perf.startOperation("spawnEmulator");
-      const child = this.spawnFn(this.emulatorPath, args);
+      let child: ChildProcess;
+      try {
+        child = this.spawnFn(this.emulatorPath, args);
+      } catch (error) {
+        if (reservedEmulator) {
+          this.releasePendingEmulatorDeviceId(reservedEmulator);
+        }
+        throw error;
+      }
       perf.endOperation("spawnEmulator");
       if (reservedEmulator) {
         this.recordReservedEmulatorDeviceId(child, reservedEmulator);
@@ -2125,9 +2154,9 @@ export class AndroidEmulatorClient implements AndroidEmulator {
     }
   }
 
-  private allocateReservedEmulatorPorts(
+  private async allocateReservedEmulatorPorts(
     preexistingDeviceIds: ReadonlySet<string>,
-  ): EmulatorPortPair {
+  ): Promise<EmulatorDeviceIdReservation> {
     const unavailablePorts = this.unavailableEmulatorPorts(preexistingDeviceIds);
     for (
       let port = MIN_EMULATOR_CONSOLE_PORT;
@@ -2135,8 +2164,18 @@ export class AndroidEmulatorClient implements AndroidEmulator {
       port += EMULATOR_CONSOLE_PORT_STEP
     ) {
       const ports = { consolePort: port, adbPort: port + 1 };
-      if (!unavailablePorts.has(ports.consolePort) && !unavailablePorts.has(ports.adbPort)) {
-        return ports;
+      if (
+        !unavailablePorts.has(ports.consolePort) &&
+        !unavailablePorts.has(ports.adbPort) &&
+        (await this.areEmulatorPortsAvailableOnHost(ports))
+      ) {
+        const currentUnavailablePorts = this.unavailableEmulatorPorts(preexistingDeviceIds);
+        if (
+          !currentUnavailablePorts.has(ports.consolePort) &&
+          !currentUnavailablePorts.has(ports.adbPort)
+        ) {
+          return this.reservePendingEmulatorDeviceId(ports, true);
+        }
       }
     }
     throw new ActionableError(
@@ -2154,12 +2193,15 @@ export class AndroidEmulatorClient implements AndroidEmulator {
       unavailablePorts.add(ports.adbPort);
     };
     for (const deviceId of preexistingDeviceIds ?? []) {
-      const ports = emulatorPortsForDeviceId(deviceId);
+      const ports = observedEmulatorPorts(deviceId);
       if (ports) {
         reservePorts(ports);
       }
     }
     for (const reservation of AndroidEmulatorClient.reservedLaunchDeviceIds.values()) {
+      reservePorts(reservation.ports);
+    }
+    for (const reservation of AndroidEmulatorClient.pendingLaunchDeviceIds.values()) {
       reservePorts(reservation.ports);
     }
     for (const reservation of AndroidEmulatorClient.terminalReservedDeviceIds.values()) {
@@ -2168,7 +2210,15 @@ export class AndroidEmulatorClient implements AndroidEmulator {
     return unavailablePorts;
   }
 
-  private assertEmulatorPortsAvailable(
+  private async areEmulatorPortsAvailableOnHost(ports: EmulatorPortPair): Promise<boolean> {
+    const availability = await Promise.all([
+      this.hostPortAvailabilityChecker.isAvailable("127.0.0.1", ports.consolePort),
+      this.hostPortAvailabilityChecker.isAvailable("127.0.0.1", ports.adbPort),
+    ]);
+    return availability.every(Boolean);
+  }
+
+  private assertEmulatorPortsNotReserved(
     ports: EmulatorPortPair,
     preexistingDeviceIds: ReadonlySet<string> | undefined,
   ): void {
@@ -2181,11 +2231,38 @@ export class AndroidEmulatorClient implements AndroidEmulator {
     }
   }
 
-  private reserveEmulatorDeviceId(
+  private async assertEmulatorPortsAvailable(
+    ports: EmulatorPortPair,
+    preexistingDeviceIds: ReadonlySet<string> | undefined,
+  ): Promise<void> {
+    this.assertEmulatorPortsNotReserved(ports, preexistingDeviceIds);
+    if (!(await this.areEmulatorPortsAvailableOnHost(ports))) {
+      throw new ActionableError(
+        `Cannot safely launch an Android emulator: emulator port pair ` +
+          `${ports.consolePort}/${ports.adbPort} is already in use`,
+      );
+    }
+    this.assertEmulatorPortsNotReserved(ports, preexistingDeviceIds);
+  }
+
+  private reservePendingEmulatorDeviceId(
+    ports: EmulatorPortPair,
+    appendPort: boolean,
+  ): EmulatorDeviceIdReservation {
+    const reservation = {
+      deviceId: emulatorDeviceIdForConsolePort(ports.consolePort),
+      ports,
+      appendPort,
+    };
+    AndroidEmulatorClient.pendingLaunchDeviceIds.set(reservation.deviceId, reservation);
+    return reservation;
+  }
+
+  private async reserveEmulatorDeviceId(
     preLaunchSnapshot: EmulatorDeviceIdSnapshot | undefined,
     args: readonly string[],
     expectedDeviceId?: string,
-  ): EmulatorDeviceIdReservation | undefined {
+  ): Promise<EmulatorDeviceIdReservation | undefined> {
     const expectedEmulatorPorts = emulatorPortsForDeviceId(expectedDeviceId);
     if (expectedDeviceId && !expectedEmulatorPorts) {
       return undefined;
@@ -2203,30 +2280,23 @@ export class AndroidEmulatorClient implements AndroidEmulator {
     }
     const ports = configuredPorts ?? expectedEmulatorPorts;
     if (ports) {
-      this.assertEmulatorPortsAvailable(ports, preLaunchSnapshot?.deviceIds);
-      return {
-        deviceId: emulatorDeviceIdForConsolePort(ports.consolePort),
-        ports,
-        appendPort: configuredPorts === undefined,
-      };
+      await this.assertEmulatorPortsAvailable(ports, preLaunchSnapshot?.deviceIds);
+      return this.reservePendingEmulatorDeviceId(ports, configuredPorts === undefined);
     }
     if (!preLaunchSnapshot?.isComplete) {
       return undefined;
     }
-    const allocatedPorts = this.allocateReservedEmulatorPorts(preLaunchSnapshot.deviceIds);
-    return {
-      deviceId: emulatorDeviceIdForConsolePort(allocatedPorts.consolePort),
-      ports: allocatedPorts,
-      appendPort: true,
-    };
+    return this.allocateReservedEmulatorPorts(
+      preLaunchSnapshot.deviceIds,
+    );
   }
 
-  private addReservedEmulatorPort(
+  private async addReservedEmulatorPort(
     args: string[],
     preLaunchSnapshot: EmulatorDeviceIdSnapshot | undefined,
     expectedDeviceId?: string,
-  ): EmulatorDeviceIdReservation | undefined {
-    const reservation = this.reserveEmulatorDeviceId(
+  ): Promise<EmulatorDeviceIdReservation | undefined> {
+    const reservation = await this.reserveEmulatorDeviceId(
       preLaunchSnapshot,
       args,
       expectedDeviceId,
@@ -2241,8 +2311,15 @@ export class AndroidEmulatorClient implements AndroidEmulator {
     childProcess: ChildProcess,
     reservation: EmulatorDeviceIdReservation,
   ): void {
+    this.releasePendingEmulatorDeviceId(reservation);
     AndroidEmulatorClient.reservedLaunchDeviceIds.set(childProcess, reservation);
     this.recordLaunchTargetDeviceId(childProcess, reservation.deviceId, "reserved console port");
+  }
+
+  private releasePendingEmulatorDeviceId(reservation: EmulatorDeviceIdReservation): void {
+    if (AndroidEmulatorClient.pendingLaunchDeviceIds.get(reservation.deviceId) === reservation) {
+      AndroidEmulatorClient.pendingLaunchDeviceIds.delete(reservation.deviceId);
+    }
   }
 
   private releaseReservedEmulatorDeviceId(childProcess?: ChildProcess | null): void {

--- a/src/utils/android-cmdline-tools/AndroidEmulatorClient.ts
+++ b/src/utils/android-cmdline-tools/AndroidEmulatorClient.ts
@@ -426,7 +426,8 @@ export class AndroidEmulatorClient implements AndroidEmulator {
   // startDevice creates a fresh client per request, so reservations must cover
   // every client in the daemon rather than one client instance.
   private static readonly reservedLaunchDeviceIds = new Map<ChildProcess, string>();
-  private static readonly terminalReservedDeviceIds = new Set<string>();
+  private static readonly terminalReservedDeviceIds = new Map<string, number>();
+  private static terminalReservationGeneration = 0;
   private readonly launchErrors = new WeakMap<ChildProcess, ActionableError>();
   private readonly launchErrorFinalizations = new WeakMap<
     ChildProcess,
@@ -468,6 +469,7 @@ export class AndroidEmulatorClient implements AndroidEmulator {
   static resetLaunchReservationsForTesting(): void {
     AndroidEmulatorClient.reservedLaunchDeviceIds.clear();
     AndroidEmulatorClient.terminalReservedDeviceIds.clear();
+    AndroidEmulatorClient.terminalReservationGeneration = 0;
   }
 
   /**
@@ -2019,6 +2021,9 @@ export class AndroidEmulatorClient implements AndroidEmulator {
     if (!capture) {
       return undefined;
     }
+    const terminalReservationsAtSnapshot = new Map(
+      AndroidEmulatorClient.terminalReservedDeviceIds,
+    );
     try {
       const adb = this.adbFactory.create(null);
       const devices = await adb.getBootedAndroidDevices({
@@ -2040,7 +2045,7 @@ export class AndroidEmulatorClient implements AndroidEmulator {
           deviceIds.add(deviceId);
         }
       }
-      this.releaseAbsentTerminalReservations(deviceIds);
+      this.releaseAbsentTerminalReservations(deviceIds, terminalReservationsAtSnapshot);
       return deviceIds;
     } catch (error) {
       if (signal?.aborted) {
@@ -2080,7 +2085,7 @@ export class AndroidEmulatorClient implements AndroidEmulator {
     return new Set([
       ...(preexistingDeviceIds ?? []),
       ...AndroidEmulatorClient.reservedLaunchDeviceIds.values(),
-      ...AndroidEmulatorClient.terminalReservedDeviceIds,
+      ...AndroidEmulatorClient.terminalReservedDeviceIds.keys(),
     ]);
   }
 
@@ -2156,13 +2161,22 @@ export class AndroidEmulatorClient implements AndroidEmulator {
       AndroidEmulatorClient.reservedLaunchDeviceIds.delete(childProcess);
       // ADB can retain an exited emulator briefly. Keep its port unavailable
       // until a later successful snapshot confirms the serial has disappeared.
-      AndroidEmulatorClient.terminalReservedDeviceIds.add(deviceId);
+      AndroidEmulatorClient.terminalReservedDeviceIds.set(
+        deviceId,
+        ++AndroidEmulatorClient.terminalReservationGeneration,
+      );
     }
   }
 
-  private releaseAbsentTerminalReservations(deviceIds: ReadonlySet<string>): void {
-    for (const deviceId of AndroidEmulatorClient.terminalReservedDeviceIds) {
-      if (!deviceIds.has(deviceId)) {
+  private releaseAbsentTerminalReservations(
+    deviceIds: ReadonlySet<string>,
+    terminalReservationsAtSnapshot: ReadonlyMap<string, number>,
+  ): void {
+    for (const [deviceId, generation] of terminalReservationsAtSnapshot) {
+      if (
+        !deviceIds.has(deviceId) &&
+        AndroidEmulatorClient.terminalReservedDeviceIds.get(deviceId) === generation
+      ) {
         AndroidEmulatorClient.terminalReservedDeviceIds.delete(deviceId);
       }
     }

--- a/src/utils/android-cmdline-tools/AndroidEmulatorClient.ts
+++ b/src/utils/android-cmdline-tools/AndroidEmulatorClient.ts
@@ -335,10 +335,12 @@ function parseEmulatorConsolePort(
     !consolePortText ||
     !Number.isInteger(consolePort) ||
     consolePort < MIN_EMULATOR_CONSOLE_PORT ||
+    consolePort > MAX_EMULATOR_CONSOLE_PORT ||
     consolePort % EMULATOR_CONSOLE_PORT_STEP !== 0
   ) {
     throw new ActionableError(
-      `Emulator ${option} must specify an even console port of at least ${MIN_EMULATOR_CONSOLE_PORT}`,
+      `Emulator ${option} must specify an even console port from ` +
+        `${MIN_EMULATOR_CONSOLE_PORT} through ${MAX_EMULATOR_CONSOLE_PORT}`,
     );
   }
   return consolePort;
@@ -384,10 +386,12 @@ function emulatorPortsForDeviceId(deviceId: string | undefined): EmulatorPortPai
   if (
     !Number.isInteger(consolePort) ||
     consolePort < MIN_EMULATOR_CONSOLE_PORT ||
+    consolePort > MAX_EMULATOR_CONSOLE_PORT ||
     consolePort % EMULATOR_CONSOLE_PORT_STEP !== 0
   ) {
     throw new ActionableError(
-      `Expected emulator device ID '${deviceId}' must use an even console port of at least ${MIN_EMULATOR_CONSOLE_PORT}`,
+      `Expected emulator device ID '${deviceId}' must use an even console port from ` +
+        `${MIN_EMULATOR_CONSOLE_PORT} through ${MAX_EMULATOR_CONSOLE_PORT}`,
     );
   }
   return { consolePort, adbPort: consolePort + 1 };
@@ -1518,6 +1522,20 @@ export class AndroidEmulatorClient implements AndroidEmulator {
     }
   }
 
+  private releaseReservationIfLaunchCancelled(
+    avdName: string,
+    reservation: EmulatorDeviceIdReservation | undefined,
+    isCancelled?: () => boolean,
+  ): void {
+    if (!isCancelled?.()) {
+      return;
+    }
+    if (reservation) {
+      this.releasePendingEmulatorDeviceId(reservation);
+    }
+    this.throwIfLaunchCancelled(avdName, isCancelled);
+  }
+
   private async startEmulatorProcess(
     avdName: string,
     requestedExtraArgs?: readonly string[],
@@ -1598,7 +1616,9 @@ export class AndroidEmulatorClient implements AndroidEmulator {
       args,
       preLaunchEmulatorDeviceSnapshot,
       expectedDeviceId,
+      signal,
     );
+    this.releaseReservationIfLaunchCancelled(avdName, reservedEmulator, isCancelled);
     logger.info(`Starting emulator with AVD: ${avdName}`);
     logger.debug(`Emulator command: ${this.emulatorPath} ${args.join(" ")}`);
 
@@ -2165,6 +2185,7 @@ export class AndroidEmulatorClient implements AndroidEmulator {
 
   private async allocateReservedEmulatorPorts(
     preexistingDeviceIds: ReadonlySet<string>,
+    signal?: AbortSignal,
   ): Promise<EmulatorDeviceIdReservation> {
     const unavailablePorts = this.unavailableEmulatorPorts(preexistingDeviceIds);
     for (
@@ -2176,7 +2197,7 @@ export class AndroidEmulatorClient implements AndroidEmulator {
       if (
         !unavailablePorts.has(ports.consolePort) &&
         !unavailablePorts.has(ports.adbPort) &&
-        (await this.areEmulatorPortsAvailableOnHost(ports))
+        (await this.areEmulatorPortsAvailableOnHost(ports, signal))
       ) {
         const currentUnavailablePorts = this.unavailableEmulatorPorts(preexistingDeviceIds);
         if (
@@ -2219,12 +2240,35 @@ export class AndroidEmulatorClient implements AndroidEmulator {
     return unavailablePorts;
   }
 
-  private async areEmulatorPortsAvailableOnHost(ports: EmulatorPortPair): Promise<boolean> {
-    const availability = await Promise.all([
+  private async areEmulatorPortsAvailableOnHost(
+    ports: EmulatorPortPair,
+    signal?: AbortSignal,
+  ): Promise<boolean> {
+    const availability = Promise.all([
       this.hostPortAvailabilityChecker.isAvailable("127.0.0.1", ports.consolePort),
       this.hostPortAvailabilityChecker.isAvailable("127.0.0.1", ports.adbPort),
     ]);
-    return availability.every(Boolean);
+    if (!signal) {
+      return (await availability).every(Boolean);
+    }
+    if (signal.aborted) {
+      throw new ActionableError("Android emulator launch was cancelled while checking host ports");
+    }
+    let rejectCancellation!: (error: ActionableError) => void;
+    const cancellation = new Promise<never>((_resolve, reject) => {
+      rejectCancellation = reject;
+    });
+    const onAbort = () => {
+      rejectCancellation(
+        new ActionableError("Android emulator launch was cancelled while checking host ports"),
+      );
+    };
+    signal.addEventListener("abort", onAbort, { once: true });
+    try {
+      return (await Promise.race([availability, cancellation])).every(Boolean);
+    } finally {
+      signal.removeEventListener("abort", onAbort);
+    }
   }
 
   private assertEmulatorPortsNotReserved(
@@ -2243,9 +2287,10 @@ export class AndroidEmulatorClient implements AndroidEmulator {
   private async assertEmulatorPortsAvailable(
     ports: EmulatorPortPair,
     preexistingDeviceIds: ReadonlySet<string> | undefined,
+    signal?: AbortSignal,
   ): Promise<void> {
     this.assertEmulatorPortsNotReserved(ports, preexistingDeviceIds);
-    if (!(await this.areEmulatorPortsAvailableOnHost(ports))) {
+    if (!(await this.areEmulatorPortsAvailableOnHost(ports, signal))) {
       throw new ActionableError(
         `Cannot safely launch an Android emulator: emulator port pair ` +
           `${ports.consolePort}/${ports.adbPort} is already in use`,
@@ -2271,6 +2316,7 @@ export class AndroidEmulatorClient implements AndroidEmulator {
     preLaunchSnapshot: EmulatorDeviceIdSnapshot | undefined,
     args: readonly string[],
     expectedDeviceId?: string,
+    signal?: AbortSignal,
   ): Promise<EmulatorDeviceIdReservation | undefined> {
     const expectedEmulatorPorts = emulatorPortsForDeviceId(expectedDeviceId);
     if (expectedDeviceId && !expectedEmulatorPorts) {
@@ -2289,7 +2335,7 @@ export class AndroidEmulatorClient implements AndroidEmulator {
     }
     const ports = configuredPorts ?? expectedEmulatorPorts;
     if (ports) {
-      await this.assertEmulatorPortsAvailable(ports, preLaunchSnapshot?.deviceIds);
+      await this.assertEmulatorPortsAvailable(ports, preLaunchSnapshot?.deviceIds, signal);
       return this.reservePendingEmulatorDeviceId(ports, configuredPorts === undefined);
     }
     if (!preLaunchSnapshot?.isComplete) {
@@ -2297,6 +2343,7 @@ export class AndroidEmulatorClient implements AndroidEmulator {
     }
     return this.allocateReservedEmulatorPorts(
       preLaunchSnapshot.deviceIds,
+      signal,
     );
   }
 
@@ -2304,11 +2351,13 @@ export class AndroidEmulatorClient implements AndroidEmulator {
     args: string[],
     preLaunchSnapshot: EmulatorDeviceIdSnapshot | undefined,
     expectedDeviceId?: string,
+    signal?: AbortSignal,
   ): Promise<EmulatorDeviceIdReservation | undefined> {
     const reservation = await this.reserveEmulatorDeviceId(
       preLaunchSnapshot,
       args,
       expectedDeviceId,
+      signal,
     );
     if (reservation?.appendPort) {
       args.push("-port", String(reservation.ports.consolePort));

--- a/src/utils/android-cmdline-tools/AndroidEmulatorClient.ts
+++ b/src/utils/android-cmdline-tools/AndroidEmulatorClient.ts
@@ -289,6 +289,11 @@ export function parseExtraEmulatorArguments(raw: string): string[] {
   return [...parsed];
 }
 
+type EmulatorPortPair = {
+  readonly consolePort: number;
+  readonly adbPort: number;
+};
+
 type EmulatorConsolePortArgument = {
   readonly option: "-port" | "-ports";
   readonly value: string | undefined;
@@ -317,8 +322,10 @@ function emulatorConsolePortArgument(
     : undefined;
 }
 
-function parseEmulatorConsolePort(argument: EmulatorConsolePortArgument): number {
-  const consolePortText = argument.value?.split(",", 1)[0];
+function parseEmulatorConsolePort(
+  consolePortText: string | undefined,
+  option: EmulatorConsolePortArgument["option"],
+): number {
   const consolePort = Number(consolePortText);
   if (
     !consolePortText ||
@@ -327,13 +334,45 @@ function parseEmulatorConsolePort(argument: EmulatorConsolePortArgument): number
     consolePort % EMULATOR_CONSOLE_PORT_STEP !== 0
   ) {
     throw new ActionableError(
-      `Emulator ${argument.option} must specify an even console port of at least ${MIN_EMULATOR_CONSOLE_PORT}`,
+      `Emulator ${option} must specify an even console port of at least ${MIN_EMULATOR_CONSOLE_PORT}`,
     );
   }
   return consolePort;
 }
 
-function emulatorDeviceIdForConsolePort(deviceId: string | undefined): string | undefined {
+function parseEmulatorAdbPort(adbPortText: string | undefined, additionalValues: readonly string[]): number {
+  const adbPort = Number(adbPortText);
+  if (
+    !adbPortText ||
+    additionalValues.length > 0 ||
+    !Number.isInteger(adbPort) ||
+    adbPort < 1 ||
+    adbPort > 65_535
+  ) {
+    throw new ActionableError(
+      "Emulator -ports must specify distinct console and ADB TCP ports",
+    );
+  }
+  return adbPort;
+}
+
+function parseEmulatorPortPair(argument: EmulatorConsolePortArgument): EmulatorPortPair {
+  const [consolePortText, adbPortText, ...additionalValues] = argument.value?.split(",") ?? [];
+  const consolePort = parseEmulatorConsolePort(consolePortText, argument.option);
+  if (argument.option === "-port") {
+    return { consolePort, adbPort: consolePort + 1 };
+  }
+
+  const adbPort = parseEmulatorAdbPort(adbPortText, additionalValues);
+  if (adbPort === consolePort) {
+    throw new ActionableError(
+      "Emulator -ports must specify distinct console and ADB TCP ports",
+    );
+  }
+  return { consolePort, adbPort };
+}
+
+function emulatorPortsForDeviceId(deviceId: string | undefined): EmulatorPortPair | undefined {
   if (!deviceId?.startsWith("emulator-")) {
     return undefined;
   }
@@ -347,6 +386,10 @@ function emulatorDeviceIdForConsolePort(deviceId: string | undefined): string | 
       `Expected emulator device ID '${deviceId}' must use an even console port of at least ${MIN_EMULATOR_CONSOLE_PORT}`,
     );
   }
+  return { consolePort, adbPort: consolePort + 1 };
+}
+
+function emulatorDeviceIdForConsolePort(consolePort: number): string {
   return `emulator-${consolePort}`;
 }
 
@@ -354,8 +397,8 @@ function shouldCaptureEmulatorReservationSnapshot(deviceId: string | undefined):
   return deviceId === undefined || deviceId.startsWith("emulator-");
 }
 
-function configuredEmulatorConsoleDeviceId(args: readonly string[]): string | undefined {
-  let configuredPort: number | undefined;
+function configuredEmulatorPorts(args: readonly string[]): EmulatorPortPair | undefined {
+  let configuredPorts: EmulatorPortPair | undefined;
   for (let index = 0; index < args.length; index += 1) {
     const argument = emulatorConsolePortArgument(args, index);
     if (!argument) {
@@ -364,20 +407,30 @@ function configuredEmulatorConsoleDeviceId(args: readonly string[]): string | un
     if (argument.consumesFollowingArgument) {
       index += 1;
     }
-    const consolePort = parseEmulatorConsolePort(argument);
-    if (configuredPort !== undefined && configuredPort !== consolePort) {
+    const ports = parseEmulatorPortPair(argument);
+    if (
+      configuredPorts &&
+      (configuredPorts.consolePort !== ports.consolePort ||
+        configuredPorts.adbPort !== ports.adbPort)
+    ) {
       throw new ActionableError(
-        "Emulator arguments specify multiple different console ports",
+        "Emulator arguments specify multiple different port pairs",
       );
     }
-    configuredPort = consolePort;
+    configuredPorts = ports;
   }
-  return configuredPort === undefined ? undefined : `emulator-${configuredPort}`;
+  return configuredPorts;
 }
 
 type EmulatorDeviceIdReservation = {
   readonly deviceId: string;
+  readonly ports: EmulatorPortPair;
   readonly appendPort: boolean;
+};
+
+type TerminalEmulatorReservation = {
+  readonly generation: number;
+  readonly ports: EmulatorPortPair;
 };
 
 type EmulatorDeviceIdSnapshot = {
@@ -430,8 +483,8 @@ export class AndroidEmulatorClient implements AndroidEmulator {
   private readonly launchTargetDeviceIds = new WeakMap<ChildProcess, string>();
   // startDevice creates a fresh client per request, so reservations must cover
   // every client in the daemon rather than one client instance.
-  private static readonly reservedLaunchDeviceIds = new Map<ChildProcess, string>();
-  private static readonly terminalReservedDeviceIds = new Map<string, number>();
+  private static readonly reservedLaunchDeviceIds = new Map<ChildProcess, EmulatorDeviceIdReservation>();
+  private static readonly terminalReservedDeviceIds = new Map<string, TerminalEmulatorReservation>();
   private static terminalReservationGeneration = 0;
   private readonly launchErrors = new WeakMap<ChildProcess, ActionableError>();
   private readonly launchErrorFinalizations = new WeakMap<
@@ -1511,7 +1564,7 @@ export class AndroidEmulatorClient implements AndroidEmulator {
       signal,
     );
     this.throwIfLaunchCancelled(avdName, isCancelled);
-    const reservedDeviceId = this.addReservedEmulatorPort(
+    const reservedEmulator = this.addReservedEmulatorPort(
       args,
       preLaunchEmulatorDeviceSnapshot,
       expectedDeviceId,
@@ -1523,8 +1576,8 @@ export class AndroidEmulatorClient implements AndroidEmulator {
       perf.startOperation("spawnEmulator");
       const child = this.spawnFn(this.emulatorPath, args);
       perf.endOperation("spawnEmulator");
-      if (reservedDeviceId) {
-        this.recordReservedEmulatorDeviceId(child, reservedDeviceId);
+      if (reservedEmulator) {
+        this.recordReservedEmulatorDeviceId(child, reservedEmulator);
       }
       onSpawn?.(child);
 
@@ -2072,18 +2125,18 @@ export class AndroidEmulatorClient implements AndroidEmulator {
     }
   }
 
-  private allocateReservedEmulatorDeviceId(
+  private allocateReservedEmulatorPorts(
     preexistingDeviceIds: ReadonlySet<string>,
-  ): string {
-    const unavailableDeviceIds = this.unavailableEmulatorDeviceIds(preexistingDeviceIds);
+  ): EmulatorPortPair {
+    const unavailablePorts = this.unavailableEmulatorPorts(preexistingDeviceIds);
     for (
       let port = MIN_EMULATOR_CONSOLE_PORT;
       port <= MAX_EMULATOR_CONSOLE_PORT;
       port += EMULATOR_CONSOLE_PORT_STEP
     ) {
-      const deviceId = `emulator-${port}`;
-      if (!unavailableDeviceIds.has(deviceId)) {
-        return deviceId;
+      const ports = { consolePort: port, adbPort: port + 1 };
+      if (!unavailablePorts.has(ports.consolePort) && !unavailablePorts.has(ports.adbPort)) {
+        return ports;
       }
     }
     throw new ActionableError(
@@ -2092,14 +2145,40 @@ export class AndroidEmulatorClient implements AndroidEmulator {
     );
   }
 
-  private unavailableEmulatorDeviceIds(
+  private unavailableEmulatorPorts(
     preexistingDeviceIds: ReadonlySet<string> | undefined,
-  ): Set<string> {
-    return new Set([
-      ...(preexistingDeviceIds ?? []),
-      ...AndroidEmulatorClient.reservedLaunchDeviceIds.values(),
-      ...AndroidEmulatorClient.terminalReservedDeviceIds.keys(),
-    ]);
+  ): Set<number> {
+    const unavailablePorts = new Set<number>();
+    const reservePorts = (ports: EmulatorPortPair) => {
+      unavailablePorts.add(ports.consolePort);
+      unavailablePorts.add(ports.adbPort);
+    };
+    for (const deviceId of preexistingDeviceIds ?? []) {
+      const ports = emulatorPortsForDeviceId(deviceId);
+      if (ports) {
+        reservePorts(ports);
+      }
+    }
+    for (const reservation of AndroidEmulatorClient.reservedLaunchDeviceIds.values()) {
+      reservePorts(reservation.ports);
+    }
+    for (const reservation of AndroidEmulatorClient.terminalReservedDeviceIds.values()) {
+      reservePorts(reservation.ports);
+    }
+    return unavailablePorts;
+  }
+
+  private assertEmulatorPortsAvailable(
+    ports: EmulatorPortPair,
+    preexistingDeviceIds: ReadonlySet<string> | undefined,
+  ): void {
+    const unavailablePorts = this.unavailableEmulatorPorts(preexistingDeviceIds);
+    if (unavailablePorts.has(ports.consolePort) || unavailablePorts.has(ports.adbPort)) {
+      throw new ActionableError(
+        `Cannot safely launch an Android emulator: console port ` +
+          `${ports.consolePort} is already in use`,
+      );
+    }
   }
 
   private reserveEmulatorDeviceId(
@@ -2107,36 +2186,37 @@ export class AndroidEmulatorClient implements AndroidEmulator {
     args: readonly string[],
     expectedDeviceId?: string,
   ): EmulatorDeviceIdReservation | undefined {
-    const expectedEmulatorDeviceId = emulatorDeviceIdForConsolePort(expectedDeviceId);
-    if (expectedDeviceId && !expectedEmulatorDeviceId) {
+    const expectedEmulatorPorts = emulatorPortsForDeviceId(expectedDeviceId);
+    if (expectedDeviceId && !expectedEmulatorPorts) {
       return undefined;
     }
-    const configuredDeviceId = configuredEmulatorConsoleDeviceId(args);
+    const configuredPorts = configuredEmulatorPorts(args);
     if (
-      expectedEmulatorDeviceId &&
-      configuredDeviceId &&
-      expectedEmulatorDeviceId !== configuredDeviceId
+      expectedEmulatorPorts &&
+      configuredPorts &&
+      expectedEmulatorPorts.consolePort !== configuredPorts.consolePort
     ) {
       throw new ActionableError(
-        `Expected emulator device ID '${expectedEmulatorDeviceId}' conflicts with configured ` +
-          `console port ${configuredDeviceId.slice("emulator-".length)}`,
+        `Expected emulator device ID '${expectedDeviceId}' conflicts with configured ` +
+          `console port ${configuredPorts.consolePort}`,
       );
     }
-    const deviceId = expectedEmulatorDeviceId ?? configuredDeviceId;
-    if (deviceId) {
-      if (this.unavailableEmulatorDeviceIds(preLaunchSnapshot?.deviceIds).has(deviceId)) {
-        throw new ActionableError(
-          `Cannot safely launch an Android emulator: console port ` +
-            `${deviceId.slice("emulator-".length)} is already in use`,
-        );
-      }
-      return { deviceId, appendPort: configuredDeviceId === undefined };
+    const ports = configuredPorts ?? expectedEmulatorPorts;
+    if (ports) {
+      this.assertEmulatorPortsAvailable(ports, preLaunchSnapshot?.deviceIds);
+      return {
+        deviceId: emulatorDeviceIdForConsolePort(ports.consolePort),
+        ports,
+        appendPort: configuredPorts === undefined,
+      };
     }
     if (!preLaunchSnapshot?.isComplete) {
       return undefined;
     }
+    const allocatedPorts = this.allocateReservedEmulatorPorts(preLaunchSnapshot.deviceIds);
     return {
-      deviceId: this.allocateReservedEmulatorDeviceId(preLaunchSnapshot.deviceIds),
+      deviceId: emulatorDeviceIdForConsolePort(allocatedPorts.consolePort),
+      ports: allocatedPorts,
       appendPort: true,
     };
   }
@@ -2145,50 +2225,50 @@ export class AndroidEmulatorClient implements AndroidEmulator {
     args: string[],
     preLaunchSnapshot: EmulatorDeviceIdSnapshot | undefined,
     expectedDeviceId?: string,
-  ): string | undefined {
+  ): EmulatorDeviceIdReservation | undefined {
     const reservation = this.reserveEmulatorDeviceId(
       preLaunchSnapshot,
       args,
       expectedDeviceId,
     );
     if (reservation?.appendPort) {
-      args.push("-port", reservation.deviceId.slice("emulator-".length));
+      args.push("-port", String(reservation.ports.consolePort));
     }
-    return reservation?.deviceId;
+    return reservation;
   }
 
   private recordReservedEmulatorDeviceId(
     childProcess: ChildProcess,
-    deviceId: string,
+    reservation: EmulatorDeviceIdReservation,
   ): void {
-    AndroidEmulatorClient.reservedLaunchDeviceIds.set(childProcess, deviceId);
-    this.recordLaunchTargetDeviceId(childProcess, deviceId, "reserved console port");
+    AndroidEmulatorClient.reservedLaunchDeviceIds.set(childProcess, reservation);
+    this.recordLaunchTargetDeviceId(childProcess, reservation.deviceId, "reserved console port");
   }
 
   private releaseReservedEmulatorDeviceId(childProcess?: ChildProcess | null): void {
     if (!childProcess) {
       return;
     }
-    const deviceId = AndroidEmulatorClient.reservedLaunchDeviceIds.get(childProcess);
-    if (deviceId) {
+    const reservation = AndroidEmulatorClient.reservedLaunchDeviceIds.get(childProcess);
+    if (reservation) {
       AndroidEmulatorClient.reservedLaunchDeviceIds.delete(childProcess);
       // ADB can retain an exited emulator briefly. Keep its port unavailable
       // until a later successful snapshot confirms the serial has disappeared.
-      AndroidEmulatorClient.terminalReservedDeviceIds.set(
-        deviceId,
-        ++AndroidEmulatorClient.terminalReservationGeneration,
-      );
+      AndroidEmulatorClient.terminalReservedDeviceIds.set(reservation.deviceId, {
+        generation: ++AndroidEmulatorClient.terminalReservationGeneration,
+        ports: reservation.ports,
+      });
     }
   }
 
   private releaseAbsentTerminalReservations(
     deviceIds: ReadonlySet<string>,
-    terminalReservationsAtSnapshot: ReadonlyMap<string, number>,
+    terminalReservationsAtSnapshot: ReadonlyMap<string, TerminalEmulatorReservation>,
   ): void {
-    for (const [deviceId, generation] of terminalReservationsAtSnapshot) {
+    for (const [deviceId, reservation] of terminalReservationsAtSnapshot) {
       if (
         !deviceIds.has(deviceId) &&
-        AndroidEmulatorClient.terminalReservedDeviceIds.get(deviceId) === generation
+        AndroidEmulatorClient.terminalReservedDeviceIds.get(deviceId)?.generation === reservation.generation
       ) {
         AndroidEmulatorClient.terminalReservedDeviceIds.delete(deviceId);
       }

--- a/src/utils/android-cmdline-tools/AndroidEmulatorClient.ts
+++ b/src/utils/android-cmdline-tools/AndroidEmulatorClient.ts
@@ -1921,7 +1921,8 @@ export class AndroidEmulatorClient implements AndroidEmulator {
       return undefined;
     }
     try {
-      const devices = await this.adbFactory.create(null).getBootedAndroidDevices({
+      const adb = this.adbFactory.create(null);
+      const devices = await adb.getBootedAndroidDevices({
         bypassCache: true,
         throwOnMissingAdb: true,
       });
@@ -1930,6 +1931,12 @@ export class AndroidEmulatorClient implements AndroidEmulator {
           .map((device) => device.deviceId)
           .filter((deviceId): deviceId is string => deviceId.startsWith("emulator-")),
       );
+      const deviceStates = (await adb.getDeviceStates?.()) ?? [];
+      for (const { deviceId } of deviceStates) {
+        if (deviceId.startsWith("emulator-")) {
+          deviceIds.add(deviceId);
+        }
+      }
       this.releaseAbsentTerminalReservations(deviceIds);
       return deviceIds;
     } catch (error) {

--- a/src/utils/android-cmdline-tools/AndroidEmulatorClient.ts
+++ b/src/utils/android-cmdline-tools/AndroidEmulatorClient.ts
@@ -350,6 +350,10 @@ function emulatorDeviceIdForConsolePort(deviceId: string | undefined): string | 
   return `emulator-${consolePort}`;
 }
 
+function shouldCaptureEmulatorReservationSnapshot(deviceId: string | undefined): boolean {
+  return deviceId === undefined || deviceId.startsWith("emulator-");
+}
+
 function configuredEmulatorConsoleDeviceId(args: readonly string[]): string | undefined {
   let configuredPort: number | undefined;
   for (let index = 0; index < args.length; index += 1) {
@@ -1376,7 +1380,7 @@ export class AndroidEmulatorClient implements AndroidEmulator {
           }
         },
         () => disposed,
-        request.deviceId === undefined,
+        shouldCaptureEmulatorReservationSnapshot(request.deviceId),
         request.deviceId,
       );
       if (disposed) {

--- a/src/utils/android-cmdline-tools/AndroidEmulatorClient.ts
+++ b/src/utils/android-cmdline-tools/AndroidEmulatorClient.ts
@@ -333,6 +333,23 @@ function parseEmulatorConsolePort(argument: EmulatorConsolePortArgument): number
   return consolePort;
 }
 
+function emulatorDeviceIdForConsolePort(deviceId: string | undefined): string | undefined {
+  if (!deviceId?.startsWith("emulator-")) {
+    return undefined;
+  }
+  const consolePort = Number(deviceId.slice("emulator-".length));
+  if (
+    !Number.isInteger(consolePort) ||
+    consolePort < MIN_EMULATOR_CONSOLE_PORT ||
+    consolePort % EMULATOR_CONSOLE_PORT_STEP !== 0
+  ) {
+    throw new ActionableError(
+      `Expected emulator device ID '${deviceId}' must use an even console port of at least ${MIN_EMULATOR_CONSOLE_PORT}`,
+    );
+  }
+  return `emulator-${consolePort}`;
+}
+
 function configuredEmulatorConsoleDeviceId(args: readonly string[]): string | undefined {
   let configuredPort: number | undefined;
   for (let index = 0; index < args.length; index += 1) {
@@ -1360,6 +1377,7 @@ export class AndroidEmulatorClient implements AndroidEmulator {
         },
         () => disposed,
         request.deviceId === undefined,
+        request.deviceId,
       );
       if (disposed) {
         if (process && !process.killed) {
@@ -1411,6 +1429,7 @@ export class AndroidEmulatorClient implements AndroidEmulator {
     onSpawn?: (process: ChildProcess) => void,
     isCancelled?: () => boolean,
     capturePreLaunchDeviceIds: boolean = false,
+    expectedDeviceId?: string,
   ): Promise<ChildProcess | null> {
     logger.info(`Using local emulator for AVD: ${avdName}`);
     const perf = createGlobalPerformanceTracker();
@@ -1481,6 +1500,7 @@ export class AndroidEmulatorClient implements AndroidEmulator {
     const reservedDeviceId = this.addReservedEmulatorPort(
       args,
       preLaunchEmulatorDeviceIds,
+      expectedDeviceId,
     );
     logger.info(`Starting emulator with AVD: ${avdName}`);
     logger.debug(`Emulator command: ${this.emulatorPath} ${args.join(" ")}`);
@@ -2052,16 +2072,32 @@ export class AndroidEmulatorClient implements AndroidEmulator {
   private reserveEmulatorDeviceId(
     preexistingDeviceIds: ReadonlySet<string> | undefined,
     args: readonly string[],
+    expectedDeviceId?: string,
   ): EmulatorDeviceIdReservation | undefined {
+    const expectedEmulatorDeviceId = emulatorDeviceIdForConsolePort(expectedDeviceId);
+    if (expectedDeviceId && !expectedEmulatorDeviceId) {
+      return undefined;
+    }
     const configuredDeviceId = configuredEmulatorConsoleDeviceId(args);
-    if (configuredDeviceId) {
-      if (this.unavailableEmulatorDeviceIds(preexistingDeviceIds).has(configuredDeviceId)) {
+    if (
+      expectedEmulatorDeviceId &&
+      configuredDeviceId &&
+      expectedEmulatorDeviceId !== configuredDeviceId
+    ) {
+      throw new ActionableError(
+        `Expected emulator device ID '${expectedEmulatorDeviceId}' conflicts with configured ` +
+          `console port ${configuredDeviceId.slice("emulator-".length)}`,
+      );
+    }
+    const deviceId = expectedEmulatorDeviceId ?? configuredDeviceId;
+    if (deviceId) {
+      if (this.unavailableEmulatorDeviceIds(preexistingDeviceIds).has(deviceId)) {
         throw new ActionableError(
-          `Cannot safely launch an Android emulator: configured console port ` +
-            `${configuredDeviceId.slice("emulator-".length)} is already in use`,
+          `Cannot safely launch an Android emulator: console port ` +
+            `${deviceId.slice("emulator-".length)} is already in use`,
         );
       }
-      return { deviceId: configuredDeviceId, appendPort: false };
+      return { deviceId, appendPort: configuredDeviceId === undefined };
     }
     if (!preexistingDeviceIds) {
       return undefined;
@@ -2075,8 +2111,13 @@ export class AndroidEmulatorClient implements AndroidEmulator {
   private addReservedEmulatorPort(
     args: string[],
     preexistingDeviceIds: ReadonlySet<string> | undefined,
+    expectedDeviceId?: string,
   ): string | undefined {
-    const reservation = this.reserveEmulatorDeviceId(preexistingDeviceIds, args);
+    const reservation = this.reserveEmulatorDeviceId(
+      preexistingDeviceIds,
+      args,
+      expectedDeviceId,
+    );
     if (reservation?.appendPort) {
       args.push("-port", reservation.deviceId.slice("emulator-".length));
     }

--- a/src/utils/android-cmdline-tools/AndroidEmulatorClient.ts
+++ b/src/utils/android-cmdline-tools/AndroidEmulatorClient.ts
@@ -289,6 +289,76 @@ export function parseExtraEmulatorArguments(raw: string): string[] {
   return [...parsed];
 }
 
+type EmulatorConsolePortArgument = {
+  readonly option: "-port" | "-ports";
+  readonly value: string | undefined;
+  readonly consumesFollowingArgument: boolean;
+};
+
+function emulatorConsolePortArgument(
+  args: readonly string[],
+  index: number,
+): EmulatorConsolePortArgument | undefined {
+  const argument = args[index];
+  if (argument === "-port" || argument === "-ports") {
+    return {
+      option: argument,
+      value: args[index + 1],
+      consumesFollowingArgument: true,
+    };
+  }
+  const match = argument.match(/^-(port|ports)=(.*)$/);
+  return match
+    ? {
+        option: `-${match[1]}` as "-port" | "-ports",
+        value: match[2],
+        consumesFollowingArgument: false,
+      }
+    : undefined;
+}
+
+function parseEmulatorConsolePort(argument: EmulatorConsolePortArgument): number {
+  const consolePortText = argument.value?.split(",", 1)[0];
+  const consolePort = Number(consolePortText);
+  if (
+    !consolePortText ||
+    !Number.isInteger(consolePort) ||
+    consolePort < MIN_EMULATOR_CONSOLE_PORT ||
+    consolePort % EMULATOR_CONSOLE_PORT_STEP !== 0
+  ) {
+    throw new ActionableError(
+      `Emulator ${argument.option} must specify an even console port of at least ${MIN_EMULATOR_CONSOLE_PORT}`,
+    );
+  }
+  return consolePort;
+}
+
+function configuredEmulatorConsoleDeviceId(args: readonly string[]): string | undefined {
+  let configuredPort: number | undefined;
+  for (let index = 0; index < args.length; index += 1) {
+    const argument = emulatorConsolePortArgument(args, index);
+    if (!argument) {
+      continue;
+    }
+    if (argument.consumesFollowingArgument) {
+      index += 1;
+    }
+    const consolePort = parseEmulatorConsolePort(argument);
+    if (configuredPort !== undefined && configuredPort !== consolePort) {
+      throw new ActionableError(
+        "Emulator arguments specify multiple different console ports",
+      );
+    }
+    configuredPort = consolePort;
+  }
+  return configuredPort === undefined ? undefined : `emulator-${configuredPort}`;
+}
+
+type EmulatorDeviceIdReservation = {
+  readonly deviceId: string;
+  readonly appendPort: boolean;
+};
+
 const execAsync = async (
   file: string,
   args: string[],
@@ -1503,11 +1573,12 @@ export class AndroidEmulatorClient implements AndroidEmulator {
           return;
         }
         clearExitDrainTimeout();
-        if (
+      if (
           duplicateAvdDetected ||
           output.includes("Running multiple emulators with the same AVD")
         ) {
           this.launchErrors.delete(child);
+          this.launchTargetDeviceIds.delete(child);
           const resolveFinalization = resolvePostValidationExit;
           resolvePostValidationExit = undefined;
           resolveFinalization(undefined);
@@ -1951,11 +2022,7 @@ export class AndroidEmulatorClient implements AndroidEmulator {
   private allocateReservedEmulatorDeviceId(
     preexistingDeviceIds: ReadonlySet<string>,
   ): string {
-    const unavailableDeviceIds = new Set([
-      ...preexistingDeviceIds,
-      ...AndroidEmulatorClient.reservedLaunchDeviceIds.values(),
-      ...AndroidEmulatorClient.terminalReservedDeviceIds,
-    ]);
+    const unavailableDeviceIds = this.unavailableEmulatorDeviceIds(preexistingDeviceIds);
     for (
       let port = MIN_EMULATOR_CONSOLE_PORT;
       port <= MAX_EMULATOR_CONSOLE_PORT;
@@ -1972,24 +2039,48 @@ export class AndroidEmulatorClient implements AndroidEmulator {
     );
   }
 
+  private unavailableEmulatorDeviceIds(
+    preexistingDeviceIds: ReadonlySet<string> | undefined,
+  ): Set<string> {
+    return new Set([
+      ...(preexistingDeviceIds ?? []),
+      ...AndroidEmulatorClient.reservedLaunchDeviceIds.values(),
+      ...AndroidEmulatorClient.terminalReservedDeviceIds,
+    ]);
+  }
+
   private reserveEmulatorDeviceId(
     preexistingDeviceIds: ReadonlySet<string> | undefined,
-  ): string | undefined {
+    args: readonly string[],
+  ): EmulatorDeviceIdReservation | undefined {
+    const configuredDeviceId = configuredEmulatorConsoleDeviceId(args);
+    if (configuredDeviceId) {
+      if (this.unavailableEmulatorDeviceIds(preexistingDeviceIds).has(configuredDeviceId)) {
+        throw new ActionableError(
+          `Cannot safely launch an Android emulator: configured console port ` +
+            `${configuredDeviceId.slice("emulator-".length)} is already in use`,
+        );
+      }
+      return { deviceId: configuredDeviceId, appendPort: false };
+    }
     if (!preexistingDeviceIds) {
       return undefined;
     }
-    return this.allocateReservedEmulatorDeviceId(preexistingDeviceIds);
+    return {
+      deviceId: this.allocateReservedEmulatorDeviceId(preexistingDeviceIds),
+      appendPort: true,
+    };
   }
 
   private addReservedEmulatorPort(
     args: string[],
     preexistingDeviceIds: ReadonlySet<string> | undefined,
   ): string | undefined {
-    const deviceId = this.reserveEmulatorDeviceId(preexistingDeviceIds);
-    if (deviceId) {
-      args.push("-port", deviceId.slice("emulator-".length));
+    const reservation = this.reserveEmulatorDeviceId(preexistingDeviceIds, args);
+    if (reservation?.appendPort) {
+      args.push("-port", reservation.deviceId.slice("emulator-".length));
     }
-    return deviceId;
+    return reservation?.deviceId;
   }
 
   private recordReservedEmulatorDeviceId(

--- a/src/utils/android-cmdline-tools/AndroidEmulatorClient.ts
+++ b/src/utils/android-cmdline-tools/AndroidEmulatorClient.ts
@@ -380,6 +380,11 @@ type EmulatorDeviceIdReservation = {
   readonly appendPort: boolean;
 };
 
+type EmulatorDeviceIdSnapshot = {
+  readonly deviceIds: ReadonlySet<string>;
+  readonly isComplete: boolean;
+};
+
 const execAsync = async (
   file: string,
   args: string[],
@@ -1501,14 +1506,14 @@ export class AndroidEmulatorClient implements AndroidEmulator {
       args.push(...parseExtraEmulatorArguments(extraArgsRaw));
     }
     this.throwIfLaunchCancelled(avdName, isCancelled);
-    const preLaunchEmulatorDeviceIds = await this.capturePreLaunchEmulatorDeviceIds(
+    const preLaunchEmulatorDeviceSnapshot = await this.capturePreLaunchEmulatorDeviceIds(
       capturePreLaunchDeviceIds,
       signal,
     );
     this.throwIfLaunchCancelled(avdName, isCancelled);
     const reservedDeviceId = this.addReservedEmulatorPort(
       args,
-      preLaunchEmulatorDeviceIds,
+      preLaunchEmulatorDeviceSnapshot,
       expectedDeviceId,
     );
     logger.info(`Starting emulator with AVD: ${avdName}`);
@@ -2017,13 +2022,14 @@ export class AndroidEmulatorClient implements AndroidEmulator {
   private async capturePreLaunchEmulatorDeviceIds(
     capture: boolean,
     signal?: AbortSignal,
-  ): Promise<ReadonlySet<string> | undefined> {
+  ): Promise<EmulatorDeviceIdSnapshot | undefined> {
     if (!capture) {
       return undefined;
     }
     const terminalReservationsAtSnapshot = new Map(
       AndroidEmulatorClient.terminalReservedDeviceIds,
     );
+    let deviceIds: Set<string> | undefined;
     try {
       const adb = this.adbFactory.create(null);
       const devices = await adb.getBootedAndroidDevices({
@@ -2031,7 +2037,7 @@ export class AndroidEmulatorClient implements AndroidEmulator {
         throwOnMissingAdb: true,
         signal,
       });
-      const deviceIds = new Set(
+      deviceIds = new Set(
         devices
           .map((device) => device.deviceId)
           .filter((deviceId): deviceId is string => deviceId.startsWith("emulator-")),
@@ -2039,17 +2045,24 @@ export class AndroidEmulatorClient implements AndroidEmulator {
       if (signal?.aborted) {
         throw signal.reason ?? new Error("Android emulator reservation snapshot was cancelled");
       }
-      const deviceStates = (await adb.getDeviceStates?.({ signal })) ?? [];
+      if (!adb.getDeviceStates) {
+        return { deviceIds, isComplete: false };
+      }
+      const deviceStates = await adb.getDeviceStates({ signal });
       for (const { deviceId } of deviceStates) {
         if (deviceId.startsWith("emulator-")) {
           deviceIds.add(deviceId);
         }
       }
       this.releaseAbsentTerminalReservations(deviceIds, terminalReservationsAtSnapshot);
-      return deviceIds;
+      return { deviceIds, isComplete: true };
     } catch (error) {
       if (signal?.aborted) {
         throw error;
+      }
+      if (deviceIds) {
+        logger.debug(`Could not capture all pre-launch emulator device IDs: ${error}`);
+        return { deviceIds, isComplete: false };
       }
       // Without a current device list, do not select a port that could belong to
       // another local emulator. Readiness can still use a captured serial or an
@@ -2090,7 +2103,7 @@ export class AndroidEmulatorClient implements AndroidEmulator {
   }
 
   private reserveEmulatorDeviceId(
-    preexistingDeviceIds: ReadonlySet<string> | undefined,
+    preLaunchSnapshot: EmulatorDeviceIdSnapshot | undefined,
     args: readonly string[],
     expectedDeviceId?: string,
   ): EmulatorDeviceIdReservation | undefined {
@@ -2111,7 +2124,7 @@ export class AndroidEmulatorClient implements AndroidEmulator {
     }
     const deviceId = expectedEmulatorDeviceId ?? configuredDeviceId;
     if (deviceId) {
-      if (this.unavailableEmulatorDeviceIds(preexistingDeviceIds).has(deviceId)) {
+      if (this.unavailableEmulatorDeviceIds(preLaunchSnapshot?.deviceIds).has(deviceId)) {
         throw new ActionableError(
           `Cannot safely launch an Android emulator: console port ` +
             `${deviceId.slice("emulator-".length)} is already in use`,
@@ -2119,22 +2132,22 @@ export class AndroidEmulatorClient implements AndroidEmulator {
       }
       return { deviceId, appendPort: configuredDeviceId === undefined };
     }
-    if (!preexistingDeviceIds) {
+    if (!preLaunchSnapshot?.isComplete) {
       return undefined;
     }
     return {
-      deviceId: this.allocateReservedEmulatorDeviceId(preexistingDeviceIds),
+      deviceId: this.allocateReservedEmulatorDeviceId(preLaunchSnapshot.deviceIds),
       appendPort: true,
     };
   }
 
   private addReservedEmulatorPort(
     args: string[],
-    preexistingDeviceIds: ReadonlySet<string> | undefined,
+    preLaunchSnapshot: EmulatorDeviceIdSnapshot | undefined,
     expectedDeviceId?: string,
   ): string | undefined {
     const reservation = this.reserveEmulatorDeviceId(
-      preexistingDeviceIds,
+      preLaunchSnapshot,
       args,
       expectedDeviceId,
     );

--- a/src/utils/android-cmdline-tools/AndroidEmulatorClient.ts
+++ b/src/utils/android-cmdline-tools/AndroidEmulatorClient.ts
@@ -329,6 +329,10 @@ export class AndroidEmulatorClient implements AndroidEmulator {
   private platform: NodeJS.Platform;
   private hostArchitecture: string;
   private readonly launchTargetDeviceIds = new WeakMap<ChildProcess, string>();
+  private readonly launchPreexistingEmulatorDeviceIds = new WeakMap<
+    ChildProcess,
+    ReadonlySet<string>
+  >();
   private readonly launchErrors = new WeakMap<ChildProcess, ActionableError>();
   private readonly launchErrorFinalizations = new WeakMap<
     ChildProcess,
@@ -1277,6 +1281,7 @@ export class AndroidEmulatorClient implements AndroidEmulator {
           }
         },
         () => disposed,
+        request.deviceId === undefined,
       );
       if (disposed) {
         if (process && !process.killed) {
@@ -1327,6 +1332,7 @@ export class AndroidEmulatorClient implements AndroidEmulator {
     requestedExtraArgs?: readonly string[],
     onSpawn?: (process: ChildProcess) => void,
     isCancelled?: () => boolean,
+    capturePreLaunchDeviceIds: boolean = false,
   ): Promise<ChildProcess | null> {
     logger.info(`Using local emulator for AVD: ${avdName}`);
     const perf = createGlobalPerformanceTracker();
@@ -1392,11 +1398,16 @@ export class AndroidEmulatorClient implements AndroidEmulator {
     logger.info(`Starting emulator with AVD: ${avdName}`);
     logger.debug(`Emulator command: ${this.emulatorPath} ${args.join(" ")}`);
     this.throwIfLaunchCancelled(avdName, isCancelled);
+    const preLaunchEmulatorDeviceIds = await this.capturePreLaunchEmulatorDeviceIds(
+      capturePreLaunchDeviceIds,
+    );
+    this.throwIfLaunchCancelled(avdName, isCancelled);
 
     return new Promise((resolve, reject) => {
       perf.startOperation("spawnEmulator");
       const child = this.spawnFn(this.emulatorPath, args);
       perf.endOperation("spawnEmulator");
+      this.recordPreLaunchEmulatorDeviceIds(child, preLaunchEmulatorDeviceIds);
       onSpawn?.(child);
 
       // Keep only a redacted tail for launch diagnostics and failure classification.
@@ -1887,6 +1898,99 @@ export class AndroidEmulatorClient implements AndroidEmulator {
     return childProcess ? this.launchTargetDeviceIds.get(childProcess) : undefined;
   }
 
+  private async capturePreLaunchEmulatorDeviceIds(
+    capture: boolean,
+  ): Promise<ReadonlySet<string> | undefined> {
+    if (!capture) {
+      return undefined;
+    }
+    try {
+      const devices = await this.adbFactory.create(null).getBootedAndroidDevices({
+        bypassCache: true,
+        throwOnMissingAdb: true,
+      });
+      return new Set(
+        devices
+          .map((device) => device.deviceId)
+          .filter((deviceId): deviceId is string => deviceId.startsWith("emulator-")),
+      );
+    } catch (error) {
+      logger.debug(`Could not capture pre-launch emulator device IDs: ${error}`);
+      return undefined;
+    }
+  }
+
+  private recordPreLaunchEmulatorDeviceIds(
+    childProcess: ChildProcess,
+    preexistingDeviceIds: ReadonlySet<string> | undefined,
+  ): void {
+    if (preexistingDeviceIds) {
+      this.launchPreexistingEmulatorDeviceIds.set(childProcess, preexistingDeviceIds);
+    }
+  }
+
+  private getLaunchPreexistingEmulatorDeviceIds(
+    childProcess?: ChildProcess | null,
+  ): ReadonlySet<string> | undefined {
+    return childProcess ? this.launchPreexistingEmulatorDeviceIds.get(childProcess) : undefined;
+  }
+
+  private correlateNewUnknownEmulator(
+    avdName: string,
+    childProcess: ChildProcess | null | undefined,
+    runningEmulators: BootedDevice[],
+  ): { emulator?: BootedDevice; failure?: string } {
+    const preexistingDeviceIds = this.getLaunchPreexistingEmulatorDeviceIds(childProcess);
+    if (!preexistingDeviceIds) {
+      return {};
+    }
+
+    const newUnknownEmulators = runningEmulators.filter(
+      (candidate) =>
+        candidate.deviceId.startsWith("emulator-") &&
+        !preexistingDeviceIds.has(candidate.deviceId) &&
+        this.isUnknownEmulatorName(candidate.name, candidate.deviceId),
+    );
+    if (newUnknownEmulators.length === 1) {
+      const emulator = newUnknownEmulators[0];
+      logger.debug(`Correlated launched emulator from pre-launch device set: ${emulator.deviceId}`);
+      return { emulator };
+    }
+    if (newUnknownEmulators.length > 1) {
+      const candidateIds = newUnknownEmulators.map((candidate) => candidate.deviceId);
+      return {
+        failure:
+          `Emulator '${avdName}' could not correlate the launched emulator ` +
+          `from ${candidateIds.length} newly discovered unknown devices: ${candidateIds.join(", ")}`,
+      };
+    }
+    return {};
+  }
+
+  private findNamedOrNewUnknownEmulator(
+    avdName: string,
+    childProcess: ChildProcess | null | undefined,
+    runningEmulators: BootedDevice[],
+  ): { emulator?: BootedDevice; failure?: string } {
+    const namedEmulator = runningEmulators.find((emulator) => emulator.name === avdName);
+    logger.debug(
+      `Exact name match for '${avdName}': ${namedEmulator ? `Found ${namedEmulator.deviceId}` : "Not found"}`,
+    );
+    if (namedEmulator) {
+      return { emulator: namedEmulator };
+    }
+
+    const correlation = this.correlateNewUnknownEmulator(
+      avdName,
+      childProcess,
+      runningEmulators,
+    );
+    if (correlation.failure) {
+      logger.debug(correlation.failure);
+    }
+    return correlation;
+  }
+
   private getLaunchError(childProcess?: ChildProcess | null): ActionableError | undefined {
     return childProcess ? this.launchErrors.get(childProcess) : undefined;
   }
@@ -1931,10 +2035,14 @@ export class AndroidEmulatorClient implements AndroidEmulator {
     avdName: string,
     timeoutMs: number,
     processExitError: ActionableError | null,
+    correlationFailure?: string,
   ): ActionableError {
     return (
       processExitError ??
-      new ActionableError(`Emulator '${avdName}' failed to become ready within ${timeoutMs}ms`)
+      new ActionableError(
+        correlationFailure ??
+          `Emulator '${avdName}' failed to become ready within ${timeoutMs}ms`,
+      )
     );
   }
 
@@ -2100,6 +2208,7 @@ export class AndroidEmulatorClient implements AndroidEmulator {
 
     // Start background polling immediately with configurable intervals
     let foundDeviceId: string | null = null;
+    let correlationFailure: string | undefined;
     const offlineTracker = { deviceId: null as string | null, since: null as number | null };
 
     perf.startOperation("devicePolling");
@@ -2136,6 +2245,7 @@ export class AndroidEmulatorClient implements AndroidEmulator {
           logger.debug(`Device scan complete - found ${runningEmulators.length} running emulators`);
           const readinessTimeoutMs = Math.max(0, timeoutMs - (this.timer.now() - startTime));
 
+          correlationFailure = undefined;
           if (runningEmulators.length > 0) {
             logger.debug(
               `Found ${runningEmulators.length} running emulators: ${runningEmulators.map((e) => `${e.name}(${e.deviceId})`).join(", ")}`,
@@ -2162,13 +2272,17 @@ export class AndroidEmulatorClient implements AndroidEmulator {
 
             // Look for emulator by name next.
             if (!emulator && !correlatedTargetDeviceId) {
-              emulator = runningEmulators.find((emu) => emu.name === avdName);
-              logger.debug(
-                `Exact name match for '${avdName}': ${emulator ? `Found ${emulator.deviceId}` : "Not found"}`,
+              const correlation = this.findNamedOrNewUnknownEmulator(
+                avdName,
+                childProcess,
+                runningEmulators,
               );
+              emulator = correlation.emulator;
+              correlationFailure = correlation.failure;
             }
 
             if (emulator && emulator.deviceId) {
+              correlationFailure = undefined;
               logger.debug(
                 `Target emulator found: ${emulator.name} (${emulator.deviceId}) - starting readiness checks`,
               );
@@ -2375,7 +2489,7 @@ export class AndroidEmulatorClient implements AndroidEmulator {
       return bootedDevice;
     }
 
-    throw this.readinessTimeoutError(avdName, timeoutMs, processExitError);
+    throw this.readinessTimeoutError(avdName, timeoutMs, processExitError, correlationFailure);
   }
 
   /**

--- a/src/utils/android-cmdline-tools/AndroidEmulatorClient.ts
+++ b/src/utils/android-cmdline-tools/AndroidEmulatorClient.ts
@@ -1382,6 +1382,7 @@ export class AndroidEmulatorClient implements AndroidEmulator {
         () => disposed,
         shouldCaptureEmulatorReservationSnapshot(request.deviceId),
         request.deviceId,
+        request.signal,
       );
       if (disposed) {
         if (process && !process.killed) {
@@ -1434,6 +1435,7 @@ export class AndroidEmulatorClient implements AndroidEmulator {
     isCancelled?: () => boolean,
     capturePreLaunchDeviceIds: boolean = false,
     expectedDeviceId?: string,
+    signal?: AbortSignal,
   ): Promise<ChildProcess | null> {
     logger.info(`Using local emulator for AVD: ${avdName}`);
     const perf = createGlobalPerformanceTracker();
@@ -1499,6 +1501,7 @@ export class AndroidEmulatorClient implements AndroidEmulator {
     this.throwIfLaunchCancelled(avdName, isCancelled);
     const preLaunchEmulatorDeviceIds = await this.capturePreLaunchEmulatorDeviceIds(
       capturePreLaunchDeviceIds,
+      signal,
     );
     this.throwIfLaunchCancelled(avdName, isCancelled);
     const reservedDeviceId = this.addReservedEmulatorPort(
@@ -2011,6 +2014,7 @@ export class AndroidEmulatorClient implements AndroidEmulator {
 
   private async capturePreLaunchEmulatorDeviceIds(
     capture: boolean,
+    signal?: AbortSignal,
   ): Promise<ReadonlySet<string> | undefined> {
     if (!capture) {
       return undefined;
@@ -2020,13 +2024,17 @@ export class AndroidEmulatorClient implements AndroidEmulator {
       const devices = await adb.getBootedAndroidDevices({
         bypassCache: true,
         throwOnMissingAdb: true,
+        signal,
       });
       const deviceIds = new Set(
         devices
           .map((device) => device.deviceId)
           .filter((deviceId): deviceId is string => deviceId.startsWith("emulator-")),
       );
-      const deviceStates = (await adb.getDeviceStates?.()) ?? [];
+      if (signal?.aborted) {
+        throw signal.reason ?? new Error("Android emulator reservation snapshot was cancelled");
+      }
+      const deviceStates = (await adb.getDeviceStates?.({ signal })) ?? [];
       for (const { deviceId } of deviceStates) {
         if (deviceId.startsWith("emulator-")) {
           deviceIds.add(deviceId);
@@ -2035,6 +2043,9 @@ export class AndroidEmulatorClient implements AndroidEmulator {
       this.releaseAbsentTerminalReservations(deviceIds);
       return deviceIds;
     } catch (error) {
+      if (signal?.aborted) {
+        throw error;
+      }
       // Without a current device list, do not select a port that could belong to
       // another local emulator. Readiness can still use a captured serial or an
       // exact AVD-name match.

--- a/src/utils/android-cmdline-tools/AndroidEmulatorClient.ts
+++ b/src/utils/android-cmdline-tools/AndroidEmulatorClient.ts
@@ -28,6 +28,9 @@ const DEFAULT_EMULATOR_POLLING_INTERVAL_MS = 500;
 const MIN_EMULATOR_POLLING_INTERVAL_MS = 100;
 const MAX_TIMER_DELAY_MS = 2_147_483_647;
 const MAX_POLLING_SLEEP_CHUNK_MS = 500;
+const MIN_EMULATOR_CONSOLE_PORT = 5554;
+const MAX_EMULATOR_CONSOLE_PORT = 5682;
+const EMULATOR_CONSOLE_PORT_STEP = 2;
 
 type LaunchFailureCategory =
   | "display_initialization_failed"
@@ -329,13 +332,10 @@ export class AndroidEmulatorClient implements AndroidEmulator {
   private platform: NodeJS.Platform;
   private hostArchitecture: string;
   private readonly launchTargetDeviceIds = new WeakMap<ChildProcess, string>();
-  // startDevice creates a fresh client per request, so this safety boundary must
-  // cover every client in the daemon rather than one client instance.
-  private static readonly unlabelledLaunchDeviceIds = new Map<ChildProcess, string | undefined>();
-  private readonly launchPreexistingEmulatorDeviceIds = new WeakMap<
-    ChildProcess,
-    ReadonlySet<string>
-  >();
+  // startDevice creates a fresh client per request, so reservations must cover
+  // every client in the daemon rather than one client instance.
+  private static readonly reservedLaunchDeviceIds = new Map<ChildProcess, string>();
+  private static readonly terminalReservedDeviceIds = new Set<string>();
   private readonly launchErrors = new WeakMap<ChildProcess, ActionableError>();
   private readonly launchErrorFinalizations = new WeakMap<
     ChildProcess,
@@ -374,8 +374,9 @@ export class AndroidEmulatorClient implements AndroidEmulator {
     this.emulatorPath = this.getFallbackEmulatorPath();
   }
 
-  static resetUnlabelledLaunchTrackingForTesting(): void {
-    AndroidEmulatorClient.unlabelledLaunchDeviceIds.clear();
+  static resetLaunchReservationsForTesting(): void {
+    AndroidEmulatorClient.reservedLaunchDeviceIds.clear();
+    AndroidEmulatorClient.terminalReservedDeviceIds.clear();
   }
 
   /**
@@ -1402,23 +1403,25 @@ export class AndroidEmulatorClient implements AndroidEmulator {
     } else if (extraArgsRaw) {
       args.push(...parseExtraEmulatorArguments(extraArgsRaw));
     }
-    logger.info(`Starting emulator with AVD: ${avdName}`);
-    logger.debug(`Emulator command: ${this.emulatorPath} ${args.join(" ")}`);
     this.throwIfLaunchCancelled(avdName, isCancelled);
     const preLaunchEmulatorDeviceIds = await this.capturePreLaunchEmulatorDeviceIds(
       capturePreLaunchDeviceIds,
     );
     this.throwIfLaunchCancelled(avdName, isCancelled);
+    const reservedDeviceId = this.addReservedEmulatorPort(
+      args,
+      preLaunchEmulatorDeviceIds,
+    );
+    logger.info(`Starting emulator with AVD: ${avdName}`);
+    logger.debug(`Emulator command: ${this.emulatorPath} ${args.join(" ")}`);
 
     return new Promise((resolve, reject) => {
       perf.startOperation("spawnEmulator");
       const child = this.spawnFn(this.emulatorPath, args);
       perf.endOperation("spawnEmulator");
-      this.recordPreLaunchEmulatorDeviceIds(
-        child,
-        preLaunchEmulatorDeviceIds,
-        capturePreLaunchDeviceIds,
-      );
+      if (reservedDeviceId) {
+        this.recordReservedEmulatorDeviceId(child, reservedDeviceId);
+      }
       onSpawn?.(child);
 
       // Keep only a redacted tail for launch diagnostics and failure classification.
@@ -1831,7 +1834,7 @@ export class AndroidEmulatorClient implements AndroidEmulator {
 
       child.on("exit", (code, signal) => {
         this.timer.clearTimeout(startupTimeout);
-        this.releaseUnlabelledLaunch(child);
+        this.releaseReservedEmulatorDeviceId(child);
         childTerminationObserved = true;
         exitCode = code;
         exitSignal = signal;
@@ -1854,7 +1857,7 @@ export class AndroidEmulatorClient implements AndroidEmulator {
 
       child.on("close", (code, signal) => {
         this.timer.clearTimeout(startupTimeout);
-        this.releaseUnlabelledLaunch(child);
+        this.releaseReservedEmulatorDeviceId(child);
         clearExitDrainTimeout();
         childTerminationObserved = true;
         exitCode ??= code;
@@ -1922,91 +1925,96 @@ export class AndroidEmulatorClient implements AndroidEmulator {
         bypassCache: true,
         throwOnMissingAdb: true,
       });
-      return new Set(
+      const deviceIds = new Set(
         devices
           .map((device) => device.deviceId)
           .filter((deviceId): deviceId is string => deviceId.startsWith("emulator-")),
       );
+      this.releaseAbsentTerminalReservations(deviceIds);
+      return deviceIds;
     } catch (error) {
-      // Without a baseline, unknown-device fallback stays disabled. Readiness can
-      // still use a captured serial or an exact AVD-name match.
+      // Without a current device list, do not select a port that could belong to
+      // another local emulator. Readiness can still use a captured serial or an
+      // exact AVD-name match.
       logger.debug(`Could not capture pre-launch emulator device IDs: ${error}`);
       return undefined;
     }
   }
 
-  private recordPreLaunchEmulatorDeviceIds(
-    childProcess: ChildProcess,
+  private allocateReservedEmulatorDeviceId(
+    preexistingDeviceIds: ReadonlySet<string>,
+  ): string {
+    const unavailableDeviceIds = new Set([
+      ...preexistingDeviceIds,
+      ...AndroidEmulatorClient.reservedLaunchDeviceIds.values(),
+      ...AndroidEmulatorClient.terminalReservedDeviceIds,
+    ]);
+    for (
+      let port = MIN_EMULATOR_CONSOLE_PORT;
+      port <= MAX_EMULATOR_CONSOLE_PORT;
+      port += EMULATOR_CONSOLE_PORT_STEP
+    ) {
+      const deviceId = `emulator-${port}`;
+      if (!unavailableDeviceIds.has(deviceId)) {
+        return deviceId;
+      }
+    }
+    throw new ActionableError(
+      `Cannot safely launch an Android emulator: all console ports from ` +
+        `${MIN_EMULATOR_CONSOLE_PORT} through ${MAX_EMULATOR_CONSOLE_PORT} are in use`,
+    );
+  }
+
+  private reserveEmulatorDeviceId(
     preexistingDeviceIds: ReadonlySet<string> | undefined,
-    trackUnlabelledLaunch: boolean,
+  ): string | undefined {
+    if (!preexistingDeviceIds) {
+      return undefined;
+    }
+    return this.allocateReservedEmulatorDeviceId(preexistingDeviceIds);
+  }
+
+  private addReservedEmulatorPort(
+    args: string[],
+    preexistingDeviceIds: ReadonlySet<string> | undefined,
+  ): string | undefined {
+    const deviceId = this.reserveEmulatorDeviceId(preexistingDeviceIds);
+    if (deviceId) {
+      args.push("-port", deviceId.slice("emulator-".length));
+    }
+    return deviceId;
+  }
+
+  private recordReservedEmulatorDeviceId(
+    childProcess: ChildProcess,
+    deviceId: string,
   ): void {
-    if (!trackUnlabelledLaunch) {
+    AndroidEmulatorClient.reservedLaunchDeviceIds.set(childProcess, deviceId);
+    this.recordLaunchTargetDeviceId(childProcess, deviceId, "reserved console port");
+  }
+
+  private releaseReservedEmulatorDeviceId(childProcess?: ChildProcess | null): void {
+    if (!childProcess) {
       return;
     }
-    if (preexistingDeviceIds) {
-      this.launchPreexistingEmulatorDeviceIds.set(childProcess, preexistingDeviceIds);
-    }
-    AndroidEmulatorClient.unlabelledLaunchDeviceIds.set(childProcess, undefined);
-  }
-
-  private releaseUnlabelledLaunch(childProcess?: ChildProcess | null): void {
-    if (childProcess) {
-      AndroidEmulatorClient.unlabelledLaunchDeviceIds.delete(childProcess);
+    const deviceId = AndroidEmulatorClient.reservedLaunchDeviceIds.get(childProcess);
+    if (deviceId) {
+      AndroidEmulatorClient.reservedLaunchDeviceIds.delete(childProcess);
+      // ADB can retain an exited emulator briefly. Keep its port unavailable
+      // until a later successful snapshot confirms the serial has disappeared.
+      AndroidEmulatorClient.terminalReservedDeviceIds.add(deviceId);
     }
   }
 
-  private getLaunchPreexistingEmulatorDeviceIds(
-    childProcess?: ChildProcess | null,
-  ): ReadonlySet<string> | undefined {
-    return childProcess ? this.launchPreexistingEmulatorDeviceIds.get(childProcess) : undefined;
+  private releaseAbsentTerminalReservations(deviceIds: ReadonlySet<string>): void {
+    for (const deviceId of AndroidEmulatorClient.terminalReservedDeviceIds) {
+      if (!deviceIds.has(deviceId)) {
+        AndroidEmulatorClient.terminalReservedDeviceIds.delete(deviceId);
+      }
+    }
   }
 
-  private correlateNewUnknownEmulator(
-    avdName: string,
-    childProcess: ChildProcess | null | undefined,
-    runningEmulators: BootedDevice[],
-  ): { emulator?: BootedDevice; failure?: string } {
-    const preexistingDeviceIds = this.getLaunchPreexistingEmulatorDeviceIds(childProcess);
-    if (!preexistingDeviceIds) {
-      return {};
-    }
-
-    const pendingUnlabelledLaunches = Array.from(
-      AndroidEmulatorClient.unlabelledLaunchDeviceIds.values(),
-    ).filter((deviceId) => deviceId === undefined).length;
-    if (pendingUnlabelledLaunches > 1) {
-      return {
-        failure:
-          `Emulator '${avdName}' cannot safely correlate the launched emulator while ` +
-          `${pendingUnlabelledLaunches} unlabelled emulator launches are pending`,
-      };
-    }
-
-    const newUnknownEmulators = runningEmulators.filter(
-      (candidate) =>
-        candidate.deviceId.startsWith("emulator-") &&
-        !preexistingDeviceIds.has(candidate.deviceId) &&
-        !this.isTrackedUnlabelledLaunchDeviceId(childProcess, candidate.deviceId) &&
-        this.isUnknownEmulatorName(candidate.name, candidate.deviceId),
-    );
-    if (newUnknownEmulators.length === 1) {
-      const emulator = newUnknownEmulators[0];
-      this.recordLaunchTargetDeviceId(childProcess, emulator.deviceId, "pre-launch device set");
-      logger.debug(`Correlated launched emulator from pre-launch device set: ${emulator.deviceId}`);
-      return { emulator };
-    }
-    if (newUnknownEmulators.length > 1) {
-      const candidateIds = newUnknownEmulators.map((candidate) => candidate.deviceId);
-      return {
-        failure:
-          `Emulator '${avdName}' could not correlate the launched emulator ` +
-          `from ${candidateIds.length} newly discovered unknown devices: ${candidateIds.join(", ")}`,
-      };
-    }
-    return {};
-  }
-
-  private findNamedOrNewUnknownEmulator(
+  private findNamedEmulator(
     avdName: string,
     childProcess: ChildProcess | null | undefined,
     runningEmulators: BootedDevice[],
@@ -2019,16 +2027,7 @@ export class AndroidEmulatorClient implements AndroidEmulator {
       this.recordLaunchTargetDeviceId(childProcess, namedEmulator.deviceId, "AVD name");
       return { emulator: namedEmulator };
     }
-
-    const correlation = this.correlateNewUnknownEmulator(
-      avdName,
-      childProcess,
-      runningEmulators,
-    );
-    if (correlation.failure) {
-      logger.debug(correlation.failure);
-    }
-    return correlation;
+    return {};
   }
 
   private getLaunchError(childProcess?: ChildProcess | null): ActionableError | undefined {
@@ -2149,20 +2148,7 @@ export class AndroidEmulatorClient implements AndroidEmulator {
       return;
     }
     this.launchTargetDeviceIds.set(childProcess, targetDeviceId);
-    if (AndroidEmulatorClient.unlabelledLaunchDeviceIds.has(childProcess)) {
-      AndroidEmulatorClient.unlabelledLaunchDeviceIds.set(childProcess, targetDeviceId);
-    }
     logger.debug(`Captured emulator launch target deviceId from ${source}: ${targetDeviceId}`);
-  }
-
-  private isTrackedUnlabelledLaunchDeviceId(
-    childProcess: ChildProcess | null | undefined,
-    deviceId: string,
-  ): boolean {
-    return Array.from(AndroidEmulatorClient.unlabelledLaunchDeviceIds.entries()).some(
-      ([trackedProcess, trackedDeviceId]) =>
-        trackedProcess !== childProcess && trackedDeviceId === deviceId,
-    );
   }
 
   /**
@@ -2334,7 +2320,7 @@ export class AndroidEmulatorClient implements AndroidEmulator {
 
             // Look for emulator by name next.
             if (!emulator && !correlatedTargetDeviceId) {
-              const correlation = this.findNamedOrNewUnknownEmulator(
+              const correlation = this.findNamedEmulator(
                 avdName,
                 childProcess,
                 runningEmulators,

--- a/test/setup/testPreload.ts
+++ b/test/setup/testPreload.ts
@@ -2,6 +2,7 @@ import {
   TelemetryRecorder,
   getNoOpTelemetryRepository,
 } from "../../src/features/telemetry/TelemetryRecorder";
+import { AndroidEmulatorClient } from "../../src/utils/android-cmdline-tools/AndroidEmulatorClient";
 
 /**
  * Globally neutralize the {@link TelemetryRecorder} for the whole suite so a
@@ -21,3 +22,9 @@ import {
  * write path, it does not block explicit assertions.
  */
 TelemetryRecorder.setDefaultRepositoryOverride(getNoOpTelemetryRepository());
+
+// Emulator launch tests must never create real TCP probes. Individual tests
+// inject unavailable ports when exercising allocation behavior.
+AndroidEmulatorClient.setHostPortAvailabilityCheckerForTesting({
+  isAvailable: async () => true,
+});

--- a/test/utils/android-cmdline-tools/AndroidEmulatorClient-corruptImage.test.ts
+++ b/test/utils/android-cmdline-tools/AndroidEmulatorClient-corruptImage.test.ts
@@ -73,16 +73,16 @@ class DeviceScopedAdbExecutor extends FakeAdbExecutor {
 
 class DeviceScopedAdbClientFactory implements AdbClientFactory {
   readonly commandLog: string[] = [];
-  private readonly deviceScans: BootedDevice[][];
+  private readonly deviceScans: Array<BootedDevice[] | Error>;
   private scanIndex = 0;
 
   constructor(
-    devices: BootedDevice[] | BootedDevice[][],
+    devices: BootedDevice[] | Array<BootedDevice[] | Error>,
     private readonly avdNamesByDeviceId = new Map<string, string>(),
   ) {
     const firstScan = devices[0];
-    this.deviceScans = Array.isArray(firstScan)
-      ? devices as BootedDevice[][]
+    this.deviceScans = Array.isArray(firstScan) || firstScan instanceof Error
+      ? devices as Array<BootedDevice[] | Error>
       : [devices as BootedDevice[]];
   }
 
@@ -93,6 +93,9 @@ class DeviceScopedAdbClientFactory implements AdbClientFactory {
   nextDevices(): BootedDevice[] {
     const devices = this.deviceScans[Math.min(this.scanIndex, this.deviceScans.length - 1)] ?? [];
     this.scanIndex += 1;
+    if (devices instanceof Error) {
+      throw devices;
+    }
     return devices;
   }
 
@@ -836,6 +839,102 @@ describe("AndroidEmulatorClient waitForEmulatorReady with child process monitori
 
     expect(scopedFactory.commandLog.some(command => command.startsWith("emulator-5558:get-state"))).toBe(false);
     secondLaunch!.emit("exit", 0);
+  });
+
+  test("counts a concurrent launch whose pre-launch snapshot failed", async () => {
+    fakeTimer.enableAutoAdvance();
+    const firstChild = createFakeChildProcess();
+    const secondChild = createFakeChildProcess();
+    const candidate: BootedDevice = {
+      name: "Unknown (emulator-5558)",
+      platform: "android",
+      deviceId: "emulator-5558",
+      source: "local",
+    };
+    const scopedFactory = new DeviceScopedAdbClientFactory([
+      [],
+      [],
+      [],
+      new Error("temporary adb device-list failure"),
+      [candidate],
+    ]);
+    const children = [firstChild, secondChild];
+    const spawnFn = ((_cmd: string, _args: string[]) => {
+      const child = children.shift()!;
+      process.nextTick(() => {
+        child.stdout!.emit("data", Buffer.from("Detected GPU type: host\n"));
+      });
+      return child;
+    }) as any;
+    const execAsync = async (_file: string, args: string[]): Promise<ExecResult> => {
+      if (args.includes("-list-avds")) {
+        return createExecResult("am-api33-ga-arm64\n");
+      }
+      return createExecResult("");
+    };
+    const client = new AndroidEmulatorClient(execAsync, spawnFn, fakeTimer, scopedFactory);
+    skipEmulatorPathDetection(client);
+
+    const firstLaunch = await client.startEmulator("am-api33-ga-arm64");
+    const secondLaunch = await client.startEmulator("am-api33-ga-arm64");
+    await expect(
+      client.waitForEmulatorReady("am-api33-ga-arm64", 100, firstLaunch),
+    ).rejects.toThrow("cannot safely correlate the launched emulator while 2 unlabelled");
+
+    expect(scopedFactory.commandLog.some(command => command.startsWith("emulator-5558:get-state"))).toBe(false);
+    secondLaunch!.emit("exit", 0);
+  });
+
+  test("does not assign a sibling launch's captured serial through fallback correlation", async () => {
+    fakeTimer.enableAutoAdvance();
+    const firstChild = createFakeChildProcess();
+    const secondChild = createFakeChildProcess();
+    const siblingDevice: BootedDevice = {
+      name: "Unknown (emulator-5558)",
+      platform: "android",
+      deviceId: "emulator-5558",
+      source: "local",
+    };
+    const launchedDevice: BootedDevice = {
+      name: "Unknown (emulator-5560)",
+      platform: "android",
+      deviceId: "emulator-5560",
+      source: "local",
+    };
+    const scopedFactory = new DeviceScopedAdbClientFactory([
+      [],
+      [],
+      [],
+      [],
+      [siblingDevice, launchedDevice],
+    ]);
+    const children = [firstChild, secondChild];
+    const spawnFn = ((_cmd: string, _args: string[]) => {
+      const child = children.shift()!;
+      const output = child === secondChild
+        ? "Detected GPU type: host\nemulator-5558\n"
+        : "Detected GPU type: host\n";
+      process.nextTick(() => {
+        child.stdout!.emit("data", Buffer.from(output));
+      });
+      return child;
+    }) as any;
+    const execAsync = async (_file: string, args: string[]): Promise<ExecResult> => {
+      if (args.includes("-list-avds")) {
+        return createExecResult("am-api33-ga-arm64\n");
+      }
+      return createExecResult("");
+    };
+    const client = new AndroidEmulatorClient(execAsync, spawnFn, fakeTimer, scopedFactory);
+    skipEmulatorPathDetection(client);
+
+    const firstLaunch = await client.startEmulator("am-api33-ga-arm64");
+    await client.startEmulator("am-api33-ga-arm64");
+    const result = await client.waitForEmulatorReady("am-api33-ga-arm64", 5_000, firstLaunch);
+
+    expect(result.deviceId).toBe("emulator-5560");
+    expect(scopedFactory.commandLog.some(command => command.startsWith("emulator-5558:get-state"))).toBe(false);
+    expect(scopedFactory.commandLog.some(command => command.startsWith("emulator-5560:get-state"))).toBe(true);
   });
 
   test("reports ambiguous unknown emulator correlation without probing either candidate", async () => {

--- a/test/utils/android-cmdline-tools/AndroidEmulatorClient-corruptImage.test.ts
+++ b/test/utils/android-cmdline-tools/AndroidEmulatorClient-corruptImage.test.ts
@@ -419,6 +419,37 @@ describe("AndroidEmulatorClient startEmulator corrupt image integration", () => 
     expect(readyDevice.deviceId).toBe("emulator-5556");
     expect(fakeAdb.getExecutedCommands().some(command => command.includes("get-state"))).toBe(true);
   });
+
+  test("keeps an exited launch port reserved while ADB reports its serial offline", async () => {
+    const firstChild = createFakeChildProcess();
+    const secondChild = createFakeChildProcess();
+    const children = [firstChild, secondChild];
+    const spawnedArgs: string[][] = [];
+    const spawnFn = ((_cmd: string, args: string[]) => {
+      spawnedArgs.push(args);
+      const child = children.shift()!;
+      process.nextTick(() => {
+        child.stdout!.emit("data", Buffer.from("Detected GPU type: host\n"));
+      });
+      return child;
+    }) as any;
+    const execAsync = async (_file: string, args: string[]): Promise<ExecResult> =>
+      args.includes("-list-avds") ? createExecResult("Pixel_9_Pro\n") : createExecResult("");
+
+    fakeTimer.enableAutoAdvance();
+    const client = new AndroidEmulatorClient(execAsync, spawnFn, fakeTimer, fakeFactory, fakeAvdConfigReader);
+    skipEmulatorPathDetection(client);
+
+    const firstLaunch = await client.startEmulator("Pixel_9_Pro");
+    firstLaunch!.emit("exit", 0);
+    fakeAdb.setDeviceStates([{ deviceId: "emulator-5554", state: "offline" }]);
+    await client.startEmulator("Pixel_9_Pro");
+
+    expect(spawnedArgs).toEqual([
+      expect.arrayContaining(["-port", "5554"]),
+      expect.arrayContaining(["-port", "5556"]),
+    ]);
+  });
 });
 
 describe("AndroidEmulatorClient waitForEmulatorReady with child process monitoring", () => {
@@ -894,11 +925,12 @@ describe("AndroidEmulatorClient waitForEmulatorReady with child process monitori
     const firstLaunch = await client.startEmulator("am-api33-ga-arm64");
     const secondLaunch = await client.startEmulator("am-api33-ga-arm64");
     await expect(
-      client.waitForEmulatorReady("am-api33-ga-arm64", 100, firstLaunch),
+      client.waitForEmulatorReady("am-api33-ga-arm64", 100, secondLaunch),
     ).rejects.toThrow("failed to become ready within 100ms");
 
     expect(spawnedArgs.some(args => !args.includes("-port"))).toBe(true);
     expect(scopedFactory.commandLog.some(command => command.startsWith("emulator-5558:get-state"))).toBe(false);
+    firstLaunch!.emit("exit", 0);
     secondLaunch!.emit("exit", 0);
   });
 

--- a/test/utils/android-cmdline-tools/AndroidEmulatorClient-corruptImage.test.ts
+++ b/test/utils/android-cmdline-tools/AndroidEmulatorClient-corruptImage.test.ts
@@ -1,4 +1,4 @@
-import { beforeEach, describe, expect, test } from "bun:test";
+import { afterEach, beforeEach, describe, expect, test } from "bun:test";
 import { AndroidEmulatorClient } from "../../../src/utils/android-cmdline-tools/AndroidEmulatorClient";
 import { ExecResult, BootedDevice } from "../../../src/models";
 import { FakeTimer } from "../../fakes/FakeTimer";
@@ -117,6 +117,10 @@ const mockExecAsync = async (_file: string, _args: string[]): Promise<ExecResult
 function skipEmulatorPathDetection(client: AndroidEmulatorClient): void {
   (client as any).ensureEmulatorPath = async () => "emulator";
 }
+
+afterEach(() => {
+  AndroidEmulatorClient.resetUnlabelledLaunchTrackingForTesting();
+});
 
 describe("AndroidEmulatorClient detectCorruptImage", () => {
   let client: AndroidEmulatorClient;
@@ -788,6 +792,50 @@ describe("AndroidEmulatorClient waitForEmulatorReady with child process monitori
     expect(result.deviceId).toBe("emulator-5558");
     expect(scopedFactory.commandLog.some(command => command.startsWith("emulator-5558:get-state"))).toBe(true);
     expect(scopedFactory.commandLog.some(command => command.startsWith("emulator-5554:get-state"))).toBe(false);
+  });
+
+  test("does not correlate an unknown emulator while another unlabelled launch is pending", async () => {
+    fakeTimer.enableAutoAdvance();
+    const firstChild = createFakeChildProcess();
+    const secondChild = createFakeChildProcess();
+    const candidate: BootedDevice = {
+      name: "Unknown (emulator-5558)",
+      platform: "android",
+      deviceId: "emulator-5558",
+      source: "local",
+    };
+    const scopedFactory = new DeviceScopedAdbClientFactory([
+      [],
+      [],
+      [],
+      [],
+      [candidate],
+    ]);
+    const children = [firstChild, secondChild];
+    const spawnFn = ((_cmd: string, _args: string[]) => {
+      const child = children.shift()!;
+      process.nextTick(() => {
+        child.stdout!.emit("data", Buffer.from("Detected GPU type: host\n"));
+      });
+      return child;
+    }) as any;
+    const execAsync = async (_file: string, args: string[]): Promise<ExecResult> => {
+      if (args.includes("-list-avds")) {
+        return createExecResult("am-api33-ga-arm64\n");
+      }
+      return createExecResult("");
+    };
+    const client = new AndroidEmulatorClient(execAsync, spawnFn, fakeTimer, scopedFactory);
+    skipEmulatorPathDetection(client);
+
+    const firstLaunch = await client.startEmulator("am-api33-ga-arm64");
+    const secondLaunch = await client.startEmulator("am-api33-ga-arm64");
+    await expect(
+      client.waitForEmulatorReady("am-api33-ga-arm64", 100, firstLaunch),
+    ).rejects.toThrow("cannot safely correlate the launched emulator while 2 unlabelled");
+
+    expect(scopedFactory.commandLog.some(command => command.startsWith("emulator-5558:get-state"))).toBe(false);
+    secondLaunch!.emit("exit", 0);
   });
 
   test("reports ambiguous unknown emulator correlation without probing either candidate", async () => {

--- a/test/utils/android-cmdline-tools/AndroidEmulatorClient-corruptImage.test.ts
+++ b/test/utils/android-cmdline-tools/AndroidEmulatorClient-corruptImage.test.ts
@@ -747,6 +747,99 @@ describe("AndroidEmulatorClient waitForEmulatorReady with child process monitori
     expect(scopedFactory.commandLog.some(command => command.startsWith("emulator-5554:get-state"))).toBe(false);
   });
 
+  test("uses one newly discovered unknown emulator when launch output and AVD-name lookup are unavailable", async () => {
+    fakeTimer.enableAutoAdvance();
+    const fakeChild = createFakeChildProcess();
+    const existingDevice: BootedDevice = {
+      name: "Unknown (emulator-5554)",
+      platform: "android",
+      deviceId: "emulator-5554",
+      source: "local",
+    };
+    const launchedDevice: BootedDevice = {
+      name: "Unknown (emulator-5558)",
+      platform: "android",
+      deviceId: "emulator-5558",
+      source: "local",
+    };
+    const scopedFactory = new DeviceScopedAdbClientFactory([
+      [existingDevice],
+      [existingDevice],
+      [existingDevice, launchedDevice],
+    ]);
+    const spawnFn = ((_cmd: string, _args: string[]) => {
+      process.nextTick(() => {
+        fakeChild.stdout!.emit("data", Buffer.from("Detected GPU type: host\n"));
+      });
+      return fakeChild;
+    }) as any;
+    const execAsync = async (_file: string, args: string[]): Promise<ExecResult> => {
+      if (args.includes("-list-avds")) {
+        return createExecResult("am-api33-ga-arm64\n");
+      }
+      return createExecResult("");
+    };
+    const client = new AndroidEmulatorClient(execAsync, spawnFn, fakeTimer, scopedFactory);
+    skipEmulatorPathDetection(client);
+
+    const child = await client.startEmulator("am-api33-ga-arm64");
+    const result = await client.waitForEmulatorReady("am-api33-ga-arm64", 5_000, child);
+
+    expect(result.deviceId).toBe("emulator-5558");
+    expect(scopedFactory.commandLog.some(command => command.startsWith("emulator-5558:get-state"))).toBe(true);
+    expect(scopedFactory.commandLog.some(command => command.startsWith("emulator-5554:get-state"))).toBe(false);
+  });
+
+  test("reports ambiguous unknown emulator correlation without probing either candidate", async () => {
+    fakeTimer.enableAutoAdvance();
+    const fakeChild = createFakeChildProcess();
+    const existingDevice: BootedDevice = {
+      name: "Unknown (emulator-5554)",
+      platform: "android",
+      deviceId: "emulator-5554",
+      source: "local",
+    };
+    const firstCandidate: BootedDevice = {
+      name: "Unknown (emulator-5558)",
+      platform: "android",
+      deviceId: "emulator-5558",
+      source: "local",
+    };
+    const secondCandidate: BootedDevice = {
+      name: "Unknown (emulator-5560)",
+      platform: "android",
+      deviceId: "emulator-5560",
+      source: "local",
+    };
+    const scopedFactory = new DeviceScopedAdbClientFactory([
+      [existingDevice],
+      [existingDevice],
+      [existingDevice, firstCandidate, secondCandidate],
+    ]);
+    const spawnFn = ((_cmd: string, _args: string[]) => {
+      process.nextTick(() => {
+        fakeChild.stdout!.emit("data", Buffer.from("Detected GPU type: host\n"));
+      });
+      return fakeChild;
+    }) as any;
+    const execAsync = async (_file: string, args: string[]): Promise<ExecResult> => {
+      if (args.includes("-list-avds")) {
+        return createExecResult("am-api33-ga-arm64\n");
+      }
+      return createExecResult("");
+    };
+    const client = new AndroidEmulatorClient(execAsync, spawnFn, fakeTimer, scopedFactory);
+    skipEmulatorPathDetection(client);
+
+    const child = await client.startEmulator("am-api33-ga-arm64");
+    await expect(
+      client.waitForEmulatorReady("am-api33-ga-arm64", 100, child),
+    ).rejects.toThrow("could not correlate the launched emulator");
+
+    expect(scopedFactory.commandLog.some(command => command.startsWith("emulator-5558:get-state"))).toBe(false);
+    expect(scopedFactory.commandLog.some(command => command.startsWith("emulator-5560:get-state"))).toBe(false);
+  });
+
   test("does not readiness-check multiple new unknown emulators", async () => {
     fakeTimer.enableAutoAdvance();
     const fakeChild = createFakeChildProcess();

--- a/test/utils/android-cmdline-tools/AndroidEmulatorClient-corruptImage.test.ts
+++ b/test/utils/android-cmdline-tools/AndroidEmulatorClient-corruptImage.test.ts
@@ -420,6 +420,42 @@ describe("AndroidEmulatorClient startEmulator corrupt image integration", () => 
     expect(fakeAdb.getExecutedCommands().some(command => command.includes("get-state"))).toBe(true);
   });
 
+  test("adopts the existing AVD after a post-validation duplicate-AVD exit", async () => {
+    const fakeChild = createFakeChildProcess();
+    const spawnFn = ((_cmd: string, _args: string[]) => {
+      process.nextTick(() => {
+        fakeChild.stdout!.emit("data", Buffer.from("Detected GPU type: host\n"));
+      });
+      return fakeChild;
+    }) as any;
+    const execAsync = async (_file: string, args: string[]): Promise<ExecResult> =>
+      args.includes("-list-avds") ? createExecResult("Pixel_9_Pro\n") : createExecResult("");
+
+    fakeTimer.enableAutoAdvance();
+    fakeAdb.setCommandResponse("emu avd name", createExecResult("Pixel_9_Pro\n"));
+    fakeAdb.setCommandResponse("get-state", createExecResult("device\n"));
+    fakeAdb.setCommandResponse("shell pm list packages", createExecResult("package:android\n"));
+    fakeAdb.setCommandResponse("shell getprop sys.boot_completed", createExecResult("1\n"));
+    fakeAdb.setCommandResponse("shell getprop init.svc.bootanim", createExecResult("stopped\n"));
+    const client = new AndroidEmulatorClient(execAsync, spawnFn, fakeTimer, fakeFactory, fakeAvdConfigReader);
+    skipEmulatorPathDetection(client);
+
+    const child = await client.startEmulator("Pixel_9_Pro");
+    fakeChild.stderr!.emit(
+      "data",
+      Buffer.from("Running multiple emulators with the same AVD is an experimental feature.\n"),
+    );
+    fakeChild.emit("exit", 1);
+    fakeChild.emit("close", 1);
+    fakeAdb.setDevices([
+      { name: "Pixel_9_Pro", platform: "android", deviceId: "emulator-5556", source: "local" },
+    ]);
+
+    await expect(client.waitForEmulatorReady("Pixel_9_Pro", 5_000, child)).resolves.toMatchObject({
+      deviceId: "emulator-5556",
+    });
+  });
+
   test("keeps an exited launch port reserved while ADB reports its serial offline", async () => {
     const firstChild = createFakeChildProcess();
     const secondChild = createFakeChildProcess();

--- a/test/utils/android-cmdline-tools/AndroidEmulatorClient-corruptImage.test.ts
+++ b/test/utils/android-cmdline-tools/AndroidEmulatorClient-corruptImage.test.ts
@@ -122,7 +122,7 @@ function skipEmulatorPathDetection(client: AndroidEmulatorClient): void {
 }
 
 afterEach(() => {
-  AndroidEmulatorClient.resetUnlabelledLaunchTrackingForTesting();
+  AndroidEmulatorClient.resetLaunchReservationsForTesting();
 });
 
 describe("AndroidEmulatorClient detectCorruptImage", () => {
@@ -376,11 +376,13 @@ describe("AndroidEmulatorClient startEmulator corrupt image integration", () => 
     expect(error.message).toContain("exited with code: 1");
   });
 
-  test("uses spawned process output deviceId to target readiness when AVD name is unavailable", async () => {
+  test("uses a reserved console port to target readiness when AVD name is unavailable", async () => {
     const fakeChild = createFakeChildProcess();
-    const spawnFn = ((_cmd: string, _args: string[]) => {
+    let spawnedArgs: string[] = [];
+    const spawnFn = ((_cmd: string, args: string[]) => {
+      spawnedArgs = args;
       process.nextTick(() => {
-        fakeChild.stdout!.emit("data", Buffer.from("emulator-5558: INFO: console port 5558\nDetected GPU type: host\n"));
+        fakeChild.stdout!.emit("data", Buffer.from("Detected GPU type: host\n"));
       });
       return fakeChild;
     }) as any;
@@ -407,12 +409,14 @@ describe("AndroidEmulatorClient startEmulator corrupt image integration", () => 
     const child = await client.startEmulator("Pixel_9_Pro");
     fakeAdb.setDevices([
       { name: "Unknown (emulator-5554)", platform: "android", deviceId: "emulator-5554", source: "local" },
-      { name: "Unknown (emulator-5558)", platform: "android", deviceId: "emulator-5558", source: "local" },
+      { name: "Unknown (emulator-5556)", platform: "android", deviceId: "emulator-5556", source: "local" },
     ]);
 
     const readyDevice = await client.waitForEmulatorReady("Pixel_9_Pro", 5_000, child);
 
-    expect(readyDevice.deviceId).toBe("emulator-5558");
+    expect(spawnedArgs).toContain("-port");
+    expect(spawnedArgs).toContain("5556");
+    expect(readyDevice.deviceId).toBe("emulator-5556");
     expect(fakeAdb.getExecutedCommands().some(command => command.includes("get-state"))).toBe(true);
   });
 });
@@ -754,7 +758,7 @@ describe("AndroidEmulatorClient waitForEmulatorReady with child process monitori
     expect(scopedFactory.commandLog.some(command => command.startsWith("emulator-5554:get-state"))).toBe(false);
   });
 
-  test("uses one newly discovered unknown emulator when launch output and AVD-name lookup are unavailable", async () => {
+  test("uses its reserved console port when launch output and AVD-name lookup are unavailable", async () => {
     fakeTimer.enableAutoAdvance();
     const fakeChild = createFakeChildProcess();
     const existingDevice: BootedDevice = {
@@ -764,9 +768,9 @@ describe("AndroidEmulatorClient waitForEmulatorReady with child process monitori
       source: "local",
     };
     const launchedDevice: BootedDevice = {
-      name: "Unknown (emulator-5558)",
+      name: "Unknown (emulator-5556)",
       platform: "android",
-      deviceId: "emulator-5558",
+      deviceId: "emulator-5556",
       source: "local",
     };
     const scopedFactory = new DeviceScopedAdbClientFactory([
@@ -774,7 +778,9 @@ describe("AndroidEmulatorClient waitForEmulatorReady with child process monitori
       [existingDevice],
       [existingDevice, launchedDevice],
     ]);
-    const spawnFn = ((_cmd: string, _args: string[]) => {
+    let spawnedArgs: string[] = [];
+    const spawnFn = ((_cmd: string, args: string[]) => {
+      spawnedArgs = args;
       process.nextTick(() => {
         fakeChild.stdout!.emit("data", Buffer.from("Detected GPU type: host\n"));
       });
@@ -792,12 +798,14 @@ describe("AndroidEmulatorClient waitForEmulatorReady with child process monitori
     const child = await client.startEmulator("am-api33-ga-arm64");
     const result = await client.waitForEmulatorReady("am-api33-ga-arm64", 5_000, child);
 
-    expect(result.deviceId).toBe("emulator-5558");
-    expect(scopedFactory.commandLog.some(command => command.startsWith("emulator-5558:get-state"))).toBe(true);
+    expect(spawnedArgs).toContain("-port");
+    expect(spawnedArgs).toContain("5556");
+    expect(result.deviceId).toBe("emulator-5556");
+    expect(scopedFactory.commandLog.some(command => command.startsWith("emulator-5556:get-state"))).toBe(true);
     expect(scopedFactory.commandLog.some(command => command.startsWith("emulator-5554:get-state"))).toBe(false);
   });
 
-  test("does not correlate an unknown emulator while another unlabelled launch is pending", async () => {
+  test("does not adopt an externally launched unknown emulator during concurrent launches", async () => {
     fakeTimer.enableAutoAdvance();
     const firstChild = createFakeChildProcess();
     const secondChild = createFakeChildProcess();
@@ -815,7 +823,9 @@ describe("AndroidEmulatorClient waitForEmulatorReady with child process monitori
       [candidate],
     ]);
     const children = [firstChild, secondChild];
-    const spawnFn = ((_cmd: string, _args: string[]) => {
+    const spawnedArgs: string[][] = [];
+    const spawnFn = ((_cmd: string, args: string[]) => {
+      spawnedArgs.push(args);
       const child = children.shift()!;
       process.nextTick(() => {
         child.stdout!.emit("data", Buffer.from("Detected GPU type: host\n"));
@@ -835,13 +845,17 @@ describe("AndroidEmulatorClient waitForEmulatorReady with child process monitori
     const secondLaunch = await client.startEmulator("am-api33-ga-arm64");
     await expect(
       client.waitForEmulatorReady("am-api33-ga-arm64", 100, firstLaunch),
-    ).rejects.toThrow("cannot safely correlate the launched emulator while 2 unlabelled");
+    ).rejects.toThrow("failed to become ready within 100ms");
 
+    expect(spawnedArgs).toEqual(expect.arrayContaining([
+      expect.arrayContaining(["-port", "5554"]),
+      expect.arrayContaining(["-port", "5556"]),
+    ]));
     expect(scopedFactory.commandLog.some(command => command.startsWith("emulator-5558:get-state"))).toBe(false);
     secondLaunch!.emit("exit", 0);
   });
 
-  test("counts a concurrent launch whose pre-launch snapshot failed", async () => {
+  test("does not infer an unknown emulator when a pre-launch snapshot fails", async () => {
     fakeTimer.enableAutoAdvance();
     const firstChild = createFakeChildProcess();
     const secondChild = createFakeChildProcess();
@@ -859,7 +873,9 @@ describe("AndroidEmulatorClient waitForEmulatorReady with child process monitori
       [candidate],
     ]);
     const children = [firstChild, secondChild];
-    const spawnFn = ((_cmd: string, _args: string[]) => {
+    const spawnedArgs: string[][] = [];
+    const spawnFn = ((_cmd: string, args: string[]) => {
+      spawnedArgs.push(args);
       const child = children.shift()!;
       process.nextTick(() => {
         child.stdout!.emit("data", Buffer.from("Detected GPU type: host\n"));
@@ -879,43 +895,36 @@ describe("AndroidEmulatorClient waitForEmulatorReady with child process monitori
     const secondLaunch = await client.startEmulator("am-api33-ga-arm64");
     await expect(
       client.waitForEmulatorReady("am-api33-ga-arm64", 100, firstLaunch),
-    ).rejects.toThrow("cannot safely correlate the launched emulator while 2 unlabelled");
+    ).rejects.toThrow("failed to become ready within 100ms");
 
+    expect(spawnedArgs.some(args => !args.includes("-port"))).toBe(true);
     expect(scopedFactory.commandLog.some(command => command.startsWith("emulator-5558:get-state"))).toBe(false);
     secondLaunch!.emit("exit", 0);
   });
 
-  test("does not assign a sibling launch's captured serial through fallback correlation", async () => {
+  test("keeps an exited launch port reserved while ADB still reports its serial", async () => {
     fakeTimer.enableAutoAdvance();
     const firstChild = createFakeChildProcess();
     const secondChild = createFakeChildProcess();
-    const siblingDevice: BootedDevice = {
-      name: "Unknown (emulator-5558)",
+    const retainedDevice: BootedDevice = {
+      name: "Unknown (emulator-5554)",
       platform: "android",
-      deviceId: "emulator-5558",
-      source: "local",
-    };
-    const launchedDevice: BootedDevice = {
-      name: "Unknown (emulator-5560)",
-      platform: "android",
-      deviceId: "emulator-5560",
+      deviceId: "emulator-5554",
       source: "local",
     };
     const scopedFactory = new DeviceScopedAdbClientFactory([
       [],
       [],
-      [],
-      [],
-      [siblingDevice, launchedDevice],
+      [retainedDevice],
+      [retainedDevice],
     ]);
     const children = [firstChild, secondChild];
-    const spawnFn = ((_cmd: string, _args: string[]) => {
+    const spawnedArgs: string[][] = [];
+    const spawnFn = ((_cmd: string, args: string[]) => {
+      spawnedArgs.push(args);
       const child = children.shift()!;
-      const output = child === secondChild
-        ? "Detected GPU type: host\nemulator-5558\n"
-        : "Detected GPU type: host\n";
       process.nextTick(() => {
-        child.stdout!.emit("data", Buffer.from(output));
+        child.stdout!.emit("data", Buffer.from("Detected GPU type: host\n"));
       });
       return child;
     }) as any;
@@ -929,15 +938,16 @@ describe("AndroidEmulatorClient waitForEmulatorReady with child process monitori
     skipEmulatorPathDetection(client);
 
     const firstLaunch = await client.startEmulator("am-api33-ga-arm64");
+    firstLaunch!.emit("exit", 0);
     await client.startEmulator("am-api33-ga-arm64");
-    const result = await client.waitForEmulatorReady("am-api33-ga-arm64", 5_000, firstLaunch);
 
-    expect(result.deviceId).toBe("emulator-5560");
-    expect(scopedFactory.commandLog.some(command => command.startsWith("emulator-5558:get-state"))).toBe(false);
-    expect(scopedFactory.commandLog.some(command => command.startsWith("emulator-5560:get-state"))).toBe(true);
+    expect(spawnedArgs).toEqual([
+      expect.arrayContaining(["-port", "5554"]),
+      expect.arrayContaining(["-port", "5556"]),
+    ]);
   });
 
-  test("reports ambiguous unknown emulator correlation without probing either candidate", async () => {
+  test("does not probe externally launched unknown emulators when the reserved target is absent", async () => {
     fakeTimer.enableAutoAdvance();
     const fakeChild = createFakeChildProcess();
     const existingDevice: BootedDevice = {
@@ -981,7 +991,7 @@ describe("AndroidEmulatorClient waitForEmulatorReady with child process monitori
     const child = await client.startEmulator("am-api33-ga-arm64");
     await expect(
       client.waitForEmulatorReady("am-api33-ga-arm64", 100, child),
-    ).rejects.toThrow("could not correlate the launched emulator");
+    ).rejects.toThrow("failed to become ready within 100ms");
 
     expect(scopedFactory.commandLog.some(command => command.startsWith("emulator-5558:get-state"))).toBe(false);
     expect(scopedFactory.commandLog.some(command => command.startsWith("emulator-5560:get-state"))).toBe(false);

--- a/test/utils/android-cmdline-tools/AndroidEmulatorClient-launchContract.test.ts
+++ b/test/utils/android-cmdline-tools/AndroidEmulatorClient-launchContract.test.ts
@@ -214,6 +214,42 @@ describe("AndroidEmulatorClient launch contract", () => {
     expect(spawns).toBe(0);
   });
 
+  test("cancels the reservation snapshot before starting the raw-state scan", async () => {
+    const controller = new AbortController();
+    const adb = new FakeAdbExecutor();
+    let releaseBootedDevices: (devices: DeviceInfo[]) => void = () => {};
+    const bootedDevices = new Promise<DeviceInfo[]>(resolve => {
+      releaseBootedDevices = resolve;
+    });
+    let bootedDeviceSignal: AbortSignal | undefined;
+    let rawStateScanStarted = false;
+    let spawns = 0;
+    adb.getBootedAndroidDevices = async options => {
+      bootedDeviceSignal = options?.signal;
+      return bootedDevices;
+    };
+    adb.getDeviceStates = async () => {
+      rawStateScanStarted = true;
+      return [];
+    };
+    const client = createClient(() => {
+      spawns += 1;
+      return createChild();
+    }, adb);
+
+    const launch = client.launchEmulator({ avdName: "Pixel 9", signal: controller.signal });
+    while (!bootedDeviceSignal) {
+      await Promise.resolve();
+    }
+    controller.abort();
+    releaseBootedDevices([]);
+
+    await expect(launch).rejects.toThrow("cancelled");
+    expect(bootedDeviceSignal).toBe(controller.signal);
+    expect(rawStateScanStarted).toBe(false);
+    expect(spawns).toBe(0);
+  });
+
   test("cancels and cleans up when aborted while startup validation is pending", async () => {
     const controller = new AbortController();
     const child = createChild();

--- a/test/utils/android-cmdline-tools/AndroidEmulatorClient-launchContract.test.ts
+++ b/test/utils/android-cmdline-tools/AndroidEmulatorClient-launchContract.test.ts
@@ -142,6 +142,37 @@ describe("AndroidEmulatorClient launch contract", () => {
     AndroidEmulatorClient.resetLaunchReservationsForTesting();
   });
 
+  test("reuses an explicit emulator serial after an all-state snapshot confirms it is absent", async () => {
+    const adb = new FakeAdbExecutor();
+    const firstChild = createChild();
+    const secondChild = createChild();
+    const children = [firstChild, secondChild];
+    const spawnedArgs: string[][] = [];
+    const client = createClient((_command, args) => {
+      spawnedArgs.push(args);
+      const child = children.shift()!;
+      queueMicrotask(() => child.stdout!.emit("data", Buffer.from("Detected GPU type: host\n")));
+      return child;
+    }, adb);
+
+    const firstLaunch = await client.launchEmulator({
+      avdName: "Pixel 9",
+      deviceId: "emulator-5554",
+    });
+    firstChild.emit("exit", 0, null);
+    await client.launchEmulator({
+      avdName: "Pixel 9",
+      deviceId: "emulator-5554",
+    });
+
+    expect(firstLaunch.targetDeviceId).toBe("emulator-5554");
+    expect(spawnedArgs).toEqual([
+      expect.arrayContaining(["-port", "5554"]),
+      expect.arrayContaining(["-port", "5554"]),
+    ]);
+    secondChild.emit("exit", 0, null);
+  });
+
   test("does not spawn when launch has already been cancelled", async () => {
     const controller = new AbortController();
     controller.abort();

--- a/test/utils/android-cmdline-tools/AndroidEmulatorClient-launchContract.test.ts
+++ b/test/utils/android-cmdline-tools/AndroidEmulatorClient-launchContract.test.ts
@@ -173,6 +173,51 @@ describe("AndroidEmulatorClient launch contract", () => {
     secondChild.emit("exit", 0, null);
   });
 
+  test("does not clear a terminal reservation created during an older snapshot", async () => {
+    const adb = new FakeAdbExecutor();
+    const firstChild = createChild();
+    const secondChild = createChild();
+    const spawnedArgs: string[][] = [];
+    const children = [firstChild, secondChild];
+    let releaseSecondStateScan: (states: []) => void = () => {};
+    const secondStateScan = new Promise<[]>(resolve => {
+      releaseSecondStateScan = resolve;
+    });
+    let stateScans = 0;
+    let secondStateScanStarted = false;
+    adb.getDeviceStates = async () => {
+      stateScans += 1;
+      if (stateScans === 2) {
+        secondStateScanStarted = true;
+        return secondStateScan;
+      }
+      return [];
+    };
+    const createSharedClient = () => createClient((_command, args) => {
+      spawnedArgs.push(args);
+      const child = children.shift()!;
+      queueMicrotask(() => child.stdout!.emit("data", Buffer.from("Detected GPU type: host\n")));
+      return child;
+    }, adb);
+    const firstClient = createSharedClient();
+    const secondClient = createSharedClient();
+
+    await firstClient.startEmulator("Pixel 9");
+    const secondLaunch = secondClient.startEmulator("Pixel 9");
+    while (!secondStateScanStarted) {
+      await Promise.resolve();
+    }
+    firstChild.emit("exit", 0, null);
+    releaseSecondStateScan([]);
+    await secondLaunch;
+
+    expect(spawnedArgs).toEqual([
+      expect.arrayContaining(["-port", "5554"]),
+      expect.arrayContaining(["-port", "5556"]),
+    ]);
+    secondChild.emit("exit", 0, null);
+  });
+
   test("does not spawn when launch has already been cancelled", async () => {
     const controller = new AbortController();
     controller.abort();

--- a/test/utils/android-cmdline-tools/AndroidEmulatorClient-launchContract.test.ts
+++ b/test/utils/android-cmdline-tools/AndroidEmulatorClient-launchContract.test.ts
@@ -111,6 +111,36 @@ describe("AndroidEmulatorClient launch contract", () => {
     }
   });
 
+  test("reserves the ADB endpoint supplied by -ports for concurrent launches", async () => {
+    const adb = new FakeAdbExecutor();
+    const firstChild = createChild();
+    const secondChild = createChild();
+    let firstSpawnedArgs: string[] = [];
+    let secondSpawnedArgs: string[] = [];
+    const firstClient = createClient((_command, args) => {
+      firstSpawnedArgs = args;
+      queueMicrotask(() => firstChild.stdout!.emit("data", Buffer.from("Detected GPU type: host\n")));
+      return firstChild;
+    }, adb);
+    const secondClient = createClient((_command, args) => {
+      secondSpawnedArgs = args;
+      queueMicrotask(() => secondChild.stdout!.emit("data", Buffer.from("Detected GPU type: host\n")));
+      return secondChild;
+    }, adb);
+
+    const firstLaunch = await firstClient.launchEmulator({
+      avdName: "Pixel 9",
+      extraArgs: ["-ports", "5562,5555"],
+    });
+    const secondLaunch = await secondClient.startEmulator("Pixel 9");
+
+    expect(firstLaunch.targetDeviceId).toBe("emulator-5562");
+    expect(firstSpawnedArgs).toEqual(expect.arrayContaining(["-ports", "5562,5555"]));
+    expect(secondSpawnedArgs).toEqual(expect.arrayContaining(["-port", "5556"]));
+    firstChild.emit("exit", 0, null);
+    secondLaunch!.emit("exit", 0, null);
+  });
+
   test("globally reserves an explicit emulator serial against a concurrent unlabelled launch", async () => {
     const adb = new FakeAdbExecutor();
     const firstChild = createChild();

--- a/test/utils/android-cmdline-tools/AndroidEmulatorClient-launchContract.test.ts
+++ b/test/utils/android-cmdline-tools/AndroidEmulatorClient-launchContract.test.ts
@@ -11,6 +11,7 @@ import { FakeTimer } from "../../fakes/FakeTimer";
 import { FakeAdbExecutor } from "../../fakes/FakeAdbExecutor";
 import type { AdbClientFactory } from "../../../src/utils/android-cmdline-tools/AdbClientFactory";
 import type { AdbExecutor } from "../../../src/utils/android-cmdline-tools/interfaces/AdbExecutor";
+import type { HostPortAvailabilityChecker } from "../../../src/utils/ios/IOSHostPortAvailabilityChecker";
 
 const execResult = (stdout = ""): ExecResult => ({
   stdout,
@@ -35,6 +36,9 @@ function createChild(): ChildProcess & EventEmitter {
 function createClient(
   spawnFn: (command: string, args: string[]) => ChildProcess,
   adb: FakeAdbExecutor = new FakeAdbExecutor(),
+  hostPortAvailabilityChecker: HostPortAvailabilityChecker = {
+    isAvailable: async () => true,
+  },
 ): AndroidEmulatorClient {
   const adbFactory: AdbClientFactory = {
     create: (): AdbExecutor => adb,
@@ -44,6 +48,10 @@ function createClient(
     spawnFn as never,
     new FakeTimer(),
     adbFactory,
+    undefined,
+    undefined,
+    undefined,
+    hostPortAvailabilityChecker,
   );
   (client as unknown as { ensureEmulatorPath: () => Promise<string> }).ensureEmulatorPath = async () => "emulator";
   (client as unknown as { listAvds: () => Promise<DeviceInfo[]> }).listAvds = async () => [
@@ -139,6 +147,106 @@ describe("AndroidEmulatorClient launch contract", () => {
     expect(secondSpawnedArgs).toEqual(expect.arrayContaining(["-port", "5556"]));
     firstChild.emit("exit", 0, null);
     secondLaunch!.emit("exit", 0, null);
+  });
+
+  test("skips an automatic port pair whose ADB endpoint is occupied outside ADB", async () => {
+    const adb = new FakeAdbExecutor();
+    adb.setDevices([
+      { name: "Unknown", platform: "android", deviceId: "emulator-5562" },
+    ]);
+    const child = createChild();
+    const checkedPorts: number[] = [];
+    let spawnedArgs: string[] = [];
+    const client = createClient(
+      (_command, args) => {
+        spawnedArgs = args;
+        queueMicrotask(() => child.stdout!.emit("data", Buffer.from("Detected GPU type: host\n")));
+        return child;
+      },
+      adb,
+      {
+        isAvailable: async (_host, port) => {
+          checkedPorts.push(port);
+          return port !== 5555;
+        },
+      },
+    );
+
+    await client.startEmulator("Pixel 9");
+
+    expect(checkedPorts).toEqual(expect.arrayContaining([5554, 5555, 5556, 5557]));
+    expect(spawnedArgs).toEqual(expect.arrayContaining(["-port", "5556"]));
+    child.emit("exit", 0, null);
+  });
+
+  test("rechecks reservations after concurrent host-port probes", async () => {
+    const adb = new FakeAdbExecutor();
+    const firstChild = createChild();
+    const secondChild = createChild();
+    const children = [firstChild, secondChild];
+    const spawnedArgs: string[][] = [];
+    let firstPairProbeCount = 0;
+    let releaseFirstPairProbes: () => void = () => {};
+    const firstPairProbes = new Promise<void>(resolve => {
+      releaseFirstPairProbes = resolve;
+    });
+    const hostPortAvailabilityChecker: HostPortAvailabilityChecker = {
+      isAvailable: async (_host, port) => {
+        if (port === 5554 || port === 5555) {
+          firstPairProbeCount += 1;
+          await firstPairProbes;
+        }
+        return true;
+      },
+    };
+    const createSharedClient = () => createClient(
+      (_command, args) => {
+        spawnedArgs.push(args);
+        const child = children.shift()!;
+        queueMicrotask(() => child.stdout!.emit("data", Buffer.from("Detected GPU type: host\n")));
+        return child;
+      },
+      adb,
+      hostPortAvailabilityChecker,
+    );
+
+    const firstLaunch = createSharedClient().startEmulator("Pixel 9");
+    while (firstPairProbeCount < 2) {
+      await Promise.resolve();
+    }
+    const secondLaunch = createSharedClient().startEmulator("Pixel 9");
+    while (firstPairProbeCount < 4) {
+      await Promise.resolve();
+    }
+    releaseFirstPairProbes();
+    await Promise.all([firstLaunch, secondLaunch]);
+
+    expect(spawnedArgs).toEqual([
+      expect.arrayContaining(["-port", "5554"]),
+      expect.arrayContaining(["-port", "5556"]),
+    ]);
+    firstChild.emit("exit", 0, null);
+    secondChild.emit("exit", 0, null);
+  });
+
+  test("tolerates odd and malformed emulator serials observed through ADB", async () => {
+    const adb = new FakeAdbExecutor();
+    adb.setDevices([
+      { name: "Odd", platform: "android", deviceId: "emulator-5555" },
+      { name: "Malformed", platform: "android", deviceId: "emulator-not-a-port" },
+    ]);
+    const child = createChild();
+    let spawnedArgs: string[] = [];
+    const client = createClient((_command, args) => {
+      spawnedArgs = args;
+      queueMicrotask(() => child.stdout!.emit("data", Buffer.from("Detected GPU type: host\n")));
+      return child;
+    }, adb);
+
+    await client.startEmulator("Pixel 9");
+
+    expect(spawnedArgs).toEqual(expect.arrayContaining(["-port", "5558"]));
+    child.emit("exit", 0, null);
   });
 
   test("globally reserves an explicit emulator serial against a concurrent unlabelled launch", async () => {

--- a/test/utils/android-cmdline-tools/AndroidEmulatorClient-launchContract.test.ts
+++ b/test/utils/android-cmdline-tools/AndroidEmulatorClient-launchContract.test.ts
@@ -8,6 +8,9 @@ import {
 } from "../../../src/utils/android-cmdline-tools/AndroidEmulatorClient";
 import type { DeviceInfo, ExecResult } from "../../../src/models";
 import { FakeTimer } from "../../fakes/FakeTimer";
+import { FakeAdbExecutor } from "../../fakes/FakeAdbExecutor";
+import type { AdbClientFactory } from "../../../src/utils/android-cmdline-tools/AdbClientFactory";
+import type { AdbExecutor } from "../../../src/utils/android-cmdline-tools/interfaces/AdbExecutor";
 
 const execResult = (stdout = ""): ExecResult => ({
   stdout,
@@ -30,10 +33,15 @@ function createChild(): ChildProcess & EventEmitter {
 }
 
 function createClient(spawnFn: (command: string, args: string[]) => ChildProcess): AndroidEmulatorClient {
+  const adb = new FakeAdbExecutor();
+  const adbFactory: AdbClientFactory = {
+    create: (): AdbExecutor => adb,
+  };
   const client = new AndroidEmulatorClient(
     async () => execResult(),
     spawnFn as never,
     new FakeTimer(),
+    adbFactory,
   );
   (client as unknown as { ensureEmulatorPath: () => Promise<string> }).ensureEmulatorPath = async () => "emulator";
   (client as unknown as { listAvds: () => Promise<DeviceInfo[]> }).listAvds = async () => [

--- a/test/utils/android-cmdline-tools/AndroidEmulatorClient-launchContract.test.ts
+++ b/test/utils/android-cmdline-tools/AndroidEmulatorClient-launchContract.test.ts
@@ -119,6 +119,19 @@ describe("AndroidEmulatorClient launch contract", () => {
     }
   });
 
+  test("rejects caller-supplied console ports outside the supported range", async () => {
+    let spawns = 0;
+    const client = createClient(() => {
+      spawns += 1;
+      return createChild();
+    });
+
+    await expect(
+      client.launchEmulator({ avdName: "Pixel 9", extraArgs: ["-port", "5684"] }),
+    ).rejects.toThrow("5554 through 5682");
+    expect(spawns).toBe(0);
+  });
+
   test("reserves the ADB endpoint supplied by -ports for concurrent launches", async () => {
     const adb = new FakeAdbExecutor();
     const firstChild = createChild();
@@ -437,6 +450,40 @@ describe("AndroidEmulatorClient launch contract", () => {
 
     await expect(launch).rejects.toThrow("cancelled");
     expect(spawns).toBe(0);
+  });
+
+  test("cancels host-port reservation before spawning", async () => {
+    const controller = new AbortController();
+    let releaseHostProbe: () => void = () => {};
+    const hostProbe = new Promise<void>(resolve => {
+      releaseHostProbe = resolve;
+    });
+    let hostProbeStarted = false;
+    let spawns = 0;
+    const client = createClient(
+      () => {
+        spawns += 1;
+        return createChild();
+      },
+      new FakeAdbExecutor(),
+      {
+        isAvailable: async () => {
+          hostProbeStarted = true;
+          await hostProbe;
+          return true;
+        },
+      },
+    );
+
+    const launch = client.launchEmulator({ avdName: "Pixel 9", signal: controller.signal });
+    while (!hostProbeStarted) {
+      await Promise.resolve();
+    }
+    controller.abort();
+
+    await expect(launch).rejects.toThrow("cancelled");
+    expect(spawns).toBe(0);
+    releaseHostProbe();
   });
 
   test("cancels the reservation snapshot before starting the raw-state scan", async () => {

--- a/test/utils/android-cmdline-tools/AndroidEmulatorClient-launchContract.test.ts
+++ b/test/utils/android-cmdline-tools/AndroidEmulatorClient-launchContract.test.ts
@@ -218,6 +218,48 @@ describe("AndroidEmulatorClient launch contract", () => {
     secondChild.emit("exit", 0, null);
   });
 
+  test("rejects an occupied selected port when the raw-state scan fails", async () => {
+    const adb = new FakeAdbExecutor();
+    adb.setDevices([
+      { name: "Unknown", platform: "android", deviceId: "emulator-5554" },
+    ]);
+    adb.getDeviceStates = async () => {
+      throw new Error("raw device-state scan failed");
+    };
+    let spawns = 0;
+    const client = createClient(() => {
+      spawns += 1;
+      return createChild();
+    }, adb);
+
+    await expect(
+      client.launchEmulator({ avdName: "Pixel 9", deviceId: "emulator-5554" }),
+    ).rejects.toThrow("console port 5554 is already in use");
+    expect(spawns).toBe(0);
+  });
+
+  test("does not allocate a console port when the raw-state scan fails", async () => {
+    const adb = new FakeAdbExecutor();
+    adb.setDevices([
+      { name: "Unknown", platform: "android", deviceId: "emulator-5554" },
+    ]);
+    adb.getDeviceStates = async () => {
+      throw new Error("raw device-state scan failed");
+    };
+    const child = createChild();
+    let spawnedArgs: string[] = [];
+    const client = createClient((_command, args) => {
+      spawnedArgs = args;
+      queueMicrotask(() => child.stdout!.emit("data", Buffer.from("Detected GPU type: host\n")));
+      return child;
+    }, adb);
+
+    await client.startEmulator("Pixel 9");
+
+    expect(spawnedArgs).not.toContain("-port");
+    child.emit("exit", 0, null);
+  });
+
   test("does not spawn when launch has already been cancelled", async () => {
     const controller = new AbortController();
     controller.abort();

--- a/test/utils/android-cmdline-tools/AndroidEmulatorClient-launchContract.test.ts
+++ b/test/utils/android-cmdline-tools/AndroidEmulatorClient-launchContract.test.ts
@@ -1,4 +1,4 @@
-import { describe, expect, test } from "bun:test";
+import { afterEach, describe, expect, test } from "bun:test";
 import { EventEmitter } from "node:events";
 import { Readable } from "node:stream";
 import type { ChildProcess } from "node:child_process";
@@ -32,8 +32,10 @@ function createChild(): ChildProcess & EventEmitter {
   return child;
 }
 
-function createClient(spawnFn: (command: string, args: string[]) => ChildProcess): AndroidEmulatorClient {
-  const adb = new FakeAdbExecutor();
+function createClient(
+  spawnFn: (command: string, args: string[]) => ChildProcess,
+  adb: FakeAdbExecutor = new FakeAdbExecutor(),
+): AndroidEmulatorClient {
   const adbFactory: AdbClientFactory = {
     create: (): AdbExecutor => adb,
   };
@@ -52,6 +54,10 @@ function createClient(spawnFn: (command: string, args: string[]) => ChildProcess
   (client as unknown as { checkArchitectureCompatibility: () => Promise<{ compatible: boolean }> }).checkArchitectureCompatibility = async () => ({ compatible: true });
   return client;
 }
+
+afterEach(() => {
+  AndroidEmulatorClient.resetLaunchReservationsForTesting();
+});
 
 describe("AndroidEmulatorClient launch contract", () => {
   test("uses a JSON argv array so values containing spaces remain one argument", () => {
@@ -103,6 +109,37 @@ describe("AndroidEmulatorClient launch contract", () => {
       child.emit("exit", 0, null);
       AndroidEmulatorClient.resetLaunchReservationsForTesting();
     }
+  });
+
+  test("globally reserves an explicit emulator serial against a concurrent unlabelled launch", async () => {
+    const adb = new FakeAdbExecutor();
+    const firstChild = createChild();
+    const secondChild = createChild();
+    let firstSpawnedArgs: string[] = [];
+    let secondSpawnedArgs: string[] = [];
+    const firstClient = createClient((_command, args) => {
+      firstSpawnedArgs = args;
+      queueMicrotask(() => firstChild.stdout!.emit("data", Buffer.from("Detected GPU type: host\n")));
+      return firstChild;
+    }, adb);
+    const secondClient = createClient((_command, args) => {
+      secondSpawnedArgs = args;
+      queueMicrotask(() => secondChild.stdout!.emit("data", Buffer.from("Detected GPU type: host\n")));
+      return secondChild;
+    }, adb);
+
+    const firstLaunch = await firstClient.launchEmulator({
+      avdName: "Pixel 9",
+      deviceId: "emulator-5554",
+    });
+    const secondLaunch = await secondClient.startEmulator("Pixel 9");
+
+    expect(firstLaunch.targetDeviceId).toBe("emulator-5554");
+    expect(firstSpawnedArgs).toEqual(expect.arrayContaining(["-port", "5554"]));
+    expect(secondSpawnedArgs).toEqual(expect.arrayContaining(["-port", "5556"]));
+    firstChild.emit("exit", 0, null);
+    secondLaunch!.emit("exit", 0, null);
+    AndroidEmulatorClient.resetLaunchReservationsForTesting();
   });
 
   test("does not spawn when launch has already been cancelled", async () => {

--- a/test/utils/android-cmdline-tools/AndroidEmulatorClient-launchContract.test.ts
+++ b/test/utils/android-cmdline-tools/AndroidEmulatorClient-launchContract.test.ts
@@ -81,6 +81,30 @@ describe("AndroidEmulatorClient launch contract", () => {
     expect(handle.process).toBe(child);
   });
 
+  test("honors caller-supplied emulator console ports without adding another port flag", async () => {
+    for (const [extraArgs, targetDeviceId] of [
+      [["-port", "5560"], "emulator-5560"],
+      [["-ports", "5562,5563"], "emulator-5562"],
+    ] as const) {
+      const child = createChild();
+      let spawnedArgs: string[] = [];
+      const client = createClient((_command, args) => {
+        spawnedArgs = args;
+        queueMicrotask(() => child.stdout!.emit("data", Buffer.from("Detected GPU type: host\n")));
+        return child;
+      });
+
+      const handle = await client.launchEmulator({ avdName: "Pixel 9", extraArgs });
+
+      expect(handle.targetDeviceId).toBe(targetDeviceId);
+      expect(spawnedArgs.filter(argument => argument === "-port" || argument === "-ports")).toEqual([
+        extraArgs[0],
+      ]);
+      child.emit("exit", 0, null);
+      AndroidEmulatorClient.resetLaunchReservationsForTesting();
+    }
+  });
+
   test("does not spawn when launch has already been cancelled", async () => {
     const controller = new AbortController();
     controller.abort();


### PR DESCRIPTION
## Summary

Capture the pre-launch Android emulator serial set for launches that do not already have an explicit serial. When launch output and `emu avd name` cannot identify the started emulator, readiness now proceeds only when exactly one new unknown emulator appears after launch. Ambiguous candidates still receive no readiness probes and report a correlation diagnostic at the deadline.

## Linked Issue

Closes [#5424](https://github.com/kaeawc/auto-mobile/issues/5424)

## Bug / Regression Context

- **Prior attempts:** Existing correlation handles an explicit device ID and serials emitted in launch output.
- **Observed symptom:** A usable newly launched emulator was eventually torn down when neither launch output nor the AVD console supplied its serial.
- **Repro steps / conditions:** Start an Android AVD without an explicit serial, omit `emulator-PORT` from launch output, and make `adb emu avd name` unavailable while normal ADB readiness commands succeed.

## Validation

- [x] `bun test test/utils/android-cmdline-tools/AndroidEmulatorClient-corruptImage.test.ts`
- [x] `bun test test/utils/android-cmdline-tools/AndroidEmulatorClient-launchContract.test.ts`
- [x] `bun run lint`
- [x] `bun run typecheck`
- [x] `bun run build`
- [x] `bun run turbo:validate` (13,593 passing; 14 skipped; 0 failed)
- [x] New coverage uses the existing fake ADB executor and FakeTimer seams.
- [x] No new dependency or generic helper introduced.
