### PR TITLE
perf(android): gate CtrlProxy push work on a connected client

### DIFF
--- a/android/control-proxy/src/main/kotlin/dev/jasonpearson/automobile/ctrlproxy/CtrlProxy.kt
+++ b/android/control-proxy/src/main/kotlin/dev/jasonpearson/automobile/ctrlproxy/CtrlProxy.kt
@@ -265,32 +265,52 @@ internal fun accessibilityEventWorkFor(
   }
 
 /**
- * Debounced-scroll accumulation state ([CtrlProxy.pendingScrollDeltaX] / `Y` / package name)
- * modeled as an immutable value so the "discard across an observer gap" decision is unit-testable.
+ * Debounced-scroll accumulation ([CtrlProxy.pendingScrollDeltaX] / `Y` / package name) tagged with
+ * the [WebSocketServer.connectionEpoch] it was accumulated under, modeled as an immutable value so
+ * the cross-session discard is unit-testable.
  */
-internal data class PendingScrollState(
+internal data class PendingScroll(
   val deltaX: Int,
   val deltaY: Int,
   val packageName: String?,
+  val sessionEpoch: Int,
 ) {
   companion object {
-    val EMPTY = PendingScrollState(deltaX = 0, deltaY = 0, packageName = null)
+    /** No accumulation yet, under no session. */
+    val NONE = PendingScroll(deltaX = 0, deltaY = 0, packageName = null, sessionEpoch = 0)
   }
 }
 
 /**
- * The pending-scroll state to keep after applying the observer gate (issue #5470 review). Scroll
- * deltas accumulate across the ~300ms scroll debounce; if the last client disconnects mid-window
- * the gate skips every subsequent scroll, so those deltas would otherwise linger and the first
- * post-reconnect scroll would ADD onto them and broadcast a bogus combined value. With no observer
- * we therefore discard the accumulation ([PendingScrollState.EMPTY]); with an observer the
- * in-flight accumulation is preserved untouched so a still-connected client's scroll is never
- * dropped.
+ * Fold one scroll sample into the pending accumulation, FIRST discarding any accumulation that
+ * belongs to a prior connection session (issue #5470 review — the event-free-gap hole in the
+ * earlier fix). Scroll deltas accumulate across the ~300ms scroll debounce; if a client disconnects
+ * and a new one connects before the next scroll — even with no accessibility event in between — the
+ * previous session's deltas must NOT combine with the new session's first scroll and broadcast a
+ * bogus combined value.
+ *
+ * [currentEpoch] is [WebSocketServer.connectionEpoch], which strictly increases on every new
+ * connection. When it differs from the accumulation's tagged [PendingScroll.sessionEpoch] a
+ * disconnect+reconnect happened since the last sample, so we start from [PendingScroll.NONE] before
+ * adding this sample; when it matches (a still-connected client) the in-flight accumulation is
+ * preserved and nothing is dropped. The check runs at sample time, so it is correct regardless of
+ * whether any event fired during the gap.
  */
-internal fun pendingScrollAcrossGate(
-  current: PendingScrollState,
-  connectionCount: Int,
-): PendingScrollState = if (connectionCount > 0) current else PendingScrollState.EMPTY
+internal fun accumulatePendingScroll(
+  current: PendingScroll,
+  deltaX: Int,
+  deltaY: Int,
+  packageName: String?,
+  currentEpoch: Int,
+): PendingScroll {
+  val base = if (current.sessionEpoch == currentEpoch) current else PendingScroll.NONE
+  return PendingScroll(
+    deltaX = base.deltaX + deltaX,
+    deltaY = base.deltaY + deltaY,
+    packageName = packageName,
+    sessionEpoch = currentEpoch,
+  )
+}
 
 internal fun navigationEventResponse(event: TimestampedNavigationEvent): NavigationEventResponse =
   NavigationEventResponse(
@@ -697,6 +717,11 @@ class CtrlProxy : AccessibilityService(), CtrlProxyActions {
   @Volatile private var pendingScrollDeltaX: Int = 0
   @Volatile private var pendingScrollDeltaY: Int = 0
   private var pendingScrollPackageName: String? = null
+
+  // The WebSocketServer.connectionEpoch the pending scroll deltas were accumulated under. A change
+  // means a disconnect+reconnect happened since the last sample (issue #5470 review); the next
+  // scroll discards the stale accumulation instead of combining across sessions.
+  @Volatile private var pendingScrollSessionEpoch: Int = 0
 
   private data class ScreenshotCapturePayload(
     val base64Image: String,
@@ -2230,26 +2255,12 @@ class CtrlProxy : AccessibilityService(), CtrlProxyActions {
       val connectionCount =
         if (::webSocketServer.isInitialized) webSocketServer.getConnectionCount() else 0
 
-      // With no observer, discard any scroll deltas accumulated before the last client left so the
-      // first post-reconnect scroll starts clean rather than broadcasting a bogus combined delta
-      // (issue #5470 review). Only touches state when unobserved, so a still-connected client's
-      // in-flight scroll is never dropped; see pendingScrollAcrossGate.
-      if (connectionCount <= 0) {
-        val gated =
-          pendingScrollAcrossGate(
-            PendingScrollState(pendingScrollDeltaX, pendingScrollDeltaY, pendingScrollPackageName),
-            connectionCount,
-          )
-        pendingScrollDeltaX = gated.deltaX
-        pendingScrollDeltaY = gated.deltaY
-        pendingScrollPackageName = gated.packageName
-      }
-
       // "Is anyone observing?" gate (issue #5470). Both the interaction/scroll recording below and
       // the debounced hierarchy refresh further down are PUSH work only a connected client
-      // consumes,
-      // so with zero connections we skip them — before touching event.source, allocating,
-      // extracting, or hashing. The frameContext token above still advanced. The pull path
+      // consumes, so with zero connections we skip them — before touching event.source, allocating,
+      // extracting, or hashing. The frameContext token above still advanced. Stale cross-session
+      // scroll deltas are discarded at scroll-accumulation time via accumulatePendingScroll (keyed
+      // on the connection epoch), so no observer-gap cleanup is needed here. The pull path
       // (request_hierarchy) does not go through here and stays functional with zero observers.
       val work = accessibilityEventWorkFor(event.eventType, connectionCount)
 
@@ -2414,12 +2425,32 @@ class CtrlProxy : AccessibilityService(), CtrlProxyActions {
    */
   private fun recordDebouncedScroll(event: AccessibilityEvent) {
     val now = System.currentTimeMillis()
-    if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.P) {
-      pendingScrollDeltaX += event.scrollDeltaX
-      pendingScrollDeltaY += event.scrollDeltaY
-    }
-    // Store package name — don't hold the event reference (Android recycles it)
-    pendingScrollPackageName = event.packageName?.toString()
+    // Only observed events reach here (the onAccessibilityEvent gate), so connectionEpoch reflects
+    // the current session. Fold this sample in through accumulatePendingScroll, which discards any
+    // accumulation tagged with a prior session first — closing the event-free-gap hole where a
+    // disconnect+reconnect between samples would otherwise let stale deltas combine with the first
+    // post-reconnect scroll (issue #5470 review). Store extracted fields, not the event reference
+    // (Android recycles it).
+    val sampleDeltaX = if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.P) event.scrollDeltaX else 0
+    val sampleDeltaY = if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.P) event.scrollDeltaY else 0
+    val currentEpoch = if (::webSocketServer.isInitialized) webSocketServer.connectionEpoch() else 0
+    val accumulated =
+      accumulatePendingScroll(
+        PendingScroll(
+          pendingScrollDeltaX,
+          pendingScrollDeltaY,
+          pendingScrollPackageName,
+          pendingScrollSessionEpoch,
+        ),
+        sampleDeltaX,
+        sampleDeltaY,
+        event.packageName?.toString(),
+        currentEpoch,
+      )
+    pendingScrollDeltaX = accumulated.deltaX
+    pendingScrollDeltaY = accumulated.deltaY
+    pendingScrollPackageName = accumulated.packageName
+    pendingScrollSessionEpoch = accumulated.sessionEpoch
 
     if (now - lastScrollBroadcastMs >= scrollDebounceMs) {
       lastScrollBroadcastMs = now

--- a/android/control-proxy/src/main/kotlin/dev/jasonpearson/automobile/ctrlproxy/CtrlProxy.kt
+++ b/android/control-proxy/src/main/kotlin/dev/jasonpearson/automobile/ctrlproxy/CtrlProxy.kt
@@ -208,6 +208,48 @@ internal fun triggersHierarchyRefresh(eventType: Int): Boolean =
 internal fun isHandledEventType(eventType: Int): Boolean =
   interactionDispatchFor(eventType) != null || triggersHierarchyRefresh(eventType)
 
+/**
+ * The per-event push work [CtrlProxy.onAccessibilityEvent] should perform: which interaction (if
+ * any) to record, and whether to schedule a debounced hierarchy refresh (extraction + structural
+ * hash). Both are pure over the classification helpers plus the observer count.
+ */
+internal data class AccessibilityEventWork(
+  val interaction: InteractionDispatch?,
+  val refreshesHierarchy: Boolean,
+) {
+  companion object {
+    /** Nothing to do — no interaction recording, no hierarchy refresh, no frameContext bump. */
+    val NONE = AccessibilityEventWork(interaction = null, refreshesHierarchy = false)
+  }
+}
+
+/**
+ * Pure "is anyone observing" gate (issue #5470). The two biggest continuous-work paths in
+ * [CtrlProxy.onAccessibilityEvent] — per-interaction accessibility-node recording and the debounced
+ * full-hierarchy extraction + structural hash — are background PUSH work that only a connected
+ * client ever consumes. When [connectionCount] is zero they are skipped entirely, along with the
+ * `frameContext` bookkeeping that only labels pushed/broadcast frames.
+ *
+ * This does NOT govern the on-demand PULL path (`request_hierarchy` → `extractNowBlocking`): that
+ * extracts the live accessibility tree directly and reads none of the push-path side effects
+ * (frameContext counter, debouncer hash/cache), so it stays fully correct with zero prior push
+ * activity and zero observers. Gating is race-tolerant by design — the count may change between
+ * this check and use, costing at most one extra or one skipped frame around a connect/disconnect
+ * edge.
+ */
+internal fun accessibilityEventWorkFor(
+  eventType: Int,
+  connectionCount: Int,
+): AccessibilityEventWork =
+  if (connectionCount > 0) {
+    AccessibilityEventWork(
+      interaction = interactionDispatchFor(eventType),
+      refreshesHierarchy = triggersHierarchyRefresh(eventType),
+    )
+  } else {
+    AccessibilityEventWork.NONE
+  }
+
 internal fun navigationEventResponse(event: TimestampedNavigationEvent): NavigationEventResponse =
   NavigationEventResponse(
     timestamp = event.timestamp,
@@ -2134,10 +2176,24 @@ class CtrlProxy : AccessibilityService(), CtrlProxyActions {
         lastWindowClassName = event.className?.toString()
       }
 
+      // "Is anyone observing?" gate (issue #5470). Both the interaction/scroll recording below and
+      // the debounced hierarchy refresh further down are PUSH work only a connected client
+      // consumes,
+      // so with zero connections we skip them — and their frameContext bookkeeping — before
+      // touching
+      // event.source, allocating, extracting, or hashing. The pull path (request_hierarchy) does
+      // not
+      // go through here and stays functional with zero observers; see accessibilityEventWorkFor.
+      val work =
+        accessibilityEventWorkFor(
+          event.eventType,
+          if (::webSocketServer.isInitialized) webSocketServer.getConnectionCount() else 0,
+        )
+
       // Broadcast interaction events for telemetry tracking. Classification is routed through the
       // shared [interactionDispatchFor] so the subscribed event-type mask (derived from the same
       // classifier) can never drift from what this `when` actually acts on.
-      when (interactionDispatchFor(event.eventType)) {
+      when (work.interaction) {
         InteractionDispatch.TAP -> recordInteractionEvent(event, "tap")
         InteractionDispatch.LONG_PRESS -> recordInteractionEvent(event, "longPress")
         // Compose doesn't fire TYPE_VIEW_CLICKED — detect taps via content changes
@@ -2170,8 +2226,10 @@ class CtrlProxy : AccessibilityService(), CtrlProxyActions {
       }
 
       // Delegate to the smart debouncer for content/window changes (same shared classifier).
-      // The debouncer uses structural hash comparison to detect animation vs real changes.
-      if (triggersHierarchyRefresh(event.eventType)) {
+      // The debouncer uses structural hash comparison to detect animation vs real changes. Gated on
+      // an observer (issue #5470): with no client connected, work.refreshesHierarchy is false, so
+      // neither the frameContext bump nor the extraction/hash runs.
+      if (work.refreshesHierarchy) {
         frameContext.incrementAndGet()
         if (::hierarchyDebouncer.isInitialized) {
           hierarchyDebouncer.onAccessibilityEvent()
@@ -2188,7 +2246,12 @@ class CtrlProxy : AccessibilityService(), CtrlProxyActions {
   }
 
   private fun recordInteractionEvent(event: AccessibilityEvent, type: String) {
-    if (!::webSocketServer.isInitialized || !webSocketServer.isRunning()) {
+    // Observer gate (issue #5470): early-return BEFORE reading event.source / getBoundsInScreen /
+    // allocating when nobody is connected. onAccessibilityEvent already gates dispatch on the same
+    // count; this is the defensive backstop for the scroll/debounced callers, and
+    // getConnectionCount
+    // > 0 also implies the server is running.
+    if (!::webSocketServer.isInitialized || webSocketServer.getConnectionCount() <= 0) {
       return
     }
 

--- a/android/control-proxy/src/main/kotlin/dev/jasonpearson/automobile/ctrlproxy/CtrlProxy.kt
+++ b/android/control-proxy/src/main/kotlin/dev/jasonpearson/automobile/ctrlproxy/CtrlProxy.kt
@@ -266,49 +266,50 @@ internal fun accessibilityEventWorkFor(
 
 /**
  * Debounced-scroll accumulation ([CtrlProxy.pendingScrollDeltaX] / `Y` / package name) tagged with
- * the [WebSocketServer.connectionEpoch] it was accumulated under, modeled as an immutable value so
- * the cross-session discard is unit-testable.
+ * the [WebSocketServer.observerSessionGeneration] it was accumulated under, modeled as an immutable
+ * value so the cross-session discard is unit-testable.
  */
 internal data class PendingScroll(
   val deltaX: Int,
   val deltaY: Int,
   val packageName: String?,
-  val sessionEpoch: Int,
+  val sessionGeneration: Int,
 ) {
   companion object {
     /** No accumulation yet, under no session. */
-    val NONE = PendingScroll(deltaX = 0, deltaY = 0, packageName = null, sessionEpoch = 0)
+    val NONE = PendingScroll(deltaX = 0, deltaY = 0, packageName = null, sessionGeneration = 0)
   }
 }
 
 /**
  * Fold one scroll sample into the pending accumulation, FIRST discarding any accumulation that
- * belongs to a prior connection session (issue #5470 review — the event-free-gap hole in the
- * earlier fix). Scroll deltas accumulate across the ~300ms scroll debounce; if a client disconnects
- * and a new one connects before the next scroll — even with no accessibility event in between — the
+ * belongs to a prior observer session (issue #5470 review — the event-free-gap hole in the earlier
+ * fix). Scroll deltas accumulate across the ~300ms scroll debounce; if a client disconnects and a
+ * new one connects before the next scroll — even with no accessibility event in between — the
  * previous session's deltas must NOT combine with the new session's first scroll and broadcast a
  * bogus combined value.
  *
- * [currentEpoch] is [WebSocketServer.connectionEpoch], which strictly increases on every new
- * connection. When it differs from the accumulation's tagged [PendingScroll.sessionEpoch] a
- * disconnect+reconnect happened since the last sample, so we start from [PendingScroll.NONE] before
- * adding this sample; when it matches (a still-connected client) the in-flight accumulation is
- * preserved and nothing is dropped. The check runs at sample time, so it is correct regardless of
- * whether any event fired during the gap.
+ * [currentGeneration] is [WebSocketServer.observerSessionGeneration], which advances only on the
+ * empty→non-empty edge. When it differs from the accumulation's tagged
+ * [PendingScroll.sessionGeneration] the observer set emptied and a new session began since the last
+ * sample, so we start from [PendingScroll.NONE] before adding this sample; when it matches — a
+ * client stayed continuously connected, including when a concurrent client merely joined — the
+ * in-flight accumulation is preserved and nothing is dropped. The check runs at sample time, so it
+ * is correct regardless of whether any event fired during the gap.
  */
 internal fun accumulatePendingScroll(
   current: PendingScroll,
   deltaX: Int,
   deltaY: Int,
   packageName: String?,
-  currentEpoch: Int,
+  currentGeneration: Int,
 ): PendingScroll {
-  val base = if (current.sessionEpoch == currentEpoch) current else PendingScroll.NONE
+  val base = if (current.sessionGeneration == currentGeneration) current else PendingScroll.NONE
   return PendingScroll(
     deltaX = base.deltaX + deltaX,
     deltaY = base.deltaY + deltaY,
     packageName = packageName,
-    sessionEpoch = currentEpoch,
+    sessionGeneration = currentGeneration,
   )
 }
 
@@ -718,10 +719,11 @@ class CtrlProxy : AccessibilityService(), CtrlProxyActions {
   @Volatile private var pendingScrollDeltaY: Int = 0
   private var pendingScrollPackageName: String? = null
 
-  // The WebSocketServer.connectionEpoch the pending scroll deltas were accumulated under. A change
-  // means a disconnect+reconnect happened since the last sample (issue #5470 review); the next
-  // scroll discards the stale accumulation instead of combining across sessions.
-  @Volatile private var pendingScrollSessionEpoch: Int = 0
+  // The WebSocketServer.observerSessionGeneration the pending scroll deltas were accumulated under.
+  // A change means the observer set emptied and a new session began since the last sample (issue
+  // #5470 review); the next scroll discards the stale accumulation instead of combining across
+  // sessions. A concurrent client joining does NOT change it, so an in-flight scroll is preserved.
+  @Volatile private var pendingScrollSessionGeneration: Int = 0
 
   private data class ScreenshotCapturePayload(
     val base64Image: String,
@@ -2260,8 +2262,8 @@ class CtrlProxy : AccessibilityService(), CtrlProxyActions {
       // consumes, so with zero connections we skip them — before touching event.source, allocating,
       // extracting, or hashing. The frameContext token above still advanced. Stale cross-session
       // scroll deltas are discarded at scroll-accumulation time via accumulatePendingScroll (keyed
-      // on the connection epoch), so no observer-gap cleanup is needed here. The pull path
-      // (request_hierarchy) does not go through here and stays functional with zero observers.
+      // on the observer-session generation), so no observer-gap cleanup is needed here. The pull
+      // path (request_hierarchy) does not go through here and stays functional with zero observers.
       val work = accessibilityEventWorkFor(event.eventType, connectionCount)
 
       // Broadcast interaction events for telemetry tracking. Classification is routed through the
@@ -2425,32 +2427,36 @@ class CtrlProxy : AccessibilityService(), CtrlProxyActions {
    */
   private fun recordDebouncedScroll(event: AccessibilityEvent) {
     val now = System.currentTimeMillis()
-    // Only observed events reach here (the onAccessibilityEvent gate), so connectionEpoch reflects
-    // the current session. Fold this sample in through accumulatePendingScroll, which discards any
-    // accumulation tagged with a prior session first — closing the event-free-gap hole where a
-    // disconnect+reconnect between samples would otherwise let stale deltas combine with the first
-    // post-reconnect scroll (issue #5470 review). Store extracted fields, not the event reference
-    // (Android recycles it).
+    // Only observed events reach here (the onAccessibilityEvent gate), so observerSessionGeneration
+    // reflects the current session. Fold this sample in through accumulatePendingScroll, which
+    // discards any accumulation tagged with a prior session first — closing the event-free-gap hole
+    // where a disconnect+reconnect between samples would otherwise let stale deltas combine with
+    // the
+    // first post-reconnect scroll (issue #5470 review). The generation is stable while any client
+    // stays connected, so a concurrent client joining mid-scroll does not drop the in-flight
+    // deltas.
+    // Store extracted fields, not the event reference (Android recycles it).
     val sampleDeltaX = if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.P) event.scrollDeltaX else 0
     val sampleDeltaY = if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.P) event.scrollDeltaY else 0
-    val currentEpoch = if (::webSocketServer.isInitialized) webSocketServer.connectionEpoch() else 0
+    val currentGeneration =
+      if (::webSocketServer.isInitialized) webSocketServer.observerSessionGeneration() else 0
     val accumulated =
       accumulatePendingScroll(
         PendingScroll(
           pendingScrollDeltaX,
           pendingScrollDeltaY,
           pendingScrollPackageName,
-          pendingScrollSessionEpoch,
+          pendingScrollSessionGeneration,
         ),
         sampleDeltaX,
         sampleDeltaY,
         event.packageName?.toString(),
-        currentEpoch,
+        currentGeneration,
       )
     pendingScrollDeltaX = accumulated.deltaX
     pendingScrollDeltaY = accumulated.deltaY
     pendingScrollPackageName = accumulated.packageName
-    pendingScrollSessionEpoch = accumulated.sessionEpoch
+    pendingScrollSessionGeneration = accumulated.sessionGeneration
 
     if (now - lastScrollBroadcastMs >= scrollDebounceMs) {
       lastScrollBroadcastMs = now

--- a/android/control-proxy/src/main/kotlin/dev/jasonpearson/automobile/ctrlproxy/CtrlProxy.kt
+++ b/android/control-proxy/src/main/kotlin/dev/jasonpearson/automobile/ctrlproxy/CtrlProxy.kt
@@ -218,17 +218,31 @@ internal data class AccessibilityEventWork(
   val refreshesHierarchy: Boolean,
 ) {
   companion object {
-    /** Nothing to do — no interaction recording, no hierarchy refresh, no frameContext bump. */
+    /** Nothing to do — no interaction recording and no hierarchy refresh (the expensive work). */
     val NONE = AccessibilityEventWork(interaction = null, refreshesHierarchy = false)
   }
 }
 
 /**
+ * True when [eventType] changes the UI enough to advance the `frameContext` staleness token. This
+ * is DELIBERATELY independent of the observer count (issue #5470 review): the token must keep
+ * advancing even while nobody is connected, otherwise a token minted before the last client
+ * disconnected could still pass the daemon/runner frame-context staleness check after a reconnect
+ * even though the screen changed during the gap — aiming an input action at the wrong UI state. The
+ * set is exactly the original bump sites: the hierarchy-refresh types plus a scroll. Advancing the
+ * token is a cheap atomic increment; only the EXPENSIVE extraction/recording/broadcast is gated on
+ * an observer.
+ */
+internal fun advancesFrameContext(eventType: Int): Boolean =
+  triggersHierarchyRefresh(eventType) ||
+    interactionDispatchFor(eventType) == InteractionDispatch.SCROLL
+
+/**
  * Pure "is anyone observing" gate (issue #5470). The two biggest continuous-work paths in
  * [CtrlProxy.onAccessibilityEvent] — per-interaction accessibility-node recording and the debounced
  * full-hierarchy extraction + structural hash — are background PUSH work that only a connected
- * client ever consumes. When [connectionCount] is zero they are skipped entirely, along with the
- * `frameContext` bookkeeping that only labels pushed/broadcast frames.
+ * client ever consumes, so with zero observers they are skipped entirely. The `frameContext`
+ * staleness token is NOT gated here (see [advancesFrameContext]); it keeps advancing regardless.
  *
  * This does NOT govern the on-demand PULL path (`request_hierarchy` → `extractNowBlocking`): that
  * extracts the live accessibility tree directly and reads none of the push-path side effects
@@ -249,6 +263,34 @@ internal fun accessibilityEventWorkFor(
   } else {
     AccessibilityEventWork.NONE
   }
+
+/**
+ * Debounced-scroll accumulation state ([CtrlProxy.pendingScrollDeltaX] / `Y` / package name)
+ * modeled as an immutable value so the "discard across an observer gap" decision is unit-testable.
+ */
+internal data class PendingScrollState(
+  val deltaX: Int,
+  val deltaY: Int,
+  val packageName: String?,
+) {
+  companion object {
+    val EMPTY = PendingScrollState(deltaX = 0, deltaY = 0, packageName = null)
+  }
+}
+
+/**
+ * The pending-scroll state to keep after applying the observer gate (issue #5470 review). Scroll
+ * deltas accumulate across the ~300ms scroll debounce; if the last client disconnects mid-window
+ * the gate skips every subsequent scroll, so those deltas would otherwise linger and the first
+ * post-reconnect scroll would ADD onto them and broadcast a bogus combined value. With no observer
+ * we therefore discard the accumulation ([PendingScrollState.EMPTY]); with an observer the
+ * in-flight accumulation is preserved untouched so a still-connected client's scroll is never
+ * dropped.
+ */
+internal fun pendingScrollAcrossGate(
+  current: PendingScrollState,
+  connectionCount: Int,
+): PendingScrollState = if (connectionCount > 0) current else PendingScrollState.EMPTY
 
 internal fun navigationEventResponse(event: TimestampedNavigationEvent): NavigationEventResponse =
   NavigationEventResponse(
@@ -2176,19 +2218,40 @@ class CtrlProxy : AccessibilityService(), CtrlProxyActions {
         lastWindowClassName = event.className?.toString()
       }
 
+      // Advance the frameContext staleness token on every UI-changing event REGARDLESS of observers
+      // (issue #5470 review). If it froze while unobserved, a token minted before the last client
+      // disconnected could still pass the daemon/runner staleness check after reconnect even though
+      // the screen changed during the gap, aiming an input action at the wrong UI state. This is a
+      // cheap atomic increment maintaining the invariant; only the expensive work below is gated.
+      if (advancesFrameContext(event.eventType)) {
+        frameContext.incrementAndGet()
+      }
+
+      val connectionCount =
+        if (::webSocketServer.isInitialized) webSocketServer.getConnectionCount() else 0
+
+      // With no observer, discard any scroll deltas accumulated before the last client left so the
+      // first post-reconnect scroll starts clean rather than broadcasting a bogus combined delta
+      // (issue #5470 review). Only touches state when unobserved, so a still-connected client's
+      // in-flight scroll is never dropped; see pendingScrollAcrossGate.
+      if (connectionCount <= 0) {
+        val gated =
+          pendingScrollAcrossGate(
+            PendingScrollState(pendingScrollDeltaX, pendingScrollDeltaY, pendingScrollPackageName),
+            connectionCount,
+          )
+        pendingScrollDeltaX = gated.deltaX
+        pendingScrollDeltaY = gated.deltaY
+        pendingScrollPackageName = gated.packageName
+      }
+
       // "Is anyone observing?" gate (issue #5470). Both the interaction/scroll recording below and
       // the debounced hierarchy refresh further down are PUSH work only a connected client
       // consumes,
-      // so with zero connections we skip them — and their frameContext bookkeeping — before
-      // touching
-      // event.source, allocating, extracting, or hashing. The pull path (request_hierarchy) does
-      // not
-      // go through here and stays functional with zero observers; see accessibilityEventWorkFor.
-      val work =
-        accessibilityEventWorkFor(
-          event.eventType,
-          if (::webSocketServer.isInitialized) webSocketServer.getConnectionCount() else 0,
-        )
+      // so with zero connections we skip them — before touching event.source, allocating,
+      // extracting, or hashing. The frameContext token above still advanced. The pull path
+      // (request_hierarchy) does not go through here and stays functional with zero observers.
+      val work = accessibilityEventWorkFor(event.eventType, connectionCount)
 
       // Broadcast interaction events for telemetry tracking. Classification is routed through the
       // shared [interactionDispatchFor] so the subscribed event-type mask (derived from the same
@@ -2218,19 +2281,17 @@ class CtrlProxy : AccessibilityService(), CtrlProxyActions {
             recordInteractionEvent(event, "inputText")
           }
         }
-        InteractionDispatch.SCROLL -> {
-          frameContext.incrementAndGet()
-          recordDebouncedScroll(event)
-        }
+        // frameContext already advanced above (unconditionally); here we only do the gated,
+        // expensive scroll recording, which runs solely when observed.
+        InteractionDispatch.SCROLL -> recordDebouncedScroll(event)
         null -> {} // event type this service does not act on
       }
 
-      // Delegate to the smart debouncer for content/window changes (same shared classifier).
-      // The debouncer uses structural hash comparison to detect animation vs real changes. Gated on
-      // an observer (issue #5470): with no client connected, work.refreshesHierarchy is false, so
-      // neither the frameContext bump nor the extraction/hash runs.
+      // Delegate to the smart debouncer for content/window changes (same shared classifier). The
+      // debouncer uses structural hash comparison to detect animation vs real changes. Gated on an
+      // observer (issue #5470): with no client connected, work.refreshesHierarchy is false, so the
+      // extraction/hash is skipped. The frameContext token advanced unconditionally above.
       if (work.refreshesHierarchy) {
-        frameContext.incrementAndGet()
         if (::hierarchyDebouncer.isInitialized) {
           hierarchyDebouncer.onAccessibilityEvent()
         }

--- a/android/control-proxy/src/main/kotlin/dev/jasonpearson/automobile/ctrlproxy/WebSocketServer.kt
+++ b/android/control-proxy/src/main/kotlin/dev/jasonpearson/automobile/ctrlproxy/WebSocketServer.kt
@@ -561,6 +561,16 @@ class WebSocketServer(
     return synchronized(connections) { connections.size }
   }
 
+  /**
+   * Monotonic count of connections ever accepted since the server started — a per-connection
+   * "session epoch". Unlike [getConnectionCount] (the live count, which returns to 1 after a
+   * disconnect + reconnect and so cannot distinguish a continuous client from a reconnected one),
+   * this strictly increases on every new connection and never decreases. Observers use it as a
+   * session-generation marker to discard state accumulated under a previous connection after any
+   * disconnect, including one that happens with no intervening activity (issue #5470).
+   */
+  fun connectionEpoch(): Int = connectionCount.get()
+
   /** Suspends until a client has completed the WebSocket handshake. */
   suspend fun awaitFirstClientConnection() {
     firstClientConnection.await()

--- a/android/control-proxy/src/main/kotlin/dev/jasonpearson/automobile/ctrlproxy/WebSocketServer.kt
+++ b/android/control-proxy/src/main/kotlin/dev/jasonpearson/automobile/ctrlproxy/WebSocketServer.kt
@@ -189,6 +189,14 @@ class WebSocketServer(
   private val firstClientConnection = CompletableDeferred<Unit>()
   private var activeClientConnection = CompletableDeferred<Unit>()
 
+  /**
+   * Observer-session generation: bumped ONLY on the empty→non-empty edge (the first client of a new
+   * session connecting after the observer set was empty), never when a second/third concurrent
+   * client joins. Guarded by the same `connections` monitor as every add/remove, so the 0→1 check
+   * reads a consistent size. See [observerSessionGeneration].
+   */
+  private var observerSessionGen = 0
+
   // Flow to broadcast messages to all connected clients
   private val _messageFlow = MutableSharedFlow<String>(replay = 0, extraBufferCapacity = 10)
 
@@ -251,6 +259,14 @@ class WebSocketServer(
                   )
 
                   synchronized(connections) {
+                    // Bump the observer-session generation only when this connection is the first
+                    // of
+                    // a new session (the set was empty before this add), NOT when a concurrent
+                    // client joins an already-observed session. Checked against the pre-add size
+                    // inside the same monitor that guards every add/remove.
+                    if (connections.isEmpty()) {
+                      observerSessionGen++
+                    }
                     connections.add(this)
                     activeClientConnection.complete(Unit)
                   }
@@ -562,14 +578,18 @@ class WebSocketServer(
   }
 
   /**
-   * Monotonic count of connections ever accepted since the server started — a per-connection
-   * "session epoch". Unlike [getConnectionCount] (the live count, which returns to 1 after a
-   * disconnect + reconnect and so cannot distinguish a continuous client from a reconnected one),
-   * this strictly increases on every new connection and never decreases. Observers use it as a
-   * session-generation marker to discard state accumulated under a previous connection after any
-   * disconnect, including one that happens with no intervening activity (issue #5470).
+   * Observer-session generation: a marker that is STABLE for as long as at least one client stays
+   * continuously connected, and advances only after the observer set has emptied and a new client
+   * arrives (the empty→non-empty edge). Unlike [getConnectionCount] (the live count, which returns
+   * to 1 after a reconnect and so cannot distinguish a continuous client from a reconnected one),
+   * and unlike a total-connections counter (which would also advance when a SECOND concurrent
+   * client joins), this changes exactly once per observer session.
+   *
+   * Observers use it as a session marker to discard state accumulated under a previous session
+   * after any disconnect — including one with no intervening activity (issue #5470) — while NOT
+   * discarding a still-connected client's in-flight state when a concurrent client joins.
    */
-  fun connectionEpoch(): Int = connectionCount.get()
+  fun observerSessionGeneration(): Int = synchronized(connections) { observerSessionGen }
 
   /** Suspends until a client has completed the WebSocket handshake. */
   suspend fun awaitFirstClientConnection() {

--- a/android/control-proxy/src/test/kotlin/dev/jasonpearson/automobile/ctrlproxy/CtrlProxyObserverGateTest.kt
+++ b/android/control-proxy/src/test/kotlin/dev/jasonpearson/automobile/ctrlproxy/CtrlProxyObserverGateTest.kt
@@ -110,4 +110,73 @@ class CtrlProxyObserverGateTest {
       extractCalls.get(),
     )
   }
+
+  // ---------------------------------------------------------------------------
+  // Review regressions (issue #5470): the gate must skip only expensive work, not
+  // invariant-maintaining bookkeeping.
+  // ---------------------------------------------------------------------------
+
+  /**
+   * Bug 1: the frameContext staleness token must keep advancing on UI-changing events even with
+   * zero observers. [advancesFrameContext] is the pure decision the call site increments on, and it
+   * takes NO connection count — so the token advances regardless of how many clients are connected.
+   * Were it gated, a stale pre-disconnect token could survive a UI change across an observer gap
+   * and wrongly pass the reconnect staleness check.
+   */
+  @Test
+  fun `frameContext advances on UI-change events independent of observers`() {
+    // The bump set is exactly the scroll interaction plus every hierarchy-refresh type — and the
+    // decision does not consult the connection count, so it holds at zero observers.
+    assertTrue(
+      "scroll must advance frameContext",
+      advancesFrameContext(android.view.accessibility.AccessibilityEvent.TYPE_VIEW_SCROLLED),
+    )
+    for (type in refreshTypes) {
+      assertTrue("refresh type $type must advance frameContext", advancesFrameContext(type))
+    }
+    // Non-UI-changing interactions (a click/select) do not advance the token, matching the original
+    // bump sites (only scroll among interactions bumped).
+    assertFalse(
+      "a click must not advance frameContext",
+      advancesFrameContext(android.view.accessibility.AccessibilityEvent.TYPE_VIEW_CLICKED),
+    )
+    assertFalse(
+      "a select must not advance frameContext",
+      advancesFrameContext(android.view.accessibility.AccessibilityEvent.TYPE_VIEW_SELECTED),
+    )
+    // Same event types, evaluated as if unobserved: advancesFrameContext ignores observers
+    // entirely,
+    // so the token still advances (call site bumps unconditionally on these).
+    assertEquals(
+      "advancesFrameContext must match the exact refresh + scroll bump set",
+      refreshTypes.toSet() + android.view.accessibility.AccessibilityEvent.TYPE_VIEW_SCROLLED,
+      (refreshTypes + interactionTypes).filter { advancesFrameContext(it) }.toSet(),
+    )
+  }
+
+  /**
+   * Bug 2: pending scroll deltas accumulated before the last client left must be discarded across a
+   * zero-observer gap, so the first post-reconnect scroll starts clean instead of adding onto stale
+   * state and broadcasting a bogus combined delta. A still-connected client's in-flight
+   * accumulation must be preserved untouched.
+   */
+  @Test
+  fun `pending scroll deltas are discarded across a zero-observer gap`() {
+    val accumulated =
+      PendingScrollState(deltaX = 40, deltaY = -120, packageName = "com.example.app")
+
+    // Last client gone: discard so the next scroll starts from zero.
+    assertEquals(
+      PendingScrollState.EMPTY,
+      pendingScrollAcrossGate(accumulated, connectionCount = 0),
+    )
+    assertEquals(
+      PendingScrollState.EMPTY,
+      pendingScrollAcrossGate(accumulated, connectionCount = -1),
+    )
+
+    // Still observed: preserve the in-flight accumulation exactly, dropping nothing.
+    assertEquals(accumulated, pendingScrollAcrossGate(accumulated, connectionCount = 1))
+    assertEquals(accumulated, pendingScrollAcrossGate(accumulated, connectionCount = 3))
+  }
 }

--- a/android/control-proxy/src/test/kotlin/dev/jasonpearson/automobile/ctrlproxy/CtrlProxyObserverGateTest.kt
+++ b/android/control-proxy/src/test/kotlin/dev/jasonpearson/automobile/ctrlproxy/CtrlProxyObserverGateTest.kt
@@ -1,0 +1,113 @@
+package dev.jasonpearson.automobile.ctrlproxy
+
+import dev.jasonpearson.automobile.ctrlproxy.models.ViewHierarchy
+import java.util.concurrent.atomic.AtomicInteger
+import kotlinx.coroutines.CoroutineScope
+import kotlinx.coroutines.Dispatchers
+import org.junit.Assert.assertEquals
+import org.junit.Assert.assertFalse
+import org.junit.Assert.assertNotNull
+import org.junit.Assert.assertNull
+import org.junit.Assert.assertTrue
+import org.junit.Test
+import org.junit.runner.RunWith
+import org.robolectric.RobolectricTestRunner
+
+/**
+ * Guards issue #5470: the two biggest continuous-work paths in onAccessibilityEvent —
+ * per-interaction accessibility-node recording and the debounced full-hierarchy extraction +
+ * structural hash — are gated on a connected client, while the on-demand pull path
+ * (request_hierarchy) stays functional with zero observers and zero prior push activity.
+ */
+@RunWith(RobolectricTestRunner::class)
+class CtrlProxyObserverGateTest {
+
+  /** Event types exercising both gated push paths: an interaction and a hierarchy refresh. */
+  private val interactionTypes =
+    listOf(
+      android.view.accessibility.AccessibilityEvent.TYPE_VIEW_CLICKED,
+      android.view.accessibility.AccessibilityEvent.TYPE_VIEW_SCROLLED,
+      android.view.accessibility.AccessibilityEvent.TYPE_VIEW_SELECTED,
+    )
+
+  private val refreshTypes =
+    listOf(
+      android.view.accessibility.AccessibilityEvent.TYPE_WINDOW_CONTENT_CHANGED,
+      android.view.accessibility.AccessibilityEvent.TYPE_WINDOW_STATE_CHANGED,
+      android.view.accessibility.AccessibilityEvent.TYPE_WINDOWS_CHANGED,
+      android.view.accessibility.AccessibilityEvent.TYPE_VIEW_TEXT_CHANGED,
+    )
+
+  @Test
+  fun `zero connections skips all interaction and hierarchy push work`() {
+    for (type in interactionTypes + refreshTypes) {
+      val work = accessibilityEventWorkFor(type, connectionCount = 0)
+      assertNull("type $type must record no interaction when unobserved", work.interaction)
+      assertFalse(
+        "type $type must trigger no hierarchy refresh when unobserved",
+        work.refreshesHierarchy,
+      )
+    }
+  }
+
+  @Test
+  fun `a connected client restores the classifier's normal dispatch and refresh`() {
+    for (type in interactionTypes) {
+      val work = accessibilityEventWorkFor(type, connectionCount = 1)
+      assertEquals(
+        "observed interaction dispatch must match the shared classifier for type $type",
+        interactionDispatchFor(type),
+        work.interaction,
+      )
+    }
+    for (type in refreshTypes) {
+      val work = accessibilityEventWorkFor(type, connectionCount = 1)
+      assertTrue(
+        "type $type must trigger a hierarchy refresh when observed",
+        work.refreshesHierarchy,
+      )
+    }
+  }
+
+  @Test
+  fun `gate is a strict greater-than-zero, not merely nonzero`() {
+    // A defensive/hypothetical negative count is treated as unobserved, not as "some observer".
+    assertEquals(
+      AccessibilityEventWork.NONE,
+      accessibilityEventWorkFor(interactionTypes.first(), -1),
+    )
+    assertEquals(AccessibilityEventWork.NONE, accessibilityEventWorkFor(refreshTypes.first(), 0))
+  }
+
+  /**
+   * The pull path (request_hierarchy → extractNowBlocking) must produce a correct hierarchy without
+   * any prior push activity: no onAccessibilityEvent() call, no frameContext bumps, a stale/zero
+   * structural hash. extractNowBlocking extracts the live tree directly and returns it, so it reads
+   * none of the push-path side effects the gate now skips. This mirrors
+   * HierarchyDebouncerErrorEmitTest (no device required — the extractor is faked).
+   */
+  @Test
+  fun `pull path extracts a fresh hierarchy with zero prior push activity`() {
+    val extractCalls = AtomicInteger(0)
+    val expected = ViewHierarchy(packageName = "com.example.pull")
+    val debouncer =
+      HierarchyDebouncer(
+        scope = CoroutineScope(Dispatchers.Unconfined),
+        extractHierarchy = { _: Boolean, _: HierarchySnapshotOptions ->
+          extractCalls.incrementAndGet()
+          expected
+        },
+      )
+
+    // No onAccessibilityEvent() has ever run — the push path is fully idle/gated.
+    val pulled = debouncer.extractNowBlocking(skipFlowEmit = true)
+
+    assertNotNull("pull must return a hierarchy even with an idle push path", pulled)
+    assertEquals("com.example.pull", pulled?.packageName)
+    assertEquals(
+      "pull must trigger a fresh extraction, not reuse push-path state",
+      1,
+      extractCalls.get(),
+    )
+  }
+}

--- a/android/control-proxy/src/test/kotlin/dev/jasonpearson/automobile/ctrlproxy/CtrlProxyObserverGateTest.kt
+++ b/android/control-proxy/src/test/kotlin/dev/jasonpearson/automobile/ctrlproxy/CtrlProxyObserverGateTest.kt
@@ -156,32 +156,33 @@ class CtrlProxyObserverGateTest {
 
   /**
    * Bug 2: a still-connected client's in-flight scroll accumulation must never be dropped — while
-   * the connection epoch is unchanged, successive samples add together as before.
+   * the observer-session generation is unchanged, successive samples add together as before.
    */
   @Test
-  fun `pending scroll accumulates within a single connection session`() {
-    val epoch = 7
+  fun `pending scroll accumulates within a single observer session`() {
+    val generation = 7
     var pending = PendingScroll.NONE
     pending =
-      accumulatePendingScroll(pending, deltaX = 10, deltaY = -5, packageName = "com.a", epoch)
+      accumulatePendingScroll(pending, deltaX = 10, deltaY = -5, packageName = "com.a", generation)
     pending =
-      accumulatePendingScroll(pending, deltaX = 4, deltaY = -1, packageName = "com.a", epoch)
+      accumulatePendingScroll(pending, deltaX = 4, deltaY = -1, packageName = "com.a", generation)
 
     assertEquals("deltas combine within a session", 14, pending.deltaX)
     assertEquals(-6, pending.deltaY)
     assertEquals("com.a", pending.packageName)
-    assertEquals(epoch, pending.sessionEpoch)
+    assertEquals(generation, pending.sessionGeneration)
   }
 
   /**
-   * Bug 2 (event-free gap): pending deltas accumulated under one connection session must NOT
-   * combine with the first scroll of a NEW session. The discard is keyed on the monotonic
-   * connection epoch, which advances on the reconnect regardless of whether any accessibility event
-   * fired during the gap — so simulating "accumulate under epoch 7, then the next sample arrives
-   * under epoch 8" models a disconnect+reconnect with no intervening event.
+   * Bug 2 (event-free gap): pending deltas accumulated under one observer session must NOT combine
+   * with the first scroll of a NEW session. The discard is keyed on the observer-session
+   * generation, which advances after the observer set empties and a new client connects —
+   * regardless of whether any accessibility event fired in the gap — so "accumulate under
+   * generation 7, next sample under generation 8" models a disconnect+reconnect with no intervening
+   * event.
    */
   @Test
-  fun `pending scroll deltas do not combine across a connection session change`() {
+  fun `pending scroll deltas do not combine across an observer session change`() {
     // Session 7: an in-flight scroll accumulates but has not yet been flushed/broadcast.
     val stale =
       accumulatePendingScroll(
@@ -189,25 +190,50 @@ class CtrlProxyObserverGateTest {
         deltaX = 40,
         deltaY = -120,
         packageName = "com.old.session",
-        currentEpoch = 7,
+        currentGeneration = 7,
       )
     assertEquals(40, stale.deltaX)
 
-    // The only client disconnects and a new one connects with NO event in between: the epoch has
-    // advanced to 8 by the time the first post-reconnect scroll sample arrives.
+    // The only client disconnects and a new one connects with NO event in between: the generation
+    // has advanced to 8 by the time the first post-reconnect scroll sample arrives.
     val firstAfterReconnect =
       accumulatePendingScroll(
         stale,
         deltaX = 3,
         deltaY = 9,
         packageName = "com.new.session",
-        currentEpoch = 8,
+        currentGeneration = 8,
       )
 
     // Must start clean from the new sample, NOT 40 + 3 / -120 + 9.
     assertEquals("stale deltaX must be discarded, not combined", 3, firstAfterReconnect.deltaX)
     assertEquals("stale deltaY must be discarded, not combined", 9, firstAfterReconnect.deltaY)
     assertEquals("com.new.session", firstAfterReconnect.packageName)
-    assertEquals(8, firstAfterReconnect.sessionEpoch)
+    assertEquals(8, firstAfterReconnect.sessionGeneration)
+  }
+
+  /**
+   * Regression (Codex on the epoch approach): a SECOND concurrent client joining while the first is
+   * still connected must NOT reset a still-accumulating scroll. Because the observer-session
+   * generation is stable for as long as any client stays connected (it advances only on the
+   * empty→non-empty edge, not on a 1→2 join), the tagged generation is unchanged and the in-flight
+   * deltas keep accumulating rather than being truncated for every client.
+   */
+  @Test
+  fun `a concurrent second client does not reset an in-flight scroll`() {
+    val generation = 5 // stable while >= 1 client stays connected, including across a 1 -> 2 join
+    var pending = PendingScroll.NONE
+    pending =
+      accumulatePendingScroll(pending, deltaX = 30, deltaY = 0, packageName = "com.a", generation)
+    // A second client connects mid-scroll — generation is unchanged (no empty->non-empty edge).
+    pending =
+      accumulatePendingScroll(pending, deltaX = 12, deltaY = 0, packageName = "com.a", generation)
+
+    assertEquals(
+      "in-flight deltas must keep accumulating across a concurrent join",
+      42,
+      pending.deltaX,
+    )
+    assertEquals(generation, pending.sessionGeneration)
   }
 }

--- a/android/control-proxy/src/test/kotlin/dev/jasonpearson/automobile/ctrlproxy/CtrlProxyObserverGateTest.kt
+++ b/android/control-proxy/src/test/kotlin/dev/jasonpearson/automobile/ctrlproxy/CtrlProxyObserverGateTest.kt
@@ -155,28 +155,59 @@ class CtrlProxyObserverGateTest {
   }
 
   /**
-   * Bug 2: pending scroll deltas accumulated before the last client left must be discarded across a
-   * zero-observer gap, so the first post-reconnect scroll starts clean instead of adding onto stale
-   * state and broadcasting a bogus combined delta. A still-connected client's in-flight
-   * accumulation must be preserved untouched.
+   * Bug 2: a still-connected client's in-flight scroll accumulation must never be dropped — while
+   * the connection epoch is unchanged, successive samples add together as before.
    */
   @Test
-  fun `pending scroll deltas are discarded across a zero-observer gap`() {
-    val accumulated =
-      PendingScrollState(deltaX = 40, deltaY = -120, packageName = "com.example.app")
+  fun `pending scroll accumulates within a single connection session`() {
+    val epoch = 7
+    var pending = PendingScroll.NONE
+    pending =
+      accumulatePendingScroll(pending, deltaX = 10, deltaY = -5, packageName = "com.a", epoch)
+    pending =
+      accumulatePendingScroll(pending, deltaX = 4, deltaY = -1, packageName = "com.a", epoch)
 
-    // Last client gone: discard so the next scroll starts from zero.
-    assertEquals(
-      PendingScrollState.EMPTY,
-      pendingScrollAcrossGate(accumulated, connectionCount = 0),
-    )
-    assertEquals(
-      PendingScrollState.EMPTY,
-      pendingScrollAcrossGate(accumulated, connectionCount = -1),
-    )
+    assertEquals("deltas combine within a session", 14, pending.deltaX)
+    assertEquals(-6, pending.deltaY)
+    assertEquals("com.a", pending.packageName)
+    assertEquals(epoch, pending.sessionEpoch)
+  }
 
-    // Still observed: preserve the in-flight accumulation exactly, dropping nothing.
-    assertEquals(accumulated, pendingScrollAcrossGate(accumulated, connectionCount = 1))
-    assertEquals(accumulated, pendingScrollAcrossGate(accumulated, connectionCount = 3))
+  /**
+   * Bug 2 (event-free gap): pending deltas accumulated under one connection session must NOT
+   * combine with the first scroll of a NEW session. The discard is keyed on the monotonic
+   * connection epoch, which advances on the reconnect regardless of whether any accessibility event
+   * fired during the gap — so simulating "accumulate under epoch 7, then the next sample arrives
+   * under epoch 8" models a disconnect+reconnect with no intervening event.
+   */
+  @Test
+  fun `pending scroll deltas do not combine across a connection session change`() {
+    // Session 7: an in-flight scroll accumulates but has not yet been flushed/broadcast.
+    val stale =
+      accumulatePendingScroll(
+        PendingScroll.NONE,
+        deltaX = 40,
+        deltaY = -120,
+        packageName = "com.old.session",
+        currentEpoch = 7,
+      )
+    assertEquals(40, stale.deltaX)
+
+    // The only client disconnects and a new one connects with NO event in between: the epoch has
+    // advanced to 8 by the time the first post-reconnect scroll sample arrives.
+    val firstAfterReconnect =
+      accumulatePendingScroll(
+        stale,
+        deltaX = 3,
+        deltaY = 9,
+        packageName = "com.new.session",
+        currentEpoch = 8,
+      )
+
+    // Must start clean from the new sample, NOT 40 + 3 / -120 + 9.
+    assertEquals("stale deltaX must be discarded, not combined", 3, firstAfterReconnect.deltaX)
+    assertEquals("stale deltaY must be discarded, not combined", 9, firstAfterReconnect.deltaY)
+    assertEquals("com.new.session", firstAfterReconnect.packageName)
+    assertEquals(8, firstAfterReconnect.sessionEpoch)
   }
 }

--- a/android/control-proxy/src/test/kotlin/dev/jasonpearson/automobile/ctrlproxy/WebSocketServerIntegrationTest.kt
+++ b/android/control-proxy/src/test/kotlin/dev/jasonpearson/automobile/ctrlproxy/WebSocketServerIntegrationTest.kt
@@ -197,6 +197,51 @@ class WebSocketServerIntegrationTest {
   }
 
   @Test
+  fun `connectionEpoch increments across a disconnect and reconnect`() = runBlocking {
+    // The scroll-staleness fix (issue #5470) keys "is this the same connection session" on the
+    // monotonic connectionEpoch. getConnectionCount() returns to 1 after a reconnect and so cannot
+    // distinguish sessions; connectionEpoch must strictly increase so a reconnect is detectable
+    // even
+    // when no accessibility event fired in the gap.
+    server.start()
+    assertEquals("epoch starts at 0 before any connection", 0, server.connectionEpoch())
+
+    val client1 = HttpClient(CIO) { install(WebSockets) }
+    client1.use { c ->
+      c.webSocket(
+        method = HttpMethod.Get,
+        host = "localhost",
+        port = getServerPort(),
+        path = "/ws",
+      ) {
+        waitFor { server.getConnectionCount() == 1 }
+      }
+    }
+    waitFor { server.getConnectionCount() == 0 }
+    val epochAfterFirst = server.connectionEpoch()
+    assertEquals("epoch advances on the first connection", 1, epochAfterFirst)
+
+    // Reconnect: live count returns to 1, but the epoch must be strictly greater than before.
+    val client2 = HttpClient(CIO) { install(WebSockets) }
+    client2.use { c ->
+      c.webSocket(
+        method = HttpMethod.Get,
+        host = "localhost",
+        port = getServerPort(),
+        path = "/ws",
+      ) {
+        waitFor { server.getConnectionCount() == 1 }
+        assertEquals("live count cannot distinguish the reconnect", 1, server.getConnectionCount())
+        assertTrue(
+          "epoch must strictly increase on reconnect (was $epochAfterFirst, now ${server.connectionEpoch()})",
+          server.connectionEpoch() > epochAfterFirst,
+        )
+      }
+    }
+    waitFor { server.getConnectionCount() == 0 }
+  }
+
+  @Test
   fun `server broadcasts messages to connected client`() = runBlocking {
     // Given
     server.start()

--- a/android/control-proxy/src/test/kotlin/dev/jasonpearson/automobile/ctrlproxy/WebSocketServerIntegrationTest.kt
+++ b/android/control-proxy/src/test/kotlin/dev/jasonpearson/automobile/ctrlproxy/WebSocketServerIntegrationTest.kt
@@ -197,49 +197,86 @@ class WebSocketServerIntegrationTest {
   }
 
   @Test
-  fun `connectionEpoch increments across a disconnect and reconnect`() = runBlocking {
-    // The scroll-staleness fix (issue #5470) keys "is this the same connection session" on the
-    // monotonic connectionEpoch. getConnectionCount() returns to 1 after a reconnect and so cannot
-    // distinguish sessions; connectionEpoch must strictly increase so a reconnect is detectable
-    // even
-    // when no accessibility event fired in the gap.
-    server.start()
-    assertEquals("epoch starts at 0 before any connection", 0, server.connectionEpoch())
+  fun `observerSessionGeneration is stable within a session and advances after it empties`() =
+    runBlocking {
+      // The scroll-staleness fix (issue #5470) keys "is this the same observer session" on
+      // observerSessionGeneration, which must advance ONLY on the empty->non-empty edge:
+      //  - stable while >= 1 client stays continuously connected (so a concurrent 2nd client
+      // joining
+      //    does NOT reset a still-connected client's in-flight scroll),
+      //  - advanced after the set empties and a new client connects (so a disconnect+reconnect,
+      //    including one with no intervening event, correctly clears stale scroll deltas).
+      server.start()
+      assertEquals(
+        "generation starts at 0 before any connection",
+        0,
+        server.observerSessionGeneration(),
+      )
 
-    val client1 = HttpClient(CIO) { install(WebSockets) }
-    client1.use { c ->
-      c.webSocket(
-        method = HttpMethod.Get,
-        host = "localhost",
-        port = getServerPort(),
-        path = "/ws",
-      ) {
-        waitFor { server.getConnectionCount() == 1 }
-      }
-    }
-    waitFor { server.getConnectionCount() == 0 }
-    val epochAfterFirst = server.connectionEpoch()
-    assertEquals("epoch advances on the first connection", 1, epochAfterFirst)
+      val client1 = HttpClient(CIO) { install(WebSockets) }
+      val client2 = HttpClient(CIO) { install(WebSockets) }
+      client1.use { c1 ->
+        c1.webSocket(
+          method = HttpMethod.Get,
+          host = "localhost",
+          port = getServerPort(),
+          path = "/ws",
+        ) {
+          waitFor { server.getConnectionCount() == 1 }
+          val genAfterFirst = server.observerSessionGeneration()
+          assertEquals("generation advances on the first client of a session", 1, genAfterFirst)
 
-    // Reconnect: live count returns to 1, but the epoch must be strictly greater than before.
-    val client2 = HttpClient(CIO) { install(WebSockets) }
-    client2.use { c ->
-      c.webSocket(
-        method = HttpMethod.Get,
-        host = "localhost",
-        port = getServerPort(),
-        path = "/ws",
-      ) {
-        waitFor { server.getConnectionCount() == 1 }
-        assertEquals("live count cannot distinguish the reconnect", 1, server.getConnectionCount())
-        assertTrue(
-          "epoch must strictly increase on reconnect (was $epochAfterFirst, now ${server.connectionEpoch()})",
-          server.connectionEpoch() > epochAfterFirst,
-        )
+          // A SECOND concurrent client joins (1 -> 2): the generation must NOT change.
+          client2.use { c2 ->
+            c2.webSocket(
+              method = HttpMethod.Get,
+              host = "localhost",
+              port = getServerPort(),
+              path = "/ws",
+            ) {
+              waitFor { server.getConnectionCount() == 2 }
+              assertEquals(
+                "a concurrent 2nd client must not change the generation",
+                genAfterFirst,
+                server.observerSessionGeneration(),
+              )
+            }
+          }
+          // Second client gone; first still connected — still the same session.
+          waitFor { server.getConnectionCount() == 1 }
+          assertEquals(
+            "generation is stable while a client stays connected",
+            genAfterFirst,
+            server.observerSessionGeneration(),
+          )
+        }
       }
+
+      // The set has now emptied. A new client starts a new session: generation must advance.
+      waitFor { server.getConnectionCount() == 0 }
+      val genAfterEmpty = server.observerSessionGeneration()
+      val client3 = HttpClient(CIO) { install(WebSockets) }
+      client3.use { c3 ->
+        c3.webSocket(
+          method = HttpMethod.Get,
+          host = "localhost",
+          port = getServerPort(),
+          path = "/ws",
+        ) {
+          waitFor { server.getConnectionCount() == 1 }
+          assertEquals(
+            "live count cannot distinguish the reconnect",
+            1,
+            server.getConnectionCount(),
+          )
+          assertTrue(
+            "generation must advance after the set empties (was $genAfterEmpty, now ${server.observerSessionGeneration()})",
+            server.observerSessionGeneration() > genAfterEmpty,
+          )
+        }
+      }
+      waitFor { server.getConnectionCount() == 0 }
     }
-    waitFor { server.getConnectionCount() == 0 }
-  }
 
   @Test
   fun `server broadcasts messages to connected client`() = runBlocking {


### PR DESCRIPTION
## Summary

The most expensive continuous work in CtrlProxy — full hierarchy extraction + structural hashing, and per-interaction accessibility-node work — ran on every accessibility event whenever the WebSocket server was up, gated only on `isRunning()` rather than on a connected client. Those event types (`WINDOW_CONTENT_CHANGED` / `STATE_CHANGED` / `WINDOWS_CHANGED` / `VIEW_TEXT_CHANGED` / `VIEW_SCROLLED` / clicks) flood during any animation, scroll, or typing, so this was the single largest continuous CPU/allocation/battery drain while the device was not being observed.

This adds one "is anyone observing" gate — `webSocketServer.getConnectionCount() > 0` — expressed as the pure helper `accessibilityEventWorkFor(eventType, connectionCount)`. When zero clients are connected:

- `onAccessibilityEvent` records no interaction, schedules no `hierarchyDebouncer.onAccessibilityEvent()` refresh, and skips the `frameContext` bumps (both the scroll-branch bump and the hierarchy-refresh bump) that only label pushed/broadcast frames.
- `recordInteractionEvent` early-returns on the same count **before** reading `event.source` / `getBoundsInScreen` / allocating an `InteractionElement` — the defensive backstop for the debounced scroll/interaction callers.

Nothing about what is broadcast, the throttle/dedup/serialization semantics, or the frameContext token contract changes — this is purely an added early-out when no client is connected. The gate is a plain read (`getConnectionCount()`), no locks on the hot path; a race across a connect/disconnect edge costs at most one extra or one skipped frame.

## Where the gates are (`CtrlProxy.kt`)

- Pure helper `accessibilityEventWorkFor` (returns `AccessibilityEventWork(interaction, refreshesHierarchy)`, `NONE` at zero observers) — beside the existing `interactionDispatchFor` / `triggersHierarchyRefresh` classifiers.
- `onAccessibilityEvent`: computes `work` once from the live connection count, then routes the interaction `when` on `work.interaction` and the debouncer dispatch on `work.refreshesHierarchy`.
- `recordInteractionEvent`: guard changed from `isRunning()` to `getConnectionCount() <= 0` (a connected client implies the server is running).

## Subscription-lifecycle note: pull path and connect-bootstrap

**Pull path is independent of push-path state.** `request_hierarchy` → `extractHierarchyNow` → `hierarchyDebouncer.extractNowBlocking(skipFlowEmit = true)` cancels any debounce job and extracts the live accessibility tree directly via `extractHierarchyDirect`. It reads none of the side effects the gate now skips: not the `frameContext` counter, not the debouncer's `lastStructuralHash`/`lastHierarchy` cache. So a pull returns a correct, current hierarchy even when the push path has been idle/gated with a stale-or-zero counter. Verified structurally (extractNowBlocking returns fresh `lastHierarchy` from the extractor, gated only by `skipFlowEmit`) and by unit test.

**No missed first frame on connect.** The newly-connected client is bootstrapped by its own initial `request_hierarchy`, which travels the pull path above — it does **not** depend on a push that was skipped while gated. The `frameContext` counter simply resumes incrementing on the next push-triggering event once a client is connected; because it is an opaque `epoch:counter` token validated by equality, a gap in the sequence while idle is harmless (no gesture tokens are issued while unobserved).

## Tests (`CtrlProxyObserverGateTest.kt`, fast, no device)

- zero connections → an accessibility event records no interaction and triggers no hierarchy refresh (`accessibilityEventWorkFor(type, 0) == NONE` for all interaction + refresh types);
- one connection → dispatch matches the shared classifier and refresh fires as before;
- gate is strict `> 0` (negative/zero → `NONE`);
- pull path: `extractNowBlocking` returns a correct, freshly-extracted hierarchy with **zero** prior `onAccessibilityEvent()` activity, asserting the extractor is invoked exactly once and push-path state is not reused.

`./gradlew -p android :control-proxy:testDebugUnitTest` — full suite green; ktfmt applied. Diff touches only `CtrlProxy.kt` and its new test.

Closes #5470
