### PR TITLE
fix: address session resource review feedback

### DIFF
--- a/docs/design-docs/mcp/resources.md
+++ b/docs/design-docs/mcp/resources.md
@@ -151,9 +151,10 @@ show whether the catalog can safely be used for provisioning decisions.
 
 ### Session Observations
 
-Session-scoped observation resources take the `sessionUuid` returned by
-`startDevice`. They resolve that active session to its assigned device and reject
-released or rebound sessions rather than accepting a second device selector.
+Session-scoped observation resources take the `sessionId` returned by
+`startDevice` as their `{sessionUuid}` segment. They resolve that active session
+to its assigned device and reject released or rebound sessions rather than
+accepting a second device selector.
 
 **URI Template**: `automobile:observation/session/{sessionUuid}/latest`
 

--- a/src/features/observe/TakeScreenshot.ts
+++ b/src/features/observe/TakeScreenshot.ts
@@ -14,6 +14,7 @@ import { ensureSecureTempDirSync, TEMP_SUBDIRS } from "../../utils/tempDir";
 import type { ScreenshotService } from "./interfaces/ScreenshotService";
 import { selectScreenshotsToEvict, SCREENSHOT_MIN_EVICT_AGE_MS } from "./screenshotCacheEviction";
 import { IOSCtrlProxyClient } from "./ios";
+import type { CtrlProxyScreenshotResult } from "./ios/types";
 import { getDeviceDataStreamServer } from "../../daemon/deviceDataStreamSocketServer";
 import { Timer, defaultTimer } from "../../utils/SystemTimer";
 import { defaultIdGenerator, IdGenerator } from "../../utils/IdGenerator";
@@ -214,7 +215,7 @@ export class TakeScreenshot implements ScreenshotService {
       case "android":
         return await this.captureAndroidScreenshot(finalPath, options, signal);
       case "ios":
-        return await this.captureiOSScreenshot(finalPath);
+        return await this.captureiOSScreenshot(finalPath, signal);
       default:
         throw new Error(`Unsupported platform: ${this.device.platform}`);
     }
@@ -256,6 +257,7 @@ export class TakeScreenshot implements ScreenshotService {
    */
   private async captureiOSScreenshot(
     finalPath: string,
+    signal?: AbortSignal,
   ): Promise<ScreenshotResult> {
     const startTime = this.timer.now();
 
@@ -269,31 +271,13 @@ export class TakeScreenshot implements ScreenshotService {
           error: "Failed to connect to CtrlProxy iOS",
         };
       }
+      if (signal?.aborted) {
+        return { success: false, error: OPERATION_CANCELLED_MESSAGE };
+      }
 
       // Request screenshot from CtrlProxy iOS
       const result = await client.requestScreenshot(10000); // 10 second timeout
-
-      if (!result.success || !result.data) {
-        return {
-          success: false,
-          error: result.error || "No screenshot data returned",
-        };
-      }
-
-      // Decode base64 and save to file securely
-      const imageBuffer = Buffer.from(result.data, "base64");
-      await writeFileSecure(finalPath, imageBuffer);
-
-      const durationMs = this.timer.now() - startTime;
-      logger.info(`[SCREENSHOT] iOS screenshot captured in ${durationMs}ms, saved to ${finalPath}`);
-
-      // Push to observation stream for IDE plugins
-      this.pushScreenshotToStream(result.data, imageBuffer);
-
-      return {
-        success: true,
-        path: finalPath,
-      };
+      return await this.writeiOSScreenshot(finalPath, result, startTime, signal);
     } catch (error) {
       const errorMessage = error instanceof Error ? error.message : String(error);
       logger.error(`[SCREENSHOT] iOS screenshot capture failed: ${errorMessage}`);
@@ -302,6 +286,42 @@ export class TakeScreenshot implements ScreenshotService {
         error: errorMessage,
       };
     }
+  }
+
+  private async writeiOSScreenshot(
+    finalPath: string,
+    result: CtrlProxyScreenshotResult,
+    startTime: number,
+    signal?: AbortSignal,
+  ): Promise<ScreenshotResult> {
+    if (signal?.aborted) {
+      return { success: false, error: OPERATION_CANCELLED_MESSAGE };
+    }
+
+    if (!result.success || !result.data) {
+      return {
+        success: false,
+        error: result.error || "No screenshot data returned",
+      };
+    }
+
+    // Decode base64 and save to file securely
+    const imageBuffer = Buffer.from(result.data, "base64");
+    await writeFileSecure(finalPath, imageBuffer);
+    if (signal?.aborted) {
+      return { success: false, error: OPERATION_CANCELLED_MESSAGE };
+    }
+
+    const durationMs = this.timer.now() - startTime;
+    logger.info(`[SCREENSHOT] iOS screenshot captured in ${durationMs}ms, saved to ${finalPath}`);
+
+    // Push to observation stream for IDE plugins
+    this.pushScreenshotToStream(result.data, imageBuffer);
+
+    return {
+      success: true,
+      path: finalPath,
+    };
   }
 
   /**

--- a/src/features/observe/screenshot/ObserveScreenshotRecorder.ts
+++ b/src/features/observe/screenshot/ObserveScreenshotRecorder.ts
@@ -107,6 +107,9 @@ export class DefaultObserveScreenshotRecorder implements ObserveScreenshotRecord
           { format: "png" },
           {
             parentSignal: signal,
+            // Awaitable observe captures share an ordinary in-flight capture,
+            // but queue behind a non-coalescible fresh resource capture.
+            coalesceWithPending: true,
             onComplete: async completion => {
               if (!completion.isLatest) {
                 return;

--- a/src/server/SessionToolBinding.ts
+++ b/src/server/SessionToolBinding.ts
@@ -3,6 +3,8 @@ import { defaultIdGenerator, type IdGenerator } from "../utils/IdGenerator";
 export class SessionToolBinding {
   private readonly boundDeviceSessions = new Map<string, string>();
   private initialSessionUuid?: string;
+  /** The single stdio transport has no MCP session ID, so retain its device session here. */
+  private directDeviceSessionUuid?: string;
   private initialCapabilityProfileUuid?: string;
   /** The single stdio transport has no MCP session ID, so retain its profile here. */
   private directCapabilityProfileUuid?: string;
@@ -17,6 +19,13 @@ export class SessionToolBinding {
     this.initialCapabilityProfileUuid = initialCapabilityProfileUuid;
   }
 
+  private boundSessionUuid(mcpSessionId: string | undefined): string | undefined {
+    if (mcpSessionId) {
+      return this.boundDeviceSessions.get(mcpSessionId) ?? this.initialSessionUuid;
+    }
+    return this.directDeviceSessionUuid ?? this.initialSessionUuid;
+  }
+
   effectiveSessionUuid(mcpSessionId: string | undefined, params?: unknown): string | undefined {
     const explicit = params && typeof params === "object" && !Array.isArray(params)
       ? (params as Record<string, unknown>).sessionUuid
@@ -24,9 +33,7 @@ export class SessionToolBinding {
     const explicitSessionUuid = typeof explicit === "string" && explicit.trim().length > 0
       ? explicit
       : undefined;
-    const boundSessionUuid = mcpSessionId
-      ? this.boundDeviceSessions.get(mcpSessionId) ?? this.initialSessionUuid
-      : this.initialSessionUuid;
+    const boundSessionUuid = this.boundSessionUuid(mcpSessionId);
     if (
       this.initialSessionUuid &&
       explicitSessionUuid &&
@@ -61,11 +68,15 @@ export class SessionToolBinding {
     if (!sessionUuid?.trim()) {
       return false;
     }
-    if (!mcpSessionId) {
-      return false;
-    }
     if (this.initialSessionUuid && sessionUuid !== this.initialSessionUuid) {
       return false;
+    }
+    if (!mcpSessionId) {
+      if (this.directDeviceSessionUuid === sessionUuid) {
+        return false;
+      }
+      this.directDeviceSessionUuid = sessionUuid;
+      return true;
     }
     if (this.boundDeviceSessions.get(mcpSessionId) === sessionUuid) {
       return false;
@@ -126,6 +137,10 @@ export class SessionToolBinding {
     }
     if (this.initialSessionUuid === sessionUuid) {
       this.initialSessionUuid = undefined;
+      removed = true;
+    }
+    if (this.directDeviceSessionUuid === sessionUuid) {
+      this.directDeviceSessionUuid = undefined;
       removed = true;
     }
     return removed;

--- a/src/server/directSessionDeviceRegistry.ts
+++ b/src/server/directSessionDeviceRegistry.ts
@@ -8,6 +8,7 @@ interface DirectSessionDevice {
 const sessions = new Map<string, BootedDevice>();
 
 export function registerDirectSessionDevice(sessionUuid: string, device: BootedDevice): void {
+  unregisterDirectSessionsForDevice(device.deviceId);
   sessions.set(sessionUuid, { ...device });
 }
 

--- a/src/server/index.ts
+++ b/src/server/index.ts
@@ -126,6 +126,36 @@ function stripInternalToolParams(params: unknown): unknown {
   return rest;
 }
 
+function getDeviceSessionIdFromResult(result: unknown): string | undefined {
+  if (!result || typeof result !== "object" || !("content" in result)) {
+    return undefined;
+  }
+  const content = (result as { content?: unknown }).content;
+  if (!Array.isArray(content)) {
+    return undefined;
+  }
+  const text = content.find(item => (
+    item
+    && typeof item === "object"
+    && "type" in item
+    && (item as { type?: unknown }).type === "text"
+    && "text" in item
+    && typeof (item as { text?: unknown }).text === "string"
+  )) as { text: string } | undefined;
+  if (!text) {
+    return undefined;
+  }
+  try {
+    const payload = JSON.parse(text.text) as { sessionId?: unknown };
+    return typeof payload.sessionId === "string" && payload.sessionId.trim().length > 0
+      ? payload.sessionId
+      : undefined;
+  } catch (error) {
+    logger.debug("[MCP] Device-start response did not contain JSON", { error });
+    return undefined;
+  }
+}
+
 function flattenZodIssues(issues: ZodIssue[]): ZodIssue[] {
   const flattened: ZodIssue[] = [];
 
@@ -292,8 +322,9 @@ export const createMcpServer = (options: McpServerOptions = {}): McpServer => {
   });
 
   // Register all resources with the server
-  ResourceRegistry.registerWithServer(server, () => ({
+  ResourceRegistry.registerWithServer(server, signal => ({
     sessionUuid: sessionToolBinding.effectiveSessionUuid(options.sessionContext?.sessionId),
+    signal,
   }));
 
   // Tear down this transport's server-side SessionToolBinding when the daemon
@@ -548,6 +579,12 @@ export const createMcpServer = (options: McpServerOptions = {}): McpServer => {
           () => tool.handler(handlerParams, progressCallback, execution.abortController.signal)
         )
       );
+      if (
+        (name === "getAndroid" || name === "getApple" || name === "startDevice")
+        && sessionToolBinding.bind(sessionId, getDeviceSessionIdFromResult(result))
+      ) {
+        ToolRegistry.notifyToolListChanged();
+      }
       // Wire-boundary output policy: strip the duplicated `structuredContent`
       // tree for no-schema tools unconditionally (issue #2759) and for schema
       // tools when the `--tool-results-no-structured-content` flag is on (issue

--- a/src/server/observationResources.ts
+++ b/src/server/observationResources.ts
@@ -231,7 +231,7 @@ function isAuthorizedSessionResource(
   context: ResourceReadContext,
   sessionUuid: string,
 ): boolean {
-  return !context.sessionUuid || context.sessionUuid === sessionUuid;
+  return context.sessionUuid === sessionUuid;
 }
 
 // Session-scoped handler for a cached observation.
@@ -359,7 +359,10 @@ async function getFreshSessionScreenshot(
       sessionScreenshotResourceDependencies.createScreenshotService(activeSession.device);
     const { promise } = screenshotService.startTrackedCapture(
       { format: "png" },
-      { queueAfterPending: true },
+      {
+        parentSignal: context.signal,
+        queueAfterPending: true,
+      },
     );
     const result = await promise;
 

--- a/src/server/resourceRegistry.ts
+++ b/src/server/resourceRegistry.ts
@@ -5,6 +5,7 @@ import { ListChangedBroadcaster } from "./listChangedBroadcast";
 
 export interface ResourceReadContext {
   sessionUuid?: string;
+  signal?: AbortSignal;
 }
 
 // Interface for resource content handlers
@@ -231,7 +232,7 @@ class ResourceRegistryClass {
   // Register all resources with an MCP server
   registerWithServer(
     server: McpServer,
-    getReadContext: () => ResourceReadContext = () => ({}),
+    getReadContext: (signal: AbortSignal) => ResourceReadContext = () => ({}),
   ): void {
     this.trackServer(server);
 
@@ -243,7 +244,7 @@ class ResourceRegistryClass {
     });
 
     // Set handler for reading resource content
-    server.server.setRequestHandler(ReadResourceRequestSchema, async request => {
+    server.server.setRequestHandler(ReadResourceRequestSchema, async (request, extra) => {
       const { uri } = request.params;
       logger.info(`[ResourceRegistry] ReadResource request for URI: ${uri}`);
 
@@ -278,7 +279,7 @@ class ResourceRegistryClass {
       if (templateMatch) {
         const { template, params } = templateMatch;
         const content = "handlerWithReadContext" in template
-          ? await template.handlerWithReadContext(params, getReadContext())
+          ? await template.handlerWithReadContext(params, getReadContext(extra.signal))
           : await template.handler(params);
         return {
           contents: [content]

--- a/test/features/observe/TakeScreenshot.test.ts
+++ b/test/features/observe/TakeScreenshot.test.ts
@@ -6,6 +6,8 @@ import { FakeFileSystem } from "../../fakes/FakeFileSystem";
 import { FakeTimer } from "../../fakes/FakeTimer";
 import { FakeAdbClientFactory } from "../../fakes/FakeAdbClientFactory";
 import { CountingIdGenerator } from "../../../src/utils/IdGenerator";
+import { IOSCtrlProxyClient } from "../../../src/features/observe/ios";
+import { OPERATION_CANCELLED_MESSAGE } from "../../../src/utils/constants";
 
 describe("TakeScreenshot", function() {
   describe("Unit Tests for Extracted Methods", function() {
@@ -111,6 +113,48 @@ describe("TakeScreenshot", function() {
       expect(calledCommand).toContain("rm"); // Should cleanup temp file in same command
 
       expect(result.success).toBe(true);
+    });
+  });
+
+  describe("iOS cancellation", function() {
+    test("does not write or publish a screenshot after the request is cancelled", async function() {
+      const iosDevice: BootedDevice = {
+        name: "iPhone",
+        platform: "ios",
+        deviceId: "ios-device-id",
+        source: "local",
+      };
+      const controller = new AbortController();
+      const originalGetInstance = IOSCtrlProxyClient.getInstance;
+      let requestScreenshotCalls = 0;
+      IOSCtrlProxyClient.getInstance = (() => ({
+        ensureConnected: async () => true,
+        requestScreenshot: async () => {
+          requestScreenshotCalls++;
+          controller.abort();
+          return {
+            success: true,
+            data: Buffer.from("image").toString("base64"),
+          };
+        },
+      })) as typeof IOSCtrlProxyClient.getInstance;
+
+      try {
+        const screenshot = new TakeScreenshot(
+          iosDevice,
+          new FakeAdbClientFactory(new FakeAdbExecutor()),
+        );
+
+        const result = await screenshot.execute({ format: "png" }, controller.signal);
+
+        expect(requestScreenshotCalls).toBe(1);
+        expect(result).toEqual({
+          success: false,
+          error: OPERATION_CANCELLED_MESSAGE,
+        });
+      } finally {
+        IOSCtrlProxyClient.getInstance = originalGetInstance;
+      }
     });
   });
 

--- a/test/features/observe/screenshot/ObserveScreenshotRecorder.test.ts
+++ b/test/features/observe/screenshot/ObserveScreenshotRecorder.test.ts
@@ -210,6 +210,14 @@ describe("DefaultObserveScreenshotRecorder.capture", () => {
 
     expect(store.getError("test-device")).toBe("network down");
   });
+
+  test("capture() coalesces ordinary work so a fresh capture is not cancelled", async () => {
+    svc.setNextResult({ success: false, error: OPERATION_CANCELLED_MESSAGE });
+
+    await recorder.capture(new NoOpPerformanceTracker());
+
+    expect(svc.lastTrackerOptions?.coalesceWithPending).toBe(true);
+  });
 });
 
 describe("DefaultObserveScreenshotRecorder.start", () => {

--- a/test/server/observationResources.test.ts
+++ b/test/server/observationResources.test.ts
@@ -20,6 +20,7 @@ import {
 import {
   clearDirectSessionDevices,
   registerDirectSessionDevice,
+  resolveDirectSessionDevice,
 } from "../../src/server/directSessionDeviceRegistry";
 import { FakeAdbClientFactory } from "../fakes/FakeAdbClientFactory";
 import { FakeAdbExecutor } from "../fakes/FakeAdbExecutor";
@@ -35,7 +36,10 @@ function activeSession(device: BootedDevice = sessionDevice) {
   return { sessionUuid, device };
 }
 
-function readTemplate(uri: string, context: ResourceReadContext = {}) {
+function readTemplate(
+  uri: string,
+  context: ResourceReadContext = { sessionUuid },
+) {
   registerObservationResources();
   const match = ResourceRegistry.matchTemplate(uri);
   expect(match).toBeDefined();
@@ -162,6 +166,25 @@ describe("session screenshot resources", () => {
     expect(screenshotServiceCalls).toBe(0);
   });
 
+  test("rejects session resource reads without a bound session", async () => {
+    let resolveCalls = 0;
+    setSessionScreenshotResourceDependencies({
+      resolveActiveSession: () => {
+        resolveCalls++;
+        return activeSession();
+      },
+      createScreenshotService: () => createTrackedScreenshot({ success: true }),
+    });
+
+    const content = await readTemplate(
+      "automobile:observation/session/session-123/latest",
+      {},
+    );
+
+    expect(JSON.parse(content.text!).error).toContain("bound device session");
+    expect(resolveCalls).toBe(0);
+  });
+
   test("returns a fresh PNG capture for an active session", async () => {
     const image = Buffer.from("fresh screenshot");
     let captureDevice: BootedDevice | undefined;
@@ -231,8 +254,34 @@ describe("session screenshot resources", () => {
     const content = await contentPromise;
 
     expect(freshCaptureCount).toBe(1);
-    expect(freshTrackerOptions).toEqual({ queueAfterPending: true });
+    expect(freshTrackerOptions).toMatchObject({ queueAfterPending: true });
     expect(content.blob).toBe(image.toString("base64"));
+  });
+
+  test("forwards the resource read cancellation signal to the fresh capture", async () => {
+    const controller = new AbortController();
+    let receivedSignal: AbortSignal | undefined;
+    setSessionScreenshotResourceDependencies({
+      resolveActiveSession: () => activeSession(),
+      createScreenshotService: () => ({
+        ...createTrackedScreenshot({ success: false, error: "cancelled" }),
+        startTrackedCapture(_options, trackerOptions) {
+          receivedSignal = trackerOptions?.parentSignal;
+          return ScreenshotJobTracker.startJob(
+            sessionDevice.deviceId,
+            async () => ({ success: false, error: "cancelled" }),
+            trackerOptions,
+          );
+        },
+      }),
+    });
+
+    await readTemplate(
+      "automobile:device-session/session-123/screenshot",
+      { sessionUuid, signal: controller.signal },
+    );
+
+    expect(receivedSignal).toBe(controller.signal);
   });
 
   test("rejects a fresh capture when the session no longer owns its device", async () => {
@@ -254,5 +303,16 @@ describe("session screenshot resources", () => {
 
     expect(content.mimeType).toBe("application/json");
     expect(JSON.parse(content.text!).error).toContain("No active device session found");
+  });
+
+  test("replaces an older direct session for the same device", () => {
+    registerDirectSessionDevice("session-old", sessionDevice);
+    registerDirectSessionDevice("session-new", sessionDevice);
+
+    expect(resolveDirectSessionDevice("session-old")).toBeUndefined();
+    expect(resolveDirectSessionDevice("session-new")).toEqual({
+      sessionUuid: "session-new",
+      device: sessionDevice,
+    });
   });
 });

--- a/test/server/resourceRegistryListChanged.test.ts
+++ b/test/server/resourceRegistryListChanged.test.ts
@@ -13,10 +13,13 @@ import { ListChangedBroadcaster } from "../../src/server/listChangedBroadcast";
 // fan-out; notifyResourceListChanged sends via `server.server.notification`.
 class FakeUnderlyingServer {
   notifications: Array<{ method: string; params?: unknown }> = [];
-  handlersBySchema = new Map<unknown, (request: unknown) => Promise<unknown>>();
+  handlersBySchema = new Map<unknown, (request: unknown, extra?: unknown) => Promise<unknown>>();
   shouldThrow = false;
   onclose?: () => void;
-  setRequestHandler(schema: unknown, handler: (request: unknown) => Promise<unknown>): void {
+  setRequestHandler(
+    schema: unknown,
+    handler: (request: unknown, extra?: unknown) => Promise<unknown>,
+  ): void {
     this.handlersBySchema.set(schema, handler);
   }
   async notification(payload: { method: string; params?: unknown }): Promise<void> {
@@ -150,22 +153,30 @@ describe("ResourceRegistry URI-template matching", () => {
       "application/json",
       async (params, context) => ({
         uri: `automobile:test/${params.id}`,
-        text: JSON.stringify(context),
+        text: JSON.stringify({
+          sessionUuid: context.sessionUuid,
+          hasSignal: context.signal === controller.signal,
+        }),
       }),
     );
+    const controller = new AbortController();
     ResourceRegistry.registerWithServer(
       server as unknown as McpServer,
-      () => ({ sessionUuid: "session-bound" }),
+      signal => ({ sessionUuid: "session-bound", signal }),
     );
 
     const readHandler = server.server.handlersBySchema.get(ReadResourceRequestSchema);
     expect(readHandler).toBeDefined();
-    const response = await readHandler!({ params: { uri: "automobile:test/one" } }) as {
+    const response = await readHandler!(
+      { params: { uri: "automobile:test/one" } },
+      { signal: controller.signal },
+    ) as {
       contents: Array<{ text?: string }>;
     };
 
     expect(JSON.parse(response.contents[0].text!)).toEqual({
       sessionUuid: "session-bound",
+      hasSignal: true,
     });
   });
 });

--- a/test/server/sessionResourceBinding.test.ts
+++ b/test/server/sessionResourceBinding.test.ts
@@ -1,0 +1,56 @@
+import { afterEach, describe, expect, test } from "bun:test";
+import { z } from "zod/v4";
+import { McpTestFixture } from "../fixtures/mcpTestFixture";
+import { ResourceRegistry } from "../../src/server/resourceRegistry";
+import { ToolRegistry } from "../../src/server/toolRegistry";
+import { createJSONToolResponse } from "../../src/utils/toolUtils";
+
+describe("session-scoped resource binding", () => {
+  let fixture: McpTestFixture | undefined;
+
+  afterEach(async () => {
+    await fixture?.teardown();
+    fixture = undefined;
+    ToolRegistry.clearTools();
+    ResourceRegistry.clearResources();
+  });
+
+  test("binds the session returned by direct getAndroid for later resource reads", async () => {
+    fixture = new McpTestFixture();
+    await fixture.setup();
+
+    ToolRegistry.clearTools();
+    ToolRegistry.register(
+      "getAndroid",
+      "getAndroid",
+      z.object({}),
+      async () => createJSONToolResponse({ sessionId: "direct-session-1" }),
+    );
+    ResourceRegistry.registerTemplateWithReadContext(
+      "automobile:test-session-binding/{sessionUuid}",
+      "Session binding test",
+      "Returns the bound session for transport binding coverage.",
+      "application/json",
+      async (_params, context) => ({
+        uri: "automobile:test-session-binding/direct-session-1",
+        text: JSON.stringify({ sessionUuid: context.sessionUuid }),
+      }),
+    );
+
+    const { client } = fixture.getContext();
+    await client.request({
+      method: "tools/call",
+      params: { name: "getAndroid", arguments: {} },
+    }, z.any());
+    const response = await client.request({
+      method: "resources/read",
+      params: { uri: "automobile:test-session-binding/direct-session-1" },
+    }, z.object({
+      contents: z.array(z.object({ text: z.string().optional() })),
+    }));
+
+    expect(JSON.parse(response.contents[0].text!)).toEqual({
+      sessionUuid: "direct-session-1",
+    });
+  });
+});

--- a/test/server/sessionToolDiscovery.test.ts
+++ b/test/server/sessionToolDiscovery.test.ts
@@ -40,6 +40,16 @@ describe("session-scoped tool discovery", () => {
     expect(binding.effectiveCapabilityProfileUuid(undefined)).toBe("capability-profile-1");
   });
 
+  test("binds a device session returned by direct startup", () => {
+    const binding = new SessionToolBinding();
+
+    expect(binding.bind(undefined, "device-session-a")).toBe(true);
+    expect(binding.effectiveSessionUuid(undefined)).toBe("device-session-a");
+    expect(binding.bind(undefined, "device-session-a")).toBe(false);
+    expect(binding.unbindSession("device-session-a")).toBe(true);
+    expect(binding.effectiveSessionUuid(undefined)).toBeUndefined();
+  });
+
   test("seeds only a recreated transport's initial session binding", () => {
     const binding = new SessionToolBinding("device-session-a");
 


### PR DESCRIPTION
## Summary

Follow-up to [#5442](https://github.com/kaeawc/auto-mobile/pull/5442) addressing all eight unresolved review threads:

- bind `getAndroid`/`getApple`/`startDevice` session results to the calling transport and require an exact session match for session-scoped resources
- carry MCP read cancellation into fresh captures and honor cancellation during iOS screenshot persistence
- prevent ordinary observe captures from cancelling fresh resource captures
- retire stale direct-mode session mappings for a reused device
- correct the resource documentation to name `sessionId` as the URI's `{sessionUuid}` value

## Validation

- `bun test test/server/sessionResourceBinding.test.ts test/server/observationResources.test.ts test/server/resourceRegistryListChanged.test.ts test/server/sessionToolDiscovery.test.ts test/features/observe/screenshot/ObserveScreenshotRecorder.test.ts test/utils/ScreenshotJobTracker.test.ts`
- `bun test test/features/observe/TakeScreenshot.test.ts`
- `bun run build`
- `bun run lint`
- `bun run typecheck`
- `bun run turbo:validate`
