### PR TITLE
fix(desktop): honor daemon socket-path overrides in MCP process detection (#4848)

### DIFF
--- a/android/desktop-core/src/main/kotlin/dev/jasonpearson/automobile/desktop/core/mcp/McpProcessDetector.kt
+++ b/android/desktop-core/src/main/kotlin/dev/jasonpearson/automobile/desktop/core/mcp/McpProcessDetector.kt
@@ -264,15 +264,21 @@ class RealMcpProcessDetector(
     // Match the default /tmp daemon sockets and the configured override path (issue #4848), so a
     // daemon listening on an AUTOMOBILE_DAEMON_SOCKET_PATH override is recognized here rather than
     // only falling through to the first-socket fallback in detectProcesses().
+    //
+    // lsof's NAME field is the trailing column and MAY contain spaces (e.g. a socket under
+    // "Application Support"), so match the override against the whole line's suffix rather than its
+    // last whitespace token. Default /tmp daemon sockets never contain spaces, so the token check
+    // stays correct for them.
     val overridePath = configuredSocketPath()
     return lines
       .mapNotNull { line ->
-        val candidate = line.trim().split(Regex("\\s+")).lastOrNull() ?: return@mapNotNull null
+        val trimmed = line.trim()
         when {
-          candidate.startsWith("/tmp/auto-mobile-daemon") && candidate.endsWith(".sock") ->
-            candidate
-          candidate == overridePath -> candidate
-          else -> null
+          overridePath.isNotEmpty() && trimmed.endsWith(overridePath) -> overridePath
+          else ->
+            trimmed.split(Regex("\\s+")).lastOrNull()?.takeIf {
+              it.startsWith("/tmp/auto-mobile-daemon") && it.endsWith(".sock")
+            }
         }
       }
       .firstOrNull()

--- a/android/desktop-core/src/main/kotlin/dev/jasonpearson/automobile/desktop/core/mcp/McpProcessDetector.kt
+++ b/android/desktop-core/src/main/kotlin/dev/jasonpearson/automobile/desktop/core/mcp/McpProcessDetector.kt
@@ -1,5 +1,6 @@
 package dev.jasonpearson.automobile.desktop.core.mcp
 
+import dev.jasonpearson.automobile.desktop.core.daemon.DaemonSocketPaths
 import java.io.BufferedReader
 import java.io.File
 import java.io.InputStreamReader
@@ -88,20 +89,33 @@ class SystemProcessRunner : ProcessRunner {
   }
 }
 
-/** Checks whether daemon socket files exist in /tmp. */
+/** Checks whether daemon socket files exist. */
 interface SocketFileChecker {
   fun findDaemonSocketFiles(): List<String>
 }
 
-class RealSocketFileChecker : SocketFileChecker {
+/**
+ * Discovers daemon socket files by scanning the default `/tmp` location AND honoring the
+ * `AUTOMOBILE_DAEMON_SOCKET_PATH` / `AUTO_MOBILE_DAEMON_SOCKET_PATH` overrides that the daemon
+ * itself resolves through [DaemonSocketPaths.socketPath]. A daemon started with a socket outside
+ * the default `/tmp/auto-mobile-daemon-*` path would otherwise be invisible to detection, so the
+ * diagnostics health sheet reports "Not Connected" for a daemon that is actually up (issue #4848).
+ */
+class RealSocketFileChecker(
+  private val defaultSocketDir: File = File("/tmp"),
+  private val configuredSocketPath: () -> String = { DaemonSocketPaths.socketPath() },
+) : SocketFileChecker {
   override fun findDaemonSocketFiles(): List<String> {
-    val tmpDir = File("/tmp")
-    if (!tmpDir.isDirectory) return emptyList()
-    return tmpDir
-      .listFiles { f ->
-        f.name.startsWith("auto-mobile-daemon") && f.name.endsWith(".sock")
-      }
-      ?.map { it.absolutePath } ?: emptyList()
+    // LinkedHashSet: preserve scan order while de-duplicating an override that sits under /tmp.
+    val results = LinkedHashSet<String>()
+    if (defaultSocketDir.isDirectory) {
+      defaultSocketDir
+        .listFiles { f -> f.name.startsWith("auto-mobile-daemon") && f.name.endsWith(".sock") }
+        ?.forEach { results.add(it.absolutePath) }
+    }
+    val overrideSocket = File(configuredSocketPath())
+    if (overrideSocket.exists()) results.add(overrideSocket.absolutePath)
+    return results.toList()
   }
 }
 
@@ -110,6 +124,7 @@ class RealMcpProcessDetector(
   private val timeProvider: TimeProvider = SystemTimeProvider,
   private val processRunner: ProcessRunner = SystemProcessRunner(),
   private val socketFileChecker: SocketFileChecker = RealSocketFileChecker(),
+  private val configuredSocketPath: () -> String = { DaemonSocketPaths.socketPath() },
 ) : McpProcessDetector {
 
   override fun detectProcesses(): List<McpProcess> {
@@ -246,11 +261,19 @@ class RealMcpProcessDetector(
     val lines =
       processRunner.runAndReadLines(listOf("lsof", "-p", pid.toString(), "-a", "-U")) ?: return null
 
+    // Match the default /tmp daemon sockets and the configured override path (issue #4848), so a
+    // daemon listening on an AUTOMOBILE_DAEMON_SOCKET_PATH override is recognized here rather than
+    // only falling through to the first-socket fallback in detectProcesses().
+    val overridePath = configuredSocketPath()
     return lines
-      .filter { it.contains("/tmp/auto-mobile-daemon") && it.contains(".sock") }
       .mapNotNull { line ->
-        val parts = line.trim().split(Regex("\\s+"))
-        parts.lastOrNull()?.takeIf { it.startsWith("/tmp/auto-mobile-daemon") }
+        val candidate = line.trim().split(Regex("\\s+")).lastOrNull() ?: return@mapNotNull null
+        when {
+          candidate.startsWith("/tmp/auto-mobile-daemon") && candidate.endsWith(".sock") ->
+            candidate
+          candidate == overridePath -> candidate
+          else -> null
+        }
       }
       .firstOrNull()
   }

--- a/android/desktop-core/src/test/kotlin/dev/jasonpearson/automobile/desktop/core/mcp/McpProcessDetectorTest.kt
+++ b/android/desktop-core/src/test/kotlin/dev/jasonpearson/automobile/desktop/core/mcp/McpProcessDetectorTest.kt
@@ -246,6 +246,37 @@ class McpProcessDetectorTest {
   }
 
   @Test
+  fun `isListeningOnSocket matches an override socket path containing whitespace`() {
+    // lsof's NAME column is the trailing field and can contain spaces; matching the last
+    // whitespace token would drop everything before the space and fall through to the /tmp decoy.
+    val overridePath = "/Users/me/Application Support/auto-mobile.sock"
+    val psRunner =
+      FakeProcessRunner(
+        responses =
+          mapOf(
+            listOf("ps", "-eo", "pid,lstart,command") to
+              listOf("97956 Wed Jan 22 11:00:00 2025 bun /path/to/auto-mobile"),
+            listOf("lsof", "-p", "97956", "-a", "-U") to
+              listOf("bun  97956 jason  17u  unix 0x1234 0t0  $overridePath"),
+          )
+      )
+    val detector =
+      RealMcpProcessDetector(
+        timeProvider = timeProvider,
+        processRunner = psRunner,
+        socketFileChecker =
+          FakeSocketFileChecker(files = listOf("/tmp/auto-mobile-daemon-999.sock", overridePath)),
+        configuredSocketPath = { overridePath },
+      )
+
+    val processes = detector.detectProcesses()
+
+    assertEquals(1, processes.size)
+    assertEquals(McpConnectionType.UnixSocket, processes[0].connectionType)
+    assertEquals(overridePath, processes[0].socketPath)
+  }
+
+  @Test
   fun `RealSocketFileChecker scans the default socket directory`() {
     val dir = newTempDir()
     File(dir, "auto-mobile-daemon-501.sock").createNewFile()

--- a/android/desktop-core/src/test/kotlin/dev/jasonpearson/automobile/desktop/core/mcp/McpProcessDetectorTest.kt
+++ b/android/desktop-core/src/test/kotlin/dev/jasonpearson/automobile/desktop/core/mcp/McpProcessDetectorTest.kt
@@ -1,15 +1,29 @@
 package dev.jasonpearson.automobile.desktop.core.mcp
 
+import java.io.File
+import java.nio.file.Files
 import kotlin.test.assertEquals
 import kotlin.test.assertFalse
 import kotlin.test.assertNotNull
 import kotlin.test.assertNull
 import kotlin.test.assertTrue
+import org.junit.After
 import org.junit.Test
 
 class McpProcessDetectorTest {
 
   private val timeProvider = FakeTimeProvider(currentTime = 1_700_000_000_000L)
+
+  private val tempDirs = mutableListOf<File>()
+
+  private fun newTempDir(): File =
+    Files.createTempDirectory("am-socket-detect").toFile().also { tempDirs += it }
+
+  @After
+  fun cleanUp() {
+    tempDirs.forEach { it.deleteRecursively() }
+    tempDirs.clear()
+  }
 
   @Test
   fun `only the unix-socket transport supports daemon input`() {
@@ -196,6 +210,94 @@ class McpProcessDetectorTest {
     assertEquals(1, processes.size)
     assertEquals(McpConnectionType.UnixSocket, processes[0].connectionType)
     assertEquals("/tmp/auto-mobile-daemon-501.sock", processes[0].socketPath)
+  }
+
+  @Test
+  fun `isListeningOnSocket resolves the configured override path over the first-socket fallback`() {
+    // A daemon on an AUTOMOBILE_DAEMON_SOCKET_PATH override outside /tmp must be recognized by its
+    // actual listening path (issue #4848), not silently mislabeled with the first discovered
+    // socket.
+    val overridePath = "/custom/run/auto-mobile.sock"
+    val psRunner =
+      FakeProcessRunner(
+        responses =
+          mapOf(
+            listOf("ps", "-eo", "pid,lstart,command") to
+              listOf("97956 Wed Jan 22 11:00:00 2025 bun /path/to/auto-mobile"),
+            listOf("lsof", "-p", "97956", "-a", "-U") to
+              listOf("bun  97956 jason  17u  unix 0x1234 0t0  $overridePath"),
+          )
+      )
+    val detector =
+      RealMcpProcessDetector(
+        timeProvider = timeProvider,
+        processRunner = psRunner,
+        // First entry is a decoy so the fallback (firstOrNull) would pick the wrong path.
+        socketFileChecker =
+          FakeSocketFileChecker(files = listOf("/tmp/auto-mobile-daemon-999.sock", overridePath)),
+        configuredSocketPath = { overridePath },
+      )
+
+    val processes = detector.detectProcesses()
+
+    assertEquals(1, processes.size)
+    assertEquals(McpConnectionType.UnixSocket, processes[0].connectionType)
+    assertEquals(overridePath, processes[0].socketPath)
+  }
+
+  @Test
+  fun `RealSocketFileChecker scans the default socket directory`() {
+    val dir = newTempDir()
+    File(dir, "auto-mobile-daemon-501.sock").createNewFile()
+    File(dir, "unrelated.sock").createNewFile()
+    File(dir, "auto-mobile-daemon-501.pid").createNewFile()
+
+    val checker =
+      RealSocketFileChecker(
+        defaultSocketDir = dir,
+        configuredSocketPath = { File(dir, "auto-mobile-daemon-501.sock").absolutePath },
+      )
+
+    assertEquals(
+      listOf(File(dir, "auto-mobile-daemon-501.sock").absolutePath),
+      checker.findDaemonSocketFiles(),
+    )
+  }
+
+  @Test
+  fun `RealSocketFileChecker includes an existing override socket outside the default directory`() {
+    val defaultDir = newTempDir()
+    val overrideDir = newTempDir()
+    File(defaultDir, "auto-mobile-daemon-501.sock").createNewFile()
+    val overrideSock = File(overrideDir, "custom-daemon.sock").apply { createNewFile() }
+
+    val checker =
+      RealSocketFileChecker(
+        defaultSocketDir = defaultDir,
+        configuredSocketPath = { overrideSock.absolutePath },
+      )
+
+    assertEquals(
+      listOf(
+        File(defaultDir, "auto-mobile-daemon-501.sock").absolutePath,
+        overrideSock.absolutePath,
+      ),
+      checker.findDaemonSocketFiles(),
+    )
+  }
+
+  @Test
+  fun `RealSocketFileChecker omits an override socket that does not exist`() {
+    val defaultDir = newTempDir()
+    val overrideDir = newTempDir()
+
+    val checker =
+      RealSocketFileChecker(
+        defaultSocketDir = defaultDir,
+        configuredSocketPath = { File(overrideDir, "missing.sock").absolutePath },
+      )
+
+    assertTrue(checker.findDaemonSocketFiles().isEmpty())
   }
 }
 


### PR DESCRIPTION
## Summary

`RealMcpProcessDetector` (the diagnostics dashboard / health sheet and `McpProcessesPanel`) discovered the daemon only via the default `/tmp/auto-mobile-daemon-*` socket location. When the daemon runs with an `AUTOMOBILE_DAEMON_SOCKET_PATH` / `AUTO_MOBILE_DAEMON_SOCKET_PATH` override that points outside `/tmp`, detection missed it entirely, so the health sheet showed **"Not Connected"** for a daemon that was actually up.

The daemon client already resolves these overrides through `DaemonSocketPaths.socketPath()`. This change makes the detector consult the same source:

- **`RealSocketFileChecker`** now scans the default socket directory **and** includes an existing configured override path (deduped, scan-order preserved). The default directory and the configured-path lookup are constructor-injected.
- **`isListeningOnSocket`** now recognizes the configured override path directly in `lsof` output, instead of only matching the `/tmp/auto-mobile-daemon` prefix and otherwise falling through to the first-socket fallback (which could mislabel the socket path when several exist).

## Testing

`./gradlew :desktop-core:test` (full module, green on `--rerun-tasks`) + `:desktop-core:detekt`. Four new unit tests cover:
- the override path winning over the first-socket fallback in `detectProcesses()`,
- the default-directory scan (temp dir, no real `/tmp`),
- an existing override socket outside the default directory being included,
- a non-existent override being omitted.

All new coverage runs against injected fakes / JUnit temp dirs — no real filesystem or live device.

## Notes

- Commits are unsigned: this `.claude` worktree runs unattended and the 1Password SSH signing agent is locked. The repo does not enforce signed commits.
- The Oxc/TS7 toolchain (oxfmt/oxlint/tsgo) is not installed in `.claude/worktrees` checkouts, so those gates run in CI. This PR touches only Kotlin.

Closes #4848