### PR TITLE
perf(android): serialize hierarchy once and skip throttled file writes

### DIFF
--- a/android/control-proxy/src/main/kotlin/dev/jasonpearson/automobile/ctrlproxy/CtrlProxy.kt
+++ b/android/control-proxy/src/main/kotlin/dev/jasonpearson/automobile/ctrlproxy/CtrlProxy.kt
@@ -476,10 +476,6 @@ class CtrlProxy : AccessibilityService(), CtrlProxyActions {
   private val recompositionStore = RecompositionStore()
   private val frameMetricsStore = FrameMetricsStore()
   private val viewHierarchyExtractor = ViewHierarchyExtractor(recompositionStore)
-  private val json = Json {
-    prettyPrint = true
-    encodeDefaults = true
-  }
   private val jsonCompact = Json {
     prettyPrint = false
     encodeDefaults = true
@@ -1252,9 +1248,19 @@ class CtrlProxy : AccessibilityService(), CtrlProxyActions {
                   TAG,
                   "Hierarchy changed (hash=${result.hash}, extraction=${result.extractionTimeMs}ms)",
                 )
-                writeHierarchyToFile(result.hierarchy)
+                // Only serialize and persist a Changed frame that will actually broadcast. A
+                // throttled frame skips both the wire push and the flushed disk write (issue
+                // #5469) — the debug file is refreshed by the next non-throttled broadcast and
+                // force-written by every explicit hierarchy request, so no real consumer is staled.
                 if (broadcastThrottler.shouldBroadcast()) {
-                  broadcastHierarchyUpdate(result.hierarchy)
+                  // Serialize the tree exactly once and reuse the compact wire form for the debug
+                  // file, so a single Changed result never serializes twice (issue #5469).
+                  val serialized =
+                    perfProvider.track("serializeHierarchy") {
+                      jsonCompact.encodeToString(result.hierarchy)
+                    }
+                  writeHierarchyToFile(result.hierarchy, serialized = serialized)
+                  broadcastHierarchyUpdate(result.hierarchy, serialized = serialized)
                 } else {
                   extractedHierarchyFrameContexts.remove(result.hierarchy)
                   Log.d(
@@ -2741,18 +2747,28 @@ class CtrlProxy : AccessibilityService(), CtrlProxyActions {
         snapshotOptions = snapshotOptions,
       )
     if (hierarchy != null) {
-      writeHierarchyToFile(hierarchy)
-      kotlinx.coroutines.runBlocking { broadcastHierarchyUpdate(hierarchy, sync = true) }
+      // Explicit request: force-write the file and broadcast, serializing the tree once (#5469).
+      val serialized =
+        perfProvider.track("serializeHierarchy") { jsonCompact.encodeToString(hierarchy) }
+      writeHierarchyToFile(hierarchy, serialized = serialized)
+      kotlinx.coroutines.runBlocking {
+        broadcastHierarchyUpdate(hierarchy, sync = true, serialized = serialized)
+      }
     }
   }
 
-  /** Writes the hierarchy to a file for synchronous access */
+  /**
+   * Writes the hierarchy to a file for synchronous access. Callers that already serialized the tree
+   * for the wire frame pass that exact compact string via [serialized] so a single change is never
+   * serialized twice (issue #5469); the file therefore holds the same canonical form as the wire.
+   */
   private fun writeHierarchyToFile(
     hierarchy: ViewHierarchy,
     filename: String = HIERARCHY_FILE_NAME,
+    serialized: String? = null,
   ) {
     try {
-      val jsonString = json.encodeToString(hierarchy)
+      val jsonString = serialized ?: jsonCompact.encodeToString(hierarchy)
       val jsonBytes = jsonString.toByteArray()
       openFileOutput(filename, Context.MODE_PRIVATE).use { output ->
         Log.d(TAG, "Writing ${jsonBytes.size} bytes to $filename")
@@ -2787,10 +2803,13 @@ class CtrlProxy : AccessibilityService(), CtrlProxyActions {
           val hierarchy = extractHierarchy(textFilter, disableAllFiltering)
           if (hierarchy != null) {
             val filename = "hierarchy_$uuid.json"
-            writeHierarchyToFile(hierarchy, filename)
+            // Explicit request: serialize once and reuse for the file and the wire frame (#5469).
+            val serialized =
+              perfProvider.track("serializeHierarchy") { jsonCompact.encodeToString(hierarchy) }
+            writeHierarchyToFile(hierarchy, filename, serialized = serialized)
 
             // Broadcast to WebSocket clients
-            broadcastHierarchyUpdate(hierarchy)
+            broadcastHierarchyUpdate(hierarchy, serialized = serialized)
 
             val message =
               if (textFilter != null) {
@@ -2919,7 +2938,11 @@ class CtrlProxy : AccessibilityService(), CtrlProxyActions {
    * @param sync If true, waits for delivery to all clients before returning. Use for critical
    *   ordering.
    */
-  private suspend fun broadcastHierarchyUpdate(hierarchy: ViewHierarchy, sync: Boolean = false) {
+  private suspend fun broadcastHierarchyUpdate(
+    hierarchy: ViewHierarchy,
+    sync: Boolean = false,
+    serialized: String? = null,
+  ) {
     val contextAtExtraction = extractedHierarchyFrameContexts.remove(hierarchy)
     if (!::webSocketServer.isInitialized || !webSocketServer.isRunning()) {
       Log.d(TAG, "WebSocket server not running, skipping broadcast")
@@ -2927,8 +2950,11 @@ class CtrlProxy : AccessibilityService(), CtrlProxyActions {
     }
 
     try {
+      // Reuse the string the caller already serialized for the disk file when present, so a single
+      // change is serialized at most once (issue #5469); otherwise serialize the wire form here.
       val jsonString =
-        perfProvider.track("serializeHierarchy") { jsonCompact.encodeToString(hierarchy) }
+        serialized
+          ?: perfProvider.track("serializeHierarchy") { jsonCompact.encodeToString(hierarchy) }
 
       val messageBuilder: (kotlinx.serialization.json.JsonElement?) -> String = { perfTiming ->
         buildString {

--- a/android/control-proxy/src/main/kotlin/dev/jasonpearson/automobile/ctrlproxy/CtrlProxy.kt
+++ b/android/control-proxy/src/main/kotlin/dev/jasonpearson/automobile/ctrlproxy/CtrlProxy.kt
@@ -1242,51 +1242,66 @@ class CtrlProxy : AccessibilityService(), CtrlProxyActions {
       hierarchyFlowJob =
         hierarchyDebouncer.hierarchyFlow
           .onEach { result ->
-            when (result) {
-              is HierarchyResult.Changed -> {
-                Log.d(
-                  TAG,
-                  "Hierarchy changed (hash=${result.hash}, extraction=${result.extractionTimeMs}ms)",
-                )
-                // Only serialize and persist a Changed frame that will actually broadcast. A
-                // throttled frame skips both the wire push and the flushed disk write (issue
-                // #5469) — the debug file is refreshed by the next non-throttled broadcast and
-                // force-written by every explicit hierarchy request, so no real consumer is staled.
-                if (broadcastThrottler.shouldBroadcast()) {
-                  // Serialize the tree exactly once and reuse the compact wire form for the debug
-                  // file, so a single Changed result never serializes twice (issue #5469).
-                  val serialized =
-                    perfProvider.track("serializeHierarchy") {
-                      jsonCompact.encodeToString(result.hierarchy)
-                    }
-                  writeHierarchyToFile(result.hierarchy, serialized = serialized)
-                  broadcastHierarchyUpdate(result.hierarchy, serialized = serialized)
-                } else {
-                  extractedHierarchyFrameContexts.remove(result.hierarchy)
+            // Guard the whole body: serialization was hoisted here (issue #5469) out of
+            // writeHierarchyToFile/broadcastHierarchyUpdate's own try/catch, so an encode failure
+            // on
+            // one frame (e.g. a NaN/Infinity textSizeInPx) would otherwise complete this collector
+            // —
+            // and it is never relaunched, silently losing all later unsolicited updates. Swallow so
+            // one bad frame is dropped, not the whole flow.
+            try {
+              when (result) {
+                is HierarchyResult.Changed -> {
                   Log.d(
                     TAG,
-                    "Throttled event-driven broadcast (${broadcastThrottler.timeSinceLastBroadcastMs()}ms since last)",
+                    "Hierarchy changed (hash=${result.hash}, extraction=${result.extractionTimeMs}ms)",
                   )
+                  // Only serialize and persist a Changed frame that will actually broadcast. A
+                  // throttled frame skips both the wire push and the flushed disk write (issue
+                  // #5469) — the debug file is refreshed by the next non-throttled broadcast and
+                  // force-written by every explicit hierarchy request, so no real consumer is
+                  // staled.
+                  if (broadcastThrottler.shouldBroadcast()) {
+                    // Serialize the tree exactly once and reuse the compact wire form for the debug
+                    // file, so a single Changed result never serializes twice (issue #5469).
+                    val serialized =
+                      perfProvider.track("serializeHierarchy") {
+                        jsonCompact.encodeToString(result.hierarchy)
+                      }
+                    writeHierarchyToFile(result.hierarchy, serialized = serialized)
+                    broadcastHierarchyUpdate(result.hierarchy, serialized = serialized)
+                  } else {
+                    extractedHierarchyFrameContexts.remove(result.hierarchy)
+                    Log.d(
+                      TAG,
+                      "Throttled event-driven broadcast (${broadcastThrottler.timeSinceLastBroadcastMs()}ms since last)",
+                    )
+                  }
                 }
-              }
-              is HierarchyResult.Unchanged -> {
-                Log.d(
-                  TAG,
-                  "Hierarchy unchanged (animation mode, skipped=${result.skippedEventCount})",
-                )
-                if (broadcastThrottler.shouldBroadcast()) {
-                  broadcastHierarchyUpdate(result.hierarchy)
-                } else {
-                  extractedHierarchyFrameContexts.remove(result.hierarchy)
+                is HierarchyResult.Unchanged -> {
                   Log.d(
                     TAG,
-                    "Throttled event-driven broadcast (${broadcastThrottler.timeSinceLastBroadcastMs()}ms since last)",
+                    "Hierarchy unchanged (animation mode, skipped=${result.skippedEventCount})",
                   )
+                  if (broadcastThrottler.shouldBroadcast()) {
+                    broadcastHierarchyUpdate(result.hierarchy)
+                  } else {
+                    extractedHierarchyFrameContexts.remove(result.hierarchy)
+                    Log.d(
+                      TAG,
+                      "Throttled event-driven broadcast (${broadcastThrottler.timeSinceLastBroadcastMs()}ms since last)",
+                    )
+                  }
+                }
+                is HierarchyResult.Error -> {
+                  Log.w(TAG, "Hierarchy extraction error: ${result.message}")
                 }
               }
-              is HierarchyResult.Error -> {
-                Log.w(TAG, "Hierarchy extraction error: ${result.message}")
-              }
+            } catch (e: CancellationException) {
+              // Let cooperative cancellation unwind the collector normally.
+              throw e
+            } catch (e: Exception) {
+              Log.e(TAG, "Error handling hierarchy result — dropping this frame", e)
             }
           }
           .launchIn(serviceScope)

--- a/android/control-proxy/src/main/kotlin/dev/jasonpearson/automobile/ctrlproxy/CtrlProxy.kt
+++ b/android/control-proxy/src/main/kotlin/dev/jasonpearson/automobile/ctrlproxy/CtrlProxy.kt
@@ -223,6 +223,41 @@ internal fun navigationEventResponse(event: TimestampedNavigationEvent): Navigat
   )
 
 /**
+ * Owns the "serialize once → write file → broadcast → always release the frame-context entry"
+ * sequence for a single hierarchy delivery (issue #5469 follow-up).
+ *
+ * Serialization was hoisted out of the writer/broadcaster's own try/catch so a change is serialized
+ * at most once (the one [serialize] result is reused for both [write] and [broadcast]). That move
+ * exposed a leak: [CtrlProxy.extractedHierarchyFrameContexts] is a strong-keyed identity map that
+ * only the broadcaster removed from, so an encode failure (e.g. a NaN/Infinity `textSizeInPx`)
+ * before the broadcast would retain a full hierarchy forever. Centralizing the sequence guarantees
+ * [releaseFrameContext] runs in a `finally` even when [serialize] throws, so no call site can
+ * serialize-then-leak.
+ *
+ * A failure in [serialize] (or [write]/[broadcast]) skips the remaining steps and rethrows so the
+ * caller drops just that one frame; the frame-context entry is released regardless. This function
+ * is pure over its injected seams — no Android or service state — so it is unit-testable with a
+ * counting serializer and fake writer/broadcaster.
+ */
+internal suspend fun deliverHierarchyFrame(
+  serialize: () -> String,
+  write: (String) -> Unit,
+  broadcast: suspend (String) -> Unit,
+  releaseFrameContext: () -> Unit,
+) {
+  try {
+    val serialized = serialize()
+    write(serialized)
+    broadcast(serialized)
+  } finally {
+    // Runs on every path: on success the broadcaster already removed the entry (this is a no-op
+    // safety net); on a serialize/write/broadcast failure this is the only removal, closing the
+    // leak. remove() is idempotent, so the redundant success-path call is harmless.
+    releaseFrameContext()
+  }
+}
+
+/**
  * Main AutoMobile Accessibility Service that provides view hierarchy extraction capabilities for
  * automated testing and UI interaction.
  */
@@ -1263,13 +1298,24 @@ class CtrlProxy : AccessibilityService(), CtrlProxyActions {
                   // staled.
                   if (broadcastThrottler.shouldBroadcast()) {
                     // Serialize the tree exactly once and reuse the compact wire form for the debug
-                    // file, so a single Changed result never serializes twice (issue #5469).
-                    val serialized =
-                      perfProvider.track("serializeHierarchy") {
-                        jsonCompact.encodeToString(result.hierarchy)
-                      }
-                    writeHierarchyToFile(result.hierarchy, serialized = serialized)
-                    broadcastHierarchyUpdate(result.hierarchy, serialized = serialized)
+                    // file, so a single Changed result never serializes twice (issue #5469). The
+                    // frame-context entry is released even if the encode throws (leak fix).
+                    deliverHierarchyFrame(
+                      serialize = {
+                        perfProvider.track("serializeHierarchy") {
+                          jsonCompact.encodeToString(result.hierarchy)
+                        }
+                      },
+                      write = { serialized ->
+                        writeHierarchyToFile(result.hierarchy, serialized = serialized)
+                      },
+                      broadcast = { serialized ->
+                        broadcastHierarchyUpdate(result.hierarchy, serialized = serialized)
+                      },
+                      releaseFrameContext = {
+                        extractedHierarchyFrameContexts.remove(result.hierarchy)
+                      },
+                    )
                   } else {
                     extractedHierarchyFrameContexts.remove(result.hierarchy)
                     Log.d(
@@ -2763,11 +2809,19 @@ class CtrlProxy : AccessibilityService(), CtrlProxyActions {
       )
     if (hierarchy != null) {
       // Explicit request: force-write the file and broadcast, serializing the tree once (#5469).
-      val serialized =
-        perfProvider.track("serializeHierarchy") { jsonCompact.encodeToString(hierarchy) }
-      writeHierarchyToFile(hierarchy, serialized = serialized)
+      // Routed through deliverHierarchyFrame so the frame-context entry is released even if the
+      // encode throws (leak fix).
       kotlinx.coroutines.runBlocking {
-        broadcastHierarchyUpdate(hierarchy, sync = true, serialized = serialized)
+        deliverHierarchyFrame(
+          serialize = {
+            perfProvider.track("serializeHierarchy") { jsonCompact.encodeToString(hierarchy) }
+          },
+          write = { serialized -> writeHierarchyToFile(hierarchy, serialized = serialized) },
+          broadcast = { serialized ->
+            broadcastHierarchyUpdate(hierarchy, sync = true, serialized = serialized)
+          },
+          releaseFrameContext = { extractedHierarchyFrameContexts.remove(hierarchy) },
+        )
       }
     }
   }
@@ -2819,12 +2873,20 @@ class CtrlProxy : AccessibilityService(), CtrlProxyActions {
           if (hierarchy != null) {
             val filename = "hierarchy_$uuid.json"
             // Explicit request: serialize once and reuse for the file and the wire frame (#5469).
-            val serialized =
-              perfProvider.track("serializeHierarchy") { jsonCompact.encodeToString(hierarchy) }
-            writeHierarchyToFile(hierarchy, filename, serialized = serialized)
-
-            // Broadcast to WebSocket clients
-            broadcastHierarchyUpdate(hierarchy, serialized = serialized)
+            // Routed through deliverHierarchyFrame so the frame-context entry is released even if
+            // the encode throws (leak fix) — the outer catch still reports the failure frame.
+            deliverHierarchyFrame(
+              serialize = {
+                perfProvider.track("serializeHierarchy") { jsonCompact.encodeToString(hierarchy) }
+              },
+              write = { serialized ->
+                writeHierarchyToFile(hierarchy, filename, serialized = serialized)
+              },
+              broadcast = { serialized ->
+                broadcastHierarchyUpdate(hierarchy, serialized = serialized)
+              },
+              releaseFrameContext = { extractedHierarchyFrameContexts.remove(hierarchy) },
+            )
 
             val message =
               if (textFilter != null) {

--- a/android/control-proxy/src/test/kotlin/dev/jasonpearson/automobile/ctrlproxy/DeliverHierarchyFrameTest.kt
+++ b/android/control-proxy/src/test/kotlin/dev/jasonpearson/automobile/ctrlproxy/DeliverHierarchyFrameTest.kt
@@ -1,0 +1,193 @@
+package dev.jasonpearson.automobile.ctrlproxy
+
+import kotlinx.coroutines.runBlocking
+import org.junit.Assert.assertEquals
+import org.junit.Assert.assertNull
+import org.junit.Assert.assertSame
+import org.junit.Assert.assertTrue
+import org.junit.Assert.fail
+import org.junit.Test
+
+/**
+ * Behavioral guard for the issue #5469 follow-up leak fix.
+ *
+ * [deliverHierarchyFrame] centralizes "serialize once → write file → broadcast → always release the
+ * frame-context entry" so that hoisting serialization out of the writer/broadcaster's try/catch can
+ * no longer leak [CtrlProxy.extractedHierarchyFrameContexts] entries on an encode failure.
+ *
+ * These tests drive the real function with a counting serializer and fake writer/broadcaster — no
+ * AccessibilityService, no device — proving the contract directly rather than by source shape:
+ * 1. a single delivery serializes exactly once and the SAME string reaches the writer and the
+ *    broadcaster (single-serialization reuse);
+ * 2. a serializer that throws still releases the frame-context entry (the leak regression guard)
+ *    and never writes or broadcasts, and the failure propagates so the caller drops just that
+ *    frame;
+ * 3. a writer or broadcaster failure likewise still releases the entry.
+ */
+class DeliverHierarchyFrameTest {
+
+  private class Fakes {
+    var serializeCount = 0
+    val written = mutableListOf<String>()
+    val broadcast = mutableListOf<String>()
+    var releaseCount = 0
+  }
+
+  @Test
+  fun `a single delivery serializes once and reuses the same string for write and broadcast`() {
+    val fakes = Fakes()
+    val payload = "{\"hierarchy\":\"once\"}"
+
+    runBlocking {
+      deliverHierarchyFrame(
+        serialize = {
+          fakes.serializeCount++
+          payload
+        },
+        write = { fakes.written += it },
+        broadcast = { fakes.broadcast += it },
+        releaseFrameContext = { fakes.releaseCount++ },
+      )
+    }
+
+    assertEquals("serialize must run exactly once per delivery", 1, fakes.serializeCount)
+    assertEquals(listOf(payload), fakes.written)
+    assertEquals(listOf(payload), fakes.broadcast)
+    // The wire frame and the debug file must be the identical string instance (reuse, not
+    // re-encode).
+    assertSame(
+      "the writer and broadcaster must receive the SAME serialized instance",
+      fakes.written.single(),
+      fakes.broadcast.single(),
+    )
+    assertEquals("the frame-context entry must be released once", 1, fakes.releaseCount)
+  }
+
+  @Test
+  fun `a serializer failure still releases the frame-context entry and skips write and broadcast`() {
+    val fakes = Fakes()
+    val boom = RuntimeException("NaN textSizeInPx cannot be encoded")
+
+    val thrown =
+      try {
+        runBlocking {
+          deliverHierarchyFrame(
+            serialize = {
+              fakes.serializeCount++
+              throw boom
+            },
+            write = { fakes.written += it },
+            broadcast = { fakes.broadcast += it },
+            releaseFrameContext = { fakes.releaseCount++ },
+          )
+        }
+        null
+      } catch (e: RuntimeException) {
+        e
+      }
+
+    assertEquals("serialize was attempted once", 1, fakes.serializeCount)
+    assertTrue("nothing may be written when serialization fails", fakes.written.isEmpty())
+    assertTrue("nothing may be broadcast when serialization fails", fakes.broadcast.isEmpty())
+    assertEquals(
+      "the frame-context entry MUST still be released on serialize failure (leak fix #5469)",
+      1,
+      fakes.releaseCount,
+    )
+    assertSame("the delivery failure must propagate so the caller drops the frame", boom, thrown)
+  }
+
+  @Test
+  fun `a writer failure still releases the frame-context entry`() {
+    val fakes = Fakes()
+    val boom = RuntimeException("disk full")
+
+    val thrown =
+      try {
+        runBlocking {
+          deliverHierarchyFrame(
+            serialize = {
+              fakes.serializeCount++
+              "payload"
+            },
+            write = { throw boom },
+            broadcast = { fakes.broadcast += it },
+            releaseFrameContext = { fakes.releaseCount++ },
+          )
+        }
+        null
+      } catch (e: RuntimeException) {
+        e
+      }
+
+    assertEquals(1, fakes.serializeCount)
+    assertTrue("broadcast must not run after a write failure", fakes.broadcast.isEmpty())
+    assertEquals(
+      "the frame-context entry MUST still be released on write failure (leak fix #5469)",
+      1,
+      fakes.releaseCount,
+    )
+    assertSame(boom, thrown)
+  }
+
+  @Test
+  fun `a broadcaster failure still releases the frame-context entry`() {
+    val fakes = Fakes()
+    val boom = RuntimeException("socket closed")
+
+    val thrown =
+      try {
+        runBlocking {
+          deliverHierarchyFrame(
+            serialize = {
+              fakes.serializeCount++
+              "payload"
+            },
+            write = { fakes.written += it },
+            broadcast = { throw boom },
+            releaseFrameContext = { fakes.releaseCount++ },
+          )
+        }
+        null
+      } catch (e: RuntimeException) {
+        e
+      }
+
+    assertEquals(1, fakes.serializeCount)
+    assertEquals("the write ran before the broadcast failed", listOf("payload"), fakes.written)
+    assertEquals(
+      "the frame-context entry MUST still be released on broadcast failure (leak fix #5469)",
+      1,
+      fakes.releaseCount,
+    )
+    assertSame(boom, thrown)
+  }
+
+  @Test
+  fun `delivery models the real leak seam an identity map entry is removed even on failure`() {
+    // Mirror the real seam: a strong-keyed identity map that only the delivery removes from. Prove
+    // a
+    // failed encode does not retain the key (the exact heap-exhaustion path from repeated invalid
+    // hierarchies).
+    val hierarchy = Any()
+    val frameContexts = java.util.IdentityHashMap<Any, String>()
+    frameContexts[hierarchy] = "epoch:token"
+
+    try {
+      runBlocking {
+        deliverHierarchyFrame(
+          serialize = { throw RuntimeException("Infinity") },
+          write = {},
+          broadcast = {},
+          releaseFrameContext = { frameContexts.remove(hierarchy) },
+        )
+      }
+      fail("expected the serialize failure to propagate")
+    } catch (_: RuntimeException) {
+      // expected — the caller drops the frame
+    }
+
+    assertNull("a failed delivery must not retain the hierarchy key", frameContexts[hierarchy])
+    assertTrue(frameContexts.isEmpty())
+  }
+}

--- a/android/control-proxy/src/test/kotlin/dev/jasonpearson/automobile/ctrlproxy/HierarchyWriteSerializationWiringTest.kt
+++ b/android/control-proxy/src/test/kotlin/dev/jasonpearson/automobile/ctrlproxy/HierarchyWriteSerializationWiringTest.kt
@@ -1,0 +1,131 @@
+package dev.jasonpearson.automobile.ctrlproxy
+
+import java.io.File
+import org.junit.Assert.assertEquals
+import org.junit.Assert.assertTrue
+import org.junit.Assert.fail
+import org.junit.Test
+
+/**
+ * Structural regression guard for issue #5469.
+ *
+ * CtrlProxy is an AccessibilityService and cannot be constructed in a fast unit test, so this test
+ * scans the live source (masking literals/comments so braces inside strings do not fool the
+ * matcher) to enforce the two acceptance criteria:
+ * 1. A single `Changed` result serializes the tree at most once — the compact wire string is reused
+ *    for the debug-file write rather than serialized a second time. The former pretty-printed
+ *    `json` file serializer is retired entirely.
+ * 2. A throttled `Changed` frame pays no disk write — `writeHierarchyToFile` for the event path
+ *    lives inside the `shouldBroadcast()` branch, so a throttled frame skips it.
+ */
+class HierarchyWriteSerializationWiringTest {
+
+  @Test
+  fun `the changed-result handler writes the hierarchy file only when it broadcasts`() {
+    val source = KotlinSourceScan.maskLiteralsAndComments(readCtrlProxySource())
+    val changedBranch = changedBranchBody(source)
+
+    val shouldBroadcastIdx = changedBranch.indexOf("broadcastThrottler.shouldBroadcast()")
+    assertTrue(
+      "the Changed branch must gate on broadcastThrottler.shouldBroadcast()",
+      shouldBroadcastIdx >= 0,
+    )
+
+    val ifBraceOpen = changedBranch.indexOf('{', shouldBroadcastIdx)
+    assertTrue("the shouldBroadcast() if-block must have a body", ifBraceOpen >= 0)
+    val ifBraceClose = KotlinSourceScan.matchBrace(changedBranch, ifBraceOpen)
+    val broadcastBlock = changedBranch.substring(ifBraceOpen, ifBraceClose)
+    val elseBlock = changedBranch.substring(ifBraceClose)
+
+    assertTrue(
+      "the event-path disk write must live inside the shouldBroadcast() branch so a throttled " +
+        "frame pays no flushed disk write (issue #5469)",
+      "writeHierarchyToFile" in broadcastBlock,
+    )
+    assertTrue(
+      "a throttled frame must not write the hierarchy file (issue #5469)",
+      "writeHierarchyToFile" !in elseBlock,
+    )
+    assertEquals(
+      "the Changed branch must call writeHierarchyToFile exactly once (only on the broadcast path)",
+      1,
+      Regex("writeHierarchyToFile").findAll(changedBranch).count(),
+    )
+  }
+
+  @Test
+  fun `a single changed result serializes the hierarchy at most once and reuses it`() {
+    val source = KotlinSourceScan.maskLiteralsAndComments(readCtrlProxySource())
+    val changedBranch = changedBranchBody(source)
+
+    assertEquals(
+      "a single Changed result must serialize the tree at most once (issue #5469)",
+      1,
+      Regex("""jsonCompact\.encodeToString""").findAll(changedBranch).count(),
+    )
+    assertTrue(
+      "the Changed branch must reuse the single serialization for both the file and the wire " +
+        "frame via the `serialized = ` parameter (issue #5469)",
+      Regex("""writeHierarchyToFile\([^)]*serialized\s*=""").containsMatchIn(changedBranch) &&
+        Regex("""broadcastHierarchyUpdate\([^)]*serialized\s*=""").containsMatchIn(changedBranch),
+    )
+  }
+
+  @Test
+  fun `the pretty-print json serializer used only for the hierarchy file is retired`() {
+    val source = KotlinSourceScan.maskLiteralsAndComments(readCtrlProxySource())
+    // The former `private val json = Json { prettyPrint = true ... }` existed solely to serialize
+    // the hierarchy file a second time. With one canonical (compact) serialization it is gone; the
+    // remaining Json instances are jsonCompact and jsonLenient.
+    assertTrue(
+      "the redundant pretty-print `json` serializer must be removed (issue #5469)",
+      !Regex("""\bval\s+json\s*=\s*Json\b""").containsMatchIn(source),
+    )
+    assertTrue(
+      "the hierarchy file must be serialized with the canonical compact form",
+      "jsonCompact.encodeToString" in writeHierarchyToFileBody(source),
+    )
+  }
+
+  private fun changedBranchBody(source: String): String {
+    val marker = "is HierarchyResult.Changed ->"
+    val start = source.indexOf(marker)
+    assertTrue("HierarchyResult.Changed branch not found in CtrlProxy.kt", start >= 0)
+    val braceOpen = source.indexOf('{', start)
+    assertTrue("Changed branch body not found", braceOpen >= 0)
+    return source.substring(braceOpen, KotlinSourceScan.matchBrace(source, braceOpen))
+  }
+
+  private fun writeHierarchyToFileBody(source: String): String {
+    val start = source.indexOf("private fun writeHierarchyToFile(")
+    assertTrue("writeHierarchyToFile not found in CtrlProxy.kt", start >= 0)
+    val braceOpen = source.indexOf('{', source.indexOf(')', start))
+    assertTrue("writeHierarchyToFile body not found", braceOpen >= 0)
+    return source.substring(braceOpen, KotlinSourceScan.matchBrace(source, braceOpen))
+  }
+
+  private fun readCtrlProxySource(): String = locateCtrlProxySource().readText()
+
+  private fun locateCtrlProxySource(): File {
+    val rel = "src/main/kotlin/dev/jasonpearson/automobile/ctrlproxy/CtrlProxy.kt"
+    val direct =
+      listOf(File(rel), File("control-proxy/$rel"), File("android/control-proxy/$rel"))
+        .firstOrNull { it.isFile }
+    if (direct != null) return direct
+
+    var dir: File? = File(System.getProperty("user.dir") ?: ".").absoluteFile
+    while (dir != null) {
+      for (candidate in
+        listOf(
+          File(dir, rel),
+          File(dir, "control-proxy/$rel"),
+          File(dir, "android/control-proxy/$rel"),
+        )) {
+        if (candidate.isFile) return candidate
+      }
+      dir = dir.parentFile
+    }
+    fail("Could not locate CtrlProxy.kt from user.dir=${System.getProperty("user.dir")}")
+    error("unreachable")
+  }
+}

--- a/android/control-proxy/src/test/kotlin/dev/jasonpearson/automobile/ctrlproxy/HierarchyWriteSerializationWiringTest.kt
+++ b/android/control-proxy/src/test/kotlin/dev/jasonpearson/automobile/ctrlproxy/HierarchyWriteSerializationWiringTest.kt
@@ -87,6 +87,30 @@ class HierarchyWriteSerializationWiringTest {
     )
   }
 
+  @Test
+  fun `the hierarchy collector guards its body so one bad frame cannot kill the flow`() {
+    // Regression guard (Codex on #5469): serialization was hoisted into the hierarchyFlow
+    // collector,
+    // out of writeHierarchyToFile/broadcastHierarchyUpdate's own try/catch. An encode failure on
+    // one
+    // frame must not complete the collector (it is launchIn'd once and never relaunched), so the
+    // onEach body must be wrapped in try/catch.
+    val source = KotlinSourceScan.maskLiteralsAndComments(readCtrlProxySource())
+    val flowStart = source.indexOf("hierarchyDebouncer.hierarchyFlow")
+    assertTrue("hierarchyFlow collector not found in CtrlProxy.kt", flowStart >= 0)
+    val onEachOpen = source.indexOf('{', source.indexOf(".onEach", flowStart))
+    assertTrue("hierarchyFlow .onEach body not found", onEachOpen >= 0)
+    val onEachBody = source.substring(onEachOpen, KotlinSourceScan.matchBrace(source, onEachOpen))
+
+    val tryIdx = onEachBody.indexOf("try {")
+    val whenIdx = onEachBody.indexOf("when (result)")
+    assertTrue("the hierarchy collector body must open a try block", tryIdx in 0 until whenIdx)
+    assertTrue(
+      "the hierarchy collector must catch exceptions so one bad frame cannot complete the flow",
+      Regex("""catch\s*\(\s*\w+\s*:\s*Exception\s*\)""").containsMatchIn(onEachBody),
+    )
+  }
+
   private fun changedBranchBody(source: String): String {
     val marker = "is HierarchyResult.Changed ->"
     val start = source.indexOf(marker)

--- a/android/control-proxy/src/test/kotlin/dev/jasonpearson/automobile/ctrlproxy/HierarchyWriteSerializationWiringTest.kt
+++ b/android/control-proxy/src/test/kotlin/dev/jasonpearson/automobile/ctrlproxy/HierarchyWriteSerializationWiringTest.kt
@@ -81,9 +81,39 @@ class HierarchyWriteSerializationWiringTest {
       "the redundant pretty-print `json` serializer must be removed (issue #5469)",
       !Regex("""\bval\s+json\s*=\s*Json\b""").containsMatchIn(source),
     )
+    val writeBody = writeHierarchyToFileBody(source)
     assertTrue(
-      "the hierarchy file must be serialized with the canonical compact form",
-      "jsonCompact.encodeToString" in writeHierarchyToFileBody(source),
+      "writeHierarchyToFile must PREFER the caller's already-serialized string (`serialized ?:`) so " +
+        "a passed frame is never re-encoded (issue #5469)",
+      Regex("""serialized\s*\?:""").containsMatchIn(writeBody),
+    )
+    assertTrue(
+      "the fallback (serialized == null) must use the canonical compact form",
+      "jsonCompact.encodeToString" in writeBody,
+    )
+  }
+
+  @Test
+  fun `every serialize-then-deliver call site routes through the leak-safe deliverHierarchyFrame seam`() {
+    // Issue #5469 follow-up: serialization was hoisted ahead of broadcastHierarchyUpdate (the only
+    // remover of the strong-keyed frame-context map). Every call site that serializes-then-delivers
+    // must go through deliverHierarchyFrame, whose finally releases the entry even when the encode
+    // throws — so no site can serialize-then-leak. Guard against a future inline regression by
+    // requiring that no serialize-then-write/broadcast happens outside the seam.
+    val source = KotlinSourceScan.maskLiteralsAndComments(readCtrlProxySource())
+
+    // The three delivery sites: collector Changed, extractHierarchyNow, ACTION_EXTRACT_HIERARCHY.
+    // Exclude the `fun deliverHierarchyFrame(` definition itself.
+    assertEquals(
+      "all three serialize-then-deliver call sites must route through deliverHierarchyFrame",
+      3,
+      Regex("""(?<!fun )deliverHierarchyFrame\(""").findAll(source).count(),
+    )
+    // deliverHierarchyFrame must release the frame context in a finally, on every path.
+    val seam = deliverHierarchyFrameBody(source)
+    assertTrue(
+      "deliverHierarchyFrame must release the frame-context entry in a finally block",
+      Regex("""finally\s*\{""").containsMatchIn(seam) && "releaseFrameContext()" in seam,
     )
   }
 
@@ -117,6 +147,18 @@ class HierarchyWriteSerializationWiringTest {
     assertTrue("HierarchyResult.Changed branch not found in CtrlProxy.kt", start >= 0)
     val braceOpen = source.indexOf('{', start)
     assertTrue("Changed branch body not found", braceOpen >= 0)
+    return source.substring(braceOpen, KotlinSourceScan.matchBrace(source, braceOpen))
+  }
+
+  private fun deliverHierarchyFrameBody(source: String): String {
+    val marker = "internal suspend fun deliverHierarchyFrame("
+    val start = source.indexOf(marker)
+    assertTrue("deliverHierarchyFrame not found in CtrlProxy.kt", start >= 0)
+    // The signature has nested parens (e.g. `broadcast: suspend (String) -> Unit`), so balance from
+    // the parameter-list '(' rather than scanning for the first ')'.
+    val parenClose = KotlinSourceScan.matchParen(source, start + marker.length - 1)
+    val braceOpen = source.indexOf('{', parenClose)
+    assertTrue("deliverHierarchyFrame body not found", braceOpen >= 0)
     return source.substring(braceOpen, KotlinSourceScan.matchBrace(source, braceOpen))
   }
 


### PR DESCRIPTION
## Summary

Each hierarchy change serialized the full tree **twice** — once with the pretty-printed `json` for the on-disk debug file, once with `jsonCompact` for the wire — and always wrote the file with `flush()` even when the subsequent broadcast was throttled away. This fixes both.

Closes #5469

## Change

- **Serialize once.** A `Changed` frame now serializes the tree exactly once (compact, under the existing `perfProvider.track("serializeHierarchy")`) and reuses that same string for both `writeHierarchyToFile` and `broadcastHierarchyUpdate`. `writeHierarchyToFile` and `broadcastHierarchyUpdate` gained an optional `serialized: String?` that callers pass to avoid re-serializing. The explicit-request paths (`extractHierarchyNow`, `ACTION_EXTRACT_HIERARCHY`) do the same.
- **Skip the throttled write.** The event-path disk write moved inside the `shouldBroadcast()` branch, so a throttled frame pays neither the wire push nor a flushed disk write.
- The now-redundant pretty-print `json` serializer (its only use was the second serialization of the file) is removed.

## One-serialization decision

I collapsed to a **single canonical form: the compact wire string**, reused verbatim for `latest_hierarchy.json`. I did not keep two formats. Before changing the file format I grepped `android/` and `src/` for readers of the hierarchy file:

- `android/control-proxy/README.md` — documents `adb shell run-as … cat files/latest_hierarchy.json` (human/`jq` inspection; whitespace-agnostic).
- `android/desktop-core/.../layout/HierarchyParser.kt` — parses the JSON structurally (`jsonObject`), formatting-agnostic.
- The daemon reads the hierarchy over the **WebSocket wire** (already compact via `waitForFreshData`), not from the file.

No consumer depends on pretty-printing, so compact is safe and the file now matches the wire byte-for-byte.

## Throttled-write case without staling a real consumer

The debug file's real consumers read it **on demand**, and every on-demand path force-writes it: `extractHierarchyNow` (WebSocket `requestHierarchy`) and `ACTION_EXTRACT_HIERARCHY` both write the file before responding. The event-driven writes only kept the file "warm" between requests; skipping them on throttled frames means the file tracks the last non-throttled broadcast (≤ the broadcast interval) and is always refreshed the instant a real consumer asks. No consumer that is supposed to see a current hierarchy is staled.

## Broadcast behavior unchanged

The wire frame carries the identical compact `data` payload and the same `perfProvider.track("serializeHierarchy")` sample as before — only the redundant file serialization was removed. No change to what is broadcast, when, or the throttle semantics.

## Tests

- New `HierarchyWriteSerializationWiringTest` (source-scan guard; CtrlProxy is an AccessibilityService and cannot be unit-constructed): asserts a single `Changed` result serializes at most once and reuses it for file + wire; the event-path `writeHierarchyToFile` lives only inside the `shouldBroadcast()` branch (throttled ⇒ no disk write); and the redundant pretty `json` serializer is gone.
- Full suite: `./gradlew -p android :control-proxy:testDebugUnitTest` → **484 tests, 0 failures**.
- ktfmt applied to both touched files.

Diff touches only `CtrlProxy.kt` and the new test file.
