### PR TITLE
refactor(daemon): route id generation through injected IdGenerator

### DIFF
--- a/src/daemon/client.ts
+++ b/src/daemon/client.ts
@@ -1,5 +1,4 @@
 import { createConnection, Socket } from "node:net";
-import { randomUUID } from "node:crypto";
 import { existsSync, statSync } from "node:fs";
 import { platform } from "node:os";
 import { logger } from "../utils/logger";
@@ -15,6 +14,7 @@ import { type BuildIdentity, getCurrentBuildIdentity } from "./buildIdentity";
 import { resolveMcpRequestTimeoutMs } from "./mcpRequestTimeout";
 import { McpTimeoutError } from "./McpTimeoutError";
 import { type Timer, defaultTimer } from "../utils/SystemTimer";
+import { type IdGenerator, defaultIdGenerator } from "../utils/IdGenerator";
 import {
   cleanupStaleDaemonFilesForDeadPidSync,
   getDaemonSocketPathList,
@@ -88,6 +88,7 @@ export class DaemonClient {
   private notificationHandlers: Set<(notification: DaemonNotification) => void> = new Set();
   private recoveryOptions: DaemonClientRecoveryOptions;
   private readonly clientIdentity: { version: string; build: BuildIdentity } | null;
+  private readonly idGenerator: IdGenerator;
 
   constructor(
     socketPath: string = SOCKET_PATH,
@@ -101,12 +102,14 @@ export class DaemonClient {
       version: DAEMON_VERSION,
       build: getCurrentBuildIdentity(),
     },
+    idGenerator: IdGenerator = defaultIdGenerator,
   ) {
     this.socketPath = socketPath;
     this.connectionTimeout = connectionTimeout;
     this.timer = timer;
     this.recoveryOptions = recoveryOptions;
     this.clientIdentity = clientIdentity;
+    this.idGenerator = idGenerator;
   }
 
   /**
@@ -442,7 +445,7 @@ export class DaemonClient {
       await this.connect();
     }
 
-    const requestId = randomUUID();
+    const requestId = this.idGenerator.next();
 
     const request: DaemonRequest = {
       id: requestId,
@@ -499,7 +502,7 @@ export class DaemonClient {
       await this.connect();
     }
 
-    const requestId = randomUUID();
+    const requestId = this.idGenerator.next();
 
     const request: DaemonRequest = {
       id: requestId,

--- a/src/daemon/daemon.ts
+++ b/src/daemon/daemon.ts
@@ -1953,6 +1953,8 @@ export class Daemon {
           undefined,
           undefined,
           FeatureFlagService.getInstance(),
+          undefined,
+          this.idGenerator,
         );
         try {
           await this.socketServer.start();

--- a/src/daemon/daemon.ts
+++ b/src/daemon/daemon.ts
@@ -399,6 +399,7 @@ export class Daemon {
       (deviceId) => this.deviceSessionRegistry.onDeviceDisconnected(deviceId),
       new EmulatorLossIncidentRepository(this.timer, this.idGenerator),
       (sessionId, reason) => executionTracker.cancelDeviceSessionExecutions(sessionId, reason),
+      this.idGenerator,
     );
     // Initialize singleton for daemon state access
     DaemonState.getInstance().initialize(
@@ -532,6 +533,8 @@ export class Daemon {
       undefined,
       undefined,
       FeatureFlagService.getInstance(),
+      undefined,
+      this.idGenerator,
     );
     logger.info("Starting Unix socket server...");
     startupBenchmark.startPhase("socketServerStart");

--- a/src/daemon/devicePool.ts
+++ b/src/daemon/devicePool.ts
@@ -1,5 +1,4 @@
 import type { ChildProcess } from "child_process";
-import { randomUUID } from "node:crypto";
 import { logger } from "../utils/logger";
 import {
   SessionManager,
@@ -14,6 +13,7 @@ import {
   waitForDeviceReadyOrCancel,
 } from "../utils/deviceUtils";
 import { Timer, defaultTimer } from "../utils/SystemTimer";
+import { type IdGenerator, defaultIdGenerator } from "../utils/IdGenerator";
 import type { InstalledAppsStore } from "../db/installedAppsRepository";
 import { InstalledAppsRepository } from "../db/installedAppsRepository";
 import { RetryExecutor, defaultRetryExecutor } from "../utils/retry/RetryExecutor";
@@ -282,6 +282,7 @@ export class DevicePool {
   private sessionManager: SessionManager;
   private assignmentMutex = new Mutex();
   private timer: Timer;
+  private readonly idGenerator: IdGenerator;
   private lastUsedAtMarker = 0;
   private lastReleasedDeviceId: string | null = null;
   private readonly mcpSessionAutolockMap: Map<string, string> = new Map();
@@ -390,10 +391,12 @@ export class DevicePool {
     onDeviceRemoved?: DeviceRemovedListener,
     emulatorLossIncidentStore: EmulatorLossIncidentStore = new InMemoryEmulatorLossIncidentStore(timer),
     cancelDeviceSessionExecutions?: DeviceSessionExecutionCanceller,
+    idGenerator: IdGenerator = defaultIdGenerator,
   ) {
     this.sessionManager = sessionManager;
     this.daemonSessionId = daemonSessionId;
     this.timer = timer;
+    this.idGenerator = idGenerator;
     this.installedAppsRepository = installedAppsRepository ?? new InstalledAppsRepository();
     this.deviceManager = deviceManager;
     this.retryExecutor = retryExecutor;
@@ -405,7 +408,7 @@ export class DevicePool {
     this.emulatorLossIncidentStore = emulatorLossIncidentStore;
     // Resolve recovery policy once so retries and status agree even if the
     // process environment changes after construction.
-    this.recoveryPolicy = { ...(recoveryPolicy ?? getDeviceRecoveryPolicy()) };
+    this.recoveryPolicy = this.resolveRecoveryPolicy(recoveryPolicy);
     this.androidDeviceReboot =
       androidDeviceReboot ?? new BoundedAndroidDeviceReboot(timer, this.recoveryPolicy.maxAttempts);
     this.releaseSessionForDisconnectedDevice =
@@ -425,6 +428,15 @@ export class DevicePool {
         this.clearReleasedAutolockState(sessionId, deviceId);
       }
     });
+  }
+
+  /**
+   * Resolve the effective recovery policy once at construction. Extracted from the
+   * constructor body so the injected-primitive parameters (timer, idGenerator, …)
+   * do not push the constructor over the complexity gate.
+   */
+  private resolveRecoveryPolicy(recoveryPolicy?: DeviceRecoveryPolicy): DeviceRecoveryPolicy {
+    return { ...(recoveryPolicy ?? getDeviceRecoveryPolicy()) };
   }
 
   /**
@@ -4394,7 +4406,7 @@ export class DevicePool {
     readinessReservationOwners?: ReadonlySet<symbol>,
     verifiedAndroidAvdIdentity?: DeviceInfo,
   ): Promise<string> {
-    const sessionId = randomUUID();
+    const sessionId = this.idGenerator.next();
     const androidAvdIdentity = verifiedAndroidAvdIdentity ?? sourceImage;
 
     // Ensure device is in the pool (it may have been freshly booted)

--- a/src/daemon/socketServer.ts
+++ b/src/daemon/socketServer.ts
@@ -1,5 +1,4 @@
 import { createServer, Server as NetServer, Socket } from "node:net";
-import { randomUUID } from "node:crypto";
 import { unlink } from "node:fs/promises";
 import { existsSync, statSync } from "node:fs";
 import path from "node:path";
@@ -48,6 +47,7 @@ import { getCurrentBuildIdentity } from "./buildIdentity";
 import { DaemonState } from "./daemonState";
 import { DaemonStateAccess, handleDaemonRequest } from "./daemonRequestHandlers";
 import { Timer, defaultTimer } from "../utils/SystemTimer";
+import { type IdGenerator, defaultIdGenerator } from "../utils/IdGenerator";
 import type { FeatureFlagService } from "../features/featureFlags/FeatureFlagService";
 import type { FeatureFlagKey } from "../features/featureFlags/FeatureFlagDefinitions";
 import {
@@ -261,6 +261,7 @@ export class UnixSocketServer {
   private activeMcpClientForwardCounts: Map<string, number> = new Map();
   private mcpClientIdleTimers: Map<string, NodeJS.Timeout> = new Map();
   private timer: Timer;
+  private readonly idGenerator: IdGenerator;
   private featureFlagService: FeatureFlagService | null;
   private readonly handshakeEnforced: boolean;
   private readonly daemonIdentity: DaemonSelfIdentity;
@@ -328,11 +329,13 @@ export class UnixSocketServer {
       enforce?: boolean;
       sessionToolSelectionService?: Pick<SessionToolSelectionService, "isEnabled" | "setEnabled">;
     } = {},
+    idGenerator: IdGenerator = defaultIdGenerator,
   ) {
     this.socketPath = socketPath;
     this.mcpEndpoint = mcpEndpoint;
     this.daemonState = daemonState;
     this.timer = timer;
+    this.idGenerator = idGenerator;
     this.featureFlagService = featureFlagService;
     this.handshakeEnforced = handshakeConfig.enforce ?? DAEMON_HANDSHAKE_ENABLED;
     this.sessionToolSelectionService = handshakeConfig.sessionToolSelectionService;
@@ -406,7 +409,7 @@ export class UnixSocketServer {
    * Handle a new client connection
    */
   private handleConnection(socket: Socket): void {
-    const sessionId = randomUUID();
+    const sessionId = this.idGenerator.next();
     const session: SessionContext = {
       sessionId,
       createdAt: this.timer.now(),

--- a/test/daemon/clientRequestIdGenerator.test.ts
+++ b/test/daemon/clientRequestIdGenerator.test.ts
@@ -1,0 +1,77 @@
+import { describe, expect, test, beforeEach } from "bun:test";
+import { Duplex } from "node:stream";
+import { DaemonClient } from "../../src/daemon/client";
+import { CountingIdGenerator } from "../../src/utils/IdGenerator";
+import { FakeTimer } from "../fakes/FakeTimer";
+
+/**
+ * Capture every frame written to the socket so the test can inspect the request
+ * `id` the client stamped. The client writes newline-delimited JSON.
+ */
+function createCapturingSocket(writes: string[]): Duplex {
+  return new Duplex({
+    read() {},
+    write(chunk, _encoding, callback) {
+      writes.push(chunk.toString());
+      callback();
+    },
+  });
+}
+
+function createConnectedClient(
+  fakeTimer: FakeTimer,
+  idGenerator: CountingIdGenerator,
+  writes: string[],
+): DaemonClient {
+  const client = new DaemonClient("/fake/socket", 1000, fakeTimer, {}, null, idGenerator);
+  (client as any).connected = true;
+  (client as any).socket = createCapturingSocket(writes);
+  return client;
+}
+
+function parseRequestIds(writes: string[]): string[] {
+  return writes
+    .join("")
+    .split("\n")
+    .filter((line) => line.trim().length > 0)
+    .map((line) => JSON.parse(line).id as string);
+}
+
+describe("DaemonClient request id comes from the injected IdGenerator", () => {
+  let fakeTimer: FakeTimer;
+
+  beforeEach(() => {
+    fakeTimer = new FakeTimer();
+  });
+
+  test("sendRequest (callTool) stamps ids from the injected generator", async () => {
+    const idGenerator = new CountingIdGenerator("req");
+    const writes: string[] = [];
+    const client = createConnectedClient(fakeTimer, idGenerator, writes);
+
+    // Never resolves (black-hole read), but the frame is written synchronously.
+    // close() below rejects these pending requests, so swallow to avoid unhandled rejections.
+    const pending = [
+      client.callTool("tapOn", {}).catch(() => {}),
+      client.callTool("tapOn", {}).catch(() => {}),
+    ];
+
+    expect(parseRequestIds(writes)).toEqual(["req-1", "req-2"]);
+
+    await client.close();
+    await Promise.all(pending);
+  });
+
+  test("callDaemonMethod stamps ids from the injected generator", async () => {
+    const idGenerator = new CountingIdGenerator("req");
+    const writes: string[] = [];
+    const client = createConnectedClient(fakeTimer, idGenerator, writes);
+
+    const pending = client.callDaemonMethod("daemon/status").catch(() => {});
+
+    expect(parseRequestIds(writes)).toEqual(["req-1"]);
+
+    await client.close();
+    await pending;
+  });
+});

--- a/test/daemon/devicePool.autolock.test.ts
+++ b/test/daemon/devicePool.autolock.test.ts
@@ -1,5 +1,6 @@
 import { describe, it, expect, beforeEach, afterEach } from "bun:test";
 import { DevicePool } from "../../src/daemon/devicePool";
+import { CountingIdGenerator } from "../../src/utils/IdGenerator";
 import { SessionManager, type KeepScreenAwakeRestorer } from "../../src/daemon/sessionManager";
 import { FakeTimer } from "../fakes/FakeTimer";
 import { FakeDeviceSessionPersistence } from "../fakes/FakeDeviceSessionPersistence";
@@ -293,6 +294,34 @@ describe("DevicePool autolock", () => {
       expect(session).not.toBeNull();
       expect(session!.assignedDevice).toBe("emulator-5554");
       expect(session!.expiresAt).toBe(timer.now() + 60_000);
+    });
+
+    it("mints the autolock session id from the injected IdGenerator", async () => {
+      const deterministicPool = new DevicePool(
+        sessionManager,
+        "daemon-session-1",
+        timer,
+        undefined,
+        fakeDeviceUtils,
+        undefined,
+        undefined,
+        undefined,
+        undefined,
+        undefined,
+        undefined,
+        undefined,
+        undefined,
+        undefined,
+        undefined,
+        new CountingIdGenerator("autolock"),
+      );
+      fakeDeviceUtils.setBootedDevices("android", [androidDevice]);
+      await deterministicPool.initializeWithDevices([androidDevice]);
+
+      const sessionId = await deterministicPool.autolockDevice("emulator-5554", "android");
+
+      expect(sessionId).toBe("autolock-1");
+      expect(deterministicPool.getDevice("emulator-5554")?.autolockSessionId).toBe("autolock-1");
     });
 
     it("rejects autolock for a stale idle iOS simulator", async () => {

--- a/test/daemon/socketServerSessionIdGenerator.test.ts
+++ b/test/daemon/socketServerSessionIdGenerator.test.ts
@@ -1,0 +1,49 @@
+import { describe, expect, test } from "bun:test";
+import { UnixSocketServer } from "../../src/daemon/socketServer";
+import { CountingIdGenerator } from "../../src/utils/IdGenerator";
+import { FakeTimer } from "../fakes/FakeTimer";
+
+function createFakeDaemonState(): any {
+  return {
+    isInitialized: () => true,
+    getSessionManager: () => ({ getSession: () => null, releaseSession: async () => null }),
+    getDevicePool: () => ({
+      refreshDevices: async () => 0,
+      getStats: () => ({ total: 0, idle: 0, assigned: 0, error: 0 }),
+      releaseDevice: async () => {},
+    }),
+  };
+}
+
+/**
+ * Minimal stand-in for the connected net.Socket. handleConnection only needs
+ * setTimeout + event registration to wire a session; no real I/O is required to
+ * observe which session id it minted.
+ */
+function createFakeSocket(): any {
+  return {
+    setTimeout() {},
+    on() {},
+    destroy() {},
+  };
+}
+
+describe("UnixSocketServer session id comes from the injected IdGenerator", () => {
+  test("handleConnection keys the session on the injected generator", () => {
+    const idGenerator = new CountingIdGenerator("session");
+    const server = new UnixSocketServer(
+      "/tmp/never-listened.sock",
+      "http://localhost:0/mcp",
+      createFakeDaemonState(),
+      new FakeTimer(),
+      null,
+      {},
+      idGenerator,
+    );
+
+    (server as any).handleConnection(createFakeSocket());
+    (server as any).handleConnection(createFakeSocket());
+
+    expect(Array.from((server as any).sessions.keys())).toEqual(["session-1", "session-2"]);
+  });
+});


### PR DESCRIPTION
## Summary

Route the remaining raw `randomUUID()` call sites in the daemon layer through the `IdGenerator` seam that is already threaded through the daemon, so ids are deterministic under test (per CLAUDE.md's "one canonical primitive per concern: UUIDs come from `IdGenerator`" rule). No new generator is created — each site now uses the daemon's existing injected `this.idGenerator`.

Converted sites:
- `src/daemon/client.ts` — `requestId` in `sendRequest` and `callDaemonMethod`
- `src/daemon/socketServer.ts` — `sessionId` in `handleConnection`
- `src/daemon/devicePool.ts` — autolock `sessionId` in `autolockDeviceExclusive`

`src/daemon/daemon.ts` threads `this.idGenerator` into `UnixSocketServer` (both construction sites) and `DevicePool`. `DaemonClient` gains an optional `idGenerator` constructor parameter defaulting to `defaultIdGenerator`.

Each converted site gets a fast unit test (interface + `CountingIdGenerator` fake) asserting the id comes from the injected generator.

The rest of the issue's evidence was already resolved in the codebase: `generateHighlightId` is consolidated onto `createTimestampedId`, there are no remaining `Math.random()` ID sites in `src/`, and the listed server-layer `randomUUID()` sites (`deviceTools`, `testRecordingManager`, `appFileService`) are already gone. After this PR there are no raw `randomUUID()`/`Math.random()` ID sites left in `src/` outside the primitives themselves.

## Linked Issue

Refs #3511

Not using `Closes` on purpose: the issue's two concrete fix items (dedupe `generateHighlightId`, route ID sites through the primitives) are now fully satisfied, but its third item — "Consider a lint rule banning raw `Math.random()`/`randomUUID()` in `src/`" — is a distinct deliverable (custom oxlint plugin rule + `test/lint/` coverage) kept out of scope here. The issue comment flags that lint rule as the anti-regression mechanism, so it should land before the issue is closed. Suggested follow-up.

## Note on the DevicePool constructor

`DevicePool`'s constructor was sitting exactly at the oxlint complexity gate (12). Adding the injected `idGenerator` parameter pushed it to 13, so the recovery-policy resolution (`{ ...(recoveryPolicy ?? getDeviceRecoveryPolicy()) }`) was extracted into a small `resolveRecoveryPolicy` helper to move that decision point out of the constructor body. Behavior is unchanged.

## Validation

- [x] `bun run lint` passes (ratchet: no new violations)
- [x] `bun test` passes (13816 pass, 0 fail)
- [x] `bun run typecheck` reports no new errors (baseline gate)
- [x] `bun run build` succeeds
- [x] New tests use interfaces + fakes; run in <100ms
