### PR TITLE
fix(ios): scope PerformanceMonitor CPU/memory metrics by device UDID (#5109)

### DIFF
--- a/src/features/performance/PerformanceMonitor.ts
+++ b/src/features/performance/PerformanceMonitor.ts
@@ -1080,36 +1080,60 @@ export class PerformanceMonitor {
   }
 
   /**
+   * Resolve the host `ps aux` columns for a simulator app process, scoped to a
+   * single simulator.
+   *
+   * iOS Simulator apps run as ordinary macOS processes whose command line is the
+   * app binary under `.../CoreSimulator/Devices/<UDID>/data/...`, so the device
+   * UDID is always present in the process line. Matching on the bundle id alone
+   * (the previous behavior) picked the *first* process on the host, so when the
+   * same bundle runs on two booted simulators both device-keyed snapshots
+   * received the first match's metrics (#5109). Requiring both the device's
+   * UDID (`device.deviceId`) and the bundle id in the same line scopes the match
+   * to this simulator. For a single simulator this is behavior-identical — the
+   * one matching line already contains its own UDID.
+   *
+   * Returns the whitespace-split `ps aux` columns of the matching line, or null
+   * when no process for this device+bundle is found. Caches the resolved PID.
+   */
+  private async resolveIOSProcessColumns(device: MonitoredDevice): Promise<string[] | null> {
+    // Run ps on the HOST (not inside simulator) to find the app process.
+    const { stdout } = await this.execFileAsync("ps", ["aux"]);
+
+    const lines = stdout.split("\n");
+    for (const line of lines) {
+      // Scope to this simulator: the command line carries both the device UDID
+      // (in the CoreSimulator data-container path) and the bundle id.
+      if (line.includes(device.deviceId) && line.includes(device.packageName)) {
+        // ps aux format: USER PID %CPU %MEM VSZ RSS TTY STAT START TIME COMMAND
+        const parts = line.trim().split(/\s+/);
+        const pid = parseInt(parts[1], 10);
+        if (!isNaN(pid) && pid > 0) {
+          device.cachedPid = pid;
+        }
+        return parts;
+      }
+    }
+
+    return null;
+  }
+
+  /**
    * Collect CPU usage for an iOS app.
-   * iOS Simulator apps run as macOS processes, so we use `ps` on the host.
-   * Searches for the process by bundle ID in the command line.
+   * iOS Simulator apps run as macOS processes, so we use `ps` on the host,
+   * scoped to this simulator's UDID (see resolveIOSProcessColumns).
    */
   private async collectIOSCpuMetrics(device: MonitoredDevice): Promise<number | null> {
     try {
-      // Run ps on the HOST (not inside simulator) to find the app process
-      // iOS simulator apps run as macOS processes
-      const { stdout } = await this.execFileAsync("ps", ["aux"]);
-
-      // Find the line with our bundle ID
-      // The process command line contains the bundle ID for iOS apps
-      const lines = stdout.split("\n");
-      for (const line of lines) {
-        if (line.includes(device.packageName)) {
-          // ps aux format: USER PID %CPU %MEM VSZ RSS TTY STAT START TIME COMMAND
-          const parts = line.trim().split(/\s+/);
-          const cpuPercent = parseFloat(parts[2]);
-          if (!isNaN(cpuPercent)) {
-            // Cache the PID while we're at it
-            const pid = parseInt(parts[1], 10);
-            if (!isNaN(pid) && pid > 0) {
-              device.cachedPid = pid;
-            }
-            return Math.min(cpuPercent, 100); // Cap at 100%
-          }
-        }
+      const parts = await this.resolveIOSProcessColumns(device);
+      if (!parts) {
+        return null;
       }
-
-      return null;
+      const cpuPercent = parseFloat(parts[2]);
+      if (isNaN(cpuPercent)) {
+        return null;
+      }
+      return Math.min(cpuPercent, 100); // Cap at 100%
     } catch (error) {
       logger.debug(`[PerformanceMonitor] iOS CPU metrics failed for ${device.deviceId}: ${error}`);
       return null;
@@ -1118,34 +1142,22 @@ export class PerformanceMonitor {
 
   /**
    * Collect memory usage for an iOS app.
-   * iOS Simulator apps run as macOS processes, so we use `ps` on the host.
+   * iOS Simulator apps run as macOS processes, so we use `ps` on the host,
+   * scoped to this simulator's UDID (see resolveIOSProcessColumns).
    * Returns RSS (Resident Set Size) in megabytes.
    */
   private async collectIOSMemoryMetrics(device: MonitoredDevice): Promise<number | null> {
     try {
-      // Run ps on the HOST (not inside simulator) to find the app process
-      const { stdout } = await this.execFileAsync("ps", ["aux"]);
-
-      // Find the line with our bundle ID
-      const lines = stdout.split("\n");
-      for (const line of lines) {
-        if (line.includes(device.packageName)) {
-          // ps aux format: USER PID %CPU %MEM VSZ RSS TTY STAT START TIME COMMAND
-          const parts = line.trim().split(/\s+/);
-          // RSS is in KB on macOS
-          const rssKb = parseInt(parts[5], 10);
-          if (!isNaN(rssKb)) {
-            // Cache the PID while we're at it
-            const pid = parseInt(parts[1], 10);
-            if (!isNaN(pid) && pid > 0) {
-              device.cachedPid = pid;
-            }
-            return rssKb / 1024; // Convert to MB
-          }
-        }
+      const parts = await this.resolveIOSProcessColumns(device);
+      if (!parts) {
+        return null;
       }
-
-      return null;
+      // RSS is in KB on macOS.
+      const rssKb = parseInt(parts[5], 10);
+      if (isNaN(rssKb)) {
+        return null;
+      }
+      return rssKb / 1024; // Convert to MB
     } catch (error) {
       logger.debug(
         `[PerformanceMonitor] iOS memory metrics failed for ${device.deviceId}: ${error}`,

--- a/test/features/performance/PerformanceMonitor.test.ts
+++ b/test/features/performance/PerformanceMonitor.test.ts
@@ -1044,6 +1044,30 @@ function createFakeExecFileAsync(options: {
   };
 }
 
+/**
+ * Build a realistic host `ps aux` line for a simulator app process. Simulator
+ * apps run as macOS processes whose command line is the app binary under the
+ * device's CoreSimulator data container, so the line carries both the device
+ * UDID and the bundle id — the two substrings the device-scoped matcher
+ * requires (#5109).
+ */
+function iosSimPsLine(opts: {
+  pid: number;
+  cpu: number;
+  rssKb: number;
+  deviceId: string;
+  bundleId: string;
+}): string {
+  const command =
+    `/Users/mobile/Library/Developer/CoreSimulator/Devices/${opts.deviceId}` +
+    `/data/Containers/Bundle/Application/6C1FAA48-3F5D-43ED-BCDA-5B57C4331B56` +
+    `/${opts.bundleId}.app/${opts.bundleId}`;
+  return `mobile ${opts.pid} ${opts.cpu}  2.3  1234567 ${opts.rssKb}   ??  Ss   10:00AM   1:23.45 ${command}`;
+}
+
+const IOS_PS_HEADER =
+  "USER     PID %CPU %MEM      VSZ    RSS   TT  STAT STARTED      TIME COMMAND";
+
 describe("PerformanceMonitor iOS", () => {
   let fakeTimer: FakeTimer;
   let fakeAdbFactory: FakeAdbClientFactory;
@@ -1075,9 +1099,9 @@ describe("PerformanceMonitor iOS", () => {
   it("should collect iOS CPU metrics via ps aux", async () => {
     // Set up fake ps aux response on the host
     const fakeExec = createFakeExecFileAsync({
-      stdout: `USER     PID %CPU %MEM      VSZ    RSS   TT  STAT STARTED      TIME COMMAND
+      stdout: `${IOS_PS_HEADER}
 root       1  0.0  0.0   407056   1632   ??  Ss   Mon09AM   0:01.23 /sbin/launchd
-mobile 12345 15.5  2.3  1234567  89012   ??  Ss   10:00AM   1:23.45 com.example.iosapp`
+${iosSimPsLine({ pid: 12345, cpu: 15.5, rssKb: 89012, deviceId: "ios-device-1", bundleId: "com.example.iosapp" })}`
     });
 
     monitor = new PerformanceMonitor(fakeTimer, fakeAdbFactory, serverGetter, fakeSimCtlFactory, fakeExec);
@@ -1096,8 +1120,8 @@ mobile 12345 15.5  2.3  1234567  89012   ??  Ss   10:00AM   1:23.45 com.example.
   it("should collect iOS memory metrics via ps aux (RSS)", async () => {
     // Set up fake ps aux response on the host
     const fakeExec = createFakeExecFileAsync({
-      stdout: `USER     PID %CPU %MEM      VSZ    RSS   TT  STAT STARTED      TIME COMMAND
-mobile 12345 5.0  2.3  1234567 102400   ??  Ss   10:00AM   1:23.45 com.example.iosapp`
+      stdout: `${IOS_PS_HEADER}
+${iosSimPsLine({ pid: 12345, cpu: 5.0, rssKb: 102400, deviceId: "ios-device-1", bundleId: "com.example.iosapp" })}`
     });
 
     monitor = new PerformanceMonitor(fakeTimer, fakeAdbFactory, serverGetter, fakeSimCtlFactory, fakeExec);
@@ -1115,7 +1139,7 @@ mobile 12345 5.0  2.3  1234567 102400   ??  Ss   10:00AM   1:23.45 com.example.i
 
   it("should return null FPS/frame time for iOS (not available)", async () => {
     const fakeExec = createFakeExecFileAsync({
-      stdout: `mobile 12345 5.0  2.3  1234567 102400   ??  Ss   10:00AM   1:23.45 com.example.iosapp`
+      stdout: iosSimPsLine({ pid: 12345, cpu: 5.0, rssKb: 102400, deviceId: "ios-device-1", bundleId: "com.example.iosapp" })
     });
 
     monitor = new PerformanceMonitor(fakeTimer, fakeAdbFactory, serverGetter, fakeSimCtlFactory, fakeExec);
@@ -1166,6 +1190,41 @@ root       1  0.0  0.0   407056   1632   ??  Ss   Mon09AM   0:01.23 /sbin/launch
     const data = fakePusher.getLastPushedData();
     expect(data).toBeDefined();
     expect(data!.metrics.cpuUsagePercent).toBeNull();
+  });
+
+  it("scopes iOS metrics per simulator when two sims run the same bundle (#5109)", async () => {
+    // Same bundle booted on two simulators. The host `ps aux` lists both
+    // processes; each app line carries its own simulator UDID in the
+    // CoreSimulator data-container path. Metrics must be scoped by deviceId,
+    // not resolved to the first matching process.
+    const bundleId = "com.example.iosapp";
+    const udidA = "AAAAAAAA-0000-0000-0000-000000000001";
+    const udidB = "BBBBBBBB-0000-0000-0000-000000000002";
+    const fakeExec = createFakeExecFileAsync({
+      stdout: `${IOS_PS_HEADER}
+${iosSimPsLine({ pid: 111, cpu: 11.0, rssKb: 51200, deviceId: udidA, bundleId })}
+${iosSimPsLine({ pid: 222, cpu: 22.0, rssKb: 204800, deviceId: udidB, bundleId })}`
+    });
+
+    monitor = new PerformanceMonitor(fakeTimer, fakeAdbFactory, serverGetter, fakeSimCtlFactory, fakeExec);
+    monitor.start();
+    monitor.startMonitoring(udidA, bundleId, "ios");
+    monitor.startMonitoring(udidB, bundleId, "ios");
+
+    // Advance far enough to also collect the slow-interval memory metric.
+    await advanceTimeAndWait(fakeTimer, PerformanceMonitor.SLOW_INTERVAL_MS);
+
+    const allData = fakePusher.getPushedData();
+    const dataA = allData.find(d => d.deviceId === udidA);
+    const dataB = allData.find(d => d.deviceId === udidB);
+
+    expect(dataA).toBeDefined();
+    expect(dataB).toBeDefined();
+    // Each device gets its own process's CPU and RSS — not the first match's.
+    expect(dataA!.metrics.cpuUsagePercent).toBe(11.0);
+    expect(dataA!.metrics.memoryUsageMb).toBe(50); // 51200 KB
+    expect(dataB!.metrics.cpuUsagePercent).toBe(22.0);
+    expect(dataB!.metrics.memoryUsageMb).toBe(200); // 204800 KB
   });
 
   describe("performance telemetry emission", () => {


### PR DESCRIPTION
## Summary

Fixes [#5109](https://github.com/kaeawc/auto-mobile/issues/5109). `PerformanceMonitor.collectIOSCpuMetrics` / `collectIOSMemoryMetrics` located the app process with a host-wide `ps aux` search matching **only** the bundle id, ignoring `deviceId`. When the same bundle runs on two booted simulators, both device-keyed snapshots received the *first* matching process's CPU/RSS.

## Fix

iOS Simulator apps run as ordinary macOS processes whose command line is the app binary under `.../CoreSimulator/Devices/<UDID>/data/...`, so the device UDID is always present in the process line (verified against a live simulator on the host). The lookup now requires **both** the device UDID (`deviceId`) and the bundle id in the same `ps` line, scoping each snapshot to its own simulator.

- Single-simulator behavior is unchanged — the one matching line already carries its own UDID.
- The two duplicated `ps`-parsing loops are consolidated into a shared `resolveIOSProcessColumns` helper (which also caches the resolved PID).
- Affects both `perfSnapshot` and the IDE performance stream (the shared sampling path).

## Tests

- Existing iOS `ps aux` fixtures updated to realistic device-scoped CoreSimulator paths (via a new `iosSimPsLine` fixture builder).
- New regression test: two simulators running the same bundle each receive their own CPU (11% vs 22%) and memory (50 MB vs 200 MB) — not the first match's.
- `bun test test/features/performance/PerformanceMonitor.test.ts` → 56 pass / 0 fail. `bun run build` green.

## Notes

- Automated change from the `next-best-issue` scheduled task.
- The local `typecheck` gate could not run in this environment (`@typescript/native-preview`/`tsgo` was not resolvable / fetchable); relying on CI for the typecheck baseline gate. Changes are type-safe by inspection (typed `string[] | null`, guarded indexing).
- The commit is unsigned because the 1Password SSH/signing agent was unavailable in the unattended run; re-sign on review if branch protection requires it.