### PR TITLE
perf(android): narrow CtrlProxy accessibility eventTypes and add notificationTimeout

### DIFF
--- a/android/control-proxy/src/main/kotlin/dev/jasonpearson/automobile/ctrlproxy/CtrlProxy.kt
+++ b/android/control-proxy/src/main/kotlin/dev/jasonpearson/automobile/ctrlproxy/CtrlProxy.kt
@@ -161,6 +161,53 @@ internal fun nodeActionId(action: String): Int? =
     else -> null
   }
 
+/**
+ * The interaction [CtrlProxy.onAccessibilityEvent] records for an accessibility event type. This is
+ * the single classification primitive shared by the handler's `when` and by the derivation of the
+ * subscribed event-type mask (issue #5467), so the "handled set" and the "subscribed set" cannot
+ * drift — a new dispatch branch here automatically flows into [CtrlProxy.HANDLED_EVENT_TYPES].
+ */
+internal enum class InteractionDispatch {
+  TAP,
+  LONG_PRESS,
+  CONTENT_CHANGED,
+  NAVIGATE,
+  SELECT,
+  INPUT_TEXT,
+  SCROLL,
+}
+
+/**
+ * The interaction the handler's `when` performs for [eventType], or null if it ignores the type.
+ */
+internal fun interactionDispatchFor(eventType: Int): InteractionDispatch? =
+  when (eventType) {
+    AccessibilityEvent.TYPE_VIEW_CLICKED -> InteractionDispatch.TAP
+    AccessibilityEvent.TYPE_VIEW_LONG_CLICKED -> InteractionDispatch.LONG_PRESS
+    AccessibilityEvent.TYPE_WINDOW_CONTENT_CHANGED -> InteractionDispatch.CONTENT_CHANGED
+    AccessibilityEvent.TYPE_WINDOW_STATE_CHANGED -> InteractionDispatch.NAVIGATE
+    AccessibilityEvent.TYPE_VIEW_SELECTED -> InteractionDispatch.SELECT
+    AccessibilityEvent.TYPE_VIEW_TEXT_CHANGED -> InteractionDispatch.INPUT_TEXT
+    AccessibilityEvent.TYPE_VIEW_SCROLLED -> InteractionDispatch.SCROLL
+    else -> null
+  }
+
+/** True when the handler feeds [eventType] to the hierarchy debouncer for a fresh capture. */
+internal fun triggersHierarchyRefresh(eventType: Int): Boolean =
+  when (eventType) {
+    AccessibilityEvent.TYPE_WINDOW_CONTENT_CHANGED,
+    AccessibilityEvent.TYPE_WINDOW_STATE_CHANGED,
+    AccessibilityEvent.TYPE_WINDOWS_CHANGED,
+    AccessibilityEvent.TYPE_VIEW_TEXT_CHANGED -> true
+    else -> false
+  }
+
+/**
+ * True when [CtrlProxy.onAccessibilityEvent] acts on [eventType] at all (interaction or refresh).
+ */
+internal fun isHandledEventType(eventType: Int): Boolean =
+  interactionDispatchFor(eventType) != null || triggersHierarchyRefresh(eventType)
+
 internal fun navigationEventResponse(event: TimestampedNavigationEvent): NavigationEventResponse =
   NavigationEventResponse(
     timestamp = event.timestamp,
@@ -189,30 +236,81 @@ class CtrlProxy : AccessibilityService(), CtrlProxyActions {
     private const val DEFAULT_HIERARCHY_BROADCAST_INTERVAL_MS = 250L
 
     /**
-     * The exact set of accessibility event types [onAccessibilityEvent] dispatches on (its `when`
-     * branches plus the hierarchy-refresh `if`). This is the single source of truth: the OS
-     * subscription mask [SUBSCRIBED_EVENT_TYPES_MASK] is derived from exactly this set, so the
-     * "handled set" and the "subscribed set" cannot drift. If a new handler branch is added, add
-     * its type here too (the unit test in CtrlProxyAccessibilityEventTypesTest enforces this).
+     * The universe of accessibility event types we classify for subscription. [HANDLED_EVENT_TYPES]
+     * is DERIVED by filtering this through the shared [isHandledEventType] classifier, so the
+     * app-dispatched subscription set is computed from the exact predicate the handler dispatches
+     * on — it cannot be hand-mis-copied out of sync with [interactionDispatchFor] /
+     * [triggersHierarchyRefresh]. Extend this only if a handler branch ever dispatches on a type
+     * not already listed here.
      */
-    val HANDLED_EVENT_TYPES: IntArray =
+    @Suppress("DEPRECATION")
+    private val CANDIDATE_EVENT_TYPES: IntArray =
       intArrayOf(
         AccessibilityEvent.TYPE_VIEW_CLICKED,
         AccessibilityEvent.TYPE_VIEW_LONG_CLICKED,
-        AccessibilityEvent.TYPE_WINDOW_CONTENT_CHANGED,
-        AccessibilityEvent.TYPE_WINDOW_STATE_CHANGED,
-        AccessibilityEvent.TYPE_WINDOWS_CHANGED,
-        AccessibilityEvent.TYPE_VIEW_TEXT_CHANGED,
-        AccessibilityEvent.TYPE_VIEW_SCROLLED,
         AccessibilityEvent.TYPE_VIEW_SELECTED,
+        AccessibilityEvent.TYPE_VIEW_FOCUSED,
+        AccessibilityEvent.TYPE_VIEW_TEXT_CHANGED,
+        AccessibilityEvent.TYPE_WINDOW_STATE_CHANGED,
+        AccessibilityEvent.TYPE_NOTIFICATION_STATE_CHANGED,
+        AccessibilityEvent.TYPE_VIEW_HOVER_ENTER,
+        AccessibilityEvent.TYPE_VIEW_HOVER_EXIT,
+        AccessibilityEvent.TYPE_TOUCH_EXPLORATION_GESTURE_START,
+        AccessibilityEvent.TYPE_TOUCH_EXPLORATION_GESTURE_END,
+        AccessibilityEvent.TYPE_WINDOW_CONTENT_CHANGED,
+        AccessibilityEvent.TYPE_VIEW_SCROLLED,
+        AccessibilityEvent.TYPE_VIEW_TEXT_SELECTION_CHANGED,
+        AccessibilityEvent.TYPE_ANNOUNCEMENT,
+        AccessibilityEvent.TYPE_VIEW_ACCESSIBILITY_FOCUSED,
+        AccessibilityEvent.TYPE_VIEW_ACCESSIBILITY_FOCUS_CLEARED,
+        AccessibilityEvent.TYPE_VIEW_TEXT_TRAVERSED_AT_MOVEMENT_GRANULARITY,
+        AccessibilityEvent.TYPE_GESTURE_DETECTION_START,
+        AccessibilityEvent.TYPE_GESTURE_DETECTION_END,
+        AccessibilityEvent.TYPE_TOUCH_INTERACTION_START,
+        AccessibilityEvent.TYPE_TOUCH_INTERACTION_END,
+        AccessibilityEvent.TYPE_WINDOWS_CHANGED,
+        AccessibilityEvent.TYPE_VIEW_CONTEXT_CLICKED,
+        AccessibilityEvent.TYPE_ASSIST_READING_CONTEXT,
+        AccessibilityEvent.TYPE_SPEECH_STATE_CHANGE,
+        AccessibilityEvent.TYPE_VIEW_TARGETED_BY_SCROLL,
       )
 
     /**
-     * OS-level `eventTypes` subscription mask: exactly the union of [HANDLED_EVENT_TYPES],
-     * replacing the former `TYPES_ALL_MASK`. The OS no longer delivers events (hover,
-     * touch-exploration, focus, gesture-detection, announcement, etc.) that the handler only drops.
+     * App-dispatched event types [onAccessibilityEvent] acts on, DERIVED from the shared
+     * [isHandledEventType] classifier over [CANDIDATE_EVENT_TYPES] rather than hand-listed, so it
+     * stays in lockstep with the handler's `when` / hierarchy-refresh `if`.
      */
-    val SUBSCRIBED_EVENT_TYPES_MASK: Int = HANDLED_EVENT_TYPES.fold(0) { acc, type -> acc or type }
+    val HANDLED_EVENT_TYPES: IntArray =
+      CANDIDATE_EVENT_TYPES.filter { isHandledEventType(it) }.toIntArray()
+
+    /**
+     * Event types the platform `AccessibilityCache` / `AccessibilityInteractionClient` consume to
+     * keep their node & focus caches coherent. We MUST stay subscribed to these even though
+     * [onAccessibilityEvent] ignores them: the cache only invalidates its focus/node state for an
+     * event when the service is subscribed to that event, so after a focus-only transition an
+     * unsubscribed service would let `rootInActiveWindow` / `findFocus` return STALE nodes to
+     * `observe` and `handleGetCurrentFocus` — the core AutoMobile read paths. Cross-checked against
+     * AOSP `AccessibilityCache.onAccessibilityEvent`; the window/content/scroll/text/click/select
+     * types that also invalidate the cache are already in [HANDLED_EVENT_TYPES], and the union
+     * below absorbs the overlap.
+     */
+    val FRAMEWORK_CACHE_EVENT_TYPES: IntArray =
+      intArrayOf(
+        AccessibilityEvent.TYPE_VIEW_FOCUSED,
+        AccessibilityEvent.TYPE_VIEW_ACCESSIBILITY_FOCUSED,
+        AccessibilityEvent.TYPE_VIEW_ACCESSIBILITY_FOCUS_CLEARED,
+        AccessibilityEvent.TYPE_VIEW_TEXT_SELECTION_CHANGED,
+      )
+
+    /**
+     * OS-level `eventTypes` subscription mask: the union of [HANDLED_EVENT_TYPES] and
+     * [FRAMEWORK_CACHE_EVENT_TYPES], replacing the former `TYPES_ALL_MASK`. High-frequency noise
+     * the service never consumes — hover, touch-exploration, touch-interaction, gesture-detection,
+     * announcement, notification-state, text-traversal, context-click, speech-state, etc. — is no
+     * longer delivered.
+     */
+    val SUBSCRIBED_EVENT_TYPES_MASK: Int =
+      (HANDLED_EVENT_TYPES + FRAMEWORK_CACHE_EVENT_TYPES).fold(0) { acc, type -> acc or type }
 
     /**
      * `notificationTimeout` coalesces bursts of same-type events at the OS boundary before
@@ -979,9 +1077,9 @@ class CtrlProxy : AccessibilityService(), CtrlProxyActions {
     super.onServiceConnected()
     Log.d(TAG, "onServiceConnected")
 
-    // Subscribe to exactly the event types onAccessibilityEvent handles
-    // (SUBSCRIBED_EVENT_TYPES_MASK)
-    // instead of TYPES_ALL_MASK, so the OS stops delivering events we only drop.
+    // Subscribe to SUBSCRIBED_EVENT_TYPES_MASK (the handled set plus the framework cache-coherence
+    // set) instead of TYPES_ALL_MASK, so the OS stops delivering high-frequency events we only drop
+    // while the AccessibilityCache still invalidates focus/node state correctly.
     // notificationTimeout
     // coalesces same-type floods at the OS boundary. flagIncludeNotImportantViews exposes
     // interactive
@@ -1969,18 +2067,17 @@ class CtrlProxy : AccessibilityService(), CtrlProxyActions {
         lastWindowClassName = event.className?.toString()
       }
 
-      // Broadcast interaction events for telemetry tracking.
-      // Also track TYPE_VIEW_ACCESSIBILITY_FOCUSED which fires when Compose
-      // moves accessibility focus after a tap (more reliable than TYPE_VIEW_CLICKED
-      // for Compose UIs). Debounce at 200ms to avoid duplicate events.
-      when (event.eventType) {
-        AccessibilityEvent.TYPE_VIEW_CLICKED -> recordInteractionEvent(event, "tap")
-        AccessibilityEvent.TYPE_VIEW_LONG_CLICKED -> recordInteractionEvent(event, "longPress")
+      // Broadcast interaction events for telemetry tracking. Classification is routed through the
+      // shared [interactionDispatchFor] so the subscribed event-type mask (derived from the same
+      // classifier) can never drift from what this `when` actually acts on.
+      when (interactionDispatchFor(event.eventType)) {
+        InteractionDispatch.TAP -> recordInteractionEvent(event, "tap")
+        InteractionDispatch.LONG_PRESS -> recordInteractionEvent(event, "longPress")
         // Compose doesn't fire TYPE_VIEW_CLICKED — detect taps via content changes
         // on clickable elements. CONTENT_CHANGE_TYPE_STATE_DESCRIPTION (64) fires
         // when Compose state changes (e.g., button click updates counter).
         // CONTENT_CHANGE_TYPE_CONTENT_DESCRIPTION (4) fires on many Compose interactions.
-        AccessibilityEvent.TYPE_WINDOW_CONTENT_CHANGED -> {
+        InteractionDispatch.CONTENT_CHANGED -> {
           if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.P) {
             val ct = event.contentChangeTypes
             // State description change = likely user interaction (Compose state update)
@@ -1989,29 +2086,25 @@ class CtrlProxy : AccessibilityService(), CtrlProxyActions {
             }
           }
         }
-        AccessibilityEvent.TYPE_WINDOW_STATE_CHANGED -> recordInteractionEvent(event, "navigate")
-        AccessibilityEvent.TYPE_VIEW_SELECTED -> recordInteractionEvent(event, "select")
-        AccessibilityEvent.TYPE_VIEW_TEXT_CHANGED -> {
+        InteractionDispatch.NAVIGATE -> recordInteractionEvent(event, "navigate")
+        InteractionDispatch.SELECT -> recordInteractionEvent(event, "select")
+        InteractionDispatch.INPUT_TEXT -> {
           val now = System.currentTimeMillis()
           if (now - lastInputTextBroadcastMs >= inputTextDebounceMs) {
             lastInputTextBroadcastMs = now
             recordInteractionEvent(event, "inputText")
           }
         }
-        AccessibilityEvent.TYPE_VIEW_SCROLLED -> {
+        InteractionDispatch.SCROLL -> {
           frameContext.incrementAndGet()
           recordDebouncedScroll(event)
         }
+        null -> {} // event type this service does not act on
       }
 
-      // Delegate to the smart debouncer for content/window changes
-      // The debouncer uses structural hash comparison to detect animation vs real changes
-      if (
-        event.eventType == AccessibilityEvent.TYPE_WINDOW_CONTENT_CHANGED ||
-          event.eventType == AccessibilityEvent.TYPE_WINDOW_STATE_CHANGED ||
-          event.eventType == AccessibilityEvent.TYPE_WINDOWS_CHANGED ||
-          event.eventType == AccessibilityEvent.TYPE_VIEW_TEXT_CHANGED
-      ) {
+      // Delegate to the smart debouncer for content/window changes (same shared classifier).
+      // The debouncer uses structural hash comparison to detect animation vs real changes.
+      if (triggersHierarchyRefresh(event.eventType)) {
         frameContext.incrementAndGet()
         if (::hierarchyDebouncer.isInitialized) {
           hierarchyDebouncer.onAccessibilityEvent()

--- a/android/control-proxy/src/main/kotlin/dev/jasonpearson/automobile/ctrlproxy/CtrlProxy.kt
+++ b/android/control-proxy/src/main/kotlin/dev/jasonpearson/automobile/ctrlproxy/CtrlProxy.kt
@@ -188,6 +188,41 @@ class CtrlProxy : AccessibilityService(), CtrlProxyActions {
     private const val HIERARCHY_FILE_NAME = "latest_hierarchy.json"
     private const val DEFAULT_HIERARCHY_BROADCAST_INTERVAL_MS = 250L
 
+    /**
+     * The exact set of accessibility event types [onAccessibilityEvent] dispatches on (its `when`
+     * branches plus the hierarchy-refresh `if`). This is the single source of truth: the OS
+     * subscription mask [SUBSCRIBED_EVENT_TYPES_MASK] is derived from exactly this set, so the
+     * "handled set" and the "subscribed set" cannot drift. If a new handler branch is added, add
+     * its type here too (the unit test in CtrlProxyAccessibilityEventTypesTest enforces this).
+     */
+    val HANDLED_EVENT_TYPES: IntArray =
+      intArrayOf(
+        AccessibilityEvent.TYPE_VIEW_CLICKED,
+        AccessibilityEvent.TYPE_VIEW_LONG_CLICKED,
+        AccessibilityEvent.TYPE_WINDOW_CONTENT_CHANGED,
+        AccessibilityEvent.TYPE_WINDOW_STATE_CHANGED,
+        AccessibilityEvent.TYPE_WINDOWS_CHANGED,
+        AccessibilityEvent.TYPE_VIEW_TEXT_CHANGED,
+        AccessibilityEvent.TYPE_VIEW_SCROLLED,
+        AccessibilityEvent.TYPE_VIEW_SELECTED,
+      )
+
+    /**
+     * OS-level `eventTypes` subscription mask: exactly the union of [HANDLED_EVENT_TYPES],
+     * replacing the former `TYPES_ALL_MASK`. The OS no longer delivers events (hover,
+     * touch-exploration, focus, gesture-detection, announcement, etc.) that the handler only drops.
+     */
+    val SUBSCRIBED_EVENT_TYPES_MASK: Int = HANDLED_EVENT_TYPES.fold(0) { acc, type -> acc or type }
+
+    /**
+     * `notificationTimeout` coalesces bursts of same-type events at the OS boundary before
+     * delivery. 100 ms matches the tightest interaction debounce the handler already applies
+     * ([inputTextDebounceMs]) and sits well under the scroll debounce (300 ms) and hierarchy
+     * broadcast interval (250 ms), so it collapses event floods without adding perceptible latency
+     * to the interaction/telemetry or hierarchy-refresh paths the debouncers rely on.
+     */
+    const val ACCESSIBILITY_NOTIFICATION_TIMEOUT_MS = 100L
+
     // Broadcast actions
     const val ACTION_EXTRACT_HIERARCHY = "dev.jasonpearson.automobile.EXTRACT_HIERARCHY"
 
@@ -944,11 +979,16 @@ class CtrlProxy : AccessibilityService(), CtrlProxyActions {
     super.onServiceConnected()
     Log.d(TAG, "onServiceConnected")
 
-    // Ensure we receive ALL accessibility event types and include not-important views
-    // (XML config may be cached). flagIncludeNotImportantViews exposes interactive nodes
-    // (e.g. long-clickable ImageViews) that Android otherwise filters as decorative.
+    // Subscribe to exactly the event types onAccessibilityEvent handles
+    // (SUBSCRIBED_EVENT_TYPES_MASK)
+    // instead of TYPES_ALL_MASK, so the OS stops delivering events we only drop.
+    // notificationTimeout
+    // coalesces same-type floods at the OS boundary. flagIncludeNotImportantViews exposes
+    // interactive
+    // nodes (e.g. long-clickable ImageViews) that Android otherwise filters as decorative.
     serviceInfo = serviceInfo?.apply {
-      eventTypes = AccessibilityEvent.TYPES_ALL_MASK
+      eventTypes = SUBSCRIBED_EVENT_TYPES_MASK
+      notificationTimeout = ACCESSIBILITY_NOTIFICATION_TIMEOUT_MS
       flags =
         flags or
           AccessibilityServiceInfo.FLAG_INCLUDE_NOT_IMPORTANT_VIEWS or

--- a/android/control-proxy/src/test/kotlin/dev/jasonpearson/automobile/ctrlproxy/CtrlProxyAccessibilityEventTypesTest.kt
+++ b/android/control-proxy/src/test/kotlin/dev/jasonpearson/automobile/ctrlproxy/CtrlProxyAccessibilityEventTypesTest.kt
@@ -95,6 +95,26 @@ class CtrlProxyAccessibilityEventTypesTest {
   }
 
   @Test
+  fun `every classifier-handled event type is present in the subscribed mask`() {
+    // Reverse direction (CodeRabbit on #5497): the derivation tests prove each HANDLED type is
+    // handled, but not that every type the shared classifier acts on is actually subscribed. If a
+    // future branch dispatches on a type absent from CANDIDATE_EVENT_TYPES, HANDLED_EVENT_TYPES
+    // would miss it and the OS would filter it out. Walk every individual accessibility event bit;
+    // whenever the classifier says it is handled, the subscription mask must include it.
+    var bit = 1
+    while (bit != 0) {
+      if (AccessibilityEvent.TYPES_ALL_MASK and bit != 0 && isHandledEventType(bit)) {
+        assertEquals(
+          "classifier handles type $bit but the subscribed mask omits it",
+          bit,
+          CtrlProxy.SUBSCRIBED_EVENT_TYPES_MASK and bit,
+        )
+      }
+      bit = bit shl 1
+    }
+  }
+
+  @Test
   fun `framework cache-coherence types are retained for focus and node correctness`() {
     val expectedCacheTypes =
       setOf(

--- a/android/control-proxy/src/test/kotlin/dev/jasonpearson/automobile/ctrlproxy/CtrlProxyAccessibilityEventTypesTest.kt
+++ b/android/control-proxy/src/test/kotlin/dev/jasonpearson/automobile/ctrlproxy/CtrlProxyAccessibilityEventTypesTest.kt
@@ -2,46 +2,126 @@ package dev.jasonpearson.automobile.ctrlproxy
 
 import android.view.accessibility.AccessibilityEvent
 import org.junit.Assert.assertEquals
+import org.junit.Assert.assertFalse
 import org.junit.Assert.assertNotEquals
+import org.junit.Assert.assertNull
 import org.junit.Assert.assertTrue
 import org.junit.Test
 import org.junit.runner.RunWith
 import org.robolectric.RobolectricTestRunner
 
 /**
- * Guards issue #5467: CtrlProxy subscribes to exactly the accessibility event types
- * onAccessibilityEvent handles (SUBSCRIBED_EVENT_TYPES_MASK) instead of TYPES_ALL_MASK, so the OS
- * stops delivering events the handler only drops. These tests pin the subscribed mask to the
- * handled set so the two cannot silently drift.
+ * Guards issue #5467: CtrlProxy subscribes to exactly the event types its handler acts on plus the
+ * types the platform AccessibilityCache needs to stay coherent, instead of TYPES_ALL_MASK.
+ *
+ * These tests drive the SHARED dispatch classifier ([interactionDispatchFor] /
+ * [triggersHierarchyRefresh]) that the real onAccessibilityEvent handler now routes through, so a
+ * new handler branch added without extending the mask fails here — the test exercises real dispatch
+ * classification rather than comparing two handwritten lists.
  */
 @RunWith(RobolectricTestRunner::class)
 class CtrlProxyAccessibilityEventTypesTest {
 
   /**
-   * The event types onAccessibilityEvent actually dispatches on, transcribed here independently of
-   * production so a future edit to the handler that forgets to update HANDLED_EVENT_TYPES fails
-   * this test. Keep in lockstep with the `when`/`if` branches in CtrlProxy.onAccessibilityEvent.
+   * Independent transcription of the interaction the handler's `when` performs per type. If a
+   * future edit changes [interactionDispatchFor] without updating this expectation the test fails,
+   * and if it adds a handled type without adding it to the subscribed mask the derivation tests
+   * below fail.
    */
-  private val expectedHandledTypes =
+  private val expectedInteractionDispatch =
+    mapOf(
+      AccessibilityEvent.TYPE_VIEW_CLICKED to InteractionDispatch.TAP,
+      AccessibilityEvent.TYPE_VIEW_LONG_CLICKED to InteractionDispatch.LONG_PRESS,
+      AccessibilityEvent.TYPE_WINDOW_CONTENT_CHANGED to InteractionDispatch.CONTENT_CHANGED,
+      AccessibilityEvent.TYPE_WINDOW_STATE_CHANGED to InteractionDispatch.NAVIGATE,
+      AccessibilityEvent.TYPE_VIEW_SELECTED to InteractionDispatch.SELECT,
+      AccessibilityEvent.TYPE_VIEW_TEXT_CHANGED to InteractionDispatch.INPUT_TEXT,
+      AccessibilityEvent.TYPE_VIEW_SCROLLED to InteractionDispatch.SCROLL,
+    )
+
+  private val expectedHierarchyRefreshTypes =
     setOf(
-      AccessibilityEvent.TYPE_VIEW_CLICKED,
-      AccessibilityEvent.TYPE_VIEW_LONG_CLICKED,
       AccessibilityEvent.TYPE_WINDOW_CONTENT_CHANGED,
       AccessibilityEvent.TYPE_WINDOW_STATE_CHANGED,
       AccessibilityEvent.TYPE_WINDOWS_CHANGED,
       AccessibilityEvent.TYPE_VIEW_TEXT_CHANGED,
-      AccessibilityEvent.TYPE_VIEW_SCROLLED,
-      AccessibilityEvent.TYPE_VIEW_SELECTED,
+    )
+
+  /** Representative high-frequency noise the service must NOT subscribe to. */
+  private val droppedNoiseTypes =
+    listOf(
+      AccessibilityEvent.TYPE_VIEW_HOVER_ENTER,
+      AccessibilityEvent.TYPE_VIEW_HOVER_EXIT,
+      AccessibilityEvent.TYPE_TOUCH_EXPLORATION_GESTURE_START,
+      AccessibilityEvent.TYPE_TOUCH_EXPLORATION_GESTURE_END,
+      AccessibilityEvent.TYPE_TOUCH_INTERACTION_START,
+      AccessibilityEvent.TYPE_TOUCH_INTERACTION_END,
+      AccessibilityEvent.TYPE_GESTURE_DETECTION_START,
+      AccessibilityEvent.TYPE_GESTURE_DETECTION_END,
+      AccessibilityEvent.TYPE_NOTIFICATION_STATE_CHANGED,
     )
 
   @Test
-  fun `handled set matches the types the handler dispatches on`() {
-    assertEquals(expectedHandledTypes, CtrlProxy.HANDLED_EVENT_TYPES.toSet())
+  fun `classifier dispatches each handled interaction type as expected`() {
+    for ((type, dispatch) in expectedInteractionDispatch) {
+      assertEquals("dispatch for type $type", dispatch, interactionDispatchFor(type))
+    }
   }
 
   @Test
-  fun `subscribed mask is exactly the union of the handled set`() {
-    val union = expectedHandledTypes.fold(0) { acc, type -> acc or type }
+  fun `classifier ignores noise types`() {
+    for (type in droppedNoiseTypes) {
+      assertNull("noise type $type must not dispatch an interaction", interactionDispatchFor(type))
+      assertFalse("noise type $type must not trigger refresh", triggersHierarchyRefresh(type))
+      assertFalse("noise type $type must not be handled", isHandledEventType(type))
+    }
+  }
+
+  @Test
+  fun `hierarchy-refresh trigger set matches the handler`() {
+    for (type in expectedHierarchyRefreshTypes) {
+      assertTrue("type $type should trigger a hierarchy refresh", triggersHierarchyRefresh(type))
+    }
+  }
+
+  @Test
+  fun `handled set is exactly the types the shared classifier acts on`() {
+    val expectedHandled = expectedInteractionDispatch.keys + expectedHierarchyRefreshTypes
+    assertEquals(expectedHandled, CtrlProxy.HANDLED_EVENT_TYPES.toSet())
+    // Every derived handled type is genuinely acted on by the shared classifier.
+    for (type in CtrlProxy.HANDLED_EVENT_TYPES) {
+      assertTrue("derived handled type $type must be handled", isHandledEventType(type))
+    }
+  }
+
+  @Test
+  fun `framework cache-coherence types are retained for focus and node correctness`() {
+    val expectedCacheTypes =
+      setOf(
+        AccessibilityEvent.TYPE_VIEW_FOCUSED,
+        AccessibilityEvent.TYPE_VIEW_ACCESSIBILITY_FOCUSED,
+        AccessibilityEvent.TYPE_VIEW_ACCESSIBILITY_FOCUS_CLEARED,
+        AccessibilityEvent.TYPE_VIEW_TEXT_SELECTION_CHANGED,
+      )
+    assertEquals(expectedCacheTypes, CtrlProxy.FRAMEWORK_CACHE_EVENT_TYPES.toSet())
+    // These are deliberately NOT app-handled — they exist solely so AccessibilityCache stays
+    // coherent (rootInActiveWindow / findFocus must not go stale after a focus-only transition).
+    for (type in CtrlProxy.FRAMEWORK_CACHE_EVENT_TYPES) {
+      assertFalse("cache type $type should not be app-handled", isHandledEventType(type))
+      assertEquals(
+        "mask must subscribe to cache type $type",
+        type,
+        CtrlProxy.SUBSCRIBED_EVENT_TYPES_MASK and type,
+      )
+    }
+  }
+
+  @Test
+  fun `subscribed mask is exactly the union of handled and framework-cache sets`() {
+    val union =
+      (CtrlProxy.HANDLED_EVENT_TYPES + CtrlProxy.FRAMEWORK_CACHE_EVENT_TYPES).fold(0) { acc, type ->
+        acc or type
+      }
     assertEquals(union, CtrlProxy.SUBSCRIBED_EVENT_TYPES_MASK)
   }
 
@@ -57,18 +137,10 @@ class CtrlProxyAccessibilityEventTypesTest {
   }
 
   @Test
-  fun `subscribed mask excludes representative unhandled types`() {
-    val unhandled =
-      listOf(
-        AccessibilityEvent.TYPE_VIEW_HOVER_ENTER,
-        AccessibilityEvent.TYPE_VIEW_HOVER_EXIT,
-        AccessibilityEvent.TYPE_TOUCH_EXPLORATION_GESTURE_START,
-        AccessibilityEvent.TYPE_VIEW_ACCESSIBILITY_FOCUSED,
-        AccessibilityEvent.TYPE_VIEW_FOCUSED,
-      )
-    for (type in unhandled) {
+  fun `subscribed mask excludes representative dropped noise types`() {
+    for (type in droppedNoiseTypes) {
       assertEquals(
-        "mask must not subscribe to unhandled type $type",
+        "mask must not subscribe to dropped noise type $type",
         0,
         CtrlProxy.SUBSCRIBED_EVENT_TYPES_MASK and type,
       )
@@ -76,11 +148,12 @@ class CtrlProxyAccessibilityEventTypesTest {
   }
 
   @Test
-  fun `subscribed mask is narrower than TYPES_ALL_MASK`() {
+  fun `subscribed mask is a strict subset of TYPES_ALL_MASK`() {
     assertNotEquals(AccessibilityEvent.TYPES_ALL_MASK, CtrlProxy.SUBSCRIBED_EVENT_TYPES_MASK)
-    assertTrue(
-      "subscribed mask must be a strict subset of TYPES_ALL_MASK",
-      CtrlProxy.SUBSCRIBED_EVENT_TYPES_MASK and AccessibilityEvent.TYPES_ALL_MASK.inv() == 0,
+    assertEquals(
+      "subscribed mask must be a subset of TYPES_ALL_MASK",
+      0,
+      CtrlProxy.SUBSCRIBED_EVENT_TYPES_MASK and AccessibilityEvent.TYPES_ALL_MASK.inv(),
     )
   }
 

--- a/android/control-proxy/src/test/kotlin/dev/jasonpearson/automobile/ctrlproxy/CtrlProxyAccessibilityEventTypesTest.kt
+++ b/android/control-proxy/src/test/kotlin/dev/jasonpearson/automobile/ctrlproxy/CtrlProxyAccessibilityEventTypesTest.kt
@@ -1,0 +1,93 @@
+package dev.jasonpearson.automobile.ctrlproxy
+
+import android.view.accessibility.AccessibilityEvent
+import org.junit.Assert.assertEquals
+import org.junit.Assert.assertNotEquals
+import org.junit.Assert.assertTrue
+import org.junit.Test
+import org.junit.runner.RunWith
+import org.robolectric.RobolectricTestRunner
+
+/**
+ * Guards issue #5467: CtrlProxy subscribes to exactly the accessibility event types
+ * onAccessibilityEvent handles (SUBSCRIBED_EVENT_TYPES_MASK) instead of TYPES_ALL_MASK, so the OS
+ * stops delivering events the handler only drops. These tests pin the subscribed mask to the
+ * handled set so the two cannot silently drift.
+ */
+@RunWith(RobolectricTestRunner::class)
+class CtrlProxyAccessibilityEventTypesTest {
+
+  /**
+   * The event types onAccessibilityEvent actually dispatches on, transcribed here independently of
+   * production so a future edit to the handler that forgets to update HANDLED_EVENT_TYPES fails
+   * this test. Keep in lockstep with the `when`/`if` branches in CtrlProxy.onAccessibilityEvent.
+   */
+  private val expectedHandledTypes =
+    setOf(
+      AccessibilityEvent.TYPE_VIEW_CLICKED,
+      AccessibilityEvent.TYPE_VIEW_LONG_CLICKED,
+      AccessibilityEvent.TYPE_WINDOW_CONTENT_CHANGED,
+      AccessibilityEvent.TYPE_WINDOW_STATE_CHANGED,
+      AccessibilityEvent.TYPE_WINDOWS_CHANGED,
+      AccessibilityEvent.TYPE_VIEW_TEXT_CHANGED,
+      AccessibilityEvent.TYPE_VIEW_SCROLLED,
+      AccessibilityEvent.TYPE_VIEW_SELECTED,
+    )
+
+  @Test
+  fun `handled set matches the types the handler dispatches on`() {
+    assertEquals(expectedHandledTypes, CtrlProxy.HANDLED_EVENT_TYPES.toSet())
+  }
+
+  @Test
+  fun `subscribed mask is exactly the union of the handled set`() {
+    val union = expectedHandledTypes.fold(0) { acc, type -> acc or type }
+    assertEquals(union, CtrlProxy.SUBSCRIBED_EVENT_TYPES_MASK)
+  }
+
+  @Test
+  fun `subscribed mask contains every handled type`() {
+    for (type in CtrlProxy.HANDLED_EVENT_TYPES) {
+      assertEquals(
+        "mask must contain handled type $type",
+        type,
+        CtrlProxy.SUBSCRIBED_EVENT_TYPES_MASK and type,
+      )
+    }
+  }
+
+  @Test
+  fun `subscribed mask excludes representative unhandled types`() {
+    val unhandled =
+      listOf(
+        AccessibilityEvent.TYPE_VIEW_HOVER_ENTER,
+        AccessibilityEvent.TYPE_VIEW_HOVER_EXIT,
+        AccessibilityEvent.TYPE_TOUCH_EXPLORATION_GESTURE_START,
+        AccessibilityEvent.TYPE_VIEW_ACCESSIBILITY_FOCUSED,
+        AccessibilityEvent.TYPE_VIEW_FOCUSED,
+      )
+    for (type in unhandled) {
+      assertEquals(
+        "mask must not subscribe to unhandled type $type",
+        0,
+        CtrlProxy.SUBSCRIBED_EVENT_TYPES_MASK and type,
+      )
+    }
+  }
+
+  @Test
+  fun `subscribed mask is narrower than TYPES_ALL_MASK`() {
+    assertNotEquals(AccessibilityEvent.TYPES_ALL_MASK, CtrlProxy.SUBSCRIBED_EVENT_TYPES_MASK)
+    assertTrue(
+      "subscribed mask must be a strict subset of TYPES_ALL_MASK",
+      CtrlProxy.SUBSCRIBED_EVENT_TYPES_MASK and AccessibilityEvent.TYPES_ALL_MASK.inv() == 0,
+    )
+  }
+
+  @Test
+  fun `notification timeout is a modest positive coalescing window`() {
+    // Must stay at or below the tightest interaction debounce so it never adds perceptible latency.
+    assertTrue(CtrlProxy.ACCESSIBILITY_NOTIFICATION_TIMEOUT_MS > 0)
+    assertTrue(CtrlProxy.ACCESSIBILITY_NOTIFICATION_TIMEOUT_MS <= 100L)
+  }
+}


### PR DESCRIPTION
## Summary

The CtrlProxy accessibility service subscribed to `AccessibilityEvent.TYPES_ALL_MASK` with no `notificationTimeout`, so the OS delivered every event type — most of which the handler drops. This narrows the subscription to the union of (a) the types the handler actually acts on and (b) the types the platform accessibility cache needs to stay coherent, and coalesces same-type floods with a 100 ms `notificationTimeout`.

## Design: two named sets, subscribe to their union

The subscribed mask is derived in one place from a **shared dispatch classifier** so the handled set and the subscribed set cannot drift:

- `interactionDispatchFor(eventType)` / `triggersHierarchyRefresh(eventType)` — the single classification primitive. The real `onAccessibilityEvent` handler now routes its `when` and hierarchy-refresh `if` through these functions.
- `HANDLED_EVENT_TYPES` — **derived** by filtering `CANDIDATE_EVENT_TYPES` through `isHandledEventType(...)`, i.e. computed from the exact predicate the handler dispatches on (not hand-listed).
- `FRAMEWORK_CACHE_EVENT_TYPES` — the types the platform `AccessibilityCache` / `AccessibilityInteractionClient` consume to invalidate their node/focus caches.
- `SUBSCRIBED_EVENT_TYPES_MASK = union(HANDLED_EVENT_TYPES ∪ FRAMEWORK_CACHE_EVENT_TYPES)`.

### Why the framework-cache set is required (Codex P1)

Deriving the mask solely from app-dispatched events is unsafe: the platform cache only invalidates its focus/node state for an event when the service is *subscribed* to that event. Without the focus/selection types, after a focus-only transition `rootInActiveWindow` and `findFocus` can return **stale** state to `observe` and `handleGetCurrentFocus` — the core AutoMobile read paths. Cross-checked against AOSP `AccessibilityCache.onAccessibilityEvent`. `FRAMEWORK_CACHE_EVENT_TYPES` is:

- `TYPE_VIEW_FOCUSED`
- `TYPE_VIEW_ACCESSIBILITY_FOCUSED`
- `TYPE_VIEW_ACCESSIBILITY_FOCUS_CLEARED`
- `TYPE_VIEW_TEXT_SELECTION_CHANGED`

(The window/content/scroll/text/click/select types that also invalidate the cache are already in `HANDLED_EVENT_TYPES`; the union absorbs the overlap.)

## KEPT vs DROPPED

**KEPT (subscribed, 12 types):** `TYPE_VIEW_CLICKED`, `TYPE_VIEW_LONG_CLICKED`, `TYPE_VIEW_SELECTED`, `TYPE_VIEW_TEXT_CHANGED`, `TYPE_VIEW_SCROLLED`, `TYPE_WINDOW_STATE_CHANGED`, `TYPE_WINDOW_CONTENT_CHANGED`, `TYPE_WINDOWS_CHANGED` (handled set) + `TYPE_VIEW_FOCUSED`, `TYPE_VIEW_ACCESSIBILITY_FOCUSED`, `TYPE_VIEW_ACCESSIBILITY_FOCUS_CLEARED`, `TYPE_VIEW_TEXT_SELECTION_CHANGED` (framework-cache set).

**DROPPED (no longer delivered — the high-frequency noise):** `TYPE_VIEW_HOVER_ENTER`, `TYPE_VIEW_HOVER_EXIT`, `TYPE_TOUCH_EXPLORATION_GESTURE_START`, `TYPE_TOUCH_EXPLORATION_GESTURE_END`, `TYPE_TOUCH_INTERACTION_START`, `TYPE_TOUCH_INTERACTION_END`, `TYPE_GESTURE_DETECTION_START`, `TYPE_GESTURE_DETECTION_END`, `TYPE_ANNOUNCEMENT`, `TYPE_NOTIFICATION_STATE_CHANGED`, `TYPE_VIEW_TEXT_TRAVERSED_AT_MOVEMENT_GRANULARITY`, `TYPE_VIEW_CONTEXT_CLICKED`, `TYPE_ASSIST_READING_CONTEXT`, `TYPE_SPEECH_STATE_CHANGE`, `TYPE_VIEW_TARGETED_BY_SCROLL`.

## notificationTimeout chosen

`100L` ms. Rationale: matches the tightest interaction debounce the handler already applies (`inputTextDebounceMs = 100`), and sits well under the scroll debounce (300 ms) and hierarchy broadcast interval (250 ms), so it collapses event floods without adding perceptible latency to the interaction/telemetry or hierarchy-refresh paths.

## Test exercises real dispatch (Codex P2)

`CtrlProxyAccessibilityEventTypesTest` no longer compares two handwritten lists. It drives the shared `interactionDispatchFor` / `triggersHierarchyRefresh` classifier — the exact primitive the handler now routes through — asserting each handled type maps to its expected `InteractionDispatch`, each refresh type triggers a refresh, and each representative noise type (e.g. `TYPE_VIEW_HOVER_ENTER`) is classified not-handled AND excluded from the mask. Because `HANDLED_EVENT_TYPES` is derived from that same classifier, a new handler branch added without updating the mask changes the derived set and fails the lockstep assertion. It also pins `FRAMEWORK_CACHE_EVENT_TYPES` into the mask and confirms the mask is a strict subset of `TYPES_ALL_MASK`.

## No regression / interplay verified

Only `eventTypes` and `notificationTimeout` change in `onServiceConnected`. `applyAccessibilityFlags` / `computeAccessibilityServiceFlags` compare and reassign **flags** only — never `eventTypes` — so the equality-guarded live-service reassignment is undisturbed. Every currently-handled type is still delivered; the platform cache stays coherent; only genuine noise stops arriving.

## Test evidence

`./gradlew -p android :control-proxy:testDebugUnitTest` — BUILD SUCCESSFUL, full suite 480 tests, 0 failures/errors (10 in `CtrlProxyAccessibilityEventTypesTest`). Touched Kotlin formatted with `scripts/ktfmt/apply_ktfmt.sh`.

Closes #5467
