### PR TITLE
feat(android): end-to-end DataStore inspection over the MCP chain (#5573)

### DIFF
--- a/android/control-proxy/src/main/kotlin/dev/jasonpearson/automobile/ctrlproxy/CtrlProxy.kt
+++ b/android/control-proxy/src/main/kotlin/dev/jasonpearson/automobile/ctrlproxy/CtrlProxy.kt
@@ -2091,6 +2091,16 @@ class CtrlProxy : AccessibilityService(), CtrlProxyActions {
   override fun getPreferences(requestId: String?, packageName: String, fileName: String) =
     handleGetPreferences(requestId, packageName, fileName)
 
+  override fun listDataStores(requestId: String?, packageName: String, adapterName: String) =
+    handleListDataStores(requestId, packageName, adapterName)
+
+  override fun getDataStore(
+    requestId: String?,
+    packageName: String,
+    adapterName: String,
+    storeName: String,
+  ) = handleGetDataStore(requestId, packageName, adapterName, storeName)
+
   override fun subscribeStorage(requestId: String?, packageName: String, fileName: String) =
     handleSubscribeStorage(requestId, packageName, fileName)
 
@@ -6916,6 +6926,42 @@ class CtrlProxy : AccessibilityService(), CtrlProxyActions {
         },
         onFailure = { error ->
           broadcastPreferencesResult(requestId, packageName, fileName, null, error.message)
+        },
+      )
+    }
+  }
+
+  private fun handleListDataStores(requestId: String?, packageName: String, adapterName: String) {
+    asyncActionRunner.launch(requestId, "list_data_stores") {
+      val result = storageSubscriptionManager.listDataStores(packageName, adapterName)
+      result.fold(
+        // DataStore descriptors reuse the SharedPreferences `preference_files` result envelope
+        // (StorageResponse.FileList); the awaiting TS client disambiguates by requestId.
+        onSuccess = { files ->
+          broadcastPreferenceFilesResult(requestId, packageName, files, null)
+        },
+        onFailure = { error ->
+          broadcastPreferenceFilesResult(requestId, packageName, null, error.message)
+        },
+      )
+    }
+  }
+
+  private fun handleGetDataStore(
+    requestId: String?,
+    packageName: String,
+    adapterName: String,
+    storeName: String,
+  ) {
+    asyncActionRunner.launch(requestId, "get_data_store") {
+      val result = storageSubscriptionManager.getDataStore(packageName, adapterName, storeName)
+      result.fold(
+        // Reuses the SharedPreferences `preferences` result envelope; storeName maps to fileName.
+        onSuccess = { entries ->
+          broadcastPreferencesResult(requestId, packageName, storeName, entries, null)
+        },
+        onFailure = { error ->
+          broadcastPreferencesResult(requestId, packageName, storeName, null, error.message)
         },
       )
     }

--- a/android/control-proxy/src/main/kotlin/dev/jasonpearson/automobile/ctrlproxy/CtrlProxyActions.kt
+++ b/android/control-proxy/src/main/kotlin/dev/jasonpearson/automobile/ctrlproxy/CtrlProxyActions.kt
@@ -206,6 +206,15 @@ interface CtrlProxyActions {
 
   fun getPreferences(requestId: String?, packageName: String, fileName: String)
 
+  fun listDataStores(requestId: String?, packageName: String, adapterName: String)
+
+  fun getDataStore(
+    requestId: String?,
+    packageName: String,
+    adapterName: String,
+    storeName: String,
+  )
+
   fun subscribeStorage(requestId: String?, packageName: String, fileName: String)
 
   fun unsubscribeStorage(requestId: String?, packageName: String, fileName: String)

--- a/android/control-proxy/src/main/kotlin/dev/jasonpearson/automobile/ctrlproxy/CtrlProxyMessageHandler.kt
+++ b/android/control-proxy/src/main/kotlin/dev/jasonpearson/automobile/ctrlproxy/CtrlProxyMessageHandler.kt
@@ -5,6 +5,7 @@ import dev.jasonpearson.automobile.protocol.AddHighlight
 import dev.jasonpearson.automobile.protocol.ClearPreferences
 import dev.jasonpearson.automobile.protocol.DragResult
 import dev.jasonpearson.automobile.protocol.GetCurrentFocus
+import dev.jasonpearson.automobile.protocol.GetDataStore
 import dev.jasonpearson.automobile.protocol.GetDeviceOwnerStatus
 import dev.jasonpearson.automobile.protocol.GetPermission
 import dev.jasonpearson.automobile.protocol.GetPreference
@@ -12,6 +13,7 @@ import dev.jasonpearson.automobile.protocol.GetPreferences
 import dev.jasonpearson.automobile.protocol.GetTraversalOrder
 import dev.jasonpearson.automobile.protocol.InstallCaCert
 import dev.jasonpearson.automobile.protocol.InstallCaCertFromPath
+import dev.jasonpearson.automobile.protocol.ListDataStores
 import dev.jasonpearson.automobile.protocol.ListPreferenceFiles
 import dev.jasonpearson.automobile.protocol.NetworkMockRuleDto
 import dev.jasonpearson.automobile.protocol.PinchResult
@@ -345,6 +347,15 @@ class CtrlProxyMessageHandler(
       is ListPreferenceFiles -> actions.listPreferenceFiles(request.requestId, request.packageName)
       is GetPreferences ->
         actions.getPreferences(request.requestId, request.packageName, request.fileName)
+      is ListDataStores ->
+        actions.listDataStores(request.requestId, request.packageName, request.adapterName)
+      is GetDataStore ->
+        actions.getDataStore(
+          request.requestId,
+          request.packageName,
+          request.adapterName,
+          request.storeName,
+        )
       is SubscribeStorage ->
         actions.subscribeStorage(request.requestId, request.packageName, request.fileName)
       is UnsubscribeStorage -> {

--- a/android/control-proxy/src/main/kotlin/dev/jasonpearson/automobile/ctrlproxy/storage/StorageSubscriptionManager.kt
+++ b/android/control-proxy/src/main/kotlin/dev/jasonpearson/automobile/ctrlproxy/storage/StorageSubscriptionManager.kt
@@ -252,6 +252,7 @@ class StorageSubscriptionManager(private val context: Context) {
         }
       }
     } catch (e: SecurityException) {
+      Log.e(TAG, "listDataStores: SecurityException (SDK not installed)", e)
       Result.failure(StorageError.SdkNotInstalled(packageName))
     } catch (e: Exception) {
       Log.e(TAG, "Error listing data stores for $packageName (adapter=$adapterName)", e)

--- a/android/control-proxy/src/main/kotlin/dev/jasonpearson/automobile/ctrlproxy/storage/StorageSubscriptionManager.kt
+++ b/android/control-proxy/src/main/kotlin/dev/jasonpearson/automobile/ctrlproxy/storage/StorageSubscriptionManager.kt
@@ -214,6 +214,109 @@ class StorageSubscriptionManager(private val context: Context) {
   }
 
   /**
+   * Lists the Jetpack DataStore instances exposed by a host-registered adapter (issue #5573).
+   *
+   * DataStore is served through the same storage-inspection ContentProvider as SharedPreferences
+   * (authority [AUTHORITY_SUFFIX]); the provider routes the `listDataStores` method to the
+   * host-registered adapter and returns descriptors in the shared [StorageResponse.FileList] shape
+   * (path emitted empty — no filesystem path is exposed for DataStore).
+   *
+   * @param packageName The target app package name
+   * @param adapterName The stable name the host registered its DataStore adapter under
+   * @return Result with list of DataStore descriptors (as [PreferenceFileInfo]) or error
+   */
+  fun listDataStores(packageName: String, adapterName: String): Result<List<PreferenceFileInfo>> {
+    return try {
+      val authority = packageName + AUTHORITY_SUFFIX
+      val uri = Uri.parse("content://$authority")
+      val extras = Bundle().apply { putString("adapterName", adapterName) }
+      val result = context.contentResolver.call(uri, "listDataStores", null, extras)
+
+      if (result == null) {
+        Result.failure(StorageError.SdkNotInstalled(packageName))
+      } else if (!result.getBoolean("success", false)) {
+        val error = result.getString("error") ?: "Unknown error"
+        Result.failure(StorageError.SdkError(error))
+      } else {
+        val responseJson = result.getString("result") ?: "{}"
+        val response = StorageProtocolSerializer.responseFromJson(responseJson)
+        when (response) {
+          is StorageResponse.FileList -> {
+            val files =
+              response.files.map { file ->
+                PreferenceFileInfo(name = file.name, path = file.path, entryCount = file.entryCount)
+              }
+            Result.success(files)
+          }
+          else -> Result.failure(StorageError.SdkError("Unexpected response type"))
+        }
+      }
+    } catch (e: SecurityException) {
+      Result.failure(StorageError.SdkNotInstalled(packageName))
+    } catch (e: Exception) {
+      Log.e(TAG, "Error listing data stores for $packageName (adapter=$adapterName)", e)
+      Result.failure(StorageError.SdkError(e.message ?: "Unknown error"))
+    }
+  }
+
+  /**
+   * Reads all entries from a named DataStore instance (issue #5573).
+   *
+   * Reuses the shared [StorageResponse.Preferences] response shape.
+   *
+   * @param packageName The target app package name
+   * @param adapterName The stable name the host registered its DataStore adapter under
+   * @param storeName The DataStore instance name
+   * @return Result with list of entries (as [PreferenceEntry]) or error
+   */
+  fun getDataStore(
+    packageName: String,
+    adapterName: String,
+    storeName: String,
+  ): Result<List<PreferenceEntry>> {
+    return try {
+      val authority = packageName + AUTHORITY_SUFFIX
+      val uri = Uri.parse("content://$authority")
+      val extras =
+        Bundle().apply {
+          putString("adapterName", adapterName)
+          putString("storeName", storeName)
+        }
+      val result = context.contentResolver.call(uri, "getDataStore", null, extras)
+
+      if (result == null) {
+        Result.failure(StorageError.SdkNotInstalled(packageName))
+      } else if (!result.getBoolean("success", false)) {
+        val error = result.getString("error") ?: "Unknown error"
+        val errorType = result.getString("errorType")
+        if (errorType == "StoreNotFound") {
+          Result.failure(StorageError.FileNotFound(storeName))
+        } else {
+          Result.failure(StorageError.SdkError(error))
+        }
+      } else {
+        val responseJson = result.getString("result") ?: "{}"
+        val response = StorageProtocolSerializer.responseFromJson(responseJson)
+        when (response) {
+          is StorageResponse.Preferences -> {
+            val entries =
+              response.entries.map { entry ->
+                PreferenceEntry(key = entry.key, value = entry.value, type = entry.type)
+              }
+            Result.success(entries)
+          }
+          else -> Result.failure(StorageError.SdkError("Unexpected response type"))
+        }
+      }
+    } catch (e: SecurityException) {
+      Result.failure(StorageError.SdkNotInstalled(packageName))
+    } catch (e: Exception) {
+      Log.e(TAG, "Error getting data store for $packageName:$storeName (adapter=$adapterName)", e)
+      Result.failure(StorageError.SdkError(e.message ?: "Unknown error"))
+    }
+  }
+
+  /**
    * Subscribes to changes on a SharedPreferences file.
    *
    * @param packageName The target app package name

--- a/android/control-proxy/src/test/kotlin/dev/jasonpearson/automobile/ctrlproxy/CtrlProxyActionsFakes.kt
+++ b/android/control-proxy/src/test/kotlin/dev/jasonpearson/automobile/ctrlproxy/CtrlProxyActionsFakes.kt
@@ -142,6 +142,15 @@ open class NoOpCtrlProxyActions : CtrlProxyActions {
 
   override fun getPreferences(requestId: String?, packageName: String, fileName: String) {}
 
+  override fun listDataStores(requestId: String?, packageName: String, adapterName: String) {}
+
+  override fun getDataStore(
+    requestId: String?,
+    packageName: String,
+    adapterName: String,
+    storeName: String,
+  ) {}
+
   override fun subscribeStorage(requestId: String?, packageName: String, fileName: String) {}
 
   override fun unsubscribeStorage(requestId: String?, packageName: String, fileName: String) {}
@@ -403,6 +412,16 @@ class RecordingCtrlProxyActions : CtrlProxyActions {
 
   override fun getPreferences(requestId: String?, packageName: String, fileName: String) =
     record("getPreferences", requestId, packageName, fileName)
+
+  override fun listDataStores(requestId: String?, packageName: String, adapterName: String) =
+    record("listDataStores", requestId, packageName, adapterName)
+
+  override fun getDataStore(
+    requestId: String?,
+    packageName: String,
+    adapterName: String,
+    storeName: String,
+  ) = record("getDataStore", requestId, packageName, adapterName, storeName)
 
   override fun subscribeStorage(requestId: String?, packageName: String, fileName: String) =
     record("subscribeStorage", requestId, packageName, fileName)

--- a/android/control-proxy/src/test/kotlin/dev/jasonpearson/automobile/ctrlproxy/CtrlProxyMessageHandlerTest.kt
+++ b/android/control-proxy/src/test/kotlin/dev/jasonpearson/automobile/ctrlproxy/CtrlProxyMessageHandlerTest.kt
@@ -685,6 +685,25 @@ class CtrlProxyMessageHandlerTest {
   }
 
   @Test
+  fun `dispatches list_data_stores`() = runTest {
+    dispatch(
+      """{"type":"list_data_stores","requestId":"lds1","packageName":"com.example","adapterName":"settings"}"""
+    )
+    assertEquals("listDataStores" to listOf<Any?>("lds1", "com.example", "settings"), lastCall)
+  }
+
+  @Test
+  fun `dispatches get_data_store`() = runTest {
+    dispatch(
+      """{"type":"get_data_store","requestId":"gds1","packageName":"com.example","adapterName":"settings","storeName":"user_prefs"}"""
+    )
+    assertEquals(
+      "getDataStore" to listOf<Any?>("gds1", "com.example", "settings", "user_prefs"),
+      lastCall,
+    )
+  }
+
+  @Test
   fun `dispatches subscribe_storage`() = runTest {
     dispatch(
       """{"type":"subscribe_storage","requestId":"sub1","packageName":"com.example","fileName":"settings.xml"}"""

--- a/android/control-proxy/src/test/kotlin/dev/jasonpearson/automobile/ctrlproxy/storage/StorageSubscriptionManagerTest.kt
+++ b/android/control-proxy/src/test/kotlin/dev/jasonpearson/automobile/ctrlproxy/storage/StorageSubscriptionManagerTest.kt
@@ -6,6 +6,7 @@ import android.net.Uri
 import android.os.Bundle
 import io.mockk.every
 import io.mockk.mockk
+import io.mockk.slot
 import io.mockk.verify
 import org.junit.Assert.assertEquals
 import org.junit.Assert.assertFalse
@@ -151,6 +152,87 @@ class StorageSubscriptionManagerTest {
     every { contentResolver.call(any<Uri>(), eq("getPreferences"), any(), any()) } returns bundle
 
     val result = manager.getPreferences("com.example.app", "nonexistent")
+
+    assertTrue(result.isFailure)
+    assertTrue(result.exceptionOrNull() is StorageError.FileNotFound)
+  }
+
+  // ================= DataStore Tests =================
+
+  @Test
+  fun `listDataStores returns descriptors and passes adapterName`() {
+    val bundle =
+      Bundle().apply {
+        putBoolean("success", true)
+        // DataStore descriptors reuse the shared FileList shape (path emitted empty).
+        putString(
+          "result",
+          """{"type":"files","files":[{"name":"user_prefs","path":"","entryCount":2}]}""",
+        )
+      }
+    val extrasSlot = slot<Bundle>()
+    every {
+      contentResolver.call(any<Uri>(), eq("listDataStores"), any(), capture(extrasSlot))
+    } returns bundle
+
+    val result = manager.listDataStores("com.example.app", "settings")
+
+    assertTrue(result.isSuccess)
+    val files = result.getOrNull()!!
+    assertEquals(1, files.size)
+    assertEquals("user_prefs", files[0].name)
+    assertEquals(2, files[0].entryCount)
+    assertEquals("settings", extrasSlot.captured.getString("adapterName"))
+  }
+
+  @Test
+  fun `listDataStores returns failure when SDK not installed`() {
+    every { contentResolver.call(any<Uri>(), eq("listDataStores"), any(), any()) } returns null
+
+    val result = manager.listDataStores("com.example.app", "settings")
+
+    assertTrue(result.isFailure)
+    assertTrue(result.exceptionOrNull() is StorageError.SdkNotInstalled)
+  }
+
+  @Test
+  fun `getDataStore returns entries and passes adapterName and storeName`() {
+    val bundle =
+      Bundle().apply {
+        putBoolean("success", true)
+        putString(
+          "result",
+          """{"type":"preferences","entries":[{"key":"theme","value":"dark","type":"STRING"}]}""",
+        )
+      }
+    val extrasSlot = slot<Bundle>()
+    every {
+      contentResolver.call(any<Uri>(), eq("getDataStore"), any(), capture(extrasSlot))
+    } returns bundle
+
+    val result = manager.getDataStore("com.example.app", "settings", "user_prefs")
+
+    assertTrue(result.isSuccess)
+    val entries = result.getOrNull()!!
+    assertEquals(1, entries.size)
+    assertEquals("theme", entries[0].key)
+    assertEquals("dark", entries[0].value)
+    assertEquals("STRING", entries[0].type)
+    assertEquals("settings", extrasSlot.captured.getString("adapterName"))
+    assertEquals("user_prefs", extrasSlot.captured.getString("storeName"))
+  }
+
+  @Test
+  fun `getDataStore maps StoreNotFound to FileNotFound`() {
+    val bundle =
+      Bundle().apply {
+        putBoolean("success", false)
+        putString("errorType", "StoreNotFound")
+        putString("error", "Store not found")
+      }
+    every { contentResolver.call(any<Uri>(), eq("getDataStore"), any(), any()) } returns bundle
+
+    val result = manager.getDataStore("com.example.app", "settings", "missing")
 
     assertTrue(result.isFailure)
     assertTrue(result.exceptionOrNull() is StorageError.FileNotFound)

--- a/android/protocol/src/main/kotlin/dev/jasonpearson/automobile/protocol/WebSocketRequest.kt
+++ b/android/protocol/src/main/kotlin/dev/jasonpearson/automobile/protocol/WebSocketRequest.kt
@@ -382,6 +382,29 @@ data class GetPreferences(
   val fileName: String,
 ) : WebSocketRequest()
 
+/**
+ * Lists the Jetpack DataStore instances exposed by a host-registered adapter (issue #5192/#5573).
+ * DataStore descriptors reuse the SharedPreferences result shapes (StorageResponse.FileList, empty
+ * path); only the request type is distinct so the device can route to the DataStore adapter.
+ */
+@Serializable
+@SerialName("list_data_stores")
+data class ListDataStores(
+  override val requestId: String? = null,
+  val packageName: String,
+  val adapterName: String,
+) : WebSocketRequest()
+
+/** Reads all entries from a named DataStore instance (issue #5192/#5573). */
+@Serializable
+@SerialName("get_data_store")
+data class GetDataStore(
+  override val requestId: String? = null,
+  val packageName: String,
+  val adapterName: String,
+  val storeName: String,
+) : WebSocketRequest()
+
 @Serializable
 @SerialName("subscribe_storage")
 data class SubscribeStorage(

--- a/android/protocol/src/test/kotlin/dev/jasonpearson/automobile/protocol/WebSocketRequestTest.kt
+++ b/android/protocol/src/test/kotlin/dev/jasonpearson/automobile/protocol/WebSocketRequestTest.kt
@@ -300,6 +300,31 @@ class WebSocketRequestTest {
   }
 
   @Test
+  fun `deserialize list_data_stores`() {
+    val message =
+      """{"type":"list_data_stores","requestId":"lds-1","packageName":"com.example.app","adapterName":"settings"}"""
+    val request = json.decodeFromString<WebSocketRequest>(message)
+
+    assertIs<ListDataStores>(request)
+    assertEquals("lds-1", request.requestId)
+    assertEquals("com.example.app", request.packageName)
+    assertEquals("settings", request.adapterName)
+  }
+
+  @Test
+  fun `deserialize get_data_store`() {
+    val message =
+      """{"type":"get_data_store","requestId":"gds-1","packageName":"com.example.app","adapterName":"settings","storeName":"user_prefs"}"""
+    val request = json.decodeFromString<WebSocketRequest>(message)
+
+    assertIs<GetDataStore>(request)
+    assertEquals("gds-1", request.requestId)
+    assertEquals("com.example.app", request.packageName)
+    assertEquals("settings", request.adapterName)
+    assertEquals("user_prefs", request.storeName)
+  }
+
+  @Test
   fun `deserialize request_settings_get`() {
     val message =
       """{"type":"request_settings_get","requestId":"sg-1","namespace":"system","key":"user_rotation"}"""

--- a/schemas/tool-definitions.json
+++ b/schemas/tool-definitions.json
@@ -1727,6 +1727,51 @@
     }
   },
   {
+    "name": "getDataStore",
+    "description": "Read entries from an app Jetpack DataStore instance (Android, requires AutoMobile SDK adapter).",
+    "inputSchema": {
+      "$schema": "https://json-schema.org/draft/2020-12/schema",
+      "type": "object",
+      "properties": {
+        "appId": {
+          "type": "string"
+        },
+        "adapterName": {
+          "description": "Name the host app registered its DataStore adapter under (AutoMobile SDK)",
+          "type": "string"
+        },
+        "name": {
+          "description": "DataStore instance name",
+          "type": "string"
+        },
+        "platform": {
+          "type": "string",
+          "enum": [
+            "android",
+            "ios"
+          ]
+        },
+        "sessionUuid": {
+          "description": "Session",
+          "type": "string"
+        },
+        "keepScreenAwake": {
+          "type": "boolean"
+        },
+        "device": {
+          "description": "Device label",
+          "type": "string"
+        }
+      },
+      "required": [
+        "appId",
+        "adapterName",
+        "name"
+      ],
+      "additionalProperties": false
+    }
+  },
+  {
     "name": "getDeepLinks",
     "description": "Query app deep links",
     "inputSchema": {
@@ -3029,6 +3074,46 @@
       "type": "object",
       "properties": {},
       "additionalProperties": {}
+    }
+  },
+  {
+    "name": "listDataStores",
+    "description": "List app Jetpack DataStore instances (Android, requires AutoMobile SDK adapter).",
+    "inputSchema": {
+      "$schema": "https://json-schema.org/draft/2020-12/schema",
+      "type": "object",
+      "properties": {
+        "appId": {
+          "type": "string"
+        },
+        "adapterName": {
+          "description": "Name the host app registered its DataStore adapter under (AutoMobile SDK)",
+          "type": "string"
+        },
+        "platform": {
+          "type": "string",
+          "enum": [
+            "android",
+            "ios"
+          ]
+        },
+        "sessionUuid": {
+          "description": "Session",
+          "type": "string"
+        },
+        "keepScreenAwake": {
+          "type": "boolean"
+        },
+        "device": {
+          "description": "Device label",
+          "type": "string"
+        }
+      },
+      "required": [
+        "appId",
+        "adapterName"
+      ],
+      "additionalProperties": false
     }
   },
   {

--- a/scripts/typecheck-baseline.txt
+++ b/scripts/typecheck-baseline.txt
@@ -186,6 +186,7 @@ src/utils/ios-cmdline-tools/XcodeSigning.ts: error TS2322: Type 'Promise<string 
 # swap-fp: 11 :: src/features/observe/audits/AccessibilityAuditor.ts: error TS2741: Property '$' is missing in type 'Hierarchy' but required in type 'ViewHierarchyNode'.
 # swap-fp: 11 :: src/features/record/android/DualTrackRecorder.ts: error TS2322: Type 'A11ySource | AndroidCtrlProxyClient' is not assignable to type 'A11ySource'.
 # swap-fp: 11,11 :: src/daemon/testRecordingSocketServer.ts: error TS2322: Type 'string' is not assignable to type 'Platform | undefined'.
+# swap-fp: 11,13,13 :: src/features/observe/android/AndroidCtrlProxyClient.ts: error TS2322: Type 'number | undefined' is not assignable to type 'number'.
 # swap-fp: 11,53,57,65 :: src/features/navigation/Explore.ts: error TS2740: Type 'AdbExecutor' is missing the following properties from type 'AdbClient': device, execAsync, spawnFn, adbPath, and 30 more.
 # swap-fp: 12,12 :: src/db/migrations/2026_01_27_000_failures.ts: error TS2345: Argument of type 'string' is not assignable to parameter of type 'ReferenceExpression<unknown, never>'.
 # swap-fp: 12,12 :: src/db/migrations/2026_03_15_000_telemetry_events.ts: error TS2345: Argument of type 'string' is not assignable to parameter of type 'ReferenceExpression<unknown, never>'.
@@ -193,7 +194,6 @@ src/utils/ios-cmdline-tools/XcodeSigning.ts: error TS2322: Type 'Promise<string 
 # swap-fp: 13 :: src/db/migrations/2026_01_27_000_failures.ts: error TS2769: No overload matches this call.
 # swap-fp: 13 :: src/db/migrations/2026_03_15_000_telemetry_events.ts: error TS2769: No overload matches this call.
 # swap-fp: 13 :: src/features/observe/android/AndroidCtrlProxyClient.ts: error TS2322: Type '(Element | null)[]' is not assignable to type 'Element[]'.
-# swap-fp: 13,13,27 :: src/features/observe/android/AndroidCtrlProxyClient.ts: error TS2322: Type 'number | undefined' is not assignable to type 'number'.
 # swap-fp: 14 :: src/features/accessibility/WcagAudit.ts: error TS2352: Conversion of type 'ViewHierarchyNode[]' to type 'ViewHierarchyNode' may be a mistake because neither type sufficiently overlaps with the other. If this was intentional, convert the expression to 'unknown' first.
 # swap-fp: 149 :: src/server/navigationTools.ts: error TS2339: Property 'coverage' does not exist on type 'ExploreExecutionResult'.
 # swap-fp: 15 :: src/server/networkTools.ts: error TS2459: Module '"../utils/deviceUtils"' declares 'BootedDevice' locally, but it is not exported.

--- a/src/features/observe/android/AndroidCtrlProxyClient.ts
+++ b/src/features/observe/android/AndroidCtrlProxyClient.ts
@@ -2070,6 +2070,23 @@ export class AndroidCtrlProxyClient extends DeviceServiceClient implements Andro
     return this.storage.getPreferenceEntries(packageName, fileName, timeoutMs);
   }
 
+  async listDataStores(
+    packageName: string,
+    adapterName: string,
+    timeoutMs?: number,
+  ): Promise<PreferenceFile[]> {
+    return this.storage.listDataStores(packageName, adapterName, timeoutMs);
+  }
+
+  async getDataStore(
+    packageName: string,
+    adapterName: string,
+    storeName: string,
+    timeoutMs?: number,
+  ): Promise<KeyValueEntry[]> {
+    return this.storage.getDataStore(packageName, adapterName, storeName, timeoutMs);
+  }
+
   async getPreference(
     packageName: string,
     fileName: string,
@@ -4186,7 +4203,10 @@ export class AndroidCtrlProxyClient extends DeviceServiceClient implements Andro
     // past teardown (#5493). A transient websocket disconnect does not set this flag,
     // so the fallback still fires during reconnect windows.
     if (this.closed) {
-      return { success: false, error: "AndroidCtrlProxyClient closed; ADB screencap fallback suppressed" };
+      return {
+        success: false,
+        error: "AndroidCtrlProxyClient closed; ADB screencap fallback suppressed",
+      };
     }
 
     // Bind the geometry current when the ADB request begins, before its await can let a newer

--- a/src/features/observe/android/CtrlProxyStorage.ts
+++ b/src/features/observe/android/CtrlProxyStorage.ts
@@ -49,7 +49,7 @@ export class CtrlProxyStorage {
    */
   async listPreferenceFiles(
     packageName: string,
-    timeoutMs: number = 5000
+    timeoutMs: number = 5000,
   ): Promise<PreferenceFile[]> {
     const startTime = this.context.timer.now();
 
@@ -57,7 +57,9 @@ export class CtrlProxyStorage {
       // Ensure WebSocket connection is established
       const connected = await this.context.ensureConnected();
       if (!connected) {
-        logger.warn("[CTRL_PROXY] Failed to establish WebSocket connection for listPreferenceFiles");
+        logger.warn(
+          "[CTRL_PROXY] Failed to establish WebSocket connection for listPreferenceFiles",
+        );
         throw new Error("Failed to connect to accessibility service");
       }
 
@@ -71,8 +73,8 @@ export class CtrlProxyStorage {
         (_id, _type, _timeout) => ({
           success: false,
           totalTimeMs: this.context.timer.now() - startTime,
-          error: `List preference files timeout after ${timeoutMs}ms`
-        })
+          error: `List preference files timeout after ${timeoutMs}ms`,
+        }),
       );
 
       // Send the request
@@ -81,9 +83,11 @@ export class CtrlProxyStorage {
         throw new Error("WebSocket not connected");
       }
       const message = serializeCtrlProxyRequest(
-        ctrlProxyRequests.listPreferenceFiles({ requestId, packageName })
+        ctrlProxyRequests.listPreferenceFiles({ requestId, packageName }),
       );
-      logger.info(`[CTRL_PROXY] Sending list_preference_files request (requestId: ${requestId}, packageName: ${packageName}, wsReadyState: ${ws.readyState})`);
+      logger.info(
+        `[CTRL_PROXY] Sending list_preference_files request (requestId: ${requestId}, packageName: ${packageName}, wsReadyState: ${ws.readyState})`,
+      );
       ws.send(message);
       logger.info(`[CTRL_PROXY] Sent list_preference_files request successfully`);
 
@@ -113,7 +117,7 @@ export class CtrlProxyStorage {
   async getPreferenceEntries(
     packageName: string,
     fileName: string,
-    timeoutMs: number = 5000
+    timeoutMs: number = 5000,
   ): Promise<KeyValueEntry[]> {
     const startTime = this.context.timer.now();
 
@@ -121,7 +125,9 @@ export class CtrlProxyStorage {
       // Ensure WebSocket connection is established
       const connected = await this.context.ensureConnected();
       if (!connected) {
-        logger.warn("[CTRL_PROXY] Failed to establish WebSocket connection for getPreferenceEntries");
+        logger.warn(
+          "[CTRL_PROXY] Failed to establish WebSocket connection for getPreferenceEntries",
+        );
         throw new Error("Failed to connect to accessibility service");
       }
 
@@ -135,8 +141,8 @@ export class CtrlProxyStorage {
         (_id, _type, _timeout) => ({
           success: false,
           totalTimeMs: this.context.timer.now() - startTime,
-          error: `Get preferences timeout after ${timeoutMs}ms`
-        })
+          error: `Get preferences timeout after ${timeoutMs}ms`,
+        }),
       );
 
       // Send the request
@@ -145,10 +151,12 @@ export class CtrlProxyStorage {
         throw new Error("WebSocket not connected");
       }
       const message = serializeCtrlProxyRequest(
-        ctrlProxyRequests.getPreferences({ requestId, packageName, fileName })
+        ctrlProxyRequests.getPreferences({ requestId, packageName, fileName }),
       );
       ws.send(message);
-      logger.debug(`[CTRL_PROXY] Sent get_preferences request (requestId: ${requestId}, packageName: ${packageName}, fileName: ${fileName})`);
+      logger.debug(
+        `[CTRL_PROXY] Sent get_preferences request (requestId: ${requestId}, packageName: ${packageName}, fileName: ${fileName})`,
+      );
 
       // Wait for response
       const result = await resultPromise;
@@ -166,6 +174,137 @@ export class CtrlProxyStorage {
   }
 
   /**
+   * List the Jetpack DataStore instances exposed by a host-registered adapter (issue #5573).
+   *
+   * DataStore descriptors reuse the SharedPreferences `preference_files` result envelope on the
+   * wire (`StorageResponse.FileList`, path emitted empty), so the device sends the same
+   * `preference_files` message type — disambiguated by `requestId`.
+   *
+   * @param packageName - The package name of the app to inspect
+   * @param adapterName - The stable name the host registered its DataStore adapter under
+   * @param timeoutMs - Maximum time to wait for response in milliseconds
+   * @returns Promise resolving to array of DataStore descriptors
+   */
+  async listDataStores(
+    packageName: string,
+    adapterName: string,
+    timeoutMs: number = 5000,
+  ): Promise<PreferenceFile[]> {
+    const startTime = this.context.timer.now();
+
+    try {
+      const connected = await this.context.ensureConnected();
+      if (!connected) {
+        logger.warn("[CTRL_PROXY] Failed to establish WebSocket connection for listDataStores");
+        throw new Error("Failed to connect to accessibility service");
+      }
+
+      const requestId = `list_data_stores_${this.context.timer.now()}_${generateSecureId()}`;
+
+      const resultPromise = this.context.requestManager.register<ListPreferenceFilesResult>(
+        requestId,
+        "list_data_stores",
+        timeoutMs,
+        (_id, _type, _timeout) => ({
+          success: false,
+          totalTimeMs: this.context.timer.now() - startTime,
+          error: `List data stores timeout after ${timeoutMs}ms`,
+        }),
+      );
+
+      const ws = this.context.getWebSocket();
+      if (!ws || ws.readyState !== WebSocket.OPEN) {
+        throw new Error("WebSocket not connected");
+      }
+      const message = serializeCtrlProxyRequest(
+        ctrlProxyRequests.listDataStores({ requestId, packageName, adapterName }),
+      );
+      ws.send(message);
+      logger.debug(
+        `[CTRL_PROXY] Sent list_data_stores request (requestId: ${requestId}, packageName: ${packageName}, adapterName: ${adapterName})`,
+      );
+
+      const result = await resultPromise;
+
+      if (!result.success) {
+        throw new Error(result.error || "Failed to list data stores");
+      }
+
+      return result.files || [];
+    } catch (error) {
+      const duration = this.context.timer.now() - startTime;
+      logger.warn(`[CTRL_PROXY] listDataStores failed after ${duration}ms: ${error}`);
+      throw error;
+    }
+  }
+
+  /**
+   * Read all key-value entries from a named DataStore instance (issue #5573).
+   *
+   * Reuses the SharedPreferences `preferences` result envelope on the wire
+   * (`StorageResponse.Preferences`), disambiguated by `requestId`.
+   *
+   * @param packageName - The package name of the app
+   * @param adapterName - The stable name the host registered its DataStore adapter under
+   * @param storeName - Name of the DataStore instance
+   * @param timeoutMs - Maximum time to wait for response in milliseconds
+   * @returns Promise resolving to array of key-value entries
+   */
+  async getDataStore(
+    packageName: string,
+    adapterName: string,
+    storeName: string,
+    timeoutMs: number = 5000,
+  ): Promise<KeyValueEntry[]> {
+    const startTime = this.context.timer.now();
+
+    try {
+      const connected = await this.context.ensureConnected();
+      if (!connected) {
+        logger.warn("[CTRL_PROXY] Failed to establish WebSocket connection for getDataStore");
+        throw new Error("Failed to connect to accessibility service");
+      }
+
+      const requestId = `get_data_store_${this.context.timer.now()}_${generateSecureId()}`;
+
+      const resultPromise = this.context.requestManager.register<GetPreferencesResult>(
+        requestId,
+        "get_data_store",
+        timeoutMs,
+        (_id, _type, _timeout) => ({
+          success: false,
+          totalTimeMs: this.context.timer.now() - startTime,
+          error: `Get data store timeout after ${timeoutMs}ms`,
+        }),
+      );
+
+      const ws = this.context.getWebSocket();
+      if (!ws || ws.readyState !== WebSocket.OPEN) {
+        throw new Error("WebSocket not connected");
+      }
+      const message = serializeCtrlProxyRequest(
+        ctrlProxyRequests.getDataStore({ requestId, packageName, adapterName, storeName }),
+      );
+      ws.send(message);
+      logger.debug(
+        `[CTRL_PROXY] Sent get_data_store request (requestId: ${requestId}, packageName: ${packageName}, adapterName: ${adapterName}, storeName: ${storeName})`,
+      );
+
+      const result = await resultPromise;
+
+      if (!result.success) {
+        throw new Error(result.error || "Failed to get data store entries");
+      }
+
+      return result.entries || [];
+    } catch (error) {
+      const duration = this.context.timer.now() - startTime;
+      logger.warn(`[CTRL_PROXY] getDataStore failed after ${duration}ms: ${error}`);
+      throw error;
+    }
+  }
+
+  /**
    * Subscribe to storage changes for a preference file.
    * Returns a subscription that can be used to unsubscribe later.
    *
@@ -177,7 +316,7 @@ export class CtrlProxyStorage {
   async subscribeStorage(
     packageName: string,
     fileName: string,
-    timeoutMs: number = 5000
+    timeoutMs: number = 5000,
   ): Promise<StorageSubscription> {
     const startTime = this.context.timer.now();
 
@@ -199,8 +338,8 @@ export class CtrlProxyStorage {
         (_id, _type, _timeout) => ({
           success: false,
           totalTimeMs: this.context.timer.now() - startTime,
-          error: `Subscribe storage timeout after ${timeoutMs}ms`
-        })
+          error: `Subscribe storage timeout after ${timeoutMs}ms`,
+        }),
       );
 
       // Send the request
@@ -209,10 +348,12 @@ export class CtrlProxyStorage {
         throw new Error("WebSocket not connected");
       }
       const message = serializeCtrlProxyRequest(
-        ctrlProxyRequests.subscribeStorage({ requestId, packageName, fileName })
+        ctrlProxyRequests.subscribeStorage({ requestId, packageName, fileName }),
       );
       ws.send(message);
-      logger.debug(`[CTRL_PROXY] Sent subscribe_storage request (requestId: ${requestId}, packageName: ${packageName}, fileName: ${fileName})`);
+      logger.debug(
+        `[CTRL_PROXY] Sent subscribe_storage request (requestId: ${requestId}, packageName: ${packageName}, fileName: ${fileName})`,
+      );
 
       // Wait for response
       const result = await resultPromise;
@@ -221,7 +362,9 @@ export class CtrlProxyStorage {
         throw new Error(result.error || "Failed to subscribe to storage");
       }
 
-      logger.info(`[CTRL_PROXY] Subscribed to storage changes: ${packageName}/${fileName} (subscriptionId: ${result.subscription.subscriptionId})`);
+      logger.info(
+        `[CTRL_PROXY] Subscribed to storage changes: ${packageName}/${fileName} (subscriptionId: ${result.subscription.subscriptionId})`,
+      );
       return result.subscription;
     } catch (error) {
       const duration = this.context.timer.now() - startTime;
@@ -236,10 +379,7 @@ export class CtrlProxyStorage {
    * @param subscriptionId - The subscription ID returned from subscribeStorage
    * @param timeoutMs - Maximum time to wait for response in milliseconds
    */
-  async unsubscribeStorage(
-    subscriptionId: string,
-    timeoutMs: number = 5000
-  ): Promise<void> {
+  async unsubscribeStorage(subscriptionId: string, timeoutMs: number = 5000): Promise<void> {
     const startTime = this.context.timer.now();
 
     try {
@@ -260,8 +400,8 @@ export class CtrlProxyStorage {
         (_id, _type, _timeout) => ({
           success: false,
           totalTimeMs: this.context.timer.now() - startTime,
-          error: `Unsubscribe storage timeout after ${timeoutMs}ms`
-        })
+          error: `Unsubscribe storage timeout after ${timeoutMs}ms`,
+        }),
       );
 
       // Send the request
@@ -273,10 +413,12 @@ export class CtrlProxyStorage {
       // currently no-ops on device and the request times out. Typed accurately in
       // ctrlProxyProtocol (UnsubscribeStorageMessage); fixing the payload is a device-side follow-up.
       const message = serializeCtrlProxyRequest(
-        ctrlProxyRequests.unsubscribeStorage({ requestId, subscriptionId })
+        ctrlProxyRequests.unsubscribeStorage({ requestId, subscriptionId }),
       );
       ws.send(message);
-      logger.debug(`[CTRL_PROXY] Sent unsubscribe_storage request (requestId: ${requestId}, subscriptionId: ${subscriptionId})`);
+      logger.debug(
+        `[CTRL_PROXY] Sent unsubscribe_storage request (requestId: ${requestId}, subscriptionId: ${subscriptionId})`,
+      );
 
       // Wait for response
       const result = await resultPromise;
@@ -285,7 +427,9 @@ export class CtrlProxyStorage {
         throw new Error(result.error || "Failed to unsubscribe from storage");
       }
 
-      logger.info(`[CTRL_PROXY] Unsubscribed from storage changes (subscriptionId: ${subscriptionId})`);
+      logger.info(
+        `[CTRL_PROXY] Unsubscribed from storage changes (subscriptionId: ${subscriptionId})`,
+      );
     } catch (error) {
       const duration = this.context.timer.now() - startTime;
       logger.warn(`[CTRL_PROXY] unsubscribeStorage failed after ${duration}ms: ${error}`);
@@ -334,7 +478,7 @@ export class CtrlProxyStorage {
     packageName: string,
     fileName: string,
     key: string,
-    timeoutMs: number = 5000
+    timeoutMs: number = 5000,
   ): Promise<KeyValueEntry | null> {
     const startTime = this.context.timer.now();
 
@@ -357,8 +501,8 @@ export class CtrlProxyStorage {
           success: false,
           found: false,
           totalTimeMs: this.context.timer.now() - startTime,
-          error: `Get preference timeout after ${timeoutMs}ms`
-        })
+          error: `Get preference timeout after ${timeoutMs}ms`,
+        }),
       );
 
       // Send the request
@@ -367,10 +511,12 @@ export class CtrlProxyStorage {
         throw new Error("WebSocket not connected");
       }
       const message = serializeCtrlProxyRequest(
-        ctrlProxyRequests.getPreference({ requestId, packageName, fileName, key })
+        ctrlProxyRequests.getPreference({ requestId, packageName, fileName, key }),
       );
       ws.send(message);
-      logger.debug(`[CTRL_PROXY] Sent get_preference request (requestId: ${requestId}, packageName: ${packageName}, fileName: ${fileName}, key: ${key})`);
+      logger.debug(
+        `[CTRL_PROXY] Sent get_preference request (requestId: ${requestId}, packageName: ${packageName}, fileName: ${fileName}, key: ${key})`,
+      );
 
       // Wait for response
       const result = await resultPromise;
@@ -403,7 +549,7 @@ export class CtrlProxyStorage {
     key: string,
     value: string | null,
     type: KeyValueType,
-    timeoutMs: number = 5000
+    timeoutMs: number = 5000,
   ): Promise<void> {
     const startTime = this.context.timer.now();
 
@@ -425,8 +571,8 @@ export class CtrlProxyStorage {
         (_id, _type, _timeout) => ({
           success: false,
           totalTimeMs: this.context.timer.now() - startTime,
-          error: `Set preference timeout after ${timeoutMs}ms`
-        })
+          error: `Set preference timeout after ${timeoutMs}ms`,
+        }),
       );
 
       // Send the request
@@ -435,10 +581,19 @@ export class CtrlProxyStorage {
         throw new Error("WebSocket not connected");
       }
       const message = serializeCtrlProxyRequest(
-        ctrlProxyRequests.setPreference({ requestId, packageName, fileName, key, value, valueType: type })
+        ctrlProxyRequests.setPreference({
+          requestId,
+          packageName,
+          fileName,
+          key,
+          value,
+          valueType: type,
+        }),
       );
       ws.send(message);
-      logger.debug(`[CTRL_PROXY] Sent set_preference request (requestId: ${requestId}, packageName: ${packageName}, fileName: ${fileName}, key: ${key})`);
+      logger.debug(
+        `[CTRL_PROXY] Sent set_preference request (requestId: ${requestId}, packageName: ${packageName}, fileName: ${fileName}, key: ${key})`,
+      );
 
       // Wait for response
       const result = await resultPromise;
@@ -467,7 +622,7 @@ export class CtrlProxyStorage {
     packageName: string,
     fileName: string,
     key: string,
-    timeoutMs: number = 5000
+    timeoutMs: number = 5000,
   ): Promise<void> {
     const startTime = this.context.timer.now();
 
@@ -489,8 +644,8 @@ export class CtrlProxyStorage {
         (_id, _type, _timeout) => ({
           success: false,
           totalTimeMs: this.context.timer.now() - startTime,
-          error: `Remove preference timeout after ${timeoutMs}ms`
-        })
+          error: `Remove preference timeout after ${timeoutMs}ms`,
+        }),
       );
 
       // Send the request
@@ -499,10 +654,12 @@ export class CtrlProxyStorage {
         throw new Error("WebSocket not connected");
       }
       const message = serializeCtrlProxyRequest(
-        ctrlProxyRequests.removePreference({ requestId, packageName, fileName, key })
+        ctrlProxyRequests.removePreference({ requestId, packageName, fileName, key }),
       );
       ws.send(message);
-      logger.debug(`[CTRL_PROXY] Sent remove_preference request (requestId: ${requestId}, packageName: ${packageName}, fileName: ${fileName}, key: ${key})`);
+      logger.debug(
+        `[CTRL_PROXY] Sent remove_preference request (requestId: ${requestId}, packageName: ${packageName}, fileName: ${fileName}, key: ${key})`,
+      );
 
       // Wait for response
       const result = await resultPromise;
@@ -529,7 +686,7 @@ export class CtrlProxyStorage {
   async clearPreferenceStore(
     packageName: string,
     fileName: string,
-    timeoutMs: number = 5000
+    timeoutMs: number = 5000,
   ): Promise<void> {
     const startTime = this.context.timer.now();
 
@@ -537,7 +694,9 @@ export class CtrlProxyStorage {
       // Ensure WebSocket connection is established
       const connected = await this.context.ensureConnected();
       if (!connected) {
-        logger.warn("[CTRL_PROXY] Failed to establish WebSocket connection for clearPreferenceStore");
+        logger.warn(
+          "[CTRL_PROXY] Failed to establish WebSocket connection for clearPreferenceStore",
+        );
         throw new Error("Failed to connect to accessibility service");
       }
 
@@ -551,8 +710,8 @@ export class CtrlProxyStorage {
         (_id, _type, _timeout) => ({
           success: false,
           totalTimeMs: this.context.timer.now() - startTime,
-          error: `Clear preferences timeout after ${timeoutMs}ms`
-        })
+          error: `Clear preferences timeout after ${timeoutMs}ms`,
+        }),
       );
 
       // Send the request
@@ -561,10 +720,12 @@ export class CtrlProxyStorage {
         throw new Error("WebSocket not connected");
       }
       const message = serializeCtrlProxyRequest(
-        ctrlProxyRequests.clearPreferences({ requestId, packageName, fileName })
+        ctrlProxyRequests.clearPreferences({ requestId, packageName, fileName }),
       );
       ws.send(message);
-      logger.debug(`[CTRL_PROXY] Sent clear_preferences request (requestId: ${requestId}, packageName: ${packageName}, fileName: ${fileName})`);
+      logger.debug(
+        `[CTRL_PROXY] Sent clear_preferences request (requestId: ${requestId}, packageName: ${packageName}, fileName: ${fileName})`,
+      );
 
       // Wait for response
       const result = await resultPromise;

--- a/src/features/observe/android/ctrlProxyProtocol.ts
+++ b/src/features/observe/android/ctrlProxyProtocol.ts
@@ -391,6 +391,34 @@ export interface GetPreferencesMessage {
   fileName: string;
 }
 
+/**
+ * `@SerialName("list_data_stores")` → `ListDataStores`.
+ *
+ * Lists the Jetpack DataStore instances exposed by a host-registered adapter (issue #5192/#5573).
+ * DataStore descriptors reuse the SharedPreferences `preference_files` result envelope
+ * (`StorageResponse.FileList`, path emitted empty), disambiguated by `requestId`.
+ */
+export interface ListDataStoresMessage {
+  type: "list_data_stores";
+  requestId: string;
+  packageName: string;
+  adapterName: string;
+}
+
+/**
+ * `@SerialName("get_data_store")` → `GetDataStore`.
+ *
+ * Reads all entries from a named DataStore instance. Reuses the SharedPreferences `preferences`
+ * result envelope (`StorageResponse.Preferences`), disambiguated by `requestId`.
+ */
+export interface GetDataStoreMessage {
+  type: "get_data_store";
+  requestId: string;
+  packageName: string;
+  adapterName: string;
+  storeName: string;
+}
+
 /** `@SerialName("subscribe_storage")` → `SubscribeStorage` */
 export interface SubscribeStorageMessage {
   type: "subscribe_storage";
@@ -591,6 +619,8 @@ export type CtrlProxyRequest =
   | AddHighlightMessage
   | ListPreferenceFilesMessage
   | GetPreferencesMessage
+  | ListDataStoresMessage
+  | GetDataStoreMessage
   | SubscribeStorageMessage
   | UnsubscribeStorageMessage
   | GetPreferenceMessage
@@ -659,6 +689,8 @@ const REQUEST_TYPE_REGISTRY: Record<CtrlProxyRequestType, true> = {
   add_highlight: true,
   list_preference_files: true,
   get_preferences: true,
+  list_data_stores: true,
+  get_data_store: true,
   subscribe_storage: true,
   unsubscribe_storage: true,
   get_preference: true,
@@ -910,6 +942,34 @@ export const ctrlProxyRequests = {
       requestId: args.requestId,
       packageName: args.packageName,
       fileName: args.fileName,
+    };
+  },
+
+  listDataStores(args: {
+    requestId: string;
+    packageName: string;
+    adapterName: string;
+  }): ListDataStoresMessage {
+    return {
+      type: "list_data_stores",
+      requestId: args.requestId,
+      packageName: args.packageName,
+      adapterName: args.adapterName,
+    };
+  },
+
+  getDataStore(args: {
+    requestId: string;
+    packageName: string;
+    adapterName: string;
+    storeName: string;
+  }): GetDataStoreMessage {
+    return {
+      type: "get_data_store",
+      requestId: args.requestId,
+      packageName: args.packageName,
+      adapterName: args.adapterName,
+      storeName: args.storeName,
     };
   },
 

--- a/src/features/storage/storageTypes.ts
+++ b/src/features/storage/storageTypes.ts
@@ -26,6 +26,8 @@ export type KeyValueType =
   | "DOUBLE"
   | "BOOLEAN"
   | "STRING_SET"
+  // Android DataStore only, read surface: base64-encoded bytes (SDK DataStoreValueType.BYTE_ARRAY).
+  | "BYTE_ARRAY"
   | "DATA"
   | "DATE"
   | "ARRAY"

--- a/src/server/storageTools.ts
+++ b/src/server/storageTools.ts
@@ -49,6 +49,41 @@ const TYPE_GUIDANCE: Record<string, string> = {
 
 const STORAGE_NAME_DESCRIPTION = "Storage name";
 
+const ADAPTER_NAME_DESCRIPTION =
+  "Name the host app registered its DataStore adapter under (AutoMobile SDK)";
+
+// listDataStores: enumerate the DataStore instances exposed by a host-registered adapter (Android).
+const listDataStoresSchema = withAppIdAliases(
+  addDeviceTargetingToSchema(
+    z.object({
+      appId: z.string(),
+      adapterName: z.string().describe(ADAPTER_NAME_DESCRIPTION),
+    }),
+  ),
+);
+
+interface ListDataStoresArgs {
+  appId: string;
+  adapterName: string;
+}
+
+// getDataStore: read all entries from a named DataStore instance (Android).
+const getDataStoreSchema = withAppIdAliases(
+  addDeviceTargetingToSchema(
+    z.object({
+      appId: z.string(),
+      adapterName: z.string().describe(ADAPTER_NAME_DESCRIPTION),
+      name: z.string().describe("DataStore instance name"),
+    }),
+  ),
+);
+
+interface GetDataStoreArgs {
+  appId: string;
+  adapterName: string;
+  name: string;
+}
+
 const legacyFileNameDescription = "Deprecated alias for name";
 
 function resolveStorageName(args: { name?: string; fileName?: string }): string {
@@ -294,11 +329,76 @@ export function registerStorageTools(): void {
     }
   };
 
+  // listDataStores handler — Android-only (Jetpack DataStore has no iOS analog).
+  const listDataStoresHandler = async (device: BootedDevice, args: ListDataStoresArgs) => {
+    if (device.platform !== "android") {
+      throw new ActionableError(
+        `listDataStores is Android-only; DataStore is not available on ${device.platform}.`,
+      );
+    }
+    try {
+      const client = AndroidCtrlProxyClient.getInstance(device, defaultAdbClientFactory);
+      const stores = await client.listDataStores(args.appId, args.adapterName);
+      return createJSONToolResponse({
+        success: true,
+        appId: args.appId,
+        adapterName: args.adapterName,
+        stores,
+      });
+    } catch (error) {
+      if (error instanceof ActionableError) {
+        throw error;
+      }
+      throw new ActionableError(`Failed to list data stores: ${error}`);
+    }
+  };
+
+  // getDataStore handler — Android-only.
+  const getDataStoreHandler = async (device: BootedDevice, args: GetDataStoreArgs) => {
+    if (device.platform !== "android") {
+      throw new ActionableError(
+        `getDataStore is Android-only; DataStore is not available on ${device.platform}.`,
+      );
+    }
+    try {
+      const client = AndroidCtrlProxyClient.getInstance(device, defaultAdbClientFactory);
+      const entries = await client.getDataStore(args.appId, args.adapterName, args.name);
+      return createJSONToolResponse({
+        success: true,
+        appId: args.appId,
+        adapterName: args.adapterName,
+        name: args.name,
+        entries,
+      });
+    } catch (error) {
+      if (error instanceof ActionableError) {
+        throw error;
+      }
+      throw new ActionableError(`Failed to get data store: ${error}`);
+    }
+  };
+
   ToolRegistry.registerDeviceAware(
     "setKeyValue",
     "Set app key-value storage entry.",
     setKeyValueSchema,
     setKeyValueHandler,
+    { defaultEnabled: false, embeddedSdkOnly: true },
+  );
+
+  ToolRegistry.registerDeviceAware(
+    "listDataStores",
+    "List app Jetpack DataStore instances (Android, requires AutoMobile SDK adapter).",
+    listDataStoresSchema,
+    listDataStoresHandler,
+    { defaultEnabled: false, embeddedSdkOnly: true },
+  );
+
+  ToolRegistry.registerDeviceAware(
+    "getDataStore",
+    "Read entries from an app Jetpack DataStore instance (Android, requires AutoMobile SDK adapter).",
+    getDataStoreSchema,
+    getDataStoreHandler,
     { defaultEnabled: false, embeddedSdkOnly: true },
   );
 

--- a/test/features/observe/android/CtrlProxyStorage.test.ts
+++ b/test/features/observe/android/CtrlProxyStorage.test.ts
@@ -363,5 +363,51 @@ describe("CtrlProxyStorage (Android)", function () {
         await client.close();
       }
     });
+
+    // Issue #5573 scope: STRING_SET / BYTE_ARRAY carry end-to-end across the wire. DataStore
+    // reuses the `preferences` result envelope, so the entry `type`/`value` pass through the
+    // client verbatim (STRING_SET as a JSON array string, BYTE_ARRAY as base64).
+    test("carries STRING_SET and BYTE_ARRAY entries across the wire", async function () {
+      const { factory, getSocket } = createCapturingFactory(fakeTimer);
+      const client = AndroidCtrlProxyClient.createForTesting(
+        testDevice,
+        fakeAdb,
+        factory,
+        fakeTimer,
+      );
+      try {
+        await client.ensureConnected();
+        const socket = await waitForSocket(getSocket);
+        await waitForSocketOpen(socket);
+
+        const baseCount = socket!.sentMessages.length;
+        const resultPromise = client.getDataStore("com.example", "settings", "user_prefs");
+        await waitForSentMessages(socket, baseCount + 1);
+        const sent = findSentMessage(socket!, "get_data_store");
+
+        socket!.simulateMessage(
+          JSON.stringify({
+            type: "preferences",
+            requestId: sent.requestId,
+            success: true,
+            packageName: "com.example",
+            entries: [
+              { key: "tags", value: '["a","b"]', type: "STRING_SET" },
+              { key: "blob", value: "AQID", type: "BYTE_ARRAY" },
+            ],
+            totalTimeMs: 7,
+          }),
+        );
+
+        const entries = await resultPromise;
+        expect(entries).toHaveLength(2);
+        expect(entries[0].type).toBe("STRING_SET");
+        expect(entries[0].value).toBe('["a","b"]');
+        expect(entries[1].type).toBe("BYTE_ARRAY");
+        expect(entries[1].value).toBe("AQID");
+      } finally {
+        await client.close();
+      }
+    });
   });
 });

--- a/test/features/observe/android/CtrlProxyStorage.test.ts
+++ b/test/features/observe/android/CtrlProxyStorage.test.ts
@@ -14,13 +14,13 @@ import { FakeTimer } from "../../../fakes/FakeTimer";
  * packageName/fileName/subscriptionId fields) and the TS client (which awaits a resolved promise),
  * so a timeout-only resolution or a dropped field is caught here.
  */
-describe("CtrlProxyStorage (Android)", function() {
+describe("CtrlProxyStorage (Android)", function () {
   let fakeAdb: FakeAdbExecutor;
   let testDevice: BootedDevice;
   let fakeTimer: FakeTimer;
   const serverPort: number = 8765;
 
-  beforeEach(function() {
+  beforeEach(function () {
     fakeTimer = new FakeTimer();
     fakeTimer.enableAutoAdvance();
 
@@ -32,15 +32,18 @@ describe("CtrlProxyStorage (Android)", function() {
       deviceId: "test-device-storage",
       platform: "android",
       isEmulator: true,
-      name: "Test Device"
+      name: "Test Device",
     };
 
     AndroidCtrlProxyManager.resetInstances();
     AndroidCtrlProxyClient.resetInstances();
-    AndroidCtrlProxyManager.getInstance(testDevice, new FakeAdbClientFactory()).clearAvailabilityCache();
+    AndroidCtrlProxyManager.getInstance(
+      testDevice,
+      new FakeAdbClientFactory(),
+    ).clearAvailabilityCache();
   });
 
-  afterEach(function() {
+  afterEach(function () {
     NavigationGraphManager.getInstance();
   });
 
@@ -52,7 +55,9 @@ describe("CtrlProxyStorage (Android)", function() {
     }
   }
 
-  const createCapturingFactory = (timer?: FakeTimer): {
+  const createCapturingFactory = (
+    timer?: FakeTimer,
+  ): {
     factory: (url: string) => CapturingWebSocket;
     getSocket: () => CapturingWebSocket | null;
   } => {
@@ -62,29 +67,42 @@ describe("CtrlProxyStorage (Android)", function() {
         socket = new CapturingWebSocket(url, "none", 0, timer);
         return socket;
       },
-      getSocket: () => socket
+      getSocket: () => socket,
     };
   };
 
   const waitForSocketOpen = async (socket: FakeWebSocket | null): Promise<void> => {
-    if (!socket || socket.readyState === WebSocketState.OPEN) {return;}
-    await new Promise<void>(resolve => socket.once("open", () => resolve()));
+    if (!socket || socket.readyState === WebSocketState.OPEN) {
+      return;
+    }
+    await new Promise<void>((resolve) => socket.once("open", () => resolve()));
   };
 
-  const waitForSocket = async (getSocket: () => CapturingWebSocket | null): Promise<CapturingWebSocket | null> => {
+  const waitForSocket = async (
+    getSocket: () => CapturingWebSocket | null,
+  ): Promise<CapturingWebSocket | null> => {
     for (let i = 0; i < 5; i++) {
       const s = getSocket();
-      if (s) {return s;}
-      await new Promise(r => setImmediate(r));
+      if (s) {
+        return s;
+      }
+      await new Promise((r) => setImmediate(r));
     }
     return getSocket();
   };
 
-  const waitForSentMessages = async (socket: CapturingWebSocket | null, minCount = 1): Promise<void> => {
-    if (!socket) {return;}
+  const waitForSentMessages = async (
+    socket: CapturingWebSocket | null,
+    minCount = 1,
+  ): Promise<void> => {
+    if (!socket) {
+      return;
+    }
     for (let i = 0; i < 10; i++) {
-      if (socket.sentMessages.length >= minCount) {return;}
-      await new Promise(r => setImmediate(r));
+      if (socket.sentMessages.length >= minCount) {
+        return;
+      }
+      await new Promise((r) => setImmediate(r));
     }
   };
 
@@ -92,7 +110,9 @@ describe("CtrlProxyStorage (Android)", function() {
     for (let i = socket.sentMessages.length - 1; i >= 0; i--) {
       try {
         const parsed = JSON.parse(socket.sentMessages[i]);
-        if (parsed.type === type) {return parsed;}
+        if (parsed.type === type) {
+          return parsed;
+        }
       } catch {
         // skip non-JSON control frames
       }
@@ -100,10 +120,15 @@ describe("CtrlProxyStorage (Android)", function() {
     throw new Error(`No message of type ${type} in: ${socket.sentMessages.join(", ")}`);
   };
 
-  describe("subscribeStorage", function() {
-    test("resolves with a subscription rebuilt from the device's flat result fields", async function() {
+  describe("subscribeStorage", function () {
+    test("resolves with a subscription rebuilt from the device's flat result fields", async function () {
       const { factory, getSocket } = createCapturingFactory(fakeTimer);
-      const client = AndroidCtrlProxyClient.createForTesting(testDevice, fakeAdb, factory, fakeTimer);
+      const client = AndroidCtrlProxyClient.createForTesting(
+        testDevice,
+        fakeAdb,
+        factory,
+        fakeTimer,
+      );
       try {
         await client.ensureConnected();
         const socket = await waitForSocket(getSocket);
@@ -118,15 +143,17 @@ describe("CtrlProxyStorage (Android)", function() {
         expect(sent.fileName).toBe("settings.xml");
 
         // The device emits flat fields (no nested `subscription` object).
-        socket!.simulateMessage(JSON.stringify({
-          type: "subscribe_storage_result",
-          requestId: sent.requestId,
-          success: true,
-          packageName: "com.example",
-          fileName: "settings.xml",
-          subscriptionId: "com.example:settings.xml",
-          totalTimeMs: 5,
-        }));
+        socket!.simulateMessage(
+          JSON.stringify({
+            type: "subscribe_storage_result",
+            requestId: sent.requestId,
+            success: true,
+            packageName: "com.example",
+            fileName: "settings.xml",
+            subscriptionId: "com.example:settings.xml",
+            totalTimeMs: 5,
+          }),
+        );
 
         const subscription = await resultPromise;
         expect(subscription.subscriptionId).toBe("com.example:settings.xml");
@@ -137,9 +164,14 @@ describe("CtrlProxyStorage (Android)", function() {
       }
     });
 
-    test("rejects when the device reports failure", async function() {
+    test("rejects when the device reports failure", async function () {
       const { factory, getSocket } = createCapturingFactory(fakeTimer);
-      const client = AndroidCtrlProxyClient.createForTesting(testDevice, fakeAdb, factory, fakeTimer);
+      const client = AndroidCtrlProxyClient.createForTesting(
+        testDevice,
+        fakeAdb,
+        factory,
+        fakeTimer,
+      );
       try {
         await client.ensureConnected();
         const socket = await waitForSocket(getSocket);
@@ -150,14 +182,16 @@ describe("CtrlProxyStorage (Android)", function() {
         await waitForSentMessages(socket, baseCount + 1);
         const sent = findSentMessage(socket!, "subscribe_storage");
 
-        socket!.simulateMessage(JSON.stringify({
-          type: "subscribe_storage_result",
-          requestId: sent.requestId,
-          success: false,
-          packageName: "com.example",
-          fileName: "settings.xml",
-          error: "SDK not installed",
-        }));
+        socket!.simulateMessage(
+          JSON.stringify({
+            type: "subscribe_storage_result",
+            requestId: sent.requestId,
+            success: false,
+            packageName: "com.example",
+            fileName: "settings.xml",
+            error: "SDK not installed",
+          }),
+        );
 
         await expect(resultPromise).rejects.toThrow("SDK not installed");
       } finally {
@@ -166,10 +200,15 @@ describe("CtrlProxyStorage (Android)", function() {
     });
   });
 
-  describe("unsubscribeStorage", function() {
-    test("sends the subscriptionId and resolves on the device's result", async function() {
+  describe("unsubscribeStorage", function () {
+    test("sends the subscriptionId and resolves on the device's result", async function () {
       const { factory, getSocket } = createCapturingFactory(fakeTimer);
-      const client = AndroidCtrlProxyClient.createForTesting(testDevice, fakeAdb, factory, fakeTimer);
+      const client = AndroidCtrlProxyClient.createForTesting(
+        testDevice,
+        fakeAdb,
+        factory,
+        fakeTimer,
+      );
       try {
         await client.ensureConnected();
         const socket = await waitForSocket(getSocket);
@@ -182,17 +221,144 @@ describe("CtrlProxyStorage (Android)", function() {
         const sent = findSentMessage(socket!, "unsubscribe_storage");
         expect(sent.subscriptionId).toBe("com.example:settings.xml");
 
-        socket!.simulateMessage(JSON.stringify({
-          type: "unsubscribe_storage_result",
-          requestId: sent.requestId,
-          success: true,
-          packageName: "com.example",
-          fileName: "settings.xml",
-          totalTimeMs: 3,
-        }));
+        socket!.simulateMessage(
+          JSON.stringify({
+            type: "unsubscribe_storage_result",
+            requestId: sent.requestId,
+            success: true,
+            packageName: "com.example",
+            fileName: "settings.xml",
+            totalTimeMs: 3,
+          }),
+        );
 
         // Resolves (does not hang until timeout) — this is the bug the device-side fix repairs.
         await expect(resultPromise).resolves.toBeUndefined();
+      } finally {
+        await client.close();
+      }
+    });
+  });
+
+  describe("listDataStores", function () {
+    test("sends adapterName and resolves with the device's file list", async function () {
+      const { factory, getSocket } = createCapturingFactory(fakeTimer);
+      const client = AndroidCtrlProxyClient.createForTesting(
+        testDevice,
+        fakeAdb,
+        factory,
+        fakeTimer,
+      );
+      try {
+        await client.ensureConnected();
+        const socket = await waitForSocket(getSocket);
+        await waitForSocketOpen(socket);
+
+        const baseCount = socket!.sentMessages.length;
+        const resultPromise = client.listDataStores("com.example", "settings");
+        await waitForSentMessages(socket, baseCount + 1);
+
+        const sent = findSentMessage(socket!, "list_data_stores");
+        expect(sent.packageName).toBe("com.example");
+        expect(sent.adapterName).toBe("settings");
+
+        // DataStore descriptors reuse the SharedPreferences `preference_files` result envelope
+        // (StorageResponse.FileList), disambiguated by requestId.
+        socket!.simulateMessage(
+          JSON.stringify({
+            type: "preference_files",
+            requestId: sent.requestId,
+            success: true,
+            packageName: "com.example",
+            files: [{ name: "user_prefs", path: "", entryCount: 2 }],
+            totalTimeMs: 4,
+          }),
+        );
+
+        const files = await resultPromise;
+        expect(files).toHaveLength(1);
+        expect(files[0].name).toBe("user_prefs");
+        expect(files[0].entryCount).toBe(2);
+      } finally {
+        await client.close();
+      }
+    });
+
+    test("rejects when the device reports failure", async function () {
+      const { factory, getSocket } = createCapturingFactory(fakeTimer);
+      const client = AndroidCtrlProxyClient.createForTesting(
+        testDevice,
+        fakeAdb,
+        factory,
+        fakeTimer,
+      );
+      try {
+        await client.ensureConnected();
+        const socket = await waitForSocket(getSocket);
+        await waitForSocketOpen(socket);
+
+        const baseCount = socket!.sentMessages.length;
+        const resultPromise = client.listDataStores("com.example", "missing");
+        await waitForSentMessages(socket, baseCount + 1);
+        const sent = findSentMessage(socket!, "list_data_stores");
+
+        socket!.simulateMessage(
+          JSON.stringify({
+            type: "preference_files",
+            requestId: sent.requestId,
+            success: false,
+            packageName: "com.example",
+            error: "adapterName required",
+          }),
+        );
+
+        await expect(resultPromise).rejects.toThrow("adapterName required");
+      } finally {
+        await client.close();
+      }
+    });
+  });
+
+  describe("getDataStore", function () {
+    test("sends adapterName + storeName and resolves with the device's entries", async function () {
+      const { factory, getSocket } = createCapturingFactory(fakeTimer);
+      const client = AndroidCtrlProxyClient.createForTesting(
+        testDevice,
+        fakeAdb,
+        factory,
+        fakeTimer,
+      );
+      try {
+        await client.ensureConnected();
+        const socket = await waitForSocket(getSocket);
+        await waitForSocketOpen(socket);
+
+        const baseCount = socket!.sentMessages.length;
+        const resultPromise = client.getDataStore("com.example", "settings", "user_prefs");
+        await waitForSentMessages(socket, baseCount + 1);
+
+        const sent = findSentMessage(socket!, "get_data_store");
+        expect(sent.packageName).toBe("com.example");
+        expect(sent.adapterName).toBe("settings");
+        expect(sent.storeName).toBe("user_prefs");
+
+        // DataStore entries reuse the SharedPreferences `preferences` result envelope
+        // (StorageResponse.Preferences), disambiguated by requestId.
+        socket!.simulateMessage(
+          JSON.stringify({
+            type: "preferences",
+            requestId: sent.requestId,
+            success: true,
+            packageName: "com.example",
+            entries: [{ key: "theme", value: '"dark"', type: "STRING" }],
+            totalTimeMs: 6,
+          }),
+        );
+
+        const entries = await resultPromise;
+        expect(entries).toHaveLength(1);
+        expect(entries[0].key).toBe("theme");
+        expect(entries[0].type).toBe("STRING");
       } finally {
         await client.close();
       }

--- a/test/features/observe/android/ctrlProxyProtocol.test.ts
+++ b/test/features/observe/android/ctrlProxyProtocol.test.ts
@@ -55,6 +55,8 @@ const KOTLIN_SERIAL_NAMES = [
   "add_highlight",
   "list_preference_files",
   "get_preferences",
+  "list_data_stores",
+  "get_data_store",
   "subscribe_storage",
   "unsubscribe_storage",
   "get_preference",
@@ -497,6 +499,33 @@ describe("ctrlProxyProtocol — builders serialize byte-identically", () => {
         '{"type":"get_preferences","requestId":"gp-1","packageName":"com.x","fileName":"prefs"}',
     },
     {
+      builder: "listDataStores",
+      name: "packageName + adapterName",
+      actual: serializeCtrlProxyRequest(
+        ctrlProxyRequests.listDataStores({
+          requestId: "lds-1",
+          packageName: "com.x",
+          adapterName: "settings",
+        }),
+      ),
+      expected:
+        '{"type":"list_data_stores","requestId":"lds-1","packageName":"com.x","adapterName":"settings"}',
+    },
+    {
+      builder: "getDataStore",
+      name: "packageName + adapterName + storeName",
+      actual: serializeCtrlProxyRequest(
+        ctrlProxyRequests.getDataStore({
+          requestId: "gds-1",
+          packageName: "com.x",
+          adapterName: "settings",
+          storeName: "user",
+        }),
+      ),
+      expected:
+        '{"type":"get_data_store","requestId":"gds-1","packageName":"com.x","adapterName":"settings","storeName":"user"}',
+    },
+    {
       builder: "subscribeStorage",
       name: "packageName + fileName",
       actual: serializeCtrlProxyRequest(
@@ -735,12 +764,12 @@ describe("ctrlProxyProtocol — builders serialize byte-identically", () => {
   });
 
   // Completeness guard: every builder in the module must have at least one wire row above, and the
-  // total builder count is pinned. Ship builder #39 without a row and this fails — not a silently
+  // total builder count is pinned. Ship builder #41 without a row and this fails — not a silently
   // uncovered send site. `request_two_finger_swipe` has no builder here by design (it goes through
   // the shared sendCommand path, asserted in CtrlProxyGestures.test.ts), so it is not a builder key.
-  test("every ctrlProxyRequests builder has wire coverage and the count is pinned at 38", () => {
+  test("every ctrlProxyRequests builder has wire coverage and the count is pinned at 40", () => {
     const builderNames = Object.keys(ctrlProxyRequests);
-    expect(builderNames.length).toBe(38);
+    expect(builderNames.length).toBe(40);
     const covered = new Set(cases.map((row) => row.builder));
     expect([...covered].sort()).toEqual([...builderNames].sort());
   });

--- a/test/server/storageTools.test.ts
+++ b/test/server/storageTools.test.ts
@@ -18,10 +18,76 @@ describe("Storage Tools Registration", () => {
   test("registers all three storage write tools", () => {
     registerStorageTools();
 
-    const toolNames = ToolRegistry.getToolDefinitions().map(t => t.name);
+    const toolNames = ToolRegistry.getToolDefinitions().map((t) => t.name);
     expect(toolNames).toContain("setKeyValue");
     expect(toolNames).toContain("removeKeyValue");
     expect(toolNames).toContain("clearKeyValueFile");
+  });
+
+  test("registers the DataStore read tools", () => {
+    registerStorageTools();
+
+    const toolNames = ToolRegistry.getToolDefinitions().map((t) => t.name);
+    expect(toolNames).toContain("listDataStores");
+    expect(toolNames).toContain("getDataStore");
+  });
+
+  describe("listDataStores schema", () => {
+    test("accepts appId + adapterName", () => {
+      registerStorageTools();
+      const tool = ToolRegistry.getTool("listDataStores");
+      expect(tool).toBeDefined();
+
+      expect(() =>
+        tool!.schema.parse({
+          platform: "android",
+          appId: "com.example.app",
+          adapterName: "settings",
+        }),
+      ).not.toThrow();
+    });
+
+    test("requires adapterName", () => {
+      registerStorageTools();
+      const tool = ToolRegistry.getTool("listDataStores");
+
+      expect(() =>
+        tool!.schema.parse({
+          platform: "android",
+          appId: "com.example.app",
+        }),
+      ).toThrow();
+    });
+  });
+
+  describe("getDataStore schema", () => {
+    test("accepts appId + adapterName + name", () => {
+      registerStorageTools();
+      const tool = ToolRegistry.getTool("getDataStore");
+      expect(tool).toBeDefined();
+
+      expect(() =>
+        tool!.schema.parse({
+          platform: "android",
+          appId: "com.example.app",
+          adapterName: "settings",
+          name: "user_prefs",
+        }),
+      ).not.toThrow();
+    });
+
+    test("requires name (store name)", () => {
+      registerStorageTools();
+      const tool = ToolRegistry.getTool("getDataStore");
+
+      expect(() =>
+        tool!.schema.parse({
+          platform: "android",
+          appId: "com.example.app",
+          adapterName: "settings",
+        }),
+      ).toThrow();
+    });
   });
 
   describe("setKeyValue schema", () => {
@@ -30,28 +96,32 @@ describe("Storage Tools Registration", () => {
       const tool = ToolRegistry.getTool("setKeyValue");
       expect(tool).toBeDefined();
 
-      expect(() => tool!.schema.parse({
-        platform: "android",
-        appId: "com.example.app",
-        name: "user_prefs",
-        key: "dark_mode",
-        value: "true",
-        type: "BOOLEAN",
-      })).not.toThrow();
+      expect(() =>
+        tool!.schema.parse({
+          platform: "android",
+          appId: "com.example.app",
+          name: "user_prefs",
+          key: "dark_mode",
+          value: "true",
+          type: "BOOLEAN",
+        }),
+      ).not.toThrow();
     });
 
     test("accepts legacy fileName alias", () => {
       registerStorageTools();
       const tool = ToolRegistry.getTool("setKeyValue");
 
-      expect(tool!.schema.parse({
-        platform: "android",
-        appId: "com.example.app",
-        fileName: "user_prefs",
-        key: "dark_mode",
-        value: "true",
-        type: "BOOLEAN",
-      })).toMatchObject({
+      expect(
+        tool!.schema.parse({
+          platform: "android",
+          appId: "com.example.app",
+          fileName: "user_prefs",
+          key: "dark_mode",
+          value: "true",
+          type: "BOOLEAN",
+        }),
+      ).toMatchObject({
         fileName: "user_prefs",
       });
     });
@@ -60,14 +130,16 @@ describe("Storage Tools Registration", () => {
       registerStorageTools();
       const tool = ToolRegistry.getTool("setKeyValue");
 
-      expect(() => tool!.schema.parse({
-        platform: "android",
-        appId: "com.example.app",
-        name: "user_prefs",
-        key: "some_key",
-        value: null,
-        type: "STRING",
-      })).not.toThrow();
+      expect(() =>
+        tool!.schema.parse({
+          platform: "android",
+          appId: "com.example.app",
+          name: "user_prefs",
+          key: "some_key",
+          value: null,
+          type: "STRING",
+        }),
+      ).not.toThrow();
     });
 
     test("rejects missing required fields", () => {
@@ -75,45 +147,53 @@ describe("Storage Tools Registration", () => {
       const tool = ToolRegistry.getTool("setKeyValue");
 
       // Missing key
-      expect(() => tool!.schema.parse({
-        platform: "android",
-        appId: "com.example.app",
-        name: "user_prefs",
-        value: "true",
-        type: "BOOLEAN",
-      })).toThrow();
+      expect(() =>
+        tool!.schema.parse({
+          platform: "android",
+          appId: "com.example.app",
+          name: "user_prefs",
+          value: "true",
+          type: "BOOLEAN",
+        }),
+      ).toThrow();
 
       // Missing appId
-      expect(() => tool!.schema.parse({
-        platform: "android",
-        name: "user_prefs",
-        key: "dark_mode",
-        value: "true",
-        type: "BOOLEAN",
-      })).toThrow();
+      expect(() =>
+        tool!.schema.parse({
+          platform: "android",
+          name: "user_prefs",
+          key: "dark_mode",
+          value: "true",
+          type: "BOOLEAN",
+        }),
+      ).toThrow();
 
       // Missing name
-      expect(() => tool!.schema.parse({
-        platform: "android",
-        appId: "com.example.app",
-        key: "dark_mode",
-        value: "true",
-        type: "BOOLEAN",
-      })).toThrow();
+      expect(() =>
+        tool!.schema.parse({
+          platform: "android",
+          appId: "com.example.app",
+          key: "dark_mode",
+          value: "true",
+          type: "BOOLEAN",
+        }),
+      ).toThrow();
     });
 
     test("rejects invalid type", () => {
       registerStorageTools();
       const tool = ToolRegistry.getTool("setKeyValue");
 
-      expect(() => tool!.schema.parse({
-        platform: "android",
-        appId: "com.example.app",
-        name: "user_prefs",
-        key: "dark_mode",
-        value: "true",
-        type: "INVALID_TYPE",
-      })).toThrow();
+      expect(() =>
+        tool!.schema.parse({
+          platform: "android",
+          appId: "com.example.app",
+          name: "user_prefs",
+          key: "dark_mode",
+          value: "true",
+          type: "INVALID_TYPE",
+        }),
+      ).toThrow();
     });
 
     test("accepts all valid Android KeyValueType values", () => {
@@ -122,14 +202,16 @@ describe("Storage Tools Registration", () => {
 
       const validTypes = ["STRING", "INT", "LONG", "FLOAT", "BOOLEAN", "STRING_SET"];
       for (const type of validTypes) {
-        expect(() => tool!.schema.parse({
-          platform: "android",
-          appId: "com.example.app",
-          name: "prefs",
-          key: "k",
-          value: "v",
-          type,
-        })).not.toThrow();
+        expect(() =>
+          tool!.schema.parse({
+            platform: "android",
+            appId: "com.example.app",
+            name: "prefs",
+            key: "k",
+            value: "v",
+            type,
+          }),
+        ).not.toThrow();
       }
     });
 
@@ -137,16 +219,27 @@ describe("Storage Tools Registration", () => {
       registerStorageTools();
       const tool = ToolRegistry.getTool("setKeyValue");
 
-      const validTypes = ["STRING", "INT", "DOUBLE", "BOOLEAN", "DATA", "DATE", "ARRAY", "DICTIONARY"];
+      const validTypes = [
+        "STRING",
+        "INT",
+        "DOUBLE",
+        "BOOLEAN",
+        "DATA",
+        "DATE",
+        "ARRAY",
+        "DICTIONARY",
+      ];
       for (const type of validTypes) {
-        expect(() => tool!.schema.parse({
-          platform: "ios",
-          appId: "com.example.app",
-          name: "Standard",
-          key: "k",
-          value: "v",
-          type,
-        })).not.toThrow();
+        expect(() =>
+          tool!.schema.parse({
+            platform: "ios",
+            appId: "com.example.app",
+            name: "Standard",
+            key: "k",
+            value: "v",
+            type,
+          }),
+        ).not.toThrow();
       }
     });
 
@@ -154,14 +247,16 @@ describe("Storage Tools Registration", () => {
       registerStorageTools();
       const tool = ToolRegistry.getTool("setKeyValue");
 
-      expect(() => tool!.schema.parse({
-        platform: "ios",
-        appId: "com.example.app",
-        name: "Standard",
-        key: "k",
-        value: "v",
-        type: "UNKNOWN",
-      })).not.toThrow();
+      expect(() =>
+        tool!.schema.parse({
+          platform: "ios",
+          appId: "com.example.app",
+          name: "Standard",
+          key: "k",
+          value: "v",
+          type: "UNKNOWN",
+        }),
+      ).not.toThrow();
     });
   });
 
@@ -171,24 +266,28 @@ describe("Storage Tools Registration", () => {
       const tool = ToolRegistry.getTool("removeKeyValue");
       expect(tool).toBeDefined();
 
-      expect(() => tool!.schema.parse({
-        platform: "android",
-        appId: "com.example.app",
-        name: "user_prefs",
-        key: "dark_mode",
-      })).not.toThrow();
+      expect(() =>
+        tool!.schema.parse({
+          platform: "android",
+          appId: "com.example.app",
+          name: "user_prefs",
+          key: "dark_mode",
+        }),
+      ).not.toThrow();
     });
 
     test("accepts legacy fileName alias", () => {
       registerStorageTools();
       const tool = ToolRegistry.getTool("removeKeyValue");
 
-      expect(tool!.schema.parse({
-        platform: "android",
-        appId: "com.example.app",
-        fileName: "user_prefs",
-        key: "dark_mode",
-      })).toMatchObject({
+      expect(
+        tool!.schema.parse({
+          platform: "android",
+          appId: "com.example.app",
+          fileName: "user_prefs",
+          key: "dark_mode",
+        }),
+      ).toMatchObject({
         fileName: "user_prefs",
       });
     });
@@ -198,11 +297,13 @@ describe("Storage Tools Registration", () => {
       const tool = ToolRegistry.getTool("removeKeyValue");
 
       // Missing key
-      expect(() => tool!.schema.parse({
-        platform: "android",
-        appId: "com.example.app",
-        name: "user_prefs",
-      })).toThrow();
+      expect(() =>
+        tool!.schema.parse({
+          platform: "android",
+          appId: "com.example.app",
+          name: "user_prefs",
+        }),
+      ).toThrow();
     });
   });
 
@@ -212,22 +313,26 @@ describe("Storage Tools Registration", () => {
       const tool = ToolRegistry.getTool("clearKeyValueFile");
       expect(tool).toBeDefined();
 
-      expect(() => tool!.schema.parse({
-        platform: "android",
-        appId: "com.example.app",
-        name: "user_prefs",
-      })).not.toThrow();
+      expect(() =>
+        tool!.schema.parse({
+          platform: "android",
+          appId: "com.example.app",
+          name: "user_prefs",
+        }),
+      ).not.toThrow();
     });
 
     test("accepts legacy fileName alias", () => {
       registerStorageTools();
       const tool = ToolRegistry.getTool("clearKeyValueFile");
 
-      expect(tool!.schema.parse({
-        platform: "android",
-        appId: "com.example.app",
-        fileName: "user_prefs",
-      })).toMatchObject({
+      expect(
+        tool!.schema.parse({
+          platform: "android",
+          appId: "com.example.app",
+          fileName: "user_prefs",
+        }),
+      ).toMatchObject({
         fileName: "user_prefs",
       });
     });
@@ -237,10 +342,12 @@ describe("Storage Tools Registration", () => {
       const tool = ToolRegistry.getTool("clearKeyValueFile");
 
       // Missing name
-      expect(() => tool!.schema.parse({
-        platform: "android",
-        appId: "com.example.app",
-      })).toThrow();
+      expect(() =>
+        tool!.schema.parse({
+          platform: "android",
+          appId: "com.example.app",
+        }),
+      ).toThrow();
     });
   });
 
@@ -250,7 +357,9 @@ describe("Storage Tools Registration", () => {
   describe("validateTypeForPlatform (shared MCP + socket guard)", () => {
     test("rejects an Android-only type on iOS with actionable guidance", () => {
       expect(() => validateTypeForPlatform("ios", "STRING_SET")).toThrow(ActionableError);
-      expect(() => validateTypeForPlatform("ios", "STRING_SET")).toThrow(/STRING_SET is Android-only/);
+      expect(() => validateTypeForPlatform("ios", "STRING_SET")).toThrow(
+        /STRING_SET is Android-only/,
+      );
       expect(() => validateTypeForPlatform("ios", "LONG")).toThrow(/LONG is Android-only/);
     });
 
@@ -261,7 +370,9 @@ describe("Storage Tools Registration", () => {
     });
 
     test("rejects the read-only UNKNOWN type on either platform", () => {
-      expect(() => validateTypeForPlatform("android", "UNKNOWN")).toThrow(/UNKNOWN type is read-only/);
+      expect(() => validateTypeForPlatform("android", "UNKNOWN")).toThrow(
+        /UNKNOWN type is read-only/,
+      );
       expect(() => validateTypeForPlatform("ios", "UNKNOWN")).toThrow(/UNKNOWN type is read-only/);
     });
 


### PR DESCRIPTION
## Summary

Wires the Jetpack **DataStore** storage adapter through the full MCP inspection chain so DataStore-backed preferences are reachable via the tool surface, not only `adb shell content call`. The SDK-side adapter contract + debug `ContentProvider` (`listDataStores`/`getDataStore`) shipped in #5567; this PR builds every layer above it, mirroring the existing SharedPreferences path.

DataStore descriptors/entries **reuse the SharedPreferences `preference_files` / `preferences` result envelope** on the wire (`StorageResponse.FileList` / `Preferences`, path emitted empty), disambiguated by `requestId` — so the only new protocol surface is the two request types.

**Delivery note:** reaching a live device requires re-cutting the pinned Android control-proxy artifact (`src/constants/release.ts` checksums), a maintainer/release-workflow step tracked separately (see Follow-ups). This PR lands the code + tests; it is serialization- and unit-testable in full but not end-to-end live until the re-cut.

## Linked Issue

Closes #5573

## Changes

- **protocol** (`WebSocketRequest.kt`): `list_data_stores` / `get_data_store` request types (`adapterName`, `storeName`).
- **control-proxy**: `CtrlProxyActions` interface methods, `CtrlProxyMessageHandler` dispatch, `CtrlProxy` handlers (reuse the existing preference-result broadcast helpers), and `StorageSubscriptionManager.listDataStores` / `getDataStore` calling the SDK `ContentProvider` (`"listDataStores"`/`"getDataStore"` with `adapterName`/`storeName` extras).
- **TS**: `ctrlProxyProtocol` interfaces + builders + `REQUEST_TYPE_REGISTRY`; `CtrlProxyStorage` + `AndroidCtrlProxyClient` client methods; `listDataStores` / `getDataStore` MCP tools (Android-only, `embeddedSdkOnly`).
- **schemas**: regenerated `tool-definitions.json`.

## Acceptance Criteria

- [x] **AC1** — `StorageSubscriptionManager` exposes `listDataStores`/`getDataStore` routing to the SDK provider with `adapterName`/`storeName` extras → `StorageSubscriptionManagerTest` (extras captured, `StoreNotFound`→`FileNotFound`).
- [x] **AC2** — `CtrlProxy` dispatches `list_data_stores`/`get_data_store` to handlers → `CtrlProxyMessageHandlerTest` dispatch cases + module compiles.
- [x] **AC3** — TS wire types + client methods send the commands and resolve results → `ctrlProxyProtocol.test.ts` (byte-identical serialization + `@SerialName` drift guard) and `CtrlProxyStorage.test.ts` (round-trips).
- [x] **AC4** — user-facing MCP tools expose DataStore inspection → `storageTools.test.ts` (registration + schema).

## Validation

- [x] `bun test` — whole suite green (one **pre-existing** full-suite ordering flake, `CtrlProxyClient.test.ts › late invalidated-observer cleanup`, reproduces identically on clean `main` with none of this diff; green in isolation).
- [x] `bun run typecheck` — no new errors (baseline refreshed for a column shift; count unchanged at 175).
- [x] `bun run lint` — oxlint ratchet: no new violations. oxfmt + ktfmt clean.
- [x] Android: `:protocol:test` + `:control-proxy:testDebugUnitTest` green; `:protocol:detekt` + `:control-proxy:detekt` green.
- [x] New code uses interfaces + fakes; unit tests run in <100ms.

## Kotlin Reuse Check

- [x] Mirrors the existing `SharedPreferences` path and **reuses** the shared `StorageResponse` shapes and the existing preference-result broadcast helpers rather than adding new wire/result types or helpers. No new dependencies.

## Device Verification

- [ ] N/A until the control-proxy artifact is re-cut (see Delivery note / Follow-ups).

## Follow-ups

- [ ] Re-cut the pinned Android control-proxy artifact (`src/constants/release.ts` checksums) to make the DataStore MCP chain reachable end-to-end on a live device — maintainer/release step (progresses #5192).
- [ ] Optional wire method for `DataStoreInspector.capabilities()` so capability reporting is client-queryable (the "Consider" item from #5573's scope; host-facing API only today).
