### PR TITLE
Honor routing-session tool disables

### DIFF
--- a/docs/using/tool-capabilities.md
+++ b/docs/using/tool-capabilities.md
@@ -76,7 +76,9 @@ public call is enabled when either relevant session explicitly enables the exact
 tool. A connection-scoped disable overrides inherited defaults, while an
 explicit routing-session enable may opt the tool back in. Discovery evaluates
 each base/label route independently, so one label's disable cannot hide a tool
-that remains available through another label.
+that remains available through another label. A raw `deviceId` selects an
+execution target but does not borrow tool grants from an unrelated device-owning
+session.
 
 Connection selection profiles remain separate from device routing, so releasing
 an `executePlan` device session does not discard the still-open connection's

--- a/docs/using/tool-capabilities.md
+++ b/docs/using/tool-capabilities.md
@@ -74,7 +74,9 @@ expose it until its debug and embedded-SDK gates are also satisfied.
 Base and derived device-label sessions retain union semantics: a device-aware
 public call is enabled when either relevant session explicitly enables the exact
 tool. A connection-scoped disable overrides inherited defaults, while an
-explicit routing-session enable may opt the tool back in.
+explicit routing-session enable may opt the tool back in. Discovery evaluates
+each base/label route independently, so one label's disable cannot hide a tool
+that remains available through another label.
 
 Connection selection profiles remain separate from device routing, so releasing
 an `executePlan` device session does not discard the still-open connection's

--- a/src/features/toolSelection/toolSelectionPolicy.ts
+++ b/src/features/toolSelection/toolSelectionPolicy.ts
@@ -109,6 +109,30 @@ export async function isToolEnabledForAnySession(
   return false;
 }
 
+export async function isToolEnabledForAnyRoute(
+  toolName: string,
+  declaredDefault: boolean,
+  routingSessionRoutes: ReadonlyArray<ReadonlyArray<string | undefined>>,
+  sessionToolSelectionService?: ToolSelectionReader,
+  connectionProfileUuid?: string,
+): Promise<boolean> {
+  const routes = routingSessionRoutes.length > 0 ? routingSessionRoutes : [[]];
+  for (const routingSessions of routes) {
+    if (
+      await isToolEnabledForAnySession(
+        toolName,
+        declaredDefault,
+        [connectionProfileUuid, ...routingSessions],
+        sessionToolSelectionService,
+        connectionProfileUuid,
+      )
+    ) {
+      return true;
+    }
+  }
+  return false;
+}
+
 export async function assertToolEnabledForAnySession(
   toolName: string,
   declaredDefault: boolean,

--- a/src/features/toolSelection/toolSelectionPolicy.ts
+++ b/src/features/toolSelection/toolSelectionPolicy.ts
@@ -95,7 +95,14 @@ export async function isToolEnabledForAnySession(
   if (connectionOverride !== undefined) {
     return connectionOverride;
   }
-  for (const sessionUuid of candidates) {
+  const routingCandidates =
+    connectionProfileUuid && service.getOverride
+      ? candidates.filter((sessionUuid) => sessionUuid !== connectionProfileUuid)
+      : candidates;
+  if (routingCandidates.length === 0) {
+    return service.isEnabled(connectionProfileUuid, toolName, declaredDefault);
+  }
+  for (const sessionUuid of routingCandidates) {
     if (await service.isEnabled(sessionUuid, toolName, declaredDefault)) {
       return true;
     }

--- a/src/features/toolSelection/toolSelectionPolicy.ts
+++ b/src/features/toolSelection/toolSelectionPolicy.ts
@@ -8,25 +8,23 @@ import { SET_TOOL_ENABLED_TOOL_NAME } from "./toolSelectionControl";
 type ToolSelectionReader = Pick<SessionToolSelectionService, "isEnabled"> &
   Partial<Pick<SessionToolSelectionService, "getOverride">>;
 
-async function connectionOverrideResult(
+async function explicitOverrideResult(
   service: ToolSelectionReader,
-  connectionProfileUuid: string | undefined,
+  sessionUuids: readonly string[],
   toolName: string,
-  candidateSessions: readonly string[],
 ): Promise<boolean | undefined> {
-  if (!connectionProfileUuid || !service.getOverride) {
+  if (!service.getOverride) {
     return undefined;
   }
-  const connectionOverride = await service.getOverride(connectionProfileUuid, toolName);
-  if (connectionOverride !== false) {
-    return connectionOverride;
-  }
-  for (const sessionUuid of candidateSessions.filter((uuid) => uuid !== connectionProfileUuid)) {
-    if ((await service.getOverride(sessionUuid, toolName)) === true) {
+  let explicitlyDisabled = false;
+  for (const sessionUuid of sessionUuids) {
+    const override = await service.getOverride(sessionUuid, toolName);
+    if (override === true) {
       return true;
     }
+    explicitlyDisabled ||= override === false;
   }
-  return false;
+  return explicitlyDisabled ? false : undefined;
 }
 
 export async function isToolEnabledForSession(
@@ -86,23 +84,24 @@ export async function isToolEnabledForAnySession(
   }
 
   const service = sessionToolSelectionService ?? getSessionToolSelectionService();
-  const connectionOverride = await connectionOverrideResult(
-    service,
-    connectionProfileUuid,
-    toolName,
-    candidates,
-  );
-  if (connectionOverride !== undefined) {
-    return connectionOverride;
+  if (service.getOverride) {
+    const connectionOverride = connectionProfileUuid
+      ? await service.getOverride(connectionProfileUuid, toolName)
+      : undefined;
+    const routingOverride = await explicitOverrideResult(
+      service,
+      candidates.filter((sessionUuid) => sessionUuid !== connectionProfileUuid),
+      toolName,
+    );
+    if (connectionOverride === true || routingOverride === true) {
+      return true;
+    }
+    if (connectionOverride === false || routingOverride === false) {
+      return false;
+    }
+    return service.isEnabled(undefined, toolName, declaredDefault);
   }
-  const routingCandidates =
-    connectionProfileUuid && service.getOverride
-      ? candidates.filter((sessionUuid) => sessionUuid !== connectionProfileUuid)
-      : candidates;
-  if (routingCandidates.length === 0) {
-    return service.isEnabled(connectionProfileUuid, toolName, declaredDefault);
-  }
-  for (const sessionUuid of routingCandidates) {
+  for (const sessionUuid of candidates) {
     if (await service.isEnabled(sessionUuid, toolName, declaredDefault)) {
       return true;
     }

--- a/src/server/index.ts
+++ b/src/server/index.ts
@@ -80,9 +80,8 @@ import {
 } from "../features/toolSelection/SessionToolSelectionService";
 import {
   assertToolEnabledForAnySession,
-  isToolEnabledForAnySession,
+  isToolEnabledForAnyRoute,
 } from "../features/toolSelection/toolSelectionPolicy";
-import { getDeviceLabelMap } from "./deviceLabelMapping";
 import { runWithToolSelectionContext } from "../features/toolSelection/toolSelectionContext";
 import {
   resolveToolSelectionBaseSessionUuid,
@@ -407,17 +406,24 @@ export const createMcpServer = (options: McpServerOptions = {}): McpServer => {
     // `tools/call` gate applies (issue #4611). The call-gate accepts a
     // `{ sessionUuid: base, device: label }` call whenever a label re-enables a
     // tool the base narrowed away; filtering discovery on the base alone would
-    // then leave that tool callable but never discovered. The base's label map is
-    // a read-only lookup (no device allocation); a session with no labels collapses
-    // to the base, preserving prior single-session filtering.
+    // then leave that tool callable but never discovered. Each label remains an
+    // independent `[base, label]` route before those route results are unioned;
+    // flattening every label into one override set would let one label's explicit
+    // disable hide a tool that is still callable through a sibling. The base's
+    // label map is a read-only lookup (no device allocation); a session with no
+    // labels collapses to the base, preserving prior single-session filtering.
     //
     // The union is per-tool and DEVICE-AWARE only, mirroring the call gate: a
-    // plain (non-`requiresDevice`) tool runs under the base session regardless of
-    // any `device` argument, so its discovery must be base-only. Advertising a
-    // plain tool that only a label enables would leave it listed but rejected by
-    // the base-only call gate — a label-only grant must not surface a plain tool.
+    // plain (non-`requiresDevice`) tool ignores any `device` argument, so its
+    // discovery only evaluates the bound routing session. Advertising a plain
+    // tool that only a sibling label enables would leave it listed but rejected
+    // by the call gate — a label-only grant must not surface a plain tool.
     const labelSessionUuids = routingBaseSessionUuid
-      ? Object.values(getDeviceLabelMap(routingBaseSessionUuid) ?? {})
+      ? Array.from(
+          new Set(
+            Object.values(selectionSessionManager?.getDeviceLabels(routingBaseSessionUuid) ?? {}),
+          ),
+        )
       : [];
     return {
       tools: (
@@ -425,18 +431,17 @@ export const createMcpServer = (options: McpServerOptions = {}): McpServer => {
           definitions.map(async (definition) => {
             const registeredTool = ToolRegistry.getTool(definition.name);
             const deviceAware = registeredTool?.requiresDevice ?? false;
-            const candidateSessions = deviceAware
-              ? [
-                  connectionProfileUuid,
-                  routingBaseSessionUuid,
-                  routingSessionUuid,
-                  ...labelSessionUuids,
-                ]
-              : [connectionProfileUuid, routingBaseSessionUuid, routingSessionUuid];
-            return (await isToolEnabledForAnySession(
+            const candidateRoutes =
+              deviceAware && labelSessionUuids.length > 0
+                ? labelSessionUuids.map((labelSessionUuid) => [
+                    routingBaseSessionUuid,
+                    labelSessionUuid,
+                  ])
+                : [[routingBaseSessionUuid, routingSessionUuid]];
+            return (await isToolEnabledForAnyRoute(
               definition.name,
               registeredTool?.defaultEnabled ?? true,
-              candidateSessions,
+              candidateRoutes,
               options.sessionToolSelectionService,
               connectionProfileUuid,
             ))
@@ -534,7 +539,7 @@ export const createMcpServer = (options: McpServerOptions = {}): McpServer => {
     );
     const derivedLabelSessionUuid =
       tool.requiresDevice && requestedDeviceLabel && routingBaseSessionUuid
-        ? getDeviceLabelMap(routingBaseSessionUuid)?.[requestedDeviceLabel]
+        ? selectionSessionManager?.getDeviceLabels(routingBaseSessionUuid)?.[requestedDeviceLabel]
         : undefined;
     const requestedDeviceId =
       typeof (toolParams as Record<string, unknown>).deviceId === "string"

--- a/src/server/index.ts
+++ b/src/server/index.ts
@@ -549,7 +549,13 @@ export const createMcpServer = (options: McpServerOptions = {}): McpServer => {
     await assertToolEnabledForAnySession(
       name,
       tool.defaultEnabled,
-      [connectionProfileUuid, routingBaseSessionUuid, routingSessionUuid, derivedLabelSessionUuid],
+      [
+        connectionProfileUuid,
+        routingBaseSessionUuid,
+        ...(requestedDeviceLabel
+          ? [derivedLabelSessionUuid]
+          : [routingSessionUuid, derivedLabelSessionUuid]),
+      ],
       options.sessionToolSelectionService,
       connectionProfileUuid,
     );

--- a/src/server/index.ts
+++ b/src/server/index.ts
@@ -524,9 +524,10 @@ export const createMcpServer = (options: McpServerOptions = {}): McpServer => {
     // would let a caller borrow the label's grants for a base-disabled plain tool
     // with `{ sessionUuid: base, device: label }`. For a plain tool, enforcement
     // is base-only; only a `requiresDevice` tool actually uses the device field.
+    const rawRequestedDeviceLabel = (toolParams as Record<string, unknown>).device;
     const requestedDeviceLabel =
-      typeof (toolParams as Record<string, unknown>).device === "string"
-        ? ((toolParams as Record<string, unknown>).device as string)
+      typeof rawRequestedDeviceLabel === "string" && rawRequestedDeviceLabel.trim().length > 0
+        ? rawRequestedDeviceLabel
         : undefined;
     const selectionSessionManager =
       options.toolSelectionSessionManager ??
@@ -541,33 +542,14 @@ export const createMcpServer = (options: McpServerOptions = {}): McpServer => {
       tool.requiresDevice && requestedDeviceLabel && routingBaseSessionUuid
         ? selectionSessionManager?.getDeviceLabels(routingBaseSessionUuid)?.[requestedDeviceLabel]
         : undefined;
-    const requestedDeviceId =
-      typeof (toolParams as Record<string, unknown>).deviceId === "string"
-        ? ((toolParams as Record<string, unknown>).deviceId as string)
-        : undefined;
-    const deviceOwnershipSessionManager =
-      tool.requiresDevice && requestedDeviceId && DaemonState.getInstance().isInitialized()
-        ? DaemonState.getInstance().getSessionManager()
-        : undefined;
-    const owningSessionUuid =
-      deviceOwnershipSessionManager && requestedDeviceId
-        ? deviceOwnershipSessionManager.getSessionForDevice?.(requestedDeviceId)
-        : undefined;
-    const owningBaseSessionUuid = resolveToolSelectionBaseSessionUuid(
-      owningSessionUuid ?? undefined,
-      deviceOwnershipSessionManager,
-    );
+    // Tool selection follows the connection's routing profile. A raw deviceId is
+    // only an execution target and must not borrow an unrelated owning session's
+    // grants (which discovery cannot advertise). When both fields are present,
+    // ToolRegistry intentionally ignores deviceId in favor of the label.
     await assertToolEnabledForAnySession(
       name,
       tool.defaultEnabled,
-      [
-        connectionProfileUuid,
-        routingBaseSessionUuid,
-        routingSessionUuid,
-        derivedLabelSessionUuid,
-        owningBaseSessionUuid,
-        owningSessionUuid ?? undefined,
-      ],
+      [connectionProfileUuid, routingBaseSessionUuid, routingSessionUuid, derivedLabelSessionUuid],
       options.sessionToolSelectionService,
       connectionProfileUuid,
     );
@@ -615,6 +597,10 @@ export const createMcpServer = (options: McpServerOptions = {}): McpServer => {
 
     const executionSessionUuid =
       derivedLabelSessionUuid ?? providedSessionUuid ?? routingSessionUuid;
+    const handlerRoutingSessionUuid =
+      tool.requiresDevice && requestedDeviceLabel && routingBaseSessionUuid
+        ? routingBaseSessionUuid
+        : routingSessionUuid;
     const executionSessionId = requestMcpSessionId ?? sessionId;
     const execution = executionTracker.startExecution(
       name,
@@ -658,7 +644,10 @@ export const createMcpServer = (options: McpServerOptions = {}): McpServer => {
       const result = await runWithAbortSignal(execution.abortController.signal, () =>
         runWithToolSelectionContext(
           {
-            routingSessionUuid,
+            // A bound derived session may still target a sibling label. Resolve
+            // that label from the base map; unlabeled calls retain the derived
+            // ambient session.
+            routingSessionUuid: handlerRoutingSessionUuid,
             execution: {
               executionId: execution.id,
               startTime: execution.startTime,

--- a/test/features/toolSelection/toolSelectionPolicy.test.ts
+++ b/test/features/toolSelection/toolSelectionPolicy.test.ts
@@ -2,6 +2,7 @@ import { describe, expect, test } from "bun:test";
 import type { SessionToolSelectionService } from "../../../src/features/toolSelection/SessionToolSelectionService";
 import {
   assertToolEnabledForAnySession,
+  isToolEnabledForAnyRoute,
   isToolEnabledForAnySession,
 } from "../../../src/features/toolSelection/toolSelectionPolicy";
 
@@ -101,6 +102,62 @@ describe("exact-tool selection union policy", () => {
     expect(
       await isToolEnabledForAnySession("observe", true, candidates, service, "connection"),
     ).toBe(true);
+  });
+
+  test("unions independent sibling-label routes without sharing their disables", async () => {
+    const overrides = new Map<string, boolean>([["base:A", false]]);
+    const service: Pick<SessionToolSelectionService, "isEnabled" | "getOverride"> = {
+      isEnabled: async (sessionUuid, _toolName, declaredDefault) =>
+        (sessionUuid ? overrides.get(sessionUuid) : undefined) ?? declaredDefault,
+      getOverride: async (sessionUuid) => overrides.get(sessionUuid),
+    };
+    const routes = [
+      ["base", "base:A"],
+      ["base", "base:B"],
+    ];
+
+    expect(
+      await isToolEnabledForAnySession(
+        "observe",
+        true,
+        ["connection", ...routes[0]],
+        service,
+        "connection",
+      ),
+    ).toBe(false);
+    expect(
+      await isToolEnabledForAnySession(
+        "observe",
+        true,
+        ["connection", ...routes[1]],
+        service,
+        "connection",
+      ),
+    ).toBe(true);
+    expect(await isToolEnabledForAnyRoute("observe", true, routes, service, "connection")).toBe(
+      true,
+    );
+
+    overrides.set("base:B", false);
+    expect(await isToolEnabledForAnyRoute("observe", true, routes, service, "connection")).toBe(
+      false,
+    );
+
+    overrides.set("base:B", true);
+    expect(await isToolEnabledForAnyRoute("observe", true, routes, service, "connection")).toBe(
+      true,
+    );
+
+    overrides.clear();
+    overrides.set("connection", false);
+    expect(await isToolEnabledForAnyRoute("observe", true, routes, service, "connection")).toBe(
+      false,
+    );
+
+    overrides.set("base:B", true);
+    expect(await isToolEnabledForAnyRoute("observe", true, routes, service, "connection")).toBe(
+      true,
+    );
   });
 
   test("reports the exact disabled tool rather than a capability group", async () => {

--- a/test/features/toolSelection/toolSelectionPolicy.test.ts
+++ b/test/features/toolSelection/toolSelectionPolicy.test.ts
@@ -57,6 +57,28 @@ describe("exact-tool selection union policy", () => {
     ).toBe(true);
   });
 
+  test("an unset connection profile does not override an explicit routing disable", async () => {
+    const overrides = new Map<string, boolean>([["routing", false]]);
+    const service: Pick<SessionToolSelectionService, "isEnabled" | "getOverride"> = {
+      isEnabled: async (sessionUuid, _toolName, declaredDefault) =>
+        (sessionUuid ? overrides.get(sessionUuid) : undefined) ?? declaredDefault,
+      getOverride: async (sessionUuid) => overrides.get(sessionUuid),
+    };
+
+    expect(
+      await isToolEnabledForAnySession(
+        "observe",
+        true,
+        ["connection", "routing"],
+        service,
+        "connection",
+      ),
+    ).toBe(false);
+    expect(
+      await isToolEnabledForAnySession("observe", true, ["connection"], service, "connection"),
+    ).toBe(true);
+  });
+
   test("reports the exact disabled tool rather than a capability group", async () => {
     const disabled: Pick<SessionToolSelectionService, "isEnabled"> = {
       isEnabled: async () => false,

--- a/test/features/toolSelection/toolSelectionPolicy.test.ts
+++ b/test/features/toolSelection/toolSelectionPolicy.test.ts
@@ -79,6 +79,30 @@ describe("exact-tool selection union policy", () => {
     ).toBe(true);
   });
 
+  test("routing sessions resolve explicit choices before inherited defaults", async () => {
+    const overrides = new Map<string, boolean>([["base:B", false]]);
+    const service: Pick<SessionToolSelectionService, "isEnabled" | "getOverride"> = {
+      isEnabled: async (sessionUuid, _toolName, declaredDefault) =>
+        (sessionUuid ? overrides.get(sessionUuid) : undefined) ?? declaredDefault,
+      getOverride: async (sessionUuid) => overrides.get(sessionUuid),
+    };
+    const candidates = ["connection", "base", "base:B"];
+
+    expect(
+      await isToolEnabledForAnySession("observe", true, candidates, service, "connection"),
+    ).toBe(false);
+
+    overrides.set("base", true);
+    expect(
+      await isToolEnabledForAnySession("observe", true, candidates, service, "connection"),
+    ).toBe(true);
+
+    overrides.clear();
+    expect(
+      await isToolEnabledForAnySession("observe", true, candidates, service, "connection"),
+    ).toBe(true);
+  });
+
   test("reports the exact disabled tool rather than a capability group", async () => {
     const disabled: Pick<SessionToolSelectionService, "isEnabled"> = {
       isEnabled: async () => false,

--- a/test/server/sessionToolSelection.test.ts
+++ b/test/server/sessionToolSelection.test.ts
@@ -272,6 +272,87 @@ describe("per-session exact-tool selection", () => {
     expect(result.content[0]?.text).toBe("ran");
   });
 
+  test("discovers a device-aware tool enabled through any sibling label route", async () => {
+    const overrides = new Map<string, boolean>([["base-session:B", true]]);
+    const profileService: Pick<SessionToolSelectionService, "isEnabled" | "getOverride"> = {
+      isEnabled: async (sessionUuid, _toolName, declaredDefault) =>
+        (sessionUuid ? overrides.get(sessionUuid) : undefined) ?? declaredDefault,
+      getOverride: async (sessionUuid) => overrides.get(sessionUuid),
+    };
+    fixture = new McpTestFixture({
+      sessionContext: { initialSessionToolBinding: "base-session" },
+      sessionToolSelectionService: profileService,
+      toolSelectionSessionManager: {
+        getDeviceLabels: (sessionUuid) =>
+          sessionUuid === "base-session" ? { A: "base-session", B: "base-session:B" } : undefined,
+      },
+    });
+    await fixture.setup();
+
+    ToolRegistry.clearTools();
+    ToolRegistry.registerDeviceAware(
+      "observe",
+      "observe",
+      z.object({}),
+      async () => ({ content: [{ type: "text", text: "ran" }] }),
+      { defaultEnabled: false },
+    );
+    ToolRegistry.register(
+      "clipboard",
+      "clipboard",
+      z.object({}),
+      async () => ({ content: [{ type: "text", text: "ran" }] }),
+      { defaultEnabled: false },
+    );
+
+    const listedNames = (await fixture.client.listTools()).tools.map((tool) => tool.name);
+    expect(listedNames).toContain("observe");
+    expect(listedNames).not.toContain("clipboard");
+  });
+
+  test("does not let one sibling label disable a tool on every route", async () => {
+    const overrides = new Map<string, boolean>([["base-session:A", false]]);
+    const profileService: Pick<SessionToolSelectionService, "isEnabled" | "getOverride"> = {
+      isEnabled: async (sessionUuid, _toolName, declaredDefault) =>
+        (sessionUuid ? overrides.get(sessionUuid) : undefined) ?? declaredDefault,
+      getOverride: async (sessionUuid) => overrides.get(sessionUuid),
+    };
+    fixture = new McpTestFixture({
+      sessionContext: { initialSessionToolBinding: "base-session" },
+      sessionToolSelectionService: profileService,
+      toolSelectionSessionManager: {
+        getDeviceLabels: (sessionUuid) =>
+          sessionUuid === "base-session" ? { A: "base-session:A", B: "base-session" } : undefined,
+      },
+    });
+    await fixture.setup();
+
+    ToolRegistry.clearTools();
+    ToolRegistry.registerDeviceAware(
+      "observe",
+      "observe",
+      z.object({}),
+      async () => ({ content: [{ type: "text", text: "ran" }] }),
+      { defaultEnabled: true },
+    );
+
+    expect((await fixture.client.listTools()).tools.map((tool) => tool.name)).toContain("observe");
+    await expect(
+      fixture.client.request(
+        {
+          method: "tools/call",
+          params: { name: "observe", arguments: { device: "A" } },
+        },
+        z.any(),
+      ),
+    ).rejects.toThrow("Tool observe is disabled");
+
+    overrides.set("base-session", false);
+    expect((await fixture.client.listTools()).tools.map((tool) => tool.name)).not.toContain(
+      "observe",
+    );
+  });
+
   test("rejects unknown, structural, and self-disable targets", async () => {
     fixture = new McpTestFixture({
       sessionToolSelectionService: {

--- a/test/server/sessionToolSelection.test.ts
+++ b/test/server/sessionToolSelection.test.ts
@@ -406,6 +406,46 @@ describe("per-session exact-tool selection", () => {
     expect(resolvedSessionUuid).toBe("base-session");
   });
 
+  test("does not authorize a targeted label from the ambient sibling route", async () => {
+    const overrides = new Map<string, boolean>([
+      ["base-session:B", true],
+      ["base-session", false],
+      ["base-session:A", false],
+    ]);
+    fixture = new McpTestFixture({
+      sessionContext: { initialSessionToolBinding: "base-session:B" },
+      sessionToolSelectionService: {
+        isEnabled: async (sessionUuid, _toolName, declaredDefault) =>
+          (sessionUuid ? overrides.get(sessionUuid) : undefined) ?? declaredDefault,
+        getOverride: async (sessionUuid, _toolName) => overrides.get(sessionUuid),
+      },
+      toolSelectionSessionManager: {
+        getDeviceLabels: (sessionUuid) =>
+          sessionUuid === "base-session" ? { A: "base-session:A", B: "base-session:B" } : undefined,
+      },
+    });
+    await fixture.setup();
+
+    ToolRegistry.clearTools();
+    ToolRegistry.registerDeviceAware(
+      "observe",
+      "observe",
+      z.object({ device: z.string().optional() }),
+      async () => ({ content: [{ type: "text", text: "ran" }] }),
+      { defaultEnabled: false },
+    );
+
+    await expect(
+      fixture.client.request(
+        {
+          method: "tools/call",
+          params: { name: "observe", arguments: { device: "A" } },
+        },
+        z.any(),
+      ),
+    ).rejects.toThrow("Tool observe is disabled");
+  });
+
   test("rejects unknown, structural, and self-disable targets", async () => {
     fixture = new McpTestFixture({
       sessionToolSelectionService: {

--- a/test/server/sessionToolSelection.test.ts
+++ b/test/server/sessionToolSelection.test.ts
@@ -7,8 +7,11 @@ import { McpTestFixture } from "../fixtures/mcpTestFixture";
 
 describe("per-session exact-tool selection", () => {
   let fixture: McpTestFixture | undefined;
+  let restoreToolPipeline: (() => void) | undefined;
 
   afterEach(async () => {
+    restoreToolPipeline?.();
+    restoreToolPipeline = undefined;
     await fixture?.teardown();
     fixture = undefined;
     ToolRegistry.clearTools();
@@ -351,6 +354,56 @@ describe("per-session exact-tool selection", () => {
     expect((await fixture.client.listTools()).tools.map((tool) => tool.name)).not.toContain(
       "observe",
     );
+  });
+
+  test("resolves a sibling label from the base when bound to a derived route", async () => {
+    fixture = new McpTestFixture({
+      sessionContext: { initialSessionToolBinding: "base-session:B" },
+      toolSelectionSessionManager: {
+        getDeviceLabels: (sessionUuid) =>
+          sessionUuid === "base-session" ? { A: "base-session", B: "base-session:B" } : undefined,
+      },
+    });
+    await fixture.setup();
+
+    let resolvedSessionUuid: string | undefined;
+    restoreToolPipeline = ToolRegistry.setPipelineOverridesForTesting({
+      executionTargetResolver: {
+        resolveExecutionTarget: async ({ args }) => {
+          resolvedSessionUuid = args.sessionUuid;
+          return {
+            args,
+            baseSessionUuid: args.sessionUuid,
+            device: undefined,
+            internalCall: false,
+            sessionUuid: args.sessionUuid,
+            shouldResolveDevice: false,
+          };
+        },
+      },
+    });
+    ToolRegistry.clearTools();
+    ToolRegistry.registerDeviceAware(
+      "observe",
+      "observe",
+      z.object({ device: z.string().optional() }),
+      async () => ({ content: [{ type: "text", text: "device" }] }),
+      {
+        defaultEnabled: true,
+        nonDeviceHandler: async () => ({ content: [{ type: "text", text: "ran" }] }),
+      },
+    );
+
+    const result = await fixture.client.request(
+      {
+        method: "tools/call",
+        params: { name: "observe", arguments: { device: "A" } },
+      },
+      z.any(),
+    );
+
+    expect(result.content[0]?.text).toBe("ran");
+    expect(resolvedSessionUuid).toBe("base-session");
   });
 
   test("rejects unknown, structural, and self-disable targets", async () => {


### PR DESCRIPTION
## Summary

- resolve explicit routing overrides before inherited tool defaults
- evaluate each base/device-label route independently so one sibling label cannot hide a tool available through another
- resolve sibling labels from the base even when the connection is bound to a derived route
- keep raw device identifiers from borrowing unrelated session grants that discovery cannot advertise
- use the injected session-manager seam for discovery and call routing
- document and test connection, base, derived-label, default, and non-device-tool precedence

## Test plan

- [x] `bun test test/features/toolSelection test/server/sessionToolSelection.test.ts test/server/sessionToolDiscovery.test.ts --bail`
- [x] `bun test --bail`
- [x] `bun run lint`
- [x] `bun run typecheck`
- [x] `bun run build`
- [x] 33/34 `scripts/all_fast_validate_checks.sh` checks; the Kotlin-only `ktfmt` check cannot identify the local corporate Java wrapper's formatter version, and this PR changes no Kotlin

Made with [Cursor](https://cursor.com)
