### PR TITLE
perf(db): add (last_seen_at, id) eviction index for nav observations (#5309)

### DIFF
--- a/src/db/migrations/2026_08_22_002_navigation_observation_eviction_index.ts
+++ b/src/db/migrations/2026_08_22_002_navigation_observation_eviction_index.ts
@@ -1,31 +1,46 @@
 import type { Kysely } from "kysely";
 
 /**
- * Composite `(build_key_id, last_seen_at)` eviction index for the navigation
- * observation tables (#5309, follow-up to #4986 Phase 3 retention).
+ * `(last_seen_at, id)` eviction index for the navigation observation tables
+ * (#5309, follow-up to #4986 Phase 3 retention).
  *
  * The size-cap eviction pass in `src/db/navigationRetention.ts`
- * (`collectOldestEvictable` and the per-build-key oldest-row subqueries) walks
- * `navigation_node_observations` / `navigation_edge_observations` ordered by
- * `last_seen_at` within a `build_key_id` scope, up to the global cap of ~500k
- * rows. Every 6 hours the background pass full-scans and temp-sorts these tables.
- * The only pre-existing composite-eligible index is the single-column
- * `idx_navigation_<t>_observations_build (build_key_id)` from #4986, which seeks
- * on `build_key_id=?` but then scans every row for that key in unspecified order,
- * forcing a `USE TEMP B-TREE FOR ORDER BY` for the `last_seen_at` ordering.
- * `(build_key_id, last_seen_at)` lets the planner seek the build-key prefix and
- * read `last_seen_at` order straight from the index — an index range scan instead
- * of scan + sort. See the note at `navigationRetention.ts` `collectOldestEvictable`.
+ * (`collectOldestEvictable` → `buildOldestNodeEvictableQuery` /
+ * `buildOldestEdgeEvictableQuery`) reads the `limit` oldest rows of
+ * `navigation_node_observations` / `navigation_edge_observations`
+ * `ORDER BY last_seen_at ASC, id ASC` — GLOBALLY across every build key (there is
+ * no `build_key_id = ?` equality; app scope, when present, is a
+ * `build_key_id IN (<app's build keys>)` filter, not an equality). Up to the
+ * global cap of ~500k rows, the 6-hourly background pass full-scans and temp-sorts
+ * these tables to satisfy that ordering.
  *
- * No DESC in the index columns: the eviction scan orders `last_seen_at` ASC
- * (oldest-first), and SQLite reads a plain ascending index in order; a plain
- * composite suffices (mirrors 2026_07_02_000_event_composite_indexes.ts).
+ * The ordering column is `last_seen_at`, so the index that removes the sort must
+ * lead with `last_seen_at`. `(last_seen_at, id)` lets the planner read rows in
+ * `last_seen_at ASC, id ASC` order straight from the index and stop at `limit` —
+ * an index range scan instead of scan + temp B-tree sort — for all three query
+ * shapes the pass issues:
+ *   - global eviction (`appId === null`): covering index scan, no sort.
+ *   - app-scoped eviction: index scan in `last_seen_at` order, `build_key_id IN`
+ *     applied as a filter, no sort.
+ *   - active-row exclusion (`protectedIds` non-empty): the outer ordering is still
+ *     served by this index; the correlated `MAX(last_seen_at) WHERE build_key_id=?`
+ *     subquery seeks via the retained single-column build index (below).
  *
- * Additive and forward-only. The standalone `idx_navigation_<t>_observations_build`
- * is now a left-prefix of this composite and functionally redundant, but it is
- * deliberately RETAINED to keep this migration purely additive (mirroring the
- * retained single-column indexes in 2026_07_02_000_event_composite_indexes.ts);
- * dropping it to cut per-insert write amplification is a separable follow-up.
+ * A leading-`build_key_id` composite such as `(build_key_id, last_seen_at)` does
+ * NOT remove the sort here: because the outer query orders by `last_seen_at`
+ * across build keys (not within one), the planner would still emit
+ * `USE TEMP B-TREE FOR ORDER BY`. See #5309 review; the planner test compiles the
+ * real query builders and asserts the sort is gone.
+ *
+ * No DESC in the index columns: the eviction scan orders ASC (oldest-first), and
+ * SQLite reads a plain ascending index in order; a plain composite suffices
+ * (mirrors 2026_07_02_000_event_composite_indexes.ts). `id` is the tiebreaker the
+ * query orders on, so including it keeps the global scan covering (no row lookup).
+ *
+ * Additive and forward-only. The #4986 single-column
+ * `idx_navigation_<t>_observations_build (build_key_id)` is deliberately RETAINED:
+ * it still seeks the correlated per-build-key `MAX(last_seen_at)` exclusion
+ * subquery, and is not a prefix of this `(last_seen_at, id)` index.
  *
  * `.ifNotExists()` / `.ifExists()` so the migration survives #2785's
  * destructive-recovery replay (drop-all then replay every migration on an empty
@@ -37,16 +52,16 @@ const TABLES = ["navigation_node_observations", "navigation_edge_observations"] 
 export async function up(db: Kysely<unknown>): Promise<void> {
   for (const table of TABLES) {
     await db.schema
-      .createIndex(`idx_${table}_build_seen`)
+      .createIndex(`idx_${table}_seen_id`)
       .ifNotExists()
       .on(table as never)
-      .columns(["build_key_id", "last_seen_at"] as never[])
+      .columns(["last_seen_at", "id"] as never[])
       .execute();
   }
 }
 
 export async function down(db: Kysely<unknown>): Promise<void> {
   for (const table of TABLES) {
-    await db.schema.dropIndex(`idx_${table}_build_seen`).ifExists().execute();
+    await db.schema.dropIndex(`idx_${table}_seen_id`).ifExists().execute();
   }
 }

--- a/src/db/migrations/2026_08_22_002_navigation_observation_eviction_index.ts
+++ b/src/db/migrations/2026_08_22_002_navigation_observation_eviction_index.ts
@@ -1,0 +1,52 @@
+import type { Kysely } from "kysely";
+
+/**
+ * Composite `(build_key_id, last_seen_at)` eviction index for the navigation
+ * observation tables (#5309, follow-up to #4986 Phase 3 retention).
+ *
+ * The size-cap eviction pass in `src/db/navigationRetention.ts`
+ * (`collectOldestEvictable` and the per-build-key oldest-row subqueries) walks
+ * `navigation_node_observations` / `navigation_edge_observations` ordered by
+ * `last_seen_at` within a `build_key_id` scope, up to the global cap of ~500k
+ * rows. Every 6 hours the background pass full-scans and temp-sorts these tables.
+ * The only pre-existing composite-eligible index is the single-column
+ * `idx_navigation_<t>_observations_build (build_key_id)` from #4986, which seeks
+ * on `build_key_id=?` but then scans every row for that key in unspecified order,
+ * forcing a `USE TEMP B-TREE FOR ORDER BY` for the `last_seen_at` ordering.
+ * `(build_key_id, last_seen_at)` lets the planner seek the build-key prefix and
+ * read `last_seen_at` order straight from the index — an index range scan instead
+ * of scan + sort. See the note at `navigationRetention.ts` `collectOldestEvictable`.
+ *
+ * No DESC in the index columns: the eviction scan orders `last_seen_at` ASC
+ * (oldest-first), and SQLite reads a plain ascending index in order; a plain
+ * composite suffices (mirrors 2026_07_02_000_event_composite_indexes.ts).
+ *
+ * Additive and forward-only. The standalone `idx_navigation_<t>_observations_build`
+ * is now a left-prefix of this composite and functionally redundant, but it is
+ * deliberately RETAINED to keep this migration purely additive (mirroring the
+ * retained single-column indexes in 2026_07_02_000_event_composite_indexes.ts);
+ * dropping it to cut per-insert write amplification is a separable follow-up.
+ *
+ * `.ifNotExists()` / `.ifExists()` so the migration survives #2785's
+ * destructive-recovery replay (drop-all then replay every migration on an empty
+ * DB) in unusual orders. Sorts after 2026_08_02_000_navigation_provenance.ts, so
+ * both observation tables exist when it runs during a full replay.
+ */
+const TABLES = ["navigation_node_observations", "navigation_edge_observations"] as const;
+
+export async function up(db: Kysely<unknown>): Promise<void> {
+  for (const table of TABLES) {
+    await db.schema
+      .createIndex(`idx_${table}_build_seen`)
+      .ifNotExists()
+      .on(table as never)
+      .columns(["build_key_id", "last_seen_at"] as never[])
+      .execute();
+  }
+}
+
+export async function down(db: Kysely<unknown>): Promise<void> {
+  for (const table of TABLES) {
+    await db.schema.dropIndex(`idx_${table}_build_seen`).ifExists().execute();
+  }
+}

--- a/src/db/navigationRetention.ts
+++ b/src/db/navigationRetention.ts
@@ -408,9 +408,11 @@ export class NavigationRetention {
    * evictable rows remain (active rows are excluded relationally, so a scope can
    * be irreducible below its active set).
    *
-   * Perf note: each batch does an ordered scan of the observation tables. A
-   * `(build_key_id, last_seen_at)` index would turn this into an index range scan;
-   * deferred as a small follow-up migration (issue #5309).
+   * Perf note: each batch reads the oldest rows `ORDER BY last_seen_at, id`
+   * across build keys. The `(last_seen_at, id)` index from
+   * 2026_08_22_002_navigation_observation_eviction_index.ts (issue #5309) serves
+   * that ordering directly, so the batch is an index range scan rather than a
+   * scan + temp-B-tree sort.
    */
   private async evictOldest(
     trx: Kysely<Database>,

--- a/test/db/navigationObservationEvictionIndex.test.ts
+++ b/test/db/navigationObservationEvictionIndex.test.ts
@@ -3,27 +3,42 @@ import { Database as BunDatabase } from "bun:sqlite";
 import { Kysely, sql } from "kysely";
 import { BunSqliteDialect } from "../../src/db/bunSqliteDialect";
 import { runMigrations } from "../../src/db/migrator";
+import type { Database } from "../../src/db/types";
 import {
-  up as evictionUp,
+  buildOldestEdgeEvictableQuery,
+  buildOldestNodeEvictableQuery,
+} from "../../src/db/navigationRetention";
+import {
   down as evictionDown,
+  up as evictionUp,
 } from "../../src/db/migrations/2026_08_22_002_navigation_observation_eviction_index";
 
 /**
  * Migration coverage for #5309. The size-cap eviction pass in
- * `src/db/navigationRetention.ts` walks the observation tables ordered by
- * `last_seen_at` within a `build_key_id` scope. With only the #4986 single-column
- * `idx_navigation_<t>_observations_build (build_key_id)` the planner seeks the
- * build key but then does `USE TEMP B-TREE FOR ORDER BY` for the `last_seen_at`
- * ordering. The `(build_key_id, last_seen_at)` composite this migration adds turns
- * that into an index range scan (seek the prefix, read `last_seen_at` in order).
+ * `src/db/navigationRetention.ts` reads the `limit` oldest rows of
+ * `navigation_node_observations` / `navigation_edge_observations`
+ * `ORDER BY last_seen_at ASC, id ASC` — GLOBALLY across every build key (app
+ * scope, when present, is a `build_key_id IN (…)` filter, not an equality). With
+ * only the #4986 single-column `idx_navigation_<t>_observations_build
+ * (build_key_id)` the planner must `USE TEMP B-TREE FOR ORDER BY` to satisfy that
+ * `last_seen_at` ordering.
  *
- * These tests pin: the composite exists on both tables with ordered columns, the
- * planner switches to the index and drops the temp B-tree, the migration is
+ * This migration adds `(last_seen_at, id)` — leading with the ordering column —
+ * so the planner reads rows in order straight from the index and stops at `limit`,
+ * an index range scan instead of scan + sort. A leading-`build_key_id` composite
+ * (`(build_key_id, last_seen_at)`) would NOT remove the sort, because the outer
+ * ordering is across build keys, not within one — so these tests compile the REAL
+ * eviction query builders (not a synthetic per-key query) and assert the temp
+ * B-tree is gone for the global, app-scoped, and active-exclusion shapes.
+ *
+ * They also pin: the index exists on both tables with ordered columns
+ * `[last_seen_at, id]`, oldest-first reads are unchanged, the migration is
  * discovered by a full replay, is idempotent / reversible / replay-safe, and does
- * not disturb the retained single-column build index.
+ * not disturb the retained single-column build index (which still seeks the
+ * correlated per-build-key MAX exclusion subquery).
  */
 const TABLES = ["navigation_node_observations", "navigation_edge_observations"] as const;
-const indexFor = (table: string): string => `idx_${table}_build_seen`;
+const indexFor = (table: string): string => `idx_${table}_seen_id`;
 const buildIndexFor = (table: string): string => `idx_${table}_build`;
 
 async function indexExists(db: Kysely<unknown>, name: string): Promise<boolean> {
@@ -42,14 +57,16 @@ async function indexColumns(db: Kysely<unknown>, name: string): Promise<string[]
 }
 
 /**
- * Minimal reproduction of the observation-table index state immediately BEFORE
- * this migration: the columns the eviction scan touches plus the #4986
- * single-column build index. Index selection depends only on the indexed columns,
- * so the focused tests stay decoupled from the full navigation migration chain
- * (its backfill reads navigation_apps/nodes/edges); the full-replay block below
+ * Minimal reproduction of the observation-table schema the eviction queries
+ * touch, plus the #4986 single-column build index and the build-key lookup table
+ * the app-scoped query joins. Seeded with a spread of build keys / apps and then
+ * ANALYZE-d so the planner has the row statistics it uses in production — index
+ * selection for the app-scoped `build_key_id IN (…)` filter is stats-driven.
+ * Index selection depends only on these columns, so the focused tests stay
+ * decoupled from the full navigation migration chain; the full-replay block below
  * proves wiring against the real schema.
  */
-async function buildPreMigrationSchema(db: Kysely<unknown>): Promise<void> {
+async function buildPreMigrationSchema(bunDb: BunDatabase, db: Kysely<unknown>): Promise<void> {
   for (const table of TABLES) {
     await db.schema
       .createTable(table)
@@ -59,38 +76,80 @@ async function buildPreMigrationSchema(db: Kysely<unknown>): Promise<void> {
       .execute();
     await db.schema.createIndex(buildIndexFor(table)).on(table).column("build_key_id").execute();
   }
+  await db.schema
+    .createTable("navigation_build_keys")
+    .addColumn("id", "integer", col => col.primaryKey())
+    .addColumn("app_id", "text")
+    .execute();
+
+  const insertNode = bunDb.prepare(
+    "INSERT INTO navigation_node_observations (build_key_id, last_seen_at) VALUES (?, ?)"
+  );
+  const insertEdge = bunDb.prepare(
+    "INSERT INTO navigation_edge_observations (build_key_id, last_seen_at) VALUES (?, ?)"
+  );
+  const seed = bunDb.transaction((rows: number) => {
+    for (let i = 0; i < rows; i++) {
+      insertNode.run(i % 30, (i * 37) % 100000);
+      insertEdge.run(i % 30, (i * 41) % 100000);
+    }
+  });
+  seed(3000);
+  const insertKey = bunDb.prepare("INSERT INTO navigation_build_keys (id, app_id) VALUES (?, ?)");
+  for (let i = 0; i < 30; i++) {
+    insertKey.run(i, `app${i % 4}`);
+  }
+  bunDb.run("ANALYZE");
+}
+
+/** EXPLAIN QUERY PLAN detail lines (newline-joined) for a compiled kysely query. */
+function planFor(bunDb: BunDatabase, compiled: { sql: string; parameters: readonly unknown[] }): string {
+  const rows = bunDb
+    .query(`EXPLAIN QUERY PLAN ${compiled.sql}`)
+    .all(...(compiled.parameters as unknown[])) as Array<{ detail: string }>;
+  return rows.map(r => r.detail).join("\n");
+}
+
+const TEMP_SORT = "USE TEMP B-TREE FOR ORDER BY";
+
+interface EvictionCase {
+  label: string;
+  table: string;
+  sql: { sql: string; parameters: readonly unknown[] };
 }
 
 /**
- * EXPLAIN QUERY PLAN detail lines for the per-build-key oldest-first scan that
- * the eviction subqueries in `collectOldestEvictable` evaluate. Runs against the
- * raw bun:sqlite handle: kysely's `sql` execute returns no rows for EXPLAIN.
+ * The three query shapes `collectOldestEvictable` issues, built from the REAL
+ * exported query builders: global eviction (`appId === null`), per-app eviction
+ * (`build_key_id IN (<app's keys>)`), and active-row exclusion (correlated
+ * per-build-key MAX). Each is exercised against both observation tables.
  */
-function evictionPlan(bunDb: BunDatabase, table: string): string[] {
-  const rows = bunDb
-    .query(
-      `EXPLAIN QUERY PLAN SELECT id, last_seen_at FROM ${table} ` +
-        "WHERE build_key_id = 5 ORDER BY last_seen_at ASC LIMIT 10"
-    )
-    .all() as Array<{ detail: string }>;
-  return rows.map(r => r.detail);
+function evictionCases(db: Kysely<Database>): EvictionCase[] {
+  return [
+    { label: "node global", table: "navigation_node_observations", sql: buildOldestNodeEvictableQuery(db, null, [], 500).compile() },
+    { label: "node app-scoped", table: "navigation_node_observations", sql: buildOldestNodeEvictableQuery(db, "app1", [], 500).compile() },
+    { label: "node protected", table: "navigation_node_observations", sql: buildOldestNodeEvictableQuery(db, null, [5, 7], 500).compile() },
+    { label: "edge global", table: "navigation_edge_observations", sql: buildOldestEdgeEvictableQuery(db, null, [], 500).compile() },
+    { label: "edge app-scoped", table: "navigation_edge_observations", sql: buildOldestEdgeEvictableQuery(db, "app1", [], 500).compile() },
+    { label: "edge protected", table: "navigation_edge_observations", sql: buildOldestEdgeEvictableQuery(db, null, [5, 7], 500).compile() },
+  ];
 }
 
 describe("2026_08_22_002_navigation_observation_eviction_index migration", () => {
   let bunDb: BunDatabase;
-  let db: Kysely<unknown>;
+  let db: Kysely<Database>;
 
   beforeEach(async () => {
     bunDb = new BunDatabase(":memory:");
-    db = new Kysely<unknown>({ dialect: new BunSqliteDialect({ database: bunDb }) });
-    await buildPreMigrationSchema(db);
+    db = new Kysely<Database>({ dialect: new BunSqliteDialect({ database: bunDb }) });
+    await buildPreMigrationSchema(bunDb, db);
   });
 
   afterEach(async () => {
     await db.destroy();
   });
 
-  test("up creates the composite eviction index on both tables with ordered columns", async () => {
+  test("up creates the (last_seen_at, id) eviction index on both tables in order", async () => {
     for (const table of TABLES) {
       expect(await indexExists(db, indexFor(table))).toBe(false);
     }
@@ -99,50 +158,41 @@ describe("2026_08_22_002_navigation_observation_eviction_index migration", () =>
 
     for (const table of TABLES) {
       expect(await indexExists(db, indexFor(table))).toBe(true);
-      expect(await indexColumns(db, indexFor(table))).toEqual(["build_key_id", "last_seen_at"]);
+      expect(await indexColumns(db, indexFor(table))).toEqual(["last_seen_at", "id"]);
     }
   });
 
-  test("planner switches to the composite range scan; temp B-tree gone", async () => {
-    for (const table of TABLES) {
-      const before = evictionPlan(bunDb, table).join("\n");
-      // Only the single-column build index exists: seek build_key_id, then sort.
-      expect(before).not.toContain(indexFor(table));
-      expect(before).toContain("USE TEMP B-TREE FOR ORDER BY");
+  test("the real global eviction queries temp-sort before the migration", () => {
+    for (const c of evictionCases(db).filter(c => c.label.endsWith("global"))) {
+      expect(planFor(bunDb, c.sql)).toContain(TEMP_SORT);
     }
+  });
 
+  test("every real eviction query drops the temp sort onto the index after migration", async () => {
     await evictionUp(db);
+    // Refresh stats so the planner accounts for the new index on the app-scoped
+    // filter (mirrors a production DB that has ANALYZE-d since the index landed).
+    bunDb.run("ANALYZE");
 
-    for (const table of TABLES) {
-      const after = evictionPlan(bunDb, table).join("\n");
-      expect(after).toContain(indexFor(table));
-      expect(after).toMatch(
-        new RegExp(`SEARCH .*USING (?:COVERING )?INDEX ${indexFor(table)} \\(build_key_id=\\?\\)`)
-      );
-      // The trailing last_seen_at column supplies the ASC order — no sort.
-      expect(after).not.toContain("USE TEMP B-TREE FOR ORDER BY");
+    for (const c of evictionCases(db)) {
+      const plan = planFor(bunDb, c.sql);
+      expect(plan, `${c.label}: ${plan}`).not.toContain(TEMP_SORT);
+      expect(plan, `${c.label}: ${plan}`).toContain(indexFor(c.table));
     }
   });
 
-  test("oldest-first scan returns the same rows before and after the migration", async () => {
-    await sql`INSERT INTO navigation_node_observations (build_key_id, last_seen_at)
-      VALUES (5, 300), (5, 100), (5, 200), (7, 50)`.execute(db);
-
-    const read = async (): Promise<Array<{ id: number; last_seen_at: number }>> => {
-      const result = await sql<{ id: number; last_seen_at: number }>`
-        SELECT id, last_seen_at FROM navigation_node_observations
-        WHERE build_key_id = 5 ORDER BY last_seen_at ASC LIMIT 10
-      `.execute(db);
-      return result.rows;
-    };
+  test("oldest-first eviction read returns the same rows before and after the migration", async () => {
+    const read = async (): Promise<Array<{ id: number; last_seen_at: number }>> =>
+      buildOldestNodeEvictableQuery(db, null, [], 5).execute();
 
     const before = await read();
     await evictionUp(db);
     const after = await read();
 
     expect(after).toEqual(before);
-    // Sanity: oldest-first within build_key_id 5 is last_seen_at 100, 200, 300.
-    expect(after.map(r => r.last_seen_at)).toEqual([100, 200, 300]);
+    // Oldest-first: last_seen_at ascending, ties broken by id ascending.
+    const seen = after.map(r => r.last_seen_at);
+    expect([...seen].sort((a, b) => a - b)).toEqual(seen);
   });
 
   test("up is idempotent (safe to re-run, as destructive-recovery replay would)", async () => {
@@ -153,7 +203,7 @@ describe("2026_08_22_002_navigation_observation_eviction_index migration", () =>
     }
   });
 
-  test("down drops the composite index on both tables", async () => {
+  test("down drops the eviction index on both tables", async () => {
     await evictionUp(db);
     await evictionDown(db);
     for (const table of TABLES) {
@@ -193,10 +243,10 @@ describe("2026_08_22_002_navigation_observation_eviction_index migration — ful
     await db.destroy();
   });
 
-  test("both composite indexes exist after a fresh full migration chain", async () => {
+  test("both eviction indexes exist after a fresh full migration chain", async () => {
     for (const table of TABLES) {
       expect(await indexExists(db, indexFor(table))).toBe(true);
-      expect(await indexColumns(db, indexFor(table))).toEqual(["build_key_id", "last_seen_at"]);
+      expect(await indexColumns(db, indexFor(table))).toEqual(["last_seen_at", "id"]);
     }
   });
 });

--- a/test/db/navigationObservationEvictionIndex.test.ts
+++ b/test/db/navigationObservationEvictionIndex.test.ts
@@ -1,0 +1,202 @@
+import { afterEach, beforeEach, describe, expect, test } from "bun:test";
+import { Database as BunDatabase } from "bun:sqlite";
+import { Kysely, sql } from "kysely";
+import { BunSqliteDialect } from "../../src/db/bunSqliteDialect";
+import { runMigrations } from "../../src/db/migrator";
+import {
+  up as evictionUp,
+  down as evictionDown,
+} from "../../src/db/migrations/2026_08_22_002_navigation_observation_eviction_index";
+
+/**
+ * Migration coverage for #5309. The size-cap eviction pass in
+ * `src/db/navigationRetention.ts` walks the observation tables ordered by
+ * `last_seen_at` within a `build_key_id` scope. With only the #4986 single-column
+ * `idx_navigation_<t>_observations_build (build_key_id)` the planner seeks the
+ * build key but then does `USE TEMP B-TREE FOR ORDER BY` for the `last_seen_at`
+ * ordering. The `(build_key_id, last_seen_at)` composite this migration adds turns
+ * that into an index range scan (seek the prefix, read `last_seen_at` in order).
+ *
+ * These tests pin: the composite exists on both tables with ordered columns, the
+ * planner switches to the index and drops the temp B-tree, the migration is
+ * discovered by a full replay, is idempotent / reversible / replay-safe, and does
+ * not disturb the retained single-column build index.
+ */
+const TABLES = ["navigation_node_observations", "navigation_edge_observations"] as const;
+const indexFor = (table: string): string => `idx_${table}_build_seen`;
+const buildIndexFor = (table: string): string => `idx_${table}_build`;
+
+async function indexExists(db: Kysely<unknown>, name: string): Promise<boolean> {
+  const result = await sql<{ name: string }>`
+    SELECT name FROM sqlite_master WHERE type = 'index' AND name = ${name}
+  `.execute(db);
+  return result.rows.length > 0;
+}
+
+/** Ordered list of column names participating in an index (PRAGMA index_info). */
+async function indexColumns(db: Kysely<unknown>, name: string): Promise<string[]> {
+  const result = await sql<{ seqno: number; name: string }>`
+    SELECT seqno, name FROM pragma_index_info(${name}) ORDER BY seqno
+  `.execute(db);
+  return result.rows.map(r => r.name);
+}
+
+/**
+ * Minimal reproduction of the observation-table index state immediately BEFORE
+ * this migration: the columns the eviction scan touches plus the #4986
+ * single-column build index. Index selection depends only on the indexed columns,
+ * so the focused tests stay decoupled from the full navigation migration chain
+ * (its backfill reads navigation_apps/nodes/edges); the full-replay block below
+ * proves wiring against the real schema.
+ */
+async function buildPreMigrationSchema(db: Kysely<unknown>): Promise<void> {
+  for (const table of TABLES) {
+    await db.schema
+      .createTable(table)
+      .addColumn("id", "integer", col => col.primaryKey().autoIncrement())
+      .addColumn("build_key_id", "integer", col => col.notNull())
+      .addColumn("last_seen_at", "integer", col => col.notNull())
+      .execute();
+    await db.schema.createIndex(buildIndexFor(table)).on(table).column("build_key_id").execute();
+  }
+}
+
+/**
+ * EXPLAIN QUERY PLAN detail lines for the per-build-key oldest-first scan that
+ * the eviction subqueries in `collectOldestEvictable` evaluate. Runs against the
+ * raw bun:sqlite handle: kysely's `sql` execute returns no rows for EXPLAIN.
+ */
+function evictionPlan(bunDb: BunDatabase, table: string): string[] {
+  const rows = bunDb
+    .query(
+      `EXPLAIN QUERY PLAN SELECT id, last_seen_at FROM ${table} ` +
+        "WHERE build_key_id = 5 ORDER BY last_seen_at ASC LIMIT 10"
+    )
+    .all() as Array<{ detail: string }>;
+  return rows.map(r => r.detail);
+}
+
+describe("2026_08_22_002_navigation_observation_eviction_index migration", () => {
+  let bunDb: BunDatabase;
+  let db: Kysely<unknown>;
+
+  beforeEach(async () => {
+    bunDb = new BunDatabase(":memory:");
+    db = new Kysely<unknown>({ dialect: new BunSqliteDialect({ database: bunDb }) });
+    await buildPreMigrationSchema(db);
+  });
+
+  afterEach(async () => {
+    await db.destroy();
+  });
+
+  test("up creates the composite eviction index on both tables with ordered columns", async () => {
+    for (const table of TABLES) {
+      expect(await indexExists(db, indexFor(table))).toBe(false);
+    }
+
+    await evictionUp(db);
+
+    for (const table of TABLES) {
+      expect(await indexExists(db, indexFor(table))).toBe(true);
+      expect(await indexColumns(db, indexFor(table))).toEqual(["build_key_id", "last_seen_at"]);
+    }
+  });
+
+  test("planner switches to the composite range scan; temp B-tree gone", async () => {
+    for (const table of TABLES) {
+      const before = evictionPlan(bunDb, table).join("\n");
+      // Only the single-column build index exists: seek build_key_id, then sort.
+      expect(before).not.toContain(indexFor(table));
+      expect(before).toContain("USE TEMP B-TREE FOR ORDER BY");
+    }
+
+    await evictionUp(db);
+
+    for (const table of TABLES) {
+      const after = evictionPlan(bunDb, table).join("\n");
+      expect(after).toContain(indexFor(table));
+      expect(after).toMatch(
+        new RegExp(`SEARCH .*USING (?:COVERING )?INDEX ${indexFor(table)} \\(build_key_id=\\?\\)`)
+      );
+      // The trailing last_seen_at column supplies the ASC order — no sort.
+      expect(after).not.toContain("USE TEMP B-TREE FOR ORDER BY");
+    }
+  });
+
+  test("oldest-first scan returns the same rows before and after the migration", async () => {
+    await sql`INSERT INTO navigation_node_observations (build_key_id, last_seen_at)
+      VALUES (5, 300), (5, 100), (5, 200), (7, 50)`.execute(db);
+
+    const read = async (): Promise<Array<{ id: number; last_seen_at: number }>> => {
+      const result = await sql<{ id: number; last_seen_at: number }>`
+        SELECT id, last_seen_at FROM navigation_node_observations
+        WHERE build_key_id = 5 ORDER BY last_seen_at ASC LIMIT 10
+      `.execute(db);
+      return result.rows;
+    };
+
+    const before = await read();
+    await evictionUp(db);
+    const after = await read();
+
+    expect(after).toEqual(before);
+    // Sanity: oldest-first within build_key_id 5 is last_seen_at 100, 200, 300.
+    expect(after.map(r => r.last_seen_at)).toEqual([100, 200, 300]);
+  });
+
+  test("up is idempotent (safe to re-run, as destructive-recovery replay would)", async () => {
+    await evictionUp(db);
+    await expect(evictionUp(db)).resolves.toBeUndefined();
+    for (const table of TABLES) {
+      expect(await indexExists(db, indexFor(table))).toBe(true);
+    }
+  });
+
+  test("down drops the composite index on both tables", async () => {
+    await evictionUp(db);
+    await evictionDown(db);
+    for (const table of TABLES) {
+      expect(await indexExists(db, indexFor(table))).toBe(false);
+    }
+  });
+
+  test("down is idempotent — a partial-up followed by down does not throw", async () => {
+    await expect(evictionDown(db)).resolves.toBeUndefined();
+    await evictionUp(db);
+    await evictionDown(db);
+    await expect(evictionDown(db)).resolves.toBeUndefined();
+  });
+
+  test("does not touch the retained single-column build index", async () => {
+    await evictionUp(db);
+    for (const table of TABLES) {
+      expect(await indexExists(db, buildIndexFor(table))).toBe(true);
+    }
+  });
+});
+
+describe("2026_08_22_002_navigation_observation_eviction_index migration — full replay", () => {
+  let db: Kysely<unknown>;
+
+  beforeEach(async () => {
+    db = new Kysely<unknown>({
+      dialect: new BunSqliteDialect({ database: new BunDatabase(":memory:") }),
+    });
+    // Full forward replay of every on-disk migration (the #2785
+    // destructive-recovery path). Proves the migration is discovered/wired
+    // against the real observation-table schema.
+    await runMigrations(db);
+  });
+
+  afterEach(async () => {
+    await db.destroy();
+  });
+
+  test("both composite indexes exist after a fresh full migration chain", async () => {
+    for (const table of TABLES) {
+      expect(await indexExists(db, indexFor(table))).toBe(true);
+      expect(await indexColumns(db, indexFor(table))).toEqual(["build_key_id", "last_seen_at"]);
+    }
+  });
+});


### PR DESCRIPTION
## What

Adds a small, additive migration (`2026_08_22_002_navigation_observation_eviction_index.ts`) creating the index `(last_seen_at, id)` on both `navigation_node_observations` and `navigation_edge_observations`.

Closes [#5309](https://github.com/kaeawc/auto-mobile/issues/5309).

## Why

The size-cap eviction pass in [`navigationRetention.ts`](src/db/navigationRetention.ts) reads the `limit` oldest rows via `buildOldestNodeEvictableQuery` / `buildOldestEdgeEvictableQuery`, ordered by **`last_seen_at ASC, id ASC` globally across build keys** — app scope, when present, is a `build_key_id IN (…)` filter (not an equality), and global eviction has no `build_key_id` predicate at all. Up to the ~500k global cap the 6-hourly background pass full-scans and temp-sorts these tables to satisfy that ordering.

The index that removes the sort must **lead with the ordering column**. `(last_seen_at, id)` lets the planner read rows in `last_seen_at ASC, id ASC` order straight from the index and stop at `limit` — an index range scan instead of scan + `USE TEMP B-TREE FOR ORDER BY`.

> **Correction (issue named the wrong column order).** #5309 requested `(build_key_id, last_seen_at)`. As [@chatgpt-codex-connector flagged in review](https://github.com/kaeawc/auto-mobile/pull/5522), a leading-`build_key_id` composite **cannot** satisfy a cross-build-key `last_seen_at` ordering, so EXPLAIN QUERY PLAN still reports SCAN + temp B-tree for the real queries; only the initial synthetic test query (`WHERE build_key_id = 5`) made it look effective. This PR ships `(last_seen_at, id)` instead, which delivers the issue's actual goal for every eviction shape at the same single-index write-amplification cost.

## Scope / design

- **Additive and forward-only.** The #4986 single-column `idx_navigation_<t>_observations_build (build_key_id)` is **retained**: it still seeks the correlated per-build-key `MAX(last_seen_at)` active-exclusion subquery, and is not a prefix of this index.
- No `DESC` in the columns: the eviction scan orders ASC and SQLite reads a plain ascending index in order. `id` is the tiebreaker the query orders on, so including it keeps the global scan covering.
- `.ifNotExists()` / `.ifExists()` so the migration survives #2785's destructive-recovery replay. Sorts after `2026_08_02_000_navigation_provenance.ts`, so both tables exist during a full replay.

## Tests

`test/db/navigationObservationEvictionIndex.test.ts` compiles the **real** exported query builders (not a synthetic query) and pins:
- the index exists on both tables with ordered columns `[last_seen_at, id]`;
- before the migration the global eviction queries `USE TEMP B-TREE FOR ORDER BY`;
- after the migration **every** eviction shape — global, per-app (`build_key_id IN (…)`), and active-exclusion (correlated MAX) on both tables — drops the temp sort onto the index (global is a covering scan). Seeded + `ANALYZE`-d so the stats-driven app-scoped plan is realistic;
- oldest-first reads are unchanged before/after;
- discovery via a full `runMigrations` replay against the real schema;
- idempotent up, reversible/idempotent down, and no disturbance to the retained single-column index.

## Validation

- `bun run typecheck` — no new type errors.
- `bun run lint` — no new violations.
- `bun run build` — ok.
- `bun test` — full suite green (13849 pass, 0 fail).

🤖 Generated with [Claude Code](https://claude.com/claude-code)