### PR TITLE
fix(desktop): bound status transport probes

### DIFF
--- a/android/desktop-core/src/main/kotlin/dev/jasonpearson/automobile/desktop/core/daemon/McpDaemonClient.kt
+++ b/android/desktop-core/src/main/kotlin/dev/jasonpearson/automobile/desktop/core/daemon/McpDaemonClient.kt
@@ -56,6 +56,7 @@ class McpDaemonClient(
    * timeout floors are honored.
    */
   private val inputRequestTimeoutMs: Long = INPUT_REQUEST_TIMEOUT_MS,
+  private val statusRequestTimeoutMs: Long = STATUS_REQUEST_TIMEOUT_MS,
 ) : AutoMobileClient {
   private var daemonLifecycle: DaemonLifecycleEnsurer? =
     if (socketPathValue == DaemonSocketPaths.socketPath()) DesktopDaemonLifecycle() else null
@@ -63,7 +64,8 @@ class McpDaemonClient(
   internal constructor(
     socketPathValue: String,
     daemonLifecycle: DaemonLifecycleEnsurer,
-  ) : this(socketPathValue = socketPathValue) {
+    statusRequestTimeoutMs: Long = STATUS_REQUEST_TIMEOUT_MS,
+  ) : this(socketPathValue = socketPathValue, statusRequestTimeoutMs = statusRequestTimeoutMs) {
     this.daemonLifecycle = daemonLifecycle
   }
 
@@ -302,7 +304,12 @@ class McpDaemonClient(
     // ide/status round-trip is ~ms, so a deadline here bounds the connectivity dot without risking
     // a
     // slow ordinary tool call (those stay unbounded; see [sendRequest]).
-    val response = sendRequest("ide/status", timeoutMs = STATUS_REQUEST_TIMEOUT_MS)
+    val response =
+      sendRequest(
+        "ide/status",
+        timeoutMs = statusRequestTimeoutMs,
+        skipLifecyclePreflight = true,
+      )
     ensureSuccess(response)
     return json.decodeFromJsonElement(
       serializer<dev.jasonpearson.automobile.desktop.core.mcp.DaemonStatusResponse>(),
@@ -933,8 +940,13 @@ class McpDaemonClient(
     method: String,
     params: JsonObject = JsonObject(emptyMap()),
     timeoutMs: Long? = null,
+    skipLifecyclePreflight: Boolean = false,
   ): DaemonResponse {
-    ensureVersionMatchedDaemon()
+    // Status is a passive health probe. Its purpose is to report a wedged daemon, so running the
+    // lifecycle preflight first can itself hang before the request watchdog is armed.
+    if (!skipLifecyclePreflight) {
+      ensureVersionMatchedDaemon()
+    }
     ensureSocketExists()
 
     val address = UnixDomainSocketAddress.of(socketPathValue)

--- a/android/desktop-core/src/main/kotlin/dev/jasonpearson/automobile/desktop/core/daemon/McpHttpClient.kt
+++ b/android/desktop-core/src/main/kotlin/dev/jasonpearson/automobile/desktop/core/daemon/McpHttpClient.kt
@@ -21,11 +21,19 @@ import kotlinx.serialization.json.jsonObject
 import kotlinx.serialization.json.put
 import kotlinx.serialization.serializer
 
+fun interface HttpRequestSender {
+  fun send(request: HttpRequest): HttpResponse<String>
+}
+
 class McpHttpClient(
   private val endpoint: String,
   private val json: Json = DaemonJson,
   private val retryPolicy: RetryPolicy = RetryPolicy(),
   private val statusRequestTimeoutMs: Long = McpDaemonClient.STATUS_REQUEST_TIMEOUT_MS,
+  private val statusDeadlineFactory: (Long) -> StatusRequestDeadline = {
+    StatusRequestDeadline(it)
+  },
+  private val requestSender: HttpRequestSender? = null,
 ) : AutoMobileClient {
   override val transportName: String = "MCP HTTP"
   override val connectionDescription: String = endpoint
@@ -246,11 +254,12 @@ class McpHttpClient(
 
   override fun getDaemonStatus():
     dev.jasonpearson.automobile.desktop.core.mcp.DaemonStatusResponse {
+    val deadline = statusDeadlineFactory(statusRequestTimeoutMs)
     val response =
       callToolWithTimeout(
         "getDaemonStatus",
         JsonObject(emptyMap()),
-        statusRequestTimeoutMs,
+        deadline,
       )
     return try {
       decodeToolResponse(
@@ -411,9 +420,9 @@ class McpHttpClient(
   private fun callToolWithTimeout(
     name: String,
     arguments: JsonObject,
-    timeoutMs: Long? = null,
+    deadline: StatusRequestDeadline? = null,
   ): JsonElement {
-    ensureInitialized(timeoutMs)
+    ensureInitialized(deadline)
     val response =
       sendRequest(
         "tools/call",
@@ -421,12 +430,12 @@ class McpHttpClient(
           put("name", JsonPrimitive(name))
           put("arguments", arguments)
         },
-        timeoutMs = timeoutMs,
+        timeoutMs = deadline?.remainingTimeoutMs(),
       )
     return response.result ?: JsonObject(emptyMap())
   }
 
-  private fun ensureInitialized(timeoutMs: Long? = null) {
+  private fun ensureInitialized(deadline: StatusRequestDeadline? = null) {
     if (initialized) {
       return
     }
@@ -436,7 +445,7 @@ class McpHttpClient(
         "initialize",
         buildInitializeParams(),
         includeSession = false,
-        timeoutMs = timeoutMs,
+        timeoutMs = deadline?.remainingTimeoutMs(),
       )
 
     val result =
@@ -445,13 +454,13 @@ class McpHttpClient(
     protocolVersion = negotiateProtocolVersion(result)
     initialized = true
 
-    sendNotification("notifications/initialized", timeoutMs = timeoutMs)
+    sendNotification("notifications/initialized", deadline = deadline)
   }
 
   private fun sendNotification(
     method: String,
     params: JsonElement? = null,
-    timeoutMs: Long? = null,
+    deadline: StatusRequestDeadline? = null,
   ) {
     val request =
       JsonRpcRequest(
@@ -459,7 +468,12 @@ class McpHttpClient(
         method = method,
         params = params,
       )
-    sendRequest(request, includeSession = true, expectResponse = false, timeoutMs = timeoutMs)
+    sendRequest(
+      request,
+      includeSession = true,
+      expectResponse = false,
+      timeoutMs = deadline?.remainingTimeoutMs(),
+    )
   }
 
   private fun sendRequest(
@@ -505,12 +519,12 @@ class McpHttpClient(
     val response =
       if (timeoutMs == null) {
         retryWithBackoffBlocking(retryPolicy, isRetryable = ::isRetryableError) {
-          httpClient.send(httpRequest, HttpResponse.BodyHandlers.ofString())
+          sendHttpRequest(httpRequest)
         }
       } else {
         // A health probe has one end-to-end hang ceiling. Retrying its individually timed requests
         // would turn a 5s deadline into an unbounded series of 5s waits.
-        httpClient.send(httpRequest, HttpResponse.BodyHandlers.ofString())
+        sendHttpRequest(httpRequest)
       }
 
     response.headers().firstValue("mcp-session-id").ifPresent { header ->
@@ -544,6 +558,9 @@ class McpHttpClient(
     }
     return rpcResponse
   }
+
+  private fun sendHttpRequest(request: HttpRequest): HttpResponse<String> =
+    requestSender?.send(request) ?: httpClient.send(request, HttpResponse.BodyHandlers.ofString())
 
   companion object {
     internal fun isRetryableError(e: Exception): Boolean =

--- a/android/desktop-core/src/main/kotlin/dev/jasonpearson/automobile/desktop/core/daemon/McpHttpClient.kt
+++ b/android/desktop-core/src/main/kotlin/dev/jasonpearson/automobile/desktop/core/daemon/McpHttpClient.kt
@@ -5,6 +5,7 @@ import java.net.URI
 import java.net.http.HttpClient
 import java.net.http.HttpRequest
 import java.net.http.HttpResponse
+import java.time.Duration
 import java.util.UUID
 import kotlin.coroutines.cancellation.CancellationException
 import kotlinx.serialization.decodeFromString
@@ -24,6 +25,7 @@ class McpHttpClient(
   private val endpoint: String,
   private val json: Json = DaemonJson,
   private val retryPolicy: RetryPolicy = RetryPolicy(),
+  private val statusRequestTimeoutMs: Long = McpDaemonClient.STATUS_REQUEST_TIMEOUT_MS,
 ) : AutoMobileClient {
   override val transportName: String = "MCP HTTP"
   override val connectionDescription: String = endpoint
@@ -244,11 +246,11 @@ class McpHttpClient(
 
   override fun getDaemonStatus():
     dev.jasonpearson.automobile.desktop.core.mcp.DaemonStatusResponse {
-    // For HTTP client, use the status tool
     val response =
-      callTool(
+      callToolWithTimeout(
         "getDaemonStatus",
         JsonObject(emptyMap()),
+        statusRequestTimeoutMs,
       )
     return try {
       decodeToolResponse(
@@ -403,7 +405,15 @@ class McpHttpClient(
   ): InputActionResult = unsupportedInputAction(transportName, "input/key")
 
   override fun callTool(name: String, arguments: JsonObject): JsonElement {
-    ensureInitialized()
+    return callToolWithTimeout(name, arguments)
+  }
+
+  private fun callToolWithTimeout(
+    name: String,
+    arguments: JsonObject,
+    timeoutMs: Long? = null,
+  ): JsonElement {
+    ensureInitialized(timeoutMs)
     val response =
       sendRequest(
         "tools/call",
@@ -411,16 +421,23 @@ class McpHttpClient(
           put("name", JsonPrimitive(name))
           put("arguments", arguments)
         },
+        timeoutMs = timeoutMs,
       )
     return response.result ?: JsonObject(emptyMap())
   }
 
-  private fun ensureInitialized() {
+  private fun ensureInitialized(timeoutMs: Long? = null) {
     if (initialized) {
       return
     }
 
-    val response = sendRequest("initialize", buildInitializeParams(), includeSession = false)
+    val response =
+      sendRequest(
+        "initialize",
+        buildInitializeParams(),
+        includeSession = false,
+        timeoutMs = timeoutMs,
+      )
 
     val result =
       response.result?.jsonObject
@@ -428,23 +445,28 @@ class McpHttpClient(
     protocolVersion = negotiateProtocolVersion(result)
     initialized = true
 
-    sendNotification("notifications/initialized")
+    sendNotification("notifications/initialized", timeoutMs = timeoutMs)
   }
 
-  private fun sendNotification(method: String, params: JsonElement? = null) {
+  private fun sendNotification(
+    method: String,
+    params: JsonElement? = null,
+    timeoutMs: Long? = null,
+  ) {
     val request =
       JsonRpcRequest(
         id = null,
         method = method,
         params = params,
       )
-    sendRequest(request, includeSession = true, expectResponse = false)
+    sendRequest(request, includeSession = true, expectResponse = false, timeoutMs = timeoutMs)
   }
 
   private fun sendRequest(
     method: String,
     params: JsonElement? = null,
     includeSession: Boolean = true,
+    timeoutMs: Long? = null,
   ): JsonRpcResponse {
     val requestId = JsonPrimitive(UUID.randomUUID().toString())
     val request =
@@ -453,13 +475,19 @@ class McpHttpClient(
         method = method,
         params = params,
       )
-    return sendRequest(request, includeSession = includeSession, expectResponse = true)
+    return sendRequest(
+      request,
+      includeSession = includeSession,
+      expectResponse = true,
+      timeoutMs = timeoutMs,
+    )
   }
 
   private fun sendRequest(
     request: JsonRpcRequest,
     includeSession: Boolean,
     expectResponse: Boolean,
+    timeoutMs: Long? = null,
   ): JsonRpcResponse {
     val requestBody = json.encodeToString(serializer<JsonRpcRequest>(), request)
     val builder =
@@ -471,42 +499,50 @@ class McpHttpClient(
     if (protocolVersion != null) {
       builder.header("mcp-protocol-version", protocolVersion!!)
     }
+    timeoutMs?.let { builder.timeout(Duration.ofMillis(it)) }
 
     val httpRequest = builder.POST(HttpRequest.BodyPublishers.ofString(requestBody)).build()
-    return retryWithBackoffBlocking(retryPolicy, isRetryable = ::isRetryableError) {
-      val response = httpClient.send(httpRequest, HttpResponse.BodyHandlers.ofString())
-
-      response.headers().firstValue("mcp-session-id").ifPresent { header ->
-        if (header.isNotBlank()) {
-          sessionId = header
+    val response =
+      if (timeoutMs == null) {
+        retryWithBackoffBlocking(retryPolicy, isRetryable = ::isRetryableError) {
+          httpClient.send(httpRequest, HttpResponse.BodyHandlers.ofString())
         }
+      } else {
+        // A health probe has one end-to-end hang ceiling. Retrying its individually timed requests
+        // would turn a 5s deadline into an unbounded series of 5s waits.
+        httpClient.send(httpRequest, HttpResponse.BodyHandlers.ofString())
       }
 
-      val statusCode = response.statusCode()
-      if (statusCode >= 500) {
-        throw McpConnectionException("MCP HTTP server error $statusCode")
+    response.headers().firstValue("mcp-session-id").ifPresent { header ->
+      if (header.isNotBlank()) {
+        sessionId = header
       }
-
-      if (!expectResponse) {
-        return@retryWithBackoffBlocking JsonRpcResponse(jsonrpc = "2.0")
-      }
-
-      val body = response.body().trim()
-      if (body.isEmpty()) {
-        throw McpConnectionException("MCP HTTP response was empty")
-      }
-
-      val rpcResponse = json.decodeFromString(serializer<JsonRpcResponse>(), body)
-      if (rpcResponse.error != null) {
-        throw McpConnectionException(
-          "MCP HTTP error ${rpcResponse.error.code}: ${rpcResponse.error.message}"
-        )
-      }
-      if (rpcResponse.result == null) {
-        throw McpConnectionException("MCP HTTP response missing result")
-      }
-      rpcResponse
     }
+
+    val statusCode = response.statusCode()
+    if (statusCode >= 500) {
+      throw McpConnectionException("MCP HTTP server error $statusCode")
+    }
+
+    if (!expectResponse) {
+      return JsonRpcResponse(jsonrpc = "2.0")
+    }
+
+    val body = response.body().trim()
+    if (body.isEmpty()) {
+      throw McpConnectionException("MCP HTTP response was empty")
+    }
+
+    val rpcResponse = json.decodeFromString(serializer<JsonRpcResponse>(), body)
+    if (rpcResponse.error != null) {
+      throw McpConnectionException(
+        "MCP HTTP error ${rpcResponse.error.code}: ${rpcResponse.error.message}"
+      )
+    }
+    if (rpcResponse.result == null) {
+      throw McpConnectionException("MCP HTTP response missing result")
+    }
+    return rpcResponse
   }
 
   companion object {

--- a/android/desktop-core/src/main/kotlin/dev/jasonpearson/automobile/desktop/core/daemon/McpStdioClient.kt
+++ b/android/desktop-core/src/main/kotlin/dev/jasonpearson/automobile/desktop/core/daemon/McpStdioClient.kt
@@ -21,6 +21,7 @@ import kotlinx.serialization.serializer
 class McpStdioClient(
   private val command: String,
   private val json: Json = DaemonJson,
+  private val statusRequestTimeoutMs: Long = McpDaemonClient.STATUS_REQUEST_TIMEOUT_MS,
 ) : AutoMobileClient {
   override val transportName: String = "MCP STDIO"
   override val connectionDescription: String = command
@@ -239,9 +240,10 @@ class McpStdioClient(
   override fun getDaemonStatus():
     dev.jasonpearson.automobile.desktop.core.mcp.DaemonStatusResponse {
     val response =
-      callTool(
+      callToolWithTimeout(
         "getDaemonStatus",
         JsonObject(emptyMap()),
+        statusRequestTimeoutMs,
       )
     return try {
       decodeToolResponse(
@@ -394,7 +396,15 @@ class McpStdioClient(
   ): InputActionResult = unsupportedInputAction(transportName, "input/key")
 
   override fun callTool(name: String, arguments: JsonObject): JsonElement {
-    ensureInitialized()
+    return callToolWithTimeout(name, arguments)
+  }
+
+  private fun callToolWithTimeout(
+    name: String,
+    arguments: JsonObject,
+    timeoutMs: Long? = null,
+  ): JsonElement {
+    ensureInitialized(timeoutMs)
     val response =
       sendRequest(
         "tools/call",
@@ -402,6 +412,7 @@ class McpStdioClient(
           put("name", JsonPrimitive(name))
           put("arguments", arguments)
         },
+        timeoutMs = timeoutMs,
       )
     return response.result ?: JsonObject(emptyMap())
   }
@@ -418,7 +429,7 @@ class McpStdioClient(
     }
   }
 
-  private fun ensureInitialized() {
+  private fun ensureInitialized(timeoutMs: Long? = null) {
     synchronized(ioLock) {
       if (initialized) {
         return
@@ -426,7 +437,7 @@ class McpStdioClient(
       ensureProcessStarted()
     }
 
-    val response = sendRequest("initialize", buildInitializeParams())
+    val response = sendRequest("initialize", buildInitializeParams(), timeoutMs = timeoutMs)
     val result =
       response.result?.jsonObject
         ?: throw McpConnectionException("Initialize response missing result")
@@ -434,20 +445,28 @@ class McpStdioClient(
     synchronized(ioLock) {
       initialized = true
     }
-    sendNotification("notifications/initialized")
+    sendNotification("notifications/initialized", timeoutMs = timeoutMs)
   }
 
-  private fun sendNotification(method: String, params: JsonElement? = null) {
+  private fun sendNotification(
+    method: String,
+    params: JsonElement? = null,
+    timeoutMs: Long? = null,
+  ) {
     val request =
       JsonRpcRequest(
         id = null,
         method = method,
         params = params,
       )
-    sendRequest(request, expectResponse = false)
+    sendRequest(request, expectResponse = false, timeoutMs = timeoutMs)
   }
 
-  private fun sendRequest(method: String, params: JsonElement? = null): JsonRpcResponse {
+  private fun sendRequest(
+    method: String,
+    params: JsonElement? = null,
+    timeoutMs: Long? = null,
+  ): JsonRpcResponse {
     val requestId = JsonPrimitive(UUID.randomUUID().toString())
     val request =
       JsonRpcRequest(
@@ -455,12 +474,17 @@ class McpStdioClient(
         method = method,
         params = params,
       )
-    return sendRequest(request, expectResponse = true)
+    return sendRequest(request, expectResponse = true, timeoutMs = timeoutMs)
   }
 
-  private fun sendRequest(request: JsonRpcRequest, expectResponse: Boolean): JsonRpcResponse {
+  private fun sendRequest(
+    request: JsonRpcRequest,
+    expectResponse: Boolean,
+    timeoutMs: Long? = null,
+  ): JsonRpcResponse {
     synchronized(ioLock) {
       ensureProcessStarted()
+      val currentProcess = process ?: throw McpConnectionException("MCP stdio process unavailable")
       val currentWriter = writer ?: throw McpConnectionException("MCP stdio writer unavailable")
       val currentReader = reader ?: throw McpConnectionException("MCP stdio reader unavailable")
 
@@ -473,28 +497,55 @@ class McpStdioClient(
         return JsonRpcResponse(jsonrpc = "2.0")
       }
 
-      val expectedId = request.id?.jsonPrimitive?.content
-      while (true) {
-        val line = currentReader.readLine() ?: throw McpConnectionException("MCP stdio closed")
-        if (line.isBlank()) {
-          continue
+      try {
+        val expectedId = request.id?.jsonPrimitive?.content
+        val read = java.util.concurrent.Callable { readResponse(currentReader, expectedId) }
+        return if (timeoutMs == null) {
+          read.call()
+        } else {
+          requestReader.submit(read).get(timeoutMs, java.util.concurrent.TimeUnit.MILLISECONDS)
         }
-        val response = json.decodeFromString(serializer<JsonRpcResponse>(), line)
-        val responseId = response.id?.jsonPrimitive?.content
-        if (expectedId != null && responseId != expectedId) {
-          continue
+      } catch (_: java.util.concurrent.TimeoutException) {
+        // BufferedReader.readLine() cannot be reliably interrupted. Its worker stays isolated on
+        // the old stream while this caller releases ioLock; later requests start a fresh process.
+        if (process === currentProcess) {
+          process = null
+          reader = null
+          writer = null
+          initialized = false
         }
-        if (response.error != null) {
-          throw McpConnectionException(
-            "MCP stdio error ${response.error.code}: ${response.error.message}"
-          )
-        }
-        if (response.result == null) {
-          throw McpConnectionException("MCP stdio response missing result")
-        }
-        return response
+        terminateProcessTree(currentProcess)
+        throw McpConnectionException(
+          "MCP stdio request '${request.method}' timed out after ${timeoutMs}ms"
+        )
+      } catch (e: java.util.concurrent.ExecutionException) {
+        throw (e.cause as? Exception ?: e)
       }
     }
+  }
+
+  private fun readResponse(currentReader: BufferedReader, expectedId: String?): JsonRpcResponse {
+    while (true) {
+      val line = currentReader.readLine() ?: throw McpConnectionException("MCP stdio closed")
+      if (line.isBlank()) continue
+      val response = json.decodeFromString(serializer<JsonRpcResponse>(), line)
+      val responseId = response.id?.jsonPrimitive?.content
+      if (expectedId != null && responseId != expectedId) continue
+      if (response.error != null) {
+        throw McpConnectionException(
+          "MCP stdio error ${response.error.code}: ${response.error.message}"
+        )
+      }
+      if (response.result == null) throw McpConnectionException("MCP stdio response missing result")
+      return response
+    }
+  }
+
+  private fun terminateProcessTree(currentProcess: Process) {
+    currentProcess.toHandle().descendants().use { descendants ->
+      descendants.forEach { descendant -> descendant.destroyForcibly() }
+    }
+    currentProcess.destroyForcibly()
   }
 
   private fun ensureProcessStarted() {
@@ -572,5 +623,12 @@ class McpStdioClient(
 
     flushCurrent()
     return parts
+  }
+
+  private companion object {
+    private val requestReader =
+      java.util.concurrent.Executors.newCachedThreadPool { runnable ->
+        Thread(runnable, "mcp-stdio-response-reader").apply { isDaemon = true }
+      }
   }
 }

--- a/android/desktop-core/src/main/kotlin/dev/jasonpearson/automobile/desktop/core/daemon/McpStdioClient.kt
+++ b/android/desktop-core/src/main/kotlin/dev/jasonpearson/automobile/desktop/core/daemon/McpStdioClient.kt
@@ -5,6 +5,8 @@ import java.io.BufferedWriter
 import java.io.InputStreamReader
 import java.io.OutputStreamWriter
 import java.util.UUID
+import java.util.concurrent.Callable
+import java.util.concurrent.TimeUnit
 import kotlinx.serialization.decodeFromString
 import kotlinx.serialization.encodeToString
 import kotlinx.serialization.json.Json
@@ -24,6 +26,16 @@ class McpStdioClient(
   private val statusRequestTimeoutMs: Long = McpDaemonClient.STATUS_REQUEST_TIMEOUT_MS,
   private val statusDeadlineFactory: (Long) -> StatusRequestDeadline = {
     StatusRequestDeadline(it)
+  },
+  private val processStarter: (List<String>) -> Process = { commandParts ->
+    ProcessBuilder(commandParts).redirectError(ProcessBuilder.Redirect.INHERIT).start()
+  },
+  private val responseReader: StdioResponseReader = StdioResponseReader { read, timeoutMs ->
+    if (timeoutMs == null) {
+      read.call()
+    } else {
+      requestReader.submit(read).get(timeoutMs, TimeUnit.MILLISECONDS)
+    }
   },
 ) : AutoMobileClient {
   override val transportName: String = "MCP STDIO"
@@ -416,7 +428,7 @@ class McpStdioClient(
           put("name", JsonPrimitive(name))
           put("arguments", arguments)
         },
-        timeoutMs = deadline?.remainingTimeoutMs(),
+        deadline = deadline,
       )
     return response.result ?: JsonObject(emptyMap())
   }
@@ -435,6 +447,7 @@ class McpStdioClient(
 
   private fun ensureInitialized(deadline: StatusRequestDeadline? = null) {
     synchronized(ioLock) {
+      deadline?.remainingTimeoutMs()
       if (initialized) {
         return
       }
@@ -445,7 +458,7 @@ class McpStdioClient(
       sendRequest(
         "initialize",
         buildInitializeParams(),
-        timeoutMs = deadline?.remainingTimeoutMs(),
+        deadline = deadline,
       )
     val result =
       response.result?.jsonObject
@@ -468,13 +481,13 @@ class McpStdioClient(
         method = method,
         params = params,
       )
-    sendRequest(request, expectResponse = false, timeoutMs = deadline?.remainingTimeoutMs())
+    sendRequest(request, expectResponse = false, deadline = deadline)
   }
 
   private fun sendRequest(
     method: String,
     params: JsonElement? = null,
-    timeoutMs: Long? = null,
+    deadline: StatusRequestDeadline? = null,
   ): JsonRpcResponse {
     val requestId = JsonPrimitive(UUID.randomUUID().toString())
     val request =
@@ -483,15 +496,16 @@ class McpStdioClient(
         method = method,
         params = params,
       )
-    return sendRequest(request, expectResponse = true, timeoutMs = timeoutMs)
+    return sendRequest(request, expectResponse = true, deadline = deadline)
   }
 
   private fun sendRequest(
     request: JsonRpcRequest,
     expectResponse: Boolean,
-    timeoutMs: Long? = null,
+    deadline: StatusRequestDeadline? = null,
   ): JsonRpcResponse {
     synchronized(ioLock) {
+      val timeoutMs = deadline?.remainingTimeoutMs()
       ensureProcessStarted()
       val currentProcess = process ?: throw McpConnectionException("MCP stdio process unavailable")
       val currentWriter = writer ?: throw McpConnectionException("MCP stdio writer unavailable")
@@ -508,12 +522,8 @@ class McpStdioClient(
 
       try {
         val expectedId = request.id?.jsonPrimitive?.content
-        val read = java.util.concurrent.Callable { readResponse(currentReader, expectedId) }
-        return if (timeoutMs == null) {
-          read.call()
-        } else {
-          requestReader.submit(read).get(timeoutMs, java.util.concurrent.TimeUnit.MILLISECONDS)
-        }
+        val read = Callable { readResponse(currentReader, expectedId) }
+        return responseReader.read(read, timeoutMs)
       } catch (_: java.util.concurrent.TimeoutException) {
         // BufferedReader.readLine() cannot be reliably interrupted. Its worker stays isolated on
         // the old stream while this caller releases ioLock; later requests start a fresh process.
@@ -551,8 +561,12 @@ class McpStdioClient(
   }
 
   private fun terminateProcessTree(currentProcess: Process) {
-    currentProcess.toHandle().descendants().use { descendants ->
-      descendants.forEach { descendant -> descendant.destroyForcibly() }
+    try {
+      currentProcess.toHandle().descendants().use { descendants ->
+        descendants.forEach { descendant -> descendant.destroyForcibly() }
+      }
+    } catch (_: UnsupportedOperationException) {
+      // Test doubles and constrained runtimes may not expose process handles.
     }
     currentProcess.destroyForcibly()
   }
@@ -567,8 +581,7 @@ class McpStdioClient(
       throw McpConnectionException("MCP stdio command is empty")
     }
 
-    val newProcess =
-      ProcessBuilder(commandParts).redirectError(ProcessBuilder.Redirect.INHERIT).start()
+    val newProcess = processStarter(commandParts)
     process = newProcess
     reader = BufferedReader(InputStreamReader(newProcess.inputStream))
     writer = BufferedWriter(OutputStreamWriter(newProcess.outputStream))
@@ -640,4 +653,8 @@ class McpStdioClient(
         Thread(runnable, "mcp-stdio-response-reader").apply { isDaemon = true }
       }
   }
+}
+
+fun interface StdioResponseReader {
+  fun read(read: Callable<JsonRpcResponse>, timeoutMs: Long?): JsonRpcResponse
 }

--- a/android/desktop-core/src/main/kotlin/dev/jasonpearson/automobile/desktop/core/daemon/McpStdioClient.kt
+++ b/android/desktop-core/src/main/kotlin/dev/jasonpearson/automobile/desktop/core/daemon/McpStdioClient.kt
@@ -22,6 +22,9 @@ class McpStdioClient(
   private val command: String,
   private val json: Json = DaemonJson,
   private val statusRequestTimeoutMs: Long = McpDaemonClient.STATUS_REQUEST_TIMEOUT_MS,
+  private val statusDeadlineFactory: (Long) -> StatusRequestDeadline = {
+    StatusRequestDeadline(it)
+  },
 ) : AutoMobileClient {
   override val transportName: String = "MCP STDIO"
   override val connectionDescription: String = command
@@ -239,11 +242,12 @@ class McpStdioClient(
 
   override fun getDaemonStatus():
     dev.jasonpearson.automobile.desktop.core.mcp.DaemonStatusResponse {
+    val deadline = statusDeadlineFactory(statusRequestTimeoutMs)
     val response =
       callToolWithTimeout(
         "getDaemonStatus",
         JsonObject(emptyMap()),
-        statusRequestTimeoutMs,
+        deadline,
       )
     return try {
       decodeToolResponse(
@@ -402,9 +406,9 @@ class McpStdioClient(
   private fun callToolWithTimeout(
     name: String,
     arguments: JsonObject,
-    timeoutMs: Long? = null,
+    deadline: StatusRequestDeadline? = null,
   ): JsonElement {
-    ensureInitialized(timeoutMs)
+    ensureInitialized(deadline)
     val response =
       sendRequest(
         "tools/call",
@@ -412,7 +416,7 @@ class McpStdioClient(
           put("name", JsonPrimitive(name))
           put("arguments", arguments)
         },
-        timeoutMs = timeoutMs,
+        timeoutMs = deadline?.remainingTimeoutMs(),
       )
     return response.result ?: JsonObject(emptyMap())
   }
@@ -429,7 +433,7 @@ class McpStdioClient(
     }
   }
 
-  private fun ensureInitialized(timeoutMs: Long? = null) {
+  private fun ensureInitialized(deadline: StatusRequestDeadline? = null) {
     synchronized(ioLock) {
       if (initialized) {
         return
@@ -437,7 +441,12 @@ class McpStdioClient(
       ensureProcessStarted()
     }
 
-    val response = sendRequest("initialize", buildInitializeParams(), timeoutMs = timeoutMs)
+    val response =
+      sendRequest(
+        "initialize",
+        buildInitializeParams(),
+        timeoutMs = deadline?.remainingTimeoutMs(),
+      )
     val result =
       response.result?.jsonObject
         ?: throw McpConnectionException("Initialize response missing result")
@@ -445,13 +454,13 @@ class McpStdioClient(
     synchronized(ioLock) {
       initialized = true
     }
-    sendNotification("notifications/initialized", timeoutMs = timeoutMs)
+    sendNotification("notifications/initialized", deadline = deadline)
   }
 
   private fun sendNotification(
     method: String,
     params: JsonElement? = null,
-    timeoutMs: Long? = null,
+    deadline: StatusRequestDeadline? = null,
   ) {
     val request =
       JsonRpcRequest(
@@ -459,7 +468,7 @@ class McpStdioClient(
         method = method,
         params = params,
       )
-    sendRequest(request, expectResponse = false, timeoutMs = timeoutMs)
+    sendRequest(request, expectResponse = false, timeoutMs = deadline?.remainingTimeoutMs())
   }
 
   private fun sendRequest(

--- a/android/desktop-core/src/main/kotlin/dev/jasonpearson/automobile/desktop/core/daemon/StatusRequestDeadline.kt
+++ b/android/desktop-core/src/main/kotlin/dev/jasonpearson/automobile/desktop/core/daemon/StatusRequestDeadline.kt
@@ -1,0 +1,19 @@
+package dev.jasonpearson.automobile.desktop.core.daemon
+
+import java.util.concurrent.TimeUnit
+
+/** One end-to-end hang budget for a passive daemon status probe. */
+class StatusRequestDeadline(
+  private val timeoutMs: Long,
+  private val nowNanos: () -> Long = System::nanoTime,
+) {
+  private val deadlineNanos = nowNanos() + TimeUnit.MILLISECONDS.toNanos(timeoutMs)
+
+  fun remainingTimeoutMs(): Long {
+    val remainingNanos = deadlineNanos - nowNanos()
+    if (remainingNanos <= 0) {
+      throw McpConnectionException("MCP status request timed out after ${timeoutMs}ms")
+    }
+    return TimeUnit.NANOSECONDS.toMillis(remainingNanos).coerceAtLeast(1)
+  }
+}

--- a/android/desktop-core/src/test/kotlin/dev/jasonpearson/automobile/desktop/core/daemon/McpDaemonClientInputTest.kt
+++ b/android/desktop-core/src/test/kotlin/dev/jasonpearson/automobile/desktop/core/daemon/McpDaemonClientInputTest.kt
@@ -190,6 +190,31 @@ class McpDaemonClientInputTest {
   }
 
   @Test
+  fun `status probe bypasses lifecycle preflight but ordinary requests retain it`() {
+    var lifecycleCalls = 0
+    val lifecycle =
+      object : DaemonLifecycleEnsurer {
+        override fun ensureVersionMatchedDaemon(): DaemonLifecycleResult {
+          lifecycleCalls++
+          return DaemonLifecycleResult.Failure("daemon version mismatch")
+        }
+      }
+
+    TestDaemonSocket(resultJson = "{}").use { server ->
+      val client =
+        McpDaemonClient(
+          socketPathValue = server.socketPath.toString(),
+          daemonLifecycle = lifecycle,
+        )
+
+      client.getDaemonStatus()
+      assertEquals(0, lifecycleCalls)
+      assertFailsWith<DaemonUnavailableException> { client.ping() }
+      assertEquals(1, lifecycleCalls)
+    }
+  }
+
+  @Test
   fun `inputTap serializes to input tap socket request`() {
     val responseResult =
       """

--- a/android/desktop-core/src/test/kotlin/dev/jasonpearson/automobile/desktop/core/daemon/McpStatusTimeoutTest.kt
+++ b/android/desktop-core/src/test/kotlin/dev/jasonpearson/automobile/desktop/core/daemon/McpStatusTimeoutTest.kt
@@ -1,5 +1,9 @@
 package dev.jasonpearson.automobile.desktop.core.daemon
 
+import java.io.ByteArrayInputStream
+import java.io.ByteArrayOutputStream
+import java.io.InputStream
+import java.io.OutputStream
 import java.net.URI
 import java.net.http.HttpClient
 import java.net.http.HttpHeaders
@@ -9,7 +13,6 @@ import java.net.http.HttpTimeoutException
 import java.time.Duration
 import java.util.Optional
 import javax.net.ssl.SSLSession
-import kotlin.system.measureTimeMillis
 import kotlin.test.assertEquals
 import kotlin.test.assertFailsWith
 import kotlin.test.assertTrue
@@ -53,20 +56,54 @@ class McpStatusTimeoutTest {
 
   @Test
   fun `STDIO status probe releases the shared client for a later retry`() {
-    val client = McpStdioClient("/bin/sh -c 'sleep 30'", statusRequestTimeoutMs = 25)
+    var starts = 0
+    val client =
+      McpStdioClient(
+        command = "unused",
+        processStarter = {
+          starts += 1
+          FakeProcess()
+        },
+        responseReader =
+          StdioResponseReader { _, _ -> throw java.util.concurrent.TimeoutException() },
+      )
     try {
       fun assertStatusTimeout() {
         val error = assertFailsWith<McpConnectionException> { client.getDaemonStatus() }
-        assertTrue(error.message.orEmpty().contains("timed out"))
+        assertTrue(error.message.orEmpty().contains("initialize' timed out"))
       }
 
-      val firstElapsedMs = measureTimeMillis(::assertStatusTimeout)
-      val retryElapsedMs = measureTimeMillis(::assertStatusTimeout)
-
-      assertTrue(firstElapsedMs < 250, "first status probe took ${firstElapsedMs}ms")
-      assertTrue(retryElapsedMs < 250, "retry status probe took ${retryElapsedMs}ms")
+      assertStatusTimeout()
+      assertStatusTimeout()
+      assertEquals(2, starts)
     } finally {
       client.close()
+    }
+  }
+
+  private class FakeProcess : Process() {
+    private val output = ByteArrayOutputStream()
+    private var alive = true
+
+    override fun getOutputStream(): OutputStream = output
+
+    override fun getInputStream(): InputStream = ByteArrayInputStream(ByteArray(0))
+
+    override fun getErrorStream(): InputStream = ByteArrayInputStream(ByteArray(0))
+
+    override fun waitFor(): Int = 0
+
+    override fun exitValue(): Int = 0
+
+    override fun destroy() {
+      alive = false
+    }
+
+    override fun isAlive(): Boolean = alive
+
+    override fun destroyForcibly(): Process {
+      alive = false
+      return this
     }
   }
 

--- a/android/desktop-core/src/test/kotlin/dev/jasonpearson/automobile/desktop/core/daemon/McpStatusTimeoutTest.kt
+++ b/android/desktop-core/src/test/kotlin/dev/jasonpearson/automobile/desktop/core/daemon/McpStatusTimeoutTest.kt
@@ -1,9 +1,16 @@
 package dev.jasonpearson.automobile.desktop.core.daemon
 
-import com.sun.net.httpserver.HttpServer
-import java.net.InetSocketAddress
+import java.net.URI
+import java.net.http.HttpClient
+import java.net.http.HttpHeaders
+import java.net.http.HttpRequest
+import java.net.http.HttpResponse
 import java.net.http.HttpTimeoutException
+import java.time.Duration
+import java.util.Optional
+import javax.net.ssl.SSLSession
 import kotlin.system.measureTimeMillis
+import kotlin.test.assertEquals
 import kotlin.test.assertFailsWith
 import kotlin.test.assertTrue
 import org.junit.Test
@@ -11,39 +18,42 @@ import org.junit.Test
 class McpStatusTimeoutTest {
 
   @Test
-  fun `HTTP status probe times out without retrying`() {
-    val server =
-      HttpServer.create(InetSocketAddress(0), 0).apply {
-        createContext("/") { exchange ->
-          try {
-            Thread.sleep(1_000)
-          } finally {
-            exchange.close()
-          }
-        }
-        start()
-      }
-    try {
-      val client =
-        McpHttpClient(
-          endpoint = "http://localhost:${server.address.port}/mcp",
-          retryPolicy = RetryPolicy(maxRetries = 3, initialDelayMs = 1),
-          statusRequestTimeoutMs = 50,
-        )
+  fun `HTTP status probe shares one deadline across initialization and tools call`() {
+    var nowNanos = 0L
+    var requests = 0
+    val client =
+      McpHttpClient(
+        endpoint = "http://localhost/mcp",
+        retryPolicy = RetryPolicy(maxRetries = 3, initialDelayMs = 1),
+        statusRequestTimeoutMs = 120,
+        statusDeadlineFactory = { timeoutMs -> StatusRequestDeadline(timeoutMs) { nowNanos } },
+        requestSender =
+          HttpRequestSender { request ->
+            when (requests++) {
+              0 -> {
+                assertEquals(Duration.ofMillis(120), request.timeout().orElseThrow())
+                nowNanos += Duration.ofMillis(80).toNanos()
+                FakeHttpResponse(request, initializeResponse)
+              }
+              1 -> {
+                assertEquals(Duration.ofMillis(40), request.timeout().orElseThrow())
+                FakeHttpResponse(request, "{}")
+              }
+              else -> {
+                assertEquals(Duration.ofMillis(40), request.timeout().orElseThrow())
+                throw HttpTimeoutException("status request timed out")
+              }
+            }
+          },
+      )
 
-      val elapsedMs = measureTimeMillis {
-        assertFailsWith<HttpTimeoutException> { client.getDaemonStatus() }
-      }
-
-      assertTrue(elapsedMs < 500, "status probe took ${elapsedMs}ms")
-    } finally {
-      server.stop(0)
-    }
+    assertFailsWith<HttpTimeoutException> { client.getDaemonStatus() }
+    assertEquals(3, requests)
   }
 
   @Test
   fun `STDIO status probe releases the shared client for a later retry`() {
-    val client = McpStdioClient("/bin/sh -c 'sleep 30'", statusRequestTimeoutMs = 50)
+    val client = McpStdioClient("/bin/sh -c 'sleep 30'", statusRequestTimeoutMs = 25)
     try {
       fun assertStatusTimeout() {
         val error = assertFailsWith<McpConnectionException> { client.getDaemonStatus() }
@@ -53,10 +63,36 @@ class McpStatusTimeoutTest {
       val firstElapsedMs = measureTimeMillis(::assertStatusTimeout)
       val retryElapsedMs = measureTimeMillis(::assertStatusTimeout)
 
-      assertTrue(firstElapsedMs < 500, "first status probe took ${firstElapsedMs}ms")
-      assertTrue(retryElapsedMs < 500, "retry status probe took ${retryElapsedMs}ms")
+      assertTrue(firstElapsedMs < 250, "first status probe took ${firstElapsedMs}ms")
+      assertTrue(retryElapsedMs < 250, "retry status probe took ${retryElapsedMs}ms")
     } finally {
       client.close()
     }
+  }
+
+  private class FakeHttpResponse(
+    private val requestValue: HttpRequest,
+    private val responseBody: String,
+  ) : HttpResponse<String> {
+    override fun statusCode(): Int = 200
+
+    override fun request(): HttpRequest = requestValue
+
+    override fun previousResponse(): Optional<HttpResponse<String>> = Optional.empty()
+
+    override fun headers(): HttpHeaders = HttpHeaders.of(emptyMap()) { _, _ -> true }
+
+    override fun body(): String = responseBody
+
+    override fun sslSession(): Optional<SSLSession> = Optional.empty()
+
+    override fun uri(): URI = requestValue.uri()
+
+    override fun version(): HttpClient.Version = HttpClient.Version.HTTP_1_1
+  }
+
+  private companion object {
+    const val initializeResponse =
+      """{"jsonrpc":"2.0","id":"initialize","result":{"protocolVersion":"2025-11-25","capabilities":{},"serverInfo":{"name":"test","version":"1"}}}"""
   }
 }

--- a/android/desktop-core/src/test/kotlin/dev/jasonpearson/automobile/desktop/core/daemon/McpStatusTimeoutTest.kt
+++ b/android/desktop-core/src/test/kotlin/dev/jasonpearson/automobile/desktop/core/daemon/McpStatusTimeoutTest.kt
@@ -42,15 +42,19 @@ class McpStatusTimeoutTest {
   }
 
   @Test
-  fun `STDIO status probe closes only the timed-out process`() {
+  fun `STDIO status probe releases the shared client for a later retry`() {
     val client = McpStdioClient("/bin/sh -c 'sleep 30'", statusRequestTimeoutMs = 50)
     try {
-      val elapsedMs = measureTimeMillis {
+      fun assertStatusTimeout() {
         val error = assertFailsWith<McpConnectionException> { client.getDaemonStatus() }
         assertTrue(error.message.orEmpty().contains("timed out"))
       }
 
-      assertTrue(elapsedMs < 500, "status probe took ${elapsedMs}ms")
+      val firstElapsedMs = measureTimeMillis(::assertStatusTimeout)
+      val retryElapsedMs = measureTimeMillis(::assertStatusTimeout)
+
+      assertTrue(firstElapsedMs < 500, "first status probe took ${firstElapsedMs}ms")
+      assertTrue(retryElapsedMs < 500, "retry status probe took ${retryElapsedMs}ms")
     } finally {
       client.close()
     }

--- a/android/desktop-core/src/test/kotlin/dev/jasonpearson/automobile/desktop/core/daemon/McpStatusTimeoutTest.kt
+++ b/android/desktop-core/src/test/kotlin/dev/jasonpearson/automobile/desktop/core/daemon/McpStatusTimeoutTest.kt
@@ -1,0 +1,58 @@
+package dev.jasonpearson.automobile.desktop.core.daemon
+
+import com.sun.net.httpserver.HttpServer
+import java.net.InetSocketAddress
+import java.net.http.HttpTimeoutException
+import kotlin.system.measureTimeMillis
+import kotlin.test.assertFailsWith
+import kotlin.test.assertTrue
+import org.junit.Test
+
+class McpStatusTimeoutTest {
+
+  @Test
+  fun `HTTP status probe times out without retrying`() {
+    val server =
+      HttpServer.create(InetSocketAddress(0), 0).apply {
+        createContext("/") { exchange ->
+          try {
+            Thread.sleep(1_000)
+          } finally {
+            exchange.close()
+          }
+        }
+        start()
+      }
+    try {
+      val client =
+        McpHttpClient(
+          endpoint = "http://localhost:${server.address.port}/mcp",
+          retryPolicy = RetryPolicy(maxRetries = 3, initialDelayMs = 1),
+          statusRequestTimeoutMs = 50,
+        )
+
+      val elapsedMs = measureTimeMillis {
+        assertFailsWith<HttpTimeoutException> { client.getDaemonStatus() }
+      }
+
+      assertTrue(elapsedMs < 500, "status probe took ${elapsedMs}ms")
+    } finally {
+      server.stop(0)
+    }
+  }
+
+  @Test
+  fun `STDIO status probe closes only the timed-out process`() {
+    val client = McpStdioClient("/bin/sh -c 'sleep 30'", statusRequestTimeoutMs = 50)
+    try {
+      val elapsedMs = measureTimeMillis {
+        val error = assertFailsWith<McpConnectionException> { client.getDaemonStatus() }
+        assertTrue(error.message.orEmpty().contains("timed out"))
+      }
+
+      assertTrue(elapsedMs < 500, "status probe took ${elapsedMs}ms")
+    } finally {
+      client.close()
+    }
+  }
+}


### PR DESCRIPTION
## Summary

- Bound HTTP `getDaemonStatus()` requests with the existing 5-second status ceiling, without applying a timeout or retry change to ordinary calls.
- Bound STDIO status reads on a daemon worker and recycle only a timed-out process so later calls can start a fresh shared process.
- Bypass the Unix-socket lifecycle preflight for the passive status probe, allowing its existing watchdog to cover a wedged daemon directly; ordinary requests retain the preflight.

## Root cause

Only the default Unix-socket client received the status watchdog from [#5580](https://github.com/kaeawc/auto-mobile/pull/5580). HTTP and STDIO could block before returning a status, and the Unix client ran an unbounded lifecycle preflight before it armed the status deadline.

## Validation

- `bun run turbo:validate`
- `bun run typecheck`
- `(cd android && ./gradlew :desktop-core:test :desktop-core:detektMain :desktop-core:detektTest)`
- `scripts/ktfmt/validate_ktfmt.sh`

Closes [#5585](https://github.com/kaeawc/auto-mobile/issues/5585)
