### PR TITLE
refactor(android): extract stale-frame rejection dispatch, keep it exhaustive (#4577)

### DIFF
--- a/android/control-proxy/src/main/kotlin/dev/jasonpearson/automobile/ctrlproxy/CtrlProxy.kt
+++ b/android/control-proxy/src/main/kotlin/dev/jasonpearson/automobile/ctrlproxy/CtrlProxy.kt
@@ -1902,29 +1902,45 @@ class CtrlProxy : AccessibilityService(), CtrlProxyActions {
     if (expected == null || expected == currentFrameContext()) return false
     val error =
       "Stale frame context for input/${action.wireName}; observe a fresh frame before retrying"
-    launchRequestScope(requestId) {
-      when (action) {
-        StaleFrameContextAction.TAP -> broadcastTapCoordinatesResult(requestId, false, error, 0)
-        StaleFrameContextAction.SWIPE -> broadcastSwipeResult(requestId, false, error, 0, null)
-        StaleFrameContextAction.DRAG -> broadcastDragResult(requestId, false, error, 0, null)
-        StaleFrameContextAction.SET_TEXT -> broadcastSetTextResult(requestId, false, error, 0)
-        StaleFrameContextAction.IME_ACTION ->
-          broadcastImeActionResult(requestId, action.wireName, false, error, 0)
-        StaleFrameContextAction.GLOBAL_ACTION ->
-          webSocketServer.broadcast(
-            dev.jasonpearson.automobile.protocol.GlobalActionResult(
-              timestamp = System.currentTimeMillis(),
-              requestId = requestId,
-              success = false,
-              action = action.wireName,
-              totalTimeMs = 0,
-              error = error,
-            )
-          )
-      }
-    }
+    launchRequestScope(requestId) { broadcastStaleFrameRejection(requestId, action, error) }
     return true
   }
+
+  /**
+   * Broadcasts the correlated stale-frame rejection for [action].
+   *
+   * A future [StaleFrameContextAction] added without its own branch must never route through no
+   * branch and leave the caller to hang until timeout (issue #4577). At this module's Kotlin
+   * language version the compiler already enforces that: a non-exhaustive `when` over the enum is a
+   * compile error in statement or expression form. This is written expression-bodied so the
+   * guarantee also survives lowering the language version below the level where non-exhaustive
+   * `when` *statements* became errors (they are only warnings pre-2.0). Do not add an `else ->`
+   * branch — it would defeat the check by making a missing action compile.
+   */
+  private suspend fun broadcastStaleFrameRejection(
+    requestId: String?,
+    action: StaleFrameContextAction,
+    error: String,
+  ) =
+    when (action) {
+      StaleFrameContextAction.TAP -> broadcastTapCoordinatesResult(requestId, false, error, 0)
+      StaleFrameContextAction.SWIPE -> broadcastSwipeResult(requestId, false, error, 0, null)
+      StaleFrameContextAction.DRAG -> broadcastDragResult(requestId, false, error, 0, null)
+      StaleFrameContextAction.SET_TEXT -> broadcastSetTextResult(requestId, false, error, 0)
+      StaleFrameContextAction.IME_ACTION ->
+        broadcastImeActionResult(requestId, action.wireName, false, error, 0)
+      StaleFrameContextAction.GLOBAL_ACTION ->
+        webSocketServer.broadcast(
+          dev.jasonpearson.automobile.protocol.GlobalActionResult(
+            timestamp = System.currentTimeMillis(),
+            requestId = requestId,
+            success = false,
+            action = action.wireName,
+            totalTimeMs = 0,
+            error = error,
+          )
+        )
+    }
 
   override fun requestPinch(
     requestId: String?,

--- a/android/control-proxy/src/test/kotlin/dev/jasonpearson/automobile/ctrlproxy/StaleFrameContextRejectionWiringTest.kt
+++ b/android/control-proxy/src/test/kotlin/dev/jasonpearson/automobile/ctrlproxy/StaleFrameContextRejectionWiringTest.kt
@@ -11,8 +11,16 @@ import org.junit.Test
  * Structural regression guard for issue #4577.
  *
  * CtrlProxy is an AccessibilityService and cannot be constructed in a fast unit test. This source
- * test instead verifies that every stale-frame rejection routes through a closed action set, and
- * that the dispatch remains exhaustive without a silent fallback branch.
+ * test instead verifies that every stale-frame rejection routes through a closed action set with an
+ * explicit correlated response per action.
+ *
+ * The compile-time no-silent-timeout guarantee comes from the Kotlin compiler: at this module's
+ * language version a non-exhaustive `when` over [StaleFrameContextAction] is a compile error
+ * (statement or expression form alike), so a future action added without a branch cannot compile.
+ * The one way to defeat that in source is a catch-all `else ->` branch, which would let the `when`
+ * compile with a missing action and reopen the silent-timeout window — so this test asserts the
+ * dispatch stays free of `else ->`, keeps a branch for every action, and preserves each action's
+ * correlated response envelope.
  */
 class StaleFrameContextRejectionWiringTest {
 
@@ -49,11 +57,16 @@ class StaleFrameContextRejectionWiringTest {
   fun `stale frame rejection accepts a typed action and dispatches every action`() {
     val source = KotlinSourceScan.maskLiteralsAndComments(readCtrlProxySource())
     val signature = rejectionSignature(source)
-    val body = rejectionBody(source)
+    val body = dispatchBody(source)
 
     assertTrue(
       "rejectStaleFrameContext must accept StaleFrameContextAction rather than a raw String",
       "action: StaleFrameContextAction" in signature,
+    )
+    assertTrue(
+      "rejectStaleFrameContext must delegate to the exhaustive dispatcher",
+      Regex("""broadcastStaleFrameRejection\(\s*requestId\s*,\s*action\s*,\s*error\s*\)""")
+        .containsMatchIn(rejectionBody(source)),
     )
     assertFalse(
       "the typed dispatch must stay exhaustive rather than silently ignoring a future action",
@@ -97,6 +110,22 @@ class StaleFrameContextRejectionWiringTest {
     val bodyOpen = source.indexOf('{', start)
     assertTrue("rejectStaleFrameContext body not found in CtrlProxy.kt", bodyOpen >= 0)
     return source.substring(bodyOpen, KotlinSourceScan.matchBrace(source, bodyOpen))
+  }
+
+  /** The `{ ... }` of the `when (action)` inside `broadcastStaleFrameRejection`. */
+  private fun dispatchBody(source: String): String {
+    val whenStart = dispatchWhenIndex(source)
+    val braceOpen = source.indexOf('{', whenStart)
+    assertTrue("broadcastStaleFrameRejection when body not found", braceOpen >= 0)
+    return source.substring(braceOpen, KotlinSourceScan.matchBrace(source, braceOpen))
+  }
+
+  private fun dispatchWhenIndex(source: String): Int {
+    val start = source.indexOf("fun broadcastStaleFrameRejection(")
+    assertTrue("broadcastStaleFrameRejection not found in CtrlProxy.kt", start >= 0)
+    val whenStart = source.indexOf("when (action)", start)
+    assertTrue("broadcastStaleFrameRejection when(action) not found", whenStart >= 0)
+    return whenStart
   }
 
   private fun routedActions(body: String): Set<String> =


### PR DESCRIPTION
Follow-up to #4577.

## What this is (and isn't)

Reviewing the code showed that **#4577's core ask was already satisfied by #4649**. At this module's Kotlin language version (`build-kotlin-language = "2.3"`), a non-exhaustive `when` over the `StaleFrameContextAction` enum is a **compile error** — in statement *and* expression form. So the typed-enum dispatch #4649 introduced already made it structurally impossible to route a stale-frame rejection through an unsupported action without a correlated response.

This PR is therefore a **small readability/robustness follow-up**, not a new guarantee:

- Extract the dispatch out of the coroutine lambda into an expression-bodied `broadcastStaleFrameRejection`. Expression form keeps exhaustiveness compiler-enforced even if the language version is ever lowered below the level where non-exhaustive `when` **statements** became errors (pre-2.0 they are only warnings).
- Behaviour is unchanged: identical per-action response envelopes for `tap`, `swipe`, `drag`, `set_text`, `ime_action`, `global_action`; same coroutine scope; same error text.
- Extend `StaleFrameContextRejectionWiringTest` to assert the delegation, and keep the meaningful source guard: **no `else ->`** (a catch-all is the one way to defeat the compiler's exhaustiveness and reopen the silent-timeout window), all six actions routed, per-action envelope shapes, typed call sites.

## Codex P2 addressed

Codex correctly pointed out that a source-shape assertion requiring the *expression body* would wrongly fail a safe block-bodied refactor, since at language 2.3 a block-bodied statement `when` is equally exhaustive. Verified locally: converting the dispatcher to a block body with a missing branch fails to compile (`'when' expression must be exhaustive`). The expression-vs-block assertion has been **removed**; the no-`else ->` guard remains.

## Validation

- `:control-proxy:testDebugUnitTest --tests "*StaleFrameContext*"` — pass
- Sibling `*BroadcastGuardScanner*` — pass
- `ktfmt --google-style` — clean; `:control-proxy:detekt` — pass
- Rebased on latest `main`.

If preferred, an equally valid outcome is to **close #4577 as already-resolved by #4649** and close this PR — its remaining value is modest.

🤖 Generated autonomously (scheduled next-best-issue run + self-review).
