### PR TITLE
test(desktop-core): FakeObservationStream fidelity — reset clears replay, request guarded (#4810)

### DIFF
--- a/android/desktop-core/src/main/kotlin/dev/jasonpearson/automobile/desktop/core/daemon/FakeObservationStream.kt
+++ b/android/desktop-core/src/main/kotlin/dev/jasonpearson/automobile/desktop/core/daemon/FakeObservationStream.kt
@@ -1,6 +1,7 @@
 package dev.jasonpearson.automobile.desktop.core.daemon
 
 import dev.jasonpearson.automobile.desktop.core.connection.ConnectionState
+import dev.jasonpearson.automobile.desktop.core.connection.isConnected
 import kotlinx.coroutines.channels.BufferOverflow
 import kotlinx.coroutines.flow.MutableSharedFlow
 import kotlinx.coroutines.flow.MutableStateFlow
@@ -45,8 +46,6 @@ class FakeObservationStream(private val failConnect: Boolean = false) : Observat
   private val _connectionState = MutableStateFlow<ConnectionState>(ConnectionState.Disconnected())
   override val connectionState: StateFlow<ConnectionState> = _connectionState.asStateFlow()
 
-  private var connected = false
-
   var connectCallCount = 0
     private set
 
@@ -72,11 +71,9 @@ class FakeObservationStream(private val failConnect: Boolean = false) : Observat
     connectCallCount++
     lastConnectedDeviceId = deviceId
     if (failConnect) {
-      connected = false
       _connectionState.value = ConnectionState.Disconnected("Socket not found")
       return
     }
-    connected = true
     _connectionState.value = ConnectionState.Connected()
   }
 
@@ -87,11 +84,12 @@ class FakeObservationStream(private val failConnect: Boolean = false) : Observat
 
   override fun disconnect() {
     disconnectCallCount++
-    connected = false
     _connectionState.value = ConnectionState.Disconnected()
   }
 
-  override fun isConnected(): Boolean = connected
+  // Derive from the published state (like the real client) so a mid-session drop injected via
+  // [emitConnectionState] is reflected here and by the [requestNavigationGraph] guard.
+  override fun isConnected(): Boolean = _connectionState.value.isConnected
 
   override fun dispose() {
     disconnect()
@@ -108,9 +106,10 @@ class FakeObservationStream(private val failConnect: Boolean = false) : Observat
   }
 
   override fun requestNavigationGraph(appId: String?) {
-    // The real ObservationStreamClient no-ops unless connected; guard the fake likewise so a
+    // The real ObservationStreamClient no-ops unless connected; gate on the published state (not a
+    // separate flag) so a mid-session drop injected via emitConnectionState is honored too, and a
     // disconnected test cannot get a false positive that a graph was requested.
-    if (!connected) return
+    if (!_connectionState.value.isConnected) return
     navigationRequestCount++
     lastNavigationAppId = appId
   }

--- a/android/desktop-core/src/main/kotlin/dev/jasonpearson/automobile/desktop/core/daemon/FakeObservationStream.kt
+++ b/android/desktop-core/src/main/kotlin/dev/jasonpearson/automobile/desktop/core/daemon/FakeObservationStream.kt
@@ -99,9 +99,18 @@ class FakeObservationStream(private val failConnect: Boolean = false) : Observat
 
   override fun setCadence(screenshotIntervalMs: Long?, hierarchyIntervalMs: Long?) = Unit
 
-  override fun resetLayoutReplayCache() = Unit
+  // Mirror the real client: drop the buffered layout replay so a resubscribing collector does not
+  // immediately receive the last pre-reset screenshot/hierarchy frame (issue #3347).
+  @OptIn(kotlinx.coroutines.ExperimentalCoroutinesApi::class)
+  override fun resetLayoutReplayCache() {
+    _screenshotUpdates.resetReplayCache()
+    _hierarchyUpdates.resetReplayCache()
+  }
 
   override fun requestNavigationGraph(appId: String?) {
+    // The real ObservationStreamClient no-ops unless connected; guard the fake likewise so a
+    // disconnected test cannot get a false positive that a graph was requested.
+    if (!connected) return
     navigationRequestCount++
     lastNavigationAppId = appId
   }

--- a/android/desktop-core/src/test/kotlin/dev/jasonpearson/automobile/desktop/core/daemon/FakeObservationStreamTest.kt
+++ b/android/desktop-core/src/test/kotlin/dev/jasonpearson/automobile/desktop/core/daemon/FakeObservationStreamTest.kt
@@ -1,5 +1,6 @@
 package dev.jasonpearson.automobile.desktop.core.daemon
 
+import dev.jasonpearson.automobile.desktop.core.connection.ConnectionState
 import org.junit.Assert.assertEquals
 import org.junit.Assert.assertFalse
 import org.junit.Assert.assertNull
@@ -38,6 +39,21 @@ class FakeObservationStreamTest {
     // Mirrors the real ObservationStreamClient, which returns early unless connected. Without this
     // guard a disconnected test could get a false positive that a graph was requested.
     val stream = FakeObservationStream()
+    assertFalse(stream.isConnected())
+
+    stream.requestNavigationGraph("com.example.app")
+
+    assertEquals(0, stream.navigationRequestCount)
+    assertNull(stream.lastNavigationAppId)
+  }
+
+  @Test
+  fun `requestNavigationGraph is a no-op after a mid-session drop`() {
+    // A drop injected via emitConnectionState must suppress requests just like the real client,
+    // which gates on the published connection state (issue #4810 / Codex review of PR #5520).
+    val stream = FakeObservationStream()
+    stream.connect("dev-1")
+    stream.emitConnectionState(ConnectionState.Disconnected("Stream ended"))
     assertFalse(stream.isConnected())
 
     stream.requestNavigationGraph("com.example.app")

--- a/android/desktop-core/src/test/kotlin/dev/jasonpearson/automobile/desktop/core/daemon/FakeObservationStreamTest.kt
+++ b/android/desktop-core/src/test/kotlin/dev/jasonpearson/automobile/desktop/core/daemon/FakeObservationStreamTest.kt
@@ -2,6 +2,7 @@ package dev.jasonpearson.automobile.desktop.core.daemon
 
 import org.junit.Assert.assertEquals
 import org.junit.Assert.assertFalse
+import org.junit.Assert.assertNull
 import org.junit.Assert.assertTrue
 import org.junit.Test
 
@@ -23,10 +24,52 @@ class FakeObservationStreamTest {
   }
 
   @Test
-  fun `requestNavigationGraph records the appId and count`() {
+  fun `requestNavigationGraph records the appId and count when connected`() {
     val stream = FakeObservationStream()
+    stream.connect("dev-1")
+
     stream.requestNavigationGraph("com.example.app")
     assertEquals(1, stream.navigationRequestCount)
     assertEquals("com.example.app", stream.lastNavigationAppId)
+  }
+
+  @Test
+  fun `requestNavigationGraph is a no-op while disconnected`() {
+    // Mirrors the real ObservationStreamClient, which returns early unless connected. Without this
+    // guard a disconnected test could get a false positive that a graph was requested.
+    val stream = FakeObservationStream()
+    assertFalse(stream.isConnected())
+
+    stream.requestNavigationGraph("com.example.app")
+
+    assertEquals(0, stream.navigationRequestCount)
+    assertNull(stream.lastNavigationAppId)
+  }
+
+  @Test
+  fun `resetLayoutReplayCache clears the replayed screenshot and hierarchy frames`() {
+    // Mirrors the real client, which drops the buffered layout replay so a resubscribing collector
+    // does not immediately receive the last pre-reset frame.
+    val stream = FakeObservationStream()
+    stream.connect("dev-1")
+
+    stream.emitScreenshot(
+      ScreenshotStreamUpdate(
+        deviceId = "dev-1",
+        timestamp = 1L,
+        screenshotBase64 = "abc",
+        screenWidth = 1080,
+        screenHeight = 2340,
+      )
+    )
+    stream.emitHierarchy(HierarchyStreamUpdate(deviceId = "dev-1", timestamp = 1L, data = null))
+
+    assertTrue(stream.screenshotUpdates.replayCache.isNotEmpty())
+    assertTrue(stream.hierarchyUpdates.replayCache.isNotEmpty())
+
+    stream.resetLayoutReplayCache()
+
+    assertTrue(stream.screenshotUpdates.replayCache.isEmpty())
+    assertTrue(stream.hierarchyUpdates.replayCache.isEmpty())
   }
 }


### PR DESCRIPTION
## Summary

Closes [#4810](https://github.com/kaeawc/auto-mobile/issues/4810).

Two fidelity gaps in `FakeObservationStream` diverged from the real `ObservationStreamClient`, letting UI tests pass on behavior the production client does not exhibit:

1. **`resetLayoutReplayCache()` was a no-op.** The real client clears the buffered `replay = 1` layout state (screenshot + hierarchy) so a resubscribing collector does not immediately replay the last pre-reset frame (issue #3347). The fake now calls `resetReplayCache()` on both `_screenshotUpdates` and `_hierarchyUpdates`, so a test relying on reset sees cleared state.

2. **`requestNavigationGraph()` recorded the call even while disconnected.** The real `ObservationStreamClient.requestNavigationGraph` returns early unless connected. The fake now guards on `connected` before incrementing, so a disconnected test can't get a false positive that a graph was requested.

Both are P2 fidelity gaps raised in review of [#4781](https://github.com/kaeawc/auto-mobile/pull/4781); they don't affect current facet tests (which connect before requesting and don't use reset).

## Tests

`FakeObservationStreamTest`:
- Updated the existing `requestNavigationGraph` test to connect first (records count when connected).
- Added `requestNavigationGraph is a no-op while disconnected` (count stays 0, appId stays null).
- Added `resetLayoutReplayCache clears the replayed screenshot and hierarchy frames` (replay caches non-empty after emit, empty after reset).

## Validation

- `./gradlew :desktop-core:test --tests "*FakeObservationStreamTest"` — pass.
- Full `:desktop-core:test` — the only failure was `LogsPanelTest > reaching the bottom re-arms follow intent`, an unrelated Compose UI flake that passes in isolation and does not touch this change.
- ktfmt applied to touched files (no changes needed).