### PR TITLE
perf(android): replace NavigationEventAccumulator CopyOnWriteArrayList ring buffer with ArrayDeque

### DIFF
--- a/android/control-proxy/src/main/kotlin/dev/jasonpearson/automobile/ctrlproxy/NavigationEventAccumulator.kt
+++ b/android/control-proxy/src/main/kotlin/dev/jasonpearson/automobile/ctrlproxy/NavigationEventAccumulator.kt
@@ -3,7 +3,6 @@ package dev.jasonpearson.automobile.ctrlproxy
 import dev.jasonpearson.automobile.protocol.SdkNavigationEvent
 import dev.jasonpearson.automobile.sdk.AutoMobileSDK
 import dev.jasonpearson.automobile.sdk.NavigationEvent
-import java.util.concurrent.CopyOnWriteArrayList
 import java.util.concurrent.atomic.AtomicLong
 import kotlinx.coroutines.flow.MutableStateFlow
 import kotlinx.coroutines.flow.StateFlow
@@ -36,14 +35,17 @@ data class TimestampedNavigationEvent(
  * - Provides accumulated events since a given timestamp
  */
 class NavigationEventAccumulator {
-  private val events = CopyOnWriteArrayList<TimestampedNavigationEvent>()
+  // ArrayDeque ring buffer: O(1) append (addLast) + evict (removeFirst), no
+  // per-event array copy. Every access is guarded by bufferLock (#5464).
+  private val events = ArrayDeque<TimestampedNavigationEvent>()
   // Incremented from two paths (addEvent + the navigation listener callback);
   // AtomicLong so concurrent events can't collide on a sequence number (#3604).
   private val sequenceNumber = AtomicLong(0L)
   private val maxEvents = 100 // Keep last 100 events
 
-  // Guards the non-atomic add+trim compound and the size/subList read so the
-  // buffer can't be trimmed mid-read (IndexOutOfBoundsException, #3604).
+  // Guards every read/write of the non-thread-safe ArrayDeque so the buffer
+  // can't be trimmed mid-read (IndexOutOfBoundsException, #3604) and reads
+  // return a consistent point-in-time snapshot.
   private val bufferLock = Any()
 
   // StateFlow for reactive consumption - emits latest event
@@ -136,31 +138,39 @@ class NavigationEventAccumulator {
 
   /** Append an event and trim the circular buffer atomically, then emit updates. */
   private fun appendEvent(event: TimestampedNavigationEvent, publishLatestEvent: Boolean = true) {
-    synchronized(bufferLock) {
-      events.add(event)
-      if (events.size > maxEvents) {
-        events.removeAt(0)
+    val size =
+      synchronized(bufferLock) {
+        events.addLast(event)
+        if (events.size > maxEvents) {
+          events.removeFirst()
+        }
+        events.size
       }
-    }
     if (publishLatestEvent) {
       _latestEvent.value = event
     }
-    _eventCount.value = events.size
+    _eventCount.value = size
   }
 
   /** Get all accumulated events. */
   fun getAllEvents(): List<TimestampedNavigationEvent> {
-    return events.toList()
+    synchronized(bufferLock) {
+      return events.toList()
+    }
   }
 
   /** Get events since a given timestamp (inclusive). */
   fun getEventsSince(sinceTimestamp: Long): List<TimestampedNavigationEvent> {
-    return events.filter { it.timestamp >= sinceTimestamp }
+    synchronized(bufferLock) {
+      return events.filter { it.timestamp >= sinceTimestamp }
+    }
   }
 
   /** Get events since a given sequence number (exclusive). */
   fun getEventsSinceSequence(sinceSequence: Long): List<TimestampedNavigationEvent> {
-    return events.filter { it.sequenceNumber > sinceSequence }
+    synchronized(bufferLock) {
+      return events.filter { it.sequenceNumber > sinceSequence }
+    }
   }
 
   /** Get the most recent N events. */
@@ -177,17 +187,21 @@ class NavigationEventAccumulator {
 
   /** Clear all accumulated events. */
   fun clear() {
-    events.clear()
+    synchronized(bufferLock) { events.clear() }
     _latestEvent.value = null
     _eventCount.value = 0
   }
 
   /** Get current statistics. */
   fun getStats(): NavigationStats {
+    val (totalEvents, oldestTimestamp, newestTimestamp) =
+      synchronized(bufferLock) {
+        Triple(events.size, events.firstOrNull()?.timestamp, events.lastOrNull()?.timestamp)
+      }
     return NavigationStats(
-      totalEvents = events.size,
-      oldestTimestamp = events.firstOrNull()?.timestamp,
-      newestTimestamp = events.lastOrNull()?.timestamp,
+      totalEvents = totalEvents,
+      oldestTimestamp = oldestTimestamp,
+      newestTimestamp = newestTimestamp,
       currentSequence = sequenceNumber.get(),
     )
   }

--- a/android/control-proxy/src/main/kotlin/dev/jasonpearson/automobile/ctrlproxy/NavigationEventAccumulator.kt
+++ b/android/control-proxy/src/main/kotlin/dev/jasonpearson/automobile/ctrlproxy/NavigationEventAccumulator.kt
@@ -138,18 +138,20 @@ class NavigationEventAccumulator {
 
   /** Append an event and trim the circular buffer atomically, then emit updates. */
   private fun appendEvent(event: TimestampedNavigationEvent, publishLatestEvent: Boolean = true) {
-    val size =
-      synchronized(bufferLock) {
-        events.addLast(event)
-        if (events.size > maxEvents) {
-          events.removeFirst()
-        }
-        events.size
+    // Publish both StateFlows while holding bufferLock so concurrent producers cannot interleave
+    // their emits: without the lock, a later producer could publish its (larger) count and then an
+    // earlier producer overwrites it with a stale one, leaving eventCount behind the buffer
+    // (#5464).
+    synchronized(bufferLock) {
+      events.addLast(event)
+      if (events.size > maxEvents) {
+        events.removeFirst()
       }
-    if (publishLatestEvent) {
-      _latestEvent.value = event
+      if (publishLatestEvent) {
+        _latestEvent.value = event
+      }
+      _eventCount.value = events.size
     }
-    _eventCount.value = size
   }
 
   /** Get all accumulated events. */

--- a/android/control-proxy/src/test/kotlin/dev/jasonpearson/automobile/ctrlproxy/NavigationEventAccumulatorTest.kt
+++ b/android/control-proxy/src/test/kotlin/dev/jasonpearson/automobile/ctrlproxy/NavigationEventAccumulatorTest.kt
@@ -80,6 +80,27 @@ class NavigationEventAccumulatorTest {
     assertEquals(150L, acc.getStats().currentSequence)
   }
 
+  @Test
+  fun `buffer never grows past capacity and evicts oldest first`() {
+    val acc = NavigationEventAccumulator()
+    // Push well past capacity to exercise steady-state eviction, checking bounds
+    // as we cross and stay past the 100-event ceiling.
+    repeat(250) { i ->
+      acc.addEvent("dest-$i", "src", emptyMap(), emptyMap())
+      assertTrue("buffer exceeded capacity at i=$i", acc.getAllEvents().size <= 100)
+    }
+
+    val all = acc.getAllEvents()
+    assertEquals(100, all.size)
+    assertEquals(100, acc.eventCount.value)
+    // Oldest-first eviction: only the last 100 destinations/sequences survive, in order.
+    assertEquals((150..249).map { "dest-$it" }, all.map { it.destination })
+    assertEquals((150L..249L).toList(), all.map { it.sequenceNumber })
+    // The evicted head is gone; the retained window starts at sequence 150.
+    assertEquals(150L, all.first().sequenceNumber)
+    assertEquals(249L, all.last().sequenceNumber)
+  }
+
   /**
    * Concurrent producers must not collide on sequence numbers, and a reader hammering
    * getRecentEvents/getAllEvents must never see an IndexOutOfBoundsException from a trim between


### PR DESCRIPTION
## Summary

`NavigationEventAccumulator` used a `CopyOnWriteArrayList` as a fixed-size ring buffer. At steady state (buffer full at 100 events) every navigation event did `events.add(...)` (copy the whole 100-element array) followed by `events.removeAt(0)` (copy again) — two full array copies per event, all already inside `bufferLock`, so the copy-on-write semantics bought nothing.

This replaces the ring buffer with an `ArrayDeque` guarded by the existing `bufferLock`:

- **O(1) append + evict**: `addLast` / `removeFirst`, no per-event array copy.
- **Snapshot reads under the lock**: `getAllEvents`, `getEventsSince`, `getEventsSinceSequence`, `getRecentEvents`, and `getStats` now take their point-in-time snapshot while holding `bufferLock` (the `ArrayDeque` is not thread-safe on its own).
- **`_eventCount` reflects size under the lock**: `appendEvent` captures `events.size` inside the synchronized block and publishes that.

External contract is unchanged: same events, order, sequence numbers, oldest-first eviction at capacity, and StateFlow size semantics.

## Scope

Only `NavigationEventAccumulator.kt` and its test file are touched.

## Tests

Added `buffer never grows past capacity and evicts oldest first`, which pushes 250 events, asserts the buffer never exceeds 100 while crossing/staying past capacity, and verifies the retained window is the last 100 destinations/sequences in order (oldest dropped first). Existing tests pass unchanged.

```
./gradlew -p android :control-proxy:testDebugUnitTest --tests '*NavigationEventAccumulator*'
BUILD SUCCESSFUL
NavigationEventAccumulatorTest: tests=5 skipped=0 failures=0 errors=0
```

Formatted with the repo ktfmt apply script.

Closes #5464
