### PR TITLE
fix(desktop): invalidate navigation node screenshot cache on re-capture (#5088)

### DIFF
--- a/android/desktop-core/src/main/kotlin/dev/jasonpearson/automobile/desktop/core/navigation/NavigationCanvasView.kt
+++ b/android/desktop-core/src/main/kotlin/dev/jasonpearson/automobile/desktop/core/navigation/NavigationCanvasView.kt
@@ -922,10 +922,20 @@ private fun ScreenNodeCard(
   var isLoadingScreenshot by remember { mutableStateOf(false) }
 
   // Load screenshot when available (key on screenshotLoader too, so it re-fires if loader becomes
-  // available later)
+  // available later). Also key on screenshotVersion: the daemon re-captures a node's screenshot
+  // under the SAME stable URI, so without a changing key this effect would never re-fire and the
+  // URI-keyed loader cache would keep serving the stale bitmap (#5088). The facet bumps the version
+  // for the node whose screenshot was just re-captured; a bump drops that node's cache entry and
+  // re-fetches, scoped to exactly this node (no mass refetch of the rest of the graph).
   val screenshotUri = screen.screenshotUri
-  LaunchedEffect(screenshotUri, screenshotLoader) {
+  val screenshotVersion = screen.screenshotVersion
+  LaunchedEffect(screenshotUri, screenshotVersion, screenshotLoader) {
     if (screenshotUri != null && screenshotLoader != null) {
+      // Only invalidate on an observed re-capture (version > 0); the first load of a node
+      // (version 0) is already a cache miss, so invalidating then would be a redundant no-op.
+      if (screenshotVersion > 0) {
+        screenshotLoader.invalidate(screenshotUri)
+      }
       isLoadingScreenshot = true
       screenshotBitmap =
         withContext(Dispatchers.IO) {

--- a/android/desktop-core/src/main/kotlin/dev/jasonpearson/automobile/desktop/core/workspace/NavigationFacet.kt
+++ b/android/desktop-core/src/main/kotlin/dev/jasonpearson/automobile/desktop/core/workspace/NavigationFacet.kt
@@ -248,6 +248,15 @@ fun NavigationFacet(
   var state by
     remember(column.deviceId) { mutableStateOf<NavigationFacetState>(NavigationFacetState.Loading) }
 
+  // Per-screen screenshot-liveness tokens for the resolved app (#5088). Reset when the app changes
+  // (a fresh app's nodes start unversioned). Bumped for the screen the device just navigated to on
+  // a same-app refresh — the node the daemon re-captured a screenshot for — then stamped onto the
+  // pulled graph so the canvas drops that node's stale cached thumbnail and re-fetches. Read and
+  // written only from the pull effect below, which runs sequentially on the composition thread, so
+  // a plain map needs no synchronization.
+  val screenshotVersions =
+    remember(column.deviceId, streamAttempt, foregroundAppId) { mutableMapOf<String, Int>() }
+
   LaunchedEffect(
     column.deviceId,
     foregroundAppId,
@@ -307,7 +316,23 @@ fun NavigationFacet(
         ) {
           is Result.Success ->
             if (result.data.screens.isEmpty()) NavigationFacetState.Empty
-            else NavigationFacetState.Resolved(appId, result.data)
+            else {
+              // A live same-app refresh means the device just navigated; the daemon re-captured a
+              // screenshot for the destination screen under its existing stable URI. Bump that
+              // node's liveness token so the canvas invalidates its cached thumbnail (#5088). The
+              // first pull of an app (sameAppRefresh == false) carries no re-capture, so its nodes
+              // keep version 0 and load normally.
+              if (sameAppRefresh) {
+                val recaptured = currentScreen
+                if (recaptured != null) {
+                  screenshotVersions[recaptured] = (screenshotVersions[recaptured] ?: 0) + 1
+                }
+              }
+              NavigationFacetState.Resolved(
+                appId,
+                stampScreenshotVersions(result.data, screenshotVersions),
+              )
+            }
           is Result.Error ->
             NavigationFacetState.Error(result.message ?: "Failed to load navigation graph")
           // A one-shot read resolves to Success/Error; treat a stray Loading as retryable.
@@ -377,6 +402,23 @@ fun NavigationFacet(
       )
   }
 }
+
+/**
+ * Stamp each node's accumulated screenshot-liveness token (#5088) onto a freshly pulled [graph].
+ * [versions] maps screen name -> the number of re-captures observed for that node this session; a
+ * node absent from it keeps version 0. Only nodes the daemon actually re-captured therefore change
+ * key, so the canvas drops and re-fetches exactly those thumbnails rather than the whole graph.
+ * Returns [graph] unchanged when nothing has been re-captured yet (the common first-pull case).
+ */
+internal fun stampScreenshotVersions(
+  graph: NavigationGraph,
+  versions: Map<String, Int>,
+): NavigationGraph =
+  if (versions.isEmpty()) {
+    graph
+  } else {
+    graph.copy(screens = graph.screens.map { it.copy(screenshotVersion = versions[it.name] ?: 0) })
+  }
 
 /** Centered single-line note for the facet's transient (loading) or empty states. */
 @Composable

--- a/android/desktop-core/src/test/kotlin/dev/jasonpearson/automobile/desktop/core/workspace/NavigationFacetTest.kt
+++ b/android/desktop-core/src/test/kotlin/dev/jasonpearson/automobile/desktop/core/workspace/NavigationFacetTest.kt
@@ -3,6 +3,7 @@ package dev.jasonpearson.automobile.desktop.core.workspace
 import androidx.compose.material3.MaterialTheme
 import androidx.compose.runtime.CompositionLocalProvider
 import androidx.compose.runtime.mutableStateOf
+import androidx.compose.ui.graphics.ImageBitmap
 import androidx.compose.ui.test.ExperimentalTestApi
 import androidx.compose.ui.test.onAllNodesWithContentDescription
 import androidx.compose.ui.test.onAllNodesWithText
@@ -29,6 +30,7 @@ import dev.jasonpearson.automobile.desktop.core.platform.AppVersionProvider
 import dev.jasonpearson.automobile.desktop.core.settings.FakeSettingsProvider
 import dev.jasonpearson.automobile.desktop.core.testing.FakeAutoMobileClient
 import dev.jasonpearson.automobile.desktop.core.update.FakeUpdateController
+import java.util.concurrent.CopyOnWriteArrayList
 import java.util.concurrent.atomic.AtomicInteger
 import kotlinx.coroutines.CompletableDeferred
 import kotlinx.coroutines.flow.FlowCollector
@@ -1001,4 +1003,92 @@ class NavigationFacetTest {
     assertEquals("a provider swap must re-resolve the loader", 2, used.size)
     assertNotSame("the loader must come from the new provider after a swap", used[0], used[1])
   }
+
+  private fun screenWithShot(name: String, screenshotUri: String) =
+    screen(name).copy(screenshotUri = screenshotUri)
+
+  /** A [ScreenshotLoader] that records load/invalidate calls; returns no bitmap (unused here). */
+  private class RecordingScreenshotLoader : ScreenshotLoader {
+    // Cross-thread: load() runs on Dispatchers.IO, invalidate() on the composition thread.
+    val loaded = CopyOnWriteArrayList<String>()
+    val invalidated = CopyOnWriteArrayList<String>()
+
+    override suspend fun load(uri: String): ImageBitmap? {
+      loaded += uri
+      return null
+    }
+
+    override fun invalidate(uri: String) {
+      invalidated += uri
+    }
+
+    override fun clearCache() = Unit
+
+    override fun cacheSize(): Int = 0
+  }
+
+  @Test
+  fun `stampScreenshotVersions applies per-node versions and leaves others at zero`() {
+    val graph = NavigationGraph(listOf(screen("Home"), screen("Details")), emptyList())
+    val stamped = stampScreenshotVersions(graph, mapOf("Home" to 3))
+    assertEquals(3, stamped.screens.first { it.name == "Home" }.screenshotVersion)
+    assertEquals(0, stamped.screens.first { it.name == "Details" }.screenshotVersion)
+  }
+
+  @Test
+  fun `stampScreenshotVersions returns the graph unchanged when nothing was re-captured`() {
+    val graph = NavigationGraph(listOf(screen("Home")), emptyList())
+    assertSame(graph, stampScreenshotVersions(graph, emptyMap()))
+  }
+
+  @Test
+  fun `same-app refresh invalidates only the re-captured node's cached screenshot`() =
+    runComposeUiTest {
+      // #5088: the daemon re-captures a node's screenshot under its SAME stable URI, so a URI-keyed
+      // thumbnail cache would keep serving the stale bitmap. On a same-app refresh the facet bumps
+      // the just-navigated screen's liveness token, and the canvas must drop exactly that node's
+      // cache entry — never the untouched siblings'.
+      val homeUri = "automobile:navigation/nodes/home/screenshot"
+      val detailsUri = "automobile:navigation/nodes/details/screenshot"
+      val source =
+        object : NavigationDataSource {
+          override suspend fun getNavigationGraph(): Result<NavigationGraph> =
+            Result.Success(
+              NavigationGraph(
+                listOf(screenWithShot("Home", homeUri), screenWithShot("Details", detailsUri)),
+                emptyList(),
+              )
+            )
+        }
+      val loader = RecordingScreenshotLoader()
+      val fake = FakeObservationStream()
+      setContent {
+        CompositionLocalProvider(LocalAutoMobileGraph provides testGraph()) {
+          MaterialTheme {
+            NavigationFacet(
+              column = column(),
+              observationStreamFactory = { fake },
+              navigationDataSourceProvider = { source },
+              screenshotLoaderProvider = { loader },
+            )
+          }
+        }
+      }
+      waitForIdle()
+
+      // First app-A update navigating to Home: initial pull, both cards load, none invalidated
+      // (version 0 is already a cache miss).
+      fake.emitNavigation(navUpdate("com.example.app", currentScreen = "Home"))
+      waitUntil(timeoutMillis = 5_000) { loader.loaded.contains(homeUri) }
+      assertTrue("first render must not invalidate anything", loader.invalidated.isEmpty())
+
+      // Second app-A update navigating to Home again (the daemon re-captured Home's screenshot):
+      // Home's token bumps, so the canvas invalidates Home's cache entry and re-fetches.
+      fake.emitNavigation(navUpdate("com.example.app", currentScreen = "Home"))
+      waitUntil(timeoutMillis = 5_000) { loader.invalidated.contains(homeUri) }
+      assertFalse(
+        "an untouched sibling node's screenshot must not be invalidated",
+        loader.invalidated.contains(detailsUri),
+      )
+    }
 }

--- a/android/desktop-domain/src/main/kotlin/dev/jasonpearson/automobile/desktop/domain/NavigationModels.kt
+++ b/android/desktop-domain/src/main/kotlin/dev/jasonpearson/automobile/desktop/domain/NavigationModels.kt
@@ -46,6 +46,16 @@ public data class ScreenNode(
   val discoveredAt: Long,
   val screenshotUri: String? = null,
   val provenance: List<ScreenProvenance> = emptyList(),
+  /**
+   * Desktop-side liveness token for this node's screenshot (#5088). The daemon keeps a node's
+   * screenshot at the same stable [screenshotUri] when it re-captures a newer image, so a URI-keyed
+   * thumbnail cache would keep serving the stale bitmap. The Navigation facet bumps this counter
+   * for the node whose screenshot was just re-captured (the screen the device navigated to on a
+   * same-app graph refresh); the canvas keys its screenshot load on it and invalidates the cache
+   * entry when it changes, forcing a re-fetch for exactly that node. Additive: `0` means "no
+   * re-capture observed this session" and every non-facet producer leaves it at the default.
+   */
+  val screenshotVersion: Int = 0,
 )
 
 public data class ScreenTransition(


### PR DESCRIPTION
## Summary

Fixes [#5088](https://github.com/kaeawc/auto-mobile/issues/5088). `NavigationScreenshotLoader` caches decoded thumbnails keyed by the **stable** per-node URI (`automobile:navigation/nodes/{nodeId}/screenshot`), and no production path invalidated it. When the daemon re-captures a newer screenshot for an existing node (`updateNodeScreenshot` keeps the same URI), `load(uri)` kept returning the stale bitmap — and the canvas `LaunchedEffect`, keyed only on the unchanged URI, never re-fetched. A node's thumbnail could not refresh without an app restart.

## Approach

The daemon re-captures a screenshot for the screen the device just navigated to, which reaches the desktop as a **same-app graph refresh** (`updateGeneration++` → re-pull). So the enriched node is precisely `currentScreen`, letting us invalidate exactly that node rather than the whole graph. Desktop-only; no daemon/wire change.

- **`ScreenNode.screenshotVersion`** — additive liveness token (default `0`); every non-facet producer leaves it at the default.
- **`NavigationFacet`** — tracks a per-screen version map (reset per app); bumps the just-navigated screen's version on a same-app refresh, then stamps versions onto the pulled graph via the pure `stampScreenshotVersions` helper. The first pull of an app carries no re-capture, so its nodes stay at version 0 and load normally.
- **`ScreenNodeCard`** — keys its screenshot load on `screenshotVersion` and, on a bump (`> 0`), invalidates that URI's cache entry before reloading. Scoped per-node, so a refresh never mass-refetches untouched siblings.

This implements fix option 1 from the issue ("invalidate the node's cache entry when screenshot enrichment updates the graph"), scoped to the enriched node.

## Acceptance criteria

- ✅ A node whose screenshot is re-captured shows the new image without an app restart (canvas re-fires + invalidates on the version bump).
- ✅ After a screenshot-enrichment update for a node, the loader returns a fresh bitmap (cache miss / invalidation), not the stale one.

## Tests (`:desktop-core:test`, `NavigationFacetTest`)

- `stampScreenshotVersions` — per-node isolation (only the versioned node changes; others stay 0) and returns the graph unchanged when nothing was re-captured.
- `same-app refresh invalidates only the re-captured node's cached screenshot` — first render invalidates nothing; a second same-app update navigating to `Home` invalidates `Home`'s URI and never the sibling `Details`.

## Validation

- `:desktop-core:test --tests NavigationFacetTest` — BUILD SUCCESSFUL
- `ktfmt --google-style` (0.64) on all changed files — no changes
- `:desktop-domain:detektMain :desktop-core:detektMain :desktop-core:detektTest` — no findings

🤖 Generated autonomously by the next-best-issue scheduled task.