### PR TITLE
fix(desktop): evict per-device nav screenshot loader when a device leaves the workspace (#5087)

### DIFF
--- a/android/desktop-core/src/main/kotlin/dev/jasonpearson/automobile/desktop/core/navigation/NavigationScreenshotLoader.kt
+++ b/android/desktop-core/src/main/kotlin/dev/jasonpearson/automobile/desktop/core/navigation/NavigationScreenshotLoader.kt
@@ -84,6 +84,16 @@ class NavigationScreenshotLoaderRegistry {
 
   /** The loader already created for [deviceId], or null if none — lets a test assert wiring. */
   internal fun peek(deviceId: String): NavigationScreenshotLoader? = byDevice[deviceId]
+
+  /**
+   * Release the loader (and its LRU thumbnail cache) held for [deviceId], called when the device
+   * leaves the workspace entirely. Without this, every distinct deviceId ever shown a Navigation
+   * facet would retain its loader — up to 100MB of decoded thumbnails each — for the whole app
+   * session (#5087). A no-op if no loader exists for [deviceId].
+   */
+  fun forget(deviceId: String) {
+    byDevice.remove(deviceId)?.clearCache()
+  }
 }
 
 /**

--- a/android/desktop-core/src/main/kotlin/dev/jasonpearson/automobile/desktop/core/workspace/WorkspaceViewModel.kt
+++ b/android/desktop-core/src/main/kotlin/dev/jasonpearson/automobile/desktop/core/workspace/WorkspaceViewModel.kt
@@ -1,6 +1,8 @@
 package dev.jasonpearson.automobile.desktop.core.workspace
 
 import dev.jasonpearson.automobile.desktop.core.logging.LoggerFactory
+import dev.jasonpearson.automobile.desktop.core.navigation.DefaultNavigationScreenshotLoaderRegistry
+import dev.jasonpearson.automobile.desktop.core.navigation.NavigationScreenshotLoaderRegistry
 import kotlinx.coroutines.CancellationException
 import kotlinx.coroutines.CoroutineScope
 import kotlinx.coroutines.Job
@@ -77,6 +79,8 @@ sealed interface WorkspaceEffect {
 class WorkspaceViewModel(
   private val scope: CoroutineScope,
   private val controlExecutor: EmulatorControlExecutor = NoOpEmulatorControlExecutor,
+  private val screenshotLoaderRegistry: NavigationScreenshotLoaderRegistry =
+    DefaultNavigationScreenshotLoaderRegistry,
 ) {
   private val _state = MutableStateFlow<WorkspaceUiState>(WorkspaceUiState.Empty)
   val state: StateFlow<WorkspaceUiState> = _state.asStateFlow()
@@ -182,6 +186,10 @@ class WorkspaceViewModel(
   }
 
   private fun close(deviceId: String) {
+    // The device is leaving the workspace: release its navigation screenshot loader so the
+    // session-scoped registry doesn't retain a per-device thumbnail cache for every device ever
+    // shown (#5087).
+    screenshotLoaderRegistry.forget(deviceId)
     _state.update { current ->
       val content = current as? WorkspaceUiState.Content ?: return@update current
       val remaining = content.columns.filterNot { it.deviceId == deviceId }

--- a/android/desktop-core/src/test/kotlin/dev/jasonpearson/automobile/desktop/core/navigation/NavigationScreenshotLoaderRegistryTest.kt
+++ b/android/desktop-core/src/test/kotlin/dev/jasonpearson/automobile/desktop/core/navigation/NavigationScreenshotLoaderRegistryTest.kt
@@ -2,7 +2,9 @@ package dev.jasonpearson.automobile.desktop.core.navigation
 
 import dev.jasonpearson.automobile.desktop.core.daemon.AutoMobileClient
 import dev.jasonpearson.automobile.desktop.core.testing.FakeAutoMobileClient
+import org.junit.Assert.assertNotNull
 import org.junit.Assert.assertNotSame
+import org.junit.Assert.assertNull
 import org.junit.Assert.assertSame
 import org.junit.Test
 
@@ -24,5 +26,45 @@ class NavigationScreenshotLoaderRegistryTest {
     val a = registry.forDevice("dev-1", clientProvider)
     val b = registry.forDevice("dev-2", clientProvider)
     assertNotSame("distinct devices must not share a loader", a, b)
+  }
+
+  @Test
+  fun `forget releases a device's loader so its cache is not retained`() {
+    val registry = NavigationScreenshotLoaderRegistry()
+    registry.forDevice("dev-1", clientProvider)
+    assertNotNull("loader should exist before forget", registry.peek("dev-1"))
+
+    registry.forget("dev-1")
+
+    assertNull("forget must release the device's loader", registry.peek("dev-1"))
+  }
+
+  @Test
+  fun `forget only affects the named device`() {
+    val registry = NavigationScreenshotLoaderRegistry()
+    val kept = registry.forDevice("dev-1", clientProvider)
+    registry.forDevice("dev-2", clientProvider)
+
+    registry.forget("dev-2")
+
+    assertSame("an untouched device keeps its loader", kept, registry.peek("dev-1"))
+    assertNull("the forgotten device is released", registry.peek("dev-2"))
+  }
+
+  @Test
+  fun `forget for an unknown device is a no-op`() {
+    val registry = NavigationScreenshotLoaderRegistry()
+    // Must not throw when no loader was ever created for the device.
+    registry.forget("never-seen")
+    assertNull(registry.peek("never-seen"))
+  }
+
+  @Test
+  fun `forDevice after forget creates a fresh loader`() {
+    val registry = NavigationScreenshotLoaderRegistry()
+    val first = registry.forDevice("dev-1", clientProvider)
+    registry.forget("dev-1")
+    val second = registry.forDevice("dev-1", clientProvider)
+    assertNotSame("a re-added device must get a new loader (empty cache)", first, second)
   }
 }

--- a/android/desktop-core/src/test/kotlin/dev/jasonpearson/automobile/desktop/core/workspace/WorkspaceViewModelTest.kt
+++ b/android/desktop-core/src/test/kotlin/dev/jasonpearson/automobile/desktop/core/workspace/WorkspaceViewModelTest.kt
@@ -1,5 +1,7 @@
 package dev.jasonpearson.automobile.desktop.core.workspace
 
+import dev.jasonpearson.automobile.desktop.core.navigation.NavigationScreenshotLoaderRegistry
+import dev.jasonpearson.automobile.desktop.core.testing.FakeAutoMobileClient
 import kotlinx.coroutines.CompletableDeferred
 import kotlinx.coroutines.ExperimentalCoroutinesApi
 import kotlinx.coroutines.test.TestScope
@@ -7,6 +9,7 @@ import kotlinx.coroutines.test.UnconfinedTestDispatcher
 import kotlinx.coroutines.test.advanceUntilIdle
 import kotlinx.coroutines.test.runTest
 import org.junit.Assert.assertEquals
+import org.junit.Assert.assertNotNull
 import org.junit.Assert.assertNull
 import org.junit.Assert.assertTrue
 import org.junit.Test
@@ -77,6 +80,20 @@ class WorkspaceViewModelTest {
     vm.onAction(WorkspaceAction.ObserveDevice(column("a")))
     vm.onAction(WorkspaceAction.CloseDevice("a"))
     assertTrue(vm.state.value is WorkspaceUiState.Empty)
+  }
+
+  @Test
+  fun `closing a column releases its navigation screenshot loader`() = testScope.runTest {
+    val registry = NavigationScreenshotLoaderRegistry()
+    val vm = WorkspaceViewModel(this, screenshotLoaderRegistry = registry)
+    vm.onAction(WorkspaceAction.ObserveDevice(column("a")))
+    // Simulate the Navigation facet having created a per-device loader for the pane.
+    registry.forDevice("a") { FakeAutoMobileClient() }
+    assertNotNull("precondition: loader exists for the open device", registry.peek("a"))
+
+    vm.onAction(WorkspaceAction.CloseDevice("a"))
+
+    assertNull("closing the device must release its screenshot loader (#5087)", registry.peek("a"))
   }
 
   @Test


### PR DESCRIPTION
## Problem

`NavigationScreenshotLoaderRegistry` (added in [#5084](https://github.com/kaeawc/auto-mobile/pull/5084) to make the nav screenshot LRU cache survive facet open/close toggles) keys per-device loaders in a **process-lifetime** `ConcurrentHashMap` with **no eviction**. Every distinct `deviceId` ever shown a Navigation facet retains its loader for the whole app session, each holding up to `maxCacheBytes` (100MB) of decoded thumbnails. Retaining across toggles is intended; the gap is that nothing releases a loader when a device leaves the workspace entirely.

Fixes [#5087](https://github.com/kaeawc/auto-mobile/issues/5087).

## Change

- Add `NavigationScreenshotLoaderRegistry.forget(deviceId)` — removes the per-device loader from the registry and clears its LRU thumbnail cache. No-op for an unknown device.
- Inject the registry into `WorkspaceViewModel` (defaulting to the shared `DefaultNavigationScreenshotLoaderRegistry`, mirroring the existing `controlExecutor` injection) and call `forget(deviceId)` from `close(deviceId)` — the single workspace device-removal path (`WorkspaceAction.CloseDevice`).

A re-added device gets a fresh loader (empty cache), so nothing stale is served after a close→reopen.

## Acceptance criteria

- [x] A device removed from the workspace has its screenshot loader (and cache) released — wired in `WorkspaceViewModel.close()`.
- [x] A test covers eviction — the registry returns a new instance after `forget`, and `WorkspaceViewModelTest` asserts `close` releases the loader.

## Tests

`:desktop-core:test` for the two affected classes, all green:
- `NavigationScreenshotLoaderRegistryTest` 2 → 6 (forget releases / isolates / no-op / fresh-loader-after-forget)
- `WorkspaceViewModelTest` 18 → 19 (closing a column releases its loader)

Also verified `:desktop-app:compileKotlin`, `:desktop-core:detekt`, and ktfmt on the touched files.

🤖 Generated with [Claude Code](https://claude.com/claude-code) via the next-best-issue scheduled task.