### PR TITLE
feat(android): add an application-provided DataStore storage adapter

### DIFF
--- a/android/auto-mobile-sdk/api/auto-mobile-sdk.api
+++ b/android/auto-mobile-sdk/api/auto-mobile-sdk.api
@@ -187,10 +187,6 @@ public final class dev.jasonpearson.automobile.sdk.FrameMetricsCollector$activit
   public void onActivityDestroyed(android.app.Activity);
 }
 Compiled from "FrameMetricsCollector.kt"
-public final class dev.jasonpearson.automobile.sdk.FrameMetricsCollector$controlReceiver$1 extends android.content.BroadcastReceiver {
-  public void onReceive(android.content.Context, android.content.Intent);
-}
-Compiled from "FrameMetricsCollector.kt"
 public final class dev.jasonpearson.automobile.sdk.FrameMetricsCollector$scheduleBroadcast$1 implements java.lang.Runnable {
   public void run();
 }
@@ -253,6 +249,18 @@ public final class dev.jasonpearson.automobile.sdk.NavigationSource extends java
   public static dev.jasonpearson.automobile.sdk.NavigationSource valueOf(java.lang.String);
   public static kotlin.enums.EnumEntries<dev.jasonpearson.automobile.sdk.NavigationSource> getEntries();
 }
+Compiled from "NetworkControlReceiverRegistrar.kt"
+public final class dev.jasonpearson.automobile.sdk.NetworkControlReceiverRegistrar$register$registeredReceiver$1 extends android.content.BroadcastReceiver {
+  public void onReceive(android.content.Context, android.content.Intent);
+}
+Compiled from "NetworkControlReceiverRegistrar.kt"
+public final class dev.jasonpearson.automobile.sdk.NetworkControlReceiverRegistrar {
+  public static final int $stable;
+  public dev.jasonpearson.automobile.sdk.NetworkControlReceiverRegistrar(kotlin.jvm.functions.Function2<? super android.content.Context, ? super android.content.Intent, kotlin.Unit>);
+  public final synchronized void register(android.content.Context, kotlin.jvm.functions.Function0<? extends android.content.IntentFilter>);
+  public final synchronized void unregister(android.content.Context);
+  public static final kotlin.jvm.functions.Function2 access$getOnControlBroadcast$p(dev.jasonpearson.automobile.sdk.NetworkControlReceiverRegistrar);
+}
 Compiled from "AutoMobileNotifications.kt"
 public final class dev.jasonpearson.automobile.sdk.NotificationAction {
   public static final int $stable;
@@ -306,10 +314,6 @@ final class dev.jasonpearson.automobile.sdk.RecompositionTracker$RollingAverage 
   public dev.jasonpearson.automobile.sdk.RecompositionTracker$RollingAverage(long);
   public final void record();
   public final double getAverage();
-}
-Compiled from "RecompositionTracker.kt"
-public final class dev.jasonpearson.automobile.sdk.RecompositionTracker$controlReceiver$1 extends android.content.BroadcastReceiver {
-  public void onReceive(android.content.Context, android.content.Intent);
 }
 Compiled from "RecompositionTracker.kt"
 public final class dev.jasonpearson.automobile.sdk.RecompositionTracker$scheduleBroadcast$1 implements java.lang.Runnable {
@@ -1339,10 +1343,6 @@ public interface dev.jasonpearson.automobile.sdk.network.NetworkMockRuleStore$Ru
   public abstract dev.jasonpearson.automobile.sdk.network.NetworkMockRuleStore$ErrorSimulationConfig getErrorSimulation();
 }
 Compiled from "NetworkMockRuleStore.kt"
-public final class dev.jasonpearson.automobile.sdk.network.NetworkMockRuleStore$receiver$1 extends android.content.BroadcastReceiver {
-  public void onReceive(android.content.Context, android.content.Intent);
-}
-Compiled from "NetworkMockRuleStore.kt"
 public final class dev.jasonpearson.automobile.sdk.network.NetworkMockRuleStore$ruleMatcher$1 implements dev.jasonpearson.automobile.sdk.network.NetworkMockRuleStore$RuleMatcher {
   public dev.jasonpearson.automobile.sdk.network.NetworkMockRuleStore$MatchedMockRule findMatchingRule(java.lang.String, java.lang.String, java.lang.String);
   public dev.jasonpearson.automobile.sdk.network.NetworkMockRuleStore$ErrorSimulationConfig getErrorSimulation();
@@ -1372,7 +1372,6 @@ public final class dev.jasonpearson.automobile.sdk.network.NetworkMockRuleStore 
   public dev.jasonpearson.automobile.sdk.network.NetworkMockRuleStore();
   public static final dev.jasonpearson.automobile.sdk.network.NetworkMockRuleStore access$getInstance$cp();
   public static final void access$setInstance$cp(dev.jasonpearson.automobile.sdk.network.NetworkMockRuleStore);
-  public static final kotlinx.serialization.json.Json access$getJson$p(dev.jasonpearson.automobile.sdk.network.NetworkMockRuleStore);
 }
 Compiled from "AutoMobileNetwork.kt"
 public final class dev.jasonpearson.automobile.sdk.network.NetworkRequestRecord {
@@ -1566,6 +1565,137 @@ public interface dev.jasonpearson.automobile.sdk.session.SessionTracking {
   public abstract void onForeground();
   public abstract void onBackground();
   public abstract void shutdown();
+}
+Compiled from "DataStoreAdapter.kt"
+public interface dev.jasonpearson.automobile.sdk.storage.DataStoreAdapter {
+  public abstract java.lang.Object storeNames(kotlin.coroutines.Continuation<? super java.util.List<java.lang.String>>);
+  public abstract java.lang.Object read(java.lang.String, kotlin.coroutines.Continuation<? super java.util.List<dev.jasonpearson.automobile.sdk.storage.DataStoreEntry>>);
+}
+Compiled from "DataStoreAdapterError.kt"
+public final class dev.jasonpearson.automobile.sdk.storage.DataStoreAdapterError$AdapterNotFound extends dev.jasonpearson.automobile.sdk.storage.DataStoreAdapterError {
+  public static final int $stable;
+  public dev.jasonpearson.automobile.sdk.storage.DataStoreAdapterError$AdapterNotFound(java.lang.String);
+}
+Compiled from "DataStoreAdapterError.kt"
+public final class dev.jasonpearson.automobile.sdk.storage.DataStoreAdapterError$ReadError extends dev.jasonpearson.automobile.sdk.storage.DataStoreAdapterError {
+  public static final int $stable;
+  public dev.jasonpearson.automobile.sdk.storage.DataStoreAdapterError$ReadError(java.lang.String, java.lang.Throwable);
+  public dev.jasonpearson.automobile.sdk.storage.DataStoreAdapterError$ReadError(java.lang.String, java.lang.Throwable, int, kotlin.jvm.internal.DefaultConstructorMarker);
+}
+Compiled from "DataStoreAdapterError.kt"
+public final class dev.jasonpearson.automobile.sdk.storage.DataStoreAdapterError$StoreNotFound extends dev.jasonpearson.automobile.sdk.storage.DataStoreAdapterError {
+  public static final int $stable;
+  public dev.jasonpearson.automobile.sdk.storage.DataStoreAdapterError$StoreNotFound(java.lang.String);
+}
+Compiled from "DataStoreAdapterError.kt"
+public final class dev.jasonpearson.automobile.sdk.storage.DataStoreAdapterError$UnsupportedValue extends dev.jasonpearson.automobile.sdk.storage.DataStoreAdapterError {
+  public static final int $stable;
+  public dev.jasonpearson.automobile.sdk.storage.DataStoreAdapterError$UnsupportedValue(java.lang.String, java.lang.String, java.lang.String);
+}
+Compiled from "DataStoreAdapterError.kt"
+public abstract class dev.jasonpearson.automobile.sdk.storage.DataStoreAdapterError extends java.lang.Exception {
+  public static final int $stable;
+  public dev.jasonpearson.automobile.sdk.storage.DataStoreAdapterError(java.lang.String, kotlin.jvm.internal.DefaultConstructorMarker);
+}
+Compiled from "DataStoreModels.kt"
+public final class dev.jasonpearson.automobile.sdk.storage.DataStoreCapabilities {
+  public static final int $stable;
+  public dev.jasonpearson.automobile.sdk.storage.DataStoreCapabilities(boolean, boolean, boolean, java.util.List<? extends dev.jasonpearson.automobile.sdk.storage.DataStoreValueType>);
+  public dev.jasonpearson.automobile.sdk.storage.DataStoreCapabilities(boolean, boolean, boolean, java.util.List, int, kotlin.jvm.internal.DefaultConstructorMarker);
+  public final boolean getReadSupported();
+  public final boolean getMutationSupported();
+  public final boolean getRedactionEnabled();
+  public final java.util.List<dev.jasonpearson.automobile.sdk.storage.DataStoreValueType> getSupportedValueTypes();
+  public final boolean component1();
+  public final boolean component2();
+  public final boolean component3();
+  public final java.util.List<dev.jasonpearson.automobile.sdk.storage.DataStoreValueType> component4();
+  public final dev.jasonpearson.automobile.sdk.storage.DataStoreCapabilities copy(boolean, boolean, boolean, java.util.List<? extends dev.jasonpearson.automobile.sdk.storage.DataStoreValueType>);
+  public static dev.jasonpearson.automobile.sdk.storage.DataStoreCapabilities copy$default(dev.jasonpearson.automobile.sdk.storage.DataStoreCapabilities, boolean, boolean, boolean, java.util.List, int, java.lang.Object);
+  public java.lang.String toString();
+  public int hashCode();
+  public boolean equals(java.lang.Object);
+}
+Compiled from "DataStoreModels.kt"
+public final class dev.jasonpearson.automobile.sdk.storage.DataStoreDescriptor {
+  public static final int $stable;
+  public dev.jasonpearson.automobile.sdk.storage.DataStoreDescriptor(java.lang.String, int);
+  public final java.lang.String getName();
+  public final int getEntryCount();
+  public final java.lang.String component1();
+  public final int component2();
+  public final dev.jasonpearson.automobile.sdk.storage.DataStoreDescriptor copy(java.lang.String, int);
+  public static dev.jasonpearson.automobile.sdk.storage.DataStoreDescriptor copy$default(dev.jasonpearson.automobile.sdk.storage.DataStoreDescriptor, java.lang.String, int, int, java.lang.Object);
+  public java.lang.String toString();
+  public int hashCode();
+  public boolean equals(java.lang.Object);
+}
+Compiled from "DataStoreModels.kt"
+public final class dev.jasonpearson.automobile.sdk.storage.DataStoreEntry {
+  public static final int $stable;
+  public dev.jasonpearson.automobile.sdk.storage.DataStoreEntry(java.lang.String, java.lang.Object, dev.jasonpearson.automobile.sdk.storage.DataStoreValueType);
+  public final java.lang.String getKey();
+  public final java.lang.Object getValue();
+  public final dev.jasonpearson.automobile.sdk.storage.DataStoreValueType getType();
+  public final java.lang.String component1();
+  public final java.lang.Object component2();
+  public final dev.jasonpearson.automobile.sdk.storage.DataStoreValueType component3();
+  public final dev.jasonpearson.automobile.sdk.storage.DataStoreEntry copy(java.lang.String, java.lang.Object, dev.jasonpearson.automobile.sdk.storage.DataStoreValueType);
+  public static dev.jasonpearson.automobile.sdk.storage.DataStoreEntry copy$default(dev.jasonpearson.automobile.sdk.storage.DataStoreEntry, java.lang.String, java.lang.Object, dev.jasonpearson.automobile.sdk.storage.DataStoreValueType, int, java.lang.Object);
+  public java.lang.String toString();
+  public int hashCode();
+  public boolean equals(java.lang.Object);
+}
+Compiled from "DataStoreInspector.kt"
+final class dev.jasonpearson.automobile.sdk.storage.DataStoreInspector$describeStores$1 extends kotlin.coroutines.jvm.internal.ContinuationImpl {
+  public final java.lang.Object invokeSuspend(java.lang.Object);
+}
+Compiled from "DataStoreInspector.kt"
+final class dev.jasonpearson.automobile.sdk.storage.DataStoreInspector$readStore$1 extends kotlin.coroutines.jvm.internal.ContinuationImpl {
+  public final java.lang.Object invokeSuspend(java.lang.Object);
+}
+Compiled from "DataStoreInspector.kt"
+final class dev.jasonpearson.automobile.sdk.storage.DataStoreInspector$storeNames$1 extends kotlin.coroutines.jvm.internal.ContinuationImpl {
+  public final java.lang.Object invokeSuspend(java.lang.Object);
+}
+Compiled from "DataStoreInspector.kt"
+public final class dev.jasonpearson.automobile.sdk.storage.DataStoreInspector {
+  public static final dev.jasonpearson.automobile.sdk.storage.DataStoreInspector INSTANCE;
+  public static final java.lang.String REDACTED_VALUE;
+  public static final int $stable;
+  public final void registerAdapter(java.lang.String, dev.jasonpearson.automobile.sdk.storage.DataStoreAdapter);
+  public final boolean unregisterAdapter(java.lang.String);
+  public final java.util.Set<java.lang.String> registeredAdapterNames();
+  public final void setRedactionPolicy(dev.jasonpearson.automobile.sdk.storage.DataStoreRedactionPolicy);
+  public final java.lang.Object storeNames(java.lang.String, kotlin.coroutines.Continuation<? super java.util.List<java.lang.String>>);
+  public final java.lang.Object describeStores(java.lang.String, kotlin.coroutines.Continuation<? super java.util.List<dev.jasonpearson.automobile.sdk.storage.DataStoreDescriptor>>);
+  public final java.lang.Object readStore(java.lang.String, java.lang.String, kotlin.coroutines.Continuation<? super java.util.List<dev.jasonpearson.automobile.sdk.storage.DataStoreEntry>>);
+  public final dev.jasonpearson.automobile.sdk.storage.DataStoreCapabilities capabilities();
+  public final void reset$auto_mobile_sdk();
+}
+Compiled from "DataStoreModels.kt"
+public final class dev.jasonpearson.automobile.sdk.storage.DataStoreRedactionPolicy$Companion {
+  public final dev.jasonpearson.automobile.sdk.storage.DataStoreRedactionPolicy getNONE();
+}
+Compiled from "DataStoreModels.kt"
+public interface dev.jasonpearson.automobile.sdk.storage.DataStoreRedactionPolicy {
+  public static final dev.jasonpearson.automobile.sdk.storage.DataStoreRedactionPolicy$Companion Companion;
+  public abstract boolean shouldRedact(java.lang.String, java.lang.String);
+}
+Compiled from "DataStoreModels.kt"
+public final class dev.jasonpearson.automobile.sdk.storage.DataStoreValueType extends java.lang.Enum<dev.jasonpearson.automobile.sdk.storage.DataStoreValueType> {
+  public static final dev.jasonpearson.automobile.sdk.storage.DataStoreValueType STRING;
+  public static final dev.jasonpearson.automobile.sdk.storage.DataStoreValueType INT;
+  public static final dev.jasonpearson.automobile.sdk.storage.DataStoreValueType LONG;
+  public static final dev.jasonpearson.automobile.sdk.storage.DataStoreValueType FLOAT;
+  public static final dev.jasonpearson.automobile.sdk.storage.DataStoreValueType DOUBLE;
+  public static final dev.jasonpearson.automobile.sdk.storage.DataStoreValueType BOOLEAN;
+  public static final dev.jasonpearson.automobile.sdk.storage.DataStoreValueType STRING_SET;
+  public static final dev.jasonpearson.automobile.sdk.storage.DataStoreValueType BYTE_ARRAY;
+  public static final dev.jasonpearson.automobile.sdk.storage.DataStoreValueType UNKNOWN;
+  public static dev.jasonpearson.automobile.sdk.storage.DataStoreValueType[] values();
+  public static dev.jasonpearson.automobile.sdk.storage.DataStoreValueType valueOf(java.lang.String);
+  public static kotlin.enums.EnumEntries<dev.jasonpearson.automobile.sdk.storage.DataStoreValueType> getEntries();
 }
 Compiled from "SharedPreferencesDriver.kt"
 public interface dev.jasonpearson.automobile.sdk.storage.FileSystemOperations {

--- a/android/auto-mobile-sdk/src/debug/kotlin/dev/jasonpearson/automobile/sdk/storage/SharedPreferencesInspectorProvider.kt
+++ b/android/auto-mobile-sdk/src/debug/kotlin/dev/jasonpearson/automobile/sdk/storage/SharedPreferencesInspectorProvider.kt
@@ -5,6 +5,7 @@ import android.content.ContentValues
 import android.database.Cursor
 import android.net.Uri
 import android.os.Bundle
+import android.util.Base64
 import dev.jasonpearson.automobile.protocol.StorageChangeEvent
 import dev.jasonpearson.automobile.protocol.StorageEntry
 import dev.jasonpearson.automobile.protocol.StorageFileInfo
@@ -12,6 +13,7 @@ import dev.jasonpearson.automobile.protocol.StorageProtocolSerializer
 import dev.jasonpearson.automobile.protocol.StorageResponse
 import dev.jasonpearson.automobile.sdk.AutoMobileSDK
 import dev.jasonpearson.automobile.sdk.DebugInspectorAccess
+import kotlinx.coroutines.runBlocking
 import kotlinx.serialization.SerializationException
 import kotlinx.serialization.decodeFromString
 import kotlinx.serialization.encodeToString
@@ -62,29 +64,39 @@ class SharedPreferencesInspectorProvider : ContentProvider() {
         return result
       }
 
-      val driver = SharedPreferencesInspector.getDriver(extras?.getString("storeName"))
+      // DataStore-backed preferences are served through this same storage inspection surface via
+      // the read-only application-provided adapter contract (issue #5192). They reuse the existing
+      // StorageResponse shapes (no path is exposed) and are handled before the SharedPreferences
+      // driver is resolved, since they do not use it.
       val responseJson =
-        when (method) {
-          "listFiles" -> handleListFiles(driver)
-          "getPreferences" -> handleGetPreferences(driver, extras)
-          "getPreference" -> handleGetPreference(driver, extras)
-          "setValue" -> {
-            requireMutationsAllowed()
-            handleSetValue(driver, extras)
+        if (method == "listDataStores") {
+          handleListDataStores(extras)
+        } else if (method == "getDataStore") {
+          handleGetDataStore(extras)
+        } else {
+          val driver = SharedPreferencesInspector.getDriver(extras?.getString("storeName"))
+          when (method) {
+            "listFiles" -> handleListFiles(driver)
+            "getPreferences" -> handleGetPreferences(driver, extras)
+            "getPreference" -> handleGetPreference(driver, extras)
+            "setValue" -> {
+              requireMutationsAllowed()
+              handleSetValue(driver, extras)
+            }
+            "removeValue" -> {
+              requireMutationsAllowed()
+              handleRemoveValue(driver, extras)
+            }
+            "clearFile" -> {
+              requireMutationsAllowed()
+              handleClearFile(driver, extras)
+            }
+            "subscribeToFile" -> handleSubscribeToFile(driver, extras)
+            "unsubscribeFromFile" -> handleUnsubscribeFromFile(driver, extras)
+            "getChanges" -> handleGetChanges(driver, extras)
+            "getListenedFiles" -> handleGetListenedFiles(driver)
+            else -> throw IllegalArgumentException("Unknown method: $method")
           }
-          "removeValue" -> {
-            requireMutationsAllowed()
-            handleRemoveValue(driver, extras)
-          }
-          "clearFile" -> {
-            requireMutationsAllowed()
-            handleClearFile(driver, extras)
-          }
-          "subscribeToFile" -> handleSubscribeToFile(driver, extras)
-          "unsubscribeFromFile" -> handleUnsubscribeFromFile(driver, extras)
-          "getChanges" -> handleGetChanges(driver, extras)
-          "getListenedFiles" -> handleGetListenedFiles(driver)
-          else -> throw IllegalArgumentException("Unknown method: $method")
         }
       result.putBoolean("success", true)
       result.putString("result", responseJson)
@@ -103,6 +115,64 @@ class SharedPreferencesInspectorProvider : ContentProvider() {
     }
 
     return result
+  }
+
+  /**
+   * Handles listDataStores - lists the DataStore instances exposed by a registered adapter.
+   *
+   * @param extras Must contain "adapterName" string
+   * @return JSON [StorageResponse.FileList]; descriptors carry an empty path (no filesystem path is
+   *   exposed for DataStore, issue #5192)
+   */
+  private fun handleListDataStores(extras: Bundle?): String {
+    val adapterName =
+      extras?.getString("adapterName") ?: throw IllegalArgumentException("adapterName required")
+    val stores = runBlocking { DataStoreInspector.describeStores(adapterName) }
+    val protocolFiles = stores.map { store ->
+      StorageFileInfo(name = store.name, path = "", entryCount = store.entryCount)
+    }
+    return StorageProtocolSerializer.responseToJson(StorageResponse.FileList(files = protocolFiles))
+  }
+
+  /**
+   * Handles getDataStore - reads all entries from a named DataStore instance.
+   *
+   * @param extras Must contain "adapterName" and "storeName" strings
+   * @return JSON [StorageResponse.Preferences]
+   */
+  private fun handleGetDataStore(extras: Bundle?): String {
+    val adapterName =
+      extras?.getString("adapterName") ?: throw IllegalArgumentException("adapterName required")
+    val storeName =
+      extras.getString("storeName") ?: throw IllegalArgumentException("storeName required")
+    val entries = runBlocking { DataStoreInspector.readStore(adapterName, storeName) }
+    val protocolEntries = entries.map { entry ->
+      StorageEntry(
+        key = entry.key,
+        value = serializeDataStoreValue(entry.value, entry.type),
+        type = entry.type.name,
+      )
+    }
+    val file = StorageFileInfo(name = storeName, path = "", entryCount = protocolEntries.size)
+    return StorageProtocolSerializer.responseToJson(
+      StorageResponse.Preferences(file = file, entries = protocolEntries)
+    )
+  }
+
+  /** Serializes a DataStore value for wire transport, mirroring [serializeValue]. */
+  private fun serializeDataStoreValue(value: Any?, type: DataStoreValueType): String? {
+    return when {
+      value == null -> null
+      type == DataStoreValueType.STRING_SET -> {
+        @Suppress("UNCHECKED_CAST") val set = value as? Set<String> ?: return null
+        json.encodeToString(set.toList())
+      }
+      type == DataStoreValueType.BYTE_ARRAY -> {
+        val bytes = value as? ByteArray ?: return null
+        Base64.encodeToString(bytes, Base64.NO_WRAP)
+      }
+      else -> value.toString()
+    }
   }
 
   private fun requireMutationsAllowed() {

--- a/android/auto-mobile-sdk/src/main/kotlin/dev/jasonpearson/automobile/sdk/AutoMobileSDK.kt
+++ b/android/auto-mobile-sdk/src/main/kotlin/dev/jasonpearson/automobile/sdk/AutoMobileSDK.kt
@@ -42,6 +42,7 @@ import dev.jasonpearson.automobile.sdk.os.AutoMobileOsEvents
 import dev.jasonpearson.automobile.sdk.persistence.EventPersistence
 import dev.jasonpearson.automobile.sdk.persistence.FileEventPersistence
 import dev.jasonpearson.automobile.sdk.session.SessionTracker
+import dev.jasonpearson.automobile.sdk.storage.DataStoreInspector
 import dev.jasonpearson.automobile.sdk.storage.SharedPreferencesInspector
 import java.io.File
 import java.util.concurrent.CopyOnWriteArrayList
@@ -529,6 +530,10 @@ object AutoMobileSDK {
         Handler(Looper.getMainLooper()).post(teardown)
       }
     }
+
+    // Clear application-provided DataStore adapters so shutdown does not retain host references
+    // (issue #5192).
+    DataStoreInspector.reset()
 
     sessionTracker?.shutdown()
     sessionTracker = null

--- a/android/auto-mobile-sdk/src/main/kotlin/dev/jasonpearson/automobile/sdk/storage/DataStoreAdapter.kt
+++ b/android/auto-mobile-sdk/src/main/kotlin/dev/jasonpearson/automobile/sdk/storage/DataStoreAdapter.kt
@@ -1,0 +1,37 @@
+package dev.jasonpearson.automobile.sdk.storage
+
+/**
+ * Application-provided adapter that exposes DataStore-backed preferences to AutoMobile for
+ * inspection.
+ *
+ * The host application implements this interface against its own DataStore instances — typically
+ * `androidx.datastore.core.DataStore<androidx.datastore.preferences.core.Preferences>` — and
+ * registers it with [DataStoreInspector.registerAdapter]. AutoMobile never links against
+ * `androidx.datastore`; the adapter is the sole integration point, which keeps the host free to
+ * choose its DataStore version and layout.
+ *
+ * Contract rules:
+ * - **Read-only.** The interface exposes no mutation entry point. Read-only enforcement therefore
+ *   lives at the AutoMobile boundary and does not depend on the host honoring a flag.
+ * - **No filesystem paths.** Stores are identified by stable, application-chosen names; the host
+ *   must never surface `preferencesDataStoreFile` paths.
+ * - **Structured values only.** Values should map onto [DataStoreValueType]. A value whose runtime
+ *   kind is not representable should be surfaced as [DataStoreValueType.UNKNOWN] (or the adapter
+ *   may throw [DataStoreAdapterError.UnsupportedValue] to reject it).
+ * - **Suspend, cooperative cancellation.** Reads are `suspend` and must honor coroutine
+ *   cancellation. Implementations must not launch unscoped coroutines or leak listeners; any
+ *   collection should complete within the calling coroutine.
+ */
+interface DataStoreAdapter {
+  /** Returns the stable names of the DataStore instances this adapter exposes. */
+  suspend fun storeNames(): List<String>
+
+  /**
+   * Returns a structured snapshot of every entry in [storeName].
+   *
+   * @throws DataStoreAdapterError.StoreNotFound if the adapter does not expose [storeName]
+   * @throws DataStoreAdapterError.UnsupportedValue if a value cannot be represented and the adapter
+   *   chooses to reject rather than mark it [DataStoreValueType.UNKNOWN]
+   */
+  suspend fun read(storeName: String): List<DataStoreEntry>
+}

--- a/android/auto-mobile-sdk/src/main/kotlin/dev/jasonpearson/automobile/sdk/storage/DataStoreAdapterError.kt
+++ b/android/auto-mobile-sdk/src/main/kotlin/dev/jasonpearson/automobile/sdk/storage/DataStoreAdapterError.kt
@@ -1,0 +1,24 @@
+package dev.jasonpearson.automobile.sdk.storage
+
+/** Structured errors surfaced by the DataStore inspection boundary. */
+sealed class DataStoreAdapterError(message: String) : Exception(message) {
+  /** No application-provided adapter was registered under the requested name. */
+  class AdapterNotFound(name: String) : DataStoreAdapterError("DataStore adapter not found: $name")
+
+  /** The adapter does not expose a DataStore instance with the requested name. */
+  class StoreNotFound(name: String) : DataStoreAdapterError("DataStore not found: $name")
+
+  /** A read failed inside the host adapter. */
+  class ReadError(reason: String, cause: Throwable? = null) :
+    DataStoreAdapterError("DataStore read error: $reason") {
+    init {
+      if (cause != null) initCause(cause)
+    }
+  }
+
+  /** A value could not be represented by the contract's supported types. */
+  class UnsupportedValue(storeName: String, key: String, valueType: String) :
+    DataStoreAdapterError(
+      "Unsupported DataStore value for $storeName/$key: $valueType is not representable"
+    )
+}

--- a/android/auto-mobile-sdk/src/main/kotlin/dev/jasonpearson/automobile/sdk/storage/DataStoreInspector.kt
+++ b/android/auto-mobile-sdk/src/main/kotlin/dev/jasonpearson/automobile/sdk/storage/DataStoreInspector.kt
@@ -120,7 +120,10 @@ object DataStoreInspector {
       throw e
     } catch (e: CancellationException) {
       throw e
-    } catch (e: Throwable) {
+    } catch (e: Exception) {
+      // Catch Exception, not Throwable: a JVM-fatal Error (OutOfMemoryError, LinkageError,
+      // ThreadDeath) must propagate rather than be rewrapped as an ordinary ReadError.
+      // CancellationException is an Exception but is handled by its explicit branch above.
       throw DataStoreAdapterError.ReadError(e.message ?: e::class.simpleName ?: "unknown", e)
     }
 }

--- a/android/auto-mobile-sdk/src/main/kotlin/dev/jasonpearson/automobile/sdk/storage/DataStoreInspector.kt
+++ b/android/auto-mobile-sdk/src/main/kotlin/dev/jasonpearson/automobile/sdk/storage/DataStoreInspector.kt
@@ -75,8 +75,11 @@ object DataStoreInspector {
    */
   suspend fun readStore(adapterName: String, storeName: String): List<DataStoreEntry> {
     val adapter = resolve(adapterName)
-    val policy = redactionPolicy
     val entries = runAdapterRead { adapter.read(storeName) }
+    // Capture the redaction policy AFTER the (suspending) read so a policy tightened concurrently
+    // while the read was suspended is honored rather than bypassed (issue #5192 review). Snapshot
+    // once into a local so it applies uniformly across every entry (no partial application).
+    val policy = redactionPolicy
     return entries.map { entry ->
       if (policy.shouldRedact(storeName, entry.key)) {
         // Redact to a STRING marker rather than keeping the original type: a redacted

--- a/android/auto-mobile-sdk/src/main/kotlin/dev/jasonpearson/automobile/sdk/storage/DataStoreInspector.kt
+++ b/android/auto-mobile-sdk/src/main/kotlin/dev/jasonpearson/automobile/sdk/storage/DataStoreInspector.kt
@@ -79,7 +79,10 @@ object DataStoreInspector {
     val entries = runAdapterRead { adapter.read(storeName) }
     return entries.map { entry ->
       if (policy.shouldRedact(storeName, entry.key)) {
-        entry.copy(value = REDACTED_VALUE)
+        // Redact to a STRING marker rather than keeping the original type: a redacted
+        // STRING_SET/BYTE_ARRAY whose value is the marker string would otherwise serialize to
+        // null downstream and be indistinguishable from an absent value (issue #5192 review).
+        entry.copy(value = REDACTED_VALUE, type = DataStoreValueType.STRING)
       } else {
         entry
       }

--- a/android/auto-mobile-sdk/src/main/kotlin/dev/jasonpearson/automobile/sdk/storage/DataStoreInspector.kt
+++ b/android/auto-mobile-sdk/src/main/kotlin/dev/jasonpearson/automobile/sdk/storage/DataStoreInspector.kt
@@ -56,9 +56,16 @@ object DataStoreInspector {
   suspend fun describeStores(adapterName: String): List<DataStoreDescriptor> {
     val adapter = resolve(adapterName)
     val names = runAdapterRead { adapter.storeNames() }
-    return names.map { name ->
-      val entries = runAdapterRead { adapter.read(name) }
-      DataStoreDescriptor(name = name, entryCount = entries.size)
+    return names.mapNotNull { name ->
+      try {
+        val entries = runAdapterRead { adapter.read(name) }
+        DataStoreDescriptor(name = name, entryCount = entries.size)
+      } catch (_: DataStoreAdapterError.StoreNotFound) {
+        // A store removed between storeNames() and its read() is simply omitted from the
+        // listing rather than failing the whole call (issue #5192). Other read failures still
+        // propagate so a genuinely broken adapter is not silently hidden.
+        null
+      }
     }
   }
 

--- a/android/auto-mobile-sdk/src/main/kotlin/dev/jasonpearson/automobile/sdk/storage/DataStoreInspector.kt
+++ b/android/auto-mobile-sdk/src/main/kotlin/dev/jasonpearson/automobile/sdk/storage/DataStoreInspector.kt
@@ -1,0 +1,113 @@
+package dev.jasonpearson.automobile.sdk.storage
+
+import java.util.concurrent.ConcurrentHashMap
+import kotlin.coroutines.cancellation.CancellationException
+
+/**
+ * Boundary object for application-provided DataStore inspection.
+ *
+ * Mirrors the registry pattern of [SharedPreferencesInspector] and
+ * [dev.jasonpearson.automobile.sdk.database.DatabaseInspector] but targets DataStore-backed
+ * preferences via the read-only [DataStoreAdapter] contract (issue #5192).
+ *
+ * Responsibilities kept at this boundary — independent of the host adapter:
+ * - Lifecycle-safe registration, replacement, and removal of adapters.
+ * - Read-only enforcement (the contract exposes no mutation entry point).
+ * - Redaction of values via a configurable [DataStoreRedactionPolicy].
+ * - Capability reporting via [capabilities].
+ *
+ * Reads run in the caller's coroutine context, so coroutine cancellation propagates cooperatively
+ * and no background coroutines or listeners are retained by this object.
+ */
+object DataStoreInspector {
+  /** Marker substituted for a redacted value. */
+  const val REDACTED_VALUE: String = "[redacted]"
+
+  private val adapters = ConcurrentHashMap<String, DataStoreAdapter>()
+  @Volatile private var redactionPolicy: DataStoreRedactionPolicy = DataStoreRedactionPolicy.NONE
+
+  /** Registers or replaces the application-provided adapter under [name]. */
+  fun registerAdapter(name: String, adapter: DataStoreAdapter) {
+    require(name.isNotBlank()) { "adapter name must not be blank" }
+    adapters[name] = adapter
+  }
+
+  /** Removes the adapter registered under [name] and returns whether one was registered. */
+  fun unregisterAdapter(name: String): Boolean = adapters.remove(name) != null
+
+  /** Returns the names of all registered adapters. */
+  fun registeredAdapterNames(): Set<String> = adapters.keys.toSet()
+
+  /** Installs the boundary redaction policy applied to every value read. */
+  fun setRedactionPolicy(policy: DataStoreRedactionPolicy) {
+    redactionPolicy = policy
+  }
+
+  /** Returns the names of the DataStore instances exposed by adapter [adapterName]. */
+  suspend fun storeNames(adapterName: String): List<String> {
+    val adapter = resolve(adapterName)
+    return runAdapterRead { adapter.storeNames() }
+  }
+
+  /**
+   * Describes the DataStore instances exposed by adapter [adapterName], including entry counts and
+   * without exposing any filesystem path (issue #5192).
+   */
+  suspend fun describeStores(adapterName: String): List<DataStoreDescriptor> {
+    val adapter = resolve(adapterName)
+    val names = runAdapterRead { adapter.storeNames() }
+    return names.map { name ->
+      val entries = runAdapterRead { adapter.read(name) }
+      DataStoreDescriptor(name = name, entryCount = entries.size)
+    }
+  }
+
+  /**
+   * Reads [storeName] from adapter [adapterName], applying the configured redaction policy at the
+   * boundary.
+   */
+  suspend fun readStore(adapterName: String, storeName: String): List<DataStoreEntry> {
+    val adapter = resolve(adapterName)
+    val policy = redactionPolicy
+    val entries = runAdapterRead { adapter.read(storeName) }
+    return entries.map { entry ->
+      if (policy.shouldRedact(storeName, entry.key)) {
+        entry.copy(value = REDACTED_VALUE)
+      } else {
+        entry
+      }
+    }
+  }
+
+  /** Reports the capabilities of the DataStore integration at the AutoMobile boundary. */
+  fun capabilities(): DataStoreCapabilities =
+    DataStoreCapabilities(
+      readSupported = adapters.isNotEmpty(),
+      redactionEnabled = redactionPolicy !== DataStoreRedactionPolicy.NONE,
+    )
+
+  /** Clears all registered adapters and resets policy. Wired into SDK shutdown. */
+  internal fun reset() {
+    adapters.clear()
+    redactionPolicy = DataStoreRedactionPolicy.NONE
+  }
+
+  private fun resolve(adapterName: String): DataStoreAdapter =
+    adapters[adapterName] ?: throw DataStoreAdapterError.AdapterNotFound(adapterName)
+
+  /**
+   * Runs a host adapter read, letting structured [DataStoreAdapterError]s and coroutine
+   * cancellation propagate unchanged while wrapping any other host failure as a structured
+   * [DataStoreAdapterError.ReadError].
+   */
+  private inline fun <T> runAdapterRead(block: () -> T): T =
+    try {
+      block()
+    } catch (e: DataStoreAdapterError) {
+      throw e
+    } catch (e: CancellationException) {
+      throw e
+    } catch (e: Throwable) {
+      throw DataStoreAdapterError.ReadError(e.message ?: e::class.simpleName ?: "unknown", e)
+    }
+}

--- a/android/auto-mobile-sdk/src/main/kotlin/dev/jasonpearson/automobile/sdk/storage/DataStoreModels.kt
+++ b/android/auto-mobile-sdk/src/main/kotlin/dev/jasonpearson/automobile/sdk/storage/DataStoreModels.kt
@@ -1,0 +1,86 @@
+package dev.jasonpearson.automobile.sdk.storage
+
+/**
+ * Describes a named DataStore instance exposed by a [DataStoreAdapter].
+ *
+ * Deliberately carries **no filesystem path**: the AutoMobile DataStore integration identifies
+ * stores by a stable, application-chosen name so that host applications never have to expose
+ * `preferencesDataStoreFile` paths or other private data-directory locations (issue #5192).
+ */
+data class DataStoreDescriptor(
+  /** Stable, application-chosen name of the DataStore instance. */
+  val name: String,
+  /** Number of key-value entries currently held by the store. */
+  val entryCount: Int,
+)
+
+/** A single structured key-value entry read from a DataStore instance. */
+data class DataStoreEntry(
+  /** The preference key. */
+  val key: String,
+  /**
+   * The preference value, or null when the key is absent or the value was redacted away. Callers
+   * should interpret the value through [type]; an [DataStoreValueType.UNKNOWN] type marks a value
+   * whose runtime kind is not representable by the contract.
+   */
+  val value: Any?,
+  /** The structured type of [value]. */
+  val type: DataStoreValueType,
+)
+
+/**
+ * The value kinds representable by the DataStore adapter contract.
+ *
+ * Mirrors the types supported by `androidx.datastore.preferences.core.Preferences` (String, Int,
+ * Long, Float, Double, Boolean, `Set<String>`, and byte arrays). [UNKNOWN] is a structured
+ * representation for a value whose runtime kind is not one of the supported types, so an
+ * unsupported value is surfaced explicitly rather than silently dropped.
+ */
+enum class DataStoreValueType {
+  STRING,
+  INT,
+  LONG,
+  FLOAT,
+  DOUBLE,
+  BOOLEAN,
+  STRING_SET,
+  BYTE_ARRAY,
+  UNKNOWN,
+}
+
+/**
+ * Boundary-side policy deciding whether an entry's value must be redacted before it leaves the SDK.
+ *
+ * Enforced by [DataStoreInspector] independently of the host adapter, so a host implementation
+ * cannot opt out of the configured redaction policy.
+ */
+fun interface DataStoreRedactionPolicy {
+  /** Returns true when the value for [key] in [storeName] must be redacted. */
+  fun shouldRedact(storeName: String, key: String): Boolean
+
+  companion object {
+    /** A policy that never redacts. */
+    val NONE: DataStoreRedactionPolicy = DataStoreRedactionPolicy { _, _ -> false }
+  }
+}
+
+/**
+ * Machine-readable report of what the DataStore integration can do at the AutoMobile boundary.
+ *
+ * Reported independently of any host adapter so a client can reason about the contract even before
+ * an adapter is registered (issue #5192).
+ */
+data class DataStoreCapabilities(
+  /** Whether at least one application-provided adapter is registered and readable. */
+  val readSupported: Boolean,
+  /**
+   * Always false: the DataStore adapter contract is read-only and exposes no mutation entry point,
+   * so mutation is unsupported at the AutoMobile boundary regardless of the host implementation.
+   */
+  val mutationSupported: Boolean = false,
+  /** Whether a non-[DataStoreRedactionPolicy.NONE] redaction policy is currently configured. */
+  val redactionEnabled: Boolean,
+  /** The value types the contract can represent. */
+  val supportedValueTypes: List<DataStoreValueType> =
+    DataStoreValueType.entries.filter { it != DataStoreValueType.UNKNOWN },
+)

--- a/android/auto-mobile-sdk/src/test/kotlin/dev/jasonpearson/automobile/sdk/storage/DataStoreInspectorTest.kt
+++ b/android/auto-mobile-sdk/src/test/kotlin/dev/jasonpearson/automobile/sdk/storage/DataStoreInspectorTest.kt
@@ -72,6 +72,25 @@ class DataStoreInspectorTest {
     assertEquals(1, byName.getValue("flags").entryCount)
   }
 
+  // AC2 — a store that vanishes between listing and read is omitted, not fatal to the listing.
+  @Test
+  fun `describeStores omits a store that disappears mid-listing`() = runTest {
+    val adapter =
+      object : DataStoreAdapter {
+        override suspend fun storeNames() = listOf("present", "vanished")
+
+        override suspend fun read(storeName: String): List<DataStoreEntry> =
+          if (storeName == "present") listOf(DataStoreEntry("k", "v", DataStoreValueType.STRING))
+          else throw DataStoreAdapterError.StoreNotFound(storeName)
+      }
+    DataStoreInspector.registerAdapter("prefs", adapter)
+
+    val described = DataStoreInspector.describeStores("prefs")
+
+    assertEquals(listOf("present"), described.map { it.name })
+    assertEquals(1, described.single().entryCount)
+  }
+
   // AC2/AC3 — structured reads of stores, keys, values, and value types.
   @Test
   fun `reads structured entries covering all supported value types`() = runTest {

--- a/android/auto-mobile-sdk/src/test/kotlin/dev/jasonpearson/automobile/sdk/storage/DataStoreInspectorTest.kt
+++ b/android/auto-mobile-sdk/src/test/kotlin/dev/jasonpearson/automobile/sdk/storage/DataStoreInspectorTest.kt
@@ -213,6 +213,22 @@ class DataStoreInspectorTest {
     assertEquals("alice", byKey.getValue("user").value)
   }
 
+  // AC4 — redacting a typed value keeps the marker visible (STRING), not dropped downstream.
+  @Test
+  fun `redacting a typed value retypes it to STRING so the marker survives`() = runTest {
+    val adapter =
+      FakeDataStoreAdapter().apply {
+        setStore("auth", linkedMapOf("scopes" to setOf("read", "write")))
+      }
+    DataStoreInspector.registerAdapter("prefs", adapter)
+    DataStoreInspector.setRedactionPolicy { _, _ -> true }
+
+    val entry = DataStoreInspector.readStore("prefs", "auth").single()
+
+    assertEquals(DataStoreInspector.REDACTED_VALUE, entry.value)
+    assertEquals(DataStoreValueType.STRING, entry.type)
+  }
+
   // AC4 — read-only mode: the boundary reports mutation unsupported.
   @Test
   fun `capabilities report read-only and supported types`() {

--- a/android/auto-mobile-sdk/src/test/kotlin/dev/jasonpearson/automobile/sdk/storage/DataStoreInspectorTest.kt
+++ b/android/auto-mobile-sdk/src/test/kotlin/dev/jasonpearson/automobile/sdk/storage/DataStoreInspectorTest.kt
@@ -1,0 +1,279 @@
+package dev.jasonpearson.automobile.sdk.storage
+
+import kotlinx.coroutines.CompletableDeferred
+import kotlinx.coroutines.ExperimentalCoroutinesApi
+import kotlinx.coroutines.launch
+import kotlinx.coroutines.test.runTest
+import kotlinx.coroutines.yield
+import org.junit.After
+import org.junit.Assert.assertEquals
+import org.junit.Assert.assertFalse
+import org.junit.Assert.assertTrue
+import org.junit.Before
+import org.junit.Test
+
+@OptIn(ExperimentalCoroutinesApi::class)
+class DataStoreInspectorTest {
+
+  @Before
+  fun setUp() {
+    DataStoreInspector.reset()
+  }
+
+  @After
+  fun tearDown() {
+    DataStoreInspector.reset()
+  }
+
+  // AC1 — register without exposing filesystem paths.
+  @Test
+  fun `registered adapter names are reported`() {
+    DataStoreInspector.registerAdapter("settings", FakeDataStoreAdapter())
+
+    assertEquals(setOf("settings"), DataStoreInspector.registeredAdapterNames())
+  }
+
+  @Test
+  fun `register rejects blank name`() {
+    try {
+      DataStoreInspector.registerAdapter("  ", FakeDataStoreAdapter())
+      throw AssertionError("Expected IllegalArgumentException")
+    } catch (e: IllegalArgumentException) {
+      assertTrue(e.message!!.contains("blank"))
+    }
+  }
+
+  @Test
+  fun `descriptor exposes no filesystem path`() = runTest {
+    val adapter = FakeDataStoreAdapter().apply { setStore("settings", mapOf("a" to 1)) }
+    DataStoreInspector.registerAdapter("prefs", adapter)
+
+    val names = DataStoreInspector.storeNames("prefs")
+
+    assertEquals(listOf("settings"), names)
+    // DataStoreDescriptor deliberately has no `path` member; entries carry no path either.
+    val entries = DataStoreInspector.readStore("prefs", "settings")
+    assertEquals(1, entries.size)
+  }
+
+  // AC2 — stores are discoverable with entry counts and no path.
+  @Test
+  fun `describeStores reports names and entry counts`() = runTest {
+    val adapter =
+      FakeDataStoreAdapter().apply {
+        setStore("settings", mapOf("a" to 1, "b" to 2))
+        setStore("flags", mapOf("x" to true))
+      }
+    DataStoreInspector.registerAdapter("prefs", adapter)
+
+    val byName = DataStoreInspector.describeStores("prefs").associateBy { it.name }
+
+    assertEquals(2, byName.getValue("settings").entryCount)
+    assertEquals(1, byName.getValue("flags").entryCount)
+  }
+
+  // AC2/AC3 — structured reads of stores, keys, values, and value types.
+  @Test
+  fun `reads structured entries covering all supported value types`() = runTest {
+    val adapter =
+      FakeDataStoreAdapter().apply {
+        setStore(
+          "typed",
+          linkedMapOf(
+            "s" to "text",
+            "i" to 7,
+            "l" to 7L,
+            "f" to 1.5f,
+            "d" to 2.5,
+            "b" to true,
+            "set" to setOf("x", "y"),
+            "bytes" to byteArrayOf(1, 2, 3),
+          ),
+        )
+      }
+    DataStoreInspector.registerAdapter("prefs", adapter)
+
+    val byKey = DataStoreInspector.readStore("prefs", "typed").associateBy { it.key }
+
+    assertEquals(DataStoreValueType.STRING, byKey.getValue("s").type)
+    assertEquals(DataStoreValueType.INT, byKey.getValue("i").type)
+    assertEquals(DataStoreValueType.LONG, byKey.getValue("l").type)
+    assertEquals(DataStoreValueType.FLOAT, byKey.getValue("f").type)
+    assertEquals(DataStoreValueType.DOUBLE, byKey.getValue("d").type)
+    assertEquals(DataStoreValueType.BOOLEAN, byKey.getValue("b").type)
+    assertEquals(DataStoreValueType.STRING_SET, byKey.getValue("set").type)
+    assertEquals(DataStoreValueType.BYTE_ARRAY, byKey.getValue("bytes").type)
+  }
+
+  // AC3 — unsupported value types have a structured representation.
+  @Test
+  fun `unsupported value maps to UNKNOWN type`() = runTest {
+    val adapter = FakeDataStoreAdapter().apply { setStore("mixed", mapOf("weird" to Any())) }
+    DataStoreInspector.registerAdapter("prefs", adapter)
+
+    val entry = DataStoreInspector.readStore("prefs", "mixed").single()
+
+    assertEquals(DataStoreValueType.UNKNOWN, entry.type)
+  }
+
+  // AC3 — unsupported value types have a structured error when the adapter rejects them.
+  @Test
+  fun `adapter that rejects unsupported value surfaces UnsupportedValue`() = runTest {
+    val adapter =
+      FakeDataStoreAdapter().apply {
+        rejectUnsupported = true
+        setStore("mixed", mapOf("weird" to Any()))
+      }
+    DataStoreInspector.registerAdapter("prefs", adapter)
+
+    try {
+      DataStoreInspector.readStore("prefs", "mixed")
+      throw AssertionError("Expected UnsupportedValue")
+    } catch (e: DataStoreAdapterError.UnsupportedValue) {
+      assertTrue(e.message!!.contains("mixed/weird"))
+    }
+  }
+
+  // AC3 — missing adapter and missing store are structured errors.
+  @Test
+  fun `unknown adapter throws AdapterNotFound`() = runTest {
+    try {
+      DataStoreInspector.storeNames("missing")
+      throw AssertionError("Expected AdapterNotFound")
+    } catch (e: DataStoreAdapterError.AdapterNotFound) {
+      assertTrue(e.message!!.contains("missing"))
+    }
+  }
+
+  @Test
+  fun `missing store throws StoreNotFound`() = runTest {
+    DataStoreInspector.registerAdapter("prefs", FakeDataStoreAdapter())
+
+    try {
+      DataStoreInspector.readStore("prefs", "nope")
+      throw AssertionError("Expected StoreNotFound")
+    } catch (e: DataStoreAdapterError.StoreNotFound) {
+      assertTrue(e.message!!.contains("nope"))
+    }
+  }
+
+  // AC3 — a host exception during read is wrapped as a structured ReadError.
+  @Test
+  fun `host read failure is wrapped as ReadError`() = runTest {
+    val adapter =
+      object : DataStoreAdapter {
+        override suspend fun storeNames() = listOf("s")
+
+        override suspend fun read(storeName: String): List<DataStoreEntry> =
+          throw IllegalStateException("boom")
+      }
+    DataStoreInspector.registerAdapter("prefs", adapter)
+
+    try {
+      DataStoreInspector.readStore("prefs", "s")
+      throw AssertionError("Expected ReadError")
+    } catch (e: DataStoreAdapterError.ReadError) {
+      assertTrue(e.message!!.contains("boom"))
+      assertTrue(e.cause is IllegalStateException)
+    }
+  }
+
+  // AC4 — redaction is enforced at the boundary, not by the host.
+  @Test
+  fun `redaction policy redacts matching values`() = runTest {
+    val adapter =
+      FakeDataStoreAdapter().apply {
+        setStore("auth", linkedMapOf("token" to "secret", "user" to "alice"))
+      }
+    DataStoreInspector.registerAdapter("prefs", adapter)
+    DataStoreInspector.setRedactionPolicy { _, key -> key == "token" }
+
+    val byKey = DataStoreInspector.readStore("prefs", "auth").associateBy { it.key }
+
+    assertEquals(DataStoreInspector.REDACTED_VALUE, byKey.getValue("token").value)
+    assertEquals("alice", byKey.getValue("user").value)
+  }
+
+  // AC4 — read-only mode: the boundary reports mutation unsupported.
+  @Test
+  fun `capabilities report read-only and supported types`() {
+    assertFalse(DataStoreInspector.capabilities().readSupported)
+
+    DataStoreInspector.registerAdapter("prefs", FakeDataStoreAdapter())
+    val caps = DataStoreInspector.capabilities()
+
+    assertTrue(caps.readSupported)
+    assertFalse(caps.mutationSupported)
+    assertFalse(caps.redactionEnabled)
+    assertTrue(caps.supportedValueTypes.contains(DataStoreValueType.DOUBLE))
+    assertTrue(caps.supportedValueTypes.contains(DataStoreValueType.BYTE_ARRAY))
+    assertFalse(caps.supportedValueTypes.contains(DataStoreValueType.UNKNOWN))
+
+    DataStoreInspector.setRedactionPolicy { _, _ -> true }
+    assertTrue(DataStoreInspector.capabilities().redactionEnabled)
+  }
+
+  // AC5 — replacement is lifecycle-safe (last registration wins).
+  @Test
+  fun `registering same name replaces adapter`() = runTest {
+    val first = FakeDataStoreAdapter().apply { setStore("s", mapOf("k" to "one")) }
+    val second = FakeDataStoreAdapter().apply { setStore("s", mapOf("k" to "two")) }
+    DataStoreInspector.registerAdapter("prefs", first)
+    DataStoreInspector.registerAdapter("prefs", second)
+
+    assertEquals(setOf("prefs"), DataStoreInspector.registeredAdapterNames())
+    assertEquals("two", DataStoreInspector.readStore("prefs", "s").single().value)
+  }
+
+  // AC5 — removal is lifecycle-safe and idempotent.
+  @Test
+  fun `unregister returns true then false`() {
+    DataStoreInspector.registerAdapter("prefs", FakeDataStoreAdapter())
+
+    assertTrue(DataStoreInspector.unregisterAdapter("prefs"))
+    assertFalse(DataStoreInspector.unregisterAdapter("prefs"))
+    assertTrue(DataStoreInspector.registeredAdapterNames().isEmpty())
+  }
+
+  // AC5/AC7 — shutdown clears adapters and policy (no leaked references).
+  @Test
+  fun `reset clears adapters and redaction policy`() = runTest {
+    val adapter = FakeDataStoreAdapter().apply { setStore("s", mapOf("token" to "secret")) }
+    DataStoreInspector.registerAdapter("prefs", adapter)
+    DataStoreInspector.setRedactionPolicy { _, _ -> true }
+
+    DataStoreInspector.reset()
+
+    assertTrue(DataStoreInspector.registeredAdapterNames().isEmpty())
+    assertFalse(DataStoreInspector.capabilities().redactionEnabled)
+    try {
+      DataStoreInspector.storeNames("prefs")
+      throw AssertionError("Expected AdapterNotFound after reset")
+    } catch (_: DataStoreAdapterError.AdapterNotFound) {
+      // expected
+    }
+  }
+
+  // AC7 — cancellation propagates cooperatively through a suspended read.
+  @Test
+  fun `read honors coroutine cancellation`() = runTest {
+    val gate = CompletableDeferred<Unit>()
+    val adapter =
+      FakeDataStoreAdapter().apply {
+        setStore("s", mapOf("k" to "v"))
+        readGate = gate
+      }
+    DataStoreInspector.registerAdapter("prefs", adapter)
+
+    var completed = false
+    val job = launch { DataStoreInspector.readStore("prefs", "s").also { completed = true } }
+    // Let the coroutine reach the suspended read gate.
+    yield()
+    job.cancel()
+    job.join()
+
+    assertTrue(job.isCancelled)
+    assertFalse("read must not complete once cancelled", completed)
+    assertFalse(gate.isCompleted)
+  }
+}

--- a/android/auto-mobile-sdk/src/test/kotlin/dev/jasonpearson/automobile/sdk/storage/DataStoreInspectorTest.kt
+++ b/android/auto-mobile-sdk/src/test/kotlin/dev/jasonpearson/automobile/sdk/storage/DataStoreInspectorTest.kt
@@ -229,6 +229,27 @@ class DataStoreInspectorTest {
     assertEquals(DataStoreValueType.STRING, entry.type)
   }
 
+  // AC4 — a policy tightened while a read is suspended is honored, not bypassed.
+  @Test
+  fun `redaction policy tightened during a suspended read is applied`() = runTest {
+    val gate = CompletableDeferred<Unit>()
+    val adapter =
+      FakeDataStoreAdapter().apply {
+        setStore("auth", mapOf("token" to "secret"))
+        readGate = gate
+      }
+    DataStoreInspector.registerAdapter("prefs", adapter)
+
+    var result: List<DataStoreEntry>? = null
+    val job = launch { result = DataStoreInspector.readStore("prefs", "auth") }
+    yield() // park the read at the gate before any policy is set
+    DataStoreInspector.setRedactionPolicy { _, _ -> true } // tighten during the suspension
+    gate.complete(Unit)
+    job.join()
+
+    assertEquals(DataStoreInspector.REDACTED_VALUE, result!!.single().value)
+  }
+
   // AC4 — read-only mode: the boundary reports mutation unsupported.
   @Test
   fun `capabilities report read-only and supported types`() {

--- a/android/auto-mobile-sdk/src/test/kotlin/dev/jasonpearson/automobile/sdk/storage/FakeDataStoreAdapter.kt
+++ b/android/auto-mobile-sdk/src/test/kotlin/dev/jasonpearson/automobile/sdk/storage/FakeDataStoreAdapter.kt
@@ -1,0 +1,61 @@
+package dev.jasonpearson.automobile.sdk.storage
+
+import kotlinx.coroutines.CompletableDeferred
+
+/**
+ * Deterministic reference/fake implementation of [DataStoreAdapter] for tests.
+ *
+ * Backed by in-memory maps keyed by store name. Value kinds map onto [DataStoreValueType] the same
+ * way a real preferences DataStore adapter would; an unrepresentable value surfaces as
+ * [DataStoreValueType.UNKNOWN] unless [rejectUnsupported] is set, in which case the adapter throws
+ * [DataStoreAdapterError.UnsupportedValue].
+ */
+class FakeDataStoreAdapter : DataStoreAdapter {
+  private val stores = linkedMapOf<String, MutableMap<String, Any?>>()
+
+  /** When true, an unrepresentable value throws instead of mapping to UNKNOWN. */
+  var rejectUnsupported: Boolean = false
+
+  /**
+   * Optional gate a test can await to hold [read] suspended, so cancellation can be exercised
+   * deterministically. When set, [read] awaits it before returning.
+   */
+  var readGate: CompletableDeferred<Unit>? = null
+
+  /** Seeds a store with entries, replacing any existing contents. */
+  fun setStore(storeName: String, data: Map<String, Any?>) {
+    stores[storeName] = data.toMutableMap()
+  }
+
+  override suspend fun storeNames(): List<String> = stores.keys.toList()
+
+  override suspend fun read(storeName: String): List<DataStoreEntry> {
+    val data = stores[storeName] ?: throw DataStoreAdapterError.StoreNotFound(storeName)
+    readGate?.await()
+    return data.map { (key, value) ->
+      val type = detectType(value)
+      if (type == DataStoreValueType.UNKNOWN && value != null && rejectUnsupported) {
+        throw DataStoreAdapterError.UnsupportedValue(
+          storeName,
+          key,
+          value::class.simpleName ?: "unknown",
+        )
+      }
+      DataStoreEntry(key = key, value = value, type = type)
+    }
+  }
+
+  private fun detectType(value: Any?): DataStoreValueType =
+    when (value) {
+      null -> DataStoreValueType.UNKNOWN
+      is String -> DataStoreValueType.STRING
+      is Int -> DataStoreValueType.INT
+      is Long -> DataStoreValueType.LONG
+      is Float -> DataStoreValueType.FLOAT
+      is Double -> DataStoreValueType.DOUBLE
+      is Boolean -> DataStoreValueType.BOOLEAN
+      is ByteArray -> DataStoreValueType.BYTE_ARRAY
+      is Set<*> -> DataStoreValueType.STRING_SET
+      else -> DataStoreValueType.UNKNOWN
+    }
+}

--- a/android/auto-mobile-sdk/src/testDebug/kotlin/dev/jasonpearson/automobile/sdk/storage/DataStoreInspectorProviderTest.kt
+++ b/android/auto-mobile-sdk/src/testDebug/kotlin/dev/jasonpearson/automobile/sdk/storage/DataStoreInspectorProviderTest.kt
@@ -1,0 +1,137 @@
+package dev.jasonpearson.automobile.sdk.storage
+
+import android.os.Bundle
+import dev.jasonpearson.automobile.protocol.StorageProtocolSerializer
+import dev.jasonpearson.automobile.protocol.StorageResponse
+import org.junit.After
+import org.junit.Assert.assertEquals
+import org.junit.Assert.assertFalse
+import org.junit.Assert.assertTrue
+import org.junit.Before
+import org.junit.Test
+import org.junit.runner.RunWith
+import org.robolectric.RobolectricTestRunner
+
+/**
+ * Regression coverage for DataStore-backed preferences served through the existing storage
+ * inspection ContentProvider surface (issue #5192).
+ */
+@RunWith(RobolectricTestRunner::class)
+class DataStoreInspectorProviderTest {
+  private val provider = SharedPreferencesInspectorProvider()
+
+  @Before
+  fun setUp() {
+    SharedPreferencesInspector.reset()
+    DataStoreInspector.reset()
+    SharedPreferencesInspector.setEnabled(true)
+  }
+
+  @After
+  fun tearDown() {
+    SharedPreferencesInspector.reset()
+    DataStoreInspector.reset()
+  }
+
+  private fun bundleOf(vararg pairs: Pair<String, String>): Bundle =
+    Bundle().apply { pairs.forEach { (k, v) -> putString(k, v) } }
+
+  private fun successResult(bundle: Bundle): StorageResponse {
+    assertTrue(
+      "expected success, got ${bundle.getString("errorType")}: ${bundle.getString("error")}",
+      bundle.getBoolean("success"),
+    )
+    val json = bundle.getString("result") ?: throw AssertionError("no result json")
+    return StorageProtocolSerializer.responseFromJson(json)
+      ?: throw AssertionError("could not parse result: $json")
+  }
+
+  @Test
+  fun `listDataStores returns registered stores without exposing a path`() {
+    DataStoreInspector.registerAdapter(
+      "prefs",
+      FakeDataStoreAdapter().apply {
+        setStore("settings", mapOf("a" to 1, "b" to 2))
+        setStore("flags", mapOf("x" to true))
+      },
+    )
+
+    val response =
+      successResult(provider.call("listDataStores", null, bundleOf("adapterName" to "prefs")))
+
+    val fileList = response as StorageResponse.FileList
+    val byName = fileList.files.associateBy { it.name }
+    assertEquals(setOf("settings", "flags"), byName.keys)
+    assertEquals(2, byName.getValue("settings").entryCount)
+    assertEquals("", byName.getValue("settings").path)
+  }
+
+  @Test
+  fun `getDataStore returns structured entries with types`() {
+    DataStoreInspector.registerAdapter(
+      "prefs",
+      FakeDataStoreAdapter().apply {
+        setStore("settings", linkedMapOf("name" to "alice", "count" to 3, "flag" to true))
+      },
+    )
+
+    val response =
+      successResult(
+        provider.call(
+          "getDataStore",
+          null,
+          bundleOf("adapterName" to "prefs", "storeName" to "settings"),
+        )
+      )
+
+    val prefs = response as StorageResponse.Preferences
+    val byKey = prefs.entries.associateBy { it.key }
+    assertEquals("alice", byKey.getValue("name").value)
+    assertEquals("STRING", byKey.getValue("name").type)
+    assertEquals("3", byKey.getValue("count").value)
+    assertEquals("INT", byKey.getValue("count").type)
+    assertEquals("BOOLEAN", byKey.getValue("flag").type)
+  }
+
+  @Test
+  fun `getDataStore applies the boundary redaction policy`() {
+    DataStoreInspector.registerAdapter(
+      "prefs",
+      FakeDataStoreAdapter().apply {
+        setStore("auth", linkedMapOf("token" to "secret", "user" to "alice"))
+      },
+    )
+    DataStoreInspector.setRedactionPolicy { _, key -> key == "token" }
+
+    val response =
+      successResult(
+        provider.call(
+          "getDataStore",
+          null,
+          bundleOf("adapterName" to "prefs", "storeName" to "auth"),
+        )
+      )
+
+    val byKey = (response as StorageResponse.Preferences).entries.associateBy { it.key }
+    assertEquals(DataStoreInspector.REDACTED_VALUE, byKey.getValue("token").value)
+    assertEquals("alice", byKey.getValue("user").value)
+  }
+
+  @Test
+  fun `unknown adapter reports a structured error`() {
+    val bundle = provider.call("listDataStores", null, bundleOf("adapterName" to "missing"))
+
+    assertFalse(bundle.getBoolean("success"))
+    assertEquals("AdapterNotFound", bundle.getString("errorType"))
+  }
+
+  @Test
+  fun `datastore methods are rejected when inspection is disabled`() {
+    SharedPreferencesInspector.setEnabled(false)
+
+    val bundle = provider.call("listDataStores", null, bundleOf("adapterName" to "prefs"))
+
+    assertFalse(bundle.getBoolean("success"))
+    assertEquals("DISABLED", bundle.getString("errorType"))
+  }
+}

--- a/android/auto-mobile-sdk/src/testDebug/kotlin/dev/jasonpearson/automobile/sdk/storage/DataStoreInspectorProviderTest.kt
+++ b/android/auto-mobile-sdk/src/testDebug/kotlin/dev/jasonpearson/automobile/sdk/storage/DataStoreInspectorProviderTest.kt
@@ -94,6 +94,35 @@ class DataStoreInspectorProviderTest {
   }
 
   @Test
+  fun `getDataStore serializes string-set and byte-array values for the wire`() {
+    DataStoreInspector.registerAdapter(
+      "prefs",
+      FakeDataStoreAdapter().apply {
+        setStore(
+          "typed",
+          linkedMapOf("tags" to setOf("a", "b"), "blob" to byteArrayOf(1, 2, 3)),
+        )
+      },
+    )
+
+    val response =
+      successResult(
+        provider.call(
+          "getDataStore",
+          null,
+          bundleOf("adapterName" to "prefs", "storeName" to "typed"),
+        )
+      )
+
+    val byKey = (response as StorageResponse.Preferences).entries.associateBy { it.key }
+    assertEquals("STRING_SET", byKey.getValue("tags").type)
+    assertEquals("[\"a\",\"b\"]", byKey.getValue("tags").value)
+    assertEquals("BYTE_ARRAY", byKey.getValue("blob").type)
+    // android.util.Base64.NO_WRAP encoding of {1,2,3}.
+    assertEquals("AQID", byKey.getValue("blob").value)
+  }
+
+  @Test
   fun `getDataStore applies the boundary redaction policy`() {
     DataStoreInspector.registerAdapter(
       "prefs",

--- a/docs/design-docs/plat/android/auto-mobile-sdk.md
+++ b/docs/design-docs/plat/android/auto-mobile-sdk.md
@@ -310,6 +310,43 @@ Provides SharedPreferences read access for debug builds. Same enable/disable pat
 
 Both inspectors follow the pattern: `initialize(context)` at SDK init, `setEnabled(true)` in debug builds, lazy driver creation on first access.
 
+### DataStore Inspection (`DataStoreInspector`)
+
+Storage inspection is otherwise blind to applications that keep preferences in [Jetpack DataStore](https://developer.android.com/topic/libraries/architecture/datastore) rather than conventional `SharedPreferences` files. `DataStoreInspector` closes that gap with an explicit, read-only, application-provided adapter contract so DataStore state is inspected through a documented interface instead of by inferring it from implementation-specific files (#5192).
+
+**Integration contract.** The host implements `DataStoreAdapter` against its own DataStore instances — typically `androidx.datastore.core.DataStore<androidx.datastore.preferences.core.Preferences>` — and registers it under a stable name:
+
+```kotlin
+class AppDataStoreAdapter(
+  private val stores: Map<String, DataStore<Preferences>>,
+) : DataStoreAdapter {
+  override suspend fun storeNames(): List<String> = stores.keys.toList()
+
+  override suspend fun read(storeName: String): List<DataStoreEntry> {
+    val store = stores[storeName] ?: throw DataStoreAdapterError.StoreNotFound(storeName)
+    return store.data.first().asMap().map { (key, value) ->
+      DataStoreEntry(key.name, value, value.toDataStoreValueType())
+    }
+  }
+}
+
+if (BuildConfig.DEBUG) {
+  SharedPreferencesInspector.setEnabled(true) // shared storage-surface enable switch
+  DataStoreInspector.registerAdapter("app", AppDataStoreAdapter(stores))
+}
+```
+
+DataStore-backed preferences are then discoverable and readable through the existing storage `ContentProvider` (`listDataStores`, `getDataStore`), reusing the same `StorageResponse` shapes as SharedPreferences. Stores are identified by name only — **no filesystem path is ever exposed** — and served via `adb shell content call ... --method getDataStore --extra adapterName:s:app --extra storeName:s:settings`.
+
+**Boundary guarantees** (enforced by `DataStoreInspector`, independent of the host adapter):
+
+- **Read-only.** The `DataStoreAdapter` contract exposes no mutation entry point, so mutation is structurally unsupported; `capabilities().mutationSupported` is always `false`.
+- **Redaction.** A configurable `DataStoreRedactionPolicy` (`setRedactionPolicy`) redacts matching values at the boundary before they leave the SDK; a host adapter cannot opt out.
+- **Structured values and errors.** Values map onto `DataStoreValueType` (String, Int, Long, Float, Double, Boolean, `Set<String>`, byte array); an unrepresentable value is surfaced as `UNKNOWN` or rejected with `DataStoreAdapterError.UnsupportedValue`. Missing adapters/stores and host read failures surface as `AdapterNotFound`, `StoreNotFound`, and `ReadError`.
+- **Lifecycle-safe.** Registration replaces by name, `unregisterAdapter` returns whether one was removed, and `AutoMobileSDK.shutdown()` clears all adapters. Reads run in the caller's coroutine context, so cancellation propagates cooperatively and no background coroutines or listeners are retained.
+
+**Limitations.** Read-only by design (no writes). Change subscriptions/listeners are not part of the contract (unlike `SharedPreferencesInspector`) — reads are point-in-time snapshots. Value redaction operates per key/store name, not on nested structured values. The SDK never links against `androidx.datastore`; representing values is the host adapter's responsibility.
+
 | Component | Description | Status |
 |-----------|-------------|--------|
 | `DatabaseInspector` | SQLite database access with lazy driver and enable/disable gating | <kbd>✅ Implemented</kbd> |
@@ -318,6 +355,8 @@ Both inspectors follow the pattern: `initialize(context)` at SDK init, `setEnabl
 | `SharedPreferencesInspector` | SharedPreferences access with lazy driver and enable/disable gating | <kbd>✅ Implemented</kbd> |
 | `SharedPreferencesDriverImpl` | SharedPreferences driver with change listeners | <kbd>✅ Implemented</kbd> |
 | `SharedPreferencesDriver` | Interface for testability | <kbd>✅ Implemented</kbd> |
+| `DataStoreInspector` | Read-only DataStore access via app-provided adapters, boundary redaction, and capability reporting | <kbd>✅ Implemented</kbd> |
+| `DataStoreAdapter` | Application-provided read-only DataStore integration contract | <kbd>✅ Implemented</kbd> |
 
 ## 12. Compose Recomposition Tracking
 

--- a/docs/design-docs/plat/android/auto-mobile-sdk.md
+++ b/docs/design-docs/plat/android/auto-mobile-sdk.md
@@ -325,9 +325,22 @@ class AppDataStoreAdapter(
   override suspend fun read(storeName: String): List<DataStoreEntry> {
     val store = stores[storeName] ?: throw DataStoreAdapterError.StoreNotFound(storeName)
     return store.data.first().asMap().map { (key, value) ->
-      DataStoreEntry(key.name, value, value.toDataStoreValueType())
+      DataStoreEntry(key.name, value, valueTypeOf(value))
     }
   }
+
+  private fun valueTypeOf(value: Any?): DataStoreValueType =
+    when (value) {
+      is String -> DataStoreValueType.STRING
+      is Int -> DataStoreValueType.INT
+      is Long -> DataStoreValueType.LONG
+      is Float -> DataStoreValueType.FLOAT
+      is Double -> DataStoreValueType.DOUBLE
+      is Boolean -> DataStoreValueType.BOOLEAN
+      is Set<*> -> DataStoreValueType.STRING_SET
+      is ByteArray -> DataStoreValueType.BYTE_ARRAY
+      else -> DataStoreValueType.UNKNOWN
+    }
 }
 
 if (BuildConfig.DEBUG) {


### PR DESCRIPTION
## Summary

Adds an application-provided **DataStore storage adapter** so AutoMobile's storage inspection covers apps that keep preferences in [Jetpack DataStore](https://developer.android.com/topic/libraries/architecture/datastore) rather than conventional `SharedPreferences` files. Previously DataStore state could only be inferred from implementation-specific files; this introduces an explicit, read-only, lifecycle-safe adapter contract instead.

The SDK never links against `androidx.datastore` — the host implements `DataStoreAdapter` against its own DataStore instances and registers it by a stable name. Read-only enforcement, redaction, and capability reporting all live at the AutoMobile boundary, independent of the host implementation.

## Linked Issue

Progresses #5192 — delivers the SDK-side DataStore adapter contract and the debug `ContentProvider` surface. Full end-to-end reach through the MCP tool → CtrlProxy → provider chain is tracked in #5573 (it requires runner-protocol wiring + an Android control-proxy release re-cut). #5192 stays open until #5573 lands.

## Changes

- **`DataStoreAdapter`** — host-provided, read-only integration contract (`suspend storeNames()` / `read()`); no filesystem paths, no mutation entry point, cooperative cancellation.
- **`DataStoreInspector`** — lifecycle-safe registry (register/replace/`unregisterAdapter`/`reset`) with boundary-enforced read-only mode, a configurable `DataStoreRedactionPolicy`, and `capabilities()` reporting. `reset()` wired into `AutoMobileSDK.shutdown()`.
- **Structured models & errors** — `DataStoreDescriptor` (name + entryCount, no path), `DataStoreEntry`, `DataStoreValueType` (incl. `DOUBLE`, `BYTE_ARRAY`, `UNKNOWN`); `AdapterNotFound` / `StoreNotFound` / `ReadError` / `UnsupportedValue`.
- **Existing surface wiring** — `listDataStores` / `getDataStore` added to the debug storage `ContentProvider`, reusing the existing `StorageResponse` shapes (no shared/runner protocol change; path emitted empty).
- **`FakeDataStoreAdapter`** reference/fake for deterministic tests.
- **Docs** — DataStore integration contract and limitations in the Android SDK design doc.

## Validation

- [x] Android changes: ran the matching `scripts/` validation (`scripts/ktfmt/validate_ktfmt.sh` clean tree-wide)
- [x] `:auto-mobile-sdk:testDebugUnitTest` full module suite green; `:auto-mobile-sdk:detekt` green
- [x] New code uses interfaces + fakes; unit tests run in <100ms
- [x] No new dependency (adapter is a pure host-provided contract)
- [ ] TypeScript checks N/A — no TS/schema surfaces touched

## Kotlin Reuse Check

- [x] Mirrors the existing `SharedPreferencesInspector` / `DatabaseInspector` registry pattern and reuses existing `StorageResponse` protocol types rather than adding new ones; no new helpers/`*Util` files or dependencies.
- [x] Read-only by contract: the interface exposes no mutation method, so read-only is structural rather than a flag the host must honor.

## Acceptance Criteria

- [x] Host can register a DataStore adapter without exposing filesystem paths (`DataStoreDescriptor` has no path member).
- [~] DataStore-backed preferences discoverable & readable through the storage **ContentProvider** surface (`listDataStores`/`getDataStore`, via `adb shell content call`). End-to-end MCP/CtrlProxy reach deferred to #5573.
- [x] Stores, keys, values, and unsupported value types have structured representations and errors.
- [x] Read-only mode and configured redaction enforced at the AutoMobile boundary.
- [x] Registration, replacement, and removal are lifecycle-safe; no leaked listeners/coroutines (reads run in caller context; `shutdown()` clears adapters).
- [x] Documentation covers the integration contract and limitations.
- [x] Tests cover a preferences DataStore fake, missing stores, malformed values, shutdown, and cancellation.


## Follow-ups

- #5573 — expose the DataStore adapter through the end-to-end MCP storage surface (runner wiring + release re-cut).
