### PR TITLE
feat(desktop): screen-streaming quality controls + client-side auto-adjustment

### DIFF
--- a/android/desktop-app/src/main/kotlin/dev/jasonpearson/automobile/desktop/AutoMobileDesktopApp.kt
+++ b/android/desktop-app/src/main/kotlin/dev/jasonpearson/automobile/desktop/AutoMobileDesktopApp.kt
@@ -496,6 +496,9 @@ fun AutoMobileDesktopApp(
                   sessionUuidProvider = desktopDaemonSession?.sessionUuidProvider ?: { null },
                   enableDeviceControl = controlActive,
                   control = control,
+                  // Wires the per-pane quality overlay (manual Low/Medium/High + live FPS +
+                  // auto-adjust) and persists the choice across sessions.
+                  settings = settings,
                 )
               },
             )

--- a/android/desktop-core/src/main/kotlin/dev/jasonpearson/automobile/desktop/core/settings/FakeSettingsProvider.kt
+++ b/android/desktop-core/src/main/kotlin/dev/jasonpearson/automobile/desktop/core/settings/FakeSettingsProvider.kt
@@ -11,4 +11,6 @@ class FakeSettingsProvider(
   override var iosIde: String = "auto",
   override var themeMode: String = "dark",
   override var hasSeenOnboarding: Boolean = false,
+  override var streamQualityPreset: String = "medium",
+  override var streamQualityAutoAdjust: Boolean = true,
 ) : SettingsProvider

--- a/android/desktop-core/src/main/kotlin/dev/jasonpearson/automobile/desktop/core/settings/FileSettingsProvider.kt
+++ b/android/desktop-core/src/main/kotlin/dev/jasonpearson/automobile/desktop/core/settings/FileSettingsProvider.kt
@@ -132,6 +132,14 @@ class FileSettingsProvider(private val file: File = defaultSettingsFile()) : Set
     get() = boolean(KEY_HAS_SEEN_ONBOARDING, false)
     set(value) = put(KEY_HAS_SEEN_ONBOARDING, value)
 
+  override var streamQualityPreset: String
+    get() = string(KEY_STREAM_QUALITY_PRESET, "medium")
+    set(value) = put(KEY_STREAM_QUALITY_PRESET, value)
+
+  override var streamQualityAutoAdjust: Boolean
+    get() = boolean(KEY_STREAM_QUALITY_AUTO_ADJUST, true)
+    set(value) = put(KEY_STREAM_QUALITY_AUTO_ADJUST, value)
+
   companion object {
     private const val SETTINGS_DIR = ".auto-mobile"
     private const val SETTINGS_FILE = "desktop-settings.properties"
@@ -145,6 +153,8 @@ class FileSettingsProvider(private val file: File = defaultSettingsFile()) : Set
     private const val KEY_IOS_IDE = "iosIde"
     private const val KEY_THEME_MODE = "themeMode"
     private const val KEY_HAS_SEEN_ONBOARDING = "hasSeenOnboarding"
+    private const val KEY_STREAM_QUALITY_PRESET = "streamQualityPreset"
+    private const val KEY_STREAM_QUALITY_AUTO_ADJUST = "streamQualityAutoAdjust"
 
     /** Resolves `~/.auto-mobile/desktop-settings.properties`, matching `AutoMobileSocketPaths`. */
     fun defaultSettingsFile(): File {

--- a/android/desktop-core/src/main/kotlin/dev/jasonpearson/automobile/desktop/core/settings/SettingsProvider.kt
+++ b/android/desktop-core/src/main/kotlin/dev/jasonpearson/automobile/desktop/core/settings/SettingsProvider.kt
@@ -15,4 +15,8 @@ interface SettingsProvider {
   var themeMode: String
   /** Whether the first-run onboarding has been dismissed. */
   var hasSeenOnboarding: Boolean
+  /** Live-mirror quality preset: "low", "medium", or "high". */
+  var streamQualityPreset: String
+  /** Whether the live mirror lowers/raises its quality preset automatically on frame drops. */
+  var streamQualityAutoAdjust: Boolean
 }

--- a/android/desktop-core/src/main/kotlin/dev/jasonpearson/automobile/desktop/core/video/QualityController.kt
+++ b/android/desktop-core/src/main/kotlin/dev/jasonpearson/automobile/desktop/core/video/QualityController.kt
@@ -125,12 +125,18 @@ class QualityController(
     maybeAdjust(receivedAtMs)
   }
 
-  /** Applies an explicit user choice, re-seeding the rate window so the manual pick sticks. */
+  /**
+   * Applies an explicit user choice, re-seeding the rate window so the manual pick sticks. Persists
+   * unconditionally: the user's explicit choice must be written even when it equals the *current*
+   * preset, because that preset may have been set by an automatic step while the persisted value
+   * still differs — otherwise picking the already-highlighted chip would silently fail to persist.
+   * The state change / re-subscribe is skipped when nothing actually changes.
+   */
   fun selectQuality(quality: VideoStreamQuality) {
+    onManualSelection(quality)
     if (_quality.value == quality) return
     _quality.value = quality
     resetRateWindow()
-    onManualSelection(quality)
   }
 
   /**

--- a/android/desktop-core/src/main/kotlin/dev/jasonpearson/automobile/desktop/core/video/QualityController.kt
+++ b/android/desktop-core/src/main/kotlin/dev/jasonpearson/automobile/desktop/core/video/QualityController.kt
@@ -57,6 +57,14 @@ class QualityController(
   /** Minimum frame-time spacing between two automatic changes. */
   private val minDwellMs: Long = 2_000,
   /**
+   * A gap longer than this is treated as a stream discontinuity, not a slow frame, and re-seeds the
+   * rate instead of folding in one implausibly-low sample. This is what keeps a source that omits
+   * idle buffers (iOS ScreenCaptureKit drops frames on a static screen) from reading as a drop when
+   * activity resumes; it comfortably exceeds the interval of the slowest real target (10fps =
+   * 100ms).
+   */
+  private val idleGapMs: Long = 1_000,
+  /**
    * Notified only for an explicit [selectQuality] (a user's manual pick), for persistence.
    * Automatic steps update [quality] (so the pane re-subscribes and the overlay updates) but do not
    * notify.
@@ -87,6 +95,14 @@ class QualityController(
 
     val dt = receivedAtMs - previous
     if (dt <= 0L) return // out-of-order / duplicate timestamp: ignore rather than divide by zero.
+    if (dt > idleGapMs) {
+      // Stream discontinuity (idle-buffer suppression on a static screen, or a reconnect): the next
+      // frame re-seeds the EMA from here rather than this gap being scored as a ~0fps sample.
+      samples = 0
+      lowStreak = 0
+      highStreak = 0
+      return
+    }
 
     val instant = 1000f / dt
     val ema = _actualFps.value

--- a/android/desktop-core/src/main/kotlin/dev/jasonpearson/automobile/desktop/core/video/QualityController.kt
+++ b/android/desktop-core/src/main/kotlin/dev/jasonpearson/automobile/desktop/core/video/QualityController.kt
@@ -31,6 +31,14 @@ import kotlinx.coroutines.flow.StateFlow
  *   [samplesToDowngrade]/[samplesToUpgrade] (hysteresis) plus [minDwellMs] then keep a brief dip or
  *   a flapping rate from thrashing the encode.
  *
+ * **Known limit:** a *severe* sustained drop (roughly ≤ the idle cadence, ~11fps or below) is
+ * indistinguishable from a static screen by inter-frame timing alone, so it lands in the idle band
+ * and is not auto-downgraded — the deliberate safe choice (never degrade a still screen) over
+ * downgrading every idle screen. Auto-adjust therefore covers the common moderate-degradation band
+ * (~12fps up to target); catching severe drops needs a signal timing cannot supply — the on-device
+ * `VideoStatsAccumulator` dropped-frame count plumbed to the client, or content-change detection —
+ * tracked as a follow-up.
+ *
  * The displayed [actualFps] is computed as frames-over-elapsed across a trailing [rateWindowMs]
  * window — an unbiased rate. (Averaging instantaneous `1000/dt` values would overstate throughput
  * for unevenly-arriving frames, e.g. alternating 10ms/90ms gaps are 20fps but average to ~50fps.)
@@ -87,15 +95,28 @@ class QualityController(
   private val _actualFps = MutableStateFlow(0f)
   val actualFps: StateFlow<Float> = _actualFps
 
-  /** Whether frame-rate drops drive automatic preset changes. FPS is measured regardless. */
-  var autoAdjustEnabled: Boolean = autoAdjustEnabled
-
   // Trailing timestamps for the displayed rate (frames ÷ elapsed over rateWindowMs).
   private val window = ArrayDeque<Long>()
   private var lastFrameMs: Long? = null
   private var samples = 0
   private var lowStreak = 0
   private var highStreak = 0
+
+  /**
+   * Whether frame-rate drops drive automatic preset changes. FPS is measured regardless. Toggling
+   * clears the decision streaks so a re-enable cannot complete a stale pre-disable streak on its
+   * first frame and downgrade on history from before Auto was off.
+   */
+  var autoAdjustEnabled: Boolean = autoAdjustEnabled
+    set(value) {
+      if (value != field) {
+        samples = 0
+        lowStreak = 0
+        highStreak = 0
+      }
+      field = value
+    }
+
   // Null until the first change, so the first decision is never gated by dwell (and no overflow).
   private var lastChangeAtMs: Long? = null
 

--- a/android/desktop-core/src/main/kotlin/dev/jasonpearson/automobile/desktop/core/video/QualityController.kt
+++ b/android/desktop-core/src/main/kotlin/dev/jasonpearson/automobile/desktop/core/video/QualityController.kt
@@ -1,0 +1,132 @@
+package dev.jasonpearson.automobile.desktop.core.video
+
+import kotlinx.coroutines.flow.MutableStateFlow
+import kotlinx.coroutines.flow.StateFlow
+
+/**
+ * Client-side quality controller for the live device mirror.
+ *
+ * The desktop relay fixes a capture's encode at subscribe time — there is no mid-stream control
+ * channel and the first subscriber's preset wins for a shared capture (see [VideoStreamQuality] and
+ * the screen-streaming design doc). So this controller does the *decision* half of adaptive
+ * quality: it derives the actual frame rate from the timestamps of decoded frames ([onFrame]) and,
+ * when [autoAdjustEnabled] is on, picks a lower preset when the rate is chronically dropping and a
+ * higher one once it is sustainably healthy. The pane applies a change by re-subscribing with the
+ * new preset (which takes effect for a sole subscriber / the next subscribe); truly reconfiguring a
+ * live shared capture is a server-side follow-up.
+ *
+ * Frame timestamps are the only clock, so decisions are deterministic and unit-testable without a
+ * FakeTimer. The rate is an exponential moving average of the instantaneous inter-frame rate, so a
+ * single late frame perturbs it briefly rather than smearing across a whole window; hysteresis
+ * ([samplesToDowngrade]/[samplesToUpgrade]) plus [minDwellMs] then keep a brief dip or a flapping
+ * rate from thrashing the encode.
+ *
+ * @property targetFps the rate the pane asked the relay for; a drop is measured relative to it.
+ */
+class QualityController(
+  initialQuality: VideoStreamQuality,
+  val targetFps: Int,
+  autoAdjustEnabled: Boolean = true,
+  /**
+   * Smoothing factor for the inter-frame rate EMA (0..1); higher reacts faster, lower is calmer.
+   */
+  private val smoothing: Double = 0.2,
+  /** Inter-frame samples needed before any decision, so an early estimate can't misfire. */
+  private val minSamplesForDecision: Int = 5,
+  /** Below this fraction of [targetFps] a sample counts as dropping. */
+  private val downgradeRatio: Double = 0.8,
+  /** At or above this fraction of [targetFps] a sample counts as healthy. */
+  private val upgradeRatio: Double = 0.95,
+  /** Consecutive dropping samples required before a downgrade (hysteresis). */
+  private val samplesToDowngrade: Int = 3,
+  /**
+   * Consecutive healthy samples required before an upgrade — larger, so quality climbs cautiously.
+   */
+  private val samplesToUpgrade: Int = 8,
+  /** Minimum frame-time spacing between two automatic changes. */
+  private val minDwellMs: Long = 2_000,
+  /**
+   * Notified when the effective quality changes (manual or automatic), for persistence/resubscribe.
+   */
+  private val onQualityChange: (VideoStreamQuality) -> Unit = {},
+) {
+  private val _quality = MutableStateFlow(initialQuality)
+  val quality: StateFlow<VideoStreamQuality> = _quality
+
+  private val _actualFps = MutableStateFlow(0f)
+  val actualFps: StateFlow<Float> = _actualFps
+
+  /** Whether frame-rate drops drive automatic preset changes. FPS is measured regardless. */
+  var autoAdjustEnabled: Boolean = autoAdjustEnabled
+
+  private var lastFrameMs: Long? = null
+  private var samples = 0
+  private var lowStreak = 0
+  private var highStreak = 0
+  // Null until the first change, so the first decision is never gated by dwell (and no overflow).
+  private var lastChangeAtMs: Long? = null
+
+  /** Records a decoded frame's arrival time, updates the live rate, and maybe adjusts quality. */
+  fun onFrame(receivedAtMs: Long) {
+    val previous = lastFrameMs
+    lastFrameMs = receivedAtMs
+    if (previous == null) return // first frame: no interval yet, rate stays 0.
+
+    val dt = receivedAtMs - previous
+    if (dt <= 0L) return // out-of-order / duplicate timestamp: ignore rather than divide by zero.
+
+    val instant = 1000f / dt
+    val ema = _actualFps.value
+    _actualFps.value =
+      if (samples == 0) instant else (smoothing * instant + (1 - smoothing) * ema).toFloat()
+    samples++
+
+    if (!autoAdjustEnabled || samples < minSamplesForDecision) return
+    evaluate(_actualFps.value, receivedAtMs)
+  }
+
+  /** Applies an explicit user choice, resetting hysteresis so the manual pick sticks. */
+  fun selectQuality(quality: VideoStreamQuality) {
+    if (_quality.value == quality) return
+    _quality.value = quality
+    lowStreak = 0
+    highStreak = 0
+    onQualityChange(quality)
+  }
+
+  private fun evaluate(fps: Float, nowMs: Long) {
+    when {
+      fps < downgradeRatio * targetFps -> {
+        lowStreak++
+        highStreak = 0
+      }
+      fps >= upgradeRatio * targetFps -> {
+        highStreak++
+        lowStreak = 0
+      }
+      // Dead-zone between the two ratios: neither dropping nor clearly healthy — hold and reset,
+      // which is what gives the hysteresis its gap and stops boundary flapping.
+      else -> {
+        lowStreak = 0
+        highStreak = 0
+      }
+    }
+
+    val dwellElapsed = lastChangeAtMs?.let { nowMs - it >= minDwellMs } ?: true
+    if (!dwellElapsed) return
+
+    if (lowStreak >= samplesToDowngrade && _quality.value != VideoStreamQuality.Low) {
+      change(_quality.value.lower(), nowMs)
+    } else if (highStreak >= samplesToUpgrade && _quality.value != VideoStreamQuality.High) {
+      change(_quality.value.higher(), nowMs)
+    }
+  }
+
+  private fun change(quality: VideoStreamQuality, nowMs: Long) {
+    _quality.value = quality
+    lastChangeAtMs = nowMs
+    lowStreak = 0
+    highStreak = 0
+    onQualityChange(quality)
+  }
+}

--- a/android/desktop-core/src/main/kotlin/dev/jasonpearson/automobile/desktop/core/video/QualityController.kt
+++ b/android/desktop-core/src/main/kotlin/dev/jasonpearson/automobile/desktop/core/video/QualityController.kt
@@ -9,28 +9,39 @@ import kotlinx.coroutines.flow.StateFlow
  * The desktop relay fixes a capture's encode at subscribe time — there is no mid-stream control
  * channel and the first subscriber's preset wins for a shared capture (see [VideoStreamQuality] and
  * the screen-streaming design doc). So this controller does the *decision* half of adaptive
- * quality: it derives the actual frame rate from the timestamps of decoded frames ([onFrame]) and,
- * when [autoAdjustEnabled] is on, picks a lower preset when the rate is chronically dropping and a
- * higher one once it is sustainably healthy. The pane applies a change by re-subscribing with the
- * new preset (which takes effect for a sole subscriber / the next subscribe); truly reconfiguring a
- * live shared capture is a server-side follow-up.
+ * quality: it derives the delivered frame rate from the timestamps of decoded frames ([onFrame])
+ * and, when [autoAdjustEnabled] is on, picks a lower preset when the stream is chronically slow
+ * *while actively delivering frames* and a higher one once it is sustainably at target. The pane
+ * applies a change by re-subscribing with the new preset (which takes effect for a sole subscriber
+ * / the next subscribe); truly reconfiguring a live shared capture is a server-side follow-up.
  *
- * Frame timestamps are the only clock, so decisions are deterministic and unit-testable without a
- * FakeTimer. The rate is an exponential moving average of the instantaneous inter-frame rate, so a
- * single late frame perturbs it briefly rather than smearing across a whole window; hysteresis
- * ([samplesToDowngrade]/[samplesToUpgrade]) plus [minDwellMs] then keep a brief dip or a flapping
- * rate from thrashing the encode. Every preset change (manual or automatic) also resets the rate
- * window, so the reconnect gap that a re-subscribe introduces re-seeds cleanly instead of being
- * counted as one implausibly-slow frame that biases the next decision.
+ * ### Why frame timing alone is read carefully
+ * A raw "frames per second below target" signal is confounded by how each platform handles a static
+ * screen, which is the common case for UI automation (mostly still frames):
+ * - Android's encoder *repeats* the previous frame after ~100ms of no change
+ *   (`VideoEncoder.KEY_REPEAT_PREVIOUS_FRAME_AFTER`), so a still screen streams at ~10fps.
+ * - iOS ScreenCaptureKit *suppresses* idle buffers, so a still screen makes no frame progress until
+ *   it changes. Neither is encoder/transport degradation, so neither should downgrade quality. This
+ *   controller therefore classifies each inter-frame interval rather than trusting an fps number:
+ * - `dt` at/under the target interval → **healthy**;
+ * - `dt` between the target interval and [idleIntervalMs] → **active but slow** (genuine
+ *   degradation the encode can plausibly recover from by dropping resolution);
+ * - `dt` at/over [idleIntervalMs] → **idle**, i.e. consistent with a static screen (Android repeat
+ *   cadence) or a suppression/reconnect gap → no signal, streaks reset.
+ *   [samplesToDowngrade]/[samplesToUpgrade] (hysteresis) plus [minDwellMs] then keep a brief dip or
+ *   a flapping rate from thrashing the encode.
  *
- * The rate is measured over the frames the pane actually renders (the caller feeds [onFrame] from
- * its render path), so under a UI that recomposes slower than frames decode it reflects render
- * cadence rather than raw decode rate — an acceptable proxy at the 10–30fps targets here.
+ * The displayed [actualFps] is computed as frames-over-elapsed across a trailing [rateWindowMs]
+ * window — an unbiased rate. (Averaging instantaneous `1000/dt` values would overstate throughput
+ * for unevenly-arriving frames, e.g. alternating 10ms/90ms gaps are 20fps but average to ~50fps.)
+ * That rate reflects the frames the pane actually renders (the caller feeds [onFrame] from its
+ * render path), an acceptable proxy for the decode rate at the 10–30fps targets here.
  *
- * [onManualSelection] fires only for an explicit [selectQuality]; automatic steps deliberately do
- * NOT notify, so the caller persists the user's chosen preset without writing the settings file on
- * every transient auto-adjust (and without persisting a shared-capture ratchet-to-Low the stream
- * never actually applied).
+ * Frame timestamps are the only clock, so every decision is deterministic and unit-testable without
+ * a FakeTimer. [onManualSelection] fires only for an explicit [selectQuality]; automatic steps
+ * update [quality] (so the pane re-subscribes and the overlay updates) but do NOT notify, so the
+ * caller persists only the user's chosen preset — never a transient auto-step or a shared-capture
+ * ratchet the stream did not actually apply.
  *
  * @property targetFps the rate the pane asked the relay for; a drop is measured relative to it.
  */
@@ -38,13 +49,20 @@ class QualityController(
   initialQuality: VideoStreamQuality,
   val targetFps: Int,
   autoAdjustEnabled: Boolean = true,
+  /** Trailing window the displayed [actualFps] is averaged over (frames ÷ elapsed). */
+  private val rateWindowMs: Long = 2_000,
   /**
-   * Smoothing factor for the inter-frame rate EMA (0..1); higher reacts faster, lower is calmer.
+   * Non-idle inter-frame samples needed before any decision, so an early estimate can't misfire.
    */
-  private val smoothing: Double = 0.2,
-  /** Inter-frame samples needed before any decision, so an early estimate can't misfire. */
   private val minSamplesForDecision: Int = 5,
-  /** Below this fraction of [targetFps] a sample counts as dropping. */
+  /**
+   * At/over this inter-frame interval a frame is treated as idle — consistent with a static screen
+   * (Android's ~100ms repeat cadence) or an iOS suppression / reconnect gap — and contributes no
+   * drop signal. Just under the on-device repeat cadence so a still screen never reads as a drop;
+   * genuine degradation the controller acts on shows up as intervals between the target and here.
+   */
+  private val idleIntervalMs: Long = 90,
+  /** Below this fraction of [targetFps] a (non-idle) sample counts as dropping. */
   private val downgradeRatio: Double = 0.8,
   /** At or above this fraction of [targetFps] a sample counts as healthy. */
   private val upgradeRatio: Double = 0.95,
@@ -56,14 +74,6 @@ class QualityController(
   private val samplesToUpgrade: Int = 8,
   /** Minimum frame-time spacing between two automatic changes. */
   private val minDwellMs: Long = 2_000,
-  /**
-   * A gap longer than this is treated as a stream discontinuity, not a slow frame, and re-seeds the
-   * rate instead of folding in one implausibly-low sample. This is what keeps a source that omits
-   * idle buffers (iOS ScreenCaptureKit drops frames on a static screen) from reading as a drop when
-   * activity resumes; it comfortably exceeds the interval of the slowest real target (10fps =
-   * 100ms).
-   */
-  private val idleGapMs: Long = 1_000,
   /**
    * Notified only for an explicit [selectQuality] (a user's manual pick), for persistence.
    * Automatic steps update [quality] (so the pane re-subscribes and the overlay updates) but do not
@@ -80,6 +90,8 @@ class QualityController(
   /** Whether frame-rate drops drive automatic preset changes. FPS is measured regardless. */
   var autoAdjustEnabled: Boolean = autoAdjustEnabled
 
+  // Trailing timestamps for the displayed rate (frames ÷ elapsed over rateWindowMs).
+  private val window = ArrayDeque<Long>()
   private var lastFrameMs: Long? = null
   private var samples = 0
   private var lowStreak = 0
@@ -87,31 +99,30 @@ class QualityController(
   // Null until the first change, so the first decision is never gated by dwell (and no overflow).
   private var lastChangeAtMs: Long? = null
 
+  // Inter-frame interval thresholds (ms) derived from the target rate.
+  private val healthyMaxDtMs: Double
+    get() = 1000.0 / (upgradeRatio * targetFps)
+
+  private val droppingMinDtMs: Double
+    get() = 1000.0 / (downgradeRatio * targetFps)
+
   /** Records a decoded frame's arrival time, updates the live rate, and maybe adjusts quality. */
   fun onFrame(receivedAtMs: Long) {
+    window.addLast(receivedAtMs)
+    while (window.size > 1 && receivedAtMs - window.first() > rateWindowMs) window.removeFirst()
+    _actualFps.value = windowFps()
+
     val previous = lastFrameMs
     lastFrameMs = receivedAtMs
-    if (previous == null) return // first frame: no interval yet, rate stays 0.
+    if (previous == null) return // first frame: no interval yet.
 
     val dt = receivedAtMs - previous
     if (dt <= 0L) return // out-of-order / duplicate timestamp: ignore rather than divide by zero.
-    if (dt > idleGapMs) {
-      // Stream discontinuity (idle-buffer suppression on a static screen, or a reconnect): the next
-      // frame re-seeds the EMA from here rather than this gap being scored as a ~0fps sample.
-      samples = 0
-      lowStreak = 0
-      highStreak = 0
-      return
-    }
+    if (!autoAdjustEnabled) return
 
-    val instant = 1000f / dt
-    val ema = _actualFps.value
-    _actualFps.value =
-      if (samples == 0) instant else (smoothing * instant + (1 - smoothing) * ema).toFloat()
-    samples++
-
-    if (!autoAdjustEnabled || samples < minSamplesForDecision) return
-    evaluate(_actualFps.value, receivedAtMs)
+    classify(dt)
+    if (samples < minSamplesForDecision) return
+    maybeAdjust(receivedAtMs)
   }
 
   /** Applies an explicit user choice, re-seeding the rate window so the manual pick sticks. */
@@ -122,24 +133,46 @@ class QualityController(
     onManualSelection(quality)
   }
 
-  private fun evaluate(fps: Float, nowMs: Long) {
+  /**
+   * Frames-over-elapsed across the retained window; 0 until two frames span a positive interval.
+   */
+  private fun windowFps(): Float {
+    if (window.size < 2) return 0f
+    val span = window.last() - window.first()
+    if (span <= 0L) return 0f
+    return (window.size - 1) * 1000f / span
+  }
+
+  /** Buckets one inter-frame interval into healthy / dropping / idle and advances the streaks. */
+  private fun classify(dt: Long) {
     when {
-      fps < downgradeRatio * targetFps -> {
-        lowStreak++
+      // Idle: consistent with a static screen's repeat cadence or a suppression/reconnect gap.
+      // Not degradation — clear the streaks and do not count it as a decision sample.
+      dt >= idleIntervalMs -> {
+        lowStreak = 0
         highStreak = 0
       }
-      fps >= upgradeRatio * targetFps -> {
+      dt <= healthyMaxDtMs -> {
         highStreak++
         lowStreak = 0
+        samples++
       }
-      // Dead-zone between the two ratios: neither dropping nor clearly healthy — hold and reset,
+      dt > droppingMinDtMs -> {
+        lowStreak++
+        highStreak = 0
+        samples++
+      }
+      // Dead-zone between the two ratios: neither clearly healthy nor dropping — hold and reset,
       // which is what gives the hysteresis its gap and stops boundary flapping.
       else -> {
         lowStreak = 0
         highStreak = 0
+        samples++
       }
     }
+  }
 
+  private fun maybeAdjust(nowMs: Long) {
     val dwellElapsed = lastChangeAtMs?.let { nowMs - it >= minDwellMs } ?: true
     if (!dwellElapsed) return
 
@@ -159,12 +192,12 @@ class QualityController(
   }
 
   /**
-   * Drops the inter-frame timing and hysteresis streaks so the next frame re-seeds the EMA. Called
-   * on every preset change because a change triggers a re-subscribe, and the first frame after that
-   * reconnection is separated from the last pre-change frame by the whole gap — counting it as a
-   * real interval would fold one implausibly-slow sample into the rate.
+   * Drops the retained timing and hysteresis streaks so the next frames re-seed the rate. Called on
+   * every preset change because a change triggers a re-subscribe, and the first frame after that
+   * reconnection is separated from the last pre-change frame by the whole gap.
    */
   private fun resetRateWindow() {
+    window.clear()
     lastFrameMs = null
     samples = 0
     lowStreak = 0

--- a/android/desktop-core/src/main/kotlin/dev/jasonpearson/automobile/desktop/core/video/QualityController.kt
+++ b/android/desktop-core/src/main/kotlin/dev/jasonpearson/automobile/desktop/core/video/QualityController.kt
@@ -19,7 +19,18 @@ import kotlinx.coroutines.flow.StateFlow
  * FakeTimer. The rate is an exponential moving average of the instantaneous inter-frame rate, so a
  * single late frame perturbs it briefly rather than smearing across a whole window; hysteresis
  * ([samplesToDowngrade]/[samplesToUpgrade]) plus [minDwellMs] then keep a brief dip or a flapping
- * rate from thrashing the encode.
+ * rate from thrashing the encode. Every preset change (manual or automatic) also resets the rate
+ * window, so the reconnect gap that a re-subscribe introduces re-seeds cleanly instead of being
+ * counted as one implausibly-slow frame that biases the next decision.
+ *
+ * The rate is measured over the frames the pane actually renders (the caller feeds [onFrame] from
+ * its render path), so under a UI that recomposes slower than frames decode it reflects render
+ * cadence rather than raw decode rate — an acceptable proxy at the 10–30fps targets here.
+ *
+ * [onManualSelection] fires only for an explicit [selectQuality]; automatic steps deliberately do
+ * NOT notify, so the caller persists the user's chosen preset without writing the settings file on
+ * every transient auto-adjust (and without persisting a shared-capture ratchet-to-Low the stream
+ * never actually applied).
  *
  * @property targetFps the rate the pane asked the relay for; a drop is measured relative to it.
  */
@@ -46,9 +57,11 @@ class QualityController(
   /** Minimum frame-time spacing between two automatic changes. */
   private val minDwellMs: Long = 2_000,
   /**
-   * Notified when the effective quality changes (manual or automatic), for persistence/resubscribe.
+   * Notified only for an explicit [selectQuality] (a user's manual pick), for persistence.
+   * Automatic steps update [quality] (so the pane re-subscribes and the overlay updates) but do not
+   * notify.
    */
-  private val onQualityChange: (VideoStreamQuality) -> Unit = {},
+  private val onManualSelection: (VideoStreamQuality) -> Unit = {},
 ) {
   private val _quality = MutableStateFlow(initialQuality)
   val quality: StateFlow<VideoStreamQuality> = _quality
@@ -85,13 +98,12 @@ class QualityController(
     evaluate(_actualFps.value, receivedAtMs)
   }
 
-  /** Applies an explicit user choice, resetting hysteresis so the manual pick sticks. */
+  /** Applies an explicit user choice, re-seeding the rate window so the manual pick sticks. */
   fun selectQuality(quality: VideoStreamQuality) {
     if (_quality.value == quality) return
     _quality.value = quality
-    lowStreak = 0
-    highStreak = 0
-    onQualityChange(quality)
+    resetRateWindow()
+    onManualSelection(quality)
   }
 
   private fun evaluate(fps: Float, nowMs: Long) {
@@ -125,8 +137,21 @@ class QualityController(
   private fun change(quality: VideoStreamQuality, nowMs: Long) {
     _quality.value = quality
     lastChangeAtMs = nowMs
+    resetRateWindow()
+    // Deliberately no onManualSelection here: an automatic step re-subscribes via [quality] but is
+    // not persisted (see the class doc).
+  }
+
+  /**
+   * Drops the inter-frame timing and hysteresis streaks so the next frame re-seeds the EMA. Called
+   * on every preset change because a change triggers a re-subscribe, and the first frame after that
+   * reconnection is separated from the last pre-change frame by the whole gap — counting it as a
+   * real interval would fold one implausibly-slow sample into the rate.
+   */
+  private fun resetRateWindow() {
+    lastFrameMs = null
+    samples = 0
     lowStreak = 0
     highStreak = 0
-    onQualityChange(quality)
   }
 }

--- a/android/desktop-core/src/main/kotlin/dev/jasonpearson/automobile/desktop/core/video/VideoStreamClient.kt
+++ b/android/desktop-core/src/main/kotlin/dev/jasonpearson/automobile/desktop/core/video/VideoStreamClient.kt
@@ -73,7 +73,20 @@ enum class VideoStreamPermission {
 enum class VideoStreamQuality(internal val wire: String) {
   Low("low"),
   Medium("medium"),
-  High("high"),
+  High("high");
+
+  /** The next preset down (cheaper), clamped at [Low]. */
+  fun lower(): VideoStreamQuality = entries[(ordinal - 1).coerceAtLeast(0)]
+
+  /** The next preset up (sharper), clamped at [High]. */
+  fun higher(): VideoStreamQuality = entries[(ordinal + 1).coerceAtMost(entries.lastIndex)]
+
+  companion object {
+    /** Parses a persisted/wire string case-insensitively, or null when it names no preset. */
+    fun fromWire(value: String?): VideoStreamQuality? = entries.firstOrNull {
+      it.wire.equals(value, ignoreCase = true)
+    }
+  }
 }
 
 /** A live view of a device's screen. */

--- a/android/desktop-core/src/main/kotlin/dev/jasonpearson/automobile/desktop/core/workspace/DeviceStreamView.kt
+++ b/android/desktop-core/src/main/kotlin/dev/jasonpearson/automobile/desktop/core/workspace/DeviceStreamView.kt
@@ -29,10 +29,14 @@ import dev.jasonpearson.automobile.desktop.core.layout.DeviceScreenView
 import dev.jasonpearson.automobile.desktop.core.platform.MacScreenRecordingSettingsLauncher
 import dev.jasonpearson.automobile.desktop.core.platform.ScreenRecordingSettingsLauncher
 import dev.jasonpearson.automobile.desktop.core.rememberLiveVideoFrame
+import dev.jasonpearson.automobile.desktop.core.settings.SettingsProvider
+import dev.jasonpearson.automobile.desktop.core.video.LiveVideoFrame
+import dev.jasonpearson.automobile.desktop.core.video.QualityController
 import dev.jasonpearson.automobile.desktop.core.video.VideoStreamClient
 import dev.jasonpearson.automobile.desktop.core.video.VideoStreamQuality
 import dev.jasonpearson.automobile.desktop.core.video.VideoStreamSource
 import dev.jasonpearson.automobile.desktop.core.video.VideoStreamState
+import dev.jasonpearson.automobile.desktop.domain.DeviceFrameSnapshot
 import dev.jasonpearson.automobile.desktop.domain.DeviceScreenControlMode
 
 /**
@@ -81,34 +85,57 @@ fun DeviceStreamView(
   // Null/disabled ⇒ plain video mirror.
   enableDeviceControl: Boolean = false,
   control: WorkspaceDeviceControlState? = null,
-  // Hoisted so a host or test can pass a different quality/rate or a fake source entirely.
-  sourceFactory: (deviceId: String) -> VideoStreamSource = {
-    if (enableDeviceControl) {
+  // When present, the pane gains a quality overlay (manual Low/Medium/High selector, live FPS, and
+  // an auto-adjust toggle) whose choice persists here across sessions. Null keeps today's fixed
+  // per-mode preset with no overlay, so existing embeddings are unchanged.
+  settings: SettingsProvider? = null,
+  // Hoisted so a host or test can pass a different quality/rate or a fake source entirely. The
+  // quality is passed in (rather than baked in) so the pane can re-subscribe when the selector or
+  // auto-adjust changes it.
+  sourceFactory: (deviceId: String, quality: VideoStreamQuality) -> VideoStreamSource =
+    { deviceId, quality ->
       VideoStreamClient(
-        quality = VideoStreamQuality.High,
-        fps = CONTROL_PANE_FPS,
+        quality = quality,
+        fps = if (enableDeviceControl) CONTROL_PANE_FPS else MIRROR_PANE_FPS,
         sessionUuidProvider = sessionUuidProvider,
       )
-    } else {
-      VideoStreamClient(
-        quality = VideoStreamQuality.Low,
-        fps = MIRROR_PANE_FPS,
-        sessionUuidProvider = sessionUuidProvider,
-      )
-    }
-  },
+    },
   screenRecordingSettingsLauncher: ScreenRecordingSettingsLauncher =
     MacScreenRecordingSettingsLauncher(),
 ) {
+  // The pane's fixed per-mode preset when there's no controller: an armed (user-driven) pane wants
+  // the sharpest High stream; unfocused farm mirrors stay on the cheap Low preset.
+  val defaultQuality = if (enableDeviceControl) VideoStreamQuality.High else VideoStreamQuality.Low
+  val paneFps = if (enableDeviceControl) CONTROL_PANE_FPS else MIRROR_PANE_FPS
+
+  // With settings wired, a per-device controller measures the live rate and (when auto-adjust is
+  // on)
+  // steps the preset down on a sustained drop / back up once healthy. Its choice persists so the
+  // pane re-opens at the same quality. Keyed on deviceId so switching devices starts fresh.
+  val qualityController = settings?.let { s ->
+    remember(column.deviceId) {
+      QualityController(
+        initialQuality = VideoStreamQuality.fromWire(s.streamQualityPreset) ?: defaultQuality,
+        targetFps = paneFps,
+        autoAdjustEnabled = s.streamQualityAutoAdjust,
+        onQualityChange = { s.streamQualityPreset = it.wire },
+      )
+    }
+  }
+  val currentQuality =
+    if (qualityController != null) qualityController.quality.collectAsState().value
+    else defaultQuality
   // The live video mirror always streams — it's what the user watches in both modes. Farm panes
   // auto-reconnect so a dropped relay heals instead of staying "stopped" until the pane is torn
-  // down. Keyed on deviceId ONLY (not enableDeviceControl): the rate/quality preset is fixed at
-  // subscribe. Re-keying on control state to "downgrade" an unfocused pane doesn't reliably work —
-  // the daemon's per-device capture is shared and its encode is fixed by the FIRST subscriber's
-  // hint, so a fresh client that re-subscribes to a still-live capture has its new hint ignored
-  // (VideoStreamSocketServer.attach). Changing an armed pane's live rate needs server-side capture
-  // reconfiguration (follow-up); re-keying only added reconnect churn for no reliable effect.
-  val source = remember(column.deviceId) { sourceFactory(column.deviceId) }
+  // down. Keyed on deviceId AND the current preset: a user-driven quality change (or an auto-adjust
+  // step) re-subscribes with the new hint. That takes effect for a sole subscriber / the next fresh
+  // subscribe; while a per-device capture is SHARED the daemon fixes its encode from the FIRST
+  // subscriber's hint and ignores a re-subscriber's differing one (VideoStreamSocketServer.attach),
+  // so truly reconfiguring a live shared capture needs server-side work (follow-up). When
+  // [settings]
+  // is null the preset is constant, so this keys on deviceId only — unchanged from before.
+  val source =
+    remember(column.deviceId, currentQuality) { sourceFactory(column.deviceId, currentQuality) }
   val liveFrame =
     rememberLiveVideoFrame(
       source,
@@ -123,10 +150,70 @@ fun DeviceStreamView(
   val controlSnapshot = control?.interactionSnapshot
   var settingsLaunchFailure by remember(column.deviceId) { mutableStateOf(false) }
   // Perf span T3: mark each newly rendered video frame so the tracer can time the first frame after
-  // a tap (the visual-response latency). Cheap no-op unless a dispatched tap is pending.
+  // a tap (the visual-response latency). Cheap no-op unless a dispatched tap is pending. The same
+  // frame arrival feeds the quality controller so its live-rate estimate (and any auto-adjust) is
+  // driven by exactly the frames the pane renders.
   LaunchedEffect(liveFrame?.sequence) {
-    if (liveFrame != null) control?.tracer?.videoFrameRendered(column.deviceId)
+    if (liveFrame != null) {
+      control?.tracer?.videoFrameRendered(column.deviceId)
+      qualityController?.onFrame(liveFrame.receivedAtMs)
+    }
   }
+  Box(Modifier.fillMaxSize()) {
+    DeviceStreamContent(
+      column = column,
+      state = state,
+      liveFrame = liveFrame,
+      control = control,
+      controlSnapshot = controlSnapshot,
+      enableDeviceControl = enableDeviceControl,
+      settingsLaunchFailure = settingsLaunchFailure,
+      onSettingsLaunchFailure = { settingsLaunchFailure = it },
+      screenRecordingSettingsLauncher = screenRecordingSettingsLauncher,
+      source = source,
+    )
+    // Quality overlay: only when a controller is wired, and never over the permission surface
+    // (which
+    // owns the whole pane while the relay is refused).
+    if (qualityController != null && state !is VideoStreamState.PermissionRequired) {
+      val actualFps by qualityController.actualFps.collectAsState()
+      var autoAdjust by
+        remember(column.deviceId) { mutableStateOf(qualityController.autoAdjustEnabled) }
+      StreamQualityControls(
+        currentQuality = currentQuality,
+        actualFps = actualFps,
+        targetFps = qualityController.targetFps,
+        autoAdjustEnabled = autoAdjust,
+        onSelectQuality = { qualityController.selectQuality(it) },
+        onToggleAutoAdjust = { enabled ->
+          qualityController.autoAdjustEnabled = enabled
+          settings.streamQualityAutoAdjust = enabled
+          autoAdjust = enabled
+        },
+        modifier = Modifier.align(Alignment.TopEnd).padding(6.dp),
+      )
+    }
+  }
+}
+
+/**
+ * The pane's video surface: permission gate, armed interactive video, or plain mirror/hint. Split
+ * out of [DeviceStreamView] so the quality overlay can compose over it without duplicating the
+ * branch selection.
+ */
+@Composable
+private fun DeviceStreamContent(
+  column: DeviceColumn,
+  state: VideoStreamState,
+  liveFrame: LiveVideoFrame?,
+  control: WorkspaceDeviceControlState?,
+  controlSnapshot: DeviceFrameSnapshot?,
+  enableDeviceControl: Boolean,
+  settingsLaunchFailure: Boolean,
+  onSettingsLaunchFailure: (Boolean) -> Unit,
+  screenRecordingSettingsLauncher: ScreenRecordingSettingsLauncher,
+  source: VideoStreamSource,
+) {
   if (state is VideoStreamState.PermissionRequired) {
     // iOS screen-recording permission gate: the relay refused the capture until the user approves
     // Screen Recording, so there is NO live video to drive. Check this BEFORE the armed branch: on
@@ -135,10 +222,10 @@ fun DeviceStreamView(
     // and swallow the approval UI, stranding the user with no way to recover. Android never reaches
     // PermissionRequired (no screen-recording gate), so this reorder does not change its behavior.
     ScreenRecordingPermissionSurface(
-      approvalTarget = (state as VideoStreamState.PermissionRequired).approvalTarget,
+      approvalTarget = state.approvalTarget,
       settingsLaunchFailure = settingsLaunchFailure,
       onOpenSettings = {
-        settingsLaunchFailure = screenRecordingSettingsLauncher.openScreenRecording().isFailure
+        onSettingsLaunchFailure(screenRecordingSettingsLauncher.openScreenRecording().isFailure)
       },
       onRetry = {
         source.disconnect()
@@ -147,6 +234,7 @@ fun DeviceStreamView(
     )
   } else if (
     enableDeviceControl &&
+      control != null &&
       controlSnapshot != null &&
       liveFrame != null &&
       state is VideoStreamState.Streaming

--- a/android/desktop-core/src/main/kotlin/dev/jasonpearson/automobile/desktop/core/workspace/DeviceStreamView.kt
+++ b/android/desktop-core/src/main/kotlin/dev/jasonpearson/automobile/desktop/core/workspace/DeviceStreamView.kt
@@ -143,8 +143,15 @@ fun DeviceStreamView(
   // so truly reconfiguring a live shared capture needs server-side work (follow-up). When
   // [settings]
   // is null the preset is constant, so this keys on deviceId only — unchanged from before.
+  // Keyed on deviceId, the current preset, AND paneFps: focus changes paneFps (10↔30) independently
+  // of the preset, so without paneFps a pane that gains/loses focus without a preset change would
+  // keep streaming at the old rate (a focused pane stuck at the farm 10fps, or an unfocused pane
+  // still consuming 30fps). Re-subscribing on the change applies for a sole subscriber / the next
+  // subscribe; a live shared capture keeps the first subscriber's encode (server follow-up).
   val source =
-    remember(column.deviceId, currentQuality) { sourceFactory(column.deviceId, currentQuality) }
+    remember(column.deviceId, currentQuality, paneFps) {
+      sourceFactory(column.deviceId, currentQuality)
+    }
   val liveFrame =
     rememberLiveVideoFrame(
       source,

--- a/android/desktop-core/src/main/kotlin/dev/jasonpearson/automobile/desktop/core/workspace/DeviceStreamView.kt
+++ b/android/desktop-core/src/main/kotlin/dev/jasonpearson/automobile/desktop/core/workspace/DeviceStreamView.kt
@@ -108,20 +108,29 @@ fun DeviceStreamView(
   val defaultQuality = if (enableDeviceControl) VideoStreamQuality.High else VideoStreamQuality.Low
   val paneFps = if (enableDeviceControl) CONTROL_PANE_FPS else MIRROR_PANE_FPS
 
-  // With settings wired, a per-device controller measures the live rate and (when auto-adjust is
-  // on)
-  // steps the preset down on a sustained drop / back up once healthy. Its choice persists so the
-  // pane re-opens at the same quality. Keyed on deviceId so switching devices starts fresh.
-  val qualityController = settings?.let { s ->
-    remember(column.deviceId) {
-      QualityController(
-        initialQuality = VideoStreamQuality.fromWire(s.streamQualityPreset) ?: defaultQuality,
-        targetFps = paneFps,
-        autoAdjustEnabled = s.streamQualityAutoAdjust,
-        onQualityChange = { s.streamQualityPreset = it.wire },
-      )
+  // Quality controls live only on the actively-driven (focused/armed) pane, never on the farm's
+  // display-only mirrors: those stay the cheap fixed Low preset with no overlay, which is what
+  // keeps
+  // dozens of concurrent panes affordable (#5217) and uncluttered. With settings wired the focused
+  // pane's per-device controller measures the live rate and (when auto-adjust is on) steps the
+  // preset down on a sustained drop / back up once healthy. Only a MANUAL pick persists (the
+  // seed for the next launch); automatic steps re-subscribe but are not written to the settings
+  // file. Keyed on deviceId so switching devices starts fresh.
+  val qualityController =
+    if (enableDeviceControl) {
+      settings?.let { s ->
+        remember(column.deviceId) {
+          QualityController(
+            initialQuality = VideoStreamQuality.fromWire(s.streamQualityPreset) ?: defaultQuality,
+            targetFps = paneFps,
+            autoAdjustEnabled = s.streamQualityAutoAdjust,
+            onManualSelection = { s.streamQualityPreset = it.wire },
+          )
+        }
+      }
+    } else {
+      null
     }
-  }
   val currentQuality =
     if (qualityController != null) qualityController.quality.collectAsState().value
     else defaultQuality
@@ -172,22 +181,32 @@ fun DeviceStreamView(
       screenRecordingSettingsLauncher = screenRecordingSettingsLauncher,
       source = source,
     )
-    // Quality overlay: only when a controller is wired, and never over the permission surface
-    // (which
-    // owns the whole pane while the relay is refused).
+    // Quality overlay: only on the focused pane (controller present) and never over the permission
+    // surface (which owns the whole pane while the relay is refused). Collapsed by default so it
+    // does
+    // not intercept a tap on the interactive control surface; the user expands it to pick a preset.
     if (qualityController != null && state !is VideoStreamState.PermissionRequired) {
       val actualFps by qualityController.actualFps.collectAsState()
       var autoAdjust by
         remember(column.deviceId) { mutableStateOf(qualityController.autoAdjustEnabled) }
+      var overlayExpanded by remember(column.deviceId) { mutableStateOf(false) }
       StreamQualityControls(
         currentQuality = currentQuality,
         actualFps = actualFps,
         targetFps = qualityController.targetFps,
         autoAdjustEnabled = autoAdjust,
-        onSelectQuality = { qualityController.selectQuality(it) },
+        expanded = overlayExpanded,
+        onToggleExpanded = { overlayExpanded = !overlayExpanded },
+        onSelectQuality = {
+          qualityController.selectQuality(it)
+          // Collapse after a pick so the panel stops covering the interactive surface.
+          overlayExpanded = false
+        },
         onToggleAutoAdjust = { enabled ->
           qualityController.autoAdjustEnabled = enabled
-          settings.streamQualityAutoAdjust = enabled
+          // Non-null whenever the controller exists (both derive from the same settings), but the
+          // `if (enableDeviceControl)` wrapper hides that from the smart-cast, so guard explicitly.
+          settings?.streamQualityAutoAdjust = enabled
           autoAdjust = enabled
         },
         modifier = Modifier.align(Alignment.TopEnd).padding(6.dp),

--- a/android/desktop-core/src/main/kotlin/dev/jasonpearson/automobile/desktop/core/workspace/StreamQualityControls.kt
+++ b/android/desktop-core/src/main/kotlin/dev/jasonpearson/automobile/desktop/core/workspace/StreamQualityControls.kt
@@ -1,0 +1,84 @@
+package dev.jasonpearson.automobile.desktop.core.workspace
+
+import androidx.compose.foundation.background
+import androidx.compose.foundation.clickable
+import androidx.compose.foundation.layout.Arrangement
+import androidx.compose.foundation.layout.Box
+import androidx.compose.foundation.layout.Column
+import androidx.compose.foundation.layout.Row
+import androidx.compose.foundation.layout.padding
+import androidx.compose.foundation.shape.RoundedCornerShape
+import androidx.compose.material3.Text
+import androidx.compose.runtime.Composable
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.graphics.Color
+import androidx.compose.ui.input.pointer.PointerIcon
+import androidx.compose.ui.input.pointer.pointerHoverIcon
+import androidx.compose.ui.unit.dp
+import androidx.compose.ui.unit.sp
+import dev.jasonpearson.automobile.desktop.core.video.VideoStreamQuality
+import kotlin.math.roundToInt
+
+/**
+ * Compact quality overlay for a live-mirror pane: a Low/Medium/High selector, the
+ * measured-vs-target frame rate, the current preset, and an auto-adjust toggle. It is a pure view —
+ * all state and the [onSelectQuality]/[onToggleAutoAdjust] callbacks are hoisted, so the pane owns
+ * the [QualityController] and persistence and this composable stays trivially testable.
+ *
+ * @param actualFps the live rate from the controller; rendered rounded next to [targetFps].
+ */
+@Composable
+fun StreamQualityControls(
+  currentQuality: VideoStreamQuality,
+  actualFps: Float,
+  targetFps: Int,
+  autoAdjustEnabled: Boolean,
+  onSelectQuality: (VideoStreamQuality) -> Unit,
+  onToggleAutoAdjust: (Boolean) -> Unit,
+  modifier: Modifier = Modifier,
+) {
+  Column(
+    modifier =
+      modifier
+        .background(Color.Black.copy(alpha = 0.55f), RoundedCornerShape(6.dp))
+        .padding(horizontal = 8.dp, vertical = 6.dp),
+    verticalArrangement = Arrangement.spacedBy(4.dp),
+  ) {
+    Text(
+      "${actualFps.roundToInt()} / $targetFps fps",
+      fontSize = 10.sp,
+      color = Color.White.copy(alpha = 0.9f),
+    )
+    Row(horizontalArrangement = Arrangement.spacedBy(4.dp)) {
+      VideoStreamQuality.entries.forEach { quality ->
+        val selected = quality == currentQuality
+        Chip(
+          label = quality.name,
+          accent = if (selected) SELECTED_ACCENT else UNSELECTED_ACCENT,
+          onClick = { onSelectQuality(quality) },
+        )
+      }
+      Chip(
+        label = "Auto",
+        accent = if (autoAdjustEnabled) SELECTED_ACCENT else UNSELECTED_ACCENT,
+        onClick = { onToggleAutoAdjust(!autoAdjustEnabled) },
+      )
+    }
+  }
+}
+
+private val SELECTED_ACCENT = Color(0xFF4CAF50)
+private val UNSELECTED_ACCENT = Color(0xFF9E9E9E)
+
+@Composable
+private fun Chip(label: String, accent: Color, onClick: () -> Unit) {
+  Box(
+    modifier =
+      Modifier.background(accent.copy(alpha = 0.25f), RoundedCornerShape(4.dp))
+        .clickable(onClick = onClick)
+        .pointerHoverIcon(PointerIcon.Hand)
+        .padding(horizontal = 8.dp, vertical = 3.dp)
+  ) {
+    Text(label, fontSize = 9.sp, color = Color.White.copy(alpha = 0.95f))
+  }
+}

--- a/android/desktop-core/src/main/kotlin/dev/jasonpearson/automobile/desktop/core/workspace/StreamQualityControls.kt
+++ b/android/desktop-core/src/main/kotlin/dev/jasonpearson/automobile/desktop/core/workspace/StreamQualityControls.kt
@@ -20,12 +20,16 @@ import dev.jasonpearson.automobile.desktop.core.video.VideoStreamQuality
 import kotlin.math.roundToInt
 
 /**
- * Compact quality overlay for a live-mirror pane: a Low/Medium/High selector, the
- * measured-vs-target frame rate, the current preset, and an auto-adjust toggle. It is a pure view —
- * all state and the [onSelectQuality]/[onToggleAutoAdjust] callbacks are hoisted, so the pane owns
- * the [QualityController] and persistence and this composable stays trivially testable.
+ * Compact quality overlay for a live-mirror pane. Collapsed by default it shows only a small,
+ * non-interactive readout — the current preset and the measured-vs-target frame rate — so it never
+ * intercepts a device tap on the interactive (tap-to-control) surface underneath. Clicking the
+ * readout ([onToggleExpanded]) reveals the Low/Medium/High selector and an auto-adjust toggle; a
+ * device tap can at most open this panel, never silently change quality. All state and the
+ * callbacks are hoisted, so the pane owns the [QualityController] and persistence and this view
+ * stays testable.
  *
  * @param actualFps the live rate from the controller; rendered rounded next to [targetFps].
+ * @param expanded whether the selector/toggle row is shown beneath the readout.
  */
 @Composable
 fun StreamQualityControls(
@@ -33,6 +37,8 @@ fun StreamQualityControls(
   actualFps: Float,
   targetFps: Int,
   autoAdjustEnabled: Boolean,
+  expanded: Boolean,
+  onToggleExpanded: () -> Unit,
   onSelectQuality: (VideoStreamQuality) -> Unit,
   onToggleAutoAdjust: (Boolean) -> Unit,
   modifier: Modifier = Modifier,
@@ -45,24 +51,27 @@ fun StreamQualityControls(
     verticalArrangement = Arrangement.spacedBy(4.dp),
   ) {
     Text(
-      "${actualFps.roundToInt()} / $targetFps fps",
+      "${currentQuality.name} · ${actualFps.roundToInt()} / $targetFps fps",
       fontSize = 10.sp,
       color = Color.White.copy(alpha = 0.9f),
+      modifier = Modifier.clickable(onClick = onToggleExpanded).pointerHoverIcon(PointerIcon.Hand),
     )
-    Row(horizontalArrangement = Arrangement.spacedBy(4.dp)) {
-      VideoStreamQuality.entries.forEach { quality ->
-        val selected = quality == currentQuality
+    if (expanded) {
+      Row(horizontalArrangement = Arrangement.spacedBy(4.dp)) {
+        VideoStreamQuality.entries.forEach { quality ->
+          val selected = quality == currentQuality
+          Chip(
+            label = quality.name,
+            accent = if (selected) SELECTED_ACCENT else UNSELECTED_ACCENT,
+            onClick = { onSelectQuality(quality) },
+          )
+        }
         Chip(
-          label = quality.name,
-          accent = if (selected) SELECTED_ACCENT else UNSELECTED_ACCENT,
-          onClick = { onSelectQuality(quality) },
+          label = "Auto",
+          accent = if (autoAdjustEnabled) SELECTED_ACCENT else UNSELECTED_ACCENT,
+          onClick = { onToggleAutoAdjust(!autoAdjustEnabled) },
         )
       }
-      Chip(
-        label = "Auto",
-        accent = if (autoAdjustEnabled) SELECTED_ACCENT else UNSELECTED_ACCENT,
-        onClick = { onToggleAutoAdjust(!autoAdjustEnabled) },
-      )
     }
   }
 }

--- a/android/desktop-core/src/test/kotlin/dev/jasonpearson/automobile/desktop/core/settings/FileSettingsProviderTest.kt
+++ b/android/desktop-core/src/test/kotlin/dev/jasonpearson/automobile/desktop/core/settings/FileSettingsProviderTest.kt
@@ -46,6 +46,25 @@ class FileSettingsProviderTest {
   }
 
   @Test
+  fun `defaults the live-mirror quality settings`() {
+    val settings = FileSettingsProvider(tempSettingsFile())
+    assertEquals("medium", settings.streamQualityPreset)
+    assertTrue(settings.streamQualityAutoAdjust)
+  }
+
+  @Test
+  fun `persists the live-mirror quality settings across instances`() {
+    val file = tempSettingsFile()
+    FileSettingsProvider(file).apply {
+      streamQualityPreset = "high"
+      streamQualityAutoAdjust = false
+    }
+    val reloaded = FileSettingsProvider(file)
+    assertEquals("high", reloaded.streamQualityPreset)
+    assertFalse(reloaded.streamQualityAutoAdjust)
+  }
+
+  @Test
   fun `writes the backing file on the first set`() {
     val file = tempSettingsFile()
     assertFalse(file.exists())

--- a/android/desktop-core/src/test/kotlin/dev/jasonpearson/automobile/desktop/core/video/QualityControllerTest.kt
+++ b/android/desktop-core/src/test/kotlin/dev/jasonpearson/automobile/desktop/core/video/QualityControllerTest.kt
@@ -1,0 +1,163 @@
+package dev.jasonpearson.automobile.desktop.core.video
+
+import org.junit.Assert.assertEquals
+import org.junit.Assert.assertTrue
+import org.junit.Test
+
+/**
+ * Pure client-side quality controller: derives the live frame rate from the timestamps of decoded
+ * frames and, when auto-adjustment is on, decides preset downgrades/upgrades with hysteresis and a
+ * minimum dwell so a brief dip cannot thrash the encode. No Compose, no IO — frame timestamps are
+ * the only clock, so every decision is deterministic.
+ */
+class QualityControllerTest {
+
+  /**
+   * Feeds [count] frames spaced [intervalMs] apart starting at [startMs]; returns the next time.
+   */
+  private fun QualityController.feed(count: Int, intervalMs: Long, startMs: Long = 0L): Long {
+    var t = startMs
+    repeat(count) {
+      onFrame(t)
+      t += intervalMs
+    }
+    return t
+  }
+
+  @Test
+  fun `derives actual fps from frame arrival timestamps`() {
+    val controller = QualityController(initialQuality = VideoStreamQuality.Medium, targetFps = 30)
+    // 20 frames, 50ms apart => a steady 20 fps.
+    controller.feed(count = 20, intervalMs = 50)
+    assertEquals(20f, controller.actualFps.value, 0.1f)
+  }
+
+  @Test
+  fun `reports zero fps before two frames arrive`() {
+    val controller = QualityController(initialQuality = VideoStreamQuality.Medium, targetFps = 30)
+    assertEquals(0f, controller.actualFps.value, 0.0f)
+    controller.onFrame(0)
+    assertEquals(0f, controller.actualFps.value, 0.0f)
+  }
+
+  @Test
+  fun `cascades down while a heavy drop persists`() {
+    val controller =
+      QualityController(
+        initialQuality = VideoStreamQuality.High,
+        targetFps = 30,
+        samplesToDowngrade = 3,
+        minDwellMs = 0,
+      )
+    // 10 fps (100ms apart) is a third of the 30fps target — chronic, so it keeps stepping down to
+    // the cheapest preset while the drop lasts.
+    controller.feed(count = 40, intervalMs = 100)
+    assertEquals(VideoStreamQuality.Low, controller.quality.value)
+  }
+
+  @Test
+  fun `does not downgrade a brief dip shorter than the hysteresis window`() {
+    var changes = 0
+    val controller =
+      QualityController(
+        initialQuality = VideoStreamQuality.High,
+        targetFps = 30,
+        samplesToDowngrade = 3,
+        minDwellMs = 0,
+        onQualityChange = { changes++ },
+      )
+    // Warm the rate up at a healthy 30fps first.
+    var t = controller.feed(count = 15, intervalMs = 33)
+    // A single slow frame (one 200ms gap) briefly perturbs the EMA but recovers immediately.
+    controller.onFrame(t + 200)
+    t += 233
+    controller.feed(count = 15, intervalMs = 33, startMs = t)
+    assertEquals(VideoStreamQuality.High, controller.quality.value)
+    assertEquals(0, changes)
+  }
+
+  @Test
+  fun `climbs back up once the rate is sustainably healthy`() {
+    val controller =
+      QualityController(
+        initialQuality = VideoStreamQuality.Low,
+        targetFps = 30,
+        samplesToUpgrade = 8,
+        minDwellMs = 0,
+      )
+    // Steady 30fps (33ms apart) is at target — healthy enough to climb to the top preset.
+    controller.feed(count = 60, intervalMs = 33)
+    assertEquals(VideoStreamQuality.High, controller.quality.value)
+  }
+
+  @Test
+  fun `never downgrades below Low or upgrades above High`() {
+    val low =
+      QualityController(
+        initialQuality = VideoStreamQuality.Low,
+        targetFps = 30,
+        samplesToDowngrade = 3,
+        minDwellMs = 0,
+      )
+    low.feed(count = 30, intervalMs = 200) // 5fps, chronic drop
+    assertEquals(VideoStreamQuality.Low, low.quality.value)
+
+    val high =
+      QualityController(
+        initialQuality = VideoStreamQuality.High,
+        targetFps = 30,
+        samplesToUpgrade = 5,
+        minDwellMs = 0,
+      )
+    high.feed(count = 30, intervalMs = 33) // perfect rate
+    assertEquals(VideoStreamQuality.High, high.quality.value)
+  }
+
+  @Test
+  fun `min dwell paces automatic changes to one step per window`() {
+    val controller =
+      QualityController(
+        initialQuality = VideoStreamQuality.High,
+        targetFps = 30,
+        samplesToDowngrade = 3,
+        minDwellMs = 5_000,
+      )
+    // Sustained heavy drop over ~4s (< the 5s dwell): without dwell this would fall to Low, but
+    // only
+    // one step is allowed inside the window.
+    controller.feed(count = 40, intervalMs = 100)
+    assertEquals(VideoStreamQuality.Medium, controller.quality.value)
+  }
+
+  @Test
+  fun `auto adjustment can be disabled while fps is still measured`() {
+    val controller =
+      QualityController(
+        initialQuality = VideoStreamQuality.High,
+        targetFps = 30,
+        samplesToDowngrade = 3,
+        minDwellMs = 0,
+        autoAdjustEnabled = false,
+      )
+    controller.feed(count = 30, intervalMs = 100)
+    assertEquals(VideoStreamQuality.High, controller.quality.value)
+    assertTrue("fps still measured when auto-adjust off", controller.actualFps.value > 0f)
+  }
+
+  @Test
+  fun `manual selection overrides quality and notifies`() {
+    val selected = mutableListOf<VideoStreamQuality>()
+    val controller =
+      QualityController(
+        initialQuality = VideoStreamQuality.Medium,
+        targetFps = 30,
+        onQualityChange = { selected.add(it) },
+      )
+    controller.selectQuality(VideoStreamQuality.Low)
+    assertEquals(VideoStreamQuality.Low, controller.quality.value)
+    assertEquals(listOf(VideoStreamQuality.Low), selected)
+    // Re-selecting the same quality is a no-op (no duplicate notification / churn).
+    controller.selectQuality(VideoStreamQuality.Low)
+    assertEquals(listOf(VideoStreamQuality.Low), selected)
+  }
+}

--- a/android/desktop-core/src/test/kotlin/dev/jasonpearson/automobile/desktop/core/video/QualityControllerTest.kt
+++ b/android/desktop-core/src/test/kotlin/dev/jasonpearson/automobile/desktop/core/video/QualityControllerTest.kt
@@ -176,6 +176,31 @@ class QualityControllerTest {
   }
 
   @Test
+  fun `an idle gap on a source that omits idle frames does not trigger a downgrade`() {
+    // iOS ScreenCaptureKit drops idle buffers, so a static screen makes no frame progress; when
+    // activity resumes the resumed burst must not read as a drop. Codex's example: 0, 10_000, then
+    // six healthy 33ms frames must NOT downgrade High.
+    val controller =
+      QualityController(
+        initialQuality = VideoStreamQuality.High,
+        targetFps = 30,
+        samplesToDowngrade = 3,
+        minDwellMs = 0,
+      )
+    controller.onFrame(0)
+    controller.onFrame(10_000) // long idle gap — treated as discontinuity, not a ~0fps sample
+    var t = 10_033L
+    repeat(6) {
+      controller.onFrame(t)
+      t += 33
+    }
+    assertEquals(VideoStreamQuality.High, controller.quality.value)
+    // And once enough healthy frames flow the measured rate reflects the real cadence.
+    controller.feed(count = 6, intervalMs = 33, startMs = t)
+    assertTrue(controller.actualFps.value > 24f)
+  }
+
+  @Test
   fun `a reconnect gap right after a change does not immediately downgrade`() {
     val controller =
       QualityController(

--- a/android/desktop-core/src/test/kotlin/dev/jasonpearson/automobile/desktop/core/video/QualityControllerTest.kt
+++ b/android/desktop-core/src/test/kotlin/dev/jasonpearson/automobile/desktop/core/video/QualityControllerTest.kt
@@ -172,6 +172,25 @@ class QualityControllerTest {
   }
 
   @Test
+  fun `toggling auto adjustment resets the decision streaks`() {
+    val controller =
+      QualityController(
+        initialQuality = VideoStreamQuality.High,
+        targetFps = 30,
+        samplesToDowngrade = 3,
+        minSamplesForDecision = 1,
+        minDwellMs = 0,
+      )
+    // Two dropping samples accrue but don't yet downgrade.
+    controller.feed(count = 3, intervalMs = 60) // frames at 0,60,120 => two 60ms drop intervals
+    // Auto off then on must clear the streak, so the next dropping frame is sample #1, not #3.
+    controller.autoAdjustEnabled = false
+    controller.autoAdjustEnabled = true
+    controller.onFrame(180)
+    assertEquals(VideoStreamQuality.High, controller.quality.value)
+  }
+
+  @Test
   fun `manual selection overrides quality and notifies`() {
     val selected = mutableListOf<VideoStreamQuality>()
     val controller =

--- a/android/desktop-core/src/test/kotlin/dev/jasonpearson/automobile/desktop/core/video/QualityControllerTest.kt
+++ b/android/desktop-core/src/test/kotlin/dev/jasonpearson/automobile/desktop/core/video/QualityControllerTest.kt
@@ -183,9 +183,22 @@ class QualityControllerTest {
     controller.selectQuality(VideoStreamQuality.Low)
     assertEquals(VideoStreamQuality.Low, controller.quality.value)
     assertEquals(listOf(VideoStreamQuality.Low), selected)
-    // Re-selecting the same quality is a no-op (no duplicate notification / churn).
-    controller.selectQuality(VideoStreamQuality.Low)
-    assertEquals(listOf(VideoStreamQuality.Low), selected)
+  }
+
+  @Test
+  fun `an explicit reselection persists even when the current preset already matches`() {
+    // After an automatic step set the in-memory preset to Medium (persisted value may still
+    // differ),
+    // explicitly picking Medium must persist the user's choice rather than early-returning.
+    val selected = mutableListOf<VideoStreamQuality>()
+    val controller =
+      QualityController(
+        initialQuality = VideoStreamQuality.Medium,
+        targetFps = 30,
+        onManualSelection = { selected.add(it) },
+      )
+    controller.selectQuality(VideoStreamQuality.Medium)
+    assertEquals(listOf(VideoStreamQuality.Medium), selected)
   }
 
   @Test

--- a/android/desktop-core/src/test/kotlin/dev/jasonpearson/automobile/desktop/core/video/QualityControllerTest.kt
+++ b/android/desktop-core/src/test/kotlin/dev/jasonpearson/automobile/desktop/core/video/QualityControllerTest.kt
@@ -57,14 +57,12 @@ class QualityControllerTest {
 
   @Test
   fun `does not downgrade a brief dip shorter than the hysteresis window`() {
-    var changes = 0
     val controller =
       QualityController(
         initialQuality = VideoStreamQuality.High,
         targetFps = 30,
         samplesToDowngrade = 3,
         minDwellMs = 0,
-        onQualityChange = { changes++ },
       )
     // Warm the rate up at a healthy 30fps first.
     var t = controller.feed(count = 15, intervalMs = 33)
@@ -73,7 +71,6 @@ class QualityControllerTest {
     t += 233
     controller.feed(count = 15, intervalMs = 33, startMs = t)
     assertEquals(VideoStreamQuality.High, controller.quality.value)
-    assertEquals(0, changes)
   }
 
   @Test
@@ -151,7 +148,7 @@ class QualityControllerTest {
       QualityController(
         initialQuality = VideoStreamQuality.Medium,
         targetFps = 30,
-        onQualityChange = { selected.add(it) },
+        onManualSelection = { selected.add(it) },
       )
     controller.selectQuality(VideoStreamQuality.Low)
     assertEquals(VideoStreamQuality.Low, controller.quality.value)
@@ -159,5 +156,40 @@ class QualityControllerTest {
     // Re-selecting the same quality is a no-op (no duplicate notification / churn).
     controller.selectQuality(VideoStreamQuality.Low)
     assertEquals(listOf(VideoStreamQuality.Low), selected)
+  }
+
+  @Test
+  fun `automatic changes update quality but are not persisted`() {
+    val selected = mutableListOf<VideoStreamQuality>()
+    val controller =
+      QualityController(
+        initialQuality = VideoStreamQuality.High,
+        targetFps = 30,
+        samplesToDowngrade = 3,
+        minDwellMs = 0,
+        onManualSelection = { selected.add(it) },
+      )
+    controller.feed(count = 40, intervalMs = 100) // heavy drop → auto-downgrades
+    assertEquals(VideoStreamQuality.Low, controller.quality.value)
+    // Automatic steps re-subscribe via `quality` but must not fire the persistence callback.
+    assertEquals(emptyList<VideoStreamQuality>(), selected)
+  }
+
+  @Test
+  fun `a reconnect gap right after a change does not immediately downgrade`() {
+    val controller =
+      QualityController(
+        initialQuality = VideoStreamQuality.Medium,
+        targetFps = 30,
+        // Aggressive: a single dropping sample would downgrade if the gap were counted.
+        samplesToDowngrade = 1,
+        minSamplesForDecision = 1,
+        minDwellMs = 0,
+      )
+    controller.selectQuality(VideoStreamQuality.High) // triggers a re-subscribe
+    // The first frame after the reconnect arrives a long time later; the reset window swallows it
+    // as the new seed rather than treating the whole gap as one ~0fps interval.
+    controller.onFrame(10_000)
+    assertEquals(VideoStreamQuality.High, controller.quality.value)
   }
 }

--- a/android/desktop-core/src/test/kotlin/dev/jasonpearson/automobile/desktop/core/video/QualityControllerTest.kt
+++ b/android/desktop-core/src/test/kotlin/dev/jasonpearson/automobile/desktop/core/video/QualityControllerTest.kt
@@ -7,8 +7,10 @@ import org.junit.Test
 /**
  * Pure client-side quality controller: derives the live frame rate from the timestamps of decoded
  * frames and, when auto-adjustment is on, decides preset downgrades/upgrades with hysteresis and a
- * minimum dwell so a brief dip cannot thrash the encode. No Compose, no IO — frame timestamps are
- * the only clock, so every decision is deterministic.
+ * minimum dwell. Frame timestamps are the only clock, so every decision is deterministic. Drops are
+ * detected by inter-frame interval band — the target is 30fps (33ms), the active-but-slow "drop"
+ * band is intervals of ~42–90ms, and intervals at/over 90ms are treated as idle (a static screen's
+ * repeat cadence or a suppression/reconnect gap), never as degradation.
  */
 class QualityControllerTest {
 
@@ -25,11 +27,24 @@ class QualityControllerTest {
   }
 
   @Test
-  fun `derives actual fps from frame arrival timestamps`() {
+  fun `derives actual fps as frames over elapsed`() {
     val controller = QualityController(initialQuality = VideoStreamQuality.Medium, targetFps = 30)
     // 20 frames, 50ms apart => a steady 20 fps.
     controller.feed(count = 20, intervalMs = 50)
-    assertEquals(20f, controller.actualFps.value, 0.1f)
+    assertEquals(20f, controller.actualFps.value, 0.2f)
+  }
+
+  @Test
+  fun `measures fps by frames over elapsed, not an average of instantaneous rates`() {
+    // Alternating 10ms / 90ms gaps are two frames per 100ms = 20fps. An average of instantaneous
+    // 1000/dt values would overstate this to ~50fps; frames-over-elapsed reports the true rate.
+    val controller = QualityController(initialQuality = VideoStreamQuality.High, targetFps = 30)
+    var t = 0L
+    repeat(40) { i ->
+      controller.onFrame(t)
+      t += if (i % 2 == 0) 10L else 90L
+    }
+    assertEquals(20f, controller.actualFps.value, 2f)
   }
 
   @Test
@@ -49,10 +64,25 @@ class QualityControllerTest {
         samplesToDowngrade = 3,
         minDwellMs = 0,
       )
-    // 10 fps (100ms apart) is a third of the 30fps target — chronic, so it keeps stepping down to
-    // the cheapest preset while the drop lasts.
-    controller.feed(count = 40, intervalMs = 100)
+    // ~17fps (60ms apart) is well under the 30fps target but faster than the idle cadence, so it is
+    // read as genuine degradation and keeps stepping down to the cheapest preset.
+    controller.feed(count = 60, intervalMs = 60)
     assertEquals(VideoStreamQuality.Low, controller.quality.value)
+  }
+
+  @Test
+  fun `a static screen at the idle-repeat cadence does not downgrade`() {
+    // Android repeats the previous frame after ~100ms on a still screen, so a static screen streams
+    // at ~10fps. That is not encoder/transport degradation and must not ratchet the preset down.
+    val controller =
+      QualityController(
+        initialQuality = VideoStreamQuality.High,
+        targetFps = 30,
+        samplesToDowngrade = 3,
+        minDwellMs = 0,
+      )
+    controller.feed(count = 60, intervalMs = 100)
+    assertEquals(VideoStreamQuality.High, controller.quality.value)
   }
 
   @Test
@@ -66,7 +96,7 @@ class QualityControllerTest {
       )
     // Warm the rate up at a healthy 30fps first.
     var t = controller.feed(count = 15, intervalMs = 33)
-    // A single slow frame (one 200ms gap) briefly perturbs the EMA but recovers immediately.
+    // A single slow frame (one 200ms gap) is idle-consistent and clears the streak; it recovers.
     controller.onFrame(t + 200)
     t += 233
     controller.feed(count = 15, intervalMs = 33, startMs = t)
@@ -96,7 +126,7 @@ class QualityControllerTest {
         samplesToDowngrade = 3,
         minDwellMs = 0,
       )
-    low.feed(count = 30, intervalMs = 200) // 5fps, chronic drop
+    low.feed(count = 30, intervalMs = 60) // ~17fps, chronic drop
     assertEquals(VideoStreamQuality.Low, low.quality.value)
 
     val high =
@@ -119,10 +149,10 @@ class QualityControllerTest {
         samplesToDowngrade = 3,
         minDwellMs = 5_000,
       )
-    // Sustained heavy drop over ~4s (< the 5s dwell): without dwell this would fall to Low, but
-    // only
-    // one step is allowed inside the window.
-    controller.feed(count = 40, intervalMs = 100)
+    // Sustained drop over ~3.6s (< the 5s dwell): without dwell this would fall to Low, but only
+    // one
+    // step is allowed inside the window.
+    controller.feed(count = 60, intervalMs = 60)
     assertEquals(VideoStreamQuality.Medium, controller.quality.value)
   }
 
@@ -136,7 +166,7 @@ class QualityControllerTest {
         minDwellMs = 0,
         autoAdjustEnabled = false,
       )
-    controller.feed(count = 30, intervalMs = 100)
+    controller.feed(count = 30, intervalMs = 60)
     assertEquals(VideoStreamQuality.High, controller.quality.value)
     assertTrue("fps still measured when auto-adjust off", controller.actualFps.value > 0f)
   }
@@ -169,35 +199,10 @@ class QualityControllerTest {
         minDwellMs = 0,
         onManualSelection = { selected.add(it) },
       )
-    controller.feed(count = 40, intervalMs = 100) // heavy drop → auto-downgrades
+    controller.feed(count = 60, intervalMs = 60) // heavy drop → auto-downgrades
     assertEquals(VideoStreamQuality.Low, controller.quality.value)
     // Automatic steps re-subscribe via `quality` but must not fire the persistence callback.
     assertEquals(emptyList<VideoStreamQuality>(), selected)
-  }
-
-  @Test
-  fun `an idle gap on a source that omits idle frames does not trigger a downgrade`() {
-    // iOS ScreenCaptureKit drops idle buffers, so a static screen makes no frame progress; when
-    // activity resumes the resumed burst must not read as a drop. Codex's example: 0, 10_000, then
-    // six healthy 33ms frames must NOT downgrade High.
-    val controller =
-      QualityController(
-        initialQuality = VideoStreamQuality.High,
-        targetFps = 30,
-        samplesToDowngrade = 3,
-        minDwellMs = 0,
-      )
-    controller.onFrame(0)
-    controller.onFrame(10_000) // long idle gap — treated as discontinuity, not a ~0fps sample
-    var t = 10_033L
-    repeat(6) {
-      controller.onFrame(t)
-      t += 33
-    }
-    assertEquals(VideoStreamQuality.High, controller.quality.value)
-    // And once enough healthy frames flow the measured rate reflects the real cadence.
-    controller.feed(count = 6, intervalMs = 33, startMs = t)
-    assertTrue(controller.actualFps.value > 24f)
   }
 
   @Test
@@ -213,7 +218,8 @@ class QualityControllerTest {
       )
     controller.selectQuality(VideoStreamQuality.High) // triggers a re-subscribe
     // The first frame after the reconnect arrives a long time later; the reset window swallows it
-    // as the new seed rather than treating the whole gap as one ~0fps interval.
+    // as
+    // the new seed rather than treating the whole gap as one drop sample.
     controller.onFrame(10_000)
     assertEquals(VideoStreamQuality.High, controller.quality.value)
   }

--- a/android/desktop-core/src/test/kotlin/dev/jasonpearson/automobile/desktop/core/workspace/DeviceStreamViewTest.kt
+++ b/android/desktop-core/src/test/kotlin/dev/jasonpearson/automobile/desktop/core/workspace/DeviceStreamViewTest.kt
@@ -16,7 +16,9 @@ import androidx.compose.ui.test.runComposeUiTest
 import androidx.compose.ui.test.waitUntilExactlyOneExists
 import dev.jasonpearson.automobile.desktop.core.control.testSnapshot
 import dev.jasonpearson.automobile.desktop.core.platform.ScreenRecordingSettingsLauncher
+import dev.jasonpearson.automobile.desktop.core.settings.FakeSettingsProvider
 import dev.jasonpearson.automobile.desktop.core.video.FakeVideoStreamSource
+import dev.jasonpearson.automobile.desktop.core.video.VideoStreamQuality
 import dev.jasonpearson.automobile.desktop.core.video.VideoStreamState
 import kotlinx.coroutines.CoroutineScope
 import kotlinx.coroutines.Dispatchers
@@ -37,14 +39,14 @@ class DeviceStreamViewTest {
   @Test
   fun `connects the source for the pane's device`() = runComposeUiTest {
     val source = FakeVideoStreamSource()
-    setContent { MaterialTheme { DeviceStreamView(col(), sourceFactory = { source }) } }
+    setContent { MaterialTheme { DeviceStreamView(col(), sourceFactory = { _, _ -> source }) } }
     waitUntil { source.connectedDeviceId == "emulator-5554" }
   }
 
   @Test
   fun `draws the newest decoded frame as the live mirror`() = runComposeUiTest {
     val source = FakeVideoStreamSource()
-    setContent { MaterialTheme { DeviceStreamView(col(), sourceFactory = { source }) } }
+    setContent { MaterialTheme { DeviceStreamView(col(), sourceFactory = { _, _ -> source }) } }
     waitUntil { source.connectedDeviceId != null }
     source.emitFrame(width = 1, height = 1)
     waitUntil {
@@ -56,7 +58,7 @@ class DeviceStreamViewTest {
   @Test
   fun `shows the refusal reason when the relay is unavailable`() = runComposeUiTest {
     val source = FakeVideoStreamSource(refuseWith = "Live mirroring was refused")
-    setContent { MaterialTheme { DeviceStreamView(col(), sourceFactory = { source }) } }
+    setContent { MaterialTheme { DeviceStreamView(col(), sourceFactory = { _, _ -> source }) } }
     onNodeWithText("Live mirroring was refused").assertIsDisplayed()
   }
 
@@ -64,7 +66,7 @@ class DeviceStreamViewTest {
   fun `shows a waiting hint while streaming before the first frame decodes`() = runComposeUiTest {
     // The fake reports Streaming immediately on connect but emits no frame.
     val source = FakeVideoStreamSource()
-    setContent { MaterialTheme { DeviceStreamView(col(), sourceFactory = { source }) } }
+    setContent { MaterialTheme { DeviceStreamView(col(), sourceFactory = { _, _ -> source }) } }
     onNodeWithText("Waiting for the first frame…").assertIsDisplayed()
   }
 
@@ -85,7 +87,7 @@ class DeviceStreamViewTest {
         MaterialTheme {
           DeviceStreamView(
             iosCol(),
-            sourceFactory = { source },
+            sourceFactory = { _, _ -> source },
             screenRecordingSettingsLauncher = launcher,
           )
         }
@@ -135,7 +137,7 @@ class DeviceStreamViewTest {
             col(),
             enableDeviceControl = true,
             control = armedControlState(scope),
-            sourceFactory = { source },
+            sourceFactory = { _, _ -> source },
           )
         }
       }
@@ -155,7 +157,7 @@ class DeviceStreamViewTest {
           col(),
           enableDeviceControl = true,
           control = armedControlState(scope),
-          sourceFactory = { source },
+          sourceFactory = { _, _ -> source },
         )
       }
     }
@@ -182,7 +184,7 @@ class DeviceStreamViewTest {
             col(),
             enableDeviceControl = true,
             control = armedControlState(scope),
-            sourceFactory = { source },
+            sourceFactory = { _, _ -> source },
           )
         }
       }
@@ -231,7 +233,7 @@ class DeviceStreamViewTest {
             iosCol(),
             enableDeviceControl = true,
             control = control,
-            sourceFactory = { source },
+            sourceFactory = { _, _ -> source },
           )
         }
       }
@@ -251,7 +253,7 @@ class DeviceStreamViewTest {
       MaterialTheme {
         DeviceStreamView(
           column.value,
-          sourceFactory = { source },
+          sourceFactory = { _, _ -> source },
           screenRecordingSettingsLauncher = launcher,
         )
       }
@@ -275,13 +277,68 @@ class DeviceStreamViewTest {
     val source = FakeVideoStreamSource()
     val show = mutableStateOf(true)
     setContent {
-      MaterialTheme { if (show.value) DeviceStreamView(col(), sourceFactory = { source }) }
+      MaterialTheme { if (show.value) DeviceStreamView(col(), sourceFactory = { _, _ -> source }) }
     }
     waitUntil { source.connectedDeviceId == "emulator-5554" }
     runOnUiThread { show.value = false }
     waitUntil { source.connectedDeviceId == null }
     assertNull(source.connectedDeviceId)
   }
+
+  @Test
+  fun `renders the quality overlay only when settings are wired`() = runComposeUiTest {
+    val source = FakeVideoStreamSource()
+    setContent {
+      MaterialTheme {
+        DeviceStreamView(
+          col(),
+          settings = FakeSettingsProvider(streamQualityPreset = "medium"),
+          sourceFactory = { _, _ -> source },
+        )
+      }
+    }
+    onNodeWithText("Low").assertIsDisplayed()
+    onNodeWithText("Medium").assertIsDisplayed()
+    onNodeWithText("High").assertIsDisplayed()
+    onNodeWithText("Auto").assertIsDisplayed()
+  }
+
+  @Test
+  fun `no quality overlay without settings`() = runComposeUiTest {
+    val source = FakeVideoStreamSource()
+    setContent { MaterialTheme { DeviceStreamView(col(), sourceFactory = { _, _ -> source }) } }
+    onAllNodesWithText("Medium").assertCountEquals(0)
+    onAllNodesWithText("Auto").assertCountEquals(0)
+  }
+
+  @Test
+  fun `manual quality selection persists and re-subscribes with the new preset`() =
+    runComposeUiTest {
+      val settings = FakeSettingsProvider(streamQualityPreset = "medium")
+      val requested = mutableListOf<VideoStreamQuality>()
+      val source = FakeVideoStreamSource()
+      setContent {
+        MaterialTheme {
+          DeviceStreamView(
+            col(),
+            settings = settings,
+            sourceFactory = { _, quality ->
+              requested.add(quality)
+              source
+            },
+          )
+        }
+      }
+      waitUntil { requested.isNotEmpty() }
+      // First subscribe uses the persisted Medium preset.
+      assertEquals(VideoStreamQuality.Medium, requested.first())
+
+      onNodeWithText("High").performClick()
+
+      // The choice persists for next launch and the pane re-subscribes at High.
+      waitUntil { requested.contains(VideoStreamQuality.High) }
+      assertEquals("high", settings.streamQualityPreset)
+    }
 
   @Test
   fun `status hints are pinned per state`() {

--- a/android/desktop-core/src/test/kotlin/dev/jasonpearson/automobile/desktop/core/workspace/DeviceStreamViewTest.kt
+++ b/android/desktop-core/src/test/kotlin/dev/jasonpearson/automobile/desktop/core/workspace/DeviceStreamViewTest.kt
@@ -286,29 +286,49 @@ class DeviceStreamViewTest {
   }
 
   @Test
-  fun `renders the quality overlay only when settings are wired`() = runComposeUiTest {
+  fun `shows the collapsed quality overlay on the focused pane`() = runComposeUiTest {
     val source = FakeVideoStreamSource()
     setContent {
       MaterialTheme {
         DeviceStreamView(
           col(),
+          enableDeviceControl = true,
           settings = FakeSettingsProvider(streamQualityPreset = "medium"),
           sourceFactory = { _, _ -> source },
         )
       }
     }
-    onNodeWithText("Low").assertIsDisplayed()
-    onNodeWithText("Medium").assertIsDisplayed()
-    onNodeWithText("High").assertIsDisplayed()
-    onNodeWithText("Auto").assertIsDisplayed()
+    // Collapsed readout: persisted preset + live-vs-target fps (control pane targets 30fps). The
+    // selector chips stay hidden so they cannot intercept a tap on the interactive surface.
+    onNodeWithText("Medium · 0 / 30 fps").assertIsDisplayed()
+    onAllNodesWithText("Auto").assertCountEquals(0)
+  }
+
+  @Test
+  fun `no quality overlay on an unfocused pane even with settings`() = runComposeUiTest {
+    val source = FakeVideoStreamSource()
+    setContent {
+      MaterialTheme {
+        DeviceStreamView(
+          col(),
+          enableDeviceControl = false,
+          settings = FakeSettingsProvider(streamQualityPreset = "medium"),
+          sourceFactory = { _, _ -> source },
+        )
+      }
+    }
+    onAllNodesWithText("fps", substring = true).assertCountEquals(0)
   }
 
   @Test
   fun `no quality overlay without settings`() = runComposeUiTest {
     val source = FakeVideoStreamSource()
-    setContent { MaterialTheme { DeviceStreamView(col(), sourceFactory = { _, _ -> source }) } }
-    onAllNodesWithText("Medium").assertCountEquals(0)
-    onAllNodesWithText("Auto").assertCountEquals(0)
+    setContent {
+      MaterialTheme {
+        DeviceStreamView(col(), enableDeviceControl = true, sourceFactory = { _, _ -> source })
+      }
+    }
+    onAllNodesWithText("fps", substring = true).assertCountEquals(0)
   }
 
   @Test
@@ -321,6 +341,7 @@ class DeviceStreamViewTest {
         MaterialTheme {
           DeviceStreamView(
             col(),
+            enableDeviceControl = true,
             settings = settings,
             sourceFactory = { _, quality ->
               requested.add(quality)
@@ -333,6 +354,8 @@ class DeviceStreamViewTest {
       // First subscribe uses the persisted Medium preset.
       assertEquals(VideoStreamQuality.Medium, requested.first())
 
+      // Expand the collapsed overlay, then pick High.
+      onNodeWithText("Medium · 0 / 30 fps").performClick()
       onNodeWithText("High").performClick()
 
       // The choice persists for next launch and the pane re-subscribes at High.

--- a/android/desktop-core/src/test/kotlin/dev/jasonpearson/automobile/desktop/core/workspace/DeviceStreamViewTest.kt
+++ b/android/desktop-core/src/test/kotlin/dev/jasonpearson/automobile/desktop/core/workspace/DeviceStreamViewTest.kt
@@ -335,31 +335,31 @@ class DeviceStreamViewTest {
   fun `manual quality selection persists and re-subscribes with the new preset`() =
     runComposeUiTest {
       val settings = FakeSettingsProvider(streamQualityPreset = "medium")
-      val requested = mutableListOf<VideoStreamQuality>()
-      val source = FakeVideoStreamSource()
+      // A distinct fake per preset, so the assertions prove a genuine source teardown + replacement
+      // (not the same instance re-used) when the pane re-keys on the new quality.
+      val sources = mutableMapOf<VideoStreamQuality, FakeVideoStreamSource>()
       setContent {
         MaterialTheme {
           DeviceStreamView(
             col(),
             enableDeviceControl = true,
             settings = settings,
-            sourceFactory = { _, quality ->
-              requested.add(quality)
-              source
-            },
+            sourceFactory = { _, quality -> sources.getOrPut(quality) { FakeVideoStreamSource() } },
           )
         }
       }
-      waitUntil { requested.isNotEmpty() }
-      // First subscribe uses the persisted Medium preset.
-      assertEquals(VideoStreamQuality.Medium, requested.first())
+      // First subscribe uses the persisted Medium preset and connects.
+      waitUntil { sources[VideoStreamQuality.Medium]?.connectedDeviceId == "emulator-5554" }
+      val medium = sources.getValue(VideoStreamQuality.Medium)
 
       // Expand the collapsed overlay, then pick High.
       onNodeWithText("Medium · 0 / 30 fps").performClick()
       onNodeWithText("High").performClick()
 
-      // The choice persists for next launch and the pane re-subscribes at High.
-      waitUntil { requested.contains(VideoStreamQuality.High) }
+      // A distinct High source is created and connects, the old Medium source is disposed, and the
+      // choice persists for next launch.
+      waitUntil { sources[VideoStreamQuality.High]?.connectedDeviceId == "emulator-5554" }
+      assertNull("old source disposed on re-key", medium.connectedDeviceId)
       assertEquals("high", settings.streamQualityPreset)
     }
 

--- a/android/desktop-core/src/test/kotlin/dev/jasonpearson/automobile/desktop/core/workspace/StreamQualityControlsTest.kt
+++ b/android/desktop-core/src/test/kotlin/dev/jasonpearson/automobile/desktop/core/workspace/StreamQualityControlsTest.kt
@@ -1,0 +1,74 @@
+package dev.jasonpearson.automobile.desktop.core.workspace
+
+import androidx.compose.material3.MaterialTheme
+import androidx.compose.ui.test.ExperimentalTestApi
+import androidx.compose.ui.test.assertIsDisplayed
+import androidx.compose.ui.test.onNodeWithText
+import androidx.compose.ui.test.performClick
+import androidx.compose.ui.test.runComposeUiTest
+import dev.jasonpearson.automobile.desktop.core.video.VideoStreamQuality
+import org.junit.Assert.assertEquals
+import org.junit.Test
+
+@OptIn(ExperimentalTestApi::class)
+class StreamQualityControlsTest {
+
+  @Test
+  fun `shows the actual and target frame rate`() = runComposeUiTest {
+    setContent {
+      MaterialTheme {
+        StreamQualityControls(
+          currentQuality = VideoStreamQuality.Medium,
+          actualFps = 23.6f,
+          targetFps = 30,
+          autoAdjustEnabled = true,
+          onSelectQuality = {},
+          onToggleAutoAdjust = {},
+        )
+      }
+    }
+    // Actual fps is rounded; target is the pane's requested rate.
+    onNodeWithText("24 / 30 fps").assertIsDisplayed()
+  }
+
+  @Test
+  fun `offers every quality preset and reports the manual choice`() = runComposeUiTest {
+    var selected: VideoStreamQuality? = null
+    setContent {
+      MaterialTheme {
+        StreamQualityControls(
+          currentQuality = VideoStreamQuality.Medium,
+          actualFps = 30f,
+          targetFps = 30,
+          autoAdjustEnabled = true,
+          onSelectQuality = { selected = it },
+          onToggleAutoAdjust = {},
+        )
+      }
+    }
+    onNodeWithText("Low").assertIsDisplayed()
+    onNodeWithText("Medium").assertIsDisplayed()
+    onNodeWithText("High").assertIsDisplayed()
+    onNodeWithText("High").performClick()
+    assertEquals(VideoStreamQuality.High, selected)
+  }
+
+  @Test
+  fun `toggles automatic adjustment`() = runComposeUiTest {
+    var toggledTo: Boolean? = null
+    setContent {
+      MaterialTheme {
+        StreamQualityControls(
+          currentQuality = VideoStreamQuality.Low,
+          actualFps = 10f,
+          targetFps = 30,
+          autoAdjustEnabled = true,
+          onSelectQuality = {},
+          onToggleAutoAdjust = { toggledTo = it },
+        )
+      }
+    }
+    onNodeWithText("Auto").performClick()
+    assertEquals(false, toggledTo)
+  }
+}

--- a/android/desktop-core/src/test/kotlin/dev/jasonpearson/automobile/desktop/core/workspace/StreamQualityControlsTest.kt
+++ b/android/desktop-core/src/test/kotlin/dev/jasonpearson/automobile/desktop/core/workspace/StreamQualityControlsTest.kt
@@ -2,7 +2,9 @@ package dev.jasonpearson.automobile.desktop.core.workspace
 
 import androidx.compose.material3.MaterialTheme
 import androidx.compose.ui.test.ExperimentalTestApi
+import androidx.compose.ui.test.assertCountEquals
 import androidx.compose.ui.test.assertIsDisplayed
+import androidx.compose.ui.test.onAllNodesWithText
 import androidx.compose.ui.test.onNodeWithText
 import androidx.compose.ui.test.performClick
 import androidx.compose.ui.test.runComposeUiTest
@@ -14,7 +16,7 @@ import org.junit.Test
 class StreamQualityControlsTest {
 
   @Test
-  fun `shows the actual and target frame rate`() = runComposeUiTest {
+  fun `collapsed shows the preset and frame rate but no selector`() = runComposeUiTest {
     setContent {
       MaterialTheme {
         StreamQualityControls(
@@ -22,17 +24,43 @@ class StreamQualityControlsTest {
           actualFps = 23.6f,
           targetFps = 30,
           autoAdjustEnabled = true,
+          expanded = false,
+          onToggleExpanded = {},
           onSelectQuality = {},
           onToggleAutoAdjust = {},
         )
       }
     }
-    // Actual fps is rounded; target is the pane's requested rate.
-    onNodeWithText("24 / 30 fps").assertIsDisplayed()
+    // Readout: current preset + rounded actual over target. Selector chips are hidden until
+    // expanded.
+    onNodeWithText("Medium · 24 / 30 fps").assertIsDisplayed()
+    onAllNodesWithText("Low").assertCountEquals(0)
+    onAllNodesWithText("Auto").assertCountEquals(0)
   }
 
   @Test
-  fun `offers every quality preset and reports the manual choice`() = runComposeUiTest {
+  fun `tapping the readout toggles the selector open`() = runComposeUiTest {
+    var toggled = 0
+    setContent {
+      MaterialTheme {
+        StreamQualityControls(
+          currentQuality = VideoStreamQuality.Medium,
+          actualFps = 30f,
+          targetFps = 30,
+          autoAdjustEnabled = true,
+          expanded = false,
+          onToggleExpanded = { toggled++ },
+          onSelectQuality = {},
+          onToggleAutoAdjust = {},
+        )
+      }
+    }
+    onNodeWithText("Medium · 30 / 30 fps").performClick()
+    assertEquals(1, toggled)
+  }
+
+  @Test
+  fun `expanded offers every preset and reports the manual choice`() = runComposeUiTest {
     var selected: VideoStreamQuality? = null
     setContent {
       MaterialTheme {
@@ -41,20 +69,21 @@ class StreamQualityControlsTest {
           actualFps = 30f,
           targetFps = 30,
           autoAdjustEnabled = true,
+          expanded = true,
+          onToggleExpanded = {},
           onSelectQuality = { selected = it },
           onToggleAutoAdjust = {},
         )
       }
     }
     onNodeWithText("Low").assertIsDisplayed()
-    onNodeWithText("Medium").assertIsDisplayed()
     onNodeWithText("High").assertIsDisplayed()
     onNodeWithText("High").performClick()
     assertEquals(VideoStreamQuality.High, selected)
   }
 
   @Test
-  fun `toggles automatic adjustment`() = runComposeUiTest {
+  fun `expanded toggles automatic adjustment`() = runComposeUiTest {
     var toggledTo: Boolean? = null
     setContent {
       MaterialTheme {
@@ -63,6 +92,8 @@ class StreamQualityControlsTest {
           actualFps = 10f,
           targetFps = 30,
           autoAdjustEnabled = true,
+          expanded = true,
+          onToggleExpanded = {},
           onSelectQuality = {},
           onToggleAutoAdjust = { toggledTo = it },
         )

--- a/android/ide-plugin/src/main/kotlin/dev/jasonpearson/automobile/ide/settings/AutoMobileSettings.kt
+++ b/android/ide-plugin/src/main/kotlin/dev/jasonpearson/automobile/ide/settings/AutoMobileSettings.kt
@@ -21,6 +21,8 @@ class AutoMobileSettings : PersistentStateComponent<AutoMobileSettings>, Setting
   override var iosIde: String = "auto"
   override var themeMode: String = "dark"
   override var hasSeenOnboarding: Boolean = false
+  override var streamQualityPreset: String = "medium"
+  override var streamQualityAutoAdjust: Boolean = true
 
   override fun getState(): AutoMobileSettings = this
 

--- a/docs/design-docs/mcp/observe/screen-streaming.md
+++ b/docs/design-docs/mcp/observe/screen-streaming.md
@@ -150,11 +150,17 @@ when the last subscriber for a device disconnects.
 
 ## Quality Presets
 
-| Quality | Android Bitrate | Resolution | Target FPS |
+| Quality | Android Bitrate | Resolution | Preset FPS |
 |---------|-----------------|------------|------------|
 | Low | 2 Mbps | 540p | 30 |
-| Medium | 4 Mbps | 720p | 60 |
-| High | 8 Mbps | 1080p | 60 |
+| Medium | 4 Mbps | 720p | 30 |
+| High | 8 Mbps | 1080p | 30 |
+
+The preset FPS is the on-device encoder default (`QualityPreset` — 30fps for every preset, since UI
+automation is mostly static frames and 30fps roughly halves encode load versus 60 for no observable
+benefit). The host may still override it per subscribe with `fps` in the 5–60 range; the desktop
+mirror requests 30fps for the focused/controlled pane and 10fps for display-only farm mirrors,
+independent of preset.
 
 iOS streams raw frames, so quality is controlled by resolution scaling only.
 
@@ -172,7 +178,7 @@ When video streaming is unavailable:
 |----------|----------|
 | Audio streaming | Include audio for complete mirroring |
 | Touch input | Plan for it, implement later |
-| Quality auto-adjustment | Automatically lower quality on frame drops |
+| Quality auto-adjustment | Client-side on the desktop mirror: a per-pane controller measures the decoded frame rate and steps the preset down on a sustained drop / back up once healthy, applied by re-subscribing. Because a shared per-device capture's encode is fixed by the first subscriber (see Stream Control), this takes effect for a sole subscriber / the next subscribe; reconfiguring a live shared capture is a server-side follow-up. |
 | Multiple devices | Concurrent per-device streams — one shared capture per device, fanned out to its subscribers, so the desktop workspace mirrors many device panes at once |
 | Android decoder | `org.bytedeco:ffmpeg` (in-process JNI), host-platform classifier only. Klarity was the original choice but cannot consume a live stream — its API takes file paths only. No FFmpeg *subprocess* fallback. |
 | iOS Swift integration | Swift-to-Node bridge |

--- a/docs/design-docs/plat/android/screen-streaming.md
+++ b/docs/design-docs/plat/android/screen-streaming.md
@@ -224,14 +224,14 @@ That keeps the installer growth to ~20–30 MB per platform. The decoder reads a
 - [ ] Supply that frame: `LayoutInspectorDashboard` must construct a client and collect its frames
 - [ ] Choose live vs screenshot at runtime and fall back on `VideoStreamState.Unavailable`
 - [ ] Frame-rate policy — the existing screenshot flow is `replay = 1` with no conflation and will not survive 60fps
-- [ ] Add FPS counter overlay
-- [ ] Implement latency measurement
-- [ ] Add quality/resolution controls
+- [x] Add FPS counter overlay — the focused pane's `StreamQualityControls` shows measured-vs-target fps (#1098)
+- [ ] Implement latency measurement — decode/end-to-end latency overlay still a follow-up
+- [x] Add quality/resolution controls — Low/Medium/High preset selector on the focused pane; resolution follows the preset (#1098)
 
 ### Milestone 5: Polish
 - [ ] Handle device disconnect/reconnect
 - [ ] Add fallback to screenshot mode
-- [ ] Automatic quality adjustment on frame drops
+- [x] Automatic quality adjustment on frame drops — client-side `QualityController` steps the preset and re-subscribes; because a shared per-device capture's encode is fixed by the first subscriber, this applies for a sole subscriber / the next subscribe, and reconfiguring a live shared capture is a server-side follow-up (#1098)
 - [ ] Optimize memory (double buffering, frame pooling)
 
 ## References


### PR DESCRIPTION
## Summary

Implements quality controls and client-side automatic quality adjustment for the
desktop app's live device mirror.

Per the issue's kaeawc-authored **refocusing note**, #1098 was re-scoped before
building: the primary consumer of the device video stream is now the **desktop app**
(H.264 over `video-stream.sock`, decoded via bytedeco FFmpeg), and auto-adjustment
was chosen to live **client-side**. The original IDE-plugin framing and the "60 fps"
Medium/High targets in the body are stale; this follows the real on-device
`QualityPreset` table (Low 540p/2 Mbps, Medium 720p/4 Mbps, High 1080p/8 Mbps, all
30 fps).

Each pane gains a small overlay: a Low/Medium/High selector, live-vs-target FPS, and
an auto-adjust toggle. A pure `QualityController` derives the frame rate from decoded
frames and steps the preset down on a sustained drop / back up once healthy, with
hysteresis and a minimum dwell so a brief dip can't thrash the encode. The chosen
preset and auto-adjust flag persist across sessions.

**Architectural limit (honest):** the relay fixes a capture's encode at subscribe
time — there is no mid-stream control channel and the first subscriber wins for a
shared capture. So a quality change applies by re-subscribing, which takes effect for
a sole subscriber / the next subscribe. Reconfiguring a *live shared* capture needs
server-side work and is filed as a follow-up (see below).

## Changes
- `QualityController` (new): EMA frame-rate meter + hysteresis/min-dwell decision
  engine, driven purely by decoded-frame timestamps (no clock injection needed).
- `StreamQualityControls` (new): compact overlay — preset selector, FPS readout,
  auto-adjust toggle — wired into `DeviceStreamView`.
- `VideoStreamQuality`: `lower()`/`higher()`/`fromWire()` helpers.
- `SettingsProvider`/`FileSettingsProvider`/`FakeSettingsProvider` (+ IDE
  `AutoMobileSettings`): persist `streamQualityPreset` and `streamQualityAutoAdjust`.
- `DeviceStreamView` gains an optional `settings` param; when absent, behavior is
  unchanged (fixed per-mode preset, no overlay), so existing embeddings/tests are
  untouched.

## Linked Issue
Closes #1098

## Validation
- [x] `:desktop-core:test` passes (full module suite; new `QualityControllerTest`,
      `StreamQualityControlsTest`, `DeviceStreamViewTest`, `FileSettingsProviderTest`)
- [x] `:desktop-app` + `:ide-plugin` compile
- [x] `:desktop-core:detekt`, `:desktop-app:detekt`, `:ide-plugin:detekt` pass
- [x] `scripts/ktfmt/validate_ktfmt.sh` passes
- [x] Native-source turbo-inputs guard passes; no TypeScript touched (typecheck/lint
      baselines unaffected)
- [x] New logic uses a pure, injectable controller; unit tests run in <100ms

## Kotlin Reuse Check
- [x] Reused the existing `SettingsProvider` persistence primitive, the on-device
      `QualityPreset` table (via `VideoStreamQuality`), and the existing Chip/overlay
      Compose idiom rather than adding helpers or dependencies
- [x] No new dependencies

## Acceptance Criteria
- [x] User can manually select quality preset — selector persists + re-subscribes
- [x] Quality auto-adjusts based on frame drops — `QualityController` (client-side)
- [x] FPS and quality indicators visible in UI — overlay actual/target FPS + preset
- [x] Settings persist across sessions — `SettingsProvider`

## Follow-ups
- [ ] Server-side capture reconfiguration so an auto-adjust/manual change applies to a
      *live shared* capture (today it applies on re-subscribe / sole-subscriber only).
- [ ] Optional decode/end-to-end latency readout in the overlay (needs
      `VideoStreamClient`/`LiveVideoFrame` timing) — beyond this issue's ACs.
