### PR TITLE
fix(ios): prevent navigation session heartbeat expiry

### DIFF
--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -22,25 +22,9 @@
       "homepage": "https://kaeawc.github.io/auto-mobile/",
       "repository": "https://github.com/kaeawc/auto-mobile",
       "license": "Apache-2.0",
-      "keywords": [
-        "mobile",
-        "android",
-        "ios",
-        "automation",
-        "testing",
-        "mcp",
-        "adb",
-        "simctl"
-      ],
+      "keywords": ["mobile", "android", "ios", "automation", "testing", "mcp", "adb", "simctl"],
       "category": "development",
-      "tags": [
-        "mobile-testing",
-        "android",
-        "ios",
-        "automation",
-        "ui-testing",
-        "device-control"
-      ],
+      "tags": ["mobile-testing", "android", "ios", "automation", "ui-testing", "device-control"],
       "strict": true
     }
   ]

--- a/.claude-plugin/plugin.json
+++ b/.claude-plugin/plugin.json
@@ -9,26 +9,13 @@
   "homepage": "https://kaeawc.github.io/auto-mobile/",
   "repository": "https://github.com/kaeawc/auto-mobile",
   "license": "Apache-2.0",
-  "keywords": [
-    "mobile",
-    "android",
-    "ios",
-    "automation",
-    "testing",
-    "mcp",
-    "adb",
-    "simctl"
-  ],
-  "commands": [
-    "./skills/"
-  ],
+  "keywords": ["mobile", "android", "ios", "automation", "testing", "mcp", "adb", "simctl"],
+  "commands": ["./skills/"],
   "hooks": "./hooks.json",
   "mcpServers": {
     "auto-mobile": {
       "command": "bunx",
-      "args": [
-        "@kaeawc/auto-mobile@latest"
-      ]
+      "args": ["@kaeawc/auto-mobile@latest"]
     }
   }
 }

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,7 +1,9 @@
 # Changelog
 
 ## [v0.0.63] - 2026-08-24
+
 ### Added
+
 - feat(android): add session-bound shared-storage fixture transfer and media indexing ([#5587](https://github.com/kaeawc/auto-mobile/issues/5587)) (android)
 - Bound getDaemonStatus on HTTP/STDIO transports + before the McpDaemonClient lifecycle preflight (follow-up to #4858) ([#5585](https://github.com/kaeawc/auto-mobile/issues/5585)) (desktop)
 - feat(ios): discover SwiftUI AttributedString inline semantic links via AXBridge (follow-up to #5560) ([#5578](https://github.com/kaeawc/auto-mobile/issues/5578)) (ios, a11y)
@@ -13,16 +15,22 @@
 - Desktop: make the daemon status probe injectable + timeout-bounded + FakeTimer-tested ([#4858](https://github.com/kaeawc/auto-mobile/issues/4858)) (desktop)
 - feat(ios): accessibility — VoiceOver enable/disable on physical iOS devices ([#2501](https://github.com/kaeawc/auto-mobile/issues/2501)) (ios, a11y)
 - Screen Streaming: Quality controls and auto-adjustment ([#1098](https://github.com/kaeawc/auto-mobile/issues/1098)) (intellij plugin)
+
 ### Changed
+
 - oxfmt is unenforced in CI and the tree isn't oxfmt-clean: align local formatting with CI and normalize the codebase ([#5531](https://github.com/kaeawc/auto-mobile/issues/5531)) (devxp)
 - chore(android): re-cut and re-pin control-proxy runner APK after CtrlProxy perf batch (#5462–#5471) ([#5490](https://github.com/kaeawc/auto-mobile/issues/5490)) (android, release engineering)
+
 ### Fixed
+
 - fix(android): preserve CtrlProxy JPEG screenshots and report correct resource MIME types ([#5605](https://github.com/kaeawc/auto-mobile/issues/5605)) (android)
 - iOS semantic accessibility-link discovery & activation are incomplete (SwiftUI links undiscovered; inline links don't activate) ([#5560](https://github.com/kaeawc/auto-mobile/issues/5560)) (ios, a11y)
 - iOS CtrlProxy runner wedges (port-health up, observation stream dead) with no self-heal — readiness times out until process is externally killed ([#5532](https://github.com/kaeawc/auto-mobile/issues/5532))
 - killDevice: restore Android observer when the shutdown command fails on a still-alive device ([#5503](https://github.com/kaeawc/auto-mobile/issues/5503)) (android)
 - killDevice: reject session admissions for a device under an active shutdown reservation ([#5494](https://github.com/kaeawc/auto-mobile/issues/5494)) (android)
+
 ### Other
+
 - Re-cut Android control-proxy artifact to deliver DataStore MCP commands (#5573) ([#5596](https://github.com/kaeawc/auto-mobile/issues/5596)) (android)
 - fix(android): make inspector driver registration/removal safe against same-name replacement ([#5581](https://github.com/kaeawc/auto-mobile/issues/5581)) (android, database)
 - iOS runner re-cut to deliver #2501 physical-device VoiceOver toggle ([#5572](https://github.com/kaeawc/auto-mobile/issues/5572)) (ios, a11y)

--- a/scripts/ios/navigation-graph-sdk-event-integration.sh
+++ b/scripts/ios/navigation-graph-sdk-event-integration.sh
@@ -55,10 +55,17 @@ ctrl_proxy_port_for_device() {
 
 wait_for_ctrl_proxy_health() {
   local ctrl_proxy_port="$1"
+  local session_uuid="${2:-}"
   local attempt
   for attempt in 1 2 3 4 5; do
     if curl --fail --silent --show-error --max-time 5 "http://127.0.0.1:${ctrl_proxy_port}/health" >/dev/null; then
       return 0
+    fi
+    # One-shot CLI clients stop their proxy heartbeat after each public call.
+    # Renew the graph session while this bounded runner-health retry is in progress.
+    if [[ -n "${session_uuid}" ]] && ! auto-mobile --daemon heartbeat "${session_uuid}" >/dev/null; then
+      echo "error: could not renew navigation graph session ownership" >&2
+      return 1
     fi
     if [[ "${attempt}" -lt 5 ]]; then
       echo "CtrlProxy health check attempt ${attempt} failed; retrying in 2s..." >&2
@@ -100,7 +107,7 @@ fi
 # Requesting debug and embedded-SDK tools can restart the daemon. That restart
 # creates a new CtrlProxy client, so the prior daemon's reported port is stale.
 ctrl_proxy_port="$(ctrl_proxy_port_for_device)"
-wait_for_ctrl_proxy_health "${ctrl_proxy_port}"
+wait_for_ctrl_proxy_health "${ctrl_proxy_port}" "${session_uuid}"
 
 event_payload() {
   local destination="$1"

--- a/scripts/ios/navigation-graph-sdk-event-integration.sh
+++ b/scripts/ios/navigation-graph-sdk-event-integration.sh
@@ -63,7 +63,7 @@ wait_for_ctrl_proxy_health() {
     fi
     # One-shot CLI clients stop their proxy heartbeat after each public call.
     # Renew the graph session while this bounded runner-health retry is in progress.
-    if [[ -n "${session_uuid}" ]] && ! auto-mobile --daemon heartbeat "${session_uuid}" >/dev/null; then
+    if [[ -n "${session_uuid}" ]] && ! AUTOMOBILE_DAEMON_TIMEOUT_MS=2000 auto-mobile --daemon heartbeat "${session_uuid}" >/dev/null; then
       echo "error: could not renew navigation graph session ownership" >&2
       return 1
     fi

--- a/src/daemon/manager.ts
+++ b/src/daemon/manager.ts
@@ -1853,6 +1853,33 @@ export async function runDaemonCommand(
         break;
       }
 
+      case "heartbeat": {
+        if (args.length === 0) {
+          throw new ActionableError("heartbeat requires a session ID argument");
+        }
+        const sessionId = args[0];
+        const daemonState = manager.getDaemonState();
+        if (daemonState.isInitialized()) {
+          const sessionManager = daemonState.getSessionManager();
+          if (!sessionManager.getSession(sessionId)) {
+            throw new ActionableError(`Session not found: ${sessionId}`);
+          }
+          sessionManager.recordHeartbeat(sessionId);
+        } else {
+          const client = manager.createClient();
+          try {
+            await client.connect();
+            await client.callDaemonMethod("daemon/heartbeat", { sessionId });
+          } catch (error) {
+            throw new ActionableError(`Failed to record session heartbeat: ${errorMessage(error)}`);
+          } finally {
+            await client.close();
+          }
+        }
+        console.log(`Session ${sessionId} heartbeat recorded`);
+        break;
+      }
+
       default:
         console.error(`Unknown daemon command: ${command}`);
         console.log("\nAvailable commands:");
@@ -1865,6 +1892,7 @@ export async function runDaemonCommand(
         console.log("  available-devices     Query device pool status");
         console.log("  session-info <id>     Get information about a session");
         console.log("  release-session <id>  Release a session and free its device");
+        console.log("  heartbeat <id>        Record a heartbeat for a session");
         process.exit(1);
     }
   } catch (error) {

--- a/test/bats/navigation-graph-sdk-event-integration.bats
+++ b/test/bats/navigation-graph-sdk-event-integration.bats
@@ -10,6 +10,7 @@ setup() {
   export SESSION_OBSERVE_FILE="${MOCK_BIN}/session-observe"
   export DOCTOR_CALLS_FILE="${MOCK_BIN}/doctor-calls"
   export HEALTH_ATTEMPTS_FILE="${MOCK_BIN}/health-attempts"
+  export HEARTBEAT_FILE="${MOCK_BIN}/heartbeats"
   export TARGET_APP_LAUNCHED_FILE="${MOCK_BIN}/target-app-launched"
   export INVOCATION_FILE="${MOCK_BIN}/invocations"
 }
@@ -29,7 +30,7 @@ SCRIPT
   chmod +x "${MOCK_BIN}/${name}"
 }
 
-@test "retries getNavigationGraph after an initial CLI failure" {
+@test "renews the graph session while retrying post-bind CtrlProxy health" {
   make_mock xcrun 'exit 0'
   make_mock curl '
 url="${!#}"
@@ -38,7 +39,7 @@ if [[ "$url" == */health ]]; then
   [ -f "$HEALTH_ATTEMPTS_FILE" ] && health_attempts="$(cat "$HEALTH_ATTEMPTS_FILE")"
   health_attempts=$((health_attempts + 1))
   printf "%s\\n" "$health_attempts" > "$HEALTH_ATTEMPTS_FILE"
-  if [ "$health_attempts" -eq 1 ]; then
+  if [ "$health_attempts" -eq 1 ] || { [ -f "$SESSION_OBSERVE_FILE" ] && [ "$health_attempts" -eq 3 ]; }; then
     exit 1
   fi
 fi
@@ -75,6 +76,14 @@ if [ "$1" = "--cli" ] && [ "$2" = "doctor" ]; then
   printf "{\"ios\":{\"checks\":[]}}\\n"
   exit 0
 fi
+if [ "$1" = "--daemon" ] && [ "$2" = "heartbeat" ] && [ "$3" = "44600000-0000-4000-8000-000000000000" ]; then
+  if [ ! -f "$SESSION_OBSERVE_FILE" ]; then
+    echo "session heartbeat ran before the graph session was bound" >&2
+    exit 1
+  fi
+  touch "$HEARTBEAT_FILE"
+  exit 0
+fi
 if [ "$1" = "--debug" ] && [ "$2" = "--embedded-sdk" ] && [ "$3" = "--cli" ] && [ "$4" = "--session-uuid" ] && [ "$6" = "launchApp" ]; then
   if [ "$7" != "--platform" ] || [ "$8" != "ios" ] || [ "$9" != "--appId" ] || [ "${10}" != "com.apple.reminders" ] || [ "${11}" != "--deviceId" ] || [ "${12}" != "simulator-udid" ]; then
     echo "unexpected target app launch arguments: $*" >&2
@@ -108,7 +117,8 @@ fi
   [ "$status" -eq 0 ]
   [ "$(cat "$GRAPH_ATTEMPTS_FILE")" = "2" ]
   [ "$(cat "$DOCTOR_CALLS_FILE")" = "2" ]
-  [ "$(cat "$HEALTH_ATTEMPTS_FILE")" = "3" ]
+  [ "$(cat "$HEALTH_ATTEMPTS_FILE")" = "4" ]
+  [ -f "$HEARTBEAT_FILE" ]
   [ -f "$TARGET_APP_LAUNCHED_FILE" ]
   [[ "$output" == *"getNavigationGraph attempt 1 failed"* ]]
   # Regression for issue #4579: the graph read must be scoped to the fixture

--- a/test/bats/navigation-graph-sdk-event-integration.bats
+++ b/test/bats/navigation-graph-sdk-event-integration.bats
@@ -81,6 +81,10 @@ if [ "$1" = "--daemon" ] && [ "$2" = "heartbeat" ] && [ "$3" = "44600000-0000-40
     echo "session heartbeat ran before the graph session was bound" >&2
     exit 1
   fi
+  if [ "${AUTOMOBILE_DAEMON_TIMEOUT_MS:-}" != "2000" ]; then
+    echo "session heartbeat did not use the bounded daemon timeout" >&2
+    exit 1
+  fi
   touch "$HEARTBEAT_FILE"
   exit 0
 fi

--- a/test/daemon/manager.test.ts
+++ b/test/daemon/manager.test.ts
@@ -1832,3 +1832,39 @@ describe("Daemon manager available-devices", () => {
     );
   });
 });
+
+describe("Daemon manager heartbeat", () => {
+  test("records a session heartbeat through the daemon socket", async () => {
+    const fakeClient = new FakeDaemonClient({});
+    const output: string[] = [];
+    const logSpy = spyOn(console, "log").mockImplementation((...args) => {
+      output.push(args.join(" "));
+    });
+
+    try {
+      await runDaemonCommand("heartbeat", ["session-1"], {
+        clientFactory: () => fakeClient,
+        stateProvider: () =>
+          ({
+            isInitialized: () => false,
+            getDevicePool: () => {
+              throw new Error("Device pool unavailable");
+            },
+            getSessionManager: () => {
+              throw new Error("Session manager unavailable");
+            },
+            getDeviceSessionRegistry: () => {
+              throw new Error("Device session registry unavailable");
+            },
+          }) satisfies DaemonStateLike,
+      });
+    } finally {
+      logSpy.mockRestore();
+    }
+
+    expect(fakeClient.callDaemonMethodCalls).toEqual([
+      { method: "daemon/heartbeat", params: { sessionId: "session-1" } },
+    ]);
+    expect(output).toContain("Session session-1 heartbeat recorded");
+  });
+});


### PR DESCRIPTION
## Summary
- add a daemon CLI heartbeat command for session-scoped integration workflows
- renew the iOS navigation session after each failed post-bind CtrlProxy health probe
- cap heartbeat socket calls at two seconds and cover the renewal path with deterministic BATS and daemon-manager tests
- normalize release-metadata formatting inherited from the current base so the repository formatting gate can run

## Root cause
One-shot CLI clients close their proxy heartbeat after each call, while the bounded CtrlProxy health retry can run longer than the daemon's 10-second session heartbeat window. The rebased base also contained three files that failed the repository-wide formatting gate.

## Validation
- `bats test/bats/navigation-graph-sdk-event-integration.bats`
- `bun test test/daemon/manager.test.ts`
- `bun test test/daemon/daemonRequestHandlers.test.ts`
- `shellcheck scripts/ios/navigation-graph-sdk-event-integration.sh`
- `bun run format:check`
- `bun run lint`
- `bun run typecheck`
- `bun run build`

Closes [#5610](https://github.com/kaeawc/auto-mobile/issues/5610).
