### PR TITLE
refactor(utils): route AdbClient tracked exec through host seam (#5459)

### DIFF
--- a/src/utils/HostCommandExecutor.ts
+++ b/src/utils/HostCommandExecutor.ts
@@ -20,6 +20,22 @@ export interface HostCommandExecutor {
  */
 export interface HostProcessExecutor extends HostCommandExecutor {
   spawn(file: string, args: string[], options?: SpawnOptions): ChildProcess;
+
+  /**
+   * Starts a short-lived command while exposing its child for callers that own
+   * cancellation and process tracking. The result still flows through the
+   * canonical exec seam.
+   */
+  executeCommandWithChild(
+    file: string,
+    args?: string[],
+    options?: HostCommandOptions
+  ): StartedHostCommand;
+}
+
+export interface StartedHostCommand {
+  child: ChildProcess;
+  result: Promise<ExecResult>;
 }
 
 export type ExecFileAsync = (
@@ -27,6 +43,17 @@ export type ExecFileAsync = (
   args: string[],
   options?: ExecSeamOptions
 ) => Promise<RawExecOutput>;
+
+export type ExecFileWithChild = (
+  file: string,
+  args: string[],
+  options: ExecSeamOptions | undefined,
+  callback: (error: Error | null, stdout: string | Buffer, stderr: string | Buffer) => void
+) => ChildProcess;
+
+/** Shared callback-style `execFile` leaf for callers that need its child handle. */
+export const execFileWithChild: ExecFileWithChild = (file, args, options, callback) =>
+  execFile(file, args, options, callback);
 
 /**
  * Shared `execFile` leaf for the host-command seam. Exported so argv-first
@@ -43,9 +70,14 @@ export const execFileAsync: ExecFileAsync = async (
 
 export class DefaultHostCommandExecutor implements HostProcessExecutor {
   private execAsync: ExecFileAsync;
+  private execWithChild: ExecFileWithChild;
 
-  constructor(execAsyncFn: ExecFileAsync = execFileAsync) {
+  constructor(
+    execAsyncFn: ExecFileAsync = execFileAsync,
+    execWithChildFn: ExecFileWithChild = execFileWithChild
+  ) {
     this.execAsync = execAsyncFn;
+    this.execWithChild = execWithChildFn;
   }
 
   async executeCommand(
@@ -62,5 +94,32 @@ export class DefaultHostCommandExecutor implements HostProcessExecutor {
 
   spawn(file: string, args: string[], options: SpawnOptions = {}): ChildProcess {
     return spawn(file, args, options);
+  }
+
+  executeCommandWithChild(
+    file: string,
+    args: string[] = [],
+    options: HostCommandOptions = {}
+  ): StartedHostCommand {
+    let child: ChildProcess | undefined;
+    const result = runExecSeam(
+      execOptions => new Promise<RawExecOutput>((resolve, reject) => {
+        child = this.execWithChild(file, args, execOptions, (error, stdout, stderr) => {
+          if (error) {
+            Object.assign(error, { stdout, stderr });
+            reject(error);
+            return;
+          }
+          resolve({ stdout, stderr });
+        });
+      }),
+      options,
+      { command: file, args, cwd: options.cwd }
+    );
+
+    if (!child) {
+      throw new Error(`Failed to start command: ${file}`);
+    }
+    return { child, result };
   }
 }

--- a/src/utils/HostCommandExecutor.ts
+++ b/src/utils/HostCommandExecutor.ts
@@ -1,6 +1,7 @@
 import { execFile, spawn, type ChildProcess, type SpawnOptions } from "child_process";
 import { promisify } from "util";
 import type { ExecResult } from "../models";
+import { wrapCommandError } from "./CommandError";
 import { runExecSeam, type ExecRequestOptions, type ExecSeamOptions, type RawExecOutput } from "./ExecSeam";
 
 export type HostCommandOptions = ExecRequestOptions;
@@ -102,23 +103,37 @@ export class DefaultHostCommandExecutor implements HostProcessExecutor {
     options: HostCommandOptions = {}
   ): StartedHostCommand {
     let child: ChildProcess | undefined;
+    let startupError: unknown;
     const result = runExecSeam(
       execOptions => new Promise<RawExecOutput>((resolve, reject) => {
-        child = this.execWithChild(file, args, execOptions, (error, stdout, stderr) => {
-          if (error) {
-            Object.assign(error, { stdout, stderr });
-            reject(error);
-            return;
-          }
-          resolve({ stdout, stderr });
-        });
+        try {
+          child = this.execWithChild(file, args, execOptions, (error, stdout, stderr) => {
+            if (error) {
+              Object.assign(error, { stdout, stderr });
+              reject(error);
+              return;
+            }
+            resolve({ stdout, stderr });
+          });
+        } catch (error) {
+          startupError = error;
+          reject(error);
+        }
       }),
       options,
       { command: file, args, cwd: options.cwd }
     );
 
     if (!child) {
-      throw new Error(`Failed to start command: ${file}`);
+      // The callback-style exec API may throw before returning a child (for
+      // example, when argv contains a NUL). The promise has already captured
+      // that failure for the shared seam; consume its wrapped rejection before
+      // surfacing the same actionable error synchronously to the caller.
+      void result.catch(() => undefined);
+      throw wrapCommandError(
+        startupError ?? new Error(`Failed to start command: ${file}`),
+        { command: file, args, cwd: options.cwd }
+      );
     }
     return { child, result };
   }

--- a/src/utils/android-cmdline-tools/AdbClient.ts
+++ b/src/utils/android-cmdline-tools/AdbClient.ts
@@ -1,7 +1,6 @@
 import { errorMessage } from "../describeUnknownError";
-import { execFile, type ChildProcess, type SpawnOptions } from "child_process";
+import { type ChildProcess, type SpawnOptions } from "child_process";
 import { logger } from "../logger";
-import { createExecResult } from "../execResult";
 import { runExecSeam } from "../ExecSeam";
 import {
   DefaultHostCommandExecutor,
@@ -28,7 +27,6 @@ import { OPERATION_CANCELLED_MESSAGE } from "../constants";
 import { RetryExecutor, defaultRetryExecutor } from "../retry/RetryExecutor";
 import { TTLCache } from "../cache/Cache";
 import { Timer, defaultTimer } from "../SystemTimer";
-import { wrapCommandError } from "../CommandError";
 import { isAdbMissingDeviceError, notifyAdbMissingDevice } from "./AdbDeviceHealth";
 import { DefaultSystemDetection, type SystemDetection } from "../system/SystemDetection";
 
@@ -915,8 +913,12 @@ export class AdbClient implements AdbExecutor {
       let settled = false;
       let pendingTerminationError: Error | undefined;
       let terminationTimeoutId: NodeJS.Timeout | undefined;
-      const options = maxBuffer ? { maxBuffer } : undefined;
-      const child = execFile(file, args, options, (error, stdout, stderr) => {
+      const { child, result } = hostProcessExecutor.executeCommandWithChild(
+        file,
+        args,
+        maxBuffer ? { maxBuffer } : undefined,
+      );
+      result.then((execResult) => {
         if (settled) {
           return;
         }
@@ -926,18 +928,14 @@ export class AdbClient implements AdbExecutor {
           reject(pendingTerminationError);
           return;
         }
-        if (error) {
-          reject(
-            wrapCommandError(error, {
-              command: file,
-              args,
-              stdout,
-              stderr,
-            }),
-          );
+        resolve(execResult);
+      }).catch((error: unknown) => {
+        if (settled) {
           return;
         }
-        resolve(createExecResult(stdout, stderr));
+        settled = true;
+        cleanup();
+        reject(error);
       });
 
       this.activeProcesses.add(child);

--- a/src/utils/android-cmdline-tools/AdbClient.ts
+++ b/src/utils/android-cmdline-tools/AdbClient.ts
@@ -45,7 +45,7 @@ type SpawnFn = (file: string, args: string[], options?: SpawnOptions) => ChildPr
 // client no longer reaches for `child_process.spawn` directly (issue #5459). The
 // executor's `spawn` is a plain passthrough, so this is behavior-identical; all
 // of AdbClient's own timeout/abort/process-tracking orchestration is unchanged.
-const hostProcessExecutor: HostProcessExecutor = new DefaultHostCommandExecutor();
+export const adbHostProcessExecutor: HostProcessExecutor = new DefaultHostCommandExecutor();
 
 /**
  * Thrown when an adb command exceeds the caller-supplied `timeoutMs` budget, as
@@ -206,7 +206,7 @@ export class AdbClient implements AdbExecutor {
     } else {
       this.execAsync = execAsyncFn ? this.wrapExecAsync(execAsyncFn) : execFileAsync;
     }
-    this.spawnFn = spawnFn || ((file, args, options) => hostProcessExecutor.spawn(file, args, options));
+    this.spawnFn = spawnFn || ((file, args, options) => adbHostProcessExecutor.spawn(file, args, options));
     this.retryExecutor = retryExecutor;
     this.timer = timer;
     // Initialize with fallback, will be updated lazily
@@ -913,7 +913,7 @@ export class AdbClient implements AdbExecutor {
       let settled = false;
       let pendingTerminationError: Error | undefined;
       let terminationTimeoutId: NodeJS.Timeout | undefined;
-      const { child, result } = hostProcessExecutor.executeCommandWithChild(
+      const { child, result } = adbHostProcessExecutor.executeCommandWithChild(
         file,
         args,
         maxBuffer ? { maxBuffer } : undefined,
@@ -935,7 +935,7 @@ export class AdbClient implements AdbExecutor {
         }
         settled = true;
         cleanup();
-        reject(error);
+        reject(pendingTerminationError ?? error);
       });
 
       this.activeProcesses.add(child);

--- a/test/fakes/FakeProcessExecutor.ts
+++ b/test/fakes/FakeProcessExecutor.ts
@@ -1,6 +1,10 @@
 import type { ChildProcess, SpawnOptions } from "child_process";
 import type { ExecResult } from "../../src/models";
-import type { HostCommandOptions, HostProcessExecutor } from "../../src/utils/HostCommandExecutor";
+import type {
+  HostCommandOptions,
+  HostProcessExecutor,
+  StartedHostCommand,
+} from "../../src/utils/HostCommandExecutor";
 import { FakeChildProcess } from "./FakeChildProcess";
 
 /**
@@ -69,6 +73,17 @@ export class FakeProcessExecutor implements HostProcessExecutor {
     this.nextSpawnProcess = null;
     this.spawnResponses.push({ command, args, options, process });
     return process;
+  }
+
+  executeCommandWithChild(
+    command: string,
+    args: string[] = [],
+    options?: HostCommandOptions
+  ): StartedHostCommand {
+    return {
+      child: this.spawn(command, args),
+      result: this.executeCommand(command, args, options),
+    };
   }
 
   private createExecResult(stdout: string, stderr: string): ExecResult {

--- a/test/utils/ExecSeam.test.ts
+++ b/test/utils/ExecSeam.test.ts
@@ -164,4 +164,15 @@ describe("argv exec seam", function() {
 
     await expect(started.result).rejects.toThrow(/callback stdout[\s\S]*callback stderr/);
   }, FAST_TEST_TIMEOUT_MS);
+
+  test("trackable command execution propagates synchronous startup failures", function() {
+    const startupError = new Error("The argument contains a NUL byte");
+    const execWithChild: ExecFileWithChild = () => {
+      throw startupError;
+    };
+
+    expect(() => new DefaultHostCommandExecutor(undefined, execWithChild)
+      .executeCommandWithChild("adb", ["shell", "a\0b"]))
+      .toThrow(/Command failed: adb shell a\0b[\s\S]*The argument contains a NUL byte/);
+  }, FAST_TEST_TIMEOUT_MS);
 });

--- a/test/utils/ExecSeam.test.ts
+++ b/test/utils/ExecSeam.test.ts
@@ -8,7 +8,9 @@ import { createExecResult } from "../../src/utils/execResult";
 import {
   DefaultHostCommandExecutor,
   type ExecFileAsync,
+  type ExecFileWithChild,
 } from "../../src/utils/HostCommandExecutor";
+import type { ChildProcess } from "child_process";
 
 const FAST_TEST_TIMEOUT_MS = 100;
 
@@ -129,5 +131,37 @@ describe("argv exec seam", function() {
     const argvSeam: ExecFileAsync = async () => ({ stdout: "argv", stderr: "" });
     const result = await new DefaultHostCommandExecutor(argvSeam).executeCommand("echo", ["argv"]);
     expect(result.stdout).toBe("argv");
+  }, FAST_TEST_TIMEOUT_MS);
+
+  test("trackable command execution shares option mapping and result coercion", async function() {
+    const child = { kill: () => true } as ChildProcess;
+    let seen: ExecSeamOptions | undefined;
+    const execWithChild: ExecFileWithChild = (_file, _args, options, callback) => {
+      seen = options;
+      callback(null, Buffer.from("tracked-out"), Buffer.from("tracked-err"));
+      return child;
+    };
+
+    const started = new DefaultHostCommandExecutor(undefined, execWithChild)
+      .executeCommandWithChild("adb", ["shell", "true"], { timeoutMs: 1234, maxBuffer: 42 });
+
+    expect(started.child).toBe(child);
+    expect(seen).toEqual({ timeout: 1234, maxBuffer: 42, cwd: undefined, signal: undefined });
+    await expect(started.result).resolves.toMatchObject({ stdout: "tracked-out", stderr: "tracked-err" });
+  }, FAST_TEST_TIMEOUT_MS);
+
+  test("trackable command execution retains callback output when wrapping errors", async function() {
+    const child = { kill: () => true } as ChildProcess;
+    const execWithChild: ExecFileWithChild = (_file, _args, _options, callback) => {
+      const error = new Error("adb failed") as Error & { code?: number };
+      error.code = 1;
+      callback(error, "callback stdout", "callback stderr");
+      return child;
+    };
+
+    const started = new DefaultHostCommandExecutor(undefined, execWithChild)
+      .executeCommandWithChild("adb", ["shell", "true"]);
+
+    await expect(started.result).rejects.toThrow(/callback stdout[\s\S]*callback stderr/);
   }, FAST_TEST_TIMEOUT_MS);
 });

--- a/test/utils/android-cmdline-tools/AdbClientExecWithSignal.test.ts
+++ b/test/utils/android-cmdline-tools/AdbClientExecWithSignal.test.ts
@@ -1,0 +1,66 @@
+import { EventEmitter } from "node:events";
+import { afterEach, describe, expect, test } from "bun:test";
+import type { ChildProcess } from "child_process";
+import {
+  AdbClient,
+  AdbCommandTimeoutError,
+  adbHostProcessExecutor,
+} from "../../../src/utils/android-cmdline-tools/AdbClient";
+import type {
+  StartedHostCommand,
+} from "../../../src/utils/HostCommandExecutor";
+import { defaultRetryExecutor } from "../../../src/utils/retry/RetryExecutor";
+import { FakeTimer } from "../../fakes/FakeTimer";
+
+type AdbClientInternals = {
+  isTestMode: boolean;
+  execWithSignal: (
+    file: string,
+    args: string[],
+    maxBuffer?: number,
+    timeoutMs?: number,
+    signal?: AbortSignal,
+    waitForProcessSettlementAfterAbort?: boolean,
+  ) => Promise<unknown>;
+};
+
+const originalExecuteCommandWithChild = adbHostProcessExecutor.executeCommandWithChild;
+
+describe.serial("AdbClient execWithSignal shared process seam", () => {
+  afterEach(() => {
+    adbHostProcessExecutor.executeCommandWithChild = originalExecuteCommandWithChild;
+  });
+
+  test("keeps the injected timeout error when SIGTERM rejects during graceful settlement", async () => {
+    const timer = new FakeTimer();
+    const child = new EventEmitter() as ChildProcess;
+    let rejectResult: ((error: Error) => void) | undefined;
+    child.kill = () => {
+      rejectResult?.(new Error("terminated by SIGTERM"));
+      return true;
+    };
+    adbHostProcessExecutor.executeCommandWithChild = (): StartedHostCommand => ({
+      child,
+      result: new Promise((_, reject) => {
+        rejectResult = reject;
+      }),
+    });
+
+    const client = new AdbClient(null, null, null, defaultRetryExecutor, timer);
+    const internals = client as unknown as AdbClientInternals;
+    internals.isTestMode = false;
+
+    const result = internals.execWithSignal(
+      "adb",
+      ["shell", "getprop"],
+      undefined,
+      5,
+      undefined,
+      true,
+    );
+    timer.advanceTime(5);
+
+    await expect(result).rejects.toBeInstanceOf(AdbCommandTimeoutError);
+    await expect(result).rejects.toThrow("Command timed out after 5ms: adb shell getprop");
+  });
+});


### PR DESCRIPTION
## Summary

Completes [#5459](https://github.com/kaeawc/auto-mobile/issues/5459)'s remaining tracked `AdbClient` execFile leg.

- Adds `HostProcessExecutor.executeCommandWithChild`, which exposes the live child while routing command option mapping, `ExecResult` coercion, and error formatting through the shared exec seam.
- Routes `AdbClient.execWithSignal` through that shared primitive, preserving client-owned process tracking and injected-Timer abort/timeout behavior.
- Preserves callback stdout/stderr in wrapped command errors and covers both the successful and error contracts.

`AdbClient` no longer directly imports or invokes `child_process.execFile`; its only `child_process` use is the `ChildProcess` type needed for lifecycle tracking.

## Validation

- `bun test test/utils/ExecSeam.test.ts test/utils/android-cmdline-tools/AdbClient-executionContract.test.ts test/utils/android-cmdline-tools/AdbClientApiLevelTimeout.test.ts test/utils/android-cmdline-tools/AdbClientPathDiscoveryTimeout.test.ts`
- `bun run turbo:validate`
- `bun run typecheck` (no new errors; existing baseline remains at 175)

Closes #5459
