### PR TITLE
chore(lint): unwrap TS non-null and optional-chain wrappers in no-inline-error-normalize (#5505)

### DIFF
--- a/oxlint-plugins/auto-mobile.mjs
+++ b/oxlint-plugins/auto-mobile.mjs
@@ -504,6 +504,21 @@ function identifierName(node) {
 	return node?.type === "Identifier" ? node.name : null;
 }
 
+// Strip transparent TS/chain wrappers that are erased or irrelevant to the
+// reference's runtime identity: a non-null assertion (`error!`) is a compile-time
+// TS construct, and a `ChainExpression` is just the optional-chaining envelope
+// (`error?.message`) whose `.message` read is identical to `error.message` on a
+// non-nullish error. Unwrapping here lets those spellings match the same subject
+// so the rule flags `error!.message` / `error?.message` instead of silently
+// treating them as different references (issue #5505, deferred edge case 3).
+function unwrapRef(node) {
+	let current = node;
+	while (current && (current.type === "TSNonNullExpression" || current.type === "ChainExpression")) {
+		current = current.expression;
+	}
+	return current;
+}
+
 // Structural token list for a side-effect-free reference expression: an identifier,
 // `this`, a non-computed member chain (`a.b.c`), or computed access by a literal or
 // identifier index (`a[0]`, `a["0"]`, `a[i]`). Returns null for anything whose repeated
@@ -511,7 +526,8 @@ function identifierName(node) {
 // is canonicalized to how JavaScript resolves the property key, so the *same* property
 // compares equal regardless of spelling (`.error`/`["error"]`, `[0]`/`["0"]`), while a
 // computed identifier key stays distinct (its value can differ from a same-text literal).
-function refTokens(node) {
+function refTokens(rawNode) {
+	const node = unwrapRef(rawNode);
 	if (!node) {
 		return null;
 	}
@@ -572,7 +588,7 @@ const noInlineErrorNormalizeRule = {
 				// consequent must be `<subject>.message` or `<subject>["message"]` (a
 				// computed access is only `.message` when its key is the string literal
 				// "message" — a computed identifier key like `[message]` is a different var).
-				const consequent = node.consequent;
+				const consequent = unwrapRef(node.consequent);
 				const consequentIsMessage =
 					consequent?.type === "MemberExpression" &&
 					stableRefKey(consequent.object) === subjectKey &&

--- a/test/lint/noInlineErrorNormalizeRule.test.ts
+++ b/test/lint/noInlineErrorNormalizeRule.test.ts
@@ -101,4 +101,45 @@ describe("auto-mobile/no-inline-error-normalize", () => {
       fires('const m = a["b.prop:c"] instanceof Error ? a.b.c.message : String(a["b.prop:c"]);'),
     ).toBe(false);
   });
+
+  // Issue #5505, deferred edge case 3: transparent TS/chain wrappers
+  // (`error!`, `error?.message`) must be unwrapped so these spellings are not
+  // false negatives that evade the recurrence guard.
+
+  test("flags a non-null-asserted subject across all three positions", () => {
+    expect(
+      fires("const m = error! instanceof Error ? error!.message : String(error!);"),
+    ).toBe(true);
+  });
+
+  test("flags a non-null assertion appearing in only one position", () => {
+    // `error!` erases to `error` at runtime, so the reference is the same.
+    expect(
+      fires("const m = error instanceof Error ? error!.message : String(error);"),
+    ).toBe(true);
+  });
+
+  test("flags an optional-chained `.message` consequent", () => {
+    expect(
+      fires("const m = error instanceof Error ? error?.message : String(error);"),
+    ).toBe(true);
+  });
+
+  test("flags a non-null-asserted member subject (`result.error!`)", () => {
+    expect(
+      fires("const m = result.error! instanceof Error ? result.error!.message : String(result.error!);"),
+    ).toBe(true);
+  });
+
+  test("flags an optional-chained member subject (`result?.error`)", () => {
+    expect(
+      fires("const m = result?.error instanceof Error ? result?.error.message : String(result?.error);"),
+    ).toBe(true);
+  });
+
+  test("still does not flag a wrapped subject when branches reference a different var", () => {
+    expect(
+      fires("const m = a! instanceof Error ? b!.message : String(c!);"),
+    ).toBe(false);
+  });
 });


### PR DESCRIPTION
Closes #5505 (deferred edge case 3).

## What

Extends the `auto-mobile/no-inline-error-normalize` oxlint rule (added in #5457 / PR #5485) to unwrap two transparent AST wrappers that previously let the banned inline idiom evade the recurrence guard as **false negatives**:

- `TSNonNullExpression` — `error!` (a compile-time TS construct, erased at runtime)
- `ChainExpression` — `error?.message` (optional-chaining envelope; reads identically to `error.message` on a non-nullish subject)

Both are transparent to the reference's runtime identity, so unwrapping them lets the *same* reference match across the ternary's test, consequent, and alternate positions. Now `error!.message` and `error?.message` spellings of the idiom are correctly flagged and steered to the canonical `errorMessage()` helper.

## How

- Add `unwrapRef()` which strips `TSNonNullExpression`/`ChainExpression` layers.
- Apply it at the head of `refTokens()` (covers the test subject, the alternate's `String(...)` argument, and every member-chain segment via the existing recursion) and to the ternary's consequent (so an optional-chained `.message` reaches its `MemberExpression`).

## Tests

Six new cases in `test/lint/noInlineErrorNormalizeRule.test.ts` (bun-native, sub-100ms), covering asserted/optional subjects across all three positions, mixed single-position wrappers, and a negative case where the branches reference different variables. Full `test/lint/` rule suite green.

## Out of scope (remain deferred in #5505)

Edge cases 1 (binding-shadow of `Error`/`String`) and 2 (side-effecting getters) — both require scope/type information the oxlint JS-plugin visitor does not expose, exactly as the issue notes.

## Validation

- `bun test test/lint/noInlineErrorNormalizeRule.test.ts` — 23 pass
- `bun run lint` — oxlint ratchet: no new violations; boundary-checks: 13/13 pass
- `bun run typecheck` — no new type errors

🤖 Generated with [Claude Code](https://claude.com/claude-code) (autonomous next-best-issue run)