### PR TITLE
refactor(utils): route AdbClient + SimCtlClient spawn through shared host-process seam (Part of #5459)

### DIFF
--- a/scripts/typecheck-baseline.txt
+++ b/scripts/typecheck-baseline.txt
@@ -172,9 +172,6 @@ src/server/testTimingResources.ts: error TS2345: Argument of type 'string' is no
 src/utils/Backoff.ts: error TS2322: Type 'BackoffPolicy | readonly number[]' is not assignable to type 'BackoffPolicy'.
 src/utils/DeepLinkManager.ts: error TS2339: Property 'toString' does not exist on type 'never'.
 src/utils/DeepLinkManager.ts: error TS2339: Property 'toString' does not exist on type 'never'.
-src/utils/android-cmdline-tools/AdbClient.ts: error TS2339: Property 'stdout' does not exist on type 'ExecResult | PromiseLike<ExecResult>'.
-src/utils/android-cmdline-tools/AdbClient.ts: error TS2339: Property 'stdout' does not exist on type 'ExecResult | PromiseLike<ExecResult>'.
-src/utils/android-cmdline-tools/AdbClient.ts: error TS2339: Property 'stdout' does not exist on type 'ExecResult | PromiseLike<ExecResult>'.
 src/utils/androidTransientLoading.ts: error TS2345: Argument of type 'object' is not assignable to parameter of type 'ViewHierarchyNode'.
 src/utils/filesystem/DefaultFileSystem.ts: error TS2339: Property 'toString' does not exist on type 'never'.
 src/utils/image/backend/JimpBackend.ts: error TS2322: Type 'JimpInstanceMethods<{ bitmap: Bitmap; background: number; formats: Format<any, undefined, undefined>[]; mime?: string | undefined; inspect(): string; toString(): string; readonly width: number; ... 11 more ...; scanIterator(x?: number | undefined, y?: number | undefined, w?: number | undefined, h?: number | undefine...' is not assignable to type '{ bitmap: Bitmap; background: number; formats: Format<any, undefined, undefined>[]; mime?: string | undefined; inspect(): string; toString(): string; readonly width: number; ... 11 more ...; scanIterator(x?: number | undefined, y?: number | undefined, w?: number | undefined, h?: number | undefined): Generator<...>; ...'.
@@ -230,7 +227,6 @@ src/utils/ios-cmdline-tools/XcodeSigning.ts: error TS2322: Type 'Promise<string 
 # swap-fp: 32 :: src/features/accessibility/WcagAudit.ts: error TS2339: Property 'class' does not exist on type 'ViewHierarchyNode'.
 # swap-fp: 32 :: src/features/observe/ios/CtrlProxyGestures.ts: error TS2459: Module '"./types"' declares 'GestureTimingResult' locally, but it is not exported.
 # swap-fp: 32 :: src/server/interactionTools.ts: error TS18048: 'freshness.actualTimestamp' is possibly 'undefined'.
-# swap-fp: 32,36,56 :: src/utils/android-cmdline-tools/AdbClient.ts: error TS2339: Property 'stdout' does not exist on type 'ExecResult | PromiseLike<ExecResult>'.
 # swap-fp: 33 :: src/db/migrator.ts: error TS7006: Parameter 'table' implicitly has an 'any' type.
 # swap-fp: 33 :: src/features/utility/DefaultElementSelector.ts: error TS2339: Property 'findClickableElementsInContainer' does not exist on type 'ElementFinder'.
 # swap-fp: 33 :: src/features/utility/DefaultElementSelector.ts: error TS2339: Property 'findClickableParentsContainingText' does not exist on type 'ElementFinder'.

--- a/src/utils/android-cmdline-tools/AdbClient.ts
+++ b/src/utils/android-cmdline-tools/AdbClient.ts
@@ -1,7 +1,9 @@
 import { errorMessage } from "../describeUnknownError";
-import { execFile, spawn, type ChildProcess } from "child_process";
+import { execFile, type ChildProcess, type SpawnOptions } from "child_process";
 import { promisify } from "util";
 import { logger } from "../logger";
+import { createExecResult } from "../execResult";
+import { DefaultHostCommandExecutor, type HostProcessExecutor } from "../HostCommandExecutor";
 import { BootedDevice, ExecResult, AndroidUser, DeviceLockState } from "../../models";
 import {
   AndroidToolsDetectionAbortError,
@@ -27,6 +29,19 @@ import { isAdbMissingDeviceError, notifyAdbMissingDevice } from "./AdbDeviceHeal
 import { DefaultSystemDetection, type SystemDetection } from "../system/SystemDetection";
 
 type ExecFileAsync = (file: string, args: string[], maxBuffer?: number) => Promise<ExecResult>;
+
+/**
+ * The long-lived spawn seam. Kept as its own injectable type so the default can
+ * route through the shared {@link HostProcessExecutor} while tests still inject a
+ * fake. Deliberately narrower than node's overloaded `typeof spawn`.
+ */
+type SpawnFn = (file: string, args: string[], options?: SpawnOptions) => ChildProcess;
+
+// Route the default long-lived spawn through the shared host-process seam so the
+// client no longer reaches for `child_process.spawn` directly (issue #5459). The
+// executor's `spawn` is a plain passthrough, so this is behavior-identical; all
+// of AdbClient's own timeout/abort/process-tracking orchestration is unchanged.
+const hostProcessExecutor: HostProcessExecutor = new DefaultHostCommandExecutor();
 
 /**
  * Thrown when an adb command exceeds the caller-supplied `timeoutMs` budget, as
@@ -104,22 +119,15 @@ const execFileAsync: ExecFileAsync = async (
   const options = maxBuffer ? { maxBuffer } : undefined;
   const result = await promisify(execFile)(file, args, options);
 
-  // Add the required string methods
-  const enhancedResult: ExecResult = {
-    stdout: typeof result.stdout === "string" ? result.stdout : result.stdout.toString(),
-    stderr: typeof result.stderr === "string" ? result.stderr : result.stderr.toString(),
-    toString() { return this.stdout; },
-    trim() { return this.stdout.trim(); },
-    includes(searchString: string) { return this.stdout.includes(searchString); }
-  };
-
-  return enhancedResult;
+  // Coerce to the canonical ExecResult (Buffer→string plus the trim/toString/
+  // includes helpers) via the shared factory rather than re-inlining it here.
+  return createExecResult(result.stdout, result.stderr);
 };
 
 export class AdbClient implements AdbExecutor {
   device: BootedDevice | null;
   execAsync: ExecFileAsync;
-  spawnFn: typeof spawn;
+  spawnFn: SpawnFn;
   private adbPath: string;
   private isTestMode: boolean;
   private activeProcesses: Set<ChildProcess> = new Set();
@@ -148,7 +156,7 @@ export class AdbClient implements AdbExecutor {
   constructor(
     device: BootedDevice | null = null,
     execAsyncFn: ((command: string, maxBuffer?: number) => Promise<ExecResult>) | ExecFileAsync | null = null,
-    spawnFn: typeof spawn | null = null,
+    spawnFn: SpawnFn | null = null,
     retryExecutor: RetryExecutor = defaultRetryExecutor,
     timer: Timer = defaultTimer,
     private readonly systemDetectionFactory: () => SystemDetection = () => new DefaultSystemDetection()
@@ -174,7 +182,7 @@ export class AdbClient implements AdbExecutor {
         ? this.wrapExecAsync(execAsyncFn)
         : execFileAsync;
     }
-    this.spawnFn = spawnFn || spawn;
+    this.spawnFn = spawnFn || ((file, args, options) => hostProcessExecutor.spawn(file, args, options));
     this.retryExecutor = retryExecutor;
     this.timer = timer;
     // Initialize with fallback, will be updated lazily
@@ -832,13 +840,7 @@ export class AdbClient implements AdbExecutor {
           }));
           return;
         }
-        resolve({
-          stdout: typeof stdout === "string" ? stdout : stdout.toString(),
-          stderr: typeof stderr === "string" ? stderr : stderr.toString(),
-          toString() { return this.stdout; },
-          trim() { return this.stdout.trim(); },
-          includes(searchString: string) { return this.stdout.includes(searchString); }
-        });
+        resolve(createExecResult(stdout, stderr));
       });
 
       this.activeProcesses.add(child);

--- a/src/utils/ios-cmdline-tools/SimCtlClient.ts
+++ b/src/utils/ios-cmdline-tools/SimCtlClient.ts
@@ -1,11 +1,12 @@
 import { errorMessage } from "../describeUnknownError";
-import { ChildProcess, execFile, spawn, type SpawnOptions } from "child_process";
+import { ChildProcess, execFile, type SpawnOptions } from "child_process";
 import { promisify } from "util";
 import { promises as fsPromises } from "fs";
 import { tmpdir } from "os";
 import { join } from "path";
 import { logger } from "../logger";
 import { createExecResult } from "../execResult";
+import { DefaultHostCommandExecutor, type HostProcessExecutor } from "../HostCommandExecutor";
 import { ExecResult, ActionableError, DeviceInfo, BootedDevice, ScreenSize } from "../../models";
 import { defaultTimer, Timer } from "../SystemTimer";
 import { createGlobalPerformanceTracker } from "../PerformanceTracker";
@@ -308,12 +309,19 @@ const execAsync = async (
   return createExecResult(stdout, stderr);
 };
 
+// Route the default long-lived spawn through the shared host-process seam so the
+// client no longer reaches for `child_process.spawn` directly (issue #5459). The
+// executor's `spawn` is a plain passthrough that already defaults `options` to
+// `{}`, so this is behavior-identical; SimCtlClient keeps its own timeout/abort
+// orchestration and the injected `spawnProcess` test seam.
+const hostProcessExecutor: HostProcessExecutor = new DefaultHostCommandExecutor();
+
 function defaultSpawnProcess(
   command: string,
   args: string[],
   options?: SpawnOptions,
 ): ChildProcess {
-  return spawn(command, args, options ?? {});
+  return hostProcessExecutor.spawn(command, args, options);
 }
 
 function splitCommandArgs(command: string): string[] {


### PR DESCRIPTION
## Summary

Part of the ExecSeam consolidation in #5459. This is the **safe, behavior-preserving subset**: it routes the long-lived `spawn` leaf of both platform command clients through the shared `HostProcessExecutor.spawn` and dedups AdbClient's hand-built `ExecResult` literals onto the shared factory. It deliberately does **not** touch the `execFile` / timeout / error-classification paths — that harder consolidation is deferred (see below) and the issue stays open for it.

## Linked Issue

Part of #5459 (intentionally not "Closes" — the deferred `execFile`-path extension keeps the issue open).

## Changes

- **AdbClient** (`src/utils/android-cmdline-tools/AdbClient.ts`)
  - `spawnFn` now defaults to `HostProcessExecutor.spawn` instead of importing `child_process.spawn` directly. The injected `spawnFn` constructor seam is unchanged, so tests still inject fakes.
  - The two hand-built `ExecResult` literals (module `execFileAsync` and `execWithSignal`'s success path) now use the shared `createExecResult` factory.
  - All of AdbClient's own timeout/abort/process-tracking orchestration and the `execFile` + `AdbCommandTimeoutError` classification path are untouched.
- **SimCtlClient** (`src/utils/ios-cmdline-tools/SimCtlClient.ts`)
  - `defaultSpawnProcess` now routes through `HostProcessExecutor.spawn` instead of `child_process.spawn`. The injected `spawnProcess` seam and the client's own timeout/abort orchestration are unchanged.
- **Typecheck baseline** ratcheted down by 3: the AdbClient `createExecResult` dedup removed three tolerated `TS2339` errors on the old literals.

`HostProcessExecutor.spawn` is a plain passthrough (`return spawn(file, args, options)`, `options` defaulting to `{}`), matching SimCtl's prior `options ?? {}`, so both changes are behavior-identical. Neither client imports `child_process.spawn` anymore (both still import `execFile`, which is out of scope for this subset).

## Why only a subset (deferred work, tracked on #5459)

Routing the `execFile`/timeout paths through `runExecSeam` as-is is **not** behavior-preserving:
- `runExecSeam` delegates timeout to node's native `execFile` timeout, which would replace AdbClient's injected-`Timer`-driven `AdbCommandTimeoutError` — breaking the `getAndroidApiLevel` caching contract (#3351), and its FakeTimer test determinism.
- `runExecSeam` always wraps errors via `wrapCommandError`, discarding `.code`/`.stderr`, which SimCtl's CoreSimulator-405 boot-recovery (`isAlreadyBootedCoreSimulator405`, #3938/#4092) reads directly.
- The clients need the live `ChildProcess` (SIGTERM on abort, tracking) that `runExecSeam` never returns.

Faithfully absorbing those would require a substantial extension of the shared `ExecSeam` primitive; that is deferred and documented on #5459.

## Validation

- [x] `bun run lint` — no new violations (631 baseline), boundary-checks 13/13 pass
- [x] `bun test` — whole suite: 13812 pass, 14 skip, 0 fail
- [x] `bun run typecheck` — no new errors; baseline ratcheted down by 3
- [x] `bun run build` — clean
- [x] adb/simctl test files run directly (AdbClient*, simctl-client*, boundary lint) — green
- [x] New code reuses existing project helpers (`HostProcessExecutor`, `createExecResult`); no new dependencies

## Follow-ups

- [ ] Deferred: extend `ExecSeam` to absorb the `execFile`/timeout/error-classification paths of both clients (documented on #5459).
- Note: AdbClient's `activeProcesses` Set is only added-to/deleted-from with no external reader (the SIGTERM kills reference the child closure directly) — left as-is, out of scope for this subset.
