### PR TITLE
perf(android): stop re-parsing JSON to recover requestId on the CtrlProxy broadcast path

### DIFF
--- a/android/control-proxy/src/main/kotlin/dev/jasonpearson/automobile/ctrlproxy/WebSocketServer.kt
+++ b/android/control-proxy/src/main/kotlin/dev/jasonpearson/automobile/ctrlproxy/WebSocketServer.kt
@@ -2,14 +2,8 @@ package dev.jasonpearson.automobile.ctrlproxy
 
 import android.util.Log
 import dev.jasonpearson.automobile.ctrlproxy.perf.PerfProvider
-import dev.jasonpearson.automobile.protocol.ConnectedResponse
-import dev.jasonpearson.automobile.protocol.ErrorResponse
-import dev.jasonpearson.automobile.protocol.RequestHierarchy
-import dev.jasonpearson.automobile.protocol.RequestHierarchyIfStale
-import dev.jasonpearson.automobile.protocol.SdkEvent
-import dev.jasonpearson.automobile.protocol.WebSocketMessageHandler
+import dev.jasonpearson.automobile.protocol.*
 import dev.jasonpearson.automobile.protocol.WebSocketRequest as ProtocolRequest
-import dev.jasonpearson.automobile.protocol.WebSocketResponse
 import io.ktor.http.*
 import io.ktor.serialization.kotlinx.json.*
 import io.ktor.server.application.*
@@ -76,12 +70,86 @@ class WebSocketServer(
         null
       }
 
+    /** Substring every correlated frame carries and no `hierarchy_update`/event frame does. */
+    private const val REQUEST_ID_TOKEN = "\"requestId\""
+
+    /**
+     * Cheap pre-check gating the full JSON parse in [extractRequestId]. The `hierarchy_update`
+     * frame is the highest-frequency, largest payload in the system and provably carries no
+     * `requestId` (see `recordsRequestOwner`), so gating on an `indexOf` lets those frames skip the
+     * O(payload) `parseToJsonElement` + throwaway element-tree allocation entirely. See #5462.
+     */
+    internal fun mightCarryRequestId(raw: String): Boolean = raw.contains(REQUEST_ID_TOKEN)
+
     /**
      * Best-effort extraction of `requestId` from a raw JSON payload for error correlation,
      * mirroring the iOS runner's `extractRequestId`. Returns null when it can't be determined.
-     * See #2985.
+     * Short-circuits without parsing when the payload cannot contain a `requestId`.
+     * See #2985, #5462.
      */
-    internal fun extractRequestId(raw: String): String? = extractStringField(raw, "requestId")
+    internal fun extractRequestId(raw: String): String? =
+      if (mightCarryRequestId(raw)) extractStringField(raw, "requestId") else null
+
+    /**
+     * `requestId` read directly off a typed [response], avoiding the encode→parse round-trip the
+     * raw-string [extractRequestId] path pays. Exhaustive over the sealed hierarchy so a newly
+     * added correlated response type fails to compile until it is wired in here (mirrors what
+     * `sendErrorResponse` reads off `ErrorResponse` directly). See #5462.
+     */
+    internal fun correlationRequestId(response: WebSocketResponse): String? =
+      when (response) {
+        is ErrorResponse -> response.requestId
+        is ScreenshotResult -> response.requestId
+        is ScreenshotErrorResult -> response.requestId
+        is SwipeResult -> response.requestId
+        is TapCoordinatesResult -> response.requestId
+        is DragResult -> response.requestId
+        is PinchResult -> response.requestId
+        is SetTextResult -> response.requestId
+        is ImeActionResult -> response.requestId
+        is SelectAllResult -> response.requestId
+        is ActionResult -> response.requestId
+        is ClipboardResult -> response.requestId
+        is SettingsGetResult -> response.requestId
+        is SettingsPutResult -> response.requestId
+        is SettingsListResult -> response.requestId
+        is CaCertResult -> response.requestId
+        is DeviceOwnerStatusResult -> response.requestId
+        is PermissionResult -> response.requestId
+        is GlobalActionResult -> response.requestId
+        is FrameContextValidationResult -> response.requestId
+        is DeviceInfoResult -> response.requestId
+        is CurrentFocusResult -> response.requestId
+        is TraversalOrderResult -> response.requestId
+        is HighlightResponse -> response.requestId
+        is PreferenceFilesResult -> response.requestId
+        is PreferencesResult -> response.requestId
+        is SubscribeStorageResult -> response.requestId
+        is UnsubscribeStorageResult -> response.requestId
+        is GetPreferenceResult -> response.requestId
+        is SetPreferenceResult -> response.requestId
+        is RemovePreferenceResult -> response.requestId
+        is ClearPreferencesResult -> response.requestId
+        is InstalledPackagesResult -> response.requestId
+        is PackageInfoResult -> response.requestId
+        is LaunchIntentResult -> response.requestId
+        // Uncorrelated event/status frames never echo a requestId.
+        is ConnectedResponse,
+        is HierarchyUpdateEvent,
+        is InteractionEvent,
+        is PackageEvent,
+        is NavigationEventResponse,
+        is HandledExceptionEvent,
+        is NetworkEventResponse,
+        is WebSocketFrameResponse,
+        is LogEventResponse,
+        is BroadcastEventResponse,
+        is LifecycleEventResponse,
+        is FrameMetricsEventResponse,
+        is StorageChangedEvent,
+        is CrashEvent,
+        is AnrEvent -> null
+      }
 
     /**
      * Maps an inbound-decode failure into an actionable, legible wire message. An unknown/
@@ -339,7 +407,7 @@ class WebSocketServer(
     waitForClient: Boolean = false,
   ) {
     val message = responseJson.encodeToString(WebSocketResponse.serializer(), response)
-    val requestId = extractRequestId(message)
+    val requestId = correlationRequestId(response)
     if (response is ErrorResponse) {
       val target =
         if (requestId != null) {

--- a/android/control-proxy/src/test/kotlin/dev/jasonpearson/automobile/ctrlproxy/WebSocketServerTest.kt
+++ b/android/control-proxy/src/test/kotlin/dev/jasonpearson/automobile/ctrlproxy/WebSocketServerTest.kt
@@ -1,5 +1,8 @@
 package dev.jasonpearson.automobile.ctrlproxy
 
+import dev.jasonpearson.automobile.protocol.ErrorResponse
+import dev.jasonpearson.automobile.protocol.HierarchyUpdateEvent
+import dev.jasonpearson.automobile.protocol.SwipeResult
 import kotlinx.coroutines.cancel
 import kotlinx.coroutines.test.TestScope
 import kotlinx.coroutines.test.runTest
@@ -113,6 +116,57 @@ class WebSocketServerTest {
   @Test
   fun `extractRequestId returns null for unparseable payload`() {
     assertNull(WebSocketServer.extractRequestId("""{not valid json"""))
+  }
+
+  // ---------------------------------------------------------------------------
+  // requestId correlation without re-parsing (issue #5462)
+  // ---------------------------------------------------------------------------
+
+  @Test
+  fun `correlationRequestId reads id off a typed correlated response`() {
+    // The typed broadcast path clears requestConnections by this id; reading it off the object
+    // (instead of encode->extractRequestId) must yield the same key the entry was recorded under.
+    val response =
+      SwipeResult(timestamp = 0L, requestId = "req-1", success = true, totalTimeMs = 5L)
+    assertEquals("req-1", WebSocketServer.correlationRequestId(response))
+  }
+
+  @Test
+  fun `correlationRequestId reads id off an error response`() {
+    val response = ErrorResponse(requestId = "err-1", error = "boom")
+    assertEquals("err-1", WebSocketServer.correlationRequestId(response))
+  }
+
+  @Test
+  fun `correlationRequestId is null for an uncorrelated hierarchy frame`() {
+    val event = HierarchyUpdateEvent(timestamp = 0L, data = "{}")
+    assertNull(WebSocketServer.correlationRequestId(event))
+  }
+
+  @Test
+  fun `mightCarryRequestId short-circuits frames without the requestId token`() {
+    // hierarchy_update is the hot, large frame and never carries a requestId; the gate must return
+    // false so extractRequestId skips parseToJsonElement entirely.
+    val hierarchyFrame =
+      """{"type":"hierarchy_update","timestamp":1,"data":"<hierarchy>...</hierarchy>"}"""
+    assertFalse(WebSocketServer.mightCarryRequestId(hierarchyFrame))
+    assertNull(WebSocketServer.extractRequestId(hierarchyFrame))
+  }
+
+  @Test
+  fun `mightCarryRequestId detects the requestId token`() {
+    assertTrue(
+      WebSocketServer.mightCarryRequestId("""{"type":"request_screenshot","requestId":"abc-123"}""")
+    )
+  }
+
+  @Test
+  fun `extractRequestId does not parse a substring-free payload`() {
+    // No `"requestId"` token but otherwise unparseable: proves the parser is never reached, since
+    // the gate returns false before parseToJsonElement would run.
+    val payload = "<<< not json and carries no token >>>"
+    assertFalse(WebSocketServer.mightCarryRequestId(payload))
+    assertNull(WebSocketServer.extractRequestId(payload))
   }
 
   @Test


### PR DESCRIPTION
## Summary

The Android CtrlProxy broadcast path re-parsed full JSON payloads purely to recover a top-level `requestId`, on the hottest and largest frames. This removes both round-trips, `WebSocketServer.kt` only.

1. **Typed `broadcast(response)`** no longer does `extractRequestId(encodeToString(response))`. It reads `requestId` off the typed object via a new internal `correlationRequestId(response)` accessor — a `when` that is **exhaustive over the sealed `WebSocketResponse` hierarchy**, so a newly added correlated response type fails to compile until it is wired in (mirrors how `sendErrorResponse` already reads `response.requestId` directly).

2. **Raw-string correlation path** (`extractRequestId`) now short-circuits on a cheap `indexOf` via `mightCarryRequestId`: a payload without the `"requestId"` substring skips `parseToJsonElement` (and its throwaway element-tree allocation) entirely. The `hierarchy_update` frame — highest-frequency, largest payload, provably uncorrelated — now pays an `indexOf`, not a full parse.

Behavior for genuinely correlated frames (results/errors) is unchanged: the owning connection is still forgotten by the same `requestId` key, exactly when it was before.

## Tests

Added to `WebSocketServerTest`:
- `correlationRequestId` reads the id off a typed correlated response (`SwipeResult`) and off an `ErrorResponse` — the key used to clear `requestConnections`, proving the entry is still cleared.
- `correlationRequestId` is null for an uncorrelated `HierarchyUpdateEvent`.
- `mightCarryRequestId` returns false for a `hierarchy_update` frame (so the parser is skipped) and true when the token is present.
- `extractRequestId` returns null for a substring-free, otherwise-unparseable payload while `mightCarryRequestId` is false — proving the parser is never reached.

## Validation

`./gradlew -p android :control-proxy:testDebugUnitTest --tests '*WebSocketServer*'` — BUILD SUCCESSFUL, all green:
- `WebSocketServerTest`: 17 tests, 0 failures (6 new)
- `WebSocketServerIntegrationTest`: 24 tests, 0 failures
- `WebSocketServerMaxFrameSizeTest`: 1 test, 0 failures

Touched files formatted with `scripts/ktfmt/apply_ktfmt.sh`.

Closes #5462
