### PR TITLE
perf(android): store UIElementInfo children as a typed list, serialize once

### DIFF
--- a/android/control-proxy/src/main/kotlin/dev/jasonpearson/automobile/ctrlproxy/StructuralHasher.kt
+++ b/android/control-proxy/src/main/kotlin/dev/jasonpearson/automobile/ctrlproxy/StructuralHasher.kt
@@ -2,10 +2,6 @@ package dev.jasonpearson.automobile.ctrlproxy
 
 import dev.jasonpearson.automobile.ctrlproxy.models.UIElementInfo
 import dev.jasonpearson.automobile.ctrlproxy.models.ViewHierarchy
-import kotlinx.serialization.json.JsonArray
-import kotlinx.serialization.json.JsonElement
-import kotlinx.serialization.json.JsonObject
-import kotlinx.serialization.json.JsonPrimitive
 
 /**
  * Computes a structural hash of the view hierarchy that ignores bounds.
@@ -73,79 +69,11 @@ object StructuralHasher {
     // - accessible (z-index percentage may fluctuate)
     // - textSize/textColor (unlikely to change during animation, but not structural)
 
-    // Recursively hash children in node
-    element.node?.let { node -> hash = 31 * hash + computeNodeHash(node) }
+    // Recursively hash the typed children (issue #5471: no JSON decode needed).
+    for (child in element.children) {
+      hash = 31 * hash + computeElementHash(child)
+    }
 
     return hash
-  }
-
-  /** Compute hash for JsonElement children (can be array, object, or primitive). */
-  private fun computeNodeHash(node: JsonElement): Int {
-    return when (node) {
-      is JsonArray -> {
-        var hash = 17
-        node.forEach { child -> hash = 31 * hash + computeNodeHash(child) }
-        hash
-      }
-      is JsonObject -> computeJsonObjectHash(node)
-      is JsonPrimitive -> node.content.hashCode()
-    }
-  }
-
-  /**
-   * Compute hash for a JsonObject representing a UIElementInfo node. Mirrors computeElementHash but
-   * works with raw JSON.
-   */
-  private fun computeJsonObjectHash(obj: JsonObject): Int {
-    var hash = 17
-
-    // Text content fields
-    hash = 31 * hash + getJsonStringHash(obj, "text")
-    hash = 31 * hash + getJsonStringHash(obj, "content-desc")
-    hash = 31 * hash + getJsonStringHash(obj, "resource-id")
-    hash = 31 * hash + getJsonStringHash(obj, "className")
-    hash = 31 * hash + getJsonStringHash(obj, "hint-text")
-    hash = 31 * hash + getJsonStringHash(obj, "error-message")
-    hash = 31 * hash + getJsonStringHash(obj, "state-description")
-    hash = 31 * hash + getJsonStringHash(obj, "pane-title")
-    hash = 31 * hash + getJsonStringHash(obj, "test-tag")
-    hash = 31 * hash + getJsonStringHash(obj, "role")
-
-    // Boolean state flags
-    hash = 31 * hash + getJsonStringHash(obj, "clickable")
-    hash = 31 * hash + getJsonStringHash(obj, "focusable")
-    hash = 31 * hash + getJsonStringHash(obj, "scrollable")
-    hash = 31 * hash + getJsonStringHash(obj, "checkable")
-    hash = 31 * hash + getJsonStringHash(obj, "checked")
-    hash = 31 * hash + getJsonStringHash(obj, "selected")
-    hash = 31 * hash + getJsonStringHash(obj, "enabled")
-    hash = 31 * hash + getJsonStringHash(obj, "focused")
-    hash = 31 * hash + getJsonStringHash(obj, "long-clickable")
-    hash = 31 * hash + getJsonStringHash(obj, "password")
-
-    // Other semantic fields
-    hash = 31 * hash + getJsonStringHash(obj, "live-region")
-    hash = 31 * hash + getJsonStringHash(obj, "collection-info")
-    hash = 31 * hash + getJsonStringHash(obj, "collection-item-info")
-    hash = 31 * hash + getJsonStringHash(obj, "range-info")
-    hash = 31 * hash + getJsonStringHash(obj, "input-type")
-    hash = 31 * hash + getJsonStringHash(obj, "fragment")
-
-    // NOTE: Intentionally EXCLUDING "bounds"
-
-    // Recursively hash children
-    obj["node"]?.let { childNode -> hash = 31 * hash + computeNodeHash(childNode) }
-
-    return hash
-  }
-
-  /** Safely get hash of a string field from JsonObject. */
-  private fun getJsonStringHash(obj: JsonObject, key: String): Int {
-    val element = obj[key] ?: return 0
-    return if (element is JsonPrimitive) {
-      element.content.hashCode()
-    } else {
-      element.toString().hashCode()
-    }
   }
 }

--- a/android/control-proxy/src/main/kotlin/dev/jasonpearson/automobile/ctrlproxy/ViewHierarchyExtractor.kt
+++ b/android/control-proxy/src/main/kotlin/dev/jasonpearson/automobile/ctrlproxy/ViewHierarchyExtractor.kt
@@ -14,13 +14,6 @@ import dev.jasonpearson.automobile.ctrlproxy.models.ViewHierarchy
 import dev.jasonpearson.automobile.ctrlproxy.models.WindowInfo
 import kotlin.math.max
 import kotlin.math.min
-import kotlinx.serialization.builtins.ListSerializer
-import kotlinx.serialization.json.Json
-import kotlinx.serialization.json.JsonArray
-import kotlinx.serialization.json.JsonElement
-import kotlinx.serialization.json.JsonObject
-import kotlinx.serialization.json.jsonArray
-import kotlinx.serialization.serializer
 
 /**
  * Component responsible for parsing AccessibilityNodeInfo trees and converting them into
@@ -52,8 +45,6 @@ class ViewHierarchyExtractor(private val recompositionStore: RecompositionStore?
         "android.widget.TextView",
       )
   }
-
-  private val json = Json { ignoreUnknownKeys = true }
 
   /**
    * Extracts view hierarchy from the active window.
@@ -122,10 +113,7 @@ class ViewHierarchyExtractor(private val recompositionStore: RecompositionStore?
         detectNotificationPermissionDialog(it, rootNode.packageName?.toString())
       }
 
-      val unifiedHierarchy = processedElement?.let {
-        val nodeElement = encodeChildrenToNodeElement(listOf(it))
-        nodeElement?.let { root -> UIElementInfo(node = root) }
-      }
+      val unifiedHierarchy = processedElement?.let { UIElementInfo(children = listOf(it)) }
 
       // Find the accessibility-focused element in the unified hierarchy
       val accessibilityFocusedElement = unifiedHierarchy?.let {
@@ -134,10 +122,11 @@ class ViewHierarchyExtractor(private val recompositionStore: RecompositionStore?
 
       ViewHierarchy(
         packageName = rootNode.packageName?.toString(),
-        hierarchy = unifiedHierarchy,
+        hierarchy = unifiedHierarchy?.let { WireNodeCodec.materialize(it) },
         intentChooserDetected = intentChooserDetected,
         notificationPermissionDetected = notificationPermissionDetected,
-        accessibilityFocusedElement = accessibilityFocusedElement,
+        accessibilityFocusedElement =
+          accessibilityFocusedElement?.let { WireNodeCodec.materialize(it) },
         contentHiddenRegions = contentHiddenRegions?.takeIf { it.isNotEmpty() },
         truncationReasons = budget.truncationReasons().ifEmpty { null },
       )
@@ -423,8 +412,8 @@ class ViewHierarchyExtractor(private val recompositionStore: RecompositionStore?
       windowEntries
         .sortedWith(compareBy<WindowEntry> { it.windowLayer }.thenBy { it.windowId })
         .map { it.hierarchy }
-    val windowRootsElement = encodeChildrenToNodeElement(sortedWindowRoots)
-    val unifiedHierarchy = windowRootsElement?.let { UIElementInfo(node = it) }
+    val unifiedHierarchy =
+      if (sortedWindowRoots.isEmpty()) null else UIElementInfo(children = sortedWindowRoots)
 
     val accessibilityFocusedElement = unifiedHierarchy?.let { findAccessibilityFocusedElement(it) }
 
@@ -444,11 +433,12 @@ class ViewHierarchyExtractor(private val recompositionStore: RecompositionStore?
 
     return ViewHierarchy(
       packageName = mainPackageName,
-      hierarchy = unifiedHierarchy,
+      hierarchy = unifiedHierarchy?.let { WireNodeCodec.materialize(it) },
       windows = windowInfos.takeIf { it.isNotEmpty() },
       intentChooserDetected = intentChooserDetected,
       notificationPermissionDetected = notificationPermissionDetected,
-      accessibilityFocusedElement = accessibilityFocusedElement,
+      accessibilityFocusedElement =
+        accessibilityFocusedElement?.let { WireNodeCodec.materialize(it) },
       ctrlProxyIncomplete = if (ctrlProxyIncomplete) true else null,
       contentHiddenRegions = detectContentHiddenRegions(contentHiddenRegionRoots, screenDimensions),
       truncationReasons = budget.truncationReasons().ifEmpty { null },
@@ -493,7 +483,7 @@ class ViewHierarchyExtractor(private val recompositionStore: RecompositionStore?
 
     fun visit(node: UIElementInfo, isComposeDescendant: Boolean) {
       val nodeIsComposeView = node.className?.contains("ComposeView") == true
-      val children = extractChildrenFromNode(node.node)
+      val children = visibleChildren(node)
 
       if (isComposeDescendant && isLikelyComposeInteropHiddenBoundary(node, children, screenArea)) {
         val bounds = node.bounds ?: return
@@ -616,7 +606,7 @@ class ViewHierarchyExtractor(private val recompositionStore: RecompositionStore?
       return true
     }
 
-    for (child in extractChildrenFromNode(element.node)) {
+    for (child in visibleChildren(element)) {
       if (detectIntentChooserIndicators(child)) {
         return true
       }
@@ -659,7 +649,7 @@ class ViewHierarchyExtractor(private val recompositionStore: RecompositionStore?
         return
       }
 
-      for (child in extractChildrenFromNode(node.node)) {
+      for (child in visibleChildren(node)) {
         visit(child)
         if (hasNotificationText && hasPermissionButtons) {
           return
@@ -927,14 +917,6 @@ class ViewHierarchyExtractor(private val recompositionStore: RecompositionStore?
           }
       }
 
-      // Create the child node structure
-      val nodeElement =
-        when {
-          children.isEmpty() -> null
-          children.size == 1 -> json.encodeToJsonElement(serializer<UIElementInfo>(), children[0])
-          else -> json.encodeToJsonElement(ListSerializer(serializer<UIElementInfo>()), children)
-        }
-
       val className =
         if (node.className.isNullOrBlank() || GENERIC_CLASS_NAMES.contains(node.className)) {
           null
@@ -999,7 +981,7 @@ class ViewHierarchyExtractor(private val recompositionStore: RecompositionStore?
           checked = if (node.isChecked) "true" else null,
           selected = if (node.isSelected) "true" else null,
           longClickable = if (node.isLongClickable) "true" else null,
-          node = nodeElement,
+          children = children,
           stateDescription = stateDescription,
           testTag = testTag,
           uniqueId = apiGatedFields.uniqueId,
@@ -1060,8 +1042,7 @@ class ViewHierarchyExtractor(private val recompositionStore: RecompositionStore?
     }
 
     // Recursively check children
-    val children = extractChildrenFromNode(element.node)
-    for (child in children) {
+    for (child in element.children) {
       val focusedInChild = findAccessibilityFocusedElement(child)
       if (focusedInChild != null) {
         return focusedInChild
@@ -1071,45 +1052,15 @@ class ViewHierarchyExtractor(private val recompositionStore: RecompositionStore?
     return null
   }
 
-  /** Extract children from node JsonElement */
-  private fun extractChildrenFromNode(nodeElement: JsonElement?): List<UIElementInfo> {
-    if (nodeElement == null) return emptyList()
-
-    return try {
-      val children =
-        when {
-          nodeElement is JsonObject -> {
-            val child = json.decodeFromJsonElement(serializer<UIElementInfo>(), nodeElement)
-            listOf(child)
-          }
-
-          nodeElement is JsonArray -> {
-            nodeElement.jsonArray.mapNotNull { childJson ->
-              try {
-                json.decodeFromJsonElement(serializer<UIElementInfo>(), childJson)
-              } catch (e: Exception) {
-                null
-              }
-            }
-          }
-
-          else -> emptyList()
-        }
-
-      // Apply filter criteria to maintain consistency with extractNodeInfo behavior
-      children.filter { child ->
-        // If the child has its own children, keep it regardless of filter criteria
-        // Otherwise, apply the filter criteria
-        if (child.node != null) {
-          true
-        } else {
-          meetsFilterCriteria(child)
-        }
-      }
-    } catch (e: Exception) {
-      emptyList()
+  /**
+   * Typed children of [element], applying the same visibility filter the old JsonElement decoder
+   * did: keep a child if it has its own descendants, otherwise only if it meets filter criteria.
+   * Walks the in-memory [UIElementInfo.children] with zero (de)serialization (issue #5471).
+   */
+  internal fun visibleChildren(element: UIElementInfo): List<UIElementInfo> =
+    element.children.filter { child ->
+      child.children.isNotEmpty() || meetsFilterCriteria(child)
     }
-  }
 
   /**
    * Resolve the accessibility state description for a node.
@@ -1245,32 +1196,6 @@ class ViewHierarchyExtractor(private val recompositionStore: RecompositionStore?
       !element.paneTitle.isNullOrBlank()
   }
 
-  private fun decodeOptimizedChildren(nodeElement: JsonElement): List<UIElementInfo>? {
-    return when {
-      nodeElement is JsonObject -> {
-        try {
-          listOf(json.decodeFromJsonElement(serializer<UIElementInfo>(), nodeElement))
-        } catch (e: Exception) {
-          null
-        }
-      }
-      nodeElement is JsonArray -> {
-        val children = mutableListOf<UIElementInfo>()
-        for (childJson in nodeElement.jsonArray) {
-          val child =
-            try {
-              json.decodeFromJsonElement(serializer<UIElementInfo>(), childJson)
-            } catch (e: Exception) {
-              return null
-            }
-          children.add(child)
-        }
-        children
-      }
-      else -> null
-    }
-  }
-
   private fun wrapOptimizedElements(elements: List<UIElementInfo>): UIElementInfo? {
     if (elements.isEmpty()) {
       return null
@@ -1278,9 +1203,7 @@ class ViewHierarchyExtractor(private val recompositionStore: RecompositionStore?
     if (elements.size == 1) {
       return elements[0]
     }
-
-    val nodeElement = encodeChildrenToNodeElement(elements) ?: return null
-    return UIElementInfo(node = nodeElement)
+    return UIElementInfo(children = elements)
   }
 
   /**
@@ -1290,6 +1213,9 @@ class ViewHierarchyExtractor(private val recompositionStore: RecompositionStore?
    * 3. Preserving text-bearing children of interactive elements (e.g., Tab labels)
    *
    * This significantly reduces hierarchy size for complex UIs like YouTube.
+   *
+   * Walks the typed [UIElementInfo.children] list directly — no per-stage JSON decode/re-encode
+   * (issue #5471).
    */
   private fun optimizeHierarchy(element: UIElementInfo): List<UIElementInfo> {
     // Check if this element is a bounds-only wrapper (has no useful properties)
@@ -1304,37 +1230,14 @@ class ViewHierarchyExtractor(private val recompositionStore: RecompositionStore?
         element.selected == "true" ||
         element.longClickable == "true"
 
-    // Debug logging
-    val elementDesc = buildString {
-      append("text=${element.text?.take(20)}, ")
-      append("resId=${element.resourceId?.substringAfterLast('.')?.take(15)}, ")
-      append("clickable=${element.clickable}, focusable=${element.focusable}, ")
-      append("bounds=${element.bounds}, ")
-      append("hasNode=${element.node != null}")
-    }
-    Log.d(
-      TAG,
-      "[OPT] Element: $elementDesc, boundsOnly=$isBoundsOnlyWrapper, interactive=$isInteractive",
-    )
-
-    // Now recursively optimize children
-    val optimizedNode = element.node?.let { optimizeNode(it) }
+    // Recursively optimize children on the typed tree.
+    val optimizedChildren = element.children.flatMap { optimizeHierarchy(it) }
 
     // Only promote children (flatten hierarchy) if this is a bounds-only wrapper AND not
     // interactive
     if (isBoundsOnlyWrapper && !isInteractive) {
-      if (optimizedNode == null) {
-        Log.d(TAG, "[OPT] -> FILTER OUT (bounds-only, no children)")
-        return emptyList()
-      }
-
-      val optimizedChildren = decodeOptimizedChildren(optimizedNode)
-      if (optimizedChildren == null) {
-        Log.d(TAG, "[OPT] -> KEEP AS-IS (couldn't decode children)")
-        return listOf(element.copy(node = optimizedNode))
-      }
       if (optimizedChildren.isEmpty()) {
-        Log.d(TAG, "[OPT] -> FILTER OUT (bounds-only, empty children)")
+        Log.d(TAG, "[OPT] -> FILTER OUT (bounds-only, no children)")
         return emptyList()
       }
       Log.d(TAG, "[OPT] -> PROMOTE ${optimizedChildren.size} children")
@@ -1342,67 +1245,7 @@ class ViewHierarchyExtractor(private val recompositionStore: RecompositionStore?
     }
 
     Log.d(TAG, "[OPT] -> KEEP (meets criteria or interactive)")
-    return listOf(element.copy(node = optimizedNode))
-  }
-
-  /** Check if a node or its children have text content */
-  private fun hasTextInNode(nodeElement: JsonElement?): Boolean {
-    if (nodeElement == null) return false
-
-    return when (nodeElement) {
-      is JsonObject -> {
-        try {
-          val element = json.decodeFromJsonElement(serializer<UIElementInfo>(), nodeElement)
-          !element.text.isNullOrBlank() || hasTextInNode(element.node)
-        } catch (e: Exception) {
-          false
-        }
-      }
-      is JsonArray -> {
-        nodeElement.jsonArray.any { hasTextInNode(it) }
-      }
-      else -> false
-    }
-  }
-
-  /** Recursively optimize node children (handles both single element and array). */
-  private fun optimizeNode(nodeElement: JsonElement): JsonElement? {
-    fun optimizeChild(childJson: JsonElement): List<JsonElement> {
-      return try {
-        val child = json.decodeFromJsonElement(serializer<UIElementInfo>(), childJson)
-        val optimizedChildren = optimizeHierarchy(child)
-        optimizedChildren.map { json.encodeToJsonElement(serializer<UIElementInfo>(), it) }
-      } catch (e: Exception) {
-        listOf(childJson)
-      }
-    }
-
-    return when {
-      nodeElement is JsonObject -> {
-        val optimizedChildren = optimizeChild(nodeElement)
-        Log.d(TAG, "[OPT-NODE] JsonObject: 1 child -> ${optimizedChildren.size} optimized")
-        when {
-          optimizedChildren.isEmpty() -> null
-          optimizedChildren.size == 1 -> optimizedChildren[0]
-          else -> JsonArray(optimizedChildren)
-        }
-      }
-      nodeElement is JsonArray -> {
-        val inputCount = nodeElement.jsonArray.size
-        val optimizedChildren =
-          nodeElement.jsonArray.flatMap { childJson -> optimizeChild(childJson) }
-        Log.d(
-          TAG,
-          "[OPT-NODE] JsonArray: $inputCount children -> ${optimizedChildren.size} optimized",
-        )
-        when {
-          optimizedChildren.isEmpty() -> null
-          optimizedChildren.size == 1 -> optimizedChildren[0]
-          else -> JsonArray(optimizedChildren)
-        }
-      }
-      else -> nodeElement
-    }
+    return listOf(element.copy(children = optimizedChildren))
   }
 
   private data class WindowEntry(
@@ -1670,7 +1513,7 @@ class ViewHierarchyExtractor(private val recompositionStore: RecompositionStore?
   ): Int {
     val start = orderCounter.value++
     var end = start
-    val children = decodeChildrenFromNode(element.node)
+    val children = element.children
 
     for ((index, child) in children.withIndex()) {
       val childPath = if (path.isBlank()) index.toString() else "$path.$index"
@@ -1722,13 +1565,11 @@ class ViewHierarchyExtractor(private val recompositionStore: RecompositionStore?
       )
     }
 
-    val children = decodeChildrenFromNode(element.node)
-    val filteredChildren = children.mapIndexedNotNull { index, child ->
-      val childPath = if (path.isBlank()) index.toString() else "$path.$index"
-      filterOccludedHierarchy(child, occlusionInfo, windowKey, childPath, isRoot = false)
-    }
-
-    val filteredNodeElement = encodeChildrenToNodeElement(filteredChildren)
+    val filteredChildren =
+      element.children.mapIndexedNotNull { index, child ->
+        val childPath = if (path.isBlank()) index.toString() else "$path.$index"
+        filterOccludedHierarchy(child, occlusionInfo, windowKey, childPath, isRoot = false)
+      }
 
     if (occlusionState == "hidden" && !isRoot) {
       if (element.text == "Tap" || element.text == "Discover") {
@@ -1737,48 +1578,13 @@ class ViewHierarchyExtractor(private val recompositionStore: RecompositionStore?
       return null
     }
 
-    val nodeToUse = filteredNodeElement
-
     return element.copy(
       viewId = resolveViewIdForOcclusionNode(element, windowKey, path),
-      node = nodeToUse,
+      children = filteredChildren,
       occlusionState = occlusionState,
       occludedBy = info?.occludedBy,
       occludedByViewId = info?.occludedByViewId,
     )
-  }
-
-  private fun decodeChildrenFromNode(nodeElement: JsonElement?): List<UIElementInfo> {
-    if (nodeElement == null) return emptyList()
-
-    return try {
-      when {
-        nodeElement is JsonObject -> {
-          val child = json.decodeFromJsonElement(serializer<UIElementInfo>(), nodeElement)
-          listOf(child)
-        }
-        nodeElement is JsonArray -> {
-          nodeElement.jsonArray.mapNotNull { childJson ->
-            try {
-              json.decodeFromJsonElement(serializer<UIElementInfo>(), childJson)
-            } catch (e: Exception) {
-              null
-            }
-          }
-        }
-        else -> emptyList()
-      }
-    } catch (e: Exception) {
-      emptyList()
-    }
-  }
-
-  private fun encodeChildrenToNodeElement(children: List<UIElementInfo>): JsonElement? {
-    return when {
-      children.isEmpty() -> null
-      children.size == 1 -> json.encodeToJsonElement(serializer<UIElementInfo>(), children[0])
-      else -> json.encodeToJsonElement(ListSerializer(serializer<UIElementInfo>()), children)
-    }
   }
 
   private fun intersectBounds(bounds: ElementBounds, other: ElementBounds): ElementBounds? {

--- a/android/control-proxy/src/main/kotlin/dev/jasonpearson/automobile/ctrlproxy/WireNodeCodec.kt
+++ b/android/control-proxy/src/main/kotlin/dev/jasonpearson/automobile/ctrlproxy/WireNodeCodec.kt
@@ -1,0 +1,64 @@
+package dev.jasonpearson.automobile.ctrlproxy
+
+import dev.jasonpearson.automobile.ctrlproxy.models.UIElementInfo
+import kotlinx.serialization.json.Json
+import kotlinx.serialization.json.JsonArray
+import kotlinx.serialization.json.JsonElement
+import kotlinx.serialization.json.JsonObject
+import kotlinx.serialization.serializer
+
+/**
+ * Converts the typed in-memory hierarchy ([UIElementInfo.children]) into the serialized wire
+ * projection ([UIElementInfo.node]) exactly once, at the wire boundary (issue #5471).
+ *
+ * The extraction pipeline (optimize, all detectors, occlusion, focus search, hashing) walks the
+ * typed [UIElementInfo.children] list and never touches [UIElementInfo.node]. Only when a snapshot
+ * is about to be emitted does [materialize] run, building the whole `node` subtree in a single
+ * O(nodes) pass.
+ *
+ * ## Byte-compatibility contract
+ * The output must match the pre-refactor format exactly:
+ * - A `UIElementInfo` serialized *directly* as a `ViewHierarchy` field (`hierarchy`,
+ *   `accessibility-focused-element`) is emitted verbosely by the caller's `encodeDefaults = true`
+ *   Json (every null field present).
+ * - Everything nested under `node` is emitted *compactly* (null fields omitted), because the child
+ *   subtree is pre-built here with an `encodeDefaults = false` Json — mirroring the old
+ *   `encodeChildrenToNodeElement` behavior.
+ *
+ * [buildElementJson] encodes only a node's own scalar fields (children stripped) once per node and
+ * then splices in the already-built child JSON, so the whole tree costs O(nodes) rather than the
+ * O(nodes * depth) of repeatedly re-encoding whole subtrees.
+ */
+internal object WireNodeCodec {
+
+  // encodeDefaults defaults to false, so nested nodes omit null fields — the compact child form the
+  // wire has always used.
+  private val compactJson = Json { ignoreUnknownKeys = true }
+
+  private val elementSerializer = serializer<UIElementInfo>()
+
+  /**
+   * Returns a copy of [element] with [UIElementInfo.node] populated from its typed
+   * [UIElementInfo.children]. Only the top-level element needs this — the returned [node] already
+   * contains the entire nested subtree as JSON.
+   */
+  fun materialize(element: UIElementInfo): UIElementInfo =
+    element.copy(node = buildNodeJson(element.children))
+
+  /** Builds the `node` wire value for a child list: null (none), object (one), or array (many). */
+  fun buildNodeJson(children: List<UIElementInfo>): JsonElement? =
+    when {
+      children.isEmpty() -> null
+      children.size == 1 -> buildElementJson(children[0])
+      else -> JsonArray(children.map { buildElementJson(it) })
+    }
+
+  private fun buildElementJson(element: UIElementInfo): JsonObject {
+    // Encode this node's own fields only (compact, node absent because it is null here), then splice
+    // in the recursively-built child JSON under "node" so it stays the last key, matching the
+    // declaration-order emission the wire has always produced.
+    val scalars = compactJson.encodeToJsonElement(elementSerializer, element) as JsonObject
+    val childJson = buildNodeJson(element.children) ?: return scalars
+    return JsonObject(scalars + ("node" to childJson))
+  }
+}

--- a/android/control-proxy/src/main/kotlin/dev/jasonpearson/automobile/ctrlproxy/WireNodeCodec.kt
+++ b/android/control-proxy/src/main/kotlin/dev/jasonpearson/automobile/ctrlproxy/WireNodeCodec.kt
@@ -54,7 +54,8 @@ internal object WireNodeCodec {
     }
 
   private fun buildElementJson(element: UIElementInfo): JsonObject {
-    // Encode this node's own fields only (compact, node absent because it is null here), then splice
+    // Encode this node's own fields only (compact, node absent because it is null here), then
+    // splice
     // in the recursively-built child JSON under "node" so it stays the last key, matching the
     // declaration-order emission the wire has always produced.
     val scalars = compactJson.encodeToJsonElement(elementSerializer, element) as JsonObject

--- a/android/control-proxy/src/main/kotlin/dev/jasonpearson/automobile/ctrlproxy/models/UIElementInfo.kt
+++ b/android/control-proxy/src/main/kotlin/dev/jasonpearson/automobile/ctrlproxy/models/UIElementInfo.kt
@@ -2,6 +2,7 @@ package dev.jasonpearson.automobile.ctrlproxy.models
 
 import kotlinx.serialization.SerialName
 import kotlinx.serialization.Serializable
+import kotlinx.serialization.Transient
 import kotlinx.serialization.json.JsonElement
 
 /**
@@ -61,8 +62,18 @@ data class UIElementInfo(
   val occludedByViewId: String? = null, // Stable view-id of the occluding view
   val recomposition: RecompositionEntry? = null,
 
-  // Use JsonElement to allow flexible structure matching test expectations
+  // Wire projection of the child subtree (issue #5471). This is the ONLY serialized
+  // representation of children: `null` (leaf), a JSON object (single child), or a JSON array
+  // (multiple children), matching the format existing desktop/MCP/TS consumers parse.
+  //
+  // During extraction this stays null — the pipeline (optimize, detectors, occlusion, focus
+  // search, hashing) walks the typed [children] list below with zero (de)serialization. `node`
+  // is materialized from [children] exactly once, at the wire boundary (see WireNodeCodec).
   val node: JsonElement? = null,
+
+  // Typed, in-memory child list. Not serialized (see [node] for the wire form). Every intermediate
+  // extraction pass operates on this list so a snapshot never re-encodes/re-decodes subtrees.
+  @Transient val children: List<UIElementInfo> = emptyList(),
 ) {
   /** Helper properties for boolean checks (for backwards compatibility) */
   val isClickable: Boolean
@@ -97,12 +108,4 @@ data class UIElementInfo(
 
   val isLongClickable: Boolean
     get() = longClickable == "true"
-
-  /**
-   * Legacy children property for backwards compatibility Note: In the new format, children are
-   * stored in the 'node' property
-   */
-  @Deprecated("Use node property instead", ReplaceWith("emptyList()"))
-  val children: List<UIElementInfo>
-    get() = emptyList()
 }

--- a/android/control-proxy/src/test/kotlin/dev/jasonpearson/automobile/ctrlproxy/ViewHierarchyExtractorTest.kt
+++ b/android/control-proxy/src/test/kotlin/dev/jasonpearson/automobile/ctrlproxy/ViewHierarchyExtractorTest.kt
@@ -5,7 +5,6 @@ import android.view.accessibility.AccessibilityWindowInfo
 import dev.jasonpearson.automobile.ctrlproxy.models.ElementBounds
 import dev.jasonpearson.automobile.ctrlproxy.models.UIElementInfo
 import kotlinx.coroutines.test.runTest
-import kotlinx.serialization.builtins.ListSerializer
 import kotlinx.serialization.json.Json
 import org.junit.Assert.assertEquals
 import org.junit.Assert.assertFalse
@@ -80,10 +79,8 @@ class ViewHierarchyExtractorTest {
     val elementWithContent = UIElementInfo(text = "Some text", clickable = "false")
 
     val children = listOf(emptyElement, interactiveElement, elementWithContent)
-    val childrenJson =
-      json.encodeToJsonElement(ListSerializer(UIElementInfo.serializer()), children)
 
-    val rootElement = UIElementInfo(className = "android.widget.LinearLayout", node = childrenJson)
+    val rootElement = UIElementInfo(className = "android.widget.LinearLayout", children = children)
 
     // Extract children from filtered hierarchy
     val filteredChildren = extractor.extractChildrenFromHierarchy(rootElement)
@@ -174,8 +171,7 @@ class ViewHierarchyExtractorTest {
   @Test
   fun `detectIntentChooserIndicators returns true for text indicator`() {
     val child = UIElementInfo(text = "Choose an app")
-    val childJson = json.encodeToJsonElement(UIElementInfo.serializer(), child)
-    val root = UIElementInfo(className = "android.widget.LinearLayout", node = childJson)
+    val root = UIElementInfo(className = "android.widget.LinearLayout", children = listOf(child))
 
     assertTrue(extractor.detectIntentChooserIndicatorsForTest(root))
   }
@@ -184,8 +180,7 @@ class ViewHierarchyExtractorTest {
   fun `detectIntentChooserIndicators returns true for resource id indicator`() {
     val child =
       UIElementInfo(resourceId = "android:id/button_once", className = "android.widget.Button")
-    val childJson = json.encodeToJsonElement(UIElementInfo.serializer(), child)
-    val root = UIElementInfo(className = "android.widget.LinearLayout", node = childJson)
+    val root = UIElementInfo(className = "android.widget.LinearLayout", children = listOf(child))
 
     assertTrue(extractor.detectIntentChooserIndicatorsForTest(root))
   }
@@ -193,8 +188,7 @@ class ViewHierarchyExtractorTest {
   @Test
   fun `detectIntentChooserIndicators returns false when no indicators present`() {
     val child = UIElementInfo(text = "Normal content", className = "android.widget.TextView")
-    val childJson = json.encodeToJsonElement(UIElementInfo.serializer(), child)
-    val root = UIElementInfo(className = "android.widget.LinearLayout", node = childJson)
+    val root = UIElementInfo(className = "android.widget.LinearLayout", children = listOf(child))
 
     assertFalse(extractor.detectIntentChooserIndicatorsForTest(root))
   }
@@ -204,12 +198,11 @@ class ViewHierarchyExtractorTest {
     val title = UIElementInfo(text = "Allow Example to send notifications?")
     val allowButton =
       UIElementInfo(resourceId = "com.android.permissioncontroller:id/permission_allow_button")
-    val childrenJson =
-      json.encodeToJsonElement(
-        ListSerializer(UIElementInfo.serializer()),
-        listOf(title, allowButton),
+    val root =
+      UIElementInfo(
+        className = "android.widget.LinearLayout",
+        children = listOf(title, allowButton),
       )
-    val root = UIElementInfo(className = "android.widget.LinearLayout", node = childrenJson)
 
     assertTrue(
       extractor.detectNotificationPermissionDialogForTest(
@@ -224,12 +217,11 @@ class ViewHierarchyExtractorTest {
     val title = UIElementInfo(text = "Allow Example to send notifications?")
     val allowButton =
       UIElementInfo(resourceId = "com.android.permissioncontroller:id/permission_allow_button")
-    val childrenJson =
-      json.encodeToJsonElement(
-        ListSerializer(UIElementInfo.serializer()),
-        listOf(title, allowButton),
+    val root =
+      UIElementInfo(
+        className = "android.widget.LinearLayout",
+        children = listOf(title, allowButton),
       )
-    val root = UIElementInfo(className = "android.widget.LinearLayout", node = childrenJson)
 
     assertFalse(
       extractor.detectNotificationPermissionDialogForTest(
@@ -244,10 +236,8 @@ class ViewHierarchyExtractorTest {
     val plainElement = UIElementInfo()
 
     val children = listOf(plainElement)
-    val childrenJson =
-      json.encodeToJsonElement(ListSerializer(UIElementInfo.serializer()), children)
 
-    val rootElement = UIElementInfo(node = childrenJson)
+    val rootElement = UIElementInfo(children = children)
     val filteredChildren = extractor.extractChildrenFromHierarchy(rootElement)
 
     // Should keep all elements with semantic properties but not the plain element
@@ -278,10 +268,8 @@ class ViewHierarchyExtractorTest {
         elementWithActions,
         elementWithRange,
       )
-    val childrenJson =
-      json.encodeToJsonElement(ListSerializer(UIElementInfo.serializer()), children)
 
-    val rootElement = UIElementInfo(node = childrenJson)
+    val rootElement = UIElementInfo(children = children)
     val filteredChildren = extractor.extractChildrenFromHierarchy(rootElement)
 
     // Should keep all elements with semantic properties but not the plain element
@@ -406,8 +394,7 @@ class ViewHierarchyExtractorTest {
   @Test
   fun `visibility audit field does not filter otherwise retained nodes`() = runTest {
     val element = UIElementInfo(text = "Compose row", visibleToUser = false)
-    val node = json.encodeToJsonElement(UIElementInfo.serializer(), element)
-    val root = UIElementInfo(node = node)
+    val root = UIElementInfo(children = listOf(element))
 
     val retained = extractor.extractChildrenFromHierarchy(root)
 
@@ -1610,21 +1597,42 @@ class ViewHierarchyExtractorTest {
     return method.invoke(this, path) as String
   }
 
-  // Helper method to extract children from hierarchy (this would be made public in the actual
-  // extractor for testing)
+  // Helper method to read the visible typed children of a hierarchy node (issue #5471).
   private fun ViewHierarchyExtractor.extractChildrenFromHierarchy(
     element: UIElementInfo
+  ): List<UIElementInfo> = this.visibleChildren(element)
+
+  @Suppress("UNCHECKED_CAST")
+  private fun ViewHierarchyExtractor.optimizeHierarchyForTest(
+    element: UIElementInfo
   ): List<UIElementInfo> {
-    return this.javaClass
-      .getDeclaredMethod(
-        "extractChildrenFromNode",
-        kotlinx.serialization.json.JsonElement::class.java,
-      )
-      .let { method ->
-        method.isAccessible = true
-        @Suppress("UNCHECKED_CAST")
-        method.invoke(this, element.node) as List<UIElementInfo>
-      }
+    val method = this.javaClass.getDeclaredMethod("optimizeHierarchy", UIElementInfo::class.java)
+    method.isAccessible = true
+    return method.invoke(this, element) as List<UIElementInfo>
+  }
+
+  // Issue #5471: the optimize pass walks typed children and performs ZERO serialization, so every
+  // element it returns still has a null `node` (the wire projection is built only at the boundary).
+  @Test
+  fun `optimize pass performs no intermediate serialization`() {
+    val leaf = UIElementInfo(text = "leaf", clickable = "true")
+    val interactiveParent = UIElementInfo(text = "row", clickable = "true", children = listOf(leaf))
+    val boundsOnlyWrapper =
+      UIElementInfo(bounds = ElementBounds(0, 0, 100, 100), children = listOf(interactiveParent))
+
+    val optimized = extractor.optimizeHierarchyForTest(boundsOnlyWrapper)
+
+    fun assertNoNode(element: UIElementInfo) {
+      assertNull("pipeline must not materialize node before the wire boundary", element.node)
+      element.children.forEach(::assertNoNode)
+    }
+    optimized.forEach(::assertNoNode)
+
+    // The bounds-only wrapper is promoted away; its interactive child (with its typed leaf)
+    // remains.
+    assertEquals(1, optimized.size)
+    assertEquals("row", optimized.single().text)
+    assertEquals("leaf", optimized.single().children.single().text)
   }
 
   private fun elementWithBounds(
@@ -1637,12 +1645,6 @@ class ViewHierarchyExtractorTest {
     actions: List<String>? = null,
     children: List<UIElementInfo> = emptyList(),
   ): UIElementInfo {
-    val node =
-      when {
-        children.isEmpty() -> null
-        children.size == 1 -> json.encodeToJsonElement(UIElementInfo.serializer(), children[0])
-        else -> json.encodeToJsonElement(ListSerializer(UIElementInfo.serializer()), children)
-      }
     return UIElementInfo(
       resourceId = resourceId,
       viewId = viewId,
@@ -1651,7 +1653,7 @@ class ViewHierarchyExtractorTest {
       text = text,
       contentDesc = contentDesc,
       actions = actions,
-      node = node,
+      children = children,
     )
   }
 
@@ -1679,7 +1681,7 @@ class ViewHierarchyExtractorTest {
     if (element.resourceId == resourceId) {
       return element
     }
-    for (child in extractor.extractChildrenFromHierarchy(element)) {
+    for (child in element.children) {
       val found = findElementByResourceId(child, resourceId)
       if (found != null) {
         return found

--- a/android/control-proxy/src/test/kotlin/dev/jasonpearson/automobile/ctrlproxy/WireNodeCodecTest.kt
+++ b/android/control-proxy/src/test/kotlin/dev/jasonpearson/automobile/ctrlproxy/WireNodeCodecTest.kt
@@ -1,0 +1,112 @@
+package dev.jasonpearson.automobile.ctrlproxy
+
+import dev.jasonpearson.automobile.ctrlproxy.models.ElementBounds
+import dev.jasonpearson.automobile.ctrlproxy.models.UIElementInfo
+import dev.jasonpearson.automobile.ctrlproxy.models.ViewHierarchy
+import kotlinx.serialization.json.Json
+import org.junit.Assert.assertEquals
+import org.junit.Assert.assertNull
+import org.junit.Assert.assertTrue
+import org.junit.Test
+import org.junit.runner.RunWith
+import org.robolectric.RobolectricTestRunner
+
+/**
+ * Wire-compatibility guard for issue #5471.
+ *
+ * `UIElementInfo` moved children from a serialized `JsonElement` subtree to a typed in-memory
+ * [UIElementInfo.children] list, with the wire `node` projection produced once at the boundary by
+ * [WireNodeCodec]. This test proves the emitted JSON is byte-for-byte identical to the pre-refactor
+ * format. [WIRE_GOLDEN] was captured from the base commit (before this change) by serializing the
+ * exact same logical tree with the production `jsonCompact` config.
+ */
+@RunWith(RobolectricTestRunner::class)
+class WireNodeCodecTest {
+
+  // Mirrors CtrlProxy.jsonCompact — the config used to serialize hierarchy frames onto the wire.
+  private val jsonCompact = Json {
+    prettyPrint = false
+    encodeDefaults = true
+  }
+
+  private fun grandchild() =
+    UIElementInfo(
+      text = "Grandchild",
+      resourceId = "com.example:id/gc",
+      viewId = "com.example:id/gc",
+      className = "android.widget.TextView",
+      bounds = ElementBounds(0, 0, 10, 10),
+      clickable = "true",
+      actions = listOf("click", "focus"),
+      extras = mapOf("k" to "v"),
+    )
+
+  private fun childA() =
+    UIElementInfo(
+      text = "ChildA",
+      bounds = ElementBounds(0, 0, 20, 20),
+      children = listOf(grandchild()),
+    )
+
+  private fun childB() =
+    UIElementInfo(
+      contentDesc = "ChildB",
+      bounds = ElementBounds(0, 20, 20, 40),
+      collectionRowIndex = 2,
+      collectionColumnIndex = 1,
+      visibleToUser = false,
+    )
+
+  private fun root() =
+    UIElementInfo(
+      className = "android.widget.FrameLayout",
+      bounds = ElementBounds(0, 0, 20, 40),
+      children = listOf(childA(), childB()),
+    )
+
+  private fun representativeHierarchy(): ViewHierarchy =
+    ViewHierarchy(
+      updatedAt = 123L,
+      packageName = "com.example.app",
+      // Synthetic root wrapper, exactly as the extractor builds it before materializing.
+      hierarchy = WireNodeCodec.materialize(UIElementInfo(children = listOf(root()))),
+    )
+
+  @Test
+  fun `serialized wire JSON is byte-identical to the pre-refactor format`() {
+    val wire = jsonCompact.encodeToString(ViewHierarchy.serializer(), representativeHierarchy())
+    assertEquals(WIRE_GOLDEN, wire)
+  }
+
+  @Test
+  fun `single child materializes as an object and multiple as an array`() {
+    val singleChildNode = WireNodeCodec.buildNodeJson(listOf(childB()))
+    assertTrue(
+      "single child must serialize as an object",
+      singleChildNode.toString().startsWith("{"),
+    )
+
+    val multiChildNode = WireNodeCodec.buildNodeJson(listOf(childA(), childB()))
+    assertTrue(
+      "multiple children must serialize as an array",
+      multiChildNode.toString().startsWith("["),
+    )
+
+    assertNull("no children must serialize as null node", WireNodeCodec.buildNodeJson(emptyList()))
+  }
+
+  @Test
+  fun `nested nodes omit null fields while the top wrapper stays verbose`() {
+    val wire = jsonCompact.encodeToString(ViewHierarchy.serializer(), representativeHierarchy())
+    // Verbose top wrapper carries explicit nulls.
+    assertTrue(wire.contains(""""hierarchy":{"text":null"""))
+    // Nested child under `node` is compact — no null keys (e.g. ChildB never emits "text":null).
+    assertTrue(wire.contains(""""content-desc":"ChildB","bounds""""))
+  }
+
+  companion object {
+    // Captured on the base commit (pre-#5471) from the production jsonCompact serializer.
+    private const val WIRE_GOLDEN =
+      """{"updatedAt":123,"packageName":"com.example.app","hierarchy":{"text":null,"textSize":null,"text-color":null,"content-desc":null,"resource-id":null,"view-id":null,"className":null,"bounds":null,"clickable":null,"enabled":null,"focusable":null,"focused":null,"accessibility-focused":null,"scrollable":null,"password":null,"checkable":null,"checked":null,"selected":null,"long-clickable":null,"fragment":null,"test-tag":null,"unique-id":null,"visible-to-user":null,"container-title":null,"role":null,"state-description":null,"error-message":null,"hint-text":null,"tooltip-text":null,"pane-title":null,"live-region":null,"collection-info":null,"collection-item-info":null,"collection-row-index":null,"collection-column-index":null,"range-info":null,"input-type":null,"actions":null,"extras":null,"occlusionState":null,"occludedBy":null,"occludedByViewId":null,"recomposition":null,"node":{"className":"android.widget.FrameLayout","bounds":{"left":0,"top":0,"right":20,"bottom":40},"node":[{"text":"ChildA","bounds":{"left":0,"top":0,"right":20,"bottom":20},"node":{"text":"Grandchild","resource-id":"com.example:id/gc","view-id":"com.example:id/gc","className":"android.widget.TextView","bounds":{"left":0,"top":0,"right":10,"bottom":10},"clickable":"true","actions":["click","focus"],"extras":{"k":"v"}}},{"content-desc":"ChildB","bounds":{"left":0,"top":20,"right":20,"bottom":40},"visible-to-user":false,"collection-row-index":2,"collection-column-index":1}]}},"windowInfo":null,"windows":null,"contentHiddenRegions":null,"intentChooserDetected":null,"notificationPermissionDetected":null,"accessibility-focused-element":null,"ctrlProxyIncomplete":null,"error":null,"screenWidth":null,"screenHeight":null,"rotation":null,"systemInsets":null,"insets":null,"wakefulness":null,"foregroundActivity":null,"density":null,"sdkInt":null,"deviceModel":null,"isEmulator":null,"nativeScale":null,"pixelWidth":null,"pixelHeight":null,"truncationReasons":null}"""
+  }
+}


### PR DESCRIPTION
## Summary

`UIElementInfo.node` stored child elements as a serialized `JsonElement` subtree, so the extraction pipeline decoded → recursed → re-encoded the whole tree at roughly every stage (optimize, all detectors, occlusion, focus search, hashing) — ~8–12 full serialize/deserialize passes per snapshot, scaling O(nodes·depth).

This moves children to a **typed in-memory representation** — a `@Transient List<UIElementInfo>` on `UIElementInfo` — that every intermediate pass walks as plain objects with **zero (de)serialization**. The wire `node` projection is produced **exactly once**, at the boundary, by the new `WireNodeCodec.materialize()` in a single O(nodes) pass.

## The wire format is byte-for-byte identical

The `UIElementInfo` serializer is **unchanged**: `node: JsonElement?` remains the only serialized child representation. During extraction it stays `null` (the pipeline uses the typed `children`); it is materialized from `children` only when a snapshot is emitted. This preserves the exact pre-refactor shape — including the format's verbose-top / compact-nested asymmetry (a `UIElementInfo` serialized directly as a `ViewHierarchy` field is emitted verbosely by the `encodeDefaults = true` `jsonCompact`, while everything nested under `node` is compact) — and every `@SerialName`.

`WireNodeCodec.buildElementJson` encodes each node's own scalar fields once (children stripped) and splices in the already-built child JSON under `node` (kept last), so the whole tree costs O(nodes) instead of O(nodes·depth).

### Readers of the wire shape verified against
- **`android/desktop-core` `HierarchyParser.kt`** (its own `UIElementInfo` model parses the `node` object/array shape) — `:desktop-core:test` green, unchanged.
- **TS consumers** in `src/features/observe/android/CtrlProxyHierarchy.ts`, `CtrlProxyFocus.ts`, `StableNodeIdentity.ts` and `src/features/observe/ViewHierarchy.ts` — read `node` as object/array; not touched (no wire change).
- **`StructuralHasher`** (in-module) — now hashes the typed `children` directly (internal frame-to-frame hash only, never on the wire).
- No other Android module imports control-proxy's `UIElementInfo` (desktop-core has its own model; coupling is wire-JSON only).

### Golden-test evidence (byte-identical)
`WireNodeCodecTest.serialized wire JSON is byte-identical to the pre-refactor format` asserts a representative tree (leaf, single-child object, multi-child array, nested subtree) serializes to a `WIRE_GOLDEN` literal **captured on the base commit** from the production `jsonCompact` serializer. It passes, proving the emitted JSON is unchanged.

### Single-serialization proof
`ViewHierarchyExtractorTest.optimize pass performs no intermediate serialization` runs `optimizeHierarchy` and asserts every returned element still has `node == null` — i.e. the pipeline never materializes JSON; the wire projection is built only at the boundary. `WireNodeCodecTest` further asserts single-child → object, multi-child → array, no children → null `node`.

## Before / after cost

Per snapshot of a tree with **n** nodes and depth **d**:

| | Serialize/deserialize work |
|---|---|
| Before | ~8–12 passes, each O(n·d) (build bottom-up + optimize decode/re-encode + each detector decode + occlusion decode/re-encode + final wrap) |
| After | **1** materialization at the wire boundary, O(n); every pipeline stage walks typed objects (0 encode/decode) |

Net source change: **−363 / +102** lines in the touched logic (deleted `extractChildrenFromNode`, `decodeChildrenFromNode`, `encodeChildrenToNodeElement`, `decodeOptimizedChildren`, `optimizeNode`, `hasTextInNode`, the `StructuralHasher` JSON-walk, and the deprecated `children` shim).

## Tests
- `:control-proxy:testDebugUnitTest` — **504 tests, 0 failures** (incl. all occlusion, content-hidden-region, detector, and the new golden + single-serialization tests).
- `:desktop-core:test` — green (wire parser unaffected).
- ktfmt applied to touched files.

## Files touched
- `models/UIElementInfo.kt` — typed `@Transient children`; `node` documented as write-once wire projection; deprecated `children` shim removed.
- `WireNodeCodec.kt` (new) — single O(n) wire materialization.
- `ViewHierarchyExtractor.kt` — pipeline rewritten to walk typed children.
- `StructuralHasher.kt` — hashes typed children.
- `WireNodeCodecTest.kt` (new) — golden byte-identity + shape tests.
- `ViewHierarchyExtractorTest.kt` — migrated `node =` constructions to `children =`; added single-serialization proof.

Closes #5471
