### PR TITLE
feat(logging): add opt-in structured container logs

### DIFF
--- a/docs/using/environment-variables.md
+++ b/docs/using/environment-variables.md
@@ -17,6 +17,8 @@ used only when the preferred name is unset.
 |----------|--------------|---------|---------|
 | `AUTOMOBILE_DATA_DIR` | `AUTO_MOBILE_DATA_DIR` | Stable base directory for AutoMobile's non-log state, including caches, screenshots, `tool_logs`, and the default log location. | `~/.auto-mobile` |
 | `AUTOMOBILE_LOG_DIR` | `AUTO_MOBILE_LOG_DIR` | Directory for structured daemon/client logs, rotated logs, and daemon-launch captures. Takes precedence over the `logs` child of `AUTOMOBILE_DATA_DIR` without relocating any non-log state. Relative paths resolve from the daemon's launch working directory. | `${AUTOMOBILE_DATA_DIR:-~/.auto-mobile}/logs` |
+| `AUTOMOBILE_LOG_FORMAT` | `AUTO_MOBILE_LOG_FORMAT` | Log record format: `text` (default) or `json` (newline-delimited JSON). | `text` |
+| `AUTOMOBILE_LOG_SINK` | `AUTO_MOBILE_LOG_SINK` | Log destination: `file` (default), `stderr`, or `both`. JSON logs written to `stderr` never use stdout, preserving MCP stdio protocol correctness. | `file` |
 
 When no home directory is available and `AUTOMOBILE_DATA_DIR` is unset, the data
 directory falls back to `os.tmpdir()/auto-mobile`; the default log directory is
@@ -29,6 +31,17 @@ location collected by your deployment:
 export AUTOMOBILE_DATA_DIR=/var/lib/automobile
 export AUTOMOBILE_LOG_DIR=/var/log/automobile
 ```
+
+For container log collection, opt into newline-delimited JSON on stderr:
+
+```bash
+export AUTOMOBILE_LOG_FORMAT=json
+export AUTOMOBILE_LOG_SINK=stderr
+```
+
+The file sink retains the existing rotation, retention, and sensitive-value
+filtering behavior. Invalid format or sink values fall back to the compatible
+text/file defaults.
 
 ## Database location & behavior (`AUTOMOBILE_DB_*`)
 

--- a/src/daemon/DaemonLauncher.ts
+++ b/src/daemon/DaemonLauncher.ts
@@ -40,6 +40,8 @@ export interface DaemonLaunchRequest {
   command: string;
   args: string[];
   spawnOptions: SpawnOptions;
+  /** Attaches any stream relays before readiness probes can complete. */
+  onSpawn?: (daemonProcess: ChildProcess) => void;
   timeoutMs: number;
   waitForReady: (timeoutMs: number, signal: AbortSignal) => Promise<boolean>;
   /**
@@ -148,6 +150,7 @@ export class DaemonLauncher {
       shell: false,
     });
     daemonProcess.unref();
+    request.onSpawn?.(daemonProcess);
 
     const readinessAbort = new AbortController();
     let cleanupProcessListeners = () => {};

--- a/src/daemon/manager.ts
+++ b/src/daemon/manager.ts
@@ -4,7 +4,7 @@ import { open, readFile, rm, unlink } from "node:fs/promises";
 import { existsSync, openSync, closeSync } from "node:fs";
 import { basename, isAbsolute, join, resolve, sep } from "node:path";
 import { tmpdir } from "node:os";
-import { logger } from "../utils/logger";
+import { isStructuredLoggingEnabled, logger, resolveAutomobileLogSink } from "../utils/logger";
 import { resolveDaemonInstallSpecifier } from "../constants/release";
 import {
   INCOMPLETE_EXTRACTION_CODE,
@@ -78,6 +78,10 @@ export type { DaemonLaunchCommand, DaemonProcessSpawner } from "./DaemonLauncher
  * All daemon lifecycle messages must go to stderr (or the file logger).
  */
 function stderrLog(message: string): void {
+  if (isStructuredLoggingEnabled()) {
+    logger.info(message);
+    return;
+  }
   process.stderr.write(message + "\n");
 }
 
@@ -643,7 +647,14 @@ export class DaemonManager implements DaemonManagerLike {
             spawnOptions: {
               detached: true,
               cwd: resolveStableDaemonWorkingDirectory(),
-              stdio: ["ignore", logFd, logFd],
+              stdio: [
+                "ignore",
+                logFd,
+                resolveAutomobileLogSink(childEnv) === "stderr" ||
+                resolveAutomobileLogSink(childEnv) === "both"
+                  ? "inherit"
+                  : logFd,
+              ],
               env: childEnv,
             },
             timeoutMs: DAEMON_STARTUP_TIMEOUT_MS,

--- a/src/daemon/manager.ts
+++ b/src/daemon/manager.ts
@@ -1,9 +1,9 @@
 import { errorMessage } from "../utils/describeUnknownError";
-import { execSync } from "node:child_process";
+import { execSync, type ChildProcess } from "node:child_process";
 import { open, readFile, rm, unlink } from "node:fs/promises";
 import { existsSync, openSync, closeSync } from "node:fs";
 import { basename, isAbsolute, join, resolve, sep } from "node:path";
-import { tmpdir } from "node:os";
+import { devNull, tmpdir } from "node:os";
 import { isStructuredLoggingEnabled, logger, resolveAutomobileLogSink } from "../utils/logger";
 import { resolveDaemonInstallSpecifier } from "../constants/release";
 import {
@@ -83,6 +83,26 @@ function stderrLog(message: string): void {
     return;
   }
   process.stderr.write(message + "\n");
+}
+
+/**
+ * Relays a detached daemon's stderr without passing the parent's descriptor to
+ * the child. The unref'd read end lets a terminating stdio host close its own
+ * stderr pipe promptly; while the host is alive, pause/resume honors sink
+ * backpressure instead of accumulating arbitrary buffered output.
+ */
+export function relayDaemonStderr(daemonProcess: ChildProcess): void {
+  const daemonStderr = daemonProcess.stderr;
+  if (!daemonStderr) {
+    return;
+  }
+  daemonStderr.on("data", (chunk: Buffer) => {
+    if (!process.stderr.write(chunk)) {
+      daemonStderr.pause();
+      process.stderr.once("drain", () => daemonStderr.resume());
+    }
+  });
+  (daemonStderr as typeof daemonStderr & { unref?: () => void }).unref?.();
 }
 
 export interface DaemonProcessRecord {
@@ -613,13 +633,6 @@ export class DaemonManager implements DaemonManagerLike {
     // and post-hoc debugging impossible (issue #2724). The logs dir is created
     // owner-only (0o700) by ensureSecureLogsDirSync, so a fixed, predictable
     // filename inside it is not exposed to other users.
-    const logPath = this.heldLockLogPath ?? this.daemonLaunchLogPath();
-    ensureSecureLogsDirSync();
-    // Open with restricted permissions (0o600 = owner read/write only).
-    // Truncate per launch so a single manager's bootstrap captures don't grow
-    // unbounded across restarts.
-    const logFd = openSync(logPath, "w", 0o600);
-
     // Propagate any non-default file paths to the child so its constants module
     // resolves to the same locations this manager polls.
     const childEnv = { ...process.env };
@@ -636,6 +649,18 @@ export class DaemonManager implements DaemonManagerLike {
     if (options.toolOutputsDir) {
       childEnv[TOOL_OUTPUTS_DIR_ENV] = options.toolOutputsDir;
     }
+    const logSink = resolveAutomobileLogSink(childEnv);
+    const capturesLaunchOutput = logSink !== "stderr";
+    const logPath = capturesLaunchOutput
+      ? (this.heldLockLogPath ?? this.daemonLaunchLogPath())
+      : devNull;
+    if (capturesLaunchOutput) {
+      ensureSecureLogsDirSync();
+    }
+    // Open with restricted permissions (0o600 = owner read/write only).
+    // Stderr-only containers deliberately skip the file capture and do not need
+    // a writable AutoMobile data directory.
+    const logFd = openSync(logPath, "w", 0o600);
 
     try {
       let retriedIncompleteExtraction = false;
@@ -649,14 +674,12 @@ export class DaemonManager implements DaemonManagerLike {
               cwd: resolveStableDaemonWorkingDirectory(),
               stdio: [
                 "ignore",
-                logFd,
-                resolveAutomobileLogSink(childEnv) === "stderr" ||
-                resolveAutomobileLogSink(childEnv) === "both"
-                  ? "inherit"
-                  : logFd,
+                capturesLaunchOutput ? logFd : "ignore",
+                logSink === "stderr" || logSink === "both" ? "pipe" : logFd,
               ],
               env: childEnv,
             },
+            onSpawn: logSink === "stderr" || logSink === "both" ? relayDaemonStderr : undefined,
             timeoutMs: DAEMON_STARTUP_TIMEOUT_MS,
             waitForReady: (timeoutMs, signal) => this.waitForReady(timeoutMs, signal),
             isReadyForLaunchedProcess: (pid, timeoutMs, signal) =>
@@ -917,14 +940,23 @@ export class DaemonManager implements DaemonManagerLike {
   private async formatDaemonStartupFailure(summary: string, logPath: string): Promise<string> {
     const logExcerpt = await this.readDaemonStartupLogExcerpt(logPath);
     if (logExcerpt.length === 0) {
+      if (logPath === devNull) {
+        return `${summary}\nDaemon stderr was relayed to the configured process sink; file capture is disabled.`;
+      }
       return `${summary}\nLogs: ${logPath} (empty)`;
     }
     return [
       summary,
       `Logs: ${logPath}`,
-      `Daemon stdout/stderr log excerpt (last ${MAX_DAEMON_STARTUP_LOG_BYTES} bytes):`,
+      `${this.daemonLaunchLogLabel()} (last ${MAX_DAEMON_STARTUP_LOG_BYTES} bytes):`,
       logExcerpt,
     ].join("\n");
+  }
+
+  private daemonLaunchLogLabel(): string {
+    return resolveAutomobileLogSink() === "file"
+      ? "Daemon stdout/stderr log excerpt"
+      : "Daemon stdout log excerpt; stderr was relayed to the configured process sink";
   }
 
   private async readDaemonStartupLogExcerpt(logPath: string): Promise<string> {

--- a/src/index.ts
+++ b/src/index.ts
@@ -2,6 +2,7 @@
 import "./runtime/reflectMetadata";
 import { errorMessage } from "./utils/describeUnknownError";
 import { bootstrapEnvironment } from "./utils/envBootstrap";
+import { writeEmergencyLog } from "./utils/loggingConfig";
 import { DAEMON_LAUNCH_CWD_ENV, safeProcessCwd } from "./utils/workingDirectory";
 
 // Run before any other imports that may resolve tool paths at module load time.
@@ -56,7 +57,7 @@ function logFatal(label: string, error: unknown): void {
   } else {
     // The file logger isn't loaded yet (crash during startup imports) — fall
     // back to stderr so the failure is never silently swallowed.
-    console.error(`${label}: ${message}`);
+    writeEmergencyLog(label, message);
   }
 }
 
@@ -639,8 +640,7 @@ async function main() {
 // this type-checks without a suppression.
 if (import.meta.main) {
   main().catch(async (err) => {
-    console.error("Fatal error in main():", err);
-    fatalLogger?.error("Fatal error in main():", err);
+    logFatal("Fatal error in main()", err);
     await fatalLogger?.closeAfterFlush();
     // An incomplete-extraction startup failure exits with a distinct, recoverable
     // code (EX_TEMPFAIL) so a wrapper can re-extract and retry (issue #2833);

--- a/src/processLifecycle.ts
+++ b/src/processLifecycle.ts
@@ -1,4 +1,5 @@
 import { defaultTimer, type Timer } from "./utils/SystemTimer";
+import { writeEmergencyLog } from "./utils/loggingConfig";
 
 export type ShutdownSignal = "SIGINT" | "SIGTERM" | "stdin";
 
@@ -142,12 +143,12 @@ export class ProcessLifecycleHandlers {
       const shutdownCompleted = await this.runShutdownHandler(signal);
       let exitCode = 0;
       if (!shutdownCompleted) {
-        console.error(`Shutdown timed out after ${this.shutdownTimeoutMs}ms; forcing exit`);
+        writeEmergencyLog(`Shutdown timed out after ${this.shutdownTimeoutMs}ms; forcing exit`);
         exitCode = (await this.runShutdownTimeoutHandler())?.exitCode ?? 1;
       }
       this.lifecycleProcess.exit(exitCode);
     } catch (error) {
-      console.error(`Error during ${signal} shutdown:`, error);
+      writeEmergencyLog(`Error during ${signal} shutdown`, error);
       this.lifecycleProcess.exit(1);
     }
   }
@@ -195,7 +196,7 @@ export class ProcessLifecycleHandlers {
     let timeoutHandle: NodeJS.Timeout | undefined;
     const timedOut = new Promise<undefined>(resolve => {
       timeoutHandle = this.timer.setTimeout(() => {
-        console.error(`Shutdown finalization timed out after ${finalizationTimeoutMs}ms; forcing exit`);
+        writeEmergencyLog(`Shutdown finalization timed out after ${finalizationTimeoutMs}ms; forcing exit`);
         resolve(undefined);
       }, finalizationTimeoutMs);
     });
@@ -213,9 +214,9 @@ export class ProcessLifecycleHandlers {
     const handler = this.fatalProcessHandler;
     if (!handler) {
       if (event.type === "uncaughtException") {
-        console.error("Uncaught exception:", event.error);
+        writeEmergencyLog("Uncaught exception", event.error);
       } else {
-        console.error("Unhandled rejection at:", event.promise, "reason:", event.reason);
+        writeEmergencyLog("Unhandled rejection", event.reason);
       }
       this.lifecycleProcess.exit(1);
       return;
@@ -224,7 +225,7 @@ export class ProcessLifecycleHandlers {
     try {
       await handler(event);
     } catch (error) {
-      console.error("Error in fatal process handler:", error);
+      writeEmergencyLog("Error in fatal process handler", error);
       this.lifecycleProcess.exit(1);
     }
   }

--- a/src/utils/logger.ts
+++ b/src/utils/logger.ts
@@ -6,6 +6,19 @@ import path from "path";
 import { statAsync, renameAsync } from "./io";
 import { ensureSecureLogsDirSync } from "./tempDir";
 import { pruneLogFiles } from "./logPruner";
+import {
+  resolveAutomobileLogFormat,
+  resolveAutomobileLogSink,
+} from "./loggingConfig";
+
+export {
+  parseAutomobileLogFormat,
+  parseAutomobileLogSink,
+  resolveAutomobileLogFormat,
+  resolveAutomobileLogSink,
+  type LogFormat,
+  type LogSink,
+} from "./loggingConfig";
 
 /**
  * Interface for logger functionality
@@ -82,38 +95,6 @@ export const LogLevel = {
 
 export type LogLevel = (typeof LogLevel)[keyof typeof LogLevel];
 
-export type LogFormat = "text" | "json";
-export type LogSink = "file" | "stderr" | "both";
-
-export function parseAutomobileLogFormat(value: string | undefined): LogFormat | null {
-  const normalized = value?.trim().toLowerCase();
-  return normalized === "text" || normalized === "json" ? normalized : null;
-}
-
-export function parseAutomobileLogSink(value: string | undefined): LogSink | null {
-  const normalized = value?.trim().toLowerCase();
-  return normalized === "file" || normalized === "stderr" || normalized === "both"
-    ? normalized
-    : null;
-}
-
-export function resolveAutomobileLogFormat(
-  environment: NodeJS.ProcessEnv = process.env,
-): LogFormat {
-  return (
-    parseAutomobileLogFormat(
-      environment.AUTOMOBILE_LOG_FORMAT ?? environment.AUTO_MOBILE_LOG_FORMAT,
-    ) ?? "text"
-  );
-}
-
-export function resolveAutomobileLogSink(environment: NodeJS.ProcessEnv = process.env): LogSink {
-  return (
-    parseAutomobileLogSink(environment.AUTOMOBILE_LOG_SINK ?? environment.AUTO_MOBILE_LOG_SINK) ??
-    "file"
-  );
-}
-
 export function isStructuredLoggingEnabled(): boolean {
   return logFormat === "json";
 }
@@ -179,17 +160,24 @@ const trackWrite = (write: Promise<void>): void => {
   lastWrite = lastWrite.then(() => write);
 };
 
-// Create the configured log directory with owner-only permissions. This may be
-// independent of AUTOMOBILE_DATA_DIR, which continues to scope non-log state.
-const logsDir = ensureSecureLogsDirSync();
+// Create the configured log directory only when the selected sink writes files.
+// Stderr-only containers must not require a writable application-data volume.
+const logsDir = logSink === "stderr" ? undefined : ensureSecureLogsDirSync();
 
 // The daemon is single-owner, so keep its stable log name easy to document and
 // tail. Stdio/client processes remain PID-scoped because several can run in
 // parallel on the same host.
 const ownLogPrefix = resolveProcessLogPrefix(process.argv, process.pid);
-const logFilePath = path.join(logsDir, `${ownLogPrefix}.log`);
-let logStream =
-  logSink === "stderr" ? undefined : fs.createWriteStream(logFilePath, { flags: "a" });
+const logFilePath = logsDir ? path.join(logsDir, `${ownLogPrefix}.log`) : undefined;
+let logStream = logFilePath ? fs.createWriteStream(logFilePath, { flags: "a" }) : undefined;
+
+function fileLogPaths(): { dir: string; path: string } | undefined {
+  if (!logsDir || !logFilePath) {
+    return undefined;
+  }
+  return { dir: logsDir, path: logFilePath };
+}
+
 interface EndableLogStream {
   end(callback: () => void): void;
   once(event: "error", listener: (error: Error) => void): void;
@@ -225,28 +213,38 @@ const ABANDONED_LOG_MAX_AGE_MS = 24 * 60 * 60 * 1000;
 // Remove old log files. Only ever deletes (a) this process's own rotated backups
 // beyond the cap, and (b) other processes' logs that are stale by mtime — never
 // another live process's current file. See logPruner.ts.
-const pruneOldLogFiles = (): Promise<void> =>
-  pruneLogFiles({
+const pruneOldLogFiles = (): Promise<void> => {
+  if (!logsDir) {
+    return Promise.resolve();
+  }
+  return pruneLogFiles({
     dir: logsDir,
     ownPrefix: ownLogPrefix,
     maxOwnFiles: MAX_LOG_FILES,
     abandonedMaxAgeMs: ABANDONED_LOG_MAX_AGE_MS,
   });
+};
 
 // Sweep logs abandoned by already-exited processes once at startup. Short-lived
 // agents exit with small logs and never reach the size-based rotation that would
 // otherwise trigger a sweep, so without this their per-PID files would accumulate
 // in the shared logs dir on a busy multi-agent host. Fire-and-forget so it never
 // delays logger initialization; the sweep itself only removes dead-owner files.
-pruneOldLogFiles().catch(() => {
-  /* best-effort startup sweep */
-});
+if (logsDir) {
+  pruneOldLogFiles().catch(() => {
+    /* best-effort startup sweep */
+  });
+}
 
 // Function to check log file size and rotate if necessary
 const checkAndRotateLog = async (): Promise<void> => {
+  const paths = fileLogPaths();
+  if (!paths || !logStream) {
+    return;
+  }
   try {
-    if (fs.existsSync(logFilePath)) {
-      const stats = await statAsync(logFilePath);
+    if (fs.existsSync(paths.path)) {
+      const stats = await statAsync(paths.path);
       if (stats.size >= MAX_LOG_SIZE) {
         // Close current stream
         logStream?.end();
@@ -254,16 +252,16 @@ const checkAndRotateLog = async (): Promise<void> => {
         // Create backup filename with timestamp, scoped to this process's PID so
         // rotation never collides with another process's files.
         const timestamp = new Date().toISOString().replace(/:/g, "-");
-        const backupPath = path.join(logsDir, `${ownLogPrefix}-${timestamp}.log`);
+        const backupPath = path.join(paths.dir, `${ownLogPrefix}-${timestamp}.log`);
 
         // Check if file still exists right before rename to avoid race condition
-        if (fs.existsSync(logFilePath)) {
+        if (fs.existsSync(paths.path)) {
           // Rename current log file to backup
-          await renameAsync(logFilePath, backupPath);
+          await renameAsync(paths.path, backupPath);
         }
 
         // Always create a new log stream after rotation attempt
-        logStream = fs.createWriteStream(logFilePath, { flags: "a" });
+        logStream = fs.createWriteStream(paths.path, { flags: "a" });
 
         // Prune old log files to stay within the cap
         await pruneOldLogFiles();
@@ -272,9 +270,9 @@ const checkAndRotateLog = async (): Promise<void> => {
   } catch (err) {
     // If rotation fails, ensure we have a valid log stream
     if (logStream?.destroyed || !logStream?.writable) {
-      logStream = fs.createWriteStream(logFilePath, { flags: "a" });
+      logStream = fs.createWriteStream(paths.path, { flags: "a" });
     }
-    console.error("Log rotation failed:", err);
+    await reportLogFailure("Log rotation failed", err);
   }
 };
 
@@ -304,9 +302,14 @@ const safeStringify = (obj: any): string => {
     return String(obj);
   }
 
+  const seen = new WeakSet<object>();
   try {
     return JSON.stringify(obj, (_key, value) => {
       if (typeof value === "object" && value !== null) {
+        if (seen.has(value)) {
+          return "[circular]";
+        }
+        seen.add(value);
         // Filter sensitive environment-like keys
         const filtered: any = {};
         for (const [k, v] of Object.entries(value)) {
@@ -319,9 +322,10 @@ const safeStringify = (obj: any): string => {
       return value;
     });
   } catch (error) {
-    // Circular and otherwise unserializable diagnostic values are expected at
-    // a logging boundary; report them and keep the primary record valid.
-    reportLogFailure(error);
+    // Circular diagnostic values are expected at a logging boundary. Preserve
+    // the primary record rather than creating a second, potentially unsinkable
+    // logging failure.
+    void error;
     return "[unserializable]";
   }
 };
@@ -359,51 +363,84 @@ const formatLogRecord = (level: string, message: string, args: any[]): string =>
   return `${timestamp} [${level}] ${boundedMessage}`;
 };
 
-const reportLogFailure = (error: unknown): void => {
-  const message = sanitizeMessage(String(error));
-  if (logFormat === "json") {
-    process.stderr.write(
-      `${JSON.stringify({
-        timestamp: new Date().toISOString(),
-        level: "error",
-        component: ownLogPrefix,
-        event: "log.write_failed",
-        message,
-      })}\n`,
-    );
+const writeToStderr = (line: string): Promise<void> =>
+  new Promise((resolve, reject) => {
+    process.stderr.write(`${line}\n`, (error) => {
+      if (error) {
+        reject(error);
+      } else {
+        resolve();
+      }
+    });
+  });
+
+const reportLogFailure = async (context: string, error: unknown): Promise<void> => {
+  if (logSink === "file") {
     return;
   }
-  console.error("Failed to write log:", error);
+  const message = `${context}: ${sanitizeMessage(String(error))}`;
+  const line =
+    logFormat === "json"
+      ? JSON.stringify({
+          timestamp: new Date().toISOString(),
+          level: "error",
+          component: ownLogPrefix,
+          event: "log.write_failed",
+          message,
+        })
+      : message;
+  try {
+    await writeToStderr(line);
+  } catch (error) {
+    // The configured stream is itself unavailable, so no diagnostic sink remains.
+    void error;
+  }
+};
+
+const writeToFile = async (line: string): Promise<void> => {
+  if (!logStream) {
+    return;
+  }
+  await checkAndRotateLog();
+  const stream = logStream;
+  if (!stream) {
+    return;
+  }
+  await new Promise<void>((resolve, reject) => {
+    stream.write(line + "\n", (error) => {
+      if (error) {
+        reject(error);
+      } else {
+        resolve();
+      }
+    });
+  });
+};
+
+const writeToConfiguredStderr = async (line: string): Promise<void> => {
+  if (logSink === "stderr" || logSink === "both") {
+    await writeToStderr(line);
+  }
+};
+
+const mirrorToLegacyStdout = (line: string): void => {
+  if (logToStdout && logFormat === "text") {
+    process.stdout.write(`${line}\n`);
+  }
 };
 
 const writeToLogFile = async (level: string, message: string, args: any[]) => {
   try {
     const safeLogMessage = formatLogRecord(level, message, args).replace(/[\r\n\t]/g, " ");
-
-    if (logStream) {
-      // Check and rotate log if needed before writing
-      await checkAndRotateLog();
-      await new Promise<void>((resolve, reject) => {
-        logStream?.write(safeLogMessage + "\n", (error) => {
-          if (error) {
-            reject(error);
-          } else {
-            resolve();
-          }
-        });
-      });
-    }
-
-    if (logSink === "stderr" || logSink === "both") {
-      process.stderr.write(`${safeLogMessage}\n`);
-    }
-
-    // The legacy stdout sink is retained for diagnostics in text mode only.
-    if (logToStdout && logFormat === "text") {
-      process.stdout.write(`${safeLogMessage}\n`);
-    }
+    // Start both configured writes before awaiting either one. A failed file
+    // sink must not suppress the process-stream record in `both` mode.
+    await Promise.all([
+      writeToFile(safeLogMessage),
+      writeToConfiguredStderr(safeLogMessage),
+    ]);
+    mirrorToLegacyStdout(safeLogMessage);
   } catch (err) {
-    reportLogFailure(err);
+    await reportLogFailure("Failed to write log", err);
   }
 };
 
@@ -452,7 +489,7 @@ export const logger: Logger = {
     if (currentLogLevel <= LogLevel.DEBUG) {
       trackWrite(
         writeToLogFile("DEBUG", message, args).catch((err) => {
-          reportLogFailure(err);
+          return reportLogFailure("Failed to write debug log", err);
         }),
       );
     }
@@ -465,7 +502,7 @@ export const logger: Logger = {
     if (currentLogLevel <= LogLevel.INFO) {
       trackWrite(
         writeToLogFile("INFO", message, args).catch((err) => {
-          reportLogFailure(err);
+          return reportLogFailure("Failed to write info log", err);
         }),
       );
     }
@@ -478,7 +515,7 @@ export const logger: Logger = {
     if (currentLogLevel <= LogLevel.WARN) {
       trackWrite(
         writeToLogFile("WARN", message, args).catch((err) => {
-          reportLogFailure(err);
+          return reportLogFailure("Failed to write warn log", err);
         }),
       );
     }
@@ -491,7 +528,7 @@ export const logger: Logger = {
     if (currentLogLevel <= LogLevel.ERROR) {
       trackWrite(
         writeToLogFile("ERROR", message, args).catch((err) => {
-          reportLogFailure(err);
+          return reportLogFailure("Failed to write error log", err);
         }),
       );
     }

--- a/src/utils/logger.ts
+++ b/src/utils/logger.ts
@@ -304,19 +304,26 @@ const safeStringify = (obj: any): string => {
     return String(obj);
   }
 
-  return JSON.stringify(obj, (_key, value) => {
-    if (typeof value === "object" && value !== null) {
-      // Filter sensitive environment-like keys
-      const filtered: any = {};
-      for (const [k, v] of Object.entries(value)) {
-        if (!SENSITIVE_ENV_KEYS.has(k.toUpperCase())) {
-          filtered[k] = v;
+  try {
+    return JSON.stringify(obj, (_key, value) => {
+      if (typeof value === "object" && value !== null) {
+        // Filter sensitive environment-like keys
+        const filtered: any = {};
+        for (const [k, v] of Object.entries(value)) {
+          if (!SENSITIVE_ENV_KEYS.has(k.toUpperCase())) {
+            filtered[k] = v;
+          }
         }
+        return filtered;
       }
-      return filtered;
-    }
-    return value;
-  });
+      return value;
+    });
+  } catch (error) {
+    // Circular and otherwise unserializable diagnostic values are expected at
+    // a logging boundary; report them and keep the primary record valid.
+    reportLogFailure(error);
+    return "[unserializable]";
+  }
 };
 
 // Function to sanitize log message to prevent log injection
@@ -352,6 +359,23 @@ const formatLogRecord = (level: string, message: string, args: any[]): string =>
   return `${timestamp} [${level}] ${boundedMessage}`;
 };
 
+const reportLogFailure = (error: unknown): void => {
+  const message = sanitizeMessage(String(error));
+  if (logFormat === "json") {
+    process.stderr.write(
+      `${JSON.stringify({
+        timestamp: new Date().toISOString(),
+        level: "error",
+        component: ownLogPrefix,
+        event: "log.write_failed",
+        message,
+      })}\n`,
+    );
+    return;
+  }
+  console.error("Failed to write log:", error);
+};
+
 const writeToLogFile = async (level: string, message: string, args: any[]) => {
   try {
     const safeLogMessage = formatLogRecord(level, message, args).replace(/[\r\n\t]/g, " ");
@@ -379,7 +403,7 @@ const writeToLogFile = async (level: string, message: string, args: any[]) => {
       process.stdout.write(`${safeLogMessage}\n`);
     }
   } catch (err) {
-    console.error("Failed to write log:", err);
+    reportLogFailure(err);
   }
 };
 
@@ -428,7 +452,7 @@ export const logger: Logger = {
     if (currentLogLevel <= LogLevel.DEBUG) {
       trackWrite(
         writeToLogFile("DEBUG", message, args).catch((err) => {
-          console.error("Failed to write debug log:", err);
+          reportLogFailure(err);
         }),
       );
     }
@@ -441,7 +465,7 @@ export const logger: Logger = {
     if (currentLogLevel <= LogLevel.INFO) {
       trackWrite(
         writeToLogFile("INFO", message, args).catch((err) => {
-          console.error("Failed to write info log:", err);
+          reportLogFailure(err);
         }),
       );
     }
@@ -454,7 +478,7 @@ export const logger: Logger = {
     if (currentLogLevel <= LogLevel.WARN) {
       trackWrite(
         writeToLogFile("WARN", message, args).catch((err) => {
-          console.error("Failed to write warn log:", err);
+          reportLogFailure(err);
         }),
       );
     }
@@ -467,7 +491,7 @@ export const logger: Logger = {
     if (currentLogLevel <= LogLevel.ERROR) {
       trackWrite(
         writeToLogFile("ERROR", message, args).catch((err) => {
-          console.error("Failed to write error log:", err);
+          reportLogFailure(err);
         }),
       );
     }

--- a/src/utils/logger.ts
+++ b/src/utils/logger.ts
@@ -77,10 +77,46 @@ export const LogLevel = {
   INFO: 1 as const,
   WARN: 2 as const,
   ERROR: 3 as const,
-  NONE: 4 as const
+  NONE: 4 as const,
 };
 
-export type LogLevel = typeof LogLevel[keyof typeof LogLevel];
+export type LogLevel = (typeof LogLevel)[keyof typeof LogLevel];
+
+export type LogFormat = "text" | "json";
+export type LogSink = "file" | "stderr" | "both";
+
+export function parseAutomobileLogFormat(value: string | undefined): LogFormat | null {
+  const normalized = value?.trim().toLowerCase();
+  return normalized === "text" || normalized === "json" ? normalized : null;
+}
+
+export function parseAutomobileLogSink(value: string | undefined): LogSink | null {
+  const normalized = value?.trim().toLowerCase();
+  return normalized === "file" || normalized === "stderr" || normalized === "both"
+    ? normalized
+    : null;
+}
+
+export function resolveAutomobileLogFormat(
+  environment: NodeJS.ProcessEnv = process.env,
+): LogFormat {
+  return (
+    parseAutomobileLogFormat(
+      environment.AUTOMOBILE_LOG_FORMAT ?? environment.AUTO_MOBILE_LOG_FORMAT,
+    ) ?? "text"
+  );
+}
+
+export function resolveAutomobileLogSink(environment: NodeJS.ProcessEnv = process.env): LogSink {
+  return (
+    parseAutomobileLogSink(environment.AUTOMOBILE_LOG_SINK ?? environment.AUTO_MOBILE_LOG_SINK) ??
+    "file"
+  );
+}
+
+export function isStructuredLoggingEnabled(): boolean {
+  return logFormat === "json";
+}
 
 /**
  * Parse `AUTOMOBILE_LOG_LEVEL` values: debug, info, warn|warning, error, none|silent.
@@ -123,7 +159,12 @@ export function resolveProcessLogPrefix(argv: readonly string[], pid: number): s
 // DaemonManager-spawned daemon inherits the var via its `{ ...process.env }`
 // child env. Falls back to INFO when unset/unrecognized; still overridable at
 // runtime via setLogLevel.
-let currentLogLevel: LogLevel = parseAutomobileLogLevel(process.env.AUTOMOBILE_LOG_LEVEL) ?? LogLevel.INFO;
+let currentLogLevel: LogLevel =
+  parseAutomobileLogLevel(process.env.AUTOMOBILE_LOG_LEVEL ?? process.env.AUTO_MOBILE_LOG_LEVEL) ??
+  LogLevel.INFO;
+
+const logFormat = resolveAutomobileLogFormat();
+const logSink = resolveAutomobileLogSink();
 
 // Flag to control whether to also log to STDOUT (in addition to files)
 let logToStdout = false;
@@ -147,7 +188,8 @@ const logsDir = ensureSecureLogsDirSync();
 // parallel on the same host.
 const ownLogPrefix = resolveProcessLogPrefix(process.argv, process.pid);
 const logFilePath = path.join(logsDir, `${ownLogPrefix}.log`);
-let logStream = fs.createWriteStream(logFilePath, { flags: "a" });
+let logStream =
+  logSink === "stderr" ? undefined : fs.createWriteStream(logFilePath, { flags: "a" });
 interface EndableLogStream {
   end(callback: () => void): void;
   once(event: "error", listener: (error: Error) => void): void;
@@ -196,7 +238,9 @@ const pruneOldLogFiles = (): Promise<void> =>
 // otherwise trigger a sweep, so without this their per-PID files would accumulate
 // in the shared logs dir on a busy multi-agent host. Fire-and-forget so it never
 // delays logger initialization; the sweep itself only removes dead-owner files.
-pruneOldLogFiles().catch(() => { /* best-effort startup sweep */ });
+pruneOldLogFiles().catch(() => {
+  /* best-effort startup sweep */
+});
 
 // Function to check log file size and rotate if necessary
 const checkAndRotateLog = async (): Promise<void> => {
@@ -205,7 +249,7 @@ const checkAndRotateLog = async (): Promise<void> => {
       const stats = await statAsync(logFilePath);
       if (stats.size >= MAX_LOG_SIZE) {
         // Close current stream
-        logStream.end();
+        logStream?.end();
 
         // Create backup filename with timestamp, scoped to this process's PID so
         // rotation never collides with another process's files.
@@ -227,7 +271,7 @@ const checkAndRotateLog = async (): Promise<void> => {
     }
   } catch (err) {
     // If rotation fails, ensure we have a valid log stream
-    if (logStream.destroyed || !logStream.writable) {
+    if (logStream?.destroyed || !logStream?.writable) {
       logStream = fs.createWriteStream(logFilePath, { flags: "a" });
     }
     console.error("Log rotation failed:", err);
@@ -284,45 +328,65 @@ const sanitizeMessage = (message: string): string => {
 export { SENSITIVE_ENV_KEYS, safeStringify, sanitizeMessage };
 
 // Function to write to log file
+const formatLogRecord = (level: string, message: string, args: any[]): string => {
+  const timestamp = new Date().toISOString();
+  const sanitizedMessage = sanitizeMessage(message);
+  const argsStr =
+    args.length > 0
+      ? ` ${args.map((arg) => sanitizeMessage(typeof arg === "object" ? safeStringify(arg) : String(arg))).join(" ")}`
+      : "";
+  const fullMessage = `${sanitizedMessage}${argsStr}`;
+  const boundedMessage =
+    fullMessage.length > 1000 ? `${fullMessage.substring(0, 1000)}... (truncated)` : fullMessage;
+
+  if (logFormat === "json") {
+    return JSON.stringify({
+      timestamp,
+      level: level.toLowerCase(),
+      component: ownLogPrefix,
+      event: "log",
+      message: boundedMessage,
+    });
+  }
+
+  return `${timestamp} [${level}] ${boundedMessage}`;
+};
+
 const writeToLogFile = async (level: string, message: string, args: any[]) => {
   try {
-    // Check and rotate log if needed before writing
-    await checkAndRotateLog();
+    const safeLogMessage = formatLogRecord(level, message, args).replace(/[\r\n\t]/g, " ");
 
-    const timestamp = new Date().toISOString();
-    const sanitizedMessage = sanitizeMessage(message);
-    let logMessage = `${timestamp} [${level}] ${sanitizedMessage}`;
-
-    if (args.length > 0) {
-      // Handle objects by converting them to strings, filtering sensitive data
-      const argsStr = args.map(arg => {
-        if (typeof arg === "object") {
-          return sanitizeMessage(safeStringify(arg));
-        }
-        return sanitizeMessage(String(arg));
-      }).join(" ");
-      logMessage += ` ${argsStr}`;
-    }
-    if (logMessage.length > 1000) {
-      logMessage = logMessage.substring(0, 1000) + "... (truncated)";
-    }
-    const safeLogMessage = logMessage.replace(/[\r\n\t]/g, " ");
-    await new Promise<void>((resolve, reject) => {
-      logStream.write(safeLogMessage + "\n", error => {
-        if (error) {
-          reject(error);
-        } else {
-          resolve();
-        }
+    if (logStream) {
+      // Check and rotate log if needed before writing
+      await checkAndRotateLog();
+      await new Promise<void>((resolve, reject) => {
+        logStream?.write(safeLogMessage + "\n", (error) => {
+          if (error) {
+            reject(error);
+          } else {
+            resolve();
+          }
+        });
       });
-    });
+    }
 
-    // Also write to STDOUT if enabled
-    if (logToStdout) {
+    if (logSink === "stderr" || logSink === "both") {
+      process.stderr.write(`${safeLogMessage}\n`);
+    }
+
+    // The legacy stdout sink is retained for diagnostics in text mode only.
+    if (logToStdout && logFormat === "text") {
       process.stdout.write(`${safeLogMessage}\n`);
     }
   } catch (err) {
     console.error("Failed to write log:", err);
+  }
+};
+
+// In stderr-only mode there is no file stream to rotate or close.
+const closeCurrentLogStream = async (): Promise<void> => {
+  if (logStream) {
+    await closeLogStream(logStream);
   }
 };
 
@@ -346,7 +410,8 @@ export const logger: Logger = {
    * Enables logging to STDOUT in addition to log files
    */
   enableStdoutLogging(): void {
-    logToStdout = true;
+    // Structured logs must never share stdout with MCP JSON-RPC traffic.
+    logToStdout = logFormat === "text";
   },
 
   /**
@@ -361,9 +426,11 @@ export const logger: Logger = {
    */
   debug(message: string, ...args: any[]): void {
     if (currentLogLevel <= LogLevel.DEBUG) {
-      trackWrite(writeToLogFile("DEBUG", message, args).catch(err => {
-        console.error("Failed to write debug log:", err);
-      }));
+      trackWrite(
+        writeToLogFile("DEBUG", message, args).catch((err) => {
+          console.error("Failed to write debug log:", err);
+        }),
+      );
     }
   },
 
@@ -372,9 +439,11 @@ export const logger: Logger = {
    */
   info(message: string, ...args: any[]): void {
     if (currentLogLevel <= LogLevel.INFO) {
-      trackWrite(writeToLogFile("INFO", message, args).catch(err => {
-        console.error("Failed to write info log:", err);
-      }));
+      trackWrite(
+        writeToLogFile("INFO", message, args).catch((err) => {
+          console.error("Failed to write info log:", err);
+        }),
+      );
     }
   },
 
@@ -383,9 +452,11 @@ export const logger: Logger = {
    */
   warn(message: string, ...args: any[]): void {
     if (currentLogLevel <= LogLevel.WARN) {
-      trackWrite(writeToLogFile("WARN", message, args).catch(err => {
-        console.error("Failed to write warn log:", err);
-      }));
+      trackWrite(
+        writeToLogFile("WARN", message, args).catch((err) => {
+          console.error("Failed to write warn log:", err);
+        }),
+      );
     }
   },
 
@@ -394,9 +465,11 @@ export const logger: Logger = {
    */
   error(message: string, ...args: any[]): void {
     if (currentLogLevel <= LogLevel.ERROR) {
-      trackWrite(writeToLogFile("ERROR", message, args).catch(err => {
-        console.error("Failed to write error log:", err);
-      }));
+      trackWrite(
+        writeToLogFile("ERROR", message, args).catch((err) => {
+          console.error("Failed to write error log:", err);
+        }),
+      );
     }
   },
 
@@ -411,11 +484,11 @@ export const logger: Logger = {
    * Flushes queued writes and closes the log stream.
    */
   close(): void {
-    logStream.end();
+    logStream?.end();
   },
 
   async closeAfterFlush(): Promise<void> {
     await lastWrite;
-    await closeLogStream(logStream);
-  }
+    await closeCurrentLogStream();
+  },
 };

--- a/src/utils/loggingConfig.ts
+++ b/src/utils/loggingConfig.ts
@@ -1,0 +1,64 @@
+export type LogFormat = "text" | "json";
+export type LogSink = "file" | "stderr" | "both";
+
+export function parseAutomobileLogFormat(value: string | undefined): LogFormat | null {
+  const normalized = value?.trim().toLowerCase();
+  return normalized === "text" || normalized === "json" ? normalized : null;
+}
+
+export function parseAutomobileLogSink(value: string | undefined): LogSink | null {
+  const normalized = value?.trim().toLowerCase();
+  return normalized === "file" || normalized === "stderr" || normalized === "both"
+    ? normalized
+    : null;
+}
+
+export function resolveAutomobileLogFormat(
+  environment: NodeJS.ProcessEnv = process.env,
+): LogFormat {
+  return (
+    parseAutomobileLogFormat(
+      environment.AUTOMOBILE_LOG_FORMAT ?? environment.AUTO_MOBILE_LOG_FORMAT,
+    ) ?? "text"
+  );
+}
+
+export function resolveAutomobileLogSink(environment: NodeJS.ProcessEnv = process.env): LogSink {
+  return (
+    parseAutomobileLogSink(environment.AUTOMOBILE_LOG_SINK ?? environment.AUTO_MOBILE_LOG_SINK) ??
+    "file"
+  );
+}
+
+function emergencyMessage(message: string, error: unknown | undefined): string {
+  if (error === undefined) {
+    return message;
+  }
+  try {
+    return `${message}: ${error instanceof Error ? (error.stack ?? error.message) : String(error)}`;
+  } catch (error) {
+    // A throwing custom error formatter must not prevent reporting the fatal event.
+    void error;
+    return message;
+  }
+}
+
+/**
+ * Writes a final process diagnostic before the full logger is initialized.
+ * JSON mode deliberately bypasses console.error so every emitted stderr line
+ * remains an independent NDJSON record.
+ */
+export function writeEmergencyLog(message: string, error?: unknown): void {
+  const formattedMessage = emergencyMessage(message, error);
+  if (resolveAutomobileLogFormat() === "json") {
+    process.stderr.write(`${JSON.stringify({
+      timestamp: new Date().toISOString(),
+      level: "error",
+      component: "process",
+      event: "log.emergency",
+      message: formattedMessage,
+    })}\n`);
+    return;
+  }
+  process.stderr.write(`${formattedMessage}\n`);
+}

--- a/src/utils/startupBenchmark.ts
+++ b/src/utils/startupBenchmark.ts
@@ -2,6 +2,7 @@ import { performance } from "node:perf_hooks";
 import fs from "node:fs";
 import path from "node:path";
 import { resolvePathFromDaemonLaunchWorkingDirectory } from "./workingDirectory";
+import { resolveAutomobileLogFormat } from "./logger";
 
 const STARTUP_BENCHMARK_PREFIX = "STARTUP_BENCHMARK";
 
@@ -20,7 +21,7 @@ interface StartupBenchmarkReport {
 
 export function isStartupBenchmarkEnabled(
   args: readonly string[],
-  environment: Readonly<Record<string, string | undefined>>
+  environment: Readonly<Record<string, string | undefined>>,
 ): boolean {
   if (args.includes("--startup-benchmark")) {
     return true;
@@ -31,8 +32,10 @@ export function isStartupBenchmarkEnabled(
     environment.AUTO_MOBILE_STARTUP_BENCHMARK ??
     ""
   ).toLowerCase();
-  return args.includes("--daemon-mode") &&
-    (envEnabled === "1" || envEnabled === "true" || envEnabled === "yes");
+  return (
+    args.includes("--daemon-mode") &&
+    (envEnabled === "1" || envEnabled === "true" || envEnabled === "yes")
+  );
 }
 
 const enabled = isStartupBenchmarkEnabled(process.argv, process.env);
@@ -42,8 +45,7 @@ const outputPath =
   process.env.AUTO_MOBILE_STARTUP_BENCHMARK_OUTPUT;
 
 const label =
-  process.env.AUTOMOBILE_STARTUP_BENCHMARK_LABEL ??
-  process.env.AUTO_MOBILE_STARTUP_BENCHMARK_LABEL;
+  process.env.AUTOMOBILE_STARTUP_BENCHMARK_LABEL ?? process.env.AUTO_MOBILE_STARTUP_BENCHMARK_LABEL;
 
 export interface StartupBenchmarkOptions {
   outputPath?: string;
@@ -139,7 +141,11 @@ export class StartupBenchmark {
     const payload = JSON.stringify(report);
 
     this.writeReport(payload);
-    process.stderr.write(`${STARTUP_BENCHMARK_PREFIX} ${payload}\n`);
+    process.stderr.write(
+      resolveAutomobileLogFormat() === "json"
+        ? `${payload}\n`
+        : `${STARTUP_BENCHMARK_PREFIX} ${payload}\n`,
+    );
   }
 
   private persistCheckpoint(): void {
@@ -155,7 +161,7 @@ export class StartupBenchmark {
   private createReport(
     type: string,
     state: StartupBenchmarkReport["state"],
-    meta: Record<string, unknown> = {}
+    meta: Record<string, unknown> = {},
   ): StartupBenchmarkReport {
     const marks = Object.fromEntries(this.marks.entries());
     const phases = Object.fromEntries(this.phases.entries());

--- a/src/utils/startupBenchmark.ts
+++ b/src/utils/startupBenchmark.ts
@@ -2,7 +2,7 @@ import { performance } from "node:perf_hooks";
 import fs from "node:fs";
 import path from "node:path";
 import { resolvePathFromDaemonLaunchWorkingDirectory } from "./workingDirectory";
-import { resolveAutomobileLogFormat } from "./logger";
+import { logger, resolveAutomobileLogFormat } from "./logger";
 
 const STARTUP_BENCHMARK_PREFIX = "STARTUP_BENCHMARK";
 
@@ -141,11 +141,11 @@ export class StartupBenchmark {
     const payload = JSON.stringify(report);
 
     this.writeReport(payload);
-    process.stderr.write(
-      resolveAutomobileLogFormat() === "json"
-        ? `${payload}\n`
-        : `${STARTUP_BENCHMARK_PREFIX} ${payload}\n`,
-    );
+    if (resolveAutomobileLogFormat() === "json") {
+      logger.info(payload);
+      return;
+    }
+    process.stderr.write(`${STARTUP_BENCHMARK_PREFIX} ${payload}\n`);
   }
 
   private persistCheckpoint(): void {

--- a/test/daemon/daemonManagerLaunch.test.ts
+++ b/test/daemon/daemonManagerLaunch.test.ts
@@ -24,6 +24,8 @@ describe("DaemonManager launch", () => {
     delete process.env[DAEMON_LAUNCH_CWD_ENV];
     delete process.env.AUTOMOBILE_DATA_DIR;
     delete process.env.AUTOMOBILE_LOG_DIR;
+    delete process.env.AUTOMOBILE_LOG_FORMAT;
+    delete process.env.AUTOMOBILE_LOG_SINK;
     delete process.env[EVENT_ALL_MARKERS_ENV];
     for (const dir of tempDirs) {
       rmSync(dir, { recursive: true, force: true });
@@ -77,6 +79,54 @@ describe("DaemonManager launch", () => {
     expect(existsSync(logsDir)).toBe(true);
     const launchLogs = readdirSync(logsDir).filter(name => name.startsWith("daemon-launch"));
     expect(launchLogs.length).toBeGreaterThan(0);
+  });
+
+  test("inherits stderr for the daemon when structured stderr logging is enabled", async () => {
+    const stateDir = createTempDir("daemon-launch-state-");
+    process.env.AUTOMOBILE_DATA_DIR = stateDir;
+    process.env.AUTOMOBILE_LOG_FORMAT = "json";
+    process.env.AUTOMOBILE_LOG_SINK = "stderr";
+
+    let capturedStdio: SpawnOptions["stdio"];
+    const processSpawner: DaemonProcessSpawner = {
+      spawn: (_command: string, _args: string[], options: SpawnOptions) => {
+        capturedStdio = options.stdio;
+        return {
+          unref() {},
+          once() { return this; },
+          off() { return this; },
+        } as ChildProcess;
+      }
+    };
+
+    let statusCallCount = 0;
+    class TestDaemonManager extends DaemonManager {
+      override findAllDaemonProcesses(): number[] { return []; }
+      override async status(): Promise<any> {
+        statusCallCount++;
+        return statusCallCount === 1
+          ? { running: false }
+          : { running: true, pid: 1234, port: 31847, socketPath: join(stateDir, "daemon.sock") };
+      }
+      override async waitForReady(_timeout: number): Promise<boolean> {
+        return true;
+      }
+    }
+
+    const manager = new TestDaemonManager(
+      undefined,
+      undefined,
+      new FakeTimer(),
+      join(stateDir, "daemon.lock"),
+      join(stateDir, "daemon.pid"),
+      join(stateDir, "daemon.sock"),
+      undefined,
+      processSpawner
+    );
+
+    await manager.start();
+
+    expect(capturedStdio).toEqual(["ignore", expect.any(Number), "inherit"]);
   });
 
   test("writes the daemon launch log to AUTOMOBILE_LOG_DIR without moving data paths", async () => {

--- a/test/daemon/daemonManagerLaunch.test.ts
+++ b/test/daemon/daemonManagerLaunch.test.ts
@@ -1,9 +1,14 @@
-import { afterEach, describe, expect, test } from "bun:test";
+import { afterEach, describe, expect, spyOn, test } from "bun:test";
 import { existsSync, mkdtempSync, readdirSync, realpathSync, rmSync } from "node:fs";
 import { tmpdir } from "node:os";
 import { join, resolve } from "node:path";
 import type { ChildProcess, SpawnOptions } from "node:child_process";
-import { DaemonManager, type DaemonProcessSpawner } from "../../src/daemon/manager";
+import { PassThrough } from "node:stream";
+import {
+  DaemonManager,
+  relayDaemonStderr,
+  type DaemonProcessSpawner,
+} from "../../src/daemon/manager";
 import { FakeTimer } from "../fakes/FakeTimer";
 import { DAEMON_LAUNCH_CWD_ENV } from "../../src/utils/workingDirectory";
 import { TOOL_OUTPUTS_DIR_ENV, TOOL_OUTPUTS_DIR_FLAG } from "../../src/utils/toolOutputArtifacts";
@@ -31,6 +36,25 @@ describe("DaemonManager launch", () => {
       rmSync(dir, { recursive: true, force: true });
     }
     tempDirs.length = 0;
+  });
+
+  test("relays piped daemon stderr without sharing the host descriptor", () => {
+    const daemonStderr = new PassThrough();
+    const writes: string[] = [];
+    const stderrSpy = spyOn(process.stderr, "write").mockImplementation(((chunk: unknown) => {
+      writes.push(String(chunk));
+      return true;
+    }) as typeof process.stderr.write);
+
+    try {
+      relayDaemonStderr({ stderr: daemonStderr } as ChildProcess);
+      daemonStderr.write("daemon structured record\n");
+    } finally {
+      stderrSpy.mockRestore();
+      daemonStderr.end();
+    }
+
+    expect(writes).toEqual(["daemon structured record\n"]);
   });
 
   test("writes the daemon launch log under the stable data dir, not an ephemeral mkdtemp", async () => {
@@ -81,7 +105,7 @@ describe("DaemonManager launch", () => {
     expect(launchLogs.length).toBeGreaterThan(0);
   });
 
-  test("inherits stderr for the daemon when structured stderr logging is enabled", async () => {
+  test("pipes stderr without a launch capture when structured stderr logging is enabled", async () => {
     const stateDir = createTempDir("daemon-launch-state-");
     process.env.AUTOMOBILE_DATA_DIR = stateDir;
     process.env.AUTOMOBILE_LOG_FORMAT = "json";
@@ -126,7 +150,7 @@ describe("DaemonManager launch", () => {
 
     await manager.start();
 
-    expect(capturedStdio).toEqual(["ignore", expect.any(Number), "inherit"]);
+    expect(capturedStdio).toEqual(["ignore", "ignore", "pipe"]);
   });
 
   test("writes the daemon launch log to AUTOMOBILE_LOG_DIR without moving data paths", async () => {

--- a/test/utils/logger-redaction.test.ts
+++ b/test/utils/logger-redaction.test.ts
@@ -61,6 +61,12 @@ describe("safeStringify redacts sensitive data", () => {
   test("serializes arrays as index-keyed objects (current documented behavior)", () => {
     expect(safeStringify([1, 2, 3])).toBe('{"0":1,"1":2,"2":3}');
   });
+
+  test("replaces circular values without throwing or recursing indefinitely", () => {
+    const circular: { self?: unknown } = {};
+    circular.self = circular;
+    expect(safeStringify(circular)).toBe('{"self":"[circular]"}');
+  });
 });
 
 describe("SENSITIVE_ENV_KEYS", () => {

--- a/test/utils/logger-structured.test.ts
+++ b/test/utils/logger-structured.test.ts
@@ -1,13 +1,29 @@
 import { describe, expect, test, spyOn } from "bun:test";
+import fs, { mkdtempSync, rmSync, writeFileSync } from "node:fs";
+import { EventEmitter } from "node:events";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
 
 let importCounter = 0;
+
+class FailingLogStream extends EventEmitter {
+  destroyed = false;
+  writable = true;
+
+  write(_chunk: unknown, callback?: (error: Error | null) => void): boolean {
+    queueMicrotask(() => callback?.(new Error("ENOSPC")));
+    return false;
+  }
+}
 
 async function loggerWithEnv(
   format: string | undefined,
   sink: string | undefined,
+  logDir?: string,
 ): Promise<typeof import("../../src/utils/logger")> {
   const previousFormat = process.env.AUTOMOBILE_LOG_FORMAT;
   const previousSink = process.env.AUTOMOBILE_LOG_SINK;
+  const previousLogDir = process.env.AUTOMOBILE_LOG_DIR;
   if (format === undefined) {
     delete process.env.AUTOMOBILE_LOG_FORMAT;
   } else {
@@ -17,6 +33,11 @@ async function loggerWithEnv(
     delete process.env.AUTOMOBILE_LOG_SINK;
   } else {
     process.env.AUTOMOBILE_LOG_SINK = sink;
+  }
+  if (logDir === undefined) {
+    delete process.env.AUTOMOBILE_LOG_DIR;
+  } else {
+    process.env.AUTOMOBILE_LOG_DIR = logDir;
   }
   try {
     return await import(`../../src/utils/logger.ts?structured-${importCounter++}`);
@@ -31,6 +52,11 @@ async function loggerWithEnv(
     } else {
       process.env.AUTOMOBILE_LOG_SINK = previousSink;
     }
+    if (previousLogDir === undefined) {
+      delete process.env.AUTOMOBILE_LOG_DIR;
+    } else {
+      process.env.AUTOMOBILE_LOG_DIR = previousLogDir;
+    }
   }
 }
 
@@ -39,12 +65,20 @@ describe("structured logging", () => {
     const mod = await loggerWithEnv("json", "stderr");
     const stderr: string[] = [];
     const stdout: string[] = [];
-    const stderrSpy = spyOn(process.stderr, "write").mockImplementation(((chunk: unknown) => {
+    const stderrSpy = spyOn(process.stderr, "write").mockImplementation(((
+      chunk: unknown,
+      callback?: (error?: Error | null) => void,
+    ) => {
       stderr.push(String(chunk));
+      queueMicrotask(() => callback?.());
       return true;
     }) as typeof process.stderr.write);
-    const stdoutSpy = spyOn(process.stdout, "write").mockImplementation(((chunk: unknown) => {
+    const stdoutSpy = spyOn(process.stdout, "write").mockImplementation(((
+      chunk: unknown,
+      callback?: (error?: Error | null) => void,
+    ) => {
       stdout.push(String(chunk));
+      queueMicrotask(() => callback?.());
       return true;
     }) as typeof process.stdout.write);
 
@@ -90,4 +124,59 @@ describe("structured logging", () => {
     expect(mod.resolveAutomobileLogSink({})).toBe("file");
     await mod.logger.closeAfterFlush();
   });
+
+  test("does not initialize a file sink for stderr-only logging", async () => {
+    const root = mkdtempSync(join(tmpdir(), "am-logger-stderr-"));
+    const unusableLogDir = join(root, "not-a-directory");
+    writeFileSync(unusableLogDir, "not a directory");
+    const mod = await loggerWithEnv("json", "stderr", unusableLogDir);
+    const stderr: string[] = [];
+    const stderrSpy = spyOn(process.stderr, "write").mockImplementation(((
+      chunk: unknown,
+      callback?: (error?: Error | null) => void,
+    ) => {
+      stderr.push(String(chunk));
+      queueMicrotask(() => callback?.());
+      return true;
+    }) as typeof process.stderr.write);
+
+    try {
+      mod.logger.info("container-ready");
+      await mod.logger.flush();
+    } finally {
+      stderrSpy.mockRestore();
+      await mod.logger.closeAfterFlush();
+      rmSync(root, { recursive: true, force: true });
+    }
+
+    expect(JSON.parse(stderr[0])).toMatchObject({ message: "container-ready" });
+  });
+
+  test("keeps the stderr record when the file sink fails in both mode", async () => {
+    const logDir = mkdtempSync(join(tmpdir(), "am-logger-both-"));
+    const createWriteStream = spyOn(fs, "createWriteStream").mockReturnValue(
+      new FailingLogStream() as unknown as fs.WriteStream,
+    );
+    const mod = await loggerWithEnv("json", "both", logDir);
+    const stderr: string[] = [];
+    const stderrSpy = spyOn(process.stderr, "write").mockImplementation(
+      ((chunk: unknown, callback?: (error?: Error | null) => void) => {
+        stderr.push(String(chunk));
+        queueMicrotask(() => callback?.());
+        return true;
+      }) as typeof process.stderr.write,
+    );
+
+    try {
+      mod.logger.info("container-ready");
+      await mod.logger.flush();
+    } finally {
+      stderrSpy.mockRestore();
+      createWriteStream.mockRestore();
+      rmSync(logDir, { recursive: true, force: true });
+    }
+
+    expect(JSON.parse(stderr[0])).toMatchObject({ event: "log", message: "container-ready" });
+  });
+
 });

--- a/test/utils/logger-structured.test.ts
+++ b/test/utils/logger-structured.test.ts
@@ -1,0 +1,93 @@
+import { describe, expect, test, spyOn } from "bun:test";
+
+let importCounter = 0;
+
+async function loggerWithEnv(
+  format: string | undefined,
+  sink: string | undefined,
+): Promise<typeof import("../../src/utils/logger")> {
+  const previousFormat = process.env.AUTOMOBILE_LOG_FORMAT;
+  const previousSink = process.env.AUTOMOBILE_LOG_SINK;
+  if (format === undefined) {
+    delete process.env.AUTOMOBILE_LOG_FORMAT;
+  } else {
+    process.env.AUTOMOBILE_LOG_FORMAT = format;
+  }
+  if (sink === undefined) {
+    delete process.env.AUTOMOBILE_LOG_SINK;
+  } else {
+    process.env.AUTOMOBILE_LOG_SINK = sink;
+  }
+  try {
+    return await import(`../../src/utils/logger.ts?structured-${importCounter++}`);
+  } finally {
+    if (previousFormat === undefined) {
+      delete process.env.AUTOMOBILE_LOG_FORMAT;
+    } else {
+      process.env.AUTOMOBILE_LOG_FORMAT = previousFormat;
+    }
+    if (previousSink === undefined) {
+      delete process.env.AUTOMOBILE_LOG_SINK;
+    } else {
+      process.env.AUTOMOBILE_LOG_SINK = previousSink;
+    }
+  }
+}
+
+describe("structured logging", () => {
+  test("emits standalone redacted JSON records to stderr without stdout output", async () => {
+    const mod = await loggerWithEnv("json", "stderr");
+    const stderr: string[] = [];
+    const stdout: string[] = [];
+    const stderrSpy = spyOn(process.stderr, "write").mockImplementation(((chunk: unknown) => {
+      stderr.push(String(chunk));
+      return true;
+    }) as typeof process.stderr.write);
+    const stdoutSpy = spyOn(process.stdout, "write").mockImplementation(((chunk: unknown) => {
+      stdout.push(String(chunk));
+      return true;
+    }) as typeof process.stdout.write);
+
+    try {
+      mod.logger.info("started\nwith unsafe text", {
+        session_id: "safe",
+        TOKEN: "redact-me",
+      });
+      mod.logger.enableStdoutLogging();
+      await mod.logger.flush();
+    } finally {
+      stderrSpy.mockRestore();
+      stdoutSpy.mockRestore();
+      await mod.logger.closeAfterFlush();
+    }
+
+    expect(stdout).toEqual([]);
+    expect(stderr).toHaveLength(1);
+    const record = JSON.parse(stderr[0]);
+    const message = record.message;
+    expect(record).toMatchObject({
+      level: "info",
+      component: expect.any(String),
+      event: "log",
+      message: expect.stringContaining("started with unsafe text"),
+    });
+    expect(typeof message).toBe("string");
+    expect(!String(message).includes("redact-me")).toBeTrue();
+  });
+
+  test("parses supported format and sink values", async () => {
+    const mod = await loggerWithEnv(undefined, undefined);
+    expect(mod.parseAutomobileLogFormat("JSON")).toBe("json");
+    expect(mod.parseAutomobileLogFormat("xml")).toBeNull();
+    expect(mod.parseAutomobileLogSink("BOTH")).toBe("both");
+    expect(mod.parseAutomobileLogSink("console")).toBeNull();
+    await mod.logger.closeAfterFlush();
+  });
+
+  test("preserves text/file defaults", async () => {
+    const mod = await loggerWithEnv(undefined, undefined);
+    expect(mod.resolveAutomobileLogFormat({})).toBe("text");
+    expect(mod.resolveAutomobileLogSink({})).toBe("file");
+    await mod.logger.closeAfterFlush();
+  });
+});

--- a/test/utils/loggingConfig.test.ts
+++ b/test/utils/loggingConfig.test.ts
@@ -1,0 +1,37 @@
+import { afterEach, describe, expect, spyOn, test } from "bun:test";
+import { writeEmergencyLog } from "../../src/utils/loggingConfig";
+
+const originalFormat = process.env.AUTOMOBILE_LOG_FORMAT;
+
+afterEach(() => {
+  if (originalFormat === undefined) {
+    delete process.env.AUTOMOBILE_LOG_FORMAT;
+  } else {
+    process.env.AUTOMOBILE_LOG_FORMAT = originalFormat;
+  }
+});
+
+describe("writeEmergencyLog", () => {
+  test("emits one valid JSON record in structured mode", () => {
+    process.env.AUTOMOBILE_LOG_FORMAT = "json";
+    const writes: string[] = [];
+    const stderrSpy = spyOn(process.stderr, "write").mockImplementation(((chunk: unknown) => {
+      writes.push(String(chunk));
+      return true;
+    }) as typeof process.stderr.write);
+
+    try {
+      writeEmergencyLog("Fatal startup failure", new Error("database unavailable"));
+    } finally {
+      stderrSpy.mockRestore();
+    }
+
+    expect(writes).toHaveLength(1);
+    expect(JSON.parse(writes[0])).toMatchObject({
+      level: "error",
+      component: "process",
+      event: "log.emergency",
+      message: expect.stringContaining("Fatal startup failure"),
+    });
+  });
+});


### PR DESCRIPTION
## Summary

- Add opt-in `text`/`json` log formats and `file`/`stderr`/`both` sinks.
- Keep text-to-file logging as the default while preserving redaction, truncation, rotation, and retention.
- Wire daemon stderr to the configured process sink without contaminating MCP stdout.
- Document container configuration and add logger/daemon wiring coverage.

## Validation

- `bun test` — 14,083 passed, 14 skipped
- `bun run build`
- `bun run typecheck`
- `bun run lint`
- `bun run turbo:validate`
- Targeted changed-file formatting check

Closes #5554
