### PR TITLE
build(android): extract shared android-app-signing convention (#5072)

### DIFF
--- a/android/build-logic/src/main/kotlin/automobile.android-app-signing.gradle.kts
+++ b/android/build-logic/src/main/kotlin/automobile.android-app-signing.gradle.kts
@@ -1,0 +1,61 @@
+import com.android.build.api.dsl.ApplicationExtension
+import java.io.File
+import org.gradle.kotlin.dsl.configure
+
+// Shared release-signing convention for AutoMobile's Android application modules
+// (control-proxy and playground/app), replacing the byte-identical signing block
+// each carried. Keystore coordinates come from the environment (CI) or
+// gradle.properties (local); when a complete keystore is present the release cert
+// is used, otherwise both build types fall back to debug signing — behavior
+// identical to the per-module blocks this replaces. Keystore paths resolve
+// against rootDir (build-level info, Isolated-Projects safe) rather than the
+// rootProject model. isMinifyEnabled/proguardFiles stay in the modules.
+
+val releaseStoreFilePath: String? =
+  System.getenv("RELEASE_KEYSTORE_PATH") ?: findProperty("RELEASE_KEYSTORE_PATH") as String?
+val releaseStorePassword: String? =
+  System.getenv("RELEASE_KEYSTORE_PASSWORD") ?: findProperty("RELEASE_KEYSTORE_PASSWORD") as String?
+val releaseKeyAlias: String? =
+  System.getenv("RELEASE_KEY_ALIAS") ?: findProperty("RELEASE_KEY_ALIAS") as String?
+val releaseKeyPassword: String? =
+  System.getenv("RELEASE_KEY_PASSWORD") ?: findProperty("RELEASE_KEY_PASSWORD") as String?
+val releaseStoreFile: File? = releaseStoreFilePath?.let { path ->
+  val file = File(path)
+  if (file.isAbsolute) file else rootDir.resolve(path)
+}
+val hasReleaseSigning =
+  releaseStoreFile?.exists() == true &&
+    !releaseStorePassword.isNullOrBlank() &&
+    !releaseKeyAlias.isNullOrBlank() &&
+    !releaseKeyPassword.isNullOrBlank()
+
+pluginManager.withPlugin("com.android.application") {
+  extensions.configure<ApplicationExtension> {
+    signingConfigs {
+      create("release") {
+        storeFile = releaseStoreFile
+        storePassword = releaseStorePassword
+        keyAlias = releaseKeyAlias
+        keyPassword = releaseKeyPassword
+      }
+    }
+    buildTypes {
+      getByName("release") {
+        signingConfig =
+          if (hasReleaseSigning) {
+            signingConfigs.getByName("release")
+          } else {
+            signingConfigs.getByName("debug")
+          }
+      }
+      getByName("debug") {
+        signingConfig =
+          if (hasReleaseSigning) {
+            signingConfigs.getByName("release")
+          } else {
+            signingConfigs.getByName("debug")
+          }
+      }
+    }
+  }
+}

--- a/android/control-proxy/build.gradle.kts
+++ b/android/control-proxy/build.gradle.kts
@@ -1,29 +1,10 @@
 plugins {
   id("automobile.kotlin-common")
+  id("automobile.android-app-signing")
   alias(libs.plugins.android.application)
   alias(libs.plugins.kotlin.serialization)
   alias(libs.plugins.compose.compiler)
 }
-
-// Signing configuration: reads from environment variables (CI) or gradle.properties (local)
-// Paths are resolved relative to project root using rootProject.file()
-val releaseStoreFilePath: String? =
-  System.getenv("RELEASE_KEYSTORE_PATH") ?: findProperty("RELEASE_KEYSTORE_PATH") as String?
-val releaseStorePassword: String? =
-  System.getenv("RELEASE_KEYSTORE_PASSWORD") ?: findProperty("RELEASE_KEYSTORE_PASSWORD") as String?
-val releaseKeyAlias: String? =
-  System.getenv("RELEASE_KEY_ALIAS") ?: findProperty("RELEASE_KEY_ALIAS") as String?
-val releaseKeyPassword: String? =
-  System.getenv("RELEASE_KEY_PASSWORD") ?: findProperty("RELEASE_KEY_PASSWORD") as String?
-val releaseStoreFile: File? = releaseStoreFilePath?.let { path ->
-  val file = File(path)
-  if (file.isAbsolute) file else rootProject.file(path)
-}
-val hasReleaseSigning =
-  releaseStoreFile?.exists() == true &&
-    !releaseStorePassword.isNullOrBlank() &&
-    !releaseKeyAlias.isNullOrBlank() &&
-    !releaseKeyPassword.isNullOrBlank()
 
 android {
   namespace = "dev.jasonpearson.automobile.ctrlproxy"
@@ -40,33 +21,10 @@ android {
     testInstrumentationRunner = "androidx.test.runner.AndroidJUnitRunner"
   }
 
-  signingConfigs {
-    create("release") {
-      storeFile = releaseStoreFile
-      storePassword = releaseStorePassword
-      keyAlias = releaseKeyAlias
-      keyPassword = releaseKeyPassword
-    }
-  }
-
   buildTypes {
     release {
       isMinifyEnabled = false
       proguardFiles(getDefaultProguardFile("proguard-android-optimize.txt"), "proguard-rules.pro")
-      signingConfig =
-        if (hasReleaseSigning) {
-          signingConfigs.getByName("release")
-        } else {
-          signingConfigs.getByName("debug")
-        }
-    }
-    debug {
-      signingConfig =
-        if (hasReleaseSigning) {
-          signingConfigs.getByName("release")
-        } else {
-          signingConfigs.getByName("debug")
-        }
     }
   }
 

--- a/android/playground/app/build.gradle.kts
+++ b/android/playground/app/build.gradle.kts
@@ -1,29 +1,10 @@
 plugins {
   id("automobile.kotlin-common")
+  id("automobile.android-app-signing")
   alias(libs.plugins.android.application)
   alias(libs.plugins.compose.compiler)
   alias(libs.plugins.kotlin.serialization)
 }
-
-// Signing configuration: reads from environment variables (CI) or gradle.properties (local)
-// Paths are resolved relative to project root using rootProject.file()
-val releaseStoreFilePath: String? =
-  System.getenv("RELEASE_KEYSTORE_PATH") ?: findProperty("RELEASE_KEYSTORE_PATH") as String?
-val releaseStorePassword: String? =
-  System.getenv("RELEASE_KEYSTORE_PASSWORD") ?: findProperty("RELEASE_KEYSTORE_PASSWORD") as String?
-val releaseKeyAlias: String? =
-  System.getenv("RELEASE_KEY_ALIAS") ?: findProperty("RELEASE_KEY_ALIAS") as String?
-val releaseKeyPassword: String? =
-  System.getenv("RELEASE_KEY_PASSWORD") ?: findProperty("RELEASE_KEY_PASSWORD") as String?
-val releaseStoreFile: File? = releaseStoreFilePath?.let { path ->
-  val file = File(path)
-  if (file.isAbsolute) file else rootProject.file(path)
-}
-val hasReleaseSigning =
-  releaseStoreFile?.exists() == true &&
-    !releaseStorePassword.isNullOrBlank() &&
-    !releaseKeyAlias.isNullOrBlank() &&
-    !releaseKeyPassword.isNullOrBlank()
 
 android {
   namespace = "dev.jasonpearson.automobile.playground"
@@ -40,33 +21,10 @@ android {
     testInstrumentationRunner = "androidx.test.runner.AndroidJUnitRunner"
   }
 
-  signingConfigs {
-    create("release") {
-      storeFile = releaseStoreFile
-      storePassword = releaseStorePassword
-      keyAlias = releaseKeyAlias
-      keyPassword = releaseKeyPassword
-    }
-  }
-
   buildTypes {
     release {
       isMinifyEnabled = false
       proguardFiles(getDefaultProguardFile("proguard-android-optimize.txt"), "proguard-rules.pro")
-      signingConfig =
-        if (hasReleaseSigning) {
-          signingConfigs.getByName("release")
-        } else {
-          signingConfigs.getByName("debug")
-        }
-    }
-    debug {
-      signingConfig =
-        if (hasReleaseSigning) {
-          signingConfigs.getByName("release")
-        } else {
-          signingConfigs.getByName("debug")
-        }
     }
   }
   compileOptions {


### PR DESCRIPTION
## Summary

Closes #5072.

`control-proxy/build.gradle.kts` and `playground/app/build.gradle.kts` each carried a byte-identical ~35-line release-signing block (keystore env/property reads, `signingConfigs { create("release") { … } }`, and the `signingConfig = if (hasReleaseSigning) release else debug` assignments on both build types). This extracts it into a single `automobile.android-app-signing` precompiled convention in `android/build-logic`, applied via `id("automobile.android-app-signing")` in the two application modules.

While extracting, keystore path resolution moves from `rootProject.file(path)` to `rootDir.resolve(path)` — Isolated-Projects safe, matching the existing [`automobile.detekt`](android/build-logic/src/main/kotlin/automobile.detekt.gradle.kts) convention's `rootDir` usage. `isMinifyEnabled`/`proguardFiles` stay in the modules (no behavior change there).

Net: **+63 / −86** across three files.

## Acceptance criteria

- [x] One `automobile.android-app-signing` convention; the duplicated block is gone from both control-proxy and playground/app.
- [x] `:control-proxy:assembleRelease` and `:playground:app:assembleRelease` sign identically to `main`: with a keystore present the APK is signed with the release cert; with none it falls back to debug signing.
- [x] No behavior change to `isMinifyEnabled`/`proguardFiles` (those stay in the modules).
- [x] IP dry-run still reports zero config-phase problems.

## Validation

Ran locally (JDK 21, Gradle 9.7):

- **No keystore** → `:control-proxy:assembleRelease` + `:playground:app:assembleRelease` both fall back to the debug cert (`CN=AutoMobile, OU=Development, O=Jason Pearson`).
- **`RELEASE_KEYSTORE_*` set** (throwaway keystore) → both APKs sign with the release cert (`CN=RELEASE-TEST-CERT`), confirmed via `apksigner verify -v --print-certs`.
- **IP dry-run** (`--dry-run -Dorg.gradle.unsafe.isolated-projects=true`) on both modules: `BUILD SUCCESSFUL`, zero config-phase problems reported.

---

🤖 Opened by an automated next-best-issue run.