### PR TITLE
feat(android): stage shared-storage picker fixtures

### DIFF
--- a/android/test-plan-validation/src/main/kotlin/dev/jasonpearson/automobile/validation/ValidTools.kt
+++ b/android/test-plan-validation/src/main/kotlin/dev/jasonpearson/automobile/validation/ValidTools.kt
@@ -70,6 +70,7 @@ object ValidTools {
       "shake",
       "sqlQuery",
       "startDevice",
+      "stageSharedStorage",
       "startTestRecording",
       "swipeOn",
       "systemTray",

--- a/android/test-plan-validation/src/test/kotlin/dev/jasonpearson/automobile/validation/TestPlanValidatorTest.kt
+++ b/android/test-plan-validation/src/test/kotlin/dev/jasonpearson/automobile/validation/TestPlanValidatorTest.kt
@@ -554,6 +554,7 @@ class TestPlanValidatorTest {
             permissions:
               - camera
         - tool: provisionDevice
+        - tool: stageSharedStorage
         - tool: deleteDevice
       """
         .trimIndent()

--- a/docs/index.md
+++ b/docs/index.md
@@ -19,6 +19,7 @@ It uses standard platform tools like `adb` & `simctl` paired with its own additi
 | **[Explore app UX](using/ux-exploration.md)** | Navigate your app, discover screens, map user flows, identify confusing interactions |
 | **[Reproduce bugs](using/reproducing-bugs.md)** | Paste a bug report and get exact reproduction steps with screenshots |
 | **[Create UI tests](using/ui-tests.md)** | Describe test scenarios in plain English, get executable test plans |
+| **[Stage Android picker fixtures](using/android-shared-storage-fixtures.md)** | Prepare bounded Downloads files for system document and media pickers |
 | **[Measure startup time](using/perf-analysis/startup.md)** | Profile cold and warm launch performance |
 | **[Check scroll performance](using/perf-analysis/scroll-framerate.md)** | Detect jank and dropped frames |
 | **[Audit contrast](using/a11y.md#contrast)** | Find accessibility issues with color contrast |

--- a/docs/using/android-shared-storage-fixtures.md
+++ b/docs/using/android-shared-storage-fixtures.md
@@ -29,9 +29,11 @@ ADB or choose a transport endpoint.
 Each request uses exactly one content source per file: `sourcePath` for a host
 file, `contentText` for UTF-8 text, or `contentBase64` for binary data. The
 result lists every logical destination, byte count, and media-indexing outcome.
-Media files receive an Android media-scanner request by default; documents
-report that indexing was not requested because the document picker discovers
-files directly from Downloads. Set `indexMedia: false` to skip that request.
+Media files receive an Android media-scanner request by default, and the tool
+waits until the corresponding media-provider row is visible before reporting
+indexing as complete. Documents report that indexing was not requested because
+the document picker discovers files directly from Downloads. Set
+`indexMedia: false` to skip that request.
 
 ## Location and safety limits
 

--- a/docs/using/android-shared-storage-fixtures.md
+++ b/docs/using/android-shared-storage-fixtures.md
@@ -1,0 +1,56 @@
+# Android shared-storage fixtures
+
+Use `stageSharedStorage` to place fixtures where Android system document and
+media pickers can discover them. It is Android-only and resolves its target
+through the normal device/session selection fields; callers do not need to use
+ADB or choose a transport endpoint.
+
+```json
+{
+  "name": "stageSharedStorage",
+  "arguments": {
+    "platform": "android",
+    "namespace": "checkout-20260823",
+    "reset": true,
+    "files": [
+      {
+        "destinationPath": "documents/terms.txt",
+        "contentText": "Terms for this test run"
+      },
+      {
+        "destinationPath": "media/receipt.png",
+        "sourcePath": "/absolute/path/to/receipt.png"
+      }
+    ]
+  }
+}
+```
+
+Each request uses exactly one content source per file: `sourcePath` for a host
+file, `contentText` for UTF-8 text, or `contentBase64` for binary data. The
+result lists every logical destination, byte count, and media-indexing outcome.
+Media files receive an Android media-scanner request by default; documents
+report that indexing was not requested because the document picker discovers
+files directly from Downloads. Set `indexMedia: false` to skip that request.
+
+## Location and safety limits
+
+The only supported destination is `/sdcard/Download/<namespace>`. A namespace
+is one non-empty directory name—slashes, backslashes, and traversal segments
+are rejected. File paths are relative to that namespace and cannot contain
+`.` or `..` segments. With `reset: true`, AutoMobile removes only the exact
+declared namespace before writing; it never resets Downloads itself or another
+namespace.
+
+This operation stages a known, small fixture set. It is not a general Android
+filesystem API and does not provide arbitrary storage access or recursive
+deletion outside its declared namespace.
+
+## Diagnosing a target app
+
+If the picker workflow still cannot use a target app after staging succeeds,
+reuse the public installed-app inventory rather than looking for a second
+package-list API. Read `automobile:apps?deviceId=<deviceId>&platform=android&search=<package>`
+and check whether the expected package is present before debugging the app or
+picker flow. See [Installed Apps](../design-docs/mcp/resources.md#installed-apps)
+for query details.

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -87,6 +87,7 @@ nav:
       - "UI Tests": using/ui-tests.md
       - "Hermetic CI Pinning": using/hermetic-ci-pinning.md
       - "Per-tool Selection & Registration Gates": using/tool-capabilities.md
+      - "Stage Android picker fixtures": using/android-shared-storage-fixtures.md
       - "WebRTC Screen Streaming": webrtc-streaming-ci-worker.md
       - "Environment Variables": using/environment-variables.md
       - "Performance Analysis":

--- a/schemas/tool-definitions.json
+++ b/schemas/tool-definitions.json
@@ -9210,10 +9210,7 @@
         }
       },
       "required": [
-        "platform",
         "namespace",
-        "reset",
-        "indexMedia",
         "files"
       ],
       "additionalProperties": false

--- a/schemas/tool-definitions.json
+++ b/schemas/tool-definitions.json
@@ -9140,6 +9140,86 @@
     }
   },
   {
+    "name": "stageSharedStorage",
+    "description": "Stage host-file, UTF-8, or base64 fixtures into one bounded Android Downloads namespace for system pickers.",
+    "inputSchema": {
+      "$schema": "https://json-schema.org/draft/2020-12/schema",
+      "type": "object",
+      "properties": {
+        "namespace": {
+          "description": "One caller-named child directory beneath Downloads",
+          "type": "string"
+        },
+        "reset": {
+          "description": "Remove only this declared namespace before writing",
+          "default": false,
+          "type": "boolean"
+        },
+        "indexMedia": {
+          "description": "Request Android media indexing for media files",
+          "default": true,
+          "type": "boolean"
+        },
+        "files": {
+          "description": "Files to stage into the namespace",
+          "minItems": 1,
+          "type": "array",
+          "items": {
+            "type": "object",
+            "properties": {
+              "sourcePath": {
+                "description": "Host file path",
+                "type": "string",
+                "minLength": 1
+              },
+              "contentText": {
+                "description": "UTF-8 content",
+                "type": "string"
+              },
+              "contentBase64": {
+                "description": "Base64 content",
+                "type": "string"
+              },
+              "destinationPath": {
+                "description": "Path relative to the declared Downloads namespace",
+                "type": "string"
+              }
+            },
+            "required": [
+              "destinationPath"
+            ],
+            "additionalProperties": false
+          }
+        },
+        "platform": {
+          "type": "string",
+          "enum": [
+            "android",
+            "ios"
+          ]
+        },
+        "sessionUuid": {
+          "description": "Session",
+          "type": "string"
+        },
+        "keepScreenAwake": {
+          "type": "boolean"
+        },
+        "device": {
+          "description": "Device label",
+          "type": "string"
+        }
+      },
+      "required": [
+        "namespace",
+        "reset",
+        "indexMedia",
+        "files"
+      ],
+      "additionalProperties": false
+    }
+  },
+  {
     "name": "startTestRecording",
     "description": "Start recording user interactions for exportPlan.",
     "inputSchema": {

--- a/schemas/tool-definitions.json
+++ b/schemas/tool-definitions.json
@@ -9146,6 +9146,12 @@
       "$schema": "https://json-schema.org/draft/2020-12/schema",
       "type": "object",
       "properties": {
+        "platform": {
+          "description": "Android platform",
+          "default": "android",
+          "type": "string",
+          "const": "android"
+        },
         "namespace": {
           "description": "One caller-named child directory beneath Downloads",
           "type": "string"
@@ -9191,13 +9197,6 @@
             "additionalProperties": false
           }
         },
-        "platform": {
-          "type": "string",
-          "enum": [
-            "android",
-            "ios"
-          ]
-        },
         "sessionUuid": {
           "description": "Session",
           "type": "string"
@@ -9211,6 +9210,7 @@
         }
       },
       "required": [
+        "platform",
         "namespace",
         "reset",
         "indexMedia",

--- a/scripts/generate-tool-definitions.ts
+++ b/scripts/generate-tool-definitions.ts
@@ -30,6 +30,7 @@ import { registerDatabaseTools } from "../src/server/databaseTools";
 import { registerStorageTools } from "../src/server/storageTools";
 import { registerPreferenceTools } from "../src/server/preferenceTools";
 import { registerAppFileTools } from "../src/server/appFileTools";
+import { registerSharedStorageTools } from "../src/server/sharedStorageTools";
 import { registerFormTools } from "../src/server/formTools";
 import { registerAccessibilityTools } from "../src/server/accessibilityTools";
 import { registerAccessibilityFocusTools } from "../src/server/accessibilityFocusTools";
@@ -60,6 +61,7 @@ function registerAllTools(): void {
   registerStorageTools();
   registerPreferenceTools();
   registerAppFileTools();
+  registerSharedStorageTools();
   registerFormTools();
   registerAccessibilityTools();
   registerAccessibilityFocusTools();

--- a/src/server/index.ts
+++ b/src/server/index.ts
@@ -52,6 +52,7 @@ import { registerDatabaseTools } from "./databaseTools";
 import { registerStorageTools } from "./storageTools";
 import { registerPreferenceTools } from "./preferenceTools";
 import { registerAppFileTools } from "./appFileTools";
+import { registerSharedStorageTools } from "./sharedStorageTools";
 import { registerFormTools } from "./formTools";
 import { registerAccessibilityTools } from "./accessibilityTools";
 import { registerAccessibilityFocusTools } from "./accessibilityFocusTools";
@@ -299,6 +300,7 @@ export function registerMcpTools(daemonMode: boolean): void {
   registerStorageTools();
   registerPreferenceTools();
   registerAppFileTools();
+  registerSharedStorageTools();
   registerFormTools();
   registerAccessibilityTools();
   registerAccessibilityFocusTools();

--- a/src/server/sharedStorageContract.ts
+++ b/src/server/sharedStorageContract.ts
@@ -1,0 +1,134 @@
+import { z } from "zod/v4";
+import { addDeviceTargetingToSchema } from "./toolSchemaHelpers";
+import type { Platform } from "../models";
+import { errorMessage } from "../utils/describeUnknownError";
+
+export interface SharedStorageFileInput {
+  destinationPath: string;
+  sourcePath?: string;
+  contentText?: string;
+  contentBase64?: string;
+}
+
+export interface StageSharedStorageArgs {
+  namespace: string;
+  reset?: boolean;
+  indexMedia?: boolean;
+  files: SharedStorageFileInput[];
+  platform?: Platform;
+  deviceId?: string;
+  device?: string;
+  sessionUuid?: string;
+  keepScreenAwake?: boolean;
+}
+
+export interface SharedStorageIndexingResult {
+  status: "completed" | "notRequested";
+  reason?: string;
+}
+
+export interface StagedSharedStorageFile {
+  destinationPath: string;
+  byteCount: number;
+  mediaIndexing: SharedStorageIndexingResult;
+}
+
+export interface StageSharedStorageResult {
+  success: true;
+  deviceId: string;
+  platform: "android";
+  namespace: string;
+  destinationDirectory: string;
+  reset: boolean;
+  files: StagedSharedStorageFile[];
+}
+
+function countDefined(values: unknown[]): number {
+  return values.filter(value => value !== undefined).length;
+}
+
+/** A namespace is exactly one Downloads child, keeping reset scope auditable. */
+export function normalizeSharedStorageNamespace(namespace: string): string {
+  const normalized = namespace.trim();
+  if (
+    normalized.length === 0 ||
+    normalized === "." ||
+    normalized === ".." ||
+    normalized.includes("/") ||
+    normalized.includes("\\") ||
+    normalized.includes("\0")
+  ) {
+    throw new Error("namespace must be a non-empty single directory name without path separators or traversal segments");
+  }
+  return normalized;
+}
+
+export function normalizeSharedStorageRelativePath(path: string): string {
+  const normalized = path.replace(/\\/g, "/").replace(/^\.\/+/, "");
+  const segments = normalized.split("/");
+  if (
+    normalized.length === 0 ||
+    normalized.startsWith("/") ||
+    segments.some(segment => segment.length === 0 || segment === "." || segment === "..")
+  ) {
+    throw new Error("destinationPath must be a non-empty relative path without '.' or '..' segments");
+  }
+  return normalized;
+}
+
+const sharedStorageFileSchema = z.object({
+  sourcePath: z.string().min(1).optional().describe("Host file path"),
+  contentText: z.string().optional().describe("UTF-8 content"),
+  contentBase64: z.string().optional().describe("Base64 content"),
+  destinationPath: z.string().describe("Path relative to the declared Downloads namespace"),
+}).superRefine((file, ctx) => {
+  if (countDefined([file.sourcePath, file.contentText, file.contentBase64]) !== 1) {
+    ctx.addIssue({
+      code: "custom",
+      message: "Provide exactly one content source: sourcePath, contentText, or contentBase64.",
+      path: ["sourcePath"],
+    });
+  }
+  try {
+    normalizeSharedStorageRelativePath(file.destinationPath);
+  } catch (error) {
+    ctx.addIssue({
+      code: "custom",
+      message: error instanceof Error ? error.message : "destinationPath must be a safe relative path",
+      path: ["destinationPath"],
+    });
+  }
+  if (file.contentBase64 !== undefined) {
+    try {
+      const decoded = Buffer.from(file.contentBase64, "base64");
+      const canonical = decoded.toString("base64");
+      const unpadded = canonical.replace(/=+$/, "");
+      if ((file.contentBase64 !== canonical && file.contentBase64 !== unpadded) || decoded.length === 0) {
+        throw new Error("invalid payload");
+      }
+    } catch (error) {
+      ctx.addIssue({
+        code: "custom",
+        message: `contentBase64 must be valid, non-empty base64 (${errorMessage(error)}).`,
+        path: ["contentBase64"],
+      });
+    }
+  }
+});
+
+export const stageSharedStorageSchema = addDeviceTargetingToSchema(z.object({
+  namespace: z.string().describe("One caller-named child directory beneath Downloads"),
+  reset: z.boolean().optional().default(false).describe("Remove only this declared namespace before writing"),
+  indexMedia: z.boolean().optional().default(true).describe("Request Android media indexing for media files"),
+  files: z.array(sharedStorageFileSchema).min(1).describe("Files to stage into the namespace"),
+})).superRefine((args, ctx) => {
+  try {
+    normalizeSharedStorageNamespace(args.namespace);
+  } catch (error) {
+    ctx.addIssue({
+      code: "custom",
+      message: error instanceof Error ? error.message : "namespace must be safe",
+      path: ["namespace"],
+    });
+  }
+});

--- a/src/server/sharedStorageContract.ts
+++ b/src/server/sharedStorageContract.ts
@@ -117,6 +117,7 @@ const sharedStorageFileSchema = z.object({
 });
 
 export const stageSharedStorageSchema = addDeviceTargetingToSchema(z.object({
+  platform: z.literal("android").optional().default("android").describe("Android platform"),
   namespace: z.string().describe("One caller-named child directory beneath Downloads"),
   reset: z.boolean().optional().default(false).describe("Remove only this declared namespace before writing"),
   indexMedia: z.boolean().optional().default(true).describe("Request Android media indexing for media files"),

--- a/src/server/sharedStorageContract.ts
+++ b/src/server/sharedStorageContract.ts
@@ -1,5 +1,5 @@
 import { z } from "zod/v4";
-import { addDeviceTargetingToSchema } from "./toolSchemaHelpers";
+import { addDeviceTargetingToSchema, withJsonSchemaOverride } from "./toolSchemaHelpers";
 import type { Platform } from "../models";
 import { errorMessage } from "../utils/describeUnknownError";
 
@@ -116,7 +116,7 @@ const sharedStorageFileSchema = z.object({
   }
 });
 
-export const stageSharedStorageSchema = addDeviceTargetingToSchema(z.object({
+export const stageSharedStorageSchema = withJsonSchemaOverride(addDeviceTargetingToSchema(z.object({
   platform: z.literal("android").optional().default("android").describe("Android platform"),
   namespace: z.string().describe("One caller-named child directory beneath Downloads"),
   reset: z.boolean().optional().default(false).describe("Remove only this declared namespace before writing"),
@@ -131,5 +131,11 @@ export const stageSharedStorageSchema = addDeviceTargetingToSchema(z.object({
       message: error instanceof Error ? error.message : "namespace must be safe",
       path: ["namespace"],
     });
+  }
+}), jsonSchema => {
+  if (Array.isArray(jsonSchema.required)) {
+    jsonSchema.required = jsonSchema.required.filter(field =>
+      field !== "platform" && field !== "reset" && field !== "indexMedia"
+    );
   }
 });

--- a/src/server/sharedStorageService.ts
+++ b/src/server/sharedStorageService.ts
@@ -9,6 +9,7 @@ import { shellQuote } from "../utils/shellQuote";
 import { resolvePathFromDaemonLaunchWorkingDirectory } from "../utils/workingDirectory";
 import { errorMessage } from "../utils/describeUnknownError";
 import { defaultTimer, type Timer } from "../utils/SystemTimer";
+import { readAndroidDeviceApiLevel } from "../utils/android-cmdline-tools/readAndroidDeviceApiLevel";
 import {
   normalizeSharedStorageNamespace,
   normalizeSharedStorageRelativePath,
@@ -130,6 +131,11 @@ class DefaultSharedStorageService implements SharedStorageService {
           source: await this.prepareSource(file),
         });
       }
+      for (const file of prepared) {
+        if (prepared.some(other => other !== file && other.destinationPath.startsWith(`${file.destinationPath}/`))) {
+          throw new ActionableError(`destinationPath conflicts with a nested fixture: ${file.destinationPath}`);
+        }
+      }
       return prepared;
     } catch (error) {
       await Promise.all(prepared.map(file => file.source.cleanup?.()));
@@ -203,17 +209,19 @@ async function indexMediaFile(
     signal,
   );
   const collection = mediaCollectionFor(destinationPath);
+  const apiLevel = await readAndroidDeviceApiLevel(adb);
+  const modernQuery = apiLevel === null || apiLevel >= 29;
   const deviceRelativePath = destination.slice(`${DOWNLOADS_ROOT}/`.length);
   const deviceRelativeDirectory = posix.dirname(deviceRelativePath);
-  const relativePath = deviceRelativeDirectory === "."
-    ? "Download/"
-    : `Download/${deviceRelativeDirectory}/`;
-  const displayName = posix.basename(destination);
-  const selection = `relative_path=${sqlString(relativePath)} AND _display_name=${sqlString(displayName)}`;
+  const relativePath = deviceRelativeDirectory === "." ? "Download/" : `Download/${deviceRelativeDirectory}/`;
+  const selection = modernQuery
+    ? `relative_path=${sqlString(relativePath)} AND _display_name=${sqlString(posix.basename(destination))}`
+    : `_data=${sqlString(destination.replace("/sdcard/", "/storage/emulated/0/"))}`;
+  const volume = modernQuery ? "external_primary" : "external";
   for (let attempt = 0; attempt < 20; attempt += 1) {
     const result = await executeResult(
       adb,
-      `shell content query --uri content://media/external_primary/${collection}/media --projection _id --where ${shellQuote(selection)}`,
+      `shell content query --uri content://media/${volume}/${collection}/media --projection _id --where ${shellQuote(selection)}`,
       signal,
     );
     if (/^Row:/m.test(result.stdout)) {

--- a/src/server/sharedStorageService.ts
+++ b/src/server/sharedStorageService.ts
@@ -1,0 +1,187 @@
+import { promises as nodeFs } from "node:fs";
+import { join, posix } from "node:path";
+import { tmpdir } from "node:os";
+import type { BootedDevice } from "../models";
+import { ActionableError } from "../models";
+import { defaultAdbClientFactory, type AdbClientFactory } from "../utils/android-cmdline-tools/AdbClientFactory";
+import type { AdbExecutor } from "../utils/android-cmdline-tools/interfaces/AdbExecutor";
+import { shellQuote } from "../utils/shellQuote";
+import { resolvePathFromDaemonLaunchWorkingDirectory } from "../utils/workingDirectory";
+import { errorMessage } from "../utils/describeUnknownError";
+import {
+  normalizeSharedStorageNamespace,
+  normalizeSharedStorageRelativePath,
+  type SharedStorageFileInput,
+  type StageSharedStorageArgs,
+  type StageSharedStorageResult,
+  type StagedSharedStorageFile,
+} from "./sharedStorageContract";
+
+const DOWNLOADS_ROOT = "/sdcard/Download";
+
+interface SharedStorageStats {
+  size: number;
+  isFile(): boolean;
+}
+
+export interface SharedStorageFileSystem {
+  stat(path: string): Promise<SharedStorageStats>;
+  mkdtemp(prefix: string): Promise<string>;
+  writeFileBuffer(path: string, data: Buffer): Promise<void>;
+  rm(path: string): Promise<void>;
+}
+
+const defaultFileSystem: SharedStorageFileSystem = {
+  stat: path => nodeFs.stat(path),
+  mkdtemp: prefix => nodeFs.mkdtemp(prefix),
+  writeFileBuffer: (path, data) => nodeFs.writeFile(path, data),
+  rm: path => nodeFs.rm(path, { recursive: true, force: true }),
+};
+
+export interface SharedStorageServiceDependencies {
+  adbFactory?: AdbClientFactory;
+  fileSystem?: SharedStorageFileSystem;
+}
+
+export interface StageSharedStorageRequest extends Omit<StageSharedStorageArgs, "device"> {
+  device: BootedDevice;
+  signal?: AbortSignal;
+}
+
+export interface SharedStorageService {
+  stage(request: StageSharedStorageRequest): Promise<StageSharedStorageResult>;
+}
+
+let sharedStorageService: SharedStorageService | null = null;
+
+export function getSharedStorageService(): SharedStorageService {
+  if (!sharedStorageService) {
+    sharedStorageService = createSharedStorageServiceForTesting();
+  }
+  return sharedStorageService;
+}
+
+export function setSharedStorageServiceForTesting(service: SharedStorageService): void {
+  sharedStorageService = service;
+}
+
+export function resetSharedStorageServiceForTesting(): void {
+  sharedStorageService = null;
+}
+
+export function createSharedStorageServiceForTesting(
+  dependencies: SharedStorageServiceDependencies = {}
+): SharedStorageService {
+  return new DefaultSharedStorageService(
+    dependencies.adbFactory ?? defaultAdbClientFactory,
+    dependencies.fileSystem ?? defaultFileSystem,
+  );
+}
+
+class DefaultSharedStorageService implements SharedStorageService {
+  constructor(
+    private readonly adbFactory: AdbClientFactory,
+    private readonly fileSystem: SharedStorageFileSystem,
+  ) {}
+
+  async stage(request: StageSharedStorageRequest): Promise<StageSharedStorageResult> {
+    if (request.device.platform !== "android") {
+      throw new ActionableError("stageSharedStorage is only supported on Android devices.");
+    }
+    const namespace = normalizeSharedStorageNamespace(request.namespace);
+    const destinationDirectory = posix.join(DOWNLOADS_ROOT, namespace);
+    const adb = this.adbFactory.create(request.device);
+
+    if (request.reset) {
+      // namespace has exactly one safe segment, so this can only remove Downloads/<namespace>.
+      await execute(adb, `shell rm -rf ${shellQuote(destinationDirectory)}`, request.signal);
+    }
+    await execute(adb, `shell mkdir -p ${shellQuote(destinationDirectory)}`, request.signal);
+
+    const files: StagedSharedStorageFile[] = [];
+    for (const file of request.files) {
+      files.push(await this.stageFile(adb, request, namespace, destinationDirectory, file));
+    }
+    return {
+      success: true,
+      deviceId: request.device.deviceId,
+      platform: "android",
+      namespace,
+      destinationDirectory,
+      reset: request.reset ?? false,
+      files,
+    };
+  }
+
+  private async stageFile(
+    adb: AdbExecutor,
+    request: StageSharedStorageRequest,
+    namespace: string,
+    destinationDirectory: string,
+    file: SharedStorageFileInput,
+  ): Promise<StagedSharedStorageFile> {
+    const destinationPath = normalizeSharedStorageRelativePath(file.destinationPath);
+    const destination = posix.join(destinationDirectory, destinationPath);
+    // Re-check the joined result so future path changes cannot widen the reset namespace.
+    if (!destination.startsWith(`${destinationDirectory}/`)) {
+      throw new ActionableError(`destinationPath escapes shared-storage namespace ${namespace}`);
+    }
+    const source = await this.prepareSource(file);
+    try {
+      await execute(adb, `shell mkdir -p ${shellQuote(posix.dirname(destination))}`, request.signal);
+      await execute(adb, `push ${shellQuote(source.path)} ${shellQuote(destination)}`, request.signal);
+      const mediaIndexing = shouldIndexMedia(destinationPath, request.indexMedia ?? true)
+        ? await indexMediaFile(adb, destination, request.signal)
+        : { status: "notRequested" as const, reason: indexingNotRequestedReason(destinationPath, request.indexMedia ?? true) };
+      return { destinationPath, byteCount: source.byteCount, mediaIndexing };
+    } finally {
+      await source.cleanup?.();
+    }
+  }
+
+  private async prepareSource(file: SharedStorageFileInput): Promise<{ path: string; byteCount: number; cleanup?: () => Promise<void> }> {
+    if (file.sourcePath !== undefined) {
+      const path = resolvePathFromDaemonLaunchWorkingDirectory(file.sourcePath);
+      const stat = await this.fileSystem.stat(path);
+      if (!stat.isFile()) {
+        throw new ActionableError(`sourcePath is not a file: ${path}`);
+      }
+      return { path, byteCount: stat.size };
+    }
+    const buffer = file.contentBase64 === undefined
+      ? Buffer.from(file.contentText ?? "", "utf8")
+      : Buffer.from(file.contentBase64, "base64");
+    const directory = await this.fileSystem.mkdtemp(join(tmpdir(), "automobile-shared-storage-"));
+    const path = join(directory, "content");
+    await this.fileSystem.writeFileBuffer(path, buffer);
+    return { path, byteCount: buffer.byteLength, cleanup: () => this.fileSystem.rm(directory) };
+  }
+}
+
+async function execute(adb: AdbExecutor, command: string, signal?: AbortSignal): Promise<void> {
+  try {
+    await adb.executeCommand(command, undefined, undefined, true, signal);
+  } catch (error) {
+    throw new ActionableError(`Android shared-storage operation failed: ${errorMessage(error)}`);
+  }
+}
+
+async function indexMediaFile(adb: AdbExecutor, destination: string, signal?: AbortSignal): Promise<{ status: "completed" }> {
+  await execute(
+    adb,
+    `shell am broadcast -a android.intent.action.MEDIA_SCANNER_SCAN_FILE -d ${shellQuote(`file://${destination}`)}`,
+    signal,
+  );
+  return { status: "completed" };
+}
+
+function shouldIndexMedia(path: string, indexMedia: boolean): boolean {
+  return indexMedia && /\.(aac|bmp|flac|gif|heic|jpeg|jpg|m4a|mkv|mov|mp3|mp4|ogg|png|wav|webm|webp)$/i.test(path);
+}
+
+function indexingNotRequestedReason(path: string, indexMedia: boolean): string {
+  if (!indexMedia) {
+    return "media indexing was disabled by indexMedia=false";
+  }
+  return `media indexing was not requested for ${path}; Android document pickers discover files directly from Downloads`;
+}

--- a/src/server/sharedStorageService.ts
+++ b/src/server/sharedStorageService.ts
@@ -132,7 +132,10 @@ class DefaultSharedStorageService implements SharedStorageService {
         });
       }
       for (const file of prepared) {
-        if (prepared.some(other => other !== file && other.destinationPath.startsWith(`${file.destinationPath}/`))) {
+        if (prepared.some(other => other !== file && (
+          other.destinationPath === file.destinationPath ||
+          other.destinationPath.startsWith(`${file.destinationPath}/`)
+        ))) {
           throw new ActionableError(`destinationPath conflicts with a nested fixture: ${file.destinationPath}`);
         }
       }
@@ -157,7 +160,7 @@ class DefaultSharedStorageService implements SharedStorageService {
       throw new ActionableError(`destinationPath escapes shared-storage namespace ${namespace}`);
     }
     await execute(adb, `shell mkdir -p ${shellQuote(posix.dirname(destination))}`, request.signal);
-    await execute(adb, `push ${shellQuote(file.source.path)} ${shellQuote(destination)}`, request.signal);
+    await executeArgs(adb, ["push", file.source.path, destination], request.signal);
     const mediaIndexing = shouldIndexMedia(destinationPath, request.indexMedia ?? true)
       ? await indexMediaFile(adb, destination, destinationPath, this.timer, request.signal)
       : { status: "notRequested" as const, reason: indexingNotRequestedReason(destinationPath, request.indexMedia ?? true) };
@@ -191,6 +194,14 @@ interface PreparedSharedStorageFile {
 async function execute(adb: AdbExecutor, command: string, signal?: AbortSignal): Promise<void> {
   try {
     await adb.executeCommand(command, undefined, undefined, true, signal);
+  } catch (error) {
+    throw new ActionableError(`Android shared-storage operation failed: ${errorMessage(error)}`);
+  }
+}
+
+async function executeArgs(adb: AdbExecutor, args: string[], signal?: AbortSignal): Promise<void> {
+  try {
+    await adb.execute(args, { noRetry: true, signal });
   } catch (error) {
     throw new ActionableError(`Android shared-storage operation failed: ${errorMessage(error)}`);
   }

--- a/src/server/sharedStorageService.ts
+++ b/src/server/sharedStorageService.ts
@@ -8,6 +8,7 @@ import type { AdbExecutor } from "../utils/android-cmdline-tools/interfaces/AdbE
 import { shellQuote } from "../utils/shellQuote";
 import { resolvePathFromDaemonLaunchWorkingDirectory } from "../utils/workingDirectory";
 import { errorMessage } from "../utils/describeUnknownError";
+import { defaultTimer, type Timer } from "../utils/SystemTimer";
 import {
   normalizeSharedStorageNamespace,
   normalizeSharedStorageRelativePath,
@@ -41,6 +42,7 @@ const defaultFileSystem: SharedStorageFileSystem = {
 export interface SharedStorageServiceDependencies {
   adbFactory?: AdbClientFactory;
   fileSystem?: SharedStorageFileSystem;
+  timer?: Timer;
 }
 
 export interface StageSharedStorageRequest extends Omit<StageSharedStorageArgs, "device"> {
@@ -75,6 +77,7 @@ export function createSharedStorageServiceForTesting(
   return new DefaultSharedStorageService(
     dependencies.adbFactory ?? defaultAdbClientFactory,
     dependencies.fileSystem ?? defaultFileSystem,
+    dependencies.timer ?? defaultTimer,
   );
 }
 
@@ -82,6 +85,7 @@ class DefaultSharedStorageService implements SharedStorageService {
   constructor(
     private readonly adbFactory: AdbClientFactory,
     private readonly fileSystem: SharedStorageFileSystem,
+    private readonly timer: Timer,
   ) {}
 
   async stage(request: StageSharedStorageRequest): Promise<StageSharedStorageResult> {
@@ -91,26 +95,46 @@ class DefaultSharedStorageService implements SharedStorageService {
     const namespace = normalizeSharedStorageNamespace(request.namespace);
     const destinationDirectory = posix.join(DOWNLOADS_ROOT, namespace);
     const adb = this.adbFactory.create(request.device);
+    const preparedFiles = await this.prepareFiles(request.files);
+    try {
+      if (request.reset) {
+        // namespace has exactly one safe segment, so this can only remove Downloads/<namespace>.
+        await execute(adb, `shell rm -rf ${shellQuote(destinationDirectory)}`, request.signal);
+      }
+      await execute(adb, `shell mkdir -p ${shellQuote(destinationDirectory)}`, request.signal);
 
-    if (request.reset) {
-      // namespace has exactly one safe segment, so this can only remove Downloads/<namespace>.
-      await execute(adb, `shell rm -rf ${shellQuote(destinationDirectory)}`, request.signal);
+      const files: StagedSharedStorageFile[] = [];
+      for (const file of preparedFiles) {
+        files.push(await this.stageFile(adb, request, namespace, destinationDirectory, file));
+      }
+      return {
+        success: true,
+        deviceId: request.device.deviceId,
+        platform: "android",
+        namespace,
+        destinationDirectory,
+        reset: request.reset ?? false,
+        files,
+      };
+    } finally {
+      await Promise.all(preparedFiles.map(file => file.source.cleanup?.()));
     }
-    await execute(adb, `shell mkdir -p ${shellQuote(destinationDirectory)}`, request.signal);
+  }
 
-    const files: StagedSharedStorageFile[] = [];
-    for (const file of request.files) {
-      files.push(await this.stageFile(adb, request, namespace, destinationDirectory, file));
+  private async prepareFiles(files: SharedStorageFileInput[]): Promise<PreparedSharedStorageFile[]> {
+    const prepared: PreparedSharedStorageFile[] = [];
+    try {
+      for (const file of files) {
+        prepared.push({
+          destinationPath: normalizeSharedStorageRelativePath(file.destinationPath),
+          source: await this.prepareSource(file),
+        });
+      }
+      return prepared;
+    } catch (error) {
+      await Promise.all(prepared.map(file => file.source.cleanup?.()));
+      throw error;
     }
-    return {
-      success: true,
-      deviceId: request.device.deviceId,
-      platform: "android",
-      namespace,
-      destinationDirectory,
-      reset: request.reset ?? false,
-      files,
-    };
   }
 
   private async stageFile(
@@ -118,25 +142,20 @@ class DefaultSharedStorageService implements SharedStorageService {
     request: StageSharedStorageRequest,
     namespace: string,
     destinationDirectory: string,
-    file: SharedStorageFileInput,
+    file: PreparedSharedStorageFile,
   ): Promise<StagedSharedStorageFile> {
-    const destinationPath = normalizeSharedStorageRelativePath(file.destinationPath);
+    const destinationPath = file.destinationPath;
     const destination = posix.join(destinationDirectory, destinationPath);
     // Re-check the joined result so future path changes cannot widen the reset namespace.
     if (!destination.startsWith(`${destinationDirectory}/`)) {
       throw new ActionableError(`destinationPath escapes shared-storage namespace ${namespace}`);
     }
-    const source = await this.prepareSource(file);
-    try {
-      await execute(adb, `shell mkdir -p ${shellQuote(posix.dirname(destination))}`, request.signal);
-      await execute(adb, `push ${shellQuote(source.path)} ${shellQuote(destination)}`, request.signal);
-      const mediaIndexing = shouldIndexMedia(destinationPath, request.indexMedia ?? true)
-        ? await indexMediaFile(adb, destination, request.signal)
-        : { status: "notRequested" as const, reason: indexingNotRequestedReason(destinationPath, request.indexMedia ?? true) };
-      return { destinationPath, byteCount: source.byteCount, mediaIndexing };
-    } finally {
-      await source.cleanup?.();
-    }
+    await execute(adb, `shell mkdir -p ${shellQuote(posix.dirname(destination))}`, request.signal);
+    await execute(adb, `push ${shellQuote(file.source.path)} ${shellQuote(destination)}`, request.signal);
+    const mediaIndexing = shouldIndexMedia(destinationPath, request.indexMedia ?? true)
+      ? await indexMediaFile(adb, destination, destinationPath, this.timer, request.signal)
+      : { status: "notRequested" as const, reason: indexingNotRequestedReason(destinationPath, request.indexMedia ?? true) };
+    return { destinationPath, byteCount: file.source.byteCount, mediaIndexing };
   }
 
   private async prepareSource(file: SharedStorageFileInput): Promise<{ path: string; byteCount: number; cleanup?: () => Promise<void> }> {
@@ -158,6 +177,11 @@ class DefaultSharedStorageService implements SharedStorageService {
   }
 }
 
+interface PreparedSharedStorageFile {
+  destinationPath: string;
+  source: { path: string; byteCount: number; cleanup?: () => Promise<void> };
+}
+
 async function execute(adb: AdbExecutor, command: string, signal?: AbortSignal): Promise<void> {
   try {
     await adb.executeCommand(command, undefined, undefined, true, signal);
@@ -166,13 +190,56 @@ async function execute(adb: AdbExecutor, command: string, signal?: AbortSignal):
   }
 }
 
-async function indexMediaFile(adb: AdbExecutor, destination: string, signal?: AbortSignal): Promise<{ status: "completed" }> {
+async function indexMediaFile(
+  adb: AdbExecutor,
+  destination: string,
+  destinationPath: string,
+  timer: Timer,
+  signal?: AbortSignal,
+): Promise<{ status: "completed" }> {
   await execute(
     adb,
     `shell am broadcast -a android.intent.action.MEDIA_SCANNER_SCAN_FILE -d ${shellQuote(`file://${destination}`)}`,
     signal,
   );
-  return { status: "completed" };
+  const collection = mediaCollectionFor(destinationPath);
+  const deviceRelativePath = destination.slice(`${DOWNLOADS_ROOT}/`.length);
+  const deviceRelativeDirectory = posix.dirname(deviceRelativePath);
+  const relativePath = deviceRelativeDirectory === "."
+    ? "Download/"
+    : `Download/${deviceRelativeDirectory}/`;
+  const displayName = posix.basename(destination);
+  const selection = `relative_path=${sqlString(relativePath)} AND _display_name=${sqlString(displayName)}`;
+  for (let attempt = 0; attempt < 20; attempt += 1) {
+    const result = await executeResult(
+      adb,
+      `shell content query --uri content://media/external_primary/${collection}/media --projection _id --where ${shellQuote(selection)}`,
+      signal,
+    );
+    if (/^Row:/m.test(result.stdout)) {
+      return { status: "completed" };
+    }
+    await timer.sleep(250);
+  }
+  throw new ActionableError(`Android media indexing did not complete for ${destination} within 5 seconds.`);
+}
+
+async function executeResult(adb: AdbExecutor, command: string, signal?: AbortSignal) {
+  try {
+    return await adb.executeCommand(command, undefined, undefined, true, signal);
+  } catch (error) {
+    throw new ActionableError(`Android shared-storage operation failed: ${errorMessage(error)}`);
+  }
+}
+
+function mediaCollectionFor(path: string): "images" | "video" | "audio" {
+  if (/\.(bmp|gif|heic|jpeg|jpg|png|webp)$/i.test(path)) {return "images";}
+  if (/\.(mkv|mov|mp4|webm)$/i.test(path)) {return "video";}
+  return "audio";
+}
+
+function sqlString(value: string): string {
+  return `'${value.replace(/'/g, "''")}'`;
 }
 
 function shouldIndexMedia(path: string, indexMedia: boolean): boolean {

--- a/src/server/sharedStorageTools.ts
+++ b/src/server/sharedStorageTools.ts
@@ -1,0 +1,16 @@
+import type { BootedDevice } from "../models";
+import { createJSONToolResponse } from "../utils/toolUtils";
+import { stageSharedStorageSchema, type StageSharedStorageArgs } from "./sharedStorageContract";
+import { getSharedStorageService } from "./sharedStorageService";
+import { ToolRegistry } from "./toolRegistry";
+
+export function registerSharedStorageTools(): void {
+  ToolRegistry.registerDeviceAware(
+    "stageSharedStorage",
+    "Stage host-file, UTF-8, or base64 fixtures into one bounded Android Downloads namespace for system pickers.",
+    stageSharedStorageSchema,
+    async (device: BootedDevice, args: StageSharedStorageArgs, _progress, signal) =>
+      createJSONToolResponse(await getSharedStorageService().stage({ ...args, device, signal })),
+    { defaultEnabled: true },
+  );
+}

--- a/test/server/sharedStorageContract.test.ts
+++ b/test/server/sharedStorageContract.test.ts
@@ -1,0 +1,42 @@
+import { describe, expect, test } from "bun:test";
+import {
+  normalizeSharedStorageNamespace,
+  stageSharedStorageSchema,
+} from "../../src/server/sharedStorageContract";
+
+describe("shared-storage contract", () => {
+  test("accepts all established file-content modes", () => {
+    for (const file of [
+      { sourcePath: "/tmp/fixture.pdf", destinationPath: "docs/fixture.pdf" },
+      { contentText: "hello", destinationPath: "notes/welcome.txt" },
+      { contentBase64: Buffer.from([0, 1, 2]).toString("base64"), destinationPath: "media/image.bin" },
+    ]) {
+      expect(stageSharedStorageSchema.safeParse({ namespace: "run-42", files: [file] }).success).toBe(true);
+    }
+  });
+
+  test("rejects unsafe namespace resets before an ADB operation can be constructed", () => {
+    for (const namespace of ["", ".", "..", "a/b", "a\\b"]) {
+      expect(stageSharedStorageSchema.safeParse({
+        namespace,
+        reset: true,
+        files: [{ contentText: "safe", destinationPath: "file.txt" }],
+      }).success).toBe(false);
+    }
+    expect(() => normalizeSharedStorageNamespace("../Downloads")).toThrow("single directory name");
+  });
+
+  test("rejects unsafe file destinations and ambiguous content sources", () => {
+    const unsafe = stageSharedStorageSchema.safeParse({
+      namespace: "run-42",
+      files: [{ contentText: "safe", destinationPath: "../outside.txt" }],
+    });
+    expect(unsafe.success).toBe(false);
+
+    const ambiguous = stageSharedStorageSchema.safeParse({
+      namespace: "run-42",
+      files: [{ contentText: "safe", contentBase64: "c2FmZQ==", destinationPath: "file.txt" }],
+    });
+    expect(ambiguous.success).toBe(false);
+  });
+});

--- a/test/server/sharedStorageContract.test.ts
+++ b/test/server/sharedStorageContract.test.ts
@@ -15,6 +15,11 @@ describe("shared-storage contract", () => {
     }
   });
 
+  test("defaults platform to Android and rejects iOS routing", () => {
+    expect(stageSharedStorageSchema.parse({ namespace: "run-42", files: [{ contentText: "x", destinationPath: "x.txt" }] }).platform).toBe("android");
+    expect(stageSharedStorageSchema.safeParse({ platform: "ios", namespace: "run-42", files: [{ contentText: "x", destinationPath: "x.txt" }] }).success).toBe(false);
+  });
+
   test("rejects unsafe namespace resets before an ADB operation can be constructed", () => {
     for (const namespace of ["", ".", "..", "a/b", "a\\b"]) {
       expect(stageSharedStorageSchema.safeParse({

--- a/test/server/sharedStorageService.test.ts
+++ b/test/server/sharedStorageService.test.ts
@@ -58,6 +58,11 @@ describe("SharedStorageService", () => {
     expect(commands).toContain("shell mkdir -p '/sdcard/Download/run-42/docs'");
     expect(commands).toContain("shell mkdir -p '/sdcard/Download/run-42/media'");
     expect(commands.some(command => command.includes("push ") && command.includes("/sdcard/Download/run-42/docs/read me.txt"))).toBe(true);
+    expect(executor.getExecutedArgv()).toContainEqual([
+      "push",
+      expect.stringContaining("automobile-shared-storage-"),
+      "/sdcard/Download/run-42/docs/read me.txt",
+    ]);
     expect(commands.some(command => command.includes("MEDIA_SCANNER_SCAN_FILE") && command.includes("file:///sdcard/Download/run-42/media/photo.png"))).toBe(true);
     expect(commands.some(command => command.includes("content query") && command.includes("external_primary/images/media"))).toBe(true);
     expect(commands.every(command => !command.includes(".."))).toBe(true);
@@ -127,6 +132,21 @@ describe("SharedStorageService", () => {
       files: [
         { contentText: "nested", destinationPath: "foo/bar.txt" },
         { contentText: "file", destinationPath: "foo" },
+      ],
+    })).rejects.toThrow("conflicts with a nested fixture");
+    expect(adbFactory.getFakeClient().getAllCommands()).toEqual([]);
+  });
+
+  test("rejects duplicate normalized destinations before touching shared storage", async () => {
+    const adbFactory = new FakeAdbClientFactory();
+    const service = createSharedStorageServiceForTesting({ adbFactory });
+    await expect(service.stage({
+      device: androidDevice,
+      namespace: "run-42",
+      reset: true,
+      files: [
+        { contentText: "first", destinationPath: "fixture.txt" },
+        { contentText: "second", destinationPath: "./fixture.txt" },
       ],
     })).rejects.toThrow("conflicts with a nested fixture");
     expect(adbFactory.getFakeClient().getAllCommands()).toEqual([]);

--- a/test/server/sharedStorageService.test.ts
+++ b/test/server/sharedStorageService.test.ts
@@ -1,0 +1,80 @@
+import { describe, expect, test } from "bun:test";
+import { createSharedStorageServiceForTesting } from "../../src/server/sharedStorageService";
+import { FakeAdbClientFactory } from "../fakes/FakeAdbClientFactory";
+import type { BootedDevice } from "../../src/models";
+
+const androidDevice: BootedDevice = { deviceId: "emulator-5554", name: "Pixel", platform: "android" };
+
+describe("SharedStorageService", () => {
+  test("resets only the declared Downloads namespace, stages every file, and indexes media", async () => {
+    const adbFactory = new FakeAdbClientFactory();
+    const service = createSharedStorageServiceForTesting({ adbFactory });
+
+    const result = await service.stage({
+      device: androidDevice,
+      namespace: "run-42",
+      reset: true,
+      files: [
+        { contentText: "read me", destinationPath: "docs/read me.txt" },
+        { contentBase64: Buffer.from([1, 2, 3]).toString("base64"), destinationPath: "media/photo.png" },
+      ],
+    });
+
+    expect(result).toEqual({
+      success: true,
+      deviceId: "emulator-5554",
+      platform: "android",
+      namespace: "run-42",
+      destinationDirectory: "/sdcard/Download/run-42",
+      reset: true,
+      files: [
+        {
+          destinationPath: "docs/read me.txt",
+          byteCount: 7,
+          mediaIndexing: {
+            status: "notRequested",
+            reason: "media indexing was not requested for docs/read me.txt; Android document pickers discover files directly from Downloads",
+          },
+        },
+        { destinationPath: "media/photo.png", byteCount: 3, mediaIndexing: { status: "completed" } },
+      ],
+    });
+
+    const commands = adbFactory.getFakeClient().getAllCommands();
+    expect(commands[0]).toBe("shell rm -rf '/sdcard/Download/run-42'");
+    expect(commands).toContain("shell mkdir -p '/sdcard/Download/run-42'");
+    expect(commands).toContain("shell mkdir -p '/sdcard/Download/run-42/docs'");
+    expect(commands).toContain("shell mkdir -p '/sdcard/Download/run-42/media'");
+    expect(commands.some(command => command.includes("push ") && command.includes("/sdcard/Download/run-42/docs/read me.txt"))).toBe(true);
+    expect(commands.some(command => command.includes("MEDIA_SCANNER_SCAN_FILE") && command.includes("file:///sdcard/Download/run-42/media/photo.png"))).toBe(true);
+    expect(commands.every(command => !command.includes(".."))).toBe(true);
+  });
+
+  test("reports why indexing was not requested when the caller opts out", async () => {
+    const adbFactory = new FakeAdbClientFactory();
+    const service = createSharedStorageServiceForTesting({ adbFactory });
+    const result = await service.stage({
+      device: androidDevice,
+      namespace: "run-42",
+      indexMedia: false,
+      files: [{ contentText: "png", destinationPath: "photo.png" }],
+    });
+
+    expect(result.files[0]?.mediaIndexing).toEqual({
+      status: "notRequested",
+      reason: "media indexing was disabled by indexMedia=false",
+    });
+    expect(adbFactory.getFakeClient().getAllCommands().some(command => command.includes("MEDIA_SCANNER_SCAN_FILE"))).toBe(false);
+  });
+
+  test("rejects non-Android devices before issuing commands", async () => {
+    const adbFactory = new FakeAdbClientFactory();
+    const service = createSharedStorageServiceForTesting({ adbFactory });
+    await expect(service.stage({
+      device: { deviceId: "ios", name: "iPhone", platform: "ios" },
+      namespace: "run-42",
+      files: [{ contentText: "hello", destinationPath: "file.txt" }],
+    })).rejects.toThrow("only supported on Android");
+    expect(adbFactory.getFakeClient().getAllCommands()).toEqual([]);
+  });
+});

--- a/test/server/sharedStorageService.test.ts
+++ b/test/server/sharedStorageService.test.ts
@@ -116,4 +116,19 @@ describe("SharedStorageService", () => {
     })).rejects.toThrow("media indexing did not complete");
     expect(executor.getExecutedCommands().filter(command => command.includes("content query"))).toHaveLength(20);
   });
+
+  test("rejects prefix-conflicting destinations before touching shared storage", async () => {
+    const adbFactory = new FakeAdbClientFactory();
+    const service = createSharedStorageServiceForTesting({ adbFactory });
+    await expect(service.stage({
+      device: androidDevice,
+      namespace: "run-42",
+      reset: true,
+      files: [
+        { contentText: "nested", destinationPath: "foo/bar.txt" },
+        { contentText: "file", destinationPath: "foo" },
+      ],
+    })).rejects.toThrow("conflicts with a nested fixture");
+    expect(adbFactory.getFakeClient().getAllCommands()).toEqual([]);
+  });
 });

--- a/test/server/sharedStorageService.test.ts
+++ b/test/server/sharedStorageService.test.ts
@@ -1,14 +1,26 @@
 import { describe, expect, test } from "bun:test";
 import { createSharedStorageServiceForTesting } from "../../src/server/sharedStorageService";
 import { FakeAdbClientFactory } from "../fakes/FakeAdbClientFactory";
+import { FakeAdbExecutor } from "../fakes/FakeAdbExecutor";
 import type { BootedDevice } from "../../src/models";
+import type { AdbClientFactory } from "../../src/utils/android-cmdline-tools/AdbClientFactory";
+import { FakeTimer } from "../fakes/FakeTimer";
 
 const androidDevice: BootedDevice = { deviceId: "emulator-5554", name: "Pixel", platform: "android" };
 
+function execResult(stdout: string) {
+  return { stdout, stderr: "", toString: () => stdout, trim: () => stdout.trim(), includes: (text: string) => stdout.includes(text) };
+}
+
+function adbFactoryFor(executor: FakeAdbExecutor): AdbClientFactory {
+  return { create: () => executor };
+}
+
 describe("SharedStorageService", () => {
   test("resets only the declared Downloads namespace, stages every file, and indexes media", async () => {
-    const adbFactory = new FakeAdbClientFactory();
-    const service = createSharedStorageServiceForTesting({ adbFactory });
+    const executor = new FakeAdbExecutor();
+    executor.setCommandResponse("content query", execResult("Row: 0 _id=42"));
+    const service = createSharedStorageServiceForTesting({ adbFactory: adbFactoryFor(executor) });
 
     const result = await service.stage({
       device: androidDevice,
@@ -40,13 +52,14 @@ describe("SharedStorageService", () => {
       ],
     });
 
-    const commands = adbFactory.getFakeClient().getAllCommands();
+    const commands = executor.getExecutedCommands();
     expect(commands[0]).toBe("shell rm -rf '/sdcard/Download/run-42'");
     expect(commands).toContain("shell mkdir -p '/sdcard/Download/run-42'");
     expect(commands).toContain("shell mkdir -p '/sdcard/Download/run-42/docs'");
     expect(commands).toContain("shell mkdir -p '/sdcard/Download/run-42/media'");
     expect(commands.some(command => command.includes("push ") && command.includes("/sdcard/Download/run-42/docs/read me.txt"))).toBe(true);
     expect(commands.some(command => command.includes("MEDIA_SCANNER_SCAN_FILE") && command.includes("file:///sdcard/Download/run-42/media/photo.png"))).toBe(true);
+    expect(commands.some(command => command.includes("content query") && command.includes("external_primary/images/media"))).toBe(true);
     expect(commands.every(command => !command.includes(".."))).toBe(true);
   });
 
@@ -76,5 +89,31 @@ describe("SharedStorageService", () => {
       files: [{ contentText: "hello", destinationPath: "file.txt" }],
     })).rejects.toThrow("only supported on Android");
     expect(adbFactory.getFakeClient().getAllCommands()).toEqual([]);
+  });
+
+  test("validates every source before resetting the existing namespace", async () => {
+    const adbFactory = new FakeAdbClientFactory();
+    const service = createSharedStorageServiceForTesting({ adbFactory });
+    await expect(service.stage({
+      device: androidDevice,
+      namespace: "run-42",
+      reset: true,
+      files: [{ sourcePath: "/definitely-missing-5587", destinationPath: "fixture.txt" }],
+    })).rejects.toThrow("ENOENT");
+    expect(adbFactory.getFakeClient().getAllCommands()).toEqual([]);
+  });
+
+  test("does not report media indexing complete until MediaStore exposes the file", async () => {
+    const executor = new FakeAdbExecutor();
+    const timer = new FakeTimer();
+    timer.enableAutoAdvance();
+    const service = createSharedStorageServiceForTesting({ adbFactory: adbFactoryFor(executor), timer });
+
+    await expect(service.stage({
+      device: androidDevice,
+      namespace: "run-42",
+      files: [{ contentBase64: Buffer.from([1, 2, 3]).toString("base64"), destinationPath: "photo.png" }],
+    })).rejects.toThrow("media indexing did not complete");
+    expect(executor.getExecutedCommands().filter(command => command.includes("content query"))).toHaveLength(20);
   });
 });

--- a/test/server/sharedStorageTools.test.ts
+++ b/test/server/sharedStorageTools.test.ts
@@ -1,3 +1,4 @@
+import Ajv2020 from "ajv/dist/2020";
 import { afterEach, beforeEach, describe, expect, test } from "bun:test";
 import { ToolRegistry } from "../../src/server/toolRegistry";
 import { registerSharedStorageTools } from "../../src/server/sharedStorageTools";
@@ -14,5 +15,16 @@ describe("shared-storage tools", () => {
     expect(tool!.inputSchema.properties.reset).toBeDefined();
     expect(tool!.inputSchema.properties.files).toBeDefined();
     expect(ToolRegistry.getTool("stageSharedStorage")!.defaultEnabled).toBe(true);
+  });
+
+  test("advertises defaulted fields as optional", () => {
+    registerSharedStorageTools();
+    const tool = ToolRegistry.getToolDefinitions().find(candidate => candidate.name === "stageSharedStorage")!;
+    const validate = new Ajv2020({ strict: false }).compile(tool.inputSchema);
+
+    expect(validate({
+      namespace: "run-42",
+      files: [{ contentText: "fixture", destinationPath: "fixture.txt" }],
+    })).toBe(true);
   });
 });

--- a/test/server/sharedStorageTools.test.ts
+++ b/test/server/sharedStorageTools.test.ts
@@ -1,0 +1,18 @@
+import { afterEach, beforeEach, describe, expect, test } from "bun:test";
+import { ToolRegistry } from "../../src/server/toolRegistry";
+import { registerSharedStorageTools } from "../../src/server/sharedStorageTools";
+
+describe("shared-storage tools", () => {
+  beforeEach(() => (ToolRegistry as any).tools.clear());
+  afterEach(() => (ToolRegistry as any).tools.clear());
+
+  test("registers a discoverable session-bound staging operation", () => {
+    registerSharedStorageTools();
+    const tool = ToolRegistry.getToolDefinitions().find(candidate => candidate.name === "stageSharedStorage");
+    expect(tool).toBeDefined();
+    expect(tool!.inputSchema.properties.namespace).toBeDefined();
+    expect(tool!.inputSchema.properties.reset).toBeDefined();
+    expect(tool!.inputSchema.properties.files).toBeDefined();
+    expect(ToolRegistry.getTool("stageSharedStorage")!.defaultEnabled).toBe(true);
+  });
+});


### PR DESCRIPTION
## Summary

- add discoverable, session-bound `stageSharedStorage` for bounded Android Downloads fixtures
- support host-path, UTF-8, and base64 content with per-file byte and indexing outcomes
- contain reset to one caller-named namespace and document picker/package diagnostics

## Validation

- `bun run turbo:validate`
- `bun run typecheck`
- device-backed staging smoke test on Android emulator (unique namespace removed afterward)

Closes #5587
