### PR TITLE
feat: add session-scoped screenshot resources

### DIFF
--- a/docs/design-docs/mcp/resources.md
+++ b/docs/design-docs/mcp/resources.md
@@ -149,6 +149,27 @@ show whether the catalog can safely be used for provisioning decisions.
 
 **URI Template**: `automobile:devices/images/{platform}`
 
+### Session Observations
+
+Session-scoped observation resources take the `sessionUuid` returned by
+`startDevice`. They resolve that active session to its assigned device and reject
+released or rebound sessions rather than accepting a second device selector.
+
+**URI Template**: `automobile:observation/session/{sessionUuid}/latest`
+
+Returns the cached observation for the active session. Call `observe` first to
+populate it.
+
+**URI Template**: `automobile:observation/session/{sessionUuid}/latest/screenshot`
+
+Returns the cached screenshot from that observation when available.
+
+**URI Template**: `automobile:device-session/{sessionUuid}/screenshot`
+
+Captures and returns a fresh PNG for the active session. A fresh request queues
+behind an in-flight screenshot for the same device, then takes its own tracked
+capture so session cleanup can cancel it safely.
+
 ### Installed Apps
 
 **URI**: `automobile:apps`

--- a/src/features/observe/TakeScreenshot.ts
+++ b/src/features/observe/TakeScreenshot.ts
@@ -16,6 +16,7 @@ import { selectScreenshotsToEvict, SCREENSHOT_MIN_EVICT_AGE_MS } from "./screens
 import { IOSCtrlProxyClient } from "./ios";
 import { getDeviceDataStreamServer } from "../../daemon/deviceDataStreamSocketServer";
 import { Timer, defaultTimer } from "../../utils/SystemTimer";
+import { defaultIdGenerator, IdGenerator } from "../../utils/IdGenerator";
 import {
   ANDROID_ADB_SCREENSHOT_METADATA,
   IOS_CTRLPROXY_SCREENSHOT_METADATA,
@@ -50,6 +51,7 @@ export class TakeScreenshot implements ScreenshotService {
   private adbFactory: AdbClientFactory;
   private window: Window;
   private timer: Timer;
+  private idGenerator: IdGenerator;
   private static cacheDir: string | null = null;
   private static readonly MAX_CACHE_SIZE_BYTES = 128 * 1024 * 1024; // 128MB
 
@@ -73,12 +75,14 @@ export class TakeScreenshot implements ScreenshotService {
     device: BootedDevice,
     adbFactory: AdbClientFactory = defaultAdbClientFactory,
     timer: Timer = defaultTimer,
+    idGenerator: IdGenerator = defaultIdGenerator,
   ) {
     this.device = device;
     this.adbFactory = adbFactory;
     this.adb = adbFactory.create(device);
     this.window = new Window(device, this.adbFactory);
     this.timer = timer;
+    this.idGenerator = idGenerator;
 
     // Manage cache size (getCacheDir ensures directory exists with secure permissions)
     this.cleanupCache();
@@ -121,13 +125,16 @@ export class TakeScreenshot implements ScreenshotService {
 
   /**
    * Generate screenshot file path
-   * @param timestamp - Timestamp for unique filename
+   * @param timestamp - Timestamp for readable filename ordering
    * @param options - Screenshot options
    * @returns Full file path for screenshot
    */
   generateScreenshotPath(timestamp: number, options: ScreenshotOptions): string {
     const fileExtension = options.format === "webp" ? "webp" : "png";
-    return path.join(TakeScreenshot.getCacheDir(), `screenshot_${timestamp}.${fileExtension}`);
+    return path.join(
+      TakeScreenshot.getCacheDir(),
+      `screenshot_${timestamp}_${this.idGenerator.next()}.${fileExtension}`,
+    );
   }
 
   /**

--- a/src/server/deviceTools.ts
+++ b/src/server/deviceTools.ts
@@ -39,6 +39,10 @@ import { getAbortSignal, runWithAbortSignal } from "../utils/AbortContext";
 import { getToolCapabilityContext } from "../features/toolCapabilities/toolCapabilityContext";
 import { executionTracker } from "./executionTracker";
 import {
+  registerDirectSessionDevice,
+  unregisterDirectSessionsForDevice,
+} from "./directSessionDeviceRegistry";
+import {
   createDefaultRunnerReadinessService,
   type RunnerReadinessRequest,
   SystemUiAnrRecoveryRequiredError,
@@ -1985,6 +1989,7 @@ export function registerDeviceTools() {
 
     const sessionId = getDeviceToolsDependencies().idGenerator.next();
     if (!daemonState.isInitialized()) {
+      registerDirectSessionDevice(sessionId, device);
       return sessionId;
     }
     return daemonState.getDevicePool().bindOrReuseDeviceSession(
@@ -2101,6 +2106,7 @@ export function registerDeviceTools() {
 
       await shutdownReservation?.release();
       shutdownReservation = undefined;
+      unregisterDirectSessionsForDevice(args.device.deviceId);
 
       perf.startOperation("cleanup");
       await clearInstalledAppsAfterShutdown(deps, args.device.deviceId);

--- a/src/server/directSessionDeviceRegistry.ts
+++ b/src/server/directSessionDeviceRegistry.ts
@@ -1,0 +1,29 @@
+import type { BootedDevice } from "../models";
+
+interface DirectSessionDevice {
+  sessionUuid: string;
+  device: BootedDevice;
+}
+
+const sessions = new Map<string, BootedDevice>();
+
+export function registerDirectSessionDevice(sessionUuid: string, device: BootedDevice): void {
+  sessions.set(sessionUuid, { ...device });
+}
+
+export function resolveDirectSessionDevice(sessionUuid: string): DirectSessionDevice | undefined {
+  const device = sessions.get(sessionUuid);
+  return device ? { sessionUuid, device: { ...device } } : undefined;
+}
+
+export function unregisterDirectSessionsForDevice(deviceId: string): void {
+  for (const [sessionUuid, device] of sessions) {
+    if (device.deviceId === deviceId) {
+      sessions.delete(sessionUuid);
+    }
+  }
+}
+
+export function clearDirectSessionDevices(): void {
+  sessions.clear();
+}

--- a/src/server/index.ts
+++ b/src/server/index.ts
@@ -292,7 +292,9 @@ export const createMcpServer = (options: McpServerOptions = {}): McpServer => {
   });
 
   // Register all resources with the server
-  ResourceRegistry.registerWithServer(server);
+  ResourceRegistry.registerWithServer(server, () => ({
+    sessionUuid: sessionToolBinding.effectiveSessionUuid(options.sessionContext?.sessionId),
+  }));
 
   // Tear down this transport's server-side SessionToolBinding when the daemon
   // actually releases a session (issue #4611 Gap D). Two release sources funnel

--- a/src/server/observationResources.ts
+++ b/src/server/observationResources.ts
@@ -416,7 +416,7 @@ export function registerObservationResources(): void {
   );
 
   // Register session-scoped observation template
-  ResourceRegistry.registerTemplate(
+  ResourceRegistry.registerTemplateWithReadContext(
     RESOURCE_URIS.SESSION_OBSERVATION,
     "Session Observation",
     "Cached screen observation for an active device session.",
@@ -425,7 +425,7 @@ export function registerObservationResources(): void {
   );
 
   // Register session-scoped cached screenshot template
-  ResourceRegistry.registerTemplate(
+  ResourceRegistry.registerTemplateWithReadContext(
     RESOURCE_URIS.SESSION_SCREENSHOT,
     "Session Screenshot",
     "Cached screen capture for an active device session.",
@@ -434,7 +434,7 @@ export function registerObservationResources(): void {
   );
 
   // Register fresh session screenshot template
-  ResourceRegistry.registerTemplate(
+  ResourceRegistry.registerTemplateWithReadContext(
     RESOURCE_URIS.FRESH_SESSION_SCREENSHOT,
     "Fresh Session Screenshot",
     "Fresh PNG screen capture for an active device session. Every read captures the current screen.",

--- a/src/server/observationResources.ts
+++ b/src/server/observationResources.ts
@@ -87,6 +87,8 @@ export const RESOURCE_URIS = {
   FRESH_SESSION_SCREENSHOT: "automobile:device-session/{sessionUuid}/screenshot",
 } as const;
 
+const FRESH_SCREENSHOT_PENDING_WAIT_MS = 10_000;
+
 // Helper to get the latest screenshot path from cache
 async function getLatestScreenshotPath(): Promise<string | undefined> {
   try {
@@ -315,16 +317,31 @@ async function getFreshSessionScreenshot(params: Record<string, string>): Promis
   }
 
   try {
-    const screenshotService =
-      sessionScreenshotResourceDependencies.createScreenshotService(activeSession.device);
-    const { promise } = screenshotService.startTrackedCapture(
-      { format: "png" },
-      { coalesceWithPending: true },
+    const pendingResult = await ScreenshotJobTracker.waitForCompletion(
+      activeSession.device.deviceId,
+      FRESH_SCREENSHOT_PENDING_WAIT_MS,
     );
-    const result = await promise;
+    if (pendingResult === null && ScreenshotJobTracker.isPending(activeSession.device.deviceId)) {
+      return {
+        uri,
+        mimeType: "application/json",
+        text: JSON.stringify({
+          error: "Timed out waiting for an in-progress screenshot capture.",
+        }, null, 2),
+      };
+    }
 
     const currentSession = sessionScreenshotResourceDependencies.resolveActiveSession(sessionUuid);
     if (currentSession?.device.deviceId !== activeSession.device.deviceId) {
+      return sessionResourceError(uri, sessionUuid);
+    }
+
+    const screenshotService =
+      sessionScreenshotResourceDependencies.createScreenshotService(currentSession.device);
+    const result = await screenshotService.execute({ format: "png" });
+
+    const completedSession = sessionScreenshotResourceDependencies.resolveActiveSession(sessionUuid);
+    if (completedSession?.device.deviceId !== activeSession.device.deviceId) {
       return sessionResourceError(uri, sessionUuid);
     }
     if (!result.success || !result.path) {

--- a/src/server/observationResources.ts
+++ b/src/server/observationResources.ts
@@ -3,6 +3,10 @@ import { RealObserveScreen } from "../features/observe/ObserveScreen";
 import { logger } from "../utils/logger";
 import { stringifyToolResponse } from "../utils/toolUtils";
 import { ScreenshotJobTracker } from "../utils/ScreenshotJobTracker";
+import { DaemonState } from "../daemon/daemonState";
+import { TakeScreenshot } from "../features/observe/TakeScreenshot";
+import type { TrackedScreenshotService } from "../features/observe/screenshot/ObserveScreenshotRecorder";
+import type { BootedDevice } from "../models";
 import * as realFs from "fs/promises";
 
 interface ScreenshotFileSystem {
@@ -20,12 +24,67 @@ export function resetScreenshotFileSystem(): void {
   screenshotFileSystem = realFs;
 }
 
+interface ActiveSessionDevice {
+  sessionUuid: string;
+  device: BootedDevice;
+}
+
+interface SessionScreenshotResourceDependencies {
+  resolveActiveSession(sessionUuid: string): ActiveSessionDevice | undefined;
+  createScreenshotService(device: BootedDevice): TrackedScreenshotService;
+}
+
+function resolveActiveSession(sessionUuid: string): ActiveSessionDevice | undefined {
+  const daemonState = DaemonState.getInstance();
+  if (!daemonState.isInitialized()) {
+    return undefined;
+  }
+
+  const session = daemonState.getSessionManager().getSession(sessionUuid);
+  if (!session) {
+    return undefined;
+  }
+
+  const pooledDevice = daemonState.getDevicePool().getDevice(session.assignedDevice);
+  if (!pooledDevice || pooledDevice.sessionId !== sessionUuid) {
+    return undefined;
+  }
+
+  return {
+    sessionUuid,
+    device: {
+      deviceId: pooledDevice.id,
+      name: pooledDevice.name,
+      platform: pooledDevice.platform,
+      iosVersion: pooledDevice.iosVersion,
+    },
+  };
+}
+
+const defaultSessionScreenshotResourceDependencies: SessionScreenshotResourceDependencies = {
+  resolveActiveSession,
+  createScreenshotService: device => new TakeScreenshot(device),
+};
+
+let sessionScreenshotResourceDependencies = defaultSessionScreenshotResourceDependencies;
+
+export function setSessionScreenshotResourceDependencies(
+  dependencies: SessionScreenshotResourceDependencies,
+): void {
+  sessionScreenshotResourceDependencies = dependencies;
+}
+
+export function resetSessionScreenshotResourceDependencies(): void {
+  sessionScreenshotResourceDependencies = defaultSessionScreenshotResourceDependencies;
+}
+
 // Resource URIs
 export const RESOURCE_URIS = {
   LATEST_OBSERVATION: "automobile:observation/latest",
   LATEST_SCREENSHOT: "automobile:observation/latest/screenshot",
-  DEVICE_OBSERVATION: "automobile:observation/{deviceId}/latest",
-  DEVICE_SCREENSHOT: "automobile:observation/{deviceId}/latest/screenshot",
+  SESSION_OBSERVATION: "automobile:observation/session/{sessionUuid}/latest",
+  SESSION_SCREENSHOT: "automobile:observation/session/{sessionUuid}/latest/screenshot",
+  FRESH_SESSION_SCREENSHOT: "automobile:device-session/{sessionUuid}/screenshot",
 } as const;
 
 // Helper to get the latest screenshot path from cache
@@ -143,10 +202,26 @@ async function getLatestScreenshot(): Promise<ResourceContent> {
   }
 }
 
-// Device-scoped handler for observation (with deviceId parameter)
-async function getDeviceObservation(params: Record<string, string>): Promise<ResourceContent> {
-  const { deviceId } = params;
-  const uri = `automobile:observation/${deviceId}/latest`;
+function sessionResourceError(uri: string, sessionUuid: string): ResourceContent {
+  return {
+    uri,
+    mimeType: "application/json",
+    text: JSON.stringify({
+      error: `No active device session found for sessionUuid ${sessionUuid}.`,
+    }, null, 2),
+  };
+}
+
+// Session-scoped handler for a cached observation.
+async function getSessionObservation(params: Record<string, string>): Promise<ResourceContent> {
+  const { sessionUuid } = params;
+  const uri = `automobile:observation/session/${sessionUuid}/latest`;
+  const activeSession = sessionScreenshotResourceDependencies.resolveActiveSession(sessionUuid);
+  if (!activeSession) {
+    return sessionResourceError(uri, sessionUuid);
+  }
+
+  const { deviceId } = activeSession.device;
   try {
     const cachedResult = RealObserveScreen.getRecentCachedResultForDevice(deviceId);
 
@@ -155,7 +230,7 @@ async function getDeviceObservation(params: Record<string, string>): Promise<Res
         uri,
         mimeType: "application/json",
         text: JSON.stringify({
-          error: `No observation available for device ${deviceId}. Call the 'observe' tool first.`
+          error: `No observation available for sessionUuid ${sessionUuid}. Call the 'observe' tool first.`
         }, null, 2)
       };
     }
@@ -166,21 +241,27 @@ async function getDeviceObservation(params: Record<string, string>): Promise<Res
       text: stringifyToolResponse(cachedResult)
     };
   } catch (error) {
-    logger.error(`[ObservationResources] Failed to get observation for device ${deviceId}: ${error}`);
+    logger.error(`[ObservationResources] Failed to get observation for session ${sessionUuid}: ${error}`);
     return {
       uri,
       mimeType: "application/json",
       text: JSON.stringify({
-        error: `Failed to retrieve observation for device ${deviceId}: ${error}`
+        error: `Failed to retrieve observation for sessionUuid ${sessionUuid}: ${error}`
       }, null, 2)
     };
   }
 }
 
-// Device-scoped handler for screenshot (with deviceId parameter)
-async function getDeviceScreenshot(params: Record<string, string>): Promise<ResourceContent> {
-  const { deviceId } = params;
-  const uri = `automobile:observation/${deviceId}/latest/screenshot`;
+// Session-scoped handler for a cached screenshot.
+async function getSessionScreenshot(params: Record<string, string>): Promise<ResourceContent> {
+  const { sessionUuid } = params;
+  const uri = `automobile:observation/session/${sessionUuid}/latest/screenshot`;
+  const activeSession = sessionScreenshotResourceDependencies.resolveActiveSession(sessionUuid);
+  if (!activeSession) {
+    return sessionResourceError(uri, sessionUuid);
+  }
+
+  const { deviceId } = activeSession.device;
   try {
     const cachedResult = RealObserveScreen.getRecentCachedResultForDevice(deviceId);
     if (!cachedResult) {
@@ -188,7 +269,7 @@ async function getDeviceScreenshot(params: Record<string, string>): Promise<Reso
         uri,
         mimeType: "application/json",
         text: JSON.stringify({
-          error: `No observation available for device ${deviceId}. Call the 'observe' tool first.`
+          error: `No observation available for sessionUuid ${sessionUuid}. Call the 'observe' tool first.`
         }, null, 2)
       };
     }
@@ -197,8 +278,8 @@ async function getDeviceScreenshot(params: Record<string, string>): Promise<Reso
     if (!screenshotPath) {
       const screenshotError = RealObserveScreen.getRecentCachedScreenshotErrorForDevice(deviceId);
       const errorMessage = screenshotError
-        ? `No screenshot available for device ${deviceId}: ${screenshotError}`
-        : `No screenshot available for device ${deviceId}. Call the 'observe' tool again.`;
+        ? `No screenshot available for sessionUuid ${sessionUuid}: ${screenshotError}`
+        : `No screenshot available for sessionUuid ${sessionUuid}. Call the 'observe' tool again.`;
       return {
         uri,
         mimeType: "application/json",
@@ -212,13 +293,64 @@ async function getDeviceScreenshot(params: Record<string, string>): Promise<Reso
 
     return { uri, mimeType, blob: base64Image };
   } catch (error) {
-    logger.error(`[ObservationResources] Failed to get screenshot for device ${deviceId}: ${error}`);
+    logger.error(`[ObservationResources] Failed to get screenshot for session ${sessionUuid}: ${error}`);
     return {
       uri,
       mimeType: "application/json",
       text: JSON.stringify({
-        error: `Failed to retrieve screenshot for device ${deviceId}: ${error}`
+        error: `Failed to retrieve screenshot for sessionUuid ${sessionUuid}: ${error}`
       }, null, 2)
+    };
+  }
+}
+
+// Session-scoped handler for a fresh screenshot. Every successful read captures
+// the screen; it deliberately does not fall back to an observe cache.
+async function getFreshSessionScreenshot(params: Record<string, string>): Promise<ResourceContent> {
+  const { sessionUuid } = params;
+  const uri = `automobile:device-session/${sessionUuid}/screenshot`;
+  const activeSession = sessionScreenshotResourceDependencies.resolveActiveSession(sessionUuid);
+  if (!activeSession) {
+    return sessionResourceError(uri, sessionUuid);
+  }
+
+  try {
+    const screenshotService =
+      sessionScreenshotResourceDependencies.createScreenshotService(activeSession.device);
+    const { promise } = screenshotService.startTrackedCapture(
+      { format: "png" },
+      { coalesceWithPending: true },
+    );
+    const result = await promise;
+
+    const currentSession = sessionScreenshotResourceDependencies.resolveActiveSession(sessionUuid);
+    if (currentSession?.device.deviceId !== activeSession.device.deviceId) {
+      return sessionResourceError(uri, sessionUuid);
+    }
+    if (!result.success || !result.path) {
+      return {
+        uri,
+        mimeType: "application/json",
+        text: JSON.stringify({
+          error: result.error || "Failed to capture a fresh screenshot.",
+        }, null, 2),
+      };
+    }
+
+    const imageBuffer = await screenshotFileSystem.readFile(result.path);
+    return {
+      uri,
+      mimeType: "image/png",
+      blob: imageBuffer.toString("base64"),
+    };
+  } catch (error) {
+    logger.error(`[ObservationResources] Failed to capture fresh screenshot for session ${sessionUuid}: ${error}`);
+    return {
+      uri,
+      mimeType: "application/json",
+      text: JSON.stringify({
+        error: `Failed to capture fresh screenshot for sessionUuid ${sessionUuid}: ${error}`,
+      }, null, 2),
     };
   }
 }
@@ -243,22 +375,31 @@ export function registerObservationResources(): void {
     getLatestScreenshot
   );
 
-  // Register device-scoped observation template
+  // Register session-scoped observation template
   ResourceRegistry.registerTemplate(
-    RESOURCE_URIS.DEVICE_OBSERVATION,
-    "Device Observation",
-    "Screen observation for a specific device. Use when multiple devices are active.",
+    RESOURCE_URIS.SESSION_OBSERVATION,
+    "Session Observation",
+    "Cached screen observation for an active device session.",
     "application/json",
-    getDeviceObservation
+    getSessionObservation
   );
 
-  // Register device-scoped screenshot template
+  // Register session-scoped cached screenshot template
   ResourceRegistry.registerTemplate(
-    RESOURCE_URIS.DEVICE_SCREENSHOT,
-    "Device Screenshot",
-    "Screen capture for a specific device. Use when multiple devices are active.",
+    RESOURCE_URIS.SESSION_SCREENSHOT,
+    "Session Screenshot",
+    "Cached screen capture for an active device session.",
     "image/png",
-    getDeviceScreenshot
+    getSessionScreenshot
+  );
+
+  // Register fresh session screenshot template
+  ResourceRegistry.registerTemplate(
+    RESOURCE_URIS.FRESH_SESSION_SCREENSHOT,
+    "Fresh Session Screenshot",
+    "Fresh PNG screen capture for an active device session. Every read captures the current screen.",
+    "image/png",
+    getFreshSessionScreenshot
   );
 
   logger.info("[ObservationResources] Registered observation resources");

--- a/src/server/observationResources.ts
+++ b/src/server/observationResources.ts
@@ -1,10 +1,15 @@
-import { ResourceRegistry, ResourceContent } from "./resourceRegistry";
+import {
+  ResourceRegistry,
+  ResourceContent,
+  type ResourceReadContext,
+} from "./resourceRegistry";
 import { RealObserveScreen } from "../features/observe/ObserveScreen";
 import { logger } from "../utils/logger";
 import { stringifyToolResponse } from "../utils/toolUtils";
 import { ScreenshotJobTracker } from "../utils/ScreenshotJobTracker";
 import { DaemonState } from "../daemon/daemonState";
 import { TakeScreenshot } from "../features/observe/TakeScreenshot";
+import { resolveDirectSessionDevice } from "./directSessionDeviceRegistry";
 import type { TrackedScreenshotService } from "../features/observe/screenshot/ObserveScreenshotRecorder";
 import type { BootedDevice } from "../models";
 import * as realFs from "fs/promises";
@@ -37,7 +42,7 @@ interface SessionScreenshotResourceDependencies {
 function resolveActiveSession(sessionUuid: string): ActiveSessionDevice | undefined {
   const daemonState = DaemonState.getInstance();
   if (!daemonState.isInitialized()) {
-    return undefined;
+    return resolveDirectSessionDevice(sessionUuid);
   }
 
   const session = daemonState.getSessionManager().getSession(sessionUuid);
@@ -212,10 +217,33 @@ function sessionResourceError(uri: string, sessionUuid: string): ResourceContent
   };
 }
 
+function unauthorizedSessionResourceError(uri: string): ResourceContent {
+  return {
+    uri,
+    mimeType: "application/json",
+    text: JSON.stringify({
+      error: "This resource can only be read by its bound device session.",
+    }, null, 2),
+  };
+}
+
+function isAuthorizedSessionResource(
+  context: ResourceReadContext,
+  sessionUuid: string,
+): boolean {
+  return !context.sessionUuid || context.sessionUuid === sessionUuid;
+}
+
 // Session-scoped handler for a cached observation.
-async function getSessionObservation(params: Record<string, string>): Promise<ResourceContent> {
+async function getSessionObservation(
+  params: Record<string, string>,
+  context: ResourceReadContext,
+): Promise<ResourceContent> {
   const { sessionUuid } = params;
   const uri = `automobile:observation/session/${sessionUuid}/latest`;
+  if (!isAuthorizedSessionResource(context, sessionUuid)) {
+    return unauthorizedSessionResourceError(uri);
+  }
   const activeSession = sessionScreenshotResourceDependencies.resolveActiveSession(sessionUuid);
   if (!activeSession) {
     return sessionResourceError(uri, sessionUuid);
@@ -253,9 +281,15 @@ async function getSessionObservation(params: Record<string, string>): Promise<Re
 }
 
 // Session-scoped handler for a cached screenshot.
-async function getSessionScreenshot(params: Record<string, string>): Promise<ResourceContent> {
+async function getSessionScreenshot(
+  params: Record<string, string>,
+  context: ResourceReadContext,
+): Promise<ResourceContent> {
   const { sessionUuid } = params;
   const uri = `automobile:observation/session/${sessionUuid}/latest/screenshot`;
+  if (!isAuthorizedSessionResource(context, sessionUuid)) {
+    return unauthorizedSessionResourceError(uri);
+  }
   const activeSession = sessionScreenshotResourceDependencies.resolveActiveSession(sessionUuid);
   if (!activeSession) {
     return sessionResourceError(uri, sessionUuid);
@@ -306,9 +340,15 @@ async function getSessionScreenshot(params: Record<string, string>): Promise<Res
 
 // Session-scoped handler for a fresh screenshot. Every successful read captures
 // the screen; it deliberately does not fall back to an observe cache.
-async function getFreshSessionScreenshot(params: Record<string, string>): Promise<ResourceContent> {
+async function getFreshSessionScreenshot(
+  params: Record<string, string>,
+  context: ResourceReadContext,
+): Promise<ResourceContent> {
   const { sessionUuid } = params;
   const uri = `automobile:device-session/${sessionUuid}/screenshot`;
+  if (!isAuthorizedSessionResource(context, sessionUuid)) {
+    return unauthorizedSessionResourceError(uri);
+  }
   const activeSession = sessionScreenshotResourceDependencies.resolveActiveSession(sessionUuid);
   if (!activeSession) {
     return sessionResourceError(uri, sessionUuid);

--- a/src/server/observationResources.ts
+++ b/src/server/observationResources.ts
@@ -87,8 +87,6 @@ export const RESOURCE_URIS = {
   FRESH_SESSION_SCREENSHOT: "automobile:device-session/{sessionUuid}/screenshot",
 } as const;
 
-const FRESH_SCREENSHOT_PENDING_WAIT_MS = 10_000;
-
 // Helper to get the latest screenshot path from cache
 async function getLatestScreenshotPath(): Promise<string | undefined> {
   try {
@@ -317,31 +315,16 @@ async function getFreshSessionScreenshot(params: Record<string, string>): Promis
   }
 
   try {
-    const pendingResult = await ScreenshotJobTracker.waitForCompletion(
-      activeSession.device.deviceId,
-      FRESH_SCREENSHOT_PENDING_WAIT_MS,
+    const screenshotService =
+      sessionScreenshotResourceDependencies.createScreenshotService(activeSession.device);
+    const { promise } = screenshotService.startTrackedCapture(
+      { format: "png" },
+      { queueAfterPending: true },
     );
-    if (pendingResult === null && ScreenshotJobTracker.isPending(activeSession.device.deviceId)) {
-      return {
-        uri,
-        mimeType: "application/json",
-        text: JSON.stringify({
-          error: "Timed out waiting for an in-progress screenshot capture.",
-        }, null, 2),
-      };
-    }
+    const result = await promise;
 
     const currentSession = sessionScreenshotResourceDependencies.resolveActiveSession(sessionUuid);
     if (currentSession?.device.deviceId !== activeSession.device.deviceId) {
-      return sessionResourceError(uri, sessionUuid);
-    }
-
-    const screenshotService =
-      sessionScreenshotResourceDependencies.createScreenshotService(currentSession.device);
-    const result = await screenshotService.execute({ format: "png" });
-
-    const completedSession = sessionScreenshotResourceDependencies.resolveActiveSession(sessionUuid);
-    if (completedSession?.device.deviceId !== activeSession.device.deviceId) {
       return sessionResourceError(uri, sessionUuid);
     }
     if (!result.success || !result.path) {

--- a/src/server/resourceRegistry.ts
+++ b/src/server/resourceRegistry.ts
@@ -9,11 +9,15 @@ export interface ResourceReadContext {
 
 // Interface for resource content handlers
 interface ResourceHandler {
-  (context: ResourceReadContext): Promise<ResourceContent>;
+  (): Promise<ResourceContent>;
 }
 
 // Interface for resource template handlers (with parameters)
 interface ResourceTemplateHandler {
+  (params: Record<string, string>): Promise<ResourceContent>;
+}
+
+interface ContextualResourceTemplateHandler {
   (params: Record<string, string>, context: ResourceReadContext): Promise<ResourceContent>;
 }
 
@@ -26,7 +30,7 @@ export interface ResourceContent {
 }
 
 // Interface for a registered resource
-interface RegisteredResource {
+interface ResourceMetadata {
   uri: string;
   name: string;
   description?: string;
@@ -34,18 +38,23 @@ interface RegisteredResource {
   handler: ResourceHandler;
 }
 
-// Interface for a registered resource template
-interface RegisteredResourceTemplate {
+type RegisteredResource = ResourceMetadata;
+
+interface ResourceTemplateMetadata {
   uriTemplate: string;
   name: string;
   description?: string;
   mimeType?: string;
-  handler: ResourceTemplateHandler;
   // Precompiled at registration so matchTemplate never compiles a RegExp inside
   // the per-request scan (issue #3427). Patterns are 100% static.
   regex: RegExp;
   paramNames: string[];
 }
+
+type RegisteredResourceTemplate = ResourceTemplateMetadata & (
+  | { handler: ResourceTemplateHandler }
+  | { handlerWithReadContext: ContextualResourceTemplateHandler }
+);
 
 // Compile an RFC 6570 URI template into an anchored RegExp plus its ordered
 // parameter names. Pure and called once per template at registration.
@@ -125,6 +134,25 @@ class ResourceRegistryClass {
   ): void {
     const { regex, paramNames } = compileUriTemplate(uriTemplate);
     this.templates.set(uriTemplate, { uriTemplate, name, description, mimeType, handler, regex, paramNames });
+  }
+
+  registerTemplateWithReadContext(
+    uriTemplate: string,
+    name: string,
+    description: string,
+    mimeType: string,
+    handlerWithReadContext: ContextualResourceTemplateHandler
+  ): void {
+    const { regex, paramNames } = compileUriTemplate(uriTemplate);
+    this.templates.set(uriTemplate, {
+      uriTemplate,
+      name,
+      description,
+      mimeType,
+      handlerWithReadContext,
+      regex,
+      paramNames,
+    });
   }
 
   // Get all registered templates
@@ -239,7 +267,7 @@ class ResourceRegistryClass {
       // First, try to find an exact match resource
       const resource = this.getResource(uri);
       if (resource) {
-        const content = await resource.handler(getReadContext());
+        const content = await resource.handler();
         return {
           contents: [content]
         };
@@ -248,10 +276,10 @@ class ResourceRegistryClass {
       // If not found, try to match a template
       const templateMatch = this.matchTemplate(uri);
       if (templateMatch) {
-        const content = await templateMatch.template.handler(
-          templateMatch.params,
-          getReadContext(),
-        );
+        const { template, params } = templateMatch;
+        const content = "handlerWithReadContext" in template
+          ? await template.handlerWithReadContext(params, getReadContext())
+          : await template.handler(params);
         return {
           contents: [content]
         };

--- a/src/server/resourceRegistry.ts
+++ b/src/server/resourceRegistry.ts
@@ -3,14 +3,18 @@ import { Resource, ResourceTemplate, ReadResourceRequestSchema, ListResourcesReq
 import { logger } from "../utils/logger";
 import { ListChangedBroadcaster } from "./listChangedBroadcast";
 
+export interface ResourceReadContext {
+  sessionUuid?: string;
+}
+
 // Interface for resource content handlers
 interface ResourceHandler {
-  (): Promise<ResourceContent>;
+  (context: ResourceReadContext): Promise<ResourceContent>;
 }
 
 // Interface for resource template handlers (with parameters)
 interface ResourceTemplateHandler {
-  (params: Record<string, string>): Promise<ResourceContent>;
+  (params: Record<string, string>, context: ResourceReadContext): Promise<ResourceContent>;
 }
 
 // Resource content can be text or blob
@@ -197,7 +201,10 @@ class ResourceRegistryClass {
   }
 
   // Register all resources with an MCP server
-  registerWithServer(server: McpServer): void {
+  registerWithServer(
+    server: McpServer,
+    getReadContext: () => ResourceReadContext = () => ({}),
+  ): void {
     this.trackServer(server);
 
     // Set handler for listing resources
@@ -232,7 +239,7 @@ class ResourceRegistryClass {
       // First, try to find an exact match resource
       const resource = this.getResource(uri);
       if (resource) {
-        const content = await resource.handler();
+        const content = await resource.handler(getReadContext());
         return {
           contents: [content]
         };
@@ -241,7 +248,10 @@ class ResourceRegistryClass {
       // If not found, try to match a template
       const templateMatch = this.matchTemplate(uri);
       if (templateMatch) {
-        const content = await templateMatch.template.handler(templateMatch.params);
+        const content = await templateMatch.template.handler(
+          templateMatch.params,
+          getReadContext(),
+        );
         return {
           contents: [content]
         };

--- a/src/utils/ScreenshotJobTracker.ts
+++ b/src/utils/ScreenshotJobTracker.ts
@@ -71,6 +71,17 @@ export class ScreenshotJobTracker {
     ScreenshotJobTracker.idGenerator = defaultIdGenerator;
   }
 
+  private static shouldQueueAfterPending(
+    options: ScreenshotJobOptions,
+    existingJobs: ScreenshotJobEntry[],
+  ): boolean {
+    if (options.queueAfterPending) {
+      return true;
+    }
+    return options.coalesceWithPending &&
+      existingJobs.some(entry => !entry.abortController.signal.aborted);
+  }
+
   static startJob(
     deviceId: string,
     runner: (signal: AbortSignal) => Promise<ScreenshotResult>,
@@ -90,10 +101,14 @@ export class ScreenshotJobTracker {
       }
     }
 
-    if (!options.queueAfterPending) {
+    const queueAfterPending = ScreenshotJobTracker.shouldQueueAfterPending(
+      options,
+      existingJobs,
+    );
+    if (!queueAfterPending) {
       ScreenshotJobTracker.cancelJob(deviceId);
     }
-    const previous = options.queueAfterPending ? existingJobs.at(-1) : undefined;
+    const previous = queueAfterPending ? existingJobs.at(-1) : undefined;
 
     const abortController = new AbortController();
     let cleanupParentSignal: (() => void) | undefined;
@@ -124,6 +139,9 @@ export class ScreenshotJobTracker {
           if (abortController.signal.aborted) {
             return { success: false, error: OPERATION_CANCELLED_MESSAGE };
           }
+        }
+        if (queueAfterPending) {
+          ScreenshotJobTracker.latestJobIds.set(deviceId, jobId);
         }
         return runner(abortController.signal);
       })
@@ -161,7 +179,9 @@ export class ScreenshotJobTracker {
 
     existingJobs.push(entry);
     ScreenshotJobTracker.jobs.set(deviceId, existingJobs);
-    ScreenshotJobTracker.latestJobIds.set(deviceId, jobId);
+    if (!queueAfterPending) {
+      ScreenshotJobTracker.latestJobIds.set(deviceId, jobId);
+    }
 
     promise.finally(() => {
       const current = ScreenshotJobTracker.jobs.get(deviceId);

--- a/src/utils/ScreenshotJobTracker.ts
+++ b/src/utils/ScreenshotJobTracker.ts
@@ -2,6 +2,7 @@ import { logger } from "./logger";
 import { ScreenshotResult } from "../models/ScreenshotResult";
 import { Timer, defaultTimer } from "./SystemTimer";
 import { defaultIdGenerator, type IdGenerator, createTimestampedId } from "./IdGenerator";
+import { OPERATION_CANCELLED_MESSAGE } from "./constants";
 
 export interface ScreenshotJobHandle {
   jobId: string;
@@ -29,6 +30,14 @@ export interface ScreenshotJobOptions {
    * previous in-flight screencap before it can complete.
    */
   coalesceWithPending?: boolean;
+  /**
+   * Register a distinct capture immediately, but do not start its runner until
+   * the most recently registered capture for this device has settled.
+   *
+   * The queued job remains tracked, so device/session cleanup can cancel it
+   * before it reaches the runner.
+   */
+  queueAfterPending?: boolean;
 }
 
 interface ScreenshotJobEntry {
@@ -36,11 +45,13 @@ interface ScreenshotJobEntry {
   promise: Promise<ScreenshotResult>;
   abortController: AbortController;
   startedAt: number;
+  allowsCoalescing: boolean;
   cleanupParentSignal?: () => void;
 }
 
 export class ScreenshotJobTracker {
-  private static jobs: Map<string, ScreenshotJobEntry> = new Map();
+  private static jobs: Map<string, ScreenshotJobEntry[]> = new Map();
+  private static latestJobIds: Map<string, string> = new Map();
   private static timer: Timer = defaultTimer;
   private static idGenerator: IdGenerator = defaultIdGenerator;
 
@@ -65,8 +76,11 @@ export class ScreenshotJobTracker {
     runner: (signal: AbortSignal) => Promise<ScreenshotResult>,
     options: ScreenshotJobOptions = {}
   ): ScreenshotJobHandle {
+    const existingJobs = ScreenshotJobTracker.jobs.get(deviceId) ?? [];
     if (options.coalesceWithPending) {
-      const existing = ScreenshotJobTracker.jobs.get(deviceId);
+      const existing = [...existingJobs]
+        .reverse()
+        .find(entry => entry.allowsCoalescing && !entry.abortController.signal.aborted);
       if (existing && !existing.abortController.signal.aborted) {
         return {
           jobId: existing.jobId,
@@ -76,7 +90,10 @@ export class ScreenshotJobTracker {
       }
     }
 
-    ScreenshotJobTracker.cancelJob(deviceId);
+    if (!options.queueAfterPending) {
+      ScreenshotJobTracker.cancelJob(deviceId);
+    }
+    const previous = options.queueAfterPending ? existingJobs.at(-1) : undefined;
 
     const abortController = new AbortController();
     let cleanupParentSignal: (() => void) | undefined;
@@ -101,7 +118,15 @@ export class ScreenshotJobTracker {
       ScreenshotJobTracker.idGenerator
     );
     const promise = Promise.resolve()
-      .then(() => runner(abortController.signal))
+      .then(async () => {
+        if (previous) {
+          await previous.promise;
+          if (abortController.signal.aborted) {
+            return { success: false, error: OPERATION_CANCELLED_MESSAGE };
+          }
+        }
+        return runner(abortController.signal);
+      })
       .catch(error => {
         const message = error instanceof Error ? error.message : String(error);
         return { success: false, error: message };
@@ -130,15 +155,27 @@ export class ScreenshotJobTracker {
       promise,
       abortController,
       startedAt: ScreenshotJobTracker.timer.now(),
+      allowsCoalescing: !options.queueAfterPending,
       cleanupParentSignal
     };
 
-    ScreenshotJobTracker.jobs.set(deviceId, entry);
+    existingJobs.push(entry);
+    ScreenshotJobTracker.jobs.set(deviceId, existingJobs);
+    ScreenshotJobTracker.latestJobIds.set(deviceId, jobId);
 
     promise.finally(() => {
       const current = ScreenshotJobTracker.jobs.get(deviceId);
-      if (current?.jobId === jobId) {
+      if (!current) {
+        cleanupParentSignal?.();
+        return;
+      }
+      const entryIndex = current.findIndex(candidate => candidate.jobId === jobId);
+      if (entryIndex !== -1) {
+        current.splice(entryIndex, 1);
+      }
+      if (current.length === 0) {
         ScreenshotJobTracker.jobs.delete(deviceId);
+        ScreenshotJobTracker.latestJobIds.delete(deviceId);
       }
       cleanupParentSignal?.();
     });
@@ -151,12 +188,14 @@ export class ScreenshotJobTracker {
   }
 
   static cancelJob(deviceId: string): void {
-    const entry = ScreenshotJobTracker.jobs.get(deviceId);
-    if (!entry) {
+    const entries = ScreenshotJobTracker.jobs.get(deviceId);
+    if (!entries) {
       return;
     }
-    if (!entry.abortController.signal.aborted) {
-      entry.abortController.abort();
+    for (const entry of entries) {
+      if (!entry.abortController.signal.aborted) {
+        entry.abortController.abort();
+      }
     }
   }
 
@@ -165,18 +204,19 @@ export class ScreenshotJobTracker {
   }
 
   static isLatest(deviceId: string, jobId: string): boolean {
-    const entry = ScreenshotJobTracker.jobs.get(deviceId);
-    return entry?.jobId === jobId;
+    return ScreenshotJobTracker.latestJobIds.get(deviceId) === jobId;
   }
 
   static getMostRecentPendingDeviceId(): string | undefined {
     let latestDeviceId: string | undefined;
     let latestStart = 0;
 
-    for (const [deviceId, entry] of ScreenshotJobTracker.jobs.entries()) {
-      if (entry.startedAt >= latestStart) {
-        latestStart = entry.startedAt;
-        latestDeviceId = deviceId;
+    for (const [deviceId, entries] of ScreenshotJobTracker.jobs.entries()) {
+      for (const entry of entries) {
+        if (entry.startedAt >= latestStart) {
+          latestStart = entry.startedAt;
+          latestDeviceId = deviceId;
+        }
       }
     }
 
@@ -184,7 +224,7 @@ export class ScreenshotJobTracker {
   }
 
   static async waitForCompletion(deviceId: string, timeoutMs: number): Promise<ScreenshotResult | null> {
-    const entry = ScreenshotJobTracker.jobs.get(deviceId);
+    const entry = ScreenshotJobTracker.jobs.get(deviceId)?.at(-1);
     if (!entry) {
       return null;
     }
@@ -204,12 +244,15 @@ export class ScreenshotJobTracker {
   }
 
   static clear(): void {
-    for (const entry of ScreenshotJobTracker.jobs.values()) {
-      if (!entry.abortController.signal.aborted) {
-        entry.abortController.abort();
+    for (const entries of ScreenshotJobTracker.jobs.values()) {
+      for (const entry of entries) {
+        if (!entry.abortController.signal.aborted) {
+          entry.abortController.abort();
+        }
+        entry.cleanupParentSignal?.();
       }
-      entry.cleanupParentSignal?.();
     }
     ScreenshotJobTracker.jobs.clear();
+    ScreenshotJobTracker.latestJobIds.clear();
   }
 }

--- a/src/utils/ScreenshotJobTracker.ts
+++ b/src/utils/ScreenshotJobTracker.ts
@@ -78,7 +78,7 @@ export class ScreenshotJobTracker {
     if (options.queueAfterPending) {
       return true;
     }
-    return options.coalesceWithPending &&
+    return options.coalesceWithPending === true &&
       existingJobs.some(entry => !entry.abortController.signal.aborted);
   }
 

--- a/test/features/observe/TakeScreenshot.test.ts
+++ b/test/features/observe/TakeScreenshot.test.ts
@@ -5,6 +5,7 @@ import { FakeAdbExecutor } from "../../fakes/FakeAdbExecutor";
 import { FakeFileSystem } from "../../fakes/FakeFileSystem";
 import { FakeTimer } from "../../fakes/FakeTimer";
 import { FakeAdbClientFactory } from "../../fakes/FakeAdbClientFactory";
+import { CountingIdGenerator } from "../../../src/utils/IdGenerator";
 
 describe("TakeScreenshot", function() {
   describe("Unit Tests for Extracted Methods", function() {
@@ -33,7 +34,7 @@ describe("TakeScreenshot", function() {
       const result = takeScreenshot.generateScreenshotPath(timestamp, options);
 
       expect(result).toContain("screenshot_1234567890123");
-      expect(result).toMatch(/screenshot_1234567890123\.png$/);
+      expect(result).toMatch(/screenshot_1234567890123_[^.]+\.png$/);
     });
 
     test("should generate correct screenshot path with webp format", function() {
@@ -43,7 +44,7 @@ describe("TakeScreenshot", function() {
       const result = takeScreenshot.generateScreenshotPath(timestamp, options);
 
       expect(result).toContain("screenshot_1234567890456");
-      expect(result).toMatch(/screenshot_1234567890456\.webp$/);
+      expect(result).toMatch(/screenshot_1234567890456_[^.]+\.webp$/);
     });
 
     test("should generate different timestamps for consecutive calls", async function() {
@@ -57,6 +58,24 @@ describe("TakeScreenshot", function() {
       const result2 = takeScreenshot.generateScreenshotPath(timestamp2, options);
 
       expect(result1).not.toBe(result2);
+    });
+
+    test("uses an injected unique suffix when captures share a timestamp", function() {
+      const idGenerator = new CountingIdGenerator("capture");
+      const sameTime = 1234567890123;
+      const screenshot = new TakeScreenshot(
+        mockDevice,
+        new FakeAdbClientFactory(fakeAdb),
+        new FakeTimer(),
+        idGenerator,
+      );
+
+      const first = screenshot.generateScreenshotPath(sameTime, { format: "png" });
+      const second = screenshot.generateScreenshotPath(sameTime, { format: "png" });
+
+      expect(first).toMatch(/screenshot_1234567890123_capture-1\.png$/);
+      expect(second).toMatch(/screenshot_1234567890123_capture-2\.png$/);
+      expect(first).not.toBe(second);
     });
 
     test("should use single optimized ADB command for screenshot capture", async function() {

--- a/test/server/deviceTools.startDevice.test.ts
+++ b/test/server/deviceTools.startDevice.test.ts
@@ -18,6 +18,10 @@ import { FakeTimer } from "../fakes/FakeTimer";
 import { FakeDeviceSessionPersistence } from "../fakes/FakeDeviceSessionPersistence";
 import { CountingIdGenerator } from "../../src/utils/IdGenerator";
 import {
+  clearDirectSessionDevices,
+  resolveDirectSessionDevice,
+} from "../../src/server/directSessionDeviceRegistry";
+import {
   DEFAULT_DEVICE_READY_TIMEOUT_MS,
   MAX_DEVICE_READY_TIMEOUT_MS,
 } from "../../src/utils/deviceTimeouts";
@@ -78,6 +82,7 @@ describe("startDevice handler", () => {
   afterEach(() => {
     resetDeviceToolsDependencies();
     clearAutolockEnv();
+    clearDirectSessionDevices();
     DaemonState.getInstance().reset();
     daemonSessionManager?.stopCleanupTimer();
   });
@@ -268,6 +273,10 @@ describe("startDevice handler", () => {
     const result = await callStartDevice({ platform: "android" });
 
     expect(result.sessionId).toBe("session-1");
+    expect(resolveDirectSessionDevice("session-1")).toEqual({
+      sessionUuid: "session-1",
+      device: androidDevice,
+    });
   });
 
   it("fails closed on an unusable iOS runner override, before touching the cached runner (#4221)", async () => {

--- a/test/server/observationResources.test.ts
+++ b/test/server/observationResources.test.ts
@@ -1,0 +1,147 @@
+import { afterEach, describe, expect, test } from "bun:test";
+import type { BootedDevice, ObserveResult } from "../../src/models";
+import type { ScreenshotResult } from "../../src/models/ScreenshotResult";
+import type { TrackedScreenshotService } from "../../src/features/observe/screenshot/ObserveScreenshotRecorder";
+import { RealObserveScreen } from "../../src/features/observe/ObserveScreen";
+import {
+  RESOURCE_URIS,
+  registerObservationResources,
+  resetSessionScreenshotResourceDependencies,
+  resetScreenshotFileSystem,
+  setSessionScreenshotResourceDependencies,
+  setScreenshotFileSystem,
+} from "../../src/server/observationResources";
+import { ResourceRegistry } from "../../src/server/resourceRegistry";
+import { FakeAdbClientFactory } from "../fakes/FakeAdbClientFactory";
+import { FakeAdbExecutor } from "../fakes/FakeAdbExecutor";
+
+const sessionUuid = "session-123";
+const sessionDevice: BootedDevice = {
+  deviceId: "emulator-5554",
+  name: "Pixel 9",
+  platform: "android",
+};
+
+function activeSession(device: BootedDevice = sessionDevice) {
+  return { sessionUuid, device };
+}
+
+function readTemplate(uri: string) {
+  registerObservationResources();
+  const match = ResourceRegistry.matchTemplate(uri);
+  expect(match).toBeDefined();
+  return match!.template.handler(match!.params);
+}
+
+function createTrackedScreenshot(result: ScreenshotResult): TrackedScreenshotService {
+  return {
+    async execute(): Promise<ScreenshotResult> {
+      return result;
+    },
+    generateScreenshotPath(): string {
+      return "/tmp/fresh.png";
+    },
+    async getActivityHash(): Promise<string> {
+      return "hash";
+    },
+    startTrackedCapture() {
+      const controller = new AbortController();
+      return {
+        jobId: "fresh-capture",
+        promise: Promise.resolve(result),
+        signal: controller.signal,
+      };
+    },
+  };
+}
+
+describe("session screenshot resources", () => {
+  afterEach(() => {
+    RealObserveScreen.clearCache();
+    resetSessionScreenshotResourceDependencies();
+    resetScreenshotFileSystem();
+  });
+
+  test("registers session-scoped cached and fresh screenshot templates", () => {
+    registerObservationResources();
+
+    expect(ResourceRegistry.getTemplate(RESOURCE_URIS.SESSION_OBSERVATION)).toBeDefined();
+    expect(ResourceRegistry.getTemplate(RESOURCE_URIS.SESSION_SCREENSHOT)).toBeDefined();
+    expect(ResourceRegistry.getTemplate(RESOURCE_URIS.FRESH_SESSION_SCREENSHOT)).toBeDefined();
+    expect(ResourceRegistry.getTemplate("automobile:observation/{deviceId}/latest")).toBeUndefined();
+  });
+
+  test("does not expose another device's cached observation through a session path", async () => {
+    const otherDevice: BootedDevice = {
+      deviceId: "emulator-5556",
+      name: "Pixel 10",
+      platform: "android",
+    };
+    const observeScreen = new RealObserveScreen(otherDevice, new FakeAdbClientFactory(new FakeAdbExecutor()));
+    const observed: ObserveResult = {
+      ...observeScreen.createBaseResult(),
+      viewHierarchy: "only-other-device",
+    };
+    await observeScreen.cacheObserveResult(observed);
+    setSessionScreenshotResourceDependencies({
+      resolveActiveSession: () => activeSession(),
+      createScreenshotService: () => createTrackedScreenshot({ success: false }),
+    });
+
+    const content = await readTemplate(
+      "automobile:observation/session/session-123/latest",
+    );
+
+    expect(content.uri).toBe("automobile:observation/session/session-123/latest");
+    expect(content.mimeType).toBe("application/json");
+    expect(JSON.parse(content.text!).error).toContain("No observation available for sessionUuid session-123");
+  });
+
+  test("returns a fresh PNG capture for an active session", async () => {
+    const image = Buffer.from("fresh screenshot");
+    let captureDevice: BootedDevice | undefined;
+    setSessionScreenshotResourceDependencies({
+      resolveActiveSession: () => activeSession(),
+      createScreenshotService: device => {
+        captureDevice = device;
+        return createTrackedScreenshot({ success: true, path: "/tmp/fresh.png" });
+      },
+    });
+    setScreenshotFileSystem({
+      stat: async () => ({ isFile: () => true }),
+      readFile: async () => image,
+    });
+
+    const content = await readTemplate(
+      "automobile:device-session/session-123/screenshot",
+    );
+
+    expect(captureDevice).toEqual(sessionDevice);
+    expect(content).toEqual({
+      uri: "automobile:device-session/session-123/screenshot",
+      mimeType: "image/png",
+      blob: image.toString("base64"),
+    });
+  });
+
+  test("rejects a fresh capture when the session no longer owns its device", async () => {
+    let reads = 0;
+    setSessionScreenshotResourceDependencies({
+      resolveActiveSession: () => {
+        reads += 1;
+        return reads === 1 ? activeSession() : undefined;
+      },
+      createScreenshotService: () => createTrackedScreenshot({
+        success: true,
+        path: "/tmp/fresh.png",
+      }),
+    });
+
+    const content = await readTemplate(
+      "automobile:device-session/session-123/screenshot",
+    );
+
+    expect(content.mimeType).toBe("application/json");
+    expect(JSON.parse(content.text!).error).toContain("No active device session found");
+  });
+});

--- a/test/server/observationResources.test.ts
+++ b/test/server/observationResources.test.ts
@@ -39,7 +39,12 @@ function readTemplate(uri: string, context: ResourceReadContext = {}) {
   registerObservationResources();
   const match = ResourceRegistry.matchTemplate(uri);
   expect(match).toBeDefined();
-  return match!.template.handler(match!.params, context);
+  const { template, params } = match!;
+  expect("handlerWithReadContext" in template).toBe(true);
+  if ("handlerWithReadContext" in template) {
+    return template.handlerWithReadContext(params, context);
+  }
+  return template.handler(params);
 }
 
 function createTrackedScreenshot(

--- a/test/server/observationResources.test.ts
+++ b/test/server/observationResources.test.ts
@@ -3,6 +3,7 @@ import type { BootedDevice, ObserveResult } from "../../src/models";
 import type { ScreenshotResult } from "../../src/models/ScreenshotResult";
 import type { TrackedScreenshotService } from "../../src/features/observe/screenshot/ObserveScreenshotRecorder";
 import { RealObserveScreen } from "../../src/features/observe/ObserveScreen";
+import { ScreenshotJobTracker } from "../../src/utils/ScreenshotJobTracker";
 import {
   RESOURCE_URIS,
   registerObservationResources,
@@ -33,9 +34,13 @@ function readTemplate(uri: string) {
   return match!.template.handler(match!.params);
 }
 
-function createTrackedScreenshot(result: ScreenshotResult): TrackedScreenshotService {
+function createTrackedScreenshot(
+  result: ScreenshotResult,
+  onExecute: () => void = () => {},
+): TrackedScreenshotService {
   return {
     async execute(): Promise<ScreenshotResult> {
+      onExecute();
       return result;
     },
     generateScreenshotPath(): string {
@@ -124,12 +129,48 @@ describe("session screenshot resources", () => {
     });
   });
 
+  test("waits for a pending capture before taking a distinct fresh capture", async () => {
+    let resolvePendingCapture: (result: ScreenshotResult) => void = () => {};
+    const pendingCapture = new Promise<ScreenshotResult>(resolve => {
+      resolvePendingCapture = resolve;
+    });
+    ScreenshotJobTracker.startJob(sessionDevice.deviceId, async () => pendingCapture);
+
+    const image = Buffer.from("fresh screenshot");
+    let freshCaptureCount = 0;
+    setSessionScreenshotResourceDependencies({
+      resolveActiveSession: () => activeSession(),
+      createScreenshotService: () => createTrackedScreenshot(
+        { success: true, path: "/tmp/fresh.png" },
+        () => {
+          freshCaptureCount++;
+        },
+      ),
+    });
+    setScreenshotFileSystem({
+      stat: async () => ({ isFile: () => true }),
+      readFile: async () => image,
+    });
+
+    const contentPromise = readTemplate(
+      "automobile:device-session/session-123/screenshot",
+    );
+    await Promise.resolve();
+    expect(freshCaptureCount).toBe(0);
+
+    resolvePendingCapture({ success: true, path: "/tmp/older.png" });
+    const content = await contentPromise;
+
+    expect(freshCaptureCount).toBe(1);
+    expect(content.blob).toBe(image.toString("base64"));
+  });
+
   test("rejects a fresh capture when the session no longer owns its device", async () => {
     let reads = 0;
     setSessionScreenshotResourceDependencies({
       resolveActiveSession: () => {
         reads += 1;
-        return reads === 1 ? activeSession() : undefined;
+        return reads <= 2 ? activeSession() : undefined;
       },
       createScreenshotService: () => createTrackedScreenshot({
         success: true,

--- a/test/server/observationResources.test.ts
+++ b/test/server/observationResources.test.ts
@@ -13,7 +13,14 @@ import {
   setSessionScreenshotResourceDependencies,
   setScreenshotFileSystem,
 } from "../../src/server/observationResources";
-import { ResourceRegistry } from "../../src/server/resourceRegistry";
+import {
+  ResourceRegistry,
+  type ResourceReadContext,
+} from "../../src/server/resourceRegistry";
+import {
+  clearDirectSessionDevices,
+  registerDirectSessionDevice,
+} from "../../src/server/directSessionDeviceRegistry";
 import { FakeAdbClientFactory } from "../fakes/FakeAdbClientFactory";
 import { FakeAdbExecutor } from "../fakes/FakeAdbExecutor";
 
@@ -28,11 +35,11 @@ function activeSession(device: BootedDevice = sessionDevice) {
   return { sessionUuid, device };
 }
 
-function readTemplate(uri: string) {
+function readTemplate(uri: string, context: ResourceReadContext = {}) {
   registerObservationResources();
   const match = ResourceRegistry.matchTemplate(uri);
   expect(match).toBeDefined();
-  return match!.template.handler(match!.params);
+  return match!.template.handler(match!.params, context);
 }
 
 function createTrackedScreenshot(
@@ -62,6 +69,7 @@ function createTrackedScreenshot(
 describe("session screenshot resources", () => {
   afterEach(() => {
     RealObserveScreen.clearCache();
+    clearDirectSessionDevices();
     resetSessionScreenshotResourceDependencies();
     resetScreenshotFileSystem();
   });
@@ -99,6 +107,54 @@ describe("session screenshot resources", () => {
     expect(content.uri).toBe("automobile:observation/session/session-123/latest");
     expect(content.mimeType).toBe("application/json");
     expect(JSON.parse(content.text!).error).toContain("No observation available for sessionUuid session-123");
+  });
+
+  test("resolves a direct-mode session registered by startDevice", async () => {
+    const observeScreen = new RealObserveScreen(
+      sessionDevice,
+      new FakeAdbClientFactory(new FakeAdbExecutor()),
+    );
+    const observed: ObserveResult = {
+      ...observeScreen.createBaseResult(),
+      viewHierarchy: "direct-mode-session",
+    };
+    await observeScreen.cacheObserveResult(observed);
+    registerDirectSessionDevice(sessionUuid, sessionDevice);
+
+    const content = await readTemplate(
+      "automobile:observation/session/session-123/latest",
+    );
+
+    expect(JSON.parse(content.text!).viewHierarchy).toBe("direct-mode-session");
+  });
+
+  test("rejects session resource reads outside the caller's bound session", async () => {
+    let resolveCalls = 0;
+    let screenshotServiceCalls = 0;
+    setSessionScreenshotResourceDependencies({
+      resolveActiveSession: () => {
+        resolveCalls++;
+        return activeSession();
+      },
+      createScreenshotService: () => {
+        screenshotServiceCalls++;
+        return createTrackedScreenshot({ success: true, path: "/tmp/fresh.png" });
+      },
+    });
+
+    for (const uri of [
+      "automobile:observation/session/session-123/latest",
+      "automobile:observation/session/session-123/latest/screenshot",
+      "automobile:device-session/session-123/screenshot",
+    ]) {
+      const content = await readTemplate(uri, { sessionUuid: "session-other" });
+
+      expect(content.mimeType).toBe("application/json");
+      expect(JSON.parse(content.text!).error).toContain("bound device session");
+    }
+
+    expect(resolveCalls).toBe(0);
+    expect(screenshotServiceCalls).toBe(0);
   });
 
   test("returns a fresh PNG capture for an active session", async () => {

--- a/test/server/observationResources.test.ts
+++ b/test/server/observationResources.test.ts
@@ -2,6 +2,7 @@ import { afterEach, describe, expect, test } from "bun:test";
 import type { BootedDevice, ObserveResult } from "../../src/models";
 import type { ScreenshotResult } from "../../src/models/ScreenshotResult";
 import type { TrackedScreenshotService } from "../../src/features/observe/screenshot/ObserveScreenshotRecorder";
+import type { ScreenshotJobOptions } from "../../src/utils/ScreenshotJobTracker";
 import { RealObserveScreen } from "../../src/features/observe/ObserveScreen";
 import { ScreenshotJobTracker } from "../../src/utils/ScreenshotJobTracker";
 import {
@@ -36,11 +37,10 @@ function readTemplate(uri: string) {
 
 function createTrackedScreenshot(
   result: ScreenshotResult,
-  onExecute: () => void = () => {},
+  deviceId: string = sessionDevice.deviceId,
 ): TrackedScreenshotService {
   return {
     async execute(): Promise<ScreenshotResult> {
-      onExecute();
       return result;
     },
     generateScreenshotPath(): string {
@@ -49,13 +49,12 @@ function createTrackedScreenshot(
     async getActivityHash(): Promise<string> {
       return "hash";
     },
-    startTrackedCapture() {
-      const controller = new AbortController();
-      return {
-        jobId: "fresh-capture",
-        promise: Promise.resolve(result),
-        signal: controller.signal,
-      };
+    startTrackedCapture(_options, trackerOptions) {
+      return ScreenshotJobTracker.startJob(
+        deviceId,
+        async () => result,
+        trackerOptions,
+      );
     },
   };
 }
@@ -138,14 +137,23 @@ describe("session screenshot resources", () => {
 
     const image = Buffer.from("fresh screenshot");
     let freshCaptureCount = 0;
+    let freshTrackerOptions: ScreenshotJobOptions | undefined;
     setSessionScreenshotResourceDependencies({
       resolveActiveSession: () => activeSession(),
-      createScreenshotService: () => createTrackedScreenshot(
-        { success: true, path: "/tmp/fresh.png" },
-        () => {
-          freshCaptureCount++;
+      createScreenshotService: () => ({
+        ...createTrackedScreenshot({ success: true, path: "/tmp/fresh.png" }),
+        startTrackedCapture(options, trackerOptions) {
+          freshTrackerOptions = trackerOptions;
+          return ScreenshotJobTracker.startJob(
+            sessionDevice.deviceId,
+            async () => {
+              freshCaptureCount++;
+              return { success: true, path: "/tmp/fresh.png" };
+            },
+            trackerOptions,
+          );
         },
-      ),
+      }),
     });
     setScreenshotFileSystem({
       stat: async () => ({ isFile: () => true }),
@@ -162,6 +170,7 @@ describe("session screenshot resources", () => {
     const content = await contentPromise;
 
     expect(freshCaptureCount).toBe(1);
+    expect(freshTrackerOptions).toEqual({ queueAfterPending: true });
     expect(content.blob).toBe(image.toString("base64"));
   });
 
@@ -170,7 +179,7 @@ describe("session screenshot resources", () => {
     setSessionScreenshotResourceDependencies({
       resolveActiveSession: () => {
         reads += 1;
-        return reads <= 2 ? activeSession() : undefined;
+        return reads === 1 ? activeSession() : undefined;
       },
       createScreenshotService: () => createTrackedScreenshot({
         success: true,

--- a/test/server/resourceRegistryListChanged.test.ts
+++ b/test/server/resourceRegistryListChanged.test.ts
@@ -143,7 +143,7 @@ describe("ResourceRegistry URI-template matching", () => {
 
   test("passes the registered server's read context to template handlers", async () => {
     const server = new FakeMcpServer();
-    ResourceRegistry.registerTemplate(
+    ResourceRegistry.registerTemplateWithReadContext(
       "automobile:test/{id}",
       "Test",
       "Test contextual template",

--- a/test/server/resourceRegistryListChanged.test.ts
+++ b/test/server/resourceRegistryListChanged.test.ts
@@ -1,6 +1,10 @@
 import { beforeEach, describe, expect, test } from "bun:test";
 import type { McpServer } from "@modelcontextprotocol/sdk/server/mcp.js";
-import { SubscribeRequestSchema, UnsubscribeRequestSchema } from "@modelcontextprotocol/sdk/types.js";
+import {
+  ReadResourceRequestSchema,
+  SubscribeRequestSchema,
+  UnsubscribeRequestSchema,
+} from "@modelcontextprotocol/sdk/types.js";
 import { ResourceRegistry } from "../../src/server/resourceRegistry";
 import { ListChangedBroadcaster } from "../../src/server/listChangedBroadcast";
 
@@ -134,6 +138,34 @@ describe("ResourceRegistry URI-template matching", () => {
 
     expect(ResourceRegistry.matchTemplate("automobile:test?first=one&second=two")).toMatchObject({
       params: { params: "first=one&second=two" }
+    });
+  });
+
+  test("passes the registered server's read context to template handlers", async () => {
+    const server = new FakeMcpServer();
+    ResourceRegistry.registerTemplate(
+      "automobile:test/{id}",
+      "Test",
+      "Test contextual template",
+      "application/json",
+      async (params, context) => ({
+        uri: `automobile:test/${params.id}`,
+        text: JSON.stringify(context),
+      }),
+    );
+    ResourceRegistry.registerWithServer(
+      server as unknown as McpServer,
+      () => ({ sessionUuid: "session-bound" }),
+    );
+
+    const readHandler = server.server.handlersBySchema.get(ReadResourceRequestSchema);
+    expect(readHandler).toBeDefined();
+    const response = await readHandler!({ params: { uri: "automobile:test/one" } }) as {
+      contents: Array<{ text?: string }>;
+    };
+
+    expect(JSON.parse(response.contents[0].text!)).toEqual({
+      sessionUuid: "session-bound",
     });
   });
 });

--- a/test/utils/ScreenshotJobTracker.test.ts
+++ b/test/utils/ScreenshotJobTracker.test.ts
@@ -206,6 +206,68 @@ describe("ScreenshotJobTracker", () => {
     expect(secondResult.path).toBe("second");
   });
 
+  test("keeps the active capture latest until its queued successor starts", async () => {
+    let resolveFirst: (result: { success: boolean; path?: string }) => void = () => {};
+    let firstWasLatest = false;
+    const first = ScreenshotJobTracker.startJob(
+      "device-queued-latest",
+      () => new Promise(resolve => {
+        resolveFirst = resolve;
+      }),
+      {
+        onComplete: completion => {
+          firstWasLatest = completion.isLatest;
+        },
+      },
+    );
+    const queued = ScreenshotJobTracker.startJob(
+      "device-queued-latest",
+      async () => ({ success: true, path: "queued" }),
+      { queueAfterPending: true },
+    );
+
+    await Promise.resolve();
+    resolveFirst({ success: true, path: "active" });
+    await first.promise;
+
+    expect(firstWasLatest).toBe(true);
+    await queued.promise;
+  });
+
+  test("queues an observe capture behind an active fresh capture", async () => {
+    let resolveFresh: (result: { success: boolean; path?: string }) => void = () => {};
+    let observeRunnerCalls = 0;
+    const fresh = ScreenshotJobTracker.startJob(
+      "device-fresh-then-observe",
+      () => new Promise(resolve => {
+        resolveFresh = resolve;
+      }),
+      { queueAfterPending: true },
+    );
+    await Promise.resolve();
+
+    const observe = ScreenshotJobTracker.startJob(
+      "device-fresh-then-observe",
+      async () => {
+        observeRunnerCalls++;
+        return { success: true, path: "observe" };
+      },
+      { coalesceWithPending: true },
+    );
+    await Promise.resolve();
+
+    expect(observe.jobId).not.toBe(fresh.jobId);
+    expect(observeRunnerCalls).toBe(0);
+    expect(fresh.signal.aborted).toBe(false);
+
+    resolveFresh({ success: true, path: "fresh" });
+    const [freshResult, observeResult] = await Promise.all([fresh.promise, observe.promise]);
+
+    expect(freshResult.path).toBe("fresh");
+    expect(observeRunnerCalls).toBe(1);
+    expect(observeResult.path).toBe("observe");
+  });
+
   test("queueAfterPending remains cancellable before its runner starts", async () => {
     let resolveFirst: (result: { success: boolean; path?: string }) => void = () => {};
     const first = ScreenshotJobTracker.startJob(

--- a/test/utils/ScreenshotJobTracker.test.ts
+++ b/test/utils/ScreenshotJobTracker.test.ts
@@ -176,6 +176,68 @@ describe("ScreenshotJobTracker", () => {
     expect(job2.jobId).not.toBe(job1.jobId);
   });
 
+  test("queueAfterPending starts a distinct capture after the current one settles", async () => {
+    let resolveFirst: (result: { success: boolean; path?: string }) => void = () => {};
+    const first = ScreenshotJobTracker.startJob(
+      "device-queue",
+      () => new Promise(resolve => {
+        resolveFirst = resolve;
+      }),
+    );
+    let secondRunnerCalls = 0;
+    const second = ScreenshotJobTracker.startJob(
+      "device-queue",
+      async () => {
+        secondRunnerCalls++;
+        return { success: true, path: "second" };
+      },
+      { queueAfterPending: true },
+    );
+
+    await Promise.resolve();
+    expect(secondRunnerCalls).toBe(0);
+    expect(ScreenshotJobTracker.isPending("device-queue")).toBe(true);
+
+    resolveFirst({ success: true, path: "first" });
+    const [firstResult, secondResult] = await Promise.all([first.promise, second.promise]);
+
+    expect(firstResult.path).toBe("first");
+    expect(secondRunnerCalls).toBe(1);
+    expect(secondResult.path).toBe("second");
+  });
+
+  test("queueAfterPending remains cancellable before its runner starts", async () => {
+    let resolveFirst: (result: { success: boolean; path?: string }) => void = () => {};
+    const first = ScreenshotJobTracker.startJob(
+      "device-cancel-queue",
+      signal => new Promise(resolve => {
+        resolveFirst = resolve;
+        signal.addEventListener("abort", () => {
+          resolve({ success: false, error: OPERATION_CANCELLED_MESSAGE });
+        }, { once: true });
+      }),
+    );
+    let queuedRunnerCalls = 0;
+    const queued = ScreenshotJobTracker.startJob(
+      "device-cancel-queue",
+      async () => {
+        queuedRunnerCalls++;
+        return { success: true, path: "queued" };
+      },
+      { queueAfterPending: true },
+    );
+
+    await Promise.resolve();
+    ScreenshotJobTracker.cancelJob("device-cancel-queue");
+    resolveFirst({ success: false, error: OPERATION_CANCELLED_MESSAGE });
+    const [firstResult, queuedResult] = await Promise.all([first.promise, queued.promise]);
+
+    expect(firstResult.success).toBe(false);
+    expect(queuedResult.success).toBe(false);
+    expect(queuedResult.error).toContain(OPERATION_CANCELLED_MESSAGE);
+    expect(queuedRunnerCalls).toBe(0);
+  });
+
   test("reports isLatest and aborted correctly to each job's completion handler", async () => {
     const completions: Array<{ jobId: string; isLatest: boolean; aborted: boolean }> = [];
     const onComplete = (c: { jobId: string; isLatest: boolean; aborted: boolean }) => {


### PR DESCRIPTION
## Summary

- replace device-ID observation resources with active session UUID resource paths
- add a fresh PNG screenshot resource that captures on every read
- retain cached observation and screenshot resources for the same active session
- make screenshot artifact names collision-resistant for concurrent captures

## Validation

- `bun run turbo:validate`
- `bun run typecheck`

Closes [issue #5437](https://github.com/kaeawc/auto-mobile/issues/5437).
