### PR TITLE
fix(resources): address catalog review feedback

### DIFF
--- a/src/server/appResources.ts
+++ b/src/server/appResources.ts
@@ -1,4 +1,8 @@
-import { ResourceRegistry, ResourceContent } from "./resourceRegistry";
+import {
+  ResourceRegistry,
+  ResourceContent,
+  getRequestedResourceUri,
+} from "./resourceRegistry";
 import { PlatformDeviceManagerFactory } from "../utils/factories/PlatformDeviceManagerFactory";
 import { ListInstalledApps } from "../features/observe/ListInstalledApps";
 import { GetAppMetadata, IosAppMetadataSource } from "../features/observe/GetAppMetadata";
@@ -10,7 +14,6 @@ import { getInstalledAppsCacheWriteCoordinator } from "../db/installedAppsCacheW
 import { getDbWriteBarrier } from "../db/dbWriteBarrier";
 import { defaultTimer, type Timer } from "../utils/SystemTimer";
 import { getIosInstalledAppBundleId } from "../utils/ios-cmdline-tools/iosInstalledApp";
-import { queryParamsToRecord } from "./queryParamValidation";
 
 // Resource URI templates
 export const APP_RESOURCE_TEMPLATES = {
@@ -24,7 +27,7 @@ export const APPS_RESOURCE_URIS = {
 } as const;
 
 const APPS_QUERY_KEYS = ["deviceId", "platform", "search", "type", "profile"] as const;
-const APPS_QUERY_TEMPLATE = `${APPS_RESOURCE_URIS.BASE}?{params}`;
+const APPS_QUERY_TEMPLATE = `${APPS_RESOURCE_URIS.BASE}{?${APPS_QUERY_KEYS.join(",")}}`;
 const APPS_QUERY_PARAM_KEYS = new Set<string>(APPS_QUERY_KEYS);
 type AppsQueryType = "user" | "system";
 
@@ -861,9 +864,8 @@ export function registerAppResources(): void {
     "application/json",
     async params => {
     try {
-      const queryParams = queryParamsToRecord(params.params ?? "");
-      const options = parseAppsQueryParams(queryParams);
-      const uri = buildAppsUri(options);
+      const options = parseAppsQueryParams(params);
+      const uri = getRequestedResourceUri(params) || buildAppsUri(options);
       return getAppsQueryResource(options, uri);
     } catch (error) {
       logger.error(`[AppResources] Failed to parse apps query params: ${error}`);

--- a/src/server/bootedDeviceResources.ts
+++ b/src/server/bootedDeviceResources.ts
@@ -49,7 +49,7 @@ export interface DeviceLockStatesResourceContent {
 }
 
 // Service status for a booted device
-interface DeviceServiceStatus {
+export interface DeviceServiceStatus {
   installed: boolean;
   enabled: boolean;
   running: boolean;
@@ -585,9 +585,7 @@ function withServiceStatus(
   return {
     ...device,
     serviceStatus,
-    readiness: {
-      state: serviceStatus.running && serviceStatus.isCompatible ? "ready" : "not_ready",
-    },
+    readiness: readinessFromServiceStatus(device.platform, serviceStatus),
     capabilities: {
       automation: {
         installed: serviceStatus.installed,
@@ -598,6 +596,21 @@ function withServiceStatus(
       },
     },
   };
+}
+
+export function readinessFromServiceStatus(
+  platform: Platform,
+  serviceStatus: DeviceServiceStatus
+): DeviceReadiness {
+  if (!serviceStatus.installed || !serviceStatus.enabled || !serviceStatus.isCompatible) {
+    return { state: "not_ready" };
+  }
+  if (platform === "android") {
+    // Android's service status only proves the APK is installed and enabled.
+    // Resource reads do not open the CtrlProxy connection, so liveness remains unknown.
+    return { state: "unknown" };
+  }
+  return { state: serviceStatus.running ? "ready" : "not_ready" };
 }
 
 async function enrichDeviceLockStates(devices: BootedDeviceInfo[]): Promise<void> {

--- a/src/server/deviceImageResources.ts
+++ b/src/server/deviceImageResources.ts
@@ -13,7 +13,6 @@ import {
   SimCtlClient,
   type AppleDeviceRuntime,
   type AppleDeviceType,
-  type SimCtl,
 } from "../utils/ios-cmdline-tools/SimCtlClient";
 
 // Resource URIs
@@ -107,7 +106,7 @@ export interface DeviceImagesResourceContent {
 interface DeviceImageResourcesDependencies {
   deviceManager: PlatformDeviceManager;
   avdManager: AvdManager;
-  simctl: Pick<SimCtl, "getDeviceTypes" | "getRuntimes">;
+  simctl: Pick<SimCtlClient, "getDeviceTypesChecked" | "getRuntimesChecked">;
 }
 
 /**
@@ -255,11 +254,16 @@ async function buildAndroidProvisioningCatalog(
   catalog: ProvisioningCatalog
 ): Promise<ProvisioningCatalogObservation> {
   try {
-    const [systemImages, profiles] = await Promise.all([
+    const [availableSystemImages, installedSystemImages, profiles] = await Promise.all([
       avdManager.listSystemImages(),
+      avdManager.listInstalledSystemImages(),
       avdManager.listDevices(),
     ]);
-    appendAndroidProvisioningCatalog(catalog, systemImages, profiles);
+    const systemImages = new Map(
+      [...availableSystemImages, ...installedSystemImages]
+        .map(image => [image.packageName, image])
+    );
+    appendAndroidProvisioningCatalog(catalog, [...systemImages.values()], profiles);
     return { catalogComplete: true };
   } catch (error) {
     logger.warn(`[DeviceImageResources] Failed to build Android provisioning catalog: ${error}`);
@@ -268,7 +272,7 @@ async function buildAndroidProvisioningCatalog(
 }
 
 async function buildIosProvisioningCatalog(
-  simctl: Pick<SimCtl, "getDeviceTypes" | "getRuntimes"> | undefined,
+  simctl: Pick<SimCtlClient, "getDeviceTypesChecked" | "getRuntimesChecked"> | undefined,
   catalog: ProvisioningCatalog
 ): Promise<ProvisioningCatalogObservation> {
   if (!simctl) {
@@ -283,8 +287,8 @@ async function buildIosProvisioningCatalog(
 
   try {
     const [runtimes, deviceTypes] = await Promise.all([
-      simctl.getRuntimes(),
-      simctl.getDeviceTypes(),
+      simctl.getRuntimesChecked(),
+      simctl.getDeviceTypesChecked(),
     ]);
     appendIosProvisioningCatalog(catalog, runtimes, deviceTypes);
     return { catalogComplete: true };

--- a/src/server/networkResources.ts
+++ b/src/server/networkResources.ts
@@ -8,7 +8,6 @@ import {
 import { NetworkState } from "./NetworkState";
 import { BODY_TRUNCATION_LIMIT } from "../utils/truncateBodyText";
 import { computePercentile } from "../utils/percentile";
-import { queryParamsToRecord } from "./queryParamValidation";
 
 const NETWORK_RESOURCE_URIS = {
   REQUEST: "automobile:network/request/{requestId}",
@@ -32,7 +31,7 @@ const TRAFFIC_QUERY_KEYS = [
   "bucketSeconds",
 ] as const;
 
-const TRAFFIC_QUERY_TEMPLATE = `${NETWORK_RESOURCE_URIS.TRAFFIC}?{params}`;
+const TRAFFIC_QUERY_TEMPLATE = `${NETWORK_RESOURCE_URIS.TRAFFIC}{?${TRAFFIC_QUERY_KEYS.join(",")}}`;
 const TRAFFIC_QUERY_PARAM_KEYS = new Set<string>(TRAFFIC_QUERY_KEYS);
 
 function eventToSummary(event: NetworkEventWithId) {
@@ -269,7 +268,7 @@ export function registerNetworkResources(): void {
     "Network Traffic",
     "Query captured network traffic with optional filters.",
     "application/json",
-    async params => handleTrafficQuery(queryParamsToRecord(params.params ?? ""))
+    async params => handleTrafficQuery(params)
   );
 
   // Single request detail by ID

--- a/src/server/performanceResources.ts
+++ b/src/server/performanceResources.ts
@@ -5,14 +5,14 @@ import {
   PERFORMANCE_RESULTS_LIMIT_MAX,
   type PerformanceAuditQueryArgs,
 } from "./performanceData";
-import { queryParamsToRecord } from "./queryParamValidation";
 
 const PERFORMANCE_RESOURCE_URIS = {
   BASE: "automobile:performance-results",
 } as const;
 
 const PERFORMANCE_QUERY_KEYS = ["startTime", "endTime", "limit", "offset", "deviceId"] as const;
-const PERFORMANCE_QUERY_TEMPLATE = `${PERFORMANCE_RESOURCE_URIS.BASE}?{params}`;
+const PERFORMANCE_QUERY_TEMPLATE =
+  `${PERFORMANCE_RESOURCE_URIS.BASE}{?${PERFORMANCE_QUERY_KEYS.join(",")}}`;
 const PERFORMANCE_QUERY_PARAM_KEYS = new Set<string>(PERFORMANCE_QUERY_KEYS);
 
 function parseInteger(
@@ -146,8 +146,7 @@ export function registerPerformanceResources(): void {
     "application/json",
     async params => {
     try {
-      const queryParams = queryParamsToRecord(params.params ?? "");
-      const options = parsePerformanceParams(queryParams);
+      const options = parsePerformanceParams(params);
       const uri = buildPerformanceUri(options);
       return getPerformanceResource(options, uri);
     } catch (error) {

--- a/src/server/resourceRegistry.ts
+++ b/src/server/resourceRegistry.ts
@@ -49,6 +49,13 @@ interface ResourceTemplateMetadata {
   // the per-request scan (issue #3427). Patterns are 100% static.
   regex: RegExp;
   paramNames: string[];
+  queryParamNames: string[];
+}
+
+const requestedResourceUri = Symbol("requestedResourceUri");
+
+export function getRequestedResourceUri(params: Record<string, string>): string | undefined {
+  return (params as Record<PropertyKey, unknown>)[requestedResourceUri] as string | undefined;
 }
 
 type RegisteredResourceTemplate = ResourceTemplateMetadata & (
@@ -62,9 +69,15 @@ type RegisteredResourceTemplate = ResourceTemplateMetadata & (
 function compileUriTemplate(template: string): {
   regex: RegExp;
   paramNames: string[];
+  queryParamNames: string[];
 } {
+  const queryExpression = template.match(/\{\?([a-zA-Z0-9_]+(?:,[a-zA-Z0-9_]+)*)\}$/);
+  const queryParamNames = queryExpression?.[1].split(",") ?? [];
+  const pathTemplate = queryExpression
+    ? template.slice(0, template.length - queryExpression[0].length)
+    : template;
   const paramNames: string[] = [];
-  const tokenizedTemplate = template.replace(/\{(\w+)\}/g, (_, paramName) => {
+  const tokenizedTemplate = pathTemplate.replace(/\{(\w+)\}/g, (_, paramName) => {
     paramNames.push(paramName);
     return `__PARAM_${paramNames.length - 1}__`;
   });
@@ -79,7 +92,12 @@ function compileUriTemplate(template: string): {
     return isGreedyTrailingParam ? "(.+)" : "([^/&]+)";
   });
 
-  return { regex: new RegExp(`^${regexPattern}$`), paramNames };
+  const querySuffix = queryParamNames.length > 0 ? "(?:\\?[^#]*)?" : "";
+  return {
+    regex: new RegExp(`^${regexPattern}${querySuffix}$`),
+    paramNames,
+    queryParamNames,
+  };
 }
 
 // Run a precompiled template's regex against a URI and, on a match, extract the
@@ -93,10 +111,23 @@ function extractTemplateParams(
     return null;
   }
 
-  const params: Record<string, string> = {};
+  const params: Record<string, string> = Object.create(null);
   template.paramNames.forEach((name, index) => {
     params[name] = match[index + 1];
   });
+  if (template.queryParamNames.length > 0) {
+    const queryStart = uri.indexOf("?");
+    const query = queryStart >= 0 ? uri.slice(queryStart + 1) : "";
+    const seen = new Set<string>();
+    for (const [name, value] of new URLSearchParams(query)) {
+      if (seen.has(name)) {
+        return null;
+      }
+      seen.add(name);
+      params[name] = value;
+    }
+  }
+  Object.defineProperty(params, requestedResourceUri, { value: uri });
 
   return params;
 }
@@ -132,8 +163,17 @@ class ResourceRegistryClass {
     mimeType: string,
     handler: ResourceTemplateHandler
   ): void {
-    const { regex, paramNames } = compileUriTemplate(uriTemplate);
-    this.templates.set(uriTemplate, { uriTemplate, name, description, mimeType, handler, regex, paramNames });
+    const { regex, paramNames, queryParamNames } = compileUriTemplate(uriTemplate);
+    this.templates.set(uriTemplate, {
+      uriTemplate,
+      name,
+      description,
+      mimeType,
+      handler,
+      regex,
+      paramNames,
+      queryParamNames,
+    });
   }
 
   registerTemplateWithReadContext(
@@ -143,7 +183,7 @@ class ResourceRegistryClass {
     mimeType: string,
     handlerWithReadContext: ContextualResourceTemplateHandler
   ): void {
-    const { regex, paramNames } = compileUriTemplate(uriTemplate);
+    const { regex, paramNames, queryParamNames } = compileUriTemplate(uriTemplate);
     this.templates.set(uriTemplate, {
       uriTemplate,
       name,
@@ -152,6 +192,7 @@ class ResourceRegistryClass {
       handlerWithReadContext,
       regex,
       paramNames,
+      queryParamNames,
     });
   }
 

--- a/src/utils/android-cmdline-tools/AvdManagerService.ts
+++ b/src/utils/android-cmdline-tools/AvdManagerService.ts
@@ -1,5 +1,6 @@
 import {
   acceptLicenses,
+  listInstalledSystemImages,
   listSystemImages,
   installSystemImage,
   listDeviceImages,
@@ -41,6 +42,13 @@ export class AvdManagerService implements AvdManager {
       return listSystemImages(filter, this.dependencies);
     }
     return listSystemImages(filter);
+  }
+
+  async listInstalledSystemImages(filter?: SystemImageFilter): Promise<SystemImage[]> {
+    if (this.dependencies) {
+      return listInstalledSystemImages(filter, this.dependencies);
+    }
+    return listInstalledSystemImages(filter);
   }
 
   async installSystemImage(packageName: string, acceptLicense = true): Promise<{

--- a/src/utils/android-cmdline-tools/interfaces/AvdManager.ts
+++ b/src/utils/android-cmdline-tools/interfaces/AvdManager.ts
@@ -28,6 +28,13 @@ export interface AvdManager {
   listSystemImages(filter?: SystemImageFilter): Promise<SystemImage[]>;
 
   /**
+   * List installed system images.
+   * @param filter - Optional filter criteria for system images
+   * @returns Promise with array of installed system images
+   */
+  listInstalledSystemImages(filter?: SystemImageFilter): Promise<SystemImage[]>;
+
+  /**
    * Download and install a system image
    * @param packageName - Package name of system image to install
    * @param acceptLicense - Whether to accept license (default: true)

--- a/src/utils/ios-cmdline-tools/SimCtlClient.ts
+++ b/src/utils/ios-cmdline-tools/SimCtlClient.ts
@@ -1566,12 +1566,26 @@ export class SimCtlClient implements SimCtl {
       signal,
     );
     try {
-      const data = JSON.parse(result.stdout);
+      const data = JSON.parse(result.stdout) as { devicetypes?: AppleDeviceType[] };
       return data.devicetypes ?? [];
     } catch (error) {
       logger.warn(`Failed to parse device types from simctl: ${error}`);
       return [];
     }
+  }
+
+  /** Get device types and preserve malformed simctl output as an error. */
+  async getDeviceTypesChecked(signal?: AbortSignal): Promise<AppleDeviceType[]> {
+    const result = await this.executeCommandArgs(
+      ["list", "devicetypes", "--json"],
+      undefined,
+      signal,
+    );
+    const data = JSON.parse(result.stdout) as { devicetypes?: unknown };
+    if (!Array.isArray(data?.devicetypes)) {
+      throw new Error("simctl device types response does not contain a devicetypes array");
+    }
+    return data.devicetypes as AppleDeviceType[];
   }
 
   /**
@@ -1581,12 +1595,22 @@ export class SimCtlClient implements SimCtl {
   async getRuntimes(): Promise<AppleDeviceRuntime[]> {
     const result = await this.executeCommandArgs(["list", "runtimes", "--json"]);
     try {
-      const data = JSON.parse(result.stdout);
-      return (data.runtimes ?? []).filter((runtime: AppleDeviceRuntime) => runtime.isAvailable);
+      const data = JSON.parse(result.stdout) as { runtimes?: AppleDeviceRuntime[] };
+      return (data.runtimes ?? []).filter(runtime => runtime.isAvailable);
     } catch (error) {
       logger.warn(`Failed to parse runtimes from simctl: ${error}`);
       return [];
     }
+  }
+
+  /** Get available runtimes and preserve malformed simctl output as an error. */
+  async getRuntimesChecked(): Promise<AppleDeviceRuntime[]> {
+    const result = await this.executeCommandArgs(["list", "runtimes", "--json"]);
+    const data = JSON.parse(result.stdout) as { runtimes?: unknown };
+    if (!Array.isArray(data?.runtimes)) {
+      throw new Error("simctl runtimes response does not contain a runtimes array");
+    }
+    return (data.runtimes as AppleDeviceRuntime[]).filter(runtime => runtime.isAvailable);
   }
 
   /**

--- a/test/fakes/FakeAvdManager.ts
+++ b/test/fakes/FakeAvdManager.ts
@@ -17,6 +17,7 @@ export class FakeAvdManager implements AvdManager {
     message: "Android SDK licenses accepted"
   };
   private listSystemImagesResponse: SystemImage[] = [];
+  private listInstalledSystemImagesResponse: SystemImage[] = [];
   private installSystemImageResponse: { success: boolean; message: string } = {
     success: true,
     message: "System image installed successfully"
@@ -35,6 +36,7 @@ export class FakeAvdManager implements AvdManager {
   // Call tracking
   private acceptLicensesCalls: number = 0;
   private listSystemImagesCalls: Array<{ filter?: SystemImageFilter }> = [];
+  private listInstalledSystemImagesCalls: Array<{ filter?: SystemImageFilter }> = [];
   private installSystemImageCalls: Array<{ packageName: string; acceptLicense?: boolean }> = [];
   private listDeviceImagesCalls: number = 0;
   private createAvdCalls: Array<{ params: CreateAvdParams }> = [];
@@ -48,6 +50,10 @@ export class FakeAvdManager implements AvdManager {
 
   setListSystemImagesResponse(response: SystemImage[]): void {
     this.listSystemImagesResponse = response;
+  }
+
+  setListInstalledSystemImagesResponse(response: SystemImage[]): void {
+    this.listInstalledSystemImagesResponse = response;
   }
 
   setInstallSystemImageResponse(response: { success: boolean; message: string }): void {
@@ -79,6 +85,10 @@ export class FakeAvdManager implements AvdManager {
     return [...this.listSystemImagesCalls];
   }
 
+  getListInstalledSystemImagesCalls(): Array<{ filter?: SystemImageFilter }> {
+    return [...this.listInstalledSystemImagesCalls];
+  }
+
   getInstallSystemImageCalls(): Array<{ packageName: string; acceptLicense?: boolean }> {
     return [...this.installSystemImageCalls];
   }
@@ -105,6 +115,7 @@ export class FakeAvdManager implements AvdManager {
   clearCallHistory(): void {
     this.acceptLicensesCalls = 0;
     this.listSystemImagesCalls = [];
+    this.listInstalledSystemImagesCalls = [];
     this.installSystemImageCalls = [];
     this.listDeviceImagesCalls = 0;
     this.createAvdCalls = [];
@@ -125,6 +136,11 @@ export class FakeAvdManager implements AvdManager {
   async listSystemImages(filter?: SystemImageFilter): Promise<SystemImage[]> {
     this.listSystemImagesCalls.push({ filter });
     return this.listSystemImagesResponse;
+  }
+
+  async listInstalledSystemImages(filter?: SystemImageFilter): Promise<SystemImage[]> {
+    this.listInstalledSystemImagesCalls.push({ filter });
+    return this.listInstalledSystemImagesResponse;
   }
 
   async installSystemImage(packageName: string, acceptLicense = true): Promise<{

--- a/test/fakes/FakeSimCtlClient.ts
+++ b/test/fakes/FakeSimCtlClient.ts
@@ -31,6 +31,8 @@ export class FakeSimCtlClient implements FakeSimCtlClientContract {
   private deviceInfo = new Map<string, AppleDevice | null>();
   private runtimes: AppleDeviceRuntime[] = [];
   private deviceTypes: AppleDeviceType[] = [];
+  private runtimesError: Error | null = null;
+  private deviceTypesError: Error | null = null;
   private installedApps: any[] = [];
   private containerPaths = new Map<string, string>();
   private containerErrors = new Map<string, Error>();
@@ -55,6 +57,14 @@ export class FakeSimCtlClient implements FakeSimCtlClientContract {
 
   setDeviceTypes(deviceTypes: AppleDeviceType[]): void {
     this.deviceTypes = deviceTypes;
+  }
+
+  setRuntimesError(error: Error | null): void {
+    this.runtimesError = error;
+  }
+
+  setDeviceTypesError(error: Error | null): void {
+    this.deviceTypesError = error;
   }
 
   setInstalledApps(apps: any[]): void {
@@ -188,6 +198,22 @@ export class FakeSimCtlClient implements FakeSimCtlClientContract {
 
   async getRuntimes(): Promise<AppleDeviceRuntime[]> {
     this.recordCall("getRuntimes", {});
+    return this.runtimes;
+  }
+
+  async getDeviceTypesChecked(): Promise<AppleDeviceType[]> {
+    this.recordCall("getDeviceTypesChecked", {});
+    if (this.deviceTypesError) {
+      throw this.deviceTypesError;
+    }
+    return this.deviceTypes;
+  }
+
+  async getRuntimesChecked(): Promise<AppleDeviceRuntime[]> {
+    this.recordCall("getRuntimesChecked", {});
+    if (this.runtimesError) {
+      throw this.runtimesError;
+    }
     return this.runtimes;
   }
 

--- a/test/server/networkResources.test.ts
+++ b/test/server/networkResources.test.ts
@@ -166,14 +166,14 @@ describe("network resource registration", () => {
     ResourceRegistry.clearResources();
   });
 
-  it("registers one raw query template for traffic filters", () => {
+  it("registers one RFC 6570 query template for traffic filters", () => {
     registerNetworkResources();
 
     const templates = ResourceRegistry.getAllTemplates()
-      .filter(template => template.uriTemplate.startsWith("automobile:network/traffic?"));
+      .filter(template => template.uriTemplate.startsWith("automobile:network/traffic"));
 
     expect(templates.map(template => template.uriTemplate)).toEqual([
-      "automobile:network/traffic?{params}"
+      "automobile:network/traffic{?host,method,statusCode,since,limit,deviceId,bucketSeconds}"
     ]);
   });
 });

--- a/test/server/performanceResources.test.ts
+++ b/test/server/performanceResources.test.ts
@@ -120,15 +120,15 @@ describe("performanceData", () => {
       ResourceRegistry.clearResources();
     });
 
-    test("registers the base URI and one raw query-param template", () => {
+    test("registers the base URI and one RFC 6570 query template", () => {
       registerPerformanceResources();
 
       expect(ResourceRegistry.getResource("automobile:performance-results")).toBeDefined();
 
       const templates = ResourceRegistry.getAllTemplates();
-      const queryTemplates = templates.filter(t => t.uriTemplate.startsWith("automobile:performance-results?"));
+      const queryTemplates = templates.filter(t => t.uriTemplate.startsWith("automobile:performance-results"));
       expect(queryTemplates.map(template => template.uriTemplate)).toEqual([
-        "automobile:performance-results?{params}"
+        "automobile:performance-results{?startTime,endTime,limit,offset,deviceId}"
       ]);
     });
   });

--- a/test/server/resourceRegistryListChanged.test.ts
+++ b/test/server/resourceRegistryListChanged.test.ts
@@ -5,7 +5,10 @@ import {
   SubscribeRequestSchema,
   UnsubscribeRequestSchema,
 } from "@modelcontextprotocol/sdk/types.js";
-import { ResourceRegistry } from "../../src/server/resourceRegistry";
+import {
+  getRequestedResourceUri,
+  ResourceRegistry,
+} from "../../src/server/resourceRegistry";
 import { ListChangedBroadcaster } from "../../src/server/listChangedBroadcast";
 
 // Minimal MCP-server stand-in for ResourceRegistry: registerWithServer installs
@@ -125,6 +128,7 @@ describe("ResourceRegistry list-changed fan-out (issue #3223)", () => {
 describe("ResourceRegistry URI-template matching", () => {
   beforeEach(() => {
     ResourceRegistry.clearResources();
+    ResourceRegistry.clearServersForTesting();
   });
 
   test("captures a raw query-string template with multiple query parameters", () => {
@@ -167,5 +171,44 @@ describe("ResourceRegistry URI-template matching", () => {
     expect(JSON.parse(response.contents[0].text!)).toEqual({
       sessionUuid: "session-bound",
     });
+  });
+
+  test("matches an RFC 6570 query expansion in any parameter order", () => {
+    ResourceRegistry.registerTemplate(
+      "automobile:test{?first,second}",
+      "Test",
+      "Test query template",
+      "application/json",
+      async () => ({ uri: "automobile:test", text: "{}" })
+    );
+
+    expect(ResourceRegistry.matchTemplate("automobile:test?second=two&first=one")).toMatchObject({
+      params: { first: "one", second: "two" }
+    });
+  });
+
+  test("retains the requested URI for an RFC 6570 template handler", async () => {
+    const server = new FakeMcpServer();
+    let handlerUri = "";
+    ResourceRegistry.registerTemplate(
+      "automobile:test{?first,second}",
+      "Test",
+      "Test query template",
+      "application/json",
+      async params => {
+        handlerUri = getRequestedResourceUri(params) ?? "";
+        return { uri: handlerUri, text: "{}" };
+      }
+    );
+    ResourceRegistry.registerWithServer(server as unknown as McpServer);
+
+    const readHandler = server.server.handlersBySchema.get(ReadResourceRequestSchema);
+    const requestedUri = "automobile:test?second=two&first=one";
+    const response = await readHandler!({ params: { uri: requestedUri } }) as {
+      contents: Array<{ uri: string }>;
+    };
+
+    expect(handlerUri).toBe(requestedUri);
+    expect(response.contents[0].uri).toBe(requestedUri);
   });
 });

--- a/test/server/resources/bootedDevices.test.ts
+++ b/test/server/resources/bootedDevices.test.ts
@@ -4,7 +4,14 @@ import { ResourceRegistry } from "../../../src/server/resourceRegistry";
 import { FakeDeviceUtils } from "../../fakes/FakeDeviceUtils";
 import { FakeTimer } from "../../fakes/FakeTimer";
 import { FakeDeviceSessionPersistence } from "../../fakes/FakeDeviceSessionPersistence";
-import { setDeviceManager, setDeviceLockProbe, notifyBootedDeviceResourcesUpdated, BootedDevicesResourceContent, DeviceLockStatesResourceContent } from "../../../src/server/bootedDeviceResources";
+import {
+  setDeviceManager,
+  setDeviceLockProbe,
+  notifyBootedDeviceResourcesUpdated,
+  BootedDevicesResourceContent,
+  DeviceLockStatesResourceContent,
+  readinessFromServiceStatus,
+} from "../../../src/server/bootedDeviceResources";
 import { BootedDevice, Platform } from "../../../src/models";
 import { DaemonState } from "../../../src/daemon/daemonState";
 import { DevicePool } from "../../../src/daemon/devicePool";
@@ -922,5 +929,32 @@ describe("ResourceRegistry Template Matching", () => {
     const match = ResourceRegistry.matchTemplate("test://files/app1/dir/sub/file.txt");
     expect(match).toBeDefined();
     expect(match!.params).toEqual({ id: "app1", path: "dir/sub/file.txt" });
+  });
+});
+
+describe("booted device readiness", () => {
+  const compatibleService = {
+    installed: true,
+    enabled: true,
+    running: true,
+    installedSha256: "a".repeat(64),
+    expectedSha256: "a".repeat(64),
+    isCompatible: true,
+  };
+
+  test("keeps Android readiness unknown until the live runner is verified", () => {
+    expect(readinessFromServiceStatus("android", compatibleService)).toEqual({ state: "unknown" });
+  });
+
+  test("reports an unavailable Android service as not ready", () => {
+    expect(readinessFromServiceStatus("android", {
+      ...compatibleService,
+      enabled: false,
+      running: false,
+    })).toEqual({ state: "not_ready" });
+  });
+
+  test("reports a verified iOS runner as ready", () => {
+    expect(readinessFromServiceStatus("ios", compatibleService)).toEqual({ state: "ready" });
   });
 });

--- a/test/server/resources/deviceImages.test.ts
+++ b/test/server/resources/deviceImages.test.ts
@@ -112,6 +112,60 @@ describe("Device Image Resources with Fakes", () => {
       });
     });
 
+    test("merges installed-only Android system images into the complete catalog", async () => {
+      fakeDeviceUtils.setDeviceImages("android", []);
+      const availableImage = {
+        packageName: "system-images;android-35;google_apis;x86_64",
+        apiLevel: 35,
+        tag: "google_apis",
+        abi: "x86_64",
+        versionInfo: "Google APIs Intel x86_64 Atom System Image",
+      };
+      const installedOnlyImage = {
+        packageName: "system-images;android-34;google_apis;arm64-v8a",
+        apiLevel: 34,
+        tag: "google_apis",
+        abi: "arm64-v8a",
+        versionInfo: "Google APIs ARM 64 v8a System Image",
+      };
+      fakeAvdManager.setListSystemImagesResponse([availableImage]);
+      fakeAvdManager.setListInstalledSystemImagesResponse([availableImage, installedOnlyImage]);
+
+      const handler = createDeviceImageResourcesHandler({
+        deviceManager: fakeDeviceUtils,
+        avdManager: fakeAvdManager,
+      });
+      const result = await handler.getDeviceImagesForPlatforms(["android"]);
+
+      expect(result.catalogComplete).toBe(true);
+      expect(result.provisioningCatalog.systemImages.map(image => image.id)).toEqual([
+        availableImage.packageName,
+        installedOnlyImage.packageName,
+      ]);
+      expect(fakeAvdManager.getListInstalledSystemImagesCalls()).toHaveLength(1);
+    });
+
+    test("reports iOS catalog failure when strict simulator discovery fails", async () => {
+      fakeDeviceUtils.setDeviceImages("ios", []);
+      fakeSimCtl.setRuntimesError(new Error("malformed simctl runtimes JSON"));
+
+      const handler = createDeviceImageResourcesHandler({
+        deviceManager: fakeDeviceUtils,
+        avdManager: fakeAvdManager,
+        simctl: fakeSimCtl,
+      });
+      const result = await handler.getDeviceImagesForPlatforms(["ios"]);
+
+      expect(result.catalogComplete).toBe(false);
+      expect(result.catalogObservations.ios).toMatchObject({
+        catalogComplete: false,
+        error: {
+          code: "failed",
+          message: expect.stringContaining("malformed simctl runtimes JSON"),
+        },
+      });
+    });
+
     test("should return correct image counts when there are images", async () => {
       // Set up mock Android devices
       const androidDevices: DeviceInfo[] = [


### PR DESCRIPTION
## Summary

- Replace raw query placeholders with RFC 6570 query expansions and preserve the exact subscribed apps URI for update notifications.
- Distinguish Android service installation from verified live readiness, include installed Android SDK images, and fail incomplete iOS simulator catalog discovery.
- Address the still-valid review feedback from [#5443](https://github.com/kaeawc/auto-mobile/pull/5443).

## Root Cause

The original resources used a nonstandard query template form, catalog discovery treated partial data as complete, and Android readiness inferred runner liveness from installation metadata.

## Impact

MCP clients receive standards-compliant resource templates, accurate readiness and catalog completeness, and a smaller advertised resource-template context.

## Validation

- `bun test --isolate` (13,722 passed, 14 expected integration skips)
- `bun run typecheck`
- `bun run lint`
- `bun run benchmark-context`
