### PR TITLE
perf(android): skip re-broadcasting unchanged hierarchies in CtrlProxy

### DIFF
--- a/android/control-proxy/src/main/kotlin/dev/jasonpearson/automobile/ctrlproxy/CtrlProxy.kt
+++ b/android/control-proxy/src/main/kotlin/dev/jasonpearson/automobile/ctrlproxy/CtrlProxy.kt
@@ -222,6 +222,42 @@ internal fun navigationEventResponse(event: TimestampedNavigationEvent): Navigat
       ),
   )
 
+/** Outcome of applying the event-driven broadcast policy to a [HierarchyResult] (#5468). */
+internal enum class HierarchyBroadcastDecision {
+  /** Serialize and broadcast the full `hierarchy_update` payload. */
+  BroadcastFull,
+  /** Drop the frame: a full broadcast happened too recently (throttled). */
+  SkipThrottled,
+  /**
+   * Drop the frame: the structural-hash gate declared the hierarchy unchanged, so the client
+   * already holds this exact hierarchy and a full re-broadcast would be byte-identical waste.
+   */
+  SkipUnchanged,
+}
+
+/**
+ * Pure event-driven broadcast policy, extracted so the "unchanged hierarchies are never
+ * re-broadcast" invariant (#5468) is unit-testable without standing up the AccessibilityService.
+ *
+ * - [HierarchyResult.Changed]: broadcast the full payload when the throttler allows, else skip.
+ * - [HierarchyResult.Unchanged]: never broadcast — the debouncer's structural-hash gate already
+ *   declared this byte-identical to what the client holds, so a full re-send is pure waste. Skip
+ *   regardless of the throttle window (no consumer relies on periodic re-sends of unchanged
+ *   hierarchies; the client retains its last hierarchy).
+ * - [HierarchyResult.Error]: never broadcast — handled by the error branch, not this policy.
+ */
+internal fun decideHierarchyBroadcast(
+  result: HierarchyResult,
+  shouldBroadcast: () -> Boolean,
+): HierarchyBroadcastDecision =
+  when (result) {
+    is HierarchyResult.Changed ->
+      if (shouldBroadcast()) HierarchyBroadcastDecision.BroadcastFull
+      else HierarchyBroadcastDecision.SkipThrottled
+    is HierarchyResult.Unchanged -> HierarchyBroadcastDecision.SkipUnchanged
+    is HierarchyResult.Error -> HierarchyBroadcastDecision.SkipUnchanged
+  }
+
 /**
  * Main AutoMobile Accessibility Service that provides view hierarchy extraction capabilities for
  * automated testing and UI interaction.
@@ -1253,30 +1289,33 @@ class CtrlProxy : AccessibilityService(), CtrlProxyActions {
                   "Hierarchy changed (hash=${result.hash}, extraction=${result.extractionTimeMs}ms)",
                 )
                 writeHierarchyToFile(result.hierarchy)
-                if (broadcastThrottler.shouldBroadcast()) {
-                  broadcastHierarchyUpdate(result.hierarchy)
-                } else {
-                  extractedHierarchyFrameContexts.remove(result.hierarchy)
-                  Log.d(
-                    TAG,
-                    "Throttled event-driven broadcast (${broadcastThrottler.timeSinceLastBroadcastMs()}ms since last)",
-                  )
+                when (decideHierarchyBroadcast(result, broadcastThrottler::shouldBroadcast)) {
+                  HierarchyBroadcastDecision.BroadcastFull ->
+                    broadcastHierarchyUpdate(result.hierarchy)
+                  else -> {
+                    // Throttled: a full broadcast happened too recently. Drop this frame and
+                    // release its retained frame context so the identity map does not leak.
+                    extractedHierarchyFrameContexts.remove(result.hierarchy)
+                    Log.d(
+                      TAG,
+                      "Throttled event-driven broadcast (${broadcastThrottler.timeSinceLastBroadcastMs()}ms since last)",
+                    )
+                  }
                 }
               }
               is HierarchyResult.Unchanged -> {
+                // #5468: the debouncer's structural-hash gate already declared this hierarchy
+                // byte-identical to the one the client holds, so re-serializing and
+                // re-broadcasting the full payload at the throttle cadence is pure waste during
+                // idle/animation. Drop the frame entirely — no consumer relies on periodic
+                // re-sends of unchanged hierarchies (the client retains its last hierarchy), so
+                // there is nothing to keep current. Release the retained frame context so the
+                // identity map does not leak.
                 Log.d(
                   TAG,
-                  "Hierarchy unchanged (animation mode, skipped=${result.skippedEventCount})",
+                  "Hierarchy unchanged (animation mode, skipped=${result.skippedEventCount}); skipping full re-broadcast (#5468)",
                 )
-                if (broadcastThrottler.shouldBroadcast()) {
-                  broadcastHierarchyUpdate(result.hierarchy)
-                } else {
-                  extractedHierarchyFrameContexts.remove(result.hierarchy)
-                  Log.d(
-                    TAG,
-                    "Throttled event-driven broadcast (${broadcastThrottler.timeSinceLastBroadcastMs()}ms since last)",
-                  )
-                }
+                extractedHierarchyFrameContexts.remove(result.hierarchy)
               }
               is HierarchyResult.Error -> {
                 Log.w(TAG, "Hierarchy extraction error: ${result.message}")

--- a/android/control-proxy/src/main/kotlin/dev/jasonpearson/automobile/ctrlproxy/CtrlProxy.kt
+++ b/android/control-proxy/src/main/kotlin/dev/jasonpearson/automobile/ctrlproxy/CtrlProxy.kt
@@ -222,40 +222,59 @@ internal fun navigationEventResponse(event: TimestampedNavigationEvent): Navigat
       ),
   )
 
-/** Outcome of applying the event-driven broadcast policy to a [HierarchyResult] (#5468). */
+/** Outcome of the content-addressed hierarchy-broadcast dedup gate (#5468). */
 internal enum class HierarchyBroadcastDecision {
-  /** Serialize and broadcast the full `hierarchy_update` payload. */
-  BroadcastFull,
-  /** Drop the frame: a full broadcast happened too recently (throttled). */
-  SkipThrottled,
+  /** Serialize and send the `hierarchy_update` frame; update the last-broadcast dedup key. */
+  Broadcast,
   /**
-   * Drop the frame: the structural-hash gate declared the hierarchy unchanged, so the client
-   * already holds this exact hierarchy and a full re-broadcast would be byte-identical waste.
+   * Suppress the frame: its wire payload is byte-identical to the one already broadcast, so the
+   * client already holds it. This is the only case that skips a send.
    */
-  SkipUnchanged,
+  SkipDuplicate,
 }
 
+/** Sentinel `updatedAt` used so the dedup key ignores the per-extraction wall-clock timestamp. */
+internal const val HIERARCHY_DEDUP_KEY_UPDATED_AT: Long = 0L
+
 /**
- * Pure event-driven broadcast policy, extracted so the "unchanged hierarchies are never
- * re-broadcast" invariant (#5468) is unit-testable without standing up the AccessibilityService.
+ * Derive the content-addressed dedup key for a hierarchy: a normalized copy whose only difference
+ * from the wire payload is that the per-extraction wall-clock [ViewHierarchy.updatedAt] is masked
+ * to a constant. `updatedAt` defaults to `System.currentTimeMillis()` at every extraction, so a raw
+ * serialized-payload comparison would never match even when the screen is genuinely unchanged.
+ * Every OTHER field (bounds, rotation, windows, insets, occlusion, focus, text, structure, ...)
+ * stays in the key, so any observable change — including the structurally-"Unchanged" bounds /
+ * rotation / insets-only changes that [StructuralHasher] deliberately excludes — produces a
+ * distinct key and is therefore never suppressed.
+ */
+internal fun hierarchyBroadcastDedupKey(hierarchy: ViewHierarchy): ViewHierarchy =
+  hierarchy.copy(updatedAt = HIERARCHY_DEDUP_KEY_UPDATED_AT)
+
+/**
+ * Pure content-addressed dedup policy, extracted so the "identical hierarchies are not re-sent, but
+ * every differing payload still flows" invariant (#5468) is unit-testable without standing up the
+ * AccessibilityService.
  *
- * - [HierarchyResult.Changed]: broadcast the full payload when the throttler allows, else skip.
- * - [HierarchyResult.Unchanged]: never broadcast — the debouncer's structural-hash gate already
- *   declared this byte-identical to what the client holds, so a full re-send is pure waste. Skip
- *   regardless of the throttle window (no consumer relies on periodic re-sends of unchanged
- *   hierarchies; the client retains its last hierarchy).
- * - [HierarchyResult.Error]: never broadcast — handled by the error branch, not this policy.
+ * The throttle gate and `Changed`/`Unchanged` flow handling are UNCHANGED from main — this policy
+ * only decides, at the actual broadcast call, whether the freshly-serialized payload is a
+ * byte-identical resend of the last one broadcast. It never suppresses:
+ * - a `sync` broadcast (explicit request-response / critical-ordering pushes must always deliver —
+ *   this is also how a newly-connected client bootstraps its first frame via `request_hierarchy`),
+ * - the first frame seen by a newly-connected client ([newClientConnected]),
+ * - any payload whose dedup key differs from the last broadcast (a real content change, or a
+ *   structurally-"Unchanged"-but-observably-different bounds / rotation / insets frame).
  */
 internal fun decideHierarchyBroadcast(
-  result: HierarchyResult,
-  shouldBroadcast: () -> Boolean,
+  dedupKey: ViewHierarchy,
+  lastBroadcastKey: ViewHierarchy?,
+  sync: Boolean,
+  newClientConnected: Boolean,
 ): HierarchyBroadcastDecision =
-  when (result) {
-    is HierarchyResult.Changed ->
-      if (shouldBroadcast()) HierarchyBroadcastDecision.BroadcastFull
-      else HierarchyBroadcastDecision.SkipThrottled
-    is HierarchyResult.Unchanged -> HierarchyBroadcastDecision.SkipUnchanged
-    is HierarchyResult.Error -> HierarchyBroadcastDecision.SkipUnchanged
+  when {
+    sync -> HierarchyBroadcastDecision.Broadcast
+    newClientConnected -> HierarchyBroadcastDecision.Broadcast
+    lastBroadcastKey != null && lastBroadcastKey == dedupKey ->
+      HierarchyBroadcastDecision.SkipDuplicate
+    else -> HierarchyBroadcastDecision.Broadcast
   }
 
 /**
@@ -596,6 +615,18 @@ class CtrlProxy : AccessibilityService(), CtrlProxyActions {
   // extraction-time token lets broadcast fail closed if an accessibility event intervenes.
   private val extractedHierarchyFrameContexts =
     Collections.synchronizedMap(IdentityHashMap<ViewHierarchy, String>())
+
+  // Content-addressed dedup for event-driven hierarchy pushes (#5468). Holds the normalized
+  // dedup key (updatedAt masked) of the last hierarchy actually broadcast, so a subsequent
+  // byte-identical async push can be suppressed instead of re-serialized and re-sent. Written
+  // only from broadcastHierarchyUpdate; @Volatile because that runs both on serviceScope and via
+  // runBlocking on caller threads. A benign race can at worst cost one extra send or one missed
+  // dedup — never a lost distinct payload.
+  @Volatile private var lastBroadcastHierarchyKey: ViewHierarchy? = null
+
+  // Connection count observed at the last actual broadcast. A rise means a client connected since
+  // then, so the next frame must send in full (bypass dedup) to bootstrap the newcomer.
+  @Volatile private var lastBroadcastConnectionCount: Int = 0
 
   @Volatile private var isRecording: Boolean = false
 
@@ -1289,33 +1320,30 @@ class CtrlProxy : AccessibilityService(), CtrlProxyActions {
                   "Hierarchy changed (hash=${result.hash}, extraction=${result.extractionTimeMs}ms)",
                 )
                 writeHierarchyToFile(result.hierarchy)
-                when (decideHierarchyBroadcast(result, broadcastThrottler::shouldBroadcast)) {
-                  HierarchyBroadcastDecision.BroadcastFull ->
-                    broadcastHierarchyUpdate(result.hierarchy)
-                  else -> {
-                    // Throttled: a full broadcast happened too recently. Drop this frame and
-                    // release its retained frame context so the identity map does not leak.
-                    extractedHierarchyFrameContexts.remove(result.hierarchy)
-                    Log.d(
-                      TAG,
-                      "Throttled event-driven broadcast (${broadcastThrottler.timeSinceLastBroadcastMs()}ms since last)",
-                    )
-                  }
+                if (broadcastThrottler.shouldBroadcast()) {
+                  broadcastHierarchyUpdate(result.hierarchy)
+                } else {
+                  extractedHierarchyFrameContexts.remove(result.hierarchy)
+                  Log.d(
+                    TAG,
+                    "Throttled event-driven broadcast (${broadcastThrottler.timeSinceLastBroadcastMs()}ms since last)",
+                  )
                 }
               }
               is HierarchyResult.Unchanged -> {
-                // #5468: the debouncer's structural-hash gate already declared this hierarchy
-                // byte-identical to the one the client holds, so re-serializing and
-                // re-broadcasting the full payload at the throttle cadence is pure waste during
-                // idle/animation. Drop the frame entirely — no consumer relies on periodic
-                // re-sends of unchanged hierarchies (the client retains its last hierarchy), so
-                // there is nothing to keep current. Release the retained frame context so the
-                // identity map does not leak.
                 Log.d(
                   TAG,
-                  "Hierarchy unchanged (animation mode, skipped=${result.skippedEventCount}); skipping full re-broadcast (#5468)",
+                  "Hierarchy unchanged (animation mode, skipped=${result.skippedEventCount})",
                 )
-                extractedHierarchyFrameContexts.remove(result.hierarchy)
+                if (broadcastThrottler.shouldBroadcast()) {
+                  broadcastHierarchyUpdate(result.hierarchy)
+                } else {
+                  extractedHierarchyFrameContexts.remove(result.hierarchy)
+                  Log.d(
+                    TAG,
+                    "Throttled event-driven broadcast (${broadcastThrottler.timeSinceLastBroadcastMs()}ms since last)",
+                  )
+                }
               }
               is HierarchyResult.Error -> {
                 Log.w(TAG, "Hierarchy extraction error: ${result.message}")
@@ -2965,6 +2993,22 @@ class CtrlProxy : AccessibilityService(), CtrlProxyActions {
       return
     }
 
+    // Content-addressed dedup (#5468): suppress ONLY a byte-identical async resend. Any payload
+    // that differs — including bounds/rotation/insets frames the debouncer classifies as
+    // structurally "Unchanged" — still flows. sync pushes and the first frame after a new client
+    // connects always send. Computed before serialization so a duplicate skips the serialize +
+    // socket write + client re-processing entirely (a normalized-copy equals walk, no allocation).
+    val connectionCount = webSocketServer.getConnectionCount()
+    val dedupKey = hierarchyBroadcastDedupKey(hierarchy)
+    val newClientConnected = connectionCount > lastBroadcastConnectionCount
+    if (
+      decideHierarchyBroadcast(dedupKey, lastBroadcastHierarchyKey, sync, newClientConnected) ==
+        HierarchyBroadcastDecision.SkipDuplicate
+    ) {
+      Log.d(TAG, "Skipping byte-identical hierarchy re-broadcast (#5468)")
+      return
+    }
+
     try {
       val jsonString =
         perfProvider.track("serializeHierarchy") { jsonCompact.encodeToString(hierarchy) }
@@ -2991,6 +3035,10 @@ class CtrlProxy : AccessibilityService(), CtrlProxyActions {
         // Async broadcast - for normal event-driven updates
         webSocketServer.broadcastWithPerf(messageBuilder)
       }
+      // Record what was actually broadcast so the next identical async push can be deduped, and
+      // the connection count so a later newcomer forces a full send (#5468).
+      lastBroadcastHierarchyKey = dedupKey
+      lastBroadcastConnectionCount = connectionCount
       Log.d(
         TAG,
         "Broadcasted hierarchy update to ${webSocketServer.getConnectionCount()} clients (sync=$sync)",

--- a/android/control-proxy/src/test/kotlin/dev/jasonpearson/automobile/ctrlproxy/HierarchyBroadcastDecisionTest.kt
+++ b/android/control-proxy/src/test/kotlin/dev/jasonpearson/automobile/ctrlproxy/HierarchyBroadcastDecisionTest.kt
@@ -1,80 +1,146 @@
 package dev.jasonpearson.automobile.ctrlproxy
 
+import dev.jasonpearson.automobile.ctrlproxy.models.UIElementInfo
 import dev.jasonpearson.automobile.ctrlproxy.models.ViewHierarchy
 import org.junit.Assert.assertEquals
+import org.junit.Assert.assertNotEquals
 import org.junit.Test
 
 /**
- * Guards the event-driven broadcast policy (#5468): an `Unchanged` hierarchy result must never
- * trigger a full `hierarchy_update` re-broadcast, while a `Changed` result still does (subject to
- * the broadcast throttle) exactly as before.
+ * Guards the content-addressed hierarchy-broadcast dedup policy (#5468).
+ *
+ * The invariant: an async `hierarchy_update` push is suppressed ONLY when its wire payload is
+ * byte-identical to the last one broadcast; every differing payload — including the
+ * structurally-"Unchanged"-but-observably-different frames [StructuralHasher] excludes (bounds,
+ * rotation, insets), and throttle-deferred changes — still flows. `sync` pushes and the first frame
+ * after a new client connects always send.
  */
 class HierarchyBroadcastDecisionTest {
 
-  private fun hierarchy() = ViewHierarchy()
+  private fun hierarchy(
+    updatedAt: Long = 1_000L,
+    rotation: Int? = 0,
+    packageName: String? = "com.example.app",
+    root: UIElementInfo? = UIElementInfo(className = "android.widget.FrameLayout"),
+  ) =
+    ViewHierarchy(
+      updatedAt = updatedAt,
+      packageName = packageName,
+      hierarchy = root,
+      rotation = rotation,
+    )
+
+  // --- dedup key normalization (Codex finding #1: lossy structural hash) ---
 
   @Test
-  fun `changed result broadcasts full payload when throttle allows`() {
-    val decision =
-      decideHierarchyBroadcast(
-        HierarchyResult.Changed(hierarchy(), hash = 1, extractionTimeMs = 5),
-        shouldBroadcast = { true },
-      )
+  fun `dedup key ignores the per-extraction updatedAt timestamp`() {
+    // Two extractions of the same screen differ only in updatedAt (defaults to now()). Without
+    // normalization a serialized-payload comparison would never match and dedup would be a no-op.
+    val a = hierarchyBroadcastDedupKey(hierarchy(updatedAt = 1_000L))
+    val b = hierarchyBroadcastDedupKey(hierarchy(updatedAt = 9_999L))
 
-    assertEquals(HierarchyBroadcastDecision.BroadcastFull, decision)
+    assertEquals(a, b)
   }
 
   @Test
-  fun `changed result skips when throttled`() {
-    val decision =
-      decideHierarchyBroadcast(
-        HierarchyResult.Changed(hierarchy(), hash = 1, extractionTimeMs = 5),
-        shouldBroadcast = { false },
-      )
+  fun `dedup key still distinguishes an observable-only change the structural hash would miss`() {
+    // Rotation is outside StructuralHasher entirely, so a rotation-only change is classified
+    // Unchanged — but it is observable and MUST NOT be deduped.
+    val portrait = hierarchyBroadcastDedupKey(hierarchy(rotation = 0))
+    val landscape = hierarchyBroadcastDedupKey(hierarchy(rotation = 1))
 
-    assertEquals(HierarchyBroadcastDecision.SkipThrottled, decision)
+    assertNotEquals(portrait, landscape)
   }
 
-  @Test
-  fun `unchanged result never broadcasts even when throttle allows`() {
-    val decision =
-      decideHierarchyBroadcast(
-        HierarchyResult.Unchanged(
-          hierarchy(),
-          hash = 1,
-          extractionTimeMs = 5,
-          skippedEventCount = 3,
-        ),
-        // Throttle wide open — the old code would have re-broadcast the full byte-identical
-        // payload here; the fix must skip it regardless.
-        shouldBroadcast = { true },
-      )
-
-    assertEquals(HierarchyBroadcastDecision.SkipUnchanged, decision)
-  }
+  // --- decision policy ---
 
   @Test
-  fun `unchanged result never broadcasts and never consults the throttle`() {
-    var throttleConsulted = false
-    val decision =
-      decideHierarchyBroadcast(
-        HierarchyResult.Unchanged(
-          hierarchy(),
-          hash = 1,
-          extractionTimeMs = 5,
-          skippedEventCount = 3,
-        ),
-        shouldBroadcast = {
-          throttleConsulted = true
-          true
-        },
-      )
+  fun `identical consecutive payload is skipped`() {
+    val first = hierarchyBroadcastDedupKey(hierarchy(updatedAt = 1_000L))
+    val second = hierarchyBroadcastDedupKey(hierarchy(updatedAt = 2_000L))
 
-    assertEquals(HierarchyBroadcastDecision.SkipUnchanged, decision)
+    // First send establishes the key.
     assertEquals(
-      "Unchanged results must skip unconditionally without touching the throttle",
-      false,
-      throttleConsulted,
+      HierarchyBroadcastDecision.Broadcast,
+      decideHierarchyBroadcast(
+        first,
+        lastBroadcastKey = null,
+        sync = false,
+        newClientConnected = false,
+      ),
+    )
+    // Second, byte-identical (updatedAt aside) push is suppressed.
+    assertEquals(
+      HierarchyBroadcastDecision.SkipDuplicate,
+      decideHierarchyBroadcast(
+        second,
+        lastBroadcastKey = first,
+        sync = false,
+        newClientConnected = false,
+      ),
+    )
+  }
+
+  @Test
+  fun `structurally-unchanged but observably-different payload still broadcasts`() {
+    // The regression guard for Codex finding #1: same structure, different rotation/insets/bounds.
+    val previous = hierarchyBroadcastDedupKey(hierarchy(rotation = 0))
+    val rotated = hierarchyBroadcastDedupKey(hierarchy(rotation = 1))
+
+    assertEquals(
+      HierarchyBroadcastDecision.Broadcast,
+      decideHierarchyBroadcast(
+        rotated,
+        lastBroadcastKey = previous,
+        sync = false,
+        newClientConnected = false,
+      ),
+    )
+  }
+
+  @Test
+  fun `changed payload broadcasts`() {
+    val previous = hierarchyBroadcastDedupKey(hierarchy(packageName = "com.example.app"))
+    val changed = hierarchyBroadcastDedupKey(hierarchy(packageName = "com.other.app"))
+
+    assertEquals(
+      HierarchyBroadcastDecision.Broadcast,
+      decideHierarchyBroadcast(
+        changed,
+        lastBroadcastKey = previous,
+        sync = false,
+        newClientConnected = false,
+      ),
+    )
+  }
+
+  @Test
+  fun `sync broadcast always sends even when identical`() {
+    val key = hierarchyBroadcastDedupKey(hierarchy())
+
+    assertEquals(
+      HierarchyBroadcastDecision.Broadcast,
+      decideHierarchyBroadcast(
+        key,
+        lastBroadcastKey = key,
+        sync = true,
+        newClientConnected = false,
+      ),
+    )
+  }
+
+  @Test
+  fun `a newly connected client forces a full send even when identical`() {
+    val key = hierarchyBroadcastDedupKey(hierarchy())
+
+    assertEquals(
+      HierarchyBroadcastDecision.Broadcast,
+      decideHierarchyBroadcast(
+        key,
+        lastBroadcastKey = key,
+        sync = false,
+        newClientConnected = true,
+      ),
     )
   }
 }

--- a/android/control-proxy/src/test/kotlin/dev/jasonpearson/automobile/ctrlproxy/HierarchyBroadcastDecisionTest.kt
+++ b/android/control-proxy/src/test/kotlin/dev/jasonpearson/automobile/ctrlproxy/HierarchyBroadcastDecisionTest.kt
@@ -1,0 +1,80 @@
+package dev.jasonpearson.automobile.ctrlproxy
+
+import dev.jasonpearson.automobile.ctrlproxy.models.ViewHierarchy
+import org.junit.Assert.assertEquals
+import org.junit.Test
+
+/**
+ * Guards the event-driven broadcast policy (#5468): an `Unchanged` hierarchy result must never
+ * trigger a full `hierarchy_update` re-broadcast, while a `Changed` result still does (subject to
+ * the broadcast throttle) exactly as before.
+ */
+class HierarchyBroadcastDecisionTest {
+
+  private fun hierarchy() = ViewHierarchy()
+
+  @Test
+  fun `changed result broadcasts full payload when throttle allows`() {
+    val decision =
+      decideHierarchyBroadcast(
+        HierarchyResult.Changed(hierarchy(), hash = 1, extractionTimeMs = 5),
+        shouldBroadcast = { true },
+      )
+
+    assertEquals(HierarchyBroadcastDecision.BroadcastFull, decision)
+  }
+
+  @Test
+  fun `changed result skips when throttled`() {
+    val decision =
+      decideHierarchyBroadcast(
+        HierarchyResult.Changed(hierarchy(), hash = 1, extractionTimeMs = 5),
+        shouldBroadcast = { false },
+      )
+
+    assertEquals(HierarchyBroadcastDecision.SkipThrottled, decision)
+  }
+
+  @Test
+  fun `unchanged result never broadcasts even when throttle allows`() {
+    val decision =
+      decideHierarchyBroadcast(
+        HierarchyResult.Unchanged(
+          hierarchy(),
+          hash = 1,
+          extractionTimeMs = 5,
+          skippedEventCount = 3,
+        ),
+        // Throttle wide open — the old code would have re-broadcast the full byte-identical
+        // payload here; the fix must skip it regardless.
+        shouldBroadcast = { true },
+      )
+
+    assertEquals(HierarchyBroadcastDecision.SkipUnchanged, decision)
+  }
+
+  @Test
+  fun `unchanged result never broadcasts and never consults the throttle`() {
+    var throttleConsulted = false
+    val decision =
+      decideHierarchyBroadcast(
+        HierarchyResult.Unchanged(
+          hierarchy(),
+          hash = 1,
+          extractionTimeMs = 5,
+          skippedEventCount = 3,
+        ),
+        shouldBroadcast = {
+          throttleConsulted = true
+          true
+        },
+      )
+
+    assertEquals(HierarchyBroadcastDecision.SkipUnchanged, decision)
+    assertEquals(
+      "Unchanged results must skip unconditionally without touching the throttle",
+      false,
+      throttleConsulted,
+    )
+  }
+}


### PR DESCRIPTION
## Summary

CtrlProxy re-serialized and re-broadcast byte-identical hierarchies to clients that already held them, wasting serialize CPU and ADB-pipe bandwidth during idle/animation. This PR suppresses only genuinely-identical re-sends via content-addressed dedup, leaving all real changes untouched.

## Why not "skip on `HierarchyResult.Unchanged`" (Codex review)

The first approach skipped the broadcast whenever the debouncer reported `Unchanged`. That is **unsafe**: `Unchanged` only means the STRUCTURAL HASH matched, and `StructuralHasher` is deliberately lossy —

- it excludes `bounds` and `accessible` (z-index/occlusion) from the element hash, and
- **all top-level metadata is outside the hash entirely**: `rotation`, `windows`, `windowInfo`, `systemInsets`/`insets`, `screenWidth/Height`, `wakefulness`, `foregroundActivity`, `density`, etc. Only `packageName` + the element tree (minus bounds) is hashed.

Consequences the naive skip broke:
1. **(P1) Observable-but-structurally-"Unchanged" frames.** During scroll/rotation/resize/focus-only changes the payload's coordinates, rotation, insets or windows differ while the structural hash matches. Dropping those discards real changes and stales `AndroidCtrlProxyClient.handleHierarchyUpdate`'s cache + the observation stream.
2. **(P1) Throttle-deferred real changes.** When a real change is throttle-dropped within the interval, `HierarchyDebouncer` updates `lastStructuralHash` *before* the drop, so the next identical extraction is classified `Unchanged`. Unconditionally skipping it (the throttler has no trailing-edge flush) could strand subscribers on the pre-change hierarchy.

## Redesign: content-addressed dedup against the last broadcast payload

- The `Changed`/`Unchanged`/throttle flow in the debouncer subscription is now **byte-identical to main** — no behavior change there.
- Suppression moved into `broadcastHierarchyUpdate`: an **async** push is skipped **only** when its wire payload is byte-identical to the last one actually broadcast (`lastBroadcastHierarchyKey`).
- **Dedup key normalizes `updatedAt`.** `ViewHierarchy.updatedAt` defaults to `System.currentTimeMillis()` at every extraction, so a raw serialized-payload comparison would *never* match even on an unchanged screen. The key is `hierarchy.copy(updatedAt = 0)`; **every other field stays in the key**, so any observable change — the structurally-"Unchanged" bounds/rotation/insets frames from finding #1, and throttle-deferred changes from finding #2 whose payload differs — produces a distinct key and still flows through the normal throttled broadcast path.
- **`sync` pushes always send** (explicit request-response / critical-ordering pushes; this is also how a newly-connected client bootstraps its first frame via `request_hierarchy` → `extractHierarchyNow(sync = true)`), and every send updates the stored key so a following identical async push is deduped.
- **New-connection reset:** a rise in `getConnectionCount()` since the last broadcast forces a full send, so a newcomer is never starved by dedup. This is self-contained in CtrlProxy (no `WebSocketServer` change); combined with the always-send `sync` request-response bootstrap, dedup cannot leave a new client without a frame.
- The compare is a normalized-copy `equals` walk computed **before** serialization, so a duplicate skips the serialize + socket write + client re-processing entirely (the net perf win); it short-circuits on the first differing field for changed frames.

### How this resolves both findings
1. Observable-field changes differ in the dedup key → still delivered.
2. A throttle-deferred change differs from the last broadcast → still eligible to broadcast when the interval opens, identical to today's behavior (no new staleness). No trailing-edge flush added — keeping the Changed/throttle path unchanged is what makes this safe.

## Tests

`HierarchyBroadcastDecisionTest` (7 cases, pure `decideHierarchyBroadcast` + `hierarchyBroadcastDedupKey`, no `AccessibilityService`):
- dedup key ignores `updatedAt`; dedup key still distinguishes a rotation-only (observable) change;
- two consecutive identical payloads → second `SkipDuplicate`;
- structurally-"Unchanged"-but-observably-different (rotation) payload → `Broadcast` (regression guard for finding #1);
- changed payload → `Broadcast`;
- `sync` always `Broadcast` even when identical;
- new-connection forces `Broadcast` even when identical.

`android/gradlew -p android :control-proxy:testDebugUnitTest` → BUILD SUCCESSFUL, full control-proxy suite **488/488** green (new class 7/7). ktfmt applied to both touched files. Diff touches only `CtrlProxy.kt` + the new test file.

Closes #5468
