### PR TITLE
fix(ios): filter direct runner candidates before probe cap

### DIFF
--- a/src/utils/IOSCtrlProxyManager.ts
+++ b/src/utils/IOSCtrlProxyManager.ts
@@ -2015,7 +2015,8 @@ export class IOSCtrlProxyManager implements CtrlProxyIosManager {
    */
   private async findHealthyExternalDirectCtrlProxyProcess(): Promise<ExternalCtrlProxyProcess | null> {
     const candidatePids = await this.processClient.findStartupCandidatePids();
-    for (const pid of candidatePids.slice(0, MAX_STARTUP_ORPHAN_RUNNER_CANDIDATES)) {
+    const eligibleCandidates: Array<{ pid: number; process: ListeningProcess }> = [];
+    for (const pid of candidatePids) {
       if (pid === this.xcTestProcessId) {
         continue;
       }
@@ -2036,11 +2037,17 @@ export class IOSCtrlProxyManager implements CtrlProxyIosManager {
       if (daemonManagedRoot.kind === "root") {
         continue;
       }
-      if (!await this.checkHealthEndpointOnPortForDevice(port, this.device.deviceId)) {
+      eligibleCandidates.push({ pid, process });
+      if (eligibleCandidates.length >= MAX_STARTUP_ORPHAN_RUNNER_CANDIDATES) {
+        break;
+      }
+    }
+    for (const { pid, process } of eligibleCandidates) {
+      if (!await this.checkHealthEndpointOnPortForDevice(process.port, this.device.deviceId)) {
         continue;
       }
       logger.info(`[IOSCtrlProxy] Found healthy external direct CtrlProxy runner: ${pid}`);
-      return { pid, port };
+      return { pid, port: process.port };
     }
     return null;
   }

--- a/src/utils/IOSCtrlProxyManager.ts
+++ b/src/utils/IOSCtrlProxyManager.ts
@@ -26,6 +26,7 @@ import { IOSCtrlProxyProcessClient } from "./ios/IOSCtrlProxyProcessClient";
 import type { ProxyManager, ProxySetupResult } from "./interfaces/ProxyManager";
 
 export const MAX_STARTUP_ORPHAN_RUNNER_CANDIDATES = 20;
+export const DIRECT_RUNNER_DISCOVERY_DEADLINE_MS = 5_000;
 export const STARTUP_ORPHAN_RUNNER_REAP_DEADLINE_MS = 5_000;
 // ProcessLifecycle and DaemonManager force-exit after ten seconds. This stage
 // shares that budget with capture cleanup, so an unresponsive proxy must not
@@ -2014,13 +2015,17 @@ export class IOSCtrlProxyManager implements CtrlProxyIosManager {
    * path still reaps a stale runner whose health endpoint is down.
    */
   private async findHealthyExternalDirectCtrlProxyProcess(): Promise<ExternalCtrlProxyProcess | null> {
-    const candidatePids = await this.processClient.findStartupCandidatePids();
+    const deadline = this.timer.now() + DIRECT_RUNNER_DISCOVERY_DEADLINE_MS;
+    const candidatePids = await this.processClient.findStartupCandidatePids(deadline);
     const eligibleCandidates: Array<{ pid: number; process: ListeningProcess }> = [];
     for (const pid of candidatePids) {
+      if (this.timer.now() >= deadline) {
+        break;
+      }
       if (pid === this.xcTestProcessId) {
         continue;
       }
-      const processInfo = await this.processClient.getProcessInfo(pid);
+      const processInfo = await this.processClient.getProcessInfo(pid, deadline);
       if (!processInfo || !IOSCtrlProxyManager.isDirectCtrlProxyRunnerCommand(processInfo.command)) {
         continue;
       }
@@ -2043,7 +2048,15 @@ export class IOSCtrlProxyManager implements CtrlProxyIosManager {
       }
     }
     for (const { pid, process } of eligibleCandidates) {
-      if (!await this.checkHealthEndpointOnPortForDevice(process.port, this.device.deviceId)) {
+      const remainingTimeoutMs = deadline - this.timer.now();
+      if (remainingTimeoutMs <= 0) {
+        break;
+      }
+      if (!await this.checkHealthEndpointOnPortForDevice(
+        process.port,
+        this.device.deviceId,
+        remainingTimeoutMs
+      )) {
         continue;
       }
       logger.info(`[IOSCtrlProxy] Found healthy external direct CtrlProxy runner: ${pid}`);
@@ -2631,8 +2644,12 @@ export class IOSCtrlProxyManager implements CtrlProxyIosManager {
     return null;
   }
 
-  private async checkHealthEndpointOnPortForDevice(port: number, deviceId: string): Promise<boolean> {
-    return this.healthClient.checkHealthEndpointOnPortForDevice(port, deviceId);
+  private async checkHealthEndpointOnPortForDevice(
+    port: number,
+    deviceId: string,
+    timeoutMs?: number
+  ): Promise<boolean> {
+    return this.healthClient.checkHealthEndpointOnPortForDevice(port, deviceId, timeoutMs);
   }
 
   private getIproxyStartTimeoutMs(): number {

--- a/src/utils/ios/IOSCtrlProxyHealthClient.ts
+++ b/src/utils/ios/IOSCtrlProxyHealthClient.ts
@@ -46,8 +46,8 @@ export class IOSCtrlProxyHealthClient {
    * body. Does not require device identity — used to gate spawn/restart on any
    * responding runner on the port.
    */
-  public async checkHealthEndpointOnPort(port: number): Promise<boolean> {
-    const body = await this.readHealthEndpointBodyOnPort(port);
+  public async checkHealthEndpointOnPort(port: number, timeoutMs?: number): Promise<boolean> {
+    const body = await this.readHealthEndpointBodyOnPort(port, timeoutMs);
     return body !== null && (body.includes("ok") || body.includes("healthy"));
   }
 
@@ -56,8 +56,12 @@ export class IOSCtrlProxyHealthClient {
    * AND identifies as `deviceId`. Rejects a sibling simulator's runner or the
    * Android runner answering the same/default port.
    */
-  public async checkHealthEndpointOnPortForDevice(port: number, deviceId: string): Promise<boolean> {
-    const body = await this.readHealthEndpointBodyOnPort(port);
+  public async checkHealthEndpointOnPortForDevice(
+    port: number,
+    deviceId: string,
+    timeoutMs?: number
+  ): Promise<boolean> {
+    const body = await this.readHealthEndpointBodyOnPort(port, timeoutMs);
     if (body === null) {
       return false;
     }
@@ -103,14 +107,18 @@ export class IOSCtrlProxyHealthClient {
    * `curl` (bounded by `--max-time`); remote probes use `fetch` bounded by a
    * timer-driven `AbortController`.
    */
-  public async readHealthEndpointBodyOnPort(port: number): Promise<string | null> {
+  public async readHealthEndpointBodyOnPort(port: number, timeoutMs?: number): Promise<string | null> {
     try {
+      const requestTimeoutMs = Math.min(
+        IOSCtrlProxyHealthClient.FETCH_TIMEOUT_MS,
+        Math.max(1, timeoutMs ?? IOSCtrlProxyHealthClient.FETCH_TIMEOUT_MS)
+      );
       const host = this.context.useRemoteRunner() ? this.context.getHost() : "localhost";
       if (this.context.useRemoteRunner()) {
         const controller = new AbortController();
         const timeoutId = this.timer.setTimeout(
           () => controller.abort(),
-          IOSCtrlProxyHealthClient.FETCH_TIMEOUT_MS
+          requestTimeoutMs
         );
         try {
           const response = await fetch(`http://${host}:${port}/health`, {
@@ -125,8 +133,8 @@ export class IOSCtrlProxyHealthClient {
       // Use curl to check the health endpoint locally
       const { stdout } = await this.processExecutor.executeCommand(
         "curl",
-        ["-s", "--max-time", "2", `http://${host}:${port}/health`],
-        { timeoutMs: IOSCtrlProxyHealthClient.FETCH_TIMEOUT_MS }
+        ["-s", "--max-time", String(requestTimeoutMs / 1000), `http://${host}:${port}/health`],
+        { timeoutMs: requestTimeoutMs }
       );
       return stdout;
     } catch (error) {

--- a/test/utils/IOSCtrlProxyManager.test.ts
+++ b/test/utils/IOSCtrlProxyManager.test.ts
@@ -1938,6 +1938,62 @@ describe("IOSCtrlProxyManager", function() {
       expect(fakeExecutor.getSpawnedProcesses()).toHaveLength(1);
     });
 
+    test("start() filters non-runner candidates before applying the direct-runner probe cap", async function() {
+      const simulatorProcess: FakeListeningProcess = {
+        pid: 2468,
+        port: 0,
+        ppid: 1,
+        command: `launchd_sim ${testDevice.deviceId}`,
+        alive: true,
+      };
+      const unrelatedProcesses = Array.from(
+        { length: MAX_STARTUP_ORPHAN_RUNNER_CANDIDATES },
+        (_, index): FakeListeningProcess => ({
+          pid: 2600 + index,
+          port: 0,
+          ppid: 1,
+          command: `xcodebuild CtrlProxy unrelated-process-${index}`,
+          alive: true,
+        })
+      );
+      const runnerProcess: FakeListeningProcess = {
+        pid: 2700,
+        port: 8790,
+        ppid: simulatorProcess.pid,
+        command: "/tmp/CtrlProxyUITests-Runner.app/PlugIns/CtrlProxyUITests.xctest/CtrlProxyUITests-Runner",
+        environment: `CTRL_PROXY_IOS_PORT=8790 AUTOMOBILE_DEVICE_ID=${testDevice.deviceId}`,
+        alive: true,
+      };
+      installListeningProcessFakes(fakeExecutor, [simulatorProcess, ...unrelatedProcesses, runnerProcess]);
+      const manager = IOSCtrlProxyManager.createForTestingWithDeps(
+        testDevice,
+        fakeTimer,
+        createFakeBuilder(),
+        fakeExecutor
+      );
+
+      fakeExecutor.setCommandResponse("pgrep -x xcodebuild", createExecResult("", ""));
+      fakeExecutor.setCommandResponse(
+        "pgrep -f 'CtrlProxy'",
+        createExecResult([...unrelatedProcesses, runnerProcess].map(process => String(process.pid)).join("\n"), "")
+      );
+      fakeExecutor.setCommandHandler("curl -s", command => {
+        const port = Number(command.match(/localhost:(\d+)\/health/)?.[1]);
+        return createExecResult(
+          port === runnerProcess.port
+            ? JSON.stringify({ status: "ok", deviceId: testDevice.deviceId })
+            : "",
+          ""
+        );
+      });
+      fakeTimer.enableAutoAdvance();
+
+      await manager.start();
+
+      expect(manager.getServicePort()).toBe(runnerProcess.port);
+      expect(fakeExecutor.getSpawnedProcesses()).toEqual([]);
+    });
+
     test("start() preserves an externally managed runner on the current port while it is still starting", async function() {
       const externalProcess: FakeListeningProcess = {
         pid: 2470,

--- a/test/utils/IOSCtrlProxyManager.test.ts
+++ b/test/utils/IOSCtrlProxyManager.test.ts
@@ -1774,6 +1774,7 @@ describe("IOSCtrlProxyManager", function() {
         alive: true,
       };
       installListeningProcessFakes(fakeExecutor, [runnerProcess, simulatorProcess]);
+      fakeExecutor.setCommandHandler("lsof -nP -iTCP:", () => createExecResult("", ""));
       const fakeBuilder = {
         getXctestrunPath: async () => {
           throw new Error("should not build when a healthy direct runner is reused");


### PR DESCRIPTION
## Summary

- Filter direct-runner candidates before applying the bounded health-probe cap.
- Bound the entire direct-runner discovery pass to a five-second deadline.
- Preserve reuse of a healthy direct CtrlProxy runner when unrelated CtrlProxy-shaped processes precede it in process discovery.

## Why

The fix in [#5575](https://github.com/kaeawc/auto-mobile/pull/5575) bounded health probes by slicing raw `pgrep` results. On hosts with many xcodebuild wrappers or other non-runner matches ahead of the target, those entries could consume the entire cap and cause a healthy custom-port runner to be relaunched. This follow-up counts only eligible direct runner candidates, while still limiting health probes.

The discovery deadline is propagated into process inspection and health transport timeouts, preventing stale candidates from delaying startup for the full 20 × 2-second probe window.

## Validation

- `bun test test/utils/IOSCtrlProxyManager.test.ts`
- `bun run typecheck`
- `bun run build`
- `bun run lint`
