### PR TITLE
perf(ios): reduce host-driven CtrlProxy device load when idle

### DIFF
--- a/src/daemon/deviceDataStreamSocketServer.ts
+++ b/src/daemon/deviceDataStreamSocketServer.ts
@@ -302,6 +302,14 @@ const MIN_HIERARCHY_INTERVAL_MS = 250;
 const MAX_SCREENSHOT_INTERVAL_MS = 2_147_483_647;
 const MAX_HIERARCHY_INTERVAL_MS = 2_147_483_647;
 
+// With no live-view subscriber, the host must NOT instruct the runner to poll
+// the (expensive) accessibility hierarchy at the fast default cadence. Send this
+// effectively-paused interval instead and rely on the on-demand
+// `request_hierarchy_if_stale` path for observes; a subscriber appearing
+// restores fast cadence via the same cadence-refresh call. This mirrors the
+// screenshot stream, which is already `hasSubscriberForDevice`-gated (#5472).
+const PAUSED_HIERARCHY_INTERVAL_MS = MAX_HIERARCHY_INTERVAL_MS;
+
 /**
  * Socket server that streams device data updates (hierarchy, screenshot, storage) to connected IDE plugins.
  *
@@ -717,6 +725,12 @@ export class DeviceDataStreamSocketServer extends PushSubscriptionSocketServer<
     deviceId: string,
     defaultIntervalMs: number = DEFAULT_HIERARCHY_INTERVAL_MS,
   ): number {
+    // Subscriber-gate the hierarchy cadence: with no active subscriber, pause
+    // runner polling entirely (observes still refresh on demand via
+    // request_hierarchy_if_stale) rather than falling back to the 1Hz default.
+    if (!this.hasSubscriberForDevice(deviceId)) {
+      return PAUSED_HIERARCHY_INTERVAL_MS;
+    }
     return this.getFastestIntervalMsForDevice(
       deviceId,
       defaultIntervalMs,

--- a/src/features/action/BaseVisualChange.ts
+++ b/src/features/action/BaseVisualChange.ts
@@ -15,6 +15,7 @@ import { NavigationGraphManager } from "../navigation/NavigationGraphManager";
 import { PredictionAnalyzer, PredictionActionContext } from "../observe/PredictionAnalyzer";
 import { Timer, defaultTimer } from "../../utils/SystemTimer";
 import { sequenceBackoff } from "../../utils/Backoff";
+import { getDeviceDataStreamServer } from "../../daemon/deviceDataStreamSocketServer";
 
 export interface ProgressCallback {
   (progress: number, total?: number, message?: string): Promise<void>;
@@ -253,6 +254,14 @@ export class BaseVisualChange {
     return `${preamble} Unlock or dismiss the keyguard before continuing.`;
   }
 
+  /**
+   * True when a live-view IDE subscriber is attached for this device, meaning a
+   * device screenshot is still worth capturing on internal re-observes.
+   */
+  private hasLiveViewSubscriber(): boolean {
+    return getDeviceDataStreamServer()?.hasSubscriberForDevice(this.device.deviceId) ?? false;
+  }
+
   private async takeObservation(
     blockResult: any,
     previousObserveResult: ObserveResult | null,
@@ -275,10 +284,17 @@ export class BaseVisualChange {
     const maxRetryAttempts = 4;
     const previousHash = this.hashViewHierarchy(previousObserveResult?.viewHierarchy);
 
+    // Internal post-action re-observes don't need a device screenshot: the PNG is
+    // only consumed by a live-view subscriber (fed separately by the
+    // subscriber-gated screenshot stream) or by tools that return the image.
+    // Skipping the capture here avoids a device round-trip per action, but stays
+    // enabled while a live view is attached (#5472, AC#3).
+    const skipScreenshot = !this.hasLiveViewSubscriber();
+
     perf.serial("finalObserve");
     // Wait for fresh data from accessibility service (skipWaitForFresh=false)
     // This ensures we get observation data that reflects the action that just completed
-    let latestObservation = await this.observeScreen.execute({ queryOptions: options.queryOptions, perf, skipWaitForFresh: false, minTimestamp, signal: options.signal });
+    let latestObservation = await this.observeScreen.execute({ queryOptions: options.queryOptions, perf, skipWaitForFresh: false, minTimestamp, signal: options.signal, skipScreenshot });
     perf.end();
 
     const shouldRetry = (observation: ObserveResult): boolean => {
@@ -304,7 +320,7 @@ export class BaseVisualChange {
       logger.info(`[BaseVisualChange] Observation appears stale/unchanged, retrying in ${delayMs}ms (attempt ${attempt + 1}/${maxRetryAttempts})`);
       await this.timer.sleep(delayMs);
       perf.serial(`finalObserve_retry_${attempt + 1}`);
-      latestObservation = await this.observeScreen.execute({ queryOptions: options.queryOptions, perf, skipWaitForFresh: false, minTimestamp, signal: options.signal });
+      latestObservation = await this.observeScreen.execute({ queryOptions: options.queryOptions, perf, skipWaitForFresh: false, minTimestamp, signal: options.signal, skipScreenshot });
       perf.end();
     }
 

--- a/src/features/observe/ios/CtrlProxyHierarchy.ts
+++ b/src/features/observe/ios/CtrlProxyHierarchy.ts
@@ -124,7 +124,11 @@ export class CtrlProxyHierarchy {
         (cachedHierarchy.captureReceivedAt ?? cachedHierarchy.receivedAt);
       const cacheAge = cachedCaptureAgeMs;
       // `fresh` is honoured as well as elapsed time: without it, invalidateCache()
-      // would be an observable no-op inside the TTL (issue #4193).
+      // would be an observable no-op inside the TTL (issue #4193). The TTL
+      // (`cacheFreshTtlMs`) was raised toward `maxObservationAgeMs` so multi-step
+      // sequences hit this cache instead of the device (#5472); it stays capped by
+      // `maxObservationAgeMs` here, and the `cacheStale` check below still forces a
+      // synchronous re-verification once a capture ages past that budget.
       const isFresh = cachedHierarchy.fresh && cacheAge < Math.min(this.context.cacheFreshTtlMs, maxObservationAgeMs());
       const meetsMinTimestamp = minTimestamp === 0 || cachedHierarchy.hierarchy.updatedAt >= minTimestamp;
 

--- a/src/features/observe/ios/IOSCtrlProxyClient.ts
+++ b/src/features/observe/ios/IOSCtrlProxyClient.ts
@@ -393,7 +393,12 @@ export class IOSCtrlProxyClient extends DeviceServiceClient implements IOSCtrlPr
    * WebSocket push events and explicit invalidateCache() calls after actions.
    */
   private cachedHierarchy: CtrlProxyCachedHierarchy | null = null;
-  private static readonly CACHE_FRESH_TTL_MS = 500;
+  // Raised from 500ms toward maxObservationAgeMs so cache hits replace device
+  // round-trips during multi-step sequences, leaning on unsolicited
+  // `hierarchy_update` pushes to keep the cache warm (#5472). Still floored by
+  // `Math.min(cacheFreshTtlMs, maxObservationAgeMs())` in CtrlProxyHierarchy, and
+  // a stale CAPTURE age past maxObservationAgeMs still forces re-verification.
+  private static readonly CACHE_FRESH_TTL_MS = 2000;
   private hierarchyNavigationDetector: HierarchyNavigationDetector | null = null;
   private readonly hierarchyObservationStreamSuppressions: Map<string, NodeJS.Timeout> = new Map();
 
@@ -466,6 +471,14 @@ export class IOSCtrlProxyClient extends DeviceServiceClient implements IOSCtrlPr
   private sdkEventPollAbortController: AbortController | null = null;
   private sdkEventPollInFlight: { generation: number; promise: Promise<SdkEventPollResult> } | null = null;
   private static readonly SDK_EVENT_POLL_TIMEOUT_MS = 2000;
+  // Fast cadence for the CtrlProxy /sdk-events long-poll (was a bare `2000`).
+  private static readonly SDK_EVENT_POLL_INTERVAL_MS = 2000;
+  // After this many consecutive empty batches (e.g. an app with no SDK
+  // integrated) the poll backs off to the slower cadence below. Any inbound WS
+  // activity resets the counter and restores fast cadence (#5472, AC#2).
+  private static readonly SDK_EVENT_POLL_EMPTY_BATCHES_BEFORE_BACKOFF = 5;
+  private static readonly SDK_EVENT_POLL_BACKOFF_INTERVAL_MS = 30_000;
+  private sdkEventPollConsecutiveEmpty = 0;
   private static readonly SDK_IDENTITY_REFRESH_TIMEOUT_MS = 100;
   private static readonly SDK_IDENTITY_REFRESH_RETRY_MS = 10;
 
@@ -954,6 +967,8 @@ export class IOSCtrlProxyClient extends DeviceServiceClient implements IOSCtrlPr
   }
 
   protected handleMessage(data: WebSocket.Data): void {
+    // Inbound frames indicate an active app; reset the SDK-event poll backoff.
+    this.noteSdkEventPollWsActivity();
     try {
       const message = JSON.parse(data.toString()) as WebSocketMessage;
       this.processMessage(message);
@@ -962,7 +977,7 @@ export class IOSCtrlProxyClient extends DeviceServiceClient implements IOSCtrlPr
     }
   }
 
-  private sdkEventPollInterval: ReturnType<typeof setInterval> | null = null;
+  private sdkEventPollTimer: ReturnType<typeof setTimeout> | null = null;
 
   protected onConnectionEstablished(): void {
     // Reset failure counter on successful connection
@@ -1064,10 +1079,62 @@ export class IOSCtrlProxyClient extends DeviceServiceClient implements IOSCtrlPr
 
   private startSdkEventPolling(): void {
     this.stopSdkEventPolling();
-    void this.pollSdkEvents();
-    this.sdkEventPollInterval = this.timer.setInterval(() => {
-      void this.pollSdkEvents();
-    }, 2000);
+    this.sdkEventPollConsecutiveEmpty = 0;
+    // Self-rescheduling loop (was a fixed setInterval) so the cadence can adapt:
+    // an immediate poll, then reschedule at fast or backed-off cadence based on
+    // whether batches keep coming back empty.
+    void this.runSdkEventPollCycle(this.sdkEventPollGeneration);
+  }
+
+  private async runSdkEventPollCycle(generation: number): Promise<void> {
+    if (generation !== this.sdkEventPollGeneration) {
+      return;
+    }
+    const result = await this.pollSdkEvents();
+    if (generation !== this.sdkEventPollGeneration) {
+      return;
+    }
+    if (result.receivedEvents) {
+      this.sdkEventPollConsecutiveEmpty = 0;
+    } else {
+      this.sdkEventPollConsecutiveEmpty++;
+    }
+    this.scheduleNextSdkEventPoll(generation);
+  }
+
+  private scheduleNextSdkEventPoll(generation: number): void {
+    if (generation !== this.sdkEventPollGeneration) {
+      return;
+    }
+    if (this.sdkEventPollTimer) {
+      this.timer.clearTimeout(this.sdkEventPollTimer);
+    }
+    this.sdkEventPollTimer = this.timer.setTimeout(() => {
+      void this.runSdkEventPollCycle(generation);
+    }, this.currentSdkEventPollIntervalMs());
+  }
+
+  private currentSdkEventPollIntervalMs(): number {
+    return this.sdkEventPollConsecutiveEmpty >= IOSCtrlProxyClient.SDK_EVENT_POLL_EMPTY_BATCHES_BEFORE_BACKOFF
+      ? IOSCtrlProxyClient.SDK_EVENT_POLL_BACKOFF_INTERVAL_MS
+      : IOSCtrlProxyClient.SDK_EVENT_POLL_INTERVAL_MS;
+  }
+
+  /**
+   * Any inbound WebSocket frame from the runner is a signal the app is active,
+   * so reset the empty-batch backoff and — if we had already backed off — restore
+   * fast cadence immediately rather than waiting out the long backoff timer.
+   */
+  private noteSdkEventPollWsActivity(): void {
+    if (this.sdkEventPollConsecutiveEmpty === 0) {
+      return;
+    }
+    const wasBackedOff =
+      this.sdkEventPollConsecutiveEmpty >= IOSCtrlProxyClient.SDK_EVENT_POLL_EMPTY_BATCHES_BEFORE_BACKOFF;
+    this.sdkEventPollConsecutiveEmpty = 0;
+    if (wasBackedOff && this.sdkEventPollTimer) {
+      this.scheduleNextSdkEventPoll(this.sdkEventPollGeneration);
+    }
   }
 
   private async pollSdkEvents(): Promise<SdkEventPollResult> {
@@ -1215,9 +1282,9 @@ export class IOSCtrlProxyClient extends DeviceServiceClient implements IOSCtrlPr
   }
 
   private stopSdkEventPolling(): void {
-    if (this.sdkEventPollInterval) {
-      this.timer.clearInterval(this.sdkEventPollInterval);
-      this.sdkEventPollInterval = null;
+    if (this.sdkEventPollTimer) {
+      this.timer.clearTimeout(this.sdkEventPollTimer);
+      this.sdkEventPollTimer = null;
     }
   }
 

--- a/test/daemon/deviceDataStreamSocketServer.test.ts
+++ b/test/daemon/deviceDataStreamSocketServer.test.ts
@@ -667,7 +667,8 @@ describe("DeviceDataStreamSocketServer", () => {
       expect(server.getSubscriberCount()).toBe(0);
       expect(server.hasSubscriberForDevice("device-1")).toBe(false);
       expect(server.getScreenshotIntervalMsForDevice("device-1")).toBe(3000);
-      expect(server.getHierarchyIntervalMsForDevice("device-1")).toBe(1000);
+      // No subscriber: the hierarchy cadence is paused, not the 1Hz default (#5472).
+      expect(server.getHierarchyIntervalMsForDevice("device-1")).toBe(2_147_483_647);
     });
 
     it("rejects a blank deviceSessionUuid", async () => {
@@ -1482,6 +1483,28 @@ describe("DeviceDataStreamSocketServer", () => {
       expect(server.getHierarchyIntervalMsForDevice("device-1", 250)).toBe(250);
     });
 
+    it("pauses hierarchy cadence when no subscriber wants the device (#5472)", () => {
+      // No subscription at all: do NOT instruct the runner to poll at 1Hz.
+      expect(server.getHierarchyIntervalMsForDevice("device-1")).toBe(2_147_483_647);
+      // A caller-provided fallback is still overridden by the no-subscriber pause.
+      expect(server.getHierarchyIntervalMsForDevice("device-1", 250)).toBe(2_147_483_647);
+    });
+
+    it("restores fast hierarchy cadence once a subscriber appears (#5472)", () => {
+      expect(server.getHierarchyIntervalMsForDevice("device-1")).toBe(2_147_483_647);
+
+      server.simulateSubscription({ deviceId: "device-1", hierarchyIntervalMs: 500 });
+
+      expect(server.getHierarchyIntervalMsForDevice("device-1")).toBe(500);
+    });
+
+    it("pauses only devices with no subscriber, leaving subscribed peers fast (#5472)", () => {
+      server.simulateSubscription({ deviceId: "device-1", hierarchyIntervalMs: 500 });
+
+      expect(server.getHierarchyIntervalMsForDevice("device-1")).toBe(500);
+      expect(server.getHierarchyIntervalMsForDevice("device-2")).toBe(2_147_483_647);
+    });
+
     it("parses requested hierarchy cadence from subscribe commands", async () => {
       const socket = new FakeSocket();
 
@@ -1559,7 +1582,7 @@ describe("DeviceDataStreamSocketServer", () => {
       expect(server.getHierarchyIntervalMsForDevice("device-1")).toBe(500);
     });
 
-    it("removes requested hierarchy cadence after unsubscribe", async () => {
+    it("pauses hierarchy cadence after unsubscribe leaves no subscriber", async () => {
       const { socket } = server.simulateSubscription({
         deviceId: "device-1",
         hierarchyIntervalMs: 500,
@@ -1574,7 +1597,8 @@ describe("DeviceDataStreamSocketServer", () => {
         }),
       );
 
-      expect(server.getHierarchyIntervalMsForDevice("device-1")).toBe(1000);
+      // No subscriber remains: pause runner polling rather than fall back to 1Hz (#5472).
+      expect(server.getHierarchyIntervalMsForDevice("device-1")).toBe(2_147_483_647);
     });
 
     it("ignores destroyed subscriber sockets when aggregating hierarchy cadence", () => {
@@ -1584,7 +1608,8 @@ describe("DeviceDataStreamSocketServer", () => {
       });
       socket.destroy();
 
-      expect(server.getHierarchyIntervalMsForDevice("device-1")).toBe(1000);
+      // A destroyed socket is not an active subscriber, so cadence is paused (#5472).
+      expect(server.getHierarchyIntervalMsForDevice("device-1")).toBe(2_147_483_647);
     });
 
     it("notifies when subscribe changes hierarchy cadence", async () => {
@@ -2109,7 +2134,8 @@ describe("DeviceDataStreamSocketServer", () => {
       expect(frames(socket).filter(f => f.type === "hierarchy_update")).toHaveLength(0);
       expect(server.hasSubscriberForDevice("device-a")).toBe(false);
       expect(server.getScreenshotIntervalMsForDevice("device-a")).toBe(3000);
-      expect(server.getHierarchyIntervalMsForDevice("device-a")).toBe(1000);
+      // Retired subscriber: hierarchy cadence pauses instead of the 1Hz default (#5472).
+      expect(server.getHierarchyIntervalMsForDevice("device-a")).toBe(2_147_483_647);
     });
 
     it("retires the previous uuid when a fake resolver rebinds a device", () => {

--- a/test/features/action/BaseVisualChange.postActionObservation.test.ts
+++ b/test/features/action/BaseVisualChange.postActionObservation.test.ts
@@ -93,6 +93,22 @@ describe("BaseVisualChange post-action observation", () => {
     expect(fakeTimer.getSleepHistory()).toEqual([]);
   });
 
+  test("defaults the post-action re-observe to skipScreenshot when no live-view subscriber (#5472)", async () => {
+    const instance = createVisualChange("ios");
+    fakeObserveScreen.setObserveResult(makeObserve());
+
+    // No DeviceDataStream server/subscriber is wired in this unit context, so the
+    // internal re-observe must skip the device PNG capture.
+    await instance.observedInteraction(async () => ({ success: true }), {
+      changeExpected: false,
+      skipPreviousObserve: true
+    });
+
+    const options = fakeObserveScreen.getExecuteOptions();
+    expect(options).toHaveLength(1);
+    expect(options[0].skipScreenshot).toBe(true);
+  });
+
   test("takes the cached fast path with a single execute when the cache is valid", async () => {
     const instance = createVisualChange("ios");
     // A valid cached hierarchy (no error) means the pre-action observe reuses the

--- a/test/features/observe/ios/IOSCtrlProxyClient.test.ts
+++ b/test/features/observe/ios/IOSCtrlProxyClient.test.ts
@@ -2600,6 +2600,75 @@ describe("IOSCtrlProxyClient", function() {
       }
     });
 
+    test("backs off the SDK-event poll after consecutive empty batches (#5472)", async function() {
+      const { factory } = createCapturingWebSocketFactory(fakeTimer);
+      const testClient = IOSCtrlProxyClient.createForTesting(testDevice, serverPort, factory, fakeTimer);
+      const originalFetch = globalThis.fetch;
+      globalThis.fetch = (async () => ({ ok: true, json: async () => [] })) as unknown as typeof fetch;
+      const internals = testClient as unknown as {
+        runSdkEventPollCycle(generation: number): Promise<void>;
+        currentSdkEventPollIntervalMs(): number;
+        stopSdkEventPolling(): void;
+        sdkEventPollGeneration: number;
+        sdkEventPollConsecutiveEmpty: number;
+      };
+
+      try {
+        const generation = internals.sdkEventPollGeneration;
+        // Below the threshold the poll stays at the fast 2s cadence.
+        for (let i = 0; i < 4; i++) {
+          await internals.runSdkEventPollCycle(generation);
+        }
+        expect(internals.sdkEventPollConsecutiveEmpty).toBe(4);
+        expect(internals.currentSdkEventPollIntervalMs()).toBe(2000);
+
+        // The 5th consecutive empty batch trips the backoff to the slow cadence.
+        await internals.runSdkEventPollCycle(generation);
+        expect(internals.sdkEventPollConsecutiveEmpty).toBe(5);
+        expect(internals.currentSdkEventPollIntervalMs()).toBe(30_000);
+
+        internals.stopSdkEventPolling();
+      } finally {
+        globalThis.fetch = originalFetch;
+        await testClient.close();
+      }
+    });
+
+    test("resets SDK-event poll backoff on inbound WebSocket activity (#5472)", async function() {
+      const { factory } = createCapturingWebSocketFactory(fakeTimer);
+      const testClient = IOSCtrlProxyClient.createForTesting(testDevice, serverPort, factory, fakeTimer);
+      const originalFetch = globalThis.fetch;
+      globalThis.fetch = (async () => ({ ok: true, json: async () => [] })) as unknown as typeof fetch;
+      const internals = testClient as unknown as {
+        runSdkEventPollCycle(generation: number): Promise<void>;
+        handleMessage(data: unknown): void;
+        currentSdkEventPollIntervalMs(): number;
+        stopSdkEventPolling(): void;
+        sdkEventPollGeneration: number;
+        sdkEventPollConsecutiveEmpty: number;
+      };
+
+      try {
+        const generation = internals.sdkEventPollGeneration;
+        for (let i = 0; i < 5; i++) {
+          await internals.runSdkEventPollCycle(generation);
+        }
+        expect(internals.currentSdkEventPollIntervalMs()).toBe(30_000);
+
+        // Any inbound runner frame is treated as app activity: reset the empty
+        // counter and restore fast cadence, even for an unrecognized message type.
+        internals.handleMessage(Buffer.from(JSON.stringify({ type: "unrecognized" })));
+
+        expect(internals.sdkEventPollConsecutiveEmpty).toBe(0);
+        expect(internals.currentSdkEventPollIntervalMs()).toBe(2000);
+
+        internals.stopSdkEventPolling();
+      } finally {
+        globalThis.fetch = originalFetch;
+        await testClient.close();
+      }
+    });
+
     test("orders tracking re-enable before an earlier-arriving navigation event", async function() {
       const { factory } = createCapturingWebSocketFactory(fakeTimer);
       const testClient = IOSCtrlProxyClient.createForTesting(testDevice, serverPort, factory, fakeTimer);


### PR DESCRIPTION
## Summary

Host-side (TypeScript) changes that stop AutoMobile from driving more iOS
CtrlProxy device work than necessary. Addresses all five acceptance criteria of
[#5472](https://github.com/kaeawc/auto-mobile/issues/5472). No Swift / runner-side
changes (kept disjoint per the issue's out-of-scope note).

### What changed, per file

- **`src/daemon/deviceDataStreamSocketServer.ts`** (AC#1) — `getHierarchyIntervalMsForDevice`
  now returns a new `PAUSED_HIERARCHY_INTERVAL_MS` (the max timer delay) when
  `hasSubscriberForDevice` is false, instead of falling back to the 1Hz default.
  With no subscriber the runner is no longer told to poll the expensive
  accessibility hierarchy; observes still refresh on demand via
  `request_hierarchy_if_stale`, and a subscriber appearing restores fast cadence
  through the existing cadence-refresh call. Mirrors the already-gated screenshot
  stream.
- **`src/features/observe/ios/IOSCtrlProxyClient.ts`** (AC#2, AC#4) —
  - The 2s SDK-event poll `setInterval` is replaced by a self-rescheduling
    loop (`runSdkEventPollCycle` → `scheduleNextSdkEventPoll`). After
    `SDK_EVENT_POLL_EMPTY_BATCHES_BEFORE_BACKOFF` (5) consecutive empty batches
    it backs off from `SDK_EVENT_POLL_INTERVAL_MS` (2000, the lifted literal) to
    `SDK_EVENT_POLL_BACKOFF_INTERVAL_MS` (30s). Any inbound WS frame
    (`noteSdkEventPollWsActivity`, called from `handleMessage`) resets the counter
    and restores fast cadence.
  - `CACHE_FRESH_TTL_MS` raised 500 → 2000 (toward `maxObservationAgeMs`) so
    multi-step sequences hit cache instead of the device.
- **`src/features/observe/ios/CtrlProxyHierarchy.ts`** (AC#4) — comment-only:
  documents the raised TTL at the freshness site; the `Math.min(cacheFreshTtlMs,
  maxObservationAgeMs())` cap and the `cacheStale` re-verification are unchanged.
- **`src/features/action/BaseVisualChange.ts`** (AC#3) — internal post-action
  re-observes now pass `skipScreenshot: true` unless a live-view subscriber is
  attached (`hasLiveViewSubscriber` via `getDeviceDataStreamServer`), avoiding a
  device PNG capture per action. Tools that return images are unaffected.

### Tests (AC#5)

- `test/daemon/deviceDataStreamSocketServer.test.ts` — new no-subscriber
  cadence-gate coverage (pause with no subscriber, override caller fallback,
  restore on subscribe, per-device isolation); updated three existing
  no-subscriber assertions from 1000 to the paused value.
- `test/features/observe/ios/IOSCtrlProxyClient.test.ts` — empty-batch backoff
  and WS-activity reset coverage.
- `test/features/action/BaseVisualChange.postActionObservation.test.ts` —
  asserts the post-action re-observe skips the screenshot with no subscriber.

## Validation

- `bun run typecheck` — pass (no new type errors vs baseline; a pre-existing
  `swap-fp` baseline error in an untouched file happened to not reproduce this
  run — left the baseline unchanged to avoid ratcheting on version-flaky entries).
- `bun run lint` — pass (oxlint ratchet: no new violations; boundary-checks 13/13).
- `bun run build` — pass.
- `bun test test/daemon/ test/features/action/ test/features/observe/` —
  4758 pass, 0 fail.

Closes #5472
