### PR TITLE
feat(resources): enrich device discovery catalogs

### DIFF
--- a/docs/design-docs/mcp/resources.md
+++ b/docs/design-docs/mcp/resources.md
@@ -126,12 +126,28 @@ Entries are ordered newest-first by the app record's `updated_at`.
 Returns booted device inventory across Android and iOS, including:
 
 - Total, per-platform, virtual, and physical device counts
+- `observationComplete` plus a per-platform completion/error result, so an
+  empty device list is only treated as durable absence after discovery completed
 - Optional daemon pool status (idle/assigned/error) when the daemon is active
 - Per-device pool assignment (status + session UUID) when available
+- Stable device identity, transient connection identity, lifecycle state,
+  runtime, form factor, readiness, and automation capability status
 
 **URI Template**: `automobile:devices/booted/{platform}`
 
 This resource supersedes the device data that the `listDevices` tool used to return. `listDevices` still exists as an MCP tool, but now returns **resource guidance** — a message pointing callers at these resource URIs — rather than device data (see `listDevicesHandler` in `src/server/deviceTools.ts`). The separate `daemon_available_devices` tool was removed.
+
+### Device Images
+
+**URI**: `automobile:devices/images`
+
+Returns startable Android AVDs and iOS simulators plus a normalized
+`provisioningCatalog`. The catalog lists available runtimes, device types,
+Android system images, and Android device profiles where the installed platform
+tools expose them. `catalogComplete` and per-platform `catalogObservations`
+show whether the catalog can safely be used for provisioning decisions.
+
+**URI Template**: `automobile:devices/images/{platform}`
 
 ### Installed Apps
 

--- a/src/server/appResources.ts
+++ b/src/server/appResources.ts
@@ -10,6 +10,7 @@ import { getInstalledAppsCacheWriteCoordinator } from "../db/installedAppsCacheW
 import { getDbWriteBarrier } from "../db/dbWriteBarrier";
 import { defaultTimer, type Timer } from "../utils/SystemTimer";
 import { getIosInstalledAppBundleId } from "../utils/ios-cmdline-tools/iosInstalledApp";
+import { queryParamsToRecord } from "./queryParamValidation";
 
 // Resource URI templates
 export const APP_RESOURCE_TEMPLATES = {
@@ -23,7 +24,8 @@ export const APPS_RESOURCE_URIS = {
 } as const;
 
 const APPS_QUERY_KEYS = ["deviceId", "platform", "search", "type", "profile"] as const;
-type AppsQueryKey = typeof APPS_QUERY_KEYS[number];
+const APPS_QUERY_TEMPLATE = `${APPS_RESOURCE_URIS.BASE}?{params}`;
+const APPS_QUERY_PARAM_KEYS = new Set<string>(APPS_QUERY_KEYS);
 type AppsQueryType = "user" | "system";
 
 interface AppsQueryOptions {
@@ -412,9 +414,8 @@ function decodeQueryParam(value: string | undefined): string | undefined {
   if (!value) {
     return undefined;
   }
-  const normalized = value.replace(/\+/g, " ");
-  const decoded = decodeURIComponent(normalized).trim();
-  return decoded ? decoded : undefined;
+  const trimmed = value.trim();
+  return trimmed ? trimmed : undefined;
 }
 
 function parseProfileParam(value: string | undefined): number | undefined {
@@ -430,6 +431,11 @@ function parseProfileParam(value: string | undefined): number | undefined {
 }
 
 function parseAppsQueryParams(params: Record<string, string>): AppsQueryOptions {
+  const unknownKeys = Object.keys(params).filter(key => !APPS_QUERY_PARAM_KEYS.has(key));
+  if (unknownKeys.length > 0) {
+    throw new Error(`Unknown query parameters: ${unknownKeys.join(", ")}`);
+  }
+
   const platformRaw = decodeQueryParam(params.platform);
   const typeRaw = decodeQueryParam(params.type);
   const search = decodeQueryParam(params.search);
@@ -484,11 +490,6 @@ function buildAppsUri(options: AppsQueryOptions): string {
 
   const queryString = query.toString();
   return queryString ? `${APPS_RESOURCE_URIS.BASE}?${queryString}` : APPS_RESOURCE_URIS.BASE;
-}
-
-function buildAppsQueryTemplate(keys: readonly AppsQueryKey[]): string {
-  const query = keys.map(key => `${key}={${key}}`).join("&");
-  return `${APPS_RESOURCE_URIS.BASE}?${query}`;
 }
 
 function filterAppsByQuery(apps: AppsQueryAppInfo[], options: AppsQueryOptions): AppsQueryAppInfo[] {
@@ -844,27 +845,6 @@ async function getAppMetadataResource(
   }
 }
 
-function registerAppsQueryTemplates(
-  handler: (params: Record<string, string>) => Promise<ResourceContent>
-): void {
-  const optionalKeys = APPS_QUERY_KEYS.filter(key => key !== "deviceId");
-  const optionalKeyCount = optionalKeys.length;
-
-  for (let mask = 0; mask < (1 << optionalKeyCount); mask += 1) {
-    const keys = [
-      "deviceId",
-      ...optionalKeys.filter((_, index) => (mask & (1 << index)) !== 0)
-    ];
-    ResourceRegistry.registerTemplate(
-      buildAppsQueryTemplate(keys),
-      "Installed Apps",
-      "List installed apps across booted devices with optional query filters.",
-      "application/json",
-      handler
-    );
-  }
-}
-
 export function registerAppResources(): void {
   ResourceRegistry.register(
     APPS_RESOURCE_URIS.BASE,
@@ -874,9 +854,15 @@ export function registerAppResources(): void {
     () => getAppsQueryResource({}, APPS_RESOURCE_URIS.BASE)
   );
 
-  registerAppsQueryTemplates(async params => {
+  ResourceRegistry.registerTemplate(
+    APPS_QUERY_TEMPLATE,
+    "Installed Apps",
+    "List installed apps across booted devices with optional query filters.",
+    "application/json",
+    async params => {
     try {
-      const options = parseAppsQueryParams(params);
+      const queryParams = queryParamsToRecord(params.params ?? "");
+      const options = parseAppsQueryParams(queryParams);
       const uri = buildAppsUri(options);
       return getAppsQueryResource(options, uri);
     } catch (error) {

--- a/src/server/bootedDeviceResources.ts
+++ b/src/server/bootedDeviceResources.ts
@@ -321,8 +321,10 @@ function toDeviceIdentity(
   isVirtual: boolean
 ): DeviceIdentity {
   const identity: DeviceIdentity = {
-    stableId: poolInfo?.avdName ?? (isVirtual ? device.name : device.deviceId),
-    connectionId: device.deviceId,
+    stableId: device.platform === "android" && isVirtual
+      ? poolInfo?.avdName ?? device.name
+      : device.deviceId,
+    connectionId: device.transportId ?? device.deviceId,
   };
   if (device.transportId) {
     identity.transportId = device.transportId;

--- a/src/server/bootedDeviceResources.ts
+++ b/src/server/bootedDeviceResources.ts
@@ -1,5 +1,8 @@
 import { ResourceRegistry, ResourceContent } from "./resourceRegistry";
-import { PlatformDeviceManager } from "../utils/deviceUtils";
+import {
+  type DeviceDiscoveryError,
+  PlatformDeviceManager,
+} from "../utils/deviceUtils";
 import { PlatformDeviceManagerFactory } from "../utils/factories/PlatformDeviceManagerFactory";
 import { logger } from "../utils/logger";
 import { BootedDevice, Platform } from "../models";
@@ -62,14 +65,37 @@ interface DeviceServiceStatus {
   supportedCommandsComplete?: boolean | null;
 }
 
+interface DeviceIdentity {
+  stableId: string;
+  connectionId: string;
+  transportId?: string;
+}
+
+interface DeviceReadiness {
+  state: "ready" | "not_ready" | "unknown";
+}
+
+interface DeviceCapabilities {
+  automation: Pick<
+    DeviceServiceStatus,
+    "installed" | "enabled" | "running" | "isCompatible" | "supportedCommandsComplete"
+  > | null;
+}
+
 // Booted device info for resource response
 interface BootedDeviceInfo {
   name: string;
   platform: Platform;
   deviceId: string;
+  identity: DeviceIdentity;
   source: "local" | "remote";
   isVirtual: boolean;
   status: "booted";
+  lifecycleState: "booted";
+  runtime?: string;
+  formFactor?: BootedDevice["formFactor"];
+  readiness: DeviceReadiness;
+  capabilities: DeviceCapabilities;
   poolStatus?: PoolDeviceStatus;
   assignedSession?: string;
   recoveryEligibility?: DeviceRecoveryEligibility;
@@ -91,8 +117,15 @@ export interface BootedDevicesResourceContent {
   virtualCount: number;
   physicalCount: number;
   lastUpdated: string;  // ISO 8601
+  observationComplete: boolean;
+  platformObservations: Partial<Record<Platform, PlatformObservation>>;
   poolStatus?: PoolStatusSummary;
   devices: BootedDeviceInfo[];
+}
+
+interface PlatformObservation {
+  observationComplete: boolean;
+  discoveryError?: DeviceDiscoveryError;
 }
 
 type PoolDeviceStatus = "idle" | "assigned" | "error";
@@ -120,6 +153,7 @@ interface PoolDeviceInfo {
   poolStatus: PoolDeviceStatus;
   assignedSession?: string;
   recoveryEligibility: DeviceRecoveryEligibility;
+  avdName?: string;
 }
 
 /**
@@ -249,28 +283,51 @@ function toBootedDeviceInfo(
   poolInfo?: PoolDeviceInfo,
   sessionInfo?: DeviceSessionInfo
 ): BootedDeviceInfo {
+  const isVirtual = isVirtualDevice(device);
+  const runtime = device.iosVersion ?? device.osVersion;
   const info: BootedDeviceInfo = {
     name: device.name,
     platform: device.platform,
     deviceId: device.deviceId,
+    identity: toDeviceIdentity(device, poolInfo, isVirtual),
     source: device.source || "local",
-    isVirtual: isVirtualDevice(device),
-    status: "booted"
+    isVirtual,
+    status: "booted",
+    lifecycleState: "booted",
+    readiness: { state: "unknown" },
+    capabilities: { automation: null },
   };
 
-  if (!poolInfo && !sessionInfo) {
-    return info;
+  if (runtime) {
+    info.runtime = runtime;
   }
+  if (device.formFactor) {
+    info.formFactor = device.formFactor;
+  }
+  if (poolInfo) {
+    info.poolStatus = poolInfo.poolStatus;
+    info.assignedSession = poolInfo.assignedSession;
+    info.recoveryEligibility = poolInfo.recoveryEligibility;
+  }
+  if (sessionInfo) {
+    info.session = sessionInfo;
+  }
+  return info;
+}
 
-  return {
-    ...info,
-    ...(poolInfo ? {
-      poolStatus: poolInfo.poolStatus,
-      ...(poolInfo.assignedSession ? { assignedSession: poolInfo.assignedSession } : {}),
-      recoveryEligibility: poolInfo.recoveryEligibility,
-    } : {}),
-    ...(sessionInfo ? { session: sessionInfo } : {})
+function toDeviceIdentity(
+  device: BootedDevice,
+  poolInfo: PoolDeviceInfo | undefined,
+  isVirtual: boolean
+): DeviceIdentity {
+  const identity: DeviceIdentity = {
+    stableId: poolInfo?.avdName ?? (isVirtual ? device.name : device.deviceId),
+    connectionId: device.deviceId,
   };
+  if (device.transportId) {
+    identity.transportId = device.transportId;
+  }
+  return identity;
 }
 
 function isVirtualDevice(device: BootedDevice): boolean {
@@ -299,6 +356,7 @@ function getPoolDeviceInfo(devicePool: DevicePool | null, deviceId: string): Poo
     poolStatus,
     assignedSession: pooledDevice.sessionId || undefined,
     recoveryEligibility: devicePool.getRecoveryEligibility(deviceId),
+    avdName: pooledDevice.avdName,
   };
 }
 
@@ -392,162 +450,216 @@ async function getBootedDevicesByPlatform(params: Record<string, string>): Promi
   };
 }
 
-// Core function to fetch booted devices for specified platforms
-async function getBootedDevicesForPlatforms(platforms: Platform[]): Promise<BootedDevicesResourceContent> {
-  const devices: BootedDeviceInfo[] = [];
-  let androidCount = 0;
-  let iosCount = 0;
+interface PlatformDiscoveryResult {
+  devices: BootedDeviceInfo[];
+  succeededPlatforms: Set<Platform>;
+  observation: PlatformObservation;
+}
+
+async function discoverBootedDevicesForPlatform(
+  platform: Platform,
+  devicePool: DevicePool | null,
+  sessionInfoByDeviceId: Map<string, DeviceSessionInfo> | null
+): Promise<PlatformDiscoveryResult> {
+  try {
+    const discovery = await PlatformDeviceManagerFactory.getInstance().getBootedDevicesDetailed(platform);
+    const complete = discovery.succeededPlatforms.has(platform);
+    return {
+      devices: discovery.devices.map(device => toBootedDeviceInfo(
+        device,
+        getPoolDeviceInfo(devicePool, device.deviceId),
+        sessionInfoByDeviceId?.get(device.deviceId)
+      )),
+      succeededPlatforms: discovery.succeededPlatforms,
+      observation: complete
+        ? { observationComplete: true }
+        : {
+          observationComplete: false,
+          discoveryError: discovery.discoveryErrors?.[platform] ?? {
+            code: "failed",
+            message: `${platform === "android" ? "Android" : "iOS"} booted-device discovery did not complete.`,
+          },
+        },
+    };
+  } catch (error) {
+    const platformName = platform === "android" ? "Android" : "iOS";
+    logger.warn(`[BootedDeviceResources] Failed to get booted ${platformName} devices: ${error}`);
+    return {
+      devices: [],
+      succeededPlatforms: new Set(),
+      observation: {
+        observationComplete: false,
+        discoveryError: {
+          code: "failed",
+          message: `${platformName} booted-device discovery failed: ${errorMessage(error)}`,
+        },
+      },
+    };
+  }
+}
+
+function errorMessage(error: unknown): string {
+  return error instanceof Error ? error.message : String(error);
+}
+
+interface DaemonDeviceContext {
+  devicePool: DevicePool | null;
+  poolStatus?: PoolStatusSummary;
+  sessionInfoByDeviceId: Map<string, DeviceSessionInfo> | null;
+}
+
+function readDaemonDeviceContext(): DaemonDeviceContext {
+  const daemonState = DaemonState.getInstance();
+  if (!daemonState.isInitialized()) {
+    return { devicePool: null, sessionInfoByDeviceId: null };
+  }
+
   let devicePool: DevicePool | null = null;
   let poolStatus: PoolStatusSummary | undefined;
   let sessionInfoByDeviceId: Map<string, DeviceSessionInfo> | null = null;
-
-  const daemonState = DaemonState.getInstance();
-  if (daemonState.isInitialized()) {
-    try {
-      devicePool = daemonState.getDevicePool();
-      poolStatus = {
-        enabled: true,
-        idle: 0,
-        assigned: 0,
-        error: 0,
-        total: 0,
-        recoveryPolicy: devicePool.getRecoveryPolicy(),
-      };
-    } catch (error) {
-      logger.warn(`[BootedDeviceResources] Failed to read device pool status: ${error}`);
-      devicePool = null;
-    }
-
-    try {
-      const sessionManager = daemonState.getSessionManager();
-      const sessions = sessionManager.getAllSessions();
-      sessionInfoByDeviceId = new Map(
-        sessions.map(session => [session.assignedDevice, toDeviceSessionInfo(session)])
-      );
-    } catch (error) {
-      logger.warn(`[BootedDeviceResources] Failed to read session manager state: ${error}`);
-      sessionInfoByDeviceId = null;
-    }
+  try {
+    devicePool = daemonState.getDevicePool();
+    poolStatus = {
+      enabled: true,
+      idle: 0,
+      assigned: 0,
+      error: 0,
+      total: 0,
+      recoveryPolicy: devicePool.getRecoveryPolicy(),
+    };
+  } catch (error) {
+    logger.warn(`[BootedDeviceResources] Failed to read device pool status: ${error}`);
   }
-
-  const succeededPlatforms = new Set<Platform>();
 
   try {
-    // Fetch Android booted devices if requested
-    if (platforms.includes("android")) {
-      try {
-        const androidDiscovery = await PlatformDeviceManagerFactory.getInstance().getBootedDevicesDetailed("android");
-        for (const discoveredPlatform of androidDiscovery.succeededPlatforms) {
-          succeededPlatforms.add(discoveredPlatform);
-        }
-        for (const device of androidDiscovery.devices) {
-          devices.push(
-            toBootedDeviceInfo(
-              device,
-              getPoolDeviceInfo(devicePool, device.deviceId),
-              sessionInfoByDeviceId?.get(device.deviceId)
-            )
-          );
-          androidCount++;
-        }
-      } catch (error) {
-        logger.warn(`[BootedDeviceResources] Failed to get booted Android devices: ${error}`);
-      }
-    }
-
-    // Fetch iOS booted simulators if requested
-    if (platforms.includes("ios")) {
-      try {
-        const iosDiscovery = await PlatformDeviceManagerFactory.getInstance().getBootedDevicesDetailed("ios");
-        for (const discoveredPlatform of iosDiscovery.succeededPlatforms) {
-          succeededPlatforms.add(discoveredPlatform);
-        }
-        for (const device of iosDiscovery.devices) {
-          devices.push(
-            toBootedDeviceInfo(
-              device,
-              getPoolDeviceInfo(devicePool, device.deviceId),
-              sessionInfoByDeviceId?.get(device.deviceId)
-            )
-          );
-          iosCount++;
-        }
-      } catch (error) {
-        logger.warn(`[BootedDeviceResources] Failed to get booted iOS simulators: ${error}`);
-      }
-    }
+    const sessions = daemonState.getSessionManager().getAllSessions();
+    sessionInfoByDeviceId = new Map(
+      sessions.map(session => [session.assignedDevice, toDeviceSessionInfo(session)])
+    );
   } catch (error) {
-    logger.error(`[BootedDeviceResources] Error fetching booted devices: ${error}`);
+    logger.warn(`[BootedDeviceResources] Failed to read session manager state: ${error}`);
   }
 
-  // Query service status for each device in parallel with per-device timeout
-  if (serviceStatusEnabled) {
-    const SERVICE_STATUS_TIMEOUT_MS = 5000;
-    const serviceStatusResults = await Promise.allSettled(
-      devices.map(async device => {
-        try {
-          return await Promise.race([
-            queryDeviceServiceStatus(device),
-            new Promise<undefined>(resolve =>
-              defaultTimer.setTimeout(() => {
-                logger.warn(`[BootedDeviceResources] Service status timeout for ${device.deviceId}`);
-                resolve(undefined);
-              }, SERVICE_STATUS_TIMEOUT_MS)
-            ),
-          ]);
-        } catch (error) {
-          logger.warn(`[BootedDeviceResources] Failed to query service status for ${device.deviceId}: ${error}`);
-          return undefined;
-        }
-      })
-    );
+  return { devicePool, poolStatus, sessionInfoByDeviceId };
+}
 
-    for (let i = 0; i < devices.length; i++) {
-      const result = serviceStatusResults[i];
-      if (result.status === "fulfilled" && result.value) {
-        devices[i] = { ...devices[i], serviceStatus: result.value };
+async function enrichDeviceServiceStatuses(devices: BootedDeviceInfo[]): Promise<void> {
+  if (!serviceStatusEnabled) {
+    return;
+  }
+
+  const SERVICE_STATUS_TIMEOUT_MS = 5000;
+  const serviceStatusResults = await Promise.allSettled(
+    devices.map(async device => {
+      try {
+        return await Promise.race([
+          queryDeviceServiceStatus(device),
+          new Promise<undefined>(resolve =>
+            defaultTimer.setTimeout(() => {
+              logger.warn(`[BootedDeviceResources] Service status timeout for ${device.deviceId}`);
+              resolve(undefined);
+            }, SERVICE_STATUS_TIMEOUT_MS)
+          ),
+        ]);
+      } catch (error) {
+        logger.warn(`[BootedDeviceResources] Failed to query service status for ${device.deviceId}: ${error}`);
+        return undefined;
       }
+    })
+  );
+
+  for (let i = 0; i < devices.length; i++) {
+    const result = serviceStatusResults[i];
+    if (result.status === "fulfilled" && result.value) {
+      devices[i] = withServiceStatus(devices[i], result.value);
     }
   }
+}
 
-  // Query per-device lock state so the desktop can gate its contextual Unlock control (#4694). Runs
-  // only with an injected probe (tests) or a real device manager (production), never against a fake
-  // manager's mock devices. Best-effort with a per-device timeout: a slow/failed read leaves `locked`
-  // unset rather than stalling the whole resource.
+function withServiceStatus(
+  device: BootedDeviceInfo,
+  serviceStatus: DeviceServiceStatus
+): BootedDeviceInfo {
+  return {
+    ...device,
+    serviceStatus,
+    readiness: {
+      state: serviceStatus.running && serviceStatus.isCompatible ? "ready" : "not_ready",
+    },
+    capabilities: {
+      automation: {
+        installed: serviceStatus.installed,
+        enabled: serviceStatus.enabled,
+        running: serviceStatus.running,
+        isCompatible: serviceStatus.isCompatible,
+        supportedCommandsComplete: serviceStatus.supportedCommandsComplete,
+      },
+    },
+  };
+}
+
+async function enrichDeviceLockStates(devices: BootedDeviceInfo[]): Promise<void> {
   const lockProbe = activeLockProbe();
-  if (lockProbe) {
-    const lockResults = await Promise.allSettled(
-      // The adb lock probe only needs the device identity; `source` (whose BootedDeviceInfo type is
-      // wider than BootedDevice's) is irrelevant, so omit it rather than force a cast.
-      devices.map(device =>
-        probeDeviceLock(
-          { name: device.name, platform: device.platform, deviceId: device.deviceId },
-          lockProbe
-        )
-      )
-    );
+  if (!lockProbe) {
+    return;
+  }
 
-    for (let i = 0; i < devices.length; i++) {
-      const result = lockResults[i];
-      if (result.status === "fulfilled" && result.value !== undefined) {
-        devices[i] = { ...devices[i], locked: result.value };
-      }
+  const lockResults = await Promise.allSettled(
+    devices.map(device =>
+      probeDeviceLock(
+        { name: device.name, platform: device.platform, deviceId: device.deviceId },
+        lockProbe
+      )
+    )
+  );
+
+  for (let i = 0; i < devices.length; i++) {
+    const result = lockResults[i];
+    if (result.status === "fulfilled" && result.value !== undefined) {
+      devices[i] = { ...devices[i], locked: result.value };
     }
   }
+}
+
+// Core function to fetch booted devices for specified platforms
+async function getBootedDevicesForPlatforms(platforms: Platform[]): Promise<BootedDevicesResourceContent> {
+  const devices: BootedDeviceInfo[] = [];
+  const daemonContext = readDaemonDeviceContext();
+
+  const succeededPlatforms = new Set<Platform>();
+  const platformObservations: Partial<Record<Platform, PlatformObservation>> = {};
+
+  for (const platform of platforms) {
+    const discovery = await discoverBootedDevicesForPlatform(
+      platform,
+      daemonContext.devicePool,
+      daemonContext.sessionInfoByDeviceId
+    );
+    devices.push(...discovery.devices);
+    platformObservations[platform] = discovery.observation;
+    for (const discoveredPlatform of discovery.succeededPlatforms) {
+      succeededPlatforms.add(discoveredPlatform);
+    }
+  }
+
+  await enrichDeviceServiceStatuses(devices);
+  await enrichDeviceLockStates(devices);
 
   const virtualCount = devices.filter(device => device.isVirtual).length;
   const physicalCount = devices.length - virtualCount;
-  if (poolStatus && devicePool) {
-    poolStatus = summarizePoolStatus(devicePool, devices, succeededPlatforms);
-  }
+  const poolStatus = daemonContext.poolStatus && daemonContext.devicePool
+    ? summarizePoolStatus(daemonContext.devicePool, devices, succeededPlatforms)
+    : undefined;
 
   return {
     totalCount: devices.length,
-    androidCount,
-    iosCount,
+    androidCount: devices.filter(device => device.platform === "android").length,
+    iosCount: devices.filter(device => device.platform === "ios").length,
     virtualCount,
     physicalCount,
     lastUpdated: new Date().toISOString(),
+    observationComplete: platforms.every(platform => platformObservations[platform]?.observationComplete === true),
+    platformObservations,
     poolStatus,
     devices
   };

--- a/src/server/deviceImageResources.ts
+++ b/src/server/deviceImageResources.ts
@@ -4,7 +4,17 @@ import { AvdManagerService } from "../utils/android-cmdline-tools/AvdManagerServ
 import { AvdManager } from "../utils/android-cmdline-tools/interfaces/AvdManager";
 import { logger } from "../utils/logger";
 import { DeviceInfo, Platform } from "../models";
-import { AvdInfo } from "../utils/android-cmdline-tools/avdmanager";
+import {
+  AvdInfo,
+  type DeviceProfile,
+  type SystemImage,
+} from "../utils/android-cmdline-tools/avdmanager";
+import {
+  SimCtlClient,
+  type AppleDeviceRuntime,
+  type AppleDeviceType,
+  type SimCtl,
+} from "../utils/ios-cmdline-tools/SimCtlClient";
 
 // Resource URIs
 export const DEVICE_IMAGE_RESOURCE_URIS = {
@@ -34,12 +44,62 @@ interface DeviceImageInfo {
   architecture?: string;
 }
 
+interface ProvisioningRuntime {
+  platform: Platform;
+  id: string;
+  name: string;
+  version?: string;
+  available?: boolean;
+}
+
+interface ProvisioningDeviceType {
+  platform: Platform;
+  id: string;
+  name: string;
+  family?: string;
+}
+
+interface ProvisioningSystemImage {
+  platform: "android";
+  id: string;
+  name: string;
+  apiLevel: number;
+  tag: string;
+  abi: string;
+  version: string;
+}
+
+interface ProvisioningProfile {
+  platform: "android";
+  id: string;
+  name: string;
+  manufacturer?: string;
+}
+
+interface ProvisioningCatalog {
+  runtimes: ProvisioningRuntime[];
+  deviceTypes: ProvisioningDeviceType[];
+  systemImages: ProvisioningSystemImage[];
+  profiles: ProvisioningProfile[];
+}
+
+interface ProvisioningCatalogObservation {
+  catalogComplete: boolean;
+  error?: {
+    code: "unavailable" | "failed";
+    message: string;
+  };
+}
+
 // Resource content schema
 export interface DeviceImagesResourceContent {
   totalCount: number;
   androidCount: number;
   iosCount: number;
   lastUpdated: string;  // ISO 8601
+  catalogComplete: boolean;
+  catalogObservations: Partial<Record<Platform, ProvisioningCatalogObservation>>;
+  provisioningCatalog: ProvisioningCatalog;
   images: DeviceImageInfo[];
 }
 
@@ -47,6 +107,7 @@ export interface DeviceImagesResourceContent {
 interface DeviceImageResourcesDependencies {
   deviceManager: PlatformDeviceManager;
   avdManager: AvdManager;
+  simctl: Pick<SimCtl, "getDeviceTypes" | "getRuntimes">;
 }
 
 /**
@@ -63,57 +124,34 @@ export function createDeviceImageResourcesHandler(
 } {
   const deviceManager = deps?.deviceManager ?? new MultiPlatformDeviceManager();
   const avdManager = deps?.avdManager ?? new AvdManagerService();
+  // Tests often inject only the Android/device seam. Avoid creating a real simctl
+  // client in those partial fakes; production construction always includes it.
+  const simctl = deps?.simctl ?? (deps ? undefined : new SimCtlClient());
 
   const getDeviceImagesForPlatformsImpl = async (platforms: Platform[]): Promise<DeviceImagesResourceContent> => {
     const images: DeviceImageInfo[] = [];
-    let androidCount = 0;
-    let iosCount = 0;
+    const provisioningCatalog: ProvisioningCatalog = {
+      runtimes: [],
+      deviceTypes: [],
+      systemImages: [],
+      profiles: [],
+    };
+    const catalogObservations: Partial<Record<Platform, ProvisioningCatalogObservation>> = {};
+    const androidCount = platforms.includes("android")
+      ? await appendAndroidImages(deviceManager, avdManager, images)
+      : 0;
+    if (platforms.includes("android")) {
+      catalogObservations.android = await buildAndroidProvisioningCatalog(
+        avdManager,
+        provisioningCatalog
+      );
+    }
 
-    try {
-      // Fetch Android device images if requested
-      if (platforms.includes("android")) {
-        try {
-          const androidDevices = await deviceManager.listDeviceImages("android");
-          let avdInfoList: AvdInfo[] = [];
-
-          // Try to get extended AVD info
-          try {
-            avdInfoList = await avdManager.listDeviceImages();
-          } catch (error) {
-            logger.warn(`[DeviceImageResources] Failed to get extended AVD info: ${error}`);
-          }
-
-          // Create a map for quick lookup
-          const avdInfoMap = new Map<string, AvdInfo>();
-          for (const avd of avdInfoList) {
-            avdInfoMap.set(avd.name, avd);
-          }
-
-          // Merge device info with extended AVD info
-          for (const device of androidDevices) {
-            const avdInfo = avdInfoMap.get(device.name);
-            images.push(toDeviceImageInfo(device, avdInfo));
-            androidCount++;
-          }
-        } catch (error) {
-          logger.warn(`[DeviceImageResources] Failed to list Android device images: ${error}`);
-        }
-      }
-
-      // Fetch iOS simulator images if requested
-      if (platforms.includes("ios")) {
-        try {
-          const iosDevices = await deviceManager.listDeviceImages("ios");
-          for (const device of iosDevices) {
-            images.push(toDeviceImageInfo(device));
-            iosCount++;
-          }
-        } catch (error) {
-          logger.warn(`[DeviceImageResources] Failed to list iOS simulator images: ${error}`);
-        }
-      }
-    } catch (error) {
-      logger.error(`[DeviceImageResources] Error fetching device images: ${error}`);
+    const iosCount = platforms.includes("ios")
+      ? await appendIosImages(deviceManager, images)
+      : 0;
+    if (platforms.includes("ios")) {
+      catalogObservations.ios = await buildIosProvisioningCatalog(simctl, provisioningCatalog);
     }
 
     return {
@@ -121,6 +159,9 @@ export function createDeviceImageResourcesHandler(
       androidCount,
       iosCount,
       lastUpdated: new Date().toISOString(),
+      catalogComplete: platforms.every(platform => catalogObservations[platform]?.catalogComplete === true),
+      catalogObservations,
+      provisioningCatalog,
       images
     };
   };
@@ -161,6 +202,179 @@ export function createDeviceImageResourcesHandler(
     getDeviceImagesByPlatform: getDeviceImagesByPlatformImpl,
     getDeviceImagesForPlatforms: getDeviceImagesForPlatformsImpl
   };
+}
+
+async function appendAndroidImages(
+  deviceManager: PlatformDeviceManager,
+  avdManager: AvdManager,
+  images: DeviceImageInfo[]
+): Promise<number> {
+  try {
+    const [androidDevices, avdInfoList] = await Promise.all([
+      deviceManager.listDeviceImages("android"),
+      readAvdInfo(avdManager),
+    ]);
+    const avdInfoByName = new Map(avdInfoList.map(avd => [avd.name, avd]));
+    for (const device of androidDevices) {
+      images.push(toDeviceImageInfo(device, avdInfoByName.get(device.name)));
+    }
+    return androidDevices.length;
+  } catch (error) {
+    logger.warn(`[DeviceImageResources] Failed to list Android device images: ${error}`);
+    return 0;
+  }
+}
+
+async function readAvdInfo(avdManager: AvdManager): Promise<AvdInfo[]> {
+  try {
+    return await avdManager.listDeviceImages();
+  } catch (error) {
+    logger.warn(`[DeviceImageResources] Failed to get extended AVD info: ${error}`);
+    return [];
+  }
+}
+
+async function appendIosImages(
+  deviceManager: PlatformDeviceManager,
+  images: DeviceImageInfo[]
+): Promise<number> {
+  try {
+    const iosDevices = await deviceManager.listDeviceImages("ios");
+    for (const device of iosDevices) {
+      images.push(toDeviceImageInfo(device));
+    }
+    return iosDevices.length;
+  } catch (error) {
+    logger.warn(`[DeviceImageResources] Failed to list iOS simulator images: ${error}`);
+    return 0;
+  }
+}
+
+async function buildAndroidProvisioningCatalog(
+  avdManager: AvdManager,
+  catalog: ProvisioningCatalog
+): Promise<ProvisioningCatalogObservation> {
+  try {
+    const [systemImages, profiles] = await Promise.all([
+      avdManager.listSystemImages(),
+      avdManager.listDevices(),
+    ]);
+    appendAndroidProvisioningCatalog(catalog, systemImages, profiles);
+    return { catalogComplete: true };
+  } catch (error) {
+    logger.warn(`[DeviceImageResources] Failed to build Android provisioning catalog: ${error}`);
+    return failedCatalogObservation("Android", error);
+  }
+}
+
+async function buildIosProvisioningCatalog(
+  simctl: Pick<SimCtl, "getDeviceTypes" | "getRuntimes"> | undefined,
+  catalog: ProvisioningCatalog
+): Promise<ProvisioningCatalogObservation> {
+  if (!simctl) {
+    return {
+      catalogComplete: false,
+      error: {
+        code: "unavailable",
+        message: "iOS provisioning catalog is unavailable.",
+      },
+    };
+  }
+
+  try {
+    const [runtimes, deviceTypes] = await Promise.all([
+      simctl.getRuntimes(),
+      simctl.getDeviceTypes(),
+    ]);
+    appendIosProvisioningCatalog(catalog, runtimes, deviceTypes);
+    return { catalogComplete: true };
+  } catch (error) {
+    logger.warn(`[DeviceImageResources] Failed to build iOS provisioning catalog: ${error}`);
+    return failedCatalogObservation("iOS", error);
+  }
+}
+
+function failedCatalogObservation(
+  platform: "Android" | "iOS",
+  error: unknown
+): ProvisioningCatalogObservation {
+  return {
+    catalogComplete: false,
+    error: {
+      code: "failed",
+      message: `${platform} provisioning catalog failed: ${errorMessage(error)}`,
+    },
+  };
+}
+
+function appendAndroidProvisioningCatalog(
+  catalog: ProvisioningCatalog,
+  systemImages: SystemImage[],
+  profiles: DeviceProfile[]
+): void {
+  for (const image of systemImages) {
+    catalog.runtimes.push({
+      platform: "android",
+      id: image.packageName,
+      name: image.versionInfo,
+      version: String(image.apiLevel),
+      available: true,
+    });
+    catalog.systemImages.push({
+      platform: "android",
+      id: image.packageName,
+      name: image.versionInfo,
+      apiLevel: image.apiLevel,
+      tag: image.tag,
+      abi: image.abi,
+      version: String(image.apiLevel),
+    });
+  }
+
+  for (const profile of profiles) {
+    const name = profile.name ?? profile.id;
+    catalog.deviceTypes.push({
+      platform: "android",
+      id: profile.id,
+      name,
+      ...(profile.oem ? { family: profile.oem } : {}),
+    });
+    catalog.profiles.push({
+      platform: "android",
+      id: profile.id,
+      name,
+      ...(profile.oem ? { manufacturer: profile.oem } : {}),
+    });
+  }
+}
+
+function appendIosProvisioningCatalog(
+  catalog: ProvisioningCatalog,
+  runtimes: AppleDeviceRuntime[],
+  deviceTypes: AppleDeviceType[]
+): void {
+  for (const runtime of runtimes) {
+    catalog.runtimes.push({
+      platform: "ios",
+      id: runtime.identifier,
+      name: runtime.name,
+      version: runtime.version,
+      available: runtime.isAvailable,
+    });
+  }
+
+  for (const deviceType of deviceTypes) {
+    catalog.deviceTypes.push({
+      platform: "ios",
+      id: deviceType.identifier,
+      name: deviceType.name,
+      family: deviceType.productFamily,
+    });
+  }
+}
+
+function errorMessage(error: unknown): string {
+  return error instanceof Error ? error.message : String(error);
 }
 
 // Convert DeviceInfo to DeviceImageInfo, merging with AvdInfo for Android

--- a/src/server/networkResources.ts
+++ b/src/server/networkResources.ts
@@ -8,6 +8,7 @@ import {
 import { NetworkState } from "./NetworkState";
 import { BODY_TRUNCATION_LIMIT } from "../utils/truncateBodyText";
 import { computePercentile } from "../utils/percentile";
+import { queryParamsToRecord } from "./queryParamValidation";
 
 const NETWORK_RESOURCE_URIS = {
   REQUEST: "automobile:network/request/{requestId}",
@@ -30,12 +31,9 @@ const TRAFFIC_QUERY_KEYS = [
   "deviceId",
   "bucketSeconds",
 ] as const;
-type TrafficQueryKey = (typeof TRAFFIC_QUERY_KEYS)[number];
 
-function buildQueryTemplate(keys: readonly TrafficQueryKey[]): string {
-  const query = keys.map(key => `${key}={${key}}`).join("&");
-  return `${NETWORK_RESOURCE_URIS.TRAFFIC}?${query}`;
-}
+const TRAFFIC_QUERY_TEMPLATE = `${NETWORK_RESOURCE_URIS.TRAFFIC}?{params}`;
+const TRAFFIC_QUERY_PARAM_KEYS = new Set<string>(TRAFFIC_QUERY_KEYS);
 
 function eventToSummary(event: NetworkEventWithId) {
   return {
@@ -84,29 +82,30 @@ function eventToDetail(event: NetworkEventWithId) {
 }
 
 function parseTrafficParams(params: Record<string, string>) {
+  const unknownKeys = Object.keys(params).filter(key => !TRAFFIC_QUERY_PARAM_KEYS.has(key));
+  if (unknownKeys.length > 0) {
+    throw new Error(`Unknown query parameters: ${unknownKeys.join(", ")}`);
+  }
+
   const since = params.since
-    ? parseInt(decodeURIComponent(params.since), 10)
+    ? parseInt(params.since, 10)
     : undefined;
   const limitRaw = params.limit
-    ? parseInt(decodeURIComponent(params.limit), 10)
+    ? parseInt(params.limit, 10)
     : undefined;
   const limit = limitRaw ? Math.min(Math.max(1, limitRaw), 200) : 50;
   const bucketRaw = params.bucketSeconds
-    ? parseInt(decodeURIComponent(params.bucketSeconds), 10)
+    ? parseInt(params.bucketSeconds, 10)
     : undefined;
   const bucketSeconds = bucketRaw && Number.isFinite(bucketRaw) && bucketRaw > 0 ? bucketRaw : undefined;
 
   return {
-    host: params.host ? decodeURIComponent(params.host) : undefined,
-    method: params.method ? decodeURIComponent(params.method) : undefined,
-    statusCode: params.statusCode
-      ? decodeURIComponent(params.statusCode)
-      : undefined,
+    host: params.host,
+    method: params.method,
+    statusCode: params.statusCode,
     sinceTimestamp: since && Number.isFinite(since) ? since : undefined,
     limit,
-    deviceId: params.deviceId
-      ? decodeURIComponent(params.deviceId)
-      : undefined,
+    deviceId: params.deviceId,
     bucketSeconds,
   };
 }
@@ -255,22 +254,6 @@ async function handleTrafficQuery(
   }
 }
 
-function registerTrafficTemplates(): void {
-  const keyCount = TRAFFIC_QUERY_KEYS.length;
-  for (let mask = 1; mask < 1 << keyCount; mask += 1) {
-    const keys = TRAFFIC_QUERY_KEYS.filter(
-      (_, index) => (mask & (1 << index)) !== 0
-    );
-    ResourceRegistry.registerTemplate(
-      buildQueryTemplate(keys),
-      "Network Traffic",
-      "Query captured network traffic with optional filters.",
-      "application/json",
-      handleTrafficQuery
-    );
-  }
-}
-
 export function registerNetworkResources(): void {
   // Base traffic resource (no filters, returns latest 50)
   ResourceRegistry.register(
@@ -281,8 +264,13 @@ export function registerNetworkResources(): void {
     () => handleTrafficQuery({})
   );
 
-  // Traffic query templates
-  registerTrafficTemplates();
+  ResourceRegistry.registerTemplate(
+    TRAFFIC_QUERY_TEMPLATE,
+    "Network Traffic",
+    "Query captured network traffic with optional filters.",
+    "application/json",
+    async params => handleTrafficQuery(queryParamsToRecord(params.params ?? ""))
+  );
 
   // Single request detail by ID
   ResourceRegistry.registerTemplate(

--- a/src/server/performanceResources.ts
+++ b/src/server/performanceResources.ts
@@ -5,18 +5,15 @@ import {
   PERFORMANCE_RESULTS_LIMIT_MAX,
   type PerformanceAuditQueryArgs,
 } from "./performanceData";
+import { queryParamsToRecord } from "./queryParamValidation";
 
 const PERFORMANCE_RESOURCE_URIS = {
   BASE: "automobile:performance-results",
 } as const;
 
 const PERFORMANCE_QUERY_KEYS = ["startTime", "endTime", "limit", "offset", "deviceId"] as const;
-type PerformanceQueryKey = typeof PERFORMANCE_QUERY_KEYS[number];
-
-function buildQueryTemplate(keys: readonly PerformanceQueryKey[]): string {
-  const query = keys.map(key => `${key}={${key}}`).join("&");
-  return `${PERFORMANCE_RESOURCE_URIS.BASE}?${query}`;
-}
+const PERFORMANCE_QUERY_TEMPLATE = `${PERFORMANCE_RESOURCE_URIS.BASE}?{params}`;
+const PERFORMANCE_QUERY_PARAM_KEYS = new Set<string>(PERFORMANCE_QUERY_KEYS);
 
 function parseInteger(
   value: string | undefined,
@@ -49,30 +46,35 @@ function parseTimestampParam(value: string | undefined, label: string): string |
     return undefined;
   }
 
-  const decoded = decodeURIComponent(value).trim();
-  if (!decoded) {
+  const normalized = value.trim();
+  if (!normalized) {
     return undefined;
   }
 
-  if (/^-?\d+$/.test(decoded)) {
-    const parsed = Number(decoded);
+  if (/^-?\d+$/.test(normalized)) {
+    const parsed = Number(normalized);
     if (!Number.isFinite(parsed)) {
       throw new Error(`Invalid ${label}: ${value}`);
     }
     return parsed;
   }
 
-  return decoded;
+  return normalized;
 }
 
 function parsePerformanceParams(
   params: Record<string, string>
 ): Pick<PerformanceAuditQueryArgs, "startTime" | "endTime" | "limit" | "offset" | "deviceId"> {
+  const unknownKeys = Object.keys(params).filter(key => !PERFORMANCE_QUERY_PARAM_KEYS.has(key));
+  if (unknownKeys.length > 0) {
+    throw new Error(`Unknown query parameters: ${unknownKeys.join(", ")}`);
+  }
+
   const startTime = parseTimestampParam(params.startTime, "startTime");
   const endTime = parseTimestampParam(params.endTime, "endTime");
-  const limitRaw = params.limit ? decodeURIComponent(params.limit).trim() : undefined;
-  const offsetRaw = params.offset ? decodeURIComponent(params.offset).trim() : undefined;
-  const deviceIdRaw = params.deviceId ? decodeURIComponent(params.deviceId).trim() : undefined;
+  const limitRaw = params.limit?.trim();
+  const offsetRaw = params.offset?.trim();
+  const deviceIdRaw = params.deviceId?.trim();
 
   return {
     startTime,
@@ -128,22 +130,6 @@ async function getPerformanceResource(
   }
 }
 
-function registerPerformanceTemplates(
-  handler: (params: Record<string, string>) => Promise<ResourceContent>
-): void {
-  const keyCount = PERFORMANCE_QUERY_KEYS.length;
-  for (let mask = 1; mask < (1 << keyCount); mask += 1) {
-    const keys = PERFORMANCE_QUERY_KEYS.filter((_, index) => (mask & (1 << index)) !== 0);
-    ResourceRegistry.registerTemplate(
-      buildQueryTemplate(keys),
-      "Performance Results",
-      "List UI performance audit results from the local database.",
-      "application/json",
-      handler
-    );
-  }
-}
-
 export function registerPerformanceResources(): void {
   ResourceRegistry.register(
     PERFORMANCE_RESOURCE_URIS.BASE,
@@ -153,9 +139,15 @@ export function registerPerformanceResources(): void {
     () => getPerformanceResource({}, PERFORMANCE_RESOURCE_URIS.BASE)
   );
 
-  registerPerformanceTemplates(async params => {
+  ResourceRegistry.registerTemplate(
+    PERFORMANCE_QUERY_TEMPLATE,
+    "Performance Results",
+    "List UI performance audit results from the local database.",
+    "application/json",
+    async params => {
     try {
-      const options = parsePerformanceParams(params);
+      const queryParams = queryParamsToRecord(params.params ?? "");
+      const options = parsePerformanceParams(queryParams);
       const uri = buildPerformanceUri(options);
       return getPerformanceResource(options, uri);
     } catch (error) {

--- a/src/server/resourceRegistry.ts
+++ b/src/server/resourceRegistry.ts
@@ -56,14 +56,14 @@ function compileUriTemplate(template: string): {
     return `__PARAM_${paramNames.length - 1}__`;
   });
   const escapedTemplate = tokenizedTemplate.replace(/[-/\\^$*+?.()|[\]{}]/g, "\\$&");
-  // Use [^/&]+ so query-string params stop at the & delimiter; a trailing
-  // {path} param is greedy so it can capture nested slashes.
+  // Use [^/&]+ so regular query-string params stop at the & delimiter; trailing
+  // {path} and {params} params are greedy for nested paths and raw query strings.
   const regexPattern = escapedTemplate.replace(/__PARAM_(\d+)__/g, (_placeholder, indexText) => {
     const index = Number(indexText);
-    const isTrailingPathParam =
-      paramNames[index] === "path" &&
+    const isGreedyTrailingParam =
+      (paramNames[index] === "path" || paramNames[index] === "params") &&
       escapedTemplate.endsWith(`__PARAM_${index}__`);
-    return isTrailingPathParam ? "(.+)" : "([^/&]+)";
+    return isGreedyTrailingParam ? "(.+)" : "([^/&]+)";
   });
 
   return { regex: new RegExp(`^${regexPattern}$`), paramNames };

--- a/src/utils/deviceUtils.ts
+++ b/src/utils/deviceUtils.ts
@@ -11,6 +11,13 @@ import { defaultTimer, type Timer } from "./SystemTimer";
 
 export { DEFAULT_DEVICE_READY_TIMEOUT_MS } from "./deviceTimeouts";
 
+export type DeviceDiscoveryErrorCode = "unavailable" | "failed";
+
+export interface DeviceDiscoveryError {
+  code: DeviceDiscoveryErrorCode;
+  message: string;
+}
+
 /**
  * Result of a discovery sweep that distinguishes per-platform success.
  *
@@ -22,11 +29,17 @@ export { DEFAULT_DEVICE_READY_TIMEOUT_MS } from "./deviceTimeouts";
 export interface BootedDeviceDiscovery {
   devices: BootedDevice[];
   succeededPlatforms: Set<Platform>;
+  /** Platform-specific typed failures for incomplete observations. */
+  discoveryErrors?: Partial<Record<Platform, DeviceDiscoveryError>>;
 }
 
 export interface BootedDeviceDiscoveryOptions {
   /** Bypass Android's short device-list cache to verify ADB transport identity. */
   bypassAndroidDeviceListCache?: boolean;
+}
+
+function errorMessage(error: unknown): string {
+  return error instanceof Error ? error.message : String(error);
 }
 
 /** Bounds and cancels a platform shutdown command. */
@@ -309,6 +322,7 @@ export class MultiPlatformDeviceManager implements PlatformDeviceManager {
   ): Promise<BootedDeviceDiscovery> {
     const devices: BootedDevice[] = [];
     const succeededPlatforms = new Set<Platform>();
+    const discoveryErrors: Partial<Record<Platform, DeviceDiscoveryError>> = {};
 
     if (platform === "android" || platform === "either") {
       try {
@@ -321,6 +335,10 @@ export class MultiPlatformDeviceManager implements PlatformDeviceManager {
         logger.warn(
           `[DeviceManager] Android booted-device discovery failed; retaining tracked Android devices: ${error}`
         );
+        discoveryErrors.android = {
+          code: "failed",
+          message: `Android booted-device discovery failed: ${errorMessage(error)}`,
+        };
       }
     }
 
@@ -329,17 +347,30 @@ export class MultiPlatformDeviceManager implements PlatformDeviceManager {
       if (ios.succeeded) {
         devices.push(...ios.devices);
         succeededPlatforms.add("ios");
+      } else if (ios.error) {
+        discoveryErrors.ios = ios.error;
       }
     }
 
-    return { devices, succeededPlatforms };
+    return { devices, succeededPlatforms, discoveryErrors };
   }
 
-  private async discoverBootedIosDevices(): Promise<{ devices: BootedDevice[]; succeeded: boolean }> {
+  private async discoverBootedIosDevices(): Promise<{
+    devices: BootedDevice[];
+    succeeded: boolean;
+    error?: DeviceDiscoveryError;
+  }> {
     // iOS tooling that is genuinely unavailable on this host cannot confirm a
     // device is gone, so report it as un-discovered rather than empty.
     if (!(await this.canDiscoverIosLocally())) {
-      return { devices: [], succeeded: false };
+      return {
+        devices: [],
+        succeeded: false,
+        error: {
+          code: "unavailable",
+          message: "iOS booted-device discovery is unavailable.",
+        },
+      };
     }
     try {
       const devices = await this.simctl.getBootedSimulatorsChecked();
@@ -348,7 +379,14 @@ export class MultiPlatformDeviceManager implements PlatformDeviceManager {
       logger.warn(
         `[DeviceManager] iOS booted-device discovery failed; retaining tracked iOS devices: ${error}`
       );
-      return { devices: [], succeeded: false };
+      return {
+        devices: [],
+        succeeded: false,
+        error: {
+          code: "failed",
+          message: `iOS booted-device discovery failed: ${errorMessage(error)}`,
+        },
+      };
     }
   }
 

--- a/test/fakes/FakeDeviceManager.ts
+++ b/test/fakes/FakeDeviceManager.ts
@@ -43,14 +43,19 @@ export class FakeDeviceManager implements PlatformDeviceManager {
     const requested: Platform[] = platform === "either" ? ["android", "ios"] : [platform];
     const devices: BootedDevice[] = [];
     const succeededPlatforms = new Set<Platform>();
+    const discoveryErrors: BootedDeviceDiscovery["discoveryErrors"] = {};
     for (const p of requested) {
       if (this.failedPlatforms.has(p)) {
+        discoveryErrors[p] = {
+          code: "unavailable",
+          message: `${p === "ios" ? "iOS" : "Android"} booted-device discovery is unavailable.`,
+        };
         continue;
       }
       succeededPlatforms.add(p);
       devices.push(...this.bootedDevices.filter(device => device.platform === p));
     }
-    return { devices, succeededPlatforms };
+    return { devices, succeededPlatforms, discoveryErrors };
   }
 
   async startDevice(device: DeviceInfo, timeoutMs: number = DEFAULT_DEVICE_READY_TIMEOUT_MS): Promise<ChildProcess> {

--- a/test/fakes/FakeDeviceUtils.ts
+++ b/test/fakes/FakeDeviceUtils.ts
@@ -174,15 +174,20 @@ export class FakeDeviceUtils implements PlatformDeviceManager {
     const requested: Platform[] = platform === "either" ? ["android", "ios"] : [platform];
     const devices: BootedDevice[] = [];
     const succeededPlatforms = new Set<Platform>();
+    const discoveryErrors: BootedDeviceDiscovery["discoveryErrors"] = {};
     for (const p of requested) {
       if (this.failedPlatforms.has(p)) {
+        discoveryErrors[p] = {
+          code: "unavailable",
+          message: `${p === "ios" ? "iOS" : "Android"} booted-device discovery is unavailable.`,
+        };
         continue;
       }
       // Delegate to getBootedDevices so operation tracking stays consistent.
       devices.push(...(await this.getBootedDevices(p)));
       succeededPlatforms.add(p);
     }
-    return { devices, succeededPlatforms };
+    return { devices, succeededPlatforms, discoveryErrors };
   }
 
   async startDevice(device: DeviceInfo, timeoutMs?: number): Promise<ChildProcess | null> {

--- a/test/fakes/FakeSimCtlClient.ts
+++ b/test/fakes/FakeSimCtlClient.ts
@@ -30,6 +30,7 @@ type FakeSimCtlClientContract = Pick<
 export class FakeSimCtlClient implements FakeSimCtlClientContract {
   private deviceInfo = new Map<string, AppleDevice | null>();
   private runtimes: AppleDeviceRuntime[] = [];
+  private deviceTypes: AppleDeviceType[] = [];
   private installedApps: any[] = [];
   private containerPaths = new Map<string, string>();
   private containerErrors = new Map<string, Error>();
@@ -50,6 +51,10 @@ export class FakeSimCtlClient implements FakeSimCtlClientContract {
 
   setRuntimes(runtimes: AppleDeviceRuntime[]): void {
     this.runtimes = runtimes;
+  }
+
+  setDeviceTypes(deviceTypes: AppleDeviceType[]): void {
+    this.deviceTypes = deviceTypes;
   }
 
   setInstalledApps(apps: any[]): void {
@@ -178,7 +183,7 @@ export class FakeSimCtlClient implements FakeSimCtlClientContract {
 
   async getDeviceTypes(): Promise<AppleDeviceType[]> {
     this.recordCall("getDeviceTypes", {});
-    return [];
+    return this.deviceTypes;
   }
 
   async getRuntimes(): Promise<AppleDeviceRuntime[]> {

--- a/test/server/networkResources.test.ts
+++ b/test/server/networkResources.test.ts
@@ -1,6 +1,8 @@
-import { describe, it, expect } from "bun:test";
+import { afterEach, describe, it, expect } from "bun:test";
 import { aggregateStatsByHost, bucketEvents } from "../../src/server/networkResources";
+import { registerNetworkResources } from "../../src/server/networkResources";
 import type { NetworkEventWithId } from "../../src/db/networkEventRepository";
+import { ResourceRegistry } from "../../src/server/resourceRegistry";
 
 function makeEvent(overrides: Partial<NetworkEventWithId> = {}): NetworkEventWithId {
   return {
@@ -156,5 +158,22 @@ describe("aggregateStatsByHost", () => {
     expect(Object.keys(stats).sort()).toEqual(["api.example.com", "constructor"]);
     expect(stats["constructor"].errors).toBe(0);
     expect(stats["api.example.com"].errors).toBe(1);
+  });
+});
+
+describe("network resource registration", () => {
+  afterEach(() => {
+    ResourceRegistry.clearResources();
+  });
+
+  it("registers one raw query template for traffic filters", () => {
+    registerNetworkResources();
+
+    const templates = ResourceRegistry.getAllTemplates()
+      .filter(template => template.uriTemplate.startsWith("automobile:network/traffic?"));
+
+    expect(templates.map(template => template.uriTemplate)).toEqual([
+      "automobile:network/traffic?{params}"
+    ]);
   });
 });

--- a/test/server/performanceResources.test.ts
+++ b/test/server/performanceResources.test.ts
@@ -120,14 +120,16 @@ describe("performanceData", () => {
       ResourceRegistry.clearResources();
     });
 
-    test("registers the base URI and query-param templates", () => {
+    test("registers the base URI and one raw query-param template", () => {
       registerPerformanceResources();
 
       expect(ResourceRegistry.getResource("automobile:performance-results")).toBeDefined();
 
       const templates = ResourceRegistry.getAllTemplates();
       const queryTemplates = templates.filter(t => t.uriTemplate.startsWith("automobile:performance-results?"));
-      expect(queryTemplates.length).toBeGreaterThan(0);
+      expect(queryTemplates.map(template => template.uriTemplate)).toEqual([
+        "automobile:performance-results?{params}"
+      ]);
     });
   });
 });

--- a/test/server/resourceRegistryListChanged.test.ts
+++ b/test/server/resourceRegistryListChanged.test.ts
@@ -117,3 +117,23 @@ describe("ResourceRegistry list-changed fan-out (issue #3223)", () => {
     }
   });
 });
+
+describe("ResourceRegistry URI-template matching", () => {
+  beforeEach(() => {
+    ResourceRegistry.clearResources();
+  });
+
+  test("captures a raw query-string template with multiple query parameters", () => {
+    ResourceRegistry.registerTemplate(
+      "automobile:test?{params}",
+      "Test",
+      "Test raw query template",
+      "application/json",
+      async () => ({ uri: "automobile:test", text: "{}" })
+    );
+
+    expect(ResourceRegistry.matchTemplate("automobile:test?first=one&second=two")).toMatchObject({
+      params: { params: "first=one&second=two" }
+    });
+  });
+});

--- a/test/server/resources/bootedDevices.test.ts
+++ b/test/server/resources/bootedDevices.test.ts
@@ -165,6 +165,20 @@ describe("MCP Booted Device Resources", () => {
       expect(data.physicalCount).toBe(0);
       expect(data.devices).toHaveLength(3);
       expect(data.poolStatus).toBeUndefined();
+      expect(data.observationComplete).toBe(true);
+      expect(data.platformObservations).toEqual({
+        android: { observationComplete: true },
+        ios: { observationComplete: true }
+      });
+      expect(data.devices[0]).toMatchObject({
+        identity: {
+          stableId: "Pixel_7_API_34",
+          connectionId: "emulator-5554"
+        },
+        lifecycleState: "booted",
+        readiness: { state: "unknown" },
+        capabilities: { automation: null }
+      });
 
       // Verify lastUpdated is a valid ISO 8601 date
       expect(() => new Date(data.lastUpdated)).not.toThrow();
@@ -603,6 +617,17 @@ describe("MCP Booted Device Resources", () => {
       const data: BootedDevicesResourceContent = JSON.parse(result.contents[0].text!);
       // The Android phantom is dropped (android discovery succeeded, empty), but
       // the still-tracked iOS device is preserved because iOS discovery failed.
+      expect(data.observationComplete).toBe(false);
+      expect(data.platformObservations).toEqual({
+        android: { observationComplete: true },
+        ios: {
+          observationComplete: false,
+          discoveryError: {
+            code: "unavailable",
+            message: "iOS booted-device discovery is unavailable."
+          }
+        }
+      });
       expect(data.poolStatus).toEqual({
         enabled: true,
         idle: 0,

--- a/test/server/resources/bootedDevices.test.ts
+++ b/test/server/resources/bootedDevices.test.ts
@@ -20,6 +20,7 @@ describe("MCP Booted Device Resources", () => {
     name: "Pixel_7_API_34",
     platform: "android",
     deviceId: "emulator-5554",
+    transportId: "1",
     source: "local"
   };
 
@@ -173,11 +174,18 @@ describe("MCP Booted Device Resources", () => {
       expect(data.devices[0]).toMatchObject({
         identity: {
           stableId: "Pixel_7_API_34",
-          connectionId: "emulator-5554"
+          connectionId: "1",
+          transportId: "1",
         },
         lifecycleState: "booted",
         readiness: { state: "unknown" },
         capabilities: { automation: null }
+      });
+      expect(data.devices[2]).toMatchObject({
+        identity: {
+          stableId: "A1B2C3D4-E5F6-7890-ABCD-EF1234567890",
+          connectionId: "A1B2C3D4-E5F6-7890-ABCD-EF1234567890",
+        },
       });
 
       // Verify lastUpdated is a valid ISO 8601 date

--- a/test/server/resources/deviceImages.test.ts
+++ b/test/server/resources/deviceImages.test.ts
@@ -1,23 +1,117 @@
 import { beforeEach, describe, expect, test } from "bun:test";
 import { FakeDeviceUtils } from "../../fakes/FakeDeviceUtils";
 import { FakeAvdManager } from "../../fakes/FakeAvdManager";
+import { FakeSimCtlClient } from "../../fakes/FakeSimCtlClient";
 import {
   createDeviceImageResourcesHandler,
   DeviceImagesResourceContent
 } from "../../../src/server/deviceImageResources";
 import { DeviceInfo } from "../../../src/models";
 import { AvdInfo } from "../../../src/utils/android-cmdline-tools/avdmanager";
+import type {
+  AppleDeviceRuntime,
+  AppleDeviceType,
+} from "../../../src/utils/ios-cmdline-tools/SimCtlClient";
 
 describe("Device Image Resources with Fakes", () => {
   let fakeDeviceUtils: FakeDeviceUtils;
   let fakeAvdManager: FakeAvdManager;
+  let fakeSimCtl: FakeSimCtlClient;
 
   beforeEach(() => {
     fakeDeviceUtils = new FakeDeviceUtils();
     fakeAvdManager = new FakeAvdManager();
+    fakeSimCtl = new FakeSimCtlClient();
   });
 
   describe("createDeviceImageResourcesHandler", () => {
+    test("returns a normalized provisioning catalog for Android and iOS", async () => {
+      fakeDeviceUtils.setDeviceImages("android", []);
+      fakeDeviceUtils.setDeviceImages("ios", []);
+      fakeAvdManager.setListSystemImagesResponse([{
+        packageName: "system-images;android-35;google_apis;x86_64",
+        apiLevel: 35,
+        tag: "google_apis",
+        abi: "x86_64",
+        versionInfo: "Google APIs Intel x86_64 Atom System Image",
+      }]);
+      fakeAvdManager.setListDevicesResponse([{
+        id: "pixel_9",
+        name: "Pixel 9",
+        oem: "Google",
+      }]);
+      const runtimes: AppleDeviceRuntime[] = [{
+        bundlePath: "/Library/Developer/CoreSimulator/Profiles/Runtimes/iOS 18.0.simruntime",
+        buildversion: "22A3354",
+        runtimeRoot: "/Library/Developer/CoreSimulator/Volumes/iOS_22A3354/Library/Developer/CoreSimulator/Profiles/Runtimes/iOS 18.0.simruntime/Contents/Resources/RuntimeRoot",
+        identifier: "com.apple.CoreSimulator.SimRuntime.iOS-18-0",
+        version: "18.0",
+        isAvailable: true,
+        name: "iOS 18.0",
+      }];
+      const deviceTypes: AppleDeviceType[] = [{
+        minRuntimeVersion: 17,
+        bundlePath: "/Library/Developer/CoreSimulator/Profiles/DeviceTypes/iPhone 16.simdevicetype",
+        maxRuntimeVersion: 18,
+        name: "iPhone 16",
+        identifier: "com.apple.CoreSimulator.SimDeviceType.iPhone-16",
+        productFamily: "iPhone",
+      }];
+      fakeSimCtl.setRuntimes(runtimes);
+      fakeSimCtl.setDeviceTypes(deviceTypes);
+
+      const handler = createDeviceImageResourcesHandler({
+        deviceManager: fakeDeviceUtils,
+        avdManager: fakeAvdManager,
+        simctl: fakeSimCtl,
+      });
+
+      const result = await handler.getDeviceImagesForPlatforms(["android", "ios"]);
+
+      expect(result.catalogComplete).toBe(true);
+      expect(result.provisioningCatalog).toEqual({
+        runtimes: expect.arrayContaining([
+          expect.objectContaining({
+            platform: "android",
+            id: "system-images;android-35;google_apis;x86_64",
+            version: "35",
+          }),
+          expect.objectContaining({
+            platform: "ios",
+            id: "com.apple.CoreSimulator.SimRuntime.iOS-18-0",
+            version: "18.0",
+          }),
+        ]),
+        deviceTypes: expect.arrayContaining([
+          expect.objectContaining({
+            platform: "android",
+            id: "pixel_9",
+            name: "Pixel 9",
+          }),
+          expect.objectContaining({
+            platform: "ios",
+            id: "com.apple.CoreSimulator.SimDeviceType.iPhone-16",
+            name: "iPhone 16",
+          }),
+        ]),
+        systemImages: [{
+          platform: "android",
+          id: "system-images;android-35;google_apis;x86_64",
+          name: "Google APIs Intel x86_64 Atom System Image",
+          apiLevel: 35,
+          tag: "google_apis",
+          abi: "x86_64",
+          version: "35",
+        }],
+        profiles: [{
+          platform: "android",
+          id: "pixel_9",
+          name: "Pixel 9",
+          manufacturer: "Google",
+        }],
+      });
+    });
+
     test("should return correct image counts when there are images", async () => {
       // Set up mock Android devices
       const androidDevices: DeviceInfo[] = [


### PR DESCRIPTION
## Summary

Implements [issue #5436](https://github.com/kaeawc/auto-mobile/issues/5436) by extending the existing read-only device resources rather than adding a competing inventory tool.

Closes [#5436](https://github.com/kaeawc/auto-mobile/issues/5436).

- Add completeness signals, typed platform discovery errors, stable and transient identity, lifecycle, runtime, form factor, readiness, and automation capability data to `automobile:devices/booted`.
- Add a normalized provisioning catalog of Android/iOS runtimes and device types plus Android system images and profiles to `automobile:devices/images`.
- Replace combinatorial query resource templates for apps, network traffic, and performance results with validated raw-query templates.

The resource-template change reduces the advertised context baseline by 9,911 tokens overall, including a 10,178-token reduction for resource templates.

## Validation

- `bun run turbo:validate`
- `bun run typecheck`
- `bun run benchmark-context`
