### PR TITLE
fix: recover unresponsive iOS CtrlProxy runner

### DIFF
--- a/src/utils/IOSCtrlProxyManager.ts
+++ b/src/utils/IOSCtrlProxyManager.ts
@@ -83,7 +83,7 @@ export interface CtrlProxyIosManager extends ProxyManager {
   getReportedRunnerPort(): Promise<number | null>;
   setAutoRestart(enabled: boolean): void;
   isAutoRestartEnabled(): boolean;
-  forceRestart(): Promise<void>;
+  forceRestart(options?: CtrlProxyStartOptions): Promise<void>;
 }
 
 interface RemoteCtrlProxyIOSRunner {
@@ -157,6 +157,14 @@ class RemoteServicePortUnavailableError extends Error {
   constructor(host: string, port: number) {
     super(`Remote runner port ${port} is already in use on ${host}`);
     this.name = "RemoteServicePortUnavailableError";
+  }
+}
+
+/** Marks a forced-restart failure caused by its initiating caller cancelling. */
+class ForceRestartCancelledError extends Error {
+  constructor(reason: unknown) {
+    super(errorMessage(reason), { cause: reason });
+    this.name = "ForceRestartCancelledError";
   }
 }
 
@@ -240,6 +248,15 @@ export class IOSCtrlProxyManager implements CtrlProxyIosManager {
 
   // Shared process startup prevents concurrent callers from launching duplicate runners.
   private sharedStart: SharedCtrlProxyStart | null = null;
+  // A forced restart must retain lifecycle ownership through its non-interruptible
+  // stop phase, even when the readiness caller times out before it settles.
+  private forceRestartInFlight: Promise<void> | null = null;
+  // Lets ordinary starts detect that a newer forced restart began while they
+  // yielded before claiming the shared-start slot.
+  private forceRestartGeneration = 0;
+  // Joining callers may need a longer health-poll budget than the restart owner.
+  // Retain their request until the forced restart reaches shared startup.
+  private readonly forceRestartHealthPollDurationsMs = new Map<symbol, number>();
 
   // Target app bundle ID for CtrlProxy to observe (instead of SpringBoard)
   private targetBundleId: string | null = null;
@@ -822,11 +839,29 @@ export class IOSCtrlProxyManager implements CtrlProxyIosManager {
    * Start CtrlProxy
    */
   public async start(options: CtrlProxyStartOptions = {}): Promise<void> {
+    for (;;) {
+      await this.waitForForceRestart(options);
+      const expectedForceRestartGeneration = this.forceRestartGeneration;
+      if (this.forceRestartInFlight) {
+        continue;
+      }
+      return this.startAfterForceRestart(options, expectedForceRestartGeneration);
+    }
+  }
+
+  private async startAfterForceRestart(
+    options: CtrlProxyStartOptions,
+    expectedForceRestartGeneration?: number,
+  ): Promise<void> {
     if (options.signal?.aborted) {
       throw options.signal.reason ?? new Error("iOS CtrlProxy startup was aborted");
     }
 
     let sharedStart = await this.waitForNonJoinableStart(options.signal);
+    if (expectedForceRestartGeneration !== undefined &&
+      (this.forceRestartGeneration !== expectedForceRestartGeneration || this.forceRestartInFlight)) {
+      return this.start(options);
+    }
     if (sharedStart) {
       logger.info("[IOSCtrlProxy] Start already in progress, waiting for it to complete");
     } else {
@@ -1667,12 +1702,131 @@ export class IOSCtrlProxyManager implements CtrlProxyIosManager {
   /**
    * Force restart the service (useful when client detects issues)
    */
-  public async forceRestart(): Promise<void> {
+  public async forceRestart(options: CtrlProxyStartOptions = {}): Promise<void> {
     logger.info("[IOSCtrlProxy] Force restart requested");
 
-    // Stop and restart
-    await this.stop();
-    await this.start();
+    const existingRestart = this.forceRestartInFlight;
+    if (existingRestart) {
+      const restarted = await this.waitForForceRestart(options);
+      if (restarted) {
+        return;
+      }
+      return this.forceRestart(options);
+    }
+
+    // Stop cannot be interrupted safely. Keep subsequent start/restart callers
+    // behind this barrier until teardown settles, even if the initiating
+    // readiness phase has already timed out.
+    this.forceRestartGeneration += 1;
+    const restart = (async () => {
+      try {
+        await this.stop();
+        if (options.signal?.aborted) {
+          throw new ForceRestartCancelledError(
+            options.signal.reason ?? new Error("iOS CtrlProxy restart was aborted"),
+          );
+        }
+        if (await this.checkHealthEndpointOnPortForDevice(this.servicePort, this.device.deviceId)) {
+          throw new Error(
+            "iOS CtrlProxy is still running after forced teardown; refusing to reuse a potentially unresponsive runner",
+          );
+        }
+        await this.startAfterForceRestart({
+          ...options,
+          minimumHealthPollDurationMs: this.maximumForceRestartHealthPollDurationMs(
+            options.minimumHealthPollDurationMs,
+          ),
+        });
+      } catch (error) {
+        if (options.signal?.aborted && !(error instanceof ForceRestartCancelledError)) {
+          throw new ForceRestartCancelledError(options.signal.reason ?? error);
+        }
+        throw error;
+      }
+    })();
+    this.forceRestartInFlight = restart;
+    void restart.finally(() => {
+      if (this.forceRestartInFlight === restart) {
+        this.forceRestartInFlight = null;
+        this.forceRestartHealthPollDurationsMs.clear();
+      }
+    }).catch(() => {});
+    await restart;
+  }
+
+  private async waitForForceRestart(options: CtrlProxyStartOptions): Promise<boolean> {
+    const restart = this.forceRestartInFlight;
+    if (!restart) {
+      return true;
+    }
+    const healthPollCaller = this.registerForceRestartHealthPollDuration(
+      options.minimumHealthPollDurationMs,
+    );
+    const waitForRestart = async (): Promise<boolean> => {
+      try {
+        await restart;
+        return true;
+      } catch (error) {
+        if (error instanceof ForceRestartCancelledError) {
+          // The earlier caller's deadline must not poison a later live caller.
+          return false;
+        }
+        throw error;
+      }
+    };
+    try {
+      const { signal } = options;
+      if (!signal) {
+        return await waitForRestart();
+      }
+      if (signal.aborted) {
+        throw signal.reason ?? new Error("iOS CtrlProxy startup was aborted");
+      }
+      return await new Promise<boolean>((resolve, reject) => {
+        const onAbort = () => reject(signal.reason ?? new Error("iOS CtrlProxy startup was aborted"));
+        signal.addEventListener("abort", onAbort, { once: true });
+        void waitForRestart().then(
+          (restarted) => {
+            signal.removeEventListener("abort", onAbort);
+            resolve(restarted);
+          },
+          (error) => {
+            signal.removeEventListener("abort", onAbort);
+            reject(error);
+          },
+        );
+      });
+    } finally {
+      this.removeForceRestartHealthPollDuration(healthPollCaller);
+    }
+  }
+
+  private maximumForceRestartHealthPollDurationMs(ownerDurationMs: number | undefined): number | undefined {
+    const joiningDurationMs = Math.max(0, ...this.forceRestartHealthPollDurationsMs.values());
+    const maximumDurationMs = Math.max(ownerDurationMs ?? 0, joiningDurationMs);
+    return maximumDurationMs > 0 ? maximumDurationMs : undefined;
+  }
+
+  private registerForceRestartHealthPollDuration(durationMs: number | undefined): symbol | undefined {
+    if (!durationMs || durationMs <= 0) {
+      return undefined;
+    }
+    const callerId = Symbol("CtrlProxy forced restart caller");
+    this.forceRestartHealthPollDurationsMs.set(callerId, durationMs);
+    if (this.sharedStart) {
+      this.extendHealthPollDeadline(this.sharedStart, callerId, durationMs);
+    }
+    return callerId;
+  }
+
+  private removeForceRestartHealthPollDuration(callerId: symbol | undefined): void {
+    if (!callerId) {
+      return;
+    }
+    this.forceRestartHealthPollDurationsMs.delete(callerId);
+    if (this.sharedStart) {
+      this.removeHealthPollDeadline(this.sharedStart, callerId);
+    }
   }
 
   /**

--- a/src/utils/RunnerReadinessService.ts
+++ b/src/utils/RunnerReadinessService.ts
@@ -74,6 +74,10 @@ export interface ReadinessAndroidManager {
 export interface ReadinessIosManager {
   isInstalled(): Promise<boolean>;
   resetSetupState(): void;
+  forceRestart(options?: {
+    signal?: AbortSignal;
+    minimumHealthPollDurationMs?: number;
+  }): Promise<void>;
   start(options?: {
     signal?: AbortSignal;
     minimumHealthPollDurationMs?: number;
@@ -639,7 +643,7 @@ export class RunnerReadinessService {
       this.dependencies.awaitIosStartupMaintenance(),
     );
     const manager = this.dependencies.getIosManager(context.device);
-    const client = this.dependencies.getIosClient(context.device, manager.getServicePort());
+    let client = this.dependencies.getIosClient(context.device, manager.getServicePort());
     if (client.isConnected()) {
       const ready = await this.runPhase(context, "runner-health", 1, () =>
         client.verifyServiceReady(1, 0, this.probeTimeout(context)),
@@ -648,6 +652,19 @@ export class RunnerReadinessService {
         return;
       }
       manager.resetSetupState();
+      // A reachable CtrlProxy endpoint can still be unable to produce a
+      // hierarchy. In that state setup() would short-circuit on port health,
+      // leaving the runner wedged indefinitely. Restart the process so the
+      // next health probe uses a fresh observation stream (#5532).
+      await this.runPhase(context, "runner-setup", 1, (signal) => manager.forceRestart({
+        signal,
+        minimumHealthPollDurationMs: this.remainingForPhase(context, "runner-setup"),
+      }));
+      // Restart can reallocate the service port when its prior listener became
+      // unavailable. Do not let a stale client accept another device's runner.
+      client = this.dependencies.getIosClient(context.device, manager.getServicePort());
+      await this.waitForResponsiveClient(context, client);
+      return;
     }
 
     if (context.skipCtrlProxyDownload) {

--- a/test/utils/DeviceSessionManager.test.ts
+++ b/test/utils/DeviceSessionManager.test.ts
@@ -674,7 +674,8 @@ describe("DeviceSessionManager legacy iOS auto-start readiness", () => {
 
     await expect(manager.ensureDeviceReady("ios")).resolves.toEqual(iosDevice);
     expect(iosManager.wasMethodCalled("resetSetupState")).toBe(true);
-    expect(iosManager.wasMethodCalled("setup")).toBe(true);
+    expect(iosManager.wasMethodCalled("forceRestart")).toBe(true);
+    expect(iosManager.wasMethodCalled("setup")).toBe(false);
   });
 
   test("does not retry the current simulator after runner readiness fails", async () => {

--- a/test/utils/IOSCtrlProxyManager.test.ts
+++ b/test/utils/IOSCtrlProxyManager.test.ts
@@ -4,6 +4,7 @@ import {
   IOSCtrlProxyManager,
   STARTUP_ORPHAN_RUNNER_REAP_DEADLINE_MS,
   MAX_STARTUP_ORPHAN_RUNNER_CANDIDATES,
+  type CtrlProxyStartOptions,
 } from "../../src/utils/IOSCtrlProxyManager";
 import { BootedDevice } from "../../src/models";
 import { FakeTimer } from "../fakes/FakeTimer";
@@ -333,6 +334,236 @@ describe("IOSCtrlProxyManager", function() {
     test("should return default port 8765", function() {
       const manager = IOSCtrlProxyManager.getInstance(testDevice);
       expect(manager.getServicePort()).toBe(8765);
+    });
+  });
+
+  describe("forceRestart", function() {
+    test("forwards caller startup options after stopping", async function() {
+      const manager = IOSCtrlProxyManager.getInstance(testDevice);
+      const controller = new AbortController();
+      const options = { signal: controller.signal, minimumHealthPollDurationMs: 1_000 };
+      spyOn(manager, "stop").mockResolvedValue();
+      spyOn(manager, "isRunning").mockResolvedValue(false);
+      const start = spyOn(
+        manager as unknown as { startAfterForceRestart(options: CtrlProxyStartOptions): Promise<void> },
+        "startAfterForceRestart",
+      ).mockResolvedValue();
+
+      await manager.forceRestart(options);
+
+      expect(start).toHaveBeenCalledWith(options);
+    });
+
+    test("does not start a replacement after cancellation during stop", async function() {
+      const manager = IOSCtrlProxyManager.getInstance(testDevice);
+      const controller = new AbortController();
+      spyOn(manager, "stop").mockImplementation(async () => {
+        controller.abort(new Error("readiness deadline expired"));
+      });
+      const start = spyOn(
+        manager as unknown as { startAfterForceRestart(options: CtrlProxyStartOptions): Promise<void> },
+        "startAfterForceRestart",
+      ).mockResolvedValue();
+
+      await expect(manager.forceRestart({ signal: controller.signal })).rejects.toThrow(
+        "readiness deadline expired",
+      );
+      expect(start).not.toHaveBeenCalled();
+    });
+
+    test("keeps a subsequent start behind a forced restart whose stop is still settling", async function() {
+      const manager = IOSCtrlProxyManager.getInstance(testDevice);
+      const stopped = deferred();
+      spyOn(manager, "stop").mockImplementation(async () => await stopped.promise);
+      spyOn(manager, "isRunning").mockResolvedValue(false);
+      const start = spyOn(
+        manager as unknown as { startAfterForceRestart(options: CtrlProxyStartOptions): Promise<void> },
+        "startAfterForceRestart",
+      ).mockResolvedValue();
+
+      const forcedRestart = manager.forceRestart();
+      await Promise.resolve();
+      const subsequentStart = manager.start();
+      await Promise.resolve();
+
+      expect(start).not.toHaveBeenCalled();
+      stopped.resolve();
+      await forcedRestart;
+      await subsequentStart;
+      expect(start).toHaveBeenCalledTimes(2);
+    });
+
+    test("lets a live caller retry after an earlier cancelled restart settles", async function() {
+      const manager = IOSCtrlProxyManager.getInstance(testDevice);
+      const stopped = deferred();
+      const controller = new AbortController();
+      const stop = spyOn(manager, "stop")
+        .mockImplementationOnce(async () => await stopped.promise)
+        .mockResolvedValue();
+      spyOn(manager, "isRunning").mockResolvedValue(false);
+      const start = spyOn(
+        manager as unknown as { startAfterForceRestart(options: CtrlProxyStartOptions): Promise<void> },
+        "startAfterForceRestart",
+      ).mockResolvedValue();
+
+      const cancelledRestart = manager.forceRestart({ signal: controller.signal });
+      await Promise.resolve();
+      const liveRestart = manager.forceRestart();
+      controller.abort(new Error("readiness deadline expired"));
+      stopped.resolve();
+
+      await expect(cancelledRestart).rejects.toThrow("readiness deadline expired");
+      await liveRestart;
+      expect(stop).toHaveBeenCalledTimes(2);
+      expect(start).toHaveBeenCalledTimes(1);
+    });
+
+    test("extends a forced restart with a joining caller's health-poll budget", async function() {
+      const manager = IOSCtrlProxyManager.getInstance(testDevice);
+      const stopped = deferred();
+      spyOn(manager, "stop").mockImplementation(async () => await stopped.promise);
+      spyOn(manager, "isRunning").mockResolvedValue(false);
+      const start = spyOn(
+        manager as unknown as { startAfterForceRestart(options: CtrlProxyStartOptions): Promise<void> },
+        "startAfterForceRestart",
+      ).mockResolvedValue();
+
+      const ownerRestart = manager.forceRestart();
+      await Promise.resolve();
+      const joiningRestart = manager.forceRestart({ minimumHealthPollDurationMs: 1_000 });
+      stopped.resolve();
+
+      await ownerRestart;
+      await joiningRestart;
+      expect(start).toHaveBeenCalledWith({ minimumHealthPollDurationMs: 1_000 });
+    });
+
+    test("lets a live caller retry after the owner's startup-phase cancellation", async function() {
+      const manager = IOSCtrlProxyManager.getInstance(testDevice);
+      const started = deferred();
+      const controller = new AbortController();
+      const stop = spyOn(manager, "stop").mockResolvedValue();
+      spyOn(manager, "isRunning").mockResolvedValue(false);
+      const start = spyOn(
+        manager as unknown as { startAfterForceRestart(options: CtrlProxyStartOptions): Promise<void> },
+        "startAfterForceRestart",
+      )
+        .mockImplementationOnce(async () => {
+          await started.promise;
+          throw controller.signal.reason;
+        })
+        .mockResolvedValue();
+
+      const cancelledRestart = manager.forceRestart({ signal: controller.signal });
+      await Promise.resolve();
+      const liveRestart = manager.forceRestart();
+      const cancelledFailure = cancelledRestart.catch(error => error);
+      controller.abort(new Error("readiness deadline expired"));
+      started.resolve();
+
+      const cancelledError = await cancelledFailure;
+      expect(cancelledError).toBeInstanceOf(Error);
+      expect((cancelledError as Error).message).toContain("readiness deadline expired");
+      await liveRestart;
+      expect(stop).toHaveBeenCalledTimes(2);
+      expect(start).toHaveBeenCalledTimes(2);
+    });
+
+    test("keeps a start behind a successor forced restart after cancellation", async function() {
+      const manager = IOSCtrlProxyManager.getInstance(testDevice);
+      const firstStop = deferred();
+      const secondStop = deferred();
+      const startGate = deferred();
+      const controller = new AbortController();
+      const stop = spyOn(manager, "stop")
+        .mockImplementationOnce(async () => await firstStop.promise)
+        .mockImplementationOnce(async () => await secondStop.promise);
+      spyOn(manager, "isRunning").mockResolvedValue(false);
+      const start = spyOn(
+        manager as unknown as { startInternal(sharedStart: unknown): Promise<void> },
+        "startInternal",
+      ).mockResolvedValue();
+      spyOn(
+        manager as unknown as {
+          waitForNonJoinableStart(signal: AbortSignal | undefined): Promise<unknown>;
+        },
+        "waitForNonJoinableStart",
+      ).mockImplementationOnce(async () => {
+        await startGate.promise;
+        return null;
+      });
+
+      const cancelledRestart = manager.forceRestart({ signal: controller.signal });
+      await Promise.resolve();
+      const ordinaryStart = manager.start();
+      const successorRestart = manager.forceRestart();
+      const cancelledFailure = cancelledRestart.catch(error => error);
+      controller.abort(new Error("readiness deadline expired"));
+      firstStop.resolve();
+
+      await cancelledFailure;
+      await Promise.resolve();
+      await Promise.resolve();
+      expect(stop).toHaveBeenCalledTimes(2);
+      expect(start).not.toHaveBeenCalled();
+      startGate.resolve();
+      await Promise.resolve();
+      expect(start).not.toHaveBeenCalled();
+      secondStop.resolve();
+
+      await ordinaryStart;
+      await successorRestart;
+      expect(start).toHaveBeenCalledTimes(2);
+    });
+
+    test("fails rather than reusing a runner that remains after forced teardown", async function() {
+      const manager = IOSCtrlProxyManager.getInstance(testDevice);
+      spyOn(manager, "stop").mockResolvedValue();
+      spyOn(
+        manager as unknown as {
+          checkHealthEndpointOnPortForDevice(port: number, deviceId: string): Promise<boolean>;
+        },
+        "checkHealthEndpointOnPortForDevice",
+      ).mockResolvedValue(true);
+      const start = spyOn(
+        manager as unknown as { startAfterForceRestart(options: CtrlProxyStartOptions): Promise<void> },
+        "startAfterForceRestart",
+      ).mockResolvedValue();
+
+      await expect(manager.forceRestart()).rejects.toThrow(
+        "iOS CtrlProxy is still running after forced teardown",
+      );
+      expect(start).not.toHaveBeenCalled();
+    });
+
+    test("propagates forced teardown failures to a concurrent start", async function() {
+      const manager = IOSCtrlProxyManager.getInstance(testDevice);
+      const stopped = deferred();
+      spyOn(manager, "stop").mockImplementation(async () => await stopped.promise);
+      spyOn(
+        manager as unknown as {
+          checkHealthEndpointOnPortForDevice(port: number, deviceId: string): Promise<boolean>;
+        },
+        "checkHealthEndpointOnPortForDevice",
+      ).mockResolvedValue(true);
+      const start = spyOn(
+        manager as unknown as { startAfterForceRestart(options: CtrlProxyStartOptions): Promise<void> },
+        "startAfterForceRestart",
+      ).mockResolvedValue();
+
+      const forcedRestart = manager.forceRestart();
+      await Promise.resolve();
+      const concurrentStart = manager.start();
+      const forcedFailure = forcedRestart.catch(error => error);
+      const concurrentFailure = concurrentStart.catch(error => error);
+      stopped.resolve();
+
+      const [forcedError, concurrentError] = await Promise.all([forcedFailure, concurrentFailure]);
+      expect(forcedError).toBeInstanceOf(Error);
+      expect(concurrentError).toBeInstanceOf(Error);
+      expect((forcedError as Error).message).toContain("iOS CtrlProxy is still running after forced teardown");
+      expect((concurrentError as Error).message).toContain("iOS CtrlProxy is still running after forced teardown");
+      expect(start).not.toHaveBeenCalled();
     });
   });
 

--- a/test/utils/RunnerReadinessService.test.ts
+++ b/test/utils/RunnerReadinessService.test.ts
@@ -102,12 +102,15 @@ class FakeAndroidManager implements ReadinessAndroidManager {
 
 class FakeIosManager implements ReadinessIosManager {
   installed = true;
+  servicePort = 8765;
   setupResult = { success: true, message: "ready" };
   setupCalls = 0;
   startCalls = 0;
+  forceRestartCalls = 0;
   setupSignal: AbortSignal | undefined;
   setupMinimumHealthPollDurationMs: number | undefined;
   startOptions: { signal?: AbortSignal; minimumHealthPollDurationMs?: number } | undefined;
+  forceRestartOptions: { signal?: AbortSignal; minimumHealthPollDurationMs?: number } | undefined;
 
   async isInstalled(): Promise<boolean> {
     return this.installed;
@@ -116,6 +119,7 @@ class FakeIosManager implements ReadinessIosManager {
   /** Optional hook to simulate elapsed provisioning time (e.g. a cold launch). */
   onStart?: () => Promise<void>;
   onSetup?: () => Promise<void>;
+  onForceRestart?: (options?: { signal?: AbortSignal; minimumHealthPollDurationMs?: number }) => Promise<void>;
 
   async start(options?: { signal?: AbortSignal; minimumHealthPollDurationMs?: number }): Promise<void> {
     this.startCalls++;
@@ -124,6 +128,14 @@ class FakeIosManager implements ReadinessIosManager {
       await this.onStart();
     }
   }
+
+  async forceRestart(options?: { signal?: AbortSignal; minimumHealthPollDurationMs?: number }): Promise<void> {
+    this.forceRestartCalls++;
+    this.forceRestartOptions = options;
+    await this.onForceRestart?.(options);
+  }
+
+  resetSetupState(): void {}
 
   async setup(
     _force?: boolean,
@@ -141,7 +153,7 @@ class FakeIosManager implements ReadinessIosManager {
   }
 
   getServicePort(): number {
-    return 8765;
+    return this.servicePort;
   }
 }
 
@@ -152,6 +164,7 @@ function createService(
     androidClient?: FakeReadinessClient;
     iosManager?: FakeIosManager;
     iosClient?: FakeReadinessClient;
+    getIosClient?: (device: BootedDevice, port: number) => FakeReadinessClient;
     autoAdvance?: boolean;
     awaitIosStartupMaintenance?: () => Promise<void>;
   } = {},
@@ -175,7 +188,7 @@ function createService(
       getAndroidManager: () => androidManager,
       getAndroidClient: () => androidClient,
       getIosManager: () => iosManager,
-      getIosClient: () => iosClient,
+      getIosClient: options.getIosClient ?? (() => iosClient),
       checkIosOverride: async () => ({ present: false, usable: true }),
       awaitIosStartupMaintenance: options.awaitIosStartupMaintenance ?? (async () => {}),
     }),
@@ -607,6 +620,82 @@ describe("RunnerReadinessService", () => {
 
     expect(iosManager.setupMinimumHealthPollDurationMs).toBe(110_000);
     expect(iosManager.setupSignal).toBeDefined();
+  });
+
+  test("force-restarts an iOS runner whose port is reachable but hierarchy health fails", async () => {
+    const iosManager = new FakeIosManager();
+    const iosClient = new FakeReadinessClient();
+    iosClient.healthResults = [false, true];
+    const { service } = createService({ iosManager, iosClient });
+
+    await service.ensureReady({
+      device: iosDevice,
+      requestedIdentity: "platform=ios deviceId=IOS-UDID",
+      totalDeadlineMs: 30_000,
+      readinessTimeoutMs: 30_000,
+    });
+
+    expect(iosManager.forceRestartCalls).toBe(1);
+    expect(iosManager.setupCalls).toBe(0);
+    expect(iosClient.healthCalls).toBe(2);
+  });
+
+  test("uses the post-restart iOS service port for readiness", async () => {
+    const iosManager = new FakeIosManager();
+    const staleClient = new FakeReadinessClient();
+    const restartedClient = new FakeReadinessClient();
+    staleClient.healthResults = [false, true];
+    restartedClient.healthResults = [true];
+    iosManager.onForceRestart = async () => {
+      iosManager.servicePort = 9_876;
+    };
+    const requestedPorts: number[] = [];
+    const { service } = createService({
+      iosManager,
+      iosClient: staleClient,
+      getIosClient: (_device, port) => {
+        requestedPorts.push(port);
+        return port === 9_876 ? restartedClient : staleClient;
+      },
+    });
+
+    await service.ensureReady({
+      device: iosDevice,
+      requestedIdentity: "platform=ios deviceId=IOS-UDID",
+      totalDeadlineMs: 30_000,
+      readinessTimeoutMs: 30_000,
+    });
+
+    expect(requestedPorts).toEqual([8_765, 9_876]);
+    expect(staleClient.healthCalls).toBe(1);
+    expect(restartedClient.healthCalls).toBe(1);
+  });
+
+  test("cancels the iOS force-restart when its readiness budget expires", async () => {
+    const timer = new FakeTimer();
+    const iosManager = new FakeIosManager();
+    const iosClient = new FakeReadinessClient();
+    iosClient.healthResults = [false];
+    iosManager.onForceRestart = async (options) => await new Promise<void>((_resolve, reject) => {
+      options?.signal?.addEventListener("abort", () => reject(options.signal?.reason), { once: true });
+    });
+    const { service } = createService({ timer, iosManager, iosClient, autoAdvance: false });
+
+    const ready = service.ensureReady({
+      device: iosDevice,
+      requestedIdentity: "platform=ios deviceId=IOS-UDID",
+      totalDeadlineMs: 1_000,
+      readinessTimeoutMs: 1_000,
+    });
+    for (let attempt = 0; attempt < 20 && iosManager.forceRestartCalls === 0; attempt++) {
+      await new Promise<void>(resolve => setImmediate(resolve));
+    }
+
+    expect(iosManager.forceRestartCalls).toBe(1);
+    expect(iosManager.forceRestartOptions?.signal).toBeDefined();
+    timer.advanceTime(1_000);
+    await expect(ready).rejects.toThrow(/phase=runner-setup/);
+    expect(iosManager.forceRestartOptions?.signal?.aborted).toBe(true);
   });
 
   test("starts only the cached iOS runner when downloads are disabled", async () => {


### PR DESCRIPTION
## Summary

When an iOS CtrlProxy endpoint is reachable but cannot return a hierarchy, readiness now resets state and force-restarts the runner before retrying the health probe. The restart carries the caller's abort signal and remaining startup budget, so it cannot outlive a timed-out readiness request. This prevents port health from trapping the daemon behind a wedged observation stream.

## Linked Issue

Closes [#5532](https://github.com/kaeawc/auto-mobile/issues/5532)

## Bug / Regression Context

- **Prior attempts:** None.
- **Observed symptom:** iOS `observe` readiness repeatedly timed out while port 8788 remained healthy; only an external process kill recovered it.
- **Repro steps / conditions:** Intermittent connected-but-unresponsive runner state, where hierarchy health fails despite a reachable endpoint.

## Validation

- [x] `bun test test/utils/RunnerReadinessService.test.ts test/utils/IOSCtrlProxyManager.test.ts`
- [x] `bun run turbo:validate`
- [x] `bun run typecheck`
- [x] New code uses an existing manager interface plus a fake and `FakeTimer`; focused tests complete in under 100ms.
- [x] No new dependency or generic helper.
- [x] Based on current `origin/main` (`5f3f28b66`).

## Device Verification

Not run: the original failure is intermittent and did not reproduce on a direct simulator attempt. The readiness-level regression is covered deterministically.
