### PR TITLE
feat(ios): discover SwiftUI AttributedString inline links via .link rotor (#5578)

### DIFF
--- a/ios/Playground/Playground.xcodeproj/project.pbxproj
+++ b/ios/Playground/Playground.xcodeproj/project.pbxproj
@@ -9,6 +9,7 @@
 /* Begin PBXBuildFile section */
 		007B2120C2735B42A20C510B /* Theme.swift in Sources */ = {isa = PBXBuildFile; fileRef = C2F4747AC5700DF138836D5F /* Theme.swift */; };
 		15B37A3EDBAFD6BD0FC98BFC /* DemosTab.swift in Sources */ = {isa = PBXBuildFile; fileRef = 25213AE8A9FD9A5B1EEFD97F /* DemosTab.swift */; };
+		1F289CED4D38B260C3F553CA /* SwiftUISemanticLinksE2ETests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 6E6860BC496A7CC1EA51E665 /* SwiftUISemanticLinksE2ETests.swift */; };
 		327A28D4620038BBA8D02656 /* Shapes.swift in Sources */ = {isa = PBXBuildFile; fileRef = 5122FF517804CD75B0F75CBA /* Shapes.swift */; };
 		4546703D0511A96D6060F587 /* CrayonSketch.swift in Sources */ = {isa = PBXBuildFile; fileRef = C0972F015B9B7D85BD6F3270 /* CrayonSketch.swift */; };
 		4E220C88A805ED0A7AFDEE38 /* PlaygroundDatabaseFixtureTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = A14ADB69D8A746CDB99D61DE /* PlaygroundDatabaseFixtureTests.swift */; };
@@ -49,6 +50,7 @@
 		5122FF517804CD75B0F75CBA /* Shapes.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = Shapes.swift; sourceTree = "<group>"; };
 		51580F5FC5ADCD5576885563 /* Typography.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = Typography.swift; sourceTree = "<group>"; };
 		64FD18EC8D1B9A665615C374 /* SettingsTab.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SettingsTab.swift; sourceTree = "<group>"; };
+		6E6860BC496A7CC1EA51E665 /* SwiftUISemanticLinksE2ETests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SwiftUISemanticLinksE2ETests.swift; sourceTree = "<group>"; };
 		8A719AFBA1888450E8653AB6 /* SdkHighlightOverlayE2ETests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SdkHighlightOverlayE2ETests.swift; sourceTree = "<group>"; };
 		A14ADB69D8A746CDB99D61DE /* PlaygroundDatabaseFixtureTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = PlaygroundDatabaseFixtureTests.swift; sourceTree = "<group>"; };
 		AA0EB8290A6E5436B2C8CE6F /* auto-mobile-sdk */ = {isa = PBXFileReference; lastKnownFileType = folder; name = "auto-mobile-sdk"; path = "../auto-mobile-sdk"; sourceTree = SOURCE_ROOT; };
@@ -154,6 +156,7 @@
 				A14ADB69D8A746CDB99D61DE /* PlaygroundDatabaseFixtureTests.swift */,
 				FBFA8ECD2DC59DBF8A6FBBF3 /* PlaygroundThemeTests.swift */,
 				8A719AFBA1888450E8653AB6 /* SdkHighlightOverlayE2ETests.swift */,
+				6E6860BC496A7CC1EA51E665 /* SwiftUISemanticLinksE2ETests.swift */,
 			);
 			path = Tests;
 			sourceTree = "<group>";
@@ -315,6 +318,7 @@
 				4E220C88A805ED0A7AFDEE38 /* PlaygroundDatabaseFixtureTests.swift in Sources */,
 				7C8CF515031B975C05FA2AD2 /* PlaygroundThemeTests.swift in Sources */,
 				B3B613858665E331B7E7EB99 /* SdkHighlightOverlayE2ETests.swift in Sources */,
+				1F289CED4D38B260C3F553CA /* SwiftUISemanticLinksE2ETests.swift in Sources */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};

--- a/ios/Playground/Tests/SwiftUISemanticLinksE2ETests.swift
+++ b/ios/Playground/Tests/SwiftUISemanticLinksE2ETests.swift
@@ -1,0 +1,101 @@
+@testable import AutoMobileSDK
+@testable import Playground
+import SwiftUI
+import XCTest
+
+#if DEBUG && canImport(UIKit) && !os(watchOS)
+    import UIKit
+
+    /// End-to-end coverage for issue #5578 on the Playground host app: render the real
+    /// SwiftUI "Semantic Links" demo on the simulator, run the in-app
+    /// `ViewHierarchyWalker`, and assert that the owning `swiftui_semantic_links_inline`
+    /// text element surfaces its three inline `AttributedString` links with the correct
+    /// per-occurrence disambiguation and on-screen activation geometry.
+    ///
+    /// SwiftUI collapses inline links into a single `staticText` accessibility node
+    /// (no readable `attributedText`, no `.link`-trait children), so the UIKit path
+    /// from #5560 finds nothing. The links are reachable in-app only through the
+    /// element's `.link` system custom rotor — this test pins that discovery.
+    final class SwiftUISemanticLinksE2ETests: XCTestCase {
+        @MainActor
+        private func renderDemoAndWalk() -> SdkViewHierarchy {
+            let scene = UIApplication.shared.connectedScenes
+                .compactMap { $0 as? UIWindowScene }
+                .first
+            let window: UIWindow = scene.map { UIWindow(windowScene: $0) } ?? UIWindow(frame: UIScreen.main.bounds)
+            let host = UIHostingController(
+                rootView: NavigationStack { SwiftUISemanticLinksDemo() }.autoMobileTheme()
+            )
+            window.rootViewController = host
+            window.makeKeyAndVisible()
+            host.view.setNeedsLayout()
+            host.view.layoutIfNeeded()
+            // SwiftUI wires up accessibility (and the link rotor) asynchronously; spin
+            // the runloop until the walker can see the inline links, up to a ceiling.
+            var hierarchy = ViewHierarchyWalker.walk()
+            var waited: TimeInterval = 0
+            while ownerNode(in: hierarchy)?.semanticLinks?.isEmpty ?? true, waited < 2.0 {
+                RunLoop.current.run(until: Date().addingTimeInterval(0.2))
+                host.view.layoutIfNeeded()
+                hierarchy = ViewHierarchyWalker.walk()
+                waited += 0.2
+            }
+            return hierarchy
+        }
+
+        private func ownerNode(in hierarchy: SdkViewHierarchy) -> SdkViewNode? {
+            guard let root = hierarchy.root else { return nil }
+            var stack = [root]
+            while let node = stack.popLast() {
+                if node.accessibilityIdentifier == "swiftui_semantic_links_inline",
+                   node.semanticLinks?.isEmpty == false
+                {
+                    return node
+                }
+                stack.append(contentsOf: node.children ?? [])
+            }
+            // Fall back to any node with the identifier even without links, for diagnostics.
+            stack = [root]
+            while let node = stack.popLast() {
+                if node.accessibilityIdentifier == "swiftui_semantic_links_inline" { return node }
+                stack.append(contentsOf: node.children ?? [])
+            }
+            return nil
+        }
+
+        @MainActor
+        func testDiscoversSwiftUIInlineLinksOnOwnerWithOccurrenceAndGeometry() {
+            let hierarchy = renderDemoAndWalk()
+            guard let owner = ownerNode(in: hierarchy) else {
+                return XCTFail("No node carrying accessibilityIdentifier swiftui_semantic_links_inline")
+            }
+            guard let links = owner.semanticLinks else {
+                return XCTFail("Owner element carries no semanticLinks (SwiftUI inline links undiscovered)")
+            }
+
+            // AC1: three inline links in document order with per-text ascending occurrence.
+            XCTAssertEqual(links.map(\.text), [
+                "Terms of Service", "Support", "Terms of Service",
+            ])
+            XCTAssertEqual(links.map(\.occurrence), [0, 0, 1])
+
+            // Every link has finite on-screen activation geometry (AC1 geometry / AC2 input).
+            for link in links {
+                guard let x = link.centerX, let y = link.centerY else {
+                    return XCTFail("Link \(link.text)#\(link.occurrence) has no center")
+                }
+                XCTAssertTrue(x.isFinite && y.isFinite)
+            }
+
+            // AC1/AC2: duplicate "Terms of Service" is disambiguable — the two occurrences
+            // sit on different lines, so their activation points must differ (occurrence 0
+            // above occurrence 1). This is exactly what makes `subtext: { occurrence }`
+            // select the correct link.
+            let terms = links.filter { $0.text == "Terms of Service" }.sorted { $0.occurrence < $1.occurrence }
+            XCTAssertEqual(terms.count, 2)
+            if terms.count == 2, let firstY = terms[0].centerY, let secondY = terms[1].centerY {
+                XCTAssertLessThan(firstY, secondY, "First 'Terms of Service' should sit above the second")
+            }
+        }
+    }
+#endif

--- a/ios/Playground/Tests/SwiftUISemanticLinksE2ETests.swift
+++ b/ios/Playground/Tests/SwiftUISemanticLinksE2ETests.swift
@@ -30,15 +30,18 @@ import XCTest
             window.makeKeyAndVisible()
             host.view.setNeedsLayout()
             host.view.layoutIfNeeded()
-            // SwiftUI wires up accessibility (and the link rotor) asynchronously; spin
-            // the runloop until the walker can see the inline links, up to a ceiling.
-            var hierarchy = ViewHierarchyWalker.walk()
+            // Walk THIS window explicitly, not the resolved key window: other tests in
+            // the suite leave overlay windows up, and on a slow CI runner the global
+            // key-window heuristic can pick one of those instead of the demo. SwiftUI
+            // also wires the link rotor asynchronously, so spin the runloop until the
+            // links appear, up to a generous ceiling.
+            var hierarchy = ViewHierarchyWalker.walk(window: window)
             var waited: TimeInterval = 0
-            while ownerNode(in: hierarchy)?.semanticLinks?.isEmpty ?? true, waited < 2.0 {
-                RunLoop.current.run(until: Date().addingTimeInterval(0.2))
+            while ownerNode(in: hierarchy)?.semanticLinks?.isEmpty ?? true, waited < 8.0 {
+                RunLoop.current.run(until: Date().addingTimeInterval(0.25))
                 host.view.layoutIfNeeded()
-                hierarchy = ViewHierarchyWalker.walk()
-                waited += 0.2
+                hierarchy = ViewHierarchyWalker.walk(window: window)
+                waited += 0.25
             }
             return hierarchy
         }
@@ -63,11 +66,30 @@ import XCTest
             return nil
         }
 
+        /// (total nodes, nodes carrying any semanticLinks) — surfaced on failure so a
+        /// CI-only miss is diagnosable without a rerun.
+        private func nodeStats(in hierarchy: SdkViewHierarchy) -> (total: Int, withLinks: Int) {
+            guard let root = hierarchy.root else { return (0, 0) }
+            var total = 0
+            var withLinks = 0
+            var stack = [root]
+            while let node = stack.popLast() {
+                total += 1
+                if node.semanticLinks?.isEmpty == false { withLinks += 1 }
+                stack.append(contentsOf: node.children ?? [])
+            }
+            return (total, withLinks)
+        }
+
         @MainActor
         func testDiscoversSwiftUIInlineLinksOnOwnerWithOccurrenceAndGeometry() {
             let hierarchy = renderDemoAndWalk()
             guard let owner = ownerNode(in: hierarchy) else {
-                return XCTFail("No node carrying accessibilityIdentifier swiftui_semantic_links_inline")
+                let (total, withLinks) = nodeStats(in: hierarchy)
+                return XCTFail(
+                    "No node carrying accessibilityIdentifier swiftui_semantic_links_inline "
+                        + "(walked \(total) nodes, \(withLinks) with semanticLinks)"
+                )
             }
             guard let links = owner.semanticLinks else {
                 return XCTFail("Owner element carries no semanticLinks (SwiftUI inline links undiscovered)")

--- a/ios/auto-mobile-sdk/Sources/AutoMobileSDK/ViewHierarchy/ViewHierarchyWalker.swift
+++ b/ios/auto-mobile-sdk/Sources/AutoMobileSDK/ViewHierarchy/ViewHierarchyWalker.swift
@@ -16,12 +16,23 @@
         /// Walk the entire view hierarchy and return a snapshot.
         /// Must be called on the main thread.
         public static func walk(bundleId: String? = nil) -> SdkViewHierarchy {
+            walk(in: visibleKeyWindow(), bundleId: bundleId)
+        }
+
+        /// Testability seam: snapshot an explicit window rather than resolving the
+        /// visible key window. Production always goes through `walk(bundleId:)`;
+        /// tests use this so a snapshot doesn't depend on which of several windows
+        /// (app, overlays) the global key-window heuristic happens to pick.
+        static func walk(window: UIWindow, bundleId: String? = nil) -> SdkViewHierarchy {
+            walk(in: window, bundleId: bundleId)
+        }
+
+        private static func walk(in keyWindow: UIWindow?, bundleId: String?) -> SdkViewHierarchy {
             let scale = Float(UIScreen.main.scale)
             let screenBounds = UIScreen.main.bounds
             let screenWidth = Int(screenBounds.width)
             let screenHeight = Int(screenBounds.height)
 
-            let keyWindow = visibleKeyWindow()
             let rootNode = keyWindow.flatMap(walkWindow)
             let safeAreaInsets = keyWindow.map {
                 SdkEdgeInsets(
@@ -423,10 +434,13 @@
             if let array = view.accessibilityElements as? [NSObject], !array.isEmpty {
                 return array
             }
-            let count = view.accessibilityElementCount()
-            guard count != NSNotFound, count > 0 else { return [] }
+            // `accessibilityElementCount()` returns `NSNotFound` for a non-container;
+            // a positive value is the number of vended elements (an Int API, not a
+            // collection count).
+            let elementCount = view.accessibilityElementCount()
+            guard elementCount != NSNotFound, elementCount > 0 else { return [] }
             var out: [NSObject] = []
-            for index in 0 ..< count {
+            for index in 0 ..< elementCount {
                 if let element = view.accessibilityElement(at: index) as? NSObject {
                     out.append(element)
                 }

--- a/ios/auto-mobile-sdk/Sources/AutoMobileSDK/ViewHierarchy/ViewHierarchyWalker.swift
+++ b/ios/auto-mobile-sdk/Sources/AutoMobileSDK/ViewHierarchy/ViewHierarchyWalker.swift
@@ -389,7 +389,17 @@
                     return withCenter(link, point: point)
                 }
 
+                // An element can expose a `.link` rotor while sitting off-screen
+                // (e.g. scrolled out), leaving a degenerate `accessibilityFrame`
+                // (`.null` has infinite origin). `sdkBounds` feeds the origin into
+                // `Int(_:)`, which traps on non-finite input, so guard here exactly
+                // as every other `sdkBounds` caller guards its frame.
                 let ownerFrame = rootView.convert(element.accessibilityFrame, from: nil)
+                guard ownerFrame.width > 0, ownerFrame.height > 0,
+                      ownerFrame.origin.x.isFinite, ownerFrame.origin.y.isFinite
+                else {
+                    continue
+                }
                 owners.append(
                     SdkViewNode(
                         className: String(describing: type(of: element)),
@@ -436,6 +446,14 @@
             var items: [(label: String, frame: CGRect)] = []
             var visited = Set<ObjectIdentifier>()
             var current = nextRotorItem(rotor, after: UIAccessibilityCustomRotorItemResult())
+            // SwiftUI (verified iOS 18) vends each inline link as its own
+            // `LinkElement` target, so distinct occurrences have distinct
+            // `targetElement`s (and distinct frames). The `targetRange` alternative —
+            // one target with per-item ranges — is intentionally unhandled: this
+            // dedup would then stop after the first item, degrading to a single
+            // whole-element link (no crash; `occurrence > 0` activation just falls
+            // back to XCUITest) rather than misreporting geometry.
+            //
             // A well-behaved rotor returns nil past its last item; the visited set +
             // hard cap defend against a wrap-around rotor that never terminates.
             var guardCount = 0

--- a/ios/auto-mobile-sdk/Sources/AutoMobileSDK/ViewHierarchy/ViewHierarchyWalker.swift
+++ b/ios/auto-mobile-sdk/Sources/AutoMobileSDK/ViewHierarchy/ViewHierarchyWalker.swift
@@ -261,6 +261,13 @@
             // Propagate any new opaque overlays discovered in children
             opaqueOverlays = childOpaqueOverlays
 
+            // SwiftUI inline `AttributedString` links collapse into a single
+            // `staticText` accessibility node whose links are reachable in-app only
+            // through its `.link` custom rotor (issue #5578). Synthesize an owner
+            // node per such element so the runner can merge + activate them, keyed
+            // by the element's own accessibility identifier.
+            childNodes.append(contentsOf: linkRotorOwnerNodes(of: view, rootView: rootView))
+
             let semanticLinks = semanticLinks(for: view, rootView: rootView)
 
             return SdkViewNode(
@@ -349,6 +356,131 @@
             // category, so reading it directly is safe for whatever concrete elements
             // (typically UIAccessibilityElement) a view vends.
             return elements.filter { $0.accessibilityTraits.contains(.link) }
+        }
+
+        /// Synthesize an owner node for every accessibility element vended by `view`
+        /// that exposes inline links through a `.link` system rotor (SwiftUI
+        /// `Text(AttributedString)`; issue #5578). Each node carries the element's
+        /// own accessibility identifier + frame and the discovered links (text,
+        /// per-text ascending occurrence, and on-screen center), so the runner's
+        /// identifier/bounds match projects them onto the owning element and the
+        /// coordinate-tap activation from #5560 works unchanged.
+        private static func linkRotorOwnerNodes(of view: UIView, rootView: UIView) -> [SdkViewNode] {
+            var owners: [SdkViewNode] = []
+            for element in accessibilityElements(of: view) {
+                guard let items = linkRotorItems(of: element), !items.isEmpty else { continue }
+                let links = SemanticLinkExtractor.links(fromAccessibilityLinkLabels: items.map(\.label))
+                guard !links.isEmpty else { continue }
+
+                // Re-pair each extracted link with the rotor item it came from,
+                // skipping the blank labels the extractor drops, so the activation
+                // frames line up (mirrors the `.link`-child pairing above).
+                var itemIndex = 0
+                let located: [SdkSemanticLink] = links.map { link in
+                    while itemIndex < items.count,
+                          items[itemIndex].label.trimmingCharacters(in: .whitespacesAndNewlines).isEmpty
+                    {
+                        itemIndex += 1
+                    }
+                    let point = itemIndex < items.count
+                        ? center(ofScreenFrame: items[itemIndex].frame, rootView: rootView)
+                        : nil
+                    itemIndex += 1
+                    return withCenter(link, point: point)
+                }
+
+                let ownerFrame = rootView.convert(element.accessibilityFrame, from: nil)
+                owners.append(
+                    SdkViewNode(
+                        className: String(describing: type(of: element)),
+                        bounds: sdkBounds(from: ownerFrame),
+                        accessibilityLabel: element.accessibilityLabel,
+                        accessibilityIdentifier: accessibilityIdentifier(of: element),
+                        isAccessibilityElement: true,
+                        accessibilityTraits: traitNames(for: element.accessibilityTraits),
+                        isUserInteractionEnabled: false,
+                        semanticLinks: located
+                    )
+                )
+            }
+            return owners
+        }
+
+        /// Flatten a view's accessibility elements, preferring the array property and
+        /// falling back to the `UIAccessibilityContainer` protocol methods (some
+        /// SwiftUI backing views populate only the latter).
+        private static func accessibilityElements(of view: UIView) -> [NSObject] {
+            if let array = view.accessibilityElements as? [NSObject], !array.isEmpty {
+                return array
+            }
+            let count = view.accessibilityElementCount()
+            guard count != NSNotFound, count > 0 else { return [] }
+            var out: [NSObject] = []
+            for index in 0 ..< count {
+                if let element = view.accessibilityElement(at: index) as? NSObject {
+                    out.append(element)
+                }
+            }
+            return out
+        }
+
+        /// The ordered link items of `element`'s `.link` system rotor, as
+        /// (label, on-screen frame) pairs in document order. `nil` when the element
+        /// has no link rotor.
+        private static func linkRotorItems(of element: NSObject) -> [(label: String, frame: CGRect)]? {
+            guard let rotors = element.accessibilityCustomRotors,
+                  let rotor = rotors.first(where: { $0.systemRotorType == .link })
+            else {
+                return nil
+            }
+            var items: [(label: String, frame: CGRect)] = []
+            var visited = Set<ObjectIdentifier>()
+            var current = nextRotorItem(rotor, after: UIAccessibilityCustomRotorItemResult())
+            // A well-behaved rotor returns nil past its last item; the visited set +
+            // hard cap defend against a wrap-around rotor that never terminates.
+            var guardCount = 0
+            while let result = current, guardCount < 256 {
+                guard let target = result.targetElement as? NSObject,
+                      visited.insert(ObjectIdentifier(target)).inserted
+                else {
+                    break
+                }
+                items.append((target.accessibilityLabel ?? "", target.accessibilityFrame))
+                current = nextRotorItem(rotor, after: result)
+                guardCount += 1
+            }
+            return items.isEmpty ? nil : items
+        }
+
+        private static func nextRotorItem(
+            _ rotor: UIAccessibilityCustomRotor,
+            after item: UIAccessibilityCustomRotorItemResult
+        )
+            -> UIAccessibilityCustomRotorItemResult?
+        {
+            let predicate = UIAccessibilityCustomRotorSearchPredicate()
+            predicate.currentItem = item
+            predicate.searchDirection = .next
+            return rotor.itemSearchBlock(predicate)
+        }
+
+        /// Read an accessibility element's identifier. SwiftUI's private element
+        /// implements `accessibilityIdentifier` but does not declare
+        /// `UIAccessibilityIdentification` conformance, so the protocol cast misses
+        /// it; fall back to the KVC-exposed getter, guarded by `responds(to:)`.
+        private static func accessibilityIdentifier(of object: NSObject) -> String? {
+            if let identified = object as? UIAccessibilityIdentification,
+               let identifier = identified.accessibilityIdentifier, !identifier.isEmpty
+            {
+                return identifier
+            }
+            let key = "accessibilityIdentifier"
+            if object.responds(to: NSSelectorFromString(key)),
+               let value = object.value(forKey: key) as? String, !value.isEmpty
+            {
+                return value
+            }
+            return nil
         }
 
         private static func linkCenter(

--- a/ios/control-proxy/Tests/CtrlProxyTests/HierarchyMergerTests.swift
+++ b/ios/control-proxy/Tests/CtrlProxyTests/HierarchyMergerTests.swift
@@ -385,6 +385,44 @@ final class HierarchyMergerTests: XCTestCase {
         XCTAssertEqual(links?[2].start, 58)
     }
 
+    func testEnrichesOwnerElementWithSwiftUIRotorSemanticLinks() {
+        // SwiftUI inline `AttributedString` links have no character range (they are
+        // discovered from the element's `.link` rotor, not an attributed string), so
+        // the SDK supplies text + occurrence + center only. The merge must still
+        // project them onto the owning element (issue #5578), matching by
+        // accessibilityIdentifier even though the synthesized SDK owner's bounds
+        // differ from the XCUITest snapshot.
+        let owner = UIElementInfo(
+            text: "Read the Terms of Service, contact Support, or review the Terms of Service again.",
+            resourceId: "swiftui_semantic_links_inline",
+            className: "CGDrawingView",
+            bounds: ElementBounds(left: 16, top: 190, right: 382, bottom: 233)
+        )
+        let sdkOwner = SdkViewNode(
+            className: "AccessibilityNode",
+            bounds: SdkBounds(left: 17, top: 190, right: 383, bottom: 233),
+            accessibilityIdentifier: "swiftui_semantic_links_inline",
+            semanticLinks: [
+                SdkSemanticLink(text: "Terms of Service", occurrence: 0, centerX: 156, centerY: 201),
+                SdkSemanticLink(text: "Support", occurrence: 0, centerX: 321, centerY: 201),
+                SdkSemanticLink(text: "Terms of Service", occurrence: 1, centerX: 168, centerY: 222),
+            ]
+        )
+
+        let result = HierarchyMerger.merge(
+            xcuitest: makeHierarchy(root: owner),
+            sdk: makeSdkHierarchy(root: sdkOwner)
+        )
+
+        let links = result.hierarchy?.semanticLinks
+        XCTAssertEqual(links?.count, 3)
+        XCTAssertEqual(links?.map(\.text), ["Terms of Service", "Support", "Terms of Service"])
+        XCTAssertEqual(links?.map(\.occurrence), [0, 0, 1])
+        // SwiftUI links carry no range; the Android-parity wire shape keeps that nil.
+        XCTAssertNil(links?[0].start)
+        XCTAssertNil(links?[2].end)
+    }
+
     func testDoesNotOverrideExistingXcuitestSemanticLinksWhenSdkHasNone() {
         // A standalone XCUITest link already carries a single-entry semanticLinks;
         // an SDK match without links must leave it intact.

--- a/ios/control-proxy/Tests/CtrlProxyTests/SemanticLinkActivationTests.swift
+++ b/ios/control-proxy/Tests/CtrlProxyTests/SemanticLinkActivationTests.swift
@@ -43,6 +43,32 @@ final class SemanticLinkActivationTests: XCTestCase {
         XCTAssertEqual(second, SemanticLinkActivation.Coordinate(x: 300, y: 20))
     }
 
+    func testResolvesSwiftUIInlineOccurrenceWithoutRange() {
+        // SwiftUI inline links are discovered from the `.link` rotor: they carry a
+        // center but no character range (issue #5578). Owner-scoped occurrence must
+        // still select the correct duplicate-text link by its distinct center.
+        let owner = node("swiftui_semantic_links_inline", links: [
+            SdkSemanticLink(text: "Terms of Service", occurrence: 0, centerX: 156, centerY: 201),
+            SdkSemanticLink(text: "Support", occurrence: 0, centerX: 321, centerY: 201),
+            SdkSemanticLink(text: "Terms of Service", occurrence: 1, centerX: 168, centerY: 222),
+        ])
+        let root = node(children: [owner])
+        let tree = hierarchy(root: root)
+
+        XCTAssertEqual(
+            SemanticLinkActivation.coordinate(
+                in: tree, ownerResourceId: "swiftui_semantic_links_inline", text: "Terms of Service", occurrence: 0
+            ),
+            SemanticLinkActivation.Coordinate(x: 156, y: 201)
+        )
+        XCTAssertEqual(
+            SemanticLinkActivation.coordinate(
+                in: tree, ownerResourceId: "swiftui_semantic_links_inline", text: "Terms of Service", occurrence: 1
+            ),
+            SemanticLinkActivation.Coordinate(x: 168, y: 222)
+        )
+    }
+
     func testMatchesLinkTextCaseInsensitively() {
         let owner = node("inline", links: [
             SdkSemanticLink(text: "Support", occurrence: 0, centerX: 10, centerY: 10),


### PR DESCRIPTION
## Summary

Follow-up to #5560, which brought inline semantic-link discovery + activation to **UIKit** on iOS. SwiftUI `Text(AttributedString)` inline links remained undiscovered because they collapse into a single `staticText` accessibility node with **no readable `attributedText`** and **no `.link`-trait children** — so both discovery paths shipped in #5560 find nothing.

The issue proposed reading these through **AXBridge** (#2274/#2273/#2266). That family is unbuilt (three open issues; #2266's process architecture is still undecided) and is an out-of-app macOS companion process. Empirically probing the real Playground demo on an iPhone 16 Pro / iOS 18 simulator showed the links are reachable **in-app** after all: each SwiftUI text `AccessibilityNode` carries a `.link` **system custom rotor** whose items are per-link `LinkElement`s with a label and a **distinct per-occurrence on-screen frame** — available without VoiceOver and without any new companion process.

This PR adds that in-app source to the SDK walker. It fully satisfies the acceptance criteria with **no AXBridge, no TypeScript change, and no wire-schema change**, reusing the merge + coordinate-tap activation from #5560 unchanged.

## Changes

- **`ViewHierarchyWalker`** — new third discovery source (`linkRotorOwnerNodes`): for each view, read the `.link` system rotor from its accessibility elements, and synthesize an owner `SdkViewNode` keyed by the element's own `accessibilityIdentifier`, carrying `bounds` (from the element frame) and the discovered `semanticLinks` (text, ascending per-text occurrence, and per-link center from the rotor item frame). Reuses the existing `SemanticLinkExtractor` occurrence logic and `center(ofScreenFrame:)` / `withCenter` geometry helpers. Reads the identifier via `UIAccessibilityIdentification`, falling back to the KVC getter (guarded by `responds(to:)`) because SwiftUI's private element implements the property without declaring the protocol.
- The runner (`HierarchyMerger`, `SemanticLinkActivation`, `CommandHandler`) is **unchanged**: it already pairs SDK nodes to XCUITest owners by identifier/bounds and activates by tapping the SDK-computed center. SwiftUI links simply carry a center and no character range, which the whole chain already tolerates.

## Linked Issue

Closes #5578

## Validation

- [x] iOS Swift suites pass with `-Xswiftc -warnings-as-errors`: `control-proxy` (503), `auto-mobile-sdk` (296), `PlaygroundTests` (21, simulator)
- [x] SwiftFormat clean; SwiftLint reports no error-severity findings on the changed files
- [x] No new xcodegen drift (regenerated with the pinned generator; pbxproj diff is only the new test file)
- [x] No TypeScript changes; semantic-link TS tests still green (32 tests)

## Device Verification

- [x] Verified on iPhone 16 Pro / iOS 18 simulator via the in-app walker against the real Playground **Semantic Links (SwiftUI)** demo (the new `SwiftUISemanticLinksE2ETests` renders the demo and asserts the owner `swiftui_semantic_links_inline` surfaces its three links with occurrences `[0, 0, 1]` and distinct per-occurrence centers). End-to-end `tapOn` → label-change against the live daemon/runner is left as a manual check (the runner activation path is unchanged from #5560 and previously live-verified for UIKit).

### Acceptance criteria

1. **`observe` surfaces inline links on the owner with per-link occurrence + geometry** — `SwiftUISemanticLinksE2ETests` (discovery on the real demo) + `HierarchyMergerTests.testEnrichesOwnerElementWithSwiftUIRotorSemanticLinks` (projection onto the owning element, matched by identifier, `start`/`end` nil).
2. **`tapOn { accessibilityLink }` / `{ subtext }` activate the specific SwiftUI link** — the two "Terms of Service" occurrences resolve to distinct centers: `SemanticLinkActivationTests.testResolvesSwiftUIInlineOccurrenceWithoutRange`, backed by the E2E's distinct-geometry assertion. Reuses the existing `SemanticLinkActivation` coordinate path.
3. **No false `success: true`** — unchanged host-side enforcement (`SemanticLinkActivation` returns nil / the activation throws `elementNotFound` when nothing matches).

## Follow-ups

- [ ] Full live `tapOn` → `semantic_links_result` label-change verification on the daemon/runner stack, if desired beyond the geometry-level pin.
