### PR TITLE
perf(ios): pause always-on CtrlProxy device samplers when no client connected

### DIFF
--- a/ios/control-proxy/Sources/CtrlProxy/CtrlProxy.swift
+++ b/ios/control-proxy/Sources/CtrlProxy/CtrlProxy.swift
@@ -101,7 +101,9 @@ public class CtrlProxy {
             // Start the server
             try server.start()
 
-            // Wire up hierarchy debouncer to broadcast updates when content changes
+            // Wire up hierarchy debouncer to broadcast updates when content changes.
+            // The result callback is installed once; the debouncer itself is only
+            // started while a client is connected (see gating below).
             hierarchyDebouncer.setOnResult { [weak self] result in
                 switch result {
                 case let .changed(hierarchy, hash, extractionTimeMs):
@@ -118,30 +120,64 @@ public class CtrlProxy {
                     print("[CtrlProxy] Hierarchy extraction error: \(message)")
                 }
             }
-            hierarchyDebouncer.start()
 
-            // Start OSLogStore-based log capture (iOS 15+)
-            if #available(iOS 15.0, *) {
-                OSLogReaderHolder.shared.start()
-                print("[CtrlProxy] OSLogReader active (polling every 500ms)")
-            }
-
-            // Start FPS monitoring and broadcast updates to connected clients
-            fpsMonitor.startMonitoring { [weak self] snapshot in
-                self?.server.broadcastPerformanceUpdate(snapshot)
+            // Gate the always-on device samplers (hierarchy debouncer, OSLog poll,
+            // CADisplayLink FPS monitor) on client presence: they start on the first
+            // connected client and stop on the last disconnect, so an idle session
+            // with no client places no continuous load on the app under test
+            // (issue #5477). Sampler start/stop is hopped to the main queue so the
+            // presence callback never blocks the server queue with a hierarchy walk.
+            server.onClientPresenceChanged = { [weak self] hasClients in
+                DispatchQueue.main.async {
+                    guard let self else { return }
+                    if hasClients {
+                        self.startSamplers()
+                    } else {
+                        self.stopSamplers()
+                    }
+                }
             }
 
             print("[CtrlProxy] Service started")
             print("[CtrlProxy] WebSocket server listening on port \(Self.defaultPort)")
             print("[CtrlProxy] Endpoint: ws://localhost:\(Self.defaultPort)/ws")
             print("[CtrlProxy] Health check: http://localhost:\(Self.defaultPort)/health")
+            print("[CtrlProxy] Device samplers idle until a client connects")
+            print("[CtrlProxy] Ready to accept connections")
+        }
+    #endif
+
+    #if canImport(XCTest) && os(iOS)
+        /// Starts the device-side samplers. Called when the first client connects.
+        /// All three start operations are idempotent.
+        private func startSamplers() {
+            hierarchyDebouncer.start()
+
+            if #available(iOS 15.0, *) {
+                OSLogReaderHolder.shared.start()
+                print("[CtrlProxy] OSLogReader active (polling every \(OSLogReader.pollIntervalMs)ms)")
+            }
+
+            fpsMonitor.startMonitoring { [weak self] snapshot in
+                self?.server.broadcastPerformanceUpdate(snapshot)
+            }
+
             print(
                 "[CtrlProxy] Hierarchy debouncer active (polling every \(HierarchyDebouncer.defaultPollIntervalMs)ms)"
             )
             print(
                 "[CtrlProxy] FPS monitor active (reporting every \(DisplayLinkFPSMonitor.defaultReportIntervalSeconds)s)"
             )
-            print("[CtrlProxy] Ready to accept connections")
+        }
+
+        /// Stops the device-side samplers. Called when the last client disconnects.
+        private func stopSamplers() {
+            if #available(iOS 15.0, *) {
+                OSLogReaderHolder.shared.stop()
+            }
+            fpsMonitor.stopMonitoring()
+            hierarchyDebouncer.stop()
+            print("[CtrlProxy] Device samplers paused (no clients connected)")
         }
     #else
         public func start(bundleId _: String? = nil) throws {
@@ -152,6 +188,9 @@ public class CtrlProxy {
 
     /// Stops the service
     public func stop() {
+        // Clear the presence hook first so closing connections during teardown does
+        // not re-enter the sampler start/stop path.
+        server.onClientPresenceChanged = nil
         if #available(iOS 15.0, *) {
             OSLogReaderHolder.shared.stop()
         }

--- a/ios/control-proxy/Sources/CtrlProxy/DisplayLinkFPSMonitor.swift
+++ b/ios/control-proxy/Sources/CtrlProxy/DisplayLinkFPSMonitor.swift
@@ -17,8 +17,11 @@ import QuartzCore
 ///
 /// Reference: WWDC sessions on hitches and frame pacing
 public class DisplayLinkFPSMonitor: PerformanceMetricsProvider {
-    /// How often to report aggregated metrics (in seconds)
-    public static let defaultReportIntervalSeconds = 0.5
+    /// How often to report aggregated metrics (in seconds). Raised from 0.5 to 1.0
+    /// (issue #5477): each report enumerates all process threads for CPU and reads
+    /// task memory, so halving the report cadence halves that per-report sampling
+    /// cost while a client is connected.
+    public static let defaultReportIntervalSeconds = 1.0
 
     /// Frame time thresholds for jank detection
     /// - 60Hz budget: 16.67ms

--- a/ios/control-proxy/Sources/CtrlProxy/HierarchyDebouncer.swift
+++ b/ios/control-proxy/Sources/CtrlProxy/HierarchyDebouncer.swift
@@ -68,11 +68,25 @@ public class HierarchyDebouncer: HierarchyDebouncing {
     /// Minimum interval between broadcasts (debounce)
     public static let broadcastDebounceMs: Int64 = 50
 
+    /// Factor by which the poll interval grows on each consecutive idle poll
+    /// (structure unchanged since the last broadcast). Backing off eliminates the
+    /// steady-state idle load of a full hierarchy walk every second on a static
+    /// screen (issue #5477).
+    public static let idleBackoffMultiplier: Int64 = 2
+
+    /// Cap on the idle backoff, as a multiple of the base poll interval — i.e. the
+    /// interval progresses base -> 2x -> 4x and then holds (e.g. 1s -> 2s -> 4s).
+    public static let maxIdleBackoffMultiplier: Int64 = 4
+
     // MARK: - Dependencies
 
     private let elementLocator: ElementLocating
     private let timer: Timer
+    /// Base (fast) poll interval; the interval used immediately after any change.
     private var pollIntervalMs: Int64
+    /// Effective interval for the next scheduled poll, grown while idle up to the
+    /// backoff cap and reset to `pollIntervalMs` on any change or explicit command.
+    private var effectivePollIntervalMs: Int64
 
     // MARK: - State
 
@@ -107,6 +121,7 @@ public class HierarchyDebouncer: HierarchyDebouncing {
         self.elementLocator = elementLocator
         self.timer = timer
         self.pollIntervalMs = pollIntervalMs
+        effectivePollIntervalMs = pollIntervalMs
     }
 
     // MARK: - Public Interface
@@ -126,6 +141,7 @@ public class HierarchyDebouncer: HierarchyDebouncing {
     public func setPollIntervalMs(_ intervalMs: Int64) {
         lock.lock()
         pollIntervalMs = max(1, intervalMs)
+        effectivePollIntervalMs = pollIntervalMs
         pollGeneration += 1
         let shouldReschedule = _isRunning
         pollScheduled = false
@@ -165,6 +181,10 @@ public class HierarchyDebouncer: HierarchyDebouncing {
         inAnimationMode = false
         lock.unlock()
 
+        // Explicit command: reset the idle backoff and reschedule the next poll at
+        // the fast base interval, cancelling any pending backed-off poll (#5477).
+        resetPollCadence()
+
         extractAndCompare(skipBroadcast: false)
     }
 
@@ -172,6 +192,8 @@ public class HierarchyDebouncer: HierarchyDebouncing {
         lock.lock()
         inAnimationMode = false
         lock.unlock()
+
+        resetPollCadence()
 
         extractAndCompare(skipBroadcast: skipFlowEmit)
 
@@ -184,6 +206,7 @@ public class HierarchyDebouncer: HierarchyDebouncing {
     public func updatePollIntervalMs(_ pollIntervalMs: Int64) {
         lock.lock()
         self.pollIntervalMs = pollIntervalMs
+        effectivePollIntervalMs = pollIntervalMs
         pollGeneration += 1
         let running = _isRunning
         pollScheduled = false
@@ -209,10 +232,26 @@ public class HierarchyDebouncer: HierarchyDebouncing {
         skippedPollCount = 0
         lastBroadcastTime = 0
         lastHierarchy = nil
+        effectivePollIntervalMs = pollIntervalMs
         lock.unlock()
     }
 
     // MARK: - Private
+
+    /// Reset the idle backoff to the fast base interval and, if running, cancel the
+    /// pending (possibly backed-off) poll and schedule a fresh one at that interval.
+    private func resetPollCadence() {
+        lock.lock()
+        effectivePollIntervalMs = pollIntervalMs
+        let running = _isRunning
+        pollGeneration += 1
+        pollScheduled = false
+        lock.unlock()
+
+        if running {
+            scheduleNextPoll()
+        }
+    }
 
     private func scheduleNextPoll() {
         lock.lock()
@@ -222,7 +261,7 @@ public class HierarchyDebouncer: HierarchyDebouncing {
         }
         pollScheduled = true
         let scheduledGeneration = pollGeneration
-        let intervalMs = pollIntervalMs
+        let intervalMs = effectivePollIntervalMs
         lock.unlock()
 
         timer.schedule(after: intervalMs) { [weak self] in
@@ -330,6 +369,12 @@ public class HierarchyDebouncer: HierarchyDebouncing {
                 inAnimationMode = true
                 animationModeEndTime = timer.now() + HierarchyDebouncer.animationSkipWindowMs
                 lastHierarchy = hierarchy
+                // Idle: nothing changed since the last broadcast, so back off the
+                // poll interval toward the cap to eliminate steady-state load.
+                effectivePollIntervalMs = min(
+                    effectivePollIntervalMs * HierarchyDebouncer.idleBackoffMultiplier,
+                    pollIntervalMs * HierarchyDebouncer.maxIdleBackoffMultiplier
+                )
                 lock.unlock()
 
                 // Don't broadcast unchanged results to reduce noise
@@ -346,6 +391,9 @@ public class HierarchyDebouncer: HierarchyDebouncing {
                 inAnimationMode = false
                 lastHierarchy = hierarchy
                 skippedPollCount = 0
+                // A real change resets the cadence to the fast base interval so we
+                // stay responsive immediately after any content change.
+                effectivePollIntervalMs = pollIntervalMs
                 lock.unlock()
 
                 // Debounce broadcasts

--- a/ios/control-proxy/Sources/CtrlProxy/OSLogReader.swift
+++ b/ios/control-proxy/Sources/CtrlProxy/OSLogReader.swift
@@ -7,11 +7,23 @@ import OSLog
 /// Requires iOS 15+ for OSLogStore access.
 @available(iOS 15.0, macOS 12.0, *)
 public final class OSLogReader {
+    /// How often to poll the process log store. Raised from 500ms to 1000ms
+    /// (issue #5477): the previous cadence re-queried the whole log store twice a
+    /// second for the entire session, loading the device even when idle.
+    public static let pollIntervalMs = 1000
+
     private let lock = NSLock()
     private var timer: DispatchSourceTimer?
     private var lastEntryDate: Date
     private var buffer: [LogEntry] = []
     private let maxBufferSize = 500
+
+    /// A single reused `OSLogStore`. The previous implementation allocated a fresh
+    /// store on every poll; the store is stable for the process lifetime, so it is
+    /// created once and reused, then released on `stop()` (issue #5477). Guarded by
+    /// `lock`.
+    private var store: OSLogStore?
+    private let storeFactory: () throws -> OSLogStore
 
     /// Lightweight struct matching the SdkLogEvent wire format.
     public struct LogEntry: Codable {
@@ -22,7 +34,10 @@ public final class OSLogReader {
         public let message: String
     }
 
-    public init() {
+    public init(storeFactory: @escaping () throws -> OSLogStore = {
+        try OSLogStore(scope: .currentProcessIdentifier)
+    }) {
+        self.storeFactory = storeFactory
         self.lastEntryDate = Date()
     }
 
@@ -35,8 +50,9 @@ public final class OSLogReader {
             return
         }
 
+        let interval = DispatchTimeInterval.milliseconds(Self.pollIntervalMs)
         let source = DispatchSource.makeTimerSource(queue: DispatchQueue.global(qos: .utility))
-        source.schedule(deadline: .now() + .milliseconds(500), repeating: .milliseconds(500))
+        source.schedule(deadline: .now() + interval, repeating: interval)
         source.setEventHandler { [weak self] in
             self?.poll()
         }
@@ -44,13 +60,14 @@ public final class OSLogReader {
         timer = source
         lock.unlock()
 
-        print("[OSLogReader] Started polling (500ms interval)")
+        print("[OSLogReader] Started polling (\(Self.pollIntervalMs)ms interval)")
     }
 
     public func stop() {
         lock.lock()
         timer?.cancel()
         timer = nil
+        store = nil
         lock.unlock()
         print("[OSLogReader] Stopped")
     }
@@ -84,9 +101,33 @@ public final class OSLogReader {
 
     // MARK: - Private
 
-    private func poll() {
+    /// Obtain the reused `OSLogStore`, lazily creating it on first use. Internal so
+    /// `OSLogReaderTests` can assert the store is created once and reused.
+    func obtainStore() throws -> OSLogStore {
+        lock.lock()
+        if let existing = store {
+            lock.unlock()
+            return existing
+        }
+        lock.unlock()
+
+        let created = try storeFactory()
+
+        lock.lock()
+        // A concurrent poll may have created one first; keep the first winner.
+        if let existing = store {
+            lock.unlock()
+            return existing
+        }
+        store = created
+        lock.unlock()
+        return created
+    }
+
+    /// Internal (not `private`) so tests can drive one poll deterministically.
+    func poll() {
         do {
-            let store = try OSLogStore(scope: .currentProcessIdentifier)
+            let store = try obtainStore()
             let position = store.position(date: lastEntryDate)
             let entries = try store.getEntries(at: position)
 

--- a/ios/control-proxy/Sources/CtrlProxy/WebSocketServer.swift
+++ b/ios/control-proxy/Sources/CtrlProxy/WebSocketServer.swift
@@ -104,9 +104,48 @@ public class WebSocketServer: WebSocketServing {
         case encodingError
     }
 
+    /// Reusable JSON coders. `JSONEncoder`/`JSONDecoder` are safe to share once
+    /// configured (we never mutate them after construction), so a single
+    /// pre-configured instance per role avoids allocating and reconfiguring one on
+    /// every encoded/decoded message on the hot wire path (issue #5477).
+    static let sortedKeysEncoder: JSONEncoder = {
+        let encoder = JSONEncoder()
+        encoder.outputFormatting = .sortedKeys
+        return encoder
+    }()
+
+    /// Plain encoder for payloads that do not require deterministic key ordering
+    /// (e.g. the one-shot connected event).
+    static let sharedEncoder = JSONEncoder()
+
+    /// Reusable decoder for inbound request framing.
+    static let sharedDecoder = JSONDecoder()
+
     private var listener: NWListener?
     private let connections = ConnectionRegistry<WebSocketConnection>()
     private var nextConnectionId = 1
+
+    /// Ids of connections that have completed the WebSocket upgrade handshake,
+    /// i.e. real subscribed clients — as distinct from transient HTTP connections
+    /// (`GET /health`, `POST /sdk-events`) that briefly appear in `connections`.
+    /// Guarded by `presenceLock`. Used to gate the always-on device samplers so
+    /// they run only while a client is actually connected (issue #5477).
+    private var upgradedClientIds = Set<Int>()
+    private let presenceLock = NSLock()
+
+    /// Invoked when the connected-client count transitions between zero and
+    /// non-zero: `true` when the first client connects, `false` when the last one
+    /// disconnects. A transient HTTP request never toggles this. Callbacks fire off
+    /// the caller's queue; consumers should hop to their own queue if needed.
+    public var onClientPresenceChanged: ((Bool) -> Void)?
+
+    /// Whether at least one WebSocket client is currently connected (upgraded).
+    public var hasConnectedClients: Bool {
+        presenceLock.lock()
+        defer { presenceLock.unlock() }
+        return !upgradedClientIds.isEmpty
+    }
+
     private let port: UInt16
     private let commandHandler: CommandHandler
     private let perfProvider: PerfProvider
@@ -213,15 +252,49 @@ public class WebSocketServer: WebSocketServing {
             sdkHierarchyCache: sdkHierarchyCache,
             onSdkHierarchyUpdated: { [weak self] in
                 self?.onSdkHierarchyUpdated?()
+            },
+            onUpgrade: { [weak self] in
+                self?.clientDidUpgrade(connectionId)
             }
         ) { [weak self] message in
             self?.handleMessage(message, connectionId: connectionId)
         } onClose: { [weak self] in
             self?.connections.removeValue(forId: connectionId)
+            self?.clientDidDisconnect(connectionId)
         }
 
         connections.set(connection, forId: connectionId)
         connection.start()
+    }
+
+    /// Records that a connection completed the WebSocket upgrade, firing the
+    /// presence hook only on the zero → non-zero transition. Internal (not
+    /// `private`) so `WebSocketServerTests` can drive the presence bookkeeping
+    /// without a live socket (issue #5477).
+    func clientDidUpgrade(_ id: Int) {
+        presenceLock.lock()
+        let wasEmpty = upgradedClientIds.isEmpty
+        upgradedClientIds.insert(id)
+        presenceLock.unlock()
+
+        if wasEmpty {
+            onClientPresenceChanged?(true)
+        }
+    }
+
+    /// Records that a connection closed, firing the presence hook only on the
+    /// non-zero → zero transition. A never-upgraded (HTTP-only) connection is a
+    /// no-op here, so `/health` probes never toggle presence.
+    func clientDidDisconnect(_ id: Int) {
+        presenceLock.lock()
+        let wasPresent = !upgradedClientIds.isEmpty
+        upgradedClientIds.remove(id)
+        let nowEmpty = upgradedClientIds.isEmpty
+        presenceLock.unlock()
+
+        if wasPresent, nowEmpty {
+            onClientPresenceChanged?(false)
+        }
     }
 
     private func handleMessage(_ data: Data, connectionId: Int) {
@@ -256,7 +329,7 @@ public class WebSocketServer: WebSocketServing {
     /// fake responder, no live `NWConnection` (issue #2859 part 4).
     func handleMessage(_ data: Data, responder: WebSocketResponding) {
         do {
-            let request = try JSONDecoder().decode(WebSocketRequest.self, from: data)
+            let request = try Self.sharedDecoder.decode(WebSocketRequest.self, from: data)
             print("[WebSocketServer] Received request type=\(request.typeString) requestId=\(request.requestId ?? "nil")")
 
             // Track the entire request handling with PerfProvider
@@ -298,8 +371,7 @@ public class WebSocketServer: WebSocketServing {
     }
 
     private func encodeResponse(_ response: Any, totalTimeMs: Int64, perfTiming: PerfTiming?) throws -> Data {
-        let encoder = JSONEncoder()
-        encoder.outputFormatting = .sortedKeys
+        let encoder = Self.sortedKeysEncoder
 
         if var wsResponse = response as? WebSocketResponse {
             // Inject perfTiming if present and response doesn't already have it.
@@ -361,9 +433,7 @@ public class WebSocketServer: WebSocketServing {
         )
 
         do {
-            let encoder = JSONEncoder()
-            encoder.outputFormatting = .sortedKeys
-            let data = try encoder.encode(response)
+            let data = try Self.sortedKeysEncoder.encode(response)
             broadcast(data)
             print("[WebSocketServer] Broadcast hierarchy update to \(connections.count) client(s)")
         } catch {
@@ -378,9 +448,7 @@ public class WebSocketServer: WebSocketServing {
         let response = PerformanceUpdateResponse(data: snapshot)
 
         do {
-            let encoder = JSONEncoder()
-            encoder.outputFormatting = .sortedKeys
-            let data = try encoder.encode(response)
+            let data = try Self.sortedKeysEncoder.encode(response)
             broadcast(data)
         } catch {
             print("[WebSocketServer] Failed to encode performance update: \(error)")
@@ -418,9 +486,7 @@ public class WebSocketServer: WebSocketServing {
         )
 
         do {
-            let encoder = JSONEncoder()
-            encoder.outputFormatting = .sortedKeys
-            return try encoder.encode(errorResponse)
+            return try sortedKeysEncoder.encode(errorResponse)
         } catch {
             let sanitizedError = String(
                 errorResponse.error?
@@ -571,6 +637,7 @@ class WebSocketConnection: WebSocketResponding {
     private let queue: DispatchQueue
     private let onMessage: (Data) -> Void
     private let onClose: () -> Void
+    private let onUpgrade: (() -> Void)?
     private let sdkHierarchyCache: (any SdkHierarchyCaching)?
     private let onSdkHierarchyUpdated: (() -> Void)?
     /// The port the server is actually bound to; echoed in /health so the daemon
@@ -587,6 +654,7 @@ class WebSocketConnection: WebSocketResponding {
         boundPort: UInt16,
         sdkHierarchyCache: (any SdkHierarchyCaching)? = nil,
         onSdkHierarchyUpdated: (() -> Void)? = nil,
+        onUpgrade: (() -> Void)? = nil,
         onMessage: @escaping (Data) -> Void,
         onClose: @escaping () -> Void
     ) {
@@ -596,6 +664,7 @@ class WebSocketConnection: WebSocketResponding {
         self.boundPort = boundPort
         self.sdkHierarchyCache = sdkHierarchyCache
         self.onSdkHierarchyUpdated = onSdkHierarchyUpdated
+        self.onUpgrade = onUpgrade
         self.onMessage = onMessage
         self.onClose = onClose
     }
@@ -821,6 +890,7 @@ class WebSocketConnection: WebSocketResponding {
             }
 
             self?.isWebSocketUpgraded = true
+            self?.onUpgrade?()
             self?.sendConnectedEvent()
             self?.receiveWebSocketFrame()
         })
@@ -829,7 +899,7 @@ class WebSocketConnection: WebSocketResponding {
     private func sendConnectedEvent() {
         let event = ConnectedEvent(id: id)
         do {
-            let data = try JSONEncoder().encode(event)
+            let data = try WebSocketServer.sharedEncoder.encode(event)
             send(data)
         } catch {
             let fallback = "{\"type\":\"connected\",\"id\":\(id)}"
@@ -934,6 +1004,30 @@ class WebSocketConnection: WebSocketResponding {
         return Int(payloadLength) + (isMasked ? 4 : 0)
     }
 
+    /// Unmask a masked WebSocket frame whose first 4 bytes are the masking key and
+    /// whose remaining bytes are the masked payload (RFC 6455 §5.3).
+    ///
+    /// The previous implementation appended one byte at a time to a growing `Data`,
+    /// reallocating repeatedly for large payloads. This pre-sizes the output and
+    /// XORs through raw buffer pointers, so a payload of N bytes is a single
+    /// allocation plus a tight loop (issue #5477). Internal (not `private`) so
+    /// `WebSocketServerTests` can pin it against a reference XOR.
+    static func unmaskFrame(_ frame: Data) -> Data {
+        guard frame.count > 4 else { return Data() }
+        let payloadCount = frame.count - 4
+        var unmasked = Data(count: payloadCount)
+        frame.withUnsafeBytes { (rawIn: UnsafeRawBufferPointer) in
+            unmasked.withUnsafeMutableBytes { (rawOut: UnsafeMutableRawBufferPointer) in
+                let src = rawIn.bindMemory(to: UInt8.self)
+                let dst = rawOut.bindMemory(to: UInt8.self)
+                for i in 0 ..< payloadCount {
+                    dst[i] = src[4 + i] ^ src[i & 3]
+                }
+            }
+        }
+        return unmasked
+    }
+
     private func readPayload(length: UInt64, isMasked: Bool, opcode: UInt8) {
         guard let totalLength = Self.frameReadLength(payloadLength: length, isMasked: isMasked) else {
             print("[WebSocketConnection] Frame payload too large (\(length) bytes), closing connection")
@@ -953,18 +1047,7 @@ class WebSocketConnection: WebSocketResponding {
                     return
                 }
 
-                var payload: Data
-                if isMasked {
-                    let mask = Array(data.prefix(4))
-                    let maskedData = data.suffix(from: 4)
-                    var unmasked = Data()
-                    for (i, byte) in maskedData.enumerated() {
-                        unmasked.append(byte ^ mask[i % 4])
-                    }
-                    payload = unmasked
-                } else {
-                    payload = data
-                }
+                let payload: Data = isMasked ? Self.unmaskFrame(data) : data
 
                 // Handle text or binary frame
                 if opcode == 0x01 || opcode == 0x02 {

--- a/ios/control-proxy/Tests/CtrlProxyTests/HierarchyDebouncerTests.swift
+++ b/ios/control-proxy/Tests/CtrlProxyTests/HierarchyDebouncerTests.swift
@@ -421,6 +421,137 @@ final class HierarchyDebouncerTests: XCTestCase {
         XCTAssertEqual(transitions.value.first?.hierarchy?.text, "B")
     }
 
+    // MARK: - Idle Backoff Tests (#5477)
+
+    /// Helper: a distinct static hierarchy so the debouncer sees "no change".
+    private func staticHierarchy(_ text: String) -> ViewHierarchy {
+        ViewHierarchy(
+            packageName: "com.test.app",
+            hierarchy: UIElementInfo(
+                text: text,
+                className: "UIView",
+                bounds: ElementBounds(left: 0, top: 0, right: 375, bottom: 812)
+            ),
+            windowInfo: WindowInfo(id: 0, type: 1, isActive: true, isFocused: true)
+        )
+    }
+
+    /// A fresh debouncer whose base interval (200ms) exceeds the 100ms animation
+    /// skip window, so backed-off polls are never mistaken for animation skips —
+    /// matching the production base of 1000ms.
+    private func makeBackoffDebouncer() -> HierarchyDebouncer {
+        HierarchyDebouncer(elementLocator: fakeLocator, timer: fakeTimer, pollIntervalMs: 200)
+    }
+
+    /// On a static screen the poll interval must grow base -> 2x -> 4x and then
+    /// hold at the cap. With base = 200ms the cap is 800ms, so polls land at
+    /// t = 200, 600, 1400, 2200, ... (intervals 200, 400, 800, 800).
+    func testBacksOffPollIntervalWhileIdle() {
+        let debouncer = makeBackoffDebouncer()
+        defer { debouncer.stop() }
+        fakeLocator.setHierarchy(staticHierarchy("Idle"))
+        debouncer.start() // captureInitialState => 1 request
+        let base = fakeLocator.hierarchyRequestCount
+        XCTAssertEqual(base, 1)
+
+        // First poll at t=200 (base interval), then backs off to 400ms.
+        fakeTimer.advance(by: 200)
+        XCTAssertEqual(fakeLocator.hierarchyRequestCount, base + 1, "first poll fires at base interval (t=200)")
+
+        // No poll for the next 200ms (next is 400ms out, at t=600).
+        fakeTimer.advance(by: 200)
+        XCTAssertEqual(fakeLocator.hierarchyRequestCount, base + 1, "interval doubled to 400ms after idle poll")
+
+        // Second poll at t=600, then backs off to 800ms (the cap).
+        fakeTimer.advance(by: 200)
+        XCTAssertEqual(fakeLocator.hierarchyRequestCount, base + 2, "second poll at t=600 (200+400)")
+
+        // No poll for the next 400ms (next is at t=1400).
+        fakeTimer.advance(by: 400)
+        XCTAssertEqual(fakeLocator.hierarchyRequestCount, base + 2, "interval grew to the 800ms cap")
+
+        // Third poll at t=1400, cap holds at 800ms.
+        fakeTimer.advance(by: 400)
+        XCTAssertEqual(fakeLocator.hierarchyRequestCount, base + 3, "third poll at t=1400 (600+800)")
+
+        // Cap holds: the next poll is a further 800ms out (t=2200), not more.
+        fakeTimer.advance(by: 800)
+        XCTAssertEqual(fakeLocator.hierarchyRequestCount, base + 4, "cap holds at 800ms, poll at t=2200")
+    }
+
+    /// A detected structural change resets the cadence back to the fast base
+    /// interval, so the debouncer is immediately responsive after any change even
+    /// if it had backed off while idle.
+    func testResetsToFastIntervalOnStructuralChange() {
+        let debouncer = makeBackoffDebouncer()
+        defer { debouncer.stop() }
+        fakeLocator.setHierarchy(staticHierarchy("Idle"))
+        debouncer.start()
+        let baseCount = fakeLocator.hierarchyRequestCount
+
+        // Idle long enough to reach the 800ms cap: polls at t=200, 600, 1400. Each
+        // poll self-reschedules the next one, so advance in per-interval steps.
+        fakeTimer.advance(by: 200) // t=200 poll, backs off to 400ms
+        fakeTimer.advance(by: 400) // t=600 poll, backs off to 800ms
+        fakeTimer.advance(by: 800) // t=1400 poll, holds at 800ms cap
+        XCTAssertEqual(fakeLocator.hierarchyRequestCount, baseCount + 3, "backed off to the cap while idle")
+
+        // A structural change arrives; the next poll (at the backed-off cadence,
+        // t=2200) detects it and resets the interval to the fast base.
+        fakeLocator.setHierarchy(staticHierarchy("Changed"))
+        fakeTimer.advance(by: 800) // t=2200: change detected, cadence reset to base (200ms)
+        XCTAssertEqual(fakeLocator.hierarchyRequestCount, baseCount + 4, "change detected at backed-off cadence")
+
+        // Now polling is fast again: the very next poll fires only 200ms later.
+        fakeTimer.advance(by: 200)
+        XCTAssertEqual(
+            fakeLocator.hierarchyRequestCount,
+            baseCount + 5,
+            "cadence reset to the fast base interval after the change"
+        )
+    }
+
+    /// An explicit `extractNow` resets the backed-off cadence to the fast base
+    /// interval, matching the "reset on explicit command" acceptance criterion.
+    func testExtractNowResetsBackoff() {
+        let debouncer = makeBackoffDebouncer()
+        defer { debouncer.stop() }
+        fakeLocator.setHierarchy(staticHierarchy("Idle"))
+        debouncer.start()
+        let baseCount = fakeLocator.hierarchyRequestCount
+
+        // Reach the 800ms cap while idle: polls at t=200, 600, 1400 (stepped so each
+        // self-rescheduled poll fires).
+        fakeTimer.advance(by: 200)
+        fakeTimer.advance(by: 400)
+        fakeTimer.advance(by: 800)
+        XCTAssertEqual(fakeLocator.hierarchyRequestCount, baseCount + 3)
+
+        // Explicit extraction (one immediate request) also resets the cadence and
+        // reschedules the next poll at the fast base interval (t=1600), cancelling
+        // the pending backed-off poll that was due at t=2200.
+        debouncer.extractNow()
+        let afterExtract = fakeLocator.hierarchyRequestCount
+        XCTAssertEqual(afterExtract, baseCount + 4, "extractNow performs one immediate extraction")
+
+        // The rescheduled poll fires 200ms later (t=1600), not at the old t=2200.
+        fakeTimer.advance(by: 200)
+        XCTAssertEqual(
+            fakeLocator.hierarchyRequestCount,
+            afterExtract + 1,
+            "reset poll fires at the base interval (t=1600)"
+        )
+
+        // The old backed-off poll (t=2200) was cancelled: advancing to t=2200 fires
+        // no extra poll beyond the rebuilt cadence (next is at t=2400).
+        fakeTimer.advance(by: 600) // t=2200
+        XCTAssertEqual(
+            fakeLocator.hierarchyRequestCount,
+            afterExtract + 1,
+            "the cancelled t=2200 poll does not fire"
+        )
+    }
+
     // MARK: - StructuralHasher Tests
 
     func testHashChangesWhenAlertNodesAdded() {

--- a/ios/control-proxy/Tests/CtrlProxyTests/OSLogReaderTests.swift
+++ b/ios/control-proxy/Tests/CtrlProxyTests/OSLogReaderTests.swift
@@ -31,4 +31,33 @@ final class OSLogReaderTests: XCTestCase {
         XCTAssertEqual(OSLogReader.mapLevel(.error), 4) // Error bucket (>=4)
         XCTAssertGreaterThanOrEqual(OSLogReader.mapLevel(.fault), 4) // Error bucket
     }
+
+    // MARK: - Idle-load reductions (#5477)
+
+    /// The poll interval was raised from 500ms to at least 1s so the idle process
+    /// log store is queried at most once per second.
+    func testPollIntervalIsAtLeastOneSecond() {
+        XCTAssertGreaterThanOrEqual(OSLogReader.pollIntervalMs, 1000)
+    }
+
+    /// The `OSLogStore` is created once and reused across polls, rather than
+    /// allocated on every tick as before.
+    func testReusesSingleOSLogStore() throws {
+        var creations = 0
+        let reader = OSLogReader(storeFactory: {
+            creations += 1
+            return try OSLogStore(scope: .currentProcessIdentifier)
+        })
+
+        let first: OSLogStore
+        do {
+            first = try reader.obtainStore()
+        } catch {
+            throw XCTSkip("OSLogStore is unavailable in this environment: \(error)")
+        }
+        let second = try reader.obtainStore()
+
+        XCTAssertEqual(creations, 1, "store should be created exactly once")
+        XCTAssertTrue(first === second, "the same OSLogStore instance is reused across polls")
+    }
 }

--- a/ios/control-proxy/Tests/CtrlProxyTests/WebSocketServerTests.swift
+++ b/ios/control-proxy/Tests/CtrlProxyTests/WebSocketServerTests.swift
@@ -540,6 +540,93 @@ final class WebSocketServerTests: XCTestCase {
             "health body should report status:ok"
         )
     }
+
+    // MARK: - Client presence gating (#5477)
+
+    /// Presence tracks only upgraded WebSocket clients and fires the hook exactly
+    /// on the zero <-> non-zero transitions, so the device samplers can start on
+    /// the first client and stop on the last disconnect.
+    func testClientPresenceTogglesOnFirstAndLastClient() {
+        let server = makeServer()
+        let events = Box<[Bool]>([])
+        server.onClientPresenceChanged = { events.value.append($0) }
+
+        XCTAssertFalse(server.hasConnectedClients, "no clients at start")
+
+        server.clientDidUpgrade(1)
+        XCTAssertTrue(server.hasConnectedClients)
+        XCTAssertEqual(events.value, [true], "first client fires presence=true")
+
+        // A second client is already-present; presence must not re-fire.
+        server.clientDidUpgrade(2)
+        XCTAssertEqual(events.value, [true], "second client does not re-fire")
+        XCTAssertTrue(server.hasConnectedClients)
+
+        // One of two disconnecting keeps presence.
+        server.clientDidDisconnect(1)
+        XCTAssertEqual(events.value, [true], "one remaining client keeps presence")
+        XCTAssertTrue(server.hasConnectedClients)
+
+        // The last disconnect fires presence=false.
+        server.clientDidDisconnect(2)
+        XCTAssertEqual(events.value, [true, false], "last disconnect fires presence=false")
+        XCTAssertFalse(server.hasConnectedClients)
+    }
+
+    /// A transient HTTP connection (`GET /health`, `POST /sdk-events`) never
+    /// upgrades, so its close must not toggle presence — otherwise health probes
+    /// would thrash the samplers on and off.
+    func testHttpOnlyConnectionCloseDoesNotTogglePresence() {
+        let server = makeServer()
+        let events = Box<[Bool]>([])
+        server.onClientPresenceChanged = { events.value.append($0) }
+
+        // An id that never upgraded closes; no transition should be reported.
+        server.clientDidDisconnect(42)
+        XCTAssertTrue(events.value.isEmpty, "an unupgraded connection close is a no-op")
+        XCTAssertFalse(server.hasConnectedClients)
+    }
+
+    // MARK: - Inbound frame unmasking (#5477 wire micro-opt)
+
+    /// The vectorized unmask must produce byte-for-byte the same result as the
+    /// reference per-byte XOR it replaces, across payload sizes and mask offsets.
+    func testUnmaskFrameMatchesReferenceXor() {
+        let mask: [UInt8] = [0x37, 0xFA, 0x21, 0x3D]
+        let payload = Array("Hello, WebSocket unmasking! 0123456789".utf8)
+        var frame = Data(mask)
+        frame.append(contentsOf: payload.enumerated().map { $0.element ^ mask[$0.offset % 4] })
+
+        XCTAssertEqual(Array(WebSocketConnection.unmaskFrame(frame)), payload)
+    }
+
+    /// A masked frame with a zero-length payload (mask key only) unmasks to empty.
+    func testUnmaskFrameEmptyPayload() {
+        let frame = Data([0x01, 0x02, 0x03, 0x04])
+        XCTAssertEqual(WebSocketConnection.unmaskFrame(frame), Data())
+    }
+
+    /// A single-byte payload exercises the offset-0 mask byte only.
+    func testUnmaskFrameSingleByte() {
+        let mask: [UInt8] = [0xAA, 0xBB, 0xCC, 0xDD]
+        let payload: [UInt8] = [0x42]
+        var frame = Data(mask)
+        frame.append(payload[0] ^ mask[0])
+        XCTAssertEqual(Array(WebSocketConnection.unmaskFrame(frame)), payload)
+    }
+
+    /// The received `Data` may be a slice with a non-zero start index; the helper
+    /// must index relative to the slice, not the backing buffer.
+    func testUnmaskFrameHandlesSlicedData() {
+        let mask: [UInt8] = [0x11, 0x22, 0x33, 0x44]
+        let payload = Array("sliced payload crossing the mask several times".utf8)
+        var full = Data([0xDE, 0xAD]) // leading bytes so the frame is a mid-buffer slice
+        full.append(Data(mask))
+        full.append(contentsOf: payload.enumerated().map { $0.element ^ mask[$0.offset % 4] })
+        let slice = full.suffix(from: 2)
+
+        XCTAssertEqual(Array(WebSocketConnection.unmaskFrame(slice)), payload)
+    }
 }
 
 /// Lock-protected reference cell so an escaping completion handler can publish a


### PR DESCRIPTION
## Summary

Implements #5477. The iOS CtrlProxy ran several continuous device-side samplers
that started unconditionally in `CtrlProxy.start()` and only tore down in
`stop()`, loading the app-under-test's device for the entire session even with
no client connected. This gates them on client presence and trims their
steady-state cost.

## Changes per file

- **WebSocketServer.swift**
  - New client-presence signal: `hasConnectedClients` accessor +
    `onClientPresenceChanged` hook. Presence tracks only **upgraded** WebSocket
    clients, so transient HTTP requests (`GET /health`, `POST /sdk-events`)
    never toggle it (no sampler thrash on health probes).
  - Reuse pre-configured static `JSONEncoder`/`JSONDecoder` instances instead of
    allocating one per message.
  - `unmaskFrame`: pre-sized, `withUnsafeMutableBytes` vectorized XOR instead of
    per-byte `Data.append`.
- **CtrlProxy.swift**: start the samplers on the first connected client and stop
  them on the last disconnect (start/stop hopped to main to keep the server
  queue free). Idle sessions place no continuous load.
- **HierarchyDebouncer.swift**: idle backoff — the poll interval grows base -> 2x
  -> 4x (1s -> 2s -> 4s, capped) while the structural hash is unchanged, and
  resets to the fast base interval on any detected change or explicit
  `extractNow`/command.
- **OSLogReader.swift**: reuse a single `OSLogStore` (created once, released on
  stop) instead of allocating one per poll; poll interval raised 500ms -> 1000ms.
- **DisplayLinkFPSMonitor.swift**: report interval raised 0.5s -> 1.0s.

Behavior is unchanged while a client is connected.

## Tests

New/updated unit tests (all deterministic, FakeTimer-driven where relevant):
- Client-presence toggles on first/last client; HTTP-only connection close does
  not toggle presence.
- Debouncer backoff progression (200 -> 400 -> 800ms cap), reset-on-change, and
  reset-on-`extractNow`.
- OSLogStore reuse and the raised interval.
- Vectorized unmask matches a reference XOR (multi-size, single-byte, empty,
  sliced `Data`).

## Validation

- `./scripts/ios/swift-build.sh` — all packages build.
- `./scripts/ios/swift-test.sh` — all packages pass (control-proxy: 466 tests).
- SwiftLint: no new violations (force_unwrapping clean).
- SwiftFormat (0.54.6, repo-pinned): zero net new violations vs baseline.

Closes #5477
