### PR TITLE
refactor(utils): route SimCtlClient execFile through the shared exec seam (#5459)

### DIFF
--- a/src/utils/ExecSeam.ts
+++ b/src/utils/ExecSeam.ts
@@ -31,6 +31,19 @@ export interface ExecRequestOptions {
   signal?: AbortSignal;
 }
 
+/** Behavior toggles for {@link runExecSeam} that do not map to node exec options. */
+export interface ExecSeamBehavior {
+  /**
+   * When true, a thrown exec error propagates unchanged instead of being run
+   * through {@link wrapCommandError}. `wrapCommandError` returns a fresh `Error`
+   * that copies only `.name`, dropping the raw `.code`/`.stderr`; SimCtlClient's
+   * CoreSimulator-405 boot recovery (issue #3938 / #4092) reads exactly those
+   * fields, so that client opts into raw-error propagation while still sharing
+   * the seam's option mapping and {@link createExecResult} coercion.
+   */
+  preserveError?: boolean;
+}
+
 /**
  * Shared exec runner: maps request options to node exec option names, invokes
  * the executor's exec seam (shell string vs. file+argv, supplied by the
@@ -42,7 +55,8 @@ export interface ExecRequestOptions {
 export async function runExecSeam(
   invoke: (options: ExecSeamOptions) => Promise<RawExecOutput>,
   options: ExecRequestOptions,
-  errorContext: CommandErrorFormatOptions
+  errorContext: CommandErrorFormatOptions,
+  behavior: ExecSeamBehavior = {}
 ): Promise<ExecResult> {
   try {
     const { stdout, stderr } = await invoke({
@@ -53,6 +67,9 @@ export async function runExecSeam(
     });
     return createExecResult(stdout, stderr);
   } catch (error) {
+    if (behavior.preserveError) {
+      throw error;
+    }
     throw wrapCommandError(error, errorContext);
   }
 }

--- a/src/utils/HostCommandExecutor.ts
+++ b/src/utils/HostCommandExecutor.ts
@@ -28,7 +28,12 @@ export type ExecFileAsync = (
   options?: ExecSeamOptions
 ) => Promise<RawExecOutput>;
 
-const execFileAsync: ExecFileAsync = async (
+/**
+ * Shared `execFile` leaf for the host-command seam. Exported so argv-first
+ * clients (e.g. `SimCtlClient`) can run their exec leg through {@link runExecSeam}
+ * without importing `child_process` themselves (issue #5459).
+ */
+export const execFileAsync: ExecFileAsync = async (
   file: string,
   args: string[],
   options?: ExecSeamOptions

--- a/src/utils/ios-cmdline-tools/SimCtlClient.ts
+++ b/src/utils/ios-cmdline-tools/SimCtlClient.ts
@@ -1,12 +1,15 @@
 import { errorMessage } from "../describeUnknownError";
-import { ChildProcess, execFile, type SpawnOptions } from "child_process";
-import { promisify } from "util";
+import { ChildProcess, type SpawnOptions } from "child_process";
 import { promises as fsPromises } from "fs";
 import { tmpdir } from "os";
 import { join } from "path";
 import { logger } from "../logger";
-import { createExecResult } from "../execResult";
-import { DefaultHostCommandExecutor, type HostProcessExecutor } from "../HostCommandExecutor";
+import { runExecSeam } from "../ExecSeam";
+import {
+  DefaultHostCommandExecutor,
+  execFileAsync as sharedExecFileAsync,
+  type HostProcessExecutor,
+} from "../HostCommandExecutor";
 import { ExecResult, ActionableError, DeviceInfo, BootedDevice, ScreenSize } from "../../models";
 import { defaultTimer, Timer } from "../SystemTimer";
 import { createGlobalPerformanceTracker } from "../PerformanceTracker";
@@ -283,30 +286,31 @@ export interface SimCtl {
   ): Promise<{ success: boolean; error?: string }>;
 }
 
-// Enhance the standard execAsync result to implement the ExecResult interface
+// Route the execFile leg through the shared exec seam (issue #5459) so the
+// option mapping and the Buffer→string / trim / includes coercion live in one
+// place and this client no longer imports `child_process` for its exec path.
+//
+// `preserveError: true` keeps the raw execFile rejection intact: the seam's
+// default `wrapCommandError` path returns a fresh Error copying only `.name`,
+// but CoreSimulator-405 boot recovery (issue #3938 / #4092) branches on the
+// original error's `.code`/`.stderr` via `isAlreadyBootedCoreSimulator405`.
+//
+// The AbortSignal is forwarded so that when a caller's timeout aborts, Node kills
+// the child process (SIGTERM) instead of leaving it booting orphaned (issue
+// #3938) — without this a timed-out `bootstatus -b` keeps booting the simulator
+// in the background after the tool has already reported failure.
 const execAsync = async (
   file: string,
   args: string[],
   maxBuffer?: number,
   signal?: AbortSignal,
 ): Promise<ExecResult> => {
-  // Pass the AbortSignal to execFile so that when a caller's timeout aborts, Node
-  // kills the child process (SIGTERM) instead of leaving it running orphaned
-  // (issue #3938). Without this a timed-out `bootstatus -b` keeps booting the
-  // simulator in the background after the tool has already reported failure.
-  const options: Parameters<typeof execFile>[2] =
-    maxBuffer && signal
-      ? { maxBuffer, signal }
-      : maxBuffer
-        ? { maxBuffer }
-        : signal
-          ? { signal }
-          : undefined;
-  const result = await promisify(execFile)(file, args, options);
-
-  const stdout = typeof result.stdout === "string" ? result.stdout : result.stdout.toString();
-  const stderr = typeof result.stderr === "string" ? result.stderr : result.stderr.toString();
-  return createExecResult(stdout, stderr);
+  return runExecSeam(
+    execOptions => sharedExecFileAsync(file, args, execOptions),
+    { maxBuffer, signal },
+    { command: file, args },
+    { preserveError: true },
+  );
 };
 
 // Route the default long-lived spawn through the shared host-process seam so the

--- a/test/utils/ExecSeam.test.ts
+++ b/test/utils/ExecSeam.test.ts
@@ -12,6 +12,19 @@ import {
 
 const FAST_TEST_TIMEOUT_MS = 100;
 
+type NodeExecError = Error & { code?: number; stderr?: string; stdout?: string };
+
+// A stand-in for the raw node execFile rejection SimCtlClient's boot recovery
+// inspects: CoreSimulator returns SimError 405 with the device already Booted.
+function coreSimulator405Error(): NodeExecError {
+  const error = new Error("Command failed: xcrun simctl bootstatus <udid> -b") as NodeExecError;
+  error.code = 149;
+  error.stderr =
+    "Unable to boot device in current state: Booted " +
+    "(domain=com.apple.CoreSimulator.SimError, code=405)";
+  return error;
+}
+
 // The canonical ExecResult factory is the single place exec output is coerced
 // (Buffer→string) for both executors; the exec-seam paths delegate to it.
 describe("createExecResult (canonical exec-seam coercion)", function() {
@@ -71,6 +84,43 @@ describe("runExecSeam", function() {
     ).rejects.toThrow(
       /Command failed: tool arg[\s\S]*cwd: \/work[\s\S]*exit code: 7[\s\S]*stderr:[\s\S]*detailed stderr/
     );
+  }, FAST_TEST_TIMEOUT_MS);
+
+  // The default wrap path returns a fresh Error copying only `.name`, so the raw
+  // `.code`/`.stderr` are lost. This pins that loss so the `preserveError`
+  // contract below is not silently equivalent (issue #5459).
+  test("default path drops the raw error's .code/.stderr", async function() {
+    const original = coreSimulator405Error();
+    let thrown: NodeExecError | undefined;
+    try {
+      await runExecSeam(async () => {
+        throw original;
+      }, {}, { command: "xcrun", args: ["simctl", "bootstatus"] });
+    } catch (error) {
+      thrown = error as NodeExecError;
+    }
+    expect(thrown).toBeDefined();
+    expect(thrown).not.toBe(original);
+    expect(thrown?.code).toBeUndefined();
+    expect(thrown?.stderr).toBeUndefined();
+  }, FAST_TEST_TIMEOUT_MS);
+
+  // SimCtlClient's execFile leg opts into `preserveError` so CoreSimulator-405
+  // boot recovery can still read the original `.code`/`.stderr` after routing
+  // through the shared seam (issue #5459, #3938 / #4092).
+  test("preserveError propagates the original error with .code/.stderr intact", async function() {
+    const original = coreSimulator405Error();
+    let thrown: NodeExecError | undefined;
+    try {
+      await runExecSeam(async () => {
+        throw original;
+      }, {}, { command: "xcrun", args: ["simctl", "bootstatus"] }, { preserveError: true });
+    } catch (error) {
+      thrown = error as NodeExecError;
+    }
+    expect(thrown).toBe(original);
+    expect(thrown?.code).toBe(149);
+    expect(thrown?.stderr).toContain("code=405");
   }, FAST_TEST_TIMEOUT_MS);
 });
 


### PR DESCRIPTION
## What

Routes `SimCtlClient`'s `execFile` leg through the shared exec seam, the remaining scope in [#5459](https://github.com/kaeawc/auto-mobile/issues/5459) after [#5508](https://github.com/kaeawc/auto-mobile/pull/5508) routed the `spawn` leg.

Before, `SimCtlClient`'s module-level `execAsync` hand-rolled `promisify(execFile)` + option shaping + Buffer→string coercion — the last direct `child_process` exec path in the client, one of the three parallel hand-rolled seams the issue calls out.

## How

- **`runExecSeam`** gains an optional `ExecSeamBehavior { preserveError }` (4th arg). When set, a thrown exec error propagates unchanged instead of being wrapped by `wrapCommandError`.
- **`execFileAsync`** is now exported from `HostCommandExecutor` as the shared `execFile` leaf, so argv-first clients can run their exec leg through the seam without importing `child_process`.
- **`SimCtlClient.execAsync`** delegates to `runExecSeam(... , { preserveError: true })` and drops the `execFile`/`promisify` imports.

### Why `preserveError`

The maintainer's [scope-finding comment](https://github.com/kaeawc/auto-mobile/issues/5459#issuecomment) flagged that `SimCtlClient.isAlreadyBootedCoreSimulator405` reads the raw error's `.code`/`.stderr` for CoreSimulator-405 boot recovery ([#3938](https://github.com/kaeawc/auto-mobile/issues/3938) / [#4092](https://github.com/kaeawc/auto-mobile/issues/4092)). The seam's default `wrapCommandError` returns a fresh `Error` copying only `.name`, which would silently break that recovery. `preserveError` is exactly the "mode that preserves `.code`/`.stderr` (no error wrapping)" the issue prescribes. `AbortSignal` forwarding (SIGTERM on timeout) is preserved.

## Tests

`test/utils/ExecSeam.test.ts` pins both halves of the contract:
- the default path **drops** the raw `.code`/`.stderr` (so the toggle isn't a silent no-op), and
- `preserveError` **propagates the original error** with `.code`/`.stderr` intact — the CoreSimulator-405 contract.

## Validation

- `bun run typecheck` — no new type errors
- `bun run lint` — ratchet: no new violations; boundary-checks: 13/13
- `bun run build` — success
- `bun test` — 13915 pass / 0 fail (+2 new)

## Scope note

Per the issue's "one client per commit" guidance, this is the SimCtlClient leg only. AdbClient's `execFile` leg needs an injected-`Timer` timeout that emits a caller-chosen error type (`AdbCommandTimeoutError`, feeding the [#3351](https://github.com/kaeawc/auto-mobile/issues/3351) API-level caching branch) — a larger seam extension left tracked in #5459.

Part of #5459.

🤖 Generated autonomously (next-best-issue scheduled task).