### PR TITLE
feat(ios): first-class local-build mode for the CtrlProxy runner (#5561)

### DIFF
--- a/skills/manual-test/SKILL.md
+++ b/skills/manual-test/SKILL.md
@@ -139,9 +139,50 @@ at a time to conserve context; never let two actors drive devices at once.
      CtrlProxy download/install, so install the freshly built APK on the emulator
      yourself (`adb install -r <fresh apk>`) before starting the daemon, or run the
      Android leg in a separate daemon without the flag.
+   - **Serve a locally built iOS runner (the reliable procedure).** `SKIP` +
+     `IOS_DERIVED_DATA` alone are **not** enough for iOS: they stop the released
+     runner from overwriting your build, but they do **not** make the daemon
+     launch your build — a second gate rejects it. Before launch the daemon
+     re-hashes the runner binary and refuses on any mismatch against the
+     release-pinned `runnerSha256`
+     (`assertRunnerBinaryHash()`, `src/utils/IOSCtrlProxyBuilder.ts`), and a
+     locally built runner **always** hashes differently:
+     ```
+     CtrlProxy runner binary SHA256 mismatch (pre-launch) for simulator.
+     Expected: <pinned>, Got: <your local build>. Refusing to launch ...
+     ```
+     Two supported ways past this — **prefer the first**:
+     1. **First-class local-build mode (recommended).** Set
+        `AUTOMOBILE_CTRL_PROXY_IOS_USE_LOCAL_BUILD=true`. The daemon then derives
+        the expected SHA from your freshly built runner, pins it, and re-verifies
+        against that pinned value before launch (so a TOCTOU swap still fails
+        closed) — no SHA to hand-copy. It logs a loud WARN that the release-pinned
+        guard is relaxed for the run. Run **without** `SKIP_CTRL_PROXY_DOWNLOAD`
+        so the builder actually runs, and point
+        `AUTOMOBILE_CTRL_PROXY_IOS_DERIVED_DATA=<derived-data-root>` at your build.
+     2. **Explicit pinned SHA (manual).** Set
+        `AUTOMOBILE_CTRL_PROXY_IOS_RUNNER_SHA256=<64-hex>` (and
+        `AUTOMOBILE_CTRL_PROXY_IOS_RUNNER_SHA256_TARGET=runner|xctest` to pick the
+        binary; defaults to the release's target). This keeps the integrity gate
+        active against *your* value. The catch is chicken-and-egg: you learn the
+        SHA only by launching once and reading the `Got:` value from the mismatch
+        error, then re-launching with it. An explicit value here **overrides**
+        local-build mode, so unset it if you want auto-derivation.
+
+     **SKIP-flag interaction:** with `AUTOMOBILE_SKIP_CTRL_PROXY_DOWNLOAD=true` the
+     iOS prefetch is disabled and the builder never launches a local runner — the
+     daemon just **reuses whatever runner is already live** on the port (often one
+     owned by another session's `bunx auto-mobile`), so freeing the port then
+     falls through to the launch/guard path above. For local-build mode, start
+     **without** the skip flag. If the daemon reuses a runner it did not launch it
+     now logs a loud WARN (`Reusing an external CtrlProxy runner this daemon did
+     not launch`) — treat that as a signal to confirm which runner served the call.
    - **Verify which runner actually served the call** — `grep xctestrun <daemon-log>`
      for the path, and `grep 'need download\|Downloading CtrlProxy bundle' <daemon-log>`
-     to confirm the released bundle did *not* replace your build.
+     to confirm the released bundle did *not* replace your build. Also
+     `grep 'Local-build mode' <daemon-log>` to confirm your local runner's derived
+     SHA was trusted, and `grep 'Reusing an external CtrlProxy runner' <daemon-log>`
+     to catch a stale/foreign runner silently serving.
    - `--embedded-sdk` — required for `sqlQuery`, `setPreference`/`getPreference`,
      in-app `highlight` (registration is **daemon-side**; the CLI must pass the same
      flag so the reuse check matches, else it restarts the daemon).

--- a/skills/manual-test/SKILL.md
+++ b/skills/manual-test/SKILL.md
@@ -157,7 +157,7 @@ at a time to conserve context; never let two actors drive devices at once.
         the expected SHA from your freshly built runner, pins it, and re-verifies
         against that pinned value before launch (so a TOCTOU swap still fails
         closed) — no SHA to hand-copy. It logs a loud WARN that the release-pinned
-        guard is relaxed for the run. Run **without** `SKIP_CTRL_PROXY_DOWNLOAD`
+        guard is relaxed for the run. Run **without** `AUTOMOBILE_SKIP_CTRL_PROXY_DOWNLOAD`
         so the builder actually runs, and point
         `AUTOMOBILE_CTRL_PROXY_IOS_DERIVED_DATA=<derived-data-root>` at your build.
      2. **Explicit pinned SHA (manual).** Set

--- a/src/utils/IOSCtrlProxyBuilder.ts
+++ b/src/utils/IOSCtrlProxyBuilder.ts
@@ -73,6 +73,20 @@ export const IOS_CTRL_PROXY_RUNNER_SHA256_ENV = "AUTOMOBILE_CTRL_PROXY_IOS_RUNNE
 /** Executable represented by {@link IOS_CTRL_PROXY_RUNNER_SHA256_ENV}. */
 export const IOS_CTRL_PROXY_RUNNER_SHA256_TARGET_ENV =
   "AUTOMOBILE_CTRL_PROXY_IOS_RUNNER_SHA256_TARGET";
+/**
+ * First-class "serve a locally built runner" switch (issue #5561). When truthy
+ * (`1`/`true`) and no explicit {@link IOS_CTRL_PROXY_RUNNER_SHA256_ENV} is set,
+ * the pre-launch integrity gate stops comparing against the release-pinned
+ * checksum — which a local build can never match — and instead DERIVES the
+ * expected hash from the freshly built runner binary at post-extract, pins it in
+ * memory, and re-verifies against that captured value before launch. The
+ * verify→execute TOCTOU protection (issue #4759) is preserved (a binary swap
+ * between post-extract and launch still fails closed); only the release-pinned
+ * baseline is relaxed. Off by default so published runs keep the pinned guard.
+ * This removes the run-fail-read-`Got:`-sha-rerun dance the manual-test flow
+ * previously required.
+ */
+export const IOS_CTRL_PROXY_USE_LOCAL_BUILD_ENV = "AUTOMOBILE_CTRL_PROXY_IOS_USE_LOCAL_BUILD";
 
 /**
  * Turn a codesign inspection outcome into a list of human-readable problems,
@@ -180,6 +194,8 @@ export class IOSCtrlProxyBuilder {
   private static expectedChecksumOverride: string | null = null;
   private static expectedRunnerChecksumOverride: string | null = null;
   private static expectedRunnerChecksumTargetOverride: RunnerSha256Target | null = null;
+  // Test seam for the local-build switch (#5561). null → read the env var.
+  private static useLocalBuildOverride: boolean | null = null;
   private static timer: Timer = defaultTimer;
 
   // Gate that decides whether the startup runner-bundle prefetch should run at
@@ -212,6 +228,12 @@ export class IOSCtrlProxyBuilder {
    * Hash is computed once per build and cached until next build/extraction.
    */
   private cachedAppBundleHash: Map<IOSCtrlProxyPlatform, string | null> = new Map();
+  /**
+   * Local-build-mode (#5561) derived runner SHA256, pinned per platform at
+   * post-extract so the pre-launch re-verification can still detect a binary
+   * swap even though there is no release-pinned baseline to compare against.
+   */
+  private derivedLocalRunnerSha256: Map<IOSCtrlProxyPlatform, string> = new Map();
 
   private constructor(
     config: Partial<CtrlProxyIosBuildConfig> = {},
@@ -255,6 +277,7 @@ export class IOSCtrlProxyBuilder {
     IOSCtrlProxyBuilder.expectedChecksumOverride = null;
     IOSCtrlProxyBuilder.expectedRunnerChecksumOverride = null;
     IOSCtrlProxyBuilder.expectedRunnerChecksumTargetOverride = null;
+    IOSCtrlProxyBuilder.useLocalBuildOverride = null;
     IOSCtrlProxyBuilder.timer = defaultTimer;
     IOSCtrlProxyBuilder.iosPrerequisiteDetector = new DefaultIosPrerequisiteDetector();
     IOSCtrlProxyBuilder.prefetchBuilderOverride = null;
@@ -299,6 +322,14 @@ export class IOSCtrlProxyBuilder {
   ): void {
     IOSCtrlProxyBuilder.expectedRunnerChecksumOverride = checksum;
     IOSCtrlProxyBuilder.expectedRunnerChecksumTargetOverride = target;
+  }
+
+  /**
+   * Override the {@link IOS_CTRL_PROXY_USE_LOCAL_BUILD_ENV} switch for testing
+   * (issue #5561). Null restores reading the environment variable.
+   */
+  public static setUseLocalBuildForTesting(useLocalBuild: boolean | null): void {
+    IOSCtrlProxyBuilder.useLocalBuildOverride = useLocalBuild;
   }
 
   /**
@@ -1164,6 +1195,15 @@ export class IOSCtrlProxyBuilder {
     platform: IOSCtrlProxyPlatform,
     phase: "post-extract" | "pre-launch"
   ): Promise<void> {
+    // First-class local-build mode (#5561): derive and trust the locally built
+    // runner's own hash instead of the release-pinned baseline it can never
+    // match. An explicit SHA override still wins (checked inside), so published
+    // and pinned-SHA runs keep their guard.
+    if (this.isLocalBuildMode() && !this.hasExplicitRunnerShaOverride()) {
+      await this.assertLocalRunnerBinaryHash(platform, phase);
+      return;
+    }
+
     const expectedRunnerSha256 = this.getExpectedRunnerChecksum();
     if (!expectedRunnerSha256 || expectedRunnerSha256.length === 0) {
       logger.warn(`[IOSCtrlProxyBuilder] Runner binary SHA256 verification skipped for ${platform} (no hash provided)`);
@@ -1183,6 +1223,66 @@ export class IOSCtrlProxyBuilder {
       );
     }
     logger.info(`[IOSCtrlProxyBuilder] Runner binary SHA256 verified (${phase})`, { platform, checksum });
+  }
+
+  /** Whether the {@link IOS_CTRL_PROXY_USE_LOCAL_BUILD_ENV} switch is active (#5561). */
+  private isLocalBuildMode(): boolean {
+    const override = IOSCtrlProxyBuilder.useLocalBuildOverride;
+    if (override !== null) {
+      return override;
+    }
+    return isTruthyEnvValue(process.env[IOS_CTRL_PROXY_USE_LOCAL_BUILD_ENV]);
+  }
+
+  /**
+   * Whether the operator hand-supplied a runner SHA256 via
+   * {@link IOS_CTRL_PROXY_RUNNER_SHA256_ENV}. That explicit value takes
+   * precedence over local-build mode so a pinned hash stays enforced (#5561).
+   * Note: the static test override is deliberately excluded — it stands in for
+   * the release-pinned baseline, which local-build mode is designed to relax.
+   */
+  private hasExplicitRunnerShaOverride(): boolean {
+    const environmentOverride = process.env[IOS_CTRL_PROXY_RUNNER_SHA256_ENV]?.trim();
+    return environmentOverride !== undefined && environmentOverride.length > 0;
+  }
+
+  /**
+   * Local-build-mode (#5561) runner integrity check. On the first call for a
+   * platform (post-extract) it computes and pins the freshly built runner's
+   * SHA256, warning loudly that the release-pinned guard is relaxed. Subsequent
+   * calls (pre-launch) re-hash and compare against that pinned value, so a binary
+   * swap in the verify→execute window still fails closed (issue #4759 TOCTOU
+   * protection preserved) even though there is no release baseline to match.
+   */
+  private async assertLocalRunnerBinaryHash(
+    platform: IOSCtrlProxyPlatform,
+    phase: "post-extract" | "pre-launch"
+  ): Promise<void> {
+    const runnerChecksumTarget = this.getExpectedRunnerChecksumTarget();
+    const runnerBinaryPath = await this.getRunnerBinaryPath(platform, runnerChecksumTarget);
+    if (!runnerBinaryPath) {
+      throw new ActionableError(`CtrlProxy runner binary missing for ${platform}`);
+    }
+    const { checksum } = await this.downloader.computeFileSha256(runnerBinaryPath);
+    const normalized = checksum.toLowerCase();
+    const pinned = this.derivedLocalRunnerSha256.get(platform);
+    if (pinned === undefined) {
+      this.derivedLocalRunnerSha256.set(platform, normalized);
+      logger.warn(
+        `[IOSCtrlProxyBuilder] Local-build mode (${IOS_CTRL_PROXY_USE_LOCAL_BUILD_ENV}) active for ` +
+        `${platform}: trusting the locally built runner (${phase}) with derived SHA256 ${normalized}. ` +
+        `The release-pinned integrity guard is intentionally bypassed for this run.`
+      );
+      return;
+    }
+    if (normalized !== pinned) {
+      throw new ActionableError(
+        `CtrlProxy runner binary SHA256 changed (${phase}) for ${platform} under local-build mode. ` +
+        `Pinned at post-extract: ${pinned}, Got: ${normalized}. Refusing to launch a runner whose ` +
+        `binary changed since it was verified (possible TOCTOU tampering).`
+      );
+    }
+    logger.info(`[IOSCtrlProxyBuilder] Local runner binary SHA256 re-verified (${phase})`, { platform, checksum: normalized });
   }
 
   /**

--- a/src/utils/IOSCtrlProxyBuilder.ts
+++ b/src/utils/IOSCtrlProxyBuilder.ts
@@ -1055,6 +1055,12 @@ export class IOSCtrlProxyBuilder {
   }
 
   private async extractBundle(bundlePath: string): Promise<void> {
+    // A re-extract replaces the runner binary, so drop any local-build-mode pin
+    // (#5561) BEFORE re-extraction — the post-extract verify a few lines down
+    // re-derives it. Clearing here (not after extract) is essential: the pin is
+    // set inside verifyExtractedArtifacts() below, so clearing post-extract would
+    // erase the fresh pin and make the next pre-launch wrongly store-and-trust.
+    this.derivedLocalRunnerSha256.clear();
     // Fail closed before wiping/repopulating the tree if it is owned by another
     // uid — extracting into a directory we do not own reopens the TOCTOU window
     // this hardening closes (issue #4759).

--- a/src/utils/IOSCtrlProxyManager.ts
+++ b/src/utils/IOSCtrlProxyManager.ts
@@ -990,8 +990,13 @@ export class IOSCtrlProxyManager implements CtrlProxyIosManager {
           perf.endOperation("externalProcessCheck");
           if (externalProcess || defaultPortIsHealthyForDevice) {
             const externalPort = externalProcess?.port ?? IOSCtrlProxyManager.DEFAULT_PORT;
-            logger.info(
-              `[IOSCtrlProxy] External CtrlProxy process detected on port ${externalPort}, skipping spawn`
+            // Warn (not info): the daemon is about to serve calls through a runner
+            // it did NOT launch (#5561). On a shared host this may be a stale or
+            // foreign runner — surfacing it loudly stops results from being
+            // misattributed to a local build that never ran.
+            logger.warn(
+              `[IOSCtrlProxy] Reusing an external CtrlProxy runner this daemon did not launch ` +
+              `(port ${externalPort}); skipping spawn. Verify it is the runner you intend to test.`
             );
             if (externalPort !== this.servicePort) {
               this.adoptServicePort(externalPort);

--- a/test/utils/IOSCtrlProxyBuilder.test.ts
+++ b/test/utils/IOSCtrlProxyBuilder.test.ts
@@ -892,6 +892,30 @@ describe("IOSCtrlProxyBuilder", function() {
         .rejects.toThrow("SHA256 changed");
     });
 
+    test("local-build mode re-derives the pin on an in-process rebuild (#5561)", async function() {
+      const derivedDataPath = path.join(tempDir, "DerivedData");
+      const cacheDir = path.join(tempDir, "cache");
+      const downloader = new FakeIOSCtrlProxyBundleDownloader();
+      downloader.checksum = "expected-checksum";
+      downloader.runnerChecksum = "c".repeat(64);
+
+      IOSCtrlProxyBuilder.setExpectedChecksumForTesting("expected-checksum");
+      IOSCtrlProxyBuilder.setExpectedRunnerChecksumForTesting("a".repeat(64), "xctest");
+      IOSCtrlProxyBuilder.setUseLocalBuildForTesting(true);
+      const builder = IOSCtrlProxyBuilder.getInstance(
+        { derivedDataPath, bundleCacheDir: cacheDir },
+        { downloader }
+      );
+
+      expect((await builder.build("simulator")).success).toBe(true);
+
+      // A legitimate rebuild produces a different local binary. The re-extract must
+      // drop the stale pin so this is NOT rejected as a TOCTOU swap.
+      downloader.runnerChecksum = "d".repeat(64);
+      expect((await builder.build("simulator")).success).toBe(true);
+      await builder.verifyRunnerBinaryBeforeLaunch("simulator");
+    });
+
     test("explicit RUNNER_SHA256 override still wins over local-build mode (#5561)", async function() {
       const derivedDataPath = path.join(tempDir, "DerivedData");
       const cacheDir = path.join(tempDir, "cache");

--- a/test/utils/IOSCtrlProxyBuilder.test.ts
+++ b/test/utils/IOSCtrlProxyBuilder.test.ts
@@ -844,6 +844,78 @@ describe("IOSCtrlProxyBuilder", function() {
         .rejects.toThrow("runner binary SHA256 mismatch (pre-launch)");
     });
 
+    test("local-build mode trusts the freshly built runner even when its SHA differs from the release-pinned checksum (#5561)", async function() {
+      const derivedDataPath = path.join(tempDir, "DerivedData");
+      const cacheDir = path.join(tempDir, "cache");
+      const downloader = new FakeIOSCtrlProxyBundleDownloader();
+      downloader.checksum = "expected-checksum";
+      downloader.runnerChecksum = "c".repeat(64);
+
+      IOSCtrlProxyBuilder.setExpectedChecksumForTesting("expected-checksum");
+      // Release-pinned checksum the local build can never match.
+      IOSCtrlProxyBuilder.setExpectedRunnerChecksumForTesting("a".repeat(64), "xctest");
+      IOSCtrlProxyBuilder.setUseLocalBuildForTesting(true);
+      const builder = IOSCtrlProxyBuilder.getInstance(
+        { derivedDataPath, bundleCacheDir: cacheDir },
+        { downloader }
+      );
+
+      // Post-extract must not reject on the release-pinned mismatch; it derives
+      // and pins the local runner's hash instead.
+      expect((await builder.build("simulator")).success).toBe(true);
+
+      // Pre-launch re-verifies against the derived hash — unchanged, so it passes.
+      await builder.verifyRunnerBinaryBeforeLaunch("simulator");
+    });
+
+    test("local-build mode still fails closed if the runner binary changes after post-extract (TOCTOU) (#5561)", async function() {
+      const derivedDataPath = path.join(tempDir, "DerivedData");
+      const cacheDir = path.join(tempDir, "cache");
+      const downloader = new FakeIOSCtrlProxyBundleDownloader();
+      downloader.checksum = "expected-checksum";
+      downloader.runnerChecksum = "c".repeat(64);
+
+      IOSCtrlProxyBuilder.setExpectedChecksumForTesting("expected-checksum");
+      IOSCtrlProxyBuilder.setExpectedRunnerChecksumForTesting("a".repeat(64), "xctest");
+      IOSCtrlProxyBuilder.setUseLocalBuildForTesting(true);
+      const builder = IOSCtrlProxyBuilder.getInstance(
+        { derivedDataPath, bundleCacheDir: cacheDir },
+        { downloader }
+      );
+
+      expect((await builder.build("simulator")).success).toBe(true);
+
+      // Swap the on-disk binary after it was pinned at post-extract.
+      downloader.runnerChecksum = "d".repeat(64);
+
+      await expect(builder.verifyRunnerBinaryBeforeLaunch("simulator"))
+        .rejects.toThrow("SHA256 changed");
+    });
+
+    test("explicit RUNNER_SHA256 override still wins over local-build mode (#5561)", async function() {
+      const derivedDataPath = path.join(tempDir, "DerivedData");
+      const cacheDir = path.join(tempDir, "cache");
+      const downloader = new FakeIOSCtrlProxyBundleDownloader();
+      downloader.checksum = "expected-checksum";
+      downloader.runnerChecksum = "f".repeat(64);
+
+      // Local-build mode is on, but an explicit SHA override is also set: the
+      // explicit value must remain enforced (mismatch => hard refusal).
+      process.env[IOS_CTRL_PROXY_RUNNER_SHA256_ENV] = "e".repeat(64);
+      process.env[IOS_CTRL_PROXY_RUNNER_SHA256_TARGET_ENV] = "xctest";
+      IOSCtrlProxyBuilder.setExpectedChecksumForTesting("expected-checksum");
+      IOSCtrlProxyBuilder.setExpectedRunnerChecksumForTesting(null);
+      IOSCtrlProxyBuilder.setUseLocalBuildForTesting(true);
+      const builder = IOSCtrlProxyBuilder.getInstance(
+        { derivedDataPath, bundleCacheDir: cacheDir },
+        { downloader }
+      );
+
+      const result = await builder.build("simulator");
+      expect(result.success).toBe(false);
+      expect(result.error).toContain("runner binary SHA256 mismatch");
+    });
+
     test("refuses to reuse a derived-data directory owned by another uid (#4759)", async function() {
       if (process.platform === "win32" || typeof process.getuid !== "function") {
         // st_uid/getuid are POSIX-only; ownership refusal no-ops on win32.


### PR DESCRIPTION
## Summary

There was no supported, documented way to make the daemon serve a **locally
built iOS CtrlProxy runner** — a locally built runner always hashes differently
from the release-pinned `runnerSha256`, so the pre-launch integrity gate
(`assertRunnerBinaryHash()`) refuses it, and the only workaround was an
undocumented env var plus a run-fail-read-`Got:`-sha-rerun dance. This adds a
first-class switch, warns loudly on foreign-runner reuse, and documents the full
procedure.

## Linked Issue

Closes #5561

## Changes

- **First-class local-build mode** — `AUTOMOBILE_CTRL_PROXY_IOS_USE_LOCAL_BUILD=true`.
  When set (and no explicit `AUTOMOBILE_CTRL_PROXY_IOS_RUNNER_SHA256` is given),
  the daemon derives the expected SHA256 from the freshly built runner at
  post-extract, pins it in memory, and re-verifies against that pinned value
  before launch — so a binary swap in the verify→execute window still fails
  closed (the #4759 TOCTOU protection is preserved). It warns loudly that the
  release-pinned guard is relaxed for the run. An explicit pinned SHA still wins,
  and published runs keep the release-pinned guard by default.
- **Loud foreign-runner reuse warning** — the daemon now logs at WARN (was INFO)
  when it reuses a CtrlProxy runner it did not launch, so a stale/foreign runner
  isn't silently serving calls.
- **Docs** — `skills/manual-test/SKILL.md` now documents the full "serve a
  locally built iOS runner" procedure: `USE_LOCAL_BUILD`,
  `RUNNER_SHA256[_TARGET]`, and the `SKIP_CTRL_PROXY_DOWNLOAD` interaction.

## Validation

- [x] `bun test` — full suite green except one pre-existing worktree artifact
  (`test/lint/oxlintConfigScoping.test.ts` needs `node_modules/.bin/oxlint`,
  absent in `.claude/worktrees`; unrelated to this change). New builder tests
  (3) and the manager suite pass; all unit tests <100ms.
- [x] `bun run lint` — ratchet gate: no new violations; boundary-checks pass.
- [x] `bun run typecheck` — no new type errors (baseline gate).
- [x] New code uses the existing downloader interface + fakes; no new deps.

## Acceptance criteria (from the issue)

1. **Document the procedure** — done in `skills/manual-test/SKILL.md`.
2. **First-class local-runner mode** — `AUTOMOBILE_CTRL_PROXY_IOS_USE_LOCAL_BUILD`
   auto-derives and trusts the local runner's hash; release-pinned guard remains
   the default. Pinned by 3 new unit tests (trust local build, TOCTOU still fails
   closed, explicit override still wins).
3. **Reuse-vs-launch detection** — deferred (see Follow-ups). Local-build mode
   removes the operational need by launching the local runner rather than
   reusing a foreign one; the residual mismatched-port reuse fix touches the
   delicate runner-start ancestry matching and warrants its own issue + tests.
4. **Warn loudly on un-launched-runner reuse** — done (INFO→WARN).

## Follow-ups

- [ ] Reuse-vs-launch detection (#5561 ask 3): when a healthy runner is listening
  on a port other than the daemon's allocated one and its listener PID can't be
  resolved, adopt it via the health endpoint instead of falling through to the
  launch/guard path. Kept separate to avoid regressing the runner-start ancestry
  guards; filed as its own issue.
