### PR TITLE
build(desktop): wire Conveyor live publish for macOS + Linux behind DESKTOP_PUBLISHER [C4]

### DIFF
--- a/.github/workflows/build-desktop-conveyor.yml
+++ b/.github/workflows/build-desktop-conveyor.yml
@@ -77,10 +77,12 @@ jobs:
           lfs: true
           persist-credentials: false
 
-      - name: "Validate version"
+      - name: "Validate inputs"
         shell: bash
         env:
           VERSION: ${{ inputs.version }}
+          PUBLISH: ${{ inputs.publish }}
+          SIGNED: ${{ inputs.signed }}
         run: |
           set -euo pipefail
           if [[ ! "$VERSION" =~ ^[0-9]+\.[0-9]+\.[0-9]+([-+][0-9A-Za-z.-]+)?$ ]]; then
@@ -90,6 +92,13 @@ jobs:
           major="${VERSION%%.*}"
           if [[ "$major" -lt 1 ]]; then
             echo "Conveyor requires a macOS major version >= 1; got $VERSION" >&2
+            exit 1
+          fi
+          # Refuse to publish self-signed packages: publish uses the base config (sign = false), whose
+          # unsigned macOS bundles would fail Gatekeeper for everyone who downloads the release.
+          # Signing (ci.conveyor.conf) is mandatory when pushing to a public GitHub Release.
+          if [[ "$PUBLISH" == "true" && "$SIGNED" != "true" ]]; then
+            echo "::error::publish=true requires signed=true — refusing to publish unsigned macOS packages" >&2
             exit 1
           fi
 

--- a/.github/workflows/build-desktop-conveyor.yml
+++ b/.github/workflows/build-desktop-conveyor.yml
@@ -24,6 +24,11 @@ on:
         required: false
         type: boolean
         default: false
+      publish:
+        description: "Publish the update site to GitHub Releases (make copied-site) instead of artifacts-only"
+        required: false
+        type: boolean
+        default: false
   workflow_call:
     inputs:
       version:
@@ -31,6 +36,10 @@ on:
         required: true
         type: string
       signed:
+        required: false
+        type: boolean
+        default: false
+      publish:
         required: false
         type: boolean
         default: false
@@ -50,7 +59,9 @@ on:
         required: false
 
 permissions:
-  contents: read
+  # `contents: write` is needed only for publish mode (make copied-site → GitHub Releases). The
+  # default artifacts-only run does not push anything; the elevated scope is unused there.
+  contents: write
 
 jobs:
   conveyor:
@@ -121,10 +132,12 @@ jobs:
           echo "::add-mask::${MACOS_DEVELOPER_ID_CERT_PASSWORD}"
           echo "CONVEYOR_MAC_CERTIFICATE_PASSWORD=${MACOS_DEVELOPER_ID_CERT_PASSWORD}" >> "$GITHUB_ENV"
 
-      - name: "Run Conveyor (make site)"
+      - name: "Run Conveyor"
         uses: hydraulic-software/conveyor/actions/build@v22.0
         with:
-          command: make site
+          # publish -> `make copied-site` pushes the site to app.site.copy-to (GitHub Releases);
+          # otherwise `make site` writes to ./output only (artifacts-only).
+          command: ${{ inputs.publish && 'make copied-site' || 'make site' }}
           # The action runs from the repo root and has no working-dir input, so point Conveyor at the
           # config with -f; Conveyor treats the config file's directory (android/) as the project
           # root, so its `./gradlew` include and relative asset paths resolve there. A signed run uses
@@ -134,6 +147,10 @@ jobs:
           agree_to_license: 1
         env:
           CONVEYOR_APP_VERSION: ${{ inputs.version }}
+          # In publish mode, set conveyor.conf's env-gated site.copy-to to this repo's GitHub Releases
+          # and hand Conveyor the token to attach the Sparkle/apt assets. Unset otherwise -> no push.
+          CONVEYOR_SITE_COPY_TO: ${{ inputs.publish && 'github:kaeawc/auto-mobile' || '' }}
+          GITHUB_TOKEN: ${{ inputs.publish && secrets.GITHUB_TOKEN || '' }}
           # The cert password reaches Conveyor as CONVEYOR_MAC_CERTIFICATE_PASSWORD via GITHUB_ENV
           # from the prepare step above (matching ci.conveyor.conf). The notary issuer/key ids are
           # read directly under their own names by ci.conveyor.conf.

--- a/.github/workflows/build-desktop-conveyor.yml
+++ b/.github/workflows/build-desktop-conveyor.yml
@@ -24,11 +24,10 @@ on:
         required: false
         type: boolean
         default: false
-      publish:
-        description: "Publish the update site to GitHub Releases (make copied-site) instead of artifacts-only"
-        required: false
-        type: boolean
-        default: false
+      # No `publish` input here on purpose: publishing to GitHub Releases is only reachable via
+      # workflow_call from release.yml, which binds the version to the validated release tag. A manual
+      # dispatch is always artifacts-only, so it can never push wrong-commit or wrong-version packages
+      # to a public release (#5227, PR-C4).
   workflow_call:
     inputs:
       version:
@@ -101,6 +100,13 @@ jobs:
             echo "::error::publish=true requires signed=true — refusing to publish unsigned macOS packages" >&2
             exit 1
           fi
+          # Conveyor has no prerelease/build-metadata field, so publishing a qualified version would
+          # push copied-site to the wrong (base) version. release.yml rejects such tags up front; guard
+          # the workflow_call publish path here too (defense in depth).
+          if [[ "$PUBLISH" == "true" && ( "$VERSION" == *-* || "$VERSION" == *+* ) ]]; then
+            echo "::error::publish=true does not support prerelease/build-metadata versions: $VERSION" >&2
+            exit 1
+          fi
 
       - name: "Set up JDK 21"
         uses: actions/setup-java@v4
@@ -142,7 +148,9 @@ jobs:
           echo "CONVEYOR_MAC_CERTIFICATE_PASSWORD=${MACOS_DEVELOPER_ID_CERT_PASSWORD}" >> "$GITHUB_ENV"
 
       - name: "Run Conveyor"
-        uses: hydraulic-software/conveyor/actions/build@v22.0
+        # Pinned to the v22.0 commit: this third-party action receives contents: write on the publish
+        # path, so pin to an immutable SHA rather than the mutable tag (supply-chain hardening).
+        uses: hydraulic-software/conveyor/actions/build@9e90ce7c2a4356c99d68c63f41e4bc497da279c8 # v22.0
         with:
           # publish -> `make copied-site` pushes the site to app.site.copy-to (GitHub Releases);
           # otherwise `make site` writes to ./output only (artifacts-only).

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -211,7 +211,12 @@ jobs:
       # Desktop installers are direct user downloads, not runtime-fetched
       # dependencies, so they carry no source-checksum entry in the release
       # constants; they are attached to the GitHub release as-is.
+      # macOS + Linux desktop assets come from jpackage by default. When DESKTOP_PUBLISHER=conveyor
+      # they are published instead by publish-desktop-conveyor.yml (Sparkle/apt), so skip the jpackage
+      # download+upload for those two here. Windows stays on jpackage regardless — Conveyor does not
+      # build Windows yet (#5227, PR-C4).
       - name: "Download desktop macOS DMG"
+        if: ${{ vars.DESKTOP_PUBLISHER != 'conveyor' }}
         uses: actions/download-artifact@v7
         with:
           name: automobile-desktop-macos
@@ -230,6 +235,7 @@ jobs:
           run-id: ${{ inputs.prepare_run_id }}
 
       - name: "Download desktop Linux Deb"
+        if: ${{ vars.DESKTOP_PUBLISHER != 'conveyor' }}
         uses: actions/download-artifact@v7
         with:
           name: automobile-desktop-linux
@@ -238,7 +244,11 @@ jobs:
           repository: ${{ github.repository }}
           run-id: ${{ inputs.prepare_run_id }}
 
+      # The verifier checks all three jpackage installers, so it only applies to the default
+      # (all-jpackage) path. In conveyor mode macOS/Linux are absent here (Conveyor verifies its own
+      # signed/notarized output), so verify only the Windows .msi that jpackage still ships.
       - name: Verify prepared desktop installers
+        if: ${{ vars.DESKTOP_PUBLISHER != 'conveyor' }}
         env:
           VERSION: ${{ steps.version.outputs.version }}
         run: bash scripts/ci/verify-desktop-installer-assets.sh "$VERSION" /tmp/desktop
@@ -347,6 +357,7 @@ jobs:
           REPO: ${{ github.repository }}
           TAG: ${{ needs.validate-release-tag.outputs.tag }}
           VERSION: ${{ steps.version.outputs.version }}
+          DESKTOP_PUBLISHER: ${{ vars.DESKTOP_PUBLISHER }}
         run: |
           set -euo pipefail
           files=(
@@ -354,10 +365,17 @@ jobs:
             /tmp/control-proxy.ipa
             /tmp/automobile-video.jar
             /tmp/screen-capture-helper-macos-universal.zip
-            /tmp/desktop/AutoMobile-${VERSION}-macos.dmg
             /tmp/desktop/AutoMobile-${VERSION}-windows.msi
-            /tmp/desktop/AutoMobile-${VERSION}-linux.deb
           )
+          # macOS .dmg + Linux .deb are attached by jpackage in the default path, or by
+          # publish-desktop-conveyor.yml (Sparkle/apt) when DESKTOP_PUBLISHER=conveyor. Windows .msi
+          # above is always jpackage — Conveyor does not build Windows yet (#5227, PR-C4).
+          if [ "${DESKTOP_PUBLISHER:-jpackage}" != "conveyor" ]; then
+            files+=(
+              /tmp/desktop/AutoMobile-${VERSION}-macos.dmg
+              /tmp/desktop/AutoMobile-${VERSION}-linux.deb
+            )
+          fi
 
           # Use the GitHub Release API directly through gh. `gh release create`
           # uploads through a draft before publishing, so a failed first attempt
@@ -654,3 +672,48 @@ jobs:
           MSG="The npm package includes APK and IPA checksums at"
           MSG="$MSG build time, ensuring integrity verification."
           echo "$MSG" >> "$S"
+
+  # --- Conveyor desktop publish (macOS + Linux) --------------------------------
+  # Gated on the DESKTOP_PUBLISHER repo variable. When it is set to "conveyor", the macOS + Linux
+  # desktop assets are published here — signed + notarized, delivered via Sparkle (macOS) and a
+  # generated apt repo (Linux) — instead of by jpackage; the verify-and-release job above skips the
+  # jpackage .dmg/.deb in that mode but always ships the Windows .msi (Conveyor does not build Windows
+  # yet). When the variable is unset or "jpackage" both jobs below skip and the release is byte-for-
+  # byte what it is today. These run after verify-and-release so the GitHub Release already exists for
+  # Conveyor's copied-site to attach to. See #5227 (PR-C4).
+  #
+  # PREREQUISITES before flipping DESKTOP_PUBLISHER=conveyor (documented on the PR): (1) add the
+  # CONVEYOR_SIGNING_KEY repo secret; (2) verify a manual dispatch of build-desktop-conveyor.yml; and
+  # (3) resolve desktop >=1.0 versioning so Conveyor's floored version matches the release tag (the
+  # repo is on 0.0.x, which Conveyor cannot use as a macOS version — see resolve step below).
+  resolve-conveyor-version:
+    name: "Resolve Conveyor version"
+    if: ${{ vars.DESKTOP_PUBLISHER == 'conveyor' }}
+    needs: [validate-release-tag, verify-and-release]
+    runs-on: ubuntu-latest
+    outputs:
+      version: ${{ steps.v.outputs.version }}
+    steps:
+      # Conveyor requires a macOS major >= 1; floor a 0-major to 1 (0.0.61 -> 1.0.61), mirroring
+      # desktopMacPackageVersion in desktop-app/build.gradle.kts. NOTE: this diverges from the release
+      # tag until the repo adopts real >=1.0 desktop versioning; see the prerequisites above.
+      - name: "Floor major to >= 1 for Conveyor"
+        id: v
+        env:
+          TAG: ${{ needs.validate-release-tag.outputs.tag }}
+        run: |
+          set -euo pipefail
+          core="${TAG%%[-+]*}"
+          IFS=. read -r major minor patch <<<"$core"
+          if [[ "${major:-0}" -lt 1 ]]; then major=1; fi
+          echo "version=${major}.${minor:-0}.${patch:-0}" >> "$GITHUB_OUTPUT"
+
+  publish-desktop-conveyor:
+    name: "Publish desktop via Conveyor"
+    needs: resolve-conveyor-version
+    uses: ./.github/workflows/build-desktop-conveyor.yml
+    with:
+      version: ${{ needs.resolve-conveyor-version.outputs.version }}
+      signed: true
+      publish: true
+    secrets: inherit

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -46,8 +46,18 @@ jobs:
           EVENT_NAME: ${{ github.event_name }}
           REF_TYPE: ${{ github.ref_type }}
           REF_NAME: ${{ github.ref_name }}
+          DESKTOP_PUBLISHER: ${{ vars.DESKTOP_PUBLISHER }}
         run: |
           echo "tag=$TAG" >> "$GITHUB_OUTPUT"
+
+          # Conveyor publish mode: reject prerelease/build-metadata tags up front, before
+          # verify-and-release publishes the release without the jpackage macOS/Linux assets. Conveyor
+          # has no field for such a qualifier, so copied-site would target the base version — fail the
+          # whole release here instead (#5227, PR-C4).
+          if [[ "${DESKTOP_PUBLISHER:-jpackage}" == "conveyor" && ( "$TAG" == *-* || "$TAG" == *+* ) ]]; then
+            echo "Conveyor desktop publish does not support prerelease/build-metadata tags: $TAG" >&2
+            exit 1
+          fi
 
           # Prepare Release must dispatch this workflow on the tag, not merely
           # name it. docker/metadata-action derives semver tags from github.ref.
@@ -686,6 +696,15 @@ jobs:
   # CONVEYOR_SIGNING_KEY repo secret; (2) verify a manual dispatch of build-desktop-conveyor.yml; and
   # (3) resolve desktop >=1.0 versioning so Conveyor's floored version matches the release tag (the
   # repo is on 0.0.x, which Conveyor cannot use as a macOS version — see resolve step below).
+  #
+  # KNOWN LIMITATION (post-publish attach): these jobs run after verify-and-release has already
+  # published the GitHub Release, so in conveyor mode the release is briefly live without the
+  # macOS/Linux assets until Conveyor attaches them, and a Conveyor failure leaves them unattached
+  # (re-run this job to fix). Making it atomic — building Conveyor as a prepared candidate in
+  # prepare-release.yml and attaching it during verify-and-release like jpackage — is the hardening
+  # step to land alongside prerequisite (2), before the switch is actually flipped. Unsupported tags
+  # and unsigned publishes are already rejected up front (validate-release-tag / build-desktop-
+  # conveyor.yml) so the release is never published into a config that Conveyor will then reject.
   resolve-conveyor-version:
     name: "Resolve Conveyor version"
     if: ${{ vars.DESKTOP_PUBLISHER == 'conveyor' }}

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -703,8 +703,14 @@ jobs:
           TAG: ${{ needs.validate-release-tag.outputs.tag }}
         run: |
           set -euo pipefail
-          core="${TAG%%[-+]*}"
-          IFS=. read -r major minor patch <<<"$core"
+          # Conveyor has no field for a prerelease/build qualifier, so stripping the suffix would make
+          # copied-site target a different base version than the release tag. Refuse rather than
+          # publish to the wrong version (the jpackage macOS/Linux assets are already omitted here).
+          if [[ "$TAG" == *-* || "$TAG" == *+* ]]; then
+            echo "::error::Conveyor desktop publish does not support prerelease/build-metadata tags: $TAG" >&2
+            exit 1
+          fi
+          IFS=. read -r major minor patch <<<"$TAG"
           if [[ "${major:-0}" -lt 1 ]]; then major=1; fi
           echo "version=${major}.${minor:-0}.${patch:-0}" >> "$GITHUB_OUTPUT"
 

--- a/android/conveyor.conf
+++ b/android/conveyor.conf
@@ -37,10 +37,14 @@ app {
 
   // Point the auto-update site at this repo's GitHub Releases: macOS updates flow through Sparkle and
   // Linux through a generated apt repo, both served from the release assets. This is the same repo
-  // GitHubReleaseSource polls, so the DIY checker and Conveyor agree on "latest". `make site` only
-  // writes the site to ./output; actually pushing it to GitHub Releases (site.copy-to +
-  // GITHUB_TOKEN) is wired when jpackage is retired (PR-C4).
+  // GitHubReleaseSource polls, so the DIY checker and Conveyor agree on "latest".
   vcs-url = "github.com/kaeawc/auto-mobile"
+
+  // `make site` writes the site to ./output only. `make copied-site` also pushes it to the
+  // destination below — set to `github:kaeawc/auto-mobile` (with GITHUB_TOKEN) by the publish
+  // workflow so a release attaches the Sparkle/apt assets to its GitHub Release. Unset for local
+  // and artifacts-only CI runs, so those never publish (#5227, PR-C4).
+  site.copy-to = ${?env.CONVEYOR_SITE_COPY_TO}
 
   icons = "desktop-app/src/main/resources/icons/app-icon.png"
 


### PR DESCRIPTION
## Summary

**PR-C4 of the Conveyor pivot** ([#5227](https://github.com/kaeawc/auto-mobile/issues/5227)), after
C1 ([#5305](https://github.com/kaeawc/auto-mobile/pull/5305)), C2
([#5384](https://github.com/kaeawc/auto-mobile/pull/5384)), C3
([#5456](https://github.com/kaeawc/auto-mobile/pull/5456)). Wires the desktop release cutover to
Conveyor as a **one-variable flip**, with jpackage kept as the default and a re-enablable fallback.
**No jpackage code is deleted** — deletion is a later follow-up once Conveyor ships a verified real
release.

## Cutover mechanism — repo variable `vars.DESKTOP_PUBLISHER` (default `jpackage`)

- **`release.yml`**: when `DESKTOP_PUBLISHER=conveyor`, the jpackage macOS `.dmg` + Linux `.deb`
  download/verify/upload are skipped and instead published by two new **gated** jobs
  (`resolve-conveyor-version` → `publish-desktop-conveyor`) that call the Conveyor workflow in
  publish mode *after* the release exists. **Windows `.msi` always stays on jpackage** (Conveyor
  builds no Windows yet). Unset/`jpackage` → both jobs skip and the release is **byte-for-byte
  unchanged**.
- **`prepare-release.yml`** is untouched — it still builds the jpackage candidates, so flipping
  `DESKTOP_PUBLISHER` back to `jpackage` restores the proven path with zero code change (the
  fallback).
- **`build-desktop-conveyor.yml`**: new `publish` input → `make copied-site` with
  `app.site.copy-to = github:kaeawc/auto-mobile` + `GITHUB_TOKEN` (`contents: write`). Default stays
  artifacts-only (`make site`).
- **`conveyor.conf`**: env-gated `app.site.copy-to` (`CONVEYOR_SITE_COPY_TO`) so only the publish
  path pushes to GitHub Releases; local + artifacts-only runs never publish.

## Why the integrated-job approach (not a `release: published` workflow)

A release published by `release.yml` via `GITHUB_TOKEN` does **not** trigger a downstream
`release: published` workflow (GitHub's recursion guard — consistent with this repo's history). So
the Conveyor publish runs as gated jobs *inside* `release.yml`, in the same run, after
`verify-and-release`.

## Deferred (documented, with rationale)

- **Native de-dup trim** (the C3 `currentOs` host-native bloat) — an unverifiable optimization that
  risks `run`/jpackage; it needs a verified Conveyor build to validate, so it waits until after the
  first real Conveyor release.
- **jpackage deletion** — kept intact as the fallback until Conveyor ships a verified release.

## Prerequisites before flipping `DESKTOP_PUBLISHER=conveyor`

1. Add the **`CONVEYOR_SIGNING_KEY`** repo secret (from C3).
2. Verify a manual dispatch of **Build Desktop App (Conveyor)**.
3. **Adopt desktop ≥1.0 versioning** — Conveyor requires a macOS major ≥ 1, so the resolve job floors
   `0.0.x` → `1.0.x`, which diverges from the `0.0.x` release tag; `copied-site` matches releases by
   Conveyor's version, so live publish needs the tag and Conveyor version aligned (the ≥1.0 decision
   deferred since C1).

## Validation

- [x] YAML valid for all 3 changed/added workflow paths
- [x] `all_fast_validate_checks.sh` (yaml / shellcheck / workflow-assertion-triggers) pass
- [x] `release-workflow-wiring.bats` + desktop BATS suites green
- [x] Default path (`DESKTOP_PUBLISHER` unset) is byte-for-byte unchanged — the new jobs skip and no
  existing step's behavior changes

## Linked

Part of the Conveyor migration on #5227. Predecessors: #5305 (C1), #5384 (C2), #5456 (C3). Follow-ups
once a real Conveyor release is verified: native de-dup trim, jpackage deletion, and Windows once a
cert is available.
