### PR TITLE
feat(voiceover): enable/disable VoiceOver on physical iOS devices (#2501)

### DIFF
--- a/docs/design-docs/mcp/a11y/talkback-voiceover.md
+++ b/docs/design-docs/mcp/a11y/talkback-voiceover.md
@@ -7,7 +7,7 @@
 > - **Android (TalkBack):** detection via ADB secure settings; TalkBack-aware `tapOn` (direct `ACTION_CLICK` activation, capability-gated semantic `ClickableSpan` activation, and opt-in cursor navigation behind the `screen-reader-navigation` feature flag) and `swipeOn` (`ACTION_SCROLL_FORWARD`/`BACKWARD` with a two-finger fallback).
 > - **iOS (VoiceOver):** detection via CtrlProxy and VoiceOver-aware tap (label-based accessibility activation). VoiceOver scrolling is unsupported: CtrlProxy scroll endpoints synthesize XCTest swipes, which do not reach VoiceOver, and there is no functional three-finger gesture fallback. The runner reports the VoiceOver cursor when the foreground app supplies SDK-enriched hierarchy data.
 >
-> **Still open:** iOS focus *control* (set/clear focus, cursor stepping), VoiceOver Rotor, Magic Tap, and physical-device VoiceOver toggle. See [`voiceover-talkback-parity.md`](./voiceover-talkback-parity.md) — the source of truth for remaining gaps — and the [Status Glossary](../../status-glossary.md) for chip definitions.
+> **Still open:** iOS focus *control* (set/clear focus, cursor stepping), VoiceOver Rotor, and Magic Tap. See [`voiceover-talkback-parity.md`](./voiceover-talkback-parity.md) — the source of truth for remaining gaps — and the [Status Glossary](../../status-glossary.md) for chip definitions.
 
 ## Overview
 
@@ -193,6 +193,33 @@ iOS VoiceOver follows the same phased approach. Key differences:
 | Focus API | `FOCUS_ACCESSIBILITY` | `UIAccessibilityFocus` |
 | Rotor | No equivalent | Two-finger rotate for navigation modes |
 
+#### Enabling/disabling VoiceOver
+
+The `accessibility { voiceover }` tool toggles VoiceOver through two strategies,
+chosen by device type (`VoiceOverToggle`):
+
+- **Simulator** — writes `com.apple.Accessibility VoiceOverTouchEnabled` via
+  `xcrun simctl spawn … defaults write`, posts the
+  `com.apple.accessibility.VoiceOverStatusDidChange` Darwin notification, and
+  kickstarts/kills `com.apple.VoiceOverTouch`, then re-detects to confirm.
+- **Physical device** — there is no command-line write into a real device's
+  system-preferences domain (no `simctl`/`defaults`/`notifyutil` analog), and no
+  public toggle API. The only realistic mechanism is automating the **Settings
+  app** through the CtrlProxy runner (`set_voiceover_state` → `handleSetVoiceOverState`):
+  deep-link to `App-Prefs:root=ACCESSIBILITY`, read the VoiceOver switch, and tap
+  only when it differs.
+
+  This physical path is deliberately **fragile and narrowly scoped**:
+  - **English locale only** for initial support — the switch is matched by the
+    "VoiceOver" label; other locales are not yet handled.
+  - **Layout drift** across iOS versions can move or rename the switch; a switch
+    that can't be located returns `supported:false` with a reason (surfaced as an
+    `ActionableError`), never a silent success.
+  - **Idempotent by necessity**: the runner early-returns when VoiceOver is
+    already in the requested state and does *not* tap. Once VoiceOver is on, every
+    tap requires the double-tap idiom, so a blind re-tap would be interpreted as a
+    VoiceOver activation rather than a toggle.
+
 ---
 
 ## Still Open
@@ -207,11 +234,11 @@ source of truth for remaining gaps:
   Standard headings are instead exposed as `role: "heading"` in SDK-backed iOS observations;
   custom rotors and Rotor-driven cursor navigation remain unavailable (parity doc Gap 4).
 - **VoiceOver Magic Tap**: two-finger double-tap for an app's primary action (parity doc Gap 5).
-- **Physical-device VoiceOver toggle**: simulator-only today; no known `idevice` equivalent.
 - **Announcement control**: trigger screen-reader announcements for user testing.
 - **Accessibility tree export**: full node hierarchy with actions, for debugging.
 - **TalkBack context menus**: local/global menu gestures.
 
 Delivered since this document was written, and no longer "future": TalkBack and VoiceOver
  detection, tap adaptation on both platforms, Android scroll-action swipe with a two-finger
- fallback, unsupported iOS VoiceOver scrolling, and WCAG auditing alongside screen-reader support.
+ fallback, unsupported iOS VoiceOver scrolling, physical-device VoiceOver enable/disable via
+ Settings automation, and WCAG auditing alongside screen-reader support.

--- a/docs/design-docs/mcp/a11y/voiceover-talkback-parity.md
+++ b/docs/design-docs/mcp/a11y/voiceover-talkback-parity.md
@@ -17,8 +17,8 @@ This document compares iOS VoiceOver and Android TalkBack support in AutoMobile 
 | `pressButton` | ✅ Unchanged | ✅ Unchanged | Device/navigation buttons |
 | `accessibilityState` in observe | ✅ `service: "talkback"` | ✅ `service: "voiceover"` | |
 | `accessibilityFocusedElement` | ✅ Reported | ✅ With iOS SDK | Requires SDK-enriched hierarchy |
-| Programmatic enable/disable | ✅ Via ADB | ✅ Simulator only | Physical device support deferred |
-| MCP tool to toggle | ✅ `TalkBackToggle` | ✅ `VoiceOverToggle` (Simulator) | Gap — see below |
+| Programmatic enable/disable | ✅ Via ADB | ✅ Simulator + physical device | Physical uses Settings automation (English locale) |
+| MCP tool to toggle | ✅ `TalkBackToggle` | ✅ `VoiceOverToggle` (Simulator + device) | See Gap 2/3 below |
 | Three-finger swipe fallback | N/A | ✅ | VoiceOver-specific |
 | Two-finger swipe fallback | ✅ | N/A | TalkBack-specific |
 | Boomerang gesture | ✅ | ✅ | Both supported |
@@ -108,7 +108,7 @@ This document compares iOS VoiceOver and Android TalkBack support in AutoMobile 
 VoiceOver and TalkBack reach parity on the core automation behaviors: detection, tool adaptations, gesture fallbacks, and observe output. The primary gaps are:
 
 1. **Accessibility cursor tracking** (Gap 1) — most impactful for agent validation workflows
-2. **Programmatic toggle** (Gaps 2 & 3) — resolved for iOS Simulator; physical device support remains a gap
+2. **Programmatic toggle** (Gaps 2 & 3) — resolved for iOS Simulator and physical devices (physical via Settings automation, English locale)
 3. **Rotor and Magic Tap** (Gaps 4 & 5) — advanced VoiceOver interactions not tested
 4. **iOS 17+ RemoteXPC** (Gap 6) — blocks direct DTX snapshot path on modern iOS
 

--- a/docs/design-docs/mcp/a11y/voiceover-talkback-parity.md
+++ b/docs/design-docs/mcp/a11y/voiceover-talkback-parity.md
@@ -42,21 +42,19 @@ This document compares iOS VoiceOver and Android TalkBack support in AutoMobile 
 
 ---
 
-### Gap 2: No programmatic VoiceOver toggle — RESOLVED (iOS Simulator)
+### Gap 2: No programmatic VoiceOver toggle — RESOLVED (Simulator + physical device)
 
 **TalkBack:** AutoMobile provides `TalkBackToggle.ts` — an MCP tool that enables or disables TalkBack via ADB secure settings. Agents can script test sessions that programmatically toggle TalkBack before and after test cases.
 
 **VoiceOver (Simulator):** Resolved via `xcrun simctl spawn <udid> defaults write com.apple.Accessibility VoiceOverTouchEnabled -bool YES/NO` followed by a `notifyutil -p com.apple.accessibility.VoiceOverStatusDidChange` notification. `VoiceOverToggle.ts` implements this and is exposed through the `accessibility` MCP tool (`voiceover: true/false`).
 
-**VoiceOver (Physical device):** No known `idevice` equivalent. Physical device support remains a gap. Enabling VoiceOver on a physical device still requires:
-- Manual: Settings > Accessibility > VoiceOver inside the device
-- Manual: Triple-click the side button (if Accessibility Shortcut is configured)
+**VoiceOver (Physical device):** Resolved by automating the Settings app through the CtrlProxy runner — there is still no `idevice`/`devicectl` equivalent and no public toggle API, so `VoiceOverToggle` routes physical devices to a `set_voiceover_state` runner command that deep-links to `App-Prefs:root=ACCESSIBILITY`, reads the VoiceOver switch, and taps only when it differs. This path is deliberately narrow: **English locale only**, sensitive to Settings **layout drift** across iOS versions, and idempotent by necessity (once VoiceOver is on, a tap is a double-tap-idiom activation, so the runner early-returns when already in the target state). A switch that can't be located returns `supported:false` with a reason rather than a silent success.
 
-**Impact (remaining):** VoiceOver test sessions on physical devices cannot be fully automated. CI-level VoiceOver testing on physical hardware requires the device to have VoiceOver pre-enabled.
+**Impact (remaining):** Physical-device toggling works in English locale; other locales and future Settings layout changes may still require the device to have VoiceOver pre-enabled or manual intervention.
 
 ---
 
-### Gap 3: No VoiceOver MCP toggle tool — RESOLVED (iOS Simulator)
+### Gap 3: No VoiceOver MCP toggle tool — RESOLVED (Simulator + physical device)
 
 **TalkBack:** The `accessibility` MCP tool (backed by `TalkBackToggle.ts`) enables/disables TalkBack from an agent session.
 
@@ -65,7 +63,7 @@ This document compares iOS VoiceOver and Android TalkBack support in AutoMobile 
 - `accessibility({ voiceover: false })` → `{ voiceover: { supported: true, applied: true, currentState: false } }`
 - `accessibility({})` → `{ enabled: true, service: "voiceover" }` (detect-only, unchanged)
 
-**VoiceOver (Physical device):** Returns `{ supported: false, applied: false, reason: "VoiceOver toggle is only supported on iOS Simulator" }`.
+**VoiceOver (Physical device):** Now supported via Settings automation (see Gap 2). `accessibility({ voiceover: true })` drives the device's Settings > Accessibility > VoiceOver switch through the runner and returns `{ supported: true, applied: true, currentState: true }`; a Settings row that can't be located (locale/layout drift) returns `{ supported: false, applied: false, reason: <specific message> }`, surfaced as an `ActionableError`.
 
 ---
 

--- a/ios/control-proxy/Sources/CtrlProxy/CommandHandler.swift
+++ b/ios/control-proxy/Sources/CtrlProxy/CommandHandler.swift
@@ -24,6 +24,7 @@ public class CommandHandler: CommandHandling {
     private let sdkDatabaseClient: (any SdkDatabaseFetching)?
     private let hierarchyDebouncer: (any HierarchyDebouncing)?
     private let voiceOverStateProvider: any VoiceOverStateProviding
+    private let voiceOverToggle: any VoiceOverToggling
     private let frameContext: FrameContext
 
     public init(
@@ -36,6 +37,7 @@ public class CommandHandler: CommandHandling {
         sdkDatabaseClient: (any SdkDatabaseFetching)? = nil,
         hierarchyDebouncer: (any HierarchyDebouncing)? = nil,
         voiceOverStateProvider: any VoiceOverStateProviding = DefaultVoiceOverStateProvider(),
+        voiceOverToggle: any VoiceOverToggling = DefaultVoiceOverToggle(),
         frameContext: FrameContext = FrameContext()
     ) {
         self.elementLocator = elementLocator
@@ -47,6 +49,7 @@ public class CommandHandler: CommandHandling {
         self.sdkDatabaseClient = sdkDatabaseClient
         self.hierarchyDebouncer = hierarchyDebouncer
         self.voiceOverStateProvider = voiceOverStateProvider
+        self.voiceOverToggle = voiceOverToggle
         self.frameContext = frameContext
     }
 
@@ -61,6 +64,7 @@ public class CommandHandler: CommandHandling {
         sdkDatabaseClient: (any SdkDatabaseFetching)? = nil,
         hierarchyDebouncer: (any HierarchyDebouncing)? = nil,
         voiceOverStateProvider: any VoiceOverStateProviding = DefaultVoiceOverStateProvider(),
+        voiceOverToggle: any VoiceOverToggling = DefaultVoiceOverToggle(),
         frameContext: FrameContext = FrameContext()
     )
         -> CommandHandler
@@ -75,6 +79,7 @@ public class CommandHandler: CommandHandling {
             sdkDatabaseClient: sdkDatabaseClient,
             hierarchyDebouncer: hierarchyDebouncer,
             voiceOverStateProvider: voiceOverStateProvider,
+            voiceOverToggle: voiceOverToggle,
             frameContext: frameContext
         )
     }
@@ -182,6 +187,9 @@ public class CommandHandler: CommandHandling {
 
             case let .getVoiceOverState(payload):
                 return try handleGetVoiceOverState(payload, startTime: startTime)
+
+            case let .setVoiceOverState(payload):
+                return handleSetVoiceOverState(payload, startTime: startTime)
 
             // Storage commands
             case let .listPreferenceFiles(payload):
@@ -1266,6 +1274,47 @@ public class CommandHandler: CommandHandling {
             enabled: enabled,
             totalTimeMs: totalTimeMs(from: startTime)
         )
+    }
+
+    /// Enable/disable VoiceOver on a physical device by driving Settings (#2501).
+    ///
+    /// Idempotent: when VoiceOver is already in the requested state this early-
+    /// returns WITHOUT tapping. That guard is load-bearing, not just an
+    /// optimization — once VoiceOver is on, every tap requires the double-tap
+    /// idiom, so a blind re-tap on the switch would be interpreted as a VoiceOver
+    /// activation rather than a toggle. A locale/layout drift that hides the
+    /// switch surfaces as `success: false` with an error, never a silent success.
+    private func handleSetVoiceOverState(
+        _ request: RequestSetVoiceOverState,
+        startTime: Date
+    )
+        -> VoiceOverSetResponse
+    {
+        let enabled = request.enabled
+
+        if voiceOverStateProvider.isVoiceOverRunning() == enabled {
+            return VoiceOverSetResponse(
+                requestId: request.requestId,
+                success: true,
+                totalTimeMs: totalTimeMs(from: startTime)
+            )
+        }
+
+        do {
+            try voiceOverToggle.setVoiceOver(enabled: enabled)
+            return VoiceOverSetResponse(
+                requestId: request.requestId,
+                success: true,
+                totalTimeMs: totalTimeMs(from: startTime)
+            )
+        } catch {
+            return VoiceOverSetResponse(
+                requestId: request.requestId,
+                success: false,
+                error: error.localizedDescription,
+                totalTimeMs: totalTimeMs(from: startTime)
+            )
+        }
     }
 
     // MARK: - Storage

--- a/ios/control-proxy/Sources/CtrlProxy/Models.swift
+++ b/ios/control-proxy/Sources/CtrlProxy/Models.swift
@@ -216,6 +216,13 @@ public struct RequestAddHighlight: Decodable {
     public var shape: HighlightShape?
 }
 
+/// Request to enable/disable VoiceOver by driving the Settings app (physical
+/// devices have no `simctl` toggle; the host handles the Simulator). See #2501.
+public struct RequestSetVoiceOverState: Decodable {
+    public var requestId: String?
+    public var enabled: Bool
+}
+
 // MARK: Storage inspection
 
 public struct RequestGetPreferences: Decodable {
@@ -348,6 +355,7 @@ extension RequestResetPermissions: CommandPayload {}
 extension RequestRotate: CommandPayload {}
 extension RequestClipboard: CommandPayload {}
 extension RequestAddHighlight: CommandPayload {}
+extension RequestSetVoiceOverState: CommandPayload {}
 extension RequestGetPreferences: CommandPayload {}
 extension RequestGetPreference: CommandPayload {}
 extension RequestSetPreference: CommandPayload {}
@@ -405,6 +413,7 @@ public enum WebSocketRequest: Decodable {
     case getTraversalOrder(RequestEnvelope)
     case addHighlight(RequestAddHighlight)
     case getVoiceOverState(RequestEnvelope)
+    case setVoiceOverState(RequestSetVoiceOverState)
 
     case listPreferenceFiles(RequestEnvelope)
     case getPreferences(RequestGetPreferences)
@@ -503,6 +512,8 @@ public enum WebSocketRequest: Decodable {
             self = try .addHighlight(RequestAddHighlight(from: decoder))
         case .getVoiceOverState:
             self = try .getVoiceOverState(RequestEnvelope(from: decoder))
+        case .setVoiceOverState:
+            self = try .setVoiceOverState(RequestSetVoiceOverState(from: decoder))
         case .listPreferenceFiles:
             self = try .listPreferenceFiles(RequestEnvelope(from: decoder))
         case .getPreferences:
@@ -570,6 +581,7 @@ public enum WebSocketRequest: Decodable {
         case .getTraversalOrder: return .getTraversalOrder
         case .addHighlight: return .addHighlight
         case .getVoiceOverState: return .getVoiceOverState
+        case .setVoiceOverState: return .setVoiceOverState
         case .listPreferenceFiles: return .listPreferenceFiles
         case .getPreferences: return .getPreferences
         case .getPreference: return .getPreference
@@ -613,6 +625,7 @@ public enum WebSocketRequest: Decodable {
              let .getVoiceOverState(payload),
              let .listPreferenceFiles(payload):
             return payload
+        case let .setVoiceOverState(payload): return payload
         case let .tapCoordinates(payload): return payload
         case let .swipe(payload): return payload
         case let .twoFingerSwipe(payload), let .multiFingerSwipe(payload):
@@ -1770,6 +1783,32 @@ public struct VoiceOverStateResponse: Codable {
     }
 }
 
+// MARK: - VoiceOver Set Response
+
+/// Response to set_voiceover_state command (physical-device toggle via Settings).
+///
+/// Carries an explicit `success`/`error` rather than throwing, so that a
+/// locale/layout drift that leaves the VoiceOver row unlocatable surfaces to the
+/// client as a typed failure (`VoiceOverToggle` maps it to `supported:false`),
+/// never a silent success (#2501).
+public struct VoiceOverSetResponse: Codable {
+    public let type: String
+    public let timestamp: Int64
+    public let requestId: String?
+    public let success: Bool
+    public let error: String?
+    public let totalTimeMs: Int64?
+
+    public init(requestId: String?, success: Bool, error: String? = nil, totalTimeMs: Int64?) {
+        type = ResponseType.voiceOverSetResult.rawValue
+        timestamp = Int64(Date().timeIntervalSince1970 * 1000)
+        self.requestId = requestId
+        self.success = success
+        self.error = error
+        self.totalTimeMs = totalTimeMs
+    }
+}
+
 // MARK: - Request Types (matching Android)
 
 public enum RequestType: String, CaseIterable {
@@ -1819,6 +1858,7 @@ public enum RequestType: String, CaseIterable {
     case getTraversalOrder = "get_traversal_order"
     case addHighlight = "add_highlight"
     case getVoiceOverState = "get_voiceover_state"
+    case setVoiceOverState = "set_voiceover_state"
 
     // Storage inspection
     case listPreferenceFiles = "list_preference_files"
@@ -1874,6 +1914,7 @@ public enum ResponseType: String {
     case traversalOrderResult = "traversal_order_result"
     case highlightResponse = "highlight_response"
     case voiceOverStateResult = "voiceover_state_result"
+    case voiceOverSetResult = "voiceover_set_result"
     case connected
 
     // Storage inspection
@@ -1941,6 +1982,7 @@ extension RequestType {
         case .getTraversalOrder: return .traversalOrderResult
         case .addHighlight: return .highlightResponse
         case .getVoiceOverState: return .voiceOverStateResult
+        case .setVoiceOverState: return .voiceOverSetResult
         case .listPreferenceFiles: return .preferenceFiles
         case .getPreferences: return .preferences
         case .getPreference: return .getPreferenceResult

--- a/ios/control-proxy/Sources/CtrlProxy/VoiceOverStateProvider.swift
+++ b/ios/control-proxy/Sources/CtrlProxy/VoiceOverStateProvider.swift
@@ -1,4 +1,7 @@
 import Foundation
+#if canImport(XCTest) && os(iOS)
+    import XCTest
+#endif
 
 /// Reads the simulator's VoiceOver service liveness state.
 ///
@@ -21,6 +24,67 @@ public final class SystemVoiceOverDefaultsReader: VoiceOverDefaultsReading {
             return UserDefaults(suiteName: domain)?.bool(forKey: key) ?? false
         #else
             return false
+        #endif
+    }
+}
+
+/// Drives the VoiceOver on/off switch. On a physical device there is no
+/// command-line write into the system-preferences domain, so the only realistic
+/// mechanism is automating the Settings app (#2501). Behind a protocol so the
+/// command handler's idempotent-early-return and error mapping stay unit-testable
+/// with a fake, while the fragile XCUITest automation lives in the default impl.
+public protocol VoiceOverToggling {
+    /// Set VoiceOver to `enabled`. Throws when the switch cannot be located
+    /// (locale/layout drift) so the caller can surface a typed failure rather
+    /// than a silent success. Callers must only invoke this when the current
+    /// state already differs from `enabled` — once VoiceOver is on, a tap is a
+    /// VoiceOver activation, not a toggle.
+    func setVoiceOver(enabled: Bool) throws
+}
+
+public enum VoiceOverToggleError: LocalizedError {
+    case switchNotFound
+    case unsupportedPlatform
+
+    public var errorDescription: String? {
+        switch self {
+        case .switchNotFound:
+            return "VoiceOver toggle row not found in Settings (locale or layout drift)"
+        case .unsupportedPlatform:
+            return "VoiceOver Settings toggle is only available on iOS devices"
+        }
+    }
+}
+
+/// Physical-device VoiceOver toggle by automating Settings → Accessibility.
+///
+/// Deep-links straight to the Accessibility pane (`App-Prefs:root=ACCESSIBILITY`)
+/// to avoid locale-fragile navigation, then taps the VoiceOver switch. English
+/// locale only for initial support; the switch is matched by label with an
+/// identifier fallback.
+public final class DefaultVoiceOverToggle: VoiceOverToggling {
+    private static let settingsBundleId = "com.apple.Preferences"
+    private static let accessibilityDeepLink = "App-Prefs:root=ACCESSIBILITY"
+    private static let switchExistenceTimeout: TimeInterval = 5
+
+    public init() {}
+
+    public func setVoiceOver(enabled _: Bool) throws {
+        #if canImport(XCTest) && os(iOS)
+            let settings = XCUIApplication(bundleIdentifier: Self.settingsBundleId)
+            settings.activate()
+            if let url = URL(string: Self.accessibilityDeepLink) {
+                XCUIDevice.shared.system.open(url)
+            }
+            let voSwitch = settings.switches["VoiceOver"].firstMatch
+            guard voSwitch.waitForExistence(timeout: Self.switchExistenceTimeout) else {
+                throw VoiceOverToggleError.switchNotFound
+            }
+            // The caller (CommandHandler) has already confirmed the current state
+            // differs, so an unconditional tap moves VoiceOver to the target state.
+            voSwitch.tap()
+        #else
+            throw VoiceOverToggleError.unsupportedPlatform
         #endif
     }
 }

--- a/ios/control-proxy/Sources/CtrlProxy/VoiceOverStateProvider.swift
+++ b/ios/control-proxy/Sources/CtrlProxy/VoiceOverStateProvider.swift
@@ -76,6 +76,19 @@ public final class DefaultVoiceOverToggle: VoiceOverToggling {
             if let url = URL(string: Self.accessibilityDeepLink) {
                 XCUIDevice.shared.system.open(url)
             }
+            // The Accessibility root pane lists "VoiceOver" as a navigation row
+            // that pushes a sub-page; the on/off switch lives on that sub-page, not
+            // at the root. If no VoiceOver switch is present at the current level,
+            // drill into the VoiceOver row first, then match the switch on the
+            // sub-page. Guarding on the switch's presence (rather than assuming the
+            // level) keeps this working if a future iOS surfaces the switch higher.
+            if !settings.switches["VoiceOver"].firstMatch.waitForExistence(timeout: Self.switchExistenceTimeout) {
+                let voRow = settings.cells["VoiceOver"].firstMatch
+                guard voRow.waitForExistence(timeout: Self.switchExistenceTimeout) else {
+                    throw VoiceOverToggleError.switchNotFound
+                }
+                voRow.tap()
+            }
             let voSwitch = settings.switches["VoiceOver"].firstMatch
             guard voSwitch.waitForExistence(timeout: Self.switchExistenceTimeout) else {
                 throw VoiceOverToggleError.switchNotFound

--- a/ios/control-proxy/Tests/CtrlProxyTests/CommandHandlerTests.swift
+++ b/ios/control-proxy/Tests/CtrlProxyTests/CommandHandlerTests.swift
@@ -9,6 +9,18 @@ private final class FakeVoiceOverStateProvider: VoiceOverStateProviding {
     }
 }
 
+private final class FakeVoiceOverToggle: VoiceOverToggling {
+    private(set) var setCalls: [Bool] = []
+    var errorToThrow: Error?
+
+    func setVoiceOver(enabled: Bool) throws {
+        setCalls.append(enabled)
+        if let errorToThrow {
+            throw errorToThrow
+        }
+    }
+}
+
 private final class FakeVoiceOverDefaultsReader: VoiceOverDefaultsReading {
     private var values: [String: Bool] = [:]
 
@@ -1629,6 +1641,70 @@ final class CommandHandlerTests: XCTestCase {
         // enabled is false in SPM tests (macOS, no UIAccessibility)
         XCTAssertFalse(voResponse.enabled)
         XCTAssertNotNil(voResponse.totalTimeMs)
+    }
+
+    private func makeHandler(
+        stateProvider: FakeVoiceOverStateProvider,
+        toggle: FakeVoiceOverToggle
+    )
+        -> CommandHandler
+    {
+        return CommandHandler.createForTesting(
+            elementLocator: fakeElementLocator,
+            gesturePerformer: fakeGesturePerformer,
+            perfProvider: perfProvider,
+            voiceOverStateProvider: stateProvider,
+            voiceOverToggle: toggle
+        )
+    }
+
+    func testSetVoiceOverStateTogglesWhenStateDiffers() {
+        let stateProvider = FakeVoiceOverStateProvider()
+        stateProvider.isRunning = false
+        let toggle = FakeVoiceOverToggle()
+        commandHandler = makeHandler(stateProvider: stateProvider, toggle: toggle)
+
+        let request = WebSocketRequest.setVoiceOverState(
+            RequestSetVoiceOverState(requestId: "vo-set-1", enabled: true))
+        guard let response = handleRequest(request, as: VoiceOverSetResponse.self) else { return }
+
+        XCTAssertEqual(response.requestId, "vo-set-1")
+        XCTAssertEqual(response.type, "voiceover_set_result")
+        XCTAssertTrue(response.success)
+        XCTAssertNil(response.error)
+        XCTAssertEqual(toggle.setCalls, [true])
+    }
+
+    func testSetVoiceOverStateIsIdempotentNoOpWhenAlreadyInTargetState() {
+        let stateProvider = FakeVoiceOverStateProvider()
+        stateProvider.isRunning = true
+        let toggle = FakeVoiceOverToggle()
+        commandHandler = makeHandler(stateProvider: stateProvider, toggle: toggle)
+
+        let request = WebSocketRequest.setVoiceOverState(
+            RequestSetVoiceOverState(requestId: "vo-set-2", enabled: true))
+        guard let response = handleRequest(request, as: VoiceOverSetResponse.self) else { return }
+
+        XCTAssertTrue(response.success)
+        // Load-bearing: no tap when already on, or VoiceOver's double-tap idiom
+        // would reinterpret the tap as an activation (#2501).
+        XCTAssertEqual(toggle.setCalls, [], "must not tap when already in target state")
+    }
+
+    func testSetVoiceOverStateSurfacesToggleFailureAsUnsuccessful() {
+        let stateProvider = FakeVoiceOverStateProvider()
+        stateProvider.isRunning = false
+        let toggle = FakeVoiceOverToggle()
+        toggle.errorToThrow = VoiceOverToggleError.switchNotFound
+        commandHandler = makeHandler(stateProvider: stateProvider, toggle: toggle)
+
+        let request = WebSocketRequest.setVoiceOverState(
+            RequestSetVoiceOverState(requestId: "vo-set-3", enabled: true))
+        guard let response = handleRequest(request, as: VoiceOverSetResponse.self) else { return }
+
+        XCTAssertFalse(response.success)
+        XCTAssertNotNil(response.error)
+        XCTAssertEqual(toggle.setCalls, [true])
     }
 
     func testGetVoiceOverStateWithNilRequestId() {

--- a/ios/control-proxy/Tests/CtrlProxyTests/CommandPayloadTests.swift
+++ b/ios/control-proxy/Tests/CtrlProxyTests/CommandPayloadTests.swift
@@ -22,6 +22,7 @@ final class CommandPayloadTests: XCTestCase {
             (.pressHome(RequestEnvelope(requestId: "home")), "home"),
             (.selectAll(RequestEnvelope(requestId: "sel")), "sel"),
             (.getVoiceOverState(RequestEnvelope(requestId: "vo")), "vo"),
+            (.setVoiceOverState(RequestSetVoiceOverState(requestId: "vo-set", enabled: true)), "vo-set"),
             (.launchApp(RequestLaunchApp(requestId: "launch", bundleId: "com.example.app")), "launch"),
             (.setPreference(RequestSetPreference(requestId: "sp", key: "k", valueType: "STRING")), "sp"),
             (.getTableStructure(RequestGetTableStructure(requestId: "ts")), "ts"),

--- a/ios/control-proxy/Tests/CtrlProxyTests/ErrorResponseTypeTests.swift
+++ b/ios/control-proxy/Tests/CtrlProxyTests/ErrorResponseTypeTests.swift
@@ -43,6 +43,7 @@ final class ErrorResponseTypeTests: XCTestCase {
             .getTraversalOrder: .traversalOrderResult,
             .addHighlight: .highlightResponse,
             .getVoiceOverState: .voiceOverStateResult,
+            .setVoiceOverState: .voiceOverSetResult,
             .listPreferenceFiles: .preferenceFiles,
             .getPreferences: .preferences,
             .getPreference: .getPreferenceResult,

--- a/ios/control-proxy/Tests/CtrlProxyTests/TypedRequestDecodeTests.swift
+++ b/ios/control-proxy/Tests/CtrlProxyTests/TypedRequestDecodeTests.swift
@@ -153,6 +153,7 @@ final class TypedRequestDecodeDispatchTests: XCTestCase {
             .getTraversalOrder: "{}",
             .addHighlight: "{}",
             .getVoiceOverState: "{}",
+            .setVoiceOverState: #"{"enabled":true}"#,
             .listPreferenceFiles: "{}",
             .getPreferences: "{}",
             .getPreference: "{}",

--- a/schemas/tool-definitions.json
+++ b/schemas/tool-definitions.json
@@ -123,6 +123,7 @@
           "type": "object",
           "properties": {
             "bounds": {
+              "description": "Element bounds. Default: positional tuple [left, top, right, bottom]; the object {left, top, right, bottom} (+ optional centerX/centerY) is also schema-valid.",
               "anyOf": [
                 {
                   "type": "object",
@@ -155,6 +156,7 @@
                   "additionalProperties": false
                 },
                 {
+                  "description": "Compact bounds tuple [left, top, right, bottom], emitted in place of the {left, top, right, bottom} object.",
                   "type": "array",
                   "prefixItems": [
                     {
@@ -169,11 +171,9 @@
                     {
                       "type": "number"
                     }
-                  ],
-                  "description": "Compact bounds tuple [left, top, right, bottom], emitted in place of the {left, top, right, bottom} object."
+                  ]
                 }
-              ],
-              "description": "Element bounds. Default: positional tuple [left, top, right, bottom]; the object {left, top, right, bottom} (+ optional centerX/centerY) is also schema-valid."
+              ]
             },
             "text": {
               "type": "string"
@@ -393,14 +393,14 @@
       "type": "object",
       "properties": {
         "lock": {
-          "type": "string",
-          "description": "Shared barrier name; all devices using the same name synchronize together"
+          "description": "Shared barrier name; all devices using the same name synchronize together",
+          "type": "string"
         },
         "deviceCount": {
+          "description": "Number of devices that must arrive before the barrier lifts",
           "type": "integer",
           "exclusiveMinimum": 0,
-          "maximum": 9007199254740991,
-          "description": "Number of devices that must arrive before the barrier lifts"
+          "maximum": 9007199254740991
         },
         "timeout": {
           "description": "Barrier timeout ms (default 30000)",
@@ -428,14 +428,14 @@
       "type": "object",
       "properties": {
         "action": {
+          "description": "match/fail/cancel/error; cancel/error require Android SDK hook",
           "type": "string",
           "enum": [
             "match",
             "fail",
             "cancel",
             "error"
-          ],
-          "description": "match/fail/cancel/error; cancel/error require Android SDK hook"
+          ]
         },
         "modality": {
           "description": "Modality: any default, fingerprint, or face",
@@ -627,8 +627,8 @@
           "type": "string"
         },
         "name": {
-          "type": "string",
-          "description": "Storage name"
+          "description": "Storage name",
+          "type": "string"
         },
         "fileName": {
           "description": "Deprecated alias for name",
@@ -732,8 +732,8 @@
       "type": "object",
       "properties": {
         "action": {
-          "type": "string",
           "description": "Clipboard action",
+          "type": "string",
           "enum": [
             "copy",
             "paste",
@@ -742,9 +742,9 @@
           ]
         },
         "text": {
+          "description": "Text to copy (required for 'copy' action)",
           "type": "string",
-          "minLength": 1,
-          "description": "Text to copy (required for 'copy' action)"
+          "minLength": 1
         },
         "platform": {
           "type": "string",
@@ -795,26 +795,27 @@
       "type": "object",
       "properties": {
         "lock": {
-          "type": "string",
-          "description": "Shared barrier lock name"
+          "description": "Shared barrier lock name",
+          "type": "string"
         },
         "steps": {
+          "description": "Serial steps; each needs params.device",
           "minItems": 1,
           "type": "array",
           "items": {
             "type": "object",
             "properties": {
               "tool": {
-                "type": "string",
-                "description": "Tool name"
+                "description": "Tool name",
+                "type": "string"
               },
               "params": {
+                "description": "Tool params; must include device",
                 "type": "object",
                 "propertyNames": {
                   "type": "string"
                 },
-                "additionalProperties": {},
-                "description": "Tool params; must include device"
+                "additionalProperties": {}
               },
               "label": {
                 "description": "Step label",
@@ -826,14 +827,13 @@
               "params"
             ],
             "additionalProperties": {}
-          },
-          "description": "Serial steps; each needs params.device"
+          }
         },
         "deviceCount": {
+          "description": "Devices required at barrier",
           "type": "integer",
           "exclusiveMinimum": 0,
-          "maximum": 9007199254740991,
-          "description": "Devices required at barrier"
+          "maximum": 9007199254740991
         },
         "timeout": {
           "description": "Barrier timeout ms (default 30000)",
@@ -901,8 +901,8 @@
               "type": "object",
               "properties": {
                 "elementId": {
-                  "type": "string",
-                  "description": "Container resource ID"
+                  "description": "Container resource ID",
+                  "type": "string"
                 }
               },
               "required": [
@@ -914,8 +914,8 @@
               "type": "object",
               "properties": {
                 "text": {
-                  "type": "string",
-                  "description": "Container text"
+                  "description": "Container text",
+                  "type": "string"
                 }
               },
               "required": [
@@ -967,31 +967,31 @@
       "type": "object",
       "properties": {
         "operationId": {
+          "description": "Caller-generated idempotency and diagnostic correlation ID",
           "type": "string",
           "format": "uuid",
-          "pattern": "^([0-9a-fA-F]{8}-[0-9a-fA-F]{4}-[1-8][0-9a-fA-F]{3}-[89abAB][0-9a-fA-F]{3}-[0-9a-fA-F]{12}|00000000-0000-0000-0000-000000000000)$",
-          "description": "Caller-generated idempotency and diagnostic correlation ID"
+          "pattern": "^([0-9a-fA-F]{8}-[0-9a-fA-F]{4}-[1-8][0-9a-fA-F]{3}-[89abAB][0-9a-fA-F]{3}-[0-9a-fA-F]{12}|00000000-0000-0000-0000-000000000000)$"
         },
         "target": {
           "type": "object",
           "properties": {
             "platform": {
+              "description": "Platform reported by automobile:devices/booted",
               "type": "string",
               "enum": [
                 "android",
                 "ios"
-              ],
-              "description": "Platform reported by automobile:devices/booted"
+              ]
             },
             "isVirtual": {
+              "description": "Virtual-device flag reported by automobile:devices/booted",
               "type": "boolean",
-              "const": true,
-              "description": "Virtual-device flag reported by automobile:devices/booted"
+              "const": true
             },
             "stableId": {
+              "description": "Stable platform device identity from automobile:devices/booted",
               "type": "string",
-              "minLength": 1,
-              "description": "Stable platform device identity from automobile:devices/booted"
+              "minLength": 1
             },
             "stableName": {
               "description": "Stable platform representation name when available",
@@ -1007,14 +1007,14 @@
           "additionalProperties": false
         },
         "mode": {
+          "description": "Stop and permanently delete the platform device representation",
           "type": "string",
-          "const": "destroy",
-          "description": "Stop and permanently delete the platform device representation"
+          "const": "destroy"
         },
         "verifyAbsence": {
+          "description": "Require a complete inventory observation proving durable absence",
           "type": "boolean",
-          "const": true,
-          "description": "Require a complete inventory observation proving durable absence"
+          "const": true
         },
         "timeoutMs": {
           "description": "Total bounded teardown timeout in ms",
@@ -1142,12 +1142,12 @@
           "additionalProperties": false,
           "properties": {
             "elementId": {
-              "type": "string",
-              "description": "Source ID"
+              "description": "Source ID",
+              "type": "string"
             },
             "text": {
-              "type": "string",
-              "description": "Source text"
+              "description": "Source text",
+              "type": "string"
             }
           },
           "oneOf": [
@@ -1169,12 +1169,12 @@
           "additionalProperties": false,
           "properties": {
             "elementId": {
-              "type": "string",
-              "description": "Target ID"
+              "description": "Target ID",
+              "type": "string"
             },
             "text": {
-              "type": "string",
-              "description": "Target text"
+              "description": "Target text",
+              "type": "string"
             }
           },
           "oneOf": [
@@ -1244,12 +1244,12 @@
       "type": "object",
       "properties": {
         "planContent": {
-          "type": "string",
-          "description": "YAML plan content"
+          "description": "YAML plan content",
+          "type": "string"
         },
         "startStep": {
-          "default": 0,
           "description": "Start step index",
+          "default": 0,
           "type": "number"
         },
         "platform": {
@@ -1281,13 +1281,13 @@
           }
         },
         "deviceAllocationTimeoutMs": {
-          "default": 300000,
           "description": "Allocation timeout ms",
+          "default": 300000,
           "type": "number"
         },
         "abortStrategy": {
-          "default": "immediate",
           "description": "Abort strategy",
+          "default": "immediate",
           "type": "string",
           "enum": [
             "immediate",
@@ -1641,9 +1641,9 @@
           "maximum": 120000
         },
         "avdName": {
+          "description": "Configured Android Virtual Device name",
           "type": "string",
-          "minLength": 1,
-          "description": "Configured Android Virtual Device name"
+          "minLength": 1
         }
       },
       "required": [
@@ -1672,9 +1672,9 @@
           "maximum": 120000
         },
         "udid": {
+          "description": "iOS Simulator UDID",
           "type": "string",
-          "minLength": 1,
-          "description": "iOS Simulator UDID"
+          "minLength": 1
         }
       },
       "required": [
@@ -1925,13 +1925,13 @@
       "type": "object",
       "properties": {
         "scope": {
+          "description": "Preference scope",
           "type": "string",
           "enum": [
             "systemProperty",
             "sharedPreferences",
             "userDefaults"
-          ],
-          "description": "Preference scope"
+          ]
         },
         "appId": {
           "description": "App package or bundle id",
@@ -1942,9 +1942,9 @@
           "type": "string"
         },
         "key": {
+          "description": "Preference key or Android system property name",
           "type": "string",
-          "minLength": 1,
-          "description": "Preference key or Android system property name"
+          "minLength": 1
         },
         "platform": {
           "type": "string",
@@ -2001,7 +2001,7 @@
         },
         "shape": {
           "description": "Optional highlight shape definition",
-          "oneOf": [
+          "anyOf": [
             {
               "type": "object",
               "properties": {
@@ -2566,12 +2566,12 @@
           ]
         },
         "elementId": {
-          "type": "string",
-          "description": "Resource ID, e.g. com.app:id/btn_login"
+          "description": "Resource ID, e.g. com.app:id/btn_login",
+          "type": "string"
         },
         "text": {
-          "type": "string",
-          "description": "Text, content-desc, or placeholder"
+          "description": "Text, content-desc, or placeholder",
+          "type": "string"
         },
         "container": {
           "description": "Scope search to a container",
@@ -2580,8 +2580,8 @@
               "type": "object",
               "properties": {
                 "elementId": {
-                  "type": "string",
-                  "description": "Container resource ID"
+                  "description": "Container resource ID",
+                  "type": "string"
                 }
               },
               "required": [
@@ -2593,8 +2593,8 @@
               "type": "object",
               "properties": {
                 "text": {
-                  "type": "string",
-                  "description": "Container text"
+                  "description": "Container text",
+                  "type": "string"
                 }
               },
               "required": [
@@ -2758,6 +2758,7 @@
       "type": "object",
       "properties": {
         "action": {
+          "description": "IME action",
           "type": "string",
           "enum": [
             "done",
@@ -2766,8 +2767,7 @@
             "send",
             "go",
             "previous"
-          ],
-          "description": "IME action"
+          ]
         },
         "platform": {
           "type": "string",
@@ -2866,8 +2866,8 @@
       "type": "object",
       "properties": {
         "artifactPath": {
-          "type": "string",
-          "description": "App artifact path (.apk, .app, or .ipa)"
+          "description": "App artifact path (.apk, .app, or .ipa)",
+          "type": "string"
         },
         "platform": {
           "type": "string",
@@ -2902,13 +2902,13 @@
       "type": "object",
       "properties": {
         "action": {
+          "description": "Keyboard action",
           "type": "string",
           "enum": [
             "open",
             "close",
             "detect"
-          ],
-          "description": "Keyboard action"
+          ]
         },
         "platform": {
           "type": "string",
@@ -2947,8 +2947,8 @@
           "type": "object",
           "properties": {
             "name": {
-              "type": "string",
-              "description": "Device image name"
+              "description": "Device image name",
+              "type": "string"
             },
             "deviceId": {
               "type": "string"
@@ -3078,12 +3078,12 @@
       "type": "object",
       "properties": {
         "host": {
-          "type": "string",
-          "description": "Host pattern (regex)"
+          "description": "Host pattern (regex)",
+          "type": "string"
         },
         "path": {
-          "type": "string",
-          "description": "Path pattern (regex)"
+          "description": "Path pattern (regex)",
+          "type": "string"
         },
         "method": {
           "description": "HTTP method; default *",
@@ -3153,8 +3153,8 @@
       "type": "object",
       "properties": {
         "targetScreen": {
-          "type": "string",
-          "description": "Target screen name"
+          "description": "Target screen name",
+          "type": "string"
         },
         "platform": {
           "default": "android",
@@ -3596,10 +3596,10 @@
           "type": "object",
           "properties": {
             "quietPeriodMs": {
+              "description": "Quiet-period ms (no hierarchy change) required after waitFor matches",
               "type": "integer",
               "exclusiveMinimum": 0,
-              "maximum": 9007199254740991,
-              "description": "Quiet-period ms (no hierarchy change) required after waitFor matches"
+              "maximum": 9007199254740991
             }
           },
           "required": [
@@ -3624,9 +3624,11 @@
           "type": "boolean"
         },
         "scope": {
+          "description": "Experimental progressive-disclosure scoping of the returned hierarchy (issue #4344)",
           "type": "object",
           "properties": {
             "focus": {
+              "description": "Scope to a subtree: true = foreground app; {resourceId|text} = anchor.",
               "anyOf": [
                 {
                   "type": "boolean"
@@ -3645,8 +3647,7 @@
                   },
                   "additionalProperties": false
                 }
-              ],
-              "description": "Scope to a subtree: true = foreground app; {resourceId|text} = anchor."
+              ]
             },
             "region": {
               "description": "Crop to a normalized 0..1 box; true = inset content rect.",
@@ -3693,8 +3694,7 @@
               "type": "boolean"
             }
           },
-          "additionalProperties": false,
-          "description": "Experimental progressive-disclosure scoping of the returned hierarchy (issue #4344)"
+          "additionalProperties": false
         },
         "sessionUuid": {
           "description": "Session",
@@ -3768,6 +3768,7 @@
           "type": "object",
           "properties": {
             "bounds": {
+              "description": "Element bounds. Default: positional tuple [left, top, right, bottom]; the object {left, top, right, bottom} (+ optional centerX/centerY) is also schema-valid.",
               "anyOf": [
                 {
                   "type": "object",
@@ -3800,6 +3801,7 @@
                   "additionalProperties": false
                 },
                 {
+                  "description": "Compact bounds tuple [left, top, right, bottom], emitted in place of the {left, top, right, bottom} object.",
                   "type": "array",
                   "prefixItems": [
                     {
@@ -3814,11 +3816,9 @@
                     {
                       "type": "number"
                     }
-                  ],
-                  "description": "Compact bounds tuple [left, top, right, bottom], emitted in place of the {left, top, right, bottom} object."
+                  ]
                 }
-              ],
-              "description": "Element bounds. Default: positional tuple [left, top, right, bottom]; the object {left, top, right, bottom} (+ optional centerX/centerY) is also schema-valid."
+              ]
             },
             "occlusionState": {
               "type": "string"
@@ -4245,6 +4245,7 @@
                         "type": "string"
                       },
                       "bounds": {
+                        "description": "Element bounds. Default: positional tuple [left, top, right, bottom]; the object {left, top, right, bottom} (+ optional centerX/centerY) is also schema-valid.",
                         "anyOf": [
                           {
                             "type": "object",
@@ -4277,6 +4278,7 @@
                             "additionalProperties": false
                           },
                           {
+                            "description": "Compact bounds tuple [left, top, right, bottom], emitted in place of the {left, top, right, bottom} object.",
                             "type": "array",
                             "prefixItems": [
                               {
@@ -4291,11 +4293,9 @@
                               {
                                 "type": "number"
                               }
-                            ],
-                            "description": "Compact bounds tuple [left, top, right, bottom], emitted in place of the {left, top, right, bottom} object."
+                            ]
                           }
-                        ],
-                        "description": "Element bounds. Default: positional tuple [left, top, right, bottom]; the object {left, top, right, bottom} (+ optional centerX/centerY) is also schema-valid."
+                        ]
                       }
                     },
                     "required": [
@@ -4442,6 +4442,7 @@
                     "type": "object",
                     "properties": {
                       "bounds": {
+                        "description": "Element bounds. Default: positional tuple [left, top, right, bottom]; the object {left, top, right, bottom} (+ optional centerX/centerY) is also schema-valid.",
                         "anyOf": [
                           {
                             "type": "object",
@@ -4474,6 +4475,7 @@
                             "additionalProperties": false
                           },
                           {
+                            "description": "Compact bounds tuple [left, top, right, bottom], emitted in place of the {left, top, right, bottom} object.",
                             "type": "array",
                             "prefixItems": [
                               {
@@ -4488,11 +4490,9 @@
                               {
                                 "type": "number"
                               }
-                            ],
-                            "description": "Compact bounds tuple [left, top, right, bottom], emitted in place of the {left, top, right, bottom} object."
+                            ]
                           }
-                        ],
-                        "description": "Element bounds. Default: positional tuple [left, top, right, bottom]; the object {left, top, right, bottom} (+ optional centerX/centerY) is also schema-valid."
+                        ]
                       },
                       "hierarchy": {
                         "$ref": "#/$defs/__schema0"
@@ -4514,6 +4514,7 @@
                     "type": "object",
                     "properties": {
                       "bounds": {
+                        "description": "Element bounds. Default: positional tuple [left, top, right, bottom]; the object {left, top, right, bottom} (+ optional centerX/centerY) is also schema-valid.",
                         "anyOf": [
                           {
                             "type": "object",
@@ -4546,6 +4547,7 @@
                             "additionalProperties": false
                           },
                           {
+                            "description": "Compact bounds tuple [left, top, right, bottom], emitted in place of the {left, top, right, bottom} object.",
                             "type": "array",
                             "prefixItems": [
                               {
@@ -4560,11 +4562,9 @@
                               {
                                 "type": "number"
                               }
-                            ],
-                            "description": "Compact bounds tuple [left, top, right, bottom], emitted in place of the {left, top, right, bottom} object."
+                            ]
                           }
-                        ],
-                        "description": "Element bounds. Default: positional tuple [left, top, right, bottom]; the object {left, top, right, bottom} (+ optional centerX/centerY) is also schema-valid."
+                        ]
                       },
                       "reason": {
                         "type": "string"
@@ -4967,6 +4967,7 @@
                 }
               },
               "bounds": {
+                "description": "Bounds as the compact [left, top, right, bottom] tuple — always this shape for skeleton entries.",
                 "type": "array",
                 "prefixItems": [
                   {
@@ -4981,8 +4982,7 @@
                   {
                     "type": "number"
                   }
-                ],
-                "description": "Bounds as the compact [left, top, right, bottom] tuple — always this shape for skeleton entries."
+                ]
               },
               "affordances": {
                 "type": "array",
@@ -5126,6 +5126,7 @@
                 "type": "object",
                 "properties": {
                   "bounds": {
+                    "description": "Element bounds. Default: positional tuple [left, top, right, bottom]; the object {left, top, right, bottom} (+ optional centerX/centerY) is also schema-valid.",
                     "anyOf": [
                       {
                         "type": "object",
@@ -5158,6 +5159,7 @@
                         "additionalProperties": false
                       },
                       {
+                        "description": "Compact bounds tuple [left, top, right, bottom], emitted in place of the {left, top, right, bottom} object.",
                         "type": "array",
                         "prefixItems": [
                           {
@@ -5172,11 +5174,9 @@
                           {
                             "type": "number"
                           }
-                        ],
-                        "description": "Compact bounds tuple [left, top, right, bottom], emitted in place of the {left, top, right, bottom} object."
+                        ]
                       }
-                    ],
-                    "description": "Element bounds. Default: positional tuple [left, top, right, bottom]; the object {left, top, right, bottom} (+ optional centerX/centerY) is also schema-valid."
+                    ]
                   }
                 },
                 "additionalProperties": {}
@@ -5206,6 +5206,7 @@
                 "type": "string"
               },
               "bounds": {
+                "description": "Element bounds. Default: positional tuple [left, top, right, bottom]; the object {left, top, right, bottom} (+ optional centerX/centerY) is also schema-valid.",
                 "anyOf": [
                   {
                     "type": "object",
@@ -5238,6 +5239,7 @@
                     "additionalProperties": false
                   },
                   {
+                    "description": "Compact bounds tuple [left, top, right, bottom], emitted in place of the {left, top, right, bottom} object.",
                     "type": "array",
                     "prefixItems": [
                       {
@@ -5252,11 +5254,9 @@
                       {
                         "type": "number"
                       }
-                    ],
-                    "description": "Compact bounds tuple [left, top, right, bottom], emitted in place of the {left, top, right, bottom} object."
+                    ]
                   }
-                ],
-                "description": "Element bounds. Default: positional tuple [left, top, right, bottom]; the object {left, top, right, bottom} (+ optional centerX/centerY) is also schema-valid."
+                ]
               },
               "indexInMatches": {
                 "type": "integer",
@@ -5302,6 +5302,7 @@
           "type": "object",
           "properties": {
             "bounds": {
+              "description": "Element bounds. Default: positional tuple [left, top, right, bottom]; the object {left, top, right, bottom} (+ optional centerX/centerY) is also schema-valid.",
               "anyOf": [
                 {
                   "type": "object",
@@ -5334,6 +5335,7 @@
                   "additionalProperties": false
                 },
                 {
+                  "description": "Compact bounds tuple [left, top, right, bottom], emitted in place of the {left, top, right, bottom} object.",
                   "type": "array",
                   "prefixItems": [
                     {
@@ -5348,11 +5350,9 @@
                     {
                       "type": "number"
                     }
-                  ],
-                  "description": "Compact bounds tuple [left, top, right, bottom], emitted in place of the {left, top, right, bottom} object."
+                  ]
                 }
-              ],
-              "description": "Element bounds. Default: positional tuple [left, top, right, bottom]; the object {left, top, right, bottom} (+ optional centerX/centerY) is also schema-valid."
+              ]
             },
             "text": {
               "type": "string"
@@ -5558,6 +5558,7 @@
           "type": "object",
           "properties": {
             "bounds": {
+              "description": "Element bounds. Default: positional tuple [left, top, right, bottom]; the object {left, top, right, bottom} (+ optional centerX/centerY) is also schema-valid.",
               "anyOf": [
                 {
                   "type": "object",
@@ -5590,6 +5591,7 @@
                   "additionalProperties": false
                 },
                 {
+                  "description": "Compact bounds tuple [left, top, right, bottom], emitted in place of the {left, top, right, bottom} object.",
                   "type": "array",
                   "prefixItems": [
                     {
@@ -5604,11 +5606,9 @@
                     {
                       "type": "number"
                     }
-                  ],
-                  "description": "Compact bounds tuple [left, top, right, bottom], emitted in place of the {left, top, right, bottom} object."
+                  ]
                 }
-              ],
-              "description": "Element bounds. Default: positional tuple [left, top, right, bottom]; the object {left, top, right, bottom} (+ optional centerX/centerY) is also schema-valid."
+              ]
             },
             "text": {
               "type": "string"
@@ -5814,6 +5814,7 @@
           "type": "object",
           "properties": {
             "bounds": {
+              "description": "Element bounds. Default: positional tuple [left, top, right, bottom]; the object {left, top, right, bottom} (+ optional centerX/centerY) is also schema-valid.",
               "anyOf": [
                 {
                   "type": "object",
@@ -5846,6 +5847,7 @@
                   "additionalProperties": false
                 },
                 {
+                  "description": "Compact bounds tuple [left, top, right, bottom], emitted in place of the {left, top, right, bottom} object.",
                   "type": "array",
                   "prefixItems": [
                     {
@@ -5860,11 +5862,9 @@
                     {
                       "type": "number"
                     }
-                  ],
-                  "description": "Compact bounds tuple [left, top, right, bottom], emitted in place of the {left, top, right, bottom} object."
+                  ]
                 }
-              ],
-              "description": "Element bounds. Default: positional tuple [left, top, right, bottom]; the object {left, top, right, bottom} (+ optional centerX/centerY) is also schema-valid."
+              ]
             },
             "text": {
               "type": "string"
@@ -6088,6 +6088,7 @@
           "type": "object",
           "properties": {
             "bounds": {
+              "description": "Element bounds. Default: positional tuple [left, top, right, bottom]; the object {left, top, right, bottom} (+ optional centerX/centerY) is also schema-valid.",
               "anyOf": [
                 {
                   "type": "object",
@@ -6120,6 +6121,7 @@
                   "additionalProperties": false
                 },
                 {
+                  "description": "Compact bounds tuple [left, top, right, bottom], emitted in place of the {left, top, right, bottom} object.",
                   "type": "array",
                   "prefixItems": [
                     {
@@ -6134,11 +6136,9 @@
                     {
                       "type": "number"
                     }
-                  ],
-                  "description": "Compact bounds tuple [left, top, right, bottom], emitted in place of the {left, top, right, bottom} object."
+                  ]
                 }
-              ],
-              "description": "Element bounds. Default: positional tuple [left, top, right, bottom]; the object {left, top, right, bottom} (+ optional centerX/centerY) is also schema-valid."
+              ]
             },
             "text": {
               "type": "string"
@@ -6346,6 +6346,7 @@
             "type": "object",
             "properties": {
               "bounds": {
+                "description": "Element bounds. Default: positional tuple [left, top, right, bottom]; the object {left, top, right, bottom} (+ optional centerX/centerY) is also schema-valid.",
                 "anyOf": [
                   {
                     "type": "object",
@@ -6378,6 +6379,7 @@
                     "additionalProperties": false
                   },
                   {
+                    "description": "Compact bounds tuple [left, top, right, bottom], emitted in place of the {left, top, right, bottom} object.",
                     "type": "array",
                     "prefixItems": [
                       {
@@ -6392,11 +6394,9 @@
                       {
                         "type": "number"
                       }
-                    ],
-                    "description": "Compact bounds tuple [left, top, right, bottom], emitted in place of the {left, top, right, bottom} object."
+                    ]
                   }
-                ],
-                "description": "Element bounds. Default: positional tuple [left, top, right, bottom]; the object {left, top, right, bottom} (+ optional centerX/centerY) is also schema-valid."
+                ]
               },
               "text": {
                 "type": "string"
@@ -7152,6 +7152,7 @@
               "maximum": 9007199254740991
             },
             "regionPx": {
+              "description": "Element bounds. Default: positional tuple [left, top, right, bottom]; the object {left, top, right, bottom} (+ optional centerX/centerY) is also schema-valid.",
               "anyOf": [
                 {
                   "type": "object",
@@ -7184,6 +7185,7 @@
                   "additionalProperties": false
                 },
                 {
+                  "description": "Compact bounds tuple [left, top, right, bottom], emitted in place of the {left, top, right, bottom} object.",
                   "type": "array",
                   "prefixItems": [
                     {
@@ -7198,11 +7200,9 @@
                     {
                       "type": "number"
                     }
-                  ],
-                  "description": "Compact bounds tuple [left, top, right, bottom], emitted in place of the {left, top, right, bottom} object."
+                  ]
                 }
-              ],
-              "description": "Element bounds. Default: positional tuple [left, top, right, bottom]; the object {left, top, right, bottom} (+ optional centerX/centerY) is also schema-valid."
+              ]
             },
             "focus": {
               "type": "object",
@@ -7282,8 +7282,8 @@
       "type": "object",
       "properties": {
         "url": {
-          "type": "string",
-          "description": "URL to open"
+          "description": "URL to open",
+          "type": "string"
         },
         "platform": {
           "type": "string",
@@ -7604,10 +7604,10 @@
           "type": "object",
           "properties": {
             "quietPeriodMs": {
+              "description": "Quiet-period ms (no hierarchy change) required after waitFor matches",
               "type": "integer",
               "exclusiveMinimum": 0,
-              "maximum": 9007199254740991,
-              "description": "Quiet-period ms (no hierarchy change) required after waitFor matches"
+              "maximum": 9007199254740991
             }
           },
           "required": [
@@ -7690,6 +7690,7 @@
       "type": "object",
       "properties": {
         "action": {
+          "description": "call/accept/cancel/busy/hold; hold needs no phoneNumber",
           "type": "string",
           "enum": [
             "call",
@@ -7697,8 +7698,7 @@
             "cancel",
             "busy",
             "hold"
-          ],
-          "description": "call/accept/cancel/busy/hold; hold needs no phoneNumber"
+          ]
         },
         "phoneNumber": {
           "description": "Phone number; required except for hold",
@@ -7737,12 +7737,12 @@
       "type": "object",
       "properties": {
         "direction": {
+          "description": "Pinch direction",
           "type": "string",
           "enum": [
             "in",
             "out"
-          ],
-          "description": "Pinch direction"
+          ]
         },
         "distanceStart": {
           "description": "Initial finger distance (px, default: 400)",
@@ -7773,12 +7773,12 @@
           "additionalProperties": false,
           "properties": {
             "elementId": {
-              "type": "string",
-              "description": "Container resource ID"
+              "description": "Container resource ID",
+              "type": "string"
             },
             "text": {
-              "type": "string",
-              "description": "Container text"
+              "description": "Container text",
+              "type": "string"
             }
           },
           "oneOf": [
@@ -7833,14 +7833,14 @@
       "type": "object",
       "properties": {
         "title": {
+          "description": "Notification title",
           "type": "string",
-          "minLength": 1,
-          "description": "Notification title"
+          "minLength": 1
         },
         "body": {
+          "description": "Notification body",
           "type": "string",
-          "minLength": 1,
-          "description": "Notification body"
+          "minLength": 1
         },
         "imageType": {
           "description": "Notification image type (default: normal)",
@@ -7861,14 +7861,14 @@
             "type": "object",
             "properties": {
               "label": {
+                "description": "Action label",
                 "type": "string",
-                "minLength": 1,
-                "description": "Action label"
+                "minLength": 1
               },
               "actionId": {
+                "description": "Action identifier",
                 "type": "string",
-                "minLength": 1,
-                "description": "Action identifier"
+                "minLength": 1
               }
             },
             "required": [
@@ -7883,9 +7883,9 @@
           "type": "string"
         },
         "appId": {
+          "description": "Android target package name or iOS target bundle ID; Android defaults to the live foreground app when omitted",
           "type": "string",
-          "minLength": 1,
-          "description": "Android target package name or iOS target bundle ID; Android defaults to the live foreground app when omitted"
+          "minLength": 1
         },
         "platform": {
           "type": "string",
@@ -7982,9 +7982,9 @@
       "type": "object",
       "properties": {
         "operationId": {
+          "description": "Caller-generated idempotency key",
           "type": "string",
-          "minLength": 1,
-          "description": "Caller-generated idempotency key"
+          "minLength": 1
         },
         "device": {
           "oneOf": [
@@ -7996,22 +7996,22 @@
                   "const": "android"
                 },
                 "name": {
+                  "description": "Exact AVD name",
                   "type": "string",
-                  "minLength": 1,
-                  "description": "Exact AVD name"
+                  "minLength": 1
                 },
                 "spec": {
                   "type": "object",
                   "properties": {
                     "runtime": {
+                      "description": "Installed Android system-image package identifier",
                       "type": "string",
-                      "minLength": 1,
-                      "description": "Installed Android system-image package identifier"
+                      "minLength": 1
                     },
                     "deviceType": {
+                      "description": "Android avdmanager device profile identifier",
                       "type": "string",
-                      "minLength": 1,
-                      "description": "Android avdmanager device profile identifier"
+                      "minLength": 1
                     },
                     "configuration": {
                       "type": "object",
@@ -8047,22 +8047,22 @@
                   "const": "ios"
                 },
                 "name": {
+                  "description": "Exact simulator name",
                   "type": "string",
-                  "minLength": 1,
-                  "description": "Exact simulator name"
+                  "minLength": 1
                 },
                 "spec": {
                   "type": "object",
                   "properties": {
                     "runtime": {
+                      "description": "CoreSimulator runtime identifier",
                       "type": "string",
-                      "minLength": 1,
-                      "description": "CoreSimulator runtime identifier"
+                      "minLength": 1
                     },
                     "deviceType": {
+                      "description": "CoreSimulator device-type identifier",
                       "type": "string",
-                      "minLength": 1,
-                      "description": "CoreSimulator device-type identifier"
+                      "minLength": 1
                     }
                   },
                   "required": [
@@ -8121,6 +8121,7 @@
           "minLength": 1
         },
         "container": {
+          "description": "App container",
           "type": "string",
           "enum": [
             "documents",
@@ -8128,8 +8129,7 @@
             "cache",
             "tmp",
             "externalFiles"
-          ],
-          "description": "App container"
+          ]
         },
         "sourcePath": {
           "description": "Host file path",
@@ -8145,8 +8145,8 @@
           "type": "string"
         },
         "destinationPath": {
-          "type": "string",
-          "description": "Container-relative destination path"
+          "description": "Container-relative destination path",
+          "type": "string"
         },
         "platform": {
           "type": "string",
@@ -8292,16 +8292,16 @@
           "type": "string"
         },
         "name": {
-          "type": "string",
-          "description": "Storage name"
+          "description": "Storage name",
+          "type": "string"
         },
         "fileName": {
           "description": "Deprecated alias for name",
           "type": "string"
         },
         "key": {
-          "type": "string",
-          "description": "Key"
+          "description": "Key",
+          "type": "string"
         },
         "platform": {
           "type": "string",
@@ -8337,13 +8337,13 @@
       "type": "object",
       "properties": {
         "appId": {
+          "description": "Required. The app whose Keychain/Keystore state to reset. NOTE: iOS Simulator only supports a device-wide reset and erases EVERY app's Keychain regardless of this value.",
           "type": "string",
-          "minLength": 1,
-          "description": "Required. The app whose Keychain/Keystore state to reset. NOTE: iOS Simulator only supports a device-wide reset and erases EVERY app's Keychain regardless of this value."
+          "minLength": 1
         },
         "confirm": {
-          "type": "boolean",
-          "description": "Required. Must be true to proceed. On iOS Simulator this erases the Keychain for EVERY app on the target simulator, not just appId."
+          "description": "Required. Must be true to proceed. On iOS Simulator this erases the Keychain for EVERY app on the target simulator, not just appId.",
+          "type": "boolean"
         },
         "platform": {
           "type": "string",
@@ -8451,12 +8451,12 @@
       "type": "object",
       "properties": {
         "phoneNumber": {
-          "type": "string",
-          "description": "Sender phone number"
+          "description": "Sender phone number",
+          "type": "string"
         },
         "message": {
-          "type": "string",
-          "description": "SMS body; max 1024 chars, no newlines/NUL"
+          "description": "SMS body; max 1024 chars, no newlines/NUL",
+          "type": "string"
         },
         "platform": {
           "type": "string",
@@ -8682,18 +8682,19 @@
           "type": "string"
         },
         "name": {
-          "type": "string",
-          "description": "Storage name"
+          "description": "Storage name",
+          "type": "string"
         },
         "fileName": {
           "description": "Deprecated alias for name",
           "type": "string"
         },
         "key": {
-          "type": "string",
-          "description": "Key"
+          "description": "Key",
+          "type": "string"
         },
         "value": {
+          "description": "Value string; null clears",
           "anyOf": [
             {
               "type": "string"
@@ -8701,10 +8702,10 @@
             {
               "type": "null"
             }
-          ],
-          "description": "Value string; null clears"
+          ]
         },
         "type": {
+          "description": "Value type",
           "type": "string",
           "enum": [
             "STRING",
@@ -8719,8 +8720,7 @@
             "ARRAY",
             "DICTIONARY",
             "UNKNOWN"
-          ],
-          "description": "Value type"
+          ]
         },
         "platform": {
           "type": "string",
@@ -8762,8 +8762,8 @@
           "minLength": 1
         },
         "policyAccess": {
-          "type": "boolean",
-          "description": "Android: allow DND policy access"
+          "description": "Android: allow DND policy access",
+          "type": "boolean"
         },
         "platform": {
           "type": "string",
@@ -8799,13 +8799,13 @@
       "type": "object",
       "properties": {
         "scope": {
+          "description": "Preference scope",
           "type": "string",
           "enum": [
             "systemProperty",
             "sharedPreferences",
             "userDefaults"
-          ],
-          "description": "Preference scope"
+          ]
         },
         "appId": {
           "description": "App package or bundle id",
@@ -8816,11 +8816,12 @@
           "type": "string"
         },
         "key": {
+          "description": "Preference key or Android system property name",
           "type": "string",
-          "minLength": 1,
-          "description": "Preference key or Android system property name"
+          "minLength": 1
         },
         "value": {
+          "description": "Value to write",
           "anyOf": [
             {
               "type": "string"
@@ -8831,18 +8832,17 @@
             {
               "type": "number"
             }
-          ],
-          "description": "Value to write"
+          ]
         },
         "type": {
+          "description": "Value type for typed preference stores",
           "type": "string",
           "enum": [
             "string",
             "bool",
             "int",
             "float"
-          ],
-          "description": "Value type for typed preference stores"
+          ]
         },
         "platform": {
           "type": "string",
@@ -8880,9 +8880,9 @@
       "type": "object",
       "properties": {
         "toolName": {
+          "description": "Exact case-sensitive AutoMobile tool name to enable or disable.",
           "type": "string",
-          "minLength": 1,
-          "description": "Exact case-sensitive AutoMobile tool name to enable or disable."
+          "minLength": 1
         },
         "enabled": {
           "description": "Whether to enable the tool (default: true).",
@@ -8909,25 +8909,26 @@
       "type": "object",
       "properties": {
         "fields": {
+          "description": "Fields to set",
           "minItems": 1,
           "type": "array",
           "items": {
             "type": "object",
             "properties": {
               "selector": {
+                "description": "Field selector",
                 "type": "object",
                 "properties": {
                   "elementId": {
-                    "type": "string",
-                    "description": "Resource ID, e.g. com.app:id/btn_login"
+                    "description": "Resource ID, e.g. com.app:id/btn_login",
+                    "type": "string"
                   },
                   "text": {
-                    "type": "string",
-                    "description": "Text, content-desc, or placeholder"
+                    "description": "Text, content-desc, or placeholder",
+                    "type": "string"
                   }
                 },
-                "additionalProperties": false,
-                "description": "Field selector"
+                "additionalProperties": false
               },
               "value": {
                 "description": "Text/dropdown value",
@@ -8942,8 +8943,7 @@
               "selector"
             ],
             "additionalProperties": false
-          },
-          "description": "Fields to set"
+          }
         },
         "scrollDirection": {
           "description": "Initial search scroll direction",
@@ -8982,10 +8982,11 @@
       "type": "object",
       "properties": {
         "success": {
-          "type": "boolean",
-          "description": "All fields set"
+          "description": "All fields set",
+          "type": "boolean"
         },
         "fields": {
+          "description": "Field results",
           "type": "array",
           "items": {
             "type": "object",
@@ -9034,12 +9035,11 @@
               "attempts"
             ],
             "additionalProperties": false
-          },
-          "description": "Field results"
+          }
         },
         "totalAttempts": {
-          "type": "number",
-          "description": "Total attempts"
+          "description": "Total attempts",
+          "type": "number"
         },
         "error": {
           "description": "Error message",
@@ -9105,12 +9105,12 @@
           "type": "string"
         },
         "databasePath": {
-          "type": "string",
-          "description": "Database path"
+          "description": "Database path",
+          "type": "string"
         },
         "query": {
-          "type": "string",
-          "description": "SQL query"
+          "description": "SQL query",
+          "type": "string"
         },
         "platform": {
           "type": "string",
@@ -9193,12 +9193,12 @@
           "additionalProperties": false,
           "properties": {
             "elementId": {
-              "type": "string",
-              "description": "Container resource ID"
+              "description": "Container resource ID",
+              "type": "string"
             },
             "text": {
-              "type": "string",
-              "description": "Container text"
+              "description": "Container text",
+              "type": "string"
             }
           },
           "oneOf": [
@@ -9220,14 +9220,14 @@
           "type": "boolean"
         },
         "direction": {
+          "description": "Swipe/scroll direction",
           "type": "string",
           "enum": [
             "up",
             "down",
             "left",
             "right"
-          ],
-          "description": "Swipe/scroll direction"
+          ]
         },
         "gestureType": {
           "description": "Finger direction or content scroll direction; default: scrollTowardsDirection",
@@ -9242,12 +9242,12 @@
           "additionalProperties": false,
           "properties": {
             "elementId": {
-              "type": "string",
-              "description": "ID of the element to look for"
+              "description": "ID of the element to look for",
+              "type": "string"
             },
             "text": {
-              "type": "string",
-              "description": "Text to look for"
+              "description": "Text to look for",
+              "type": "string"
             }
           },
           "oneOf": [
@@ -9323,6 +9323,7 @@
       "type": "object",
       "properties": {
         "action": {
+          "description": "open/close/find/tap/dismiss/clearAll notification",
           "type": "string",
           "enum": [
             "open",
@@ -9331,8 +9332,7 @@
             "tap",
             "dismiss",
             "clearAll"
-          ],
-          "description": "open/close/find/tap/dismiss/clearAll notification"
+          ]
         },
         "notification": {
           "description": "Notification criteria to match",
@@ -9399,12 +9399,12 @@
           "additionalProperties": false,
           "properties": {
             "elementId": {
-              "type": "string",
-              "description": "Container resource ID"
+              "description": "Container resource ID",
+              "type": "string"
             },
             "text": {
-              "type": "string",
-              "description": "Container text"
+              "description": "Container text",
+              "type": "string"
             }
           },
           "oneOf": [
@@ -9434,8 +9434,8 @@
           "type": "boolean"
         },
         "action": {
-          "default": "tap",
           "description": "Action type (default: tap)",
+          "default": "tap",
           "type": "string",
           "enum": [
             "tap",
@@ -9498,33 +9498,33 @@
           "additionalProperties": false,
           "properties": {
             "elementId": {
+              "description": "Resource ID, e.g. com.app:id/btn_login",
               "type": "string",
-              "minLength": 1,
-              "description": "Resource ID, e.g. com.app:id/btn_login"
+              "minLength": 1
             },
             "testTag": {
+              "description": "Android accessibility test tag",
               "type": "string",
-              "minLength": 1,
-              "description": "Android accessibility test tag"
+              "minLength": 1
             },
             "text": {
+              "description": "Text, content-desc, or placeholder",
               "type": "string",
-              "minLength": 1,
-              "description": "Text, content-desc, or placeholder"
+              "minLength": 1
             },
             "accessibilityLink": {
+              "description": "Exact visible text of a semantic accessibility link",
               "type": "string",
-              "minLength": 1,
-              "description": "Exact visible text of a semantic accessibility link"
+              "minLength": 1
             },
             "textAny": {
+              "description": "Ordered text variants; first visible match wins",
               "minItems": 1,
               "type": "array",
               "items": {
                 "type": "string",
                 "minLength": 1
-              },
-              "description": "Ordered text variants; first visible match wins"
+              }
             }
           },
           "oneOf": [
@@ -9565,12 +9565,12 @@
           "additionalProperties": false,
           "properties": {
             "elementId": {
-              "type": "string",
-              "description": "Container resource ID"
+              "description": "Container resource ID",
+              "type": "string"
             },
             "text": {
-              "type": "string",
-              "description": "Container text"
+              "description": "Container text",
+              "type": "string"
             }
           },
           "oneOf": [
@@ -9588,8 +9588,8 @@
           "description": "Scope search to a container"
         },
         "action": {
-          "default": "tap",
           "description": "Action type (default: tap)",
+          "default": "tap",
           "type": "string",
           "enum": [
             "tap",
@@ -9621,9 +9621,9 @@
           "type": "object",
           "properties": {
             "text": {
+              "description": "Exact visible text of a semantic link inside the selected element",
               "type": "string",
-              "minLength": 1,
-              "description": "Exact visible text of a semantic link inside the selected element"
+              "minLength": 1
             },
             "occurrence": {
               "description": "Zero-based occurrence among exact semantic-link matches (default: 0)",
@@ -9794,6 +9794,7 @@
           "type": "object",
           "properties": {
             "bounds": {
+              "description": "Element bounds. Default: positional tuple [left, top, right, bottom]; the object {left, top, right, bottom} (+ optional centerX/centerY) is also schema-valid.",
               "anyOf": [
                 {
                   "type": "object",
@@ -9826,6 +9827,7 @@
                   "additionalProperties": false
                 },
                 {
+                  "description": "Compact bounds tuple [left, top, right, bottom], emitted in place of the {left, top, right, bottom} object.",
                   "type": "array",
                   "prefixItems": [
                     {
@@ -9840,11 +9842,9 @@
                     {
                       "type": "number"
                     }
-                  ],
-                  "description": "Compact bounds tuple [left, top, right, bottom], emitted in place of the {left, top, right, bottom} object."
+                  ]
                 }
-              ],
-              "description": "Element bounds. Default: positional tuple [left, top, right, bottom]; the object {left, top, right, bottom} (+ optional centerX/centerY) is also schema-valid."
+              ]
             },
             "text": {
               "type": "string"
@@ -10066,6 +10066,7 @@
                         "type": "string"
                       },
                       "bounds": {
+                        "description": "Element bounds. Default: positional tuple [left, top, right, bottom]; the object {left, top, right, bottom} (+ optional centerX/centerY) is also schema-valid.",
                         "anyOf": [
                           {
                             "type": "object",
@@ -10098,6 +10099,7 @@
                             "additionalProperties": false
                           },
                           {
+                            "description": "Compact bounds tuple [left, top, right, bottom], emitted in place of the {left, top, right, bottom} object.",
                             "type": "array",
                             "prefixItems": [
                               {
@@ -10112,11 +10114,9 @@
                               {
                                 "type": "number"
                               }
-                            ],
-                            "description": "Compact bounds tuple [left, top, right, bottom], emitted in place of the {left, top, right, bottom} object."
+                            ]
                           }
-                        ],
-                        "description": "Element bounds. Default: positional tuple [left, top, right, bottom]; the object {left, top, right, bottom} (+ optional centerX/centerY) is also schema-valid."
+                        ]
                       },
                       "indexInMatches": {
                         "type": "integer",
@@ -10162,6 +10162,7 @@
                   "type": "object",
                   "properties": {
                     "bounds": {
+                      "description": "Element bounds. Default: positional tuple [left, top, right, bottom]; the object {left, top, right, bottom} (+ optional centerX/centerY) is also schema-valid.",
                       "anyOf": [
                         {
                           "type": "object",
@@ -10194,6 +10195,7 @@
                           "additionalProperties": false
                         },
                         {
+                          "description": "Compact bounds tuple [left, top, right, bottom], emitted in place of the {left, top, right, bottom} object.",
                           "type": "array",
                           "prefixItems": [
                             {
@@ -10208,11 +10210,9 @@
                             {
                               "type": "number"
                             }
-                          ],
-                          "description": "Compact bounds tuple [left, top, right, bottom], emitted in place of the {left, top, right, bottom} object."
+                          ]
                         }
-                      ],
-                      "description": "Element bounds. Default: positional tuple [left, top, right, bottom]; the object {left, top, right, bottom} (+ optional centerX/centerY) is also schema-valid."
+                      ]
                     },
                     "text": {
                       "type": "string"
@@ -10418,6 +10418,7 @@
                   "type": "object",
                   "properties": {
                     "bounds": {
+                      "description": "Element bounds. Default: positional tuple [left, top, right, bottom]; the object {left, top, right, bottom} (+ optional centerX/centerY) is also schema-valid.",
                       "anyOf": [
                         {
                           "type": "object",
@@ -10450,6 +10451,7 @@
                           "additionalProperties": false
                         },
                         {
+                          "description": "Compact bounds tuple [left, top, right, bottom], emitted in place of the {left, top, right, bottom} object.",
                           "type": "array",
                           "prefixItems": [
                             {
@@ -10464,11 +10466,9 @@
                             {
                               "type": "number"
                             }
-                          ],
-                          "description": "Compact bounds tuple [left, top, right, bottom], emitted in place of the {left, top, right, bottom} object."
+                          ]
                         }
-                      ],
-                      "description": "Element bounds. Default: positional tuple [left, top, right, bottom]; the object {left, top, right, bottom} (+ optional centerX/centerY) is also schema-valid."
+                      ]
                     },
                     "text": {
                       "type": "string"
@@ -11048,6 +11048,7 @@
               "type": "string"
             },
             "bounds": {
+              "description": "Element bounds. Default: positional tuple [left, top, right, bottom]; the object {left, top, right, bottom} (+ optional centerX/centerY) is also schema-valid.",
               "anyOf": [
                 {
                   "type": "object",
@@ -11080,6 +11081,7 @@
                   "additionalProperties": false
                 },
                 {
+                  "description": "Compact bounds tuple [left, top, right, bottom], emitted in place of the {left, top, right, bottom} object.",
                   "type": "array",
                   "prefixItems": [
                     {
@@ -11094,11 +11096,9 @@
                     {
                       "type": "number"
                     }
-                  ],
-                  "description": "Compact bounds tuple [left, top, right, bottom], emitted in place of the {left, top, right, bottom} object."
+                  ]
                 }
-              ],
-              "description": "Element bounds. Default: positional tuple [left, top, right, bottom]; the object {left, top, right, bottom} (+ optional centerX/centerY) is also schema-valid."
+              ]
             },
             "indexInMatches": {
               "type": "integer",
@@ -11173,6 +11173,7 @@
                 "type": "string"
               },
               "bounds": {
+                "description": "Element bounds. Default: positional tuple [left, top, right, bottom]; the object {left, top, right, bottom} (+ optional centerX/centerY) is also schema-valid.",
                 "anyOf": [
                   {
                     "type": "object",
@@ -11205,6 +11206,7 @@
                     "additionalProperties": false
                   },
                   {
+                    "description": "Compact bounds tuple [left, top, right, bottom], emitted in place of the {left, top, right, bottom} object.",
                     "type": "array",
                     "prefixItems": [
                       {
@@ -11219,11 +11221,9 @@
                       {
                         "type": "number"
                       }
-                    ],
-                    "description": "Compact bounds tuple [left, top, right, bottom], emitted in place of the {left, top, right, bottom} object."
+                    ]
                   }
-                ],
-                "description": "Element bounds. Default: positional tuple [left, top, right, bottom]; the object {left, top, right, bottom} (+ optional centerX/centerY) is also schema-valid."
+                ]
               },
               "indexInMatches": {
                 "type": "integer",
@@ -11307,15 +11307,17 @@
           "type": "object",
           "properties": {
             "reachable": {
-              "type": "boolean",
-              "description": "Whether swipe cursor navigation reached the target"
+              "description": "Whether swipe cursor navigation reached the target",
+              "type": "boolean"
             },
             "traversalOrder": {
+              "description": "Focused nodes in cursor traversal order",
               "type": "array",
               "items": {
                 "type": "object",
                 "properties": {
                   "bounds": {
+                    "description": "Element bounds. Default: positional tuple [left, top, right, bottom]; the object {left, top, right, bottom} (+ optional centerX/centerY) is also schema-valid.",
                     "anyOf": [
                       {
                         "type": "object",
@@ -11348,6 +11350,7 @@
                         "additionalProperties": false
                       },
                       {
+                        "description": "Compact bounds tuple [left, top, right, bottom], emitted in place of the {left, top, right, bottom} object.",
                         "type": "array",
                         "prefixItems": [
                           {
@@ -11362,11 +11365,9 @@
                           {
                             "type": "number"
                           }
-                        ],
-                        "description": "Compact bounds tuple [left, top, right, bottom], emitted in place of the {left, top, right, bottom} object."
+                        ]
                       }
-                    ],
-                    "description": "Element bounds. Default: positional tuple [left, top, right, bottom]; the object {left, top, right, bottom} (+ optional centerX/centerY) is also schema-valid."
+                    ]
                   },
                   "text": {
                     "type": "string"
@@ -11567,12 +11568,11 @@
                   "bounds"
                 ],
                 "additionalProperties": {}
-              },
-              "description": "Focused nodes in cursor traversal order"
+              }
             },
             "focusTrapDetected": {
-              "type": "boolean",
-              "description": "Whether cursor navigation got stuck or failed to converge"
+              "description": "Whether cursor navigation got stuck or failed to converge",
+              "type": "boolean"
             }
           },
           "required": [
@@ -11765,6 +11765,7 @@
                 "type": "string"
               },
               "shape": {
+                "description": "Highlight shape",
                 "oneOf": [
                   {
                     "type": "object",
@@ -12327,8 +12328,7 @@
                     ],
                     "additionalProperties": false
                   }
-                ],
-                "description": "Highlight shape"
+                ]
               },
               "timing": {
                 "description": "Highlight timing",

--- a/schemas/tool-definitions.json
+++ b/schemas/tool-definitions.json
@@ -1,7 +1,7 @@
 [
   {
     "name": "accessibility",
-    "description": "Check or control accessibility services. On Android: omit talkback to check TalkBack state, or pass talkback: true/false to enable/disable it. On iOS: omit voiceover to check VoiceOver state, or pass voiceover: true/false to enable/disable it (Simulator only). Always returns fresh state from the device.",
+    "description": "Check or control accessibility services. On Android: omit talkback to check TalkBack state, or pass talkback: true/false to enable/disable it. On iOS: omit voiceover to check VoiceOver state, or pass voiceover: true/false to enable/disable it (Simulator via simctl, physical devices via the Settings app). Always returns fresh state from the device.",
     "inputSchema": {
       "$schema": "https://json-schema.org/draft/2020-12/schema",
       "type": "object",
@@ -11,7 +11,7 @@
           "type": "boolean"
         },
         "voiceover": {
-          "description": "Enable (true) or disable (false) VoiceOver on iOS Simulator",
+          "description": "Enable (true) or disable (false) VoiceOver on an iOS device (Simulator via simctl; physical devices are driven through the Settings app)",
           "type": "boolean"
         },
         "platform": {
@@ -123,7 +123,6 @@
           "type": "object",
           "properties": {
             "bounds": {
-              "description": "Element bounds. Default: positional tuple [left, top, right, bottom]; the object {left, top, right, bottom} (+ optional centerX/centerY) is also schema-valid.",
               "anyOf": [
                 {
                   "type": "object",
@@ -156,7 +155,6 @@
                   "additionalProperties": false
                 },
                 {
-                  "description": "Compact bounds tuple [left, top, right, bottom], emitted in place of the {left, top, right, bottom} object.",
                   "type": "array",
                   "prefixItems": [
                     {
@@ -171,9 +169,11 @@
                     {
                       "type": "number"
                     }
-                  ]
+                  ],
+                  "description": "Compact bounds tuple [left, top, right, bottom], emitted in place of the {left, top, right, bottom} object."
                 }
-              ]
+              ],
+              "description": "Element bounds. Default: positional tuple [left, top, right, bottom]; the object {left, top, right, bottom} (+ optional centerX/centerY) is also schema-valid."
             },
             "text": {
               "type": "string"
@@ -393,14 +393,14 @@
       "type": "object",
       "properties": {
         "lock": {
-          "description": "Shared barrier name; all devices using the same name synchronize together",
-          "type": "string"
+          "type": "string",
+          "description": "Shared barrier name; all devices using the same name synchronize together"
         },
         "deviceCount": {
-          "description": "Number of devices that must arrive before the barrier lifts",
           "type": "integer",
           "exclusiveMinimum": 0,
-          "maximum": 9007199254740991
+          "maximum": 9007199254740991,
+          "description": "Number of devices that must arrive before the barrier lifts"
         },
         "timeout": {
           "description": "Barrier timeout ms (default 30000)",
@@ -428,14 +428,14 @@
       "type": "object",
       "properties": {
         "action": {
-          "description": "match/fail/cancel/error; cancel/error require Android SDK hook",
           "type": "string",
           "enum": [
             "match",
             "fail",
             "cancel",
             "error"
-          ]
+          ],
+          "description": "match/fail/cancel/error; cancel/error require Android SDK hook"
         },
         "modality": {
           "description": "Modality: any default, fingerprint, or face",
@@ -627,8 +627,8 @@
           "type": "string"
         },
         "name": {
-          "description": "Storage name",
-          "type": "string"
+          "type": "string",
+          "description": "Storage name"
         },
         "fileName": {
           "description": "Deprecated alias for name",
@@ -732,8 +732,8 @@
       "type": "object",
       "properties": {
         "action": {
-          "description": "Clipboard action",
           "type": "string",
+          "description": "Clipboard action",
           "enum": [
             "copy",
             "paste",
@@ -742,9 +742,9 @@
           ]
         },
         "text": {
-          "description": "Text to copy (required for 'copy' action)",
           "type": "string",
-          "minLength": 1
+          "minLength": 1,
+          "description": "Text to copy (required for 'copy' action)"
         },
         "platform": {
           "type": "string",
@@ -795,27 +795,26 @@
       "type": "object",
       "properties": {
         "lock": {
-          "description": "Shared barrier lock name",
-          "type": "string"
+          "type": "string",
+          "description": "Shared barrier lock name"
         },
         "steps": {
-          "description": "Serial steps; each needs params.device",
           "minItems": 1,
           "type": "array",
           "items": {
             "type": "object",
             "properties": {
               "tool": {
-                "description": "Tool name",
-                "type": "string"
+                "type": "string",
+                "description": "Tool name"
               },
               "params": {
-                "description": "Tool params; must include device",
                 "type": "object",
                 "propertyNames": {
                   "type": "string"
                 },
-                "additionalProperties": {}
+                "additionalProperties": {},
+                "description": "Tool params; must include device"
               },
               "label": {
                 "description": "Step label",
@@ -827,13 +826,14 @@
               "params"
             ],
             "additionalProperties": {}
-          }
+          },
+          "description": "Serial steps; each needs params.device"
         },
         "deviceCount": {
-          "description": "Devices required at barrier",
           "type": "integer",
           "exclusiveMinimum": 0,
-          "maximum": 9007199254740991
+          "maximum": 9007199254740991,
+          "description": "Devices required at barrier"
         },
         "timeout": {
           "description": "Barrier timeout ms (default 30000)",
@@ -901,8 +901,8 @@
               "type": "object",
               "properties": {
                 "elementId": {
-                  "description": "Container resource ID",
-                  "type": "string"
+                  "type": "string",
+                  "description": "Container resource ID"
                 }
               },
               "required": [
@@ -914,8 +914,8 @@
               "type": "object",
               "properties": {
                 "text": {
-                  "description": "Container text",
-                  "type": "string"
+                  "type": "string",
+                  "description": "Container text"
                 }
               },
               "required": [
@@ -967,31 +967,31 @@
       "type": "object",
       "properties": {
         "operationId": {
-          "description": "Caller-generated idempotency and diagnostic correlation ID",
           "type": "string",
           "format": "uuid",
-          "pattern": "^([0-9a-fA-F]{8}-[0-9a-fA-F]{4}-[1-8][0-9a-fA-F]{3}-[89abAB][0-9a-fA-F]{3}-[0-9a-fA-F]{12}|00000000-0000-0000-0000-000000000000)$"
+          "pattern": "^([0-9a-fA-F]{8}-[0-9a-fA-F]{4}-[1-8][0-9a-fA-F]{3}-[89abAB][0-9a-fA-F]{3}-[0-9a-fA-F]{12}|00000000-0000-0000-0000-000000000000)$",
+          "description": "Caller-generated idempotency and diagnostic correlation ID"
         },
         "target": {
           "type": "object",
           "properties": {
             "platform": {
-              "description": "Platform reported by automobile:devices/booted",
               "type": "string",
               "enum": [
                 "android",
                 "ios"
-              ]
+              ],
+              "description": "Platform reported by automobile:devices/booted"
             },
             "isVirtual": {
-              "description": "Virtual-device flag reported by automobile:devices/booted",
               "type": "boolean",
-              "const": true
+              "const": true,
+              "description": "Virtual-device flag reported by automobile:devices/booted"
             },
             "stableId": {
-              "description": "Stable platform device identity from automobile:devices/booted",
               "type": "string",
-              "minLength": 1
+              "minLength": 1,
+              "description": "Stable platform device identity from automobile:devices/booted"
             },
             "stableName": {
               "description": "Stable platform representation name when available",
@@ -1007,14 +1007,14 @@
           "additionalProperties": false
         },
         "mode": {
-          "description": "Stop and permanently delete the platform device representation",
           "type": "string",
-          "const": "destroy"
+          "const": "destroy",
+          "description": "Stop and permanently delete the platform device representation"
         },
         "verifyAbsence": {
-          "description": "Require a complete inventory observation proving durable absence",
           "type": "boolean",
-          "const": true
+          "const": true,
+          "description": "Require a complete inventory observation proving durable absence"
         },
         "timeoutMs": {
           "description": "Total bounded teardown timeout in ms",
@@ -1142,12 +1142,12 @@
           "additionalProperties": false,
           "properties": {
             "elementId": {
-              "description": "Source ID",
-              "type": "string"
+              "type": "string",
+              "description": "Source ID"
             },
             "text": {
-              "description": "Source text",
-              "type": "string"
+              "type": "string",
+              "description": "Source text"
             }
           },
           "oneOf": [
@@ -1169,12 +1169,12 @@
           "additionalProperties": false,
           "properties": {
             "elementId": {
-              "description": "Target ID",
-              "type": "string"
+              "type": "string",
+              "description": "Target ID"
             },
             "text": {
-              "description": "Target text",
-              "type": "string"
+              "type": "string",
+              "description": "Target text"
             }
           },
           "oneOf": [
@@ -1244,12 +1244,12 @@
       "type": "object",
       "properties": {
         "planContent": {
-          "description": "YAML plan content",
-          "type": "string"
+          "type": "string",
+          "description": "YAML plan content"
         },
         "startStep": {
-          "description": "Start step index",
           "default": 0,
+          "description": "Start step index",
           "type": "number"
         },
         "platform": {
@@ -1281,13 +1281,13 @@
           }
         },
         "deviceAllocationTimeoutMs": {
-          "description": "Allocation timeout ms",
           "default": 300000,
+          "description": "Allocation timeout ms",
           "type": "number"
         },
         "abortStrategy": {
-          "description": "Abort strategy",
           "default": "immediate",
+          "description": "Abort strategy",
           "type": "string",
           "enum": [
             "immediate",
@@ -1641,9 +1641,9 @@
           "maximum": 120000
         },
         "avdName": {
-          "description": "Configured Android Virtual Device name",
           "type": "string",
-          "minLength": 1
+          "minLength": 1,
+          "description": "Configured Android Virtual Device name"
         }
       },
       "required": [
@@ -1672,9 +1672,9 @@
           "maximum": 120000
         },
         "udid": {
-          "description": "iOS Simulator UDID",
           "type": "string",
-          "minLength": 1
+          "minLength": 1,
+          "description": "iOS Simulator UDID"
         }
       },
       "required": [
@@ -1925,13 +1925,13 @@
       "type": "object",
       "properties": {
         "scope": {
-          "description": "Preference scope",
           "type": "string",
           "enum": [
             "systemProperty",
             "sharedPreferences",
             "userDefaults"
-          ]
+          ],
+          "description": "Preference scope"
         },
         "appId": {
           "description": "App package or bundle id",
@@ -1942,9 +1942,9 @@
           "type": "string"
         },
         "key": {
-          "description": "Preference key or Android system property name",
           "type": "string",
-          "minLength": 1
+          "minLength": 1,
+          "description": "Preference key or Android system property name"
         },
         "platform": {
           "type": "string",
@@ -2001,7 +2001,7 @@
         },
         "shape": {
           "description": "Optional highlight shape definition",
-          "anyOf": [
+          "oneOf": [
             {
               "type": "object",
               "properties": {
@@ -2566,12 +2566,12 @@
           ]
         },
         "elementId": {
-          "description": "Resource ID, e.g. com.app:id/btn_login",
-          "type": "string"
+          "type": "string",
+          "description": "Resource ID, e.g. com.app:id/btn_login"
         },
         "text": {
-          "description": "Text, content-desc, or placeholder",
-          "type": "string"
+          "type": "string",
+          "description": "Text, content-desc, or placeholder"
         },
         "container": {
           "description": "Scope search to a container",
@@ -2580,8 +2580,8 @@
               "type": "object",
               "properties": {
                 "elementId": {
-                  "description": "Container resource ID",
-                  "type": "string"
+                  "type": "string",
+                  "description": "Container resource ID"
                 }
               },
               "required": [
@@ -2593,8 +2593,8 @@
               "type": "object",
               "properties": {
                 "text": {
-                  "description": "Container text",
-                  "type": "string"
+                  "type": "string",
+                  "description": "Container text"
                 }
               },
               "required": [
@@ -2758,7 +2758,6 @@
       "type": "object",
       "properties": {
         "action": {
-          "description": "IME action",
           "type": "string",
           "enum": [
             "done",
@@ -2767,7 +2766,8 @@
             "send",
             "go",
             "previous"
-          ]
+          ],
+          "description": "IME action"
         },
         "platform": {
           "type": "string",
@@ -2866,8 +2866,8 @@
       "type": "object",
       "properties": {
         "artifactPath": {
-          "description": "App artifact path (.apk, .app, or .ipa)",
-          "type": "string"
+          "type": "string",
+          "description": "App artifact path (.apk, .app, or .ipa)"
         },
         "platform": {
           "type": "string",
@@ -2902,13 +2902,13 @@
       "type": "object",
       "properties": {
         "action": {
-          "description": "Keyboard action",
           "type": "string",
           "enum": [
             "open",
             "close",
             "detect"
-          ]
+          ],
+          "description": "Keyboard action"
         },
         "platform": {
           "type": "string",
@@ -2947,8 +2947,8 @@
           "type": "object",
           "properties": {
             "name": {
-              "description": "Device image name",
-              "type": "string"
+              "type": "string",
+              "description": "Device image name"
             },
             "deviceId": {
               "type": "string"
@@ -3078,12 +3078,12 @@
       "type": "object",
       "properties": {
         "host": {
-          "description": "Host pattern (regex)",
-          "type": "string"
+          "type": "string",
+          "description": "Host pattern (regex)"
         },
         "path": {
-          "description": "Path pattern (regex)",
-          "type": "string"
+          "type": "string",
+          "description": "Path pattern (regex)"
         },
         "method": {
           "description": "HTTP method; default *",
@@ -3153,8 +3153,8 @@
       "type": "object",
       "properties": {
         "targetScreen": {
-          "description": "Target screen name",
-          "type": "string"
+          "type": "string",
+          "description": "Target screen name"
         },
         "platform": {
           "default": "android",
@@ -3596,10 +3596,10 @@
           "type": "object",
           "properties": {
             "quietPeriodMs": {
-              "description": "Quiet-period ms (no hierarchy change) required after waitFor matches",
               "type": "integer",
               "exclusiveMinimum": 0,
-              "maximum": 9007199254740991
+              "maximum": 9007199254740991,
+              "description": "Quiet-period ms (no hierarchy change) required after waitFor matches"
             }
           },
           "required": [
@@ -3624,11 +3624,9 @@
           "type": "boolean"
         },
         "scope": {
-          "description": "Experimental progressive-disclosure scoping of the returned hierarchy (issue #4344)",
           "type": "object",
           "properties": {
             "focus": {
-              "description": "Scope to a subtree: true = foreground app; {resourceId|text} = anchor.",
               "anyOf": [
                 {
                   "type": "boolean"
@@ -3647,7 +3645,8 @@
                   },
                   "additionalProperties": false
                 }
-              ]
+              ],
+              "description": "Scope to a subtree: true = foreground app; {resourceId|text} = anchor."
             },
             "region": {
               "description": "Crop to a normalized 0..1 box; true = inset content rect.",
@@ -3694,7 +3693,8 @@
               "type": "boolean"
             }
           },
-          "additionalProperties": false
+          "additionalProperties": false,
+          "description": "Experimental progressive-disclosure scoping of the returned hierarchy (issue #4344)"
         },
         "sessionUuid": {
           "description": "Session",
@@ -3768,7 +3768,6 @@
           "type": "object",
           "properties": {
             "bounds": {
-              "description": "Element bounds. Default: positional tuple [left, top, right, bottom]; the object {left, top, right, bottom} (+ optional centerX/centerY) is also schema-valid.",
               "anyOf": [
                 {
                   "type": "object",
@@ -3801,7 +3800,6 @@
                   "additionalProperties": false
                 },
                 {
-                  "description": "Compact bounds tuple [left, top, right, bottom], emitted in place of the {left, top, right, bottom} object.",
                   "type": "array",
                   "prefixItems": [
                     {
@@ -3816,9 +3814,11 @@
                     {
                       "type": "number"
                     }
-                  ]
+                  ],
+                  "description": "Compact bounds tuple [left, top, right, bottom], emitted in place of the {left, top, right, bottom} object."
                 }
-              ]
+              ],
+              "description": "Element bounds. Default: positional tuple [left, top, right, bottom]; the object {left, top, right, bottom} (+ optional centerX/centerY) is also schema-valid."
             },
             "occlusionState": {
               "type": "string"
@@ -4245,7 +4245,6 @@
                         "type": "string"
                       },
                       "bounds": {
-                        "description": "Element bounds. Default: positional tuple [left, top, right, bottom]; the object {left, top, right, bottom} (+ optional centerX/centerY) is also schema-valid.",
                         "anyOf": [
                           {
                             "type": "object",
@@ -4278,7 +4277,6 @@
                             "additionalProperties": false
                           },
                           {
-                            "description": "Compact bounds tuple [left, top, right, bottom], emitted in place of the {left, top, right, bottom} object.",
                             "type": "array",
                             "prefixItems": [
                               {
@@ -4293,9 +4291,11 @@
                               {
                                 "type": "number"
                               }
-                            ]
+                            ],
+                            "description": "Compact bounds tuple [left, top, right, bottom], emitted in place of the {left, top, right, bottom} object."
                           }
-                        ]
+                        ],
+                        "description": "Element bounds. Default: positional tuple [left, top, right, bottom]; the object {left, top, right, bottom} (+ optional centerX/centerY) is also schema-valid."
                       }
                     },
                     "required": [
@@ -4442,7 +4442,6 @@
                     "type": "object",
                     "properties": {
                       "bounds": {
-                        "description": "Element bounds. Default: positional tuple [left, top, right, bottom]; the object {left, top, right, bottom} (+ optional centerX/centerY) is also schema-valid.",
                         "anyOf": [
                           {
                             "type": "object",
@@ -4475,7 +4474,6 @@
                             "additionalProperties": false
                           },
                           {
-                            "description": "Compact bounds tuple [left, top, right, bottom], emitted in place of the {left, top, right, bottom} object.",
                             "type": "array",
                             "prefixItems": [
                               {
@@ -4490,9 +4488,11 @@
                               {
                                 "type": "number"
                               }
-                            ]
+                            ],
+                            "description": "Compact bounds tuple [left, top, right, bottom], emitted in place of the {left, top, right, bottom} object."
                           }
-                        ]
+                        ],
+                        "description": "Element bounds. Default: positional tuple [left, top, right, bottom]; the object {left, top, right, bottom} (+ optional centerX/centerY) is also schema-valid."
                       },
                       "hierarchy": {
                         "$ref": "#/$defs/__schema0"
@@ -4514,7 +4514,6 @@
                     "type": "object",
                     "properties": {
                       "bounds": {
-                        "description": "Element bounds. Default: positional tuple [left, top, right, bottom]; the object {left, top, right, bottom} (+ optional centerX/centerY) is also schema-valid.",
                         "anyOf": [
                           {
                             "type": "object",
@@ -4547,7 +4546,6 @@
                             "additionalProperties": false
                           },
                           {
-                            "description": "Compact bounds tuple [left, top, right, bottom], emitted in place of the {left, top, right, bottom} object.",
                             "type": "array",
                             "prefixItems": [
                               {
@@ -4562,9 +4560,11 @@
                               {
                                 "type": "number"
                               }
-                            ]
+                            ],
+                            "description": "Compact bounds tuple [left, top, right, bottom], emitted in place of the {left, top, right, bottom} object."
                           }
-                        ]
+                        ],
+                        "description": "Element bounds. Default: positional tuple [left, top, right, bottom]; the object {left, top, right, bottom} (+ optional centerX/centerY) is also schema-valid."
                       },
                       "reason": {
                         "type": "string"
@@ -4967,7 +4967,6 @@
                 }
               },
               "bounds": {
-                "description": "Bounds as the compact [left, top, right, bottom] tuple — always this shape for skeleton entries.",
                 "type": "array",
                 "prefixItems": [
                   {
@@ -4982,7 +4981,8 @@
                   {
                     "type": "number"
                   }
-                ]
+                ],
+                "description": "Bounds as the compact [left, top, right, bottom] tuple — always this shape for skeleton entries."
               },
               "affordances": {
                 "type": "array",
@@ -5126,7 +5126,6 @@
                 "type": "object",
                 "properties": {
                   "bounds": {
-                    "description": "Element bounds. Default: positional tuple [left, top, right, bottom]; the object {left, top, right, bottom} (+ optional centerX/centerY) is also schema-valid.",
                     "anyOf": [
                       {
                         "type": "object",
@@ -5159,7 +5158,6 @@
                         "additionalProperties": false
                       },
                       {
-                        "description": "Compact bounds tuple [left, top, right, bottom], emitted in place of the {left, top, right, bottom} object.",
                         "type": "array",
                         "prefixItems": [
                           {
@@ -5174,9 +5172,11 @@
                           {
                             "type": "number"
                           }
-                        ]
+                        ],
+                        "description": "Compact bounds tuple [left, top, right, bottom], emitted in place of the {left, top, right, bottom} object."
                       }
-                    ]
+                    ],
+                    "description": "Element bounds. Default: positional tuple [left, top, right, bottom]; the object {left, top, right, bottom} (+ optional centerX/centerY) is also schema-valid."
                   }
                 },
                 "additionalProperties": {}
@@ -5206,7 +5206,6 @@
                 "type": "string"
               },
               "bounds": {
-                "description": "Element bounds. Default: positional tuple [left, top, right, bottom]; the object {left, top, right, bottom} (+ optional centerX/centerY) is also schema-valid.",
                 "anyOf": [
                   {
                     "type": "object",
@@ -5239,7 +5238,6 @@
                     "additionalProperties": false
                   },
                   {
-                    "description": "Compact bounds tuple [left, top, right, bottom], emitted in place of the {left, top, right, bottom} object.",
                     "type": "array",
                     "prefixItems": [
                       {
@@ -5254,9 +5252,11 @@
                       {
                         "type": "number"
                       }
-                    ]
+                    ],
+                    "description": "Compact bounds tuple [left, top, right, bottom], emitted in place of the {left, top, right, bottom} object."
                   }
-                ]
+                ],
+                "description": "Element bounds. Default: positional tuple [left, top, right, bottom]; the object {left, top, right, bottom} (+ optional centerX/centerY) is also schema-valid."
               },
               "indexInMatches": {
                 "type": "integer",
@@ -5302,7 +5302,6 @@
           "type": "object",
           "properties": {
             "bounds": {
-              "description": "Element bounds. Default: positional tuple [left, top, right, bottom]; the object {left, top, right, bottom} (+ optional centerX/centerY) is also schema-valid.",
               "anyOf": [
                 {
                   "type": "object",
@@ -5335,7 +5334,6 @@
                   "additionalProperties": false
                 },
                 {
-                  "description": "Compact bounds tuple [left, top, right, bottom], emitted in place of the {left, top, right, bottom} object.",
                   "type": "array",
                   "prefixItems": [
                     {
@@ -5350,9 +5348,11 @@
                     {
                       "type": "number"
                     }
-                  ]
+                  ],
+                  "description": "Compact bounds tuple [left, top, right, bottom], emitted in place of the {left, top, right, bottom} object."
                 }
-              ]
+              ],
+              "description": "Element bounds. Default: positional tuple [left, top, right, bottom]; the object {left, top, right, bottom} (+ optional centerX/centerY) is also schema-valid."
             },
             "text": {
               "type": "string"
@@ -5558,7 +5558,6 @@
           "type": "object",
           "properties": {
             "bounds": {
-              "description": "Element bounds. Default: positional tuple [left, top, right, bottom]; the object {left, top, right, bottom} (+ optional centerX/centerY) is also schema-valid.",
               "anyOf": [
                 {
                   "type": "object",
@@ -5591,7 +5590,6 @@
                   "additionalProperties": false
                 },
                 {
-                  "description": "Compact bounds tuple [left, top, right, bottom], emitted in place of the {left, top, right, bottom} object.",
                   "type": "array",
                   "prefixItems": [
                     {
@@ -5606,9 +5604,11 @@
                     {
                       "type": "number"
                     }
-                  ]
+                  ],
+                  "description": "Compact bounds tuple [left, top, right, bottom], emitted in place of the {left, top, right, bottom} object."
                 }
-              ]
+              ],
+              "description": "Element bounds. Default: positional tuple [left, top, right, bottom]; the object {left, top, right, bottom} (+ optional centerX/centerY) is also schema-valid."
             },
             "text": {
               "type": "string"
@@ -5814,7 +5814,6 @@
           "type": "object",
           "properties": {
             "bounds": {
-              "description": "Element bounds. Default: positional tuple [left, top, right, bottom]; the object {left, top, right, bottom} (+ optional centerX/centerY) is also schema-valid.",
               "anyOf": [
                 {
                   "type": "object",
@@ -5847,7 +5846,6 @@
                   "additionalProperties": false
                 },
                 {
-                  "description": "Compact bounds tuple [left, top, right, bottom], emitted in place of the {left, top, right, bottom} object.",
                   "type": "array",
                   "prefixItems": [
                     {
@@ -5862,9 +5860,11 @@
                     {
                       "type": "number"
                     }
-                  ]
+                  ],
+                  "description": "Compact bounds tuple [left, top, right, bottom], emitted in place of the {left, top, right, bottom} object."
                 }
-              ]
+              ],
+              "description": "Element bounds. Default: positional tuple [left, top, right, bottom]; the object {left, top, right, bottom} (+ optional centerX/centerY) is also schema-valid."
             },
             "text": {
               "type": "string"
@@ -6088,7 +6088,6 @@
           "type": "object",
           "properties": {
             "bounds": {
-              "description": "Element bounds. Default: positional tuple [left, top, right, bottom]; the object {left, top, right, bottom} (+ optional centerX/centerY) is also schema-valid.",
               "anyOf": [
                 {
                   "type": "object",
@@ -6121,7 +6120,6 @@
                   "additionalProperties": false
                 },
                 {
-                  "description": "Compact bounds tuple [left, top, right, bottom], emitted in place of the {left, top, right, bottom} object.",
                   "type": "array",
                   "prefixItems": [
                     {
@@ -6136,9 +6134,11 @@
                     {
                       "type": "number"
                     }
-                  ]
+                  ],
+                  "description": "Compact bounds tuple [left, top, right, bottom], emitted in place of the {left, top, right, bottom} object."
                 }
-              ]
+              ],
+              "description": "Element bounds. Default: positional tuple [left, top, right, bottom]; the object {left, top, right, bottom} (+ optional centerX/centerY) is also schema-valid."
             },
             "text": {
               "type": "string"
@@ -6346,7 +6346,6 @@
             "type": "object",
             "properties": {
               "bounds": {
-                "description": "Element bounds. Default: positional tuple [left, top, right, bottom]; the object {left, top, right, bottom} (+ optional centerX/centerY) is also schema-valid.",
                 "anyOf": [
                   {
                     "type": "object",
@@ -6379,7 +6378,6 @@
                     "additionalProperties": false
                   },
                   {
-                    "description": "Compact bounds tuple [left, top, right, bottom], emitted in place of the {left, top, right, bottom} object.",
                     "type": "array",
                     "prefixItems": [
                       {
@@ -6394,9 +6392,11 @@
                       {
                         "type": "number"
                       }
-                    ]
+                    ],
+                    "description": "Compact bounds tuple [left, top, right, bottom], emitted in place of the {left, top, right, bottom} object."
                   }
-                ]
+                ],
+                "description": "Element bounds. Default: positional tuple [left, top, right, bottom]; the object {left, top, right, bottom} (+ optional centerX/centerY) is also schema-valid."
               },
               "text": {
                 "type": "string"
@@ -7152,7 +7152,6 @@
               "maximum": 9007199254740991
             },
             "regionPx": {
-              "description": "Element bounds. Default: positional tuple [left, top, right, bottom]; the object {left, top, right, bottom} (+ optional centerX/centerY) is also schema-valid.",
               "anyOf": [
                 {
                   "type": "object",
@@ -7185,7 +7184,6 @@
                   "additionalProperties": false
                 },
                 {
-                  "description": "Compact bounds tuple [left, top, right, bottom], emitted in place of the {left, top, right, bottom} object.",
                   "type": "array",
                   "prefixItems": [
                     {
@@ -7200,9 +7198,11 @@
                     {
                       "type": "number"
                     }
-                  ]
+                  ],
+                  "description": "Compact bounds tuple [left, top, right, bottom], emitted in place of the {left, top, right, bottom} object."
                 }
-              ]
+              ],
+              "description": "Element bounds. Default: positional tuple [left, top, right, bottom]; the object {left, top, right, bottom} (+ optional centerX/centerY) is also schema-valid."
             },
             "focus": {
               "type": "object",
@@ -7282,8 +7282,8 @@
       "type": "object",
       "properties": {
         "url": {
-          "description": "URL to open",
-          "type": "string"
+          "type": "string",
+          "description": "URL to open"
         },
         "platform": {
           "type": "string",
@@ -7604,10 +7604,10 @@
           "type": "object",
           "properties": {
             "quietPeriodMs": {
-              "description": "Quiet-period ms (no hierarchy change) required after waitFor matches",
               "type": "integer",
               "exclusiveMinimum": 0,
-              "maximum": 9007199254740991
+              "maximum": 9007199254740991,
+              "description": "Quiet-period ms (no hierarchy change) required after waitFor matches"
             }
           },
           "required": [
@@ -7690,7 +7690,6 @@
       "type": "object",
       "properties": {
         "action": {
-          "description": "call/accept/cancel/busy/hold; hold needs no phoneNumber",
           "type": "string",
           "enum": [
             "call",
@@ -7698,7 +7697,8 @@
             "cancel",
             "busy",
             "hold"
-          ]
+          ],
+          "description": "call/accept/cancel/busy/hold; hold needs no phoneNumber"
         },
         "phoneNumber": {
           "description": "Phone number; required except for hold",
@@ -7737,12 +7737,12 @@
       "type": "object",
       "properties": {
         "direction": {
-          "description": "Pinch direction",
           "type": "string",
           "enum": [
             "in",
             "out"
-          ]
+          ],
+          "description": "Pinch direction"
         },
         "distanceStart": {
           "description": "Initial finger distance (px, default: 400)",
@@ -7773,12 +7773,12 @@
           "additionalProperties": false,
           "properties": {
             "elementId": {
-              "description": "Container resource ID",
-              "type": "string"
+              "type": "string",
+              "description": "Container resource ID"
             },
             "text": {
-              "description": "Container text",
-              "type": "string"
+              "type": "string",
+              "description": "Container text"
             }
           },
           "oneOf": [
@@ -7833,14 +7833,14 @@
       "type": "object",
       "properties": {
         "title": {
-          "description": "Notification title",
           "type": "string",
-          "minLength": 1
+          "minLength": 1,
+          "description": "Notification title"
         },
         "body": {
-          "description": "Notification body",
           "type": "string",
-          "minLength": 1
+          "minLength": 1,
+          "description": "Notification body"
         },
         "imageType": {
           "description": "Notification image type (default: normal)",
@@ -7861,14 +7861,14 @@
             "type": "object",
             "properties": {
               "label": {
-                "description": "Action label",
                 "type": "string",
-                "minLength": 1
+                "minLength": 1,
+                "description": "Action label"
               },
               "actionId": {
-                "description": "Action identifier",
                 "type": "string",
-                "minLength": 1
+                "minLength": 1,
+                "description": "Action identifier"
               }
             },
             "required": [
@@ -7883,9 +7883,9 @@
           "type": "string"
         },
         "appId": {
-          "description": "Android target package name or iOS target bundle ID; Android defaults to the live foreground app when omitted",
           "type": "string",
-          "minLength": 1
+          "minLength": 1,
+          "description": "Android target package name or iOS target bundle ID; Android defaults to the live foreground app when omitted"
         },
         "platform": {
           "type": "string",
@@ -7982,9 +7982,9 @@
       "type": "object",
       "properties": {
         "operationId": {
-          "description": "Caller-generated idempotency key",
           "type": "string",
-          "minLength": 1
+          "minLength": 1,
+          "description": "Caller-generated idempotency key"
         },
         "device": {
           "oneOf": [
@@ -7996,22 +7996,22 @@
                   "const": "android"
                 },
                 "name": {
-                  "description": "Exact AVD name",
                   "type": "string",
-                  "minLength": 1
+                  "minLength": 1,
+                  "description": "Exact AVD name"
                 },
                 "spec": {
                   "type": "object",
                   "properties": {
                     "runtime": {
-                      "description": "Installed Android system-image package identifier",
                       "type": "string",
-                      "minLength": 1
+                      "minLength": 1,
+                      "description": "Installed Android system-image package identifier"
                     },
                     "deviceType": {
-                      "description": "Android avdmanager device profile identifier",
                       "type": "string",
-                      "minLength": 1
+                      "minLength": 1,
+                      "description": "Android avdmanager device profile identifier"
                     },
                     "configuration": {
                       "type": "object",
@@ -8047,22 +8047,22 @@
                   "const": "ios"
                 },
                 "name": {
-                  "description": "Exact simulator name",
                   "type": "string",
-                  "minLength": 1
+                  "minLength": 1,
+                  "description": "Exact simulator name"
                 },
                 "spec": {
                   "type": "object",
                   "properties": {
                     "runtime": {
-                      "description": "CoreSimulator runtime identifier",
                       "type": "string",
-                      "minLength": 1
+                      "minLength": 1,
+                      "description": "CoreSimulator runtime identifier"
                     },
                     "deviceType": {
-                      "description": "CoreSimulator device-type identifier",
                       "type": "string",
-                      "minLength": 1
+                      "minLength": 1,
+                      "description": "CoreSimulator device-type identifier"
                     }
                   },
                   "required": [
@@ -8121,7 +8121,6 @@
           "minLength": 1
         },
         "container": {
-          "description": "App container",
           "type": "string",
           "enum": [
             "documents",
@@ -8129,7 +8128,8 @@
             "cache",
             "tmp",
             "externalFiles"
-          ]
+          ],
+          "description": "App container"
         },
         "sourcePath": {
           "description": "Host file path",
@@ -8145,8 +8145,8 @@
           "type": "string"
         },
         "destinationPath": {
-          "description": "Container-relative destination path",
-          "type": "string"
+          "type": "string",
+          "description": "Container-relative destination path"
         },
         "platform": {
           "type": "string",
@@ -8292,16 +8292,16 @@
           "type": "string"
         },
         "name": {
-          "description": "Storage name",
-          "type": "string"
+          "type": "string",
+          "description": "Storage name"
         },
         "fileName": {
           "description": "Deprecated alias for name",
           "type": "string"
         },
         "key": {
-          "description": "Key",
-          "type": "string"
+          "type": "string",
+          "description": "Key"
         },
         "platform": {
           "type": "string",
@@ -8337,13 +8337,13 @@
       "type": "object",
       "properties": {
         "appId": {
-          "description": "Required. The app whose Keychain/Keystore state to reset. NOTE: iOS Simulator only supports a device-wide reset and erases EVERY app's Keychain regardless of this value.",
           "type": "string",
-          "minLength": 1
+          "minLength": 1,
+          "description": "Required. The app whose Keychain/Keystore state to reset. NOTE: iOS Simulator only supports a device-wide reset and erases EVERY app's Keychain regardless of this value."
         },
         "confirm": {
-          "description": "Required. Must be true to proceed. On iOS Simulator this erases the Keychain for EVERY app on the target simulator, not just appId.",
-          "type": "boolean"
+          "type": "boolean",
+          "description": "Required. Must be true to proceed. On iOS Simulator this erases the Keychain for EVERY app on the target simulator, not just appId."
         },
         "platform": {
           "type": "string",
@@ -8451,12 +8451,12 @@
       "type": "object",
       "properties": {
         "phoneNumber": {
-          "description": "Sender phone number",
-          "type": "string"
+          "type": "string",
+          "description": "Sender phone number"
         },
         "message": {
-          "description": "SMS body; max 1024 chars, no newlines/NUL",
-          "type": "string"
+          "type": "string",
+          "description": "SMS body; max 1024 chars, no newlines/NUL"
         },
         "platform": {
           "type": "string",
@@ -8682,19 +8682,18 @@
           "type": "string"
         },
         "name": {
-          "description": "Storage name",
-          "type": "string"
+          "type": "string",
+          "description": "Storage name"
         },
         "fileName": {
           "description": "Deprecated alias for name",
           "type": "string"
         },
         "key": {
-          "description": "Key",
-          "type": "string"
+          "type": "string",
+          "description": "Key"
         },
         "value": {
-          "description": "Value string; null clears",
           "anyOf": [
             {
               "type": "string"
@@ -8702,10 +8701,10 @@
             {
               "type": "null"
             }
-          ]
+          ],
+          "description": "Value string; null clears"
         },
         "type": {
-          "description": "Value type",
           "type": "string",
           "enum": [
             "STRING",
@@ -8720,7 +8719,8 @@
             "ARRAY",
             "DICTIONARY",
             "UNKNOWN"
-          ]
+          ],
+          "description": "Value type"
         },
         "platform": {
           "type": "string",
@@ -8762,8 +8762,8 @@
           "minLength": 1
         },
         "policyAccess": {
-          "description": "Android: allow DND policy access",
-          "type": "boolean"
+          "type": "boolean",
+          "description": "Android: allow DND policy access"
         },
         "platform": {
           "type": "string",
@@ -8799,13 +8799,13 @@
       "type": "object",
       "properties": {
         "scope": {
-          "description": "Preference scope",
           "type": "string",
           "enum": [
             "systemProperty",
             "sharedPreferences",
             "userDefaults"
-          ]
+          ],
+          "description": "Preference scope"
         },
         "appId": {
           "description": "App package or bundle id",
@@ -8816,12 +8816,11 @@
           "type": "string"
         },
         "key": {
-          "description": "Preference key or Android system property name",
           "type": "string",
-          "minLength": 1
+          "minLength": 1,
+          "description": "Preference key or Android system property name"
         },
         "value": {
-          "description": "Value to write",
           "anyOf": [
             {
               "type": "string"
@@ -8832,17 +8831,18 @@
             {
               "type": "number"
             }
-          ]
+          ],
+          "description": "Value to write"
         },
         "type": {
-          "description": "Value type for typed preference stores",
           "type": "string",
           "enum": [
             "string",
             "bool",
             "int",
             "float"
-          ]
+          ],
+          "description": "Value type for typed preference stores"
         },
         "platform": {
           "type": "string",
@@ -8880,9 +8880,9 @@
       "type": "object",
       "properties": {
         "toolName": {
-          "description": "Exact case-sensitive AutoMobile tool name to enable or disable.",
           "type": "string",
-          "minLength": 1
+          "minLength": 1,
+          "description": "Exact case-sensitive AutoMobile tool name to enable or disable."
         },
         "enabled": {
           "description": "Whether to enable the tool (default: true).",
@@ -8909,26 +8909,25 @@
       "type": "object",
       "properties": {
         "fields": {
-          "description": "Fields to set",
           "minItems": 1,
           "type": "array",
           "items": {
             "type": "object",
             "properties": {
               "selector": {
-                "description": "Field selector",
                 "type": "object",
                 "properties": {
                   "elementId": {
-                    "description": "Resource ID, e.g. com.app:id/btn_login",
-                    "type": "string"
+                    "type": "string",
+                    "description": "Resource ID, e.g. com.app:id/btn_login"
                   },
                   "text": {
-                    "description": "Text, content-desc, or placeholder",
-                    "type": "string"
+                    "type": "string",
+                    "description": "Text, content-desc, or placeholder"
                   }
                 },
-                "additionalProperties": false
+                "additionalProperties": false,
+                "description": "Field selector"
               },
               "value": {
                 "description": "Text/dropdown value",
@@ -8943,7 +8942,8 @@
               "selector"
             ],
             "additionalProperties": false
-          }
+          },
+          "description": "Fields to set"
         },
         "scrollDirection": {
           "description": "Initial search scroll direction",
@@ -8982,11 +8982,10 @@
       "type": "object",
       "properties": {
         "success": {
-          "description": "All fields set",
-          "type": "boolean"
+          "type": "boolean",
+          "description": "All fields set"
         },
         "fields": {
-          "description": "Field results",
           "type": "array",
           "items": {
             "type": "object",
@@ -9035,11 +9034,12 @@
               "attempts"
             ],
             "additionalProperties": false
-          }
+          },
+          "description": "Field results"
         },
         "totalAttempts": {
-          "description": "Total attempts",
-          "type": "number"
+          "type": "number",
+          "description": "Total attempts"
         },
         "error": {
           "description": "Error message",
@@ -9105,12 +9105,12 @@
           "type": "string"
         },
         "databasePath": {
-          "description": "Database path",
-          "type": "string"
+          "type": "string",
+          "description": "Database path"
         },
         "query": {
-          "description": "SQL query",
-          "type": "string"
+          "type": "string",
+          "description": "SQL query"
         },
         "platform": {
           "type": "string",
@@ -9193,12 +9193,12 @@
           "additionalProperties": false,
           "properties": {
             "elementId": {
-              "description": "Container resource ID",
-              "type": "string"
+              "type": "string",
+              "description": "Container resource ID"
             },
             "text": {
-              "description": "Container text",
-              "type": "string"
+              "type": "string",
+              "description": "Container text"
             }
           },
           "oneOf": [
@@ -9220,14 +9220,14 @@
           "type": "boolean"
         },
         "direction": {
-          "description": "Swipe/scroll direction",
           "type": "string",
           "enum": [
             "up",
             "down",
             "left",
             "right"
-          ]
+          ],
+          "description": "Swipe/scroll direction"
         },
         "gestureType": {
           "description": "Finger direction or content scroll direction; default: scrollTowardsDirection",
@@ -9242,12 +9242,12 @@
           "additionalProperties": false,
           "properties": {
             "elementId": {
-              "description": "ID of the element to look for",
-              "type": "string"
+              "type": "string",
+              "description": "ID of the element to look for"
             },
             "text": {
-              "description": "Text to look for",
-              "type": "string"
+              "type": "string",
+              "description": "Text to look for"
             }
           },
           "oneOf": [
@@ -9323,7 +9323,6 @@
       "type": "object",
       "properties": {
         "action": {
-          "description": "open/close/find/tap/dismiss/clearAll notification",
           "type": "string",
           "enum": [
             "open",
@@ -9332,7 +9331,8 @@
             "tap",
             "dismiss",
             "clearAll"
-          ]
+          ],
+          "description": "open/close/find/tap/dismiss/clearAll notification"
         },
         "notification": {
           "description": "Notification criteria to match",
@@ -9399,12 +9399,12 @@
           "additionalProperties": false,
           "properties": {
             "elementId": {
-              "description": "Container resource ID",
-              "type": "string"
+              "type": "string",
+              "description": "Container resource ID"
             },
             "text": {
-              "description": "Container text",
-              "type": "string"
+              "type": "string",
+              "description": "Container text"
             }
           },
           "oneOf": [
@@ -9434,8 +9434,8 @@
           "type": "boolean"
         },
         "action": {
-          "description": "Action type (default: tap)",
           "default": "tap",
+          "description": "Action type (default: tap)",
           "type": "string",
           "enum": [
             "tap",
@@ -9498,33 +9498,33 @@
           "additionalProperties": false,
           "properties": {
             "elementId": {
-              "description": "Resource ID, e.g. com.app:id/btn_login",
               "type": "string",
-              "minLength": 1
+              "minLength": 1,
+              "description": "Resource ID, e.g. com.app:id/btn_login"
             },
             "testTag": {
-              "description": "Android accessibility test tag",
               "type": "string",
-              "minLength": 1
+              "minLength": 1,
+              "description": "Android accessibility test tag"
             },
             "text": {
-              "description": "Text, content-desc, or placeholder",
               "type": "string",
-              "minLength": 1
+              "minLength": 1,
+              "description": "Text, content-desc, or placeholder"
             },
             "accessibilityLink": {
-              "description": "Exact visible text of a semantic accessibility link",
               "type": "string",
-              "minLength": 1
+              "minLength": 1,
+              "description": "Exact visible text of a semantic accessibility link"
             },
             "textAny": {
-              "description": "Ordered text variants; first visible match wins",
               "minItems": 1,
               "type": "array",
               "items": {
                 "type": "string",
                 "minLength": 1
-              }
+              },
+              "description": "Ordered text variants; first visible match wins"
             }
           },
           "oneOf": [
@@ -9565,12 +9565,12 @@
           "additionalProperties": false,
           "properties": {
             "elementId": {
-              "description": "Container resource ID",
-              "type": "string"
+              "type": "string",
+              "description": "Container resource ID"
             },
             "text": {
-              "description": "Container text",
-              "type": "string"
+              "type": "string",
+              "description": "Container text"
             }
           },
           "oneOf": [
@@ -9588,8 +9588,8 @@
           "description": "Scope search to a container"
         },
         "action": {
-          "description": "Action type (default: tap)",
           "default": "tap",
+          "description": "Action type (default: tap)",
           "type": "string",
           "enum": [
             "tap",
@@ -9621,9 +9621,9 @@
           "type": "object",
           "properties": {
             "text": {
-              "description": "Exact visible text of a semantic link inside the selected element",
               "type": "string",
-              "minLength": 1
+              "minLength": 1,
+              "description": "Exact visible text of a semantic link inside the selected element"
             },
             "occurrence": {
               "description": "Zero-based occurrence among exact semantic-link matches (default: 0)",
@@ -9794,7 +9794,6 @@
           "type": "object",
           "properties": {
             "bounds": {
-              "description": "Element bounds. Default: positional tuple [left, top, right, bottom]; the object {left, top, right, bottom} (+ optional centerX/centerY) is also schema-valid.",
               "anyOf": [
                 {
                   "type": "object",
@@ -9827,7 +9826,6 @@
                   "additionalProperties": false
                 },
                 {
-                  "description": "Compact bounds tuple [left, top, right, bottom], emitted in place of the {left, top, right, bottom} object.",
                   "type": "array",
                   "prefixItems": [
                     {
@@ -9842,9 +9840,11 @@
                     {
                       "type": "number"
                     }
-                  ]
+                  ],
+                  "description": "Compact bounds tuple [left, top, right, bottom], emitted in place of the {left, top, right, bottom} object."
                 }
-              ]
+              ],
+              "description": "Element bounds. Default: positional tuple [left, top, right, bottom]; the object {left, top, right, bottom} (+ optional centerX/centerY) is also schema-valid."
             },
             "text": {
               "type": "string"
@@ -10066,7 +10066,6 @@
                         "type": "string"
                       },
                       "bounds": {
-                        "description": "Element bounds. Default: positional tuple [left, top, right, bottom]; the object {left, top, right, bottom} (+ optional centerX/centerY) is also schema-valid.",
                         "anyOf": [
                           {
                             "type": "object",
@@ -10099,7 +10098,6 @@
                             "additionalProperties": false
                           },
                           {
-                            "description": "Compact bounds tuple [left, top, right, bottom], emitted in place of the {left, top, right, bottom} object.",
                             "type": "array",
                             "prefixItems": [
                               {
@@ -10114,9 +10112,11 @@
                               {
                                 "type": "number"
                               }
-                            ]
+                            ],
+                            "description": "Compact bounds tuple [left, top, right, bottom], emitted in place of the {left, top, right, bottom} object."
                           }
-                        ]
+                        ],
+                        "description": "Element bounds. Default: positional tuple [left, top, right, bottom]; the object {left, top, right, bottom} (+ optional centerX/centerY) is also schema-valid."
                       },
                       "indexInMatches": {
                         "type": "integer",
@@ -10162,7 +10162,6 @@
                   "type": "object",
                   "properties": {
                     "bounds": {
-                      "description": "Element bounds. Default: positional tuple [left, top, right, bottom]; the object {left, top, right, bottom} (+ optional centerX/centerY) is also schema-valid.",
                       "anyOf": [
                         {
                           "type": "object",
@@ -10195,7 +10194,6 @@
                           "additionalProperties": false
                         },
                         {
-                          "description": "Compact bounds tuple [left, top, right, bottom], emitted in place of the {left, top, right, bottom} object.",
                           "type": "array",
                           "prefixItems": [
                             {
@@ -10210,9 +10208,11 @@
                             {
                               "type": "number"
                             }
-                          ]
+                          ],
+                          "description": "Compact bounds tuple [left, top, right, bottom], emitted in place of the {left, top, right, bottom} object."
                         }
-                      ]
+                      ],
+                      "description": "Element bounds. Default: positional tuple [left, top, right, bottom]; the object {left, top, right, bottom} (+ optional centerX/centerY) is also schema-valid."
                     },
                     "text": {
                       "type": "string"
@@ -10418,7 +10418,6 @@
                   "type": "object",
                   "properties": {
                     "bounds": {
-                      "description": "Element bounds. Default: positional tuple [left, top, right, bottom]; the object {left, top, right, bottom} (+ optional centerX/centerY) is also schema-valid.",
                       "anyOf": [
                         {
                           "type": "object",
@@ -10451,7 +10450,6 @@
                           "additionalProperties": false
                         },
                         {
-                          "description": "Compact bounds tuple [left, top, right, bottom], emitted in place of the {left, top, right, bottom} object.",
                           "type": "array",
                           "prefixItems": [
                             {
@@ -10466,9 +10464,11 @@
                             {
                               "type": "number"
                             }
-                          ]
+                          ],
+                          "description": "Compact bounds tuple [left, top, right, bottom], emitted in place of the {left, top, right, bottom} object."
                         }
-                      ]
+                      ],
+                      "description": "Element bounds. Default: positional tuple [left, top, right, bottom]; the object {left, top, right, bottom} (+ optional centerX/centerY) is also schema-valid."
                     },
                     "text": {
                       "type": "string"
@@ -11048,7 +11048,6 @@
               "type": "string"
             },
             "bounds": {
-              "description": "Element bounds. Default: positional tuple [left, top, right, bottom]; the object {left, top, right, bottom} (+ optional centerX/centerY) is also schema-valid.",
               "anyOf": [
                 {
                   "type": "object",
@@ -11081,7 +11080,6 @@
                   "additionalProperties": false
                 },
                 {
-                  "description": "Compact bounds tuple [left, top, right, bottom], emitted in place of the {left, top, right, bottom} object.",
                   "type": "array",
                   "prefixItems": [
                     {
@@ -11096,9 +11094,11 @@
                     {
                       "type": "number"
                     }
-                  ]
+                  ],
+                  "description": "Compact bounds tuple [left, top, right, bottom], emitted in place of the {left, top, right, bottom} object."
                 }
-              ]
+              ],
+              "description": "Element bounds. Default: positional tuple [left, top, right, bottom]; the object {left, top, right, bottom} (+ optional centerX/centerY) is also schema-valid."
             },
             "indexInMatches": {
               "type": "integer",
@@ -11173,7 +11173,6 @@
                 "type": "string"
               },
               "bounds": {
-                "description": "Element bounds. Default: positional tuple [left, top, right, bottom]; the object {left, top, right, bottom} (+ optional centerX/centerY) is also schema-valid.",
                 "anyOf": [
                   {
                     "type": "object",
@@ -11206,7 +11205,6 @@
                     "additionalProperties": false
                   },
                   {
-                    "description": "Compact bounds tuple [left, top, right, bottom], emitted in place of the {left, top, right, bottom} object.",
                     "type": "array",
                     "prefixItems": [
                       {
@@ -11221,9 +11219,11 @@
                       {
                         "type": "number"
                       }
-                    ]
+                    ],
+                    "description": "Compact bounds tuple [left, top, right, bottom], emitted in place of the {left, top, right, bottom} object."
                   }
-                ]
+                ],
+                "description": "Element bounds. Default: positional tuple [left, top, right, bottom]; the object {left, top, right, bottom} (+ optional centerX/centerY) is also schema-valid."
               },
               "indexInMatches": {
                 "type": "integer",
@@ -11307,17 +11307,15 @@
           "type": "object",
           "properties": {
             "reachable": {
-              "description": "Whether swipe cursor navigation reached the target",
-              "type": "boolean"
+              "type": "boolean",
+              "description": "Whether swipe cursor navigation reached the target"
             },
             "traversalOrder": {
-              "description": "Focused nodes in cursor traversal order",
               "type": "array",
               "items": {
                 "type": "object",
                 "properties": {
                   "bounds": {
-                    "description": "Element bounds. Default: positional tuple [left, top, right, bottom]; the object {left, top, right, bottom} (+ optional centerX/centerY) is also schema-valid.",
                     "anyOf": [
                       {
                         "type": "object",
@@ -11350,7 +11348,6 @@
                         "additionalProperties": false
                       },
                       {
-                        "description": "Compact bounds tuple [left, top, right, bottom], emitted in place of the {left, top, right, bottom} object.",
                         "type": "array",
                         "prefixItems": [
                           {
@@ -11365,9 +11362,11 @@
                           {
                             "type": "number"
                           }
-                        ]
+                        ],
+                        "description": "Compact bounds tuple [left, top, right, bottom], emitted in place of the {left, top, right, bottom} object."
                       }
-                    ]
+                    ],
+                    "description": "Element bounds. Default: positional tuple [left, top, right, bottom]; the object {left, top, right, bottom} (+ optional centerX/centerY) is also schema-valid."
                   },
                   "text": {
                     "type": "string"
@@ -11568,11 +11567,12 @@
                   "bounds"
                 ],
                 "additionalProperties": {}
-              }
+              },
+              "description": "Focused nodes in cursor traversal order"
             },
             "focusTrapDetected": {
-              "description": "Whether cursor navigation got stuck or failed to converge",
-              "type": "boolean"
+              "type": "boolean",
+              "description": "Whether cursor navigation got stuck or failed to converge"
             }
           },
           "required": [
@@ -11765,7 +11765,6 @@
                 "type": "string"
               },
               "shape": {
-                "description": "Highlight shape",
                 "oneOf": [
                   {
                     "type": "object",
@@ -12328,7 +12327,8 @@
                     ],
                     "additionalProperties": false
                   }
-                ]
+                ],
+                "description": "Highlight shape"
               },
               "timing": {
                 "description": "Highlight timing",

--- a/src/features/accessibility/VoiceOverToggle.ts
+++ b/src/features/accessibility/VoiceOverToggle.ts
@@ -51,10 +51,15 @@ export class VoiceOverToggle {
     const client = this.clientProvider();
     const result = await client.requestSetVoiceOverEnabled(enabled);
     if (!result.success) {
+      const reason = result.error ?? "Failed to toggle VoiceOver via Settings";
+      // Log before returning so the Settings-row-not-found case leaves a trace,
+      // matching the Simulator path's logger.warn (the reason also surfaces to
+      // the client as an ActionableError).
+      logger.warn(`[VoiceOverToggle] Failed to ${enabled ? "enable" : "disable"} VoiceOver via Settings: ${reason}`);
       return {
         supported: false,
         applied: false,
-        reason: result.error ?? "Failed to toggle VoiceOver via Settings"
+        reason
       };
     }
 

--- a/src/features/accessibility/VoiceOverToggle.ts
+++ b/src/features/accessibility/VoiceOverToggle.ts
@@ -7,7 +7,7 @@ import { iosVoiceOverDetector } from "../../utils/IosVoiceOverDetector";
 import { DefaultHostCommandExecutor, type HostCommandExecutor } from "../../utils/HostCommandExecutor";
 import { isIosSimulatorUdid } from "../../utils/ios-cmdline-tools/iosDeviceType";
 import { type Timer, defaultTimer } from "../../utils/SystemTimer";
-import { IOSCtrlProxyClient } from "../observe/ios";
+import { IOSCtrlProxyClient, type IOSCtrlProxy } from "../observe/ios";
 
 const VOICEOVER_CONFIRMATION_TIMEOUT_MS = 10_000;
 const VOICEOVER_CONFIRMATION_POLL_INTERVAL_MS = 500;
@@ -17,18 +17,58 @@ export class VoiceOverToggle {
     private readonly device: BootedDevice,
     private readonly detector: IosVoiceOverDetector = iosVoiceOverDetector,
     private readonly processExecutor: HostCommandExecutor = new DefaultHostCommandExecutor(),
-    private readonly timer: Timer = defaultTimer
+    private readonly timer: Timer = defaultTimer,
+    // Resolve lazily so the iOS singleton is only touched when the toggle runs,
+    // and so tests can inject a fake CtrlProxy for the physical-device path.
+    private readonly clientProvider: () => IOSCtrlProxy = () =>
+      IOSCtrlProxyClient.getInstance(this.device)
   ) {}
 
   async toggle(enabled: boolean): Promise<VoiceOverResult> {
     if (!this.isSimulator()) {
+      return this.toggleViaSettings(enabled);
+    }
+
+    return this.toggleViaSimctl(enabled);
+  }
+
+  /**
+   * Physical-device path: drive the Settings app through the CtrlProxy runner.
+   *
+   * There is no command-line write into a real device's system-preferences
+   * domain (no `simctl`/`defaults`/`notifyutil` analog), so the runner opens
+   * `App-Prefs:root=ACCESSIBILITY`, reads the VoiceOver switch, and taps only
+   * when it differs — early-returning when already in the target state because
+   * once VoiceOver is on every tap requires the double-tap idiom (#2501).
+   *
+   * We trust the runner's `success` (it confirms/early-returns on-device) rather
+   * than re-detecting host-side: unlike the Simulator's fire-and-forget `simctl`
+   * write, the Settings tap is synchronous on the device. A failure (e.g. the
+   * locale-fragile Settings row could not be found) surfaces as
+   * `supported:false` with the reason — never a silent success (#2501, inv. 5).
+   */
+  private async toggleViaSettings(enabled: boolean): Promise<VoiceOverResult> {
+    const client = this.clientProvider();
+    const result = await client.requestSetVoiceOverEnabled(enabled);
+    if (!result.success) {
       return {
         supported: false,
         applied: false,
-        reason: "VoiceOver toggle is only supported on iOS Simulator"
+        reason: result.error ?? "Failed to toggle VoiceOver via Settings"
       };
     }
 
+    // Parity with the Simulator path: a successful toggle changes device state,
+    // so the cached detection is now stale.
+    this.detector.invalidateCache(this.device.deviceId);
+    return {
+      supported: true,
+      applied: true,
+      currentState: enabled
+    };
+  }
+
+  private async toggleViaSimctl(enabled: boolean): Promise<VoiceOverResult> {
     // Always run the simctl commands — they are idempotent and skipping them
     // based on a detection result is unsafe: IosVoiceOverDetector maps
     // detection failures to false, so a CtrlProxy outage would cause
@@ -73,7 +113,7 @@ export class VoiceOverToggle {
     // requested one (#3921). Detection failure maps to `false`, so a confirmation
     // that cannot be read reports the toggle as not-applied (conservative).
     // Resolve lazily so the iOS singleton is only touched on the iOS path.
-    const client = IOSCtrlProxyClient.getInstance(this.device);
+    const client = this.clientProvider();
     const confirmedEnabled = await this.waitForState(enabled, client);
 
     return {
@@ -92,7 +132,7 @@ export class VoiceOverToggle {
    * Poll the post-apply confirmation through the injectable timer so a successful
    * enable is not reported as failed merely because its service is still starting.
    */
-  private async waitForState(enabled: boolean, client: IOSCtrlProxyClient): Promise<boolean> {
+  private async waitForState(enabled: boolean, client: IOSCtrlProxy): Promise<boolean> {
     const deadline = this.timer.now() + VOICEOVER_CONFIRMATION_TIMEOUT_MS;
     let confirmedEnabled = false;
 

--- a/src/features/observe/ios/CtrlProxyVoiceOver.ts
+++ b/src/features/observe/ios/CtrlProxyVoiceOver.ts
@@ -134,6 +134,45 @@ export class CtrlProxyVoiceOver {
    * @param perf - Optional performance tracker
    * @returns Action result
    */
+  /**
+   * Enable or disable VoiceOver via the runner.
+   *
+   * On the Simulator VoiceOver is toggled host-side with `simctl` (see
+   * VoiceOverToggle); on a **physical** device there is no command-line write
+   * into the system-preferences domain, so the runner drives the Settings app
+   * (open `App-Prefs:root=ACCESSIBILITY`, read the VoiceOver switch, tap only
+   * when it differs). The runner early-returns when already in the target state
+   * because once VoiceOver is on every tap requires the double-tap idiom — so a
+   * blind re-tap would be interpreted as an activation, not a toggle (#2501).
+   *
+   * @param enabled - Target VoiceOver state
+   * @param timeoutMs - Request timeout (default 30000; Settings navigation is slow)
+   * @param perf - Optional performance tracker
+   * @returns Action result — `success:false` with `error` when the Settings row
+   *          cannot be located (locale/layout drift), never a silent success.
+   */
+  async requestSetVoiceOverEnabled(
+    enabled: boolean,
+    timeoutMs: number = 30000,
+    perf?: PerformanceTracker,
+  ): Promise<CtrlProxyActionResult> {
+    return sendCommand<CtrlProxyActionResult>(this.context, {
+      idPrefix: "voiceover_set",
+      responseType: "voiceover_set",
+      messageType: "set_voiceover_state",
+      params: { enabled },
+      timeoutMs,
+      perf,
+      cancelScreenshotBackoff: false,
+      notConnectedError: () => ({ success: false, error: "Not connected to CtrlProxy" }),
+      // The command is new: an older runner that predates it must surface as a
+      // typed failure so VoiceOverToggle reports supported:false (never a silent
+      // success), parity with requestVoiceOverActivate.
+      unsupportedCommandError: (_messageType, error) => ({ success: false, totalTimeMs: 0, error }),
+      timeoutError: () => ({ success: false, error: "Timeout waiting for voiceover_set_result" }),
+    });
+  }
+
   async requestVoiceOverActivate(
     label: string,
     action: "activate" | "long_press",

--- a/src/features/observe/ios/IOSCtrlProxyClient.ts
+++ b/src/features/observe/ios/IOSCtrlProxyClient.ts
@@ -380,6 +380,12 @@ export interface IOSCtrlProxy extends CtrlProxyClient {
     perf?: PerformanceTracker,
   ): Promise<CtrlProxyActionResult>;
 
+  requestSetVoiceOverEnabled(
+    enabled: boolean,
+    timeoutMs?: number,
+    perf?: PerformanceTracker,
+  ): Promise<CtrlProxyActionResult>;
+
   requestAction(
     action: string,
     resourceId?: string,
@@ -2327,6 +2333,14 @@ export class IOSCtrlProxyClient extends DeviceServiceClient implements IOSCtrlPr
     perf?: PerformanceTracker,
   ): Promise<CtrlProxyActionResult> {
     return this.voiceOver.requestVoiceOverActivate(label, action, timeoutMs, perf);
+  }
+
+  async requestSetVoiceOverEnabled(
+    enabled: boolean,
+    timeoutMs?: number,
+    perf?: PerformanceTracker,
+  ): Promise<CtrlProxyActionResult> {
+    return this.voiceOver.requestSetVoiceOverEnabled(enabled, timeoutMs, perf);
   }
 
   async requestAction(

--- a/src/features/observe/ios/ctrlProxyRequestTypes.ts
+++ b/src/features/observe/ios/ctrlProxyRequestTypes.ts
@@ -65,6 +65,7 @@ export const IOS_KNOWN_REQUEST_TYPES = [
   "get_traversal_order",
   "add_highlight",
   "get_voiceover_state",
+  "set_voiceover_state",
 
   // Storage inspection
   "list_preference_files",

--- a/src/features/observe/ios/decodeCtrlProxyMessage.ts
+++ b/src/features/observe/ios/decodeCtrlProxyMessage.ts
@@ -141,6 +141,18 @@ export function decodeCtrlProxyMessage(message: WebSocketMessage): DecodedCtrlPr
       };
       break;
 
+    case "voiceover_set_result":
+      // The runner deliberately returns success:false with an error (e.g. the
+      // Settings VoiceOver row could not be located) rather than throwing, so it
+      // must RESOLVE as a typed CtrlProxyActionResult — VoiceOverToggle maps
+      // success:false to supported:false, never a silent success (#2501).
+      result = {
+        success: message.success ?? false,
+        totalTimeMs: message.totalTimeMs ?? 0,
+        error: message.error,
+      };
+      break;
+
     case "highlight_response":
       result = {
         success: message.success ?? false,

--- a/src/server/accessibilityTools.ts
+++ b/src/server/accessibilityTools.ts
@@ -23,7 +23,9 @@ export const accessibilitySchema = addDeviceTargetingToSchema(
     voiceover: z
       .boolean()
       .optional()
-      .describe("Enable (true) or disable (false) VoiceOver on iOS Simulator"),
+      .describe(
+        "Enable (true) or disable (false) VoiceOver on an iOS device (Simulator via simctl; physical devices are driven through the Settings app)",
+      ),
   }),
 );
 
@@ -111,7 +113,7 @@ export function registerAccessibilityTools() {
 
   ToolRegistry.registerDeviceAware(
     "accessibility",
-    "Check or control accessibility services. On Android: omit talkback to check TalkBack state, or pass talkback: true/false to enable/disable it. On iOS: omit voiceover to check VoiceOver state, or pass voiceover: true/false to enable/disable it (Simulator only). Always returns fresh state from the device.",
+    "Check or control accessibility services. On Android: omit talkback to check TalkBack state, or pass talkback: true/false to enable/disable it. On iOS: omit voiceover to check VoiceOver state, or pass voiceover: true/false to enable/disable it (Simulator via simctl, physical devices via the Settings app). Always returns fresh state from the device.",
     accessibilitySchema,
     accessibilityHandler,
     { defaultEnabled: false, outputSchema: accessibilityStateSchema },

--- a/test/fakes/FakeIOSCtrlProxy.ts
+++ b/test/fakes/FakeIOSCtrlProxy.ts
@@ -116,6 +116,7 @@ export class FakeIOSCtrlProxy implements IOSCtrlProxy {
   private recentAppsResult: CtrlProxyRecentAppsResult | null = null;
   private voiceOverState: boolean = false;
   private voiceOverActivateResult: CtrlProxyActionResult | null = null;
+  private setVoiceOverEnabledResult: CtrlProxyActionResult | null = null;
   private multiFingerSwipeResult: CtrlProxySwipeResult | null = null;
   private actionResult: CtrlProxyActionResult | null = null;
   private clipboardResult: CtrlProxyClipboardResult | null = null;
@@ -131,6 +132,9 @@ export class FakeIOSCtrlProxy implements IOSCtrlProxy {
     label: string;
     action: "activate" | "long_press";
   }> = [];
+
+  // requestSetVoiceOverEnabled call history
+  private setVoiceOverEnabledHistory: boolean[] = [];
 
   private actionHistory: Array<{
     action: string;
@@ -248,6 +252,20 @@ export class FakeIOSCtrlProxy implements IOSCtrlProxy {
    */
   setVoiceOverActivateResult(result: CtrlProxyActionResult | null): void {
     this.voiceOverActivateResult = result;
+  }
+
+  /**
+   * Configure the result of requestSetVoiceOverEnabled (null = default success)
+   */
+  setSetVoiceOverEnabledResult(result: CtrlProxyActionResult | null): void {
+    this.setVoiceOverEnabledResult = result;
+  }
+
+  /**
+   * Get requestSetVoiceOverEnabled call history (the requested enabled values)
+   */
+  getSetVoiceOverEnabledHistory(): boolean[] {
+    return [...this.setVoiceOverEnabledHistory];
   }
 
   /**
@@ -453,6 +471,7 @@ export class FakeIOSCtrlProxy implements IOSCtrlProxy {
     this.rotateHistory = [];
     this.currentOrientation = "portrait";
     this.voiceOverActivateHistory = [];
+    this.setVoiceOverEnabledHistory = [];
     this.actionHistory = [];
     this.multiFingerSwipeHistory = [];
     this.clipboardHistory = [];
@@ -963,6 +982,26 @@ export class FakeIOSCtrlProxy implements IOSCtrlProxy {
     return {
       success: true,
       action,
+      totalTimeMs: 50,
+    };
+  }
+
+  async requestSetVoiceOverEnabled(
+    enabled: boolean,
+    timeoutMs: number = 30000,
+    perf?: PerformanceTracker,
+  ): Promise<CtrlProxyActionResult> {
+    await this.applyDelay("setVoiceOverEnabled");
+    this.checkFailure("setVoiceOverEnabled");
+
+    this.setVoiceOverEnabledHistory.push(enabled);
+
+    if (this.setVoiceOverEnabledResult) {
+      return this.setVoiceOverEnabledResult;
+    }
+
+    return {
+      success: true,
       totalTimeMs: 50,
     };
   }

--- a/test/features/accessibility/VoiceOverToggle.test.ts
+++ b/test/features/accessibility/VoiceOverToggle.test.ts
@@ -3,6 +3,7 @@ import { VoiceOverToggle } from "../../../src/features/accessibility/VoiceOverTo
 import { FakeIosVoiceOverDetector } from "../../fakes/FakeIosVoiceOverDetector";
 import { FakeProcessExecutor } from "../../fakes/FakeProcessExecutor";
 import { FakeTimer } from "../../fakes/FakeTimer";
+import { FakeIOSCtrlProxy } from "../../fakes/FakeIOSCtrlProxy";
 import type { BootedDevice } from "../../../src/models";
 
 const SIMULATOR_DEVICE: BootedDevice = {
@@ -30,21 +31,66 @@ describe("VoiceOverToggle", () => {
     fakeDetector.reset();
   });
 
-  describe("physical device", () => {
-    test("returns supported:false for physical device UDID", async () => {
-      const toggle = new VoiceOverToggle(PHYSICAL_DEVICE, fakeDetector, fakeExec);
-      const result = await toggle.toggle(true);
+  describe("physical device (Settings-driven via CtrlProxy)", () => {
+    let fakeClient: FakeIOSCtrlProxy;
+
+    const makeToggle = () =>
+      new VoiceOverToggle(PHYSICAL_DEVICE, fakeDetector, fakeExec, defaultPhysicalTimer(), () => fakeClient);
+
+    const defaultPhysicalTimer = () => {
+      const t = new FakeTimer();
+      t.enableAutoAdvance();
+      return t;
+    };
+
+    beforeEach(() => {
+      fakeClient = new FakeIOSCtrlProxy();
+    });
+
+    test("enable routes to the runner and reports applied:true", async () => {
+      const result = await makeToggle().toggle(true);
+
+      expect(result.supported).toBe(true);
+      expect(result.applied).toBe(true);
+      expect(result.currentState).toBe(true);
+      expect(result.reason).toBeUndefined();
+      expect(fakeClient.getSetVoiceOverEnabledHistory()).toEqual([true]);
+    });
+
+    test("disable routes to the runner and reports applied:false state", async () => {
+      const result = await makeToggle().toggle(false);
+
+      expect(result.supported).toBe(true);
+      expect(result.applied).toBe(true);
+      expect(result.currentState).toBe(false);
+      expect(fakeClient.getSetVoiceOverEnabledHistory()).toEqual([false]);
+    });
+
+    test("never runs simctl for a physical device (no Simulator mechanism)", async () => {
+      await makeToggle().toggle(true);
+
+      expect(fakeExec.getExecutedCommands()).toHaveLength(0);
+    });
+
+    test("invalidates the detector cache after a successful physical toggle", async () => {
+      await makeToggle().toggle(true);
+
+      expect(fakeDetector.getInvalidatedDevices()).toContain(PHYSICAL_DEVICE.deviceId);
+    });
+
+    test("surfaces a runner failure as supported:false with the reason (never silent success)", async () => {
+      fakeClient.setSetVoiceOverEnabledResult({
+        success: false,
+        error: "VoiceOver toggle row not found",
+      });
+
+      const result = await makeToggle().toggle(true);
 
       expect(result.supported).toBe(false);
       expect(result.applied).toBe(false);
-      expect(result.reason).toBe("VoiceOver toggle is only supported on iOS Simulator");
-    });
-
-    test("does not run any process commands for physical device", async () => {
-      const toggle = new VoiceOverToggle(PHYSICAL_DEVICE, fakeDetector, fakeExec);
-      await toggle.toggle(true);
-
-      expect(fakeExec.getExecutedCommands()).toHaveLength(0);
+      expect(result.reason).toContain("VoiceOver toggle row not found");
+      // A failed toggle must not falsely invalidate the cache as if state changed.
+      expect(fakeDetector.getInvalidatedDevices()).not.toContain(PHYSICAL_DEVICE.deviceId);
     });
   });
 
@@ -243,11 +289,20 @@ describe("VoiceOverToggle", () => {
       expect(fakeDetector.getInvalidatedDevices()).toContain(SIMULATOR_DEVICE.deviceId);
     });
 
-    test("does not invalidate cache for physical device (no commands run)", async () => {
-      const toggle = new VoiceOverToggle(PHYSICAL_DEVICE, fakeDetector, fakeExec);
+    test("invalidates cache for physical device after a Settings-driven toggle", async () => {
+      const fakeClient = new FakeIOSCtrlProxy();
+      const fakeTimer = new FakeTimer();
+      fakeTimer.enableAutoAdvance();
+      const toggle = new VoiceOverToggle(
+        PHYSICAL_DEVICE,
+        fakeDetector,
+        fakeExec,
+        fakeTimer,
+        () => fakeClient,
+      );
       await toggle.toggle(true);
 
-      expect(fakeDetector.getInvalidatedDevices()).toHaveLength(0);
+      expect(fakeDetector.getInvalidatedDevices()).toContain(PHYSICAL_DEVICE.deviceId);
     });
   });
 });

--- a/test/features/observe/ios/CtrlProxyVoiceOver.test.ts
+++ b/test/features/observe/ios/CtrlProxyVoiceOver.test.ts
@@ -300,4 +300,65 @@ describe("CtrlProxyVoiceOver", function() {
       }
     });
   });
+
+  describe("requestSetVoiceOverEnabled", function() {
+    test("emits set_voiceover_state with the enabled param and resolves on success", async function() {
+      const { factory, getSocket } = createCapturingFactory(fakeTimer);
+      const client = IOSCtrlProxyClient.createForTesting(testDevice, serverPort, factory, fakeTimer);
+
+      try {
+        const resultPromise = client.requestSetVoiceOverEnabled(true);
+        const socket = await waitForSocket(getSocket);
+        expect(socket).not.toBeNull();
+        await waitForSocketOpen(socket);
+        await waitForSentMessages(socket, 1);
+
+        const sentMsg = commandPayloads(socket!)[0];
+        expect(sentMsg.type).toBe("set_voiceover_state");
+        expect((sentMsg as { enabled?: boolean }).enabled).toBe(true);
+        expect(typeof sentMsg.requestId).toBe("string");
+
+        socket!.simulateMessage(JSON.stringify({
+          type: "voiceover_set_result",
+          requestId: sentMsg.requestId,
+          success: true,
+          totalTimeMs: 3,
+        }));
+
+        const result = await resultPromise;
+        expect(result.success).toBe(true);
+      } finally {
+        await client.close();
+      }
+    });
+
+    test("resolves a runner failure as a typed result (never a silent success)", async function() {
+      const { factory, getSocket } = createCapturingFactory(fakeTimer);
+      const client = IOSCtrlProxyClient.createForTesting(testDevice, serverPort, factory, fakeTimer);
+
+      try {
+        const resultPromise = client.requestSetVoiceOverEnabled(false);
+        const socket = await waitForSocket(getSocket);
+        await waitForSocketOpen(socket);
+        await waitForSentMessages(socket, 1);
+
+        const sentMsg = commandPayloads(socket!)[0];
+        expect((sentMsg as { enabled?: boolean }).enabled).toBe(false);
+
+        socket!.simulateMessage(JSON.stringify({
+          type: "voiceover_set_result",
+          requestId: sentMsg.requestId,
+          success: false,
+          error: "VoiceOver toggle row not found",
+          totalTimeMs: 4,
+        }));
+
+        const result = await resultPromise;
+        expect(result.success).toBe(false);
+        expect(result.error).toContain("VoiceOver toggle row not found");
+      } finally {
+        await client.close();
+      }
+    });
+  });
 });

--- a/test/features/observe/ios/ctrlProxyWireParity.test.ts
+++ b/test/features/observe/ios/ctrlProxyWireParity.test.ts
@@ -69,6 +69,7 @@ const SWIFT_REQUEST_TYPES = [
   "get_traversal_order",
   "add_highlight",
   "get_voiceover_state",
+  "set_voiceover_state",
   "list_preference_files",
   "get_preferences",
   "get_preference",

--- a/test/features/observe/ios/decodeCtrlProxyMessage.test.ts
+++ b/test/features/observe/ios/decodeCtrlProxyMessage.test.ts
@@ -170,6 +170,21 @@ describe("decodeCtrlProxyMessage", () => {
     expect((decoded?.result as { enabled: boolean }).enabled).toBe(false);
   });
 
+  test("voiceover_set_result resolves a runner failure as a typed result (not a rejection)", () => {
+    const decoded = decodeCtrlProxyMessage(
+      msg({ type: "voiceover_set_result", success: false, error: "VoiceOver toggle row not found", totalTimeMs: 12 }),
+    );
+    // Must resolve (result set, errorMessage undefined) so VoiceOverToggle maps
+    // success:false → supported:false, never a silent success (#2501).
+    expect(decoded?.errorMessage).toBeUndefined();
+    expect(decoded?.result).toEqual({ success: false, totalTimeMs: 12, error: "VoiceOver toggle row not found" });
+  });
+
+  test("voiceover_set_result carries a success through", () => {
+    const decoded = decodeCtrlProxyMessage(msg({ type: "voiceover_set_result", success: true, totalTimeMs: 5 }));
+    expect(decoded?.result).toEqual({ success: true, totalTimeMs: 5, error: undefined });
+  });
+
 
   test("highlight_response defaults success to false and echoes requestId/timestamp", () => {
     const decoded = decodeCtrlProxyMessage(msg({ type: "highlight_response", timestamp: 42 }));
@@ -417,8 +432,8 @@ describe("decodeCtrlProxyMessage ↔ Swift ResponseType parity (ADD-3 / item 4)"
     "set_network_fault_rules_result",
   ];
 
-  test("Swift ResponseType declares exactly 45 rawValues", () => {
-    expect(rawValues.length).toBe(45);
+  test("Swift ResponseType declares exactly 46 rawValues", () => {
+    expect(rawValues.length).toBe(46);
   });
 
   test("rawValues are unique (no accidental duplicate)", () => {
@@ -431,8 +446,8 @@ describe("decodeCtrlProxyMessage ↔ Swift ResponseType parity (ADD-3 / item 4)"
     }
   });
 
-  test("the decoder explicitly reshapes exactly 38 response types", () => {
-    expect(rawValues.filter(isExplicitlyDecoded).length).toBe(38);
+  test("the decoder explicitly reshapes exactly 39 response types", () => {
+    expect(rawValues.filter(isExplicitlyDecoded).length).toBe(39);
   });
 
   test("the only unhandled ResponseType (excluding fire-and-forget) is shake_result", () => {
@@ -455,7 +470,7 @@ describe("decodeCtrlProxyMessage ↔ Swift ResponseType parity (ADD-3 / item 4)"
  */
 describe("decodeCtrlProxyMessage success defaulting (PARAM-5 / item 11)", () => {
   // One row per decoded response type → the value of `success` when the wire
-  // message omits it. 38 rows = the 38 explicitly-decoded ResponseTypes.
+  // message omits it. 39 rows = the 39 explicitly-decoded ResponseTypes.
   const DEFAULT_WHEN_ABSENT: Array<{ type: string; expected: boolean | undefined }> = [
     { type: "hierarchy_update", expected: undefined },
     { type: "screenshot", expected: true },
@@ -478,6 +493,7 @@ describe("decodeCtrlProxyMessage success defaulting (PARAM-5 / item 11)", () => 
     { type: "ime_action_result", expected: true },
     { type: "action_result", expected: true },
     { type: "voiceover_state_result", expected: true },
+    { type: "voiceover_set_result", expected: false },
     { type: "multi_finger_swipe_result", expected: true },
     { type: "clipboard_result", expected: true },
     { type: "highlight_response", expected: false },
@@ -497,8 +513,8 @@ describe("decodeCtrlProxyMessage success defaulting (PARAM-5 / item 11)", () => 
     { type: "table_structure_result", expected: false },
   ];
 
-  test("the default table covers all 38 explicitly-decoded types", () => {
-    expect(DEFAULT_WHEN_ABSENT.length).toBe(38);
+  test("the default table covers all 39 explicitly-decoded types", () => {
+    expect(DEFAULT_WHEN_ABSENT.length).toBe(39);
   });
 
   for (const { type, expected } of DEFAULT_WHEN_ABSENT) {
@@ -515,8 +531,8 @@ describe("decodeCtrlProxyMessage success defaulting (PARAM-5 / item 11)", () => 
     .filter(row => row.type !== "hierarchy_update" && row.type !== "screenshot")
     .map(row => row.type);
 
-  test("the passthrough set is the 36 success-reading types", () => {
-    expect(READS_MESSAGE_SUCCESS.length).toBe(36);
+  test("the passthrough set is the 37 success-reading types", () => {
+    expect(READS_MESSAGE_SUCCESS.length).toBe(37);
   });
 
   for (const type of READS_MESSAGE_SUCCESS) {


### PR DESCRIPTION
## Summary

The `accessibility { voiceover }` MCP tool could only toggle VoiceOver on the iOS **Simulator** — `VoiceOverToggle` bailed out with `supported: false` for any physical-device UDID, which then became a hard `ActionableError`. Physical devices have no command-line write into the system-preferences domain (no `simctl`/`defaults`/`notifyutil` analog) and no public toggle API, so this routes physical devices through a new CtrlProxy runner command that automates **Settings → Accessibility → VoiceOver** instead. The Simulator path is unchanged.

## Linked Issue

Closes #2501

## Changes

- **`VoiceOverToggle`** branches on device type: Simulator keeps the existing `simctl` + `notifyutil` + re-detect path; physical devices call `requestSetVoiceOverEnabled` and invalidate the detector cache on success. A runner failure (e.g. the Settings row can't be located) returns `supported:false` with a reason — surfaced as an `ActionableError`, never a silent success. The CtrlProxy client is injected (`clientProvider`) so the physical branch is unit-testable with a fake.
- **iOS wire:** new `set_voiceover_state` → `voiceover_set_result` command, delegated through `CtrlProxyVoiceOver`, added to the request-type registry + wire-parity guard, and decoded so a runner `success:false` **resolves as a typed result** rather than rejecting the promise.
- **Runner (`handleSetVoiceOverState`)** is idempotent: it early-returns when `isVoiceOverRunning()` already equals the target and does **not** tap — once VoiceOver is on, every tap is a double-tap-idiom activation, not a toggle. The fragile XCUITest Settings automation lives behind a `VoiceOverToggling` protocol so the handler's early-return + error mapping stay unit-testable with a fake.
- **Schema/docs:** the `accessibility` tool description and the `voiceover` param no longer claim "Simulator only"; `talkback-voiceover.md` and `voiceover-talkback-parity.md` document the physical-device path and its fragility (English locale only, Settings layout drift).

## Acceptance criteria (from #2501)

- [x] `voiceover: true` on a physical device returns `{ enabled: true, service: "voiceover" }` (no `ActionableError`)
- [x] `voiceover: false` disables and returns `{ enabled: false, service: "unknown" }`, correct even when VoiceOver was already active (runner handles the gesture model)
- [x] Idempotent: requesting the already-current state is a no-op with no spurious Settings tap (runner early-return, unit-tested)
- [x] Simulator behavior unchanged — existing `simctl`/`notifyutil` path and all `VoiceOverToggle.test.ts` assertions still pass
- [x] Detector cache invalidated after a successful physical-device toggle
- [x] Settings-row-not-found → `{ supported: false, reason }` surfaced as `ActionableError`, never a silent success
- [x] Unit tests (<100ms, interface + fake, no real device): physical enable/disable/backend-failure branches on both TS and Swift sides
- [x] Schema/description text no longer says "Simulator only"
- [x] Docs updated with the physical-device path and its limitations

## Validation

- [x] `bun test` — full suite green (14127 pass; the previously-drifted `tool-definitions.json` enforcement test now passes after the commit hook regenerated it)
- [x] `swift test` (CtrlProxyTests) — 491 tests, 0 failures (new decode/mapping/payload/handler cases)
- [x] `bun run typecheck` — no new errors (baseline gate)
- [x] `bun run lint` — no new ratchet violations, boundary-checks pass
- [x] New code uses interface + fake + FakeTimer; unit tests run in <100ms

## Device Verification

- [ ] **Not run** — the physical-device path requires a real iPhone with the CtrlProxy runner installed **and a runner re-cut/release** to deliver the new Swift command on-device. The XCUITest Settings automation (`DefaultVoiceOverToggle`) is exercised only on hardware; its handler *logic* (idempotent early-return, error mapping) is unit-tested via a fake. Manual test plan is in #2501.

## Follow-ups

- VoiceOver Settings toggle is **English-locale only** and sensitive to Settings layout drift across iOS versions — localized label matching is a deliberate follow-up, noted in the design docs.
