### PR TITLE
refactor(observe): lift delegate-context scaffolding onto DeviceServiceClient

### DIFF
--- a/src/features/observe/DeviceServiceClient.ts
+++ b/src/features/observe/DeviceServiceClient.ts
@@ -23,6 +23,7 @@ import { defaultTimer } from "../../utils/SystemTimer";
 import { RequestManager } from "../../utils/RequestManager";
 import { RetryExecutor, defaultRetryExecutor } from "../../utils/retry/RetryExecutor";
 import type { CtrlProxyReconnectStatus } from "../../models/CtrlProxyReconnectStatus";
+import type { DelegateContext } from "./shared/types";
 
 /**
  * Factory function type for creating WebSocket instances.
@@ -142,6 +143,13 @@ export abstract class DeviceServiceClient {
    * For iOS, this may resolve the host address.
    */
   protected abstract setupBeforeConnect(perf: PerformanceTracker): Promise<void>;
+
+  /**
+   * Cancel any pending screenshot backoff captures.
+   * Wired into every delegate context via {@link createDelegateContext}; the
+   * concrete backoff scheduler lives on the platform subclass.
+   */
+  protected abstract cancelScreenshotBackoff(): void;
 
   // ===========================================================================
   // Connection management (shared implementation)
@@ -469,6 +477,60 @@ export abstract class DeviceServiceClient {
    */
   protected getTimer(): Timer {
     return this.timer;
+  }
+
+  // ===========================================================================
+  // Delegate context + lazy delegate scaffolding (shared implementation)
+  // ===========================================================================
+
+  /**
+   * Platform-specific additions to the base {@link DelegateContext}.
+   *
+   * The base builds the fields common to both platforms; a subclass overrides
+   * this hook to contribute the fields only it wires (e.g. iOS's command-
+   * capability accessors). The default contributes nothing, so a platform whose
+   * context is exactly the shared set (Android) needs no override.
+   */
+  protected extraDelegateContextFields(): Partial<DelegateContext> {
+    return {};
+  }
+
+  /**
+   * Build the base {@link DelegateContext} handed to every delegate.
+   *
+   * The shared fields are wired here from base state; platform-specific fields
+   * come from {@link extraDelegateContextFields}. Subclasses that need an
+   * extended context (e.g. a HierarchyDelegateContext) spread the result of this
+   * method and add their own fields.
+   */
+  protected createDelegateContext(): DelegateContext {
+    return {
+      getWebSocket: () => this.ws,
+      requestManager: this.requestManager,
+      timer: this.timer,
+      ensureConnected: perf => this.ensureConnected(perf),
+      cancelScreenshotBackoff: () => this.cancelScreenshotBackoff(),
+      ...this.extraDelegateContextFields(),
+    };
+  }
+
+  /**
+   * Lazily construct and cache a delegate, replacing the copy-pasted
+   * `if (!this._x) { this._x = new X(...); } return this._x;` getter body.
+   *
+   * The cache slot stays a subclass field (accessed through the get/set pair)
+   * so existing direct-field reads keep working and the singleton semantics are
+   * unchanged: the factory runs at most once and the same instance is returned
+   * on every subsequent access.
+   */
+  protected lazyDelegate<T>(get: () => T | null, set: (value: T) => void, factory: () => T): T {
+    const existing = get();
+    if (existing) {
+      return existing;
+    }
+    const created = factory();
+    set(created);
+    return created;
   }
 
   /**

--- a/src/features/observe/android/AndroidCtrlProxyClient.ts
+++ b/src/features/observe/android/AndroidCtrlProxyClient.ts
@@ -120,7 +120,6 @@ import { CtrlProxyPackages, type PackageInfoOptions } from "./CtrlProxyPackages"
 
 // Import types
 import type {
-  DelegateContext,
   HierarchyDelegateContext,
   CertificatesDelegateContext,
   AccessibilityHierarchy,
@@ -1310,16 +1309,6 @@ export class AndroidCtrlProxyClient extends DeviceServiceClient implements Andro
   // Delegate Context Factories
   // ===========================================================================
 
-  private createDelegateContext(): DelegateContext {
-    return {
-      getWebSocket: () => this.ws,
-      requestManager: this.requestManager,
-      timer: this.timer,
-      ensureConnected: perf => this.ensureConnected(perf),
-      cancelScreenshotBackoff: () => this.cancelScreenshotBackoff(),
-    };
-  }
-
   private createHierarchyDelegateContext(): HierarchyDelegateContext {
     return {
       ...this.createDelegateContext(),
@@ -1344,62 +1333,70 @@ export class AndroidCtrlProxyClient extends DeviceServiceClient implements Andro
   // ===========================================================================
 
   private get gestures(): CtrlProxyGestures {
-    if (!this._gestures) {
-      this._gestures = new CtrlProxyGestures(this.createDelegateContext());
-    }
-    return this._gestures;
+    return this.lazyDelegate(
+      () => this._gestures,
+      value => { this._gestures = value; },
+      () => new CtrlProxyGestures(this.createDelegateContext())
+    );
   }
 
   private get text(): CtrlProxyText {
-    if (!this._text) {
-      this._text = new CtrlProxyText(this.createDelegateContext());
-    }
-    return this._text;
+    return this.lazyDelegate(
+      () => this._text,
+      value => { this._text = value; },
+      () => new CtrlProxyText(this.createDelegateContext())
+    );
   }
 
   private get hierarchy(): CtrlProxyHierarchy {
-    if (!this._hierarchy) {
-      this._hierarchy = new CtrlProxyHierarchy(this.createHierarchyDelegateContext());
-    }
-    return this._hierarchy;
+    return this.lazyDelegate(
+      () => this._hierarchy,
+      value => { this._hierarchy = value; },
+      () => new CtrlProxyHierarchy(this.createHierarchyDelegateContext())
+    );
   }
 
   private get storage(): CtrlProxyStorage {
-    if (!this._storage) {
-      this._storage = new CtrlProxyStorage(this.createDelegateContext());
-    }
-    return this._storage;
+    return this.lazyDelegate(
+      () => this._storage,
+      value => { this._storage = value; },
+      () => new CtrlProxyStorage(this.createDelegateContext())
+    );
   }
 
   private get certificates(): CtrlProxyCertificates {
-    if (!this._certificates) {
-      this._certificates = new CtrlProxyCertificates(
+    return this.lazyDelegate(
+      () => this._certificates,
+      value => { this._certificates = value; },
+      () => new CtrlProxyCertificates(
         this.createCertificatesDelegateContext(),
         this.certificateFileSystem
-      );
-    }
-    return this._certificates;
+      )
+    );
   }
 
   private get focus(): CtrlProxyFocus {
-    if (!this._focus) {
-      this._focus = new CtrlProxyFocus(this.createDelegateContext());
-    }
-    return this._focus;
+    return this.lazyDelegate(
+      () => this._focus,
+      value => { this._focus = value; },
+      () => new CtrlProxyFocus(this.createDelegateContext())
+    );
   }
 
   private get highlights(): CtrlProxyHighlights {
-    if (!this._highlights) {
-      this._highlights = new CtrlProxyHighlights(this.createDelegateContext());
-    }
-    return this._highlights;
+    return this.lazyDelegate(
+      () => this._highlights,
+      value => { this._highlights = value; },
+      () => new CtrlProxyHighlights(this.createDelegateContext())
+    );
   }
 
   private get packages(): CtrlProxyPackages {
-    if (!this._packages) {
-      this._packages = new CtrlProxyPackages(this.createDelegateContext());
-    }
-    return this._packages;
+    return this.lazyDelegate(
+      () => this._packages,
+      value => { this._packages = value; },
+      () => new CtrlProxyPackages(this.createDelegateContext())
+    );
   }
 
   async requestInstalledPackages(

--- a/src/features/observe/ios/IOSCtrlProxyClient.ts
+++ b/src/features/observe/ios/IOSCtrlProxyClient.ts
@@ -844,17 +844,12 @@ export class IOSCtrlProxyClient extends DeviceServiceClient implements IOSCtrlPr
   // Delegate Context Factories
   // ===========================================================================
 
-  private createDelegateContext(): DelegateContext {
+  protected override extraDelegateContextFields(): Partial<DelegateContext> {
     return {
-      getWebSocket: () => this.ws,
-      requestManager: this.requestManager,
-      timer: this.timer,
-      ensureConnected: perf => this.ensureConnected(perf),
       getReconnectStatus: () => this.getReconnectStatus(),
       isCommandSupported: messageType => this.isCommandSupported(messageType),
       getSupportedCommands: () => this.getSupportedCommands(),
       unsupportedCommandError: messageType => this.buildUnsupportedCommandError(messageType),
-      cancelScreenshotBackoff: () => this.cancelScreenshotBackoff(),
     };
   }
 
@@ -874,87 +869,99 @@ export class IOSCtrlProxyClient extends DeviceServiceClient implements IOSCtrlPr
   // ===========================================================================
 
   private get gestures(): CtrlProxyGestures {
-    if (!this._gestures) {
-      this._gestures = new CtrlProxyGestures(this.createDelegateContext());
-    }
-    return this._gestures;
+    return this.lazyDelegate(
+      () => this._gestures,
+      value => { this._gestures = value; },
+      () => new CtrlProxyGestures(this.createDelegateContext())
+    );
   }
 
   private get text(): CtrlProxyText {
-    if (!this._text) {
-      this._text = new CtrlProxyText(this.createDelegateContext());
-    }
-    return this._text;
+    return this.lazyDelegate(
+      () => this._text,
+      value => { this._text = value; },
+      () => new CtrlProxyText(this.createDelegateContext())
+    );
   }
 
   private get hierarchy(): CtrlProxyHierarchyDelegate {
-    if (!this._hierarchy) {
-      this._hierarchy = new CtrlProxyHierarchyDelegate(this.createHierarchyDelegateContext());
-    }
-    return this._hierarchy;
+    return this.lazyDelegate(
+      () => this._hierarchy,
+      value => { this._hierarchy = value; },
+      () => new CtrlProxyHierarchyDelegate(this.createHierarchyDelegateContext())
+    );
   }
 
   private get screenshot(): CtrlProxyScreenshot {
-    if (!this._screenshot) {
-      this._screenshot = new CtrlProxyScreenshot(this.createDelegateContext());
-    }
-    return this._screenshot;
+    return this.lazyDelegate(
+      () => this._screenshot,
+      value => { this._screenshot = value; },
+      () => new CtrlProxyScreenshot(this.createDelegateContext())
+    );
   }
 
   private get navigation(): CtrlProxyNavigation {
-    if (!this._navigation) {
-      this._navigation = new CtrlProxyNavigation(this.createDelegateContext());
-    }
-    return this._navigation;
+    return this.lazyDelegate(
+      () => this._navigation,
+      value => { this._navigation = value; },
+      () => new CtrlProxyNavigation(this.createDelegateContext())
+    );
   }
 
   private get clipboard(): CtrlProxyClipboard {
-    if (!this._clipboard) {
-      this._clipboard = new CtrlProxyClipboard(this.createDelegateContext());
-    }
-    return this._clipboard;
+    return this.lazyDelegate(
+      () => this._clipboard,
+      value => { this._clipboard = value; },
+      () => new CtrlProxyClipboard(this.createDelegateContext())
+    );
   }
 
   private get voiceOver(): CtrlProxyVoiceOver {
-    if (!this._voiceOver) {
-      this._voiceOver = new CtrlProxyVoiceOver(this.createDelegateContext());
-    }
-    return this._voiceOver;
+    return this.lazyDelegate(
+      () => this._voiceOver,
+      value => { this._voiceOver = value; },
+      () => new CtrlProxyVoiceOver(this.createDelegateContext())
+    );
   }
 
   private get storage(): CtrlProxyStorage {
-    if (!this._storage) {
-      this._storage = new CtrlProxyStorage(this.createDelegateContext());
-    }
-    return this._storage;
+    return this.lazyDelegate(
+      () => this._storage,
+      value => { this._storage = value; },
+      () => new CtrlProxyStorage(this.createDelegateContext())
+    );
   }
 
   private get keyboard(): CtrlProxyKeyboard {
-    if (!this._keyboard) {
-      this._keyboard = new CtrlProxyKeyboard(this.createDelegateContext());
-    }
-    return this._keyboard;
+    return this.lazyDelegate(
+      () => this._keyboard,
+      value => { this._keyboard = value; },
+      () => new CtrlProxyKeyboard(this.createDelegateContext())
+    );
   }
 
   private get highlights(): CtrlProxyHighlights {
-    if (!this._highlights) {
-      this._highlights = new CtrlProxyHighlights(this.createDelegateContext());
-    }
-    return this._highlights;
+    return this.lazyDelegate(
+      () => this._highlights,
+      value => { this._highlights = value; },
+      () => new CtrlProxyHighlights(this.createDelegateContext())
+    );
   }
 
   private get database(): CtrlProxyDatabase {
-    if (!this._database) {
-      this._database = new CtrlProxyDatabase(this.createDelegateContext());
-    }
-    return this._database;
+    return this.lazyDelegate(
+      () => this._database,
+      value => { this._database = value; },
+      () => new CtrlProxyDatabase(this.createDelegateContext())
+    );
   }
 
   private get permissions(): CtrlProxyPermissions {
-    if (!this._permissions) {
-      this._permissions = new CtrlProxyPermissions(this.createDelegateContext());
-    }
-    return this._permissions;
+    return this.lazyDelegate(
+      () => this._permissions,
+      value => { this._permissions = value; },
+      () => new CtrlProxyPermissions(this.createDelegateContext())
+    );
   }
 
   // ===========================================================================

--- a/test/features/observe/delegateContextScaffolding.test.ts
+++ b/test/features/observe/delegateContextScaffolding.test.ts
@@ -1,0 +1,197 @@
+/**
+ * Pinning test for the delegate-context scaffolding shared by the Android and iOS
+ * CtrlProxy clients (issue #5458).
+ *
+ * Both clients build a `DelegateContext` (and a platform-specific
+ * `HierarchyDelegateContext`) and hand it to a family of lazily-constructed delegate
+ * objects. The context-builders and the lazy-getter singleton pattern were previously
+ * copy-pasted per client; #5458 lifts the shared scaffolding onto the
+ * `DeviceServiceClient` base.
+ *
+ * This suite pins the observable contract that the refactor must preserve:
+ *   - the exact field set of each client's base `DelegateContext`,
+ *   - the wiring of those fields to live client state,
+ *   - the exact field set of each client's `HierarchyDelegateContext`,
+ *   - the singleton-caching semantics of the delegate getters.
+ *
+ * Private members are reached with `(client as any)` — the established pattern in the
+ * sibling client suites — because the getters and context-builders are intentionally
+ * private.
+ */
+
+import { describe, expect, test } from "bun:test";
+import { AndroidCtrlProxyClient } from "../../../src/features/observe/android";
+import { IOSCtrlProxyClient } from "../../../src/features/observe/ios";
+import { BootedDevice } from "../../../src/models";
+import { FakeAdbExecutor } from "../../fakes/FakeAdbExecutor";
+import { FakeTimer } from "../../fakes/FakeTimer";
+import { FakeWebSocket } from "../../fakes/FakeWebSocket";
+import type { WebSocketFactory } from "../../../src/features/observe/DeviceServiceClient";
+
+const androidDevice: BootedDevice = {
+  deviceId: "delegate-context-android",
+  platform: "android",
+  isEmulator: true,
+  name: "Test Device",
+};
+
+const iosDevice: BootedDevice = {
+  deviceId: "A1B2C3D4-E5F6-7890-ABCD-EF1234567890",
+  platform: "ios",
+  name: "iPhone 16 Simulator",
+};
+
+function createAndroidClient(): AndroidCtrlProxyClient {
+  const fakeAdb = new FakeAdbExecutor();
+  fakeAdb.setCommandResponse("forward", { stdout: "8765", stderr: "" });
+  fakeAdb.setScreenState(true);
+  const fakeTimer = new FakeTimer();
+  AndroidCtrlProxyClient.resetInstances();
+  return AndroidCtrlProxyClient.createForTesting(
+    androidDevice,
+    fakeAdb,
+    (url: string) => new FakeWebSocket(url, "none", 0, fakeTimer) as unknown as WebSocket,
+    fakeTimer
+  );
+}
+
+function createIosClient(): IOSCtrlProxyClient {
+  const fakeTimer = new FakeTimer();
+  IOSCtrlProxyClient.resetInstances();
+  const factory: WebSocketFactory = (url: string) =>
+    new FakeWebSocket(url, "none", 0, fakeTimer) as unknown as WebSocket;
+  return IOSCtrlProxyClient.createForTesting(iosDevice, 8765, factory, fakeTimer);
+}
+
+describe("DelegateContext scaffolding (issue #5458)", () => {
+  describe("Android base DelegateContext", () => {
+    test("exposes exactly the shared field set", () => {
+      const client = createAndroidClient();
+      const ctx = (client as any).createDelegateContext();
+      expect(Object.keys(ctx).sort()).toEqual([
+        "cancelScreenshotBackoff",
+        "ensureConnected",
+        "getWebSocket",
+        "requestManager",
+        "timer",
+      ]);
+    });
+
+    test("wires the shared fields to live client state", () => {
+      const client = createAndroidClient();
+      const ctx = (client as any).createDelegateContext();
+      expect(ctx.requestManager).toBe((client as any).requestManager);
+      expect(ctx.timer).toBe((client as any).timer);
+      // Not connected yet: the WebSocket accessor mirrors the client's null socket.
+      expect(ctx.getWebSocket()).toBe((client as any).ws);
+      expect(typeof ctx.ensureConnected).toBe("function");
+      expect(typeof ctx.cancelScreenshotBackoff).toBe("function");
+    });
+  });
+
+  describe("Android HierarchyDelegateContext", () => {
+    test("extends the base with the Android-specific fields", () => {
+      const client = createAndroidClient();
+      const ctx = (client as any).createHierarchyDelegateContext();
+      expect(Object.keys(ctx).sort()).toEqual([
+        "adb",
+        "cancelScreenshotBackoff",
+        "device",
+        "ensureConnected",
+        "getCachedHierarchy",
+        "getLastWebSocketTimeout",
+        "getWebSocket",
+        "requestManager",
+        "setCachedHierarchy",
+        "setLastWebSocketTimeout",
+        "timer",
+      ]);
+      expect(ctx.device).toBe((client as any).device);
+      expect(ctx.adb).toBe((client as any).adb);
+    });
+  });
+
+  describe("iOS base DelegateContext", () => {
+    test("exposes the shared fields plus the iOS command-capability fields", () => {
+      const client = createIosClient();
+      const ctx = (client as any).createDelegateContext();
+      expect(Object.keys(ctx).sort()).toEqual([
+        "cancelScreenshotBackoff",
+        "ensureConnected",
+        "getReconnectStatus",
+        "getSupportedCommands",
+        "getWebSocket",
+        "isCommandSupported",
+        "requestManager",
+        "timer",
+        "unsupportedCommandError",
+      ]);
+    });
+
+    test("wires the shared fields to live client state", () => {
+      const client = createIosClient();
+      const ctx = (client as any).createDelegateContext();
+      expect(ctx.requestManager).toBe((client as any).requestManager);
+      expect(ctx.timer).toBe((client as any).timer);
+      expect(ctx.getWebSocket()).toBe((client as any).ws);
+      expect(typeof ctx.ensureConnected).toBe("function");
+      expect(typeof ctx.cancelScreenshotBackoff).toBe("function");
+      expect(typeof ctx.getReconnectStatus).toBe("function");
+      expect(typeof ctx.isCommandSupported).toBe("function");
+      expect(typeof ctx.getSupportedCommands).toBe("function");
+      expect(typeof ctx.unsupportedCommandError).toBe("function");
+    });
+  });
+
+  describe("iOS HierarchyDelegateContext", () => {
+    test("extends the base with the iOS-specific fields", () => {
+      const client = createIosClient();
+      const ctx = (client as any).createHierarchyDelegateContext();
+      expect(Object.keys(ctx).sort()).toEqual([
+        "cacheFreshTtlMs",
+        "cancelScreenshotBackoff",
+        "ensureConnected",
+        "getCachedHierarchy",
+        "getReconnectStatus",
+        "getSupportedCommands",
+        "getWebSocket",
+        "isCommandSupported",
+        "requestManager",
+        "setCachedHierarchy",
+        "suppressHierarchyObservationStreamPush",
+        "timer",
+        "unsupportedCommandError",
+      ]);
+    });
+  });
+
+  describe("delegate getters are cached singletons", () => {
+    test("Android getters return a stable instance", () => {
+      const client = createAndroidClient();
+      expect((client as any).gestures).toBe((client as any).gestures);
+      expect((client as any).text).toBe((client as any).text);
+      expect((client as any).hierarchy).toBe((client as any).hierarchy);
+      expect((client as any).storage).toBe((client as any).storage);
+      expect((client as any).certificates).toBe((client as any).certificates);
+      expect((client as any).focus).toBe((client as any).focus);
+      expect((client as any).highlights).toBe((client as any).highlights);
+      expect((client as any).packages).toBe((client as any).packages);
+    });
+
+    test("iOS getters return a stable instance", () => {
+      const client = createIosClient();
+      expect((client as any).gestures).toBe((client as any).gestures);
+      expect((client as any).text).toBe((client as any).text);
+      expect((client as any).hierarchy).toBe((client as any).hierarchy);
+      expect((client as any).screenshot).toBe((client as any).screenshot);
+      expect((client as any).navigation).toBe((client as any).navigation);
+      expect((client as any).clipboard).toBe((client as any).clipboard);
+      expect((client as any).voiceOver).toBe((client as any).voiceOver);
+      expect((client as any).storage).toBe((client as any).storage);
+      expect((client as any).keyboard).toBe((client as any).keyboard);
+      expect((client as any).highlights).toBe((client as any).highlights);
+      expect((client as any).database).toBe((client as any).database);
+      expect((client as any).permissions).toBe((client as any).permissions);
+    });
+  });
+});


### PR DESCRIPTION
## Summary

`AndroidCtrlProxyClient` and `IOSCtrlProxyClient` both `extends DeviceServiceClient`, yet each independently reimplemented the same delegate-context scaffolding: a `createDelegateContext()` builder with an identical set of shared fields, and a copy-pasted lazy-getter body (`if (!this._x) { this._x = new X(...); } return this._x;`) per delegate (~8 in Android, ~12 in iOS).

This lifts the shared scaffolding onto the `DeviceServiceClient` base:

- **`createDelegateContext()`** now lives on the base and wires the five shared fields (`getWebSocket`, `requestManager`, `timer`, `ensureConnected`, `cancelScreenshotBackoff`). A new `protected abstract cancelScreenshotBackoff()` declares the one platform-specific field the shared builder needs.
- **`extraDelegateContextFields()`** is a `protected` hook (default `{}`) that the base spreads into the context. iOS overrides it to contribute its command-capability accessors (`getReconnectStatus`, `isCommandSupported`, `getSupportedCommands`, `unsupportedCommandError`); Android uses the default. This is how the two clients' genuinely-different fields are handled without a lossy abstraction.
- **`lazyDelegate<T>(get, set, factory)`** replaces the per-getter boilerplate. The cache slot stays a subclass field (reached via the get/set pair) so existing direct-field reads — e.g. `this._hierarchy?.rejectPendingHierarchy(...)` — keep working and the singleton semantics are unchanged.

`createHierarchyDelegateContext()` stays in each subclass: its extra fields (Android's `device`/`adb`/`getLastWebSocketTimeout`, iOS's `cacheFreshTtlMs`/`suppress…`) are entirely platform-specific and diverge in both shape and interface type. Both now benefit from the lifted `createDelegateContext()` they spread.

This is a **behavior-preserving** refactor: the `DelegateContext` each delegate receives is field-for-field identical to before, and delegate getters remain cached singletons. A new pinning test (`test/features/observe/delegateContextScaffolding.test.ts`) locks the exact field set of each client's base and hierarchy contexts and the getter singleton semantics.

Note: this PR shares the two CtrlProxy client files with #5460 (pollUntil), which branches from post-#5458 main and lands after this.

## Linked Issue

Closes #5458

## Validation

- [x] `scripts/all_fast_validate_checks.sh` passes (`bun run lint` + `bun test`)
- [x] `bun run typecheck` reports no new errors (baseline gate)
- [x] New code uses interfaces + fakes + FakeTimer; unit tests run in <100ms
- [x] New generic code reuses existing project helpers; no new dependency
- [x] Rebased onto latest `main`, conflicts resolved

## Device Verification

- N/A — internal, behavior-preserving refactor covered by the full unit suite (13821 pass).
