### PR TITLE
fix(observe): discover semantic accessibility links

### DIFF
--- a/android/control-proxy/src/main/kotlin/dev/jasonpearson/automobile/ctrlproxy/ViewHierarchyExtractor.kt
+++ b/android/control-proxy/src/main/kotlin/dev/jasonpearson/automobile/ctrlproxy/ViewHierarchyExtractor.kt
@@ -1023,7 +1023,10 @@ class ViewHierarchyExtractor(private val recompositionStore: RecompositionStore?
    * Returns only the link metadata needed to discover native [ClickableSpan] activation.
    * Accessibility exposes these spans from API 26 onward; callers omit the field when absent.
    */
-  internal fun semanticLinksFromText(text: CharSequence?, apiLevel: Int = Build.VERSION.SDK_INT): List<SemanticLink>? {
+  internal fun semanticLinksFromText(
+    text: CharSequence?,
+    apiLevel: Int = Build.VERSION.SDK_INT,
+  ): List<SemanticLink>? {
     if (apiLevel < Build.VERSION_CODES.O || text !is Spanned) return null
     val occurrences = mutableMapOf<String, Int>()
     val links =

--- a/android/control-proxy/src/main/kotlin/dev/jasonpearson/automobile/ctrlproxy/ViewHierarchyExtractor.kt
+++ b/android/control-proxy/src/main/kotlin/dev/jasonpearson/automobile/ctrlproxy/ViewHierarchyExtractor.kt
@@ -2,12 +2,15 @@ package dev.jasonpearson.automobile.ctrlproxy
 
 import android.graphics.Rect
 import android.os.Build
+import android.text.Spanned
+import android.text.style.ClickableSpan
 import android.util.Log
 import android.view.accessibility.AccessibilityNodeInfo
 import android.view.accessibility.AccessibilityWindowInfo
 import dev.jasonpearson.automobile.ctrlproxy.models.ContentHiddenRegion
 import dev.jasonpearson.automobile.ctrlproxy.models.ElementBounds
 import dev.jasonpearson.automobile.ctrlproxy.models.ScreenDimensions
+import dev.jasonpearson.automobile.ctrlproxy.models.SemanticLink
 import dev.jasonpearson.automobile.ctrlproxy.models.TraversalOrderResult
 import dev.jasonpearson.automobile.ctrlproxy.models.UIElementInfo
 import dev.jasonpearson.automobile.ctrlproxy.models.ViewHierarchy
@@ -812,6 +815,7 @@ class ViewHierarchyExtractor(private val recompositionStore: RecompositionStore?
 
       val extrasMap = extractExtras(node)
       val testTag = extractTestTag(extrasMap)
+      val semanticLinks = if (node.isPassword) null else semanticLinksFromText(node.text)
 
       // Check direct APIs if available (API 30+) with an extras fallback for Compose on API < 30
       val stateDescription: String? = extractStateDescription(node, extrasMap)
@@ -984,6 +988,7 @@ class ViewHierarchyExtractor(private val recompositionStore: RecompositionStore?
           children = children,
           stateDescription = stateDescription,
           testTag = testTag,
+          semanticLinks = semanticLinks,
           uniqueId = apiGatedFields.uniqueId,
           visibleToUser = node.isVisibleToUser,
           containerTitle = apiGatedFields.containerTitle,
@@ -1012,6 +1017,30 @@ class ViewHierarchyExtractor(private val recompositionStore: RecompositionStore?
       Log.e(TAG, "Error extracting node info at depth $depth", e)
       null
     }
+  }
+
+  /**
+   * Returns only the link metadata needed to discover native [ClickableSpan] activation.
+   * Accessibility exposes these spans from API 26 onward; callers omit the field when absent.
+   */
+  internal fun semanticLinksFromText(text: CharSequence?, apiLevel: Int = Build.VERSION.SDK_INT): List<SemanticLink>? {
+    if (apiLevel < Build.VERSION_CODES.O || text !is Spanned) return null
+    val occurrences = mutableMapOf<String, Int>()
+    val links =
+      text
+        .getSpans(0, text.length, ClickableSpan::class.java)
+        .sortedWith(compareBy({ text.getSpanStart(it) }, { text.getSpanEnd(it) }))
+        .mapNotNull { span ->
+          val start = text.getSpanStart(span)
+          val end = text.getSpanEnd(span)
+          if (start < 0 || end <= start || end > text.length) return@mapNotNull null
+          val visibleText = text.subSequence(start, end).toString()
+          if (visibleText.isBlank()) return@mapNotNull null
+          val occurrence = occurrences[visibleText] ?: 0
+          occurrences[visibleText] = occurrence + 1
+          SemanticLink(visibleText, occurrence, start, end)
+        }
+    return links.ifEmpty { null }
   }
 
   /**

--- a/android/control-proxy/src/main/kotlin/dev/jasonpearson/automobile/ctrlproxy/ViewHierarchyExtractor.kt
+++ b/android/control-proxy/src/main/kotlin/dev/jasonpearson/automobile/ctrlproxy/ViewHierarchyExtractor.kt
@@ -15,6 +15,7 @@ import dev.jasonpearson.automobile.ctrlproxy.models.TraversalOrderResult
 import dev.jasonpearson.automobile.ctrlproxy.models.UIElementInfo
 import dev.jasonpearson.automobile.ctrlproxy.models.ViewHierarchy
 import dev.jasonpearson.automobile.ctrlproxy.models.WindowInfo
+import java.util.Locale
 import kotlin.math.max
 import kotlin.math.min
 
@@ -1039,8 +1040,11 @@ class ViewHierarchyExtractor(private val recompositionStore: RecompositionStore?
           if (start < 0 || end <= start || end > text.length) return@mapNotNull null
           val visibleText = text.subSequence(start, end).toString()
           if (visibleText.isBlank()) return@mapNotNull null
-          val occurrence = occurrences[visibleText] ?: 0
-          occurrences[visibleText] = occurrence + 1
+          // Activation matches span text case-insensitively, so discovery must
+          // use the same equivalence relation for occurrence numbering.
+          val occurrenceKey = visibleText.lowercase(Locale.ROOT)
+          val occurrence = occurrences[occurrenceKey] ?: 0
+          occurrences[occurrenceKey] = occurrence + 1
           SemanticLink(visibleText, occurrence, start, end)
         }
     return links.ifEmpty { null }

--- a/android/control-proxy/src/main/kotlin/dev/jasonpearson/automobile/ctrlproxy/models/UIElementInfo.kt
+++ b/android/control-proxy/src/main/kotlin/dev/jasonpearson/automobile/ctrlproxy/models/UIElementInfo.kt
@@ -1,10 +1,10 @@
 package dev.jasonpearson.automobile.ctrlproxy.models
 
+import kotlinx.serialization.EncodeDefault
+import kotlinx.serialization.ExperimentalSerializationApi
 import kotlinx.serialization.SerialName
 import kotlinx.serialization.Serializable
 import kotlinx.serialization.Transient
-import kotlinx.serialization.EncodeDefault
-import kotlinx.serialization.ExperimentalSerializationApi
 import kotlinx.serialization.json.JsonElement
 
 /** An activatable link embedded in an accessibility element's text. */
@@ -50,7 +50,8 @@ data class UIElementInfo(
   // Additional accessibility semantics fields
   @SerialName("test-tag") val testTag: String? = null, // Compose or View accessibility-extra tag
   @EncodeDefault(EncodeDefault.Mode.NEVER)
-  @SerialName("semantic-links") val semanticLinks: List<SemanticLink>? = null,
+  @SerialName("semantic-links")
+  val semanticLinks: List<SemanticLink>? = null,
   @SerialName("unique-id") val uniqueId: String? = null, // Android-owned ID (API 33+)
   @SerialName("visible-to-user") val visibleToUser: Boolean? = null,
   @SerialName("container-title") val containerTitle: String? = null, // API 34+

--- a/android/control-proxy/src/main/kotlin/dev/jasonpearson/automobile/ctrlproxy/models/UIElementInfo.kt
+++ b/android/control-proxy/src/main/kotlin/dev/jasonpearson/automobile/ctrlproxy/models/UIElementInfo.kt
@@ -3,7 +3,18 @@ package dev.jasonpearson.automobile.ctrlproxy.models
 import kotlinx.serialization.SerialName
 import kotlinx.serialization.Serializable
 import kotlinx.serialization.Transient
+import kotlinx.serialization.EncodeDefault
+import kotlinx.serialization.ExperimentalSerializationApi
 import kotlinx.serialization.json.JsonElement
+
+/** An activatable link embedded in an accessibility element's text. */
+@Serializable
+data class SemanticLink(
+  val text: String,
+  val occurrence: Int,
+  val start: Int? = null,
+  val end: Int? = null,
+)
 
 /**
  * Data class representing UI elements with all relevant properties extracted from
@@ -13,6 +24,7 @@ import kotlinx.serialization.json.JsonElement
  * existing test frameworks.
  */
 @Serializable
+@OptIn(ExperimentalSerializationApi::class)
 data class UIElementInfo(
   val text: String? = null,
   val textSize: Float? = null,
@@ -37,6 +49,8 @@ data class UIElementInfo(
 
   // Additional accessibility semantics fields
   @SerialName("test-tag") val testTag: String? = null, // Compose or View accessibility-extra tag
+  @EncodeDefault(EncodeDefault.Mode.NEVER)
+  @SerialName("semantic-links") val semanticLinks: List<SemanticLink>? = null,
   @SerialName("unique-id") val uniqueId: String? = null, // Android-owned ID (API 33+)
   @SerialName("visible-to-user") val visibleToUser: Boolean? = null,
   @SerialName("container-title") val containerTitle: String? = null, // API 34+

--- a/android/control-proxy/src/test/kotlin/dev/jasonpearson/automobile/ctrlproxy/ViewHierarchyExtractorTest.kt
+++ b/android/control-proxy/src/test/kotlin/dev/jasonpearson/automobile/ctrlproxy/ViewHierarchyExtractorTest.kt
@@ -1,8 +1,12 @@
 package dev.jasonpearson.automobile.ctrlproxy
 
 import android.graphics.Rect
+import android.text.SpannableString
+import android.text.style.ClickableSpan
+import android.view.View
 import android.view.accessibility.AccessibilityWindowInfo
 import dev.jasonpearson.automobile.ctrlproxy.models.ElementBounds
+import dev.jasonpearson.automobile.ctrlproxy.models.SemanticLink
 import dev.jasonpearson.automobile.ctrlproxy.models.UIElementInfo
 import kotlinx.coroutines.test.runTest
 import kotlinx.serialization.json.Json
@@ -166,6 +170,51 @@ class ViewHierarchyExtractorTest {
 
     assertFalse(element.isClickable)
     assertTrue(element.isEnabled) // Should default to true
+  }
+
+  @Test
+  fun `semantic links preserve visible text ranges and per-text occurrences`() {
+    val text = SpannableString("Read Terms, Privacy, and Terms")
+    val firstTerms = object : ClickableSpan() { override fun onClick(widget: View) = Unit }
+    val privacy = object : ClickableSpan() { override fun onClick(widget: View) = Unit }
+    val secondTerms = object : ClickableSpan() { override fun onClick(widget: View) = Unit }
+    text.setSpan(firstTerms, 5, 10, 0)
+    text.setSpan(privacy, 12, 19, 0)
+    text.setSpan(secondTerms, 25, 30, 0)
+
+    assertEquals(
+      listOf(
+        SemanticLink("Terms", 0, 5, 10),
+        SemanticLink("Privacy", 0, 12, 19),
+        SemanticLink("Terms", 1, 25, 30),
+      ),
+      extractor.semanticLinksFromText(text, apiLevel = 26),
+    )
+  }
+
+  @Test
+  fun `semantic links stay absent below API 26 and for plain text`() {
+    val spanned = SpannableString("Terms")
+    spanned.setSpan(object : ClickableSpan() { override fun onClick(widget: View) = Unit }, 0, 5, 0)
+
+    assertNull(extractor.semanticLinksFromText(spanned, apiLevel = 25))
+    assertNull(extractor.semanticLinksFromText("Terms", apiLevel = 35))
+  }
+
+  @Test
+  fun `semantic link metadata stays omitted unless an element contains links`() {
+    val verboseJson = Json { encodeDefaults = true }
+
+    assertFalse(
+      verboseJson.encodeToString(UIElementInfo.serializer(), UIElementInfo(text = "Plain text"))
+        .contains("semantic-links")
+    )
+    assertTrue(
+      verboseJson.encodeToString(
+        UIElementInfo.serializer(),
+        UIElementInfo(semanticLinks = listOf(SemanticLink("Terms", 0, 0, 5))),
+      ).contains("semantic-links")
+    )
   }
 
   @Test

--- a/android/control-proxy/src/test/kotlin/dev/jasonpearson/automobile/ctrlproxy/ViewHierarchyExtractorTest.kt
+++ b/android/control-proxy/src/test/kotlin/dev/jasonpearson/automobile/ctrlproxy/ViewHierarchyExtractorTest.kt
@@ -175,9 +175,18 @@ class ViewHierarchyExtractorTest {
   @Test
   fun `semantic links preserve visible text ranges and per-text occurrences`() {
     val text = SpannableString("Read Terms, Privacy, and Terms")
-    val firstTerms = object : ClickableSpan() { override fun onClick(widget: View) = Unit }
-    val privacy = object : ClickableSpan() { override fun onClick(widget: View) = Unit }
-    val secondTerms = object : ClickableSpan() { override fun onClick(widget: View) = Unit }
+    val firstTerms =
+      object : ClickableSpan() {
+        override fun onClick(widget: View) = Unit
+      }
+    val privacy =
+      object : ClickableSpan() {
+        override fun onClick(widget: View) = Unit
+      }
+    val secondTerms =
+      object : ClickableSpan() {
+        override fun onClick(widget: View) = Unit
+      }
     text.setSpan(firstTerms, 5, 10, 0)
     text.setSpan(privacy, 12, 19, 0)
     text.setSpan(secondTerms, 25, 30, 0)
@@ -195,7 +204,14 @@ class ViewHierarchyExtractorTest {
   @Test
   fun `semantic links stay absent below API 26 and for plain text`() {
     val spanned = SpannableString("Terms")
-    spanned.setSpan(object : ClickableSpan() { override fun onClick(widget: View) = Unit }, 0, 5, 0)
+    spanned.setSpan(
+      object : ClickableSpan() {
+        override fun onClick(widget: View) = Unit
+      },
+      0,
+      5,
+      0,
+    )
 
     assertNull(extractor.semanticLinksFromText(spanned, apiLevel = 25))
     assertNull(extractor.semanticLinksFromText("Terms", apiLevel = 35))
@@ -206,14 +222,17 @@ class ViewHierarchyExtractorTest {
     val verboseJson = Json { encodeDefaults = true }
 
     assertFalse(
-      verboseJson.encodeToString(UIElementInfo.serializer(), UIElementInfo(text = "Plain text"))
+      verboseJson
+        .encodeToString(UIElementInfo.serializer(), UIElementInfo(text = "Plain text"))
         .contains("semantic-links")
     )
     assertTrue(
-      verboseJson.encodeToString(
-        UIElementInfo.serializer(),
-        UIElementInfo(semanticLinks = listOf(SemanticLink("Terms", 0, 0, 5))),
-      ).contains("semantic-links")
+      verboseJson
+        .encodeToString(
+          UIElementInfo.serializer(),
+          UIElementInfo(semanticLinks = listOf(SemanticLink("Terms", 0, 0, 5))),
+        )
+        .contains("semantic-links")
     )
   }
 

--- a/android/control-proxy/src/test/kotlin/dev/jasonpearson/automobile/ctrlproxy/ViewHierarchyExtractorTest.kt
+++ b/android/control-proxy/src/test/kotlin/dev/jasonpearson/automobile/ctrlproxy/ViewHierarchyExtractorTest.kt
@@ -174,7 +174,7 @@ class ViewHierarchyExtractorTest {
 
   @Test
   fun `semantic links preserve visible text ranges and per-text occurrences`() {
-    val text = SpannableString("Read Terms, Privacy, and Terms")
+    val text = SpannableString("Read Terms, Privacy, and terms")
     val firstTerms =
       object : ClickableSpan() {
         override fun onClick(widget: View) = Unit
@@ -195,7 +195,7 @@ class ViewHierarchyExtractorTest {
       listOf(
         SemanticLink("Terms", 0, 5, 10),
         SemanticLink("Privacy", 0, 12, 19),
-        SemanticLink("Terms", 1, 25, 30),
+        SemanticLink("terms", 1, 25, 30),
       ),
       extractor.semanticLinksFromText(text, apiLevel = 26),
     )

--- a/ios/control-proxy/Sources/CtrlProxy/ElementLocator.swift
+++ b/ios/control-proxy/Sources/CtrlProxy/ElementLocator.swift
@@ -1101,6 +1101,9 @@ public class ElementLocator: ElementLocating {
                 checked: isChecked ? "true" : nil,
                 selected: isSelected ? "true" : nil,
                 longClickable: nil, // Don't include - same as clickable on iOS
+                semanticLinks: snapshot.elementType == .link
+                    ? label.map { [SemanticLink(text: $0, occurrence: 0)] }
+                    : nil,
                 testTag: nil, // Don't duplicate - identifier is in resourceId
                 role: mapRole(snapshot.elementType),
                 stateDescription: nil,
@@ -1649,6 +1652,7 @@ public class ElementLocator: ElementLocating {
             checked: element.checked,
             selected: element.selected,
             longClickable: element.longClickable,
+            semanticLinks: element.semanticLinks,
             testTag: element.testTag,
             role: element.role,
             stateDescription: element.stateDescription,

--- a/ios/control-proxy/Sources/CtrlProxy/ElementLocator.swift
+++ b/ios/control-proxy/Sources/CtrlProxy/ElementLocator.swift
@@ -1186,33 +1186,7 @@ public class ElementLocator: ElementLocating {
 
             // Root element is always kept
             if isRoot {
-                return [UIElementInfo(
-                    text: element.text,
-                    value: element.value,
-                    textSize: element.textSize,
-                    contentDesc: element.contentDesc,
-                    resourceId: element.resourceId,
-                    className: element.className,
-                    bounds: element.bounds,
-                    clickable: element.clickable,
-                    enabled: element.enabled,
-                    focusable: element.focusable,
-                    focused: element.focused,
-                    accessibilityFocused: element.accessibilityFocused,
-                    scrollable: element.scrollable,
-                    password: element.password,
-                    checkable: element.checkable,
-                    checked: element.checked,
-                    selected: element.selected,
-                    longClickable: element.longClickable,
-                    testTag: element.testTag,
-                    role: element.role,
-                    stateDescription: element.stateDescription,
-                    errorMessage: element.errorMessage,
-                    hintText: element.hintText,
-                    actions: element.actions,
-                    node: optimizedChildren
-                )]
+                return [Self.copying(element, node: optimizedChildren)]
             }
 
             // Only promote children (flatten hierarchy) if this is a bounds-only wrapper AND not interactive
@@ -1229,33 +1203,7 @@ public class ElementLocator: ElementLocating {
             }
 
             // Keep this element with optimized children
-            return [UIElementInfo(
-                text: element.text,
-                value: element.value,
-                textSize: element.textSize,
-                contentDesc: element.contentDesc,
-                resourceId: element.resourceId,
-                className: element.className,
-                bounds: element.bounds,
-                clickable: element.clickable,
-                enabled: element.enabled,
-                focusable: element.focusable,
-                focused: element.focused,
-                accessibilityFocused: element.accessibilityFocused,
-                scrollable: element.scrollable,
-                password: element.password,
-                checkable: element.checkable,
-                checked: element.checked,
-                selected: element.selected,
-                longClickable: element.longClickable,
-                testTag: element.testTag,
-                role: element.role,
-                stateDescription: element.stateDescription,
-                errorMessage: element.errorMessage,
-                hintText: element.hintText,
-                actions: element.actions,
-                node: optimizedChildren
-            )]
+            return [Self.copying(element, node: optimizedChildren)]
         }
 
 
@@ -1632,7 +1580,7 @@ public class ElementLocator: ElementLocating {
             && lhsBounds.bottom == rhsBounds.bottom
     }
 
-    private static func copying(_ element: UIElementInfo, node: [UIElementInfo]?) -> UIElementInfo {
+    static func copying(_ element: UIElementInfo, node: [UIElementInfo]?) -> UIElementInfo {
         UIElementInfo(
             text: element.text,
             value: element.value,

--- a/ios/control-proxy/Sources/CtrlProxy/HierarchyMerger.swift
+++ b/ios/control-proxy/Sources/CtrlProxy/HierarchyMerger.swift
@@ -525,6 +525,7 @@ public enum HierarchyMerger {
             checked: element.checked,
             selected: element.selected,
             longClickable: element.longClickable,
+            semanticLinks: element.semanticLinks,
             testTag: element.testTag,
             role: element.role,
             stateDescription: element.stateDescription,

--- a/ios/control-proxy/Sources/CtrlProxy/Models.swift
+++ b/ios/control-proxy/Sources/CtrlProxy/Models.swift
@@ -155,6 +155,21 @@ public struct RequestActivateAccessibilityLink: Decodable {
     public var ownerResourceId: String?
 }
 
+/// Compact metadata for a discoverable accessibility link in an observed element.
+public struct SemanticLink: Codable, Equatable {
+    public let text: String
+    public let occurrence: Int
+    public let start: Int?
+    public let end: Int?
+
+    public init(text: String, occurrence: Int, start: Int? = nil, end: Int? = nil) {
+        self.text = text
+        self.occurrence = occurrence
+        self.start = start
+        self.end = end
+    }
+}
+
 public struct RequestLaunchApp: Decodable {
     public var requestId: String?
     public var bundleId: String
@@ -1166,6 +1181,7 @@ public struct UIElementInfo: Codable {
     public let checked: String?
     public let selected: String?
     public let longClickable: String?
+    public let semanticLinks: [SemanticLink]?
     public let testTag: String?
     public let role: String?
     public let stateDescription: String?
@@ -1180,6 +1196,7 @@ public struct UIElementInfo: Codable {
         case text, value, textSize, className, bounds, clickable, enabled
         case focusable, focused, scrollable, password, checkable, checked
         case selected, actions, node, role, testTag, extras
+        case semanticLinks = "semantic-links"
         case viewId = "view-id"
         case contentDesc = "content-desc"
         case resourceId = "resource-id"
@@ -1209,6 +1226,7 @@ public struct UIElementInfo: Codable {
         checked: String? = nil,
         selected: String? = nil,
         longClickable: String? = nil,
+        semanticLinks: [SemanticLink]? = nil,
         testTag: String? = nil,
         role: String? = nil,
         stateDescription: String? = nil,
@@ -1237,6 +1255,7 @@ public struct UIElementInfo: Codable {
         self.checked = checked
         self.selected = selected
         self.longClickable = longClickable
+        self.semanticLinks = semanticLinks
         self.testTag = testTag
         self.role = role
         self.stateDescription = stateDescription

--- a/ios/control-proxy/Tests/CtrlProxyTests/ElementLocatorTests.swift
+++ b/ios/control-proxy/Tests/CtrlProxyTests/ElementLocatorTests.swift
@@ -2,6 +2,18 @@
 import XCTest
 
 final class ElementLocatorTests: XCTestCase {
+    func testCopyingPreservesSemanticLinksOnRetainedLink() {
+        let link = UIElementInfo(
+            text: "Terms of Service",
+            clickable: "true",
+            semanticLinks: [SemanticLink(text: "Terms of Service", occurrence: 0)],
+            role: "link"
+        )
+        let optimized = ElementLocator.copying(link, node: nil)
+
+        XCTAssertEqual(optimized.semanticLinks, link.semanticLinks)
+    }
+
     // MARK: - SpringBoard fallback lookup (#4014)
 
     func testFirstMatchingElement_prefersForegroundApplication() {

--- a/ios/control-proxy/Tests/CtrlProxyTests/ModelsTests.swift
+++ b/ios/control-proxy/Tests/CtrlProxyTests/ModelsTests.swift
@@ -345,6 +345,24 @@ final class ModelsTests: XCTestCase {
         XCTAssertEqual(element.clickable, "false")
     }
 
+    func testUIElementInfoEncodesCompactSemanticLinkMetadata() throws {
+        let info = UIElementInfo(
+            text: "Terms of Service",
+            semanticLinks: [SemanticLink(text: "Terms of Service", occurrence: 0)],
+            role: "link"
+        )
+
+        let data = try JSONEncoder().encode(info)
+        let json = try XCTUnwrap(JSONSerialization.jsonObject(with: data) as? [String: Any])
+        let links = try XCTUnwrap(json["semantic-links"] as? [[String: Any]])
+
+        XCTAssertEqual(links.count, 1)
+        XCTAssertEqual(links[0]["text"] as? String, "Terms of Service")
+        XCTAssertEqual(links[0]["occurrence"] as? Int, 0)
+        XCTAssertNil(json["start"])
+        XCTAssertNil(json["end"])
+    }
+
     // MARK: - ElementBounds Tests
 
     func testElementBoundsComputedProperties() {

--- a/schemas/tool-definitions.json
+++ b/schemas/tool-definitions.json
@@ -336,6 +336,38 @@
                   "const": "false"
                 }
               ]
+            },
+            "semantic-links": {
+              "type": "array",
+              "items": {
+                "type": "object",
+                "properties": {
+                  "text": {
+                    "type": "string",
+                    "minLength": 1
+                  },
+                  "occurrence": {
+                    "type": "integer",
+                    "minimum": 0,
+                    "maximum": 9007199254740991
+                  },
+                  "start": {
+                    "type": "integer",
+                    "minimum": 0,
+                    "maximum": 9007199254740991
+                  },
+                  "end": {
+                    "type": "integer",
+                    "minimum": 0,
+                    "maximum": 9007199254740991
+                  }
+                },
+                "required": [
+                  "text",
+                  "occurrence"
+                ],
+                "additionalProperties": false
+              }
             }
           },
           "required": [
@@ -5448,6 +5480,38 @@
                   "const": "false"
                 }
               ]
+            },
+            "semantic-links": {
+              "type": "array",
+              "items": {
+                "type": "object",
+                "properties": {
+                  "text": {
+                    "type": "string",
+                    "minLength": 1
+                  },
+                  "occurrence": {
+                    "type": "integer",
+                    "minimum": 0,
+                    "maximum": 9007199254740991
+                  },
+                  "start": {
+                    "type": "integer",
+                    "minimum": 0,
+                    "maximum": 9007199254740991
+                  },
+                  "end": {
+                    "type": "integer",
+                    "minimum": 0,
+                    "maximum": 9007199254740991
+                  }
+                },
+                "required": [
+                  "text",
+                  "occurrence"
+                ],
+                "additionalProperties": false
+              }
             }
           },
           "required": [
@@ -5672,6 +5736,38 @@
                   "const": "false"
                 }
               ]
+            },
+            "semantic-links": {
+              "type": "array",
+              "items": {
+                "type": "object",
+                "properties": {
+                  "text": {
+                    "type": "string",
+                    "minLength": 1
+                  },
+                  "occurrence": {
+                    "type": "integer",
+                    "minimum": 0,
+                    "maximum": 9007199254740991
+                  },
+                  "start": {
+                    "type": "integer",
+                    "minimum": 0,
+                    "maximum": 9007199254740991
+                  },
+                  "end": {
+                    "type": "integer",
+                    "minimum": 0,
+                    "maximum": 9007199254740991
+                  }
+                },
+                "required": [
+                  "text",
+                  "occurrence"
+                ],
+                "additionalProperties": false
+              }
             }
           },
           "required": [
@@ -5896,6 +5992,38 @@
                   "const": "false"
                 }
               ]
+            },
+            "semantic-links": {
+              "type": "array",
+              "items": {
+                "type": "object",
+                "properties": {
+                  "text": {
+                    "type": "string",
+                    "minLength": 1
+                  },
+                  "occurrence": {
+                    "type": "integer",
+                    "minimum": 0,
+                    "maximum": 9007199254740991
+                  },
+                  "start": {
+                    "type": "integer",
+                    "minimum": 0,
+                    "maximum": 9007199254740991
+                  },
+                  "end": {
+                    "type": "integer",
+                    "minimum": 0,
+                    "maximum": 9007199254740991
+                  }
+                },
+                "required": [
+                  "text",
+                  "occurrence"
+                ],
+                "additionalProperties": false
+              }
             }
           },
           "required": [
@@ -6138,6 +6266,38 @@
                   "const": "false"
                 }
               ]
+            },
+            "semantic-links": {
+              "type": "array",
+              "items": {
+                "type": "object",
+                "properties": {
+                  "text": {
+                    "type": "string",
+                    "minLength": 1
+                  },
+                  "occurrence": {
+                    "type": "integer",
+                    "minimum": 0,
+                    "maximum": 9007199254740991
+                  },
+                  "start": {
+                    "type": "integer",
+                    "minimum": 0,
+                    "maximum": 9007199254740991
+                  },
+                  "end": {
+                    "type": "integer",
+                    "minimum": 0,
+                    "maximum": 9007199254740991
+                  }
+                },
+                "required": [
+                  "text",
+                  "occurrence"
+                ],
+                "additionalProperties": false
+              }
             }
           },
           "required": [
@@ -6364,6 +6524,38 @@
                     "const": "false"
                   }
                 ]
+              },
+              "semantic-links": {
+                "type": "array",
+                "items": {
+                  "type": "object",
+                  "properties": {
+                    "text": {
+                      "type": "string",
+                      "minLength": 1
+                    },
+                    "occurrence": {
+                      "type": "integer",
+                      "minimum": 0,
+                      "maximum": 9007199254740991
+                    },
+                    "start": {
+                      "type": "integer",
+                      "minimum": 0,
+                      "maximum": 9007199254740991
+                    },
+                    "end": {
+                      "type": "integer",
+                      "minimum": 0,
+                      "maximum": 9007199254740991
+                    }
+                  },
+                  "required": [
+                    "text",
+                    "occurrence"
+                  ],
+                  "additionalProperties": false
+                }
               }
             },
             "required": [
@@ -9738,6 +9930,38 @@
                   "const": "false"
                 }
               ]
+            },
+            "semantic-links": {
+              "type": "array",
+              "items": {
+                "type": "object",
+                "properties": {
+                  "text": {
+                    "type": "string",
+                    "minLength": 1
+                  },
+                  "occurrence": {
+                    "type": "integer",
+                    "minimum": 0,
+                    "maximum": 9007199254740991
+                  },
+                  "start": {
+                    "type": "integer",
+                    "minimum": 0,
+                    "maximum": 9007199254740991
+                  },
+                  "end": {
+                    "type": "integer",
+                    "minimum": 0,
+                    "maximum": 9007199254740991
+                  }
+                },
+                "required": [
+                  "text",
+                  "occurrence"
+                ],
+                "additionalProperties": false
+              }
             }
           },
           "required": [
@@ -10074,6 +10298,38 @@
                           "const": "false"
                         }
                       ]
+                    },
+                    "semantic-links": {
+                      "type": "array",
+                      "items": {
+                        "type": "object",
+                        "properties": {
+                          "text": {
+                            "type": "string",
+                            "minLength": 1
+                          },
+                          "occurrence": {
+                            "type": "integer",
+                            "minimum": 0,
+                            "maximum": 9007199254740991
+                          },
+                          "start": {
+                            "type": "integer",
+                            "minimum": 0,
+                            "maximum": 9007199254740991
+                          },
+                          "end": {
+                            "type": "integer",
+                            "minimum": 0,
+                            "maximum": 9007199254740991
+                          }
+                        },
+                        "required": [
+                          "text",
+                          "occurrence"
+                        ],
+                        "additionalProperties": false
+                      }
                     }
                   },
                   "required": [
@@ -10298,6 +10554,38 @@
                           "const": "false"
                         }
                       ]
+                    },
+                    "semantic-links": {
+                      "type": "array",
+                      "items": {
+                        "type": "object",
+                        "properties": {
+                          "text": {
+                            "type": "string",
+                            "minLength": 1
+                          },
+                          "occurrence": {
+                            "type": "integer",
+                            "minimum": 0,
+                            "maximum": 9007199254740991
+                          },
+                          "start": {
+                            "type": "integer",
+                            "minimum": 0,
+                            "maximum": 9007199254740991
+                          },
+                          "end": {
+                            "type": "integer",
+                            "minimum": 0,
+                            "maximum": 9007199254740991
+                          }
+                        },
+                        "required": [
+                          "text",
+                          "occurrence"
+                        ],
+                        "additionalProperties": false
+                      }
                     }
                   },
                   "required": [
@@ -11165,6 +11453,38 @@
                         "const": "false"
                       }
                     ]
+                  },
+                  "semantic-links": {
+                    "type": "array",
+                    "items": {
+                      "type": "object",
+                      "properties": {
+                        "text": {
+                          "type": "string",
+                          "minLength": 1
+                        },
+                        "occurrence": {
+                          "type": "integer",
+                          "minimum": 0,
+                          "maximum": 9007199254740991
+                        },
+                        "start": {
+                          "type": "integer",
+                          "minimum": 0,
+                          "maximum": 9007199254740991
+                        },
+                        "end": {
+                          "type": "integer",
+                          "minimum": 0,
+                          "maximum": 9007199254740991
+                        }
+                      },
+                      "required": [
+                        "text",
+                        "occurrence"
+                      ],
+                      "additionalProperties": false
+                    }
                   }
                 },
                 "required": [

--- a/schemas/tool-definitions.json
+++ b/schemas/tool-definitions.json
@@ -4931,6 +4931,41 @@
               "label": {
                 "type": "string"
               },
+              "testTag": {
+                "type": "string"
+              },
+              "semanticLinks": {
+                "type": "array",
+                "items": {
+                  "type": "object",
+                  "properties": {
+                    "text": {
+                      "type": "string",
+                      "minLength": 1
+                    },
+                    "occurrence": {
+                      "type": "integer",
+                      "minimum": 0,
+                      "maximum": 9007199254740991
+                    },
+                    "start": {
+                      "type": "integer",
+                      "minimum": 0,
+                      "maximum": 9007199254740991
+                    },
+                    "end": {
+                      "type": "integer",
+                      "minimum": 0,
+                      "maximum": 9007199254740991
+                    }
+                  },
+                  "required": [
+                    "text",
+                    "occurrence"
+                  ],
+                  "additionalProperties": false
+                }
+              },
               "bounds": {
                 "description": "Bounds as the compact [left, top, right, bottom] tuple — always this shape for skeleton entries.",
                 "type": "array",

--- a/src/features/observe/ViewHierarchy.ts
+++ b/src/features/observe/ViewHierarchy.ts
@@ -732,6 +732,7 @@ export class ViewHierarchy implements ViewHierarchyInterface {
       "content-desc",
       "clickable",
       "long-clickable",
+      "semantic-links",
       "scrollable",
       "enabled",
       "focusable",

--- a/src/features/observe/android/CtrlProxyHierarchy.ts
+++ b/src/features/observe/android/CtrlProxyHierarchy.ts
@@ -976,6 +976,9 @@ export class CtrlProxyHierarchy {
     if (node["long-clickable"] && node["long-clickable"] !== "false") {
       converted["long-clickable"] = node["long-clickable"];
     }
+    if (node["semantic-links"] && node["semantic-links"].length > 0) {
+      converted["semantic-links"] = node["semantic-links"];
+    }
 
     if (node.occlusionState) {
       converted.occlusionState = node.occlusionState;

--- a/src/features/observe/android/types.ts
+++ b/src/features/observe/android/types.ts
@@ -9,6 +9,7 @@ import type {
   BootedDevice,
   ContentHiddenRegion,
   RecompositionNodeInfo,
+  SemanticLink,
   ViewHierarchyWindowInfo
 } from "../../../models";
 import type { AdbExecutor } from "../../../utils/android-cmdline-tools/interfaces/AdbExecutor";
@@ -73,6 +74,7 @@ export interface AccessibilityNode {
   checked?: string;
   selected?: string;
   "long-clickable"?: string;
+  "semantic-links"?: SemanticLink[];
   occlusionState?: string;
   occludedBy?: string;
   occludedByViewId?: string;

--- a/src/features/observe/ios/CtrlProxyHierarchy.ts
+++ b/src/features/observe/ios/CtrlProxyHierarchy.ts
@@ -5,7 +5,7 @@
  * via the iOS CtrlProxy iOS WebSocket API.
  */
 
-import type { ViewHierarchyResult } from "../../../models";
+import type { SemanticLink, ViewHierarchyResult } from "../../../models";
 import { isDeepStrictEqual } from "node:util";
 import { screenScaleMetadataSpread } from "../../../models/ScreenScaleMetadata";
 import type { ViewHierarchyQueryOptions } from "../../../models/ViewHierarchyQueryOptions";
@@ -383,6 +383,7 @@ export class CtrlProxyHierarchy {
     const testTag = this.readNodeField<string>(node, "testTag", "test-tag");
     const accessibilityFocused = this.readNodeField<string>(node, "accessibilityFocused", "accessibility-focused");
     const longClickable = this.readNodeField<string>(node, "longClickable", "long-clickable");
+    const semanticLinks = this.readNodeField<SemanticLink[]>(node, "semanticLinks", "semantic-links");
     const stateDescription = this.readNodeField<string>(node, "stateDescription", "state-description");
     const errorMessage = this.readNodeField<string>(node, "errorMessage", "error-message");
     const hintText = this.readNodeField<string>(node, "hintText", "hint-text");
@@ -406,6 +407,9 @@ export class CtrlProxyHierarchy {
     if (node.checked) {attrs["checked"] = node.checked;}
     if (node.selected) {attrs["selected"] = node.selected;}
     if (longClickable) {attrs["long-clickable"] = longClickable;}
+    if (semanticLinks && semanticLinks.length > 0) {
+      attrs["semantic-links"] = semanticLinks;
+    }
     if (hasIosHeaderTrait(node.extras)) {
       attrs["role"] = "heading";
     } else if (node.role) {

--- a/src/features/observe/ios/types.ts
+++ b/src/features/observe/ios/types.ts
@@ -5,7 +5,7 @@
  * shared state and functionality from the main CtrlProxyClient.
  */
 
-import type { ViewHierarchyWindowInfo } from "../../../models";
+import type { SemanticLink, ViewHierarchyWindowInfo } from "../../../models";
 import type { ObservationInsets } from "../../../models/ObservationInsets";
 import type { CtrlProxyReconnectStatus } from "../../../models/CtrlProxyReconnectStatus";
 import type { HighlightOperationResult } from "../../../models";
@@ -54,6 +54,8 @@ export interface CtrlProxyNode {
   checked?: string;
   selected?: string;
   longClickable?: string;
+  semanticLinks?: SemanticLink[];
+  "semantic-links"?: SemanticLink[];
   testTag?: string;
   role?: string;
   stateDescription?: string;

--- a/src/features/observe/output/SkeletonProjection.ts
+++ b/src/features/observe/output/SkeletonProjection.ts
@@ -8,7 +8,9 @@ import type { Affordance, ObserveResult, SkeletonElement } from "../../../models
  *
  * `toSkeleton` collapses the already-computed `ObserveResult.elements`
  * (`{ clickable, scrollable, text, media }`) into a flat, actionable-only list —
- * `{ id, label, bounds, affordances }` — dropping layout scaffolding. It is a
+ * `{ id, label, bounds, affordances }` — dropping layout scaffolding. Embedded
+ * semantic links and a Compose test tag are retained only when present, because
+ * they make otherwise inaccessible link activation discoverable. It is a
  * pure merge + dedup + compaction of that structure: no device I/O, no tree
  * walk. The output is what an agent needs to decide "what can I do here, and
  * what does it say?", at a fraction of the token cost of the full hierarchy.
@@ -31,8 +33,8 @@ function nonEmptyString(value: unknown): string | undefined {
 /**
  * `id = resource-id ?? view-id`. The `view-id` slot is the stable content-hash
  * id from `assignStableViewIds` (`s-…`, #3228), so a row keeps its id across a
- * scroll. Compose `testTag` surfaces through `resource-id` in this codebase, so
- * there is no separate `test-tag` attribute to fall back to.
+ * scroll. A test tag is carried separately for Compose owners that do not enable
+ * `testTagsAsResourceId`.
  */
 function deriveId(el: Element): string | undefined {
   return nonEmptyString(el["resource-id"]) ?? nonEmptyString(el["view-id"]);
@@ -107,6 +109,8 @@ function boundsTuple(el: Element): SkeletonElement["bounds"] | undefined {
 interface SkeletonAccumulator {
   id?: string;
   label?: string;
+  testTag?: string;
+  semanticLinks?: SkeletonElement["semanticLinks"];
   bounds: SkeletonElement["bounds"];
   affordances: Set<Affordance>;
   checked?: boolean;
@@ -160,6 +164,12 @@ function accumulateByIdentity(elements: ObserveElements): SkeletonAccumulator[] 
     if (affordances.includes("toggle")) {
       acc.checked = isTruthy(el.checked);
     }
+    if (acc.testTag === undefined) {
+      acc.testTag = nonEmptyString(el["test-tag"]);
+    }
+    if (acc.semanticLinks === undefined && el["semantic-links"]?.length) {
+      acc.semanticLinks = el["semantic-links"];
+    }
   }
   return [...byIdentity.values()];
 }
@@ -191,6 +201,12 @@ function toSkeletonEntry(acc: SkeletonAccumulator): SkeletonElement {
   }
   if (acc.label !== undefined) {
     entry.label = acc.label;
+  }
+  if (acc.testTag !== undefined) {
+    entry.testTag = acc.testTag;
+  }
+  if (acc.semanticLinks !== undefined) {
+    entry.semanticLinks = acc.semanticLinks;
   }
   if (acc.checked !== undefined) {
     entry.checked = acc.checked;

--- a/src/models/Element.ts
+++ b/src/models/Element.ts
@@ -1,4 +1,5 @@
 import { ElementBounds } from "./ElementBounds";
+import type { SemanticLink } from "./SemanticLink";
 
 /**
  * Represents a UI element with its properties
@@ -21,6 +22,7 @@ export interface Element {
   scrollable?: boolean | string;
   orientation?: string;
   selected?: boolean | string;
+  "semantic-links"?: SemanticLink[];
   /** Hierarchy depth injected during exploration element extraction */
   hierarchyDepth?: number;
   /** Child nodes from XML parsing (e.g., Compose UI elements) */

--- a/src/models/ObserveResult.ts
+++ b/src/models/ObserveResult.ts
@@ -18,6 +18,7 @@ import type { MediaView } from "../features/observe/IdentifyMediaViews";
 import type { ObserveError } from "../features/observe/ObserveError";
 import type { LayoutWarnings, ObservationInsets } from "./ObservationInsets";
 import type { ObserveScopeMetadata } from "./ObserveScope";
+import type { SemanticLink } from "./SemanticLink";
 
 export interface PredictionTarget {
   text?: string;
@@ -78,6 +79,10 @@ export interface SkeletonElement {
   id?: string;
   /** `text ?? content-desc`. */
   label?: string;
+  /** Compose test tag, when supplied by the app; usable as the stable owner key for `subtext`. */
+  testTag?: string;
+  /** Embedded accessibility links, omitted unless this element exposes one. */
+  semanticLinks?: SemanticLink[];
   /** Compact bounds tuple `[left, top, right, bottom]`. */
   bounds: [number, number, number, number];
   /** Actionable affordances, in canonical order tap, long-press, input, scroll, toggle. */

--- a/src/models/SemanticLink.ts
+++ b/src/models/SemanticLink.ts
@@ -1,0 +1,10 @@
+/**
+ * An activatable accessibility link embedded in an observed text element.
+ * `occurrence` is zero-based among matching visible link texts in that element.
+ */
+export interface SemanticLink {
+  text: string;
+  occurrence: number;
+  start?: number;
+  end?: number;
+}

--- a/src/models/index.ts
+++ b/src/models/index.ts
@@ -94,6 +94,7 @@ export * from "./ViewHierarchyCache";
 export * from "./ViewHierarchyQueryOptions";
 export * from "./ViewHierarchyResult";
 export * from "./ScreenScaleMetadata";
+export * from "./SemanticLink";
 export * from "./CtrlProxyReconnectStatus";
 export * from "./Plan";
 export * from "./ExportPlanResult";

--- a/src/server/toolOutputSchemas.ts
+++ b/src/server/toolOutputSchemas.ts
@@ -4,6 +4,13 @@ import { z } from "zod/v4";
 // This schema accepts both for compatibility
 const booleanOrString = z.union([z.boolean(), z.literal("true"), z.literal("false")]).optional();
 
+const semanticLinkSchema = z.object({
+  text: z.string().min(1),
+  occurrence: z.number().int().nonnegative(),
+  start: z.number().int().nonnegative().optional(),
+  end: z.number().int().nonnegative().optional(),
+});
+
 // Default (verbose) bounds shape: the four-key object plus optional centers.
 //
 // Coordinates are plain numbers, NOT `.int()` (issue #3206): Android bounds are
@@ -77,6 +84,7 @@ export const elementSchema = z
     "accessibility-focused": booleanOrString,
     scrollable: booleanOrString,
     selected: booleanOrString,
+    "semantic-links": z.array(semanticLinkSchema).optional(),
   })
   .passthrough();
 

--- a/src/server/toolOutputSchemas.ts
+++ b/src/server/toolOutputSchemas.ts
@@ -528,6 +528,8 @@ export const skeletonElementSchema = z
   .object({
     id: z.string().optional(),
     label: z.string().optional(),
+    testTag: z.string().optional(),
+    semanticLinks: z.array(semanticLinkSchema).optional(),
     bounds: compactBoundsTupleSchema.describe(
       "Bounds as the compact [left, top, right, bottom] tuple — always this shape " +
         "for skeleton entries.",

--- a/test/features/action/TapOnElement.selectedElement.test.ts
+++ b/test/features/action/TapOnElement.selectedElement.test.ts
@@ -58,6 +58,21 @@ describe("TapOnElement selectedElement metadata", () => {
     expect((tapOnElement as any).hasUniqueSemanticLinkOwner(owner, hierarchy)).toBe(true);
   });
 
+  test("accepts a Compose semantic-link owner identified only by test tag", () => {
+    const tapOnElement = createTapOnElement();
+    const owner = ResultFaker.element({
+      text: "Terms and privacy",
+      "test-tag": "legal-copy",
+    });
+    const hierarchy = {
+      hierarchy: {
+        node: [{ ...owner, children: [] }],
+      },
+    };
+
+    expect((tapOnElement as any).hasUniqueSemanticLinkOwner(owner, hierarchy)).toBe(true);
+  });
+
   test("uses Android's complete stable selector for duplicate resource IDs", () => {
     const tapOnElement = createTapOnElement();
     const owner = ResultFaker.element({

--- a/test/features/observe/ViewHierarchy.test.ts
+++ b/test/features/observe/ViewHierarchy.test.ts
@@ -523,6 +523,28 @@ describe("ViewHierarchy", function() {
       });
     });
 
+    test("keeps semantic-link metadata while filtering hierarchy properties", function() {
+      const result = viewHierarchy.filterViewHierarchy({
+        hierarchy: {
+          $: { class: "android.widget.TextView" },
+          node: {
+            $: {
+              text: "Terms of Service",
+              "semantic-links": [{ text: "Terms of Service", occurrence: 0, start: 0, end: 16 }],
+            },
+          },
+        },
+      });
+
+      expect(result.hierarchy).toEqual({
+        $: { class: "android.widget.TextView" },
+        node: {
+          text: "Terms of Service",
+          "semantic-links": [{ text: "Terms of Service", occurrence: 0, start: 0, end: 16 }],
+        },
+      });
+    });
+
     test("returns an empty child list at the root when every descendant is filtered out", function() {
       // Regression for issue #4172 item 4 / A3: filterSingleNode's root branch
       // must overwrite the cloned children even when NOTHING survives, otherwise

--- a/test/features/observe/android/ctrlProxyHierarchySemanticLinks.test.ts
+++ b/test/features/observe/android/ctrlProxyHierarchySemanticLinks.test.ts
@@ -1,0 +1,40 @@
+import { describe, expect, test } from "bun:test";
+import { CtrlProxyHierarchy } from "../../../../src/features/observe/android/CtrlProxyHierarchy";
+import type { HierarchyDelegateContext } from "../../../../src/features/observe/android/types";
+import { RequestManager } from "../../../../src/utils/RequestManager";
+import { FakeTimer } from "../../../fakes/FakeTimer";
+
+function createHierarchy(): CtrlProxyHierarchy {
+  const timer = new FakeTimer();
+  const context: HierarchyDelegateContext = {
+    getWebSocket: () => null,
+    requestManager: new RequestManager(timer),
+    timer,
+    ensureConnected: async () => true,
+    cancelScreenshotBackoff: () => {},
+    device: { deviceId: "emulator-5554", platform: "android" } as never,
+    adb: {} as never,
+    getCachedHierarchy: () => null,
+    setCachedHierarchy: () => {},
+    getLastWebSocketTimeout: () => 0,
+    setLastWebSocketTimeout: () => {},
+  };
+  return new CtrlProxyHierarchy(context);
+}
+
+describe("CtrlProxyHierarchy semantic links", () => {
+  test("retains Android runner semantic-link metadata in the converted hierarchy", () => {
+    const result = createHierarchy().convertToViewHierarchyResult({
+      hierarchy: {
+        text: "Read the Terms of Service",
+        bounds: { left: 0, top: 0, right: 200, bottom: 40 },
+        "semantic-links": [{ text: "Terms of Service", occurrence: 0, start: 9, end: 25 }],
+      },
+      updatedAt: 1,
+    });
+
+    expect(result.hierarchy["semantic-links"]).toEqual([
+      { text: "Terms of Service", occurrence: 0, start: 9, end: 25 },
+    ]);
+  });
+});

--- a/test/features/observe/android/ctrlProxyProtocol.test.ts
+++ b/test/features/observe/android/ctrlProxyProtocol.test.ts
@@ -272,6 +272,20 @@ describe("ctrlProxyProtocol — builders serialize byte-identically", () => {
         '{"type":"request_activate_accessibility_link","requestId":"link-1","text":"Terms of Service","occurrence":1,"selector":{"resourceId":"com.example:id/legal"}}',
     },
     {
+      builder: "requestActivateAccessibilityLink",
+      name: "semantic link activation carries a Compose test-tag owner selector",
+      actual: serializeCtrlProxyRequest(
+        ctrlProxyRequests.requestActivateAccessibilityLink({
+          requestId: "link-2",
+          text: "Privacy Policy",
+          occurrence: 0,
+          selector: { testTag: "legal-copy" },
+        }),
+      ),
+      expected:
+        '{"type":"request_activate_accessibility_link","requestId":"link-2","text":"Privacy Policy","occurrence":0,"selector":{"testTag":"legal-copy"}}',
+    },
+    {
       builder: "requestClipboard",
       name: "text included for copy",
       actual: serializeCtrlProxyRequest(

--- a/test/features/observe/ios/CtrlProxyHierarchy.test.ts
+++ b/test/features/observe/ios/CtrlProxyHierarchy.test.ts
@@ -39,6 +39,18 @@ function makeHierarchy(root: CtrlProxyNode): any {
 describe("CtrlProxyHierarchy.convertToViewHierarchyResult", () => {
   const subject = new CtrlProxyHierarchy(stubContext);
 
+  test("preserves compact semantic-link metadata from the iOS runner", () => {
+    const result = subject.convertToViewHierarchyResult(makeHierarchy({
+      text: "Terms of Service",
+      role: "link",
+      "semantic-links": [{ text: "Terms of Service", occurrence: 0 }],
+    }));
+
+    expect((result.hierarchy.node as any).$["semantic-links"]).toEqual([
+      { text: "Terms of Service", occurrence: 0 },
+    ]);
+  });
+
   test("preserves capture-time device rotation", () => {
     const result = subject.convertToViewHierarchyResult({
       ...makeHierarchy({ className: "XCUIApplication" }),

--- a/test/features/observe/output/skeletonProjection.test.ts
+++ b/test/features/observe/output/skeletonProjection.test.ts
@@ -62,6 +62,27 @@ describe("toSkeleton — acceptance criteria", () => {
     });
   });
 
+  test("retains compact semantic links and a Compose owner test tag when present", () => {
+    const composeText: Element = {
+      bounds: bounds(0, 0, 200, 40),
+      text: "Terms of Service",
+      "test-tag": "legal-copy",
+      "semantic-links": [{ text: "Terms of Service", occurrence: 0, start: 0, end: 16 }],
+    };
+
+    const skeleton = toSkeleton(makeElements({ text: [composeText] }));
+
+    expect(skeleton).toEqual([
+      {
+        bounds: [0, 0, 200, 40],
+        label: "Terms of Service",
+        testTag: "legal-copy",
+        semanticLinks: [{ text: "Terms of Service", occurrence: 0, start: 0, end: 16 }],
+        affordances: [],
+      },
+    ]);
+  });
+
   describe("AC3: affordance derivation across boolean | string inputs", () => {
     const cases: Array<{ name: string; attr: Partial<Element>; expected: SkeletonElement["affordances"] }> = [
       { name: "clickable", attr: { clickable: true }, expected: ["tap"] },

--- a/test/server/finalizeToolResponse.test.ts
+++ b/test/server/finalizeToolResponse.test.ts
@@ -1752,6 +1752,8 @@ describe("finalizeToolResponse", () => {
             "resource-id": "com.example:id/btn",
             "text": "Submit",
             "clickable": "true",
+            "test-tag": "submit-with-terms",
+            "semantic-links": [{ text: "Terms", occurrence: 0, start: 7, end: 12 }],
           } as any,
         ],
         scrollable: [],
@@ -1771,6 +1773,8 @@ describe("finalizeToolResponse", () => {
       expect(sc.skeleton!.length).toBeGreaterThan(0);
       expect(sc.viewHierarchy).toBeUndefined();
       expect(sc.elements).toBeUndefined();
+      expect(sc.skeleton![0].testTag).toBe("submit-with-terms");
+      expect(sc.skeleton![0].semanticLinks).toEqual([{ text: "Terms", occurrence: 0, start: 7, end: 12 }]);
       // text mirror agrees with structuredContent.
       const parsed = JSON.parse(finalized.content[0].text);
       expect(parsed.skeleton.length).toBe(sc.skeleton!.length);

--- a/test/server/observeOutputSchema.test.ts
+++ b/test/server/observeOutputSchema.test.ts
@@ -473,6 +473,8 @@ describe("observe tool registration advertises the schema (#3025)", () => {
       const json = JSON.stringify((observe as Record<string, unknown>).outputSchema);
       expect(json).toContain("\"skeleton\"");
       expect(json).toContain("\"affordances\"");
+      expect(json).toContain("\"semanticLinks\"");
+      expect(json).toContain("\"testTag\"");
     });
   });
 });

--- a/test/server/toolOutputSchemas.test.ts
+++ b/test/server/toolOutputSchemas.test.ts
@@ -48,6 +48,18 @@ describe("elementBoundsSchema: object + compact tuple (#2990)", () => {
     expect(elementSchema.parse(el)).toMatchObject({ bounds: tupleBounds, text: "btn" });
   });
 
+  test("elementSchema advertises compact semantic-link metadata", () => {
+    const element = elementSchema.parse({
+      bounds: tupleBounds,
+      text: "Read Terms of Service",
+      "semantic-links": [{ text: "Terms of Service", occurrence: 0, start: 5, end: 21 }],
+    });
+
+    expect(element["semantic-links"]).toEqual([
+      { text: "Terms of Service", occurrence: 0, start: 5, end: 21 },
+    ]);
+  });
+
   test("the advertised JSON schema documents the tuple order (machine-readable)", () => {
     const json = JSON.stringify(toJSONSchema(tapOnResultSchema));
     // The union carries a description naming the positional tuple order, so an


### PR DESCRIPTION
## Summary

Follow-up to [#5536](https://github.com/kaeawc/auto-mobile/pull/5536) that makes semantic accessibility links discoverable through `observe`.

- Android emits compact `semantic-links` metadata for `ClickableSpan` text, including visible text, per-text occurrence, and character range.
- iOS emits equivalent metadata for native `.link` elements and preserves it through the TypeScript hierarchy path.
- Regenerates the observe output schema/tool definitions and adds regression coverage for the existing Compose `testTag` owner-selector activation route.

## Why

`tapOn` could activate semantic links, but agents could not discover embedded Android links from an observation. Link metadata is omitted when absent to preserve default payload size.

## User impact

Agents can inspect `semantic-links` before choosing an accessibility-link target. A re-cut Android CtrlProxy APK and iOS runner are required before connected devices expose the new field.

## Validation

- `turbo run lint build test`
- `bun run typecheck`
- `bash scripts/oxlint-baseline.sh`
- `(cd android && ./gradlew :control-proxy:testDebugUnitTest)`
- `(cd ios/control-proxy && swift test)`
