### PR TITLE
fix(daemon): extend cold iOS startup budget

### DIFF
--- a/.github/workflows/pull_request.yml
+++ b/.github/workflows/pull_request.yml
@@ -1067,8 +1067,7 @@ jobs:
         shell: bash
         continue-on-error: true
         env:
-          # The default 10s daemon budget is lower than cold hosted macOS
-          # startup variance. Keep this aligned with ensure-daemon-ready.sh.
+          # Pin the installer benchmark to the standard 30s daemon startup budget.
           AUTOMOBILE_DAEMON_STARTUP_TIMEOUT_MS: "30000"
           AUTOMOBILE_STARTUP_BENCHMARK: "1"
           AUTOMOBILE_STARTUP_BENCHMARK_OUTPUT: "${{ github.workspace }}/ci-logs/installer-daemon-startup.json"
@@ -1775,13 +1774,12 @@ jobs:
     # then kill+respawn) a runner still coming up, and let an `observe` request wait
     # (150s > 120s) for that cold start instead of aborting at the 30s default (#2834).
     #
-    # The daemon's own readiness budget (DAEMON_STARTUP_TIMEOUT_MS, default 10s) must
+    # The daemon's own readiness budget (DAEMON_STARTUP_TIMEOUT_MS, default 30s) must
     # cover the entire serial bring-up: Bun cold start + from-scratch migrations +
-    # `initializeDevicePoolWithTimeout(5s)` + `initializeIosServices(5s)`. On a cold
-    # macOS runner the two 5s device probes alone can exhaust 10s before Bun start and
-    # migrations are even counted, hard-failing the Swift tests' daemon start. Raise it
-    # to 60s here, consistent with the sibling budgets above (#3110). The env var name
-    # must match src/daemon/constants.ts exactly — a typo silently falls back to 10000.
+    # `initializeDevicePoolWithTimeout(5s)` + `initializeIosServices(5s)`. The default
+    # covers normal cold startup; this Xcode lane can add two serial iOS readiness probes,
+    # so keep its explicit 60s budget. The env var name must match
+    # src/daemon/constants.ts exactly — a typo silently falls back to 30000.
     env:
       AUTOMOBILE_CTRL_PROXY_HEALTH_MAX_ATTEMPTS: "240"
       AUTOMOBILE_OBSERVE_MCP_TIMEOUT_MS: "150000"

--- a/android/desktop-core/src/main/kotlin/dev/jasonpearson/automobile/desktop/core/daemon/DesktopDaemonLifecycle.kt
+++ b/android/desktop-core/src/main/kotlin/dev/jasonpearson/automobile/desktop/core/daemon/DesktopDaemonLifecycle.kt
@@ -199,14 +199,14 @@ internal object SystemDaemonCommandExecutor : DaemonCommandExecutor {
     startupTimeoutOverride: String? =
       System.getenv("AUTOMOBILE_DAEMON_STARTUP_TIMEOUT_MS")
         ?: System.getenv("AUTO_MOBILE_DAEMON_STARTUP_TIMEOUT_MS")
-  ): Long =
-    maxOf(
-      DEFAULT_COMMAND_TIMEOUT_MILLIS,
-      startupTimeoutOverride
-        ?.toLongOrNull()
-        ?.takeIf { it > 0 }
-        ?.plus(TERMINATION_TIMEOUT_SECONDS * 1_000) ?: DEFAULT_COMMAND_TIMEOUT_MILLIS,
-    )
+  ): Long {
+    val startupTimeoutMillis =
+      startupTimeoutOverride?.toLongOrNull()?.takeIf { it > 0 }
+        ?: DEFAULT_DAEMON_STARTUP_TIMEOUT_MILLIS
+    return (startupTimeoutMillis.coerceAtMost(
+      (Long.MAX_VALUE - TERMINATION_TIMEOUT_MILLIS) / DAEMON_STARTUP_LIFECYCLE_BUDGETS
+    ) * DAEMON_STARTUP_LIFECYCLE_BUDGETS) + TERMINATION_TIMEOUT_MILLIS
+  }
 
   private fun drainOutput(
     process: Process,
@@ -221,8 +221,10 @@ internal object SystemDaemonCommandExecutor : DaemonCommandExecutor {
     return output.toString()
   }
 
-  private const val DEFAULT_COMMAND_TIMEOUT_MILLIS = 60_000L
+  private const val DEFAULT_DAEMON_STARTUP_TIMEOUT_MILLIS = 30_000L
+  private const val DAEMON_STARTUP_LIFECYCLE_BUDGETS = 3L
   private const val TERMINATION_TIMEOUT_SECONDS = 5L
+  private const val TERMINATION_TIMEOUT_MILLIS = TERMINATION_TIMEOUT_SECONDS * 1_000
   private const val TIMEOUT_EXIT_CODE = -1
   private const val CANCELLED_EXIT_CODE = -2
 }

--- a/android/desktop-core/src/test/kotlin/dev/jasonpearson/automobile/desktop/core/daemon/DesktopDaemonLifecycleTest.kt
+++ b/android/desktop-core/src/test/kotlin/dev/jasonpearson/automobile/desktop/core/daemon/DesktopDaemonLifecycleTest.kt
@@ -385,9 +385,9 @@ class DesktopDaemonLifecycleTest {
   }
 
   @Test
-  fun `extends the command timeout for a configured daemon startup timeout`() {
-    assertEquals(125_000L, SystemDaemonCommandExecutor.commandTimeoutMillis("120000"))
-    assertEquals(60_000L, SystemDaemonCommandExecutor.commandTimeoutMillis("invalid"))
+  fun `reserves the full daemon startup lifecycle for commands`() {
+    assertEquals(365_000L, SystemDaemonCommandExecutor.commandTimeoutMillis("120000"))
+    assertEquals(95_000L, SystemDaemonCommandExecutor.commandTimeoutMillis("invalid"))
   }
 
   @Test

--- a/android/junit-runner/src/main/kotlin/dev/jasonpearson/automobile/junit/DaemonSocketClient.kt
+++ b/android/junit-runner/src/main/kotlin/dev/jasonpearson/automobile/junit/DaemonSocketClient.kt
@@ -360,14 +360,13 @@ internal object DaemonSocketPaths {
   }
 
   /**
-   * Bound the launcher process for the daemon's full startup lifecycle: one
-   * lock-holder wait plus up to two startup attempts.
+   * Bound the launcher process for the daemon's full startup lifecycle: one lock-holder wait plus
+   * up to two startup attempts.
    */
   fun daemonLauncherTimeoutMs(): Long {
-    return (
-      daemonStartTimeoutMs()
-        .coerceAtMost(Long.MAX_VALUE / DAEMON_STARTUP_LIFECYCLE_BUDGETS)
-      ) * DAEMON_STARTUP_LIFECYCLE_BUDGETS
+    return (daemonStartTimeoutMs()
+      .coerceAtMost(Long.MAX_VALUE / DAEMON_STARTUP_LIFECYCLE_BUDGETS)) *
+      DAEMON_STARTUP_LIFECYCLE_BUDGETS
   }
 
   fun buildDaemonStartCommand(): List<String> {

--- a/android/junit-runner/src/main/kotlin/dev/jasonpearson/automobile/junit/DaemonSocketClient.kt
+++ b/android/junit-runner/src/main/kotlin/dev/jasonpearson/automobile/junit/DaemonSocketClient.kt
@@ -161,7 +161,7 @@ internal object DaemonSocketClientManager {
     val environmentOverrides = resolveDaemonEnvironmentOverrides()
     AutoMobileSharedUtils.executeCommand(
       startCommand,
-      DaemonSocketPaths.daemonStartTimeoutMs(),
+      DaemonSocketPaths.daemonLauncherTimeoutMs(),
       environmentOverrides,
     )
 
@@ -340,6 +340,7 @@ internal object DaemonSocketClientManager {
 
 internal object DaemonSocketPaths {
   private const val DEFAULT_DAEMON_STARTUP_TIMEOUT_MS = 30000L
+  private const val DAEMON_STARTUP_LIFECYCLE_BUDGETS = 3L
   private const val DAEMON_PACKAGE_NAME = "@kaeawc/auto-mobile"
   private const val DAEMON_PACKAGE_VERSION_PROPERTY = "automobile.daemon.package.version"
   private val ignoredPackageVersions = setOf("latest", "unknown")
@@ -356,6 +357,17 @@ internal object DaemonSocketPaths {
     val configured =
       sysProp.ifEmpty { envVar }.ifEmpty { DEFAULT_DAEMON_STARTUP_TIMEOUT_MS.toString() }
     return configured.toLongOrNull() ?: DEFAULT_DAEMON_STARTUP_TIMEOUT_MS
+  }
+
+  /**
+   * Bound the launcher process for the daemon's full startup lifecycle: one
+   * lock-holder wait plus up to two startup attempts.
+   */
+  fun daemonLauncherTimeoutMs(): Long {
+    return (
+      daemonStartTimeoutMs()
+        .coerceAtMost(Long.MAX_VALUE / DAEMON_STARTUP_LIFECYCLE_BUDGETS)
+      ) * DAEMON_STARTUP_LIFECYCLE_BUDGETS
   }
 
   fun buildDaemonStartCommand(): List<String> {

--- a/android/junit-runner/src/main/kotlin/dev/jasonpearson/automobile/junit/DaemonSocketClient.kt
+++ b/android/junit-runner/src/main/kotlin/dev/jasonpearson/automobile/junit/DaemonSocketClient.kt
@@ -339,7 +339,7 @@ internal object DaemonSocketClientManager {
 }
 
 internal object DaemonSocketPaths {
-  private const val DEFAULT_DAEMON_STARTUP_TIMEOUT_MS = 10000L
+  private const val DEFAULT_DAEMON_STARTUP_TIMEOUT_MS = 30000L
   private const val DAEMON_PACKAGE_NAME = "@kaeawc/auto-mobile"
   private const val DAEMON_PACKAGE_VERSION_PROPERTY = "automobile.daemon.package.version"
   private val ignoredPackageVersions = setOf("latest", "unknown")

--- a/android/junit-runner/src/main/kotlin/dev/jasonpearson/automobile/junit/README.md
+++ b/android/junit-runner/src/main/kotlin/dev/jasonpearson/automobile/junit/README.md
@@ -76,7 +76,7 @@ When using prompt-based testing:
 - `automobile.daemon.no.ui.perf.mode`: When `true`, appends `--no-ui-perf-mode` to the daemon `start` / `restart` command (same as CLI pre-start). Use in CI so a runner-triggered `--daemon restart` does not re-enable UI perf auditing. Can also be set via `AUTOMOBILE_DAEMON_NO_UI_PERF` (`1`, `true`, or `yes`).
 - `automobile.daemon.no.navigation.screenshots`: When `true`, appends `--no-navigation-screenshots` to the daemon command. Disables screenshot capture on navigation events, reducing emulator resource usage in CI. Can also be set via `AUTOMOBILE_DAEMON_NO_NAVIGATION_SCREENSHOTS` (`1`, `true`, or `yes`).
 - `automobile.daemon.no.waitfor.polling.overhead`: When `true`, appends `--no-waitfor-polling-overhead` to the daemon command. Skips screenshots and back stack collection during `observe` `waitFor` polling loops, reducing ADB contention that can cause ctrl-proxy WebSocket instability on resource-constrained CI emulators. Can also be set via `AUTOMOBILE_DAEMON_NO_WAITFOR_POLLING_OVERHEAD` (`1`, `true`, or `yes`).
-- `automobile.daemon.startup.timeout.ms`: Daemon startup timeout in milliseconds (default: 10000). Can also be set via `AUTOMOBILE_DAEMON_STARTUP_TIMEOUT_MS` environment variable.
+- `automobile.daemon.startup.timeout.ms`: Daemon startup timeout in milliseconds (default: 30000). Can also be set via `AUTOMOBILE_DAEMON_STARTUP_TIMEOUT_MS` environment variable.
 - `automobile.junit.shuffle.enabled`: Randomize test execution order (default: true)
 - `automobile.junit.shuffle.seed`: Seed for randomized order (default: current time)
 - `automobile.junit.timing.enabled`: Fetch historical timing data from the daemon (default: true)

--- a/android/junit-runner/src/test/kotlin/dev/jasonpearson/automobile/junit/DaemonSocketPathsFlagWiringTest.kt
+++ b/android/junit-runner/src/test/kotlin/dev/jasonpearson/automobile/junit/DaemonSocketPathsFlagWiringTest.kt
@@ -62,6 +62,7 @@ class DaemonSocketPathsFlagWiringTest {
     SystemPropertyCache.clear()
 
     assertEquals(30_000L, DaemonSocketPaths.daemonStartTimeoutMs())
+    assertEquals(90_000L, DaemonSocketPaths.daemonLauncherTimeoutMs())
   }
 
   @Test

--- a/android/junit-runner/src/test/kotlin/dev/jasonpearson/automobile/junit/DaemonSocketPathsFlagWiringTest.kt
+++ b/android/junit-runner/src/test/kotlin/dev/jasonpearson/automobile/junit/DaemonSocketPathsFlagWiringTest.kt
@@ -56,6 +56,11 @@ class DaemonSocketPathsFlagWiringTest {
 
   @Test
   fun `daemon startup timeout defaults to 30 seconds`() {
+    // CI provides a valid environment override for emulator startup; an invalid
+    // system property takes precedence and exercises this method's fallback.
+    System.setProperty("automobile.daemon.startup.timeout.ms", "not-a-number")
+    SystemPropertyCache.clear()
+
     assertEquals(30_000L, DaemonSocketPaths.daemonStartTimeoutMs())
   }
 

--- a/android/junit-runner/src/test/kotlin/dev/jasonpearson/automobile/junit/DaemonSocketPathsFlagWiringTest.kt
+++ b/android/junit-runner/src/test/kotlin/dev/jasonpearson/automobile/junit/DaemonSocketPathsFlagWiringTest.kt
@@ -17,6 +17,7 @@ class DaemonSocketPathsFlagWiringTest {
       "automobile.daemon.no.navigation.screenshots",
       "automobile.daemon.no.waitfor.polling.overhead",
       "automobile.daemon.package.version",
+      "automobile.daemon.startup.timeout.ms",
     )
 
   @Before
@@ -51,6 +52,11 @@ class DaemonSocketPathsFlagWiringTest {
       "should not contain --no-waitfor-polling-overhead",
       command.contains("--no-waitfor-polling-overhead"),
     )
+  }
+
+  @Test
+  fun `daemon startup timeout defaults to 30 seconds`() {
+    assertEquals(30_000L, DaemonSocketPaths.daemonStartTimeoutMs())
   }
 
   @Test

--- a/ios/XCTestRunner/Sources/XCTestRunner/AutoMobileEnvironment.swift
+++ b/ios/XCTestRunner/Sources/XCTestRunner/AutoMobileEnvironment.swift
@@ -494,10 +494,10 @@ public enum DaemonManager {
     ) -> TimeInterval {
         let configuredStartupMilliseconds = Int(environment["AUTOMOBILE_DAEMON_STARTUP_TIMEOUT_MS"] ?? "")
             ?? Int(environment["AUTO_MOBILE_DAEMON_STARTUP_TIMEOUT_MS"] ?? "")
-            ?? 10_000
+            ?? 30_000
         let startupSeconds = configuredStartupMilliseconds > 0
             ? TimeInterval(configuredStartupMilliseconds) / 1000
-            : 10
+            : 30
         // DaemonManager can wait for a lock holder, then make two startup attempts while
         // recovering an incomplete package extraction, each with the configured startup budget.
         let startupLifecycleSeconds = 3 * startupSeconds

--- a/ios/XCTestRunner/Sources/XCTestRunnerTests/AutoMobileVersionTests.swift
+++ b/ios/XCTestRunner/Sources/XCTestRunnerTests/AutoMobileVersionTests.swift
@@ -529,7 +529,7 @@ final class AutoMobileVersionTests: XCTestCase {
             subcommand: "restart",
             readinessTimeoutSeconds: 15,
             environment: [:]
-        ), 36)
+        ), 96)
         XCTAssertEqual(DaemonManager.daemonLauncherTimeoutSeconds(
             subcommand: "restart",
             readinessTimeoutSeconds: 15,
@@ -544,7 +544,7 @@ final class AutoMobileVersionTests: XCTestCase {
             subcommand: "start",
             readinessTimeoutSeconds: 15,
             environment: [:]
-        ), 30)
+        ), 90)
     }
 
     func testEnsureDaemonRunningAcceptsDaemonMatchingPinnedClientVersion() {

--- a/scripts/android/run-emulator-tests.sh
+++ b/scripts/android/run-emulator-tests.sh
@@ -320,7 +320,7 @@ echo "Working directory: $(pwd)"
 echo "About to execute: $TEST_SCRIPT"
 echo ""
 
-# Increase daemon startup timeout for CI environments (default 10s is too short)
+# Increase daemon startup timeout for CI environments (default 30s is too short)
 # The emulator environment is slower, so we give the daemon more time to start
 export AUTOMOBILE_DAEMON_STARTUP_TIMEOUT_MS=60000
 echo "AutoMobile configuration:"

--- a/scripts/ci/ensure-daemon-ready.sh
+++ b/scripts/ci/ensure-daemon-ready.sh
@@ -39,12 +39,8 @@ BUN_BIN_DIR="${HOME}/.bun/bin"
 export PATH="${BUN_BIN_DIR}:${PATH}"
 hash -r 2>/dev/null || true
 
-# Give the cold-runner daemon a realistic startup ceiling. The default is 10s
-# (DAEMON_STARTUP_TIMEOUT_MS, src/daemon/constants.ts), which a cold CI runner can
-# exceed on the first `--daemon start` below — surfacing a misleading
-# "Daemon failed to start within 10000ms" line even though the health-poll loop
-# then brings it up fine. Raise it to 30s so the first attempt reports success
-# instead of a scary error. An explicit outer override still wins.
+# Use the standard 30s daemon startup ceiling on cold CI runners. An explicit
+# outer override still wins.
 export AUTOMOBILE_DAEMON_STARTUP_TIMEOUT_MS="${AUTOMOBILE_DAEMON_STARTUP_TIMEOUT_MS:-30000}"
 
 # Persist the bin dir for the *subsequent* workflow steps: `swift test` spawns

--- a/src/daemon/constants.ts
+++ b/src/daemon/constants.ts
@@ -85,7 +85,9 @@ export const CONNECTION_TIMEOUT_MS =
 
 /**
  * Daemon startup timeout in milliseconds
- * How long to wait for daemon to become ready
+ * How long to wait for daemon to become ready. Cold startup serially discovers
+ * devices and initializes iOS services, so the default allows normal
+ * multi-simulator bring-up while remaining bounded.
  */
 const startupTimeoutOverride =
   process.env.AUTOMOBILE_DAEMON_STARTUP_TIMEOUT_MS ??
@@ -96,7 +98,7 @@ const parsedStartupTimeout = startupTimeoutOverride
 export const DAEMON_STARTUP_TIMEOUT_MS =
   Number.isFinite(parsedStartupTimeout) && parsedStartupTimeout > 0
     ? parsedStartupTimeout
-    : 10000;
+    : 30000;
 
 /**
  * Daemon shutdown timeout in milliseconds

--- a/src/daemon/manager.ts
+++ b/src/daemon/manager.ts
@@ -522,9 +522,7 @@ export class DaemonManager implements DaemonManagerLike {
         stderrLog("Daemon started by another process (retry)");
         return;
       }
-      throw new ActionableError(
-        "Another process is starting the daemon but it failed to become ready"
-      );
+      throw await this.createLockHolderStartupFailure();
     }
 
     try {
@@ -787,6 +785,37 @@ export class DaemonManager implements DaemonManagerLike {
       (error as { code?: string }).code = INCOMPLETE_EXTRACTION_CODE;
     }
     return error;
+  }
+
+  private async createLockHolderStartupFailure(): Promise<Error> {
+    const summary = "Another process is starting the daemon but it failed to become ready";
+    const logPath = await this.getLockHolderStartupLogPath();
+    if (!logPath) {
+      return new ActionableError(
+        `${summary}; the startup lock did not contain a usable holder PID for diagnostics.`
+      );
+    }
+    return new ActionableError(await this.formatDaemonStartupFailure(summary, logPath));
+  }
+
+  private async getLockHolderStartupLogPath(): Promise<string | null> {
+    try {
+      const lockContents = await readFile(this.lockFilePath, "utf-8");
+      const trimmedLockContents = lockContents.trim();
+      if (!/^\d+$/.test(trimmedLockContents)) {
+        return null;
+      }
+      const lockHolderPid = Number.parseInt(trimmedLockContents, 10);
+      if (!Number.isSafeInteger(lockHolderPid) || lockHolderPid <= 0) {
+        return null;
+      }
+      return join(ensureSecureLogsDirSync(), `daemon-launch-${lockHolderPid}.log`);
+    } catch (error) {
+      logger.debug(
+        `[DaemonManager] Unable to read startup lock holder diagnostics: ${this.describeError(error)}`
+      );
+      return null;
+    }
   }
 
   private async createDaemonExitFailure(

--- a/src/daemon/manager.ts
+++ b/src/daemon/manager.ts
@@ -1,7 +1,7 @@
 import { execSync } from "node:child_process";
 import { open, readFile, rm, unlink } from "node:fs/promises";
 import { existsSync, openSync, closeSync } from "node:fs";
-import { join, resolve, sep } from "node:path";
+import { basename, isAbsolute, join, resolve, sep } from "node:path";
 import { tmpdir } from "node:os";
 import { logger } from "../utils/logger";
 import { resolveDaemonInstallSpecifier } from "../constants/release";
@@ -9,7 +9,7 @@ import {
   INCOMPLETE_EXTRACTION_CODE,
   INCOMPLETE_EXTRACTION_EXIT_CODE,
 } from "../db/migrationDependencyIntegrity";
-import { ensureSecureLogsDirSync } from "../utils/tempDir";
+import { ensureSecureLogsDirSync, resolveAutoMobileLogsDir } from "../utils/tempDir";
 import { outputReductionFlagsToArgs } from "../utils/outputReductionFlags";
 import {
   EVENT_ALL_MARKERS_FLAG,
@@ -48,7 +48,7 @@ import {
   cleanupDaemonFiles,
   isProcessRunning as isDaemonProcessRunning,
 } from "./daemonFiles";
-import { releaseExclusiveLock, tryAcquireExclusiveLock } from "../utils/fileLock";
+import { parseLockContent, releaseExclusiveLock, tryAcquireExclusiveLock } from "../utils/fileLock";
 import {
   DAEMON_LAUNCH_CWD_ENV,
   resolveDaemonLaunchWorkingDirectory,
@@ -359,6 +359,7 @@ export class DaemonManager implements DaemonManagerLike {
   private readonly launcher: DaemonLauncher;
   private readonly fallbackLauncher: DaemonLauncher;
   private readonly launchCommandResolver: (() => DaemonLaunchCommand) | undefined;
+  private heldLockLogPath: string | undefined;
 
   constructor(
     clientFactory: DaemonClientFactory | undefined = undefined,
@@ -415,9 +416,13 @@ export class DaemonManager implements DaemonManagerLike {
    * from another manager instance still reads as actively held.
    */
   acquireLock(): boolean {
-    return tryAcquireExclusiveLock(this.lockFilePath, {
+    const logPath = this.daemonLaunchLogPath();
+    const acquired = tryAcquireExclusiveLock(this.lockFilePath, {
       isProcessRunning: pid => this.isProcessRunning(pid),
+      metadata: Buffer.from(logPath, "utf8").toString("base64url"),
     });
+    this.heldLockLogPath = acquired ? logPath : undefined;
+    return acquired;
   }
 
   /**
@@ -426,6 +431,7 @@ export class DaemonManager implements DaemonManagerLike {
    */
   releaseLock(): void {
     releaseExclusiveLock(this.lockFilePath);
+    this.heldLockLogPath = undefined;
   }
 
   createClient(): DaemonClientLike {
@@ -584,8 +590,8 @@ export class DaemonManager implements DaemonManagerLike {
     // and post-hoc debugging impossible (issue #2724). The logs dir is created
     // owner-only (0o700) by ensureSecureLogsDirSync, so a fixed, predictable
     // filename inside it is not exposed to other users.
-    const logsDir = ensureSecureLogsDirSync();
-    const logPath = join(logsDir, `daemon-launch-${process.pid}.log`);
+    const logPath = this.heldLockLogPath ?? this.daemonLaunchLogPath();
+    ensureSecureLogsDirSync();
     // Open with restricted permissions (0o600 = owner read/write only).
     // Truncate per launch so a single manager's bootstrap captures don't grow
     // unbounded across restarts.
@@ -801,21 +807,28 @@ export class DaemonManager implements DaemonManagerLike {
   private async getLockHolderStartupLogPath(): Promise<string | null> {
     try {
       const lockContents = await readFile(this.lockFilePath, "utf-8");
-      const trimmedLockContents = lockContents.trim();
-      if (!/^\d+$/.test(trimmedLockContents)) {
-        return null;
-      }
-      const lockHolderPid = Number.parseInt(trimmedLockContents, 10);
+      const { pid: lockHolderPid, metadata } = parseLockContent(lockContents.trim());
       if (!Number.isSafeInteger(lockHolderPid) || lockHolderPid <= 0) {
         return null;
       }
-      return join(ensureSecureLogsDirSync(), `daemon-launch-${lockHolderPid}.log`);
+      if (!metadata) {
+        return null;
+      }
+      const logPath = Buffer.from(metadata, "base64url").toString("utf8");
+      if (!isAbsolute(logPath) || basename(logPath) !== `daemon-launch-${lockHolderPid}.log`) {
+        return null;
+      }
+      return logPath;
     } catch (error) {
       logger.debug(
         `[DaemonManager] Unable to read startup lock holder diagnostics: ${this.describeError(error)}`
       );
       return null;
     }
+  }
+
+  private daemonLaunchLogPath(): string {
+    return join(resolveAutoMobileLogsDir(), `daemon-launch-${process.pid}.log`);
   }
 
   private async createDaemonExitFailure(

--- a/src/daemon/manager.ts
+++ b/src/daemon/manager.ts
@@ -523,12 +523,13 @@ export class DaemonManager implements DaemonManagerLike {
       }
       // Another process won the retry race — wait for it to finish
       stderrLog("Another process is retrying daemon start, waiting...");
+      const retryHolderLogPath = await this.getLockHolderStartupLogPath();
       const retryReady = await this.waitForReady(DAEMON_STARTUP_TIMEOUT_MS);
       if (retryReady) {
         stderrLog("Daemon started by another process (retry)");
         return;
       }
-      throw await this.createLockHolderStartupFailure();
+      throw await this.createLockHolderStartupFailure(retryHolderLogPath);
     }
 
     try {
@@ -793,9 +794,9 @@ export class DaemonManager implements DaemonManagerLike {
     return error;
   }
 
-  private async createLockHolderStartupFailure(): Promise<Error> {
+  private async createLockHolderStartupFailure(retainedLogPath?: string | null): Promise<Error> {
     const summary = "Another process is starting the daemon but it failed to become ready";
-    const logPath = await this.getLockHolderStartupLogPath();
+    const logPath = retainedLogPath ?? await this.getLockHolderStartupLogPath();
     if (!logPath) {
       return new ActionableError(
         `${summary}; the startup lock did not contain a usable holder PID for diagnostics.`

--- a/src/utils/fileLock.ts
+++ b/src/utils/fileLock.ts
@@ -66,6 +66,13 @@ export interface ExclusiveLockOptions {
    * from `IdGenerator`; a future caller must uphold the same shape.
    */
   ownerToken?: string;
+
+  /**
+   * Optional single-line metadata written on line 3 of the lock file. It is
+   * opaque to this primitive; callers that need to preserve arbitrary data must
+   * encode it before passing it here.
+   */
+  metadata?: string;
 }
 
 /**
@@ -84,25 +91,39 @@ export interface LockContent {
   pid: number;
   /** Per-process-instance token (line 2), or `undefined` when absent. */
   token: string | undefined;
+  /** Optional caller-defined metadata (line 3). */
+  metadata?: string;
 }
 
 /**
  * Serialize a lock file body. PID on line 1 (bare integer, always), token on an
- * optional line 2. Inverse of {@link parseLockContent}. Centralizes the positional
- * format so a future field can't silently move the PID off line 1 (#3006).
+ * optional line 2, and opaque metadata on an optional line 3. Inverse of
+ * {@link parseLockContent}. Centralizes the positional format so a future field
+ * can't silently move the PID off line 1 (#3006).
  */
-export function formatLockContent(pid: number, ownerToken?: string): string {
-  return ownerToken === undefined ? String(pid) : `${pid}\n${ownerToken}`;
+export function formatLockContent(pid: number, ownerToken?: string, metadata?: string): string {
+  if (metadata === undefined) {
+    return ownerToken === undefined ? String(pid) : `${pid}\n${ownerToken}`;
+  }
+  return `${pid}\n${ownerToken ?? ""}\n${metadata}`;
 }
 
 /**
  * Parse a lock file body (already `trim()`-ed by the caller) into its PID and
- * optional token. Line 1 is parsed as an integer PID (`NaN` when unreadable); line
- * 2, if present, is the token. Inverse of {@link formatLockContent} (#3006).
+ * optional token and metadata. Line 1 is parsed as an integer PID (`NaN` when
+ * unreadable); line 2, if present, is the token; line 3 is caller-defined
+ * metadata. Inverse of {@link formatLockContent} (#3006).
  */
 export function parseLockContent(content: string): LockContent {
-  const [pidLine, tokenLine] = content.split("\n", 2);
-  return { pid: Number.parseInt(pidLine, 10), token: tokenLine };
+  const [pidLine, tokenLine, metadataLine] = content.split("\n", 3);
+  const parsed: LockContent = {
+    pid: Number.parseInt(pidLine, 10),
+    token: tokenLine || undefined,
+  };
+  if (metadataLine) {
+    parsed.metadata = metadataLine;
+  }
+  return parsed;
 }
 
 /**
@@ -117,8 +138,9 @@ export function tryAcquireExclusiveLock(
   const isProcessRunning = options.isProcessRunning ?? defaultIsProcessRunning;
   const reclaimOwnPid = options.reclaimOwnPid ?? false;
   const ownerToken = options.ownerToken;
+  const metadata = options.metadata;
 
-  if (writeExclusiveLockFile(lockFilePath, pid, ownerToken)) {
+  if (writeExclusiveLockFile(lockFilePath, pid, ownerToken, metadata)) {
     return true;
   }
 
@@ -191,7 +213,7 @@ export function tryAcquireExclusiveLock(
   } catch {
     // Best-effort: the consumed stale marker is ours to remove.
   }
-  return writeExclusiveLockFile(lockFilePath, pid, ownerToken);
+  return writeExclusiveLockFile(lockFilePath, pid, ownerToken, metadata);
 }
 
 /**
@@ -249,11 +271,16 @@ export function releaseExclusiveLock(
  * this process instance's live lock from a recycled-PID leak (#2947); the PID
  * stays on the first line so `parseInt`-based readers are unaffected.
  */
-function writeExclusiveLockFile(lockFilePath: string, pid: number, ownerToken?: string): boolean {
+function writeExclusiveLockFile(
+  lockFilePath: string,
+  pid: number,
+  ownerToken?: string,
+  metadata?: string
+): boolean {
   try {
     mkdirSync(dirname(lockFilePath), { recursive: true });
     const fd = openSync(lockFilePath, "wx", 0o600);
-    writeFileSync(fd, formatLockContent(pid, ownerToken));
+    writeFileSync(fd, formatLockContent(pid, ownerToken, metadata));
     closeSync(fd);
     return true;
   } catch (error) {

--- a/test/daemon/daemonManagerLock.test.ts
+++ b/test/daemon/daemonManagerLock.test.ts
@@ -1,6 +1,6 @@
 import { describe, expect, test, afterEach } from "bun:test";
-import { existsSync, writeFileSync, mkdtempSync } from "node:fs";
-import { join } from "node:path";
+import { existsSync, mkdirSync, writeFileSync, mkdtempSync } from "node:fs";
+import { dirname, join } from "node:path";
 import { tmpdir } from "node:os";
 import { DaemonManager } from "../../src/daemon/manager";
 import { FakeTimer } from "../fakes/FakeTimer";
@@ -153,15 +153,23 @@ describe("DaemonManager file lock", () => {
       unlinkSync(lockPath);
     });
 
-    test("throws when lock is held and daemon fails to start", async () => {
+    test("waits through the cold-start budget and includes lock-holder diagnostics when startup fails", async () => {
       const lockPath = createTempLockPath();
       const fakeTimer = new FakeTimer();
       fakeTimer.enableAutoAdvance();
 
       writeFileSync(lockPath, String(process.pid));
+      const logsDir = join(dirname(lockPath), "logs");
+      mkdirSync(logsDir, { recursive: true });
+      writeFileSync(
+        join(logsDir, `daemon-launch-${process.pid}.log`),
+        "Initializing CtrlProxy iOS for SIMULATOR-B\nrunner-health: connection refused\n",
+      );
+      const timeouts: number[] = [];
 
       class TestDaemonManager extends DaemonManager {
-        override async waitForReady(_timeout: number): Promise<boolean> {
+        override async waitForReady(timeout: number): Promise<boolean> {
+          timeouts.push(timeout);
           return false; // Daemon never becomes ready
         }
         override findAllDaemonProcesses(): number[] { return []; }
@@ -170,8 +178,9 @@ describe("DaemonManager file lock", () => {
       const manager = new TestDaemonManager(undefined, undefined, fakeTimer, lockPath);
 
       await expect(manager.start()).rejects.toThrow(
-        "Another process is starting the daemon but it failed to become ready"
+        /Another process is starting the daemon but it failed to become ready[\s\S]*daemon-launch-\d+\.log[\s\S]*SIMULATOR-B/
       );
+      expect(timeouts).toEqual([30_000, 30_000]);
 
       // Clean up
       const { unlinkSync } = require("node:fs");

--- a/test/daemon/daemonManagerLock.test.ts
+++ b/test/daemon/daemonManagerLock.test.ts
@@ -158,16 +158,20 @@ describe("DaemonManager file lock", () => {
       const fakeTimer = new FakeTimer();
       fakeTimer.enableAutoAdvance();
 
-      writeFileSync(lockPath, String(process.pid));
+      const lockHolderPid = 424_242;
+      writeFileSync(lockPath, String(lockHolderPid));
       const logsDir = join(dirname(lockPath), "logs");
       mkdirSync(logsDir, { recursive: true });
       writeFileSync(
-        join(logsDir, `daemon-launch-${process.pid}.log`),
+        join(logsDir, `daemon-launch-${lockHolderPid}.log`),
         "Initializing CtrlProxy iOS for SIMULATOR-B\nrunner-health: connection refused\n",
       );
       const timeouts: number[] = [];
 
       class TestDaemonManager extends DaemonManager {
+        override acquireLock(): boolean {
+          return false;
+        }
         override async waitForReady(timeout: number): Promise<boolean> {
           timeouts.push(timeout);
           return false; // Daemon never becomes ready
@@ -178,7 +182,7 @@ describe("DaemonManager file lock", () => {
       const manager = new TestDaemonManager(undefined, undefined, fakeTimer, lockPath);
 
       await expect(manager.start()).rejects.toThrow(
-        /Another process is starting the daemon but it failed to become ready[\s\S]*daemon-launch-\d+\.log[\s\S]*SIMULATOR-B/
+        /Another process is starting the daemon but it failed to become ready[\s\S]*daemon-launch-424242\.log[\s\S]*SIMULATOR-B/
       );
       expect(timeouts).toEqual([30_000, 30_000]);
 

--- a/test/daemon/daemonManagerLock.test.ts
+++ b/test/daemon/daemonManagerLock.test.ts
@@ -193,6 +193,46 @@ describe("DaemonManager file lock", () => {
       holder.releaseLock();
     });
 
+    test("retains retry-holder diagnostics after the retry holder releases its lock", async () => {
+      const lockPath = createTempLockPath();
+      const fakeTimer = new FakeTimer();
+      fakeTimer.enableAutoAdvance();
+      const holderLogsDir = join(dirname(lockPath), "retry-holder-logs");
+      let retryHolder: DaemonManager | undefined;
+      let waitCount = 0;
+
+      class TestDaemonManager extends DaemonManager {
+        override acquireLock(): boolean {
+          return false;
+        }
+        override async waitForReady(_timeout: number): Promise<boolean> {
+          waitCount++;
+          if (waitCount === 1) {
+            process.env.AUTOMOBILE_LOG_DIR = holderLogsDir;
+            retryHolder = new DaemonManager(undefined, undefined, fakeTimer, lockPath);
+            expect(retryHolder.acquireLock()).toBe(true);
+            mkdirSync(holderLogsDir, { recursive: true });
+            writeFileSync(
+              join(holderLogsDir, `daemon-launch-${process.pid}.log`),
+              "Retry holder failed to start CtrlProxy\n",
+            );
+            return false;
+          }
+
+          retryHolder?.releaseLock();
+          return false;
+        }
+        override findAllDaemonProcesses(): number[] { return []; }
+      }
+
+      const manager = new TestDaemonManager(undefined, undefined, fakeTimer, lockPath);
+
+      await expect(manager.start()).rejects.toThrow(
+        /Another process is starting the daemon but it failed to become ready[\s\S]*retry-holder-logs[\s\S]*Retry holder failed/
+      );
+      expect(waitCount).toBe(2);
+    });
+
     test("releases lock after successful start", async () => {
       const lockPath = createTempLockPath();
       const fakeTimer = new FakeTimer();

--- a/test/daemon/daemonManagerLock.test.ts
+++ b/test/daemon/daemonManagerLock.test.ts
@@ -26,6 +26,7 @@ describe("DaemonManager file lock", () => {
     }
     tempDirs.length = 0;
     delete process.env.AUTOMOBILE_DATA_DIR;
+    delete process.env.AUTOMOBILE_LOG_DIR;
   });
 
   describe("acquireLock", () => {
@@ -158,14 +159,17 @@ describe("DaemonManager file lock", () => {
       const fakeTimer = new FakeTimer();
       fakeTimer.enableAutoAdvance();
 
-      const lockHolderPid = 424_242;
-      writeFileSync(lockPath, String(lockHolderPid));
-      const logsDir = join(dirname(lockPath), "logs");
-      mkdirSync(logsDir, { recursive: true });
+      const holderLogsDir = join(dirname(lockPath), "holder-logs");
+      process.env.AUTOMOBILE_LOG_DIR = holderLogsDir;
+      const holder = new DaemonManager(undefined, undefined, fakeTimer, lockPath);
+      expect(holder.acquireLock()).toBe(true);
+      mkdirSync(holderLogsDir, { recursive: true });
       writeFileSync(
-        join(logsDir, `daemon-launch-${lockHolderPid}.log`),
+        join(holderLogsDir, `daemon-launch-${process.pid}.log`),
         "Initializing CtrlProxy iOS for SIMULATOR-B\nrunner-health: connection refused\n",
       );
+
+      process.env.AUTOMOBILE_LOG_DIR = join(dirname(lockPath), "follower-logs");
       const timeouts: number[] = [];
 
       class TestDaemonManager extends DaemonManager {
@@ -182,13 +186,11 @@ describe("DaemonManager file lock", () => {
       const manager = new TestDaemonManager(undefined, undefined, fakeTimer, lockPath);
 
       await expect(manager.start()).rejects.toThrow(
-        /Another process is starting the daemon but it failed to become ready[\s\S]*daemon-launch-424242\.log[\s\S]*SIMULATOR-B/
+        /Another process is starting the daemon but it failed to become ready[\s\S]*holder-logs[\s\S]*SIMULATOR-B/
       );
       expect(timeouts).toEqual([30_000, 30_000]);
 
-      // Clean up
-      const { unlinkSync } = require("node:fs");
-      unlinkSync(lockPath);
+      holder.releaseLock();
     });
 
     test("releases lock after successful start", async () => {

--- a/test/utils/fileLock.test.ts
+++ b/test/utils/fileLock.test.ts
@@ -220,12 +220,18 @@ describe("fileLock primitive", () => {
     test("formatLockContent keeps the PID a bare integer on line 1", () => {
       expect(formatLockContent(100)).toBe("100");
       expect(formatLockContent(100, "tok-A")).toBe("100\ntok-A");
+      expect(formatLockContent(100, undefined, "holder-log-path")).toBe("100\n\nholder-log-path");
       expect(Number.parseInt(formatLockContent(100, "tok-A"), 10)).toBe(100);
     });
 
     test("parseLockContent round-trips formatLockContent", () => {
       expect(parseLockContent(formatLockContent(100))).toEqual({ pid: 100, token: undefined });
       expect(parseLockContent(formatLockContent(100, "tok-A"))).toEqual({ pid: 100, token: "tok-A" });
+      expect(parseLockContent(formatLockContent(100, undefined, "holder-log-path"))).toEqual({
+        pid: 100,
+        token: undefined,
+        metadata: "holder-log-path",
+      });
     });
 
     test("parseLockContent reports NaN for an unreadable PID line", () => {


### PR DESCRIPTION
## Summary

Raises the default daemon startup budget from 10 seconds to 30 seconds so normal
cold multi-simulator initialization has time to complete. When a second process
waits behind the startup lock and the daemon never becomes ready, its error now
includes the lock holder's bounded launch-log diagnostics.

## Linked Issue

Closes [#5431](https://github.com/kaeawc/auto-mobile/issues/5431).

## Bug / Regression Context

- **Observed symptom:** Cold iOS multi-simulator startup could consume the
  serialized setup budget before the daemon opened its socket.
- **Repro conditions:** Start the daemon on a cold host with multiple iOS
  simulators, then start a second client while the startup lock is held.
- **Root cause:** The 10-second general readiness deadline did not account for
  serial device discovery and iOS CtrlProxy initialization.

## Validation

- [x] `bun test test/daemon/daemonManagerLock.test.ts test/daemon/daemonManagerReadiness.test.ts test/daemon/daemonStartupGuard.test.ts`
- [x] `bun run typecheck`
- [x] `bun run turbo:validate`
- [x] `scripts/all_fast_validate_checks.sh`
- [x] New coverage uses the existing `FakeTimer` seam and filesystem-backed
  launch-log fixture; no new dependencies or generic helpers were added.
