### PR TITLE
fix(db): keep proxy startup database-free

### DIFF
--- a/src/daemon/directModeStartup.ts
+++ b/src/daemon/directModeStartup.ts
@@ -4,8 +4,8 @@
  * `src/index.ts` (there is no `main()` test harness). Issue #2871 stretch AC.
  *
  * The invariant: under `--no-proxy`/`--direct` the DB-ownership guard MUST run
- * BEFORE the first DB touch. When proxy mode is used (`noProxy` false), the guard
- * is skipped entirely — the daemon owns the DB and the guard doesn't apply.
+ * BEFORE the first DB touch. Proxy mode does not touch the DB at all: the daemon
+ * owns feature-flag initialization and reports any startup failure to the proxy.
  */
 export interface DirectModeStartupSteps {
   /** True only under `--no-proxy`/`--direct`. */
@@ -28,11 +28,13 @@ export interface DirectModeStartupSteps {
  * the ownership guard runs before the first DB touch so a second writer on a
  * daemon-owned SQLite file is refused before this process opens it (issue #2795).
  * With an isolated `AUTOMOBILE_DB_PATH` the guard is a no-op and startup proceeds
- * normally. In proxy mode the guard is skipped altogether.
+ * normally. In proxy mode, the daemon owns both the guard and feature-flag work,
+ * so this client opens no SQLite connection before its stdio transport is ready.
  */
 export async function runDirectModeStartup(steps: DirectModeStartupSteps): Promise<void> {
-  if (steps.noProxy) {
-    await steps.assertDbOwnership();
+  if (!steps.noProxy) {
+    return;
   }
+  await steps.assertDbOwnership();
   await steps.applyFeatureFlagStartup();
 }

--- a/test/daemon/directModeStartup.test.ts
+++ b/test/daemon/directModeStartup.test.ts
@@ -39,12 +39,12 @@ describe("runDirectModeStartup", () => {
     expect(calls).toEqual(["assertDbOwnership", "applyFeatureFlagStartup"]);
   });
 
-  test("skips the ownership guard entirely in proxy mode", async () => {
+  test("does not touch the database in proxy mode", async () => {
     const { steps, calls } = recordingSteps(false);
 
     await runDirectModeStartup(steps);
 
-    expect(calls).toEqual(["applyFeatureFlagStartup"]);
+    expect(calls).toEqual([]);
   });
 
   test("does not touch the DB when the guard refuses (guard throws)", async () => {


### PR DESCRIPTION
## Summary
- Keep proxy-client startup free of SQLite access.
- Leave feature-flag initialization to the daemon, where database startup failures are guarded and can be reported through the connected proxy.

## Validation
- `bun test test/daemon/directModeStartup.test.ts`
- `bun test --isolate`
- `bun run turbo:validate`
- `bun run typecheck`

## Risk
Direct mode remains unchanged. In proxy mode, non-reuse-critical flag persistence now occurs only when the daemon starts or restarts, rather than through a separate proxy-client database writer.

Closes [#5612](https://github.com/kaeawc/auto-mobile/issues/5612).
