### PR TITLE
fix(mcp): machine-readable failure codes for fresh session screenshot (#5571)

### DIFF
--- a/docs/design-docs/mcp/resources.md
+++ b/docs/design-docs/mcp/resources.md
@@ -171,6 +171,22 @@ Captures and returns a fresh PNG for the active session. A fresh request queues
 behind an in-flight screenshot for the same device, then takes its own tracked
 capture so session cleanup can cancel it safely.
 
+A read that cannot return a PNG returns an `application/json` body with a stable,
+machine-readable failure code and a retry classification instead of only a
+content-type mismatch, so a caller can tell a released session, lost ownership,
+and a capture failure apart:
+
+| `code` | Meaning | `retry` |
+| --- | --- | --- |
+| `SESSION_UNAUTHORIZED` | Read attempted outside the resource's bound session | `STOP` |
+| `SESSION_NOT_ACTIVE` | No active session owns the device (released/unknown) | `NEW_SESSION` |
+| `SESSION_OWNERSHIP_LOST` | The session lost the device during capture | `NEW_SESSION` |
+| `SCREENSHOT_CAPTURE_FAILED` | Capture ran but produced no PNG | `RETRY_CAPTURE` |
+
+The body also carries the `sessionUuid`, a human-readable `error`, and — when one
+is available — the underlying capture or session `reason`. The `retry` values are
+`RETRY_CAPTURE`, `NEW_SESSION`, `RECOVER_DEVICE`, and `STOP`.
+
 ### Installed Apps
 
 **URI**: `automobile:apps`

--- a/src/server/observationResources.ts
+++ b/src/server/observationResources.ts
@@ -227,6 +227,69 @@ function unauthorizedSessionResourceError(uri: string): ResourceContent {
   };
 }
 
+// Stable, machine-readable failure codes for the fresh session screenshot
+// resource. The successful read is an `image/png` blob; every failure is a typed
+// `application/json` body carrying one of these codes so a caller can tell a
+// released session, lost ownership, and a capture failure apart rather than only
+// seeing a MIME mismatch. Codes are part of the resource contract — do not
+// rename or repurpose them.
+export type FreshScreenshotFailureCode =
+  | "SESSION_UNAUTHORIZED"
+  | "SESSION_NOT_ACTIVE"
+  | "SESSION_OWNERSHIP_LOST"
+  | "SCREENSHOT_CAPTURE_FAILED";
+
+// Retry classification tells the caller how to recover: retry the capture,
+// establish a new session, recover the device, or stop.
+export type FreshScreenshotRetry =
+  | "RETRY_CAPTURE"
+  | "NEW_SESSION"
+  | "RECOVER_DEVICE"
+  | "STOP";
+
+// Derived deterministically from the code so the classification stays stable.
+const FRESH_SCREENSHOT_RETRY: Record<FreshScreenshotFailureCode, FreshScreenshotRetry> = {
+  SESSION_UNAUTHORIZED: "STOP",
+  SESSION_NOT_ACTIVE: "NEW_SESSION",
+  SESSION_OWNERSHIP_LOST: "NEW_SESSION",
+  SCREENSHOT_CAPTURE_FAILED: "RETRY_CAPTURE",
+};
+
+export interface FreshScreenshotFailureBody {
+  // Human-readable summary, preserved for backward compatibility with callers
+  // that only read `error`.
+  error: string;
+  code: FreshScreenshotFailureCode;
+  retry: FreshScreenshotRetry;
+  sessionUuid: string;
+  // The underlying capture or session reason, when one is available, so callers
+  // keep the real cause instead of only a content-type mismatch.
+  reason?: string;
+}
+
+function freshScreenshotFailure(
+  uri: string,
+  sessionUuid: string,
+  code: FreshScreenshotFailureCode,
+  message: string,
+  reason?: string,
+): ResourceContent {
+  const body: FreshScreenshotFailureBody = {
+    error: message,
+    code,
+    retry: FRESH_SCREENSHOT_RETRY[code],
+    sessionUuid,
+  };
+  if (reason !== undefined && reason !== "") {
+    body.reason = reason;
+  }
+  return {
+    uri,
+    mimeType: "application/json",
+    text: JSON.stringify(body, null, 2),
+  };
+}
+
 function isAuthorizedSessionResource(
   context: ResourceReadContext,
   sessionUuid: string,
@@ -347,11 +410,21 @@ async function getFreshSessionScreenshot(
   const { sessionUuid } = params;
   const uri = `automobile:device-session/${sessionUuid}/screenshot`;
   if (!isAuthorizedSessionResource(context, sessionUuid)) {
-    return unauthorizedSessionResourceError(uri);
+    return freshScreenshotFailure(
+      uri,
+      sessionUuid,
+      "SESSION_UNAUTHORIZED",
+      "This resource can only be read by its bound device session.",
+    );
   }
   const activeSession = sessionScreenshotResourceDependencies.resolveActiveSession(sessionUuid);
   if (!activeSession) {
-    return sessionResourceError(uri, sessionUuid);
+    return freshScreenshotFailure(
+      uri,
+      sessionUuid,
+      "SESSION_NOT_ACTIVE",
+      `No active device session found for sessionUuid ${sessionUuid}.`,
+    );
   }
 
   try {
@@ -368,16 +441,21 @@ async function getFreshSessionScreenshot(
 
     const currentSession = sessionScreenshotResourceDependencies.resolveActiveSession(sessionUuid);
     if (currentSession?.device.deviceId !== activeSession.device.deviceId) {
-      return sessionResourceError(uri, sessionUuid);
+      return freshScreenshotFailure(
+        uri,
+        sessionUuid,
+        "SESSION_OWNERSHIP_LOST",
+        `Device ownership for sessionUuid ${sessionUuid} changed during capture.`,
+      );
     }
     if (!result.success || !result.path) {
-      return {
+      return freshScreenshotFailure(
         uri,
-        mimeType: "application/json",
-        text: JSON.stringify({
-          error: result.error || "Failed to capture a fresh screenshot.",
-        }, null, 2),
-      };
+        sessionUuid,
+        "SCREENSHOT_CAPTURE_FAILED",
+        "Failed to capture a fresh screenshot.",
+        result.error,
+      );
     }
 
     const imageBuffer = await screenshotFileSystem.readFile(result.path);
@@ -388,13 +466,13 @@ async function getFreshSessionScreenshot(
     };
   } catch (error) {
     logger.error(`[ObservationResources] Failed to capture fresh screenshot for session ${sessionUuid}: ${error}`);
-    return {
+    return freshScreenshotFailure(
       uri,
-      mimeType: "application/json",
-      text: JSON.stringify({
-        error: `Failed to capture fresh screenshot for sessionUuid ${sessionUuid}: ${error}`,
-      }, null, 2),
-    };
+      sessionUuid,
+      "SCREENSHOT_CAPTURE_FAILED",
+      `Failed to capture fresh screenshot for sessionUuid ${sessionUuid}.`,
+      `${error}`,
+    );
   }
 }
 

--- a/test/server/observationResources.test.ts
+++ b/test/server/observationResources.test.ts
@@ -284,7 +284,7 @@ describe("session screenshot resources", () => {
     expect(receivedSignal).toBe(controller.signal);
   });
 
-  test("rejects a fresh capture when the session no longer owns its device", async () => {
+  test("reports SESSION_OWNERSHIP_LOST when the session loses its device mid-capture", async () => {
     let reads = 0;
     setSessionScreenshotResourceDependencies({
       resolveActiveSession: () => {
@@ -302,7 +302,93 @@ describe("session screenshot resources", () => {
     );
 
     expect(content.mimeType).toBe("application/json");
-    expect(JSON.parse(content.text!).error).toContain("No active device session found");
+    const body = JSON.parse(content.text!);
+    expect(body.code).toBe("SESSION_OWNERSHIP_LOST");
+    expect(body.retry).toBe("NEW_SESSION");
+    expect(body.sessionUuid).toBe(sessionUuid);
+    expect(body.error).toContain("ownership");
+  });
+
+  test("reports SESSION_NOT_ACTIVE when no session owns the device", async () => {
+    setSessionScreenshotResourceDependencies({
+      resolveActiveSession: () => undefined,
+      createScreenshotService: () => createTrackedScreenshot({ success: true, path: "/tmp/fresh.png" }),
+    });
+
+    const content = await readTemplate(
+      "automobile:device-session/session-123/screenshot",
+    );
+
+    expect(content.mimeType).toBe("application/json");
+    const body = JSON.parse(content.text!);
+    expect(body.code).toBe("SESSION_NOT_ACTIVE");
+    expect(body.retry).toBe("NEW_SESSION");
+    expect(body.sessionUuid).toBe(sessionUuid);
+    // Backward compatibility: callers reading only `error` still get a message.
+    expect(body.error).toContain("No active device session found");
+  });
+
+  test("reports SESSION_UNAUTHORIZED for a read outside the bound session", async () => {
+    setSessionScreenshotResourceDependencies({
+      resolveActiveSession: () => activeSession(),
+      createScreenshotService: () => createTrackedScreenshot({ success: true, path: "/tmp/fresh.png" }),
+    });
+
+    const content = await readTemplate(
+      "automobile:device-session/session-123/screenshot",
+      { sessionUuid: "session-other" },
+    );
+
+    expect(content.mimeType).toBe("application/json");
+    const body = JSON.parse(content.text!);
+    expect(body.code).toBe("SESSION_UNAUTHORIZED");
+    expect(body.retry).toBe("STOP");
+    expect(body.error).toContain("bound device session");
+  });
+
+  test("reports SCREENSHOT_CAPTURE_FAILED and preserves the underlying reason", async () => {
+    setSessionScreenshotResourceDependencies({
+      resolveActiveSession: () => activeSession(),
+      createScreenshotService: () => createTrackedScreenshot({
+        success: false,
+        error: "screencap timed out",
+      }),
+    });
+
+    const content = await readTemplate(
+      "automobile:device-session/session-123/screenshot",
+    );
+
+    expect(content.mimeType).toBe("application/json");
+    const body = JSON.parse(content.text!);
+    expect(body.code).toBe("SCREENSHOT_CAPTURE_FAILED");
+    expect(body.retry).toBe("RETRY_CAPTURE");
+    expect(body.sessionUuid).toBe(sessionUuid);
+    // The capture reason is preserved rather than reduced to a MIME mismatch.
+    expect(body.reason).toBe("screencap timed out");
+  });
+
+  test("reports SCREENSHOT_CAPTURE_FAILED when reading the captured file throws", async () => {
+    setSessionScreenshotResourceDependencies({
+      resolveActiveSession: () => activeSession(),
+      createScreenshotService: () => createTrackedScreenshot({ success: true, path: "/tmp/fresh.png" }),
+    });
+    setScreenshotFileSystem({
+      stat: async () => ({ isFile: () => true }),
+      readFile: async () => {
+        throw new Error("disk read failed");
+      },
+    });
+
+    const content = await readTemplate(
+      "automobile:device-session/session-123/screenshot",
+    );
+
+    expect(content.mimeType).toBe("application/json");
+    const body = JSON.parse(content.text!);
+    expect(body.code).toBe("SCREENSHOT_CAPTURE_FAILED");
+    expect(body.retry).toBe("RETRY_CAPTURE");
+    expect(body.reason).toContain("disk read failed");
   });
 
   test("replaces an older direct session for the same device", () => {


### PR DESCRIPTION
## Summary

Closes #5571.

The `automobile:device-session/{sessionUuid}/screenshot` resource advertises an `image/png` blob, but on failure it returned free-form `application/json` error text. A caller expecting an image then saw only a MIME mismatch and could not reliably distinguish a released session, lost ownership, or a capture failure.

`getFreshSessionScreenshot` now returns a **typed, machine-readable** `application/json` body for every non-PNG outcome, with a stable `code`, a `retry` classification, the `sessionUuid`, and the underlying capture/session `reason` when available:

| `code` | `retry` |
| --- | --- |
| `SESSION_UNAUTHORIZED` | `STOP` |
| `SESSION_NOT_ACTIVE` | `NEW_SESSION` |
| `SESSION_OWNERSHIP_LOST` | `NEW_SESSION` |
| `SCREENSHOT_CAPTURE_FAILED` | `RETRY_CAPTURE` |

The `retry` classification is derived deterministically from the code (`RETRY_CAPTURE` / `NEW_SESSION` / `RECOVER_DEVICE` / `STOP`) so it stays stable. The successful path is unchanged (`image/png` blob).

## Acceptance criteria

- [x] Stable, machine-readable failure code + retry classification for failed fresh screenshot reads.
- [x] Underlying capture/session `reason` preserved instead of only a content-type mismatch.
- [x] Unavailable session, ownership loss during capture, and capture failure covered with tests (also unauthorized read and a file-read failure).

## Backward compatibility

The human-readable `error` field is retained in every failure body, so callers that only read `error` continue to work.

## Notes

- Only the fresh-screenshot handler changed; the shared `sessionResourceError` / `unauthorizedSessionResourceError` helpers still back the cached observation/screenshot resources unchanged.
- Contract documented in `docs/design-docs/mcp/resources.md`.
- Validation: `bun test test/server/observationResources.test.ts` (14 pass), `bun run build`, `bun run lint` (no new ratchet violations), `bun run typecheck` (no new type errors).

🤖 Generated with [Claude Code](https://claude.com/claude-code) — autonomous next-best-issue run