### PR TITLE
fix(desktop): make Conveyor make-site work end-to-end (signed macOS + Linux)

### DIFF
--- a/.github/workflows/build-desktop-conveyor.yml
+++ b/.github/workflows/build-desktop-conveyor.yml
@@ -179,6 +179,8 @@ jobs:
         uses: actions/upload-artifact@v4
         with:
           name: automobile-desktop-conveyor
-          path: android/output
+          # Conveyor writes `make site` output to ./output relative to the CWD (the repo root the
+          # action runs from), not the -f config's directory.
+          path: output
           if-no-files-found: error
           retention-days: 7

--- a/.github/workflows/build-desktop-conveyor.yml
+++ b/.github/workflows/build-desktop-conveyor.yml
@@ -159,14 +159,15 @@ jobs:
           # config with -f; Conveyor treats the config file's directory (android/) as the project
           # root, so its `./gradlew` include and relative asset paths resolve there. A signed run uses
           # ci.conveyor.conf (Developer ID + notarization over the base); the default self-signs.
-          extra_flags: ${{ inputs.signed && '-f android/ci.conveyor.conf' || '-f android/conveyor.conf' }}
+          # Publish adds the copy-to destination as a -K override so the key is absent (not blank) on
+          # non-publish runs. Signed runs layer ci.conveyor.conf (Developer ID + notarization).
+          extra_flags: >-
+            ${{ inputs.signed && '-f android/ci.conveyor.conf' || '-f android/conveyor.conf' }}${{ inputs.publish && ' -Kapp.site.copy-to=github:kaeawc/auto-mobile' || '' }}
           signing_key: ${{ secrets.CONVEYOR_SIGNING_KEY }}
           agree_to_license: 1
         env:
           CONVEYOR_APP_VERSION: ${{ inputs.version }}
-          # In publish mode, set conveyor.conf's env-gated site.copy-to to this repo's GitHub Releases
-          # and hand Conveyor the token to attach the Sparkle/apt assets. Unset otherwise -> no push.
-          CONVEYOR_SITE_COPY_TO: ${{ inputs.publish && 'github:kaeawc/auto-mobile' || '' }}
+          # Publishing to GitHub Releases needs the token; unset otherwise so no push can happen.
           GITHUB_TOKEN: ${{ inputs.publish && secrets.GITHUB_TOKEN || '' }}
           # The cert password reaches Conveyor as CONVEYOR_MAC_CERTIFICATE_PASSWORD via GITHUB_ENV
           # from the prepare step above (matching ci.conveyor.conf). The notary issuer/key ids are

--- a/.github/workflows/build-desktop-conveyor.yml
+++ b/.github/workflows/build-desktop-conveyor.yml
@@ -162,7 +162,7 @@ jobs:
           # Publish adds the copy-to destination as a -K override so the key is absent (not blank) on
           # non-publish runs. Signed runs layer ci.conveyor.conf (Developer ID + notarization).
           extra_flags: >-
-            ${{ inputs.signed && '-f android/ci.conveyor.conf' || '-f android/conveyor.conf' }}${{ inputs.publish && ' -Kapp.site.copy-to=github:kaeawc/auto-mobile' || '' }}
+            ${{ inputs.signed && '-f android/ci.conveyor.conf --passphrase env:CONVEYOR_MAC_CERTIFICATE_PASSWORD' || '-f android/conveyor.conf' }}${{ inputs.publish && ' -Kapp.site.copy-to=github:kaeawc/auto-mobile' || '' }}
           signing_key: ${{ secrets.CONVEYOR_SIGNING_KEY }}
           agree_to_license: 1
         env:

--- a/android/ci.conveyor.conf
+++ b/android/ci.conveyor.conf
@@ -21,9 +21,10 @@ app {
 
   mac {
     // Reuse the existing Developer ID Application identity rather than a Conveyor-generated one.
-    // The workflow decodes MACOS_DEVELOPER_ID_CERT_BASE64 to a .p12 and exports its path + password.
+    // The workflow decodes MACOS_DEVELOPER_ID_CERT_BASE64 to this .p12. The p12 is passphrase-
+    // protected; Conveyor takes the passphrase from the `--passphrase env:CONVEYOR_MAC_CERTIFICATE_
+    // PASSWORD` CLI flag the workflow passes (not a config key).
     certificate = ${?env.CONVEYOR_MAC_CERTIFICATE_P12}
-    certificate-password = ${?env.CONVEYOR_MAC_CERTIFICATE_PASSWORD}
 
     // Notarize with the App Store Connect API key already used by the jpackage flow
     // (APPLE_NOTARY_ISSUER_ID / APPLE_NOTARY_KEY_ID + the .p8 decoded to a file by the workflow).

--- a/android/ci.conveyor.conf
+++ b/android/ci.conveyor.conf
@@ -20,10 +20,13 @@ app {
   sign = true
 
   mac {
-    // Reuse the existing Developer ID Application identity rather than a Conveyor-generated one.
-    // The workflow decodes MACOS_DEVELOPER_ID_CERT_BASE64 to this .p12. The p12 is passphrase-
-    // protected; Conveyor takes the passphrase from the `--passphrase env:CONVEYOR_MAC_CERTIFICATE_
-    // PASSWORD` CLI flag the workflow passes (not a config key).
+    // Reuse the existing Developer ID Application identity rather than a Conveyor-generated one. The
+    // .p12 (decoded from MACOS_DEVELOPER_ID_CERT_BASE64) holds BOTH the cert and its private key, so
+    // point signing-key AND certificate at it — otherwise Conveyor signs with its own key derived
+    // from the root key, which won't match this externally-issued cert. macOS uses this p12 key; the
+    // root key (-Kapp.signing-key on the CLI) still covers Linux. The p12 is passphrase-protected;
+    // Conveyor reads it from `--passphrase env:CONVEYOR_MAC_CERTIFICATE_PASSWORD` (a CLI flag).
+    signing-key = ${?env.CONVEYOR_MAC_CERTIFICATE_P12}
     certificate = ${?env.CONVEYOR_MAC_CERTIFICATE_P12}
 
     // Notarize with the App Store Connect API key already used by the jpackage flow

--- a/android/conveyor.conf
+++ b/android/conveyor.conf
@@ -19,6 +19,9 @@ include "#!./gradlew -q :desktop-app:printConveyorConfig"
 
 app {
   display-name = "AutoMobile"
+  // Conveyor derives fsname (package filenames, install dirs, Linux pkg name) from display-name and
+  // requires it in kebab-case; the Gradle-emitted value "AutoMobile" fails validation, so pin it.
+  fsname = "auto-mobile"
   // Stable package identity across releases (macOS bundle id, Linux package name).
   rdns-name = "dev.jasonpearson.automobile.desktop"
   vendor = "AutoMobile"

--- a/android/conveyor.conf
+++ b/android/conveyor.conf
@@ -43,11 +43,10 @@ app {
   // GitHubReleaseSource polls, so the DIY checker and Conveyor agree on "latest".
   vcs-url = "github.com/kaeawc/auto-mobile"
 
-  // `make site` writes the site to ./output only. `make copied-site` also pushes it to the
-  // destination below — set to `github:kaeawc/auto-mobile` (with GITHUB_TOKEN) by the publish
-  // workflow so a release attaches the Sparkle/apt assets to its GitHub Release. Unset for local
-  // and artifacts-only CI runs, so those never publish (#5227, PR-C4).
-  site.copy-to = ${?env.CONVEYOR_SITE_COPY_TO}
+  // No `site.copy-to` here: `make site` writes the site to ./output only. Publishing to GitHub
+  // Releases is done by `make copied-site`, and the publish workflow passes the destination as a
+  // command-line override (-Kapp.site.copy-to=github:kaeawc/auto-mobile) so the key is simply absent
+  // on local and artifacts-only runs — a blank/empty copy-to fails Conveyor validation (#5227, C4).
 
   icons = "desktop-app/src/main/resources/icons/app-icon.png"
 


### PR DESCRIPTION
## Summary

Follow-up to the Conveyor migration ([#5227](https://github.com/kaeawc/auto-mobile/issues/5227); C1
#5305, C2 #5384, C3 #5456, C4 #5506). With the `CONVEYOR_SIGNING_KEY` secret now provisioned, I
dispatched the **Build Desktop App (Conveyor)** workflow (`signed: true`) and iterated until
`conveyor make site` **succeeds end-to-end** — this fixes the five real config/wiring issues that
could only surface once the Conveyor CLI actually ran (they were flagged as "verify on first
dispatch" in C3/C4).

**Verified green** — run `32635348623`: both macOS arches **Developer ID-signed + Apple
notarized + stapled**, the Linux `.deb` + apt repo built, and the update site produced and uploaded
(`automobile-desktop-conveyor`, 654 MB). This clears the second of the three flip-prerequisites (a
verified dispatch).

## The five fixes (each found by one dispatch)

1. **`app.fsname` kebab-case** — Conveyor requires it kebab-case; the Gradle-derived value was
   `AutoMobile`. Pinned `fsname = "auto-mobile"` in `conveyor.conf`.
2. **`copy-to` blank** — the workflow exported `CONVEYOR_SITE_COPY_TO=''` on non-publish runs, and
   HOCON treats a defined-but-empty env as blank (not absent), failing validation. Removed
   `site.copy-to` from `conveyor.conf`; the publish path now passes
   `-Kapp.site.copy-to=github:kaeawc/auto-mobile` only when `publish=true`.
3. **Cert passphrase** — Conveyor takes a key/cert passphrase from the `--passphrase` CLI flag, not
   an `app.mac.certificate-password` config key. Dropped that key; pass
   `--passphrase env:CONVEYOR_MAC_CERTIFICATE_PASSWORD` on signed runs.
4. **Bring-your-own macOS key** — Conveyor signs with a key *derived from the root key* unless told
   otherwise, so it rejected the externally-issued Developer ID cert ("private key (derived) doesn't
   match"). Point **both** `app.mac.signing-key` and `app.mac.certificate` at the `.p12` (cert+key);
   the root key still covers Linux.
5. **Artifact path** — Conveyor writes `make site` output to `./output` relative to the CWD (repo
   root), not the `-f` config's directory. Upload `output`, not `android/output`.

## Scope / safety

Only the Conveyor config + its workflow change; **the default release path is untouched** — this
branch never sets `DESKTOP_PUBLISHER`, so releases still go through jpackage. This just makes the
(still inert) Conveyor path actually functional.

## Validation

- [x] `conveyor make site` **signed** run green end-to-end (run 32635348623), artifact uploaded
- [x] macOS amd64 + arm64 signed with the existing Developer ID and notarized by Apple
- [x] Linux `.deb` + apt repo generated
- [x] `all_fast_validate_checks.sh` (yaml / shellcheck / workflow-assertion-triggers) pass

## Remaining before flipping `DESKTOP_PUBLISHER=conveyor`

Only the **≥1.0 desktop versioning** decision now (the test used `1.0.0`; Conveyor needs a macOS
major ≥1 and `copied-site` matches the release by that version). Still-open follow-ups from C4:
native de-dup trim (the 654 MB site likely carries host natives), atomic pre-publish attach, and
Windows (needs a cert).
