### PR TITLE
fix(desktop): normalize multi-window wrapper in hierarchy compare + namespace per-window IDs

### DIFF
--- a/android/desktop-core/src/main/kotlin/dev/jasonpearson/automobile/desktop/core/layout/HierarchyDiff.kt
+++ b/android/desktop-core/src/main/kotlin/dev/jasonpearson/automobile/desktop/core/layout/HierarchyDiff.kt
@@ -95,10 +95,32 @@ private fun classifyMatched(nodeA: UIElementInfo, nodeB: UIElementInfo?): NodeDi
 /**
  * Build a stable key -> node map in pre-order. Keys are unique within one tree by construction (the
  * per-level sibling index disambiguates siblings, and the ancestor chain disambiguates subtrees).
+ *
+ * The synthetic multi-window wrapper (see [MULTI_WINDOW_ROOT_CLASS_NAME], issue #4874) is
+ * **transparent** to the diff: each window is indexed as if it were a top-level root, keyed by its
+ * window index. Without this, a frame with an extra window (e.g. an IME) is wrapped while the other
+ * side is not, so every node's key gains a `AutoMobile.MultiWindowRoot/…` prefix on only one side
+ * and nothing matches — the whole app reports as OnlyInA/OnlyInB instead of isolating the extra
+ * window. Normalizing both shapes lets a single-window frame (window index 0) still match the first
+ * window of a wrapped multi-window frame, so only the genuinely-extra windows surface.
+ *
+ * Windows are paired positionally (by window index). Known limitation: when both sides are
+ * multi-window and a window is inserted or removed *before* another, the survivors shift index and
+ * their subtrees surface as removed+added. A stable cross-side window identity would fix this, but
+ * none survives to this layer — bounds are excluded by design (resolution differs), and the wire's
+ * only per-window id is a content hash (`src/features/observe/android/StableNodeIdentity.ts`), not
+ * a stable window handle. Tracked as a follow-up; the common single-vs-multi and parallel-window
+ * cases pair correctly.
  */
 private fun indexByPathKey(root: UIElementInfo): LinkedHashMap<String, UIElementInfo> {
   val map = LinkedHashMap<String, UIElementInfo>()
-  addSubtree(map, root, parentKey = "", siblingIndex = 0)
+  if (root.className == MULTI_WINDOW_ROOT_CLASS_NAME) {
+    root.children.forEachIndexed { index, window ->
+      addSubtree(map, window, parentKey = "", siblingIndex = index)
+    }
+  } else {
+    addSubtree(map, root, parentKey = "", siblingIndex = 0)
+  }
   return map
 }
 

--- a/android/desktop-core/src/main/kotlin/dev/jasonpearson/automobile/desktop/core/layout/HierarchyParser.kt
+++ b/android/desktop-core/src/main/kotlin/dev/jasonpearson/automobile/desktop/core/layout/HierarchyParser.kt
@@ -91,8 +91,20 @@ private fun buildMultiWindowRoot(
   elementMap: MutableMap<String, UIElementInfo>,
   parentMap: MutableMap<String, String>,
 ): UIElementInfo? {
-  val windows = rootElements.mapIndexedNotNull { index, element ->
-    parseNodeElement(element, 1, index, elementMap, parentMap)
+  // Each window is parsed at a fixed sibling index (0), not its array position, and with an ID
+  // depth
+  // offset of 1 (the windows sit at tree depth 1 under this synthetic root). A node's ID therefore
+  // depends only on its place *within its own window*: never on where the window sits in the frame,
+  // and never on the extra wrapper level — so a window's IDs are identical whether it is the
+  // unwrapped single-window root (offset 0) or a wrapped multi-window child (offset 1). A surviving
+  // window's IDs stay stable when an unrelated window is added, removed, or re-sorted, and when the
+  // wrapper itself appears/disappears (e.g. the IME opening/closing), which keeps a valid Layout
+  // Inspector selection. Uniqueness across windows is handled by collision disambiguation in
+  // parseJsonObjectNode (two windows can otherwise hold identically-shaped descendants), so only
+  // the
+  // genuinely-indistinguishable nodes take an order-dependent suffix (issue #4874 review).
+  val windows = rootElements.mapNotNull { element ->
+    parseNodeElement(element, 1, 0, elementMap, parentMap, idDepthOffset = 1)
   }
   if (windows.isEmpty()) return null
 
@@ -133,20 +145,26 @@ private fun buildMultiWindowRoot(
   return root
 }
 
-/** Parse a node JsonElement which can be either a single node or array of nodes. */
+/**
+ * Parse a node JsonElement which can be either a single node or array of nodes. [idDepthOffset] is
+ * subtracted from a node's tree depth when forming its ID, so a window's subtree gets
+ * window-relative depths regardless of whether the frame is single- or multi-window.
+ */
 private fun parseNodeElement(
   nodeElement: JsonElement,
   depth: Int,
   siblingIndex: Int,
   elementMap: MutableMap<String, UIElementInfo>,
   parentMap: MutableMap<String, String>,
+  idDepthOffset: Int = 0,
 ): UIElementInfo? {
   return when (nodeElement) {
-    is JsonObject -> parseJsonObjectNode(nodeElement, depth, siblingIndex, elementMap, parentMap)
+    is JsonObject ->
+      parseJsonObjectNode(nodeElement, depth, siblingIndex, elementMap, parentMap, idDepthOffset)
     is JsonArray -> {
       // If it's an array, parse the first element
       nodeElement.firstOrNull()?.let {
-        parseNodeElement(it, depth, siblingIndex, elementMap, parentMap)
+        parseNodeElement(it, depth, siblingIndex, elementMap, parentMap, idDepthOffset)
       }
     }
     else -> null
@@ -160,6 +178,7 @@ private fun parseJsonObjectNode(
   siblingIndex: Int,
   elementMap: MutableMap<String, UIElementInfo>,
   parentMap: MutableMap<String, String>,
+  idDepthOffset: Int = 0,
 ): UIElementInfo {
   // Check if attributes are in "$" or at root level
   val attrs = nodeObj["\$"]?.jsonObject ?: nodeObj
@@ -193,14 +212,26 @@ private fun parseJsonObjectNode(
 
   // Parse children from "node" field
   val childrenElement = nodeObj["node"]
-  val children = parseChildren(childrenElement, depth + 1, elementMap, parentMap)
+  val children = parseChildren(childrenElement, depth + 1, elementMap, parentMap, idDepthOffset)
 
-  // Generate stable ID from depth, sibling index, and bounds — no global counter
-  // so IDs remain stable when nodes are added/removed in unrelated subtrees.
+  // Generate a stable ID. It deliberately encodes no global counter and no window frame position:
+  // - depth is *window-relative* (depth - idDepthOffset), so a node keeps its ID when its window
+  //   moves between the unwrapped single-window root (offset 0) and a wrapped multi-window child
+  //   (offset 1) — e.g. as the IME opens/closes — rather than churning on the extra wrapper level.
+  // - the base prefers resource-id, then content-desc/text, then className, so two different-class
+  //   identity-less nodes get distinct IDs instead of colliding.
+  // If two nodes still generate the same ID — two windows can hold identically-shaped descendants
+  // (issue #4874) — the later one is suffixed so the element/parent maps stay one-to-one; only
+  // these
+  // genuinely-indistinguishable nodes take an order-dependent suffix.
+  val idDepth = depth - idDepthOffset
   val baseId =
-    resourceId ?: contentDesc?.let { "desc:$it" } ?: text?.take(20)?.let { "text:$it" } ?: "view"
+    resourceId ?: contentDesc?.let { "desc:$it" } ?: text?.take(20)?.let { "text:$it" } ?: className
   val id =
-    "$baseId@d${depth}s${siblingIndex}:${bounds.left},${bounds.top}-${bounds.right},${bounds.bottom}"
+    disambiguateId(
+      "$baseId@d${idDepth}s${siblingIndex}:${bounds.left},${bounds.top}-${bounds.right},${bounds.bottom}",
+      elementMap,
+    )
 
   val element =
     UIElementInfo(
@@ -289,20 +320,39 @@ private fun parseChildren(
   parentDepth: Int,
   elementMap: MutableMap<String, UIElementInfo>,
   parentMap: MutableMap<String, String>,
+  idDepthOffset: Int = 0,
 ): List<UIElementInfo> {
   if (childrenElement == null) return emptyList()
 
   return when (childrenElement) {
     is JsonArray -> {
       childrenElement.mapIndexedNotNull { index, elem ->
-        parseNodeElement(elem, parentDepth, index, elementMap, parentMap)
+        parseNodeElement(elem, parentDepth, index, elementMap, parentMap, idDepthOffset)
       }
     }
     is JsonObject -> {
-      listOfNotNull(parseJsonObjectNode(childrenElement, parentDepth, 0, elementMap, parentMap))
+      listOfNotNull(
+        parseJsonObjectNode(childrenElement, parentDepth, 0, elementMap, parentMap, idDepthOffset)
+      )
     }
     else -> emptyList()
   }
+}
+
+/**
+ * Return [base] unchanged if no node with that ID exists yet, otherwise the first free `base#N` (N
+ * starting at 2). Keeps the element/parent maps one-to-one when two nodes would otherwise share a
+ * generated ID — chiefly identically-shaped descendants in different windows of a multi-window
+ * frame (issue #4874). The vast majority of nodes never collide and keep their natural, position-
+ * independent ID.
+ */
+private fun disambiguateId(base: String, elementMap: Map<String, UIElementInfo>): String {
+  if (!elementMap.containsKey(base)) return base
+  var suffix = 2
+  while (elementMap.containsKey("$base#$suffix")) {
+    suffix++
+  }
+  return "$base#$suffix"
 }
 
 /**

--- a/android/desktop-core/src/test/kotlin/dev/jasonpearson/automobile/desktop/core/layout/HierarchyDiffTest.kt
+++ b/android/desktop-core/src/test/kotlin/dev/jasonpearson/automobile/desktop/core/layout/HierarchyDiffTest.kt
@@ -3,6 +3,7 @@ package dev.jasonpearson.automobile.desktop.core.layout
 import dev.jasonpearson.automobile.desktop.domain.ElementBounds
 import org.junit.Assert.assertEquals
 import org.junit.Assert.assertFalse
+import org.junit.Assert.assertNull
 import org.junit.Assert.assertTrue
 import org.junit.Test
 
@@ -225,5 +226,52 @@ class HierarchyDiffTest {
     // Root, then A (both from A's pre-order), then the B-only node appended last.
     assertEquals(NodeDiffStatus.OnlyInB, entries.last().status)
     assertTrue(entries.last().key.contains("Bonly:bo"))
+  }
+
+  /** A synthetic multi-window root as [parseHierarchyFromJson] emits for a 2+ window frame. */
+  private fun multiWindowRoot(vararg windows: UIElementInfo): UIElementInfo =
+    node(MULTI_WINDOW_ROOT_CLASS_NAME, "multiwindow", children = windows.toList())
+
+  @Test
+  fun `wrapped multi-window frame diffed against a single-window frame isolates the extra window`() {
+    // A carries an extra IME window, so the parser wraps it under the synthetic root; B is a plain
+    // single-window frame. The synthetic wrapper must be transparent: the shared app window matches
+    // and only the extra IME window surfaces as OnlyInA — not the whole app as OnlyInA/OnlyInB.
+    val appSubtree =
+      node(
+        "app.Window",
+        "app",
+        children = listOf(node("android.widget.TextView", "title", text = "Hi")),
+      )
+    val a = multiWindowRoot(appSubtree, node("ime.Window", "ime"))
+    val b =
+      node(
+        "app.Window",
+        "app",
+        children = listOf(node("android.widget.TextView", "title", text = "Hi")),
+      )
+
+    val diff = diffHierarchies(a, b)
+
+    assertEquals(NodeDiffStatus.Equal, statusOf(diff, "app.Window:app"))
+    assertEquals(NodeDiffStatus.Equal, statusOf(diff, "TextView:title"))
+    assertEquals(NodeDiffStatus.OnlyInA, statusOf(diff, "ime.Window:ime"))
+    assertEquals(1, diff.onlyInA)
+    assertEquals(0, diff.onlyInB)
+    // The synthetic wrapper never appears as a diff entry on either side.
+    assertNull(statusOf(diff, MULTI_WINDOW_ROOT_CLASS_NAME))
+  }
+
+  @Test
+  fun `two identical wrapped multi-window frames report no differences`() {
+    val a = multiWindowRoot(node("app.Window", "app"), node("ime.Window", "ime"))
+    val b = multiWindowRoot(node("app.Window", "app"), node("ime.Window", "ime"))
+
+    val diff = diffHierarchies(a, b)
+
+    assertFalse(diff.hasDifferences)
+    // Both windows match; the synthetic wrapper is transparent so it is not counted.
+    assertEquals(2, diff.equal)
+    assertNull(statusOf(diff, MULTI_WINDOW_ROOT_CLASS_NAME))
   }
 }

--- a/android/desktop-core/src/test/kotlin/dev/jasonpearson/automobile/desktop/core/layout/HierarchyParserMultiRootTest.kt
+++ b/android/desktop-core/src/test/kotlin/dev/jasonpearson/automobile/desktop/core/layout/HierarchyParserMultiRootTest.kt
@@ -110,6 +110,177 @@ class HierarchyParserMultiRootTest {
   }
 
   @Test
+  fun `identically-shaped descendants in two windows do not collide in the maps`() {
+    // Both windows carry a generic child with no preferred id, sharing depth, sibling index, and
+    // bounds — the exact shape that generated a colliding element id before per-window namespacing.
+    // Each must remain independently resolvable and parented to its own window.
+    val json =
+      """
+      { "hierarchy": { "node": [
+        { "className": "app.Window", "resource-id": "app",
+          "bounds": { "left": 0, "top": 0, "right": 100, "bottom": 100 },
+          "node": { "className": "android.view.View",
+            "bounds": { "left": 0, "top": 0, "right": 100, "bottom": 100 } } },
+        { "className": "overlay.Window", "resource-id": "overlay",
+          "bounds": { "left": 0, "top": 0, "right": 100, "bottom": 100 },
+          "node": { "className": "android.view.View",
+            "bounds": { "left": 0, "top": 0, "right": 100, "bottom": 100 } } }
+      ] } }
+      """
+    val parsed = parse(json)
+    val (appWindow, overlayWindow) = parsed.root.children
+    val appChild = appWindow.children.single()
+    val overlayChild = overlayWindow.children.single()
+
+    // Distinct ids and both survive in the element map (no overwrite).
+    assertTrue(appChild.id != overlayChild.id, "the two windows' children must have distinct ids")
+    assertEquals(appChild, parsed.elementMap[appChild.id], "app window child must be indexed")
+    assertEquals(
+      overlayChild,
+      parsed.elementMap[overlayChild.id],
+      "overlay window child must be indexed",
+    )
+    // Each child's parent traversal resolves to its own window, not the other.
+    assertEquals(appWindow.id, parsed.parentMap[appChild.id])
+    assertEquals(overlayWindow.id, parsed.parentMap[overlayChild.id])
+  }
+
+  @Test
+  fun `a surviving window keeps stable ids when a preceding window disappears`() {
+    // The window namespace is derived from the window's own identity, not its array position, so a
+    // surviving window's descendant ids do not churn when an unrelated window is dropped or the
+    // extractor re-sorts windows by z-order (which would otherwise clear a valid Layout Inspector
+    // selection and mark the whole subtree as changed).
+    val app =
+      """{ "className": "app.Window", "resource-id": "app",
+           "bounds": { "left": 0, "top": 0, "right": 100, "bottom": 100 },
+           "node": { "className": "android.widget.Button", "resource-id": "submit",
+             "bounds": { "left": 10, "top": 10, "right": 90, "bottom": 40 } } }"""
+    val ime =
+      """{ "className": "ime.Window", "resource-id": "ime",
+           "bounds": { "left": 0, "top": 100, "right": 100, "bottom": 200 } }"""
+    val sysui =
+      """{ "className": "sysui.Window", "resource-id": "sysui",
+           "bounds": { "left": 0, "top": 0, "right": 100, "bottom": 20 } }"""
+
+    fun buttonId(frame: ParsedHierarchy): String =
+      frame.elementMap.keys.single { it.contains("submit") }
+
+    // Frame 1: [sysui, app, ime] — app is the middle window. Frame 2: sysui gone, still
+    // multi-window.
+    val before = parse("""{ "hierarchy": { "node": [ $sysui, $app, $ime ] } }""")
+    val after = parse("""{ "hierarchy": { "node": [ $app, $ime ] } }""")
+
+    assertEquals(
+      buttonId(before),
+      buttonId(after),
+      "the app window's descendant ids must not churn when an unrelated window disappears",
+    )
+  }
+
+  @Test
+  fun `windows with no resource-id or class keep stable ids when a preceding window disappears`() {
+    // The real wire shape: production captures (e.g. test/fixtures/observe/diff/text-input-empty
+    // .json, and scroll-before.json which is that frame with the middle window removed) have window
+    // roots with no resource-id and no class, distinguished only by their bounds. A node's id must
+    // not encode the window's frame position, or a surviving window churns when a preceding one
+    // drops. Bounds below mirror those three fixture window roots.
+    fun window(top: Int, bottom: Int, childText: String) =
+      """{ "bounds": { "left": 0, "top": $top, "right": 1080, "bottom": $bottom },
+           "node": { "text": "$childText",
+             "bounds": { "left": 10, "top": ${top + 10}, "right": 90, "bottom": ${top + 40} } } }"""
+    val topWin = window(0, 2400, "T")
+    val midWin = window(63, 2400, "M")
+    val bottomWin = window(0, 63, "B")
+
+    fun idContaining(frame: ParsedHierarchy, marker: String): String =
+      frame.elementMap.keys.single { it.contains("text:$marker") }
+
+    val before = parse("""{ "hierarchy": { "node": [ $topWin, $midWin, $bottomWin ] } }""")
+    val after = parse("""{ "hierarchy": { "node": [ $topWin, $bottomWin ] } }""")
+
+    assertEquals(
+      idContaining(before, "B"),
+      idContaining(after, "B"),
+      "the last window's ids must be stable when the middle window disappears",
+    )
+    assertEquals(
+      idContaining(before, "T"),
+      idContaining(after, "T"),
+      "the first window's ids stay stable too",
+    )
+  }
+
+  @Test
+  fun `a window keeps stable ids when the multi-window wrapper disappears`() {
+    // A 2-window frame (wrapped) becoming a 1-window frame (unwrapped) — e.g. the IME closing. IDs
+    // use window-relative depth, so the surviving window's descendant ids are identical whether the
+    // window is a wrapped multi-window child (depth offset 1) or the unwrapped single-window root
+    // (offset 0), rather than churning because of the extra wrapper level.
+    val app =
+      """{ "className": "app.Window", "resource-id": "app",
+           "bounds": { "left": 0, "top": 0, "right": 100, "bottom": 100 },
+           "node": { "className": "android.widget.Button", "resource-id": "go",
+             "bounds": { "left": 10, "top": 10, "right": 90, "bottom": 40 } } }"""
+    val ime =
+      """{ "className": "ime.Window", "resource-id": "ime",
+           "bounds": { "left": 0, "top": 100, "right": 100, "bottom": 200 } }"""
+
+    fun goId(frame: ParsedHierarchy): String = frame.elementMap.keys.single { it.contains("go@") }
+
+    val multi = parse("""{ "hierarchy": { "node": [ $app, $ime ] } }""")
+    val single = parse("""{ "hierarchy": { "node": [ $app ] } }""")
+
+    assertEquals(
+      goId(multi),
+      goId(single),
+      "the surviving window's ids must not change when the multi-window wrapper disappears",
+    )
+  }
+
+  @Test
+  fun `different-class identity-less nodes in separate windows keep distinct order-independent ids`() {
+    // Two identity-less children (no resource-id/text/content-desc) of different classes sharing
+    // depth, sibling index, and bounds. Including className in the id base keeps them distinct
+    // without an order-dependent #suffix, so a z-order flip cannot silently reassign one node's id
+    // to the other node.
+    val buttonWin =
+      """{ "className": "a.Window", "resource-id": "a",
+           "bounds": { "left": 0, "top": 0, "right": 100, "bottom": 100 },
+           "node": { "className": "android.widget.Button",
+             "bounds": { "left": 5, "top": 5, "right": 95, "bottom": 95 } } }"""
+    val imageWin =
+      """{ "className": "b.Window", "resource-id": "b",
+           "bounds": { "left": 0, "top": 0, "right": 100, "bottom": 100 },
+           "node": { "className": "android.widget.ImageView",
+             "bounds": { "left": 5, "top": 5, "right": 95, "bottom": 95 } } }"""
+
+    fun idFor(frame: ParsedHierarchy, className: String): String =
+      frame.elementMap.keys.single { it.contains("$className@") }
+
+    val forward = parse("""{ "hierarchy": { "node": [ $buttonWin, $imageWin ] } }""")
+    val flipped = parse("""{ "hierarchy": { "node": [ $imageWin, $buttonWin ] } }""")
+
+    // No collision suffix — the two nodes are distinguished by class, not traversal order.
+    assertTrue(
+      !idFor(forward, "android.widget.Button").contains("#"),
+      "distinct-class nodes must not need a collision suffix",
+    )
+    assertTrue(!idFor(forward, "android.widget.ImageView").contains("#"), "no collision suffix")
+    // A z-order flip does not move an id onto the other node.
+    assertEquals(
+      idFor(forward, "android.widget.Button"),
+      idFor(flipped, "android.widget.Button"),
+      "the Button's id must be independent of window order",
+    )
+    assertEquals(
+      idFor(forward, "android.widget.ImageView"),
+      idFor(flipped, "android.widget.ImageView"),
+      "the ImageView's id must be independent of window order",
+    )
+  }
+
+  @Test
   fun `single-window frame is returned unwrapped`() {
     val json =
       """


### PR DESCRIPTION
## Summary

Follow-up to [#5527](https://github.com/kaeawc/auto-mobile/pull/5527) (multi-window parse for [#4874](https://github.com/kaeawc/auto-mobile/issues/4874)), which merged with unaddressed Codex review findings on the synthetic `AutoMobile.MultiWindowRoot` wrapper. This PR fixes the correctness issues and makes generated IDs stable.

### Compare transparency (P1)

`diffHierarchies` keys every node by its full ancestor chain. When one frame is a multi-window capture (wrapped under the synthetic root) and the other is a plain single-window frame (unwrapped), every key on the wrapped side gained a `AutoMobile.MultiWindowRoot/…` prefix the other side lacked — so **nothing matched** and the entire app surfaced as `OnlyInA`/`OnlyInB` instead of isolating the one genuinely-extra window.

**Fix:** `indexByPathKey` treats the synthetic root **transparently** — each window is indexed as if it were a top-level root. A single-window frame still matches the first window of a wrapped multi-window frame, so only the genuinely-extra windows surface.

### Collision-safe, position-independent element IDs (P2)

Two top-level windows can hold descendants with the same preferred id, depth, sibling index, and bounds (e.g. an app window and a full-screen overlay). Those generated **identical** element ids, so parsing the second window overwrote the first in the shared `elementMap`/`parentMap`.

**Fix:** each window is parsed at a **fixed sibling index**, and a node id is disambiguated **only on an actual collision** (`base#2`, `base#3`, …). A node id therefore never encodes the window's frame position, so a surviving window's ids stay **stable** when an unrelated window is added, removed, or re-sorted by z-order (no cleared Layout Inspector selection, no whole-subtree churn). Only genuinely-indistinguishable nodes take an order-dependent suffix. The single-window path is unchanged.

This deliberately avoids two tempting-but-unsound namespaces flagged in review: a **positional prefix** churns on window reorder, and the wire's per-window **`view-id`** is a `sha256` content hash of the subtree (`src/features/observe/android/StableNodeIdentity.ts`), so it churns on any content change.

## Tests

- `HierarchyDiffTest`: asymmetric (multi vs single) compare isolates the extra window; symmetric (multi vs multi) reports no differences; the synthetic wrapper never appears as a diff entry.
- `HierarchyParserMultiRootTest`: cross-window id-collision disambiguation; window-removal id-stability with resource-id windows; and the **real null-identity wire shape** (`text-input-empty.json` / `scroll-before.json` bounds) proving surviving-window ids are stable when the middle window disappears.

## Known limitation (deferred → #5533)

The compare still pairs windows **positionally**. When both sides are multi-window and a window is inserted/removed *before* another, survivors shift index. No stable cross-side window identity survives to this layer (bounds are excluded by design; the only per-window wire id is a content hash). Documented in `indexByPathKey` and tracked in [#5533](https://github.com/kaeawc/auto-mobile/issues/5533). The common single-vs-multi and parallel-window cases pair correctly.

## Validation

- `:desktop-core:test` (full module) — green
- `:desktop-core:detekt` — green
- ktfmt (`scripts/ktfmt/validate_ktfmt.sh`) — clean

## Notes

- Automated follow-up from the Desktop App milestone burn-down. The original PR auto-merged on a CI re-run mid-review, so these findings land as a separate PR.
- Commit is unsigned (1Password SSH/signing agent unavailable in the unattended run); re-sign on review if branch protection requires it.
