### PR TITLE
fix(junit): reserve daemon restart overhead

### DIFF
--- a/android/junit-runner/src/main/kotlin/dev/jasonpearson/automobile/junit/DaemonSocketClient.kt
+++ b/android/junit-runner/src/main/kotlin/dev/jasonpearson/automobile/junit/DaemonSocketClient.kt
@@ -144,8 +144,9 @@ internal object DaemonSocketClientManager {
       return
     }
 
+    val restartRequired = forceRestart || skew
     val startCommand =
-      if (forceRestart || skew) {
+      if (restartRequired) {
         DaemonSocketPaths.buildDaemonRestartCommand()
       } else {
         DaemonSocketPaths.buildDaemonStartCommand()
@@ -161,7 +162,7 @@ internal object DaemonSocketClientManager {
     val environmentOverrides = resolveDaemonEnvironmentOverrides()
     AutoMobileSharedUtils.executeCommand(
       startCommand,
-      DaemonSocketPaths.daemonLauncherTimeoutMs(),
+      DaemonSocketPaths.daemonLauncherTimeoutMs(isRestart = restartRequired),
       environmentOverrides,
     )
 
@@ -341,6 +342,20 @@ internal object DaemonSocketClientManager {
 internal object DaemonSocketPaths {
   private const val DEFAULT_DAEMON_STARTUP_TIMEOUT_MS = 30000L
   private const val DAEMON_STARTUP_LIFECYCLE_BUDGETS = 3L
+  private const val DAEMON_LAUNCHER_FINAL_READINESS_CHECK_TIMEOUT_MS = 10000L
+  private const val DAEMON_LAUNCHER_TIMED_OUT_PROCESS_STOP_TIMEOUT_MS = 10000L
+  private const val DAEMON_LAUNCHER_POST_TIMEOUT_OVERHEAD_MS =
+    DAEMON_LAUNCHER_FINAL_READINESS_CHECK_TIMEOUT_MS +
+      DAEMON_LAUNCHER_TIMED_OUT_PROCESS_STOP_TIMEOUT_MS
+  private const val DAEMON_INCOMPLETE_EXTRACTION_CLEANUP_ALLOWANCE_MS =
+    DEFAULT_DAEMON_STARTUP_TIMEOUT_MS
+  private const val DAEMON_RESTART_GRACEFUL_SHUTDOWN_TIMEOUT_MS = 10000L
+  private const val DAEMON_RESTART_FORCE_STOP_TIMEOUT_MS = 1000L
+  private const val DAEMON_RESTART_DELAY_MS = 1000L
+  private const val DAEMON_RESTART_OVERHEAD_MS =
+    DAEMON_RESTART_GRACEFUL_SHUTDOWN_TIMEOUT_MS +
+      DAEMON_RESTART_FORCE_STOP_TIMEOUT_MS +
+      DAEMON_RESTART_DELAY_MS
   private const val DAEMON_PACKAGE_NAME = "@kaeawc/auto-mobile"
   private const val DAEMON_PACKAGE_VERSION_PROPERTY = "automobile.daemon.package.version"
   private val ignoredPackageVersions = setOf("latest", "unknown")
@@ -361,12 +376,24 @@ internal object DaemonSocketPaths {
 
   /**
    * Bound the launcher process for the daemon's full startup lifecycle: one lock-holder wait plus
-   * up to two startup attempts.
+   * up to two startup attempts. A timed-out attempt may then perform a bounded final readiness
+   * check and process teardown. A retryable incomplete extraction needs one cleanup allowance
+   * before the fallback launch; restarts also budget their bounded shutdown and delay phases.
    */
-  fun daemonLauncherTimeoutMs(): Long {
-    return (daemonStartTimeoutMs()
-      .coerceAtMost(Long.MAX_VALUE / DAEMON_STARTUP_LIFECYCLE_BUDGETS)) *
-      DAEMON_STARTUP_LIFECYCLE_BUDGETS
+  fun daemonLauncherTimeoutMs(isRestart: Boolean): Long {
+    val lifecycleOverheadMs =
+      DAEMON_LAUNCHER_POST_TIMEOUT_OVERHEAD_MS +
+        DAEMON_INCOMPLETE_EXTRACTION_CLEANUP_ALLOWANCE_MS +
+        if (isRestart) DAEMON_RESTART_OVERHEAD_MS else 0L
+    val startupTimeoutMs = daemonStartTimeoutMs()
+    val maximumStartupTimeoutMs =
+      (Long.MAX_VALUE - lifecycleOverheadMs) / DAEMON_STARTUP_LIFECYCLE_BUDGETS
+
+    return if (startupTimeoutMs > maximumStartupTimeoutMs) {
+      Long.MAX_VALUE
+    } else {
+      startupTimeoutMs * DAEMON_STARTUP_LIFECYCLE_BUDGETS + lifecycleOverheadMs
+    }
   }
 
   fun buildDaemonStartCommand(): List<String> {

--- a/android/junit-runner/src/test/kotlin/dev/jasonpearson/automobile/junit/DaemonSocketPathsFlagWiringTest.kt
+++ b/android/junit-runner/src/test/kotlin/dev/jasonpearson/automobile/junit/DaemonSocketPathsFlagWiringTest.kt
@@ -55,14 +55,33 @@ class DaemonSocketPathsFlagWiringTest {
   }
 
   @Test
-  fun `daemon startup timeout defaults to 30 seconds`() {
+  fun `daemon launcher timeout reserves full lifecycle defaults`() {
     // CI provides a valid environment override for emulator startup; an invalid
     // system property takes precedence and exercises this method's fallback.
     System.setProperty("automobile.daemon.startup.timeout.ms", "not-a-number")
     SystemPropertyCache.clear()
 
     assertEquals(30_000L, DaemonSocketPaths.daemonStartTimeoutMs())
-    assertEquals(90_000L, DaemonSocketPaths.daemonLauncherTimeoutMs())
+    assertEquals(140_000L, DaemonSocketPaths.daemonLauncherTimeoutMs(isRestart = false))
+    assertEquals(152_000L, DaemonSocketPaths.daemonLauncherTimeoutMs(isRestart = true))
+  }
+
+  @Test
+  fun `daemon restart launcher timeout includes full lifecycle allowance for configured startup timeout`() {
+    System.setProperty("automobile.daemon.startup.timeout.ms", "120000")
+    SystemPropertyCache.clear()
+
+    assertEquals(410_000L, DaemonSocketPaths.daemonLauncherTimeoutMs(isRestart = false))
+    assertEquals(422_000L, DaemonSocketPaths.daemonLauncherTimeoutMs(isRestart = true))
+  }
+
+  @Test
+  fun `daemon launcher timeout saturates for extreme configured startup timeout`() {
+    System.setProperty("automobile.daemon.startup.timeout.ms", Long.MAX_VALUE.toString())
+    SystemPropertyCache.clear()
+
+    assertEquals(Long.MAX_VALUE, DaemonSocketPaths.daemonLauncherTimeoutMs(isRestart = false))
+    assertEquals(Long.MAX_VALUE, DaemonSocketPaths.daemonLauncherTimeoutMs(isRestart = true))
   }
 
   @Test

--- a/src/daemon/DaemonLauncher.ts
+++ b/src/daemon/DaemonLauncher.ts
@@ -46,7 +46,11 @@ export interface DaemonLaunchRequest {
    * Rechecks that the exact spawned PID is now the reachable daemon before the
    * launcher terminates it for a readiness timeout.
    */
-  isReadyForLaunchedProcess?: (pid: number | undefined) => Promise<boolean>;
+  isReadyForLaunchedProcess?: (
+    pid: number | undefined,
+    timeoutMs: number,
+    signal: AbortSignal,
+  ) => Promise<boolean>;
   formatFailure: (summary: string) => Promise<Error>;
   formatExitFailure?: (code: number | null, signal: NodeJS.Signals | null) => Promise<Error>;
 }
@@ -204,9 +208,15 @@ export class DaemonLauncher {
         readinessAbort.abort();
         // Keep the startup listeners installed while the final check awaits so
         // a late child error or exit cannot become unobserved in that window.
+        const finalReadinessAbort = new AbortController();
         const isReadyAtDeadline = await this.waitForFinalReadinessCheck(
-          request.isReadyForLaunchedProcess?.(daemonProcess.pid) ?? Promise.resolve(false),
+          request.isReadyForLaunchedProcess?.(
+            daemonProcess.pid,
+            DAEMON_SHUTDOWN_TIMEOUT_MS,
+            finalReadinessAbort.signal,
+          ) ?? Promise.resolve(false),
           processFailure,
+          finalReadinessAbort,
         );
         if (processFailureObserved) {
           await processFailure;
@@ -242,6 +252,7 @@ export class DaemonLauncher {
   private async waitForFinalReadinessCheck(
     readinessCheck: Promise<boolean>,
     processFailure: Promise<never>,
+    readinessAbort: AbortController,
   ): Promise<boolean> {
     let timeout: NodeJS.Timeout | undefined;
     const deadline = new Promise<boolean>(resolve => {
@@ -250,6 +261,7 @@ export class DaemonLauncher {
     try {
       return await Promise.race([readinessCheck, processFailure, deadline]);
     } finally {
+      readinessAbort.abort();
       if (timeout) {
         this.timer.clearTimeout(timeout);
       }

--- a/src/daemon/client.ts
+++ b/src/daemon/client.ts
@@ -189,26 +189,44 @@ export class DaemonClient {
   /**
    * Connect to the daemon
    */
-  async connect(): Promise<void> {
+  async connect(timeoutMs: number = this.connectionTimeout, signal?: AbortSignal): Promise<void> {
     if (this.connected) {
       return;
     }
 
+    const deadline = this.timer.now() + timeoutMs;
     try {
-      await this.connectOnce();
+      await this.connectOnce(this.remainingConnectTimeout(deadline, timeoutMs), signal);
       return;
     } catch (error) {
-      if (DaemonClient.cleanupStaleSocketIfDaemonDead(this.socketPath, this.recoveryOptions)) {
-        await this.connectOnce();
+      if (
+        !signal?.aborted &&
+        DaemonClient.cleanupStaleSocketIfDaemonDead(this.socketPath, this.recoveryOptions)
+      ) {
+        await this.connectOnce(this.remainingConnectTimeout(deadline, timeoutMs), signal);
         return;
       }
       throw error;
     }
   }
 
-  private async connectOnce(): Promise<void> {
+  private remainingConnectTimeout(deadline: number, timeoutMs: number): number {
+    const remaining = deadline - this.timer.now();
+    if (remaining <= 0) {
+      throw new DaemonUnavailableError(
+        `Failed to connect to daemon within ${timeoutMs}ms`
+      );
+    }
+    return remaining;
+  }
+
+  private async connectOnce(connectionTimeout: number, signal?: AbortSignal): Promise<void> {
     if (this.connected) {
       return;
+    }
+
+    if (signal?.aborted) {
+      throw new DaemonUnavailableError("Daemon connection attempt aborted");
     }
 
     if (!existsSync(this.socketPath)) {
@@ -219,6 +237,7 @@ export class DaemonClient {
 
     return new Promise((resolve, reject) => {
       let settled = false;
+      let removeAbortListener = () => {};
 
       const rejectPendingRequests = (error: Error) => {
         for (const [, { reject, timeout }] of this.pendingRequests) {
@@ -230,6 +249,7 @@ export class DaemonClient {
 
       const fail = (error: Error) => {
         this.timer.clearTimeout(timeout);
+        removeAbortListener();
         this.connected = false;
         if (this.socket) {
           this.socket.destroy();
@@ -249,13 +269,20 @@ export class DaemonClient {
       const timeout = this.timer.setTimeout(() => {
         fail(
           new DaemonUnavailableError(
-            `Failed to connect to daemon within ${this.connectionTimeout}ms`
+            `Failed to connect to daemon within ${connectionTimeout}ms`
           )
         );
-      }, this.connectionTimeout);
+      }, connectionTimeout);
+
+      if (signal) {
+        const onAbort = () => fail(new DaemonUnavailableError("Daemon connection attempt aborted"));
+        signal.addEventListener("abort", onAbort, { once: true });
+        removeAbortListener = () => signal.removeEventListener("abort", onAbort);
+      }
 
       this.socket = createConnection(this.socketPath, () => {
         this.timer.clearTimeout(timeout);
+        removeAbortListener();
         this.connected = true;
         logger.info(`Connected to daemon at ${this.socketPath}`);
         if (!settled) {
@@ -538,7 +565,7 @@ export class DaemonClient {
 }
 
 export interface DaemonClientLike {
-  connect(): Promise<void>;
+  connect(timeoutMs?: number, signal?: AbortSignal): Promise<void>;
   close(): Promise<void>;
   callTool(toolName: string, params: Record<string, any>): Promise<any>;
   readResource(uri: string, params?: Record<string, any>): Promise<any>;

--- a/src/daemon/constants.ts
+++ b/src/daemon/constants.ts
@@ -95,9 +95,11 @@ const startupTimeoutOverride =
 const parsedStartupTimeout = startupTimeoutOverride
   ? Number.parseInt(startupTimeoutOverride, 10)
   : NaN;
+// Node and Bun clamp timer delays above this value to 1ms.
+const MAX_DAEMON_STARTUP_TIMEOUT_MS = 2_147_483_647;
 export const DAEMON_STARTUP_TIMEOUT_MS =
   Number.isFinite(parsedStartupTimeout) && parsedStartupTimeout > 0
-    ? parsedStartupTimeout
+    ? Math.min(parsedStartupTimeout, MAX_DAEMON_STARTUP_TIMEOUT_MS)
     : 30000;
 
 /**

--- a/src/daemon/manager.ts
+++ b/src/daemon/manager.ts
@@ -405,7 +405,7 @@ export class DaemonManager implements DaemonManagerLike {
       spawn: processSpawner?.spawn.bind(processSpawner),
       timer,
     });
-    this.clientFactory = clientFactory ?? (() => new DaemonClient(this.socketPath));
+    this.clientFactory = clientFactory ?? (() => new DaemonClient(this.socketPath, undefined, timer));
   }
 
   /**
@@ -632,7 +632,8 @@ export class DaemonManager implements DaemonManagerLike {
             },
             timeoutMs: DAEMON_STARTUP_TIMEOUT_MS,
             waitForReady: (timeoutMs, signal) => this.waitForReady(timeoutMs, signal),
-            isReadyForLaunchedProcess: pid => this.isLaunchedProcessReady(pid),
+            isReadyForLaunchedProcess: (pid, timeoutMs, signal) =>
+              this.isLaunchedProcessReady(pid, timeoutMs, signal),
             formatFailure: summary => this.createDaemonStartupFailure(summary, logPath),
             formatExitFailure: (code, signal) => this.createDaemonExitFailure(code, signal, logPath),
           });
@@ -1016,10 +1017,13 @@ export class DaemonManager implements DaemonManagerLike {
       Object.entries(options).filter(([, value]) => value !== undefined)
     ) as DaemonOptions;
     const restartOptions: DaemonOptions = { ...runningOptions, ...requestedOptions };
-    if (status.running) {
-      await this.stop();
-    }
-    await this.stopUnrecordedDaemonsForExplicitRestart(status.pid);
+    // All restart cleanup follows the same 10s graceful + 1s forced-stop
+    // budget. Run the PID-recorded daemon and every cross-namespace candidate
+    // concurrently so the launcher timeout remains bounded by one cleanup window.
+    await this.awaitRestartCleanup([
+      () => status.running ? this.stop() : undefined,
+      () => this.stopUnrecordedDaemonsForExplicitRestart(status.pid),
+    ]);
     // Wait a bit before starting
     await this.timer.sleep(1000);
     await this.start(restartOptions);
@@ -1041,8 +1045,22 @@ export class DaemonManager implements DaemonManagerLike {
     stderrLog(
       `Explicit restart force-stopping ${candidates.length} live AutoMobile daemon candidate(s) without this namespace's PID record...`
     );
-    for (const pid of candidates) {
-      await this.stopUnrecordedDaemonProcess(pid);
+    await this.awaitRestartCleanup(
+      candidates.map(pid => () => this.stopUnrecordedDaemonProcess(pid))
+    );
+  }
+
+  private async awaitRestartCleanup(
+    operations: ReadonlyArray<() => void | Promise<void>>,
+  ): Promise<void> {
+    const results = await Promise.allSettled(
+      operations.map(operation => Promise.resolve().then(operation))
+    );
+    const failure = results.find(
+      (result): result is PromiseRejectedResult => result.status === "rejected"
+    );
+    if (failure) {
+      throw failure.reason;
     }
   }
 
@@ -1098,11 +1116,12 @@ export class DaemonManager implements DaemonManagerLike {
    */
   async waitForReady(timeout: number, signal?: AbortSignal): Promise<boolean> {
     const startTime = this.timer.now();
+    const deadline = startTime + timeout;
     const pollInterval = 100; // Poll every 100ms
     let pollCount = 0;
     let socketObserved = false;
 
-    while (this.timer.now() - startTime < timeout) {
+    while (this.timer.now() < deadline) {
       if (signal?.aborted) {
         return false;
       }
@@ -1112,7 +1131,7 @@ export class DaemonManager implements DaemonManagerLike {
         // A daemon started from another checkout can own this namespace's socket
         // without writing this namespace's PID record. The socket connection is
         // authoritative readiness in that case; status() cannot prove ownership.
-        if (await this.verifyDaemonConnection()) {
+        if (await this.verifyDaemonConnection(this.remainingTime(deadline), signal)) {
           stderrLog(
             `Daemon readiness probe succeeded after ${this.timer.now() - startTime}ms ` +
             `(${pollCount} polls; socket observed)`
@@ -1128,7 +1147,11 @@ export class DaemonManager implements DaemonManagerLike {
         }
       }
 
-      await this.sleepUnlessAborted(pollInterval, signal);
+      const remainingPollTimeMs = this.remainingTime(deadline);
+      if (remainingPollTimeMs === 0) {
+        break;
+      }
+      await this.sleepUnlessAborted(Math.min(pollInterval, remainingPollTimeMs), signal);
     }
 
     stderrLog(
@@ -1140,13 +1163,18 @@ export class DaemonManager implements DaemonManagerLike {
 
   private async waitForExistingDaemon(timeout: number): Promise<boolean> {
     const startTime = this.timer.now();
+    const deadline = startTime + timeout;
     const pollInterval = 100;
 
-    while (this.timer.now() - startTime < timeout) {
-      if (await this.verifyDaemonConnection()) {
+    while (this.timer.now() < deadline) {
+      if (await this.verifyDaemonConnection(this.remainingTime(deadline))) {
         return true;
       }
-      await this.timer.sleep(pollInterval);
+      const remainingPollTimeMs = this.remainingTime(deadline);
+      if (remainingPollTimeMs === 0) {
+        break;
+      }
+      await this.timer.sleep(Math.min(pollInterval, remainingPollTimeMs));
     }
 
     return false;
@@ -1175,7 +1203,13 @@ export class DaemonManager implements DaemonManagerLike {
     });
   }
 
-  private async verifyDaemonConnection(): Promise<boolean> {
+  private remainingTime(deadline: number): number {
+    return Math.max(0, deadline - this.timer.now());
+  }
+
+  private async verifyDaemonConnection(timeoutMs: number, signal?: AbortSignal): Promise<boolean> {
+    const deadline = this.timer.now() + timeoutMs;
+
     // Retry the connect probe before declaring the socket dead. A single failed
     // probe is not authoritative — a live daemon under load can transiently
     // refuse a connection. Only a socket that fails every attempt is treated as
@@ -1183,9 +1217,13 @@ export class DaemonManager implements DaemonManagerLike {
     // healthy daemon's socket from being unlinked on a flaky probe, the dominant
     // cause of "devices not found after daemon start/restart".
     for (let attempt = 1; attempt <= READINESS_PROBE_MAX_ATTEMPTS; attempt++) {
+      const remainingTimeoutMs = this.remainingTime(deadline);
+      if (remainingTimeoutMs === 0 || signal?.aborted) {
+        return false;
+      }
       const client = this.createClient();
       try {
-        await client.connect();
+        await this.connectReadinessProbe(client, remainingTimeoutMs, signal);
         return true;
       } catch (error) {
         logger.debug(
@@ -1199,21 +1237,62 @@ export class DaemonManager implements DaemonManagerLike {
         }
       }
 
-      if (attempt < READINESS_PROBE_MAX_ATTEMPTS) {
-        await this.timer.sleep(READINESS_PROBE_BACKOFF_MS);
+      const remainingAfterProbeMs = this.remainingTime(deadline);
+      if (attempt < READINESS_PROBE_MAX_ATTEMPTS && remainingAfterProbeMs > 0) {
+        await this.sleepUnlessAborted(
+          Math.min(READINESS_PROBE_BACKOFF_MS, remainingAfterProbeMs),
+          signal,
+        );
       }
     }
 
     return false;
   }
 
-  private async isLaunchedProcessReady(pid: number | undefined): Promise<boolean> {
+  private async connectReadinessProbe(
+    client: DaemonClientLike,
+    timeoutMs: number,
+    signal?: AbortSignal,
+  ): Promise<void> {
+    const probeAbort = new AbortController();
+    const forwardAbort = () => probeAbort.abort();
+    signal?.addEventListener("abort", forwardAbort, { once: true });
+    let timeout: NodeJS.Timeout | undefined;
+
+    try {
+      await Promise.race([
+        client.connect(timeoutMs, probeAbort.signal),
+        new Promise<never>((_, reject) => {
+          timeout = this.timer.setTimeout(() => {
+            probeAbort.abort();
+            reject(new Error(`Daemon readiness probe timed out after ${timeoutMs}ms`));
+          }, timeoutMs);
+        }),
+      ]);
+    } finally {
+      probeAbort.abort();
+      signal?.removeEventListener("abort", forwardAbort);
+      if (timeout) {
+        this.timer.clearTimeout(timeout);
+      }
+    }
+  }
+
+  private async isLaunchedProcessReady(
+    pid: number | undefined,
+    timeoutMs: number,
+    signal: AbortSignal,
+  ): Promise<boolean> {
     if (pid === undefined) {
       return false;
     }
 
     const status = await this.status();
-    return status.running === true && status.pid === pid && await this.verifyDaemonConnection();
+    return (
+      status.running === true &&
+      status.pid === pid &&
+      await this.verifyDaemonConnection(timeoutMs, signal)
+    );
   }
 
   /**

--- a/test/daemon/DaemonLauncher.test.ts
+++ b/test/daemon/DaemonLauncher.test.ts
@@ -249,13 +249,19 @@ describe("DaemonLauncher", () => {
       timer,
     });
 
+    let finalTimeoutMs: number | undefined;
+    let finalReadinessSignal: AbortSignal | undefined;
     const launch = launcher.launchAndWait({
       command: "auto-mobile",
       args: ["--daemon-mode"],
       spawnOptions: {},
       timeoutMs: 100,
       waitForReady: async () => false,
-      isReadyForLaunchedProcess: async () => new Promise<boolean>(() => {}),
+      isReadyForLaunchedProcess: async (_pid, timeoutMs, signal) => {
+        finalTimeoutMs = timeoutMs;
+        finalReadinessSignal = signal;
+        return new Promise<boolean>(() => {});
+      },
       formatFailure: async summary => new Error(summary),
     });
 
@@ -268,6 +274,8 @@ describe("DaemonLauncher", () => {
 
     expect(spawner.process.signals).toEqual(["SIGTERM"]);
     expect(timer.getPendingTimeoutCount()).toBe(0);
+    expect(finalTimeoutMs).toBe(DAEMON_SHUTDOWN_TIMEOUT_MS);
+    expect(finalReadinessSignal?.aborted).toBe(true);
   });
 
   test("escalates the detached POSIX process group to reap a package-runner child", async () => {

--- a/test/daemon/daemonManagerReadiness.test.ts
+++ b/test/daemon/daemonManagerReadiness.test.ts
@@ -15,11 +15,19 @@ import type { ChildProcess, SpawnOptions } from "node:child_process";
 class ProbeClient implements DaemonClientLike {
   connectCallCount = 0;
   closeCallCount = 0;
+  readonly connectionTimeouts: number[] = [];
+  readonly connectionSignals: AbortSignal[] = [];
 
   constructor(private readonly canConnect: boolean) {}
 
-  async connect(): Promise<void> {
+  async connect(timeoutMs?: number, signal?: AbortSignal): Promise<void> {
     this.connectCallCount++;
+    if (timeoutMs !== undefined) {
+      this.connectionTimeouts.push(timeoutMs);
+    }
+    if (signal !== undefined) {
+      this.connectionSignals.push(signal);
+    }
     if (!this.canConnect) {
       throw new Error("socket not accepting connections");
     }
@@ -205,9 +213,11 @@ describe("DaemonManager readiness", () => {
     );
 
     await expect(manager.waitForReady(250)).resolves.toBe(false);
-    // The probe is retried before the socket is treated as dead, so a fully
-    // unreachable socket is probed READINESS_PROBE_MAX_ATTEMPTS times.
-    expect(clients).toHaveLength(READINESS_PROBE_MAX_ATTEMPTS);
+    // The probe is retried before the socket is treated as dead, bounded by the
+    // remaining readiness deadline. A slow probe can consume the remaining budget
+    // before every retry runs.
+    expect(clients.length).toBeGreaterThan(0);
+    expect(clients.length).toBeLessThanOrEqual(READINESS_PROBE_MAX_ATTEMPTS);
     expect(clients[0].connectCallCount).toBe(1);
     expect(clients[0].closeCallCount).toBe(1);
     expect(existsSync(socketPath)).toBe(false);
@@ -252,7 +262,8 @@ describe("DaemonManager readiness", () => {
       );
 
       await expect(manager.waitForReady(250)).resolves.toBe(false);
-      expect(clients).toHaveLength(READINESS_PROBE_MAX_ATTEMPTS);
+      expect(clients.length).toBeGreaterThan(0);
+      expect(clients.length).toBeLessThanOrEqual(READINESS_PROBE_MAX_ATTEMPTS);
       expect(clients[0].connectCallCount).toBe(1);
       expect(clients[0].closeCallCount).toBe(1);
       expect(existsSync(socketPath)).toBe(false);
@@ -321,6 +332,50 @@ describe("DaemonManager readiness", () => {
     await expect(ready).resolves.toBe(false);
     expect(fakeTimer.getPendingTimeoutCount()).toBe(0);
     expect(clients).toHaveLength(0);
+  });
+
+  test("bounds a stalled socket connection by the remaining readiness deadline", async () => {
+    const { lockPath, pidPath, socketPath } = createPaths();
+    const fakeTimer = new FakeTimer();
+    const clients: ProbeClient[] = [];
+    writeFileSync(socketPath, "socket placeholder");
+
+    const manager = new DaemonManager(
+      () => {
+        const client = new ProbeClient(true);
+        client.connect = async (timeoutMs?: number, signal?: AbortSignal) => {
+          client.connectCallCount++;
+          if (timeoutMs !== undefined) {
+            client.connectionTimeouts.push(timeoutMs);
+          }
+          if (signal !== undefined) {
+            client.connectionSignals.push(signal);
+          }
+          await new Promise<void>((_resolve, reject) => {
+            signal?.addEventListener("abort", () => reject(new Error("probe aborted")), {
+              once: true,
+            });
+          });
+        };
+        clients.push(client);
+        return client;
+      },
+      undefined,
+      fakeTimer,
+      lockPath,
+      pidPath,
+      socketPath
+    );
+
+    const ready = manager.waitForReady(100);
+    await new Promise<void>(resolve => setImmediate(resolve));
+    expect(clients).toHaveLength(1);
+    expect(clients[0].connectionTimeouts).toEqual([100]);
+
+    fakeTimer.advanceTime(100);
+
+    await expect(ready).resolves.toBe(false);
+    expect(clients[0].connectionSignals[0].aborted).toBe(true);
   });
 
   test("reports elapsed readiness timing when no daemon socket appears", async () => {

--- a/test/daemon/daemonStartupTimeoutConfig.test.ts
+++ b/test/daemon/daemonStartupTimeoutConfig.test.ts
@@ -1,0 +1,36 @@
+import { afterEach, describe, expect, test } from "bun:test";
+
+const STARTUP_TIMEOUT_ENV = "AUTOMOBILE_DAEMON_STARTUP_TIMEOUT_MS";
+const LEGACY_STARTUP_TIMEOUT_ENV = "AUTO_MOBILE_DAEMON_STARTUP_TIMEOUT_MS";
+const MAX_TIMER_DELAY_MS = 2_147_483_647;
+
+describe("daemon startup timeout configuration", () => {
+  const originalEnvironment = new Map(
+    [STARTUP_TIMEOUT_ENV, LEGACY_STARTUP_TIMEOUT_ENV].map(key => [key, process.env[key]])
+  );
+
+  function restoreEnvironment(): void {
+    for (const [key, value] of originalEnvironment) {
+      if (value === undefined) {
+        delete process.env[key];
+      } else {
+        process.env[key] = value;
+      }
+    }
+  }
+
+  async function importFreshConstants() {
+    return import(`../../src/daemon/constants.ts?startup-timeout=${Date.now()}-${Math.random()}`);
+  }
+
+  afterEach(restoreEnvironment);
+
+  test("caps an oversized override at the runtime timer maximum", async () => {
+    process.env[STARTUP_TIMEOUT_ENV] = "9223372036854775807";
+    delete process.env[LEGACY_STARTUP_TIMEOUT_ENV];
+
+    const constants = await importFreshConstants();
+
+    expect(constants.DAEMON_STARTUP_TIMEOUT_MS).toBe(MAX_TIMER_DELAY_MS);
+  });
+});

--- a/test/daemon/manager.test.ts
+++ b/test/daemon/manager.test.ts
@@ -1028,6 +1028,193 @@ describe("Daemon manager process detection", () => {
     }
   });
 
+  test("explicit restart bounds recorded and cross-namespace shutdown in one cleanup window", async () => {
+    const fakeTimer = new FakeTimer();
+    fakeTimer.enableAutoAdvance();
+    const recordedPid = 451;
+    const crossNamespacePid = 452;
+    const livePids = new Set([recordedPid, crossNamespacePid]);
+    const processFinder: DaemonProcessFinder & DaemonProcessLivenessChecker = {
+      findDaemonProcesses: () => [recordedPid, crossNamespacePid].map(pid => ({
+        pid,
+        ppid: 1,
+        command: "bun /other-checkout/dist/src/index.js --daemon-mode",
+      })),
+      isProcessRunning: pid => livePids.has(pid),
+    };
+    const signaler = new FakeDaemonProcessSignaler((pid, signal) => {
+      if (pid === crossNamespacePid && signal === "SIGKILL") {
+        fakeTimer.setTimeout(() => { livePids.delete(pid); }, 1_000);
+      }
+    });
+    const manager = new DaemonManager(
+      undefined,
+      undefined,
+      fakeTimer,
+      undefined,
+      undefined,
+      undefined,
+      processFinder,
+      undefined,
+      undefined,
+      undefined,
+      signaler,
+    );
+    const statusSpy = spyOn(manager, "status").mockResolvedValue({
+      running: true,
+      pid: recordedPid,
+    });
+    const startSpy = spyOn(manager, "start").mockResolvedValue(undefined);
+    const killSpy = spyOn(process, "kill").mockImplementation((_pid, signal) => {
+      if (signal === "SIGKILL") {
+        fakeTimer.setTimeout(() => { livePids.delete(recordedPid); }, 1_000);
+      }
+      return true;
+    });
+
+    try {
+      await manager.restart();
+
+      expect(killSpy.mock.calls.filter(([pid]) => pid === recordedPid)).toEqual([
+        [recordedPid, "SIGTERM"],
+        [recordedPid, "SIGKILL"],
+      ]);
+      expect(signaler.signals).toEqual([
+        { pid: crossNamespacePid, signal: "SIGTERM" },
+        { pid: crossNamespacePid, signal: "SIGKILL" },
+      ]);
+      expect(fakeTimer.now()).toBe(12_000);
+      expect(startSpy).toHaveBeenCalledWith({});
+    } finally {
+      killSpy.mockRestore();
+      startSpy.mockRestore();
+      statusSpy.mockRestore();
+    }
+  });
+
+  test("explicit restart awaits the recorded daemon cleanup after a cross-namespace failure", async () => {
+    const fakeTimer = new FakeTimer();
+    const recordedPid = 451;
+    const crossNamespacePid = 452;
+    const processFinder: DaemonProcessFinder & DaemonProcessLivenessChecker = {
+      findDaemonProcesses: () => [recordedPid, crossNamespacePid].map(pid => ({
+        pid,
+        ppid: 1,
+        command: "bun /other-checkout/dist/src/index.js --daemon-mode",
+      })),
+      isProcessRunning: () => true,
+    };
+    const signaler = new FakeDaemonProcessSignaler(() => {
+      throw new Error("EPERM");
+    });
+    const manager = new DaemonManager(
+      undefined,
+      undefined,
+      fakeTimer,
+      undefined,
+      undefined,
+      undefined,
+      processFinder,
+      undefined,
+      undefined,
+      undefined,
+      signaler,
+    );
+    const statusSpy = spyOn(manager, "status").mockResolvedValue({
+      running: true,
+      pid: recordedPid,
+    });
+    let recordedCleanupCompleted = false;
+    const stopSpy = spyOn(manager, "stop").mockImplementation(async () => {
+      await fakeTimer.sleep(1_000);
+      recordedCleanupCompleted = true;
+    });
+    const restart = manager.restart();
+    let restartSettled = false;
+    void restart.then(
+      () => { restartSettled = true; },
+      () => { restartSettled = true; },
+    );
+
+    try {
+      await new Promise<void>(resolve => setImmediate(resolve));
+
+      expect(restartSettled).toBe(false);
+      expect(recordedCleanupCompleted).toBe(false);
+
+      await fakeTimer.advanceTimersByTimeAsync(1_000);
+
+      await expect(restart).rejects.toThrow("Failed to stop verified daemon process 452");
+      expect(recordedCleanupCompleted).toBe(true);
+    } finally {
+      stopSpy.mockRestore();
+      statusSpy.mockRestore();
+    }
+  });
+
+  test("explicit restart awaits every cross-namespace cleanup after one candidate fails", async () => {
+    const fakeTimer = new FakeTimer();
+    const failingPid = 452;
+    const slowPid = 453;
+    const livePids = new Set([failingPid, slowPid]);
+    const processFinder: DaemonProcessFinder & DaemonProcessLivenessChecker = {
+      findDaemonProcesses: () => [failingPid, slowPid].map(pid => ({
+        pid,
+        ppid: 1,
+        command: "bun /other-checkout/dist/src/index.js --daemon-mode",
+      })),
+      isProcessRunning: pid => livePids.has(pid),
+    };
+    const signaler = new FakeDaemonProcessSignaler((pid, signal) => {
+      if (pid === failingPid && signal === "SIGTERM") {
+        throw new Error("EPERM");
+      }
+      if (pid === slowPid && signal === "SIGTERM") {
+        fakeTimer.setTimeout(() => { livePids.delete(pid); }, 1_000);
+      }
+    });
+    const manager = new DaemonManager(
+      undefined,
+      undefined,
+      fakeTimer,
+      undefined,
+      undefined,
+      undefined,
+      processFinder,
+      undefined,
+      undefined,
+      undefined,
+      signaler,
+    );
+    const statusSpy = spyOn(manager, "status").mockResolvedValue({ running: false });
+    const startSpy = spyOn(manager, "start").mockResolvedValue(undefined);
+    const restart = manager.restart();
+    let restartSettled = false;
+    void restart.then(
+      () => { restartSettled = true; },
+      () => { restartSettled = true; },
+    );
+
+    try {
+      await new Promise<void>(resolve => setImmediate(resolve));
+
+      expect(restartSettled).toBe(false);
+      expect(signaler.signals).toEqual([
+        { pid: failingPid, signal: "SIGTERM" },
+        { pid: slowPid, signal: "SIGTERM" },
+      ]);
+
+      await fakeTimer.advanceTimersByTimeAsync(1_000);
+
+      await expect(restart).rejects.toThrow("Failed to stop verified daemon process 452");
+      expect(livePids.has(slowPid)).toBe(false);
+      expect(startSpy).not.toHaveBeenCalled();
+    } finally {
+      startSpy.mockRestore();
+      statusSpy.mockRestore();
+    }
+  });
+
   test("explicit restart does not signal a candidate that exits before the forced stop", async () => {
     const fakeTimer = new FakeTimer();
     fakeTimer.enableAutoAdvance();


### PR DESCRIPTION
## Summary

Reserve the bounded restart overhead in the JUnit daemon launcher timeout:

- Keep the existing three-startup-budget timeout for `--daemon start`.
- Add the 10-second graceful-stop, 1-second forced-stop, and 1-second restart-delay budget for `--daemon restart`.
- Saturate timeout arithmetic at `Long.MAX_VALUE`.

## Root Cause

The JUnit runner used one three-startup-budget timeout for both `start` and `restart`. A restart can consume up to 12 seconds before daemon startup begins, allowing `executeCommand` to terminate a valid cold or contended restart too early.

## Validation

- `:junit-runner:test --tests dev.jasonpearson.automobile.junit.DaemonSocketPathsFlagWiringTest`
- `bun run typecheck`
- `bun run turbo:validate`
- `ONLY_TOUCHED_FILES=true scripts/ktfmt/validate_ktfmt.sh`

Closes [#5445](https://github.com/kaeawc/auto-mobile/issues/5445).
