### PR TITLE
fix(desktop): pair multi-window compare frames by subtree similarity (#5533)

### DIFF
--- a/android/desktop-core/src/main/kotlin/dev/jasonpearson/automobile/desktop/core/layout/HierarchyDiff.kt
+++ b/android/desktop-core/src/main/kotlin/dev/jasonpearson/automobile/desktop/core/layout/HierarchyDiff.kt
@@ -249,19 +249,59 @@ private fun alignWindowSlots(
 }
 
 /**
- * The set of structural path keys of a window's subtree, computed independently of the window's
- * slot (the window root sits at sibling index 0). Two windows with identical structure produce
- * identical key sets, so [jaccard] overlap measures subtree similarity for [alignWindowSlots].
+ * The semantic-aware signature key set of a window's subtree, computed independently of the
+ * window's slot (the window root sits at sibling index 0). Two windows that are fully equal
+ * (structure **and** compared attributes) produce identical key sets, so [jaccard] overlap measures
+ * subtree similarity for [alignWindowSlots]. See [collectSignatureKeys].
  */
 private fun signatureKeys(window: UIElementInfo): Set<String> {
-  val map = LinkedHashMap<String, UIElementInfo>()
-  addSubtree(map, window, parentKey = "", siblingIndex = 0)
-  return map.keys
+  val keys = LinkedHashSet<String>()
+  collectSignatureKeys(keys, window, parentKey = "", siblingIndex = 0)
+  return keys
 }
 
 /**
- * A canonical, order-independent string for a window's structural key set: its keys sorted and
- * joined. Two windows compare equal here iff they have the same set of structural keys, so it is a
+ * Accumulate a window's subtree into semantic-aware signature keys. Each node contributes its
+ * **structural** path key (via [pathKey], so the ancestor chain and sibling indexes match the diff)
+ * plus a digest of the same attributes [nodeAttributesDiffer] compares. Descendants nest under the
+ * structural parent key, so a semantic difference on one node changes only that node's key.
+ *
+ * Folding semantics in is what lets [alignWindowSlots] pair the *right* window when a side holds
+ * structurally-identical duplicates that differ only in content: a fully-equal window then scores
+ * Jaccard 1 while a same-shape-but-changed one scores lower, so the aligner prefers the true match
+ * instead of arbitrarily pairing a trailing duplicate.
+ */
+private fun collectSignatureKeys(
+  keys: MutableSet<String>,
+  node: UIElementInfo,
+  parentKey: String,
+  siblingIndex: Int,
+) {
+  val structural = pathKey(parentKey, node, siblingIndex)
+  keys.add("$structural::${semanticDigest(node)}")
+  node.children.forEachIndexed { index, child ->
+    collectSignatureKeys(keys, child, structural, index)
+  }
+}
+
+/** The compared semantic attributes of a node, joined — the [nodeAttributesDiffer] surface. */
+private fun semanticDigest(node: UIElementInfo): String =
+  listOf(
+      node.text ?: "",
+      node.contentDescription ?: "",
+      node.isClickable,
+      node.isEnabled,
+      node.isFocused,
+      node.isSelected,
+      node.isScrollable,
+      node.isCheckable,
+      node.isChecked,
+    )
+    .joinToString("|")
+
+/**
+ * A canonical, order-independent string for a window's signature key set: its keys sorted and
+ * joined. Two windows compare equal here iff they have the same set of signature keys, so it is a
  * side-independent total order for the transposition-invariant tie-break in [alignWindowSlots].
  */
 private fun canonicalSignature(signature: Set<String>): String =

--- a/android/desktop-core/src/main/kotlin/dev/jasonpearson/automobile/desktop/core/layout/HierarchyDiff.kt
+++ b/android/desktop-core/src/main/kotlin/dev/jasonpearson/automobile/desktop/core/layout/HierarchyDiff.kt
@@ -69,8 +69,11 @@ private const val PATH_SEPARATOR = "/"
  * exactly an `OnlyInB` key in the other; `Changed`/`Equal` key sets are identical).
  */
 fun diffHierarchies(a: UIElementInfo, b: UIElementInfo): HierarchyDiff {
-  val mapA = indexByPathKey(a)
-  val mapB = indexByPathKey(b)
+  val windowsA = windowsOf(a)
+  val windowsB = windowsOf(b)
+  val (slotsA, slotsB) = alignWindowSlots(windowsA, windowsB)
+  val mapA = indexWindows(windowsA, slotsA)
+  val mapB = indexWindows(windowsB, slotsB)
   val entries = ArrayList<HierarchyDiffEntry>(mapA.size + mapB.size)
   for ((key, nodeA) in mapA) {
     val nodeB = mapB[key]
@@ -93,35 +96,162 @@ private fun classifyMatched(nodeA: UIElementInfo, nodeB: UIElementInfo?): NodeDi
   }
 
 /**
- * Build a stable key -> node map in pre-order. Keys are unique within one tree by construction (the
- * per-level sibling index disambiguates siblings, and the ancestor chain disambiguates subtrees).
- *
- * The synthetic multi-window wrapper (see [MULTI_WINDOW_ROOT_CLASS_NAME], issue #4874) is
- * **transparent** to the diff: each window is indexed as if it were a top-level root, keyed by its
- * window index. Without this, a frame with an extra window (e.g. an IME) is wrapped while the other
- * side is not, so every node's key gains a `AutoMobile.MultiWindowRoot/…` prefix on only one side
- * and nothing matches — the whole app reports as OnlyInA/OnlyInB instead of isolating the extra
- * window. Normalizing both shapes lets a single-window frame (window index 0) still match the first
- * window of a wrapped multi-window frame, so only the genuinely-extra windows surface.
- *
- * Windows are paired positionally (by window index). Known limitation: when both sides are
- * multi-window and a window is inserted or removed *before* another, the survivors shift index and
- * their subtrees surface as removed+added. A stable cross-side window identity would fix this, but
- * none survives to this layer — bounds are excluded by design (resolution differs), and the wire's
- * only per-window id is a content hash (`src/features/observe/android/StableNodeIdentity.ts`), not
- * a stable window handle. Tracked as a follow-up; the common single-vs-multi and parallel-window
- * cases pair correctly.
+ * The top-level windows of a frame. The synthetic multi-window wrapper (see
+ * [MULTI_WINDOW_ROOT_CLASS_NAME], issue #4874) is unwrapped to its window children; a plain
+ * single-window frame is its own only window. This normalization is what lets a single-window frame
+ * match the corresponding window of a wrapped multi-window frame (see [alignWindowSlots]).
  */
-private fun indexByPathKey(root: UIElementInfo): LinkedHashMap<String, UIElementInfo> {
+private fun windowsOf(root: UIElementInfo): List<UIElementInfo> =
+  if (root.className == MULTI_WINDOW_ROOT_CLASS_NAME) root.children else listOf(root)
+
+/**
+ * Build a stable key -> node map in pre-order for a frame's [windows], keying each window's subtree
+ * at its assigned **window slot** (from [alignWindowSlots]) as the top-level sibling index. Keys
+ * are unique within one tree by construction (the per-level sibling index disambiguates siblings,
+ * and the ancestor chain disambiguates subtrees).
+ *
+ * The synthetic multi-window wrapper is **transparent** to the diff: each window is indexed as if
+ * it were a top-level root. Without this, a frame with an extra window (e.g. an IME) is wrapped
+ * while the other side is not, so every node's key gains a `AutoMobile.MultiWindowRoot/…` prefix on
+ * only one side and nothing matches — the whole app reports as OnlyInA/OnlyInB instead of isolating
+ * the extra window.
+ *
+ * The window slot (not the raw window index) is the top-level sibling index, so windows the aligner
+ * paired across the two frames share a key namespace even when a window was inserted or removed
+ * *before* them and their raw indexes shifted.
+ */
+private fun indexWindows(
+  windows: List<UIElementInfo>,
+  slots: IntArray,
+): LinkedHashMap<String, UIElementInfo> {
   val map = LinkedHashMap<String, UIElementInfo>()
-  if (root.className == MULTI_WINDOW_ROOT_CLASS_NAME) {
-    root.children.forEachIndexed { index, window ->
-      addSubtree(map, window, parentKey = "", siblingIndex = index)
-    }
-  } else {
-    addSubtree(map, root, parentKey = "", siblingIndex = 0)
+  windows.forEachIndexed { index, window ->
+    addSubtree(map, window, parentKey = "", siblingIndex = slots[index])
   }
   return map
+}
+
+/**
+ * Assign each window of frame A and frame B a **window slot** — the top-level sibling index its
+ * subtree is keyed at — such that windows that are the "same window" across the two frames share a
+ * slot and thus pair in the diff, while inserted/removed windows get their own slots and surface as
+ * OnlyIn.
+ *
+ * Windows carry no stable cross-side identity at this layer — bounds are excluded by design
+ * (resolution differs) and the wire's only per-window id is a content hash
+ * (`src/features/observe/android/StableNodeIdentity.ts`), not a stable window handle. So windows
+ * are matched by **subtree similarity** with an **order-preserving alignment** (a Needleman–Wunsch
+ * global alignment over the window sequences, scoring a pairing by the Jaccard overlap of the two
+ * subtrees' structural path keys, gaps free). Order preservation reflects z-order: an inserted or
+ * removed window shifts the survivors' indexes but not their relative order.
+ *
+ * This subsumes the previous positional pairing: for equal-length frames the diagonal (pair window
+ * _i_ with window _i_) alignment maximizes the score and is preferred on ties, so parallel window
+ * stacks and single-vs-single frames pair exactly as before. Only when a strictly-better alignment
+ * exists — i.e. a window was inserted/removed before another — are gaps introduced, pairing the
+ * surviving windows so just the genuinely-extra window surfaces (issue #5533).
+ *
+ * Alignment columns are numbered left-to-right, so a paired column gives both its windows the same
+ * slot and a gap column gives its one window a slot of its own. This numbering is a pure function
+ * of the (order-preserving, hence non-crossing) alignment, so `diffHierarchies(a, b)` and
+ * `diffHierarchies(b, a)` assign every window the same slot — preserving the A/B symmetry contract
+ * of [diffHierarchies].
+ */
+private fun alignWindowSlots(
+  windowsA: List<UIElementInfo>,
+  windowsB: List<UIElementInfo>,
+): Pair<IntArray, IntArray> {
+  val n = windowsA.size
+  val m = windowsB.size
+  val slotsA = IntArray(n)
+  val slotsB = IntArray(m)
+  // Common fast paths: a single window per side always pairs at slot 0 (identical to the previous
+  // positional behavior, including for zero-overlap cross-platform frames).
+  if (n <= 1 && m <= 1) {
+    return slotsA to slotsB
+  }
+
+  val signaturesA = windowsA.map { signatureKeys(it) }
+  val signaturesB = windowsB.map { signatureKeys(it) }
+
+  // Needleman–Wunsch: score[i][j] is the best alignment score of the first i A-windows against the
+  // first j B-windows. A diagonal step pairs the two windows (adds their similarity); an up/left
+  // step leaves a window unpaired (a gap, scored 0).
+  val score = Array(n + 1) { DoubleArray(m + 1) }
+  for (i in 1..n) {
+    for (j in 1..m) {
+      val diagonal = score[i - 1][j - 1] + jaccard(signaturesA[i - 1], signaturesB[j - 1])
+      val skipA = score[i - 1][j]
+      val skipB = score[i][j - 1]
+      score[i][j] = maxOf(diagonal, skipA, skipB)
+    }
+  }
+
+  // Backtrack to the alignment columns, then number them left-to-right. Ties prefer the diagonal
+  // (keeps positional pairing) and then skipA over skipB (a fixed, direction-consistent order so
+  // the
+  // swapped call produces the mirror alignment and hence identical slots).
+  val columnsA = ArrayList<Int>()
+  val columnsB = ArrayList<Int>()
+  var i = n
+  var j = m
+  while (i > 0 || j > 0) {
+    val diagonal =
+      if (i > 0 && j > 0) score[i - 1][j - 1] + jaccard(signaturesA[i - 1], signaturesB[j - 1])
+      else Double.NEGATIVE_INFINITY
+    val skipA = if (i > 0) score[i - 1][j] else Double.NEGATIVE_INFINITY
+    val skipB = if (j > 0) score[i][j - 1] else Double.NEGATIVE_INFINITY
+    when {
+      i > 0 && j > 0 && diagonal >= skipA && diagonal >= skipB -> {
+        columnsA.add(i - 1)
+        columnsB.add(j - 1)
+        i--
+        j--
+      }
+      i > 0 && skipA >= skipB -> {
+        columnsA.add(i - 1)
+        columnsB.add(-1)
+        i--
+      }
+      else -> {
+        columnsA.add(-1)
+        columnsB.add(j - 1)
+        j--
+      }
+    }
+  }
+  // Backtracking yielded columns right-to-left; number them so the leftmost column is slot 0.
+  var slot = 0
+  for (column in columnsA.indices.reversed()) {
+    val aIndex = columnsA[column]
+    val bIndex = columnsB[column]
+    if (aIndex >= 0) slotsA[aIndex] = slot
+    if (bIndex >= 0) slotsB[bIndex] = slot
+    slot++
+  }
+  return slotsA to slotsB
+}
+
+/**
+ * The set of structural path keys of a window's subtree, computed independently of the window's
+ * slot (the window root sits at sibling index 0). Two windows with identical structure produce
+ * identical key sets, so [jaccard] overlap measures subtree similarity for [alignWindowSlots].
+ */
+private fun signatureKeys(window: UIElementInfo): Set<String> {
+  val map = LinkedHashMap<String, UIElementInfo>()
+  addSubtree(map, window, parentKey = "", siblingIndex = 0)
+  return map.keys
+}
+
+/** Jaccard overlap |a ∩ b| / |a ∪ b| of two structural key sets; 0 when both are empty. */
+private fun jaccard(a: Set<String>, b: Set<String>): Double {
+  if (a.isEmpty() && b.isEmpty()) return 0.0
+  var intersection = 0
+  for (key in a) {
+    if (key in b) intersection++
+  }
+  val union = a.size + b.size - intersection
+  return if (union == 0) 0.0 else intersection.toDouble() / union.toDouble()
 }
 
 private fun addSubtree(

--- a/android/desktop-core/src/main/kotlin/dev/jasonpearson/automobile/desktop/core/layout/HierarchyDiff.kt
+++ b/android/desktop-core/src/main/kotlin/dev/jasonpearson/automobile/desktop/core/layout/HierarchyDiff.kt
@@ -173,6 +173,11 @@ private fun alignWindowSlots(
 
   val signaturesA = windowsA.map { signatureKeys(it) }
   val signaturesB = windowsB.map { signatureKeys(it) }
+  // A canonical, side-independent ordering key per window (its sorted signature). Used only to
+  // break a skipA-vs-skipB tie deterministically by window *content* rather than by side, so the
+  // choice is transposition-invariant (see the backtrack below).
+  val canonicalA = signaturesA.map { canonicalSignature(it) }
+  val canonicalB = signaturesB.map { canonicalSignature(it) }
 
   // Needleman–Wunsch: score[i][j] is the best alignment score of the first i A-windows against the
   // first j B-windows. A diagonal step pairs the two windows (adds their similarity); an up/left
@@ -188,9 +193,11 @@ private fun alignWindowSlots(
   }
 
   // Backtrack to the alignment columns, then number them left-to-right. Ties prefer the diagonal
-  // (keeps positional pairing) and then skipA over skipB (a fixed, direction-consistent order so
-  // the
-  // swapped call produces the mirror alignment and hence identical slots).
+  // (keeps positional pairing). When a gap must be chosen and skipA and skipB score equally, break
+  // the tie by window *content* — skip the canonically-smaller window — not by A/B side. A fixed
+  // side preference (always skipA) is not transposition-invariant: two windows that reverse
+  // z-order (similarities `[[0,1],[1,0]]`) then pair differently under swap, breaking the symmetry
+  // contract of [diffHierarchies]. Choosing by content skips the *same* window either way.
   val columnsA = ArrayList<Int>()
   val columnsB = ArrayList<Int>()
   var i = n
@@ -201,6 +208,15 @@ private fun alignWindowSlots(
       else Double.NEGATIVE_INFINITY
     val skipA = if (i > 0) score[i - 1][j] else Double.NEGATIVE_INFINITY
     val skipB = if (j > 0) score[i][j - 1] else Double.NEGATIVE_INFINITY
+    val takeSkipA =
+      when {
+        j == 0 -> true
+        i == 0 -> false
+        skipA > skipB -> true
+        skipB > skipA -> false
+        // Equal scores: skip the canonically-smaller window (ties → skipA); side-independent.
+        else -> canonicalA[i - 1] <= canonicalB[j - 1]
+      }
     when {
       i > 0 && j > 0 && diagonal >= skipA && diagonal >= skipB -> {
         columnsA.add(i - 1)
@@ -208,7 +224,7 @@ private fun alignWindowSlots(
         i--
         j--
       }
-      i > 0 && skipA >= skipB -> {
+      takeSkipA -> {
         columnsA.add(i - 1)
         columnsB.add(-1)
         i--
@@ -242,6 +258,14 @@ private fun signatureKeys(window: UIElementInfo): Set<String> {
   addSubtree(map, window, parentKey = "", siblingIndex = 0)
   return map.keys
 }
+
+/**
+ * A canonical, order-independent string for a window's structural key set: its keys sorted and
+ * joined. Two windows compare equal here iff they have the same set of structural keys, so it is a
+ * side-independent total order for the transposition-invariant tie-break in [alignWindowSlots].
+ */
+private fun canonicalSignature(signature: Set<String>): String =
+  signature.sorted().joinToString(" ")
 
 /** Jaccard overlap |a ∩ b| / |a ∪ b| of two structural key sets; 0 when both are empty. */
 private fun jaccard(a: Set<String>, b: Set<String>): Double {

--- a/android/desktop-core/src/test/kotlin/dev/jasonpearson/automobile/desktop/core/layout/HierarchyDiffTest.kt
+++ b/android/desktop-core/src/test/kotlin/dev/jasonpearson/automobile/desktop/core/layout/HierarchyDiffTest.kt
@@ -376,6 +376,28 @@ class HierarchyDiffTest {
   }
 
   @Test
+  fun `structurally identical windows differing in content pair the semantic survivor`() {
+    // A holds two dialogs with identical structure but different text; B keeps only the first.
+    // Structural similarity alone is 1 for every pairing, so a diagonal-on-tie would pair B with
+    // A's *second* dialog and report Changed. Semantic-aware similarity must pair the true survivor
+    // (Equal) and surface the removed dialog (OnlyInA).
+    val dialog = { t: String ->
+      node("dialog.Window", "dialog", children = listOf(node("TextView", "msg", text = t)))
+    }
+    val a = multiWindowRoot(dialog("kept"), dialog("removed"))
+    val b = multiWindowRoot(dialog("kept"))
+
+    val diff = diffHierarchies(a, b)
+
+    // The surviving "kept" dialog pairs as Equal, not Changed against the "removed" one.
+    assertEquals(NodeDiffStatus.Equal, statusOf(diff, "TextView:msg"))
+    assertEquals(0, diff.changed)
+    // The removed dialog window and its text node surface as OnlyInA.
+    assertEquals(2, diff.onlyInA)
+    assertEquals(0, diff.onlyInB)
+  }
+
+  @Test
   fun `parallel multi-window stacks still pair positionally by highest similarity`() {
     // Two devices, same two-window stack, differing only in a text value on the first window: the
     // diagonal alignment wins, so windows pair by position and just the changed node is Changed.

--- a/android/desktop-core/src/test/kotlin/dev/jasonpearson/automobile/desktop/core/layout/HierarchyDiffTest.kt
+++ b/android/desktop-core/src/test/kotlin/dev/jasonpearson/automobile/desktop/core/layout/HierarchyDiffTest.kt
@@ -357,6 +357,25 @@ class HierarchyDiffTest {
   }
 
   @Test
+  fun `z-order-reversed windows classify symmetrically under A and B swap`() {
+    // Two windows that swap z-order: the similarity matrix is [[0,1],[1,0]] with two equally
+    // optimal order-preserving alignments. The tie-break must pick by window content, not by side,
+    // so diffHierarchies(a, b) and diffHierarchies(b, a) agree once A/B roles are swapped.
+    val a = multiWindowRoot(windowA(), windowC())
+    val b = multiWindowRoot(windowC(), windowA())
+    val ab = diffHierarchies(a, b)
+    val ba = diffHierarchies(b, a)
+
+    fun keys(diff: HierarchyDiff, status: NodeDiffStatus) =
+      diff.entries.filter { it.status == status }.map { it.key }.toSet()
+
+    assertEquals(keys(ab, NodeDiffStatus.OnlyInA), keys(ba, NodeDiffStatus.OnlyInB))
+    assertEquals(keys(ab, NodeDiffStatus.OnlyInB), keys(ba, NodeDiffStatus.OnlyInA))
+    assertEquals(keys(ab, NodeDiffStatus.Changed), keys(ba, NodeDiffStatus.Changed))
+    assertEquals(keys(ab, NodeDiffStatus.Equal), keys(ba, NodeDiffStatus.Equal))
+  }
+
+  @Test
   fun `parallel multi-window stacks still pair positionally by highest similarity`() {
     // Two devices, same two-window stack, differing only in a text value on the first window: the
     // diagonal alignment wins, so windows pair by position and just the changed node is Changed.

--- a/android/desktop-core/src/test/kotlin/dev/jasonpearson/automobile/desktop/core/layout/HierarchyDiffTest.kt
+++ b/android/desktop-core/src/test/kotlin/dev/jasonpearson/automobile/desktop/core/layout/HierarchyDiffTest.kt
@@ -274,4 +274,115 @@ class HierarchyDiffTest {
     assertEquals(2, diff.equal)
     assertNull(statusOf(diff, MULTI_WINDOW_ROOT_CLASS_NAME))
   }
+
+  // --- Multi-window pairing by subtree similarity (issue #5533) ----------------------------------
+  //
+  // The `text-input-empty.json` / `scroll-before.json` fixtures are a 3-window frame and the same
+  // frame with the *middle* window removed. Positional (by-index) pairing shifts the surviving
+  // third window into the second slot, so both survivors surface as removed+added. Order-preserving
+  // similarity matching must instead pair the two survivors and report only the removed window.
+
+  private fun windowA() =
+    node(
+      "app.Window",
+      "app",
+      children = listOf(node("android.widget.TextView", "title", text = "Home")),
+    )
+
+  private fun windowB() =
+    node(
+      "dialog.Window",
+      "dialog",
+      children = listOf(node("android.widget.Button", "ok", text = "OK")),
+    )
+
+  private fun windowC() =
+    node(
+      "ime.Window",
+      "ime",
+      children = listOf(node("android.widget.EditText", "field", text = "abc")),
+    )
+
+  @Test
+  fun `middle window removed pairs the surviving windows and surfaces only the removed one`() {
+    // A has three windows [app, dialog, ime]; B is the same frame with the middle (dialog) removed.
+    val a = multiWindowRoot(windowA(), windowB(), windowC())
+    val b = multiWindowRoot(windowA(), windowC())
+
+    val diff = diffHierarchies(a, b)
+
+    // The two survivors pair as Equal despite the index shift of the third window...
+    assertEquals(NodeDiffStatus.Equal, statusOf(diff, "app.Window:app"))
+    assertEquals(NodeDiffStatus.Equal, statusOf(diff, "EditText:field"))
+    assertEquals(NodeDiffStatus.Equal, statusOf(diff, "ime.Window:ime"))
+    // ...and only the genuinely-removed middle window (and its subtree) surfaces as OnlyInA.
+    assertEquals(NodeDiffStatus.OnlyInA, statusOf(diff, "dialog.Window:dialog"))
+    assertEquals(NodeDiffStatus.OnlyInA, statusOf(diff, "Button:ok"))
+    assertEquals(2, diff.onlyInA) // dialog window + its button
+    assertEquals(0, diff.onlyInB)
+    assertNull(statusOf(diff, MULTI_WINDOW_ROOT_CLASS_NAME))
+  }
+
+  @Test
+  fun `inserted middle window is the mirror of a removed one`() {
+    // Symmetric to the removal case: inserting a window before another must surface only the
+    // inserted window as OnlyInB, not both survivors.
+    val a = multiWindowRoot(windowA(), windowC())
+    val b = multiWindowRoot(windowA(), windowB(), windowC())
+
+    val diff = diffHierarchies(a, b)
+
+    assertEquals(NodeDiffStatus.Equal, statusOf(diff, "app.Window:app"))
+    assertEquals(NodeDiffStatus.Equal, statusOf(diff, "ime.Window:ime"))
+    assertEquals(NodeDiffStatus.OnlyInB, statusOf(diff, "dialog.Window:dialog"))
+    assertEquals(0, diff.onlyInA)
+    assertEquals(2, diff.onlyInB)
+  }
+
+  @Test
+  fun `multi-window removal classification is symmetric when A and B are swapped`() {
+    val a = multiWindowRoot(windowA(), windowB(), windowC())
+    val b = multiWindowRoot(windowA(), windowC())
+    val ab = diffHierarchies(a, b)
+    val ba = diffHierarchies(b, a)
+
+    fun keys(diff: HierarchyDiff, status: NodeDiffStatus) =
+      diff.entries.filter { it.status == status }.map { it.key }.toSet()
+
+    // The removed window's keys are identical strings in both directions (same window slot), just
+    // labeled OnlyInA one way and OnlyInB the other — the symmetry contract of diffHierarchies.
+    assertEquals(keys(ab, NodeDiffStatus.OnlyInA), keys(ba, NodeDiffStatus.OnlyInB))
+    assertEquals(keys(ab, NodeDiffStatus.OnlyInB), keys(ba, NodeDiffStatus.OnlyInA))
+    assertEquals(keys(ab, NodeDiffStatus.Equal), keys(ba, NodeDiffStatus.Equal))
+  }
+
+  @Test
+  fun `parallel multi-window stacks still pair positionally by highest similarity`() {
+    // Two devices, same two-window stack, differing only in a text value on the first window: the
+    // diagonal alignment wins, so windows pair by position and just the changed node is Changed.
+    val a =
+      multiWindowRoot(
+        node(
+          "app.Window",
+          "app",
+          children = listOf(node("android.widget.TextView", "title", text = "Home")),
+        ),
+        node("ime.Window", "ime"),
+      )
+    val b =
+      multiWindowRoot(
+        node(
+          "app.Window",
+          "app",
+          children = listOf(node("android.widget.TextView", "title", text = "Away")),
+        ),
+        node("ime.Window", "ime"),
+      )
+
+    val diff = diffHierarchies(a, b)
+
+    assertEquals(NodeDiffStatus.Changed, statusOf(diff, "TextView:title"))
+    assertEquals(0, diff.onlyInA)
+    assertEquals(0, diff.onlyInB)
+  }
 }


### PR DESCRIPTION
## Summary

Closes #5533.

`HierarchyDiff.diffHierarchies` paired the top-level windows of a multi-window frame **positionally** (by window index). When **both** compared frames are multi-window and a window is inserted or removed *before* another in z-order, the survivors shift index and their subtrees surface as `OnlyInA` + `OnlyInB` (removed + added) rather than being recognized as unchanged. The repo fixture shape `text-input-empty.json` (3 window roots) vs `scroll-before.json` (same frame, middle root removed) exhibits exactly this.

## Approach

This takes option 2 from the issue — **match windows before flattening**, at the diff layer only, with no change to ingest or the parser's element-id stability:

- Unwrap each frame to its top-level windows (`windowsOf`); a single-window frame is its own only window (so single-vs-multi still matches).
- Align the two window sequences with an **order-preserving Needleman–Wunsch** global alignment (`alignWindowSlots`), scoring a pairing by the **Jaccard overlap** of the two subtrees' structural path keys, gaps free, ties preferring the diagonal. Order preservation reflects z-order: an inserted/removed window shifts the survivors' indexes but not their relative order.
- Key each window's subtree at its assigned alignment **slot** rather than its raw index, so paired windows share a key namespace across the frames.

### Why this is safe

- **Subsumes the old positional pairing.** For equal-length frames the diagonal (window _i_ ↔ window _i_) alignment maximizes the score and wins on ties, so parallel window stacks and single-vs-single frames pair exactly as before. Only a strictly-better alignment — i.e. a real insert/remove — introduces a gap.
- **Preserves the A/B symmetry contract.** Alignment columns are numbered left-to-right; because the alignment is order-preserving (non-crossing), the slot assignment is a pure function of the alignment, so `diffHierarchies(a, b)` and `diffHierarchies(b, a)` give every window the same slot. A new symmetry test locks this in for the multi-window removal case.
- **Parser untouched.** Element-id stability (achieved in #5529) is preserved by construction.

## Tests

`:desktop-core:test --tests HierarchyDiffTest` — 18/18 pass (14 existing + 4 new):
- middle window removed pairs the survivors and surfaces only the removed window;
- the mirror insertion case;
- multi-window removal classification is symmetric under A/B swap;
- parallel multi-window stacks still pair positionally by highest similarity.

## Acceptance criteria

- [x] A two-multi-window compare where a middle window is removed/inserted pairs the surviving windows and reports only the genuinely-changed window (covered by tests using the `text-input-empty.json` / `scroll-before.json` shape).
- [x] The parser's element-id stability is preserved (unchanged).

## Validation

- `:desktop-core:test` (HierarchyDiffTest) green
- `:desktop-core:detektMain` / `:desktop-core:detektTest` clean
- ktfmt (touched files) clean