### PR TITLE
ci(test): prevent macOS Node tests from starting adb

### DIFF
--- a/.github/workflows/merge.yml
+++ b/.github/workflows/merge.yml
@@ -674,8 +674,9 @@ jobs:
       - name: "Run Tests"
         shell: bash
         env:
-          # Force AdbClient into test mode on Windows to prevent adb daemon startup
-          AUTOMOBILE_TEST_MODE: ${{ matrix.os == 'windows-latest' && 'true' || '' }}
+          # Unit tests use injected fakes; real ADB coverage belongs to the
+          # dedicated device-integration jobs. Never start an adb daemon here.
+          AUTOMOBILE_TEST_MODE: "true"
           TURBO_TELEMETRY_DISABLED: "1"
           TURBO_NO_UPDATE_NOTIFIER: "1"
           DO_NOT_TRACK: "1"

--- a/.github/workflows/pull_request.yml
+++ b/.github/workflows/pull_request.yml
@@ -1314,10 +1314,9 @@ jobs:
         if: env.RUN_MCP_BUILD_TEST == 'true'
         shell: bash
         env:
-          # Enable debug logging on Windows to trace what's starting the adb daemon
-          DEBUG_ADB_EXEC: ${{ matrix.os == 'windows-latest' && 'true' || '' }}
-          # Force AdbClient into test mode on Windows to prevent adb daemon startup
-          AUTOMOBILE_TEST_MODE: ${{ matrix.os == 'windows-latest' && 'true' || '' }}
+          # Unit tests use injected fakes; real ADB coverage belongs to the
+          # dedicated device-integration jobs. Never start an adb daemon here.
+          AUTOMOBILE_TEST_MODE: "true"
           TURBO_TELEMETRY_DISABLED: "1"
           TURBO_NO_UPDATE_NOTIFIER: "1"
           DO_NOT_TRACK: "1"

--- a/test/scripts/nodeTestWorkflow.test.ts
+++ b/test/scripts/nodeTestWorkflow.test.ts
@@ -1,0 +1,15 @@
+import { describe, expect, test } from "bun:test";
+import { loadJobSteps, stepNamed } from "../helpers/workflowSteps";
+
+const WORKFLOWS = [".github/workflows/pull_request.yml", ".github/workflows/merge.yml"] as const;
+
+describe("Node test workflow isolation", () => {
+  for (const workflow of WORKFLOWS) {
+    test(`${workflow} prevents unit tests from starting a real adb daemon`, () => {
+      const runTests = stepNamed(loadJobSteps(workflow, "mcp-build-and-test"), "Run Tests");
+
+      expect(runTests).toBeDefined();
+      expect(runTests?.env?.AUTOMOBILE_TEST_MODE).toBe("true");
+    });
+  }
+});


### PR DESCRIPTION
## Problem

The macOS Node unit-test lane is intermittently hanging or timing out despite the reported test files being deterministic and fully in-memory. Ten recent failures included three 12-minute watchdog aborts and a recurring `HandleIntentChooser` timeout at the raised 20-second per-test ceiling.

The cross-platform Node job only enabled `AUTOMOBILE_TEST_MODE` on Windows. On macOS, unit tests therefore constructed real `AdbClient`s; `HandleIntentChooser.test.ts` reached two unbounded `adb shell date` probes through `BaseVisualChange`, and a wedged adb subprocess could outlive the individual test.

## Solution

- Enable the existing `AdbClient` test seam for every OS in the PR and merge Node unit-test matrices.
- Keep real ADB coverage in the dedicated device-integration jobs.
- Add a YAML-parsed contract test covering both workflows so macOS cannot silently fall back to real ADB again.

## Validation

- `bun test test/scripts/nodeTestWorkflow.test.ts`
- `AUTOMOBILE_TEST_MODE=true bun test test/features/action/HandleIntentChooser.test.ts`
- `scripts/all_fast_validate_checks.sh --only yaml,workflow-assertion-triggers`
- `bun run typecheck`
- `bun run turbo:validate` — 14,117 passed, 14 skipped, 0 failed
- `bunx oxfmt --check test/scripts/nodeTestWorkflow.test.ts`

Repository-wide `bun run format:check` remains pre-existing red on 1,804 files; the new test file is individually formatted.

## Risk

Low. This only affects unit-test jobs. The same test-mode path has run on Windows since January, and platform/device integration jobs remain unchanged.

Made with [Cursor](https://cursor.com)