### PR TITLE
perf(ios): trim redundant hierarchy extraction in CtrlProxy command path

### DIFF
--- a/ios/control-proxy/Sources/CtrlProxy/CommandHandler.swift
+++ b/ios/control-proxy/Sources/CtrlProxy/CommandHandler.swift
@@ -419,12 +419,17 @@ public class CommandHandler: CommandHandling {
     }
 
     private func handleRequestScreenshot(_ request: RequestEnvelope, startTime _: Date) throws -> ScreenshotResponse {
-        // Read the hierarchy on both sides of the pixel capture. A change during capture leaves
-        // the context absent, which makes a context-aware client fail closed instead of pairing
-        // pixels from one screen with the identity of another.
-        let before = currentFrameContext()
+        // Frame-context correlation is opt-in: only when the client supplies a `frameContext`
+        // does the screenshot pay for the surrounding hierarchy walks. A plain screenshot
+        // performs zero extractions and returns `frameContext: nil`.
+        //
+        // When requested, read the hierarchy on both sides of the pixel capture. A change during
+        // capture leaves the context absent, which makes a context-aware client fail closed
+        // instead of pairing pixels from one screen with the identity of another.
+        let correlate = request.frameContext != nil
+        let before = correlate ? currentFrameContext() : nil
         let screenshot = try gesturePerformer.getScreenshotCapture()
-        let after = currentFrameContext()
+        let after = correlate ? currentFrameContext() : nil
         let base64 = screenshot.data.base64EncodedString()
 
         return ScreenshotResponse(
@@ -432,7 +437,7 @@ public class CommandHandler: CommandHandling {
             data: base64,
             format: "png",
             rotation: screenshot.rotation,
-            frameContext: before == after ? before : nil
+            frameContext: correlate && before == after ? before : nil
         )
     }
 
@@ -440,14 +445,7 @@ public class CommandHandler: CommandHandling {
         guard let hierarchy = try? elementLocator.getViewHierarchy(disableAllFiltering: false) else {
             return nil
         }
-        return frameContext.context(for: enrichWithMatchingSdkHierarchy(hierarchy))
-    }
-
-    private func requireCurrentFrameContext(_ expected: String?) throws {
-        guard let expected else { return }
-        guard currentFrameContext() == expected else {
-            throw CommandError.executionFailed("Stale frame context; observe a fresh frame before retrying")
-        }
+        return frameContext.context(for: enrichWithCachedSdkHierarchy(hierarchy))
     }
 
     private func performContextCheckedGesture<T>(
@@ -456,10 +454,18 @@ public class CommandHandler: CommandHandling {
     )
         throws -> T
     {
-        let hierarchy = try? elementLocator.getViewHierarchy(disableAllFiltering: false)
+        // No expected context means there is nothing to validate: `performIfCurrent` returns
+        // `operation()` immediately for a nil `expected` (dispatched on the transition executor),
+        // so skip the hierarchy extraction and blocking SDK fetch entirely on this fast path.
+        // When context IS supplied, extract once and prefer the zero-device-cost cached SDK
+        // hierarchy — the observe that produced `expected` also warmed that cache — instead of
+        // the slow `/hierarchy/fresh` main-thread walk in the target app.
+        let hierarchy = expected == nil
+            ? nil
+            : (try? elementLocator.getViewHierarchy(disableAllFiltering: false)).map(enrichWithCachedSdkHierarchy)
         return try frameContext.performIfCurrent(
             expected: expected,
-            hierarchy: hierarchy.map(enrichWithMatchingSdkHierarchy),
+            hierarchy: hierarchy,
             operation: operation
         )
     }
@@ -488,7 +494,6 @@ public class CommandHandler: CommandHandling {
     }
 
     private func handleTapCoordinates(_ request: RequestTapCoordinates, startTime: Date) throws -> WebSocketResponse {
-        try requireCurrentFrameContext(request.frameContext)
         try requireFinite(request.x, field: "x")
         try requireFinite(request.y, field: "y")
         let duration = request.duration ?? 0
@@ -504,7 +509,6 @@ public class CommandHandler: CommandHandling {
     }
 
     private func handleSwipe(_ request: RequestSwipe, startTime: Date) throws -> WebSocketResponse {
-        try requireCurrentFrameContext(request.frameContext)
         try requireFinite(request.x1, field: "x1")
         try requireFinite(request.y1, field: "y1")
         try requireFinite(request.x2, field: "x2")
@@ -563,7 +567,6 @@ public class CommandHandler: CommandHandling {
     }
 
     private func handleDrag(_ request: RequestDrag, startTime: Date) throws -> WebSocketResponse {
-        try requireCurrentFrameContext(request.frameContext)
         try requireFinite(request.x1, field: "x1")
         try requireFinite(request.y1, field: "y1")
         try requireFinite(request.x2, field: "x2")
@@ -632,7 +635,6 @@ public class CommandHandler: CommandHandling {
             )
 
         do {
-            try requireCurrentFrameContext(request.frameContext)
             try performContextCheckedGesture(expected: request.frameContext) {
                 if let resourceId = resourceId {
                     try perfProvider.track("setText.byResourceId") {
@@ -669,7 +671,6 @@ public class CommandHandler: CommandHandling {
         perfProvider.serial("handleAppendText")
         defer { perfProvider.end() }
 
-        try requireCurrentFrameContext(request.frameContext)
         try performContextCheckedGesture(expected: request.frameContext) {
             try perfProvider.track("appendText") {
                 try gesturePerformer.appendText(text: request.text)
@@ -821,7 +822,6 @@ public class CommandHandler: CommandHandling {
         perfProvider.serial("handlePressButton")
         defer { perfProvider.end() }
 
-        try requireCurrentFrameContext(request.frameContext)
         try performContextCheckedGesture(expected: request.frameContext) {
             try perfProvider.track("pressButton") {
                 try gesturePerformer.pressButton(button)
@@ -848,7 +848,6 @@ public class CommandHandler: CommandHandling {
         perfProvider.serial("handlePressHome")
         defer { perfProvider.end() }
 
-        try requireCurrentFrameContext(request.frameContext)
         try performContextCheckedGesture(expected: request.frameContext) {
             try perfProvider.track("pressHome") {
                 try gesturePerformer.pressHome()
@@ -874,7 +873,6 @@ public class CommandHandler: CommandHandling {
         perfProvider.serial("handlePressBack")
         defer { perfProvider.end() }
 
-        try requireCurrentFrameContext(request.frameContext)
         try performContextCheckedGesture(expected: request.frameContext) {
             try perfProvider.track("pressBack") {
                 try gesturePerformer.pressBack()
@@ -907,7 +905,6 @@ public class CommandHandler: CommandHandling {
         perfProvider.serial("handleRecentApps")
         defer { perfProvider.end() }
 
-        try requireCurrentFrameContext(request.frameContext)
         let didOpen = try performContextCheckedGesture(expected: request.frameContext) {
             try perfProvider.track("openRecentApps") {
                 try gesturePerformer.openRecentApps()

--- a/ios/control-proxy/Sources/CtrlProxy/FrameContext.swift
+++ b/ios/control-proxy/Sources/CtrlProxy/FrameContext.swift
@@ -76,13 +76,20 @@ public final class FrameContext {
         }
     }
 
+    /// Shared encoder for `semanticHash`. `.outputFormatting` is set once and never mutated
+    /// afterward, so read-only `encode(_:)` calls are safe to share; this avoids allocating a
+    /// fresh `JSONEncoder` on every hash (one per gesture validation and screenshot pairing).
+    private static let semanticHashEncoder: JSONEncoder = {
+        let encoder = JSONEncoder()
+        encoder.outputFormatting = .sortedKeys
+        return encoder
+    }()
+
     private static func semanticHash(_ hierarchy: ViewHierarchy) -> String? {
         // `updatedAt` is assigned for every extraction, so including it would reject an unchanged
         // screen merely because validation sampled it a millisecond later. Hash only semantic
         // screen state, with sorted keys for deterministic dictionary encoding.
-        let encoder = JSONEncoder()
-        encoder.outputFormatting = .sortedKeys
-        guard let data = try? encoder.encode(SemanticHierarchy(hierarchy)) else { return nil }
+        guard let data = try? semanticHashEncoder.encode(SemanticHierarchy(hierarchy)) else { return nil }
         var hash: UInt64 = 0xCBF2_9CE4_8422_2325
         for byte in data {
             hash ^= UInt64(byte)

--- a/ios/control-proxy/Tests/CtrlProxyTests/CommandHandlerTests.swift
+++ b/ios/control-proxy/Tests/CtrlProxyTests/CommandHandlerTests.swift
@@ -354,6 +354,43 @@ final class CommandHandlerTests: XCTestCase {
         XCTAssertEqual(cache.clearCallCount, 1)
     }
 
+    func testContextCheckedGesturePrefersCachedSdkHierarchyOverFreshFetch() {
+        // A fresh hierarchy is available and the server bundle matches, but the gesture hot path
+        // must never pay for the slow `/hierarchy/fresh` walk: it enriches from the cache only.
+        let fetcher = FakeSdkHierarchyFetcher()
+        fetcher.setServerInfo(SdkHierarchyServerInfo(status: "ok", bundleId: "com.test.app"))
+        fetcher.setFreshHierarchy(makeSdkHierarchy(bundleId: "com.test.app"))
+
+        let cache = FakeSdkHierarchyCache()
+        cache.update(makeSdkHierarchy(bundleId: "com.test.app"))
+
+        let frameContext = FrameContext()
+        commandHandler = CommandHandler.createForTesting(
+            elementLocator: fakeElementLocator,
+            gesturePerformer: fakeGesturePerformer,
+            perfProvider: perfProvider,
+            sdkHierarchyClient: fetcher,
+            sdkHierarchyCache: cache,
+            frameContext: frameContext
+        )
+
+        let hierarchy = makeHierarchy(packageName: "com.test.app")
+        fakeElementLocator.setHierarchy(hierarchy)
+        // Derive the expected context the same way the dispatch boundary will: cached enrichment.
+        let expected = frameContext.context(for: commandHandler.enrichWithCachedSdkHierarchy(hierarchy))
+
+        let response = handleRequest(
+            WebSocketRequest.tapCoordinates(
+                RequestTapCoordinates(requestId: "tap", x: 10, y: 20, frameContext: expected)
+            ),
+            as: WebSocketResponse.self
+        )
+
+        XCTAssertEqual(response?.success, true)
+        XCTAssertEqual(fakeGesturePerformer.getTapHistory().count, 1)
+        XCTAssertEqual(fetcher.fetchFreshCallCount, 0)
+    }
+
     func testRequestHierarchyFetchesFreshSdkHierarchyOnlyWhenServerBundleMatchesForeground() {
         let fetcher = FakeSdkHierarchyFetcher()
         fetcher.setServerInfo(SdkHierarchyServerInfo(status: "ok", bundleId: "com.test.app"))

--- a/ios/control-proxy/Tests/CtrlProxyTests/FrameContextSafetyTests.swift
+++ b/ios/control-proxy/Tests/CtrlProxyTests/FrameContextSafetyTests.swift
@@ -39,9 +39,73 @@ final class FrameContextSafetyTests: XCTestCase {
             frameContext?.recordTransition(to: screenA)
         }
 
-        let response = commandHandler.handle(.requestScreenshot(RequestEnvelope(requestId: "capture"))) as? ScreenshotResponse
+        // Correlation is opt-in via a supplied frameContext; the ABA transition during capture
+        // still makes the before/after contexts disagree, so the paired context is withheld.
+        let response = commandHandler.handle(
+            .requestScreenshot(RequestEnvelope(requestId: "capture", frameContext: "correlate"))
+        ) as? ScreenshotResponse
 
         XCTAssertNil(response?.frameContext)
+    }
+
+    func testScreenshotWithoutRequestedContextSkipsExtractionAndReturnsNilContext() {
+        let screenA = makeHierarchy(text: "A")
+        fakeElementLocator.setHierarchy(screenA)
+
+        let response = commandHandler
+            .handle(.requestScreenshot(RequestEnvelope(requestId: "capture"))) as? ScreenshotResponse
+
+        XCTAssertNotNil(response?.data)
+        XCTAssertNil(response?.frameContext)
+        // Opt-out means neither the before nor the after hierarchy is walked.
+        XCTAssertEqual(fakeElementLocator.hierarchyRequestCount, 0)
+    }
+
+    func testScreenshotWithRequestedContextPairsStableScreen() {
+        let screenA = makeHierarchy(text: "A")
+        fakeElementLocator.setHierarchy(screenA)
+
+        let response = commandHandler.handle(
+            .requestScreenshot(RequestEnvelope(requestId: "capture", frameContext: "correlate"))
+        ) as? ScreenshotResponse
+
+        // No transition during capture, so the before/after contexts agree and one is returned.
+        XCTAssertNotNil(response?.frameContext)
+        XCTAssertEqual(response?.frameContext, frameContext.context(for: screenA))
+    }
+
+    func testContextlessGesturePerformsNoHierarchyExtraction() {
+        fakeElementLocator.setHierarchy(makeHierarchy(text: "A"))
+
+        let response = commandHandler.handle(.tapCoordinates(RequestTapCoordinates(
+            requestId: "tap",
+            x: 10,
+            y: 20,
+            frameContext: nil
+        ))) as? WebSocketResponse
+
+        XCTAssertEqual(response?.success, true)
+        XCTAssertEqual(fakeGesturePerformer.getTapHistory().count, 1)
+        // No expected context means no staleness check, so the hierarchy is never extracted.
+        XCTAssertEqual(fakeElementLocator.hierarchyRequestCount, 0)
+    }
+
+    func testContextBearingGesturePerformsExactlyOneHierarchyExtraction() {
+        let screenA = makeHierarchy(text: "A")
+        let expected = frameContext.context(for: screenA)
+        fakeElementLocator.setHierarchy(screenA)
+
+        let response = commandHandler.handle(.tapCoordinates(RequestTapCoordinates(
+            requestId: "tap",
+            x: 10,
+            y: 20,
+            frameContext: expected
+        ))) as? WebSocketResponse
+
+        XCTAssertEqual(response?.success, true)
+        XCTAssertEqual(fakeGesturePerformer.getTapHistory().count, 1)
+        // The redundant pre-check is gone: the dispatch boundary extracts the hierarchy once.
+        XCTAssertEqual(fakeElementLocator.hierarchyRequestCount, 1)
     }
 
     func testContextBearingGesturesRevalidateAtDispatchBoundary() {
@@ -96,14 +160,10 @@ final class FrameContextSafetyTests: XCTestCase {
         ]
 
         for request in requests {
-            fakeElementLocator.setHierarchy(screenA)
-            fakeElementLocator.onHierarchyRead = { [fakeElementLocator] in
-                // FakeElementLocator invokes this after returning the first hierarchy, so the
-                // initial requireCurrentFrameContext sees A and the serialized execution check
-                // sees B.
-                fakeElementLocator?.setHierarchy(screenB)
-                fakeElementLocator?.onHierarchyRead = nil
-            }
+            // `expected` was computed from screen A, but the screen has since transitioned to B.
+            // The single dispatch-boundary extraction now sees B, so the hash mismatch rejects
+            // the stale context and the gesture never executes.
+            fakeElementLocator.setHierarchy(screenB)
             let response = commandHandler.handle(request) as? WebSocketResponse
             XCTAssertEqual(response?.success, false)
         }

--- a/schemas/tool-definitions.json
+++ b/schemas/tool-definitions.json
@@ -123,7 +123,6 @@
           "type": "object",
           "properties": {
             "bounds": {
-              "description": "Element bounds. Default: positional tuple [left, top, right, bottom]; the object {left, top, right, bottom} (+ optional centerX/centerY) is also schema-valid.",
               "anyOf": [
                 {
                   "type": "object",
@@ -156,7 +155,6 @@
                   "additionalProperties": false
                 },
                 {
-                  "description": "Compact bounds tuple [left, top, right, bottom], emitted in place of the {left, top, right, bottom} object.",
                   "type": "array",
                   "prefixItems": [
                     {
@@ -171,9 +169,11 @@
                     {
                       "type": "number"
                     }
-                  ]
+                  ],
+                  "description": "Compact bounds tuple [left, top, right, bottom], emitted in place of the {left, top, right, bottom} object."
                 }
-              ]
+              ],
+              "description": "Element bounds. Default: positional tuple [left, top, right, bottom]; the object {left, top, right, bottom} (+ optional centerX/centerY) is also schema-valid."
             },
             "text": {
               "type": "string"
@@ -361,14 +361,14 @@
       "type": "object",
       "properties": {
         "lock": {
-          "description": "Shared barrier name; all devices using the same name synchronize together",
-          "type": "string"
+          "type": "string",
+          "description": "Shared barrier name; all devices using the same name synchronize together"
         },
         "deviceCount": {
-          "description": "Number of devices that must arrive before the barrier lifts",
           "type": "integer",
           "exclusiveMinimum": 0,
-          "maximum": 9007199254740991
+          "maximum": 9007199254740991,
+          "description": "Number of devices that must arrive before the barrier lifts"
         },
         "timeout": {
           "description": "Barrier timeout ms (default 30000)",
@@ -396,14 +396,14 @@
       "type": "object",
       "properties": {
         "action": {
-          "description": "match/fail/cancel/error; cancel/error require Android SDK hook",
           "type": "string",
           "enum": [
             "match",
             "fail",
             "cancel",
             "error"
-          ]
+          ],
+          "description": "match/fail/cancel/error; cancel/error require Android SDK hook"
         },
         "modality": {
           "description": "Modality: any default, fingerprint, or face",
@@ -595,8 +595,8 @@
           "type": "string"
         },
         "name": {
-          "description": "Storage name",
-          "type": "string"
+          "type": "string",
+          "description": "Storage name"
         },
         "fileName": {
           "description": "Deprecated alias for name",
@@ -700,8 +700,8 @@
       "type": "object",
       "properties": {
         "action": {
-          "description": "Clipboard action",
           "type": "string",
+          "description": "Clipboard action",
           "enum": [
             "copy",
             "paste",
@@ -710,9 +710,9 @@
           ]
         },
         "text": {
-          "description": "Text to copy (required for 'copy' action)",
           "type": "string",
-          "minLength": 1
+          "minLength": 1,
+          "description": "Text to copy (required for 'copy' action)"
         },
         "platform": {
           "type": "string",
@@ -763,27 +763,26 @@
       "type": "object",
       "properties": {
         "lock": {
-          "description": "Shared barrier lock name",
-          "type": "string"
+          "type": "string",
+          "description": "Shared barrier lock name"
         },
         "steps": {
-          "description": "Serial steps; each needs params.device",
           "minItems": 1,
           "type": "array",
           "items": {
             "type": "object",
             "properties": {
               "tool": {
-                "description": "Tool name",
-                "type": "string"
+                "type": "string",
+                "description": "Tool name"
               },
               "params": {
-                "description": "Tool params; must include device",
                 "type": "object",
                 "propertyNames": {
                   "type": "string"
                 },
-                "additionalProperties": {}
+                "additionalProperties": {},
+                "description": "Tool params; must include device"
               },
               "label": {
                 "description": "Step label",
@@ -795,13 +794,14 @@
               "params"
             ],
             "additionalProperties": {}
-          }
+          },
+          "description": "Serial steps; each needs params.device"
         },
         "deviceCount": {
-          "description": "Devices required at barrier",
           "type": "integer",
           "exclusiveMinimum": 0,
-          "maximum": 9007199254740991
+          "maximum": 9007199254740991,
+          "description": "Devices required at barrier"
         },
         "timeout": {
           "description": "Barrier timeout ms (default 30000)",
@@ -869,8 +869,8 @@
               "type": "object",
               "properties": {
                 "elementId": {
-                  "description": "Container resource ID",
-                  "type": "string"
+                  "type": "string",
+                  "description": "Container resource ID"
                 }
               },
               "required": [
@@ -882,8 +882,8 @@
               "type": "object",
               "properties": {
                 "text": {
-                  "description": "Container text",
-                  "type": "string"
+                  "type": "string",
+                  "description": "Container text"
                 }
               },
               "required": [
@@ -1037,12 +1037,12 @@
           "additionalProperties": false,
           "properties": {
             "elementId": {
-              "description": "Source ID",
-              "type": "string"
+              "type": "string",
+              "description": "Source ID"
             },
             "text": {
-              "description": "Source text",
-              "type": "string"
+              "type": "string",
+              "description": "Source text"
             }
           },
           "oneOf": [
@@ -1064,12 +1064,12 @@
           "additionalProperties": false,
           "properties": {
             "elementId": {
-              "description": "Target ID",
-              "type": "string"
+              "type": "string",
+              "description": "Target ID"
             },
             "text": {
-              "description": "Target text",
-              "type": "string"
+              "type": "string",
+              "description": "Target text"
             }
           },
           "oneOf": [
@@ -1139,12 +1139,12 @@
       "type": "object",
       "properties": {
         "planContent": {
-          "description": "YAML plan content",
-          "type": "string"
+          "type": "string",
+          "description": "YAML plan content"
         },
         "startStep": {
-          "description": "Start step index",
           "default": 0,
+          "description": "Start step index",
           "type": "number"
         },
         "platform": {
@@ -1176,13 +1176,13 @@
           }
         },
         "deviceAllocationTimeoutMs": {
-          "description": "Allocation timeout ms",
           "default": 300000,
+          "description": "Allocation timeout ms",
           "type": "number"
         },
         "abortStrategy": {
-          "description": "Abort strategy",
           "default": "immediate",
+          "description": "Abort strategy",
           "type": "string",
           "enum": [
             "immediate",
@@ -1536,9 +1536,9 @@
           "maximum": 120000
         },
         "avdName": {
-          "description": "Configured Android Virtual Device name",
           "type": "string",
-          "minLength": 1
+          "minLength": 1,
+          "description": "Configured Android Virtual Device name"
         }
       },
       "required": [
@@ -1567,9 +1567,9 @@
           "maximum": 120000
         },
         "udid": {
-          "description": "iOS Simulator UDID",
           "type": "string",
-          "minLength": 1
+          "minLength": 1,
+          "description": "iOS Simulator UDID"
         }
       },
       "required": [
@@ -1820,13 +1820,13 @@
       "type": "object",
       "properties": {
         "scope": {
-          "description": "Preference scope",
           "type": "string",
           "enum": [
             "systemProperty",
             "sharedPreferences",
             "userDefaults"
-          ]
+          ],
+          "description": "Preference scope"
         },
         "appId": {
           "description": "App package or bundle id",
@@ -1837,9 +1837,9 @@
           "type": "string"
         },
         "key": {
-          "description": "Preference key or Android system property name",
           "type": "string",
-          "minLength": 1
+          "minLength": 1,
+          "description": "Preference key or Android system property name"
         },
         "platform": {
           "type": "string",
@@ -1896,7 +1896,7 @@
         },
         "shape": {
           "description": "Optional highlight shape definition",
-          "anyOf": [
+          "oneOf": [
             {
               "type": "object",
               "properties": {
@@ -2461,12 +2461,12 @@
           ]
         },
         "elementId": {
-          "description": "Resource ID, e.g. com.app:id/btn_login",
-          "type": "string"
+          "type": "string",
+          "description": "Resource ID, e.g. com.app:id/btn_login"
         },
         "text": {
-          "description": "Text, content-desc, or placeholder",
-          "type": "string"
+          "type": "string",
+          "description": "Text, content-desc, or placeholder"
         },
         "container": {
           "description": "Scope search to a container",
@@ -2475,8 +2475,8 @@
               "type": "object",
               "properties": {
                 "elementId": {
-                  "description": "Container resource ID",
-                  "type": "string"
+                  "type": "string",
+                  "description": "Container resource ID"
                 }
               },
               "required": [
@@ -2488,8 +2488,8 @@
               "type": "object",
               "properties": {
                 "text": {
-                  "description": "Container text",
-                  "type": "string"
+                  "type": "string",
+                  "description": "Container text"
                 }
               },
               "required": [
@@ -2653,7 +2653,6 @@
       "type": "object",
       "properties": {
         "action": {
-          "description": "IME action",
           "type": "string",
           "enum": [
             "done",
@@ -2662,7 +2661,8 @@
             "send",
             "go",
             "previous"
-          ]
+          ],
+          "description": "IME action"
         },
         "platform": {
           "type": "string",
@@ -2761,8 +2761,8 @@
       "type": "object",
       "properties": {
         "artifactPath": {
-          "description": "App artifact path (.apk, .app, or .ipa)",
-          "type": "string"
+          "type": "string",
+          "description": "App artifact path (.apk, .app, or .ipa)"
         },
         "platform": {
           "type": "string",
@@ -2797,13 +2797,13 @@
       "type": "object",
       "properties": {
         "action": {
-          "description": "Keyboard action",
           "type": "string",
           "enum": [
             "open",
             "close",
             "detect"
-          ]
+          ],
+          "description": "Keyboard action"
         },
         "platform": {
           "type": "string",
@@ -2842,8 +2842,8 @@
           "type": "object",
           "properties": {
             "name": {
-              "description": "Device image name",
-              "type": "string"
+              "type": "string",
+              "description": "Device image name"
             },
             "deviceId": {
               "type": "string"
@@ -2973,12 +2973,12 @@
       "type": "object",
       "properties": {
         "host": {
-          "description": "Host pattern (regex)",
-          "type": "string"
+          "type": "string",
+          "description": "Host pattern (regex)"
         },
         "path": {
-          "description": "Path pattern (regex)",
-          "type": "string"
+          "type": "string",
+          "description": "Path pattern (regex)"
         },
         "method": {
           "description": "HTTP method; default *",
@@ -3048,8 +3048,8 @@
       "type": "object",
       "properties": {
         "targetScreen": {
-          "description": "Target screen name",
-          "type": "string"
+          "type": "string",
+          "description": "Target screen name"
         },
         "platform": {
           "default": "android",
@@ -3491,10 +3491,10 @@
           "type": "object",
           "properties": {
             "quietPeriodMs": {
-              "description": "Quiet-period ms (no hierarchy change) required after waitFor matches",
               "type": "integer",
               "exclusiveMinimum": 0,
-              "maximum": 9007199254740991
+              "maximum": 9007199254740991,
+              "description": "Quiet-period ms (no hierarchy change) required after waitFor matches"
             }
           },
           "required": [
@@ -3519,11 +3519,9 @@
           "type": "boolean"
         },
         "scope": {
-          "description": "Experimental progressive-disclosure scoping of the returned hierarchy (issue #4344)",
           "type": "object",
           "properties": {
             "focus": {
-              "description": "Scope to a subtree: true = foreground app; {resourceId|text} = anchor.",
               "anyOf": [
                 {
                   "type": "boolean"
@@ -3542,7 +3540,8 @@
                   },
                   "additionalProperties": false
                 }
-              ]
+              ],
+              "description": "Scope to a subtree: true = foreground app; {resourceId|text} = anchor."
             },
             "region": {
               "description": "Crop to a normalized 0..1 box; true = inset content rect.",
@@ -3589,7 +3588,8 @@
               "type": "boolean"
             }
           },
-          "additionalProperties": false
+          "additionalProperties": false,
+          "description": "Experimental progressive-disclosure scoping of the returned hierarchy (issue #4344)"
         },
         "sessionUuid": {
           "description": "Session",
@@ -3663,7 +3663,6 @@
           "type": "object",
           "properties": {
             "bounds": {
-              "description": "Element bounds. Default: positional tuple [left, top, right, bottom]; the object {left, top, right, bottom} (+ optional centerX/centerY) is also schema-valid.",
               "anyOf": [
                 {
                   "type": "object",
@@ -3696,7 +3695,6 @@
                   "additionalProperties": false
                 },
                 {
-                  "description": "Compact bounds tuple [left, top, right, bottom], emitted in place of the {left, top, right, bottom} object.",
                   "type": "array",
                   "prefixItems": [
                     {
@@ -3711,9 +3709,11 @@
                     {
                       "type": "number"
                     }
-                  ]
+                  ],
+                  "description": "Compact bounds tuple [left, top, right, bottom], emitted in place of the {left, top, right, bottom} object."
                 }
-              ]
+              ],
+              "description": "Element bounds. Default: positional tuple [left, top, right, bottom]; the object {left, top, right, bottom} (+ optional centerX/centerY) is also schema-valid."
             },
             "occlusionState": {
               "type": "string"
@@ -4140,7 +4140,6 @@
                         "type": "string"
                       },
                       "bounds": {
-                        "description": "Element bounds. Default: positional tuple [left, top, right, bottom]; the object {left, top, right, bottom} (+ optional centerX/centerY) is also schema-valid.",
                         "anyOf": [
                           {
                             "type": "object",
@@ -4173,7 +4172,6 @@
                             "additionalProperties": false
                           },
                           {
-                            "description": "Compact bounds tuple [left, top, right, bottom], emitted in place of the {left, top, right, bottom} object.",
                             "type": "array",
                             "prefixItems": [
                               {
@@ -4188,9 +4186,11 @@
                               {
                                 "type": "number"
                               }
-                            ]
+                            ],
+                            "description": "Compact bounds tuple [left, top, right, bottom], emitted in place of the {left, top, right, bottom} object."
                           }
-                        ]
+                        ],
+                        "description": "Element bounds. Default: positional tuple [left, top, right, bottom]; the object {left, top, right, bottom} (+ optional centerX/centerY) is also schema-valid."
                       }
                     },
                     "required": [
@@ -4337,7 +4337,6 @@
                     "type": "object",
                     "properties": {
                       "bounds": {
-                        "description": "Element bounds. Default: positional tuple [left, top, right, bottom]; the object {left, top, right, bottom} (+ optional centerX/centerY) is also schema-valid.",
                         "anyOf": [
                           {
                             "type": "object",
@@ -4370,7 +4369,6 @@
                             "additionalProperties": false
                           },
                           {
-                            "description": "Compact bounds tuple [left, top, right, bottom], emitted in place of the {left, top, right, bottom} object.",
                             "type": "array",
                             "prefixItems": [
                               {
@@ -4385,9 +4383,11 @@
                               {
                                 "type": "number"
                               }
-                            ]
+                            ],
+                            "description": "Compact bounds tuple [left, top, right, bottom], emitted in place of the {left, top, right, bottom} object."
                           }
-                        ]
+                        ],
+                        "description": "Element bounds. Default: positional tuple [left, top, right, bottom]; the object {left, top, right, bottom} (+ optional centerX/centerY) is also schema-valid."
                       },
                       "hierarchy": {
                         "$ref": "#/$defs/__schema0"
@@ -4409,7 +4409,6 @@
                     "type": "object",
                     "properties": {
                       "bounds": {
-                        "description": "Element bounds. Default: positional tuple [left, top, right, bottom]; the object {left, top, right, bottom} (+ optional centerX/centerY) is also schema-valid.",
                         "anyOf": [
                           {
                             "type": "object",
@@ -4442,7 +4441,6 @@
                             "additionalProperties": false
                           },
                           {
-                            "description": "Compact bounds tuple [left, top, right, bottom], emitted in place of the {left, top, right, bottom} object.",
                             "type": "array",
                             "prefixItems": [
                               {
@@ -4457,9 +4455,11 @@
                               {
                                 "type": "number"
                               }
-                            ]
+                            ],
+                            "description": "Compact bounds tuple [left, top, right, bottom], emitted in place of the {left, top, right, bottom} object."
                           }
-                        ]
+                        ],
+                        "description": "Element bounds. Default: positional tuple [left, top, right, bottom]; the object {left, top, right, bottom} (+ optional centerX/centerY) is also schema-valid."
                       },
                       "reason": {
                         "type": "string"
@@ -4827,7 +4827,6 @@
                 "type": "string"
               },
               "bounds": {
-                "description": "Bounds as the compact [left, top, right, bottom] tuple — always this shape for skeleton entries.",
                 "type": "array",
                 "prefixItems": [
                   {
@@ -4842,7 +4841,8 @@
                   {
                     "type": "number"
                   }
-                ]
+                ],
+                "description": "Bounds as the compact [left, top, right, bottom] tuple — always this shape for skeleton entries."
               },
               "affordances": {
                 "type": "array",
@@ -4986,7 +4986,6 @@
                 "type": "object",
                 "properties": {
                   "bounds": {
-                    "description": "Element bounds. Default: positional tuple [left, top, right, bottom]; the object {left, top, right, bottom} (+ optional centerX/centerY) is also schema-valid.",
                     "anyOf": [
                       {
                         "type": "object",
@@ -5019,7 +5018,6 @@
                         "additionalProperties": false
                       },
                       {
-                        "description": "Compact bounds tuple [left, top, right, bottom], emitted in place of the {left, top, right, bottom} object.",
                         "type": "array",
                         "prefixItems": [
                           {
@@ -5034,9 +5032,11 @@
                           {
                             "type": "number"
                           }
-                        ]
+                        ],
+                        "description": "Compact bounds tuple [left, top, right, bottom], emitted in place of the {left, top, right, bottom} object."
                       }
-                    ]
+                    ],
+                    "description": "Element bounds. Default: positional tuple [left, top, right, bottom]; the object {left, top, right, bottom} (+ optional centerX/centerY) is also schema-valid."
                   }
                 },
                 "additionalProperties": {}
@@ -5066,7 +5066,6 @@
                 "type": "string"
               },
               "bounds": {
-                "description": "Element bounds. Default: positional tuple [left, top, right, bottom]; the object {left, top, right, bottom} (+ optional centerX/centerY) is also schema-valid.",
                 "anyOf": [
                   {
                     "type": "object",
@@ -5099,7 +5098,6 @@
                     "additionalProperties": false
                   },
                   {
-                    "description": "Compact bounds tuple [left, top, right, bottom], emitted in place of the {left, top, right, bottom} object.",
                     "type": "array",
                     "prefixItems": [
                       {
@@ -5114,9 +5112,11 @@
                       {
                         "type": "number"
                       }
-                    ]
+                    ],
+                    "description": "Compact bounds tuple [left, top, right, bottom], emitted in place of the {left, top, right, bottom} object."
                   }
-                ]
+                ],
+                "description": "Element bounds. Default: positional tuple [left, top, right, bottom]; the object {left, top, right, bottom} (+ optional centerX/centerY) is also schema-valid."
               },
               "indexInMatches": {
                 "type": "integer",
@@ -5162,7 +5162,6 @@
           "type": "object",
           "properties": {
             "bounds": {
-              "description": "Element bounds. Default: positional tuple [left, top, right, bottom]; the object {left, top, right, bottom} (+ optional centerX/centerY) is also schema-valid.",
               "anyOf": [
                 {
                   "type": "object",
@@ -5195,7 +5194,6 @@
                   "additionalProperties": false
                 },
                 {
-                  "description": "Compact bounds tuple [left, top, right, bottom], emitted in place of the {left, top, right, bottom} object.",
                   "type": "array",
                   "prefixItems": [
                     {
@@ -5210,9 +5208,11 @@
                     {
                       "type": "number"
                     }
-                  ]
+                  ],
+                  "description": "Compact bounds tuple [left, top, right, bottom], emitted in place of the {left, top, right, bottom} object."
                 }
-              ]
+              ],
+              "description": "Element bounds. Default: positional tuple [left, top, right, bottom]; the object {left, top, right, bottom} (+ optional centerX/centerY) is also schema-valid."
             },
             "text": {
               "type": "string"
@@ -5386,7 +5386,6 @@
           "type": "object",
           "properties": {
             "bounds": {
-              "description": "Element bounds. Default: positional tuple [left, top, right, bottom]; the object {left, top, right, bottom} (+ optional centerX/centerY) is also schema-valid.",
               "anyOf": [
                 {
                   "type": "object",
@@ -5419,7 +5418,6 @@
                   "additionalProperties": false
                 },
                 {
-                  "description": "Compact bounds tuple [left, top, right, bottom], emitted in place of the {left, top, right, bottom} object.",
                   "type": "array",
                   "prefixItems": [
                     {
@@ -5434,9 +5432,11 @@
                     {
                       "type": "number"
                     }
-                  ]
+                  ],
+                  "description": "Compact bounds tuple [left, top, right, bottom], emitted in place of the {left, top, right, bottom} object."
                 }
-              ]
+              ],
+              "description": "Element bounds. Default: positional tuple [left, top, right, bottom]; the object {left, top, right, bottom} (+ optional centerX/centerY) is also schema-valid."
             },
             "text": {
               "type": "string"
@@ -5610,7 +5610,6 @@
           "type": "object",
           "properties": {
             "bounds": {
-              "description": "Element bounds. Default: positional tuple [left, top, right, bottom]; the object {left, top, right, bottom} (+ optional centerX/centerY) is also schema-valid.",
               "anyOf": [
                 {
                   "type": "object",
@@ -5643,7 +5642,6 @@
                   "additionalProperties": false
                 },
                 {
-                  "description": "Compact bounds tuple [left, top, right, bottom], emitted in place of the {left, top, right, bottom} object.",
                   "type": "array",
                   "prefixItems": [
                     {
@@ -5658,9 +5656,11 @@
                     {
                       "type": "number"
                     }
-                  ]
+                  ],
+                  "description": "Compact bounds tuple [left, top, right, bottom], emitted in place of the {left, top, right, bottom} object."
                 }
-              ]
+              ],
+              "description": "Element bounds. Default: positional tuple [left, top, right, bottom]; the object {left, top, right, bottom} (+ optional centerX/centerY) is also schema-valid."
             },
             "text": {
               "type": "string"
@@ -5852,7 +5852,6 @@
           "type": "object",
           "properties": {
             "bounds": {
-              "description": "Element bounds. Default: positional tuple [left, top, right, bottom]; the object {left, top, right, bottom} (+ optional centerX/centerY) is also schema-valid.",
               "anyOf": [
                 {
                   "type": "object",
@@ -5885,7 +5884,6 @@
                   "additionalProperties": false
                 },
                 {
-                  "description": "Compact bounds tuple [left, top, right, bottom], emitted in place of the {left, top, right, bottom} object.",
                   "type": "array",
                   "prefixItems": [
                     {
@@ -5900,9 +5898,11 @@
                     {
                       "type": "number"
                     }
-                  ]
+                  ],
+                  "description": "Compact bounds tuple [left, top, right, bottom], emitted in place of the {left, top, right, bottom} object."
                 }
-              ]
+              ],
+              "description": "Element bounds. Default: positional tuple [left, top, right, bottom]; the object {left, top, right, bottom} (+ optional centerX/centerY) is also schema-valid."
             },
             "text": {
               "type": "string"
@@ -6078,7 +6078,6 @@
             "type": "object",
             "properties": {
               "bounds": {
-                "description": "Element bounds. Default: positional tuple [left, top, right, bottom]; the object {left, top, right, bottom} (+ optional centerX/centerY) is also schema-valid.",
                 "anyOf": [
                   {
                     "type": "object",
@@ -6111,7 +6110,6 @@
                     "additionalProperties": false
                   },
                   {
-                    "description": "Compact bounds tuple [left, top, right, bottom], emitted in place of the {left, top, right, bottom} object.",
                     "type": "array",
                     "prefixItems": [
                       {
@@ -6126,9 +6124,11 @@
                       {
                         "type": "number"
                       }
-                    ]
+                    ],
+                    "description": "Compact bounds tuple [left, top, right, bottom], emitted in place of the {left, top, right, bottom} object."
                   }
-                ]
+                ],
+                "description": "Element bounds. Default: positional tuple [left, top, right, bottom]; the object {left, top, right, bottom} (+ optional centerX/centerY) is also schema-valid."
               },
               "text": {
                 "type": "string"
@@ -6852,7 +6852,6 @@
               "maximum": 9007199254740991
             },
             "regionPx": {
-              "description": "Element bounds. Default: positional tuple [left, top, right, bottom]; the object {left, top, right, bottom} (+ optional centerX/centerY) is also schema-valid.",
               "anyOf": [
                 {
                   "type": "object",
@@ -6885,7 +6884,6 @@
                   "additionalProperties": false
                 },
                 {
-                  "description": "Compact bounds tuple [left, top, right, bottom], emitted in place of the {left, top, right, bottom} object.",
                   "type": "array",
                   "prefixItems": [
                     {
@@ -6900,9 +6898,11 @@
                     {
                       "type": "number"
                     }
-                  ]
+                  ],
+                  "description": "Compact bounds tuple [left, top, right, bottom], emitted in place of the {left, top, right, bottom} object."
                 }
-              ]
+              ],
+              "description": "Element bounds. Default: positional tuple [left, top, right, bottom]; the object {left, top, right, bottom} (+ optional centerX/centerY) is also schema-valid."
             },
             "focus": {
               "type": "object",
@@ -6982,8 +6982,8 @@
       "type": "object",
       "properties": {
         "url": {
-          "description": "URL to open",
-          "type": "string"
+          "type": "string",
+          "description": "URL to open"
         },
         "platform": {
           "type": "string",
@@ -7304,10 +7304,10 @@
           "type": "object",
           "properties": {
             "quietPeriodMs": {
-              "description": "Quiet-period ms (no hierarchy change) required after waitFor matches",
               "type": "integer",
               "exclusiveMinimum": 0,
-              "maximum": 9007199254740991
+              "maximum": 9007199254740991,
+              "description": "Quiet-period ms (no hierarchy change) required after waitFor matches"
             }
           },
           "required": [
@@ -7390,7 +7390,6 @@
       "type": "object",
       "properties": {
         "action": {
-          "description": "call/accept/cancel/busy/hold; hold needs no phoneNumber",
           "type": "string",
           "enum": [
             "call",
@@ -7398,7 +7397,8 @@
             "cancel",
             "busy",
             "hold"
-          ]
+          ],
+          "description": "call/accept/cancel/busy/hold; hold needs no phoneNumber"
         },
         "phoneNumber": {
           "description": "Phone number; required except for hold",
@@ -7437,12 +7437,12 @@
       "type": "object",
       "properties": {
         "direction": {
-          "description": "Pinch direction",
           "type": "string",
           "enum": [
             "in",
             "out"
-          ]
+          ],
+          "description": "Pinch direction"
         },
         "distanceStart": {
           "description": "Initial finger distance (px, default: 400)",
@@ -7473,12 +7473,12 @@
           "additionalProperties": false,
           "properties": {
             "elementId": {
-              "description": "Container resource ID",
-              "type": "string"
+              "type": "string",
+              "description": "Container resource ID"
             },
             "text": {
-              "description": "Container text",
-              "type": "string"
+              "type": "string",
+              "description": "Container text"
             }
           },
           "oneOf": [
@@ -7533,14 +7533,14 @@
       "type": "object",
       "properties": {
         "title": {
-          "description": "Notification title",
           "type": "string",
-          "minLength": 1
+          "minLength": 1,
+          "description": "Notification title"
         },
         "body": {
-          "description": "Notification body",
           "type": "string",
-          "minLength": 1
+          "minLength": 1,
+          "description": "Notification body"
         },
         "imageType": {
           "description": "Notification image type (default: normal)",
@@ -7561,14 +7561,14 @@
             "type": "object",
             "properties": {
               "label": {
-                "description": "Action label",
                 "type": "string",
-                "minLength": 1
+                "minLength": 1,
+                "description": "Action label"
               },
               "actionId": {
-                "description": "Action identifier",
                 "type": "string",
-                "minLength": 1
+                "minLength": 1,
+                "description": "Action identifier"
               }
             },
             "required": [
@@ -7583,9 +7583,9 @@
           "type": "string"
         },
         "appId": {
-          "description": "Android target package name or iOS target bundle ID; Android defaults to the live foreground app when omitted",
           "type": "string",
-          "minLength": 1
+          "minLength": 1,
+          "description": "Android target package name or iOS target bundle ID; Android defaults to the live foreground app when omitted"
         },
         "platform": {
           "type": "string",
@@ -7682,12 +7682,12 @@
       "type": "object",
       "properties": {
         "operationId": {
-          "description": "Caller-generated idempotency key",
           "type": "string",
-          "minLength": 1
+          "minLength": 1,
+          "description": "Caller-generated idempotency key"
         },
         "device": {
-          "anyOf": [
+          "oneOf": [
             {
               "type": "object",
               "properties": {
@@ -7696,22 +7696,22 @@
                   "const": "android"
                 },
                 "name": {
-                  "description": "Exact AVD name",
                   "type": "string",
-                  "minLength": 1
+                  "minLength": 1,
+                  "description": "Exact AVD name"
                 },
                 "spec": {
                   "type": "object",
                   "properties": {
                     "runtime": {
-                      "description": "Installed Android system-image package identifier",
                       "type": "string",
-                      "minLength": 1
+                      "minLength": 1,
+                      "description": "Installed Android system-image package identifier"
                     },
                     "deviceType": {
-                      "description": "Android avdmanager device profile identifier",
                       "type": "string",
-                      "minLength": 1
+                      "minLength": 1,
+                      "description": "Android avdmanager device profile identifier"
                     },
                     "configuration": {
                       "type": "object",
@@ -7747,22 +7747,22 @@
                   "const": "ios"
                 },
                 "name": {
-                  "description": "Exact simulator name",
                   "type": "string",
-                  "minLength": 1
+                  "minLength": 1,
+                  "description": "Exact simulator name"
                 },
                 "spec": {
                   "type": "object",
                   "properties": {
                     "runtime": {
-                      "description": "CoreSimulator runtime identifier",
                       "type": "string",
-                      "minLength": 1
+                      "minLength": 1,
+                      "description": "CoreSimulator runtime identifier"
                     },
                     "deviceType": {
-                      "description": "CoreSimulator device-type identifier",
                       "type": "string",
-                      "minLength": 1
+                      "minLength": 1,
+                      "description": "CoreSimulator device-type identifier"
                     }
                   },
                   "required": [
@@ -7821,7 +7821,6 @@
           "minLength": 1
         },
         "container": {
-          "description": "App container",
           "type": "string",
           "enum": [
             "documents",
@@ -7829,7 +7828,8 @@
             "cache",
             "tmp",
             "externalFiles"
-          ]
+          ],
+          "description": "App container"
         },
         "sourcePath": {
           "description": "Host file path",
@@ -7845,8 +7845,8 @@
           "type": "string"
         },
         "destinationPath": {
-          "description": "Container-relative destination path",
-          "type": "string"
+          "type": "string",
+          "description": "Container-relative destination path"
         },
         "platform": {
           "type": "string",
@@ -7992,16 +7992,16 @@
           "type": "string"
         },
         "name": {
-          "description": "Storage name",
-          "type": "string"
+          "type": "string",
+          "description": "Storage name"
         },
         "fileName": {
           "description": "Deprecated alias for name",
           "type": "string"
         },
         "key": {
-          "description": "Key",
-          "type": "string"
+          "type": "string",
+          "description": "Key"
         },
         "platform": {
           "type": "string",
@@ -8109,12 +8109,12 @@
       "type": "object",
       "properties": {
         "phoneNumber": {
-          "description": "Sender phone number",
-          "type": "string"
+          "type": "string",
+          "description": "Sender phone number"
         },
         "message": {
-          "description": "SMS body; max 1024 chars, no newlines/NUL",
-          "type": "string"
+          "type": "string",
+          "description": "SMS body; max 1024 chars, no newlines/NUL"
         },
         "platform": {
           "type": "string",
@@ -8340,19 +8340,18 @@
           "type": "string"
         },
         "name": {
-          "description": "Storage name",
-          "type": "string"
+          "type": "string",
+          "description": "Storage name"
         },
         "fileName": {
           "description": "Deprecated alias for name",
           "type": "string"
         },
         "key": {
-          "description": "Key",
-          "type": "string"
+          "type": "string",
+          "description": "Key"
         },
         "value": {
-          "description": "Value string; null clears",
           "anyOf": [
             {
               "type": "string"
@@ -8360,10 +8359,10 @@
             {
               "type": "null"
             }
-          ]
+          ],
+          "description": "Value string; null clears"
         },
         "type": {
-          "description": "Value type",
           "type": "string",
           "enum": [
             "STRING",
@@ -8378,7 +8377,8 @@
             "ARRAY",
             "DICTIONARY",
             "UNKNOWN"
-          ]
+          ],
+          "description": "Value type"
         },
         "platform": {
           "type": "string",
@@ -8420,8 +8420,8 @@
           "minLength": 1
         },
         "policyAccess": {
-          "description": "Android: allow DND policy access",
-          "type": "boolean"
+          "type": "boolean",
+          "description": "Android: allow DND policy access"
         },
         "platform": {
           "type": "string",
@@ -8457,13 +8457,13 @@
       "type": "object",
       "properties": {
         "scope": {
-          "description": "Preference scope",
           "type": "string",
           "enum": [
             "systemProperty",
             "sharedPreferences",
             "userDefaults"
-          ]
+          ],
+          "description": "Preference scope"
         },
         "appId": {
           "description": "App package or bundle id",
@@ -8474,12 +8474,11 @@
           "type": "string"
         },
         "key": {
-          "description": "Preference key or Android system property name",
           "type": "string",
-          "minLength": 1
+          "minLength": 1,
+          "description": "Preference key or Android system property name"
         },
         "value": {
-          "description": "Value to write",
           "anyOf": [
             {
               "type": "string"
@@ -8490,17 +8489,18 @@
             {
               "type": "number"
             }
-          ]
+          ],
+          "description": "Value to write"
         },
         "type": {
-          "description": "Value type for typed preference stores",
           "type": "string",
           "enum": [
             "string",
             "bool",
             "int",
             "float"
-          ]
+          ],
+          "description": "Value type for typed preference stores"
         },
         "platform": {
           "type": "string",
@@ -8538,7 +8538,6 @@
       "type": "object",
       "properties": {
         "capability": {
-          "description": "Optional tool capability to enable or disable for this MCP session.",
           "type": "string",
           "enum": [
             "clipboard",
@@ -8556,7 +8555,8 @@
             "app-routing",
             "navigation-modeling",
             "biometric-auth"
-          ]
+          ],
+          "description": "Optional tool capability to enable or disable for this MCP session."
         },
         "enabled": {
           "description": "Whether to enable the capability (default: true).",
@@ -8583,26 +8583,25 @@
       "type": "object",
       "properties": {
         "fields": {
-          "description": "Fields to set",
           "minItems": 1,
           "type": "array",
           "items": {
             "type": "object",
             "properties": {
               "selector": {
-                "description": "Field selector",
                 "type": "object",
                 "properties": {
                   "elementId": {
-                    "description": "Resource ID, e.g. com.app:id/btn_login",
-                    "type": "string"
+                    "type": "string",
+                    "description": "Resource ID, e.g. com.app:id/btn_login"
                   },
                   "text": {
-                    "description": "Text, content-desc, or placeholder",
-                    "type": "string"
+                    "type": "string",
+                    "description": "Text, content-desc, or placeholder"
                   }
                 },
-                "additionalProperties": false
+                "additionalProperties": false,
+                "description": "Field selector"
               },
               "value": {
                 "description": "Text/dropdown value",
@@ -8617,7 +8616,8 @@
               "selector"
             ],
             "additionalProperties": false
-          }
+          },
+          "description": "Fields to set"
         },
         "scrollDirection": {
           "description": "Initial search scroll direction",
@@ -8656,11 +8656,10 @@
       "type": "object",
       "properties": {
         "success": {
-          "description": "All fields set",
-          "type": "boolean"
+          "type": "boolean",
+          "description": "All fields set"
         },
         "fields": {
-          "description": "Field results",
           "type": "array",
           "items": {
             "type": "object",
@@ -8709,11 +8708,12 @@
               "attempts"
             ],
             "additionalProperties": false
-          }
+          },
+          "description": "Field results"
         },
         "totalAttempts": {
-          "description": "Total attempts",
-          "type": "number"
+          "type": "number",
+          "description": "Total attempts"
         },
         "error": {
           "description": "Error message",
@@ -8779,12 +8779,12 @@
           "type": "string"
         },
         "databasePath": {
-          "description": "Database path",
-          "type": "string"
+          "type": "string",
+          "description": "Database path"
         },
         "query": {
-          "description": "SQL query",
-          "type": "string"
+          "type": "string",
+          "description": "SQL query"
         },
         "platform": {
           "type": "string",
@@ -8867,12 +8867,12 @@
           "additionalProperties": false,
           "properties": {
             "elementId": {
-              "description": "Container resource ID",
-              "type": "string"
+              "type": "string",
+              "description": "Container resource ID"
             },
             "text": {
-              "description": "Container text",
-              "type": "string"
+              "type": "string",
+              "description": "Container text"
             }
           },
           "oneOf": [
@@ -8894,14 +8894,14 @@
           "type": "boolean"
         },
         "direction": {
-          "description": "Swipe/scroll direction",
           "type": "string",
           "enum": [
             "up",
             "down",
             "left",
             "right"
-          ]
+          ],
+          "description": "Swipe/scroll direction"
         },
         "gestureType": {
           "description": "Finger direction or content scroll direction; default: scrollTowardsDirection",
@@ -8916,12 +8916,12 @@
           "additionalProperties": false,
           "properties": {
             "elementId": {
-              "description": "ID of the element to look for",
-              "type": "string"
+              "type": "string",
+              "description": "ID of the element to look for"
             },
             "text": {
-              "description": "Text to look for",
-              "type": "string"
+              "type": "string",
+              "description": "Text to look for"
             }
           },
           "oneOf": [
@@ -8997,7 +8997,6 @@
       "type": "object",
       "properties": {
         "action": {
-          "description": "open/close/find/tap/dismiss/clearAll notification",
           "type": "string",
           "enum": [
             "open",
@@ -9006,7 +9005,8 @@
             "tap",
             "dismiss",
             "clearAll"
-          ]
+          ],
+          "description": "open/close/find/tap/dismiss/clearAll notification"
         },
         "notification": {
           "description": "Notification criteria to match",
@@ -9073,12 +9073,12 @@
           "additionalProperties": false,
           "properties": {
             "elementId": {
-              "description": "Container resource ID",
-              "type": "string"
+              "type": "string",
+              "description": "Container resource ID"
             },
             "text": {
-              "description": "Container text",
-              "type": "string"
+              "type": "string",
+              "description": "Container text"
             }
           },
           "oneOf": [
@@ -9108,8 +9108,8 @@
           "type": "boolean"
         },
         "action": {
-          "description": "Action type (default: tap)",
           "default": "tap",
+          "description": "Action type (default: tap)",
           "type": "string",
           "enum": [
             "tap",
@@ -9172,28 +9172,28 @@
           "additionalProperties": false,
           "properties": {
             "elementId": {
-              "description": "Resource ID, e.g. com.app:id/btn_login",
               "type": "string",
-              "minLength": 1
+              "minLength": 1,
+              "description": "Resource ID, e.g. com.app:id/btn_login"
             },
             "testTag": {
-              "description": "Android accessibility test tag",
               "type": "string",
-              "minLength": 1
+              "minLength": 1,
+              "description": "Android accessibility test tag"
             },
             "text": {
-              "description": "Text, content-desc, or placeholder",
               "type": "string",
-              "minLength": 1
+              "minLength": 1,
+              "description": "Text, content-desc, or placeholder"
             },
             "textAny": {
-              "description": "Ordered text variants; first visible match wins",
               "minItems": 1,
               "type": "array",
               "items": {
                 "type": "string",
                 "minLength": 1
-              }
+              },
+              "description": "Ordered text variants; first visible match wins"
             }
           },
           "oneOf": [
@@ -9229,12 +9229,12 @@
           "additionalProperties": false,
           "properties": {
             "elementId": {
-              "description": "Container resource ID",
-              "type": "string"
+              "type": "string",
+              "description": "Container resource ID"
             },
             "text": {
-              "description": "Container text",
-              "type": "string"
+              "type": "string",
+              "description": "Container text"
             }
           },
           "oneOf": [
@@ -9252,8 +9252,8 @@
           "description": "Scope search to a container"
         },
         "action": {
-          "description": "Action type (default: tap)",
           "default": "tap",
+          "description": "Action type (default: tap)",
           "type": "string",
           "enum": [
             "tap",
@@ -9348,7 +9348,6 @@
           "type": "object",
           "properties": {
             "bounds": {
-              "description": "Element bounds. Default: positional tuple [left, top, right, bottom]; the object {left, top, right, bottom} (+ optional centerX/centerY) is also schema-valid.",
               "anyOf": [
                 {
                   "type": "object",
@@ -9381,7 +9380,6 @@
                   "additionalProperties": false
                 },
                 {
-                  "description": "Compact bounds tuple [left, top, right, bottom], emitted in place of the {left, top, right, bottom} object.",
                   "type": "array",
                   "prefixItems": [
                     {
@@ -9396,9 +9394,11 @@
                     {
                       "type": "number"
                     }
-                  ]
+                  ],
+                  "description": "Compact bounds tuple [left, top, right, bottom], emitted in place of the {left, top, right, bottom} object."
                 }
-              ]
+              ],
+              "description": "Element bounds. Default: positional tuple [left, top, right, bottom]; the object {left, top, right, bottom} (+ optional centerX/centerY) is also schema-valid."
             },
             "text": {
               "type": "string"
@@ -9588,7 +9588,6 @@
                         "type": "string"
                       },
                       "bounds": {
-                        "description": "Element bounds. Default: positional tuple [left, top, right, bottom]; the object {left, top, right, bottom} (+ optional centerX/centerY) is also schema-valid.",
                         "anyOf": [
                           {
                             "type": "object",
@@ -9621,7 +9620,6 @@
                             "additionalProperties": false
                           },
                           {
-                            "description": "Compact bounds tuple [left, top, right, bottom], emitted in place of the {left, top, right, bottom} object.",
                             "type": "array",
                             "prefixItems": [
                               {
@@ -9636,9 +9634,11 @@
                               {
                                 "type": "number"
                               }
-                            ]
+                            ],
+                            "description": "Compact bounds tuple [left, top, right, bottom], emitted in place of the {left, top, right, bottom} object."
                           }
-                        ]
+                        ],
+                        "description": "Element bounds. Default: positional tuple [left, top, right, bottom]; the object {left, top, right, bottom} (+ optional centerX/centerY) is also schema-valid."
                       },
                       "indexInMatches": {
                         "type": "integer",
@@ -9684,7 +9684,6 @@
                   "type": "object",
                   "properties": {
                     "bounds": {
-                      "description": "Element bounds. Default: positional tuple [left, top, right, bottom]; the object {left, top, right, bottom} (+ optional centerX/centerY) is also schema-valid.",
                       "anyOf": [
                         {
                           "type": "object",
@@ -9717,7 +9716,6 @@
                           "additionalProperties": false
                         },
                         {
-                          "description": "Compact bounds tuple [left, top, right, bottom], emitted in place of the {left, top, right, bottom} object.",
                           "type": "array",
                           "prefixItems": [
                             {
@@ -9732,9 +9730,11 @@
                             {
                               "type": "number"
                             }
-                          ]
+                          ],
+                          "description": "Compact bounds tuple [left, top, right, bottom], emitted in place of the {left, top, right, bottom} object."
                         }
-                      ]
+                      ],
+                      "description": "Element bounds. Default: positional tuple [left, top, right, bottom]; the object {left, top, right, bottom} (+ optional centerX/centerY) is also schema-valid."
                     },
                     "text": {
                       "type": "string"
@@ -9908,7 +9908,6 @@
                   "type": "object",
                   "properties": {
                     "bounds": {
-                      "description": "Element bounds. Default: positional tuple [left, top, right, bottom]; the object {left, top, right, bottom} (+ optional centerX/centerY) is also schema-valid.",
                       "anyOf": [
                         {
                           "type": "object",
@@ -9941,7 +9940,6 @@
                           "additionalProperties": false
                         },
                         {
-                          "description": "Compact bounds tuple [left, top, right, bottom], emitted in place of the {left, top, right, bottom} object.",
                           "type": "array",
                           "prefixItems": [
                             {
@@ -9956,9 +9954,11 @@
                             {
                               "type": "number"
                             }
-                          ]
+                          ],
+                          "description": "Compact bounds tuple [left, top, right, bottom], emitted in place of the {left, top, right, bottom} object."
                         }
-                      ]
+                      ],
+                      "description": "Element bounds. Default: positional tuple [left, top, right, bottom]; the object {left, top, right, bottom} (+ optional centerX/centerY) is also schema-valid."
                     },
                     "text": {
                       "type": "string"
@@ -10506,7 +10506,6 @@
               "type": "string"
             },
             "bounds": {
-              "description": "Element bounds. Default: positional tuple [left, top, right, bottom]; the object {left, top, right, bottom} (+ optional centerX/centerY) is also schema-valid.",
               "anyOf": [
                 {
                   "type": "object",
@@ -10539,7 +10538,6 @@
                   "additionalProperties": false
                 },
                 {
-                  "description": "Compact bounds tuple [left, top, right, bottom], emitted in place of the {left, top, right, bottom} object.",
                   "type": "array",
                   "prefixItems": [
                     {
@@ -10554,9 +10552,11 @@
                     {
                       "type": "number"
                     }
-                  ]
+                  ],
+                  "description": "Compact bounds tuple [left, top, right, bottom], emitted in place of the {left, top, right, bottom} object."
                 }
-              ]
+              ],
+              "description": "Element bounds. Default: positional tuple [left, top, right, bottom]; the object {left, top, right, bottom} (+ optional centerX/centerY) is also schema-valid."
             },
             "indexInMatches": {
               "type": "integer",
@@ -10612,7 +10612,6 @@
                 "type": "string"
               },
               "bounds": {
-                "description": "Element bounds. Default: positional tuple [left, top, right, bottom]; the object {left, top, right, bottom} (+ optional centerX/centerY) is also schema-valid.",
                 "anyOf": [
                   {
                     "type": "object",
@@ -10645,7 +10644,6 @@
                     "additionalProperties": false
                   },
                   {
-                    "description": "Compact bounds tuple [left, top, right, bottom], emitted in place of the {left, top, right, bottom} object.",
                     "type": "array",
                     "prefixItems": [
                       {
@@ -10660,9 +10658,11 @@
                       {
                         "type": "number"
                       }
-                    ]
+                    ],
+                    "description": "Compact bounds tuple [left, top, right, bottom], emitted in place of the {left, top, right, bottom} object."
                   }
-                ]
+                ],
+                "description": "Element bounds. Default: positional tuple [left, top, right, bottom]; the object {left, top, right, bottom} (+ optional centerX/centerY) is also schema-valid."
               },
               "indexInMatches": {
                 "type": "integer",
@@ -10746,17 +10746,15 @@
           "type": "object",
           "properties": {
             "reachable": {
-              "description": "Whether swipe cursor navigation reached the target",
-              "type": "boolean"
+              "type": "boolean",
+              "description": "Whether swipe cursor navigation reached the target"
             },
             "traversalOrder": {
-              "description": "Focused nodes in cursor traversal order",
               "type": "array",
               "items": {
                 "type": "object",
                 "properties": {
                   "bounds": {
-                    "description": "Element bounds. Default: positional tuple [left, top, right, bottom]; the object {left, top, right, bottom} (+ optional centerX/centerY) is also schema-valid.",
                     "anyOf": [
                       {
                         "type": "object",
@@ -10789,7 +10787,6 @@
                         "additionalProperties": false
                       },
                       {
-                        "description": "Compact bounds tuple [left, top, right, bottom], emitted in place of the {left, top, right, bottom} object.",
                         "type": "array",
                         "prefixItems": [
                           {
@@ -10804,9 +10801,11 @@
                           {
                             "type": "number"
                           }
-                        ]
+                        ],
+                        "description": "Compact bounds tuple [left, top, right, bottom], emitted in place of the {left, top, right, bottom} object."
                       }
-                    ]
+                    ],
+                    "description": "Element bounds. Default: positional tuple [left, top, right, bottom]; the object {left, top, right, bottom} (+ optional centerX/centerY) is also schema-valid."
                   },
                   "text": {
                     "type": "string"
@@ -10975,11 +10974,12 @@
                   "bounds"
                 ],
                 "additionalProperties": {}
-              }
+              },
+              "description": "Focused nodes in cursor traversal order"
             },
             "focusTrapDetected": {
-              "description": "Whether cursor navigation got stuck or failed to converge",
-              "type": "boolean"
+              "type": "boolean",
+              "description": "Whether cursor navigation got stuck or failed to converge"
             }
           },
           "required": [
@@ -11172,8 +11172,7 @@
                 "type": "string"
               },
               "shape": {
-                "description": "Highlight shape",
-                "anyOf": [
+                "oneOf": [
                   {
                     "type": "object",
                     "properties": {
@@ -11735,7 +11734,8 @@
                     ],
                     "additionalProperties": false
                   }
-                ]
+                ],
+                "description": "Highlight shape"
               },
               "timing": {
                 "description": "Highlight timing",

--- a/schemas/tool-definitions.json
+++ b/schemas/tool-definitions.json
@@ -123,6 +123,7 @@
           "type": "object",
           "properties": {
             "bounds": {
+              "description": "Element bounds. Default: positional tuple [left, top, right, bottom]; the object {left, top, right, bottom} (+ optional centerX/centerY) is also schema-valid.",
               "anyOf": [
                 {
                   "type": "object",
@@ -155,6 +156,7 @@
                   "additionalProperties": false
                 },
                 {
+                  "description": "Compact bounds tuple [left, top, right, bottom], emitted in place of the {left, top, right, bottom} object.",
                   "type": "array",
                   "prefixItems": [
                     {
@@ -169,11 +171,9 @@
                     {
                       "type": "number"
                     }
-                  ],
-                  "description": "Compact bounds tuple [left, top, right, bottom], emitted in place of the {left, top, right, bottom} object."
+                  ]
                 }
-              ],
-              "description": "Element bounds. Default: positional tuple [left, top, right, bottom]; the object {left, top, right, bottom} (+ optional centerX/centerY) is also schema-valid."
+              ]
             },
             "text": {
               "type": "string"
@@ -361,14 +361,14 @@
       "type": "object",
       "properties": {
         "lock": {
-          "type": "string",
-          "description": "Shared barrier name; all devices using the same name synchronize together"
+          "description": "Shared barrier name; all devices using the same name synchronize together",
+          "type": "string"
         },
         "deviceCount": {
+          "description": "Number of devices that must arrive before the barrier lifts",
           "type": "integer",
           "exclusiveMinimum": 0,
-          "maximum": 9007199254740991,
-          "description": "Number of devices that must arrive before the barrier lifts"
+          "maximum": 9007199254740991
         },
         "timeout": {
           "description": "Barrier timeout ms (default 30000)",
@@ -396,14 +396,14 @@
       "type": "object",
       "properties": {
         "action": {
+          "description": "match/fail/cancel/error; cancel/error require Android SDK hook",
           "type": "string",
           "enum": [
             "match",
             "fail",
             "cancel",
             "error"
-          ],
-          "description": "match/fail/cancel/error; cancel/error require Android SDK hook"
+          ]
         },
         "modality": {
           "description": "Modality: any default, fingerprint, or face",
@@ -595,8 +595,8 @@
           "type": "string"
         },
         "name": {
-          "type": "string",
-          "description": "Storage name"
+          "description": "Storage name",
+          "type": "string"
         },
         "fileName": {
           "description": "Deprecated alias for name",
@@ -700,8 +700,8 @@
       "type": "object",
       "properties": {
         "action": {
-          "type": "string",
           "description": "Clipboard action",
+          "type": "string",
           "enum": [
             "copy",
             "paste",
@@ -710,9 +710,9 @@
           ]
         },
         "text": {
+          "description": "Text to copy (required for 'copy' action)",
           "type": "string",
-          "minLength": 1,
-          "description": "Text to copy (required for 'copy' action)"
+          "minLength": 1
         },
         "platform": {
           "type": "string",
@@ -763,26 +763,27 @@
       "type": "object",
       "properties": {
         "lock": {
-          "type": "string",
-          "description": "Shared barrier lock name"
+          "description": "Shared barrier lock name",
+          "type": "string"
         },
         "steps": {
+          "description": "Serial steps; each needs params.device",
           "minItems": 1,
           "type": "array",
           "items": {
             "type": "object",
             "properties": {
               "tool": {
-                "type": "string",
-                "description": "Tool name"
+                "description": "Tool name",
+                "type": "string"
               },
               "params": {
+                "description": "Tool params; must include device",
                 "type": "object",
                 "propertyNames": {
                   "type": "string"
                 },
-                "additionalProperties": {},
-                "description": "Tool params; must include device"
+                "additionalProperties": {}
               },
               "label": {
                 "description": "Step label",
@@ -794,14 +795,13 @@
               "params"
             ],
             "additionalProperties": {}
-          },
-          "description": "Serial steps; each needs params.device"
+          }
         },
         "deviceCount": {
+          "description": "Devices required at barrier",
           "type": "integer",
           "exclusiveMinimum": 0,
-          "maximum": 9007199254740991,
-          "description": "Devices required at barrier"
+          "maximum": 9007199254740991
         },
         "timeout": {
           "description": "Barrier timeout ms (default 30000)",
@@ -869,8 +869,8 @@
               "type": "object",
               "properties": {
                 "elementId": {
-                  "type": "string",
-                  "description": "Container resource ID"
+                  "description": "Container resource ID",
+                  "type": "string"
                 }
               },
               "required": [
@@ -882,8 +882,8 @@
               "type": "object",
               "properties": {
                 "text": {
-                  "type": "string",
-                  "description": "Container text"
+                  "description": "Container text",
+                  "type": "string"
                 }
               },
               "required": [
@@ -1037,12 +1037,12 @@
           "additionalProperties": false,
           "properties": {
             "elementId": {
-              "type": "string",
-              "description": "Source ID"
+              "description": "Source ID",
+              "type": "string"
             },
             "text": {
-              "type": "string",
-              "description": "Source text"
+              "description": "Source text",
+              "type": "string"
             }
           },
           "oneOf": [
@@ -1064,12 +1064,12 @@
           "additionalProperties": false,
           "properties": {
             "elementId": {
-              "type": "string",
-              "description": "Target ID"
+              "description": "Target ID",
+              "type": "string"
             },
             "text": {
-              "type": "string",
-              "description": "Target text"
+              "description": "Target text",
+              "type": "string"
             }
           },
           "oneOf": [
@@ -1139,12 +1139,12 @@
       "type": "object",
       "properties": {
         "planContent": {
-          "type": "string",
-          "description": "YAML plan content"
+          "description": "YAML plan content",
+          "type": "string"
         },
         "startStep": {
-          "default": 0,
           "description": "Start step index",
+          "default": 0,
           "type": "number"
         },
         "platform": {
@@ -1176,13 +1176,13 @@
           }
         },
         "deviceAllocationTimeoutMs": {
-          "default": 300000,
           "description": "Allocation timeout ms",
+          "default": 300000,
           "type": "number"
         },
         "abortStrategy": {
-          "default": "immediate",
           "description": "Abort strategy",
+          "default": "immediate",
           "type": "string",
           "enum": [
             "immediate",
@@ -1536,9 +1536,9 @@
           "maximum": 120000
         },
         "avdName": {
+          "description": "Configured Android Virtual Device name",
           "type": "string",
-          "minLength": 1,
-          "description": "Configured Android Virtual Device name"
+          "minLength": 1
         }
       },
       "required": [
@@ -1567,9 +1567,9 @@
           "maximum": 120000
         },
         "udid": {
+          "description": "iOS Simulator UDID",
           "type": "string",
-          "minLength": 1,
-          "description": "iOS Simulator UDID"
+          "minLength": 1
         }
       },
       "required": [
@@ -1820,13 +1820,13 @@
       "type": "object",
       "properties": {
         "scope": {
+          "description": "Preference scope",
           "type": "string",
           "enum": [
             "systemProperty",
             "sharedPreferences",
             "userDefaults"
-          ],
-          "description": "Preference scope"
+          ]
         },
         "appId": {
           "description": "App package or bundle id",
@@ -1837,9 +1837,9 @@
           "type": "string"
         },
         "key": {
+          "description": "Preference key or Android system property name",
           "type": "string",
-          "minLength": 1,
-          "description": "Preference key or Android system property name"
+          "minLength": 1
         },
         "platform": {
           "type": "string",
@@ -1896,7 +1896,7 @@
         },
         "shape": {
           "description": "Optional highlight shape definition",
-          "oneOf": [
+          "anyOf": [
             {
               "type": "object",
               "properties": {
@@ -2461,12 +2461,12 @@
           ]
         },
         "elementId": {
-          "type": "string",
-          "description": "Resource ID, e.g. com.app:id/btn_login"
+          "description": "Resource ID, e.g. com.app:id/btn_login",
+          "type": "string"
         },
         "text": {
-          "type": "string",
-          "description": "Text, content-desc, or placeholder"
+          "description": "Text, content-desc, or placeholder",
+          "type": "string"
         },
         "container": {
           "description": "Scope search to a container",
@@ -2475,8 +2475,8 @@
               "type": "object",
               "properties": {
                 "elementId": {
-                  "type": "string",
-                  "description": "Container resource ID"
+                  "description": "Container resource ID",
+                  "type": "string"
                 }
               },
               "required": [
@@ -2488,8 +2488,8 @@
               "type": "object",
               "properties": {
                 "text": {
-                  "type": "string",
-                  "description": "Container text"
+                  "description": "Container text",
+                  "type": "string"
                 }
               },
               "required": [
@@ -2653,6 +2653,7 @@
       "type": "object",
       "properties": {
         "action": {
+          "description": "IME action",
           "type": "string",
           "enum": [
             "done",
@@ -2661,8 +2662,7 @@
             "send",
             "go",
             "previous"
-          ],
-          "description": "IME action"
+          ]
         },
         "platform": {
           "type": "string",
@@ -2761,8 +2761,8 @@
       "type": "object",
       "properties": {
         "artifactPath": {
-          "type": "string",
-          "description": "App artifact path (.apk, .app, or .ipa)"
+          "description": "App artifact path (.apk, .app, or .ipa)",
+          "type": "string"
         },
         "platform": {
           "type": "string",
@@ -2797,13 +2797,13 @@
       "type": "object",
       "properties": {
         "action": {
+          "description": "Keyboard action",
           "type": "string",
           "enum": [
             "open",
             "close",
             "detect"
-          ],
-          "description": "Keyboard action"
+          ]
         },
         "platform": {
           "type": "string",
@@ -2842,8 +2842,8 @@
           "type": "object",
           "properties": {
             "name": {
-              "type": "string",
-              "description": "Device image name"
+              "description": "Device image name",
+              "type": "string"
             },
             "deviceId": {
               "type": "string"
@@ -2973,12 +2973,12 @@
       "type": "object",
       "properties": {
         "host": {
-          "type": "string",
-          "description": "Host pattern (regex)"
+          "description": "Host pattern (regex)",
+          "type": "string"
         },
         "path": {
-          "type": "string",
-          "description": "Path pattern (regex)"
+          "description": "Path pattern (regex)",
+          "type": "string"
         },
         "method": {
           "description": "HTTP method; default *",
@@ -3048,8 +3048,8 @@
       "type": "object",
       "properties": {
         "targetScreen": {
-          "type": "string",
-          "description": "Target screen name"
+          "description": "Target screen name",
+          "type": "string"
         },
         "platform": {
           "default": "android",
@@ -3491,10 +3491,10 @@
           "type": "object",
           "properties": {
             "quietPeriodMs": {
+              "description": "Quiet-period ms (no hierarchy change) required after waitFor matches",
               "type": "integer",
               "exclusiveMinimum": 0,
-              "maximum": 9007199254740991,
-              "description": "Quiet-period ms (no hierarchy change) required after waitFor matches"
+              "maximum": 9007199254740991
             }
           },
           "required": [
@@ -3519,9 +3519,11 @@
           "type": "boolean"
         },
         "scope": {
+          "description": "Experimental progressive-disclosure scoping of the returned hierarchy (issue #4344)",
           "type": "object",
           "properties": {
             "focus": {
+              "description": "Scope to a subtree: true = foreground app; {resourceId|text} = anchor.",
               "anyOf": [
                 {
                   "type": "boolean"
@@ -3540,8 +3542,7 @@
                   },
                   "additionalProperties": false
                 }
-              ],
-              "description": "Scope to a subtree: true = foreground app; {resourceId|text} = anchor."
+              ]
             },
             "region": {
               "description": "Crop to a normalized 0..1 box; true = inset content rect.",
@@ -3588,8 +3589,7 @@
               "type": "boolean"
             }
           },
-          "additionalProperties": false,
-          "description": "Experimental progressive-disclosure scoping of the returned hierarchy (issue #4344)"
+          "additionalProperties": false
         },
         "sessionUuid": {
           "description": "Session",
@@ -3663,6 +3663,7 @@
           "type": "object",
           "properties": {
             "bounds": {
+              "description": "Element bounds. Default: positional tuple [left, top, right, bottom]; the object {left, top, right, bottom} (+ optional centerX/centerY) is also schema-valid.",
               "anyOf": [
                 {
                   "type": "object",
@@ -3695,6 +3696,7 @@
                   "additionalProperties": false
                 },
                 {
+                  "description": "Compact bounds tuple [left, top, right, bottom], emitted in place of the {left, top, right, bottom} object.",
                   "type": "array",
                   "prefixItems": [
                     {
@@ -3709,11 +3711,9 @@
                     {
                       "type": "number"
                     }
-                  ],
-                  "description": "Compact bounds tuple [left, top, right, bottom], emitted in place of the {left, top, right, bottom} object."
+                  ]
                 }
-              ],
-              "description": "Element bounds. Default: positional tuple [left, top, right, bottom]; the object {left, top, right, bottom} (+ optional centerX/centerY) is also schema-valid."
+              ]
             },
             "occlusionState": {
               "type": "string"
@@ -4140,6 +4140,7 @@
                         "type": "string"
                       },
                       "bounds": {
+                        "description": "Element bounds. Default: positional tuple [left, top, right, bottom]; the object {left, top, right, bottom} (+ optional centerX/centerY) is also schema-valid.",
                         "anyOf": [
                           {
                             "type": "object",
@@ -4172,6 +4173,7 @@
                             "additionalProperties": false
                           },
                           {
+                            "description": "Compact bounds tuple [left, top, right, bottom], emitted in place of the {left, top, right, bottom} object.",
                             "type": "array",
                             "prefixItems": [
                               {
@@ -4186,11 +4188,9 @@
                               {
                                 "type": "number"
                               }
-                            ],
-                            "description": "Compact bounds tuple [left, top, right, bottom], emitted in place of the {left, top, right, bottom} object."
+                            ]
                           }
-                        ],
-                        "description": "Element bounds. Default: positional tuple [left, top, right, bottom]; the object {left, top, right, bottom} (+ optional centerX/centerY) is also schema-valid."
+                        ]
                       }
                     },
                     "required": [
@@ -4337,6 +4337,7 @@
                     "type": "object",
                     "properties": {
                       "bounds": {
+                        "description": "Element bounds. Default: positional tuple [left, top, right, bottom]; the object {left, top, right, bottom} (+ optional centerX/centerY) is also schema-valid.",
                         "anyOf": [
                           {
                             "type": "object",
@@ -4369,6 +4370,7 @@
                             "additionalProperties": false
                           },
                           {
+                            "description": "Compact bounds tuple [left, top, right, bottom], emitted in place of the {left, top, right, bottom} object.",
                             "type": "array",
                             "prefixItems": [
                               {
@@ -4383,11 +4385,9 @@
                               {
                                 "type": "number"
                               }
-                            ],
-                            "description": "Compact bounds tuple [left, top, right, bottom], emitted in place of the {left, top, right, bottom} object."
+                            ]
                           }
-                        ],
-                        "description": "Element bounds. Default: positional tuple [left, top, right, bottom]; the object {left, top, right, bottom} (+ optional centerX/centerY) is also schema-valid."
+                        ]
                       },
                       "hierarchy": {
                         "$ref": "#/$defs/__schema0"
@@ -4409,6 +4409,7 @@
                     "type": "object",
                     "properties": {
                       "bounds": {
+                        "description": "Element bounds. Default: positional tuple [left, top, right, bottom]; the object {left, top, right, bottom} (+ optional centerX/centerY) is also schema-valid.",
                         "anyOf": [
                           {
                             "type": "object",
@@ -4441,6 +4442,7 @@
                             "additionalProperties": false
                           },
                           {
+                            "description": "Compact bounds tuple [left, top, right, bottom], emitted in place of the {left, top, right, bottom} object.",
                             "type": "array",
                             "prefixItems": [
                               {
@@ -4455,11 +4457,9 @@
                               {
                                 "type": "number"
                               }
-                            ],
-                            "description": "Compact bounds tuple [left, top, right, bottom], emitted in place of the {left, top, right, bottom} object."
+                            ]
                           }
-                        ],
-                        "description": "Element bounds. Default: positional tuple [left, top, right, bottom]; the object {left, top, right, bottom} (+ optional centerX/centerY) is also schema-valid."
+                        ]
                       },
                       "reason": {
                         "type": "string"
@@ -4827,6 +4827,7 @@
                 "type": "string"
               },
               "bounds": {
+                "description": "Bounds as the compact [left, top, right, bottom] tuple — always this shape for skeleton entries.",
                 "type": "array",
                 "prefixItems": [
                   {
@@ -4841,8 +4842,7 @@
                   {
                     "type": "number"
                   }
-                ],
-                "description": "Bounds as the compact [left, top, right, bottom] tuple — always this shape for skeleton entries."
+                ]
               },
               "affordances": {
                 "type": "array",
@@ -4986,6 +4986,7 @@
                 "type": "object",
                 "properties": {
                   "bounds": {
+                    "description": "Element bounds. Default: positional tuple [left, top, right, bottom]; the object {left, top, right, bottom} (+ optional centerX/centerY) is also schema-valid.",
                     "anyOf": [
                       {
                         "type": "object",
@@ -5018,6 +5019,7 @@
                         "additionalProperties": false
                       },
                       {
+                        "description": "Compact bounds tuple [left, top, right, bottom], emitted in place of the {left, top, right, bottom} object.",
                         "type": "array",
                         "prefixItems": [
                           {
@@ -5032,11 +5034,9 @@
                           {
                             "type": "number"
                           }
-                        ],
-                        "description": "Compact bounds tuple [left, top, right, bottom], emitted in place of the {left, top, right, bottom} object."
+                        ]
                       }
-                    ],
-                    "description": "Element bounds. Default: positional tuple [left, top, right, bottom]; the object {left, top, right, bottom} (+ optional centerX/centerY) is also schema-valid."
+                    ]
                   }
                 },
                 "additionalProperties": {}
@@ -5066,6 +5066,7 @@
                 "type": "string"
               },
               "bounds": {
+                "description": "Element bounds. Default: positional tuple [left, top, right, bottom]; the object {left, top, right, bottom} (+ optional centerX/centerY) is also schema-valid.",
                 "anyOf": [
                   {
                     "type": "object",
@@ -5098,6 +5099,7 @@
                     "additionalProperties": false
                   },
                   {
+                    "description": "Compact bounds tuple [left, top, right, bottom], emitted in place of the {left, top, right, bottom} object.",
                     "type": "array",
                     "prefixItems": [
                       {
@@ -5112,11 +5114,9 @@
                       {
                         "type": "number"
                       }
-                    ],
-                    "description": "Compact bounds tuple [left, top, right, bottom], emitted in place of the {left, top, right, bottom} object."
+                    ]
                   }
-                ],
-                "description": "Element bounds. Default: positional tuple [left, top, right, bottom]; the object {left, top, right, bottom} (+ optional centerX/centerY) is also schema-valid."
+                ]
               },
               "indexInMatches": {
                 "type": "integer",
@@ -5162,6 +5162,7 @@
           "type": "object",
           "properties": {
             "bounds": {
+              "description": "Element bounds. Default: positional tuple [left, top, right, bottom]; the object {left, top, right, bottom} (+ optional centerX/centerY) is also schema-valid.",
               "anyOf": [
                 {
                   "type": "object",
@@ -5194,6 +5195,7 @@
                   "additionalProperties": false
                 },
                 {
+                  "description": "Compact bounds tuple [left, top, right, bottom], emitted in place of the {left, top, right, bottom} object.",
                   "type": "array",
                   "prefixItems": [
                     {
@@ -5208,11 +5210,9 @@
                     {
                       "type": "number"
                     }
-                  ],
-                  "description": "Compact bounds tuple [left, top, right, bottom], emitted in place of the {left, top, right, bottom} object."
+                  ]
                 }
-              ],
-              "description": "Element bounds. Default: positional tuple [left, top, right, bottom]; the object {left, top, right, bottom} (+ optional centerX/centerY) is also schema-valid."
+              ]
             },
             "text": {
               "type": "string"
@@ -5386,6 +5386,7 @@
           "type": "object",
           "properties": {
             "bounds": {
+              "description": "Element bounds. Default: positional tuple [left, top, right, bottom]; the object {left, top, right, bottom} (+ optional centerX/centerY) is also schema-valid.",
               "anyOf": [
                 {
                   "type": "object",
@@ -5418,6 +5419,7 @@
                   "additionalProperties": false
                 },
                 {
+                  "description": "Compact bounds tuple [left, top, right, bottom], emitted in place of the {left, top, right, bottom} object.",
                   "type": "array",
                   "prefixItems": [
                     {
@@ -5432,11 +5434,9 @@
                     {
                       "type": "number"
                     }
-                  ],
-                  "description": "Compact bounds tuple [left, top, right, bottom], emitted in place of the {left, top, right, bottom} object."
+                  ]
                 }
-              ],
-              "description": "Element bounds. Default: positional tuple [left, top, right, bottom]; the object {left, top, right, bottom} (+ optional centerX/centerY) is also schema-valid."
+              ]
             },
             "text": {
               "type": "string"
@@ -5610,6 +5610,7 @@
           "type": "object",
           "properties": {
             "bounds": {
+              "description": "Element bounds. Default: positional tuple [left, top, right, bottom]; the object {left, top, right, bottom} (+ optional centerX/centerY) is also schema-valid.",
               "anyOf": [
                 {
                   "type": "object",
@@ -5642,6 +5643,7 @@
                   "additionalProperties": false
                 },
                 {
+                  "description": "Compact bounds tuple [left, top, right, bottom], emitted in place of the {left, top, right, bottom} object.",
                   "type": "array",
                   "prefixItems": [
                     {
@@ -5656,11 +5658,9 @@
                     {
                       "type": "number"
                     }
-                  ],
-                  "description": "Compact bounds tuple [left, top, right, bottom], emitted in place of the {left, top, right, bottom} object."
+                  ]
                 }
-              ],
-              "description": "Element bounds. Default: positional tuple [left, top, right, bottom]; the object {left, top, right, bottom} (+ optional centerX/centerY) is also schema-valid."
+              ]
             },
             "text": {
               "type": "string"
@@ -5852,6 +5852,7 @@
           "type": "object",
           "properties": {
             "bounds": {
+              "description": "Element bounds. Default: positional tuple [left, top, right, bottom]; the object {left, top, right, bottom} (+ optional centerX/centerY) is also schema-valid.",
               "anyOf": [
                 {
                   "type": "object",
@@ -5884,6 +5885,7 @@
                   "additionalProperties": false
                 },
                 {
+                  "description": "Compact bounds tuple [left, top, right, bottom], emitted in place of the {left, top, right, bottom} object.",
                   "type": "array",
                   "prefixItems": [
                     {
@@ -5898,11 +5900,9 @@
                     {
                       "type": "number"
                     }
-                  ],
-                  "description": "Compact bounds tuple [left, top, right, bottom], emitted in place of the {left, top, right, bottom} object."
+                  ]
                 }
-              ],
-              "description": "Element bounds. Default: positional tuple [left, top, right, bottom]; the object {left, top, right, bottom} (+ optional centerX/centerY) is also schema-valid."
+              ]
             },
             "text": {
               "type": "string"
@@ -6078,6 +6078,7 @@
             "type": "object",
             "properties": {
               "bounds": {
+                "description": "Element bounds. Default: positional tuple [left, top, right, bottom]; the object {left, top, right, bottom} (+ optional centerX/centerY) is also schema-valid.",
                 "anyOf": [
                   {
                     "type": "object",
@@ -6110,6 +6111,7 @@
                     "additionalProperties": false
                   },
                   {
+                    "description": "Compact bounds tuple [left, top, right, bottom], emitted in place of the {left, top, right, bottom} object.",
                     "type": "array",
                     "prefixItems": [
                       {
@@ -6124,11 +6126,9 @@
                       {
                         "type": "number"
                       }
-                    ],
-                    "description": "Compact bounds tuple [left, top, right, bottom], emitted in place of the {left, top, right, bottom} object."
+                    ]
                   }
-                ],
-                "description": "Element bounds. Default: positional tuple [left, top, right, bottom]; the object {left, top, right, bottom} (+ optional centerX/centerY) is also schema-valid."
+                ]
               },
               "text": {
                 "type": "string"
@@ -6852,6 +6852,7 @@
               "maximum": 9007199254740991
             },
             "regionPx": {
+              "description": "Element bounds. Default: positional tuple [left, top, right, bottom]; the object {left, top, right, bottom} (+ optional centerX/centerY) is also schema-valid.",
               "anyOf": [
                 {
                   "type": "object",
@@ -6884,6 +6885,7 @@
                   "additionalProperties": false
                 },
                 {
+                  "description": "Compact bounds tuple [left, top, right, bottom], emitted in place of the {left, top, right, bottom} object.",
                   "type": "array",
                   "prefixItems": [
                     {
@@ -6898,11 +6900,9 @@
                     {
                       "type": "number"
                     }
-                  ],
-                  "description": "Compact bounds tuple [left, top, right, bottom], emitted in place of the {left, top, right, bottom} object."
+                  ]
                 }
-              ],
-              "description": "Element bounds. Default: positional tuple [left, top, right, bottom]; the object {left, top, right, bottom} (+ optional centerX/centerY) is also schema-valid."
+              ]
             },
             "focus": {
               "type": "object",
@@ -6982,8 +6982,8 @@
       "type": "object",
       "properties": {
         "url": {
-          "type": "string",
-          "description": "URL to open"
+          "description": "URL to open",
+          "type": "string"
         },
         "platform": {
           "type": "string",
@@ -7304,10 +7304,10 @@
           "type": "object",
           "properties": {
             "quietPeriodMs": {
+              "description": "Quiet-period ms (no hierarchy change) required after waitFor matches",
               "type": "integer",
               "exclusiveMinimum": 0,
-              "maximum": 9007199254740991,
-              "description": "Quiet-period ms (no hierarchy change) required after waitFor matches"
+              "maximum": 9007199254740991
             }
           },
           "required": [
@@ -7390,6 +7390,7 @@
       "type": "object",
       "properties": {
         "action": {
+          "description": "call/accept/cancel/busy/hold; hold needs no phoneNumber",
           "type": "string",
           "enum": [
             "call",
@@ -7397,8 +7398,7 @@
             "cancel",
             "busy",
             "hold"
-          ],
-          "description": "call/accept/cancel/busy/hold; hold needs no phoneNumber"
+          ]
         },
         "phoneNumber": {
           "description": "Phone number; required except for hold",
@@ -7437,12 +7437,12 @@
       "type": "object",
       "properties": {
         "direction": {
+          "description": "Pinch direction",
           "type": "string",
           "enum": [
             "in",
             "out"
-          ],
-          "description": "Pinch direction"
+          ]
         },
         "distanceStart": {
           "description": "Initial finger distance (px, default: 400)",
@@ -7473,12 +7473,12 @@
           "additionalProperties": false,
           "properties": {
             "elementId": {
-              "type": "string",
-              "description": "Container resource ID"
+              "description": "Container resource ID",
+              "type": "string"
             },
             "text": {
-              "type": "string",
-              "description": "Container text"
+              "description": "Container text",
+              "type": "string"
             }
           },
           "oneOf": [
@@ -7533,14 +7533,14 @@
       "type": "object",
       "properties": {
         "title": {
+          "description": "Notification title",
           "type": "string",
-          "minLength": 1,
-          "description": "Notification title"
+          "minLength": 1
         },
         "body": {
+          "description": "Notification body",
           "type": "string",
-          "minLength": 1,
-          "description": "Notification body"
+          "minLength": 1
         },
         "imageType": {
           "description": "Notification image type (default: normal)",
@@ -7561,14 +7561,14 @@
             "type": "object",
             "properties": {
               "label": {
+                "description": "Action label",
                 "type": "string",
-                "minLength": 1,
-                "description": "Action label"
+                "minLength": 1
               },
               "actionId": {
+                "description": "Action identifier",
                 "type": "string",
-                "minLength": 1,
-                "description": "Action identifier"
+                "minLength": 1
               }
             },
             "required": [
@@ -7583,9 +7583,9 @@
           "type": "string"
         },
         "appId": {
+          "description": "Android target package name or iOS target bundle ID; Android defaults to the live foreground app when omitted",
           "type": "string",
-          "minLength": 1,
-          "description": "Android target package name or iOS target bundle ID; Android defaults to the live foreground app when omitted"
+          "minLength": 1
         },
         "platform": {
           "type": "string",
@@ -7682,12 +7682,12 @@
       "type": "object",
       "properties": {
         "operationId": {
+          "description": "Caller-generated idempotency key",
           "type": "string",
-          "minLength": 1,
-          "description": "Caller-generated idempotency key"
+          "minLength": 1
         },
         "device": {
-          "oneOf": [
+          "anyOf": [
             {
               "type": "object",
               "properties": {
@@ -7696,22 +7696,22 @@
                   "const": "android"
                 },
                 "name": {
+                  "description": "Exact AVD name",
                   "type": "string",
-                  "minLength": 1,
-                  "description": "Exact AVD name"
+                  "minLength": 1
                 },
                 "spec": {
                   "type": "object",
                   "properties": {
                     "runtime": {
+                      "description": "Installed Android system-image package identifier",
                       "type": "string",
-                      "minLength": 1,
-                      "description": "Installed Android system-image package identifier"
+                      "minLength": 1
                     },
                     "deviceType": {
+                      "description": "Android avdmanager device profile identifier",
                       "type": "string",
-                      "minLength": 1,
-                      "description": "Android avdmanager device profile identifier"
+                      "minLength": 1
                     },
                     "configuration": {
                       "type": "object",
@@ -7747,22 +7747,22 @@
                   "const": "ios"
                 },
                 "name": {
+                  "description": "Exact simulator name",
                   "type": "string",
-                  "minLength": 1,
-                  "description": "Exact simulator name"
+                  "minLength": 1
                 },
                 "spec": {
                   "type": "object",
                   "properties": {
                     "runtime": {
+                      "description": "CoreSimulator runtime identifier",
                       "type": "string",
-                      "minLength": 1,
-                      "description": "CoreSimulator runtime identifier"
+                      "minLength": 1
                     },
                     "deviceType": {
+                      "description": "CoreSimulator device-type identifier",
                       "type": "string",
-                      "minLength": 1,
-                      "description": "CoreSimulator device-type identifier"
+                      "minLength": 1
                     }
                   },
                   "required": [
@@ -7821,6 +7821,7 @@
           "minLength": 1
         },
         "container": {
+          "description": "App container",
           "type": "string",
           "enum": [
             "documents",
@@ -7828,8 +7829,7 @@
             "cache",
             "tmp",
             "externalFiles"
-          ],
-          "description": "App container"
+          ]
         },
         "sourcePath": {
           "description": "Host file path",
@@ -7845,8 +7845,8 @@
           "type": "string"
         },
         "destinationPath": {
-          "type": "string",
-          "description": "Container-relative destination path"
+          "description": "Container-relative destination path",
+          "type": "string"
         },
         "platform": {
           "type": "string",
@@ -7992,16 +7992,16 @@
           "type": "string"
         },
         "name": {
-          "type": "string",
-          "description": "Storage name"
+          "description": "Storage name",
+          "type": "string"
         },
         "fileName": {
           "description": "Deprecated alias for name",
           "type": "string"
         },
         "key": {
-          "type": "string",
-          "description": "Key"
+          "description": "Key",
+          "type": "string"
         },
         "platform": {
           "type": "string",
@@ -8109,12 +8109,12 @@
       "type": "object",
       "properties": {
         "phoneNumber": {
-          "type": "string",
-          "description": "Sender phone number"
+          "description": "Sender phone number",
+          "type": "string"
         },
         "message": {
-          "type": "string",
-          "description": "SMS body; max 1024 chars, no newlines/NUL"
+          "description": "SMS body; max 1024 chars, no newlines/NUL",
+          "type": "string"
         },
         "platform": {
           "type": "string",
@@ -8340,18 +8340,19 @@
           "type": "string"
         },
         "name": {
-          "type": "string",
-          "description": "Storage name"
+          "description": "Storage name",
+          "type": "string"
         },
         "fileName": {
           "description": "Deprecated alias for name",
           "type": "string"
         },
         "key": {
-          "type": "string",
-          "description": "Key"
+          "description": "Key",
+          "type": "string"
         },
         "value": {
+          "description": "Value string; null clears",
           "anyOf": [
             {
               "type": "string"
@@ -8359,10 +8360,10 @@
             {
               "type": "null"
             }
-          ],
-          "description": "Value string; null clears"
+          ]
         },
         "type": {
+          "description": "Value type",
           "type": "string",
           "enum": [
             "STRING",
@@ -8377,8 +8378,7 @@
             "ARRAY",
             "DICTIONARY",
             "UNKNOWN"
-          ],
-          "description": "Value type"
+          ]
         },
         "platform": {
           "type": "string",
@@ -8420,8 +8420,8 @@
           "minLength": 1
         },
         "policyAccess": {
-          "type": "boolean",
-          "description": "Android: allow DND policy access"
+          "description": "Android: allow DND policy access",
+          "type": "boolean"
         },
         "platform": {
           "type": "string",
@@ -8457,13 +8457,13 @@
       "type": "object",
       "properties": {
         "scope": {
+          "description": "Preference scope",
           "type": "string",
           "enum": [
             "systemProperty",
             "sharedPreferences",
             "userDefaults"
-          ],
-          "description": "Preference scope"
+          ]
         },
         "appId": {
           "description": "App package or bundle id",
@@ -8474,11 +8474,12 @@
           "type": "string"
         },
         "key": {
+          "description": "Preference key or Android system property name",
           "type": "string",
-          "minLength": 1,
-          "description": "Preference key or Android system property name"
+          "minLength": 1
         },
         "value": {
+          "description": "Value to write",
           "anyOf": [
             {
               "type": "string"
@@ -8489,18 +8490,17 @@
             {
               "type": "number"
             }
-          ],
-          "description": "Value to write"
+          ]
         },
         "type": {
+          "description": "Value type for typed preference stores",
           "type": "string",
           "enum": [
             "string",
             "bool",
             "int",
             "float"
-          ],
-          "description": "Value type for typed preference stores"
+          ]
         },
         "platform": {
           "type": "string",
@@ -8538,6 +8538,7 @@
       "type": "object",
       "properties": {
         "capability": {
+          "description": "Optional tool capability to enable or disable for this MCP session.",
           "type": "string",
           "enum": [
             "clipboard",
@@ -8555,8 +8556,7 @@
             "app-routing",
             "navigation-modeling",
             "biometric-auth"
-          ],
-          "description": "Optional tool capability to enable or disable for this MCP session."
+          ]
         },
         "enabled": {
           "description": "Whether to enable the capability (default: true).",
@@ -8583,25 +8583,26 @@
       "type": "object",
       "properties": {
         "fields": {
+          "description": "Fields to set",
           "minItems": 1,
           "type": "array",
           "items": {
             "type": "object",
             "properties": {
               "selector": {
+                "description": "Field selector",
                 "type": "object",
                 "properties": {
                   "elementId": {
-                    "type": "string",
-                    "description": "Resource ID, e.g. com.app:id/btn_login"
+                    "description": "Resource ID, e.g. com.app:id/btn_login",
+                    "type": "string"
                   },
                   "text": {
-                    "type": "string",
-                    "description": "Text, content-desc, or placeholder"
+                    "description": "Text, content-desc, or placeholder",
+                    "type": "string"
                   }
                 },
-                "additionalProperties": false,
-                "description": "Field selector"
+                "additionalProperties": false
               },
               "value": {
                 "description": "Text/dropdown value",
@@ -8616,8 +8617,7 @@
               "selector"
             ],
             "additionalProperties": false
-          },
-          "description": "Fields to set"
+          }
         },
         "scrollDirection": {
           "description": "Initial search scroll direction",
@@ -8656,10 +8656,11 @@
       "type": "object",
       "properties": {
         "success": {
-          "type": "boolean",
-          "description": "All fields set"
+          "description": "All fields set",
+          "type": "boolean"
         },
         "fields": {
+          "description": "Field results",
           "type": "array",
           "items": {
             "type": "object",
@@ -8708,12 +8709,11 @@
               "attempts"
             ],
             "additionalProperties": false
-          },
-          "description": "Field results"
+          }
         },
         "totalAttempts": {
-          "type": "number",
-          "description": "Total attempts"
+          "description": "Total attempts",
+          "type": "number"
         },
         "error": {
           "description": "Error message",
@@ -8779,12 +8779,12 @@
           "type": "string"
         },
         "databasePath": {
-          "type": "string",
-          "description": "Database path"
+          "description": "Database path",
+          "type": "string"
         },
         "query": {
-          "type": "string",
-          "description": "SQL query"
+          "description": "SQL query",
+          "type": "string"
         },
         "platform": {
           "type": "string",
@@ -8867,12 +8867,12 @@
           "additionalProperties": false,
           "properties": {
             "elementId": {
-              "type": "string",
-              "description": "Container resource ID"
+              "description": "Container resource ID",
+              "type": "string"
             },
             "text": {
-              "type": "string",
-              "description": "Container text"
+              "description": "Container text",
+              "type": "string"
             }
           },
           "oneOf": [
@@ -8894,14 +8894,14 @@
           "type": "boolean"
         },
         "direction": {
+          "description": "Swipe/scroll direction",
           "type": "string",
           "enum": [
             "up",
             "down",
             "left",
             "right"
-          ],
-          "description": "Swipe/scroll direction"
+          ]
         },
         "gestureType": {
           "description": "Finger direction or content scroll direction; default: scrollTowardsDirection",
@@ -8916,12 +8916,12 @@
           "additionalProperties": false,
           "properties": {
             "elementId": {
-              "type": "string",
-              "description": "ID of the element to look for"
+              "description": "ID of the element to look for",
+              "type": "string"
             },
             "text": {
-              "type": "string",
-              "description": "Text to look for"
+              "description": "Text to look for",
+              "type": "string"
             }
           },
           "oneOf": [
@@ -8997,6 +8997,7 @@
       "type": "object",
       "properties": {
         "action": {
+          "description": "open/close/find/tap/dismiss/clearAll notification",
           "type": "string",
           "enum": [
             "open",
@@ -9005,8 +9006,7 @@
             "tap",
             "dismiss",
             "clearAll"
-          ],
-          "description": "open/close/find/tap/dismiss/clearAll notification"
+          ]
         },
         "notification": {
           "description": "Notification criteria to match",
@@ -9073,12 +9073,12 @@
           "additionalProperties": false,
           "properties": {
             "elementId": {
-              "type": "string",
-              "description": "Container resource ID"
+              "description": "Container resource ID",
+              "type": "string"
             },
             "text": {
-              "type": "string",
-              "description": "Container text"
+              "description": "Container text",
+              "type": "string"
             }
           },
           "oneOf": [
@@ -9108,8 +9108,8 @@
           "type": "boolean"
         },
         "action": {
-          "default": "tap",
           "description": "Action type (default: tap)",
+          "default": "tap",
           "type": "string",
           "enum": [
             "tap",
@@ -9172,28 +9172,28 @@
           "additionalProperties": false,
           "properties": {
             "elementId": {
+              "description": "Resource ID, e.g. com.app:id/btn_login",
               "type": "string",
-              "minLength": 1,
-              "description": "Resource ID, e.g. com.app:id/btn_login"
+              "minLength": 1
             },
             "testTag": {
+              "description": "Android accessibility test tag",
               "type": "string",
-              "minLength": 1,
-              "description": "Android accessibility test tag"
+              "minLength": 1
             },
             "text": {
+              "description": "Text, content-desc, or placeholder",
               "type": "string",
-              "minLength": 1,
-              "description": "Text, content-desc, or placeholder"
+              "minLength": 1
             },
             "textAny": {
+              "description": "Ordered text variants; first visible match wins",
               "minItems": 1,
               "type": "array",
               "items": {
                 "type": "string",
                 "minLength": 1
-              },
-              "description": "Ordered text variants; first visible match wins"
+              }
             }
           },
           "oneOf": [
@@ -9229,12 +9229,12 @@
           "additionalProperties": false,
           "properties": {
             "elementId": {
-              "type": "string",
-              "description": "Container resource ID"
+              "description": "Container resource ID",
+              "type": "string"
             },
             "text": {
-              "type": "string",
-              "description": "Container text"
+              "description": "Container text",
+              "type": "string"
             }
           },
           "oneOf": [
@@ -9252,8 +9252,8 @@
           "description": "Scope search to a container"
         },
         "action": {
-          "default": "tap",
           "description": "Action type (default: tap)",
+          "default": "tap",
           "type": "string",
           "enum": [
             "tap",
@@ -9348,6 +9348,7 @@
           "type": "object",
           "properties": {
             "bounds": {
+              "description": "Element bounds. Default: positional tuple [left, top, right, bottom]; the object {left, top, right, bottom} (+ optional centerX/centerY) is also schema-valid.",
               "anyOf": [
                 {
                   "type": "object",
@@ -9380,6 +9381,7 @@
                   "additionalProperties": false
                 },
                 {
+                  "description": "Compact bounds tuple [left, top, right, bottom], emitted in place of the {left, top, right, bottom} object.",
                   "type": "array",
                   "prefixItems": [
                     {
@@ -9394,11 +9396,9 @@
                     {
                       "type": "number"
                     }
-                  ],
-                  "description": "Compact bounds tuple [left, top, right, bottom], emitted in place of the {left, top, right, bottom} object."
+                  ]
                 }
-              ],
-              "description": "Element bounds. Default: positional tuple [left, top, right, bottom]; the object {left, top, right, bottom} (+ optional centerX/centerY) is also schema-valid."
+              ]
             },
             "text": {
               "type": "string"
@@ -9588,6 +9588,7 @@
                         "type": "string"
                       },
                       "bounds": {
+                        "description": "Element bounds. Default: positional tuple [left, top, right, bottom]; the object {left, top, right, bottom} (+ optional centerX/centerY) is also schema-valid.",
                         "anyOf": [
                           {
                             "type": "object",
@@ -9620,6 +9621,7 @@
                             "additionalProperties": false
                           },
                           {
+                            "description": "Compact bounds tuple [left, top, right, bottom], emitted in place of the {left, top, right, bottom} object.",
                             "type": "array",
                             "prefixItems": [
                               {
@@ -9634,11 +9636,9 @@
                               {
                                 "type": "number"
                               }
-                            ],
-                            "description": "Compact bounds tuple [left, top, right, bottom], emitted in place of the {left, top, right, bottom} object."
+                            ]
                           }
-                        ],
-                        "description": "Element bounds. Default: positional tuple [left, top, right, bottom]; the object {left, top, right, bottom} (+ optional centerX/centerY) is also schema-valid."
+                        ]
                       },
                       "indexInMatches": {
                         "type": "integer",
@@ -9684,6 +9684,7 @@
                   "type": "object",
                   "properties": {
                     "bounds": {
+                      "description": "Element bounds. Default: positional tuple [left, top, right, bottom]; the object {left, top, right, bottom} (+ optional centerX/centerY) is also schema-valid.",
                       "anyOf": [
                         {
                           "type": "object",
@@ -9716,6 +9717,7 @@
                           "additionalProperties": false
                         },
                         {
+                          "description": "Compact bounds tuple [left, top, right, bottom], emitted in place of the {left, top, right, bottom} object.",
                           "type": "array",
                           "prefixItems": [
                             {
@@ -9730,11 +9732,9 @@
                             {
                               "type": "number"
                             }
-                          ],
-                          "description": "Compact bounds tuple [left, top, right, bottom], emitted in place of the {left, top, right, bottom} object."
+                          ]
                         }
-                      ],
-                      "description": "Element bounds. Default: positional tuple [left, top, right, bottom]; the object {left, top, right, bottom} (+ optional centerX/centerY) is also schema-valid."
+                      ]
                     },
                     "text": {
                       "type": "string"
@@ -9908,6 +9908,7 @@
                   "type": "object",
                   "properties": {
                     "bounds": {
+                      "description": "Element bounds. Default: positional tuple [left, top, right, bottom]; the object {left, top, right, bottom} (+ optional centerX/centerY) is also schema-valid.",
                       "anyOf": [
                         {
                           "type": "object",
@@ -9940,6 +9941,7 @@
                           "additionalProperties": false
                         },
                         {
+                          "description": "Compact bounds tuple [left, top, right, bottom], emitted in place of the {left, top, right, bottom} object.",
                           "type": "array",
                           "prefixItems": [
                             {
@@ -9954,11 +9956,9 @@
                             {
                               "type": "number"
                             }
-                          ],
-                          "description": "Compact bounds tuple [left, top, right, bottom], emitted in place of the {left, top, right, bottom} object."
+                          ]
                         }
-                      ],
-                      "description": "Element bounds. Default: positional tuple [left, top, right, bottom]; the object {left, top, right, bottom} (+ optional centerX/centerY) is also schema-valid."
+                      ]
                     },
                     "text": {
                       "type": "string"
@@ -10506,6 +10506,7 @@
               "type": "string"
             },
             "bounds": {
+              "description": "Element bounds. Default: positional tuple [left, top, right, bottom]; the object {left, top, right, bottom} (+ optional centerX/centerY) is also schema-valid.",
               "anyOf": [
                 {
                   "type": "object",
@@ -10538,6 +10539,7 @@
                   "additionalProperties": false
                 },
                 {
+                  "description": "Compact bounds tuple [left, top, right, bottom], emitted in place of the {left, top, right, bottom} object.",
                   "type": "array",
                   "prefixItems": [
                     {
@@ -10552,11 +10554,9 @@
                     {
                       "type": "number"
                     }
-                  ],
-                  "description": "Compact bounds tuple [left, top, right, bottom], emitted in place of the {left, top, right, bottom} object."
+                  ]
                 }
-              ],
-              "description": "Element bounds. Default: positional tuple [left, top, right, bottom]; the object {left, top, right, bottom} (+ optional centerX/centerY) is also schema-valid."
+              ]
             },
             "indexInMatches": {
               "type": "integer",
@@ -10612,6 +10612,7 @@
                 "type": "string"
               },
               "bounds": {
+                "description": "Element bounds. Default: positional tuple [left, top, right, bottom]; the object {left, top, right, bottom} (+ optional centerX/centerY) is also schema-valid.",
                 "anyOf": [
                   {
                     "type": "object",
@@ -10644,6 +10645,7 @@
                     "additionalProperties": false
                   },
                   {
+                    "description": "Compact bounds tuple [left, top, right, bottom], emitted in place of the {left, top, right, bottom} object.",
                     "type": "array",
                     "prefixItems": [
                       {
@@ -10658,11 +10660,9 @@
                       {
                         "type": "number"
                       }
-                    ],
-                    "description": "Compact bounds tuple [left, top, right, bottom], emitted in place of the {left, top, right, bottom} object."
+                    ]
                   }
-                ],
-                "description": "Element bounds. Default: positional tuple [left, top, right, bottom]; the object {left, top, right, bottom} (+ optional centerX/centerY) is also schema-valid."
+                ]
               },
               "indexInMatches": {
                 "type": "integer",
@@ -10746,15 +10746,17 @@
           "type": "object",
           "properties": {
             "reachable": {
-              "type": "boolean",
-              "description": "Whether swipe cursor navigation reached the target"
+              "description": "Whether swipe cursor navigation reached the target",
+              "type": "boolean"
             },
             "traversalOrder": {
+              "description": "Focused nodes in cursor traversal order",
               "type": "array",
               "items": {
                 "type": "object",
                 "properties": {
                   "bounds": {
+                    "description": "Element bounds. Default: positional tuple [left, top, right, bottom]; the object {left, top, right, bottom} (+ optional centerX/centerY) is also schema-valid.",
                     "anyOf": [
                       {
                         "type": "object",
@@ -10787,6 +10789,7 @@
                         "additionalProperties": false
                       },
                       {
+                        "description": "Compact bounds tuple [left, top, right, bottom], emitted in place of the {left, top, right, bottom} object.",
                         "type": "array",
                         "prefixItems": [
                           {
@@ -10801,11 +10804,9 @@
                           {
                             "type": "number"
                           }
-                        ],
-                        "description": "Compact bounds tuple [left, top, right, bottom], emitted in place of the {left, top, right, bottom} object."
+                        ]
                       }
-                    ],
-                    "description": "Element bounds. Default: positional tuple [left, top, right, bottom]; the object {left, top, right, bottom} (+ optional centerX/centerY) is also schema-valid."
+                    ]
                   },
                   "text": {
                     "type": "string"
@@ -10974,12 +10975,11 @@
                   "bounds"
                 ],
                 "additionalProperties": {}
-              },
-              "description": "Focused nodes in cursor traversal order"
+              }
             },
             "focusTrapDetected": {
-              "type": "boolean",
-              "description": "Whether cursor navigation got stuck or failed to converge"
+              "description": "Whether cursor navigation got stuck or failed to converge",
+              "type": "boolean"
             }
           },
           "required": [
@@ -11172,7 +11172,8 @@
                 "type": "string"
               },
               "shape": {
-                "oneOf": [
+                "description": "Highlight shape",
+                "anyOf": [
                   {
                     "type": "object",
                     "properties": {
@@ -11734,8 +11735,7 @@
                     ],
                     "additionalProperties": false
                   }
-                ],
-                "description": "Highlight shape"
+                ]
               },
               "timing": {
                 "description": "Highlight timing",


### PR DESCRIPTION
## Summary

Eliminates redundant per-command view-hierarchy extraction in the CtrlProxy
command-dispatch path, cutting the device round-trips a tap/swipe/text/screenshot
triggers. Net effect: taps/swipes/text/screenshots now perform **at most one**
hierarchy extraction (zero when no frame context is supplied).

## Changes

**`CommandHandler.swift`**
- Removed the redundant `requireCurrentFrameContext(...)` pre-check from every
  gesture handler (tap/swipe/drag/setText/appendText/pressButton/pressHome/
  pressBack/recentApps) and deleted the helper. `performContextCheckedGesture` →
  `FrameContext.performIfCurrent` already re-extracts and validates `expected`
  and throws on staleness, so the pre-check was a second full extraction + SDK
  fetch for the same answer.
- `performContextCheckedGesture` no longer extracts the hierarchy when
  `expected == nil` — the no-context fast path pays for zero extraction and zero
  blocking SDK fetch (`performIfCurrent` returns `operation()` immediately for a
  nil `expected`, still dispatched on the transition executor).
- Screenshot frame-context pairing is now **opt-in**: `handleRequestScreenshot`
  only performs the before/after hierarchy walks when the client supplies a
  `frameContext`; a plain screenshot performs zero extractions and returns
  `frameContext: nil`. Clients that DO use frame context keep the fail-closed
  ABA-correlation behavior.
- The gesture/screenshot hot path now enriches from the cached SDK hierarchy
  (`enrichWithCachedSdkHierarchy`, zero device cost) instead of
  `enrichWithMatchingSdkHierarchy`, which falls back to the slow
  `/hierarchy/fresh` main-thread walk in the target app. The observe that
  produced `expected` also warms that cache, so the staleness hash still matches.
  The explicit `request_hierarchy` path is unchanged and still fetches fresh when
  the cache is missing/stale.

**`FrameContext.swift`**
- `semanticHash` reuses a shared `JSONEncoder` instead of allocating one per hash
  (one allocation per gesture validation / screenshot pairing removed).

## Tests

- `FrameContextSafetyTests`: rewrote the dispatch-boundary revalidation test for
  the single-extraction path; added coverage for the no-context no-extraction
  gesture path, the single-extraction context-bearing path, screenshot opt-out
  (no extraction, `frameContext: nil`), and screenshot opt-in pairing.
- `CommandHandlerTests`: added a test asserting the context-checked gesture path
  prefers the cached SDK hierarchy and never calls `fetchFreshHierarchy()`.

Stale-context still throws (covered), and clients that pass `frameContext` are
still validated.

## Validation

- `./scripts/ios/swift-build.sh` — all packages build.
- `./scripts/ios/swift-test.sh` — control-proxy 460 tests pass (0 failures);
  XCTestRunner suite passes in isolation (1 daemon-integration test skipped, an
  unrelated pre-existing environmental skip).
- SwiftLint (repo config) clean on changed files; SwiftFormat 0.54.6 clean on all
  lines in this diff.

Closes #5473
