### PR TITLE
fix(observe): retain scoped semantic links

### DIFF
--- a/android/control-proxy/src/main/kotlin/dev/jasonpearson/automobile/ctrlproxy/ViewHierarchyExtractor.kt
+++ b/android/control-proxy/src/main/kotlin/dev/jasonpearson/automobile/ctrlproxy/ViewHierarchyExtractor.kt
@@ -15,7 +15,6 @@ import dev.jasonpearson.automobile.ctrlproxy.models.TraversalOrderResult
 import dev.jasonpearson.automobile.ctrlproxy.models.UIElementInfo
 import dev.jasonpearson.automobile.ctrlproxy.models.ViewHierarchy
 import dev.jasonpearson.automobile.ctrlproxy.models.WindowInfo
-import java.util.Locale
 import kotlin.math.max
 import kotlin.math.min
 
@@ -1029,7 +1028,7 @@ class ViewHierarchyExtractor(private val recompositionStore: RecompositionStore?
     apiLevel: Int = Build.VERSION.SDK_INT,
   ): List<SemanticLink>? {
     if (apiLevel < Build.VERSION_CODES.O || text !is Spanned) return null
-    val occurrences = mutableMapOf<String, Int>()
+    val priorLinkTexts = mutableListOf<String>()
     val links =
       text
         .getSpans(0, text.length, ClickableSpan::class.java)
@@ -1040,11 +1039,10 @@ class ViewHierarchyExtractor(private val recompositionStore: RecompositionStore?
           if (start < 0 || end <= start || end > text.length) return@mapNotNull null
           val visibleText = text.subSequence(start, end).toString()
           if (visibleText.isBlank()) return@mapNotNull null
-          // Activation matches span text case-insensitively, so discovery must
-          // use the same equivalence relation for occurrence numbering.
-          val occurrenceKey = visibleText.lowercase(Locale.ROOT)
-          val occurrence = occurrences[occurrenceKey] ?: 0
-          occurrences[occurrenceKey] = occurrence + 1
+          // Activation uses String.equals(ignoreCase = true); count prior links
+          // with that exact equivalence rather than an approximate lowercase key.
+          val occurrence = priorLinkTexts.count { it.equals(visibleText, ignoreCase = true) }
+          priorLinkTexts += visibleText
           SemanticLink(visibleText, occurrence, start, end)
         }
     return links.ifEmpty { null }

--- a/android/control-proxy/src/test/kotlin/dev/jasonpearson/automobile/ctrlproxy/ViewHierarchyExtractorTest.kt
+++ b/android/control-proxy/src/test/kotlin/dev/jasonpearson/automobile/ctrlproxy/ViewHierarchyExtractorTest.kt
@@ -202,6 +202,35 @@ class ViewHierarchyExtractorTest {
   }
 
   @Test
+  fun `semantic link occurrences use the same Unicode case matching as activation`() {
+    val text = SpannableString("İ i")
+    text.setSpan(
+      object : ClickableSpan() {
+        override fun onClick(widget: View) = Unit
+      },
+      0,
+      1,
+      0,
+    )
+    text.setSpan(
+      object : ClickableSpan() {
+        override fun onClick(widget: View) = Unit
+      },
+      2,
+      3,
+      0,
+    )
+
+    assertEquals(
+      listOf(
+        SemanticLink("İ", 0, 0, 1),
+        SemanticLink("i", 1, 2, 3),
+      ),
+      extractor.semanticLinksFromText(text, apiLevel = 26),
+    )
+  }
+
+  @Test
   fun `semantic links stay absent below API 26 and for plain text`() {
     val spanned = SpannableString("Terms")
     spanned.setSpan(

--- a/ios/control-proxy/CtrlProxy.xcodeproj/project.pbxproj
+++ b/ios/control-proxy/CtrlProxy.xcodeproj/project.pbxproj
@@ -73,6 +73,7 @@
 		BD4056F11836FEAB9B99D1AC /* RotationChangeGenerationTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 0033E307147A024BE2F74149 /* RotationChangeGenerationTests.swift */; };
 		BD627F44D1B9F2D3976AA0EC /* Models.swift in Sources */ = {isa = PBXBuildFile; fileRef = D81453AD074F2A392251CFC3 /* Models.swift */; };
 		BD7D2FF024054ED74F17958D /* Models.swift in Sources */ = {isa = PBXBuildFile; fileRef = D81453AD074F2A392251CFC3 /* Models.swift */; };
+		BFB031F7CA24581B120C7245 /* GesturePerformerSemanticLinkTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 5183F2760E4AF36B69D80293 /* GesturePerformerSemanticLinkTests.swift */; };
 		C1398B388B401E28BC727863 /* OSLogReader.swift in Sources */ = {isa = PBXBuildFile; fileRef = DBA97A6C3A1240A055D9876C /* OSLogReader.swift */; };
 		C194D73F02D0776F0F7FCA7B /* CtrlProxy.swift in Sources */ = {isa = PBXBuildFile; fileRef = 0EE277596991C059142C485B /* CtrlProxy.swift */; };
 		C2DCB71857A14ED314300AAC /* WebSocketServer.swift in Sources */ = {isa = PBXBuildFile; fileRef = B4CB9272A186932D89EB1072 /* WebSocketServer.swift */; };
@@ -203,6 +204,7 @@
 		3E5AAA4E2861D92C17F39B14 /* HierarchyDebouncerTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = HierarchyDebouncerTests.swift; sourceTree = "<group>"; };
 		42C53A4D56EE97B5BD11EC63 /* Debug.xcconfig */ = {isa = PBXFileReference; lastKnownFileType = text.xcconfig; path = Debug.xcconfig; sourceTree = "<group>"; };
 		4EE070E3D058AF5F67D2E1F3 /* PinchGeometryTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = PinchGeometryTests.swift; sourceTree = "<group>"; };
+		5183F2760E4AF36B69D80293 /* GesturePerformerSemanticLinkTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = GesturePerformerSemanticLinkTests.swift; sourceTree = "<group>"; };
 		5408FE8438060177DDAE7177 /* SdkHierarchyCacheTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SdkHierarchyCacheTests.swift; sourceTree = "<group>"; };
 		637A2A05C90AA6E64D224651 /* CtrlProxyTests.xctest */ = {isa = PBXFileReference; includeInIndex = 0; lastKnownFileType = wrapper.cfbundle; path = CtrlProxyTests.xctest; sourceTree = BUILT_PRODUCTS_DIR; };
 		649A3185201F07E4D152CED6 /* ObjCExceptionBridgeTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ObjCExceptionBridgeTests.swift; sourceTree = "<group>"; };
@@ -300,6 +302,7 @@
 				B7BE98EA2924A42A6CD22993 /* ElementLocatorTests.swift */,
 				76DC5538569B4FCF89EA7547 /* ErrorResponseTypeTests.swift */,
 				0C7A827A4CDA083F75436C2A /* FrameContextSafetyTests.swift */,
+				5183F2760E4AF36B69D80293 /* GesturePerformerSemanticLinkTests.swift */,
 				CCAAB1439B71724CA0BF2401 /* GesturePerformerSymbolsUnavailableWiringTests.swift */,
 				3E5AAA4E2861D92C17F39B14 /* HierarchyDebouncerTests.swift */,
 				0F6E995191B4AF437EDB71CA /* HierarchyMergerTests.swift */,
@@ -646,6 +649,7 @@
 				E8B2051927387427E1F14EC2 /* ElementLocatorTests.swift in Sources */,
 				FBAA2ADC92863B6A10403BA1 /* ErrorResponseTypeTests.swift in Sources */,
 				9344F9D095AA18CD7DAC3C91 /* FrameContextSafetyTests.swift in Sources */,
+				BFB031F7CA24581B120C7245 /* GesturePerformerSemanticLinkTests.swift in Sources */,
 				671E243A2BD5CAF78FF48E1D /* GesturePerformerSymbolsUnavailableWiringTests.swift in Sources */,
 				4413FD9E4C8BF4071C74D482 /* HierarchyDebouncerTests.swift in Sources */,
 				CFCA362E1EF1F3251B19BC1B /* HierarchyMergerTests.swift in Sources */,

--- a/ios/control-proxy/Sources/CtrlProxy/GesturePerformer.swift
+++ b/ios/control-proxy/Sources/CtrlProxy/GesturePerformer.swift
@@ -269,6 +269,16 @@ public class GesturePerformer: GesturePerforming {
         }
     }
 
+    /// Includes a scoped owner when the owner is itself a link; XCUITest's
+    /// descendants query otherwise excludes that element.
+    static func scopedLinkCandidates<Element>(
+        owner: Element,
+        ownerIsLink: Bool,
+        descendants: [Element]
+    ) -> [Element] {
+        ownerIsLink ? [owner] + descendants : descendants
+    }
+
     /// Every AutoMobile permission name that maps to a resettable iOS
     /// `XCUIProtectedResource` (Xcode 26.3 header). The `all` keyword expands to
     /// this list; the TS host list in `IosPhysicalPermissions.ts`
@@ -1106,7 +1116,12 @@ public class GesturePerformer: GesturePerforming {
                             "Semantic link owner '\(ownerResourceId)' is missing, not actionable, or ambiguous"
                         )
                     }
-                    links = owners[0].descendants(matching: .link).allElementsBoundByIndex
+                    let owner = owners[0]
+                    links = Self.scopedLinkCandidates(
+                        owner: owner,
+                        ownerIsLink: owner.elementType == .link,
+                        descendants: owner.descendants(matching: .link).allElementsBoundByIndex
+                    )
                 } else {
                     links = app.links.allElementsBoundByIndex
                 }

--- a/ios/control-proxy/Tests/CtrlProxyTests/GesturePerformerSemanticLinkTests.swift
+++ b/ios/control-proxy/Tests/CtrlProxyTests/GesturePerformerSemanticLinkTests.swift
@@ -1,0 +1,26 @@
+@testable import CtrlProxy
+import XCTest
+
+final class GesturePerformerSemanticLinkTests: XCTestCase {
+    func testScopedLinkCandidatesIncludesAnOwnerThatIsItselfALink() {
+        XCTAssertEqual(
+            GesturePerformer.scopedLinkCandidates(
+                owner: "Terms of Service",
+                ownerIsLink: true,
+                descendants: ["Privacy Policy"]
+            ),
+            ["Terms of Service", "Privacy Policy"]
+        )
+    }
+
+    func testScopedLinkCandidatesExcludesANonLinkOwner() {
+        XCTAssertEqual(
+            GesturePerformer.scopedLinkCandidates(
+                owner: "Legal card",
+                ownerIsLink: false,
+                descendants: ["Terms of Service"]
+            ),
+            ["Terms of Service"]
+        )
+    }
+}

--- a/src/features/observe/output/SkeletonProjection.ts
+++ b/src/features/observe/output/SkeletonProjection.ts
@@ -175,13 +175,16 @@ function accumulateByIdentity(elements: ObserveElements): SkeletonAccumulator[] 
 }
 
 /**
- * Keep rule (issue #4388): a row is kept if it has ≥1 affordance, OR it carries
- * a non-empty label with no clickable ancestor (so pure-content screens stay
- * readable/assertable, while a button's inner label is suppressed in favor of
- * the tappable row).
+ * Keep rule (issue #4388): a row is kept if it has ≥1 affordance, carries
+ * semantic links, OR carries a non-empty label with no clickable ancestor.
+ * Semantic links remain independently discoverable even when the linked text is
+ * inside a generic tappable card that would otherwise suppress its text row.
  */
 function shouldKeep(acc: SkeletonAccumulator, clickableBounds: SkeletonElement["bounds"][]): boolean {
   if (acc.affordances.size > 0) {
+    return true;
+  }
+  if (acc.semanticLinks?.length) {
     return true;
   }
   if (acc.label === undefined) {

--- a/test/features/action/InputText.test.ts
+++ b/test/features/action/InputText.test.ts
@@ -114,19 +114,16 @@ describe("InputText", () => {
     const inputText = new InputText(androidDevice, factory as AdbClientFactory);
 
     let capturedFactory: unknown = undefined;
-    AndroidCtrlProxyClient.getInstance = ((device: BootedDevice, adbFactory: AdbClientFactory) => {
+    AndroidCtrlProxyClient.getInstance = ((_device: BootedDevice, adbFactory: AdbClientFactory) => {
       capturedFactory = adbFactory;
-      return originalGetInstance(device, adbFactory);
+      return {
+        requestSetText: async () => ({ success: false, totalTimeMs: 0 }),
+      };
     }) as typeof AndroidCtrlProxyClient.getInstance;
 
-    try {
-      await (inputText as unknown as {
-        executeAndroidTextInput: (text: string) => Promise<unknown>;
-      }).executeAndroidTextInput("hello");
-    } catch {
-      // Ignore downstream failures — we only care that getInstance was
-      // handed a factory, not an executor.
-    }
+    await (inputText as unknown as {
+      executeAndroidTextInput: (text: string) => Promise<unknown>;
+    }).executeAndroidTextInput("hello");
 
     expect(capturedFactory).toBeDefined();
     expect(typeof (capturedFactory as AdbClientFactory).create).toBe("function");

--- a/test/features/observe/output/skeletonProjection.test.ts
+++ b/test/features/observe/output/skeletonProjection.test.ts
@@ -243,6 +243,28 @@ describe("toSkeleton — acceptance criteria", () => {
       expect(skeleton[0].id).toBe("row");
       expect(skeleton[0].affordances).toEqual(["tap"]);
     });
+
+    test("linked text with a clickable ancestor remains discoverable", () => {
+      const card: Element = {
+        bounds: bounds(0, 0, 300, 80),
+        "resource-id": "card",
+        clickable: "true",
+      };
+      const linkedText: Element = {
+        bounds: bounds(20, 20, 120, 60),
+        text: "Terms of Service",
+        "test-tag": "legal-copy",
+        "semantic-links": [{ text: "Terms of Service", occurrence: 0, start: 0, end: 16 }],
+      };
+
+      const skeleton = toSkeleton(makeElements({ clickable: [card], text: [linkedText] }));
+
+      expect(skeleton).toHaveLength(2);
+      expect(skeleton.find(entry => entry.testTag === "legal-copy")).toMatchObject({
+        label: "Terms of Service",
+        semanticLinks: [{ text: "Terms of Service", occurrence: 0, start: 0, end: 16 }],
+      });
+    });
   });
 
   describe("AC6: bounds emitted as the CompactBounds tuple", () => {


### PR DESCRIPTION
## Summary

Follow-up to [#5552](https://github.com/kaeawc/auto-mobile/pull/5552), addressing the remaining semantic-link review findings after that PR merged.

- Keep linked-text skeleton rows when they are nested inside a generic clickable ancestor, so default `observe` remains discoverable.
- Let an iOS `.link` element act as its own owner for scoped semantic-link activation.
- Number Android link occurrences with the exact same Unicode case-insensitive comparison used during activation.
- Make the unrelated `InputText` factory-forwarding regression test deterministic by using its existing fake seam rather than a live CtrlProxy request.

## Root cause

The compact skeleton's text suppression treated embedded links like ordinary inner labels. iOS descendant lookup excludes its owner, and Android lowercasing was not equivalent to `String.equals(ignoreCase = true)` for every Unicode label.

## Validation

- `bunx turbo run lint build test`
- `bun run typecheck`
- `bash scripts/oxlint-baseline.sh`
- `./scripts/ktfmt/validate_ktfmt.sh`
- `(cd android && ./gradlew :control-proxy:testDebugUnitTest)`
- `(cd ios/control-proxy && swift test)`
