### PR TITLE
refactor(observe): migrate iOS verifyServiceReady onto shared RetryExecutor

### DIFF
--- a/src/features/observe/ios/IOSCtrlProxyClient.ts
+++ b/src/features/observe/ios/IOSCtrlProxyClient.ts
@@ -27,6 +27,7 @@ import { readScreenScaleMetadata } from "../../../models/ScreenScaleMetadata";
 import { ViewHierarchyQueryOptions } from "../../../models/ViewHierarchyQueryOptions";
 import { PerformanceTracker, NoOpPerformanceTracker } from "../../../utils/PerformanceTracker";
 import { Timer, defaultTimer } from "../../../utils/SystemTimer";
+import { RetryExecutor, defaultRetryExecutor } from "../../../utils/retry/RetryExecutor";
 import { IOS_CTRL_PROXY_RESERVED_PORTS, PortManager } from "../../../utils/PortManager";
 import { requireBootedDevice } from "../../../utils/requireBootedDevice";
 import { IOSCtrlProxyManager, CtrlProxyIosManager } from "../../../utils/IOSCtrlProxyManager";
@@ -490,9 +491,10 @@ export class IOSCtrlProxyClient extends DeviceServiceClient implements IOSCtrlPr
     serviceManagerFactory: ServiceManagerFactory = defaultServiceManagerFactory,
     bootedDeviceLister: BootedDeviceLister = defaultBootedDeviceLister,
     deviceConnectionLostNotifier: DeviceConnectionLostNotifier = observationStreamDeviceConnectionLostNotifier,
-    sdkEventIngestor?: IosSdkEventIngestor
+    sdkEventIngestor?: IosSdkEventIngestor,
+    retryExecutor: RetryExecutor = defaultRetryExecutor
   ) {
-    super(timer, wsFactory, { connectionResetMs: IOSCtrlProxyClient.CONNECTION_RESET_MS });
+    super(timer, wsFactory, { connectionResetMs: IOSCtrlProxyClient.CONNECTION_RESET_MS }, retryExecutor);
     this.device = device;
     this.port = port;
     this.serviceManagerFactory = serviceManagerFactory;
@@ -705,7 +707,8 @@ export class IOSCtrlProxyClient extends DeviceServiceClient implements IOSCtrlPr
     serviceManagerFactory: ServiceManagerFactory = noOpServiceManagerFactory,
     bootedDeviceLister?: BootedDeviceLister,
     deviceConnectionLostNotifier?: DeviceConnectionLostNotifier,
-    sdkEventIngestor?: IosSdkEventIngestor
+    sdkEventIngestor?: IosSdkEventIngestor,
+    retryExecutor?: RetryExecutor
   ): IOSCtrlProxyClient {
     // Default test lister always reports the device as booted so existing tests
     // are unaffected. Tests that verify boot-check behavior supply their own lister.
@@ -718,7 +721,8 @@ export class IOSCtrlProxyClient extends DeviceServiceClient implements IOSCtrlPr
       serviceManagerFactory,
       lister,
       deviceConnectionLostNotifier,
-      sdkEventIngestor
+      sdkEventIngestor,
+      retryExecutor
     );
   }
 
@@ -2107,25 +2111,35 @@ export class IOSCtrlProxyClient extends DeviceServiceClient implements IOSCtrlPr
     delayMs: number = 1000,
     timeoutMs: number = 5000
   ): Promise<boolean> {
-    for (let i = 0; i < maxAttempts; i++) {
-      if (!await this.ensureConnected()) {
-        await this.timer.sleep(delayMs);
-        continue;
-      }
+    // Sits on the shared RetryExecutor (issue #5460), matching how
+    // DeviceServiceClient.waitForConnection and AndroidCtrlProxyClient.verifyServiceReady
+    // already retry service-readiness. The two-phase probe is preserved: a failed
+    // connection throws to consume an attempt without a hierarchy request, and a
+    // connected-but-empty/failed hierarchy throws to retry. Any throw becomes a
+    // retryable attempt with a fixed `delayMs` wait between attempts — so the loop
+    // waits maxAttempts - 1 times, not once per attempt as the previous hand-rolled
+    // loop did (it slept even after the final failed attempt; that trailing wait was
+    // pure wasted latency on the error path).
+    const result = await this.retryExecutor.execute(
+      async () => {
+        if (!await this.ensureConnected()) {
+          throw new Error("CtrlProxy WebSocket not connected");
+        }
 
-      // Try to get hierarchy to verify service is working
-      try {
-        const result = await this.requestHierarchySync(undefined, false, undefined, timeoutMs);
-        if (result?.hierarchy) {
+        const hierarchyResult = await this.requestHierarchySync(undefined, false, undefined, timeoutMs);
+        if (hierarchyResult?.hierarchy) {
           return true;
         }
-      } catch {
-        // Continue retrying
-      }
 
-      await this.timer.sleep(delayMs);
-    }
-    return false;
+        throw new Error("CtrlProxy returned no hierarchy");
+      },
+      {
+        maxAttempts,
+        delays: delayMs,
+      }
+    );
+
+    return result.value ?? false;
   }
 
   // ===========================================================================

--- a/test/features/observe/ios/IOSCtrlProxyClient.test.ts
+++ b/test/features/observe/ios/IOSCtrlProxyClient.test.ts
@@ -10,6 +10,7 @@ import {
   WebSocketState
 } from "../../../fakes/FakeWebSocket";
 import { FakeTimer } from "../../../fakes/FakeTimer";
+import { DefaultRetryExecutor } from "../../../../src/utils/retry/RetryExecutor";
 import { FakeScreenshotBackoffScheduler } from "../../../../src/features/observe/ScreenshotBackoffScheduler";
 import type { DeviceConnectionLostNotifier } from "../../../../src/features/observe/DeviceConnectionLostNotifier";
 import { FakeIosSdkEventIngestor } from "../../../fakes/FakeIosSdkEventIngestor";
@@ -3131,6 +3132,142 @@ describe("IOSCtrlProxyClient", function() {
           expect(bound.width).toBe(vector.expectedPixelWidth);
           expect(bound.height).toBe(vector.expectedPixelHeight);
         });
+      }
+    });
+  });
+
+  describe("verifyServiceReady", function() {
+    // Regression pin for the iOS readiness loop (issue #5460). Behaviour under test:
+    // the two-phase probe (ensureConnected -> on false, count a failed attempt and
+    // wait; else requestHierarchySync and succeed on a truthy `hierarchy`), the
+    // maxAttempts budget, the fixed between-attempts delay, and the boolean outcome.
+    //
+    // Each test stubs `ensureConnected` and `requestHierarchySync` on a fresh
+    // instance so no WebSocket/runner is involved, and drives an auto-advancing
+    // FakeTimer so the delays resolve without wall-clock time. `getSleepHistory()`
+    // pins the exact number of between-attempts waits — this is where the one
+    // intentional behaviour change lands (RetryExecutor waits between attempts only,
+    // i.e. maxAttempts - 1 waits, dropping the old loop's wasted trailing wait after
+    // the final failed attempt).
+    interface ProbeStub {
+      connect: boolean[] | boolean;
+      hierarchy: Array<{ hierarchy: unknown } | null | Error>;
+    }
+
+    const buildClient = (timer: FakeTimer, stub: ProbeStub): IOSCtrlProxyClient => {
+      const client = IOSCtrlProxyClient.createForTesting(
+        testDevice,
+        serverPort,
+        createSuccessWebSocketFactory(timer),
+        timer,
+        undefined,
+        undefined,
+        undefined,
+        undefined,
+        // Retry delays must run on the SAME fake timer so the test controls them.
+        new DefaultRetryExecutor(timer)
+      );
+
+      let connectIndex = 0;
+      (client as any).ensureConnected = async (): Promise<boolean> => {
+        if (typeof stub.connect === "boolean") {
+          return stub.connect;
+        }
+        const value = stub.connect[Math.min(connectIndex, stub.connect.length - 1)]!;
+        connectIndex++;
+        return value;
+      };
+
+      let hierarchyIndex = 0;
+      (client as any).requestHierarchySync = async (): Promise<{ hierarchy: unknown } | null> => {
+        const value = stub.hierarchy[Math.min(hierarchyIndex, stub.hierarchy.length - 1)]!;
+        hierarchyIndex++;
+        if (value instanceof Error) {
+          throw value;
+        }
+        return value;
+      };
+
+      return client;
+    };
+
+    test("returns true on the first attempt when connected and hierarchy is present", async function() {
+      const timer = new FakeTimer();
+      timer.enableAutoAdvance();
+      const client = buildClient(timer, { connect: true, hierarchy: [{ hierarchy: {} }] });
+      try {
+        expect(await client.verifyServiceReady(3, 1000, 5000)).toBe(true);
+        // Success on attempt 1 waits zero times.
+        expect(timer.getSleepHistory()).toEqual([]);
+      } finally {
+        await client.close();
+      }
+    });
+
+    test("two-phase probe: a failed connection consumes an attempt, then it succeeds", async function() {
+      const timer = new FakeTimer();
+      timer.enableAutoAdvance();
+      // Attempt 1 fails to connect (waits, no hierarchy request), attempt 2 connects
+      // and returns a hierarchy.
+      const client = buildClient(timer, { connect: [false, true], hierarchy: [{ hierarchy: {} }] });
+      try {
+        expect(await client.verifyServiceReady(3, 1000, 5000)).toBe(true);
+        expect(timer.getSleepHistory()).toEqual([1000]);
+      } finally {
+        await client.close();
+      }
+    });
+
+    test("retries when connected but hierarchy is null, then succeeds", async function() {
+      const timer = new FakeTimer();
+      timer.enableAutoAdvance();
+      const client = buildClient(timer, { connect: true, hierarchy: [null, { hierarchy: {} }] });
+      try {
+        expect(await client.verifyServiceReady(3, 1000, 5000)).toBe(true);
+        expect(timer.getSleepHistory()).toEqual([1000]);
+      } finally {
+        await client.close();
+      }
+    });
+
+    test("treats a thrown hierarchy request as a failed attempt", async function() {
+      const timer = new FakeTimer();
+      timer.enableAutoAdvance();
+      const client = buildClient(timer, {
+        connect: true,
+        hierarchy: [new Error("hierarchy request failed"), { hierarchy: {} }],
+      });
+      try {
+        expect(await client.verifyServiceReady(3, 1000, 5000)).toBe(true);
+        expect(timer.getSleepHistory()).toEqual([1000]);
+      } finally {
+        await client.close();
+      }
+    });
+
+    test("returns false after exhausting maxAttempts when hierarchy never becomes ready", async function() {
+      const timer = new FakeTimer();
+      timer.enableAutoAdvance();
+      const client = buildClient(timer, { connect: true, hierarchy: [null] });
+      try {
+        expect(await client.verifyServiceReady(3, 1000, 5000)).toBe(false);
+        // Three attempts, waiting only BETWEEN attempts (RetryExecutor semantics):
+        // maxAttempts - 1 = 2 waits, no wasted trailing wait after the final failure.
+        expect(timer.getSleepHistory()).toEqual([1000, 1000]);
+      } finally {
+        await client.close();
+      }
+    });
+
+    test("returns false when the device never connects", async function() {
+      const timer = new FakeTimer();
+      timer.enableAutoAdvance();
+      const client = buildClient(timer, { connect: false, hierarchy: [null] });
+      try {
+        expect(await client.verifyServiceReady(3, 1000, 5000)).toBe(false);
+        expect(timer.getSleepHistory()).toEqual([1000, 1000]);
+      } finally {
+        await client.close();
       }
     });
   });


### PR DESCRIPTION
## Summary

Migrates `IOSCtrlProxyClient.verifyServiceReady()` onto the shared `RetryExecutor` (`src/utils/retry/RetryExecutor.ts`). It was the last of the three service-readiness loops still hand-rolled — `DeviceServiceClient.waitForConnection()` and `AndroidCtrlProxyClient.verifyServiceReady()` already sit on `RetryExecutor` (since #1124). Now all three retry service readiness on the one canonical primitive, reusing the canonical `Backoff`/`Timer` instead of a hand-rolled `for`-loop with inline `timer.sleep`.

Scope note: this is the **narrowed** realization of #5460. The issue originally proposed extracting a new generic `pollUntil` primitive and migrating three loops onto it, but two of the three already use `RetryExecutor`, so a new `pollUntil` would be a third primitive overlapping `RetryExecutor` (against "one canonical primitive per concern") and would be lossy against the attempt-budget + short-circuit + two-phase realities of these loops. The rescope to "migrate the one remaining hand-rolled iOS loop onto `RetryExecutor`" is documented on the issue.

The two-phase probe is preserved: a failed `ensureConnected()` throws to consume an attempt without a hierarchy request; a connected-but-empty/failed `requestHierarchySync()` throws to retry. `maxAttempts` (default 3), the fixed between-attempts delay (default 1000ms), the `result.hierarchy` success predicate, and the boolean return are all unchanged.

A `retryExecutor` injection seam was added to the iOS client constructor and `createForTesting` (mirroring the Android client) so the retry delays run on the injected timer under test.

## Linked Issue

Closes #5460

## Behavior change

**One intentional change:** the old hand-rolled loop slept `delayMs` at the end of **every** iteration, including after the **final** failed attempt — so a full failure with `maxAttempts=3` waited 3× `delayMs` (~3000ms) even though no fourth attempt follows. `RetryExecutor` waits **between** attempts only (`maxAttempts - 1` waits), so a full failure now waits 2× `delayMs`. This drops one trailing ~1000ms sleep that was pure wasted latency on the error path. Nothing else changes: same attempts, same success/return semantics, same delay between attempts. The regression pin asserts the new wait count (`[1000, 1000]` on full failure).

## Validation

- [x] `bun run lint` — ratchet gate: no new violations; boundary-checks 13/13
- [x] `bun test` — 13827 pass, 14 skip, 0 fail (977 files)
- [x] `bun run typecheck` — no new type errors (179 baseline)
- [x] `bun run build` — success
- [x] New test uses interface + fake + FakeTimer; the `verifyServiceReady` suite runs <100ms and never resolves the real file-backed `getDatabase()`
- [x] Reuses the existing `RetryExecutor`/`Backoff`/`Timer` helpers — no new dependency

## Device Verification

N/A — behavior-preserving refactor of the readiness retry loop; timing/return semantics pinned by a FakeTimer unit test. The only runtime change is a slightly faster failure path (one fewer trailing sleep).

## Follow-ups

The broader #5460 observation (15+ waitFor/poll loops reimplement a similar skeleton) is left for later **individual** triage — they vary widely (wall-clock vs attempt-budget budgets, custom predicates, abort handling) and should not be swept into one primitive. Candidates for future consolidation onto `RetryExecutor`/`pollObserveUntil`:
`src/features/observe/AwaitIdle.ts`, `GetBackStack.ts`, `DeviceServiceUtils.ts`; `src/features/action/{BaseVisualChange,TapOnElement,SetUIState,LaunchApp}.ts`; `src/features/navigation/{NavigateTo,UIStateExtractor}.ts`; `src/utils/{DeepLinkManager,IOSCtrlProxyManager,IOSCtrlProxyBuilder}.ts`; `src/server/ToolExecutionContext.ts`.
