### PR TITLE
fix: restore Android observer after failed shutdown

### DIFF
--- a/src/features/observe/android/AndroidCtrlProxyClient.ts
+++ b/src/features/observe/android/AndroidCtrlProxyClient.ts
@@ -1185,6 +1185,18 @@ export class AndroidCtrlProxyClient extends DeviceServiceClient implements Andro
   }
 
   /**
+   * Evict this client before its asynchronous close can complete. Its port is
+   * held so a replacement client cannot share an ADB forward with late cleanup.
+   */
+  public invalidateForShutdownRecovery(): void {
+    if (AndroidCtrlProxyClient.getExistingInstance(this.device.deviceId) === this) {
+      AndroidCtrlProxyClient.removeInstance(this.device.deviceId);
+    }
+    PortManager.releaseIfAllocated(this.device.deviceId, this.localPort);
+    PortManager.holdForCleanup(this.localPort);
+  }
+
+  /**
    * Bind this client to a session for multi-agent NavigationGraphManager isolation.
    * Called when a tool execution context binds a session to this device.
    */
@@ -2990,7 +3002,8 @@ export class AndroidCtrlProxyClient extends DeviceServiceClient implements Andro
         this.portForwardingSetup = false;
       }
 
-      PortManager.release(this.device.deviceId);
+      PortManager.releaseIfAllocated(this.device.deviceId, this.localPort);
+      PortManager.releaseCleanupHold(this.localPort);
     } catch (error) {
       logger.warn(`[CTRL_PROXY] Error during cleanup: ${error}`);
     }

--- a/src/features/observe/android/AndroidCtrlProxyClient.ts
+++ b/src/features/observe/android/AndroidCtrlProxyClient.ts
@@ -1217,11 +1217,10 @@ export class AndroidCtrlProxyClient extends DeviceServiceClient implements Andro
   }
 
   /**
-   * Test-only accessor for the currently bound session (or null when unbound).
-   * Lets isolation tests pin the routing invariant that `bindSession` is
-   * last-writer-wins and that an unbound client has no session.
+   * Returns the session currently receiving this device's navigation events,
+   * or null when the client is unbound.
    */
-  public getBoundSessionIdForTesting(): string | null {
+  public getBoundSessionId(): string | null {
     return this.boundSessionId;
   }
 

--- a/src/features/observe/android/AndroidCtrlProxyClient.ts
+++ b/src/features/observe/android/AndroidCtrlProxyClient.ts
@@ -1225,6 +1225,15 @@ export class AndroidCtrlProxyClient extends DeviceServiceClient implements Andro
   }
 
   /**
+   * Returns the booted-device identity that constructed this client. Callers
+   * use this after teardown to distinguish the original emulator incarnation
+   * from a same-ID replacement.
+   */
+  public getBootedDeviceIdentity(): BootedDevice {
+    return { ...this.device };
+  }
+
+  /**
    * Release this client's binding to a session that has ended (#4984). If still
    * bound to `sessionId`, drop the binding and dispose the cached hierarchy detector
    * so a post-release event (before any new session binds the still-connected

--- a/src/features/observe/android/AndroidCtrlProxyClient.ts
+++ b/src/features/observe/android/AndroidCtrlProxyClient.ts
@@ -1022,6 +1022,8 @@ export class AndroidCtrlProxyClient extends DeviceServiceClient implements Andro
 
   // Android-specific state
   private portForwardingSetup: boolean = false;
+  private inFlightEnsureConnected: Promise<boolean> | null = null;
+  private cleanupHeldPort: number | null = null;
   private lastWebSocketTimeout: number = 0;
   // Terminal-close latch (#5493): set once by close() so the best-effort ADB
   // screencap fallback in captureScreenshotViaAdb() cannot outlive the client.
@@ -1194,6 +1196,7 @@ export class AndroidCtrlProxyClient extends DeviceServiceClient implements Andro
     }
     PortManager.releaseIfAllocated(this.device.deviceId, this.localPort);
     PortManager.holdForCleanup(this.localPort);
+    this.cleanupHeldPort = this.localPort;
   }
 
   /**
@@ -1608,11 +1611,22 @@ export class AndroidCtrlProxyClient extends DeviceServiceClient implements Andro
   public override async ensureConnected(
     perf: PerformanceTracker = new NoOpPerformanceTracker(),
   ): Promise<boolean> {
-    const connected = await super.ensureConnected(perf);
-    if (connected) {
-      this.syncAccessibilityFlagsToDevice();
+    const connection = super.ensureConnected(perf);
+    this.inFlightEnsureConnected = connection;
+    try {
+      const connected = await connection;
+      if (connected) {
+        this.syncAccessibilityFlagsToDevice();
+      }
+      return connected;
+    } finally {
+      if (this.inFlightEnsureConnected === connection) {
+        this.inFlightEnsureConnected = null;
+      }
+      if (this.closed) {
+        await this.finishInvalidatedConnectionCleanup();
+      }
     }
-    return connected;
   }
 
   protected onConnectionEstablished(): void {
@@ -3003,7 +3017,7 @@ export class AndroidCtrlProxyClient extends DeviceServiceClient implements Andro
       }
 
       PortManager.releaseIfAllocated(this.device.deviceId, this.localPort);
-      PortManager.releaseCleanupHold(this.localPort);
+      await this.finishInvalidatedConnectionCleanup();
     } catch (error) {
       logger.warn(`[CTRL_PROXY] Error during cleanup: ${error}`);
     }
@@ -3036,6 +3050,9 @@ export class AndroidCtrlProxyClient extends DeviceServiceClient implements Andro
   private async setupPortForwarding(
     perf: PerformanceTracker = new NoOpPerformanceTracker(),
   ): Promise<void> {
+    if (this.closed) {
+      return;
+    }
     // Verify port forwarding is still active even if we think it's set up
     // Port forwarding can be lost if ADB server restarts or emulator restarts
     if (this.portForwardingSetup) {
@@ -3053,6 +3070,9 @@ export class AndroidCtrlProxyClient extends DeviceServiceClient implements Andro
       await perf.track("clearPortForward", () =>
         this.adb.executeCommand(`forward --remove tcp:${this.localPort}`).catch(() => {}),
       );
+      if (this.closed) {
+        return;
+      }
 
       this.ensureLocalPortAvailableForForwarding();
       logger.debug(
@@ -3069,12 +3089,27 @@ export class AndroidCtrlProxyClient extends DeviceServiceClient implements Andro
         this.adb.executeCommand(`forward tcp:${this.localPort} tcp:${PortManager.DEVICE_PORT}`),
       );
 
+      if (this.closed) {
+        await this.adb.executeCommand(`forward --remove tcp:${this.localPort}`).catch(() => {});
+        return;
+      }
+
       this.portForwardingSetup = true;
       logger.debug(`[CTRL_PROXY] Port forwarding setup complete (localhost:${this.localPort})`);
     } catch (error) {
       logger.warn(`[CTRL_PROXY] Failed to setup port forwarding: ${error}`);
       throw error;
     }
+  }
+
+  private async finishInvalidatedConnectionCleanup(): Promise<void> {
+    if (this.inFlightEnsureConnected !== null || this.cleanupHeldPort === null) {
+      return;
+    }
+    const heldPort = this.cleanupHeldPort;
+    this.cleanupHeldPort = null;
+    PortManager.releaseIfAllocated(this.device.deviceId, this.localPort);
+    PortManager.releaseCleanupHold(heldPort);
   }
 
   /**

--- a/src/features/observe/android/AndroidCtrlProxyClient.ts
+++ b/src/features/observe/android/AndroidCtrlProxyClient.ts
@@ -1022,7 +1022,7 @@ export class AndroidCtrlProxyClient extends DeviceServiceClient implements Andro
 
   // Android-specific state
   private portForwardingSetup: boolean = false;
-  private inFlightEnsureConnected: Promise<boolean> | null = null;
+  private inFlightConnection: Promise<boolean> | null = null;
   private cleanupHeldPort: number | null = null;
   private lastWebSocketTimeout: number = 0;
   // Terminal-close latch (#5493): set once by close() so the best-effort ADB
@@ -1611,17 +1611,23 @@ export class AndroidCtrlProxyClient extends DeviceServiceClient implements Andro
   public override async ensureConnected(
     perf: PerformanceTracker = new NoOpPerformanceTracker(),
   ): Promise<boolean> {
-    const connection = super.ensureConnected(perf);
-    this.inFlightEnsureConnected = connection;
+    const connected = await super.ensureConnected(perf);
+    if (connected) {
+      this.syncAccessibilityFlagsToDevice();
+    }
+    return connected;
+  }
+
+  protected override async connectWebSocket(
+    perf: PerformanceTracker = new NoOpPerformanceTracker(),
+  ): Promise<boolean> {
+    const connection = super.connectWebSocket(perf);
+    this.inFlightConnection = connection;
     try {
-      const connected = await connection;
-      if (connected) {
-        this.syncAccessibilityFlagsToDevice();
-      }
-      return connected;
+      return await connection;
     } finally {
-      if (this.inFlightEnsureConnected === connection) {
-        this.inFlightEnsureConnected = null;
+      if (this.inFlightConnection === connection) {
+        this.inFlightConnection = null;
       }
       if (this.closed) {
         await this.finishInvalidatedConnectionCleanup();
@@ -3103,7 +3109,7 @@ export class AndroidCtrlProxyClient extends DeviceServiceClient implements Andro
   }
 
   private async finishInvalidatedConnectionCleanup(): Promise<void> {
-    if (this.inFlightEnsureConnected !== null || this.cleanupHeldPort === null) {
+    if (this.inFlightConnection !== null || this.cleanupHeldPort === null) {
       return;
     }
     const heldPort = this.cleanupHeldPort;

--- a/src/server/deviceTools.ts
+++ b/src/server/deviceTools.ts
@@ -860,6 +860,20 @@ function shouldRestoreAndroidObserverAfterCommandFailure(
   );
 }
 
+function hasLiveAndroidObserverSessionBinding(
+  device: BootedDevice,
+  boundSessionId: string | null,
+): boundSessionId is string {
+  if (boundSessionId === null) {
+    return false;
+  }
+  const daemonState = DaemonState.getInstance();
+  return (
+    daemonState.isInitialized() &&
+    daemonState.getSessionManager().getSessionForDevice(device.deviceId) === boundSessionId
+  );
+}
+
 async function restoreAndroidObserverAfterCommandFailure(
   deviceManager: PlatformDeviceManager,
   device: BootedDevice,
@@ -897,18 +911,26 @@ async function restoreAndroidObserverAfterCommandFailure(
       isSameBootedDeviceIdentity(device, survivingDevice)
     ) {
       const observer = AndroidCtrlProxyClient.getInstance(survivingDevice);
-      if (observerState.boundSessionId !== null) {
+      if (hasLiveAndroidObserverSessionBinding(device, observerState.boundSessionId)) {
         observer.bindSession(observerState.boundSessionId);
       }
-      const connected = await runWithinShutdownDeadline(
-        device,
-        timer,
-        shutdownDeadlineMs,
-        "Android observer reconnect did not complete",
-        requestAbortSignal,
-        async () => await observer.ensureConnected(),
-        timeoutMs,
-      );
+      const reconnect = async (): Promise<boolean> =>
+        await runWithinShutdownDeadline(
+          device,
+          timer,
+          shutdownDeadlineMs,
+          "Android observer reconnect did not complete",
+          requestAbortSignal,
+          async () => await observer.ensureConnected(),
+          timeoutMs,
+        );
+      let connected = await reconnect();
+      if (!connected) {
+        // A failed port-forward setup has no WebSocket close event to trigger
+        // the normal automatic reconnect. Retry once while the shutdown budget
+        // is still live so existing passive subscribers regain their cadence.
+        connected = await reconnect();
+      }
       if (!connected) {
         logger.warn(
           `[DeviceTools] Failed to reconnect Android observer after kill failure for ${device.deviceId}`,

--- a/src/server/deviceTools.ts
+++ b/src/server/deviceTools.ts
@@ -889,6 +889,22 @@ function hasLiveAndroidObserverSessionBinding(
   );
 }
 
+function bindLiveAndroidObserverSession(
+  observer: AndroidCtrlProxyClient,
+  device: BootedDevice,
+  observerState: AndroidObserverShutdownState,
+): void {
+  if (
+    hasLiveAndroidObserverSessionBinding(
+      device,
+      observerState.boundSessionId,
+      observerState.deviceIdentity,
+    )
+  ) {
+    observer.bindSession(observerState.boundSessionId);
+  }
+}
+
 function invalidateAndroidObserver(observer: AndroidCtrlProxyClient, deviceId: string): void {
   // Removal is deliberately synchronous and precedes cleanup. `close()` can
   // wait on an ADB forward removal that does not honour the shutdown deadline;
@@ -1010,6 +1026,10 @@ async function restoreAndroidObserverAfterCommandFailure(
       isSameBootedDeviceIdentity(observerState.deviceIdentity, survivingDevice)
     ) {
       const observer = AndroidCtrlProxyClient.getInstance(survivingDevice);
+      // Bind before connecting so a frame arriving immediately after the socket
+      // opens is attributed to the surviving session. A post-connect identity
+      // mismatch still invalidates this client before it is retained.
+      bindLiveAndroidObserverSession(observer, device, observerState);
       const connected = await reconnectAndroidObserverWithinShutdownDeadline(
         observer,
         device,
@@ -1037,15 +1057,6 @@ async function restoreAndroidObserverAfterCommandFailure(
       if (!sameIncarnation) {
         invalidateAndroidObserver(observer, device.deviceId);
         return;
-      }
-      if (
-        hasLiveAndroidObserverSessionBinding(
-          device,
-          observerState.boundSessionId,
-          observerState.deviceIdentity,
-        )
-      ) {
-        observer.bindSession(observerState.boundSessionId);
       }
     }
   } catch (restoreError) {

--- a/src/server/deviceTools.ts
+++ b/src/server/deviceTools.ts
@@ -662,6 +662,11 @@ interface ShutdownDeadlineContext {
   retainReservationUntil?: (operation: Promise<unknown>, releaseAfterFailure?: boolean) => void;
 }
 
+interface AndroidObserverShutdownState {
+  hadActiveObserver: boolean;
+  boundSessionId: string | null;
+}
+
 function shouldPropagateShutdownPreparationError(
   error: unknown,
   requestAbortSignal: AbortSignal | undefined,
@@ -773,12 +778,15 @@ async function stopAndroidCtrlProxyBeforeShutdown(
   context: ShutdownDeadlineContext,
   perf: ReturnType<typeof createPerformanceTracker>,
   stopAndroidObservers: (device: BootedDevice) => Promise<void>,
-): Promise<boolean> {
+): Promise<AndroidObserverShutdownState> {
   if (context.device.platform !== "android") {
-    return false;
+    return { hadActiveObserver: false, boundSessionId: null };
   }
-  const hadActiveObserver =
-    AndroidCtrlProxyClient.getExistingInstance(context.device.deviceId) !== null;
+  const activeObserver = AndroidCtrlProxyClient.getExistingInstance(context.device.deviceId);
+  const observerState: AndroidObserverShutdownState = {
+    hadActiveObserver: activeObserver !== null,
+    boundSessionId: activeObserver?.getBoundSessionId() ?? null,
+  };
   let stop: Promise<void> | undefined;
   perf.startOperation("stopAndroidCtrlProxy");
   try {
@@ -805,7 +813,7 @@ async function stopAndroidCtrlProxyBeforeShutdown(
   } finally {
     perf.endOperation("stopAndroidCtrlProxy");
   }
-  return hadActiveObserver;
+  return observerState;
 }
 
 function shutdownTimeoutError(
@@ -855,7 +863,7 @@ function shouldRestoreAndroidObserverAfterCommandFailure(
 async function restoreAndroidObserverAfterCommandFailure(
   deviceManager: PlatformDeviceManager,
   device: BootedDevice,
-  hadActiveObserver: boolean,
+  observerState: AndroidObserverShutdownState,
   error: unknown,
   timer: Timer,
   shutdownDeadlineMs: number,
@@ -863,7 +871,7 @@ async function restoreAndroidObserverAfterCommandFailure(
   timeoutMs: number,
 ): Promise<void> {
   if (
-    !hadActiveObserver ||
+    !observerState.hadActiveObserver ||
     !shouldRestoreAndroidObserverAfterCommandFailure(device, error, requestAbortSignal)
   ) {
     return;
@@ -889,7 +897,19 @@ async function restoreAndroidObserverAfterCommandFailure(
       isSameBootedDeviceIdentity(device, survivingDevice)
     ) {
       const observer = AndroidCtrlProxyClient.getInstance(survivingDevice);
-      if (!await observer.ensureConnected()) {
+      if (observerState.boundSessionId !== null) {
+        observer.bindSession(observerState.boundSessionId);
+      }
+      const connected = await runWithinShutdownDeadline(
+        device,
+        timer,
+        shutdownDeadlineMs,
+        "Android observer reconnect did not complete",
+        requestAbortSignal,
+        async () => await observer.ensureConnected(),
+        timeoutMs,
+      );
+      if (!connected) {
         logger.warn(
           `[DeviceTools] Failed to reconnect Android observer after kill failure for ${device.deviceId}`,
         );
@@ -1501,7 +1521,7 @@ async function killProcessAndRetireOwnership(
   requestAbortSignal: AbortSignal | undefined,
   devicePool: DevicePool | undefined,
   expectedPooledDevice: PooledDevice | null,
-  hadActiveAndroidObserver: boolean,
+  androidObserverState: AndroidObserverShutdownState,
   shutdownDeadlineMs: number,
   retainReservationUntil: (
     retirement: Promise<void>,
@@ -1541,7 +1561,7 @@ async function killProcessAndRetireOwnership(
     await restoreAndroidObserverAfterCommandFailure(
       deviceManager,
       device,
-      hadActiveAndroidObserver,
+      androidObserverState,
       error,
       dependencies.timer,
       shutdownDeadlineMs,
@@ -1674,7 +1694,7 @@ async function shutdownDevice(
       };
       await stopVideoRecordingsBeforeShutdown(shutdownContext, perf);
       await stopIosCtrlProxyBeforeShutdown(shutdownContext, perf);
-      const hadActiveAndroidObserver = await stopAndroidCtrlProxyBeforeShutdown(
+      const androidObserverState = await stopAndroidCtrlProxyBeforeShutdown(
         shutdownContext,
         perf,
         dependencies.stopAndroidObservers,
@@ -1687,7 +1707,7 @@ async function shutdownDevice(
         requestAbortSignal,
         devicePool,
         expectedPooledDevice,
-        hadActiveAndroidObserver,
+        androidObserverState,
         shutdownDeadlineMs,
         (retirement, releaseReservationAfterFailure) => {
           retainShutdownUntil(retirement, releaseReservationAfterFailure);

--- a/src/server/deviceTools.ts
+++ b/src/server/deviceTools.ts
@@ -837,6 +837,57 @@ function shouldKeepIntentionalShutdownAfterCommandError(
   return requestAbortSignal?.aborted === true || isShutdownTimeoutError(error);
 }
 
+function shouldRestoreAndroidObserverAfterCommandFailure(
+  device: BootedDevice,
+  error: unknown,
+  requestAbortSignal: AbortSignal | undefined,
+): boolean {
+  return (
+    device.platform === "android" &&
+    !isAlreadyStoppedDeviceError(device.platform, device.deviceId, error) &&
+    !shouldKeepIntentionalShutdownAfterCommandError(error, requestAbortSignal)
+  );
+}
+
+async function restoreAndroidObserverAfterCommandFailure(
+  deviceManager: PlatformDeviceManager,
+  device: BootedDevice,
+  error: unknown,
+  timer: Timer,
+  shutdownDeadlineMs: number,
+  requestAbortSignal: AbortSignal | undefined,
+  timeoutMs: number,
+): Promise<void> {
+  if (!shouldRestoreAndroidObserverAfterCommandFailure(device, error, requestAbortSignal)) {
+    return;
+  }
+  try {
+    // The pre-kill teardown evicts the observer to release its transport hold.
+    // Recreate it only after a fresh, uncached discovery proves this exact
+    // incarnation survived the failed command; a disappeared device or a
+    // same-ID reboot must stay detached.
+    const discovery = await getShutdownDiscovery(
+      deviceManager,
+      device,
+      timer,
+      shutdownDeadlineMs,
+      requestAbortSignal,
+      timeoutMs,
+    );
+    const survivingDevice = findDiscoveredDevice(discovery, device);
+    if (survivingDevice && isSameBootedDeviceIdentity(device, survivingDevice)) {
+      AndroidCtrlProxyClient.getInstance(survivingDevice);
+    }
+  } catch (restoreError) {
+    // Preserve the original shutdown command failure. A later explicit tool
+    // call can still recreate the observer if this confirmation was unavailable.
+    logger.warn(
+      `[DeviceTools] Failed to restore Android observer after kill failure for ${device.deviceId}: ${restoreError}`,
+      restoreError,
+    );
+  }
+}
+
 function handleShutdownCommandError(
   device: BootedDevice,
   error: unknown,
@@ -1469,6 +1520,15 @@ async function killProcessAndRetireOwnership(
     shutdownDevice = killedDevice ?? device;
   } catch (error) {
     retainLatePlatformShutdown(platformShutdown, platformShutdownSettled, retainReservationUntil);
+    await restoreAndroidObserverAfterCommandFailure(
+      deviceManager,
+      device,
+      error,
+      dependencies.timer,
+      shutdownDeadlineMs,
+      requestAbortSignal,
+      timeoutMs,
+    );
     alreadyStoppedMessage = handleShutdownCommandError(
       device,
       error,

--- a/src/server/deviceTools.ts
+++ b/src/server/deviceTools.ts
@@ -665,6 +665,7 @@ interface ShutdownDeadlineContext {
 interface AndroidObserverShutdownState {
   hadActiveObserver: boolean;
   boundSessionId: string | null;
+  deviceIdentity: BootedDevice | null;
 }
 
 function shouldPropagateShutdownPreparationError(
@@ -780,12 +781,19 @@ async function stopAndroidCtrlProxyBeforeShutdown(
   stopAndroidObservers: (device: BootedDevice) => Promise<void>,
 ): Promise<AndroidObserverShutdownState> {
   if (context.device.platform !== "android") {
-    return { hadActiveObserver: false, boundSessionId: null };
+    return { hadActiveObserver: false, boundSessionId: null, deviceIdentity: null };
   }
   const activeObserver = AndroidCtrlProxyClient.getExistingInstance(context.device.deviceId);
+  const activeDeviceIdentity = activeObserver?.getBootedDeviceIdentity();
   const observerState: AndroidObserverShutdownState = {
     hadActiveObserver: activeObserver !== null,
     boundSessionId: activeObserver?.getBoundSessionId() ?? null,
+    deviceIdentity: activeDeviceIdentity
+      ? {
+          ...activeDeviceIdentity,
+          transportId: activeDeviceIdentity.transportId ?? context.device.transportId,
+        }
+      : null,
   };
   let stop: Promise<void> | undefined;
   perf.startOperation("stopAndroidCtrlProxy");
@@ -906,9 +914,9 @@ async function restoreAndroidObserverAfterCommandFailure(
     const survivingDevice = findDiscoveredDevice(discovery, device);
     if (
       survivingDevice &&
-      device.transportId !== undefined &&
+      observerState.deviceIdentity?.transportId !== undefined &&
       survivingDevice.transportId !== undefined &&
-      isSameBootedDeviceIdentity(device, survivingDevice)
+      isSameBootedDeviceIdentity(observerState.deviceIdentity, survivingDevice)
     ) {
       const observer = AndroidCtrlProxyClient.getInstance(survivingDevice);
       if (hasLiveAndroidObserverSessionBinding(device, observerState.boundSessionId)) {

--- a/src/server/deviceTools.ts
+++ b/src/server/deviceTools.ts
@@ -773,10 +773,12 @@ async function stopAndroidCtrlProxyBeforeShutdown(
   context: ShutdownDeadlineContext,
   perf: ReturnType<typeof createPerformanceTracker>,
   stopAndroidObservers: (device: BootedDevice) => Promise<void>,
-): Promise<void> {
+): Promise<boolean> {
   if (context.device.platform !== "android") {
-    return;
+    return false;
   }
+  const hadActiveObserver =
+    AndroidCtrlProxyClient.getExistingInstance(context.device.deviceId) !== null;
   let stop: Promise<void> | undefined;
   perf.startOperation("stopAndroidCtrlProxy");
   try {
@@ -803,6 +805,7 @@ async function stopAndroidCtrlProxyBeforeShutdown(
   } finally {
     perf.endOperation("stopAndroidCtrlProxy");
   }
+  return hadActiveObserver;
 }
 
 function shutdownTimeoutError(
@@ -852,13 +855,17 @@ function shouldRestoreAndroidObserverAfterCommandFailure(
 async function restoreAndroidObserverAfterCommandFailure(
   deviceManager: PlatformDeviceManager,
   device: BootedDevice,
+  hadActiveObserver: boolean,
   error: unknown,
   timer: Timer,
   shutdownDeadlineMs: number,
   requestAbortSignal: AbortSignal | undefined,
   timeoutMs: number,
 ): Promise<void> {
-  if (!shouldRestoreAndroidObserverAfterCommandFailure(device, error, requestAbortSignal)) {
+  if (
+    !hadActiveObserver ||
+    !shouldRestoreAndroidObserverAfterCommandFailure(device, error, requestAbortSignal)
+  ) {
     return;
   }
   try {
@@ -875,8 +882,18 @@ async function restoreAndroidObserverAfterCommandFailure(
       timeoutMs,
     );
     const survivingDevice = findDiscoveredDevice(discovery, device);
-    if (survivingDevice && isSameBootedDeviceIdentity(device, survivingDevice)) {
-      AndroidCtrlProxyClient.getInstance(survivingDevice);
+    if (
+      survivingDevice &&
+      device.transportId !== undefined &&
+      survivingDevice.transportId !== undefined &&
+      isSameBootedDeviceIdentity(device, survivingDevice)
+    ) {
+      const observer = AndroidCtrlProxyClient.getInstance(survivingDevice);
+      if (!await observer.ensureConnected()) {
+        logger.warn(
+          `[DeviceTools] Failed to reconnect Android observer after kill failure for ${device.deviceId}`,
+        );
+      }
     }
   } catch (restoreError) {
     // Preserve the original shutdown command failure. A later explicit tool
@@ -1484,6 +1501,7 @@ async function killProcessAndRetireOwnership(
   requestAbortSignal: AbortSignal | undefined,
   devicePool: DevicePool | undefined,
   expectedPooledDevice: PooledDevice | null,
+  hadActiveAndroidObserver: boolean,
   shutdownDeadlineMs: number,
   retainReservationUntil: (
     retirement: Promise<void>,
@@ -1523,6 +1541,7 @@ async function killProcessAndRetireOwnership(
     await restoreAndroidObserverAfterCommandFailure(
       deviceManager,
       device,
+      hadActiveAndroidObserver,
       error,
       dependencies.timer,
       shutdownDeadlineMs,
@@ -1655,7 +1674,7 @@ async function shutdownDevice(
       };
       await stopVideoRecordingsBeforeShutdown(shutdownContext, perf);
       await stopIosCtrlProxyBeforeShutdown(shutdownContext, perf);
-      await stopAndroidCtrlProxyBeforeShutdown(
+      const hadActiveAndroidObserver = await stopAndroidCtrlProxyBeforeShutdown(
         shutdownContext,
         perf,
         dependencies.stopAndroidObservers,
@@ -1668,6 +1687,7 @@ async function shutdownDevice(
         requestAbortSignal,
         devicePool,
         expectedPooledDevice,
+        hadActiveAndroidObserver,
         shutdownDeadlineMs,
         (retirement, releaseReservationAfterFailure) => {
           retainShutdownUntil(retirement, releaseReservationAfterFailure);

--- a/src/server/deviceTools.ts
+++ b/src/server/deviceTools.ts
@@ -895,7 +895,7 @@ async function restoreAndroidObserverAfterCommandFailure(
     // Recreate it only after a fresh, uncached discovery proves this exact
     // incarnation survived the failed command; a disappeared device or a
     // same-ID reboot must stay detached.
-    const discovery = await getShutdownDiscovery(
+    const discovery = await getCompleteShutdownDiscovery(
       deviceManager,
       device,
       timer,
@@ -914,16 +914,30 @@ async function restoreAndroidObserverAfterCommandFailure(
       if (hasLiveAndroidObserverSessionBinding(device, observerState.boundSessionId)) {
         observer.bindSession(observerState.boundSessionId);
       }
-      const reconnect = async (): Promise<boolean> =>
-        await runWithinShutdownDeadline(
-          device,
-          timer,
-          shutdownDeadlineMs,
-          "Android observer reconnect did not complete",
-          requestAbortSignal,
-          async () => await observer.ensureConnected(),
-          timeoutMs,
-        );
+      const reconnect = async (): Promise<boolean> => {
+        try {
+          return await runWithinShutdownDeadline(
+            device,
+            timer,
+            shutdownDeadlineMs,
+            "Android observer reconnect did not complete",
+            requestAbortSignal,
+            async () => await observer.ensureConnected(),
+            timeoutMs,
+          );
+        } catch (error) {
+          if (isShutdownTimeoutError(error) || requestAbortSignal?.aborted) {
+            // Platform setup does not accept an AbortSignal. Invalidate the
+            // in-flight client so a late port-forward cannot register a stale
+            // observer or leave future callers waiting on its connection.
+            await observer.close();
+            if (AndroidCtrlProxyClient.getExistingInstance(device.deviceId) === observer) {
+              AndroidCtrlProxyClient.removeInstance(device.deviceId);
+            }
+          }
+          throw error;
+        }
+      };
       let connected = await reconnect();
       if (!connected) {
         // A failed port-forward setup has no WebSocket close event to trigger
@@ -1100,6 +1114,34 @@ async function getShutdownDiscovery(
       }),
     timeoutMs,
   );
+}
+
+async function getCompleteShutdownDiscovery(
+  deviceManager: PlatformDeviceManager,
+  device: BootedDevice,
+  timer: Timer,
+  deadlineMs: number,
+  requestAbortSignal: AbortSignal | undefined,
+  timeoutMs = DEVICE_SHUTDOWN_TIMEOUT_MS,
+) {
+  for (;;) {
+    const discovery = await getShutdownDiscovery(
+      deviceManager,
+      device,
+      timer,
+      deadlineMs,
+      requestAbortSignal,
+      timeoutMs,
+    );
+    if (discovery.succeededPlatforms.has(device.platform)) {
+      return discovery;
+    }
+    const remainingMs = deadlineMs - timer.now();
+    if (remainingMs <= 0) {
+      throw shutdownTimeoutError(device, "platform discovery did not complete", timeoutMs);
+    }
+    await timer.sleep(Math.min(DEVICE_SHUTDOWN_POLL_INTERVAL_MS, remainingMs));
+  }
 }
 
 async function waitForDeviceShutdown(

--- a/src/server/deviceTools.ts
+++ b/src/server/deviceTools.ts
@@ -882,6 +882,92 @@ function hasLiveAndroidObserverSessionBinding(
   );
 }
 
+function invalidateAndroidObserver(observer: AndroidCtrlProxyClient, deviceId: string): void {
+  // Removal is deliberately synchronous and precedes cleanup. `close()` can
+  // wait on an ADB forward removal that does not honour the shutdown deadline;
+  // retaining the singleton until that completes would keep an obsolete client
+  // (and the failed-shutdown reservation) alive indefinitely.
+  if (AndroidCtrlProxyClient.getExistingInstance(deviceId) === observer) {
+    AndroidCtrlProxyClient.removeInstance(deviceId);
+  }
+  void observer.close().catch(error => {
+    logger.warn(`[DeviceTools] Failed to clean up invalidated Android observer for ${deviceId}: ${error}`);
+  });
+}
+
+async function reconnectAndroidObserverWithinShutdownDeadline(
+  observer: AndroidCtrlProxyClient,
+  device: BootedDevice,
+  timer: Timer,
+  shutdownDeadlineMs: number,
+  requestAbortSignal: AbortSignal | undefined,
+  timeoutMs: number,
+): Promise<boolean> {
+  const reconnect = async (): Promise<boolean> => {
+    try {
+      return await runWithinShutdownDeadline(
+        device,
+        timer,
+        shutdownDeadlineMs,
+        "Android observer reconnect did not complete",
+        requestAbortSignal,
+        async () => await observer.ensureConnected(),
+        timeoutMs,
+      );
+    } catch (error) {
+      if (isShutdownTimeoutError(error) || requestAbortSignal?.aborted) {
+        // Platform setup does not accept an AbortSignal. Invalidate the
+        // in-flight client so a late port-forward cannot register a stale
+        // observer or leave future callers waiting on its connection.
+        invalidateAndroidObserver(observer, device.deviceId);
+      }
+      throw error;
+    }
+  };
+  const connected = await reconnect();
+  // A failed port-forward setup has no WebSocket close event to trigger the
+  // normal automatic reconnect. Retry once while the shutdown budget is still
+  // live so existing passive subscribers regain their cadence.
+  return connected || (await reconnect());
+}
+
+async function revalidateReconnectedAndroidObserver(
+  deviceManager: PlatformDeviceManager,
+  device: BootedDevice,
+  observer: AndroidCtrlProxyClient,
+  observerState: AndroidObserverShutdownState,
+  timer: Timer,
+  shutdownDeadlineMs: number,
+  requestAbortSignal: AbortSignal | undefined,
+  timeoutMs: number,
+): Promise<boolean> {
+  try {
+    // Recheck after the awaited reconnect: ADB addresses a reusable serial,
+    // so the original pre-connect check is no longer sufficient if an emulator
+    // rebooted while its port-forward or WebSocket was starting.
+    const discovery = await getCompleteShutdownDiscovery(
+      deviceManager,
+      device,
+      timer,
+      shutdownDeadlineMs,
+      requestAbortSignal,
+      timeoutMs,
+    );
+    const reconnectedDevice = findDiscoveredDevice(discovery, device);
+    return (
+      reconnectedDevice !== undefined &&
+      observerState.deviceIdentity?.transportId !== undefined &&
+      reconnectedDevice.transportId !== undefined &&
+      isSameBootedDeviceIdentity(observerState.deviceIdentity, reconnectedDevice)
+    );
+  } catch (error) {
+    // A connected observer cannot be safely retained when its incarnation
+    // could not be reconfirmed within the same failed-shutdown budget.
+    invalidateAndroidObserver(observer, device.deviceId);
+    throw error;
+  }
+}
+
 async function restoreAndroidObserverAfterCommandFailure(
   deviceManager: PlatformDeviceManager,
   device: BootedDevice,
@@ -919,44 +1005,36 @@ async function restoreAndroidObserverAfterCommandFailure(
       isSameBootedDeviceIdentity(observerState.deviceIdentity, survivingDevice)
     ) {
       const observer = AndroidCtrlProxyClient.getInstance(survivingDevice);
-      if (hasLiveAndroidObserverSessionBinding(device, observerState.boundSessionId)) {
-        observer.bindSession(observerState.boundSessionId);
-      }
-      const reconnect = async (): Promise<boolean> => {
-        try {
-          return await runWithinShutdownDeadline(
-            device,
-            timer,
-            shutdownDeadlineMs,
-            "Android observer reconnect did not complete",
-            requestAbortSignal,
-            async () => await observer.ensureConnected(),
-            timeoutMs,
-          );
-        } catch (error) {
-          if (isShutdownTimeoutError(error) || requestAbortSignal?.aborted) {
-            // Platform setup does not accept an AbortSignal. Invalidate the
-            // in-flight client so a late port-forward cannot register a stale
-            // observer or leave future callers waiting on its connection.
-            await observer.close();
-            if (AndroidCtrlProxyClient.getExistingInstance(device.deviceId) === observer) {
-              AndroidCtrlProxyClient.removeInstance(device.deviceId);
-            }
-          }
-          throw error;
-        }
-      };
-      let connected = await reconnect();
-      if (!connected) {
-        // A failed port-forward setup has no WebSocket close event to trigger
-        // the normal automatic reconnect. Retry once while the shutdown budget
-        // is still live so existing passive subscribers regain their cadence.
-        connected = await reconnect();
-      }
+      const connected = await reconnectAndroidObserverWithinShutdownDeadline(
+        observer,
+        device,
+        timer,
+        shutdownDeadlineMs,
+        requestAbortSignal,
+        timeoutMs,
+      );
       if (!connected) {
         logger.warn(
           `[DeviceTools] Failed to reconnect Android observer after kill failure for ${device.deviceId}`,
         );
+        return;
+      }
+      const sameIncarnation = await revalidateReconnectedAndroidObserver(
+        deviceManager,
+        device,
+        observer,
+        observerState,
+        timer,
+        shutdownDeadlineMs,
+        requestAbortSignal,
+        timeoutMs,
+      );
+      if (!sameIncarnation) {
+        invalidateAndroidObserver(observer, device.deviceId);
+        return;
+      }
+      if (hasLiveAndroidObserverSessionBinding(device, observerState.boundSessionId)) {
+        observer.bindSession(observerState.boundSessionId);
       }
     }
   } catch (restoreError) {

--- a/src/server/deviceTools.ts
+++ b/src/server/deviceTools.ts
@@ -887,9 +887,7 @@ function invalidateAndroidObserver(observer: AndroidCtrlProxyClient, deviceId: s
   // wait on an ADB forward removal that does not honour the shutdown deadline;
   // retaining the singleton until that completes would keep an obsolete client
   // (and the failed-shutdown reservation) alive indefinitely.
-  if (AndroidCtrlProxyClient.getExistingInstance(deviceId) === observer) {
-    AndroidCtrlProxyClient.removeInstance(deviceId);
-  }
+  observer.invalidateForShutdownRecovery();
   void observer.close().catch(error => {
     logger.warn(`[DeviceTools] Failed to clean up invalidated Android observer for ${deviceId}: ${error}`);
   });
@@ -1051,12 +1049,12 @@ function handleShutdownCommandError(
   device: BootedDevice,
   error: unknown,
   devicePool: DevicePool | undefined,
-  requestAbortSignal: AbortSignal | undefined,
+  keepIntentionalShutdown: boolean,
 ): string | undefined {
   if (isAlreadyStoppedDeviceError(device.platform, device.deviceId, error)) {
     return `Failed to kill ${device.platform} device: ${error}`;
   }
-  if (!shouldKeepIntentionalShutdownAfterCommandError(error, requestAbortSignal)) {
+  if (!keepIntentionalShutdown) {
     devicePool?.clearIntentionalShutdown(device.deviceId);
   }
   throw error;
@@ -1707,6 +1705,10 @@ async function killProcessAndRetireOwnership(
     );
     shutdownDevice = killedDevice ?? device;
   } catch (error) {
+    const keepIntentionalShutdown = shouldKeepIntentionalShutdownAfterCommandError(
+      error,
+      requestAbortSignal,
+    );
     retainLatePlatformShutdown(platformShutdown, platformShutdownSettled, retainReservationUntil);
     await restoreAndroidObserverAfterCommandFailure(
       deviceManager,
@@ -1722,7 +1724,7 @@ async function killProcessAndRetireOwnership(
       device,
       error,
       devicePool,
-      requestAbortSignal,
+      keepIntentionalShutdown,
     );
   }
   perf.endOperation("killProcess");

--- a/src/server/deviceTools.ts
+++ b/src/server/deviceTools.ts
@@ -62,6 +62,7 @@ import { getToolSelectionContext } from "../features/toolSelection/toolSelection
 import { executionTracker } from "./executionTracker";
 import {
   registerDirectSessionDevice,
+  resolveDirectSessionDevice,
   unregisterDirectSessionsForDevice,
   unregisterDirectSessionsForStableIdentity,
 } from "./directSessionDeviceRegistry";
@@ -871,14 +872,20 @@ function shouldRestoreAndroidObserverAfterCommandFailure(
 function hasLiveAndroidObserverSessionBinding(
   device: BootedDevice,
   boundSessionId: string | null,
+  deviceIdentity: BootedDevice | null,
 ): boundSessionId is string {
   if (boundSessionId === null) {
     return false;
   }
   const daemonState = DaemonState.getInstance();
+  if (daemonState.isInitialized()) {
+    return daemonState.getSessionManager().getSessionForDevice(device.deviceId) === boundSessionId;
+  }
+  const directSession = resolveDirectSessionDevice(boundSessionId);
   return (
-    daemonState.isInitialized() &&
-    daemonState.getSessionManager().getSessionForDevice(device.deviceId) === boundSessionId
+    directSession !== undefined &&
+    deviceIdentity !== null &&
+    isSameBootedDeviceIdentity(deviceIdentity, directSession.device)
   );
 }
 
@@ -1031,7 +1038,13 @@ async function restoreAndroidObserverAfterCommandFailure(
         invalidateAndroidObserver(observer, device.deviceId);
         return;
       }
-      if (hasLiveAndroidObserverSessionBinding(device, observerState.boundSessionId)) {
+      if (
+        hasLiveAndroidObserverSessionBinding(
+          device,
+          observerState.boundSessionId,
+          observerState.deviceIdentity,
+        )
+      ) {
         observer.bindSession(observerState.boundSessionId);
       }
     }

--- a/src/utils/PortManager.ts
+++ b/src/utils/PortManager.ts
@@ -76,6 +76,7 @@ class BunPortAvailabilityChecker implements PortAvailabilityChecker {
  */
 export class PortManager {
   private static allocatedPorts: Map<string, number> = new Map();
+  private static cleanupHeldPorts: Set<number> = new Set();
   private static readonly DEFAULT_BASE_PORT = 8765;
   private static readonly DEFAULT_MAX_DEVICES = 100;
   private static readonly basePort = PortManager.resolveBasePort();
@@ -103,7 +104,7 @@ export class PortManager {
     }
 
     // Find next available port
-    const usedPorts = new Set(this.allocatedPorts.values());
+    const usedPorts = new Set([...this.allocatedPorts.values(), ...this.cleanupHeldPorts]);
     const reservedPorts = new Set(options.reservedPorts ?? []);
     const availabilityChecker = options.availabilityChecker ?? this.portAvailabilityChecker;
     for (let port = this.basePort; port <= 65535; port++) {
@@ -140,6 +141,27 @@ export class PortManager {
     if (port !== undefined) {
       this.allocatedPorts.delete(deviceId);
       logger.info(`[PortManager] Released port ${port} for device ${deviceId}`);
+    }
+  }
+
+  /**
+   * Keep a just-invalidated observer's port unavailable until its asynchronous
+   * cleanup has finished. A replacement observer must use a different port so
+   * late cleanup cannot tear down its ADB forward.
+   */
+  public static holdForCleanup(port: number): void {
+    this.cleanupHeldPorts.add(port);
+  }
+
+  /** Release a port held by a completed invalidated-observer cleanup. */
+  public static releaseCleanupHold(port: number): void {
+    this.cleanupHeldPorts.delete(port);
+  }
+
+  /** Release only when this caller still owns the device's allocated port. */
+  public static releaseIfAllocated(deviceId: string, port: number): void {
+    if (this.allocatedPorts.get(deviceId) === port) {
+      this.release(deviceId);
     }
   }
 
@@ -202,6 +224,7 @@ export class PortManager {
   public static reset(): void {
     const count = this.allocatedPorts.size;
     this.allocatedPorts.clear();
+    this.cleanupHeldPorts.clear();
     logger.info(`[PortManager] Reset all port allocations (cleared ${count} allocations)`);
   }
 

--- a/test/features/observe/CtrlProxyClient.test.ts
+++ b/test/features/observe/CtrlProxyClient.test.ts
@@ -888,6 +888,30 @@ describe("AndroidCtrlProxyClient", function() {
     }
   });
 
+  test("late invalidated-observer cleanup cannot release a replacement observer's port", async function() {
+    await accessibilityServiceClient.close();
+    AndroidCtrlProxyClient.resetInstances();
+    PortManager.reset();
+    PortManager.setPortAvailabilityCheckerForTesting({ isPortAvailable: () => true });
+    try {
+      const original = AndroidCtrlProxyClient.getInstance(testDevice, fakeAdbFactory);
+      const originalPort = PortManager.getPort(testDevice.deviceId);
+      original.invalidateForShutdownRecovery();
+
+      const replacement = AndroidCtrlProxyClient.getInstance(testDevice, fakeAdbFactory);
+      const replacementPort = PortManager.getPort(testDevice.deviceId);
+      expect(replacementPort).not.toBe(originalPort);
+
+      await original.close();
+      expect(PortManager.getPort(testDevice.deviceId)).toBe(replacementPort);
+
+      await replacement.close();
+    } finally {
+      PortManager.setPortAvailabilityCheckerForTesting(null);
+      PortManager.reset();
+    }
+  });
+
   describe("connection lifecycle", function() {
     test("notifies the observation stream when the WebSocket connection closes", function() {
       const lostDeviceIds: string[] = [];

--- a/test/features/observe/CtrlProxyClient.test.ts
+++ b/test/features/observe/CtrlProxyClient.test.ts
@@ -1490,20 +1490,20 @@ describe("AndroidCtrlProxyClient", function() {
 
       try {
         testClient.bindSession("session-A");
-        expect(testClient.getBoundSessionIdForTesting()).toBe("session-A");
+        expect(testClient.getBoundSessionId()).toBe("session-A");
         const detectorBoundToA = testClient.getHierarchyNavigationDetector();
 
         testClient.releaseSessionBinding("session-A");
 
         // Binding cleared and the cached detector dropped (recreated on next access),
         // so post-release events route to the unattributed global manager, not A's.
-        expect(testClient.getBoundSessionIdForTesting()).toBeNull();
+        expect(testClient.getBoundSessionId()).toBeNull();
         expect(testClient.getHierarchyNavigationDetector()).not.toBe(detectorBoundToA);
 
         // A non-matching release is a no-op once a new session has bound.
         testClient.bindSession("session-B");
         testClient.releaseSessionBinding("session-A");
-        expect(testClient.getBoundSessionIdForTesting()).toBe("session-B");
+        expect(testClient.getBoundSessionId()).toBe("session-B");
       } finally {
         await testClient.close();
         await navHarness.dispose();
@@ -3607,23 +3607,23 @@ describe("AndroidCtrlProxyClient", function() {
     // one session's navigation state into another's.
     test("is unbound (null) until a session is bound", function() {
       // The per-test client from beforeEach is created without a session bound.
-      expect(accessibilityServiceClient.getBoundSessionIdForTesting()).toBeNull();
+      expect(accessibilityServiceClient.getBoundSessionId()).toBeNull();
     });
 
     test("is last-writer-wins: the most recently bound session is the active one", function() {
       accessibilityServiceClient.bindSession("session-A");
-      expect(accessibilityServiceClient.getBoundSessionIdForTesting()).toBe("session-A");
+      expect(accessibilityServiceClient.getBoundSessionId()).toBe("session-A");
 
       // Rebinding (e.g. the device is reassigned to a new session) switches the
       // active session; the previous binding does not linger.
       accessibilityServiceClient.bindSession("session-B");
-      expect(accessibilityServiceClient.getBoundSessionIdForTesting()).toBe("session-B");
+      expect(accessibilityServiceClient.getBoundSessionId()).toBe("session-B");
     });
 
     test("re-binding the same session is idempotent", function() {
       accessibilityServiceClient.bindSession("session-A");
       accessibilityServiceClient.bindSession("session-A");
-      expect(accessibilityServiceClient.getBoundSessionIdForTesting()).toBe("session-A");
+      expect(accessibilityServiceClient.getBoundSessionId()).toBe("session-A");
     });
   });
 

--- a/test/features/observe/CtrlProxyClient.test.ts
+++ b/test/features/observe/CtrlProxyClient.test.ts
@@ -888,7 +888,9 @@ describe("AndroidCtrlProxyClient", function() {
     }
   });
 
-  test("late invalidated-observer cleanup cannot release a replacement observer's port", async function() {
+  // Windows Bun evaluates the Android barrel and direct import as separate module
+  // records, so their singleton registries cannot exercise this lifecycle.
+  test.skipIf(process.platform === "win32")("late invalidated-observer cleanup cannot release a replacement observer's port", async function() {
     await accessibilityServiceClient.close();
     AndroidCtrlProxyClient.resetInstances();
     PortManager.reset();

--- a/test/server/deviceTools.killDevice.test.ts
+++ b/test/server/deviceTools.killDevice.test.ts
@@ -2649,6 +2649,7 @@ describe("killDevice handler", () => {
     // An active observation-stream subscriber has already caused this singleton
     // to exist. Its cadence callback later resolves only an existing instance.
     const activeObserver = AndroidCtrlProxyClient.getInstance(device, new FakeAdbClientFactory());
+    activeObserver.bindSession("session-5503");
     const closeSpy = spyOn(activeObserver, "close").mockResolvedValue(undefined);
     const originalGetInstance = AndroidCtrlProxyClient.getInstance;
     let restoredObserver: AndroidCtrlProxyClient | undefined;
@@ -2672,6 +2673,53 @@ describe("killDevice handler", () => {
       const registeredObserver = AndroidCtrlProxyClient.getExistingInstance(device.deviceId);
       expect(registeredObserver).toBe(restoredObserver);
       expect(registeredObserver).not.toBe(activeObserver);
+      expect(registeredObserver?.getBoundSessionId()).toBe("session-5503");
+    } finally {
+      ensureConnectedSpy?.mockRestore();
+      getInstanceSpy.mockRestore();
+      closeSpy.mockRestore();
+    }
+  });
+
+  test.skipIf(process.platform === "win32")("keeps the original kill failure bounded when observer reconnection stalls", async () => {
+    const timer = new FakeTimer();
+    const device: BootedDevice = {
+      name: "Pixel 8",
+      platform: "android",
+      deviceId: "emulator-5554",
+      transportId: "1",
+    };
+    manager.setBootedDevices("android", [device]);
+    setDeviceToolsDependencies({
+      deviceManagerFactory: () => manager,
+      notifyResourcesChanged: async () => {},
+      ensureCtrlProxyReady: async () => {},
+      clearInstalledAppsForDevice: async () => {},
+      timer,
+    });
+    const activeObserver = AndroidCtrlProxyClient.getInstance(device, new FakeAdbClientFactory());
+    const closeSpy = spyOn(activeObserver, "close").mockResolvedValue(undefined);
+    const originalGetInstance = AndroidCtrlProxyClient.getInstance;
+    let ensureConnectedSpy: ReturnType<typeof spyOn> | undefined;
+    const getInstanceSpy = spyOn(AndroidCtrlProxyClient, "getInstance").mockImplementation(target => {
+      const restoredObserver = originalGetInstance(target, new FakeAdbClientFactory());
+      ensureConnectedSpy = spyOn(restoredObserver, "ensureConnected").mockImplementation(
+        async () => await new Promise<boolean>(() => {}),
+      );
+      return restoredObserver;
+    });
+    try {
+      const tool = ToolRegistry.getTool("killDevice");
+      if (!tool) {
+        throw new Error("killDevice not registered");
+      }
+
+      const result = tool.handler({ device });
+      await new Promise(resolve => setImmediate(resolve));
+      timer.advanceTime(30_000);
+
+      await expect(result).rejects.toThrow("adb emu kill failed");
+      expect(ensureConnectedSpy).toHaveBeenCalledTimes(1);
     } finally {
       ensureConnectedSpy?.mockRestore();
       getInstanceSpy.mockRestore();

--- a/test/server/deviceTools.killDevice.test.ts
+++ b/test/server/deviceTools.killDevice.test.ts
@@ -1078,6 +1078,7 @@ describe("killDevice handler", () => {
       name: "Pixel 8",
       platform: "android",
       deviceId: "emulator-5554",
+      transportId: "1",
     };
     delayedManager.setBootedDevices("android", [device]);
     const tool = ToolRegistry.getTool("killDevice");
@@ -2635,6 +2636,7 @@ describe("killDevice handler", () => {
       name: "Pixel 8",
       platform: "android",
       deviceId: "emulator-5554",
+      transportId: "1",
     };
     manager.setBootedDevices("android", [device]);
     setDeviceToolsDependencies({
@@ -2649,9 +2651,13 @@ describe("killDevice handler", () => {
     const activeObserver = AndroidCtrlProxyClient.getInstance(device, new FakeAdbClientFactory());
     const closeSpy = spyOn(activeObserver, "close").mockResolvedValue(undefined);
     const originalGetInstance = AndroidCtrlProxyClient.getInstance;
-    const getInstanceSpy = spyOn(AndroidCtrlProxyClient, "getInstance").mockImplementation(target =>
-      originalGetInstance(target, new FakeAdbClientFactory()),
-    );
+    let restoredObserver: AndroidCtrlProxyClient | undefined;
+    let ensureConnectedSpy: ReturnType<typeof spyOn> | undefined;
+    const getInstanceSpy = spyOn(AndroidCtrlProxyClient, "getInstance").mockImplementation(target => {
+      restoredObserver = originalGetInstance(target, new FakeAdbClientFactory());
+      ensureConnectedSpy = spyOn(restoredObserver, "ensureConnected").mockResolvedValue(true);
+      return restoredObserver;
+    });
     try {
       const tool = ToolRegistry.getTool("killDevice");
       if (!tool) {
@@ -2662,15 +2668,12 @@ describe("killDevice handler", () => {
 
       expect(closeSpy).toHaveBeenCalledTimes(1);
       expect(getInstanceSpy).toHaveBeenCalledWith(device);
-      const restoredObserver = AndroidCtrlProxyClient.getExistingInstance(device.deviceId);
-      expect(restoredObserver).not.toBeNull();
-      expect(restoredObserver).not.toBe(activeObserver);
-
-      const cadenceSpy = spyOn(restoredObserver!, "refreshObservationStreamScreenshotCadence");
-      AndroidCtrlProxyClient.getExistingInstance(device.deviceId)?.refreshObservationStreamScreenshotCadence();
-      expect(cadenceSpy).toHaveBeenCalledTimes(1);
-      cadenceSpy.mockRestore();
+      expect(ensureConnectedSpy).toHaveBeenCalledTimes(1);
+      const registeredObserver = AndroidCtrlProxyClient.getExistingInstance(device.deviceId);
+      expect(registeredObserver).toBe(restoredObserver);
+      expect(registeredObserver).not.toBe(activeObserver);
     } finally {
+      ensureConnectedSpy?.mockRestore();
       getInstanceSpy.mockRestore();
       closeSpy.mockRestore();
     }
@@ -2703,6 +2706,77 @@ describe("killDevice handler", () => {
       expect(closeSpy).toHaveBeenCalledTimes(1);
       expect(AndroidCtrlProxyClient.getExistingInstance(device.deviceId)).toBeNull();
     } finally {
+      closeSpy.mockRestore();
+    }
+  });
+
+  test.skipIf(process.platform === "win32")("does not create an Android observer when no active observer was detached", async () => {
+    const timer = new FakeTimer();
+    const device: BootedDevice = {
+      name: "Pixel 8",
+      platform: "android",
+      deviceId: "emulator-5554",
+      transportId: "1",
+    };
+    manager.setBootedDevices("android", [device]);
+    setDeviceToolsDependencies({
+      deviceManagerFactory: () => manager,
+      notifyResourcesChanged: async () => {},
+      ensureCtrlProxyReady: async () => {},
+      clearInstalledAppsForDevice: async () => {},
+      timer,
+    });
+    const getInstanceSpy = spyOn(AndroidCtrlProxyClient, "getInstance");
+    try {
+      const tool = ToolRegistry.getTool("killDevice");
+      if (!tool) {
+        throw new Error("killDevice not registered");
+      }
+
+      await expect(tool.handler({ device })).rejects.toThrow("adb emu kill failed");
+
+      expect(getInstanceSpy).not.toHaveBeenCalled();
+      expect(AndroidCtrlProxyClient.getExistingInstance(device.deviceId)).toBeNull();
+    } finally {
+      getInstanceSpy.mockRestore();
+    }
+  });
+
+  test.skipIf(process.platform === "win32")("does not restore an observer onto a same-ID Android replacement when the original transport is unknown", async () => {
+    const timer = new FakeTimer();
+    const device: BootedDevice = {
+      name: "Pixel 8",
+      platform: "android",
+      deviceId: "emulator-5554",
+    };
+    const replacement: BootedDevice = {
+      ...device,
+      transportId: "2",
+    };
+    manager.setBootedDevices("android", [replacement]);
+    setDeviceToolsDependencies({
+      deviceManagerFactory: () => manager,
+      notifyResourcesChanged: async () => {},
+      ensureCtrlProxyReady: async () => {},
+      clearInstalledAppsForDevice: async () => {},
+      timer,
+    });
+    const observer = AndroidCtrlProxyClient.getInstance(device, new FakeAdbClientFactory());
+    const closeSpy = spyOn(observer, "close").mockResolvedValue(undefined);
+    const getInstanceSpy = spyOn(AndroidCtrlProxyClient, "getInstance");
+    try {
+      const tool = ToolRegistry.getTool("killDevice");
+      if (!tool) {
+        throw new Error("killDevice not registered");
+      }
+
+      await expect(tool.handler({ device })).rejects.toThrow("adb emu kill failed");
+
+      expect(closeSpy).toHaveBeenCalledTimes(1);
+      expect(getInstanceSpy).not.toHaveBeenCalled();
+      expect(AndroidCtrlProxyClient.getExistingInstance(device.deviceId)).toBeNull();
+    } finally {
+      getInstanceSpy.mockRestore();
       closeSpy.mockRestore();
     }
   });

--- a/test/server/deviceTools.killDevice.test.ts
+++ b/test/server/deviceTools.killDevice.test.ts
@@ -2688,7 +2688,10 @@ describe("killDevice handler", () => {
     });
     // An active observation-stream subscriber has already caused this singleton
     // to exist. Its cadence callback later resolves only an existing instance.
-    const activeObserver = AndroidCtrlProxyClient.getInstance(device, new FakeAdbClientFactory());
+    const activeObserver = AndroidCtrlProxyClient.getInstance(
+      { ...device, transportId: undefined },
+      new FakeAdbClientFactory(),
+    );
     activeObserver.bindSession("session-5503");
     const closeSpy = spyOn(activeObserver, "close").mockResolvedValue(undefined);
     const originalGetInstance = AndroidCtrlProxyClient.getInstance;
@@ -2919,6 +2922,54 @@ describe("killDevice handler", () => {
       expect(AndroidCtrlProxyClient.getExistingInstance(device.deviceId)).toBeNull();
     } finally {
       getInstanceSpy.mockRestore();
+    }
+  });
+
+  test.skipIf(process.platform === "win32")("restores an observer when the kill request omits its known transport", async () => {
+    const timer = new FakeTimer();
+    const requestedDevice: BootedDevice = {
+      name: "Pixel 8",
+      platform: "android",
+      deviceId: "emulator-5554",
+    };
+    const observedDevice: BootedDevice = {
+      ...requestedDevice,
+      transportId: "1",
+    };
+    manager.setBootedDevices("android", [observedDevice]);
+    setDeviceToolsDependencies({
+      deviceManagerFactory: () => manager,
+      notifyResourcesChanged: async () => {},
+      ensureCtrlProxyReady: async () => {},
+      clearInstalledAppsForDevice: async () => {},
+      timer,
+    });
+    const activeObserver = AndroidCtrlProxyClient.getInstance(
+      observedDevice,
+      new FakeAdbClientFactory(),
+    );
+    const closeSpy = spyOn(activeObserver, "close").mockResolvedValue(undefined);
+    const originalGetInstance = AndroidCtrlProxyClient.getInstance;
+    let ensureConnectedSpy: ReturnType<typeof spyOn> | undefined;
+    const getInstanceSpy = spyOn(AndroidCtrlProxyClient, "getInstance").mockImplementation(target => {
+      const restoredObserver = originalGetInstance(target, new FakeAdbClientFactory());
+      ensureConnectedSpy = spyOn(restoredObserver, "ensureConnected").mockResolvedValue(true);
+      return restoredObserver;
+    });
+    try {
+      const tool = ToolRegistry.getTool("killDevice");
+      if (!tool) {
+        throw new Error("killDevice not registered");
+      }
+
+      await expect(tool.handler({ device: requestedDevice })).rejects.toThrow("adb emu kill failed");
+
+      expect(getInstanceSpy).toHaveBeenCalledWith(observedDevice);
+      expect(ensureConnectedSpy).toHaveBeenCalledTimes(1);
+    } finally {
+      ensureConnectedSpy?.mockRestore();
+      getInstanceSpy.mockRestore();
+      closeSpy.mockRestore();
     }
   });
 

--- a/test/server/deviceTools.killDevice.test.ts
+++ b/test/server/deviceTools.killDevice.test.ts
@@ -2639,6 +2639,27 @@ describe("killDevice handler", () => {
       transportId: "1",
     };
     manager.setBootedDevices("android", [device]);
+    const deviceSessionRepository = new FakeDeviceSessionRepository();
+    sessionManager = new SessionManager(timer, deviceSessionRepository);
+    const image: DeviceInfo = {
+      name: device.name,
+      platform: device.platform,
+      deviceId: device.deviceId,
+      isRunning: false,
+      source: "local",
+    };
+    manager.setDeviceImages("android", [image]);
+    const pool = new DevicePool(
+      sessionManager,
+      "daemon-session",
+      timer,
+      new FakeInstalledAppsRepository(),
+      manager,
+      new DefaultRetryExecutor(timer),
+      deviceSessionRepository,
+    );
+    DaemonState.getInstance().initialize(sessionManager, pool);
+    await pool.assignMultipleDevices(["session-5503"], 1_000, "android");
     setDeviceToolsDependencies({
       deviceManagerFactory: () => manager,
       notifyResourcesChanged: async () => {},
@@ -2656,7 +2677,9 @@ describe("killDevice handler", () => {
     let ensureConnectedSpy: ReturnType<typeof spyOn> | undefined;
     const getInstanceSpy = spyOn(AndroidCtrlProxyClient, "getInstance").mockImplementation(target => {
       restoredObserver = originalGetInstance(target, new FakeAdbClientFactory());
-      ensureConnectedSpy = spyOn(restoredObserver, "ensureConnected").mockResolvedValue(true);
+      ensureConnectedSpy = spyOn(restoredObserver, "ensureConnected")
+        .mockResolvedValueOnce(false)
+        .mockResolvedValue(true);
       return restoredObserver;
     });
     try {
@@ -2669,7 +2692,7 @@ describe("killDevice handler", () => {
 
       expect(closeSpy).toHaveBeenCalledTimes(1);
       expect(getInstanceSpy).toHaveBeenCalledWith(device);
-      expect(ensureConnectedSpy).toHaveBeenCalledTimes(1);
+      expect(ensureConnectedSpy).toHaveBeenCalledTimes(2);
       const registeredObserver = AndroidCtrlProxyClient.getExistingInstance(device.deviceId);
       expect(registeredObserver).toBe(restoredObserver);
       expect(registeredObserver).not.toBe(activeObserver);
@@ -2720,6 +2743,50 @@ describe("killDevice handler", () => {
 
       await expect(result).rejects.toThrow("adb emu kill failed");
       expect(ensureConnectedSpy).toHaveBeenCalledTimes(1);
+    } finally {
+      ensureConnectedSpy?.mockRestore();
+      getInstanceSpy.mockRestore();
+      closeSpy.mockRestore();
+    }
+  });
+
+  test.skipIf(process.platform === "win32")("does not rebind an observer to a session released during failed shutdown", async () => {
+    const timer = new FakeTimer();
+    const device: BootedDevice = {
+      name: "Pixel 8",
+      platform: "android",
+      deviceId: "emulator-5554",
+      transportId: "1",
+    };
+    manager.setBootedDevices("android", [device]);
+    setDeviceToolsDependencies({
+      deviceManagerFactory: () => manager,
+      notifyResourcesChanged: async () => {},
+      ensureCtrlProxyReady: async () => {},
+      clearInstalledAppsForDevice: async () => {},
+      timer,
+    });
+    const activeObserver = AndroidCtrlProxyClient.getInstance(device, new FakeAdbClientFactory());
+    activeObserver.bindSession("released-session");
+    const closeSpy = spyOn(activeObserver, "close").mockResolvedValue(undefined);
+    const originalGetInstance = AndroidCtrlProxyClient.getInstance;
+    let restoredObserver: AndroidCtrlProxyClient | undefined;
+    let ensureConnectedSpy: ReturnType<typeof spyOn> | undefined;
+    const getInstanceSpy = spyOn(AndroidCtrlProxyClient, "getInstance").mockImplementation(target => {
+      restoredObserver = originalGetInstance(target, new FakeAdbClientFactory());
+      ensureConnectedSpy = spyOn(restoredObserver, "ensureConnected").mockResolvedValue(true);
+      return restoredObserver;
+    });
+    try {
+      const tool = ToolRegistry.getTool("killDevice");
+      if (!tool) {
+        throw new Error("killDevice not registered");
+      }
+
+      await expect(tool.handler({ device })).rejects.toThrow("adb emu kill failed");
+
+      expect(ensureConnectedSpy).toHaveBeenCalledTimes(1);
+      expect(restoredObserver?.getBoundSessionId()).toBeNull();
     } finally {
       ensureConnectedSpy?.mockRestore();
       getInstanceSpy.mockRestore();

--- a/test/server/deviceTools.killDevice.test.ts
+++ b/test/server/deviceTools.killDevice.test.ts
@@ -212,6 +212,25 @@ class TransientAbsenceThenSameIncarnationDeviceManager extends DelayedSuccessful
   }
 }
 
+class IncompleteThenBootedDiscoveryKillDeviceManager extends FailingKillDeviceManager {
+  private recoveryDiscoveryCalls = 0;
+
+  constructor(private readonly device: BootedDevice) {
+    super();
+  }
+
+  override async getBootedDevicesDetailed(platform: SomePlatform): Promise<BootedDeviceDiscovery> {
+    this.recoveryDiscoveryCalls++;
+    if (this.recoveryDiscoveryCalls === 1) {
+      return { devices: [], succeededPlatforms: new Set() };
+    }
+    return {
+      devices: [this.device],
+      succeededPlatforms: new Set(platform === "either" ? ["android"] : [platform]),
+    };
+  }
+}
+
 class ReplacementDuringCacheClearRepository extends FakeInstalledAppsRepository {
   constructor(private readonly onClearDeviceSession: () => Promise<void>) {
     super();
@@ -2740,6 +2759,52 @@ describe("killDevice handler", () => {
       const result = tool.handler({ device });
       await new Promise(resolve => setImmediate(resolve));
       timer.advanceTime(30_000);
+
+      await expect(result).rejects.toThrow("adb emu kill failed");
+      expect(ensureConnectedSpy).toHaveBeenCalledTimes(1);
+      expect(AndroidCtrlProxyClient.getExistingInstance(device.deviceId)).toBeNull();
+    } finally {
+      ensureConnectedSpy?.mockRestore();
+      getInstanceSpy.mockRestore();
+      closeSpy.mockRestore();
+    }
+  });
+
+  test.skipIf(process.platform === "win32")("retries incomplete Android discovery before restoring an observer", async () => {
+    const timer = new FakeTimer();
+    const device: BootedDevice = {
+      name: "Pixel 8",
+      platform: "android",
+      deviceId: "emulator-5554",
+      transportId: "1",
+    };
+    const incompleteManager = new IncompleteThenBootedDiscoveryKillDeviceManager(device);
+    manager = incompleteManager;
+    setDeviceToolsDependencies({
+      deviceManagerFactory: () => incompleteManager,
+      notifyResourcesChanged: async () => {},
+      ensureCtrlProxyReady: async () => {},
+      clearInstalledAppsForDevice: async () => {},
+      timer,
+    });
+    const activeObserver = AndroidCtrlProxyClient.getInstance(device, new FakeAdbClientFactory());
+    const closeSpy = spyOn(activeObserver, "close").mockResolvedValue(undefined);
+    const originalGetInstance = AndroidCtrlProxyClient.getInstance;
+    let ensureConnectedSpy: ReturnType<typeof spyOn> | undefined;
+    const getInstanceSpy = spyOn(AndroidCtrlProxyClient, "getInstance").mockImplementation(target => {
+      const restoredObserver = originalGetInstance(target, new FakeAdbClientFactory());
+      ensureConnectedSpy = spyOn(restoredObserver, "ensureConnected").mockResolvedValue(true);
+      return restoredObserver;
+    });
+    try {
+      const tool = ToolRegistry.getTool("killDevice");
+      if (!tool) {
+        throw new Error("killDevice not registered");
+      }
+
+      const result = tool.handler({ device });
+      await new Promise(resolve => setImmediate(resolve));
+      timer.advanceTime(1_000);
 
       await expect(result).rejects.toThrow("adb emu kill failed");
       expect(ensureConnectedSpy).toHaveBeenCalledTimes(1);

--- a/test/server/deviceTools.killDevice.test.ts
+++ b/test/server/deviceTools.killDevice.test.ts
@@ -231,6 +231,25 @@ class IncompleteThenBootedDiscoveryKillDeviceManager extends FailingKillDeviceMa
   }
 }
 
+class ReplacementAfterObserverReconnectDeviceManager extends FailingKillDeviceManager {
+  private recoveryDiscoveryCalls = 0;
+
+  constructor(
+    private readonly original: BootedDevice,
+    private readonly replacement: BootedDevice,
+  ) {
+    super();
+  }
+
+  override async getBootedDevicesDetailed(platform: SomePlatform): Promise<BootedDeviceDiscovery> {
+    this.recoveryDiscoveryCalls++;
+    return {
+      devices: [this.recoveryDiscoveryCalls === 1 ? this.original : this.replacement],
+      succeededPlatforms: new Set(platform === "either" ? ["android"] : [platform]),
+    };
+  }
+}
+
 class ReplacementDuringCacheClearRepository extends FakeInstalledAppsRepository {
   constructor(private readonly onClearDeviceSession: () => Promise<void>) {
     super();
@@ -2746,10 +2765,14 @@ describe("killDevice handler", () => {
     const closeSpy = spyOn(activeObserver, "close").mockResolvedValue(undefined);
     const originalGetInstance = AndroidCtrlProxyClient.getInstance;
     let ensureConnectedSpy: ReturnType<typeof spyOn> | undefined;
+    let restoredCloseSpy: ReturnType<typeof spyOn> | undefined;
     const getInstanceSpy = spyOn(AndroidCtrlProxyClient, "getInstance").mockImplementation(target => {
       const restoredObserver = originalGetInstance(target, new FakeAdbClientFactory());
       ensureConnectedSpy = spyOn(restoredObserver, "ensureConnected").mockImplementation(
         async () => await new Promise<boolean>(() => {}),
+      );
+      restoredCloseSpy = spyOn(restoredObserver, "close").mockImplementation(
+        async () => await new Promise<void>(() => {}),
       );
       return restoredObserver;
     });
@@ -2765,8 +2788,62 @@ describe("killDevice handler", () => {
 
       await expect(result).rejects.toThrow("adb emu kill failed");
       expect(ensureConnectedSpy).toHaveBeenCalledTimes(1);
+      expect(restoredCloseSpy).toHaveBeenCalledTimes(1);
       expect(AndroidCtrlProxyClient.getExistingInstance(device.deviceId)).toBeNull();
     } finally {
+      restoredCloseSpy?.mockRestore();
+      ensureConnectedSpy?.mockRestore();
+      getInstanceSpy.mockRestore();
+      closeSpy.mockRestore();
+    }
+  });
+
+  test.skipIf(process.platform === "win32")("evicts an observer when its device is replaced during reconnection", async () => {
+    const timer = new FakeTimer();
+    const device: BootedDevice = {
+      name: "Pixel 8",
+      platform: "android",
+      deviceId: "emulator-5554",
+      transportId: "1",
+    };
+    const replacement: BootedDevice = { ...device, transportId: "2" };
+    const replacementManager = new ReplacementAfterObserverReconnectDeviceManager(
+      device,
+      replacement,
+    );
+    manager = replacementManager;
+    setDeviceToolsDependencies({
+      deviceManagerFactory: () => replacementManager,
+      notifyResourcesChanged: async () => {},
+      ensureCtrlProxyReady: async () => {},
+      clearInstalledAppsForDevice: async () => {},
+      timer,
+    });
+    const activeObserver = AndroidCtrlProxyClient.getInstance(device, new FakeAdbClientFactory());
+    const closeSpy = spyOn(activeObserver, "close").mockResolvedValue(undefined);
+    const originalGetInstance = AndroidCtrlProxyClient.getInstance;
+    let restoredObserver: AndroidCtrlProxyClient | undefined;
+    let ensureConnectedSpy: ReturnType<typeof spyOn> | undefined;
+    let restoredCloseSpy: ReturnType<typeof spyOn> | undefined;
+    const getInstanceSpy = spyOn(AndroidCtrlProxyClient, "getInstance").mockImplementation(target => {
+      restoredObserver = originalGetInstance(target, new FakeAdbClientFactory());
+      ensureConnectedSpy = spyOn(restoredObserver, "ensureConnected").mockResolvedValue(true);
+      restoredCloseSpy = spyOn(restoredObserver, "close").mockResolvedValue(undefined);
+      return restoredObserver;
+    });
+    try {
+      const tool = ToolRegistry.getTool("killDevice");
+      if (!tool) {
+        throw new Error("killDevice not registered");
+      }
+
+      await expect(tool.handler({ device })).rejects.toThrow("adb emu kill failed");
+
+      expect(ensureConnectedSpy).toHaveBeenCalledTimes(1);
+      expect(restoredCloseSpy).toHaveBeenCalledTimes(1);
+      expect(AndroidCtrlProxyClient.getExistingInstance(device.deviceId)).toBeNull();
+    } finally {
+      restoredCloseSpy?.mockRestore();
       ensureConnectedSpy?.mockRestore();
       getInstanceSpy.mockRestore();
       closeSpy.mockRestore();

--- a/test/server/deviceTools.killDevice.test.ts
+++ b/test/server/deviceTools.killDevice.test.ts
@@ -2629,6 +2629,84 @@ describe("killDevice handler", () => {
     expect(JSON.stringify(response)).not.toContain("Timed out waiting for");
   });
 
+  test.skipIf(process.platform === "win32")("restores an active Android observer when an ordinary kill failure leaves its incarnation booted", async () => {
+    const timer = new FakeTimer();
+    const device: BootedDevice = {
+      name: "Pixel 8",
+      platform: "android",
+      deviceId: "emulator-5554",
+    };
+    manager.setBootedDevices("android", [device]);
+    setDeviceToolsDependencies({
+      deviceManagerFactory: () => manager,
+      notifyResourcesChanged: async () => {},
+      ensureCtrlProxyReady: async () => {},
+      clearInstalledAppsForDevice: async () => {},
+      timer,
+    });
+    // An active observation-stream subscriber has already caused this singleton
+    // to exist. Its cadence callback later resolves only an existing instance.
+    const activeObserver = AndroidCtrlProxyClient.getInstance(device, new FakeAdbClientFactory());
+    const closeSpy = spyOn(activeObserver, "close").mockResolvedValue(undefined);
+    const originalGetInstance = AndroidCtrlProxyClient.getInstance;
+    const getInstanceSpy = spyOn(AndroidCtrlProxyClient, "getInstance").mockImplementation(target =>
+      originalGetInstance(target, new FakeAdbClientFactory()),
+    );
+    try {
+      const tool = ToolRegistry.getTool("killDevice");
+      if (!tool) {
+        throw new Error("killDevice not registered");
+      }
+
+      await expect(tool.handler({ device })).rejects.toThrow("adb emu kill failed");
+
+      expect(closeSpy).toHaveBeenCalledTimes(1);
+      expect(getInstanceSpy).toHaveBeenCalledWith(device);
+      const restoredObserver = AndroidCtrlProxyClient.getExistingInstance(device.deviceId);
+      expect(restoredObserver).not.toBeNull();
+      expect(restoredObserver).not.toBe(activeObserver);
+
+      const cadenceSpy = spyOn(restoredObserver!, "refreshObservationStreamScreenshotCadence");
+      AndroidCtrlProxyClient.getExistingInstance(device.deviceId)?.refreshObservationStreamScreenshotCadence();
+      expect(cadenceSpy).toHaveBeenCalledTimes(1);
+      cadenceSpy.mockRestore();
+    } finally {
+      getInstanceSpy.mockRestore();
+      closeSpy.mockRestore();
+    }
+  });
+
+  test.skipIf(process.platform === "win32")("keeps an Android observer detached when a failed kill leaves no booted device", async () => {
+    const timer = new FakeTimer();
+    const device: BootedDevice = {
+      name: "Pixel 8",
+      platform: "android",
+      deviceId: "emulator-5554",
+    };
+    setDeviceToolsDependencies({
+      deviceManagerFactory: () => manager,
+      notifyResourcesChanged: async () => {},
+      ensureCtrlProxyReady: async () => {},
+      clearInstalledAppsForDevice: async () => {},
+      timer,
+    });
+    const observer = AndroidCtrlProxyClient.getInstance(device, new FakeAdbClientFactory());
+    const closeSpy = spyOn(observer, "close").mockResolvedValue(undefined);
+    try {
+      const tool = ToolRegistry.getTool("killDevice");
+      if (!tool) {
+        throw new Error("killDevice not registered");
+      }
+
+      await expect(tool.handler({ device })).rejects.toThrow("adb emu kill failed");
+
+      expect(closeSpy).toHaveBeenCalledTimes(1);
+      expect(AndroidCtrlProxyClient.getExistingInstance(device.deviceId)).toBeNull();
+    } finally {
+      closeSpy.mockRestore();
+    }
+  });
+
   // Skipped on Windows: bun evaluates `AndroidCtrlProxyClient` as more than one
   // module record there (the singleton creators import it via the
   // `features/observe/android` barrel while `deviceTools` teardown imports the


### PR DESCRIPTION
## Summary

- restore the Android CtrlProxy observer after an ordinary `killDevice` command failure only when fresh uncached discovery confirms the same device incarnation is still booted
- preserve teardown for disappeared, replacement, already-stopped, timeout, and aborted shutdown paths
- cover both recovery and detached-device safeguards with fake-device and `FakeTimer` tests

## Root cause

Shutdown detached and evicted the per-device observer before issuing the platform kill command. When that command failed while the emulator stayed alive, nothing recreated the observer, so passive observation streams lost their client.

## Validation

- `bun test test/server/deviceTools.killDevice.test.ts`
- `bun run lint`
- `bun run typecheck`
- `bun run turbo:validate`

Closes #5503
