### PR TITLE
perf(android): cut CtrlProxy highlight-overlay per-frame draw/alloc cost

### DIFF
--- a/android/control-proxy/src/main/kotlin/dev/jasonpearson/automobile/ctrlproxy/OverlayDrawer.kt
+++ b/android/control-proxy/src/main/kotlin/dev/jasonpearson/automobile/ctrlproxy/OverlayDrawer.kt
@@ -1,5 +1,6 @@
 package dev.jasonpearson.automobile.ctrlproxy
 
+import android.animation.ValueAnimator
 import android.graphics.Canvas
 import android.graphics.Color
 import android.graphics.DashPathEffect
@@ -9,6 +10,7 @@ import android.graphics.PathMeasure
 import android.graphics.PointF
 import android.graphics.RectF
 import android.util.Log
+import androidx.annotation.VisibleForTesting
 import dev.jasonpearson.automobile.ctrlproxy.models.HighlightBounds
 import dev.jasonpearson.automobile.ctrlproxy.models.HighlightLineCap
 import dev.jasonpearson.automobile.ctrlproxy.models.HighlightLineJoin
@@ -42,7 +44,7 @@ class OverlayDrawer(
     private const val DEFAULT_STROKE_WIDTH = 8f
     private const val DEFAULT_PATH_STROKE_WIDTH = 8f
     private const val DEFAULT_PATH_TENSION = 0.5f
-    private const val ELLIPSE_SEGMENT_COUNT = 160
+    private const val ELLIPSE_SEGMENT_COUNT = 64
     private const val ELLIPSE_JITTER_RATIO = 0.035f
     private const val ELLIPSE_JITTER_FREQ_X = 2.3f
     private const val ELLIPSE_JITTER_FREQ_Y = 3.7f
@@ -59,6 +61,17 @@ class OverlayDrawer(
 
   private val lock = Any()
   private val highlights = LinkedHashMap<String, HighlightRenderState>()
+
+  // Reusable render snapshot rebuilt only when the highlight set changes, so the
+  // hot onDraw path does not allocate a fresh list every frame (issue #5465).
+  private var renderSnapshot: List<HighlightRenderState> = emptyList()
+  private var snapshotRebuildCount = 0
+
+  // Coalesces the per-frame invalidations: the animator updates alpha and draw
+  // progress separately each frame, but we only need to schedule one redraw. The
+  // flag is cleared in draw() once the frame is consumed (issue #5465).
+  private var invalidatePending = false
+
   private var overlayView: HighlightOverlayView? = null
   private val pathSmoother = PathSmoother()
   private val animator =
@@ -77,6 +90,12 @@ class OverlayDrawer(
     overlayView = view
     view.setAnimationActive(animator.isAnimating())
   }
+
+  @VisibleForTesting
+  internal fun getAnimatorForTest(id: String): ValueAnimator? = animator.getAnimatorForTest(id)
+
+  @VisibleForTesting
+  internal fun snapshotRebuildCountForTest(): Int = synchronized(lock) { snapshotRebuildCount }
 
   fun addHighlight(id: String?, shape: HighlightShape?): HighlightOperationResult {
     if (id.isNullOrBlank()) {
@@ -101,9 +120,12 @@ class OverlayDrawer(
     }
 
     animator.cancel(id)
-    synchronized(lock) { highlights[id] = renderState }
+    synchronized(lock) {
+      highlights[id] = renderState
+      rebuildSnapshotLocked()
+    }
     animator.startFadeOut(id)
-    overlayView?.invalidate()
+    scheduleInvalidate()
     return HighlightOperationResult(true, null)
   }
 
@@ -111,6 +133,7 @@ class OverlayDrawer(
     animator.cancelAll()
     synchronized(lock) {
       highlights.clear()
+      rebuildSnapshotLocked()
       overlayManager?.hide()
     }
     overlayView = null
@@ -124,16 +147,43 @@ class OverlayDrawer(
 
     synchronized(lock) {
       highlights.remove(id)
+      rebuildSnapshotLocked()
       if (highlights.isEmpty()) {
         overlayManager?.hide()
       }
     }
 
-    overlayView?.invalidate()
+    scheduleInvalidate()
+  }
+
+  private fun rebuildSnapshotLocked() {
+    renderSnapshot = ArrayList(highlights.values)
+    snapshotRebuildCount++
+  }
+
+  private fun scheduleInvalidate() {
+    val view = overlayView ?: return
+    val shouldInvalidate =
+      synchronized(lock) {
+        if (invalidatePending) {
+          false
+        } else {
+          invalidatePending = true
+          true
+        }
+      }
+    if (shouldInvalidate) {
+      view.invalidate()
+    }
   }
 
   internal fun draw(canvas: Canvas) {
-    val snapshot = synchronized(lock) { highlights.values.toList() }
+    val snapshot =
+      synchronized(lock) {
+        // Frame consumed: allow the next animation update to schedule a redraw.
+        invalidatePending = false
+        renderSnapshot
+      }
     snapshot.forEach { renderState ->
       when (renderState.shapeType) {
         ShapeType.BOX,
@@ -212,13 +262,13 @@ class OverlayDrawer(
   private fun updateHighlightAlpha(id: String, alpha: Float) {
     val clamped = alpha.coerceIn(0f, 1f)
     synchronized(lock) { highlights[id]?.alpha = clamped }
-    overlayView?.invalidate()
+    scheduleInvalidate()
   }
 
   private fun updateHighlightDrawProgress(id: String, progress: Float) {
     val clamped = progress.coerceIn(0f, 1f)
     synchronized(lock) { highlights[id]?.drawProgress = clamped }
-    overlayView?.invalidate()
+    scheduleInvalidate()
   }
 
   private fun applyStrokeAlpha(renderState: HighlightRenderState, paint: Paint) {
@@ -467,7 +517,7 @@ class OverlayDrawer(
   }
 
   private fun buildEllipseSegments(rect: RectF, baseStrokeWidth: Float): List<EllipseSegment> {
-    val segmentCount = ELLIPSE_SEGMENT_COUNT.coerceAtLeast(100)
+    val segmentCount = ELLIPSE_SEGMENT_COUNT
     if (segmentCount <= 0) {
       return emptyList()
     }

--- a/android/control-proxy/src/test/kotlin/dev/jasonpearson/automobile/ctrlproxy/OverlayDrawerTest.kt
+++ b/android/control-proxy/src/test/kotlin/dev/jasonpearson/automobile/ctrlproxy/OverlayDrawerTest.kt
@@ -1,0 +1,102 @@
+package dev.jasonpearson.automobile.ctrlproxy
+
+import android.animation.ValueAnimator
+import android.graphics.Canvas
+import android.graphics.Color
+import android.graphics.RectF
+import dev.jasonpearson.automobile.ctrlproxy.models.HighlightBounds
+import dev.jasonpearson.automobile.ctrlproxy.models.HighlightShape
+import io.mockk.every
+import io.mockk.mockk
+import io.mockk.verify
+import org.junit.Assert.assertEquals
+import org.junit.Assert.assertTrue
+import org.junit.Test
+import org.junit.runner.RunWith
+import org.robolectric.RobolectricTestRunner
+
+/**
+ * Guards the highlight-overlay per-frame cost reductions from issue #5465:
+ * - at most one `invalidate()` per animation frame (alpha + draw-progress updates coalesce),
+ * - no per-frame render-list allocation (the snapshot is rebuilt only when the set changes),
+ * - a bounded ellipse segment count.
+ */
+@RunWith(RobolectricTestRunner::class)
+class OverlayDrawerTest {
+
+  private fun boxShape(): HighlightShape =
+    HighlightShape(type = "box", bounds = HighlightBounds(x = 0, y = 0, width = 120, height = 80))
+
+  private fun createDrawer(view: HighlightOverlayView): OverlayDrawer {
+    val overlayManager = mockk<OverlayManager>(relaxed = true)
+    every { overlayManager.show() } returns true
+    val drawer =
+      OverlayDrawer(
+        overlayManager = overlayManager,
+        colorParser = { Color.RED },
+      )
+    drawer.attachView(view)
+    return drawer
+  }
+
+  @Test
+  fun `each animation frame schedules at most one invalidate`() {
+    val view = mockk<HighlightOverlayView>(relaxed = true)
+    val drawer = createDrawer(view)
+    val canvas = mockk<Canvas>(relaxed = true)
+
+    // addHighlight schedules the initial redraw.
+    assertTrue(drawer.addHighlight("h", boxShape()).success)
+    val animator: ValueAnimator = drawer.getAnimatorForTest("h")!!
+
+    // Frame 1: consume the pending invalidate, then advance the animator. The
+    // animator drives alpha AND draw-progress in the same frame; both funnel into
+    // a single scheduled invalidate.
+    drawer.draw(canvas)
+    animator.setCurrentPlayTime(100)
+
+    // Frame 2.
+    drawer.draw(canvas)
+    animator.setCurrentPlayTime(200)
+
+    // 1 (addHighlight) + 1 (frame 1) + 1 (frame 2) = 3. Without coalescing the two
+    // per-frame updates it would be 5.
+    verify(exactly = 3) { view.invalidate() }
+  }
+
+  @Test
+  fun `onDraw does not rebuild the render snapshot every frame`() {
+    val view = mockk<HighlightOverlayView>(relaxed = true)
+    val drawer = createDrawer(view)
+    val canvas = mockk<Canvas>(relaxed = true)
+
+    assertTrue(drawer.addHighlight("h", boxShape()).success)
+    val afterAdd = drawer.snapshotRebuildCountForTest()
+
+    repeat(10) { drawer.draw(canvas) }
+
+    // Drawing must not rebuild the snapshot list; the count is stable across frames.
+    assertEquals(afterAdd, drawer.snapshotRebuildCountForTest())
+
+    // A change to the highlight set does rebuild it exactly once.
+    assertTrue(drawer.addHighlight("h2", boxShape()).success)
+    assertEquals(afterAdd + 1, drawer.snapshotRebuildCountForTest())
+  }
+
+  @Test
+  fun `full ellipse draw uses a bounded number of arc segments`() {
+    val view = mockk<HighlightOverlayView>(relaxed = true)
+    val drawer = createDrawer(view)
+    val canvas = mockk<Canvas>(relaxed = true)
+
+    assertTrue(drawer.addHighlight("h", boxShape()).success)
+    val animator: ValueAnimator = drawer.getAnimatorForTest("h")!!
+
+    // Advance into the display phase where drawProgress == 1 (all segments drawn).
+    animator.setCurrentPlayTime(700)
+    drawer.draw(canvas)
+
+    verify(atMost = 64) { canvas.drawArc(any<RectF>(), any(), any(), any(), any()) }
+    verify(atLeast = 1) { canvas.drawArc(any<RectF>(), any(), any(), any(), any()) }
+  }
+}


### PR DESCRIPTION
## Summary

Cuts the CtrlProxy highlight-overlay per-frame draw/allocation cost called out in the issue. All changes are confined to `OverlayDrawer.kt` (plus its new test).

1. **Fewer arc segments.** `ELLIPSE_SEGMENT_COUNT` 160 -> 64, and the `coerceAtLeast(100)` floor in `buildEllipseSegments` (which silently pinned any lower value back to 100) is removed. 64 keeps a smooth ring while cutting per-frame `drawArc` ops by ~60%.
2. **One invalidate per frame.** The animator drives alpha and draw-progress as two separate callbacks each frame, and each previously called `overlayView.invalidate()`. They now funnel through `scheduleInvalidate()`, which schedules at most one redraw per frame; the pending flag is cleared once `draw()` consumes the frame. `addHighlight`/`removeHighlightInternal` route through the same path.
3. **No per-frame list allocation.** `onDraw`'s `synchronized(lock) { highlights.values.toList() }` is replaced with a reusable snapshot rebuilt only when the highlight set changes (add/remove/clear). The render state objects are held by reference, so in-place alpha/draw-progress mutations are still reflected.

No behavioral change to the animation (still a smooth ring with draw-on + staggered fade).

## Tests

New `OverlayDrawerTest`:
- asserts exactly one `invalidate()` per animation frame (3 total across add + 2 frames; would be 5 without coalescing),
- asserts `draw()` does not rebuild the render snapshot across repeated frames, and rebuilds exactly once when the set changes,
- asserts the full-ring ellipse draw issues a bounded (<= 64) number of `drawArc` calls.

```
./gradlew -p android :control-proxy:testDebugUnitTest --tests '*Overlay*' --tests '*Highlight*'
```
BUILD SUCCESSFUL — OverlayDrawerTest 3/3, HighlightAnimatorTest 3/3, OverlayManagerTest 4/4, HighlightShapeConvertersTest 6/6; 0 failures.

Touched files formatted with `scripts/ktfmt/apply_ktfmt.sh`.

Closes #5465
