### PR TITLE
perf(android): remove in-production debug serialization/scans from CtrlProxy hierarchy path

### DIFF
--- a/android/control-proxy/src/main/kotlin/dev/jasonpearson/automobile/ctrlproxy/CtrlProxy.kt
+++ b/android/control-proxy/src/main/kotlin/dev/jasonpearson/automobile/ctrlproxy/CtrlProxy.kt
@@ -1925,14 +1925,6 @@ class CtrlProxy : AccessibilityService(), CtrlProxyActions {
     }
 
     try {
-      // Log accessibility events for debugging
-      if (event.packageName?.toString()?.contains("playground") == true) {
-        Log.d(
-          TAG,
-          "A11Y event type=${event.eventType} class=${event.className} pkg=${event.packageName} text=${event.text} contentChange=${event.contentChangeTypes} action=${event.action}",
-        )
-      }
-
       if (event.eventType == AccessibilityEvent.TYPE_WINDOW_STATE_CHANGED) {
         lastWindowClassName = event.className?.toString()
       }
@@ -2804,14 +2796,6 @@ class CtrlProxy : AccessibilityService(), CtrlProxyActions {
     try {
       val jsonString =
         perfProvider.track("serializeHierarchy") { jsonCompact.encodeToString(hierarchy) }
-
-      // Debug: Check if text labels are in the serialized hierarchy
-      val hasTapText = jsonString.contains("\"text\":\"Tap\"")
-      val hasDiscoverText = jsonString.contains("\"text\":\"Discover\"")
-      Log.d(
-        TAG,
-        "[BROADCAST] Hierarchy contains: Tap=$hasTapText, Discover=$hasDiscoverText, size=${jsonString.length}",
-      )
 
       val messageBuilder: (kotlinx.serialization.json.JsonElement?) -> String = { perfTiming ->
         buildString {

--- a/android/control-proxy/src/main/kotlin/dev/jasonpearson/automobile/ctrlproxy/ViewHierarchyExtractor.kt
+++ b/android/control-proxy/src/main/kotlin/dev/jasonpearson/automobile/ctrlproxy/ViewHierarchyExtractor.kt
@@ -107,11 +107,6 @@ class ViewHierarchyExtractor(private val recompositionStore: RecompositionStore?
           Log.d(TAG, "[PROCESS] After optimizeHierarchy: ${optimizedList?.size} elements")
 
           val wrappedElement = optimizedList?.let { wrapOptimizedElements(it) }
-          val wrappedTextCount = wrappedElement?.let { countTextNodes(it) } ?: 0
-          Log.d(
-            TAG,
-            "[PROCESS] After wrapOptimizedElements: hasElement=${wrappedElement != null}, textNodes=$wrappedTextCount",
-          )
 
           // Single-window occlusion filtering is intentionally skipped.
           // After optimizeHierarchy promotes children from bounds-only wrappers, the tree
@@ -292,14 +287,7 @@ class ViewHierarchyExtractor(private val recompositionStore: RecompositionStore?
           } else {
             element?.let {
               val optimizedList = optimizeHierarchy(it)
-              val wrapped = wrapOptimizedElements(optimizedList)
-              // Debug: Check if Tab elements have text children
-              if (wrapped != null && window.isActive) {
-                val wrappedJson = json.encodeToString(serializer<UIElementInfo>(), wrapped)
-                val hasTabText = wrappedJson.contains("\"text\":\"Tap\"")
-                Log.d(TAG, "[WRAP-ACTIVE] Has Tap text after wrap: $hasTabText")
-              }
-              wrapped
+              wrapOptimizedElements(optimizedList)
             }
           }
         val packageName = rootNode.packageName?.toString()
@@ -418,13 +406,6 @@ class ViewHierarchyExtractor(private val recompositionStore: RecompositionStore?
             if (primaryAppWindowId != null) it.windowId == primaryAppWindowId else it.isActive
           }
           ?.hierarchy ?: mainHierarchy
-
-      // Debug: Check if Tab text survives occlusion filtering
-      mainHierarchy?.let {
-        val filteredJson = json.encodeToString(serializer<UIElementInfo>(), it)
-        val hasTabText = filteredJson.contains("\"text\":\"Tap\"")
-        Log.d(TAG, "[OCCLUSION-FILTERED] Has Tap text after filtering: $hasTabText")
-      }
     }
 
     if (windowEntries.isEmpty()) {
@@ -1382,36 +1363,6 @@ class ViewHierarchyExtractor(private val recompositionStore: RecompositionStore?
       }
       else -> false
     }
-  }
-
-  /** Count text nodes recursively in hierarchy */
-  private fun countTextNodes(element: UIElementInfo): Int {
-    val hasText = if (!element.text.isNullOrBlank()) 1 else 0
-    val childrenCount =
-      element.node?.let { node ->
-        when (node) {
-          is JsonObject -> {
-            try {
-              val child = json.decodeFromJsonElement(serializer<UIElementInfo>(), node)
-              countTextNodes(child)
-            } catch (e: Exception) {
-              0
-            }
-          }
-          is JsonArray -> {
-            node.jsonArray.sumOf { childJson ->
-              try {
-                val child = json.decodeFromJsonElement(serializer<UIElementInfo>(), childJson)
-                countTextNodes(child)
-              } catch (e: Exception) {
-                0
-              }
-            }
-          }
-          else -> 0
-        }
-      } ?: 0
-    return hasText + childrenCount
   }
 
   /** Recursively optimize node children (handles both single element and array). */


### PR DESCRIPTION
## Summary

Removes debug-only work from the CtrlProxy hierarchy hot path. `Log.d`
arguments are always evaluated regardless of log level, so these full-tree
serializations and large-string `contains` scans ran in production on every
broadcast / snapshot / accessibility event.

Closes #5466

## Sites changed (all deleted — pure removal of dead-in-prod diagnostics)

1. **`CtrlProxy.broadcastHierarchyUpdate`** — removed the two full-payload
   `jsonString.contains("\"text\":\"Tap\"")` / `contains("\"text\":\"Discover\"")`
   scans and the `[BROADCAST]` `Log.d` they fed.
2. **`ViewHierarchyExtractor` active-window wrap** — removed the full-tree
   `json.encodeToString(...)` + `contains` for the `[WRAP-ACTIVE]` `Log.d`.
3. **`ViewHierarchyExtractor` occlusion path** — removed the full-tree
   `json.encodeToString(...)` + `contains` for the `[OCCLUSION-FILTERED]` `Log.d`.
4. **`ViewHierarchyExtractor.extractFromActiveWindow`** — removed the
   `countTextNodes(...)` whole-tree decode used only by the `[PROCESS]`
   `textNodes` `Log.d`, and deleted the now-unused `countTextNodes` helper.
5. **`CtrlProxy.onAccessibilityEvent`** — removed the per-event
   `packageName?.contains("playground")` check and its large interpolated
   A11Y-event `Log.d`.

All sites were **deleted** rather than guarded (they were pure diagnostics
with no functional purpose). No new payload-building `Log.d` was introduced.

## Functional output unchanged

This PR only removes diagnostic work. No code that produces the hierarchy sent
to clients, the extraction result, or any wire frame was touched — the
functional output is byte-for-byte unchanged. `wrapOptimizedElements` /
`optimizeHierarchy` / `mainHierarchy` return values are preserved exactly; only
the surrounding debug reads were removed.

## Tests

- `android/gradlew -p android :control-proxy:testDebugUnitTest` — **BUILD SUCCESSFUL** (full control-proxy suite passes).
- ktfmt applied to both touched files.
- Grepped the test dir: no test asserted on any of the removed log lines.

Diff touches only `CtrlProxy.kt` and `ViewHierarchyExtractor.kt`.
