### PR TITLE
feat(tap): support precise targets within Android elements

### DIFF
--- a/docs/design-docs/mcp/a11y/talkback-voiceover.md
+++ b/docs/design-docs/mcp/a11y/talkback-voiceover.md
@@ -126,7 +126,7 @@ When TalkBack is active, Android reserves certain gestures:
 
 ### Per-Tool Adaptations
 
-**tapOn**: Use `ACTION_CLICK` on the target element instead of a coordinate-based tap. Optionally set accessibility focus first to mimic user behavior and trigger TalkBack announcement. Long press uses `ACTION_LONG_CLICK`. When Android-only `relativePosition: { x, y }` is present, bypass semantic activation and dispatch the normalized coordinate through CtrlProxy so distinct targets within one accessibility node remain addressable; the option is unsupported with `focus`.
+**tapOn**: Use `ACTION_CLICK` on the target element instead of a coordinate-based tap. Optionally set accessibility focus first to mimic user behavior and trigger TalkBack announcement. Long press uses `ACTION_LONG_CLICK`. When Android-only `relativePosition: { x, y }` is present, bypass node-level semantic activation: focus the normalized coordinate through CtrlProxy, wait outside TalkBack's double-tap window, then send the activation double-tap so distinct targets within one accessibility node remain addressable. The option is unsupported with `focus`.
 
 **swipeOn / scroll**: Three approaches in priority order:
 1. **Accessibility scroll actions** (preferred for known scrollable containers) - uses `ACTION_SCROLL_FORWARD`/`ACTION_SCROLL_BACKWARD`

--- a/docs/design-docs/mcp/a11y/talkback-voiceover.md
+++ b/docs/design-docs/mcp/a11y/talkback-voiceover.md
@@ -4,7 +4,7 @@
 
 > **Current state:** Screen-reader detection and the core tool adaptations are **implemented on both platforms**.
 >
-> - **Android (TalkBack):** detection via ADB secure settings; TalkBack-aware `tapOn` (direct `ACTION_CLICK` activation, with opt-in cursor navigation behind the `screen-reader-navigation` feature flag) and `swipeOn` (`ACTION_SCROLL_FORWARD`/`BACKWARD` with a two-finger fallback).
+> - **Android (TalkBack):** detection via ADB secure settings; TalkBack-aware `tapOn` (direct `ACTION_CLICK` activation, precise `relativePosition` coordinate gestures, and opt-in cursor navigation behind the `screen-reader-navigation` feature flag) and `swipeOn` (`ACTION_SCROLL_FORWARD`/`BACKWARD` with a two-finger fallback).
 > - **iOS (VoiceOver):** detection via CtrlProxy and VoiceOver-aware tap (label-based accessibility activation). VoiceOver scrolling is unsupported: CtrlProxy scroll endpoints synthesize XCTest swipes, which do not reach VoiceOver, and there is no functional three-finger gesture fallback. The runner reports the VoiceOver cursor when the foreground app supplies SDK-enriched hierarchy data.
 >
 > **Still open:** iOS focus *control* (set/clear focus, cursor stepping), VoiceOver Rotor, Magic Tap, and physical-device VoiceOver toggle. See [`voiceover-talkback-parity.md`](./voiceover-talkback-parity.md) — the source of truth for remaining gaps — and the [Status Glossary](../../status-glossary.md) for chip definitions.
@@ -126,7 +126,7 @@ When TalkBack is active, Android reserves certain gestures:
 
 ### Per-Tool Adaptations
 
-**tapOn**: Use `ACTION_CLICK` on the target element instead of coordinate-based tap. Optionally set accessibility focus first to mimic user behavior and trigger TalkBack announcement. Long press uses `ACTION_LONG_CLICK`.
+**tapOn**: Use `ACTION_CLICK` on the target element instead of a coordinate-based tap. Optionally set accessibility focus first to mimic user behavior and trigger TalkBack announcement. Long press uses `ACTION_LONG_CLICK`. When Android-only `relativePosition: { x, y }` is present, bypass semantic activation and dispatch the normalized coordinate through CtrlProxy so distinct targets within one accessibility node remain addressable; the option is unsupported with `focus`.
 
 **swipeOn / scroll**: Three approaches in priority order:
 1. **Accessibility scroll actions** (preferred for known scrollable containers) - uses `ACTION_SCROLL_FORWARD`/`ACTION_SCROLL_BACKWARD`

--- a/docs/design-docs/mcp/tools.md
+++ b/docs/design-docs/mcp/tools.md
@@ -8,7 +8,7 @@ Almost all other tool calls have built-in observation via the [interaction loop]
 
 #### Interactions
 
-- 👆 `tapOn` supports tap, double-tap, long press, and long-press drag actions. Selectors include `selector.text`, `selector.textAny`, and `selector.elementId`; `sibling: true` taps a clickable sibling of the selector match. When multiple elements match, `index` (0-based) taps the Nth on-screen match instead of applying `selectionStrategy`.
+- 👆 `tapOn` supports tap, double-tap, long press, and long-press drag actions. Selectors include `selector.text`, `selector.textAny`, and `selector.elementId`; `sibling: true` taps a clickable sibling of the selector match. When multiple elements match, `index` (0-based) taps the Nth on-screen match instead of applying `selectionStrategy`. On Android, `relativePosition: { x, y }` targets a normalized point from `0` to `1` within the resolved element instead of its center; successful results report the resolved `x` and `y` screen coordinates.
 - 👉 `swipeOn` handles directional swipes and scrolling within container bounds.
 - ↔️ `dragAndDrop` for element-to-element moves.
 - 🔍 `pinchOn` for zoom in/out gestures.

--- a/docs/using/talkback.md
+++ b/docs/using/talkback.md
@@ -14,7 +14,7 @@ Understanding these differences helps explain why `observe` output may look diff
 
 TalkBack takes over single-finger swipes for linear navigation through focusable elements (swipe right = next, swipe left = previous). A single tap announces an element; a double-tap activates it. Two-finger swipes scroll content. Three-finger swipes are reserved for system navigation.
 
-Because standard coordinate-based taps and single-finger swipes conflict with TalkBack gestures, AutoMobile replaces them with accessibility actions internally.
+Because standard coordinate-based taps and single-finger swipes conflict with TalkBack gestures, AutoMobile normally replaces them with accessibility actions internally. Android `tapOn` calls with `relativePosition` are the exception: they intentionally use a CtrlProxy coordinate gesture so a target such as one `ClickableSpan` inside a larger text element is not replaced by node-level activation.
 
 ### View hierarchy differences
 
@@ -49,13 +49,13 @@ AutoMobile reads the active accessibility services from ADB secure settings when
 
 | Tool | Standard behavior | TalkBack behavior |
 |------|------------------|-------------------|
-| `tapOn` | Coordinate-based tap | `ACTION_CLICK` on the target element |
+| `tapOn` | Coordinate-based tap | `ACTION_CLICK` on the target element; `relativePosition` uses the requested coordinate |
 | `swipeOn` / scroll | Single-finger swipe | `ACTION_SCROLL_FORWARD`/`BACKWARD` or two-finger swipe |
 | `inputText` / `clearText` | `ACTION_SET_TEXT` | `ACTION_SET_TEXT` (unchanged) |
 | `pressButton` | Device/navigation button | Device/navigation button (unchanged; see note below) |
 | `launchApp`, `terminateApp`, `installApp` | Standard | Unchanged |
 
-No tool parameters change. Existing automation scripts work without modification.
+Existing automation scripts work without modification. For precise Android targeting, optional `relativePosition: { x, y }` values range from `0` to `1` within the resolved element; it is unsupported on iOS and with the `focus` action.
 
 **Back button note.** When TalkBack's local context menu is open, the back button closes the menu rather than navigating back in the app. If navigation behaves unexpectedly after a back press, this is the likely cause.
 

--- a/docs/using/talkback.md
+++ b/docs/using/talkback.md
@@ -14,7 +14,7 @@ Understanding these differences helps explain why `observe` output may look diff
 
 TalkBack takes over single-finger swipes for linear navigation through focusable elements (swipe right = next, swipe left = previous). A single tap announces an element; a double-tap activates it. Two-finger swipes scroll content. Three-finger swipes are reserved for system navigation.
 
-Because standard coordinate-based taps and single-finger swipes conflict with TalkBack gestures, AutoMobile normally replaces them with accessibility actions internally. Android `tapOn` calls with `relativePosition` are the exception: they intentionally use a CtrlProxy coordinate gesture so a target such as one `ClickableSpan` inside a larger text element is not replaced by node-level activation.
+Because standard coordinate-based taps and single-finger swipes conflict with TalkBack gestures, AutoMobile normally replaces them with accessibility actions internally. Android `tapOn` calls with `relativePosition` are the exception: they use CtrlProxy to focus the requested coordinate and then send TalkBack's activation double-tap, so a target such as one `ClickableSpan` inside a larger text element is not replaced by node-level activation.
 
 ### View hierarchy differences
 
@@ -49,7 +49,7 @@ AutoMobile reads the active accessibility services from ADB secure settings when
 
 | Tool | Standard behavior | TalkBack behavior |
 |------|------------------|-------------------|
-| `tapOn` | Coordinate-based tap | `ACTION_CLICK` on the target element; `relativePosition` uses the requested coordinate |
+| `tapOn` | Coordinate-based tap | `ACTION_CLICK` on the target element; `relativePosition` focuses the requested coordinate, then activates it |
 | `swipeOn` / scroll | Single-finger swipe | `ACTION_SCROLL_FORWARD`/`BACKWARD` or two-finger swipe |
 | `inputText` / `clearText` | `ACTION_SET_TEXT` | `ACTION_SET_TEXT` (unchanged) |
 | `pressButton` | Device/navigation button | Device/navigation button (unchanged; see note below) |

--- a/schemas/tool-definitions.json
+++ b/schemas/tool-definitions.json
@@ -9264,6 +9264,29 @@
           "description": "Long press duration (ms)",
           "type": "number"
         },
+        "relativePosition": {
+          "description": "Android-only precise target within the resolved element; omit to tap its center",
+          "type": "object",
+          "properties": {
+            "x": {
+              "description": "Horizontal position within the resolved element: 0 is left, 1 is the rightmost addressable pixel",
+              "type": "number",
+              "minimum": 0,
+              "maximum": 1
+            },
+            "y": {
+              "description": "Vertical position within the resolved element: 0 is top, 1 is the bottommost addressable pixel",
+              "type": "number",
+              "minimum": 0,
+              "maximum": 1
+            }
+          },
+          "required": [
+            "x",
+            "y"
+          ],
+          "additionalProperties": false
+        },
         "searchUntil": {
           "description": "Poll for element before tapping",
           "type": "object",
@@ -9327,6 +9350,14 @@
         },
         "message": {
           "type": "string"
+        },
+        "x": {
+          "description": "Horizontal coordinate of the resolved target used for the tap",
+          "type": "number"
+        },
+        "y": {
+          "description": "Vertical coordinate of the resolved target used for the tap",
+          "type": "number"
         },
         "element": {
           "type": "object",

--- a/schemas/tool-definitions.json
+++ b/schemas/tool-definitions.json
@@ -9336,7 +9336,27 @@
         "action",
         "platform"
       ],
-      "additionalProperties": false
+      "additionalProperties": false,
+      "if": {
+        "required": [
+          "relativePosition"
+        ]
+      },
+      "then": {
+        "properties": {
+          "action": {
+            "not": {
+              "const": "focus"
+            }
+          },
+          "platform": {
+            "const": "android"
+          }
+        },
+        "required": [
+          "platform"
+        ]
+      }
     },
     "outputSchema": {
       "$schema": "https://json-schema.org/draft/2020-12/schema",

--- a/src/features/action/TapOnElement.ts
+++ b/src/features/action/TapOnElement.ts
@@ -45,8 +45,10 @@ import { hasAccessibilityAction, isTruthyFlag } from "../../utils/elementPropert
 import {
   requiresNodeSelector,
   stableNodeSelectorForElement,
+  TALKBACK_PRECISE_FOCUS_SETTLE_MS,
   TalkBackTapStrategy,
-  type ScreenReaderNavigationResult
+  type ScreenReaderNavigationResult,
+  type TalkBackTapResult
 } from "../talkback/TalkBackTapStrategy";
 import {
   DefaultTalkBackNavigationDriverFactory,
@@ -1693,6 +1695,44 @@ export class TapOnElement extends BaseVisualChange {
       || this.featureFlags.isEnabled("screen-reader-navigation");
   }
 
+  private async executeRemainingPreciseTalkBackInput(
+    action: string,
+    x: number,
+    y: number,
+    durationMs: number,
+    element: Element,
+    preciseResult: TalkBackTapResult,
+    signal?: AbortSignal
+  ): Promise<void> {
+    let remainingAction = action;
+    if (action === "tap") {
+      if (!preciseResult.focusCompleted) {
+        await this.executeAndroidTapWithCoordinates(
+          "tap",
+          x,
+          y,
+          durationMs,
+          element,
+          signal,
+          true
+        );
+        await this.timer.sleep(TALKBACK_PRECISE_FOCUS_SETTLE_MS);
+      }
+      remainingAction = preciseResult.completedTaps === 1 ? "tap" : "doubleTap";
+    } else if (action === "doubleTap" && preciseResult.completedTaps === 1) {
+      remainingAction = "tap";
+    }
+    await this.executeAndroidTapWithCoordinates(
+      remainingAction,
+      x,
+      y,
+      durationMs,
+      element,
+      signal,
+      true
+    );
+  }
+
   private async executeAndroidTapWithAccessibility(
     action: string,
     x: number,
@@ -1706,29 +1746,28 @@ export class TapOnElement extends BaseVisualChange {
     let screenReaderNavigation: ScreenReaderNavigationResult | undefined;
 
     if (options?.relativePosition) {
-      const preciseResult = await this.talkBackStrategy.executeCoordinateFallback(
-        x,
-        y,
-        action as "tap" | "doubleTap" | "longPress",
-        durationMs,
-        driver
-      );
+      const preciseResult = action === "tap"
+        ? await this.talkBackStrategy.executePreciseTap(x, y, driver)
+        : await this.talkBackStrategy.executeCoordinateFallback(
+          x,
+          y,
+          action as "doubleTap" | "longPress",
+          durationMs,
+          driver
+        );
       if (!preciseResult.success) {
-        const remainingAction = action === "doubleTap" && preciseResult.completedTaps === 1
-          ? "tap"
-          : action;
         logger.warn(
           `[TapOnElement] Precise TalkBack coordinate gesture failed (${preciseResult.error}), ` +
-          `falling back to ADB input at (${x}, ${y})`
+          `falling back to remaining input at (${x}, ${y})`
         );
-        await this.executeAndroidTapWithCoordinates(
-          remainingAction,
+        await this.executeRemainingPreciseTalkBackInput(
+          action,
           x,
           y,
           durationMs,
           element,
-          signal,
-          true
+          preciseResult,
+          signal
         );
       }
       return undefined;

--- a/src/features/action/TapOnElement.ts
+++ b/src/features/action/TapOnElement.ts
@@ -443,6 +443,23 @@ export class TapOnElement extends BaseVisualChange {
     };
   }
 
+  private updateObservationHierarchy(
+    observeResult: ObserveResult,
+    viewHierarchy: ViewHierarchyResult
+  ): void {
+    observeResult.viewHierarchy = viewHierarchy;
+    const screenSize = this.getScreenSizeFromHierarchy(viewHierarchy);
+    if (screenSize) {
+      observeResult.screenSize = screenSize;
+    }
+  }
+
+  private logClickableParentSelection(usedParent: boolean): void {
+    if (usedParent) {
+      logger.info("[TapOnElement] Using clickable parent for non-clickable element");
+    }
+  }
+
   private findElementInHierarchy(
     options: TapOnElementOptions,
     viewHierarchy: ViewHierarchyResult
@@ -1232,10 +1249,7 @@ export class TapOnElement extends BaseVisualChange {
             this.searchForElement(options, observeResult, signal)
           );
           searchUntilStats = searchOutcome.stats;
-          observeResult.viewHierarchy = searchOutcome.viewHierarchy;
-          observeResult.screenSize =
-            this.getScreenSizeFromHierarchy(searchOutcome.viewHierarchy) ??
-            observeResult.screenSize;
+          this.updateObservationHierarchy(observeResult, searchOutcome.viewHierarchy);
           viewHierarchy = searchOutcome.viewHierarchy;
           if (!searchOutcome.selection.element) {
             await this.handleElementNotFound(options, observeResult, searchOutcome.containerFound, signal);
@@ -1299,18 +1313,13 @@ export class TapOnElement extends BaseVisualChange {
               perf.end();
               return { success: false, error: stable.error };
             }
-            observeResult.viewHierarchy = stable.viewHierarchy;
-            observeResult.screenSize =
-              this.getScreenSizeFromHierarchy(stable.viewHierarchy) ??
-              observeResult.screenSize;
+            this.updateObservationHierarchy(observeResult, stable.viewHierarchy);
             viewHierarchy = stable.viewHierarchy;
             tapElement = stable.tapElement;
             usedParent = stable.usedParent;
           }
 
-          if (usedParent) {
-            logger.info("[TapOnElement] Using clickable parent for non-clickable element");
-          }
+          this.logClickableParentSelection(usedParent);
           const tapPoint = this.resolveTapPoint(
             tapElement,
             observeResult.screenSize,
@@ -1489,20 +1498,21 @@ export class TapOnElement extends BaseVisualChange {
       ? isTalkBackEnabled
       : (await this.accessibilityDetector.detectMethod(this.device.deviceId, this.adb)) === "talkback";
 
-    if (talkBackEnabled && !options?.relativePosition) {
-      // TalkBack mode: Use accessibility actions with coordinate fallback
+    if (talkBackEnabled) {
+      // TalkBack mode: Use accessibility actions or precise coordinate
+      // gestures through its CtrlProxy driver, with ADB as the last fallback.
       return this.executeAndroidTapWithAccessibility(action, x, y, element, durationMs, options, signal);
-    } else {
-      // Standard mode and precise targets use coordinates. A relative target
-      // must not be replaced by node-level ACTION_CLICK under TalkBack because
-      // that cannot distinguish ClickableSpans within one TextView.
-      if (options?.relativePosition) {
-        await this.executeAndroidTapWithCoordinates(action, x, y, durationMs, element, signal, true);
-      } else {
-        await this.executeAndroidTapWithCoordinates(action, x, y, durationMs, element, signal);
-      }
-      return undefined;
     }
+
+    // Standard mode and precise targets use coordinates. Precise long presses
+    // must not be replaced by node-level ACTION_LONG_CLICK because that cannot
+    // distinguish targets within one element.
+    if (options?.relativePosition) {
+      await this.executeAndroidTapWithCoordinates(action, x, y, durationMs, element, signal, true);
+    } else {
+      await this.executeAndroidTapWithCoordinates(action, x, y, durationMs, element, signal);
+    }
+    return undefined;
   }
 
   /**
@@ -1637,6 +1647,32 @@ export class TapOnElement extends BaseVisualChange {
   ): Promise<ScreenReaderNavigationResult | undefined> {
     const driver = this.talkBackDriverFactory.createDriver(this.device);
     let screenReaderNavigation: ScreenReaderNavigationResult | undefined;
+
+    if (options?.relativePosition) {
+      const preciseResult = await this.talkBackStrategy.executeCoordinateFallback(
+        x,
+        y,
+        action as "tap" | "doubleTap" | "longPress",
+        durationMs,
+        driver
+      );
+      if (!preciseResult.success) {
+        logger.warn(
+          `[TapOnElement] Precise TalkBack coordinate gesture failed (${preciseResult.error}), ` +
+          `falling back to ADB input at (${x}, ${y})`
+        );
+        await this.executeAndroidTapWithCoordinates(
+          action,
+          x,
+          y,
+          durationMs,
+          element,
+          signal,
+          true
+        );
+      }
+      return undefined;
+    }
 
     if (action === "longPress") {
       // Long press: try ACTION_LONG_CLICK first, then coordinate gesture fallback

--- a/src/features/action/TapOnElement.ts
+++ b/src/features/action/TapOnElement.ts
@@ -8,13 +8,10 @@ import {
   ObserveResult,
   TapOnElementResult,
   TapOnSelectedElement,
-  ViewHierarchyResult
+  ViewHierarchyResult,
 } from "../../models";
 import { AdbClient } from "../../utils/android-cmdline-tools/AdbClient";
-import type {
-  RelativeTapPosition,
-  TapOnElementOptions
-} from "../../models/TapOnElementOptions";
+import type { RelativeTapPosition, TapOnElementOptions } from "../../models/TapOnElementOptions";
 import type { ElementParser } from "../../utils/interfaces/ElementParser";
 import type { ElementFinder } from "../../utils/interfaces/ElementFinder";
 import type { ElementGeometry } from "../../utils/interfaces/ElementGeometry";
@@ -26,10 +23,20 @@ import { logger } from "../../utils/logger";
 import { AndroidCtrlProxyClient } from "../observe/android";
 import { IOSCtrlProxyClient } from "../observe/ios";
 import { createGlobalPerformanceTracker } from "../../utils/PerformanceTracker";
-import { DEFAULT_VISION_CONFIG, getVisionEnrichedError, type VisionFallbackConfig, type VisionAnalyzer } from "../../vision/index";
+import {
+  DEFAULT_VISION_CONFIG,
+  getVisionEnrichedError,
+  type VisionFallbackConfig,
+  type VisionAnalyzer,
+} from "../../vision/index";
 import { buildElementSearchDebugContext } from "../../utils/DebugContextBuilder";
 import { throwIfAborted } from "../../utils/toolUtils";
-import { SelectionStateTracker, SelectionCaptureState, TakeScreenshotCapturer, type ScreenshotCapturer } from "../navigation/SelectionStateTracker";
+import {
+  SelectionStateTracker,
+  SelectionCaptureState,
+  TakeScreenshotCapturer,
+  type ScreenshotCapturer,
+} from "../navigation/SelectionStateTracker";
 import { AccessibilityDetector } from "../../utils/interfaces/AccessibilityDetector";
 import { accessibilityDetector as defaultAccessibilityDetector } from "../../utils/AccessibilityDetector";
 import type { ElementSelector } from "../../utils/interfaces/ElementSelector";
@@ -48,11 +55,11 @@ import {
   TALKBACK_PRECISE_FOCUS_SETTLE_MS,
   TalkBackTapStrategy,
   type ScreenReaderNavigationResult,
-  type TalkBackTapResult
+  type TalkBackTapResult,
 } from "../talkback/TalkBackTapStrategy";
 import {
   DefaultTalkBackNavigationDriverFactory,
-  type TalkBackNavigationDriverFactory
+  type TalkBackNavigationDriverFactory,
 } from "../talkback/TalkBackNavigationDriver";
 import type { IosVoiceOverDetector } from "../../utils/interfaces/IosVoiceOverDetector";
 import { iosVoiceOverDetector as defaultIosVoiceOverDetector } from "../../utils/IosVoiceOverDetector";
@@ -191,7 +198,7 @@ export class TapOnElement extends BaseVisualChange {
   constructor(
     device: BootedDevice,
     adb: AdbClient | null = null,
-    options: TapOnElementDependencies = {}
+    options: TapOnElementDependencies = {},
   ) {
     super(device, adb, options.timer);
     this.finder = new DefaultElementFinder();
@@ -199,28 +206,36 @@ export class TapOnElement extends BaseVisualChange {
     this.elementParser = new DefaultElementParser();
     this.accessibilityService = AndroidCtrlProxyClient.getInstance(device, this.adbFactory);
     this.visionConfig = options.visionConfig || DEFAULT_VISION_CONFIG;
-    this.screenshotCapturer = options.screenshotCapturer ?? new TakeScreenshotCapturer(device, this.adbFactory);
+    this.screenshotCapturer =
+      options.screenshotCapturer ?? new TakeScreenshotCapturer(device, this.adbFactory);
     this.visionAnalyzer = options.visionAnalyzer;
     this.viewHierarchy = new ViewHierarchy(device, this.adbFactory);
-    this.selectionStateTracker = options.selectionStateTracker ?? new SelectionStateTracker({
-      screenshotCapturer: this.screenshotCapturer
-    });
+    this.selectionStateTracker =
+      options.selectionStateTracker ??
+      new SelectionStateTracker({
+        screenshotCapturer: this.screenshotCapturer,
+      });
     this.accessibilityDetector = options.accessibilityDetector || defaultAccessibilityDetector;
     this.elementSelector = options.elementSelector ?? new DefaultElementSelector();
-    this.talkBackDriverFactory = options.talkBackDriverFactory ?? new DefaultTalkBackNavigationDriverFactory(this.adbFactory);
-    this.talkBackStrategy = options.talkBackStrategy ?? new TalkBackTapStrategy({
-      timer: this.timer,
-      driverFactory: this.talkBackDriverFactory,
-    });
+    this.talkBackDriverFactory =
+      options.talkBackDriverFactory ?? new DefaultTalkBackNavigationDriverFactory(this.adbFactory);
+    this.talkBackStrategy =
+      options.talkBackStrategy ??
+      new TalkBackTapStrategy({
+        timer: this.timer,
+        driverFactory: this.talkBackDriverFactory,
+      });
     this.iosVoiceOverDetector = options.iosVoiceOverDetector ?? defaultIosVoiceOverDetector;
     this.featureFlags = options.featureFlags ?? FeatureFlagService.getInstance();
-    this.strategy = options.tapStrategy ?? createTapStrategy(
-      device,
-      this.adb,
-      this.accessibilityDetector,
-      this.iosVoiceOverDetector,
-      this.featureFlags
-    );
+    this.strategy =
+      options.tapStrategy ??
+      createTapStrategy(
+        device,
+        this.adb,
+        this.accessibilityDetector,
+        this.iosVoiceOverDetector,
+        this.featureFlags,
+      );
     this.longPressMetadataDetector = new LongPressMetadataDetector(this.elementParser);
   }
 
@@ -236,13 +251,18 @@ export class TapOnElement extends BaseVisualChange {
       action: action,
       error,
       element: {
-        bounds: { left: 0, top: 0, right: 0, bottom: 0 }
-      } as Element
+        bounds: { left: 0, top: 0, right: 0, bottom: 0 },
+      } as Element,
     };
   }
 
   private validateOptions(options: TapOnElementOptions): string | null {
-    const selectorCount = [options.text, options.elementId, options.testTag, options.textAny].filter(Boolean).length;
+    const selectorCount = [
+      options.text,
+      options.elementId,
+      options.testTag,
+      options.textAny,
+    ].filter(Boolean).length;
     if (selectorCount !== 1) {
       return "tapOn requires exactly one of text, textAny, elementId, or testTag";
     }
@@ -252,7 +272,9 @@ export class TapOnElement extends BaseVisualChange {
     }
 
     if (options.container) {
-      const containerSelectorCount = [options.container.elementId, options.container.text].filter(Boolean).length;
+      const containerSelectorCount = [options.container.elementId, options.container.text].filter(
+        Boolean,
+      ).length;
       if (containerSelectorCount !== 1) {
         return "tapOn container must specify exactly one of elementId or text";
       }
@@ -285,9 +307,11 @@ export class TapOnElement extends BaseVisualChange {
 
   private hasAddressablePixels(bounds: Element["bounds"]): boolean {
     const coordinates = [bounds.left, bounds.top, bounds.right, bounds.bottom];
-    return coordinates.every(Number.isFinite)
-      && bounds.right - bounds.left >= 1
-      && bounds.bottom - bounds.top >= 1;
+    return (
+      coordinates.every(Number.isFinite) &&
+      bounds.right - bounds.left >= 1 &&
+      bounds.bottom - bounds.top >= 1
+    );
   }
 
   private hasValidScreenDimensions(screenSize: ObserveResult["screenSize"]): boolean {
@@ -295,36 +319,38 @@ export class TapOnElement extends BaseVisualChange {
       return false;
     }
     return [screenSize.width, screenSize.height].every(
-      dimension => Number.isFinite(dimension) && dimension >= 1
+      (dimension) => Number.isFinite(dimension) && dimension >= 1,
     );
   }
 
   private isPointInHalfOpenBounds(
     point: { x: number; y: number },
-    bounds: Element["bounds"]
+    bounds: Element["bounds"],
   ): boolean {
-    return point.x >= bounds.left
-      && point.x < bounds.right
-      && point.y >= bounds.top
-      && point.y < bounds.bottom;
+    return (
+      point.x >= bounds.left &&
+      point.x < bounds.right &&
+      point.y >= bounds.top &&
+      point.y < bounds.bottom
+    );
   }
 
   private relativeTapPoint(
     bounds: Element["bounds"],
-    relativePosition: RelativeTapPosition
+    relativePosition: RelativeTapPosition,
   ): { x: number; y: number } {
     const width = bounds.right - bounds.left;
     const height = bounds.bottom - bounds.top;
     return {
       x: Math.round(bounds.left + relativePosition.x * (width - 1)),
-      y: Math.round(bounds.top + relativePosition.y * (height - 1))
+      y: Math.round(bounds.top + relativePosition.y * (height - 1)),
     };
   }
 
   private resolveTapPoint(
     element: Element,
     screenSize: ObserveResult["screenSize"],
-    relativePosition?: RelativeTapPosition
+    relativePosition?: RelativeTapPosition,
   ): { x: number; y: number } {
     if (!relativePosition) {
       return this.geometry.getElementCenter(element);
@@ -333,14 +359,12 @@ export class TapOnElement extends BaseVisualChange {
     const bounds = element.bounds;
     if (!this.hasAddressablePixels(bounds)) {
       throw new ActionableError(
-        `tapOn relativePosition requires valid element bounds, received ${JSON.stringify(bounds)}`
+        `tapOn relativePosition requires valid element bounds, received ${JSON.stringify(bounds)}`,
       );
     }
 
     if (!this.hasValidScreenDimensions(screenSize)) {
-      throw new ActionableError(
-        "tapOn relativePosition requires valid Android screen dimensions"
-      );
+      throw new ActionableError("tapOn relativePosition requires valid Android screen dimensions");
     }
 
     // Android bounds are half-open. Scale across addressable pixels so 0 and 1
@@ -350,8 +374,8 @@ export class TapOnElement extends BaseVisualChange {
     const { x, y } = point;
     if (!this.isPointInHalfOpenBounds(point, bounds)) {
       throw new ActionableError(
-        `tapOn relativePosition resolved to (${x}, ${y}) outside element bounds `
-        + `${JSON.stringify(bounds)}`
+        `tapOn relativePosition resolved to (${x}, ${y}) outside element bounds ` +
+          `${JSON.stringify(bounds)}`,
       );
     }
 
@@ -359,12 +383,12 @@ export class TapOnElement extends BaseVisualChange {
       left: 0,
       top: 0,
       right: screenSize.width,
-      bottom: screenSize.height
+      bottom: screenSize.height,
     };
     if (!this.isPointInHalfOpenBounds(point, screenBounds)) {
       throw new ActionableError(
-        `tapOn relativePosition resolved to (${x}, ${y}) outside screen bounds `
-        + `[0, ${screenSize.width}) x [0, ${screenSize.height})`
+        `tapOn relativePosition resolved to (${x}, ${y}) outside screen bounds ` +
+          `[0, ${screenSize.width}) x [0, ${screenSize.height})`,
       );
     }
 
@@ -380,13 +404,13 @@ export class TapOnElement extends BaseVisualChange {
 
     if (duration < TapOnElement.SEARCH_UNTIL_MIN_MS) {
       throw new ActionableError(
-        `searchUntil.duration must be at least ${TapOnElement.SEARCH_UNTIL_MIN_MS}ms`
+        `searchUntil.duration must be at least ${TapOnElement.SEARCH_UNTIL_MIN_MS}ms`,
       );
     }
 
     if (duration > TapOnElement.SEARCH_UNTIL_MAX_MS) {
       throw new ActionableError(
-        `searchUntil.duration must be at most ${TapOnElement.SEARCH_UNTIL_MAX_MS}ms`
+        `searchUntil.duration must be at most ${TapOnElement.SEARCH_UNTIL_MAX_MS}ms`,
       );
     }
 
@@ -408,7 +432,7 @@ export class TapOnElement extends BaseVisualChange {
   private isElementTapTargetOffScreen(
     element: Element,
     screenSize?: ObserveResult["screenSize"],
-    relativePosition?: RelativeTapPosition
+    relativePosition?: RelativeTapPosition,
   ): boolean {
     if (!screenSize?.width || !screenSize?.height || !element.bounds) {
       return false;
@@ -425,20 +449,19 @@ export class TapOnElement extends BaseVisualChange {
         left: 0,
         top: 0,
         right: screenSize.width,
-        bottom: screenSize.height
+        bottom: screenSize.height,
       });
     }
     const centerX = (element.bounds.left + element.bounds.right) / 2;
     const centerY = (element.bounds.top + element.bounds.bottom) / 2;
-    return centerX < 0 || centerX > screenSize.width ||
-           centerY < 0 || centerY > screenSize.height;
+    return centerX < 0 || centerX > screenSize.width || centerY < 0 || centerY > screenSize.height;
   }
 
   private isSelectionTapTargetOffScreen(
     element: Element,
     viewHierarchy: ViewHierarchyResult,
     screenSize: ObserveResult["screenSize"] | undefined,
-    options: TapOnElementOptions
+    options: TapOnElementOptions,
   ): boolean {
     const target = options.relativePosition
       ? this.resolveTapTargetElement(element, viewHierarchy, options.action, false).element
@@ -446,20 +469,22 @@ export class TapOnElement extends BaseVisualChange {
     return this.isElementTapTargetOffScreen(target, screenSize, options.relativePosition);
   }
 
-  private getScreenSizeFromHierarchy(viewHierarchy: ViewHierarchyResult): ObserveResult["screenSize"] | undefined {
+  private getScreenSizeFromHierarchy(
+    viewHierarchy: ViewHierarchyResult,
+  ): ObserveResult["screenSize"] | undefined {
     if (!viewHierarchy.screenWidth || !viewHierarchy.screenHeight) {
       return undefined;
     }
 
     return {
       width: viewHierarchy.screenWidth,
-      height: viewHierarchy.screenHeight
+      height: viewHierarchy.screenHeight,
     };
   }
 
   private updateObservationHierarchy(
     observeResult: ObserveResult,
-    viewHierarchy: ViewHierarchyResult
+    viewHierarchy: ViewHierarchyResult,
   ): void {
     observeResult.viewHierarchy = viewHierarchy;
     const screenSize = this.getScreenSizeFromHierarchy(viewHierarchy);
@@ -476,7 +501,7 @@ export class TapOnElement extends BaseVisualChange {
 
   private requiresResourceIdForTapTarget(
     isAccessibilityServiceEnabled: boolean,
-    options: TapOnElementOptions
+    options: TapOnElementOptions,
   ): boolean {
     return isAccessibilityServiceEnabled && !options.relativePosition;
   }
@@ -486,7 +511,7 @@ export class TapOnElement extends BaseVisualChange {
     action: string,
     observation: ObserveResult,
     element: Element,
-    signal?: AbortSignal
+    signal?: AbortSignal,
   ): Promise<SelectionCaptureState | null> {
     if (options.relativePosition) {
       // Visual selection enrichment is best-effort; its screenshot await can
@@ -497,27 +522,31 @@ export class TapOnElement extends BaseVisualChange {
       action,
       observation,
       element,
-      signal
+      signal,
     });
   }
 
   private findElementInHierarchy(
     options: TapOnElementOptions,
-    viewHierarchy: ViewHierarchyResult
+    viewHierarchy: ViewHierarchyResult,
   ): { selection: ElementSelectionResult; containerFound: boolean } {
     const containerFound = this.isContainerAvailable(viewHierarchy, options.container);
 
     if (options.text) {
       if (options.sibling) {
         return {
-          selection: this.elementSelector.selectClickableSiblingOfText(viewHierarchy, options.text, {
-            container: options.container,
-            fuzzyMatch: true,
-            caseSensitive: false,
-            strategy: options.selectionStrategy,
-            index: options.index
-          }),
-          containerFound
+          selection: this.elementSelector.selectClickableSiblingOfText(
+            viewHierarchy,
+            options.text,
+            {
+              container: options.container,
+              fuzzyMatch: true,
+              caseSensitive: false,
+              strategy: options.selectionStrategy,
+              index: options.index,
+            },
+          ),
+          containerFound,
         };
       }
 
@@ -527,9 +556,9 @@ export class TapOnElement extends BaseVisualChange {
           partialMatch: true,
           caseSensitive: false,
           strategy: options.selectionStrategy,
-          index: options.index
+          index: options.index,
         }),
-        containerFound
+        containerFound,
       };
     }
 
@@ -540,27 +569,29 @@ export class TapOnElement extends BaseVisualChange {
       for (const text of options.textAny) {
         const selection = options.sibling
           ? this.elementSelector.selectClickableSiblingOfText(viewHierarchy, text, {
-            container: options.container,
-            fuzzyMatch: true,
-            caseSensitive: false,
-            strategy: options.selectionStrategy,
-            index: options.index
-          })
+              container: options.container,
+              fuzzyMatch: true,
+              caseSensitive: false,
+              strategy: options.selectionStrategy,
+              index: options.index,
+            })
           : this.elementSelector.selectByText(viewHierarchy, text, {
-            container: options.container,
-            partialMatch: true,
-            caseSensitive: false,
-            strategy: options.selectionStrategy,
-            index: options.index
-          });
+              container: options.container,
+              partialMatch: true,
+              caseSensitive: false,
+              strategy: options.selectionStrategy,
+              index: options.index,
+            });
         lastSelection = selection;
         if (selection.element) {
-          if (this.isSelectionTapTargetOffScreen(
-            selection.element,
-            viewHierarchy,
-            screenSize,
-            options
-          )) {
+          if (
+            this.isSelectionTapTargetOffScreen(
+              selection.element,
+              viewHierarchy,
+              screenSize,
+              options,
+            )
+          ) {
             offScreenSelection = selection;
             continue;
           }
@@ -571,7 +602,7 @@ export class TapOnElement extends BaseVisualChange {
       if (offScreenSelection) {
         return {
           selection: { ...offScreenSelection, element: null },
-          containerFound
+          containerFound,
         };
       }
 
@@ -583,13 +614,17 @@ export class TapOnElement extends BaseVisualChange {
     if (options.elementId) {
       if (options.sibling) {
         return {
-          selection: this.elementSelector.selectClickableSiblingOfResourceId(viewHierarchy, options.elementId, {
-            container: options.container,
-            partialMatch: false,
-            strategy: options.selectionStrategy,
-            index: options.index
-          }),
-          containerFound
+          selection: this.elementSelector.selectClickableSiblingOfResourceId(
+            viewHierarchy,
+            options.elementId,
+            {
+              container: options.container,
+              partialMatch: false,
+              strategy: options.selectionStrategy,
+              index: options.index,
+            },
+          ),
+          containerFound,
         };
       }
 
@@ -598,9 +633,9 @@ export class TapOnElement extends BaseVisualChange {
           container: options.container,
           partialMatch: false,
           strategy: options.selectionStrategy,
-          index: options.index
+          index: options.index,
         }),
-        containerFound
+        containerFound,
       };
     }
 
@@ -608,22 +643,24 @@ export class TapOnElement extends BaseVisualChange {
       selection: this.elementSelector.selectByTestTag(viewHierarchy, this.requireTestTag(options), {
         container: options.container,
         strategy: options.selectionStrategy,
-        index: options.index
+        index: options.index,
       }),
-      containerFound
+      containerFound,
     };
   }
 
   private requireTestTag(options: TapOnElementOptions): string {
     if (!options.testTag) {
-      throw new ActionableError("tapOn requires non-blank text, textAny, elementId, or testTag to interact with");
+      throw new ActionableError(
+        "tapOn requires non-blank text, textAny, elementId, or testTag to interact with",
+      );
     }
     return options.testTag;
   }
 
   private prepareViewHierarchyForResponse(
     rawHierarchy: ViewHierarchyResult,
-    screenSize?: ObserveResult["screenSize"]
+    screenSize?: ObserveResult["screenSize"],
   ): ViewHierarchyResult {
     if (!serverConfig.isRawElementSearchEnabled()) {
       return rawHierarchy;
@@ -641,7 +678,7 @@ export class TapOnElement extends BaseVisualChange {
     const filtered = this.strategy.prepareViewHierarchyForResponse(
       rawHierarchy,
       this.viewHierarchy,
-      screenSize
+      screenSize,
     );
     return filtered ?? rawHierarchy;
   }
@@ -649,7 +686,7 @@ export class TapOnElement extends BaseVisualChange {
   private async refreshViewHierarchy(
     timeoutMs: number,
     screenSize?: ObserveResult["screenSize"],
-    signal?: AbortSignal
+    signal?: AbortSignal,
   ): Promise<ViewHierarchyResult | null> {
     const effectiveTimeoutMs = Math.max(0, timeoutMs);
     switch (this.device.platform) {
@@ -658,20 +695,15 @@ export class TapOnElement extends BaseVisualChange {
           this.accessibilityService,
           this.viewHierarchy,
           effectiveTimeoutMs,
-          signal
+          signal,
         );
 
-        return rawHierarchy
-          ? this.prepareViewHierarchyForResponse(rawHierarchy, screenSize)
-          : null;
+        return rawHierarchy ? this.prepareViewHierarchyForResponse(rawHierarchy, screenSize) : null;
       }
-      case "ios":
-      {
+      case "ios": {
         const xcTestClient = IOSCtrlProxyClient.getInstance(this.device);
         const rawHierarchy = await xcTestClient.getAccessibilityHierarchy();
-        return rawHierarchy
-          ? this.prepareViewHierarchyForResponse(rawHierarchy, screenSize)
-          : null;
+        return rawHierarchy ? this.prepareViewHierarchyForResponse(rawHierarchy, screenSize) : null;
       }
       default:
         throw new ActionableError(`Unsupported platform: ${this.device.platform}`);
@@ -689,7 +721,7 @@ export class TapOnElement extends BaseVisualChange {
     observeResult: ObserveResult,
     action: TapOnElementOptions["action"],
     requireResourceId: boolean,
-    signal?: AbortSignal
+    signal?: AbortSignal,
   ): Promise<
     | { ok: true; viewHierarchy: ViewHierarchyResult; tapElement: Element; usedParent: boolean }
     | { ok: false; error: string }
@@ -760,7 +792,7 @@ export class TapOnElement extends BaseVisualChange {
       const freshHierarchy = await this.refreshViewHierarchy(
         TapOnElement.ANDROID_PRE_TAP_REFRESH_TIMEOUT_MS,
         observeResult.screenSize,
-        signal
+        signal,
       );
       if (!freshHierarchy) {
         // The failed refresh itself burned wall-clock (up to the timeout); exclude
@@ -770,15 +802,15 @@ export class TapOnElement extends BaseVisualChange {
         consecutiveNoHierarchy++;
         logger.warn(
           `[TapOnElement] Android pre-tap refresh returned no hierarchy ` +
-          `(consecutive: ${consecutiveNoHierarchy}/${TapOnElement.ANDROID_PRE_TAP_NO_HIERARCHY_MAX_CONSECUTIVE}, ` +
-          `refind attempt: ${refindAttempt})`
+            `(consecutive: ${consecutiveNoHierarchy}/${TapOnElement.ANDROID_PRE_TAP_NO_HIERARCHY_MAX_CONSECUTIVE}, ` +
+            `refind attempt: ${refindAttempt})`,
         );
         if (consecutiveNoHierarchy >= TapOnElement.ANDROID_PRE_TAP_NO_HIERARCHY_MAX_CONSECUTIVE) {
           return {
             ok: false,
             error:
               `Android tap aborted: accessibility service was unreachable for ${consecutiveNoHierarchy} consecutive attempts ` +
-              `(ctrl-proxy WebSocket unresponsive). The device may be under heavy load or the accessibility service may need reconnection.`
+              `(ctrl-proxy WebSocket unresponsive). The device may be under heavy load or the accessibility service may need reconnection.`,
           };
         }
         consecutiveStable = 0;
@@ -797,14 +829,14 @@ export class TapOnElement extends BaseVisualChange {
         minProductivePolls = TapOnElement.ANDROID_PRE_TAP_REFIND_MIN_POLLS_WHEN_LOADING;
         logger.info(
           `[TapOnElement] Android pre-tap: loading/progress indicators present; ` +
-          `extending refind budget to ${budgetMs}ms / ${minProductivePolls} polls`
+            `extending refind budget to ${budgetMs}ms / ${minProductivePolls} polls`,
         );
       }
 
       const refind = this.findElementInHierarchy(options, freshHierarchy);
       if (!refind.selection.element) {
         logger.warn(
-          `[TapOnElement] Android pre-tap refresh attempt ${refindAttempt} did not re-find tap target`
+          `[TapOnElement] Android pre-tap refresh attempt ${refindAttempt} did not re-find tap target`,
         );
         consecutiveStable = 0;
         prevBounds = null;
@@ -815,7 +847,7 @@ export class TapOnElement extends BaseVisualChange {
         refind.selection.element as Element,
         freshHierarchy,
         action,
-        requireResourceId
+        requireResourceId,
       );
       const b = refreshed.element.bounds;
       if (b === undefined || b === null) {
@@ -836,12 +868,12 @@ export class TapOnElement extends BaseVisualChange {
       best = {
         viewHierarchy: freshHierarchy,
         tapElement: refreshed.element,
-        usedParent: refreshed.usedParent
+        usedParent: refreshed.usedParent,
       };
 
       if (consecutiveStable >= stableMatchesRequired) {
         logger.info(
-          `[TapOnElement] Android tap target stable after ${refindAttempt} refresh(es) (bounds matched on last ${stableMatchesRequired} consecutive re-find(s), ε=${TapOnElement.ANDROID_PRE_TAP_BOUNDS_EPSILON_PX}px)`
+          `[TapOnElement] Android tap target stable after ${refindAttempt} refresh(es) (bounds matched on last ${stableMatchesRequired} consecutive re-find(s), ε=${TapOnElement.ANDROID_PRE_TAP_BOUNDS_EPSILON_PX}px)`,
         );
         return { ok: true, ...best };
       }
@@ -850,14 +882,14 @@ export class TapOnElement extends BaseVisualChange {
     return {
       ok: false,
       error:
-        "Android tap aborted: could not re-find the target in the accessibility hierarchy with stable bounds after repeated refreshes (refusing tap using pre-observe coordinates). The UI may still be updating (list, keyboard, loading overlay, or animation)."
+        "Android tap aborted: could not re-find the target in the accessibility hierarchy with stable bounds after repeated refreshes (refusing tap using pre-observe coordinates). The UI may still be updating (list, keyboard, loading overlay, or animation).",
     };
   }
 
   private async searchForElement(
     options: TapOnElementOptions,
     observeResult: ObserveResult,
-    signal?: AbortSignal
+    signal?: AbortSignal,
   ): Promise<{
     selection: ElementSelectionResult;
     viewHierarchy: ViewHierarchyResult;
@@ -886,18 +918,13 @@ export class TapOnElement extends BaseVisualChange {
 
     if (
       !element ||
-      this.isSelectionTapTargetOffScreen(
-        element,
-        latestViewHierarchy,
-        latestScreenSize,
-        options
-      )
+      this.isSelectionTapTargetOffScreen(element, latestViewHierarchy, latestScreenSize, options)
     ) {
       if (element) {
         logger.warn(
           `[TapOnElement] Element found but tap target is off-screen, will retry. ` +
-          `bounds=${JSON.stringify(element.bounds)}, ` +
-          `screen=${latestScreenSize?.width}x${latestScreenSize?.height}`
+            `bounds=${JSON.stringify(element.bounds)}, ` +
+            `screen=${latestScreenSize?.width}x${latestScreenSize?.height}`,
         );
         selection = { ...selection, element: null };
         element = null;
@@ -910,7 +937,7 @@ export class TapOnElement extends BaseVisualChange {
         const refreshedHierarchy = await this.refreshViewHierarchy(
           remainingTimeMs,
           latestScreenSize,
-          signal
+          signal,
         );
         requestCount += 1;
 
@@ -919,8 +946,7 @@ export class TapOnElement extends BaseVisualChange {
         }
 
         latestViewHierarchy = refreshedHierarchy;
-        latestScreenSize =
-          this.getScreenSizeFromHierarchy(refreshedHierarchy) ?? latestScreenSize;
+        latestScreenSize = this.getScreenSizeFromHierarchy(refreshedHierarchy) ?? latestScreenSize;
         const hash = this.hashViewHierarchy(refreshedHierarchy);
         if (hash && hash !== lastHash) {
           changeCount += 1;
@@ -936,16 +962,11 @@ export class TapOnElement extends BaseVisualChange {
         containerFoundEver = containerFoundEver || searchResult.containerFound;
         if (
           element &&
-          this.isSelectionTapTargetOffScreen(
-            element,
-            refreshedHierarchy,
-            latestScreenSize,
-            options
-          )
+          this.isSelectionTapTargetOffScreen(element, refreshedHierarchy, latestScreenSize, options)
         ) {
           logger.warn(
             `[TapOnElement] Element found but tap target is off-screen, retrying. ` +
-            `bounds=${JSON.stringify(element.bounds)}`
+              `bounds=${JSON.stringify(element.bounds)}`,
           );
           selection = { ...selection, element: null };
           element = null;
@@ -961,41 +982,43 @@ export class TapOnElement extends BaseVisualChange {
     if (offScreenRejections > 0 && !element) {
       logger.error(
         `[TapOnElement] Element was found ${offScreenRejections} time(s) but always with off-screen bounds. ` +
-        `The accessibility framework is reporting incorrect bounds for this element.`
+          `The accessibility framework is reporting incorrect bounds for this element.`,
       );
     }
 
     const stats: SearchUntilStats = {
       durationMs: Math.max(0, Math.round(this.timer.now() - startTime)),
       requestCount,
-      changeCount
+      changeCount,
     };
 
     return {
       selection,
       viewHierarchy: latestViewHierarchy,
       containerFound: containerFoundEver,
-      stats
+      stats,
     };
   }
 
-  private buildSelectedElementMetadata(selection: ElementSelectionResult): TapOnSelectedElement | undefined {
+  private buildSelectedElementMetadata(
+    selection: ElementSelectionResult,
+  ): TapOnSelectedElement | undefined {
     if (!selection.element) {
       return undefined;
     }
 
     const bounds = selection.element.bounds;
     const center = this.geometry.getElementCenter(selection.element);
-    const text = typeof selection.element.text === "string" && selection.element.text.length > 0
-      ? selection.element.text
-      : (typeof selection.element["content-desc"] === "string"
-        ? selection.element["content-desc"]
-        : (typeof selection.element["ios-accessibility-label"] === "string"
-          ? selection.element["ios-accessibility-label"]
-          : ""));
-    const resourceId = typeof selection.element["resource-id"] === "string"
-      ? selection.element["resource-id"]
-      : "";
+    const text =
+      typeof selection.element.text === "string" && selection.element.text.length > 0
+        ? selection.element.text
+        : typeof selection.element["content-desc"] === "string"
+          ? selection.element["content-desc"]
+          : typeof selection.element["ios-accessibility-label"] === "string"
+            ? selection.element["ios-accessibility-label"]
+            : "";
+    const resourceId =
+      typeof selection.element["resource-id"] === "string" ? selection.element["resource-id"] : "";
 
     return {
       text,
@@ -1006,11 +1029,11 @@ export class TapOnElement extends BaseVisualChange {
         right: bounds.right,
         bottom: bounds.bottom,
         centerX: center.x,
-        centerY: center.y
+        centerY: center.y,
       },
       indexInMatches: selection.indexInMatches,
       totalMatches: selection.totalMatches,
-      selectionStrategy: selection.strategy
+      selectionStrategy: selection.strategy,
     };
   }
 
@@ -1018,15 +1041,13 @@ export class TapOnElement extends BaseVisualChange {
     options: TapOnElementOptions,
     observeResult?: ObserveResult,
     containerFound: boolean = true,
-    signal?: AbortSignal
+    signal?: AbortSignal,
   ): Promise<never> {
     if (options.container && !containerFound) {
       const containerLabel = options.container.elementId
         ? `elementId '${options.container.elementId}'`
         : `text '${options.container.text}'`;
-      throw new ActionableError(
-        `Container element not found with provided ${containerLabel}`
-      );
+      throw new ActionableError(`Container element not found with provided ${containerLabel}`);
     }
 
     const containerHint = options.container
@@ -1059,7 +1080,7 @@ export class TapOnElement extends BaseVisualChange {
         this.visionConfig,
         baseError,
         signal,
-        this.visionAnalyzer
+        this.visionAnalyzer,
       );
       throw new ActionableError(enrichedMsg);
     }
@@ -1069,7 +1090,7 @@ export class TapOnElement extends BaseVisualChange {
 
   private isContainerAvailable(
     viewHierarchy: ViewHierarchyResult,
-    container?: { elementId?: string; text?: string }
+    container?: { elementId?: string; text?: string },
   ): boolean {
     if (!container) {
       return true;
@@ -1083,9 +1104,11 @@ export class TapOnElement extends BaseVisualChange {
   }
 
   private isLongClickableElement(element: Element): boolean {
-    return isTruthyFlag(element["long-clickable"]) ||
+    return (
+      isTruthyFlag(element["long-clickable"]) ||
       isTruthyFlag(element.longClickable) ||
-      hasAccessibilityAction(element.actions, "long_click");
+      hasAccessibilityAction(element.actions, "long_click")
+    );
   }
 
   private isClickableProps(props: Record<string, unknown>): boolean {
@@ -1093,15 +1116,17 @@ export class TapOnElement extends BaseVisualChange {
   }
 
   private isLongClickableProps(props: Record<string, unknown>): boolean {
-    return isTruthyFlag(props["long-clickable"]) ||
+    return (
+      isTruthyFlag(props["long-clickable"]) ||
       isTruthyFlag(props.longClickable) ||
-      hasAccessibilityAction(props.actions, "long_click");
+      hasAccessibilityAction(props.actions, "long_click")
+    );
   }
 
   private nodeMatchesElement(
     target: Element,
     props: Record<string, unknown>,
-    parsed: Element
+    parsed: Element,
   ): boolean {
     if (!boundsEqual(parsed.bounds, target.bounds)) {
       return false;
@@ -1133,7 +1158,7 @@ export class TapOnElement extends BaseVisualChange {
   private findAncestorChain(viewHierarchy: ViewHierarchyResult, target: Element): any[] | null {
     const roots = [
       ...this.elementParser.extractRootNodes(viewHierarchy),
-      ...this.elementParser.extractWindowRootNodes(viewHierarchy, "topmost-first")
+      ...this.elementParser.extractWindowRootNodes(viewHierarchy, "topmost-first"),
     ];
 
     const stack: any[] = [];
@@ -1174,7 +1199,7 @@ export class TapOnElement extends BaseVisualChange {
   private findAncestorByPredicate(
     chain: any[],
     predicate: (props: Record<string, unknown>) => boolean,
-    requireResourceId: boolean
+    requireResourceId: boolean,
   ): Element | null {
     for (let i = chain.length - 2; i >= 0; i--) {
       const node = chain[i];
@@ -1197,14 +1222,16 @@ export class TapOnElement extends BaseVisualChange {
   private selectAncestorForAction(
     chain: any[],
     action: string,
-    requireResourceId: boolean
+    requireResourceId: boolean,
   ): Element | null {
-    const primary = action === "longPress"
-      ? (props: Record<string, unknown>) => this.isLongClickableProps(props)
-      : (props: Record<string, unknown>) => this.isClickableProps(props);
-    const secondary = action === "longPress"
-      ? (props: Record<string, unknown>) => this.isClickableProps(props)
-      : (props: Record<string, unknown>) => this.isLongClickableProps(props);
+    const primary =
+      action === "longPress"
+        ? (props: Record<string, unknown>) => this.isLongClickableProps(props)
+        : (props: Record<string, unknown>) => this.isClickableProps(props);
+    const secondary =
+      action === "longPress"
+        ? (props: Record<string, unknown>) => this.isClickableProps(props)
+        : (props: Record<string, unknown>) => this.isLongClickableProps(props);
 
     return (
       this.findAncestorByPredicate(chain, primary, requireResourceId) ??
@@ -1216,7 +1243,7 @@ export class TapOnElement extends BaseVisualChange {
     element: Element,
     viewHierarchy: ViewHierarchyResult | null,
     action: string,
-    requireResourceId: boolean
+    requireResourceId: boolean,
   ): { element: Element; usedParent: boolean } {
     if (this.device.platform !== "android" || !viewHierarchy) {
       return { element, usedParent: false };
@@ -1259,12 +1286,12 @@ export class TapOnElement extends BaseVisualChange {
    * Execute a tap on text
    * @param options - Command options
    * @param progress - Optional progress callback
-    * @returns Result of the command
+   * @returns Result of the command
    */
   async execute(
     options: TapOnElementOptions,
     progress?: ProgressCallback,
-    signal?: AbortSignal
+    signal?: AbortSignal,
   ): Promise<TapOnElementResult> {
     if (!options.action) {
       return this.createErrorResult(options.action, "tap on action is required");
@@ -1300,13 +1327,18 @@ export class TapOnElement extends BaseVisualChange {
           }
 
           const searchOutcome = await perf.track("findElement", () =>
-            this.searchForElement(options, observeResult, signal)
+            this.searchForElement(options, observeResult, signal),
           );
           searchUntilStats = searchOutcome.stats;
           this.updateObservationHierarchy(observeResult, searchOutcome.viewHierarchy);
           viewHierarchy = searchOutcome.viewHierarchy;
           if (!searchOutcome.selection.element) {
-            await this.handleElementNotFound(options, observeResult, searchOutcome.containerFound, signal);
+            await this.handleElementNotFound(
+              options,
+              observeResult,
+              searchOutcome.containerFound,
+              signal,
+            );
           }
           const selection = searchOutcome.selection;
           const element = selection.element as Element;
@@ -1331,7 +1363,7 @@ export class TapOnElement extends BaseVisualChange {
                 wasAlreadyFocused: true,
                 focusChanged: false,
                 x: initialTapPoint.x,
-                y: initialTapPoint.y
+                y: initialTapPoint.y,
               };
             }
 
@@ -1346,7 +1378,7 @@ export class TapOnElement extends BaseVisualChange {
           const isAccessibilityServiceEnabled = await this.strategy.isAccessibilityServiceEnabled();
           const requireResourceId = this.requiresResourceIdForTapTarget(
             isAccessibilityServiceEnabled,
-            options
+            options,
           );
           let tapElement: Element;
           let usedParent: boolean;
@@ -1354,7 +1386,7 @@ export class TapOnElement extends BaseVisualChange {
             element,
             viewHierarchy,
             action,
-            requireResourceId
+            requireResourceId,
           );
           tapElement = initialTapTarget.element;
           usedParent = initialTapTarget.usedParent;
@@ -1365,7 +1397,7 @@ export class TapOnElement extends BaseVisualChange {
               observeResult,
               action,
               requireResourceId,
-              signal
+              signal,
             );
             if (!stable.ok) {
               perf.end();
@@ -1381,14 +1413,14 @@ export class TapOnElement extends BaseVisualChange {
           const tapPoint = this.resolveTapPoint(
             tapElement,
             observeResult.screenSize,
-            options.relativePosition
+            options.relativePosition,
           );
           const tapBounds = tapElement.bounds;
           logger.info(
             `[TapOnElement] Tapping (${tapPoint.x}, ${tapPoint.y}) on element: ` +
-            `text=${JSON.stringify(tapElement.text ?? options.text)}, ` +
-            `bounds=${JSON.stringify(tapBounds)}, ` +
-            `clickable=${tapElement.clickable}, usedParent=${usedParent}`
+              `text=${JSON.stringify(tapElement.text ?? options.text)}, ` +
+              `bounds=${JSON.stringify(tapBounds)}, ` +
+              `clickable=${tapElement.clickable}, usedParent=${usedParent}`,
           );
 
           selectionCapture = await this.prepareSelectionCapture(
@@ -1396,12 +1428,10 @@ export class TapOnElement extends BaseVisualChange {
             action,
             observeResult,
             tapElement,
-            signal
+            signal,
           );
 
-          const preTapHash = options.retryIfNoChange
-            ? this.hashViewHierarchy(viewHierarchy)
-            : null;
+          const preTapHash = options.retryIfNoChange ? this.hashViewHierarchy(viewHierarchy) : null;
           let screenReaderNavigation: ScreenReaderNavigationResult | undefined;
 
           // Platform-specific tap execution
@@ -1416,11 +1446,18 @@ export class TapOnElement extends BaseVisualChange {
                   tapElement,
                   signal,
                   options,
-                  isAccessibilityServiceEnabled
+                  isAccessibilityServiceEnabled,
                 );
                 break;
               case "ios":
-                await this.executeiOSTap(action, tapPoint.x, tapPoint.y, longPressDuration, tapElement, isAccessibilityServiceEnabled);
+                await this.executeiOSTap(
+                  action,
+                  tapPoint.x,
+                  tapPoint.y,
+                  longPressDuration,
+                  tapElement,
+                  isAccessibilityServiceEnabled,
+                );
                 break;
               default:
                 throw new ActionableError(`Unsupported platform: ${this.device.platform}`);
@@ -1457,7 +1494,7 @@ export class TapOnElement extends BaseVisualChange {
           queryOptions: {
             text: options.text ?? options.textAny?.[0],
             elementId: options.elementId,
-            containerElementId: options.container?.elementId
+            containerElementId: options.container?.elementId,
           },
           changeExpected: false,
           timeoutMs: 800, // Reduce timeout for faster execution
@@ -1476,10 +1513,10 @@ export class TapOnElement extends BaseVisualChange {
               searchUntil: options.searchUntil,
               selectionStrategy: options.selectionStrategy,
               relativePosition: options.relativePosition,
-              platform: this.device.platform
-            }
-          }
-        }
+              platform: this.device.platform,
+            },
+          },
+        },
       );
 
       if (result.success && result.observation && result.element) {
@@ -1489,7 +1526,7 @@ export class TapOnElement extends BaseVisualChange {
           currentObservation: result.observation,
           previousObservation: previousObserveResult,
           element: result.element,
-          signal
+          signal,
         });
         if (selectedElements.length > 0) {
           result.observation.selectedElements = selectedElements;
@@ -1500,7 +1537,7 @@ export class TapOnElement extends BaseVisualChange {
         const metadata = this.detectLongPressMetadata(previousObserveResult, result.observation);
         return {
           ...result,
-          ...metadata
+          ...metadata,
         };
       }
       return result;
@@ -1508,14 +1545,11 @@ export class TapOnElement extends BaseVisualChange {
       perf.end();
 
       // Build debug context if debug mode is enabled
-      const debugContext = await buildElementSearchDebugContext(
-        this.device,
-        {
-          text: options.text,
-          resourceId: options.elementId,
-          container: options.container
-        }
-      );
+      const debugContext = await buildElementSearchDebugContext(this.device, {
+        text: options.text,
+        resourceId: options.elementId,
+        container: options.container,
+      });
 
       // Return error result with debug info instead of throwing
       const errorMsg = errorMessage(error);
@@ -1524,10 +1558,10 @@ export class TapOnElement extends BaseVisualChange {
         action: options.action,
         error: `Failed to perform tap on element: ${errorMsg}`,
         element: {
-          bounds: { left: 0, top: 0, right: 0, bottom: 0 }
+          bounds: { left: 0, top: 0, right: 0, bottom: 0 },
         } as Element,
         ...(searchUntilStats ? { searchUntil: searchUntilStats } : {}),
-        ...(debugContext ? { debug: { elementSearch: debugContext } } : {})
+        ...(debugContext ? { debug: { elementSearch: debugContext } } : {}),
       };
     }
   }
@@ -1550,17 +1584,27 @@ export class TapOnElement extends BaseVisualChange {
     element: Element,
     signal?: AbortSignal,
     options?: TapOnElementOptions,
-    isTalkBackEnabled?: boolean
+    isTalkBackEnabled?: boolean,
   ): Promise<ScreenReaderNavigationResult | undefined> {
     // Check if TalkBack is enabled (not just any accessibility service)
-    const talkBackEnabled = typeof isTalkBackEnabled === "boolean"
-      ? isTalkBackEnabled
-      : (await this.accessibilityDetector.detectMethod(this.device.deviceId, this.adb)) === "talkback";
+    const talkBackEnabled =
+      typeof isTalkBackEnabled === "boolean"
+        ? isTalkBackEnabled
+        : (await this.accessibilityDetector.detectMethod(this.device.deviceId, this.adb)) ===
+          "talkback";
 
     if (talkBackEnabled) {
       // TalkBack mode: Use accessibility actions or precise coordinate
       // gestures through its CtrlProxy driver, with ADB as the last fallback.
-      return this.executeAndroidTapWithAccessibility(action, x, y, element, durationMs, options, signal);
+      return this.executeAndroidTapWithAccessibility(
+        action,
+        x,
+        y,
+        element,
+        durationMs,
+        options,
+        signal,
+      );
     }
 
     // Standard mode and precise targets use coordinates. Precise long presses
@@ -1585,29 +1629,51 @@ export class TapOnElement extends BaseVisualChange {
     durationMs: number,
     element: Element,
     signal?: AbortSignal,
-    skipSemanticLongPress: boolean = false
+    skipSemanticLongPress: boolean = false,
   ): Promise<void> {
     if (action === "tap") {
       const result = await this.accessibilityService.requestTapCoordinates(x, y, 10);
       if (!result.success) {
         logger.warn(
-          `[TapOnElement] dispatchGesture tap failed (${result.error}), falling back to ADB input`
+          `[TapOnElement] dispatchGesture tap failed (${result.error}), falling back to ADB input`,
         );
-        await this.adb.executeCommand(`shell input touchscreen tap ${x} ${y}`, undefined, undefined, undefined, signal);
+        await this.adb.executeCommand(
+          `shell input touchscreen tap ${x} ${y}`,
+          undefined,
+          undefined,
+          undefined,
+          signal,
+        );
       }
     } else if (action === "longPress") {
       await this.executeAndroidLongPress(x, y, durationMs, element, signal, skipSemanticLongPress);
     } else if (action === "doubleTap") {
       const first = await this.accessibilityService.requestTapCoordinates(x, y, 10);
       if (!first.success) {
-        logger.warn(`[TapOnElement] dispatchGesture first tap failed (${first.error}), falling back to ADB`);
-        await this.adb.executeCommand(`shell input touchscreen tap ${x} ${y}`, undefined, undefined, undefined, signal);
+        logger.warn(
+          `[TapOnElement] dispatchGesture first tap failed (${first.error}), falling back to ADB`,
+        );
+        await this.adb.executeCommand(
+          `shell input touchscreen tap ${x} ${y}`,
+          undefined,
+          undefined,
+          undefined,
+          signal,
+        );
       }
       await this.timer.sleep(200);
       const second = await this.accessibilityService.requestTapCoordinates(x, y, 10);
       if (!second.success) {
-        logger.warn(`[TapOnElement] dispatchGesture second tap failed (${second.error}), falling back to ADB`);
-        await this.adb.executeCommand(`shell input touchscreen tap ${x} ${y}`, undefined, undefined, undefined, signal);
+        logger.warn(
+          `[TapOnElement] dispatchGesture second tap failed (${second.error}), falling back to ADB`,
+        );
+        await this.adb.executeCommand(
+          `shell input touchscreen tap ${x} ${y}`,
+          undefined,
+          undefined,
+          undefined,
+          signal,
+        );
       }
     }
   }
@@ -1632,7 +1698,7 @@ export class TapOnElement extends BaseVisualChange {
     const postTapHierarchy = await this.refreshViewHierarchy(
       POST_TAP_REFRESH_TIMEOUT_MS,
       screenSize,
-      signal
+      signal,
     );
 
     if (!postTapHierarchy) {
@@ -1642,7 +1708,7 @@ export class TapOnElement extends BaseVisualChange {
       // step's waitFor/observe surface a real failure.
       logger.warn(
         `[TapOnElement][retryIfNoChange] Post-tap refresh returned no hierarchy ` +
-        `within ${POST_TAP_REFRESH_TIMEOUT_MS}ms — skipping retry (likely activity transition in progress)`
+          `within ${POST_TAP_REFRESH_TIMEOUT_MS}ms — skipping retry (likely activity transition in progress)`,
       );
       return;
     }
@@ -1650,15 +1716,13 @@ export class TapOnElement extends BaseVisualChange {
     const postTapHash = this.hashViewHierarchy(postTapHierarchy);
 
     if (postTapHash && postTapHash !== preTapHash) {
-      logger.info(
-        `[TapOnElement][retryIfNoChange] Hierarchy changed after tap — tap registered`
-      );
+      logger.info(`[TapOnElement][retryIfNoChange] Hierarchy changed after tap — tap registered`);
       return;
     }
 
     logger.warn(
       `[TapOnElement][retryIfNoChange] Hierarchy unchanged after tap at ` +
-      `(${tapPoint.x}, ${tapPoint.y}) — ghost tap detected, retrying`
+        `(${tapPoint.x}, ${tapPoint.y}) — ghost tap detected, retrying`,
     );
 
     await this.timer.sleep(PRE_RETRY_DELAY_MS);
@@ -1671,7 +1735,7 @@ export class TapOnElement extends BaseVisualChange {
       tapElement,
       signal,
       options,
-      isTalkBackEnabled
+      isTalkBackEnabled,
     );
   }
 
@@ -1691,8 +1755,10 @@ export class TapOnElement extends BaseVisualChange {
    * stays direct-activation (#3936).
    */
   private isScreenReaderNavigationEnabled(options?: TapOnElementOptions): boolean {
-    return Boolean(options?.screenReaderNavigation)
-      || this.featureFlags.isEnabled("screen-reader-navigation");
+    return (
+      Boolean(options?.screenReaderNavigation) ||
+      this.featureFlags.isEnabled("screen-reader-navigation")
+    );
   }
 
   private async executeRemainingPreciseTalkBackInput(
@@ -1702,20 +1768,12 @@ export class TapOnElement extends BaseVisualChange {
     durationMs: number,
     element: Element,
     preciseResult: TalkBackTapResult,
-    signal?: AbortSignal
+    signal?: AbortSignal,
   ): Promise<void> {
     let remainingAction = action;
     if (action === "tap") {
       if (!preciseResult.focusCompleted) {
-        await this.executeAndroidTapWithCoordinates(
-          "tap",
-          x,
-          y,
-          durationMs,
-          element,
-          signal,
-          true
-        );
+        await this.executeAndroidTapWithCoordinates("tap", x, y, durationMs, element, signal, true);
         await this.timer.sleep(TALKBACK_PRECISE_FOCUS_SETTLE_MS);
       }
       remainingAction = preciseResult.completedTaps === 1 ? "tap" : "doubleTap";
@@ -1729,7 +1787,7 @@ export class TapOnElement extends BaseVisualChange {
       durationMs,
       element,
       signal,
-      true
+      true,
     );
   }
 
@@ -1740,25 +1798,26 @@ export class TapOnElement extends BaseVisualChange {
     element: Element,
     durationMs: number,
     options?: TapOnElementOptions,
-    signal?: AbortSignal
+    signal?: AbortSignal,
   ): Promise<ScreenReaderNavigationResult | undefined> {
     const driver = this.talkBackDriverFactory.createDriver(this.device);
     let screenReaderNavigation: ScreenReaderNavigationResult | undefined;
 
     if (options?.relativePosition) {
-      const preciseResult = action === "tap" || action === "doubleTap"
-        ? await this.talkBackStrategy.executePreciseTap(x, y, driver)
-        : await this.talkBackStrategy.executeCoordinateFallback(
-          x,
-          y,
-          "longPress",
-          durationMs,
-          driver
-        );
+      const preciseResult =
+        action === "tap" || action === "doubleTap"
+          ? await this.talkBackStrategy.executePreciseTap(x, y, driver)
+          : await this.talkBackStrategy.executeCoordinateFallback(
+              x,
+              y,
+              "longPress",
+              durationMs,
+              driver,
+            );
       if (!preciseResult.success) {
         logger.warn(
           `[TapOnElement] Precise TalkBack coordinate gesture failed (${preciseResult.error}), ` +
-          `falling back to remaining input at (${x}, ${y})`
+            `falling back to remaining input at (${x}, ${y})`,
         );
         await this.executeRemainingPreciseTalkBackInput(
           action,
@@ -1767,7 +1826,7 @@ export class TapOnElement extends BaseVisualChange {
           durationMs,
           element,
           preciseResult,
-          signal
+          signal,
         );
       }
       return undefined;
@@ -1780,18 +1839,18 @@ export class TapOnElement extends BaseVisualChange {
         y,
         durationMs,
         element,
-        driver
+        driver,
       );
 
       if (!longPressResult.success) {
         if (longPressResult.semanticActionFailure) {
           throw new Error(
-            `Semantic long press failed for the selected element: ${longPressResult.error ?? "unknown error"}`
+            `Semantic long press failed for the selected element: ${longPressResult.error ?? "unknown error"}`,
           );
         }
         logger.warn(
           `[TapOnElement] Long press accessibility methods failed (${longPressResult.error}), ` +
-          `falling back to ADB tap at (${x}, ${y})`
+            `falling back to ADB tap at (${x}, ${y})`,
         );
         await this.executeAndroidTapWithCoordinates(action, x, y, durationMs, element, signal);
       }
@@ -1805,7 +1864,7 @@ export class TapOnElement extends BaseVisualChange {
         const result = await this.talkBackStrategy.executeTap(
           this.device.deviceId,
           element,
-          driver
+          driver,
         );
 
         if (result.success) {
@@ -1814,7 +1873,7 @@ export class TapOnElement extends BaseVisualChange {
 
         logger.warn(
           `[TapOnElement] Focus navigation failed (${result.error}), ` +
-          `falling back to coordinate-based tap at (${x}, ${y})`
+            `falling back to coordinate-based tap at (${x}, ${y})`,
         );
         screenReaderNavigation = result.screenReaderNavigation;
       } else if (action === "tap") {
@@ -1829,7 +1888,7 @@ export class TapOnElement extends BaseVisualChange {
 
         logger.warn(
           `[TapOnElement] Direct accessibility activation failed (${result.error}), ` +
-          `falling back to coordinate-based tap at (${x}, ${y})`
+            `falling back to coordinate-based tap at (${x}, ${y})`,
         );
       }
     }
@@ -1841,13 +1900,13 @@ export class TapOnElement extends BaseVisualChange {
       y,
       fallbackAction,
       durationMs,
-      driver
+      driver,
     );
 
     if (!fallbackResult.success) {
       logger.warn(
         `[TapOnElement] Accessibility coordinate tap failed (${fallbackResult.error}), ` +
-        `falling back to ADB tap at (${x}, ${y})`
+          `falling back to ADB tap at (${x}, ${y})`,
       );
       await this.executeAndroidTapWithCoordinates(action, x, y, durationMs, element, signal);
     }
@@ -1869,7 +1928,7 @@ export class TapOnElement extends BaseVisualChange {
     y: number,
     durationMs: number,
     element?: Element,
-    isVoiceOverEnabled?: boolean
+    isVoiceOverEnabled?: boolean,
   ): Promise<void> {
     if (isVoiceOverEnabled && element) {
       await this.executeIOSTapWithVoiceOver(action, element, x, y, durationMs);
@@ -1886,7 +1945,7 @@ export class TapOnElement extends BaseVisualChange {
     action: string,
     x: number,
     y: number,
-    durationMs: number
+    durationMs: number,
   ): Promise<void> {
     // Use short duration (50ms) for tap/doubleTap, full duration for longPress
     const tapDuration = action === "longPress" ? durationMs : 50;
@@ -1930,12 +1989,15 @@ export class TapOnElement extends BaseVisualChange {
     element: Element,
     x: number,
     y: number,
-    durationMs: number
+    durationMs: number,
   ): Promise<void> {
     // Resolve accessibility label: ios-accessibility-label > content-desc > text > fallback
-    const label = (element["ios-accessibility-label"] as string | undefined)
-      ?? (typeof element["content-desc"] === "string" && element["content-desc"] ? element["content-desc"] : undefined)
-      ?? (typeof element.text === "string" && element.text ? element.text : undefined);
+    const label =
+      (element["ios-accessibility-label"] as string | undefined) ??
+      (typeof element["content-desc"] === "string" && element["content-desc"]
+        ? element["content-desc"]
+        : undefined) ??
+      (typeof element.text === "string" && element.text ? element.text : undefined);
 
     if (!label) {
       logger.info("[TapOnElement] VoiceOver: no label available, falling back to coordinate tap");
@@ -1944,7 +2006,8 @@ export class TapOnElement extends BaseVisualChange {
     }
 
     // Map action to VoiceOver action
-    const voiceOverAction: "activate" | "long_press" = action === "longPress" ? "long_press" : "activate";
+    const voiceOverAction: "activate" | "long_press" =
+      action === "longPress" ? "long_press" : "activate";
 
     const client = IOSCtrlProxyClient.getInstance(this.device);
     const result = await client.requestVoiceOverActivate(label, voiceOverAction);
@@ -1952,7 +2015,7 @@ export class TapOnElement extends BaseVisualChange {
     if (!result.success) {
       logger.warn(
         `[TapOnElement] VoiceOver action failed for label "${label}": ${result.error ?? "unknown error"}, ` +
-        `falling back to coordinate tap at (${x}, ${y})`
+          `falling back to coordinate tap at (${x}, ${y})`,
       );
       await this.executeiOSTapWithCoordinates(action, x, y, durationMs);
     }
@@ -1965,39 +2028,50 @@ export class TapOnElement extends BaseVisualChange {
     return this.strategy.longPressDurationMs;
   }
 
-
   private async executeAndroidLongPress(
     x: number,
     y: number,
     durationMs: number,
     element: Element,
     signal?: AbortSignal,
-    skipSemanticAction: boolean = false
+    skipSemanticAction: boolean = false,
   ): Promise<void> {
     throwIfAborted(signal);
     if (!skipSemanticAction) {
       const selector = stableNodeSelectorForElement(element);
-      if (selector && await this.trySemanticAndroidLongPress(element, selector)) {
+      if (selector && (await this.trySemanticAndroidLongPress(element, selector))) {
         return;
       }
     }
 
     try {
-      await this.adb.executeCommand(`shell input touchscreen swipe ${x} ${y} ${x} ${y} ${durationMs}`, undefined, undefined, undefined, signal);
+      await this.adb.executeCommand(
+        `shell input touchscreen swipe ${x} ${y} ${x} ${y} ${durationMs}`,
+        undefined,
+        undefined,
+        undefined,
+        signal,
+      );
     } catch (error) {
       logger.warn(`[TapOnElement] touch input swipe failed, falling back to input swipe: ${error}`);
-      await this.adb.executeCommand(`shell input swipe ${x} ${y} ${x} ${y} ${durationMs}`, undefined, undefined, undefined, signal);
+      await this.adb.executeCommand(
+        `shell input swipe ${x} ${y} ${x} ${y} ${durationMs}`,
+        undefined,
+        undefined,
+        undefined,
+        signal,
+      );
     }
   }
 
   private async trySemanticAndroidLongPress(
     element: Element,
-    selector: NonNullable<ReturnType<typeof stableNodeSelectorForElement>>
+    selector: NonNullable<ReturnType<typeof stableNodeSelectorForElement>>,
   ): Promise<boolean> {
     const needsNodeSelector = requiresNodeSelector(selector);
     if (needsNodeSelector && !(await this.accessibilityService.supportsNodeActionSelectors())) {
       logger.info(
-        "[TapOnElement] Runner does not support stable node selectors; using coordinate long press"
+        "[TapOnElement] Runner does not support stable node selectors; using coordinate long press",
       );
       return false;
     }
@@ -2011,7 +2085,7 @@ export class TapOnElement extends BaseVisualChange {
       }
       if (hasAccessibilityAction(element.actions, "long_click")) {
         throw new ActionableError(
-          `Semantic long press failed for the selected element: ${result.error ?? "unknown error"}`
+          `Semantic long press failed for the selected element: ${result.error ?? "unknown error"}`,
         );
       }
       logger.warn(`[TapOnElement] Accessibility long click failed: ${result.error}`);
@@ -2024,10 +2098,9 @@ export class TapOnElement extends BaseVisualChange {
     return false;
   }
 
-
   private detectLongPressMetadata(
     previousObservation: ObserveResult | null,
-    currentObservation?: ObserveResult
+    currentObservation?: ObserveResult,
   ): LongPressMetadata {
     return this.longPressMetadataDetector.detect(previousObservation, currentObservation);
   }

--- a/src/features/action/TapOnElement.ts
+++ b/src/features/action/TapOnElement.ts
@@ -11,7 +11,10 @@ import {
   ViewHierarchyResult
 } from "../../models";
 import { AdbClient } from "../../utils/android-cmdline-tools/AdbClient";
-import { TapOnElementOptions } from "../../models/TapOnElementOptions";
+import type {
+  RelativeTapPosition,
+  TapOnElementOptions
+} from "../../models/TapOnElementOptions";
 import type { ElementParser } from "../../utils/interfaces/ElementParser";
 import type { ElementFinder } from "../../utils/interfaces/ElementFinder";
 import type { ElementGeometry } from "../../utils/interfaces/ElementGeometry";
@@ -253,7 +256,107 @@ export class TapOnElement extends BaseVisualChange {
       }
     }
 
+    return this.validateRelativePosition(options);
+  }
+
+  private validateRelativePosition(options: TapOnElementOptions): string | null {
+    if (!options.relativePosition) {
+      return null;
+    }
+    if (this.device.platform !== "android") {
+      return "tapOn relativePosition is only supported on Android";
+    }
+    if (options.action === "focus") {
+      return "tapOn relativePosition cannot be used with the focus action";
+    }
+
+    const { x, y } = options.relativePosition;
+    if (![x, y].every(Number.isFinite)) {
+      return "tapOn relativePosition x and y must be finite numbers";
+    }
+    if (x < 0 || x > 1 || y < 0 || y > 1) {
+      return "tapOn relativePosition x and y must be between 0 and 1";
+    }
+
     return null;
+  }
+
+  private hasAddressablePixels(bounds: Element["bounds"]): boolean {
+    const coordinates = [bounds.left, bounds.top, bounds.right, bounds.bottom];
+    return coordinates.every(Number.isFinite)
+      && bounds.right - bounds.left >= 1
+      && bounds.bottom - bounds.top >= 1;
+  }
+
+  private hasValidScreenDimensions(screenSize: ObserveResult["screenSize"]): boolean {
+    if (!screenSize) {
+      return false;
+    }
+    return [screenSize.width, screenSize.height].every(
+      dimension => Number.isFinite(dimension) && dimension >= 1
+    );
+  }
+
+  private isPointInHalfOpenBounds(
+    point: { x: number; y: number },
+    bounds: Element["bounds"]
+  ): boolean {
+    return point.x >= bounds.left
+      && point.x < bounds.right
+      && point.y >= bounds.top
+      && point.y < bounds.bottom;
+  }
+
+  private resolveTapPoint(
+    element: Element,
+    screenSize: ObserveResult["screenSize"],
+    relativePosition?: RelativeTapPosition
+  ): { x: number; y: number } {
+    if (!relativePosition) {
+      return this.geometry.getElementCenter(element);
+    }
+
+    const bounds = element.bounds;
+    const width = bounds.right - bounds.left;
+    const height = bounds.bottom - bounds.top;
+    if (!this.hasAddressablePixels(bounds)) {
+      throw new ActionableError(
+        `tapOn relativePosition requires valid element bounds, received ${JSON.stringify(bounds)}`
+      );
+    }
+
+    if (!this.hasValidScreenDimensions(screenSize)) {
+      throw new ActionableError(
+        "tapOn relativePosition requires valid Android screen dimensions"
+      );
+    }
+
+    // Android bounds are half-open. Scale across addressable pixels so 0 and 1
+    // map to the first and last valid pixels rather than the exclusive edge.
+    const x = bounds.left + Math.round(relativePosition.x * (width - 1));
+    const y = bounds.top + Math.round(relativePosition.y * (height - 1));
+    const point = { x, y };
+    if (!this.isPointInHalfOpenBounds(point, bounds)) {
+      throw new ActionableError(
+        `tapOn relativePosition resolved to (${x}, ${y}) outside element bounds `
+        + `${JSON.stringify(bounds)}`
+      );
+    }
+
+    const screenBounds = {
+      left: 0,
+      top: 0,
+      right: screenSize.width,
+      bottom: screenSize.height
+    };
+    if (!this.isPointInHalfOpenBounds(point, screenBounds)) {
+      throw new ActionableError(
+        `tapOn relativePosition resolved to (${x}, ${y}) outside screen bounds `
+        + `[0, ${screenSize.width}) x [0, ${screenSize.height})`
+      );
+    }
+
+    return point;
   }
 
   private getSearchUntilDuration(options: TapOnElementOptions): number {
@@ -1163,7 +1266,11 @@ export class TapOnElement extends BaseVisualChange {
           if (usedParent) {
             logger.info("[TapOnElement] Using clickable parent for non-clickable element");
           }
-          const tapPoint = this.geometry.getElementCenter(tapElement);
+          const tapPoint = this.resolveTapPoint(
+            tapElement,
+            observeResult.screenSize,
+            options.relativePosition
+          );
           const tapBounds = tapElement.bounds;
           logger.info(
             `[TapOnElement] Tapping (${tapPoint.x}, ${tapPoint.y}) on element: ` +
@@ -1228,6 +1335,8 @@ export class TapOnElement extends BaseVisualChange {
             element: tapElement,
             selectedElement: selectedElementMetadata,
             searchUntil: searchOutcome.stats,
+            x: tapPoint.x,
+            y: tapPoint.y,
             ...(screenReaderNavigation ? { screenReaderNavigation } : {}),
           };
         },
@@ -1253,6 +1362,7 @@ export class TapOnElement extends BaseVisualChange {
               container: options.container,
               searchUntil: options.searchUntil,
               selectionStrategy: options.selectionStrategy,
+              relativePosition: options.relativePosition,
               platform: this.device.platform
             }
           }
@@ -1334,11 +1444,13 @@ export class TapOnElement extends BaseVisualChange {
       ? isTalkBackEnabled
       : (await this.accessibilityDetector.detectMethod(this.device.deviceId, this.adb)) === "talkback";
 
-    if (talkBackEnabled) {
+    if (talkBackEnabled && !options?.relativePosition) {
       // TalkBack mode: Use accessibility actions with coordinate fallback
       return this.executeAndroidTapWithAccessibility(action, x, y, element, durationMs, options, signal);
     } else {
-      // Standard mode: Use coordinate-based taps
+      // Standard mode and precise targets use coordinates. A relative target
+      // must not be replaced by node-level ACTION_CLICK under TalkBack because
+      // that cannot distinguish ClickableSpans within one TextView.
       await this.executeAndroidTapWithCoordinates(action, x, y, durationMs, element, signal);
       return undefined;
     }

--- a/src/features/action/TapOnElement.ts
+++ b/src/features/action/TapOnElement.ts
@@ -307,6 +307,18 @@ export class TapOnElement extends BaseVisualChange {
       && point.y < bounds.bottom;
   }
 
+  private relativeTapPoint(
+    bounds: Element["bounds"],
+    relativePosition: RelativeTapPosition
+  ): { x: number; y: number } {
+    const width = bounds.right - bounds.left;
+    const height = bounds.bottom - bounds.top;
+    return {
+      x: Math.round(bounds.left + relativePosition.x * (width - 1)),
+      y: Math.round(bounds.top + relativePosition.y * (height - 1))
+    };
+  }
+
   private resolveTapPoint(
     element: Element,
     screenSize: ObserveResult["screenSize"],
@@ -317,8 +329,6 @@ export class TapOnElement extends BaseVisualChange {
     }
 
     const bounds = element.bounds;
-    const width = bounds.right - bounds.left;
-    const height = bounds.bottom - bounds.top;
     if (!this.hasAddressablePixels(bounds)) {
       throw new ActionableError(
         `tapOn relativePosition requires valid element bounds, received ${JSON.stringify(bounds)}`
@@ -333,9 +343,9 @@ export class TapOnElement extends BaseVisualChange {
 
     // Android bounds are half-open. Scale across addressable pixels so 0 and 1
     // map to the first and last valid pixels rather than the exclusive edge.
-    const x = bounds.left + Math.round(relativePosition.x * (width - 1));
-    const y = bounds.top + Math.round(relativePosition.y * (height - 1));
-    const point = { x, y };
+    // Round here, before validation and reporting, to match Android dispatch.
+    const point = this.relativeTapPoint(bounds, relativePosition);
+    const { x, y } = point;
     if (!this.isPointInHalfOpenBounds(point, bounds)) {
       throw new ActionableError(
         `tapOn relativePosition resolved to (${x}, ${y}) outside element bounds `
@@ -393,12 +403,28 @@ export class TapOnElement extends BaseVisualChange {
     }
   }
 
-  private isElementCenterOffScreen(
+  private isElementTapTargetOffScreen(
     element: Element,
-    screenSize?: ObserveResult["screenSize"]
+    screenSize?: ObserveResult["screenSize"],
+    relativePosition?: RelativeTapPosition
   ): boolean {
     if (!screenSize?.width || !screenSize?.height || !element.bounds) {
       return false;
+    }
+    if (relativePosition) {
+      if (!this.hasAddressablePixels(element.bounds)) {
+        return false;
+      }
+      const point = this.relativeTapPoint(element.bounds, relativePosition);
+      if (!this.isPointInHalfOpenBounds(point, element.bounds)) {
+        return false;
+      }
+      return !this.isPointInHalfOpenBounds(point, {
+        left: 0,
+        top: 0,
+        right: screenSize.width,
+        bottom: screenSize.height
+      });
     }
     const centerX = (element.bounds.left + element.bounds.right) / 2;
     const centerY = (element.bounds.top + element.bounds.bottom) / 2;
@@ -471,7 +497,13 @@ export class TapOnElement extends BaseVisualChange {
           });
         lastSelection = selection;
         if (selection.element) {
-          if (this.isElementCenterOffScreen(selection.element, screenSize)) {
+          if (
+            this.isElementTapTargetOffScreen(
+              selection.element,
+              screenSize,
+              options.relativePosition
+            )
+          ) {
             offScreenSelection = selection;
             continue;
           }
@@ -793,10 +825,13 @@ export class TapOnElement extends BaseVisualChange {
     let element = selection.element;
     let containerFoundEver = initialSearch.containerFound;
 
-    if (!element || this.isElementCenterOffScreen(element, observeResult.screenSize)) {
+    if (
+      !element ||
+      this.isElementTapTargetOffScreen(element, observeResult.screenSize, options.relativePosition)
+    ) {
       if (element) {
         logger.warn(
-          `[TapOnElement] Element found but center is off-screen, will retry. ` +
+          `[TapOnElement] Element found but tap target is off-screen, will retry. ` +
           `bounds=${JSON.stringify(element.bounds)}, ` +
           `screen=${observeResult.screenSize?.width}x${observeResult.screenSize?.height}`
         );
@@ -833,9 +868,12 @@ export class TapOnElement extends BaseVisualChange {
         selection = searchResult.selection;
         element = selection.element;
         containerFoundEver = containerFoundEver || searchResult.containerFound;
-        if (element && this.isElementCenterOffScreen(element, observeResult.screenSize)) {
+        if (
+          element &&
+          this.isElementTapTargetOffScreen(element, observeResult.screenSize, options.relativePosition)
+        ) {
           logger.warn(
-            `[TapOnElement] Element found but center is off-screen, retrying. ` +
+            `[TapOnElement] Element found but tap target is off-screen, retrying. ` +
             `bounds=${JSON.stringify(element.bounds)}`
           );
           selection = { ...selection, element: null };
@@ -1195,6 +1233,9 @@ export class TapOnElement extends BaseVisualChange {
           );
           searchUntilStats = searchOutcome.stats;
           observeResult.viewHierarchy = searchOutcome.viewHierarchy;
+          observeResult.screenSize =
+            this.getScreenSizeFromHierarchy(searchOutcome.viewHierarchy) ??
+            observeResult.screenSize;
           viewHierarchy = searchOutcome.viewHierarchy;
           if (!searchOutcome.selection.element) {
             await this.handleElementNotFound(options, observeResult, searchOutcome.containerFound, signal);
@@ -1259,6 +1300,10 @@ export class TapOnElement extends BaseVisualChange {
               return { success: false, error: stable.error };
             }
             observeResult.viewHierarchy = stable.viewHierarchy;
+            observeResult.screenSize =
+              this.getScreenSizeFromHierarchy(stable.viewHierarchy) ??
+              observeResult.screenSize;
+            viewHierarchy = stable.viewHierarchy;
             tapElement = stable.tapElement;
             usedParent = stable.usedParent;
           }

--- a/src/features/action/TapOnElement.ts
+++ b/src/features/action/TapOnElement.ts
@@ -1746,12 +1746,12 @@ export class TapOnElement extends BaseVisualChange {
     let screenReaderNavigation: ScreenReaderNavigationResult | undefined;
 
     if (options?.relativePosition) {
-      const preciseResult = action === "tap"
+      const preciseResult = action === "tap" || action === "doubleTap"
         ? await this.talkBackStrategy.executePreciseTap(x, y, driver)
         : await this.talkBackStrategy.executeCoordinateFallback(
           x,
           y,
-          action as "doubleTap" | "longPress",
+          "longPress",
           durationMs,
           driver
         );

--- a/src/features/action/TapOnElement.ts
+++ b/src/features/action/TapOnElement.ts
@@ -432,6 +432,18 @@ export class TapOnElement extends BaseVisualChange {
            centerY < 0 || centerY > screenSize.height;
   }
 
+  private isSelectionTapTargetOffScreen(
+    element: Element,
+    viewHierarchy: ViewHierarchyResult,
+    screenSize: ObserveResult["screenSize"] | undefined,
+    options: TapOnElementOptions
+  ): boolean {
+    const target = options.relativePosition
+      ? this.resolveTapTargetElement(element, viewHierarchy, options.action, false).element
+      : element;
+    return this.isElementTapTargetOffScreen(target, screenSize, options.relativePosition);
+  }
+
   private getScreenSizeFromHierarchy(viewHierarchy: ViewHierarchyResult): ObserveResult["screenSize"] | undefined {
     if (!viewHierarchy.screenWidth || !viewHierarchy.screenHeight) {
       return undefined;
@@ -458,6 +470,33 @@ export class TapOnElement extends BaseVisualChange {
     if (usedParent) {
       logger.info("[TapOnElement] Using clickable parent for non-clickable element");
     }
+  }
+
+  private requiresResourceIdForTapTarget(
+    isAccessibilityServiceEnabled: boolean,
+    options: TapOnElementOptions
+  ): boolean {
+    return isAccessibilityServiceEnabled && !options.relativePosition;
+  }
+
+  private async prepareSelectionCapture(
+    options: TapOnElementOptions,
+    action: string,
+    observation: ObserveResult,
+    element: Element,
+    signal?: AbortSignal
+  ): Promise<SelectionCaptureState | null> {
+    if (options.relativePosition) {
+      // Visual selection enrichment is best-effort; its screenshot await can
+      // make a precise coordinate stale before dispatch.
+      return null;
+    }
+    return this.selectionStateTracker.prepare({
+      action,
+      observation,
+      element,
+      signal
+    });
   }
 
   private findElementInHierarchy(
@@ -514,13 +553,12 @@ export class TapOnElement extends BaseVisualChange {
           });
         lastSelection = selection;
         if (selection.element) {
-          if (
-            this.isElementTapTargetOffScreen(
-              selection.element,
-              screenSize,
-              options.relativePosition
-            )
-          ) {
+          if (this.isSelectionTapTargetOffScreen(
+            selection.element,
+            viewHierarchy,
+            screenSize,
+            options
+          )) {
             offScreenSelection = selection;
             continue;
           }
@@ -648,7 +686,7 @@ export class TapOnElement extends BaseVisualChange {
     options: TapOnElementOptions,
     observeResult: ObserveResult,
     action: TapOnElementOptions["action"],
-    isTalkBackEnabled: boolean,
+    requireResourceId: boolean,
     signal?: AbortSignal
   ): Promise<
     | { ok: true; viewHierarchy: ViewHierarchyResult; tapElement: Element; usedParent: boolean }
@@ -775,7 +813,7 @@ export class TapOnElement extends BaseVisualChange {
         refind.selection.element as Element,
         freshHierarchy,
         action,
-        isTalkBackEnabled
+        requireResourceId
       );
       const b = refreshed.element.bounds;
       if (b === undefined || b === null) {
@@ -837,6 +875,8 @@ export class TapOnElement extends BaseVisualChange {
     let lastHash = this.hashViewHierarchy(viewHierarchy);
 
     let latestViewHierarchy = viewHierarchy;
+    let latestScreenSize =
+      this.getScreenSizeFromHierarchy(latestViewHierarchy) ?? observeResult.screenSize;
     const initialSearch = this.findElementInHierarchy(options, latestViewHierarchy);
     let selection = initialSearch.selection;
     let element = selection.element;
@@ -844,13 +884,18 @@ export class TapOnElement extends BaseVisualChange {
 
     if (
       !element ||
-      this.isElementTapTargetOffScreen(element, observeResult.screenSize, options.relativePosition)
+      this.isSelectionTapTargetOffScreen(
+        element,
+        latestViewHierarchy,
+        latestScreenSize,
+        options
+      )
     ) {
       if (element) {
         logger.warn(
           `[TapOnElement] Element found but tap target is off-screen, will retry. ` +
           `bounds=${JSON.stringify(element.bounds)}, ` +
-          `screen=${observeResult.screenSize?.width}x${observeResult.screenSize?.height}`
+          `screen=${latestScreenSize?.width}x${latestScreenSize?.height}`
         );
         selection = { ...selection, element: null };
         element = null;
@@ -862,7 +907,7 @@ export class TapOnElement extends BaseVisualChange {
         const remainingTimeMs = Math.max(0, deadline - this.timer.now());
         const refreshedHierarchy = await this.refreshViewHierarchy(
           remainingTimeMs,
-          observeResult.screenSize,
+          latestScreenSize,
           signal
         );
         requestCount += 1;
@@ -872,6 +917,8 @@ export class TapOnElement extends BaseVisualChange {
         }
 
         latestViewHierarchy = refreshedHierarchy;
+        latestScreenSize =
+          this.getScreenSizeFromHierarchy(refreshedHierarchy) ?? latestScreenSize;
         const hash = this.hashViewHierarchy(refreshedHierarchy);
         if (hash && hash !== lastHash) {
           changeCount += 1;
@@ -887,7 +934,12 @@ export class TapOnElement extends BaseVisualChange {
         containerFoundEver = containerFoundEver || searchResult.containerFound;
         if (
           element &&
-          this.isElementTapTargetOffScreen(element, observeResult.screenSize, options.relativePosition)
+          this.isSelectionTapTargetOffScreen(
+            element,
+            refreshedHierarchy,
+            latestScreenSize,
+            options
+          )
         ) {
           logger.warn(
             `[TapOnElement] Element found but tap target is off-screen, retrying. ` +
@@ -1290,13 +1342,17 @@ export class TapOnElement extends BaseVisualChange {
           // Android, VoiceOver on iOS. Downstream call paths are split by
           // the platform switch below, so a single flag suffices.
           const isAccessibilityServiceEnabled = await this.strategy.isAccessibilityServiceEnabled();
+          const requireResourceId = this.requiresResourceIdForTapTarget(
+            isAccessibilityServiceEnabled,
+            options
+          );
           let tapElement: Element;
           let usedParent: boolean;
           const initialTapTarget = this.resolveTapTargetElement(
             element,
             viewHierarchy,
             action,
-            isAccessibilityServiceEnabled
+            requireResourceId
           );
           tapElement = initialTapTarget.element;
           usedParent = initialTapTarget.usedParent;
@@ -1306,7 +1362,7 @@ export class TapOnElement extends BaseVisualChange {
               options,
               observeResult,
               action,
-              isAccessibilityServiceEnabled,
+              requireResourceId,
               signal
             );
             if (!stable.ok) {
@@ -1333,12 +1389,13 @@ export class TapOnElement extends BaseVisualChange {
             `clickable=${tapElement.clickable}, usedParent=${usedParent}`
           );
 
-          selectionCapture = await this.selectionStateTracker.prepare({
+          selectionCapture = await this.prepareSelectionCapture(
+            options,
             action,
-            observation: observeResult,
-            element: tapElement,
+            observeResult,
+            tapElement,
             signal
-          });
+          );
 
           const preTapHash = options.retryIfNoChange
             ? this.hashViewHierarchy(viewHierarchy)
@@ -1657,12 +1714,15 @@ export class TapOnElement extends BaseVisualChange {
         driver
       );
       if (!preciseResult.success) {
+        const remainingAction = action === "doubleTap" && preciseResult.completedTaps === 1
+          ? "tap"
+          : action;
         logger.warn(
           `[TapOnElement] Precise TalkBack coordinate gesture failed (${preciseResult.error}), ` +
           `falling back to ADB input at (${x}, ${y})`
         );
         await this.executeAndroidTapWithCoordinates(
-          action,
+          remainingAction,
           x,
           y,
           durationMs,

--- a/src/features/action/TapOnElement.ts
+++ b/src/features/action/TapOnElement.ts
@@ -1451,7 +1451,11 @@ export class TapOnElement extends BaseVisualChange {
       // Standard mode and precise targets use coordinates. A relative target
       // must not be replaced by node-level ACTION_CLICK under TalkBack because
       // that cannot distinguish ClickableSpans within one TextView.
-      await this.executeAndroidTapWithCoordinates(action, x, y, durationMs, element, signal);
+      if (options?.relativePosition) {
+        await this.executeAndroidTapWithCoordinates(action, x, y, durationMs, element, signal, true);
+      } else {
+        await this.executeAndroidTapWithCoordinates(action, x, y, durationMs, element, signal);
+      }
       return undefined;
     }
   }
@@ -1466,7 +1470,8 @@ export class TapOnElement extends BaseVisualChange {
     y: number,
     durationMs: number,
     element: Element,
-    signal?: AbortSignal
+    signal?: AbortSignal,
+    skipSemanticLongPress: boolean = false
   ): Promise<void> {
     if (action === "tap") {
       const result = await this.accessibilityService.requestTapCoordinates(x, y, 10);
@@ -1477,7 +1482,7 @@ export class TapOnElement extends BaseVisualChange {
         await this.adb.executeCommand(`shell input touchscreen tap ${x} ${y}`, undefined, undefined, undefined, signal);
       }
     } else if (action === "longPress") {
-      await this.executeAndroidLongPress(x, y, durationMs, element, signal);
+      await this.executeAndroidLongPress(x, y, durationMs, element, signal, skipSemanticLongPress);
     } else if (action === "doubleTap") {
       const first = await this.accessibilityService.requestTapCoordinates(x, y, 10);
       if (!first.success) {
@@ -1786,12 +1791,15 @@ export class TapOnElement extends BaseVisualChange {
     y: number,
     durationMs: number,
     element: Element,
-    signal?: AbortSignal
+    signal?: AbortSignal,
+    skipSemanticAction: boolean = false
   ): Promise<void> {
     throwIfAborted(signal);
-    const selector = stableNodeSelectorForElement(element);
-    if (selector && await this.trySemanticAndroidLongPress(element, selector)) {
-      return;
+    if (!skipSemanticAction) {
+      const selector = stableNodeSelectorForElement(element);
+      if (selector && await this.trySemanticAndroidLongPress(element, selector)) {
+        return;
+      }
     }
 
     try {

--- a/src/features/talkback/TalkBackTapStrategy.ts
+++ b/src/features/talkback/TalkBackTapStrategy.ts
@@ -19,6 +19,8 @@ export interface TalkBackTapResult {
   error?: string;
   /** A stable selector and advertised action rejected the semantic request. */
   semanticActionFailure?: boolean;
+  /** Whether a precise coordinate focus tap completed before activation. */
+  focusCompleted?: boolean;
   /** Number of taps completed before a coordinate double-tap failed. */
   completedTaps?: number;
   screenReaderNavigation?: ScreenReaderNavigationResult;
@@ -35,6 +37,7 @@ export interface ScreenReaderNavigationResult {
 }
 
 export type TalkBackFallbackAction = "tap" | "doubleTap" | "longPress";
+export const TALKBACK_PRECISE_FOCUS_SETTLE_MS = 500;
 
 interface TalkBackTapStrategyDependencies {
   matcher?: FocusElementMatcher;
@@ -386,7 +389,7 @@ export class TalkBackTapStrategy {
         };
       }
 
-      return { success: true, method: "coordinate-fallback" };
+      return { success: true, method: "coordinate-fallback", completedTaps: 2 };
     }
 
     // Single tap or long press
@@ -400,6 +403,41 @@ export class TalkBackTapStrategy {
     }
 
     return { success: true, method: "coordinate-fallback" };
+  }
+
+  /**
+   * Focus a coordinate through TalkBack touch exploration, then activate the
+   * resulting focused target with TalkBack's double-tap gesture.
+   */
+  async executePreciseTap(
+    x: number,
+    y: number,
+    driver: TalkBackNavigationDriver
+  ): Promise<TalkBackTapResult> {
+    const focusResult = await driver.requestTapCoordinates(x, y, 50);
+    if (!focusResult.success) {
+      return {
+        success: false,
+        method: "coordinate-fallback",
+        error: `Focus tap failed: ${focusResult.error}`,
+        focusCompleted: false,
+        completedTaps: 0
+      };
+    }
+
+    // Keep the focus tap outside TalkBack's activation double-tap window.
+    await this.timer.sleep(TALKBACK_PRECISE_FOCUS_SETTLE_MS);
+    const activationResult = await this.executeCoordinateFallback(
+      x,
+      y,
+      "doubleTap",
+      50,
+      driver
+    );
+    return {
+      ...activationResult,
+      focusCompleted: true
+    };
   }
 
   /**

--- a/src/features/talkback/TalkBackTapStrategy.ts
+++ b/src/features/talkback/TalkBackTapStrategy.ts
@@ -4,7 +4,10 @@ import { logger } from "../../utils/logger";
 import { defaultTimer, type Timer } from "../../utils/SystemTimer";
 import type { AccessibilityNodeSelector } from "../observe/android/types";
 import { FocusElementMatcher } from "./FocusElementMatcher";
-import { FocusNavigationExecutor, type FocusNavigationDriverFactory } from "./FocusNavigationExecutor";
+import {
+  FocusNavigationExecutor,
+  type FocusNavigationDriverFactory,
+} from "./FocusNavigationExecutor";
 import { FocusPathCalculator } from "./FocusPathCalculator";
 import type { TalkBackNavigationDriver } from "./TalkBackNavigationDriver";
 
@@ -55,7 +58,9 @@ function numberValue(value: unknown): number | undefined {
   return typeof value === "number" && Number.isInteger(value) ? value : undefined;
 }
 
-export function stableNodeSelectorForElement(element: Element): AccessibilityNodeSelector | undefined {
+export function stableNodeSelectorForElement(
+  element: Element,
+): AccessibilityNodeSelector | undefined {
   const selector: AccessibilityNodeSelector = {
     resourceId: nonEmptyString(element["resource-id"]),
     testTag: nonEmptyString(element["test-tag"]),
@@ -63,7 +68,8 @@ export function stableNodeSelectorForElement(element: Element): AccessibilityNod
   };
   const collectionRow = numberValue(element["collection-row-index"]);
   const collectionColumn = numberValue(element["collection-column-index"]);
-  const hasStableIdentity = selector.resourceId !== undefined ||
+  const hasStableIdentity =
+    selector.resourceId !== undefined ||
     selector.testTag !== undefined ||
     selector.uniqueId !== undefined;
   if (hasStableIdentity && collectionRow !== undefined && collectionColumn !== undefined) {
@@ -75,10 +81,12 @@ export function stableNodeSelectorForElement(element: Element): AccessibilityNod
 }
 
 export function requiresNodeSelector(selector: AccessibilityNodeSelector): boolean {
-  return selector.testTag !== undefined ||
+  return (
+    selector.testTag !== undefined ||
     selector.uniqueId !== undefined ||
     selector.collectionRow !== undefined ||
-    selector.collectionColumn !== undefined;
+    selector.collectionColumn !== undefined
+  );
 }
 
 function advertisesAction(element: Element, action: string): boolean {
@@ -102,12 +110,14 @@ export class TalkBackTapStrategy {
   constructor(dependencies: TalkBackTapStrategyDependencies = {}) {
     this.matcher = dependencies.matcher ?? new FocusElementMatcher();
     this.pathCalculator = dependencies.pathCalculator ?? new FocusPathCalculator(this.matcher);
-    this.executor = dependencies.executor ?? new FocusNavigationExecutor({
-      matcher: this.matcher,
-      pathCalculator: this.pathCalculator,
-      timer: dependencies.timer,
-      driverFactory: dependencies.driverFactory,
-    });
+    this.executor =
+      dependencies.executor ??
+      new FocusNavigationExecutor({
+        matcher: this.matcher,
+        pathCalculator: this.pathCalculator,
+        timer: dependencies.timer,
+        driverFactory: dependencies.driverFactory,
+      });
     this.timer = dependencies.timer ?? defaultTimer;
   }
 
@@ -132,7 +142,7 @@ export class TalkBackTapStrategy {
   async executeTap(
     deviceId: string,
     element: Element,
-    driver: TalkBackNavigationDriver
+    driver: TalkBackNavigationDriver,
   ): Promise<TalkBackTapResult> {
     let screenReaderNavigation: ScreenReaderNavigationResult | undefined;
     const resourceId = element?.["resource-id"] as string | undefined;
@@ -147,20 +157,22 @@ export class TalkBackTapStrategy {
         screenReaderNavigation: {
           reachable: false,
           traversalOrder: [],
-          focusTrapDetected: false
-        }
+          focusTrapDetected: false,
+        },
       };
     }
 
     try {
-      logger.debug(`[TalkBackTapStrategy] Attempting focus navigation to element (resourceId: ${resourceId}, text: ${elementText})`);
+      logger.debug(
+        `[TalkBackTapStrategy] Attempting focus navigation to element (resourceId: ${resourceId}, text: ${elementText})`,
+      );
 
       // Build selector from available fields (include bounds for disambiguation in list views)
       const targetSelector = {
         ...(resourceId ? { resourceId } : {}),
         ...(elementText ? { text: elementText } : {}),
         ...(elementContentDesc ? { contentDesc: elementContentDesc } : {}),
-        bounds: element.bounds
+        bounds: element.bounds,
       };
 
       // Get traversal order and current focus
@@ -173,8 +185,8 @@ export class TalkBackTapStrategy {
           screenReaderNavigation: {
             reachable: false,
             traversalOrder: [],
-            focusTrapDetected: false
-          }
+            focusTrapDetected: false,
+          },
         };
       }
 
@@ -197,7 +209,7 @@ export class TalkBackTapStrategy {
       const navigationResult: ScreenReaderNavigationResult = {
         reachable: false,
         traversalOrder: currentFocus ? [currentFocus] : [],
-        focusTrapDetected: false
+        focusTrapDetected: false,
       };
       screenReaderNavigation = navigationResult;
 
@@ -205,7 +217,7 @@ export class TalkBackTapStrategy {
       const navigationPath = this.pathCalculator.calculatePath(
         currentFocus,
         targetSelector,
-        orderedElements
+        orderedElements,
       );
 
       if (!navigationPath) {
@@ -213,12 +225,12 @@ export class TalkBackTapStrategy {
           success: false,
           method: "focus-navigation",
           error: "Could not calculate navigation path to target element",
-          screenReaderNavigation: navigationResult
+          screenReaderNavigation: navigationResult,
         };
       }
 
       logger.debug(
-        `[TalkBackTapStrategy] Calculated path: ${navigationPath.swipeCount} swipes ${navigationPath.direction}`
+        `[TalkBackTapStrategy] Calculated path: ${navigationPath.swipeCount} swipes ${navigationPath.direction}`,
       );
 
       // Navigate to element
@@ -231,8 +243,8 @@ export class TalkBackTapStrategy {
           // Fidelity assertions need every focused node, not periodic samples.
           verificationInterval: 1,
           swipeDelay: 100,
-          onFocusObserved: focus => this.appendTraversalFocus(navigationResult, focus)
-        }
+          onFocusObserved: (focus) => this.appendTraversalFocus(navigationResult, focus),
+        },
       );
 
       if (!navigationSuccess) {
@@ -240,7 +252,7 @@ export class TalkBackTapStrategy {
           success: false,
           method: "focus-navigation",
           error: "Focus navigation did not reach target element",
-          screenReaderNavigation: navigationResult
+          screenReaderNavigation: navigationResult,
         };
       }
 
@@ -251,7 +263,6 @@ export class TalkBackTapStrategy {
       // Activate the focused element with double-tap gesture
       const activationResult = await this.activateElement(element, driver);
       return { ...activationResult, screenReaderNavigation: navigationResult };
-
     } catch (error) {
       const errorMsg = errorMessage(error);
       logger.warn(`[TalkBackTapStrategy] Focus navigation failed: ${errorMsg}`);
@@ -261,15 +272,16 @@ export class TalkBackTapStrategy {
         error: errorMsg,
         screenReaderNavigation: screenReaderNavigation
           ? { ...screenReaderNavigation, focusTrapDetected: this.isFocusTrapError(errorMsg) }
-          : { reachable: false, traversalOrder: [], focusTrapDetected: this.isFocusTrapError(errorMsg) }
+          : {
+              reachable: false,
+              traversalOrder: [],
+              focusTrapDetected: this.isFocusTrapError(errorMsg),
+            },
       };
     }
   }
 
-  private appendTraversalFocus(
-    result: ScreenReaderNavigationResult,
-    focus: Element | null
-  ): void {
+  private appendTraversalFocus(result: ScreenReaderNavigationResult, focus: Element | null): void {
     if (!focus) {
       return;
     }
@@ -285,14 +297,16 @@ export class TalkBackTapStrategy {
       element["resource-id"] ?? "",
       element["content-desc"] ?? "",
       element.text ?? "",
-      bounds ? `${bounds.left},${bounds.top},${bounds.right},${bounds.bottom}` : ""
+      bounds ? `${bounds.left},${bounds.top},${bounds.right},${bounds.bottom}` : "",
     ].join("|");
   }
 
   private isFocusTrapError(error: string): boolean {
-    return error.includes("Focus did not move")
-      || error.includes("could not track the TalkBack cursor")
-      || error.includes("not converging on the target");
+    return (
+      error.includes("Focus did not move") ||
+      error.includes("could not track the TalkBack cursor") ||
+      error.includes("not converging on the target")
+    );
   }
 
   /**
@@ -310,14 +324,14 @@ export class TalkBackTapStrategy {
    */
   async executeDirectActivation(
     element: Element,
-    driver: TalkBackNavigationDriver
+    driver: TalkBackNavigationDriver,
   ): Promise<TalkBackTapResult> {
     const selector = stableNodeSelectorForElement(element);
     if (!selector) {
       return {
         success: false,
         method: "accessibility-action",
-        error: "Element has no stable selector for direct accessibility activation"
+        error: "Element has no stable selector for direct accessibility activation",
       };
     }
 
@@ -325,7 +339,7 @@ export class TalkBackTapStrategy {
       return {
         success: false,
         method: "accessibility-action",
-        error: "Runner does not support stable node selectors"
+        error: "Runner does not support stable node selectors",
       };
     }
 
@@ -340,7 +354,7 @@ export class TalkBackTapStrategy {
     return {
       success: false,
       method: "accessibility-action",
-      error: result.error ?? "ACTION_CLICK failed"
+      error: result.error ?? "ACTION_CLICK failed",
     };
   }
 
@@ -359,7 +373,7 @@ export class TalkBackTapStrategy {
     y: number,
     action: TalkBackFallbackAction,
     durationMs: number,
-    driver: TalkBackNavigationDriver
+    driver: TalkBackNavigationDriver,
   ): Promise<TalkBackTapResult> {
     const tapDuration = action === "longPress" ? durationMs : 50;
 
@@ -371,7 +385,7 @@ export class TalkBackTapStrategy {
           success: false,
           method: "coordinate-fallback",
           error: `First tap failed: ${firstResult.error}`,
-          completedTaps: 0
+          completedTaps: 0,
         };
       }
 
@@ -385,7 +399,7 @@ export class TalkBackTapStrategy {
           success: false,
           method: "coordinate-fallback",
           error: `Second tap failed: ${secondResult.error}`,
-          completedTaps: 1
+          completedTaps: 1,
         };
       }
 
@@ -398,7 +412,7 @@ export class TalkBackTapStrategy {
       return {
         success: false,
         method: "coordinate-fallback",
-        error: result.error
+        error: result.error,
       };
     }
 
@@ -412,7 +426,7 @@ export class TalkBackTapStrategy {
   async executePreciseTap(
     x: number,
     y: number,
-    driver: TalkBackNavigationDriver
+    driver: TalkBackNavigationDriver,
   ): Promise<TalkBackTapResult> {
     const focusResult = await driver.requestTapCoordinates(x, y, 50);
     if (!focusResult.success) {
@@ -421,22 +435,16 @@ export class TalkBackTapStrategy {
         method: "coordinate-fallback",
         error: `Focus tap failed: ${focusResult.error}`,
         focusCompleted: false,
-        completedTaps: 0
+        completedTaps: 0,
       };
     }
 
     // Keep the focus tap outside TalkBack's activation double-tap window.
     await this.timer.sleep(TALKBACK_PRECISE_FOCUS_SETTLE_MS);
-    const activationResult = await this.executeCoordinateFallback(
-      x,
-      y,
-      "doubleTap",
-      50,
-      driver
-    );
+    const activationResult = await this.executeCoordinateFallback(x, y, "doubleTap", 50, driver);
     return {
       ...activationResult,
-      focusCompleted: true
+      focusCompleted: true,
     };
   }
 
@@ -460,14 +468,14 @@ export class TalkBackTapStrategy {
     y: number,
     durationMs: number,
     element: Element,
-    driver: TalkBackNavigationDriver
+    driver: TalkBackNavigationDriver,
   ): Promise<TalkBackTapResult> {
     const selector = stableNodeSelectorForElement(element);
 
     if (selector) {
       if (requiresNodeSelector(selector) && !(await driver.supportsNodeActionSelectors())) {
         logger.info(
-          "[TalkBackTapStrategy] Runner does not support stable node selectors; using coordinate long press"
+          "[TalkBackTapStrategy] Runner does not support stable node selectors; using coordinate long press",
         );
         return this.executeCoordinateFallback(x, y, "longPress", durationMs, driver);
       }
@@ -488,7 +496,7 @@ export class TalkBackTapStrategy {
       }
       logger.warn(
         `[TalkBackTapStrategy] ACTION_LONG_CLICK failed (${longClickResult.error}), ` +
-        `falling back to coordinate gesture`
+          `falling back to coordinate gesture`,
       );
     }
 
@@ -500,7 +508,7 @@ export class TalkBackTapStrategy {
    */
   private async activateElement(
     element: Element,
-    driver: TalkBackNavigationDriver
+    driver: TalkBackNavigationDriver,
   ): Promise<TalkBackTapResult> {
     const resourceId = element["resource-id"] as string | undefined;
     // Activate against the node TalkBack actually focused (live bounds), not the
@@ -514,7 +522,7 @@ export class TalkBackTapStrategy {
     if (!center) {
       if (resourceId) {
         logger.warn(
-          "[TalkBackTapStrategy] Activation target has no bounds; using ACTION_CLICK fallback"
+          "[TalkBackTapStrategy] Activation target has no bounds; using ACTION_CLICK fallback",
         );
         const clickResult = await driver.requestAction("click", resourceId);
         if (clickResult.success) {
@@ -523,13 +531,13 @@ export class TalkBackTapStrategy {
         return {
           success: false,
           method: "focus-navigation",
-          error: `Activation failed: target has no bounds and ACTION_CLICK failed (${clickResult.error ?? "unknown"})`
+          error: `Activation failed: target has no bounds and ACTION_CLICK failed (${clickResult.error ?? "unknown"})`,
         };
       }
       return {
         success: false,
         method: "focus-navigation",
-        error: "Activation failed: target has no bounds and no resource-id for ACTION_CLICK"
+        error: "Activation failed: target has no bounds and no resource-id for ACTION_CLICK",
       };
     }
 
@@ -539,13 +547,15 @@ export class TalkBackTapStrategy {
     if (!firstTap.success) {
       if (resourceId) {
         // If double-tap fails, try ACTION_CLICK on the resource-id
-        logger.warn(`[TalkBackTapStrategy] Double-tap activation failed, trying ACTION_CLICK fallback`);
+        logger.warn(
+          `[TalkBackTapStrategy] Double-tap activation failed, trying ACTION_CLICK fallback`,
+        );
         const clickResult = await driver.requestAction("click", resourceId);
         if (!clickResult.success) {
           return {
             success: false,
             method: "focus-navigation",
-            error: `Activation failed: double-tap and ACTION_CLICK both failed`
+            error: `Activation failed: double-tap and ACTION_CLICK both failed`,
           };
         }
         return { success: true, method: "accessibility-action" };
@@ -553,7 +563,7 @@ export class TalkBackTapStrategy {
       return {
         success: false,
         method: "focus-navigation",
-        error: `Activation failed: double-tap failed`
+        error: `Activation failed: double-tap failed`,
       };
     }
 
@@ -571,7 +581,7 @@ export class TalkBackTapStrategy {
           return {
             success: false,
             method: "focus-navigation",
-            error: `Activation failed: second tap and ACTION_CLICK both failed`
+            error: `Activation failed: second tap and ACTION_CLICK both failed`,
           };
         }
         return { success: true, method: "accessibility-action" };
@@ -579,7 +589,7 @@ export class TalkBackTapStrategy {
       return {
         success: false,
         method: "focus-navigation",
-        error: `Activation failed: second tap failed`
+        error: `Activation failed: second tap failed`,
       };
     }
 
@@ -599,7 +609,7 @@ export class TalkBackTapStrategy {
     }
     return {
       x: Math.round((element.bounds.left + element.bounds.right) / 2),
-      y: Math.round((element.bounds.top + element.bounds.bottom) / 2)
+      y: Math.round((element.bounds.top + element.bounds.bottom) / 2),
     };
   }
 
@@ -612,7 +622,7 @@ export class TalkBackTapStrategy {
    */
   private async resolveActivationCenter(
     element: Element,
-    driver: TalkBackNavigationDriver
+    driver: TalkBackNavigationDriver,
   ): Promise<{ x: number; y: number } | null> {
     try {
       const focus = await driver.requestCurrentFocus();

--- a/src/features/talkback/TalkBackTapStrategy.ts
+++ b/src/features/talkback/TalkBackTapStrategy.ts
@@ -19,6 +19,8 @@ export interface TalkBackTapResult {
   error?: string;
   /** A stable selector and advertised action rejected the semantic request. */
   semanticActionFailure?: boolean;
+  /** Number of taps completed before a coordinate double-tap failed. */
+  completedTaps?: number;
   screenReaderNavigation?: ScreenReaderNavigationResult;
 }
 
@@ -365,7 +367,8 @@ export class TalkBackTapStrategy {
         return {
           success: false,
           method: "coordinate-fallback",
-          error: `First tap failed: ${firstResult.error}`
+          error: `First tap failed: ${firstResult.error}`,
+          completedTaps: 0
         };
       }
 
@@ -378,7 +381,8 @@ export class TalkBackTapStrategy {
         return {
           success: false,
           method: "coordinate-fallback",
-          error: `Second tap failed: ${secondResult.error}`
+          error: `Second tap failed: ${secondResult.error}`,
+          completedTaps: 1
         };
       }
 

--- a/src/models/TapOnElementOptions.ts
+++ b/src/models/TapOnElementOptions.ts
@@ -1,5 +1,12 @@
 import type { ElementSelectionStrategy } from "./ElementSelectionStrategy";
 
+export interface RelativeTapPosition {
+  /** Horizontal position from 0 (left) to 1 (rightmost addressable pixel). */
+  x: number;
+  /** Vertical position from 0 (top) to 1 (bottommost addressable pixel). */
+  y: number;
+}
+
 export interface TapOnElementOptions {
   // Element selection - one of these must be provided
   text?: string;
@@ -50,4 +57,8 @@ export interface TapOnElementOptions {
   preTapStability?: boolean;
   retryIfNoChange?: boolean;
   ensureTap?: boolean;
+
+  // Android-only normalized position within the final resolved element.
+  // Omit to preserve center tapping.
+  relativePosition?: RelativeTapPosition;
 }

--- a/src/models/TapOnElementResult.ts
+++ b/src/models/TapOnElementResult.ts
@@ -25,9 +25,9 @@ export interface TapOnSelectedElement {
 export interface TapOnElementResult extends BaseActionResult {
   action: string;
   element: Element;
-  /** Actual horizontal coordinate used for a successful tap. */
+  /** Resolved horizontal target coordinate for a successful interaction. */
   x?: number;
-  /** Actual vertical coordinate used for a successful tap. */
+  /** Resolved vertical target coordinate for a successful interaction. */
   y?: number;
   selectedElement?: TapOnSelectedElement;
   debug?: ToolDebugInfo;

--- a/src/models/TapOnElementResult.ts
+++ b/src/models/TapOnElementResult.ts
@@ -25,6 +25,10 @@ export interface TapOnSelectedElement {
 export interface TapOnElementResult extends BaseActionResult {
   action: string;
   element: Element;
+  /** Actual horizontal coordinate used for a successful tap. */
+  x?: number;
+  /** Actual vertical coordinate used for a successful tap. */
+  y?: number;
   selectedElement?: TapOnSelectedElement;
   debug?: ToolDebugInfo;
   pressRecognized?: boolean;

--- a/src/server/interactionToolTypes.ts
+++ b/src/server/interactionToolTypes.ts
@@ -2,7 +2,12 @@
  * Type definitions for interaction tools.
  * Extracted from interactionTools.ts for maintainability.
  */
-import type { Platform, ElementSelectionStrategy, ImeAction } from "../models";
+import type {
+  Platform,
+  ElementSelectionStrategy,
+  ImeAction,
+  RelativeTapPosition
+} from "../models";
 import type { ObserveWaitForOptions, SettledOptions } from "./observeTools";
 
 // ============================================================================
@@ -79,6 +84,7 @@ export interface TapOnArgs {
   preTapStability?: boolean;
   retryIfNoChange?: boolean;
   ensureTap?: boolean;
+  relativePosition?: RelativeTapPosition;
 }
 
 export interface TapAnyArgs {

--- a/src/server/interactionTools.ts
+++ b/src/server/interactionTools.ts
@@ -244,8 +244,36 @@ export const tapOnSchema = withJsonSchemaOverride(
         platform: platformSchema,
       })
       .strict(),
-  ),
-  (js) => compactExclusiveSelectorProperties(js, ["selector", "container"]),
+  ).superRefine((value, ctx) => {
+    if (!value.relativePosition) {
+      return;
+    }
+    if (value.platform !== "android") {
+      ctx.addIssue({
+        code: z.ZodIssueCode.custom,
+        message: "relativePosition is supported only on Android",
+        path: ["relativePosition"],
+      });
+    }
+    if (value.action === "focus") {
+      ctx.addIssue({
+        code: z.ZodIssueCode.custom,
+        message: "relativePosition is not supported for focus actions",
+        path: ["relativePosition"],
+      });
+    }
+  }),
+  (js) => {
+    compactExclusiveSelectorProperties(js, ["selector", "container"]);
+    js.if = { required: ["relativePosition"] };
+    js.then = {
+      properties: {
+        action: { not: { const: "focus" } },
+        platform: { const: "android" },
+      },
+      required: ["platform"],
+    };
+  },
 );
 
 export const tapAnySchema = withJsonSchemaOverride(

--- a/src/server/interactionTools.ts
+++ b/src/server/interactionTools.ts
@@ -199,6 +199,28 @@ export const tapOnSchema = withJsonSchemaOverride(
               "selectionStrategy — for repeated controls with no unique text. Out of range → no match.",
           ),
         duration: z.number().optional().describe("Long press duration (ms)"),
+        relativePosition: z
+          .object({
+            x: z
+              .number()
+              .min(0)
+              .max(1)
+              .describe(
+                "Horizontal position within the resolved element: 0 is left, 1 is the rightmost addressable pixel",
+              ),
+            y: z
+              .number()
+              .min(0)
+              .max(1)
+              .describe(
+                "Vertical position within the resolved element: 0 is top, 1 is the bottommost addressable pixel",
+              ),
+          })
+          .strict()
+          .optional()
+          .describe(
+            "Android-only precise target within the resolved element; omit to tap its center",
+          ),
         searchUntil: z
           .object({
             duration: z
@@ -681,6 +703,7 @@ export function registerInteractionTools() {
         preTapStability: args.preTapStability,
         retryIfNoChange: args.retryIfNoChange,
         ensureTap: args.ensureTap,
+        relativePosition: args.relativePosition,
       },
       progress,
     );

--- a/src/server/toolOutputSchemas.ts
+++ b/src/server/toolOutputSchemas.ts
@@ -204,6 +204,8 @@ export const tapOnResultSchema = z
     success: z.boolean(),
     action: z.string().optional(),
     message: z.string().optional(),
+    x: z.number().optional().describe("Horizontal coordinate of the resolved target used for the tap"),
+    y: z.number().optional().describe("Vertical coordinate of the resolved target used for the tap"),
     element: elementSchema.optional(),
     observation: z.union([observationSummarySchema, toolOutputArtifactMetadataSchema]).optional(),
     observationDiff: observationDiffMetadataSchema.optional(),

--- a/test/fakes/FakeTalkBackTapStrategy.ts
+++ b/test/fakes/FakeTalkBackTapStrategy.ts
@@ -102,7 +102,7 @@ export class FakeTalkBackTapStrategy implements TalkBackTapStrategyContract {
   async executeTap(
     deviceId: string,
     element: Element,
-    _driver: TalkBackNavigationDriver
+    _driver: TalkBackNavigationDriver,
   ): Promise<TalkBackTapResult> {
     this.tapCalls.push({ deviceId, element });
 
@@ -115,7 +115,7 @@ export class FakeTalkBackTapStrategy implements TalkBackTapStrategyContract {
 
   async executeDirectActivation(
     element: Element,
-    _driver: TalkBackNavigationDriver
+    _driver: TalkBackNavigationDriver,
   ): Promise<TalkBackTapResult> {
     this.directActivationCalls.push({ element });
 
@@ -131,7 +131,7 @@ export class FakeTalkBackTapStrategy implements TalkBackTapStrategyContract {
     y: number,
     action: TalkBackFallbackAction,
     durationMs: number,
-    _driver: TalkBackNavigationDriver
+    _driver: TalkBackNavigationDriver,
   ): Promise<TalkBackTapResult> {
     this.fallbackCalls.push({ x, y, action, durationMs });
 
@@ -145,7 +145,7 @@ export class FakeTalkBackTapStrategy implements TalkBackTapStrategyContract {
   async executePreciseTap(
     x: number,
     y: number,
-    _driver: TalkBackNavigationDriver
+    _driver: TalkBackNavigationDriver,
   ): Promise<TalkBackTapResult> {
     this.preciseTapCalls.push({ x, y });
     return this.preciseTapResult;
@@ -156,7 +156,7 @@ export class FakeTalkBackTapStrategy implements TalkBackTapStrategyContract {
     y: number,
     durationMs: number,
     element: Element,
-    _driver: TalkBackNavigationDriver
+    _driver: TalkBackNavigationDriver,
   ): Promise<TalkBackTapResult> {
     this.longPressCalls.push({ x, y, durationMs, element });
 

--- a/test/fakes/FakeTalkBackTapStrategy.ts
+++ b/test/fakes/FakeTalkBackTapStrategy.ts
@@ -11,6 +11,7 @@ type TalkBackTapStrategyContract = Pick<
   | "executeTap"
   | "executeDirectActivation"
   | "executeCoordinateFallback"
+  | "executePreciseTap"
   | "executeLongPress"
 >;
 
@@ -20,6 +21,12 @@ type TalkBackTapStrategyContract = Pick<
 export class FakeTalkBackTapStrategy implements TalkBackTapStrategyContract {
   tapResult: TalkBackTapResult = { success: true, method: "focus-navigation" };
   fallbackResult: TalkBackTapResult = { success: true, method: "coordinate-fallback" };
+  preciseTapResult: TalkBackTapResult = {
+    success: true,
+    method: "coordinate-fallback",
+    focusCompleted: true,
+    completedTaps: 2,
+  };
   longPressResult: TalkBackTapResult = { success: true, method: "accessibility-action" };
   directActivationResult: TalkBackTapResult = { success: true, method: "accessibility-action" };
 
@@ -37,6 +44,11 @@ export class FakeTalkBackTapStrategy implements TalkBackTapStrategyContract {
     y: number;
     action: TalkBackFallbackAction;
     durationMs: number;
+  }> = [];
+
+  preciseTapCalls: Array<{
+    x: number;
+    y: number;
   }> = [];
 
   longPressCalls: Array<{
@@ -65,6 +77,10 @@ export class FakeTalkBackTapStrategy implements TalkBackTapStrategyContract {
 
   setFallbackResult(result: TalkBackTapResult): void {
     this.fallbackResult = result;
+  }
+
+  setPreciseTapResult(result: TalkBackTapResult): void {
+    this.preciseTapResult = result;
   }
 
   setLongPressResult(result: TalkBackTapResult): void {
@@ -124,6 +140,15 @@ export class FakeTalkBackTapStrategy implements TalkBackTapStrategyContract {
     }
 
     return this.fallbackResult;
+  }
+
+  async executePreciseTap(
+    x: number,
+    y: number,
+    _driver: TalkBackNavigationDriver
+  ): Promise<TalkBackTapResult> {
+    this.preciseTapCalls.push({ x, y });
+    return this.preciseTapResult;
   }
 
   async executeLongPress(

--- a/test/features/action/TapOnElement.relativePosition.test.ts
+++ b/test/features/action/TapOnElement.relativePosition.test.ts
@@ -193,4 +193,51 @@ describe("TapOnElement relative position", () => {
       }),
     ).toContain("focus");
   });
+
+  test("uses the requested coordinate instead of semantic activation for long press", async () => {
+    const adb = new FakeAdbClient();
+    const command = new TapOnElement(
+      { name: "test-device", platform: "android", deviceId: "emulator-5554" } as any,
+      adb as any,
+      {
+        accessibilityDetector: new FakeAccessibilityDetector(),
+        timer: new FakeTimer(),
+      },
+    );
+    const semanticActions: string[] = [];
+    (command as any).accessibilityService = {
+      supportsNodeActionSelectors: async () => true,
+      requestNodeAction: async (action: string) => {
+        semanticActions.push(action);
+        return { success: true };
+      },
+      requestAction: async (action: string) => {
+        semanticActions.push(action);
+        return { success: true };
+      },
+    };
+
+    await (command as any).executeAndroidTap(
+      "longPress",
+      491,
+      230,
+      750,
+      {
+        ...SPANNABLE_TEXT_ELEMENT,
+        actions: ["long_click"],
+      },
+      undefined,
+      {
+        action: "longPress",
+        elementId: "test:id/spannable_text",
+        relativePosition: { x: 0.98, y: 0.5 },
+      },
+      true,
+    );
+
+    expect(semanticActions).toEqual([]);
+    expect(adb.getAllCommands()).toEqual([
+      "shell input touchscreen swipe 491 230 491 230 750",
+    ]);
+  });
 });

--- a/test/features/action/TapOnElement.relativePosition.test.ts
+++ b/test/features/action/TapOnElement.relativePosition.test.ts
@@ -33,7 +33,7 @@ function createHarness(element: Element = SPANNABLE_TEXT_ELEMENT) {
     ...(await block(observation)),
     observation,
   }));
-  spyOn(command as any, "searchForElement").mockResolvedValue({
+  const searchForElement = spyOn(command as any, "searchForElement").mockResolvedValue({
     selection: { element, indexInMatches: 0, totalMatches: 1, strategy: "first" },
     viewHierarchy: observation.viewHierarchy,
     containerFound: true,
@@ -48,7 +48,7 @@ function createHarness(element: Element = SPANNABLE_TEXT_ELEMENT) {
   spyOn((command as any).selectionStateTracker, "finalize").mockResolvedValue([]);
   const executeAndroidTap = spyOn(command as any, "executeAndroidTap").mockResolvedValue(undefined);
 
-  return { command, executeAndroidTap, observation };
+  return { command, executeAndroidTap, observation, searchForElement };
 }
 
 describe("TapOnElement relative position", () => {
@@ -201,27 +201,40 @@ describe("TapOnElement relative position", () => {
     expect(retryTapIfNoChange.mock.calls[0]?.[0]).toBe("stable-hash");
   });
 
-  test("keeps a partially clipped element when its requested point is visible", () => {
+  test("executes against a partially clipped element when its requested point is visible", async () => {
     const partiallyVisible = {
       ...SPANNABLE_TEXT_ELEMENT,
       bounds: { left: -400, top: 10, right: 100, bottom: 50 },
     };
-    const { command } = createHarness(partiallyVisible);
+    const { command, executeAndroidTap, searchForElement } = createHarness(partiallyVisible);
+    searchForElement.mockRestore();
+    spyOn(command as any, "findElementInHierarchy").mockReturnValue({
+      selection: {
+        element: partiallyVisible,
+        indexInMatches: 0,
+        totalMatches: 1,
+        strategy: "first",
+      },
+      containerFound: true,
+    });
 
-    expect(
-      (command as any).isElementTapTargetOffScreen(
-        partiallyVisible,
-        { width: 600, height: 800 },
-        { x: 1, y: 0.5 },
-      ),
-    ).toBe(false);
-    expect(
-      (command as any).isElementTapTargetOffScreen(
-        partiallyVisible,
-        { width: 600, height: 800 },
-        { x: 0, y: 0.5 },
-      ),
-    ).toBe(true);
+    const result = await command.execute({
+      action: "tap",
+      elementId: "test:id/spannable_text",
+      relativePosition: { x: 1, y: 0.5 },
+    });
+
+    expect(result).toMatchObject({ success: true, x: 99, y: 30 });
+    expect(executeAndroidTap).toHaveBeenCalledWith(
+      "tap",
+      99,
+      30,
+      expect.any(Number),
+      partiallyVisible,
+      undefined,
+      expect.anything(),
+      false,
+    );
   });
 
   test("rejects a resolved point outside the screen before device contact", () => {

--- a/test/features/action/TapOnElement.relativePosition.test.ts
+++ b/test/features/action/TapOnElement.relativePosition.test.ts
@@ -134,6 +134,96 @@ describe("TapOnElement relative position", () => {
     );
   });
 
+  test("uses refreshed screen dimensions after stable re-resolution", async () => {
+    const { command, executeAndroidTap } = createHarness();
+    const stableHierarchy = {
+      hierarchy: {},
+      screenWidth: 800,
+      screenHeight: 600,
+    };
+    const stableElement = {
+      ...SPANNABLE_TEXT_ELEMENT,
+      bounds: { left: 600, top: 100, right: 800, bottom: 200 },
+    };
+    spyOn(command as any, "resolveAndroidStableTapTargetAfterRefreshes").mockResolvedValue({
+      ok: true,
+      viewHierarchy: stableHierarchy,
+      tapElement: stableElement,
+      usedParent: false,
+    });
+
+    const result = await command.execute({
+      action: "tap",
+      elementId: "test:id/spannable_text",
+      relativePosition: { x: 0.5, y: 0.5 },
+      preTapStability: true,
+    });
+
+    expect(result).toMatchObject({ success: true, x: 700, y: 150 });
+    expect(executeAndroidTap).toHaveBeenCalledWith(
+      "tap",
+      700,
+      150,
+      expect.any(Number),
+      stableElement,
+      undefined,
+      expect.anything(),
+      false,
+    );
+  });
+
+  test("hashes the stable hierarchy before checking whether to retry", async () => {
+    const { command, observation } = createHarness();
+    const stableHierarchy = { hierarchy: { node: { text: "stable" } } };
+    spyOn(command as any, "resolveAndroidStableTapTargetAfterRefreshes").mockResolvedValue({
+      ok: true,
+      viewHierarchy: stableHierarchy,
+      tapElement: SPANNABLE_TEXT_ELEMENT,
+      usedParent: false,
+    });
+    spyOn(command as any, "hashViewHierarchy").mockImplementation(
+      (hierarchy: unknown) => hierarchy === stableHierarchy ? "stable-hash" : "initial-hash",
+    );
+    const retryTapIfNoChange = spyOn(
+      command as any,
+      "retryTapIfNoChange",
+    ).mockResolvedValue(undefined);
+
+    await command.execute({
+      action: "tap",
+      elementId: "test:id/spannable_text",
+      relativePosition: { x: 0.5, y: 0.5 },
+      preTapStability: true,
+      retryIfNoChange: true,
+    });
+
+    expect(observation.viewHierarchy).toBe(stableHierarchy);
+    expect(retryTapIfNoChange.mock.calls[0]?.[0]).toBe("stable-hash");
+  });
+
+  test("keeps a partially clipped element when its requested point is visible", () => {
+    const partiallyVisible = {
+      ...SPANNABLE_TEXT_ELEMENT,
+      bounds: { left: -400, top: 10, right: 100, bottom: 50 },
+    };
+    const { command } = createHarness(partiallyVisible);
+
+    expect(
+      (command as any).isElementTapTargetOffScreen(
+        partiallyVisible,
+        { width: 600, height: 800 },
+        { x: 1, y: 0.5 },
+      ),
+    ).toBe(false);
+    expect(
+      (command as any).isElementTapTargetOffScreen(
+        partiallyVisible,
+        { width: 600, height: 800 },
+        { x: 0, y: 0.5 },
+      ),
+    ).toBe(true);
+  });
+
   test("rejects a resolved point outside the screen before device contact", () => {
     const partiallyOffscreen = {
       ...SPANNABLE_TEXT_ELEMENT,
@@ -149,6 +239,22 @@ describe("TapOnElement relative position", () => {
       ),
     ).toThrow("outside screen bounds");
     expect(executeAndroidTap).not.toHaveBeenCalled();
+  });
+
+  test("validates the integer coordinate Android actually dispatches", () => {
+    const fractionalBounds = {
+      ...SPANNABLE_TEXT_ELEMENT,
+      bounds: { left: 0.25, top: 10.25, right: 1.25, bottom: 11.25 },
+    };
+    const { command } = createHarness(fractionalBounds);
+
+    expect(() =>
+      (command as any).resolveTapPoint(
+        fractionalBounds,
+        { width: 600, height: 800 },
+        { x: 0, y: 0 },
+      ),
+    ).toThrow("outside element bounds");
   });
 
   test("rejects a target for an element without an addressable pixel", () => {

--- a/test/features/action/TapOnElement.relativePosition.test.ts
+++ b/test/features/action/TapOnElement.relativePosition.test.ts
@@ -39,16 +39,30 @@ function createHarness(element: Element = SPANNABLE_TEXT_ELEMENT) {
     containerFound: true,
     stats: { durationMs: 0, requestCount: 1, changeCount: 0 },
   });
-  spyOn(command as any, "resolveTapTargetElement").mockReturnValue({
+  const resolveTapTargetElement = spyOn(command as any, "resolveTapTargetElement").mockReturnValue({
     element,
     usedParent: false,
   });
-  spyOn((command as any).strategy, "isAccessibilityServiceEnabled").mockResolvedValue(false);
-  spyOn((command as any).selectionStateTracker, "prepare").mockResolvedValue(null);
+  const isAccessibilityServiceEnabled = spyOn(
+    (command as any).strategy,
+    "isAccessibilityServiceEnabled",
+  ).mockResolvedValue(false);
+  const prepareSelectionState = spyOn(
+    (command as any).selectionStateTracker,
+    "prepare",
+  ).mockResolvedValue(null);
   spyOn((command as any).selectionStateTracker, "finalize").mockResolvedValue([]);
   const executeAndroidTap = spyOn(command as any, "executeAndroidTap").mockResolvedValue(undefined);
 
-  return { command, executeAndroidTap, observation, searchForElement };
+  return {
+    command,
+    executeAndroidTap,
+    isAccessibilityServiceEnabled,
+    observation,
+    prepareSelectionState,
+    resolveTapTargetElement,
+    searchForElement,
+  };
 }
 
 describe("TapOnElement relative position", () => {
@@ -99,6 +113,19 @@ describe("TapOnElement relative position", () => {
       expect.not.objectContaining({ relativePosition: expect.anything() }),
       false,
     );
+  });
+
+  test("skips best-effort selection capture before a precise coordinate tap", async () => {
+    const { command, prepareSelectionState } = createHarness();
+
+    const result = await command.execute({
+      action: "tap",
+      elementId: "test:id/spannable_text",
+      relativePosition: { x: 0.98, y: 0.5 },
+    });
+
+    expect(result).toMatchObject({ success: true, x: 491, y: 230 });
+    expect(prepareSelectionState).not.toHaveBeenCalled();
   });
 
   test("resolves against the stable final element bounds", async () => {
@@ -168,6 +195,132 @@ describe("TapOnElement relative position", () => {
       stableElement,
       undefined,
       expect.anything(),
+      false,
+    );
+  });
+
+  test("uses refreshed screen dimensions while polling for the target", async () => {
+    const refreshedElement = {
+      ...SPANNABLE_TEXT_ELEMENT,
+      bounds: { left: 650, top: 100, right: 700, bottom: 200 },
+    };
+    const {
+      command,
+      executeAndroidTap,
+      observation,
+      searchForElement,
+    } = createHarness(refreshedElement);
+    searchForElement.mockRestore();
+    const refreshedHierarchy = {
+      hierarchy: { node: { text: "refreshed" } },
+      screenWidth: 800,
+      screenHeight: 600,
+    };
+    spyOn(command as any, "findElementInHierarchy").mockImplementation(
+      (_options: unknown, hierarchy: unknown) => ({
+        selection: hierarchy === observation.viewHierarchy
+          ? { element: null }
+          : {
+            element: refreshedElement,
+            indexInMatches: 0,
+            totalMatches: 1,
+            strategy: "first",
+          },
+        containerFound: true,
+      }),
+    );
+    spyOn(command as any, "refreshViewHierarchy").mockResolvedValue(refreshedHierarchy);
+
+    const result = await command.execute({
+      action: "tap",
+      elementId: "test:id/spannable_text",
+      relativePosition: { x: 1, y: 0.5 },
+    });
+
+    expect(result).toMatchObject({ success: true, x: 699, y: 150 });
+    expect(executeAndroidTap).toHaveBeenCalledWith(
+      "tap",
+      699,
+      150,
+      expect.any(Number),
+      refreshedElement,
+      undefined,
+      expect.anything(),
+      false,
+    );
+  });
+
+  test("polls visibility using the promoted tap parent", async () => {
+    const child = {
+      ...SPANNABLE_TEXT_ELEMENT,
+      clickable: false,
+      bounds: { left: 0, top: 10, right: 100, bottom: 50 },
+    };
+    const offscreenParent = {
+      ...SPANNABLE_TEXT_ELEMENT,
+      text: "parent",
+      bounds: { left: -400, top: 0, right: 600, bottom: 100 },
+    };
+    const onscreenParent = {
+      ...offscreenParent,
+      bounds: { left: 0, top: 0, right: 1000, bottom: 100 },
+    };
+    const {
+      command,
+      executeAndroidTap,
+      isAccessibilityServiceEnabled,
+      observation,
+      resolveTapTargetElement,
+      searchForElement,
+    } = createHarness(child);
+    isAccessibilityServiceEnabled.mockResolvedValue(true);
+    searchForElement.mockRestore();
+    const initialHierarchy = observation.viewHierarchy;
+    const refreshedHierarchy = {
+      hierarchy: { node: { text: "refreshed" } },
+      screenWidth: 1000,
+      screenHeight: 800,
+    };
+    spyOn(command as any, "findElementInHierarchy").mockReturnValue({
+      selection: {
+        element: child,
+        indexInMatches: 0,
+        totalMatches: 1,
+        strategy: "first",
+      },
+      containerFound: true,
+    });
+    resolveTapTargetElement.mockImplementation(
+      (_element: unknown, hierarchy: unknown) => ({
+        element: hierarchy === initialHierarchy
+          ? offscreenParent
+          : onscreenParent,
+        usedParent: true,
+      }),
+    );
+    spyOn(command as any, "refreshViewHierarchy").mockResolvedValue(refreshedHierarchy);
+
+    const result = await command.execute({
+      action: "tap",
+      elementId: "test:id/spannable_text",
+      relativePosition: { x: 0, y: 0.5 },
+    });
+
+    expect(result).toMatchObject({ success: true, x: 0, y: 50 });
+    expect(executeAndroidTap).toHaveBeenCalledWith(
+      "tap",
+      0,
+      50,
+      expect.any(Number),
+      onscreenParent,
+      undefined,
+      expect.anything(),
+      true,
+    );
+    expect(resolveTapTargetElement).toHaveBeenCalledWith(
+      child,
+      refreshedHierarchy,
+      "tap",
       false,
     );
   });

--- a/test/features/action/TapOnElement.relativePosition.test.ts
+++ b/test/features/action/TapOnElement.relativePosition.test.ts
@@ -338,7 +338,7 @@ describe("TapOnElement relative position", () => {
         elementId: "test:id/spannable_text",
         relativePosition: { x: 0.98, y: 0.5 },
       },
-      true,
+      false,
     );
 
     expect(semanticActions).toEqual([]);

--- a/test/features/action/TapOnElement.relativePosition.test.ts
+++ b/test/features/action/TapOnElement.relativePosition.test.ts
@@ -204,12 +204,8 @@ describe("TapOnElement relative position", () => {
       ...SPANNABLE_TEXT_ELEMENT,
       bounds: { left: 650, top: 100, right: 700, bottom: 200 },
     };
-    const {
-      command,
-      executeAndroidTap,
-      observation,
-      searchForElement,
-    } = createHarness(refreshedElement);
+    const { command, executeAndroidTap, observation, searchForElement } =
+      createHarness(refreshedElement);
     searchForElement.mockRestore();
     const refreshedHierarchy = {
       hierarchy: { node: { text: "refreshed" } },
@@ -218,14 +214,15 @@ describe("TapOnElement relative position", () => {
     };
     spyOn(command as any, "findElementInHierarchy").mockImplementation(
       (_options: unknown, hierarchy: unknown) => ({
-        selection: hierarchy === observation.viewHierarchy
-          ? { element: null }
-          : {
-            element: refreshedElement,
-            indexInMatches: 0,
-            totalMatches: 1,
-            strategy: "first",
-          },
+        selection:
+          hierarchy === observation.viewHierarchy
+            ? { element: null }
+            : {
+                element: refreshedElement,
+                indexInMatches: 0,
+                totalMatches: 1,
+                strategy: "first",
+              },
         containerFound: true,
       }),
     );
@@ -290,14 +287,10 @@ describe("TapOnElement relative position", () => {
       },
       containerFound: true,
     });
-    resolveTapTargetElement.mockImplementation(
-      (_element: unknown, hierarchy: unknown) => ({
-        element: hierarchy === initialHierarchy
-          ? offscreenParent
-          : onscreenParent,
-        usedParent: true,
-      }),
-    );
+    resolveTapTargetElement.mockImplementation((_element: unknown, hierarchy: unknown) => ({
+      element: hierarchy === initialHierarchy ? offscreenParent : onscreenParent,
+      usedParent: true,
+    }));
     spyOn(command as any, "refreshViewHierarchy").mockResolvedValue(refreshedHierarchy);
 
     const result = await command.execute({
@@ -317,12 +310,7 @@ describe("TapOnElement relative position", () => {
       expect.anything(),
       true,
     );
-    expect(resolveTapTargetElement).toHaveBeenCalledWith(
-      child,
-      refreshedHierarchy,
-      "tap",
-      false,
-    );
+    expect(resolveTapTargetElement).toHaveBeenCalledWith(child, refreshedHierarchy, "tap", false);
   });
 
   test("hashes the stable hierarchy before checking whether to retry", async () => {
@@ -334,13 +322,12 @@ describe("TapOnElement relative position", () => {
       tapElement: SPANNABLE_TEXT_ELEMENT,
       usedParent: false,
     });
-    spyOn(command as any, "hashViewHierarchy").mockImplementation(
-      (hierarchy: unknown) => hierarchy === stableHierarchy ? "stable-hash" : "initial-hash",
+    spyOn(command as any, "hashViewHierarchy").mockImplementation((hierarchy: unknown) =>
+      hierarchy === stableHierarchy ? "stable-hash" : "initial-hash",
     );
-    const retryTapIfNoChange = spyOn(
-      command as any,
-      "retryTapIfNoChange",
-    ).mockResolvedValue(undefined);
+    const retryTapIfNoChange = spyOn(command as any, "retryTapIfNoChange").mockResolvedValue(
+      undefined,
+    );
 
     await command.execute({
       action: "tap",
@@ -508,8 +495,6 @@ describe("TapOnElement relative position", () => {
     );
 
     expect(semanticActions).toEqual([]);
-    expect(adb.getAllCommands()).toEqual([
-      "shell input touchscreen swipe 491 230 491 230 750",
-    ]);
+    expect(adb.getAllCommands()).toEqual(["shell input touchscreen swipe 491 230 491 230 750"]);
   });
 });

--- a/test/features/action/TapOnElement.relativePosition.test.ts
+++ b/test/features/action/TapOnElement.relativePosition.test.ts
@@ -1,0 +1,196 @@
+import { describe, expect, spyOn, test } from "bun:test";
+import type { Element } from "../../../src/models";
+import { TapOnElement } from "../../../src/features/action/TapOnElement";
+import { FakeAccessibilityDetector } from "../../fakes/FakeAccessibilityDetector";
+import { FakeAdbClient } from "../../fakes/FakeAdbClient";
+import { FakeTimer } from "../../fakes/FakeTimer";
+
+const SPANNABLE_TEXT_ELEMENT: Element = {
+  "resource-id": "test:id/spannable_text",
+  class: "android.widget.TextView",
+  text: "Left link and ordinary text and right link",
+  clickable: true,
+  bounds: { left: 100, top: 200, right: 500, bottom: 260 },
+};
+
+function createHarness(element: Element = SPANNABLE_TEXT_ELEMENT) {
+  const accessibilityDetector = new FakeAccessibilityDetector();
+  accessibilityDetector.setTalkBackEnabled(false);
+  const command = new TapOnElement(
+    { name: "test-device", platform: "android", deviceId: "emulator-5554" } as any,
+    new FakeAdbClient() as any,
+    {
+      accessibilityDetector,
+      timer: new FakeTimer(),
+    },
+  );
+  const observation = {
+    viewHierarchy: { hierarchy: {} },
+    screenSize: { width: 600, height: 800 },
+  } as any;
+
+  spyOn(command as any, "observedInteraction").mockImplementation(async (block: any) => ({
+    ...(await block(observation)),
+    observation,
+  }));
+  spyOn(command as any, "searchForElement").mockResolvedValue({
+    selection: { element, indexInMatches: 0, totalMatches: 1, strategy: "first" },
+    viewHierarchy: observation.viewHierarchy,
+    containerFound: true,
+    stats: { durationMs: 0, requestCount: 1, changeCount: 0 },
+  });
+  spyOn(command as any, "resolveTapTargetElement").mockReturnValue({
+    element,
+    usedParent: false,
+  });
+  spyOn((command as any).strategy, "isAccessibilityServiceEnabled").mockResolvedValue(false);
+  spyOn((command as any).selectionStateTracker, "prepare").mockResolvedValue(null);
+  spyOn((command as any).selectionStateTracker, "finalize").mockResolvedValue([]);
+  const executeAndroidTap = spyOn(command as any, "executeAndroidTap").mockResolvedValue(undefined);
+
+  return { command, executeAndroidTap, observation };
+}
+
+describe("TapOnElement relative position", () => {
+  test.each([
+    ["left-edge ClickableSpan", { x: 0.02, y: 0.5 }, { x: 108, y: 230 }],
+    ["right-edge ClickableSpan", { x: 0.98, y: 0.5 }, { x: 491, y: 230 }],
+  ] as const)(
+    "targets a %s at the resolved coordinate",
+    async (_label, relativePosition, expected) => {
+      const { command, executeAndroidTap } = createHarness();
+
+      const result = await command.execute({
+        action: "tap",
+        elementId: "test:id/spannable_text",
+        relativePosition,
+      });
+
+      expect(result).toMatchObject({ success: true, ...expected });
+      expect(executeAndroidTap).toHaveBeenCalledWith(
+        "tap",
+        expected.x,
+        expected.y,
+        expect.any(Number),
+        SPANNABLE_TEXT_ELEMENT,
+        undefined,
+        expect.objectContaining({ relativePosition }),
+        false,
+      );
+    },
+  );
+
+  test("preserves center tapping when relativePosition is omitted", async () => {
+    const { command, executeAndroidTap } = createHarness();
+
+    const result = await command.execute({
+      action: "tap",
+      elementId: "test:id/spannable_text",
+    });
+
+    expect(result).toMatchObject({ success: true, x: 300, y: 230 });
+    expect(executeAndroidTap).toHaveBeenCalledWith(
+      "tap",
+      300,
+      230,
+      expect.any(Number),
+      SPANNABLE_TEXT_ELEMENT,
+      undefined,
+      expect.not.objectContaining({ relativePosition: expect.anything() }),
+      false,
+    );
+  });
+
+  test("resolves against the stable final element bounds", async () => {
+    const { command, executeAndroidTap, observation } = createHarness();
+    const stableElement = {
+      ...SPANNABLE_TEXT_ELEMENT,
+      bounds: { left: 200, top: 300, right: 600, bottom: 360 },
+    };
+    spyOn(command as any, "resolveAndroidStableTapTargetAfterRefreshes").mockResolvedValue({
+      ok: true,
+      viewHierarchy: observation.viewHierarchy,
+      tapElement: stableElement,
+      usedParent: false,
+    });
+
+    const result = await command.execute({
+      action: "tap",
+      elementId: "test:id/spannable_text",
+      relativePosition: { x: 0, y: 1 },
+      preTapStability: true,
+    });
+
+    expect(result).toMatchObject({ success: true, x: 200, y: 359 });
+    expect(executeAndroidTap).toHaveBeenCalledWith(
+      "tap",
+      200,
+      359,
+      expect.any(Number),
+      stableElement,
+      undefined,
+      expect.anything(),
+      false,
+    );
+  });
+
+  test("rejects a resolved point outside the screen before device contact", () => {
+    const partiallyOffscreen = {
+      ...SPANNABLE_TEXT_ELEMENT,
+      bounds: { left: -40, top: 200, right: 360, bottom: 260 },
+    };
+    const { command, executeAndroidTap } = createHarness(partiallyOffscreen);
+
+    expect(() =>
+      (command as any).resolveTapPoint(
+        partiallyOffscreen,
+        { width: 600, height: 800 },
+        { x: 0, y: 0.5 },
+      ),
+    ).toThrow("outside screen bounds");
+    expect(executeAndroidTap).not.toHaveBeenCalled();
+  });
+
+  test("rejects a target for an element without an addressable pixel", () => {
+    const zeroWidth = {
+      ...SPANNABLE_TEXT_ELEMENT,
+      bounds: { left: 100, top: 200, right: 100, bottom: 260 },
+    };
+    const { command, executeAndroidTap } = createHarness(zeroWidth);
+
+    expect(() =>
+      (command as any).resolveTapPoint(zeroWidth, { width: 600, height: 800 }, { x: 0.5, y: 0.5 }),
+    ).toThrow("valid element bounds");
+    expect(executeAndroidTap).not.toHaveBeenCalled();
+  });
+
+  test("rejects relative positioning on iOS and for focus actions", () => {
+    const { command } = createHarness();
+
+    expect(
+      (command as any).validateOptions({
+        action: "tap",
+        elementId: "test:id/spannable_text",
+        relativePosition: { x: 0.5, y: 0.5 },
+      }),
+    ).toBeNull();
+
+    (command as any).device.platform = "ios";
+    expect(
+      (command as any).validateOptions({
+        action: "tap",
+        elementId: "test:id/spannable_text",
+        relativePosition: { x: 0.5, y: 0.5 },
+      }),
+    ).toContain("Android");
+
+    (command as any).device.platform = "android";
+    expect(
+      (command as any).validateOptions({
+        action: "focus",
+        elementId: "test:id/spannable_text",
+        relativePosition: { x: 0.5, y: 0.5 },
+      }),
+    ).toContain("focus");
+  });
+});

--- a/test/features/action/TapOnElement.talkback.test.ts
+++ b/test/features/action/TapOnElement.talkback.test.ts
@@ -586,17 +586,36 @@ describe("TapOnElement TalkBackTapStrategy delegation", () => {
       expect(fakeTalkBackStrategy.fallbackCalls[0].action).toBe("doubleTap");
     });
 
-    test("precise doubleTap retries only the missing second tap", async () => {
-      fakeTalkBackStrategy.setFallbackResult({
+    test("precise tap focuses the requested coordinate before activating it", async () => {
+      const element = makeElement();
+
+      await (tapOnElement as any).executeAndroidTapWithAccessibility(
+        "tap",
+        80,
+        40,
+        element,
+        500,
+        { relativePosition: { x: 0.8, y: 0.4 } },
+        undefined
+      );
+
+      expect(fakeTalkBackStrategy.preciseTapCalls).toEqual([{ x: 80, y: 40 }]);
+      expect(fakeTalkBackStrategy.fallbackCalls).toHaveLength(0);
+      expect(executeAndroidTapWithCoordinates).not.toHaveBeenCalled();
+    });
+
+    test("precise tap retries only the missing second activation tap", async () => {
+      fakeTalkBackStrategy.setPreciseTapResult({
         success: false,
         method: "coordinate-fallback",
         error: "Second tap failed",
+        focusCompleted: true,
         completedTaps: 1
       });
       const element = makeElement();
 
       await (tapOnElement as any).executeAndroidTapWithAccessibility(
-        "doubleTap",
+        "tap",
         50,
         50,
         element,
@@ -605,9 +624,51 @@ describe("TapOnElement TalkBackTapStrategy delegation", () => {
         undefined
       );
 
-      expect(fakeTalkBackStrategy.fallbackCalls).toHaveLength(1);
+      expect(fakeTalkBackStrategy.preciseTapCalls).toEqual([{ x: 50, y: 50 }]);
       expect(executeAndroidTapWithCoordinates).toHaveBeenCalledWith(
         "tap",
+        50,
+        50,
+        500,
+        element,
+        undefined,
+        true
+      );
+    });
+
+    test("precise tap retries focus and activation when coordinate focus fails", async () => {
+      fakeTalkBackStrategy.setPreciseTapResult({
+        success: false,
+        method: "coordinate-fallback",
+        error: "Focus tap failed",
+        focusCompleted: false,
+        completedTaps: 0
+      });
+      const element = makeElement();
+
+      await (tapOnElement as any).executeAndroidTapWithAccessibility(
+        "tap",
+        50,
+        50,
+        element,
+        500,
+        { relativePosition: { x: 0.5, y: 0.5 } },
+        undefined
+      );
+
+      expect(executeAndroidTapWithCoordinates).toHaveBeenNthCalledWith(
+        1,
+        "tap",
+        50,
+        50,
+        500,
+        element,
+        undefined,
+        true
+      );
+      expect(executeAndroidTapWithCoordinates).toHaveBeenNthCalledWith(
+        2,
+        "doubleTap",
         50,
         50,
         500,

--- a/test/features/action/TapOnElement.talkback.test.ts
+++ b/test/features/action/TapOnElement.talkback.test.ts
@@ -131,6 +131,39 @@ describe("TapOnElement TalkBack mode detection", () => {
       expect(executeAndroidTapWithCoordinates).not.toHaveBeenCalled();
     });
 
+    test("uses the requested coordinate instead of semantic activation for a relative position", async () => {
+      const element = {
+        "bounds": { left: 100, top: 200, right: 500, bottom: 260 },
+        "resource-id": "test:id/spannable_text",
+        "text": "Left link and ordinary text and right link",
+      } as any;
+      const options = {
+        action: "tap" as const,
+        elementId: "test:id/spannable_text",
+        relativePosition: { x: 0.98, y: 0.5 },
+      };
+
+      await (tapOnElement as any).executeAndroidTap(
+        "tap",
+        491,
+        230,
+        500,
+        element,
+        undefined,
+        options
+      );
+
+      expect(executeAndroidTapWithCoordinates).toHaveBeenCalledWith(
+        "tap",
+        491,
+        230,
+        500,
+        element,
+        undefined
+      );
+      expect(executeAndroidTapWithAccessibility).not.toHaveBeenCalled();
+    });
+
     test("passes options to accessibility method", async () => {
       const element = {
         "bounds": { left: 0, top: 0, right: 100, bottom: 100 },

--- a/test/features/action/TapOnElement.talkback.test.ts
+++ b/test/features/action/TapOnElement.talkback.test.ts
@@ -30,19 +30,19 @@ describe("TapOnElement TalkBack mode detection", () => {
       fakeAdb as any,
       {
         accessibilityDetector: fakeAccessibilityDetector,
-        timer: fakeTimer
-      }
+        timer: fakeTimer,
+      },
     );
 
     // Spy on the private methods to verify dispatch logic
     executeAndroidTapWithCoordinates = spyOn(
       tapOnElement as any,
-      "executeAndroidTapWithCoordinates"
+      "executeAndroidTapWithCoordinates",
     ).mockResolvedValue(undefined);
 
     executeAndroidTapWithAccessibility = spyOn(
       tapOnElement as any,
-      "executeAndroidTapWithAccessibility"
+      "executeAndroidTapWithAccessibility",
     ).mockResolvedValue(undefined);
   });
 
@@ -53,19 +53,14 @@ describe("TapOnElement TalkBack mode detection", () => {
 
     test("dispatches to coordinate-based tap method", async () => {
       const element = {
-        "bounds": { left: 0, top: 0, right: 100, bottom: 100 },
+        bounds: { left: 0, top: 0, right: 100, bottom: 100 },
         "resource-id": "test:id/button",
       } as any;
 
-      await (tapOnElement as any).executeAndroidTap(
-        "tap",
-        50,
-        50,
-        500,
-        element,
-        undefined,
-        { action: "tap", elementId: "test:id/button" }
-      );
+      await (tapOnElement as any).executeAndroidTap("tap", 50, 50, 500, element, undefined, {
+        action: "tap",
+        elementId: "test:id/button",
+      });
 
       expect(executeAndroidTapWithCoordinates).toHaveBeenCalledTimes(1);
       expect(executeAndroidTapWithAccessibility).not.toHaveBeenCalled();
@@ -73,25 +68,46 @@ describe("TapOnElement TalkBack mode detection", () => {
 
     test("uses coordinate method for all action types", async () => {
       const element = {
-        "bounds": { left: 0, top: 0, right: 100, bottom: 100 },
+        bounds: { left: 0, top: 0, right: 100, bottom: 100 },
         "resource-id": "test:id/button",
       } as any;
 
       // Test tap
       await (tapOnElement as any).executeAndroidTap("tap", 50, 50, 500, element);
-      expect(executeAndroidTapWithCoordinates).toHaveBeenCalledWith("tap", 50, 50, 500, element, undefined);
+      expect(executeAndroidTapWithCoordinates).toHaveBeenCalledWith(
+        "tap",
+        50,
+        50,
+        500,
+        element,
+        undefined,
+      );
 
       executeAndroidTapWithCoordinates.mockClear();
 
       // Test longPress
       await (tapOnElement as any).executeAndroidTap("longPress", 50, 50, 1000, element);
-      expect(executeAndroidTapWithCoordinates).toHaveBeenCalledWith("longPress", 50, 50, 1000, element, undefined);
+      expect(executeAndroidTapWithCoordinates).toHaveBeenCalledWith(
+        "longPress",
+        50,
+        50,
+        1000,
+        element,
+        undefined,
+      );
 
       executeAndroidTapWithCoordinates.mockClear();
 
       // Test doubleTap
       await (tapOnElement as any).executeAndroidTap("doubleTap", 50, 50, 500, element);
-      expect(executeAndroidTapWithCoordinates).toHaveBeenCalledWith("doubleTap", 50, 50, 500, element, undefined);
+      expect(executeAndroidTapWithCoordinates).toHaveBeenCalledWith(
+        "doubleTap",
+        50,
+        50,
+        500,
+        element,
+        undefined,
+      );
     });
   });
 
@@ -102,7 +118,7 @@ describe("TapOnElement TalkBack mode detection", () => {
 
     test("dispatches to accessibility-based tap method", async () => {
       const element = {
-        "bounds": { left: 0, top: 0, right: 100, bottom: 100 },
+        bounds: { left: 0, top: 0, right: 100, bottom: 100 },
         "resource-id": "test:id/button",
       } as any;
 
@@ -115,7 +131,7 @@ describe("TapOnElement TalkBack mode detection", () => {
         500,
         element,
         undefined,
-        options
+        options,
       );
 
       expect(executeAndroidTapWithAccessibility).toHaveBeenCalledTimes(1);
@@ -126,16 +142,16 @@ describe("TapOnElement TalkBack mode detection", () => {
         element,
         500,
         options,
-        undefined
+        undefined,
       );
       expect(executeAndroidTapWithCoordinates).not.toHaveBeenCalled();
     });
 
     test("uses the requested coordinate instead of semantic activation for a relative position", async () => {
       const element = {
-        "bounds": { left: 100, top: 200, right: 500, bottom: 260 },
+        bounds: { left: 100, top: 200, right: 500, bottom: 260 },
         "resource-id": "test:id/spannable_text",
-        "text": "Left link and ordinary text and right link",
+        text: "Left link and ordinary text and right link",
       } as any;
       const options = {
         action: "tap" as const,
@@ -150,7 +166,7 @@ describe("TapOnElement TalkBack mode detection", () => {
         500,
         element,
         undefined,
-        options
+        options,
       );
 
       expect(executeAndroidTapWithAccessibility).toHaveBeenCalledWith(
@@ -167,7 +183,7 @@ describe("TapOnElement TalkBack mode detection", () => {
 
     test("passes options to accessibility method", async () => {
       const element = {
-        "bounds": { left: 0, top: 0, right: 100, bottom: 100 },
+        bounds: { left: 0, top: 0, right: 100, bottom: 100 },
         "resource-id": "test:id/button",
       } as any;
 
@@ -184,7 +200,7 @@ describe("TapOnElement TalkBack mode detection", () => {
         500,
         element,
         undefined,
-        options
+        options,
       );
 
       expect(executeAndroidTapWithAccessibility).toHaveBeenCalledWith(
@@ -194,25 +210,19 @@ describe("TapOnElement TalkBack mode detection", () => {
         element,
         500,
         options,
-        undefined
+        undefined,
       );
     });
 
     test("dispatches to accessibility-based tap method for element without resource-id", async () => {
       const element = {
-        "bounds": { left: 0, top: 0, right: 100, bottom: 100 },
-        "text": "Settings",
+        bounds: { left: 0, top: 0, right: 100, bottom: 100 },
+        text: "Settings",
       } as any;
 
-      await (tapOnElement as any).executeAndroidTap(
-        "tap",
-        50,
-        50,
-        500,
-        element,
-        undefined,
-        { action: "tap" }
-      );
+      await (tapOnElement as any).executeAndroidTap("tap", 50, 50, 500, element, undefined, {
+        action: "tap",
+      });
 
       expect(executeAndroidTapWithAccessibility).toHaveBeenCalledTimes(1);
       expect(executeAndroidTapWithCoordinates).not.toHaveBeenCalled();
@@ -220,25 +230,65 @@ describe("TapOnElement TalkBack mode detection", () => {
 
     test("uses accessibility method for all action types", async () => {
       const element = {
-        "bounds": { left: 0, top: 0, right: 100, bottom: 100 },
+        bounds: { left: 0, top: 0, right: 100, bottom: 100 },
         "resource-id": "test:id/button",
       } as any;
 
       // Test tap
       await (tapOnElement as any).executeAndroidTap("tap", 50, 50, 500, element, undefined, {});
-      expect(executeAndroidTapWithAccessibility).toHaveBeenCalledWith("tap", 50, 50, element, 500, {}, undefined);
+      expect(executeAndroidTapWithAccessibility).toHaveBeenCalledWith(
+        "tap",
+        50,
+        50,
+        element,
+        500,
+        {},
+        undefined,
+      );
 
       executeAndroidTapWithAccessibility.mockClear();
 
       // Test longPress
-      await (tapOnElement as any).executeAndroidTap("longPress", 50, 50, 1000, element, undefined, {});
-      expect(executeAndroidTapWithAccessibility).toHaveBeenCalledWith("longPress", 50, 50, element, 1000, {}, undefined);
+      await (tapOnElement as any).executeAndroidTap(
+        "longPress",
+        50,
+        50,
+        1000,
+        element,
+        undefined,
+        {},
+      );
+      expect(executeAndroidTapWithAccessibility).toHaveBeenCalledWith(
+        "longPress",
+        50,
+        50,
+        element,
+        1000,
+        {},
+        undefined,
+      );
 
       executeAndroidTapWithAccessibility.mockClear();
 
       // Test doubleTap
-      await (tapOnElement as any).executeAndroidTap("doubleTap", 50, 50, 500, element, undefined, {});
-      expect(executeAndroidTapWithAccessibility).toHaveBeenCalledWith("doubleTap", 50, 50, element, 500, {}, undefined);
+      await (tapOnElement as any).executeAndroidTap(
+        "doubleTap",
+        50,
+        50,
+        500,
+        element,
+        undefined,
+        {},
+      );
+      expect(executeAndroidTapWithAccessibility).toHaveBeenCalledWith(
+        "doubleTap",
+        50,
+        50,
+        element,
+        500,
+        {},
+        undefined,
+      );
     });
   });
 
@@ -247,7 +297,7 @@ describe("TapOnElement TalkBack mode detection", () => {
       fakeAccessibilityDetector.setTalkBackEnabled(true);
 
       const element = {
-        "bounds": { left: 0, top: 0, right: 100, bottom: 100 },
+        bounds: { left: 0, top: 0, right: 100, bottom: 100 },
         "resource-id": "test:id/button",
       } as any;
 
@@ -265,7 +315,7 @@ describe("TapOnElement TalkBack mode detection", () => {
       fakeAccessibilityDetector.setTalkBackEnabled(false);
 
       const element = {
-        "bounds": { left: 0, top: 0, right: 100, bottom: 100 },
+        bounds: { left: 0, top: 0, right: 100, bottom: 100 },
         "resource-id": "test:id/button",
       } as any;
 
@@ -291,36 +341,36 @@ describe("TapOnElement TalkBack mode detection", () => {
         hierarchy: {
           node: {
             $: {
-              "class": "android.widget.LinearLayout",
-              "clickable": "true",
-              "bounds": { left: 0, top: 0, right: 100, bottom: 100 },
-              "resource-id": "parent:id"
+              class: "android.widget.LinearLayout",
+              clickable: "true",
+              bounds: { left: 0, top: 0, right: 100, bottom: 100 },
+              "resource-id": "parent:id",
             },
             node: [
               {
                 $: {
-                  "class": "android.widget.TextView",
-                  "text": "Markup",
-                  "bounds": { left: 10, top: 10, right: 50, bottom: 50 },
-                  "resource-id": "android:id/text1"
-                }
-              }
-            ]
-          }
-        }
+                  class: "android.widget.TextView",
+                  text: "Markup",
+                  bounds: { left: 10, top: 10, right: 50, bottom: 50 },
+                  "resource-id": "android:id/text1",
+                },
+              },
+            ],
+          },
+        },
       } as any;
 
       const childElement = {
-        "bounds": { left: 10, top: 10, right: 50, bottom: 50 },
-        "text": "Markup",
-        "resource-id": "android:id/text1"
+        bounds: { left: 10, top: 10, right: 50, bottom: 50 },
+        text: "Markup",
+        "resource-id": "android:id/text1",
       } as any;
 
       const result = (tapOnElement as any).resolveTapTargetElement(
         childElement,
         viewHierarchy,
         "tap",
-        true
+        true,
       );
 
       expect(result.usedParent).toBe(true);
@@ -332,28 +382,28 @@ describe("TapOnElement TalkBack mode detection", () => {
         hierarchy: {
           node: {
             $: {
-              "class": "android.widget.LinearLayout",
-              "clickable": "true",
-              "bounds": { left: 0, top: 0, right: 200, bottom: 80 },
-              "resource-id": "com.example:id/settings_row"
+              class: "android.widget.LinearLayout",
+              clickable: "true",
+              bounds: { left: 0, top: 0, right: 200, bottom: 80 },
+              "resource-id": "com.example:id/settings_row",
             },
             node: [
               {
                 $: {
-                  "class": "android.widget.TextView",
-                  "text": "Settings",
-                  "bounds": { left: 10, top: 10, right: 190, bottom: 70 }
+                  class: "android.widget.TextView",
+                  text: "Settings",
+                  bounds: { left: 10, top: 10, right: 190, bottom: 70 },
                   // no resource-id
-                }
-              }
-            ]
-          }
-        }
+                },
+              },
+            ],
+          },
+        },
       } as any;
 
       const textOnlyChild = {
         bounds: { left: 10, top: 10, right: 190, bottom: 70 },
-        text: "Settings"
+        text: "Settings",
         // no resource-id
       } as any;
 
@@ -362,7 +412,7 @@ describe("TapOnElement TalkBack mode detection", () => {
         textOnlyChild,
         viewHierarchy,
         "tap",
-        true
+        true,
       );
 
       expect(result.usedParent).toBe(true);
@@ -374,34 +424,34 @@ describe("TapOnElement TalkBack mode detection", () => {
         hierarchy: {
           node: {
             $: {
-              "class": "android.view.View",
-              "actions": ["click"],
-              "bounds": { left: 0, top: 0, right: 240, bottom: 96 },
-              "resource-id": "com.example:id/action_row"
+              class: "android.view.View",
+              actions: ["click"],
+              bounds: { left: 0, top: 0, right: 240, bottom: 96 },
+              "resource-id": "com.example:id/action_row",
             },
             node: [
               {
                 $: {
-                  "class": "android.widget.TextView",
-                  "text": "Manage account",
-                  "bounds": { left: 24, top: 24, right: 216, bottom: 72 }
-                }
-              }
-            ]
-          }
-        }
+                  class: "android.widget.TextView",
+                  text: "Manage account",
+                  bounds: { left: 24, top: 24, right: 216, bottom: 72 },
+                },
+              },
+            ],
+          },
+        },
       } as any;
 
       const textOnlyChild = {
         bounds: { left: 24, top: 24, right: 216, bottom: 72 },
-        text: "Manage account"
+        text: "Manage account",
       } as any;
 
       const result = (tapOnElement as any).resolveTapTargetElement(
         textOnlyChild,
         viewHierarchy,
         "tap",
-        true
+        true,
       );
 
       expect(result.usedParent).toBe(true);
@@ -413,32 +463,32 @@ describe("TapOnElement TalkBack mode detection", () => {
         hierarchy: {
           node: {
             $: {
-              "class": "android.view.View",
-              "actions": ["long_click"],
-              "bounds": { left: 0, top: 0, right: 240, bottom: 96 },
-              "resource-id": "com.example:id/action_row"
+              class: "android.view.View",
+              actions: ["long_click"],
+              bounds: { left: 0, top: 0, right: 240, bottom: 96 },
+              "resource-id": "com.example:id/action_row",
             },
             node: {
               $: {
-                "class": "android.widget.TextView",
-                "text": "Manage account",
-                "bounds": { left: 24, top: 24, right: 216, bottom: 72 }
-              }
-            }
-          }
-        }
+                class: "android.widget.TextView",
+                text: "Manage account",
+                bounds: { left: 24, top: 24, right: 216, bottom: 72 },
+              },
+            },
+          },
+        },
       } as any;
 
       const textOnlyChild = {
         bounds: { left: 24, top: 24, right: 216, bottom: 72 },
-        text: "Manage account"
+        text: "Manage account",
       } as any;
 
       const result = (tapOnElement as any).resolveTapTargetElement(
         textOnlyChild,
         viewHierarchy,
         "longPress",
-        true
+        true,
       );
 
       expect(result.usedParent).toBe(true);
@@ -450,32 +500,32 @@ describe("TapOnElement TalkBack mode detection", () => {
         hierarchy: {
           node: {
             $: {
-              "class": "android.widget.LinearLayout",
+              class: "android.widget.LinearLayout",
               "long-clickable": "true",
-              "bounds": { left: 0, top: 0, right: 100, bottom: 100 },
-              "resource-id": "parent:long"
+              bounds: { left: 0, top: 0, right: 100, bottom: 100 },
+              "resource-id": "parent:long",
             },
             node: {
               $: {
                 class: "android.widget.TextView",
                 text: "Markup",
-                bounds: { left: 10, top: 10, right: 50, bottom: 50 }
-              }
-            }
-          }
-        }
+                bounds: { left: 10, top: 10, right: 50, bottom: 50 },
+              },
+            },
+          },
+        },
       } as any;
 
       const childElement = {
         bounds: { left: 10, top: 10, right: 50, bottom: 50 },
-        text: "Markup"
+        text: "Markup",
       } as any;
 
       const result = (tapOnElement as any).resolveTapTargetElement(
         childElement,
         viewHierarchy,
         "longPress",
-        true
+        true,
       );
 
       expect(result.usedParent).toBe(true);
@@ -492,10 +542,11 @@ describe("TapOnElement TalkBackTapStrategy delegation", () => {
   let tapOnElement: TapOnElement;
   let executeAndroidTapWithCoordinates: any;
 
-  const makeElement = () => ({
-    "resource-id": "test:id/button",
-    "bounds": { left: 0, top: 0, right: 100, bottom: 100 }
-  } as any);
+  const makeElement = () =>
+    ({
+      "resource-id": "test:id/button",
+      bounds: { left: 0, top: 0, right: 100, bottom: 100 },
+    }) as any;
 
   beforeEach(() => {
     fakeAccessibilityDetector = new FakeAccessibilityDetector();
@@ -515,13 +566,13 @@ describe("TapOnElement TalkBackTapStrategy delegation", () => {
       {
         accessibilityDetector: fakeAccessibilityDetector,
         timer: fakeTimer,
-        talkBackStrategy: fakeTalkBackStrategy
-      }
+        talkBackStrategy: fakeTalkBackStrategy,
+      },
     );
 
     executeAndroidTapWithCoordinates = spyOn(
       tapOnElement as any,
-      "executeAndroidTapWithCoordinates"
+      "executeAndroidTapWithCoordinates",
     ).mockResolvedValue(undefined);
   });
 
@@ -530,7 +581,13 @@ describe("TapOnElement TalkBackTapStrategy delegation", () => {
       const element = makeElement();
 
       await (tapOnElement as any).executeAndroidTapWithAccessibility(
-        "tap", 50, 50, element, 500, {}, undefined
+        "tap",
+        50,
+        50,
+        element,
+        500,
+        {},
+        undefined,
       );
 
       expect(fakeTalkBackStrategy.directActivationCalls).toHaveLength(1);
@@ -542,12 +599,20 @@ describe("TapOnElement TalkBackTapStrategy delegation", () => {
 
     test("tap falls back to coordinate gesture when direct activation fails", async () => {
       fakeTalkBackStrategy.setDirectActivationResult({
-        success: false, method: "accessibility-action", error: "no node"
+        success: false,
+        method: "accessibility-action",
+        error: "no node",
       });
       const element = makeElement();
 
       await (tapOnElement as any).executeAndroidTapWithAccessibility(
-        "tap", 50, 50, element, 500, {}, undefined
+        "tap",
+        50,
+        50,
+        element,
+        500,
+        {},
+        undefined,
       );
 
       expect(fakeTalkBackStrategy.directActivationCalls).toHaveLength(1);
@@ -558,26 +623,49 @@ describe("TapOnElement TalkBackTapStrategy delegation", () => {
 
     test("tap falls back to ADB when direct activation and coordinate gesture both fail", async () => {
       fakeTalkBackStrategy.setDirectActivationResult({
-        success: false, method: "accessibility-action", error: "no node"
+        success: false,
+        method: "accessibility-action",
+        error: "no node",
       });
       fakeTalkBackStrategy.setFallbackResult({
-        success: false, method: "coordinate-fallback", error: "fallback failed"
+        success: false,
+        method: "coordinate-fallback",
+        error: "fallback failed",
       });
       const element = makeElement();
 
       await (tapOnElement as any).executeAndroidTapWithAccessibility(
-        "tap", 50, 50, element, 500, {}, undefined
+        "tap",
+        50,
+        50,
+        element,
+        500,
+        {},
+        undefined,
       );
 
       expect(fakeTalkBackStrategy.fallbackCalls).toHaveLength(1);
-      expect(executeAndroidTapWithCoordinates).toHaveBeenCalledWith("tap", 50, 50, 500, element, undefined);
+      expect(executeAndroidTapWithCoordinates).toHaveBeenCalledWith(
+        "tap",
+        50,
+        50,
+        500,
+        element,
+        undefined,
+      );
     });
 
     test("doubleTap uses coordinate fallback (no ACTION_CLICK, no cursor navigation)", async () => {
       const element = makeElement();
 
       await (tapOnElement as any).executeAndroidTapWithAccessibility(
-        "doubleTap", 50, 50, element, 500, {}, undefined
+        "doubleTap",
+        50,
+        50,
+        element,
+        500,
+        {},
+        undefined,
       );
 
       expect(fakeTalkBackStrategy.directActivationCalls).toHaveLength(0);
@@ -596,7 +684,7 @@ describe("TapOnElement TalkBackTapStrategy delegation", () => {
         element,
         500,
         { relativePosition: { x: 0.8, y: 0.4 } },
-        undefined
+        undefined,
       );
 
       expect(fakeTalkBackStrategy.preciseTapCalls).toEqual([{ x: 80, y: 40 }]);
@@ -614,7 +702,7 @@ describe("TapOnElement TalkBackTapStrategy delegation", () => {
         element,
         500,
         { relativePosition: { x: 0.8, y: 0.4 } },
-        undefined
+        undefined,
       );
 
       expect(fakeTalkBackStrategy.preciseTapCalls).toEqual([{ x: 80, y: 40 }]);
@@ -628,7 +716,7 @@ describe("TapOnElement TalkBackTapStrategy delegation", () => {
         method: "coordinate-fallback",
         error: "Second tap failed",
         focusCompleted: true,
-        completedTaps: 1
+        completedTaps: 1,
       });
       const element = makeElement();
 
@@ -639,7 +727,7 @@ describe("TapOnElement TalkBackTapStrategy delegation", () => {
         element,
         500,
         { relativePosition: { x: 0.5, y: 0.5 } },
-        undefined
+        undefined,
       );
 
       expect(fakeTalkBackStrategy.preciseTapCalls).toEqual([{ x: 50, y: 50 }]);
@@ -650,7 +738,7 @@ describe("TapOnElement TalkBackTapStrategy delegation", () => {
         500,
         element,
         undefined,
-        true
+        true,
       );
     });
 
@@ -660,7 +748,7 @@ describe("TapOnElement TalkBackTapStrategy delegation", () => {
         method: "coordinate-fallback",
         error: "Focus tap failed",
         focusCompleted: false,
-        completedTaps: 0
+        completedTaps: 0,
       });
       const element = makeElement();
 
@@ -671,7 +759,7 @@ describe("TapOnElement TalkBackTapStrategy delegation", () => {
         element,
         500,
         { relativePosition: { x: 0.5, y: 0.5 } },
-        undefined
+        undefined,
       );
 
       expect(executeAndroidTapWithCoordinates).toHaveBeenNthCalledWith(
@@ -682,7 +770,7 @@ describe("TapOnElement TalkBackTapStrategy delegation", () => {
         500,
         element,
         undefined,
-        true
+        true,
       );
       expect(executeAndroidTapWithCoordinates).toHaveBeenNthCalledWith(
         2,
@@ -692,7 +780,7 @@ describe("TapOnElement TalkBackTapStrategy delegation", () => {
         500,
         element,
         undefined,
-        true
+        true,
       );
     });
   });
@@ -707,13 +795,19 @@ describe("TapOnElement TalkBackTapStrategy delegation", () => {
         screenReaderNavigation: {
           reachable: true,
           traversalOrder: [makeElement()],
-          focusTrapDetected: false
-        }
+          focusTrapDetected: false,
+        },
       });
       const element = makeElement();
 
       const result = await (tapOnElement as any).executeAndroidTapWithAccessibility(
-        "tap", 50, 50, element, 500, navOptions, undefined
+        "tap",
+        50,
+        50,
+        element,
+        500,
+        navOptions,
+        undefined,
       );
 
       expect(fakeTalkBackStrategy.tapCalls).toHaveLength(1);
@@ -728,7 +822,13 @@ describe("TapOnElement TalkBackTapStrategy delegation", () => {
       const element = makeElement();
 
       await (tapOnElement as any).executeAndroidTapWithAccessibility(
-        "doubleTap", 50, 50, element, 500, navOptions, undefined
+        "doubleTap",
+        50,
+        50,
+        element,
+        500,
+        navOptions,
+        undefined,
       );
 
       // Both "tap" and "doubleTap" route to executeTap; TalkBack activation is
@@ -739,12 +839,20 @@ describe("TapOnElement TalkBackTapStrategy delegation", () => {
 
     test("falls back to coordinate gesture when cursor navigation fails", async () => {
       fakeTalkBackStrategy.setTapResult({
-        success: false, method: "focus-navigation", error: "Navigation failed"
+        success: false,
+        method: "focus-navigation",
+        error: "Navigation failed",
       });
       const element = makeElement();
 
       await (tapOnElement as any).executeAndroidTapWithAccessibility(
-        "tap", 50, 50, element, 500, navOptions, undefined
+        "tap",
+        50,
+        50,
+        element,
+        500,
+        navOptions,
+        undefined,
       );
 
       expect(fakeTalkBackStrategy.tapCalls).toHaveLength(1);
@@ -754,20 +862,37 @@ describe("TapOnElement TalkBackTapStrategy delegation", () => {
 
     test("falls back to ADB when cursor navigation and coordinate gesture both fail", async () => {
       fakeTalkBackStrategy.setTapResult({
-        success: false, method: "focus-navigation", error: "Navigation failed"
+        success: false,
+        method: "focus-navigation",
+        error: "Navigation failed",
       });
       fakeTalkBackStrategy.setFallbackResult({
-        success: false, method: "coordinate-fallback", error: "Fallback failed"
+        success: false,
+        method: "coordinate-fallback",
+        error: "Fallback failed",
       });
       const element = makeElement();
 
       await (tapOnElement as any).executeAndroidTapWithAccessibility(
-        "tap", 50, 50, element, 500, navOptions, undefined
+        "tap",
+        50,
+        50,
+        element,
+        500,
+        navOptions,
+        undefined,
       );
 
       expect(fakeTalkBackStrategy.tapCalls).toHaveLength(1);
       expect(fakeTalkBackStrategy.fallbackCalls).toHaveLength(1);
-      expect(executeAndroidTapWithCoordinates).toHaveBeenCalledWith("tap", 50, 50, 500, element, undefined);
+      expect(executeAndroidTapWithCoordinates).toHaveBeenCalledWith(
+        "tap",
+        50,
+        50,
+        500,
+        element,
+        undefined,
+      );
     });
   });
 
@@ -776,7 +901,7 @@ describe("TapOnElement TalkBackTapStrategy delegation", () => {
   describe("screen-reader-navigation feature flag (global opt-in)", () => {
     const makeFlaggedTapOnElement = (flagEnabled: boolean) => {
       const featureFlags = {
-        isEnabled: (key: string) => flagEnabled && key === "screen-reader-navigation"
+        isEnabled: (key: string) => flagEnabled && key === "screen-reader-navigation",
       } as unknown as FeatureFlagService;
       const tap = new TapOnElement(
         { name: "test-device", platform: "android", deviceId: "emulator-5554" } as any,
@@ -785,8 +910,8 @@ describe("TapOnElement TalkBackTapStrategy delegation", () => {
           accessibilityDetector: fakeAccessibilityDetector,
           timer: fakeTimer,
           talkBackStrategy: fakeTalkBackStrategy,
-          featureFlags
-        }
+          featureFlags,
+        },
       );
       spyOn(tap as any, "executeAndroidTapWithCoordinates").mockResolvedValue(undefined);
       return tap;
@@ -797,7 +922,13 @@ describe("TapOnElement TalkBackTapStrategy delegation", () => {
       const element = makeElement();
 
       await (tap as any).executeAndroidTapWithAccessibility(
-        "tap", 50, 50, element, 500, {}, undefined
+        "tap",
+        50,
+        50,
+        element,
+        500,
+        {},
+        undefined,
       );
 
       expect(fakeTalkBackStrategy.tapCalls).toHaveLength(1);
@@ -810,7 +941,13 @@ describe("TapOnElement TalkBackTapStrategy delegation", () => {
       const element = makeElement();
 
       await (tap as any).executeAndroidTapWithAccessibility(
-        "tap", 50, 50, element, 500, {}, undefined
+        "tap",
+        50,
+        50,
+        element,
+        500,
+        {},
+        undefined,
       );
 
       expect(fakeTalkBackStrategy.directActivationCalls).toHaveLength(1);
@@ -826,13 +963,19 @@ describe("TapOnElement TalkBackTapStrategy delegation", () => {
       };
 
       await (tapOnElement as any).executeAndroidTapWithAccessibility(
-        "longPress", 90, 50, element, 1000, options, undefined
+        "longPress",
+        90,
+        50,
+        element,
+        1000,
+        options,
+        undefined,
       );
 
       expect(fakeTalkBackStrategy.longPressCalls).toHaveLength(0);
       expect(fakeTalkBackStrategy.directActivationCalls).toHaveLength(0);
       expect(fakeTalkBackStrategy.fallbackCalls).toEqual([
-        { x: 90, y: 50, action: "longPress", durationMs: 1000 }
+        { x: 90, y: 50, action: "longPress", durationMs: 1000 },
       ]);
       expect(executeAndroidTapWithCoordinates).not.toHaveBeenCalled();
     });
@@ -841,30 +984,54 @@ describe("TapOnElement TalkBackTapStrategy delegation", () => {
       const element = makeElement();
 
       await (tapOnElement as any).executeAndroidTapWithAccessibility(
-        "longPress", 50, 50, element, 1000, {}, undefined
+        "longPress",
+        50,
+        50,
+        element,
+        1000,
+        {},
+        undefined,
       );
 
       expect(fakeTalkBackStrategy.tapCalls).toHaveLength(0);
       expect(fakeTalkBackStrategy.directActivationCalls).toHaveLength(0);
       expect(fakeTalkBackStrategy.longPressCalls).toHaveLength(1);
       expect(fakeTalkBackStrategy.longPressCalls[0]).toMatchObject({
-        x: 50, y: 50, durationMs: 1000, element
+        x: 50,
+        y: 50,
+        durationMs: 1000,
+        element,
       });
       expect(fakeTalkBackStrategy.fallbackCalls).toHaveLength(0);
     });
 
     test("falls back to ADB tap when executeLongPress fails", async () => {
       fakeTalkBackStrategy.setLongPressResult({
-        success: false, method: "coordinate-fallback", error: "Long press failed"
+        success: false,
+        method: "coordinate-fallback",
+        error: "Long press failed",
       });
       const element = makeElement();
 
       await (tapOnElement as any).executeAndroidTapWithAccessibility(
-        "longPress", 50, 50, element, 1000, {}, undefined
+        "longPress",
+        50,
+        50,
+        element,
+        1000,
+        {},
+        undefined,
       );
 
       expect(fakeTalkBackStrategy.longPressCalls).toHaveLength(1);
-      expect(executeAndroidTapWithCoordinates).toHaveBeenCalledWith("longPress", 50, 50, 1000, element, undefined);
+      expect(executeAndroidTapWithCoordinates).toHaveBeenCalledWith(
+        "longPress",
+        50,
+        50,
+        1000,
+        element,
+        undefined,
+      );
     });
 
     test("reports a rejected advertised semantic long press without a coordinate fallback", async () => {
@@ -878,8 +1045,14 @@ describe("TapOnElement TalkBackTapStrategy delegation", () => {
 
       await expect(
         (tapOnElement as any).executeAndroidTapWithAccessibility(
-          "longPress", 50, 50, element, 1000, {}, undefined
-        )
+          "longPress",
+          50,
+          50,
+          element,
+          1000,
+          {},
+          undefined,
+        ),
       ).rejects.toThrow("Semantic long press failed");
 
       expect(fakeTalkBackStrategy.longPressCalls).toHaveLength(1);
@@ -891,14 +1064,14 @@ describe("TapOnElement TalkBackTapStrategy delegation", () => {
 describe("TapOnElement screen-reader navigation result", () => {
   const element = {
     "resource-id": "test:id/button",
-    "bounds": { left: 0, top: 0, right: 100, bottom: 100 },
-    "clickable": true
+    bounds: { left: 0, top: 0, right: 100, bottom: 100 },
+    clickable: true,
   } as any;
 
   const journey = {
     reachable: true,
     traversalOrder: [element],
-    focusTrapDetected: false
+    focusTrapDetected: false,
   };
 
   const createCommand = (tapResult: any) => {
@@ -913,31 +1086,40 @@ describe("TapOnElement screen-reader navigation result", () => {
         accessibilityDetector,
         timer: new FakeTimer(),
         talkBackStrategy: strategy,
-        featureFlags: { isEnabled: (key: string) => key === "screen-reader-navigation" } as FeatureFlagService
-      }
+        featureFlags: {
+          isEnabled: (key: string) => key === "screen-reader-navigation",
+        } as FeatureFlagService,
+      },
     );
     const observation = {
       viewHierarchy: { hierarchy: {} },
-      screenSize: { width: 100, height: 100 }
+      screenSize: { width: 100, height: 100 },
     } as any;
     spyOn(command as any, "observedInteraction").mockImplementation(async (block: any) => ({
       ...(await block(observation)),
-      observation
+      observation,
     }));
     spyOn(command as any, "searchForElement").mockResolvedValue({
       selection: { element, indexInMatches: 0, totalMatches: 1, strategy: "first" },
       viewHierarchy: observation.viewHierarchy,
       containerFound: true,
-      stats: { durationMs: 0, requestCount: 0, changeCount: 0 }
+      stats: { durationMs: 0, requestCount: 0, changeCount: 0 },
     });
-    spyOn(command as any, "resolveTapTargetElement").mockReturnValue({ element, usedParent: false });
+    spyOn(command as any, "resolveTapTargetElement").mockReturnValue({
+      element,
+      usedParent: false,
+    });
     spyOn((command as any).selectionStateTracker, "prepare").mockResolvedValue(null);
     spyOn((command as any).selectionStateTracker, "finalize").mockResolvedValue([]);
     return command;
   };
 
   test("returns the successful cursor journey from public execute", async () => {
-    const command = createCommand({ success: true, method: "focus-navigation", screenReaderNavigation: journey });
+    const command = createCommand({
+      success: true,
+      method: "focus-navigation",
+      screenReaderNavigation: journey,
+    });
 
     const result = await command.execute({ action: "tap", elementId: "test:id/button" });
 
@@ -951,7 +1133,7 @@ describe("TapOnElement screen-reader navigation result", () => {
       success: false,
       method: "focus-navigation",
       error: "Focus navigation is not converging on the target.",
-      screenReaderNavigation: failedJourney
+      screenReaderNavigation: failedJourney,
     });
 
     const result = await command.execute({ action: "tap", elementId: "test:id/button" });

--- a/test/features/action/TapOnElement.talkback.test.ts
+++ b/test/features/action/TapOnElement.talkback.test.ts
@@ -153,16 +153,16 @@ describe("TapOnElement TalkBack mode detection", () => {
         options
       );
 
-      expect(executeAndroidTapWithCoordinates).toHaveBeenCalledWith(
+      expect(executeAndroidTapWithAccessibility).toHaveBeenCalledWith(
         "tap",
         491,
         230,
-        500,
         element,
+        500,
+        options,
         undefined,
-        true
       );
-      expect(executeAndroidTapWithAccessibility).not.toHaveBeenCalled();
+      expect(executeAndroidTapWithCoordinates).not.toHaveBeenCalled();
     });
 
     test("passes options to accessibility method", async () => {
@@ -709,6 +709,24 @@ describe("TapOnElement TalkBackTapStrategy delegation", () => {
   });
 
   describe("longPress (unaffected by navigation mode)", () => {
+    test("uses a CtrlProxy coordinate gesture for a precise long press", async () => {
+      const element = makeElement();
+      const options = {
+        relativePosition: { x: 0.9, y: 0.5 },
+      };
+
+      await (tapOnElement as any).executeAndroidTapWithAccessibility(
+        "longPress", 90, 50, element, 1000, options, undefined
+      );
+
+      expect(fakeTalkBackStrategy.longPressCalls).toHaveLength(0);
+      expect(fakeTalkBackStrategy.directActivationCalls).toHaveLength(0);
+      expect(fakeTalkBackStrategy.fallbackCalls).toEqual([
+        { x: 90, y: 50, action: "longPress", durationMs: 1000 }
+      ]);
+      expect(executeAndroidTapWithCoordinates).not.toHaveBeenCalled();
+    });
+
     test("uses executeLongPress for longPress action", async () => {
       const element = makeElement();
 

--- a/test/features/action/TapOnElement.talkback.test.ts
+++ b/test/features/action/TapOnElement.talkback.test.ts
@@ -585,6 +585,37 @@ describe("TapOnElement TalkBackTapStrategy delegation", () => {
       expect(fakeTalkBackStrategy.fallbackCalls).toHaveLength(1);
       expect(fakeTalkBackStrategy.fallbackCalls[0].action).toBe("doubleTap");
     });
+
+    test("precise doubleTap retries only the missing second tap", async () => {
+      fakeTalkBackStrategy.setFallbackResult({
+        success: false,
+        method: "coordinate-fallback",
+        error: "Second tap failed",
+        completedTaps: 1
+      });
+      const element = makeElement();
+
+      await (tapOnElement as any).executeAndroidTapWithAccessibility(
+        "doubleTap",
+        50,
+        50,
+        element,
+        500,
+        { relativePosition: { x: 0.5, y: 0.5 } },
+        undefined
+      );
+
+      expect(fakeTalkBackStrategy.fallbackCalls).toHaveLength(1);
+      expect(executeAndroidTapWithCoordinates).toHaveBeenCalledWith(
+        "tap",
+        50,
+        50,
+        500,
+        element,
+        undefined,
+        true
+      );
+    });
   });
 
   describe("opt-in screen-reader navigation (fidelity mode)", () => {

--- a/test/features/action/TapOnElement.talkback.test.ts
+++ b/test/features/action/TapOnElement.talkback.test.ts
@@ -159,7 +159,8 @@ describe("TapOnElement TalkBack mode detection", () => {
         230,
         500,
         element,
-        undefined
+        undefined,
+        true
       );
       expect(executeAndroidTapWithAccessibility).not.toHaveBeenCalled();
     });

--- a/test/features/action/TapOnElement.talkback.test.ts
+++ b/test/features/action/TapOnElement.talkback.test.ts
@@ -604,6 +604,24 @@ describe("TapOnElement TalkBackTapStrategy delegation", () => {
       expect(executeAndroidTapWithCoordinates).not.toHaveBeenCalled();
     });
 
+    test("precise doubleTap focuses the requested coordinate before activating it", async () => {
+      const element = makeElement();
+
+      await (tapOnElement as any).executeAndroidTapWithAccessibility(
+        "doubleTap",
+        80,
+        40,
+        element,
+        500,
+        { relativePosition: { x: 0.8, y: 0.4 } },
+        undefined
+      );
+
+      expect(fakeTalkBackStrategy.preciseTapCalls).toEqual([{ x: 80, y: 40 }]);
+      expect(fakeTalkBackStrategy.fallbackCalls).toHaveLength(0);
+      expect(executeAndroidTapWithCoordinates).not.toHaveBeenCalled();
+    });
+
     test("precise tap retries only the missing second activation tap", async () => {
       fakeTalkBackStrategy.setPreciseTapResult({
         success: false,

--- a/test/features/talkback/TalkBackTapStrategy.test.ts
+++ b/test/features/talkback/TalkBackTapStrategy.test.ts
@@ -23,14 +23,14 @@ describe("TalkBackTapStrategy", () => {
     mockExecutor = new FocusNavigationExecutor({
       matcher,
       pathCalculator: mockPathCalculator,
-      timer: fakeTimer
+      timer: fakeTimer,
     });
 
     strategy = new TalkBackTapStrategy({
       matcher,
       pathCalculator: mockPathCalculator,
       executor: mockExecutor,
-      timer: fakeTimer
+      timer: fakeTimer,
     });
 
     driver = new FakeTalkBackNavigationDriver();
@@ -39,7 +39,7 @@ describe("TalkBackTapStrategy", () => {
   describe("executeTap", () => {
     test("returns error when element has no identifying information", async () => {
       const element = {
-        bounds: { left: 0, top: 0, right: 100, bottom: 100 }
+        bounds: { left: 0, top: 0, right: 100, bottom: 100 },
         // no text, no resource-id, no content-desc
       } as Element;
 
@@ -53,13 +53,12 @@ describe("TalkBackTapStrategy", () => {
     test("navigates using text match when element has no resource-id", async () => {
       const element = {
         bounds: { left: 0, top: 0, right: 100, bottom: 100 },
-        text: "Button"
+        text: "Button",
       } as Element;
 
       driver.setElements([element], 0);
 
-      const navigateToElement = spyOn(mockExecutor, "navigateToElement")
-        .mockResolvedValue(true);
+      const navigateToElement = spyOn(mockExecutor, "navigateToElement").mockResolvedValue(true);
 
       const result = await strategy.executeTap("device-1", element, driver);
 
@@ -68,28 +67,27 @@ describe("TalkBackTapStrategy", () => {
       expect(result.screenReaderNavigation).toMatchObject({
         reachable: true,
         focusTrapDetected: false,
-        traversalOrder: [element]
+        traversalOrder: [element],
       });
       expect(navigateToElement).toHaveBeenCalledTimes(1);
       expect(navigateToElement).toHaveBeenCalledWith(
         "device-1",
         expect.anything(),
         expect.anything(),
-        expect.objectContaining({ verificationInterval: 1 })
+        expect.objectContaining({ verificationInterval: 1 }),
       );
       expect(driver.getTapCount()).toBe(2); // Double-tap to activate
     });
 
     test("navigates using content-desc match when element has no resource-id", async () => {
       const element = {
-        "bounds": { left: 0, top: 0, right: 100, bottom: 100 },
-        "content-desc": "Close dialog"
+        bounds: { left: 0, top: 0, right: 100, bottom: 100 },
+        "content-desc": "Close dialog",
       } as Element;
 
       driver.setElements([element], 0);
 
-      const navigateToElement = spyOn(mockExecutor, "navigateToElement")
-        .mockResolvedValue(true);
+      const navigateToElement = spyOn(mockExecutor, "navigateToElement").mockResolvedValue(true);
 
       const result = await strategy.executeTap("device-1", element, driver);
 
@@ -101,14 +99,13 @@ describe("TalkBackTapStrategy", () => {
     test("uses focus navigation for tap action", async () => {
       const element = {
         "resource-id": "test:id/button",
-        "bounds": { left: 0, top: 0, right: 100, bottom: 100 }
+        bounds: { left: 0, top: 0, right: 100, bottom: 100 },
       } as Element;
 
       // Set up driver with element in traversal order
       driver.setElements([element], 0);
 
-      const navigateToElement = spyOn(mockExecutor, "navigateToElement")
-        .mockResolvedValue(true);
+      const navigateToElement = spyOn(mockExecutor, "navigateToElement").mockResolvedValue(true);
 
       const result = await strategy.executeTap("device-1", element, driver);
 
@@ -121,13 +118,14 @@ describe("TalkBackTapStrategy", () => {
     test("returns error when focus navigation fails", async () => {
       const element = {
         "resource-id": "test:id/button",
-        "bounds": { left: 0, top: 0, right: 100, bottom: 100 }
+        bounds: { left: 0, top: 0, right: 100, bottom: 100 },
       } as Element;
 
       driver.setElements([element], 0);
 
-      const navigateToElement = spyOn(mockExecutor, "navigateToElement")
-        .mockRejectedValue(new Error("Navigation failed"));
+      const navigateToElement = spyOn(mockExecutor, "navigateToElement").mockRejectedValue(
+        new Error("Navigation failed"),
+      );
 
       const result = await strategy.executeTap("device-1", element, driver);
 
@@ -137,7 +135,7 @@ describe("TalkBackTapStrategy", () => {
       expect(result.screenReaderNavigation).toMatchObject({
         reachable: false,
         focusTrapDetected: false,
-        traversalOrder: [element]
+        traversalOrder: [element],
       });
       expect(navigateToElement).toHaveBeenCalledTimes(1);
     });
@@ -145,11 +143,11 @@ describe("TalkBackTapStrategy", () => {
     test("reports a focus trap when the convergence guard stops navigation", async () => {
       const element = {
         "resource-id": "test:id/button",
-        "bounds": { left: 0, top: 0, right: 100, bottom: 100 }
+        bounds: { left: 0, top: 0, right: 100, bottom: 100 },
       } as Element;
       driver.setElements([element], 0);
       spyOn(mockExecutor, "navigateToElement").mockRejectedValue(
-        new Error("Focus navigation is not converging on the target.")
+        new Error("Focus navigation is not converging on the target."),
       );
 
       const result = await strategy.executeTap("device-1", element, driver);
@@ -157,7 +155,7 @@ describe("TalkBackTapStrategy", () => {
       expect(result.screenReaderNavigation).toMatchObject({
         reachable: false,
         focusTrapDetected: true,
-        traversalOrder: [element]
+        traversalOrder: [element],
       });
     });
 
@@ -169,26 +167,23 @@ describe("TalkBackTapStrategy", () => {
       ["Focus navigation could not track the TalkBack cursor position. Try narrowing.", true],
       ["Focus navigation is not converging on the target. Try scrolling.", true],
       ["Navigation failed for an unrelated reason", false],
-    ])(
-      "maps navigation error %j to focusTrapDetected=%p",
-      async (message, expectedTrap) => {
-        const element = {
-          "resource-id": "test:id/button",
-          "bounds": { left: 0, top: 0, right: 100, bottom: 100 }
-        } as Element;
-        driver.setElements([element], 0);
-        spyOn(mockExecutor, "navigateToElement").mockRejectedValue(new Error(message as string));
+    ])("maps navigation error %j to focusTrapDetected=%p", async (message, expectedTrap) => {
+      const element = {
+        "resource-id": "test:id/button",
+        bounds: { left: 0, top: 0, right: 100, bottom: 100 },
+      } as Element;
+      driver.setElements([element], 0);
+      spyOn(mockExecutor, "navigateToElement").mockRejectedValue(new Error(message as string));
 
-        const result = await strategy.executeTap("device-1", element, driver);
+      const result = await strategy.executeTap("device-1", element, driver);
 
-        expect(result.screenReaderNavigation?.focusTrapDetected).toBe(expectedTrap as boolean);
-      }
-    );
+      expect(result.screenReaderNavigation?.focusTrapDetected).toBe(expectedTrap as boolean);
+    });
 
     test("uses ACTION_CLICK fallback if double-tap activation fails", async () => {
       const element = {
         "resource-id": "test:id/button",
-        "bounds": { left: 0, top: 0, right: 100, bottom: 100 }
+        bounds: { left: 0, top: 0, right: 100, bottom: 100 },
       } as Element;
 
       driver.setElements([element], 0);
@@ -209,7 +204,7 @@ describe("TalkBackTapStrategy", () => {
     test("returns failure when text-only element activation double-tap fails (no ACTION_CLICK fallback)", async () => {
       const element = {
         bounds: { left: 0, top: 0, right: 100, bottom: 100 },
-        text: "Button"
+        text: "Button",
       } as Element;
 
       driver.setElements([element], 0);
@@ -227,7 +222,7 @@ describe("TalkBackTapStrategy", () => {
     test("returns failure when text-only element second tap fails (no ACTION_CLICK fallback)", async () => {
       const element = {
         bounds: { left: 0, top: 0, right: 100, bottom: 100 },
-        text: "Button"
+        text: "Button",
       } as Element;
 
       driver.setElements([element], 0);
@@ -246,14 +241,19 @@ describe("TalkBackTapStrategy", () => {
     test("returns error if both double-tap and ACTION_CLICK fail", async () => {
       const element = {
         "resource-id": "test:id/button",
-        "bounds": { left: 0, top: 0, right: 100, bottom: 100 }
+        bounds: { left: 0, top: 0, right: 100, bottom: 100 },
       } as Element;
 
       driver.setElements([element], 0);
 
       spyOn(mockExecutor, "navigateToElement").mockResolvedValue(true);
       driver.queueTapResult({ success: false, totalTimeMs: 1, error: "tap failed" });
-      driver.setActionResult({ success: false, action: "click", totalTimeMs: 1, error: "click failed" });
+      driver.setActionResult({
+        success: false,
+        action: "click",
+        totalTimeMs: 1,
+        error: "click failed",
+      });
 
       const result = await strategy.executeTap("device-1", element, driver);
 
@@ -269,12 +269,12 @@ describe("TalkBackTapStrategy", () => {
       // The caller's element carries stale bounds (center 5,5)...
       const staleElement = {
         "resource-id": "test:id/button",
-        "bounds": { left: 0, top: 0, right: 10, bottom: 10 }
+        bounds: { left: 0, top: 0, right: 10, bottom: 10 },
       } as Element;
       // ...while the node TalkBack actually focused is elsewhere (center 600,700).
       const liveFocusedElement = {
         "resource-id": "test:id/button",
-        "bounds": { left: 500, top: 600, right: 700, bottom: 800 }
+        bounds: { left: 500, top: 600, right: 700, bottom: 800 },
       } as Element;
 
       driver.setElements([liveFocusedElement], 0);
@@ -293,7 +293,7 @@ describe("TalkBackTapStrategy", () => {
     // Regression for #3918: a bounds-less activation target must never tap (0,0).
     test("falls back to ACTION_CLICK (never taps 0,0) when the target has no bounds", async () => {
       const boundsLessElement = {
-        "resource-id": "test:id/button"
+        "resource-id": "test:id/button",
         // no bounds on the caller's element...
       } as Element;
       // ...and the live focused node also has no bounds.
@@ -330,13 +330,19 @@ describe("TalkBackTapStrategy", () => {
     test("returns error when navigation path cannot be calculated", async () => {
       const element = {
         "resource-id": "test:id/nonexistent",
-        "bounds": { left: 0, top: 0, right: 100, bottom: 100 }
+        bounds: { left: 0, top: 0, right: 100, bottom: 100 },
       } as Element;
 
       // Element not in traversal order
-      driver.setElements([
-        { "resource-id": "test:id/other", "bounds": { left: 0, top: 0, right: 50, bottom: 50 } } as Element
-      ], 0);
+      driver.setElements(
+        [
+          {
+            "resource-id": "test:id/other",
+            bounds: { left: 0, top: 0, right: 50, bottom: 50 },
+          } as Element,
+        ],
+        0,
+      );
 
       const result = await strategy.executeTap("device-1", element, driver);
 
@@ -348,7 +354,7 @@ describe("TalkBackTapStrategy", () => {
     test("returns error when traversal order request fails", async () => {
       const element = {
         "resource-id": "test:id/button",
-        "bounds": { left: 0, top: 0, right: 100, bottom: 100 }
+        bounds: { left: 0, top: 0, right: 100, bottom: 100 },
       } as Element;
 
       driver.queueTraversalResult({ error: "Service unavailable", totalTimeMs: 1 });
@@ -365,7 +371,7 @@ describe("TalkBackTapStrategy", () => {
     test("uses ACTION_LONG_CLICK when element has resource-id", async () => {
       const element = {
         "resource-id": "test:id/button",
-        "bounds": { left: 0, top: 0, right: 100, bottom: 100 }
+        bounds: { left: 0, top: 0, right: 100, bottom: 100 },
       } as Element;
 
       driver.setActionResult({ success: true, action: "long_click", totalTimeMs: 1 });
@@ -375,18 +381,26 @@ describe("TalkBackTapStrategy", () => {
       expect(result.success).toBe(true);
       expect(result.method).toBe("accessibility-action");
       expect(driver.actionHistory).toHaveLength(1);
-      expect(driver.actionHistory[0]).toEqual({ action: "long_click", resourceId: "test:id/button" });
+      expect(driver.actionHistory[0]).toEqual({
+        action: "long_click",
+        resourceId: "test:id/button",
+      });
       expect(driver.getTapCount()).toBe(0); // No coordinate taps
     });
 
     test("does not fall back when an advertised semantic long click fails", async () => {
       const element = {
         "test-tag": "message_row_42",
-        "actions": ["long_click"],
-        "bounds": { left: 0, top: 0, right: 100, bottom: 100 }
+        actions: ["long_click"],
+        bounds: { left: 0, top: 0, right: 100, bottom: 100 },
       } as Element;
 
-      driver.setActionResult({ success: false, action: "long_click", totalTimeMs: 1, error: "service unavailable" });
+      driver.setActionResult({
+        success: false,
+        action: "long_click",
+        totalTimeMs: 1,
+        error: "service unavailable",
+      });
 
       const result = await strategy.executeLongPress(50, 50, 1000, element, driver);
 
@@ -394,7 +408,7 @@ describe("TalkBackTapStrategy", () => {
       expect(result.method).toBe("accessibility-action");
       expect(result.error).toContain("service unavailable");
       expect(driver.actionHistory).toEqual([
-        { action: "long_click", selector: { testTag: "message_row_42" } }
+        { action: "long_click", selector: { testTag: "message_row_42" } },
       ]);
       expect(driver.getTapCount()).toBe(0);
     });
@@ -402,8 +416,8 @@ describe("TalkBackTapStrategy", () => {
     test("uses a coordinate fallback for a test tag when the runner lacks selector support", async () => {
       const element = {
         "test-tag": "message_row_42",
-        "actions": ["long_click"],
-        "bounds": { left: 0, top: 0, right: 100, bottom: 100 }
+        actions: ["long_click"],
+        bounds: { left: 0, top: 0, right: 100, bottom: 100 },
       } as Element;
       driver.setNodeActionSelectorsSupported(false);
 
@@ -418,8 +432,8 @@ describe("TalkBackTapStrategy", () => {
       const element = {
         "collection-row-index": 0,
         "collection-column-index": 0,
-        "actions": ["long_click"],
-        "bounds": { left: 0, top: 0, right: 100, bottom: 100 }
+        actions: ["long_click"],
+        bounds: { left: 0, top: 0, right: 100, bottom: 100 },
       } as Element;
 
       const result = await strategy.executeLongPress(50, 50, 1000, element, driver);
@@ -432,7 +446,7 @@ describe("TalkBackTapStrategy", () => {
     test("uses coordinate gesture directly when element has no resource-id", async () => {
       const element = {
         bounds: { left: 0, top: 0, right: 100, bottom: 100 },
-        text: "Button"
+        text: "Button",
       } as Element;
 
       const result = await strategy.executeLongPress(50, 50, 1000, element, driver);
@@ -447,10 +461,15 @@ describe("TalkBackTapStrategy", () => {
     test("returns error when coordinate fallback also fails", async () => {
       const element = {
         "resource-id": "test:id/button",
-        "bounds": { left: 0, top: 0, right: 100, bottom: 100 }
+        bounds: { left: 0, top: 0, right: 100, bottom: 100 },
       } as Element;
 
-      driver.setActionResult({ success: false, action: "long_click", totalTimeMs: 1, error: "failed" });
+      driver.setActionResult({
+        success: false,
+        action: "long_click",
+        totalTimeMs: 1,
+        error: "failed",
+      });
       driver.setTapResult({ success: false, totalTimeMs: 1, error: "gesture failed" });
 
       const result = await strategy.executeLongPress(50, 50, 1000, element, driver);
@@ -560,7 +579,7 @@ describe("TalkBackTapStrategy", () => {
     test("activates via ACTION_CLICK when element has a resource-id", async () => {
       const element = {
         "resource-id": "test:id/button",
-        "bounds": { left: 0, top: 0, right: 100, bottom: 100 }
+        bounds: { left: 0, top: 0, right: 100, bottom: 100 },
       } as Element;
 
       driver.setActionResult({ success: true, action: "click", totalTimeMs: 1 });
@@ -577,7 +596,7 @@ describe("TalkBackTapStrategy", () => {
     test("returns failure without attempting an action when element has no resource-id", async () => {
       const element = {
         bounds: { left: 0, top: 0, right: 100, bottom: 100 },
-        text: "Button"
+        text: "Button",
       } as Element;
 
       const result = await strategy.executeDirectActivation(element, driver);
@@ -591,10 +610,15 @@ describe("TalkBackTapStrategy", () => {
     test("returns failure when ACTION_CLICK is rejected", async () => {
       const element = {
         "resource-id": "test:id/button",
-        "bounds": { left: 0, top: 0, right: 100, bottom: 100 }
+        bounds: { left: 0, top: 0, right: 100, bottom: 100 },
       } as Element;
 
-      driver.setActionResult({ success: false, action: "click", totalTimeMs: 1, error: "node not found" });
+      driver.setActionResult({
+        success: false,
+        action: "click",
+        totalTimeMs: 1,
+        error: "node not found",
+      });
 
       const result = await strategy.executeDirectActivation(element, driver);
 

--- a/test/features/talkback/TalkBackTapStrategy.test.ts
+++ b/test/features/talkback/TalkBackTapStrategy.test.ts
@@ -525,6 +525,37 @@ describe("TalkBackTapStrategy", () => {
     });
   });
 
+  describe("executePreciseTap", () => {
+    test("focuses the requested coordinate before the activation double-tap", async () => {
+      const result = await strategy.executePreciseTap(80, 40, driver);
+
+      expect(result).toMatchObject({
+        success: true,
+        method: "coordinate-fallback",
+        focusCompleted: true,
+        completedTaps: 2,
+      });
+      expect(driver.tapHistory).toEqual([
+        { x: 80, y: 40, durationMs: 50 },
+        { x: 80, y: 40, durationMs: 50 },
+        { x: 80, y: 40, durationMs: 50 },
+      ]);
+    });
+
+    test("reports when the focus tap fails before activation", async () => {
+      driver.queueTapResult({ success: false, totalTimeMs: 1, error: "focus failed" });
+
+      const result = await strategy.executePreciseTap(80, 40, driver);
+
+      expect(result).toMatchObject({
+        success: false,
+        focusCompleted: false,
+        completedTaps: 0,
+      });
+      expect(driver.getTapCount()).toBe(1);
+    });
+  });
+
   describe("executeDirectActivation", () => {
     test("activates via ACTION_CLICK when element has a resource-id", async () => {
       const element = {

--- a/test/features/talkback/TalkBackTapStrategy.test.ts
+++ b/test/features/talkback/TalkBackTapStrategy.test.ts
@@ -497,6 +497,7 @@ describe("TalkBackTapStrategy", () => {
       expect(result.success).toBe(false);
       expect(result.method).toBe("coordinate-fallback");
       expect(result.error).toContain("First tap failed");
+      expect(result.completedTaps).toBe(0);
       expect(driver.getTapCount()).toBe(1);
     });
 
@@ -509,6 +510,7 @@ describe("TalkBackTapStrategy", () => {
       expect(result.success).toBe(false);
       expect(result.method).toBe("coordinate-fallback");
       expect(result.error).toContain("Second tap failed");
+      expect(result.completedTaps).toBe(1);
       expect(driver.getTapCount()).toBe(2);
     });
 

--- a/test/server/toolOutputSchemas.test.ts
+++ b/test/server/toolOutputSchemas.test.ts
@@ -54,6 +54,21 @@ describe("elementBoundsSchema: object + compact tuple (#2990)", () => {
 });
 
 describe("tool output artifact metadata schema (#3480)", () => {
+  test("tapOn results advertise and accept resolved target coordinates", () => {
+    const result = tapOnResultSchema.parse({
+      success: true,
+      action: "tap",
+      x: 491,
+      y: 230,
+    });
+    const json = JSON.stringify(toJSONSchema(tapOnResultSchema));
+
+    expect(result).toMatchObject({ x: 491, y: 230 });
+    expect(json).toContain("\"x\"");
+    expect(json).toContain("\"y\"");
+    expect(json).toContain("resolved target");
+  });
+
   test("advertises screen-reader navigation fidelity assertions (#3963)", () => {
     const json = JSON.stringify(toJSONSchema(tapOnResultSchema));
 

--- a/test/server/toolRegistration.test.ts
+++ b/test/server/toolRegistration.test.ts
@@ -127,7 +127,7 @@ describe("Tool Registration Validation (Integration Tests)", () => {
   //      tools (barrier/criticalSection) too — they are deliberately absent
   //      from getToolDefinitions() (see A1) but present in the committed file,
   //      so a plan-inclusive roster is the correct comparison.
-  //   3. body/description: each committed entry's description and inputSchema
+  //   3. body/description: each committed entry's description, inputSchema, and outputSchema
   //      deep-match the live definition (drift is 0 today).
   test("committed tool-definitions.json matches the live schemas in both directions", async () => {
     const fs = await import("fs/promises");
@@ -163,6 +163,9 @@ describe("Tool Registration Validation (Integration Tests)", () => {
         expect(committedDef, `${liveDef.name} missing from committed file`).toBeDefined();
         expect(committedDef!.description).toBe(liveDef.description);
         expect(committedDef!.inputSchema).toEqual(liveDef.inputSchema as ToolSchemaDefinition["inputSchema"]);
+        expect(committedDef!.outputSchema).toEqual(
+          liveDef.outputSchema as ToolSchemaDefinition["outputSchema"]
+        );
       }
     } finally {
       ToolRegistry.clearTools();

--- a/test/server/toolRegistration.test.ts
+++ b/test/server/toolRegistration.test.ts
@@ -52,9 +52,14 @@ describe("Tool Registration Validation (Integration Tests)", () => {
 
   test("should verify critical tools from issue #745 exist in actual code", async () => {
     const interactionTools = await actualModules.interaction();
-    const criticalSchemas = ["clearTextSchema", "selectAllTextSchema", "pressButtonSchema", "systemTraySchema"];
+    const criticalSchemas = [
+      "clearTextSchema",
+      "selectAllTextSchema",
+      "pressButtonSchema",
+      "systemTraySchema",
+    ];
 
-    criticalSchemas.forEach(schemaName => {
+    criticalSchemas.forEach((schemaName) => {
       expect(interactionTools).toHaveProperty(schemaName);
       expect(interactionTools[schemaName]).toBeDefined();
     });
@@ -86,7 +91,7 @@ describe("Tool Registration Validation (Integration Tests)", () => {
 
     const content = await fs.readFile(schemaPath, "utf-8");
     const schemas = JSON.parse(content) as ToolSchemaDefinition[];
-    const observe = schemas.find(schema => schema.name === "observe");
+    const observe = schemas.find((schema) => schema.name === "observe");
 
     expect(observe?.outputSchema).toBeDefined();
     expect(() => compileJsonSchema(observe!.outputSchema)).not.toThrow();
@@ -105,9 +110,15 @@ describe("Tool Registration Validation (Integration Tests)", () => {
     expect(schemas.length).toBeGreaterThan(0);
 
     for (const schema of schemas) {
-      expect(() => compileJsonSchema(schema.inputSchema), `${schema.name} inputSchema`).not.toThrow();
+      expect(
+        () => compileJsonSchema(schema.inputSchema),
+        `${schema.name} inputSchema`,
+      ).not.toThrow();
       if (schema.outputSchema !== undefined) {
-        expect(() => compileJsonSchema(schema.outputSchema), `${schema.name} outputSchema`).not.toThrow();
+        expect(
+          () => compileJsonSchema(schema.outputSchema),
+          `${schema.name} outputSchema`,
+        ).not.toThrow();
       }
     }
   });
@@ -117,7 +128,7 @@ describe("Tool Registration Validation (Integration Tests)", () => {
     const path = await import("path");
     const schemaPath = path.join(process.cwd(), "schemas", "tool-definitions.json");
     const schemas = JSON.parse(await fs.readFile(schemaPath, "utf-8")) as ToolSchemaDefinition[];
-    const tapOn = schemas.find(schema => schema.name === "tapOn");
+    const tapOn = schemas.find((schema) => schema.name === "tapOn");
     const validate = new Ajv2020({ strict: false }).compile(tapOn!.inputSchema);
     const baseInput = {
       selector: { text: "Read @mention now" },
@@ -161,28 +172,30 @@ describe("Tool Registration Validation (Integration Tests)", () => {
 
       const schemaContent = await fs.readFile(schemaPath, "utf-8");
       const committed = JSON.parse(schemaContent) as ToolSchemaDefinition[];
-      const committedNames = new Set(committed.map(tool => tool.name));
+      const committedNames = new Set(committed.map((tool) => tool.name));
       const served = ToolRegistry.getToolDefinitions();
-      const servedNames = served.map(tool => tool.name);
+      const servedNames = served.map((tool) => tool.name);
 
       // 1. served -> committed
-      expect(servedNames.filter(name => !committedNames.has(name))).toEqual([]);
+      expect(servedNames.filter((name) => !committedNames.has(name))).toEqual([]);
 
       // 2. committed -> served (plan-only tools resolve via getToolForPlan)
       const orphanedCommitted = committed
-        .map(tool => tool.name)
-        .filter(name => ToolRegistry.getToolForPlan(name) === undefined);
+        .map((tool) => tool.name)
+        .filter((name) => ToolRegistry.getToolForPlan(name) === undefined);
       expect(orphanedCommitted).toEqual([]);
 
       // 3. body/description byte-match for every served tool
-      const committedByName = new Map(committed.map(tool => [tool.name, tool]));
+      const committedByName = new Map(committed.map((tool) => [tool.name, tool]));
       for (const liveDef of served) {
         const committedDef = committedByName.get(liveDef.name);
         expect(committedDef, `${liveDef.name} missing from committed file`).toBeDefined();
         expect(committedDef!.description).toBe(liveDef.description);
-        expect(committedDef!.inputSchema).toEqual(liveDef.inputSchema as ToolSchemaDefinition["inputSchema"]);
+        expect(committedDef!.inputSchema).toEqual(
+          liveDef.inputSchema as ToolSchemaDefinition["inputSchema"],
+        );
         expect(committedDef!.outputSchema).toEqual(
-          liveDef.outputSchema as ToolSchemaDefinition["outputSchema"]
+          liveDef.outputSchema as ToolSchemaDefinition["outputSchema"],
         );
       }
     } finally {

--- a/test/server/toolRegistration.test.ts
+++ b/test/server/toolRegistration.test.ts
@@ -4,6 +4,7 @@ import { createMcpServer } from "../../src/server";
 import { serverConfig } from "../../src/utils/ServerConfig";
 import { setDebugModeEnabled } from "../../src/utils/debug";
 import { compileJsonSchema } from "../helpers/jsonSchemaCompile";
+import Ajv2020 from "ajv/dist/2020";
 
 /**
  * Tool Registration Regression Tests
@@ -109,6 +110,23 @@ describe("Tool Registration Validation (Integration Tests)", () => {
         expect(() => compileJsonSchema(schema.outputSchema), `${schema.name} outputSchema`).not.toThrow();
       }
     }
+  });
+
+  test("committed tapOn schema rejects unsupported relativePosition combinations", async () => {
+    const fs = await import("fs/promises");
+    const path = await import("path");
+    const schemaPath = path.join(process.cwd(), "schemas", "tool-definitions.json");
+    const schemas = JSON.parse(await fs.readFile(schemaPath, "utf-8")) as ToolSchemaDefinition[];
+    const tapOn = schemas.find(schema => schema.name === "tapOn");
+    const validate = new Ajv2020({ strict: false }).compile(tapOn!.inputSchema);
+    const baseInput = {
+      selector: { text: "Read @mention now" },
+      relativePosition: { x: 0.95, y: 0.5 },
+    };
+
+    expect(validate({ ...baseInput, platform: "android", action: "tap" })).toBe(true);
+    expect(validate({ ...baseInput, platform: "ios", action: "tap" })).toBe(false);
+    expect(validate({ ...baseInput, platform: "android", action: "focus" })).toBe(false);
   });
 
   // R9 (issue #4183): a negative assertion so the compile check cannot silently

--- a/test/server/tools/tapOnTapAnySchema.test.ts
+++ b/test/server/tools/tapOnTapAnySchema.test.ts
@@ -20,7 +20,7 @@ function zodIssues(fn: () => unknown): z.core.$ZodIssue[] {
 
 function expectRejectedKey(schema: z.ZodType, input: unknown, key: string): void {
   const unrecognized = zodIssues(() => schema.parse(input)).find(
-    issue => issue.code === "unrecognized_keys"
+    (issue) => issue.code === "unrecognized_keys",
   ) as { keys?: string[] } | undefined;
   expect(unrecognized, `expected an unrecognized_keys issue for "${key}"`).toBeDefined();
   expect(unrecognized!.keys).toContain(key);
@@ -65,7 +65,7 @@ describe("tapOn schema", () => {
       tapOnSchema.parse({
         platform: "android",
         selector: { text: "Login", elementId: "com.app:id/btn_login" },
-      })
+      }),
     ).toThrow();
   });
 
@@ -74,7 +74,7 @@ describe("tapOn schema", () => {
       tapOnSchema.parse({
         platform: "ios",
         selector: { textAny: [] },
-      })
+      }),
     ).toThrow();
   });
 
@@ -82,7 +82,7 @@ describe("tapOn schema", () => {
     expect(() =>
       tapOnSchema.parse({
         platform: "android",
-      })
+      }),
     ).toThrow();
   });
 
@@ -91,7 +91,7 @@ describe("tapOn schema", () => {
       tapOnSchema.parse({
         platform: "android",
         text: "Login",
-      })
+      }),
     ).toThrow();
   });
 
@@ -132,7 +132,7 @@ describe("tapOn schema", () => {
         ...target,
         selector: { text: "Read @mention now" },
         relativePosition: { x: 0.95, y: 0.5 },
-      })
+      }),
     ).toThrow();
   });
 
@@ -141,23 +141,21 @@ describe("tapOn schema", () => {
     ["x beyond the element", { x: 1.01, y: 0.5 }, "x", "too_big"],
     ["y above the element", { x: 0.5, y: -0.01 }, "y", "too_small"],
     ["y below the element", { x: 0.5, y: 1.01 }, "y", "too_big"],
-  ] as const)("rejects an out-of-bounds relative position: %s", (
-    _reason,
-    relativePosition,
-    coordinate,
-    expectedCode
-  ) => {
-    const issue = zodIssues(() =>
-      tapOnSchema.parse({
-        platform: "android",
-        selector: { text: "Read @mention now" },
-        relativePosition,
-      })
-    ).find(candidate => candidate.path.join(".") === `relativePosition.${coordinate}`);
+  ] as const)(
+    "rejects an out-of-bounds relative position: %s",
+    (_reason, relativePosition, coordinate, expectedCode) => {
+      const issue = zodIssues(() =>
+        tapOnSchema.parse({
+          platform: "android",
+          selector: { text: "Read @mention now" },
+          relativePosition,
+        }),
+      ).find((candidate) => candidate.path.join(".") === `relativePosition.${coordinate}`);
 
-    expect(issue).toBeDefined();
-    expect(issue!.code).toBe(expectedCode);
-  });
+      expect(issue).toBeDefined();
+      expect(issue!.code).toBe(expectedCode);
+    },
+  );
 
   test("accepts container", () => {
     const result = tapOnSchema.parse({
@@ -199,7 +197,7 @@ describe("tapOn schema", () => {
     expectRejectedKey(
       tapOnSchema,
       { platform: "android", selector: { text: "Login" }, [key]: value },
-      key
+      key,
     );
   });
 });
@@ -253,8 +251,8 @@ describe("tapAny schema", () => {
   // path ["action"], not `unrecognized_keys`. Asserted separately.
   test("rejects the focus action as an invalid value on the action path", () => {
     const actionIssue = zodIssues(() =>
-      tapAnySchema.parse({ platform: "android", action: "focus" })
-    ).find(issue => issue.path[0] === "action");
+      tapAnySchema.parse({ platform: "android", action: "focus" }),
+    ).find((issue) => issue.path[0] === "action");
     expect(actionIssue).toBeDefined();
     expect(actionIssue!.code).toBe("invalid_value");
   });

--- a/test/server/tools/tapOnTapAnySchema.test.ts
+++ b/test/server/tools/tapOnTapAnySchema.test.ts
@@ -124,6 +124,19 @@ describe("tapOn schema", () => {
   });
 
   test.each([
+    ["iOS", { platform: "ios", action: "tap" }],
+    ["focus", { platform: "android", action: "focus" }],
+  ] as const)("rejects relativePosition with unsupported %s targeting", (_label, target) => {
+    expect(() =>
+      tapOnSchema.parse({
+        ...target,
+        selector: { text: "Read @mention now" },
+        relativePosition: { x: 0.95, y: 0.5 },
+      })
+    ).toThrow();
+  });
+
+  test.each([
     ["x below the element", { x: -0.01, y: 0.5 }, "x", "too_small"],
     ["x beyond the element", { x: 1.01, y: 0.5 }, "x", "too_big"],
     ["y above the element", { x: 0.5, y: -0.01 }, "y", "too_small"],

--- a/test/server/tools/tapOnTapAnySchema.test.ts
+++ b/test/server/tools/tapOnTapAnySchema.test.ts
@@ -110,6 +110,40 @@ describe("tapOn schema", () => {
       selector: { text: "Login" },
     });
     expect(result.sibling).toBeUndefined();
+    expect(result.relativePosition).toBeUndefined();
+  });
+
+  test("accepts a normalized position within the matched Android element", () => {
+    const result = tapOnSchema.parse({
+      platform: "android",
+      selector: { text: "Read @mention now" },
+      relativePosition: { x: 0.95, y: 0.5 },
+    });
+
+    expect(result.relativePosition).toEqual({ x: 0.95, y: 0.5 });
+  });
+
+  test.each([
+    ["x below the element", { x: -0.01, y: 0.5 }, "x", "too_small"],
+    ["x beyond the element", { x: 1.01, y: 0.5 }, "x", "too_big"],
+    ["y above the element", { x: 0.5, y: -0.01 }, "y", "too_small"],
+    ["y below the element", { x: 0.5, y: 1.01 }, "y", "too_big"],
+  ] as const)("rejects an out-of-bounds relative position: %s", (
+    _reason,
+    relativePosition,
+    coordinate,
+    expectedCode
+  ) => {
+    const issue = zodIssues(() =>
+      tapOnSchema.parse({
+        platform: "android",
+        selector: { text: "Read @mention now" },
+        relativePosition,
+      })
+    ).find(candidate => candidate.path.join(".") === `relativePosition.${coordinate}`);
+
+    expect(issue).toBeDefined();
+    expect(issue!.code).toBe(expectedCode);
   });
 
   test("accepts container", () => {
@@ -135,11 +169,13 @@ describe("tapOn schema", () => {
       preTapStability: true,
       retryIfNoChange: true,
       ensureTap: true,
+      relativePosition: { x: 0.1, y: 0.9 },
     });
     expect(result.action).toBe("longPress");
     expect(result.duration).toBe(2000);
     expect(result.index).toBe(1);
     expect(result.preTapStability).toBe(true);
+    expect(result.relativePosition).toEqual({ x: 0.1, y: 0.9 });
   });
 
   test.each([


### PR DESCRIPTION
## Summary

- add an optional normalized `relativePosition` for precise Android taps within the final resolved element
- validate the resolved point against half-open element and screen bounds while preserving center taps by default
- report resolved `x`/`y` target coordinates and force coordinate execution under TalkBack so embedded `ClickableSpan` targets are honored
- publish and drift-check the updated tool schemas, document TalkBack behavior, and cover edge spans, clipping, rotation, stability, invalid targets, and routing

## Linked Issue

Closes https://github.com/kaeawc/auto-mobile/issues/5500

## Validation

- [x] Focused tap and schema suite: 211 passed
- [x] `bun run turbo:validate -- --env-mode=loose`: 7/7 tasks, 13,802 tests passed, 0 failed
- [x] `bun run typecheck`: no new errors
- [x] `scripts/all_fast_validate_checks.sh --skip ktfmt`: 33/33 applicable checks passed; no Kotlin files changed
- [x] New code uses existing interfaces/fakes and deterministic unit tests complete well under 100ms each
- [x] No new helper package or direct dependency
- [x] Integrated latest `main`

## Device Verification

- [ ] Verified on a real Android device
- [ ] Screenshots or before/after attached

The existing Android coordinate transport already accepts arbitrary points; focused fakes cover dispatch and TalkBack routing without requiring a protocol or Kotlin change.
