### PR TITLE
fix(desktop): parse all top-level windows in multi-window frames (#4874)

### DIFF
--- a/android/desktop-core/src/main/kotlin/dev/jasonpearson/automobile/desktop/core/layout/HierarchyParser.kt
+++ b/android/desktop-core/src/main/kotlin/dev/jasonpearson/automobile/desktop/core/layout/HierarchyParser.kt
@@ -30,7 +30,7 @@ fun parseHierarchyFromJson(hierarchyJson: JsonElement): ParsedHierarchy? {
     val elementMap = mutableMapOf<String, UIElementInfo>()
     val parentMap = mutableMapOf<String, String>()
 
-    val root = parseNodeElement(nodeElement, 0, 0, elementMap, parentMap) ?: return null
+    val root = parseRoots(nodeElement, elementMap, parentMap) ?: return null
 
     // Extract rotation from the ViewHierarchyResult data
     val rotation = (jsonObj["rotation"] as? JsonPrimitive)?.intOrNull ?: 0
@@ -45,6 +45,92 @@ fun parseHierarchyFromJson(hierarchyJson: JsonElement): ParsedHierarchy? {
     log.warn("Failed to parse hierarchy JSON: ${e.message}", e)
     null
   }
+}
+
+/**
+ * Class name of the synthetic root that wraps a multi-window frame. Android captures often carry
+ * several top-level windows (app + IME + System UI); wrapping them keeps the single-root
+ * [ParsedHierarchy.root] contract while ensuring the tree/diff covers every window (issue #4874).
+ */
+const val MULTI_WINDOW_ROOT_CLASS_NAME = "AutoMobile.MultiWindowRoot"
+
+/**
+ * Parse the top-level `node` element into a single root.
+ *
+ * A frame may expose one window (single object, or a one-element array) or several (array of 2+
+ * windows — app + IME + System UI). A single window is returned unwrapped so existing single-root
+ * behavior is unchanged; 2+ windows are wrapped under a synthetic root so no window is dropped and
+ * a compare/diff covers every window rather than only the first.
+ */
+private fun parseRoots(
+  nodeElement: JsonElement,
+  elementMap: MutableMap<String, UIElementInfo>,
+  parentMap: MutableMap<String, String>,
+): UIElementInfo? {
+  val rootElements =
+    when (nodeElement) {
+      is JsonArray -> nodeElement.toList()
+      is JsonObject -> listOf(nodeElement)
+      else -> return null
+    }
+
+  return when (rootElements.size) {
+    0 -> null
+    // Single window: unwrapped root at depth 0 — identical to the pre-#4874 behavior.
+    1 -> parseNodeElement(rootElements[0], 0, 0, elementMap, parentMap)
+    else -> buildMultiWindowRoot(rootElements, elementMap, parentMap)
+  }
+}
+
+/**
+ * Wrap 2+ top-level windows under a synthetic root at depth 0, each window parsed at depth 1. The
+ * synthetic root's bounds are the union of its windows so it frames the whole capture.
+ */
+private fun buildMultiWindowRoot(
+  rootElements: List<JsonElement>,
+  elementMap: MutableMap<String, UIElementInfo>,
+  parentMap: MutableMap<String, String>,
+): UIElementInfo? {
+  val windows = rootElements.mapIndexedNotNull { index, element ->
+    parseNodeElement(element, 1, index, elementMap, parentMap)
+  }
+  if (windows.isEmpty()) return null
+
+  val bounds =
+    ElementBounds(
+      left = windows.minOf { it.bounds.left },
+      top = windows.minOf { it.bounds.top },
+      right = windows.maxOf { it.bounds.right },
+      bottom = windows.maxOf { it.bounds.bottom },
+    )
+  val id = "multiwindow@d0s0:${bounds.left},${bounds.top}-${bounds.right},${bounds.bottom}"
+
+  val root =
+    UIElementInfo(
+      id = id,
+      className = MULTI_WINDOW_ROOT_CLASS_NAME,
+      resourceId = null,
+      text = null,
+      contentDescription = null,
+      bounds = bounds,
+      isClickable = false,
+      isEnabled = true,
+      isFocused = false,
+      isSelected = false,
+      isScrollable = false,
+      isCheckable = false,
+      isChecked = false,
+      depth = 0,
+      children = windows,
+      extras = emptyMap(),
+      diffState = null,
+    )
+
+  elementMap[id] = root
+  for (window in windows) {
+    parentMap[window.id] = id
+  }
+  return root
 }
 
 /** Parse a node JsonElement which can be either a single node or array of nodes. */

--- a/android/desktop-core/src/test/kotlin/dev/jasonpearson/automobile/desktop/core/layout/HierarchyParserMultiRootTest.kt
+++ b/android/desktop-core/src/test/kotlin/dev/jasonpearson/automobile/desktop/core/layout/HierarchyParserMultiRootTest.kt
@@ -1,0 +1,140 @@
+package dev.jasonpearson.automobile.desktop.core.layout
+
+import kotlin.test.assertEquals
+import kotlin.test.assertNotNull
+import kotlin.test.assertNull
+import kotlin.test.assertTrue
+import kotlinx.serialization.json.Json
+import org.junit.Test
+
+/**
+ * Multi-root coverage for [parseHierarchyFromJson] (issue #4874).
+ *
+ * Android captures often carry several top-level windows in a single frame (app + IME + System UI).
+ * The parser's array branch previously kept only `firstOrNull()`, silently dropping every window
+ * after the first — which made a two-device compare over such a frame omit all but the primary
+ * window and could show a false "Hierarchies match". The fix wraps 2+ roots under a synthetic root
+ * so the tree/diff covers every window, while a single-root frame is returned unwrapped
+ * (unchanged).
+ */
+class HierarchyParserMultiRootTest {
+
+  private fun parse(hierarchyJson: String): ParsedHierarchy {
+    val parsed = parseHierarchyFromJson(Json.parseToJsonElement(hierarchyJson))
+    return assertNotNull(parsed, "hierarchy should parse")
+  }
+
+  @Test
+  fun `parses all top-level windows, not just the first`() {
+    val json =
+      """
+      { "hierarchy": { "node": [
+        { "className": "android.widget.FrameLayout", "resource-id": "app.window",
+          "bounds": { "left": 0, "top": 0, "right": 1080, "bottom": 2000 } },
+        { "className": "android.inputmethodservice.SoftInputWindow", "resource-id": "ime.window",
+          "bounds": { "left": 0, "top": 1400, "right": 1080, "bottom": 2400 } },
+        { "className": "com.android.systemui.StatusBar", "resource-id": "sysui.window",
+          "bounds": { "left": 0, "top": 0, "right": 1080, "bottom": 63 } }
+      ] } }
+      """
+    val root = parse(json).root
+
+    val classNames = root.children.map { it.className }
+    assertEquals(
+      listOf(
+        "android.widget.FrameLayout",
+        "android.inputmethodservice.SoftInputWindow",
+        "com.android.systemui.StatusBar",
+      ),
+      classNames,
+      "every top-level window must survive parsing",
+    )
+  }
+
+  @Test
+  fun `synthetic root spans the union of every window's bounds`() {
+    val json =
+      """
+      { "hierarchy": { "node": [
+        { "className": "app", "resource-id": "a",
+          "bounds": { "left": 10, "top": 20, "right": 500, "bottom": 900 } },
+        { "className": "ime", "resource-id": "b",
+          "bounds": { "left": 0, "top": 1400, "right": 1080, "bottom": 2400 } }
+      ] } }
+      """
+    val root = parse(json).root
+    assertEquals(ElementBounds(left = 0, top = 20, right = 1080, bottom = 2400), root.bounds)
+  }
+
+  @Test
+  fun `synthetic root and its windows are indexed for lookup and parent traversal`() {
+    val json =
+      """
+      { "hierarchy": { "node": [
+        { "className": "app", "resource-id": "a", "bounds": { "left": 0, "top": 0, "right": 10, "bottom": 10 } },
+        { "className": "ime", "resource-id": "b", "bounds": { "left": 0, "top": 0, "right": 10, "bottom": 10 } }
+      ] } }
+      """
+    val parsed = parse(json)
+    val root = parsed.root
+
+    // The synthetic root and both windows are in the element map.
+    assertNotNull(parsed.elementMap[root.id], "synthetic root must be indexed")
+    for (window in root.children) {
+      assertEquals(window, parsed.elementMap[window.id], "each window must be indexed")
+      assertEquals(
+        root.id,
+        parsed.parentMap[window.id],
+        "each window's parent must be the synthetic root",
+      )
+    }
+    // The synthetic root itself has no parent.
+    assertNull(parsed.parentMap[root.id], "synthetic root has no parent")
+  }
+
+  @Test
+  fun `windows under the synthetic root sit one level deeper`() {
+    val json =
+      """
+      { "hierarchy": { "node": [
+        { "className": "app", "resource-id": "a", "bounds": { "left": 0, "top": 0, "right": 10, "bottom": 10 } },
+        { "className": "ime", "resource-id": "b", "bounds": { "left": 0, "top": 0, "right": 10, "bottom": 10 } }
+      ] } }
+      """
+    val root = parse(json).root
+    assertEquals(0, root.depth, "synthetic root is at depth 0")
+    assertTrue(
+      root.children.all { it.depth == 1 },
+      "windows sit at depth 1 under the synthetic root",
+    )
+  }
+
+  @Test
+  fun `single-window frame is returned unwrapped`() {
+    val json =
+      """
+      { "hierarchy": { "node": {
+        "className": "android.widget.FrameLayout", "resource-id": "only.window",
+        "bounds": { "left": 0, "top": 0, "right": 1080, "bottom": 2400 }
+      } } }
+      """
+    val root = parse(json).root
+    // No synthetic wrapper: the real window is the root.
+    assertEquals("android.widget.FrameLayout", root.className)
+    assertEquals(0, root.depth)
+  }
+
+  @Test
+  fun `single-element array is returned unwrapped`() {
+    val json =
+      """
+      { "hierarchy": { "node": [
+        { "className": "android.widget.FrameLayout", "resource-id": "only.window",
+          "bounds": { "left": 0, "top": 0, "right": 1080, "bottom": 2400 } }
+      ] } }
+      """
+    val root = parse(json).root
+    assertEquals("android.widget.FrameLayout", root.className)
+    assertEquals(0, root.depth)
+  }
+}


### PR DESCRIPTION
## Summary

`HierarchyParser.parseHierarchyFromJson`'s array branch parsed only `firstOrNull()` of a multi-root frame. Android captures often carry several top-level windows in one frame (app + IME + System UI — e.g. `test/fixtures/observe/diff/text-input-empty.json`, which has 3 roots), so every window after the first was silently dropped.

Surfaced by two-device compare ([#4866](https://github.com/kaeawc/auto-mobile/issues/4866) / [PR #4871](https://github.com/kaeawc/auto-mobile/pull/4871)): a diff over such a frame omitted all but the primary window and could show a false "Hierarchies match". Also affects the Layout Inspector, which uses the same parser. Pre-existing parser behavior.

## Fix

Wrap **2+ top-level windows** under a synthetic root (`AutoMobile.MultiWindowRoot`, bounds = union of its windows) so the tree/diff covers every window. A **single window** (single object, or a one-element array) is returned **unwrapped** at depth 0, so existing single-root behavior — and every existing single-root test — is unchanged.

Consumers (`HierarchyTreeView` / compare / inspector) render and diff `ParsedHierarchy.root` recursively, so the synthetic root and its windows flow through with **no consumer change needed**. The synthetic root and its windows are added to `elementMap`/`parentMap` so lookup and parent traversal keep working.

## Tests

New `HierarchyParserMultiRootTest`:
- all top-level windows survive parsing (not just the first)
- synthetic root spans the union of every window's bounds
- synthetic root + windows are indexed for lookup and parent traversal
- windows sit one level deeper (depth 1) under the depth-0 synthetic root
- single-window frame and single-element array are returned unwrapped

Full `:desktop-core:test` module is green; ktfmt (`--google-style`) clean.

Closes #4874