### PR TITLE
fix: harden Android device recovery identity

### DIFF
--- a/src/daemon/daemon.ts
+++ b/src/daemon/daemon.ts
@@ -1388,6 +1388,7 @@ export class Daemon {
     const deviceManager = new MultiPlatformDeviceManager();
 
     this.deviceDisconnectMonitor = new SingleFlightInterval(this.timer, DEVICE_DISCONNECT_POLL_INTERVAL_MS, async () => {
+      let adbServerResetCohort: readonly PooledDevice[] = [];
       try {
         if (serverConfig.isPlanExecutionActive()) {
           logger.debug("[DisconnectMonitor] Skipping — plan execution active");
@@ -1452,7 +1453,7 @@ export class Daemon {
           this.forceDisconnectedDeviceIds,
           this.devicePool.getAllDevices(),
         );
-        const adbServerResetCohort = detectedAdbServerResetCohort.length > 0
+        adbServerResetCohort = detectedAdbServerResetCohort.length > 0
           ? await this.devicePool.detachAdbServerResetCohort(detectedAdbServerResetCohort)
           : [];
         const processWideAdbServerReset = adbServerResetCohort.length > 0;
@@ -1596,6 +1597,8 @@ export class Daemon {
         }
       } catch (error) {
         logger.warn(`[Daemon] Device disconnect monitor failed: ${error}`);
+      } finally {
+        await this.devicePool.releaseAdbServerResetCohortReservations(adbServerResetCohort);
       }
     });
     this.deviceDisconnectMonitor.start();
@@ -1628,9 +1631,18 @@ export class Daemon {
     const recovered = await this.devicePool
       .recoverSessionBoundAndroidDeviceAfterAdbServerReset(deviceId, pooledDevice);
     if (!recovered) {
+      this.retireAdbServerResetDisconnectState(deviceId, forceGenerationAtDisconnect);
       return false;
     }
 
+    this.retireAdbServerResetDisconnectState(deviceId, forceGenerationAtDisconnect);
+    return true;
+  }
+
+  private retireAdbServerResetDisconnectState(
+    deviceId: string,
+    forceGenerationAtDisconnect: number | undefined,
+  ): void {
     this.socketServer?.evictDeviceInputCache(deviceId);
     this.deviceDisconnectMisses.delete(deviceId);
     this.deviceDisconnectMissIncarnations.delete(deviceId);
@@ -1639,7 +1651,6 @@ export class Daemon {
       this.forceDisconnectedDeviceIds.delete(deviceId);
       this.forceDisconnectedDeviceGenerations.delete(deviceId);
     }
-    return true;
   }
 
   private async stopRecordingAfterDeviceDisconnect(recordingId: string, deviceId: string): Promise<boolean> {

--- a/src/daemon/daemon.ts
+++ b/src/daemon/daemon.ts
@@ -141,22 +141,37 @@ type DeviceSessionRoutingTargets = {
   telemetryPush: ReturnType<typeof getTelemetryPushServer>;
 };
 
-export function isProcessWideAdbServerReset(
+export function getProcessWideAdbServerResetCohort(
   bootedDeviceIds: ReadonlySet<string>,
   succeededPlatforms: ReadonlySet<Platform>,
   pooledDevices: readonly PooledDevice[],
-): boolean {
+): readonly PooledDevice[] {
   const ownedAndroidEmulators = pooledDevices.filter(device =>
     device.platform === "android" &&
     device.avdName !== undefined &&
     device.androidImage !== undefined &&
     device.id.startsWith("emulator-"),
   );
-  return (
-    succeededPlatforms.has("android") &&
-    ownedAndroidEmulators.length > 0 &&
-    ownedAndroidEmulators.every(device => !bootedDeviceIds.has(device.id))
-  );
+  if (
+    !succeededPlatforms.has("android") ||
+    ownedAndroidEmulators.length === 0 ||
+    !ownedAndroidEmulators.every(device => !bootedDeviceIds.has(device.id))
+  ) {
+    return [];
+  }
+  return ownedAndroidEmulators;
+}
+
+export function isProcessWideAdbServerReset(
+  bootedDeviceIds: ReadonlySet<string>,
+  succeededPlatforms: ReadonlySet<Platform>,
+  pooledDevices: readonly PooledDevice[],
+): boolean {
+  return getProcessWideAdbServerResetCohort(
+    bootedDeviceIds,
+    succeededPlatforms,
+    pooledDevices,
+  ).length > 0;
 }
 
 /**
@@ -1427,16 +1442,20 @@ export class Daemon {
         for (const deviceId of disconnectResult.disconnected) {
           missingByDevice.set(deviceId, []);
         }
-        const processWideAdbServerReset = isProcessWideAdbServerReset(
+        const adbServerResetCohort = getProcessWideAdbServerResetCohort(
           bootedDeviceIds,
           succeededPlatforms,
           this.devicePool.getAllDevices(),
         );
+        const processWideAdbServerReset = adbServerResetCohort.length > 0;
         if (processWideAdbServerReset) {
           logger.warn(
             "[DisconnectMonitor] All AutoMobile-owned Android emulators disappeared together; " +
               "treating this as an ADB server reset and recovering by AVD name",
           );
+          for (const device of adbServerResetCohort) {
+            missingByDevice.set(device.id, []);
+          }
         }
 
         for (const recording of activeRecordings) {

--- a/src/daemon/daemon.ts
+++ b/src/daemon/daemon.ts
@@ -1505,7 +1505,7 @@ export class Daemon {
           }
 
           if (processWideAdbServerReset && pooledDeviceAtDisconnect) {
-            if (await this.recoverProcessWideAdbServerResetDevice(
+            if (await this.tryRecoverProcessWideAdbServerResetDevice(
               deviceId,
               pooledDeviceAtDisconnect,
               forceGenerationAtDisconnect,
@@ -1592,6 +1592,25 @@ export class Daemon {
       }
     });
     this.deviceDisconnectMonitor.start();
+  }
+
+  private async tryRecoverProcessWideAdbServerResetDevice(
+    deviceId: string,
+    pooledDevice: PooledDevice,
+    forceGenerationAtDisconnect: number | undefined,
+  ): Promise<boolean> {
+    try {
+      return await this.recoverProcessWideAdbServerResetDevice(
+        deviceId,
+        pooledDevice,
+        forceGenerationAtDisconnect,
+      );
+    } catch (error) {
+      logger.warn(
+        `[DisconnectMonitor] ADB-reset recovery failed for ${deviceId}; continuing cohort cleanup: ${error}`,
+      );
+      return false;
+    }
   }
 
   private async recoverProcessWideAdbServerResetDevice(

--- a/src/daemon/daemon.ts
+++ b/src/daemon/daemon.ts
@@ -344,6 +344,7 @@ export class Daemon {
       recoveryConfiguration.policy,
       deviceId => this.deviceSessionRegistry.onDeviceDisconnected(deviceId),
       new EmulatorLossIncidentRepository(this.timer, this.idGenerator),
+      (sessionId, reason) => executionTracker.cancelDeviceSessionExecutions(sessionId, reason),
     );
     // Initialize singleton for daemon state access
     DaemonState.getInstance().initialize(

--- a/src/daemon/daemon.ts
+++ b/src/daemon/daemon.ts
@@ -144,6 +144,7 @@ type DeviceSessionRoutingTargets = {
 export function getProcessWideAdbServerResetCohort(
   bootedDeviceIds: ReadonlySet<string>,
   succeededPlatforms: ReadonlySet<Platform>,
+  forceDisconnectedDeviceIds: ReadonlySet<string>,
   pooledDevices: readonly PooledDevice[],
 ): readonly PooledDevice[] {
   const ownedAndroidEmulators = pooledDevices.filter(device =>
@@ -154,8 +155,9 @@ export function getProcessWideAdbServerResetCohort(
   );
   if (
     !succeededPlatforms.has("android") ||
-    ownedAndroidEmulators.length === 0 ||
-    !ownedAndroidEmulators.every(device => !bootedDeviceIds.has(device.id))
+    ownedAndroidEmulators.length < 2 ||
+    !ownedAndroidEmulators.every(device => !bootedDeviceIds.has(device.id)) ||
+    !ownedAndroidEmulators.some(device => forceDisconnectedDeviceIds.has(device.id))
   ) {
     return [];
   }
@@ -165,11 +167,13 @@ export function getProcessWideAdbServerResetCohort(
 export function isProcessWideAdbServerReset(
   bootedDeviceIds: ReadonlySet<string>,
   succeededPlatforms: ReadonlySet<Platform>,
+  forceDisconnectedDeviceIds: ReadonlySet<string>,
   pooledDevices: readonly PooledDevice[],
 ): boolean {
   return getProcessWideAdbServerResetCohort(
     bootedDeviceIds,
     succeededPlatforms,
+    forceDisconnectedDeviceIds,
     pooledDevices,
   ).length > 0;
 }
@@ -1445,6 +1449,7 @@ export class Daemon {
         const adbServerResetCohort = getProcessWideAdbServerResetCohort(
           bootedDeviceIds,
           succeededPlatforms,
+          this.forceDisconnectedDeviceIds,
           this.devicePool.getAllDevices(),
         );
         const processWideAdbServerReset = adbServerResetCohort.length > 0;

--- a/src/daemon/daemon.ts
+++ b/src/daemon/daemon.ts
@@ -1446,13 +1446,19 @@ export class Daemon {
         for (const deviceId of disconnectResult.disconnected) {
           missingByDevice.set(deviceId, []);
         }
-        const adbServerResetCohort = getProcessWideAdbServerResetCohort(
+        const detectedAdbServerResetCohort = getProcessWideAdbServerResetCohort(
           bootedDeviceIds,
           succeededPlatforms,
           this.forceDisconnectedDeviceIds,
           this.devicePool.getAllDevices(),
         );
+        const adbServerResetCohort = detectedAdbServerResetCohort.length > 0
+          ? await this.devicePool.detachAdbServerResetCohort(detectedAdbServerResetCohort)
+          : [];
         const processWideAdbServerReset = adbServerResetCohort.length > 0;
+        const adbServerResetCohortByDeviceId = new Map(
+          adbServerResetCohort.map(device => [device.id, device]),
+        );
         if (processWideAdbServerReset) {
           logger.warn(
             "[DisconnectMonitor] All AutoMobile-owned Android emulators disappeared together; " +
@@ -1504,10 +1510,11 @@ export class Daemon {
             continue;
           }
 
-          if (processWideAdbServerReset && pooledDeviceAtDisconnect) {
+          const adbServerResetTarget = adbServerResetCohortByDeviceId.get(deviceId);
+          if (adbServerResetTarget) {
             if (await this.tryRecoverProcessWideAdbServerResetDevice(
               deviceId,
-              pooledDeviceAtDisconnect,
+              adbServerResetTarget,
               forceGenerationAtDisconnect,
             )) {
               continue;

--- a/src/daemon/daemon.ts
+++ b/src/daemon/daemon.ts
@@ -1453,9 +1453,16 @@ export class Daemon {
           this.forceDisconnectedDeviceIds,
           this.devicePool.getAllDevices(),
         );
-        adbServerResetCohort = detectedAdbServerResetCohort.length > 0
+        const adbServerResetDetachment = detectedAdbServerResetCohort.length > 0
           ? await this.devicePool.detachAdbServerResetCohort(detectedAdbServerResetCohort)
-          : [];
+          : { devices: [], deferred: false };
+        if (adbServerResetDetachment.deferred) {
+          logger.info(
+            "[DisconnectMonitor] Deferring process-wide ADB reset recovery until matching Android startup completes",
+          );
+          return;
+        }
+        adbServerResetCohort = adbServerResetDetachment.devices;
         const processWideAdbServerReset = adbServerResetCohort.length > 0;
         const adbServerResetCohortByDeviceId = new Map(
           adbServerResetCohort.map(device => [device.id, device]),

--- a/src/daemon/daemon.ts
+++ b/src/daemon/daemon.ts
@@ -1485,7 +1485,8 @@ export class Daemon {
             ? this.sessionManager.getSession(sessionIdAtDisconnect)
             : null;
           const forceGenerationAtDisconnect = this.forceDisconnectedDeviceGenerations.get(deviceId);
-          if (await this.shouldSkipStaleDisconnectCleanup(
+          const adbServerResetTarget = adbServerResetCohortByDeviceId.get(deviceId);
+          if (!adbServerResetTarget && await this.shouldSkipStaleDisconnectCleanup(
             pooledDeviceAtDisconnect,
             deviceId,
             forceGenerationAtDisconnect,
@@ -1503,7 +1504,7 @@ export class Daemon {
             }
           }
 
-          if (await this.shouldSkipStaleDisconnectCleanup(
+          if (!adbServerResetTarget && await this.shouldSkipStaleDisconnectCleanup(
             pooledDeviceAtDisconnect,
             deviceId,
             forceGenerationAtDisconnect,
@@ -1511,7 +1512,6 @@ export class Daemon {
             continue;
           }
 
-          const adbServerResetTarget = adbServerResetCohortByDeviceId.get(deviceId);
           if (adbServerResetTarget) {
             if (await this.tryRecoverProcessWideAdbServerResetDevice(
               deviceId,

--- a/src/daemon/daemon.ts
+++ b/src/daemon/daemon.ts
@@ -98,7 +98,7 @@ import {
   setFatalProcessHandler,
   setProcessShutdownHandler,
 } from "../processLifecycle";
-import type { BootedDevice } from "../models";
+import type { BootedDevice, Platform } from "../models";
 import {
   DAEMON_LAUNCH_CWD_ENV,
   safeProcessCwd,
@@ -142,7 +142,8 @@ type DeviceSessionRoutingTargets = {
 };
 
 export function isProcessWideAdbServerReset(
-  disconnectedDeviceIds: ReadonlySet<string>,
+  bootedDeviceIds: ReadonlySet<string>,
+  succeededPlatforms: ReadonlySet<Platform>,
   pooledDevices: readonly PooledDevice[],
 ): boolean {
   const ownedAndroidEmulators = pooledDevices.filter(device =>
@@ -152,8 +153,9 @@ export function isProcessWideAdbServerReset(
     device.id.startsWith("emulator-"),
   );
   return (
+    succeededPlatforms.has("android") &&
     ownedAndroidEmulators.length > 0 &&
-    ownedAndroidEmulators.every(device => disconnectedDeviceIds.has(device.id))
+    ownedAndroidEmulators.every(device => !bootedDeviceIds.has(device.id))
   );
 }
 
@@ -1426,7 +1428,8 @@ export class Daemon {
           missingByDevice.set(deviceId, []);
         }
         const processWideAdbServerReset = isProcessWideAdbServerReset(
-          new Set(disconnectResult.disconnected),
+          bootedDeviceIds,
+          succeededPlatforms,
           this.devicePool.getAllDevices(),
         );
         if (processWideAdbServerReset) {

--- a/src/daemon/devicePool.ts
+++ b/src/daemon/devicePool.ts
@@ -153,6 +153,12 @@ interface ReadinessReservationTarget {
   incarnation: number;
 }
 
+interface AdbServerResetRecoveryReservation {
+  image: DeviceInfo;
+  settled: Promise<void>;
+  resolve(): void;
+}
+
 export interface SystemUiAnrRecoveryHandoff {
   readonly preservedSessionId?: string;
   readonly replacementDevice: PooledDevice;
@@ -274,6 +280,13 @@ export class DevicePool {
   private readonly androidDeviceReboot: AndroidDeviceReboot;
   private readonly recoveryPolicy: DeviceRecoveryPolicy;
   private readonly recoveringAndroidImages: Map<string, DeviceInfo> = new Map();
+  /**
+   * A reset cohort is reserved before its first member is restarted. This keeps
+   * a concurrent named getAndroid call from booting a later cohort member while
+   * its detached AVD/session relationship is still being restored.
+   */
+  private readonly adbServerResetRecoveryReservations:
+    Map<string, AdbServerResetRecoveryReservation> = new Map();
   private readonly recoveringAndroidDeviceIds: Set<string> = new Set();
   private readonly startedDeviceProcesses: Map<string, ChildProcess> = new Map();
   private readonly startedDeviceProcessOutput: Map<string, EmulatorProcessOutputTail> = new Map();
@@ -1629,20 +1642,33 @@ export class DevicePool {
     return (
       this.suppressedAutoStartDeviceImageKeys.has(this.criteriaMatcher.getDeviceImageKey(image)) ||
       this.suppressedAutoStartDeviceImageKeys.has(`${image.platform}:${image.name}`) ||
-      (image.platform === "android" && this.recoveringAndroidImages.has(image.name))
+      (image.platform === "android" && (
+        this.recoveringAndroidImages.has(image.name) ||
+        this.adbServerResetRecoveryReservations.has(image.name)
+      ))
     );
   }
 
   private hasPendingAndroidRecovery(platform?: Platform): boolean {
     return (
-      (platform === undefined || platform === "android") && this.recoveringAndroidImages.size > 0
+      (platform === undefined || platform === "android") &&
+      (
+        this.recoveringAndroidImages.size > 0 ||
+        this.adbServerResetRecoveryReservations.size > 0
+      )
     );
   }
 
   private hasPendingAndroidRecoveryMatching(criteria?: DeviceAllocationCriteria): boolean {
-    return this.criteriaMatcher.someDeviceImageMatchesCriteria(
-      this.recoveringAndroidImages.values(),
-      criteria,
+    return (
+      this.criteriaMatcher.someDeviceImageMatchesCriteria(
+        this.recoveringAndroidImages.values(),
+        criteria,
+      ) ||
+      this.criteriaMatcher.someDeviceImageMatchesCriteria(
+        Array.from(this.adbServerResetRecoveryReservations.values(), reservation => reservation.image),
+        criteria,
+      )
     );
   }
 
@@ -1922,25 +1948,81 @@ export class DevicePool {
       for (const device of cohort) {
         if (
           this.devices.get(device.id) !== device ||
-          !device.sessionId ||
           !this.isAutoMobileOwnedAndroidVirtualDevice(device)
         ) {
           continue;
         }
-        const session = this.sessionManager.getSession(device.sessionId);
-        if (
-          !session ||
-          session.assignedDevice !== device.id ||
-          session.platform !== "android"
-        ) {
-          continue;
+        if (device.sessionId) {
+          const session = this.sessionManager.getSession(device.sessionId);
+          if (
+            !session ||
+            session.assignedDevice !== device.id ||
+            session.platform !== "android"
+          ) {
+            continue;
+          }
         }
+        this.reserveAdbServerResetRecovery(device);
         device.sessionId = null;
         device.status = "idle";
         await this.removeDevice(device.id, false, device);
         detached.push(device);
       }
       return detached;
+    });
+  }
+
+  /**
+   * Wait for a cohort-level reservation created before ADB-reset recovery
+   * starts. Named startup uses this so it cannot race a later cohort member.
+   */
+  async waitForAdbServerResetRecovery(avdName: string, signal?: AbortSignal): Promise<void> {
+    const reservation = this.adbServerResetRecoveryReservations.get(avdName);
+    if (!reservation) {
+      return;
+    }
+    await runWithAbortSignal(signal, async () => await reservation.settled);
+  }
+
+  async releaseAdbServerResetCohortReservations(
+    cohort: readonly PooledDevice[],
+  ): Promise<void> {
+    await this.assignmentMutex.runExclusive(() => {
+      for (const device of cohort) {
+        if (!device.avdName) {
+          continue;
+        }
+        const reservation = this.adbServerResetRecoveryReservations.get(device.avdName);
+        if (!reservation) {
+          continue;
+        }
+        this.adbServerResetRecoveryReservations.delete(device.avdName);
+        reservation.resolve();
+      }
+    });
+  }
+
+  private reserveAdbServerResetRecovery(device: PooledDevice): void {
+    if (!device.avdName || !device.androidImage) {
+      return;
+    }
+    if (this.adbServerResetRecoveryReservations.has(device.avdName)) {
+      return;
+    }
+    let resolve!: () => void;
+    const settled = new Promise<void>(resolvePromise => {
+      resolve = resolvePromise;
+    });
+    this.adbServerResetRecoveryReservations.set(device.avdName, {
+      image: {
+        ...device.androidImage,
+        name: device.avdName,
+        platform: "android",
+        isRunning: false,
+        source: "local",
+      },
+      settled,
+      resolve,
     });
   }
 

--- a/src/daemon/devicePool.ts
+++ b/src/daemon/devicePool.ts
@@ -148,6 +148,10 @@ interface DeviceRemovedListener {
   (deviceId: string): void;
 }
 
+interface DeviceSessionExecutionCanceller {
+  (sessionId: string, reason: string): Promise<number>;
+}
+
 export type DeviceReadinessReservation = (() => Promise<void>) & {
   readonly owner: symbol;
 };
@@ -293,6 +297,7 @@ export class DevicePool {
   private readonly releaseSessionForDisconnectedDevice: DeviceDisconnectSessionReleaser;
   private readonly onDeviceReady: DeviceReadyListener | undefined;
   private readonly onDeviceRemoved: DeviceRemovedListener | undefined;
+  private readonly cancelDeviceSessionExecutions: DeviceSessionExecutionCanceller;
   private readonly androidDeviceReboot: AndroidDeviceReboot;
   private readonly recoveryPolicy: DeviceRecoveryPolicy;
   private readonly recoveringAndroidImages: Map<string, DeviceInfo> = new Map();
@@ -384,6 +389,7 @@ export class DevicePool {
     recoveryPolicy?: DeviceRecoveryPolicy,
     onDeviceRemoved?: DeviceRemovedListener,
     emulatorLossIncidentStore: EmulatorLossIncidentStore = new InMemoryEmulatorLossIncidentStore(timer),
+    cancelDeviceSessionExecutions?: DeviceSessionExecutionCanceller,
   ) {
     this.sessionManager = sessionManager;
     this.daemonSessionId = daemonSessionId;
@@ -395,6 +401,7 @@ export class DevicePool {
     this.criteriaMatcher = criteriaMatcher;
     this.onDeviceReady = onDeviceReady;
     this.onDeviceRemoved = onDeviceRemoved;
+    this.cancelDeviceSessionExecutions = cancelDeviceSessionExecutions ?? (async () => 0);
     this.emulatorLossIncidentStore = emulatorLossIncidentStore;
     // Resolve recovery policy once so retries and status agree even if the
     // process environment changes after construction.
@@ -1997,7 +2004,7 @@ export class DevicePool {
         // disconnects, permanently separating their preserved sessions.
         return { devices: [], deferred: true };
       }
-      await this.stopTrackedIdleAdbResetCohortProcesses(cohort);
+      await this.prepareAdbServerResetCohortDetachment(cohort);
       const detached: PooledDevice[] = [];
       for (const device of cohort) {
         if (
@@ -2014,10 +2021,10 @@ export class DevicePool {
             session.assignedDevice !== device.id ||
             session.platform !== "android"
           ) {
+            this.adbServerResetQuarantinedSessions.delete(device.sessionId);
             continue;
           }
           device.adbServerResetSessionId = device.sessionId;
-          this.adbServerResetQuarantinedSessions.add(device.sessionId);
         }
         device.adbServerResetAutolockSessionId = device.autolockSessionId;
         const trackedProcess = this.startedDeviceProcesses.get(device.id);
@@ -2032,6 +2039,51 @@ export class DevicePool {
       }
       return { devices: detached, deferred: false };
     });
+  }
+
+  private async prepareAdbServerResetCohortDetachment(
+    cohort: readonly PooledDevice[],
+  ): Promise<void> {
+    const sessionIds = this.getAdbServerResetCohortSessionIds(cohort);
+    for (const sessionId of sessionIds) {
+      this.adbServerResetQuarantinedSessions.add(sessionId);
+    }
+    try {
+      await Promise.all(
+        sessionIds.map(sessionId =>
+          this.cancelDeviceSessionExecutions(
+            sessionId,
+            "device-disconnected:process-wide-adb-reset",
+          ),
+        ),
+      );
+      await this.stopTrackedIdleAdbResetCohortProcesses(cohort);
+    } catch (error) {
+      for (const sessionId of sessionIds) {
+        this.adbServerResetQuarantinedSessions.delete(sessionId);
+      }
+      throw error;
+    }
+  }
+
+  private getAdbServerResetCohortSessionIds(
+    cohort: readonly PooledDevice[],
+  ): string[] {
+    const sessionIds = new Set<string>();
+    for (const device of cohort) {
+      if (
+        this.devices.get(device.id) !== device ||
+        !this.isAutoMobileOwnedAndroidVirtualDevice(device) ||
+        !device.sessionId
+      ) {
+        continue;
+      }
+      const session = this.sessionManager.getSession(device.sessionId);
+      if (session?.assignedDevice === device.id && session.platform === "android") {
+        sessionIds.add(device.sessionId);
+      }
+    }
+    return [...sessionIds];
   }
 
   private async stopTrackedIdleAdbResetCohortProcesses(
@@ -4493,6 +4545,9 @@ export class DevicePool {
 
     const device = this.devices.get(session.assignedDevice);
     if (!device || device.autolockSessionId !== sessionId) {
+      if (this.adbServerResetQuarantinedSessions.has(sessionId)) {
+        return !platform || session.platform === platform ? sessionId : undefined;
+      }
       this.mcpSessionAutolockMap.delete(mcpSessionId);
       return undefined;
     }

--- a/src/daemon/devicePool.ts
+++ b/src/daemon/devicePool.ts
@@ -639,13 +639,6 @@ export class DevicePool {
     }
   }
 
-  /** Persist a verified Android AVD identity without claiming a new process start. */
-  async recordAndroidAvdIdentity(deviceId: string, sourceImage: DeviceInfo): Promise<void> {
-    await this.assignmentMutex.runExclusive(() => {
-      this.recordSourceAndroidAvd(deviceId, sourceImage);
-    });
-  }
-
   /**
    * Replace a pooled connection whose stable serial now identifies a different
    * runtime. Preserve AutoMobile-owned emulator state because the process and
@@ -3572,14 +3565,16 @@ export class DevicePool {
     expectedIdentity?: Pick<BootedDevice, "deviceId" | "name" | "platform">,
     allowSessionRebind = false,
     readinessReservationOwners?: ReadonlySet<symbol>,
+    verifiedAndroidAvdIdentity?: DeviceInfo,
   ): Promise<string> {
     return await this.assignmentMutex.runExclusive(async () => {
+      const androidAvdIdentity = verifiedAndroidAvdIdentity ?? sourceImage;
       const alreadyPooled = this.devices.has(deviceId);
       if (!alreadyPooled) {
         const bootedDevices = await this.deviceManager.getBootedDevices(platform);
         const booted = bootedDevices.find((d) => d.deviceId === deviceId);
         if (booted) {
-          await this.addDevice(booted, sourceImage);
+          await this.addDevice(booted, androidAvdIdentity);
         }
       }
 
@@ -3593,7 +3588,7 @@ export class DevicePool {
         `Device '${deviceId}' is shutting down and cannot be assigned.`,
       );
       if (alreadyPooled) {
-        this.recordSourceAndroidAvd(deviceId, sourceImage);
+        this.recordSourceAndroidAvd(deviceId, androidAvdIdentity);
         this.notifyDeviceReady(deviceId);
       }
       await this.trackStartedDeviceProcess(
@@ -3805,6 +3800,7 @@ export class DevicePool {
     childProcess?: ChildProcess | null,
     expectedIdentity?: Pick<BootedDevice, "deviceId" | "name" | "platform">,
     readinessReservationOwners?: ReadonlySet<symbol>,
+    verifiedAndroidAvdIdentity?: DeviceInfo,
   ): Promise<string | undefined> {
     if (!isDevicePoolAutolockEnabled()) {
       return undefined;
@@ -3818,6 +3814,7 @@ export class DevicePool {
         childProcess,
         expectedIdentity,
         readinessReservationOwners,
+        verifiedAndroidAvdIdentity,
       ),
     );
   }
@@ -3830,8 +3827,10 @@ export class DevicePool {
     childProcess?: ChildProcess | null,
     expectedIdentity?: Pick<BootedDevice, "deviceId" | "name" | "platform">,
     readinessReservationOwners?: ReadonlySet<symbol>,
+    verifiedAndroidAvdIdentity?: DeviceInfo,
   ): Promise<string> {
     const sessionId = randomUUID();
+    const androidAvdIdentity = verifiedAndroidAvdIdentity ?? sourceImage;
 
     // Ensure device is in the pool (it may have been freshly booted)
     const alreadyPooled = this.devices.has(deviceId);
@@ -3839,7 +3838,7 @@ export class DevicePool {
       const bootedDevices = await this.deviceManager.getBootedDevices(platform);
       const booted = bootedDevices.find((d) => d.deviceId === deviceId);
       if (booted) {
-        await this.addDevice(booted, sourceImage);
+        await this.addDevice(booted, androidAvdIdentity);
       }
     }
 
@@ -3861,7 +3860,7 @@ export class DevicePool {
       `Device '${deviceId}' is shutting down and cannot be autolocked.`,
     );
     if (alreadyPooled) {
-      this.recordSourceAndroidAvd(deviceId, sourceImage);
+      this.recordSourceAndroidAvd(deviceId, androidAvdIdentity);
       this.notifyDeviceReady(deviceId);
     }
     await this.trackStartedDeviceProcess(

--- a/src/daemon/devicePool.ts
+++ b/src/daemon/devicePool.ts
@@ -310,6 +310,8 @@ export class DevicePool {
    * through session binding so a reset cohort cannot detach that AVD mid-start.
    */
   private readonly androidStartupLeases: Map<symbol, AndroidStartupLeaseRequest> = new Map();
+  /** Sessions whose old serial may be reused before their reset cohort settles. */
+  private readonly adbServerResetQuarantinedSessions: Set<string> = new Set();
   private readonly recoveringAndroidDeviceIds: Set<string> = new Set();
   private readonly startedDeviceProcesses: Map<string, ChildProcess> = new Map();
   private readonly startedDeviceProcessOutput: Map<string, EmulatorProcessOutputTail> = new Map();
@@ -1995,6 +1997,7 @@ export class DevicePool {
         // disconnects, permanently separating their preserved sessions.
         return { devices: [], deferred: true };
       }
+      await this.stopTrackedIdleAdbResetCohortProcesses(cohort);
       const detached: PooledDevice[] = [];
       for (const device of cohort) {
         if (
@@ -2014,15 +2017,12 @@ export class DevicePool {
             continue;
           }
           device.adbServerResetSessionId = device.sessionId;
+          this.adbServerResetQuarantinedSessions.add(device.sessionId);
         }
         device.adbServerResetAutolockSessionId = device.autolockSessionId;
         const trackedProcess = this.startedDeviceProcesses.get(device.id);
         if (trackedProcess && sessionId) {
           this.adbServerResetTrackedProcesses.set(device, trackedProcess);
-        } else if (trackedProcess) {
-          // Idle cohort members cannot restore ownership through session
-          // recovery, so terminate their tracked process before detaching.
-          await this.stopTrackedEmulatorProcess(device.id);
         }
         this.reserveAdbServerResetRecovery(device);
         device.sessionId = null;
@@ -2032,6 +2032,24 @@ export class DevicePool {
       }
       return { devices: detached, deferred: false };
     });
+  }
+
+  private async stopTrackedIdleAdbResetCohortProcesses(
+    cohort: readonly PooledDevice[],
+  ): Promise<void> {
+    // Stop every fallible idle process before reserving or detaching any cohort
+    // member. A failed stop then leaves all session routes and reservations intact.
+    for (const device of cohort) {
+      if (
+        this.devices.get(device.id) !== device ||
+        !this.isAutoMobileOwnedAndroidVirtualDevice(device) ||
+        device.sessionId !== null ||
+        !this.startedDeviceProcesses.has(device.id)
+      ) {
+        continue;
+      }
+      await this.stopTrackedEmulatorProcess(device.id);
+    }
   }
 
   /**
@@ -2108,6 +2126,9 @@ export class DevicePool {
   ): Promise<void> {
     await this.assignmentMutex.runExclusive(() => {
       for (const device of cohort) {
+        if (device.adbServerResetSessionId) {
+          this.adbServerResetQuarantinedSessions.delete(device.adbServerResetSessionId);
+        }
         if (!device.avdName) {
           continue;
         }
@@ -2549,9 +2570,9 @@ export class DevicePool {
 
   private async stopTrackedEmulatorProcess(deviceId: string): Promise<void> {
     const childProcess = this.startedDeviceProcesses.get(deviceId);
+    await this.stopEmulatorProcess(childProcess);
     this.startedDeviceProcesses.delete(deviceId);
     this.startedDeviceProcessOutput.delete(deviceId);
-    await this.stopEmulatorProcess(childProcess);
   }
 
   private async stopDiscoveredEmulatorByAvdName(avdName: string): Promise<void> {
@@ -4633,6 +4654,14 @@ export class DevicePool {
    */
   getDeviceForSession(sessionId: string): PooledDevice | null {
     return Array.from(this.devices.values()).find((d) => d.sessionId === sessionId) || null;
+  }
+
+  assertSessionReadyForAutomation(sessionId: string): void {
+    if (this.adbServerResetQuarantinedSessions.has(sessionId)) {
+      throw new ActionableError(
+        `Session '${sessionId}' is recovering from a process-wide ADB reset. Retry after device recovery completes.`,
+      );
+    }
   }
 
   /**

--- a/src/daemon/devicePool.ts
+++ b/src/daemon/devicePool.ts
@@ -165,6 +165,11 @@ interface AdbServerResetRecoveryReservation {
   resolve(): void;
 }
 
+export interface AdbServerResetCohortDetachment {
+  devices: readonly PooledDevice[];
+  deferred: boolean;
+}
+
 interface AndroidStartupLeaseRequest {
   name?: string;
   exactName: boolean;
@@ -1022,6 +1027,15 @@ export class DevicePool {
   }
 
   markIntentionalShutdown(deviceId: string): void {
+    const resetReservation = Array.from(this.adbServerResetRecoveryReservations.values()).find(
+      reservation => reservation.deviceId === deviceId,
+    );
+    if (resetReservation) {
+      // Resolve reset-cohort ownership before consulting the current serial. A
+      // prior recovery may already have reused this serial for a different AVD.
+      resetReservation.cancelled = true;
+      return;
+    }
     const device = this.devices.get(deviceId);
     if (device) {
       // Tie the marker to the incarnation present now, so a later same-serial
@@ -1029,15 +1043,7 @@ export class DevicePool {
       this.intentionalShutdowns.set(deviceId, device.incarnation);
       return;
     }
-    const resetReservation = Array.from(this.adbServerResetRecoveryReservations.values()).find(
-      reservation => reservation.deviceId === deviceId,
-    );
-    if (resetReservation) {
-      // The cohort member is no longer pooled and its former serial can be
-      // reused by an earlier recovery. Keep this cancellation on its AVD
-      // reservation rather than a serial-scoped marker.
-      resetReservation.cancelled = true;
-    } else if (this.recoveringAndroidDeviceIds.has(deviceId)) {
+    if (this.recoveringAndroidDeviceIds.has(deviceId)) {
       // No pooled device yet (an in-flight recovery owns the serial); the mark
       // applies to whatever incarnation the recovery produces.
       this.intentionalShutdowns.set(deviceId, INCARNATION_ANY);
@@ -1978,14 +1984,22 @@ export class DevicePool {
    */
   async detachAdbServerResetCohort(
     cohort: readonly PooledDevice[],
-  ): Promise<readonly PooledDevice[]> {
+  ): Promise<AdbServerResetCohortDetachment> {
     return await this.assignmentMutex.runExclusive(async () => {
+      if (cohort.some(device =>
+        this.isAutoMobileOwnedAndroidVirtualDevice(device) &&
+        this.isLeasedForAndroidStartup(device.avdName),
+      )) {
+        // An ADB reset affects every member of this captured cohort. Leaving a
+        // subset pooled would make later polling treat those members as ordinary
+        // disconnects, permanently separating their preserved sessions.
+        return { devices: [], deferred: true };
+      }
       const detached: PooledDevice[] = [];
       for (const device of cohort) {
         if (
           this.devices.get(device.id) !== device ||
-          !this.isAutoMobileOwnedAndroidVirtualDevice(device) ||
-          this.isLeasedForAndroidStartup(device.avdName)
+          !this.isAutoMobileOwnedAndroidVirtualDevice(device)
         ) {
           continue;
         }
@@ -2016,7 +2030,7 @@ export class DevicePool {
         await this.removeDevice(device.id, false, device);
         detached.push(device);
       }
-      return detached;
+      return { devices: detached, deferred: false };
     });
   }
 
@@ -4054,6 +4068,12 @@ export class DevicePool {
           existingSession.assignedDevice === deviceId &&
           existingSession.platform === device.platform
         ) {
+          this.assertExistingRecoverySessionOwner(
+            existingSession,
+            sessionId,
+            deviceId,
+            expectedExistingSessionDeviceId,
+          );
           return this.reuseExistingDeviceSession(deviceId, existingSession.sessionId, sourceImage);
         }
 
@@ -4113,6 +4133,19 @@ export class DevicePool {
         session.platform !== platform
       )
     ) {
+      throw new ActionableError(
+        `Session '${sessionId}' changed while device '${deviceId}' was recovering.`,
+      );
+    }
+  }
+
+  private assertExistingRecoverySessionOwner(
+    session: Session,
+    sessionId: string,
+    deviceId: string,
+    expectedDeviceId: string | undefined,
+  ): void {
+    if (expectedDeviceId !== undefined && session.sessionId !== sessionId) {
       throw new ActionableError(
         `Session '${sessionId}' changed while device '${deviceId}' was recovering.`,
       );

--- a/src/daemon/devicePool.ts
+++ b/src/daemon/devicePool.ts
@@ -100,6 +100,8 @@ export interface PooledDevice {
   avdName?: string;
   /** Source image metadata used to evaluate allocation criteria during recovery. */
   androidImage?: DeviceInfo;
+  /** Session captured before a process-wide ADB reset detaches this connection. */
+  adbServerResetSessionId?: string;
   /**
    * Monotonic id for this pooled connection incarnation, assigned when the
    * device is first added to the pool. A serial (`id`) can be reused across
@@ -1915,7 +1917,12 @@ export class DevicePool {
       return expectedDevice;
     }
     if (expectedDevice !== undefined && currentDevice !== expectedDevice) {
-      return undefined;
+      // A preceding cohort member can legitimately reuse this detached
+      // member's old serial. Keep recovering the captured AVD by its stable
+      // name rather than treating that different replacement as this device.
+      return this.isAutoMobileOwnedAndroidVirtualDevice(expectedDevice)
+        ? expectedDevice
+        : undefined;
     }
     return this.isAutoMobileOwnedAndroidVirtualDevice(currentDevice)
       ? currentDevice
@@ -1923,7 +1930,10 @@ export class DevicePool {
   }
 
   private getAdbResetRecoverySession(device: PooledDevice): Session | undefined {
-    const sessionId = device.sessionId ?? this.sessionManager.getSessionForDevice(device.id);
+    const sessionId =
+      device.adbServerResetSessionId ??
+      device.sessionId ??
+      this.sessionManager.getSessionForDevice(device.id);
     const session = sessionId ? this.sessionManager.getSession(sessionId) : null;
     if (
       !session ||
@@ -1961,6 +1971,7 @@ export class DevicePool {
           ) {
             continue;
           }
+          device.adbServerResetSessionId = device.sessionId;
         }
         this.reserveAdbServerResetRecovery(device);
         device.sessionId = null;
@@ -2073,8 +2084,12 @@ export class DevicePool {
     this.recoveringAndroidDeviceIds.add(device.id);
     let recoveryAttempt = 0;
     try {
+      let replacementState: "stopped" | "same-avd";
       try {
-        await this.stopAndroidEmulatorForRecovery(device.id, avdName);
+        replacementState = await this.stopAndroidEmulatorForRecovery(
+          device,
+          avdName,
+        );
       } catch (error) {
         logger.warn(
           `[DevicePool] Could not terminate disconnected emulator ${device.id}: ${error}`,
@@ -2083,15 +2098,14 @@ export class DevicePool {
         await this.completeEmulatorLossRecovery(incidentId, "exhausted");
         return false;
       }
-      const current = this.devices.get(device.id);
-      if (current && current !== device) {
+      if (replacementState === "same-avd") {
         await this.completeEmulatorLossRecovery(incidentId, "recovered");
         return true;
       }
       if (!this.detachSessionForAndroidRecovery(device, preservedSessionId)) {
         return false;
       }
-      await this.removeDevice(device.id);
+      await this.removeDevice(device.id, true, device);
       let intentionallyStopped = false;
       let intentionalShutdownCleanupError: unknown;
       const recovered = await this.androidDeviceReboot.run(target, async () => {
@@ -2183,12 +2197,26 @@ export class DevicePool {
     }
   }
 
-  private async stopAndroidEmulatorForRecovery(deviceId: string, avdName: string): Promise<void> {
-    const hadTrackedProcess = this.startedDeviceProcesses.has(deviceId);
-    await this.stopTrackedEmulatorProcess(deviceId);
+  private async stopAndroidEmulatorForRecovery(
+    device: PooledDevice,
+    avdName: string,
+  ): Promise<"stopped" | "same-avd"> {
+    const current = this.devices.get(device.id);
+    if (current && current !== device) {
+      if (current.avdName === avdName) {
+        return "same-avd";
+      }
+      logger.info(
+        `[DevicePool] Preserving replacement ${current.id} while recovering ${avdName} after ADB reset`,
+      );
+      return "stopped";
+    }
+    const hadTrackedProcess = this.startedDeviceProcesses.has(device.id);
+    await this.stopTrackedEmulatorProcess(device.id);
     if (!hadTrackedProcess) {
       await this.stopDiscoveredEmulatorByAvdName(avdName);
     }
+    return "stopped";
   }
 
   private detachSessionForAndroidRecovery(

--- a/src/daemon/devicePool.ts
+++ b/src/daemon/devicePool.ts
@@ -156,6 +156,7 @@ interface ReadinessReservationTarget {
 }
 
 interface AdbServerResetRecoveryReservation {
+  deviceId: string;
   image: DeviceInfo;
   settled: Promise<void>;
   resolve(): void;
@@ -1011,9 +1012,15 @@ export class DevicePool {
       // Tie the marker to the incarnation present now, so a later same-serial
       // replacement is not treated as intentionally stopped.
       this.intentionalShutdowns.set(deviceId, device.incarnation);
-    } else if (this.recoveringAndroidDeviceIds.has(deviceId)) {
+    } else if (
+      this.recoveringAndroidDeviceIds.has(deviceId) ||
+      Array.from(this.adbServerResetRecoveryReservations.values()).some(
+        reservation => reservation.deviceId === deviceId,
+      )
+    ) {
       // No pooled device yet (an in-flight recovery owns the serial); the mark
-      // applies to whatever incarnation the recovery produces.
+      // applies to whatever incarnation the recovery produces. A reset cohort
+      // reserves detached later members before their own recovery turn.
       this.intentionalShutdowns.set(deviceId, INCARNATION_ANY);
     }
   }
@@ -1992,7 +1999,24 @@ export class DevicePool {
     if (!reservation) {
       return;
     }
-    await runWithAbortSignal(signal, async () => await reservation.settled);
+    await this.waitForAdbServerResetReservations([reservation], signal);
+  }
+
+  /**
+   * Legacy startDevice accepts a partial name, unlike getAndroid's exact AVD
+   * name. Do not let that compatibility path select a reserved reset member.
+   */
+  async waitForAdbServerResetRecoveryMatchingName(
+    name: string | undefined,
+    signal?: AbortSignal,
+  ): Promise<void> {
+    const normalizedName = name?.toLowerCase();
+    const reservations = Array.from(this.adbServerResetRecoveryReservations.values()).filter(
+      reservation =>
+        normalizedName === undefined ||
+        reservation.image.name.toLowerCase().includes(normalizedName),
+    );
+    await this.waitForAdbServerResetReservations(reservations, signal);
   }
 
   async releaseAdbServerResetCohortReservations(
@@ -2032,9 +2056,40 @@ export class DevicePool {
         isRunning: false,
         source: "local",
       },
+      deviceId: device.id,
       settled,
       resolve,
     });
+  }
+
+  private async waitForAdbServerResetReservations(
+    reservations: readonly AdbServerResetRecoveryReservation[],
+    signal?: AbortSignal,
+  ): Promise<void> {
+    if (reservations.length === 0) {
+      return;
+    }
+    let abortListener: (() => void) | undefined;
+    const cancellation = signal
+      ? new Promise<never>((_resolve, reject) => {
+        abortListener = () => reject(signal.reason ?? new Error("Device preparation cancelled"));
+        if (signal.aborted) {
+          abortListener();
+          return;
+        }
+        signal.addEventListener("abort", abortListener, { once: true });
+      })
+      : undefined;
+    try {
+      await Promise.race([
+        Promise.all(reservations.map(reservation => reservation.settled)),
+        ...(cancellation ? [cancellation] : []),
+      ]);
+    } finally {
+      if (abortListener) {
+        signal?.removeEventListener("abort", abortListener);
+      }
+    }
   }
 
   private async releasePreservedAdbResetSessionIfDetached(
@@ -2099,6 +2154,14 @@ export class DevicePool {
         return false;
       }
       if (replacementState === "same-avd") {
+        if (!await this.rebindSameAvdReplacementSession(
+          device,
+          avdName,
+          preservedSessionId,
+          recoveryImage,
+        )) {
+          return false;
+        }
         await this.completeEmulatorLossRecovery(incidentId, "recovered");
         return true;
       }
@@ -2182,7 +2245,7 @@ export class DevicePool {
           `[DevicePool] Cancelled Android emulator ${avdName} recovery after intentional shutdown`,
         );
         await this.completeEmulatorLossRecovery(incidentId, "not-attempted");
-        return true;
+        return false;
       }
       if (recovered) {
         logger.info(`[DevicePool] Restarted Android emulator ${avdName} after disconnect`);
@@ -2217,6 +2280,43 @@ export class DevicePool {
       await this.stopDiscoveredEmulatorByAvdName(avdName);
     }
     return "stopped";
+  }
+
+  private async rebindSameAvdReplacementSession(
+    device: PooledDevice,
+    avdName: string,
+    preservedSessionId: string | undefined,
+    recoveryImage: DeviceInfo,
+  ): Promise<boolean> {
+    const replacement = this.devices.get(device.id);
+    if (!replacement || replacement.avdName !== avdName) {
+      return false;
+    }
+    if (!preservedSessionId) {
+      return true;
+    }
+    try {
+      await this.bindOrReuseDeviceSession(
+        preservedSessionId,
+        replacement.id,
+        "android",
+        recoveryImage,
+        undefined,
+        {
+          deviceId: replacement.id,
+          name: replacement.name,
+          platform: "android",
+        },
+        true,
+      );
+      return this.sessionManager.getSession(preservedSessionId)?.assignedDevice === replacement.id;
+    } catch (error) {
+      logger.warn(
+        `[DevicePool] Could not rebind session ${preservedSessionId} to same-AVD replacement ${avdName}: ${error}`,
+        error,
+      );
+      return false;
+    }
   }
 
   private detachSessionForAndroidRecovery(

--- a/src/daemon/devicePool.ts
+++ b/src/daemon/devicePool.ts
@@ -639,6 +639,13 @@ export class DevicePool {
     }
   }
 
+  /** Persist a verified Android AVD identity without claiming a new process start. */
+  async recordAndroidAvdIdentity(deviceId: string, sourceImage: DeviceInfo): Promise<void> {
+    await this.assignmentMutex.runExclusive(() => {
+      this.recordSourceAndroidAvd(deviceId, sourceImage);
+    });
+  }
+
   /**
    * Replace a pooled connection whose stable serial now identifies a different
    * runtime. Preserve AutoMobile-owned emulator state because the process and
@@ -1866,10 +1873,37 @@ export class DevicePool {
       undefined,
       "absent",
     );
-    return await this.rebootDisconnectedAndroidDevice(device, incidentId, {
-      preserveSessionId: session.sessionId,
-      bypassRecoveryPolicy: true,
-    });
+    try {
+      const recovered = await this.rebootDisconnectedAndroidDevice(device, incidentId, {
+        preserveSessionId: session.sessionId,
+        bypassRecoveryPolicy: true,
+      });
+      if (!recovered) {
+        await this.releasePreservedAdbResetSessionIfDetached(device, session.sessionId, incidentId);
+      }
+      return recovered;
+    } catch (error) {
+      await this.releasePreservedAdbResetSessionIfDetached(device, session.sessionId, incidentId);
+      throw error;
+    }
+  }
+
+  private async releasePreservedAdbResetSessionIfDetached(
+    device: PooledDevice,
+    sessionId: string,
+    incidentId: string | undefined,
+  ): Promise<void> {
+    if (
+      this.devices.get(device.id) === device ||
+      this.sessionManager.getSession(sessionId)?.assignedDevice !== device.id
+    ) {
+      return;
+    }
+    await this.releaseSessionForDisconnectedDevice(
+      sessionId,
+      device.id,
+      deviceLossCancellationReason(device.id, incidentId),
+    );
   }
 
   private async rebootDisconnectedAndroidDevice(
@@ -3816,8 +3850,8 @@ export class DevicePool {
         `Device '${deviceId}' is not available for autolock.\n` +
           `The device may have been shut down or disconnected.\n\n` +
           `Options:\n` +
-          `  - Use 'startDevice' with the same criteria to boot a new device\n` +
-          `  - Use 'startDevice' with deviceId to restart this specific device\n` +
+          `  - Use 'getAndroid' or 'getApple' with the target's stable identifier to prepare a device\n` +
+          `  - Use the returned sessionId to target this specific device\n` +
           `  - Use 'listDevices' to see currently available devices`,
       );
     }
@@ -3855,8 +3889,8 @@ export class DevicePool {
       `Device '${deviceId}' is not available for autolock.\n` +
         `The device may have been shut down or disconnected.\n\n` +
         `Options:\n` +
-        `  - Use 'startDevice' with the same criteria to boot a new device\n` +
-        `  - Use 'startDevice' with deviceId to restart this specific device\n` +
+        `  - Use 'getAndroid' or 'getApple' with the target's stable identifier to prepare a device\n` +
+        `  - Use the returned sessionId to target this specific device\n` +
         `  - Use 'listDevices' to see currently available devices`,
       readinessReservationOwners,
     );
@@ -4054,10 +4088,10 @@ export class DevicePool {
       throw new ActionableError(
         `Device '${deviceId}' is locked to another session.\n` +
           `Autolock is enabled, so tool calls must either come from the same MCP session ` +
-          `that called 'startDevice' or include the sessionId returned for this device.\n\n` +
+          `that called 'getAndroid' or 'getApple', or include the sessionId returned for this device.\n\n` +
           `Options:\n` +
-          `  - Pass the sessionId from the 'startDevice' that locked this device\n` +
-          `  - Use 'startDevice' to lock a different available device\n` +
+          `  - Pass the sessionId from getAndroid or getApple that locked this device\n` +
+          `  - Use getAndroid or getApple to lock a different available device\n` +
           `  - Wait for the idle timeout to release this device`,
       );
     }

--- a/src/daemon/devicePool.ts
+++ b/src/daemon/devicePool.ts
@@ -102,6 +102,8 @@ export interface PooledDevice {
   androidImage?: DeviceInfo;
   /** Session captured before a process-wide ADB reset detaches this connection. */
   adbServerResetSessionId?: string;
+  /** Autolock owner captured before a process-wide ADB reset detaches this connection. */
+  adbServerResetAutolockSessionId?: string;
   /**
    * Monotonic id for this pooled connection incarnation, assigned when the
    * device is first added to the pool. A serial (`id`) can be reused across
@@ -158,6 +160,7 @@ interface ReadinessReservationTarget {
 interface AdbServerResetRecoveryReservation {
   deviceId: string;
   image: DeviceInfo;
+  cancelled: boolean;
   settled: Promise<void>;
   resolve(): void;
 }
@@ -290,6 +293,8 @@ export class DevicePool {
    */
   private readonly adbServerResetRecoveryReservations:
     Map<string, AdbServerResetRecoveryReservation> = new Map();
+  /** Child-process handles retained after reset cohort pool entries are detached. */
+  private readonly adbServerResetTrackedProcesses: WeakMap<PooledDevice, ChildProcess> = new WeakMap();
   private readonly recoveringAndroidDeviceIds: Set<string> = new Set();
   private readonly startedDeviceProcesses: Map<string, ChildProcess> = new Map();
   private readonly startedDeviceProcessOutput: Map<string, EmulatorProcessOutputTail> = new Map();
@@ -1012,15 +1017,19 @@ export class DevicePool {
       // Tie the marker to the incarnation present now, so a later same-serial
       // replacement is not treated as intentionally stopped.
       this.intentionalShutdowns.set(deviceId, device.incarnation);
-    } else if (
-      this.recoveringAndroidDeviceIds.has(deviceId) ||
-      Array.from(this.adbServerResetRecoveryReservations.values()).some(
-        reservation => reservation.deviceId === deviceId,
-      )
-    ) {
+      return;
+    }
+    const resetReservation = Array.from(this.adbServerResetRecoveryReservations.values()).find(
+      reservation => reservation.deviceId === deviceId,
+    );
+    if (resetReservation) {
+      // The cohort member is no longer pooled and its former serial can be
+      // reused by an earlier recovery. Keep this cancellation on its AVD
+      // reservation rather than a serial-scoped marker.
+      resetReservation.cancelled = true;
+    } else if (this.recoveringAndroidDeviceIds.has(deviceId)) {
       // No pooled device yet (an in-flight recovery owns the serial); the mark
-      // applies to whatever incarnation the recovery produces. A reset cohort
-      // reserves detached later members before their own recovery turn.
+      // applies to whatever incarnation the recovery produces.
       this.intentionalShutdowns.set(deviceId, INCARNATION_ANY);
     }
   }
@@ -1980,6 +1989,11 @@ export class DevicePool {
           }
           device.adbServerResetSessionId = device.sessionId;
         }
+        device.adbServerResetAutolockSessionId = device.autolockSessionId;
+        const trackedProcess = this.startedDeviceProcesses.get(device.id);
+        if (trackedProcess) {
+          this.adbServerResetTrackedProcesses.set(device, trackedProcess);
+        }
         this.reserveAdbServerResetRecovery(device);
         device.sessionId = null;
         device.status = "idle";
@@ -2057,6 +2071,7 @@ export class DevicePool {
         source: "local",
       },
       deviceId: device.id,
+      cancelled: false,
       settled,
       resolve,
     });
@@ -2121,6 +2136,8 @@ export class DevicePool {
 
     const avdName = device.avdName;
     const preservedSessionId = options.preserveSessionId;
+    const preservedAutolockSessionId =
+      device.adbServerResetAutolockSessionId ?? device.autolockSessionId;
     const recoveryDeviceIds = new Set([device.id]);
     const recoveryImage: DeviceInfo = {
       ...device.androidImage,
@@ -2154,16 +2171,14 @@ export class DevicePool {
         return false;
       }
       if (replacementState === "same-avd") {
-        if (!await this.rebindSameAvdReplacementSession(
+        return await this.recoverSameAvdReplacement(
           device,
           avdName,
           preservedSessionId,
+          preservedAutolockSessionId,
           recoveryImage,
-        )) {
-          return false;
-        }
-        await this.completeEmulatorLossRecovery(incidentId, "recovered");
-        return true;
+          incidentId,
+        );
       }
       if (!this.detachSessionForAndroidRecovery(device, preservedSessionId)) {
         return false;
@@ -2172,7 +2187,7 @@ export class DevicePool {
       let intentionallyStopped = false;
       let intentionalShutdownCleanupError: unknown;
       const recovered = await this.androidDeviceReboot.run(target, async () => {
-        if (this.consumeIntentionalShutdown(recoveryDeviceIds)) {
+        if (this.consumeAndroidRecoveryCancellation(device, recoveryDeviceIds)) {
           intentionallyStopped = true;
           return;
         }
@@ -2204,12 +2219,12 @@ export class DevicePool {
           readinessCompleted = true;
           recoveryDeviceIds.add(ready.deviceId);
           this.recoveringAndroidDeviceIds.add(ready.deviceId);
-          if (this.consumeIntentionalShutdown(recoveryDeviceIds)) {
+          if (this.consumeAndroidRecoveryCancellation(device, recoveryDeviceIds)) {
             await stopCancelledRecovery();
             return;
           }
           await this.addDevice(ready, recoveryImage);
-          if (this.consumeIntentionalShutdown(recoveryDeviceIds)) {
+          if (this.consumeAndroidRecoveryCancellation(device, recoveryDeviceIds)) {
             await stopCancelledRecovery(ready);
             return;
           }
@@ -2220,13 +2235,14 @@ export class DevicePool {
             ready,
             recoveryImage,
             childProcess,
+            preservedAutolockSessionId,
           );
           await this.recordEmulatorLossRecoveryAttempt(incidentId, {
             attempt,
             outcome: "succeeded",
           });
         } catch (error) {
-          if (this.consumeIntentionalShutdown(recoveryDeviceIds)) {
+          if (this.consumeAndroidRecoveryCancellation(device, recoveryDeviceIds)) {
             await stopCancelledRecovery(readinessCompleted ? ready : undefined);
             return;
           }
@@ -2274,6 +2290,12 @@ export class DevicePool {
       );
       return "stopped";
     }
+    const detachedProcess = this.adbServerResetTrackedProcesses.get(device);
+    if (detachedProcess) {
+      this.adbServerResetTrackedProcesses.delete(device);
+      await this.stopEmulatorProcess(detachedProcess);
+      return "stopped";
+    }
     const hadTrackedProcess = this.startedDeviceProcesses.has(device.id);
     await this.stopTrackedEmulatorProcess(device.id);
     if (!hadTrackedProcess) {
@@ -2286,6 +2308,7 @@ export class DevicePool {
     device: PooledDevice,
     avdName: string,
     preservedSessionId: string | undefined,
+    preservedAutolockSessionId: string | undefined,
     recoveryImage: DeviceInfo,
   ): Promise<boolean> {
     const replacement = this.devices.get(device.id);
@@ -2309,6 +2332,12 @@ export class DevicePool {
         },
         true,
       );
+      replacement.autolockSessionId = preservedAutolockSessionId;
+      const detachedProcess = this.adbServerResetTrackedProcesses.get(device);
+      if (detachedProcess) {
+        this.adbServerResetTrackedProcesses.delete(device);
+        this.startedDeviceProcesses.set(replacement.id, detachedProcess);
+      }
       return this.sessionManager.getSession(preservedSessionId)?.assignedDevice === replacement.id;
     } catch (error) {
       logger.warn(
@@ -2317,6 +2346,27 @@ export class DevicePool {
       );
       return false;
     }
+  }
+
+  private async recoverSameAvdReplacement(
+    device: PooledDevice,
+    avdName: string,
+    preservedSessionId: string | undefined,
+    preservedAutolockSessionId: string | undefined,
+    recoveryImage: DeviceInfo,
+    incidentId: string | undefined,
+  ): Promise<boolean> {
+    if (!await this.rebindSameAvdReplacementSession(
+      device,
+      avdName,
+      preservedSessionId,
+      preservedAutolockSessionId,
+      recoveryImage,
+    )) {
+      return false;
+    }
+    await this.completeEmulatorLossRecovery(incidentId, "recovered");
+    return true;
   }
 
   private detachSessionForAndroidRecovery(
@@ -2343,6 +2393,7 @@ export class DevicePool {
     ready: BootedDevice,
     recoveryImage: DeviceInfo,
     childProcess: ChildProcess | null,
+    preservedAutolockSessionId: string | undefined,
   ): Promise<void> {
     if (!preservedSessionId) {
       await this.trackStartedDeviceProcess(ready, childProcess);
@@ -2362,6 +2413,30 @@ export class DevicePool {
       ready,
       true,
     );
+    const replacement = this.devices.get(ready.deviceId);
+    if (replacement?.sessionId === preservedSessionId) {
+      replacement.autolockSessionId = preservedAutolockSessionId;
+    }
+  }
+
+  private consumeAdbServerResetRecoveryCancellation(device: PooledDevice): boolean {
+    if (!device.avdName) {
+      return false;
+    }
+    const reservation = this.adbServerResetRecoveryReservations.get(device.avdName);
+    if (!reservation || reservation.deviceId !== device.id || !reservation.cancelled) {
+      return false;
+    }
+    reservation.cancelled = false;
+    return true;
+  }
+
+  private consumeAndroidRecoveryCancellation(
+    device: PooledDevice,
+    recoveryDeviceIds: ReadonlySet<string>,
+  ): boolean {
+    return this.consumeAdbServerResetRecoveryCancellation(device) ||
+      this.consumeIntentionalShutdown(recoveryDeviceIds);
   }
 
   private consumeIntentionalShutdown(deviceIds: ReadonlySet<string>): boolean {

--- a/src/daemon/devicePool.ts
+++ b/src/daemon/devicePool.ts
@@ -165,6 +165,11 @@ interface AdbServerResetRecoveryReservation {
   resolve(): void;
 }
 
+interface AndroidStartupLeaseRequest {
+  name?: string;
+  exactName: boolean;
+}
+
 export interface SystemUiAnrRecoveryHandoff {
   readonly preservedSessionId?: string;
   readonly replacementDevice: PooledDevice;
@@ -295,6 +300,11 @@ export class DevicePool {
     Map<string, AdbServerResetRecoveryReservation> = new Map();
   /** Child-process handles retained after reset cohort pool entries are detached. */
   private readonly adbServerResetTrackedProcesses: WeakMap<PooledDevice, ChildProcess> = new WeakMap();
+  /**
+   * A named Android start holds this lease from reset-reservation preflight
+   * through session binding so a reset cohort cannot detach that AVD mid-start.
+   */
+  private readonly androidStartupLeases: Map<symbol, AndroidStartupLeaseRequest> = new Map();
   private readonly recoveringAndroidDeviceIds: Set<string> = new Set();
   private readonly startedDeviceProcesses: Map<string, ChildProcess> = new Map();
   private readonly startedDeviceProcessOutput: Map<string, EmulatorProcessOutputTail> = new Map();
@@ -1974,10 +1984,12 @@ export class DevicePool {
       for (const device of cohort) {
         if (
           this.devices.get(device.id) !== device ||
-          !this.isAutoMobileOwnedAndroidVirtualDevice(device)
+          !this.isAutoMobileOwnedAndroidVirtualDevice(device) ||
+          this.isLeasedForAndroidStartup(device.avdName)
         ) {
           continue;
         }
+        const sessionId = device.sessionId;
         if (device.sessionId) {
           const session = this.sessionManager.getSession(device.sessionId);
           if (
@@ -1991,8 +2003,12 @@ export class DevicePool {
         }
         device.adbServerResetAutolockSessionId = device.autolockSessionId;
         const trackedProcess = this.startedDeviceProcesses.get(device.id);
-        if (trackedProcess) {
+        if (trackedProcess && sessionId) {
           this.adbServerResetTrackedProcesses.set(device, trackedProcess);
+        } else if (trackedProcess) {
+          // Idle cohort members cannot restore ownership through session
+          // recovery, so terminate their tracked process before detaching.
+          await this.stopTrackedEmulatorProcess(device.id);
         }
         this.reserveAdbServerResetRecovery(device);
         device.sessionId = null;
@@ -2014,6 +2030,46 @@ export class DevicePool {
       return;
     }
     await this.waitForAdbServerResetReservations([reservation], signal);
+  }
+
+  /**
+   * Atomically wait for matching reset recovery and reserve the requested AVD
+   * against a concurrent reset-cohort detachment. The returned release must
+   * remain held until startup has bound or abandoned the device.
+   */
+  async reserveAndroidStartupLease(
+    name: string | undefined,
+    exactName: boolean,
+    signal?: AbortSignal,
+  ): Promise<() => Promise<void>> {
+    const owner = Symbol("android-startup-lease");
+    const request: AndroidStartupLeaseRequest = { name, exactName };
+    for (;;) {
+      let matchingReservations: AdbServerResetRecoveryReservation[] = [];
+      await this.assignmentMutex.runExclusive(() => {
+        matchingReservations = Array.from(this.adbServerResetRecoveryReservations.entries())
+          .filter(([avdName]) => this.androidStartupRequestMatchesAvd(request, avdName))
+          .map(([, reservation]) => reservation);
+        if (matchingReservations.length === 0) {
+          this.androidStartupLeases.set(owner, request);
+        }
+      });
+      if (matchingReservations.length === 0) {
+        break;
+      }
+      await this.waitForAdbServerResetReservations(matchingReservations, signal);
+    }
+
+    let released = false;
+    return async () => {
+      if (released) {
+        return;
+      }
+      released = true;
+      await this.assignmentMutex.runExclusive(() => {
+        this.androidStartupLeases.delete(owner);
+      });
+    };
   }
 
   /**
@@ -2075,6 +2131,26 @@ export class DevicePool {
       settled,
       resolve,
     });
+  }
+
+  private isLeasedForAndroidStartup(avdName: string): boolean {
+    return Array.from(this.androidStartupLeases.values()).some(request =>
+      this.androidStartupRequestMatchesAvd(request, avdName),
+    );
+  }
+
+  private androidStartupRequestMatchesAvd(
+    request: AndroidStartupLeaseRequest,
+    avdName: string,
+  ): boolean {
+    if (!request.name) {
+      return true;
+    }
+    const normalizedName = request.name.toLowerCase();
+    const normalizedAvdName = avdName.toLowerCase();
+    return request.exactName
+      ? normalizedAvdName === normalizedName
+      : normalizedAvdName.includes(normalizedName);
   }
 
   private async waitForAdbServerResetReservations(
@@ -2331,6 +2407,9 @@ export class DevicePool {
           platform: "android",
         },
         true,
+        undefined,
+        undefined,
+        device.id,
       );
       replacement.autolockSessionId = preservedAutolockSessionId;
       const detachedProcess = this.adbServerResetTrackedProcesses.get(device);
@@ -2412,6 +2491,9 @@ export class DevicePool {
       childProcess,
       ready,
       true,
+      undefined,
+      undefined,
+      previousDeviceId,
     );
     const replacement = this.devices.get(ready.deviceId);
     if (replacement?.sessionId === preservedSessionId) {
@@ -3914,6 +3996,7 @@ export class DevicePool {
     allowSessionRebind = false,
     readinessReservationOwners?: ReadonlySet<symbol>,
     verifiedAndroidAvdIdentity?: DeviceInfo,
+    expectedExistingSessionDeviceId?: string,
   ): Promise<string> {
     return await this.assignmentMutex.runExclusive(async () => {
       const androidAvdIdentity = verifiedAndroidAvdIdentity ?? sourceImage;
@@ -3986,6 +4069,13 @@ export class DevicePool {
 
       const assignmentSnapshot = this.snapshotSessionAssignment(device);
       const previousSession = this.sessionManager.getSession(sessionId);
+      this.assertExpectedRecoverySession(
+        previousSession,
+        sessionId,
+        deviceId,
+        platform,
+        expectedExistingSessionDeviceId,
+      );
       device.sessionId = sessionId;
       device.status = "busy";
       device.lastUsedAt = this.nextLastUsedAt();
@@ -4006,6 +4096,27 @@ export class DevicePool {
       logger.info(`Bound device ${deviceId} to session ${sessionId}`);
       return sessionId;
     });
+  }
+
+  private assertExpectedRecoverySession(
+    session: Session | null,
+    sessionId: string,
+    deviceId: string,
+    platform: Platform,
+    expectedDeviceId: string | undefined,
+  ): void {
+    if (
+      expectedDeviceId !== undefined &&
+      (
+        !session ||
+        session.assignedDevice !== expectedDeviceId ||
+        session.platform !== platform
+      )
+    ) {
+      throw new ActionableError(
+        `Session '${sessionId}' changed while device '${deviceId}' was recovering.`,
+      );
+    }
   }
 
   private async validateOrReloadIdlePooledDevice(

--- a/src/daemon/devicePool.ts
+++ b/src/daemon/devicePool.ts
@@ -1841,22 +1841,13 @@ export class DevicePool {
     deviceId: string,
     expectedDevice?: PooledDevice,
   ): Promise<boolean> {
-    const device = this.devices.get(deviceId);
-    if (
-      !device ||
-      (expectedDevice !== undefined && device !== expectedDevice) ||
-      !device.sessionId ||
-      !this.isAutoMobileOwnedAndroidVirtualDevice(device)
-    ) {
+    const device = this.getAdbResetRecoveryDevice(deviceId, expectedDevice);
+    if (!device) {
       return false;
     }
 
-    const session = this.sessionManager.getSession(device.sessionId);
-    if (
-      !session ||
-      session.assignedDevice !== device.id ||
-      session.platform !== "android"
-    ) {
+    const session = this.getAdbResetRecoverySession(device);
+    if (!session) {
       return false;
     }
 
@@ -1887,6 +1878,70 @@ export class DevicePool {
       logger.warn(`[DevicePool] ADB-reset recovery failed for ${device.id}: ${error}`, error);
       return false;
     }
+  }
+
+  private getAdbResetRecoveryDevice(
+    deviceId: string,
+    expectedDevice: PooledDevice | undefined,
+  ): PooledDevice | undefined {
+    const currentDevice = this.devices.get(deviceId);
+    if (currentDevice === undefined) {
+      return expectedDevice;
+    }
+    if (expectedDevice !== undefined && currentDevice !== expectedDevice) {
+      return undefined;
+    }
+    return this.isAutoMobileOwnedAndroidVirtualDevice(currentDevice)
+      ? currentDevice
+      : undefined;
+  }
+
+  private getAdbResetRecoverySession(device: PooledDevice): Session | undefined {
+    const sessionId = device.sessionId ?? this.sessionManager.getSessionForDevice(device.id);
+    const session = sessionId ? this.sessionManager.getSession(sessionId) : null;
+    if (
+      !session ||
+      session.assignedDevice !== device.id ||
+      session.platform !== "android"
+    ) {
+      return undefined;
+    }
+    return session;
+  }
+
+  /**
+   * Remove every captured reset-cohort connection before any AVD is restarted.
+   * The session manager intentionally retains each old serial until recovery
+   * rebinds it, so a replacement can safely reuse another cohort member's port.
+   */
+  async detachAdbServerResetCohort(
+    cohort: readonly PooledDevice[],
+  ): Promise<readonly PooledDevice[]> {
+    return await this.assignmentMutex.runExclusive(async () => {
+      const detached: PooledDevice[] = [];
+      for (const device of cohort) {
+        if (
+          this.devices.get(device.id) !== device ||
+          !device.sessionId ||
+          !this.isAutoMobileOwnedAndroidVirtualDevice(device)
+        ) {
+          continue;
+        }
+        const session = this.sessionManager.getSession(device.sessionId);
+        if (
+          !session ||
+          session.assignedDevice !== device.id ||
+          session.platform !== "android"
+        ) {
+          continue;
+        }
+        device.sessionId = null;
+        device.status = "idle";
+        await this.removeDevice(device.id, false, device);
+        detached.push(device);
+      }
+      return detached;
+    });
   }
 
   private async releasePreservedAdbResetSessionIfDetached(

--- a/src/daemon/devicePool.ts
+++ b/src/daemon/devicePool.ts
@@ -1876,8 +1876,16 @@ export class DevicePool {
       }
       return recovered;
     } catch (error) {
-      await this.releasePreservedAdbResetSessionIfDetached(device, session.sessionId, incidentId);
-      throw error;
+      try {
+        await this.releasePreservedAdbResetSessionIfDetached(device, session.sessionId, incidentId);
+      } catch (releaseError) {
+        logger.warn(
+          `[DevicePool] Failed to release detached session ${session.sessionId}: ${releaseError}`,
+          releaseError,
+        );
+      }
+      logger.warn(`[DevicePool] ADB-reset recovery failed for ${device.id}: ${error}`, error);
+      return false;
     }
   }
 

--- a/src/server/ToolExecutionContext.ts
+++ b/src/server/ToolExecutionContext.ts
@@ -81,6 +81,7 @@ export async function createToolExecutionContext(
     return {};
   }
 
+  devicePool.assertSessionReadyForAutomation(sessionUuid);
   const existingSession = sessionManager.getSessionForNewExecution(sessionUuid, execution);
 
   // Get or create session

--- a/src/server/deviceTools.ts
+++ b/src/server/deviceTools.ts
@@ -1664,6 +1664,20 @@ async function prepareRecoveredDeviceForRunnerReadiness(
   );
 }
 
+async function recordWarmAndroidAvdIdentity(
+  devicePool: DevicePool | undefined,
+  boot: DeviceBootResult,
+  sourceImage: DeviceInfo | undefined,
+): Promise<void> {
+  if (boot.source === "booted" && sourceImage?.platform === "android") {
+    await devicePool?.recordAndroidAvdIdentity(boot.device.deviceId, sourceImage);
+  }
+}
+
+function getInitializedDevicePool(daemonState: DaemonState): DevicePool | undefined {
+  return daemonState.isInitialized() ? daemonState.getDevicePool() : undefined;
+}
+
 export function registerDeviceTools() {
   // List AVDs handler
   const listDeviceImagesHandler = async (args: ListDeviceImagesArgs) => {
@@ -1819,7 +1833,7 @@ export function registerDeviceTools() {
         validatePreservedSession,
         retireRecoveredReplacement,
       );
-      const devicePool = daemonState.isInitialized() ? daemonState.getDevicePool() : undefined;
+      const devicePool = getInitializedDevicePool(daemonState);
       const sessionId = preservedSessionId ?? await bindBootedDeviceSession(
         boot.device,
         args,
@@ -1827,9 +1841,7 @@ export function registerDeviceTools() {
         boot.processHandle,
         new Set(releaseReadinessReservations.map((reservation) => reservation.owner)),
       );
-      if (boot.source === "booted" && sourceImage?.platform === "android") {
-        await devicePool?.recordAndroidAvdIdentity(boot.device.deviceId, sourceImage);
-      }
+      await recordWarmAndroidAvdIdentity(devicePool, boot, sourceImage);
       ownershipTransferred = true;
 
       await notifyResourcesAfterDeviceBoot(boot, perf, deps.notifyResourcesChanged);

--- a/src/server/deviceTools.ts
+++ b/src/server/deviceTools.ts
@@ -1664,18 +1664,14 @@ async function prepareRecoveredDeviceForRunnerReadiness(
   );
 }
 
-async function recordWarmAndroidAvdIdentity(
-  devicePool: DevicePool | undefined,
+function getVerifiedWarmAndroidAvdIdentity(
   boot: DeviceBootResult,
   sourceImage: DeviceInfo | undefined,
-): Promise<void> {
+): DeviceInfo | undefined {
   if (boot.source === "booted" && sourceImage?.platform === "android") {
-    await devicePool?.recordAndroidAvdIdentity(boot.device.deviceId, sourceImage);
+    return sourceImage;
   }
-}
-
-function getInitializedDevicePool(daemonState: DaemonState): DevicePool | undefined {
-  return daemonState.isInitialized() ? daemonState.getDevicePool() : undefined;
+  return undefined;
 }
 
 export function registerDeviceTools() {
@@ -1833,15 +1829,18 @@ export function registerDeviceTools() {
         validatePreservedSession,
         retireRecoveredReplacement,
       );
-      const devicePool = getInitializedDevicePool(daemonState);
+      const verifiedWarmAndroidAvdIdentity = getVerifiedWarmAndroidAvdIdentity(
+        boot,
+        sourceImage,
+      );
       const sessionId = preservedSessionId ?? await bindBootedDeviceSession(
         boot.device,
         args,
         boot.source === "cold-boot" ? sourceImage : undefined,
         boot.processHandle,
         new Set(releaseReadinessReservations.map((reservation) => reservation.owner)),
+        verifiedWarmAndroidAvdIdentity,
       );
-      await recordWarmAndroidAvdIdentity(devicePool, boot, sourceImage);
       ownershipTransferred = true;
 
       await notifyResourcesAfterDeviceBoot(boot, perf, deps.notifyResourcesChanged);
@@ -1983,6 +1982,7 @@ export function registerDeviceTools() {
     sourceImage?: DeviceInfo,
     childProcess?: ChildProcess | null,
     readinessReservationOwners?: ReadonlySet<symbol>,
+    verifiedAndroidAvdIdentity?: DeviceInfo,
   ): Promise<string> {
     // Reserve the exact ready device before resource notifications publish it
     // to concurrent allocators.
@@ -1996,6 +1996,7 @@ export function registerDeviceTools() {
         childProcess,
         device,
         readinessReservationOwners,
+        verifiedAndroidAvdIdentity,
       );
       if (autolockSessionId) {
         return autolockSessionId;
@@ -2015,6 +2016,7 @@ export function registerDeviceTools() {
       device,
       false,
       readinessReservationOwners,
+      verifiedAndroidAvdIdentity,
     );
   }
 

--- a/src/server/deviceTools.ts
+++ b/src/server/deviceTools.ts
@@ -1614,6 +1614,20 @@ function getStartDevicePool(daemonState: DaemonState): DevicePool | undefined {
   return daemonState.isInitialized() ? daemonState.getDevicePool() : undefined;
 }
 
+async function waitForPendingAndroidResetRecovery(
+  args: StartDeviceArgs,
+  budgets: { androidAvdName?: string },
+  signal?: AbortSignal,
+): Promise<void> {
+  if (args.platform !== "android" || !budgets.androidAvdName) {
+    return;
+  }
+  await getStartDevicePool(DaemonState.getInstance())?.waitForAdbServerResetRecovery(
+    budgets.androidAvdName,
+    signal,
+  );
+}
+
 function createRunnerReadinessAttempt(
   input: StartDeviceRunnerReadinessInput,
 ): (candidate: DeviceBootResult) => Promise<void> {
@@ -1751,6 +1765,7 @@ export function registerDeviceTools() {
     let retireRecoveredReplacement: (() => Promise<void>) | undefined;
 
     try {
+      await waitForPendingAndroidResetRecovery(args, budgets, signal);
       const bootService = new DeviceBootService({
         deviceManager: deviceUtils,
         deviceMatcher: deps.deviceMatcherFactory(),

--- a/src/server/deviceTools.ts
+++ b/src/server/deviceTools.ts
@@ -1617,15 +1617,40 @@ function getStartDevicePool(daemonState: DaemonState): DevicePool | undefined {
 async function waitForPendingAndroidResetRecovery(
   args: StartDeviceArgs,
   budgets: { androidAvdName?: string },
+  bootDeadlineMs: number,
+  timer: Timer,
   signal?: AbortSignal,
 ): Promise<void> {
-  if (args.platform !== "android" || !budgets.androidAvdName) {
+  const avdName = args.platform === "android"
+    ? budgets.androidAvdName ?? args.name
+    : undefined;
+  if (!avdName) {
     return;
   }
-  await getStartDevicePool(DaemonState.getInstance())?.waitForAdbServerResetRecovery(
-    budgets.androidAvdName,
-    signal,
-  );
+  const devicePool = getStartDevicePool(DaemonState.getInstance());
+  if (!devicePool) {
+    return;
+  }
+  const remainingMs = bootDeadlineMs - timer.now();
+  if (remainingMs <= 0) {
+    throw new ActionableError(`Timed out waiting for Android AVD reset recovery of '${avdName}'`);
+  }
+  let timeout: NodeJS.Timeout | undefined;
+  const timeoutPromise = new Promise<never>((_resolve, reject) => {
+    timeout = timer.setTimeout(() => {
+      reject(new ActionableError(`Timed out waiting for Android AVD reset recovery of '${avdName}'`));
+    }, remainingMs);
+  });
+  try {
+    await Promise.race([
+      devicePool.waitForAdbServerResetRecovery(avdName, signal),
+      timeoutPromise,
+    ]);
+  } finally {
+    if (timeout) {
+      timer.clearTimeout(timeout);
+    }
+  }
 }
 
 function createRunnerReadinessAttempt(
@@ -1765,7 +1790,7 @@ export function registerDeviceTools() {
     let retireRecoveredReplacement: (() => Promise<void>) | undefined;
 
     try {
-      await waitForPendingAndroidResetRecovery(args, budgets, signal);
+      await waitForPendingAndroidResetRecovery(args, budgets, bootDeadlineMs, deps.timer, signal);
       const bootService = new DeviceBootService({
         deviceManager: deviceUtils,
         deviceMatcher: deps.deviceMatcherFactory(),

--- a/src/server/deviceTools.ts
+++ b/src/server/deviceTools.ts
@@ -241,6 +241,8 @@ export interface StartDeviceArgs {
   runnerReadinessTimeoutMs?: number;
   createIfMissing?: boolean;
   __mcpSessionId?: string;
+  /** Internal exact runtime identity used by getAndroid. */
+  matchExactName?: boolean;
 }
 
 export interface GetAndroidArgs {
@@ -1817,10 +1819,14 @@ export function registerDeviceTools() {
         validatePreservedSession,
         retireRecoveredReplacement,
       );
+      const devicePool = daemonState.isInitialized() ? daemonState.getDevicePool() : undefined;
+      if (boot.source === "booted" && sourceImage?.platform === "android") {
+        await devicePool?.recordAndroidAvdIdentity(boot.device.deviceId, sourceImage);
+      }
       const sessionId = preservedSessionId ?? await bindBootedDeviceSession(
         boot.device,
         args,
-        sourceImage,
+        boot.source === "cold-boot" ? sourceImage : undefined,
         boot.processHandle,
         new Set(releaseReadinessReservations.map((reservation) => reservation.owner)),
       );
@@ -1896,6 +1902,7 @@ export function registerDeviceTools() {
       {
         platform: "android",
         name: args.avdName,
+        matchExactName: true,
         preferRunning: true,
         createIfMissing: false,
         __mcpSessionId: typeof __mcpSessionId === "string" ? __mcpSessionId : undefined,

--- a/src/server/deviceTools.ts
+++ b/src/server/deviceTools.ts
@@ -1820,9 +1820,6 @@ export function registerDeviceTools() {
         retireRecoveredReplacement,
       );
       const devicePool = daemonState.isInitialized() ? daemonState.getDevicePool() : undefined;
-      if (boot.source === "booted" && sourceImage?.platform === "android") {
-        await devicePool?.recordAndroidAvdIdentity(boot.device.deviceId, sourceImage);
-      }
       const sessionId = preservedSessionId ?? await bindBootedDeviceSession(
         boot.device,
         args,
@@ -1830,6 +1827,9 @@ export function registerDeviceTools() {
         boot.processHandle,
         new Set(releaseReadinessReservations.map((reservation) => reservation.owner)),
       );
+      if (boot.source === "booted" && sourceImage?.platform === "android") {
+        await devicePool?.recordAndroidAvdIdentity(boot.device.deviceId, sourceImage);
+      }
       ownershipTransferred = true;
 
       await notifyResourcesAfterDeviceBoot(boot, perf, deps.notifyResourcesChanged);

--- a/src/server/deviceTools.ts
+++ b/src/server/deviceTools.ts
@@ -1621,10 +1621,7 @@ async function waitForPendingAndroidResetRecovery(
   timer: Timer,
   signal?: AbortSignal,
 ): Promise<void> {
-  const avdName = args.platform === "android"
-    ? budgets.androidAvdName ?? args.name
-    : undefined;
-  if (!avdName) {
+  if (args.platform !== "android") {
     return;
   }
   const devicePool = getStartDevicePool(DaemonState.getInstance());
@@ -1632,18 +1629,25 @@ async function waitForPendingAndroidResetRecovery(
     return;
   }
   const remainingMs = bootDeadlineMs - timer.now();
+  const requestedName = budgets.androidAvdName ?? args.name;
   if (remainingMs <= 0) {
-    throw new ActionableError(`Timed out waiting for Android AVD reset recovery of '${avdName}'`);
+    throw new ActionableError(
+      `Timed out waiting for Android AVD reset recovery${requestedName ? ` of '${requestedName}'` : ""}`,
+    );
   }
   let timeout: NodeJS.Timeout | undefined;
   const timeoutPromise = new Promise<never>((_resolve, reject) => {
     timeout = timer.setTimeout(() => {
-      reject(new ActionableError(`Timed out waiting for Android AVD reset recovery of '${avdName}'`));
+      reject(new ActionableError(
+        `Timed out waiting for Android AVD reset recovery${requestedName ? ` of '${requestedName}'` : ""}`,
+      ));
     }, remainingMs);
   });
   try {
     await Promise.race([
-      devicePool.waitForAdbServerResetRecovery(avdName, signal),
+      budgets.androidAvdName
+        ? devicePool.waitForAdbServerResetRecovery(budgets.androidAvdName, signal)
+        : devicePool.waitForAdbServerResetRecoveryMatchingName(args.name, signal),
       timeoutPromise,
     ]);
   } finally {

--- a/src/server/deviceTools.ts
+++ b/src/server/deviceTools.ts
@@ -1614,19 +1614,19 @@ function getStartDevicePool(daemonState: DaemonState): DevicePool | undefined {
   return daemonState.isInitialized() ? daemonState.getDevicePool() : undefined;
 }
 
-async function waitForPendingAndroidResetRecovery(
+async function reserveAndroidStartupLease(
   args: StartDeviceArgs,
   budgets: { androidAvdName?: string },
   bootDeadlineMs: number,
   timer: Timer,
   signal?: AbortSignal,
-): Promise<void> {
+): Promise<(() => Promise<void>) | undefined> {
   if (args.platform !== "android") {
-    return;
+    return undefined;
   }
   const devicePool = getStartDevicePool(DaemonState.getInstance());
   if (!devicePool) {
-    return;
+    return undefined;
   }
   const remainingMs = bootDeadlineMs - timer.now();
   const requestedName = budgets.androidAvdName ?? args.name;
@@ -1635,25 +1635,30 @@ async function waitForPendingAndroidResetRecovery(
       `Timed out waiting for Android AVD reset recovery${requestedName ? ` of '${requestedName}'` : ""}`,
     );
   }
-  let timeout: NodeJS.Timeout | undefined;
-  const timeoutPromise = new Promise<never>((_resolve, reject) => {
-    timeout = timer.setTimeout(() => {
-      reject(new ActionableError(
-        `Timed out waiting for Android AVD reset recovery${requestedName ? ` of '${requestedName}'` : ""}`,
-      ));
-    }, remainingMs);
-  });
+  const timeoutController = new AbortController();
+  const abortForTimeout = () => timeoutController.abort(
+    new ActionableError(
+      `Timed out waiting for Android AVD reset recovery${requestedName ? ` of '${requestedName}'` : ""}`,
+    ),
+  );
+  const abortForCaller = () => timeoutController.abort(
+    signal?.reason ?? new Error("Device preparation cancelled"),
+  );
+  if (signal?.aborted) {
+    abortForCaller();
+  } else {
+    signal?.addEventListener("abort", abortForCaller, { once: true });
+  }
+  const timeout = timer.setTimeout(abortForTimeout, remainingMs);
   try {
-    await Promise.race([
-      budgets.androidAvdName
-        ? devicePool.waitForAdbServerResetRecovery(budgets.androidAvdName, signal)
-        : devicePool.waitForAdbServerResetRecoveryMatchingName(args.name, signal),
-      timeoutPromise,
-    ]);
+    return await devicePool.reserveAndroidStartupLease(
+      requestedName,
+      budgets.androidAvdName !== undefined,
+      timeoutController.signal,
+    );
   } finally {
-    if (timeout) {
-      timer.clearTimeout(timeout);
-    }
+    timer.clearTimeout(timeout);
+    signal?.removeEventListener("abort", abortForCaller);
   }
 }
 
@@ -1792,9 +1797,16 @@ export function registerDeviceTools() {
     let preservedSessionId: string | undefined;
     let validatePreservedSession: (() => Promise<void>) | undefined;
     let retireRecoveredReplacement: (() => Promise<void>) | undefined;
+    let releaseAndroidStartupLease: (() => Promise<void>) | undefined;
 
     try {
-      await waitForPendingAndroidResetRecovery(args, budgets, bootDeadlineMs, deps.timer, signal);
+      releaseAndroidStartupLease = await reserveAndroidStartupLease(
+        args,
+        budgets,
+        bootDeadlineMs,
+        deps.timer,
+        signal,
+      );
       const bootService = new DeviceBootService({
         deviceManager: deviceUtils,
         deviceMatcher: deps.deviceMatcherFactory(),
@@ -1906,10 +1918,21 @@ export function registerDeviceTools() {
       }
       throw new ActionableError(`Failed to start ${args.platform} device: ${error}`);
     } finally {
-      for (const releaseReservation of releaseReadinessReservations.reverse()) {
-        await releaseReservation();
-      }
+      await releaseDevicePreparationReservations(
+        releaseReadinessReservations,
+        releaseAndroidStartupLease,
+      );
     }
+  };
+
+  const releaseDevicePreparationReservations = async (
+    readinessReservations: DeviceReadinessReservation[],
+    releaseAndroidStartupLease: (() => Promise<void>) | undefined,
+  ): Promise<void> => {
+    for (const releaseReservation of readinessReservations.reverse()) {
+      await releaseReservation();
+    }
+    await releaseAndroidStartupLease?.();
   };
 
   // Compatibility implementation. New callers use getAndroid/getApple so their

--- a/src/server/executionTracker.ts
+++ b/src/server/executionTracker.ts
@@ -145,6 +145,28 @@ export class ExecutionTracker {
     );
   }
 
+  /**
+   * Cancels both explicit and implicit work bound to a concrete device session.
+   * Implicit autolock calls are added to a separate index after routing resolves.
+   */
+  async cancelDeviceSessionExecutions(
+    sessionUuid: string,
+    reason: string = "unspecified",
+    options: ExecutionCancellationOptions = {},
+  ): Promise<number> {
+    const executionIds = new Set<string>([
+      ...(this.sessionUuidExecutions.get(sessionUuid) ?? []),
+      ...(this.autolockSessionExecutions.get(sessionUuid) ?? []),
+    ]);
+    return this.cancelExecutionIds(
+      executionIds,
+      "deviceSessionUuid",
+      sessionUuid,
+      reason,
+      options,
+    );
+  }
+
   hasActiveSessionUuidExecutions(sessionUuid: string, query?: ActiveExecutionQuery): boolean {
     return this.hasActiveExecutionsForKey(this.sessionUuidExecutions, sessionUuid, query);
   }
@@ -269,13 +291,28 @@ export class ExecutionTracker {
     cancelReason: string = "unspecified",
     options: ExecutionCancellationOptions = {},
   ): Promise<number> {
-    const executions = executionMap.get(key);
-    if (!executions || executions.size === 0) {
+    return this.cancelExecutionIds(
+      executionMap.get(key),
+      label,
+      key,
+      cancelReason,
+      options,
+    );
+  }
+
+  private async cancelExecutionIds(
+    executionIds: Iterable<string> | undefined,
+    label: "sessionId" | "sessionUuid" | "deviceSessionUuid",
+    key: string,
+    cancelReason: string = "unspecified",
+    options: ExecutionCancellationOptions = {},
+  ): Promise<number> {
+    if (!executionIds) {
       return 0;
     }
 
     let cancelled = 0;
-    for (const executionId of executions) {
+    for (const executionId of executionIds) {
       const execution = this.executions.get(executionId);
       if (!execution) {
         continue;

--- a/src/server/toolRegistry.ts
+++ b/src/server/toolRegistry.ts
@@ -604,7 +604,7 @@ class DefaultExecutionTargetResolver implements ExecutionTargetResolver {
 
     throw new ActionableError(
       "Device pool autolock is enabled and multiple devices are available. " +
-      "Call startDevice first from this MCP session, or provide the sessionId returned by 'startDevice' (or a deviceId) to target a specific device."
+      "Call getAndroid or getApple first from this MCP session, or provide the returned sessionId (or a deviceId) to target a specific device."
     );
   }
 }

--- a/src/utils/deviceBootService.ts
+++ b/src/utils/deviceBootService.ts
@@ -57,6 +57,8 @@ export interface DeviceBootRequest {
   createIfMissing?: boolean;
   /** Internal CI policy: preserve OS bounds for provisioning while matching its exact owned name across runtime fallback. */
   matchNamedDeviceIgnoringOsVersion?: boolean;
+  /** Internal identity policy: select a named runtime only when its name is an exact match. */
+  matchExactName?: boolean;
 }
 
 export interface DeviceBootProgress {
@@ -202,7 +204,9 @@ export class DeviceBootService {
     if (running) {
       return running;
     }
-    const image = deviceMatcher.matchDeviceImage(criteria, images, matchingStrategy);
+    const image = request.matchExactName && request.name
+      ? images.find(candidate => candidate.name === request.name) ?? null
+      : deviceMatcher.matchDeviceImage(criteria, images, matchingStrategy);
     if (image) {
       return this.bootMatchedImage(image, context, progress);
     }
@@ -225,11 +229,14 @@ export class DeviceBootService {
       () => this.dependencies.deviceManager.getBootedDevices(request.platform),
       false,
     );
-    const match = this.dependencies.deviceMatcher.matchBootedDevice(
-      criteria,
-      enrichBootedDevicesFromImages(booted, images),
-      this.dependencies.matchingStrategy,
-    );
+    const enriched = enrichBootedDevicesFromImages(booted, images);
+    const match = request.matchExactName && request.name
+      ? enriched.find(candidate => candidate.name === request.name) ?? null
+      : this.dependencies.deviceMatcher.matchBootedDevice(
+        criteria,
+        enriched,
+        this.dependencies.matchingStrategy,
+      );
     if (!match) {
       return undefined;
     }

--- a/test/daemon/adbServerResetDetection.test.ts
+++ b/test/daemon/adbServerResetDetection.test.ts
@@ -1,5 +1,8 @@
 import { describe, expect, test } from "bun:test";
-import { isProcessWideAdbServerReset } from "../../src/daemon/daemon";
+import {
+  getProcessWideAdbServerResetCohort,
+  isProcessWideAdbServerReset,
+} from "../../src/daemon/daemon";
 import type { PooledDevice } from "../../src/daemon/devicePool";
 
 function ownedAndroidEmulator(id: string): PooledDevice {
@@ -47,12 +50,14 @@ describe("ADB server reset detection", () => {
     expect(isProcessWideAdbServerReset(new Set(), new Set(["android"]), [physical])).toBe(false);
   });
 
-  test("detects the reset before an individual forced disconnect bypasses miss counting", () => {
+  test("returns every absent owned emulator for recovery even when miss counting only forces one", () => {
     const first = ownedAndroidEmulator("emulator-5554");
     const second = ownedAndroidEmulator("emulator-5556");
 
-    expect(
-      isProcessWideAdbServerReset(new Set(), new Set(["android"]), [first, second]),
-    ).toBe(true);
+    expect(getProcessWideAdbServerResetCohort(
+      new Set(),
+      new Set(["android"]),
+      [first, second],
+    )).toEqual([first, second]);
   });
 });

--- a/test/daemon/adbServerResetDetection.test.ts
+++ b/test/daemon/adbServerResetDetection.test.ts
@@ -28,8 +28,12 @@ describe("ADB server reset detection", () => {
     const first = ownedAndroidEmulator("emulator-5554");
     const second = ownedAndroidEmulator("emulator-5556");
 
-    expect(isProcessWideAdbServerReset(new Set([first.id, second.id]), [first, second])).toBe(true);
-    expect(isProcessWideAdbServerReset(new Set([first.id]), [first, second])).toBe(false);
+    expect(
+      isProcessWideAdbServerReset(new Set(), new Set(["android"]), [first, second]),
+    ).toBe(true);
+    expect(
+      isProcessWideAdbServerReset(new Set([first.id]), new Set(["android"]), [first, second]),
+    ).toBe(false);
   });
 
   test("does not infer an ADB reset from physical Android devices", () => {
@@ -40,6 +44,15 @@ describe("ADB server reset detection", () => {
       androidImage: undefined,
     };
 
-    expect(isProcessWideAdbServerReset(new Set([physical.id]), [physical])).toBe(false);
+    expect(isProcessWideAdbServerReset(new Set(), new Set(["android"]), [physical])).toBe(false);
+  });
+
+  test("detects the reset before an individual forced disconnect bypasses miss counting", () => {
+    const first = ownedAndroidEmulator("emulator-5554");
+    const second = ownedAndroidEmulator("emulator-5556");
+
+    expect(
+      isProcessWideAdbServerReset(new Set(), new Set(["android"]), [first, second]),
+    ).toBe(true);
   });
 });

--- a/test/daemon/adbServerResetDetection.test.ts
+++ b/test/daemon/adbServerResetDetection.test.ts
@@ -32,10 +32,20 @@ describe("ADB server reset detection", () => {
     const second = ownedAndroidEmulator("emulator-5556");
 
     expect(
-      isProcessWideAdbServerReset(new Set(), new Set(["android"]), [first, second]),
+      isProcessWideAdbServerReset(
+        new Set(),
+        new Set(["android"]),
+        new Set([first.id]),
+        [first, second],
+      ),
     ).toBe(true);
     expect(
-      isProcessWideAdbServerReset(new Set([first.id]), new Set(["android"]), [first, second]),
+      isProcessWideAdbServerReset(
+        new Set([first.id]),
+        new Set(["android"]),
+        new Set([first.id]),
+        [first, second],
+      ),
     ).toBe(false);
   });
 
@@ -47,16 +57,25 @@ describe("ADB server reset detection", () => {
       androidImage: undefined,
     };
 
-    expect(isProcessWideAdbServerReset(new Set(), new Set(["android"]), [physical])).toBe(false);
+    expect(
+      isProcessWideAdbServerReset(new Set(), new Set(["android"]), new Set([physical.id]), [physical]),
+    ).toBe(false);
   });
 
-  test("returns every absent owned emulator for recovery even when miss counting only forces one", () => {
+  test("requires an ADB missing-device event before returning the reset cohort", () => {
     const first = ownedAndroidEmulator("emulator-5554");
     const second = ownedAndroidEmulator("emulator-5556");
 
     expect(getProcessWideAdbServerResetCohort(
       new Set(),
       new Set(["android"]),
+      new Set(),
+      [first, second],
+    )).toEqual([]);
+    expect(getProcessWideAdbServerResetCohort(
+      new Set(),
+      new Set(["android"]),
+      new Set([first.id]),
       [first, second],
     )).toEqual([first, second]);
   });

--- a/test/daemon/adbServerResetRecovery.test.ts
+++ b/test/daemon/adbServerResetRecovery.test.ts
@@ -270,6 +270,140 @@ describe("ADB server reset session recovery", () => {
     }
   });
 
+  test("rebinds the preserved session before accepting a same-AVD replacement", async () => {
+    const timer = new FakeTimer();
+    const sessionManager = new SessionManager(timer, new FakeDeviceSessionPersistence());
+    const manager = new FakeDeviceManager();
+    const pool = new DevicePool(
+      sessionManager,
+      "daemon-session",
+      timer,
+      new FakeInstalledAppsRepository(),
+      manager,
+      new DefaultRetryExecutor(timer),
+    );
+    const original: BootedDevice = {
+      platform: "android",
+      name: "Pixel_8_API_35",
+      deviceId: "emulator-5554",
+    };
+    const image: DeviceInfo = {
+      name: original.name,
+      platform: "android",
+      isRunning: true,
+      source: "local",
+    };
+    manager.bootedDevices = [original];
+    await pool.addDevice(original, image);
+    await pool.bindOrReuseDeviceSession("session-1", original.deviceId, "android", image);
+    const detached = await pool.detachAdbServerResetCohort([pool.getDevice(original.deviceId)!]);
+
+    try {
+      await pool.addDevice(original, image);
+
+      await expect(
+        pool.recoverSessionBoundAndroidDeviceAfterAdbServerReset(original.deviceId, detached[0]),
+      ).resolves.toBe(true);
+
+      expect(manager.startedDevices).toHaveLength(0);
+      expect(pool.getDevice(original.deviceId)).toMatchObject({
+        avdName: original.name,
+        sessionId: "session-1",
+        status: "busy",
+      });
+      expect(sessionManager.getSession("session-1")?.assignedDevice).toBe(original.deviceId);
+    } finally {
+      await pool.releaseAdbServerResetCohortReservations(detached);
+      sessionManager.stopCleanupTimer();
+    }
+  });
+
+  test("cancels a detached reset member and releases its preserved session", async () => {
+    const timer = new FakeTimer();
+    const sessionManager = new SessionManager(timer, new FakeDeviceSessionPersistence());
+    const manager = new FakeDeviceManager();
+    const releasedSessionIds: string[] = [];
+    const pool = new DevicePool(
+      sessionManager,
+      "daemon-session",
+      timer,
+      new FakeInstalledAppsRepository(),
+      manager,
+      new DefaultRetryExecutor(timer),
+      undefined,
+      undefined,
+      async (sessionId) => {
+        releasedSessionIds.push(sessionId);
+      },
+    );
+    const original: BootedDevice = {
+      platform: "android",
+      name: "Pixel_8_API_35",
+      deviceId: "emulator-5554",
+    };
+    const image: DeviceInfo = {
+      name: original.name,
+      platform: "android",
+      isRunning: true,
+      source: "local",
+    };
+    manager.bootedDevices = [original];
+    await pool.addDevice(original, image);
+    await pool.bindOrReuseDeviceSession("session-1", original.deviceId, "android", image);
+    const detached = await pool.detachAdbServerResetCohort([pool.getDevice(original.deviceId)!]);
+
+    try {
+      pool.markIntentionalShutdown(original.deviceId);
+
+      await expect(
+        pool.recoverSessionBoundAndroidDeviceAfterAdbServerReset(original.deviceId, detached[0]),
+      ).resolves.toBe(false);
+
+      expect(manager.startedDevices).toHaveLength(0);
+      expect(releasedSessionIds).toEqual(["session-1"]);
+    } finally {
+      await pool.releaseAdbServerResetCohortReservations(detached);
+      sessionManager.stopCleanupTimer();
+    }
+  });
+
+  test("cancels reset reservation waits when the caller aborts", async () => {
+    const timer = new FakeTimer();
+    const sessionManager = new SessionManager(timer, new FakeDeviceSessionPersistence());
+    const manager = new FakeDeviceManager();
+    const pool = new DevicePool(
+      sessionManager,
+      "daemon-session",
+      timer,
+      new FakeInstalledAppsRepository(),
+      manager,
+      new DefaultRetryExecutor(timer),
+    );
+    const original: BootedDevice = {
+      platform: "android",
+      name: "Pixel_8_API_35",
+      deviceId: "emulator-5554",
+    };
+    const image: DeviceInfo = {
+      name: original.name,
+      platform: "android",
+      isRunning: true,
+      source: "local",
+    };
+    await pool.addDevice(original, image);
+    const detached = await pool.detachAdbServerResetCohort([pool.getDevice(original.deviceId)!]);
+    const controller = new AbortController();
+
+    try {
+      const waiting = pool.waitForAdbServerResetRecovery(original.name, controller.signal);
+      controller.abort(new Error("request cancelled"));
+      await expect(waiting).rejects.toThrow("request cancelled");
+    } finally {
+      await pool.releaseAdbServerResetCohortReservations(detached);
+      sessionManager.stopCleanupTimer();
+    }
+  });
+
   test("releases the preserved session when reboot rejects after detaching the old serial", async () => {
     const timer = new FakeTimer();
     const sessionManager = new SessionManager(timer, new FakeDeviceSessionPersistence());

--- a/test/daemon/adbServerResetRecovery.test.ts
+++ b/test/daemon/adbServerResetRecovery.test.ts
@@ -4,6 +4,7 @@ import { DevicePool } from "../../src/daemon/devicePool";
 import { SessionManager } from "../../src/daemon/sessionManager";
 import type { BootedDevice, DeviceInfo } from "../../src/models";
 import { DefaultRetryExecutor } from "../../src/utils/retry/RetryExecutor";
+import type { AndroidDeviceReboot } from "../../src/utils/androidDeviceReboot";
 import { FakeDeviceManager } from "../fakes/FakeDeviceManager";
 import { FakeDeviceSessionPersistence } from "../fakes/FakeDeviceSessionPersistence";
 import { FakeInstalledAppsRepository } from "../fakes/FakeInstalledAppsRepository";
@@ -119,6 +120,65 @@ describe("ADB server reset session recovery", () => {
         pool.recoverSessionBoundAndroidDeviceAfterAdbServerReset(device.deviceId),
       ).resolves.toBe(false);
       expect(sessionManager.getSession("session-1")?.assignedDevice).toBe(device.deviceId);
+    } finally {
+      sessionManager.stopCleanupTimer();
+    }
+  });
+
+  test("releases the preserved session when recovery exhausts after detaching the old serial", async () => {
+    const timer = new FakeTimer();
+    const sessionManager = new SessionManager(timer, new FakeDeviceSessionPersistence());
+    const manager = new FakeDeviceManager();
+    const releasedSessionIds: string[] = [];
+    const reboot: AndroidDeviceReboot = {
+      run: async (_target, attempt) => {
+        try {
+          await attempt();
+        } catch {
+          // Exercise the exhausted-retry result after the pool removed the old serial.
+        }
+        return false;
+      },
+    };
+    const pool = new DevicePool(
+      sessionManager,
+      "daemon-session",
+      timer,
+      new FakeInstalledAppsRepository(),
+      manager,
+      new DefaultRetryExecutor(timer),
+      undefined,
+      undefined,
+      async (sessionId) => {
+        releasedSessionIds.push(sessionId);
+      },
+      undefined,
+      reboot,
+    );
+    const original: BootedDevice = {
+      platform: "android",
+      name: "Pixel_8_API_35",
+      deviceId: "emulator-5554",
+    };
+    const image: DeviceInfo = {
+      name: original.name,
+      platform: "android",
+      isRunning: true,
+      source: "local",
+    };
+    manager.bootedDevices = [original];
+    await pool.addDevice(original, image);
+    await pool.bindOrReuseDeviceSession("session-1", original.deviceId, "android", image);
+    manager.startDevice = async () => {
+      throw new Error("emulator launch failed");
+    };
+
+    try {
+      await expect(
+        pool.recoverSessionBoundAndroidDeviceAfterAdbServerReset(original.deviceId),
+      ).resolves.toBe(false);
+      expect(pool.getDevice(original.deviceId)).toBeNull();
+      expect(releasedSessionIds).toEqual(["session-1"]);
     } finally {
       sessionManager.stopCleanupTimer();
     }

--- a/test/daemon/adbServerResetRecovery.test.ts
+++ b/test/daemon/adbServerResetRecovery.test.ts
@@ -188,6 +188,47 @@ describe("ADB server reset session recovery", () => {
     }
   });
 
+  test("does not detach an AVD while named startup holds its reset lease", async () => {
+    const timer = new FakeTimer();
+    const sessionManager = new SessionManager(timer, new FakeDeviceSessionPersistence());
+    const manager = new FakeDeviceManager();
+    const pool = new DevicePool(
+      sessionManager,
+      "daemon-session",
+      timer,
+      new FakeInstalledAppsRepository(),
+      manager,
+      new DefaultRetryExecutor(timer),
+    );
+    const device: BootedDevice = {
+      platform: "android",
+      name: "Pixel_8_API_35",
+      deviceId: "emulator-5554",
+    };
+    const image: DeviceInfo = {
+      name: device.name,
+      platform: "android",
+      isRunning: true,
+      source: "local",
+    };
+    await pool.addDevice(device, image);
+    const releaseStartupLease = await pool.reserveAndroidStartupLease(device.name, true);
+
+    try {
+      expect(
+        await pool.detachAdbServerResetCohort([pool.getDevice(device.deviceId)!]),
+      ).toEqual([]);
+
+      await releaseStartupLease();
+      const detached = await pool.detachAdbServerResetCohort([pool.getDevice(device.deviceId)!]);
+      expect(detached).toHaveLength(1);
+      await pool.releaseAdbServerResetCohortReservations(detached);
+    } finally {
+      await releaseStartupLease();
+      sessionManager.stopCleanupTimer();
+    }
+  });
+
   test("recovers both captured AVDs when the first reuses the second serial", async () => {
     class SwappedSerialDeviceManager extends FakeDeviceManager {
       override async startDevice(device: DeviceInfo): Promise<ChildProcess> {
@@ -425,6 +466,108 @@ describe("ADB server reset session recovery", () => {
       expect(killCount).toBe(1);
     } finally {
       await pool.releaseAdbServerResetCohortReservations(detached);
+      sessionManager.stopCleanupTimer();
+    }
+  });
+
+  test("terminates a tracked idle reset-cohort emulator before detaching it", async () => {
+    const timer = new FakeTimer();
+    const sessionManager = new SessionManager(timer, new FakeDeviceSessionPersistence());
+    const manager = new FakeDeviceManager();
+    const pool = new DevicePool(
+      sessionManager,
+      "daemon-session",
+      timer,
+      new FakeInstalledAppsRepository(),
+      manager,
+      new DefaultRetryExecutor(timer),
+    );
+    const original: BootedDevice = {
+      platform: "android",
+      name: "Pixel_8_API_35",
+      deviceId: "emulator-5554",
+    };
+    const image: DeviceInfo = {
+      name: original.name,
+      platform: "android",
+      isRunning: true,
+      source: "local",
+    };
+    let killCount = 0;
+    const childProcess = {
+      pid: 123,
+      kill: () => {
+        killCount++;
+        return true;
+      },
+      once: () => childProcess,
+    } as ChildProcess;
+    manager.bootedDevices = [original];
+    await pool.addDevice(original, image);
+    await pool.bindOrReuseDeviceSession(
+      "session-1",
+      original.deviceId,
+      "android",
+      image,
+      childProcess,
+      original,
+    );
+    await pool.releaseDevice(original.deviceId, "session-1");
+
+    try {
+      const detached = await pool.detachAdbServerResetCohort([pool.getDevice(original.deviceId)!]);
+
+      expect(detached).toHaveLength(1);
+      expect(killCount).toBe(1);
+      await pool.releaseAdbServerResetCohortReservations(detached);
+    } finally {
+      sessionManager.stopCleanupTimer();
+    }
+  });
+
+  test("does not recreate an absent preserved session for a recovery replacement", async () => {
+    const timer = new FakeTimer();
+    const sessionManager = new SessionManager(timer, new FakeDeviceSessionPersistence());
+    const manager = new FakeDeviceManager();
+    const pool = new DevicePool(
+      sessionManager,
+      "daemon-session",
+      timer,
+      new FakeInstalledAppsRepository(),
+      manager,
+      new DefaultRetryExecutor(timer),
+    );
+    const replacement: BootedDevice = {
+      platform: "android",
+      name: "Pixel_8_API_35",
+      deviceId: "emulator-5560",
+    };
+    const image: DeviceInfo = {
+      name: replacement.name,
+      platform: "android",
+      isRunning: true,
+      source: "local",
+    };
+    manager.bootedDevices = [replacement];
+    await pool.addDevice(replacement, image);
+
+    try {
+      await expect(
+        pool.bindOrReuseDeviceSession(
+          "session-1",
+          replacement.deviceId,
+          "android",
+          image,
+          undefined,
+          replacement,
+          true,
+          undefined,
+          undefined,
+          "emulator-5554",
+        ),
+      ).rejects.toThrow(/changed while device .* was recovering/);
+      expect(sessionManager.getSession("session-1")).toBeNull();
+    } finally {
       sessionManager.stopCleanupTimer();
     }
   });

--- a/test/daemon/adbServerResetRecovery.test.ts
+++ b/test/daemon/adbServerResetRecovery.test.ts
@@ -315,6 +315,63 @@ describe("ADB server reset session recovery", () => {
     }
   });
 
+  test("cancels cohort session executions before detaching reusable serials", async () => {
+    const timer = new FakeTimer();
+    const sessionManager = new SessionManager(timer, new FakeDeviceSessionPersistence());
+    const manager = new FakeDeviceManager();
+    const cancellations: Array<{ sessionId: string; deviceStillPooled: boolean }> = [];
+    const pool = new DevicePool(
+      sessionManager,
+      "daemon-session",
+      timer,
+      new FakeInstalledAppsRepository(),
+      manager,
+      new DefaultRetryExecutor(timer),
+      undefined,
+      undefined,
+      undefined,
+      undefined,
+      undefined,
+      undefined,
+      undefined,
+      undefined,
+      async sessionId => {
+        cancellations.push({
+          sessionId,
+          deviceStillPooled: pool.getDevice("emulator-5554") !== null,
+        });
+        return 1;
+      },
+    );
+    const device: BootedDevice = {
+      platform: "android",
+      name: "Pixel_8_API_35",
+      deviceId: "emulator-5554",
+    };
+    const image: DeviceInfo = {
+      name: device.name,
+      platform: "android",
+      isRunning: true,
+      source: "local",
+    };
+    manager.bootedDevices = [device];
+    await pool.addDevice(device, image);
+    await pool.bindOrReuseDeviceSession("session-active", device.deviceId, "android", image);
+
+    try {
+      const detached = await pool.detachAdbServerResetCohort([pool.getDevice(device.deviceId)!]);
+
+      expect(cancellations).toEqual([{
+        sessionId: "session-active",
+        deviceStillPooled: true,
+      }]);
+      expect(detached.devices).toHaveLength(1);
+      await pool.releaseAdbServerResetCohortReservations(detached.devices);
+    } finally {
+      sessionManager.stopCleanupTimer();
+    }
+  });
+
   test("recovers both captured AVDs when the first reuses the second serial", async () => {
     class SwappedSerialDeviceManager extends FakeDeviceManager {
       override async startDevice(device: DeviceInfo): Promise<ChildProcess> {

--- a/test/daemon/adbServerResetRecovery.test.ts
+++ b/test/daemon/adbServerResetRecovery.test.ts
@@ -166,7 +166,7 @@ describe("ADB server reset session recovery", () => {
     try {
       const detached = await pool.detachAdbServerResetCohort(cohort);
 
-      expect(detached).toEqual(cohort);
+      expect(detached).toEqual({ devices: cohort, deferred: false });
       expect(pool.getDevice(devices[0].deviceId)).toBeNull();
       expect(pool.getDevice(devices[1].deviceId)).toBeNull();
       expect(pool.getDevice(devices[2].deviceId)).toBeNull();
@@ -180,7 +180,7 @@ describe("ADB server reset session recovery", () => {
         });
       await Promise.resolve();
       expect(idleReservationSettled).toBe(false);
-      await pool.releaseAdbServerResetCohortReservations(detached);
+      await pool.releaseAdbServerResetCohortReservations(detached.devices);
       await idleReservation;
       expect(idleReservationSettled).toBe(true);
     } finally {
@@ -188,7 +188,7 @@ describe("ADB server reset session recovery", () => {
     }
   });
 
-  test("does not detach an AVD while named startup holds its reset lease", async () => {
+  test("defers the entire reset cohort while named startup holds a matching lease", async () => {
     const timer = new FakeTimer();
     const sessionManager = new SessionManager(timer, new FakeDeviceSessionPersistence());
     const manager = new FakeDeviceManager();
@@ -200,29 +200,43 @@ describe("ADB server reset session recovery", () => {
       manager,
       new DefaultRetryExecutor(timer),
     );
-    const device: BootedDevice = {
-      platform: "android",
-      name: "Pixel_8_API_35",
-      deviceId: "emulator-5554",
-    };
-    const image: DeviceInfo = {
-      name: device.name,
-      platform: "android",
-      isRunning: true,
-      source: "local",
-    };
-    await pool.addDevice(device, image);
-    const releaseStartupLease = await pool.reserveAndroidStartupLease(device.name, true);
+    const devices: BootedDevice[] = [
+      {
+        platform: "android",
+        name: "Pixel_8_API_35",
+        deviceId: "emulator-5554",
+      },
+      {
+        platform: "android",
+        name: "Pixel_9_API_36",
+        deviceId: "emulator-5556",
+      },
+    ];
+    for (const device of devices) {
+      await pool.addDevice(device, {
+        name: device.name,
+        platform: "android",
+        isRunning: true,
+        source: "local",
+      });
+    }
+    const releaseStartupLease = await pool.reserveAndroidStartupLease(devices[0].name, true);
 
     try {
-      expect(
-        await pool.detachAdbServerResetCohort([pool.getDevice(device.deviceId)!]),
-      ).toEqual([]);
+      const deferred = await pool.detachAdbServerResetCohort(
+        devices.map(device => pool.getDevice(device.deviceId)!),
+      );
+      expect(deferred).toEqual({ devices: [], deferred: true });
+      expect(pool.getDevice(devices[0].deviceId)).not.toBeNull();
+      expect(pool.getDevice(devices[1].deviceId)).not.toBeNull();
 
       await releaseStartupLease();
-      const detached = await pool.detachAdbServerResetCohort([pool.getDevice(device.deviceId)!]);
-      expect(detached).toHaveLength(1);
-      await pool.releaseAdbServerResetCohortReservations(detached);
+      const detached = await pool.detachAdbServerResetCohort(
+        devices.map(device => pool.getDevice(device.deviceId)!),
+      );
+      expect(detached).toMatchObject({ deferred: false });
+      expect(detached.devices).toHaveLength(2);
+      await pool.releaseAdbServerResetCohortReservations(detached.devices);
     } finally {
       await releaseStartupLease();
       sessionManager.stopCleanupTimer();
@@ -289,13 +303,13 @@ describe("ADB server reset session recovery", () => {
       await expect(
         pool.recoverSessionBoundAndroidDeviceAfterAdbServerReset(
           originals[0].deviceId,
-          detached[0],
+          detached.devices[0],
         ),
       ).resolves.toBe(true);
       await expect(
         pool.recoverSessionBoundAndroidDeviceAfterAdbServerReset(
           originals[1].deviceId,
-          detached[1],
+          detached.devices[1],
         ),
       ).resolves.toBe(true);
 
@@ -312,7 +326,7 @@ describe("ADB server reset session recovery", () => {
         sessionId: "session-1",
       });
     } finally {
-      await pool.releaseAdbServerResetCohortReservations(detached);
+      await pool.releaseAdbServerResetCohortReservations(detached.devices);
       sessionManager.stopCleanupTimer();
     }
   });
@@ -349,7 +363,10 @@ describe("ADB server reset session recovery", () => {
       await pool.addDevice(original, image);
 
       await expect(
-        pool.recoverSessionBoundAndroidDeviceAfterAdbServerReset(original.deviceId, detached[0]),
+        pool.recoverSessionBoundAndroidDeviceAfterAdbServerReset(
+          original.deviceId,
+          detached.devices[0],
+        ),
       ).resolves.toBe(true);
 
       expect(manager.startedDevices).toHaveLength(0);
@@ -360,7 +377,64 @@ describe("ADB server reset session recovery", () => {
       });
       expect(sessionManager.getSession("session-1")?.assignedDevice).toBe(original.deviceId);
     } finally {
-      await pool.releaseAdbServerResetCohortReservations(detached);
+      await pool.releaseAdbServerResetCohortReservations(detached.devices);
+      sessionManager.stopCleanupTimer();
+    }
+  });
+
+  test("does not overwrite a same-AVD replacement owned by another session", async () => {
+    const timer = new FakeTimer();
+    const sessionManager = new SessionManager(timer, new FakeDeviceSessionPersistence());
+    const manager = new FakeDeviceManager();
+    const pool = new DevicePool(
+      sessionManager,
+      "daemon-session",
+      timer,
+      new FakeInstalledAppsRepository(),
+      manager,
+      new DefaultRetryExecutor(timer),
+    );
+    const original: BootedDevice = {
+      platform: "android",
+      name: "Pixel_8_API_35",
+      deviceId: "emulator-5554",
+    };
+    const image: DeviceInfo = {
+      name: original.name,
+      platform: "android",
+      isRunning: true,
+      source: "local",
+    };
+    manager.bootedDevices = [original];
+    await pool.addDevice(original, image);
+    await pool.bindOrReuseDeviceSession("session-1", original.deviceId, "android", image);
+    const detached = await pool.detachAdbServerResetCohort([pool.getDevice(original.deviceId)!]);
+    await pool.addDevice(original, image);
+    await sessionManager.createSession("session-2", original.deviceId, "android");
+    await pool.bindOrReuseDeviceSession("session-2", original.deviceId, "android");
+    const replacement = pool.getDevice(original.deviceId);
+    if (!replacement) {
+      throw new Error("expected same-AVD replacement");
+    }
+    replacement.autolockSessionId = "session-2";
+
+    try {
+      await expect(
+        pool.recoverSessionBoundAndroidDeviceAfterAdbServerReset(
+          original.deviceId,
+          detached.devices[0],
+        ),
+      ).resolves.toBe(false);
+
+      expect(manager.startedDevices).toHaveLength(0);
+      expect(pool.getDevice(original.deviceId)).toMatchObject({
+        avdName: original.name,
+        sessionId: "session-2",
+        autolockSessionId: "session-2",
+      });
+      expect(sessionManager.getSession("session-2")?.assignedDevice).toBe(original.deviceId);
+    } finally {
+      await pool.releaseAdbServerResetCohortReservations(detached.devices);
       sessionManager.stopCleanupTimer();
     }
   });
@@ -403,13 +477,16 @@ describe("ADB server reset session recovery", () => {
       pool.markIntentionalShutdown(original.deviceId);
 
       await expect(
-        pool.recoverSessionBoundAndroidDeviceAfterAdbServerReset(original.deviceId, detached[0]),
+        pool.recoverSessionBoundAndroidDeviceAfterAdbServerReset(
+          original.deviceId,
+          detached.devices[0],
+        ),
       ).resolves.toBe(false);
 
       expect(manager.startedDevices).toHaveLength(0);
       expect(releasedSessionIds).toEqual(["session-1"]);
     } finally {
-      await pool.releaseAdbServerResetCohortReservations(detached);
+      await pool.releaseAdbServerResetCohortReservations(detached.devices);
       sessionManager.stopCleanupTimer();
     }
   });
@@ -460,12 +537,15 @@ describe("ADB server reset session recovery", () => {
 
     try {
       await expect(
-        pool.recoverSessionBoundAndroidDeviceAfterAdbServerReset(original.deviceId, detached[0]),
+        pool.recoverSessionBoundAndroidDeviceAfterAdbServerReset(
+          original.deviceId,
+          detached.devices[0],
+        ),
       ).resolves.toBe(true);
 
       expect(killCount).toBe(1);
     } finally {
-      await pool.releaseAdbServerResetCohortReservations(detached);
+      await pool.releaseAdbServerResetCohortReservations(detached.devices);
       sessionManager.stopCleanupTimer();
     }
   });
@@ -517,9 +597,9 @@ describe("ADB server reset session recovery", () => {
     try {
       const detached = await pool.detachAdbServerResetCohort([pool.getDevice(original.deviceId)!]);
 
-      expect(detached).toHaveLength(1);
+      expect(detached.devices).toHaveLength(1);
       expect(killCount).toBe(1);
-      await pool.releaseAdbServerResetCohortReservations(detached);
+      await pool.releaseAdbServerResetCohortReservations(detached.devices);
     } finally {
       sessionManager.stopCleanupTimer();
     }
@@ -621,18 +701,17 @@ describe("ADB server reset session recovery", () => {
     );
 
     try {
-      pool.markIntentionalShutdown(originals[1].deviceId);
-
       await expect(
         pool.recoverSessionBoundAndroidDeviceAfterAdbServerReset(
           originals[0].deviceId,
-          detached[0],
+          detached.devices[0],
         ),
       ).resolves.toBe(true);
+      pool.markIntentionalShutdown(originals[1].deviceId);
       await expect(
         pool.recoverSessionBoundAndroidDeviceAfterAdbServerReset(
           originals[1].deviceId,
-          detached[1],
+          detached.devices[1],
         ),
       ).resolves.toBe(false);
 
@@ -642,7 +721,7 @@ describe("ADB server reset session recovery", () => {
         sessionId: "session-0",
       });
     } finally {
-      await pool.releaseAdbServerResetCohortReservations(detached);
+      await pool.releaseAdbServerResetCohortReservations(detached.devices);
       sessionManager.stopCleanupTimer();
     }
   });
@@ -679,7 +758,7 @@ describe("ADB server reset session recovery", () => {
       controller.abort(new Error("request cancelled"));
       await expect(waiting).rejects.toThrow("request cancelled");
     } finally {
-      await pool.releaseAdbServerResetCohortReservations(detached);
+      await pool.releaseAdbServerResetCohortReservations(detached.devices);
       sessionManager.stopCleanupTimer();
     }
   });

--- a/test/daemon/adbServerResetRecovery.test.ts
+++ b/test/daemon/adbServerResetRecovery.test.ts
@@ -243,6 +243,78 @@ describe("ADB server reset session recovery", () => {
     }
   });
 
+  test("does not partially detach a cohort when an idle tracked process cannot stop", async () => {
+    const timer = new FakeTimer();
+    const sessionManager = new SessionManager(timer, new FakeDeviceSessionPersistence());
+    const manager = new FakeDeviceManager();
+    const pool = new DevicePool(
+      sessionManager,
+      "daemon-session",
+      timer,
+      new FakeInstalledAppsRepository(),
+      manager,
+      new DefaultRetryExecutor(timer),
+    );
+    const active: BootedDevice = {
+      platform: "android",
+      name: "Pixel_8_API_35",
+      deviceId: "emulator-5554",
+    };
+    const idle: BootedDevice = {
+      platform: "android",
+      name: "Pixel_9_API_36",
+      deviceId: "emulator-5556",
+    };
+    const image = (device: BootedDevice): DeviceInfo => ({
+      name: device.name,
+      platform: "android",
+      isRunning: true,
+      source: "local",
+    });
+    manager.bootedDevices = [active, idle];
+    await pool.addDevice(active, image(active));
+    await pool.addDevice(idle, image(idle));
+    await pool.bindOrReuseDeviceSession("session-active", active.deviceId, "android", image(active));
+    const childProcess = {
+      pid: 123,
+      kill: () => {
+        throw new Error("process did not stop");
+      },
+      once: () => childProcess,
+    } as ChildProcess;
+    await pool.bindOrReuseDeviceSession(
+      "session-idle",
+      idle.deviceId,
+      "android",
+      image(idle),
+      childProcess,
+      idle,
+    );
+    await pool.releaseDevice(idle.deviceId, "session-idle");
+
+    try {
+      await expect(
+        pool.detachAdbServerResetCohort([
+          pool.getDevice(active.deviceId)!,
+          pool.getDevice(idle.deviceId)!,
+        ]),
+      ).rejects.toThrow("process did not stop");
+
+      expect(pool.getDevice(active.deviceId)).toMatchObject({
+        sessionId: "session-active",
+        status: "busy",
+      });
+      expect(pool.getDevice(idle.deviceId)).toMatchObject({
+        sessionId: null,
+        status: "idle",
+      });
+      expect(sessionManager.getSession("session-active")?.assignedDevice).toBe(active.deviceId);
+      await expect(pool.waitForAdbServerResetRecovery(active.name)).resolves.toBeUndefined();
+    } finally {
+      sessionManager.stopCleanupTimer();
+    }
+  });
+
   test("recovers both captured AVDs when the first reuses the second serial", async () => {
     class SwappedSerialDeviceManager extends FakeDeviceManager {
       override async startDevice(device: DeviceInfo): Promise<ChildProcess> {

--- a/test/daemon/adbServerResetRecovery.test.ts
+++ b/test/daemon/adbServerResetRecovery.test.ts
@@ -125,7 +125,7 @@ describe("ADB server reset session recovery", () => {
     }
   });
 
-  test("detaches every reset-cohort serial while retaining its session mapping", async () => {
+  test("detaches every reset-cohort serial while retaining bound session mappings", async () => {
     const timer = new FakeTimer();
     const sessionManager = new SessionManager(timer, new FakeDeviceSessionPersistence());
     const manager = new FakeDeviceManager();
@@ -140,6 +140,7 @@ describe("ADB server reset session recovery", () => {
     const devices: BootedDevice[] = [
       { platform: "android", name: "Pixel_8_API_35", deviceId: "emulator-5554" },
       { platform: "android", name: "Pixel_9_API_36", deviceId: "emulator-5556" },
+      { platform: "android", name: "Pixel_9_Pro_API_36", deviceId: "emulator-5558" },
     ];
     manager.bootedDevices = devices;
     for (const [index, device] of devices.entries()) {
@@ -150,7 +151,9 @@ describe("ADB server reset session recovery", () => {
         source: "local",
       };
       await pool.addDevice(device, image);
-      await pool.bindOrReuseDeviceSession(`session-${index}`, device.deviceId, "android", image);
+      if (index < 2) {
+        await pool.bindOrReuseDeviceSession(`session-${index}`, device.deviceId, "android", image);
+      }
     }
     const cohort = devices.map(device => pool.getDevice(device.deviceId)!);
 
@@ -160,8 +163,20 @@ describe("ADB server reset session recovery", () => {
       expect(detached).toEqual(cohort);
       expect(pool.getDevice(devices[0].deviceId)).toBeNull();
       expect(pool.getDevice(devices[1].deviceId)).toBeNull();
+      expect(pool.getDevice(devices[2].deviceId)).toBeNull();
       expect(sessionManager.getSession("session-0")?.assignedDevice).toBe(devices[0].deviceId);
       expect(sessionManager.getSession("session-1")?.assignedDevice).toBe(devices[1].deviceId);
+      let idleReservationSettled = false;
+      const idleReservation = pool
+        .waitForAdbServerResetRecovery(devices[2].name)
+        .then(() => {
+          idleReservationSettled = true;
+        });
+      await Promise.resolve();
+      expect(idleReservationSettled).toBe(false);
+      await pool.releaseAdbServerResetCohortReservations(detached);
+      await idleReservation;
+      expect(idleReservationSettled).toBe(true);
     } finally {
       sessionManager.stopCleanupTimer();
     }

--- a/test/daemon/adbServerResetRecovery.test.ts
+++ b/test/daemon/adbServerResetRecovery.test.ts
@@ -71,6 +71,11 @@ describe("ADB server reset session recovery", () => {
       undefined,
       original,
     );
+    const captured = pool.getDevice(original.deviceId);
+    if (!captured) {
+      throw new Error("expected captured device");
+    }
+    captured.autolockSessionId = "session-1";
 
     try {
       await expect(
@@ -87,6 +92,7 @@ describe("ADB server reset session recovery", () => {
         avdName: "Pixel_8_API_35",
         sessionId: "session-1",
         status: "busy",
+        autolockSessionId: "session-1",
       });
       expect(sessionManager.getSession("session-1")?.assignedDevice).toBe("emulator-5560");
     } finally {
@@ -361,6 +367,137 @@ describe("ADB server reset session recovery", () => {
 
       expect(manager.startedDevices).toHaveLength(0);
       expect(releasedSessionIds).toEqual(["session-1"]);
+    } finally {
+      await pool.releaseAdbServerResetCohortReservations(detached);
+      sessionManager.stopCleanupTimer();
+    }
+  });
+
+  test("stops the process retained from a detached reset cohort member", async () => {
+    const timer = new FakeTimer();
+    const sessionManager = new SessionManager(timer, new FakeDeviceSessionPersistence());
+    const manager = new FakeDeviceManager();
+    const pool = new DevicePool(
+      sessionManager,
+      "daemon-session",
+      timer,
+      new FakeInstalledAppsRepository(),
+      manager,
+      new DefaultRetryExecutor(timer),
+    );
+    const original: BootedDevice = {
+      platform: "android",
+      name: "Pixel_8_API_35",
+      deviceId: "emulator-5554",
+    };
+    const image: DeviceInfo = {
+      name: original.name,
+      platform: "android",
+      isRunning: true,
+      source: "local",
+    };
+    let killCount = 0;
+    const childProcess = {
+      pid: 123,
+      kill: () => {
+        killCount++;
+        return true;
+      },
+      once: () => childProcess,
+    } as ChildProcess;
+    manager.bootedDevices = [original];
+    await pool.addDevice(original, image);
+    await pool.bindOrReuseDeviceSession(
+      "session-1",
+      original.deviceId,
+      "android",
+      image,
+      childProcess,
+      original,
+    );
+    const detached = await pool.detachAdbServerResetCohort([pool.getDevice(original.deviceId)!]);
+
+    try {
+      await expect(
+        pool.recoverSessionBoundAndroidDeviceAfterAdbServerReset(original.deviceId, detached[0]),
+      ).resolves.toBe(true);
+
+      expect(killCount).toBe(1);
+    } finally {
+      await pool.releaseAdbServerResetCohortReservations(detached);
+      sessionManager.stopCleanupTimer();
+    }
+  });
+
+  test("cancels the reserved AVD when an earlier recovery reuses its serial", async () => {
+    class SwappedSerialDeviceManager extends FakeDeviceManager {
+      override async startDevice(device: DeviceInfo): Promise<ChildProcess> {
+        this.startedDevices.push(device);
+        const deviceId = device.name === "Pixel_8_API_35" ? "emulator-5556" : "emulator-5558";
+        this.bootedDevices = [{ name: device.name, platform: "android", deviceId }];
+        return { pid: 0 } as ChildProcess;
+      }
+
+      override async waitForDeviceReady(device: DeviceInfo): Promise<BootedDevice> {
+        return {
+          name: device.name,
+          platform: "android",
+          deviceId: device.name === "Pixel_8_API_35" ? "emulator-5556" : "emulator-5558",
+        };
+      }
+    }
+
+    const timer = new FakeTimer();
+    const sessionManager = new SessionManager(timer, new FakeDeviceSessionPersistence());
+    const manager = new SwappedSerialDeviceManager();
+    const pool = new DevicePool(
+      sessionManager,
+      "daemon-session",
+      timer,
+      new FakeInstalledAppsRepository(),
+      manager,
+      new DefaultRetryExecutor(timer),
+    );
+    const originals: BootedDevice[] = [
+      { platform: "android", name: "Pixel_8_API_35", deviceId: "emulator-5554" },
+      { platform: "android", name: "Pixel_9_API_36", deviceId: "emulator-5556" },
+    ];
+    manager.bootedDevices = originals;
+    for (const [index, device] of originals.entries()) {
+      const image: DeviceInfo = {
+        name: device.name,
+        platform: "android",
+        isRunning: true,
+        source: "local",
+      };
+      await pool.addDevice(device, image);
+      await pool.bindOrReuseDeviceSession(`session-${index}`, device.deviceId, "android", image);
+    }
+    const detached = await pool.detachAdbServerResetCohort(
+      originals.map(device => pool.getDevice(device.deviceId)!),
+    );
+
+    try {
+      pool.markIntentionalShutdown(originals[1].deviceId);
+
+      await expect(
+        pool.recoverSessionBoundAndroidDeviceAfterAdbServerReset(
+          originals[0].deviceId,
+          detached[0],
+        ),
+      ).resolves.toBe(true);
+      await expect(
+        pool.recoverSessionBoundAndroidDeviceAfterAdbServerReset(
+          originals[1].deviceId,
+          detached[1],
+        ),
+      ).resolves.toBe(false);
+
+      expect(manager.startedDevices.map(device => device.name)).toEqual(["Pixel_8_API_35"]);
+      expect(pool.getDevice("emulator-5556")).toMatchObject({
+        avdName: "Pixel_8_API_35",
+        sessionId: "session-0",
+      });
     } finally {
       await pool.releaseAdbServerResetCohortReservations(detached);
       sessionManager.stopCleanupTimer();

--- a/test/daemon/adbServerResetRecovery.test.ts
+++ b/test/daemon/adbServerResetRecovery.test.ts
@@ -182,6 +182,94 @@ describe("ADB server reset session recovery", () => {
     }
   });
 
+  test("recovers both captured AVDs when the first reuses the second serial", async () => {
+    class SwappedSerialDeviceManager extends FakeDeviceManager {
+      override async startDevice(device: DeviceInfo): Promise<ChildProcess> {
+        this.startedDevices.push(device);
+        const deviceId = device.name === "Pixel_8_API_35" ? "emulator-5556" : "emulator-5558";
+        this.bootedDevices = [{
+          name: device.name,
+          platform: "android",
+          deviceId,
+        }];
+        return { pid: 0 } as ChildProcess;
+      }
+
+      override async killDevice(device: BootedDevice): Promise<void> {
+        this.bootedDevices = this.bootedDevices.filter(candidate => candidate.deviceId !== device.deviceId);
+      }
+
+      override async waitForDeviceReady(device: DeviceInfo): Promise<BootedDevice> {
+        return {
+          name: device.name,
+          platform: "android",
+          deviceId: device.name === "Pixel_8_API_35" ? "emulator-5556" : "emulator-5558",
+        };
+      }
+    }
+
+    const timer = new FakeTimer();
+    const sessionManager = new SessionManager(timer, new FakeDeviceSessionPersistence());
+    const manager = new SwappedSerialDeviceManager();
+    const pool = new DevicePool(
+      sessionManager,
+      "daemon-session",
+      timer,
+      new FakeInstalledAppsRepository(),
+      manager,
+      new DefaultRetryExecutor(timer),
+    );
+    const originals: BootedDevice[] = [
+      { platform: "android", name: "Pixel_8_API_35", deviceId: "emulator-5554" },
+      { platform: "android", name: "Pixel_9_API_36", deviceId: "emulator-5556" },
+    ];
+    manager.bootedDevices = originals;
+    for (const [index, device] of originals.entries()) {
+      const image: DeviceInfo = {
+        name: device.name,
+        platform: "android",
+        isRunning: true,
+        source: "local",
+      };
+      await pool.addDevice(device, image);
+      await pool.bindOrReuseDeviceSession(`session-${index}`, device.deviceId, "android", image);
+    }
+    const detached = await pool.detachAdbServerResetCohort(
+      originals.map(device => pool.getDevice(device.deviceId)!),
+    );
+
+    try {
+      await expect(
+        pool.recoverSessionBoundAndroidDeviceAfterAdbServerReset(
+          originals[0].deviceId,
+          detached[0],
+        ),
+      ).resolves.toBe(true);
+      await expect(
+        pool.recoverSessionBoundAndroidDeviceAfterAdbServerReset(
+          originals[1].deviceId,
+          detached[1],
+        ),
+      ).resolves.toBe(true);
+
+      expect(manager.startedDevices.map(device => device.name)).toEqual([
+        "Pixel_8_API_35",
+        "Pixel_9_API_36",
+      ]);
+      expect(pool.getDevice("emulator-5556")).toMatchObject({
+        avdName: "Pixel_8_API_35",
+        sessionId: "session-0",
+      });
+      expect(pool.getDevice("emulator-5558")).toMatchObject({
+        avdName: "Pixel_9_API_36",
+        sessionId: "session-1",
+      });
+    } finally {
+      await pool.releaseAdbServerResetCohortReservations(detached);
+      sessionManager.stopCleanupTimer();
+    }
+  });
+
   test("releases the preserved session when reboot rejects after detaching the old serial", async () => {
     const timer = new FakeTimer();
     const sessionManager = new SessionManager(timer, new FakeDeviceSessionPersistence());

--- a/test/daemon/adbServerResetRecovery.test.ts
+++ b/test/daemon/adbServerResetRecovery.test.ts
@@ -125,7 +125,7 @@ describe("ADB server reset session recovery", () => {
     }
   });
 
-  test("releases the preserved session when recovery exhausts after detaching the old serial", async () => {
+  test("releases the preserved session when reboot rejects after detaching the old serial", async () => {
     const timer = new FakeTimer();
     const sessionManager = new SessionManager(timer, new FakeDeviceSessionPersistence());
     const manager = new FakeDeviceManager();
@@ -135,9 +135,9 @@ describe("ADB server reset session recovery", () => {
         try {
           await attempt();
         } catch {
-          // Exercise the exhausted-retry result after the pool removed the old serial.
+          // Detach the old serial before the reboot implementation itself rejects.
         }
-        return false;
+        throw new Error("reboot runner unavailable");
       },
     };
     const pool = new DevicePool(

--- a/test/daemon/adbServerResetRecovery.test.ts
+++ b/test/daemon/adbServerResetRecovery.test.ts
@@ -125,6 +125,48 @@ describe("ADB server reset session recovery", () => {
     }
   });
 
+  test("detaches every reset-cohort serial while retaining its session mapping", async () => {
+    const timer = new FakeTimer();
+    const sessionManager = new SessionManager(timer, new FakeDeviceSessionPersistence());
+    const manager = new FakeDeviceManager();
+    const pool = new DevicePool(
+      sessionManager,
+      "daemon-session",
+      timer,
+      new FakeInstalledAppsRepository(),
+      manager,
+      new DefaultRetryExecutor(timer),
+    );
+    const devices: BootedDevice[] = [
+      { platform: "android", name: "Pixel_8_API_35", deviceId: "emulator-5554" },
+      { platform: "android", name: "Pixel_9_API_36", deviceId: "emulator-5556" },
+    ];
+    manager.bootedDevices = devices;
+    for (const [index, device] of devices.entries()) {
+      const image: DeviceInfo = {
+        name: device.name,
+        platform: "android",
+        isRunning: true,
+        source: "local",
+      };
+      await pool.addDevice(device, image);
+      await pool.bindOrReuseDeviceSession(`session-${index}`, device.deviceId, "android", image);
+    }
+    const cohort = devices.map(device => pool.getDevice(device.deviceId)!);
+
+    try {
+      const detached = await pool.detachAdbServerResetCohort(cohort);
+
+      expect(detached).toEqual(cohort);
+      expect(pool.getDevice(devices[0].deviceId)).toBeNull();
+      expect(pool.getDevice(devices[1].deviceId)).toBeNull();
+      expect(sessionManager.getSession("session-0")?.assignedDevice).toBe(devices[0].deviceId);
+      expect(sessionManager.getSession("session-1")?.assignedDevice).toBe(devices[1].deviceId);
+    } finally {
+      sessionManager.stopCleanupTimer();
+    }
+  });
+
   test("releases the preserved session when reboot rejects after detaching the old serial", async () => {
     const timer = new FakeTimer();
     const sessionManager = new SessionManager(timer, new FakeDeviceSessionPersistence());

--- a/test/server/ToolExecutionContext.test.ts
+++ b/test/server/ToolExecutionContext.test.ts
@@ -178,6 +178,47 @@ describe("ToolExecutionContext", () => {
     expect(() => devicePool.assertSessionReadyForAutomation("reset-session-2")).not.toThrow();
   });
 
+  test("retains an implicit autolock mapping while its reset cohort is quarantined", async () => {
+    process.env.AUTOMOBILE_DEVICE_POOL_AUTOLOCK = "1";
+    const device: BootedDevice = {
+      name: "Pixel_8_API_35",
+      platform: "android",
+      deviceId: "emulator-5554",
+    };
+    const image: DeviceInfo = {
+      name: device.name,
+      platform: "android",
+      isRunning: true,
+      source: "local",
+    };
+    fakeDeviceManager.bootedDevices = [device];
+    await devicePool.addDevice(device, image);
+    const sessionId = await devicePool.autolockDevice(
+      device.deviceId,
+      "android",
+      "mcp-session",
+      image,
+    );
+    const detached = await devicePool.detachAdbServerResetCohort([
+      devicePool.getDevice(device.deviceId)!,
+    ]);
+
+    try {
+      expect(
+        devicePool.resolveAutolockSessionForMcpSession("mcp-session", "android"),
+      ).toBe(sessionId);
+      await expect(
+        createToolExecutionContext(sessionId, sessionManager, devicePool, sessionOptions),
+      ).rejects.toThrow(/recovering from a process-wide ADB reset/);
+      expect(
+        devicePool.resolveAutolockSessionForMcpSession("mcp-session", "android"),
+      ).toBe(sessionId);
+    } finally {
+      await devicePool.releaseAdbServerResetCohortReservations(detached.devices);
+      delete process.env.AUTOMOBILE_DEVICE_POOL_AUTOLOCK;
+    }
+  });
+
   test("runs first-session setup when a released UUID is recreated during context creation", async () => {
     let setupCalls = 0;
     AndroidCtrlProxyManager.getInstance = () =>

--- a/test/server/ToolExecutionContext.test.ts
+++ b/test/server/ToolExecutionContext.test.ts
@@ -9,13 +9,14 @@ import { FakeInstalledAppsRepository } from "../fakes/FakeInstalledAppsRepositor
 import { FakeTimer } from "../fakes/FakeTimer";
 import { FakeDeviceSessionPersistence } from "../fakes/FakeDeviceSessionPersistence";
 import { FakeDeviceManager } from "../fakes/FakeDeviceManager";
-import { BootedDevice } from "../../src/models";
+import type { BootedDevice, DeviceInfo } from "../../src/models";
 
 describe("ToolExecutionContext", () => {
   let sessionManager: SessionManager;
   let devicePool: DevicePool;
   let fakeAppsRepo: FakeInstalledAppsRepository;
   let fakeTimer: FakeTimer;
+  let fakeDeviceManager: FakeDeviceManager;
   let originalGetInstance: typeof AndroidCtrlProxyManager.getInstance;
   let originalClientGetInstance: typeof AndroidCtrlProxyClient.getInstance;
   const sessionOptions = { keepScreenAwake: false };
@@ -30,7 +31,7 @@ describe("ToolExecutionContext", () => {
     fakeTimer.enableAutoAdvance();
     sessionManager = new SessionManager(fakeTimer, new FakeDeviceSessionPersistence());
     fakeAppsRepo = new FakeInstalledAppsRepository();
-    const fakeDeviceManager = new FakeDeviceManager();
+    fakeDeviceManager = new FakeDeviceManager();
     devicePool = new DevicePool(sessionManager, "test-daemon-session-id", fakeTimer, fakeAppsRepo, fakeDeviceManager);
     await devicePool.initializeWithDevices([createBootedDevice("device-1")]);
     originalGetInstance = AndroidCtrlProxyManager.getInstance;
@@ -137,6 +138,44 @@ describe("ToolExecutionContext", () => {
 
     expect(context.deviceId).toBe("device-1");
     expect(setupCalls).toBe(0);
+  });
+
+  test("quarantines preserved reset-cohort session routing until recovery settles", async () => {
+    const first: BootedDevice = {
+      name: "Pixel_8_API_35",
+      platform: "android",
+      deviceId: "emulator-5554",
+    };
+    const second: BootedDevice = {
+      name: "Pixel_9_API_36",
+      platform: "android",
+      deviceId: "emulator-5556",
+    };
+    const image = (device: BootedDevice): DeviceInfo => ({
+      name: device.name,
+      platform: "android",
+      isRunning: true,
+      source: "local",
+    });
+    fakeDeviceManager.bootedDevices = [first, second];
+    await devicePool.addDevice(first, image(first));
+    await devicePool.addDevice(second, image(second));
+    await devicePool.bindOrReuseDeviceSession("reset-session-1", first.deviceId, "android", image(first));
+    await devicePool.bindOrReuseDeviceSession("reset-session-2", second.deviceId, "android", image(second));
+    const detached = await devicePool.detachAdbServerResetCohort([
+      devicePool.getDevice(first.deviceId)!,
+      devicePool.getDevice(second.deviceId)!,
+    ]);
+
+    try {
+      await expect(
+        createToolExecutionContext("reset-session-2", sessionManager, devicePool, sessionOptions),
+      ).rejects.toThrow(/recovering from a process-wide ADB reset/);
+    } finally {
+      await devicePool.releaseAdbServerResetCohortReservations(detached.devices);
+    }
+
+    expect(() => devicePool.assertSessionReadyForAutomation("reset-session-2")).not.toThrow();
   });
 
   test("runs first-session setup when a released UUID is recreated during context creation", async () => {

--- a/test/server/deviceTools.platformPreparation.test.ts
+++ b/test/server/deviceTools.platformPreparation.test.ts
@@ -237,7 +237,7 @@ describe("platform device preparation tools", () => {
     expect(settled).toBe(false);
     expect(deviceUtils.getExecutedOperations()).not.toContain(`startDevice:${stale.name}:120000`);
 
-    await pool.releaseAdbServerResetCohortReservations(detached);
+    await pool.releaseAdbServerResetCohortReservations(detached.devices);
     await expect(preparation).resolves.toMatchObject({
       deviceIdentity: { avdName: stale.name },
     });
@@ -278,7 +278,7 @@ describe("platform device preparation tools", () => {
       timer.advanceTime(10);
       await expect(preparation).rejects.toThrow(/Timed out waiting for Android AVD reset recovery/);
     } finally {
-      await pool.releaseAdbServerResetCohortReservations(detached);
+      await pool.releaseAdbServerResetCohortReservations(detached.devices);
     }
   });
 
@@ -321,11 +321,11 @@ describe("platform device preparation tools", () => {
       expect(deviceUtils.getExecutedOperations()).not.toContain(`startDevice:${stale.name}:120000`);
 
       deviceUtils.setBootedDevices("android", [stale]);
-      await pool.releaseAdbServerResetCohortReservations(detached);
+      await pool.releaseAdbServerResetCohortReservations(detached.devices);
       await preparation.catch(() => undefined);
       expect(settled).toBe(true);
     } finally {
-      await pool.releaseAdbServerResetCohortReservations(detached);
+      await pool.releaseAdbServerResetCohortReservations(detached.devices);
     }
   });
 });

--- a/test/server/deviceTools.platformPreparation.test.ts
+++ b/test/server/deviceTools.platformPreparation.test.ts
@@ -174,4 +174,30 @@ describe("platform device preparation tools", () => {
     expect(second.sessionId).toBe(first.sessionId);
     expect(pool.getDevice(emulator.deviceId)).toMatchObject({ avdName: emulator.name });
   });
+
+  test("records the AVD identity after binding an externally booted emulator", async () => {
+    const emulator: BootedDevice = {
+      platform: "android",
+      name: "Pixel_9_API_36",
+      deviceId: "emulator-5562",
+    };
+    sessionManager = new SessionManager(timer, new FakeDeviceSessionPersistence());
+    const pool = new DevicePool(
+      sessionManager,
+      "daemon-session",
+      timer,
+      new FakeInstalledAppsRepository(),
+      deviceUtils,
+      new DefaultRetryExecutor(timer),
+    );
+    DaemonState.getInstance().initialize(sessionManager, pool);
+    deviceUtils.setBootedDevices("android", [emulator]);
+
+    await callTool("getAndroid", { avdName: emulator.name });
+
+    expect(pool.getDevice(emulator.deviceId)).toMatchObject({
+      avdName: emulator.name,
+      androidImage: { name: emulator.name, platform: "android" },
+    });
+  });
 });

--- a/test/server/deviceTools.platformPreparation.test.ts
+++ b/test/server/deviceTools.platformPreparation.test.ts
@@ -8,14 +8,21 @@ import {
 } from "../../src/server/deviceTools";
 import { ToolRegistry } from "../../src/server/toolRegistry";
 import type { BootedDevice, DeviceInfo } from "../../src/models";
+import { DaemonState } from "../../src/daemon/daemonState";
+import { DevicePool } from "../../src/daemon/devicePool";
+import { SessionManager } from "../../src/daemon/sessionManager";
+import { DefaultRetryExecutor } from "../../src/utils/retry/RetryExecutor";
 import { FakeDeviceMatcher } from "../fakes/FakeDeviceMatcher";
+import { FakeDeviceSessionPersistence } from "../fakes/FakeDeviceSessionPersistence";
 import { FakeDeviceUtils } from "../fakes/FakeDeviceUtils";
+import { FakeInstalledAppsRepository } from "../fakes/FakeInstalledAppsRepository";
 import { FakeTimer } from "../fakes/FakeTimer";
 
 describe("platform device preparation tools", () => {
   let deviceUtils: FakeDeviceUtils;
   let matcher: FakeDeviceMatcher;
   let timer: FakeTimer;
+  let sessionManager: SessionManager | undefined;
 
   beforeEach(() => {
     deviceUtils = new FakeDeviceUtils();
@@ -33,6 +40,8 @@ describe("platform device preparation tools", () => {
 
   afterEach(() => {
     resetDeviceToolsDependencies();
+    DaemonState.getInstance().reset();
+    sessionManager?.stopCleanupTimer();
   });
 
   async function callTool(name: "getAndroid" | "getApple", args: Record<string, unknown>) {
@@ -94,7 +103,7 @@ describe("platform device preparation tools", () => {
       isRunning: false,
     };
     let readinessRequest: { readinessTimeoutMs: number; totalDeadlineMs: number } | undefined;
-    matcher.setImageResult(image);
+    deviceUtils.setDeviceImages("android", [image]);
     setDeviceToolsDependencies({
       ensureCtrlProxyReady: async (request) => {
         readinessRequest = {
@@ -119,5 +128,50 @@ describe("platform device preparation tools", () => {
       getAndroidSchema.parse({ avdName: image.name, deviceId: "emulator-5554" }),
     ).toThrow();
     expect(() => getAppleSchema.parse({ udid: "sim-udid", platform: "ios" })).toThrow();
+  });
+
+  test("matches the requested Android AVD name exactly", async () => {
+    const exact: BootedDevice = {
+      platform: "android",
+      name: "Pixel_9",
+      deviceId: "emulator-5554",
+    };
+    const overlapping: BootedDevice = {
+      platform: "android",
+      name: "Pixel_9_Pro",
+      deviceId: "emulator-5556",
+    };
+    deviceUtils.setBootedDevices("android", [overlapping, exact]);
+
+    const result = await callTool("getAndroid", { avdName: exact.name });
+
+    expect(result.name).toBe(exact.name);
+    expect(result.deviceIdentity).toMatchObject({ avdName: exact.name, adbSerial: exact.deviceId });
+  });
+
+  test("reuses the existing session for repeated warm getAndroid calls", async () => {
+    const emulator: BootedDevice = {
+      platform: "android",
+      name: "Pixel_9_API_36",
+      deviceId: "emulator-5562",
+    };
+    sessionManager = new SessionManager(timer, new FakeDeviceSessionPersistence());
+    const pool = new DevicePool(
+      sessionManager,
+      "daemon-session",
+      timer,
+      new FakeInstalledAppsRepository(),
+      deviceUtils,
+      new DefaultRetryExecutor(timer),
+    );
+    await pool.addDevice(emulator);
+    DaemonState.getInstance().initialize(sessionManager, pool);
+    deviceUtils.setBootedDevices("android", [emulator]);
+
+    const first = await callTool("getAndroid", { avdName: emulator.name });
+    const second = await callTool("getAndroid", { avdName: emulator.name });
+
+    expect(second.sessionId).toBe(first.sessionId);
+    expect(pool.getDevice(emulator.deviceId)).toMatchObject({ avdName: emulator.name });
   });
 });

--- a/test/server/deviceTools.platformPreparation.test.ts
+++ b/test/server/deviceTools.platformPreparation.test.ts
@@ -44,7 +44,7 @@ describe("platform device preparation tools", () => {
     sessionManager?.stopCleanupTimer();
   });
 
-  async function callTool(name: "getAndroid" | "getApple", args: Record<string, unknown>) {
+  async function callTool(name: "getAndroid" | "getApple" | "startDevice", args: Record<string, unknown>) {
     const tool = ToolRegistry.getTool(name);
     if (!tool) {
       throw new Error(`${name} is not registered`);
@@ -241,5 +241,44 @@ describe("platform device preparation tools", () => {
     await expect(preparation).resolves.toMatchObject({
       deviceIdentity: { avdName: stale.name },
     });
+  });
+
+  test("applies the named boot deadline while waiting for reset recovery", async () => {
+    const stale: BootedDevice = {
+      platform: "android",
+      name: "Pixel_9_API_36",
+      deviceId: "emulator-5562",
+    };
+    const image: DeviceInfo = {
+      platform: "android",
+      name: stale.name,
+      isRunning: false,
+      source: "local",
+    };
+    sessionManager = new SessionManager(timer, new FakeDeviceSessionPersistence());
+    const pool = new DevicePool(
+      sessionManager,
+      "daemon-session",
+      timer,
+      new FakeInstalledAppsRepository(),
+      deviceUtils,
+      new DefaultRetryExecutor(timer),
+    );
+    await pool.addDevice(stale, image);
+    DaemonState.getInstance().initialize(sessionManager, pool);
+    const detached = await pool.detachAdbServerResetCohort([pool.getDevice(stale.deviceId)!]);
+    const preparation = callTool("startDevice", {
+      platform: "android",
+      name: stale.name,
+      timeoutMs: 10,
+    });
+
+    try {
+      await Promise.resolve();
+      timer.advanceTime(10);
+      await expect(preparation).rejects.toThrow(/Timed out waiting for Android AVD reset recovery/);
+    } finally {
+      await pool.releaseAdbServerResetCohortReservations(detached);
+    }
   });
 });

--- a/test/server/deviceTools.platformPreparation.test.ts
+++ b/test/server/deviceTools.platformPreparation.test.ts
@@ -200,4 +200,46 @@ describe("platform device preparation tools", () => {
       androidImage: { name: emulator.name, platform: "android" },
     });
   });
+
+  test("waits for a reset-cohort reservation before booting the requested AVD", async () => {
+    const stale: BootedDevice = {
+      platform: "android",
+      name: "Pixel_9_API_36",
+      deviceId: "emulator-5562",
+    };
+    const image: DeviceInfo = {
+      platform: "android",
+      name: stale.name,
+      isRunning: false,
+      source: "local",
+    };
+    sessionManager = new SessionManager(timer, new FakeDeviceSessionPersistence());
+    const pool = new DevicePool(
+      sessionManager,
+      "daemon-session",
+      timer,
+      new FakeInstalledAppsRepository(),
+      deviceUtils,
+      new DefaultRetryExecutor(timer),
+    );
+    await pool.addDevice(stale, image);
+    DaemonState.getInstance().initialize(sessionManager, pool);
+    deviceUtils.setDeviceImages("android", [image]);
+    const detached = await pool.detachAdbServerResetCohort([pool.getDevice(stale.deviceId)!]);
+
+    let settled = false;
+    const preparation = callTool("getAndroid", { avdName: stale.name }).then(result => {
+      settled = true;
+      return result;
+    });
+    await Promise.resolve();
+
+    expect(settled).toBe(false);
+    expect(deviceUtils.getExecutedOperations()).not.toContain(`startDevice:${stale.name}:120000`);
+
+    await pool.releaseAdbServerResetCohortReservations(detached);
+    await expect(preparation).resolves.toMatchObject({
+      deviceIdentity: { avdName: stale.name },
+    });
+  });
 });

--- a/test/server/deviceTools.platformPreparation.test.ts
+++ b/test/server/deviceTools.platformPreparation.test.ts
@@ -281,4 +281,51 @@ describe("platform device preparation tools", () => {
       await pool.releaseAdbServerResetCohortReservations(detached);
     }
   });
+
+  test("waits for fuzzy legacy Android names that match a reserved AVD", async () => {
+    const stale: BootedDevice = {
+      platform: "android",
+      name: "Pixel_9_API_36",
+      deviceId: "emulator-5562",
+    };
+    const image: DeviceInfo = {
+      platform: "android",
+      name: stale.name,
+      isRunning: false,
+      source: "local",
+    };
+    sessionManager = new SessionManager(timer, new FakeDeviceSessionPersistence());
+    const pool = new DevicePool(
+      sessionManager,
+      "daemon-session",
+      timer,
+      new FakeInstalledAppsRepository(),
+      deviceUtils,
+      new DefaultRetryExecutor(timer),
+    );
+    await pool.addDevice(stale, image);
+    DaemonState.getInstance().initialize(sessionManager, pool);
+    deviceUtils.setDeviceImages("android", [image]);
+    const detached = await pool.detachAdbServerResetCohort([pool.getDevice(stale.deviceId)!]);
+    let settled = false;
+    const preparation = callTool("startDevice", {
+      platform: "android",
+      name: "Pixel",
+    }).finally(() => {
+      settled = true;
+    });
+
+    try {
+      await Promise.resolve();
+      expect(settled).toBe(false);
+      expect(deviceUtils.getExecutedOperations()).not.toContain(`startDevice:${stale.name}:120000`);
+
+      deviceUtils.setBootedDevices("android", [stale]);
+      await pool.releaseAdbServerResetCohortReservations(detached);
+      await preparation.catch(() => undefined);
+      expect(settled).toBe(true);
+    } finally {
+      await pool.releaseAdbServerResetCohortReservations(detached);
+    }
+  });
 });

--- a/test/server/executionTracker.test.ts
+++ b/test/server/executionTracker.test.ts
@@ -140,6 +140,25 @@ describe("ExecutionTracker", function() {
     expect(tracker.hasActiveAutolockSessionExecutions("autolock-session")).toBe(false);
   });
 
+  test("cancels explicit and implicit work for one device session", async function() {
+    const tracker = new ExecutionTracker(
+      new FakeTimer(),
+      new FakeIdGenerator(["explicit", "implicit"]),
+    );
+    const explicit = tracker.startExecution("tapOn", "mcp-explicit", "device-session");
+    const implicit = tracker.startExecution("tapOn", "mcp-implicit");
+    tracker.setResolvedAutolockSessionUuid(implicit.id, "device-session");
+
+    const cancelled = await tracker.cancelDeviceSessionExecutions(
+      "device-session",
+      "device-disconnected:process-wide-adb-reset",
+    );
+
+    expect(cancelled).toBe(2);
+    expect(explicit.abortController.signal.aborted).toBe(true);
+    expect(implicit.abortController.signal.aborted).toBe(true);
+  });
+
   // #4183 item 6 (A3): the scope fallback in hasActiveToolExecution (executionTracker.ts)
   // had no table coverage. The scope order is: explicit "global" → sessionUuid map →
   // sessionId map → global fallback when neither key is provided.


### PR DESCRIPTION
## Summary

- match `getAndroid` targets by exact AVD name and retain that identity for warm sessions
- detect process-wide ADB resets from the full successful Android discovery snapshot
- release a preserved session when ADB-reset recovery cannot restore its original AVD
- point autolock guidance at the public `getAndroid` and `getApple` APIs

Follow-up to [#5433](https://github.com/kaeawc/auto-mobile/issues/5433) after post-merge review of [#5440](https://github.com/kaeawc/auto-mobile/pull/5440).

## Validation

- `bun test test/server/deviceTools.platformPreparation.test.ts test/daemon/adbServerResetDetection.test.ts test/daemon/adbServerResetRecovery.test.ts`
- `bun test test/utils/deviceBootService.test.ts test/server/deviceTools.startDevice.test.ts test/daemon/devicePool.test.ts test/server/tools/registry.test.ts`
- `bun run typecheck`
- `bun run build`
- `bunx oxlint src/utils/deviceBootService.ts src/server/deviceTools.ts src/daemon/devicePool.ts src/daemon/daemon.ts src/server/toolRegistry.ts`
