### PR TITLE
perf(android): gate CtrlProxy logcat parsing on a connected client

### DIFF
--- a/android/control-proxy/src/main/kotlin/dev/jasonpearson/automobile/ctrlproxy/CtrlProxy.kt
+++ b/android/control-proxy/src/main/kotlin/dev/jasonpearson/automobile/ctrlproxy/CtrlProxy.kt
@@ -1194,12 +1194,19 @@ class CtrlProxy : AccessibilityService(), CtrlProxyActions {
       sdkEventBatchProcessor.start()
       Log.d(TAG, "SDK event batch processor started")
 
-      // Start logcat reader for automatic log capture
-      logcatReader = LogcatReader { response ->
-        if (::webSocketServer.isInitialized && webSocketServer.isRunning()) {
-          serviceScope.launch { webSocketServer.broadcast(response) }
-        }
-      }
+      // Start logcat reader for automatic log capture. Gate parsing on a connected client so a
+      // chatty device is not regex-parsed while nobody is consuming logs.
+      logcatReader =
+        LogcatReader(
+          onLogEvent = { response ->
+            if (::webSocketServer.isInitialized && webSocketServer.isRunning()) {
+              serviceScope.launch { webSocketServer.broadcast(response) }
+            }
+          },
+          hasConsumer = {
+            ::webSocketServer.isInitialized && webSocketServer.getConnectionCount() > 0
+          },
+        )
       logcatReader?.start()
       Log.d(TAG, "Logcat reader started")
 

--- a/android/control-proxy/src/main/kotlin/dev/jasonpearson/automobile/ctrlproxy/LogcatReader.kt
+++ b/android/control-proxy/src/main/kotlin/dev/jasonpearson/automobile/ctrlproxy/LogcatReader.kt
@@ -13,10 +13,20 @@ import java.io.InputStreamReader
  * Runs `logcat -v threadtime -T 1` to capture only new entries, parses each line with the
  * threadtime format, and invokes [onLogEvent] for every successfully parsed entry.
  *
+ * When no client is consuming logs ([hasConsumer] returns false), delivered lines are dropped
+ * before the [THREADTIME_REGEX] match and [LogEventResponse] allocation, so a chatty device does
+ * not pay for regex + allocation per log line that would be delivered to nobody.
+ *
  * Lifecycle: [start] from onServiceConnected, [stop] from onDestroy. Auto-reconnects if the logcat
  * process dies unexpectedly.
+ *
+ * @param hasConsumer seam returning whether any client is currently connected; injected so the gate
+ *   is unit-testable without a live WebSocket. Defaults to always-on for callers that never gate.
  */
-class LogcatReader(private val onLogEvent: (WebSocketResponse) -> Unit) {
+class LogcatReader(
+  private val onLogEvent: (WebSocketResponse) -> Unit,
+  private val hasConsumer: () -> Boolean = { true },
+) {
 
   companion object {
     private const val TAG = "LogcatReader"
@@ -104,13 +114,7 @@ class LogcatReader(private val onLogEvent: (WebSocketResponse) -> Unit) {
     try {
       var line = reader.readLine()
       while (line != null && running) {
-        parseLine(line)?.let { response ->
-          try {
-            onLogEvent(response)
-          } catch (e: Exception) {
-            Log.w(TAG, "Error broadcasting log event", e)
-          }
-        }
+        handleLine(line)
         line = reader.readLine()
       }
     } finally {
@@ -121,10 +125,30 @@ class LogcatReader(private val onLogEvent: (WebSocketResponse) -> Unit) {
   }
 
   /**
+   * Gate + parse + broadcast a single raw logcat line. Drops the line before any parsing or
+   * allocation when [hasConsumer] reports no connected client, so nothing is parsed for nobody.
+   */
+  internal fun handleLine(line: String) {
+    // No client is consuming logs — skip the regex match + LogEventResponse allocation entirely.
+    if (!hasConsumer()) return
+    parseLine(line)?.let { response ->
+      try {
+        onLogEvent(response)
+      } catch (e: Exception) {
+        Log.w(TAG, "Error broadcasting log event", e)
+      }
+    }
+  }
+
+  /**
    * Parse a single threadtime-formatted logcat line into a [LogEventResponse]. Returns null for
    * lines that don't match the expected format (e.g., headers).
    */
   internal fun parseLine(line: String): LogEventResponse? {
+    // Cheap prefilter: every threadtime entry starts with a two-digit month ("MM-DD ..."). Header
+    // lines ("--------- beginning of main") and blanks never do, so this skips the full regex on
+    // the non-entry lines a chatty logcat interleaves.
+    if (line.length < 2 || !line[0].isDigit() || !line[1].isDigit()) return null
     val match = THREADTIME_REGEX.matchEntire(line) ?: return null
     val (_, _, pidStr, tidStr, levelStr, tag, message) = match.destructured
 

--- a/android/control-proxy/src/test/kotlin/dev/jasonpearson/automobile/ctrlproxy/LogcatReaderTest.kt
+++ b/android/control-proxy/src/test/kotlin/dev/jasonpearson/automobile/ctrlproxy/LogcatReaderTest.kt
@@ -1,0 +1,77 @@
+package dev.jasonpearson.automobile.ctrlproxy
+
+import dev.jasonpearson.automobile.protocol.WebSocketResponse
+import org.junit.Assert.assertEquals
+import org.junit.Assert.assertNotNull
+import org.junit.Assert.assertNull
+import org.junit.Assert.assertTrue
+import org.junit.Test
+
+class LogcatReaderTest {
+
+  private val sampleLine = "04-01 12:34:56.789  1234  5678 D MyTag: Hello world"
+
+  private class Recorder {
+    val events = mutableListOf<WebSocketResponse>()
+
+    fun onLogEvent(response: WebSocketResponse) {
+      events.add(response)
+    }
+  }
+
+  @Test
+  fun `with zero connections a delivered line produces no broadcast`() {
+    val recorder = Recorder()
+    val reader = LogcatReader(onLogEvent = recorder::onLogEvent, hasConsumer = { false })
+
+    reader.handleLine(sampleLine)
+
+    assertTrue("No broadcast expected when no client is connected", recorder.events.isEmpty())
+  }
+
+  @Test
+  fun `with a connection a delivered line produces a broadcast`() {
+    val recorder = Recorder()
+    val reader = LogcatReader(onLogEvent = recorder::onLogEvent, hasConsumer = { true })
+
+    reader.handleLine(sampleLine)
+
+    assertEquals(1, recorder.events.size)
+  }
+
+  @Test
+  fun `connection state is evaluated per line`() {
+    val recorder = Recorder()
+    var connected = false
+    val reader = LogcatReader(onLogEvent = recorder::onLogEvent, hasConsumer = { connected })
+
+    reader.handleLine(sampleLine)
+    assertTrue(recorder.events.isEmpty())
+
+    connected = true
+    reader.handleLine(sampleLine)
+    assertEquals(1, recorder.events.size)
+
+    connected = false
+    reader.handleLine(sampleLine)
+    assertEquals(1, recorder.events.size)
+  }
+
+  @Test
+  fun `parseLine parses a valid threadtime line`() {
+    val reader = LogcatReader(onLogEvent = {})
+
+    val response = reader.parseLine(sampleLine)
+
+    assertNotNull(response)
+  }
+
+  @Test
+  fun `parseLine prefilter rejects non-entry lines without regex`() {
+    val reader = LogcatReader(onLogEvent = {})
+
+    assertNull(reader.parseLine("--------- beginning of main"))
+    assertNull(reader.parseLine(""))
+    assertNull(reader.parseLine("not a log line"))
+  }
+}


### PR DESCRIPTION
## Summary

`LogcatReader` ran `logcat -v threadtime -T 1` and pushed **every** device
log line through `THREADTIME_REGEX` with a `LogEventResponse` allocation
*before* the connection check, so a chatty device paid for regex + allocation
per line even when no client was consuming logs.

## Change

- **`LogcatReader.kt`** — inject a `hasConsumer: () -> Boolean` seam
  (defaults to always-on for backward compatibility) and gate parsing on it in
  a new `internal fun handleLine`: with no connected client the raw line is
  dropped **before** the regex match and `LogEventResponse` allocation. Added a
  cheap two-digit-month prefilter in `parseLine` so non-entry lines (blanks,
  `--------- beginning of main` headers) skip the full regex.
- **`CtrlProxy.kt`** — single localized hunk at the reader start site: wire
  `hasConsumer` to `webSocketServer.getConnectionCount() > 0`. No other
  CtrlProxy.kt changes.

A subscribed client receives the same events as before — no behavioral change
for connected consumers.

## Tests

New `LogcatReaderTest.kt` (interfaces/fakes only, no live device/logcat):

- zero connections → a delivered line produces no broadcast
- a connection → a delivered line produces a broadcast
- connection state evaluated per line (off → on → off)
- `parseLine` parses a valid threadtime line
- `parseLine` prefilter rejects non-entry lines

```
./gradlew -p android :control-proxy:testDebugUnitTest --tests '*Logcat*'
BUILD SUCCESSFUL — LogcatReaderTest: tests=5 failures=0 errors=0 skipped=0
```

Touched files formatted with `scripts/ktfmt/apply_ktfmt.sh`.

Closes #5463
