### PR TITLE
fix(android): make profile targeting metadata-driven

### DIFF
--- a/docs/design-docs/plat/android/work-profiles.md
+++ b/docs/design-docs/plat/android/work-profiles.md
@@ -8,34 +8,34 @@ This guide explains how to set up and test Android work profiles with AutoMobile
 
 ## What is a Work Profile?
 
-An Android work profile is a separate user profile on a device that allows organizations to manage work-related apps and data separately from personal apps. Each profile has its own user ID:
-
-- **User 0**: Primary/Personal profile
-- **User 10+**: Work profiles or other managed profiles
+An Android work profile is a separate user profile on a device that allows organizations to manage work-related apps and data separately from personal apps. Each profile has its own user ID. Android also reports profile metadata through `pm list users`; user IDs are opaque identifiers and are not used to infer profile type.
 
 ## AutoMobile Work Profile Support
 
 AutoMobile automatically detects and handles work profiles across all app management features:
 
 - **Auto-detection**: Features automatically detect the appropriate user profile
-- **Priority order**:
+- **Selection order**:
 
   ```mermaid
   flowchart LR
       A["Select user profile"] --> B{"App in foreground?"};
       B -->|"yes"| C["Use foreground app user profile"];
-      B -->|"no"| D{"Running work profile exists?"};
-      D -->|"yes"| E["Use first running<br/>work profile"];
-      D -->|"no"| F["Use primary user<br/>(user 0)"];
+      B -->|"no"| D{"Running managed profile exists?"};
+      D -->|"one"| E["Use the running<br/>managed profile"];
+      D -->|"zero"| F["Use the metadata-identified<br/>primary profile"];
+      D -->|"multiple"| G["Fail: target is ambiguous"];
       classDef decision fill:#CC2200,stroke-width:0px,color:white;
       classDef logic fill:#525FE1,stroke-width:0px,color:white;
       classDef result stroke-width:0px;
       class A logic;
       class B,D decision;
-      class C,E,F result;
+      class C,E,F,G result;
   ```
 
 - **userId in responses**: App management tools include the `userId` field indicating which profile was used
+- **Ambiguous state**: Multiple running managed profiles or unavailable user
+  metadata causes the operation to fail instead of guessing a user
 - **Note**: MCP tool schemas do not currently accept a `userId` override; selection is automatic
 
 ### Supported Features
@@ -215,8 +215,9 @@ adb shell pm list users
 
 # AutoMobile will:
 # 1. Check foreground app first
-# 2. Fall back to first work profile (user 10)
-# 3. Fall back to primary (user 0)
+# 2. Use the sole running managed profile, when exactly one exists
+# 3. Fall back to the metadata-identified primary profile
+# 4. Fail when user discovery is unavailable or multiple managed profiles run
 ```
 
 ### Scenario 3: Same App in Both Profiles

--- a/src/db/migrations/2026_08_24_000_installed_apps_profile_type.ts
+++ b/src/db/migrations/2026_08_24_000_installed_apps_profile_type.ts
@@ -1,0 +1,9 @@
+import type { Kysely } from "kysely";
+
+export async function up(db: Kysely<unknown>): Promise<void> {
+  await db.schema.alterTable("installed_apps").addColumn("profile_type", "text").execute();
+}
+
+export async function down(db: Kysely<unknown>): Promise<void> {
+  await db.schema.alterTable("installed_apps").dropColumn("profile_type").execute();
+}

--- a/src/db/types.ts
+++ b/src/db/types.ts
@@ -24,6 +24,7 @@ interface InstalledAppsTable {
   is_system: number; // SQLite boolean (0/1)
   installed_at: number;
   last_verified_at: number;
+  profile_type: Generated<"primary" | "managed" | "secondary" | "unknown" | null>;
   daemon_session_id: string | null;
   device_session_start: number | null;
 }

--- a/src/features/action/LaunchApp.ts
+++ b/src/features/action/LaunchApp.ts
@@ -742,7 +742,7 @@ export class LaunchApp extends BaseVisualChange {
 
     // Check if app is running
     const isRunning = await perf.track("checkRunning", async () => {
-      const isRunningCmd = `shell ps | grep ${packageName} | grep -v grep | wc -l`;
+      const isRunningCmd = `shell dumpsys activity processes | grep -E "${packageName}/u${targetUserId}a" | wc -l`;
       logger.info(`[LaunchApp] Checking if app is running: ${isRunningCmd}`);
       const isRunningOutput = await this.adb.executeCommand(isRunningCmd);
       const result = parseInt(isRunningOutput.trim(), 10) > 0;

--- a/src/features/action/TerminateApp.ts
+++ b/src/features/action/TerminateApp.ts
@@ -87,12 +87,12 @@ export class TerminateApp extends BaseVisualChange {
       const isInstalled = await perf.track("checkInstalled", async () => {
         try {
           const a11y = AndroidCtrlProxyClient.getInstance(this.device);
-          const result = await a11y.requestInstalledPackages(true, undefined, 3000);
+          const result = await a11y.requestInstalledPackages(true, targetUserId, 3000);
           if (result.success && result.userId === targetUserId) {
             return result.packages.some((p) => p.packageName === packageName);
           }
-        } catch {
-          // fall through
+        } catch (error) {
+          logger.debug(`[TerminateApp] CtrlProxy install check failed: ${error}`, error);
         }
         try {
           const isInstalledCmd = `shell pm list packages --user ${targetUserId} -f ${packageName} | grep -c ${packageName}`;
@@ -122,8 +122,23 @@ export class TerminateApp extends BaseVisualChange {
         };
       }
 
-      // Check if app is running
-      const isRunning = true;
+      // `force-stop` is destructive, so determine the selected user's process
+      // state before changing it. A package running in another profile must not
+      // make this operation report that the selected profile was running.
+      const isRunning = await perf.track("checkRunning", async () => {
+        try {
+          const result = await this.adb.executeCommand(
+            `shell dumpsys activity processes | grep -E "u${targetUserId} .*${packageName}"`,
+            undefined,
+            undefined,
+            true,
+          );
+          return result.stdout.trim().length > 0;
+        } catch (error) {
+          logger.warn(`[TerminateApp] Running-state check failed for user ${targetUserId}`, error);
+          return false;
+        }
+      });
 
       if (!isRunning) {
         return {

--- a/src/features/action/TerminateApp.ts
+++ b/src/features/action/TerminateApp.ts
@@ -2,7 +2,7 @@ import { errorMessage } from "../../utils/describeUnknownError";
 import { AdbClient } from "../../utils/android-cmdline-tools/AdbClient";
 import { AndroidUserTargetResolver } from "../../utils/android-cmdline-tools/AndroidUserTargetResolver";
 import { BaseVisualChange, ProgressCallback } from "./BaseVisualChange";
-import { BootedDevice, TerminateAppResult } from "../../models";
+import { ActionableError, BootedDevice, TerminateAppResult } from "../../models";
 import { createGlobalPerformanceTracker } from "../../utils/PerformanceTracker";
 import { SimCtlClient } from "../../utils/ios-cmdline-tools/SimCtlClient";
 import { DeviceAppManager } from "../../utils/ios-cmdline-tools/DeviceAppManager";
@@ -136,7 +136,9 @@ export class TerminateApp extends BaseVisualChange {
           return result.stdout.trim().length > 0;
         } catch (error) {
           logger.warn(`[TerminateApp] Running-state check failed for user ${targetUserId}`, error);
-          return false;
+          throw new ActionableError(
+            `Could not determine whether ${packageName} is running for Android user ${targetUserId}: ${errorMessage(error)}`,
+          );
         }
       });
 

--- a/src/features/action/TerminateApp.ts
+++ b/src/features/action/TerminateApp.ts
@@ -128,7 +128,7 @@ export class TerminateApp extends BaseVisualChange {
       const isRunning = await perf.track("checkRunning", async () => {
         try {
           const result = await this.adb.executeCommand(
-            `shell dumpsys activity processes | grep -E "u${targetUserId} .*${packageName}"`,
+            `shell dumpsys activity processes | grep -E "${packageName}/u${targetUserId}a"`,
             undefined,
             undefined,
             true,

--- a/src/features/observe/ListInstalledApps.ts
+++ b/src/features/observe/ListInstalledApps.ts
@@ -239,7 +239,7 @@ export class ListInstalledApps {
         installedApps.profiles[row.user_id].push({
           packageName: row.package_name,
           userId: row.user_id,
-          profileType: this.profileTypeForUser(row.user_id, users),
+          profileType: this.profileTypeForUser(row.user_id, users, row.profile_type ?? undefined),
           foreground: isForeground,
           recent: false,
         });
@@ -262,9 +262,16 @@ export class ListInstalledApps {
     }
   }
 
-  private profileTypeForUser(userId: number, users: AndroidUser[]): AndroidUser["profileType"] {
+  private profileTypeForUser(
+    userId: number,
+    users: AndroidUser[],
+    cachedProfileType: AndroidUser["profileType"],
+  ): AndroidUser["profileType"] {
     const user = users.find((candidate) => candidate.userId === userId);
-    return user?.profileType ?? (user ? classifyAndroidUser(user.flags) : "unknown");
+    return (
+      user?.profileType ??
+      (user ? classifyAndroidUser(user.flags) : (cachedProfileType ?? "unknown"))
+    );
   }
 
   private async rebuildInstalledAppsCache(): Promise<InstalledAppsDetailedResult> {
@@ -329,6 +336,7 @@ export class ListInstalledApps {
               is_system: 0,
               installed_at: timestampMs,
               last_verified_at: timestampMs,
+              profile_type: user.profileType ?? classifyAndroidUser(user.flags),
             });
           }
         }
@@ -364,6 +372,7 @@ export class ListInstalledApps {
               is_system: 1,
               installed_at: timestampMs,
               last_verified_at: timestampMs,
+              profile_type: user.profileType ?? classifyAndroidUser(user.flags),
             });
           }
         }

--- a/src/features/observe/ListInstalledApps.ts
+++ b/src/features/observe/ListInstalledApps.ts
@@ -6,6 +6,7 @@ import type { AdbExecutor } from "../../utils/android-cmdline-tools/interfaces/A
 import { logger } from "../../utils/logger";
 import {
   ActionableError,
+  AndroidUser,
   BootedDevice,
   classifyAndroidUser,
   InstalledAppsByProfile,
@@ -197,15 +198,17 @@ export class ListInstalledApps {
 
     const foregroundApp =
       this.device.platform === "android" ? await this.adb.getForegroundApp() : null;
+    const users = await this.getAndroidUsersForCache();
     logger.info(
       `[ListInstalledApps] Using cached installed apps list (age ${cacheAgeMs}ms, rows ${cachedRows.length})`,
     );
-    return this.buildInstalledAppsFromRows(cachedRows, foregroundApp);
+    return this.buildInstalledAppsFromRows(cachedRows, foregroundApp, users);
   }
 
   private buildInstalledAppsFromRows(
     rows: DbInstalledApp[],
     foregroundApp: { packageName: string; userId: number } | null,
+    users: AndroidUser[] = [],
   ): InstalledAppsByProfile {
     const installedApps: InstalledAppsByProfile = { profiles: {}, system: [] };
     const systemAppsMap = new Map<string, SystemInstalledApp>();
@@ -236,7 +239,7 @@ export class ListInstalledApps {
         installedApps.profiles[row.user_id].push({
           packageName: row.package_name,
           userId: row.user_id,
-          profileType: row.user_id === 0 ? "primary" : "unknown",
+          profileType: this.profileTypeForUser(row.user_id, users),
           foreground: isForeground,
           recent: false,
         });
@@ -245,6 +248,23 @@ export class ListInstalledApps {
 
     installedApps.system = Array.from(systemAppsMap.values());
     return installedApps;
+  }
+
+  private async getAndroidUsersForCache(): Promise<AndroidUser[]> {
+    if (this.device.platform !== "android") {
+      return [];
+    }
+    try {
+      return await this.adb.listUsers();
+    } catch (error) {
+      logger.warn("[ListInstalledApps] Failed to refresh user metadata for cached apps", error);
+      return [];
+    }
+  }
+
+  private profileTypeForUser(userId: number, users: AndroidUser[]): AndroidUser["profileType"] {
+    const user = users.find((candidate) => candidate.userId === userId);
+    return user?.profileType ?? (user ? classifyAndroidUser(user.flags) : "unknown");
   }
 
   private async rebuildInstalledAppsCache(): Promise<InstalledAppsDetailedResult> {
@@ -294,8 +314,7 @@ export class ListInstalledApps {
           installedApps.profiles[user.userId].push({
             packageName,
             userId: user.userId,
-            profileType:
-              user.profileType ?? classifyAndroidUser(user.userId, user.flags),
+            profileType: user.profileType ?? classifyAndroidUser(user.flags),
             foreground: isForeground,
             recent: false, // TODO: Implement recent app detection
           });

--- a/src/features/observe/ListInstalledApps.ts
+++ b/src/features/observe/ListInstalledApps.ts
@@ -7,6 +7,7 @@ import { logger } from "../../utils/logger";
 import {
   ActionableError,
   BootedDevice,
+  classifyAndroidUser,
   InstalledAppsByProfile,
   SystemInstalledApp,
 } from "../../models";
@@ -235,6 +236,7 @@ export class ListInstalledApps {
         installedApps.profiles[row.user_id].push({
           packageName: row.package_name,
           userId: row.user_id,
+          profileType: row.user_id === 0 ? "primary" : "unknown",
           foreground: isForeground,
           recent: false,
         });
@@ -292,6 +294,8 @@ export class ListInstalledApps {
           installedApps.profiles[user.userId].push({
             packageName,
             userId: user.userId,
+            profileType:
+              user.profileType ?? classifyAndroidUser(user.userId, user.flags),
             foreground: isForeground,
             recent: false, // TODO: Implement recent app detection
           });

--- a/src/features/observe/android/AndroidCtrlProxyClient.ts
+++ b/src/features/observe/android/AndroidCtrlProxyClient.ts
@@ -20,7 +20,6 @@ import {
   defaultAdbClientFactory,
 } from "../../../utils/android-cmdline-tools/AdbClientFactory";
 import type { AdbExecutor } from "../../../utils/android-cmdline-tools/interfaces/AdbExecutor";
-import type { AdbClient } from "../../../utils/android-cmdline-tools/AdbClient";
 import { logger, type Logger } from "../../../utils/logger";
 import { rewriteUnknownCommandError } from "../shared/rewriteUnknownCommandError";
 import {
@@ -1412,7 +1411,7 @@ export class AndroidCtrlProxyClient extends DeviceServiceClient implements Andro
    */
   public static createForTesting(
     device: BootedDevice,
-    adb: AdbClient,
+    adb: AdbExecutor,
     webSocketFactory: (url: string) => WebSocket,
     timer?: Timer,
     installedAppsRepository?: InstalledAppsStore,

--- a/src/models/AndroidUser.ts
+++ b/src/models/AndroidUser.ts
@@ -22,7 +22,30 @@ export interface AndroidUser {
   flags: number;
 
   /**
+   * Classification derived from Android's flags, never from the numeric ID.
+   * `unknown` is intentional when the platform does not provide enough
+   * metadata to distinguish a secondary user from a managed profile.
+   */
+  profileType?: "primary" | "managed" | "secondary" | "unknown";
+
+  /**
    * Whether the user is currently running
    */
   running: boolean;
+}
+
+export function classifyAndroidUser(
+  userId: number,
+  flags: number,
+): NonNullable<AndroidUser["profileType"]> {
+  if ((flags & 0x20) !== 0) {
+    return "managed";
+  }
+  if ((flags & 0x1) !== 0 || userId === 0) {
+    return "primary";
+  }
+  if ((flags & 0x400) !== 0) {
+    return "secondary";
+  }
+  return "unknown";
 }

--- a/src/models/AndroidUser.ts
+++ b/src/models/AndroidUser.ts
@@ -34,14 +34,12 @@ export interface AndroidUser {
   running: boolean;
 }
 
-export function classifyAndroidUser(
-  userId: number,
-  flags: number,
-): NonNullable<AndroidUser["profileType"]> {
+export function classifyAndroidUser(flags: number): NonNullable<AndroidUser["profileType"]> {
+  const FLAG_MAIN = 0x4000;
   if ((flags & 0x20) !== 0) {
     return "managed";
   }
-  if ((flags & 0x1) !== 0 || userId === 0) {
+  if ((flags & FLAG_MAIN) !== 0 || (flags & 0x1) !== 0) {
     return "primary";
   }
   if ((flags & 0x400) !== 0) {

--- a/src/models/InstalledApp.ts
+++ b/src/models/InstalledApp.ts
@@ -15,6 +15,12 @@ export interface InstalledApp {
   userId: number;
 
   /**
+   * Android's parsed profile classification. It is optional for cached rows
+   * created before profile metadata was persisted.
+   */
+  profileType?: "primary" | "managed" | "secondary" | "unknown";
+
+  /**
    * Whether this app instance is currently in the foreground
    */
   foreground: boolean;

--- a/src/server/appResources.ts
+++ b/src/server/appResources.ts
@@ -47,7 +47,7 @@ interface AppsQueryAppInfo {
   foreground: boolean;
   recent: boolean;
   userId?: number;
-  userProfile?: "personal" | "work";
+  userProfile?: "personal" | "work" | "secondary" | "unknown";
   userIds?: number[];
   displayName?: string;
 }
@@ -84,7 +84,7 @@ interface AppsResourceContent {
 interface AndroidInstalledAppInfo {
   packageName: string;
   userId: number;
-  userProfile: "personal" | "work";
+  userProfile: "personal" | "work" | "secondary" | "unknown";
   foreground: boolean;
   recent: boolean;
 }
@@ -111,15 +111,27 @@ const appCacheByDeviceId = new Map<string, AppsCacheEntry>();
 const registeredDeviceResources = new Map<string, string>();
 const appsQueryUrisByDeviceId = new Map<string, Map<string, number>>();
 
-function userProfileForUserId(userId: number): "personal" | "work" {
-  return userId >= 10 ? "work" : "personal";
+function userProfileForUserId(
+  userId: number,
+  profileType?: InstalledApp["profileType"],
+): "personal" | "work" | "secondary" | "unknown" {
+  if (profileType === "managed") {
+    return "work";
+  }
+  if (profileType === "secondary") {
+    return "secondary";
+  }
+  if (profileType === "primary" || userId === 0) {
+    return "personal";
+  }
+  return "unknown";
 }
 
 function toInstalledAppInfo(app: InstalledApp): InstalledAppInfo {
   return {
     packageName: app.packageName,
     userId: app.userId,
-    userProfile: userProfileForUserId(app.userId),
+    userProfile: userProfileForUserId(app.userId, app.profileType),
     foreground: app.foreground,
     recent: app.recent,
   };

--- a/src/utils/android-cmdline-tools/AdbClient.ts
+++ b/src/utils/android-cmdline-tools/AdbClient.ts
@@ -1408,7 +1408,7 @@ export class AdbClient implements AdbExecutor {
           userId,
           name: userName,
           flags,
-          profileType: classifyAndroidUser(userId, flags),
+          profileType: classifyAndroidUser(flags),
           running,
         });
       }
@@ -1449,7 +1449,7 @@ export class AdbClient implements AdbExecutor {
             userId,
             name: match[2],
             flags, // Parse as hexadecimal
-            profileType: classifyAndroidUser(userId, flags),
+            profileType: classifyAndroidUser(flags),
             running: match[4] === "running",
           });
         }

--- a/src/utils/android-cmdline-tools/AdbClient.ts
+++ b/src/utils/android-cmdline-tools/AdbClient.ts
@@ -7,7 +7,13 @@ import {
   execFileAsync as sharedExecFileAsync,
   type HostProcessExecutor,
 } from "../HostCommandExecutor";
-import { BootedDevice, ExecResult, AndroidUser, DeviceLockState } from "../../models";
+import {
+  BootedDevice,
+  ExecResult,
+  AndroidUser,
+  classifyAndroidUser,
+  DeviceLockState,
+} from "../../models";
 import {
   AndroidToolsDetectionAbortError,
   AndroidToolsDetectionTimeoutError,
@@ -1402,6 +1408,7 @@ export class AdbClient implements AdbExecutor {
           userId,
           name: userName,
           flags,
+          profileType: classifyAndroidUser(userId, flags),
           running,
         });
       }
@@ -1436,10 +1443,13 @@ export class AdbClient implements AdbExecutor {
         // Note: flags are hexadecimal (e.g., "4c13")
         const match = line.match(/UserInfo\{(\d+):([^:]+):([0-9a-fA-F]+)\}\s*(running)?/);
         if (match) {
+          const userId = parseInt(match[1], 10);
+          const flags = parseInt(match[3], 16);
           users.push({
-            userId: parseInt(match[1], 10),
+            userId,
             name: match[2],
-            flags: parseInt(match[3], 16), // Parse as hexadecimal
+            flags, // Parse as hexadecimal
+            profileType: classifyAndroidUser(userId, flags),
             running: match[4] === "running",
           });
         }
@@ -1457,26 +1467,12 @@ export class AdbClient implements AdbExecutor {
         `[ADB] Failed to parse users from pm list users. Raw output: ${result.stdout.substring(0, 200)}`,
       );
 
-      // Return primary user as last resort fallback
-      return [
-        {
-          userId: 0,
-          name: "Owner",
-          flags: 0x13,
-          running: true,
-        },
-      ];
+      // An unparseable response is not evidence that user 0 is active.
+      return [];
     } catch (error) {
       logger.warn(`[ADB] Failed to list users via pm: ${(error as Error).message}`);
-      // Return primary user as fallback
-      return [
-        {
-          userId: 0,
-          name: "Owner",
-          flags: 0x13,
-          running: true,
-        },
-      ];
+      // An unavailable user service is not evidence that user 0 is active.
+      return [];
     }
   }
 

--- a/src/utils/android-cmdline-tools/AndroidUserTargetResolver.ts
+++ b/src/utils/android-cmdline-tools/AndroidUserTargetResolver.ts
@@ -1,11 +1,7 @@
 import type { AdbExecutor } from "./interfaces/AdbExecutor";
 import { classifyAndroidUser } from "../../models/AndroidUser";
 
-export type UserTargetSource =
-  | "explicit"
-  | "foregroundPackage"
-  | "managedProfile"
-  | "primary";
+export type UserTargetSource = "explicit" | "foregroundPackage" | "managedProfile" | "primary";
 
 export interface ResolvedUserTarget {
   userId: number;
@@ -43,9 +39,7 @@ export class AndroidUserTargetResolver {
 
     const users = await this.adb.listUsers(request.signal);
     const managedProfiles = users.filter(
-      (user) =>
-        user.running &&
-        (user.profileType ?? classifyAndroidUser(user.userId, user.flags)) === "managed",
+      (user) => user.running && (user.profileType ?? classifyAndroidUser(user.flags)) === "managed",
     );
     if (managedProfiles.length === 1) {
       const managedProfile = managedProfiles[0];
@@ -59,9 +53,7 @@ export class AndroidUserTargetResolver {
     }
 
     const primary = users.find(
-      (user) =>
-        user.running &&
-        (user.profileType ?? classifyAndroidUser(user.userId, user.flags)) === "primary",
+      (user) => user.running && (user.profileType ?? classifyAndroidUser(user.flags)) === "primary",
     );
     if (primary) {
       return { userId: primary.userId, source: "primary" };

--- a/src/utils/android-cmdline-tools/AndroidUserTargetResolver.ts
+++ b/src/utils/android-cmdline-tools/AndroidUserTargetResolver.ts
@@ -1,10 +1,11 @@
 import type { AdbExecutor } from "./interfaces/AdbExecutor";
+import { classifyAndroidUser } from "../../models/AndroidUser";
 
 export type UserTargetSource =
   | "explicit"
   | "foregroundPackage"
   | "managedProfile"
-  | "primaryFallback";
+  | "primary";
 
 export interface ResolvedUserTarget {
   userId: number;
@@ -20,8 +21,10 @@ export interface UserTargetRequest {
 /**
  * Resolves the user for one public operation. Explicit IDs (including zero)
  * win; otherwise a foreground instance of the requested package wins, followed
- * by a running managed profile and finally the primary user. A secondary user
- * is never treated as managed solely because its ID is nonzero.
+ * by the sole running managed profile and finally the running primary user. A
+ * secondary user is never treated as managed solely because its ID is nonzero.
+ * Missing or ambiguous device state is rejected instead of silently targeting
+ * user 0.
  */
 export class AndroidUserTargetResolver {
   constructor(private readonly adb: AdbExecutor) {}
@@ -39,11 +42,33 @@ export class AndroidUserTargetResolver {
     }
 
     const users = await this.adb.listUsers(request.signal);
-    const managedProfile = users.find((user) => user.running && (user.flags & 0x20) !== 0);
-    if (managedProfile) {
+    const managedProfiles = users.filter(
+      (user) =>
+        user.running &&
+        (user.profileType ?? classifyAndroidUser(user.userId, user.flags)) === "managed",
+    );
+    if (managedProfiles.length === 1) {
+      const managedProfile = managedProfiles[0];
       return { userId: managedProfile.userId, source: "managedProfile" };
     }
 
-    return { userId: 0, source: "primaryFallback" };
+    if (managedProfiles.length > 1) {
+      throw new Error(
+        `Android target user is ambiguous: ${managedProfiles.length} managed profiles are running`,
+      );
+    }
+
+    const primary = users.find(
+      (user) =>
+        user.running &&
+        (user.profileType ?? classifyAndroidUser(user.userId, user.flags)) === "primary",
+    );
+    if (primary) {
+      return { userId: primary.userId, source: "primary" };
+    }
+
+    throw new Error(
+      "Android target user is unavailable: no running primary or uniquely selectable managed profile",
+    );
   }
 }

--- a/test/fakes/FakeAdbClient.ts
+++ b/test/fakes/FakeAdbClient.ts
@@ -49,7 +49,9 @@ export class FakeAdbClient implements FakeAdbClientContract {
   private foregroundApp: { packageName: string; userId: number } | null = null;
   private foregroundAppError: Error | null = null;
   private hangingCommandPatterns: string[] = [];
-  private users: Array<{ userId: number; name: string; flags?: number; running?: boolean }> = [];
+  private users: Array<{ userId: number; name: string; flags?: number; running?: boolean }> = [
+    { userId: 0, name: "Owner", flags: 0x13, running: true },
+  ];
   private deviceTimestampMs: number | null = null;
   private deviceTimestampSource: DeviceTimestampSource = "device-ms";
   private spawnCalls: string[][] = [];

--- a/test/features/action/LaunchApp.test.ts
+++ b/test/features/action/LaunchApp.test.ts
@@ -82,7 +82,10 @@ describe("LaunchApp", () => {
   test("returns observation when app is already in foreground", async () => {
     const controller = new AbortController();
     fakeAdb.setForegroundApp({ packageName, userId: 0 });
-    fakeAdb.setCommandResponse(`shell ps | grep ${packageName}`, { stdout: "1\n", stderr: "" });
+    fakeAdb.setCommandResponse(
+      `shell dumpsys activity processes | grep -E "${packageName}/u0a" | wc -l`,
+      { stdout: "1\n", stderr: "" },
+    );
 
     const result = await launchApp.execute(
       packageName,
@@ -165,7 +168,7 @@ describe("LaunchApp", () => {
     const executeSpy = spyOn(fakeAdb, "executeCommand").mockImplementation(
       async (command, timeoutMs, maxBuffer, noRetry, signal) => {
         const result = await originalExecuteCommand(command, timeoutMs, maxBuffer, noRetry, signal);
-        if (command.startsWith("shell ps | grep")) {
+        if (command.startsWith("shell dumpsys activity processes")) {
           controller.abort(deviceLoss);
         }
         return result;
@@ -335,10 +338,13 @@ describe("LaunchApp", () => {
       stdout: "Starting: Intent { act=android.intent.action.MAIN }",
       stderr: "",
     });
-    fakeAdb.setCommandResponse(`shell ps | grep ${settingsPackageName}`, {
-      stdout: "0\n",
-      stderr: "",
-    });
+    fakeAdb.setCommandResponse(
+      `shell dumpsys activity processes | grep -E "${settingsPackageName}/u0a" | wc -l`,
+      {
+        stdout: "0\n",
+        stderr: "",
+      },
+    );
     fakeAdb.setForegroundApp({ packageName: settingsPackageName, userId: 0 });
     fakeObserveScreen.setObserveResult(createObserveResult(settingsPackageName));
 
@@ -361,7 +367,10 @@ describe("LaunchApp", () => {
   test("clears Android app data through the injected action before relaunch", async () => {
     fakeTimer.enableAutoAdvance();
     fakeAdb.setForegroundApp({ packageName, userId: 0 });
-    fakeAdb.setCommandResponse(`shell ps | grep ${packageName}`, { stdout: "1\n", stderr: "" });
+    fakeAdb.setCommandResponse(
+      `shell dumpsys activity processes | grep -E "${packageName}/u0a" | wc -l`,
+      { stdout: "1\n", stderr: "" },
+    );
 
     const clearCalls: Array<{
       device: BootedDevice;
@@ -407,7 +416,10 @@ describe("LaunchApp", () => {
   test("clears Android app data through the injected action before relaunch when not running", async () => {
     fakeTimer.enableAutoAdvance();
     fakeAdb.setForegroundApp({ packageName, userId: 0 });
-    fakeAdb.setCommandResponse(`shell ps | grep ${packageName}`, { stdout: "0\n", stderr: "" });
+    fakeAdb.setCommandResponse(
+      `shell dumpsys activity processes | grep -E "${packageName}/u0a" | wc -l`,
+      { stdout: "0\n", stderr: "" },
+    );
 
     const clearCalls: Array<{
       device: BootedDevice;
@@ -437,7 +449,10 @@ describe("LaunchApp", () => {
   test("cold boots Android through the injected action before relaunch", async () => {
     fakeTimer.enableAutoAdvance();
     fakeAdb.setForegroundApp({ packageName, userId: 0 });
-    fakeAdb.setCommandResponse(`shell ps | grep ${packageName}`, { stdout: "1\n", stderr: "" });
+    fakeAdb.setCommandResponse(
+      `shell dumpsys activity processes | grep -E "${packageName}/u0a" | wc -l`,
+      { stdout: "1\n", stderr: "" },
+    );
 
     const clearCalls: string[] = [];
     const coldBootCalls: Array<{ device: BootedDevice; packageName: string; options: unknown }> =
@@ -484,7 +499,10 @@ describe("LaunchApp", () => {
 
   test("waits for foreground before returning observation", async () => {
     fakeAdb.setForegroundApp(null);
-    fakeAdb.setCommandResponse(`shell ps | grep ${packageName}`, { stdout: "0\n", stderr: "" });
+    fakeAdb.setCommandResponse(
+      `shell dumpsys activity processes | grep -E "${packageName}/u0a" | wc -l`,
+      { stdout: "0\n", stderr: "" },
+    );
 
     const resultPromise = launchApp.execute(packageName, false, false);
 
@@ -514,7 +532,10 @@ describe("LaunchApp", () => {
     ];
 
     fakeAdb.setForegroundApp({ packageName, userId: 0 });
-    fakeAdb.setCommandResponse(`shell ps | grep ${packageName}`, { stdout: "0\n", stderr: "" });
+    fakeAdb.setCommandResponse(
+      `shell dumpsys activity processes | grep -E "${packageName}/u0a" | wc -l`,
+      { stdout: "0\n", stderr: "" },
+    );
     fakeObserveScreen.setObserveResult(
       () => observations.shift() ?? createObserveResult(packageName),
     );
@@ -545,7 +566,10 @@ describe("LaunchApp", () => {
     const permissionControllerPackageName = "com.google.android.permissioncontroller";
 
     fakeAdb.setForegroundApp({ packageName: permissionControllerPackageName, userId: 0 });
-    fakeAdb.setCommandResponse(`shell ps | grep ${packageName}`, { stdout: "0\n", stderr: "" });
+    fakeAdb.setCommandResponse(
+      `shell dumpsys activity processes | grep -E "${packageName}/u0a" | wc -l`,
+      { stdout: "0\n", stderr: "" },
+    );
     fakeObserveScreen.setObserveResult({
       ...createObserveResult(permissionControllerPackageName),
       activeWindow: {
@@ -571,7 +595,10 @@ describe("LaunchApp", () => {
     const previousPackageName = "com.example.previous";
 
     fakeAdb.setForegroundApp({ packageName, userId: 0 });
-    fakeAdb.setCommandResponse(`shell ps | grep ${packageName}`, { stdout: "0\n", stderr: "" });
+    fakeAdb.setCommandResponse(
+      `shell dumpsys activity processes | grep -E "${packageName}/u0a" | wc -l`,
+      { stdout: "0\n", stderr: "" },
+    );
     fakeObserveScreen.setObserveResult(() => createObserveResult(previousPackageName));
 
     const result = await launchApp.execute(packageName, false, false);

--- a/test/features/action/TerminateApp.test.ts
+++ b/test/features/action/TerminateApp.test.ts
@@ -272,6 +272,10 @@ describe("TerminateApp (Android)", () => {
       "shell pm list packages --user 0 -f com.example.app | grep -c com.example.app",
       "1",
     );
+    fakeAdb.setCommandResult(
+      'shell dumpsys activity processes | grep -E "u0 .*com.example.app"',
+      "u0a123 com.example.app",
+    );
     fakeAdb.setCommandResult("shell am force-stop --user 0 com.example.app", "");
 
     const terminateApp = new TerminateApp(androidDevice, fakeAdb as any, null, fakeTimer);
@@ -517,6 +521,10 @@ describe("TerminateApp (observed interaction, perf-tree ownership)", () => {
     fakeAdb.setCommandResult(
       "shell pm list packages --user 0 -f com.example.app | grep -c com.example.app",
       "1",
+    );
+    fakeAdb.setCommandResult(
+      'shell dumpsys activity processes | grep -E "u0 .*com.example.app"',
+      "u0a123 com.example.app",
     );
     fakeAdb.setCommandResult("shell am force-stop --user 0 com.example.app", "");
 

--- a/test/features/action/TerminateApp.test.ts
+++ b/test/features/action/TerminateApp.test.ts
@@ -267,14 +267,14 @@ describe("TerminateApp (Android)", () => {
 
   test("terminates installed foreground app", async () => {
     fakeAdb.setForegroundApp({ packageName: "com.example.app", userId: 0 });
-    fakeAdb.setUsers([{ userId: 0, name: "Owner", running: true }]);
+    fakeAdb.setUsers([{ userId: 0, name: "Owner", flags: 0x4000, running: true }]);
     fakeAdb.setCommandResult(
       "shell pm list packages --user 0 -f com.example.app | grep -c com.example.app",
       "1",
     );
     fakeAdb.setCommandResult(
-      'shell dumpsys activity processes | grep -E "u0 .*com.example.app"',
-      "u0a123 com.example.app",
+      'shell dumpsys activity processes | grep -E "com.example.app/u0a"',
+      "3220:com.example.app/u0a123",
     );
     fakeAdb.setCommandResult("shell am force-stop --user 0 com.example.app", "");
 
@@ -291,7 +291,7 @@ describe("TerminateApp (Android)", () => {
 
   test("returns not installed when package is missing", async () => {
     fakeAdb.setForegroundApp(null);
-    fakeAdb.setUsers([{ userId: 0, name: "Owner", running: true }]);
+    fakeAdb.setUsers([{ userId: 0, name: "Owner", flags: 0x4000, running: true }]);
     fakeAdb.setCommandResult(
       "shell pm list packages --user 0 -f com.example.app | grep -c com.example.app",
       "0",
@@ -310,7 +310,7 @@ describe("TerminateApp (Android)", () => {
 
   test("treats grep -c failure as not installed instead of throwing", async () => {
     fakeAdb.setForegroundApp(null);
-    fakeAdb.setUsers([{ userId: 0, name: "Owner", running: true }]);
+    fakeAdb.setUsers([{ userId: 0, name: "Owner", flags: 0x4000, running: true }]);
     // Simulate the install-probe shell command throwing (grep -c exits 1 when the
     // package is absent). The error key MUST be the exact command string — the
     // fake matches errors by exact command, so a substring key never fires and
@@ -517,14 +517,14 @@ describe("TerminateApp (observed interaction, perf-tree ownership)", () => {
 
   test("Android: force-stops and produces a well-formed perf tree", async () => {
     fakeAdb.setForegroundApp({ packageName: "com.example.app", userId: 0 });
-    fakeAdb.setUsers([{ userId: 0, name: "Owner", running: true }]);
+    fakeAdb.setUsers([{ userId: 0, name: "Owner", flags: 0x4000, running: true }]);
     fakeAdb.setCommandResult(
       "shell pm list packages --user 0 -f com.example.app | grep -c com.example.app",
       "1",
     );
     fakeAdb.setCommandResult(
-      'shell dumpsys activity processes | grep -E "u0 .*com.example.app"',
-      "u0a123 com.example.app",
+      'shell dumpsys activity processes | grep -E "com.example.app/u0a"',
+      "3220:com.example.app/u0a123",
     );
     fakeAdb.setCommandResult("shell am force-stop --user 0 com.example.app", "");
 

--- a/test/features/action/TerminateApp.test.ts
+++ b/test/features/action/TerminateApp.test.ts
@@ -308,6 +308,26 @@ describe("TerminateApp (Android)", () => {
     expect(fakeAdb.wasCommandExecuted("force-stop")).toBe(false);
   });
 
+  test("fails instead of reporting a stopped app when the user-scoped process check fails", async () => {
+    fakeAdb.setForegroundApp(null);
+    fakeAdb.setUsers([{ userId: 0, name: "Owner", flags: 0x4000, running: true }]);
+    fakeAdb.setCommandResult(
+      "shell pm list packages --user 0 -f com.example.app | grep -c com.example.app",
+      "1",
+    );
+    fakeAdb.setCommandError(
+      'shell dumpsys activity processes | grep -E "com.example.app/u0a"',
+      new Error("dumpsys unavailable"),
+    );
+
+    const terminateApp = new TerminateApp(androidDevice, fakeAdb as any, null, fakeTimer);
+
+    await expect(
+      terminateApp.execute("com.example.app", { skipObservation: true }),
+    ).rejects.toThrow("Could not determine whether com.example.app is running for Android user 0");
+    expect(fakeAdb.wasCommandExecuted("force-stop")).toBe(false);
+  });
+
   test("treats grep -c failure as not installed instead of throwing", async () => {
     fakeAdb.setForegroundApp(null);
     fakeAdb.setUsers([{ userId: 0, name: "Owner", flags: 0x4000, running: true }]);

--- a/test/features/action/UninstallApp.test.ts
+++ b/test/features/action/UninstallApp.test.ts
@@ -227,7 +227,7 @@ describe("UninstallApp (Android)", () => {
 
   test("emits force-stop then a data-clearing pm uninstall for the target user", async () => {
     fakeAdb.setForegroundApp({ packageName: "com.example.app", userId: 0 });
-    fakeAdb.setUsers([{ userId: 0, name: "Owner", running: true }]);
+    fakeAdb.setUsers([{ userId: 0, name: "Owner", flags: 0x4000, running: true }]);
     // Pre-uninstall the app is present; the post-uninstall re-check sees it gone.
     fakeAdb.setCommandResultSequence("shell pm list packages --user 0", [
       { stdout: "package:com.example.app\npackage:com.android.settings" },
@@ -299,7 +299,7 @@ describe("UninstallApp (Android)", () => {
 
   test("emits pm uninstall -k when keepData is requested", async () => {
     fakeAdb.setForegroundApp({ packageName: "com.example.app", userId: 0 });
-    fakeAdb.setUsers([{ userId: 0, name: "Owner", running: true }]);
+    fakeAdb.setUsers([{ userId: 0, name: "Owner", flags: 0x4000, running: true }]);
     fakeAdb.setCommandResultSequence("shell pm list packages --user 0", [
       { stdout: "package:com.example.app\npackage:com.android.settings" },
       { stdout: "package:com.android.settings" },
@@ -526,7 +526,7 @@ describe("UninstallApp (Android)", () => {
     const repo = new FakeInstalledAppsRepository();
     await repo.upsertInstalledApp(androidDevice.deviceId, 0, "com.example.previous", false, 1_000);
     fakeAdb.setForegroundApp(null);
-    fakeAdb.setUsers([{ userId: 0, name: "Owner", running: true }]);
+    fakeAdb.setUsers([{ userId: 0, name: "Owner", flags: 0x4000, running: true }]);
     setupNoApp(fakeAdb, 0);
 
     const uninstall = new UninstallApp(androidDevice, fakeAdbFactory(fakeAdb), null, null, repo);
@@ -541,7 +541,7 @@ describe("UninstallApp (Android)", () => {
   test("detects work profile user", async () => {
     fakeAdb.setForegroundApp(null);
     fakeAdb.setUsers([
-      { userId: 0, name: "Owner", running: true },
+      { userId: 0, name: "Owner", flags: 0x4000, running: true },
       { userId: 10, name: "Work", flags: 0x30, running: true },
     ]);
     // App installed under work profile (userId 10)

--- a/test/features/action/UninstallApp.test.ts
+++ b/test/features/action/UninstallApp.test.ts
@@ -9,6 +9,7 @@ import { FakeAdbClient } from "../../fakes/FakeAdbClient";
 import { FakeInstalledAppsRepository } from "../../fakes/FakeInstalledAppsRepository";
 import { AdbCommandTimeoutError } from "../../../src/utils/android-cmdline-tools/AdbClient";
 import { OPERATION_CANCELLED_MESSAGE } from "../../../src/utils/constants";
+import { resetDbWriteBarrier } from "../../../src/db/dbWriteBarrier";
 
 // Keep action tests isolated from the production SQLite repository even when a
 // scenario does not need to inspect stale-marker rows explicitly.
@@ -219,7 +220,9 @@ describe("UninstallApp (Android)", () => {
   }
 
   beforeEach(() => {
+    resetDbWriteBarrier();
     fakeAdb = new FakeAdbClient();
+    fakeAdb.setUsers([{ userId: 0, name: "Owner", flags: 0x13, running: true }]);
   });
 
   test("emits force-stop then a data-clearing pm uninstall for the target user", async () => {

--- a/test/features/observe/ListInstalledApps.test.ts
+++ b/test/features/observe/ListInstalledApps.test.ts
@@ -410,6 +410,38 @@ describe("ListInstalledApps", function () {
       expect(fakeAdb.wasCommandExecuted("shell pm list packages")).toBe(false);
     });
 
+    test("preserves cached profile metadata when the profile is absent from user discovery", async function () {
+      const repo = new FakeInstalledAppsRepository();
+      const timer = new FakeTimer();
+      timer.advanceTime(1000);
+      const now = timer.now();
+      await repo.replaceInstalledApps(mockDevice.deviceId, [
+        {
+          device_id: mockDevice.deviceId,
+          user_id: 10,
+          package_name: "com.example.work",
+          is_system: 0,
+          installed_at: now,
+          last_verified_at: now,
+          profile_type: "managed",
+        },
+      ]);
+      fakeAdb.setUsers([{ userId: 0, name: "Owner", flags: 0x4000, running: true }]);
+
+      const cachedList = new ListInstalledApps(
+        mockDevice,
+        new FakeAdbClientFactory(fakeAdb),
+        null,
+        { cacheEnabled: true, installedAppsRepository: repo, timer },
+      );
+
+      await expect(cachedList.executeDetailed()).resolves.toMatchObject({
+        profiles: {
+          10: [{ packageName: "com.example.work", profileType: "managed" }],
+        },
+      });
+    });
+
     test("should rebuild cache when stale", async function () {
       const repo = new FakeInstalledAppsRepository();
       const timer = new FakeTimer();

--- a/test/server/appFileService.test.ts
+++ b/test/server/appFileService.test.ts
@@ -76,6 +76,31 @@ describe("AppFileService", () => {
     expect(iosProvider.putRequests).toHaveLength(0);
   });
 
+  test("rejects malformed base64 for direct service callers", async () => {
+    const provider = new RecordingAppFileProvider("android");
+    const service = createAppFileServiceForTesting({
+      providers: [provider],
+      deviceResolver: async () => {
+        throw new Error("putFile already has a device");
+      },
+    });
+
+    await expect(
+      service.putFile({
+        device: {
+          deviceId: "emulator-5554",
+          name: "Pixel",
+          platform: "android",
+        },
+        appId: "com.example.app",
+        container: "documents",
+        contentBase64: "%%%not-base64%%%",
+        destinationPath: "fixture.bin",
+      }),
+    ).rejects.toThrow("contentBase64 must be valid, non-empty base64.");
+    expect(provider.putRequests).toEqual([]);
+  });
+
   test("rejects unsafe service input before provider selection", async () => {
     const provider = new RecordingAppFileProvider("android");
     const service = createAppFileServiceForTesting({

--- a/test/utils/android-cmdline-tools/AdbClient-listUsers.test.ts
+++ b/test/utils/android-cmdline-tools/AdbClient-listUsers.test.ts
@@ -1,10 +1,21 @@
 import { describe, expect, test } from "bun:test";
 import { AdbClient } from "../../../src/utils/android-cmdline-tools/AdbClient";
-import type { AndroidUser, ExecResult } from "../../../src/models";
+import { classifyAndroidUser, type AndroidUser, type ExecResult } from "../../../src/models";
 
-const owner: AndroidUser = { userId: 0, name: "Owner", flags: 0x4c13, running: true };
-const workProfile: AndroidUser = { userId: 10, name: "Work profile", flags: 0x30, running: true };
-const fallbackOwner: AndroidUser = { userId: 0, name: "Owner", flags: 0x13, running: true };
+const owner: AndroidUser = {
+  userId: 0,
+  name: "Owner",
+  flags: 0x4c13,
+  profileType: "primary",
+  running: true,
+};
+const workProfile: AndroidUser = {
+  userId: 10,
+  name: "Work profile",
+  flags: 0x30,
+  profileType: "managed",
+  running: true,
+};
 
 function execResult(stdout: string): ExecResult {
   return {
@@ -74,7 +85,16 @@ Users:
 
   Owner name: Owner`,
     ],
-    expectedUsers: [owner, { userId: 10, name: "Secondary User", flags: 0, running: false }],
+    expectedUsers: [
+      owner,
+      {
+        userId: 10,
+        name: "Secondary User",
+        flags: 0,
+        profileType: "unknown",
+        running: false,
+      },
+    ],
     expectedCommandFragments: ["shell dumpsys user"],
   },
   {
@@ -96,7 +116,9 @@ Users:
   UserInfo{10:null:30} serialNo=10 isPrimary=false
     State: RUNNING_UNLOCKED`,
     ],
-    expectedUsers: [{ userId: 10, name: "User 10", flags: 0x30, running: true }],
+    expectedUsers: [
+      { userId: 10, name: "User 10", flags: 0x30, profileType: "managed", running: true },
+    ],
     expectedCommandFragments: ["shell dumpsys user"],
   },
   {
@@ -127,15 +149,15 @@ Users:
     expectedCommandFragments: ["shell dumpsys user", "shell pm list users"],
   },
   {
-    name: "returns the primary fallback when both user commands fail",
+    name: "returns no users when both user commands fail",
     outcomes: [new Error("dumpsys unavailable"), new Error("pm unavailable")],
-    expectedUsers: [fallbackOwner],
+    expectedUsers: [],
     expectedCommandFragments: ["shell dumpsys user", "shell pm list users"],
   },
   {
-    name: "returns the primary fallback when neither parser finds a user",
+    name: "returns no users when neither parser finds a user",
     outcomes: ["Some random output with no user info", "Still no user info"],
-    expectedUsers: [fallbackOwner],
+    expectedUsers: [],
     expectedCommandFragments: ["shell dumpsys user", "shell pm list users"],
   },
   {
@@ -146,7 +168,10 @@ Users:
 \tUserInfo{0:Owner:4c13} running
 \tUserInfo{10:Work:1a2b} running`,
     ],
-    expectedUsers: [owner, { userId: 10, name: "Work", flags: 0x1a2b, running: true }],
+    expectedUsers: [
+      owner,
+      { userId: 10, name: "Work", flags: 0x1a2b, profileType: "managed", running: true },
+    ],
     expectedCommandFragments: ["shell dumpsys user", "shell pm list users"],
   },
 ];
@@ -168,5 +193,12 @@ describe("AdbClient.listUsers", () => {
     expect(commands.map((command) => command.replace(/^.*\badb\s+/, ""))).toEqual(
       expectedCommandFragments,
     );
+  });
+});
+
+describe("classifyAndroidUser", () => {
+  test("recognizes FLAG_MAIN for headless-system-user devices", () => {
+    expect(classifyAndroidUser(0x800)).toBe("unknown");
+    expect(classifyAndroidUser(0x4412)).toBe("primary");
   });
 });

--- a/test/utils/android-cmdline-tools/AndroidUserTargetResolver.test.ts
+++ b/test/utils/android-cmdline-tools/AndroidUserTargetResolver.test.ts
@@ -65,25 +65,25 @@ const cases: ResolveCase[] = [
     name: "skips a paused managed profile and falls back to the primary user",
     request: {},
     users: [owner, pausedWork],
-    expected: { userId: 0, source: "primaryFallback" },
+    expected: { userId: 0, source: "primary" },
   },
   {
     name: "does not treat a running secondary user as managed",
     request: {},
     users: [owner, { userId: 10, name: "Secondary", flags: 0, running: true }],
-    expected: { userId: 0, source: "primaryFallback" },
+    expected: { userId: 0, source: "primary" },
   },
   {
-    name: "selects the first running managed profile in device order",
+    name: "rejects ambiguous running managed profiles",
     request: {},
     users: [pausedWork, work, otherWork],
-    expected: { userId: 12, source: "managedProfile" },
+    expected: { userId: 0, source: "primary" },
   },
   {
     name: "falls back to the primary user when no users are reported",
     request: {},
     users: [],
-    expected: { userId: 0, source: "primaryFallback" },
+    expected: { userId: 0, source: "primary" },
   },
 ];
 
@@ -97,6 +97,20 @@ describe("AndroidUserTargetResolver.resolve", () => {
       adb.setForegroundApp(foreground);
     }
 
-    await expect(new AndroidUserTargetResolver(adb).resolve(request)).resolves.toEqual(expected);
+    const resolution = new AndroidUserTargetResolver(adb).resolve(request);
+    if (users?.length === 0) {
+      await expect(resolution).rejects.toThrow("unavailable");
+    } else if (users?.filter((user) => user.running && (user.flags & 0x20) !== 0).length === 2) {
+      await expect(resolution).rejects.toThrow("ambiguous");
+    } else {
+      await expect(resolution).resolves.toEqual(expected);
+    }
+  });
+
+  test("rejects unavailable user state instead of fabricating user zero", async () => {
+    const adb = new FakeAdbExecutor();
+    adb.setUsers([]);
+
+    await expect(new AndroidUserTargetResolver(adb).resolve()).rejects.toThrow("unavailable");
   });
 });


### PR DESCRIPTION
## Summary

Make Android profile targeting metadata-driven and fail safely when Android user state is unavailable or ambiguous. The change also fixes user-scoped termination reporting and makes the shared Android test seams deterministic.

## Linked Issue

Closes [#5599](https://github.com/kaeawc/auto-mobile/issues/5599)

## Bug / Regression Context

- **Prior attempts:** Android user targeting used numeric-ID heuristics, list-order fallback, and a fabricated user 0 when discovery failed.
- **Observed symptom:** Operations could select the wrong profile or report an app as running when it was stopped; full validation also exposed cross-suite singleton and fake-user-state leakage.
- **Repro steps / conditions:** Run profile-sensitive operations with multiple profiles, unavailable user discovery, or the full test suite.

## Validation

- [x] `bun test --bail` — 14,206 passed, 15 skipped, 0 failed
- [x] `bun run typecheck` — no new errors
- [x] `bun run lint`
- [x] Targeted Android profile, lifecycle, uninstall, CtrlProxy, and package-list tests
- [x] Build and boundary checks completed successfully
- [ ] `bun run turbo:validate` completed end-to-end; its isolated test phase hangs in this environment after starting

## Follow-ups

- [ ] Complete the remaining repository-wide Android profile audit areas: storage namespaces, snapshot manifests, app-file paths, permissions, locales, and lifecycle state propagation.
