### PR TITLE
fix(android): recover from System UI ANRs

### DIFF
--- a/src/daemon/devicePool.ts
+++ b/src/daemon/devicePool.ts
@@ -261,6 +261,8 @@ export class DevicePool {
   /** Latest refresh request; older discovery snapshots must not overwrite it. */
   private refreshGeneration = 0;
   private readonly readinessReservationCounts: Map<string, number> = new Map();
+  /** Stable runtime names reserved while a booted serial is being replaced. */
+  private readonly readinessReservationNames: Map<string, number> = new Map();
   /**
    * Captured incarnations that an explicit shutdown is retiring. Unlike a
    * readiness reservation, this excludes direct startDevice/autolock binding
@@ -2828,6 +2830,24 @@ export class DevicePool {
   }
 
   /**
+   * A System UI recovery that has confirmed shutdown but cannot restore the
+   * AVD has no usable successor for the session. Release it before retiring
+   * the captured connection epoch.
+   */
+  async retireDeviceAfterSystemUiAnrRecoveryFailure(
+    expectedDevice: PooledDevice,
+  ): Promise<boolean> {
+    if (expectedDevice.sessionId) {
+      await this.releaseSessionForDisconnectedDevice(
+        expectedDevice.sessionId,
+        expectedDevice.id,
+        deviceLossCancellationReason(expectedDevice.id),
+      );
+    }
+    return await this.retireDeviceForShutdown(expectedDevice);
+  }
+
+  /**
    * Atomically replace a captured stopped-device incarnation with the device
    * discovered under the same ID. This keeps allocators from claiming the old
    * device during the handoff.
@@ -2854,6 +2874,118 @@ export class DevicePool {
       );
       return this.devices.get(replacement.deviceId);
     });
+  }
+
+  /**
+   * Replace a stopped Android runtime while retaining the active AutoMobile
+   * session. The caller keeps both a shutdown reservation and a stable AVD
+   * readiness reservation until this handoff has completed.
+   */
+  async replaceDeviceForSystemUiAnrRecovery(
+    expectedDevice: PooledDevice,
+    replacement: BootedDevice,
+    sourceImage: DeviceInfo,
+    childProcess?: ChildProcess | null,
+  ): Promise<string | undefined> {
+    return await this.assignmentMutex.runExclusive(async () => {
+      if (this.devices.get(expectedDevice.id) !== expectedDevice) {
+        throw new ActionableError(
+          `Device '${expectedDevice.id}' changed while System UI recovery was in progress.`,
+        );
+      }
+      this.assertSystemUiAnrReplacement(expectedDevice, replacement, sourceImage);
+
+      const preservedSessionId = this.systemUiAnrRecoverySessionId(expectedDevice);
+      const replacementDevice = await this.replaceStoppedDeviceForSystemUiAnr(
+        expectedDevice,
+        replacement,
+        sourceImage,
+        childProcess,
+      );
+      await this.restoreSystemUiAnrRecoverySession(preservedSessionId, replacementDevice);
+      this.intentionalShutdowns.delete(expectedDevice.id);
+      return preservedSessionId;
+    });
+  }
+
+  private assertSystemUiAnrReplacement(
+    expectedDevice: PooledDevice,
+    replacement: BootedDevice,
+    sourceImage: DeviceInfo,
+  ): void {
+    if (
+      expectedDevice.platform !== "android" ||
+      replacement.platform !== "android" ||
+      sourceImage.platform !== "android" ||
+      replacement.name !== sourceImage.name
+    ) {
+      throw new ActionableError(
+        `System UI recovery must replace Android AVD '${sourceImage.name}' with the same runtime.`,
+      );
+    }
+  }
+
+  private systemUiAnrRecoverySessionId(expectedDevice: PooledDevice): string | undefined {
+    const sessionId = expectedDevice.sessionId;
+    const session = sessionId ? this.sessionManager.getSession(sessionId) : null;
+    if (
+      session === null ||
+      session.assignedDevice !== expectedDevice.id ||
+      session.platform !== "android"
+    ) {
+      return undefined;
+    }
+    return sessionId ?? undefined;
+  }
+
+  private async replaceStoppedDeviceForSystemUiAnr(
+    expectedDevice: PooledDevice,
+    replacement: BootedDevice,
+    sourceImage: DeviceInfo,
+    childProcess: ChildProcess | null | undefined,
+  ): Promise<PooledDevice> {
+    const priorAssignmentCount = expectedDevice.assignmentCount;
+    const priorLastUsedAt = expectedDevice.lastUsedAt;
+
+    // removeDevice rejects busy entries, so detach pool ownership only after
+    // capturing any session that must be rebound below. The replacement remains
+    // unavailable through the caller's readiness reservation while this runs.
+    this.releaseCapturedDeviceForShutdown(expectedDevice);
+    await this.removeDevice(expectedDevice.id, false, expectedDevice);
+    if (this.devices.has(replacement.deviceId)) {
+      throw new ActionableError(
+        `Replacement device '${replacement.deviceId}' was already added to the device pool.`,
+      );
+    }
+
+    await this.addDevice(replacement, sourceImage, false);
+    await this.trackStartedDeviceProcess(replacement, childProcess);
+    const replacementDevice = this.devices.get(replacement.deviceId);
+    if (!replacementDevice) {
+      throw new ActionableError(
+        `Replacement device '${replacement.deviceId}' was not retained by the device pool.`,
+      );
+    }
+    replacementDevice.assignmentCount = priorAssignmentCount;
+    replacementDevice.lastUsedAt = priorLastUsedAt;
+    return replacementDevice;
+  }
+
+  private async restoreSystemUiAnrRecoverySession(
+    sessionId: string | undefined,
+    replacementDevice: PooledDevice,
+  ): Promise<void> {
+    if (!sessionId) {
+      return;
+    }
+    await this.sessionManager.rebindSession(
+      sessionId,
+      replacementDevice.id,
+      replacementDevice.platform,
+    );
+    replacementDevice.sessionId = sessionId;
+    replacementDevice.status = "busy";
+    replacementDevice.lastUsedAt = this.nextLastUsedAt();
   }
 
   private sourceImageForSameAndroidReplacement(
@@ -2892,7 +3024,12 @@ export class DevicePool {
   async reserveDeviceForReadiness(
     deviceId: string,
     expectedIdentity: Pick<BootedDevice, "deviceId" | "name" | "platform" | "transportId">,
+    stableRuntimeName = expectedIdentity.name,
   ): Promise<() => Promise<void>> {
+    const stableRuntimeKey = this.readinessReservationNameKey({
+      name: stableRuntimeName,
+      platform: expectedIdentity.platform,
+    });
     await this.assignmentMutex.runExclusive(async () => {
       const pooled = this.devices.get(deviceId);
       if (pooled) {
@@ -2906,6 +3043,10 @@ export class DevicePool {
         deviceId,
         (this.readinessReservationCounts.get(deviceId) ?? 0) + 1,
       );
+      this.readinessReservationNames.set(
+        stableRuntimeKey,
+        (this.readinessReservationNames.get(stableRuntimeKey) ?? 0) + 1,
+      );
     });
 
     let released = false;
@@ -2918,15 +3059,37 @@ export class DevicePool {
         const count = this.readinessReservationCounts.get(deviceId);
         if (count === undefined || count <= 1) {
           this.readinessReservationCounts.delete(deviceId);
-          return;
+        } else {
+          this.readinessReservationCounts.set(deviceId, count - 1);
         }
-        this.readinessReservationCounts.set(deviceId, count - 1);
+        const nameCount = this.readinessReservationNames.get(stableRuntimeKey);
+        if (nameCount === undefined || nameCount <= 1) {
+          this.readinessReservationNames.delete(stableRuntimeKey);
+        } else {
+          this.readinessReservationNames.set(stableRuntimeKey, nameCount - 1);
+        }
       });
     };
   }
 
   private isReservedForReadiness(deviceId: string): boolean {
     return (this.readinessReservationCounts.get(deviceId) ?? 0) > 0;
+  }
+
+  private readinessReservationNameKey(
+    device: Pick<BootedDevice, "name" | "platform">,
+  ): string {
+    return `${device.platform}:${device.name}`;
+  }
+
+  private hasReadinessNameReservation(device: PooledDevice): boolean {
+    return (
+      this.readinessReservationNames.has(this.readinessReservationNameKey(device)) ||
+      (device.avdName !== undefined &&
+        this.readinessReservationNames.has(
+          this.readinessReservationNameKey({ name: device.avdName, platform: device.platform }),
+        ))
+    );
   }
 
   /**
@@ -2977,7 +3140,11 @@ export class DevicePool {
   }
 
   private isReservedForAssignment(device: PooledDevice): boolean {
-    return this.isReservedForReadiness(device.id) || this.isReservedForShutdown(device);
+    return (
+      this.isReservedForReadiness(device.id) ||
+      this.hasReadinessNameReservation(device) ||
+      this.isReservedForShutdown(device)
+    );
   }
 
   private assertNotReservedForShutdown(device: PooledDevice, unavailableMessage: string): void {

--- a/src/daemon/devicePool.ts
+++ b/src/daemon/devicePool.ts
@@ -144,6 +144,21 @@ interface DeviceRemovedListener {
   (deviceId: string): void;
 }
 
+export type DeviceReadinessReservation = (() => Promise<void>) & {
+  readonly owner: symbol;
+};
+
+interface ReadinessReservationTarget {
+  deviceId: string;
+  incarnation: number;
+}
+
+export interface SystemUiAnrRecoveryHandoff {
+  readonly preservedSessionId?: string;
+  readonly replacementDevice: PooledDevice;
+  validatePreservedSession(): Promise<void>;
+}
+
 /**
  * A process can emit output after readiness. Capture its redacted bounded tail
  * so a later unexpected exit has the same useful evidence as an early launch
@@ -261,8 +276,17 @@ export class DevicePool {
   /** Latest refresh request; older discovery snapshots must not overwrite it. */
   private refreshGeneration = 0;
   private readonly readinessReservationCounts: Map<string, number> = new Map();
-  /** Stable runtime names reserved while a booted serial is being replaced. */
-  private readonly readinessReservationNames: Map<string, number> = new Map();
+  /**
+   * Stable runtime names reserved while a booted serial is being replaced,
+   * keyed by reservation owner to its exact device incarnation. Concurrent
+   * readiness for the same device can share that device, while a replacement
+   * serial or incarnation remains unavailable until its owner transfers the
+   * reservation.
+   */
+  private readonly readinessReservationNames: Map<
+    string,
+    Map<symbol, ReadinessReservationTarget>
+  > = new Map();
   /**
    * Captured incarnations that an explicit shutdown is retiring. Unlike a
    * readiness reservation, this excludes direct startDevice/autolock binding
@@ -2536,9 +2560,13 @@ export class DevicePool {
   private async assertIdleDeviceAssignable(
     device: PooledDevice,
     unavailableMessage: string,
+    readinessReservationOwners?: ReadonlySet<symbol>,
   ): Promise<void> {
     if (device.status !== "idle" || device.sessionId) {
       return;
+    }
+    if (this.hasReadinessNameReservation(device, readinessReservationOwners)) {
+      throw new ActionableError(unavailableMessage);
     }
 
     const iosLiveness = device.platform === "ios" ? await this.getIosLivenessSnapshot() : undefined;
@@ -2837,14 +2865,23 @@ export class DevicePool {
   async retireDeviceAfterSystemUiAnrRecoveryFailure(
     expectedDevice: PooledDevice,
   ): Promise<boolean> {
+    let releaseError: unknown;
     if (expectedDevice.sessionId) {
-      await this.releaseSessionForDisconnectedDevice(
-        expectedDevice.sessionId,
-        expectedDevice.id,
-        deviceLossCancellationReason(expectedDevice.id),
-      );
+      try {
+        await this.releaseSessionForDisconnectedDevice(
+          expectedDevice.sessionId,
+          expectedDevice.id,
+          deviceLossCancellationReason(expectedDevice.id),
+        );
+      } catch (error) {
+        releaseError = error;
+      }
     }
-    return await this.retireDeviceForShutdown(expectedDevice);
+    const retired = await this.retireDeviceForShutdown(expectedDevice);
+    if (releaseError) {
+      throw releaseError;
+    }
+    return retired;
   }
 
   /**
@@ -2886,58 +2923,111 @@ export class DevicePool {
     replacement: BootedDevice,
     sourceImage: DeviceInfo,
     childProcess?: ChildProcess | null,
-  ): Promise<string | undefined> {
+  ): Promise<SystemUiAnrRecoveryHandoff> {
     return await this.assignmentMutex.runExclusive(async () => {
-      if (this.devices.get(expectedDevice.id) !== expectedDevice) {
+      const currentExpectedDevice = this.devices.get(expectedDevice.id);
+      const existingReplacement = this.devices.get(replacement.deviceId);
+      if (
+        currentExpectedDevice !== expectedDevice &&
+        (existingReplacement === undefined || existingReplacement === expectedDevice)
+      ) {
         throw new ActionableError(
           `Device '${expectedDevice.id}' changed while System UI recovery was in progress.`,
         );
       }
       this.assertSystemUiAnrReplacement(expectedDevice, replacement, sourceImage);
 
-      const preservedSessionId = this.systemUiAnrRecoverySessionId(expectedDevice);
+      const preservedSession = this.systemUiAnrRecoverySession(expectedDevice);
+      const preservedSessionId = preservedSession?.sessionId;
       const preservedAutolockSessionId = expectedDevice.autolockSessionId;
-      const replacementDevice = await this.replaceStoppedDeviceForSystemUiAnr(
-        expectedDevice,
-        replacement,
-        sourceImage,
-        childProcess,
-      );
+      let replacementDevice: PooledDevice | undefined;
       try {
+        replacementDevice = await this.replaceStoppedDeviceForSystemUiAnr(
+          expectedDevice,
+          replacement,
+          sourceImage,
+        );
+        await this.trackStartedDeviceProcess(replacement, childProcess);
+        if (this.devices.get(replacementDevice.id) !== replacementDevice) {
+          throw new ActionableError(
+            `Replacement device '${replacementDevice.id}' exited before its recovery session was rebound.`,
+          );
+        }
         await this.restoreSystemUiAnrRecoverySession(
-          preservedSessionId,
+          preservedSession,
+          expectedDevice.id,
           replacementDevice,
           preservedAutolockSessionId,
         );
       } catch (error) {
-        // The destructive pool handoff already published the replacement and
-        // removed the old incarnation. If the session rebind fails, roll the
-        // replacement back and release the preserved session so the caller's
-        // cleanup (which targets the removed original) cannot leave an idle,
-        // assignable device still mapped to the stopped serial.
-        await this.rollbackSystemUiAnrRecoveryReplacement(
-          replacementDevice,
-          preservedSessionId,
-          expectedDevice.id,
-        );
+        // Once the handoff has detached the original incarnation, roll any
+        // replacement back and release the preserved session so caller cleanup
+        // cannot leave an idle device mapped to the stopped serial.
+        const originalWasDetached =
+          this.devices.get(expectedDevice.id) !== expectedDevice ||
+          (preservedSession !== undefined && expectedDevice.sessionId === null);
+        if (originalWasDetached) {
+          await this.rollbackSystemUiAnrRecoveryReplacement(
+            replacementDevice,
+            preservedSession,
+          );
+        }
         throw error;
       }
+      if (!replacementDevice) {
+        throw new ActionableError(
+          `Replacement device '${replacement.deviceId}' was not retained by the device pool.`,
+        );
+      }
       this.intentionalShutdowns.delete(expectedDevice.id);
-      return preservedSessionId;
+      return {
+        preservedSessionId,
+        replacementDevice,
+        validatePreservedSession: async () => {
+          await this.validateSystemUiAnrRecoverySession(
+            preservedSession,
+            replacementDevice,
+          );
+        },
+      };
+    });
+  }
+
+  private async validateSystemUiAnrRecoverySession(
+    preservedSession: Session | undefined,
+    replacementDevice: PooledDevice,
+  ): Promise<void> {
+    if (!preservedSession) {
+      return;
+    }
+    await this.assignmentMutex.runExclusive(() => {
+      if (
+        this.devices.get(replacementDevice.id) !== replacementDevice ||
+        replacementDevice.sessionId !== preservedSession.sessionId ||
+        replacementDevice.status !== "busy" ||
+        this.sessionManager.getSession(preservedSession.sessionId) !== preservedSession ||
+        preservedSession.assignedDevice !== replacementDevice.id
+      ) {
+        throw new ActionableError(
+          `Session '${preservedSession.sessionId}' was released while System UI recovery was becoming ready.`,
+        );
+      }
     });
   }
 
   private async rollbackSystemUiAnrRecoveryReplacement(
-    replacementDevice: PooledDevice,
-    preservedSessionId: string | undefined,
-    originalDeviceId: string,
+    replacementDevice: PooledDevice | undefined,
+    preservedSession: Session | undefined,
   ): Promise<void> {
-    await this.removeDevice(replacementDevice.id, false, replacementDevice);
-    if (preservedSessionId) {
-      await this.releaseSessionForDisconnectedDevice(
-        preservedSessionId,
-        originalDeviceId,
-        deviceLossCancellationReason(originalDeviceId),
+    if (replacementDevice) {
+      await this.removeDevice(replacementDevice.id, false, replacementDevice);
+    }
+    if (preservedSession && this.sessionManager.getSession(preservedSession.sessionId) === preservedSession) {
+      await this.sessionManager.releaseSessionIfOwned(
+        preservedSession.sessionId,
+        preservedSession,
+        preservedSession.assignedDevice,
+        deviceLossCancellationReason(replacementDevice?.id ?? preservedSession.assignedDevice),
       );
     }
   }
@@ -2959,7 +3049,7 @@ export class DevicePool {
     }
   }
 
-  private systemUiAnrRecoverySessionId(expectedDevice: PooledDevice): string | undefined {
+  private systemUiAnrRecoverySession(expectedDevice: PooledDevice): Session | undefined {
     const sessionId = expectedDevice.sessionId;
     const session = sessionId ? this.sessionManager.getSession(sessionId) : null;
     if (
@@ -2969,17 +3059,31 @@ export class DevicePool {
     ) {
       return undefined;
     }
-    return sessionId ?? undefined;
+    return session;
   }
 
   private async replaceStoppedDeviceForSystemUiAnr(
     expectedDevice: PooledDevice,
     replacement: BootedDevice,
     sourceImage: DeviceInfo,
-    childProcess: ChildProcess | null | undefined,
   ): Promise<PooledDevice> {
     const priorAssignmentCount = expectedDevice.assignmentCount;
     const priorLastUsedAt = expectedDevice.lastUsedAt;
+    const existingReplacement = this.devices.get(replacement.deviceId);
+
+    if (existingReplacement && existingReplacement !== expectedDevice) {
+      this.assertPooledSystemUiAnrReplacement(existingReplacement, sourceImage);
+      if (this.devices.get(expectedDevice.id) === expectedDevice) {
+        this.releaseCapturedDeviceForShutdown(expectedDevice);
+        await this.removeDevice(expectedDevice.id, false, expectedDevice);
+      }
+      return await this.adoptSystemUiAnrReplacement(
+        existingReplacement,
+        sourceImage,
+        priorAssignmentCount,
+        priorLastUsedAt,
+      );
+    }
 
     // removeDevice rejects busy entries, so detach pool ownership only after
     // capturing any session that must be rebound below. The replacement remains
@@ -2993,7 +3097,6 @@ export class DevicePool {
     }
 
     await this.addDevice(replacement, sourceImage, false);
-    await this.trackStartedDeviceProcess(replacement, childProcess);
     const replacementDevice = this.devices.get(replacement.deviceId);
     if (!replacementDevice) {
       throw new ActionableError(
@@ -3005,20 +3108,71 @@ export class DevicePool {
     return replacementDevice;
   }
 
+  private assertPooledSystemUiAnrReplacement(
+    replacement: PooledDevice,
+    sourceImage: DeviceInfo,
+  ): void {
+    if (
+      replacement.platform !== "android" ||
+      sourceImage.platform !== "android" ||
+      replacement.name !== sourceImage.name
+    ) {
+      throw new ActionableError(
+        `System UI recovery replacement '${replacement.id}' does not match Android AVD '${sourceImage.name}'.`,
+      );
+    }
+    if (replacement.status !== "idle" || replacement.sessionId !== null) {
+      throw new ActionableError(
+        `System UI recovery replacement '${replacement.id}' is already assigned to a session.`,
+      );
+    }
+  }
+
+  private async adoptSystemUiAnrReplacement(
+    replacementDevice: PooledDevice,
+    sourceImage: DeviceInfo,
+    priorAssignmentCount: number,
+    priorLastUsedAt: number,
+  ): Promise<PooledDevice> {
+    this.recordSourceAndroidAvd(replacementDevice.id, sourceImage);
+    replacementDevice.assignmentCount = priorAssignmentCount;
+    replacementDevice.lastUsedAt = priorLastUsedAt;
+    return replacementDevice;
+  }
+
   private async restoreSystemUiAnrRecoverySession(
-    sessionId: string | undefined,
+    session: Session | undefined,
+    originalDeviceId: string,
     replacementDevice: PooledDevice,
     autolockSessionId: string | undefined,
   ): Promise<void> {
-    if (!sessionId) {
+    if (!session) {
       return;
     }
-    await this.sessionManager.rebindSession(
-      sessionId,
+    if (
+      this.sessionManager.getSession(session.sessionId) !== session ||
+      session.assignedDevice !== originalDeviceId
+    ) {
+      throw new ActionableError(
+        `Session '${session.sessionId}' was released while System UI recovery was in progress.`,
+      );
+    }
+    const reboundSession = await this.sessionManager.rebindSession(
+      session.sessionId,
       replacementDevice.id,
       replacementDevice.platform,
+      { force: true },
     );
-    replacementDevice.sessionId = sessionId;
+    if (
+      this.devices.get(replacementDevice.id) !== replacementDevice ||
+      reboundSession !== session ||
+      reboundSession.assignedDevice !== replacementDevice.id
+    ) {
+      throw new ActionableError(
+        `Replacement device '${replacementDevice.id}' disconnected while its recovery session was being rebound.`,
+      );
+    }
+    replacementDevice.sessionId = session.sessionId;
     replacementDevice.status = "busy";
     // addDevice leaves autolockSessionId undefined, which assertAutolockAccess
     // reads as "unlocked" and would let any session drive the recovered device
@@ -3065,15 +3219,17 @@ export class DevicePool {
     deviceId: string,
     expectedIdentity: Pick<BootedDevice, "deviceId" | "name" | "platform" | "transportId">,
     stableRuntimeName = expectedIdentity.name,
-  ): Promise<() => Promise<void>> {
+    verifiedAndroidAvdName?: string,
+  ): Promise<DeviceReadinessReservation> {
     // The stable-name reservation exists to bridge an Android emulator changing
     // serials across a reboot. iOS UDIDs are stable, so a name reservation there
     // only hides other idle simulators that share a (non-unique) display name.
-    const trackStableName = expectedIdentity.platform === "android";
     const stableRuntimeKey = this.readinessReservationNameKey({
       name: stableRuntimeName,
       platform: expectedIdentity.platform,
     });
+    const owner = Symbol("readiness-reservation");
+    let trackStableName = false;
     await this.assignmentMutex.runExclusive(async () => {
       const pooled = this.devices.get(deviceId);
       if (pooled) {
@@ -3083,20 +3239,27 @@ export class DevicePool {
           this.assertRuntimeIdentity(pooled, expectedIdentity);
         }
       }
+      const current = this.devices.get(deviceId);
+      trackStableName =
+        current?.platform === "android" &&
+        current.id.startsWith("emulator-") &&
+        (current.avdName === stableRuntimeName ||
+          verifiedAndroidAvdName === stableRuntimeName);
       this.readinessReservationCounts.set(
         deviceId,
         (this.readinessReservationCounts.get(deviceId) ?? 0) + 1,
       );
-      if (trackStableName) {
-        this.readinessReservationNames.set(
-          stableRuntimeKey,
-          (this.readinessReservationNames.get(stableRuntimeKey) ?? 0) + 1,
-        );
+      if (trackStableName && current) {
+        const owners =
+          this.readinessReservationNames.get(stableRuntimeKey) ??
+          new Map<symbol, ReadinessReservationTarget>();
+        owners.set(owner, { deviceId: current.id, incarnation: current.incarnation });
+        this.readinessReservationNames.set(stableRuntimeKey, owners);
       }
     });
 
     let released = false;
-    return async () => {
+    const release = async (): Promise<void> => {
       if (released) {
         return;
       }
@@ -3111,14 +3274,17 @@ export class DevicePool {
         if (!trackStableName) {
           return;
         }
-        const nameCount = this.readinessReservationNames.get(stableRuntimeKey);
-        if (nameCount === undefined || nameCount <= 1) {
+        const owners = this.readinessReservationNames.get(stableRuntimeKey);
+        if (!owners) {
+          return;
+        }
+        owners.delete(owner);
+        if (owners.size === 0) {
           this.readinessReservationNames.delete(stableRuntimeKey);
-        } else {
-          this.readinessReservationNames.set(stableRuntimeKey, nameCount - 1);
         }
       });
     };
+    return Object.assign(release, { owner });
   }
 
   private isReservedForReadiness(deviceId: string): boolean {
@@ -3131,14 +3297,37 @@ export class DevicePool {
     return `${device.platform}:${device.name}`;
   }
 
-  private hasReadinessNameReservation(device: PooledDevice): boolean {
+  private hasReadinessNameReservation(
+    device: PooledDevice,
+    readinessReservationOwners?: ReadonlySet<symbol>,
+  ): boolean {
     return (
-      this.readinessReservationNames.has(this.readinessReservationNameKey(device)) ||
+      this.hasReadinessReservationName(
+        this.readinessReservationNameKey(device),
+        device,
+        readinessReservationOwners,
+      ) ||
       (device.avdName !== undefined &&
-        this.readinessReservationNames.has(
+        this.hasReadinessReservationName(
           this.readinessReservationNameKey({ name: device.avdName, platform: device.platform }),
+          device,
+          readinessReservationOwners,
         ))
     );
+  }
+
+  private hasReadinessReservationName(
+    nameKey: string,
+    device: PooledDevice,
+    readinessReservationOwners: ReadonlySet<symbol> | undefined,
+  ): boolean {
+    const owners = this.readinessReservationNames.get(nameKey);
+    return owners !== undefined &&
+      Array.from(owners).some(
+        ([owner, target]) =>
+          (target.deviceId !== device.id || target.incarnation !== device.incarnation) &&
+          !readinessReservationOwners?.has(owner),
+      );
   }
 
   /**
@@ -3215,6 +3404,7 @@ export class DevicePool {
     childProcess?: ChildProcess | null,
     expectedIdentity?: Pick<BootedDevice, "deviceId" | "name" | "platform">,
     allowSessionRebind = false,
+    readinessReservationOwners?: ReadonlySet<symbol>,
   ): Promise<string> {
     return await this.assignmentMutex.runExclusive(async () => {
       const alreadyPooled = this.devices.has(deviceId);
@@ -3253,6 +3443,7 @@ export class DevicePool {
       await this.assertIdleDeviceAssignable(
         device,
         `Device '${deviceId}' is not available in the device pool.`,
+        readinessReservationOwners,
       );
 
       device = await this.validateOrReloadIdlePooledDevice(
@@ -3260,6 +3451,7 @@ export class DevicePool {
         expectedIdentity,
         `Device '${deviceId}' is not available in the device pool. ` +
           "It may have been shut down or disconnected.",
+        readinessReservationOwners,
       );
 
       if (device.sessionId) {
@@ -3310,6 +3502,7 @@ export class DevicePool {
     device: PooledDevice,
     expectedIdentity: Pick<BootedDevice, "deviceId" | "name" | "platform"> | undefined,
     unavailableMessage: string,
+    readinessReservationOwners?: ReadonlySet<symbol>,
   ): Promise<PooledDevice> {
     if (await this.ensurePooledDevicePresentForUse(device, false, true)) {
       return device;
@@ -3319,7 +3512,11 @@ export class DevicePool {
       throw new ActionableError(unavailableMessage);
     }
     this.assertRuntimeIdentity(replacement, expectedIdentity);
-    await this.assertIdleDeviceAssignable(replacement, unavailableMessage);
+    await this.assertIdleDeviceAssignable(
+      replacement,
+      unavailableMessage,
+      readinessReservationOwners,
+    );
     return replacement;
   }
 
@@ -3440,6 +3637,7 @@ export class DevicePool {
     sourceImage?: DeviceInfo,
     childProcess?: ChildProcess | null,
     expectedIdentity?: Pick<BootedDevice, "deviceId" | "name" | "platform">,
+    readinessReservationOwners?: ReadonlySet<symbol>,
   ): Promise<string | undefined> {
     if (!isDevicePoolAutolockEnabled()) {
       return undefined;
@@ -3452,6 +3650,7 @@ export class DevicePool {
         sourceImage,
         childProcess,
         expectedIdentity,
+        readinessReservationOwners,
       ),
     );
   }
@@ -3463,6 +3662,7 @@ export class DevicePool {
     sourceImage?: DeviceInfo,
     childProcess?: ChildProcess | null,
     expectedIdentity?: Pick<BootedDevice, "deviceId" | "name" | "platform">,
+    readinessReservationOwners?: ReadonlySet<symbol>,
   ): Promise<string> {
     const sessionId = randomUUID();
 
@@ -3513,6 +3713,7 @@ export class DevicePool {
       device,
       `Device '${deviceId}' is not available for autolock.\n` +
         `The device may have been shut down or disconnected.`,
+      readinessReservationOwners,
     );
 
     device = await this.validateOrReloadIdlePooledDevice(
@@ -3524,6 +3725,7 @@ export class DevicePool {
         `  - Use 'startDevice' with the same criteria to boot a new device\n` +
         `  - Use 'startDevice' with deviceId to restart this specific device\n` +
         `  - Use 'listDevices' to see currently available devices`,
+      readinessReservationOwners,
     );
 
     const assignmentSnapshot = this.snapshotSessionAssignment(device);

--- a/src/daemon/devicePool.ts
+++ b/src/daemon/devicePool.ts
@@ -2896,16 +2896,50 @@ export class DevicePool {
       this.assertSystemUiAnrReplacement(expectedDevice, replacement, sourceImage);
 
       const preservedSessionId = this.systemUiAnrRecoverySessionId(expectedDevice);
+      const preservedAutolockSessionId = expectedDevice.autolockSessionId;
       const replacementDevice = await this.replaceStoppedDeviceForSystemUiAnr(
         expectedDevice,
         replacement,
         sourceImage,
         childProcess,
       );
-      await this.restoreSystemUiAnrRecoverySession(preservedSessionId, replacementDevice);
+      try {
+        await this.restoreSystemUiAnrRecoverySession(
+          preservedSessionId,
+          replacementDevice,
+          preservedAutolockSessionId,
+        );
+      } catch (error) {
+        // The destructive pool handoff already published the replacement and
+        // removed the old incarnation. If the session rebind fails, roll the
+        // replacement back and release the preserved session so the caller's
+        // cleanup (which targets the removed original) cannot leave an idle,
+        // assignable device still mapped to the stopped serial.
+        await this.rollbackSystemUiAnrRecoveryReplacement(
+          replacementDevice,
+          preservedSessionId,
+          expectedDevice.id,
+        );
+        throw error;
+      }
       this.intentionalShutdowns.delete(expectedDevice.id);
       return preservedSessionId;
     });
+  }
+
+  private async rollbackSystemUiAnrRecoveryReplacement(
+    replacementDevice: PooledDevice,
+    preservedSessionId: string | undefined,
+    originalDeviceId: string,
+  ): Promise<void> {
+    await this.removeDevice(replacementDevice.id, false, replacementDevice);
+    if (preservedSessionId) {
+      await this.releaseSessionForDisconnectedDevice(
+        preservedSessionId,
+        originalDeviceId,
+        deviceLossCancellationReason(originalDeviceId),
+      );
+    }
   }
 
   private assertSystemUiAnrReplacement(
@@ -2974,6 +3008,7 @@ export class DevicePool {
   private async restoreSystemUiAnrRecoverySession(
     sessionId: string | undefined,
     replacementDevice: PooledDevice,
+    autolockSessionId: string | undefined,
   ): Promise<void> {
     if (!sessionId) {
       return;
@@ -2985,6 +3020,11 @@ export class DevicePool {
     );
     replacementDevice.sessionId = sessionId;
     replacementDevice.status = "busy";
+    // addDevice leaves autolockSessionId undefined, which assertAutolockAccess
+    // reads as "unlocked" and would let any session drive the recovered device
+    // while the mcpSessionAutolockMap still points at the original. Carry the
+    // lock forward so the original session keeps exclusive access.
+    replacementDevice.autolockSessionId = autolockSessionId;
     replacementDevice.lastUsedAt = this.nextLastUsedAt();
   }
 
@@ -3026,6 +3066,10 @@ export class DevicePool {
     expectedIdentity: Pick<BootedDevice, "deviceId" | "name" | "platform" | "transportId">,
     stableRuntimeName = expectedIdentity.name,
   ): Promise<() => Promise<void>> {
+    // The stable-name reservation exists to bridge an Android emulator changing
+    // serials across a reboot. iOS UDIDs are stable, so a name reservation there
+    // only hides other idle simulators that share a (non-unique) display name.
+    const trackStableName = expectedIdentity.platform === "android";
     const stableRuntimeKey = this.readinessReservationNameKey({
       name: stableRuntimeName,
       platform: expectedIdentity.platform,
@@ -3043,10 +3087,12 @@ export class DevicePool {
         deviceId,
         (this.readinessReservationCounts.get(deviceId) ?? 0) + 1,
       );
-      this.readinessReservationNames.set(
-        stableRuntimeKey,
-        (this.readinessReservationNames.get(stableRuntimeKey) ?? 0) + 1,
-      );
+      if (trackStableName) {
+        this.readinessReservationNames.set(
+          stableRuntimeKey,
+          (this.readinessReservationNames.get(stableRuntimeKey) ?? 0) + 1,
+        );
+      }
     });
 
     let released = false;
@@ -3061,6 +3107,9 @@ export class DevicePool {
           this.readinessReservationCounts.delete(deviceId);
         } else {
           this.readinessReservationCounts.set(deviceId, count - 1);
+        }
+        if (!trackStableName) {
+          return;
         }
         const nameCount = this.readinessReservationNames.get(stableRuntimeKey);
         if (nameCount === undefined || nameCount <= 1) {

--- a/src/daemon/sessionManager.ts
+++ b/src/daemon/sessionManager.ts
@@ -115,6 +115,14 @@ export interface SessionDeviceAssigner {
   assignDeviceToSession(sessionId: string, platform?: Platform): Promise<string>;
 }
 
+export interface RebindSessionOptions {
+  /**
+   * The runtime behind the same device ID restarted, so device-scoped session
+   * state must be cleared even though the serial is unchanged.
+   */
+  force?: boolean;
+}
+
 const KEEP_SCREEN_AWAKE_RESTORE_TIMEOUT_MS = 1_000;
 const SESSION_SETUP_DRAIN_TIMEOUT_MS = 1_000;
 const EXPIRY_RELEASE_REASONS = new Set([
@@ -463,19 +471,20 @@ export class SessionManager {
     sessionId: string,
     assignedDevice: string,
     platform: Platform,
+    options: RebindSessionOptions = {},
   ): Promise<Session> {
     const existing = this.sessions.get(sessionId);
     if (!existing) {
       return await this.createSession(sessionId, assignedDevice, platform);
     }
-    if (existing.assignedDevice === assignedDevice) {
+    if (existing.assignedDevice === assignedDevice && !options.force) {
       return existing;
     }
 
     const pendingRebind = this.pendingSessionRebinds.get(sessionId);
     if (pendingRebind) {
       await pendingRebind.promise;
-      return await this.rebindSession(sessionId, assignedDevice, platform);
+      return await this.rebindSession(sessionId, assignedDevice, platform, options);
     }
 
     const inFlightRelease = this.releasePromises.get(sessionId);

--- a/src/server/deviceTools.ts
+++ b/src/server/deviceTools.ts
@@ -24,7 +24,11 @@ import { DEVICE_POOL_MATCHING, isDevicePoolAutolockEnabled } from "../daemon/poo
 import { DEVICE_CREATE_ENV_VAR, getDeviceCreationGate, type DeviceCreationGate } from "../utils/deviceCreationGate";
 import { createDefaultDeviceProvisioner, type DeviceProvisioner } from "../utils/deviceProvisioning";
 import { DaemonState } from "../daemon/daemonState";
-import type { DevicePool, PooledDevice } from "../daemon/devicePool";
+import type {
+  DevicePool,
+  DeviceReadinessReservation,
+  PooledDevice,
+} from "../daemon/devicePool";
 import type { SessionManager } from "../daemon/sessionManager";
 import { DeviceBootService, type DeviceBootResult } from "../utils/deviceBootService";
 import { getInstalledAppsCacheWriteCoordinator } from "../db/installedAppsCacheWriteCoordinator";
@@ -1165,7 +1169,9 @@ async function rebootAndroidAfterSystemUiAnr(
 ): Promise<{
   boot: DeviceBootResult;
   preservedSessionId?: string;
-  releaseReadinessReservation?: () => Promise<void>;
+  releaseReadinessReservation?: DeviceReadinessReservation;
+  retireReplacement?: () => Promise<void>;
+  validatePreservedSession?: () => Promise<void>;
 }> {
   const sourceImage = await resolveSystemUiRecoveryImage(
     boot,
@@ -1180,13 +1186,13 @@ async function rebootAndroidAfterSystemUiAnr(
       boot.device.deviceId,
       boot.device,
       sourceImage.name,
+      sourceImage.name,
     )
     : undefined;
   let shutdownReservation: Awaited<ReturnType<DevicePool["reserveDeviceForShutdown"]>>;
   let shutdownWasConfirmed = false;
   let keepReadinessReservation = false;
   let replacementBoot: DeviceBootResult | undefined;
-  let replacementAdopted = false;
   try {
     shutdownReservation = await reserveSystemUiAnrShutdown(devicePool, boot.device.deviceId, signal);
     await shutdownAndroidForSystemUiAnr(
@@ -1206,29 +1212,45 @@ async function rebootAndroidAfterSystemUiAnr(
       signal,
       progress,
     );
-    const preservedSessionId = await handoffSystemUiAnrReplacement(
+    const adoptedReplacementBoot = replacementBoot;
+    const handoff = await handoffSystemUiAnrReplacement(
       devicePool,
       shutdownReservation,
-      replacementBoot,
+      adoptedReplacementBoot,
       sourceImage,
     );
-    replacementAdopted = true;
     keepReadinessReservation = true;
-    return { boot: replacementBoot, preservedSessionId, releaseReadinessReservation };
+    return {
+      boot: adoptedReplacementBoot,
+      preservedSessionId: handoff?.preservedSessionId,
+      releaseReadinessReservation,
+      retireReplacement: async () =>
+        await retireSystemUiAnrReplacement(
+          devicePool,
+          handoff?.replacementDevice,
+          adoptedReplacementBoot,
+        ),
+      validatePreservedSession: handoff?.validatePreservedSession,
+    };
   } catch (error) {
-    // A replacement that booted but was never adopted by the pool (handoff
-    // rejected, or rolled back) leaks its emulator process: the outer handler
-    // only tracks the original boot. Cancel it here where its handle is in scope.
-    if (!replacementAdopted) {
-      cancelUnownedColdBoot(replacementBoot);
+    // The pool rolls an adopted replacement back before rejecting its handoff,
+    // so any replacement still in scope here is safe to cancel as an unowned
+    // cold boot.
+    cancelUnownedColdBoot(replacementBoot);
+    try {
+      await cleanUpFailedSystemUiAnrRecovery(
+        devicePool,
+        shutdownReservation,
+        shutdownWasConfirmed,
+        boot.device.deviceId,
+        signal,
+      );
+    } catch (cleanupError) {
+      logger.warn(
+        `[DeviceTools] Failed to clean up after System UI ANR recovery failure: ${cleanupError}`,
+        cleanupError,
+      );
     }
-    await cleanUpFailedSystemUiAnrRecovery(
-      devicePool,
-      shutdownReservation,
-      shutdownWasConfirmed,
-      boot.device.deviceId,
-      signal,
-    );
     throw error;
   } finally {
     await shutdownReservation?.release();
@@ -1305,7 +1327,7 @@ async function handoffSystemUiAnrReplacement(
   shutdownReservation: Awaited<ReturnType<DevicePool["reserveDeviceForShutdown"]>>,
   replacementBoot: DeviceBootResult,
   sourceImage: DeviceInfo,
-): Promise<string | undefined> {
+): Promise<Awaited<ReturnType<DevicePool["replaceDeviceForSystemUiAnrRecovery"]>> | undefined> {
   if (!devicePool || !shutdownReservation) {
     return undefined;
   }
@@ -1340,7 +1362,46 @@ async function cleanUpFailedSystemUiAnrRecovery(
   }
 }
 
+async function retireSystemUiAnrReplacement(
+  devicePool: DevicePool | undefined,
+  expectedReplacement: PooledDevice | undefined,
+  replacementBoot: DeviceBootResult,
+): Promise<void> {
+  try {
+    if (expectedReplacement) {
+      await devicePool?.retireDeviceAfterSystemUiAnrRecoveryFailure(expectedReplacement);
+    }
+  } finally {
+    // Retiring the pool entry drops its process tracking, allowing the existing
+    // cold-boot cleanup to terminate this recovered emulator deterministically.
+    cancelUnownedColdBoot(replacementBoot);
+  }
+}
+
 type SystemUiAnrRecoveryResult = Awaited<ReturnType<typeof rebootAndroidAfterSystemUiAnr>>;
+
+async function validatePreservedSystemUiAnrRecoverySession(
+  preservedSessionId: string | undefined,
+  validatePreservedSession: (() => Promise<void>) | undefined,
+  retireReplacement: (() => Promise<void>) | undefined,
+): Promise<void> {
+  if (!preservedSessionId) {
+    return;
+  }
+  try {
+    await validatePreservedSession?.();
+  } catch (error) {
+    try {
+      await retireReplacement?.();
+    } catch (retireError) {
+      logger.warn(
+        `[DeviceTools] Failed to retire stale System UI recovery replacement: ${retireError}`,
+        retireError,
+      );
+    }
+    throw error;
+  }
+}
 
 async function ensureRunnerReadyWithSystemUiAnrRecovery(
   boot: DeviceBootResult,
@@ -1358,11 +1419,26 @@ async function ensureRunnerReadyWithSystemUiAnrRecovery(
     try {
       await ensureRunnerReady(recovery.boot);
     } catch (readinessError) {
-      // rebootAfterSystemUiAnr retained the readiness reservation for the
-      // replacement, but it only reaches the caller's ordered cleanup once this
-      // returns. Release it here so a failed second readiness check does not
-      // strand the recovered AVD out of general allocation forever.
-      await recovery.releaseReadinessReservation?.();
+      try {
+        await recovery.retireReplacement?.();
+      } catch (retireError) {
+        logger.warn(
+          `[DeviceTools] Failed to retire System UI recovery replacement: ${retireError}`,
+          retireError,
+        );
+      }
+      try {
+        // rebootAfterSystemUiAnr retained the readiness reservation for the
+        // replacement, but it only reaches the caller's ordered cleanup once this
+        // returns. Release it here so a failed second readiness check does not
+        // strand the recovered AVD out of general allocation forever.
+        await recovery.releaseReadinessReservation?.();
+      } catch (releaseError) {
+        logger.warn(
+          `[DeviceTools] Failed to release System UI recovery readiness reservation: ${releaseError}`,
+          releaseError,
+        );
+      }
       throw readinessError;
     }
     return { ...recovery, recovered: true };
@@ -1374,7 +1450,7 @@ async function reserveRecoveredDeviceForReadiness(
   boot: DeviceBootResult,
   args: StartDeviceArgs,
   requestedIdentity: string,
-  releaseReadinessReservations: Array<() => Promise<void>>,
+  releaseReadinessReservations: DeviceReadinessReservation[],
 ): Promise<void> {
   validateBootIdentity(args, boot.device, boot.source, boot.sourceImage);
   validatePooledDeviceMapping(boot.device, requestedIdentity);
@@ -1393,7 +1469,7 @@ async function reserveRecoveredDeviceForReadiness(
 async function reserveInitialDeviceForReadiness(
   daemonState: DaemonState,
   boot: DeviceBootResult,
-  releaseReadinessReservations: Array<() => Promise<void>>,
+  releaseReadinessReservations: DeviceReadinessReservation[],
 ): Promise<void> {
   const devicePool = getStartDevicePool(daemonState);
   if (!devicePool) {
@@ -1435,12 +1511,12 @@ interface StartDeviceRunnerReadinessInput {
   perf: ReturnType<typeof createPerformanceTracker>;
   requestedIdentity: string;
   ensureCtrlProxyReady: (request: RunnerReadinessRequest) => Promise<void>;
-  releaseReadinessReservations: Array<() => Promise<void>>;
+  releaseReadinessReservations: DeviceReadinessReservation[];
 }
 
 async function prepareStartDeviceRunnerReadiness(
   input: StartDeviceRunnerReadinessInput,
-): Promise<{ boot: DeviceBootResult; preservedSessionId?: string }> {
+): Promise<SystemUiAnrRecoveryResult & { recovered: boolean }> {
   const devicePool = getStartDevicePool(input.daemonState);
   const readinessResult = await ensureRunnerReadyWithSystemUiAnrRecovery(
     input.boot,
@@ -1448,7 +1524,19 @@ async function prepareStartDeviceRunnerReadiness(
     createSystemUiAnrRebooter(input, devicePool),
   );
   if (readinessResult.recovered) {
-    await prepareRecoveredDeviceForRunnerReadiness(input, devicePool, readinessResult);
+    try {
+      await prepareRecoveredDeviceForRunnerReadiness(input, devicePool, readinessResult);
+    } catch (error) {
+      try {
+        await readinessResult.retireReplacement?.();
+      } catch (cleanupError) {
+        logger.warn(
+          `[DeviceTools] Failed to retire replacement after recovered readiness reservation failed: ${cleanupError}`,
+          cleanupError,
+        );
+      }
+      throw error;
+    }
   }
   return readinessResult;
 }
@@ -1580,8 +1668,10 @@ export function registerDeviceTools() {
     const requestedIdentity = describeStartDeviceRequest(args);
     let boot: DeviceBootResult | undefined;
     let ownershipTransferred = false;
-    const releaseReadinessReservations: Array<() => Promise<void>> = [];
+    const releaseReadinessReservations: DeviceReadinessReservation[] = [];
     let preservedSessionId: string | undefined;
+    let validatePreservedSession: (() => Promise<void>) | undefined;
+    let retireRecoveredReplacement: (() => Promise<void>) | undefined;
 
     try {
       const bootService = new DeviceBootService({
@@ -1632,6 +1722,8 @@ export function registerDeviceTools() {
       );
       boot = readinessResult.boot;
       preservedSessionId = readinessResult.preservedSessionId;
+      validatePreservedSession = readinessResult.validatePreservedSession;
+      retireRecoveredReplacement = readinessResult.retireReplacement;
       // Re-check under the later binding lock because pool identity can change
       // while runner setup is in flight.
       validatePooledDeviceMapping(boot.device, requestedIdentity);
@@ -1639,11 +1731,17 @@ export function registerDeviceTools() {
       // Publish only after runner health passes. Readiness remains per-device,
       // so 20-40 concurrent emulators do not serialize on a host-wide gate.
       publishWarmDeviceReady(boot.source, boot.device.deviceId);
+      await validatePreservedSystemUiAnrRecoverySession(
+        preservedSessionId,
+        validatePreservedSession,
+        retireRecoveredReplacement,
+      );
       const sessionId = preservedSessionId ?? await bindBootedDeviceSession(
         boot.device,
         args,
         boot.sourceImage,
         boot.processHandle,
+        new Set(releaseReadinessReservations.map((reservation) => reservation.owner)),
       );
       ownershipTransferred = true;
 
@@ -1687,7 +1785,8 @@ export function registerDeviceTools() {
     device: BootedDevice,
     args: StartDeviceArgs,
     sourceImage?: DeviceInfo,
-    childProcess?: ChildProcess | null
+    childProcess?: ChildProcess | null,
+    readinessReservationOwners?: ReadonlySet<symbol>,
   ): Promise<string> {
     // Reserve the exact ready device before resource notifications publish it
     // to concurrent allocators.
@@ -1700,6 +1799,7 @@ export function registerDeviceTools() {
         sourceImage,
         childProcess,
         device,
+        readinessReservationOwners,
       );
       if (autolockSessionId) {
         return autolockSessionId;
@@ -1717,6 +1817,8 @@ export function registerDeviceTools() {
       sourceImage,
       childProcess,
       device,
+      false,
+      readinessReservationOwners,
     );
   }
 

--- a/src/server/deviceTools.ts
+++ b/src/server/deviceTools.ts
@@ -37,6 +37,7 @@ import { executionTracker } from "./executionTracker";
 import {
   createDefaultRunnerReadinessService,
   type RunnerReadinessRequest,
+  SystemUiAnrRecoveryRequiredError,
 } from "../utils/RunnerReadinessService";
 import {
   MAX_RUNNER_READINESS_TIMEOUT_MS,
@@ -1110,6 +1111,376 @@ function publishWarmDeviceReady(source: "booted" | "cold-boot", deviceId: string
   }
 }
 
+function isUnknownAndroidRuntimeName(device: BootedDevice): boolean {
+  return device.name === `Unknown (${device.deviceId})`;
+}
+
+async function resolveSystemUiRecoveryImage(
+  boot: DeviceBootResult,
+  deviceManager: PlatformDeviceManager,
+  devicePool: DevicePool | undefined,
+  timer: Timer,
+  totalDeadlineMs: number,
+  signal: AbortSignal | undefined,
+): Promise<DeviceInfo> {
+  const pooled = devicePool?.getDevice(boot.device.deviceId);
+  const avdName =
+    pooled?.avdName ??
+    (boot.sourceImage?.platform === "android" ? boot.sourceImage.name : undefined) ??
+    (isUnknownAndroidRuntimeName(boot.device) ? undefined : boot.device.name);
+  if (!avdName) {
+    throw new ActionableError(
+      `Cannot restart Android device '${boot.device.deviceId}' after a System UI ANR because its AVD name is unknown.`,
+    );
+  }
+  const images = await runWithinShutdownDeadline(
+    boot.device,
+    timer,
+    totalDeadlineMs,
+    "System UI recovery image lookup did not complete",
+    signal,
+    async () => await deviceManager.listDeviceImages("android"),
+  );
+  const image = images.find(
+    (candidate) => candidate.platform === "android" && candidate.name === avdName,
+  );
+  if (!image) {
+    throw new ActionableError(
+      `Cannot restart Android device '${boot.device.deviceId}' after a System UI ANR because AVD '${avdName}' is unavailable.`,
+    );
+  }
+  return { ...image, isRunning: false };
+}
+
+async function rebootAndroidAfterSystemUiAnr(
+  boot: DeviceBootResult,
+  args: StartDeviceArgs,
+  bootService: DeviceBootService,
+  deviceManager: PlatformDeviceManager,
+  devicePool: DevicePool | undefined,
+  totalDeadlineMs: number,
+  timer: Timer,
+  signal: AbortSignal | undefined,
+  progress: { report: ProgressCallback } | undefined,
+): Promise<{
+  boot: DeviceBootResult;
+  preservedSessionId?: string;
+  releaseReadinessReservation?: () => Promise<void>;
+}> {
+  const sourceImage = await resolveSystemUiRecoveryImage(
+    boot,
+    deviceManager,
+    devicePool,
+    timer,
+    totalDeadlineMs,
+    signal,
+  );
+  const releaseReadinessReservation = devicePool
+    ? await devicePool.reserveDeviceForReadiness(
+      boot.device.deviceId,
+      boot.device,
+      sourceImage.name,
+    )
+    : undefined;
+  let shutdownReservation: Awaited<ReturnType<DevicePool["reserveDeviceForShutdown"]>>;
+  let shutdownWasConfirmed = false;
+  let keepReadinessReservation = false;
+  try {
+    shutdownReservation = await reserveSystemUiAnrShutdown(devicePool, boot.device.deviceId, signal);
+    await shutdownAndroidForSystemUiAnr(
+      boot.device,
+      deviceManager,
+      timer,
+      totalDeadlineMs,
+      signal,
+    );
+    shutdownWasConfirmed = true;
+
+    const replacementBoot = await bootSystemUiAnrReplacement(
+      bootService,
+      args,
+      sourceImage,
+      totalDeadlineMs,
+      signal,
+      progress,
+    );
+    const preservedSessionId = await handoffSystemUiAnrReplacement(
+      devicePool,
+      shutdownReservation,
+      replacementBoot,
+      sourceImage,
+    );
+    keepReadinessReservation = true;
+    return { boot: replacementBoot, preservedSessionId, releaseReadinessReservation };
+  } catch (error) {
+    await cleanUpFailedSystemUiAnrRecovery(
+      devicePool,
+      shutdownReservation,
+      shutdownWasConfirmed,
+      boot.device.deviceId,
+    );
+    throw error;
+  } finally {
+    await shutdownReservation?.release();
+    if (!keepReadinessReservation) {
+      await releaseReadinessReservation?.();
+    }
+  }
+}
+
+async function reserveSystemUiAnrShutdown(
+  devicePool: DevicePool | undefined,
+  deviceId: string,
+  signal: AbortSignal | undefined,
+): Promise<Awaited<ReturnType<DevicePool["reserveDeviceForShutdown"]>>> {
+  if (!devicePool) {
+    return undefined;
+  }
+  const reservation = await devicePool.reserveDeviceForShutdown(deviceId, signal);
+  if (reservation) {
+    devicePool.markIntentionalShutdown(deviceId);
+  }
+  return reservation;
+}
+
+async function shutdownAndroidForSystemUiAnr(
+  device: BootedDevice,
+  deviceManager: PlatformDeviceManager,
+  timer: Timer,
+  totalDeadlineMs: number,
+  signal: AbortSignal | undefined,
+): Promise<void> {
+  const shutdownDevice = await runWithinShutdownDeadline(
+    device,
+    timer,
+    totalDeadlineMs,
+    "System UI recovery shutdown command did not complete",
+    signal,
+    async (shutdownSignal, timeoutMs) =>
+      await deviceManager.killDevice(device, { signal: shutdownSignal, timeoutMs }),
+  );
+  await waitForDeviceShutdown(
+    deviceManager,
+    shutdownDevice ?? device,
+    timer,
+    totalDeadlineMs,
+    signal,
+  );
+}
+
+async function bootSystemUiAnrReplacement(
+  bootService: DeviceBootService,
+  args: StartDeviceArgs,
+  sourceImage: DeviceInfo,
+  totalDeadlineMs: number,
+  signal: AbortSignal | undefined,
+  progress: { report: ProgressCallback } | undefined,
+): Promise<DeviceBootResult> {
+  const replacement = await bootService.boot(
+    {
+      ...args,
+      deviceId: undefined,
+      name: sourceImage.name,
+      preferRunning: false,
+      totalDeadlineMs,
+      signal,
+    },
+    progress,
+  );
+  return { ...replacement, sourceImage };
+}
+
+async function handoffSystemUiAnrReplacement(
+  devicePool: DevicePool | undefined,
+  shutdownReservation: Awaited<ReturnType<DevicePool["reserveDeviceForShutdown"]>>,
+  replacementBoot: DeviceBootResult,
+  sourceImage: DeviceInfo,
+): Promise<string | undefined> {
+  if (!devicePool || !shutdownReservation) {
+    return undefined;
+  }
+  return await devicePool.replaceDeviceForSystemUiAnrRecovery(
+    shutdownReservation.device,
+    replacementBoot.device,
+    sourceImage,
+    replacementBoot.processHandle,
+  );
+}
+
+async function cleanUpFailedSystemUiAnrRecovery(
+  devicePool: DevicePool | undefined,
+  shutdownReservation: Awaited<ReturnType<DevicePool["reserveDeviceForShutdown"]>>,
+  shutdownWasConfirmed: boolean,
+  deviceId: string,
+): Promise<void> {
+  if (!shutdownReservation) {
+    return;
+  }
+  if (shutdownWasConfirmed) {
+    await devicePool?.retireDeviceAfterSystemUiAnrRecoveryFailure(shutdownReservation.device);
+    return;
+  }
+  devicePool?.clearIntentionalShutdown(deviceId);
+}
+
+type SystemUiAnrRecoveryResult = Awaited<ReturnType<typeof rebootAndroidAfterSystemUiAnr>>;
+
+async function ensureRunnerReadyWithSystemUiAnrRecovery(
+  boot: DeviceBootResult,
+  ensureRunnerReady: (candidate: DeviceBootResult) => Promise<void>,
+  rebootAfterSystemUiAnr: (candidate: DeviceBootResult) => Promise<SystemUiAnrRecoveryResult>,
+): Promise<SystemUiAnrRecoveryResult & { recovered: boolean }> {
+  try {
+    await ensureRunnerReady(boot);
+    return { boot, recovered: false };
+  } catch (error) {
+    if (!(error instanceof SystemUiAnrRecoveryRequiredError) || boot.device.platform !== "android") {
+      throw error;
+    }
+    const recovery = await rebootAfterSystemUiAnr(boot);
+    await ensureRunnerReady(recovery.boot);
+    return { ...recovery, recovered: true };
+  }
+}
+
+async function reserveRecoveredDeviceForReadiness(
+  devicePool: DevicePool | undefined,
+  boot: DeviceBootResult,
+  args: StartDeviceArgs,
+  requestedIdentity: string,
+  releaseReadinessReservations: Array<() => Promise<void>>,
+): Promise<void> {
+  validateBootIdentity(args, boot.device, boot.source, boot.sourceImage);
+  validatePooledDeviceMapping(boot.device, requestedIdentity);
+  if (devicePool) {
+    releaseReadinessReservations.push(
+      await devicePool.reserveDeviceForReadiness(
+        boot.device.deviceId,
+        boot.device,
+        boot.sourceImage?.name ?? boot.device.name,
+      ),
+    );
+  }
+  clearColdBootShutdownMarker(boot.source, boot.device.deviceId);
+}
+
+async function reserveInitialDeviceForReadiness(
+  daemonState: DaemonState,
+  boot: DeviceBootResult,
+  releaseReadinessReservations: Array<() => Promise<void>>,
+): Promise<void> {
+  const devicePool = getStartDevicePool(daemonState);
+  if (!devicePool) {
+    return;
+  }
+  releaseReadinessReservations.push(
+    await devicePool.reserveDeviceForReadiness(
+      boot.device.deviceId,
+      boot.device,
+      boot.sourceImage?.name ?? boot.device.name,
+    ),
+  );
+}
+
+async function notifyResourcesAfterDeviceBoot(
+  boot: DeviceBootResult,
+  perf: ReturnType<typeof createPerformanceTracker>,
+  notifyResourcesChanged: () => Promise<void>,
+): Promise<void> {
+  if (boot.source !== "cold-boot" && !boot.provisioned) {
+    return;
+  }
+  perf.startOperation("notifyResources");
+  await notifyResourcesChanged();
+  perf.endOperation("notifyResources");
+}
+
+interface StartDeviceRunnerReadinessInput {
+  boot: DeviceBootResult;
+  args: StartDeviceArgs;
+  bootService: DeviceBootService;
+  deviceUtils: PlatformDeviceManager;
+  daemonState: DaemonState;
+  totalDeadlineMs: number;
+  readinessTimeoutMs: number;
+  timer: Timer;
+  signal: AbortSignal | undefined;
+  progress: ProgressCallback | undefined;
+  perf: ReturnType<typeof createPerformanceTracker>;
+  requestedIdentity: string;
+  ensureCtrlProxyReady: (request: RunnerReadinessRequest) => Promise<void>;
+  releaseReadinessReservations: Array<() => Promise<void>>;
+}
+
+async function prepareStartDeviceRunnerReadiness(
+  input: StartDeviceRunnerReadinessInput,
+): Promise<{ boot: DeviceBootResult; preservedSessionId?: string }> {
+  const devicePool = getStartDevicePool(input.daemonState);
+  const readinessResult = await ensureRunnerReadyWithSystemUiAnrRecovery(
+    input.boot,
+    createRunnerReadinessAttempt(input),
+    createSystemUiAnrRebooter(input, devicePool),
+  );
+  if (readinessResult.recovered) {
+    await prepareRecoveredDeviceForRunnerReadiness(input, devicePool, readinessResult);
+  }
+  return readinessResult;
+}
+
+function getStartDevicePool(daemonState: DaemonState): DevicePool | undefined {
+  return daemonState.isInitialized() ? daemonState.getDevicePool() : undefined;
+}
+
+function createRunnerReadinessAttempt(
+  input: StartDeviceRunnerReadinessInput,
+): (candidate: DeviceBootResult) => Promise<void> {
+  return async (candidate) =>
+    await input.ensureCtrlProxyReady({
+      device: candidate.device,
+      requestedIdentity: input.requestedIdentity,
+      totalDeadlineMs: input.totalDeadlineMs,
+      readinessTimeoutMs: input.readinessTimeoutMs,
+      skipCtrlProxyDownload: serverConfig.isSkipCtrlProxyDownloadEnabled(),
+      perf: input.perf,
+      signal: input.signal,
+    });
+}
+
+function createSystemUiAnrRebooter(
+  input: StartDeviceRunnerReadinessInput,
+  devicePool: DevicePool | undefined,
+): (candidate: DeviceBootResult) => Promise<SystemUiAnrRecoveryResult> {
+  return async (candidate) =>
+    await rebootAndroidAfterSystemUiAnr(
+      candidate,
+      input.args,
+      input.bootService,
+      input.deviceUtils,
+      devicePool,
+      input.totalDeadlineMs,
+      input.timer,
+      input.signal,
+      input.progress ? { report: input.progress } : undefined,
+    );
+}
+
+async function prepareRecoveredDeviceForRunnerReadiness(
+  input: StartDeviceRunnerReadinessInput,
+  devicePool: DevicePool | undefined,
+  recovery: SystemUiAnrRecoveryResult,
+): Promise<void> {
+  if (recovery.releaseReadinessReservation) {
+    input.releaseReadinessReservations.push(recovery.releaseReadinessReservation);
+  }
+  await reserveRecoveredDeviceForReadiness(
+    devicePool,
+    recovery.boot,
+    input.args,
+    input.requestedIdentity,
+    input.releaseReadinessReservations,
+  );
+}
+
 export function registerDeviceTools() {
   // List AVDs handler
   const listDeviceImagesHandler = async (args: ListDeviceImagesArgs) => {
@@ -1183,7 +1554,8 @@ export function registerDeviceTools() {
     const requestedIdentity = describeStartDeviceRequest(args);
     let boot: DeviceBootResult | undefined;
     let ownershipTransferred = false;
-    let releaseReadinessReservation: (() => Promise<void>) | undefined;
+    const releaseReadinessReservations: Array<() => Promise<void>> = [];
+    let preservedSessionId: string | undefined;
 
     try {
       const bootService = new DeviceBootService({
@@ -1203,26 +1575,37 @@ export function registerDeviceTools() {
       validateBootIdentity(args, boot.device, boot.source, boot.sourceImage);
       validatePooledDeviceMapping(boot.device, requestedIdentity);
       const daemonState = DaemonState.getInstance();
-      if (daemonState.isInitialized()) {
-        releaseReadinessReservation = await daemonState
-          .getDevicePool()
-          .reserveDeviceForReadiness(boot.device.deviceId, boot.device);
-      }
+      await reserveInitialDeviceForReadiness(
+        daemonState,
+        boot,
+        releaseReadinessReservations,
+      );
 
       // A new incarnation must not inherit a prior intentional-shutdown marker
       // while its per-device runner setup is in flight.
       clearColdBootShutdownMarker(boot.source, boot.device.deviceId);
 
       const ctrlProxySetup = deps.ensureCtrlProxyReady ?? ensureCtrlProxyReady;
-      await ctrlProxySetup({
-        device: boot.device,
-        requestedIdentity,
-        totalDeadlineMs,
-        readinessTimeoutMs,
-        skipCtrlProxyDownload: serverConfig.isSkipCtrlProxyDownloadEnabled(),
-        perf,
-        signal,
-      });
+      const readinessResult = await prepareStartDeviceRunnerReadiness(
+        {
+          boot,
+          args,
+          bootService,
+          deviceUtils,
+          daemonState,
+          totalDeadlineMs,
+          readinessTimeoutMs,
+          timer: deps.timer,
+          signal,
+          progress,
+          perf,
+          requestedIdentity,
+          ensureCtrlProxyReady: ctrlProxySetup,
+          releaseReadinessReservations,
+        },
+      );
+      boot = readinessResult.boot;
+      preservedSessionId = readinessResult.preservedSessionId;
       // Re-check under the later binding lock because pool identity can change
       // while runner setup is in flight.
       validatePooledDeviceMapping(boot.device, requestedIdentity);
@@ -1230,19 +1613,15 @@ export function registerDeviceTools() {
       // Publish only after runner health passes. Readiness remains per-device,
       // so 20-40 concurrent emulators do not serialize on a host-wide gate.
       publishWarmDeviceReady(boot.source, boot.device.deviceId);
-      const sessionId = await bindBootedDeviceSession(
+      const sessionId = preservedSessionId ?? await bindBootedDeviceSession(
         boot.device,
         args,
         boot.sourceImage,
-        boot.processHandle
+        boot.processHandle,
       );
       ownershipTransferred = true;
 
-      if (boot.source === "cold-boot" || boot.provisioned) {
-        perf.startOperation("notifyResources");
-        await deps.notifyResourcesChanged();
-        perf.endOperation("notifyResources");
-      }
+      await notifyResourcesAfterDeviceBoot(boot, perf, deps.notifyResourcesChanged);
       return await buildBootedResponse(
         boot.device,
         boot.source,
@@ -1260,7 +1639,9 @@ export function registerDeviceTools() {
       }
       throw new ActionableError(`Failed to start ${args.platform} device: ${error}`);
     } finally {
-      await releaseReadinessReservation?.();
+      for (const releaseReservation of releaseReadinessReservations.reverse()) {
+        await releaseReservation();
+      }
     }
   };
 

--- a/src/server/deviceTools.ts
+++ b/src/server/deviceTools.ts
@@ -1185,6 +1185,8 @@ async function rebootAndroidAfterSystemUiAnr(
   let shutdownReservation: Awaited<ReturnType<DevicePool["reserveDeviceForShutdown"]>>;
   let shutdownWasConfirmed = false;
   let keepReadinessReservation = false;
+  let replacementBoot: DeviceBootResult | undefined;
+  let replacementAdopted = false;
   try {
     shutdownReservation = await reserveSystemUiAnrShutdown(devicePool, boot.device.deviceId, signal);
     await shutdownAndroidForSystemUiAnr(
@@ -1196,7 +1198,7 @@ async function rebootAndroidAfterSystemUiAnr(
     );
     shutdownWasConfirmed = true;
 
-    const replacementBoot = await bootSystemUiAnrReplacement(
+    replacementBoot = await bootSystemUiAnrReplacement(
       bootService,
       args,
       sourceImage,
@@ -1210,14 +1212,22 @@ async function rebootAndroidAfterSystemUiAnr(
       replacementBoot,
       sourceImage,
     );
+    replacementAdopted = true;
     keepReadinessReservation = true;
     return { boot: replacementBoot, preservedSessionId, releaseReadinessReservation };
   } catch (error) {
+    // A replacement that booted but was never adopted by the pool (handoff
+    // rejected, or rolled back) leaks its emulator process: the outer handler
+    // only tracks the original boot. Cancel it here where its handle is in scope.
+    if (!replacementAdopted) {
+      cancelUnownedColdBoot(replacementBoot);
+    }
     await cleanUpFailedSystemUiAnrRecovery(
       devicePool,
       shutdownReservation,
       shutdownWasConfirmed,
       boot.device.deviceId,
+      signal,
     );
     throw error;
   } finally {
@@ -1312,6 +1322,7 @@ async function cleanUpFailedSystemUiAnrRecovery(
   shutdownReservation: Awaited<ReturnType<DevicePool["reserveDeviceForShutdown"]>>,
   shutdownWasConfirmed: boolean,
   deviceId: string,
+  signal: AbortSignal | undefined,
 ): Promise<void> {
   if (!shutdownReservation) {
     return;
@@ -1320,7 +1331,13 @@ async function cleanUpFailedSystemUiAnrRecovery(
     await devicePool?.retireDeviceAfterSystemUiAnrRecoveryFailure(shutdownReservation.device);
     return;
   }
-  devicePool?.clearIntentionalShutdown(deviceId);
+  // Caller cancellation may have already stopped the emulator while shutdown
+  // confirmation was still in flight. Retain the intentional-shutdown marker so
+  // the deferred process-exit is not treated as unexpected loss, mirroring the
+  // regular kill path's guard.
+  if (shouldClearIntentionalShutdownAfterFailure("android", signal)) {
+    devicePool?.clearIntentionalShutdown(deviceId);
+  }
 }
 
 type SystemUiAnrRecoveryResult = Awaited<ReturnType<typeof rebootAndroidAfterSystemUiAnr>>;
@@ -1338,7 +1355,16 @@ async function ensureRunnerReadyWithSystemUiAnrRecovery(
       throw error;
     }
     const recovery = await rebootAfterSystemUiAnr(boot);
-    await ensureRunnerReady(recovery.boot);
+    try {
+      await ensureRunnerReady(recovery.boot);
+    } catch (readinessError) {
+      // rebootAfterSystemUiAnr retained the readiness reservation for the
+      // replacement, but it only reaches the caller's ordered cleanup once this
+      // returns. Release it here so a failed second readiness check does not
+      // strand the recovered AVD out of general allocation forever.
+      await recovery.releaseReadinessReservation?.();
+      throw readinessError;
+    }
     return { ...recovery, recovered: true };
   }
 }

--- a/src/utils/RunnerReadinessService.ts
+++ b/src/utils/RunnerReadinessService.ts
@@ -411,6 +411,7 @@ export class RunnerReadinessService {
       this.remainingSystemUiAnrRecoveryBudget(recoveryDeadlineMs),
     );
     if (timeoutMs <= 0) {
+      this.throwIfCallerCancelled(context);
       if (!required) {
         return null;
       }
@@ -431,16 +432,17 @@ export class RunnerReadinessService {
           timeoutMs,
         ),
       );
-      // The production client resolves timeouts and transport failures to
-      // `null`. A required read must treat that as an unconfirmed dialog so the
-      // caller reboots, rather than as an ANR that has cleared.
-      if (hierarchy === null && required) {
+      // The production client can fall back to a cached tree when both its
+      // fresh-data wait and synchronous request fail. A required read must not
+      // treat that stale tree as confirmation that the dialog cleared.
+      const isUnavailable = this.isSystemUiAnrHierarchyUnavailable(hierarchy, minTimestamp);
+      if (isUnavailable && required) {
         throw this.systemUiAnrRecoveryRequired(
           context,
           "could not confirm dialog recovery: hierarchy unavailable",
         );
       }
-      return hierarchy;
+      return isUnavailable ? null : hierarchy;
     } catch (error) {
       if (error instanceof SystemUiAnrRecoveryRequiredError) {
         throw error;
@@ -448,9 +450,7 @@ export class RunnerReadinessService {
       // Genuine cancellation or device loss aborts the request signal. Treating
       // that as "no dialog" would let startDevice bind a session after the
       // caller has already given up, so propagate it on every probe.
-      if (context.signal?.aborted) {
-        throw error;
-      }
+      this.throwIfCallerCancelled(context, error);
       if (!required) {
         return null;
       }
@@ -459,6 +459,16 @@ export class RunnerReadinessService {
         `could not confirm dialog recovery: ${normalizeDiagnostic(error)}`,
       );
     }
+  }
+
+  private isSystemUiAnrHierarchyUnavailable(
+    hierarchy: ViewHierarchyResult | null,
+    minTimestamp: number,
+  ): boolean {
+    if (hierarchy === null || hierarchy.fresh === false) {
+      return true;
+    }
+    return hierarchy.updatedAt !== undefined && hierarchy.updatedAt < minTimestamp;
   }
 
   private async selectSystemUiAnrWait(
@@ -484,6 +494,7 @@ export class RunnerReadinessService {
         throw new Error(tap.error ?? "unknown tap failure");
       }
     } catch (error) {
+      this.throwIfCallerCancelled(context, error);
       throw this.systemUiAnrRecoveryRequired(
         context,
         `could not select Wait: ${normalizeDiagnostic(error)}`,
@@ -529,6 +540,12 @@ export class RunnerReadinessService {
 
   private remainingSystemUiAnrRecoveryBudget(recoveryDeadlineMs: number): number {
     return Math.max(0, recoveryDeadlineMs - this.dependencies.timer.now());
+  }
+
+  private throwIfCallerCancelled(context: ReadinessAttemptContext, fallback?: unknown): void {
+    if (context.signal?.aborted) {
+      throw context.signal.reason ?? fallback ?? new Error("System UI ANR recovery cancelled");
+    }
   }
 
   private systemUiAnrRecoveryRequired(
@@ -751,6 +768,7 @@ export class RunnerReadinessService {
       if (controller.signal.aborted) {
         await this.awaitAbortSettlement(operationPromise);
       }
+      this.throwIfCallerCancelled(context, error);
       return this.fail(context, phase, attempts, normalizeDiagnostic(error));
     } finally {
       if (timeoutHandle) {

--- a/src/utils/RunnerReadinessService.ts
+++ b/src/utils/RunnerReadinessService.ts
@@ -414,10 +414,13 @@ export class RunnerReadinessService {
       if (!required) {
         return null;
       }
-      throw this.systemUiAnrRecoveryRequired(context, "dialog persisted after selecting Wait");
+      throw this.systemUiAnrRecoveryRequired(
+        context,
+        "recovery budget expired before the dialog state could be confirmed",
+      );
     }
     try {
-      return await this.runPhase(context, "runner-health", 1, async (signal) =>
+      const hierarchy = await this.runPhase(context, "runner-health", 1, async (signal) =>
         await client.getAccessibilityHierarchy(
           undefined,
           undefined,
@@ -428,7 +431,26 @@ export class RunnerReadinessService {
           timeoutMs,
         ),
       );
+      // The production client resolves timeouts and transport failures to
+      // `null`. A required read must treat that as an unconfirmed dialog so the
+      // caller reboots, rather than as an ANR that has cleared.
+      if (hierarchy === null && required) {
+        throw this.systemUiAnrRecoveryRequired(
+          context,
+          "could not confirm dialog recovery: hierarchy unavailable",
+        );
+      }
+      return hierarchy;
     } catch (error) {
+      if (error instanceof SystemUiAnrRecoveryRequiredError) {
+        throw error;
+      }
+      // Genuine cancellation or device loss aborts the request signal. Treating
+      // that as "no dialog" would let startDevice bind a session after the
+      // caller has already given up, so propagate it on every probe.
+      if (context.signal?.aborted) {
+        throw error;
+      }
       if (!required) {
         return null;
       }

--- a/src/utils/RunnerReadinessService.ts
+++ b/src/utils/RunnerReadinessService.ts
@@ -10,11 +10,20 @@ import { defaultTimer, type Timer } from "./SystemTimer";
 import type { PerformanceTracker } from "./PerformanceTracker";
 import type { ProxySetupResult } from "./interfaces/ProxyManager";
 import { runWithAbortSignal } from "./AbortContext";
+import {
+  centerOfBounds,
+  findSystemUiAnrDialog,
+  type SystemUiAnrDialog,
+} from "./androidSystemUiAnr";
+import type { ViewHierarchyResult } from "../models/ViewHierarchyResult";
 
 const READINESS_RETRY_DELAY_MS = 250;
 const READINESS_PROBE_TIMEOUT_MS = 2_000;
 const MAX_DIAGNOSTIC_LENGTH = 4_000;
 const ABORT_SETTLEMENT_GRACE_MS = 1_000;
+const SYSTEM_UI_ANR_RECOVERY_POLL_MS = 1_000;
+const SYSTEM_UI_ANR_RECOVERY_HEALTHY_POLLS = 2;
+const SYSTEM_UI_ANR_RECOVERY_TIMEOUT_MS = 5_000;
 
 type RunnerReadinessPhase =
   | "package-compatibility"
@@ -23,6 +32,8 @@ type RunnerReadinessPhase =
   | "runner-health";
 
 export class RunnerReadinessError extends ActionableError {}
+
+export class SystemUiAnrRecoveryRequiredError extends RunnerReadinessError {}
 
 export interface AndroidCompatibilityResult {
   status:
@@ -79,6 +90,26 @@ export interface ReadinessClient {
   isConnected(): boolean;
   waitForConnection(maxAttempts?: number, delayMs?: number): Promise<boolean>;
   verifyServiceReady(maxAttempts?: number, delayMs?: number, timeoutMs?: number): Promise<boolean>;
+  getAccessibilityHierarchy?(
+    queryOptions?: undefined,
+    perf?: undefined,
+    skipWaitForFresh?: boolean,
+    minTimestamp?: number,
+    disableAllFiltering?: boolean,
+    signal?: AbortSignal,
+    timeoutMs?: number,
+  ): Promise<ViewHierarchyResult | null>;
+  requestTapCoordinates?(
+    x: number,
+    y: number,
+    duration?: number,
+    timeoutMs?: number,
+  ): Promise<{ success: boolean; error?: string }>;
+}
+
+interface SystemUiAnrReadinessClient {
+  getAccessibilityHierarchy: NonNullable<ReadinessClient["getAccessibilityHierarchy"]>;
+  requestTapCoordinates: NonNullable<ReadinessClient["requestTapCoordinates"]>;
 }
 
 export interface RunnerReadinessDependencies {
@@ -269,6 +300,7 @@ export class RunnerReadinessService {
       Promise.all([manager.isInstalled(signal), manager.isEnabled(signal)]),
     );
     if (await this.isResponsiveFastPath(context, client, installed && enabled)) {
+      await this.recoverSystemUiAnrIfPresent(context, client);
       return;
     }
 
@@ -277,6 +309,7 @@ export class RunnerReadinessService {
     }
     await this.setupAndroidRunner(context, manager);
     await this.waitForResponsiveClient(context, client);
+    await this.recoverSystemUiAnrIfPresent(context, client);
   }
 
   private async ensureAndroidReadyWithoutDownloads(
@@ -307,12 +340,187 @@ export class RunnerReadinessService {
       );
     }
     if (await this.isResponsiveFastPath(context, client, enabled)) {
+      await this.recoverSystemUiAnrIfPresent(context, client);
       return;
     }
     if (!enabled) {
       await this.runPhase(context, "runner-setup", 1, () => manager.enable());
     }
     await this.waitForResponsiveClient(context, client);
+    await this.recoverSystemUiAnrIfPresent(context, client);
+  }
+
+  private async recoverSystemUiAnrIfPresent(
+    context: ReadinessAttemptContext,
+    client: ReadinessClient,
+  ): Promise<void> {
+    const anrClient = this.systemUiAnrClient(context, client);
+    if (!anrClient) {
+      return;
+    }
+
+    const recoveryDeadlineMs = Math.min(
+      context.healthDeadlineMs ?? context.totalDeadlineMs,
+      this.dependencies.timer.now() + SYSTEM_UI_ANR_RECOVERY_TIMEOUT_MS,
+    );
+    const initialHierarchy = await this.readSystemUiAnrHierarchy(
+      context,
+      anrClient,
+      recoveryDeadlineMs,
+    );
+    const dialog = findSystemUiAnrDialog(initialHierarchy ?? { hierarchy: {} });
+    if (!dialog) {
+      return;
+    }
+
+    await this.selectSystemUiAnrWait(context, anrClient, dialog.waitBounds, recoveryDeadlineMs);
+    await this.waitForSystemUiAnrRecovery(
+      context,
+      anrClient,
+      recoveryDeadlineMs,
+      initialHierarchy?.updatedAt,
+    );
+  }
+
+  private systemUiAnrClient(
+    context: ReadinessAttemptContext,
+    client: ReadinessClient,
+  ): SystemUiAnrReadinessClient | undefined {
+    if (
+      context.device.platform !== "android" ||
+      !client.getAccessibilityHierarchy ||
+      !client.requestTapCoordinates
+    ) {
+      return undefined;
+    }
+    return {
+      getAccessibilityHierarchy: (...args) => client.getAccessibilityHierarchy!(...args),
+      requestTapCoordinates: (...args) => client.requestTapCoordinates!(...args),
+    };
+  }
+
+  private async readSystemUiAnrHierarchy(
+    context: ReadinessAttemptContext,
+    client: SystemUiAnrReadinessClient,
+    recoveryDeadlineMs: number,
+    minTimestamp = 0,
+    required = false,
+  ): Promise<ViewHierarchyResult | null> {
+    const timeoutMs = Math.min(
+      this.probeTimeout(context),
+      this.remainingSystemUiAnrRecoveryBudget(recoveryDeadlineMs),
+    );
+    if (timeoutMs <= 0) {
+      if (!required) {
+        return null;
+      }
+      throw this.systemUiAnrRecoveryRequired(context, "dialog persisted after selecting Wait");
+    }
+    try {
+      return await this.runPhase(context, "runner-health", 1, async (signal) =>
+        await client.getAccessibilityHierarchy(
+          undefined,
+          undefined,
+          true,
+          minTimestamp,
+          true,
+          signal,
+          timeoutMs,
+        ),
+      );
+    } catch (error) {
+      if (!required) {
+        return null;
+      }
+      throw this.systemUiAnrRecoveryRequired(
+        context,
+        `could not confirm dialog recovery: ${normalizeDiagnostic(error)}`,
+      );
+    }
+  }
+
+  private async selectSystemUiAnrWait(
+    context: ReadinessAttemptContext,
+    client: SystemUiAnrReadinessClient,
+    bounds: SystemUiAnrDialog["waitBounds"],
+    recoveryDeadlineMs: number,
+  ): Promise<void> {
+    const { x, y } = centerOfBounds(bounds);
+    try {
+      const tap = await this.runPhase(context, "runner-health", 1, async () =>
+        await client.requestTapCoordinates(
+          x,
+          y,
+          10,
+          Math.min(
+            this.probeTimeout(context),
+            this.remainingSystemUiAnrRecoveryBudget(recoveryDeadlineMs),
+          ),
+        ),
+      );
+      if (!tap.success) {
+        throw new Error(tap.error ?? "unknown tap failure");
+      }
+    } catch (error) {
+      throw this.systemUiAnrRecoveryRequired(
+        context,
+        `could not select Wait: ${normalizeDiagnostic(error)}`,
+      );
+    }
+  }
+
+  private async waitForSystemUiAnrRecovery(
+    context: ReadinessAttemptContext,
+    client: SystemUiAnrReadinessClient,
+    recoveryDeadlineMs: number,
+    initialUpdatedAt: number | undefined,
+  ): Promise<void> {
+    let healthyPolls = 0;
+    let freshAfter = (initialUpdatedAt ?? 0) + 1;
+    while (this.remainingSystemUiAnrRecoveryBudget(recoveryDeadlineMs) > 0) {
+      await this.dependencies.timer.sleep(
+        Math.min(
+          SYSTEM_UI_ANR_RECOVERY_POLL_MS,
+          this.remainingSystemUiAnrRecoveryBudget(recoveryDeadlineMs),
+        ),
+      );
+      const hierarchy = await this.readSystemUiAnrHierarchy(
+        context,
+        client,
+        recoveryDeadlineMs,
+        freshAfter,
+        true,
+      );
+      freshAfter = Math.max(freshAfter, (hierarchy?.updatedAt ?? 0) + 1);
+      if (findSystemUiAnrDialog(hierarchy ?? { hierarchy: {} })) {
+        healthyPolls = 0;
+        continue;
+      }
+      healthyPolls++;
+      if (healthyPolls >= SYSTEM_UI_ANR_RECOVERY_HEALTHY_POLLS) {
+        return;
+      }
+    }
+
+    throw this.systemUiAnrRecoveryRequired(context, "dialog persisted after selecting Wait");
+  }
+
+  private remainingSystemUiAnrRecoveryBudget(recoveryDeadlineMs: number): number {
+    return Math.max(0, recoveryDeadlineMs - this.dependencies.timer.now());
+  }
+
+  private systemUiAnrRecoveryRequired(
+    context: ReadinessAttemptContext,
+    detail: string,
+  ): SystemUiAnrRecoveryRequiredError {
+    return new SystemUiAnrRecoveryRequiredError(this.systemUiAnrDiagnostic(context, detail));
+  }
+
+  private systemUiAnrDiagnostic(context: ReadinessAttemptContext, detail: string): string {
+    return (
+      `System UI ANR recovery required: platform=android requested=[${context.requestedIdentity}] ` +
+      `resolved=[${context.device.name} (${context.device.deviceId})]: ${detail}`
+    );
   }
 
   private assertAndroidCompatibility(
@@ -450,6 +658,7 @@ export class RunnerReadinessService {
     let attempts = 0;
     let connected = client.isConnected();
     let phase: RunnerReadinessPhase = connected ? "runner-health" : "runner-connect";
+    let lastSystemUiProbeMs = Number.NEGATIVE_INFINITY;
     while (this.remainingForPhase(context, "runner-health") > 0) {
       attempts++;
       connected = client.isConnected();
@@ -467,6 +676,13 @@ export class RunnerReadinessService {
         if (ready) {
           return;
         }
+      }
+      if (
+        context.device.platform === "android" &&
+        this.dependencies.timer.now() - lastSystemUiProbeMs >= SYSTEM_UI_ANR_RECOVERY_POLL_MS
+      ) {
+        lastSystemUiProbeMs = this.dependencies.timer.now();
+        await this.recoverSystemUiAnrIfPresent(context, client);
       }
 
       const remaining = this.remainingForPhase(context, "runner-health");

--- a/src/utils/androidSystemUiAnr.ts
+++ b/src/utils/androidSystemUiAnr.ts
@@ -1,0 +1,77 @@
+import type { ElementBounds, ViewHierarchyNode, ViewHierarchyResult } from "../models";
+import { DefaultElementParser } from "../features/utility/ElementParser";
+
+const SYSTEM_UI_PACKAGE = "com.android.systemui";
+const SYSTEM_UI_ANR_TITLE = "System UI isn't responding";
+const WAIT_ACTION = "Wait";
+const CLOSE_APP_ACTION = "Close app";
+
+export interface SystemUiAnrDialog {
+  waitBounds: ElementBounds;
+}
+
+/**
+ * Detects the Android framework System UI ANR dialog in the topmost window.
+ * A matching title alone is insufficient because an app can render the same
+ * text; require System UI ownership or both framework action labels.
+ */
+export function findSystemUiAnrDialog(
+  viewHierarchy: ViewHierarchyResult,
+  parser: Pick<
+    DefaultElementParser,
+    | "extractNodeProperties"
+    | "extractWindowRootGroups"
+    | "extractRootNodes"
+    | "parseBounds"
+    | "traverseNode"
+  > = new DefaultElementParser(),
+): SystemUiAnrDialog | undefined {
+  const topmostWindow =
+    parser.extractWindowRootGroups(viewHierarchy, "topmost-first")[0] ??
+    parser.extractRootNodes(viewHierarchy);
+  if (topmostWindow.length === 0) {
+    return undefined;
+  }
+
+  let systemUi = topmostWindowPackageIsSystemUi(viewHierarchy);
+  let titleFound = false;
+  let closeAppFound = false;
+  let waitBounds: ElementBounds | undefined;
+
+  for (const root of topmostWindow) {
+    parser.traverseNode(root, (node: ViewHierarchyNode) => {
+      const properties = parser.extractNodeProperties(node);
+      const text = String(properties.text ?? properties["content-desc"] ?? "");
+      const packageName = String(properties.package ?? properties["package-name"] ?? "");
+      systemUi ||= packageName === SYSTEM_UI_PACKAGE;
+      titleFound ||= text === SYSTEM_UI_ANR_TITLE;
+      closeAppFound ||= text === CLOSE_APP_ACTION;
+      if (text === WAIT_ACTION) {
+        waitBounds ??= parser.parseBounds(properties.bounds ?? node.bounds) ?? undefined;
+      }
+    });
+  }
+
+  if (!titleFound || !waitBounds || (!systemUi && !closeAppFound)) {
+    return undefined;
+  }
+  return { waitBounds };
+}
+
+function topmostWindowPackageIsSystemUi(viewHierarchy: ViewHierarchyResult): boolean {
+  const windows = viewHierarchy.windows;
+  if (!windows || windows.length === 0) {
+    return false;
+  }
+  const topmost = windows.reduce((current, candidate) =>
+    (candidate.windowLayer ?? 0) > (current.windowLayer ?? 0) ? candidate : current,
+  );
+  return topmost.packageName === SYSTEM_UI_PACKAGE;
+}
+
+export function centerOfBounds(bounds: ElementBounds): { x: number; y: number } {
+  return {
+    x: Math.floor((bounds.left + bounds.right) / 2),
+    y: Math.floor((bounds.top + bounds.bottom) / 2),
+  };
+}

--- a/src/utils/androidSystemUiAnr.ts
+++ b/src/utils/androidSystemUiAnr.ts
@@ -6,8 +6,36 @@ const SYSTEM_UI_ANR_TITLE = "System UI isn't responding";
 const WAIT_ACTION = "Wait";
 const CLOSE_APP_ACTION = "Close app";
 
+// The ANR dialog title and action labels are localized, so exact English text
+// never matches on non-English devices. The framework AlertDialog resource IDs
+// are stable across locales: `alertTitle` names the title, and AOSP's
+// AppNotRespondingDialog wires BUTTON_NEGATIVE ("Wait") and BUTTON_POSITIVE
+// ("Close app"), which the AlertController renders as `button2`/`button1`.
+const ALERT_TITLE_RESOURCE_ID = "android:id/alertTitle";
+const WAIT_BUTTON_RESOURCE_ID = "android:id/button2";
+const CLOSE_APP_BUTTON_RESOURCE_ID = "android:id/button1";
+
 export interface SystemUiAnrDialog {
   waitBounds: ElementBounds;
+}
+
+type AnrDialogParser = Pick<
+  DefaultElementParser,
+  | "extractNodeProperties"
+  | "extractWindowRootGroups"
+  | "extractRootNodes"
+  | "parseBounds"
+  | "traverseNode"
+>;
+
+interface SystemUiAnrSignals {
+  systemUi: boolean;
+  titleFound: boolean;
+  closeAppFound: boolean;
+  alertTitleFound: boolean;
+  closeAppResourceFound: boolean;
+  waitBounds?: ElementBounds;
+  waitBoundsByResourceId?: ElementBounds;
 }
 
 /**
@@ -17,14 +45,7 @@ export interface SystemUiAnrDialog {
  */
 export function findSystemUiAnrDialog(
   viewHierarchy: ViewHierarchyResult,
-  parser: Pick<
-    DefaultElementParser,
-    | "extractNodeProperties"
-    | "extractWindowRootGroups"
-    | "extractRootNodes"
-    | "parseBounds"
-    | "traverseNode"
-  > = new DefaultElementParser(),
+  parser: AnrDialogParser = new DefaultElementParser(),
 ): SystemUiAnrDialog | undefined {
   const topmostWindow =
     parser.extractWindowRootGroups(viewHierarchy, "topmost-first")[0] ??
@@ -33,29 +54,85 @@ export function findSystemUiAnrDialog(
     return undefined;
   }
 
-  let systemUi = topmostWindowPackageIsSystemUi(viewHierarchy);
-  let titleFound = false;
-  let closeAppFound = false;
-  let waitBounds: ElementBounds | undefined;
-
+  const signals: SystemUiAnrSignals = {
+    systemUi: topmostWindowPackageIsSystemUi(viewHierarchy),
+    titleFound: false,
+    closeAppFound: false,
+    alertTitleFound: false,
+    closeAppResourceFound: false,
+  };
   for (const root of topmostWindow) {
-    parser.traverseNode(root, (node: ViewHierarchyNode) => {
-      const properties = parser.extractNodeProperties(node);
-      const text = String(properties.text ?? properties["content-desc"] ?? "");
-      const packageName = String(properties.package ?? properties["package-name"] ?? "");
-      systemUi ||= packageName === SYSTEM_UI_PACKAGE;
-      titleFound ||= text === SYSTEM_UI_ANR_TITLE;
-      closeAppFound ||= text === CLOSE_APP_ACTION;
-      if (text === WAIT_ACTION) {
-        waitBounds ??= parser.parseBounds(properties.bounds ?? node.bounds) ?? undefined;
-      }
-    });
+    parser.traverseNode(root, (node: ViewHierarchyNode) =>
+      inspectSystemUiAnrNode(node, parser, signals),
+    );
   }
 
-  if (!titleFound || !waitBounds || (!systemUi && !closeAppFound)) {
-    return undefined;
+  // English match: exact localized-in-English strings, ownership-or-Close-app.
+  const englishWaitBounds = matchesEnglishSystemUiAnr(signals) ? signals.waitBounds : undefined;
+  if (englishWaitBounds) {
+    return { waitBounds: englishWaitBounds };
   }
-  return { waitBounds };
+  // Localized fallback: a System UI-owned framework AlertDialog with the ANR
+  // button layout (alert title plus both Wait/Close-app buttons). Gating on
+  // System UI ownership keeps this from matching unrelated app dialogs.
+  const localizedWaitBounds = matchesLocalizedSystemUiAnr(signals)
+    ? signals.waitBoundsByResourceId
+    : undefined;
+  if (localizedWaitBounds) {
+    return { waitBounds: localizedWaitBounds };
+  }
+  return undefined;
+}
+
+function matchesEnglishSystemUiAnr(signals: SystemUiAnrSignals): boolean {
+  return (
+    signals.titleFound &&
+    signals.waitBounds !== undefined &&
+    (signals.systemUi || signals.closeAppFound)
+  );
+}
+
+function matchesLocalizedSystemUiAnr(signals: SystemUiAnrSignals): boolean {
+  return (
+    signals.systemUi &&
+    signals.alertTitleFound &&
+    signals.closeAppResourceFound &&
+    signals.waitBoundsByResourceId !== undefined
+  );
+}
+
+function inspectSystemUiAnrNode(
+  node: ViewHierarchyNode,
+  parser: AnrDialogParser,
+  signals: SystemUiAnrSignals,
+): void {
+  const properties = parser.extractNodeProperties(node);
+  const text = coalesceString(properties.text, properties["content-desc"]);
+  const packageName = coalesceString(properties.package, properties["package-name"]);
+  const resourceId = coalesceString(properties["resource-id"], properties.resourceId);
+  signals.systemUi ||= packageName === SYSTEM_UI_PACKAGE;
+  signals.titleFound ||= text === SYSTEM_UI_ANR_TITLE;
+  signals.closeAppFound ||= text === CLOSE_APP_ACTION;
+  signals.alertTitleFound ||= resourceId === ALERT_TITLE_RESOURCE_ID;
+  signals.closeAppResourceFound ||= resourceId === CLOSE_APP_BUTTON_RESOURCE_ID;
+  if (text === WAIT_ACTION) {
+    signals.waitBounds ??= boundsOfNode(parser, properties, node);
+  }
+  if (resourceId === WAIT_BUTTON_RESOURCE_ID) {
+    signals.waitBoundsByResourceId ??= boundsOfNode(parser, properties, node);
+  }
+}
+
+function coalesceString(primary: unknown, fallback: unknown): string {
+  return String(primary ?? fallback ?? "");
+}
+
+function boundsOfNode(
+  parser: AnrDialogParser,
+  properties: { bounds?: unknown },
+  node: ViewHierarchyNode,
+): ElementBounds | undefined {
+  return parser.parseBounds(properties.bounds ?? node.bounds) ?? undefined;
 }
 
 function topmostWindowPackageIsSystemUi(viewHierarchy: ViewHierarchyResult): boolean {

--- a/src/utils/androidSystemUiAnr.ts
+++ b/src/utils/androidSystemUiAnr.ts
@@ -4,7 +4,6 @@ import { DefaultElementParser } from "../features/utility/ElementParser";
 const SYSTEM_UI_PACKAGE = "com.android.systemui";
 const SYSTEM_UI_ANR_TITLE = "System UI isn't responding";
 const WAIT_ACTION = "Wait";
-const CLOSE_APP_ACTION = "Close app";
 
 // The ANR dialog title and action labels are localized, so exact English text
 // never matches on non-English devices. The framework AlertDialog resource IDs
@@ -14,6 +13,7 @@ const CLOSE_APP_ACTION = "Close app";
 const ALERT_TITLE_RESOURCE_ID = "android:id/alertTitle";
 const WAIT_BUTTON_RESOURCE_ID = "android:id/button2";
 const CLOSE_APP_BUTTON_RESOURCE_ID = "android:id/button1";
+const SYSTEM_WINDOW_TYPE = 3;
 
 export interface SystemUiAnrDialog {
   waitBounds: ElementBounds;
@@ -30,8 +30,8 @@ type AnrDialogParser = Pick<
 
 interface SystemUiAnrSignals {
   systemUi: boolean;
+  systemWindow: boolean;
   titleFound: boolean;
-  closeAppFound: boolean;
   alertTitleFound: boolean;
   closeAppResourceFound: boolean;
   waitBounds?: ElementBounds;
@@ -41,7 +41,7 @@ interface SystemUiAnrSignals {
 /**
  * Detects the Android framework System UI ANR dialog in the topmost window.
  * A matching title alone is insufficient because an app can render the same
- * text; require System UI ownership or both framework action labels.
+ * text; require System UI ownership.
  */
 export function findSystemUiAnrDialog(
   viewHierarchy: ViewHierarchyResult,
@@ -55,9 +55,9 @@ export function findSystemUiAnrDialog(
   }
 
   const signals: SystemUiAnrSignals = {
-    systemUi: topmostWindowPackageIsSystemUi(viewHierarchy),
+    systemUi: hierarchyPackageIsSystemUi(viewHierarchy) || topmostWindowPackageIsSystemUi(viewHierarchy),
+    systemWindow: topmostWindowIsSystemWindow(viewHierarchy),
     titleFound: false,
-    closeAppFound: false,
     alertTitleFound: false,
     closeAppResourceFound: false,
   };
@@ -67,14 +67,14 @@ export function findSystemUiAnrDialog(
     );
   }
 
-  // English match: exact localized-in-English strings, ownership-or-Close-app.
+  // English match: exact localized-in-English strings plus System UI ownership.
   const englishWaitBounds = matchesEnglishSystemUiAnr(signals) ? signals.waitBounds : undefined;
   if (englishWaitBounds) {
     return { waitBounds: englishWaitBounds };
   }
-  // Localized fallback: a System UI-owned framework AlertDialog with the ANR
-  // button layout (alert title plus both Wait/Close-app buttons). Gating on
-  // System UI ownership keeps this from matching unrelated app dialogs.
+  // Localized fallback: CtrlProxy exposes AccessibilityWindowInfo types, where
+  // Android framework dialogs are TYPE_SYSTEM (3). Requiring a system window
+  // prevents an app-owned AlertDialog from being mistaken for a localized ANR.
   const localizedWaitBounds = matchesLocalizedSystemUiAnr(signals)
     ? signals.waitBoundsByResourceId
     : undefined;
@@ -88,13 +88,14 @@ function matchesEnglishSystemUiAnr(signals: SystemUiAnrSignals): boolean {
   return (
     signals.titleFound &&
     signals.waitBounds !== undefined &&
-    (signals.systemUi || signals.closeAppFound)
+    signals.systemUi
   );
 }
 
 function matchesLocalizedSystemUiAnr(signals: SystemUiAnrSignals): boolean {
   return (
     signals.systemUi &&
+    signals.systemWindow &&
     signals.alertTitleFound &&
     signals.closeAppResourceFound &&
     signals.waitBoundsByResourceId !== undefined
@@ -108,11 +109,13 @@ function inspectSystemUiAnrNode(
 ): void {
   const properties = parser.extractNodeProperties(node);
   const text = coalesceString(properties.text, properties["content-desc"]);
-  const packageName = coalesceString(properties.package, properties["package-name"]);
+  const packageName = coalesceString(
+    properties.packageName,
+    coalesceString(properties.package, properties["package-name"]),
+  );
   const resourceId = coalesceString(properties["resource-id"], properties.resourceId);
   signals.systemUi ||= packageName === SYSTEM_UI_PACKAGE;
   signals.titleFound ||= text === SYSTEM_UI_ANR_TITLE;
-  signals.closeAppFound ||= text === CLOSE_APP_ACTION;
   signals.alertTitleFound ||= resourceId === ALERT_TITLE_RESOURCE_ID;
   signals.closeAppResourceFound ||= resourceId === CLOSE_APP_BUTTON_RESOURCE_ID;
   if (text === WAIT_ACTION) {
@@ -136,14 +139,27 @@ function boundsOfNode(
 }
 
 function topmostWindowPackageIsSystemUi(viewHierarchy: ViewHierarchyResult): boolean {
+  return topmostWindow(viewHierarchy)?.packageName === SYSTEM_UI_PACKAGE;
+}
+
+function hierarchyPackageIsSystemUi(viewHierarchy: ViewHierarchyResult): boolean {
+  return viewHierarchy.packageName === SYSTEM_UI_PACKAGE;
+}
+
+function topmostWindowIsSystemWindow(viewHierarchy: ViewHierarchyResult): boolean {
+  return topmostWindow(viewHierarchy)?.type === SYSTEM_WINDOW_TYPE;
+}
+
+function topmostWindow(
+  viewHierarchy: ViewHierarchyResult,
+): NonNullable<ViewHierarchyResult["windows"]>[number] | undefined {
   const windows = viewHierarchy.windows;
   if (!windows || windows.length === 0) {
-    return false;
+    return undefined;
   }
-  const topmost = windows.reduce((current, candidate) =>
+  return windows.reduce((current, candidate) =>
     (candidate.windowLayer ?? 0) > (current.windowLayer ?? 0) ? candidate : current,
   );
-  return topmost.packageName === SYSTEM_UI_PACKAGE;
 }
 
 export function centerOfBounds(bounds: ElementBounds): { x: number; y: number } {

--- a/test/daemon/devicePool.test.ts
+++ b/test/daemon/devicePool.test.ts
@@ -287,9 +287,15 @@ describe("DevicePool", () => {
   }
 
   class DeferredDeviceSessionPersistence implements DeviceSessionPersistence {
-    private readonly writeStarted = Promise.withResolvers<void>();
-    private readonly writeFinished = Promise.withResolvers<void>();
+    private writeStarted = Promise.withResolvers<void>();
+    private writeFinished = Promise.withResolvers<void>();
     private deferWrite = true;
+
+    deferNextUpsert(): void {
+      this.writeStarted = Promise.withResolvers<void>();
+      this.writeFinished = Promise.withResolvers<void>();
+      this.deferWrite = true;
+    }
 
     async waitForUpsert(): Promise<void> {
       await this.writeStarted.promise;
@@ -1518,6 +1524,239 @@ describe("DevicePool", () => {
         sessionId: "session-usb",
       });
     });
+
+    test("does not hide same-model physical Android devices behind an AVD reservation", async () => {
+      const firstPhone = createBootedDevice("R5CT123456", "android", "Pixel 8");
+      const secondPhone = createBootedDevice("R5CT654321", "android", "Pixel 8");
+      await initializeLiveDevices([firstPhone, secondPhone]);
+      const releaseReservation = await devicePool.reserveDeviceForReadiness(
+        firstPhone.deviceId,
+        firstPhone,
+        "Pixel 8",
+        "Pixel 8",
+      );
+
+      try {
+        await expect(
+          devicePool.assignDeviceToSession("second-phone-session", "android"),
+        ).resolves.toBe(secondPhone.deviceId);
+      } finally {
+        await releaseReservation();
+      }
+    });
+
+    test("reserves a verified AVD name when the running emulator lacks AVD metadata", async () => {
+      const original = createBootedDevice(
+        "emulator-5554",
+        "android",
+        "Unknown (emulator-5554)",
+      );
+      const replacement = createBootedDevice("emulator-5556", "android", "Pixel 8");
+      const sourceImage: DeviceInfo = {
+        name: "Pixel 8",
+        platform: "android",
+        isRunning: false,
+        source: "local",
+      };
+      await initializeLiveDevices([original, replacement]);
+      const releaseReservation = await devicePool.reserveDeviceForReadiness(
+        original.deviceId,
+        original,
+        sourceImage.name,
+        sourceImage.name,
+      );
+
+      try {
+        expect(devicePool.getIdleDevices().map((device) => device.id)).not.toContain(
+          replacement.deviceId,
+        );
+      } finally {
+        await releaseReservation();
+      }
+    });
+
+    test("rejects direct binding to an AVD reserved for recovery readiness", async () => {
+      const original = createBootedDevice(
+        "emulator-5554",
+        "android",
+        "Unknown (emulator-5554)",
+      );
+      const replacement = createBootedDevice("emulator-5556", "android", "Pixel 8");
+      const sourceImage: DeviceInfo = {
+        name: "Pixel 8",
+        platform: "android",
+        isRunning: false,
+        source: "local",
+      };
+      await initializeLiveDevices([original, replacement]);
+      const releaseReservation = await devicePool.reserveDeviceForReadiness(
+        original.deviceId,
+        original,
+        sourceImage.name,
+        sourceImage.name,
+      );
+
+      try {
+        await expect(
+          devicePool.bindOrReuseDeviceSession(
+            "competing-session",
+            replacement.deviceId,
+            "android",
+            sourceImage,
+          ),
+        ).rejects.toThrow("not available");
+        expect(sessionManager.getSession("competing-session")).toBeNull();
+      } finally {
+        await releaseReservation();
+      }
+    });
+
+    test("allows the readiness reservation owner to bind its recovered AVD", async () => {
+      const original = createBootedDevice(
+        "emulator-5554",
+        "android",
+        "Unknown (emulator-5554)",
+      );
+      const replacement = createBootedDevice("emulator-5556", "android", "Pixel 8");
+      const sourceImage: DeviceInfo = {
+        name: "Pixel 8",
+        platform: "android",
+        isRunning: false,
+        source: "local",
+      };
+      await initializeLiveDevices([original, replacement]);
+      const reservation = await devicePool.reserveDeviceForReadiness(
+        original.deviceId,
+        original,
+        sourceImage.name,
+        sourceImage.name,
+      );
+
+      try {
+        await expect(
+          devicePool.bindOrReuseDeviceSession(
+            "recovery-session",
+            replacement.deviceId,
+            "android",
+            sourceImage,
+            undefined,
+            undefined,
+            false,
+            new Set([reservation.owner]),
+          ),
+        ).resolves.toBe("recovery-session");
+        expect(sessionManager.getSession("recovery-session")?.assignedDevice).toBe(
+          replacement.deviceId,
+        );
+      } finally {
+        await reservation();
+      }
+    });
+
+    test("keeps a same-serial recovery replacement reserved for its readiness owner", async () => {
+      const original = createBootedDevice("emulator-5554", "android", "Pixel 8");
+      const sourceImage: DeviceInfo = {
+        name: "Pixel 8",
+        platform: "android",
+        isRunning: false,
+        source: "local",
+      };
+      fakeDeviceManager.bootedDevices = [original];
+      await devicePool.addDevice(original, sourceImage);
+      const reservation = await devicePool.reserveDeviceForReadiness(
+        original.deviceId,
+        original,
+        sourceImage.name,
+      );
+      const originalIncarnation = devicePool.getDevice(original.deviceId)?.incarnation;
+
+      await devicePool.removeDevice(original.deviceId);
+      const replacement = { ...original, transportId: "2" };
+      fakeDeviceManager.bootedDevices = [replacement];
+      await devicePool.addDevice(replacement, sourceImage);
+
+      try {
+        expect(devicePool.getDevice(replacement.deviceId)?.incarnation).not.toBe(originalIncarnation);
+        await expect(
+          devicePool.bindOrReuseDeviceSession(
+            "competing-session",
+            replacement.deviceId,
+            "android",
+            sourceImage,
+          ),
+        ).rejects.toThrow("not available");
+        await expect(
+          devicePool.bindOrReuseDeviceSession(
+            "recovery-session",
+            replacement.deviceId,
+            "android",
+            sourceImage,
+            undefined,
+            undefined,
+            false,
+            new Set([reservation.owner]),
+          ),
+        ).resolves.toBe("recovery-session");
+        expect(sessionManager.getSession("competing-session")).toBeNull();
+        expect(sessionManager.getSession("recovery-session")?.assignedDevice).toBe(
+          replacement.deviceId,
+        );
+      } finally {
+        await reservation();
+      }
+    });
+
+    test("allows concurrent readiness owners to reuse their exact same AVD", async () => {
+      const device = createBootedDevice("emulator-5554", "android", "Pixel 8");
+      const sourceImage: DeviceInfo = {
+        name: "Pixel 8",
+        platform: "android",
+        isRunning: false,
+        source: "local",
+      };
+      fakeDeviceManager.bootedDevices = [device];
+      await devicePool.addDevice(device, sourceImage);
+      const firstReservation = await devicePool.reserveDeviceForReadiness(
+        device.deviceId,
+        device,
+        sourceImage.name,
+      );
+      const secondReservation = await devicePool.reserveDeviceForReadiness(
+        device.deviceId,
+        device,
+        sourceImage.name,
+      );
+
+      try {
+        await expect(
+          devicePool.bindOrReuseDeviceSession(
+            "first-session",
+            device.deviceId,
+            "android",
+            undefined,
+            undefined,
+            device,
+            false,
+            new Set([firstReservation.owner]),
+          ),
+        ).resolves.toBe("first-session");
+        await expect(
+          devicePool.bindOrReuseDeviceSession(
+            "second-session",
+            device.deviceId,
+            "android",
+            undefined,
+            undefined,
+            device,
+            false,
+            new Set([secondReservation.owner]),
+          ),
+        ).resolves.toBe("first-session");
+      } finally {
+        await firstReservation();
+        await secondReservation();
+      }
+    });
   });
 
   describe("device-ready notifications", () => {
@@ -1856,13 +2095,13 @@ describe("DevicePool", () => {
           ...device,
           deviceId: "emulator-5556",
         };
-        const preservedSessionId = await devicePool.replaceDeviceForSystemUiAnrRecovery(
+        const handoff = await devicePool.replaceDeviceForSystemUiAnrRecovery(
           shutdownReservation.device,
           replacement,
           sourceImage,
         );
 
-        expect(preservedSessionId).toBe("owner-session");
+        expect(handoff.preservedSessionId).toBe("owner-session");
         expect(devicePool.getDevice(device.deviceId)).toBeNull();
         expect(devicePool.getDevice(replacement.deviceId)).toMatchObject({
           sessionId: "owner-session",
@@ -1932,6 +2171,210 @@ describe("DevicePool", () => {
       }
     });
 
+    test("resets device-scoped session state when recovery reuses the serial", async () => {
+      const device = createBootedDevice("emulator-5554", "android", "Pixel 8");
+      const sourceImage: DeviceInfo = {
+        name: "Pixel 8",
+        platform: "android",
+        isRunning: false,
+        source: "local",
+      };
+      const unboundDevices: string[] = [];
+      fakeDeviceManager.bootedDevices = [device];
+      await devicePool.initializeWithDevices([device]);
+      await devicePool.bindOrReuseDeviceSession(
+        "owner-session",
+        device.deviceId,
+        "android",
+        sourceImage,
+      );
+      sessionManager.setLastHierarchy("owner-session", { hierarchy: {} });
+      sessionManager.setKeepScreenAwake("owner-session", { applied: true });
+      sessionManager.onSessionDeviceUnbound((_sessionId, deviceId) => unboundDevices.push(deviceId));
+      const shutdownReservation = await devicePool.reserveDeviceForShutdown(device.deviceId);
+      if (!shutdownReservation) {
+        throw new Error("expected shutdown reservation");
+      }
+
+      try {
+        fakeDeviceManager.bootedDevices = [];
+        await devicePool.removeDisconnectedDevice(device.deviceId, false);
+        await devicePool.replaceDeviceForSystemUiAnrRecovery(
+          shutdownReservation.device,
+          device,
+          sourceImage,
+        );
+
+        expect(sessionManager.getSession("owner-session")).toMatchObject({
+          assignedDevice: device.deviceId,
+          cacheData: {},
+        });
+        expect(unboundDevices).toEqual([device.deviceId]);
+      } finally {
+        await shutdownReservation.release();
+      }
+    });
+
+    test("adopts a matching replacement that refresh already added before handoff", async () => {
+      const device = createBootedDevice("emulator-5554", "android", "Pixel 8");
+      const replacement = createBootedDevice("emulator-5556", "android", "Pixel 8");
+      const sourceImage: DeviceInfo = {
+        name: "Pixel 8",
+        platform: "android",
+        isRunning: false,
+        source: "local",
+      };
+      fakeDeviceManager.bootedDevices = [device, replacement];
+      await devicePool.initializeWithDevices([device]);
+      await devicePool.bindOrReuseDeviceSession(
+        "owner-session",
+        device.deviceId,
+        "android",
+        sourceImage,
+      );
+      const captured = devicePool.getDevice(device.deviceId);
+      if (!captured) {
+        throw new Error("expected recovery device to be pooled");
+      }
+      const shutdownReservation = await devicePool.reserveDeviceForShutdown(device.deviceId);
+      if (!shutdownReservation) {
+        throw new Error("expected shutdown reservation");
+      }
+
+      try {
+        // Discovery can add the booted replacement before the recovery handoff
+        // observes it. The handoff must adopt this instance rather than deleting
+        // the original first and then rejecting the already-pooled replacement.
+        await devicePool.addDevice(replacement);
+        await devicePool.replaceDeviceForSystemUiAnrRecovery(
+          shutdownReservation.device,
+          replacement,
+          sourceImage,
+        );
+
+        expect(devicePool.getDevice(device.deviceId)).toBeNull();
+        expect(devicePool.getDevice(replacement.deviceId)).toMatchObject({
+          sessionId: "owner-session",
+          status: "busy",
+          avdName: sourceImage.name,
+        });
+        expect(sessionManager.getSession("owner-session")?.assignedDevice).toBe(
+          replacement.deviceId,
+        );
+      } finally {
+        await shutdownReservation.release();
+      }
+    });
+
+    test("does not adopt a matching replacement that another session already owns", async () => {
+      const device = createBootedDevice("emulator-5554", "android", "Pixel 8");
+      const replacement = createBootedDevice("emulator-5556", "android", "Pixel 8");
+      const sourceImage: DeviceInfo = {
+        name: "Pixel 8",
+        platform: "android",
+        isRunning: false,
+        source: "local",
+      };
+      fakeDeviceManager.bootedDevices = [device, replacement];
+      await devicePool.initializeWithDevices([device, replacement]);
+      await devicePool.bindOrReuseDeviceSession(
+        "owner-session",
+        device.deviceId,
+        "android",
+        sourceImage,
+      );
+      await devicePool.bindOrReuseDeviceSession(
+        "competing-session",
+        replacement.deviceId,
+        "android",
+        sourceImage,
+      );
+      const shutdownReservation = await devicePool.reserveDeviceForShutdown(device.deviceId);
+      if (!shutdownReservation) {
+        throw new Error("expected shutdown reservation");
+      }
+
+      try {
+        await expect(
+          devicePool.replaceDeviceForSystemUiAnrRecovery(
+            shutdownReservation.device,
+            replacement,
+            sourceImage,
+          ),
+        ).rejects.toThrow("already assigned to a session");
+        expect(sessionManager.getSession("owner-session")?.assignedDevice).toBe(device.deviceId);
+        expect(sessionManager.getSession("competing-session")?.assignedDevice).toBe(
+          replacement.deviceId,
+        );
+      } finally {
+        await shutdownReservation.release();
+      }
+    });
+
+    test("does not retire a same-serial successor while cleaning up a recovery replacement", async () => {
+      const device = createBootedDevice("emulator-5554", "android", "Pixel 8");
+      const replacement = createBootedDevice("emulator-5556", "android", "Pixel 8");
+      const sourceImage: DeviceInfo = {
+        name: "Pixel 8",
+        platform: "android",
+        isRunning: false,
+        source: "local",
+      };
+      fakeDeviceManager.bootedDevices = [device];
+      await devicePool.initializeWithDevices([device]);
+      await devicePool.bindOrReuseDeviceSession(
+        "owner-session",
+        device.deviceId,
+        "android",
+        sourceImage,
+      );
+      const shutdownReservation = await devicePool.reserveDeviceForShutdown(device.deviceId);
+      if (!shutdownReservation) {
+        throw new Error("expected shutdown reservation");
+      }
+
+      try {
+        fakeDeviceManager.bootedDevices = [];
+        await devicePool.removeDisconnectedDevice(device.deviceId, false);
+        const handoff = await devicePool.replaceDeviceForSystemUiAnrRecovery(
+          shutdownReservation.device,
+          replacement,
+          sourceImage,
+        );
+
+        await sessionManager.releaseSession("owner-session", "test replacement exit");
+        await devicePool.releaseDevice(replacement.deviceId, "owner-session");
+        await devicePool.removeDevice(
+          replacement.deviceId,
+          false,
+          handoff.replacementDevice,
+        );
+        fakeDeviceManager.bootedDevices = [replacement];
+        await devicePool.addDevice(replacement, sourceImage);
+        await devicePool.bindOrReuseDeviceSession(
+          "successor-session",
+          replacement.deviceId,
+          "android",
+          sourceImage,
+        );
+
+        await expect(handoff.validatePreservedSession()).rejects.toThrow(
+          "was released while System UI recovery was becoming ready",
+        );
+        expect(
+          await devicePool.retireDeviceAfterSystemUiAnrRecoveryFailure(
+            handoff.replacementDevice,
+          ),
+        ).toBe(false);
+        expect(devicePool.getDevice(replacement.deviceId)).toMatchObject({
+          sessionId: "successor-session",
+          status: "busy",
+        });
+      } finally {
+        await shutdownReservation.release();
+      }
+    });
+
     test("rolls back the replacement when the recovery session rebind fails", async () => {
       sessionManager.stopCleanupTimer();
       const sessionPersistence = new FakeDeviceSessionPersistence();
@@ -1985,6 +2428,127 @@ describe("DevicePool", () => {
         expect(devicePool.getDevice(replacement.deviceId)).toBeNull();
         expect(devicePool.getIdleDevices()).toEqual([]);
         expect(sessionManager.getSession("owner-session")).toBeNull();
+      } finally {
+        await shutdownReservation.release();
+      }
+    });
+
+    test("rolls back when the replacement exits during recovery session persistence", async () => {
+      const manager = new FakeDeviceManagerWithStartedProcess();
+      const persistence = new DeferredDeviceSessionPersistence();
+      sessionManager.stopCleanupTimer();
+      sessionManager = new SessionManager(fakeTimer, persistence);
+      devicePool = new DevicePool(
+        sessionManager,
+        "test-daemon-session-id",
+        fakeTimer,
+        fakeAppsRepo,
+        manager,
+        new DefaultRetryExecutor(fakeTimer),
+      );
+      const device = createBootedDevice("emulator-5554", "android", "Pixel 8");
+      const sourceImage: DeviceInfo = {
+        name: "Pixel 8",
+        platform: "android",
+        isRunning: false,
+        source: "local",
+      };
+      manager.bootedDevices = [device];
+      await devicePool.initializeWithDevices([device]);
+
+      const binding = devicePool.bindOrReuseDeviceSession(
+        "owner-session",
+        device.deviceId,
+        "android",
+        sourceImage,
+      );
+      await persistence.waitForUpsert();
+      persistence.finishUpsert();
+      await binding;
+      persistence.deferNextUpsert();
+
+      const shutdownReservation = await devicePool.reserveDeviceForShutdown(device.deviceId);
+      if (!shutdownReservation) {
+        throw new Error("expected shutdown reservation");
+      }
+
+      try {
+        manager.bootedDevices = [];
+        await devicePool.removeDisconnectedDevice(device.deviceId, false);
+        const replacement = { ...device, deviceId: "emulator-5556" };
+        const handoff = devicePool.replaceDeviceForSystemUiAnrRecovery(
+          shutdownReservation.device,
+          replacement,
+          sourceImage,
+          manager.childProcess,
+        );
+        await persistence.waitForUpsert();
+        manager.childProcess.emit("exit", 0, null);
+        await new Promise((resolve) => setImmediate(resolve));
+        persistence.finishUpsert();
+
+        await expect(handoff).rejects.toThrow(
+          "disconnected while its recovery session was being rebound",
+        );
+        expect(devicePool.getDevice(replacement.deviceId)).toBeNull();
+        expect(sessionManager.getSession("owner-session")).toBeNull();
+        expect(sessionManager.getSessionForDevice(replacement.deviceId)).toBeNull();
+      } finally {
+        await shutdownReservation.release();
+      }
+    });
+
+    test("rolls back when the replacement exited before process tracking", async () => {
+      const manager = new FakeDeviceManagerWithStartedProcess();
+      sessionManager.stopCleanupTimer();
+      sessionManager = new SessionManager(fakeTimer, new FakeDeviceSessionPersistence());
+      devicePool = new DevicePool(
+        sessionManager,
+        "test-daemon-session-id",
+        fakeTimer,
+        fakeAppsRepo,
+        manager,
+        new DefaultRetryExecutor(fakeTimer),
+      );
+      const device = createBootedDevice("emulator-5554", "android", "Pixel 8");
+      const sourceImage: DeviceInfo = {
+        name: "Pixel 8",
+        platform: "android",
+        isRunning: false,
+        source: "local",
+      };
+      manager.bootedDevices = [device];
+      await devicePool.initializeWithDevices([device]);
+      await devicePool.bindOrReuseDeviceSession(
+        "owner-session",
+        device.deviceId,
+        "android",
+        sourceImage,
+      );
+      const shutdownReservation = await devicePool.reserveDeviceForShutdown(device.deviceId);
+      if (!shutdownReservation) {
+        throw new Error("expected shutdown reservation");
+      }
+
+      try {
+        manager.bootedDevices = [];
+        await devicePool.removeDisconnectedDevice(device.deviceId, false);
+        const replacement = { ...device, deviceId: "emulator-5556" };
+        manager.childProcess.exitCode = 1;
+        manager.childProcess.signalCode = null;
+
+        await expect(
+          devicePool.replaceDeviceForSystemUiAnrRecovery(
+            shutdownReservation.device,
+            replacement,
+            sourceImage,
+            manager.childProcess,
+          ),
+        ).rejects.toThrow("exited before process tracking completed");
+
+        expect(devicePool.getDevice(replacement.deviceId)).toBeNull();
+        expect(sessionManager.getSession("owner-session")).toBeNull();
+        expect(sessionManager.getSessionForDevice(device.deviceId)).toBeNull();
       } finally {
         await shutdownReservation.release();
       }

--- a/test/daemon/devicePool.test.ts
+++ b/test/daemon/devicePool.test.ts
@@ -1879,16 +1879,72 @@ describe("DevicePool", () => {
       }
     });
 
-    test("defers monitor loss recovery while System UI recovery owns the emulator", async () => {
-      const originalRecoveryOnLoss = process.env.AUTOMOBILE_ANDROID_REBOOT_ON_DEATH;
-      process.env.AUTOMOBILE_ANDROID_REBOOT_ON_DEATH = "1";
-      const manager = new FakeDeviceManager();
-      const pool = new DevicePool(
+    test("carries the autolock owner onto the System UI recovery replacement", async () => {
+      const device = createBootedDevice("emulator-5554", "android", "Pixel 8");
+      const sourceImage: DeviceInfo = {
+        name: "Pixel 8",
+        platform: "android",
+        isRunning: false,
+        source: "local",
+      };
+      fakeDeviceManager.bootedDevices = [device];
+      await devicePool.initializeWithDevices([device]);
+      await devicePool.bindOrReuseDeviceSession(
+        "owner-session",
+        device.deviceId,
+        "android",
+        sourceImage,
+      );
+      const captured = devicePool.getDevice(device.deviceId);
+      if (!captured) {
+        throw new Error("expected recovery device to be pooled");
+      }
+      // Simulate an autolocked device so recovery must preserve exclusivity; an
+      // unset autolockSessionId on the replacement would let any session drive it.
+      captured.autolockSessionId = "owner-session";
+      const readinessRelease = await devicePool.reserveDeviceForReadiness(
+        device.deviceId,
+        device,
+        sourceImage.name,
+      );
+      const shutdownReservation = await devicePool.reserveDeviceForShutdown(device.deviceId);
+      if (!shutdownReservation) {
+        throw new Error("expected shutdown reservation");
+      }
+
+      try {
+        fakeDeviceManager.bootedDevices = [];
+        await devicePool.removeDisconnectedDevice(device.deviceId, false);
+        const replacement = { ...device, deviceId: "emulator-5556" };
+        await devicePool.replaceDeviceForSystemUiAnrRecovery(
+          shutdownReservation.device,
+          replacement,
+          sourceImage,
+        );
+
+        expect(devicePool.getDevice(replacement.deviceId)).toMatchObject({
+          sessionId: "owner-session",
+          autolockSessionId: "owner-session",
+        });
+      } finally {
+        await shutdownReservation.release();
+        await readinessRelease();
+      }
+    });
+
+    test("rolls back the replacement when the recovery session rebind fails", async () => {
+      sessionManager.stopCleanupTimer();
+      const sessionPersistence = new FakeDeviceSessionPersistence();
+      // The first upsert binds the owner session; the rebind onto the
+      // replacement is the second, and it rejects here.
+      sessionPersistence.createFailureOnAttempt = 2;
+      sessionManager = new SessionManager(fakeTimer, sessionPersistence);
+      devicePool = new DevicePool(
         sessionManager,
-        "daemon-session",
+        "test-daemon-session-id",
         fakeTimer,
         fakeAppsRepo,
-        manager,
+        fakeDeviceManager,
         new DefaultRetryExecutor(fakeTimer),
       );
       const device = createBootedDevice("emulator-5554", "android", "Pixel 8");
@@ -1898,37 +1954,99 @@ describe("DevicePool", () => {
         isRunning: false,
         source: "local",
       };
-      manager.bootedDevices = [device];
-      await pool.initializeWithDevices([device]);
-      await pool.bindOrReuseDeviceSession(
+      fakeDeviceManager.bootedDevices = [device];
+      await devicePool.initializeWithDevices([device]);
+      await devicePool.bindOrReuseDeviceSession(
         "owner-session",
         device.deviceId,
         "android",
         sourceImage,
       );
-      const captured = pool.getDevice(device.deviceId);
-      if (!captured) {
-        throw new Error("expected recovery device to be pooled");
-      }
-      const reservation = await pool.reserveDeviceForShutdown(captured.id);
-      if (!reservation) {
+      const shutdownReservation = await devicePool.reserveDeviceForShutdown(device.deviceId);
+      if (!shutdownReservation) {
         throw new Error("expected shutdown reservation");
       }
 
       try {
-        manager.bootedDevices = [];
-        await pool.removeDisconnectedDevice(device.deviceId, false);
+        fakeDeviceManager.bootedDevices = [];
+        await devicePool.removeDisconnectedDevice(device.deviceId, false);
+        const replacement = { ...device, deviceId: "emulator-5556" };
 
-        expect(pool.getDevice(device.deviceId)).toBe(captured);
-        expect(sessionManager.getSession("owner-session")?.assignedDevice).toBe(device.deviceId);
-        expect(manager.startedDevices).toEqual([]);
+        await expect(
+          devicePool.replaceDeviceForSystemUiAnrRecovery(
+            shutdownReservation.device,
+            replacement,
+            sourceImage,
+          ),
+        ).rejects.toThrow("persist create failed");
+
+        // The failed rebind must not strand an idle, assignable replacement that
+        // still maps to the stopped serial.
+        expect(devicePool.getDevice(replacement.deviceId)).toBeNull();
+        expect(devicePool.getIdleDevices()).toEqual([]);
+        expect(sessionManager.getSession("owner-session")).toBeNull();
       } finally {
-        await reservation.release();
+        await shutdownReservation.release();
+      }
+    });
+
+    test("defers monitor loss recovery while System UI recovery owns the emulator", async () => {
+      const originalRecoveryOnLoss = process.env.AUTOMOBILE_ANDROID_REBOOT_ON_DEATH;
+      const restoreRecoveryOnLoss = () => {
         if (originalRecoveryOnLoss === undefined) {
           delete process.env.AUTOMOBILE_ANDROID_REBOOT_ON_DEATH;
         } else {
           process.env.AUTOMOBILE_ANDROID_REBOOT_ON_DEATH = originalRecoveryOnLoss;
         }
+      };
+
+      try {
+        process.env.AUTOMOBILE_ANDROID_REBOOT_ON_DEATH = "1";
+        const manager = new FakeDeviceManager();
+        const pool = new DevicePool(
+          sessionManager,
+          "daemon-session",
+          fakeTimer,
+          fakeAppsRepo,
+          manager,
+          new DefaultRetryExecutor(fakeTimer),
+        );
+        const device = createBootedDevice("emulator-5554", "android", "Pixel 8");
+        const sourceImage: DeviceInfo = {
+          name: "Pixel 8",
+          platform: "android",
+          isRunning: false,
+          source: "local",
+        };
+        manager.bootedDevices = [device];
+        await pool.initializeWithDevices([device]);
+        await pool.bindOrReuseDeviceSession(
+          "owner-session",
+          device.deviceId,
+          "android",
+          sourceImage,
+        );
+        const captured = pool.getDevice(device.deviceId);
+        if (!captured) {
+          throw new Error("expected recovery device to be pooled");
+        }
+        const reservation = await pool.reserveDeviceForShutdown(captured.id);
+        if (!reservation) {
+          throw new Error("expected shutdown reservation");
+        }
+
+        try {
+          manager.bootedDevices = [];
+          await pool.removeDisconnectedDevice(device.deviceId, false);
+
+          expect(pool.getDevice(device.deviceId)).toBe(captured);
+          expect(sessionManager.getSession("owner-session")?.assignedDevice).toBe(device.deviceId);
+          expect(manager.startedDevices).toEqual([]);
+        } finally {
+          await reservation.release();
+        }
+      } finally {
+        restoreRecoveryOnLoss();
       }
     });
 

--- a/test/daemon/devicePool.test.ts
+++ b/test/daemon/devicePool.test.ts
@@ -1816,6 +1816,122 @@ describe("DevicePool", () => {
       expect(devicePool.getDevice(captured.id)).toBeNull();
     });
 
+    test("keeps the existing session through a System UI recovery handoff", async () => {
+      const device = createBootedDevice("emulator-5554", "android", "Pixel 8");
+      const sourceImage: DeviceInfo = {
+        name: "Pixel 8",
+        platform: "android",
+        isRunning: false,
+        source: "local",
+      };
+      fakeDeviceManager.bootedDevices = [device];
+      await devicePool.initializeWithDevices([device]);
+      await devicePool.bindOrReuseDeviceSession(
+        "owner-session",
+        device.deviceId,
+        "android",
+        sourceImage,
+      );
+      const captured = devicePool.getDevice(device.deviceId);
+      if (!captured) {
+        throw new Error("expected recovery device to be pooled");
+      }
+      const readinessRelease = await devicePool.reserveDeviceForReadiness(
+        device.deviceId,
+        device,
+        sourceImage.name,
+      );
+      const shutdownReservation = await devicePool.reserveDeviceForShutdown(device.deviceId);
+      if (!shutdownReservation) {
+        throw new Error("expected shutdown reservation");
+      }
+
+      try {
+        fakeDeviceManager.bootedDevices = [];
+        await devicePool.removeDisconnectedDevice(device.deviceId, false);
+        expect(devicePool.getDevice(device.deviceId)).toBe(captured);
+        expect(sessionManager.getSession("owner-session")?.assignedDevice).toBe(device.deviceId);
+
+        const replacement = {
+          ...device,
+          deviceId: "emulator-5556",
+        };
+        const preservedSessionId = await devicePool.replaceDeviceForSystemUiAnrRecovery(
+          shutdownReservation.device,
+          replacement,
+          sourceImage,
+        );
+
+        expect(preservedSessionId).toBe("owner-session");
+        expect(devicePool.getDevice(device.deviceId)).toBeNull();
+        expect(devicePool.getDevice(replacement.deviceId)).toMatchObject({
+          sessionId: "owner-session",
+          status: "busy",
+          avdName: sourceImage.name,
+        });
+        expect(sessionManager.getSession("owner-session")?.assignedDevice).toBe(
+          replacement.deviceId,
+        );
+        expect(devicePool.getIdleDevices()).toEqual([]);
+      } finally {
+        await shutdownReservation.release();
+        await readinessRelease();
+      }
+    });
+
+    test("defers monitor loss recovery while System UI recovery owns the emulator", async () => {
+      const originalRecoveryOnLoss = process.env.AUTOMOBILE_ANDROID_REBOOT_ON_DEATH;
+      process.env.AUTOMOBILE_ANDROID_REBOOT_ON_DEATH = "1";
+      const manager = new FakeDeviceManager();
+      const pool = new DevicePool(
+        sessionManager,
+        "daemon-session",
+        fakeTimer,
+        fakeAppsRepo,
+        manager,
+        new DefaultRetryExecutor(fakeTimer),
+      );
+      const device = createBootedDevice("emulator-5554", "android", "Pixel 8");
+      const sourceImage: DeviceInfo = {
+        name: "Pixel 8",
+        platform: "android",
+        isRunning: false,
+        source: "local",
+      };
+      manager.bootedDevices = [device];
+      await pool.initializeWithDevices([device]);
+      await pool.bindOrReuseDeviceSession(
+        "owner-session",
+        device.deviceId,
+        "android",
+        sourceImage,
+      );
+      const captured = pool.getDevice(device.deviceId);
+      if (!captured) {
+        throw new Error("expected recovery device to be pooled");
+      }
+      const reservation = await pool.reserveDeviceForShutdown(captured.id);
+      if (!reservation) {
+        throw new Error("expected shutdown reservation");
+      }
+
+      try {
+        manager.bootedDevices = [];
+        await pool.removeDisconnectedDevice(device.deviceId, false);
+
+        expect(pool.getDevice(device.deviceId)).toBe(captured);
+        expect(sessionManager.getSession("owner-session")?.assignedDevice).toBe(device.deviceId);
+        expect(manager.startedDevices).toEqual([]);
+      } finally {
+        await reservation.release();
+        if (originalRecoveryOnLoss === undefined) {
+          delete process.env.AUTOMOBILE_ANDROID_REBOOT_ON_DEATH;
+        } else {
+          process.env.AUTOMOBILE_ANDROID_REBOOT_ON_DEATH = originalRecoveryOnLoss;
+        }
+      }
+    });
+
     test("does not hold the assignment mutex for replacement session tracking", async () => {
       const device = createBootedDevice("emulator-5554", "android", "Pixel 8");
       const appsRepository = new DeferredSessionTrackingAppsRepository();

--- a/test/daemon/sessionManager.test.ts
+++ b/test/daemon/sessionManager.test.ts
@@ -583,6 +583,37 @@ describe("SessionManager", () => {
       }
     });
 
+    test("clears device-scoped state when a new runtime reuses the serial", async () => {
+      const repository = new FakeDeviceSessionPersistence();
+      const restoredDevices: string[] = [];
+      const manager = new SessionManager(
+        fakeTimer,
+        repository,
+        undefined,
+        device => ({ restore: async () => { restoredDevices.push(device.deviceId); } }),
+      );
+      const unboundDevices: string[] = [];
+
+      try {
+        await manager.createSession("session-1", "emulator-5554", "android");
+        manager.setLastHierarchy("session-1", makeHierarchy("old"));
+        manager.setKeepScreenAwake("session-1", { applied: true });
+        manager.onSessionDeviceUnbound((_sessionId, deviceId) => unboundDevices.push(deviceId));
+
+        await expect(
+          manager.rebindSession("session-1", "emulator-5554", "android", { force: true }),
+        ).resolves.toMatchObject({
+          assignedDevice: "emulator-5554",
+          cacheData: {},
+        });
+
+        expect(restoredDevices).toEqual(["emulator-5554"]);
+        expect(unboundDevices).toEqual(["emulator-5554"]);
+      } finally {
+        manager.stopCleanupTimer();
+      }
+    });
+
     test("serializes a pending rebind with release and clears device-scoped state", async () => {
       const repository = new DeferredDeviceSessionPersistence();
       const restoredDevices: string[] = [];

--- a/test/server/deviceTools.startDevice.test.ts
+++ b/test/server/deviceTools.startDevice.test.ts
@@ -25,6 +25,7 @@ import {
   MAX_RUNNER_READINESS_TIMEOUT_MS,
   MIN_RUNNER_READINESS_TIMEOUT_MS,
 } from "../../src/utils/runnerReadinessConfig";
+import { SystemUiAnrRecoveryRequiredError } from "../../src/utils/RunnerReadinessService";
 import { DefaultRetryExecutor } from "../../src/utils/retry/RetryExecutor";
 import * as os from "os";
 
@@ -544,6 +545,186 @@ describe("startDevice handler", () => {
 
     expect(pool.getIdleDevices().map((device) => device.id)).toEqual([androidDevice.deviceId]);
     expect(pool.getDevice(androidDevice.deviceId)?.sessionId).toBeNull();
+  });
+
+  it("restarts the pooled AVD and preserves its session after a System UI ANR", async () => {
+    const timer = new FakeTimer();
+    daemonSessionManager = new SessionManager(timer, new FakeDeviceSessionPersistence());
+    const pool = new DevicePool(
+      daemonSessionManager,
+      "daemon-session",
+      timer,
+      undefined,
+      fakeDeviceUtils,
+    );
+    const recoveryImage = {
+      ...androidImage,
+      deviceId: "emulator-5556",
+    };
+    const unknownRuntimeDevice = {
+      ...androidDevice,
+      name: `Unknown (${androidDevice.deviceId})`,
+    };
+    fakeDeviceUtils.setBootedDevices("android", [unknownRuntimeDevice]);
+    await pool.initializeWithDevices([unknownRuntimeDevice]);
+    await pool.bindOrReuseDeviceSession(
+      "owner-session",
+      unknownRuntimeDevice.deviceId,
+      "android",
+      recoveryImage,
+    );
+    DaemonState.getInstance().initialize(daemonSessionManager, pool);
+    fakeDeviceUtils.setDeviceImages("android", [recoveryImage]);
+    fakeMatcher.setBootedResult(unknownRuntimeDevice);
+    fakeMatcher.setImageResult(recoveryImage);
+    const originalKillDevice = fakeDeviceUtils.killDevice.bind(fakeDeviceUtils);
+    fakeDeviceUtils.killDevice = async (device, options) => {
+      await originalKillDevice(device, options);
+      fakeDeviceUtils.setBootedDevices("android", []);
+    };
+    let readinessAttempts = 0;
+    setDeviceToolsDependencies({
+      timer,
+      ensureCtrlProxyReady: async () => {
+        readinessAttempts++;
+        if (readinessAttempts === 1) {
+          throw new SystemUiAnrRecoveryRequiredError("System UI ANR persisted after Wait");
+        }
+      },
+    });
+    registerDeviceTools();
+
+    const result = await callStartDevice({ platform: "android" });
+
+    expect(result.deviceId).toBe("emulator-5556");
+    expect(result.sessionId).toBe("owner-session");
+    expect(fakeDeviceUtils.getExecutedOperations()).toContain(
+      "killDevice:Unknown (emulator-5554)",
+    );
+    expect(fakeDeviceUtils.getExecutedOperations()).toContain(
+      "startDevice:Pixel_7_API_34:120000",
+    );
+    expect(pool.getDevice("emulator-5556")).toMatchObject({
+      sessionId: "owner-session",
+      status: "busy",
+      avdName: "Pixel_7_API_34",
+    });
+    expect(pool.getIdleDevices()).toEqual([]);
+    expect(daemonSessionManager.getSession("owner-session")?.assignedDevice).toBe(
+      "emulator-5556",
+    );
+  });
+
+  it("keeps the original session when System UI recovery cannot stop the emulator", async () => {
+    const timer = new FakeTimer();
+    daemonSessionManager = new SessionManager(timer, new FakeDeviceSessionPersistence());
+    const pool = new DevicePool(
+      daemonSessionManager,
+      "daemon-session",
+      timer,
+      undefined,
+      fakeDeviceUtils,
+    );
+    fakeDeviceUtils.setBootedDevices("android", [androidDevice]);
+    await pool.initializeWithDevices([androidDevice]);
+    await pool.bindOrReuseDeviceSession(
+      "owner-session",
+      androidDevice.deviceId,
+      "android",
+      androidImage,
+    );
+    DaemonState.getInstance().initialize(daemonSessionManager, pool);
+    fakeDeviceUtils.setDeviceImages("android", [androidImage]);
+    fakeMatcher.setBootedResult(androidDevice);
+    fakeDeviceUtils.killDevice = async () => {
+      throw new Error("emulator shutdown failed");
+    };
+    setDeviceToolsDependencies({
+      timer,
+      ensureCtrlProxyReady: async () => {
+        throw new SystemUiAnrRecoveryRequiredError("System UI ANR persisted after Wait");
+      },
+    });
+    registerDeviceTools();
+
+    await expect(callStartDevice({ platform: "android" })).rejects.toThrow(
+      /emulator shutdown failed/,
+    );
+
+    expect(pool.getDevice(androidDevice.deviceId)).toMatchObject({
+      sessionId: "owner-session",
+      status: "busy",
+    });
+    expect(daemonSessionManager.getSession("owner-session")?.assignedDevice).toBe(
+      androidDevice.deviceId,
+    );
+  });
+
+  it("releases the session when confirmed System UI recovery cannot restart the AVD", async () => {
+    const timer = new FakeTimer();
+    daemonSessionManager = new SessionManager(timer, new FakeDeviceSessionPersistence());
+    const pool = new DevicePool(
+      daemonSessionManager,
+      "daemon-session",
+      timer,
+      undefined,
+      fakeDeviceUtils,
+    );
+    fakeDeviceUtils.setBootedDevices("android", [androidDevice]);
+    await pool.initializeWithDevices([androidDevice]);
+    await pool.bindOrReuseDeviceSession(
+      "owner-session",
+      androidDevice.deviceId,
+      "android",
+      androidImage,
+    );
+    DaemonState.getInstance().initialize(daemonSessionManager, pool);
+    fakeDeviceUtils.setDeviceImages("android", [androidImage]);
+    fakeMatcher.setBootedResult(androidDevice);
+    fakeMatcher.setImageResult(androidImage);
+    const originalKillDevice = fakeDeviceUtils.killDevice.bind(fakeDeviceUtils);
+    fakeDeviceUtils.killDevice = async (device, options) => {
+      await originalKillDevice(device, options);
+      fakeDeviceUtils.setBootedDevices("android", []);
+    };
+    fakeDeviceUtils.startDevice = async () => {
+      throw new Error("AVD restart failed");
+    };
+    setDeviceToolsDependencies({
+      timer,
+      ensureCtrlProxyReady: async () => {
+        throw new SystemUiAnrRecoveryRequiredError("System UI ANR persisted after Wait");
+      },
+    });
+    registerDeviceTools();
+
+    await expect(callStartDevice({ platform: "android" })).rejects.toThrow(/AVD restart failed/);
+
+    expect(pool.getDevice(androidDevice.deviceId)).toBeNull();
+    expect(daemonSessionManager.getSession("owner-session")).toBeNull();
+  });
+
+  it("does not guess an AVD when an unknown Android runtime needs System UI recovery", async () => {
+    const unknownDevice = {
+      ...androidDevice,
+      name: "Unknown (emulator-5554)",
+    };
+    fakeDeviceUtils.setBootedDevices("android", [unknownDevice]);
+    fakeDeviceUtils.setDeviceImages("android", [androidImage]);
+    fakeMatcher.setBootedResult(unknownDevice);
+    let readinessAttempts = 0;
+    setDeviceToolsDependencies({
+      ensureCtrlProxyReady: async () => {
+        readinessAttempts++;
+        throw new SystemUiAnrRecoveryRequiredError("System UI ANR persisted after Wait");
+      },
+    });
+    registerDeviceTools();
+
+    await expect(callStartDevice({ platform: "android" })).rejects.toThrow(/AVD name is unknown/);
+
+    expect(readinessAttempts).toBe(1);
+    expect(fakeDeviceUtils.wasMethodCalled("killDevice")).toBe(false);
   });
 
   it("cold-boots without a process handle (adopted device: startDevice returns null)", async () => {

--- a/test/server/deviceTools.startDevice.test.ts
+++ b/test/server/deviceTools.startDevice.test.ts
@@ -615,6 +615,332 @@ describe("startDevice handler", () => {
     );
   });
 
+  it("binds an idle System UI recovery replacement through its own readiness reservation", async () => {
+    const timer = new FakeTimer();
+    daemonSessionManager = new SessionManager(timer, new FakeDeviceSessionPersistence());
+    const pool = new DevicePool(
+      daemonSessionManager,
+      "daemon-session",
+      timer,
+      undefined,
+      fakeDeviceUtils,
+    );
+    const recoveryImage = {
+      ...androidImage,
+      deviceId: "emulator-5556",
+    };
+    const unknownRuntimeDevice = {
+      ...androidDevice,
+      name: `Unknown (${androidDevice.deviceId})`,
+    };
+    fakeDeviceUtils.setBootedDevices("android", [unknownRuntimeDevice]);
+    await pool.initializeWithDevices([unknownRuntimeDevice]);
+    await pool.addDevice(unknownRuntimeDevice, recoveryImage);
+    DaemonState.getInstance().initialize(daemonSessionManager, pool);
+    fakeDeviceUtils.setDeviceImages("android", [recoveryImage]);
+    fakeMatcher.setBootedResult(unknownRuntimeDevice);
+    fakeMatcher.setImageResult(recoveryImage);
+    const originalKillDevice = fakeDeviceUtils.killDevice.bind(fakeDeviceUtils);
+    fakeDeviceUtils.killDevice = async (device, options) => {
+      await originalKillDevice(device, options);
+      fakeDeviceUtils.setBootedDevices("android", []);
+    };
+    let readinessAttempts = 0;
+    setDeviceToolsDependencies({
+      timer,
+      idGenerator: new CountingIdGenerator("session"),
+      ensureCtrlProxyReady: async () => {
+        readinessAttempts++;
+        if (readinessAttempts === 1) {
+          throw new SystemUiAnrRecoveryRequiredError("System UI ANR persisted after Wait");
+        }
+      },
+    });
+    registerDeviceTools();
+
+    const result = await callStartDevice({ platform: "android" });
+
+    expect(result.deviceId).toBe("emulator-5556");
+    expect(result.sessionId).toBe("session-1");
+    expect(pool.getDevice("emulator-5556")).toMatchObject({
+      sessionId: "session-1",
+      status: "busy",
+    });
+  });
+
+  it("retires an adopted replacement when its second readiness check fails", async () => {
+    const timer = new FakeTimer();
+    daemonSessionManager = new SessionManager(timer, new FakeDeviceSessionPersistence());
+    const pool = new DevicePool(
+      daemonSessionManager,
+      "daemon-session",
+      timer,
+      undefined,
+      fakeDeviceUtils,
+    );
+    const recoveryImage = {
+      ...androidImage,
+      deviceId: "emulator-5556",
+    };
+    const unknownRuntimeDevice = {
+      ...androidDevice,
+      name: `Unknown (${androidDevice.deviceId})`,
+    };
+    const replacementProcess = new FakeExitChildProcess();
+    fakeDeviceUtils.setBootedDevices("android", [unknownRuntimeDevice]);
+    await pool.initializeWithDevices([unknownRuntimeDevice]);
+    await pool.bindOrReuseDeviceSession(
+      "owner-session",
+      unknownRuntimeDevice.deviceId,
+      "android",
+      recoveryImage,
+    );
+    DaemonState.getInstance().initialize(daemonSessionManager, pool);
+    fakeDeviceUtils.setDeviceImages("android", [recoveryImage]);
+    fakeDeviceUtils.setMockChildProcess(
+      recoveryImage.name,
+      replacementProcess as unknown as ChildProcess,
+    );
+    fakeMatcher.setBootedResult(unknownRuntimeDevice);
+    fakeMatcher.setImageResult(recoveryImage);
+    const originalKillDevice = fakeDeviceUtils.killDevice.bind(fakeDeviceUtils);
+    fakeDeviceUtils.killDevice = async (device, options) => {
+      await originalKillDevice(device, options);
+      fakeDeviceUtils.setBootedDevices("android", []);
+    };
+    setDeviceToolsDependencies({
+      timer,
+      ensureCtrlProxyReady: async () => {
+        throw new SystemUiAnrRecoveryRequiredError("System UI ANR persisted after Wait");
+      },
+    });
+    registerDeviceTools();
+
+    await expect(callStartDevice({ platform: "android" })).rejects.toThrow(
+      "System UI ANR persisted after Wait",
+    );
+
+    expect(replacementProcess.killed).toBe(true);
+    expect(pool.getDevice(unknownRuntimeDevice.deviceId)).toBeNull();
+    expect(pool.getDevice(recoveryImage.deviceId!)).toBeNull();
+    expect(pool.getIdleDevices()).toEqual([]);
+    expect(daemonSessionManager.getSession("owner-session")).toBeNull();
+  });
+
+  it("retires an adopted replacement when its recovered readiness reservation fails", async () => {
+    const timer = new FakeTimer();
+    daemonSessionManager = new SessionManager(timer, new FakeDeviceSessionPersistence());
+    const pool = new DevicePool(
+      daemonSessionManager,
+      "daemon-session",
+      timer,
+      undefined,
+      fakeDeviceUtils,
+    );
+    const recoveryImage = {
+      ...androidImage,
+      deviceId: "emulator-5556",
+    };
+    const unknownRuntimeDevice = {
+      ...androidDevice,
+      name: `Unknown (${androidDevice.deviceId})`,
+    };
+    const replacementProcess = new FakeExitChildProcess();
+    fakeDeviceUtils.setBootedDevices("android", [unknownRuntimeDevice]);
+    await pool.initializeWithDevices([unknownRuntimeDevice]);
+    await pool.bindOrReuseDeviceSession(
+      "owner-session",
+      unknownRuntimeDevice.deviceId,
+      "android",
+      recoveryImage,
+    );
+    DaemonState.getInstance().initialize(daemonSessionManager, pool);
+    fakeDeviceUtils.setDeviceImages("android", [recoveryImage]);
+    fakeDeviceUtils.setMockChildProcess(
+      recoveryImage.name,
+      replacementProcess as unknown as ChildProcess,
+    );
+    fakeMatcher.setBootedResult(unknownRuntimeDevice);
+    fakeMatcher.setImageResult(recoveryImage);
+    const originalKillDevice = fakeDeviceUtils.killDevice.bind(fakeDeviceUtils);
+    fakeDeviceUtils.killDevice = async (device, options) => {
+      await originalKillDevice(device, options);
+      fakeDeviceUtils.setBootedDevices("android", []);
+    };
+    const reserveDeviceForReadiness = pool.reserveDeviceForReadiness.bind(pool);
+    let readinessReservations = 0;
+    pool.reserveDeviceForReadiness = async (...args) => {
+      readinessReservations++;
+      if (readinessReservations === 3) {
+        throw new Error("recovered reservation identity changed");
+      }
+      return await reserveDeviceForReadiness(...args);
+    };
+    let readinessAttempts = 0;
+    setDeviceToolsDependencies({
+      timer,
+      ensureCtrlProxyReady: async () => {
+        readinessAttempts++;
+        if (readinessAttempts === 1) {
+          throw new SystemUiAnrRecoveryRequiredError("System UI ANR persisted after Wait");
+        }
+      },
+    });
+    registerDeviceTools();
+
+    await expect(callStartDevice({ platform: "android" })).rejects.toThrow(
+      "recovered reservation identity changed",
+    );
+
+    expect(replacementProcess.killed).toBe(true);
+    expect(pool.getDevice(unknownRuntimeDevice.deviceId)).toBeNull();
+    expect(pool.getDevice(recoveryImage.deviceId!)).toBeNull();
+    expect(pool.getIdleDevices()).toEqual([]);
+    expect(daemonSessionManager.getSession("owner-session")).toBeNull();
+  });
+
+  it("preserves the second readiness error when recovery cleanup fails", async () => {
+    const timer = new FakeTimer();
+    daemonSessionManager = new SessionManager(timer, new FakeDeviceSessionPersistence());
+    const pool = new DevicePool(
+      daemonSessionManager,
+      "daemon-session",
+      timer,
+      undefined,
+      fakeDeviceUtils,
+      undefined,
+      undefined,
+      undefined,
+      async () => {
+        throw new Error("cleanup persistence failed");
+      },
+    );
+    const recoveryImage = {
+      ...androidImage,
+      deviceId: "emulator-5556",
+    };
+    const unknownRuntimeDevice = {
+      ...androidDevice,
+      name: `Unknown (${androidDevice.deviceId})`,
+    };
+    const replacementProcess = new FakeExitChildProcess();
+    fakeDeviceUtils.setBootedDevices("android", [unknownRuntimeDevice]);
+    await pool.initializeWithDevices([unknownRuntimeDevice]);
+    await pool.bindOrReuseDeviceSession(
+      "owner-session",
+      unknownRuntimeDevice.deviceId,
+      "android",
+      recoveryImage,
+    );
+    DaemonState.getInstance().initialize(daemonSessionManager, pool);
+    fakeDeviceUtils.setDeviceImages("android", [recoveryImage]);
+    fakeDeviceUtils.setMockChildProcess(
+      recoveryImage.name,
+      replacementProcess as unknown as ChildProcess,
+    );
+    fakeMatcher.setBootedResult(unknownRuntimeDevice);
+    fakeMatcher.setImageResult(recoveryImage);
+    const originalKillDevice = fakeDeviceUtils.killDevice.bind(fakeDeviceUtils);
+    fakeDeviceUtils.killDevice = async (device, options) => {
+      await originalKillDevice(device, options);
+      fakeDeviceUtils.setBootedDevices("android", []);
+    };
+    let readinessAttempts = 0;
+    setDeviceToolsDependencies({
+      timer,
+      ensureCtrlProxyReady: async () => {
+        readinessAttempts++;
+        if (readinessAttempts === 1) {
+          throw new SystemUiAnrRecoveryRequiredError("System UI ANR persisted after Wait");
+        }
+        throw new Error("replacement runner unavailable");
+      },
+    });
+    registerDeviceTools();
+
+    await expect(callStartDevice({ platform: "android" })).rejects.toThrow(
+      "replacement runner unavailable",
+    );
+    expect(replacementProcess.killed).toBe(true);
+    expect(pool.getDevice(recoveryImage.deviceId!)).toBeNull();
+    expect(pool.getIdleDevices()).toEqual([]);
+  });
+
+  it("fails rather than returning a System UI recovery session released during readiness", async () => {
+    const timer = new FakeTimer();
+    daemonSessionManager = new SessionManager(timer, new FakeDeviceSessionPersistence());
+    const pool = new DevicePool(
+      daemonSessionManager,
+      "daemon-session",
+      timer,
+      undefined,
+      fakeDeviceUtils,
+    );
+    const recoveryImage = {
+      ...androidImage,
+      deviceId: "emulator-5556",
+    };
+    const unknownRuntimeDevice = {
+      ...androidDevice,
+      name: `Unknown (${androidDevice.deviceId})`,
+    };
+    const replacementProcess = new FakeExitChildProcess();
+    fakeDeviceUtils.setBootedDevices("android", [unknownRuntimeDevice]);
+    await pool.initializeWithDevices([unknownRuntimeDevice]);
+    await pool.bindOrReuseDeviceSession(
+      "owner-session",
+      unknownRuntimeDevice.deviceId,
+      "android",
+      recoveryImage,
+    );
+    DaemonState.getInstance().initialize(daemonSessionManager, pool);
+    fakeDeviceUtils.setDeviceImages("android", [recoveryImage]);
+    fakeDeviceUtils.setMockChildProcess(
+      recoveryImage.name,
+      replacementProcess as unknown as ChildProcess,
+    );
+    fakeMatcher.setBootedResult(unknownRuntimeDevice);
+    fakeMatcher.setImageResult(recoveryImage);
+    const originalKillDevice = fakeDeviceUtils.killDevice.bind(fakeDeviceUtils);
+    fakeDeviceUtils.killDevice = async (device, options) => {
+      await originalKillDevice(device, options);
+      fakeDeviceUtils.setBootedDevices("android", []);
+    };
+    let beginSecondReadiness!: () => void;
+    const secondReadinessStarted = new Promise<void>((resolve) => {
+      beginSecondReadiness = resolve;
+    });
+    let finishSecondReadiness!: () => void;
+    const secondReadiness = new Promise<void>((resolve) => {
+      finishSecondReadiness = resolve;
+    });
+    let readinessAttempts = 0;
+    setDeviceToolsDependencies({
+      timer,
+      ensureCtrlProxyReady: async () => {
+        readinessAttempts++;
+        if (readinessAttempts === 1) {
+          throw new SystemUiAnrRecoveryRequiredError("System UI ANR persisted after Wait");
+        }
+        beginSecondReadiness();
+        await secondReadiness;
+      },
+    });
+    registerDeviceTools();
+
+    const start = callStartDevice({ platform: "android" });
+    await secondReadinessStarted;
+    await daemonSessionManager.releaseSession("owner-session", "test released during readiness");
+    finishSecondReadiness();
+
+    await expect(start).rejects.toThrow(
+      "was released while System UI recovery was becoming ready",
+    );
+    expect(replacementProcess.killed).toBe(true);
+    expect(pool.getDevice(recoveryImage.deviceId!)).toBeNull();
+    expect(daemonSessionManager.getSession("owner-session")).toBeNull();
+  });
+
   it("keeps the original session when System UI recovery cannot stop the emulator", async () => {
     const timer = new FakeTimer();
     daemonSessionManager = new SessionManager(timer, new FakeDeviceSessionPersistence());
@@ -702,6 +1028,58 @@ describe("startDevice handler", () => {
 
     expect(pool.getDevice(androidDevice.deviceId)).toBeNull();
     expect(daemonSessionManager.getSession("owner-session")).toBeNull();
+  });
+
+  it("preserves an AVD reboot failure when post-shutdown cleanup fails", async () => {
+    const timer = new FakeTimer();
+    daemonSessionManager = new SessionManager(timer, new FakeDeviceSessionPersistence());
+    const pool = new DevicePool(
+      daemonSessionManager,
+      "daemon-session",
+      timer,
+      undefined,
+      fakeDeviceUtils,
+      undefined,
+      undefined,
+      undefined,
+      async () => {
+        throw new Error("cleanup persistence failed");
+      },
+    );
+    fakeDeviceUtils.setBootedDevices("android", [androidDevice]);
+    await pool.initializeWithDevices([androidDevice]);
+    await pool.bindOrReuseDeviceSession(
+      "owner-session",
+      androidDevice.deviceId,
+      "android",
+      androidImage,
+    );
+    DaemonState.getInstance().initialize(daemonSessionManager, pool);
+    fakeDeviceUtils.setDeviceImages("android", [androidImage]);
+    fakeMatcher.setBootedResult(androidDevice);
+    fakeMatcher.setImageResult(androidImage);
+    const originalKillDevice = fakeDeviceUtils.killDevice.bind(fakeDeviceUtils);
+    fakeDeviceUtils.killDevice = async (device, options) => {
+      await originalKillDevice(device, options);
+      fakeDeviceUtils.setBootedDevices("android", []);
+    };
+    fakeDeviceUtils.startDevice = async () => {
+      throw new Error("AVD restart failed");
+    };
+    setDeviceToolsDependencies({
+      timer,
+      ensureCtrlProxyReady: async () => {
+        throw new SystemUiAnrRecoveryRequiredError("System UI ANR persisted after Wait");
+      },
+    });
+    registerDeviceTools();
+
+    await expect(callStartDevice({ platform: "android" })).rejects.toThrow(/AVD restart failed/);
+
+    expect(pool.getDevice(androidDevice.deviceId)).toBeNull();
+    expect(daemonSessionManager.getSession("owner-session")?.assignedDevice).toBe(
+      androidDevice.deviceId,
+    );
   });
 
   it("does not guess an AVD when an unknown Android runtime needs System UI recovery", async () => {

--- a/test/utils/RunnerReadinessService.test.ts
+++ b/test/utils/RunnerReadinessService.test.ts
@@ -2,6 +2,7 @@ import { describe, expect, test } from "bun:test";
 import type { BootedDevice } from "../../src/models";
 import {
   RunnerReadinessService,
+  SystemUiAnrRecoveryRequiredError,
   type ReadinessAndroidManager,
   type ReadinessClient,
   type ReadinessIosManager,
@@ -179,6 +180,10 @@ function createService(
   };
 }
 
+function clearedAnrHierarchy(): ViewHierarchyResult {
+  return { hierarchy: {}, windows: [] };
+}
+
 function systemUiAnrHierarchy(): ViewHierarchyResult {
   return {
     hierarchy: {},
@@ -217,7 +222,11 @@ describe("RunnerReadinessService", () => {
   test("checks for a System UI ANR while runner health is failing", async () => {
     const androidClient = new FakeReadinessClient();
     androidClient.healthResults = [false, false, true];
-    androidClient.accessibilityHierarchies = [systemUiAnrHierarchy(), null, null];
+    androidClient.accessibilityHierarchies = [
+      systemUiAnrHierarchy(),
+      clearedAnrHierarchy(),
+      clearedAnrHierarchy(),
+    ];
     const { service, androidManager } = createService({ androidClient });
 
     await service.ensureReady({
@@ -230,6 +239,25 @@ describe("RunnerReadinessService", () => {
     expect(androidManager.setupCalls).toBe(1);
     expect(androidClient.tapCoordinates).toEqual([{ x: 200, y: 230 }]);
     expect(androidClient.healthCalls).toBe(3);
+  });
+
+  test("treats unreadable confirmation hierarchies as an unrecovered ANR", async () => {
+    const androidClient = new FakeReadinessClient();
+    androidClient.healthResults = [false, false, true];
+    // The dialog is present, then both post-tap confirmation reads fail. A failed
+    // read must not be mistaken for a cleared dialog (#5430 review), so recovery
+    // is still required rather than reported as healthy.
+    androidClient.accessibilityHierarchies = [systemUiAnrHierarchy(), null, null];
+    const { service } = createService({ androidClient });
+
+    await expect(
+      service.ensureReady({
+        device: androidDevice(),
+        requestedIdentity: "platform=android name=Pixel_9_Pro",
+        totalDeadlineMs: 30_000,
+        readinessTimeoutMs: 30_000,
+      }),
+    ).rejects.toThrow(SystemUiAnrRecoveryRequiredError);
   });
 
   test("repairs a missing Android package before checking observation health", async () => {

--- a/test/utils/RunnerReadinessService.test.ts
+++ b/test/utils/RunnerReadinessService.test.ts
@@ -30,6 +30,7 @@ class FakeReadinessClient implements ReadinessClient {
   accessibilityHierarchies: Array<ViewHierarchyResult | null> = [];
   tapResult = { success: true };
   tapCoordinates: Array<{ x: number; y: number }> = [];
+  onTap?: () => Promise<void> | void;
 
   isConnected(): boolean {
     return this.connected;
@@ -53,6 +54,7 @@ class FakeReadinessClient implements ReadinessClient {
 
   async requestTapCoordinates(x: number, y: number): Promise<{ success: boolean; error?: string }> {
     this.tapCoordinates.push({ x, y });
+    await this.onTap?.();
     return this.tapResult;
   }
 }
@@ -186,17 +188,66 @@ function clearedAnrHierarchy(): ViewHierarchyResult {
 
 function systemUiAnrHierarchy(): ViewHierarchyResult {
   return {
+    packageName: "com.android.systemui",
     hierarchy: {},
     windows: [
       {
         windowLayer: 100,
-        packageName: "com.android.systemui",
         hierarchy: {
-          $: {},
           node: [
-            { $: { text: "System UI isn't responding" } },
-            { $: { text: "Close app" } },
-            { $: { text: "Wait", bounds: "[100,200][300,260]" } },
+            { text: "System UI isn't responding" },
+            { text: "Close app" },
+            { text: "Wait", bounds: "[100,200][300,260]" },
+          ],
+        },
+      },
+    ],
+  };
+}
+
+function localizedSystemUiAnrHierarchy(windowType = 3): ViewHierarchyResult {
+  return {
+    packageName: "com.android.systemui",
+    hierarchy: {},
+    windows: [
+      {
+        windowLayer: 100,
+        type: windowType,
+        hierarchy: {
+          node: [
+            {
+              text: "Systemoberflache reagiert nicht",
+              "resource-id": "android:id/alertTitle",
+            },
+            {
+              text: "App schliessen",
+              "resource-id": "android:id/button1",
+            },
+            {
+              text: "Warten",
+              "resource-id": "android:id/button2",
+              bounds: "[100,200][300,260]",
+            },
+          ],
+        },
+      },
+    ],
+  };
+}
+
+function appScreenMimickingEnglishSystemUiAnr(): ViewHierarchyResult {
+  return {
+    packageName: "com.example.app",
+    hierarchy: {},
+    windows: [
+      {
+        windowLayer: 100,
+        type: 3,
+        hierarchy: {
+          node: [
+            { text: "System UI isn't responding" },
+            { text: "Close app" },
+            { text: "Wait", bounds: "[100,200][300,260]" },
           ],
         },
       },
@@ -241,6 +292,117 @@ describe("RunnerReadinessService", () => {
     expect(androidClient.healthCalls).toBe(3);
   });
 
+  test("requires device replacement when the ANR Wait tap fails", async () => {
+    const androidClient = new FakeReadinessClient();
+    androidClient.healthResults = [false];
+    androidClient.accessibilityHierarchies = [systemUiAnrHierarchy()];
+    androidClient.tapResult = { success: false, error: "tap transport failed" };
+    const { service } = createService({ androidClient });
+
+    await expect(
+      service.ensureReady({
+        device: androidDevice(),
+        requestedIdentity: "platform=android name=Pixel_9_Pro",
+        totalDeadlineMs: 30_000,
+        readinessTimeoutMs: 30_000,
+      }),
+    ).rejects.toThrow("could not select Wait: tap transport failed");
+  });
+
+  test("requires device replacement when the ANR persists after Wait", async () => {
+    const androidClient = new FakeReadinessClient();
+    androidClient.healthResults = [false];
+    androidClient.accessibilityHierarchies = Array.from(
+      { length: 32 },
+      () => systemUiAnrHierarchy(),
+    );
+    const { service } = createService({ androidClient });
+
+    await expect(
+      service.ensureReady({
+        device: androidDevice(),
+        requestedIdentity: "platform=android name=Pixel_9_Pro",
+        totalDeadlineMs: 30_000,
+        readinessTimeoutMs: 30_000,
+      }),
+    ).rejects.toThrow(SystemUiAnrRecoveryRequiredError);
+  });
+
+  test("recognizes a localized ANR from a System UI window", async () => {
+    const androidClient = new FakeReadinessClient();
+    androidClient.healthResults = [false, false, true];
+    androidClient.accessibilityHierarchies = [
+      localizedSystemUiAnrHierarchy(),
+      clearedAnrHierarchy(),
+      clearedAnrHierarchy(),
+    ];
+    const { service } = createService({ androidClient });
+
+    await service.ensureReady({
+      device: androidDevice(),
+      requestedIdentity: "platform=android name=Pixel_9_Pro",
+      totalDeadlineMs: 30_000,
+      readinessTimeoutMs: 30_000,
+    });
+
+    expect(androidClient.tapCoordinates).toEqual([{ x: 200, y: 230 }]);
+  });
+
+  test("does not tap an app screen mimicking the English System UI ANR", async () => {
+    const androidClient = new FakeReadinessClient();
+    androidClient.healthResults = [false, true];
+    androidClient.accessibilityHierarchies = [appScreenMimickingEnglishSystemUiAnr()];
+    const { service } = createService({ androidClient });
+
+    await service.ensureReady({
+      device: androidDevice(),
+      requestedIdentity: "platform=android name=Pixel_9_Pro",
+      totalDeadlineMs: 30_000,
+      readinessTimeoutMs: 30_000,
+    });
+
+    expect(androidClient.tapCoordinates).toEqual([]);
+  });
+
+  test("does not tap a generic System UI AlertDialog as a localized ANR", async () => {
+    const androidClient = new FakeReadinessClient();
+    androidClient.healthResults = [false, true];
+    androidClient.accessibilityHierarchies = [localizedSystemUiAnrHierarchy(1)];
+    const { service } = createService({ androidClient });
+
+    await service.ensureReady({
+      device: androidDevice(),
+      requestedIdentity: "platform=android name=Pixel_9_Pro",
+      totalDeadlineMs: 30_000,
+      readinessTimeoutMs: 30_000,
+    });
+
+    expect(androidClient.tapCoordinates).toEqual([]);
+  });
+
+  test("propagates cancellation that interrupts the ANR Wait tap", async () => {
+    const androidClient = new FakeReadinessClient();
+    const abortController = new AbortController();
+    const cancellation = new Error("caller cancelled readiness");
+    androidClient.healthResults = [false];
+    androidClient.accessibilityHierarchies = [systemUiAnrHierarchy()];
+    androidClient.onTap = () => {
+      abortController.abort(cancellation);
+      throw cancellation;
+    };
+    const { service } = createService({ androidClient });
+
+    await expect(
+      service.ensureReady({
+        device: androidDevice(),
+        requestedIdentity: "platform=android name=Pixel_9_Pro",
+        totalDeadlineMs: 30_000,
+        readinessTimeoutMs: 30_000,
+        signal: abortController.signal,
+      }),
+    ).rejects.toBe(cancellation);
+  });
+
   test("treats unreadable confirmation hierarchies as an unrecovered ANR", async () => {
     const androidClient = new FakeReadinessClient();
     androidClient.healthResults = [false, false, true];
@@ -248,6 +410,47 @@ describe("RunnerReadinessService", () => {
     // read must not be mistaken for a cleared dialog (#5430 review), so recovery
     // is still required rather than reported as healthy.
     androidClient.accessibilityHierarchies = [systemUiAnrHierarchy(), null, null];
+    const { service } = createService({ androidClient });
+
+    await expect(
+      service.ensureReady({
+        device: androidDevice(),
+        requestedIdentity: "platform=android name=Pixel_9_Pro",
+        totalDeadlineMs: 30_000,
+        readinessTimeoutMs: 30_000,
+      }),
+    ).rejects.toThrow(SystemUiAnrRecoveryRequiredError);
+  });
+
+  test("does not confirm ANR recovery from stale hierarchies", async () => {
+    const androidClient = new FakeReadinessClient();
+    androidClient.healthResults = [false, false, true];
+    // CtrlProxy may return this cached tree after both its fresh-data wait and
+    // sync fallback fail. It must not count toward the two healthy polls.
+    androidClient.accessibilityHierarchies = [
+      systemUiAnrHierarchy(),
+      { ...clearedAnrHierarchy(), fresh: false },
+      { ...clearedAnrHierarchy(), fresh: false },
+    ];
+    const { service } = createService({ androidClient });
+
+    await expect(
+      service.ensureReady({
+        device: androidDevice(),
+        requestedIdentity: "platform=android name=Pixel_9_Pro",
+        totalDeadlineMs: 30_000,
+        readinessTimeoutMs: 30_000,
+      }),
+    ).rejects.toThrow(SystemUiAnrRecoveryRequiredError);
+  });
+
+  test("does not confirm ANR recovery from an older hierarchy", async () => {
+    const androidClient = new FakeReadinessClient();
+    androidClient.healthResults = [false, false, true];
+    androidClient.accessibilityHierarchies = [
+      { ...systemUiAnrHierarchy(), updatedAt: 10 },
+      { ...clearedAnrHierarchy(), fresh: true, updatedAt: 10 },
+    ];
     const { service } = createService({ androidClient });
 
     await expect(

--- a/test/utils/RunnerReadinessService.test.ts
+++ b/test/utils/RunnerReadinessService.test.ts
@@ -26,6 +26,9 @@ class FakeReadinessClient implements ReadinessClient {
   connectionResults: boolean[] = [true];
   healthCalls = 0;
   connectionCalls = 0;
+  accessibilityHierarchies: Array<ViewHierarchyResult | null> = [];
+  tapResult = { success: true };
+  tapCoordinates: Array<{ x: number; y: number }> = [];
 
   isConnected(): boolean {
     return this.connected;
@@ -41,6 +44,15 @@ class FakeReadinessClient implements ReadinessClient {
   async verifyServiceReady(): Promise<boolean> {
     this.healthCalls++;
     return this.healthResults.shift() ?? false;
+  }
+
+  async getAccessibilityHierarchy(): Promise<ViewHierarchyResult | null> {
+    return this.accessibilityHierarchies.shift() ?? null;
+  }
+
+  async requestTapCoordinates(x: number, y: number): Promise<{ success: boolean; error?: string }> {
+    this.tapCoordinates.push({ x, y });
+    return this.tapResult;
   }
 }
 
@@ -167,6 +179,26 @@ function createService(
   };
 }
 
+function systemUiAnrHierarchy(): ViewHierarchyResult {
+  return {
+    hierarchy: {},
+    windows: [
+      {
+        windowLayer: 100,
+        packageName: "com.android.systemui",
+        hierarchy: {
+          $: {},
+          node: [
+            { $: { text: "System UI isn't responding" } },
+            { $: { text: "Close app" } },
+            { $: { text: "Wait", bounds: "[100,200][300,260]" } },
+          ],
+        },
+      },
+    ],
+  };
+}
+
 describe("RunnerReadinessService", () => {
   test("keeps an already-ready Android device on the fast path", async () => {
     const { service, androidManager, androidClient } = createService();
@@ -180,6 +212,24 @@ describe("RunnerReadinessService", () => {
 
     expect(androidManager.setupCalls).toBe(0);
     expect(androidClient.healthCalls).toBe(1);
+  });
+
+  test("checks for a System UI ANR while runner health is failing", async () => {
+    const androidClient = new FakeReadinessClient();
+    androidClient.healthResults = [false, false, true];
+    androidClient.accessibilityHierarchies = [systemUiAnrHierarchy(), null, null];
+    const { service, androidManager } = createService({ androidClient });
+
+    await service.ensureReady({
+      device: androidDevice(),
+      requestedIdentity: "platform=android name=Pixel_9_Pro",
+      totalDeadlineMs: 30_000,
+      readinessTimeoutMs: 30_000,
+    });
+
+    expect(androidManager.setupCalls).toBe(1);
+    expect(androidClient.tapCoordinates).toEqual([{ x: 200, y: 230 }]);
+    expect(androidClient.healthCalls).toBe(3);
   });
 
   test("repairs a missing Android package before checking observation health", async () => {


### PR DESCRIPTION
## Summary

- Detect the Android framework System UI ANR dialog during CtrlProxy readiness and try its Wait action.
- Reboot persistent ANRs through pool shutdown and reservation ownership, then atomically rebind the existing session to the replacement.
- Preserve the source AVD identity for adopted emulators, including `Unknown (emulator-...)` runtime labels.

## Root Cause

AutoMobile treated the persistent framework dialog as a generic readiness timeout. A direct reboot could also race the pool disconnect monitor and lose the owning session, while an adopted emulator could be restarted from an unstable runtime label.

## Impact

Android device setup recovers one persistent System UI ANR without exposing a generic CtrlProxy initialize timeout, while preventing competing pool recovery and session reassignment.

## Validation

- `bun test test/server/deviceTools.startDevice.test.ts test/daemon/devicePool.test.ts test/utils/RunnerReadinessService.test.ts`
- `bun run build`
- `bun run lint`
