### PR TITLE
feat(daemon): validate key-value type against platform in ide/setKeyValue (#5022)

### DIFF
--- a/src/daemon/socketServer.ts
+++ b/src/daemon/socketServer.ts
@@ -57,6 +57,7 @@ import {
 import { assertToolEnabledForAnySession } from "../features/toolSelection/toolSelectionPolicy";
 import { resolveToolSelectionBaseSessionUuid } from "../features/toolSelection/selectionSessionResolver";
 import { ToolRegistry } from "../server/toolRegistry";
+import { validateTypeForPlatform } from "../server/storageTools";
 import { getMcpServerVersion } from "../utils/mcpVersion";
 import {
   IOS_CTRL_PROXY_APP_HASH,
@@ -1582,10 +1583,17 @@ export class UnixSocketServer {
           throw new Error("setKeyValue requires deviceId, appId, fileName, key, and type params");
         }
         await this.assertSocketToolEnabled(args.deviceId, "setKeyValue");
-        const client = await this.resolveKeyValueMutationClient(args.platform, args.deviceId);
+        const { platform, client } = await this.resolveKeyValueMutationClient(
+          args.platform,
+          args.deviceId,
+        );
         if (args.value === null || args.value === undefined) {
           await client.removePreference(args.appId, args.fileName, args.key);
         } else {
+          // Enforce the same cross-platform type guidance as the MCP-tool path
+          // (storageTools.ts) before dispatch, so a platform-incompatible type
+          // fails with an actionable error rather than deeper in the client (#5022).
+          validateTypeForPlatform(platform, args.type as KeyValueType);
           await client.setPreference(
             args.appId,
             args.fileName,
@@ -1608,7 +1616,7 @@ export class UnixSocketServer {
           throw new Error("removeKeyValue requires deviceId, appId, fileName, and key params");
         }
         await this.assertSocketToolEnabled(args.deviceId, "removeKeyValue");
-        const client = await this.resolveKeyValueMutationClient(args.platform, args.deviceId);
+        const { client } = await this.resolveKeyValueMutationClient(args.platform, args.deviceId);
         await client.removePreference(args.appId, args.fileName, args.key);
         return { success: true };
       }
@@ -1623,7 +1631,7 @@ export class UnixSocketServer {
           throw new Error("clearKeyValueFile requires deviceId, appId, and fileName params");
         }
         await this.assertSocketToolEnabled(args.deviceId, "clearKeyValueFile");
-        const client = await this.resolveKeyValueMutationClient(args.platform, args.deviceId);
+        const { client } = await this.resolveKeyValueMutationClient(args.platform, args.deviceId);
         await client.clearPreferenceStore(args.appId, args.fileName);
         return { success: true };
       }
@@ -1641,7 +1649,7 @@ export class UnixSocketServer {
   private async resolveKeyValueMutationClient(
     platformValue: string | undefined,
     deviceId: string,
-  ): Promise<KeyValueMutationClient> {
+  ): Promise<{ platform: "android" | "ios"; client: KeyValueMutationClient }> {
     const platform = platformValue ?? "android";
     if (platform !== "android" && platform !== "ios") {
       throw new Error(`Invalid platform: ${platform}. Must be 'android' or 'ios'.`);
@@ -1652,9 +1660,11 @@ export class UnixSocketServer {
     if (!targetDevice) {
       throw new Error(`Device not found: ${deviceId}`);
     }
-    return platform === "ios"
-      ? IOSCtrlProxyClient.getInstance(targetDevice)
-      : AndroidCtrlProxyClient.getInstance(targetDevice, defaultAdbClientFactory);
+    const client =
+      platform === "ios"
+        ? IOSCtrlProxyClient.getInstance(targetDevice)
+        : AndroidCtrlProxyClient.getInstance(targetDevice, defaultAdbClientFactory);
+    return { platform, client };
   }
 
   private async assertSocketToolEnabled(deviceId: string, toolName: string): Promise<void> {

--- a/src/server/storageTools.ts
+++ b/src/server/storageTools.ts
@@ -154,8 +154,12 @@ function buildEntriesUri(deviceId: string, packageName: string, fileName: string
 
 /**
  * Validate that the type is supported on the given platform. Throws ActionableError with guidance if not.
+ *
+ * Exported so the daemon `ide/*` socket key-value handlers can enforce the same
+ * cross-platform type guidance as the MCP-tool path, without duplicating the
+ * platform-specific type sets (issue #5022).
  */
-function validateTypeForPlatform(platform: string, type: KeyValueType): void {
+export function validateTypeForPlatform(platform: string, type: KeyValueType): void {
   if (type === "UNKNOWN") {
     throw new ActionableError(
       "UNKNOWN type is read-only and cannot be used for write operations. " +

--- a/test/daemon/socketServerKeyValue.test.ts
+++ b/test/daemon/socketServerKeyValue.test.ts
@@ -231,4 +231,57 @@ describe("UnixSocketServer key-value mutation platform routing (#4708)", () => {
     expect(response.success).toBe(false);
     expect(response.error).toContain("Invalid platform");
   });
+
+  // Cross-platform type guidance now enforced on the socket path, matching the
+  // MCP-tool path (issue #5022). Previously an incompatible type reached the
+  // CtrlProxy client and failed deeper with a less actionable message.
+
+  test("ide/setKeyValue rejects an Android-only type on an iOS device with actionable guidance", async () => {
+    const response = await sendRequest(socketPath, "ide/setKeyValue", {
+      platform: "ios",
+      deviceId: iosDevice.deviceId,
+      appId: "com.example.app",
+      fileName: "prefs",
+      key: "tags",
+      value: "a,b",
+      type: "STRING_SET",
+    });
+
+    expect(response.success).toBe(false);
+    expect(response.error).toContain("STRING_SET is Android-only");
+    expect(iosSetPreference).not.toHaveBeenCalled();
+  });
+
+  test("ide/setKeyValue rejects an iOS-only type on an Android device with actionable guidance", async () => {
+    const response = await sendRequest(socketPath, "ide/setKeyValue", {
+      deviceId: androidDevice.deviceId,
+      appId: "com.example.app",
+      fileName: "prefs",
+      key: "ratio",
+      value: "1.5",
+      type: "DOUBLE",
+    });
+
+    expect(response.success).toBe(false);
+    expect(response.error).toContain("DOUBLE is iOS-only");
+    expect(androidSetPreference).not.toHaveBeenCalled();
+  });
+
+  test("ide/setKeyValue with a null value skips type validation and removes on iOS", async () => {
+    // A null value is a remove, which the MCP path never type-validates; an
+    // Android-only type must not block a cross-platform clear.
+    const response = await sendRequest(socketPath, "ide/setKeyValue", {
+      platform: "ios",
+      deviceId: iosDevice.deviceId,
+      appId: "com.example.app",
+      fileName: "prefs",
+      key: "tags",
+      value: null,
+      type: "STRING_SET",
+    });
+
+    expect(response.success).toBe(true);
+    expect(iosRemovePreference).toHaveBeenCalledWith("com.example.app", "prefs", "tags");
+    expect(iosSetPreference).not.toHaveBeenCalled();
+  });
 });

--- a/test/server/storageTools.test.ts
+++ b/test/server/storageTools.test.ts
@@ -1,7 +1,8 @@
 import { afterEach, beforeEach, describe, expect, test } from "bun:test";
-import { registerStorageTools } from "../../src/server/storageTools";
+import { registerStorageTools, validateTypeForPlatform } from "../../src/server/storageTools";
 import { ToolRegistry } from "../../src/server/toolRegistry";
 import { serverConfig } from "../../src/utils/ServerConfig";
+import { ActionableError } from "../../src/models";
 
 describe("Storage Tools Registration", () => {
   beforeEach(() => {
@@ -240,6 +241,35 @@ describe("Storage Tools Registration", () => {
         platform: "android",
         appId: "com.example.app",
       })).toThrow();
+    });
+  });
+
+  // The setKeyValue MCP-tool handler runs args.type through validateTypeForPlatform
+  // before dispatch; the daemon `ide/setKeyValue` socket handler now reuses the same
+  // guard (issue #5022). These pin the shared guidance both paths depend on.
+  describe("validateTypeForPlatform (shared MCP + socket guard)", () => {
+    test("rejects an Android-only type on iOS with actionable guidance", () => {
+      expect(() => validateTypeForPlatform("ios", "STRING_SET")).toThrow(ActionableError);
+      expect(() => validateTypeForPlatform("ios", "STRING_SET")).toThrow(/STRING_SET is Android-only/);
+      expect(() => validateTypeForPlatform("ios", "LONG")).toThrow(/LONG is Android-only/);
+    });
+
+    test("rejects an iOS-only type on Android with actionable guidance", () => {
+      expect(() => validateTypeForPlatform("android", "DOUBLE")).toThrow(ActionableError);
+      expect(() => validateTypeForPlatform("android", "DOUBLE")).toThrow(/DOUBLE is iOS-only/);
+      expect(() => validateTypeForPlatform("android", "ARRAY")).toThrow(/ARRAY is iOS-only/);
+    });
+
+    test("rejects the read-only UNKNOWN type on either platform", () => {
+      expect(() => validateTypeForPlatform("android", "UNKNOWN")).toThrow(/UNKNOWN type is read-only/);
+      expect(() => validateTypeForPlatform("ios", "UNKNOWN")).toThrow(/UNKNOWN type is read-only/);
+    });
+
+    test("accepts a shared type on both platforms", () => {
+      expect(() => validateTypeForPlatform("android", "STRING")).not.toThrow();
+      expect(() => validateTypeForPlatform("ios", "STRING")).not.toThrow();
+      expect(() => validateTypeForPlatform("android", "STRING_SET")).not.toThrow();
+      expect(() => validateTypeForPlatform("ios", "DOUBLE")).not.toThrow();
     });
   });
 });


### PR DESCRIPTION
Closes #5022.

## Problem

The daemon socket key-value handler `ide/setKeyValue` (`src/daemon/socketServer.ts`) dispatched writes to the CtrlProxy client **without** validating the `type` against the resolved platform, unlike the MCP-tool path in `src/server/storageTools.ts` (`validateTypeForPlatform`). Since the desktop workspace Storage facet was enabled for iOS panes (#4708 / PR #5020), an iOS write with a platform-incompatible `type` (e.g. an Android-only `STRING_SET`) reached `IOSCtrlProxyClient.setPreference` through the socket path without the friendly cross-platform `ActionableError` guidance the MCP tool raises. The write still failed safely (no corruption) — it just failed deeper, with a less actionable message.

## Change

- **Export** `validateTypeForPlatform` from `storageTools.ts` and reuse it in the socket handler — the platform-specific type sets stay defined in one place (no duplication, per the issue's AC).
- `resolveKeyValueMutationClient` now returns the **resolved platform** alongside the client, so the handler validates against the exact platform it dispatches to (post the `?? "android"` back-compat default).
- Validate in `ide/setKeyValue` **before dispatch**, and only for non-null values — matching the MCP path exactly, where a `null` value is a remove that is never type-checked.

## Acceptance criteria

1. ✅ `ide/setKeyValue` validates `type` against the resolved platform before dispatch, raising the same actionable guidance as the MCP-tool path (reuses `validateTypeForPlatform`, does not duplicate the type sets).
2. ✅ Unit tests: an Android-only type on iOS and an iOS-only type on Android return the actionable guidance error — covered on both the **socket** path (`test/daemon/socketServerKeyValue.test.ts`) and the **shared guard** the MCP-tool path depends on (`test/server/storageTools.test.ts`). A null-value clear is shown to skip validation.

## Validation

- `bun test test/daemon/socketServerKeyValue.test.ts test/server/storageTools.test.ts` — 28 pass
- `bun run typecheck` — no new type errors
- `bun run lint` — oxlint ratchet: no new violations; boundary-checks: 13/13
- `bun run build` — success

Note: the daemon already imports from `../server/` (`toolRegistry`, broadcast helpers), so importing `validateTypeForPlatform` from `../server/storageTools` introduces no new layering; boundary checks pass.

🤖 Generated with [Claude Code](https://claude.com/claude-code) (autonomous next-best-issue run)