### PR TITLE
fix: resolve Android AVD name from system property

### DIFF
--- a/src/utils/android-cmdline-tools/AndroidEmulatorClient.ts
+++ b/src/utils/android-cmdline-tools/AndroidEmulatorClient.ts
@@ -1322,6 +1322,51 @@ export class AndroidEmulatorClient implements AndroidEmulator {
     }
   }
 
+  private async getRunningAVDName(
+    device: BootedDevice,
+    infoTimeoutMs: number,
+    signal?: AbortSignal,
+  ): Promise<string> {
+    const deviceId = device.deviceId;
+    const adbWithDevice = this.adbFactory.create(device);
+    try {
+      const result = await adbWithDevice.executeCommand(
+        "emu avd name",
+        infoTimeoutMs,
+        undefined,
+        true,
+        signal,
+      );
+      const avdName = result.stdout.trim().replace(/\r?\n.*$/, "");
+      logger.debug(
+        `AVD name detection for ${deviceId}: raw="${result.stdout}" (${result.stdout.length} chars), cleaned="${avdName}"`,
+      );
+      if (avdName) {
+        return avdName;
+      }
+    } catch (error) {
+      logger.debug(`Failed to get AVD name for ${deviceId}: ${error}`);
+    }
+
+    try {
+      const result = await adbWithDevice.executeCommand(
+        "shell getprop ro.boot.qemu.avd_name",
+        infoTimeoutMs,
+        undefined,
+        true,
+        signal,
+      );
+      const avdName = result.stdout.trim().replace(/\r?\n.*$/, "");
+      logger.debug(
+        `AVD name property fallback for ${deviceId}: raw="${result.stdout}" (${result.stdout.length} chars), cleaned="${avdName}"`,
+      );
+      return avdName;
+    } catch (error) {
+      logger.debug(`Failed to get AVD name property for ${deviceId}: ${error}`);
+      return "";
+    }
+  }
+
   /**
    * Like {@link getBootedDevices} but rethrows discovery failures (e.g. adb
    * unreachable) instead of swallowing them into an empty list. Callers that
@@ -1353,40 +1398,15 @@ export class AndroidEmulatorClient implements AndroidEmulator {
       perf.startOperation("avdNameResolution");
       for (const device of emulatorDevices) {
         const deviceId = device.deviceId;
-        try {
-          // Try to get the AVD name from the running emulator
-          const adbWithDevice = this.adbFactory.create(device);
-          const result = await adbWithDevice.executeCommand(
-            "emu avd name",
-            infoTimeoutMs,
-            undefined,
-            true,
-            signal,
-          );
-          const avdName = result.stdout.trim().replace(/\r?\n.*$/, ""); // Remove any trailing newlines and additional text
+        const avdName = await this.getRunningAVDName(device, infoTimeoutMs, signal);
 
-          logger.debug(
-            `AVD name detection for ${deviceId}: raw="${result.stdout}" (${result.stdout.length} chars), cleaned="${avdName}"`,
-          );
-
-          runningDevices.push({
-            ...device,
-            name: avdName || this.unknownEmulatorName(deviceId),
-            platform: "android",
-            deviceId: deviceId,
-            source: "local",
-          });
-        } catch (error) {
-          // If we can't get the AVD name, just use the device ID
-          logger.debug(`Failed to get AVD name for ${deviceId}: ${error}`);
-          runningDevices.push({
-            ...device,
-            name: this.unknownEmulatorName(deviceId),
-            platform: "android",
-            deviceId: deviceId,
-            source: "local",
-          });
-        }
+        runningDevices.push({
+          ...device,
+          name: avdName || this.unknownEmulatorName(deviceId),
+          platform: "android",
+          deviceId: deviceId,
+          source: "local",
+        });
       }
 
       for (const device of physicalDevices) {

--- a/test/utils/android-cmdline-tools/AndroidEmulatorClient-getBootedDevices.test.ts
+++ b/test/utils/android-cmdline-tools/AndroidEmulatorClient-getBootedDevices.test.ts
@@ -5,6 +5,16 @@ import { FakeAdbClientFactory } from "../../fakes/FakeAdbClientFactory";
 import { FakeAdbExecutor } from "../../fakes/FakeAdbExecutor";
 import { FakeTimer } from "../../fakes/FakeTimer";
 
+function execResult(stdout: string) {
+  return {
+    stdout,
+    stderr: "",
+    toString: () => stdout,
+    trim: () => stdout.trim(),
+    includes: (search: string) => stdout.includes(search),
+  };
+}
+
 class FailingDiscoveryAdbExecutor extends FakeAdbExecutor {
   override async getBootedAndroidDevices(): Promise<BootedDevice[]> {
     throw new Error("adb server unavailable");
@@ -23,6 +33,32 @@ class RecordingAdbExecutor extends FakeAdbExecutor {
 }
 
 describe("AndroidEmulatorClient.getBootedDevicesChecked", () => {
+  test("uses the AVD name property when the emulator console returns no name", async () => {
+    const adb = new FakeAdbExecutor();
+    adb.setDevices([{
+      name: "ignored",
+      platform: "android",
+      deviceId: "emulator-5554",
+    } satisfies BootedDevice]);
+    adb.setCommandResponse("emu avd name", execResult("\n"));
+    adb.setCommandResponse(
+      "shell getprop ro.boot.qemu.avd_name",
+      execResult("Codex_KVM_Verify\nignored trailing output"),
+    );
+    const client = new AndroidEmulatorClient(null, null, new FakeTimer(), new FakeAdbClientFactory(adb));
+
+    await expect(client.getBootedDevicesChecked()).resolves.toEqual([{
+      name: "Codex_KVM_Verify",
+      platform: "android",
+      deviceId: "emulator-5554",
+      source: "local",
+    }]);
+    expect(adb.getExecutedCommands()).toEqual([
+      "emu avd name",
+      "shell getprop ro.boot.qemu.avd_name",
+    ]);
+  });
+
   test("preserves transport identity when AVD-name lookup fails", async () => {
     const adb = new FakeAdbExecutor();
     adb.setDevices([{


### PR DESCRIPTION
Closes #5450

## Summary

- resolve an Android emulator's AVD name from `ro.boot.qemu.avd_name` when the emulator-console query is empty or unavailable
- retain the emulator-console query as the primary lookup
- cover the fallback and command ordering with a focused discovery test

## Root cause

Some emulator environments can report an empty result for `adb emu avd name` after boot. AutoMobile then treated the serial as an unknown AVD name, preventing readiness from associating the launched emulator with its requested AVD.

## Validation

- `bun test test/utils/android-cmdline-tools/AndroidEmulatorClient-getBootedDevices.test.ts`
- `bun run build`
- `bun run lint`
- `bun run turbo:validate` (13,768 pass, 14 skipped, 0 fail)
