### PR TITLE
feat(desktop): show the update affordance on picker/onboarding surfaces (#5271)

### DIFF
--- a/android/desktop-app/src/main/kotlin/dev/jasonpearson/automobile/desktop/AutoMobileDesktopApp.kt
+++ b/android/desktop-app/src/main/kotlin/dev/jasonpearson/automobile/desktop/AutoMobileDesktopApp.kt
@@ -32,6 +32,7 @@ import dev.jasonpearson.automobile.desktop.core.logging.LoggerFactory
 import dev.jasonpearson.automobile.desktop.core.mcp.DaemonMcpResourceClient
 import dev.jasonpearson.automobile.desktop.core.mcp.ResourceReadResult
 import dev.jasonpearson.automobile.desktop.core.settings.SettingsProvider
+import dev.jasonpearson.automobile.desktop.core.shell.FloatingUpdateAffordance
 import dev.jasonpearson.automobile.desktop.core.shell.MenuBarActions
 import dev.jasonpearson.automobile.desktop.core.shell.UpdateDetailsContent
 import dev.jasonpearson.automobile.desktop.core.shell.openReleaseNotesInBrowser
@@ -383,149 +384,186 @@ fun AutoMobileDesktopApp(
       // Device-tab workspace is the desktop app root (replaces ThreePaneShell). AutoMobileContent
       // is retained and still used by the IDE plugin; dashboards return as workspace facets in
       // follow-up PRs. menuBarActions is plumbed for later re-wiring once facets/panes exist.
-      when {
-        showOnboarding ->
-          OnboardingScreen(
-            onGetStarted = {
-              settings.hasSeenOnboarding = true
-              showOnboarding = false
-            }
-          )
-        // The device grid is the home surface whenever nothing is observed (true on launch), and
-        // also whenever "Devices +" explicitly opens it over a live workspace. Observing a device
-        // makes the workspace non-empty, which drops the picker for WorkspaceShell.
-        pickerOpen || workspaceState is WorkspaceUiState.Empty ->
-          DevicePicker(
-            state = pickerState,
-            onAction = pickerViewModel::onAction,
-            onClose = { pickerOpen = false },
-            // Only offer Close when there is an observed workspace to return to.
-            canClose = workspaceState is WorkspaceUiState.Content,
-          )
-        else ->
-          Box(Modifier.fillMaxSize()) {
-            // Roll live connection health up into the top-bar status dot. The daemon signal is
-            // polled here; per-device stream health is not yet fed in — device streams are
-            // facet-owned and carry screenshots, so opening extra status-only streams would be
-            // wasteful. deriveWorkspaceStatus already handles the device dimension, so it can be
-            // fed once a central per-device stream registry exists (follow-up).
-            val workspaceStatus =
-              remember(daemonConnectionState) {
-                deriveWorkspaceStatus(daemon = daemonConnectionState, devices = emptyList())
+      //
+      // The launch surfaces (onboarding + device picker) have no top bar to host the "update ready"
+      // pill, so a user who never observes a device would never see the affordance even though the
+      // startup check already ran (#5271). The workspace keeps its integrated top-bar pill; these
+      // surfaces get a shared floating affordance instead, hosted above the surface switch so it is
+      // reachable from either one. It self-hides unless updateStatus is UpdateAvailable.
+      val onLaunchSurface = showOnboarding || pickerOpen || workspaceState is WorkspaceUiState.Empty
+      Box(Modifier.fillMaxSize()) {
+        when {
+          showOnboarding ->
+            OnboardingScreen(
+              onGetStarted = {
+                settings.hasSeenOnboarding = true
+                showOnboarding = false
               }
-
-            WorkspaceShell(
-              state = workspaceState,
-              onAction = workspaceViewModel::onAction,
-              onOpenPicker = workspaceViewModel::openPicker,
-              onOpenPalette = { paletteOpen = true },
-              status = workspaceStatus.status,
-              statusDetail = workspaceStatus.detail,
-              updateStatus = updateStatus,
-              onUpdateClick = { showUpdateDetails = true },
-              facetContent = { column, tool -> WorkspaceFacet(column, tool) },
-              // Inspect mode's Layout inspector renders live video for its pixels; the session
-              // provider authenticates that subscribe against the stream-socket guard (#4751),
-              // exactly as the stream pane below.
-              inspectContent = { column ->
-                LayoutFacet(
-                  column,
-                  sessionUuidProvider = desktopDaemonSession?.sessionUuidProvider ?: { null },
-                )
-              },
-              // Live device mirror in each pane's stream area, fed by the daemon's video-stream
-              // relay. The pane authenticates with the workspace daemon session (#4977) bound to
-              // the focused device above; when no session is available (non-Unix daemon, or the
-              // bind failed) the provider yields null and the pane shows the auth refusal, with
-              // AUTOMOBILE_DAEMON_STREAM_AUTH=0 as the operator escape hatch.
-              streamContent = { column ->
-                // Tap-to-control is armed ONLY for the FOCUSED pane on a Unix daemon.
-                //  - Unix: the other transports (MCP HTTP/STDIO) don't serve the direct `input/*`
-                //    helpers, so `workspaceControlClientProvider` yields null there and a tap could
-                //    never reach the device — arming would only pay for a High-fps stream + an
-                //    observation stream that drive nothing.
-                //  - Focused: only one pane is being driven at a time. Gating on focus keeps the
-                //    unfocused farm panes as cheap Low-fps mirrors (no per-pane observation stream)
-                //    and means only the focused pane requests Compose keyboard focus, so a second
-                //    pane arming can't silently steal keystrokes mid-type (#5217). Click a pane to
-                //    focus (and thus drive) it; the single-device case is always focused.
-                val controlActive =
-                  graph.autoMobileClient.transportName == "Unix Socket" &&
-                    (workspaceState as? WorkspaceUiState.Content)?.focusedDeviceId ==
-                      column.deviceId
-                val control =
-                  rememberWorkspaceDeviceControl(
-                    column = column,
-                    clientProvider = workspaceControlClientProvider,
-                    enabled = controlActive,
-                  )
-                DeviceStreamView(
-                  column,
-                  sessionUuidProvider = desktopDaemonSession?.sessionUuidProvider ?: { null },
-                  enableDeviceControl = controlActive,
-                  control = control,
-                  // Wires the per-pane quality overlay (manual Low/Medium/High + live FPS +
-                  // auto-adjust) and persists the choice across sessions.
-                  settings = settings,
-                )
-              },
             )
-            if (paletteOpen) {
-              CommandPalette(
-                commands =
-                  buildWorkspaceCommands(
-                    workspaceState,
-                    onOpenPicker = workspaceViewModel::openPicker,
-                    onAction = workspaceViewModel::onAction,
-                  ),
-                onDismiss = { paletteOpen = false },
-              )
-            }
-
-            // Details popup for the top-bar update pill (#5225). `as?` closes it automatically if
-            // the
-            // status leaves UpdateAvailable while open. Applying the update is a later item, so the
-            // install action inside is disabled.
-            val availableUpdate = updateStatus as? UpdateStatus.UpdateAvailable
-            if (showUpdateDetails && availableUpdate != null) {
-              // Anchor the popup under the top-right pill (below the 40dp top bar) rather than the
-              // window's default top-left, so it reads as coming from its trigger.
-              val popupOffset =
-                with(LocalDensity.current) {
-                  IntOffset(x = -8.dp.roundToPx(), y = 44.dp.roundToPx())
+          // The device grid is the home surface whenever nothing is observed (true on launch), and
+          // also whenever "Devices +" explicitly opens it over a live workspace. Observing a device
+          // makes the workspace non-empty, which drops the picker for WorkspaceShell.
+          pickerOpen || workspaceState is WorkspaceUiState.Empty ->
+            DevicePicker(
+              state = pickerState,
+              onAction = pickerViewModel::onAction,
+              onClose = { pickerOpen = false },
+              // Only offer Close when there is an observed workspace to return to.
+              canClose = workspaceState is WorkspaceUiState.Content,
+            )
+          else ->
+            Box(Modifier.fillMaxSize()) {
+              // Roll live connection health up into the top-bar status dot. The daemon signal is
+              // polled here; per-device stream health is not yet fed in — device streams are
+              // facet-owned and carry screenshots, so opening extra status-only streams would be
+              // wasteful. deriveWorkspaceStatus already handles the device dimension, so it can be
+              // fed once a central per-device stream registry exists (follow-up).
+              val workspaceStatus =
+                remember(daemonConnectionState) {
+                  deriveWorkspaceStatus(daemon = daemonConnectionState, devices = emptyList())
                 }
-              Popup(
-                alignment = Alignment.TopEnd,
-                offset = popupOffset,
-                onDismissRequest = { showUpdateDetails = false },
-                properties = PopupProperties(focusable = true),
-              ) {
-                Surface(
-                  shape = RoundedCornerShape(6.dp),
-                  color = MaterialTheme.colorScheme.surface,
-                  shadowElevation = 8.dp,
-                ) {
-                  UpdateDetailsContent(
-                    update = availableUpdate,
-                    currentVersion = graph.appVersionProvider.current().raw,
-                    onOpenReleaseNotes = {
-                      availableUpdate.releaseNotesUrl?.let { openReleaseNotesInBrowser(it) }
-                    },
-                    // Only a Conveyor package can apply in place; the GitHub path reports false and
-                    // the install action stays disabled. Conveyor tears the app down as it
-                    // restarts,
-                    // so this is the last thing the process does.
-                    onInstall =
-                      if (updateController.canApplyUpdate()) {
-                        { scope.launch { updateController.applyUpdate() } }
-                      } else {
-                        null
-                      },
+
+              WorkspaceShell(
+                state = workspaceState,
+                onAction = workspaceViewModel::onAction,
+                onOpenPicker = workspaceViewModel::openPicker,
+                onOpenPalette = { paletteOpen = true },
+                status = workspaceStatus.status,
+                statusDetail = workspaceStatus.detail,
+                updateStatus = updateStatus,
+                onUpdateClick = { showUpdateDetails = true },
+                facetContent = { column, tool -> WorkspaceFacet(column, tool) },
+                // Inspect mode's Layout inspector renders live video for its pixels; the session
+                // provider authenticates that subscribe against the stream-socket guard (#4751),
+                // exactly as the stream pane below.
+                inspectContent = { column ->
+                  LayoutFacet(
+                    column,
+                    sessionUuidProvider = desktopDaemonSession?.sessionUuidProvider ?: { null },
                   )
+                },
+                // Live device mirror in each pane's stream area, fed by the daemon's video-stream
+                // relay. The pane authenticates with the workspace daemon session (#4977) bound to
+                // the focused device above; when no session is available (non-Unix daemon, or the
+                // bind failed) the provider yields null and the pane shows the auth refusal, with
+                // AUTOMOBILE_DAEMON_STREAM_AUTH=0 as the operator escape hatch.
+                streamContent = { column ->
+                  // Tap-to-control is armed ONLY for the FOCUSED pane on a Unix daemon.
+                  //  - Unix: the other transports (MCP HTTP/STDIO) don't serve the direct `input/*`
+                  //    helpers, so `workspaceControlClientProvider` yields null there and a tap
+                  // could
+                  //    never reach the device — arming would only pay for a High-fps stream + an
+                  //    observation stream that drive nothing.
+                  //  - Focused: only one pane is being driven at a time. Gating on focus keeps the
+                  //    unfocused farm panes as cheap Low-fps mirrors (no per-pane observation
+                  // stream)
+                  //    and means only the focused pane requests Compose keyboard focus, so a second
+                  //    pane arming can't silently steal keystrokes mid-type (#5217). Click a pane
+                  // to
+                  //    focus (and thus drive) it; the single-device case is always focused.
+                  val controlActive =
+                    graph.autoMobileClient.transportName == "Unix Socket" &&
+                      (workspaceState as? WorkspaceUiState.Content)?.focusedDeviceId ==
+                        column.deviceId
+                  val control =
+                    rememberWorkspaceDeviceControl(
+                      column = column,
+                      clientProvider = workspaceControlClientProvider,
+                      enabled = controlActive,
+                    )
+                  DeviceStreamView(
+                    column,
+                    sessionUuidProvider = desktopDaemonSession?.sessionUuidProvider ?: { null },
+                    enableDeviceControl = controlActive,
+                    control = control,
+                    // Wires the per-pane quality overlay (manual Low/Medium/High + live FPS +
+                    // auto-adjust) and persists the choice across sessions.
+                    settings = settings,
+                  )
+                },
+              )
+              if (paletteOpen) {
+                CommandPalette(
+                  commands =
+                    buildWorkspaceCommands(
+                      workspaceState,
+                      onOpenPicker = workspaceViewModel::openPicker,
+                      onAction = workspaceViewModel::onAction,
+                    ),
+                  onDismiss = { paletteOpen = false },
+                )
+              }
+
+              // Details popup for the top-bar update pill (#5225). `as?` closes it automatically if
+              // the
+              // status leaves UpdateAvailable while open. Applying the update is a later item, so
+              // the
+              // install action inside is disabled.
+              val availableUpdate = updateStatus as? UpdateStatus.UpdateAvailable
+              if (showUpdateDetails && availableUpdate != null) {
+                // Anchor the popup under the top-right pill (below the 40dp top bar) rather than
+                // the
+                // window's default top-left, so it reads as coming from its trigger.
+                val popupOffset =
+                  with(LocalDensity.current) {
+                    IntOffset(x = -8.dp.roundToPx(), y = 44.dp.roundToPx())
+                  }
+                Popup(
+                  alignment = Alignment.TopEnd,
+                  offset = popupOffset,
+                  onDismissRequest = { showUpdateDetails = false },
+                  properties = PopupProperties(focusable = true),
+                ) {
+                  Surface(
+                    shape = RoundedCornerShape(6.dp),
+                    color = MaterialTheme.colorScheme.surface,
+                    shadowElevation = 8.dp,
+                  ) {
+                    UpdateDetailsContent(
+                      update = availableUpdate,
+                      currentVersion = graph.appVersionProvider.current().raw,
+                      onOpenReleaseNotes = {
+                        availableUpdate.releaseNotesUrl?.let { openReleaseNotesInBrowser(it) }
+                      },
+                      // Only a Conveyor package can apply in place; the GitHub path reports false
+                      // and
+                      // the install action stays disabled. Conveyor tears the app down as it
+                      // restarts,
+                      // so this is the last thing the process does.
+                      onInstall =
+                        if (updateController.canApplyUpdate()) {
+                          { scope.launch { updateController.applyUpdate() } }
+                        } else {
+                          null
+                        },
+                    )
+                  }
                 }
               }
             }
-          }
+        }
+
+        // Shared floating "update ready" affordance for the launch surfaces (#5271). Clicking it
+        // opens the same UpdateDetailsContent the workspace pill uses, wired to apply-in-place only
+        // when the packaging supports it (canApplyUpdate) — the GitHub-Releases path leaves the
+        // install action disabled until the apply item (#5226) lands.
+        if (onLaunchSurface) {
+          FloatingUpdateAffordance(
+            status = updateStatus,
+            currentVersion = graph.appVersionProvider.current().raw,
+            onOpenReleaseNotes = {
+              (updateStatus as? UpdateStatus.UpdateAvailable)?.releaseNotesUrl?.let {
+                openReleaseNotesInBrowser(it)
+              }
+            },
+            onInstall =
+              if (updateController.canApplyUpdate()) {
+                { scope.launch { updateController.applyUpdate() } }
+              } else {
+                null
+              },
+          )
+        }
       }
     }
   }

--- a/android/desktop-core/src/main/kotlin/dev/jasonpearson/automobile/desktop/core/shell/UpdateReadyButton.kt
+++ b/android/desktop-core/src/main/kotlin/dev/jasonpearson/automobile/desktop/core/shell/UpdateReadyButton.kt
@@ -3,9 +3,11 @@ package dev.jasonpearson.automobile.desktop.core.shell
 import androidx.compose.foundation.background
 import androidx.compose.foundation.clickable
 import androidx.compose.foundation.layout.Arrangement
+import androidx.compose.foundation.layout.Box
 import androidx.compose.foundation.layout.Column
 import androidx.compose.foundation.layout.Row
 import androidx.compose.foundation.layout.Spacer
+import androidx.compose.foundation.layout.fillMaxSize
 import androidx.compose.foundation.layout.padding
 import androidx.compose.foundation.layout.width
 import androidx.compose.foundation.shape.RoundedCornerShape
@@ -14,9 +16,14 @@ import androidx.compose.material.icons.filled.Download
 import androidx.compose.material.icons.filled.SystemUpdateAlt
 import androidx.compose.material3.Icon
 import androidx.compose.material3.MaterialTheme
+import androidx.compose.material3.Surface
 import androidx.compose.material3.Text
 import androidx.compose.material3.TextButton
 import androidx.compose.runtime.Composable
+import androidx.compose.runtime.getValue
+import androidx.compose.runtime.mutableStateOf
+import androidx.compose.runtime.remember
+import androidx.compose.runtime.setValue
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.draw.clip
@@ -121,6 +128,60 @@ fun UpdateDetailsContent(
         Spacer(Modifier.width(4.dp))
         Text("Install & restart")
       }
+    }
+  }
+}
+
+/**
+ * A self-contained "update ready" affordance for the surfaces that have no top bar to host the pill
+ * — the device picker and onboarding (#5271). The workspace keeps its integrated top-bar pill
+ * (#5225 maintainer decision); this gives the launch surfaces the same reachability so a user who
+ * never observes a device still sees that an update is waiting.
+ *
+ * It overlays a [fillMaxSize] parent and pins itself to the bottom-end corner, clear of the
+ * picker's title (top-start) and Close control (top-end) and of onboarding's centered column — so
+ * placement is intentional and collision-free rather than fighting per-surface chrome. Clicking the
+ * pill toggles the same [UpdateDetailsContent] used by the workspace popup, expanded just above the
+ * pill.
+ *
+ * Pure: it renders from [status] and the passed callbacks and owns only its local expand/collapse
+ * state; nothing is silenced unless [status] is not [UpdateStatus.UpdateAvailable].
+ */
+@Composable
+fun FloatingUpdateAffordance(
+  status: UpdateStatus,
+  currentVersion: String,
+  onOpenReleaseNotes: () -> Unit,
+  modifier: Modifier = Modifier,
+  onInstall: (() -> Unit)? = null,
+) {
+  // Only a genuine update surfaces the affordance; every other state renders nothing at all.
+  val update = status as? UpdateStatus.UpdateAvailable ?: return
+  var showDetails by remember { mutableStateOf(false) }
+
+  Box(modifier = modifier.fillMaxSize()) {
+    Column(
+      modifier = Modifier.align(Alignment.BottomEnd).padding(16.dp),
+      horizontalAlignment = Alignment.End,
+      verticalArrangement = Arrangement.spacedBy(8.dp),
+    ) {
+      // The details card expands directly above the pill so the affordance reads as one control
+      // anchored to its trigger, rather than a popup floating in from a window corner.
+      if (showDetails) {
+        Surface(
+          shape = RoundedCornerShape(6.dp),
+          color = MaterialTheme.colorScheme.surface,
+          shadowElevation = 8.dp,
+        ) {
+          UpdateDetailsContent(
+            update = update,
+            currentVersion = currentVersion,
+            onOpenReleaseNotes = onOpenReleaseNotes,
+            onInstall = onInstall,
+          )
+        }
+      }
+      UpdateReadyButton(status = update, onClick = { showDetails = !showDetails })
     }
   }
 }

--- a/android/desktop-core/src/test/kotlin/dev/jasonpearson/automobile/desktop/core/shell/FloatingUpdateAffordanceUiTest.kt
+++ b/android/desktop-core/src/test/kotlin/dev/jasonpearson/automobile/desktop/core/shell/FloatingUpdateAffordanceUiTest.kt
@@ -1,0 +1,140 @@
+package dev.jasonpearson.automobile.desktop.core.shell
+
+import androidx.compose.material3.MaterialTheme
+import androidx.compose.ui.test.ExperimentalTestApi
+import androidx.compose.ui.test.assertIsDisplayed
+import androidx.compose.ui.test.assertIsEnabled
+import androidx.compose.ui.test.assertIsNotEnabled
+import androidx.compose.ui.test.onNodeWithText
+import androidx.compose.ui.test.performClick
+import androidx.compose.ui.test.runComposeUiTest
+import dev.jasonpearson.automobile.desktop.core.update.ReleaseAsset
+import dev.jasonpearson.automobile.desktop.core.update.UpdateStatus
+import kotlin.test.assertEquals
+import org.junit.Test
+
+/**
+ * Covers the launch-surface (device-picker / onboarding) update affordance (#5271). The affordance
+ * is the only "update ready" surface those screens have — the workspace hosts its own top-bar pill
+ * — so these tests pin the behavior the picker/onboarding path relies on.
+ */
+@OptIn(ExperimentalTestApi::class)
+class FloatingUpdateAffordanceUiTest {
+
+  private val available =
+    UpdateStatus.UpdateAvailable(
+      version = "0.0.53",
+      asset = ReleaseAsset("AutoMobile-0.0.53-macos.dmg", "https://x/dmg", 10),
+      releaseNotesUrl = "https://notes",
+    )
+
+  @Test
+  fun `affordance is shown on a launch surface when an update is available`() = runComposeUiTest {
+    setContent {
+      MaterialTheme {
+        FloatingUpdateAffordance(
+          status = available,
+          currentVersion = "0.0.52",
+          onOpenReleaseNotes = {},
+        )
+      }
+    }
+    onNodeWithText("Update ready").assertIsDisplayed()
+  }
+
+  @Test
+  fun `affordance is hidden for non-available states`() {
+    for (status in
+      listOf(
+        UpdateStatus.Idle,
+        UpdateStatus.Checking,
+        UpdateStatus.UpToDate,
+        UpdateStatus.Failed("boom"),
+      )) {
+      runComposeUiTest {
+        setContent {
+          MaterialTheme {
+            FloatingUpdateAffordance(
+              status = status,
+              currentVersion = "0.0.52",
+              onOpenReleaseNotes = {},
+            )
+          }
+        }
+        onNodeWithText("Update ready").assertDoesNotExist()
+      }
+    }
+  }
+
+  @Test
+  fun `details are collapsed until the pill is clicked`() = runComposeUiTest {
+    setContent {
+      MaterialTheme {
+        FloatingUpdateAffordance(
+          status = available,
+          currentVersion = "0.0.52",
+          onOpenReleaseNotes = {},
+        )
+      }
+    }
+    // Before any click the details surface is not present, only the pill.
+    onNodeWithText("is available", substring = true).assertDoesNotExist()
+    onNodeWithText("Update ready").performClick()
+    // Clicking opens the same details content: available + current version and the notes link.
+    onNodeWithText("0.0.53", substring = true).assertIsDisplayed()
+    onNodeWithText("0.0.52", substring = true).assertIsDisplayed()
+    onNodeWithText("Release notes", substring = true).assertIsDisplayed()
+  }
+
+  @Test
+  fun `clicking release notes invokes the callback`() = runComposeUiTest {
+    var opened = 0
+    setContent {
+      MaterialTheme {
+        FloatingUpdateAffordance(
+          status = available,
+          currentVersion = "0.0.52",
+          onOpenReleaseNotes = { opened++ },
+        )
+      }
+    }
+    onNodeWithText("Update ready").performClick()
+    onNodeWithText("Release notes", substring = true).performClick()
+    assertEquals(1, opened)
+  }
+
+  @Test
+  fun `install action is disabled until an apply callback is supplied`() = runComposeUiTest {
+    setContent {
+      MaterialTheme {
+        FloatingUpdateAffordance(
+          status = available,
+          currentVersion = "0.0.52",
+          onOpenReleaseNotes = {},
+          // onInstall defaults to null (the GitHub-Releases path; apply lands in #5226).
+        )
+      }
+    }
+    onNodeWithText("Update ready").performClick()
+    onNodeWithText("Install", substring = true).assertIsNotEnabled()
+  }
+
+  @Test
+  fun `install action is enabled and invokes the callback when supplied`() = runComposeUiTest {
+    var installs = 0
+    setContent {
+      MaterialTheme {
+        FloatingUpdateAffordance(
+          status = available,
+          currentVersion = "0.0.52",
+          onOpenReleaseNotes = {},
+          onInstall = { installs++ },
+        )
+      }
+    }
+    onNodeWithText("Update ready").performClick()
+    onNodeWithText("Install", substring = true).assertIsEnabled()
+    onNodeWithText("Install", substring = true).performClick()
+    assertEquals(1, installs)
+  }
+}


### PR DESCRIPTION
## Summary

Follow-up from [#5225](https://github.com/kaeawc/auto-mobile/pull/5264) (raised as Codex P1 in review of PR #5264). The desktop "update ready" pill was rendered only in the **WorkspaceShell top bar**, so it appeared only once a device is observed. A user who stayed on the **device picker** or **onboarding** surface — the launch surface when no device is observed — never saw the affordance, even though the startup update check had already run and `UpdateController` reported `UpdateAvailable`. The startup check is correctly hoisted above the surface switch in `AutoMobileDesktopApp`, so the state was already available on every surface; only the *presentation* was workspace-only.

## What changed

- **New `FloatingUpdateAffordance`** (`desktop-core` `core/shell/UpdateReadyButton.kt`) — a self-contained, pure composable that renders the existing `UpdateReadyButton` pill and toggles the existing `UpdateDetailsContent` on click. It self-hides unless `status is UpdateAvailable`.
- **Hosted above the root surface switch** in `AutoMobileDesktopApp`: the `when {}` is wrapped in a `Box`, and the affordance is rendered for the launch surfaces (`showOnboarding || pickerOpen || Empty`). The **workspace keeps its integrated top-bar pill** (the #5225 maintainer decision), so there is exactly one affordance per surface — no duplicate pill on the workspace.

## Acceptance criteria

1. ✅ When `UpdateController.status` is `UpdateAvailable`, the affordance is reachable on the device-picker and onboarding surfaces too (not only the workspace top bar).
2. ✅ Clicking it opens the same details surface — new version, current version, release-notes link, and a disabled install action (enabled only when the packaging can apply in place via `canApplyUpdate()`; the GitHub-Releases path leaves it disabled until the apply item #5226 lands).
3. ✅ Placement is intentional/consistent: the workspace keeps its top-bar pill; the launch surfaces get a shared floating affordance pinned to the **bottom-end** corner — clear of the picker's title (top-start) and Close control (top-end) and of onboarding's centered column, so it never fights per-surface chrome.
4. ✅ Tests cover the picker/onboarding affordance (`FloatingUpdateAffordanceUiTest`), not only `WorkspaceShell`.

## Design note

AC3 offered a choice between "a shared floating affordance above the root surface switch" and "per-surface chrome." I chose the **shared floating affordance**, gated to the launch surfaces only, because the workspace already hosts the pill in its top bar (#5225) and a second pill there would be redundant. Bottom-end placement was chosen over top-end because the picker's `HeaderRow` already occupies both top corners (title + Close).

## Testing

- `FloatingUpdateAffordanceUiTest` (6 cases): affordance shown only on `UpdateAvailable`; hidden for Idle/Checking/UpToDate/Failed; details collapsed until clicked then showing available+current version and the notes link; release-notes callback fires; install disabled without an apply callback and enabled/invoked with one.
- `:desktop-core:test` (shell) green, `:desktop-app:compileKotlin` green, `ktfmt --google-style` clean, `:desktop-core:detekt` + `:desktop-app:detekt` clean.

The app-level `onLaunchSurface` gating in `AutoMobileDesktopApp` is a thin conditional over DI-graph state and is not independently unit-tested — consistent with the existing workspace pill, whose behavior is likewise covered at the component level (`UpdateReadyButtonUiTest`) rather than app-level. The reusable `FloatingUpdateAffordance` is the component that renders exclusively on those surfaces, so its test pins the launch-surface behavior.

Closes #5271

🤖 Generated with [Claude Code](https://claude.com/claude-code)