### PR TITLE
fix(ios): keep navigation session alive during doctor

### DIFF
--- a/scripts/ios/navigation-graph-sdk-event-integration.sh
+++ b/scripts/ios/navigation-graph-sdk-event-integration.sh
@@ -45,7 +45,7 @@ ctrl_proxy_port_for_device() {
   # non-zero for unrelated diagnostics, but still emits the JSON round-trip
   # report that contains this ready runner's port.
   local session_uuid="${1:-}"
-  local doctor_report ctrl_proxy_port
+  local doctor_report ctrl_proxy_port renew_status=0
   if [[ -z "${session_uuid}" ]]; then
     doctor_report="$(auto-mobile --cli doctor --ios --json || true)"
   else
@@ -57,7 +57,13 @@ ctrl_proxy_port_for_device() {
     doctor_pid=$!
     while kill -0 "${doctor_pid}" 2>/dev/null; do
       sleep 2
-      if kill -0 "${doctor_pid}" 2>/dev/null && ! renew_session_ownership "${session_uuid}"; then
+      if kill -0 "${doctor_pid}" 2>/dev/null; then
+        set +e
+        renew_session_ownership "${session_uuid}"
+        renew_status=$?
+        set -e
+      fi
+      if [[ "${renew_status:-0}" -ne 0 ]]; then
         kill "${doctor_pid}" 2>/dev/null || true
         wait "${doctor_pid}" 2>/dev/null || true
         rm -f "${doctor_report_file}"
@@ -87,15 +93,21 @@ ctrl_proxy_port_for_device() {
 wait_for_ctrl_proxy_health() {
   local ctrl_proxy_port="$1"
   local session_uuid="${2:-}"
-  local attempt
+  local attempt renew_status
   for attempt in 1 2 3 4 5; do
     if curl --fail --silent --show-error --max-time 5 "http://127.0.0.1:${ctrl_proxy_port}/health" >/dev/null; then
       return 0
     fi
     # One-shot CLI clients stop their proxy heartbeat after each public call.
     # Renew the graph session while this bounded runner-health retry is in progress.
-    if [[ -n "${session_uuid}" ]] && ! renew_session_ownership "${session_uuid}"; then
-      return 1
+    if [[ -n "${session_uuid}" ]]; then
+      set +e
+      renew_session_ownership "${session_uuid}"
+      renew_status=$?
+      set -e
+      if [[ "${renew_status}" -ne 0 ]]; then
+        return 1
+      fi
     fi
     if [[ "${attempt}" -lt 5 ]]; then
       echo "CtrlProxy health check attempt ${attempt} failed; retrying in 2s..." >&2

--- a/scripts/ios/navigation-graph-sdk-event-integration.sh
+++ b/scripts/ios/navigation-graph-sdk-event-integration.sh
@@ -26,17 +26,48 @@ require_command auto-mobile
 require_command base64
 require_command curl
 require_command jq
+require_command mktemp
 require_command xcrun
 
 xcrun simctl getenv "${device_id}" HOME >/dev/null
+
+renew_session_ownership() {
+  local session_uuid="$1"
+  if ! AUTOMOBILE_DAEMON_TIMEOUT_MS=2000 auto-mobile --daemon heartbeat "${session_uuid}" >/dev/null; then
+    echo "error: could not renew navigation graph session ownership" >&2
+    return 1
+  fi
+}
 
 ctrl_proxy_port_for_device() {
   # CtrlProxy allocates a per-device host port; 8765 is only its preferred
   # default and may already belong to another local service. `doctor` can exit
   # non-zero for unrelated diagnostics, but still emits the JSON round-trip
   # report that contains this ready runner's port.
+  local session_uuid="${1:-}"
   local doctor_report ctrl_proxy_port
-  doctor_report="$(auto-mobile --cli doctor --ios --json || true)"
+  if [[ -z "${session_uuid}" ]]; then
+    doctor_report="$(auto-mobile --cli doctor --ios --json || true)"
+  else
+    local doctor_report_file doctor_pid
+    doctor_report_file="$(mktemp)"
+    # Doctor can run multiple iOS diagnostics longer than the session heartbeat
+    # window, so renew ownership while its JSON report is still being collected.
+    auto-mobile --cli doctor --ios --json >"${doctor_report_file}" &
+    doctor_pid=$!
+    while kill -0 "${doctor_pid}" 2>/dev/null; do
+      sleep 2
+      if kill -0 "${doctor_pid}" 2>/dev/null && ! renew_session_ownership "${session_uuid}"; then
+        kill "${doctor_pid}" 2>/dev/null || true
+        wait "${doctor_pid}" 2>/dev/null || true
+        rm -f "${doctor_report_file}"
+        return 1
+      fi
+    done
+    wait "${doctor_pid}" 2>/dev/null || true
+    doctor_report="$(<"${doctor_report_file}")"
+    rm -f "${doctor_report_file}"
+  fi
   if ! ctrl_proxy_port="$(jq -er --arg device_id "${device_id}" '
       .ios.checks[]
       | select(.name == "iOS Observe Round Trip")
@@ -63,8 +94,7 @@ wait_for_ctrl_proxy_health() {
     fi
     # One-shot CLI clients stop their proxy heartbeat after each public call.
     # Renew the graph session while this bounded runner-health retry is in progress.
-    if [[ -n "${session_uuid}" ]] && ! AUTOMOBILE_DAEMON_TIMEOUT_MS=2000 auto-mobile --daemon heartbeat "${session_uuid}" >/dev/null; then
-      echo "error: could not renew navigation graph session ownership" >&2
+    if [[ -n "${session_uuid}" ]] && ! renew_session_ownership "${session_uuid}"; then
       return 1
     fi
     if [[ "${attempt}" -lt 5 ]]; then
@@ -106,7 +136,7 @@ fi
 
 # Requesting debug and embedded-SDK tools can restart the daemon. That restart
 # creates a new CtrlProxy client, so the prior daemon's reported port is stale.
-ctrl_proxy_port="$(ctrl_proxy_port_for_device)"
+ctrl_proxy_port="$(ctrl_proxy_port_for_device "${session_uuid}")"
 wait_for_ctrl_proxy_health "${ctrl_proxy_port}" "${session_uuid}"
 
 event_payload() {

--- a/test/bats/navigation-graph-sdk-event-integration.bats
+++ b/test/bats/navigation-graph-sdk-event-integration.bats
@@ -9,6 +9,8 @@ setup() {
   export CURL_URL_FILE="${MOCK_BIN}/curl-urls"
   export SESSION_OBSERVE_FILE="${MOCK_BIN}/session-observe"
   export DOCTOR_CALLS_FILE="${MOCK_BIN}/doctor-calls"
+  export POST_BIND_DOCTOR_FILE="${MOCK_BIN}/post-bind-doctor"
+  export POST_BIND_DOCTOR_FAILURE_FILE="${MOCK_BIN}/post-bind-doctor-failure"
   export HEALTH_ATTEMPTS_FILE="${MOCK_BIN}/health-attempts"
   export HEARTBEAT_FILE="${MOCK_BIN}/heartbeats"
   export TARGET_APP_LAUNCHED_FILE="${MOCK_BIN}/target-app-launched"
@@ -57,6 +59,9 @@ if [ "$1" = "-cn" ]; then
   exit 0
 fi
 if [ "$1" = "-er" ]; then
+  if [ -f "$POST_BIND_DOCTOR_FAILURE_FILE" ]; then
+    exit 1
+  fi
   doctor_calls="$(cat "$DOCTOR_CALLS_FILE")"
   if [ "$doctor_calls" -eq 1 ]; then
     printf "8768\\n"
@@ -73,6 +78,14 @@ if [ "$1" = "--cli" ] && [ "$2" = "doctor" ]; then
   doctor_calls=0
   [ -f "$DOCTOR_CALLS_FILE" ] && doctor_calls="$(cat "$DOCTOR_CALLS_FILE")"
   printf "%s\\n" "$((doctor_calls + 1))" > "$DOCTOR_CALLS_FILE"
+  if [ -f "$SESSION_OBSERVE_FILE" ]; then
+    touch "$POST_BIND_DOCTOR_FILE"
+    /bin/sleep 0.1
+    if [ ! -f "$HEARTBEAT_FILE" ]; then
+      touch "$POST_BIND_DOCTOR_FAILURE_FILE"
+      exit 1
+    fi
+  fi
   printf "{\"ios\":{\"checks\":[]}}\\n"
   exit 0
 fi
@@ -122,6 +135,7 @@ fi
   [ "$(cat "$GRAPH_ATTEMPTS_FILE")" = "2" ]
   [ "$(cat "$DOCTOR_CALLS_FILE")" = "2" ]
   [ "$(cat "$HEALTH_ATTEMPTS_FILE")" = "4" ]
+  [ -f "$POST_BIND_DOCTOR_FILE" ]
   [ -f "$HEARTBEAT_FILE" ]
   [ -f "$TARGET_APP_LAUNCHED_FILE" ]
   [[ "$output" == *"getNavigationGraph attempt 1 failed"* ]]


### PR DESCRIPTION
## Summary
- Continue renewing the bound navigation-graph session while the post-bind iOS doctor command discovers CtrlProxy's port.
- Add a regression test that requires a heartbeat before the post-bind doctor returns.

Follow-up to [#5611](https://github.com/kaeawc/auto-mobile/pull/5611).

## Test plan
- [x] `bats test/bats/navigation-graph-sdk-event-integration.bats`
- [x] `shellcheck scripts/ios/navigation-graph-sdk-event-integration.sh`
- [x] `bun run format:check`

Made with [Cursor](https://cursor.com)