### PR TITLE
feat: recover Android sessions after ADB resets

### DIFF
--- a/docs/using/environment-variables.md
+++ b/docs/using/environment-variables.md
@@ -124,9 +124,9 @@ explicitly, per run or per environment.
 
 | Variable | Purpose | Default |
 |----------|---------|---------|
-| `AUTOMOBILE_ALLOW_DEVICE_CREATE` | When `1` or `true`, `startDevice` creates a device (iOS: `simctl create`; Android: `avdmanager create avd`) instead of failing when nothing matches the requested criteria. | unset (off) |
+| `AUTOMOBILE_ALLOW_DEVICE_CREATE` | Legacy `startDevice` compatibility only: when `1` or `true`, its broad matcher may create a device (iOS: `simctl create`; Android: `avdmanager create avd`). `getAndroid` and `getApple` never create devices. | unset (off) |
 
-The equivalent per-call flag is `--create-if-missing` on the device-start path:
+The equivalent per-call flag is available only on the hidden compatibility path:
 
 ```bash
 auto-mobile --cli startDevice --platform ios --create-if-missing
@@ -140,6 +140,21 @@ neither, creation is off.
 Created devices are named `AutoMobile-<model>-<id>` so they are easy to find and
 clean up (`xcrun simctl delete <udid>` / `avdmanager delete avd -n <name>`), and
 the resolved device type and runtime are logged at creation time.
+
+## Managed ADB server lifecycle
+
+By default, AutoMobile treats the local ADB server as shared infrastructure and
+does not stop it at process shutdown. This is safe for developer machines and
+for hosts where another service or user may use the same server.
+
+| Variable | Legacy alias | Purpose | Default |
+|----------|--------------|---------|---------|
+| `AUTOMOBILE_MANAGED_ADB_SERVER` | `AUTO_MOBILE_MANAGED_ADB_SERVER` | When `1` or `true`, declares that the daemon or direct AutoMobile process owns the local ADB server lifecycle. A clean shutdown runs a bounded `adb kill-server` after active device sessions are released. | unset (off) |
+
+Enable this only when the surrounding service scope owns the local ADB server.
+Do not enable it for a server shared with another AutoMobile daemon, developer,
+or unrelated Android tool. Proxy clients never stop the server; cleanup runs in
+the daemon or explicit direct (`--no-proxy`) process that performs Android work.
 
 ## Managed-device recovery
 

--- a/docs/using/tool-capabilities.md
+++ b/docs/using/tool-capabilities.md
@@ -20,7 +20,7 @@ These tools are never gated — they are present the moment you connect:
 `observe`, `tapOn`, `tapAny`, `swipeOn`, `inputText`, `clearText`, `keyboard`,
 `pressButton`, `homeScreen`, `recentApps`, `launchApp`, `terminateApp`,
 `installApp`, `uninstallApp`, `listApps`, `listDevices`, `listDeviceImages`,
-`startDevice`, `killDevice`, `setActiveDevice`, `wakeAndUnlock`, and the
+`getAndroid`, `getApple`, `killDevice`, `setActiveDevice`, `wakeAndUnlock`, and the
 capability control tool `setToolCapability`.
 
 Everything beyond this is reached through one of the three gates below.

--- a/schemas/tool-definitions.json
+++ b/schemas/tool-definitions.json
@@ -1517,6 +1517,68 @@
     }
   },
   {
+    "name": "getAndroid",
+    "description": "Find or recover an Android AVD and prepare it for automation.",
+    "inputSchema": {
+      "$schema": "https://json-schema.org/draft/2020-12/schema",
+      "type": "object",
+      "properties": {
+        "bootTimeoutMs": {
+          "description": "Maximum time to find, recover, or boot the device operating system",
+          "type": "integer",
+          "exclusiveMinimum": 0,
+          "maximum": 890000
+        },
+        "automationReadyTimeoutMs": {
+          "description": "Maximum time to install, update, start, and verify the automation runner",
+          "type": "integer",
+          "minimum": 1000,
+          "maximum": 120000
+        },
+        "avdName": {
+          "description": "Configured Android Virtual Device name",
+          "type": "string",
+          "minLength": 1
+        }
+      },
+      "required": [
+        "avdName"
+      ],
+      "additionalProperties": false
+    }
+  },
+  {
+    "name": "getApple",
+    "description": "Find or recover an iOS Simulator and prepare it for automation.",
+    "inputSchema": {
+      "$schema": "https://json-schema.org/draft/2020-12/schema",
+      "type": "object",
+      "properties": {
+        "bootTimeoutMs": {
+          "description": "Maximum time to find, recover, or boot the device operating system",
+          "type": "integer",
+          "exclusiveMinimum": 0,
+          "maximum": 890000
+        },
+        "automationReadyTimeoutMs": {
+          "description": "Maximum time to install, update, start, and verify the automation runner",
+          "type": "integer",
+          "minimum": 1000,
+          "maximum": 120000
+        },
+        "udid": {
+          "description": "iOS Simulator UDID",
+          "type": "string",
+          "minLength": 1
+        }
+      },
+      "required": [
+        "udid"
+      ],
+      "additionalProperties": false
+    }
+  },
+  {
     "name": "getAppPermissions",
     "description": "Read app permission state",
     "inputSchema": {
@@ -8611,89 +8673,6 @@
         "appId",
         "databasePath",
         "query"
-      ],
-      "additionalProperties": false
-    }
-  },
-  {
-    "name": "startDevice",
-    "description": "Start device",
-    "inputSchema": {
-      "$schema": "https://json-schema.org/draft/2020-12/schema",
-      "type": "object",
-      "properties": {
-        "platform": {
-          "type": "string",
-          "enum": [
-            "android",
-            "ios"
-          ]
-        },
-        "minOsVersion": {
-          "description": "Minimum OS version, inclusive (e.g., '14', '17.2')",
-          "type": "string"
-        },
-        "maxOsVersion": {
-          "description": "Maximum OS version, inclusive (e.g., '15', '18.0')",
-          "type": "string"
-        },
-        "name": {
-          "description": "Device name to match (e.g., 'iPhone 16e', 'Pixel_9_Pro')",
-          "type": "string"
-        },
-        "formFactor": {
-          "description": "Device form factor",
-          "type": "string",
-          "enum": [
-            "phone",
-            "tablet"
-          ]
-        },
-        "screenSize": {
-          "description": "Desired screen dimensions",
-          "type": "object",
-          "properties": {
-            "width": {
-              "description": "Screen width in pixels",
-              "type": "number"
-            },
-            "height": {
-              "description": "Screen height in pixels",
-              "type": "number"
-            }
-          },
-          "required": [
-            "width",
-            "height"
-          ],
-          "additionalProperties": false
-        },
-        "deviceId": {
-          "type": "string"
-        },
-        "preferRunning": {
-          "description": "Prefer already-booted device (default true)",
-          "type": "boolean"
-        },
-        "timeoutMs": {
-          "description": "Total device boot and automation-readiness timeout in ms",
-          "type": "integer",
-          "exclusiveMinimum": 0,
-          "maximum": 890000
-        },
-        "runnerReadinessTimeoutMs": {
-          "description": "Runner-readiness budget in ms within timeoutMs; overrides the shared timeout (1000-120000)",
-          "type": "integer",
-          "minimum": 1000,
-          "maximum": 120000
-        },
-        "createIfMissing": {
-          "description": "Create a device when nothing matches (CLI: --create-if-missing). Default off; AUTOMOBILE_ALLOW_DEVICE_CREATE=1 enables it when this flag is not supplied, and the flag wins.",
-          "type": "boolean"
-        }
-      },
-      "required": [
-        "platform"
       ],
       "additionalProperties": false
     }

--- a/src/cli/index.ts
+++ b/src/cli/index.ts
@@ -627,8 +627,8 @@ Examples:
   bunx ${installSpecifier} --cli listDeviceImages
   bunx ${installSpecifier} --cli observe
   bunx ${installSpecifier} --cli tapOn --text "Submit"
-  bunx ${installSpecifier} --cli startDevice --avdName "pixel_7_api_34"
-  bunx ${installSpecifier} --cli startDevice --platform ios --create-if-missing
+  bunx ${installSpecifier} --cli getAndroid --avd-name "pixel_7_api_34"
+  bunx ${installSpecifier} --cli getApple --udid "SIMULATOR-UDID"
   bunx ${installSpecifier} --cli --session-uuid abc-123-uuid observe
   bunx ${installSpecifier} --cli --session-uuid $SESSION_UUID tapOn --text "Submit"
 
@@ -657,7 +657,8 @@ Session-based Execution:
     "setActiveDevice",
     "listDevices",
     "listDeviceImages",
-    "startDevice",
+    "getAndroid",
+    "getApple",
     "killDevice",
     "checkRunningDevices"
   ];

--- a/src/daemon/daemon.ts
+++ b/src/daemon/daemon.ts
@@ -110,6 +110,7 @@ import {
   type ObservationStreamHealth,
 } from "./ObservationStreamHealth";
 import { onAdbMissingDevice } from "../utils/android-cmdline-tools/AdbDeviceHealth";
+import { stopManagedAdbServer } from "../utils/android-cmdline-tools/AdbServerLifecycle";
 import { iosSimulatorCaptureHelperPool } from "../features/screen-stream";
 import { runShutdownCleanupStages } from "../shutdownCleanup";
 import { cleanupDaemonChildProcesses } from "./childProcessCleanup";
@@ -132,12 +133,29 @@ const MIGRATION_SETTLE_TIMEOUT_MS = 5_000;
 
 type HealthFailureKind = "http" | "socket" | "database" | "unknown";
 type DatabaseHealthFailureRecovery = (code: number) => void | Promise<void>;
+type ManagedAdbServerShutdown = () => Promise<void>;
 type DeviceSessionRoutingTargets = {
   deviceDataStream: ReturnType<typeof getDeviceDataStreamServer>;
   performancePush: ReturnType<typeof getPerformancePushServer>;
   failuresPush: ReturnType<typeof getFailuresPushServer>;
   telemetryPush: ReturnType<typeof getTelemetryPushServer>;
 };
+
+export function isProcessWideAdbServerReset(
+  disconnectedDeviceIds: ReadonlySet<string>,
+  pooledDevices: readonly PooledDevice[],
+): boolean {
+  const ownedAndroidEmulators = pooledDevices.filter(device =>
+    device.platform === "android" &&
+    device.avdName !== undefined &&
+    device.androidImage !== undefined &&
+    device.id.startsWith("emulator-"),
+  );
+  return (
+    ownedAndroidEmulators.length > 0 &&
+    ownedAndroidEmulators.every(device => disconnectedDeviceIds.has(device.id))
+  );
+}
 
 /**
  * Main daemon process
@@ -180,6 +198,7 @@ export class Daemon {
   private databaseHealthProbe: DatabaseHealthProbe;
   private startupFailureTracker: StartupFailureTracker;
   private recoverFromDatabaseHealthFailure: DatabaseHealthFailureRecovery;
+  private readonly stopManagedAdbServer: ManagedAdbServerShutdown;
   private observationStreamHealth: ObservationStreamHealth;
   private deviceDataStreamServer: ReturnType<typeof getDeviceDataStreamServer> = null;
   private readonly navigationGraphListenerManagers = new WeakSet<NavigationGraphManager>();
@@ -200,6 +219,7 @@ export class Daemon {
     databaseHealthProbe: DatabaseHealthProbe = new DefaultDatabaseHealthProbe({ timer }),
     recoverFromDatabaseHealthFailure?: DatabaseHealthFailureRecovery,
     recoveryPolicyEnvironment: NodeJS.ProcessEnv = process.env,
+    managedAdbServerShutdown: ManagedAdbServerShutdown = stopManagedAdbServer,
   ) {
     this.options = { ...options };
     this.port = options.port || DEFAULT_DAEMON_PORT;
@@ -213,6 +233,7 @@ export class Daemon {
     this.databaseInitializer = databaseInitializer;
     this.databaseHealthProbe = databaseHealthProbe;
     this.startupFailureTracker = startupFailureTracker;
+    this.stopManagedAdbServer = managedAdbServerShutdown;
     this.recoverFromDatabaseHealthFailure = recoverFromDatabaseHealthFailure ?? (async code => {
       cleanupDaemonFilesSync(this.getDaemonFileCleanupOptions());
       try {
@@ -1404,6 +1425,16 @@ export class Daemon {
         for (const deviceId of disconnectResult.disconnected) {
           missingByDevice.set(deviceId, []);
         }
+        const processWideAdbServerReset = isProcessWideAdbServerReset(
+          new Set(disconnectResult.disconnected),
+          this.devicePool.getAllDevices(),
+        );
+        if (processWideAdbServerReset) {
+          logger.warn(
+            "[DisconnectMonitor] All AutoMobile-owned Android emulators disappeared together; " +
+              "treating this as an ADB server reset and recovering by AVD name",
+          );
+        }
 
         for (const recording of activeRecordings) {
           if (missingByDevice.has(recording.deviceId)) {
@@ -1444,6 +1475,16 @@ export class Daemon {
             forceGenerationAtDisconnect,
           )) {
             continue;
+          }
+
+          if (processWideAdbServerReset && pooledDeviceAtDisconnect) {
+            if (await this.recoverProcessWideAdbServerResetDevice(
+              deviceId,
+              pooledDeviceAtDisconnect,
+              forceGenerationAtDisconnect,
+            )) {
+              continue;
+            }
           }
 
           // Cancel active executions and release the session so the test fails
@@ -1524,6 +1565,28 @@ export class Daemon {
       }
     });
     this.deviceDisconnectMonitor.start();
+  }
+
+  private async recoverProcessWideAdbServerResetDevice(
+    deviceId: string,
+    pooledDevice: PooledDevice,
+    forceGenerationAtDisconnect: number | undefined,
+  ): Promise<boolean> {
+    const recovered = await this.devicePool
+      .recoverSessionBoundAndroidDeviceAfterAdbServerReset(deviceId, pooledDevice);
+    if (!recovered) {
+      return false;
+    }
+
+    this.socketServer?.evictDeviceInputCache(deviceId);
+    this.deviceDisconnectMisses.delete(deviceId);
+    this.deviceDisconnectMissIncarnations.delete(deviceId);
+    this.confirmedDisconnectedDeviceIds.delete(deviceId);
+    if (this.forceDisconnectedDeviceGenerations.get(deviceId) === forceGenerationAtDisconnect) {
+      this.forceDisconnectedDeviceIds.delete(deviceId);
+      this.forceDisconnectedDeviceGenerations.delete(deviceId);
+    }
+    return true;
   }
 
   private async stopRecordingAfterDeviceDisconnect(recordingId: string, deviceId: string): Promise<boolean> {
@@ -2027,6 +2090,7 @@ export class Daemon {
           run: () => this.closeHttpListener(),
         },
         { name: "active device sessions", run: () => this.releaseActiveSessionsForShutdown() },
+        { name: "managed ADB server", run: this.stopManagedAdbServer },
         { name: "daemon files", run: () => cleanupDaemonFiles(this.getDaemonFileCleanupOptions()) },
         {
           name: "database write drain",

--- a/src/daemon/devicePool.ts
+++ b/src/daemon/devicePool.ts
@@ -159,6 +159,11 @@ export interface SystemUiAnrRecoveryHandoff {
   validatePreservedSession(): Promise<void>;
 }
 
+interface AndroidEmulatorRecoveryOptions {
+  preserveSessionId?: string;
+  bypassRecoveryPolicy?: boolean;
+}
+
 /**
  * A process can emit output after readiness. Capture its redacted bounded tail
  * so a later unexpected exit has the same useful evidence as an early launch
@@ -1817,23 +1822,67 @@ export class DevicePool {
 
   private shouldRebootDisconnectedAndroidDevice(
     device: PooledDevice,
+    options: AndroidEmulatorRecoveryOptions = {},
   ): device is PooledDevice & { avdName: string } {
     return (
-      this.getRecoveryPolicy().onLoss &&
+      (options.bypassRecoveryPolicy || this.getRecoveryPolicy().onLoss) &&
       this.isAutoMobileOwnedAndroidVirtualDevice(device) &&
       !this.recoveringAndroidImages.has(device.avdName)
     );
   }
 
+  /**
+   * A process-wide ADB reset can make every emulator disappear at once. Only a
+   * session already bound to an AutoMobile-started AVD can retain its ownership:
+   * the replacement is selected by that recorded AVD name, never by a reused
+   * emulator port or serial.
+   */
+  async recoverSessionBoundAndroidDeviceAfterAdbServerReset(
+    deviceId: string,
+    expectedDevice?: PooledDevice,
+  ): Promise<boolean> {
+    const device = this.devices.get(deviceId);
+    if (
+      !device ||
+      (expectedDevice !== undefined && device !== expectedDevice) ||
+      !device.sessionId ||
+      !this.isAutoMobileOwnedAndroidVirtualDevice(device)
+    ) {
+      return false;
+    }
+
+    const session = this.sessionManager.getSession(device.sessionId);
+    if (
+      !session ||
+      session.assignedDevice !== device.id ||
+      session.platform !== "android"
+    ) {
+      return false;
+    }
+
+    const incidentId = await this.recordEmulatorLossIncident(
+      device.id,
+      "adb-server-reset",
+      undefined,
+      "absent",
+    );
+    return await this.rebootDisconnectedAndroidDevice(device, incidentId, {
+      preserveSessionId: session.sessionId,
+      bypassRecoveryPolicy: true,
+    });
+  }
+
   private async rebootDisconnectedAndroidDevice(
     device: PooledDevice,
     incidentId?: string,
+    options: AndroidEmulatorRecoveryOptions = {},
   ): Promise<boolean> {
-    if (!this.shouldRebootDisconnectedAndroidDevice(device)) {
+    if (!this.shouldRebootDisconnectedAndroidDevice(device, options)) {
       return false;
     }
 
     const avdName = device.avdName;
+    const preservedSessionId = options.preserveSessionId;
     const recoveryDeviceIds = new Set([device.id]);
     const recoveryImage: DeviceInfo = {
       ...device.androidImage,
@@ -1853,7 +1902,7 @@ export class DevicePool {
     let recoveryAttempt = 0;
     try {
       try {
-        await this.stopTrackedEmulatorProcess(device.id);
+        await this.stopAndroidEmulatorForRecovery(device.id, avdName);
       } catch (error) {
         logger.warn(
           `[DevicePool] Could not terminate disconnected emulator ${device.id}: ${error}`,
@@ -1866,6 +1915,9 @@ export class DevicePool {
       if (current && current !== device) {
         await this.completeEmulatorLossRecovery(incidentId, "recovered");
         return true;
+      }
+      if (!this.detachSessionForAndroidRecovery(device, preservedSessionId)) {
+        return false;
       }
       await this.removeDevice(device.id);
       let intentionallyStopped = false;
@@ -1912,7 +1964,14 @@ export class DevicePool {
             await stopCancelledRecovery(ready);
             return;
           }
-          await this.trackStartedDeviceProcess(ready, childProcess);
+          await this.bindRecoveredAndroidDeviceSession(
+            device.id,
+            avdName,
+            preservedSessionId,
+            ready,
+            recoveryImage,
+            childProcess,
+          );
           await this.recordEmulatorLossRecoveryAttempt(incidentId, {
             attempt,
             outcome: "succeeded",
@@ -1952,6 +2011,59 @@ export class DevicePool {
     }
   }
 
+  private async stopAndroidEmulatorForRecovery(deviceId: string, avdName: string): Promise<void> {
+    const hadTrackedProcess = this.startedDeviceProcesses.has(deviceId);
+    await this.stopTrackedEmulatorProcess(deviceId);
+    if (!hadTrackedProcess) {
+      await this.stopDiscoveredEmulatorByAvdName(avdName);
+    }
+  }
+
+  private detachSessionForAndroidRecovery(
+    device: PooledDevice,
+    preservedSessionId: string | undefined,
+  ): boolean {
+    if (!preservedSessionId) {
+      return true;
+    }
+    if (this.sessionManager.getSession(preservedSessionId)?.assignedDevice !== device.id) {
+      return false;
+    }
+    // Keep the session manager's old routing until the ready replacement is
+    // proven. removeDevice requires an unassigned pool entry.
+    device.sessionId = null;
+    device.status = "idle";
+    return true;
+  }
+
+  private async bindRecoveredAndroidDeviceSession(
+    previousDeviceId: string,
+    avdName: string,
+    preservedSessionId: string | undefined,
+    ready: BootedDevice,
+    recoveryImage: DeviceInfo,
+    childProcess: ChildProcess | null,
+  ): Promise<void> {
+    if (!preservedSessionId) {
+      await this.trackStartedDeviceProcess(ready, childProcess);
+      return;
+    }
+    if (this.sessionManager.getSession(preservedSessionId)?.assignedDevice !== previousDeviceId) {
+      throw new ActionableError(
+        `Session '${preservedSessionId}' changed while Android AVD '${avdName}' was recovering.`,
+      );
+    }
+    await this.bindOrReuseDeviceSession(
+      preservedSessionId,
+      ready.deviceId,
+      "android",
+      recoveryImage,
+      childProcess,
+      ready,
+      true,
+    );
+  }
+
   private consumeIntentionalShutdown(deviceIds: ReadonlySet<string>): boolean {
     // Recovery cancellation is deliberately serial-scoped: a user's kill of a
     // serial cancels a pool reboot of that same serial regardless of incarnation
@@ -1969,6 +2081,27 @@ export class DevicePool {
     this.startedDeviceProcesses.delete(deviceId);
     this.startedDeviceProcessOutput.delete(deviceId);
     await this.stopEmulatorProcess(childProcess);
+  }
+
+  private async stopDiscoveredEmulatorByAvdName(avdName: string): Promise<void> {
+    try {
+      const booted = await this.deviceManager.getBootedDevices("android");
+      const matchingAvd = booted.find(device =>
+        device.platform === "android" && device.name === avdName,
+      );
+      if (!matchingAvd) {
+        return;
+      }
+      await this.deviceManager.killDevice(matchingAvd);
+      logger.info(`[DevicePool] Stopped untracked Android emulator ${avdName} before recovery`);
+    } catch (error) {
+      // ADB may still be rebuilding after a process-wide kill-server. The
+      // bounded launch retries below make another recovery attempt without
+      // ever selecting an emulator by its recycled serial.
+      logger.warn(
+        `[DevicePool] Could not stop untracked Android emulator ${avdName} before recovery: ${error}`,
+      );
+    }
   }
 
   private async stopEmulatorProcess(childProcess: ChildProcess | null | undefined): Promise<void> {

--- a/src/daemon/emulatorLossIncident.ts
+++ b/src/daemon/emulatorLossIncident.ts
@@ -9,7 +9,8 @@ export const DEFAULT_MAX_RETAINED_EMULATOR_LOSS_INCIDENTS = 50;
 export type EmulatorLossDetectionPath =
   | "watched-process-exit"
   | "device-discovery-miss"
-  | "adb-transport-failure";
+  | "adb-transport-failure"
+  | "adb-server-reset";
 
 export type EmulatorRecoveryOutcome = "recovered" | "exhausted" | "not-attempted";
 

--- a/src/daemon/mcpRequestTimeout.ts
+++ b/src/daemon/mcpRequestTimeout.ts
@@ -1,5 +1,10 @@
 import type { DaemonRequest } from "./types";
-import { MAX_DEVICE_READY_TIMEOUT_MS, START_DEVICE_MCP_TIMEOUT_OVERHEAD_MS } from "../utils/deviceTimeouts";
+import {
+  DEFAULT_DEVICE_READY_TIMEOUT_MS,
+  MAX_DEVICE_READY_TIMEOUT_MS,
+  START_DEVICE_MCP_TIMEOUT_OVERHEAD_MS,
+} from "../utils/deviceTimeouts";
+import { DEFAULT_RUNNER_READINESS_TIMEOUT_MS } from "../utils/runnerReadinessConfig";
 
 export { START_DEVICE_MCP_TIMEOUT_OVERHEAD_MS };
 
@@ -16,7 +21,7 @@ export const DEFAULT_MCP_REQUEST_TIMEOUT_MS = 30_000;
 export const MIN_EXECUTE_PLAN_MCP_TIMEOUT_MS = 600_000;
 
 /**
- * Floor for `startDevice` — cold-booting an emulator can take 45-90s depending on
+ * Floor for device preparation — cold-booting an emulator can take 45-90s depending on
  * host performance (especially under emulation/Rosetta).
  */
 export const MIN_START_DEVICE_MCP_TIMEOUT_MS = 180_000;
@@ -83,6 +88,8 @@ function resolveToolTimeoutFloorMs(toolName: string | undefined): number | undef
   switch (toolName) {
     case "executePlan":
       return MIN_EXECUTE_PLAN_MCP_TIMEOUT_MS;
+    case "getAndroid":
+    case "getApple":
     case "startDevice":
       return MIN_START_DEVICE_MCP_TIMEOUT_MS;
     case "launchApp":
@@ -118,14 +125,17 @@ function positiveFiniteNumber(value: unknown): number | undefined {
     : undefined;
 }
 
-function resolveStartDeviceToolBudgetMs(request: DaemonRequest): number | undefined {
-  if (request.method !== "tools/call" || request.params?.name !== "startDevice") {
-    return undefined;
-  }
-  const argumentsRecord = asRecord(request.params?.arguments);
-  if (!argumentsRecord) {
-    return undefined;
-  }
+function resolveNamedDevicePreparationBudgetMs(argumentsRecord: Record<string, unknown>): number {
+  const bootTimeoutMs =
+    positiveFiniteNumber(argumentsRecord.bootTimeoutMs) ?? DEFAULT_DEVICE_READY_TIMEOUT_MS;
+  const automationReadyTimeoutMs =
+    positiveFiniteNumber(argumentsRecord.automationReadyTimeoutMs) ??
+    DEFAULT_RUNNER_READINESS_TIMEOUT_MS;
+  return Math.min(bootTimeoutMs + automationReadyTimeoutMs, MAX_DEVICE_READY_TIMEOUT_MS) +
+    START_DEVICE_MCP_TIMEOUT_OVERHEAD_MS;
+}
+
+function resolveLegacyStartDeviceBudgetMs(argumentsRecord: Record<string, unknown>): number | undefined {
   const legacyTimeoutMs = asRecord(argumentsRecord.device)?.timeoutMs;
   // Match startDeviceSchema's legacy normalization: an explicit top-level value
   // wins over the nested device payload.
@@ -137,6 +147,25 @@ function resolveStartDeviceToolBudgetMs(request: DaemonRequest): number | undefi
     START_DEVICE_MCP_TIMEOUT_OVERHEAD_MS;
 }
 
+function resolveDevicePreparationToolBudgetMs(request: DaemonRequest): number | undefined {
+  if (request.method !== "tools/call") {
+    return undefined;
+  }
+  const argumentsRecord = asRecord(request.params?.arguments);
+  if (!argumentsRecord) {
+    return undefined;
+  }
+  switch (request.params?.name) {
+    case "getAndroid":
+    case "getApple":
+      return resolveNamedDevicePreparationBudgetMs(argumentsRecord);
+    case "startDevice":
+      return resolveLegacyStartDeviceBudgetMs(argumentsRecord);
+    default:
+      return undefined;
+  }
+}
+
 export function resolveMcpRequestTimeoutMs(request: DaemonRequest): number {
   const raw = request.timeoutMs;
   const base =
@@ -146,6 +175,6 @@ export function resolveMcpRequestTimeoutMs(request: DaemonRequest): number {
   const floor = request.method === "tools/call"
     ? resolveToolTimeoutFloorMs(request.params?.name)
     : undefined;
-  const startDeviceBudget = resolveStartDeviceToolBudgetMs(request);
-  return Math.max(base, floor ?? 0, startDeviceBudget ?? 0);
+  const devicePreparationBudget = resolveDevicePreparationToolBudgetMs(request);
+  return Math.max(base, floor ?? 0, devicePreparationBudget ?? 0);
 }

--- a/src/index.ts
+++ b/src/index.ts
@@ -114,6 +114,7 @@ async function main() {
   const { IOSCtrlProxyBuilder } = await import("./utils/IOSCtrlProxyBuilder");
   const { IOSCtrlProxyManager } = await import("./utils/IOSCtrlProxyManager");
   const { cleanupDaemonChildProcesses } = await import("./daemon/childProcessCleanup");
+  const { stopManagedAdbServer } = await import("./utils/android-cmdline-tools/AdbServerLifecycle");
   startupBenchmark.endPhase("moduleImports");
 
   const { startVideoRecordingSocketServer, stopVideoRecordingSocketServer } =
@@ -138,6 +139,14 @@ async function main() {
           run: async () => {
             if (directModeActive) {
               await cleanupDaemonChildProcesses();
+            }
+          },
+        },
+        {
+          name: "direct-mode managed ADB server",
+          run: async () => {
+            if (directModeActive) {
+              await stopManagedAdbServer();
             }
           },
         },

--- a/src/server/deviceTools.ts
+++ b/src/server/deviceTools.ts
@@ -44,6 +44,7 @@ import {
   SystemUiAnrRecoveryRequiredError,
 } from "../utils/RunnerReadinessService";
 import {
+  DEFAULT_RUNNER_READINESS_TIMEOUT_MS,
   MAX_RUNNER_READINESS_TIMEOUT_MS,
   MIN_RUNNER_READINESS_TIMEOUT_MS,
 } from "../utils/runnerReadinessConfig";
@@ -113,6 +114,41 @@ export const startDeviceSchema = z.preprocess(input => {
     ...parsed,
   };
 }, startDeviceParametersSchema);
+
+const devicePreparationTimeoutSchema = z.object({
+  bootTimeoutMs: z.number()
+    .int()
+    .positive()
+    .max(MAX_DEVICE_READY_TIMEOUT_MS)
+    .optional()
+    .describe("Maximum time to find, recover, or boot the device operating system"),
+  automationReadyTimeoutMs: z.number()
+    .int()
+    .min(MIN_RUNNER_READINESS_TIMEOUT_MS)
+    .max(MAX_RUNNER_READINESS_TIMEOUT_MS)
+    .optional()
+    .describe("Maximum time to install, update, start, and verify the automation runner"),
+}).strict().superRefine((value, context) => {
+  const totalTimeoutMs =
+    (value.bootTimeoutMs ?? DEFAULT_DEVICE_READY_TIMEOUT_MS) +
+    (value.automationReadyTimeoutMs ?? DEFAULT_RUNNER_READINESS_TIMEOUT_MS);
+  if (totalTimeoutMs > MAX_DEVICE_READY_TIMEOUT_MS) {
+    context.addIssue({
+      code: "custom",
+      message:
+        `bootTimeoutMs + automationReadyTimeoutMs must be <= ${MAX_DEVICE_READY_TIMEOUT_MS}`,
+      path: ["bootTimeoutMs"],
+    });
+  }
+});
+
+export const getAndroidSchema = devicePreparationTimeoutSchema.extend({
+  avdName: z.string().min(1).describe("Configured Android Virtual Device name"),
+});
+
+export const getAppleSchema = devicePreparationTimeoutSchema.extend({
+  udid: z.string().min(1).describe("iOS Simulator UDID"),
+});
 
 export const killDeviceSchema = z.object({
   device: z.object({
@@ -207,8 +243,39 @@ export interface StartDeviceArgs {
   __mcpSessionId?: string;
 }
 
+export interface GetAndroidArgs {
+  avdName: string;
+  bootTimeoutMs?: number;
+  automationReadyTimeoutMs?: number;
+}
+
+export interface GetAppleArgs {
+  udid: string;
+  bootTimeoutMs?: number;
+  automationReadyTimeoutMs?: number;
+}
+
 export interface KillDeviceArgs {
   device: BootedDevice;
+}
+
+function deviceIdentityPayload(device: BootedDevice, sourceImage?: DeviceInfo): Record<string, unknown> {
+  if (device.platform === "android") {
+    const portMatch = /^emulator-(\d+)$/.exec(device.deviceId);
+    return {
+      platform: "android",
+      avdName: sourceImage?.platform === "android" ? sourceImage.name : device.name,
+      adbSerial: device.deviceId,
+      emulatorConsolePort: portMatch ? Number(portMatch[1]) : null,
+      adbTransportId: device.transportId ?? null,
+    };
+  }
+
+  return {
+    platform: "ios",
+    simulatorUdid: device.deviceId,
+    simulatorName: device.name,
+  };
 }
 
 export interface ListDeviceImagesArgs {
@@ -1629,9 +1696,9 @@ export function registerDeviceTools() {
         `  - automobile:devices/images/android - Android AVDs\n` +
         `  - automobile:devices/images/ios - iOS simulator runtimes\n\n` +
         "WORKFLOW:\n" +
-        "  1. Read 'automobile:devices/booted' to see running devices and get deviceId\n" +
-        "  2. Use deviceId with other resources (e.g., automobile:devices/{deviceId}/apps)\n" +
-        "  3. To start a new device, read 'automobile:devices/images' then use startDevice tool",
+        "  1. Read 'automobile:devices/images/android' to select an Android AVD by name\n" +
+        "  2. Read 'automobile:devices/images/ios' to select an iOS simulator by UDID\n" +
+        "  3. Call getAndroid or getApple, then use its returned sessionId for automation",
       resources: [
         BOOTED_DEVICE_RESOURCE_URIS.ALL_BOOTED,
         `${BOOTED_DEVICE_RESOURCE_URIS.ALL_BOOTED}/android`,
@@ -1644,27 +1711,25 @@ export function registerDeviceTools() {
     });
   };
 
-  // Start device handler — matches criteria against booted devices and images
-  const startDeviceHandler = async (
+  type DevicePreparationBudgets = {
+    bootTimeoutMs: number;
+    automationReadyTimeoutMs: number;
+    automationDeadlineMs: number;
+    operationName: string;
+    androidAvdName?: string;
+  };
+
+  const prepareDevice = async (
     args: StartDeviceArgs,
+    budgets: DevicePreparationBudgets,
     progress?: ProgressCallback,
     signal?: AbortSignal,
   ) => {
-    const internalSessionId = args.__mcpSessionId;
-    args = {
-      ...startDeviceSchema.parse(args),
-      __mcpSessionId: internalSessionId,
-    };
     const perf = createPerformanceTracker(true);
-    perf.serial("startDevice");
+    perf.serial(budgets.operationName);
     const deps = getDeviceToolsDependencies();
     const deviceUtils = deps.deviceManagerFactory();
-    const totalTimeoutMs = args.timeoutMs ?? DEFAULT_DEVICE_READY_TIMEOUT_MS;
-    // An explicit timeoutMs is an end-to-end startDevice contract. Preserve it
-    // for runner readiness unless the caller deliberately supplies a narrower
-    // phase-specific budget.
-    const readinessTimeoutMs = resolveRunnerReadinessTimeoutMs(args);
-    const totalDeadlineMs = deps.timer.now() + totalTimeoutMs;
+    const bootDeadlineMs = deps.timer.now() + budgets.bootTimeoutMs;
     const requestedIdentity = describeStartDeviceRequest(args);
     let boot: DeviceBootResult | undefined;
     let ownershipTransferred = false;
@@ -1684,12 +1749,27 @@ export function registerDeviceTools() {
       });
       perf.startOperation("bootDevice");
       boot = await bootService.boot(
-        { ...args, totalDeadlineMs, signal },
+        {
+          ...args,
+          timeoutMs: budgets.bootTimeoutMs,
+          totalDeadlineMs: bootDeadlineMs,
+          signal,
+        },
         progress ? { report: progress } : undefined,
       );
       perf.endOperation("bootDevice");
       validateBootIdentity(args, boot.device, boot.source, boot.sourceImage);
       validatePooledDeviceMapping(boot.device, requestedIdentity);
+      // A warm AVD has no cold-boot source image, but its explicit getAndroid
+      // identifier is still the stable identity needed for later recovery.
+      let sourceImage = boot.sourceImage ?? (budgets.androidAvdName
+        ? {
+          name: budgets.androidAvdName,
+          platform: "android" as const,
+          isRunning: true,
+          source: "local" as const,
+        }
+        : undefined);
       const daemonState = DaemonState.getInstance();
       await reserveInitialDeviceForReadiness(
         daemonState,
@@ -1709,8 +1789,8 @@ export function registerDeviceTools() {
           bootService,
           deviceUtils,
           daemonState,
-          totalDeadlineMs,
-          readinessTimeoutMs,
+          totalDeadlineMs: budgets.automationDeadlineMs,
+          readinessTimeoutMs: budgets.automationReadyTimeoutMs,
           timer: deps.timer,
           signal,
           progress,
@@ -1724,6 +1804,7 @@ export function registerDeviceTools() {
       preservedSessionId = readinessResult.preservedSessionId;
       validatePreservedSession = readinessResult.validatePreservedSession;
       retireRecoveredReplacement = readinessResult.retireReplacement;
+      sourceImage = boot.sourceImage ?? sourceImage;
       // Re-check under the later binding lock because pool identity can change
       // while runner setup is in flight.
       validatePooledDeviceMapping(boot.device, requestedIdentity);
@@ -1739,7 +1820,7 @@ export function registerDeviceTools() {
       const sessionId = preservedSessionId ?? await bindBootedDeviceSession(
         boot.device,
         args,
-        boot.sourceImage,
+        sourceImage,
         boot.processHandle,
         new Set(releaseReadinessReservations.map((reservation) => reservation.owner)),
       );
@@ -1752,6 +1833,7 @@ export function registerDeviceTools() {
         perf,
         sessionId,
         boot.processId,
+        sourceImage,
       );
     } catch (error) {
       perf.end();
@@ -1767,6 +1849,101 @@ export function registerDeviceTools() {
         await releaseReservation();
       }
     }
+  };
+
+  // Compatibility implementation. New callers use getAndroid/getApple so their
+  // platform identity and readiness budgets are explicit.
+  const startDeviceHandler = async (
+    rawArgs: StartDeviceArgs,
+    progress?: ProgressCallback,
+    signal?: AbortSignal,
+  ) => {
+    const internalSessionId = rawArgs.__mcpSessionId;
+    const args = {
+      ...startDeviceSchema.parse(rawArgs),
+      __mcpSessionId: internalSessionId,
+    };
+    const totalTimeoutMs = args.timeoutMs ?? DEFAULT_DEVICE_READY_TIMEOUT_MS;
+    return await prepareDevice(
+      args,
+      {
+        bootTimeoutMs: totalTimeoutMs,
+        automationReadyTimeoutMs: resolveRunnerReadinessTimeoutMs(args),
+        automationDeadlineMs: getDeviceToolsDependencies().timer.now() + totalTimeoutMs,
+        operationName: "startDevice",
+      },
+      progress,
+      signal,
+    );
+  };
+
+  const getAndroidHandler = async (
+    rawArgs: GetAndroidArgs & Record<string, unknown>,
+    progress?: ProgressCallback,
+    signal?: AbortSignal,
+  ) => {
+    const { __mcpSessionId } = rawArgs;
+    const externalArgs = { ...rawArgs };
+    delete externalArgs.__mcpSessionId;
+    delete externalArgs.__executionId;
+    delete externalArgs.__executionStartTime;
+    const args = getAndroidSchema.parse(externalArgs);
+    const bootTimeoutMs = args.bootTimeoutMs ?? DEFAULT_DEVICE_READY_TIMEOUT_MS;
+    const automationReadyTimeoutMs =
+      args.automationReadyTimeoutMs ?? DEFAULT_RUNNER_READINESS_TIMEOUT_MS;
+    const startedAtMs = getDeviceToolsDependencies().timer.now();
+    return await prepareDevice(
+      {
+        platform: "android",
+        name: args.avdName,
+        preferRunning: true,
+        createIfMissing: false,
+        __mcpSessionId: typeof __mcpSessionId === "string" ? __mcpSessionId : undefined,
+      },
+      {
+        bootTimeoutMs,
+        automationReadyTimeoutMs,
+        automationDeadlineMs: startedAtMs + bootTimeoutMs + automationReadyTimeoutMs,
+        operationName: "getAndroid",
+        androidAvdName: args.avdName,
+      },
+      progress,
+      signal,
+    );
+  };
+
+  const getAppleHandler = async (
+    rawArgs: GetAppleArgs & Record<string, unknown>,
+    progress?: ProgressCallback,
+    signal?: AbortSignal,
+  ) => {
+    const { __mcpSessionId } = rawArgs;
+    const externalArgs = { ...rawArgs };
+    delete externalArgs.__mcpSessionId;
+    delete externalArgs.__executionId;
+    delete externalArgs.__executionStartTime;
+    const args = getAppleSchema.parse(externalArgs);
+    const bootTimeoutMs = args.bootTimeoutMs ?? DEFAULT_DEVICE_READY_TIMEOUT_MS;
+    const automationReadyTimeoutMs =
+      args.automationReadyTimeoutMs ?? DEFAULT_RUNNER_READINESS_TIMEOUT_MS;
+    const startedAtMs = getDeviceToolsDependencies().timer.now();
+    return await prepareDevice(
+      {
+        platform: "ios",
+        deviceId: args.udid,
+        preferRunning: true,
+        createIfMissing: false,
+        __mcpSessionId: typeof __mcpSessionId === "string" ? __mcpSessionId : undefined,
+      },
+      {
+        bootTimeoutMs,
+        automationReadyTimeoutMs,
+        automationDeadlineMs: startedAtMs + bootTimeoutMs + automationReadyTimeoutMs,
+        operationName: "getApple",
+      },
+      progress,
+      signal,
+    );
   };
 
 
@@ -1828,6 +2005,7 @@ export function registerDeviceTools() {
     perf: ReturnType<typeof createPerformanceTracker>,
     sessionId: string,
     processId?: number,
+    sourceImage?: DeviceInfo,
   ) {
     perf.end();
     const timing = perf.getTimings();
@@ -1851,6 +2029,7 @@ export function registerDeviceTools() {
     return createJSONToolResponse({
       message: `${device.platform} '${device.name}' is ready (${source})`,
       ...result,
+      deviceIdentity: deviceIdentityPayload(device, sourceImage),
     });
   }
 
@@ -1959,7 +2138,29 @@ export function registerDeviceTools() {
     listDevicesHandler
   );
 
-  ToolRegistry.register("startDevice", "Start device", startDeviceSchema, startDeviceHandler, { supportsProgress: true });
+  ToolRegistry.register(
+    "getAndroid",
+    "Find or recover an Android AVD and prepare it for automation.",
+    getAndroidSchema,
+    getAndroidHandler,
+    { supportsProgress: true },
+  );
+
+  ToolRegistry.register(
+    "getApple",
+    "Find or recover an iOS Simulator and prepare it for automation.",
+    getAppleSchema,
+    getAppleHandler,
+    { supportsProgress: true },
+  );
+
+  ToolRegistry.register(
+    "startDevice",
+    "Start device",
+    startDeviceSchema,
+    startDeviceHandler,
+    { supportsProgress: true, hidden: true },
+  );
 
   ToolRegistry.register(
     "killDevice",

--- a/src/server/toolRegistry.ts
+++ b/src/server/toolRegistry.ts
@@ -112,6 +112,7 @@ function preservesPlanCapabilityAuthorization(
 interface ToolRegistrationOptions {
   supportsProgress?: boolean;
   debugOnly?: boolean;
+  hidden?: boolean;
   outputSchema?: any;
   /** Accept the plan executor's internal coordination namespace. */
   acceptsPlanLockNamespace?: boolean;
@@ -153,6 +154,7 @@ export interface RegisteredTool {
   requiresDevice?: boolean;
   deviceAwareHandler?: DeviceAwareToolHandler;
   debugOnly?: boolean;
+  hidden?: boolean;
   embeddedSdkOnly?: boolean;
   planExecutable?: boolean;
   planOnly?: boolean;
@@ -973,6 +975,7 @@ export class ToolRegistryClass {
       supportsProgress: options.supportsProgress ?? false,
       requiresDevice: false,
       debugOnly: options.debugOnly ?? false,
+      hidden: options.hidden ?? false,
       embeddedSdkOnly: false,
       acceptsPlanLockNamespace: options.acceptsPlanLockNamespace ?? false,
       outputSchema: options.outputSchema,
@@ -1141,9 +1144,9 @@ export class ToolRegistryClass {
   getAllTools(options: ToolListingOptions = {}): RegisteredTool[] {
     const tools = Array.from(this.tools.values());
     if (options.includeUnavailable) {
-      return tools;
+      return tools.filter(tool => !tool.hidden);
     }
-    return tools.filter(tool => this.isToolAvailable(tool));
+    return tools.filter(tool => !tool.hidden && this.isToolAvailable(tool));
   }
 
   // Get a specific tool by name
@@ -1351,7 +1354,7 @@ export class ToolRegistryClass {
     this.trackServer(server);
 
     this.tools.forEach(tool => {
-      if (!this.isToolAvailable(tool)) {
+      if (tool.hidden || !this.isToolAvailable(tool)) {
         return;
       }
 

--- a/src/utils/android-cmdline-tools/AdbServerLifecycle.ts
+++ b/src/utils/android-cmdline-tools/AdbServerLifecycle.ts
@@ -1,0 +1,60 @@
+import type { AdbClientFactory } from "./AdbClientFactory";
+import { defaultAdbClientFactory } from "./AdbClientFactory";
+import { defaultTimer, type Timer } from "../SystemTimer";
+
+export const MANAGED_ADB_SERVER_ENV = "AUTOMOBILE_MANAGED_ADB_SERVER";
+export const LEGACY_MANAGED_ADB_SERVER_ENV = "AUTO_MOBILE_MANAGED_ADB_SERVER";
+export const MANAGED_ADB_SERVER_SHUTDOWN_TIMEOUT_MS = 5_000;
+
+export interface ManagedAdbServerShutdownDependencies {
+  readonly adbFactory?: AdbClientFactory;
+  readonly environment?: NodeJS.ProcessEnv;
+  readonly timer?: Timer;
+  readonly shutdownTimeoutMs?: number;
+}
+
+/**
+ * Managed mode is an explicit process-scope ownership claim. It is off by
+ * default so that routine client shutdowns never stop a shared local server.
+ */
+export function isManagedAdbServerEnabled(environment: NodeJS.ProcessEnv = process.env): boolean {
+  const value = environment[MANAGED_ADB_SERVER_ENV] ?? environment[LEGACY_MANAGED_ADB_SERVER_ENV];
+  return value?.trim().toLowerCase() === "1" || value?.trim().toLowerCase() === "true";
+}
+
+export async function stopManagedAdbServer(
+  dependencies: ManagedAdbServerShutdownDependencies = {},
+): Promise<void> {
+  const environment = dependencies.environment ?? process.env;
+  if (!isManagedAdbServerEnabled(environment)) {
+    return;
+  }
+
+  const timeoutMs = dependencies.shutdownTimeoutMs ?? MANAGED_ADB_SERVER_SHUTDOWN_TIMEOUT_MS;
+  const timer = dependencies.timer ?? defaultTimer;
+  const controller = new AbortController();
+  const adb = (dependencies.adbFactory ?? defaultAdbClientFactory).create();
+  let timeoutHandle: NodeJS.Timeout | undefined;
+  const timeoutMessage = `Managed ADB server shutdown timed out after ${timeoutMs}ms`;
+  const timeout = new Promise<never>((_, reject) => {
+    timeoutHandle = timer.setTimeout(() => {
+      controller.abort(new Error(timeoutMessage));
+      reject(new Error(timeoutMessage));
+    }, timeoutMs);
+  });
+
+  try {
+    await Promise.race([
+      adb.execute(["kill-server"], {
+        timeoutMs,
+        noRetry: true,
+        signal: controller.signal,
+      }),
+      timeout,
+    ]);
+  } finally {
+    if (timeoutHandle !== undefined) {
+      timer.clearTimeout(timeoutHandle);
+    }
+  }
+}

--- a/test/daemon/adbServerResetDetection.test.ts
+++ b/test/daemon/adbServerResetDetection.test.ts
@@ -1,0 +1,45 @@
+import { describe, expect, test } from "bun:test";
+import { isProcessWideAdbServerReset } from "../../src/daemon/daemon";
+import type { PooledDevice } from "../../src/daemon/devicePool";
+
+function ownedAndroidEmulator(id: string): PooledDevice {
+  return {
+    id,
+    name: `Unknown (${id})`,
+    platform: "android",
+    sessionId: "session-1",
+    status: "busy",
+    lastUsedAt: 0,
+    assignmentCount: 1,
+    errorCount: 0,
+    avdName: "Pixel_8_API_35",
+    androidImage: {
+      name: "Pixel_8_API_35",
+      platform: "android",
+      isRunning: true,
+      source: "local",
+    },
+    incarnation: 1,
+  };
+}
+
+describe("ADB server reset detection", () => {
+  test("requires every AutoMobile-owned Android emulator to disappear together", () => {
+    const first = ownedAndroidEmulator("emulator-5554");
+    const second = ownedAndroidEmulator("emulator-5556");
+
+    expect(isProcessWideAdbServerReset(new Set([first.id, second.id]), [first, second])).toBe(true);
+    expect(isProcessWideAdbServerReset(new Set([first.id]), [first, second])).toBe(false);
+  });
+
+  test("does not infer an ADB reset from physical Android devices", () => {
+    const physical: PooledDevice = {
+      ...ownedAndroidEmulator("physical-serial"),
+      id: "physical-serial",
+      avdName: undefined,
+      androidImage: undefined,
+    };
+
+    expect(isProcessWideAdbServerReset(new Set([physical.id]), [physical])).toBe(false);
+  });
+});

--- a/test/daemon/adbServerResetRecovery.test.ts
+++ b/test/daemon/adbServerResetRecovery.test.ts
@@ -1,0 +1,126 @@
+import { describe, expect, test } from "bun:test";
+import type { ChildProcess } from "node:child_process";
+import { DevicePool } from "../../src/daemon/devicePool";
+import { SessionManager } from "../../src/daemon/sessionManager";
+import type { BootedDevice, DeviceInfo } from "../../src/models";
+import { DefaultRetryExecutor } from "../../src/utils/retry/RetryExecutor";
+import { FakeDeviceManager } from "../fakes/FakeDeviceManager";
+import { FakeDeviceSessionPersistence } from "../fakes/FakeDeviceSessionPersistence";
+import { FakeInstalledAppsRepository } from "../fakes/FakeInstalledAppsRepository";
+import { FakeTimer } from "../fakes/FakeTimer";
+
+describe("ADB server reset session recovery", () => {
+  test("rebinds a live session only after restarting its recorded AVD", async () => {
+    class ReplacementSerialDeviceManager extends FakeDeviceManager {
+      readonly killedDeviceIds: string[] = [];
+
+      override async startDevice(device: DeviceInfo): Promise<ChildProcess> {
+        this.startedDevices.push(device);
+        this.bootedDevices = [{
+          name: device.name,
+          platform: "android",
+          deviceId: "emulator-5560",
+        }];
+        return { pid: 0 } as ChildProcess;
+      }
+
+      override async killDevice(device: BootedDevice): Promise<void> {
+        this.killedDeviceIds.push(device.deviceId);
+        this.bootedDevices = [];
+      }
+
+      override async waitForDeviceReady(device: DeviceInfo): Promise<BootedDevice> {
+        return {
+          name: device.name,
+          platform: "android",
+          deviceId: "emulator-5560",
+        };
+      }
+    }
+
+    const timer = new FakeTimer();
+    const sessionManager = new SessionManager(timer, new FakeDeviceSessionPersistence());
+    const manager = new ReplacementSerialDeviceManager();
+    const pool = new DevicePool(
+      sessionManager,
+      "daemon-session",
+      timer,
+      new FakeInstalledAppsRepository(),
+      manager,
+      new DefaultRetryExecutor(timer),
+    );
+    const original: BootedDevice = {
+      platform: "android",
+      name: "Pixel_8_API_35",
+      deviceId: "emulator-5554",
+    };
+    const image: DeviceInfo = {
+      name: "Pixel_8_API_35",
+      platform: "android",
+      isRunning: true,
+      source: "local",
+    };
+    manager.bootedDevices = [original];
+    await pool.addDevice(original, image);
+    await pool.bindOrReuseDeviceSession(
+      "session-1",
+      original.deviceId,
+      "android",
+      image,
+      undefined,
+      original,
+    );
+
+    try {
+      await expect(
+        pool.recoverSessionBoundAndroidDeviceAfterAdbServerReset(
+          original.deviceId,
+          pool.getDevice(original.deviceId) ?? undefined,
+        ),
+      ).resolves.toBe(true);
+
+      expect(manager.killedDeviceIds).toEqual([original.deviceId]);
+      expect(manager.startedDevices.map(device => device.name)).toEqual(["Pixel_8_API_35"]);
+      expect(pool.getDevice(original.deviceId)).toBeNull();
+      expect(pool.getDevice("emulator-5560")).toMatchObject({
+        avdName: "Pixel_8_API_35",
+        sessionId: "session-1",
+        status: "busy",
+      });
+      expect(sessionManager.getSession("session-1")?.assignedDevice).toBe("emulator-5560");
+    } finally {
+      sessionManager.stopCleanupTimer();
+    }
+  });
+
+  test("refuses to rebind when the original AVD identity was never recorded", async () => {
+    const timer = new FakeTimer();
+    const sessionManager = new SessionManager(timer, new FakeDeviceSessionPersistence());
+    const manager = new FakeDeviceManager();
+    const pool = new DevicePool(
+      sessionManager,
+      "daemon-session",
+      timer,
+      new FakeInstalledAppsRepository(),
+      manager,
+      new DefaultRetryExecutor(timer),
+    );
+    const device: BootedDevice = {
+      platform: "android",
+      name: "Pixel 8",
+      deviceId: "emulator-5554",
+    };
+    manager.bootedDevices = [device];
+    await pool.initializeWithDevices([device]);
+    await pool.bindOrReuseDeviceSession("session-1", device.deviceId, "android");
+
+    try {
+      await expect(
+        pool.recoverSessionBoundAndroidDeviceAfterAdbServerReset(device.deviceId),
+      ).resolves.toBe(false);
+      expect(sessionManager.getSession("session-1")?.assignedDevice).toBe(device.deviceId);
+    } finally {
+      sessionManager.stopCleanupTimer();
+    }
+  });
+});

--- a/test/daemon/daemonShutdownSessionRelease.test.ts
+++ b/test/daemon/daemonShutdownSessionRelease.test.ts
@@ -122,6 +122,53 @@ describe("Daemon shutdown session release (issue #5303)", () => {
     }
   });
 
+  test("stops a managed ADB server after releasing active sessions", async () => {
+    const timer = new FakeTimer();
+    const repository = new FakeDeviceSessionRepository();
+    const daemon = new Daemon(
+      {},
+      new FakeInstalledAppsRepository(),
+      timer,
+      repository as unknown as DeviceSessionRepository,
+      undefined,
+      undefined,
+      undefined,
+      undefined,
+      undefined,
+      process.env,
+      async () => {
+        repository.events.push("stopManagedAdbServer");
+      },
+    );
+    const sessionManager = daemon.getSessionManager();
+    const devicePool = daemon.getDevicePool();
+    const loggerCloseSpy = spyOn(logger, "closeAfterFlush").mockResolvedValue(undefined);
+    const closeDatabaseSpy = spyOn(databaseModule, "closeDatabase").mockImplementation(async () => {
+      repository.events.push("closeDatabase");
+    });
+
+    try {
+      await devicePool.initializeWithDevices([{
+        name: "Managed Android",
+        deviceId: "managed-physical-device",
+        platform: "android",
+      }]);
+      await devicePool.assignDeviceToSession("managed-adb-session", "android");
+
+      await daemon.stop();
+
+      expect(sessionManager.getSession("managed-adb-session")).toBeNull();
+      expect(repository.events).toEqual([
+        "markReleased",
+        "stopManagedAdbServer",
+        "closeDatabase",
+      ]);
+    } finally {
+      loggerCloseSpy.mockRestore();
+      closeDatabaseSpy.mockRestore();
+    }
+  });
+
   test("continues releasing other sessions when one teardown fails", async () => {
     const timer = new FakeTimer();
     const repository = new FakeDeviceSessionRepository();

--- a/test/daemon/mcpRequestTimeout.test.ts
+++ b/test/daemon/mcpRequestTimeout.test.ts
@@ -164,6 +164,43 @@ describe("resolveMcpRequestTimeoutMs", () => {
     );
   });
 
+  test("keeps transport alive for getAndroid's named preparation budgets", () => {
+    const request: DaemonRequest = {
+      id: "1",
+      type: "mcp_request",
+      method: "tools/call",
+      params: {
+        name: "getAndroid",
+        arguments: { bootTimeoutMs: 300_000, automationReadyTimeoutMs: 45_000 },
+      },
+    };
+
+    expect(resolveMcpRequestTimeoutMs(request)).toBe(
+      345_000 + START_DEVICE_MCP_TIMEOUT_OVERHEAD_MS,
+    );
+  });
+
+  test("caps getApple's combined preparation budgets below the daemon socket idle timeout", () => {
+    const request: DaemonRequest = {
+      id: "1",
+      type: "mcp_request",
+      method: "tools/call",
+      params: {
+        name: "getApple",
+        arguments: {
+          bootTimeoutMs: Number.MAX_SAFE_INTEGER,
+          automationReadyTimeoutMs: Number.MAX_SAFE_INTEGER,
+        },
+      },
+    };
+
+    const resolved = resolveMcpRequestTimeoutMs(request);
+    expect(resolved).toBe(
+      MAX_DEVICE_READY_TIMEOUT_MS + START_DEVICE_MCP_TIMEOUT_OVERHEAD_MS,
+    );
+    expect(resolved).toBeLessThan(DAEMON_RPC_SOCKET_IDLE_TIMEOUT_MS);
+  });
+
   test("keeps transport alive for the legacy nested startDevice timeout", () => {
     const request: DaemonRequest = {
       id: "1",

--- a/test/server/deviceTools.platformPreparation.test.ts
+++ b/test/server/deviceTools.platformPreparation.test.ts
@@ -1,0 +1,123 @@
+import { afterEach, beforeEach, describe, expect, test } from "bun:test";
+import {
+  getAndroidSchema,
+  getAppleSchema,
+  registerDeviceTools,
+  resetDeviceToolsDependencies,
+  setDeviceToolsDependencies,
+} from "../../src/server/deviceTools";
+import { ToolRegistry } from "../../src/server/toolRegistry";
+import type { BootedDevice, DeviceInfo } from "../../src/models";
+import { FakeDeviceMatcher } from "../fakes/FakeDeviceMatcher";
+import { FakeDeviceUtils } from "../fakes/FakeDeviceUtils";
+import { FakeTimer } from "../fakes/FakeTimer";
+
+describe("platform device preparation tools", () => {
+  let deviceUtils: FakeDeviceUtils;
+  let matcher: FakeDeviceMatcher;
+  let timer: FakeTimer;
+
+  beforeEach(() => {
+    deviceUtils = new FakeDeviceUtils();
+    matcher = new FakeDeviceMatcher();
+    timer = new FakeTimer();
+    setDeviceToolsDependencies({
+      deviceManagerFactory: () => deviceUtils,
+      deviceMatcherFactory: () => matcher,
+      ensureCtrlProxyReady: async () => {},
+      notifyResourcesChanged: async () => {},
+      timer,
+    });
+    registerDeviceTools();
+  });
+
+  afterEach(() => {
+    resetDeviceToolsDependencies();
+  });
+
+  async function callTool(name: "getAndroid" | "getApple", args: Record<string, unknown>) {
+    const tool = ToolRegistry.getTool(name);
+    if (!tool) {
+      throw new Error(`${name} is not registered`);
+    }
+    const result = await tool.handler(args);
+    return JSON.parse(
+      typeof result === "string" ? result : ((result as any).content?.[0]?.text ?? "{}"),
+    );
+  }
+
+  test("getAndroid returns the AVD to ADB serial and port mapping", async () => {
+    const emulator: BootedDevice = {
+      platform: "android",
+      name: "Pixel_9_API_36",
+      deviceId: "emulator-5562",
+      transportId: "17",
+    };
+    deviceUtils.setBootedDevices("android", [emulator]);
+    matcher.setBootedResult(emulator);
+
+    const result = await callTool("getAndroid", { avdName: "Pixel_9_API_36" });
+
+    expect(result.sessionId).toBeDefined();
+    expect(result.deviceIdentity).toEqual({
+      platform: "android",
+      avdName: "Pixel_9_API_36",
+      adbSerial: "emulator-5562",
+      emulatorConsolePort: 5562,
+      adbTransportId: "17",
+    });
+  });
+
+  test("getApple accepts only a simulator UDID and returns its simulator identity", async () => {
+    const simulator: DeviceInfo = {
+      platform: "ios",
+      name: "iPhone 17",
+      deviceId: "E2F46BCE-4C97-4AA0-BD9D-544756FAB545",
+      isRunning: false,
+    };
+    deviceUtils.setDeviceImages("ios", [simulator]);
+
+    const result = await callTool("getApple", { udid: simulator.deviceId });
+
+    expect(result.deviceIdentity).toEqual({
+      platform: "ios",
+      simulatorUdid: simulator.deviceId,
+      simulatorName: simulator.name,
+    });
+    expect(deviceUtils.getExecutedOperations()).toContain(`startDevice:${simulator.name}:120000`);
+  });
+
+  test("uses explicit boot and automation readiness budgets without accepting matcher inputs", async () => {
+    const image: DeviceInfo = {
+      platform: "android",
+      name: "Pixel_9_API_36",
+      isRunning: false,
+    };
+    let readinessRequest: { readinessTimeoutMs: number; totalDeadlineMs: number } | undefined;
+    matcher.setImageResult(image);
+    setDeviceToolsDependencies({
+      ensureCtrlProxyReady: async (request) => {
+        readinessRequest = {
+          readinessTimeoutMs: request.readinessTimeoutMs,
+          totalDeadlineMs: request.totalDeadlineMs,
+        };
+      },
+    });
+
+    await callTool("getAndroid", {
+      avdName: image.name,
+      bootTimeoutMs: 40_000,
+      automationReadyTimeoutMs: 20_000,
+    });
+
+    expect(deviceUtils.getExecutedOperations()).toContain(`startDevice:${image.name}:40000`);
+    expect(readinessRequest).toEqual({
+      readinessTimeoutMs: 20_000,
+      totalDeadlineMs: 60_000,
+    });
+    expect(() =>
+      getAndroidSchema.parse({ avdName: image.name, deviceId: "emulator-5554" }),
+    ).toThrow();
+    expect(() => getAppleSchema.parse({ udid: "sim-udid", platform: "ios" })).toThrow();
+  });
+});

--- a/test/server/tools/registry.test.ts
+++ b/test/server/tools/registry.test.ts
@@ -107,7 +107,7 @@ describe("MCP Tools Registry", () => {
       interaction: ["tapOn", "inputText", "clearText", "pressButton", "swipeOn", "dragAndDrop", "pinchOn"],
       app: ["launchApp", "terminateApp", "installApp", "uninstallApp", "listApps"],
       utility: ["rotate", "setActiveDevice", "openLink", "getDeviceState", "setDeviceState"],
-      device: ["listDeviceImages", "listDevices", "startDevice", "killDevice"],
+      device: ["listDeviceImages", "listDevices", "getAndroid", "getApple", "killDevice"],
     };
 
     for (const [category, expected] of Object.entries(expectedByCategory)) {

--- a/test/utils/android-cmdline-tools/AdbServerLifecycle.test.ts
+++ b/test/utils/android-cmdline-tools/AdbServerLifecycle.test.ts
@@ -1,0 +1,114 @@
+import { describe, expect, test } from "bun:test";
+import {
+  LEGACY_MANAGED_ADB_SERVER_ENV,
+  MANAGED_ADB_SERVER_ENV,
+  MANAGED_ADB_SERVER_SHUTDOWN_TIMEOUT_MS,
+  isManagedAdbServerEnabled,
+  stopManagedAdbServer,
+} from "../../../src/utils/android-cmdline-tools/AdbServerLifecycle";
+import type { AdbClientFactory } from "../../../src/utils/android-cmdline-tools/AdbClientFactory";
+import type {
+  AdbExecuteOptions,
+  AdbExecutor,
+} from "../../../src/utils/android-cmdline-tools/interfaces/AdbExecutor";
+import { FakeTimer } from "../../fakes/FakeTimer";
+
+function environment(values: Record<string, string | undefined>): NodeJS.ProcessEnv {
+  return values;
+}
+
+describe("managed ADB server lifecycle configuration", () => {
+  test("is disabled by default and preserves a shared ADB server", () => {
+    expect(isManagedAdbServerEnabled(environment({}))).toBeFalse();
+  });
+
+  test("accepts the canonical opt-in and retains the legacy alias", () => {
+    expect(isManagedAdbServerEnabled(environment({ [MANAGED_ADB_SERVER_ENV]: "true" }))).toBeTrue();
+    expect(
+      isManagedAdbServerEnabled(environment({ [LEGACY_MANAGED_ADB_SERVER_ENV]: "1" })),
+    ).toBeTrue();
+  });
+
+  test("gives the canonical setting precedence over the legacy alias", () => {
+    expect(
+      isManagedAdbServerEnabled(
+        environment({
+          [MANAGED_ADB_SERVER_ENV]: "0",
+          [LEGACY_MANAGED_ADB_SERVER_ENV]: "1",
+        }),
+      ),
+    ).toBeFalse();
+  });
+});
+
+describe("stopManagedAdbServer", () => {
+  test("does not construct an ADB client when managed mode is disabled", async () => {
+    let created = 0;
+    const adbFactory: AdbClientFactory = {
+      create: () => {
+        created += 1;
+        throw new Error("should not create an ADB client");
+      },
+    };
+
+    await stopManagedAdbServer({ adbFactory, environment: environment({}) });
+
+    expect(created).toBe(0);
+  });
+
+  test("stops the process-wide ADB server once when the managed mode owns it", async () => {
+    const calls: Array<{ args: string[]; options: AdbExecuteOptions | undefined }> = [];
+    const adb: Pick<AdbExecutor, "execute"> = {
+      async execute(args, options): Promise<never> {
+        calls.push({ args, options });
+        return undefined as never;
+      },
+    };
+    const adbFactory: AdbClientFactory = {
+      create: () => adb as AdbExecutor,
+    };
+
+    await stopManagedAdbServer({
+      adbFactory,
+      environment: environment({ [MANAGED_ADB_SERVER_ENV]: "1" }),
+    });
+
+    expect(calls).toHaveLength(1);
+    expect(calls[0]).toMatchObject({
+      args: ["kill-server"],
+      options: {
+        timeoutMs: MANAGED_ADB_SERVER_SHUTDOWN_TIMEOUT_MS,
+        noRetry: true,
+      },
+    });
+    expect(calls[0].options?.signal).toBeInstanceOf(AbortSignal);
+  });
+
+  test("aborts a hung server shutdown at the fixed cleanup bound", async () => {
+    const timer = new FakeTimer();
+    let signal: AbortSignal | undefined;
+    const adb: Pick<AdbExecutor, "execute"> = {
+      async execute(_args, options): Promise<never> {
+        signal = options?.signal;
+        return await new Promise<never>(() => {});
+      },
+    };
+    const adbFactory: AdbClientFactory = {
+      create: () => adb as AdbExecutor,
+    };
+
+    const shutdown = stopManagedAdbServer({
+      adbFactory,
+      environment: environment({ [MANAGED_ADB_SERVER_ENV]: "1" }),
+      timer,
+    });
+    await Promise.resolve();
+
+    timer.advanceTime(MANAGED_ADB_SERVER_SHUTDOWN_TIMEOUT_MS);
+
+    await expect(shutdown).rejects.toThrow(
+      `Managed ADB server shutdown timed out after ${MANAGED_ADB_SERVER_SHUTDOWN_TIMEOUT_MS}ms`,
+    );
+    expect(signal?.aborted).toBeTrue();
+  });
+});


### PR DESCRIPTION
## Summary

- Replace public `startDevice` discovery with `getAndroid(avdName)` and `getApple(udid)`, each with independent boot and automation-readiness budgets.
- Return stable device identity and operational mapping, including Android AVD name, ADB serial, emulator console port, and transport ID.
- Preserve a session through a process-wide ADB server reset by restarting the originally recorded Android AVD, then rebinding that session to its new serial.
- Add an opt-in, bounded managed ADB-server shutdown for daemon and direct-mode ownership.

## Why

ADB server resets invalidate emulator serial discovery across the process. Recovering by the original AVD name preserves the session-to-device relationship even when emulator ports are reassigned.

## Validation

- `bun test test/utils/android-cmdline-tools/AdbServerLifecycle.test.ts test/server/deviceTools.platformPreparation.test.ts test/daemon/adbServerResetDetection.test.ts test/daemon/adbServerResetRecovery.test.ts test/daemon/daemonShutdownSessionRelease.test.ts test/daemon/mcpRequestTimeout.test.ts test/server/tools/registry.test.ts`
- `bun run typecheck`
- `bun run turbo:validate` completed 13,640 passing tests; one unrelated `PinchOn vision fallback` full-suite timeout passed when rerun in isolation.

Closes [#5433](https://github.com/kaeawc/auto-mobile/issues/5433)
