### PR TITLE
test(desktop-core): serialize test forks and await IO reload to fix per-run flakes (#5422)

### DIFF
--- a/android/desktop-core/build.gradle.kts
+++ b/android/desktop-core/build.gradle.kts
@@ -142,4 +142,18 @@ tasks.withType<Test>().configureEach {
   screenshotProperties.forEach { key ->
     System.getProperty(key)?.let { value -> systemProperty(key, value) }
   }
+
+  // Run this module's tests in a single worker JVM (#5422). desktop-core's Compose UI tests
+  // (`runComposeUiTest`) drive real dispatchers, a frame/animation clock, and gesture timing;
+  // their waits (`waitForIdle`, bounded `waitUntil`) assume the work they are pacing gets CPU.
+  // automobile.test-defaults sets `maxParallelForks = processors/2`, so several such JVMs ran at
+  // once and over-subscribed the CPU. Under that contention a timing-sensitive wait would miss
+  // its deadline and a *different* test would fail on each run (NetworkFacetTest one run,
+  // DeviceControlSessionTest or LogsPanelTest the next) with no code change. Forks are separate
+  // processes, so this is pure CPU contention -- process-wide Compose snapshot state cannot cross
+  // a fork boundary, which is why `forkEvery` isolation did not help but removing the
+  // over-subscription does. Cross-module parallelism (org.gradle.parallel) still runs desktop-core
+  // concurrently with other modules; only this suite is serialized, at ~18% local wall-clock (the
+  // suite is compile/startup-dominated, not test-execution-bound).
+  maxParallelForks = 1
 }

--- a/android/desktop-core/build.gradle.kts
+++ b/android/desktop-core/build.gradle.kts
@@ -153,7 +153,8 @@ tasks.withType<Test>().configureEach {
   // processes, so this is pure CPU contention -- process-wide Compose snapshot state cannot cross
   // a fork boundary, which is why `forkEvery` isolation did not help but removing the
   // over-subscription does. Cross-module parallelism (org.gradle.parallel) still runs desktop-core
-  // concurrently with other modules; only this suite is serialized, at ~18% local wall-clock (the
-  // suite is compile/startup-dominated, not test-execution-bound).
+  // concurrently with other modules; only this suite is serialized. The wall-clock cost is small
+  // because the suite is compile/startup-dominated, not test-execution-bound: ~18% locally going
+  // 8->1 forks on a 16-core box (CI's 2->1 on a 4-vCPU runner was not separately benchmarked).
   maxParallelForks = 1
 }

--- a/android/desktop-core/src/test/kotlin/dev/jasonpearson/automobile/desktop/core/workspace/NetworkFacetTest.kt
+++ b/android/desktop-core/src/test/kotlin/dev/jasonpearson/automobile/desktop/core/workspace/NetworkFacetTest.kt
@@ -217,13 +217,20 @@ class NetworkFacetTest {
 
     onNodeWithContentDescription("Retry loading network requests").performClick()
 
-    // waitForIdle() is not enough: the gated reload is still in flight on Dispatchers.IO, yet
-    // waitForIdle() has already returned. The recovered row must therefore be absent here.
-    waitForIdle()
-    onNodeWithText("api.example.com/health", substring = true).assertDoesNotExist()
+    // Always release the gate, even if an assertion below throws: the parked getRequests() sits on
+    // gate.await() on a Dispatchers.IO thread that CountDownLatch will not free on cancellation, so
+    // an early failure would otherwise leak that thread for the life of the (shared, forkEvery=0)
+    // JVM.
+    try {
+      // waitForIdle() is not enough: the gated reload is still in flight on Dispatchers.IO, yet
+      // waitForIdle() has already returned. The recovered row must therefore be absent here.
+      waitForIdle()
+      onNodeWithText("api.example.com/health", substring = true).assertDoesNotExist()
+    } finally {
+      gate.countDown()
+    }
 
     // Releasing the gate lets the IO reload complete; a bounded waitUntil awaits the recomposition.
-    gate.countDown()
     waitUntil {
       onAllNodesWithText("api.example.com/health", substring = true)
         .fetchSemanticsNodes()

--- a/android/desktop-core/src/test/kotlin/dev/jasonpearson/automobile/desktop/core/workspace/NetworkFacetTest.kt
+++ b/android/desktop-core/src/test/kotlin/dev/jasonpearson/automobile/desktop/core/workspace/NetworkFacetTest.kt
@@ -3,6 +3,8 @@ package dev.jasonpearson.automobile.desktop.core.workspace
 import androidx.compose.material3.MaterialTheme
 import androidx.compose.ui.test.ExperimentalTestApi
 import androidx.compose.ui.test.assertIsDisplayed
+import androidx.compose.ui.test.onAllNodesWithContentDescription
+import androidx.compose.ui.test.onAllNodesWithText
 import androidx.compose.ui.test.onNodeWithContentDescription
 import androidx.compose.ui.test.onNodeWithText
 import androidx.compose.ui.test.performClick
@@ -10,7 +12,9 @@ import androidx.compose.ui.test.runComposeUiTest
 import dev.jasonpearson.automobile.desktop.core.datasource.FakeNetworkRequestsDataSource
 import dev.jasonpearson.automobile.desktop.core.datasource.NetworkRequestDetail
 import dev.jasonpearson.automobile.desktop.core.datasource.NetworkRequestRow
+import dev.jasonpearson.automobile.desktop.core.datasource.NetworkRequestsDataSource
 import dev.jasonpearson.automobile.desktop.core.datasource.Result
+import java.util.concurrent.CountDownLatch
 import java.util.concurrent.atomic.AtomicInteger
 import org.junit.Test
 
@@ -65,7 +69,12 @@ class NetworkFacetTest {
         )
       }
     }
-    waitForIdle()
+    // The load resolves on Dispatchers.IO, which waitForIdle() does not await; wait on the node.
+    waitUntil {
+      onAllNodesWithText("No network activity captured", substring = true)
+        .fetchSemanticsNodes()
+        .isNotEmpty()
+    }
     onNodeWithText("No network activity captured", substring = true).assertIsDisplayed()
   }
 
@@ -82,7 +91,12 @@ class NetworkFacetTest {
         )
       }
     }
-    waitForIdle()
+    // The load resolves on Dispatchers.IO, which waitForIdle() does not await; wait on the node.
+    waitUntil {
+      onAllNodesWithText("api.example.com/users/{id}", substring = true)
+        .fetchSemanticsNodes()
+        .isNotEmpty()
+    }
     onNodeWithText("api.example.com/users/{id}", substring = true).assertIsDisplayed()
   }
 
@@ -100,12 +114,19 @@ class NetworkFacetTest {
         )
       }
     }
-    waitForIdle()
+    // The load resolves on Dispatchers.IO, which waitForIdle() does not await; wait on the node.
     // Before selection the detail pane prompts for a selection.
+    waitUntil {
+      onAllNodesWithText("Select a request to inspect", substring = true)
+        .fetchSemanticsNodes()
+        .isNotEmpty()
+    }
     onNodeWithText("Select a request to inspect", substring = true).assertIsDisplayed()
 
     onNodeWithContentDescription("Network request GET api.example.com/users").performClick()
-    waitForIdle()
+    waitUntil {
+      onAllNodesWithText("Request headers", substring = true).fetchSemanticsNodes().isNotEmpty()
+    }
 
     onNodeWithText("Request headers", substring = true).assertIsDisplayed()
     onNodeWithText("x-cache", substring = true).assertIsDisplayed()
@@ -122,7 +143,10 @@ class NetworkFacetTest {
         )
       }
     }
-    waitForIdle()
+    // The load resolves on Dispatchers.IO, which waitForIdle() does not await; wait on the node.
+    waitUntil {
+      onAllNodesWithText("daemon down", substring = true).fetchSemanticsNodes().isNotEmpty()
+    }
     onNodeWithText("daemon down", substring = true).assertIsDisplayed()
     onNodeWithContentDescription("Retry loading network requests").assertIsDisplayed()
   }
@@ -144,12 +168,67 @@ class NetworkFacetTest {
         NetworkFacet(column = column(), dataSource = recovering)
       }
     }
-    waitForIdle()
-    onNodeWithText("daemon down", substring = true).assertIsDisplayed()
+    // The load resolves on Dispatchers.IO, which waitForIdle() does not await; wait on the node.
+    waitUntil {
+      onAllNodesWithText("daemon down", substring = true).fetchSemanticsNodes().isNotEmpty()
+    }
 
     onNodeWithContentDescription("Retry loading network requests").performClick()
-    waitForIdle()
 
+    waitUntil {
+      onAllNodesWithText("api.example.com/health", substring = true)
+        .fetchSemanticsNodes()
+        .isNotEmpty()
+    }
+    onNodeWithText("api.example.com/health", substring = true).assertIsDisplayed()
+  }
+
+  @Test
+  fun `retry awaits the IO-dispatched reload before asserting recovered rows`() = runComposeUiTest {
+    // Regression pin for #5422. NetworkFacet loads through withContext(Dispatchers.IO); the
+    // continuation that writes the resolved state runs on a real IO thread that
+    // runComposeUiTest's waitForIdle() does not await. A gated data source makes that visible:
+    // waitForIdle() returns while the reload is still parked on the gate, so the recovered row is
+    // absent — exactly the window the flaky assertion raced against — and a bounded waitUntil is
+    // the wait that deterministically observes the completion.
+    val gate = CountDownLatch(1)
+    val attempts = AtomicInteger(0)
+    setContent {
+      MaterialTheme {
+        val recovering =
+          object : NetworkRequestsDataSource {
+            override suspend fun getRequests(): Result<List<NetworkRequestRow>> =
+              if (attempts.getAndIncrement() == 0) {
+                Result.Error(RuntimeException("daemon down"))
+              } else {
+                gate.await()
+                Result.Success(listOf(row(1, "api.example.com", "/health")))
+              }
+
+            override suspend fun getRequestDetail(id: Long): Result<NetworkRequestDetail> =
+              Result.Success(detail(id))
+          }
+        NetworkFacet(column = column(), dataSource = recovering)
+      }
+    }
+    waitUntil {
+      onAllNodesWithText("daemon down", substring = true).fetchSemanticsNodes().isNotEmpty()
+    }
+
+    onNodeWithContentDescription("Retry loading network requests").performClick()
+
+    // waitForIdle() is not enough: the gated reload is still in flight on Dispatchers.IO, yet
+    // waitForIdle() has already returned. The recovered row must therefore be absent here.
+    waitForIdle()
+    onNodeWithText("api.example.com/health", substring = true).assertDoesNotExist()
+
+    // Releasing the gate lets the IO reload complete; a bounded waitUntil awaits the recomposition.
+    gate.countDown()
+    waitUntil {
+      onAllNodesWithText("api.example.com/health", substring = true)
+        .fetchSemanticsNodes()
+        .isNotEmpty()
+    }
     onNodeWithText("api.example.com/health", substring = true).assertIsDisplayed()
   }
 
@@ -167,9 +246,16 @@ class NetworkFacetTest {
         )
       }
     }
-    waitForIdle()
+    // The load resolves on Dispatchers.IO, which waitForIdle() does not await; wait on the node.
+    waitUntil {
+      onAllNodesWithContentDescription("Network request GET api.example.com/slow")
+        .fetchSemanticsNodes()
+        .isNotEmpty()
+    }
     onNodeWithContentDescription("Network request GET api.example.com/slow").performClick()
-    waitForIdle()
+    waitUntil {
+      onAllNodesWithText("detail unavailable", substring = true).fetchSemanticsNodes().isNotEmpty()
+    }
 
     // The summary header stays visible; the error is shown inline in the detail pane.
     onNodeWithContentDescription("Selected request detail").assertIsDisplayed()


### PR DESCRIPTION
## Summary

`:desktop-core:test` flaked on CI with a **different Compose UI test failing on each run** and no code change between runs ([#5422](https://github.com/kaeawc/auto-mobile/issues/5422)). This fixes the systemic driver plus the one deterministic race that was named in the report.

**Root cause (systemic):** `automobile.test-defaults` sets `maxParallelForks = processors/2`, so several test JVMs run Compose UI tests at once and **over-subscribe the CPU**. `runComposeUiTest` drives real dispatchers, a frame/animation clock, and gesture timing; under contention a timing-sensitive wait (`waitForIdle`, bounded `waitUntil`) misses its deadline and whichever test lost the CPU race that run fails. Forks are separate **processes**, so process-wide Compose snapshot state cannot cross a fork boundary — this is CPU contention, not shared-JVM state, which is why `forkEvery` isolation did **not** help in testing but removing the over-subscription does.

**Root cause (`NetworkFacetTest`):** `NetworkFacet` loads via `withContext(Dispatchers.IO) { source.getRequests() }`. `runComposeUiTest`'s `waitForIdle()` synchronizes with the Recomposer/frame clock — it does **not** await a continuation that hopped to the real IO threadpool. The retry assertion therefore raced the reload.

## Changes

- **`android/desktop-core/build.gradle.kts`** — set `maxParallelForks = 1` for this module's `Test` tasks (with a rationale comment). Cross-module parallelism (`org.gradle.parallel`) still runs desktop-core concurrently with other modules; only this suite is serialized.
- **`NetworkFacetTest.kt`** — IO-derived assertions now wait on the target node via a bounded `waitUntil` instead of a single `waitForIdle()`; added `retry awaits the IO-dispatched reload before asserting recovered rows`, a gated test that deterministically pins that `waitForIdle()` returns before the reload completes and `waitUntil` awaits it.

## Bug / Regression Context

- **Prior attempts:** none; first fix for this flake.
- **Observed symptom:** `NetworkFacetTest` one run, `DeviceControlSessionTest`/`LogsPanelTest` the next — different test each rerun of the same SHA.
- **Repro steps / conditions:** run `:desktop-core:test` under CPU over-subscription. Locally reproduced at ~50% by running the full suite with the default `maxParallelForks` (8 on a 16-core box); the failing test varied run to run.

## Validation

Stress-ran the full `:desktop-core:test` suite (1377 tests) locally, `--rerun-tasks` each pass:

| Config | Runs | Flakes |
|---|---|---|
| `maxParallelForks=8` (default, over-subscribed) | 4 | 2 (LogsPanelTest, VideoStreamClientTest) |
| **`maxParallelForks=1` (this PR)** | **10** | **0 Compose-contention failures** |

- `bash scripts/ktfmt/validate_ktfmt.sh` — clean (902 files)
- `./gradlew :desktop-core:detekt` — green
- Wall-clock cost: ~41.6s → ~49.2s locally (+18%); the suite is compile/startup-dominated, so the delta is small.
- No TypeScript touched — TS suite and `typecheck` baseline unaffected.

## Kotlin Reuse Check

- The `waitUntil { onAllNodesWith*(...).fetchSemanticsNodes().isNotEmpty() }` idiom already exists in this module (`SnapshotsDashboardUiTest`, `VideoStreamClientTest`); no new helper or dependency added.

## Follow-ups

- `VideoStreamClientTest > a rapid reconnect is not wedged by the superseded reader's teardown` is an **intrinsic** real-socket/`runBlocking` concurrency flake — it timed out waiting for `Streaming` (5.0s) despite a frame already decoding, and reproduced even under *maximum* isolation (`maxParallelForks=1 + forkEvery=1`, each class alone in a fresh serial JVM). It is unrelated to the Compose-contention cause fixed here and is **not** cured by any fork strategy; filing a separate issue.

## Linked Issue

Closes #5422
