### PR TITLE
fix(daemon): prune release-tracking maps on DaemonMcpProxy.close() (#4689)

### DIFF
--- a/src/daemon/daemonMcpProxy.ts
+++ b/src/daemon/daemonMcpProxy.ts
@@ -1741,6 +1741,16 @@ export class DaemonMcpProxy {
     this.connected = false;
     this.clearBoundSessionUuid();
     this.terminalBoundSession = undefined;
+    // Drain the per-UUID release-tracking maps at the close/reconnect boundary.
+    // Ordinary completion already evicts each entry when its last in-flight
+    // reference drops (issue #4655 / #5412), so these maps are bounded by the
+    // count of concurrently in-flight calls. Clearing them on close is the
+    // backstop the reference counter does not cover — a proxy closed with calls
+    // still in flight, or reused across a reconnect, cannot retain release
+    // records across its lifetime (issue #4689).
+    this.releasedSessionEpochs.clear();
+    this.releasedSessionReasons.clear();
+    this.activeReleaseEpochReferences.clear();
     this.invalidateCache();
     logger.debug("[DaemonMcpProxy] Disconnected from daemon");
   }

--- a/test/daemon/daemonMcpProxy.test.ts
+++ b/test/daemon/daemonMcpProxy.test.ts
@@ -3437,4 +3437,85 @@ describe("DaemonMcpProxy", () => {
       expect(error.message).toContain("bunx @kaeawc/auto-mobile@0.0.40 --daemon restart");
     });
   });
+
+  // The per-UUID release-tracking maps (`releasedSessionEpochs`,
+  // `releasedSessionReasons`, `activeReleaseEpochReferences`) must not grow
+  // unbounded over a long-lived proxy (issue #4689, follow-up to #4655). Ordinary
+  // completion evicts each entry when its last in-flight reference drops
+  // (#5412); close() drains any residue at the close/reconnect boundary the
+  // reference counter does not cover.
+  describe("release-tracking maps stay bounded (issue #4689)", () => {
+    const releaseMapSizes = (
+      proxy: DaemonMcpProxy,
+    ): { epochs: number; reasons: number; references: number } => {
+      const internals = proxy as unknown as {
+        releasedSessionEpochs: Map<string, number>;
+        releasedSessionReasons: Map<string, string>;
+        activeReleaseEpochReferences: Map<string, number>;
+      };
+      return {
+        epochs: internals.releasedSessionEpochs.size,
+        reasons: internals.releasedSessionReasons.size,
+        references: internals.activeReleaseEpochReferences.size,
+      };
+    };
+
+    test("a completed call leaves no residual release record (reference-counted bound)", async () => {
+      // recordSessionReleased only writes an entry while an in-flight call holds a
+      // reference to the forwarded UUID, and the call's finally drops that
+      // reference and evicts the entry. Firing the release DURING the call writes
+      // the record mid-flight; by completion it must be gone.
+      const fakeClient: FakeDaemonClient = new FakeDaemonClient({
+        toolResult: { content: [{ type: "text", text: "ok" }] },
+        onCallTool: () => {
+          fakeClient.emitNotification(SESSION_RELEASED_NOTIFICATION_METHOD, "session-a");
+        },
+      });
+      const isAvailableSpy = spyOn(DaemonClient, "isAvailable").mockResolvedValue(true);
+      const proxy = new DaemonMcpProxy({
+        clientFactory: () => fakeClient,
+        daemonManager: matchingDaemonManager(),
+        autoStartDaemon: false,
+      });
+
+      try {
+        await proxy.callTool("observe", { sessionUuid: "session-a", deviceId: "device-a" });
+        expect(releaseMapSizes(proxy)).toEqual({ epochs: 0, reasons: 0, references: 0 });
+      } finally {
+        isAvailableSpy.mockRestore();
+        await proxy.close();
+      }
+    });
+
+    test("close() prunes any residual release-tracking records", async () => {
+      const fakeClient = new FakeDaemonClient({
+        toolResult: { content: [{ type: "text", text: "ok" }] },
+      });
+      const isAvailableSpy = spyOn(DaemonClient, "isAvailable").mockResolvedValue(true);
+      const proxy = new DaemonMcpProxy({
+        clientFactory: () => fakeClient,
+        daemonManager: matchingDaemonManager(),
+        autoStartDaemon: false,
+      });
+
+      const internals = proxy as unknown as {
+        releasedSessionEpochs: Map<string, number>;
+        releasedSessionReasons: Map<string, string>;
+        activeReleaseEpochReferences: Map<string, number>;
+      };
+      // Simulate a record that outlived its in-flight reference (e.g. a future
+      // regression in the retain/release pairing). close() must still drain it so
+      // the maps cannot accumulate across the proxy's lifetime.
+      internals.releasedSessionEpochs.set("stale-session", 7);
+      internals.releasedSessionReasons.set("stale-session", "released");
+      internals.activeReleaseEpochReferences.set("stale-session", 1);
+
+      try {
+        await proxy.close();
+        expect(releaseMapSizes(proxy)).toEqual({ epochs: 0, reasons: 0, references: 0 });
+      } finally {
+        isAvailableSpy.mockRestore();
+      }
+    });
+  });
 });


### PR DESCRIPTION
## What

Adds the close()/reconnect backstop for the per-UUID release-tracking maps on `DaemonMcpProxy`, and pins the bounded-growth invariant with tests. Addresses the hardening follow-up in [#4689](https://github.com/kaeawc/auto-mobile/issues/4689) (item 1).

## Background — #4689 status

[#4689](https://github.com/kaeawc/auto-mobile/issues/4689) captured three non-blocking hardening follow-ups from the [#4655](https://github.com/kaeawc/auto-mobile/pull/4655) review. Re-checking each against current `main`:

1. **Prune `releasedSessionEpochs` (unbounded growth).** Largely resolved after #4689 was filed: [#5412](https://github.com/kaeawc/auto-mobile/pull/5412) introduced reference counting (`activeReleaseEpochReferences`). `recordSessionReleased` now only writes an entry while an in-flight `callTool` holds a reference to the forwarded UUID (`daemonMcpProxy.ts:1472`), and `releaseReleaseEpochReference` deletes the entry from all three maps in the `callTool` `finally` when the last reference drops (`:1279`, `:1498`). So the maps are bounded by the count of *concurrently in-flight* calls — they cannot grow unbounded over a long-lived proxy. **The one gap that remained:** `close()` did not drain the maps, so a proxy closed with calls still in flight, or reused across a reconnect, could retain records. **This PR adds that clear.**
2. **Per-kind discovery epoch.** Explicitly *optional* in the issue and correctness-safe today; deferred (out of scope here).
3. **`resolveCapabilityBaseSessionUuid` identity-on-genuine-base contract.** The resolver was renamed to `resolveToolSelectionBaseSessionUuid`, and its identity-on-genuine-base contract is **already test-pinned** at `test/features/toolSelection/selectionSessionResolver.test.ts:19` (`"base-session"` → `"base-session"`), plus the derived/unknown/undefined cases. No new test needed.

## Changes

- `DaemonMcpProxy.close()` now clears `releasedSessionEpochs`, `releasedSessionReasons`, and `activeReleaseEpochReferences` — the close/reconnect boundary the reference counter does not cover.
- Two regression tests in `test/daemon/daemonMcpProxy.test.ts`:
  - **reference-counted bound** — a completed call whose forwarded session is released mid-flight leaves no residue (guards the #5412 behavior against regression).
  - **close() prunes residual records** — seeds a residual entry and asserts `close()` drains it. Verified to fail without the source change (expected 0, received 3).

## Validation

- `bun test test/daemon/daemonMcpProxy.test.ts` → 106 pass / 0 fail
- `bun run build` → ok
- `bun run typecheck` → no new type errors
- `oxlint` on changed files → no new warnings (two pre-existing `complexity` warnings are in untouched functions)

## Follow-ups

- #4689 item 2 (per-kind discovery epoch) remains open as an optional, correctness-safe optimization. Leaving the issue open for it rather than auto-closing.