### PR TITLE
ci(format): fail formatter gate when change detection skips

### DIFF
--- a/.github/workflows/merge.yml
+++ b/.github/workflows/merge.yml
@@ -243,6 +243,26 @@ jobs:
         run: |
           INSTALL_KTFMT_WHEN_MISSING=true ONLY_TOUCHED_FILES=false scripts/ktfmt/validate_ktfmt.sh
 
+  oxfmt:
+    name: "oxfmt"
+    runs-on: ubuntu-latest
+    steps:
+      - name: "Git Checkout"
+        uses: actions/checkout@v6
+        with:
+          lfs: false
+
+      - name: "Setup Bun"
+        uses: oven-sh/setup-bun@v2
+        with:
+          bun-version: 1.3.14
+
+      - name: "Install Bun dependencies"
+        run: bun install --frozen-lockfile
+
+      - name: "Run oxfmt"
+        run: bun run format:check
+
   # The full-tree backstop. PRs run detekt scoped to the modules they changed
   # (pull_request.yml), which cannot see a violation introduced in a *consumer*
   # of a changed module -- this unscoped post-merge run is what catches that.

--- a/.github/workflows/pull_request.yml
+++ b/.github/workflows/pull_request.yml
@@ -713,7 +713,12 @@ jobs:
       - name: "Require formatter result"
         shell: bash
         run: |
+          detect_result="${{ needs.detect-changes.result }}"
           formatter_result="${{ needs.format-check.result }}"
+          if [[ "$detect_result" != "success" ]]; then
+            echo "Change detection concluded $detect_result; formatter gate cannot be trusted"
+            exit 1
+          fi
           if [[ "$formatter_result" == "failure" || "$formatter_result" == "cancelled" ]]; then
             echo "Formatter gate concluded $formatter_result"
             exit 1

--- a/test/scripts/oxfmtWorkflow.test.ts
+++ b/test/scripts/oxfmtWorkflow.test.ts
@@ -2,6 +2,7 @@ import { describe, expect, test } from "bun:test";
 import { loadJobSteps, loadWorkflow, stepNamed } from "../helpers/workflowSteps";
 
 const WORKFLOW = ".github/workflows/pull_request.yml";
+const MERGE_WORKFLOW = ".github/workflows/merge.yml";
 const JOB_ID = "format-check";
 const FORMAT_STEP = "Check formatting";
 
@@ -32,8 +33,27 @@ describe("#5531 formatting workflow", () => {
   test("makes formatting a dependency of required Fast Validation", () => {
     const fastValidation = loadWorkflow(WORKFLOW).jobs?.["fast-validation"];
     expect(fastValidation?.needs).toContain("format-check");
-    expect(loadJobSteps(WORKFLOW, "fast-validation").map((step) => step.name)).toContain(
-      "Require formatter result",
+    const guard = stepNamed(loadJobSteps(WORKFLOW, "fast-validation"), "Require formatter result");
+
+    expect(guard).toBeDefined();
+    expect(guard?.run).toContain('detect_result="${{ needs.detect-changes.result }}"');
+    expect(guard?.run).toContain('if [[ "$detect_result" != "success" ]]; then');
+    expect(guard?.run).toContain(
+      'echo "Change detection concluded $detect_result; formatter gate cannot be trusted"',
     );
+    expect(guard?.run).toContain('formatter_result="${{ needs.format-check.result }}"');
+    expect(guard?.run).toContain(
+      'if [[ "$formatter_result" == "failure" || "$formatter_result" == "cancelled" ]]; then',
+    );
+  });
+
+  test("runs the full-tree formatter backstop after merge", () => {
+    const steps = loadJobSteps(MERGE_WORKFLOW, "oxfmt");
+    const format = stepNamed(steps, "Run oxfmt");
+
+    expect(steps.length).toBeGreaterThan(0);
+    expect(format?.run).toBe("bun run format:check");
+    expect(steps.some((step) => step.uses === "actions/checkout@v6")).toBe(true);
+    expect(steps.some((step) => step.uses === "oven-sh/setup-bun@v2")).toBe(true);
   });
 });


### PR DESCRIPTION
## Summary

- Close the P1 raised during review of [#5566](https://github.com/kaeawc/auto-mobile/pull/5566): make Fast Validation fail closed when change detection fails or is cancelled, preventing a skipped formatter job from passing the required gate.
- Add an `oxfmt --check` full-tree post-merge backstop to `merge.yml`, matching the existing ktfmt and detekt safety nets.
- Extend formatter workflow regression coverage for the detection-result guard and merge backstop.

## Root cause

`format-check` is skipped when `detect-changes` does not succeed. The existing required-gate step only rejected formatter failure/cancellation, so a failed or cancelled detection job could result in a green Fast Validation check without verifying formatting.

## Validation

- `bun run validate:yaml`
- `bun test test/scripts/oxfmtWorkflow.test.ts`
- `bats test/bats/pr-gate-wiring.bats`
- `bunx oxfmt --check .github/workflows/pull_request.yml .github/workflows/merge.yml test/scripts/oxfmtWorkflow.test.ts`
