### PR TITLE
perf(ios): scan raw bytes for view_hierarchy marker in SdkHierarchyCache

### DIFF
--- a/ios/control-proxy/Sources/CtrlProxy/SdkHierarchyCache.swift
+++ b/ios/control-proxy/Sources/CtrlProxy/SdkHierarchyCache.swift
@@ -59,6 +59,9 @@ public enum SdkHierarchyExtractor {
     /// Matches SDK's `SdkEventType.viewHierarchy.rawValue` (separate package, can't share the enum).
     private static let viewHierarchyEventType = "view_hierarchy"
 
+    /// UTF-8 bytes of `viewHierarchyEventType`, used for the raw-buffer presence scan.
+    private static let viewHierarchyEventTypeBytes = Data(viewHierarchyEventType.utf8)
+
     /// Try to extract a view hierarchy event from the raw batch data.
     /// Called on every `POST /sdk-events` — skips full decode when no hierarchy event is present.
     public static func extractIfPresent(
@@ -66,9 +69,9 @@ public enum SdkHierarchyExtractor {
         into cache: any SdkHierarchyCaching,
         onHierarchyUpdated: (() -> Void)? = nil
     ) {
-        // Fast path: skip full JSON decode if batch doesn't contain a hierarchy event
-        guard let jsonString = String(data: batchData, encoding: .utf8),
-              jsonString.contains(viewHierarchyEventType) else { return }
+        // Fast path: skip full JSON decode if batch doesn't contain a hierarchy event.
+        // Scan the raw UTF-8 bytes rather than allocating a whole-buffer String copy.
+        guard batchData.range(of: viewHierarchyEventTypeBytes) != nil else { return }
 
         guard let batch = try? JSONDecoder().decode(SdkEventBatchEnvelope.self, from: batchData) else { return }
 

--- a/ios/control-proxy/Tests/CtrlProxyTests/SdkHierarchyCacheTests.swift
+++ b/ios/control-proxy/Tests/CtrlProxyTests/SdkHierarchyCacheTests.swift
@@ -84,6 +84,40 @@ final class SdkHierarchyCacheTests: XCTestCase {
         XCTAssertNil(cache.latest)
     }
 
+    private func makeHierarchyEventBatch(timestamp: Int64) throws -> Data {
+        let hierarchy = makeSdkHierarchy(timestamp: timestamp)
+        let payload = try JSONEncoder().encode(["hierarchy": hierarchy])
+        return Data(
+            """
+            {"events":[{"eventType":"view_hierarchy","payload":"\(payload.base64EncodedString())"}]}
+            """.utf8
+        )
+    }
+
+    func testBatchContainingViewHierarchyStillDecodes() throws {
+        let cache = SdkHierarchyCache()
+        let batch = try makeHierarchyEventBatch(timestamp: 4242)
+
+        SdkHierarchyExtractor.extractIfPresent(from: batch, into: cache)
+
+        XCTAssertEqual(cache.latest?.timestamp, 4242)
+    }
+
+    func testBatchWithoutViewHierarchyIsSkipped() {
+        let cache = SdkHierarchyCache()
+        // Well-formed batch whose only event is a non-hierarchy type: the raw-byte
+        // scan must not find "view_hierarchy" and must skip the decode entirely.
+        let batch = Data(
+            """
+            {"events":[{"eventType":"lifecycle","payload":"\(Data("{}".utf8).base64EncodedString())"}]}
+            """.utf8
+        )
+
+        SdkHierarchyExtractor.extractIfPresent(from: batch, into: cache)
+
+        XCTAssertNil(cache.latest)
+    }
+
     func testHierarchyEventBroadcastsFreshChromeForUnchangedXcuitestHierarchy() throws {
         let cache = SdkHierarchyCache()
         let xcuitest = ViewHierarchy(


### PR DESCRIPTION
## Summary

On every `POST /sdk-events`, `SdkHierarchyExtractor.extractIfPresent` copied the
entire event batch into a `String` via `String(data:encoding:.utf8)` purely to
test for the `"view_hierarchy"` substring before deciding to decode. That
allocated a whole-buffer UTF-8 copy of every batch on the on-device runner's SDK
event hot path.

This replaces the gate with a raw-byte scan: `Data.range(of:)` over the
precomputed UTF-8 bytes of `"view_hierarchy"` (cached as a static `Data`). No
intermediate `String` is allocated. Which batches proceed to decode is unchanged
for valid UTF-8 JSON — the real input on this path.

## Changes

- `ios/control-proxy/Sources/CtrlProxy/SdkHierarchyCache.swift`: add a static
  `viewHierarchyEventTypeBytes` (`Data(viewHierarchyEventType.utf8)`) and gate the
  decode on `batchData.range(of:) != nil` instead of building a full `String`.
- `SdkHierarchyCacheTests`: add two tests proving behavior is unchanged with no
  dependence on the intermediate `String` — a batch containing `view_hierarchy`
  still decodes; a well-formed batch whose only event is a non-hierarchy type is
  still skipped.

## Validation

- `./scripts/ios/swift-build.sh` — all packages build.
- `./scripts/ios/swift-test.sh` — `control-proxy` package passes (9/9 in
  `SdkHierarchyCacheTests`). The only failure in the full run is
  `XCTestRunner`'s `RemindersAddPlanTests.testAddReminderPlan`, a device-integration
  test that timed out ("Set text timed out after 5000ms") with no live simulator —
  unrelated to this change and in a different package.
- SwiftLint/SwiftFormat: no new violations introduced (the remaining reported
  items pre-exist unchanged in the file).

Closes #5476

Part of the iOS CtrlProxy device-load reduction effort.
