### PR TITLE
fix(android): suppress leaked ADB screencap fallback after AndroidCtrlProxyClient close (#5493)

### DIFF
--- a/src/features/observe/android/AndroidCtrlProxyClient.ts
+++ b/src/features/observe/android/AndroidCtrlProxyClient.ts
@@ -1023,6 +1023,11 @@ export class AndroidCtrlProxyClient extends DeviceServiceClient implements Andro
   // Android-specific state
   private portForwardingSetup: boolean = false;
   private lastWebSocketTimeout: number = 0;
+  // Terminal-close latch (#5493): set once by close() so the best-effort ADB
+  // screencap fallback in captureScreenshotViaAdb() cannot outlive the client.
+  // Distinct from a transient websocket disconnect (onConnectionClosed), which
+  // must still allow the ADB fallback.
+  private closed: boolean = false;
 
   // Delegate instances (lazy initialized)
   private _gestures: CtrlProxyGestures | null = null;
@@ -2961,6 +2966,11 @@ export class AndroidCtrlProxyClient extends DeviceServiceClient implements Andro
   // ===========================================================================
 
   async close(): Promise<void> {
+    // Latch closed BEFORE super.close(): super.close() rejects the in-flight
+    // CtrlProxy screenshot request (requestManager.cancelAll), whose catch falls
+    // through to captureScreenshotViaAdb("ctrlproxy_exception"). Setting the flag
+    // first makes that leaked one-shot fallback short-circuit (#5493).
+    this.closed = true;
     try {
       // Stop work profile monitor if running
       this.stopWorkProfileMonitor();
@@ -4109,6 +4119,14 @@ export class AndroidCtrlProxyClient extends DeviceServiceClient implements Andro
   private async captureScreenshotViaAdb(
     fallbackReason?: ScreenshotFallbackReason,
   ): Promise<ScreenshotCaptureResult> {
+    // Once the client is terminally closed, suppress the signal-less ADB screencap
+    // fallback so a capture rejected by close() cannot keep the transport referenced
+    // past teardown (#5493). A transient websocket disconnect does not set this flag,
+    // so the fallback still fires during reconnect windows.
+    if (this.closed) {
+      return { success: false, error: "AndroidCtrlProxyClient closed; ADB screencap fallback suppressed" };
+    }
+
     // Bind the geometry current when the ADB request begins, before its await can let a newer
     // hierarchy relabel the returned pixels.
     const captureBinding = this.screenGeometry.bind() ?? undefined;

--- a/test/features/observe/android/AndroidCtrlProxyClientCloseSuppressesAdbFallback.test.ts
+++ b/test/features/observe/android/AndroidCtrlProxyClientCloseSuppressesAdbFallback.test.ts
@@ -1,0 +1,81 @@
+import { afterEach, beforeEach, describe, expect, test } from "bun:test";
+import { AndroidCtrlProxyClient } from "../../../../src/features/observe/android";
+import { BootedDevice } from "../../../../src/models";
+import { AndroidCtrlProxyManager } from "../../../../src/utils/CtrlProxyManager";
+import { FakeAdbExecutor } from "../../../fakes/FakeAdbExecutor";
+import { FakeAdbClientFactory } from "../../../fakes/FakeAdbClientFactory";
+import { FakeTimer } from "../../../fakes/FakeTimer";
+import { FakeWebSocket } from "../../../fakes/FakeWebSocket";
+
+// Regression coverage for #5493: when killDevice closes the per-device
+// AndroidCtrlProxyClient, an in-flight screenshot capture must not leak a
+// signal-less ADB screencap fallback that outlives close(). The client latches
+// a `closed` flag in close() so captureScreenshotViaAdb() short-circuits.
+describe("AndroidCtrlProxyClient close() suppresses the ADB screencap fallback", function() {
+  let fakeAdb: FakeAdbExecutor;
+  let fakeTimer: FakeTimer;
+  let testDevice: BootedDevice;
+
+  beforeEach(function() {
+    fakeTimer = new FakeTimer();
+    fakeAdb = new FakeAdbExecutor();
+    fakeAdb.setCommandResponse("forward", { stdout: "8765", stderr: "" });
+    // Configure a *successful* screencap so any fallback that fires would visibly
+    // succeed — the suppression under test is the only reason it must not.
+    fakeAdb.setCommandResponse("screencap", { stdout: "aGVsbG8=", stderr: "" });
+    fakeAdb.setScreenState(true);
+    testDevice = {
+      deviceId: "test-device-close-fallback",
+      platform: "android",
+      isEmulator: true,
+      name: "Test Device",
+    };
+    AndroidCtrlProxyManager.resetInstances();
+    AndroidCtrlProxyClient.resetInstances();
+    AndroidCtrlProxyManager.getInstance(testDevice, new FakeAdbClientFactory()).clearAvailabilityCache();
+  });
+
+  afterEach(async function() {
+    AndroidCtrlProxyClient.resetInstances();
+  });
+
+  function createClient(): AndroidCtrlProxyClient {
+    return AndroidCtrlProxyClient.createForTesting(
+      testDevice,
+      fakeAdb,
+      url => new FakeWebSocket(url, "none", 0, fakeTimer) as unknown as WebSocket,
+      fakeTimer
+    );
+  }
+
+  test("issues no ADB screencap once the client is closed", async function() {
+    const client = createClient();
+    // Force the a11y-unsupported branch so captureScreenshotForObservationStream()
+    // routes straight to the ADB fallback, isolating the guard under test.
+    (client as unknown as { a11yScreenshotSupported: boolean }).a11yScreenshotSupported = false;
+
+    await client.close();
+    fakeAdb.clearHistory();
+
+    const result = await client.captureScreenshotForObservationStream();
+
+    expect(result.success).toBe(false);
+    expect(fakeAdb.wasCommandExecuted("screencap")).toBe(false);
+  });
+
+  test("still falls back to ADB screencap when merely disconnected (not closed)", async function() {
+    const client = createClient();
+    (client as unknown as { a11yScreenshotSupported: boolean }).a11yScreenshotSupported = false;
+
+    try {
+      // No close(): a transient disconnect / never-connected client must still
+      // serve the ADB fallback, proving the suppression is close-specific.
+      const result = await client.captureScreenshotForObservationStream();
+
+      expect(result.success).toBe(true);
+      expect(fakeAdb.wasCommandExecuted("screencap")).toBe(true);
+    } finally {
+      await client.close();
+    }
+  });
+});


### PR DESCRIPTION
## Summary

Fixes #5493 (follow-up from #5491 / #5452).

When `killDevice` closes the per-device `AndroidCtrlProxyClient` while a screenshot capture is in flight, `close()` → `super.close()` (`DeviceServiceClient.close()` → `requestManager.cancelAll`) **rejects** the pending CtrlProxy screenshot request. That rejection is caught in `captureScreenshotForObservationStream` and falls through to `captureScreenshotViaAdb("ctrlproxy_exception")`, a **signal-less, timeout-less one-shot** ADB `screencap` (`this.adb.executeCommand(...)` with no `timeoutMs`/`AbortSignal`) that can outlive `close()` and keep the transport referenced past teardown.

## Fix

Latch a `closed` flag at the **top of `close()`** — before `super.close()`, so the rejection-driven fallback observes it — and short-circuit `captureScreenshotViaAdb` when set. Placing the guard at that single choke point covers every fallback caller (`ctrlproxy_exception`, `websocket_unavailable`, `a11y_screenshot_unsupported`).

The flag is deliberately distinct from a transient websocket disconnect (`onConnectionClosed`), which does **not** set it — so the ADB fallback still fires during normal reconnect windows. This is option 1 from the issue (closed-flag short-circuit), chosen over threading an `AbortSignal` through the hot path as the smaller, lower-risk change.

## Test

`test/features/observe/android/AndroidCtrlProxyClientCloseSuppressesAdbFallback.test.ts` (blocked-fake-ADB + `FakeTimer`), differential:

- **Guard**: after `close()`, `captureScreenshotForObservationStream()` issues **no** `screencap` and returns a failure — even with a *successful* screencap stubbed, so suppression is the only reason it doesn't fire.
- **Positive control**: a non-closed, disconnected client **still** serves the ADB fallback, proving the suppression is close-specific and not a blanket disable.

## Validation

- `bun test test/features/observe/android/` — 160 pass
- `bun run lint` — ratchet clean (no new violations)
- `bun run typecheck` — gate clean (no new type errors)
- `bun run build` — success

## Notes

Autonomous scheduled-task run; the issue specified exact file:line, two fix options, and the required test shape, so no clarifying questions were needed. Chose option 1 (closed flag) per the rationale above.