### PR TITLE
fix(ios): discover & activate UIKit inline semantic links (#5560)

### DIFF
--- a/ios/auto-mobile-sdk/Sources/AutoMobileSDK/ViewHierarchy/SdkViewNode.swift
+++ b/ios/auto-mobile-sdk/Sources/AutoMobileSDK/ViewHierarchy/SdkViewNode.swift
@@ -101,6 +101,12 @@ public struct SdkViewNode: Codable, Sendable {
     public let isUserInteractionEnabled: Bool
     public let hasTapTarget: Bool
     public let isOccluded: Bool
+    /// Inline accessibility links discovered on this text element (issue #5560).
+    /// Non-nil only for text-bearing views (`UITextView`/`UILabel` attributed
+    /// text, or SwiftUI text whose inline links surface as `.link`-trait
+    /// accessibility children). The runner projects these onto the owning
+    /// element's `semantic-links` for Android parity.
+    public let semanticLinks: [SdkSemanticLink]?
     public let children: [SdkViewNode]?
 
     public init(
@@ -124,6 +130,7 @@ public struct SdkViewNode: Codable, Sendable {
         isUserInteractionEnabled: Bool = true,
         hasTapTarget: Bool = false,
         isOccluded: Bool = false,
+        semanticLinks: [SdkSemanticLink]? = nil,
         children: [SdkViewNode]? = nil
     ) {
         self.className = className
@@ -146,6 +153,7 @@ public struct SdkViewNode: Codable, Sendable {
         self.isUserInteractionEnabled = isUserInteractionEnabled
         self.hasTapTarget = hasTapTarget
         self.isOccluded = isOccluded
+        self.semanticLinks = semanticLinks
         self.children = children
     }
 
@@ -155,32 +163,33 @@ public struct SdkViewNode: Codable, Sendable {
              accessibilityTraits, accessibilityCustomActions, gestureRecognizers,
              alpha, backgroundColor, cornerRadius,
              borderColor, borderWidth, isLayerNode,
-             isHidden, isUserInteractionEnabled, hasTapTarget, isOccluded, children
+             isHidden, isUserInteractionEnabled, hasTapTarget, isOccluded, semanticLinks, children
     }
 
     public init(from decoder: Decoder) throws {
         let c = try decoder.container(keyedBy: CodingKeys.self)
-        self.className = try c.decode(String.self, forKey: .className)
-        self.bounds = try c.decode(SdkBounds.self, forKey: .bounds)
-        self.accessibilityLabel = try c.decodeIfPresent(String.self, forKey: .accessibilityLabel)
-        self.accessibilityIdentifier = try c.decodeIfPresent(String.self, forKey: .accessibilityIdentifier)
-        self.isAccessibilityElement = try c.decodeIfPresent(Bool.self, forKey: .isAccessibilityElement) ?? false
-        self.isAccessibilityFocused = try c.decodeIfPresent(Bool.self, forKey: .isAccessibilityFocused) ?? false
-        self.accessibilityElementsHidden = try c.decodeIfPresent(Bool.self, forKey: .accessibilityElementsHidden) ?? false
-        self.accessibilityTraits = try c.decodeIfPresent([String].self, forKey: .accessibilityTraits) ?? []
-        self.accessibilityCustomActions = try c.decodeIfPresent([String].self, forKey: .accessibilityCustomActions) ?? []
-        self.gestureRecognizers = try c.decodeIfPresent([SdkGestureInfo].self, forKey: .gestureRecognizers) ?? []
-        self.alpha = try c.decodeIfPresent(Float.self, forKey: .alpha) ?? 1.0
-        self.backgroundColor = try c.decodeIfPresent(String.self, forKey: .backgroundColor)
-        self.cornerRadius = try c.decodeIfPresent(Float.self, forKey: .cornerRadius) ?? 0
-        self.borderColor = try c.decodeIfPresent(String.self, forKey: .borderColor)
-        self.borderWidth = try c.decodeIfPresent(Float.self, forKey: .borderWidth) ?? 0
-        self.isLayerNode = try c.decodeIfPresent(Bool.self, forKey: .isLayerNode) ?? false
-        self.isHidden = try c.decodeIfPresent(Bool.self, forKey: .isHidden) ?? false
-        self.isUserInteractionEnabled = try c.decodeIfPresent(Bool.self, forKey: .isUserInteractionEnabled) ?? true
-        self.hasTapTarget = try c.decodeIfPresent(Bool.self, forKey: .hasTapTarget) ?? false
-        self.isOccluded = try c.decodeIfPresent(Bool.self, forKey: .isOccluded) ?? false
-        self.children = try c.decodeIfPresent([SdkViewNode].self, forKey: .children)
+        className = try c.decode(String.self, forKey: .className)
+        bounds = try c.decode(SdkBounds.self, forKey: .bounds)
+        accessibilityLabel = try c.decodeIfPresent(String.self, forKey: .accessibilityLabel)
+        accessibilityIdentifier = try c.decodeIfPresent(String.self, forKey: .accessibilityIdentifier)
+        isAccessibilityElement = try c.decodeIfPresent(Bool.self, forKey: .isAccessibilityElement) ?? false
+        isAccessibilityFocused = try c.decodeIfPresent(Bool.self, forKey: .isAccessibilityFocused) ?? false
+        accessibilityElementsHidden = try c.decodeIfPresent(Bool.self, forKey: .accessibilityElementsHidden) ?? false
+        accessibilityTraits = try c.decodeIfPresent([String].self, forKey: .accessibilityTraits) ?? []
+        accessibilityCustomActions = try c.decodeIfPresent([String].self, forKey: .accessibilityCustomActions) ?? []
+        gestureRecognizers = try c.decodeIfPresent([SdkGestureInfo].self, forKey: .gestureRecognizers) ?? []
+        alpha = try c.decodeIfPresent(Float.self, forKey: .alpha) ?? 1.0
+        backgroundColor = try c.decodeIfPresent(String.self, forKey: .backgroundColor)
+        cornerRadius = try c.decodeIfPresent(Float.self, forKey: .cornerRadius) ?? 0
+        borderColor = try c.decodeIfPresent(String.self, forKey: .borderColor)
+        borderWidth = try c.decodeIfPresent(Float.self, forKey: .borderWidth) ?? 0
+        isLayerNode = try c.decodeIfPresent(Bool.self, forKey: .isLayerNode) ?? false
+        isHidden = try c.decodeIfPresent(Bool.self, forKey: .isHidden) ?? false
+        isUserInteractionEnabled = try c.decodeIfPresent(Bool.self, forKey: .isUserInteractionEnabled) ?? true
+        hasTapTarget = try c.decodeIfPresent(Bool.self, forKey: .hasTapTarget) ?? false
+        isOccluded = try c.decodeIfPresent(Bool.self, forKey: .isOccluded) ?? false
+        semanticLinks = try c.decodeIfPresent([SdkSemanticLink].self, forKey: .semanticLinks)
+        children = try c.decodeIfPresent([SdkViewNode].self, forKey: .children)
     }
 }
 

--- a/ios/auto-mobile-sdk/Sources/AutoMobileSDK/ViewHierarchy/SemanticLinkExtractor.swift
+++ b/ios/auto-mobile-sdk/Sources/AutoMobileSDK/ViewHierarchy/SemanticLinkExtractor.swift
@@ -1,0 +1,86 @@
+import Foundation
+
+/// A single inline accessibility link discovered on an owning text element.
+///
+/// Mirrors the Android `SemanticLink` contract (text + occurrence + optional
+/// character range) so the merged AutoMobile hierarchy is shaped identically on
+/// both platforms (issue #5560). `centerX`/`centerY` are an iOS-only addition —
+/// the in-app SDK can compute a link's on-screen point, which the out-of-process
+/// runner uses to activate a specific inline link by coordinate. They are dropped
+/// when the node is projected to the Android-parity wire shape.
+public struct SdkSemanticLink: Codable, Sendable, Equatable {
+    public let text: String
+    public let occurrence: Int
+    /// UTF-16 offset (NSString semantics) of the link's first character, when the
+    /// source is a real attributed string. `nil` for accessibility-element
+    /// fallbacks (e.g. SwiftUI inline links) where no range is exposed.
+    public let start: Int?
+    /// UTF-16 offset one past the link's last character. `nil` when `start` is nil.
+    public let end: Int?
+    public let centerX: Double?
+    public let centerY: Double?
+
+    public init(
+        text: String,
+        occurrence: Int,
+        start: Int? = nil,
+        end: Int? = nil,
+        centerX: Double? = nil,
+        centerY: Double? = nil
+    ) {
+        self.text = text
+        self.occurrence = occurrence
+        self.start = start
+        self.end = end
+        self.centerX = centerX
+        self.centerY = centerY
+    }
+}
+
+/// Extracts inline semantic links from attributed text and ordered accessibility
+/// elements. Pure Foundation logic (no UIKit) so it runs on the macOS `swift test`
+/// destination; the UIKit walker feeds it live `UITextView`/`UILabel`
+/// `attributedText` and, for SwiftUI, the ordered `.link`-trait accessibility
+/// elements.
+public enum SemanticLinkExtractor {
+    /// Discover every `.link` run in `attributed`, assigning an ascending
+    /// `occurrence` per distinct visible text so duplicate link labels remain
+    /// disambiguable — exactly how Android's `semanticLinksFromText` behaves.
+    public static func links(from attributed: NSAttributedString) -> [SdkSemanticLink] {
+        let nsText = attributed.string as NSString
+        var links: [SdkSemanticLink] = []
+        var occurrenceByText: [String: Int] = [:]
+        let fullRange = NSRange(location: 0, length: attributed.length)
+        attributed.enumerateAttribute(.link, in: fullRange) { value, range, _ in
+            guard value != nil, range.length > 0 else { return }
+            let text = nsText.substring(with: range)
+            let occurrence = occurrenceByText[text, default: 0]
+            occurrenceByText[text] = occurrence + 1
+            links.append(
+                SdkSemanticLink(
+                    text: text,
+                    occurrence: occurrence,
+                    start: range.location,
+                    end: range.location + range.length
+                )
+            )
+        }
+        return links
+    }
+
+    /// Build links from the ordered accessibility labels of a text element's
+    /// `.link`-trait children. SwiftUI inline links only surface this way, with no
+    /// character range — occurrence is still assigned in document order.
+    public static func links(fromAccessibilityLinkLabels labels: [String]) -> [SdkSemanticLink] {
+        var links: [SdkSemanticLink] = []
+        var occurrenceByText: [String: Int] = [:]
+        for label in labels {
+            let trimmed = label.trimmingCharacters(in: .whitespacesAndNewlines)
+            guard !trimmed.isEmpty else { continue }
+            let occurrence = occurrenceByText[trimmed, default: 0]
+            occurrenceByText[trimmed] = occurrence + 1
+            links.append(SdkSemanticLink(text: trimmed, occurrence: occurrence))
+        }
+        return links
+    }
+}

--- a/ios/auto-mobile-sdk/Sources/AutoMobileSDK/ViewHierarchy/ViewHierarchyWalker.swift
+++ b/ios/auto-mobile-sdk/Sources/AutoMobileSDK/ViewHierarchy/ViewHierarchyWalker.swift
@@ -1,496 +1,621 @@
 #if canImport(UIKit) && !os(watchOS)
-import UIKit
+    import UIKit
 
-/// Walks the live UIView hierarchy in-process, extracting rich properties
-/// not available through XCUITest's accessibility service.
-///
-/// Must be called on the main thread (UIView access requirement).
-/// Patterns borrowed from Slack's AccessibilityAuditor.
-public enum ViewHierarchyWalker {
+    /// Walks the live UIView hierarchy in-process, extracting rich properties
+    /// not available through XCUITest's accessibility service.
+    ///
+    /// Must be called on the main thread (UIView access requirement).
+    /// Patterns borrowed from Slack's AccessibilityAuditor.
+    public enum ViewHierarchyWalker {
+        // MARK: - Configuration
 
-    // MARK: - Configuration
+        private static let maxDepth = 30
 
-    private static let maxDepth = 30
+        // MARK: - Public API
 
-    // MARK: - Public API
+        /// Walk the entire view hierarchy and return a snapshot.
+        /// Must be called on the main thread.
+        public static func walk(bundleId: String? = nil) -> SdkViewHierarchy {
+            let scale = Float(UIScreen.main.scale)
+            let screenBounds = UIScreen.main.bounds
+            let screenWidth = Int(screenBounds.width)
+            let screenHeight = Int(screenBounds.height)
 
-    /// Walk the entire view hierarchy and return a snapshot.
-    /// Must be called on the main thread.
-    public static func walk(bundleId: String? = nil) -> SdkViewHierarchy {
-        let scale = Float(UIScreen.main.scale)
-        let screenBounds = UIScreen.main.bounds
-        let screenWidth = Int(screenBounds.width)
-        let screenHeight = Int(screenBounds.height)
-
-        let keyWindow = visibleKeyWindow()
-        let rootNode = keyWindow.flatMap(walkWindow)
-        let safeAreaInsets = keyWindow.map {
-            SdkEdgeInsets(
-                top: Double($0.safeAreaInsets.top),
-                right: Double($0.safeAreaInsets.right),
-                bottom: Double($0.safeAreaInsets.bottom),
-                left: Double($0.safeAreaInsets.left)
-            )
-        }
-        let systemChrome = keyWindow.flatMap(systemChrome(for:))
-
-        return SdkViewHierarchy(
-            bundleId: bundleId,
-            screenScale: scale,
-            screenWidth: screenWidth,
-            screenHeight: screenHeight,
-            safeAreaInsets: safeAreaInsets,
-            systemChrome: systemChrome,
-            root: rootNode
-        )
-    }
-
-    /// Compute a hierarchy hash for change detection.
-    /// Ignores per-view bounds (which change during animations), while retaining screen and
-    /// safe-area metrics because they determine the coordinate and layout-warning contract.
-    public static func computeHash(_ hierarchy: SdkViewHierarchy) -> Int {
-        var hasher = Hasher()
-        if let bundleId = hierarchy.bundleId {
-            hasher.combine(bundleId)
-        }
-        hasher.combine(hierarchy.screenScale)
-        hasher.combine(hierarchy.screenWidth)
-        hasher.combine(hierarchy.screenHeight)
-        if let safeAreaInsets = hierarchy.safeAreaInsets {
-            hasher.combine(true)
-            hasher.combine(safeAreaInsets.top)
-            hasher.combine(safeAreaInsets.right)
-            hasher.combine(safeAreaInsets.bottom)
-            hasher.combine(safeAreaInsets.left)
-        } else {
-            hasher.combine(false)
-        }
-        if let systemChrome = hierarchy.systemChrome {
-            hasher.combine(true)
-            hasher.combine(systemChrome.visibility)
-            hasher.combine(systemChrome.statusBar)
-            hasher.combine(systemChrome.homeIndicatorAutoHideRequested)
-            hasher.combine(systemChrome.source)
-        } else {
-            hasher.combine(false)
-        }
-        if let root = hierarchy.root {
-            hashNode(root, into: &hasher, depth: 0)
-        }
-        return hasher.finalize()
-    }
-
-    // MARK: - Window Enumeration
-
-    private static func visibleKeyWindow() -> UIWindow? {
-        let windows: [UIWindow]
-        if #available(iOS 15.0, *) {
-            windows = UIApplication.shared.connectedScenes
-                .compactMap { $0 as? UIWindowScene }
-                .flatMap { $0.windows }
-        } else {
-            windows = UIApplication.shared.windows
-        }
-
-        // Find topmost visible window: prefer key window, then highest window level
-        return windows
-            .filter({ !$0.isHidden && $0.alpha > 0 })
-            .max(by: { a, b in
-                if a.windowLevel != b.windowLevel { return a.windowLevel < b.windowLevel }
-                return !a.isKeyWindow && b.isKeyWindow
-            })
-    }
-
-    private static func systemChrome(for window: UIWindow) -> SdkSystemChrome? {
-        guard #available(iOS 13.0, *),
-              let statusBarManager = window.windowScene?.statusBarManager
-        else {
-            return nil
-        }
-
-        let statusBarHidden = statusBarManager.isStatusBarHidden
-        let homeIndicatorAutoHideRequested = visibleViewController(from: window.rootViewController)?
-            .prefersHomeIndicatorAutoHidden
-        return systemChrome(
-            statusBarHidden: statusBarHidden,
-            homeIndicatorAutoHideRequested: homeIndicatorAutoHideRequested
-        )
-    }
-
-    static func systemChrome(
-        statusBarHidden: Bool,
-        homeIndicatorAutoHideRequested: Bool?
-    ) -> SdkSystemChrome {
-        return SdkSystemChrome(
-            visibility: statusBarHidden ? "hidden" : "visible",
-            statusBar: statusBarHidden ? "hidden" : "visible",
-            homeIndicatorAutoHideRequested: homeIndicatorAutoHideRequested,
-            source: "ios-status-bar-manager"
-        )
-    }
-
-    private static func visibleViewController(from controller: UIViewController?) -> UIViewController? {
-        guard let controller else { return nil }
-        if let presented = controller.presentedViewController, !presented.isBeingDismissed {
-            return visibleViewController(from: presented)
-        }
-        if let navigation = controller as? UINavigationController {
-            return visibleViewController(from: navigation.visibleViewController)
-        }
-        if let tab = controller as? UITabBarController {
-            return visibleViewController(from: tab.selectedViewController)
-        }
-        if let split = controller as? UISplitViewController {
-            return visibleViewController(from: split.viewControllers.last)
-        }
-        if let page = controller as? UIPageViewController {
-            return visibleViewController(from: page.viewControllers?.last)
-        }
-        return controller
-    }
-
-    private static func walkWindow(_ keyWindow: UIWindow) -> SdkViewNode? {
-        var opaqueOverlays: [CGRect] = []
-        let rootBounds = keyWindow.bounds
-
-        return walkView(
-            keyWindow,
-            rootView: keyWindow,
-            rootBounds: rootBounds,
-            depth: 0,
-            opaqueOverlays: &opaqueOverlays
-        )
-    }
-
-    // MARK: - Recursive View Walk
-
-    private static func walkView(
-        _ view: UIView,
-        rootView: UIView,
-        rootBounds: CGRect,
-        depth: Int,
-        opaqueOverlays: inout [CGRect]
-    ) -> SdkViewNode? {
-        guard depth < maxDepth else { return nil }
-        guard !view.isHidden, view.alpha > 0 else { return nil }
-
-        let frameInRoot = frameInRootView(for: view, rootView: rootView)
-        guard frameInRoot.width > 0, frameInRoot.height > 0 else { return nil }
-        guard rootBounds.intersects(frameInRoot) else { return nil }
-
-        let occluded = isOccludedByOpaqueOverlay(frameInRoot, overlays: opaqueOverlays)
-
-        let className = String(describing: type(of: view))
-
-        let bounds = sdkBounds(from: frameInRoot)
-        let traits = traitNames(for: view.accessibilityTraits)
-        let customActions = (view.accessibilityCustomActions ?? []).map(\.name)
-        let gestures = (view.gestureRecognizers ?? []).map { gr in
-            SdkGestureInfo(
-                type: String(describing: type(of: gr)),
-                isEnabled: gr.isEnabled
-            )
-        }
-        let hasTap = hasOwnInteractiveAction(view)
-        let bgColor = hexColor(view.backgroundColor) ?? hexColor(view.layer.backgroundColor.flatMap { UIColor(cgColor: $0) })
-        let borderColor = view.layer.borderWidth > 0 ? hexColor(view.layer.borderColor.flatMap { UIColor(cgColor: $0) }) : nil
-        let borderWidth = sanitizeFloat(Float(view.layer.borderWidth))
-
-        // Walk children front-to-back for opaque overlay tracking.
-        // Always use UIView.subviews — accessibilityElements may contain
-        // non-UIView objects (e.g. SwiftUI accessibility nodes) that would
-        // cause us to miss the real view subtree.
-        let subviews = view.subviews
-        var childNodes: [SdkViewNode] = []
-        var childOpaqueOverlays = opaqueOverlays
-
-        for child in subviews.reversed() {
-            let childFrame = frameInRootView(for: child, rootView: rootView)
-            if isOccludedByOpaqueOverlay(childFrame, overlays: childOpaqueOverlays) {
-                continue
+            let keyWindow = visibleKeyWindow()
+            let rootNode = keyWindow.flatMap(walkWindow)
+            let safeAreaInsets = keyWindow.map {
+                SdkEdgeInsets(
+                    top: Double($0.safeAreaInsets.top),
+                    right: Double($0.safeAreaInsets.right),
+                    bottom: Double($0.safeAreaInsets.bottom),
+                    left: Double($0.safeAreaInsets.left)
+                )
             }
-            if let childNode = walkView(
-                child,
-                rootView: rootView,
+            let systemChrome = keyWindow.flatMap(systemChrome(for:))
+
+            return SdkViewHierarchy(
+                bundleId: bundleId,
+                screenScale: scale,
+                screenWidth: screenWidth,
+                screenHeight: screenHeight,
+                safeAreaInsets: safeAreaInsets,
+                systemChrome: systemChrome,
+                root: rootNode
+            )
+        }
+
+        /// Compute a hierarchy hash for change detection.
+        /// Ignores per-view bounds (which change during animations), while retaining screen and
+        /// safe-area metrics because they determine the coordinate and layout-warning contract.
+        public static func computeHash(_ hierarchy: SdkViewHierarchy) -> Int {
+            var hasher = Hasher()
+            if let bundleId = hierarchy.bundleId {
+                hasher.combine(bundleId)
+            }
+            hasher.combine(hierarchy.screenScale)
+            hasher.combine(hierarchy.screenWidth)
+            hasher.combine(hierarchy.screenHeight)
+            if let safeAreaInsets = hierarchy.safeAreaInsets {
+                hasher.combine(true)
+                hasher.combine(safeAreaInsets.top)
+                hasher.combine(safeAreaInsets.right)
+                hasher.combine(safeAreaInsets.bottom)
+                hasher.combine(safeAreaInsets.left)
+            } else {
+                hasher.combine(false)
+            }
+            if let systemChrome = hierarchy.systemChrome {
+                hasher.combine(true)
+                hasher.combine(systemChrome.visibility)
+                hasher.combine(systemChrome.statusBar)
+                hasher.combine(systemChrome.homeIndicatorAutoHideRequested)
+                hasher.combine(systemChrome.source)
+            } else {
+                hasher.combine(false)
+            }
+            if let root = hierarchy.root {
+                hashNode(root, into: &hasher, depth: 0)
+            }
+            return hasher.finalize()
+        }
+
+        // MARK: - Window Enumeration
+
+        private static func visibleKeyWindow() -> UIWindow? {
+            let windows: [UIWindow]
+            if #available(iOS 15.0, *) {
+                windows = UIApplication.shared.connectedScenes
+                    .compactMap { $0 as? UIWindowScene }
+                    .flatMap { $0.windows }
+            } else {
+                windows = UIApplication.shared.windows
+            }
+
+            // Find topmost visible window: prefer key window, then highest window level.
+            let visible = windows.filter { !$0.isHidden && $0.alpha > 0 }
+            // Exclude empty UIKit overlay windows (text-effects / keyboard). iOS
+            // keeps them at a higher window level than app content once any text
+            // field has appeared, so selecting by max level would snapshot an empty
+            // overlay and drop the whole app tree (issue #5560). Fall back to the
+            // unfiltered set if filtering leaves nothing, so this never yields nil
+            // where the old logic would have found a window.
+            let content = visible.filter {
+                !WindowClassification.isNonContentWindow(className: String(describing: type(of: $0)))
+            }
+            let candidates = content.isEmpty ? visible : content
+            return candidates
+                .max(by: { a, b in
+                    if a.windowLevel != b.windowLevel { return a.windowLevel < b.windowLevel }
+                    return !a.isKeyWindow && b.isKeyWindow
+                })
+        }
+
+        private static func systemChrome(for window: UIWindow) -> SdkSystemChrome? {
+            guard #available(iOS 13.0, *),
+                  let statusBarManager = window.windowScene?.statusBarManager
+            else {
+                return nil
+            }
+
+            let statusBarHidden = statusBarManager.isStatusBarHidden
+            let homeIndicatorAutoHideRequested = visibleViewController(from: window.rootViewController)?
+                .prefersHomeIndicatorAutoHidden
+            return systemChrome(
+                statusBarHidden: statusBarHidden,
+                homeIndicatorAutoHideRequested: homeIndicatorAutoHideRequested
+            )
+        }
+
+        static func systemChrome(
+            statusBarHidden: Bool,
+            homeIndicatorAutoHideRequested: Bool?
+        )
+            -> SdkSystemChrome
+        {
+            return SdkSystemChrome(
+                visibility: statusBarHidden ? "hidden" : "visible",
+                statusBar: statusBarHidden ? "hidden" : "visible",
+                homeIndicatorAutoHideRequested: homeIndicatorAutoHideRequested,
+                source: "ios-status-bar-manager"
+            )
+        }
+
+        private static func visibleViewController(from controller: UIViewController?) -> UIViewController? {
+            guard let controller else { return nil }
+            if let presented = controller.presentedViewController, !presented.isBeingDismissed {
+                return visibleViewController(from: presented)
+            }
+            if let navigation = controller as? UINavigationController {
+                return visibleViewController(from: navigation.visibleViewController)
+            }
+            if let tab = controller as? UITabBarController {
+                return visibleViewController(from: tab.selectedViewController)
+            }
+            if let split = controller as? UISplitViewController {
+                return visibleViewController(from: split.viewControllers.last)
+            }
+            if let page = controller as? UIPageViewController {
+                return visibleViewController(from: page.viewControllers?.last)
+            }
+            return controller
+        }
+
+        private static func walkWindow(_ keyWindow: UIWindow) -> SdkViewNode? {
+            var opaqueOverlays: [CGRect] = []
+            let rootBounds = keyWindow.bounds
+
+            return walkView(
+                keyWindow,
+                rootView: keyWindow,
                 rootBounds: rootBounds,
-                depth: depth + 1,
-                opaqueOverlays: &childOpaqueOverlays
-            ) {
-                childNodes.append(childNode)
-            }
-            if isOpaqueOverlay(child) {
-                childOpaqueOverlays.append(childFrame)
-            }
-        }
-        // Reverse back to natural subview order for output
-        childNodes.reverse()
-
-        // Walk layer-only sublayers (SwiftUI shapes render as CALayer without backing UIView).
-        // Exclude layers that belong to subviews since those are already represented as SdkViewNodes.
-        let subviewLayerIds = Set(subviews.map { ObjectIdentifier($0.layer) })
-        if let sublayers = view.layer.sublayers {
-            for sublayer in sublayers {
-                if subviewLayerIds.contains(ObjectIdentifier(sublayer)) { continue }
-                if let layerNode = walkLayer(
-                    sublayer,
-                    hostLayer: view.layer,
-                    rootView: rootView,
-                    rootBounds: rootBounds,
-                    depth: depth + 1
-                ) {
-                    childNodes.append(layerNode)
-                }
-            }
-        }
-
-        // Propagate any new opaque overlays discovered in children
-        opaqueOverlays = childOpaqueOverlays
-
-        return SdkViewNode(
-            className: className,
-            bounds: bounds,
-            accessibilityLabel: view.accessibilityLabel,
-            accessibilityIdentifier: view.accessibilityIdentifier,
-            isAccessibilityElement: view.isAccessibilityElement,
-            // Only readable in-process: the out-of-process runner cannot query the
-            // VoiceOver cursor, so the SDK captures it here (#3924).
-            isAccessibilityFocused: view.accessibilityElementIsFocused(),
-            accessibilityElementsHidden: view.accessibilityElementsHidden,
-            accessibilityTraits: traits,
-            accessibilityCustomActions: customActions,
-            gestureRecognizers: gestures,
-            alpha: sanitizeFloat(Float(view.alpha)),
-            backgroundColor: bgColor,
-            cornerRadius: sanitizeFloat(Float(view.layer.cornerRadius)),
-            borderColor: borderColor,
-            borderWidth: borderWidth,
-            isLayerNode: false,
-            isHidden: view.isHidden,
-            isUserInteractionEnabled: view.isUserInteractionEnabled,
-            hasTapTarget: hasTap,
-            isOccluded: occluded,
-            children: childNodes.isEmpty ? nil : childNodes
-        )
-    }
-
-    // MARK: - Recursive Layer Walk
-
-    /// Walk a CALayer that has no backing UIView (e.g. SwiftUI shape rendering).
-    /// Emits a synthetic SdkViewNode describing the layer's visual properties.
-    private static func walkLayer(
-        _ layer: CALayer,
-        hostLayer: CALayer,
-        rootView: UIView,
-        rootBounds: CGRect,
-        depth: Int
-    ) -> SdkViewNode? {
-        guard depth < maxDepth else { return nil }
-        guard !layer.isHidden, layer.opacity > 0 else { return nil }
-
-        // Convert layer frame to root-view coordinates.
-        // layer.frame is expressed in its superlayer's coordinate space.
-        let frameInRoot: CGRect
-        if let superlayer = layer.superlayer {
-            let converted = superlayer.convert(layer.frame, to: rootView.layer)
-            frameInRoot = CGRect(
-                x: converted.origin.x.rounded(),
-                y: converted.origin.y.rounded(),
-                width: converted.size.width.rounded(),
-                height: converted.size.height.rounded()
+                depth: 0,
+                opaqueOverlays: &opaqueOverlays
             )
-        } else {
-            frameInRoot = layer.frame
         }
 
-        guard frameInRoot.width > 0, frameInRoot.height > 0 else { return nil }
-        guard rootBounds.intersects(frameInRoot) else { return nil }
+        // MARK: - Recursive View Walk
 
-        let hasAnyVisual = layer.backgroundColor != nil
-            || layer.cornerRadius > 0
-            || layer.borderWidth > 0
-            || layer is CAShapeLayer
-            || layer is CAGradientLayer
+        private static func walkView(
+            _ view: UIView,
+            rootView: UIView,
+            rootBounds: CGRect,
+            depth: Int,
+            opaqueOverlays: inout [CGRect]
+        )
+            -> SdkViewNode?
+        {
+            guard depth < maxDepth else { return nil }
+            guard !view.isHidden, view.alpha > 0 else { return nil }
 
-        // Recurse into sublayers first so we can decide whether to emit this node
-        var childNodes: [SdkViewNode] = []
-        if let sublayers = layer.sublayers {
-            for sub in sublayers {
-                if let childNode = walkLayer(
-                    sub,
-                    hostLayer: hostLayer,
+            let frameInRoot = frameInRootView(for: view, rootView: rootView)
+            guard frameInRoot.width > 0, frameInRoot.height > 0 else { return nil }
+            guard rootBounds.intersects(frameInRoot) else { return nil }
+
+            let occluded = isOccludedByOpaqueOverlay(frameInRoot, overlays: opaqueOverlays)
+
+            let className = String(describing: type(of: view))
+
+            let bounds = sdkBounds(from: frameInRoot)
+            let traits = traitNames(for: view.accessibilityTraits)
+            let customActions = (view.accessibilityCustomActions ?? []).map(\.name)
+            let gestures = (view.gestureRecognizers ?? []).map { gr in
+                SdkGestureInfo(
+                    type: String(describing: type(of: gr)),
+                    isEnabled: gr.isEnabled
+                )
+            }
+            let hasTap = hasOwnInteractiveAction(view)
+            let bgColor = hexColor(view.backgroundColor) ??
+                hexColor(view.layer.backgroundColor.flatMap { UIColor(cgColor: $0) })
+            let borderColor = view.layer
+                .borderWidth > 0 ? hexColor(view.layer.borderColor.flatMap { UIColor(cgColor: $0) }) : nil
+            let borderWidth = sanitizeFloat(Float(view.layer.borderWidth))
+
+            // Walk children front-to-back for opaque overlay tracking.
+            // Always use UIView.subviews — accessibilityElements may contain
+            // non-UIView objects (e.g. SwiftUI accessibility nodes) that would
+            // cause us to miss the real view subtree.
+            let subviews = view.subviews
+            var childNodes: [SdkViewNode] = []
+            var childOpaqueOverlays = opaqueOverlays
+
+            for child in subviews.reversed() {
+                let childFrame = frameInRootView(for: child, rootView: rootView)
+                if isOccludedByOpaqueOverlay(childFrame, overlays: childOpaqueOverlays) {
+                    continue
+                }
+                if let childNode = walkView(
+                    child,
                     rootView: rootView,
                     rootBounds: rootBounds,
-                    depth: depth + 1
+                    depth: depth + 1,
+                    opaqueOverlays: &childOpaqueOverlays
                 ) {
                     childNodes.append(childNode)
                 }
+                if isOpaqueOverlay(child) {
+                    childOpaqueOverlays.append(childFrame)
+                }
+            }
+            // Reverse back to natural subview order for output
+            childNodes.reverse()
+
+            // Walk layer-only sublayers (SwiftUI shapes render as CALayer without backing UIView).
+            // Exclude layers that belong to subviews since those are already represented as SdkViewNodes.
+            let subviewLayerIds = Set(subviews.map { ObjectIdentifier($0.layer) })
+            if let sublayers = view.layer.sublayers {
+                for sublayer in sublayers {
+                    if subviewLayerIds.contains(ObjectIdentifier(sublayer)) { continue }
+                    if let layerNode = walkLayer(
+                        sublayer,
+                        hostLayer: view.layer,
+                        rootView: rootView,
+                        rootBounds: rootBounds,
+                        depth: depth + 1
+                    ) {
+                        childNodes.append(layerNode)
+                    }
+                }
+            }
+
+            // Propagate any new opaque overlays discovered in children
+            opaqueOverlays = childOpaqueOverlays
+
+            let semanticLinks = semanticLinks(for: view, rootView: rootView)
+
+            return SdkViewNode(
+                className: className,
+                bounds: bounds,
+                accessibilityLabel: view.accessibilityLabel,
+                accessibilityIdentifier: view.accessibilityIdentifier,
+                isAccessibilityElement: view.isAccessibilityElement,
+                // Only readable in-process: the out-of-process runner cannot query the
+                // VoiceOver cursor, so the SDK captures it here (#3924).
+                isAccessibilityFocused: view.accessibilityElementIsFocused(),
+                accessibilityElementsHidden: view.accessibilityElementsHidden,
+                accessibilityTraits: traits,
+                accessibilityCustomActions: customActions,
+                gestureRecognizers: gestures,
+                alpha: sanitizeFloat(Float(view.alpha)),
+                backgroundColor: bgColor,
+                cornerRadius: sanitizeFloat(Float(view.layer.cornerRadius)),
+                borderColor: borderColor,
+                borderWidth: borderWidth,
+                isLayerNode: false,
+                isHidden: view.isHidden,
+                isUserInteractionEnabled: view.isUserInteractionEnabled,
+                hasTapTarget: hasTap,
+                isOccluded: occluded,
+                semanticLinks: semanticLinks,
+                children: childNodes.isEmpty ? nil : childNodes
+            )
+        }
+
+        // MARK: - Semantic Links
+
+        /// Discover inline semantic links owned by `view` and, where possible, the
+        /// on-screen point (root-view coordinates, matching `bounds`) the runner can
+        /// tap to activate each one (issue #5560).
+        ///
+        /// Two sources, in priority order:
+        /// 1. `UITextView`/`UILabel.attributedText` — a real attributed string, so the
+        ///    full text+occurrence+range contract is available (UIKit demo path). For
+        ///    `UITextView` the glyph rect gives a precise activation point.
+        /// 2. Ordered `.link`-trait accessibility children — SwiftUI inline links only
+        ///    surface this way, carrying a label and frame but no character range.
+        private static func semanticLinks(for view: UIView, rootView: UIView) -> [SdkSemanticLink]? {
+            if let attributed = attributedText(of: view), attributed.length > 0 {
+                let links = SemanticLinkExtractor.links(from: attributed)
+                guard !links.isEmpty else { return nil }
+                return links.map { link in
+                    withCenter(link, point: linkCenter(link, in: view, rootView: rootView))
+                }
+            }
+
+            let accessibilityLinks = linkAccessibilityElements(of: view)
+            guard !accessibilityLinks.isEmpty else { return nil }
+            let labels = accessibilityLinks.map { $0.accessibilityLabel ?? "" }
+            let links = SemanticLinkExtractor.links(fromAccessibilityLinkLabels: labels)
+            guard !links.isEmpty else { return nil }
+            // Re-pair each extracted link with the accessibility element it came from,
+            // skipping the blank labels the extractor drops, so frames line up.
+            var elementIndex = 0
+            return links.map { link in
+                while elementIndex < accessibilityLinks.count,
+                      (accessibilityLinks[elementIndex].accessibilityLabel ?? "")
+                      .trimmingCharacters(in: .whitespacesAndNewlines).isEmpty
+                {
+                    elementIndex += 1
+                }
+                let point = elementIndex < accessibilityLinks.count
+                    ? center(ofScreenFrame: accessibilityLinks[elementIndex].accessibilityFrame, rootView: rootView)
+                    : nil
+                elementIndex += 1
+                return withCenter(link, point: point)
             }
         }
 
-        // Skip purely structural layer nodes with no visual properties and no interesting children.
-        guard hasAnyVisual || !childNodes.isEmpty else { return nil }
-
-        let bgColor = hexColor(layer.backgroundColor.flatMap { UIColor(cgColor: $0) })
-        let borderColor = layer.borderWidth > 0 ? hexColor(layer.borderColor.flatMap { UIColor(cgColor: $0) }) : nil
-
-        return SdkViewNode(
-            className: String(describing: type(of: layer)),
-            bounds: sdkBounds(from: frameInRoot),
-            accessibilityLabel: nil,
-            accessibilityIdentifier: layer.name,
-            isAccessibilityElement: false,
-            accessibilityElementsHidden: false,
-            accessibilityTraits: [],
-            accessibilityCustomActions: [],
-            gestureRecognizers: [],
-            alpha: sanitizeFloat(layer.opacity),
-            backgroundColor: bgColor,
-            cornerRadius: sanitizeFloat(Float(layer.cornerRadius)),
-            borderColor: borderColor,
-            borderWidth: sanitizeFloat(Float(layer.borderWidth)),
-            isLayerNode: true,
-            isHidden: layer.isHidden,
-            isUserInteractionEnabled: false,
-            hasTapTarget: false,
-            isOccluded: false,
-            children: childNodes.isEmpty ? nil : childNodes
-        )
-    }
-
-    // MARK: - Coordinate Conversion
-
-    private static func frameInRootView(for view: UIView, rootView: UIView) -> CGRect {
-        let frame = view.convert(view.bounds, to: rootView)
-        return CGRect(
-            x: frame.origin.x.rounded(),
-            y: frame.origin.y.rounded(),
-            width: frame.size.width.rounded(),
-            height: frame.size.height.rounded()
-        )
-    }
-
-    private static func sdkBounds(from rect: CGRect) -> SdkBounds {
-        SdkBounds(
-            left: Int(rect.origin.x),
-            top: Int(rect.origin.y),
-            right: Int(rect.origin.x + rect.width),
-            bottom: Int(rect.origin.y + rect.height)
-        )
-    }
-
-    // MARK: - Opaque Overlay Detection
-
-    private static func isOccludedByOpaqueOverlay(_ frame: CGRect, overlays: [CGRect]) -> Bool {
-        let area = frame.width * frame.height
-        guard area > 0 else { return false }
-        return overlays.contains { overlay in
-            let intersection = overlay.intersection(frame)
-            guard !intersection.isNull else { return false }
-            let intersectionArea = intersection.width * intersection.height
-            return intersectionArea / area >= 0.9
+        private static func attributedText(of view: UIView) -> NSAttributedString? {
+            if let textView = view as? UITextView { return textView.attributedText }
+            if let label = view as? UILabel { return label.attributedText }
+            return nil
         }
-    }
 
-    private static func isOpaqueOverlay(_ view: UIView) -> Bool {
-        guard !view.isHidden, view.alpha == 1.0 else { return false }
-        if let bg = view.backgroundColor, isOpaque(bg) { return true }
-        if let layerBg = view.layer.backgroundColor, isOpaque(UIColor(cgColor: layerBg)) { return true }
-        return false
-    }
-
-    private static func isOpaque(_ color: UIColor) -> Bool {
-        var alpha: CGFloat = 0
-        color.getRed(nil, green: nil, blue: nil, alpha: &alpha)
-        return alpha == 1.0
-    }
-
-    // MARK: - Interactive Action Detection
-
-    private static func hasOwnInteractiveAction(_ view: UIView) -> Bool {
-        if let control = view as? UIControl {
-            if !control.allTargets.isEmpty || control.showsMenuAsPrimaryAction { return true }
+        /// Flatten a view's accessibility elements, keeping those exposing the `.link`
+        /// trait in document order.
+        private static func linkAccessibilityElements(of view: UIView) -> [NSObject] {
+            guard let elements = view.accessibilityElements as? [NSObject] else { return [] }
+            // Every NSObject exposes `accessibilityTraits` via UIKit's UIAccessibility
+            // category, so reading it directly is safe for whatever concrete elements
+            // (typically UIAccessibilityElement) a view vends.
+            return elements.filter { $0.accessibilityTraits.contains(.link) }
         }
-        if hasContentTapGesture(view) { return true }
-        return false
-    }
 
-    /// Whether the view has a tap gesture that represents content interaction
-    /// (excludes VC root views and scroll view containers).
-    private static func hasContentTapGesture(_ view: UIView) -> Bool {
-        guard !(view.next is UIViewController) else { return false }
-        guard !(view is UIScrollView) else { return false }
-        if let gestureRecognizers = view.gestureRecognizers {
-            return gestureRecognizers.contains(where: { $0 is UITapGestureRecognizer && $0.isEnabled })
-        }
-        return false
-    }
-
-    // MARK: - Accessibility Traits
-
-    private static func traitNames(for traits: UIAccessibilityTraits) -> [String] {
-        var names: [String] = []
-        if traits.contains(.button) { names.append("button") }
-        if traits.contains(.link) { names.append("link") }
-        if traits.contains(.header) { names.append("header") }
-        if traits.contains(.searchField) { names.append("searchField") }
-        if traits.contains(.image) { names.append("image") }
-        if traits.contains(.selected) { names.append("selected") }
-        if traits.contains(.playsSound) { names.append("playsSound") }
-        if traits.contains(.keyboardKey) { names.append("keyboardKey") }
-        if traits.contains(.staticText) { names.append("staticText") }
-        if traits.contains(.summaryElement) { names.append("summaryElement") }
-        if traits.contains(.notEnabled) { names.append("notEnabled") }
-        if traits.contains(.updatesFrequently) { names.append("updatesFrequently") }
-        if traits.contains(.startsMediaSession) { names.append("startsMediaSession") }
-        if traits.contains(.adjustable) { names.append("adjustable") }
-        if traits.contains(.allowsDirectInteraction) { names.append("allowsDirectInteraction") }
-        if traits.contains(.causesPageTurn) { names.append("causesPageTurn") }
-        if traits.contains(.tabBar) { names.append("tabBar") }
-        if #available(iOS 17.0, *) {
-            if traits.contains(.toggleButton) { names.append("toggleButton") }
-        }
-        return names
-    }
-
-    // MARK: - Float Sanitization
-
-    private static func sanitizeFloat(_ value: Float) -> Float {
-        value.isFinite ? value : 0
-    }
-
-    // MARK: - Color Helpers
-
-    private static func hexColor(_ color: UIColor?) -> String? {
-        guard let color = color else { return nil }
-        var r: CGFloat = 0, g: CGFloat = 0, b: CGFloat = 0, a: CGFloat = 0
-        color.getRed(&r, green: &g, blue: &b, alpha: &a)
-        guard a > 0 else { return nil }
-        return String(
-            format: "#%02X%02X%02X%02X",
-            Int(r * 255), Int(g * 255), Int(b * 255), Int(a * 255)
+        private static func linkCenter(
+            _ link: SdkSemanticLink,
+            in view: UIView,
+            rootView: UIView
         )
-    }
+            -> CGPoint?
+        {
+            guard let textView = view as? UITextView,
+                  let start = link.start,
+                  let end = link.end,
+                  let startPosition = textView.position(from: textView.beginningOfDocument, offset: start),
+                  let endPosition = textView.position(from: startPosition, offset: end - start),
+                  let textRange = textView.textRange(from: startPosition, to: endPosition)
+            else {
+                return nil
+            }
+            let rectInTextView = textView.firstRect(for: textRange)
+            guard rectInTextView.width > 0, rectInTextView.height > 0, rectInTextView.origin.x.isFinite else {
+                return nil
+            }
+            let center = CGPoint(x: rectInTextView.midX, y: rectInTextView.midY)
+            return textView.convert(center, to: rootView)
+        }
 
-    // MARK: - Structural Hash
+        private static func center(ofScreenFrame frame: CGRect, rootView: UIView) -> CGPoint? {
+            guard frame.width > 0, frame.height > 0, frame.origin.x.isFinite else { return nil }
+            let center = CGPoint(x: frame.midX, y: frame.midY)
+            // `accessibilityFrame` is in screen coordinates; `convert(_:from: nil)`
+            // treats the point as window-based. Window and screen origins coincide for
+            // a full-screen app window, which is the case for the text owners here.
+            return rootView.convert(center, from: nil)
+        }
 
-    private static func hashNode(_ node: SdkViewNode, into hasher: inout Hasher, depth: Int) {
-        guard depth < 15 else { return }
-        hasher.combine(node.className)
-        hasher.combine(node.accessibilityLabel)
-        hasher.combine(node.accessibilityIdentifier)
-        hasher.combine(node.isAccessibilityElement)
-        hasher.combine(node.accessibilityElementsHidden)
-        hasher.combine(node.accessibilityTraits)
-        hasher.combine(node.accessibilityCustomActions)
-        hasher.combine(node.isHidden)
-        hasher.combine(node.isUserInteractionEnabled)
-        hasher.combine(node.hasTapTarget)
-        if let children = node.children {
-            hasher.combine(children.count)
-            for child in children {
-                hashNode(child, into: &hasher, depth: depth + 1)
+        private static func withCenter(_ link: SdkSemanticLink, point: CGPoint?) -> SdkSemanticLink {
+            guard let point else { return link }
+            return SdkSemanticLink(
+                text: link.text,
+                occurrence: link.occurrence,
+                start: link.start,
+                end: link.end,
+                centerX: Double(point.x.rounded()),
+                centerY: Double(point.y.rounded())
+            )
+        }
+
+        // MARK: - Recursive Layer Walk
+
+        /// Walk a CALayer that has no backing UIView (e.g. SwiftUI shape rendering).
+        /// Emits a synthetic SdkViewNode describing the layer's visual properties.
+        private static func walkLayer(
+            _ layer: CALayer,
+            hostLayer: CALayer,
+            rootView: UIView,
+            rootBounds: CGRect,
+            depth: Int
+        )
+            -> SdkViewNode?
+        {
+            guard depth < maxDepth else { return nil }
+            guard !layer.isHidden, layer.opacity > 0 else { return nil }
+
+            // Convert layer frame to root-view coordinates.
+            // layer.frame is expressed in its superlayer's coordinate space.
+            let frameInRoot: CGRect
+            if let superlayer = layer.superlayer {
+                let converted = superlayer.convert(layer.frame, to: rootView.layer)
+                frameInRoot = CGRect(
+                    x: converted.origin.x.rounded(),
+                    y: converted.origin.y.rounded(),
+                    width: converted.size.width.rounded(),
+                    height: converted.size.height.rounded()
+                )
+            } else {
+                frameInRoot = layer.frame
+            }
+
+            guard frameInRoot.width > 0, frameInRoot.height > 0 else { return nil }
+            guard rootBounds.intersects(frameInRoot) else { return nil }
+
+            let hasAnyVisual = layer.backgroundColor != nil
+                || layer.cornerRadius > 0
+                || layer.borderWidth > 0
+                || layer is CAShapeLayer
+                || layer is CAGradientLayer
+
+            // Recurse into sublayers first so we can decide whether to emit this node
+            var childNodes: [SdkViewNode] = []
+            if let sublayers = layer.sublayers {
+                for sub in sublayers {
+                    if let childNode = walkLayer(
+                        sub,
+                        hostLayer: hostLayer,
+                        rootView: rootView,
+                        rootBounds: rootBounds,
+                        depth: depth + 1
+                    ) {
+                        childNodes.append(childNode)
+                    }
+                }
+            }
+
+            // Skip purely structural layer nodes with no visual properties and no interesting children.
+            guard hasAnyVisual || !childNodes.isEmpty else { return nil }
+
+            let bgColor = hexColor(layer.backgroundColor.flatMap { UIColor(cgColor: $0) })
+            let borderColor = layer.borderWidth > 0 ? hexColor(layer.borderColor.flatMap { UIColor(cgColor: $0) }) : nil
+
+            return SdkViewNode(
+                className: String(describing: type(of: layer)),
+                bounds: sdkBounds(from: frameInRoot),
+                accessibilityLabel: nil,
+                accessibilityIdentifier: layer.name,
+                isAccessibilityElement: false,
+                accessibilityElementsHidden: false,
+                accessibilityTraits: [],
+                accessibilityCustomActions: [],
+                gestureRecognizers: [],
+                alpha: sanitizeFloat(layer.opacity),
+                backgroundColor: bgColor,
+                cornerRadius: sanitizeFloat(Float(layer.cornerRadius)),
+                borderColor: borderColor,
+                borderWidth: sanitizeFloat(Float(layer.borderWidth)),
+                isLayerNode: true,
+                isHidden: layer.isHidden,
+                isUserInteractionEnabled: false,
+                hasTapTarget: false,
+                isOccluded: false,
+                children: childNodes.isEmpty ? nil : childNodes
+            )
+        }
+
+        // MARK: - Coordinate Conversion
+
+        private static func frameInRootView(for view: UIView, rootView: UIView) -> CGRect {
+            let frame = view.convert(view.bounds, to: rootView)
+            return CGRect(
+                x: frame.origin.x.rounded(),
+                y: frame.origin.y.rounded(),
+                width: frame.size.width.rounded(),
+                height: frame.size.height.rounded()
+            )
+        }
+
+        private static func sdkBounds(from rect: CGRect) -> SdkBounds {
+            SdkBounds(
+                left: Int(rect.origin.x),
+                top: Int(rect.origin.y),
+                right: Int(rect.origin.x + rect.width),
+                bottom: Int(rect.origin.y + rect.height)
+            )
+        }
+
+        // MARK: - Opaque Overlay Detection
+
+        private static func isOccludedByOpaqueOverlay(_ frame: CGRect, overlays: [CGRect]) -> Bool {
+            let area = frame.width * frame.height
+            guard area > 0 else { return false }
+            return overlays.contains { overlay in
+                let intersection = overlay.intersection(frame)
+                guard !intersection.isNull else { return false }
+                let intersectionArea = intersection.width * intersection.height
+                return intersectionArea / area >= 0.9
+            }
+        }
+
+        private static func isOpaqueOverlay(_ view: UIView) -> Bool {
+            guard !view.isHidden, view.alpha == 1.0 else { return false }
+            if let bg = view.backgroundColor, isOpaque(bg) { return true }
+            if let layerBg = view.layer.backgroundColor, isOpaque(UIColor(cgColor: layerBg)) { return true }
+            return false
+        }
+
+        private static func isOpaque(_ color: UIColor) -> Bool {
+            var alpha: CGFloat = 0
+            color.getRed(nil, green: nil, blue: nil, alpha: &alpha)
+            return alpha == 1.0
+        }
+
+        // MARK: - Interactive Action Detection
+
+        private static func hasOwnInteractiveAction(_ view: UIView) -> Bool {
+            if let control = view as? UIControl {
+                if !control.allTargets.isEmpty || control.showsMenuAsPrimaryAction { return true }
+            }
+            if hasContentTapGesture(view) { return true }
+            return false
+        }
+
+        /// Whether the view has a tap gesture that represents content interaction
+        /// (excludes VC root views and scroll view containers).
+        private static func hasContentTapGesture(_ view: UIView) -> Bool {
+            guard !(view.next is UIViewController) else { return false }
+            guard !(view is UIScrollView) else { return false }
+            if let gestureRecognizers = view.gestureRecognizers {
+                return gestureRecognizers.contains(where: { $0 is UITapGestureRecognizer && $0.isEnabled })
+            }
+            return false
+        }
+
+        // MARK: - Accessibility Traits
+
+        private static func traitNames(for traits: UIAccessibilityTraits) -> [String] {
+            var names: [String] = []
+            if traits.contains(.button) { names.append("button") }
+            if traits.contains(.link) { names.append("link") }
+            if traits.contains(.header) { names.append("header") }
+            if traits.contains(.searchField) { names.append("searchField") }
+            if traits.contains(.image) { names.append("image") }
+            if traits.contains(.selected) { names.append("selected") }
+            if traits.contains(.playsSound) { names.append("playsSound") }
+            if traits.contains(.keyboardKey) { names.append("keyboardKey") }
+            if traits.contains(.staticText) { names.append("staticText") }
+            if traits.contains(.summaryElement) { names.append("summaryElement") }
+            if traits.contains(.notEnabled) { names.append("notEnabled") }
+            if traits.contains(.updatesFrequently) { names.append("updatesFrequently") }
+            if traits.contains(.startsMediaSession) { names.append("startsMediaSession") }
+            if traits.contains(.adjustable) { names.append("adjustable") }
+            if traits.contains(.allowsDirectInteraction) { names.append("allowsDirectInteraction") }
+            if traits.contains(.causesPageTurn) { names.append("causesPageTurn") }
+            if traits.contains(.tabBar) { names.append("tabBar") }
+            if #available(iOS 17.0, *) {
+                if traits.contains(.toggleButton) { names.append("toggleButton") }
+            }
+            return names
+        }
+
+        // MARK: - Float Sanitization
+
+        private static func sanitizeFloat(_ value: Float) -> Float {
+            value.isFinite ? value : 0
+        }
+
+        // MARK: - Color Helpers
+
+        private static func hexColor(_ color: UIColor?) -> String? {
+            guard let color = color else { return nil }
+            var r: CGFloat = 0, g: CGFloat = 0, b: CGFloat = 0, a: CGFloat = 0
+            color.getRed(&r, green: &g, blue: &b, alpha: &a)
+            guard a > 0 else { return nil }
+            return String(
+                format: "#%02X%02X%02X%02X",
+                Int(r * 255), Int(g * 255), Int(b * 255), Int(a * 255)
+            )
+        }
+
+        // MARK: - Structural Hash
+
+        private static func hashNode(_ node: SdkViewNode, into hasher: inout Hasher, depth: Int) {
+            guard depth < 15 else { return }
+            hasher.combine(node.className)
+            hasher.combine(node.accessibilityLabel)
+            hasher.combine(node.accessibilityIdentifier)
+            hasher.combine(node.isAccessibilityElement)
+            hasher.combine(node.accessibilityElementsHidden)
+            hasher.combine(node.accessibilityTraits)
+            hasher.combine(node.accessibilityCustomActions)
+            hasher.combine(node.isHidden)
+            hasher.combine(node.isUserInteractionEnabled)
+            hasher.combine(node.hasTapTarget)
+            if let children = node.children {
+                hasher.combine(children.count)
+                for child in children {
+                    hashNode(child, into: &hasher, depth: depth + 1)
+                }
             }
         }
     }
-}
 #endif

--- a/ios/auto-mobile-sdk/Sources/AutoMobileSDK/ViewHierarchy/ViewHierarchyWalker.swift
+++ b/ios/auto-mobile-sdk/Sources/AutoMobileSDK/ViewHierarchy/ViewHierarchyWalker.swift
@@ -385,7 +385,11 @@
         }
 
         private static func withCenter(_ link: SdkSemanticLink, point: CGPoint?) -> SdkSemanticLink {
-            guard let point else { return link }
+            // Both coordinates must be finite before they reach JSONEncoder: a
+            // single non-finite center would throw and blank the ENTIRE hierarchy
+            // encode, not just this link. The upstream producers already reject
+            // degenerate rects, so this only closes the finite-x / non-finite-y gap.
+            guard let point, point.x.isFinite, point.y.isFinite else { return link }
             return SdkSemanticLink(
                 text: link.text,
                 occurrence: link.occurrence,

--- a/ios/auto-mobile-sdk/Sources/AutoMobileSDK/ViewHierarchy/WindowClassification.swift
+++ b/ios/auto-mobile-sdk/Sources/AutoMobileSDK/ViewHierarchy/WindowClassification.swift
@@ -1,0 +1,26 @@
+import Foundation
+
+/// Classifies `UIWindow` subclasses for the in-process hierarchy walk.
+///
+/// iOS keeps empty system overlay windows at a *higher* `windowLevel` than the
+/// app's own content window once any text input appears on screen
+/// (`UITextEffectsWindow` for text-effects, `UIRemoteKeyboardWindow` for the
+/// keyboard). A walker that selects the window purely by highest level would then
+/// snapshot that empty overlay and drop the entire app tree — which is why the
+/// in-app SDK hierarchy (and, downstream, iOS semantic-link discovery) went blank
+/// on any screen that had shown a text field (issue #5560).
+///
+/// Pure string classification (no UIKit) so it runs on the macOS `swift test`
+/// destination; the UIKit walker feeds it `String(describing: type(of: window))`.
+public enum WindowClassification {
+    /// UIKit-internal overlay window classes that never carry app content and must
+    /// not be chosen over the real content window.
+    public static let nonContentWindowClassNames: Set<String> = [
+        "UITextEffectsWindow",
+        "UIRemoteKeyboardWindow",
+    ]
+
+    public static func isNonContentWindow(className: String) -> Bool {
+        nonContentWindowClassNames.contains(className)
+    }
+}

--- a/ios/auto-mobile-sdk/Tests/AutoMobileSDKTests/SemanticLinkExtractorTests.swift
+++ b/ios/auto-mobile-sdk/Tests/AutoMobileSDKTests/SemanticLinkExtractorTests.swift
@@ -1,0 +1,89 @@
+@testable import AutoMobileSDK
+import Foundation
+import XCTest
+
+/// Pure-logic coverage for the attributed-string → semantic-link extraction that
+/// brings iOS discovery to parity with Android (issue #5560). The extractor is
+/// Foundation-only so these run on the macOS `swift test` destination; the UIKit
+/// wiring that feeds it real `UITextView.attributedText` is verified on-device.
+final class SemanticLinkExtractorTests: XCTestCase {
+    private func linked(_ string: String, ranges: [(NSRange, String)]) -> NSAttributedString {
+        let attributed = NSMutableAttributedString(string: string)
+        for (range, url) in ranges {
+            attributed.addAttribute(.link, value: URL(string: url) ?? url as Any, range: range)
+        }
+        return attributed
+    }
+
+    func testExtractsSingleLinkWithTextOccurrenceAndRange() {
+        let text = "Read the Privacy Policy now."
+        let range = (text as NSString).range(of: "Privacy Policy")
+        let links = SemanticLinkExtractor.links(from: linked(text, ranges: [(range, "https://x/privacy")]))
+
+        XCTAssertEqual(links.count, 1)
+        XCTAssertEqual(links[0].text, "Privacy Policy")
+        XCTAssertEqual(links[0].occurrence, 0)
+        XCTAssertEqual(links[0].start, range.location)
+        XCTAssertEqual(links[0].end, range.location + range.length)
+    }
+
+    func testDuplicateLinkTextGetsDistinctAscendingOccurrences() {
+        // Mirrors the Playground demo: "Terms of Service" appears twice in one
+        // owner paragraph and must be disambiguable by occurrence 0 vs 1.
+        let text = "Read the Terms of Service, contact Support, or review the Terms of Service again."
+        let ns = text as NSString
+        let first = ns.range(of: "Terms of Service")
+        let support = ns.range(of: "Support")
+        let secondSearchStart = first.location + first.length
+        let second = ns.range(
+            of: "Terms of Service",
+            options: [],
+            range: NSRange(location: secondSearchStart, length: ns.length - secondSearchStart)
+        )
+        let links = SemanticLinkExtractor.links(from: linked(text, ranges: [
+            (first, "https://x/terms-first"),
+            (support, "https://x/support"),
+            (second, "https://x/terms-second"),
+        ]))
+
+        XCTAssertEqual(links.map(\.text), ["Terms of Service", "Support", "Terms of Service"])
+        XCTAssertEqual(links.map(\.occurrence), [0, 0, 1])
+        XCTAssertEqual(links[0].start, first.location)
+        XCTAssertEqual(links[2].start, second.location)
+        XCTAssertNotEqual(links[0].start, links[2].start)
+    }
+
+    func testStringValuedLinkAttributeIsAlsoDiscovered() {
+        let text = "See Support here."
+        let range = (text as NSString).range(of: "Support")
+        let attributed = NSMutableAttributedString(string: text)
+        attributed.addAttribute(.link, value: "app://support", range: range)
+        let links = SemanticLinkExtractor.links(from: attributed)
+
+        XCTAssertEqual(links.map(\.text), ["Support"])
+    }
+
+    func testPlainTextYieldsNoLinks() {
+        XCTAssertTrue(SemanticLinkExtractor.links(from: NSAttributedString(string: "no links here")).isEmpty)
+    }
+
+    func testAccessibilityLinkLabelsFallbackAssignsOccurrencesInOrder() {
+        // SwiftUI inline links surface only as ordered accessibility elements with
+        // the .link trait — no character range is available, but occurrence must
+        // still increase for duplicate labels.
+        let links = SemanticLinkExtractor.links(fromAccessibilityLinkLabels: [
+            "Terms of Service", "Support", "Terms of Service",
+        ])
+
+        XCTAssertEqual(links.map(\.text), ["Terms of Service", "Support", "Terms of Service"])
+        XCTAssertEqual(links.map(\.occurrence), [0, 0, 1])
+        XCTAssertNil(links[0].start)
+        XCTAssertNil(links[0].end)
+    }
+
+    func testAccessibilityLinkLabelsSkipBlankEntries() {
+        let links = SemanticLinkExtractor.links(fromAccessibilityLinkLabels: ["  ", "Privacy Policy", ""])
+        XCTAssertEqual(links.map(\.text), ["Privacy Policy"])
+        XCTAssertEqual(links[0].occurrence, 0)
+    }
+}

--- a/ios/auto-mobile-sdk/Tests/AutoMobileSDKTests/WindowClassificationTests.swift
+++ b/ios/auto-mobile-sdk/Tests/AutoMobileSDKTests/WindowClassificationTests.swift
@@ -1,0 +1,21 @@
+@testable import AutoMobileSDK
+import XCTest
+
+/// Pins which UIWindow subclasses the in-process walker must skip when choosing the
+/// window to snapshot (issue #5560). iOS keeps empty system overlay windows
+/// (`UITextEffectsWindow`, `UIRemoteKeyboardWindow`) at a *higher* window level than
+/// the app's content once any text input appears; selecting purely by window level
+/// would then snapshot that empty overlay and hide the entire app tree. Foundation-only
+/// so it runs on the macOS `swift test` destination.
+final class WindowClassificationTests: XCTestCase {
+    func testTextEffectsAndKeyboardOverlaysAreNonContent() {
+        XCTAssertTrue(WindowClassification.isNonContentWindow(className: "UITextEffectsWindow"))
+        XCTAssertTrue(WindowClassification.isNonContentWindow(className: "UIRemoteKeyboardWindow"))
+    }
+
+    func testAppAndSystemAlertWindowsRemainContent() {
+        XCTAssertFalse(WindowClassification.isNonContentWindow(className: "UIWindow"))
+        XCTAssertFalse(WindowClassification.isNonContentWindow(className: "UIStatusBarWindow"))
+        XCTAssertFalse(WindowClassification.isNonContentWindow(className: "MyAppWindow"))
+    }
+}

--- a/ios/control-proxy/CtrlProxy.xcodeproj/project.pbxproj
+++ b/ios/control-proxy/CtrlProxy.xcodeproj/project.pbxproj
@@ -47,6 +47,7 @@
 		671E243A2BD5CAF78FF48E1D /* GesturePerformerSymbolsUnavailableWiringTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = CCAAB1439B71724CA0BF2401 /* GesturePerformerSymbolsUnavailableWiringTests.swift */; };
 		6733CA6A1FABC8D7C34F9327 /* ObjCExceptionBridgeTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 649A3185201F07E4D152CED6 /* ObjCExceptionBridgeTests.swift */; };
 		6798190F766D01F963F6DFD0 /* SdkDatabaseClient.swift in Sources */ = {isa = PBXBuildFile; fileRef = 0EDA90BC9E26458BCE47381F /* SdkDatabaseClient.swift */; };
+		6B55D827D015776972629D1F /* SemanticLinkActivation.swift in Sources */ = {isa = PBXBuildFile; fileRef = 86E304C3C42FE1AECFDB293B /* SemanticLinkActivation.swift */; };
 		714A3E41ACE47ACF314E0FC2 /* ClipboardResolutionTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = E30D131E590A0CF8F9674B0E /* ClipboardResolutionTests.swift */; };
 		74B1E8F78E9FF807417ABC2D /* PinchGeometryTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 4EE070E3D058AF5F67D2E1F3 /* PinchGeometryTests.swift */; };
 		74CA22BFA1779993CDCF59AE /* CtrlProxy.swift in Sources */ = {isa = PBXBuildFile; fileRef = 0EE277596991C059142C485B /* CtrlProxy.swift */; };
@@ -63,6 +64,7 @@
 		9EFF1197D83979B0FC0E0BCE /* CommandPayloadTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 8A702D259D2A37D9AA088EF8 /* CommandPayloadTests.swift */; };
 		9FE4564D1819768FEFD62606 /* ElementLocator.swift in Sources */ = {isa = PBXBuildFile; fileRef = 95565999DC108319DEED894A /* ElementLocator.swift */; };
 		9FED7BF37AFE34ADDF4E730A /* PinchFallback.swift in Sources */ = {isa = PBXBuildFile; fileRef = 0FEB521226F4C469CBFE7296 /* PinchFallback.swift */; };
+		A10EB8CB7F9F91B1B86CBAAF /* SemanticLinkActivationTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 8E1D0E93B99CBC6F7ED64B7B /* SemanticLinkActivationTests.swift */; };
 		A603343B94D35DDF48F7AA4D /* Fakes.swift in Sources */ = {isa = PBXBuildFile; fileRef = 9A1B2931E58B158EE51C5F4F /* Fakes.swift */; };
 		A9D79278D7A9C7ED3E7E4F8C /* CtrlProxy.framework in Embed Frameworks */ = {isa = PBXBuildFile; fileRef = 056D5DCA8003C7DFA37244C4 /* CtrlProxy.framework */; settings = {ATTRIBUTES = (CodeSignOnCopy, RemoveHeadersOnCopy, ); }; };
 		A9E8300EE35B13DED1A0E579 /* MainThreadRunner.swift in Sources */ = {isa = PBXBuildFile; fileRef = 6B8E0FBA4D04484920DA1D03 /* MainThreadRunner.swift */; };
@@ -84,6 +86,7 @@
 		CDEF0C911EA979C4E9C54B0B /* DefaultStorageInspecting.swift in Sources */ = {isa = PBXBuildFile; fileRef = 1CFB4EDEE20CB1CE002E68A5 /* DefaultStorageInspecting.swift */; };
 		CFCA362E1EF1F3251B19BC1B /* HierarchyMergerTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 0F6E995191B4AF437EDB71CA /* HierarchyMergerTests.swift */; };
 		D0C171171348407EBFF5BAB7 /* PerfProvider.swift in Sources */ = {isa = PBXBuildFile; fileRef = A284B6FFBE969931BB03A2FF /* PerfProvider.swift */; };
+		D2E88D247B7DA9F929D0CB6B /* SemanticLinkActivation.swift in Sources */ = {isa = PBXBuildFile; fileRef = 86E304C3C42FE1AECFDB293B /* SemanticLinkActivation.swift */; };
 		D9EF3A486E53F97C1CCB7A3B /* GesturePerformer.swift in Sources */ = {isa = PBXBuildFile; fileRef = F2144B84CD70DB35A1030624 /* GesturePerformer.swift */; };
 		DFEE186C8B4CD32EF76D995A /* AppDelegate.swift in Sources */ = {isa = PBXBuildFile; fileRef = 878A53A7F0EDDABDF2435E7F /* AppDelegate.swift */; };
 		E48A38EAE6AD5408BB7007CE /* OSLogReaderTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = DB4D52EC87CA484C4BC98756 /* OSLogReaderTests.swift */; };
@@ -217,9 +220,11 @@
 		77305F40F85694E983987E68 /* CommandHandler.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CommandHandler.swift; sourceTree = "<group>"; };
 		802717F6B1F37809C4806C23 /* CtrlProxyUITests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CtrlProxyUITests.swift; sourceTree = "<group>"; };
 		83E0B84D4CA225ECB1E09064 /* SdkHierarchyModels.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SdkHierarchyModels.swift; sourceTree = "<group>"; };
+		86E304C3C42FE1AECFDB293B /* SemanticLinkActivation.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SemanticLinkActivation.swift; sourceTree = "<group>"; };
 		878A53A7F0EDDABDF2435E7F /* AppDelegate.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AppDelegate.swift; sourceTree = "<group>"; };
 		8A702D259D2A37D9AA088EF8 /* CommandPayloadTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CommandPayloadTests.swift; sourceTree = "<group>"; };
 		8CB532F74A3F3A670BD526CC /* MultiFingerSwipeDiagnostics.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MultiFingerSwipeDiagnostics.swift; sourceTree = "<group>"; };
+		8E1D0E93B99CBC6F7ED64B7B /* SemanticLinkActivationTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SemanticLinkActivationTests.swift; sourceTree = "<group>"; };
 		95565999DC108319DEED894A /* ElementLocator.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ElementLocator.swift; sourceTree = "<group>"; };
 		9A1B2931E58B158EE51C5F4F /* Fakes.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = Fakes.swift; sourceTree = "<group>"; };
 		9BD704E3A2708D91D4FABE3E /* CtrlProxyApp.app */ = {isa = PBXFileReference; includeInIndex = 0; lastKnownFileType = wrapper.application; path = CtrlProxyApp.app; sourceTree = BUILT_PRODUCTS_DIR; };
@@ -316,6 +321,7 @@
 				A158ADBA8E3301E9FF181598 /* RequestSnapshotWireParityTests.swift */,
 				0033E307147A024BE2F74149 /* RotationChangeGenerationTests.swift */,
 				5408FE8438060177DDAE7177 /* SdkHierarchyCacheTests.swift */,
+				8E1D0E93B99CBC6F7ED64B7B /* SemanticLinkActivationTests.swift */,
 				EA84FDE08DAFEAD66F399887 /* TypedRequestDecodeTests.swift */,
 				AC68B1D8C55DA187332B555E /* WebSocketServerTests.swift */,
 			);
@@ -402,6 +408,7 @@
 				043D2CA5107B76077BA6301C /* SdkHierarchyCache.swift */,
 				E7C65BE687554E71E587B731 /* SdkHierarchyClient.swift */,
 				83E0B84D4CA225ECB1E09064 /* SdkHierarchyModels.swift */,
+				86E304C3C42FE1AECFDB293B /* SemanticLinkActivation.swift */,
 				10362B68AB9153544B411CCA /* VoiceOverStateProvider.swift */,
 				B4CB9272A186932D89EB1072 /* WebSocketServer.swift */,
 			);
@@ -625,6 +632,7 @@
 				0DCD8748EF0E74AD806385A5 /* SdkHierarchyCache.swift in Sources */,
 				0A4F48C4211E43B829855704 /* SdkHierarchyClient.swift in Sources */,
 				2CFEE57D3D518C352BAB2937 /* SdkHierarchyModels.swift in Sources */,
+				6B55D827D015776972629D1F /* SemanticLinkActivation.swift in Sources */,
 				E75D4EFAF582079165A67B66 /* VoiceOverStateProvider.swift in Sources */,
 				C2DCB71857A14ED314300AAC /* WebSocketServer.swift in Sources */,
 			);
@@ -663,6 +671,7 @@
 				1E92C9DDBA24968595494BA3 /* RequestSnapshotWireParityTests.swift in Sources */,
 				BD4056F11836FEAB9B99D1AC /* RotationChangeGenerationTests.swift in Sources */,
 				2ABF683DE1AD6578F8EAF168 /* SdkHierarchyCacheTests.swift in Sources */,
+				A10EB8CB7F9F91B1B86CBAAF /* SemanticLinkActivationTests.swift in Sources */,
 				0F29D59ABFB52692F62B434F /* TypedRequestDecodeTests.swift in Sources */,
 				B33435D31AF41A6C03499842 /* WebSocketServerTests.swift in Sources */,
 			);
@@ -697,6 +706,7 @@
 				EE7765F6DA0807474D52C3DD /* SdkHierarchyCache.swift in Sources */,
 				261F76AE6277D92BD87CFB1C /* SdkHierarchyClient.swift in Sources */,
 				CB577FE46E063BB09F5D4010 /* SdkHierarchyModels.swift in Sources */,
+				D2E88D247B7DA9F929D0CB6B /* SemanticLinkActivation.swift in Sources */,
 				7EBA4E6991444E3154C6BC84 /* VoiceOverStateProvider.swift in Sources */,
 				53A41EE5F98E771345D6EA90 /* WebSocketServer.swift in Sources */,
 			);

--- a/ios/control-proxy/Sources/CtrlProxy/CommandHandler.swift
+++ b/ios/control-proxy/Sources/CtrlProxy/CommandHandler.swift
@@ -152,6 +152,7 @@ public class CommandHandler: CommandHandling {
             // Action commands
             case let .action(payload):
                 return try handleAction(payload, startTime: startTime)
+
             case let .activateAccessibilityLink(payload):
                 return try handleActivateAccessibilityLink(payload, startTime: startTime)
 
@@ -952,12 +953,28 @@ public class CommandHandler: CommandHandling {
     private func handleActivateAccessibilityLink(
         _ request: RequestActivateAccessibilityLink,
         startTime: Date
-    ) throws -> WebSocketResponse {
-        try gesturePerformer.activateAccessibilityLink(
+    )
+        throws -> WebSocketResponse
+    {
+        // Prefer the in-app SDK's per-link geometry: it is the only source that
+        // can disambiguate duplicate inline links and see SwiftUI inline links,
+        // which XCUITest's `.link` query cannot (issue #5560). A resolved center
+        // is tapped directly; otherwise fall back to the XCUITest `.link` path,
+        // which still throws cleanly (never a false success) when nothing matches.
+        if let coordinate = SemanticLinkActivation.coordinate(
+            in: sdkHierarchyClient?.fetchFreshHierarchy(),
+            ownerResourceId: request.ownerResourceId,
             text: request.text,
-            occurrence: request.occurrence,
-            ownerResourceId: request.ownerResourceId
-        )
+            occurrence: request.occurrence
+        ) {
+            try gesturePerformer.tap(x: coordinate.x, y: coordinate.y, duration: 0)
+        } else {
+            try gesturePerformer.activateAccessibilityLink(
+                text: request.text,
+                occurrence: request.occurrence,
+                ownerResourceId: request.ownerResourceId
+            )
+        }
         return WebSocketResponse.success(
             type: ResponseType.actionResult.rawValue,
             requestId: request.requestId,
@@ -1471,11 +1488,11 @@ public class CommandHandler: CommandHandling {
                 success: true,
                 queryType: result.queryType,
                 columns: result.columns,
-                    rows: result.rows,
-                    rowsAffected: result.rowsAffected,
-                    diagnostic: result.diagnostic,
-                    truncated: result.truncated,
-                    totalTimeMs: totalTimeMs(from: startTime)
+                rows: result.rows,
+                rowsAffected: result.rowsAffected,
+                diagnostic: result.diagnostic,
+                truncated: result.truncated,
+                totalTimeMs: totalTimeMs(from: startTime)
             )
         } catch {
             return ExecuteSqlResponse(
@@ -1518,7 +1535,9 @@ public class CommandHandler: CommandHandling {
     private func handleStorageCapabilities(
         _ request: RequestStorageCapabilities,
         startTime: Date
-    ) -> StorageCapabilitiesResponse {
+    )
+        -> StorageCapabilitiesResponse
+    {
         guard let client = sdkDatabaseClient else {
             return StorageCapabilitiesResponse(
                 requestId: request.requestId,

--- a/ios/control-proxy/Sources/CtrlProxy/HierarchyMerger.swift
+++ b/ios/control-proxy/Sources/CtrlProxy/HierarchyMerger.swift
@@ -488,8 +488,18 @@ public enum HierarchyMerger {
         // from the matched in-app SDK node; fall back to the existing value when there is
         // no SDK match. Follows the "true"-or-nil convention (#3924).
         let enrichedFocused = node.fullMatch?.isAccessibilityFocused == true ? "true" : element.accessibilityFocused
+        // Inline semantic links only the in-app SDK can see (attributed text /
+        // SwiftUI link accessibility elements) are projected onto the owning
+        // element as the Android-parity `semanticLinks` (issue #5560). Prefer the
+        // SDK's richer links (real occurrence + range) when present; otherwise keep
+        // whatever XCUITest already surfaced (e.g. a standalone `.link` element).
+        let enrichedSemanticLinks = semanticLinks(from: node.fullMatch) ?? element.semanticLinks
         let enrichmentChanged = node.fullMatch != nil &&
-            (enrichedExtras != element.extras || enrichedFocused != element.accessibilityFocused)
+            (
+                enrichedExtras != element.extras ||
+                    enrichedFocused != element.accessibilityFocused ||
+                    enrichedSemanticLinks != element.semanticLinks
+            )
 
         // Nothing touched this node or its subtree — return the original by value, skipping
         // the field-by-field copy.
@@ -525,7 +535,7 @@ public enum HierarchyMerger {
             checked: element.checked,
             selected: element.selected,
             longClickable: element.longClickable,
-            semanticLinks: element.semanticLinks,
+            semanticLinks: enrichedSemanticLinks,
             testTag: element.testTag,
             role: element.role,
             stateDescription: element.stateDescription,
@@ -537,6 +547,15 @@ public enum HierarchyMerger {
             node: finalChildren
         )
         return (rebuilt, true)
+    }
+
+    /// Project a matched SDK node's inline links onto the Android-parity wire
+    /// shape (`text`/`occurrence`/range), dropping the iOS-only activation center.
+    /// Returns `nil` when the node has no links, so callers can fall back to any
+    /// links XCUITest already surfaced.
+    private static func semanticLinks(from sdkNode: SdkViewNode?) -> [SemanticLink]? {
+        guard let links = sdkNode?.semanticLinks, !links.isEmpty else { return nil }
+        return links.map { SemanticLink(text: $0.text, occurrence: $0.occurrence, start: $0.start, end: $0.end) }
     }
 
     /// Populate `sdk.*` extras from a matched SDK node. Only non-default SDK fields are

--- a/ios/control-proxy/Sources/CtrlProxy/SdkHierarchyModels.swift
+++ b/ios/control-proxy/Sources/CtrlProxy/SdkHierarchyModels.swift
@@ -1,6 +1,7 @@
 import Foundation
 
 // MARK: - SDK View Hierarchy Models
+
 // Duplicated from AutoMobileSDK since the two packages have no shared dependency.
 
 /// Complete snapshot of the in-process UIView hierarchy from the SDK.
@@ -87,6 +88,11 @@ public struct SdkViewNode: Codable, Sendable {
     public let isUserInteractionEnabled: Bool
     public let hasTapTarget: Bool
     public let isOccluded: Bool
+    /// Inline semantic links the in-app SDK discovered on this text element
+    /// (issue #5560). The runner projects these onto the merged element's
+    /// `semantic-links` and uses the optional per-link center point to activate a
+    /// specific inline link by coordinate.
+    public let semanticLinks: [SdkSemanticLink]?
     public let children: [SdkViewNode]?
 
     public init(
@@ -110,6 +116,7 @@ public struct SdkViewNode: Codable, Sendable {
         isUserInteractionEnabled: Bool = true,
         hasTapTarget: Bool = false,
         isOccluded: Bool = false,
+        semanticLinks: [SdkSemanticLink]? = nil,
         children: [SdkViewNode]? = nil
     ) {
         self.className = className
@@ -132,6 +139,7 @@ public struct SdkViewNode: Codable, Sendable {
         self.isUserInteractionEnabled = isUserInteractionEnabled
         self.hasTapTarget = hasTapTarget
         self.isOccluded = isOccluded
+        self.semanticLinks = semanticLinks
         self.children = children
     }
 
@@ -141,32 +149,62 @@ public struct SdkViewNode: Codable, Sendable {
              accessibilityTraits, accessibilityCustomActions, gestureRecognizers,
              alpha, backgroundColor, cornerRadius,
              borderColor, borderWidth, isLayerNode,
-             isHidden, isUserInteractionEnabled, hasTapTarget, isOccluded, children
+             isHidden, isUserInteractionEnabled, hasTapTarget, isOccluded, semanticLinks, children
     }
 
     public init(from decoder: Decoder) throws {
         let c = try decoder.container(keyedBy: CodingKeys.self)
-        self.className = try c.decode(String.self, forKey: .className)
-        self.bounds = try c.decode(SdkBounds.self, forKey: .bounds)
-        self.accessibilityLabel = try c.decodeIfPresent(String.self, forKey: .accessibilityLabel)
-        self.accessibilityIdentifier = try c.decodeIfPresent(String.self, forKey: .accessibilityIdentifier)
-        self.isAccessibilityElement = try c.decodeIfPresent(Bool.self, forKey: .isAccessibilityElement) ?? false
-        self.isAccessibilityFocused = try c.decodeIfPresent(Bool.self, forKey: .isAccessibilityFocused) ?? false
-        self.accessibilityElementsHidden = try c.decodeIfPresent(Bool.self, forKey: .accessibilityElementsHidden) ?? false
-        self.accessibilityTraits = try c.decodeIfPresent([String].self, forKey: .accessibilityTraits) ?? []
-        self.accessibilityCustomActions = try c.decodeIfPresent([String].self, forKey: .accessibilityCustomActions) ?? []
-        self.gestureRecognizers = try c.decodeIfPresent([SdkGestureInfo].self, forKey: .gestureRecognizers) ?? []
-        self.alpha = try c.decodeIfPresent(Float.self, forKey: .alpha) ?? 1.0
-        self.backgroundColor = try c.decodeIfPresent(String.self, forKey: .backgroundColor)
-        self.cornerRadius = try c.decodeIfPresent(Float.self, forKey: .cornerRadius) ?? 0
-        self.borderColor = try c.decodeIfPresent(String.self, forKey: .borderColor)
-        self.borderWidth = try c.decodeIfPresent(Float.self, forKey: .borderWidth) ?? 0
-        self.isLayerNode = try c.decodeIfPresent(Bool.self, forKey: .isLayerNode) ?? false
-        self.isHidden = try c.decodeIfPresent(Bool.self, forKey: .isHidden) ?? false
-        self.isUserInteractionEnabled = try c.decodeIfPresent(Bool.self, forKey: .isUserInteractionEnabled) ?? true
-        self.hasTapTarget = try c.decodeIfPresent(Bool.self, forKey: .hasTapTarget) ?? false
-        self.isOccluded = try c.decodeIfPresent(Bool.self, forKey: .isOccluded) ?? false
-        self.children = try c.decodeIfPresent([SdkViewNode].self, forKey: .children)
+        className = try c.decode(String.self, forKey: .className)
+        bounds = try c.decode(SdkBounds.self, forKey: .bounds)
+        accessibilityLabel = try c.decodeIfPresent(String.self, forKey: .accessibilityLabel)
+        accessibilityIdentifier = try c.decodeIfPresent(String.self, forKey: .accessibilityIdentifier)
+        isAccessibilityElement = try c.decodeIfPresent(Bool.self, forKey: .isAccessibilityElement) ?? false
+        isAccessibilityFocused = try c.decodeIfPresent(Bool.self, forKey: .isAccessibilityFocused) ?? false
+        accessibilityElementsHidden = try c.decodeIfPresent(Bool.self, forKey: .accessibilityElementsHidden) ?? false
+        accessibilityTraits = try c.decodeIfPresent([String].self, forKey: .accessibilityTraits) ?? []
+        accessibilityCustomActions = try c.decodeIfPresent([String].self, forKey: .accessibilityCustomActions) ?? []
+        gestureRecognizers = try c.decodeIfPresent([SdkGestureInfo].self, forKey: .gestureRecognizers) ?? []
+        alpha = try c.decodeIfPresent(Float.self, forKey: .alpha) ?? 1.0
+        backgroundColor = try c.decodeIfPresent(String.self, forKey: .backgroundColor)
+        cornerRadius = try c.decodeIfPresent(Float.self, forKey: .cornerRadius) ?? 0
+        borderColor = try c.decodeIfPresent(String.self, forKey: .borderColor)
+        borderWidth = try c.decodeIfPresent(Float.self, forKey: .borderWidth) ?? 0
+        isLayerNode = try c.decodeIfPresent(Bool.self, forKey: .isLayerNode) ?? false
+        isHidden = try c.decodeIfPresent(Bool.self, forKey: .isHidden) ?? false
+        isUserInteractionEnabled = try c.decodeIfPresent(Bool.self, forKey: .isUserInteractionEnabled) ?? true
+        hasTapTarget = try c.decodeIfPresent(Bool.self, forKey: .hasTapTarget) ?? false
+        isOccluded = try c.decodeIfPresent(Bool.self, forKey: .isOccluded) ?? false
+        semanticLinks = try c.decodeIfPresent([SdkSemanticLink].self, forKey: .semanticLinks)
+        children = try c.decodeIfPresent([SdkViewNode].self, forKey: .children)
+    }
+}
+
+/// A single inline semantic link the in-app SDK discovered on a text element,
+/// as decoded from the SDK's hierarchy payload (issue #5560). Mirrors the SDK's
+/// `SdkSemanticLink` wire shape: the Android-parity `text`/`occurrence`/range plus
+/// the iOS-only optional on-screen center point used for coordinate activation.
+public struct SdkSemanticLink: Codable, Sendable, Equatable {
+    public let text: String
+    public let occurrence: Int
+    public let start: Int?
+    public let end: Int?
+    public let centerX: Double?
+    public let centerY: Double?
+
+    public init(
+        text: String,
+        occurrence: Int,
+        start: Int? = nil,
+        end: Int? = nil,
+        centerX: Double? = nil,
+        centerY: Double? = nil
+    ) {
+        self.text = text
+        self.occurrence = occurrence
+        self.start = start
+        self.end = end
+        self.centerX = centerX
+        self.centerY = centerY
     }
 }
 

--- a/ios/control-proxy/Sources/CtrlProxy/SemanticLinkActivation.swift
+++ b/ios/control-proxy/Sources/CtrlProxy/SemanticLinkActivation.swift
@@ -1,0 +1,95 @@
+import Foundation
+
+/// Resolves an inline semantic link to the on-screen point the runner taps to
+/// activate it (issue #5560).
+///
+/// XCUITest can only tap a link that surfaces as its own `.link` element, which
+/// fails for duplicate inline links (all report occurrence 0) and for SwiftUI
+/// inline links (never surfaced). The in-app SDK, however, walks the real
+/// attributed text / link accessibility elements and reports each link's center
+/// point; this projects the requested `(owner, text, occurrence)` onto that
+/// point so the runner can activate the exact link by coordinate.
+public enum SemanticLinkActivation {
+    public struct Coordinate: Equatable, Sendable {
+        public let x: Double
+        public let y: Double
+
+        public init(x: Double, y: Double) {
+            self.x = x
+            self.y = y
+        }
+    }
+
+    /// The activation point for the requested link, or `nil` when it cannot be
+    /// resolved from the SDK hierarchy (no SDK match, or the matched link has no
+    /// geometry) — in which case the caller falls back to the XCUITest path.
+    ///
+    /// - With `ownerResourceId`: match within elements carrying that identifier,
+    ///   using the link's own per-owner `occurrence`.
+    /// - Without an owner: index the `occurrence`-th matching-text link across the
+    ///   whole tree in document order.
+    public static func coordinate(
+        in hierarchy: SdkViewHierarchy?,
+        ownerResourceId: String?,
+        text: String,
+        occurrence: Int
+    )
+        -> Coordinate?
+    {
+        guard let root = hierarchy?.root else { return nil }
+
+        if let ownerResourceId {
+            for owner in matchingNodes(from: root, where: { $0.accessibilityIdentifier == ownerResourceId }) {
+                if let link = owner.semanticLinks?.first(where: {
+                    $0.occurrence == occurrence && matches($0.text, text)
+                }), let coordinate = coordinate(of: link) {
+                    return coordinate
+                }
+            }
+            return nil
+        }
+
+        var matchIndex = 0
+        for node in preorder(root) {
+            for link in node.semanticLinks ?? [] where matches(link.text, text) {
+                if matchIndex == occurrence {
+                    return coordinate(of: link)
+                }
+                matchIndex += 1
+            }
+        }
+        return nil
+    }
+
+    private static func matches(_ lhs: String, _ rhs: String) -> Bool {
+        lhs.caseInsensitiveCompare(rhs) == .orderedSame
+    }
+
+    private static func coordinate(of link: SdkSemanticLink) -> Coordinate? {
+        guard let x = link.centerX, let y = link.centerY else { return nil }
+        return Coordinate(x: x, y: y)
+    }
+
+    private static func matchingNodes(
+        from root: SdkViewNode,
+        where predicate: (SdkViewNode) -> Bool
+    )
+        -> [SdkViewNode]
+    {
+        preorder(root).filter(predicate)
+    }
+
+    /// Depth-first, parent-before-children traversal so "document order" matches
+    /// the visual reading order of the merged hierarchy.
+    private static func preorder(_ root: SdkViewNode) -> [SdkViewNode] {
+        var out: [SdkViewNode] = []
+        var stack: [SdkViewNode] = [root]
+        while let node = stack.popLast() {
+            out.append(node)
+            if let children = node.children {
+                stack.append(contentsOf: children.reversed())
+            }
+        }
+        return out
+    }
+}

--- a/ios/control-proxy/Tests/CtrlProxyTests/CommandHandlerTests.swift
+++ b/ios/control-proxy/Tests/CtrlProxyTests/CommandHandlerTests.swift
@@ -176,13 +176,14 @@ final class CommandHandlerTests: XCTestCase {
             sdkHierarchyClient: fetcher
         )
 
-        let response = commandHandler.handle(WebSocketRequest.setNetworkErrorSimulation(RequestSetNetworkErrorSimulation(
-            requestId: "sim-sync-1",
-            enabled: true,
-            errorType: "timeout",
-            limit: 2,
-            expiresAtEpochMs: 1_720_000_000_000
-        )))
+        let response = commandHandler
+            .handle(WebSocketRequest.setNetworkErrorSimulation(RequestSetNetworkErrorSimulation(
+                requestId: "sim-sync-1",
+                enabled: true,
+                errorType: "timeout",
+                limit: 2,
+                expiresAtEpochMs: 1_720_000_000_000
+            )))
 
         guard let typed = response as? SetNetworkErrorSimulationResponse else {
             XCTFail("Expected SetNetworkErrorSimulationResponse, got \(Swift.type(of: response))")
@@ -622,8 +623,10 @@ final class CommandHandlerTests: XCTestCase {
 
         XCTAssertFalse(response.success ?? true)
         XCTAssertEqual(response.type, "multi_finger_swipe_result")
-        XCTAssertTrue(response.error?
-            .contains("XCTest private multi-touch event synthesis classes are unavailable") ?? false)
+        XCTAssertTrue(
+            response.error?
+                .contains("XCTest private multi-touch event synthesis classes are unavailable") ?? false
+        )
     }
 
     func testPinchSuccessForwardsRequestPayload() {
@@ -2286,5 +2289,97 @@ final class DatabaseCommandHandlerTests: XCTestCase {
         XCTAssertEqual(CommandHandler.sanitizedTableOffset(.infinity), 0)
         XCTAssertEqual(CommandHandler.sanitizedTableOffset(-.infinity), 0)
         XCTAssertEqual(CommandHandler.sanitizedTableOffset(.nan), 0)
+    }
+}
+
+/// Routing coverage for `request_activate_accessibility_link` (issue #5560): an
+/// SDK-resolved inline link is tapped by coordinate; anything the SDK cannot
+/// resolve falls back to the XCUITest `.link` activation path.
+final class ActivateAccessibilityLinkCommandHandlerTests: XCTestCase {
+    private var fakeGesturePerformer: FakeGesturePerformer!
+    private var fakeSdkHierarchy: FakeSdkHierarchyFetcher!
+    private var perfProvider: PerfProvider!
+    private var commandHandler: CommandHandler!
+
+    override func setUp() {
+        super.setUp()
+        perfProvider = PerfProvider.createForTesting(timeProvider: FakeTimeProvider(initialTime: 1000))
+        fakeGesturePerformer = FakeGesturePerformer()
+        fakeSdkHierarchy = FakeSdkHierarchyFetcher()
+        commandHandler = CommandHandler.createForTesting(
+            elementLocator: FakeElementLocator(),
+            gesturePerformer: fakeGesturePerformer,
+            perfProvider: perfProvider,
+            sdkHierarchyClient: fakeSdkHierarchy
+        )
+    }
+
+    override func tearDown() {
+        perfProvider.clear()
+        PerfProvider.resetInstance()
+        super.tearDown()
+    }
+
+    private func ownerHierarchy(links: [SdkSemanticLink]) -> SdkViewHierarchy {
+        SdkViewHierarchy(
+            timestamp: 1,
+            bundleId: "com.example.app",
+            screenScale: 3,
+            screenWidth: 375,
+            screenHeight: 812,
+            root: SdkViewNode(
+                className: "UITextView",
+                bounds: SdkBounds(left: 0, top: 0, right: 375, bottom: 72),
+                accessibilityIdentifier: "inline_owner",
+                semanticLinks: links
+            )
+        )
+    }
+
+    private func activate(text: String, occurrence: Int, owner: String?) {
+        _ = commandHandler.handle(.activateAccessibilityLink(RequestActivateAccessibilityLink(
+            requestId: "link-1",
+            text: text,
+            occurrence: occurrence,
+            ownerResourceId: owner
+        )))
+    }
+
+    func testResolvedInlineLinkIsActivatedByCoordinateTap() {
+        fakeSdkHierarchy.setFreshHierarchy(ownerHierarchy(links: [
+            SdkSemanticLink(text: "Terms of Service", occurrence: 0, start: 9, end: 25, centerX: 40, centerY: 20),
+            SdkSemanticLink(text: "Terms of Service", occurrence: 1, start: 58, end: 74, centerX: 300, centerY: 20),
+        ]))
+
+        activate(text: "Terms of Service", occurrence: 1, owner: "inline_owner")
+
+        let taps = fakeGesturePerformer.getTapHistory()
+        XCTAssertEqual(taps.count, 1)
+        XCTAssertEqual(taps.first?.x, 300)
+        XCTAssertEqual(taps.first?.y, 20)
+        // The XCUITest fallback path must not also run.
+        XCTAssertTrue(fakeGesturePerformer.getActionHistory().isEmpty)
+    }
+
+    func testUnresolvedLinkFallsBackToXcuitestActivation() {
+        // No SDK geometry (link lacks a center) → fall through to the XCUITest path.
+        fakeSdkHierarchy.setFreshHierarchy(ownerHierarchy(links: [
+            SdkSemanticLink(text: "Support", occurrence: 0),
+        ]))
+
+        activate(text: "Support", occurrence: 0, owner: "inline_owner")
+
+        XCTAssertTrue(fakeGesturePerformer.getTapHistory().isEmpty)
+        let actions = fakeGesturePerformer.getActionHistory()
+        XCTAssertEqual(actions.count, 1)
+        XCTAssertEqual(actions.first?.action, "activate_accessibility_link")
+        XCTAssertEqual(actions.first?.label, "Support#0")
+    }
+
+    func testNoSdkHierarchyFallsBackToXcuitestActivation() {
+        activate(text: "Privacy Policy", occurrence: 0, owner: nil)
+
+        XCTAssertTrue(fakeGesturePerformer.getTapHistory().isEmpty)
+        XCTAssertEqual(fakeGesturePerformer.getActionHistory().first?.action, "activate_accessibility_link")
     }
 }

--- a/ios/control-proxy/Tests/CtrlProxyTests/HierarchyMergerTests.swift
+++ b/ios/control-proxy/Tests/CtrlProxyTests/HierarchyMergerTests.swift
@@ -351,6 +351,64 @@ final class HierarchyMergerTests: XCTestCase {
         XCTAssertEqual(childExtras?["sdk.backgroundColor"], "#00FF00FF")
     }
 
+    func testEnrichesOwnerElementWithSdkSemanticLinks() {
+        // The XCUITest snapshot of an inline-link text owner carries no links;
+        // the in-app SDK supplies them and the merge must project them onto the
+        // owning element as `semantic-links` (issue #5560).
+        let owner = UIElementInfo(
+            text: "Read the Terms of Service, contact Support, or review the Terms of Service again.",
+            resourceId: "uikit_semantic_links_inline",
+            className: "UITextView",
+            bounds: ElementBounds(left: 0, top: 0, right: 375, bottom: 72)
+        )
+        let sdkOwner = SdkViewNode(
+            className: "UITextView",
+            bounds: SdkBounds(left: 0, top: 0, right: 375, bottom: 72),
+            accessibilityIdentifier: "uikit_semantic_links_inline",
+            semanticLinks: [
+                SdkSemanticLink(text: "Terms of Service", occurrence: 0, start: 9, end: 25, centerX: 40, centerY: 20),
+                SdkSemanticLink(text: "Support", occurrence: 0, start: 35, end: 42),
+                SdkSemanticLink(text: "Terms of Service", occurrence: 1, start: 58, end: 74),
+            ]
+        )
+
+        let result = HierarchyMerger.merge(
+            xcuitest: makeHierarchy(root: owner),
+            sdk: makeSdkHierarchy(root: sdkOwner)
+        )
+
+        let links = result.hierarchy?.semanticLinks
+        XCTAssertEqual(links?.count, 3)
+        XCTAssertEqual(links?.map(\.text), ["Terms of Service", "Support", "Terms of Service"])
+        XCTAssertEqual(links?.map(\.occurrence), [0, 0, 1])
+        XCTAssertEqual(links?[0].start, 9)
+        XCTAssertEqual(links?[2].start, 58)
+    }
+
+    func testDoesNotOverrideExistingXcuitestSemanticLinksWhenSdkHasNone() {
+        // A standalone XCUITest link already carries a single-entry semanticLinks;
+        // an SDK match without links must leave it intact.
+        let standalone = UIElementInfo(
+            resourceId: "uikit_semantic_links_standalone",
+            className: "UITextView",
+            bounds: ElementBounds(left: 0, top: 0, right: 200, bottom: 28),
+            semanticLinks: [SemanticLink(text: "Privacy Policy", occurrence: 0)]
+        )
+        let sdkStandalone = SdkViewNode(
+            className: "UITextView",
+            bounds: SdkBounds(left: 0, top: 0, right: 200, bottom: 28),
+            accessibilityIdentifier: "uikit_semantic_links_standalone",
+            backgroundColor: "#00000000"
+        )
+
+        let result = HierarchyMerger.merge(
+            xcuitest: makeHierarchy(root: standalone),
+            sdk: makeSdkHierarchy(root: sdkStandalone)
+        )
+
+        XCTAssertEqual(result.hierarchy?.semanticLinks?.map(\.text), ["Privacy Policy"])
+    }
+
     func testIdentifierFallbackMatchesDifferentBounds() {
         // XCUITest and SDK have different bounds but same accessibilityIdentifier
         let xcuiWithId = UIElementInfo(

--- a/ios/control-proxy/Tests/CtrlProxyTests/SemanticLinkActivationTests.swift
+++ b/ios/control-proxy/Tests/CtrlProxyTests/SemanticLinkActivationTests.swift
@@ -1,0 +1,111 @@
+@testable import CtrlProxy
+import XCTest
+
+/// Pure resolution of an inline semantic link to the on-screen point the runner
+/// taps to activate it (issue #5560). The coordinate tap itself is XCUITest and
+/// verified on-device; this pins the owner/occurrence/geometry selection logic.
+final class SemanticLinkActivationTests: XCTestCase {
+    private func node(
+        _ identifier: String? = nil,
+        links: [SdkSemanticLink]? = nil,
+        children: [SdkViewNode]? = nil
+    )
+        -> SdkViewNode
+    {
+        SdkViewNode(
+            className: "UITextView",
+            bounds: SdkBounds(left: 0, top: 0, right: 375, bottom: 100),
+            accessibilityIdentifier: identifier,
+            semanticLinks: links,
+            children: children
+        )
+    }
+
+    private func hierarchy(root: SdkViewNode) -> SdkViewHierarchy {
+        SdkViewHierarchy(timestamp: 1, bundleId: "x", screenScale: 3, screenWidth: 375, screenHeight: 812, root: root)
+    }
+
+    func testResolvesOwnerScopedOccurrenceToItsCenter() {
+        let owner = node("inline", links: [
+            SdkSemanticLink(text: "Terms of Service", occurrence: 0, start: 9, end: 25, centerX: 40, centerY: 20),
+            SdkSemanticLink(text: "Terms of Service", occurrence: 1, start: 58, end: 74, centerX: 300, centerY: 20),
+        ])
+        let root = node(children: [owner])
+
+        let first = SemanticLinkActivation.coordinate(
+            in: hierarchy(root: root), ownerResourceId: "inline", text: "Terms of Service", occurrence: 0
+        )
+        let second = SemanticLinkActivation.coordinate(
+            in: hierarchy(root: root), ownerResourceId: "inline", text: "Terms of Service", occurrence: 1
+        )
+
+        XCTAssertEqual(first, SemanticLinkActivation.Coordinate(x: 40, y: 20))
+        XCTAssertEqual(second, SemanticLinkActivation.Coordinate(x: 300, y: 20))
+    }
+
+    func testMatchesLinkTextCaseInsensitively() {
+        let owner = node("inline", links: [
+            SdkSemanticLink(text: "Support", occurrence: 0, centerX: 10, centerY: 10),
+        ])
+        let coordinate = SemanticLinkActivation.coordinate(
+            in: hierarchy(root: node(children: [owner])),
+            ownerResourceId: "inline",
+            text: "support",
+            occurrence: 0
+        )
+        XCTAssertEqual(coordinate, SemanticLinkActivation.Coordinate(x: 10, y: 10))
+    }
+
+    func testWithoutOwnerPicksNthMatchingLinkInDocumentOrder() {
+        // Bare `accessibilityLink` path: occurrence indexes matching-text links
+        // across the whole tree in document order.
+        let a = node("a", links: [SdkSemanticLink(text: "Docs", occurrence: 0, centerX: 1, centerY: 1)])
+        let b = node("b", links: [SdkSemanticLink(text: "Docs", occurrence: 0, centerX: 2, centerY: 2)])
+        let root = node(children: [a, b])
+
+        XCTAssertEqual(
+            SemanticLinkActivation.coordinate(
+                in: hierarchy(root: root),
+                ownerResourceId: nil,
+                text: "Docs",
+                occurrence: 0
+            ),
+            SemanticLinkActivation.Coordinate(x: 1, y: 1)
+        )
+        XCTAssertEqual(
+            SemanticLinkActivation.coordinate(
+                in: hierarchy(root: root),
+                ownerResourceId: nil,
+                text: "Docs",
+                occurrence: 1
+            ),
+            SemanticLinkActivation.Coordinate(x: 2, y: 2)
+        )
+    }
+
+    func testReturnsNilWhenLinkLacksCenter() {
+        let owner = node("inline", links: [SdkSemanticLink(text: "Support", occurrence: 0)])
+        XCTAssertNil(SemanticLinkActivation.coordinate(
+            in: hierarchy(root: node(children: [owner])),
+            ownerResourceId: "inline", text: "Support", occurrence: 0
+        ))
+    }
+
+    func testReturnsNilWhenOwnerOrLinkMissing() {
+        let owner = node("inline", links: [SdkSemanticLink(text: "Support", occurrence: 0, centerX: 1, centerY: 1)])
+        let h = hierarchy(root: node(children: [owner]))
+        XCTAssertNil(SemanticLinkActivation.coordinate(in: h, ownerResourceId: "other", text: "Support", occurrence: 0))
+        XCTAssertNil(SemanticLinkActivation.coordinate(
+            in: h,
+            ownerResourceId: "inline",
+            text: "Support",
+            occurrence: 5
+        ))
+        XCTAssertNil(SemanticLinkActivation.coordinate(
+            in: nil,
+            ownerResourceId: "inline",
+            text: "Support",
+            occurrence: 0
+        ))
+    }
+}


### PR DESCRIPTION
## Summary

Brings iOS to parity with Android for **UIKit** `UITextView`/`NSAttributedString` inline accessibility links (issue #5560). `observe` now surfaces inline `semantic-links` on the **owning** text element with correct per-link `occurrence` and character range (so duplicate link text is disambiguable), and `tapOn { accessibilityLink }` / `{ selector, subtext }` activate the specific inline link.

The mechanism follows Android's in-process approach: the in-app SDK view-walk reads the text view's `attributedText`, extracts each `.link` run, and attaches the full link list to the owning element; the runner merges those onto the owning `UIElementInfo` and activates a specific link by tapping the SDK-computed per-link center point (the only way to disambiguate duplicate inline links and reach links XCUITest cannot see).

## Linked Issue

Closes #5560

## Bug / Regression Context

- **Observed symptom:** on iOS, inline links surfaced only as separate per-child `UILink` elements each stamped `occurrence: 0` (no way to tell the first "Terms of Service" from the second), and inline links could not be activated. A prerequisite bug also surfaced: once any text field appeared, iOS keeps an empty `UITextEffectsWindow`/`UIRemoteKeyboardWindow` above the app content, and the SDK walker (which selects the highest window level) snapshotted that empty overlay — blanking the **entire** in-app SDK hierarchy.
- **Repro:** Playground → Demos → "Semantic Links (UIKit)"; `observe`, then `tapOn { selector: { accessibilityLink: "Terms of Service" }, index: 1 }`.

## Changes

- **`SemanticLinkExtractor`** (SDK, pure/Foundation) — `NSAttributedString → [SdkSemanticLink]` with per-text ascending `occurrence` + UTF-16 range; plus an ordered-`.link`-accessibility-element fallback.
- **`ViewHierarchyWalker`** — computes `semanticLinks` (and a tappable center via TextKit `firstRect(for:)`) for text views; **`WindowClassification`** skips empty overlay windows in `visibleKeyWindow()`.
- **`HierarchyMerger`** — projects the SDK's links onto the owning element's `semantic-links`, preferring them over XCUITest's single-entry links.
- **`SemanticLinkActivation` + `CommandHandler`** — resolve `(owner, text, occurrence)` to the SDK center point and tap it; fall back to the XCUITest `.link` path; never report a false `success`.

## Validation

- [x] `scripts/ios/swift-test.sh` — all 4 packages pass (auto-mobile-sdk **296**, control-proxy **498**, XCTestRunner, screen-capture); `swift build -warnings-as-errors`
- [x] SwiftLint / SwiftFormat clean on changed files; `xcodegen` regenerated (`CtrlProxy.xcodeproj`)
- [x] No TS changes (host already reads `semantic-links` and routes owner/subtext); typecheck/JS suites unaffected
- [x] New Swift logic uses pure, injected helpers unit-tested on the macOS destination

## Device Verification

Verified end-to-end on an iPhone 16 Pro simulator (iOS 18) with a locally built runner + SDK against the "Semantic Links (UIKit)" demo:

- **Discovery** — owner `UITextView` carries `[{Terms occ 0, 9–25}, {Support occ 0, 35–42}, {Terms occ 1, 58–74}]`.
- **Activation** — `Support` → "Last activated: Support"; index 0 → "Terms of Service (first)"; index 1 → "Terms of Service (second)"; standalone → "Privacy Policy".
- **Clean failure** — nonexistent link → `success:false, "Element not found: semantic link '…' occurrence 0"`, label unchanged.

## Follow-ups

- [x] SwiftUI `Text(AttributedString)` inline-link discovery (invisible to both XCUITest and a plain UIView walk; needs an AXBridge secondary hierarchy source) filed as #5578, scoped to the AXBridge family (#2274/#2273/#2266).



### Reviewed & intentionally deferred (edge cases, non-blocking)
Self-review surfaced three narrow edge cases, all out of scope for this PR (ACs target in-view links and are device-verified):
- **Off-screen link → blind coordinate tap reports success.** The SDK-coordinate path does not re-check on-screen/hittability the way the XCUITest fallback does, so a link scrolled off-screen could no-op yet report success. Nonexistent links still fail cleanly (AC3 holds).
- **Owner-uniqueness re-check races the fresh SDK fetch.** `TapOnElement.hasUniqueSemanticLinkOwner` gates uniqueness against the observed hierarchy; the runner then fetches a *fresh* hierarchy that is not re-checked. Only matters if a duplicate `resource-id` appears between observe and activation.
- **UTF-16 vs grapheme offset.** `linkCenter` feeds NSString UTF-16 offsets into `UITextInput.position(from:offset:)`; astral-plane characters (emoji) preceding a link would shift the computed tap center. Cosmetic mis-center only.

A non-finite center-coordinate guard (would otherwise blank the whole hierarchy encode) was addressed in this PR.
