### PR TITLE
fix(desktop): injectable, timeout-bounded daemon status probe (#4858)

### DIFF
--- a/android/desktop-app/src/main/kotlin/dev/jasonpearson/automobile/desktop/AutoMobileDesktopApp.kt
+++ b/android/desktop-app/src/main/kotlin/dev/jasonpearson/automobile/desktop/AutoMobileDesktopApp.kt
@@ -23,7 +23,6 @@ import androidx.compose.ui.unit.dp
 import androidx.compose.ui.window.Popup
 import androidx.compose.ui.window.PopupProperties
 import dev.jasonpearson.automobile.desktop.core.connection.ConnectionState
-import dev.jasonpearson.automobile.desktop.core.connection.DaemonConnectionMonitor
 import dev.jasonpearson.automobile.desktop.core.daemon.AutoMobileClient
 import dev.jasonpearson.automobile.desktop.core.daemon.DaemonSocketPaths
 import dev.jasonpearson.automobile.desktop.core.daemon.DesktopDaemonSession
@@ -71,7 +70,6 @@ import dev.jasonpearson.automobile.desktop.core.workspace.rememberWorkspaceDevic
 import dev.jasonpearson.automobile.desktop.core.workspace.wireName
 import dev.jasonpearson.automobile.desktop.theme.AutoMobileTheme
 import java.util.concurrent.atomic.AtomicLong
-import kotlin.time.Duration.Companion.milliseconds
 import kotlinx.coroutines.CancellationException
 import kotlinx.coroutines.CoroutineScope
 import kotlinx.coroutines.Dispatchers
@@ -90,10 +88,6 @@ private val LOG = LoggerFactory.getLogger("AutoMobileDesktopApp")
 // Matches AutoMobileContent's binding heartbeat cadence.
 private const val DESKTOP_SESSION_HEARTBEAT_MS = 2_000L
 
-// How often the top-bar status dot re-probes daemon connectivity. Matches the health sheet's
-// read-only refresh cadence (WorkspaceShell.HEALTH_SHEET_REFRESH_MS).
-private const val DAEMON_STATUS_POLL_MS = 5_000L
-
 // How often each observed pane's lock state is re-read so the contextual Unlock control appears or
 // disappears as the device locks/unlocks. Runs only while at least one device is observed. NOTE:
 // it re-reads the whole booted-devices resource, which recomputes service status AND the keyguard
@@ -105,29 +99,6 @@ private const val LOCK_STATE_POLL_MS = 4_000L
 // started/killed by another client appear without a manual refresh. Matches AutoMobileContent's
 // booted-devices poll cadence.
 private const val GRID_REFRESH_POLL_MS = 5_000L
-
-/**
- * Live daemon connectivity as a [ConnectionState], polled from [AutoMobileClient.getDaemonStatus].
- * A successful status call means the daemon socket is reachable ([ConnectionState.Connected]); a
- * throw means it is not ([ConnectionState.Disconnected]). Starts as [ConnectionState.Connecting]
- * until the first probe resolves.
- */
-@Composable
-private fun rememberDaemonConnectionState(client: AutoMobileClient): ConnectionState {
-  val monitor =
-    remember(client) {
-      DaemonConnectionMonitor(
-        probe = { withContext(Dispatchers.IO) { client.getDaemonStatus() } },
-        pollInterval = DAEMON_STATUS_POLL_MS.milliseconds,
-        // A failed status call means the daemon socket is unreachable; the dot goes red via the
-        // returned Disconnected state, and this keeps a trace behind the dot.
-        onProbeFailure = { error ->
-          LOG.warn("Daemon status poll failed: ${error.message}", error)
-        },
-      )
-    }
-  return monitor.connectionStates.collectAsState(initial = ConnectionState.Connecting).value
-}
 
 /**
  * Wraps a [SettingsProvider] so that [themeMode] is backed by Compose snapshot state, enabling
@@ -148,6 +119,10 @@ private class ObservableSettingsProvider(private val delegate: SettingsProvider)
 fun AutoMobileDesktopApp(
   @Suppress("UNUSED_PARAMETER") menuBarActions: MenuBarActions = remember { MenuBarActions() },
   openPaletteRequest: Int = 0,
+  // Hoisted from the single app-level DaemonConnectionMonitor in Main.kt so the status dot and the
+  // system-tray icon share one daemon-health source instead of each running its own 5s poll
+  // (#4858).
+  daemonConnectionState: ConnectionState = ConnectionState.Connecting,
 ) {
   val graph = LocalAutoMobileGraph.current
 
@@ -434,10 +409,9 @@ fun AutoMobileDesktopApp(
             // facet-owned and carry screenshots, so opening extra status-only streams would be
             // wasteful. deriveWorkspaceStatus already handles the device dimension, so it can be
             // fed once a central per-device stream registry exists (follow-up).
-            val daemonState = rememberDaemonConnectionState(graph.autoMobileClient)
             val workspaceStatus =
-              remember(daemonState) {
-                deriveWorkspaceStatus(daemon = daemonState, devices = emptyList())
+              remember(daemonConnectionState) {
+                deriveWorkspaceStatus(daemon = daemonConnectionState, devices = emptyList())
               }
 
             WorkspaceShell(

--- a/android/desktop-app/src/main/kotlin/dev/jasonpearson/automobile/desktop/AutoMobileDesktopApp.kt
+++ b/android/desktop-app/src/main/kotlin/dev/jasonpearson/automobile/desktop/AutoMobileDesktopApp.kt
@@ -126,7 +126,7 @@ private fun rememberDaemonConnectionState(client: AutoMobileClient): ConnectionS
         },
       )
     }
-  return monitor.connectionStates().collectAsState(initial = ConnectionState.Connecting).value
+  return monitor.connectionStates.collectAsState(initial = ConnectionState.Connecting).value
 }
 
 /**

--- a/android/desktop-app/src/main/kotlin/dev/jasonpearson/automobile/desktop/AutoMobileDesktopApp.kt
+++ b/android/desktop-app/src/main/kotlin/dev/jasonpearson/automobile/desktop/AutoMobileDesktopApp.kt
@@ -23,6 +23,7 @@ import androidx.compose.ui.unit.dp
 import androidx.compose.ui.window.Popup
 import androidx.compose.ui.window.PopupProperties
 import dev.jasonpearson.automobile.desktop.core.connection.ConnectionState
+import dev.jasonpearson.automobile.desktop.core.connection.DaemonConnectionMonitor
 import dev.jasonpearson.automobile.desktop.core.daemon.AutoMobileClient
 import dev.jasonpearson.automobile.desktop.core.daemon.DaemonSocketPaths
 import dev.jasonpearson.automobile.desktop.core.daemon.DesktopDaemonSession
@@ -70,6 +71,7 @@ import dev.jasonpearson.automobile.desktop.core.workspace.rememberWorkspaceDevic
 import dev.jasonpearson.automobile.desktop.core.workspace.wireName
 import dev.jasonpearson.automobile.desktop.theme.AutoMobileTheme
 import java.util.concurrent.atomic.AtomicLong
+import kotlin.time.Duration.Companion.milliseconds
 import kotlinx.coroutines.CancellationException
 import kotlinx.coroutines.CoroutineScope
 import kotlinx.coroutines.Dispatchers
@@ -112,27 +114,19 @@ private const val GRID_REFRESH_POLL_MS = 5_000L
  */
 @Composable
 private fun rememberDaemonConnectionState(client: AutoMobileClient): ConnectionState {
-  var state by remember(client) { mutableStateOf<ConnectionState>(ConnectionState.Connecting) }
-  LaunchedEffect(client) {
-    while (true) {
-      state =
-        try {
-          withContext(Dispatchers.IO) { client.getDaemonStatus() }
-          ConnectionState.Connected()
-        } catch (cancellation: CancellationException) {
-          // Disposal cancels this effect; propagate it instead of logging a false daemon failure
-          // and flipping the dot to disconnected during teardown.
-          throw cancellation
-        } catch (error: Exception) {
-          // A failed status call means the daemon socket is unreachable; surface it as
-          // disconnected so the status dot goes red. Logged so there is a trace behind the dot.
+  val monitor =
+    remember(client) {
+      DaemonConnectionMonitor(
+        probe = { withContext(Dispatchers.IO) { client.getDaemonStatus() } },
+        pollInterval = DAEMON_STATUS_POLL_MS.milliseconds,
+        // A failed status call means the daemon socket is unreachable; the dot goes red via the
+        // returned Disconnected state, and this keeps a trace behind the dot.
+        onProbeFailure = { error ->
           LOG.warn("Daemon status poll failed: ${error.message}", error)
-          ConnectionState.Disconnected(error.message)
-        }
-      delay(DAEMON_STATUS_POLL_MS)
+        },
+      )
     }
-  }
-  return state
+  return monitor.connectionStates().collectAsState(initial = ConnectionState.Connecting).value
 }
 
 /**

--- a/android/desktop-app/src/main/kotlin/dev/jasonpearson/automobile/desktop/Main.kt
+++ b/android/desktop-app/src/main/kotlin/dev/jasonpearson/automobile/desktop/Main.kt
@@ -1,7 +1,7 @@
 package dev.jasonpearson.automobile.desktop
 
 import androidx.compose.runtime.CompositionLocalProvider
-import androidx.compose.runtime.LaunchedEffect
+import androidx.compose.runtime.collectAsState
 import androidx.compose.runtime.getValue
 import androidx.compose.runtime.mutableStateOf
 import androidx.compose.runtime.remember
@@ -21,18 +21,17 @@ import androidx.compose.ui.window.Window
 import androidx.compose.ui.window.WindowPosition
 import androidx.compose.ui.window.application
 import androidx.compose.ui.window.rememberWindowState
-import dev.jasonpearson.automobile.desktop.core.daemon.McpConnectionException
+import dev.jasonpearson.automobile.desktop.core.connection.ConnectionState
+import dev.jasonpearson.automobile.desktop.core.connection.DaemonConnectionMonitor
 import dev.jasonpearson.automobile.desktop.core.di.LocalAutoMobileGraph
 import dev.jasonpearson.automobile.desktop.core.shell.MenuBarActions
 import dev.jasonpearson.automobile.desktop.core.workspace.isCommandPaletteShortcut
 import dev.jasonpearson.automobile.desktop.di.AutoMobileGraph
 import dev.zacsweers.metro.createGraphFactory
-import java.io.IOException
 import java.io.RandomAccessFile
 import java.nio.channels.FileLock
 import java.nio.file.Path
 import kotlinx.coroutines.Dispatchers
-import kotlinx.coroutines.delay
 import kotlinx.coroutines.withContext
 
 /** True when running on macOS; used to pick Meta (Cmd) vs Ctrl for accelerators. */
@@ -95,25 +94,18 @@ fun main() {
 
   application {
     var isWindowVisible by remember { mutableStateOf(true) }
-    var isDaemonConnected by remember { mutableStateOf(false) }
 
-    // Poll daemon connection state every 5 seconds using the DI graph's client.
-    LaunchedEffect(Unit) {
-      while (true) {
-        isDaemonConnected =
-          try {
-            withContext(Dispatchers.IO) {
-              graph.autoMobileClient.getDaemonStatus()
-            }
-            true
-          } catch (_: IOException) {
-            false
-          } catch (_: McpConnectionException) {
-            false
-          }
-        delay(5_000L)
-      }
+    // Poll daemon connectivity through the same injectable, timeout-bounded seam that backs the
+    // in-window status dot (#4858), so the tray and the dot share one daemon-health source rather
+    // than running two overlapping 5s loops.
+    val daemonMonitor = remember {
+      DaemonConnectionMonitor(
+        probe = { withContext(Dispatchers.IO) { graph.autoMobileClient.getDaemonStatus() } }
+      )
     }
+    val daemonState by
+      daemonMonitor.connectionStates().collectAsState(initial = ConnectionState.Connecting)
+    val isDaemonConnected = daemonState is ConnectionState.Connected
 
     AutoMobileSystemTray(
       isConnected = isDaemonConnected,

--- a/android/desktop-app/src/main/kotlin/dev/jasonpearson/automobile/desktop/Main.kt
+++ b/android/desktop-app/src/main/kotlin/dev/jasonpearson/automobile/desktop/Main.kt
@@ -24,6 +24,7 @@ import androidx.compose.ui.window.rememberWindowState
 import dev.jasonpearson.automobile.desktop.core.connection.ConnectionState
 import dev.jasonpearson.automobile.desktop.core.connection.DaemonConnectionMonitor
 import dev.jasonpearson.automobile.desktop.core.di.LocalAutoMobileGraph
+import dev.jasonpearson.automobile.desktop.core.logging.LoggerFactory
 import dev.jasonpearson.automobile.desktop.core.shell.MenuBarActions
 import dev.jasonpearson.automobile.desktop.core.workspace.isCommandPaletteShortcut
 import dev.jasonpearson.automobile.desktop.di.AutoMobileGraph
@@ -33,6 +34,8 @@ import java.nio.channels.FileLock
 import java.nio.file.Path
 import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.withContext
+
+private val LOG = LoggerFactory.getLogger("Main")
 
 /** True when running on macOS; used to pick Meta (Cmd) vs Ctrl for accelerators. */
 private val IS_MACOS: Boolean = System.getProperty("os.name")?.lowercase()?.contains("mac") == true
@@ -100,7 +103,12 @@ fun main() {
     // than running two overlapping 5s loops.
     val daemonMonitor = remember {
       DaemonConnectionMonitor(
-        probe = { withContext(Dispatchers.IO) { graph.autoMobileClient.getDaemonStatus() } }
+        probe = { withContext(Dispatchers.IO) { graph.autoMobileClient.getDaemonStatus() } },
+        // A failed status call means the daemon socket is unreachable; the dot/tray go red via the
+        // returned Disconnected state, and this keeps a trace behind them.
+        onProbeFailure = { error ->
+          LOG.warn("Daemon status poll failed: ${error.message}", error)
+        },
       )
     }
     val daemonState by
@@ -220,6 +228,7 @@ fun main() {
         AutoMobileDesktopApp(
           menuBarActions = menuBarActions,
           openPaletteRequest = openPaletteRequest,
+          daemonConnectionState = daemonState,
         )
       }
     }

--- a/android/desktop-app/src/main/kotlin/dev/jasonpearson/automobile/desktop/Main.kt
+++ b/android/desktop-app/src/main/kotlin/dev/jasonpearson/automobile/desktop/Main.kt
@@ -104,7 +104,7 @@ fun main() {
       )
     }
     val daemonState by
-      daemonMonitor.connectionStates().collectAsState(initial = ConnectionState.Connecting)
+      daemonMonitor.connectionStates.collectAsState(initial = ConnectionState.Connecting)
     val isDaemonConnected = daemonState is ConnectionState.Connected
 
     AutoMobileSystemTray(

--- a/android/desktop-core/src/main/kotlin/dev/jasonpearson/automobile/desktop/core/connection/DaemonConnectionMonitor.kt
+++ b/android/desktop-core/src/main/kotlin/dev/jasonpearson/automobile/desktop/core/connection/DaemonConnectionMonitor.kt
@@ -30,7 +30,12 @@ import kotlinx.coroutines.withTimeout
  *
  * @param probe suspends until the daemon status resolves, or throws if it is unreachable. Callers
  *   dispatch the blocking client call (e.g. `withContext(Dispatchers.IO) { client.getDaemonStatus()
- *   }`) so [withTimeout] has a suspension point at which to abandon a stalled read.
+ *   }`). The real hang bound lives in the client: `getDaemonStatus()` passes a transport hang
+ *   ceiling that closes the socket on a wedged daemon, which makes the blocking read throw so the
+ *   probe returns as Disconnected. [probeTimeout] here is a coarser coroutine-level backstop — it
+ *   cannot interrupt an uninterruptible blocking read (structured concurrency waits for the
+ *   `withContext` child), so it only bounds cooperative probes; the transport ceiling is what
+ *   actually un-sticks the dot.
  * @param pollInterval delay between the end of one probe and the start of the next.
  * @param probeTimeout deadline for a single probe before it is treated as Disconnected.
  * @param onProbeFailure invoked with the failure (a timeout or a thrown error) whenever a probe
@@ -47,8 +52,14 @@ class DaemonConnectionMonitor(
   /**
    * Emits [ConnectionState.Connecting] immediately, then one state per poll until the collector is
    * cancelled. The flow never completes on its own.
+   *
+   * This is a stable `val`, not a method: `collectAsState` keys its collection on the flow
+   * instance, so handing out a fresh cold flow per access (a `fun`) would restart collection on
+   * every recomposition — re-emitting Connecting and re-probing immediately, defeating
+   * [pollInterval]. One cached instance keeps a single collection alive across recompositions. It
+   * is a cold flow, so each distinct collector still gets its own independent poll loop.
    */
-  fun connectionStates(): Flow<ConnectionState> = flow {
+  val connectionStates: Flow<ConnectionState> = flow {
     emit(ConnectionState.Connecting)
     while (currentCoroutineContext().isActive) {
       emit(probeOnce())

--- a/android/desktop-core/src/main/kotlin/dev/jasonpearson/automobile/desktop/core/connection/DaemonConnectionMonitor.kt
+++ b/android/desktop-core/src/main/kotlin/dev/jasonpearson/automobile/desktop/core/connection/DaemonConnectionMonitor.kt
@@ -1,0 +1,88 @@
+package dev.jasonpearson.automobile.desktop.core.connection
+
+import kotlin.time.Duration
+import kotlin.time.Duration.Companion.seconds
+import kotlinx.coroutines.CancellationException
+import kotlinx.coroutines.TimeoutCancellationException
+import kotlinx.coroutines.currentCoroutineContext
+import kotlinx.coroutines.delay
+import kotlinx.coroutines.flow.Flow
+import kotlinx.coroutines.flow.flow
+import kotlinx.coroutines.isActive
+import kotlinx.coroutines.withTimeout
+
+/**
+ * Injectable, timeout-bounded poller for daemon connectivity (#4858).
+ *
+ * This is the single seam behind every daemon-health poll in the desktop app: it replaces the two
+ * hand-rolled `while (true) { getDaemonStatus(); delay(5s) }` loops that previously lived in
+ * `Main.kt` (system-tray dot) and `AutoMobileDesktopApp.rememberDaemonConnectionState` (status
+ * dot). The loop is a plain suspend flow so its cadence, its
+ * exception→[ConnectionState.Disconnected] transitions, and its cancellation behavior are all
+ * coverable with virtual time.
+ *
+ * The [probe] is bounded by [probeTimeout] via [withTimeout]. A [TimeoutCancellationException] is a
+ * [CancellationException] subtype, so it MUST be caught before the plain-cancellation rethrow —
+ * otherwise a hung daemon (socket accepted but no reply) would tear the collecting effect down
+ * during a live poll instead of surfacing as Disconnected, leaving the dot stuck and disposal slow.
+ * The rethrow of a genuine [CancellationException] (effect disposal) stays intact so teardown does
+ * not log a false daemon failure.
+ *
+ * @param probe suspends until the daemon status resolves, or throws if it is unreachable. Callers
+ *   dispatch the blocking client call (e.g. `withContext(Dispatchers.IO) { client.getDaemonStatus()
+ *   }`) so [withTimeout] has a suspension point at which to abandon a stalled read.
+ * @param pollInterval delay between the end of one probe and the start of the next.
+ * @param probeTimeout deadline for a single probe before it is treated as Disconnected.
+ * @param onProbeFailure invoked with the failure (a timeout or a thrown error) whenever a probe
+ *   resolves to Disconnected, so callers can keep a log trace behind the dot. Never invoked for a
+ *   successful probe or for genuine collector cancellation.
+ */
+class DaemonConnectionMonitor(
+  private val probe: suspend () -> Unit,
+  private val pollInterval: Duration = DEFAULT_POLL_INTERVAL,
+  private val probeTimeout: Duration = DEFAULT_PROBE_TIMEOUT,
+  private val onProbeFailure: (Throwable) -> Unit = {},
+) {
+
+  /**
+   * Emits [ConnectionState.Connecting] immediately, then one state per poll until the collector is
+   * cancelled. The flow never completes on its own.
+   */
+  fun connectionStates(): Flow<ConnectionState> = flow {
+    emit(ConnectionState.Connecting)
+    while (currentCoroutineContext().isActive) {
+      emit(probeOnce())
+      delay(pollInterval)
+    }
+  }
+
+  private suspend fun probeOnce(): ConnectionState =
+    try {
+      withTimeout(probeTimeout) { probe() }
+      ConnectionState.Connected()
+    } catch (timeout: TimeoutCancellationException) {
+      // Bounded probe deadline hit. Caught BEFORE the CancellationException branch below so a
+      // timeout surfaces as Disconnected and the loop keeps polling, rather than being rethrown.
+      onProbeFailure(timeout)
+      ConnectionState.Disconnected("Daemon status probe timed out after $probeTimeout")
+    } catch (cancellation: CancellationException) {
+      // Genuine disposal (collector cancelled). Propagate so teardown does not log a false daemon
+      // failure and flip the dot to disconnected while the app is closing.
+      throw cancellation
+    } catch (error: Exception) {
+      // A failed status call means the daemon socket is unreachable; surface it as Disconnected.
+      onProbeFailure(error)
+      ConnectionState.Disconnected(error.message)
+    }
+
+  companion object {
+    /**
+     * Matches the health sheet's read-only refresh cadence
+     * (WorkspaceShell.HEALTH_SHEET_REFRESH_MS).
+     */
+    val DEFAULT_POLL_INTERVAL: Duration = 5.seconds
+
+    /** Deadline for a single status probe before the daemon is treated as unreachable. */
+    val DEFAULT_PROBE_TIMEOUT: Duration = 10.seconds
+  }
+}

--- a/android/desktop-core/src/main/kotlin/dev/jasonpearson/automobile/desktop/core/connection/DaemonConnectionMonitor.kt
+++ b/android/desktop-core/src/main/kotlin/dev/jasonpearson/automobile/desktop/core/connection/DaemonConnectionMonitor.kt
@@ -14,12 +14,13 @@ import kotlinx.coroutines.withTimeout
 /**
  * Injectable, timeout-bounded poller for daemon connectivity (#4858).
  *
- * This is the single seam behind every daemon-health poll in the desktop app: it replaces the two
+ * This is the single seam behind daemon-health polling in the desktop app: it replaces the two
  * hand-rolled `while (true) { getDaemonStatus(); delay(5s) }` loops that previously lived in
- * `Main.kt` (system-tray dot) and `AutoMobileDesktopApp.rememberDaemonConnectionState` (status
- * dot). The loop is a plain suspend flow so its cadence, its
- * exception→[ConnectionState.Disconnected] transitions, and its cancellation behavior are all
- * coverable with virtual time.
+ * `Main.kt` (system-tray dot) and `AutoMobileDesktopApp` (status dot). One instance is created in
+ * `Main.kt` and its [connectionStates] is collected once, feeding both the tray icon and the status
+ * dot — a single daemon-health source rather than two overlapping polls. The loop is a plain
+ * suspend flow so its cadence, its exception→[ConnectionState.Disconnected] transitions, and its
+ * cancellation behavior are all coverable with virtual time.
  *
  * The [probe] is bounded by [probeTimeout] via [withTimeout]. A [TimeoutCancellationException] is a
  * [CancellationException] subtype, so it MUST be caught before the plain-cancellation rethrow —

--- a/android/desktop-core/src/main/kotlin/dev/jasonpearson/automobile/desktop/core/daemon/McpDaemonClient.kt
+++ b/android/desktop-core/src/main/kotlin/dev/jasonpearson/automobile/desktop/core/daemon/McpDaemonClient.kt
@@ -296,7 +296,13 @@ class McpDaemonClient(
 
   override fun getDaemonStatus():
     dev.jasonpearson.automobile.desktop.core.mcp.DaemonStatusResponse {
-    val response = sendRequest("ide/status")
+    // Hang ceiling on the status probe (#4858). The blocking SocketChannel read is not cancellable
+    // by coroutine cancellation, so a wrapping withTimeout at the caller cannot unblock a daemon
+    // that accepts but never replies — only this watchdog, which closes the socket, can. A healthy
+    // ide/status round-trip is ~ms, so a deadline here bounds the connectivity dot without risking
+    // a
+    // slow ordinary tool call (those stay unbounded; see [sendRequest]).
+    val response = sendRequest("ide/status", timeoutMs = STATUS_REQUEST_TIMEOUT_MS)
     ensureSuccess(response)
     return json.decodeFromJsonElement(
       serializer<dev.jasonpearson.automobile.desktop.core.mcp.DaemonStatusResponse>(),
@@ -1051,6 +1057,11 @@ class McpDaemonClient(
     /** Hang ceiling for ordinary daemon requests (tool calls can legitimately take tens of s). */
     /** Hang ceiling for the input helpers; a healthy input round-trip is ~milliseconds. */
     const val INPUT_REQUEST_TIMEOUT_MS = 5_000L
+
+    /**
+     * Hang ceiling for the daemon connectivity probe (ide/status); a healthy probe is ~ms (#4858).
+     */
+    const val STATUS_REQUEST_TIMEOUT_MS = 5_000L
 
     // One shared daemon thread arms/cancels every request deadline. It only ever runs a
     // channel.close() for a request that overran its ceiling, so it stays idle in normal use.

--- a/android/desktop-core/src/test/kotlin/dev/jasonpearson/automobile/desktop/core/connection/DaemonConnectionMonitorTest.kt
+++ b/android/desktop-core/src/test/kotlin/dev/jasonpearson/automobile/desktop/core/connection/DaemonConnectionMonitorTest.kt
@@ -1,0 +1,146 @@
+package dev.jasonpearson.automobile.desktop.core.connection
+
+import kotlin.test.Test
+import kotlin.test.assertEquals
+import kotlin.test.assertTrue
+import kotlin.time.Duration.Companion.milliseconds
+import kotlinx.coroutines.CancellationException
+import kotlinx.coroutines.awaitCancellation
+import kotlinx.coroutines.flow.take
+import kotlinx.coroutines.flow.toList
+import kotlinx.coroutines.launch
+import kotlinx.coroutines.test.advanceTimeBy
+import kotlinx.coroutines.test.runCurrent
+import kotlinx.coroutines.test.runTest
+
+class DaemonConnectionMonitorTest {
+
+  private fun monitor(
+    probe: suspend () -> Unit,
+    pollIntervalMs: Long = 5_000,
+    probeTimeoutMs: Long = 10_000,
+    onProbeFailure: (Throwable) -> Unit = {},
+  ) =
+    DaemonConnectionMonitor(
+      probe = probe,
+      pollInterval = pollIntervalMs.milliseconds,
+      probeTimeout = probeTimeoutMs.milliseconds,
+      onProbeFailure = onProbeFailure,
+    )
+
+  @Test
+  fun `first emission is Connecting before any probe runs`() = runTest {
+    var probes = 0
+    val first = monitor(probe = { probes++ }).connectionStates().take(1).toList().single()
+
+    assertEquals(ConnectionState.Connecting, first)
+    assertEquals(0, probes, "Connecting must be emitted before the first probe")
+  }
+
+  @Test
+  fun `successful probe yields Connected`() = runTest {
+    val states = monitor(probe = {}).connectionStates().take(2).toList()
+
+    assertEquals(ConnectionState.Connecting, states[0])
+    assertTrue(states[1] is ConnectionState.Connected, "expected Connected, got ${states[1]}")
+  }
+
+  @Test
+  fun `throwing probe yields Disconnected carrying the failure reason`() = runTest {
+    val states =
+      monitor(probe = { throw IllegalStateException("socket refused") })
+        .connectionStates()
+        .take(2)
+        .toList()
+
+    val disconnected = states[1] as ConnectionState.Disconnected
+    assertEquals("socket refused", disconnected.reason)
+  }
+
+  @Test
+  fun `monitor re-probes on the poll interval cadence`() = runTest {
+    var probes = 0
+    val job = backgroundScope.launch {
+      monitor(probe = { probes++ }, pollIntervalMs = 5_000).connectionStates().collect {}
+    }
+
+    runCurrent()
+    assertEquals(1, probes, "one probe should run immediately")
+
+    advanceTimeBy(5_001)
+    assertEquals(2, probes)
+
+    advanceTimeBy(5_000)
+    assertEquals(3, probes)
+
+    job.cancel()
+  }
+
+  @Test
+  fun `probe that never completes times out to Disconnected and the loop keeps polling`() =
+    runTest {
+      // A probe that suspends forever must be bounded by probeTimeout and surface Disconnected —
+      // and, crucially, the loop must survive the TimeoutCancellationException (a
+      // CancellationException subtype) rather than being torn down by it (#4858).
+      val states =
+        monitor(probe = { awaitCancellation() }, probeTimeoutMs = 10_000)
+          .connectionStates()
+          .take(3)
+          .toList()
+
+      assertEquals(ConnectionState.Connecting, states[0])
+      val firstTimeout = states[1] as ConnectionState.Disconnected
+      assertTrue(
+        firstTimeout.reason?.contains("timed out") == true,
+        "expected a timeout reason, got ${firstTimeout.reason}",
+      )
+      // A third emission proves the poll loop continued after the timeout.
+      assertTrue(states[2] is ConnectionState.Disconnected)
+    }
+
+  @Test
+  fun `onProbeFailure fires for a thrown probe but not for a success`() = runTest {
+    val failures = mutableListOf<Throwable>()
+    var throwNext = false
+    monitor(
+        probe = {
+          if (throwNext) throw IllegalStateException("socket refused") else throwNext = true
+        },
+        onProbeFailure = { failures.add(it) },
+      )
+      .connectionStates()
+      .take(3)
+      .toList()
+
+    // First probe succeeds (no failure recorded), second throws (recorded once). The instance may
+    // be a stacktrace-recovery copy from crossing the withTimeout coroutine boundary, so compare on
+    // type + message rather than identity.
+    val failure = failures.single()
+    assertTrue(failure is IllegalStateException, "expected IllegalStateException, got $failure")
+    assertEquals("socket refused", failure.message)
+  }
+
+  @Test
+  fun `cancelling collection stops the poll loop without leaking a cancellation`() = runTest {
+    var probes = 0
+    var leaked: Throwable? = null
+    val job = backgroundScope.launch {
+      try {
+        monitor(probe = { probes++ }, pollIntervalMs = 5_000).connectionStates().collect {}
+      } catch (_: CancellationException) {
+        // expected on cancel; cooperative
+      } catch (t: Throwable) {
+        leaked = t
+      }
+    }
+
+    runCurrent()
+    advanceTimeBy(5_001)
+    val probesAtCancel = probes
+    job.cancel()
+    advanceTimeBy(50_000)
+
+    assertEquals(probesAtCancel, probes, "no further probes after cancellation")
+    assertEquals(null, leaked, "cancellation must not surface as a non-cancellation failure")
+  }
+}

--- a/android/desktop-core/src/test/kotlin/dev/jasonpearson/automobile/desktop/core/connection/DaemonConnectionMonitorTest.kt
+++ b/android/desktop-core/src/test/kotlin/dev/jasonpearson/automobile/desktop/core/connection/DaemonConnectionMonitorTest.kt
@@ -2,6 +2,7 @@ package dev.jasonpearson.automobile.desktop.core.connection
 
 import kotlin.test.Test
 import kotlin.test.assertEquals
+import kotlin.test.assertSame
 import kotlin.test.assertTrue
 import kotlin.time.Duration.Companion.milliseconds
 import kotlinx.coroutines.CancellationException
@@ -29,9 +30,18 @@ class DaemonConnectionMonitorTest {
     )
 
   @Test
+  fun `connectionStates is a stable instance across accesses`() {
+    // collectAsState keys its collection on the flow instance; a fresh instance per access would
+    // restart collection on every recomposition (re-emitting Connecting and re-probing). Pin that
+    // the property hands back the same instance so consumers get a single continuous poll loop.
+    val m = monitor(probe = {})
+    assertSame(m.connectionStates, m.connectionStates)
+  }
+
+  @Test
   fun `first emission is Connecting before any probe runs`() = runTest {
     var probes = 0
-    val first = monitor(probe = { probes++ }).connectionStates().take(1).toList().single()
+    val first = monitor(probe = { probes++ }).connectionStates.take(1).toList().single()
 
     assertEquals(ConnectionState.Connecting, first)
     assertEquals(0, probes, "Connecting must be emitted before the first probe")
@@ -39,7 +49,7 @@ class DaemonConnectionMonitorTest {
 
   @Test
   fun `successful probe yields Connected`() = runTest {
-    val states = monitor(probe = {}).connectionStates().take(2).toList()
+    val states = monitor(probe = {}).connectionStates.take(2).toList()
 
     assertEquals(ConnectionState.Connecting, states[0])
     assertTrue(states[1] is ConnectionState.Connected, "expected Connected, got ${states[1]}")
@@ -49,7 +59,7 @@ class DaemonConnectionMonitorTest {
   fun `throwing probe yields Disconnected carrying the failure reason`() = runTest {
     val states =
       monitor(probe = { throw IllegalStateException("socket refused") })
-        .connectionStates()
+        .connectionStates
         .take(2)
         .toList()
 
@@ -61,7 +71,7 @@ class DaemonConnectionMonitorTest {
   fun `monitor re-probes on the poll interval cadence`() = runTest {
     var probes = 0
     val job = backgroundScope.launch {
-      monitor(probe = { probes++ }, pollIntervalMs = 5_000).connectionStates().collect {}
+      monitor(probe = { probes++ }, pollIntervalMs = 5_000).connectionStates.collect {}
     }
 
     runCurrent()
@@ -84,7 +94,7 @@ class DaemonConnectionMonitorTest {
       // CancellationException subtype) rather than being torn down by it (#4858).
       val states =
         monitor(probe = { awaitCancellation() }, probeTimeoutMs = 10_000)
-          .connectionStates()
+          .connectionStates
           .take(3)
           .toList()
 
@@ -108,7 +118,7 @@ class DaemonConnectionMonitorTest {
         },
         onProbeFailure = { failures.add(it) },
       )
-      .connectionStates()
+      .connectionStates
       .take(3)
       .toList()
 
@@ -126,7 +136,7 @@ class DaemonConnectionMonitorTest {
     var leaked: Throwable? = null
     val job = backgroundScope.launch {
       try {
-        monitor(probe = { probes++ }, pollIntervalMs = 5_000).connectionStates().collect {}
+        monitor(probe = { probes++ }, pollIntervalMs = 5_000).connectionStates.collect {}
       } catch (_: CancellationException) {
         // expected on cancel; cooperative
       } catch (t: Throwable) {


### PR DESCRIPTION
## Summary

Follow-up to #4845 / PR #4856. The daemon status derivation (`deriveWorkspaceStatus`) is pure and unit-tested, but the host pollers that feed it were not: `rememberDaemonConnectionState` (in-window status dot) and the system-tray loop in `Main.kt` each hand-rolled a `while (true) { getDaemonStatus(); delay(5s) }` on `Dispatchers.IO`, so their cadence, exception→Disconnected transitions, and cancellation behavior were untested, and a hung daemon (socket accepted but no reply) could leave the dot stuck and slow disposal.

This extracts the loop into a single injectable, timeout-bounded `DaemonConnectionMonitor` in `desktop-core`, tested with virtual time, and routes **both** desktop-app poll sites through it — one daemon-health source instead of two overlapping loops (per @kaeawc's consolidation note on the issue).

## Linked Issue

Closes #4858

## Changes

- **New `DaemonConnectionMonitor`** (`desktop-core/.../connection`): exposes `connectionStates: Flow<ConnectionState>` (a **stable cached instance**) with injected `probe`, `pollInterval`, `probeTimeout`, and an optional `onProbeFailure` hook (preserves the "trace behind the dot" log). Emits `Connecting` first, then one state per poll; never completes on its own.
- **Timeout ordering:** the probe is bounded by `withTimeout`; `TimeoutCancellationException` (a `CancellationException` subtype) is caught **before** the plain-cancellation rethrow, so a cooperative probe deadline surfaces as `Disconnected` and the loop keeps polling, while genuine collector cancellation (disposal) still propagates without logging a false failure.
- **Real transport deadline:** `McpDaemonClient.getDaemonStatus()` now passes a hang ceiling (`STATUS_REQUEST_TIMEOUT_MS`) to `sendRequest`, arming the existing socket-closing watchdog. A coroutine `withTimeout` cannot interrupt the uninterruptible blocking `SocketChannel` read (structured concurrency waits for the `withContext` child), so only closing the socket actually un-sticks a wedged daemon. Scoped to the status probe — ordinary tool calls stay unbounded per the existing design.
- **Consolidation:** both `AutoMobileDesktopApp.rememberDaemonConnectionState` and `Main.kt`'s tray loop now `collectAsState` from the one monitor.

## Acceptance criteria

- [x] Poll loop extracted into a plain testable suspend/flow seam, tested with virtual time (`runTest`): first-emission `Connecting`, success→`Connected`, throw→`Disconnected(reason)`, poll cadence, cancellation stops the loop, stable flow instance, `onProbeFailure` hook.
- [x] Probe is transport-timeout-bounded and surfaced through the seam; `TimeoutCancellationException` caught before the `#4856` cancellation-rethrow.
- [x] The single seam backs both daemon-status poll loops.

## Bug / Regression Context

- **Observed symptom:** a daemon that accepts the socket but stops replying left the connectivity dot stuck (no bound on the blocking read) and slowed window disposal.
- **Repro conditions:** wedged/half-open daemon socket (e.g. after sleep/wake).

## Validation

- [x] `:desktop-core:test` + `:desktop-app:test` green (8 `DaemonConnectionMonitorTest` cases, virtual-time, <100ms)
- [x] `:desktop-core:detektMain/detektTest` + `:desktop-app:detektMain` pass; `scripts/ktfmt/validate_ktfmt.sh` clean on touched files
- [x] N/A: no TypeScript/schema/shell/Swift surfaces touched (Kotlin-only), so `bun`/`typecheck` gates are unaffected

## Kotlin Reuse Check

- [x] Reuses `kotlinx.coroutines` (`withTimeout`, `Flow`), the existing `ConnectionState` model, and `McpDaemonClient`'s existing request watchdog; no new helpers/`*Util`/dependencies
- [x] `runTest`/virtual time is the repo's established FakeTimer equivalent for coroutine code in this module

## Notes

- Three review lenses (runtime, delivery, Compose/coroutine lifecycle) ran on the first push; two independently flagged (a) the per-recomposition re-collection and (b) that a coroutine `withTimeout` cannot bound the blocking socket read. Both are fixed here — (a) via the stable `val`, (b) via the transport hang ceiling — rather than deferred.

### Deferred hardening → #5585

Review (3 lenses + Codex) surfaced two further transport-deadline gaps, both verified but deliberately out of scope here to avoid regression-prone changes to shared-client paths used by every tool call:
- `getDaemonStatus()` is bounded only for the **default** `McpDaemonClient` (Unix socket). The opt-in `McpHttpClient` / `McpStdioClient` transports (selected by `McpClientFactory.createPreferred()` when `AUTOMOBILE_MCP_HTTP_URL` / `AUTOMOBILE_MCP_STDIO_COMMAND` is set) still block in an untimed `send`/`readLine`.
- `McpDaemonClient.sendRequest` runs the lifecycle preflight (`ensureVersionMatchedDaemon`) before arming the watchdog, so a full accept-backlog can hang the preflight connect before the deadline exists.

Both tracked in #5585. The default desktop configuration this PR targets is fully bounded.
