### PR TITLE
fix(video): report the recording's actual codec instead of a constant (#4965)

### DIFF
--- a/src/features/video/FfmpegVideoProcessingBackend.ts
+++ b/src/features/video/FfmpegVideoProcessingBackend.ts
@@ -11,6 +11,10 @@ import type { AdbClientFactory } from "../../utils/android-cmdline-tools/AdbClie
 import { SimCtlClient, type SimCtl } from "../../utils/ios-cmdline-tools/SimCtlClient";
 import { logger } from "../../utils/logger";
 import {
+  defaultRecordingCodecProbe,
+  type RecordingCodecProbe,
+} from "./recordingCodec";
+import {
   DefaultFfmpegClient,
   type FfmpegClient,
   type FfmpegProcess,
@@ -360,6 +364,9 @@ export class FfmpegVideoProcessingBackend implements VideoCaptureBackend {
     // Injectable so hardware-accel detection can be tested for every OS branch on
     // any CI host, rather than only the branch matching the runner's platform.
     private readonly platformProvider: () => NodeJS.Platform = platform,
+    // Injectable so the codec label can be asserted from synthetic files without
+    // producing real recordings (#4965).
+    private readonly codecProbe: RecordingCodecProbe = defaultRecordingCodecProbe,
   ) {}
 
   async start(config: VideoCaptureConfig): Promise<RecordingHandle> {
@@ -412,7 +419,10 @@ export class FfmpegVideoProcessingBackend implements VideoCaptureBackend {
     }
 
     const sizeBytes = await getFileSize(handle.outputPath);
-    const codec = "h264";
+    // Report what was actually produced. The iOS `-c copy` fast path preserves
+    // the simctl source (HEVC on modern hardware), while the re-encode branches
+    // emit H.264 — a single constant mislabeled the common case (#4965).
+    const codec = await this.codecProbe.codec(handle.outputPath);
 
     this.logProcessWarnings("capture", backendHandle.captureTracker);
     if (backendHandle.ffmpegTracker) {

--- a/src/features/video/PlatformVideoCaptureBackend.ts
+++ b/src/features/video/PlatformVideoCaptureBackend.ts
@@ -18,6 +18,10 @@ import type {
   VideoCaptureConfig,
 } from "./VideoRecorderService";
 import { ANDROID_SCREENRECORD_MAX_SECONDS } from "./androidScreenrecord";
+import {
+  defaultRecordingCodecProbe,
+  type RecordingCodecProbe,
+} from "./recordingCodec";
 
 interface AndroidBackendHandle {
   kind: "android";
@@ -57,6 +61,9 @@ export class PlatformVideoCaptureBackend implements VideoCaptureBackend {
   constructor(
     private readonly adbFactory: AdbClientFactory = defaultAdbClientFactory,
     private readonly timer: Timer = defaultTimer,
+    // Injectable so the codec label can be asserted from synthetic files without
+    // producing real recordings (#4965).
+    private readonly codecProbe: RecordingCodecProbe = defaultRecordingCodecProbe,
   ) {}
 
   async start(config: VideoCaptureConfig): Promise<RecordingHandle> {
@@ -189,7 +196,10 @@ export class PlatformVideoCaptureBackend implements VideoCaptureBackend {
     // Absolute host path leaks the local username; keep it diagnostic-only.
     logger.debug(`[VideoCapture] Output file at ${handle.outputPath}`);
 
-    const codec = "h264";
+    // Android `screenrecord` emits H.264, so this path was coincidentally
+    // correct — but probe the finalized file rather than trusting a constant, so
+    // the two backends stay honest through the same seam (#4965).
+    const codec = await this.codecProbe.codec(handle.outputPath);
 
     if (backendHandle.exitState.exitCode && backendHandle.exitState.exitCode !== 0) {
       logger.warn(

--- a/src/features/video/recordingCodec.ts
+++ b/src/features/video/recordingCodec.ts
@@ -1,0 +1,185 @@
+import { promises as fsPromises } from "node:fs";
+import { logger } from "../../utils/logger";
+
+/**
+ * Determines the *actual* video codec of a finalized recording file instead of
+ * trusting a hard-coded constant. Both capture backends previously reported
+ * `codec: "h264"` unconditionally, which mislabeled every iOS simulator
+ * recording taken through the fast `-c copy` remux (simctl `recordVideo`
+ * defaults to HEVC on modern hardware, and `-c copy` preserves it) — see
+ * issue #4965. Narrowed to a single `codec()` method so the backends can be
+ * unit-tested with a fake instead of a real file read.
+ */
+export interface RecordingCodecProbe {
+  /**
+   * Resolve the recording's video codec (e.g. `"h264"`, `"hevc"`), or
+   * `undefined` when it cannot be determined. Callers surface `undefined` as
+   * `"unknown"` rather than guessing, so a probe miss never re-introduces a
+   * misleading label.
+   */
+  codec(filePath: string): Promise<string | undefined>;
+}
+
+// ISO-BMFF (MP4/MOV) container boxes that nest the ones below them. We only ever
+// descend into these on the way to `stsd`; everything else (notably the giant
+// `mdat` payload) is skipped by its declared size without being read.
+const CONTAINER_BOX_TYPES = new Set(["moov", "trak", "mdia", "minf", "stbl"]);
+
+// Sample-entry FourCCs → normalized codec name. `avc1`/`avc3` are H.264;
+// `hvc1`/`hev1` are HEVC (H.265). Audio entries (e.g. `mp4a`) are absent on
+// purpose so the walker keeps looking for the video track.
+const FOURCC_TO_CODEC: Readonly<Record<string, string>> = {
+  avc1: "h264",
+  avc3: "h264",
+  hvc1: "hevc",
+  hev1: "hevc",
+};
+
+const BOX_HEADER_SIZE = 8;
+const LARGE_BOX_HEADER_SIZE = 16;
+// version(1) + flags(3) + entry_count(4) precede the sample entries in `stsd`.
+const STSD_ENTRIES_OFFSET = 8;
+
+interface BoxHeader {
+  readonly size: number;
+  readonly type: string;
+  readonly headerSize: number;
+}
+
+/**
+ * Decode the size/type header of a single ISO-BMFF box, resolving the 32-bit
+ * size, the 64-bit `largesize` extension (`size === 1`), and the
+ * extends-to-end sentinel (`size === 0`). Returns `undefined` when there are
+ * not enough bytes for the header or the declared size cannot contain it.
+ */
+function readBoxHeader(view: Buffer, offset: number, available: number, remaining: number): BoxHeader | undefined {
+  if (available < BOX_HEADER_SIZE) {
+    return undefined;
+  }
+  let size = view.readUInt32BE(offset);
+  const type = view.toString("latin1", offset + 4, offset + 8);
+  let headerSize = BOX_HEADER_SIZE;
+
+  if (size === 1) {
+    // 64-bit `largesize` follows the type field.
+    if (available < LARGE_BOX_HEADER_SIZE) {
+      return undefined;
+    }
+    const high = view.readUInt32BE(offset + 8);
+    const low = view.readUInt32BE(offset + 12);
+    size = high * 2 ** 32 + low;
+    headerSize = LARGE_BOX_HEADER_SIZE;
+  } else if (size === 0) {
+    // A declared size of 0 means "to the end of the enclosing box".
+    size = remaining;
+  }
+
+  if (size < headerSize) {
+    return undefined;
+  }
+  return { size, type, headerSize };
+}
+
+/**
+ * Read the first recognized video-codec FourCC out of an in-memory ISO-BMFF
+ * buffer. Pure and synchronous so it can be exercised with tiny synthetic
+ * fixtures. Returns `undefined` when the buffer is not a recognizable container
+ * or carries no known video sample entry.
+ */
+export function parseMp4VideoCodec(buffer: Buffer): string | undefined {
+  return findVideoCodecInBoxes(buffer, 0, buffer.length);
+}
+
+function findVideoCodecInBoxes(buffer: Buffer, start: number, end: number): string | undefined {
+  let offset = start;
+  while (offset + BOX_HEADER_SIZE <= end) {
+    const header = readBoxHeader(buffer, offset, end - offset, end - offset);
+    if (!header || offset + header.size > end) {
+      return undefined;
+    }
+
+    const payloadStart = offset + header.headerSize;
+    const payloadEnd = offset + header.size;
+
+    if (CONTAINER_BOX_TYPES.has(header.type)) {
+      const found = findVideoCodecInBoxes(buffer, payloadStart, payloadEnd);
+      if (found) {
+        return found;
+      }
+    } else if (header.type === "stsd") {
+      const found = parseSampleDescription(buffer, payloadStart, payloadEnd);
+      if (found) {
+        return found;
+      }
+    }
+
+    offset += header.size;
+  }
+  return undefined;
+}
+
+function parseSampleDescription(buffer: Buffer, start: number, end: number): string | undefined {
+  let offset = start + STSD_ENTRIES_OFFSET;
+  while (offset + BOX_HEADER_SIZE <= end) {
+    const entry = readBoxHeader(buffer, offset, end - offset, end - offset);
+    if (!entry || offset + entry.size > end) {
+      return undefined;
+    }
+    const codec = FOURCC_TO_CODEC[entry.type.toLowerCase()];
+    if (codec) {
+      return codec;
+    }
+    offset += entry.size;
+  }
+  return undefined;
+}
+
+/**
+ * Read only the `moov` box out of a recording file to determine its video
+ * codec, seeking past the (potentially very large) `mdat` payload rather than
+ * loading the whole file into memory. Both capture backends write
+ * `-movflags +faststart`, so `moov` precedes `mdat`, but this walker does not
+ * rely on that ordering — it scans top-level boxes until it finds `moov`.
+ */
+async function readRecordingVideoCodec(filePath: string): Promise<string | undefined> {
+  const handle = await fsPromises.open(filePath, "r");
+  try {
+    const { size: fileSize } = await handle.stat();
+    const header = Buffer.alloc(LARGE_BOX_HEADER_SIZE);
+    let position = 0;
+
+    while (position + BOX_HEADER_SIZE <= fileSize) {
+      const { bytesRead } = await handle.read(header, 0, LARGE_BOX_HEADER_SIZE, position);
+      const box = readBoxHeader(header, 0, bytesRead, fileSize - position);
+      if (!box) {
+        return undefined;
+      }
+
+      if (box.type === "moov") {
+        const available = Math.min(box.size, fileSize - position);
+        const moov = Buffer.alloc(available);
+        await handle.read(moov, 0, available, position);
+        return findVideoCodecInBoxes(moov, box.headerSize, available);
+      }
+
+      position += box.size;
+    }
+    return undefined;
+  } finally {
+    await handle.close();
+  }
+}
+
+export const defaultRecordingCodecProbe: RecordingCodecProbe = {
+  async codec(filePath: string): Promise<string | undefined> {
+    try {
+      return await readRecordingVideoCodec(filePath);
+    } catch (error) {
+      // Best-effort metadata: the recording itself is valid and already
+      // persisted. A probe failure yields `undefined` (surfaced as "unknown"),
+      // never a guessed codec. Warn so a systematic parse failure is visible.
+      logger.warn(`[RecordingCodec] Failed to probe codec for ${filePath}: ${error}`, error);
+      return undefined;
+    }
+  },
+};

--- a/test/features/video/PlatformVideoCaptureBackend.test.ts
+++ b/test/features/video/PlatformVideoCaptureBackend.test.ts
@@ -344,6 +344,32 @@ describe("PlatformVideoCaptureBackend - Unit Tests", () => {
       expect(result.recordingId).toBe("test-stop-sequence");
     });
 
+    test("reports the probed codec instead of a hard-coded constant (#4965)", async () => {
+      const fakeFactory = new FakeAdbClientFactory();
+      const fakeTimer = new FakeTimer();
+      fakeTimer.enableAutoAdvance();
+
+      const probedPaths: string[] = [];
+      const codecProbe = {
+        async codec(filePath: string): Promise<string | undefined> {
+          probedPaths.push(filePath);
+          return "h264";
+        },
+      };
+      const backend = new PlatformVideoCaptureBackend(fakeFactory, fakeTimer, codecProbe);
+      const fakeProcess = new FakeChildProcess();
+      fakeProcess.exitCode = 0;
+
+      const outputPath = path.join(tempDir, "probed.mp4");
+      await fsPromises.writeFile(outputPath, Buffer.alloc(64, 1));
+      const handle = buildAndroidStopHandle(outputPath, fakeProcess);
+
+      const result = await backend.stop(handle);
+
+      expect(result.codec).toBe("h264");
+      expect(probedPaths).toEqual([outputPath]);
+    });
+
     test("still removes the /sdcard temp file when the pull itself fails", async () => {
       const fakeFactory = new FakeAdbClientFactory();
       const fakeClient = fakeFactory.getFakeClient();

--- a/test/features/video/recordingCodec.test.ts
+++ b/test/features/video/recordingCodec.test.ts
@@ -1,0 +1,122 @@
+import { afterEach, beforeEach, describe, expect, test } from "bun:test";
+import { promises as fsPromises } from "node:fs";
+import os from "node:os";
+import path from "node:path";
+import {
+  defaultRecordingCodecProbe,
+  parseMp4VideoCodec,
+} from "../../../src/features/video/recordingCodec";
+
+/** Build an ISO-BMFF box: [uint32 size][4-char type][payload]. */
+function box(type: string, ...children: Buffer[]): Buffer {
+  const payload = Buffer.concat(children);
+  const header = Buffer.alloc(8);
+  header.writeUInt32BE(8 + payload.length, 0);
+  header.write(type, 4, "latin1");
+  return Buffer.concat([header, payload]);
+}
+
+/** A `stsd` box wrapping the given sample-entry boxes. */
+function stsd(...entries: Buffer[]): Buffer {
+  const preamble = Buffer.alloc(8); // version(1) + flags(3) + entry_count(4)
+  preamble.writeUInt32BE(entries.length, 4);
+  return box("stsd", preamble, ...entries);
+}
+
+/** A sample-entry box whose FourCC type carries the codec identity. */
+function sampleEntry(fourcc: string): Buffer {
+  // Real sample entries carry reserved fields; the parser only reads the header,
+  // so any payload length is fine.
+  return box(fourcc, Buffer.alloc(16));
+}
+
+/** Wrap sample-description entries in the moov→trak→…→stbl nesting. */
+function trak(...entries: Buffer[]): Buffer {
+  return box("trak", box("mdia", box("minf", box("stbl", stsd(...entries)))));
+}
+
+function moov(...traks: Buffer[]): Buffer {
+  return box("moov", ...traks);
+}
+
+const FTYP = box("ftyp", Buffer.from("isomiso2", "latin1"));
+
+describe("parseMp4VideoCodec", () => {
+  test("maps an avc1 sample entry to h264", () => {
+    const mp4 = Buffer.concat([FTYP, moov(trak(sampleEntry("avc1"))), box("mdat", Buffer.alloc(8))]);
+    expect(parseMp4VideoCodec(mp4)).toBe("h264");
+  });
+
+  test("maps avc3 to h264", () => {
+    expect(parseMp4VideoCodec(moov(trak(sampleEntry("avc3"))))).toBe("h264");
+  });
+
+  test("maps hvc1 (simctl default) to hevc", () => {
+    const mp4 = Buffer.concat([FTYP, moov(trak(sampleEntry("hvc1"))), box("mdat", Buffer.alloc(8))]);
+    expect(parseMp4VideoCodec(mp4)).toBe("hevc");
+  });
+
+  test("maps hev1 to hevc", () => {
+    expect(parseMp4VideoCodec(moov(trak(sampleEntry("hev1"))))).toBe("hevc");
+  });
+
+  test("skips a leading audio track and finds the video track", () => {
+    const mp4 = moov(trak(sampleEntry("mp4a")), trak(sampleEntry("hvc1")));
+    expect(parseMp4VideoCodec(mp4)).toBe("hevc");
+  });
+
+  test("returns undefined when no known video codec is present", () => {
+    expect(parseMp4VideoCodec(moov(trak(sampleEntry("mp4a"))))).toBeUndefined();
+  });
+
+  test("returns undefined for an empty or non-container buffer", () => {
+    expect(parseMp4VideoCodec(Buffer.alloc(0))).toBeUndefined();
+    expect(parseMp4VideoCodec(Buffer.from("not an mp4 file", "latin1"))).toBeUndefined();
+  });
+
+  test("does not descend into a declared box size that overruns the buffer", () => {
+    // A truncated moov whose declared size exceeds the buffer must not throw.
+    const truncated = moov(trak(sampleEntry("avc1"))).subarray(0, 20);
+    expect(parseMp4VideoCodec(truncated)).toBeUndefined();
+  });
+});
+
+describe("defaultRecordingCodecProbe", () => {
+  let tempDir: string;
+
+  beforeEach(async () => {
+    tempDir = await fsPromises.mkdtemp(path.join(os.tmpdir(), "recording-codec-"));
+  });
+
+  afterEach(async () => {
+    await fsPromises.rm(tempDir, { recursive: true, force: true });
+  });
+
+  test("reads the codec from a finalized file (moov before mdat)", async () => {
+    const filePath = path.join(tempDir, "faststart.mp4");
+    const mp4 = Buffer.concat([FTYP, moov(trak(sampleEntry("hvc1"))), box("mdat", Buffer.alloc(64))]);
+    await fsPromises.writeFile(filePath, mp4);
+    expect(await defaultRecordingCodecProbe.codec(filePath)).toBe("hevc");
+  });
+
+  test("skips a large mdat that precedes moov without misreading its bytes", async () => {
+    const filePath = path.join(tempDir, "mdat-first.mp4");
+    // mdat payload deliberately contains bytes that look like an avc1 stsd, to
+    // prove the walker skips mdat by its declared size rather than scanning it.
+    const decoy = moov(trak(sampleEntry("avc1")));
+    const mdat = box("mdat", decoy);
+    const mp4 = Buffer.concat([FTYP, mdat, moov(trak(sampleEntry("hvc1")))]);
+    await fsPromises.writeFile(filePath, mp4);
+    expect(await defaultRecordingCodecProbe.codec(filePath)).toBe("hevc");
+  });
+
+  test("returns undefined for a non-mp4 file rather than throwing", async () => {
+    const filePath = path.join(tempDir, "bogus.mp4");
+    await fsPromises.writeFile(filePath, Buffer.alloc(4096, 1));
+    expect(await defaultRecordingCodecProbe.codec(filePath)).toBeUndefined();
+  });
+
+  test("returns undefined when the file does not exist rather than throwing", async () => {
+    expect(await defaultRecordingCodecProbe.codec(path.join(tempDir, "missing.mp4"))).toBeUndefined();
+  });
+});


### PR DESCRIPTION
## Summary

Both video capture backends hard-coded `codec: "h264"` in `stop()`, so the reported metadata (and the persisted recording-metadata JSON) misdescribed every recording that did not actually produce H.264. In practice that mislabels **every default-path iOS simulator recording**: `simctl recordVideo` defaults to HEVC on modern hardware, and the finalize step's fast `-c copy` remux preserves that HEVC — but we reported `h264`. Fixes [#4965](https://github.com/kaeawc/auto-mobile/issues/4965).

## What changed

- New shared `src/features/video/recordingCodec.ts`:
  - `RecordingCodecProbe` interface + `defaultRecordingCodecProbe` that reads the **video sample-entry FourCC** from the finalized MP4/ISO-BMFF container (`avc1`/`avc3` → `h264`, `hvc1`/`hev1` → `hevc`). It reads only the `moov` box and seeks past `mdat`, so it never loads the (potentially large) media payload.
  - A pure, synchronous `parseMp4VideoCodec(buffer)` for fixture-based unit tests.
- Wired the probe into both backends through an injectable seam (mirroring the existing `RecordingFileProbe` pattern):
  - `FfmpegVideoProcessingBackend` (the iOS path, and Android when the ffmpeg-pipe env flag is set).
  - `PlatformVideoCaptureBackend` (the default Android `screenrecord` path — coincidentally already H.264, now honest through the same seam).
- A probe miss returns `undefined`, which callers already surface as `"unknown"` (`videoRecordingTools.ts`, DB `codec: string | null`) — so a failed probe never re-introduces a **guessed** label.

## Why probe the container rather than derive from the ffmpeg branch

Deriving the codec from which finalize branch ran (`-c copy` vs re-encode) is cheaper but assumes the simctl source is HEVC. Reading the actual sample-entry FourCC is authoritative for every path and both platforms, which is exactly the robustness the issue asked for, and it needs no new external binary (there is no `ffprobe` wrapper in the codebase — `FfmpegClient` wraps `ffmpeg`).

## Testing

- `test/features/video/recordingCodec.test.ts` (new): FourCC mapping, audio-track-first ordering, `undefined` for non-video/empty/truncated buffers, and file-backed cases including a decoy `mdat` placed before `moov` to prove the walker skips `mdat` by its declared size.
- `PlatformVideoCaptureBackend.test.ts`: added a wiring test asserting `stop()` reports the probed codec and probes the finalized output path.
- `bun test test/features/video/` passes (the one unrelated failure — `should produce playable trimmed output …` — is a pre-existing environmental failure of a real-`ffprobe` duration assertion on this host's ffmpeg 9.0.1; it fails identically on `main` with these changes reverted and does not touch `stop()`/codec).
- `bun run build` passes; `oxlint` on the changed files is clean (the one remaining `complexity` warning is pre-existing in the untouched `waitForRecordingFileReady` and already in the ratchet baseline); `tsc --noEmit` reports no errors in the changed files.

🤖 Generated with [Claude Code](https://claude.com/claude-code) as part of an automated next-best-issue run.