### PR TITLE
fix(daemon): reject session admission for a device under active shutdown (#5494)

### DIFF
--- a/src/daemon/devicePool.ts
+++ b/src/daemon/devicePool.ts
@@ -5662,6 +5662,45 @@ export class DevicePool {
         `Session '${sessionId}' is recovering from a process-wide ADB reset. Retry after device recovery completes.`,
       );
     }
+    // Reject admission for a session whose device is being killed. Without this,
+    // a session already bound to the device passes the gate during the killDevice
+    // window and re-creates a fresh auto-reconnecting AndroidCtrlProxyClient via
+    // getInstance, recreating the transport hold the teardown just removed. The
+    // shutdown reservation blocks new *allocation* but not an already-bound
+    // session; execution cancellation only happens later in retirement, so this
+    // is the gate that closes that window (see #5494, follow-up to #5452/#5491).
+    const assignedDeviceId = this.sessionManager.getSession(sessionId)?.assignedDevice;
+    if (assignedDeviceId && this.isDeviceUnderShutdown(assignedDeviceId)) {
+      throw new ActionableError(
+        `Session '${sessionId}' is bound to device '${assignedDeviceId}', which is shutting down. ` +
+          `Retry after the device is released or reassigned.`,
+      );
+    }
+  }
+
+  /**
+   * Whether the currently-bound incarnation of a device is being killed: either
+   * held under an active shutdown reservation, or carrying an intentional-shutdown
+   * marker that applies to the current incarnation. Incarnation-gated (mirroring
+   * {@link applyIntentionalShutdownOnDisconnect}) so a same-serial replacement,
+   * whose own marker/reservation lifecycle is independent, is not blocked by a
+   * stale marker left behind by a device that is already gone.
+   */
+  private isDeviceUnderShutdown(deviceId: string): boolean {
+    const device = this.devices.get(deviceId);
+    const reservation = this.shutdownReservations.get(deviceId);
+    if (reservation !== undefined && (device === undefined || reservation === device)) {
+      return true;
+    }
+    const markerIncarnation = this.intentionalShutdowns.get(deviceId);
+    if (markerIncarnation === undefined) {
+      return false;
+    }
+    return (
+      device === undefined ||
+      markerIncarnation === INCARNATION_ANY ||
+      markerIncarnation === device.incarnation
+    );
   }
 
   /**

--- a/test/daemon/devicePool.test.ts
+++ b/test/daemon/devicePool.test.ts
@@ -673,6 +673,93 @@ describe("DevicePool", () => {
     sessionManager.stopCleanupTimer();
   });
 
+  describe("assertSessionReadyForAutomation shutdown admission (#5494)", () => {
+    const sourceImage: DeviceInfo = {
+      name: "Pixel 8",
+      platform: "android",
+      isRunning: false,
+      source: "local",
+    };
+
+    const bindOwnerSession = async (sessionId: string, deviceId: string): Promise<void> => {
+      const device = createBootedDevice(deviceId, "android", "Pixel 8");
+      fakeDeviceManager.bootedDevices = [device];
+      await devicePool.initializeWithDevices([device]);
+      await devicePool.bindOrReuseDeviceSession(sessionId, deviceId, "android", sourceImage);
+      expect(sessionManager.getSession(sessionId)?.assignedDevice).toBe(deviceId);
+    };
+
+    test("rejects a bound session while its device holds a shutdown reservation", async () => {
+      await bindOwnerSession("owner-session", "emulator-5554");
+
+      expect(() => devicePool.assertSessionReadyForAutomation("owner-session")).not.toThrow();
+
+      const reservation = await devicePool.reserveDeviceForShutdown("emulator-5554");
+      if (!reservation) {
+        throw new Error("expected shutdown reservation");
+      }
+      try {
+        expect(() => devicePool.assertSessionReadyForAutomation("owner-session")).toThrow(
+          /shutting down/,
+        );
+      } finally {
+        await reservation.release();
+      }
+
+      // Retirement releases the reservation, so admission resumes.
+      expect(() => devicePool.assertSessionReadyForAutomation("owner-session")).not.toThrow();
+    });
+
+    test("rejects a bound session while its device carries an intentional-shutdown marker", async () => {
+      await bindOwnerSession("owner-session", "emulator-5554");
+
+      devicePool.markIntentionalShutdown("emulator-5554");
+      expect(() => devicePool.assertSessionReadyForAutomation("owner-session")).toThrow(
+        /shutting down/,
+      );
+
+      devicePool.clearIntentionalShutdown("emulator-5554");
+      expect(() => devicePool.assertSessionReadyForAutomation("owner-session")).not.toThrow();
+    });
+
+    test("does not block a session bound to a different, healthy device", async () => {
+      const owner = createBootedDevice("emulator-5554", "android", "Pixel 8");
+      const other = createBootedDevice("emulator-5556", "android", "Pixel 8");
+      fakeDeviceManager.bootedDevices = [owner, other];
+      await devicePool.initializeWithDevices([owner, other]);
+      await devicePool.bindOrReuseDeviceSession(
+        "owner-session",
+        owner.deviceId,
+        "android",
+        sourceImage,
+      );
+      await devicePool.bindOrReuseDeviceSession(
+        "other-session",
+        other.deviceId,
+        "android",
+        sourceImage,
+      );
+
+      const reservation = await devicePool.reserveDeviceForShutdown(owner.deviceId);
+      if (!reservation) {
+        throw new Error("expected shutdown reservation");
+      }
+      try {
+        expect(() => devicePool.assertSessionReadyForAutomation("owner-session")).toThrow(
+          /shutting down/,
+        );
+        // The sibling session on a healthy device is unaffected.
+        expect(() => devicePool.assertSessionReadyForAutomation("other-session")).not.toThrow();
+      } finally {
+        await reservation.release();
+      }
+    });
+
+    test("does not block an unknown session with no device binding", () => {
+      expect(() => devicePool.assertSessionReadyForAutomation("no-such-session")).not.toThrow();
+    });
+  });
+
   describe("initializeWithDevices", () => {
     test("should initialize with empty device list", async () => {
       await devicePool.initializeWithDevices([]);


### PR DESCRIPTION
## Summary

`assertSessionReadyForAutomation` (`src/daemon/devicePool.ts`) is the sole session-admission gate on the tool path (called from `ToolExecutionContext`), but it only rejected `adbServerResetQuarantinedSessions`. A session already bound to a device being killed therefore passed the gate during the `killDevice` window and re-created a fresh, auto-reconnecting `AndroidCtrlProxyClient` via `getInstance`, recreating the transport hold the observer teardown from #5491 had just removed.

This closes that window: admission is now rejected when the session's bound device is under an active shutdown reservation or carries an intentional-shutdown marker for the current incarnation. The check is incarnation-gated (mirroring `applyIntentionalShutdownOnDisconnect`) so a same-serial replacement — whose own marker/reservation lifecycle is independent — is not blocked by a stale marker left behind by a device that is already gone. The block naturally persists from reservation through retirement (which releases the reservation / consumes the marker), so admission resumes once the device is released or reassigned.

Per the issue, the cheaper alternative (moving session-execution cancellation ahead of the observer teardown) was rejected — it reorders behavior guarded by `test/server/deviceTools.killDevice.test.ts` and is regression-prone.

## Linked Issue

Closes #5494

## Bug / Regression Context

- **Prior attempts:** #5491 (fixed #5452) — closes+evicts the per-device `AndroidCtrlProxyClient` before the kill command. It does not create this window; it only changes what a concurrent tool does inside a pre-existing window (re-create vs reuse the never-closed client).
- **Observed symptom:** during the kill window, a concurrent `observe`/`tapOn` on the still-bound session re-creates a fresh auto-reconnecting `AndroidCtrlProxyClient`, re-establishing the transport hold teardown was meant to remove.
- **Repro conditions:** `killDevice(X)` in flight while a session bound to X is admitted for another device tool (between eviction and the retirement-time `cancelSessionUuidExecutions`).

## Validation

- [x] `bun test` — full suite green (14115 pass, 0 fail)
- [x] `bun run lint` — ratchet gate: no new violations; boundary-checks all pass
- [x] `bun run typecheck` reports no new errors (baseline gate)
- [x] New unit tests use the existing DevicePool + FakeTimer harness; run in <100ms
- [x] New code reuses existing helpers/markers (`shutdownReservations`, `intentionalShutdowns`, `INCARNATION_ANY`); no new dependency
- [x] Rebased onto latest `main`

### Tests (`test/daemon/devicePool.test.ts`, `describe("assertSessionReadyForAutomation shutdown admission")`)
- rejects a bound session while its device holds a shutdown reservation (and admission resumes after release)
- rejects a bound session while its device carries an intentional-shutdown marker (and resumes after `clearIntentionalShutdown`)
- does not block a sibling session bound to a different, healthy device
- does not block an unknown session with no device binding

## Follow-ups

Siblings of #5494 tracked separately: #5503 (restore Android observer on failed-kill-but-alive). No new follow-ups from this change.
