### PR TITLE
fix(navigation): fire resource-update notifications for session-scoped writes (#4932)

### DIFF
--- a/src/features/navigation/NavigationGraphManager.ts
+++ b/src/features/navigation/NavigationGraphManager.ts
@@ -276,6 +276,16 @@ export class NavigationGraphManager implements NavigationGraphService {
   // growth over a long-lived daemon.
   private static releasedSessions: Set<string> = new Set();
   private static readonly RELEASED_SESSIONS_CAP = 4096;
+  // Graph-update listener attached to every session-scoped instance minted by
+  // getInstanceForSession (#4932). Session managers keep their own listener list
+  // (reset to [] per session), so the resource layer — which attaches its notify
+  // callback only to the global instance via setGraphUpdateListener — never hears
+  // about session-scoped writes. The daemon registers a single (debounced)
+  // callback here at startup; the same callback coalesces notifications across the
+  // global instance and every session. Attached at instance-creation time only:
+  // the daemon registers before any session exists, so retroactive attachment is
+  // unnecessary.
+  private static sessionGraphUpdateListener: (() => void | Promise<void>) | null = null;
 
   private repository: NavigationRepository;
   private testCoverageRepository: TestCoverageRepository;
@@ -396,6 +406,11 @@ export class NavigationGraphManager implements NavigationGraphService {
         return NavigationGraphManager.getInstance();
       }
       instance = new NavigationGraphManager(undefined, undefined, undefined, sessionId);
+      // Attach the resource-layer notify callback so session-scoped writes refresh
+      // the navigation resources, not only writes on the global instance (#4932).
+      if (NavigationGraphManager.sessionGraphUpdateListener) {
+        instance.setGraphUpdateListener(NavigationGraphManager.sessionGraphUpdateListener);
+      }
       NavigationGraphManager.sessionInstances.set(sessionId, instance);
     }
     return instance;
@@ -449,6 +464,9 @@ export class NavigationGraphManager implements NavigationGraphService {
     NavigationGraphManager.instance = null;
     NavigationGraphManager.sessionInstances.clear();
     NavigationGraphManager.releasedSessions.clear();
+    // Clear the process-wide session listener too, so a listener registered by one
+    // test (or the daemon) never leaks into a sibling suite in the same process.
+    NavigationGraphManager.sessionGraphUpdateListener = null;
   }
 
   /**
@@ -1962,6 +1980,20 @@ export class NavigationGraphManager implements NavigationGraphService {
     } else {
       this.graphUpdateListeners.push(listener);
     }
+  }
+
+  /**
+   * Register a graph-update listener that getInstanceForSession attaches to every
+   * session-scoped instance it mints (#4932). Session managers keep their own
+   * per-session listener list, so without this the resource layer's notify
+   * callback — attached only to the global instance — never fires on session-scoped
+   * writes and subscribers retain stale navigation graph/history/apps data. The
+   * daemon registers this once at startup; passing null clears it.
+   */
+  public static setSessionGraphUpdateListener(
+    listener: (() => void | Promise<void>) | null
+  ): void {
+    NavigationGraphManager.sessionGraphUpdateListener = listener;
   }
 
   private notifyGraphUpdated(): void {

--- a/src/server/navigationResources.ts
+++ b/src/server/navigationResources.ts
@@ -315,6 +315,10 @@ export function registerNavigationResources(options: {
   }
 
   attachGraphUpdateListener(getNavigationGraphProvider());
+  // Session-scoped managers (getInstanceForSession) keep their own listener list,
+  // so the global-instance listener above never fires on session-scoped writes.
+  // Register the same debounced callback for every session instance (#4932).
+  NavigationGraphManager.setSessionGraphUpdateListener(scheduleNavigationGraphUpdate);
 
   ResourceRegistry.register(
     NAVIGATION_RESOURCE_URIS.APPS,

--- a/test/features/navigation/NavigationGraphManager.test.ts
+++ b/test/features/navigation/NavigationGraphManager.test.ts
@@ -1257,6 +1257,37 @@ describe("NavigationGraphManager - Multi-session isolation", () => {
     const freshSession = NavigationGraphManager.getInstanceForSession("session-reset");
     expect(freshSession.getCurrentAppId()).toBeNull();
   });
+
+  // #4932: the resource layer attaches its notify callback only to the global
+  // instance, so before this fix a session-scoped write refreshed no navigation
+  // resource. setSessionGraphUpdateListener wires the callback into every session
+  // instance getInstanceForSession mints.
+  test("session-scoped writes fire the registered session graph-update listener (#4932)", async () => {
+    let notified = 0;
+    NavigationGraphManager.setSessionGraphUpdateListener(() => {
+      notified++;
+    });
+
+    const session = NavigationGraphManager.getInstanceForSession("session-notify");
+    // setCurrentApp is a session-scoped write that fires notifyGraphUpdated.
+    await session.setCurrentApp("com.app.notify");
+
+    expect(notified).toBe(1);
+  });
+
+  test("resetInstance clears the process-wide session graph-update listener (#4932)", async () => {
+    let notified = 0;
+    NavigationGraphManager.setSessionGraphUpdateListener(() => {
+      notified++;
+    });
+
+    NavigationGraphManager.resetInstance();
+
+    const session = NavigationGraphManager.getInstanceForSession("session-after-reset");
+    await session.setCurrentApp("com.app.after-reset");
+
+    expect(notified).toBe(0);
+  });
 });
 
 /**


### PR DESCRIPTION
## Problem

Navigation resource update-notifications were wired only to the **global** `NavigationGraphManager` instance. `registerNavigationResources()` attaches its debounced notify callback via `attachGraphUpdateListener(getNavigationGraphProvider())`, which resolves to `NavigationGraphManager.getInstance()`. But normal daemon requests carrying a `sessionUuid` persist navigation through `NavigationGraphManager.getInstanceForSession(...)`, which maintains its **own** `graphUpdateListeners` list (reset to `[]` per session). That session listener list never invoked the resource-update callback.

### Impact

When a session-scoped write created or changed an app graph, subscribers to these resources received no `notifyResourcesUpdated` and retained stale data until a manual re-read:

- `automobile:navigation/graph`
- `automobile:navigation/history`
- `automobile:navigation/apps`

This is the same limitation the pre-existing graph/history notifications already had (not specific to the apps resource). Raised by Codex (P2) on [#4928](https://github.com/kaeawc/auto-mobile/pull/4928).

## Fix

Add `NavigationGraphManager.setSessionGraphUpdateListener(listener)`, a process-wide registration that `getInstanceForSession(...)` attaches to every session instance it mints. The daemon registers the same debounced `scheduleNavigationGraphUpdate` callback once in `registerNavigationResources()`, so notifications coalesce across the global instance and all sessions. `resetInstance()` clears the listener so a registration never leaks into a sibling test suite in the same process.

Attachment is at instance-creation time only: the daemon registers before any session exists, so retroactive attachment to pre-existing instances is unnecessary.

## Tests

Two tests added to the multi-session isolation suite (`NavigationGraphManager.test.ts`), which already backs `getInstanceForSession` with a temp-file DB:

- a session-scoped write (`setCurrentApp`) fires the registered session listener;
- `resetInstance()` clears the process-wide session listener.

## Validation

- `bun test test/features/navigation/NavigationGraphManager.test.ts` — 95 pass
- related daemon/resource suites green
- `bun run lint` — ratchet gate: no new violations
- `bun run typecheck` — no new type errors
- `bun run build` — success

Closes #4932

🤖 Generated with [Claude Code](https://claude.com/claude-code) (autonomous next-best-issue run)