### PR TITLE
fix(resources): classify fresh screenshot failures

### DIFF
--- a/docs/design-docs/mcp/resources.md
+++ b/docs/design-docs/mcp/resources.md
@@ -170,6 +170,15 @@ Captures and returns a fresh PNG for the active session. A fresh request queues
 behind an in-flight screenshot for the same device, then takes its own tracked
 capture so session cleanup can cancel it safely.
 
+When a PNG cannot be returned, the resource returns `application/json` with
+`code`, `retryable`, and `error` fields:
+
+- `SESSION_NOT_ACTIVE` and `SCREENSHOT_ACCESS_DENIED` are non-retryable.
+- `SESSION_OWNERSHIP_LOST` is non-retryable when the session changes during capture or file read.
+- `SCREENSHOT_CAPTURE_CANCELLED` is non-retryable when the request is cancelled.
+- `SCREENSHOT_CAPTURE_FAILED` is retryable for transient capture failures.
+- `SCREENSHOT_READ_FAILED` is non-retryable for host-side file-read failures.
+
 ### Installed Apps
 
 **URI**: `automobile:apps`

--- a/src/daemon/constants.ts
+++ b/src/daemon/constants.ts
@@ -147,6 +147,12 @@ export const DAEMON_TOOL_SELECTION_PROFILE_PARAM = "__autoMobileToolSelectionPro
  */
 export const DAEMON_BOUND_SESSION_PARAM = "__autoMobileBoundSessionUuid";
 
+/** Socket RPC field identifying a released session used only for inactive resource reads. */
+export const DAEMON_RELEASED_SESSION_PARAM = "__autoMobileReleasedSessionUuid";
+
+/** Loopback-only header for a released session's inactive resource-read capability. */
+export const DAEMON_RELEASED_SESSION_HEADER = "x-auto-mobile-released-session-uuid";
+
 /**
  * How long the proxy will keep replaying a remembered session binding on
  * sessionless calls before treating it as retired (issue #4610). It mirrors the

--- a/src/daemon/daemon.ts
+++ b/src/daemon/daemon.ts
@@ -17,6 +17,7 @@ import {
   SOCKET_PATH,
   MCP_STREAMABLE_PATH,
   DAEMON_SESSION_TOOL_BINDING_HEADER,
+  DAEMON_RELEASED_SESSION_HEADER,
   DAEMON_TOOL_SELECTION_PROFILE_HEADER,
   DAEMON_PORT_RANGE_START,
   DAEMON_PORT_RANGE_END,
@@ -813,10 +814,20 @@ export class Daemon {
           const sessionContext: {
             sessionId?: string;
             initialSessionToolBinding?: string;
+            initialReleasedSession?: string;
             initialToolSelectionProfile?: string;
           } = {
-            ...(typeof boundSessionUuid === "string" && boundSessionUuid.trim().length > 0
+            ...(typeof boundSessionUuid === "string" &&
+            boundSessionUuid.trim().length > 0 &&
+            !(
+              typeof req.headers[DAEMON_RELEASED_SESSION_HEADER] === "string" &&
+              req.headers[DAEMON_RELEASED_SESSION_HEADER].trim() === boundSessionUuid.trim()
+            )
               ? { initialSessionToolBinding: boundSessionUuid }
+              : {}),
+            ...(typeof req.headers[DAEMON_RELEASED_SESSION_HEADER] === "string" &&
+            req.headers[DAEMON_RELEASED_SESSION_HEADER].trim().length > 0
+              ? { initialReleasedSession: req.headers[DAEMON_RELEASED_SESSION_HEADER] }
               : {}),
             ...(typeof boundToolSelectionProfileUuid === "string" &&
             boundToolSelectionProfileUuid.trim().length > 0

--- a/src/daemon/daemonMcpProxy.ts
+++ b/src/daemon/daemonMcpProxy.ts
@@ -51,6 +51,10 @@ export type BuildMismatchReason = "autoStartDisabled" | "cooldown" | "restartMis
 
 const DAEMON_MCP_HEARTBEAT_INTERVAL_MS = 2_000;
 
+function isFreshSessionScreenshotUri(uri: string, sessionUuid: string): boolean {
+  return uri === `automobile:device-session/${sessionUuid}/screenshot`;
+}
+
 function heartbeatIntervalMs(config: DaemonMcpProxyConfig): number {
   const configuredTimeout = config.heartbeatTimeoutMs;
   const configuredInterval = config.heartbeatIntervalMs;
@@ -1089,13 +1093,14 @@ export class DaemonMcpProxy {
   private async withRecoverableReconnect<T>(
     operation: () => Promise<T>,
     attemptedSessionUuid?: string,
+    allowReleasedSession?: boolean,
   ): Promise<T> {
     if (this.closing) {
       throw new DaemonUnavailableError("MCP proxy is closing");
     }
-    this.throwIfBoundSessionFenced();
+    this.throwIfBoundSessionFenced(allowReleasedSession);
     await this.ensureConnected();
-    this.throwIfBoundSessionFenced();
+    this.throwIfBoundSessionFenced(allowReleasedSession);
 
     try {
       return await operation();
@@ -1103,7 +1108,7 @@ export class DaemonMcpProxy {
       if (this.closing) {
         throw error;
       }
-      this.throwIfBoundSessionFenced();
+      this.throwIfBoundSessionFenced(allowReleasedSession);
       if (!this.isRecoverableDaemonSessionError(error)) {
         throw error;
       }
@@ -1112,13 +1117,13 @@ export class DaemonMcpProxy {
         `[DaemonMcpProxy] Daemon session is stale, reconnecting and retrying once: ${errorMessage(error)}`,
       );
       await this.resetConnection();
-      this.throwIfBoundSessionFenced();
+      this.throwIfBoundSessionFenced(allowReleasedSession);
       await this.ensureConnected();
-      this.throwIfBoundSessionFenced();
+      this.throwIfBoundSessionFenced(allowReleasedSession);
       try {
         return await operation();
       } catch (retryError) {
-        this.throwIfBoundSessionFenced();
+        this.throwIfBoundSessionFenced(allowReleasedSession);
         if (
           attemptedSessionUuid &&
           this.boundSessionUuid === attemptedSessionUuid &&
@@ -1402,8 +1407,8 @@ export class DaemonMcpProxy {
     void this.stopBoundSessionHeartbeat();
   }
 
-  private throwIfBoundSessionFenced(): void {
-    if (this.terminalBoundSession) {
+  private throwIfBoundSessionFenced(allowReleasedSession = false): void {
+    if (this.terminalBoundSession && !allowReleasedSession) {
       throw this.boundSessionExpiredError();
     }
   }
@@ -1702,10 +1707,19 @@ export class DaemonMcpProxy {
    * Read a resource from the daemon
    */
   async readResource(uri: string): Promise<any> {
-    const forwardedParams = this.withBoundSessionUuid({});
+    const terminalSessionUuid = this.terminalBoundSession?.sessionUuid;
+    const allowReleasedSession =
+      terminalSessionUuid !== undefined && isFreshSessionScreenshotUri(uri, terminalSessionUuid);
+    const forwardedParams = allowReleasedSession
+      ? {
+          sessionUuid: terminalSessionUuid,
+          [DAEMON_BOUND_SESSION_PARAM]: terminalSessionUuid,
+        }
+      : this.withBoundSessionUuid({});
     return await this.withRecoverableReconnect(
       () => this.client!.readResource(uri, forwardedParams),
       this.sessionUuidFromArgs(forwardedParams),
+      allowReleasedSession,
     );
   }
 

--- a/src/daemon/daemonMcpProxy.ts
+++ b/src/daemon/daemonMcpProxy.ts
@@ -16,6 +16,7 @@ import {
   DAEMON_BOUND_SESSION_REPLAY_TTL_MS,
   DAEMON_TOOL_SELECTION_PROFILE_PARAM,
   DAEMON_BOUND_SESSION_PARAM,
+  DAEMON_RELEASED_SESSION_PARAM,
 } from "./constants";
 import type { DaemonNotification, DaemonOptions } from "./types";
 import { listChangedKindForMethod, type ListChangedKind } from "../server/listChangedBroadcast";
@@ -1714,6 +1715,7 @@ export class DaemonMcpProxy {
       ? {
           sessionUuid: terminalSessionUuid,
           [DAEMON_BOUND_SESSION_PARAM]: terminalSessionUuid,
+          [DAEMON_RELEASED_SESSION_PARAM]: terminalSessionUuid,
         }
       : this.withBoundSessionUuid({});
     return await this.withRecoverableReconnect(

--- a/src/daemon/socketServer.ts
+++ b/src/daemon/socketServer.ts
@@ -1031,7 +1031,6 @@ export class UnixSocketServer {
     request: DaemonRequest,
     socketSessionId: string,
   ): McpForwardRoute {
-    this.throwIfReleasedBoundSession(request.params);
     const sessionUuid = this.getSessionUuid(request.params);
     if (sessionUuid) {
       return this.sessionScopedForwardRoute(socketSessionId, sessionUuid, undefined);

--- a/src/daemon/socketServer.ts
+++ b/src/daemon/socketServer.ts
@@ -19,9 +19,11 @@ import {
   DAEMON_HANDSHAKE_ENABLED,
   DAEMON_SUBSCRIBE_NOTIFICATIONS_METHOD,
   DAEMON_SESSION_TOOL_BINDING_HEADER,
+  DAEMON_RELEASED_SESSION_HEADER,
   DAEMON_TOOL_SELECTION_PROFILE_HEADER,
   DAEMON_TOOL_SELECTION_PROFILE_PARAM,
   DAEMON_BOUND_SESSION_PARAM,
+  DAEMON_RELEASED_SESSION_PARAM,
   DAEMON_VERSION,
   INTERNAL_MCP_REQUEST_TIMEOUT_PARAM,
 } from "./constants";
@@ -146,6 +148,7 @@ interface SocketFileIdentity {
 export type McpClientFactory = (
   boundSessionUuid?: string,
   toolSelectionProfileUuid?: string,
+  releasedSessionUuid?: string,
 ) => Promise<Client>;
 
 /**
@@ -185,6 +188,7 @@ interface McpForwardRoute {
   /** Replayed when this transport needs to establish a fresh MCP session. */
   sessionUuid?: string;
   toolSelectionProfileUuid?: string;
+  releasedSessionUuid?: string;
 }
 
 interface DeviceControlTransportIdentity {
@@ -325,8 +329,11 @@ export class UnixSocketServer {
    * Defaults to the real {@link createMcpClient}; tests assign a fake here to
    * exercise forwarding without a live HTTP endpoint.
    */
-  mcpClientFactory: McpClientFactory = (sessionUuid, toolSelectionProfileUuid) =>
-    this.createMcpClient(sessionUuid, toolSelectionProfileUuid);
+  mcpClientFactory: McpClientFactory = (
+    sessionUuid,
+    toolSelectionProfileUuid,
+    releasedSessionUuid,
+  ) => this.createMcpClient(sessionUuid, toolSelectionProfileUuid, releasedSessionUuid);
 
   /**
    * Factory for the Android append-text helper behind `input/typeText mode:"append"`.
@@ -1033,7 +1040,21 @@ export class UnixSocketServer {
   ): McpForwardRoute {
     const sessionUuid = this.getSessionUuid(request.params);
     if (sessionUuid) {
-      return this.sessionScopedForwardRoute(socketSessionId, sessionUuid, undefined);
+      const releasedSessionUuid =
+        request.params?.[DAEMON_RELEASED_SESSION_PARAM] === sessionUuid ? sessionUuid : undefined;
+      const isReleasedScreenshot =
+        releasedSessionUuid !== undefined &&
+        request.params?.uri === `automobile:device-session/${sessionUuid}/screenshot`;
+      if (!isReleasedScreenshot) {
+        this.throwIfReleasedBoundSession(request.params);
+      }
+      return this.sessionScopedForwardRoute(
+        socketSessionId,
+        sessionUuid,
+        undefined,
+        undefined,
+        releasedSessionUuid === sessionUuid ? releasedSessionUuid : undefined,
+      );
     }
     const uri = request.params?.uri;
     return this.sharedMcpForwardRoute(
@@ -1093,10 +1114,13 @@ export class UnixSocketServer {
     socketSessionId: string,
     sessionUuid: string,
     toolSelectionProfileUuid?: string,
+    releasedSessionUuid?: string,
   ): string {
-    return toolSelectionProfileUuid
-      ? `socket:${socketSessionId}:session:${sessionUuid}:tool-selection:${toolSelectionProfileUuid}`
-      : `socket:${socketSessionId}:session:${sessionUuid}`;
+    const profileSuffix = toolSelectionProfileUuid
+      ? `:tool-selection:${toolSelectionProfileUuid}`
+      : "";
+    const releaseSuffix = releasedSessionUuid ? ":released-resource" : "";
+    return `socket:${socketSessionId}:session:${sessionUuid}${profileSuffix}${releaseSuffix}`;
   }
 
   private toolSelectionProfileMcpClientKey(
@@ -1114,12 +1138,19 @@ export class UnixSocketServer {
     sessionUuid: string,
     scopedKey: string | undefined,
     toolSelectionProfileUuid?: string,
+    releasedSessionUuid?: string,
   ): McpForwardRoute {
     return {
       executionKey: scopedKey ?? `session:${sessionUuid}`,
-      clientKey: this.sessionMcpClientKey(socketSessionId, sessionUuid, toolSelectionProfileUuid),
+      clientKey: this.sessionMcpClientKey(
+        socketSessionId,
+        sessionUuid,
+        toolSelectionProfileUuid,
+        releasedSessionUuid,
+      ),
       sessionUuid,
       toolSelectionProfileUuid,
+      releasedSessionUuid,
     };
   }
 
@@ -1299,6 +1330,7 @@ export class UnixSocketServer {
         context.route.clientKey,
         context.route.sessionUuid,
         context.route.toolSelectionProfileUuid,
+        context.route.releasedSessionUuid,
       );
     } catch (error) {
       if (!this.isDeviceControlSocketClosure(context.request, error)) {
@@ -1363,6 +1395,7 @@ export class UnixSocketServer {
         context.route.clientKey,
         context.route.sessionUuid,
         context.route.toolSelectionProfileUuid,
+        context.route.releasedSessionUuid,
       );
     } catch (error) {
       if (!this.isDeviceControlSocketClosure(context.request, error)) {
@@ -1726,6 +1759,7 @@ export class UnixSocketServer {
       input.route.clientKey,
       input.route.sessionUuid,
       input.route.toolSelectionProfileUuid,
+      input.route.releasedSessionUuid,
     );
     // getMcpClient registers its pending creation synchronously, so this snapshot
     // identifies the attempt this wait started. Staggered deadlines can share a
@@ -3923,6 +3957,7 @@ export class UnixSocketServer {
     const boundSessionUuid = this.getSessionUuid(forwardedArgs);
     const usesBoundSession = forwardedArgs[DAEMON_BOUND_SESSION_PARAM] === boundSessionUuid;
     delete forwardedArgs[DAEMON_BOUND_SESSION_PARAM];
+    delete forwardedArgs[DAEMON_RELEASED_SESSION_PARAM];
     // Connection-bound sessions are carried by the loopback transport header.
     // Never let a stale injected UUID reach ToolExecutionContext, whose legacy
     // explicit-session contract would otherwise create a replacement session.
@@ -3942,6 +3977,7 @@ export class UnixSocketServer {
   private async createMcpClient(
     boundSessionUuid?: string,
     toolSelectionProfileUuid?: string,
+    releasedSessionUuid?: string,
   ): Promise<Client> {
     logger.info(`Creating MCP client with endpoint: "${this.mcpEndpoint}"`);
     if (!this.mcpEndpoint) {
@@ -3950,12 +3986,15 @@ export class UnixSocketServer {
     }
     const transport = new StreamableHTTPClientTransport(new URL(this.mcpEndpoint), {
       reconnectionOptions: DAEMON_LOOPBACK_STREAMABLE_HTTP_RECONNECTION,
-      ...(boundSessionUuid || toolSelectionProfileUuid
+      ...(boundSessionUuid || toolSelectionProfileUuid || releasedSessionUuid
         ? {
             requestInit: {
               headers: {
                 ...(boundSessionUuid
                   ? { [DAEMON_SESSION_TOOL_BINDING_HEADER]: boundSessionUuid }
+                  : {}),
+                ...(releasedSessionUuid
+                  ? { [DAEMON_RELEASED_SESSION_HEADER]: releasedSessionUuid }
                   : {}),
                 ...(toolSelectionProfileUuid
                   ? { [DAEMON_TOOL_SELECTION_PROFILE_HEADER]: toolSelectionProfileUuid }
@@ -3989,6 +4028,7 @@ export class UnixSocketServer {
     key: string,
     boundSessionUuid?: string,
     toolSelectionProfileUuid?: string,
+    releasedSessionUuid?: string,
   ): Promise<Client> {
     this.clearMcpClientIdleTimer(key);
 
@@ -4003,7 +4043,11 @@ export class UnixSocketServer {
     }
 
     const generation = this.lifecycleGeneration;
-    const clientPromise = this.mcpClientFactory(boundSessionUuid, toolSelectionProfileUuid)
+    const clientPromise = this.mcpClientFactory(
+      boundSessionUuid,
+      toolSelectionProfileUuid,
+      releasedSessionUuid,
+    )
       .then(async (client) => {
         if (
           this.closing ||

--- a/src/server/SessionToolBinding.ts
+++ b/src/server/SessionToolBinding.ts
@@ -50,15 +50,10 @@ export class SessionToolBinding {
     return explicitSessionUuid ?? boundSessionUuid;
   }
 
-  /**
-   * Preserve a released transport's session identity only for resources/read so
-   * a previously advertised session resource can report a typed inactive-session
-   * result. Tool routing deliberately remains unbound after release.
-   */
-  effectiveResourceSessionUuid(mcpSessionId: string | undefined): string | undefined {
-    const activeSessionUuid = this.boundSessionUuid(mcpSessionId);
-    if (activeSessionUuid) {
-      return activeSessionUuid;
+  /** A released identity is not an authorization grant for a replacement session. */
+  releasedResourceSessionUuid(mcpSessionId: string | undefined): string | undefined {
+    if (this.boundSessionUuid(mcpSessionId)) {
+      return undefined;
     }
     if (mcpSessionId) {
       return this.releasedDeviceSessions.get(mcpSessionId) ?? this.releasedInitialSessionUuid;

--- a/src/server/SessionToolBinding.ts
+++ b/src/server/SessionToolBinding.ts
@@ -17,9 +17,11 @@ export class SessionToolBinding {
     initialSessionUuid?: string,
     initialToolSelectionProfileUuid?: string,
     private readonly idGenerator: IdGenerator = defaultIdGenerator,
+    initialReleasedSessionUuid?: string,
   ) {
     this.initialSessionUuid = initialSessionUuid;
     this.initialToolSelectionProfileUuid = initialToolSelectionProfileUuid;
+    this.releasedInitialSessionUuid = initialReleasedSessionUuid;
   }
 
   private boundSessionUuid(mcpSessionId: string | undefined): string | undefined {

--- a/src/server/SessionToolBinding.ts
+++ b/src/server/SessionToolBinding.ts
@@ -2,9 +2,12 @@ import { defaultIdGenerator, type IdGenerator } from "../utils/IdGenerator";
 
 export class SessionToolBinding {
   private readonly boundDeviceSessions = new Map<string, string>();
+  private readonly releasedDeviceSessions = new Map<string, string>();
   private initialSessionUuid?: string;
+  private releasedInitialSessionUuid?: string;
   /** The single stdio transport has no MCP session ID, so retain its device session here. */
   private directDeviceSessionUuid?: string;
+  private releasedDirectDeviceSessionUuid?: string;
   private initialToolSelectionProfileUuid?: string;
   /** The single stdio transport has no MCP session ID, so retain its profile here. */
   private directToolSelectionProfileUuid?: string;
@@ -48,6 +51,22 @@ export class SessionToolBinding {
   }
 
   /**
+   * Preserve a released transport's session identity only for resources/read so
+   * a previously advertised session resource can report a typed inactive-session
+   * result. Tool routing deliberately remains unbound after release.
+   */
+  effectiveResourceSessionUuid(mcpSessionId: string | undefined): string | undefined {
+    const activeSessionUuid = this.boundSessionUuid(mcpSessionId);
+    if (activeSessionUuid) {
+      return activeSessionUuid;
+    }
+    if (mcpSessionId) {
+      return this.releasedDeviceSessions.get(mcpSessionId) ?? this.releasedInitialSessionUuid;
+    }
+    return this.releasedDirectDeviceSessionUuid ?? this.releasedInitialSessionUuid;
+  }
+
+  /**
    * Resolve the profile used solely for exact-tool selection. A generated
    * connection profile deliberately never becomes a routing/device session:
    * executePlan may release device sessions, but that must not erase a user's
@@ -82,12 +101,14 @@ export class SessionToolBinding {
         return false;
       }
       this.directDeviceSessionUuid = sessionUuid;
+      this.releasedDirectDeviceSessionUuid = undefined;
       return true;
     }
     if (this.boundDeviceSessions.get(mcpSessionId) === sessionUuid) {
       return false;
     }
     this.boundDeviceSessions.set(mcpSessionId, sessionUuid);
+    this.releasedDeviceSessions.delete(mcpSessionId);
     return true;
   }
 
@@ -141,15 +162,18 @@ export class SessionToolBinding {
     for (const [mcpSessionId, boundSessionUuid] of this.boundDeviceSessions) {
       if (boundSessionUuid === sessionUuid) {
         this.boundDeviceSessions.delete(mcpSessionId);
+        this.releasedDeviceSessions.set(mcpSessionId, sessionUuid);
         removed = true;
       }
     }
     if (this.initialSessionUuid === sessionUuid) {
       this.initialSessionUuid = undefined;
+      this.releasedInitialSessionUuid = sessionUuid;
       removed = true;
     }
     if (this.directDeviceSessionUuid === sessionUuid) {
       this.directDeviceSessionUuid = undefined;
+      this.releasedDirectDeviceSessionUuid = sessionUuid;
       removed = true;
     }
     return removed;

--- a/src/server/directSessionDeviceRegistry.ts
+++ b/src/server/directSessionDeviceRegistry.ts
@@ -3,18 +3,23 @@ import type { BootedDevice, Platform } from "../models";
 interface DirectSessionDevice {
   sessionUuid: string;
   device: BootedDevice;
+  incarnation: number;
 }
 
 const sessions = new Map<string, BootedDevice>();
+const incarnations = new Map<string, number>();
 
 export function registerDirectSessionDevice(sessionUuid: string, device: BootedDevice): void {
   unregisterDirectSessionsForDevice(device.deviceId);
   sessions.set(sessionUuid, { ...device });
+  incarnations.set(sessionUuid, (incarnations.get(sessionUuid) ?? 0) + 1);
 }
 
 export function resolveDirectSessionDevice(sessionUuid: string): DirectSessionDevice | undefined {
   const device = sessions.get(sessionUuid);
-  return device ? { sessionUuid, device: { ...device } } : undefined;
+  return device
+    ? { sessionUuid, device: { ...device }, incarnation: incarnations.get(sessionUuid) ?? 0 }
+    : undefined;
 }
 
 export function unregisterDirectSessionsForDevice(deviceId: string): void {

--- a/src/server/index.ts
+++ b/src/server/index.ts
@@ -392,7 +392,10 @@ export const createMcpServer = (options: McpServerOptions = {}): McpServer => {
 
   // Register all resources with the server
   ResourceRegistry.registerWithServer(server, (signal) => ({
-    sessionUuid: sessionToolBinding.effectiveResourceSessionUuid(options.sessionContext?.sessionId),
+    sessionUuid: sessionToolBinding.effectiveSessionUuid(options.sessionContext?.sessionId),
+    releasedSessionUuid: sessionToolBinding.releasedResourceSessionUuid(
+      options.sessionContext?.sessionId,
+    ),
     signal,
   }));
 

--- a/src/server/index.ts
+++ b/src/server/index.ts
@@ -103,6 +103,7 @@ export interface McpServerOptions {
   sessionContext?: {
     sessionId?: string;
     initialSessionToolBinding?: string;
+    initialReleasedSession?: string;
     initialToolSelectionProfile?: string;
   };
   planExecutionLock?: PlanExecutionLock;
@@ -312,6 +313,8 @@ export const createMcpServer = (options: McpServerOptions = {}): McpServer => {
   const sessionToolBinding = new SessionToolBinding(
     options.sessionContext?.initialSessionToolBinding,
     options.sessionContext?.initialToolSelectionProfile,
+    undefined,
+    options.sessionContext?.initialReleasedSession,
   );
   // Plan execution lock with per-session scope to prevent interference during executePlan
   // Each test thread gets its own sessionUuid, enabling parallel execution on different devices

--- a/src/server/index.ts
+++ b/src/server/index.ts
@@ -392,7 +392,7 @@ export const createMcpServer = (options: McpServerOptions = {}): McpServer => {
 
   // Register all resources with the server
   ResourceRegistry.registerWithServer(server, (signal) => ({
-    sessionUuid: sessionToolBinding.effectiveSessionUuid(options.sessionContext?.sessionId),
+    sessionUuid: sessionToolBinding.effectiveResourceSessionUuid(options.sessionContext?.sessionId),
     signal,
   }));
 

--- a/src/server/observationResources.ts
+++ b/src/server/observationResources.ts
@@ -276,6 +276,25 @@ function isAuthorizedSessionResource(context: ResourceReadContext, sessionUuid: 
   return context.sessionUuid === sessionUuid;
 }
 
+function releasedSessionNotActiveError(
+  uri: string,
+  context: ResourceReadContext,
+  sessionUuid: string,
+): ResourceContent | undefined {
+  if (
+    context.releasedSessionUuid === sessionUuid
+    && !sessionScreenshotResourceDependencies.resolveActiveSession(sessionUuid)
+  ) {
+    return freshSessionScreenshotError(
+      uri,
+      "SESSION_NOT_ACTIVE",
+      false,
+      `No active device session found for sessionUuid ${sessionUuid}.`,
+    );
+  }
+  return undefined;
+}
+
 // Session-scoped handler for a cached observation.
 async function getSessionObservation(
   params: Record<string, string>,
@@ -409,7 +428,7 @@ async function getFreshSessionScreenshot(
   const { sessionUuid } = params;
   const uri = `automobile:device-session/${sessionUuid}/screenshot`;
   if (!isAuthorizedSessionResource(context, sessionUuid)) {
-    return unauthorizedSessionResourceError(uri);
+    return releasedSessionNotActiveError(uri, context, sessionUuid) ?? unauthorizedSessionResourceError(uri);
   }
   const activeSession = sessionScreenshotResourceDependencies.resolveActiveSession(sessionUuid);
   if (!activeSession) {

--- a/src/server/observationResources.ts
+++ b/src/server/observationResources.ts
@@ -10,6 +10,7 @@ import type { TrackedScreenshotService } from "../features/observe/screenshot/Ob
 import type { BootedDevice } from "../models";
 import * as realFs from "fs/promises";
 import { errorMessage } from "../utils/describeUnknownError";
+import { OPERATION_CANCELLED_MESSAGE } from "../utils/constants";
 
 interface ScreenshotFileSystem {
   stat(path: string): Promise<{ isFile(): boolean }>;
@@ -29,11 +30,25 @@ export function resetScreenshotFileSystem(): void {
 interface ActiveSessionDevice {
   sessionUuid: string;
   device: BootedDevice;
+  incarnation?: number;
 }
 
 interface SessionScreenshotResourceDependencies {
   resolveActiveSession(sessionUuid: string): ActiveSessionDevice | undefined;
   createScreenshotService(device: BootedDevice): TrackedScreenshotService;
+}
+
+let nextSessionIncarnation = 0;
+const sessionIncarnations = new WeakMap<object, number>();
+
+function getSessionIncarnation(session: object): number {
+  const existing = sessionIncarnations.get(session);
+  if (existing !== undefined) {
+    return existing;
+  }
+  const incarnation = ++nextSessionIncarnation;
+  sessionIncarnations.set(session, incarnation);
+  return incarnation;
 }
 
 function resolveActiveSession(sessionUuid: string): ActiveSessionDevice | undefined {
@@ -54,6 +69,7 @@ function resolveActiveSession(sessionUuid: string): ActiveSessionDevice | undefi
 
   return {
     sessionUuid,
+    incarnation: getSessionIncarnation(session),
     device: {
       deviceId: pooledDevice.id,
       name: pooledDevice.name,
@@ -243,7 +259,10 @@ function sessionResourceError(uri: string, sessionUuid: string): ResourceContent
 type FreshSessionScreenshotFailureCode =
   | "SESSION_NOT_ACTIVE"
   | "SESSION_OWNERSHIP_LOST"
-  | "SCREENSHOT_CAPTURE_FAILED";
+  | "SCREENSHOT_CAPTURE_FAILED"
+  | "SCREENSHOT_CAPTURE_CANCELLED"
+  | "SCREENSHOT_READ_FAILED"
+  | "SCREENSHOT_ACCESS_DENIED";
 
 function freshSessionScreenshotError(
   uri: string,
@@ -256,6 +275,20 @@ function freshSessionScreenshotError(
     mimeType: "application/json",
     text: JSON.stringify({ code, retryable, error }, null, 2),
   };
+}
+
+function freshScreenshotCaptureFailure(
+  uri: string,
+  signal: AbortSignal | undefined,
+  error: string,
+): ResourceContent {
+  if (signal?.aborted || error.includes(OPERATION_CANCELLED_MESSAGE)) {
+    return freshSessionScreenshotError(uri, "SCREENSHOT_CAPTURE_CANCELLED", false, error);
+  }
+  if (/EACCES|EPERM|permission denied|read-only/i.test(error)) {
+    return freshSessionScreenshotError(uri, "SCREENSHOT_ACCESS_DENIED", false, error);
+  }
+  return freshSessionScreenshotError(uri, "SCREENSHOT_CAPTURE_FAILED", true, error);
 }
 
 function unauthorizedSessionResourceError(uri: string): ResourceContent {
@@ -272,6 +305,28 @@ function unauthorizedSessionResourceError(uri: string): ResourceContent {
   };
 }
 
+function unauthorizedFreshScreenshotError(uri: string): ResourceContent {
+  return freshSessionScreenshotError(
+    uri,
+    "SCREENSHOT_ACCESS_DENIED",
+    false,
+    "This resource can only be read by its bound device session.",
+  );
+}
+
+function sessionOwnershipChanged(
+  currentSession: ActiveSessionDevice | undefined,
+  originalSession: ActiveSessionDevice,
+): boolean {
+  if (currentSession?.device.deviceId !== originalSession.device.deviceId) {
+    return true;
+  }
+  if (currentSession?.incarnation !== undefined && originalSession.incarnation !== undefined) {
+    return currentSession.incarnation !== originalSession.incarnation;
+  }
+  return false;
+}
+
 function isAuthorizedSessionResource(context: ResourceReadContext, sessionUuid: string): boolean {
   return context.sessionUuid === sessionUuid;
 }
@@ -282,8 +337,8 @@ function releasedSessionNotActiveError(
   sessionUuid: string,
 ): ResourceContent | undefined {
   if (
-    context.releasedSessionUuid === sessionUuid
-    && !sessionScreenshotResourceDependencies.resolveActiveSession(sessionUuid)
+    context.releasedSessionUuid === sessionUuid &&
+    !sessionScreenshotResourceDependencies.resolveActiveSession(sessionUuid)
   ) {
     return freshSessionScreenshotError(
       uri,
@@ -293,6 +348,64 @@ function releasedSessionNotActiveError(
     );
   }
   return undefined;
+}
+
+async function readFreshScreenshot(
+  uri: string,
+  sessionUuid: string,
+  activeSession: ActiveSessionDevice,
+  context: ResourceReadContext,
+  path: string,
+): Promise<ResourceContent> {
+  try {
+    const imageBuffer = await screenshotFileSystem.readFile(path);
+    if (context.signal?.aborted) {
+      return freshSessionScreenshotError(
+        uri,
+        "SCREENSHOT_CAPTURE_CANCELLED",
+        false,
+        OPERATION_CANCELLED_MESSAGE,
+      );
+    }
+    const finalSession = sessionScreenshotResourceDependencies.resolveActiveSession(sessionUuid);
+    if (sessionOwnershipChanged(finalSession, activeSession)) {
+      return freshSessionScreenshotError(
+        uri,
+        "SESSION_OWNERSHIP_LOST",
+        false,
+        "Device session ownership was lost while reading a fresh screenshot.",
+      );
+    }
+    return {
+      uri,
+      mimeType: "image/png",
+      blob: imageBuffer.toString("base64"),
+    };
+  } catch (error) {
+    const reason = errorMessage(error);
+    logger.error(
+      `[ObservationResources] Failed to read fresh screenshot for session ${sessionUuid}: ${reason}`,
+    );
+    if (context.signal?.aborted || reason.includes(OPERATION_CANCELLED_MESSAGE)) {
+      return freshSessionScreenshotError(uri, "SCREENSHOT_CAPTURE_CANCELLED", false, reason);
+    }
+    const failedReadSession =
+      sessionScreenshotResourceDependencies.resolveActiveSession(sessionUuid);
+    if (sessionOwnershipChanged(failedReadSession, activeSession)) {
+      return freshSessionScreenshotError(
+        uri,
+        "SESSION_OWNERSHIP_LOST",
+        false,
+        "Device session ownership was lost while reading a fresh screenshot.",
+      );
+    }
+    return freshSessionScreenshotError(
+      uri,
+      "SCREENSHOT_READ_FAILED",
+      false,
+      `Failed to read fresh screenshot for sessionUuid ${sessionUuid}: ${reason}`,
+    );
+  }
 }
 
 // Session-scoped handler for a cached observation.
@@ -428,7 +541,10 @@ async function getFreshSessionScreenshot(
   const { sessionUuid } = params;
   const uri = `automobile:device-session/${sessionUuid}/screenshot`;
   if (!isAuthorizedSessionResource(context, sessionUuid)) {
-    return releasedSessionNotActiveError(uri, context, sessionUuid) ?? unauthorizedSessionResourceError(uri);
+    return (
+      releasedSessionNotActiveError(uri, context, sessionUuid) ??
+      unauthorizedFreshScreenshotError(uri)
+    );
   }
   const activeSession = sessionScreenshotResourceDependencies.resolveActiveSession(sessionUuid);
   if (!activeSession) {
@@ -454,7 +570,7 @@ async function getFreshSessionScreenshot(
     const result = await promise;
 
     const currentSession = sessionScreenshotResourceDependencies.resolveActiveSession(sessionUuid);
-    if (currentSession?.device.deviceId !== activeSession.device.deviceId) {
+    if (sessionOwnershipChanged(currentSession, activeSession)) {
       return freshSessionScreenshotError(
         uri,
         "SESSION_OWNERSHIP_LOST",
@@ -470,27 +586,17 @@ async function getFreshSessionScreenshot(
       );
     }
 
-    const imageBuffer = await screenshotFileSystem.readFile(result.path);
-    return {
-      uri,
-      mimeType: "image/png",
-      blob: imageBuffer.toString("base64"),
-    };
+    return readFreshScreenshot(uri, sessionUuid, activeSession, context, result.path);
   } catch (error) {
+    const reason = errorMessage(error);
     logger.error(
-      `[ObservationResources] Failed to capture fresh screenshot for session ${sessionUuid}: ${error}`,
+      `[ObservationResources] Failed to capture fresh screenshot for session ${sessionUuid}: ${reason}`,
     );
-    return {
+    return freshScreenshotCaptureFailure(
       uri,
-      mimeType: "application/json",
-      text: JSON.stringify(
-        {
-          error: `Failed to capture fresh screenshot for sessionUuid ${sessionUuid}: ${error}`,
-        },
-        null,
-        2,
-      ),
-    };
+      context.signal,
+      `Failed to capture fresh screenshot for sessionUuid ${sessionUuid}: ${reason}`,
+    );
   }
 }
 

--- a/src/server/observationResources.ts
+++ b/src/server/observationResources.ts
@@ -9,6 +9,7 @@ import { resolveDirectSessionDevice } from "./directSessionDeviceRegistry";
 import type { TrackedScreenshotService } from "../features/observe/screenshot/ObserveScreenshotRecorder";
 import type { BootedDevice } from "../models";
 import * as realFs from "fs/promises";
+import { errorMessage } from "../utils/describeUnknownError";
 
 interface ScreenshotFileSystem {
   stat(path: string): Promise<{ isFile(): boolean }>;
@@ -239,6 +240,24 @@ function sessionResourceError(uri: string, sessionUuid: string): ResourceContent
   };
 }
 
+type FreshSessionScreenshotFailureCode =
+  | "SESSION_NOT_ACTIVE"
+  | "SESSION_OWNERSHIP_LOST"
+  | "SCREENSHOT_CAPTURE_FAILED";
+
+function freshSessionScreenshotError(
+  uri: string,
+  code: FreshSessionScreenshotFailureCode,
+  retryable: boolean,
+  error: string,
+): ResourceContent {
+  return {
+    uri,
+    mimeType: "application/json",
+    text: JSON.stringify({ code, retryable, error }, null, 2),
+  };
+}
+
 function unauthorizedSessionResourceError(uri: string): ResourceContent {
   return {
     uri,
@@ -394,7 +413,12 @@ async function getFreshSessionScreenshot(
   }
   const activeSession = sessionScreenshotResourceDependencies.resolveActiveSession(sessionUuid);
   if (!activeSession) {
-    return sessionResourceError(uri, sessionUuid);
+    return freshSessionScreenshotError(
+      uri,
+      "SESSION_NOT_ACTIVE",
+      false,
+      `No active device session found for sessionUuid ${sessionUuid}.`,
+    );
   }
 
   try {
@@ -412,20 +436,19 @@ async function getFreshSessionScreenshot(
 
     const currentSession = sessionScreenshotResourceDependencies.resolveActiveSession(sessionUuid);
     if (currentSession?.device.deviceId !== activeSession.device.deviceId) {
-      return sessionResourceError(uri, sessionUuid);
+      return freshSessionScreenshotError(
+        uri,
+        "SESSION_OWNERSHIP_LOST",
+        false,
+        "Device session ownership was lost while capturing a fresh screenshot.",
+      );
     }
     if (!result.success || !result.path) {
-      return {
+      return freshScreenshotCaptureFailure(
         uri,
-        mimeType: "application/json",
-        text: JSON.stringify(
-          {
-            error: result.error || "Failed to capture a fresh screenshot.",
-          },
-          null,
-          2,
-        ),
-      };
+        context.signal,
+        result.error || "Failed to capture a fresh screenshot.",
+      );
     }
 
     const imageBuffer = await screenshotFileSystem.readFile(result.path);

--- a/src/server/resourceRegistry.ts
+++ b/src/server/resourceRegistry.ts
@@ -13,6 +13,8 @@ import { ListChangedBroadcaster } from "./listChangedBroadcast";
 
 export interface ResourceReadContext {
   sessionUuid?: string;
+  /** A released session identity, available only to handlers that safely report inactivity. */
+  releasedSessionUuid?: string;
   signal?: AbortSignal;
 }
 

--- a/test/daemon/daemonMcpProxy.test.ts
+++ b/test/daemon/daemonMcpProxy.test.ts
@@ -2301,6 +2301,43 @@ describe("DaemonMcpProxy", () => {
       }
     });
 
+    test("forwards only the released session's fresh screenshot read", async () => {
+      const expectedResult = {
+        contents: [{
+          uri: "automobile:device-session/session-a/screenshot",
+          mimeType: "application/json",
+          text: JSON.stringify({ code: "SESSION_NOT_ACTIVE" }),
+        }],
+      };
+      const fakeClient = new FakeDaemonClient({
+        daemonMethodResults: new Map([["tools/list", { tools: [] }]]),
+        resourceResult: expectedResult,
+      });
+      const isAvailableSpy = spyOn(DaemonClient, "isAvailable").mockResolvedValue(true);
+      const proxy = new DaemonMcpProxy({
+        initialSessionUuid: "session-a",
+        clientFactory: () => fakeClient,
+        daemonManager: matchingDaemonManager(),
+        autoStartDaemon: false,
+      });
+
+      try {
+        await proxy.listTools();
+        fakeClient.emitNotification(SESSION_RELEASED_NOTIFICATION_METHOD, "session-a");
+
+        await expect(
+          proxy.readResource("automobile:device-session/session-a/screenshot"),
+        ).resolves.toEqual(expectedResult);
+        await expect(proxy.readResource("automobile:devices/booted")).rejects.toThrow(
+          /session-a.*(?:expired|released)/i,
+        );
+        expect(fakeClient.readResourceParams).toEqual([{ sessionUuid: "session-a" }]);
+      } finally {
+        isAvailableSpy.mockRestore();
+        await proxy.close();
+      }
+    });
+
     test("preserves the daemon heartbeat snapshot on a terminal binding error", async () => {
       const timer = new FakeTimer();
       const fakeClient = new FakeDaemonClient({

--- a/test/daemon/daemonMcpProxy.test.ts
+++ b/test/daemon/daemonMcpProxy.test.ts
@@ -2303,11 +2303,13 @@ describe("DaemonMcpProxy", () => {
 
     test("forwards only the released session's fresh screenshot read", async () => {
       const expectedResult = {
-        contents: [{
-          uri: "automobile:device-session/session-a/screenshot",
-          mimeType: "application/json",
-          text: JSON.stringify({ code: "SESSION_NOT_ACTIVE" }),
-        }],
+        contents: [
+          {
+            uri: "automobile:device-session/session-a/screenshot",
+            mimeType: "application/json",
+            text: JSON.stringify({ code: "SESSION_NOT_ACTIVE" }),
+          },
+        ],
       };
       const fakeClient = new FakeDaemonClient({
         daemonMethodResults: new Map([["tools/list", { tools: [] }]]),
@@ -2331,7 +2333,12 @@ describe("DaemonMcpProxy", () => {
         await expect(proxy.readResource("automobile:devices/booted")).rejects.toThrow(
           /session-a.*(?:expired|released)/i,
         );
-        expect(fakeClient.readResourceParams).toEqual([{ sessionUuid: "session-a" }]);
+        expect(fakeClient.readResourceParams).toEqual([
+          {
+            sessionUuid: "session-a",
+            __autoMobileReleasedSessionUuid: "session-a",
+          },
+        ]);
       } finally {
         isAvailableSpy.mockRestore();
         await proxy.close();

--- a/test/daemon/socketServerMcpForwardSerialization.test.ts
+++ b/test/daemon/socketServerMcpForwardSerialization.test.ts
@@ -1071,6 +1071,41 @@ describe("UnixSocketServer MCP forward serialization", () => {
     expect(clientBindings).toEqual(["session-a"]);
   });
 
+  test("routes a released bound resource read so its handler can report the inactive session", async () => {
+    const clientBindings: Array<string | undefined> = [];
+    server.mcpClientFactory = async (boundSessionUuid) => {
+      clientBindings.push(boundSessionUuid);
+      return {
+        listTools: async () => ({ tools: [] }),
+        callTool: async () => ({ content: [] }),
+        listResources: async () => ({ resources: [] }),
+        readResource: async () => ({
+          contents: [{
+            uri: "automobile:device-session/released-session/screenshot",
+            mimeType: "application/json",
+            text: JSON.stringify({ code: "SESSION_NOT_ACTIVE" }),
+          }],
+        }),
+        listResourceTemplates: async () => ({ resourceTemplates: [] }),
+        close: async () => {},
+      };
+    };
+
+    const response = await sendRequest(socketPath, {
+      id: randomUUID(),
+      type: "mcp_request",
+      method: "resources/read",
+      params: {
+        uri: "automobile:device-session/released-session/screenshot",
+        sessionUuid: "released-session",
+        [DAEMON_BOUND_SESSION_PARAM]: "released-session",
+      },
+    });
+
+    expect(response.success).toBe(true);
+    expect(clientBindings).toEqual(["released-session"]);
+  });
+
   test("retains a bound socket transport past the idle client deadline", async () => {
     sessionDevices.set("session-a", "device-a");
     let closeCalls = 0;

--- a/test/daemon/socketServerMcpForwardSerialization.test.ts
+++ b/test/daemon/socketServerMcpForwardSerialization.test.ts
@@ -10,6 +10,7 @@ import { SOCKET_REQUEST_DEADLINE_MS, sendRawSocketRequest } from "./helpers/sock
 import { defaultTimer } from "../../src/utils/SystemTimer";
 import {
   DAEMON_BOUND_SESSION_PARAM,
+  DAEMON_RELEASED_SESSION_PARAM,
   DAEMON_TOOL_SELECTION_PROFILE_PARAM,
   INTERNAL_MCP_REQUEST_TIMEOUT_PARAM,
 } from "../../src/daemon/constants";
@@ -1000,6 +1001,7 @@ describe("UnixSocketServer MCP forward serialization", () => {
       params: {
         sessionUuid: "released-session",
         [DAEMON_BOUND_SESSION_PARAM]: "released-session",
+        [DAEMON_RELEASED_SESSION_PARAM]: "released-session",
       },
     });
 
@@ -1009,9 +1011,9 @@ describe("UnixSocketServer MCP forward serialization", () => {
   });
 
   test("rejects released bound resource discovery before shared routing", async () => {
-    const clientBindings: Array<string | undefined> = [];
-    server.mcpClientFactory = async (boundSessionUuid) => {
-      clientBindings.push(boundSessionUuid);
+    const clientBindings: Array<[string | undefined, string | undefined]> = [];
+    server.mcpClientFactory = async (boundSessionUuid, _profile, releasedSessionUuid) => {
+      clientBindings.push([boundSessionUuid, releasedSessionUuid]);
       return {
         listTools: async () => ({ tools: [] }),
         callTool: async () => ({ content: [] }),
@@ -1072,19 +1074,21 @@ describe("UnixSocketServer MCP forward serialization", () => {
   });
 
   test("routes a released bound resource read so its handler can report the inactive session", async () => {
-    const clientBindings: Array<string | undefined> = [];
-    server.mcpClientFactory = async (boundSessionUuid) => {
-      clientBindings.push(boundSessionUuid);
+    const clientBindings: Array<[string | undefined, string | undefined]> = [];
+    server.mcpClientFactory = async (boundSessionUuid, _profile, releasedSessionUuid) => {
+      clientBindings.push([boundSessionUuid, releasedSessionUuid]);
       return {
         listTools: async () => ({ tools: [] }),
         callTool: async () => ({ content: [] }),
         listResources: async () => ({ resources: [] }),
         readResource: async () => ({
-          contents: [{
-            uri: "automobile:device-session/released-session/screenshot",
-            mimeType: "application/json",
-            text: JSON.stringify({ code: "SESSION_NOT_ACTIVE" }),
-          }],
+          contents: [
+            {
+              uri: "automobile:device-session/released-session/screenshot",
+              mimeType: "application/json",
+              text: JSON.stringify({ code: "SESSION_NOT_ACTIVE" }),
+            },
+          ],
         }),
         listResourceTemplates: async () => ({ resourceTemplates: [] }),
         close: async () => {},
@@ -1099,11 +1103,12 @@ describe("UnixSocketServer MCP forward serialization", () => {
         uri: "automobile:device-session/released-session/screenshot",
         sessionUuid: "released-session",
         [DAEMON_BOUND_SESSION_PARAM]: "released-session",
+        [DAEMON_RELEASED_SESSION_PARAM]: "released-session",
       },
     });
 
     expect(response.success).toBe(true);
-    expect(clientBindings).toEqual(["released-session"]);
+    expect(clientBindings).toEqual([["released-session", "released-session"]]);
   });
 
   test("retains a bound socket transport past the idle client deadline", async () => {

--- a/test/features/observe/CtrlProxyClient.test.ts
+++ b/test/features/observe/CtrlProxyClient.test.ts
@@ -935,34 +935,37 @@ describe("AndroidCtrlProxyClient", function () {
     }
   });
 
-  // Windows Bun evaluates the Android barrel and direct import as separate module
-  // records, so their singleton registries cannot exercise this lifecycle.
-  test.skipIf(process.platform === "win32")(
-    "late invalidated-observer cleanup cannot release a replacement observer's port",
-    async function () {
-      await accessibilityServiceClient.close();
-      AndroidCtrlProxyClient.resetInstances();
-      PortManager.reset();
-      PortManager.setPortAvailabilityCheckerForTesting({ isPortAvailable: () => true });
-      try {
-        const original = AndroidCtrlProxyClient.getInstance(testDevice, fakeAdbFactory);
-        const originalPort = PortManager.getPort(testDevice.deviceId);
-        original.invalidateForShutdownRecovery();
+  test("late invalidated-observer cleanup cannot release a replacement observer's port", async function () {
+    await accessibilityServiceClient.close();
+    const isolatedDevice = { ...testDevice, deviceId: "late-cleanup-isolated-device" };
+    PortManager.setPortAvailabilityCheckerForTesting({ isPortAvailable: () => true });
+    const original = AndroidCtrlProxyClient.createForTesting(
+      isolatedDevice,
+      fakeAdb,
+      createSuccessWebSocketFactory(),
+      fakeTimer,
+    );
+    const originalPort = PortManager.getPort(isolatedDevice.deviceId);
+    original.invalidateForShutdownRecovery();
 
-        const replacement = AndroidCtrlProxyClient.getInstance(testDevice, fakeAdbFactory);
-        const replacementPort = PortManager.getPort(testDevice.deviceId);
-        expect(replacementPort).not.toBe(originalPort);
+    const replacement = AndroidCtrlProxyClient.createForTesting(
+      isolatedDevice,
+      fakeAdb,
+      createSuccessWebSocketFactory(),
+      fakeTimer,
+    );
+    const replacementPort = PortManager.getPort(isolatedDevice.deviceId);
+    try {
+      expect(replacementPort).not.toBe(originalPort);
 
-        await original.close();
-        expect(PortManager.getPort(testDevice.deviceId)).toBe(replacementPort);
-
-        await replacement.close();
-      } finally {
-        PortManager.setPortAvailabilityCheckerForTesting(null);
-        PortManager.reset();
-      }
-    },
-  );
+      await original.close();
+      expect(PortManager.getPort(isolatedDevice.deviceId)).toBe(replacementPort);
+    } finally {
+      await replacement.close();
+      PortManager.setPortAvailabilityCheckerForTesting(null);
+      PortManager.release(isolatedDevice.deviceId);
+    }
+  });
 
   describe("connection lifecycle", function () {
     test("notifies the observation stream when the WebSocket connection closes", function () {

--- a/test/server/deviceTools.startDevice.test.ts
+++ b/test/server/deviceTools.startDevice.test.ts
@@ -277,6 +277,7 @@ describe("startDevice handler", () => {
     expect(resolveDirectSessionDevice("session-1")).toEqual({
       sessionUuid: "session-1",
       device: androidDevice,
+      incarnation: expect.any(Number),
     });
   });
 

--- a/test/server/deviceTools.teardownDevice.test.ts
+++ b/test/server/deviceTools.teardownDevice.test.ts
@@ -409,6 +409,7 @@ describe("deleteDevice handler", () => {
     expect(resolveDirectSessionDevice("physical-session")).toEqual({
       sessionUuid: "physical-session",
       device: physicalDevice,
+      incarnation: expect.any(Number),
     });
   });
 

--- a/test/server/observationResources.test.ts
+++ b/test/server/observationResources.test.ts
@@ -207,9 +207,7 @@ describe("session screenshot resources", () => {
       createScreenshotService: () => createTrackedScreenshot({ success: false }),
     });
 
-    const content = await readTemplate(
-      "automobile:device-session/session-123/screenshot",
-    );
+    const content = await readTemplate("automobile:device-session/session-123/screenshot");
 
     expect(content.mimeType).toBe("application/json");
     expect(JSON.parse(content.text!)).toEqual({
@@ -229,10 +227,9 @@ describe("session screenshot resources", () => {
       },
     });
 
-    const content = await readTemplate(
-      "automobile:device-session/session-123/screenshot",
-      { releasedSessionUuid: sessionUuid },
-    );
+    const content = await readTemplate("automobile:device-session/session-123/screenshot", {
+      releasedSessionUuid: sessionUuid,
+    });
 
     expect(JSON.parse(content.text!).error).toContain("bound device session");
     expect(screenshotServiceCalls).toBe(0);
@@ -241,15 +238,14 @@ describe("session screenshot resources", () => {
   test("returns a typed retryable failure when fresh screenshot capture fails", async () => {
     setSessionScreenshotResourceDependencies({
       resolveActiveSession: () => activeSession(),
-      createScreenshotService: () => createTrackedScreenshot({
-        success: false,
-        error: "ADB screencap timed out",
-      }),
+      createScreenshotService: () =>
+        createTrackedScreenshot({
+          success: false,
+          error: "ADB screencap timed out",
+        }),
     });
 
-    const content = await readTemplate(
-      "automobile:device-session/session-123/screenshot",
-    );
+    const content = await readTemplate("automobile:device-session/session-123/screenshot");
 
     expect(content.mimeType).toBe("application/json");
     expect(JSON.parse(content.text!)).toEqual({
@@ -264,16 +260,17 @@ describe("session screenshot resources", () => {
     controller.abort();
     setSessionScreenshotResourceDependencies({
       resolveActiveSession: () => activeSession(),
-      createScreenshotService: () => createTrackedScreenshot({
-        success: false,
-        error: OPERATION_CANCELLED_MESSAGE,
-      }),
+      createScreenshotService: () =>
+        createTrackedScreenshot({
+          success: false,
+          error: OPERATION_CANCELLED_MESSAGE,
+        }),
     });
 
-    const content = await readTemplate(
-      "automobile:device-session/session-123/screenshot",
-      { sessionUuid, signal: controller.signal },
-    );
+    const content = await readTemplate("automobile:device-session/session-123/screenshot", {
+      sessionUuid,
+      signal: controller.signal,
+    });
 
     expect(JSON.parse(content.text!)).toEqual({
       code: "SCREENSHOT_CAPTURE_CANCELLED",
@@ -285,10 +282,11 @@ describe("session screenshot resources", () => {
   test("returns a typed non-retryable failure when the fresh screenshot cannot be read", async () => {
     setSessionScreenshotResourceDependencies({
       resolveActiveSession: () => activeSession(),
-      createScreenshotService: () => createTrackedScreenshot({
-        success: true,
-        path: "/tmp/fresh.png",
-      }),
+      createScreenshotService: () =>
+        createTrackedScreenshot({
+          success: true,
+          path: "/tmp/fresh.png",
+        }),
     });
     setScreenshotFileSystem({
       stat: async () => ({ isFile: () => true }),
@@ -297,39 +295,39 @@ describe("session screenshot resources", () => {
       },
     });
 
-    const content = await readTemplate(
-      "automobile:device-session/session-123/screenshot",
-    );
+    const content = await readTemplate("automobile:device-session/session-123/screenshot");
 
     expect(JSON.parse(content.text!)).toEqual({
       code: "SCREENSHOT_READ_FAILED",
       retryable: false,
-      error: "Failed to read fresh screenshot for sessionUuid session-123: EACCES: permission denied",
+      error:
+        "Failed to read fresh screenshot for sessionUuid session-123: EACCES: permission denied",
     });
   });
 
   test("does not return a PNG when cancellation occurs while reading the fresh screenshot", async () => {
     const controller = new AbortController();
     let resolveRead: (image: Buffer) => void = () => {};
-    const pendingRead = new Promise<Buffer>(resolve => {
+    const pendingRead = new Promise<Buffer>((resolve) => {
       resolveRead = resolve;
     });
     setSessionScreenshotResourceDependencies({
       resolveActiveSession: () => activeSession(),
-      createScreenshotService: () => createTrackedScreenshot({
-        success: true,
-        path: "/tmp/fresh.png",
-      }),
+      createScreenshotService: () =>
+        createTrackedScreenshot({
+          success: true,
+          path: "/tmp/fresh.png",
+        }),
     });
     setScreenshotFileSystem({
       stat: async () => ({ isFile: () => true }),
       readFile: () => pendingRead,
     });
 
-    const readPromise = readTemplate(
-      "automobile:device-session/session-123/screenshot",
-      { sessionUuid, signal: controller.signal },
-    );
+    const readPromise = readTemplate("automobile:device-session/session-123/screenshot", {
+      sessionUuid,
+      signal: controller.signal,
+    });
     controller.abort();
     resolveRead(Buffer.from("fresh"));
 
@@ -342,24 +340,23 @@ describe("session screenshot resources", () => {
   test("does not return a PNG when ownership is lost while reading the fresh screenshot", async () => {
     let owned = true;
     let resolveRead: (image: Buffer) => void = () => {};
-    const pendingRead = new Promise<Buffer>(resolve => {
+    const pendingRead = new Promise<Buffer>((resolve) => {
       resolveRead = resolve;
     });
     setSessionScreenshotResourceDependencies({
-      resolveActiveSession: () => owned ? activeSession() : undefined,
-      createScreenshotService: () => createTrackedScreenshot({
-        success: true,
-        path: "/tmp/fresh.png",
-      }),
+      resolveActiveSession: () => (owned ? activeSession() : undefined),
+      createScreenshotService: () =>
+        createTrackedScreenshot({
+          success: true,
+          path: "/tmp/fresh.png",
+        }),
     });
     setScreenshotFileSystem({
       stat: async () => ({ isFile: () => true }),
       readFile: () => pendingRead,
     });
 
-    const readPromise = readTemplate(
-      "automobile:device-session/session-123/screenshot",
-    );
+    const readPromise = readTemplate("automobile:device-session/session-123/screenshot");
     owned = false;
     resolveRead(Buffer.from("fresh"));
 
@@ -471,6 +468,7 @@ describe("session screenshot resources", () => {
     expect(resolveDirectSessionDevice("session-new")).toEqual({
       sessionUuid: "session-new",
       device: sessionDevice,
+      incarnation: expect.any(Number),
     });
   });
 });

--- a/test/server/observationResources.test.ts
+++ b/test/server/observationResources.test.ts
@@ -200,6 +200,45 @@ describe("session screenshot resources", () => {
     });
   });
 
+  test("returns a typed non-retryable failure when no fresh screenshot session is active", async () => {
+    setSessionScreenshotResourceDependencies({
+      resolveActiveSession: () => undefined,
+      createScreenshotService: () => createTrackedScreenshot({ success: false }),
+    });
+
+    const content = await readTemplate(
+      "automobile:device-session/session-123/screenshot",
+    );
+
+    expect(content.mimeType).toBe("application/json");
+    expect(JSON.parse(content.text!)).toEqual({
+      code: "SESSION_NOT_ACTIVE",
+      retryable: false,
+      error: "No active device session found for sessionUuid session-123.",
+    });
+  });
+
+  test("returns a typed retryable failure when fresh screenshot capture fails", async () => {
+    setSessionScreenshotResourceDependencies({
+      resolveActiveSession: () => activeSession(),
+      createScreenshotService: () => createTrackedScreenshot({
+        success: false,
+        error: "ADB screencap timed out",
+      }),
+    });
+
+    const content = await readTemplate(
+      "automobile:device-session/session-123/screenshot",
+    );
+
+    expect(content.mimeType).toBe("application/json");
+    expect(JSON.parse(content.text!)).toEqual({
+      code: "SCREENSHOT_CAPTURE_FAILED",
+      retryable: true,
+      error: "ADB screencap timed out",
+    });
+  });
+
   test("waits for a pending capture before taking a distinct fresh capture", async () => {
     let resolvePendingCapture: (result: ScreenshotResult) => void = () => {};
     const pendingCapture = new Promise<ScreenshotResult>((resolve) => {
@@ -287,7 +326,11 @@ describe("session screenshot resources", () => {
     const content = await readTemplate("automobile:device-session/session-123/screenshot");
 
     expect(content.mimeType).toBe("application/json");
-    expect(JSON.parse(content.text!).error).toContain("No active device session found");
+    expect(JSON.parse(content.text!)).toEqual({
+      code: "SESSION_OWNERSHIP_LOST",
+      retryable: false,
+      error: "Device session ownership was lost while capturing a fresh screenshot.",
+    });
   });
 
   test("replaces an older direct session for the same device", () => {

--- a/test/server/observationResources.test.ts
+++ b/test/server/observationResources.test.ts
@@ -308,6 +308,67 @@ describe("session screenshot resources", () => {
     });
   });
 
+  test("does not return a PNG when cancellation occurs while reading the fresh screenshot", async () => {
+    const controller = new AbortController();
+    let resolveRead: (image: Buffer) => void = () => {};
+    const pendingRead = new Promise<Buffer>(resolve => {
+      resolveRead = resolve;
+    });
+    setSessionScreenshotResourceDependencies({
+      resolveActiveSession: () => activeSession(),
+      createScreenshotService: () => createTrackedScreenshot({
+        success: true,
+        path: "/tmp/fresh.png",
+      }),
+    });
+    setScreenshotFileSystem({
+      stat: async () => ({ isFile: () => true }),
+      readFile: () => pendingRead,
+    });
+
+    const readPromise = readTemplate(
+      "automobile:device-session/session-123/screenshot",
+      { sessionUuid, signal: controller.signal },
+    );
+    controller.abort();
+    resolveRead(Buffer.from("fresh"));
+
+    expect(JSON.parse((await readPromise).text!)).toMatchObject({
+      code: "SCREENSHOT_CAPTURE_CANCELLED",
+      retryable: false,
+    });
+  });
+
+  test("does not return a PNG when ownership is lost while reading the fresh screenshot", async () => {
+    let owned = true;
+    let resolveRead: (image: Buffer) => void = () => {};
+    const pendingRead = new Promise<Buffer>(resolve => {
+      resolveRead = resolve;
+    });
+    setSessionScreenshotResourceDependencies({
+      resolveActiveSession: () => owned ? activeSession() : undefined,
+      createScreenshotService: () => createTrackedScreenshot({
+        success: true,
+        path: "/tmp/fresh.png",
+      }),
+    });
+    setScreenshotFileSystem({
+      stat: async () => ({ isFile: () => true }),
+      readFile: () => pendingRead,
+    });
+
+    const readPromise = readTemplate(
+      "automobile:device-session/session-123/screenshot",
+    );
+    owned = false;
+    resolveRead(Buffer.from("fresh"));
+
+    expect(JSON.parse((await readPromise).text!)).toMatchObject({
+      code: "SESSION_OWNERSHIP_LOST",
+      retryable: false,
+    });
+  });
+
   test("waits for a pending capture before taking a distinct fresh capture", async () => {
     let resolvePendingCapture: (result: ScreenshotResult) => void = () => {};
     const pendingCapture = new Promise<ScreenshotResult>((resolve) => {

--- a/test/server/observationResources.test.ts
+++ b/test/server/observationResources.test.ts
@@ -5,6 +5,7 @@ import type { TrackedScreenshotService } from "../../src/features/observe/screen
 import type { ScreenshotJobOptions } from "../../src/utils/ScreenshotJobTracker";
 import { RealObserveScreen } from "../../src/features/observe/ObserveScreen";
 import { ScreenshotJobTracker } from "../../src/utils/ScreenshotJobTracker";
+import { OPERATION_CANCELLED_MESSAGE } from "../../src/utils/constants";
 import {
   RESOURCE_URIS,
   registerObservationResources,
@@ -236,6 +237,55 @@ describe("session screenshot resources", () => {
       code: "SCREENSHOT_CAPTURE_FAILED",
       retryable: true,
       error: "ADB screencap timed out",
+    });
+  });
+
+  test("returns a typed non-retryable failure when fresh screenshot capture is cancelled", async () => {
+    const controller = new AbortController();
+    controller.abort();
+    setSessionScreenshotResourceDependencies({
+      resolveActiveSession: () => activeSession(),
+      createScreenshotService: () => createTrackedScreenshot({
+        success: false,
+        error: OPERATION_CANCELLED_MESSAGE,
+      }),
+    });
+
+    const content = await readTemplate(
+      "automobile:device-session/session-123/screenshot",
+      { sessionUuid, signal: controller.signal },
+    );
+
+    expect(JSON.parse(content.text!)).toEqual({
+      code: "SCREENSHOT_CAPTURE_CANCELLED",
+      retryable: false,
+      error: OPERATION_CANCELLED_MESSAGE,
+    });
+  });
+
+  test("returns a typed non-retryable failure when the fresh screenshot cannot be read", async () => {
+    setSessionScreenshotResourceDependencies({
+      resolveActiveSession: () => activeSession(),
+      createScreenshotService: () => createTrackedScreenshot({
+        success: true,
+        path: "/tmp/fresh.png",
+      }),
+    });
+    setScreenshotFileSystem({
+      stat: async () => ({ isFile: () => true }),
+      readFile: async () => {
+        throw new Error("EACCES: permission denied");
+      },
+    });
+
+    const content = await readTemplate(
+      "automobile:device-session/session-123/screenshot",
+    );
+
+    expect(JSON.parse(content.text!)).toEqual({
+      code: "SCREENSHOT_READ_FAILED",
+      retryable: false,
+      error: "Failed to read fresh screenshot for sessionUuid session-123: EACCES: permission denied",
     });
   });
 

--- a/test/server/observationResources.test.ts
+++ b/test/server/observationResources.test.ts
@@ -219,6 +219,25 @@ describe("session screenshot resources", () => {
     });
   });
 
+  test("does not authorize a replacement session from a released session identity", async () => {
+    let screenshotServiceCalls = 0;
+    setSessionScreenshotResourceDependencies({
+      resolveActiveSession: () => activeSession(),
+      createScreenshotService: () => {
+        screenshotServiceCalls++;
+        return createTrackedScreenshot({ success: true, path: "/tmp/fresh.png" });
+      },
+    });
+
+    const content = await readTemplate(
+      "automobile:device-session/session-123/screenshot",
+      { releasedSessionUuid: sessionUuid },
+    );
+
+    expect(JSON.parse(content.text!).error).toContain("bound device session");
+    expect(screenshotServiceCalls).toBe(0);
+  });
+
   test("returns a typed retryable failure when fresh screenshot capture fails", async () => {
     setSessionScreenshotResourceDependencies({
       resolveActiveSession: () => activeSession(),

--- a/test/server/planReleaseTransportBindingTeardown.test.ts
+++ b/test/server/planReleaseTransportBindingTeardown.test.ts
@@ -60,7 +60,10 @@ describe("createMcpServer server-side session-binding teardown (issue #4611 Gap 
       },
     });
     fixture = new McpTestFixture({
-      sessionContext: { sessionId: "transport-resource", initialSessionToolBinding: RELEASED_SESSION },
+      sessionContext: {
+        sessionId: "transport-resource",
+        initialSessionToolBinding: RELEASED_SESSION,
+      },
     });
     await fixture.setup();
     const { client } = fixture.getContext();

--- a/test/server/planReleaseTransportBindingTeardown.test.ts
+++ b/test/server/planReleaseTransportBindingTeardown.test.ts
@@ -2,6 +2,10 @@ import { afterEach, describe, expect, test } from "bun:test";
 import { McpTestFixture } from "../fixtures/mcpTestFixture";
 import { SessionReleaseBroadcaster } from "../../src/server/sessionReleaseBroadcast";
 import type { ToolCapability } from "../../src/features/toolSelection/SessionToolSelectionService";
+import {
+  resetSessionScreenshotResourceDependencies,
+  setSessionScreenshotResourceDependencies,
+} from "../../src/server/observationResources";
 
 // End-to-end coverage for the server-side SessionToolBinding teardown wired into
 // createMcpServer (issue #4611 Gap D). A transport seeded with a released-able
@@ -18,6 +22,7 @@ describe("createMcpServer server-side session-binding teardown (issue #4611 Gap 
       await fixture.teardown();
       fixture = undefined;
     }
+    resetSessionScreenshotResourceDependencies();
   });
 
   // Narrow the released session so the whole "clipboard" capability is disabled
@@ -45,6 +50,31 @@ describe("createMcpServer server-side session-binding teardown (issue #4611 Gap 
     // The binding is gone, so tools/list reverts to the unbound (unfiltered) surface.
     const after = await client.listTools();
     expect(after.tools.map((tool) => tool.name)).toContain("clipboard");
+  });
+
+  test("a session release preserves typed fresh screenshot failures for the same transport", async () => {
+    setSessionScreenshotResourceDependencies({
+      resolveActiveSession: () => undefined,
+      createScreenshotService: () => {
+        throw new Error("inactive sessions must not capture screenshots");
+      },
+    });
+    fixture = new McpTestFixture({
+      sessionContext: { sessionId: "transport-resource", initialSessionToolBinding: RELEASED_SESSION },
+    });
+    await fixture.setup();
+    const { client } = fixture.getContext();
+
+    SessionReleaseBroadcaster.emit(RELEASED_SESSION);
+
+    const response = await client.readResource({
+      uri: `automobile:device-session/${RELEASED_SESSION}/screenshot`,
+    });
+
+    expect(JSON.parse(response.contents[0].text!)).toMatchObject({
+      code: "SESSION_NOT_ACTIVE",
+      retryable: false,
+    });
   });
 
   test("releasing an unrelated session leaves the bound profile intact", async () => {

--- a/test/server/sessionToolDiscovery.test.ts
+++ b/test/server/sessionToolDiscovery.test.ts
@@ -92,6 +92,22 @@ describe("session-scoped tool discovery", () => {
     expect(binding.effectiveSessionUuid("transport-c")).toBe("session-2");
   });
 
+  test("retains a released session only for its transport's resource reads", () => {
+    const binding = new SessionToolBinding();
+    binding.bind("transport-a", "session-1");
+    binding.bind("transport-b", "session-2");
+
+    expect(binding.unbindSession("session-1")).toBe(true);
+
+    expect(binding.effectiveSessionUuid("transport-a")).toBeUndefined();
+    expect(binding.effectiveResourceSessionUuid("transport-a")).toBe("session-1");
+    expect(binding.effectiveResourceSessionUuid("transport-b")).toBe("session-2");
+
+    binding.bind("transport-a", "session-3");
+
+    expect(binding.effectiveResourceSessionUuid("transport-a")).toBe("session-3");
+  });
+
   test("unbindSession reports no change when nothing matches the released session", () => {
     const binding = new SessionToolBinding();
     binding.bind("transport", "session-1");

--- a/test/server/sessionToolDiscovery.test.ts
+++ b/test/server/sessionToolDiscovery.test.ts
@@ -100,12 +100,12 @@ describe("session-scoped tool discovery", () => {
     expect(binding.unbindSession("session-1")).toBe(true);
 
     expect(binding.effectiveSessionUuid("transport-a")).toBeUndefined();
-    expect(binding.effectiveResourceSessionUuid("transport-a")).toBe("session-1");
-    expect(binding.effectiveResourceSessionUuid("transport-b")).toBe("session-2");
+    expect(binding.releasedResourceSessionUuid("transport-a")).toBe("session-1");
+    expect(binding.releasedResourceSessionUuid("transport-b")).toBeUndefined();
 
     binding.bind("transport-a", "session-3");
 
-    expect(binding.effectiveResourceSessionUuid("transport-a")).toBe("session-3");
+    expect(binding.releasedResourceSessionUuid("transport-a")).toBeUndefined();
   });
 
   test("unbindSession reports no change when nothing matches the released session", () => {


### PR DESCRIPTION
## Summary

Fresh session screenshot reads now return stable JSON failures with `code`, `retryable`, and the underlying `error` reason when PNG cannot be returned. This lets clients distinguish inactive sessions, lost ownership, and retryable capture failures.

## Linked Issue

Closes [#5571](https://github.com/kaeawc/auto-mobile/issues/5571)

## Bug / Regression Context

- **Observed symptom:** an unavailable session or failed capture returned free-form JSON from an image resource, leaving clients with only a MIME mismatch.

## Validation

- [x] `bun test test/server/observationResources.test.ts`
- [x] `bun run turbo:validate`
- [x] `bun run typecheck` (no new errors)
- [x] `scripts/all_fast_validate_checks.sh`
- [x] New code reuses existing dependency injection; focused tests are deterministic and complete in under 100ms.
