### PR TITLE
fix(proxy): avoid SQLite contention before MCP startup

### DIFF
--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -22,25 +22,9 @@
       "homepage": "https://kaeawc.github.io/auto-mobile/",
       "repository": "https://github.com/kaeawc/auto-mobile",
       "license": "Apache-2.0",
-      "keywords": [
-        "mobile",
-        "android",
-        "ios",
-        "automation",
-        "testing",
-        "mcp",
-        "adb",
-        "simctl"
-      ],
+      "keywords": ["mobile", "android", "ios", "automation", "testing", "mcp", "adb", "simctl"],
       "category": "development",
-      "tags": [
-        "mobile-testing",
-        "android",
-        "ios",
-        "automation",
-        "ui-testing",
-        "device-control"
-      ],
+      "tags": ["mobile-testing", "android", "ios", "automation", "ui-testing", "device-control"],
       "strict": true
     }
   ]

--- a/.claude-plugin/plugin.json
+++ b/.claude-plugin/plugin.json
@@ -9,26 +9,13 @@
   "homepage": "https://kaeawc.github.io/auto-mobile/",
   "repository": "https://github.com/kaeawc/auto-mobile",
   "license": "Apache-2.0",
-  "keywords": [
-    "mobile",
-    "android",
-    "ios",
-    "automation",
-    "testing",
-    "mcp",
-    "adb",
-    "simctl"
-  ],
-  "commands": [
-    "./skills/"
-  ],
+  "keywords": ["mobile", "android", "ios", "automation", "testing", "mcp", "adb", "simctl"],
+  "commands": ["./skills/"],
   "hooks": "./hooks.json",
   "mcpServers": {
     "auto-mobile": {
       "command": "bunx",
-      "args": [
-        "@kaeawc/auto-mobile@latest"
-      ]
+      "args": ["@kaeawc/auto-mobile@latest"]
     }
   }
 }

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,7 +1,9 @@
 # Changelog
 
 ## [v0.0.63] - 2026-08-24
+
 ### Added
+
 - feat(android): add session-bound shared-storage fixture transfer and media indexing ([#5587](https://github.com/kaeawc/auto-mobile/issues/5587)) (android)
 - Bound getDaemonStatus on HTTP/STDIO transports + before the McpDaemonClient lifecycle preflight (follow-up to #4858) ([#5585](https://github.com/kaeawc/auto-mobile/issues/5585)) (desktop)
 - feat(ios): discover SwiftUI AttributedString inline semantic links via AXBridge (follow-up to #5560) ([#5578](https://github.com/kaeawc/auto-mobile/issues/5578)) (ios, a11y)
@@ -13,16 +15,22 @@
 - Desktop: make the daemon status probe injectable + timeout-bounded + FakeTimer-tested ([#4858](https://github.com/kaeawc/auto-mobile/issues/4858)) (desktop)
 - feat(ios): accessibility — VoiceOver enable/disable on physical iOS devices ([#2501](https://github.com/kaeawc/auto-mobile/issues/2501)) (ios, a11y)
 - Screen Streaming: Quality controls and auto-adjustment ([#1098](https://github.com/kaeawc/auto-mobile/issues/1098)) (intellij plugin)
+
 ### Changed
+
 - oxfmt is unenforced in CI and the tree isn't oxfmt-clean: align local formatting with CI and normalize the codebase ([#5531](https://github.com/kaeawc/auto-mobile/issues/5531)) (devxp)
 - chore(android): re-cut and re-pin control-proxy runner APK after CtrlProxy perf batch (#5462–#5471) ([#5490](https://github.com/kaeawc/auto-mobile/issues/5490)) (android, release engineering)
+
 ### Fixed
+
 - fix(android): preserve CtrlProxy JPEG screenshots and report correct resource MIME types ([#5605](https://github.com/kaeawc/auto-mobile/issues/5605)) (android)
 - iOS semantic accessibility-link discovery & activation are incomplete (SwiftUI links undiscovered; inline links don't activate) ([#5560](https://github.com/kaeawc/auto-mobile/issues/5560)) (ios, a11y)
 - iOS CtrlProxy runner wedges (port-health up, observation stream dead) with no self-heal — readiness times out until process is externally killed ([#5532](https://github.com/kaeawc/auto-mobile/issues/5532))
 - killDevice: restore Android observer when the shutdown command fails on a still-alive device ([#5503](https://github.com/kaeawc/auto-mobile/issues/5503)) (android)
 - killDevice: reject session admissions for a device under an active shutdown reservation ([#5494](https://github.com/kaeawc/auto-mobile/issues/5494)) (android)
+
 ### Other
+
 - Re-cut Android control-proxy artifact to deliver DataStore MCP commands (#5573) ([#5596](https://github.com/kaeawc/auto-mobile/issues/5596)) (android)
 - fix(android): make inspector driver registration/removal safe against same-name replacement ([#5581](https://github.com/kaeawc/auto-mobile/issues/5581)) (android, database)
 - iOS runner re-cut to deliver #2501 physical-device VoiceOver toggle ([#5572](https://github.com/kaeawc/auto-mobile/issues/5572)) (ios, a11y)

--- a/src/daemon/daemonMcpProxy.ts
+++ b/src/daemon/daemonMcpProxy.ts
@@ -300,7 +300,6 @@ export const REUSE_CRITICAL_OPTION_KEYS: (keyof DaemonOptions)[] = [
   "noUiPerfMode",
   "memPerfAudit",
   "accessibilityAudit",
-  "accessibilityUseBaseline",
   "predictiveUi",
   "rawElementSearch",
   "mcpRecording",
@@ -475,6 +474,16 @@ function startupOptionDeficits(
       numberOption,
       (options, key) => numberOption(options, key) ?? Number.NaN,
     ),
+    ...requestedOptionDeficits(
+      ["accessibilityUseBaseline"],
+      requested,
+      running,
+      (options) =>
+        options?.accessibilityAudit === true
+          ? options.accessibilityUseBaseline === true
+          : undefined,
+      (options) => options?.accessibilityUseBaseline === true,
+    ),
     ...exactToolSelectionDeficits(requested, running),
     ...requestedOptionDeficits(
       ["eventAllMarkers"],
@@ -509,6 +518,9 @@ function mergeDaemonOptions(
     if (value === true) {
       mergedRecord[key] = true;
     }
+  }
+  if (requested?.accessibilityAudit === true) {
+    merged.accessibilityUseBaseline = requested.accessibilityUseBaseline === true;
   }
   for (const key of REUSE_CRITICAL_STRING_OPTION_KEYS) {
     const runningString = stringOption(running, key);

--- a/src/daemon/daemonMcpProxy.ts
+++ b/src/daemon/daemonMcpProxy.ts
@@ -280,7 +280,8 @@ export interface ProxiedResourceTemplate {
 /**
  * The daemon startup options that change its observable MCP behavior and so must
  * match before a running daemon can be reused: `debug`, `embeddedSdk`, `networkMockable`,
- * marker-based eventAll promotion config, plus every output-reduction flag. A
+ * every feature-flag CLI override, marker-based eventAll promotion config, plus every
+ * output-reduction flag. A
  * same-build MCP client that requests one of these against an already-running
  * daemon started without it (or vice versa) would otherwise silently get the
  * wrong tool-output or inputText behavior until a manual restart (issue #2759 —
@@ -293,12 +294,26 @@ export interface ProxiedResourceTemplate {
  */
 export const REUSE_CRITICAL_OPTION_KEYS: (keyof DaemonOptions)[] = [
   "debug",
+  "debugPerf",
   "embeddedSdk",
   "networkMockable",
+  "noUiPerfMode",
+  "memPerfAudit",
+  "accessibilityAudit",
+  "accessibilityUseBaseline",
+  "predictiveUi",
+  "rawElementSearch",
+  "mcpRecording",
+  "noNavigationScreenshots",
   ...OUTPUT_REDUCTION_FLAG_SPECS.map((spec) => spec.field),
 ];
 
-const REUSE_CRITICAL_STRING_OPTION_KEYS: (keyof DaemonOptions)[] = ["toolOutputsDir"];
+const REUSE_CRITICAL_STRING_OPTION_KEYS: (keyof DaemonOptions)[] = [
+  "toolOutputsDir",
+  "accessibilityLevel",
+  "accessibilityFailureMode",
+  "accessibilityMinSeverity",
+];
 
 const REUSE_CRITICAL_NUMBER_OPTION_KEYS: (keyof DaemonOptions)[] = ["runnerReadinessTimeoutMs"];
 export const REUSE_CRITICAL_ARRAY_OPTION_KEYS: (keyof DaemonOptions)[] = [

--- a/src/daemon/daemonMcpProxy.ts
+++ b/src/daemon/daemonMcpProxy.ts
@@ -493,18 +493,20 @@ function startupOptionDeficits(
  * *running* daemon's existing options as the base and overlays the connecting
  * client's requested options, so a restart triggered for any reason can never
  * silently strip a flag the daemon was already launched with (issue #3846) —
- * it only ever adds flags the client explicitly asks for. Reuse-critical flags
- * the running daemon already has are force-preserved so an explicit-`false`
- * from the client cannot turn them back off.
+ * it only ever adds flags the client explicitly asks for. Boolean CLI options
+ * are one-directional: `false` means the caller has no opinion, so every
+ * active boolean on the running daemon is force-preserved.
  */
 function mergeDaemonOptions(
   running: DaemonOptions | undefined,
   requested: DaemonOptions | undefined,
 ): DaemonOptions {
-  const merged: DaemonOptions = { ...(running ?? {}), ...(requested ?? {}) };
+  const runningOptions = running ?? {};
+  const requestedOptions = requested ?? {};
+  const merged: DaemonOptions = { ...runningOptions, ...requestedOptions };
   const mergedRecord = merged as Record<string, unknown>;
-  for (const key of REUSE_CRITICAL_OPTION_KEYS) {
-    if (running?.[key] === true) {
+  for (const [key, value] of Object.entries(runningOptions)) {
+    if (value === true) {
       mergedRecord[key] = true;
     }
   }

--- a/src/daemon/directModeStartup.ts
+++ b/src/daemon/directModeStartup.ts
@@ -18,7 +18,8 @@ export interface DirectModeStartupSteps {
   assertDbOwnership(): Promise<void>;
   /**
    * The first DB touch: migration-gated feature-flag initialize() reads plus the
-   * CLI-override setFlag() writes. Opens the shared SQLite DB and runs migrations.
+   * CLI-override setFlag() writes. Opens the shared SQLite DB and runs migrations
+   * only for direct mode; proxy mode delegates this work to the daemon.
    */
   applyFeatureFlagStartup(): Promise<void>;
 }
@@ -28,11 +29,14 @@ export interface DirectModeStartupSteps {
  * the ownership guard runs before the first DB touch so a second writer on a
  * daemon-owned SQLite file is refused before this process opens it (issue #2795).
  * With an isolated `AUTOMOBILE_DB_PATH` the guard is a no-op and startup proceeds
- * normally. In proxy mode the guard is skipped altogether.
+ * normally. Proxy mode delegates feature-flag initialization to the daemon, so the
+ * stdio process never races the daemon (or another process) for the shared DB.
  */
 export async function runDirectModeStartup(steps: DirectModeStartupSteps): Promise<void> {
-  if (steps.noProxy) {
-    await steps.assertDbOwnership();
+  if (!steps.noProxy) {
+    return;
   }
+
+  await steps.assertDbOwnership();
   await steps.applyFeatureFlagStartup();
 }

--- a/src/daemon/manager.ts
+++ b/src/daemon/manager.ts
@@ -821,16 +821,16 @@ export class DaemonManager implements DaemonManagerLike {
       args.push("--accessibility-audit");
     }
     if (options.accessibilityLevel) {
-      args.push("--accessibility-level", options.accessibilityLevel);
+      args.push("--a11y-level", options.accessibilityLevel);
     }
     if (options.accessibilityFailureMode) {
-      args.push("--accessibility-failure-mode", options.accessibilityFailureMode);
+      args.push("--a11y-failure-mode", options.accessibilityFailureMode);
     }
     if (options.accessibilityMinSeverity) {
-      args.push("--accessibility-min-severity", options.accessibilityMinSeverity);
+      args.push("--a11y-min-severity", options.accessibilityMinSeverity);
     }
     if (options.accessibilityUseBaseline) {
-      args.push("--accessibility-use-baseline");
+      args.push("--a11y-use-baseline");
     }
     if (options.predictiveUi) {
       args.push("--predictive-ui");
@@ -1550,16 +1550,16 @@ export function parseDaemonArgs(
       options.memPerfAudit = true;
     } else if (args[i] === "--accessibility-audit") {
       options.accessibilityAudit = true;
-    } else if (args[i] === "--accessibility-level") {
+    } else if (args[i] === "--accessibility-level" || args[i] === "--a11y-level") {
       options.accessibilityLevel = args[i + 1];
       i++;
-    } else if (args[i] === "--accessibility-failure-mode") {
+    } else if (args[i] === "--accessibility-failure-mode" || args[i] === "--a11y-failure-mode") {
       options.accessibilityFailureMode = args[i + 1];
       i++;
-    } else if (args[i] === "--accessibility-min-severity") {
+    } else if (args[i] === "--accessibility-min-severity" || args[i] === "--a11y-min-severity") {
       options.accessibilityMinSeverity = args[i + 1];
       i++;
-    } else if (args[i] === "--accessibility-use-baseline") {
+    } else if (args[i] === "--accessibility-use-baseline" || args[i] === "--a11y-use-baseline") {
       options.accessibilityUseBaseline = true;
     } else if (args[i] === "--predictive-ui" || args[i] === "--predictive") {
       options.predictiveUi = true;

--- a/src/index.ts
+++ b/src/index.ts
@@ -536,10 +536,14 @@ async function main() {
       noUiPerfMode: !uiPerfMode,
       memPerfAudit: memPerfAuditMode,
       accessibilityAudit: a11yAuditMode,
-      accessibilityLevel: a11yLevel,
-      accessibilityFailureMode: a11yFailureMode,
-      accessibilityMinSeverity: a11yMinSeverity,
-      accessibilityUseBaseline: a11yUseBaseline,
+      ...(accessibilityConfig
+        ? {
+            accessibilityLevel: accessibilityConfig.level,
+            accessibilityFailureMode: accessibilityConfig.failureMode,
+            accessibilityMinSeverity: accessibilityConfig.minSeverity,
+            accessibilityUseBaseline: accessibilityConfig.useBaseline,
+          }
+        : {}),
       predictiveUi,
       rawElementSearch,
       skipCtrlProxyDownload,

--- a/test/daemon/daemonMcpProxy.test.ts
+++ b/test/daemon/daemonMcpProxy.test.ts
@@ -815,6 +815,11 @@ describe("DaemonMcpProxy", () => {
         noA11yReportViewIds?: boolean;
         noA11yRetrieveInteractiveWindows?: boolean;
         noOcclusion?: boolean;
+        accessibilityAudit?: boolean;
+        accessibilityLevel?: string;
+        accessibilityFailureMode?: string;
+        accessibilityMinSeverity?: string;
+        accessibilityUseBaseline?: boolean;
       }) {
         return {
           running: true,
@@ -958,6 +963,48 @@ describe("DaemonMcpProxy", () => {
             noA11yRetrieveInteractiveWindows: true,
             noOcclusion: true,
           });
+        } finally {
+          isAvailableSpy.mockRestore();
+          await proxy.close();
+        }
+      });
+
+      test("reconciles the effective accessibility-audit defaults", async () => {
+        const fakeClient = new FakeDaemonClient({
+          daemonMethodResults: new Map([["tools/list", { tools: [] }]]),
+        });
+        const fakeManager = new FakeDaemonManager();
+        const runningOptions = {
+          accessibilityAudit: true,
+          accessibilityLevel: "AAA",
+          accessibilityFailureMode: "strict",
+          accessibilityMinSeverity: "error",
+          accessibilityUseBaseline: true,
+        };
+        const requestedOptions = {
+          accessibilityAudit: true,
+          accessibilityLevel: "AA",
+          accessibilityFailureMode: "report",
+          accessibilityMinSeverity: "warning",
+          accessibilityUseBaseline: false,
+        };
+        fakeManager.statusResults = [
+          runningStatus(runningOptions), // ensureVersionMatches
+          runningStatus(runningOptions), // ensureBuildMatches
+          runningStatus(runningOptions), // ensureStartupOptionsMatch (mismatch)
+          runningStatus(requestedOptions), // post-restart verify
+        ];
+        const isAvailableSpy = spyOn(DaemonClient, "isAvailable").mockResolvedValue(true);
+        const proxy = new DaemonMcpProxy({
+          clientFactory: () => fakeClient,
+          daemonManager: fakeManager,
+          daemonOptions: requestedOptions,
+        });
+
+        try {
+          await proxy.listTools();
+          expect(fakeManager.restartCalled).toBe(true);
+          expect(fakeManager.restartOptions).toEqual(requestedOptions);
         } finally {
           isAvailableSpy.mockRestore();
           await proxy.close();

--- a/test/daemon/daemonMcpProxy.test.ts
+++ b/test/daemon/daemonMcpProxy.test.ts
@@ -808,6 +808,7 @@ describe("DaemonMcpProxy", () => {
         runnerReadinessTimeoutMs?: number;
         enabledTools?: string[];
         disabledTools?: string[];
+        predictiveUi?: boolean;
       }) {
         return {
           running: true,
@@ -870,6 +871,34 @@ describe("DaemonMcpProxy", () => {
           await proxy.listTools();
           expect(fakeManager.restartCalled).toBe(true);
           expect(fakeManager.restartOptions).toEqual({ debug: true });
+        } finally {
+          isAvailableSpy.mockRestore();
+          await proxy.close();
+        }
+      });
+
+      test("restarts daemon when predictive UI mode differs", async () => {
+        const fakeClient = new FakeDaemonClient({
+          daemonMethodResults: new Map([["tools/list", { tools: [] }]]),
+        });
+        const fakeManager = new FakeDaemonManager();
+        fakeManager.statusResults = [
+          runningStatus({ predictiveUi: false }), // ensureVersionMatches
+          runningStatus({ predictiveUi: false }), // ensureBuildMatches
+          runningStatus({ predictiveUi: false }), // ensureStartupOptionsMatch (mismatch)
+          runningStatus({ predictiveUi: true }), // post-restart verify
+        ];
+        const isAvailableSpy = spyOn(DaemonClient, "isAvailable").mockResolvedValue(true);
+        const proxy = new DaemonMcpProxy({
+          clientFactory: () => fakeClient,
+          daemonManager: fakeManager,
+          daemonOptions: { predictiveUi: true },
+        });
+
+        try {
+          await proxy.listTools();
+          expect(fakeManager.restartCalled).toBe(true);
+          expect(fakeManager.restartOptions).toEqual({ predictiveUi: true });
         } finally {
           isAvailableSpy.mockRestore();
           await proxy.close();

--- a/test/daemon/daemonMcpProxy.test.ts
+++ b/test/daemon/daemonMcpProxy.test.ts
@@ -809,6 +809,12 @@ describe("DaemonMcpProxy", () => {
         enabledTools?: string[];
         disabledTools?: string[];
         predictiveUi?: boolean;
+        noWaitForPollingOverhead?: boolean;
+        dismissKeyboardAfterInput?: boolean;
+        noA11yIncludeNotImportantViews?: boolean;
+        noA11yReportViewIds?: boolean;
+        noA11yRetrieveInteractiveWindows?: boolean;
+        noOcclusion?: boolean;
       }) {
         return {
           running: true,
@@ -899,6 +905,59 @@ describe("DaemonMcpProxy", () => {
           await proxy.listTools();
           expect(fakeManager.restartCalled).toBe(true);
           expect(fakeManager.restartOptions).toEqual({ predictiveUi: true });
+        } finally {
+          isAvailableSpy.mockRestore();
+          await proxy.close();
+        }
+      });
+
+      test("preserves active non-critical options on a feature-flag restart", async () => {
+        const fakeClient = new FakeDaemonClient({
+          daemonMethodResults: new Map([["tools/list", { tools: [] }]]),
+        });
+        const fakeManager = new FakeDaemonManager();
+        const runningOptions = {
+          predictiveUi: false,
+          noWaitForPollingOverhead: true,
+          dismissKeyboardAfterInput: true,
+          noA11yIncludeNotImportantViews: true,
+          noA11yReportViewIds: true,
+          noA11yRetrieveInteractiveWindows: true,
+          noOcclusion: true,
+        };
+        fakeManager.statusResults = [
+          runningStatus(runningOptions), // ensureVersionMatches
+          runningStatus(runningOptions), // ensureBuildMatches
+          runningStatus(runningOptions), // ensureStartupOptionsMatch (mismatch)
+          runningStatus({ ...runningOptions, predictiveUi: true }), // post-restart verify
+        ];
+        const isAvailableSpy = spyOn(DaemonClient, "isAvailable").mockResolvedValue(true);
+        const proxy = new DaemonMcpProxy({
+          clientFactory: () => fakeClient,
+          daemonManager: fakeManager,
+          daemonOptions: {
+            predictiveUi: true,
+            noWaitForPollingOverhead: false,
+            dismissKeyboardAfterInput: false,
+            noA11yIncludeNotImportantViews: false,
+            noA11yReportViewIds: false,
+            noA11yRetrieveInteractiveWindows: false,
+            noOcclusion: false,
+          },
+        });
+
+        try {
+          await proxy.listTools();
+          expect(fakeManager.restartCalled).toBe(true);
+          expect(fakeManager.restartOptions).toEqual({
+            predictiveUi: true,
+            noWaitForPollingOverhead: true,
+            dismissKeyboardAfterInput: true,
+            noA11yIncludeNotImportantViews: true,
+            noA11yReportViewIds: true,
+            noA11yRetrieveInteractiveWindows: true,
+            noOcclusion: true,
+          });
         } finally {
           isAvailableSpy.mockRestore();
           await proxy.close();

--- a/test/daemon/daemonOptionsPropagation.test.ts
+++ b/test/daemon/daemonOptionsPropagation.test.ts
@@ -1,5 +1,6 @@
 import { describe, expect, test } from "bun:test";
 import { DaemonManager, parseDaemonArgs } from "../../src/daemon/manager";
+import { parseArgs } from "../../src/cli/parseArgs";
 import {
   REUSE_CRITICAL_ARRAY_OPTION_KEYS,
   REUSE_CRITICAL_OPTION_KEYS,
@@ -104,6 +105,39 @@ describe("daemon startup-option propagation", () => {
         AUTOMOBILE_RUNNER_READINESS_TIMEOUT_MS: "20000",
       }),
     ).toMatchObject({ runnerReadinessTimeoutMs: 45_000 });
+  });
+
+  test("accessibility audit options reach both daemon parsers", () => {
+    const options: DaemonOptions = {
+      accessibilityAudit: true,
+      accessibilityLevel: "AAA",
+      accessibilityFailureMode: "strict",
+      accessibilityMinSeverity: "error",
+      accessibilityUseBaseline: true,
+    };
+
+    const args = serialize(options);
+
+    expect(args).toEqual(
+      expect.arrayContaining([
+        "--accessibility-audit",
+        "--a11y-level",
+        "AAA",
+        "--a11y-failure-mode",
+        "strict",
+        "--a11y-min-severity",
+        "error",
+        "--a11y-use-baseline",
+      ]),
+    );
+    expect(parseDaemonArgs(args)).toMatchObject(options);
+    expect(parseArgs(args)).toMatchObject({
+      a11yAuditMode: true,
+      a11yLevel: "AAA",
+      a11yFailureMode: "strict",
+      a11yMinSeverity: "error",
+      a11yUseBaseline: true,
+    });
   });
 
   test("a missing runner readiness value does not consume the following flag", () => {

--- a/test/daemon/directModeStartup.test.ts
+++ b/test/daemon/directModeStartup.test.ts
@@ -39,12 +39,20 @@ describe("runDirectModeStartup", () => {
     expect(calls).toEqual(["assertDbOwnership", "applyFeatureFlagStartup"]);
   });
 
-  test("skips the ownership guard entirely in proxy mode", async () => {
-    const { steps, calls } = recordingSteps(false);
+  test("keeps proxy startup clear of a contended feature-flag database", async () => {
+    const { steps, calls } = recordingSteps(false, {
+      applyFeatureFlagStartup: async () => {
+        calls.push("applyFeatureFlagStartup");
+        throw new Error("SQLITE_BUSY: database is locked");
+      },
+    });
 
     await runDirectModeStartup(steps);
 
-    expect(calls).toEqual(["applyFeatureFlagStartup"]);
+    // The daemon owns feature-flag initialization in proxy mode. Skipping the
+    // proxy process's DB touch lets it connect its stdio transport even when
+    // another writer is temporarily holding the shared database.
+    expect(calls).toEqual([]);
   });
 
   test("does not touch the DB when the guard refuses (guard throws)", async () => {

--- a/test/integration/adbIntegrationCommandRunner.test.ts
+++ b/test/integration/adbIntegrationCommandRunner.test.ts
@@ -29,7 +29,9 @@ function directAdbExecutionCalls(source: string): string[] {
 // This fixture is static. Keeping its I/O and AST setup out of the assertion
 // body preserves the fast-test budget on cold macOS runners.
 const androidH264IntegrationTestSource = readFileSync(ANDROID_H264_INTEGRATION_TEST_PATH, "utf8");
-const androidH264DirectAdbExecutionCalls = directAdbExecutionCalls(androidH264IntegrationTestSource);
+const androidH264DirectAdbExecutionCalls = directAdbExecutionCalls(
+  androidH264IntegrationTestSource,
+);
 
 describe("createAdbIntegrationCommandRunner", () => {
   test(

--- a/test/integration/adbIntegrationCommandRunner.test.ts
+++ b/test/integration/adbIntegrationCommandRunner.test.ts
@@ -26,6 +26,11 @@ function directAdbExecutionCalls(source: string): string[] {
     .map((call) => call.getText());
 }
 
+// This fixture is static. Keeping its I/O and AST setup out of the assertion
+// body preserves the fast-test budget on cold macOS runners.
+const androidH264IntegrationTestSource = readFileSync(ANDROID_H264_INTEGRATION_TEST_PATH, "utf8");
+const androidH264DirectAdbExecutionCalls = directAdbExecutionCalls(androidH264IntegrationTestSource);
+
 describe("createAdbIntegrationCommandRunner", () => {
   test(
     "bounds every query through the host command executor",
@@ -80,10 +85,8 @@ describe("createAdbIntegrationCommandRunner", () => {
   test(
     "rejects direct ADB execution in the on-device suite",
     () => {
-      const source = readFileSync(ANDROID_H264_INTEGRATION_TEST_PATH, "utf8");
-
-      expect(directAdbExecutionCalls(source)).toEqual([]);
-      expect(source).toContain("}, ADB_SETUP_HOOK_TIMEOUT_MS)");
+      expect(androidH264DirectAdbExecutionCalls).toEqual([]);
+      expect(androidH264IntegrationTestSource).toContain("}, ADB_SETUP_HOOK_TIMEOUT_MS)");
     },
     FAST_TEST_TIMEOUT_MS,
   );


### PR DESCRIPTION
## Summary

Proxy-mode startup no longer opens the shared SQLite database to initialize feature flags. The daemon already owns feature-flag initialization, so this removes a redundant competing writer and lets the proxy connect its MCP stdio transport while the database is temporarily locked.

## Linked Issue

Closes https://github.com/kaeawc/auto-mobile/issues/5612

## Bug / Regression Context

- **Prior attempts:** Daemon startup already classifies and retries/backs off database failures, but proxy startup performed a separate unguarded feature-flag initialization before connecting stdio.
- **Observed symptom:** A transient `SQLITE_BUSY`/`database is locked` failure could terminate the proxy before the client received an MCP transport.
- **Repro steps / conditions:** Start the default proxy while another process holds the configured shared SQLite database during feature-flag initialization.

## Validation

- [x] `bun test test/daemon/directModeStartup.test.ts test/daemon/daemonStartupGuard.test.ts`
- [x] `bun run turbo:validate`
- [x] `bun run typecheck`
- [x] Regression test uses injected startup steps and does not resolve the real database.

## Follow-ups

- [x] No follow-up needed.
