### PR TITLE
fix(release): force Isolated Projects off for Maven publish invocations

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -477,12 +477,17 @@ jobs:
           # (not SNAPSHOT in gradle.properties)
           # Publish dependency modules first — separate invocation
           # guarantees completion before consumer modules
+          # Isolated Projects forbids --no-configuration-cache; force IP off for
+          # these publish invocations only so a runner-global gradle.properties
+          # enabling IP can't break the release. Normal builds are unaffected.
           ./gradlew :protocol:publish :test-plan-validation:publish \
             -PVERSION_NAME=${{ steps.version.outputs.version }} \
-            --no-configuration-cache
+            --no-configuration-cache \
+            -Dorg.gradle.unsafe.isolated-projects=false
           ./gradlew :junit-runner:publish :auto-mobile-sdk:publish \
             -PVERSION_NAME=${{ steps.version.outputs.version }} \
-            --no-configuration-cache
+            --no-configuration-cache \
+            -Dorg.gradle.unsafe.isolated-projects=false
 
       - name: Publish to npm
         env:

--- a/scripts/release/maven-publication-manifest-preflight.sh
+++ b/scripts/release/maven-publication-manifest-preflight.sh
@@ -52,8 +52,12 @@ else
   (
     cd "$android_dir"
     rm -rf build/central-manifest
+    # Isolated Projects forbids --no-configuration-cache; force it off for this
+    # preflight invocation only so a global/CI ~/.gradle enabling IP can't break
+    # staging. Normal builds are unaffected. See android/gradle.properties.
     ./gradlew ${tasks[@]+"${tasks[@]}"} -PVERSION_NAME="$VERSION" \
-      -PmavenManifestStaging --no-configuration-cache
+      -PmavenManifestStaging --no-configuration-cache \
+      -Dorg.gradle.unsafe.isolated-projects=false
   )
 fi
 

--- a/scripts/release/release.sh
+++ b/scripts/release/release.sh
@@ -111,7 +111,10 @@ update_gradle_version "$version"
 
 echo ""
 echo -e "${GREEN}Step 2: Publish to Maven Central${NC}"
-run_gradle :protocol:publishAndReleaseToMavenCentral :test-plan-validation:publishAndReleaseToMavenCentral :junit-runner:publishAndReleaseToMavenCentral :auto-mobile-sdk:publishAndReleaseToMavenCentral --no-configuration-cache
+# Isolated Projects forbids --no-configuration-cache, so force it off for this
+# publish invocation only — a global/CI ~/.gradle enabling IP must not break the
+# release. Does not touch IP for normal builds. See android/gradle.properties.
+run_gradle :protocol:publishAndReleaseToMavenCentral :test-plan-validation:publishAndReleaseToMavenCentral :junit-runner:publishAndReleaseToMavenCentral :auto-mobile-sdk:publishAndReleaseToMavenCentral --no-configuration-cache -Dorg.gradle.unsafe.isolated-projects=false
 
 echo ""
 echo -e "${GREEN}Step 3: Restore snapshot version ($next_snapshot)${NC}"


### PR DESCRIPTION
## Problem

Maven Central publishing invokes Gradle with `--no-configuration-cache` (the vanniktech/maven-publish path isn't configuration-cache-safe). Gradle 8.x **rejects** that flag whenever Isolated Projects (IP) is enabled:

```
Configuration Cache cannot be disabled when Isolated Projects is enabled.
BUILD FAILED
```

The android tree pins `org.gradle.unsafe.isolated-projects=false` in [`android/gradle.properties`](android/gradle.properties), but a developer's global `~/.gradle/gradle.properties` — or a CI runner — can enable IP, and that machine-wide override silently breaks **every** publish invocation. The release should not depend on IP being disabled machine-wide.

## Fix

Make the publish commands self-defensive: pass `-Dorg.gradle.unsafe.isolated-projects=false` alongside the existing `--no-configuration-cache` so the two flags can never conflict, regardless of the global/CI `gradle.properties`. The command-line `-D` override wins over `gradle.properties` and is scoped to the publish invocation only — IP is left untouched for normal builds, and no global or committed `gradle.properties` is modified.

Applied to all four publish invocations that pass `--no-configuration-cache`:

- [`scripts/release/release.sh`](scripts/release/release.sh) — `:*:publishAndReleaseToMavenCentral`
- [`scripts/release/maven-publication-manifest-preflight.sh`](scripts/release/maven-publication-manifest-preflight.sh) — `mavenManifestStaging` preflight
- [`.github/workflows/release.yml`](.github/workflows/release.yml) — both `./gradlew ... :publish` steps

## Verification

Simulated a machine with IP enabled globally (temp Gradle user home with `org.gradle.unsafe.isolated-projects=true`):

- **Before** (`help --no-configuration-cache`): `Configuration Cache cannot be disabled when Isolated Projects is enabled.` → `BUILD FAILED`
- **After** (same + `-Dorg.gradle.unsafe.isolated-projects=false`): `BUILD SUCCESSFUL`

Also run:
- `shellcheck` on both edited scripts — clean (fast-validation `--only shellcheck` OK)
- `test/bats/release-workflow-wiring.bats` (41) + `test/bats/maven-publication-manifest.bats` — all pass

No version bump, no actual release performed.