### PR TITLE
fix(android): recover closed device-control transport

### DIFF
--- a/docs/design-docs/mcp/daemon/unix-socket-api.md
+++ b/docs/design-docs/mcp/daemon/unix-socket-api.md
@@ -67,7 +67,7 @@ All messages are newline-delimited JSON sent over the Unix socket. Each request 
 | `success` | `boolean` | `true` on success, `false` on error |
 | `result` | `object` | Present when `success` is `true` |
 | `error` | `string` | Present when `success` is `false` |
-| `transportFailure` | `object` | Optional machine-readable device-control transport failure metadata. New clients can inspect its stable code, tool/device/session identity, phase, validity, retryability, and recovery/replay flags; `sessionValid` is true only while the daemon session assignment and captured device epoch still match. Legacy clients can continue using `error`. |
+| `transportFailure` | `object` | Optional machine-readable device-control transport failure metadata. The allowlisted fields are `code`, `transport`, `toolName`, optional `deviceId`, optional `deviceSessionUuid`, optional `sessionUuid`, `sessionValid`, `deviceSessionValid`, `phase`, `retryable`, `reconnectAttempted`, and `replayAttempted`. `sessionValid` reports daemon-session assignment validity; `deviceSessionValid` independently reports whether the captured device epoch is still current. Legacy clients can continue using `error`. |
 
 ---
 

--- a/docs/design-docs/mcp/daemon/unix-socket-api.md
+++ b/docs/design-docs/mcp/daemon/unix-socket-api.md
@@ -67,7 +67,7 @@ All messages are newline-delimited JSON sent over the Unix socket. Each request 
 | `success` | `boolean` | `true` on success, `false` on error |
 | `result` | `object` | Present when `success` is `true` |
 | `error` | `string` | Present when `success` is `false` |
-| `transportFailure` | `object` | Optional machine-readable device-control transport failure metadata. The allowlisted fields are `code`, `transport`, `toolName`, optional `deviceId`, optional `deviceSessionUuid`, optional `sessionUuid`, `sessionValid`, `deviceSessionValid`, `phase`, `retryable`, `reconnectAttempted`, and `replayAttempted`. `sessionValid` reports daemon-session assignment validity; `deviceSessionValid` independently reports whether the captured device epoch is still current. Legacy clients can continue using `error`. |
+| `transportFailure` | `object` | Optional machine-readable device-control transport failure metadata. The allowlisted fields are `code`, `transport`, `toolName`, optional `deviceId`, optional `deviceSessionUuid`, optional target-owner `sessionUuid`, optional caller `routingSessionUuid`, `sessionValid`, `deviceSessionValid`, `phase`, `retryable`, `reconnectAttempted`, and `replayAttempted`. `sessionValid` reports whether all captured daemon-session identities remain valid; `deviceSessionValid` independently reports whether the captured device epoch is still current. Legacy clients can continue using `error`. |
 
 ---
 

--- a/docs/design-docs/mcp/daemon/unix-socket-api.md
+++ b/docs/design-docs/mcp/daemon/unix-socket-api.md
@@ -67,6 +67,7 @@ All messages are newline-delimited JSON sent over the Unix socket. Each request 
 | `success` | `boolean` | `true` on success, `false` on error |
 | `result` | `object` | Present when `success` is `true` |
 | `error` | `string` | Present when `success` is `false` |
+| `transportFailure` | `object` | Optional machine-readable device-control transport failure metadata. New clients can inspect its stable code, tool/device/session identity, phase, validity, retryability, and recovery/replay flags; legacy clients can continue using `error`. |
 
 ---
 

--- a/docs/design-docs/mcp/daemon/unix-socket-api.md
+++ b/docs/design-docs/mcp/daemon/unix-socket-api.md
@@ -67,7 +67,7 @@ All messages are newline-delimited JSON sent over the Unix socket. Each request 
 | `success` | `boolean` | `true` on success, `false` on error |
 | `result` | `object` | Present when `success` is `true` |
 | `error` | `string` | Present when `success` is `false` |
-| `transportFailure` | `object` | Optional machine-readable device-control transport failure metadata. New clients can inspect its stable code, tool/device/session identity, phase, validity, retryability, and recovery/replay flags; legacy clients can continue using `error`. |
+| `transportFailure` | `object` | Optional machine-readable device-control transport failure metadata. New clients can inspect its stable code, tool/device/session identity, phase, validity, retryability, and recovery/replay flags; `sessionValid` is true only while the daemon session assignment and captured device epoch still match. Legacy clients can continue using `error`. |
 
 ---
 

--- a/src/daemon/client.ts
+++ b/src/daemon/client.ts
@@ -15,6 +15,7 @@ import { type BuildIdentity, getCurrentBuildIdentity } from "./buildIdentity";
 import { resolveMcpRequestTimeoutMs } from "./mcpRequestTimeout";
 import { McpTimeoutError } from "./McpTimeoutError";
 import { type Timer, defaultTimer } from "../utils/SystemTimer";
+import { DeviceControlTransportError } from "./deviceControlTransportFailure";
 import {
   cleanupStaleDaemonFilesForDeadPidSync,
   getDaemonSocketPathList,
@@ -414,7 +415,12 @@ export class DaemonClient {
       pending.resolve(response);
     } else {
       pending.reject(
-        new ActionableError(response.error || "Unknown error from daemon")
+        response.transportFailure
+          ? new DeviceControlTransportError(
+            response.error || "Device-control transport failure",
+            response.transportFailure,
+          )
+          : new ActionableError(response.error || "Unknown error from daemon")
       );
     }
   }

--- a/src/daemon/client.ts
+++ b/src/daemon/client.ts
@@ -15,7 +15,10 @@ import { type BuildIdentity, getCurrentBuildIdentity } from "./buildIdentity";
 import { resolveMcpRequestTimeoutMs } from "./mcpRequestTimeout";
 import { McpTimeoutError } from "./McpTimeoutError";
 import { type Timer, defaultTimer } from "../utils/SystemTimer";
-import { DeviceControlTransportError } from "./deviceControlTransportFailure";
+import {
+  DeviceControlTransportError,
+  sanitizeDeviceControlTransportFailure,
+} from "./deviceControlTransportFailure";
 import {
   cleanupStaleDaemonFilesForDeadPidSync,
   getDaemonSocketPathList,
@@ -414,11 +417,14 @@ export class DaemonClient {
     if (response.success) {
       pending.resolve(response);
     } else {
+      const transportFailure = sanitizeDeviceControlTransportFailure(
+        response.transportFailure,
+      );
       pending.reject(
-        response.transportFailure
+        transportFailure
           ? new DeviceControlTransportError(
             response.error || "Device-control transport failure",
-            response.transportFailure,
+            transportFailure,
           )
           : new ActionableError(response.error || "Unknown error from daemon")
       );

--- a/src/daemon/daemonMcpProxy.ts
+++ b/src/daemon/daemonMcpProxy.ts
@@ -37,6 +37,7 @@ import {
   describeBuildIdentity,
   getCurrentBuildIdentity,
 } from "./buildIdentity";
+import { DeviceControlTransportError } from "./deviceControlTransportFailure";
 
 export type VersionMismatchReason =
   | "autoStartDisabled"
@@ -1144,6 +1145,10 @@ export class DaemonMcpProxy {
     return message.includes("Unknown tool:");
   }
 
+  private isPreDispatchDeviceControlTransportError(error: unknown): boolean {
+    return error instanceof DeviceControlTransportError && error.failure.phase === "connect";
+  }
+
   private async resetConnection(): Promise<void> {
     const staleClient = this.client;
     this.connected = false;
@@ -1558,8 +1563,9 @@ export class DaemonMcpProxy {
   //   - executePlan owns its own binding lifecycle via the release signal; leave
   //     it untouched so a pre-handler plan rejection does not strand the binding.
   //   - a recoverable error (DaemonUnavailableError transport/connect failure,
-  //     "Session not found", or an unknown-tool build-skew) never reached the
-  //     handler with a live session, so the lease must be allowed to expire.
+  //     "Session not found", or an unknown-tool build-skew), or a device-control
+  //     connect-phase failure, never reached the handler with a live session, so
+  //     the lease must be allowed to expire.
   private refreshReplayLeaseAfterAdmittedFailure(
     name: string,
     forwardedArgs: Record<string, unknown>,
@@ -1569,7 +1575,8 @@ export class DaemonMcpProxy {
     if (
       name === "executePlan" ||
       name === SET_TOOL_ENABLED_TOOL_NAME ||
-      this.isRecoverableDaemonSessionError(error)
+      this.isRecoverableDaemonSessionError(error) ||
+      this.isPreDispatchDeviceControlTransportError(error)
     ) {
       return;
     }

--- a/src/daemon/daemonMcpProxy.ts
+++ b/src/daemon/daemonMcpProxy.ts
@@ -1145,8 +1145,11 @@ export class DaemonMcpProxy {
     return message.includes("Unknown tool:");
   }
 
-  private isPreDispatchDeviceControlTransportError(error: unknown): boolean {
-    return error instanceof DeviceControlTransportError && error.failure.phase === "connect";
+  private shouldSkipLeaseRefreshForDeviceControlTransportError(error: unknown): boolean {
+    return (
+      error instanceof DeviceControlTransportError
+      && (error.failure.phase === "connect" || !error.failure.sessionValid)
+    );
   }
 
   private async resetConnection(): Promise<void> {
@@ -1564,8 +1567,9 @@ export class DaemonMcpProxy {
   //     it untouched so a pre-handler plan rejection does not strand the binding.
   //   - a recoverable error (DaemonUnavailableError transport/connect failure,
   //     "Session not found", or an unknown-tool build-skew), or a device-control
-  //     connect-phase failure, never reached the handler with a live session, so
-  //     the lease must be allowed to expire.
+  //     connect-phase failure never reached the handler with a live session; a
+  //     response failure with sessionValid=false confirms the session is stale.
+  //     Neither may refresh or establish the replay lease.
   private refreshReplayLeaseAfterAdmittedFailure(
     name: string,
     forwardedArgs: Record<string, unknown>,
@@ -1576,7 +1580,7 @@ export class DaemonMcpProxy {
       name === "executePlan" ||
       name === SET_TOOL_ENABLED_TOOL_NAME ||
       this.isRecoverableDaemonSessionError(error) ||
-      this.isPreDispatchDeviceControlTransportError(error)
+      this.shouldSkipLeaseRefreshForDeviceControlTransportError(error)
     ) {
       return;
     }

--- a/src/daemon/deviceControlTransportFailure.ts
+++ b/src/daemon/deviceControlTransportFailure.ts
@@ -13,8 +13,10 @@ export interface DeviceControlTransportFailure {
   deviceId?: string;
   deviceSessionUuid?: string;
   sessionUuid?: string;
-  /** True only while the daemon session assignment and captured device epoch remain valid. */
+  /** Whether the captured daemon session still exists and retains its device assignment. */
   sessionValid: boolean;
+  /** Whether the captured device epoch is still current for the target device. */
+  deviceSessionValid: boolean;
   phase: DeviceControlTransportPhase;
   retryable: boolean;
   reconnectAttempted: boolean;
@@ -81,6 +83,7 @@ function hasTransportFailureState(
   record: Record<string, unknown>,
 ): record is Record<string, unknown> & {
   sessionValid: boolean;
+  deviceSessionValid: boolean;
   phase: DeviceControlTransportPhase;
   retryable: boolean;
   reconnectAttempted: boolean;
@@ -88,6 +91,7 @@ function hasTransportFailureState(
 } {
   return (
     typeof record.sessionValid === "boolean"
+    && typeof record.deviceSessionValid === "boolean"
     && (record.phase === "connect" || record.phase === "response")
     && typeof record.retryable === "boolean"
     && typeof record.reconnectAttempted === "boolean"
@@ -116,6 +120,7 @@ export function sanitizeDeviceControlTransportFailure(
     toolName: record.toolName,
     ...identity,
     sessionValid: record.sessionValid,
+    deviceSessionValid: record.deviceSessionValid,
     phase: record.phase,
     retryable: record.retryable,
     reconnectAttempted: record.reconnectAttempted,

--- a/src/daemon/deviceControlTransportFailure.ts
+++ b/src/daemon/deviceControlTransportFailure.ts
@@ -1,4 +1,5 @@
 import type { DaemonRequest } from "./types";
+import { McpError } from "@modelcontextprotocol/sdk/types.js";
 
 export const DEVICE_CONTROL_TRANSPORT_FAILURE_CODE = "device_control_transport_failure";
 
@@ -29,6 +30,9 @@ export class DeviceControlTransportError extends Error {
 }
 
 export function isUnexpectedSocketClosure(error: unknown): boolean {
+  if (error instanceof McpError) {
+    return false;
+  }
   const message = error instanceof Error ? error.message : String(error);
   return message.includes("The socket connection was closed unexpectedly");
 }

--- a/src/daemon/deviceControlTransportFailure.ts
+++ b/src/daemon/deviceControlTransportFailure.ts
@@ -12,6 +12,7 @@ export interface DeviceControlTransportFailure {
   deviceId?: string;
   deviceSessionUuid?: string;
   sessionUuid?: string;
+  /** True only while the daemon session assignment and captured device epoch remain valid. */
   sessionValid: boolean;
   phase: DeviceControlTransportPhase;
   retryable: boolean;
@@ -27,6 +28,98 @@ export class DeviceControlTransportError extends Error {
     super(message);
     this.name = "DeviceControlTransportError";
   }
+}
+
+function hasTransportFailureHeader(
+  record: Record<string, unknown>,
+): record is Record<string, unknown> & {
+  code: typeof DEVICE_CONTROL_TRANSPORT_FAILURE_CODE;
+  transport: "daemon_loopback_http";
+  toolName: string;
+} {
+  return (
+    record.code === DEVICE_CONTROL_TRANSPORT_FAILURE_CODE
+    && record.transport === "daemon_loopback_http"
+    && typeof record.toolName === "string"
+    && record.toolName.length > 0
+  );
+}
+
+function sanitizeTransportFailureIdentity(
+  record: Record<string, unknown>,
+): Pick<
+  DeviceControlTransportFailure,
+  "deviceId" | "deviceSessionUuid" | "sessionUuid"
+> | undefined {
+  const identity: Pick<
+    DeviceControlTransportFailure,
+    "deviceId" | "deviceSessionUuid" | "sessionUuid"
+  > = {};
+  if (record.deviceId !== undefined) {
+    if (typeof record.deviceId !== "string") {
+      return undefined;
+    }
+    identity.deviceId = record.deviceId;
+  }
+  if (record.deviceSessionUuid !== undefined) {
+    if (typeof record.deviceSessionUuid !== "string") {
+      return undefined;
+    }
+    identity.deviceSessionUuid = record.deviceSessionUuid;
+  }
+  if (record.sessionUuid !== undefined) {
+    if (typeof record.sessionUuid !== "string") {
+      return undefined;
+    }
+    identity.sessionUuid = record.sessionUuid;
+  }
+  return identity;
+}
+
+function hasTransportFailureState(
+  record: Record<string, unknown>,
+): record is Record<string, unknown> & {
+  sessionValid: boolean;
+  phase: DeviceControlTransportPhase;
+  retryable: boolean;
+  reconnectAttempted: boolean;
+  replayAttempted: boolean;
+} {
+  return (
+    typeof record.sessionValid === "boolean"
+    && (record.phase === "connect" || record.phase === "response")
+    && typeof record.retryable === "boolean"
+    && typeof record.reconnectAttempted === "boolean"
+    && typeof record.replayAttempted === "boolean"
+  );
+}
+
+export function sanitizeDeviceControlTransportFailure(
+  value: unknown,
+): DeviceControlTransportFailure | undefined {
+  if (!value || typeof value !== "object" || Array.isArray(value)) {
+    return undefined;
+  }
+  const record = value as Record<string, unknown>;
+  const identity = sanitizeTransportFailureIdentity(record);
+  if (
+    !hasTransportFailureHeader(record)
+    || !identity
+    || !hasTransportFailureState(record)
+  ) {
+    return undefined;
+  }
+  return {
+    code: DEVICE_CONTROL_TRANSPORT_FAILURE_CODE,
+    transport: "daemon_loopback_http",
+    toolName: record.toolName,
+    ...identity,
+    sessionValid: record.sessionValid,
+    phase: record.phase,
+    retryable: record.retryable,
+    reconnectAttempted: record.reconnectAttempted,
+    replayAttempted: record.replayAttempted,
+  };
 }
 
 export function isUnexpectedSocketClosure(error: unknown): boolean {

--- a/src/daemon/deviceControlTransportFailure.ts
+++ b/src/daemon/deviceControlTransportFailure.ts
@@ -13,6 +13,7 @@ export interface DeviceControlTransportFailure {
   deviceId?: string;
   deviceSessionUuid?: string;
   sessionUuid?: string;
+  routingSessionUuid?: string;
   /** Whether the captured daemon session still exists and retains its device assignment. */
   sessionValid: boolean;
   /** Whether the captured device epoch is still current for the target device. */
@@ -52,11 +53,11 @@ function sanitizeTransportFailureIdentity(
   record: Record<string, unknown>,
 ): Pick<
   DeviceControlTransportFailure,
-  "deviceId" | "deviceSessionUuid" | "sessionUuid"
+  "deviceId" | "deviceSessionUuid" | "sessionUuid" | "routingSessionUuid"
 > | undefined {
   const identity: Pick<
     DeviceControlTransportFailure,
-    "deviceId" | "deviceSessionUuid" | "sessionUuid"
+    "deviceId" | "deviceSessionUuid" | "sessionUuid" | "routingSessionUuid"
   > = {};
   if (record.deviceId !== undefined) {
     if (typeof record.deviceId !== "string") {
@@ -75,6 +76,12 @@ function sanitizeTransportFailureIdentity(
       return undefined;
     }
     identity.sessionUuid = record.sessionUuid;
+  }
+  if (record.routingSessionUuid !== undefined) {
+    if (typeof record.routingSessionUuid !== "string") {
+      return undefined;
+    }
+    identity.routingSessionUuid = record.routingSessionUuid;
   }
   return identity;
 }

--- a/src/daemon/deviceControlTransportFailure.ts
+++ b/src/daemon/deviceControlTransportFailure.ts
@@ -1,0 +1,51 @@
+import type { DaemonRequest } from "./types";
+
+export const DEVICE_CONTROL_TRANSPORT_FAILURE_CODE = "device_control_transport_failure";
+
+export type DeviceControlTransportPhase = "connect" | "response";
+
+export interface DeviceControlTransportFailure {
+  code: typeof DEVICE_CONTROL_TRANSPORT_FAILURE_CODE;
+  transport: "daemon_loopback_http";
+  toolName: string;
+  deviceId?: string;
+  deviceSessionUuid?: string;
+  sessionUuid?: string;
+  sessionValid: boolean;
+  phase: DeviceControlTransportPhase;
+  retryable: boolean;
+  reconnectAttempted: boolean;
+  replayAttempted: boolean;
+}
+
+export class DeviceControlTransportError extends Error {
+  constructor(
+    message: string,
+    readonly failure: DeviceControlTransportFailure,
+  ) {
+    super(message);
+    this.name = "DeviceControlTransportError";
+  }
+}
+
+export function isUnexpectedSocketClosure(error: unknown): boolean {
+  const message = error instanceof Error ? error.message : String(error);
+  return message.includes("The socket connection was closed unexpectedly");
+}
+
+export function isDeviceControlTransportRequest(request: DaemonRequest): boolean {
+  if (request.method !== "tools/call") {
+    return false;
+  }
+  const toolName = request.params?.name;
+  return toolName === "launchApp" || toolName === "observe";
+}
+
+export function isReplaySafeAfterResponseClosure(request: DaemonRequest): boolean {
+  return request.method === "tools/call" && request.params?.name === "observe";
+}
+
+export function deviceControlToolName(request: DaemonRequest): string {
+  const name = request.method === "tools/call" ? request.params?.name : undefined;
+  return typeof name === "string" && name.length > 0 ? name : request.method;
+}

--- a/src/daemon/deviceControlTransportFailure.ts
+++ b/src/daemon/deviceControlTransportFailure.ts
@@ -1,5 +1,6 @@
 import type { DaemonRequest } from "./types";
 import { McpError } from "@modelcontextprotocol/sdk/types.js";
+import { errorMessage } from "../utils/describeUnknownError";
 
 export const DEVICE_CONTROL_TRANSPORT_FAILURE_CODE = "device_control_transport_failure";
 
@@ -126,8 +127,7 @@ export function isUnexpectedSocketClosure(error: unknown): boolean {
   if (error instanceof McpError) {
     return false;
   }
-  const message = error instanceof Error ? error.message : String(error);
-  return message.includes("The socket connection was closed unexpectedly");
+  return errorMessage(error).includes("The socket connection was closed unexpectedly");
 }
 
 export function isDeviceControlTransportRequest(request: DaemonRequest): boolean {

--- a/src/daemon/socketServer.ts
+++ b/src/daemon/socketServer.ts
@@ -87,6 +87,16 @@ import { getDeviceDataStreamServer } from "./deviceDataStreamSocketServer";
 import type { KeyValueType } from "../features/storage/storageTypes";
 import type { BootedDevice, ImeAction, ScreenScaleMetadata } from "../models";
 import type { DeviceService } from "../features/observe/DeviceService";
+import {
+  DEVICE_CONTROL_TRANSPORT_FAILURE_CODE,
+  DeviceControlTransportError,
+  deviceControlToolName,
+  isDeviceControlTransportRequest,
+  isReplaySafeAfterResponseClosure,
+  isUnexpectedSocketClosure,
+  type DeviceControlTransportFailure,
+  type DeviceControlTransportPhase,
+} from "./deviceControlTransportFailure";
 const MCP_CLIENT_IDLE_CLOSE_MS = 5 * 60 * 1000;
 /** Keep shutdown bounded if a request handler ignores its disconnected peer. */
 const DAEMON_REQUEST_HANDLER_DRAIN_TIMEOUT_MS = 1_000;
@@ -171,6 +181,20 @@ interface McpForwardRoute {
   /** Replayed when this transport needs to establish a fresh MCP session. */
   sessionUuid?: string;
   toolSelectionProfileUuid?: string;
+}
+
+interface DeviceControlTransportIdentity {
+  sessionUuid?: string;
+  deviceId?: string;
+  deviceSessionUuid?: string;
+}
+
+interface McpForwardRecoveryContext {
+  request: DaemonRequest;
+  route: McpForwardRoute;
+  socketSessionId: string;
+  remainingTimeoutMs: number;
+  forwardStartMs: number;
 }
 
 const isNonBlankSessionUuid = (value: unknown): value is string =>
@@ -644,68 +668,22 @@ export class UnixSocketServer {
 
             const forwardStartMs = this.timer.now();
             try {
-              const mcpClient = await this.getMcpClient(
-                route.clientKey,
-                route.sessionUuid,
-                route.toolSelectionProfileUuid,
-              );
               const sessionWasActiveBeforeForward = this.wasRequestSessionActive(request);
-
-              try {
-                const response = await this.handleIdeRequest(
-                  mcpClient,
-                  request,
-                  remainingTimeoutMs,
-                  sessionId,
-                );
-                this.recordBoundMcpClientKey(
-                  request,
-                  sessionId,
-                  route,
-                  sessionWasActiveBeforeForward,
-                  response,
-                );
-                return response;
-              } catch (ideError) {
-                const ideErrorMessage = errorMessage(ideError);
-                if (ideErrorMessage.includes("Session not found")) {
-                  logger.warn("MCP client session expired, reconnecting and retrying...");
-                  await this.resetMcpClient(route.clientKey);
-                  const freshClient = await this.getMcpClient(
-                    route.clientKey,
-                    route.sessionUuid,
-                    route.toolSelectionProfileUuid,
-                  );
-                  const retryRemainingMs = remainingTimeoutMs - (this.timer.now() - forwardStartMs);
-                  if (retryRemainingMs <= 0) {
-                    const toolName =
-                      request.method === "tools/call"
-                        ? (request.params?.name ?? request.method)
-                        : request.method;
-                    throw new McpTimeoutError({
-                      toolName,
-                      timeoutMs: remainingTimeoutMs,
-                      origin: "UnixSocketServer.handleRequest",
-                      detail: `no budget remaining after session reconnect (elapsed ${this.timer.now() - forwardStartMs}ms)`,
-                    });
-                  }
-                  const response = await this.handleIdeRequest(
-                    freshClient,
-                    request,
-                    retryRemainingMs,
-                    sessionId,
-                  );
-                  this.recordBoundMcpClientKey(
-                    request,
-                    sessionId,
-                    route,
-                    sessionWasActiveBeforeForward,
-                    response,
-                  );
-                  return response;
-                }
-                throw ideError;
-              }
+              const response = await this.forwardMcpRequestWithRecovery({
+                request,
+                route,
+                socketSessionId: sessionId,
+                remainingTimeoutMs,
+                forwardStartMs,
+              });
+              this.recordBoundMcpClientKey(
+                request,
+                sessionId,
+                route,
+                sessionWasActiveBeforeForward,
+                response,
+              );
+              return response;
             } finally {
               logger.debug(
                 `[McpForward] end executionKey=${route.executionKey} clientKey=${route.clientKey} socketSession=${sessionId} requestId=${request.id} ${forwardLabel} forwardMs=${this.timer.now() - forwardStartMs}`,
@@ -734,6 +712,9 @@ export class UnixSocketServer {
           type: "mcp_response",
           success: false,
           error: errorMsg,
+          ...(error instanceof DeviceControlTransportError
+            ? { transportFailure: error.failure }
+            : {}),
           ...(error instanceof InputTypeTextAppendError ? { charsSent: error.charsSent } : {}),
         };
       }
@@ -1239,6 +1220,313 @@ export class UnixSocketServer {
       }
     }
     return false;
+  }
+
+  private isDeviceControlSocketClosure(
+    request: DaemonRequest,
+    error: unknown,
+  ): boolean {
+    return isDeviceControlTransportRequest(request) && isUnexpectedSocketClosure(error);
+  }
+
+  private async forwardMcpRequestWithRecovery(
+    context: McpForwardRecoveryContext,
+  ): Promise<unknown> {
+    const identity = this.getDeviceControlTransportIdentity(context.request, context.route);
+    let mcpClient: Client;
+    try {
+      mcpClient = await this.getMcpClient(
+        context.route.clientKey,
+        context.route.sessionUuid,
+        context.route.toolSelectionProfileUuid,
+      );
+    } catch (error) {
+      if (!this.isDeviceControlSocketClosure(context.request, error)) {
+        throw error;
+      }
+      return this.recoverDeviceControlTransport({
+        ...context,
+        phase: "connect",
+        identity,
+      });
+    }
+    return this.forwardConnectedMcpRequest(context, identity, mcpClient);
+  }
+
+  private async forwardConnectedMcpRequest(
+    context: McpForwardRecoveryContext,
+    identity: DeviceControlTransportIdentity,
+    mcpClient: Client,
+  ): Promise<unknown> {
+    try {
+      return await this.handleIdeRequest(
+        mcpClient,
+        context.request,
+        context.remainingTimeoutMs,
+        context.socketSessionId,
+      );
+    } catch (error) {
+      const message = error instanceof Error ? error.message : String(error);
+      if (message.includes("Session not found")) {
+        return this.retryExpiredMcpSession(context);
+      }
+      if (this.isDeviceControlSocketClosure(context.request, error)) {
+        return this.recoverDeviceControlTransport({
+          ...context,
+          phase: "response",
+          identity,
+        });
+      }
+      throw error;
+    }
+  }
+
+  private async retryExpiredMcpSession(
+    context: McpForwardRecoveryContext,
+  ): Promise<unknown> {
+    logger.warn("MCP client session expired, reconnecting and retrying...");
+    await this.resetMcpClient(context.route.clientKey);
+    const freshClient = await this.getMcpClient(
+      context.route.clientKey,
+      context.route.sessionUuid,
+      context.route.toolSelectionProfileUuid,
+    );
+    const retryRemainingMs =
+      context.remainingTimeoutMs - (this.timer.now() - context.forwardStartMs);
+    if (retryRemainingMs <= 0) {
+      const toolName = context.request.method === "tools/call"
+        ? context.request.params?.name ?? context.request.method
+        : context.request.method;
+      throw new McpTimeoutError({
+        toolName,
+        timeoutMs: context.remainingTimeoutMs,
+        origin: "UnixSocketServer.handleRequest",
+        detail: `no budget remaining after session reconnect (elapsed ${this.timer.now() - context.forwardStartMs}ms)`,
+      });
+    }
+    return this.handleIdeRequest(
+      freshClient,
+      context.request,
+      retryRemainingMs,
+      context.socketSessionId,
+    );
+  }
+
+  private getDeviceControlTransportIdentity(
+    request: DaemonRequest,
+    route: McpForwardRoute,
+  ): DeviceControlTransportIdentity {
+    const args = request.method === "tools/call" ? request.params?.arguments : undefined;
+    const sessionUuid = route.sessionUuid ?? this.getSessionUuid(args);
+    const deviceId = this.resolveDeviceControlDeviceId(args, sessionUuid);
+    const deviceSessionUuid = this.resolveDeviceControlSessionUuid(deviceId);
+    return { sessionUuid, deviceId, deviceSessionUuid };
+  }
+
+  private resolveDeviceControlDeviceId(
+    args: unknown,
+    sessionUuid?: string,
+  ): string | undefined {
+    if (args && typeof args === "object" && !Array.isArray(args)) {
+      const explicitDeviceId = (args as Record<string, unknown>).deviceId;
+      if (typeof explicitDeviceId === "string") {
+        return explicitDeviceId;
+      }
+    }
+    if (!sessionUuid || !this.daemonState.isInitialized()) {
+      return undefined;
+    }
+    try {
+      return this.daemonState.getSessionManager().getSession(sessionUuid)?.assignedDevice;
+    } catch (error) {
+      logger.debug(`Unable to resolve transport session ${sessionUuid}: ${error}`);
+      return undefined;
+    }
+  }
+
+  private resolveDeviceControlSessionUuid(deviceId?: string): string | undefined {
+    if (!deviceId || !this.daemonState.isInitialized()) {
+      return undefined;
+    }
+    try {
+      return this.daemonState
+        .getDeviceSessionRegistry()
+        .list()
+        .find(record => record.deviceId === deviceId)
+        ?.deviceSessionUuid;
+    } catch (error) {
+      logger.debug(`Unable to resolve transport device epoch for ${deviceId}: ${error}`);
+      return undefined;
+    }
+  }
+
+  private isDeviceControlTransportIdentityValid(
+    identity: DeviceControlTransportIdentity,
+  ): boolean {
+    if (
+      !this.daemonState.isInitialized()
+      || !identity.deviceId
+      || !identity.deviceSessionUuid
+    ) {
+      return false;
+    }
+    try {
+      if (identity.sessionUuid) {
+        const session = this.daemonState.getSessionManager().getSession(identity.sessionUuid);
+        if (!session || session.assignedDevice !== identity.deviceId) {
+          return false;
+        }
+      }
+      const liveDeviceSession = this.daemonState
+        .getDeviceSessionRegistry()
+        .list()
+        .find(record => record.deviceId === identity.deviceId);
+      return liveDeviceSession?.deviceSessionUuid === identity.deviceSessionUuid;
+    } catch (error) {
+      logger.debug(`Unable to validate device-control transport identity: ${error}`);
+      return false;
+    }
+  }
+
+  private deviceControlTransportError(input: {
+    request: DaemonRequest;
+    identity: DeviceControlTransportIdentity;
+    phase: DeviceControlTransportPhase;
+    reconnectAttempted: boolean;
+    replayAttempted: boolean;
+    recoveryExhausted: boolean;
+  }): DeviceControlTransportError {
+    const toolName = deviceControlToolName(input.request);
+    const sessionValid = this.isDeviceControlTransportIdentityValid(input.identity);
+    const retryable =
+      sessionValid
+      && (
+        input.phase === "connect"
+        || isReplaySafeAfterResponseClosure(input.request)
+      );
+    const failure: DeviceControlTransportFailure = {
+      code: DEVICE_CONTROL_TRANSPORT_FAILURE_CODE,
+      transport: "daemon_loopback_http",
+      toolName,
+      ...(input.identity.deviceId ? { deviceId: input.identity.deviceId } : {}),
+      ...(input.identity.deviceSessionUuid
+        ? { deviceSessionUuid: input.identity.deviceSessionUuid }
+        : {}),
+      ...(input.identity.sessionUuid ? { sessionUuid: input.identity.sessionUuid } : {}),
+      sessionValid,
+      phase: input.phase,
+      retryable,
+      reconnectAttempted: input.reconnectAttempted,
+      replayAttempted: input.replayAttempted,
+    };
+    const message = input.recoveryExhausted
+      ? `Device-control transport recovery exhausted while handling ${toolName}`
+      : `Device-control transport closed while handling ${toolName}`;
+    return new DeviceControlTransportError(message, failure);
+  }
+
+  private async recoverDeviceControlTransport(input: {
+    request: DaemonRequest;
+    route: McpForwardRoute;
+    socketSessionId: string;
+    remainingTimeoutMs: number;
+    forwardStartMs: number;
+    phase: DeviceControlTransportPhase;
+    identity: DeviceControlTransportIdentity;
+  }): Promise<unknown> {
+    if (!this.isDeviceControlTransportIdentityValid(input.identity)) {
+      throw this.deviceControlTransportError({
+        request: input.request,
+        identity: input.identity,
+        phase: input.phase,
+        reconnectAttempted: false,
+        replayAttempted: false,
+        recoveryExhausted: false,
+      });
+    }
+
+    const replayAfterResponse =
+      input.phase === "response"
+      && isReplaySafeAfterResponseClosure(input.request);
+    logger.warn(
+      `[McpForward] device-control transport closed for ${deviceControlToolName(input.request)} during ${input.phase}; reconnecting once`,
+    );
+    await this.resetMcpClient(input.route.clientKey);
+    const retryRemainingMs =
+      input.remainingTimeoutMs - (this.timer.now() - input.forwardStartMs);
+    if (retryRemainingMs <= 0) {
+      throw this.deviceControlTransportError({
+        request: input.request,
+        identity: input.identity,
+        phase: input.phase,
+        reconnectAttempted: true,
+        replayAttempted: false,
+        recoveryExhausted: true,
+      });
+    }
+
+    let freshClient: Client;
+    try {
+      freshClient = await this.getMcpClient(
+        input.route.clientKey,
+        input.route.sessionUuid,
+        input.route.toolSelectionProfileUuid,
+      );
+    } catch {
+      logger.warn(
+        `[McpForward] device-control transport reconnect failed for ${deviceControlToolName(input.request)}`,
+      );
+      throw this.deviceControlTransportError({
+        request: input.request,
+        identity: input.identity,
+        phase: input.phase,
+        reconnectAttempted: true,
+        replayAttempted: false,
+        recoveryExhausted: true,
+      });
+    }
+
+    if (!this.isDeviceControlTransportIdentityValid(input.identity)) {
+      throw this.deviceControlTransportError({
+        request: input.request,
+        identity: input.identity,
+        phase: input.phase,
+        reconnectAttempted: true,
+        replayAttempted: false,
+        recoveryExhausted: false,
+      });
+    }
+    if (input.phase === "response" && !replayAfterResponse) {
+      throw this.deviceControlTransportError({
+        request: input.request,
+        identity: input.identity,
+        phase: input.phase,
+        reconnectAttempted: true,
+        replayAttempted: false,
+        recoveryExhausted: false,
+      });
+    }
+
+    try {
+      return await this.handleIdeRequest(
+        freshClient,
+        input.request,
+        retryRemainingMs,
+        input.socketSessionId,
+      );
+    } catch (error) {
+      if (!isUnexpectedSocketClosure(error)) {
+        throw error;
+      }
+      throw this.deviceControlTransportError({
+        request: input.request,
+        identity: input.identity,
+        phase: "response",
+        reconnectAttempted: true,
+        replayAttempted: replayAfterResponse,
+        recoveryExhausted: true,
+      });
+    }
   }
 
   private wasRequestSessionActive(request: DaemonRequest): boolean {

--- a/src/daemon/socketServer.ts
+++ b/src/daemon/socketServer.ts
@@ -197,6 +197,11 @@ interface McpForwardRecoveryContext {
   forwardStartMs: number;
 }
 
+interface DeviceControlTransportRecoveryContext extends McpForwardRecoveryContext {
+  phase: DeviceControlTransportPhase;
+  identity: DeviceControlTransportIdentity;
+}
+
 const isNonBlankSessionUuid = (value: unknown): value is string =>
   typeof value === "string" && value.trim().length > 0;
 
@@ -1278,10 +1283,13 @@ export class UnixSocketServer {
         return this.retryExpiredMcpSession(context, identity);
       }
       if (this.isDeviceControlSocketClosure(context.request, error)) {
+        const recoveryIdentity = this.hasEstablishedDeviceControlTransportIdentity(identity)
+          ? identity
+          : this.getDeviceControlTransportIdentity(context);
         return this.recoverDeviceControlTransport({
           ...context,
           phase: "response",
-          identity,
+          identity: recoveryIdentity,
         });
       }
       throw error;
@@ -1438,6 +1446,12 @@ export class UnixSocketServer {
     }
   }
 
+  private hasEstablishedDeviceControlTransportIdentity(
+    identity: DeviceControlTransportIdentity,
+  ): boolean {
+    return Boolean(identity.deviceId && identity.deviceSessionUuid);
+  }
+
   private isDeviceControlTransportIdentityValid(
     identity: DeviceControlTransportIdentity,
   ): boolean {
@@ -1466,6 +1480,28 @@ export class UnixSocketServer {
     }
   }
 
+  private isDeviceControlRecoveryIdentityValid(
+    identity: DeviceControlTransportIdentity,
+    phase: DeviceControlTransportPhase,
+  ): boolean {
+    if (
+      phase === "connect"
+      && !this.hasEstablishedDeviceControlTransportIdentity(identity)
+    ) {
+      return true;
+    }
+    return this.isDeviceControlTransportIdentityValid(identity);
+  }
+
+  private isDeviceControlReplayResultIdentityValid(
+    identity: DeviceControlTransportIdentity,
+  ): boolean {
+    return (
+      !this.hasEstablishedDeviceControlTransportIdentity(identity)
+      || this.isDeviceControlTransportIdentityValid(identity)
+    );
+  }
+
   private deviceControlTransportError(input: {
     request: DaemonRequest;
     identity: DeviceControlTransportIdentity;
@@ -1476,12 +1512,12 @@ export class UnixSocketServer {
   }): DeviceControlTransportError {
     const toolName = deviceControlToolName(input.request);
     const sessionValid = this.isDeviceControlTransportIdentityValid(input.identity);
+    const identityEstablished =
+      this.hasEstablishedDeviceControlTransportIdentity(input.identity);
     const retryable =
-      sessionValid
-      && (
-        input.phase === "connect"
-        || isReplaySafeAfterResponseClosure(input.request)
-      );
+      input.phase === "connect"
+        ? !identityEstablished || sessionValid
+        : sessionValid && isReplaySafeAfterResponseClosure(input.request);
     const failure: DeviceControlTransportFailure = {
       code: DEVICE_CONTROL_TRANSPORT_FAILURE_CODE,
       transport: "daemon_loopback_http",
@@ -1546,17 +1582,53 @@ export class UnixSocketServer {
     }
   }
 
-  private async recoverDeviceControlTransport(input: {
-    request: DaemonRequest;
-    route: McpForwardRoute;
-    socketSessionId: string;
-    remainingTimeoutMs: number;
-    forwardStartMs: number;
-    phase: DeviceControlTransportPhase;
-    identity: DeviceControlTransportIdentity;
-  }): Promise<unknown> {
+  private isDeviceControlReconnectExhaustion(
+    request: DaemonRequest,
+    error: unknown,
+  ): boolean {
+    return (
+      error instanceof McpClientReconnectDeadlineError
+      || this.isDeviceControlSocketClosure(request, error)
+    );
+  }
+
+  private getDeviceControlRecoveryFailureIdentity(
+    context: McpForwardRecoveryContext,
+    identity: DeviceControlTransportIdentity,
+  ): DeviceControlTransportIdentity {
+    return this.hasEstablishedDeviceControlTransportIdentity(identity)
+      ? identity
+      : this.getDeviceControlTransportIdentity(context);
+  }
+
+  private async reconnectDeviceControlTransport(
+    input: DeviceControlTransportRecoveryContext,
+  ): Promise<Client> {
+    try {
+      return await this.reconnectMcpClientWithinDeadline(input);
+    } catch (error) {
+      if (!this.isDeviceControlReconnectExhaustion(input.request, error)) {
+        throw error;
+      }
+      logger.warn(
+        `[McpForward] device-control transport reconnect failed for ${deviceControlToolName(input.request)}`,
+      );
+      throw this.deviceControlTransportError({
+        request: input.request,
+        identity: input.identity,
+        phase: input.phase,
+        reconnectAttempted: true,
+        replayAttempted: false,
+        recoveryExhausted: true,
+      });
+    }
+  }
+
+  private async recoverDeviceControlTransport(
+    input: DeviceControlTransportRecoveryContext,
+  ): Promise<unknown> {
     await this.resetMcpClient(input.route.clientKey, "detach");
-    if (!this.isDeviceControlTransportIdentityValid(input.identity)) {
+    if (!this.isDeviceControlRecoveryIdentityValid(input.identity, input.phase)) {
       throw this.deviceControlTransportError({
         request: input.request,
         identity: input.identity,
@@ -1584,22 +1656,7 @@ export class UnixSocketServer {
       });
     }
 
-    let freshClient: Client;
-    try {
-      freshClient = await this.reconnectMcpClientWithinDeadline(input);
-    } catch {
-      logger.warn(
-        `[McpForward] device-control transport reconnect failed for ${deviceControlToolName(input.request)}`,
-      );
-      throw this.deviceControlTransportError({
-        request: input.request,
-        identity: input.identity,
-        phase: input.phase,
-        reconnectAttempted: true,
-        replayAttempted: false,
-        recoveryExhausted: true,
-      });
-    }
+    const freshClient = await this.reconnectDeviceControlTransport(input);
 
     const retryRemainingMs = this.remainingMcpForwardBudget(input);
     if (retryRemainingMs <= 0) {
@@ -1612,7 +1669,7 @@ export class UnixSocketServer {
         recoveryExhausted: true,
       });
     }
-    if (!this.isDeviceControlTransportIdentityValid(input.identity)) {
+    if (!this.isDeviceControlRecoveryIdentityValid(input.identity, input.phase)) {
       await this.resetMcpClient(input.route.clientKey, "detach");
       throw this.deviceControlTransportError({
         request: input.request,
@@ -1641,7 +1698,7 @@ export class UnixSocketServer {
         retryRemainingMs,
         input.socketSessionId,
       );
-      if (!this.isDeviceControlTransportIdentityValid(input.identity)) {
+      if (!this.isDeviceControlReplayResultIdentityValid(input.identity)) {
         await this.resetMcpClient(input.route.clientKey, "detach");
         throw this.deviceControlTransportError({
           request: input.request,
@@ -1658,9 +1715,13 @@ export class UnixSocketServer {
         throw error;
       }
       await this.resetMcpClient(input.route.clientKey, "detach");
+      const failureIdentity = this.getDeviceControlRecoveryFailureIdentity(
+        input,
+        input.identity,
+      );
       throw this.deviceControlTransportError({
         request: input.request,
-        identity: input.identity,
+        identity: failureIdentity,
         phase: "response",
         reconnectAttempted: true,
         replayAttempted: replayAfterResponse,

--- a/src/daemon/socketServer.ts
+++ b/src/daemon/socketServer.ts
@@ -185,7 +185,9 @@ interface McpForwardRoute {
 
 interface DeviceControlTransportIdentity {
   sessionUuid?: string;
+  sessionIncarnation?: object;
   routingSessionUuid?: string;
+  routingSessionIncarnation?: object;
   deviceId?: string;
   deviceSessionUuid?: string;
   deviceLabelResolved?: boolean;
@@ -1384,12 +1386,19 @@ export class UnixSocketServer {
       args && typeof args === "object" && !Array.isArray(args)
         ? this.getSessionUuid(args as Record<string, unknown>) ?? context.route.sessionUuid
         : context.route.sessionUuid;
+    const sessionIncarnation = this.getDeviceControlSessionIncarnation(sessionUuid);
+    const routingSessionIncarnation =
+      routingSessionUuid === sessionUuid
+        ? sessionIncarnation
+        : this.getDeviceControlSessionIncarnation(routingSessionUuid);
     const deviceId = this.resolveDeviceControlDeviceId(args, sessionUuid);
     const deviceSessionUuid = this.resolveDeviceControlSessionUuid(deviceId);
     const deviceLabelResolved = this.getDeviceControlLabelResolution(args);
     return {
       sessionUuid,
+      sessionIncarnation,
       routingSessionUuid,
+      routingSessionIncarnation,
       deviceId,
       deviceSessionUuid,
       deviceLabelResolved,
@@ -1458,6 +1467,20 @@ export class UnixSocketServer {
     }
   }
 
+  private getDeviceControlSessionIncarnation(
+    sessionUuid: string | undefined,
+  ): object | undefined {
+    if (!sessionUuid || !this.daemonState.isInitialized()) {
+      return undefined;
+    }
+    try {
+      return this.daemonState.getSessionManager().getSession(sessionUuid) ?? undefined;
+    } catch (error) {
+      logger.debug(`Unable to capture device-control session ${sessionUuid}: ${error}`);
+      return undefined;
+    }
+  }
+
   private resolveDeviceControlDeviceId(
     args: unknown,
     sessionUuid?: string,
@@ -1520,7 +1543,11 @@ export class UnixSocketServer {
     }
     try {
       const session = this.daemonState.getSessionManager().getSession(identity.sessionUuid);
-      return Boolean(session && (!identity.deviceId || session.assignedDevice === identity.deviceId));
+      return Boolean(
+        session
+        && session === identity.sessionIncarnation
+        && (!identity.deviceId || session.assignedDevice === identity.deviceId),
+      );
     } catch (error) {
       logger.debug(`Unable to validate device-control target owner: ${error}`);
       return false;
@@ -1537,10 +1564,12 @@ export class UnixSocketServer {
       return true;
     }
     try {
+      const session = this.daemonState
+        .getSessionManager()
+        .getSession(identity.routingSessionUuid);
       return Boolean(
-        this.daemonState
-          .getSessionManager()
-          .getSession(identity.routingSessionUuid),
+        session
+        && session === identity.routingSessionIncarnation,
       );
     } catch (error) {
       logger.debug(`Unable to validate device-control routing session: ${error}`);
@@ -1708,8 +1737,13 @@ export class UnixSocketServer {
     const refreshedIdentity = this.getDeviceControlTransportIdentity(context);
     return {
       sessionUuid: identity.sessionUuid ?? refreshedIdentity.sessionUuid,
+      sessionIncarnation:
+        identity.sessionIncarnation ?? refreshedIdentity.sessionIncarnation,
       routingSessionUuid:
         identity.routingSessionUuid ?? refreshedIdentity.routingSessionUuid,
+      routingSessionIncarnation:
+        identity.routingSessionIncarnation
+        ?? refreshedIdentity.routingSessionIncarnation,
       deviceId: identity.deviceId ?? refreshedIdentity.deviceId,
       deviceSessionUuid:
         identity.deviceSessionUuid ?? refreshedIdentity.deviceSessionUuid,
@@ -1750,9 +1784,10 @@ export class UnixSocketServer {
       const pinnedArguments: Record<string, unknown> = {
         ...originalArguments,
         deviceId: identity.deviceId,
+        ...(identity.sessionUuid ? { sessionUuid: identity.sessionUuid } : {}),
       };
-      // Preserve the base session's authorization scope while replacing the
-      // mutable label selector with the captured physical target.
+      // Preserve the captured execution session while replacing the mutable
+      // label selector with the captured physical target.
       delete pinnedArguments.device;
       return {
         ...request,
@@ -1807,10 +1842,22 @@ export class UnixSocketServer {
     replayAfterResponse: boolean,
   ): McpForwardRoute {
     if (
+      replayAfterResponse
+      && input.identity.deviceLabelResolved === true
+      && input.identity.sessionUuid
+    ) {
+      return this.sessionScopedForwardRoute(
+        input.socketSessionId,
+        input.identity.sessionUuid,
+        input.route.executionKey,
+        input.identity.routingSessionUuid
+          ?? input.route.toolSelectionProfileUuid,
+      );
+    }
+    if (
       !replayAfterResponse
       || !input.identity.sessionUuid
       || input.route.sessionUuid === input.identity.sessionUuid
-      || input.identity.deviceLabelResolved === true
       || this.hasStableExplicitDeviceControlTarget(input.request, input.identity)
     ) {
       return input.route;

--- a/src/daemon/socketServer.ts
+++ b/src/daemon/socketServer.ts
@@ -1275,7 +1275,7 @@ export class UnixSocketServer {
     } catch (error) {
       const message = error instanceof Error ? error.message : String(error);
       if (message.includes("Session not found")) {
-        return this.retryExpiredMcpSession(context);
+        return this.retryExpiredMcpSession(context, identity);
       }
       if (this.isDeviceControlSocketClosure(context.request, error)) {
         return this.recoverDeviceControlTransport({
@@ -1290,14 +1290,30 @@ export class UnixSocketServer {
 
   private async retryExpiredMcpSession(
     context: McpForwardRecoveryContext,
+    identity: DeviceControlTransportIdentity,
   ): Promise<unknown> {
     logger.warn("MCP client session expired, reconnecting and retrying...");
     await this.resetMcpClient(context.route.clientKey);
-    const freshClient = await this.getMcpClient(
-      context.route.clientKey,
-      context.route.sessionUuid,
-      context.route.toolSelectionProfileUuid,
-    );
+    let freshClient: Client;
+    try {
+      freshClient = await this.getMcpClient(
+        context.route.clientKey,
+        context.route.sessionUuid,
+        context.route.toolSelectionProfileUuid,
+      );
+    } catch (error) {
+      if (!this.isDeviceControlSocketClosure(context.request, error)) {
+        throw error;
+      }
+      throw this.deviceControlTransportError({
+        request: context.request,
+        identity,
+        phase: "connect",
+        reconnectAttempted: true,
+        replayAttempted: false,
+        recoveryExhausted: true,
+      });
+    }
     const retryRemainingMs =
       context.remainingTimeoutMs - (this.timer.now() - context.forwardStartMs);
     if (retryRemainingMs <= 0) {
@@ -1311,12 +1327,27 @@ export class UnixSocketServer {
         detail: `no budget remaining after session reconnect (elapsed ${this.timer.now() - context.forwardStartMs}ms)`,
       });
     }
-    return this.handleIdeRequest(
-      freshClient,
-      context.request,
-      retryRemainingMs,
-      context.socketSessionId,
-    );
+    try {
+      return await this.handleIdeRequest(
+        freshClient,
+        context.request,
+        retryRemainingMs,
+        context.socketSessionId,
+      );
+    } catch (error) {
+      if (!this.isDeviceControlSocketClosure(context.request, error)) {
+        throw error;
+      }
+      await this.resetMcpClient(context.route.clientKey, "detach");
+      throw this.deviceControlTransportError({
+        request: context.request,
+        identity,
+        phase: "response",
+        reconnectAttempted: true,
+        replayAttempted: true,
+        recoveryExhausted: true,
+      });
+    }
   }
 
   private getDeviceControlTransportIdentity(

--- a/src/daemon/socketServer.ts
+++ b/src/daemon/socketServer.ts
@@ -1652,6 +1652,11 @@ export class UnixSocketServer {
     ) {
       return request;
     }
+    if (this.hasStableExplicitDeviceControlTarget(request, identity)) {
+      // deviceId is already immutable; retaining the original routing session also
+      // preserves its tool-selection grant alongside the target device's grant.
+      return request;
+    }
     const pinnedArguments: Record<string, unknown> = {
       ...(args as Record<string, unknown>),
       ...(identity.sessionUuid
@@ -1672,6 +1677,21 @@ export class UnixSocketServer {
     };
   }
 
+  private hasStableExplicitDeviceControlTarget(
+    request: DaemonRequest,
+    identity: DeviceControlTransportIdentity,
+  ): boolean {
+    if (identity.deviceLabelResolved === true || request.method !== "tools/call") {
+      return false;
+    }
+    const args = request.params?.arguments;
+    if (!args || typeof args !== "object" || Array.isArray(args)) {
+      return false;
+    }
+    const deviceId = (args as Record<string, unknown>).deviceId;
+    return typeof deviceId === "string" && deviceId.length > 0;
+  }
+
   private getDeviceControlRecoveryRoute(
     input: DeviceControlTransportRecoveryContext,
     replayAfterResponse: boolean,
@@ -1680,6 +1700,7 @@ export class UnixSocketServer {
       !replayAfterResponse
       || !input.identity.sessionUuid
       || input.route.sessionUuid === input.identity.sessionUuid
+      || this.hasStableExplicitDeviceControlTarget(input.request, input.identity)
     ) {
       return input.route;
     }

--- a/src/daemon/socketServer.ts
+++ b/src/daemon/socketServer.ts
@@ -1609,7 +1609,7 @@ export class UnixSocketServer {
     const args = request.method === "tools/call" ? request.params?.arguments : undefined;
     if (
       phase !== "response"
-      || !identity.sessionUuid
+      || !identity.deviceId
       || !args
       || typeof args !== "object"
       || Array.isArray(args)
@@ -1618,10 +1618,15 @@ export class UnixSocketServer {
     }
     const pinnedArguments: Record<string, unknown> = {
       ...(args as Record<string, unknown>),
-      sessionUuid: identity.sessionUuid,
+      ...(identity.sessionUuid
+        ? { sessionUuid: identity.sessionUuid }
+        : { deviceId: identity.deviceId }),
     };
-    // A label can be remapped while reconnecting; replay the captured session instead.
+    // A label can be remapped while reconnecting; replay the captured target instead.
     delete pinnedArguments.device;
+    if (identity.sessionUuid) {
+      delete pinnedArguments.deviceId;
+    }
     return {
       ...request,
       params: {
@@ -1629,6 +1634,37 @@ export class UnixSocketServer {
         arguments: pinnedArguments,
       },
     };
+  }
+
+  private getDeviceControlRecoveryRoute(
+    input: DeviceControlTransportRecoveryContext,
+    replayAfterResponse: boolean,
+  ): McpForwardRoute {
+    if (
+      !replayAfterResponse
+      || !input.identity.sessionUuid
+      || input.route.sessionUuid === input.identity.sessionUuid
+    ) {
+      return input.route;
+    }
+    return this.sessionScopedForwardRoute(
+      input.socketSessionId,
+      input.identity.sessionUuid,
+      input.route.executionKey,
+      input.route.toolSelectionProfileUuid,
+    );
+  }
+
+  private scheduleDistinctRecoveryRouteIdleClose(
+    originalRoute: McpForwardRoute,
+    recoveryRoute: McpForwardRoute,
+  ): void {
+    if (
+      recoveryRoute.clientKey !== originalRoute.clientKey
+      && this.mcpClients.has(recoveryRoute.clientKey)
+    ) {
+      this.scheduleMcpClientIdleClose(recoveryRoute.clientKey);
+    }
   }
 
   private async reconnectDeviceControlTransport(
@@ -1686,10 +1722,13 @@ export class UnixSocketServer {
       });
     }
 
-    const freshClient = await this.reconnectDeviceControlTransport(input);
+    const recoveryRoute = this.getDeviceControlRecoveryRoute(input, replayAfterResponse);
+    const recoveryInput = { ...input, route: recoveryRoute };
+    const freshClient = await this.reconnectDeviceControlTransport(recoveryInput);
 
     const retryRemainingMs = this.remainingMcpForwardBudget(input);
     if (retryRemainingMs <= 0) {
+      this.scheduleDistinctRecoveryRouteIdleClose(input.route, recoveryRoute);
       throw this.deviceControlTransportError({
         request: input.request,
         identity: input.identity,
@@ -1700,7 +1739,7 @@ export class UnixSocketServer {
       });
     }
     if (!this.isDeviceControlRecoveryIdentityValid(input.identity, input.phase)) {
-      await this.resetMcpClient(input.route.clientKey, "detach");
+      await this.resetMcpClient(recoveryRoute.clientKey, "detach");
       throw this.deviceControlTransportError({
         request: input.request,
         identity: input.identity,
@@ -1734,7 +1773,7 @@ export class UnixSocketServer {
         input.socketSessionId,
       );
       if (!this.isDeviceControlReplayResultIdentityValid(input.identity)) {
-        await this.resetMcpClient(input.route.clientKey, "detach");
+        await this.resetMcpClient(recoveryRoute.clientKey, "detach");
         throw this.deviceControlTransportError({
           request: input.request,
           identity: input.identity,
@@ -1749,7 +1788,7 @@ export class UnixSocketServer {
       if (!isUnexpectedSocketClosure(error)) {
         throw error;
       }
-      await this.resetMcpClient(input.route.clientKey, "detach");
+      await this.resetMcpClient(recoveryRoute.clientKey, "detach");
       const failureIdentity = this.getDeviceControlRecoveryFailureIdentity(
         input,
         input.identity,
@@ -1762,6 +1801,8 @@ export class UnixSocketServer {
         replayAttempted: replayAfterResponse,
         recoveryExhausted: true,
       });
+    } finally {
+      this.scheduleDistinctRecoveryRouteIdleClose(input.route, recoveryRoute);
     }
   }
 

--- a/src/daemon/socketServer.ts
+++ b/src/daemon/socketServer.ts
@@ -1487,7 +1487,20 @@ export class UnixSocketServer {
     return Boolean(identity.deviceId && identity.deviceSessionUuid);
   }
 
-  private isDeviceControlTransportIdentityValid(
+  private isDeviceControlSessionValid(identity: DeviceControlTransportIdentity): boolean {
+    if (!this.daemonState.isInitialized() || !identity.sessionUuid) {
+      return false;
+    }
+    try {
+      const session = this.daemonState.getSessionManager().getSession(identity.sessionUuid);
+      return Boolean(session && (!identity.deviceId || session.assignedDevice === identity.deviceId));
+    } catch (error) {
+      logger.debug(`Unable to validate device-control daemon session: ${error}`);
+      return false;
+    }
+  }
+
+  private isDeviceControlDeviceSessionValid(
     identity: DeviceControlTransportIdentity,
   ): boolean {
     if (
@@ -1498,21 +1511,23 @@ export class UnixSocketServer {
       return false;
     }
     try {
-      if (identity.sessionUuid) {
-        const session = this.daemonState.getSessionManager().getSession(identity.sessionUuid);
-        if (!session || session.assignedDevice !== identity.deviceId) {
-          return false;
-        }
-      }
       const liveDeviceSession = this.daemonState
         .getDeviceSessionRegistry()
         .list()
         .find(record => record.deviceId === identity.deviceId);
       return liveDeviceSession?.deviceSessionUuid === identity.deviceSessionUuid;
     } catch (error) {
-      logger.debug(`Unable to validate device-control transport identity: ${error}`);
+      logger.debug(`Unable to validate device-control device epoch: ${error}`);
       return false;
     }
+  }
+
+  private isDeviceControlTransportIdentityValid(
+    identity: DeviceControlTransportIdentity,
+  ): boolean {
+    const sessionValid =
+      !identity.sessionUuid || this.isDeviceControlSessionValid(identity);
+    return sessionValid && this.isDeviceControlDeviceSessionValid(identity);
   }
 
   private isDeviceControlRecoveryIdentityValid(
@@ -1546,13 +1561,16 @@ export class UnixSocketServer {
     recoveryExhausted: boolean;
   }): DeviceControlTransportError {
     const toolName = deviceControlToolName(input.request);
-    const sessionValid = this.isDeviceControlTransportIdentityValid(input.identity);
+    const sessionValid = this.isDeviceControlSessionValid(input.identity);
+    const deviceSessionValid = this.isDeviceControlDeviceSessionValid(input.identity);
+    const identityValid =
+      (!input.identity.sessionUuid || sessionValid) && deviceSessionValid;
     const identityEstablished =
       this.hasEstablishedDeviceControlTransportIdentity(input.identity);
     const retryable =
       input.phase === "connect"
-        ? !identityEstablished || sessionValid
-        : sessionValid && isReplaySafeAfterResponseClosure(input.request);
+        ? !identityEstablished || identityValid
+        : identityValid && isReplaySafeAfterResponseClosure(input.request);
     const failure: DeviceControlTransportFailure = {
       code: DEVICE_CONTROL_TRANSPORT_FAILURE_CODE,
       transport: "daemon_loopback_http",
@@ -1563,6 +1581,7 @@ export class UnixSocketServer {
         : {}),
       ...(input.identity.sessionUuid ? { sessionUuid: input.identity.sessionUuid } : {}),
       sessionValid,
+      deviceSessionValid,
       phase: input.phase,
       retryable,
       reconnectAttempted: input.reconnectAttempted,

--- a/src/daemon/socketServer.ts
+++ b/src/daemon/socketServer.ts
@@ -252,6 +252,13 @@ class InputTypeTextAppendError extends Error {
   }
 }
 
+class McpClientReconnectDeadlineError extends Error {
+  constructor() {
+    super("MCP client reconnect exceeded the request deadline");
+    this.name = "McpClientReconnectDeadlineError";
+  }
+}
+
 export class UnixSocketServer {
   private server: NetServer | null = null;
   private closing = false;
@@ -1232,7 +1239,7 @@ export class UnixSocketServer {
   private async forwardMcpRequestWithRecovery(
     context: McpForwardRecoveryContext,
   ): Promise<unknown> {
-    const identity = this.getDeviceControlTransportIdentity(context.request, context.route);
+    const identity = this.getDeviceControlTransportIdentity(context);
     let mcpClient: Client;
     try {
       mcpClient = await this.getMcpClient(
@@ -1313,35 +1320,75 @@ export class UnixSocketServer {
   }
 
   private getDeviceControlTransportIdentity(
-    request: DaemonRequest,
-    route: McpForwardRoute,
+    context: McpForwardRecoveryContext,
   ): DeviceControlTransportIdentity {
-    const args = request.method === "tools/call" ? request.params?.arguments : undefined;
-    const sessionUuid = route.sessionUuid ?? this.getSessionUuid(args);
+    const args =
+      context.request.method === "tools/call"
+        ? context.request.params?.arguments
+        : undefined;
+    const sessionUuid = this.resolveDeviceControlIdentitySession(
+      args,
+      context.route.sessionUuid,
+      context.socketSessionId,
+    );
     const deviceId = this.resolveDeviceControlDeviceId(args, sessionUuid);
     const deviceSessionUuid = this.resolveDeviceControlSessionUuid(deviceId);
     return { sessionUuid, deviceId, deviceSessionUuid };
+  }
+
+  private resolveDeviceControlIdentitySession(
+    args: unknown,
+    routeSessionUuid: string | undefined,
+    socketSessionId: string,
+  ): string | undefined {
+    if (args && typeof args === "object" && !Array.isArray(args)) {
+      const record = args as Record<string, unknown>;
+      const baseSessionUuid = this.getSessionUuid(record);
+      if (baseSessionUuid && typeof record.device === "string" && record.device.length > 0) {
+        return this.resolveDeviceLabelSession(baseSessionUuid, record.device);
+      }
+      if (typeof record.deviceId === "string" && record.deviceId.length > 0) {
+        return this.getSessionForDevice(record.deviceId);
+      }
+      if (baseSessionUuid) {
+        return baseSessionUuid;
+      }
+    }
+    return (
+      routeSessionUuid
+      ?? this.resolveImplicitAutolockSession(socketSessionId, args)
+    );
+  }
+
+  private getSessionForDevice(deviceId: string): string | undefined {
+    if (!this.daemonState.isInitialized()) {
+      return undefined;
+    }
+    try {
+      return this.daemonState.getSessionManager().getSessionForDevice?.(deviceId) ?? undefined;
+    } catch (error) {
+      logger.debug(`Unable to resolve session for transport device ${deviceId}: ${error}`);
+      return undefined;
+    }
   }
 
   private resolveDeviceControlDeviceId(
     args: unknown,
     sessionUuid?: string,
   ): string | undefined {
+    if (sessionUuid) {
+      const assignedDevice = this.getAssignedDeviceForSession(sessionUuid);
+      if (assignedDevice) {
+        return assignedDevice;
+      }
+    }
     if (args && typeof args === "object" && !Array.isArray(args)) {
       const explicitDeviceId = (args as Record<string, unknown>).deviceId;
       if (typeof explicitDeviceId === "string") {
         return explicitDeviceId;
       }
     }
-    if (!sessionUuid || !this.daemonState.isInitialized()) {
-      return undefined;
-    }
-    try {
-      return this.daemonState.getSessionManager().getSession(sessionUuid)?.assignedDevice;
-    } catch (error) {
-      logger.debug(`Unable to resolve transport session ${sessionUuid}: ${error}`);
-      return undefined;
-    }
+    return undefined;
   }
 
   private resolveDeviceControlSessionUuid(deviceId?: string): string | undefined {
@@ -1425,6 +1472,49 @@ export class UnixSocketServer {
     return new DeviceControlTransportError(message, failure);
   }
 
+  private remainingMcpForwardBudget(input: {
+    remainingTimeoutMs: number;
+    forwardStartMs: number;
+  }): number {
+    return input.remainingTimeoutMs - (this.timer.now() - input.forwardStartMs);
+  }
+
+  private async reconnectMcpClientWithinDeadline(input: {
+    route: McpForwardRoute;
+    remainingTimeoutMs: number;
+    forwardStartMs: number;
+  }): Promise<Client> {
+    const remainingMs = this.remainingMcpForwardBudget(input);
+    if (remainingMs <= 0) {
+      throw new McpClientReconnectDeadlineError();
+    }
+
+    let deadlineTimer: NodeJS.Timeout | undefined;
+    const deadline = new Promise<never>((_resolve, reject) => {
+      deadlineTimer = this.timer.setTimeout(
+        () => reject(new McpClientReconnectDeadlineError()),
+        remainingMs,
+      );
+    });
+    const connection = this.getMcpClient(
+      input.route.clientKey,
+      input.route.sessionUuid,
+      input.route.toolSelectionProfileUuid,
+    );
+    try {
+      return await Promise.race([connection, deadline]);
+    } catch (error) {
+      if (error instanceof McpClientReconnectDeadlineError) {
+        await this.resetMcpClient(input.route.clientKey);
+      }
+      throw error;
+    } finally {
+      if (deadlineTimer) {
+        this.timer.clearTimeout(deadlineTimer);
+      }
+    }
+  }
+
   private async recoverDeviceControlTransport(input: {
     request: DaemonRequest;
     route: McpForwardRoute;
@@ -1434,6 +1524,7 @@ export class UnixSocketServer {
     phase: DeviceControlTransportPhase;
     identity: DeviceControlTransportIdentity;
   }): Promise<unknown> {
+    await this.resetMcpClient(input.route.clientKey);
     if (!this.isDeviceControlTransportIdentityValid(input.identity)) {
       throw this.deviceControlTransportError({
         request: input.request,
@@ -1451,15 +1542,12 @@ export class UnixSocketServer {
     logger.warn(
       `[McpForward] device-control transport closed for ${deviceControlToolName(input.request)} during ${input.phase}; reconnecting once`,
     );
-    await this.resetMcpClient(input.route.clientKey);
-    const retryRemainingMs =
-      input.remainingTimeoutMs - (this.timer.now() - input.forwardStartMs);
-    if (retryRemainingMs <= 0) {
+    if (this.remainingMcpForwardBudget(input) <= 0) {
       throw this.deviceControlTransportError({
         request: input.request,
         identity: input.identity,
         phase: input.phase,
-        reconnectAttempted: true,
+        reconnectAttempted: false,
         replayAttempted: false,
         recoveryExhausted: true,
       });
@@ -1467,11 +1555,7 @@ export class UnixSocketServer {
 
     let freshClient: Client;
     try {
-      freshClient = await this.getMcpClient(
-        input.route.clientKey,
-        input.route.sessionUuid,
-        input.route.toolSelectionProfileUuid,
-      );
+      freshClient = await this.reconnectMcpClientWithinDeadline(input);
     } catch {
       logger.warn(
         `[McpForward] device-control transport reconnect failed for ${deviceControlToolName(input.request)}`,
@@ -1486,7 +1570,19 @@ export class UnixSocketServer {
       });
     }
 
+    const retryRemainingMs = this.remainingMcpForwardBudget(input);
+    if (retryRemainingMs <= 0) {
+      throw this.deviceControlTransportError({
+        request: input.request,
+        identity: input.identity,
+        phase: input.phase,
+        reconnectAttempted: true,
+        replayAttempted: false,
+        recoveryExhausted: true,
+      });
+    }
     if (!this.isDeviceControlTransportIdentityValid(input.identity)) {
+      await this.resetMcpClient(input.route.clientKey);
       throw this.deviceControlTransportError({
         request: input.request,
         identity: input.identity,
@@ -1518,6 +1614,7 @@ export class UnixSocketServer {
       if (!isUnexpectedSocketClosure(error)) {
         throw error;
       }
+      await this.resetMcpClient(input.route.clientKey);
       throw this.deviceControlTransportError({
         request: input.request,
         identity: input.identity,
@@ -1623,6 +1720,14 @@ export class UnixSocketServer {
   }
 
   private getImplicitAutolockScopeKey(mcpSessionId: string, args: unknown): string | undefined {
+    const autolockSession = this.resolveImplicitAutolockSession(mcpSessionId, args);
+    return autolockSession ? this.sessionToScopeKey(autolockSession) : undefined;
+  }
+
+  private resolveImplicitAutolockSession(
+    mcpSessionId: string,
+    args: unknown,
+  ): string | undefined {
     if (!this.daemonState.isInitialized()) {
       return undefined;
     }
@@ -1634,7 +1739,7 @@ export class UnixSocketServer {
       if (!autolockSession) {
         return undefined;
       }
-      return this.sessionToScopeKey(autolockSession);
+      return autolockSession;
     } catch (error) {
       logger.debug(`Unable to resolve autolock session for MCP session ${mcpSessionId}: ${error}`);
       return undefined;
@@ -3395,14 +3500,16 @@ export class UnixSocketServer {
     const generation = this.lifecycleGeneration;
     const clientPromise = this.mcpClientFactory(boundSessionUuid, toolSelectionProfileUuid)
       .then(async (client) => {
-        if (this.closing || generation !== this.lifecycleGeneration) {
+        if (
+          this.closing
+          || generation !== this.lifecycleGeneration
+          || this.mcpClientPromises.get(key) !== clientPromise
+        ) {
           await client.close();
-          throw new Error("Unix socket server is closing");
+          throw new Error("MCP client creation was superseded");
         }
         this.mcpClients.set(key, client);
-        if (this.mcpClientPromises.get(key) === clientPromise) {
-          this.mcpClientPromises.delete(key);
-        }
+        this.mcpClientPromises.delete(key);
         return client;
       })
       .catch((error) => {

--- a/src/daemon/socketServer.ts
+++ b/src/daemon/socketServer.ts
@@ -1602,11 +1602,18 @@ export class UnixSocketServer {
   private isDeviceControlTransportIdentityValid(
     identity: DeviceControlTransportIdentity,
   ): boolean {
+    return (
+      this.isDeviceControlCapturedSessionIdentityValid(identity)
+      && this.isDeviceControlDeviceSessionValid(identity)
+    );
+  }
+
+  private isDeviceControlCapturedSessionIdentityValid(
+    identity: DeviceControlTransportIdentity,
+  ): boolean {
     const hasSessionIdentity =
       Boolean(identity.sessionUuid || identity.routingSessionUuid);
-    const sessionValid =
-      !hasSessionIdentity || this.isDeviceControlSessionValid(identity);
-    return sessionValid && this.isDeviceControlDeviceSessionValid(identity);
+    return !hasSessionIdentity || this.isDeviceControlSessionValid(identity);
   }
 
   private isDeviceControlRecoveryIdentityValid(
@@ -1617,7 +1624,7 @@ export class UnixSocketServer {
       phase === "connect"
       && !this.hasEstablishedDeviceControlTransportIdentity(identity)
     ) {
-      return true;
+      return this.isDeviceControlCapturedSessionIdentityValid(identity);
     }
     return this.isDeviceControlTransportIdentityValid(identity);
   }
@@ -1625,10 +1632,9 @@ export class UnixSocketServer {
   private isDeviceControlReplayResultIdentityValid(
     identity: DeviceControlTransportIdentity,
   ): boolean {
-    return (
-      !this.hasEstablishedDeviceControlTransportIdentity(identity)
-      || this.isDeviceControlTransportIdentityValid(identity)
-    );
+    return this.hasEstablishedDeviceControlTransportIdentity(identity)
+      ? this.isDeviceControlTransportIdentityValid(identity)
+      : this.isDeviceControlCapturedSessionIdentityValid(identity);
   }
 
   private deviceControlTransportError(input: {
@@ -1642,15 +1648,15 @@ export class UnixSocketServer {
     const toolName = deviceControlToolName(input.request);
     const sessionValid = this.isDeviceControlSessionValid(input.identity);
     const deviceSessionValid = this.isDeviceControlDeviceSessionValid(input.identity);
-    const hasSessionIdentity =
-      Boolean(input.identity.sessionUuid || input.identity.routingSessionUuid);
+    const capturedSessionIdentityValid =
+      this.isDeviceControlCapturedSessionIdentityValid(input.identity);
     const identityValid =
-      (!hasSessionIdentity || sessionValid) && deviceSessionValid;
+      capturedSessionIdentityValid && deviceSessionValid;
     const identityEstablished =
       this.hasEstablishedDeviceControlTransportIdentity(input.identity);
     const retryable =
       input.phase === "connect"
-        ? !identityEstablished || identityValid
+        ? capturedSessionIdentityValid && (!identityEstablished || deviceSessionValid)
         : identityValid && isReplaySafeAfterResponseClosure(input.request);
     const failure: DeviceControlTransportFailure = {
       code: DEVICE_CONTROL_TRANSPORT_FAILURE_CODE,

--- a/src/daemon/socketServer.ts
+++ b/src/daemon/socketServer.ts
@@ -1285,9 +1285,10 @@ export class UnixSocketServer {
         return this.retryExpiredMcpSession(context, identity, mcpClient);
       }
       if (this.isDeviceControlSocketClosure(context.request, error)) {
-        const recoveryIdentity = this.hasEstablishedDeviceControlTransportIdentity(identity)
-          ? identity
-          : this.getDeviceControlTransportIdentity(context);
+        const recoveryIdentity = this.getDeviceControlRecoveryFailureIdentity(
+          context,
+          identity,
+        );
         return this.recoverDeviceControlTransport({
           ...context,
           phase: "response",
@@ -1650,9 +1651,15 @@ export class UnixSocketServer {
     context: McpForwardRecoveryContext,
     identity: DeviceControlTransportIdentity,
   ): DeviceControlTransportIdentity {
-    return this.hasEstablishedDeviceControlTransportIdentity(identity)
-      ? identity
-      : this.getDeviceControlTransportIdentity(context);
+    const refreshedIdentity = this.getDeviceControlTransportIdentity(context);
+    return {
+      sessionUuid: identity.sessionUuid ?? refreshedIdentity.sessionUuid,
+      deviceId: identity.deviceId ?? refreshedIdentity.deviceId,
+      deviceSessionUuid:
+        identity.deviceSessionUuid ?? refreshedIdentity.deviceSessionUuid,
+      deviceLabelResolved:
+        identity.deviceLabelResolved ?? refreshedIdentity.deviceLabelResolved,
+    };
   }
 
   private pinDeviceControlRecoveryRequest(

--- a/src/daemon/socketServer.ts
+++ b/src/daemon/socketServer.ts
@@ -1712,11 +1712,17 @@ export class UnixSocketServer {
       input.route.sessionUuid,
       input.route.toolSelectionProfileUuid,
     );
+    // getMcpClient registers its pending creation synchronously, so this snapshot
+    // identifies the attempt this wait started. Staggered deadlines can share a
+    // clientKey; without this fence a longer wait's expiry would unconditionally
+    // tear down whatever occupies the key, closing a replacement client that a
+    // sibling wait or an unrelated request already installed (issue #5499).
+    const pendingCreation = this.mcpClientPromises.get(input.route.clientKey);
     try {
       return await Promise.race([connection, deadline]);
     } catch (error) {
       if (error instanceof McpClientReconnectDeadlineError) {
-        await this.resetMcpClient(input.route.clientKey, "detach");
+        this.discardTimedOutMcpReconnect(input.route.clientKey, connection, pendingCreation);
       }
       throw error;
     } finally {
@@ -1852,12 +1858,17 @@ export class UnixSocketServer {
       && input.identity.deviceLabelResolved === true
       && input.identity.sessionUuid
     ) {
+      // Replay the original tool-selection profile verbatim. routingSessionUuid
+      // is a session UUID, not a profile: feeding it here would send a bogus
+      // tool-selection-profile header (createMcpClient forwards this field on the
+      // wire) and drop the generated profile injected by
+      // DaemonMcpProxy.withToolSelectionProfile, so a profile-gated tool admitted
+      // on the original call would be rejected as disabled on replay (issue #5499).
       return this.sessionScopedForwardRoute(
         input.socketSessionId,
         input.identity.sessionUuid,
         input.route.executionKey,
-        input.identity.routingSessionUuid
-          ?? input.route.toolSelectionProfileUuid,
+        input.route.toolSelectionProfileUuid,
       );
     }
     if (
@@ -3961,6 +3972,29 @@ export class UnixSocketServer {
     }
     await this.resetMcpClient(key, closeMode);
     return true;
+  }
+
+  // Clean up after a reconnect that blew its deadline without clobbering an
+  // unrelated request. Two teardown paths, each fenced to what this wait owns:
+  //   1. If our creation is still the pending one, drop it so a hung factory does
+  //      not leak; a resolved or superseded creation has already cleared itself.
+  //   2. When our own creation does resolve, close that specific client only while
+  //      it remains the cached one — never a replacement another request installed
+  //      under the same key (issue #5499). Fire-and-forget: the connection may
+  //      never settle, so the request must not block on it.
+  private discardTimedOutMcpReconnect(
+    key: string,
+    connection: Promise<Client>,
+    pendingCreation: Promise<Client> | undefined,
+  ): void {
+    if (pendingCreation && this.mcpClientPromises.get(key) === pendingCreation) {
+      this.mcpClientPromises.delete(key);
+    }
+    void connection
+      .then(client => this.resetMcpClientIfCurrent(key, client, "detach"))
+      .catch(() => {
+        // Creation was superseded or failed; nothing of ours remains to discard.
+      });
   }
 
   private scheduleMcpClientIdleClose(key: string): void {

--- a/src/daemon/socketServer.ts
+++ b/src/daemon/socketServer.ts
@@ -187,6 +187,7 @@ interface DeviceControlTransportIdentity {
   sessionUuid?: string;
   deviceId?: string;
   deviceSessionUuid?: string;
+  deviceLabelResolved?: boolean;
 }
 
 interface McpForwardRecoveryContext {
@@ -200,6 +201,7 @@ interface McpForwardRecoveryContext {
 interface DeviceControlTransportRecoveryContext extends McpForwardRecoveryContext {
   phase: DeviceControlTransportPhase;
   identity: DeviceControlTransportIdentity;
+  failedClient?: Client;
 }
 
 const isNonBlankSessionUuid = (value: unknown): value is string =>
@@ -1280,7 +1282,7 @@ export class UnixSocketServer {
     } catch (error) {
       const message = errorMessage(error);
       if (message.includes("Session not found")) {
-        return this.retryExpiredMcpSession(context, identity);
+        return this.retryExpiredMcpSession(context, identity, mcpClient);
       }
       if (this.isDeviceControlSocketClosure(context.request, error)) {
         const recoveryIdentity = this.hasEstablishedDeviceControlTransportIdentity(identity)
@@ -1290,6 +1292,7 @@ export class UnixSocketServer {
           ...context,
           phase: "response",
           identity: recoveryIdentity,
+          failedClient: mcpClient,
         });
       }
       throw error;
@@ -1299,9 +1302,10 @@ export class UnixSocketServer {
   private async retryExpiredMcpSession(
     context: McpForwardRecoveryContext,
     identity: DeviceControlTransportIdentity,
+    failedClient: Client,
   ): Promise<unknown> {
     logger.warn("MCP client session expired, reconnecting and retrying...");
-    await this.resetMcpClient(context.route.clientKey);
+    await this.resetMcpClientIfCurrent(context.route.clientKey, failedClient);
     let freshClient: Client;
     try {
       freshClient = await this.getMcpClient(
@@ -1346,7 +1350,7 @@ export class UnixSocketServer {
       if (!this.isDeviceControlSocketClosure(context.request, error)) {
         throw error;
       }
-      await this.resetMcpClient(context.route.clientKey, "detach");
+      await this.resetMcpClientIfCurrent(context.route.clientKey, freshClient, "detach");
       const failureIdentity = this.getDeviceControlRecoveryFailureIdentity(
         context,
         identity,
@@ -1376,7 +1380,34 @@ export class UnixSocketServer {
     );
     const deviceId = this.resolveDeviceControlDeviceId(args, sessionUuid);
     const deviceSessionUuid = this.resolveDeviceControlSessionUuid(deviceId);
-    return { sessionUuid, deviceId, deviceSessionUuid };
+    const deviceLabelResolved = this.getDeviceControlLabelResolution(args);
+    return { sessionUuid, deviceId, deviceSessionUuid, deviceLabelResolved };
+  }
+
+  private getDeviceControlLabelResolution(args: unknown): boolean | undefined {
+    if (!args || typeof args !== "object" || Array.isArray(args)) {
+      return undefined;
+    }
+    const record = args as Record<string, unknown>;
+    const baseSessionUuid = this.getSessionUuid(record);
+    const deviceLabel = record.device;
+    if (typeof deviceLabel !== "string" || deviceLabel.length === 0) {
+      return undefined;
+    }
+    if (!baseSessionUuid || !this.daemonState.isInitialized()) {
+      return false;
+    }
+    try {
+      const mappedSession = this.daemonState
+        .getSessionManager()
+        .getDeviceLabels(baseSessionUuid)?.[deviceLabel];
+      return typeof mappedSession === "string" && mappedSession.length > 0;
+    } catch (error) {
+      logger.debug(
+        `Unable to verify device label ${deviceLabel} for session ${baseSessionUuid}: ${error}`,
+      );
+      return false;
+    }
   }
 
   private resolveDeviceControlIdentitySession(
@@ -1614,6 +1645,7 @@ export class UnixSocketServer {
     if (
       phase !== "response"
       || !identity.deviceId
+      || identity.deviceLabelResolved === false
       || !args
       || typeof args !== "object"
       || Array.isArray(args)
@@ -1697,7 +1729,13 @@ export class UnixSocketServer {
   private async recoverDeviceControlTransport(
     input: DeviceControlTransportRecoveryContext,
   ): Promise<unknown> {
-    await this.resetMcpClient(input.route.clientKey, "detach");
+    if (input.failedClient) {
+      await this.resetMcpClientIfCurrent(
+        input.route.clientKey,
+        input.failedClient,
+        "detach",
+      );
+    }
     if (!this.isDeviceControlRecoveryIdentityValid(input.identity, input.phase)) {
       throw this.deviceControlTransportError({
         request: input.request,
@@ -1743,7 +1781,7 @@ export class UnixSocketServer {
       });
     }
     if (!this.isDeviceControlRecoveryIdentityValid(input.identity, input.phase)) {
-      await this.resetMcpClient(recoveryRoute.clientKey, "detach");
+      await this.resetMcpClientIfCurrent(recoveryRoute.clientKey, freshClient, "detach");
       throw this.deviceControlTransportError({
         request: input.request,
         identity: input.identity,
@@ -1777,7 +1815,7 @@ export class UnixSocketServer {
         input.socketSessionId,
       );
       if (!this.isDeviceControlReplayResultIdentityValid(input.identity)) {
-        await this.resetMcpClient(recoveryRoute.clientKey, "detach");
+        await this.resetMcpClientIfCurrent(recoveryRoute.clientKey, freshClient, "detach");
         throw this.deviceControlTransportError({
           request: input.request,
           identity: input.identity,
@@ -1792,7 +1830,7 @@ export class UnixSocketServer {
       if (!isUnexpectedSocketClosure(error)) {
         throw error;
       }
-      await this.resetMcpClient(recoveryRoute.clientKey, "detach");
+      await this.resetMcpClientIfCurrent(recoveryRoute.clientKey, freshClient, "detach");
       const failureIdentity = this.getDeviceControlRecoveryFailureIdentity(
         input,
         input.identity,
@@ -3726,6 +3764,18 @@ export class UnixSocketServer {
     if (closeMode === "wait") {
       await close;
     }
+  }
+
+  private async resetMcpClientIfCurrent(
+    key: string,
+    expectedClient: Client,
+    closeMode: "wait" | "detach" = "wait",
+  ): Promise<boolean> {
+    if (this.mcpClients.get(key) !== expectedClient) {
+      return false;
+    }
+    await this.resetMcpClient(key, closeMode);
+    return true;
   }
 
   private scheduleMcpClientIdleClose(key: string): void {

--- a/src/daemon/socketServer.ts
+++ b/src/daemon/socketServer.ts
@@ -1424,6 +1424,8 @@ export class UnixSocketServer {
         .getDeviceLabels(baseSessionUuid)?.[deviceLabel];
       return typeof mappedSession === "string" && mappedSession.length > 0;
     } catch (error) {
+      // A session-manager lookup failure cannot prove the label still maps to a
+      // live session, so treat the label as unresolved and fail recovery closed.
       logger.debug(
         `Unable to verify device label ${deviceLabel} for session ${baseSessionUuid}: ${error}`,
       );
@@ -1462,6 +1464,8 @@ export class UnixSocketServer {
     try {
       return this.daemonState.getSessionManager().getSessionForDevice?.(deviceId) ?? undefined;
     } catch (error) {
+      // Without a proven device→session mapping the caller must fall back to no
+      // session identity rather than guess an owner, so fail closed to undefined.
       logger.debug(`Unable to resolve session for transport device ${deviceId}: ${error}`);
       return undefined;
     }
@@ -1476,6 +1480,8 @@ export class UnixSocketServer {
     try {
       return this.daemonState.getSessionManager().getSession(sessionUuid) ?? undefined;
     } catch (error) {
+      // A missing incarnation snapshot is safe: downstream owner validation treats
+      // an absent incarnation as unverifiable and fails the ownership check closed.
       logger.debug(`Unable to capture device-control session ${sessionUuid}: ${error}`);
       return undefined;
     }
@@ -1511,6 +1517,8 @@ export class UnixSocketServer {
         .find(record => record.deviceId === deviceId)
         ?.deviceSessionUuid;
     } catch (error) {
+      // An unresolved device epoch is safe: device-session validation treats an
+      // absent epoch as unestablished and will not admit a replay against it.
       logger.debug(`Unable to resolve transport device epoch for ${deviceId}: ${error}`);
       return undefined;
     }
@@ -1549,6 +1557,8 @@ export class UnixSocketServer {
         && (!identity.deviceId || session.assignedDevice === identity.deviceId),
       );
     } catch (error) {
+      // Ownership must be provable to replay; a lookup failure leaves it unproven,
+      // so fail closed to reject the recovery rather than risk a stale-owner replay.
       logger.debug(`Unable to validate device-control target owner: ${error}`);
       return false;
     }
@@ -1572,6 +1582,8 @@ export class UnixSocketServer {
         && session === identity.routingSessionIncarnation,
       );
     } catch (error) {
+      // The routing session's grant must be provable to replay; an unverifiable
+      // lookup fails closed so a superseded routing session cannot authorize it.
       logger.debug(`Unable to validate device-control routing session: ${error}`);
       return false;
     }
@@ -1594,6 +1606,8 @@ export class UnixSocketServer {
         .find(record => record.deviceId === identity.deviceId);
       return liveDeviceSession?.deviceSessionUuid === identity.deviceSessionUuid;
     } catch (error) {
+      // A device-epoch lookup failure cannot confirm the captured epoch is still
+      // live, so fail closed to block replay against a possibly-recreated device.
       logger.debug(`Unable to validate device-control device epoch: ${error}`);
       return false;
     }
@@ -1747,18 +1761,33 @@ export class UnixSocketServer {
     identity: DeviceControlTransportIdentity,
   ): DeviceControlTransportIdentity {
     const refreshedIdentity = this.getDeviceControlTransportIdentity(context);
+    // An incarnation/epoch token only proves ownership as the pair captured with
+    // its identity key. Once the original call captured a session UUID (or device
+    // id), inheriting a *refreshed* token for that same key would let a session
+    // released and recreated on the same device mid-dispatch adopt the replacement
+    // incarnation: the unchanged device epoch and replacement session would then
+    // pass every recovery check and the request would replay and be accepted after
+    // the caller's original ownership ended (issue #5499). So a refreshed token is
+    // only inherited when its key was itself absent at capture — i.e. the key and
+    // its token arrive together from the same refresh, never mixing a captured key
+    // with a post-release token.
     return {
       sessionUuid: identity.sessionUuid ?? refreshedIdentity.sessionUuid,
       sessionIncarnation:
-        identity.sessionIncarnation ?? refreshedIdentity.sessionIncarnation,
+        identity.sessionUuid !== undefined
+          ? identity.sessionIncarnation
+          : refreshedIdentity.sessionIncarnation,
       routingSessionUuid:
         identity.routingSessionUuid ?? refreshedIdentity.routingSessionUuid,
       routingSessionIncarnation:
-        identity.routingSessionIncarnation
-        ?? refreshedIdentity.routingSessionIncarnation,
+        identity.routingSessionUuid !== undefined
+          ? identity.routingSessionIncarnation
+          : refreshedIdentity.routingSessionIncarnation,
       deviceId: identity.deviceId ?? refreshedIdentity.deviceId,
       deviceSessionUuid:
-        identity.deviceSessionUuid ?? refreshedIdentity.deviceSessionUuid,
+        identity.deviceId !== undefined
+          ? identity.deviceSessionUuid
+          : refreshedIdentity.deviceSessionUuid,
       deviceLabelResolved:
         identity.deviceLabelResolved ?? refreshedIdentity.deviceLabelResolved,
     };

--- a/src/daemon/socketServer.ts
+++ b/src/daemon/socketServer.ts
@@ -1505,7 +1505,7 @@ export class UnixSocketServer {
       return await Promise.race([connection, deadline]);
     } catch (error) {
       if (error instanceof McpClientReconnectDeadlineError) {
-        await this.resetMcpClient(input.route.clientKey);
+        await this.resetMcpClient(input.route.clientKey, "detach");
       }
       throw error;
     } finally {
@@ -1524,7 +1524,7 @@ export class UnixSocketServer {
     phase: DeviceControlTransportPhase;
     identity: DeviceControlTransportIdentity;
   }): Promise<unknown> {
-    await this.resetMcpClient(input.route.clientKey);
+    await this.resetMcpClient(input.route.clientKey, "detach");
     if (!this.isDeviceControlTransportIdentityValid(input.identity)) {
       throw this.deviceControlTransportError({
         request: input.request,
@@ -1582,7 +1582,7 @@ export class UnixSocketServer {
       });
     }
     if (!this.isDeviceControlTransportIdentityValid(input.identity)) {
-      await this.resetMcpClient(input.route.clientKey);
+      await this.resetMcpClient(input.route.clientKey, "detach");
       throw this.deviceControlTransportError({
         request: input.request,
         identity: input.identity,
@@ -1604,17 +1604,29 @@ export class UnixSocketServer {
     }
 
     try {
-      return await this.handleIdeRequest(
+      const response = await this.handleIdeRequest(
         freshClient,
         input.request,
         retryRemainingMs,
         input.socketSessionId,
       );
+      if (!this.isDeviceControlTransportIdentityValid(input.identity)) {
+        await this.resetMcpClient(input.route.clientKey, "detach");
+        throw this.deviceControlTransportError({
+          request: input.request,
+          identity: input.identity,
+          phase: input.phase,
+          reconnectAttempted: true,
+          replayAttempted: replayAfterResponse,
+          recoveryExhausted: false,
+        });
+      }
+      return response;
     } catch (error) {
       if (!isUnexpectedSocketClosure(error)) {
         throw error;
       }
-      await this.resetMcpClient(input.route.clientKey);
+      await this.resetMcpClient(input.route.clientKey, "detach");
       throw this.deviceControlTransportError({
         request: input.request,
         identity: input.identity,
@@ -3523,7 +3535,10 @@ export class UnixSocketServer {
     return clientPromise;
   }
 
-  private async resetMcpClient(key: string): Promise<void> {
+  private async resetMcpClient(
+    key: string,
+    closeMode: "wait" | "detach" = "wait",
+  ): Promise<void> {
     this.clearMcpClientIdleTimer(key);
     const existingClient = this.mcpClients.get(key);
     this.mcpClients.delete(key);
@@ -3531,10 +3546,13 @@ export class UnixSocketServer {
     if (!existingClient) {
       return;
     }
-    try {
-      await existingClient.close();
-    } catch (error) {
-      logger.warn(`Error closing MCP client for key ${key}:`, error);
+    const close = Promise.resolve()
+      .then(() => existingClient.close())
+      .catch(error => {
+        logger.warn(`Error closing MCP client for key ${key}:`, error);
+      });
+    if (closeMode === "wait") {
+      await close;
     }
   }
 

--- a/src/daemon/socketServer.ts
+++ b/src/daemon/socketServer.ts
@@ -185,6 +185,7 @@ interface McpForwardRoute {
 
 interface DeviceControlTransportIdentity {
   sessionUuid?: string;
+  routingSessionUuid?: string;
   deviceId?: string;
   deviceSessionUuid?: string;
   deviceLabelResolved?: boolean;
@@ -1379,10 +1380,20 @@ export class UnixSocketServer {
       context.route.sessionUuid,
       context.socketSessionId,
     );
+    const routingSessionUuid =
+      args && typeof args === "object" && !Array.isArray(args)
+        ? this.getSessionUuid(args as Record<string, unknown>) ?? context.route.sessionUuid
+        : context.route.sessionUuid;
     const deviceId = this.resolveDeviceControlDeviceId(args, sessionUuid);
     const deviceSessionUuid = this.resolveDeviceControlSessionUuid(deviceId);
     const deviceLabelResolved = this.getDeviceControlLabelResolution(args);
-    return { sessionUuid, deviceId, deviceSessionUuid, deviceLabelResolved };
+    return {
+      sessionUuid,
+      routingSessionUuid,
+      deviceId,
+      deviceSessionUuid,
+      deviceLabelResolved,
+    };
   }
 
   private getDeviceControlLabelResolution(args: unknown): boolean | undefined {
@@ -1489,14 +1500,50 @@ export class UnixSocketServer {
   }
 
   private isDeviceControlSessionValid(identity: DeviceControlTransportIdentity): boolean {
-    if (!this.daemonState.isInitialized() || !identity.sessionUuid) {
+    if (
+      !this.daemonState.isInitialized()
+      || (!identity.sessionUuid && !identity.routingSessionUuid)
+    ) {
       return false;
+    }
+    return (
+      this.isDeviceControlTargetOwnerValid(identity)
+      && this.isDeviceControlRoutingSessionValid(identity)
+    );
+  }
+
+  private isDeviceControlTargetOwnerValid(
+    identity: DeviceControlTransportIdentity,
+  ): boolean {
+    if (!identity.sessionUuid) {
+      return true;
     }
     try {
       const session = this.daemonState.getSessionManager().getSession(identity.sessionUuid);
       return Boolean(session && (!identity.deviceId || session.assignedDevice === identity.deviceId));
     } catch (error) {
-      logger.debug(`Unable to validate device-control daemon session: ${error}`);
+      logger.debug(`Unable to validate device-control target owner: ${error}`);
+      return false;
+    }
+  }
+
+  private isDeviceControlRoutingSessionValid(
+    identity: DeviceControlTransportIdentity,
+  ): boolean {
+    if (
+      !identity.routingSessionUuid
+      || identity.routingSessionUuid === identity.sessionUuid
+    ) {
+      return true;
+    }
+    try {
+      return Boolean(
+        this.daemonState
+          .getSessionManager()
+          .getSession(identity.routingSessionUuid),
+      );
+    } catch (error) {
+      logger.debug(`Unable to validate device-control routing session: ${error}`);
       return false;
     }
   }
@@ -1526,8 +1573,10 @@ export class UnixSocketServer {
   private isDeviceControlTransportIdentityValid(
     identity: DeviceControlTransportIdentity,
   ): boolean {
+    const hasSessionIdentity =
+      Boolean(identity.sessionUuid || identity.routingSessionUuid);
     const sessionValid =
-      !identity.sessionUuid || this.isDeviceControlSessionValid(identity);
+      !hasSessionIdentity || this.isDeviceControlSessionValid(identity);
     return sessionValid && this.isDeviceControlDeviceSessionValid(identity);
   }
 
@@ -1564,8 +1613,10 @@ export class UnixSocketServer {
     const toolName = deviceControlToolName(input.request);
     const sessionValid = this.isDeviceControlSessionValid(input.identity);
     const deviceSessionValid = this.isDeviceControlDeviceSessionValid(input.identity);
+    const hasSessionIdentity =
+      Boolean(input.identity.sessionUuid || input.identity.routingSessionUuid);
     const identityValid =
-      (!input.identity.sessionUuid || sessionValid) && deviceSessionValid;
+      (!hasSessionIdentity || sessionValid) && deviceSessionValid;
     const identityEstablished =
       this.hasEstablishedDeviceControlTransportIdentity(input.identity);
     const retryable =
@@ -1581,6 +1632,9 @@ export class UnixSocketServer {
         ? { deviceSessionUuid: input.identity.deviceSessionUuid }
         : {}),
       ...(input.identity.sessionUuid ? { sessionUuid: input.identity.sessionUuid } : {}),
+      ...(input.identity.routingSessionUuid
+        ? { routingSessionUuid: input.identity.routingSessionUuid }
+        : {}),
       sessionValid,
       deviceSessionValid,
       phase: input.phase,
@@ -1654,6 +1708,8 @@ export class UnixSocketServer {
     const refreshedIdentity = this.getDeviceControlTransportIdentity(context);
     return {
       sessionUuid: identity.sessionUuid ?? refreshedIdentity.sessionUuid,
+      routingSessionUuid:
+        identity.routingSessionUuid ?? refreshedIdentity.routingSessionUuid,
       deviceId: identity.deviceId ?? refreshedIdentity.deviceId,
       deviceSessionUuid:
         identity.deviceSessionUuid ?? refreshedIdentity.deviceSessionUuid,

--- a/src/daemon/socketServer.ts
+++ b/src/daemon/socketServer.ts
@@ -1347,9 +1347,13 @@ export class UnixSocketServer {
         throw error;
       }
       await this.resetMcpClient(context.route.clientKey, "detach");
+      const failureIdentity = this.getDeviceControlRecoveryFailureIdentity(
+        context,
+        identity,
+      );
       throw this.deviceControlTransportError({
         request: context.request,
-        identity,
+        identity: failureIdentity,
         phase: "response",
         reconnectAttempted: true,
         replayAttempted: true,

--- a/src/daemon/socketServer.ts
+++ b/src/daemon/socketServer.ts
@@ -1601,6 +1601,36 @@ export class UnixSocketServer {
       : this.getDeviceControlTransportIdentity(context);
   }
 
+  private pinDeviceControlRecoveryRequest(
+    request: DaemonRequest,
+    identity: DeviceControlTransportIdentity,
+    phase: DeviceControlTransportPhase,
+  ): DaemonRequest {
+    const args = request.method === "tools/call" ? request.params?.arguments : undefined;
+    if (
+      phase !== "response"
+      || !identity.sessionUuid
+      || !args
+      || typeof args !== "object"
+      || Array.isArray(args)
+    ) {
+      return request;
+    }
+    const pinnedArguments: Record<string, unknown> = {
+      ...(args as Record<string, unknown>),
+      sessionUuid: identity.sessionUuid,
+    };
+    // A label can be remapped while reconnecting; replay the captured session instead.
+    delete pinnedArguments.device;
+    return {
+      ...request,
+      params: {
+        ...request.params,
+        arguments: pinnedArguments,
+      },
+    };
+  }
+
   private async reconnectDeviceControlTransport(
     input: DeviceControlTransportRecoveryContext,
   ): Promise<Client> {
@@ -1692,9 +1722,14 @@ export class UnixSocketServer {
     }
 
     try {
+      const recoveryRequest = this.pinDeviceControlRecoveryRequest(
+        input.request,
+        input.identity,
+        input.phase,
+      );
       const response = await this.handleIdeRequest(
         freshClient,
-        input.request,
+        recoveryRequest,
         retryRemainingMs,
         input.socketSessionId,
       );

--- a/src/daemon/socketServer.ts
+++ b/src/daemon/socketServer.ts
@@ -1273,7 +1273,7 @@ export class UnixSocketServer {
         context.socketSessionId,
       );
     } catch (error) {
-      const message = error instanceof Error ? error.message : String(error);
+      const message = errorMessage(error);
       if (message.includes("Session not found")) {
         return this.retryExpiredMcpSession(context, identity);
       }

--- a/src/daemon/socketServer.ts
+++ b/src/daemon/socketServer.ts
@@ -1671,18 +1671,46 @@ export class UnixSocketServer {
     ) {
       return request;
     }
+    return this.pinEstablishedDeviceControlRecoveryRequest(
+      request,
+      identity,
+      args as Record<string, unknown>,
+    );
+  }
+
+  private pinEstablishedDeviceControlRecoveryRequest(
+    request: DaemonRequest,
+    identity: DeviceControlTransportIdentity,
+    originalArguments: Record<string, unknown>,
+  ): DaemonRequest {
+    if (identity.deviceLabelResolved === true) {
+      const pinnedArguments: Record<string, unknown> = {
+        ...originalArguments,
+        deviceId: identity.deviceId,
+      };
+      // Preserve the base session's authorization scope while replacing the
+      // mutable label selector with the captured physical target.
+      delete pinnedArguments.device;
+      return {
+        ...request,
+        params: {
+          ...request.params,
+          arguments: pinnedArguments,
+        },
+      };
+    }
     if (this.hasStableExplicitDeviceControlTarget(request, identity)) {
       // deviceId is already immutable; retaining the original routing session also
       // preserves its tool-selection grant alongside the target device's grant.
       return request;
     }
     const pinnedArguments: Record<string, unknown> = {
-      ...(args as Record<string, unknown>),
+      ...originalArguments,
       ...(identity.sessionUuid
         ? { sessionUuid: identity.sessionUuid }
         : { deviceId: identity.deviceId }),
     };
-    // A label can be remapped while reconnecting; replay the captured target instead.
+    // Pin implicit/autolocked recovery to the captured target.
     delete pinnedArguments.device;
     if (identity.sessionUuid) {
       delete pinnedArguments.deviceId;
@@ -1719,6 +1747,7 @@ export class UnixSocketServer {
       !replayAfterResponse
       || !input.identity.sessionUuid
       || input.route.sessionUuid === input.identity.sessionUuid
+      || input.identity.deviceLabelResolved === true
       || this.hasStableExplicitDeviceControlTarget(input.request, input.identity)
     ) {
       return input.route;

--- a/src/daemon/types.ts
+++ b/src/daemon/types.ts
@@ -1,3 +1,5 @@
+import type { DeviceControlTransportFailure } from "./deviceControlTransportFailure";
+
 /**
  * Request sent from CLI client to daemon
  */
@@ -41,6 +43,12 @@ export interface DaemonResponse {
   result?: any;
   /** Error message if unsuccessful */
   error?: string;
+  /**
+   * Safe, machine-readable details for a loopback device-control transport
+   * failure. Optional so older Kotlin, Swift, and TypeScript clients keep using
+   * the legacy string error without a wire-version break.
+   */
+  transportFailure?: DeviceControlTransportFailure;
   /**
    * Number of leading characters delivered by a failed Android
    * `input/typeText` append request. Present only when the append operation

--- a/src/server/proxyServer.ts
+++ b/src/server/proxyServer.ts
@@ -17,6 +17,7 @@ import {
 } from "../daemon/daemonMcpProxy";
 import { ActionableError } from "../models";
 import { getMcpServerVersion } from "../utils/mcpVersion";
+import { DeviceControlTransportError } from "../daemon/deviceControlTransportFailure";
 
 /**
  * Options for creating a proxy MCP server
@@ -60,6 +61,25 @@ function sessionOwnershipLostResult(
 function sessionOwnershipLostError(error: DaemonBoundSessionExpiredError): McpError {
   const payload = sessionOwnershipLostPayload(error);
   return new McpError(-32603, sessionOwnershipLostMessage(error), payload);
+}
+
+function deviceControlTransportFailureResult(
+  error: DeviceControlTransportError,
+): CallToolResult {
+  return {
+    content: [
+      {
+        type: "text",
+        text: JSON.stringify({
+          error: {
+            message: error.message,
+            ...error.failure,
+          },
+        }),
+      },
+    ],
+    isError: true,
+  };
 }
 
 /**
@@ -163,6 +183,12 @@ export function createProxyMcpServer(options: ProxyMcpServerOptions = {}): {
           `[ProxyServer] Session ownership lost for ${error.sessionUuid}: ${error.reason}`,
         );
         return sessionOwnershipLostResult(error);
+      }
+      if (error instanceof DeviceControlTransportError) {
+        logger.warn(
+          `[ProxyServer] Device-control transport failure for ${error.failure.toolName} during ${error.failure.phase}`,
+        );
+        return deviceControlTransportFailureResult(error);
       }
       logger.error(`[ProxyServer] Tool call failed: ${name} - ${error}`);
       // Return error as tool result (not throwing) to match expected MCP behavior

--- a/src/server/proxyServer.ts
+++ b/src/server/proxyServer.ts
@@ -17,7 +17,10 @@ import {
 } from "../daemon/daemonMcpProxy";
 import { ActionableError } from "../models";
 import { getMcpServerVersion } from "../utils/mcpVersion";
-import { DeviceControlTransportError } from "../daemon/deviceControlTransportFailure";
+import {
+  DeviceControlTransportError,
+  sanitizeDeviceControlTransportFailure,
+} from "../daemon/deviceControlTransportFailure";
 
 /**
  * Options for creating a proxy MCP server
@@ -66,6 +69,7 @@ function sessionOwnershipLostError(error: DaemonBoundSessionExpiredError): McpEr
 function deviceControlTransportFailureResult(
   error: DeviceControlTransportError,
 ): CallToolResult {
+  const failure = sanitizeDeviceControlTransportFailure(error.failure);
   return {
     content: [
       {
@@ -73,7 +77,7 @@ function deviceControlTransportFailureResult(
         text: JSON.stringify({
           error: {
             message: error.message,
-            ...error.failure,
+            ...failure,
           },
         }),
       },

--- a/test/daemon/daemonMcpProxy.test.ts
+++ b/test/daemon/daemonMcpProxy.test.ts
@@ -2485,9 +2485,60 @@ describe("DaemonMcpProxy", () => {
           toolName: "observe",
           sessionUuid: "session-a",
           sessionValid: false,
+          deviceSessionValid: false,
           phase: "connect",
           retryable: true,
           reconnectAttempted: true,
+          replayAttempted: false,
+        },
+      );
+      const fakeClient = new FakeDaemonClient({
+        onCallTool: () => {
+          callCount++;
+          if (callCount === 1) {
+            throw transportError;
+          }
+        },
+      });
+      const isAvailableSpy = spyOn(DaemonClient, "isAvailable").mockResolvedValue(true);
+      const proxy = new DaemonMcpProxy({
+        clientFactory: () => fakeClient,
+        daemonManager: matchingDaemonManager(),
+        autoStartDaemon: false,
+      });
+
+      try {
+        await expect(
+          proxy.callTool("observe", { sessionUuid: "session-a", deviceId: "device-a" }),
+        ).rejects.toBe(transportError);
+        await proxy.callTool("observe", { deviceId: "device-a" });
+
+        expect(fakeClient.callToolCalls).toEqual([
+          { toolName: "observe", params: { sessionUuid: "session-a", deviceId: "device-a" } },
+          { toolName: "observe", params: { deviceId: "device-a" } },
+        ]);
+      } finally {
+        isAvailableSpy.mockRestore();
+        await proxy.close();
+      }
+    });
+
+    test("an invalid response session does not refresh the replay lease", async () => {
+      let callCount = 0;
+      const transportError = new DeviceControlTransportError(
+        "Device-control transport closed while handling observe",
+        {
+          code: "device_control_transport_failure",
+          transport: "daemon_loopback_http",
+          toolName: "observe",
+          deviceId: "device-a",
+          deviceSessionUuid: "device-epoch-a",
+          sessionUuid: "session-a",
+          sessionValid: false,
+          deviceSessionValid: true,
+          phase: "response",
+          retryable: false,
+          reconnectAttempted: false,
           replayAttempted: false,
         },
       );
@@ -2535,6 +2586,7 @@ describe("DaemonMcpProxy", () => {
           deviceSessionUuid: "device-epoch-a",
           sessionUuid: "session-a",
           sessionValid: true,
+          deviceSessionValid: true,
           phase: "response",
           retryable: true,
           reconnectAttempted: true,

--- a/test/daemon/daemonMcpProxy.test.ts
+++ b/test/daemon/daemonMcpProxy.test.ts
@@ -22,6 +22,7 @@ import { FakeDaemonManager } from "../fakes/FakeDaemonManager";
 import { FakeDaemonClient } from "../fakes/FakeDaemonClient";
 import { FakeTimer } from "../fakes/FakeTimer";
 import { SESSION_RELEASED_NOTIFICATION_METHOD } from "../../src/server/sessionReleaseBroadcast";
+import { DeviceControlTransportError } from "../../src/daemon/deviceControlTransportFailure";
 
 const OLDER_VERSION = "0.0.1";
 const NEWER_VERSION = "9999.0.0";
@@ -2467,6 +2468,116 @@ describe("DaemonMcpProxy", () => {
         expect(fakeClient.callToolCalls).toEqual([
           { toolName: "observe", params: { sessionUuid: "session-a", deviceId: "device-a" } },
           { toolName: "tapOn", params: { deviceId: "device-a", sessionUuid: "session-a" } },
+        ]);
+      } finally {
+        isAvailableSpy.mockRestore();
+        await proxy.close();
+      }
+    });
+
+    test("a pre-dispatch transport failure does not refresh the replay lease", async () => {
+      let callCount = 0;
+      const transportError = new DeviceControlTransportError(
+        "Device-control transport recovery exhausted while handling observe",
+        {
+          code: "device_control_transport_failure",
+          transport: "daemon_loopback_http",
+          toolName: "observe",
+          sessionUuid: "session-a",
+          sessionValid: false,
+          phase: "connect",
+          retryable: true,
+          reconnectAttempted: true,
+          replayAttempted: false,
+        },
+      );
+      const fakeClient = new FakeDaemonClient({
+        onCallTool: () => {
+          callCount++;
+          if (callCount === 1) {
+            throw transportError;
+          }
+        },
+      });
+      const isAvailableSpy = spyOn(DaemonClient, "isAvailable").mockResolvedValue(true);
+      const proxy = new DaemonMcpProxy({
+        clientFactory: () => fakeClient,
+        daemonManager: matchingDaemonManager(),
+        autoStartDaemon: false,
+      });
+
+      try {
+        await expect(
+          proxy.callTool("observe", { sessionUuid: "session-a", deviceId: "device-a" }),
+        ).rejects.toBe(transportError);
+        await proxy.callTool("observe", { deviceId: "device-a" });
+
+        expect(fakeClient.callToolCalls).toEqual([
+          { toolName: "observe", params: { sessionUuid: "session-a", deviceId: "device-a" } },
+          { toolName: "observe", params: { deviceId: "device-a" } },
+        ]);
+      } finally {
+        isAvailableSpy.mockRestore();
+        await proxy.close();
+      }
+    });
+
+    test("a response-phase transport failure still refreshes an admitted replay lease", async () => {
+      const timer = new FakeTimer();
+      let callCount = 0;
+      const responseError = new DeviceControlTransportError(
+        "Device-control transport recovery exhausted while handling observe",
+        {
+          code: "device_control_transport_failure",
+          transport: "daemon_loopback_http",
+          toolName: "observe",
+          deviceId: "device-a",
+          deviceSessionUuid: "device-epoch-a",
+          sessionUuid: "session-a",
+          sessionValid: true,
+          phase: "response",
+          retryable: true,
+          reconnectAttempted: true,
+          replayAttempted: true,
+        },
+      );
+      const fakeClient = new FakeDaemonClient({
+        onCallTool: () => {
+          callCount++;
+          if (callCount === 2) {
+            throw responseError;
+          }
+        },
+        onCallDaemonMethod: (method) => {
+          if (method === "daemon/heartbeat") {
+            throw new Error("heartbeat disabled for lease-refresh isolation");
+          }
+        },
+      });
+      const isAvailableSpy = spyOn(DaemonClient, "isAvailable").mockResolvedValue(true);
+      const proxy = new DaemonMcpProxy({
+        clientFactory: () => fakeClient,
+        daemonManager: matchingDaemonManager(),
+        autoStartDaemon: false,
+        timer,
+        heartbeatIntervalMs: DAEMON_BOUND_SESSION_REPLAY_TTL_MS * 2,
+      });
+
+      try {
+        await proxy.callTool("observe", { sessionUuid: "session-a", deviceId: "device-a" });
+        await Promise.resolve();
+        await Promise.resolve();
+        timer.advanceTime(DAEMON_BOUND_SESSION_REPLAY_TTL_MS - 1);
+        await expect(proxy.callTool("observe", { deviceId: "device-a" })).rejects.toBe(
+          responseError,
+        );
+        timer.advanceTime(2);
+        await proxy.callTool("observe", { deviceId: "device-a" });
+
+        expect(fakeClient.callToolCalls).toEqual([
+          { toolName: "observe", params: { sessionUuid: "session-a", deviceId: "device-a" } },
+          { toolName: "observe", params: { deviceId: "device-a", sessionUuid: "session-a" } },
+          { toolName: "observe", params: { deviceId: "device-a", sessionUuid: "session-a" } },
         ]);
       } finally {
         isAvailableSpy.mockRestore();

--- a/test/daemon/daemonTransportError.test.ts
+++ b/test/daemon/daemonTransportError.test.ts
@@ -121,6 +121,10 @@ describe("DaemonClient device-control transport response", () => {
         reconnectAttempted: true,
         replayAttempted: false,
       };
+      const wireFailure = {
+        ...failure,
+        endpoint: "https://secret.invalid?token=hidden",
+      };
 
       server = createServer((connection: Socket) => {
         connection.once("data", data => {
@@ -130,7 +134,7 @@ describe("DaemonClient device-control transport response", () => {
             type: "mcp_response",
             success: false,
             error: "Device-control transport closed while handling launchApp",
-            transportFailure: failure,
+            transportFailure: wireFailure,
           })}\n`);
         });
       });
@@ -148,6 +152,9 @@ describe("DaemonClient device-control transport response", () => {
       } catch (error) {
         expect(error).toBeInstanceOf(DeviceControlTransportError);
         expect((error as DeviceControlTransportError).failure).toEqual(failure);
+        expect(JSON.stringify((error as DeviceControlTransportError).failure)).not.toContain(
+          "secret.invalid",
+        );
       } finally {
         await client.close();
       }

--- a/test/daemon/daemonTransportError.test.ts
+++ b/test/daemon/daemonTransportError.test.ts
@@ -8,6 +8,7 @@ import {
   DaemonUnavailableError,
   toDaemonTransportError,
 } from "../../src/daemon/client";
+import { DeviceControlTransportError } from "../../src/daemon/deviceControlTransportFailure";
 
 const isWindows = platform() === "win32";
 
@@ -83,5 +84,73 @@ describe("DaemonClient in-flight request on connection reset (#2737)", () => {
 
       await client.close();
     }
+  );
+});
+
+describe("DaemonClient device-control transport response", () => {
+  const tempDirs: string[] = [];
+  let server: Server | null = null;
+
+  afterEach(async () => {
+    if (server) {
+      await new Promise<void>(resolve => server!.close(() => resolve()));
+      server = null;
+    }
+    for (const dir of tempDirs) {
+      rmSync(dir, { recursive: true, force: true });
+    }
+    tempDirs.length = 0;
+  });
+
+  (isWindows ? test.skip : test)(
+    "rehydrates safe transport metadata as a typed error",
+    async () => {
+      const dir = mkdtempSync(join(tmpdir(), "daemon-transport-payload-test-"));
+      tempDirs.push(dir);
+      const socketPath = join(dir, "daemon.sock");
+      const failure = {
+        code: "device_control_transport_failure" as const,
+        transport: "daemon_loopback_http" as const,
+        toolName: "launchApp",
+        deviceId: "emulator-5554",
+        deviceSessionUuid: "device-epoch-a",
+        sessionUuid: "session-a",
+        sessionValid: true,
+        phase: "response" as const,
+        retryable: false,
+        reconnectAttempted: true,
+        replayAttempted: false,
+      };
+
+      server = createServer((connection: Socket) => {
+        connection.once("data", data => {
+          const request = JSON.parse(data.toString().trim()) as { id: string };
+          connection.write(`${JSON.stringify({
+            id: request.id,
+            type: "mcp_response",
+            success: false,
+            error: "Device-control transport closed while handling launchApp",
+            transportFailure: failure,
+          })}\n`);
+        });
+      });
+      await new Promise<void>(resolve => server!.listen(socketPath, resolve));
+
+      const client = new DaemonClient(socketPath, 2000);
+      await client.connect();
+
+      try {
+        await client.callTool("launchApp", {
+          sessionUuid: "session-a",
+          appId: "dev.example",
+        });
+        throw new Error("Expected launchApp to reject");
+      } catch (error) {
+        expect(error).toBeInstanceOf(DeviceControlTransportError);
+        expect((error as DeviceControlTransportError).failure).toEqual(failure);
+      } finally {
+        await client.close();
+      }
+    },
   );
 });

--- a/test/daemon/daemonTransportError.test.ts
+++ b/test/daemon/daemonTransportError.test.ts
@@ -115,6 +115,7 @@ describe("DaemonClient device-control transport response", () => {
         deviceId: "emulator-5554",
         deviceSessionUuid: "device-epoch-a",
         sessionUuid: "session-a",
+        routingSessionUuid: "session-a",
         sessionValid: true,
         deviceSessionValid: true,
         phase: "response" as const,

--- a/test/daemon/daemonTransportError.test.ts
+++ b/test/daemon/daemonTransportError.test.ts
@@ -116,6 +116,7 @@ describe("DaemonClient device-control transport response", () => {
         deviceSessionUuid: "device-epoch-a",
         sessionUuid: "session-a",
         sessionValid: true,
+        deviceSessionValid: true,
         phase: "response" as const,
         retryable: false,
         reconnectAttempted: true,

--- a/test/daemon/socketServerMcpReconnect.test.ts
+++ b/test/daemon/socketServerMcpReconnect.test.ts
@@ -10,6 +10,7 @@ import { UnixSocketServer } from "../../src/daemon/socketServer";
 import { SOCKET_REQUEST_DEADLINE_MS, sendSocketRequest } from "./helpers/socketRequest";
 import { defaultTimer } from "../../src/utils/SystemTimer";
 import { FakeTimer } from "../fakes/FakeTimer";
+import { SessionToolBinding } from "../../src/server/SessionToolBinding";
 import type { DaemonResponse } from "../../src/daemon/types";
 
 /**
@@ -747,9 +748,20 @@ describe("UnixSocketServer MCP session reconnect", () => {
 
   test("pins a device-label target before replaying observe", async () => {
     let clientsCreated = 0;
+    let closeCalls = 0;
     let replayedArguments: Record<string, unknown> | undefined;
+    const clientBindings: Array<string | undefined> = [];
+    let signalReplayStarted = () => {};
+    const replayStarted = new Promise<void>(resolve => {
+      signalReplayStarted = resolve;
+    });
+    let finishReplay = () => {};
+    const replayResult = new Promise<unknown>(resolve => {
+      finishReplay = () => resolve({ content: [{ type: "text", text: "observed" }] });
+    });
 
-    server.mcpClientFactory = async () => {
+    server.mcpClientFactory = async boundSessionUuid => {
+      clientBindings.push(boundSessionUuid);
       const clientIndex = ++clientsCreated;
       return createFakeMcpClient({
         callTool: async (...args: unknown[]) => {
@@ -759,20 +771,47 @@ describe("UnixSocketServer MCP session reconnect", () => {
           }
           const [toolCall] = args as [{ arguments: Record<string, unknown> }];
           replayedArguments = toolCall.arguments;
-          return { content: [{ type: "text", text: "observed" }] };
+          new SessionToolBinding(boundSessionUuid).effectiveSessionUuid(
+            "replay-mcp-session",
+            replayedArguments,
+          );
+          signalReplayStarted();
+          return replayResult;
+        },
+        close: async () => {
+          closeCalls++;
         },
       });
     };
 
-    const response = await sendRequest(socketPath, "tools/call", {
+    const responsePromise = sendRequest(socketPath, "tools/call", {
       name: "observe",
       arguments: { sessionUuid: "session-a", device: "B" },
     });
+    await replayStarted;
 
-    expect(response.success).toBe(true);
     expect(clientsCreated).toBe(2);
+    expect(clientBindings).toEqual(["session-a", "session-b"]);
     expect(replayedArguments).toMatchObject({ sessionUuid: "session-b" });
     expect(replayedArguments).not.toHaveProperty("device");
+    expect(replayedArguments).not.toHaveProperty("deviceId");
+    expect((server as any).mcpClients.size).toBe(1);
+
+    fakeTimer.advanceTime(5 * 60 * 1000);
+    await Promise.resolve();
+
+    expect(closeCalls).toBe(1);
+    expect((server as any).mcpClients.size).toBe(1);
+
+    finishReplay();
+    const response = await responsePromise;
+    expect(response.success).toBe(true);
+
+    fakeTimer.advanceTime(5 * 60 * 1000);
+    await Promise.resolve();
+
+    expect(closeCalls).toBe(2);
+    expect((server as any).mcpClients.size).toBe(0);
   });
 
   test("recovers observe for an implicit autolock session", async () => {

--- a/test/daemon/socketServerMcpReconnect.test.ts
+++ b/test/daemon/socketServerMcpReconnect.test.ts
@@ -52,6 +52,7 @@ function createFakeDaemonState(
   resolveAutolockSession: () => string | undefined,
   resolveDeviceLabelSession: () => string | undefined,
   resolvePrimaryDeviceOwnerSession: () => string | undefined,
+  resolvePrimarySessionGeneration: () => number,
 ) {
   const session = {
     sessionId: "session-a",
@@ -72,6 +73,10 @@ function createFakeDaemonState(
     sessionId: "session-b",
     assignedDevice: "emulator-5556",
   };
+  const replacementSession = {
+    ...session,
+    cacheData: {},
+  };
   const deviceSession = {
     deviceSessionUuid: "device-epoch-a",
     deviceId: "emulator-5554",
@@ -88,7 +93,9 @@ function createFakeDaemonState(
     getSessionManager: () => ({
       getSession: (sessionId: string) =>
         sessionId === session.sessionId && sessionIsValid()
-          ? session
+          ? resolvePrimarySessionGeneration() === 0
+            ? session
+            : replacementSession
           : sessionId === secondarySession.sessionId && secondarySessionIsValid()
             ? secondarySession
             : null,
@@ -211,6 +218,7 @@ describe("UnixSocketServer MCP session reconnect", () => {
   let autolockSessionUuid: string | undefined;
   let deviceLabelSessionUuid: string | undefined;
   let primaryDeviceOwnerSessionUuid: string | undefined;
+  let primarySessionGeneration: number;
 
   beforeEach(async () => {
     socketPath = join(tmpdir(), `mcp-rc-${randomUUID()}.sock`);
@@ -222,6 +230,7 @@ describe("UnixSocketServer MCP session reconnect", () => {
     autolockSessionUuid = undefined;
     deviceLabelSessionUuid = "session-b";
     primaryDeviceOwnerSessionUuid = "session-a";
+    primarySessionGeneration = 0;
     server = new UnixSocketServer(
       socketPath,
       "http://localhost:0/mcp",
@@ -233,6 +242,7 @@ describe("UnixSocketServer MCP session reconnect", () => {
         () => autolockSessionUuid,
         () => deviceLabelSessionUuid,
         () => primaryDeviceOwnerSessionUuid,
+        () => primarySessionGeneration,
       ),
       fakeTimer,
     );
@@ -743,6 +753,42 @@ describe("UnixSocketServer MCP session reconnect", () => {
     });
   });
 
+  test("does not recover across same-UUID session recreation", async () => {
+    let clientsCreated = 0;
+    let callsDispatched = 0;
+
+    server.mcpClientFactory = async () => {
+      clientsCreated++;
+      return createFakeMcpClient({
+        callTool: async () => {
+          callsDispatched++;
+          primarySessionGeneration = 1;
+          throw socketClosedError();
+        },
+      });
+    };
+
+    const response = await sendRequest(socketPath, "tools/call", {
+      name: "observe",
+      arguments: {
+        sessionUuid: "session-a",
+        deviceId: "emulator-5554",
+      },
+    });
+
+    expect(response.success).toBe(false);
+    expect(clientsCreated).toBe(1);
+    expect(callsDispatched).toBe(1);
+    expect(response.transportFailure).toMatchObject({
+      sessionUuid: "session-a",
+      routingSessionUuid: "session-a",
+      sessionValid: false,
+      deviceSessionValid: true,
+      reconnectAttempted: false,
+      replayAttempted: false,
+    });
+  });
+
   test("does not replay when only the captured device epoch becomes invalid", async () => {
     let clientsCreated = 0;
     let callsDispatched = 0;
@@ -854,6 +900,7 @@ describe("UnixSocketServer MCP session reconnect", () => {
     let closeCalls = 0;
     let replayedArguments: Record<string, unknown> | undefined;
     const clientBindings: Array<string | undefined> = [];
+    const clientProfiles: Array<string | undefined> = [];
     let signalReplayStarted = () => {};
     const replayStarted = new Promise<void>(resolve => {
       signalReplayStarted = resolve;
@@ -863,8 +910,9 @@ describe("UnixSocketServer MCP session reconnect", () => {
       finishReplay = () => resolve({ content: [{ type: "text", text: "observed" }] });
     });
 
-    server.mcpClientFactory = async boundSessionUuid => {
+    server.mcpClientFactory = async (boundSessionUuid, toolSelectionProfileUuid) => {
       clientBindings.push(boundSessionUuid);
+      clientProfiles.push(toolSelectionProfileUuid);
       const clientIndex = ++clientsCreated;
       return createFakeMcpClient({
         callTool: async (...args: unknown[]) => {
@@ -894,9 +942,10 @@ describe("UnixSocketServer MCP session reconnect", () => {
     await replayStarted;
 
     expect(clientsCreated).toBe(2);
-    expect(clientBindings).toEqual(["session-a", "session-a"]);
+    expect(clientBindings).toEqual(["session-a", "session-b"]);
+    expect(clientProfiles).toEqual([undefined, "session-a"]);
     expect(replayedArguments).toMatchObject({
-      sessionUuid: "session-a",
+      sessionUuid: "session-b",
       deviceId: "emulator-5556",
     });
     expect(replayedArguments).not.toHaveProperty("device");
@@ -915,8 +964,8 @@ describe("UnixSocketServer MCP session reconnect", () => {
     fakeTimer.advanceTime(5 * 60 * 1000);
     await Promise.resolve();
 
-    expect(closeCalls).toBe(1);
-    expect((server as any).mcpClients.size).toBe(1);
+    expect(closeCalls).toBe(2);
+    expect((server as any).mcpClients.size).toBe(0);
   });
 
   test("preserves an unresolved device label when replaying observe", async () => {

--- a/test/daemon/socketServerMcpReconnect.test.ts
+++ b/test/daemon/socketServerMcpReconnect.test.ts
@@ -49,6 +49,7 @@ function createFakeDaemonState(
   resolveDeviceEpochUuid: () => string | undefined,
   resolveSecondaryDeviceEpochUuid: () => string | undefined,
   resolveAutolockSession: () => string | undefined,
+  resolveDeviceLabelSession: () => string | undefined,
 ) {
   const session = {
     sessionId: "session-a",
@@ -95,8 +96,12 @@ function createFakeDaemonState(
           : deviceId === secondarySession.assignedDevice
             ? secondarySession.sessionId
             : null,
-      getDeviceLabels: (sessionId: string) =>
-        sessionId === session.sessionId ? { B: secondarySession.sessionId } : undefined,
+      getDeviceLabels: (sessionId: string) => {
+        const labeledSession = resolveDeviceLabelSession();
+        return sessionId === session.sessionId && labeledSession
+          ? { B: labeledSession }
+          : undefined;
+      },
       releaseSession: async () => null,
     }),
     getDevicePool: () => ({
@@ -202,6 +207,7 @@ describe("UnixSocketServer MCP session reconnect", () => {
   let deviceEpochUuid: string | undefined;
   let secondaryDeviceEpochUuid: string | undefined;
   let autolockSessionUuid: string | undefined;
+  let deviceLabelSessionUuid: string | undefined;
 
   beforeEach(async () => {
     socketPath = join(tmpdir(), `mcp-rc-${randomUUID()}.sock`);
@@ -211,6 +217,7 @@ describe("UnixSocketServer MCP session reconnect", () => {
     deviceEpochUuid = "device-epoch-a";
     secondaryDeviceEpochUuid = "device-epoch-b";
     autolockSessionUuid = undefined;
+    deviceLabelSessionUuid = "session-b";
     server = new UnixSocketServer(
       socketPath,
       "http://localhost:0/mcp",
@@ -220,6 +227,7 @@ describe("UnixSocketServer MCP session reconnect", () => {
         () => deviceEpochUuid,
         () => secondaryDeviceEpochUuid,
         () => autolockSessionUuid,
+        () => deviceLabelSessionUuid,
       ),
       fakeTimer,
     );
@@ -735,6 +743,36 @@ describe("UnixSocketServer MCP session reconnect", () => {
       reconnectAttempted: false,
       replayAttempted: false,
     });
+  });
+
+  test("pins a device-label target before replaying observe", async () => {
+    let clientsCreated = 0;
+    let replayedArguments: Record<string, unknown> | undefined;
+
+    server.mcpClientFactory = async () => {
+      const clientIndex = ++clientsCreated;
+      return createFakeMcpClient({
+        callTool: async (...args: unknown[]) => {
+          if (clientIndex === 1) {
+            deviceLabelSessionUuid = "session-a";
+            throw socketClosedError();
+          }
+          const [toolCall] = args as [{ arguments: Record<string, unknown> }];
+          replayedArguments = toolCall.arguments;
+          return { content: [{ type: "text", text: "observed" }] };
+        },
+      });
+    };
+
+    const response = await sendRequest(socketPath, "tools/call", {
+      name: "observe",
+      arguments: { sessionUuid: "session-a", device: "B" },
+    });
+
+    expect(response.success).toBe(true);
+    expect(clientsCreated).toBe(2);
+    expect(replayedArguments).toMatchObject({ sessionUuid: "session-b" });
+    expect(replayedArguments).not.toHaveProperty("device");
   });
 
   test("recovers observe for an implicit autolock session", async () => {

--- a/test/daemon/socketServerMcpReconnect.test.ts
+++ b/test/daemon/socketServerMcpReconnect.test.ts
@@ -900,6 +900,40 @@ describe("UnixSocketServer MCP session reconnect", () => {
     });
   });
 
+  test("preserves the caller session grant when replaying an explicit device target", async () => {
+    let clientsCreated = 0;
+    let replayedArguments: Record<string, unknown> | undefined;
+    const clientBindings: Array<string | undefined> = [];
+
+    server.mcpClientFactory = async boundSessionUuid => {
+      clientBindings.push(boundSessionUuid);
+      const clientIndex = ++clientsCreated;
+      return createFakeMcpClient({
+        callTool: async (...args: unknown[]) => {
+          if (clientIndex === 1) {
+            throw socketClosedError();
+          }
+          const [toolCall] = args as [{ arguments: Record<string, unknown> }];
+          replayedArguments = toolCall.arguments;
+          return { content: [{ type: "text", text: "observed" }] };
+        },
+      });
+    };
+
+    const response = await sendRequest(socketPath, "tools/call", {
+      name: "observe",
+      arguments: { sessionUuid: "session-a", deviceId: "emulator-5556" },
+    });
+
+    expect(response.success).toBe(true);
+    expect(clientsCreated).toBe(2);
+    expect(clientBindings).toEqual(["session-a", "session-a"]);
+    expect(replayedArguments).toMatchObject({
+      sessionUuid: "session-a",
+      deviceId: "emulator-5556",
+    });
+  });
+
   test("recovers observe for an implicit autolock session", async () => {
     let clientsCreated = 0;
     let callsDispatched = 0;

--- a/test/daemon/socketServerMcpReconnect.test.ts
+++ b/test/daemon/socketServerMcpReconnect.test.ts
@@ -36,14 +36,48 @@ function createFakeMcpClient(overrides: Partial<FakeMcpClient> = {}): FakeMcpCli
   };
 }
 
-function createFakeDaemonState() {
+function socketClosedError(sensitiveDetail = ""): Error {
+  return new Error(
+    `The socket connection was closed unexpectedly. For more information, pass verbose: true.${sensitiveDetail}`,
+  );
+}
+
+function createFakeDaemonState(sessionIsValid: () => boolean) {
+  const session = {
+    sessionId: "session-a",
+    assignedDevice: "emulator-5554",
+    platform: "android" as const,
+    createdAt: 0,
+    lastUsedAt: 0,
+    expiresAt: Number.MAX_SAFE_INTEGER,
+    cacheData: {},
+    lastHeartbeat: 0,
+    sessionTimeoutMs: 60_000,
+    heartbeatTimeoutMs: 60_000,
+    heartbeatTimeoutSource: "default" as const,
+    hasReceivedHeartbeat: true,
+  };
+  const deviceSession = {
+    deviceSessionUuid: "device-epoch-a",
+    deviceId: "emulator-5554",
+    platform: "android" as const,
+    epochStartedAt: 0,
+  };
   return {
     isInitialized: () => true,
-    getSessionManager: () => ({ getSession: () => null, releaseSession: async () => null }),
+    getSessionManager: () => ({
+      getSession: (sessionId: string) =>
+        sessionId === session.sessionId && sessionIsValid() ? session : null,
+      getDeviceLabels: () => undefined,
+      releaseSession: async () => null,
+    }),
     getDevicePool: () => ({
       refreshDevices: async () => 0,
       getStats: () => ({ total: 0, idle: 0, assigned: 0, error: 0 }),
       releaseDevice: async () => {},
+    }),
+    getDeviceSessionRegistry: () => ({
+      list: () => sessionIsValid() ? [deviceSession] : [],
     }),
   };
 }
@@ -115,14 +149,16 @@ describe("UnixSocketServer MCP session reconnect", () => {
   let socketPath: string;
   let server: UnixSocketServer;
   let fakeTimer: FakeTimer;
+  let sessionIsValid: boolean;
 
   beforeEach(async () => {
     socketPath = join(tmpdir(), `mcp-rc-${randomUUID()}.sock`);
     fakeTimer = new FakeTimer();
+    sessionIsValid = true;
     server = new UnixSocketServer(
       socketPath,
       "http://localhost:0/mcp",
-      createFakeDaemonState(),
+      createFakeDaemonState(() => sessionIsValid),
       fakeTimer,
     );
     await server.start();
@@ -199,6 +235,173 @@ describe("UnixSocketServer MCP session reconnect", () => {
     expect(response.error).toContain("Connection refused");
     // Only one client created — no retry
     expect(clientsCreated).toBe(1);
+  });
+
+  test("reconnects launchApp after a socket closure before request dispatch", async () => {
+    let clientsCreated = 0;
+    let callsDispatched = 0;
+
+    server.mcpClientFactory = async () => {
+      clientsCreated++;
+      if (clientsCreated === 1) {
+        throw socketClosedError();
+      }
+      return createFakeMcpClient({
+        callTool: async () => {
+          callsDispatched++;
+          return { content: [{ type: "text", text: "launched" }] };
+        },
+      });
+    };
+
+    const response = await sendRequest(socketPath, "tools/call", {
+      name: "launchApp",
+      arguments: { sessionUuid: "session-a", appId: "dev.example" },
+    });
+
+    expect(response.success).toBe(true);
+    expect(clientsCreated).toBe(2);
+    expect(callsDispatched).toBe(1);
+  });
+
+  test("reconnects and replays observe after a socket closure while handling the response", async () => {
+    let clientsCreated = 0;
+    let callsDispatched = 0;
+
+    server.mcpClientFactory = async () => {
+      const clientIndex = ++clientsCreated;
+      return createFakeMcpClient({
+        callTool: async () => {
+          callsDispatched++;
+          if (clientIndex === 1) {
+            throw socketClosedError();
+          }
+          return { content: [{ type: "text", text: "observed" }] };
+        },
+      });
+    };
+
+    const response = await sendRequest(socketPath, "tools/call", {
+      name: "observe",
+      arguments: { sessionUuid: "session-a" },
+    });
+
+    expect(response.success).toBe(true);
+    expect(clientsCreated).toBe(2);
+    expect(callsDispatched).toBe(2);
+  });
+
+  test("does not replay launchApp after an ambiguous response closure", async () => {
+    let clientsCreated = 0;
+    let callsDispatched = 0;
+
+    server.mcpClientFactory = async () => {
+      clientsCreated++;
+      return createFakeMcpClient({
+        callTool: async () => {
+          callsDispatched++;
+          throw socketClosedError(" endpoint=https://secret.invalid?token=hidden");
+        },
+      });
+    };
+
+    const response = await sendRequest(socketPath, "tools/call", {
+      name: "launchApp",
+      arguments: { sessionUuid: "session-a", appId: "dev.example" },
+    });
+
+    expect(response.success).toBe(false);
+    expect(clientsCreated).toBe(2);
+    expect(callsDispatched).toBe(1);
+    expect(response.error).toBe("Device-control transport closed while handling launchApp");
+    expect(response.error).not.toContain("secret.invalid");
+    expect(response.transportFailure).toEqual({
+      code: "device_control_transport_failure",
+      transport: "daemon_loopback_http",
+      toolName: "launchApp",
+      deviceId: "emulator-5554",
+      deviceSessionUuid: "device-epoch-a",
+      sessionUuid: "session-a",
+      sessionValid: true,
+      phase: "response",
+      retryable: false,
+      reconnectAttempted: true,
+      replayAttempted: false,
+    });
+  });
+
+  test("returns a retryable structured error after observe reconnection exhaustion", async () => {
+    let clientsCreated = 0;
+    let callsDispatched = 0;
+
+    server.mcpClientFactory = async () => {
+      clientsCreated++;
+      return createFakeMcpClient({
+        callTool: async () => {
+          callsDispatched++;
+          throw socketClosedError(" endpoint=https://secret.invalid?token=hidden");
+        },
+      });
+    };
+
+    const response = await sendRequest(socketPath, "tools/call", {
+      name: "observe",
+      arguments: { sessionUuid: "session-a" },
+    });
+
+    expect(response.success).toBe(false);
+    expect(clientsCreated).toBe(2);
+    expect(callsDispatched).toBe(2);
+    expect(response.error).toBe("Device-control transport recovery exhausted while handling observe");
+    expect(JSON.stringify(response)).not.toContain("secret.invalid");
+    expect(response.transportFailure).toMatchObject({
+      code: "device_control_transport_failure",
+      toolName: "observe",
+      deviceId: "emulator-5554",
+      deviceSessionUuid: "device-epoch-a",
+      sessionUuid: "session-a",
+      sessionValid: true,
+      phase: "response",
+      retryable: true,
+      reconnectAttempted: true,
+      replayAttempted: true,
+    });
+  });
+
+  test("does not reconnect or replay after the bound device session becomes invalid", async () => {
+    let clientsCreated = 0;
+    let callsDispatched = 0;
+
+    server.mcpClientFactory = async () => {
+      clientsCreated++;
+      return createFakeMcpClient({
+        callTool: async () => {
+          callsDispatched++;
+          sessionIsValid = false;
+          throw socketClosedError();
+        },
+      });
+    };
+
+    const response = await sendRequest(socketPath, "tools/call", {
+      name: "observe",
+      arguments: { sessionUuid: "session-a" },
+    });
+
+    expect(response.success).toBe(false);
+    expect(clientsCreated).toBe(1);
+    expect(callsDispatched).toBe(1);
+    expect(response.transportFailure).toMatchObject({
+      code: "device_control_transport_failure",
+      deviceId: "emulator-5554",
+      deviceSessionUuid: "device-epoch-a",
+      sessionUuid: "session-a",
+      sessionValid: false,
+      phase: "response",
+      retryable: false,
+      reconnectAttempted: false,
+      replayAttempted: false,
+    });
   });
 
   test("subsequent requests reuse the reconnected client without creating another", async () => {

--- a/test/daemon/socketServerMcpReconnect.test.ts
+++ b/test/daemon/socketServerMcpReconnect.test.ts
@@ -46,6 +46,8 @@ function socketClosedError(sensitiveDetail = ""): Error {
 function createFakeDaemonState(
   sessionIsValid: () => boolean,
   secondarySessionIsValid: () => boolean,
+  resolveDeviceEpochUuid: () => string | undefined,
+  resolveSecondaryDeviceEpochUuid: () => string | undefined,
   resolveAutolockSession: () => string | undefined,
 ) {
   const session = {
@@ -104,10 +106,21 @@ function createFakeDaemonState(
       resolveAutolockSessionForMcpSession: () => resolveAutolockSession(),
     }),
     getDeviceSessionRegistry: () => ({
-      list: () => [
-        ...(sessionIsValid() ? [deviceSession] : []),
-        ...(secondarySessionIsValid() ? [secondaryDeviceSession] : []),
-      ],
+      list: () => {
+        const deviceEpochUuid = resolveDeviceEpochUuid();
+        const secondaryDeviceEpochUuid = resolveSecondaryDeviceEpochUuid();
+        return [
+          ...(deviceEpochUuid
+            ? [{ ...deviceSession, deviceSessionUuid: deviceEpochUuid }]
+            : []),
+          ...(secondaryDeviceEpochUuid
+            ? [{
+              ...secondaryDeviceSession,
+              deviceSessionUuid: secondaryDeviceEpochUuid,
+            }]
+            : []),
+        ];
+      },
     }),
   };
 }
@@ -186,6 +199,8 @@ describe("UnixSocketServer MCP session reconnect", () => {
   let fakeTimer: FakeTimer;
   let sessionIsValid: boolean;
   let secondarySessionIsValid: boolean;
+  let deviceEpochUuid: string | undefined;
+  let secondaryDeviceEpochUuid: string | undefined;
   let autolockSessionUuid: string | undefined;
 
   beforeEach(async () => {
@@ -193,6 +208,8 @@ describe("UnixSocketServer MCP session reconnect", () => {
     fakeTimer = new FakeTimer();
     sessionIsValid = true;
     secondarySessionIsValid = true;
+    deviceEpochUuid = "device-epoch-a";
+    secondaryDeviceEpochUuid = "device-epoch-b";
     autolockSessionUuid = undefined;
     server = new UnixSocketServer(
       socketPath,
@@ -200,6 +217,8 @@ describe("UnixSocketServer MCP session reconnect", () => {
       createFakeDaemonState(
         () => sessionIsValid,
         () => secondarySessionIsValid,
+        () => deviceEpochUuid,
+        () => secondaryDeviceEpochUuid,
         () => autolockSessionUuid,
       ),
       fakeTimer,
@@ -305,6 +324,43 @@ describe("UnixSocketServer MCP session reconnect", () => {
     expect(response.success).toBe(true);
     expect(clientsCreated).toBe(2);
     expect(callsDispatched).toBe(1);
+  });
+
+  test("classifies a closure during the existing session-expiry replay", async () => {
+    let clientsCreated = 0;
+    let callsDispatched = 0;
+
+    server.mcpClientFactory = async () => {
+      const clientIndex = ++clientsCreated;
+      return createFakeMcpClient({
+        callTool: async () => {
+          callsDispatched++;
+          if (clientIndex === 1) {
+            throw new Error("Session not found");
+          }
+          throw socketClosedError(" endpoint=https://secret.invalid?token=hidden");
+        },
+      });
+    };
+
+    const response = await sendRequest(socketPath, "tools/call", {
+      name: "observe",
+      arguments: { sessionUuid: "session-a" },
+    });
+
+    expect(response.success).toBe(false);
+    expect(clientsCreated).toBe(2);
+    expect(callsDispatched).toBe(2);
+    expect(response.error).toBe("Device-control transport recovery exhausted while handling observe");
+    expect(JSON.stringify(response)).not.toContain("secret.invalid");
+    expect(response.transportFailure).toMatchObject({
+      sessionValid: true,
+      phase: "response",
+      retryable: true,
+      reconnectAttempted: true,
+      replayAttempted: true,
+    });
+    expect((server as any).mcpClients.size).toBe(0);
   });
 
   test("reconnects and replays observe after a socket closure while handling the response", async () => {
@@ -500,6 +556,40 @@ describe("UnixSocketServer MCP session reconnect", () => {
     });
   });
 
+  test("does not replay when only the captured device epoch becomes invalid", async () => {
+    let clientsCreated = 0;
+    let callsDispatched = 0;
+
+    server.mcpClientFactory = async () => {
+      clientsCreated++;
+      return createFakeMcpClient({
+        callTool: async () => {
+          callsDispatched++;
+          deviceEpochUuid = "device-epoch-a-replacement";
+          throw socketClosedError();
+        },
+      });
+    };
+
+    const response = await sendRequest(socketPath, "tools/call", {
+      name: "observe",
+      arguments: { sessionUuid: "session-a" },
+    });
+
+    expect(response.success).toBe(false);
+    expect(sessionIsValid).toBe(true);
+    expect(clientsCreated).toBe(1);
+    expect(callsDispatched).toBe(1);
+    expect(response.transportFailure).toMatchObject({
+      deviceId: "emulator-5554",
+      deviceSessionUuid: "device-epoch-a",
+      sessionUuid: "session-a",
+      sessionValid: false,
+      reconnectAttempted: false,
+      replayAttempted: false,
+    });
+  });
+
   test("rejects a replay result when the device epoch becomes invalid in flight", async () => {
     let clientsCreated = 0;
     let callsDispatched = 0;
@@ -512,7 +602,7 @@ describe("UnixSocketServer MCP session reconnect", () => {
           if (clientIndex === 1) {
             throw socketClosedError();
           }
-          sessionIsValid = false;
+          deviceEpochUuid = "device-epoch-a-replacement";
           return { content: [{ type: "text", text: "stale observation" }] };
         },
       });
@@ -524,6 +614,7 @@ describe("UnixSocketServer MCP session reconnect", () => {
     });
 
     expect(response.success).toBe(false);
+    expect(sessionIsValid).toBe(true);
     expect(clientsCreated).toBe(2);
     expect(callsDispatched).toBe(2);
     expect(response.transportFailure).toMatchObject({

--- a/test/daemon/socketServerMcpReconnect.test.ts
+++ b/test/daemon/socketServerMcpReconnect.test.ts
@@ -421,6 +421,41 @@ describe("UnixSocketServer MCP session reconnect", () => {
     expect((server as any).mcpClients.size).toBe(0);
   });
 
+  test("refreshes autolock identity when session-expiry replay closes", async () => {
+    let clientsCreated = 0;
+
+    server.mcpClientFactory = async () => {
+      const clientIndex = ++clientsCreated;
+      return createFakeMcpClient({
+        callTool: async () => {
+          if (clientIndex === 1) {
+            autolockSessionUuid = "session-a";
+            throw new Error("Session not found");
+          }
+          throw socketClosedError();
+        },
+      });
+    };
+
+    const response = await sendRequest(socketPath, "tools/call", {
+      name: "observe",
+      arguments: { platform: "android" },
+    });
+
+    expect(response.success).toBe(false);
+    expect(clientsCreated).toBe(2);
+    expect(response.transportFailure).toMatchObject({
+      deviceId: "emulator-5554",
+      deviceSessionUuid: "device-epoch-a",
+      sessionUuid: "session-a",
+      sessionValid: true,
+      phase: "response",
+      retryable: true,
+      reconnectAttempted: true,
+      replayAttempted: true,
+    });
+  });
+
   test("reconnects and replays observe after a socket closure while handling the response", async () => {
     let clientsCreated = 0;
     let callsDispatched = 0;

--- a/test/daemon/socketServerMcpReconnect.test.ts
+++ b/test/daemon/socketServerMcpReconnect.test.ts
@@ -334,6 +334,42 @@ describe("UnixSocketServer MCP session reconnect", () => {
     expect(callsDispatched).toBe(2);
   });
 
+  test("reconnects without waiting for a stale client's close to settle", async () => {
+    let clientsCreated = 0;
+    let callsDispatched = 0;
+    let closeCalls = 0;
+
+    server.mcpClientFactory = async () => {
+      const clientIndex = ++clientsCreated;
+      return createFakeMcpClient({
+        callTool: async () => {
+          callsDispatched++;
+          if (clientIndex === 1) {
+            throw socketClosedError();
+          }
+          return { content: [{ type: "text", text: "observed" }] };
+        },
+        close: async () => {
+          closeCalls++;
+          if (clientIndex === 1) {
+            return new Promise<void>(() => {});
+          }
+        },
+      });
+    };
+
+    const response = await sendRequest(socketPath, "tools/call", {
+      name: "observe",
+      arguments: { sessionUuid: "session-a" },
+    });
+
+    expect(response.success).toBe(true);
+    expect(clientsCreated).toBe(2);
+    expect(callsDispatched).toBe(2);
+    expect(closeCalls).toBe(1);
+    expect((server as any).mcpClients.size).toBe(1);
+  });
+
   test("does not replay launchApp after an ambiguous response closure", async () => {
     let clientsCreated = 0;
     let callsDispatched = 0;
@@ -462,6 +498,42 @@ describe("UnixSocketServer MCP session reconnect", () => {
       reconnectAttempted: false,
       replayAttempted: false,
     });
+  });
+
+  test("rejects a replay result when the device epoch becomes invalid in flight", async () => {
+    let clientsCreated = 0;
+    let callsDispatched = 0;
+
+    server.mcpClientFactory = async () => {
+      const clientIndex = ++clientsCreated;
+      return createFakeMcpClient({
+        callTool: async () => {
+          callsDispatched++;
+          if (clientIndex === 1) {
+            throw socketClosedError();
+          }
+          sessionIsValid = false;
+          return { content: [{ type: "text", text: "stale observation" }] };
+        },
+      });
+    };
+
+    const response = await sendRequest(socketPath, "tools/call", {
+      name: "observe",
+      arguments: { sessionUuid: "session-a" },
+    });
+
+    expect(response.success).toBe(false);
+    expect(clientsCreated).toBe(2);
+    expect(callsDispatched).toBe(2);
+    expect(response.transportFailure).toMatchObject({
+      sessionValid: false,
+      phase: "response",
+      retryable: false,
+      reconnectAttempted: true,
+      replayAttempted: true,
+    });
+    expect((server as any).mcpClients.size).toBe(0);
   });
 
   test("fences recovery to the device-label session and epoch", async () => {

--- a/test/daemon/socketServerMcpReconnect.test.ts
+++ b/test/daemon/socketServerMcpReconnect.test.ts
@@ -818,6 +818,50 @@ describe("UnixSocketServer MCP session reconnect", () => {
     });
   });
 
+  test("does not adopt a post-release incarnation for a session captured without one", async () => {
+    // First-use observe: session-a is absent when the identity is captured, so the
+    // captured incarnation is undefined even though the UUID is known. During
+    // dispatch the session is created and recreated on the same device (a fresh
+    // incarnation). Recovery must NOT inherit that replacement incarnation for the
+    // already-captured UUID, or the request would replay and be accepted after the
+    // original caller's ownership ended (issue #5499).
+    sessionIsValid = false;
+    let clientsCreated = 0;
+    let callsDispatched = 0;
+
+    server.mcpClientFactory = async () => {
+      clientsCreated++;
+      return createFakeMcpClient({
+        callTool: async () => {
+          callsDispatched++;
+          // Session-a comes into existence as a *replacement* incarnation.
+          sessionIsValid = true;
+          primarySessionGeneration = 1;
+          throw socketClosedError();
+        },
+      });
+    };
+
+    const response = await sendRequest(socketPath, "tools/call", {
+      name: "observe",
+      arguments: {
+        sessionUuid: "session-a",
+        deviceId: "emulator-5554",
+      },
+    });
+
+    expect(response.success).toBe(false);
+    // No reconnect or replay may be attempted — recovery is rejected up front.
+    expect(clientsCreated).toBe(1);
+    expect(callsDispatched).toBe(1);
+    expect(response.transportFailure).toMatchObject({
+      sessionUuid: "session-a",
+      sessionValid: false,
+      reconnectAttempted: false,
+      replayAttempted: false,
+    });
+  });
+
   test("does not replay when only the captured device epoch becomes invalid", async () => {
     let clientsCreated = 0;
     let callsDispatched = 0;

--- a/test/daemon/socketServerMcpReconnect.test.ts
+++ b/test/daemon/socketServerMcpReconnect.test.ts
@@ -602,6 +602,7 @@ describe("UnixSocketServer MCP session reconnect", () => {
       deviceId: "emulator-5554",
       deviceSessionUuid: "device-epoch-a",
       sessionUuid: "session-a",
+      routingSessionUuid: "session-a",
       sessionValid: true,
       deviceSessionValid: true,
       phase: "response",
@@ -981,6 +982,44 @@ describe("UnixSocketServer MCP session reconnect", () => {
     expect(replayedArguments).toMatchObject({
       sessionUuid: "session-a",
       deviceId: "emulator-5556",
+    });
+  });
+
+  test("fences explicit-device recovery on the caller routing session", async () => {
+    let clientsCreated = 0;
+    let callsDispatched = 0;
+
+    server.mcpClientFactory = async () => {
+      clientsCreated++;
+      return createFakeMcpClient({
+        callTool: async () => {
+          callsDispatched++;
+          sessionIsValid = false;
+          throw socketClosedError();
+        },
+      });
+    };
+
+    const response = await sendRequest(socketPath, "tools/call", {
+      name: "observe",
+      arguments: {
+        sessionUuid: "session-a",
+        deviceId: "emulator-5556",
+      },
+    });
+
+    expect(response.success).toBe(false);
+    expect(clientsCreated).toBe(1);
+    expect(callsDispatched).toBe(1);
+    expect(response.transportFailure).toMatchObject({
+      deviceId: "emulator-5556",
+      deviceSessionUuid: "device-epoch-b",
+      sessionUuid: "session-b",
+      routingSessionUuid: "session-a",
+      sessionValid: false,
+      deviceSessionValid: true,
+      reconnectAttempted: false,
+      replayAttempted: false,
     });
   });
 

--- a/test/daemon/socketServerMcpReconnect.test.ts
+++ b/test/daemon/socketServerMcpReconnect.test.ts
@@ -972,7 +972,10 @@ describe("UnixSocketServer MCP session reconnect", () => {
 
     expect(clientsCreated).toBe(2);
     expect(clientBindings).toEqual(["session-a", "session-b"]);
-    expect(clientProfiles).toEqual([undefined, "session-a"]);
+    // The replay reuses the original route's tool-selection profile (none here);
+    // it must NOT send the routing session UUID as a profile, which would put a
+    // session UUID on the tool-selection-profile wire header (issue #5499).
+    expect(clientProfiles).toEqual([undefined, undefined]);
     expect(replayedArguments).toMatchObject({
       sessionUuid: "session-b",
       deviceId: "emulator-5556",
@@ -1300,5 +1303,81 @@ describe("UnixSocketServer MCP session reconnect", () => {
 
     expect(closeCalls).toBe(1);
     expect((server as any).mcpClients.size).toBe(0);
+  });
+
+  test("labeled replay carries the original tool-selection profile, not the routing session (#5499)", () => {
+    const route = (server as any).getDeviceControlRecoveryRoute(
+      {
+        socketSessionId: "socket-1",
+        request: {
+          method: "tools/call",
+          params: {
+            name: "observe",
+            arguments: { sessionUuid: "session-a", device: "B" },
+          },
+        },
+        route: {
+          executionKey: "exec-1",
+          clientKey: "orig-key",
+          sessionUuid: "session-b",
+          toolSelectionProfileUuid: "profile-x",
+        },
+        remainingTimeoutMs: 1000,
+        forwardStartMs: 0,
+        phase: "response",
+        identity: {
+          sessionUuid: "session-b",
+          routingSessionUuid: "session-a",
+          deviceLabelResolved: true,
+        },
+      },
+      true,
+    );
+
+    // The recovery route must replay the generated profile from the original
+    // route, never the routing session UUID masquerading as a profile.
+    expect(route.toolSelectionProfileUuid).toBe("profile-x");
+    expect(route.clientKey).toBe(
+      "socket:socket-1:session:session-b:tool-selection:profile-x",
+    );
+    expect(route.clientKey).not.toContain("session-a");
+  });
+
+  test("a stale reconnect deadline leaves a replacement client under the same key intact (#5499)", async () => {
+    const key = "socket-1:session:session-x";
+    // Never resolve: this wait's creation stays pending and the deadline wins.
+    server.mcpClientFactory = () => new Promise<never>(() => {});
+    const internals = server as any;
+
+    const reconnectPromise = internals.reconnectMcpClientWithinDeadline({
+      route: { executionKey: "exec-1", clientKey: key },
+      remainingTimeoutMs: 1000,
+      forwardStartMs: 0,
+    });
+
+    // getMcpClient registers this wait's pending creation synchronously.
+    expect(internals.mcpClientPromises.get(key)).toBeDefined();
+
+    // A sibling wait clears that pending creation; an unrelated request then
+    // installs a replacement client under the same key.
+    internals.mcpClientPromises.delete(key);
+    let replacementClosed = false;
+    const replacement = createFakeMcpClient({
+      close: async () => {
+        replacementClosed = true;
+      },
+    });
+    internals.mcpClients.set(key, replacement);
+
+    fakeTimer.advanceTime(1000);
+    await expect(reconnectPromise).rejects.toThrow(
+      "MCP client reconnect exceeded the request deadline",
+    );
+    await Promise.resolve();
+
+    // The stale deadline reset is fenced to this wait's own (now superseded)
+    // pending creation, so the replacement survives.
+    expect(replacementClosed).toBe(false);
+    expect(internals.mcpClients.get(key)).toBe(replacement);
   });
 });

--- a/test/daemon/socketServerMcpReconnect.test.ts
+++ b/test/daemon/socketServerMcpReconnect.test.ts
@@ -449,6 +449,7 @@ describe("UnixSocketServer MCP session reconnect", () => {
       deviceSessionUuid: "device-epoch-a",
       sessionUuid: "session-a",
       sessionValid: true,
+      deviceSessionValid: true,
       phase: "response",
       retryable: true,
       reconnectAttempted: true,
@@ -598,6 +599,7 @@ describe("UnixSocketServer MCP session reconnect", () => {
       deviceSessionUuid: "device-epoch-a",
       sessionUuid: "session-a",
       sessionValid: true,
+      deviceSessionValid: true,
       phase: "response",
       retryable: false,
       reconnectAttempted: true,
@@ -689,6 +691,7 @@ describe("UnixSocketServer MCP session reconnect", () => {
       deviceSessionUuid: "device-epoch-a",
       sessionUuid: "session-a",
       sessionValid: false,
+      deviceSessionValid: true,
       phase: "response",
       retryable: false,
       reconnectAttempted: false,
@@ -724,7 +727,8 @@ describe("UnixSocketServer MCP session reconnect", () => {
       deviceId: "emulator-5554",
       deviceSessionUuid: "device-epoch-a",
       sessionUuid: "session-a",
-      sessionValid: false,
+      sessionValid: true,
+      deviceSessionValid: false,
       reconnectAttempted: false,
       replayAttempted: false,
     });
@@ -758,7 +762,8 @@ describe("UnixSocketServer MCP session reconnect", () => {
     expect(clientsCreated).toBe(2);
     expect(callsDispatched).toBe(2);
     expect(response.transportFailure).toMatchObject({
-      sessionValid: false,
+      sessionValid: true,
+      deviceSessionValid: false,
       phase: "response",
       retryable: false,
       reconnectAttempted: true,

--- a/test/daemon/socketServerMcpReconnect.test.ts
+++ b/test/daemon/socketServerMcpReconnect.test.ts
@@ -326,6 +326,55 @@ describe("UnixSocketServer MCP session reconnect", () => {
     expect(callsDispatched).toBe(1);
   });
 
+  test("reconnects a sessionless call after a socket closure before request dispatch", async () => {
+    let clientsCreated = 0;
+    let callsDispatched = 0;
+
+    server.mcpClientFactory = async () => {
+      clientsCreated++;
+      if (clientsCreated === 1) {
+        throw socketClosedError();
+      }
+      return createFakeMcpClient({
+        callTool: async () => {
+          callsDispatched++;
+          return { content: [{ type: "text", text: "observed" }] };
+        },
+      });
+    };
+
+    const response = await sendRequest(socketPath, "tools/call", {
+      name: "observe",
+      arguments: { platform: "android" },
+    });
+
+    expect(response.success).toBe(true);
+    expect(clientsCreated).toBe(2);
+    expect(callsDispatched).toBe(1);
+  });
+
+  test("preserves an unrelated failure while reconnecting before request dispatch", async () => {
+    let clientsCreated = 0;
+
+    server.mcpClientFactory = async () => {
+      clientsCreated++;
+      if (clientsCreated === 1) {
+        throw socketClosedError();
+      }
+      throw new Error("MCP configuration rejected");
+    };
+
+    const response = await sendRequest(socketPath, "tools/call", {
+      name: "observe",
+      arguments: { sessionUuid: "session-a" },
+    });
+
+    expect(response.success).toBe(false);
+    expect(clientsCreated).toBe(2);
+    expect(response.error).toContain("MCP configuration rejected");
+    expect(response.transportFailure).toBeUndefined();
+  });
+
   test("classifies a closure during the existing session-expiry replay", async () => {
     let clientsCreated = 0;
     let callsDispatched = 0;
@@ -383,6 +432,34 @@ describe("UnixSocketServer MCP session reconnect", () => {
     const response = await sendRequest(socketPath, "tools/call", {
       name: "observe",
       arguments: { sessionUuid: "session-a" },
+    });
+
+    expect(response.success).toBe(true);
+    expect(clientsCreated).toBe(2);
+    expect(callsDispatched).toBe(2);
+  });
+
+  test("refreshes first-use autolock identity before replaying observe", async () => {
+    let clientsCreated = 0;
+    let callsDispatched = 0;
+
+    server.mcpClientFactory = async () => {
+      const clientIndex = ++clientsCreated;
+      return createFakeMcpClient({
+        callTool: async () => {
+          callsDispatched++;
+          if (clientIndex === 1) {
+            autolockSessionUuid = "session-a";
+            throw socketClosedError();
+          }
+          return { content: [{ type: "text", text: "observed" }] };
+        },
+      });
+    };
+
+    const response = await sendRequest(socketPath, "tools/call", {
+      name: "observe",
+      arguments: { platform: "android" },
     });
 
     expect(response.success).toBe(true);

--- a/test/daemon/socketServerMcpReconnect.test.ts
+++ b/test/daemon/socketServerMcpReconnect.test.ts
@@ -5,6 +5,7 @@ import { existsSync } from "node:fs";
 import { unlink } from "node:fs/promises";
 import { tmpdir } from "node:os";
 import { join } from "node:path";
+import { ErrorCode, McpError } from "@modelcontextprotocol/sdk/types.js";
 import { UnixSocketServer } from "../../src/daemon/socketServer";
 import { SOCKET_REQUEST_DEADLINE_MS, sendSocketRequest } from "./helpers/socketRequest";
 import { defaultTimer } from "../../src/utils/SystemTimer";
@@ -42,7 +43,11 @@ function socketClosedError(sensitiveDetail = ""): Error {
   );
 }
 
-function createFakeDaemonState(sessionIsValid: () => boolean) {
+function createFakeDaemonState(
+  sessionIsValid: () => boolean,
+  secondarySessionIsValid: () => boolean,
+  resolveAutolockSession: () => string | undefined,
+) {
   const session = {
     sessionId: "session-a",
     assignedDevice: "emulator-5554",
@@ -57,33 +62,63 @@ function createFakeDaemonState(sessionIsValid: () => boolean) {
     heartbeatTimeoutSource: "default" as const,
     hasReceivedHeartbeat: true,
   };
+  const secondarySession = {
+    ...session,
+    sessionId: "session-b",
+    assignedDevice: "emulator-5556",
+  };
   const deviceSession = {
     deviceSessionUuid: "device-epoch-a",
     deviceId: "emulator-5554",
     platform: "android" as const,
     epochStartedAt: 0,
   };
+  const secondaryDeviceSession = {
+    ...deviceSession,
+    deviceSessionUuid: "device-epoch-b",
+    deviceId: "emulator-5556",
+  };
   return {
     isInitialized: () => true,
     getSessionManager: () => ({
       getSession: (sessionId: string) =>
-        sessionId === session.sessionId && sessionIsValid() ? session : null,
-      getDeviceLabels: () => undefined,
+        sessionId === session.sessionId && sessionIsValid()
+          ? session
+          : sessionId === secondarySession.sessionId && secondarySessionIsValid()
+            ? secondarySession
+            : null,
+      getSessionForDevice: (deviceId: string) =>
+        deviceId === session.assignedDevice
+          ? session.sessionId
+          : deviceId === secondarySession.assignedDevice
+            ? secondarySession.sessionId
+            : null,
+      getDeviceLabels: (sessionId: string) =>
+        sessionId === session.sessionId ? { B: secondarySession.sessionId } : undefined,
       releaseSession: async () => null,
     }),
     getDevicePool: () => ({
       refreshDevices: async () => 0,
       getStats: () => ({ total: 0, idle: 0, assigned: 0, error: 0 }),
       releaseDevice: async () => {},
+      resolveAutolockSessionForMcpSession: () => resolveAutolockSession(),
     }),
     getDeviceSessionRegistry: () => ({
-      list: () => sessionIsValid() ? [deviceSession] : [],
+      list: () => [
+        ...(sessionIsValid() ? [deviceSession] : []),
+        ...(secondarySessionIsValid() ? [secondaryDeviceSession] : []),
+      ],
     }),
   };
 }
 
-function sendRequest(socketPath: string, method: string, params: Record<string, unknown> = {}): Promise<DaemonResponse> {
-  return sendSocketRequest(socketPath, method, params);
+function sendRequest(
+  socketPath: string,
+  method: string,
+  params: Record<string, unknown> = {},
+  timeoutMs?: number,
+): Promise<DaemonResponse> {
+  return sendSocketRequest(socketPath, method, params, timeoutMs);
 }
 
 class PersistentSocketClient {
@@ -150,15 +185,23 @@ describe("UnixSocketServer MCP session reconnect", () => {
   let server: UnixSocketServer;
   let fakeTimer: FakeTimer;
   let sessionIsValid: boolean;
+  let secondarySessionIsValid: boolean;
+  let autolockSessionUuid: string | undefined;
 
   beforeEach(async () => {
     socketPath = join(tmpdir(), `mcp-rc-${randomUUID()}.sock`);
     fakeTimer = new FakeTimer();
     sessionIsValid = true;
+    secondarySessionIsValid = true;
+    autolockSessionUuid = undefined;
     server = new UnixSocketServer(
       socketPath,
       "http://localhost:0/mcp",
-      createFakeDaemonState(() => sessionIsValid),
+      createFakeDaemonState(
+        () => sessionIsValid,
+        () => secondarySessionIsValid,
+        () => autolockSessionUuid,
+      ),
       fakeTimer,
     );
     await server.start();
@@ -333,13 +376,20 @@ describe("UnixSocketServer MCP session reconnect", () => {
   test("returns a retryable structured error after observe reconnection exhaustion", async () => {
     let clientsCreated = 0;
     let callsDispatched = 0;
+    let closeCalls = 0;
 
     server.mcpClientFactory = async () => {
-      clientsCreated++;
+      const clientIndex = ++clientsCreated;
       return createFakeMcpClient({
         callTool: async () => {
           callsDispatched++;
-          throw socketClosedError(" endpoint=https://secret.invalid?token=hidden");
+          if (clientIndex <= 2) {
+            throw socketClosedError(" endpoint=https://secret.invalid?token=hidden");
+          }
+          return { content: [{ type: "text", text: "observed" }] };
+        },
+        close: async () => {
+          closeCalls++;
         },
       });
     };
@@ -366,6 +416,16 @@ describe("UnixSocketServer MCP session reconnect", () => {
       reconnectAttempted: true,
       replayAttempted: true,
     });
+    expect(closeCalls).toBe(2);
+    expect((server as any).mcpClients.size).toBe(0);
+
+    const nextResponse = await sendRequest(socketPath, "tools/call", {
+      name: "observe",
+      arguments: { sessionUuid: "session-a" },
+    });
+    expect(nextResponse.success).toBe(true);
+    expect(clientsCreated).toBe(3);
+    expect(callsDispatched).toBe(3);
   });
 
   test("does not reconnect or replay after the bound device session becomes invalid", async () => {
@@ -402,6 +462,138 @@ describe("UnixSocketServer MCP session reconnect", () => {
       reconnectAttempted: false,
       replayAttempted: false,
     });
+  });
+
+  test("fences recovery to the device-label session and epoch", async () => {
+    let clientsCreated = 0;
+    let callsDispatched = 0;
+
+    server.mcpClientFactory = async () => {
+      clientsCreated++;
+      return createFakeMcpClient({
+        callTool: async () => {
+          callsDispatched++;
+          secondarySessionIsValid = false;
+          throw socketClosedError();
+        },
+      });
+    };
+
+    const response = await sendRequest(socketPath, "tools/call", {
+      name: "observe",
+      arguments: { sessionUuid: "session-a", device: "B" },
+    });
+
+    expect(response.success).toBe(false);
+    expect(clientsCreated).toBe(1);
+    expect(callsDispatched).toBe(1);
+    expect(response.transportFailure).toMatchObject({
+      deviceId: "emulator-5556",
+      deviceSessionUuid: "device-epoch-b",
+      sessionUuid: "session-b",
+      sessionValid: false,
+      reconnectAttempted: false,
+      replayAttempted: false,
+    });
+  });
+
+  test("recovers observe for an implicit autolock session", async () => {
+    let clientsCreated = 0;
+    let callsDispatched = 0;
+    autolockSessionUuid = "session-a";
+
+    server.mcpClientFactory = async () => {
+      const clientIndex = ++clientsCreated;
+      return createFakeMcpClient({
+        callTool: async () => {
+          callsDispatched++;
+          if (clientIndex === 1) {
+            throw socketClosedError();
+          }
+          return { content: [{ type: "text", text: "observed" }] };
+        },
+      });
+    };
+
+    const response = await sendRequest(socketPath, "tools/call", {
+      name: "observe",
+      arguments: { platform: "android" },
+    });
+
+    expect(response.success).toBe(true);
+    expect(clientsCreated).toBe(2);
+    expect(callsDispatched).toBe(2);
+  });
+
+  test("does not dispatch after reconnect consumes the remaining deadline", async () => {
+    let clientsCreated = 0;
+    let callsDispatched = 0;
+    let closeCalls = 0;
+
+    server.mcpClientFactory = async () => {
+      const clientIndex = ++clientsCreated;
+      if (clientIndex === 2) {
+        fakeTimer.advanceTime(90_001);
+      }
+      return createFakeMcpClient({
+        callTool: async () => {
+          callsDispatched++;
+          if (clientIndex === 1) {
+            throw socketClosedError();
+          }
+          return { content: [{ type: "text", text: "observed" }] };
+        },
+        close: async () => {
+          closeCalls++;
+        },
+      });
+    };
+
+    const response = await sendRequest(
+      socketPath,
+      "tools/call",
+      {
+        name: "observe",
+        arguments: { sessionUuid: "session-a" },
+      },
+      100,
+    );
+
+    expect(response.success).toBe(false);
+    expect(clientsCreated).toBe(2);
+    expect(callsDispatched).toBe(1);
+    expect(response.transportFailure).toMatchObject({
+      retryable: true,
+      reconnectAttempted: true,
+      replayAttempted: false,
+    });
+    expect(closeCalls).toBe(2);
+    expect((server as any).mcpClients.size).toBe(0);
+  });
+
+  test("does not classify an MCP application error by message text", async () => {
+    let clientsCreated = 0;
+
+    server.mcpClientFactory = async () => {
+      clientsCreated++;
+      return createFakeMcpClient({
+        callTool: async () => {
+          throw new McpError(
+            ErrorCode.InternalError,
+            "The socket connection was closed unexpectedly in the application",
+          );
+        },
+      });
+    };
+
+    const response = await sendRequest(socketPath, "tools/call", {
+      name: "observe",
+      arguments: { sessionUuid: "session-a" },
+    });
+
+    expect(response.success).toBe(false);
+    expect(clientsCreated).toBe(1);
+    expect(response.transportFailure).toBeUndefined();
   });
 
   test("subsequent requests reuse the reconnected client without creating another", async () => {

--- a/test/daemon/socketServerMcpReconnect.test.ts
+++ b/test/daemon/socketServerMcpReconnect.test.ts
@@ -547,6 +547,25 @@ describe("UnixSocketServer MCP session reconnect", () => {
     expect((server as any).mcpClients.size).toBe(1);
   });
 
+  test("does not evict a replacement client while resetting a failed route", async () => {
+    let replacementCloseCalls = 0;
+    const failedClient = createFakeMcpClient();
+    const replacementClient = createFakeMcpClient({
+      close: async () => {
+        replacementCloseCalls++;
+      },
+    });
+    const clientKey = "session:replacement-race";
+    const internals = server as any;
+    internals.mcpClients.set(clientKey, replacementClient);
+
+    const reset = await internals.resetMcpClientIfCurrent(clientKey, failedClient, "detach");
+
+    expect(reset).toBe(false);
+    expect(internals.mcpClients.get(clientKey)).toBe(replacementClient);
+    expect(replacementCloseCalls).toBe(0);
+  });
+
   test("does not replay launchApp after an ambiguous response closure", async () => {
     let clientsCreated = 0;
     let callsDispatched = 0;
@@ -847,6 +866,38 @@ describe("UnixSocketServer MCP session reconnect", () => {
 
     expect(closeCalls).toBe(2);
     expect((server as any).mcpClients.size).toBe(0);
+  });
+
+  test("preserves an unresolved device label when replaying observe", async () => {
+    let clientsCreated = 0;
+    let replayedArguments: Record<string, unknown> | undefined;
+    deviceLabelSessionUuid = undefined;
+
+    server.mcpClientFactory = async () => {
+      const clientIndex = ++clientsCreated;
+      return createFakeMcpClient({
+        callTool: async (...args: unknown[]) => {
+          if (clientIndex === 1) {
+            throw socketClosedError();
+          }
+          const [toolCall] = args as [{ arguments: Record<string, unknown> }];
+          replayedArguments = toolCall.arguments;
+          return { content: [{ type: "text", text: "observed" }] };
+        },
+      });
+    };
+
+    const response = await sendRequest(socketPath, "tools/call", {
+      name: "observe",
+      arguments: { sessionUuid: "session-a", device: "unknown" },
+    });
+
+    expect(response.success).toBe(true);
+    expect(clientsCreated).toBe(2);
+    expect(replayedArguments).toMatchObject({
+      sessionUuid: "session-a",
+      device: "unknown",
+    });
   });
 
   test("recovers observe for an implicit autolock session", async () => {

--- a/test/daemon/socketServerMcpReconnect.test.ts
+++ b/test/daemon/socketServerMcpReconnect.test.ts
@@ -376,6 +376,35 @@ describe("UnixSocketServer MCP session reconnect", () => {
     expect(callsDispatched).toBe(1);
   });
 
+  test("does not reconnect an unestablished device across session recreation", async () => {
+    let clientsCreated = 0;
+    deviceEpochUuid = undefined;
+
+    server.mcpClientFactory = async () => {
+      clientsCreated++;
+      primarySessionGeneration = 1;
+      throw socketClosedError();
+    };
+
+    const response = await sendRequest(socketPath, "tools/call", {
+      name: "observe",
+      arguments: { sessionUuid: "session-a" },
+    });
+
+    expect(response.success).toBe(false);
+    expect(clientsCreated).toBe(1);
+    expect(response.transportFailure).toMatchObject({
+      sessionUuid: "session-a",
+      routingSessionUuid: "session-a",
+      sessionValid: false,
+      deviceSessionValid: false,
+      phase: "connect",
+      retryable: false,
+      reconnectAttempted: false,
+      replayAttempted: false,
+    });
+  });
+
   test("preserves an unrelated failure while reconnecting before request dispatch", async () => {
     let clientsCreated = 0;
 

--- a/test/daemon/socketServerMcpReconnect.test.ts
+++ b/test/daemon/socketServerMcpReconnect.test.ts
@@ -51,6 +51,7 @@ function createFakeDaemonState(
   resolveSecondaryDeviceEpochUuid: () => string | undefined,
   resolveAutolockSession: () => string | undefined,
   resolveDeviceLabelSession: () => string | undefined,
+  resolvePrimaryDeviceOwnerSession: () => string | undefined,
 ) {
   const session = {
     sessionId: "session-a",
@@ -93,7 +94,7 @@ function createFakeDaemonState(
             : null,
       getSessionForDevice: (deviceId: string) =>
         deviceId === session.assignedDevice
-          ? session.sessionId
+          ? resolvePrimaryDeviceOwnerSession()
           : deviceId === secondarySession.assignedDevice
             ? secondarySession.sessionId
             : null,
@@ -209,6 +210,7 @@ describe("UnixSocketServer MCP session reconnect", () => {
   let secondaryDeviceEpochUuid: string | undefined;
   let autolockSessionUuid: string | undefined;
   let deviceLabelSessionUuid: string | undefined;
+  let primaryDeviceOwnerSessionUuid: string | undefined;
 
   beforeEach(async () => {
     socketPath = join(tmpdir(), `mcp-rc-${randomUUID()}.sock`);
@@ -219,6 +221,7 @@ describe("UnixSocketServer MCP session reconnect", () => {
     secondaryDeviceEpochUuid = "device-epoch-b";
     autolockSessionUuid = undefined;
     deviceLabelSessionUuid = "session-b";
+    primaryDeviceOwnerSessionUuid = "session-a";
     server = new UnixSocketServer(
       socketPath,
       "http://localhost:0/mcp",
@@ -229,6 +232,7 @@ describe("UnixSocketServer MCP session reconnect", () => {
         () => secondaryDeviceEpochUuid,
         () => autolockSessionUuid,
         () => deviceLabelSessionUuid,
+        () => primaryDeviceOwnerSessionUuid,
       ),
       fakeTimer,
     );
@@ -694,6 +698,45 @@ describe("UnixSocketServer MCP session reconnect", () => {
       deviceSessionValid: true,
       phase: "response",
       retryable: false,
+      reconnectAttempted: false,
+      replayAttempted: false,
+    });
+  });
+
+  test("refreshes newly assigned ownership before response recovery", async () => {
+    let clientsCreated = 0;
+    let callsDispatched = 0;
+    primaryDeviceOwnerSessionUuid = undefined;
+
+    server.mcpClientFactory = async () => {
+      clientsCreated++;
+      return createFakeMcpClient({
+        callTool: async () => {
+          callsDispatched++;
+          primaryDeviceOwnerSessionUuid = "session-a";
+          sessionIsValid = false;
+          throw socketClosedError();
+        },
+      });
+    };
+
+    const response = await sendRequest(socketPath, "tools/call", {
+      name: "observe",
+      arguments: {
+        sessionUuid: "session-a",
+        deviceId: "emulator-5554",
+      },
+    });
+
+    expect(response.success).toBe(false);
+    expect(clientsCreated).toBe(1);
+    expect(callsDispatched).toBe(1);
+    expect(response.transportFailure).toMatchObject({
+      deviceId: "emulator-5554",
+      deviceSessionUuid: "device-epoch-a",
+      sessionUuid: "session-a",
+      sessionValid: false,
+      deviceSessionValid: true,
       reconnectAttempted: false,
       replayAttempted: false,
     });

--- a/test/daemon/socketServerMcpReconnect.test.ts
+++ b/test/daemon/socketServerMcpReconnect.test.ts
@@ -850,10 +850,12 @@ describe("UnixSocketServer MCP session reconnect", () => {
     await replayStarted;
 
     expect(clientsCreated).toBe(2);
-    expect(clientBindings).toEqual(["session-a", "session-b"]);
-    expect(replayedArguments).toMatchObject({ sessionUuid: "session-b" });
+    expect(clientBindings).toEqual(["session-a", "session-a"]);
+    expect(replayedArguments).toMatchObject({
+      sessionUuid: "session-a",
+      deviceId: "emulator-5556",
+    });
     expect(replayedArguments).not.toHaveProperty("device");
-    expect(replayedArguments).not.toHaveProperty("deviceId");
     expect((server as any).mcpClients.size).toBe(1);
 
     fakeTimer.advanceTime(5 * 60 * 1000);
@@ -869,8 +871,8 @@ describe("UnixSocketServer MCP session reconnect", () => {
     fakeTimer.advanceTime(5 * 60 * 1000);
     await Promise.resolve();
 
-    expect(closeCalls).toBe(2);
-    expect((server as any).mcpClients.size).toBe(0);
+    expect(closeCalls).toBe(1);
+    expect((server as any).mcpClients.size).toBe(1);
   });
 
   test("preserves an unresolved device label when replaying observe", async () => {

--- a/test/server/proxyServerTransportFailure.test.ts
+++ b/test/server/proxyServerTransportFailure.test.ts
@@ -29,6 +29,7 @@ describe("proxy server device-control transport errors", () => {
       deviceSessionUuid: "device-epoch-a",
       sessionUuid: "session-a",
       sessionValid: true,
+      deviceSessionValid: true,
       phase: "response",
       retryable: false,
       reconnectAttempted: true,

--- a/test/server/proxyServerTransportFailure.test.ts
+++ b/test/server/proxyServerTransportFailure.test.ts
@@ -34,11 +34,15 @@ describe("proxy server device-control transport errors", () => {
       reconnectAttempted: true,
       replayAttempted: false,
     };
+    const unsafeFailure = {
+      ...failure,
+      endpoint: "https://secret.invalid?token=hidden",
+    } as DeviceControlTransportFailure;
     const fakeClient = new FakeDaemonClient({
       onCallTool: () => {
         throw new DeviceControlTransportError(
           "Device-control transport closed while handling launchApp",
-          failure,
+          unsafeFailure,
         );
       },
     });
@@ -80,6 +84,7 @@ describe("proxy server device-control transport errors", () => {
         ],
         isError: true,
       });
+      expect(JSON.stringify(result)).not.toContain("secret.invalid");
     } finally {
       await client.close();
       await server.close();

--- a/test/server/proxyServerTransportFailure.test.ts
+++ b/test/server/proxyServerTransportFailure.test.ts
@@ -28,6 +28,7 @@ describe("proxy server device-control transport errors", () => {
       deviceId: "emulator-5554",
       deviceSessionUuid: "device-epoch-a",
       sessionUuid: "session-a",
+      routingSessionUuid: "session-a",
       sessionValid: true,
       deviceSessionValid: true,
       phase: "response",

--- a/test/server/proxyServerTransportFailure.test.ts
+++ b/test/server/proxyServerTransportFailure.test.ts
@@ -1,0 +1,89 @@
+import { afterEach, describe, expect, spyOn, test } from "bun:test";
+import { Client } from "@modelcontextprotocol/sdk/client/index.js";
+import { InMemoryTransport } from "@modelcontextprotocol/sdk/inMemory.js";
+import { DaemonClient } from "../../src/daemon/client";
+import { DAEMON_VERSION } from "../../src/daemon/constants";
+import {
+  DeviceControlTransportError,
+  type DeviceControlTransportFailure,
+} from "../../src/daemon/deviceControlTransportFailure";
+import { createProxyMcpServer } from "../../src/server/proxyServer";
+import { FakeDaemonClient } from "../fakes/FakeDaemonClient";
+import { FakeDaemonManager } from "../fakes/FakeDaemonManager";
+
+let isAvailableSpy: ReturnType<typeof spyOn> | null = null;
+
+afterEach(() => {
+  isAvailableSpy?.mockRestore();
+  isAvailableSpy = null;
+});
+
+describe("proxy server device-control transport errors", () => {
+  test("returns safe machine-readable transport failure details", async () => {
+    isAvailableSpy = spyOn(DaemonClient, "isAvailable").mockResolvedValue(true);
+    const failure: DeviceControlTransportFailure = {
+      code: "device_control_transport_failure",
+      transport: "daemon_loopback_http",
+      toolName: "launchApp",
+      deviceId: "emulator-5554",
+      deviceSessionUuid: "device-epoch-a",
+      sessionUuid: "session-a",
+      sessionValid: true,
+      phase: "response",
+      retryable: false,
+      reconnectAttempted: true,
+      replayAttempted: false,
+    };
+    const fakeClient = new FakeDaemonClient({
+      onCallTool: () => {
+        throw new DeviceControlTransportError(
+          "Device-control transport closed while handling launchApp",
+          failure,
+        );
+      },
+    });
+    const daemonManager = new FakeDaemonManager();
+    daemonManager.statusResult = {
+      ...daemonManager.statusResult,
+      version: DAEMON_VERSION,
+    };
+    const { server, proxy } = createProxyMcpServer({
+      proxyConfig: {
+        clientFactory: () => fakeClient,
+        daemonManager,
+        autoStartDaemon: false,
+      },
+    });
+    const [serverTransport, clientTransport] = InMemoryTransport.createLinkedPair();
+    const client = new Client({ name: "transport-failure-test-client", version: "0.0.1" });
+
+    try {
+      await server.connect(serverTransport);
+      await client.connect(clientTransport);
+
+      const result = await client.callTool({
+        name: "launchApp",
+        arguments: { sessionUuid: "session-a", appId: "dev.example" },
+      });
+
+      expect(result).toEqual({
+        content: [
+          {
+            type: "text",
+            text: JSON.stringify({
+              error: {
+                message: "Device-control transport closed while handling launchApp",
+                ...failure,
+              },
+            }),
+          },
+        ],
+        isError: true,
+      });
+    } finally {
+      await client.close();
+      await server.close();
+      await proxy.close();
+    }
+  });
+});


### PR DESCRIPTION
## Summary

Classify Bun loopback socket closures as typed device-control transport failures. Reconnect once within the existing request deadline, replay `observe` when safe, and reconnect without replaying an ambiguously completed `launchApp`.

The structured failure preserves the legacy daemon error string while adding safe device/session identity, transport phase, session validity, retryability, and recovery-attempt metadata through the TypeScript proxy.

## Linked Issue

Closes #5499

## Bug / Regression Context

- **Prior attempts:** The daemon already recreated loopback MCP clients for `Session not found`, but generic socket closures were flattened to raw fetch errors.
- **Observed symptom:** `launchApp` or `observe` could fail with `The socket connection was closed unexpectedly` after Android startup and setup succeeded.
- **Repro steps / conditions:** Close the daemon loopback Streamable HTTP connection before request dispatch or while the response is in flight.

## Validation

- [x] `bun run turbo:validate`
- [x] `bun run typecheck`
- [x] Focused daemon reconnect, transport-wire, and proxy-wire tests pass
- [x] New recovery uses the existing injected MCP client factory and `FakeTimer`; unit tests remain under 100ms each
- [x] No new dependency or generic helper
- [x] Rebased onto latest `main`, conflicts resolved

## Follow-ups

No follow-up issue identified.
