### PR TITLE
fix(tap): preserve unique semantic link owners

### DIFF
--- a/ios/control-proxy/Sources/CtrlProxy/GesturePerformer.swift
+++ b/ios/control-proxy/Sources/CtrlProxy/GesturePerformer.swift
@@ -1095,12 +1095,18 @@ public class GesturePerformer: GesturePerforming {
             try runOnMainThread {
                 let links: [XCUIElement]
                 if let ownerResourceId {
-                    guard let owner = self.elementLocator.findElement(byResourceId: ownerResourceId) as? XCUIElement,
-                          owner.exists
-                    else {
-                        throw GestureError.elementNotFound(ownerResourceId)
+                    let owners = app.descendants(matching: .any).allElementsBoundByIndex.filter {
+                        $0.identifier == ownerResourceId &&
+                            $0.exists &&
+                            $0.isHittable &&
+                            !$0.frame.isEmpty
                     }
-                    links = owner.descendants(matching: .link).allElementsBoundByIndex
+                    guard owners.count == 1 else {
+                        throw GestureError.gestureFailed(
+                            "Semantic link owner '\(ownerResourceId)' is missing, not actionable, or ambiguous"
+                        )
+                    }
+                    links = owners[0].descendants(matching: .link).allElementsBoundByIndex
                 } else {
                     links = app.links.allElementsBoundByIndex
                 }

--- a/src/features/action/TapOnElement.ts
+++ b/src/features/action/TapOnElement.ts
@@ -353,7 +353,15 @@ export class TapOnElement extends BaseVisualChange {
     text: string,
     occurrence: number,
     owner?: Element,
+    viewHierarchy?: ViewHierarchyResult,
   ): Promise<{ success: boolean; error?: string }> {
+    if (owner && !this.hasUniqueSemanticLinkOwner(owner, viewHierarchy)) {
+      return {
+        success: false,
+        error:
+          "Container-scoped semantic link activation requires a unique resource-id owner identity",
+      };
+    }
     if (this.device.platform === "android") {
       const selector = owner ? stableNodeSelectorForElement(owner) : undefined;
       if (owner && !selector) {
@@ -385,6 +393,51 @@ export class TapOnElement extends BaseVisualChange {
       return { success: result.success, error: result.error };
     }
     return { success: false, error: `Unsupported platform: ${this.device.platform}` };
+  }
+
+  private hasUniqueSemanticLinkOwner(
+    owner: Element,
+    viewHierarchy: ViewHierarchyResult | undefined,
+  ): boolean {
+    if (!viewHierarchy) {
+      return false;
+    }
+    const elements = this.elementParser.flattenViewHierarchy(viewHierarchy).map(({ element }) => element);
+    if (this.device.platform === "ios") {
+      const ownerResourceId = owner["resource-id"];
+      return (
+        typeof ownerResourceId === "string" &&
+        ownerResourceId.length > 0 &&
+        elements.filter((element) => element["resource-id"] === ownerResourceId).length === 1
+      );
+    }
+    const selector = stableNodeSelectorForElement(owner);
+    return (
+      selector !== undefined &&
+      elements.filter((element) => this.matchesNativeOwnerSelector(element, selector)).length === 1
+    );
+  }
+
+  private matchesNativeOwnerSelector(
+    element: Element,
+    selector: NonNullable<ReturnType<typeof stableNodeSelectorForElement>>,
+  ): boolean {
+    const resourceId = element["resource-id"];
+    if (
+      selector.resourceId !== undefined &&
+      (typeof resourceId !== "string" ||
+        (resourceId !== selector.resourceId && !resourceId.endsWith(`:id/${selector.resourceId}`)))
+    ) {
+      return false;
+    }
+    return (
+      (selector.testTag === undefined || element["test-tag"] === selector.testTag) &&
+      (selector.uniqueId === undefined || element["unique-id"] === selector.uniqueId) &&
+      (selector.collectionRow === undefined ||
+        element["collection-row-index"] === selector.collectionRow) &&
+      (selector.collectionColumn === undefined ||
+        element["collection-column-index"] === selector.collectionColumn)
+    );
   }
 
   private getSearchUntilDuration(options: TapOnElementOptions): number {
@@ -1295,6 +1348,7 @@ export class TapOnElement extends BaseVisualChange {
               options.accessibilityLink,
               occurrence,
               owner,
+              viewHierarchy,
             );
             if (!activation.success) {
               return { success: false, error: activation.error };
@@ -1333,6 +1387,7 @@ export class TapOnElement extends BaseVisualChange {
               options.subtext.text,
               occurrence,
               element,
+              viewHierarchy,
             );
             if (!activation.success) {
               return { success: false, error: activation.error };

--- a/test/features/action/TapOnElement.selectedElement.test.ts
+++ b/test/features/action/TapOnElement.selectedElement.test.ts
@@ -9,11 +9,11 @@ import { FakeAdbClient } from "../../fakes/FakeAdbClient";
 import { FakeTimer } from "../../fakes/FakeTimer";
 import { ResultFaker } from "../../fakes/ResultFaker";
 
-const createTapOnElement = (): TapOnElement => {
+const createTapOnElement = (platform: "android" | "ios" = "android"): TapOnElement => {
   return new TapOnElement(
     {
       name: "test-device",
-      platform: "android",
+      platform,
       deviceId: "emulator-5554",
     } as any,
     new FakeAdbClient() as any,
@@ -24,6 +24,61 @@ const createTapOnElement = (): TapOnElement => {
 };
 
 describe("TapOnElement selectedElement metadata", () => {
+  test("rejects a semantic-link owner whose resource ID is shared by another row", () => {
+    const tapOnElement = createTapOnElement();
+    const owner = ResultFaker.element({
+      text: "Account B",
+      "resource-id": "com.example:id/account_row",
+    });
+    const duplicateOwner = ResultFaker.element({
+      text: "Account A",
+      "resource-id": "com.example:id/account_row",
+    });
+    const hierarchy = {
+      hierarchy: {
+        node: [{ ...duplicateOwner, children: [] }, { ...owner, children: [] }],
+      },
+    };
+
+    expect((tapOnElement as any).hasUniqueSemanticLinkOwner(owner, hierarchy)).toBe(false);
+  });
+
+  test("accepts a semantic-link owner with a unique resource ID", () => {
+    const tapOnElement = createTapOnElement();
+    const owner = ResultFaker.element({
+      text: "Account B",
+      "resource-id": "com.example:id/account_row_b",
+    });
+    const hierarchy = {
+      hierarchy: {
+        node: [{ ...owner, children: [] }],
+      },
+    };
+
+    expect((tapOnElement as any).hasUniqueSemanticLinkOwner(owner, hierarchy)).toBe(true);
+  });
+
+  test("uses Android's complete stable selector for duplicate resource IDs", () => {
+    const tapOnElement = createTapOnElement();
+    const owner = ResultFaker.element({
+      text: "Account B",
+      "resource-id": "com.example:id/account_row",
+      "unique-id": "account-row-b",
+    });
+    const duplicateOwner = ResultFaker.element({
+      text: "Account A",
+      "resource-id": "com.example:id/account_row",
+      "unique-id": "account-row-a",
+    });
+    const hierarchy = {
+      hierarchy: {
+        node: [{ ...duplicateOwner, children: [] }, { ...owner, children: [] }],
+      },
+    };
+
+    expect((tapOnElement as any).hasUniqueSemanticLinkOwner(owner, hierarchy)).toBe(true);
+  });
+
   test("populates selection metadata and computes bounds centers", () => {
     const tapOnElement = createTapOnElement();
     const element: Element = {


### PR DESCRIPTION
## Summary
- Prevent container-scoped semantic link activation from resolving a shared owner identity to the first matching row.
- Preserve Android matching through the complete stable selector while requiring a unique actionable owner on iOS.
- Add regression coverage for shared resource IDs and Android unique IDs.

## Test plan
- [x] `bun test test/features/action/TapOnElement.selectedElement.test.ts`
- [x] `bun run lint`
- [x] `bun run typecheck`
- [x] `swift test` in `ios/control-proxy`

Made with [Cursor](https://cursor.com)