### PR TITLE
feat(ios): add semantic links playground demos

### DIFF
--- a/ios/Playground/Playground.xcodeproj/project.pbxproj
+++ b/ios/Playground/Playground.xcodeproj/project.pbxproj
@@ -18,6 +18,7 @@
 		619CDEE3F264DBB3415041D0 /* ShantellSans.ttf in Resources */ = {isa = PBXBuildFile; fileRef = E1B25FBAC5217DE05EA701CF /* ShantellSans.ttf */; };
 		72CDA6DB361FDC97490C3C2C /* AutoMobileSDK in Frameworks */ = {isa = PBXBuildFile; productRef = 3137B15D8D485C363DB78A3E /* AutoMobileSDK */; };
 		7C8CF515031B975C05FA2AD2 /* PlaygroundThemeTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = FBFA8ECD2DC59DBF8A6FBBF3 /* PlaygroundThemeTests.swift */; };
+		7FDB62C4B6F0092619122928 /* SemanticLinksDemo.swift in Sources */ = {isa = PBXBuildFile; fileRef = CAF63AC7E447335C9A68A4F7 /* SemanticLinksDemo.swift */; };
 		95CF2D08679D32C4A9966ACD /* CrayonSketchTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 11B156E0FBE749405E1F2D0D /* CrayonSketchTests.swift */; };
 		97CA6F2DE628A139094EF72D /* Colors.swift in Sources */ = {isa = PBXBuildFile; fileRef = 2B46870C2DDF4A2F73A5778B /* Colors.swift */; };
 		B3B613858665E331B7E7EB99 /* SdkHighlightOverlayE2ETests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 8A719AFBA1888450E8653AB6 /* SdkHighlightOverlayE2ETests.swift */; };
@@ -57,6 +58,7 @@
 		C6D8C10EFC976E6B3CCD16BD /* Debug.xcconfig */ = {isa = PBXFileReference; lastKnownFileType = text.xcconfig; path = Debug.xcconfig; sourceTree = "<group>"; };
 		C6EA6F80147865B6F32DD526 /* PlaygroundApp.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = PlaygroundApp.swift; sourceTree = "<group>"; };
 		CAC67DC1CDDC454A7BB7870A /* Assets.xcassets */ = {isa = PBXFileReference; lastKnownFileType = folder; name = Assets.xcassets; path = Sources/Assets.xcassets; sourceTree = SOURCE_ROOT; };
+		CAF63AC7E447335C9A68A4F7 /* SemanticLinksDemo.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SemanticLinksDemo.swift; sourceTree = "<group>"; };
 		CBBA4475C2A7A68AE3987086 /* PlaygroundTests.xctest */ = {isa = PBXFileReference; includeInIndex = 0; lastKnownFileType = wrapper.cfbundle; path = PlaygroundTests.xctest; sourceTree = BUILT_PRODUCTS_DIR; };
 		D01BCE22E951887741F32904 /* ContentView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ContentView.swift; sourceTree = "<group>"; };
 		D61225B3155981050B6A59A6 /* AccessibilityRotorDemo.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AccessibilityRotorDemo.swift; sourceTree = "<group>"; };
@@ -183,6 +185,7 @@
 				D61225B3155981050B6A59A6 /* AccessibilityRotorDemo.swift */,
 				25213AE8A9FD9A5B1EEFD97F /* DemosTab.swift */,
 				FF86B8E1368C9B39424F13C0 /* DiscoverTab.swift */,
+				CAF63AC7E447335C9A68A4F7 /* SemanticLinksDemo.swift */,
 				64FD18EC8D1B9A665615C374 /* SettingsTab.swift */,
 			);
 			path = Tabs;
@@ -296,6 +299,7 @@
 				EA349DF37933D70B410F7135 /* DiscoverTab.swift in Sources */,
 				553F94B4D033BCA44B07AC4E /* PlaygroundApp.swift in Sources */,
 				C9A1977492B71CC9FE85DA16 /* PlaygroundDatabaseFixture.swift in Sources */,
+				7FDB62C4B6F0092619122928 /* SemanticLinksDemo.swift in Sources */,
 				54C16E199D10E281E1E316CF /* SettingsTab.swift in Sources */,
 				327A28D4620038BBA8D02656 /* Shapes.swift in Sources */,
 				007B2120C2735B42A20C510B /* Theme.swift in Sources */,

--- a/ios/Playground/Sources/Tabs/DemosTab.swift
+++ b/ios/Playground/Sources/Tabs/DemosTab.swift
@@ -123,6 +123,26 @@ struct DemosTab: View {
                             icon: "dial.medium.fill"
                         )
                     }
+
+                    NavigationLink {
+                        SwiftUISemanticLinksDemo()
+                    } label: {
+                        DemoRow(
+                            title: "Semantic Links (SwiftUI)",
+                            description: "AttributedString inline accessibility links",
+                            icon: "link"
+                        )
+                    }
+
+                    NavigationLink {
+                        UIKitSemanticLinksDemo()
+                    } label: {
+                        DemoRow(
+                            title: "Semantic Links (UIKit)",
+                            description: "UITextView inline accessibility links",
+                            icon: "link.circle"
+                        )
+                    }
                 }
 
                 Section("View Hierarchy") {

--- a/ios/Playground/Sources/Tabs/SemanticLinksDemo.swift
+++ b/ios/Playground/Sources/Tabs/SemanticLinksDemo.swift
@@ -1,0 +1,291 @@
+import Foundation
+import SwiftUI
+import UIKit
+
+// MARK: - Semantic Links Demos
+
+/// A positive fixture for semantic accessibility-link activation.
+///
+/// Both variants deliberately repeat the visible "Terms of Service" link text
+/// in one owner paragraph. This makes `subtext: { text, occurrence }` useful:
+/// occurrence 0 and 1 have independent actions, while the standalone Privacy
+/// Policy link is addressable through `selector.accessibilityLink`.
+private enum SemanticLinkDestination: String {
+    case termsFirst = "terms-first"
+    case termsSecond = "terms-second"
+    case support
+    case privacy
+
+    var url: URL {
+        var components = URLComponents()
+        components.scheme = "automobile-playground"
+        components.host = "semantic-links"
+        components.path = "/\(rawValue)"
+        return components.url ?? URL(filePath: "/semantic-links/\(rawValue)")
+    }
+
+    var activationName: String {
+        switch self {
+        case .termsFirst:
+            "Terms of Service (first)"
+        case .termsSecond:
+            "Terms of Service (second)"
+        case .support:
+            "Support"
+        case .privacy:
+            "Privacy Policy"
+        }
+    }
+
+    init?(url: URL) {
+        self.init(rawValue: url.lastPathComponent)
+    }
+}
+
+private struct SemanticLinksResult: View {
+    let lastActivated: String
+    @Environment(\.autoMobileTheme) private var theme
+
+    var body: some View {
+        Text("Last activated: \(lastActivated)")
+            .font(theme.typography.titleMedium)
+            .foregroundStyle(theme.textPrimary)
+            .accessibilityIdentifier("semantic_links_result")
+    }
+}
+
+private struct SemanticLinksInstructions: View {
+    @Environment(\.autoMobileTheme) private var theme
+
+    var body: some View {
+        Text(
+            "Activate either Terms of Service occurrence, Support, or the standalone Privacy Policy link. "
+                + "Each activation changes the result below without navigating."
+        )
+        .font(theme.typography.bodyMedium)
+        .foregroundStyle(theme.textSecondary)
+    }
+}
+
+struct SwiftUISemanticLinksDemo: View {
+    @State private var lastActivated = "None"
+    @Environment(\.autoMobileTheme) private var theme
+
+    var body: some View {
+        ScrollView {
+            VStack(alignment: .leading, spacing: 20) {
+                SemanticLinksInstructions()
+
+                Text(swiftUIInlineLinks)
+                    .font(theme.typography.bodyLarge)
+                    .accessibilityIdentifier("swiftui_semantic_links_inline")
+
+                Link("Privacy Policy", destination: SemanticLinkDestination.privacy.url)
+                    .font(theme.typography.titleMedium)
+                    .accessibilityIdentifier("swiftui_semantic_links_standalone")
+
+                SemanticLinksResult(lastActivated: lastActivated)
+            }
+            .padding()
+        }
+        .navigationTitle("Semantic Links (SwiftUI)")
+        .navigationBarTitleDisplayMode(.inline)
+        .environment(\.openURL, OpenURLAction { url in
+            activate(url)
+            return .handled
+        })
+        .trackNavigation(destination: "SwiftUISemanticLinksDemo")
+    }
+
+    private var swiftUIInlineLinks: AttributedString {
+        var firstTerms = AttributedString("Terms of Service")
+        firstTerms.link = SemanticLinkDestination.termsFirst.url
+        var support = AttributedString("Support")
+        support.link = SemanticLinkDestination.support.url
+        var secondTerms = AttributedString("Terms of Service")
+        secondTerms.link = SemanticLinkDestination.termsSecond.url
+
+        var text = AttributedString("Read the ")
+        text += firstTerms
+        text += AttributedString(", contact ")
+        text += support
+        text += AttributedString(", or review the ")
+        text += secondTerms
+        text += AttributedString(" again.")
+        return text
+    }
+
+    private func activate(_ url: URL) {
+        guard let destination = SemanticLinkDestination(url: url) else {
+            return
+        }
+        lastActivated = destination.activationName
+    }
+}
+
+struct UIKitSemanticLinksDemo: View {
+    @State private var lastActivated = "None"
+    @Environment(\.autoMobileTheme) private var theme
+
+    var body: some View {
+        ScrollView {
+            VStack(alignment: .leading, spacing: 20) {
+                SemanticLinksInstructions()
+
+                UIKitSemanticLinkTextView(
+                    attributedText: uikitInlineLinks,
+                    accessibilityIdentifier: "uikit_semantic_links_inline",
+                    onActivate: activate
+                )
+                .frame(minHeight: 72)
+
+                UIKitSemanticLinkTextView(
+                    attributedText: uikitStandaloneLink,
+                    accessibilityIdentifier: "uikit_semantic_links_standalone",
+                    onActivate: activate
+                )
+                .frame(height: 28)
+
+                SemanticLinksResult(lastActivated: lastActivated)
+            }
+            .padding()
+        }
+        .navigationTitle("Semantic Links (UIKit)")
+        .navigationBarTitleDisplayMode(.inline)
+        .trackNavigation(destination: "UIKitSemanticLinksDemo")
+    }
+
+    private var uikitInlineLinks: NSAttributedString {
+        let text = NSMutableAttributedString(
+            string: "Read the Terms of Service, contact Support, or review the Terms of Service again.",
+            attributes: [
+                .font: UIFont.preferredFont(forTextStyle: .body),
+                .foregroundColor: UIColor.label
+            ]
+        )
+        addLink(.termsFirst, label: "Terms of Service", occurrence: 0, to: text)
+        addLink(.support, label: "Support", occurrence: 0, to: text)
+        addLink(.termsSecond, label: "Terms of Service", occurrence: 1, to: text)
+        return text
+    }
+
+    private var uikitStandaloneLink: NSAttributedString {
+        let text = NSMutableAttributedString(
+            string: "Privacy Policy",
+            attributes: [
+                .font: UIFont.preferredFont(forTextStyle: .body),
+                .foregroundColor: UIColor.label
+            ]
+        )
+        addLink(.privacy, label: "Privacy Policy", occurrence: 0, to: text)
+        return text
+    }
+
+    private func addLink(
+        _ destination: SemanticLinkDestination,
+        label: String,
+        occurrence: Int,
+        to text: NSMutableAttributedString
+    ) {
+        guard let range = range(of: label, occurrence: occurrence, in: text.string as NSString) else {
+            return
+        }
+        text.addAttribute(.link, value: destination.url, range: range)
+    }
+
+    private func range(of label: String, occurrence: Int, in text: NSString) -> NSRange? {
+        var searchRange = NSRange(location: 0, length: text.length)
+        for index in 0 ... occurrence {
+            let foundRange = text.range(of: label, options: [], range: searchRange)
+            guard foundRange.location != NSNotFound else {
+                return nil
+            }
+            if index == occurrence {
+                return foundRange
+            }
+            let nextLocation = NSMaxRange(foundRange)
+            searchRange = NSRange(location: nextLocation, length: text.length - nextLocation)
+        }
+        return nil
+    }
+
+    private func activate(_ url: URL) {
+        guard let destination = SemanticLinkDestination(url: url) else {
+            return
+        }
+        lastActivated = destination.activationName
+    }
+}
+
+private struct UIKitSemanticLinkTextView: UIViewRepresentable {
+    let attributedText: NSAttributedString
+    let accessibilityIdentifier: String
+    let onActivate: (URL) -> Void
+
+    func makeCoordinator() -> Coordinator {
+        Coordinator(onActivate: onActivate)
+    }
+
+    func makeUIView(context: Context) -> UITextView {
+        let textView = UITextView()
+        textView.delegate = context.coordinator
+        textView.isEditable = false
+        textView.isScrollEnabled = false
+        textView.backgroundColor = .clear
+        textView.textContainerInset = .zero
+        textView.textContainer.lineFragmentPadding = 0
+        textView.adjustsFontForContentSizeCategory = true
+        textView.accessibilityTraits = .link
+        return textView
+    }
+
+    func updateUIView(_ textView: UITextView, context: Context) {
+        textView.attributedText = attributedText
+        textView.accessibilityIdentifier = accessibilityIdentifier
+        context.coordinator.onActivate = onActivate
+    }
+
+    func sizeThatFits(
+        _ proposal: ProposedViewSize,
+        uiView: UITextView,
+        context: Context
+    ) -> CGSize? {
+        let width = proposal.width ?? UIScreen.main.bounds.width
+        return uiView.sizeThatFits(CGSize(width: width, height: .greatestFiniteMagnitude))
+    }
+
+    final class Coordinator: NSObject, UITextViewDelegate {
+        var onActivate: (URL) -> Void
+
+        init(onActivate: @escaping (URL) -> Void) {
+            self.onActivate = onActivate
+        }
+
+        func textView(
+            _ textView: UITextView,
+            primaryActionFor textItem: UITextItem,
+            defaultAction: UIAction
+        ) -> UIAction? {
+            guard case let .link(url) = textItem.content else {
+                return defaultAction
+            }
+            return UIAction { [onActivate] _ in
+                onActivate(url)
+            }
+        }
+    }
+}
+
+#Preview("SwiftUI Semantic Links") {
+    NavigationStack {
+        SwiftUISemanticLinksDemo()
+    }
+    .autoMobileTheme()
+}
+
+#Preview("UIKit Semantic Links") {
+    NavigationStack {
+        UIKitSemanticLinksDemo()
+    }
+    .autoMobileTheme()
+}


### PR DESCRIPTION
## Summary

- add SwiftUI and UIKit Semantic Links demos to the iOS Playground Demos tab
- provide repeated inline `Terms of Service` link runs, standalone links, owner identifiers, and an observable activation result
- regenerate the Xcode project so the new fixture is included in Playground builds

## Why

Provides a controlled positive iOS fixture for [#5536](https://github.com/kaeawc/auto-mobile/issues/5536) semantic accessibility-link activation. The repeated inline label exercises owner-scoped `subtext` occurrence selection; the result label verifies activation without navigation.

## Validation

- `cd ios/Playground && xcodegen generate`
- `swiftlint lint --strict Sources/Tabs/SemanticLinksDemo.swift`
- `xcodebuild -project Playground.xcodeproj -scheme Playground -destination 'platform=iOS Simulator,name=iPhone 16 Pro,OS=18.6' build`
- installed and visually checked both screens on the iPhone 16 Pro simulator
