### PR TITLE
fix(android): identity-safe inspector driver registration

### DIFF
--- a/android/auto-mobile-sdk/api/auto-mobile-sdk.api
+++ b/android/auto-mobile-sdk/api/auto-mobile-sdk.api
@@ -211,6 +211,10 @@ public final class dev.jasonpearson.automobile.sdk.InspectorRegistration {
   public dev.jasonpearson.automobile.sdk.InspectorRegistration(kotlin.jvm.functions.Function0<java.lang.Boolean>);
   public final boolean unregister();
 }
+Compiled from "InspectorRegistration.kt"
+public final class dev.jasonpearson.automobile.sdk.InspectorRegistrationKt {
+  public static final <V> boolean removeIfIdentical(java.util.concurrent.ConcurrentHashMap<java.lang.String, V>, java.lang.String, V);
+}
 Compiled from "NavigationEvent.kt"
 public final class dev.jasonpearson.automobile.sdk.NavigationEvent {
   public static final int $stable;

--- a/android/auto-mobile-sdk/api/auto-mobile-sdk.api
+++ b/android/auto-mobile-sdk/api/auto-mobile-sdk.api
@@ -205,6 +205,12 @@ public final class dev.jasonpearson.automobile.sdk.FrameMetricsCollector {
   public static final void access$attachWindow(dev.jasonpearson.automobile.sdk.FrameMetricsCollector, android.view.Window);
   public static final void access$detachWindow(dev.jasonpearson.automobile.sdk.FrameMetricsCollector, android.view.Window);
 }
+Compiled from "InspectorRegistration.kt"
+public final class dev.jasonpearson.automobile.sdk.InspectorRegistration {
+  public static final int $stable;
+  public dev.jasonpearson.automobile.sdk.InspectorRegistration(kotlin.jvm.functions.Function0<java.lang.Boolean>);
+  public final boolean unregister();
+}
 Compiled from "NavigationEvent.kt"
 public final class dev.jasonpearson.automobile.sdk.NavigationEvent {
   public static final int $stable;
@@ -813,7 +819,7 @@ public final class dev.jasonpearson.automobile.sdk.database.DatabaseInspector {
   public final void initialize$auto_mobile_sdk(android.content.Context);
   public final boolean isEnabled();
   public final void setEnabled(boolean);
-  public final void registerDriver(java.lang.String, dev.jasonpearson.automobile.sdk.database.DatabaseDriver);
+  public final dev.jasonpearson.automobile.sdk.InspectorRegistration registerDriver(java.lang.String, dev.jasonpearson.automobile.sdk.database.DatabaseDriver);
   public final boolean unregisterDriver(java.lang.String);
   public final java.util.Set<java.lang.String> registeredDriverNames();
   public final dev.jasonpearson.automobile.sdk.database.DatabaseDriver getDriver$auto_mobile_sdk(java.lang.String);
@@ -1663,7 +1669,7 @@ public final class dev.jasonpearson.automobile.sdk.storage.DataStoreInspector {
   public static final dev.jasonpearson.automobile.sdk.storage.DataStoreInspector INSTANCE;
   public static final java.lang.String REDACTED_VALUE;
   public static final int $stable;
-  public final void registerAdapter(java.lang.String, dev.jasonpearson.automobile.sdk.storage.DataStoreAdapter);
+  public final dev.jasonpearson.automobile.sdk.InspectorRegistration registerAdapter(java.lang.String, dev.jasonpearson.automobile.sdk.storage.DataStoreAdapter);
   public final boolean unregisterAdapter(java.lang.String);
   public final java.util.Set<java.lang.String> registeredAdapterNames();
   public final void setRedactionPolicy(dev.jasonpearson.automobile.sdk.storage.DataStoreRedactionPolicy);
@@ -1874,7 +1880,7 @@ public final class dev.jasonpearson.automobile.sdk.storage.SharedPreferencesInsp
   public final void initialize$auto_mobile_sdk(android.content.Context);
   public final boolean isEnabled();
   public final void setEnabled(boolean);
-  public final void registerDriver(java.lang.String, dev.jasonpearson.automobile.sdk.storage.SharedPreferencesDriver);
+  public final dev.jasonpearson.automobile.sdk.InspectorRegistration registerDriver(java.lang.String, dev.jasonpearson.automobile.sdk.storage.SharedPreferencesDriver);
   public final boolean unregisterDriver(java.lang.String);
   public final java.util.Set<java.lang.String> registeredDriverNames();
   public final dev.jasonpearson.automobile.sdk.storage.SharedPreferencesDriver getDriver$auto_mobile_sdk(java.lang.String);

--- a/android/auto-mobile-sdk/src/main/kotlin/dev/jasonpearson/automobile/sdk/InspectorRegistration.kt
+++ b/android/auto-mobile-sdk/src/main/kotlin/dev/jasonpearson/automobile/sdk/InspectorRegistration.kt
@@ -1,5 +1,31 @@
 package dev.jasonpearson.automobile.sdk
 
+import java.util.concurrent.ConcurrentHashMap
+
+/**
+ * Removes [name] only if it currently maps to the exact [value] instance (reference identity, not
+ * [equals]). Returns whether it was removed.
+ *
+ * `ConcurrentHashMap.remove(key, value)` compares with `equals`, so two distinct drivers that
+ * compare equal (or the same instance registered twice) would let a stale handle remove a live
+ * replacement (issue #5581). This uses `===` under an atomic `computeIfPresent` instead.
+ */
+internal fun <V : Any> ConcurrentHashMap<String, V>.removeIfIdentical(
+  name: String,
+  value: V,
+): Boolean {
+  var removed = false
+  computeIfPresent(name) { _, current ->
+    if (current === value) {
+      removed = true
+      null // returning null removes the mapping
+    } else {
+      current
+    }
+  }
+  return removed
+}
+
 /**
  * Handle returned by an inspector's driver/adapter registration
  * ([dev.jasonpearson.automobile.sdk.storage.SharedPreferencesInspector.registerDriver],

--- a/android/auto-mobile-sdk/src/main/kotlin/dev/jasonpearson/automobile/sdk/InspectorRegistration.kt
+++ b/android/auto-mobile-sdk/src/main/kotlin/dev/jasonpearson/automobile/sdk/InspectorRegistration.kt
@@ -1,0 +1,21 @@
+package dev.jasonpearson.automobile.sdk
+
+/**
+ * Handle returned by an inspector's driver/adapter registration
+ * ([dev.jasonpearson.automobile.sdk.storage.SharedPreferencesInspector.registerDriver],
+ * [dev.jasonpearson.automobile.sdk.database.DatabaseInspector.registerDriver],
+ * [dev.jasonpearson.automobile.sdk.storage.DataStoreInspector.registerAdapter]).
+ *
+ * Removal via this handle is **identity-conditioned**: it removes the registration only if it is
+ * still the current one for its name. When a second lifecycle owner registers under the same stable
+ * name, the newer registration replaces the older; a stale owner calling [unregister] on its old
+ * handle then no-ops instead of tearing down the replacement (issue #5581). The name-based
+ * `unregister*` entry points remain for callers that manage lifetime by name.
+ */
+class InspectorRegistration internal constructor(private val remove: () -> Boolean) {
+  /**
+   * Removes this registration if it is still the current one for its name. Returns whether it was
+   * removed (false if it had already been replaced or removed).
+   */
+  fun unregister(): Boolean = remove()
+}

--- a/android/auto-mobile-sdk/src/main/kotlin/dev/jasonpearson/automobile/sdk/database/DatabaseInspector.kt
+++ b/android/auto-mobile-sdk/src/main/kotlin/dev/jasonpearson/automobile/sdk/database/DatabaseInspector.kt
@@ -2,6 +2,7 @@ package dev.jasonpearson.automobile.sdk.database
 
 import android.content.Context
 import dev.jasonpearson.automobile.sdk.InspectorRegistration
+import dev.jasonpearson.automobile.sdk.removeIfIdentical
 import java.util.concurrent.ConcurrentHashMap
 
 /**
@@ -67,7 +68,7 @@ object DatabaseInspector {
   fun registerDriver(name: String, driver: DatabaseDriver): InspectorRegistration {
     require(name.isNotBlank()) { "driver name must not be blank" }
     customDrivers[name] = driver
-    return InspectorRegistration { customDrivers.remove(name, driver) }
+    return InspectorRegistration { customDrivers.removeIfIdentical(name, driver) }
   }
 
   /** Removes an application-owned database driver and returns whether it was registered. */

--- a/android/auto-mobile-sdk/src/main/kotlin/dev/jasonpearson/automobile/sdk/database/DatabaseInspector.kt
+++ b/android/auto-mobile-sdk/src/main/kotlin/dev/jasonpearson/automobile/sdk/database/DatabaseInspector.kt
@@ -1,6 +1,7 @@
 package dev.jasonpearson.automobile.sdk.database
 
 import android.content.Context
+import dev.jasonpearson.automobile.sdk.InspectorRegistration
 import java.util.concurrent.ConcurrentHashMap
 
 /**
@@ -57,10 +58,16 @@ object DatabaseInspector {
     }
   }
 
-  /** Registers an application-owned database driver under a stable store name. */
-  fun registerDriver(name: String, driver: DatabaseDriver) {
+  /**
+   * Registers an application-owned database driver under a stable store name.
+   *
+   * Returns an [InspectorRegistration] whose [InspectorRegistration.unregister] removes this driver
+   * only if it has not since been replaced under the same name (issue #5581).
+   */
+  fun registerDriver(name: String, driver: DatabaseDriver): InspectorRegistration {
     require(name.isNotBlank()) { "driver name must not be blank" }
     customDrivers[name] = driver
+    return InspectorRegistration { customDrivers.remove(name, driver) }
   }
 
   /** Removes an application-owned database driver and returns whether it was registered. */

--- a/android/auto-mobile-sdk/src/main/kotlin/dev/jasonpearson/automobile/sdk/storage/DataStoreInspector.kt
+++ b/android/auto-mobile-sdk/src/main/kotlin/dev/jasonpearson/automobile/sdk/storage/DataStoreInspector.kt
@@ -1,5 +1,6 @@
 package dev.jasonpearson.automobile.sdk.storage
 
+import dev.jasonpearson.automobile.sdk.InspectorRegistration
 import java.util.concurrent.ConcurrentHashMap
 import kotlin.coroutines.cancellation.CancellationException
 
@@ -26,10 +27,16 @@ object DataStoreInspector {
   private val adapters = ConcurrentHashMap<String, DataStoreAdapter>()
   @Volatile private var redactionPolicy: DataStoreRedactionPolicy = DataStoreRedactionPolicy.NONE
 
-  /** Registers or replaces the application-provided adapter under [name]. */
-  fun registerAdapter(name: String, adapter: DataStoreAdapter) {
+  /**
+   * Registers or replaces the application-provided adapter under [name].
+   *
+   * Returns an [InspectorRegistration] whose [InspectorRegistration.unregister] removes this
+   * adapter only if it has not since been replaced under the same name (issue #5581).
+   */
+  fun registerAdapter(name: String, adapter: DataStoreAdapter): InspectorRegistration {
     require(name.isNotBlank()) { "adapter name must not be blank" }
     adapters[name] = adapter
+    return InspectorRegistration { adapters.remove(name, adapter) }
   }
 
   /** Removes the adapter registered under [name] and returns whether one was registered. */

--- a/android/auto-mobile-sdk/src/main/kotlin/dev/jasonpearson/automobile/sdk/storage/DataStoreInspector.kt
+++ b/android/auto-mobile-sdk/src/main/kotlin/dev/jasonpearson/automobile/sdk/storage/DataStoreInspector.kt
@@ -1,6 +1,7 @@
 package dev.jasonpearson.automobile.sdk.storage
 
 import dev.jasonpearson.automobile.sdk.InspectorRegistration
+import dev.jasonpearson.automobile.sdk.removeIfIdentical
 import java.util.concurrent.ConcurrentHashMap
 import kotlin.coroutines.cancellation.CancellationException
 
@@ -36,7 +37,7 @@ object DataStoreInspector {
   fun registerAdapter(name: String, adapter: DataStoreAdapter): InspectorRegistration {
     require(name.isNotBlank()) { "adapter name must not be blank" }
     adapters[name] = adapter
-    return InspectorRegistration { adapters.remove(name, adapter) }
+    return InspectorRegistration { adapters.removeIfIdentical(name, adapter) }
   }
 
   /** Removes the adapter registered under [name] and returns whether one was registered. */

--- a/android/auto-mobile-sdk/src/main/kotlin/dev/jasonpearson/automobile/sdk/storage/DataStoreModels.kt
+++ b/android/auto-mobile-sdk/src/main/kotlin/dev/jasonpearson/automobile/sdk/storage/DataStoreModels.kt
@@ -19,9 +19,12 @@ data class DataStoreEntry(
   /** The preference key. */
   val key: String,
   /**
-   * The preference value, or null when the key is absent or the value was redacted away. Callers
-   * should interpret the value through [type]; an [DataStoreValueType.UNKNOWN] type marks a value
-   * whose runtime kind is not representable by the contract.
+   * The preference value, or null when the key is absent. A value removed by the configured
+   * redaction policy is replaced with the [DataStoreInspector.REDACTED_VALUE] marker string and its
+   * [type] is set to [DataStoreValueType.STRING] (so the marker survives wire serialization) —
+   * redaction never yields null. Callers should interpret the value through [type]; an
+   * [DataStoreValueType.UNKNOWN] type marks a value whose runtime kind is not representable by the
+   * contract.
    */
   val value: Any?,
   /** The structured type of [value]. */
@@ -71,7 +74,10 @@ fun interface DataStoreRedactionPolicy {
  * an adapter is registered (issue #5192).
  */
 data class DataStoreCapabilities(
-  /** Whether at least one application-provided adapter is registered and readable. */
+  /**
+   * Whether at least one application-provided adapter is currently registered. This reflects
+   * registration only — it does not verify that an adapter can successfully list or read a store.
+   */
   val readSupported: Boolean,
   /**
    * Always false: the DataStore adapter contract is read-only and exposes no mutation entry point,

--- a/android/auto-mobile-sdk/src/main/kotlin/dev/jasonpearson/automobile/sdk/storage/SharedPreferencesInspector.kt
+++ b/android/auto-mobile-sdk/src/main/kotlin/dev/jasonpearson/automobile/sdk/storage/SharedPreferencesInspector.kt
@@ -2,6 +2,7 @@ package dev.jasonpearson.automobile.sdk.storage
 
 import android.content.Context
 import dev.jasonpearson.automobile.sdk.InspectorRegistration
+import dev.jasonpearson.automobile.sdk.removeIfIdentical
 import java.util.concurrent.ConcurrentHashMap
 
 /**
@@ -67,7 +68,7 @@ object SharedPreferencesInspector {
   fun registerDriver(name: String, driver: SharedPreferencesDriver): InspectorRegistration {
     require(name.isNotBlank()) { "driver name must not be blank" }
     customDrivers[name] = driver
-    return InspectorRegistration { customDrivers.remove(name, driver) }
+    return InspectorRegistration { customDrivers.removeIfIdentical(name, driver) }
   }
 
   /** Removes an application-owned key-value driver and returns whether it was registered. */

--- a/android/auto-mobile-sdk/src/main/kotlin/dev/jasonpearson/automobile/sdk/storage/SharedPreferencesInspector.kt
+++ b/android/auto-mobile-sdk/src/main/kotlin/dev/jasonpearson/automobile/sdk/storage/SharedPreferencesInspector.kt
@@ -1,6 +1,7 @@
 package dev.jasonpearson.automobile.sdk.storage
 
 import android.content.Context
+import dev.jasonpearson.automobile.sdk.InspectorRegistration
 import java.util.concurrent.ConcurrentHashMap
 
 /**
@@ -57,10 +58,16 @@ object SharedPreferencesInspector {
     }
   }
 
-  /** Registers an application-owned key-value driver under a stable store name. */
-  fun registerDriver(name: String, driver: SharedPreferencesDriver) {
+  /**
+   * Registers an application-owned key-value driver under a stable store name.
+   *
+   * Returns an [InspectorRegistration] whose [InspectorRegistration.unregister] removes this driver
+   * only if it has not since been replaced under the same name (issue #5581).
+   */
+  fun registerDriver(name: String, driver: SharedPreferencesDriver): InspectorRegistration {
     require(name.isNotBlank()) { "driver name must not be blank" }
     customDrivers[name] = driver
+    return InspectorRegistration { customDrivers.remove(name, driver) }
   }
 
   /** Removes an application-owned key-value driver and returns whether it was registered. */

--- a/android/auto-mobile-sdk/src/test/kotlin/dev/jasonpearson/automobile/sdk/database/DatabaseInspectorTest.kt
+++ b/android/auto-mobile-sdk/src/test/kotlin/dev/jasonpearson/automobile/sdk/database/DatabaseInspectorTest.kt
@@ -37,6 +37,43 @@ class DatabaseInspectorTest {
     assertFalse(DatabaseInspector.unregisterDriver("room"))
   }
 
+  private fun newDriver() =
+    object : DatabaseDriver {
+      override fun getDatabases() = emptyList<DatabaseDescriptor>()
+
+      override fun getTables(databasePath: String) = emptyList<String>()
+
+      override fun getTableData(databasePath: String, table: String, limit: Int, offset: Int) =
+        TableDataResult(emptyList(), emptyList(), 0)
+
+      override fun getTableStructure(databasePath: String, table: String) =
+        TableStructureResult(emptyList())
+
+      override fun executeSQL(databasePath: String, query: String) =
+        SQLExecutionResult.Query(emptyList(), emptyList())
+    }
+
+  // #5581 — a stale registration handle must not remove a replacement registered under the same
+  // name.
+  @Test
+  fun `stale registration handle does not remove a replacement`() {
+    val firstReg = DatabaseInspector.registerDriver("room", newDriver())
+    DatabaseInspector.registerDriver("room", newDriver()) // replaces first
+
+    assertFalse(firstReg.unregister())
+    assertEquals(setOf("room"), DatabaseInspector.registeredDriverNames())
+  }
+
+  // #5581 — a current registration handle removes only its own registration.
+  @Test
+  fun `current registration handle removes its driver`() {
+    val reg = DatabaseInspector.registerDriver("room", newDriver())
+
+    assertTrue(reg.unregister())
+    assertTrue(DatabaseInspector.registeredDriverNames().isEmpty())
+    assertFalse(reg.unregister())
+  }
+
   @Test
   fun `unknown named driver does not fall back to default`() {
     try {

--- a/android/auto-mobile-sdk/src/test/kotlin/dev/jasonpearson/automobile/sdk/storage/DataStoreInspectorTest.kt
+++ b/android/auto-mobile-sdk/src/test/kotlin/dev/jasonpearson/automobile/sdk/storage/DataStoreInspectorTest.kt
@@ -281,6 +281,29 @@ class DataStoreInspectorTest {
     assertEquals("two", DataStoreInspector.readStore("prefs", "s").single().value)
   }
 
+  // #5581 — a stale registration handle must not remove a replacement registered under the same
+  // name.
+  @Test
+  fun `stale registration handle does not remove a replacement`() {
+    val first = FakeDataStoreAdapter()
+    val second = FakeDataStoreAdapter()
+    val firstReg = DataStoreInspector.registerAdapter("prefs", first)
+    DataStoreInspector.registerAdapter("prefs", second) // replaces first
+
+    assertFalse(firstReg.unregister())
+    assertEquals(setOf("prefs"), DataStoreInspector.registeredAdapterNames())
+  }
+
+  // #5581 — a current registration handle removes only its own registration.
+  @Test
+  fun `current registration handle removes its adapter`() {
+    val reg = DataStoreInspector.registerAdapter("prefs", FakeDataStoreAdapter())
+
+    assertTrue(reg.unregister())
+    assertTrue(DataStoreInspector.registeredAdapterNames().isEmpty())
+    assertFalse(reg.unregister())
+  }
+
   // AC5 — removal is lifecycle-safe and idempotent.
   @Test
   fun `unregister returns true then false`() {

--- a/android/auto-mobile-sdk/src/test/kotlin/dev/jasonpearson/automobile/sdk/storage/DataStoreInspectorTest.kt
+++ b/android/auto-mobile-sdk/src/test/kotlin/dev/jasonpearson/automobile/sdk/storage/DataStoreInspectorTest.kt
@@ -15,6 +15,13 @@ import org.junit.Test
 @OptIn(ExperimentalCoroutinesApi::class)
 class DataStoreInspectorTest {
 
+  /** An adapter with value equality, to prove removal keys on reference identity not equals. */
+  private data class EqualAdapter(val tag: String = "same") : DataStoreAdapter {
+    override suspend fun storeNames() = emptyList<String>()
+
+    override suspend fun read(storeName: String) = emptyList<DataStoreEntry>()
+  }
+
   @Before
   fun setUp() {
     DataStoreInspector.reset()
@@ -287,6 +294,20 @@ class DataStoreInspectorTest {
   fun `stale registration handle does not remove a replacement`() {
     val first = FakeDataStoreAdapter()
     val second = FakeDataStoreAdapter()
+    val firstReg = DataStoreInspector.registerAdapter("prefs", first)
+    DataStoreInspector.registerAdapter("prefs", second) // replaces first
+
+    assertFalse(firstReg.unregister())
+    assertEquals(setOf("prefs"), DataStoreInspector.registeredAdapterNames())
+  }
+
+  // #5581 — identity is by reference, not equals: two distinct-but-equal adapters must not let a
+  // stale handle remove the replacement (a ConcurrentHashMap.remove(k,v) equals-based check would).
+  @Test
+  fun `stale handle does not remove an equals-equal replacement`() {
+    val first = EqualAdapter()
+    val second = EqualAdapter()
+    assertEquals(first, second) // value-equal, distinct instances
     val firstReg = DataStoreInspector.registerAdapter("prefs", first)
     DataStoreInspector.registerAdapter("prefs", second) // replaces first
 

--- a/android/auto-mobile-sdk/src/test/kotlin/dev/jasonpearson/automobile/sdk/storage/SharedPreferencesInspectorTest.kt
+++ b/android/auto-mobile-sdk/src/test/kotlin/dev/jasonpearson/automobile/sdk/storage/SharedPreferencesInspectorTest.kt
@@ -73,6 +73,46 @@ class SharedPreferencesInspectorTest {
     assertFalse(SharedPreferencesInspector.unregisterDriver("datastore"))
   }
 
+  private fun newDriver() =
+    object : SharedPreferencesDriver {
+      override fun getPreferenceFiles() = emptyList<PreferenceFileDescriptor>()
+
+      override fun getPreferences(fileName: String) = emptyList<KeyValuePair>()
+
+      override fun registerOnChangeListener(listener: OnPreferenceChangeListener) = Unit
+
+      override fun unregisterOnChangeListener(listener: OnPreferenceChangeListener) = Unit
+
+      override fun getPreference(fileName: String, key: String) = null
+
+      override fun setValue(fileName: String, key: String, value: Any?, type: KeyValueType) = Unit
+
+      override fun removeValue(fileName: String, key: String) = Unit
+
+      override fun clear(fileName: String) = Unit
+    }
+
+  // #5581 — a stale registration handle must not remove a replacement registered under the same
+  // name.
+  @Test
+  fun `stale registration handle does not remove a replacement`() {
+    val firstReg = SharedPreferencesInspector.registerDriver("prefs", newDriver())
+    SharedPreferencesInspector.registerDriver("prefs", newDriver()) // replaces first
+
+    assertFalse(firstReg.unregister())
+    assertEquals(setOf("prefs"), SharedPreferencesInspector.registeredDriverNames())
+  }
+
+  // #5581 — a current registration handle removes only its own registration.
+  @Test
+  fun `current registration handle removes its driver`() {
+    val reg = SharedPreferencesInspector.registerDriver("prefs", newDriver())
+
+    assertTrue(reg.unregister())
+    assertTrue(SharedPreferencesInspector.registeredDriverNames().isEmpty())
+    assertFalse(reg.unregister())
+  }
+
   @Test
   fun `unknown named driver does not fall back to default`() {
     try {

--- a/docs/design-docs/plat/android/auto-mobile-sdk.md
+++ b/docs/design-docs/plat/android/auto-mobile-sdk.md
@@ -354,7 +354,7 @@ DataStore-backed preferences are then discoverable and readable through the exis
 **Boundary guarantees** (enforced by `DataStoreInspector`, independent of the host adapter):
 
 - **Read-only.** The `DataStoreAdapter` contract exposes no mutation entry point, so mutation is structurally unsupported; `capabilities().mutationSupported` is always `false`.
-- **Redaction.** A configurable `DataStoreRedactionPolicy` (`setRedactionPolicy`) redacts matching values at the boundary before they leave the SDK; a host adapter cannot opt out.
+- **Redaction.** A configurable `DataStoreRedactionPolicy` (`setRedactionPolicy`) redacts matching values at the boundary before they leave the SDK; a host adapter cannot opt out. A redacted value is replaced with the `DataStoreInspector.REDACTED_VALUE` marker string and its type is set to `STRING` (so the marker survives wire serialization) — redaction never yields a null value.
 - **Structured values and errors.** Values map onto `DataStoreValueType` (String, Int, Long, Float, Double, Boolean, `Set<String>`, byte array); an unrepresentable value is surfaced as `UNKNOWN` or rejected with `DataStoreAdapterError.UnsupportedValue`. Missing adapters/stores and host read failures surface as `AdapterNotFound`, `StoreNotFound`, and `ReadError`.
 - **Lifecycle-safe.** Registration replaces by name, `unregisterAdapter` returns whether one was removed, and `AutoMobileSDK.shutdown()` clears all adapters. Reads run in the caller's coroutine context, so cancellation propagates cooperatively and no background coroutines or listeners are retained.
 

--- a/docs/design-docs/plat/android/auto-mobile-sdk.md
+++ b/docs/design-docs/plat/android/auto-mobile-sdk.md
@@ -345,7 +345,10 @@ class AppDataStoreAdapter(
 
 if (BuildConfig.DEBUG) {
   SharedPreferencesInspector.setEnabled(true) // shared storage-surface enable switch
-  DataStoreInspector.registerAdapter("app", AppDataStoreAdapter(stores))
+  // Retain the returned handle for registration-scoped teardown (see Lifecycle-safe below).
+  val registration = DataStoreInspector.registerAdapter("app", AppDataStoreAdapter(stores))
+  // ... later, when this owner is torn down:
+  registration.unregister() // removes only if it has not since been replaced
 }
 ```
 
@@ -356,7 +359,7 @@ DataStore-backed preferences are then discoverable and readable through the exis
 - **Read-only.** The `DataStoreAdapter` contract exposes no mutation entry point, so mutation is structurally unsupported; `capabilities().mutationSupported` is always `false`.
 - **Redaction.** A configurable `DataStoreRedactionPolicy` (`setRedactionPolicy`) redacts matching values at the boundary before they leave the SDK; a host adapter cannot opt out. A redacted value is replaced with the `DataStoreInspector.REDACTED_VALUE` marker string and its type is set to `STRING` (so the marker survives wire serialization) — redaction never yields a null value.
 - **Structured values and errors.** Values map onto `DataStoreValueType` (String, Int, Long, Float, Double, Boolean, `Set<String>`, byte array); an unrepresentable value is surfaced as `UNKNOWN` or rejected with `DataStoreAdapterError.UnsupportedValue`. Missing adapters/stores and host read failures surface as `AdapterNotFound`, `StoreNotFound`, and `ReadError`.
-- **Lifecycle-safe.** Registration replaces by name, `unregisterAdapter` returns whether one was removed, and `AutoMobileSDK.shutdown()` clears all adapters. Reads run in the caller's coroutine context, so cancellation propagates cooperatively and no background coroutines or listeners are retained.
+- **Lifecycle-safe.** Registration replaces by name and returns an `InspectorRegistration` handle. For registration-scoped teardown, keep that handle and call `registration.unregister()` — it removes the adapter **only if it has not since been replaced** under the same name, so a stale owner cannot tear down a newer owner's replacement. The name-based `unregisterAdapter(name)` removes whatever is currently registered under that name (use it only when you own the name unconditionally). `AutoMobileSDK.shutdown()` clears all adapters. Reads run in the caller's coroutine context, so cancellation propagates cooperatively and no background coroutines or listeners are retained.
 
 **Limitations.** Read-only by design (no writes). Change subscriptions/listeners are not part of the contract (unlike `SharedPreferencesInspector`) — reads are point-in-time snapshots. Value redaction operates per key/store name, not on nested structured values. The SDK never links against `androidx.datastore`; representing values is the host adapter's responsibility.
 


### PR DESCRIPTION
## Summary

Makes application-provided driver/adapter registration on all three SDK inspectors resilient to same-name replacement, and folds in two DataStore KDoc corrections from #5567 review.

The registries key drivers by a caller-chosen name and previously removed them by that name. When two lifecycle owners register under the same stable name, the newer registration replaced the older, but the older owner's later `unregister*` still removed the **newer** driver by name — tearing down a live replacement.

## Linked Issue

Closes #5581

## Changes

- New public `InspectorRegistration` (root `dev.jasonpearson.automobile.sdk`) with `unregister(): Boolean`.
- `SharedPreferencesInspector.registerDriver`, `DatabaseInspector.registerDriver`, and `DataStoreInspector.registerAdapter` now return an `InspectorRegistration` whose `unregister()` is **identity-conditioned** (`ConcurrentHashMap.remove(name, value)`) — a stale handle no-ops instead of removing a replacement.
- **Backward compatible**: name-based `unregisterDriver`/`unregisterAdapter(name)` retained; the `register*` return-type change (`Unit` → `InspectorRegistration`) is source-compatible for callers that ignore the result.
- Regenerated the `auto-mobile-sdk` public API baseline (`apiDump`).
- DataStore KDoc fixes (CodeRabbit, #5567): `DataStoreEntry.value` documents the `REDACTED_VALUE` STRING marker (redaction never yields null); `DataStoreCapabilities.readSupported` documents that it reflects registration only, not readability; design-doc redaction note added.

## Validation

- [x] `:auto-mobile-sdk:testDebugUnitTest` (incl. new identity tests in all 3 inspector test suites), `:auto-mobile-sdk:detekt`, `:auto-mobile-sdk:apiCheck` all green locally
- [x] `scripts/ktfmt/validate_ktfmt.sh` clean tree-wide
- [x] Interface + fake unit tests, <100ms
- [ ] TypeScript checks N/A — no TS/schema surfaces touched

## Kotlin Reuse Check

- [x] Uniform mechanism across all three inspectors via one shared `InspectorRegistration` type; no new dependency.

## Acceptance Criteria

- [x] Registration exposes a handle; removal conditioned on driver identity so a stale owner cannot remove a replacement.
- [x] Applied uniformly across all three inspectors.
- [x] Backward compatible (name-based path retained; source-compatible return-type change).
- [x] Public API baseline regenerated and committed.
- [x] Tests: replace-then-stale-unregister does not remove the replacement; current handle removes; name-based path still works.
- [x] Folded-in DataStore KDoc corrections.
