### PR TITLE
build(desktop): Conveyor macOS + Linux packaging + CI (coexists with jpackage) [C3]

### DIFF
--- a/.github/workflows/build-desktop-conveyor.yml
+++ b/.github/workflows/build-desktop-conveyor.yml
@@ -1,0 +1,142 @@
+name: "Build Desktop App (Conveyor)"
+
+# Cross-builds the Compose Desktop app (`android/desktop-app`) for macOS + Linux with Hydraulic
+# Conveyor and produces an auto-update site, uploaded as CI artifacts (no live publish). Windows is
+# intentionally out of scope for now. This coexists with build-desktop-app-installers.yml (jpackage);
+# it does not replace it yet (that is PR-C4, #5227).
+#
+# Manual/dispatch only for now — it does not run on release tags, so it never collides with the
+# jpackage .dmg/.deb that release.yml already uploads to the GitHub Release. When jpackage is retired
+# (C4), this becomes the release publisher (via app.vcs-url = github.com/kaeawc/auto-mobile).
+#
+# Conveyor cross-builds every target from one Linux machine; the desktop-app build declares each
+# target's Skiko + ffmpeg natives (macAmd64/macAarch64/linuxAmd64 configurations) so the resolved
+# per-machine `app.inputs` are correct. See android/conveyor.conf and android/ci.conveyor.conf.
+on:
+  workflow_dispatch:
+    inputs:
+      version:
+        description: "Package version (plain semver, macOS major >= 1, e.g. 1.0.0)"
+        required: true
+        type: string
+      signed:
+        description: "Sign + notarize macOS with the Developer ID (needs the Apple secrets)"
+        required: false
+        type: boolean
+        default: false
+  workflow_call:
+    inputs:
+      version:
+        description: "Package version (plain semver, macOS major >= 1)"
+        required: true
+        type: string
+      signed:
+        required: false
+        type: boolean
+        default: false
+    secrets:
+      CONVEYOR_SIGNING_KEY:
+        description: "Conveyor root signing key (conveyor keys generate). Free for OSS."
+        required: true
+      MACOS_DEVELOPER_ID_CERT_BASE64:
+        required: false
+      MACOS_DEVELOPER_ID_CERT_PASSWORD:
+        required: false
+      APPLE_NOTARY_KEY_ID:
+        required: false
+      APPLE_NOTARY_ISSUER_ID:
+        required: false
+      APPLE_NOTARY_PRIVATE_KEY_BASE64:
+        required: false
+
+permissions:
+  contents: read
+
+jobs:
+  conveyor:
+    name: "Conveyor make site (macOS + Linux)"
+    runs-on: ubuntu-latest
+    timeout-minutes: 45
+    steps:
+      - name: "Git Checkout"
+        uses: actions/checkout@v6
+        with:
+          # Conveyor reads the app icon (conveyor.conf `icons`), which is LFS-tracked, so unlike the
+          # jpackage workflow the pointer must be smudged to the real PNG.
+          lfs: true
+          persist-credentials: false
+
+      - name: "Validate version"
+        shell: bash
+        env:
+          VERSION: ${{ inputs.version }}
+        run: |
+          set -euo pipefail
+          if [[ ! "$VERSION" =~ ^[0-9]+\.[0-9]+\.[0-9]+([-+][0-9A-Za-z.-]+)?$ ]]; then
+            echo "Invalid version: $VERSION (expected MAJOR.MINOR.PATCH semver)" >&2
+            exit 1
+          fi
+          major="${VERSION%%.*}"
+          if [[ "$major" -lt 1 ]]; then
+            echo "Conveyor requires a macOS major version >= 1; got $VERSION" >&2
+            exit 1
+          fi
+
+      - name: "Set up JDK 21"
+        uses: actions/setup-java@v4
+        with:
+          distribution: temurin
+          java-version: "21"
+
+      - name: "Set up AutoMobile npm package"
+        uses: ./.github/actions/setup-auto-mobile-npm-package
+
+      # Build the module jars up front. The Conveyor CLI resolves runtimeClasspath (via
+      # printConveyorConfig) to compute app.inputs; the StripFfmpegProgramsTransform passthrough
+      # requires those jars to exist. printConveyorConfig now depends on runtimeClasspath so this is
+      # belt-and-suspenders, but it also warms the build cache before Conveyor runs.
+      - name: "Build desktop jars"
+        working-directory: android
+        run: ./gradlew :desktop-app:jar
+
+      # Decode the Apple credentials to files only for a signed build. Left unset for the default
+      # (self-signed) artifacts-only run, so no Apple secrets are needed to dispatch.
+      - name: "Prepare macOS signing credentials"
+        if: ${{ inputs.signed }}
+        env:
+          MACOS_DEVELOPER_ID_CERT_BASE64: ${{ secrets.MACOS_DEVELOPER_ID_CERT_BASE64 }}
+          APPLE_NOTARY_PRIVATE_KEY_BASE64: ${{ secrets.APPLE_NOTARY_PRIVATE_KEY_BASE64 }}
+        run: |
+          set -euo pipefail
+          mkdir -p "${RUNNER_TEMP}/conveyor-signing"
+          cert="${RUNNER_TEMP}/conveyor-signing/developer-id.p12"
+          p8="${RUNNER_TEMP}/conveyor-signing/notary.p8"
+          printf '%s' "$MACOS_DEVELOPER_ID_CERT_BASE64" | base64 --decode > "$cert"
+          printf '%s' "$APPLE_NOTARY_PRIVATE_KEY_BASE64" | base64 --decode > "$p8"
+          echo "CONVEYOR_MAC_CERTIFICATE_P12=$cert" >> "$GITHUB_ENV"
+          echo "CONVEYOR_NOTARY_PRIVATE_KEY_P8=$p8" >> "$GITHUB_ENV"
+
+      - name: "Run Conveyor (make site)"
+        uses: hydraulic-software/conveyor/actions/build@v22.0
+        with:
+          command: make site
+          # The action runs from the repo root and has no working-dir input, so point Conveyor at the
+          # config with -f; Conveyor treats the config file's directory (android/) as the project
+          # root, so its `./gradlew` include and relative asset paths resolve there. A signed run uses
+          # ci.conveyor.conf (Developer ID + notarization over the base); the default self-signs.
+          extra_flags: ${{ inputs.signed && '-f android/ci.conveyor.conf' || '-f android/conveyor.conf' }}
+          signing_key: ${{ secrets.CONVEYOR_SIGNING_KEY }}
+          agree_to_license: 1
+        env:
+          CONVEYOR_APP_VERSION: ${{ inputs.version }}
+          MACOS_DEVELOPER_ID_CERT_PASSWORD: ${{ secrets.MACOS_DEVELOPER_ID_CERT_PASSWORD }}
+          APPLE_NOTARY_ISSUER_ID: ${{ secrets.APPLE_NOTARY_ISSUER_ID }}
+          APPLE_NOTARY_KEY_ID: ${{ secrets.APPLE_NOTARY_KEY_ID }}
+
+      - name: "Upload Conveyor site + packages"
+        uses: actions/upload-artifact@v4
+        with:
+          name: automobile-desktop-conveyor
+          path: android/output
+          if-no-files-found: error
+          retention-days: 7

--- a/.github/workflows/build-desktop-conveyor.yml
+++ b/.github/workflows/build-desktop-conveyor.yml
@@ -106,6 +106,7 @@ jobs:
         env:
           MACOS_DEVELOPER_ID_CERT_BASE64: ${{ secrets.MACOS_DEVELOPER_ID_CERT_BASE64 }}
           APPLE_NOTARY_PRIVATE_KEY_BASE64: ${{ secrets.APPLE_NOTARY_PRIVATE_KEY_BASE64 }}
+          MACOS_DEVELOPER_ID_CERT_PASSWORD: ${{ secrets.MACOS_DEVELOPER_ID_CERT_PASSWORD }}
         run: |
           set -euo pipefail
           mkdir -p "${RUNNER_TEMP}/conveyor-signing"
@@ -115,6 +116,10 @@ jobs:
           printf '%s' "$APPLE_NOTARY_PRIVATE_KEY_BASE64" | base64 --decode > "$p8"
           echo "CONVEYOR_MAC_CERTIFICATE_P12=$cert" >> "$GITHUB_ENV"
           echo "CONVEYOR_NOTARY_PRIVATE_KEY_P8=$p8" >> "$GITHUB_ENV"
+          # Forward the .p12 password under the name ci.conveyor.conf reads
+          # (certificate-password = ${env.CONVEYOR_MAC_CERTIFICATE_PASSWORD}).
+          echo "::add-mask::${MACOS_DEVELOPER_ID_CERT_PASSWORD}"
+          echo "CONVEYOR_MAC_CERTIFICATE_PASSWORD=${MACOS_DEVELOPER_ID_CERT_PASSWORD}" >> "$GITHUB_ENV"
 
       - name: "Run Conveyor (make site)"
         uses: hydraulic-software/conveyor/actions/build@v22.0
@@ -129,7 +134,9 @@ jobs:
           agree_to_license: 1
         env:
           CONVEYOR_APP_VERSION: ${{ inputs.version }}
-          MACOS_DEVELOPER_ID_CERT_PASSWORD: ${{ secrets.MACOS_DEVELOPER_ID_CERT_PASSWORD }}
+          # The cert password reaches Conveyor as CONVEYOR_MAC_CERTIFICATE_PASSWORD via GITHUB_ENV
+          # from the prepare step above (matching ci.conveyor.conf). The notary issuer/key ids are
+          # read directly under their own names by ci.conveyor.conf.
           APPLE_NOTARY_ISSUER_ID: ${{ secrets.APPLE_NOTARY_ISSUER_ID }}
           APPLE_NOTARY_KEY_ID: ${{ secrets.APPLE_NOTARY_KEY_ID }}
 

--- a/android/ci.conveyor.conf
+++ b/android/ci.conveyor.conf
@@ -1,0 +1,36 @@
+// CI overlay for signed/notarized Conveyor builds — macOS Developer ID + notarization (PR-C3, #5227).
+//
+// The base conveyor.conf self-signs so a local `conveyor make` works without certificates. This
+// overlay layers real signing on top for release builds, reading every credential from environment
+// variables so nothing sensitive is committed. Use it explicitly:
+//   conveyor -f ci.conveyor.conf make site
+//
+// It reuses the Apple credentials the jpackage pipeline already stores as GitHub Actions secrets
+// (see .github/workflows/build-desktop-app-installers.yml): the Developer ID Application cert and
+// the App Store Connect notary API key. The CI workflow decodes the base64 secrets to files and
+// exports the paths below. Linux packages are not code-signed (apt signing is handled by Conveyor).
+//
+// NOTE: verify the exact macOS signing keys against the live Conveyor signing docs on the first CI
+// run — the notarization block below matches Conveyor's App Store Connect API-key form, and the
+// Developer ID certificate is supplied as a PKCS#12 that Conveyor imports.
+
+include "conveyor.conf"
+
+app {
+  sign = true
+
+  mac {
+    // Reuse the existing Developer ID Application identity rather than a Conveyor-generated one.
+    // The workflow decodes MACOS_DEVELOPER_ID_CERT_BASE64 to a .p12 and exports its path + password.
+    certificate = ${?env.CONVEYOR_MAC_CERTIFICATE_P12}
+    certificate-password = ${?env.CONVEYOR_MAC_CERTIFICATE_PASSWORD}
+
+    // Notarize with the App Store Connect API key already used by the jpackage flow
+    // (APPLE_NOTARY_ISSUER_ID / APPLE_NOTARY_KEY_ID + the .p8 decoded to a file by the workflow).
+    notarization {
+      issuer-id = ${?env.APPLE_NOTARY_ISSUER_ID}
+      key-id = ${?env.APPLE_NOTARY_KEY_ID}
+      private-key = ${?env.CONVEYOR_NOTARY_PRIVATE_KEY_P8}
+    }
+  }
+}

--- a/android/conveyor.conf
+++ b/android/conveyor.conf
@@ -1,33 +1,51 @@
-// Conveyor packaging + auto-update — LOCAL PROOF-OF-CONCEPT (PR-C1, see #5227).
+// Conveyor packaging + auto-update for the AutoMobile desktop app — macOS + Linux (PR-C3, see #5227).
 //
-// This coexists with the jpackage `compose.desktop` block in desktop-app/build.gradle.kts; it does
-// not replace it yet. Run from the `android/` directory with the Conveyor CLI:
-//   conveyor make site        # builds packages + update site into ./output (no upload)
+// Windows is intentionally out of scope for now (no Authenticode cert). This still coexists with the
+// jpackage `compose.desktop` block in desktop-app/build.gradle.kts — it does not replace it yet
+// (that is PR-C4). Build from the `android/` directory with the Conveyor CLI:
+//   conveyor make site          # builds packages + update site into ./output (no upload)
 // The CLI is a separate download (https://hydraulic.dev); it is NOT a Gradle dependency. The
 // Gradle-side integration (the printConveyorConfig task this file includes) can be validated without
 // the CLI via:  ./gradlew :desktop-app:printConveyorConfig
+//
+// Signing/notarization credentials are NOT here — they live in ci.conveyor.conf, which includes this
+// file and adds the Developer ID cert + notary key from environment variables. Run signed builds in
+// CI with:  conveyor -f ci.conveyor.conf make site
 
-// Pull the app's main class, JVM args, and resolved runtime classpath from the Gradle build.
+// Pull the app's main class, JVM args, and the resolved per-machine runtime classpaths from Gradle.
+// The build declares macAmd64 / macAarch64 / linuxAmd64 native variants so this emits correct
+// per-machine `app.<os>.<arch>.inputs` for cross-building all targets from one machine.
 include "#!./gradlew -q :desktop-app:printConveyorConfig"
 
 app {
   display-name = "AutoMobile"
-  // Stable package identity across releases (macOS bundle id / Windows MSIX upgrade identity).
+  // Stable package identity across releases (macOS bundle id, Linux package name).
   rdns-name = "dev.jasonpearson.automobile.desktop"
   vendor = "AutoMobile"
+  description = "AutoMobile Desktop - Device automation and testing dashboard"
 
-  // POC override: the repo version is 0.0.x-SNAPSHOT, but Conveyor requires a purely-numeric
-  // version with macOS major >= 1. Real versioning is a migration decision (#5227); 1.0.0 here just
-  // lets the POC build.
+  // Conveyor requires a purely-numeric version (no -SNAPSHOT) with a macOS major >= 1, but the repo
+  // version is 0.0.x-SNAPSHOT. CI passes the release version via CONVEYOR_APP_VERSION (derived from
+  // the release tag, floored to major >= 1 the same way desktopMacPackageVersion is). The 1.0.0
+  // default lets a local `conveyor make` run without the env var set.
   version = "1.0.0"
+  version = ${?env.CONVEYOR_APP_VERSION}
 
-  // Publish the update site to localhost so Conveyor stays in its free tier for the POC (no license
-  // key, no real upload). The GitHub-Releases site (app.vcs-url + app.site.copy-to) comes in PR-C3.
-  site.base-url = "localhost:3000"
+  // Ship only macOS + Linux for now; drop Conveyor's default Windows machine so `make` does not try
+  // to build a Windows package (and so no Authenticode cert is required).
+  machines = [ mac.amd64, mac.aarch64, linux.amd64.glibc ]
+
+  // Point the auto-update site at this repo's GitHub Releases: macOS updates flow through Sparkle and
+  // Linux through a generated apt repo, both served from the release assets. This is the same repo
+  // GitHubReleaseSource polls, so the DIY checker and Conveyor agree on "latest". `make site` only
+  // writes the site to ./output; actually pushing it to GitHub Releases (site.copy-to +
+  // GITHUB_TOKEN) is wired when jpackage is retired (PR-C4).
+  vcs-url = "github.com/kaeawc/auto-mobile"
 
   icons = "desktop-app/src/main/resources/icons/app-icon.png"
 
-  // No code signing for the local POC — validates packaging config without certs. Real signing
-  // (macOS Developer ID reuse + a new Windows cert) is PR-C3.
+  // Default to a self-signed build so a local `conveyor make` works without certificates. CI layers
+  // real macOS Developer ID signing + notarization on top via ci.conveyor.conf. Linux packages are
+  // not code-signed (apt uses the repo's own signing, handled by Conveyor).
   sign = false
 }

--- a/android/desktop-app/build.gradle.kts
+++ b/android/desktop-app/build.gradle.kts
@@ -169,6 +169,20 @@ configurations.named("runtimeClasspath") {
   attributes.attribute(ffmpegProgramsStripped, true)
 }
 
+// Conveyor's tasks resolve `runtimeClasspath` to compute `app.inputs`, which triggers the
+// StripFfmpegProgramsTransform on every jar — including this project's module jars (:desktop-core,
+// :protocol, …). The non-ffmpeg passthrough returns the input jar as-is, so those jars must already
+// exist on disk or the transform fails with "output must exist". Depending on the configuration's
+// producer tasks builds the module jars before Conveyor resolves the classpath, so
+// `printConveyorConfig` / `conveyor make` work from a clean checkout without a manual pre-build
+// (see
+// #5227, PR-C3).
+tasks
+  .matching { it.name == "printConveyorConfig" || it.name == "writeConveyorConfig" }
+  .configureEach {
+    dependsOn(configurations.named("runtimeClasspath"))
+  }
+
 dependencies {
   // Shared module (UX, unix socket architecture, settings, data sources)
   implementation(project(":desktop-core"))
@@ -189,6 +203,24 @@ dependencies {
   testImplementation(libs.kotlin.test)
   testImplementation(libs.kotlinx.coroutines.test)
   testImplementation(libs.junit)
+
+  // Conveyor cross-build natives (#5227, PR-C3). `compose.desktop.currentOs` and the host-only
+  // ffmpeg classifier above resolve only the build machine's natives, but `conveyor make` packages
+  // every target from a single machine. The Conveyor Gradle plugin exposes a resolvable
+  // configuration per target machine; declaring each target's Compose/Skiko runtime + bytedeco
+  // ffmpeg/javacpp JNI natives here lets printConveyorConfig emit correct per-machine `app.inputs`.
+  // Windows is intentionally omitted for now (macOS + Linux only).
+  macAmd64(compose.desktop.macos_x64)
+  macAmd64(variantOf(libs.bytedeco.ffmpeg) { classifier("macosx-x86_64") })
+  macAmd64(variantOf(libs.bytedeco.javacpp) { classifier("macosx-x86_64") })
+
+  macAarch64(compose.desktop.macos_arm64)
+  macAarch64(variantOf(libs.bytedeco.ffmpeg) { classifier("macosx-arm64") })
+  macAarch64(variantOf(libs.bytedeco.javacpp) { classifier("macosx-arm64") })
+
+  linuxAmd64(compose.desktop.linux_x64)
+  linuxAmd64(variantOf(libs.bytedeco.ffmpeg) { classifier("linux-x86_64") })
+  linuxAmd64(variantOf(libs.bytedeco.javacpp) { classifier("linux-x86_64") })
 }
 
 compose.desktop {


### PR DESCRIPTION
## Summary

**PR-C3 of the Conveyor pivot** ([#5227](https://github.com/kaeawc/auto-mobile/issues/5227)), on top
of C1 ([#5305](https://github.com/kaeawc/auto-mobile/pull/5305)) and C2
([#5384](https://github.com/kaeawc/auto-mobile/pull/5384)). Makes `conveyor make` actually work for
**macOS + Linux** and adds a CI workflow that builds the signed packages + auto-update site.
**Windows is intentionally out of scope** for now (no Authenticode cert). This still **coexists with
jpackage** — it does not retire it (that's C4).

## Changes

- **Fix the C1 blocker (Finding #1).** Conveyor resolves `runtimeClasspath` to compute `app.inputs`,
  which triggers `StripFfmpegProgramsTransform` on the module jars; the non-ffmpeg passthrough
  returns the input jar, which must already exist. `printConveyorConfig` now
  `dependsOn(runtimeClasspath)` so the module jars build first.
  **Verified: `printConveyorConfig` succeeds from a clean checkout** (it failed before this).

- **Per-target natives for single-machine cross-build.** `compose.desktop.currentOs` + the host
  ffmpeg classifier only resolve the build machine's natives, but Conveyor packages every target
  from one machine. The Conveyor Gradle plugin exposes a resolvable configuration per machine, so
  `macAmd64` / `macAarch64` / `linuxAmd64` now each get the matching Compose/Skiko runtime + bytedeco
  `ffmpeg`/`javacpp` classifier jars. `printConveyorConfig` now emits `app.mac.amd64.inputs`,
  `app.mac.aarch64.inputs`, and `app.linux.amd64.glibc.inputs` (verified).

- **`conveyor.conf`** — real mac+linux config: `machines` list (no Windows), GitHub-Releases update
  site via `app.vcs-url`, version from `CONVEYOR_APP_VERSION` (macOS major ≥ 1, `1.0.0` default),
  self-signing by default so a local `conveyor make` needs no certs.

- **`ci.conveyor.conf`** — overlay layering real macOS Developer ID signing + notarization from env,
  reusing the Apple credentials the jpackage flow already stores as secrets.

- **`.github/workflows/build-desktop-conveyor.yml`** — `workflow_dispatch` + `workflow_call`, ubuntu
  runner, builds jars, runs the Conveyor GitHub Action `make site`, uploads the site + packages as
  artifacts. **No live publish** — avoids colliding with the jpackage `.dmg`/`.deb` that
  `release.yml` already uploads to the GitHub Release. A `signed` input switches to `ci.conveyor.conf`.

## Validation

- [x] `printConveyorConfig` succeeds from a **clean checkout** (C1 Finding #1 fixed)
- [x] per-machine `app.<os>.<arch>.inputs` emitted for mac amd64/aarch64 + linux amd64
- [x] `:desktop-app:test` + Detekt (main + test) green; jpackage tasks (`createDistributable` /
  `packageDmg` / `packageDeb`) still present
- [x] ktfmt validator + `scripts/all_fast_validate_checks.sh` (34 passed / 0 failed)

## Requires before first dispatch

- A **`CONVEYOR_SIGNING_KEY`** repo secret — Conveyor's root signing key (`conveyor keys generate`),
  free for OSS. The `signed` path also reuses the existing `MACOS_DEVELOPER_ID_*` / `APPLE_NOTARY_*`
  secrets.

## Confirmed on first CI run (the CLI can't run locally)

`conveyor make` needs the Conveyor CLI + license key, so it runs only in CI. Three things to confirm
on the first dispatch, all with clear fallbacks:
1. **Native de-duplication** — the common `app.inputs` still carries the CI host's (Linux) Skiko/ffmpeg
   alongside the per-machine target natives, so mac packages may bundle unused Linux `.so` files
   (bloat, not breakage — Skiko loads per-OS at runtime). Trimming `currentOs` out of the Conveyor
   input path is a follow-up.
2. **Per-machine ffmpeg stripping** — the per-target ffmpeg classifier jars don't go through the
   strip transform; a signed Conveyor build signs all Mach-O (including the ffmpeg programs), so
   notarization should pass. If it rejects them, force `ffmpegProgramsStripped` on those configs.
3. **Exact macOS signing keys** in `ci.conveyor.conf` (Developer ID cert + notary API key form).

## Linked

Part of the Conveyor migration on #5227. Predecessors: #5305 (C1), #5384 (C2). Follow-up: **PR-C4** —
retire jpackage, flip Conveyor to live GitHub-Releases publishing (`site.copy-to` + `GITHUB_TOKEN`),
and add Windows once a cert is available.
