### PR TITLE
fix(ios): reuse healthy direct CtrlProxy runners

### DIFF
--- a/src/utils/IOSCtrlProxyManager.ts
+++ b/src/utils/IOSCtrlProxyManager.ts
@@ -2009,7 +2009,8 @@ export class IOSCtrlProxyManager implements CtrlProxyIosManager {
    * path still reaps a stale runner whose health endpoint is down.
    */
   private async findHealthyExternalDirectCtrlProxyProcess(): Promise<ExternalCtrlProxyProcess | null> {
-    for (const pid of await this.processClient.findStartupCandidatePids()) {
+    const candidatePids = await this.processClient.findStartupCandidatePids();
+    for (const pid of candidatePids.slice(0, MAX_STARTUP_ORPHAN_RUNNER_CANDIDATES)) {
       if (pid === this.xcTestProcessId) {
         continue;
       }
@@ -2027,7 +2028,7 @@ export class IOSCtrlProxyManager implements CtrlProxyIosManager {
         this.processClient,
         process
       );
-      if (daemonManagedRoot.kind === "root" && daemonManagedRoot.pid !== process.pid) {
+      if (daemonManagedRoot.kind === "root") {
         continue;
       }
       if (!await this.checkHealthEndpointOnPortForDevice(port, this.device.deviceId)) {

--- a/src/utils/IOSCtrlProxyManager.ts
+++ b/src/utils/IOSCtrlProxyManager.ts
@@ -1977,6 +1977,10 @@ export class IOSCtrlProxyManager implements CtrlProxyIosManager {
     if (externalXcodebuildProcess) {
       return externalXcodebuildProcess;
     }
+    const healthyDirectProcess = await this.findHealthyExternalDirectCtrlProxyProcess();
+    if (healthyDirectProcess) {
+      return healthyDirectProcess;
+    }
     return this.findExternalDirectCtrlProxyProcess();
   }
 
@@ -1990,6 +1994,46 @@ export class IOSCtrlProxyManager implements CtrlProxyIosManager {
       if (!IOSCtrlProxyManager.hasDeviceIdentity(identityText, this.device.deviceId)) {continue;}
       const port = this.parseCtrlProxyPortFromProcessArgs(argsOut) ?? this.parseCtrlProxyPortFromProcessArgs(processInfo?.environment ?? "") ?? IOSCtrlProxyManager.DEFAULT_PORT;
       logger.info(`[IOSCtrlProxy] Found external xcodebuild CtrlProxy process: ${pid}`);
+      return { pid, port };
+    }
+    return null;
+  }
+
+  /**
+   * Finds a healthy direct runner even when `lsof` cannot expose its listener PID.
+   *
+   * Direct simulator runners inherit their CtrlProxy port, so their process
+   * environment identifies a probe candidate. Health is the authority for
+   * adoption: it must confirm the exact device before we reserve that port.
+   * Daemon-managed trees are deliberately excluded so the regular port-cleanup
+   * path still reaps a stale runner whose health endpoint is down.
+   */
+  private async findHealthyExternalDirectCtrlProxyProcess(): Promise<ExternalCtrlProxyProcess | null> {
+    for (const pid of await this.processClient.findStartupCandidatePids()) {
+      if (pid === this.xcTestProcessId) {
+        continue;
+      }
+      const processInfo = await this.processClient.getProcessInfo(pid);
+      if (!processInfo || !IOSCtrlProxyManager.isDirectCtrlProxyRunnerCommand(processInfo.command)) {
+        continue;
+      }
+      const port = this.parseCtrlProxyPortFromProcessArgs(processInfo.command) ??
+        this.parseCtrlProxyPortFromProcessArgs(processInfo.environment ?? "");
+      if (port === null) {
+        continue;
+      }
+      const process: ListeningProcess = { pid, port, ...processInfo };
+      const daemonManagedRoot = await IOSCtrlProxyManager.findDaemonManagedRunnerTreeRoot(
+        this.processClient,
+        process
+      );
+      if (daemonManagedRoot.kind === "root" && daemonManagedRoot.pid !== process.pid) {
+        continue;
+      }
+      if (!await this.checkHealthEndpointOnPortForDevice(port, this.device.deviceId)) {
+        continue;
+      }
+      logger.info(`[IOSCtrlProxy] Found healthy external direct CtrlProxy runner: ${pid}`);
       return { pid, port };
     }
     return null;

--- a/test/utils/IOSCtrlProxyManager.test.ts
+++ b/test/utils/IOSCtrlProxyManager.test.ts
@@ -2471,7 +2471,7 @@ describe("IOSCtrlProxyManager", function() {
         port: 8765,
         ppid: 2226,
         command: `/tmp/CtrlProxyUITests-Runner.app/PlugIns/CtrlProxyUITests.xctest/CtrlProxyUITests-Runner`,
-        environment: `AUTOMOBILE_DEVICE_ID=${testDevice.deviceId}`,
+        environment: `CTRL_PROXY_IOS_PORT=8765 AUTOMOBILE_DEVICE_ID=${testDevice.deviceId}`,
         alive: true,
       };
       const daemonXcodebuild: FakeListeningProcess = {
@@ -2517,6 +2517,7 @@ describe("IOSCtrlProxyManager", function() {
 
       await manager.start();
 
+      expect(fakeExecutor.wasCommandExecuted("ps -p 2226")).toBe(true);
       expect(fakeExecutor.wasCommandExecuted("kill -TERM -- -2225")).toBe(true);
       expect(fakeExecutor.wasCommandExecuted("kill -TERM 2226")).toBe(true);
       expect(fakeExecutor.wasCommandExecuted("kill -TERM 2227")).toBe(true);

--- a/test/utils/IOSCtrlProxyManager.test.ts
+++ b/test/utils/IOSCtrlProxyManager.test.ts
@@ -1757,6 +1757,102 @@ describe("IOSCtrlProxyManager", function() {
       expect(fakeExecutor.getSpawnedProcesses()).toEqual([]);
     });
 
+    test("start() adopts a healthy direct runner on an unallocated custom port when listener lookup misses it", async function() {
+      const runnerProcess: FakeListeningProcess = {
+        pid: 2473,
+        port: 8790,
+        ppid: 2468,
+        command: "/tmp/CtrlProxyUITests-Runner.app/PlugIns/CtrlProxyUITests.xctest/CtrlProxyUITests-Runner",
+        environment: `CTRL_PROXY_IOS_PORT=8790 AUTOMOBILE_DEVICE_ID=${testDevice.deviceId}`,
+        alive: true,
+      };
+      const simulatorProcess: FakeListeningProcess = {
+        pid: 2468,
+        port: 0,
+        ppid: 1,
+        command: `launchd_sim ${testDevice.deviceId}`,
+        alive: true,
+      };
+      installListeningProcessFakes(fakeExecutor, [runnerProcess, simulatorProcess]);
+      const fakeBuilder = {
+        getXctestrunPath: async () => {
+          throw new Error("should not build when a healthy direct runner is reused");
+        },
+        getRunnerBinaryPath: async () => null,
+        verifyRunnerBinaryBeforeLaunch: async () => {},
+        writeRunnerEnvironment: fakeWriteRunnerEnvironment,
+      } as unknown as IOSCtrlProxyBuilder;
+      const manager = IOSCtrlProxyManager.createForTestingWithDeps(
+        testDevice,
+        fakeTimer,
+        fakeBuilder,
+        fakeExecutor
+      );
+
+      fakeExecutor.setCommandResponse("http://localhost:8765/health", createExecResult("", ""));
+      fakeExecutor.setCommandResponse(
+        "http://localhost:8790/health",
+        createExecResult(JSON.stringify({ status: "ok", deviceId: testDevice.deviceId }), "")
+      );
+      fakeExecutor.setCommandResponse("pgrep -x xcodebuild", createExecResult("", ""));
+      fakeExecutor.setCommandResponse("pgrep -f 'CtrlProxy'", createExecResult("2473\n", ""));
+      fakeTimer.enableAutoAdvance();
+
+      await manager.start();
+
+      expect(manager.getServicePort()).toBe(8790);
+      expect(PortManager.getPort(testDevice.deviceId)).toBe(8790);
+      expect(fakeExecutor.getSpawnedProcesses()).toEqual([]);
+    });
+
+    test("start() does not adopt a direct runner whose health identifies another simulator", async function() {
+      const runnerProcess: FakeListeningProcess = {
+        pid: 2474,
+        port: 8790,
+        ppid: 2468,
+        command: "/tmp/CtrlProxyUITests-Runner.app/PlugIns/CtrlProxyUITests.xctest/CtrlProxyUITests-Runner",
+        environment: "CTRL_PROXY_IOS_PORT=8790 AUTOMOBILE_DEVICE_ID=OTHER-SIMULATOR",
+        alive: true,
+      };
+      const simulatorProcess: FakeListeningProcess = {
+        pid: 2468,
+        port: 0,
+        ppid: 1,
+        command: "launchd_sim OTHER-SIMULATOR",
+        alive: true,
+      };
+      installListeningProcessFakes(fakeExecutor, [runnerProcess, simulatorProcess]);
+      const manager = IOSCtrlProxyManager.createForTestingWithDeps(
+        testDevice,
+        fakeTimer,
+        createFakeBuilder(),
+        fakeExecutor
+      );
+
+      fakeExecutor.setCommandResponse("http://localhost:8790/health", createExecResult(
+        JSON.stringify({ status: "ok", deviceId: "OTHER-SIMULATOR" }),
+        ""
+      ));
+      fakeExecutor.setCommandResponse("pgrep -x xcodebuild", createExecResult("", ""));
+      fakeExecutor.setCommandResponse("pgrep -f 'CtrlProxy'", createExecResult("2474\n", ""));
+      fakeExecutor.setCommandHandler("curl -s", command => {
+        const port = Number(command.match(/localhost:(\d+)\/health/)?.[1]);
+        return createExecResult(
+          port === 8790
+            ? JSON.stringify({ status: "ok", deviceId: "OTHER-SIMULATOR" })
+            : fakeExecutor.getSpawnedProcesses().length > 0 ? "ok" : "",
+          ""
+        );
+      });
+      fakeTimer.enableAutoAdvance();
+
+      await manager.start();
+
+      expect(manager.getServicePort()).toBe(8765);
+      expect(runnerProcess.alive).toBe(true);
+      expect(fakeExecutor.getSpawnedProcesses()).toHaveLength(1);
+    });
+
     test("start() preserves an externally managed runner on the current port while it is still starting", async function() {
       const externalProcess: FakeListeningProcess = {
         pid: 2470,
@@ -2313,6 +2409,10 @@ describe("IOSCtrlProxyManager", function() {
       };
       installListeningProcessFakes(fakeExecutor, [staleListener, daemonXcodebuild, daemonShell]);
       fakeExecutor.setCommandResponse("pgrep -x xcodebuild", createExecResult("", ""));
+      // The health-first direct-runner probe sees this candidate, but its
+      // daemon-managed shell root must keep it out of adoption so port cleanup
+      // can reap the dead runner tree.
+      fakeExecutor.setCommandResponse("pgrep -f 'CtrlProxy'", createExecResult("2227\n", ""));
       fakeExecutor.setCommandHandler("curl -s", () =>
         createExecResult(fakeExecutor.getSpawnedProcesses().length > 0 ? "ok" : "", "")
       );

--- a/test/utils/IOSCtrlProxyManager.test.ts
+++ b/test/utils/IOSCtrlProxyManager.test.ts
@@ -1853,6 +1853,91 @@ describe("IOSCtrlProxyManager", function() {
       expect(fakeExecutor.getSpawnedProcesses()).toHaveLength(1);
     });
 
+    test("start() does not adopt a healthy direct runner rooted at an orphaned daemon process", async function() {
+      const orphanedRunner: FakeListeningProcess = {
+        pid: 2475,
+        port: 8790,
+        ppid: 1,
+        command: "/tmp/CtrlProxyUITests-Runner.app/PlugIns/CtrlProxyUITests.xctest/CtrlProxyUITests-Runner",
+        environment: `CTRL_PROXY_IOS_PORT=8790 AUTOMOBILE_DEVICE_ID=${testDevice.deviceId}`,
+        alive: true,
+      };
+      installListeningProcessFakes(fakeExecutor, [orphanedRunner]);
+      const manager = IOSCtrlProxyManager.createForTestingWithDeps(
+        testDevice,
+        fakeTimer,
+        createFakeBuilder(),
+        fakeExecutor
+      );
+
+      fakeExecutor.setCommandResponse("pgrep -x xcodebuild", createExecResult("", ""));
+      fakeExecutor.setCommandResponse("pgrep -f 'CtrlProxy'", createExecResult("2475\n", ""));
+      fakeExecutor.setCommandHandler("curl -s", command => {
+        const port = Number(command.match(/localhost:(\d+)\/health/)?.[1]);
+        return createExecResult(
+          port === 8790
+            ? JSON.stringify({ status: "ok", deviceId: testDevice.deviceId })
+            : fakeExecutor.getSpawnedProcesses().length > 0 ? "ok" : "",
+          ""
+        );
+      });
+      fakeTimer.enableAutoAdvance();
+
+      await manager.start();
+
+      expect(manager.getServicePort()).toBe(8765);
+      expect(fakeExecutor.getSpawnedProcesses()).toHaveLength(1);
+    });
+
+    test("start() bounds health probes for direct-runner candidates", async function() {
+      const simulatorProcess: FakeListeningProcess = {
+        pid: 2468,
+        port: 0,
+        ppid: 1,
+        command: `launchd_sim ${testDevice.deviceId}`,
+        alive: true,
+      };
+      const candidateProcesses = Array.from(
+        { length: MAX_STARTUP_ORPHAN_RUNNER_CANDIDATES + 1 },
+        (_, index): FakeListeningProcess => ({
+          pid: 2500 + index,
+          port: 8800 + index,
+          ppid: simulatorProcess.pid,
+          command: "/tmp/CtrlProxyUITests-Runner.app/PlugIns/CtrlProxyUITests.xctest/CtrlProxyUITests-Runner",
+          environment: `CTRL_PROXY_IOS_PORT=${8800 + index} AUTOMOBILE_DEVICE_ID=${testDevice.deviceId}`,
+          alive: true,
+        })
+      );
+      installListeningProcessFakes(fakeExecutor, [simulatorProcess, ...candidateProcesses]);
+      const manager = IOSCtrlProxyManager.createForTestingWithDeps(
+        testDevice,
+        fakeTimer,
+        createFakeBuilder(),
+        fakeExecutor
+      );
+      let customPortHealthProbeCount = 0;
+
+      fakeExecutor.setCommandResponse("pgrep -x xcodebuild", createExecResult("", ""));
+      fakeExecutor.setCommandResponse(
+        "pgrep -f 'CtrlProxy'",
+        createExecResult(candidateProcesses.map(process => String(process.pid)).join("\n"), "")
+      );
+      fakeExecutor.setCommandHandler("curl -s", command => {
+        const port = Number(command.match(/localhost:(\d+)\/health/)?.[1]);
+        if (port >= 8800 && port <= 8800 + MAX_STARTUP_ORPHAN_RUNNER_CANDIDATES) {
+          customPortHealthProbeCount++;
+          return createExecResult("", "");
+        }
+        return createExecResult(fakeExecutor.getSpawnedProcesses().length > 0 ? "ok" : "", "");
+      });
+      fakeTimer.enableAutoAdvance();
+
+      await manager.start();
+
+      expect(customPortHealthProbeCount).toBe(MAX_STARTUP_ORPHAN_RUNNER_CANDIDATES);
+      expect(fakeExecutor.getSpawnedProcesses()).toHaveLength(1);
+    });
+
     test("start() preserves an externally managed runner on the current port while it is still starting", async function() {
       const externalProcess: FakeListeningProcess = {
         pid: 2470,


### PR DESCRIPTION
## Summary

When listener-PID lookup cannot discover a direct iOS CtrlProxy runner, startup now
enumerates CtrlProxy candidates, reads each advertised port, and adopts only a healthy
runner whose health response identifies the requested simulator. Daemon-managed runner
trees remain excluded so the existing stale-runner cleanup still reaps dead processes.

## Linked Issue

Closes [#5568](https://github.com/kaeawc/auto-mobile/issues/5568)

## Bug / Regression Context

- **Prior attempts:** Default-port and xcodebuild-process reuse covered only discoverable listeners or process arguments.
- **Observed symptom:** A healthy direct runner on a mismatched custom port was relaunched when `lsof` could not resolve its listener PID.
- **Repro steps / conditions:** Start a direct runner with `CTRL_PROXY_IOS_PORT` set to a non-allocated port, make its `/health` endpoint report the requested device, and make listener lookup return no PID.

## Validation

- [x] `bun test test/utils/IOSCtrlProxyManager.test.ts`
- [x] `bun run turbo:validate`
- [x] `bun run typecheck`
- [x] `scripts/all_fast_validate_checks.sh`
- [x] New behavior uses the existing process and health-client seams with fakes and FakeTimer.

## Follow-ups

- [x] No follow-up issues needed.
