### PR TITLE
fix(android): preserve CtrlProxy JPEG screenshots

### DIFF
--- a/src/features/observe/ScreenshotMetadata.ts
+++ b/src/features/observe/ScreenshotMetadata.ts
@@ -1,6 +1,6 @@
-export type ScreenshotFormat = "jpeg" | "png";
+export type ScreenshotFormat = "jpeg" | "png" | "webp";
 
-export type ScreenshotMimeType = "image/jpeg" | "image/png";
+export type ScreenshotMimeType = "image/jpeg" | "image/png" | "image/webp";
 
 export type ScreenshotCaptureSource =
   | "android_ctrlproxy_a11y"
@@ -71,6 +71,12 @@ export function metadataForScreenshotFormat(
         ...metadataWithoutFormat,
         screenshotMimeType: "image/png",
         screenshotFormat: "png",
+      };
+    case "webp":
+      return {
+        ...metadataWithoutFormat,
+        screenshotMimeType: "image/webp",
+        screenshotFormat: "webp",
       };
     default:
       return metadataWithoutFormat;

--- a/src/features/observe/TakeScreenshot.ts
+++ b/src/features/observe/TakeScreenshot.ts
@@ -22,13 +22,16 @@ import { ensureSecureTempDirSync, TEMP_SUBDIRS } from "../../utils/tempDir";
 import type { ScreenshotService } from "./interfaces/ScreenshotService";
 import { selectScreenshotsToEvict, SCREENSHOT_MIN_EVICT_AGE_MS } from "./screenshotCacheEviction";
 import { IOSCtrlProxyClient } from "./ios";
+import { AndroidCtrlProxyClient } from "./android";
 import type { CtrlProxyScreenshotResult } from "./ios/types";
 import { getDeviceDataStreamServer } from "../../daemon/deviceDataStreamSocketServer";
 import { Timer, defaultTimer } from "../../utils/SystemTimer";
 import { defaultIdGenerator, IdGenerator } from "../../utils/IdGenerator";
 import {
   ANDROID_ADB_SCREENSHOT_METADATA,
+  ANDROID_CTRLPROXY_SCREENSHOT_METADATA,
   IOS_CTRLPROXY_SCREENSHOT_METADATA,
+  metadataForScreenshotFormat,
 } from "./ScreenshotMetadata";
 
 /** Secure file mode: owner read/write only */
@@ -48,8 +51,12 @@ async function writeFileSecure(filePath: string, data: Buffer): Promise<void> {
   }
 }
 
+function replaceScreenshotExtension(filePath: string, extension: string): string {
+  return filePath.replace(/\.[^.]+$/, `.${extension}`);
+}
+
 export interface ScreenshotOptions {
-  format?: "png" | "webp";
+  format?: "jpeg" | "png" | "webp";
   quality?: number;
   lossless?: boolean;
 }
@@ -139,7 +146,8 @@ export class TakeScreenshot implements ScreenshotService {
    * @returns Full file path for screenshot
    */
   generateScreenshotPath(timestamp: number, options: ScreenshotOptions): string {
-    const fileExtension = options.format === "webp" ? "webp" : "png";
+    const fileExtension =
+      options.format === "webp" ? "webp" : options.format === "jpeg" ? "jpg" : "png";
     return path.join(
       TakeScreenshot.getCacheDir(),
       `screenshot_${timestamp}_${this.idGenerator.next()}.${fileExtension}`,
@@ -245,6 +253,16 @@ export class TakeScreenshot implements ScreenshotService {
   ): Promise<ScreenshotResult> {
     logger.info(`[SCREENSHOT] Starting screenshot capture with format: ${options.format}`);
 
+    if (options.format === undefined || options.format === "jpeg") {
+      try {
+        return await this.captureScreenshotViaCtrlProxy(finalPath, signal);
+      } catch (error) {
+        logger.info(`[SCREENSHOT] CtrlProxy capture failed, falling back to ADB: ${error}`);
+        finalPath = replaceScreenshotExtension(finalPath, "png");
+        options = { ...options, format: "png" };
+      }
+    }
+
     // Try base64 approach first (faster for smaller screenshots)
     try {
       return await this.captureScreenshotBase64(finalPath, options, signal);
@@ -264,6 +282,33 @@ export class TakeScreenshot implements ScreenshotService {
         throw err;
       }
     }
+  }
+
+  private async captureScreenshotViaCtrlProxy(
+    finalPath: string,
+    signal?: AbortSignal,
+  ): Promise<ScreenshotResult> {
+    const client = AndroidCtrlProxyClient.getInstance(this.device, this.adbFactory);
+    const result = await client.requestScreenshot(10000);
+    if (signal?.aborted) {
+      return { success: false, error: OPERATION_CANCELLED_MESSAGE };
+    }
+    if (!result.success || !result.data) {
+      throw new Error(result.error || "No screenshot data returned from Android CtrlProxy");
+    }
+
+    const format = result.format?.toLowerCase() === "png" ? "png" : "jpeg";
+    const imageBuffer = Buffer.from(result.data, "base64");
+    const screenshotPath = replaceScreenshotExtension(
+      finalPath,
+      format === "jpeg" ? "jpg" : format,
+    );
+    await writeFileSecure(screenshotPath, imageBuffer);
+    return {
+      success: true,
+      path: screenshotPath,
+      ...metadataForScreenshotFormat(ANDROID_CTRLPROXY_SCREENSHOT_METADATA, format),
+    };
   }
 
   /**
@@ -337,6 +382,7 @@ export class TakeScreenshot implements ScreenshotService {
     return {
       success: true,
       path: finalPath,
+      ...IOS_CTRLPROXY_SCREENSHOT_METADATA,
     };
   }
 
@@ -448,6 +494,7 @@ export class TakeScreenshot implements ScreenshotService {
     return {
       success: true,
       path: finalPath,
+      ...ANDROID_ADB_SCREENSHOT_METADATA,
     };
   }
 
@@ -548,6 +595,7 @@ export class TakeScreenshot implements ScreenshotService {
       return {
         success: true,
         path: finalPath,
+        ...ANDROID_ADB_SCREENSHOT_METADATA,
       };
     } catch (err) {
       const totalDuration = this.timer.now() - startTime;

--- a/src/features/observe/TakeScreenshot.ts
+++ b/src/features/observe/TakeScreenshot.ts
@@ -494,7 +494,7 @@ export class TakeScreenshot implements ScreenshotService {
     return {
       success: true,
       path: finalPath,
-      ...ANDROID_ADB_SCREENSHOT_METADATA,
+      ...metadataForScreenshotFormat(ANDROID_ADB_SCREENSHOT_METADATA, options.format),
     };
   }
 
@@ -595,7 +595,7 @@ export class TakeScreenshot implements ScreenshotService {
       return {
         success: true,
         path: finalPath,
-        ...ANDROID_ADB_SCREENSHOT_METADATA,
+        ...metadataForScreenshotFormat(ANDROID_ADB_SCREENSHOT_METADATA, options.format),
       };
     } catch (err) {
       const totalDuration = this.timer.now() - startTime;

--- a/src/features/observe/screenshot/ObserveScreenshotRecorder.ts
+++ b/src/features/observe/screenshot/ObserveScreenshotRecorder.ts
@@ -71,7 +71,7 @@ export class DefaultObserveScreenshotRecorder implements ObserveScreenshotRecord
   start(perf: PerformanceTracker = new NoOpPerformanceTracker(), signal?: AbortSignal): void {
     perf.startOperation("screenshot");
     const { promise } = this.screenshotUtil.startTrackedCapture(
-      { format: "png" },
+      {},
       {
         parentSignal: signal,
         // Fire-and-forget: if a screencap is already in flight (e.g. mid-poll
@@ -115,7 +115,7 @@ export class DefaultObserveScreenshotRecorder implements ObserveScreenshotRecord
     try {
       await perf.track("screenshot", async () => {
         const { promise } = this.screenshotUtil.startTrackedCapture(
-          { format: "png" },
+          {},
           {
             parentSignal: signal,
             // Awaitable observe captures share an ordinary in-flight capture,

--- a/src/models/ScreenshotResult.ts
+++ b/src/models/ScreenshotResult.ts
@@ -1,3 +1,5 @@
+import type { ScreenshotFormat, ScreenshotMimeType } from "../features/observe/ScreenshotMetadata";
+
 /**
  * Result of a screenshot operation
  */
@@ -5,4 +7,6 @@ export interface ScreenshotResult {
   success: boolean;
   path?: string;
   error?: string;
+  screenshotFormat?: ScreenshotFormat;
+  screenshotMimeType?: ScreenshotMimeType;
 }

--- a/src/server/observationResources.ts
+++ b/src/server/observationResources.ts
@@ -11,6 +11,7 @@ import type { BootedDevice } from "../models";
 import * as realFs from "fs/promises";
 import { errorMessage } from "../utils/describeUnknownError";
 import { OPERATION_CANCELLED_MESSAGE } from "../utils/constants";
+import { detectImageMimeType } from "../utils/screenshot/imageHeaderDimensions";
 
 interface ScreenshotFileSystem {
   stat(path: string): Promise<{ isFile(): boolean }>;
@@ -94,6 +95,20 @@ export function setSessionScreenshotResourceDependencies(
 
 export function resetSessionScreenshotResourceDependencies(): void {
   sessionScreenshotResourceDependencies = defaultSessionScreenshotResourceDependencies;
+}
+
+function screenshotMimeType(path: string, imageBuffer: Buffer): string {
+  const detected = detectImageMimeType(imageBuffer);
+  if (detected) {
+    return detected;
+  }
+  if (path.endsWith(".webp")) {
+    return "image/webp";
+  }
+  if (path.endsWith(".jpg") || path.endsWith(".jpeg")) {
+    return "image/jpeg";
+  }
+  return "image/png";
 }
 
 // Resource URIs
@@ -219,7 +234,7 @@ async function getLatestScreenshot(): Promise<ResourceContent> {
     const base64Image = imageBuffer.toString("base64");
 
     // Determine mime type from file extension
-    const mimeType = screenshotPath.endsWith(".webp") ? "image/webp" : "image/png";
+    const mimeType = screenshotMimeType(screenshotPath, imageBuffer);
 
     return {
       uri: RESOURCE_URIS.LATEST_SCREENSHOT,
@@ -378,7 +393,7 @@ async function readFreshScreenshot(
     }
     return {
       uri,
-      mimeType: "image/png",
+      mimeType: screenshotMimeType(path, imageBuffer),
       blob: imageBuffer.toString("base64"),
     };
   } catch (error) {
@@ -511,7 +526,7 @@ async function getSessionScreenshot(
 
     const imageBuffer = await screenshotFileSystem.readFile(screenshotPath);
     const base64Image = imageBuffer.toString("base64");
-    const mimeType = screenshotPath.endsWith(".webp") ? "image/webp" : "image/png";
+    const mimeType = screenshotMimeType(screenshotPath, imageBuffer);
 
     return { uri, mimeType, blob: base64Image };
   } catch (error) {
@@ -561,7 +576,7 @@ async function getFreshSessionScreenshot(
       activeSession.device,
     );
     const { promise } = screenshotService.startTrackedCapture(
-      { format: "png" },
+      {},
       {
         parentSignal: context.signal,
         queueAfterPending: true,

--- a/src/utils/screenshot/imageHeaderDimensions.ts
+++ b/src/utils/screenshot/imageHeaderDimensions.ts
@@ -19,6 +19,26 @@ export interface ImagePixelDimensions {
 /** PNG signature: the 8-byte magic that opens every PNG. */
 const PNG_SIGNATURE = Buffer.from([0x89, 0x50, 0x4e, 0x47, 0x0d, 0x0a, 0x1a, 0x0a]);
 
+export type ImageMimeType = "image/jpeg" | "image/png" | "image/webp";
+
+/** Detect the image container from its magic bytes without decoding pixels. */
+export function detectImageMimeType(buffer: Buffer): ImageMimeType | null {
+  if (buffer.subarray(0, PNG_SIGNATURE.length).equals(PNG_SIGNATURE)) {
+    return "image/png";
+  }
+  if (buffer.length >= 3 && buffer[0] === 0xff && buffer[1] === 0xd8 && buffer[2] === 0xff) {
+    return "image/jpeg";
+  }
+  if (
+    buffer.length >= 12 &&
+    buffer.toString("ascii", 0, 4) === "RIFF" &&
+    buffer.toString("ascii", 8, 12) === "WEBP"
+  ) {
+    return "image/webp";
+  }
+  return null;
+}
+
 /** Offset of the IHDR chunk's declared length (immediately after the 8-byte signature). */
 const PNG_IHDR_LENGTH_OFFSET = 8;
 /** Offset of the IHDR chunk type. */

--- a/test/features/observe/ScreenshotMetadata.test.ts
+++ b/test/features/observe/ScreenshotMetadata.test.ts
@@ -48,8 +48,12 @@ describe("metadataForScreenshotFormat", () => {
       });
     });
 
-    test(`${name} + webp drops mime/format (unknown format)`, () => {
-      expect(metadataForScreenshotFormat(value, "webp")).toEqual(rest);
+    test(`${name} + webp is labelled image/webp`, () => {
+      expect(metadataForScreenshotFormat(value, "webp")).toEqual({
+        ...rest,
+        screenshotMimeType: "image/webp",
+        screenshotFormat: "webp",
+      });
     });
 
     test(`${name} + undefined format drops mime/format`, () => {

--- a/test/features/observe/TakeScreenshot.test.ts
+++ b/test/features/observe/TakeScreenshot.test.ts
@@ -1,4 +1,5 @@
 import { beforeEach, describe, expect, test } from "bun:test";
+import { readFileSync } from "node:fs";
 import { TakeScreenshot } from "../../../src/features/observe/TakeScreenshot";
 import { BootedDevice } from "../../../src/models/DeviceInfo";
 import { FakeAdbExecutor } from "../../fakes/FakeAdbExecutor";
@@ -48,6 +49,28 @@ describe("TakeScreenshot", function () {
 
       expect(result).toContain("screenshot_1234567890456");
       expect(result).toMatch(/screenshot_1234567890456_[^.]+\.webp$/);
+    });
+
+    test("tracks WebP metadata when requested", async function () {
+      const originalGetInstance = AndroidCtrlProxyClient.getInstance;
+      AndroidCtrlProxyClient.getInstance = (() => ({
+        requestScreenshot: async () => ({ success: false, error: "CtrlProxy unavailable" }),
+      })) as typeof AndroidCtrlProxyClient.getInstance;
+      fakeAdb.setDefaultResponse({
+        stdout: readFileSync("test/fixtures/screenshots/black-on-white.png").toString("base64"),
+        stderr: "",
+      });
+
+      try {
+        const result = await takeScreenshot.execute({ format: "webp" });
+
+        expect(result.success).toBe(true);
+        expect(result.path).toMatch(/\.webp$/);
+        expect(result.screenshotFormat).toBe("webp");
+        expect(result.screenshotMimeType).toBe("image/webp");
+      } finally {
+        AndroidCtrlProxyClient.getInstance = originalGetInstance;
+      }
     });
 
     test("should generate different timestamps for consecutive calls", async function () {

--- a/test/features/observe/TakeScreenshot.test.ts
+++ b/test/features/observe/TakeScreenshot.test.ts
@@ -7,6 +7,7 @@ import { FakeTimer } from "../../fakes/FakeTimer";
 import { FakeAdbClientFactory } from "../../fakes/FakeAdbClientFactory";
 import { CountingIdGenerator } from "../../../src/utils/IdGenerator";
 import { IOSCtrlProxyClient } from "../../../src/features/observe/ios";
+import { AndroidCtrlProxyClient } from "../../../src/features/observe/android";
 import { OPERATION_CANCELLED_MESSAGE } from "../../../src/utils/constants";
 
 describe("TakeScreenshot", function () {
@@ -78,6 +79,51 @@ describe("TakeScreenshot", function () {
       expect(first).toMatch(/screenshot_1234567890123_capture-1\.png$/);
       expect(second).toMatch(/screenshot_1234567890123_capture-2\.png$/);
       expect(first).not.toBe(second);
+    });
+
+    test("persists native Android CtrlProxy JPEG as jpg with metadata", async () => {
+      const originalGetInstance = AndroidCtrlProxyClient.getInstance;
+      AndroidCtrlProxyClient.getInstance = (() => ({
+        requestScreenshot: async () => ({
+          success: true,
+          data: Buffer.from([0xff, 0xd8, 0xff, 0xe0]).toString("base64"),
+          format: "jpeg",
+        }),
+      })) as typeof AndroidCtrlProxyClient.getInstance;
+
+      try {
+        const result = await takeScreenshot.execute({});
+
+        expect(result.success).toBe(true);
+        expect(result.path).toMatch(/\.jpg$/);
+        expect(result.screenshotFormat).toBe("jpeg");
+        expect(result.screenshotMimeType).toBe("image/jpeg");
+        expect(fakeAdb.getExecutedCommands()).toHaveLength(0);
+      } finally {
+        AndroidCtrlProxyClient.getInstance = originalGetInstance;
+      }
+    });
+
+    test("keeps the ADB fallback as PNG", async () => {
+      const originalGetInstance = AndroidCtrlProxyClient.getInstance;
+      AndroidCtrlProxyClient.getInstance = (() => ({
+        requestScreenshot: async () => ({ success: false, error: "CtrlProxy unavailable" }),
+      })) as typeof AndroidCtrlProxyClient.getInstance;
+      fakeAdb.setDefaultResponse({
+        stdout: Buffer.from("png bytes").toString("base64"),
+        stderr: "",
+      });
+
+      try {
+        const result = await takeScreenshot.execute({});
+
+        expect(result.success).toBe(true);
+        expect(result.path).toMatch(/\.png$/);
+        expect(result.screenshotFormat).toBe("png");
+        expect(result.screenshotMimeType).toBe("image/png");
+      } finally {
+        AndroidCtrlProxyClient.getInstance = originalGetInstance;
+      }
     });
 
     test("should use single optimized ADB command for screenshot capture", async function () {

--- a/test/features/observe/screenshot/ObserveScreenshotRecorder.test.ts
+++ b/test/features/observe/screenshot/ObserveScreenshotRecorder.test.ts
@@ -38,6 +38,7 @@ class FakeTrackedScreenshotService implements TrackedScreenshotService {
   private nextThrow: Error | null = null;
   private latestPromise: Promise<ScreenshotResult> | null = null;
   public lastTrackerOptions: ScreenshotJobOptions | null = null;
+  public lastCaptureOptions: ScreenshotOptions | undefined;
 
   setNextResult(result: ScreenshotResult): void {
     this.nextResult = result;
@@ -78,9 +79,10 @@ class FakeTrackedScreenshotService implements TrackedScreenshotService {
   }
 
   startTrackedCapture(
-    _options: ScreenshotOptions = { format: "png" },
+    options: ScreenshotOptions = { format: "png" },
     trackerOptions: ScreenshotJobOptions = {},
   ): ScreenshotJobHandle {
+    this.lastCaptureOptions = options;
     this.lastTrackerOptions = trackerOptions;
     const abortController = new AbortController();
     const result = this.nextResult;
@@ -142,6 +144,17 @@ describe("DefaultObserveScreenshotRecorder.capture", () => {
 
     expect(store.getPath("test-device")).toBe(file);
     expect(store.getError("test-device")).toBeUndefined();
+  });
+
+  test("requests native screenshot format", async () => {
+    const dir = mkdtempSync(path.join(tmpdir(), "obs-rec-"));
+    const file = path.join(dir, "shot.jpg");
+    writeFileSync(file, "img");
+
+    svc.setNextResult({ success: true, path: file, screenshotFormat: "jpeg" });
+    await recorder.capture(new NoOpPerformanceTracker());
+
+    expect(svc.lastCaptureOptions).toEqual({});
   });
 
   test("failure writes error to store", async () => {

--- a/test/server/observationResources.test.ts
+++ b/test/server/observationResources.test.ts
@@ -14,6 +14,7 @@ import {
   setSessionScreenshotResourceDependencies,
   setScreenshotFileSystem,
 } from "../../src/server/observationResources";
+import { getScreenshotStateStore } from "../../src/features/observe/screenshot/ScreenshotStateRegistry";
 import { ResourceRegistry, type ResourceReadContext } from "../../src/server/resourceRegistry";
 import {
   clearDirectSessionDevices,
@@ -46,6 +47,25 @@ function readTemplate(uri: string, context: ResourceReadContext = { sessionUuid 
   return template.handler(params);
 }
 
+function readLatestScreenshot() {
+  registerObservationResources();
+  return ResourceRegistry.getResource(RESOURCE_URIS.LATEST_SCREENSHOT)!.handler();
+}
+
+const imageFixtures = [
+  { extension: "jpg", mimeType: "image/jpeg", bytes: Buffer.from([0xff, 0xd8, 0xff, 0xe0]) },
+  {
+    extension: "png",
+    mimeType: "image/png",
+    bytes: Buffer.from("89504e470d0a1a0a", "hex"),
+  },
+  {
+    extension: "webp",
+    mimeType: "image/webp",
+    bytes: Buffer.from("RIFF\x00\x00\x00\x00WEBPVP8 ", "binary"),
+  },
+] as const;
+
 function createTrackedScreenshot(
   result: ScreenshotResult,
   deviceId: string = sessionDevice.deviceId,
@@ -72,6 +92,28 @@ describe("session screenshot resources", () => {
     clearDirectSessionDevices();
     resetSessionScreenshotResourceDependencies();
     resetScreenshotFileSystem();
+  });
+
+  test("returns the actual MIME type for the latest cached screenshot", async () => {
+    const observeScreen = new RealObserveScreen(
+      sessionDevice,
+      new FakeAdbClientFactory(new FakeAdbExecutor()),
+    );
+    await observeScreen.cacheObserveResult(observeScreen.createBaseResult());
+
+    for (const fixture of imageFixtures) {
+      const screenshotPath = `/tmp/latest.${fixture.extension}`;
+      getScreenshotStateStore().update(sessionDevice.deviceId, screenshotPath);
+      setScreenshotFileSystem({
+        stat: async () => ({ isFile: () => true }),
+        readFile: async () => fixture.bytes,
+      });
+
+      const content = await readLatestScreenshot();
+
+      expect(content.mimeType).toBe(fixture.mimeType);
+      expect(content.blob).toBe(fixture.bytes.toString("base64"));
+    }
   });
 
   test("registers session-scoped cached and fresh screenshot templates", () => {
@@ -199,6 +241,27 @@ describe("session screenshot resources", () => {
       mimeType: "image/png",
       blob: image.toString("base64"),
     });
+  });
+
+  test("returns the actual MIME type for fresh JPEG, PNG, and WebP captures", async () => {
+    for (const fixture of imageFixtures) {
+      const image = fixture.bytes;
+      const screenshotPath = `/tmp/fresh.${fixture.extension}`;
+      setSessionScreenshotResourceDependencies({
+        resolveActiveSession: () => activeSession(),
+        createScreenshotService: () =>
+          createTrackedScreenshot({ success: true, path: screenshotPath }),
+      });
+      setScreenshotFileSystem({
+        stat: async () => ({ isFile: () => true }),
+        readFile: async () => image,
+      });
+
+      const content = await readTemplate("automobile:device-session/session-123/screenshot");
+
+      expect(content.mimeType).toBe(fixture.mimeType);
+      expect(content.blob).toBe(image.toString("base64"));
+    }
   });
 
   test("returns a typed non-retryable failure when no fresh screenshot session is active", async () => {

--- a/test/utils/imageHeaderDimensions.test.ts
+++ b/test/utils/imageHeaderDimensions.test.ts
@@ -1,5 +1,8 @@
 import { describe, expect, it } from "bun:test";
-import { readImageHeaderDimensions } from "../../src/utils/screenshot/imageHeaderDimensions";
+import {
+  detectImageMimeType,
+  readImageHeaderDimensions,
+} from "../../src/utils/screenshot/imageHeaderDimensions";
 
 /** Build a minimal PNG whose IHDR declares the given size. */
 function png(width: number, height: number): Buffer {
@@ -78,5 +81,19 @@ describe("readImageHeaderDimensions", () => {
   it("returns null rather than guessing when a JPEG reaches scan data with no frame header", () => {
     // SOI then SOS: entropy-coded data follows and no SOFn can appear after it.
     expect(readImageHeaderDimensions(Buffer.from([0xff, 0xd8, 0xff, 0xda, 0x00, 0x02]))).toBeNull();
+  });
+});
+
+describe("detectImageMimeType", () => {
+  it.each([
+    ["JPEG", Buffer.from([0xff, 0xd8, 0xff, 0xe0]), "image/jpeg"],
+    ["PNG", png(1, 1), "image/png"],
+    ["WebP", Buffer.from("RIFF\x00\x00\x00\x00WEBPVP8 ", "binary"), "image/webp"],
+  ])("detects %s bytes", (_name, buffer, mimeType) => {
+    expect(detectImageMimeType(buffer)).toBe(mimeType);
+  });
+
+  it("returns null for unknown bytes", () => {
+    expect(detectImageMimeType(Buffer.from("not an image"))).toBeNull();
   });
 });


### PR DESCRIPTION
## Summary

Preserve Android CtrlProxy-native JPEG screenshots through observe and fresh screenshot capture, persist them with the correct `.jpg` extension and metadata, and detect the actual MIME type for cached and fresh screenshot resources. ADB and iOS PNG behavior remains unchanged.

## Linked Issue

Closes [#5605](https://github.com/kaeawc/auto-mobile/issues/5605)

## Bug / Regression Context

- **Prior attempts:** The existing capture/resource paths forced or assumed PNG even though Android CtrlProxy returns JPEG natively.
- **Observed symptom:** JPEG screenshot bytes could be served as `image/png`, breaking MCP clients that decode resource blobs according to MIME type.
- **Repro steps / conditions:** Read the latest or session fresh screenshot resource after an Android observe/capture.

## Validation

- [x] Focused screenshot, resource, metadata, and recorder tests pass.
- [x] `bun run lint` passes with no new lint violations.
- [x] `bun run typecheck` reports no new errors (baseline gate).
- [x] Full `bun run turbo:validate` passes locally.
- [x] New code uses existing metadata helpers, injected filesystem seams, and fakes; no dependency added.
- [ ] Rebased onto latest `main`, conflicts resolved

## Device Verification

- [ ] Verified on a real Android device / iOS simulator via `observe`

## Follow-ups

- [x] No out-of-scope follow-up issues identified.
