### PR TITLE
feat(device-control): add exact virtual device provisioning

### DIFF
--- a/docs/design-docs/mcp/tools.md
+++ b/docs/design-docs/mcp/tools.md
@@ -143,6 +143,7 @@ cat "$APP_CONTAINER/Documents/fixtures/hello.txt"
 
 - 📋 Device inventory and pool status are exposed via the `automobile:devices/booted` resource.
 - 🚀 `startDevice` starts a device with the specified device image.
+- 🧱 `provisionDevice` creates or adopts an exact virtual-device identity. It requires the `device-control` capability.
 - ❌ `killDevice` terminates a running device.
 - 🔧 `setActiveDevice` sets the active device for subsequent operations. It is a
   compatibility API; new multi-client daemon integrations should bind a

--- a/docs/using/tool-capabilities.md
+++ b/docs/using/tool-capabilities.md
@@ -44,12 +44,12 @@ below.
 
 ## Tool capabilities (the primary registration flags)
 
-Advanced tools are grouped into **14 capabilities**. Each is **off by default**;
+Advanced tools are grouped into **15 capabilities**. Each is **off by default**;
 an agent opts into the ones it needs for the current session. Opting in is
 cheap, reversible, and scoped to the session — it does not change what any other
 connected client sees.
 
-### The 14 capabilities
+### The 15 capabilities
 
 | Capability | Tools it exposes | Extra process gate on some tools |
 |---|---|---|
@@ -57,6 +57,7 @@ connected client sees.
 | `advanced-interaction` | `openLink`, `imeAction`, `dragAndDrop`, `pinchOn`, `shake`, `rotate` | — |
 | `app-permissions` | `getAppPermissions`, `setAppPermissions` | — |
 | `device-settings` | `changeLocalization`, `getDeviceState`, `setDeviceState` | — |
+| `device-control` | `provisionDevice` | — |
 | `app-data-interop` | `putAppFile`, `getPreference`, `setPreference`, `sqlQuery`, `setKeyValue`, `removeKeyValue`, `clearKeyValueFile` | `sqlQuery`, `setKeyValue`, `removeKeyValue`, `clearKeyValueFile` also need **`--embedded-sdk`** |
 | `notifications` | `systemTray`, `postNotification`, `getNotificationPolicy`, `setNotificationPolicy` | — |
 | `telephony` | `phoneCall`, `sendSms` | — |
@@ -199,7 +200,7 @@ surface them in `tools/list` — this is by design.
 Because the gates are cumulative, work through them in order:
 
 1. **Is it a capability tool?** Find the tool in the
-   [14-capability table](#the-14-capabilities). If it's there, enable that
+   [15-capability table](#the-15-capabilities). If it's there, enable that
    capability — `setToolCapability` for this session, or `AUTOMOBILE_TOOLSET_*`
    at startup.
 2. **Does it carry an extra process gate?** The right-hand column of that table

--- a/schemas/tool-definitions.json
+++ b/schemas/tool-definitions.json
@@ -7675,6 +7675,141 @@
     }
   },
   {
+    "name": "provisionDevice",
+    "description": "Provision exact virtual device",
+    "inputSchema": {
+      "$schema": "https://json-schema.org/draft/2020-12/schema",
+      "type": "object",
+      "properties": {
+        "operationId": {
+          "description": "Caller-generated idempotency key",
+          "type": "string",
+          "minLength": 1
+        },
+        "device": {
+          "anyOf": [
+            {
+              "type": "object",
+              "properties": {
+                "platform": {
+                  "type": "string",
+                  "const": "android"
+                },
+                "name": {
+                  "description": "Exact AVD name",
+                  "type": "string",
+                  "minLength": 1
+                },
+                "spec": {
+                  "type": "object",
+                  "properties": {
+                    "runtime": {
+                      "description": "Installed Android system-image package identifier",
+                      "type": "string",
+                      "minLength": 1
+                    },
+                    "deviceType": {
+                      "description": "Android avdmanager device profile identifier",
+                      "type": "string",
+                      "minLength": 1
+                    },
+                    "configuration": {
+                      "type": "object",
+                      "properties": {
+                        "memoryMb": {
+                          "type": "integer",
+                          "exclusiveMinimum": 0,
+                          "maximum": 9007199254740991
+                        }
+                      },
+                      "additionalProperties": false
+                    }
+                  },
+                  "required": [
+                    "runtime",
+                    "deviceType"
+                  ],
+                  "additionalProperties": false
+                }
+              },
+              "required": [
+                "platform",
+                "name",
+                "spec"
+              ],
+              "additionalProperties": false
+            },
+            {
+              "type": "object",
+              "properties": {
+                "platform": {
+                  "type": "string",
+                  "const": "ios"
+                },
+                "name": {
+                  "description": "Exact simulator name",
+                  "type": "string",
+                  "minLength": 1
+                },
+                "spec": {
+                  "type": "object",
+                  "properties": {
+                    "runtime": {
+                      "description": "CoreSimulator runtime identifier",
+                      "type": "string",
+                      "minLength": 1
+                    },
+                    "deviceType": {
+                      "description": "CoreSimulator device-type identifier",
+                      "type": "string",
+                      "minLength": 1
+                    }
+                  },
+                  "required": [
+                    "runtime",
+                    "deviceType"
+                  ],
+                  "additionalProperties": false
+                }
+              },
+              "required": [
+                "platform",
+                "name",
+                "spec"
+              ],
+              "additionalProperties": false
+            }
+          ]
+        },
+        "boot": {
+          "description": "Boot the resolved device after creation or adoption",
+          "default": true,
+          "type": "boolean"
+        },
+        "readiness": {
+          "description": "Whether to wait for the AutoMobile automation runner after device boot",
+          "default": "automation",
+          "type": "string",
+          "enum": [
+            "automation",
+            "none"
+          ]
+        },
+        "timeoutMs": {
+          "description": "Total provision, boot, and readiness timeout in ms",
+          "type": "integer",
+          "exclusiveMinimum": 0,
+          "maximum": 890000
+        }
+      },
+      "required": [
+        "operationId",
+        "device"
+      ],
+      "additionalProperties": false
+    }
+  },
+  {
     "name": "putAppFile",
     "description": "Write file/text/base64 content into an app container.",
     "inputSchema": {
@@ -8410,6 +8545,7 @@
             "advanced-interaction",
             "app-permissions",
             "device-settings",
+            "device-control",
             "app-data-interop",
             "notifications",
             "telephony",

--- a/src/daemon/devicePool.ts
+++ b/src/daemon/devicePool.ts
@@ -3959,6 +3959,37 @@ export class DevicePool {
   }
 
   /**
+   * Associate a live autolock session with a reconnected MCP client session.
+   */
+  async attachAutolockSessionToMcpSession(
+    sessionId: string,
+    mcpSessionId: string | undefined,
+  ): Promise<void> {
+    if (!mcpSessionId) {
+      return;
+    }
+    await this.assignmentMutex.runExclusive(async () => {
+      const session = this.sessionManager.getSession(sessionId);
+      const device = session ? this.devices.get(session.assignedDevice) : undefined;
+      if (
+        !session ||
+        !device ||
+        device.sessionId !== sessionId ||
+        device.autolockSessionId !== sessionId
+      ) {
+        return;
+      }
+      await this.deviceSessionRepository.markAutolockSession(sessionId, {
+        mcpSessionId,
+        daemonSessionId: this.daemonSessionId,
+        lastUsedAtMs: session.lastUsedAt,
+        expiresAtMs: session.expiresAt,
+      });
+      this.mcpSessionAutolockMap.set(mcpSessionId, sessionId);
+    });
+  }
+
+  /**
    * Free a device whose autolock session has been released or has expired.
    *
    * Invoked via the SessionManager expiry callback. Only acts when the device

--- a/src/daemon/mcpRequestTimeout.ts
+++ b/src/daemon/mcpRequestTimeout.ts
@@ -1,6 +1,7 @@
 import type { DaemonRequest } from "./types";
 import {
   DEFAULT_DEVICE_READY_TIMEOUT_MS,
+  DEFAULT_PROVISION_DEVICE_TIMEOUT_MS,
   MAX_DEVICE_READY_TIMEOUT_MS,
   START_DEVICE_MCP_TIMEOUT_OVERHEAD_MS,
 } from "../utils/deviceTimeouts";
@@ -25,6 +26,14 @@ export const MIN_EXECUTE_PLAN_MCP_TIMEOUT_MS = 600_000;
  * host performance (especially under emulation/Rosetta).
  */
 export const MIN_START_DEVICE_MCP_TIMEOUT_MS = 180_000;
+
+/**
+ * Floor for exact virtual-device provisioning. Android AVD creation alone
+ * permits a five-minute command budget before the shared boot/readiness path,
+ * and the transport needs time to persist and return its final result.
+ */
+export const MIN_PROVISION_DEVICE_MCP_TIMEOUT_MS =
+  DEFAULT_PROVISION_DEVICE_TIMEOUT_MS + START_DEVICE_MCP_TIMEOUT_OVERHEAD_MS;
 
 /**
  * Floor for `launchApp` — an iOS cold launch waits for CtrlProxy to deliver the
@@ -92,6 +101,8 @@ function resolveToolTimeoutFloorMs(toolName: string | undefined): number | undef
     case "getApple":
     case "startDevice":
       return MIN_START_DEVICE_MCP_TIMEOUT_MS;
+    case "provisionDevice":
+      return MIN_PROVISION_DEVICE_MCP_TIMEOUT_MS;
     case "launchApp":
       return MIN_LAUNCH_APP_MCP_TIMEOUT_MS;
     case "uninstallApp":
@@ -161,6 +172,13 @@ function resolveDevicePreparationToolBudgetMs(request: DaemonRequest): number | 
       return resolveNamedDevicePreparationBudgetMs(argumentsRecord);
     case "startDevice":
       return resolveLegacyStartDeviceBudgetMs(argumentsRecord);
+    case "provisionDevice": {
+      const timeoutMs =
+        positiveFiniteNumber(argumentsRecord.timeoutMs) ??
+        DEFAULT_PROVISION_DEVICE_TIMEOUT_MS;
+      return Math.min(timeoutMs, MAX_DEVICE_READY_TIMEOUT_MS) +
+        START_DEVICE_MCP_TIMEOUT_OVERHEAD_MS;
+    }
     default:
       return undefined;
   }

--- a/src/db/migrations/2026_08_22_000_provision_device_operations.ts
+++ b/src/db/migrations/2026_08_22_000_provision_device_operations.ts
@@ -1,0 +1,27 @@
+import { type Kysely, sql } from "kysely";
+
+export async function up(db: Kysely<unknown>): Promise<void> {
+  await db.schema
+    .createTable("provision_device_operations")
+    .ifNotExists()
+    .addColumn("operation_id", "text", (column) => column.primaryKey())
+    .addColumn("request_fingerprint", "text", (column) => column.notNull())
+    .addColumn("status", "text", (column) => column.notNull())
+    .addColumn("result_json", "text")
+    .addColumn("error_code", "text")
+    .addColumn("error_message", "text")
+    .addColumn("creation_started", "integer", (column) =>
+      column.notNull().defaultTo(0),
+    )
+    .addColumn("created_at", "text", (column) =>
+      column.notNull().defaultTo(sql`(datetime('now'))`),
+    )
+    .addColumn("updated_at", "text", (column) =>
+      column.notNull().defaultTo(sql`(datetime('now'))`),
+    )
+    .execute();
+}
+
+export async function down(db: Kysely<unknown>): Promise<void> {
+  await db.schema.dropTable("provision_device_operations").execute();
+}

--- a/src/db/provisionDeviceOperationRepository.ts
+++ b/src/db/provisionDeviceOperationRepository.ts
@@ -1,0 +1,186 @@
+import type { Kysely } from "kysely";
+import { getDatabase } from "./database";
+import type { Database } from "./types";
+import { logger } from "../utils/logger";
+
+export interface ProvisionDeviceOperationStore {
+  begin(
+    operationId: string,
+    requestFingerprint: string,
+  ): Promise<
+    | { started: true; reconcileExistingConfiguration: boolean }
+    | {
+      started: false;
+      result: Record<string, unknown>;
+      reconcileExistingConfiguration: boolean;
+    }
+  >;
+  markDeviceCreationStarted(operationId: string): Promise<void>;
+  complete(operationId: string, result: Record<string, unknown>): Promise<void>;
+  fail(operationId: string, errorCode: string, message: string): Promise<void>;
+}
+
+export class ProvisionDeviceOperationConflictError extends Error {
+  constructor(operationId: string) {
+    super(`operationId '${operationId}' was already used for a different provisionDevice request`);
+    this.name = "ProvisionDeviceOperationConflictError";
+  }
+}
+
+interface StoredResult {
+  result: Record<string, unknown>;
+}
+
+function decodeResult(value: string): Record<string, unknown> | undefined {
+  try {
+    const parsed: unknown = JSON.parse(value);
+    if (
+      typeof parsed === "object" &&
+      parsed !== null &&
+      !Array.isArray(parsed) &&
+      "result" in parsed &&
+      typeof (parsed as StoredResult).result === "object" &&
+      (parsed as StoredResult).result !== null
+    ) {
+      return (parsed as StoredResult).result;
+    }
+  } catch (error) {
+    logger.warn(`[ProvisionDeviceOperationRepository] Invalid stored result: ${error}`);
+  }
+  return undefined;
+}
+
+export class ProvisionDeviceOperationRepository implements ProvisionDeviceOperationStore {
+  constructor(private readonly database?: Kysely<Database>) {}
+
+  async begin(
+    operationId: string,
+    requestFingerprint: string,
+  ): Promise<
+    | { started: true; reconcileExistingConfiguration: boolean }
+    | {
+      started: false;
+      result: Record<string, unknown>;
+      reconcileExistingConfiguration: boolean;
+    }
+  > {
+    const db = this.getDb();
+    const existing = await db
+      .selectFrom("provision_device_operations")
+      .selectAll()
+      .where("operation_id", "=", operationId)
+      .executeTakeFirst();
+
+    if (existing) {
+      return this.resolveExisting(operationId, requestFingerprint, existing);
+    }
+
+    try {
+      await db
+        .insertInto("provision_device_operations")
+        .values({
+          operation_id: operationId,
+          request_fingerprint: requestFingerprint,
+          status: "running",
+          result_json: null,
+          error_code: null,
+          error_message: null,
+          creation_started: 0,
+        })
+        .execute();
+      return { started: true, reconcileExistingConfiguration: false };
+    } catch (error) {
+      const raced = await db
+        .selectFrom("provision_device_operations")
+        .selectAll()
+        .where("operation_id", "=", operationId)
+        .executeTakeFirst();
+      if (!raced) {
+        throw new Error(
+          `Could not create provisionDevice operation '${operationId}': ` +
+          `${error instanceof Error ? error.message : String(error)}`,
+        );
+      }
+      return this.resolveExisting(operationId, requestFingerprint, raced);
+    }
+  }
+
+  async complete(operationId: string, result: Record<string, unknown>): Promise<void> {
+    await this.getDb()
+      .updateTable("provision_device_operations")
+      .set({
+        status: "succeeded",
+        result_json: JSON.stringify({ result }),
+        error_code: null,
+        error_message: null,
+        updated_at: new Date().toISOString(),
+      })
+      .where("operation_id", "=", operationId)
+      .execute();
+  }
+
+  async markDeviceCreationStarted(operationId: string): Promise<void> {
+    await this.getDb()
+      .updateTable("provision_device_operations")
+      .set({
+        creation_started: 1,
+        updated_at: new Date().toISOString(),
+      })
+      .where("operation_id", "=", operationId)
+      .execute();
+  }
+
+  async fail(operationId: string, errorCode: string, message: string): Promise<void> {
+    await this.getDb()
+      .updateTable("provision_device_operations")
+      .set({
+        status: "failed",
+        error_code: errorCode,
+        error_message: message,
+        updated_at: new Date().toISOString(),
+      })
+      .where("operation_id", "=", operationId)
+      .execute();
+  }
+
+  private getDb(): Kysely<Database> {
+    return this.database ?? getDatabase();
+  }
+
+  private resolveExisting(
+    operationId: string,
+    requestFingerprint: string,
+    existing: {
+      request_fingerprint: string;
+      status: string;
+      result_json: string | null;
+      error_code: string | null;
+      error_message: string | null;
+      creation_started: number;
+    },
+  ):
+    | { started: true; reconcileExistingConfiguration: boolean }
+    | {
+      started: false;
+      result: Record<string, unknown>;
+      reconcileExistingConfiguration: boolean;
+    } {
+    if (existing.request_fingerprint !== requestFingerprint) {
+      throw new ProvisionDeviceOperationConflictError(operationId);
+    }
+    if (existing.status === "succeeded" && existing.result_json) {
+      const result = decodeResult(existing.result_json);
+      if (result) {
+        return {
+          started: false,
+          result,
+          reconcileExistingConfiguration: existing.creation_started === 1,
+        };
+      }
+    }
+    return {
+      started: true,
+      reconcileExistingConfiguration: existing.creation_started === 1,
+    };
+  }
+}

--- a/src/db/types.ts
+++ b/src/db/types.ts
@@ -533,6 +533,18 @@ export interface EmulatorLossIncidentsTable {
   created_at: Generated<string>;
 }
 
+export interface ProvisionDeviceOperationsTable {
+  operation_id: string;
+  request_fingerprint: string;
+  status: string;
+  result_json: string | null;
+  error_code: string | null;
+  error_message: string | null;
+  creation_started: number;
+  created_at: Generated<string>;
+  updated_at: Generated<string>;
+}
+
 // Feature flags table
 export interface FeatureFlagsTable {
   key: string;
@@ -763,6 +775,7 @@ export interface Database {
   device_sessions: DeviceSessionsTable;
   device_locks: DeviceLocksTable;
   emulator_loss_incidents: EmulatorLossIncidentsTable;
+  provision_device_operations: ProvisionDeviceOperationsTable;
 }
 
 // Convenience types for each table

--- a/src/features/toolCapabilities/SessionToolProfileService.ts
+++ b/src/features/toolCapabilities/SessionToolProfileService.ts
@@ -4,6 +4,7 @@ export const TOOL_CAPABILITIES = [
   "advanced-interaction",
   "app-permissions",
   "device-settings",
+  "device-control",
   "app-data-interop",
   "notifications",
   "telephony",

--- a/src/features/toolCapabilities/toolCapabilityMap.ts
+++ b/src/features/toolCapabilities/toolCapabilityMap.ts
@@ -5,6 +5,7 @@ const groups: Record<ToolCapability, readonly string[]> = {
   "advanced-interaction": ["openLink", "imeAction", "dragAndDrop", "pinchOn", "shake", "rotate"],
   "app-permissions": ["getAppPermissions", "setAppPermissions"],
   "device-settings": ["changeLocalization", "getDeviceState", "setDeviceState"],
+  "device-control": ["provisionDevice"],
   "app-data-interop": ["putAppFile", "getPreference", "setPreference", "sqlQuery", "setKeyValue", "removeKeyValue", "clearKeyValueFile"],
   "notifications": ["systemTray", "postNotification", "getNotificationPolicy", "setNotificationPolicy"],
   "telephony": ["phoneCall", "sendSms"],

--- a/src/server/deviceTools.ts
+++ b/src/server/deviceTools.ts
@@ -2013,7 +2013,7 @@ export function registerDeviceTools() {
         if (!args.boot) {
           return operation.result;
         }
-        if (await revalidateLiveProvisionDeviceSession(args, deps, operation.result, signal)) {
+        if (await revalidateProvisionDeviceReplay(args, deps, operation.result, signal)) {
           return operation.result;
         }
         await releaseErroredProvisionDeviceSession(operation.result);
@@ -2078,7 +2078,29 @@ export function registerDeviceTools() {
         perf.end();
       }
     }
-    return getLiveProvisionDeviceSession(result) !== undefined;
+    const revalidatedSession = getPersistedProvisionDeviceSession(result);
+    if (!revalidatedSession || !getLiveProvisionDeviceSession(result)) {
+      return false;
+    }
+    await DaemonState.getInstance().getDevicePool().attachAutolockSessionToMcpSession(
+      revalidatedSession.sessionId,
+      args.__mcpSessionId,
+    );
+    return true;
+  }
+
+  async function revalidateProvisionDeviceReplay(
+    args: ProvisionDeviceArgs,
+    deps: DeviceToolsDependencies,
+    result: Record<string, unknown>,
+    signal: AbortSignal | undefined,
+  ): Promise<boolean> {
+    try {
+      return await revalidateLiveProvisionDeviceSession(args, deps, result, signal);
+    } catch (error) {
+      await releaseProvisionDeviceSession(result, "provision-device-replay-validation-failed");
+      throw error;
+    }
   }
 
   function getLiveProvisionDeviceSession(
@@ -2237,12 +2259,19 @@ export function registerDeviceTools() {
         markDeviceCreationStarted,
         signal,
       );
+      const createdByOperation = reconcileExistingConfiguration || provisioned.created;
       if (!args.boot) {
         if (provisioned.created) {
           await deps.notifyResourcesChanged();
         }
         perf.end();
-        return buildProvisionDeviceResult(args, provisioned, perf, undefined);
+        return buildProvisionDeviceResult(
+          args,
+          provisioned,
+          createdByOperation,
+          perf,
+          undefined,
+        );
       }
 
       const booted = await bootExactProvisionedDevice(
@@ -2259,7 +2288,7 @@ export function registerDeviceTools() {
         await deps.notifyResourcesChanged();
       }
       perf.end();
-      return buildProvisionDeviceResult(args, provisioned, perf, booted);
+      return buildProvisionDeviceResult(args, provisioned, createdByOperation, perf, booted);
     } catch (error) {
       perf.end();
       throw error;
@@ -2426,6 +2455,7 @@ export function registerDeviceTools() {
   function buildProvisionDeviceResult(
     args: ProvisionDeviceArgs,
     provisioned: Awaited<ReturnType<ExactDeviceProvisioner["provision"]>>,
+    createdByOperation: boolean,
     perf: ReturnType<typeof createPerformanceTracker>,
     booted: { device: BootedDevice; sessionId: string } | undefined,
   ): Record<string, unknown> {
@@ -2434,9 +2464,9 @@ export function registerDeviceTools() {
       device: booted?.device ?? provisioned.device,
       requestedSpec: args.device.spec,
       resolvedSpec: provisioned.resolvedSpec,
-      created: provisioned.created,
-      adopted: !provisioned.created,
-      lifecycleState: booted ? "ready" : provisioned.created ? "created" : "adopted",
+      created: createdByOperation,
+      adopted: !createdByOperation,
+      lifecycleState: booted ? "ready" : createdByOperation ? "created" : "adopted",
       readiness: {
         mode: args.readiness,
         status: booted

--- a/src/server/deviceTools.ts
+++ b/src/server/deviceTools.ts
@@ -2008,30 +2008,31 @@ export function registerDeviceTools() {
     const deps = getDeviceToolsDependencies();
     const store = deps.provisionDeviceOperationStoreFactory();
     const operation = await store.begin(args.operationId, fingerprint);
-    if (!operation.started) {
-      if (!args.boot) {
-        return operation.result;
-      }
-      if (hasLiveProvisionDeviceSession(operation.result)) {
-        return operation.result;
-      }
-
-      // Sessions are daemon-local and are expired during daemon startup. A
-      // replay of a completed boot operation therefore runs the idempotent
-      // lifecycle again to bind a live session before reporting readiness.
-      const rebound = await runProvisionDeviceLifecycle(
-        args,
-        deps,
-        operation.reconcileExistingConfiguration,
-        () => store.markDeviceCreationStarted(args.operationId),
-        signal,
-      );
-      const refreshed = preserveProvisionDeviceOwnership(operation.result, rebound);
-      await store.complete(args.operationId, refreshed);
-      return refreshed;
-    }
-
     try {
+      if (!operation.started) {
+        if (!args.boot) {
+          return operation.result;
+        }
+        if (await revalidateLiveProvisionDeviceSession(args, deps, operation.result, signal)) {
+          return operation.result;
+        }
+        await releaseErroredProvisionDeviceSession(operation.result);
+
+        // Sessions are daemon-local and are expired during daemon startup. A
+        // replay of a completed boot operation therefore runs the idempotent
+        // lifecycle again to bind a live session before reporting readiness.
+        const rebound = await runProvisionDeviceLifecycle(
+          args,
+          deps,
+          operation.reconcileExistingConfiguration,
+          () => store.markDeviceCreationStarted(args.operationId),
+          signal,
+        );
+        const refreshed = preserveProvisionDeviceOwnership(operation.result, rebound);
+        await completeProvisionDeviceOperation(store, args.operationId, refreshed);
+        return refreshed;
+      }
+
       const result = await runProvisionDeviceLifecycle(
         args,
         deps,
@@ -2039,7 +2040,7 @@ export function registerDeviceTools() {
         () => store.markDeviceCreationStarted(args.operationId),
         signal,
       );
-      await store.complete(args.operationId, result);
+      await completeProvisionDeviceOperation(store, args.operationId, result);
       return result;
     } catch (error) {
       const provisionError = toProvisionDeviceError(args, error);
@@ -2048,26 +2049,64 @@ export function registerDeviceTools() {
     }
   }
 
-  function hasLiveProvisionDeviceSession(result: Record<string, unknown>): boolean {
+  async function revalidateLiveProvisionDeviceSession(
+    args: ProvisionDeviceArgs,
+    deps: DeviceToolsDependencies,
+    result: Record<string, unknown>,
+    signal: AbortSignal | undefined,
+  ): Promise<boolean> {
+    const liveSession = getLiveProvisionDeviceSession(result);
+    if (!liveSession) {
+      return false;
+    }
+    if (args.readiness === "automation") {
+      const perf = createPerformanceTracker(true);
+      perf.serial("provisionDeviceReplay");
+      try {
+        const totalDeadlineMs = deps.timer.now() +
+          (args.timeoutMs ?? DEFAULT_PROVISION_DEVICE_TIMEOUT_MS);
+        await ensureProvisionDeviceReadiness(
+          args,
+          deps,
+          liveSession.device,
+          `platform=${args.device.platform} name=${args.device.name}`,
+          totalDeadlineMs,
+          perf,
+          signal,
+        );
+      } finally {
+        perf.end();
+      }
+    }
+    return getLiveProvisionDeviceSession(result) !== undefined;
+  }
+
+  function getLiveProvisionDeviceSession(
+    result: Record<string, unknown>,
+  ): { device: BootedDevice } | undefined {
     const persistedSession = getPersistedProvisionDeviceSession(result);
     const daemonState = DaemonState.getInstance();
     if (!persistedSession || !daemonState.isInitialized()) {
-      return false;
+      return undefined;
     }
 
     const session = daemonState.getSessionManager().getSession(persistedSession.sessionId);
     const pooledDevice = daemonState.getDevicePool().getDeviceForSession(persistedSession.sessionId);
-    return (
+    if (
       session?.assignedDevice === persistedSession.deviceId &&
       session.platform === persistedSession.platform &&
       pooledDevice?.id === persistedSession.deviceId &&
-      pooledDevice.platform === persistedSession.platform
-    );
+      pooledDevice.platform === persistedSession.platform &&
+      pooledDevice.status === "busy"
+    ) {
+      return { device: persistedSession.device };
+    }
+    return undefined;
   }
 
   function getPersistedProvisionDeviceSession(
     result: Record<string, unknown>,
-  ): { sessionId: string; deviceId: string; platform: "android" | "ios" } | undefined {
+  ): { sessionId: string; deviceId: string; platform: "android" | "ios"; device: BootedDevice } | undefined {
     if (typeof result.sessionId !== "string") {
       return undefined;
     }
@@ -2076,7 +2115,7 @@ export function registerDeviceTools() {
       return undefined;
     }
     const deviceRecord = device as Record<string, unknown>;
-    if (typeof deviceRecord.deviceId !== "string") {
+    if (typeof deviceRecord.deviceId !== "string" || typeof deviceRecord.name !== "string") {
       return undefined;
     }
     if (deviceRecord.platform !== "android" && deviceRecord.platform !== "ios") {
@@ -2086,7 +2125,63 @@ export function registerDeviceTools() {
       sessionId: result.sessionId,
       deviceId: deviceRecord.deviceId,
       platform: deviceRecord.platform,
+      device: deviceRecord as BootedDevice,
     };
+  }
+
+  async function releaseErroredProvisionDeviceSession(result: Record<string, unknown>): Promise<void> {
+    const persistedSession = getPersistedProvisionDeviceSession(result);
+    const daemonState = DaemonState.getInstance();
+    if (!persistedSession || !daemonState.isInitialized()) {
+      return;
+    }
+    const pooledDevice = daemonState.getDevicePool().getDeviceForSession(persistedSession.sessionId);
+    if (pooledDevice?.status !== "error") {
+      return;
+    }
+    await releaseProvisionDeviceSession(result, "provision-device-errored-replay");
+  }
+
+  async function completeProvisionDeviceOperation(
+    store: ProvisionDeviceOperationStore,
+    operationId: string,
+    result: Record<string, unknown>,
+  ): Promise<void> {
+    try {
+      await store.complete(operationId, result);
+    } catch (error) {
+      await releaseProvisionDeviceSession(result, "provision-device-persistence-failed");
+      throw error;
+    }
+  }
+
+  async function releaseProvisionDeviceSession(
+    result: Record<string, unknown>,
+    reason: string,
+  ): Promise<void> {
+    const persistedSession = getPersistedProvisionDeviceSession(result);
+    const daemonState = DaemonState.getInstance();
+    if (!persistedSession || !daemonState.isInitialized()) {
+      return;
+    }
+    const sessionManager = daemonState.getSessionManager();
+    const session = sessionManager.getSession(persistedSession.sessionId);
+    if (
+      session?.assignedDevice !== persistedSession.deviceId ||
+      session.platform !== persistedSession.platform
+    ) {
+      return;
+    }
+    try {
+      const releasedDeviceId = await sessionManager.releaseSession(persistedSession.sessionId, reason);
+      if (releasedDeviceId === persistedSession.deviceId) {
+        await daemonState.getDevicePool().releaseDevice(releasedDeviceId, persistedSession.sessionId);
+      }
+    } catch (error) {
+      logger.warn(
+        `[DeviceTools] Failed to release provisionDevice session ${persistedSession.sessionId}: ${error}`,
+      );
+    }
   }
 
   function preserveProvisionDeviceOwnership(

--- a/src/server/deviceTools.ts
+++ b/src/server/deviceTools.ts
@@ -1,4 +1,5 @@
 import type { ChildProcess } from "child_process";
+import { createHash } from "node:crypto";
 import { z } from "zod/v4";
 import { defaultIdGenerator, type IdGenerator } from "../utils/IdGenerator";
 import { ToolRegistry, ProgressCallback } from "./toolRegistry";
@@ -51,8 +52,22 @@ import {
 import { serverConfig } from "../utils/ServerConfig";
 import {
   DEFAULT_DEVICE_READY_TIMEOUT_MS,
+  DEFAULT_PROVISION_DEVICE_TIMEOUT_MS,
   MAX_DEVICE_READY_TIMEOUT_MS,
 } from "../utils/deviceTimeouts";
+import {
+  createDefaultExactDeviceProvisioner,
+  type ExactDeviceProvisioner,
+  type ExactDeviceSpecification,
+  ProvisionDeviceError,
+} from "../utils/exactDeviceProvisioning";
+import { MIN_AVD_RAM_MB } from "../utils/android-cmdline-tools/AvdConfigReader";
+import {
+  ProvisionDeviceOperationRepository,
+  ProvisionDeviceOperationConflictError,
+  type ProvisionDeviceOperationStore,
+} from "../db/provisionDeviceOperationRepository";
+import { stableStringify } from "../utils/stableStringify";
 
 // Schema definitions
 export const listDeviceImagesSchema = z.object({
@@ -149,6 +164,70 @@ export const getAndroidSchema = devicePreparationTimeoutSchema.extend({
 export const getAppleSchema = devicePreparationTimeoutSchema.extend({
   udid: z.string().min(1).describe("iOS Simulator UDID"),
 });
+
+const MODERN_PLAY_IMAGE_MIN_API_LEVEL = 30;
+
+function isModernPlayStoreRuntime(runtime: string): boolean {
+  const [kind, apiIdentifier, tag] = runtime.split(";");
+  const apiMatch = /^android-(\d+)$/.exec(apiIdentifier ?? "");
+  return (
+    kind === "system-images" &&
+    tag === "google_apis_playstore" &&
+    apiMatch !== null &&
+    Number(apiMatch[1]) >= MODERN_PLAY_IMAGE_MIN_API_LEVEL
+  );
+}
+
+const androidProvisionDeviceSpecSchema = z.object({
+  runtime: z.string().min(1).describe("Installed Android system-image package identifier"),
+  deviceType: z.string().min(1).describe("Android avdmanager device profile identifier"),
+  configuration: z.object({
+    memoryMb: z.number().int().positive().optional(),
+  }).strict().optional(),
+}).strict().superRefine((spec, context) => {
+  const memoryMb = spec.configuration?.memoryMb;
+  if (
+    memoryMb !== undefined &&
+    memoryMb < MIN_AVD_RAM_MB &&
+    isModernPlayStoreRuntime(spec.runtime)
+  ) {
+    context.addIssue({
+      code: "custom",
+      message:
+        `memoryMb must be at least ${MIN_AVD_RAM_MB} for Android API ` +
+        `${MODERN_PLAY_IMAGE_MIN_API_LEVEL}+ Play Store images`,
+      path: ["configuration", "memoryMb"],
+    });
+  }
+});
+
+const iosProvisionDeviceSpecSchema = z.object({
+  runtime: z.string().min(1).describe("CoreSimulator runtime identifier"),
+  deviceType: z.string().min(1).describe("CoreSimulator device-type identifier"),
+}).strict();
+
+export const provisionDeviceSchema = z.object({
+  operationId: z.string().min(1).describe("Caller-generated idempotency key"),
+  device: z.discriminatedUnion("platform", [
+    z.object({
+      platform: z.literal("android"),
+      name: z.string().min(1).describe("Exact AVD name"),
+      spec: androidProvisionDeviceSpecSchema,
+    }).strict(),
+    z.object({
+      platform: z.literal("ios"),
+      name: z.string().min(1).describe("Exact simulator name"),
+      spec: iosProvisionDeviceSpecSchema,
+    }).strict(),
+  ]),
+  boot: z.boolean().default(true).optional().describe("Boot the resolved device after creation or adoption"),
+  readiness: z.enum(["automation", "none"]).default("automation").optional().describe(
+    "Whether to wait for the AutoMobile automation runner after device boot",
+  ),
+  timeoutMs: z.number().int().positive().max(MAX_DEVICE_READY_TIMEOUT_MS).optional().describe(
+    "Total provision, boot, and readiness timeout in ms",
+  ),
+}).strict();
 
 export const killDeviceSchema = z.object({
   device: z.object({
@@ -255,6 +334,19 @@ export interface GetAppleArgs {
   automationReadyTimeoutMs?: number;
 }
 
+export interface ProvisionDeviceArgs {
+  operationId: string;
+  device: {
+    platform: "android" | "ios";
+    name: string;
+    spec: ExactDeviceSpecification;
+  };
+  boot: boolean;
+  readiness: "automation" | "none";
+  timeoutMs?: number;
+  __mcpSessionId?: string;
+}
+
 export interface KillDeviceArgs {
   device: BootedDevice;
 }
@@ -293,11 +385,21 @@ export interface DeviceToolsDependencies {
   ensureCtrlProxyReady?: (request: RunnerReadinessRequest) => Promise<void>;
   deviceCreationGateFactory: () => DeviceCreationGate;
   deviceProvisionerFactory: () => DeviceProvisioner;
+  exactDeviceProvisionerFactory: (
+    deviceManager: PlatformDeviceManager,
+    deviceCreationGate: DeviceCreationGate,
+  ) => ExactDeviceProvisioner;
+  provisionDeviceOperationStoreFactory: () => ProvisionDeviceOperationStore;
   clearInstalledAppsForDevice: (deviceId: string) => Promise<void>;
   stopPerformanceMonitoring: (deviceId: string) => void;
   idGenerator: IdGenerator;
   timer: Timer;
 }
+
+const activeProvisionDeviceOperations = new Map<
+  string,
+  { fingerprint: string; promise: Promise<Record<string, unknown>> }
+>();
 
 async function defaultNotifyResourcesChanged(): Promise<void> {
   await notifyBootedDeviceResourcesUpdated();
@@ -1044,6 +1146,9 @@ function getDeviceToolsDependencies(): DeviceToolsDependencies {
       notifyResourcesChanged: defaultNotifyResourcesChanged,
       deviceCreationGateFactory: () => getDeviceCreationGate(),
       deviceProvisionerFactory: () => createDefaultDeviceProvisioner(),
+      exactDeviceProvisionerFactory: (deviceManager, deviceCreationGate) =>
+        createDefaultExactDeviceProvisioner(deviceManager, deviceCreationGate),
+      provisionDeviceOperationStoreFactory: () => new ProvisionDeviceOperationRepository(),
       clearInstalledAppsForDevice: defaultClearInstalledAppsForDevice,
       stopPerformanceMonitoring: deviceId => getPerformanceMonitor().stopMonitoring(deviceId),
       idGenerator: defaultIdGenerator,
@@ -1051,6 +1156,21 @@ function getDeviceToolsDependencies(): DeviceToolsDependencies {
     };
   }
   return moduleDependencies;
+}
+
+function provisionDeviceDependencyOverrides(
+  deps: Partial<DeviceToolsDependencies>,
+  currentDeps: DeviceToolsDependencies,
+): Pick<
+  DeviceToolsDependencies,
+  "exactDeviceProvisionerFactory" | "provisionDeviceOperationStoreFactory"
+> {
+  return {
+    exactDeviceProvisionerFactory:
+      deps.exactDeviceProvisionerFactory ?? currentDeps.exactDeviceProvisionerFactory,
+    provisionDeviceOperationStoreFactory:
+      deps.provisionDeviceOperationStoreFactory ?? currentDeps.provisionDeviceOperationStoreFactory,
+  };
 }
 
 export function setDeviceToolsDependencies(deps: Partial<DeviceToolsDependencies>): void {
@@ -1062,6 +1182,7 @@ export function setDeviceToolsDependencies(deps: Partial<DeviceToolsDependencies
     ensureCtrlProxyReady: deps.ensureCtrlProxyReady ?? currentDeps.ensureCtrlProxyReady,
     deviceCreationGateFactory: deps.deviceCreationGateFactory ?? currentDeps.deviceCreationGateFactory,
     deviceProvisionerFactory: deps.deviceProvisionerFactory ?? currentDeps.deviceProvisionerFactory,
+    ...provisionDeviceDependencyOverrides(deps, currentDeps),
     clearInstalledAppsForDevice:
       deps.clearInstalledAppsForDevice ?? currentDeps.clearInstalledAppsForDevice,
     stopPerformanceMonitoring:
@@ -1073,6 +1194,7 @@ export function setDeviceToolsDependencies(deps: Partial<DeviceToolsDependencies
 
 export function resetDeviceToolsDependencies(): void {
   moduleDependencies = null;
+  activeProvisionDeviceOperations.clear();
 }
 
 function describeStartDeviceRequest(args: StartDeviceArgs): string {
@@ -1092,6 +1214,125 @@ function resolveRunnerReadinessTimeoutMs(args: StartDeviceArgs): number {
     args.timeoutMs ??
     serverConfig.getRunnerReadinessTimeoutMs()
   );
+}
+
+function provisionDeviceFingerprint(args: ProvisionDeviceArgs): string {
+  return createHash("sha256")
+    .update(stableStringify({
+      device: args.device,
+      boot: args.boot,
+      readiness: args.readiness,
+      timeoutMs: args.timeoutMs,
+    }))
+    .digest("hex");
+}
+
+function parseProvisionDeviceArgs(input: ProvisionDeviceArgs): ProvisionDeviceArgs {
+  const __mcpSessionId = input.__mcpSessionId;
+  const publicInput: Record<string, unknown> = { ...input };
+  delete publicInput.__mcpSessionId;
+  delete publicInput.__executionId;
+  delete publicInput.__executionStartTime;
+  const parsed = provisionDeviceSchema.parse(publicInput);
+  return {
+    ...parsed,
+    boot: parsed.boot ?? true,
+    readiness: parsed.readiness ?? "automation",
+    __mcpSessionId,
+  };
+}
+
+function provisionDeviceTimeoutError(phase: string): ProvisionDeviceError {
+  return new ProvisionDeviceError(
+    "timeout",
+    `provisionDevice timeout exhausted while ${phase}; remainingBudgetMs=0`,
+  );
+}
+
+async function runProvisionDeviceWithinDeadline<T>(
+  timer: Pick<Timer, "now" | "setTimeout" | "clearTimeout">,
+  totalDeadlineMs: number,
+  requestSignal: AbortSignal | undefined,
+  phase: string,
+  operation: (signal: AbortSignal) => Promise<T>,
+): Promise<T> {
+  const remainingMs = Math.floor(totalDeadlineMs - timer.now());
+  if (remainingMs <= 0) {
+    throw provisionDeviceTimeoutError(phase);
+  }
+
+  const controller = new AbortController();
+  const signal = requestSignal
+    ? AbortSignal.any([requestSignal, controller.signal])
+    : controller.signal;
+  let timeoutHandle: NodeJS.Timeout | undefined;
+  let removeAbortListener: (() => void) | undefined;
+  const operationPromise = operation(signal);
+  void operationPromise.catch(() => {});
+
+  try {
+    return await Promise.race([
+      operationPromise,
+      new Promise<never>((_resolve, reject) => {
+        timeoutHandle = timer.setTimeout(() => {
+          const error = provisionDeviceTimeoutError(phase);
+          controller.abort(error);
+          reject(error);
+        }, remainingMs);
+      }),
+      ...(requestSignal
+        ? [new Promise<never>((_resolve, reject) => {
+            const rejectForAbort = () => reject(requestSignal.reason);
+            if (requestSignal.aborted) {
+              rejectForAbort();
+              return;
+            }
+            requestSignal.addEventListener("abort", rejectForAbort, { once: true });
+            removeAbortListener = () =>
+              requestSignal.removeEventListener("abort", rejectForAbort);
+          })]
+        : []),
+    ]);
+  } finally {
+    if (timeoutHandle) {
+      timer.clearTimeout(timeoutHandle);
+    }
+    removeAbortListener?.();
+  }
+}
+
+async function waitForProvisionDeviceOperation<T>(
+  promise: Promise<T>,
+  signal: AbortSignal | undefined,
+): Promise<T> {
+  if (!signal) {
+    return await promise;
+  }
+  if (signal.aborted) {
+    throw signal.reason;
+  }
+
+  let removeAbortListener: (() => void) | undefined;
+  try {
+    return await Promise.race([
+      promise,
+      new Promise<never>((_resolve, reject) => {
+        const rejectForAbort = () => reject(signal.reason);
+        signal.addEventListener("abort", rejectForAbort, { once: true });
+        removeAbortListener = () => signal.removeEventListener("abort", rejectForAbort);
+      }),
+    ]);
+  } finally {
+    removeAbortListener?.();
+  }
+}
+
+function createProvisionDeviceResponse(result: Record<string, unknown>) {
+  const device = result.device as { name: string; platform: string };
+  return createJSONToolResponse({
+    message: `${device.platform} '${device.name}' provisioned (${result.lifecycleState})`,
+    ...result,
+  });
 }
 
 function validateBootIdentity(
@@ -1711,6 +1952,415 @@ export function registerDeviceTools() {
     });
   };
 
+  const provisionDeviceHandler = async (
+    input: ProvisionDeviceArgs,
+    _progress?: ProgressCallback,
+    signal?: AbortSignal,
+  ) => {
+    const args = parseProvisionDeviceArgs(input);
+    const fingerprint = provisionDeviceFingerprint(args);
+    const active = activeProvisionDeviceOperations.get(args.operationId);
+    if (active) {
+      if (active.fingerprint !== fingerprint) {
+        return createToolErrorResponse(
+          "operation_conflict",
+          `operationId '${args.operationId}' is already running with a different provisionDevice request.`,
+        );
+      }
+      try {
+        return createProvisionDeviceResponse(
+          await waitForProvisionDeviceOperation(active.promise, signal),
+        );
+      } catch (error) {
+        return provisionDeviceErrorResponse(error);
+      }
+    }
+
+    const sharedController = new AbortController();
+    const promise = executeProvisionDevice(args, fingerprint, sharedController.signal);
+    activeProvisionDeviceOperations.set(args.operationId, { fingerprint, promise });
+    void promise.then(
+      () => {
+        if (activeProvisionDeviceOperations.get(args.operationId)?.promise === promise) {
+          activeProvisionDeviceOperations.delete(args.operationId);
+        }
+      },
+      () => {
+        if (activeProvisionDeviceOperations.get(args.operationId)?.promise === promise) {
+          activeProvisionDeviceOperations.delete(args.operationId);
+        }
+      },
+    );
+    try {
+      return createProvisionDeviceResponse(
+        await waitForProvisionDeviceOperation(promise, signal),
+      );
+    } catch (error) {
+      return provisionDeviceErrorResponse(error);
+    }
+  };
+
+  async function executeProvisionDevice(
+    args: ProvisionDeviceArgs,
+    fingerprint: string,
+    signal: AbortSignal | undefined,
+  ): Promise<Record<string, unknown>> {
+    const deps = getDeviceToolsDependencies();
+    const store = deps.provisionDeviceOperationStoreFactory();
+    const operation = await store.begin(args.operationId, fingerprint);
+    if (!operation.started) {
+      if (!args.boot) {
+        return operation.result;
+      }
+      if (hasLiveProvisionDeviceSession(operation.result)) {
+        return operation.result;
+      }
+
+      // Sessions are daemon-local and are expired during daemon startup. A
+      // replay of a completed boot operation therefore runs the idempotent
+      // lifecycle again to bind a live session before reporting readiness.
+      const rebound = await runProvisionDeviceLifecycle(
+        args,
+        deps,
+        operation.reconcileExistingConfiguration,
+        () => store.markDeviceCreationStarted(args.operationId),
+        signal,
+      );
+      const refreshed = preserveProvisionDeviceOwnership(operation.result, rebound);
+      await store.complete(args.operationId, refreshed);
+      return refreshed;
+    }
+
+    try {
+      const result = await runProvisionDeviceLifecycle(
+        args,
+        deps,
+        operation.reconcileExistingConfiguration,
+        () => store.markDeviceCreationStarted(args.operationId),
+        signal,
+      );
+      await store.complete(args.operationId, result);
+      return result;
+    } catch (error) {
+      const provisionError = toProvisionDeviceError(args, error);
+      await store.fail(args.operationId, provisionError.code, provisionError.message);
+      throw provisionError;
+    }
+  }
+
+  function hasLiveProvisionDeviceSession(result: Record<string, unknown>): boolean {
+    const persistedSession = getPersistedProvisionDeviceSession(result);
+    const daemonState = DaemonState.getInstance();
+    if (!persistedSession || !daemonState.isInitialized()) {
+      return false;
+    }
+
+    const session = daemonState.getSessionManager().getSession(persistedSession.sessionId);
+    const pooledDevice = daemonState.getDevicePool().getDeviceForSession(persistedSession.sessionId);
+    return (
+      session?.assignedDevice === persistedSession.deviceId &&
+      session.platform === persistedSession.platform &&
+      pooledDevice?.id === persistedSession.deviceId &&
+      pooledDevice.platform === persistedSession.platform
+    );
+  }
+
+  function getPersistedProvisionDeviceSession(
+    result: Record<string, unknown>,
+  ): { sessionId: string; deviceId: string; platform: "android" | "ios" } | undefined {
+    if (typeof result.sessionId !== "string") {
+      return undefined;
+    }
+    const device = result.device;
+    if (typeof device !== "object" || device === null || Array.isArray(device)) {
+      return undefined;
+    }
+    const deviceRecord = device as Record<string, unknown>;
+    if (typeof deviceRecord.deviceId !== "string") {
+      return undefined;
+    }
+    if (deviceRecord.platform !== "android" && deviceRecord.platform !== "ios") {
+      return undefined;
+    }
+    return {
+      sessionId: result.sessionId,
+      deviceId: deviceRecord.deviceId,
+      platform: deviceRecord.platform,
+    };
+  }
+
+  function preserveProvisionDeviceOwnership(
+    persisted: Record<string, unknown>,
+    refreshed: Record<string, unknown>,
+  ): Record<string, unknown> {
+    return {
+      ...refreshed,
+      created: persisted.created,
+      adopted: persisted.adopted,
+    };
+  }
+
+  function toProvisionDeviceError(
+    args: ProvisionDeviceArgs,
+    error: unknown,
+  ): ProvisionDeviceError {
+    if (error instanceof ProvisionDeviceError) {
+      return error;
+    }
+    return new ProvisionDeviceError(
+      "platform_command_failed",
+      `Failed to provision ${args.device.platform} device '${args.device.name}': ${error instanceof Error ? error.message : String(error)}`,
+    );
+  }
+
+  async function runProvisionDeviceLifecycle(
+    args: ProvisionDeviceArgs,
+    deps: DeviceToolsDependencies,
+    reconcileExistingConfiguration: boolean,
+    markDeviceCreationStarted: () => Promise<void>,
+    signal: AbortSignal | undefined,
+  ): Promise<Record<string, unknown>> {
+    const perf = createPerformanceTracker(true);
+    perf.serial("provisionDevice");
+    const totalDeadlineMs = deps.timer.now() +
+      (args.timeoutMs ?? DEFAULT_PROVISION_DEVICE_TIMEOUT_MS);
+    try {
+      const deviceManager = deps.deviceManagerFactory();
+      const deviceCreationGate = deps.deviceCreationGateFactory();
+      const provisioned = await provisionExactDevice(
+        args,
+        deps.exactDeviceProvisionerFactory(deviceManager, deviceCreationGate),
+        perf,
+        deps.timer,
+        totalDeadlineMs,
+        reconcileExistingConfiguration,
+        markDeviceCreationStarted,
+        signal,
+      );
+      if (!args.boot) {
+        if (provisioned.created) {
+          await deps.notifyResourcesChanged();
+        }
+        perf.end();
+        return buildProvisionDeviceResult(args, provisioned, perf, undefined);
+      }
+
+      const booted = await bootExactProvisionedDevice(
+        args,
+        deps,
+        deviceManager,
+        deviceCreationGate,
+        provisioned,
+        perf,
+        totalDeadlineMs,
+        signal,
+      );
+      if (provisioned.created || booted.source === "cold-boot") {
+        await deps.notifyResourcesChanged();
+      }
+      perf.end();
+      return buildProvisionDeviceResult(args, provisioned, perf, booted);
+    } catch (error) {
+      perf.end();
+      throw error;
+    }
+  }
+
+  async function provisionExactDevice(
+    args: ProvisionDeviceArgs,
+    provisioner: ExactDeviceProvisioner,
+    perf: ReturnType<typeof createPerformanceTracker>,
+    timer: Timer,
+    totalDeadlineMs: number,
+    reconcileExistingConfiguration: boolean,
+    markDeviceCreationStarted: () => Promise<void>,
+    signal: AbortSignal | undefined,
+  ): Promise<Awaited<ReturnType<ExactDeviceProvisioner["provision"]>>> {
+    perf.startOperation("provisionExactDevice");
+    try {
+      return await runProvisionDeviceWithinDeadline(
+        timer,
+        totalDeadlineMs,
+        signal,
+        "provisioning the exact device",
+        async deadlineSignal => await provisioner.provision({
+          platform: args.device.platform,
+          name: args.device.name,
+          spec: args.device.spec,
+          reconcileExistingConfiguration,
+          onBeforeCreate: markDeviceCreationStarted,
+          signal: deadlineSignal,
+        }),
+      );
+    } finally {
+      perf.endOperation("provisionExactDevice");
+    }
+  }
+
+  async function bootExactProvisionedDevice(
+    args: ProvisionDeviceArgs,
+    deps: DeviceToolsDependencies,
+    deviceManager: PlatformDeviceManager,
+    deviceCreationGate: DeviceCreationGate,
+    provisioned: Awaited<ReturnType<ExactDeviceProvisioner["provision"]>>,
+    perf: ReturnType<typeof createPerformanceTracker>,
+    totalDeadlineMs: number,
+    signal: AbortSignal | undefined,
+  ): Promise<{ device: BootedDevice; sessionId: string; source: "booted" | "cold-boot" }> {
+    const requestedIdentity = `platform=${args.device.platform} name=${args.device.name}`;
+    const bootService = new DeviceBootService({
+      deviceManager,
+      deviceMatcher: deps.deviceMatcherFactory(),
+      deviceCreationGate,
+      deviceProvisioner: deps.deviceProvisionerFactory(),
+      matchingStrategy: DEVICE_POOL_MATCHING,
+      timer: deps.timer,
+    });
+    let boot: DeviceBootResult | undefined;
+    let ownershipTransferred = false;
+    let releaseReadinessReservation: (() => Promise<void>) | undefined;
+    try {
+      const alreadyBooted = await runProvisionDeviceWithinDeadline(
+        deps.timer,
+        totalDeadlineMs,
+        signal,
+        "discovering an already-running exact device",
+        async () => await deviceManager.getBootedDevices(args.device.platform),
+      );
+      const exactBootedDevice = args.device.platform === "ios"
+        ? alreadyBooted.find((device) => device.deviceId === provisioned.device.deviceId)
+        : alreadyBooted.find(
+          (device) =>
+            device.deviceId === provisioned.device.deviceId ||
+            device.name === provisioned.device.name,
+        );
+      if (args.device.platform === "ios" && !provisioned.device.deviceId) {
+        throw new ProvisionDeviceError(
+          "identity_conflict",
+          `Exact iOS simulator '${args.device.name}' has no UDID.`,
+        );
+      }
+      perf.startOperation("bootDevice");
+      boot = await bootService.boot({
+        platform: args.device.platform,
+        deviceId: exactBootedDevice?.deviceId ??
+          provisioned.device.deviceId ??
+          provisioned.device.name,
+        timeoutMs: Math.max(1, totalDeadlineMs - deps.timer.now()),
+        totalDeadlineMs,
+        signal,
+      });
+      perf.endOperation("bootDevice");
+      if (
+        args.device.platform === "ios" &&
+        boot.device.deviceId !== provisioned.device.deviceId
+      ) {
+        throw new ProvisionDeviceError(
+          "identity_conflict",
+          `Exact iOS simulator '${args.device.name}' resolved to unexpected UDID '${boot.device.deviceId}'.`,
+        );
+      }
+      validatePooledDeviceMapping(boot.device, requestedIdentity);
+      releaseReadinessReservation = await reserveProvisionDeviceReadiness(boot.device);
+      clearColdBootShutdownMarker(boot.source, boot.device.deviceId);
+      await ensureProvisionDeviceReadiness(args, deps, boot.device, requestedIdentity, totalDeadlineMs, perf, signal);
+      validatePooledDeviceMapping(boot.device, requestedIdentity);
+      publishWarmDeviceReady(boot.source, boot.device.deviceId);
+      const sessionId = await bindBootedDeviceSession(
+        boot.device,
+        {
+          platform: args.device.platform,
+          name: args.device.name,
+          timeoutMs: args.timeoutMs,
+          __mcpSessionId: args.__mcpSessionId,
+        },
+        provisioned.device,
+        boot.processHandle,
+      );
+      ownershipTransferred = true;
+      return { device: boot.device, sessionId, source: boot.source };
+    } catch (error) {
+      if (!ownershipTransferred) {
+        cancelUnownedColdBoot(boot);
+      }
+      throw error;
+    } finally {
+      await releaseReadinessReservation?.();
+    }
+  }
+
+  async function reserveProvisionDeviceReadiness(
+    device: BootedDevice,
+  ): Promise<(() => Promise<void>) | undefined> {
+    const daemonState = DaemonState.getInstance();
+    if (!daemonState.isInitialized()) {
+      return undefined;
+    }
+    return await daemonState.getDevicePool().reserveDeviceForReadiness(device.deviceId, device);
+  }
+
+  async function ensureProvisionDeviceReadiness(
+    args: ProvisionDeviceArgs,
+    deps: DeviceToolsDependencies,
+    device: BootedDevice,
+    requestedIdentity: string,
+    totalDeadlineMs: number,
+    perf: ReturnType<typeof createPerformanceTracker>,
+    signal: AbortSignal | undefined,
+  ): Promise<void> {
+    if (args.readiness !== "automation") {
+      return;
+    }
+    const ctrlProxySetup = deps.ensureCtrlProxyReady ?? ensureCtrlProxyReady;
+    await ctrlProxySetup({
+      device,
+      requestedIdentity,
+      totalDeadlineMs,
+      readinessTimeoutMs: args.timeoutMs ?? serverConfig.getRunnerReadinessTimeoutMs(),
+      skipCtrlProxyDownload: serverConfig.isSkipCtrlProxyDownloadEnabled(),
+      perf,
+      signal,
+    });
+  }
+
+  function buildProvisionDeviceResult(
+    args: ProvisionDeviceArgs,
+    provisioned: Awaited<ReturnType<ExactDeviceProvisioner["provision"]>>,
+    perf: ReturnType<typeof createPerformanceTracker>,
+    booted: { device: BootedDevice; sessionId: string } | undefined,
+  ): Record<string, unknown> {
+    return {
+      operationId: args.operationId,
+      device: booted?.device ?? provisioned.device,
+      requestedSpec: args.device.spec,
+      resolvedSpec: provisioned.resolvedSpec,
+      created: provisioned.created,
+      adopted: !provisioned.created,
+      lifecycleState: booted ? "ready" : provisioned.created ? "created" : "adopted",
+      readiness: {
+        mode: args.readiness,
+        status: booted
+          ? args.readiness === "automation" ? "automation_ready" : "device_ready"
+          : "not_requested",
+      },
+      ...(booted ? { sessionId: booted.sessionId } : {}),
+      timing: perf.getTimings(),
+    };
+  }
+
+  function provisionDeviceErrorResponse(error: unknown) {
+    if (error instanceof ProvisionDeviceError) {
+      return createToolErrorResponse(error.code, error.message);
+    }
+    if (error instanceof ProvisionDeviceOperationConflictError) {
+      return createToolErrorResponse("operation_conflict", error.message);
+    }
+    return createToolErrorResponse(
+      "platform_command_failed",
+      error instanceof Error ? error.message : String(error),
+    );
+  }
+
   type DevicePreparationBudgets = {
     bootTimeoutMs: number;
     automationReadyTimeoutMs: number;
@@ -2160,6 +2810,13 @@ export function registerDeviceTools() {
     startDeviceSchema,
     startDeviceHandler,
     { supportsProgress: true, hidden: true },
+  );
+
+  ToolRegistry.register(
+    "provisionDevice",
+    "Provision exact virtual device",
+    provisionDeviceSchema,
+    provisionDeviceHandler,
   );
 
   ToolRegistry.register(

--- a/src/server/deviceTools.ts
+++ b/src/server/deviceTools.ts
@@ -2121,11 +2121,16 @@ export function registerDeviceTools() {
     if (deviceRecord.platform !== "android" && deviceRecord.platform !== "ios") {
       return undefined;
     }
+    const persistedDevice: BootedDevice = {
+      name: deviceRecord.name,
+      platform: deviceRecord.platform,
+      deviceId: deviceRecord.deviceId,
+    };
     return {
       sessionId: result.sessionId,
       deviceId: deviceRecord.deviceId,
       platform: deviceRecord.platform,
-      device: deviceRecord as BootedDevice,
+      device: persistedDevice,
     };
   }
 

--- a/src/utils/android-cmdline-tools/AvdConfigReader.ts
+++ b/src/utils/android-cmdline-tools/AvdConfigReader.ts
@@ -1,4 +1,5 @@
 import { logger } from "../logger";
+import { dirname, join } from "node:path";
 
 /** Minimum guest memory required by modern Play Store system images. */
 export const MIN_AVD_RAM_MB = 2048;
@@ -56,6 +57,25 @@ export function apiLevelToVersion(apiLevel: number): string | undefined {
   return API_LEVEL_TO_VERSION[apiLevel];
 }
 
+function nonEmptyEnvironmentValue(value: string | undefined): string | undefined {
+  return value || undefined;
+}
+
+export function resolveAndroidAvdHome(
+  environment: NodeJS.ProcessEnv,
+  homeDirectory?: string,
+): string {
+  const androidUserHome = nonEmptyEnvironmentValue(environment.ANDROID_USER_HOME);
+  const avdHome = nonEmptyEnvironmentValue(environment.ANDROID_AVD_HOME);
+  const androidSdkHome = nonEmptyEnvironmentValue(environment.ANDROID_SDK_HOME);
+  const configHome =
+    nonEmptyEnvironmentValue(environment.ANDROID_EMULATOR_HOME) ??
+    androidUserHome ??
+    (androidSdkHome ? join(androidSdkHome, ".android") : undefined) ??
+    (homeDirectory ? join(homeDirectory, ".android") : "");
+  return avdHome ?? join(configHome, "avd");
+}
+
 /**
  * Reads AVD config.ini files from the AVD home directory.
  */
@@ -76,21 +96,22 @@ export class FileAvdConfigReader implements AvdConfigReader {
     this.existsFn = existsFn ?? ((p: string) => fs.existsSync(p));
 
     const homeDir = process.env.HOME || process.env.USERPROFILE;
-    const androidUserHome = process.env.ANDROID_USER_HOME || undefined;
-    const avdHomeEnv = process.env.ANDROID_AVD_HOME || undefined;
-    const configHome = process.env.ANDROID_EMULATOR_HOME
+    const androidUserHome = nonEmptyEnvironmentValue(process.env.ANDROID_USER_HOME);
+    const avdHomeEnv = nonEmptyEnvironmentValue(process.env.ANDROID_AVD_HOME);
+    const androidSdkHome = nonEmptyEnvironmentValue(process.env.ANDROID_SDK_HOME);
+    const configHome = nonEmptyEnvironmentValue(process.env.ANDROID_EMULATOR_HOME)
       || androidUserHome
-      || (process.env.ANDROID_SDK_HOME ? path.join(process.env.ANDROID_SDK_HOME, ".android") : undefined)
+      || (androidSdkHome ? path.join(androidSdkHome, ".android") : undefined)
       || (homeDir ? path.join(homeDir, ".android") : "");
     this.avdHome = avdHome
       ?? avdHomeEnv
-      ?? path.join(configHome, "avd");
+      ?? resolveAndroidAvdHome(process.env, homeDir);
     this.configHome = avdHome
-      ? path.dirname(avdHome)
-      : (process.env.ANDROID_EMULATOR_HOME
+      ? dirname(avdHome)
+      : (nonEmptyEnvironmentValue(process.env.ANDROID_EMULATOR_HOME)
         || androidUserHome
-        || (process.env.ANDROID_SDK_HOME ? path.join(process.env.ANDROID_SDK_HOME, ".android") : undefined)
-        || (avdHomeEnv ? path.dirname(this.avdHome) : configHome));
+        || (androidSdkHome ? path.join(androidSdkHome, ".android") : undefined)
+        || (avdHomeEnv ? dirname(this.avdHome) : configHome));
   }
 
   async readConfig(avdName: string): Promise<AvdConfig | null> {

--- a/src/utils/android-cmdline-tools/AvdConfigReader.ts
+++ b/src/utils/android-cmdline-tools/AvdConfigReader.ts
@@ -246,7 +246,7 @@ function parseArchitecture(props: Map<string, string>): Pick<AvdConfig, "archite
     imagePathSegments?.at(-1),
   ];
   for (const candidate of candidates) {
-    const architecture = normalizeArchitecture(candidate);
+    const architecture = normalizeAndroidArchitecture(candidate);
     if (architecture) {
       return { architecture };
     }
@@ -254,7 +254,7 @@ function parseArchitecture(props: Map<string, string>): Pick<AvdConfig, "archite
   return {};
 }
 
-function normalizeArchitecture(value: string | undefined): string | undefined {
+export function normalizeAndroidArchitecture(value: string | undefined): string | undefined {
   switch (value?.trim().toLowerCase()) {
     case "arm64":
     case "arm64-v8a":

--- a/src/utils/deviceTimeouts.ts
+++ b/src/utils/deviceTimeouts.ts
@@ -1,4 +1,7 @@
 export const DEFAULT_DEVICE_READY_TIMEOUT_MS = 120000;
+// Exact virtual-device provisioning can spend up to five minutes in
+// `avdmanager create avd` before the regular boot/readiness phases begin.
+export const DEFAULT_PROVISION_DEVICE_TIMEOUT_MS = 8 * 60 * 1000;
 export const START_DEVICE_MCP_TIMEOUT_OVERHEAD_MS = 5_000;
 export const DAEMON_RPC_SOCKET_IDLE_TIMEOUT_MS = 15 * 60 * 1000;
 const DAEMON_RPC_SOCKET_COMPLETION_HEADROOM_MS = 5_000;

--- a/src/utils/exactDeviceProvisioning.ts
+++ b/src/utils/exactDeviceProvisioning.ts
@@ -8,11 +8,13 @@ import type { PlatformDeviceManager } from "./deviceUtils";
 import type { AvdConfigReader } from "./android-cmdline-tools/AvdConfigReader";
 import {
   FileAvdConfigReader,
+  normalizeAndroidArchitecture,
   resolveAndroidAvdHome,
 } from "./android-cmdline-tools/AvdConfigReader";
 import { AvdManagerClient } from "./android-cmdline-tools/AvdManagerClient";
 import type { CreateAvdParams } from "./android-cmdline-tools/avdmanager";
 import { SimCtlClient } from "./ios-cmdline-tools/SimCtlClient";
+import { throwIfAborted } from "./toolUtils";
 
 export interface AndroidDeviceSpecification {
   runtime: string;
@@ -171,7 +173,7 @@ function requestedAndroidRuntime(runtime: string): {
   return {
     apiLevel: Number(apiMatch[1]),
     tag: parts[2],
-    architecture: parts[3] === "arm64-v8a" ? "arm64" : parts[3],
+    architecture: normalizeAndroidArchitecture(parts[3]) ?? parts[3],
   };
 }
 
@@ -209,6 +211,7 @@ const exactProvisioningLocks = new Map<string, Promise<void>>();
 async function runWithExactProvisioningLock<T>(
   platform: "android" | "ios",
   name: string,
+  signal: AbortSignal | undefined,
   operation: () => Promise<T>,
 ): Promise<T> {
   const key = `${platform}:${name}`;
@@ -218,8 +221,8 @@ async function runWithExactProvisioningLock<T>(
     release = resolve;
   });
   exactProvisioningLocks.set(key, current);
-  await previous;
   try {
+    await waitForExactProvisioningTurn(previous, signal);
     return await operation();
   } finally {
     release();
@@ -227,6 +230,40 @@ async function runWithExactProvisioningLock<T>(
       exactProvisioningLocks.delete(key);
     }
   }
+}
+
+async function waitForExactProvisioningTurn(
+  previous: Promise<void> | undefined,
+  signal: AbortSignal | undefined,
+): Promise<void> {
+  throwIfAborted(signal);
+  if (!previous || !signal) {
+    await previous;
+    return;
+  }
+
+  let removeAbortListener: (() => void) | undefined;
+  const aborted = new Promise<never>((_resolve, reject) => {
+    const rejectIfAborted = (): void => {
+      try {
+        throwIfAborted(signal);
+      } catch (error) {
+        reject(error);
+      }
+    };
+    if (signal.aborted) {
+      rejectIfAborted();
+      return;
+    }
+    signal.addEventListener("abort", rejectIfAborted, { once: true });
+    removeAbortListener = () => signal.removeEventListener("abort", rejectIfAborted);
+  });
+  try {
+    await Promise.race([previous, aborted]);
+  } finally {
+    removeAbortListener?.();
+  }
+  throwIfAborted(signal);
 }
 
 /**
@@ -240,6 +277,7 @@ export class DefaultExactDeviceProvisioner implements ExactDeviceProvisioner {
     return await runWithExactProvisioningLock(
       request.platform,
       request.name,
+      request.signal,
       async () => await this.provisionLocked(request),
     );
   }

--- a/src/utils/exactDeviceProvisioning.ts
+++ b/src/utils/exactDeviceProvisioning.ts
@@ -1,0 +1,437 @@
+import { promises as fs } from "node:fs";
+import { homedir } from "node:os";
+import { join } from "node:path";
+import type { DeviceInfo } from "../models";
+import { ActionableError } from "../models";
+import type { DeviceCreationGate } from "./deviceCreationGate";
+import type { PlatformDeviceManager } from "./deviceUtils";
+import type { AvdConfigReader } from "./android-cmdline-tools/AvdConfigReader";
+import {
+  FileAvdConfigReader,
+  resolveAndroidAvdHome,
+} from "./android-cmdline-tools/AvdConfigReader";
+import { AvdManagerClient } from "./android-cmdline-tools/AvdManagerClient";
+import type { CreateAvdParams } from "./android-cmdline-tools/avdmanager";
+import { SimCtlClient } from "./ios-cmdline-tools/SimCtlClient";
+
+export interface AndroidDeviceSpecification {
+  runtime: string;
+  deviceType: string;
+  configuration?: {
+    memoryMb?: number;
+  };
+}
+
+export interface IosDeviceSpecification {
+  runtime: string;
+  deviceType: string;
+}
+
+export type ExactDeviceSpecification = AndroidDeviceSpecification | IosDeviceSpecification;
+
+export interface ExactDeviceProvisionRequest {
+  platform: "android" | "ios";
+  name: string;
+  deviceId?: string;
+  spec: ExactDeviceSpecification;
+  /** Reconcile mutable configuration only for a replay of the same operation. */
+  reconcileExistingConfiguration?: boolean;
+  /** Persist ownership immediately before creating a previously absent device. */
+  onBeforeCreate?: () => Promise<void>;
+  signal?: AbortSignal;
+}
+
+export interface ExactProvisionedDevice {
+  device: DeviceInfo;
+  created: boolean;
+  resolvedSpec: ExactDeviceSpecification;
+}
+
+export type ProvisionDeviceFailureCode =
+  | "creation_not_allowed"
+  | "identity_conflict"
+  | "timeout"
+  | "platform_command_failed";
+
+export class ProvisionDeviceError extends ActionableError {
+  constructor(
+    public readonly code: ProvisionDeviceFailureCode,
+    message: string,
+  ) {
+    super(message);
+    this.name = "ProvisionDeviceError";
+  }
+}
+
+export interface ExactAndroidAvdClient {
+  createAvd(
+    params: CreateAvdParams,
+    options?: { signal?: AbortSignal },
+  ): Promise<{ success: boolean; message: string; avdName?: string }>;
+}
+
+export interface ExactIosSimulatorClient {
+  createSimulator(
+    name: string,
+    deviceType: string,
+    runtime: string,
+    signal?: AbortSignal,
+  ): Promise<string>;
+}
+
+export interface AndroidAvdConfigWriter {
+  setMemoryMb(avdName: string, memoryMb: number): Promise<void>;
+}
+
+interface FileAndroidAvdConfigWriterDependencies {
+  readFile(path: string, encoding: "utf8"): Promise<string>;
+  writeFile(path: string, content: string, encoding: "utf8"): Promise<void>;
+  environment: NodeJS.ProcessEnv;
+  homeDirectory: () => string;
+}
+
+function defaultAndroidAvdConfigWriterDependencies(): FileAndroidAvdConfigWriterDependencies {
+  return {
+    readFile: (path, encoding) => fs.readFile(path, encoding),
+    writeFile: (path, content, encoding) => fs.writeFile(path, content, encoding),
+    environment: process.env,
+    homeDirectory: homedir,
+  };
+}
+
+/**
+ * Applies a small, typed subset of AVD hardware configuration after
+ * `avdmanager create avd`. The caller creates only default-path AVDs, so the
+ * standard AVD-home location is authoritative here.
+ */
+export class FileAndroidAvdConfigWriter implements AndroidAvdConfigWriter {
+  constructor(
+    private readonly dependencies: FileAndroidAvdConfigWriterDependencies =
+      defaultAndroidAvdConfigWriterDependencies(),
+  ) {}
+
+  async setMemoryMb(avdName: string, memoryMb: number): Promise<void> {
+    if (!Number.isInteger(memoryMb) || memoryMb <= 0) {
+      throw new ProvisionDeviceError(
+        "platform_command_failed",
+        `Android AVD memoryMb must be a positive integer; got ${memoryMb}.`,
+      );
+    }
+    const avdHome = resolveAndroidAvdHome(
+      this.dependencies.environment,
+      this.dependencies.homeDirectory(),
+    );
+    const configPath = join(avdHome, `${avdName}.avd`, "config.ini");
+    const content = await this.dependencies.readFile(configPath, "utf8");
+    const lines = content.split(/\r?\n/);
+    let replaced = false;
+    const updated = lines.map((line) => {
+      if (line.startsWith("hw.ramSize=")) {
+        replaced = true;
+        return `hw.ramSize=${memoryMb}`;
+      }
+      return line;
+    });
+    if (!replaced) {
+      if (updated.at(-1) !== "") {
+        updated.push("");
+      }
+      updated.push(`hw.ramSize=${memoryMb}`, "");
+    }
+    await this.dependencies.writeFile(configPath, updated.join("\n"), "utf8");
+  }
+}
+
+export interface ExactDeviceProvisioner {
+  provision(request: ExactDeviceProvisionRequest): Promise<ExactProvisionedDevice>;
+}
+
+export interface DefaultExactDeviceProvisionerDependencies {
+  listDeviceImages: PlatformDeviceManager["listDeviceImages"];
+  isCreationAllowed: DeviceCreationGate["isCreationAllowed"];
+  avdManager: ExactAndroidAvdClient;
+  androidConfigReader: AvdConfigReader;
+  androidConfigWriter: AndroidAvdConfigWriter;
+  iosSimulator: ExactIosSimulatorClient;
+}
+
+function requestedAndroidRuntime(runtime: string): {
+  apiLevel: number;
+  tag: string;
+  architecture: string;
+} | undefined {
+  const parts = runtime.split(";");
+  if (parts.length !== 4 || parts[0] !== "system-images") {
+    return undefined;
+  }
+  const apiMatch = /^android-(\d+)$/.exec(parts[1] ?? "");
+  if (!apiMatch || !parts[2] || !parts[3]) {
+    return undefined;
+  }
+  return {
+    apiLevel: Number(apiMatch[1]),
+    tag: parts[2],
+    architecture: parts[3] === "arm64-v8a" ? "arm64" : parts[3],
+  };
+}
+
+function sameAndroidDeviceIdentity(
+  spec: AndroidDeviceSpecification,
+  config: Awaited<ReturnType<AvdConfigReader["readConfig"]>>,
+): boolean {
+  const runtime = requestedAndroidRuntime(spec.runtime);
+  if (!runtime || !config) {
+    return false;
+  }
+  if (
+    config.apiLevel !== runtime.apiLevel ||
+    config.tag !== runtime.tag ||
+    config.architecture !== runtime.architecture ||
+    config.deviceName !== spec.deviceType
+  ) {
+    return false;
+  }
+  return true;
+}
+
+function sameAndroidSpecification(
+  spec: AndroidDeviceSpecification,
+  config: Awaited<ReturnType<AvdConfigReader["readConfig"]>>,
+): boolean {
+  return sameAndroidDeviceIdentity(spec, config) && (
+    spec.configuration?.memoryMb === undefined ||
+    config?.ramSizeMb === spec.configuration.memoryMb
+  );
+}
+
+const exactProvisioningLocks = new Map<string, Promise<void>>();
+
+async function runWithExactProvisioningLock<T>(
+  platform: "android" | "ios",
+  name: string,
+  operation: () => Promise<T>,
+): Promise<T> {
+  const key = `${platform}:${name}`;
+  const previous = exactProvisioningLocks.get(key);
+  let release!: () => void;
+  const current = new Promise<void>((resolve) => {
+    release = resolve;
+  });
+  exactProvisioningLocks.set(key, current);
+  await previous;
+  try {
+    return await operation();
+  } finally {
+    release();
+    if (exactProvisioningLocks.get(key) === current) {
+      exactProvisioningLocks.delete(key);
+    }
+  }
+}
+
+/**
+ * Exact virtual-device creation used by trusted controllers. It intentionally
+ * never falls back to a "close enough" image, runtime, or device profile.
+ */
+export class DefaultExactDeviceProvisioner implements ExactDeviceProvisioner {
+  constructor(private readonly dependencies: DefaultExactDeviceProvisionerDependencies) {}
+
+  async provision(request: ExactDeviceProvisionRequest): Promise<ExactProvisionedDevice> {
+    return await runWithExactProvisioningLock(
+      request.platform,
+      request.name,
+      async () => await this.provisionLocked(request),
+    );
+  }
+
+  private async provisionLocked(request: ExactDeviceProvisionRequest): Promise<ExactProvisionedDevice> {
+    const images = await this.dependencies.listDeviceImages(request.platform);
+    const existing = this.findExisting(images, request);
+    if (existing) {
+      await this.assertExistingMatches(request, existing);
+      return {
+        device: existing,
+        created: false,
+        resolvedSpec: request.spec,
+      };
+    }
+
+    if (!this.dependencies.isCreationAllowed(true)) {
+      throw new ProvisionDeviceError(
+        "creation_not_allowed",
+        `Device creation is disabled; cannot provision exact ${request.platform} device '${request.name}'.`,
+      );
+    }
+
+    await request.onBeforeCreate?.();
+    if (request.platform === "android") {
+      return await this.createAndroid(request, request.spec as AndroidDeviceSpecification);
+    }
+    return await this.createIos(request, request.spec as IosDeviceSpecification);
+  }
+
+  private findExisting(
+    images: DeviceInfo[],
+    request: ExactDeviceProvisionRequest,
+  ): DeviceInfo | undefined {
+    if (request.platform !== "ios") {
+      return images.find((image) =>
+        image.name === request.name ||
+        (request.deviceId !== undefined && image.deviceId === request.deviceId),
+      );
+    }
+
+    if (request.deviceId !== undefined) {
+      return images.find((image) => image.deviceId === request.deviceId);
+    }
+
+    const candidates = images.filter((image) => image.name === request.name);
+    const spec = request.spec as IosDeviceSpecification;
+    return candidates.find((image) =>
+      image.isAvailable !== false &&
+      image.runtime === spec.runtime &&
+      image.deviceType === spec.deviceType,
+    ) ?? candidates.find((image) =>
+      image.runtime === spec.runtime &&
+      image.deviceType === spec.deviceType,
+    ) ?? candidates[0];
+  }
+
+  private async assertExistingMatches(
+    request: ExactDeviceProvisionRequest,
+    existing: DeviceInfo,
+  ): Promise<void> {
+    if (existing.platform !== request.platform) {
+      throw new ProvisionDeviceError(
+        "identity_conflict",
+        `Requested ${request.platform} device '${request.name}' conflicts with existing ${existing.platform} device.`,
+      );
+    }
+    if (existing.name !== request.name) {
+      throw new ProvisionDeviceError(
+        "identity_conflict",
+        `Requested device name '${request.name}' conflicts with existing '${existing.name}' for the supplied identity.`,
+      );
+    }
+
+    if (request.platform === "android") {
+      await this.assertAndroidExistingMatches(request, existing);
+      return;
+    }
+
+    this.assertIosExistingMatches(request, existing);
+  }
+
+  private async assertAndroidExistingMatches(
+    request: ExactDeviceProvisionRequest,
+    existing: DeviceInfo,
+  ): Promise<void> {
+    const spec = request.spec as AndroidDeviceSpecification;
+    const config = await this.dependencies.androidConfigReader.readConfig(existing.name);
+    if (sameAndroidSpecification(spec, config)) {
+      return;
+    }
+    if (
+      request.reconcileExistingConfiguration &&
+      spec.configuration?.memoryMb !== undefined &&
+      sameAndroidDeviceIdentity(spec, config)
+    ) {
+      await this.dependencies.androidConfigWriter.setMemoryMb(existing.name, spec.configuration.memoryMb);
+      const reconciled = await this.dependencies.androidConfigReader.readConfig(existing.name);
+      if (sameAndroidSpecification(spec, reconciled)) {
+        return;
+      }
+    }
+    throw new ProvisionDeviceError(
+      "identity_conflict",
+      `Existing Android AVD '${existing.name}' does not match the requested runtime, device type, and configuration.`,
+    );
+  }
+
+  private assertIosExistingMatches(
+    request: ExactDeviceProvisionRequest,
+    existing: DeviceInfo,
+  ): void {
+    const spec = request.spec as IosDeviceSpecification;
+    if (existing.isAvailable === false) {
+      throw new ProvisionDeviceError(
+        "identity_conflict",
+        `Existing iOS simulator '${existing.name}' is unavailable: ${existing.availabilityError ?? "CoreSimulator marked it unavailable"}.`,
+      );
+    }
+    if (existing.runtime !== spec.runtime || existing.deviceType !== spec.deviceType) {
+      throw new ProvisionDeviceError(
+        "identity_conflict",
+        `Existing iOS simulator '${existing.name}' does not match the requested runtime and device type.`,
+      );
+    }
+  }
+
+  private async createAndroid(
+    request: ExactDeviceProvisionRequest,
+    spec: AndroidDeviceSpecification,
+  ): Promise<ExactProvisionedDevice> {
+    const created = await this.dependencies.avdManager.createAvd({
+      name: request.name,
+      package: spec.runtime,
+      device: spec.deviceType,
+    }, { signal: request.signal });
+    if (!created.success) {
+      throw new ProvisionDeviceError(
+        "platform_command_failed",
+        `Failed to create Android AVD '${request.name}': ${created.message}`,
+      );
+    }
+    if (spec.configuration?.memoryMb !== undefined) {
+      await this.dependencies.androidConfigWriter.setMemoryMb(request.name, spec.configuration.memoryMb);
+    }
+    return {
+      created: true,
+      device: {
+        name: request.name,
+        platform: "android",
+        isRunning: false,
+      },
+      resolvedSpec: spec,
+    };
+  }
+
+  private async createIos(
+    request: ExactDeviceProvisionRequest,
+    spec: IosDeviceSpecification,
+  ): Promise<ExactProvisionedDevice> {
+    const deviceId = await this.dependencies.iosSimulator.createSimulator(
+      request.name,
+      spec.deviceType,
+      spec.runtime,
+      request.signal,
+    );
+    return {
+      created: true,
+      device: {
+        name: request.name,
+        platform: "ios",
+        deviceId,
+        isRunning: false,
+        runtime: spec.runtime,
+        deviceType: spec.deviceType,
+      },
+      resolvedSpec: spec,
+    };
+  }
+}
+
+export function createDefaultExactDeviceProvisioner(
+  deviceManager: PlatformDeviceManager,
+  deviceCreationGate: DeviceCreationGate,
+  androidConfigWriter: AndroidAvdConfigWriter = new FileAndroidAvdConfigWriter(),
+): ExactDeviceProvisioner {
+  return new DefaultExactDeviceProvisioner({
+    listDeviceImages: deviceManager.listDeviceImages.bind(deviceManager),
+    isCreationAllowed: deviceCreationGate.isCreationAllowed.bind(deviceCreationGate),
+    avdManager: new AvdManagerClient(),
+    androidConfigReader: new FileAvdConfigReader(),
+    androidConfigWriter,
+    iosSimulator: new SimCtlClient(null),
+  });
+}

--- a/test/daemon/mcpRequestTimeout.test.ts
+++ b/test/daemon/mcpRequestTimeout.test.ts
@@ -7,6 +7,7 @@ import {
   LEGACY_OPEN_LINK_MCP_TIMEOUT_ENV_VAR,
   MIN_EXECUTE_PLAN_MCP_TIMEOUT_MS,
   MIN_LAUNCH_APP_MCP_TIMEOUT_MS,
+  MIN_PROVISION_DEVICE_MCP_TIMEOUT_MS,
   MIN_START_DEVICE_MCP_TIMEOUT_MS,
   MIN_UNINSTALL_APP_MCP_TIMEOUT_MS,
   OBSERVE_MCP_TIMEOUT_ENV_VAR,
@@ -16,6 +17,7 @@ import {
 } from "../../src/daemon/mcpRequestTimeout";
 import type { DaemonRequest } from "../../src/daemon/types";
 import {
+  DEFAULT_PROVISION_DEVICE_TIMEOUT_MS,
   DAEMON_RPC_SOCKET_IDLE_TIMEOUT_MS,
   MAX_DEVICE_READY_TIMEOUT_MS,
 } from "../../src/utils/deviceTimeouts";
@@ -67,6 +69,7 @@ describe("resolveMcpRequestTimeoutMs", () => {
     { name: "tool without a floor -> default", tool: "tapOn", expected: DEFAULT_MCP_REQUEST_TIMEOUT_MS },
     { name: "executePlan floor when timeoutMs omitted", tool: "executePlan", expected: MIN_EXECUTE_PLAN_MCP_TIMEOUT_MS },
     { name: "startDevice floor when timeoutMs omitted", tool: "startDevice", expected: MIN_START_DEVICE_MCP_TIMEOUT_MS },
+    { name: "provisionDevice floor when timeoutMs omitted", tool: "provisionDevice", expected: MIN_PROVISION_DEVICE_MCP_TIMEOUT_MS },
     { name: "launchApp floor when timeoutMs omitted", tool: "launchApp", expected: MIN_LAUNCH_APP_MCP_TIMEOUT_MS },
     { name: "uninstallApp floor when timeoutMs omitted", tool: "uninstallApp", expected: MIN_UNINSTALL_APP_MCP_TIMEOUT_MS },
     { name: "observe default floor when timeoutMs omitted", tool: "observe", expected: DEFAULT_OBSERVE_MCP_TIMEOUT_MS },
@@ -75,6 +78,7 @@ describe("resolveMcpRequestTimeoutMs", () => {
     // --- Short timeouts are raised to the floor (base < floor) ---
     { name: "raises short executePlan to floor", tool: "executePlan", timeoutMs: 180_000, expected: MIN_EXECUTE_PLAN_MCP_TIMEOUT_MS },
     { name: "raises short startDevice to floor", tool: "startDevice", timeoutMs: 60_000, expected: MIN_START_DEVICE_MCP_TIMEOUT_MS },
+    { name: "raises short provisionDevice to floor", tool: "provisionDevice", timeoutMs: 60_000, expected: MIN_PROVISION_DEVICE_MCP_TIMEOUT_MS },
     { name: "raises short launchApp to floor", tool: "launchApp", timeoutMs: 10_000, expected: MIN_LAUNCH_APP_MCP_TIMEOUT_MS },
     { name: "raises short uninstallApp to floor", tool: "uninstallApp", timeoutMs: 30_000, expected: MIN_UNINSTALL_APP_MCP_TIMEOUT_MS },
     { name: "raises short observe to floor", tool: "observe", timeoutMs: 30_000, expected: DEFAULT_OBSERVE_MCP_TIMEOUT_MS },
@@ -83,6 +87,12 @@ describe("resolveMcpRequestTimeoutMs", () => {
     // --- Timeouts above the floor are preserved (base > floor) ---
     { name: "preserves executePlan above floor", tool: "executePlan", timeoutMs: 900_000, expected: 900_000 },
     { name: "preserves startDevice above floor", tool: "startDevice", timeoutMs: 300_000, expected: 300_000 },
+    {
+      name: "preserves provisionDevice outer request timeout above the floor",
+      tool: "provisionDevice",
+      timeoutMs: 600_000,
+      expected: 600_000,
+    },
     { name: "preserves launchApp above floor", tool: "launchApp", timeoutMs: 150_000, expected: 150_000 },
     { name: "preserves uninstallApp above floor", tool: "uninstallApp", timeoutMs: 90_000, expected: 90_000 },
     { name: "preserves observe above floor", tool: "observe", timeoutMs: 150_000, expected: 150_000 },
@@ -165,6 +175,7 @@ describe("resolveMcpRequestTimeoutMs", () => {
   });
 
   test("keeps transport alive for getAndroid's named preparation budgets", () => {
+
     const request: DaemonRequest = {
       id: "1",
       type: "mcp_request",
@@ -177,6 +188,41 @@ describe("resolveMcpRequestTimeoutMs", () => {
 
     expect(resolveMcpRequestTimeoutMs(request)).toBe(
       345_000 + START_DEVICE_MCP_TIMEOUT_OVERHEAD_MS,
+    );
+  });
+
+  test("keeps transport alive beyond the provisionDevice tool budget", () => {
+    const request: DaemonRequest = {
+      id: "1",
+      type: "mcp_request",
+      method: "tools/call",
+      params: {
+        name: "provisionDevice",
+        arguments: { timeoutMs: 600_000 },
+      },
+    };
+
+    expect(resolveMcpRequestTimeoutMs(request)).toBe(
+      600_000 + START_DEVICE_MCP_TIMEOUT_OVERHEAD_MS,
+    );
+  });
+
+  test("keeps transport headroom when provisionDevice uses its default lifecycle budget", () => {
+    const request: DaemonRequest = {
+      id: "1",
+      type: "mcp_request",
+      method: "tools/call",
+      params: {
+        name: "provisionDevice",
+        arguments: {},
+      },
+    };
+
+    expect(MIN_PROVISION_DEVICE_MCP_TIMEOUT_MS).toBe(
+      DEFAULT_PROVISION_DEVICE_TIMEOUT_MS + START_DEVICE_MCP_TIMEOUT_OVERHEAD_MS,
+    );
+    expect(resolveMcpRequestTimeoutMs(request)).toBe(
+      DEFAULT_PROVISION_DEVICE_TIMEOUT_MS + START_DEVICE_MCP_TIMEOUT_OVERHEAD_MS,
     );
   });
 
@@ -200,7 +246,6 @@ describe("resolveMcpRequestTimeoutMs", () => {
     );
     expect(resolved).toBeLessThan(DAEMON_RPC_SOCKET_IDLE_TIMEOUT_MS);
   });
-
   test("keeps transport alive for the legacy nested startDevice timeout", () => {
     const request: DaemonRequest = {
       id: "1",

--- a/test/db/provisionDeviceOperationRepository.test.ts
+++ b/test/db/provisionDeviceOperationRepository.test.ts
@@ -1,0 +1,76 @@
+import { afterEach, beforeEach, describe, expect, test } from "bun:test";
+import type { Kysely } from "kysely";
+import { ProvisionDeviceOperationRepository } from "../../src/db/provisionDeviceOperationRepository";
+import type { Database } from "../../src/db/types";
+import { createTestDatabase } from "./testDbHelper";
+
+describe("ProvisionDeviceOperationRepository", () => {
+  let db: Kysely<Database>;
+
+  beforeEach(async () => {
+    db = await createTestDatabase();
+  });
+
+  afterEach(async () => {
+    await db.destroy();
+  });
+
+  test("replays a completed operation and rejects reuse with a different request", async () => {
+    const repository = new ProvisionDeviceOperationRepository(db);
+
+    expect(await repository.begin("operation-1", "request-a")).toEqual({
+      started: true,
+      reconcileExistingConfiguration: false,
+    });
+    await repository.complete("operation-1", {
+      deviceId: "emulator-5554",
+      name: "phone-api-36-a",
+    });
+
+    expect(await repository.begin("operation-1", "request-a")).toEqual({
+      started: false,
+      result: {
+        deviceId: "emulator-5554",
+        name: "phone-api-36-a",
+      },
+      reconcileExistingConfiguration: false,
+    });
+    await expect(repository.begin("operation-1", "request-b")).rejects.toThrow(
+      "operationId 'operation-1' was already used for a different provisionDevice request",
+    );
+  });
+
+  test("permits configuration reconciliation only after creation began", async () => {
+    const repository = new ProvisionDeviceOperationRepository(db);
+
+    await repository.begin("operation-retry", "request-a");
+    await repository.fail("operation-retry", "platform_command_failed", "config write failed");
+
+    expect(await repository.begin("operation-retry", "request-a")).toEqual({
+      started: true,
+      reconcileExistingConfiguration: false,
+    });
+
+    await repository.markDeviceCreationStarted("operation-retry");
+    await repository.fail("operation-retry", "platform_command_failed", "config write failed");
+
+    expect(await repository.begin("operation-retry", "request-a")).toEqual({
+      started: true,
+      reconcileExistingConfiguration: true,
+    });
+  });
+
+  test("retains creation provenance when replaying a completed operation", async () => {
+    const repository = new ProvisionDeviceOperationRepository(db);
+
+    await repository.begin("operation-created", "request-a");
+    await repository.markDeviceCreationStarted("operation-created");
+    await repository.complete("operation-created", { created: true });
+
+    expect(await repository.begin("operation-created", "request-a")).toEqual({
+      started: false,
+      result: { created: true },
+      reconcileExistingConfiguration: true,
+    });
+  });
+});

--- a/test/server/deviceTools.provisionDevice.test.ts
+++ b/test/server/deviceTools.provisionDevice.test.ts
@@ -1,0 +1,625 @@
+import { afterEach, beforeEach, describe, expect, test } from "bun:test";
+import {
+  provisionDeviceSchema,
+  registerDeviceTools,
+  resetDeviceToolsDependencies,
+  setDeviceToolsDependencies,
+} from "../../src/server/deviceTools";
+import { ToolRegistry } from "../../src/server/toolRegistry";
+import type {
+  ExactDeviceProvisionRequest,
+  ExactDeviceProvisioner,
+  ExactProvisionedDevice,
+} from "../../src/utils/exactDeviceProvisioning";
+import type { ProvisionDeviceOperationStore } from "../../src/db/provisionDeviceOperationRepository";
+import { ProvisionDeviceOperationConflictError } from "../../src/db/provisionDeviceOperationRepository";
+import { FakeDeviceUtils } from "../fakes/FakeDeviceUtils";
+import { FakeTimer } from "../fakes/FakeTimer";
+import { DaemonState } from "../../src/daemon/daemonState";
+import { SessionManager } from "../../src/daemon/sessionManager";
+import { DevicePool } from "../../src/daemon/devicePool";
+import { FakeDeviceSessionPersistence } from "../fakes/FakeDeviceSessionPersistence";
+
+class FakeExactDeviceProvisioner implements ExactDeviceProvisioner {
+  readonly requests: ExactDeviceProvisionRequest[] = [];
+
+  async provision(request: ExactDeviceProvisionRequest): Promise<ExactProvisionedDevice> {
+    this.requests.push(request);
+    return {
+      created: true,
+      device: {
+        name: request.name,
+        platform: request.platform,
+        isRunning: false,
+      },
+      resolvedSpec: request.spec,
+    };
+  }
+}
+
+class FakeProvisionDeviceOperationStore implements ProvisionDeviceOperationStore {
+  private readonly results = new Map<
+    string,
+    { fingerprint: string; result?: Record<string, unknown>; creationStarted: boolean }
+  >();
+
+  async begin(operationId: string, requestFingerprint: string) {
+    const existing = this.results.get(operationId);
+    if (!existing) {
+      this.results.set(operationId, {
+        fingerprint: requestFingerprint,
+        creationStarted: false,
+      });
+      return { started: true, reconcileExistingConfiguration: false } as const;
+    }
+    if (existing.fingerprint !== requestFingerprint) {
+      throw new ProvisionDeviceOperationConflictError(operationId);
+    }
+    return existing.result
+      ? {
+        started: false as const,
+        result: existing.result,
+        reconcileExistingConfiguration: existing.creationStarted,
+      }
+      : {
+        started: true as const,
+        reconcileExistingConfiguration: existing.creationStarted,
+      };
+  }
+
+  async markDeviceCreationStarted(operationId: string): Promise<void> {
+    const operation = this.results.get(operationId);
+    if (!operation) {
+      throw new Error(`missing operation ${operationId}`);
+    }
+    operation.creationStarted = true;
+  }
+
+  async complete(operationId: string, result: Record<string, unknown>): Promise<void> {
+    const operation = this.results.get(operationId);
+    if (!operation) {
+      throw new Error(`missing operation ${operationId}`);
+    }
+    operation.result = result;
+  }
+
+  async fail(): Promise<void> {}
+}
+
+describe("provisionDevice handler", () => {
+  let deviceManager: FakeDeviceUtils;
+  let exactProvisioner: FakeExactDeviceProvisioner;
+  let operationStore: FakeProvisionDeviceOperationStore;
+
+  beforeEach(() => {
+    deviceManager = new FakeDeviceUtils();
+    exactProvisioner = new FakeExactDeviceProvisioner();
+    operationStore = new FakeProvisionDeviceOperationStore();
+    setDeviceToolsDependencies({
+      deviceManagerFactory: () => deviceManager,
+      exactDeviceProvisionerFactory: () => exactProvisioner,
+      provisionDeviceOperationStoreFactory: () => operationStore,
+      notifyResourcesChanged: async () => {},
+    });
+    registerDeviceTools();
+  });
+
+  afterEach(() => {
+    resetDeviceToolsDependencies();
+    DaemonState.getInstance().reset();
+  });
+
+  test("accepts omitted boot and readiness with their documented defaults", () => {
+    expect(provisionDeviceSchema.parse({
+      operationId: "operation-defaults",
+      device: {
+        platform: "android",
+        name: "phone-api-36-a",
+        spec: {
+          runtime: "system-images;android-36;google_apis;x86_64",
+          deviceType: "pixel_9",
+        },
+      },
+    })).toMatchObject({
+      boot: true,
+      readiness: "automation",
+    });
+  });
+
+  test("rejects unbootable memory for modern Play Store Android images", () => {
+    expect(() => provisionDeviceSchema.parse({
+      operationId: "operation-low-play-memory",
+      device: {
+        platform: "android",
+        name: "phone-api-36-play",
+        spec: {
+          runtime: "system-images;android-36;google_apis_playstore;x86_64",
+          deviceType: "pixel_9",
+          configuration: { memoryMb: 1024 },
+        },
+      },
+    })).toThrow(/at least 2048/);
+  });
+
+  test("creates the caller-specified device once and replays its structured result by operationId", async () => {
+    const tool = ToolRegistry.getTool("provisionDevice");
+    if (!tool) {
+      throw new Error("provisionDevice not registered");
+    }
+    const args = {
+      operationId: "operation-5434",
+      device: {
+        platform: "android",
+        name: "phone-api-36-a",
+        spec: {
+          runtime: "system-images;android-36;google_apis;x86_64",
+          deviceType: "pixel_9",
+          configuration: { memoryMb: 4096 },
+        },
+      },
+      boot: false,
+      readiness: "automation",
+    };
+
+    const first = JSON.parse((await tool.handler({
+      ...args,
+      __mcpSessionId: "mcp-session-5434",
+      __executionId: "execution-5434",
+      __executionStartTime: 0,
+    } as any) as any).content[0].text);
+    const second = JSON.parse((await tool.handler(args) as any).content[0].text);
+
+    expect(exactProvisioner.requests).toHaveLength(1);
+    expect(exactProvisioner.requests[0]).toMatchObject({
+      platform: "android",
+      name: "phone-api-36-a",
+      spec: {
+        runtime: "system-images;android-36;google_apis;x86_64",
+        deviceType: "pixel_9",
+        configuration: { memoryMb: 4096 },
+      },
+    });
+    expect(exactProvisioner.requests[0]?.signal).toBeInstanceOf(AbortSignal);
+    expect(first).toMatchObject({
+      operationId: "operation-5434",
+      created: true,
+      adopted: false,
+      lifecycleState: "created",
+      readiness: { status: "not_requested" },
+      device: {
+        name: "phone-api-36-a",
+        platform: "android",
+      },
+    });
+    expect(second).toEqual(first);
+  });
+
+  test("boots the exact device and runs automation readiness when requested", async () => {
+    deviceManager.setDeviceImages("android", [{
+      name: "phone-api-36-a",
+      platform: "android",
+      isRunning: false,
+    }]);
+    let readinessRequest: unknown;
+    setDeviceToolsDependencies({
+      ensureCtrlProxyReady: async (request) => {
+        readinessRequest = request;
+      },
+    });
+    registerDeviceTools();
+    const tool = ToolRegistry.getTool("provisionDevice");
+    if (!tool) {
+      throw new Error("provisionDevice not registered");
+    }
+
+    const result = JSON.parse((await tool.handler({
+      operationId: "operation-boot",
+      device: {
+        platform: "android",
+        name: "phone-api-36-a",
+        spec: {
+          runtime: "system-images;android-36;google_apis;x86_64",
+          deviceType: "pixel_9",
+        },
+      },
+      boot: true,
+      readiness: "automation",
+    }) as any).content[0].text);
+
+    expect(deviceManager.wasMethodCalled("startDevice")).toBe(true);
+    expect(readinessRequest).toMatchObject({
+      device: { name: "phone-api-36-a", platform: "android" },
+    });
+    expect(result).toMatchObject({
+      lifecycleState: "ready",
+      readiness: { mode: "automation", status: "automation_ready" },
+      sessionId: expect.any(String),
+    });
+  });
+
+  test("adopts a running Android AVD by resolving its transport ID before boot", async () => {
+    deviceManager.setDeviceImages("android", [{
+      name: "phone-api-36-a",
+      platform: "android",
+      isRunning: true,
+    }]);
+    deviceManager.setBootedDevices("android", [{
+      name: "phone-api-36-a",
+      platform: "android",
+      deviceId: "emulator-5554",
+    }]);
+    const tool = ToolRegistry.getTool("provisionDevice");
+    if (!tool) {
+      throw new Error("provisionDevice not registered");
+    }
+
+    const result = JSON.parse((await tool.handler({
+      operationId: "operation-adopt-running",
+      device: {
+        platform: "android",
+        name: "phone-api-36-a",
+        spec: {
+          runtime: "system-images;android-36;google_apis;x86_64",
+          deviceType: "pixel_9",
+        },
+      },
+      boot: true,
+      readiness: "none",
+    }) as any).content[0].text);
+
+    expect(deviceManager.wasMethodCalled("startDevice")).toBe(false);
+    expect(result).toMatchObject({
+      lifecycleState: "ready",
+      device: {
+        deviceId: "emulator-5554",
+        name: "phone-api-36-a",
+      },
+    });
+  });
+
+  test("boots the provisioned iOS UDID instead of another running simulator with the same name", async () => {
+    deviceManager.setDeviceImages("ios", [{
+      name: "phone-api-36-a",
+      platform: "ios",
+      deviceId: "requested-udid",
+      isRunning: false,
+      runtime: "com.apple.CoreSimulator.SimRuntime.iOS-26-0",
+      deviceType: "com.apple.CoreSimulator.SimDeviceType.iPhone-17",
+    }]);
+    deviceManager.setBootedDevices("ios", [{
+      name: "phone-api-36-a",
+      platform: "ios",
+      deviceId: "other-udid",
+    }]);
+    const exactIosProvisioner: ExactDeviceProvisioner = {
+      provision: async () => ({
+        created: false,
+        device: {
+          name: "phone-api-36-a",
+          platform: "ios",
+          deviceId: "requested-udid",
+          isRunning: false,
+          runtime: "com.apple.CoreSimulator.SimRuntime.iOS-26-0",
+          deviceType: "com.apple.CoreSimulator.SimDeviceType.iPhone-17",
+        },
+        resolvedSpec: {
+          runtime: "com.apple.CoreSimulator.SimRuntime.iOS-26-0",
+          deviceType: "com.apple.CoreSimulator.SimDeviceType.iPhone-17",
+        },
+      }),
+    };
+    setDeviceToolsDependencies({
+      exactDeviceProvisionerFactory: () => exactIosProvisioner,
+    });
+    registerDeviceTools();
+    const tool = ToolRegistry.getTool("provisionDevice");
+    if (!tool) {
+      throw new Error("provisionDevice not registered");
+    }
+
+    const response = JSON.parse((await tool.handler({
+      operationId: "operation-ios-running-identity",
+      device: {
+        platform: "ios",
+        name: "phone-api-36-a",
+        spec: {
+          runtime: "com.apple.CoreSimulator.SimRuntime.iOS-26-0",
+          deviceType: "com.apple.CoreSimulator.SimDeviceType.iPhone-17",
+        },
+      },
+      boot: true,
+      readiness: "none",
+    }) as any).content[0].text);
+
+    expect(response).toMatchObject({
+      device: {
+        deviceId: "requested-udid",
+      },
+    });
+    expect(deviceManager.getExecutedOperations()).toContainEqual(
+      expect.stringContaining("startDevice:phone-api-36-a"),
+    );
+  });
+
+  test("rebinds a live session before replaying a completed boot operation", async () => {
+    deviceManager.setDeviceImages("android", [{
+      name: "phone-api-36-a",
+      platform: "android",
+      isRunning: false,
+    }]);
+    const tool = ToolRegistry.getTool("provisionDevice");
+    if (!tool) {
+      throw new Error("provisionDevice not registered");
+    }
+    const args = {
+      operationId: "operation-rebind-session",
+      device: {
+        platform: "android" as const,
+        name: "phone-api-36-a",
+        spec: {
+          runtime: "system-images;android-36;google_apis;x86_64",
+          deviceType: "pixel_9",
+        },
+      },
+      boot: true,
+      readiness: "none" as const,
+    };
+
+    const first = JSON.parse((await tool.handler(args) as any).content[0].text);
+    await Promise.resolve();
+    const second = JSON.parse((await tool.handler(args) as any).content[0].text);
+
+    expect(exactProvisioner.requests).toHaveLength(2);
+    expect(exactProvisioner.requests[1]?.reconcileExistingConfiguration).toBe(false);
+    expect(deviceManager.getCallCount("getBootedDevices")).toBeGreaterThanOrEqual(2);
+    expect(second).toMatchObject({
+      lifecycleState: "ready",
+      sessionId: expect.any(String),
+    });
+    expect(second.sessionId).not.toBe(first.sessionId);
+  });
+
+  test("returns a completed boot operation while its session is still live", async () => {
+    const timer = new FakeTimer();
+    const sessionManager = new SessionManager(timer, new FakeDeviceSessionPersistence());
+    const pool = new DevicePool(
+      sessionManager,
+      "daemon-session",
+      timer,
+      undefined,
+      deviceManager,
+    );
+    const bootedDevice = {
+      name: "phone-api-36-a",
+      platform: "android" as const,
+      deviceId: "mock-phone-api-36-a",
+    };
+    deviceManager.setDeviceImages("android", [{
+      name: "phone-api-36-a",
+      platform: "android",
+      isRunning: false,
+    }]);
+    await pool.initializeWithDevices([bootedDevice]);
+    DaemonState.getInstance().initialize(sessionManager, pool);
+
+    const tool = ToolRegistry.getTool("provisionDevice");
+    if (!tool) {
+      throw new Error("provisionDevice not registered");
+    }
+    const args = {
+      operationId: "operation-live-session",
+      device: {
+        platform: "android" as const,
+        name: "phone-api-36-a",
+        spec: {
+          runtime: "system-images;android-36;google_apis;x86_64",
+          deviceType: "pixel_9",
+        },
+      },
+      boot: true,
+      readiness: "none" as const,
+    };
+
+    const first = JSON.parse((await tool.handler(args) as any).content[0].text);
+    const second = JSON.parse((await tool.handler(args) as any).content[0].text);
+
+    expect(second).toEqual(first);
+    expect(exactProvisioner.requests).toHaveLength(1);
+    expect(deviceManager.getCallCount("startDevice")).toBe(1);
+    sessionManager.stopCleanupTimer();
+  });
+
+  test("retains creation ownership when a completed boot operation rebinds", async () => {
+    let calls = 0;
+    const replayProvisioner: ExactDeviceProvisioner = {
+      provision: async (request) => {
+        calls++;
+        return {
+          created: calls === 1,
+          device: {
+            name: request.name,
+            platform: "android",
+            isRunning: false,
+          },
+          resolvedSpec: request.spec,
+        };
+      },
+    };
+    deviceManager.setDeviceImages("android", [{
+      name: "phone-api-36-a",
+      platform: "android",
+      isRunning: false,
+    }]);
+    setDeviceToolsDependencies({
+      exactDeviceProvisionerFactory: () => replayProvisioner,
+    });
+    registerDeviceTools();
+    const tool = ToolRegistry.getTool("provisionDevice");
+    if (!tool) {
+      throw new Error("provisionDevice not registered");
+    }
+    const args = {
+      operationId: "operation-preserve-created",
+      device: {
+        platform: "android" as const,
+        name: "phone-api-36-a",
+        spec: {
+          runtime: "system-images;android-36;google_apis;x86_64",
+          deviceType: "pixel_9",
+        },
+      },
+      boot: true,
+      readiness: "none" as const,
+    };
+
+    const first = JSON.parse((await tool.handler(args) as any).content[0].text);
+    const second = JSON.parse((await tool.handler(args) as any).content[0].text);
+
+    expect(calls).toBe(2);
+    expect(first).toMatchObject({ created: true, adopted: false });
+    expect(second).toMatchObject({ created: true, adopted: false });
+  });
+
+  test("keeps a shared operation running when its initiating caller aborts", async () => {
+    let resolveProvision!: (result: ExactProvisionedDevice) => void;
+    let provisionSignal: AbortSignal | undefined;
+    const pendingProvisioner: ExactDeviceProvisioner = {
+      provision: async (request) => await new Promise<ExactProvisionedDevice>((resolve) => {
+        provisionSignal = request.signal;
+        resolveProvision = resolve;
+      }),
+    };
+    setDeviceToolsDependencies({
+      exactDeviceProvisionerFactory: () => pendingProvisioner,
+    });
+    registerDeviceTools();
+    const tool = ToolRegistry.getTool("provisionDevice");
+    if (!tool) {
+      throw new Error("provisionDevice not registered");
+    }
+    const args = {
+      operationId: "operation-shared-abort",
+      device: {
+        platform: "android" as const,
+        name: "phone-api-36-a",
+        spec: {
+          runtime: "system-images;android-36;google_apis;x86_64",
+          deviceType: "pixel_9",
+        },
+      },
+      boot: false,
+      readiness: "none" as const,
+    };
+    const firstCaller = new AbortController();
+    const first = tool.handler(args, undefined, firstCaller.signal);
+    await Promise.resolve();
+    const second = tool.handler(args);
+    firstCaller.abort(new Error("first caller disconnected"));
+
+    expect(JSON.parse((await first as any).content[0].text)).toMatchObject({
+      success: false,
+    });
+    expect(provisionSignal?.aborted).toBe(false);
+
+    resolveProvision({
+      created: true,
+      device: {
+        name: "phone-api-36-a",
+        platform: "android",
+        isRunning: false,
+      },
+      resolvedSpec: args.device.spec,
+    });
+
+    expect(JSON.parse((await second as any).content[0].text)).toMatchObject({
+      operationId: "operation-shared-abort",
+    });
+    expect(provisionSignal?.aborted).toBe(false);
+  });
+
+  test("returns a typed operation conflict when an operationId is reused for a different request", async () => {
+    const tool = ToolRegistry.getTool("provisionDevice");
+    if (!tool) {
+      throw new Error("provisionDevice not registered");
+    }
+    const base = {
+      operationId: "operation-conflict",
+      device: {
+        platform: "ios",
+        name: "phone-api-36-a",
+        spec: {
+          runtime: "com.apple.CoreSimulator.SimRuntime.iOS-26-0",
+          deviceType: "com.apple.CoreSimulator.SimDeviceType.iPhone-17",
+        },
+      },
+      boot: false,
+      readiness: "none",
+    };
+
+    await tool.handler(base);
+    const conflicting = JSON.parse((await tool.handler({
+      ...base,
+      device: {
+        ...base.device,
+        spec: {
+          ...base.device.spec,
+          deviceType: "com.apple.CoreSimulator.SimDeviceType.iPad-Pro-13-inch-M4",
+        },
+      },
+    }) as any).content[0].text);
+
+    expect(conflicting).toMatchObject({
+      success: false,
+      error: {
+        code: "operation_conflict",
+      },
+    });
+  });
+
+  test("enforces timeoutMs across exact provisioning before boot begins", async () => {
+    const timer = new FakeTimer();
+    let provisionSignal: AbortSignal | undefined;
+    const pendingProvisioner: ExactDeviceProvisioner = {
+      provision: async (request) => await new Promise<ExactProvisionedDevice>((_resolve, reject) => {
+        provisionSignal = request.signal;
+        request.signal?.addEventListener("abort", () => reject(request.signal?.reason), { once: true });
+      }),
+    };
+    setDeviceToolsDependencies({
+      timer,
+      exactDeviceProvisionerFactory: () => pendingProvisioner,
+    });
+    registerDeviceTools();
+    const tool = ToolRegistry.getTool("provisionDevice");
+    if (!tool) {
+      throw new Error("provisionDevice not registered");
+    }
+
+    const response = tool.handler({
+      operationId: "operation-timeout",
+      device: {
+        platform: "android",
+        name: "phone-api-36-a",
+        spec: {
+          runtime: "system-images;android-36;google_apis;x86_64",
+          deviceType: "pixel_9",
+        },
+      },
+      boot: true,
+      readiness: "automation",
+      timeoutMs: 1_000,
+    });
+
+    await Promise.resolve();
+    timer.advanceTime(1_000);
+
+    expect(JSON.parse((await response as any).content[0].text)).toMatchObject({
+      success: false,
+      error: {
+        code: "timeout",
+      },
+    });
+    expect(provisionSignal?.aborted).toBe(true);
+    expect(deviceManager.wasMethodCalled("startDevice")).toBe(false);
+  });
+});

--- a/test/server/deviceTools.provisionDevice.test.ts
+++ b/test/server/deviceTools.provisionDevice.test.ts
@@ -443,6 +443,137 @@ describe("provisionDevice handler", () => {
     sessionManager.stopCleanupTimer();
   });
 
+  test("associates a live autolock session with a reconnected MCP client", async () => {
+    const originalAutolock = process.env.AUTOMOBILE_DEVICE_POOL_AUTOLOCK;
+    process.env.AUTOMOBILE_DEVICE_POOL_AUTOLOCK = "1";
+    const timer = new FakeTimer();
+    const sessionManager = new SessionManager(timer, new FakeDeviceSessionPersistence());
+    const pool = new DevicePool(
+      sessionManager,
+      "daemon-session",
+      timer,
+      undefined,
+      deviceManager,
+    );
+    const bootedDevice = {
+      name: "phone-api-36-a",
+      platform: "android" as const,
+      deviceId: "mock-phone-api-36-a",
+    };
+    try {
+      deviceManager.setDeviceImages("android", [{
+        name: "phone-api-36-a",
+        platform: "android",
+        isRunning: false,
+      }]);
+      await pool.initializeWithDevices([bootedDevice]);
+      DaemonState.getInstance().initialize(sessionManager, pool);
+      const tool = ToolRegistry.getTool("provisionDevice");
+      if (!tool) {
+        throw new Error("provisionDevice not registered");
+      }
+      const args = {
+        operationId: "operation-reconnected-mcp-session",
+        device: {
+          platform: "android" as const,
+          name: "phone-api-36-a",
+          spec: {
+            runtime: "system-images;android-36;google_apis;x86_64",
+            deviceType: "pixel_9",
+          },
+        },
+        boot: true,
+        readiness: "none" as const,
+      };
+
+      const first = JSON.parse((await tool.handler({
+        ...args,
+        __mcpSessionId: "mcp-session-original",
+      }) as any).content[0].text);
+      const second = JSON.parse((await tool.handler({
+        ...args,
+        __mcpSessionId: "mcp-session-reconnected",
+      }) as any).content[0].text);
+
+      expect(second).toEqual(first);
+      expect(pool.resolveAutolockSessionForMcpSession(
+        "mcp-session-reconnected",
+        "android",
+      )).toBe(first.sessionId);
+    } finally {
+      sessionManager.stopCleanupTimer();
+      if (originalAutolock === undefined) {
+        delete process.env.AUTOMOBILE_DEVICE_POOL_AUTOLOCK;
+      } else {
+        process.env.AUTOMOBILE_DEVICE_POOL_AUTOLOCK = originalAutolock;
+      }
+    }
+  });
+
+  test("releases a live replay session when automation readiness fails", async () => {
+    const timer = new FakeTimer();
+    const sessionManager = new SessionManager(timer, new FakeDeviceSessionPersistence());
+    const pool = new DevicePool(
+      sessionManager,
+      "daemon-session",
+      timer,
+      undefined,
+      deviceManager,
+    );
+    const bootedDevice = {
+      name: "phone-api-36-a",
+      platform: "android" as const,
+      deviceId: "mock-phone-api-36-a",
+    };
+    deviceManager.setDeviceImages("android", [{
+      name: "phone-api-36-a",
+      platform: "android",
+      isRunning: false,
+    }]);
+    await pool.initializeWithDevices([bootedDevice]);
+    DaemonState.getInstance().initialize(sessionManager, pool);
+    let readinessCalls = 0;
+    setDeviceToolsDependencies({
+      ensureCtrlProxyReady: async () => {
+        readinessCalls++;
+        if (readinessCalls === 2) {
+          throw new Error("readiness failed");
+        }
+      },
+    });
+    const tool = ToolRegistry.getTool("provisionDevice");
+    if (!tool) {
+      throw new Error("provisionDevice not registered");
+    }
+    const args = {
+      operationId: "operation-replay-readiness-failure",
+      device: {
+        platform: "android" as const,
+        name: "phone-api-36-a",
+        spec: {
+          runtime: "system-images;android-36;google_apis;x86_64",
+          deviceType: "pixel_9",
+        },
+      },
+      boot: true,
+      readiness: "automation" as const,
+    };
+
+    await tool.handler(args);
+    const failedReplay = JSON.parse((await tool.handler(args) as any).content[0].text);
+
+    expect(failedReplay).toMatchObject({
+      success: false,
+      error: { code: "platform_command_failed" },
+    });
+    expect(pool.getDevice(bootedDevice.deviceId)).toMatchObject({
+      sessionId: null,
+      status: "idle",
+    });
+    expect(operationStore.failCalls).toBe(1);
+    sessionManager.stopCleanupTimer();
+  });
+
   test("rebinds an errored persisted session instead of replaying its stale readiness", async () => {
     const timer = new FakeTimer();
     const sessionManager = new SessionManager(timer, new FakeDeviceSessionPersistence());
@@ -607,6 +738,67 @@ describe("provisionDevice handler", () => {
     expect(calls).toBe(2);
     expect(first).toMatchObject({ created: true, adopted: false });
     expect(second).toMatchObject({ created: true, adopted: false });
+  });
+
+  test("retains creation ownership after a failed lifecycle retry", async () => {
+    let calls = 0;
+    const retryingProvisioner: ExactDeviceProvisioner = {
+      provision: async (request) => {
+        calls++;
+        if (calls === 1) {
+          await request.onBeforeCreate?.();
+        }
+        return {
+          created: calls === 1,
+          device: {
+            name: request.name,
+            platform: "android",
+            isRunning: false,
+          },
+          resolvedSpec: request.spec,
+        };
+      },
+    };
+    let readinessCalls = 0;
+    deviceManager.setDeviceImages("android", [{
+      name: "phone-api-36-a",
+      platform: "android",
+      isRunning: false,
+    }]);
+    setDeviceToolsDependencies({
+      exactDeviceProvisionerFactory: () => retryingProvisioner,
+      ensureCtrlProxyReady: async () => {
+        readinessCalls++;
+        if (readinessCalls === 1) {
+          throw new Error("first readiness attempt failed");
+        }
+      },
+    });
+    registerDeviceTools();
+    const tool = ToolRegistry.getTool("provisionDevice");
+    if (!tool) {
+      throw new Error("provisionDevice not registered");
+    }
+    const args = {
+      operationId: "operation-retry-created-ownership",
+      device: {
+        platform: "android" as const,
+        name: "phone-api-36-a",
+        spec: {
+          runtime: "system-images;android-36;google_apis;x86_64",
+          deviceType: "pixel_9",
+        },
+      },
+      boot: true,
+      readiness: "automation" as const,
+    };
+
+    const failed = JSON.parse((await tool.handler(args) as any).content[0].text);
+    const retried = JSON.parse((await tool.handler(args) as any).content[0].text);
+
+    expect(failed).toMatchObject({ success: false });
+    expect(retried).toMatchObject({ created: true, adopted: false });
+    expect(calls).toBe(2);
   });
 
   test("keeps a shared operation running when its initiating caller aborts", async () => {

--- a/test/server/deviceTools.provisionDevice.test.ts
+++ b/test/server/deviceTools.provisionDevice.test.ts
@@ -42,6 +42,8 @@ class FakeProvisionDeviceOperationStore implements ProvisionDeviceOperationStore
     string,
     { fingerprint: string; result?: Record<string, unknown>; creationStarted: boolean }
   >();
+  completeError: Error | undefined;
+  failCalls = 0;
 
   async begin(operationId: string, requestFingerprint: string) {
     const existing = this.results.get(operationId);
@@ -76,6 +78,9 @@ class FakeProvisionDeviceOperationStore implements ProvisionDeviceOperationStore
   }
 
   async complete(operationId: string, result: Record<string, unknown>): Promise<void> {
+    if (this.completeError) {
+      throw this.completeError;
+    }
     const operation = this.results.get(operationId);
     if (!operation) {
       throw new Error(`missing operation ${operationId}`);
@@ -83,7 +88,9 @@ class FakeProvisionDeviceOperationStore implements ProvisionDeviceOperationStore
     operation.result = result;
   }
 
-  async fail(): Promise<void> {}
+  async fail(): Promise<void> {
+    this.failCalls++;
+  }
 }
 
 describe("provisionDevice handler", () => {
@@ -401,6 +408,12 @@ describe("provisionDevice handler", () => {
     }]);
     await pool.initializeWithDevices([bootedDevice]);
     DaemonState.getInstance().initialize(sessionManager, pool);
+    let readinessCalls = 0;
+    setDeviceToolsDependencies({
+      ensureCtrlProxyReady: async () => {
+        readinessCalls++;
+      },
+    });
 
     const tool = ToolRegistry.getTool("provisionDevice");
     if (!tool) {
@@ -417,7 +430,7 @@ describe("provisionDevice handler", () => {
         },
       },
       boot: true,
-      readiness: "none" as const,
+      readiness: "automation" as const,
     };
 
     const first = JSON.parse((await tool.handler(args) as any).content[0].text);
@@ -426,6 +439,122 @@ describe("provisionDevice handler", () => {
     expect(second).toEqual(first);
     expect(exactProvisioner.requests).toHaveLength(1);
     expect(deviceManager.getCallCount("startDevice")).toBe(1);
+    expect(readinessCalls).toBe(2);
+    sessionManager.stopCleanupTimer();
+  });
+
+  test("rebinds an errored persisted session instead of replaying its stale readiness", async () => {
+    const timer = new FakeTimer();
+    const sessionManager = new SessionManager(timer, new FakeDeviceSessionPersistence());
+    const pool = new DevicePool(
+      sessionManager,
+      "daemon-session",
+      timer,
+      undefined,
+      deviceManager,
+    );
+    const bootedDevice = {
+      name: "phone-api-36-a",
+      platform: "android" as const,
+      deviceId: "mock-phone-api-36-a",
+    };
+    deviceManager.setDeviceImages("android", [{
+      name: "phone-api-36-a",
+      platform: "android",
+      isRunning: false,
+    }]);
+    await pool.initializeWithDevices([bootedDevice]);
+    DaemonState.getInstance().initialize(sessionManager, pool);
+
+    const tool = ToolRegistry.getTool("provisionDevice");
+    if (!tool) {
+      throw new Error("provisionDevice not registered");
+    }
+    const args = {
+      operationId: "operation-errored-session",
+      device: {
+        platform: "android" as const,
+        name: "phone-api-36-a",
+        spec: {
+          runtime: "system-images;android-36;google_apis;x86_64",
+          deviceType: "pixel_9",
+        },
+      },
+      boot: true,
+      readiness: "none" as const,
+    };
+
+    const first = JSON.parse((await tool.handler(args) as any).content[0].text);
+    const pooledDevice = pool.getDevice(bootedDevice.deviceId);
+    if (!pooledDevice) {
+      throw new Error("expected pooled device");
+    }
+    pooledDevice.status = "error";
+    const second = JSON.parse((await tool.handler(args) as any).content[0].text);
+
+    expect(second).toMatchObject({
+      lifecycleState: "ready",
+      sessionId: expect.any(String),
+    });
+    expect(second.sessionId).not.toBe(first.sessionId);
+    expect(exactProvisioner.requests).toHaveLength(2);
+    expect(pool.getDevice(bootedDevice.deviceId)?.status).toBe("busy");
+    sessionManager.stopCleanupTimer();
+  });
+
+  test("releases the bound session when completion persistence fails", async () => {
+    const timer = new FakeTimer();
+    const sessionManager = new SessionManager(timer, new FakeDeviceSessionPersistence());
+    const pool = new DevicePool(
+      sessionManager,
+      "daemon-session",
+      timer,
+      undefined,
+      deviceManager,
+    );
+    const bootedDevice = {
+      name: "phone-api-36-a",
+      platform: "android" as const,
+      deviceId: "mock-phone-api-36-a",
+    };
+    deviceManager.setDeviceImages("android", [{
+      name: "phone-api-36-a",
+      platform: "android",
+      isRunning: false,
+    }]);
+    await pool.initializeWithDevices([bootedDevice]);
+    DaemonState.getInstance().initialize(sessionManager, pool);
+    operationStore.completeError = new Error("database unavailable");
+
+    const tool = ToolRegistry.getTool("provisionDevice");
+    if (!tool) {
+      throw new Error("provisionDevice not registered");
+    }
+    const response = JSON.parse((await tool.handler({
+      operationId: "operation-persistence-failure",
+      device: {
+        platform: "android",
+        name: "phone-api-36-a",
+        spec: {
+          runtime: "system-images;android-36;google_apis;x86_64",
+          deviceType: "pixel_9",
+        },
+      },
+      boot: true,
+      readiness: "none",
+    }) as any).content[0].text);
+
+    expect(response).toMatchObject({
+      success: false,
+      error: {
+        code: "platform_command_failed",
+      },
+    });
+    expect(pool.getDevice(bootedDevice.deviceId)).toMatchObject({
+      sessionId: null,
+      status: "idle",
+    });
+    expect(operationStore.failCalls).toBe(1);
     sessionManager.stopCleanupTimer();
   });
 

--- a/test/server/tools/list.test.ts
+++ b/test/server/tools/list.test.ts
@@ -81,6 +81,7 @@ describe("MCP Tools List", () => {
       expect(toolNames).toContain("inputText");
       expect(toolNames).not.toContain("clipboard");
       expect(toolNames).not.toContain("openLink");
+      expect(toolNames).not.toContain("provisionDevice");
       expect(toolNames).not.toContain("settleObserve");
       expect(toolNames).not.toContain("waitForCondition");
     });

--- a/test/utils/exactDeviceProvisioning.test.ts
+++ b/test/utils/exactDeviceProvisioning.test.ts
@@ -1,0 +1,420 @@
+import { describe, expect, test } from "bun:test";
+import { join } from "node:path";
+import type { DeviceInfo } from "../../src/models";
+import {
+  DefaultExactDeviceProvisioner,
+  FileAndroidAvdConfigWriter,
+  ProvisionDeviceError,
+  type AndroidAvdConfigWriter,
+  type ExactAndroidAvdClient,
+  type ExactIosSimulatorClient,
+} from "../../src/utils/exactDeviceProvisioning";
+
+const ANDROID_SPEC = {
+  runtime: "system-images;android-36;google_apis;x86_64",
+  deviceType: "pixel_9",
+  configuration: { memoryMb: 4096 },
+} as const;
+
+function androidImage(name: string): DeviceInfo {
+  return {
+    name,
+    platform: "android",
+    isRunning: false,
+  };
+}
+
+describe("DefaultExactDeviceProvisioner", () => {
+  test("updates only hw.ramSize in the conventional AVD config", async () => {
+    const writes: Array<{ path: string; content: string }> = [];
+    const writer = new FileAndroidAvdConfigWriter({
+      readFile: async () => "avd.ini.displayname=phone-api-36-a\nhw.ramSize=2048\n",
+      writeFile: async (path, content) => {
+        writes.push({ path, content });
+      },
+      environment: { ANDROID_AVD_HOME: "/avds" },
+      homeDirectory: () => "/home/test",
+    });
+
+    await writer.setMemoryMb("phone-api-36-a", 4096);
+
+    expect(writes).toEqual([{
+      path: join("/avds", "phone-api-36-a.avd", "config.ini"),
+      content: "avd.ini.displayname=phone-api-36-a\nhw.ramSize=4096\n",
+    }]);
+  });
+
+  test("uses the same non-empty Android AVD home fallback as the config reader", async () => {
+    const writes: Array<{ path: string; content: string }> = [];
+    const writer = new FileAndroidAvdConfigWriter({
+      readFile: async () => "hw.ramSize=2048\n",
+      writeFile: async (path, content) => {
+        writes.push({ path, content });
+      },
+      environment: {
+        ANDROID_AVD_HOME: "",
+        ANDROID_EMULATOR_HOME: "",
+        ANDROID_USER_HOME: "",
+        ANDROID_SDK_HOME: "/sdk-home",
+      },
+      homeDirectory: () => "/home/test",
+    });
+
+    await writer.setMemoryMb("phone-api-36-a", 4096);
+
+    expect(writes).toEqual([{
+      path: join("/sdk-home", ".android", "avd", "phone-api-36-a.avd", "config.ini"),
+      content: "hw.ramSize=4096\n",
+    }]);
+  });
+
+  test("creates the requested Android AVD without selecting a substitute", async () => {
+    const calls: unknown[] = [];
+    const avdManager: ExactAndroidAvdClient = {
+      createAvd: async (params) => {
+        calls.push(params);
+        return { success: true, message: "created", avdName: params.name };
+      },
+    };
+    const configWriter: AndroidAvdConfigWriter = {
+      setMemoryMb: async (name, memoryMb) => {
+        calls.push({ name, memoryMb });
+      },
+    };
+    const provisioner = new DefaultExactDeviceProvisioner({
+      listDeviceImages: async () => [],
+      isCreationAllowed: () => true,
+      avdManager,
+      androidConfigReader: { readConfig: async () => null },
+      androidConfigWriter: configWriter,
+      iosSimulator: {} as ExactIosSimulatorClient,
+    });
+
+    let creationStarted = false;
+    const result = await provisioner.provision({
+      platform: "android",
+      name: "phone-api-36-a",
+      spec: ANDROID_SPEC,
+      onBeforeCreate: async () => {
+        creationStarted = true;
+      },
+    });
+
+    expect(creationStarted).toBe(true);
+    expect(result).toEqual({
+      created: true,
+      device: androidImage("phone-api-36-a"),
+      resolvedSpec: ANDROID_SPEC,
+    });
+    expect(calls).toEqual([
+      {
+        name: "phone-api-36-a",
+        package: "system-images;android-36;google_apis;x86_64",
+        device: "pixel_9",
+      },
+      { name: "phone-api-36-a", memoryMb: 4096 },
+    ]);
+  });
+
+  test("adopts an existing iOS simulator only when its exact runtime and device type match", async () => {
+    let created = false;
+    const iosSimulator: ExactIosSimulatorClient = {
+      createSimulator: async () => {
+        created = true;
+        return "new-udid";
+      },
+    };
+    const provisioner = new DefaultExactDeviceProvisioner({
+      listDeviceImages: async () => [{
+        name: "phone-api-36-a",
+        platform: "ios",
+        deviceId: "existing-udid",
+        isRunning: false,
+        runtime: "com.apple.CoreSimulator.SimRuntime.iOS-26-0",
+        deviceType: "com.apple.CoreSimulator.SimDeviceType.iPhone-17",
+      }],
+      isCreationAllowed: () => true,
+      avdManager: {} as ExactAndroidAvdClient,
+      androidConfigReader: { readConfig: async () => null },
+      androidConfigWriter: {} as AndroidAvdConfigWriter,
+      iosSimulator,
+    });
+
+    const result = await provisioner.provision({
+      platform: "ios",
+      name: "phone-api-36-a",
+      spec: {
+        runtime: "com.apple.CoreSimulator.SimRuntime.iOS-26-0",
+        deviceType: "com.apple.CoreSimulator.SimDeviceType.iPhone-17",
+      },
+    });
+
+    expect(created).toBe(false);
+    expect(result).toEqual({
+      created: false,
+      device: {
+        name: "phone-api-36-a",
+        platform: "ios",
+        deviceId: "existing-udid",
+        isRunning: false,
+        runtime: "com.apple.CoreSimulator.SimRuntime.iOS-26-0",
+        deviceType: "com.apple.CoreSimulator.SimDeviceType.iPhone-17",
+      },
+      resolvedSpec: {
+        runtime: "com.apple.CoreSimulator.SimRuntime.iOS-26-0",
+        deviceType: "com.apple.CoreSimulator.SimDeviceType.iPhone-17",
+      },
+    });
+  });
+
+  test("selects a later same-name iOS simulator when it is the exact available match", async () => {
+    let created = false;
+    const provisioner = new DefaultExactDeviceProvisioner({
+      listDeviceImages: async () => [
+        {
+          name: "phone-api-36-a",
+          platform: "ios",
+          deviceId: "wrong-udid",
+          isRunning: false,
+          runtime: "com.apple.CoreSimulator.SimRuntime.iOS-25-0",
+          deviceType: "com.apple.CoreSimulator.SimDeviceType.iPhone-17",
+        },
+        {
+          name: "phone-api-36-a",
+          platform: "ios",
+          deviceId: "exact-udid",
+          isRunning: false,
+          runtime: "com.apple.CoreSimulator.SimRuntime.iOS-26-0",
+          deviceType: "com.apple.CoreSimulator.SimDeviceType.iPhone-17",
+        },
+      ],
+      isCreationAllowed: () => true,
+      avdManager: {} as ExactAndroidAvdClient,
+      androidConfigReader: { readConfig: async () => null },
+      androidConfigWriter: {} as AndroidAvdConfigWriter,
+      iosSimulator: {
+        createSimulator: async () => {
+          created = true;
+          return "new-udid";
+        },
+      },
+    });
+
+    const result = await provisioner.provision({
+      platform: "ios",
+      name: "phone-api-36-a",
+      spec: {
+        runtime: "com.apple.CoreSimulator.SimRuntime.iOS-26-0",
+        deviceType: "com.apple.CoreSimulator.SimDeviceType.iPhone-17",
+      },
+    });
+
+    expect(created).toBe(false);
+    expect(result.device.deviceId).toBe("exact-udid");
+  });
+
+  test("rejects an unavailable exact iOS simulator instead of adopting it", async () => {
+    const provisioner = new DefaultExactDeviceProvisioner({
+      listDeviceImages: async () => [{
+        name: "phone-api-36-a",
+        platform: "ios",
+        deviceId: "unavailable-udid",
+        isRunning: false,
+        isAvailable: false,
+        availabilityError: "runtime is unavailable",
+        runtime: "com.apple.CoreSimulator.SimRuntime.iOS-26-0",
+        deviceType: "com.apple.CoreSimulator.SimDeviceType.iPhone-17",
+      }],
+      isCreationAllowed: () => true,
+      avdManager: {} as ExactAndroidAvdClient,
+      androidConfigReader: { readConfig: async () => null },
+      androidConfigWriter: {} as AndroidAvdConfigWriter,
+      iosSimulator: {
+        createSimulator: async () => {
+          throw new Error("must not create a duplicate named simulator");
+        },
+      },
+    });
+
+    await expect(provisioner.provision({
+      platform: "ios",
+      name: "phone-api-36-a",
+      spec: {
+        runtime: "com.apple.CoreSimulator.SimRuntime.iOS-26-0",
+        deviceType: "com.apple.CoreSimulator.SimDeviceType.iPhone-17",
+      },
+    })).rejects.toMatchObject({
+      code: "identity_conflict",
+      message: expect.stringContaining("unavailable"),
+    });
+  });
+
+  test("serializes same-name creation before recording retry provenance", async () => {
+    let images: DeviceInfo[] = [];
+    let createCalls = 0;
+    let allowCreate!: () => void;
+    const creationStarted = new Promise<void>((resolve) => {
+      allowCreate = resolve;
+    });
+    let signalCreateStarted!: () => void;
+    const createHasStarted = new Promise<void>((resolve) => {
+      signalCreateStarted = resolve;
+    });
+    const provisioner = new DefaultExactDeviceProvisioner({
+      listDeviceImages: async () => images,
+      isCreationAllowed: () => true,
+      avdManager: {
+        createAvd: async (params) => {
+          createCalls++;
+          signalCreateStarted();
+          await creationStarted;
+          images = [androidImage(params.name)];
+          return { success: true, message: "created", avdName: params.name };
+        },
+      },
+      androidConfigReader: {
+        readConfig: async () => ({
+          apiLevel: 36,
+          tag: "google_apis",
+          architecture: "x86_64",
+          deviceName: "pixel_9",
+          ramSizeMb: 4096,
+        }),
+      },
+      androidConfigWriter: {
+        setMemoryMb: async () => {},
+      },
+      iosSimulator: {} as ExactIosSimulatorClient,
+    });
+    const request = {
+      platform: "android" as const,
+      name: "phone-api-36-a",
+      spec: ANDROID_SPEC,
+      onBeforeCreate: async () => {},
+    };
+
+    const first = provisioner.provision(request);
+    await createHasStarted;
+    const second = provisioner.provision(request);
+    allowCreate();
+
+    const [firstResult, secondResult] = await Promise.all([first, second]);
+
+    expect(createCalls).toBe(1);
+    expect(firstResult.created).toBe(true);
+    expect(secondResult).toMatchObject({
+      created: false,
+      device: androidImage("phone-api-36-a"),
+    });
+  });
+
+  test("does not adopt an existing Android AVD when its resolved specification conflicts", async () => {
+    const provisioner = new DefaultExactDeviceProvisioner({
+      listDeviceImages: async () => [androidImage("phone-api-36-a")],
+      isCreationAllowed: () => true,
+      avdManager: {
+        createAvd: async () => {
+          throw new Error("must not create a replacement");
+        },
+      },
+      androidConfigReader: {
+        readConfig: async () => ({
+          apiLevel: 35,
+          tag: "google_apis",
+          architecture: "x86_64",
+          deviceName: "pixel_9",
+          ramSizeMb: 4096,
+        }),
+      },
+      androidConfigWriter: {} as AndroidAvdConfigWriter,
+      iosSimulator: {} as ExactIosSimulatorClient,
+    });
+
+    try {
+      await provisioner.provision({
+        platform: "android",
+        name: "phone-api-36-a",
+        spec: ANDROID_SPEC,
+      });
+      throw new Error("expected provision to reject");
+    } catch (error) {
+      expect(error).toBeInstanceOf(ProvisionDeviceError);
+      expect((error as ProvisionDeviceError).code).toBe("identity_conflict");
+    }
+  });
+
+  test("reconciles requested Android memory on a retry after partial provisioning", async () => {
+    let ramSizeMb = 2048;
+    const writes: number[] = [];
+    const provisioner = new DefaultExactDeviceProvisioner({
+      listDeviceImages: async () => [androidImage("phone-api-36-a")],
+      isCreationAllowed: () => true,
+      avdManager: {} as ExactAndroidAvdClient,
+      androidConfigReader: {
+        readConfig: async () => ({
+          apiLevel: 36,
+          tag: "google_apis",
+          architecture: "x86_64",
+          deviceName: "pixel_9",
+          ramSizeMb,
+        }),
+      },
+      androidConfigWriter: {
+        setMemoryMb: async (_name, memoryMb) => {
+          writes.push(memoryMb);
+          ramSizeMb = memoryMb;
+        },
+      },
+      iosSimulator: {} as ExactIosSimulatorClient,
+    });
+
+    const result = await provisioner.provision({
+      platform: "android",
+      name: "phone-api-36-a",
+      spec: ANDROID_SPEC,
+      reconcileExistingConfiguration: true,
+    });
+
+    expect(writes).toEqual([4096]);
+    expect(result).toEqual({
+      created: false,
+      device: androidImage("phone-api-36-a"),
+      resolvedSpec: ANDROID_SPEC,
+    });
+  });
+
+  test("does not reconcile a pre-existing Android AVD without creation provenance", async () => {
+    const writes: number[] = [];
+    const provisioner = new DefaultExactDeviceProvisioner({
+      listDeviceImages: async () => [androidImage("phone-api-36-a")],
+      isCreationAllowed: () => true,
+      avdManager: {} as ExactAndroidAvdClient,
+      androidConfigReader: {
+        readConfig: async () => ({
+          apiLevel: 36,
+          tag: "google_apis",
+          architecture: "x86_64",
+          deviceName: "pixel_9",
+          ramSizeMb: 2048,
+        }),
+      },
+      androidConfigWriter: {
+        setMemoryMb: async (_name, memoryMb) => {
+          writes.push(memoryMb);
+        },
+      },
+      iosSimulator: {} as ExactIosSimulatorClient,
+    });
+
+    await expect(provisioner.provision({
+      platform: "android",
+      name: "phone-api-36-a",
+      spec: ANDROID_SPEC,
+      reconcileExistingConfiguration: false,
+    })).rejects.toMatchObject({
+      code: "identity_conflict",
+    });
+
+    expect(writes).toEqual([]);
+  });
+});

--- a/test/utils/exactDeviceProvisioning.test.ts
+++ b/test/utils/exactDeviceProvisioning.test.ts
@@ -308,6 +308,93 @@ describe("DefaultExactDeviceProvisioner", () => {
     });
   });
 
+  test("cancels a waiting same-name request before it enters the provisioning lock", async () => {
+    let images: DeviceInfo[] = [];
+    let createCalls = 0;
+    let allowCreate!: () => void;
+    const creationStarted = new Promise<void>((resolve) => {
+      allowCreate = resolve;
+    });
+    let signalCreateStarted!: () => void;
+    const createHasStarted = new Promise<void>((resolve) => {
+      signalCreateStarted = resolve;
+    });
+    const provisioner = new DefaultExactDeviceProvisioner({
+      listDeviceImages: async () => images,
+      isCreationAllowed: () => true,
+      avdManager: {
+        createAvd: async (params) => {
+          createCalls++;
+          signalCreateStarted();
+          await creationStarted;
+          images = [androidImage(params.name)];
+          return { success: true, message: "created", avdName: params.name };
+        },
+      },
+      androidConfigReader: {
+        readConfig: async () => ({
+          apiLevel: 36,
+          tag: "google_apis",
+          architecture: "x86_64",
+          deviceName: "pixel_9",
+          ramSizeMb: 4096,
+        }),
+      },
+      androidConfigWriter: { setMemoryMb: async () => {} },
+      iosSimulator: {} as ExactIosSimulatorClient,
+    });
+    const request = {
+      platform: "android" as const,
+      name: "phone-api-36-a",
+      spec: ANDROID_SPEC,
+    };
+
+    const first = provisioner.provision(request);
+    await createHasStarted;
+    const controller = new AbortController();
+    const second = provisioner.provision({ ...request, signal: controller.signal });
+    controller.abort();
+
+    await expect(second).rejects.toThrow(/cancelled/i);
+    allowCreate();
+    await first;
+    expect(createCalls).toBe(1);
+  });
+
+  test("normalizes supported Android ABI aliases before matching an existing AVD", async () => {
+    const provisioner = new DefaultExactDeviceProvisioner({
+      listDeviceImages: async () => [androidImage("phone-api-36-a")],
+      isCreationAllowed: () => true,
+      avdManager: {
+        createAvd: async () => {
+          throw new Error("must not create a replacement");
+        },
+      },
+      androidConfigReader: {
+        readConfig: async () => ({
+          apiLevel: 36,
+          tag: "google_apis",
+          architecture: "arm",
+          deviceName: "pixel_9",
+          ramSizeMb: 4096,
+        }),
+      },
+      androidConfigWriter: {} as AndroidAvdConfigWriter,
+      iosSimulator: {} as ExactIosSimulatorClient,
+    });
+
+    const result = await provisioner.provision({
+      platform: "android",
+      name: "phone-api-36-a",
+      spec: {
+        ...ANDROID_SPEC,
+        runtime: "system-images;android-36;google_apis;armeabi-v7a",
+      },
+    });
+
+    expect(result).toMatchObject({ created: false, device: androidImage("phone-api-36-a") });
+  });
+
   test("does not adopt an existing Android AVD when its resolved specification conflicts", async () => {
     const provisioner = new DefaultExactDeviceProvisioner({
       listDeviceImages: async () => [androidImage("phone-api-36-a")],


### PR DESCRIPTION
## Summary

- add the controller-only `provisionDevice` MCP tool for exact Android AVD and iOS Simulator provisioning
- validate platform-specific runtime, device type, and Android memory specifications before booting or adopting the requested identity
- persist operation-id idempotency results and reuse the existing boot, readiness, pool, and session lifecycle paths

## Impact

Trusted callers can provision or adopt a named virtual device without `startDevice` selecting a different device.

Fixes [#5434](https://github.com/kaeawc/auto-mobile/issues/5434).

## Validation

- `bun run turbo:validate`
- `bun run typecheck`
